### PR TITLE
fix: resolve svelte-check type error breaking CI

### DIFF
--- a/web/src/lib/components/collections/TableView.svelte
+++ b/web/src/lib/components/collections/TableView.svelte
@@ -26,7 +26,7 @@
 		relationLabels
 	}: Props = $props();
 
-	let resolvedWsSlug = $derived(wsSlug || page.params.workspace);
+	let resolvedWsSlug = $derived(wsSlug || page.params.workspace || '');
 	let schema = $derived(parseSchema(collection));
 	let visibleFields = $derived(schema.fields.filter((f) => !f.computed));
 


### PR DESCRIPTION
## Summary
- `page.params.workspace` is `string | undefined` in SvelteKit, but `EmptyState` component expects `wsSlug: string`
- Added `|| ''` fallback in `TableView.svelte` to narrow the type
- This was the sole error causing CI to fail (`svelte-check found 1 error`)

## Test plan
- [x] `npx svelte-check` — 0 errors, 20 warnings (all pre-existing CSS/a11y warnings)
- [x] `npm run build` — web build succeeds