### PR TITLE
feat: rich activity metadata with field change diffs

### DIFF
--- a/internal/server/handlers_documents.go
+++ b/internal/server/handlers_documents.go
@@ -1,7 +1,10 @@
 package server
 
 import (
+	"encoding/json"
+	"fmt"
 	"net/http"
+	"sort"
 	"strings"
 
 	"github.com/go-chi/chi/v5"
@@ -351,6 +354,11 @@ func (s *Server) publishEvent(eventType, workspaceID, documentID, title, docType
 
 // logActivity is a helper that logs activity, ignoring errors (best-effort).
 func (s *Server) logActivity(workspaceID, documentID, action, actor, source string) {
+	s.logActivityWithMeta(workspaceID, documentID, action, actor, source, "")
+}
+
+// logActivityWithMeta logs activity with optional JSON metadata.
+func (s *Server) logActivityWithMeta(workspaceID, documentID, action, actor, source, metadata string) {
 	if actor == "" {
 		actor = "user"
 	}
@@ -363,5 +371,36 @@ func (s *Server) logActivity(workspaceID, documentID, action, actor, source stri
 		Action:      action,
 		Actor:       actor,
 		Source:      source,
+		Metadata:    metadata,
 	})
+}
+
+// diffFields compares old and new field JSON strings and returns a human-readable
+// summary of changes (e.g. "status: open → done, priority: medium → high").
+func diffFields(oldFields, newFields string) string {
+	var oldMap, newMap map[string]any
+	if err := json.Unmarshal([]byte(oldFields), &oldMap); err != nil {
+		return ""
+	}
+	if err := json.Unmarshal([]byte(newFields), &newMap); err != nil {
+		return ""
+	}
+
+	var changes []string
+	for key, newVal := range newMap {
+		oldVal, exists := oldMap[key]
+		newStr := fmt.Sprintf("%v", newVal)
+		if !exists {
+			changes = append(changes, fmt.Sprintf("%s: → %s", key, newStr))
+		} else {
+			oldStr := fmt.Sprintf("%v", oldVal)
+			if oldStr != newStr {
+				changes = append(changes, fmt.Sprintf("%s: %s → %s", key, oldStr, newStr))
+			}
+		}
+	}
+
+	// Sort for deterministic output
+	sort.Strings(changes)
+	return strings.Join(changes, ", ")
 }

--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -248,7 +248,17 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	s.logActivity(workspaceID, updated.ID, "updated", input.LastModifiedBy, input.Source)
+	// Build rich metadata describing what changed
+	var meta string
+	if changes := diffFields(item.Fields, updated.Fields); changes != "" {
+		meta = fmt.Sprintf(`{"changes":%q}`, changes)
+	}
+	if input.Title != nil && *input.Title != item.Title {
+		if meta == "" {
+			meta = fmt.Sprintf(`{"changes":"title: %s → %s"}`, item.Title, *input.Title)
+		}
+	}
+	s.logActivityWithMeta(workspaceID, updated.ID, "updated", input.LastModifiedBy, input.Source, meta)
 	s.publishItemEvent(events.ItemUpdated, workspaceID, updated.ID, updated.Title, updated.CollectionSlug, input.LastModifiedBy, input.Source)
 	s.dispatchWebhook(workspaceID, "item.updated", updated)
 


### PR DESCRIPTION
## Summary
- Item updates now include what changed in the activity metadata (e.g. `"status: open → done, priority: low → high"`)
- New `logActivityWithMeta()` helper alongside existing `logActivity()`
- New `diffFields()` function compares old vs new field JSON and produces human-readable summary
- Activity feed page already renders `meta.changes` — this populates it with real data

## Before/After
**Before:** `Updated Fix OAuth` (no context)
**After:** `Updated Fix OAuth` — `status: open → done, priority: low → high`

## Test plan
- [x] `go test ./...` — all pass
- [x] Manual test: created task, updated status+priority, verified activity API returns changes
- [x] Verified field diff is sorted alphabetically for deterministic output
- [ ] Visual check: activity page shows change details below item titles