### PR TITLE
feat: optional password authentication for web UI

### DIFF
--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -194,6 +194,12 @@ func serveCmd() *cobra.Command {
 
 			srv := server.New(s)
 
+			// Enable password auth if configured
+			if cfg.Password != "" {
+				srv.SetPassword(cfg.Password)
+				log.Printf("Password authentication enabled")
+			}
+
 			// Attach event bus for real-time SSE
 			srv.SetEventBus(events.New())
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,8 +16,14 @@ type Config struct {
 	URL      string `toml:"url"`      // Optional: full base URL (e.g., https://api.getpad.dev). Overrides host/port for CLI.
 	Editor   string `toml:"editor"`
 	LogLevel string `toml:"log_level"`
-	DBPath   string `toml:"-"` // computed, not from config file
-	DataDir  string `toml:"-"` // computed
+	Password string `toml:"password"` // Optional: password for web UI access. Set via config or PAD_PASSWORD env var.
+	DBPath   string `toml:"-"`        // computed, not from config file
+	DataDir  string `toml:"-"`        // computed
+}
+
+// AuthEnabled returns true if a password is configured.
+func (c *Config) AuthEnabled() bool {
+	return c.Password != ""
 }
 
 func DefaultConfig() *Config {
@@ -73,6 +79,9 @@ func Load() (*Config, error) {
 	if v := os.Getenv("PAD_DB_PATH"); v != "" {
 		cfg.DBPath = v
 		cfg.DataDir = filepath.Dir(cfg.DBPath)
+	}
+	if v := os.Getenv("PAD_PASSWORD"); v != "" {
+		cfg.Password = v
 	}
 
 	return cfg, nil

--- a/internal/server/handlers_auth.go
+++ b/internal/server/handlers_auth.go
@@ -1,0 +1,91 @@
+package server
+
+import (
+	"crypto/subtle"
+	"net/http"
+	"time"
+)
+
+// handleLogin validates the password and creates a session.
+func (s *Server) handleLogin(w http.ResponseWriter, r *http.Request) {
+	if s.password == "" {
+		writeJSON(w, http.StatusOK, map[string]interface{}{
+			"ok":            true,
+			"auth_required": false,
+		})
+		return
+	}
+
+	var input struct {
+		Password string `json:"password"`
+	}
+	if err := decodeJSON(r, &input); err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", "Invalid request body")
+		return
+	}
+
+	// Constant-time comparison to prevent timing attacks
+	if subtle.ConstantTimeCompare([]byte(input.Password), []byte(s.password)) != 1 {
+		// Slow down brute force attempts
+		time.Sleep(500 * time.Millisecond)
+		writeError(w, http.StatusUnauthorized, "unauthorized", "Invalid password")
+		return
+	}
+
+	// Create session
+	cookieValue := s.sessions.Create()
+	http.SetCookie(w, &http.Cookie{
+		Name:     sessionCookie,
+		Value:    cookieValue,
+		Path:     "/",
+		MaxAge:   int(sessionTTL.Seconds()),
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+		// Secure: false — not using HTTPS for localhost
+	})
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"ok": true,
+	})
+}
+
+// handleSessionCheck returns current auth status. This endpoint is exempt from auth middleware.
+func (s *Server) handleSessionCheck(w http.ResponseWriter, r *http.Request) {
+	if s.password == "" {
+		writeJSON(w, http.StatusOK, map[string]interface{}{
+			"authenticated": true,
+			"auth_required": false,
+		})
+		return
+	}
+
+	authenticated := false
+	if cookie, err := r.Cookie(sessionCookie); err == nil {
+		authenticated = s.sessions.Validate(cookie.Value)
+	}
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"authenticated": authenticated,
+		"auth_required": true,
+	})
+}
+
+// handleLogout destroys the session and clears the cookie.
+func (s *Server) handleLogout(w http.ResponseWriter, r *http.Request) {
+	if cookie, err := r.Cookie(sessionCookie); err == nil {
+		s.sessions.Destroy(cookie.Value)
+	}
+
+	http.SetCookie(w, &http.Cookie{
+		Name:     sessionCookie,
+		Value:    "",
+		Path:     "/",
+		MaxAge:   -1,
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+	})
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"ok": true,
+	})
+}

--- a/internal/server/middleware_auth.go
+++ b/internal/server/middleware_auth.go
@@ -63,3 +63,60 @@ func tokenWorkspaceID(r *http.Request) string {
 	v, _ := r.Context().Value(ctxTokenWorkspaceID).(string)
 	return v
 }
+
+// PasswordAuth middleware protects routes when a password is configured.
+// When no password is set, all requests pass through (existing localhost behaviour).
+// When a password is set, requests must have a valid session cookie OR a valid API token.
+func (s *Server) PasswordAuth(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// No password configured => passthrough
+		if s.password == "" {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		path := r.URL.Path
+
+		// Auth endpoints are always exempt
+		if strings.HasPrefix(path, "/api/v1/auth/") || path == "/api/v1/health" {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		// Static assets are exempt (CSS, JS, images, fonts, manifest)
+		if strings.HasPrefix(path, "/_app/") ||
+			path == "/favicon.ico" ||
+			strings.HasSuffix(path, ".png") ||
+			strings.HasSuffix(path, ".svg") ||
+			strings.HasSuffix(path, ".ico") ||
+			strings.HasSuffix(path, ".webmanifest") ||
+			strings.HasSuffix(path, ".json") && !strings.HasPrefix(path, "/api/") {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		// Already authenticated by TokenAuth (valid API token)
+		if tokenWorkspaceID(r) != "" {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		// Valid session cookie
+		if cookie, err := r.Cookie(sessionCookie); err == nil {
+			if s.sessions != nil && s.sessions.Validate(cookie.Value) {
+				next.ServeHTTP(w, r)
+				return
+			}
+		}
+
+		// Unauthenticated — return 401 for API, let SPA handle the redirect for browser
+		if strings.HasPrefix(path, "/api/") {
+			writeError(w, http.StatusUnauthorized, "unauthorized", "Authentication required")
+			return
+		}
+
+		// For browser page requests, serve the SPA (the frontend will check auth and show login)
+		next.ServeHTTP(w, r)
+	})
+}
+

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -24,12 +24,20 @@ type Server struct {
 	webFS    fs.FS                // embedded web UI static files (optional)
 	events   *events.Bus          // real-time event bus (optional)
 	webhooks *webhooks.Dispatcher // webhook dispatcher (optional)
+	password string               // optional password for web UI access
+	sessions *SessionManager      // session manager (initialized when password is set)
 }
 
 func New(s *store.Store) *Server {
 	srv := &Server{store: s}
 	srv.setupRouter()
 	return srv
+}
+
+// SetPassword enables password authentication for the web UI.
+func (s *Server) SetPassword(pw string) {
+	s.password = pw
+	s.sessions = NewSessionManager()
 }
 
 // SetEventBus attaches an event bus for real-time SSE streaming.
@@ -57,6 +65,7 @@ func (s *Server) setupRouter() {
 		MaxAge:           300,
 	}))
 	r.Use(s.TokenAuth)
+	r.Use(s.PasswordAuth)
 	r.Use(jsonContentType)
 
 	// SSE endpoint (outside jsonContentType middleware)
@@ -65,6 +74,13 @@ func (s *Server) setupRouter() {
 	// API routes
 	r.Route("/api/v1", func(r chi.Router) {
 		r.Get("/health", s.handleHealth)
+
+		// Auth endpoints (exempt from PasswordAuth middleware)
+		r.Route("/auth", func(r chi.Router) {
+			r.Get("/session", s.handleSessionCheck)
+			r.Post("/login", s.handleLogin)
+			r.Post("/logout", s.handleLogout)
+		})
 
 		// Templates
 		r.Get("/templates", s.handleListTemplates)

--- a/internal/server/session.go
+++ b/internal/server/session.go
@@ -1,0 +1,114 @@
+package server
+
+import (
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	sessionTTL    = 7 * 24 * time.Hour // 7 days
+	sessionCookie = "pad_session"
+)
+
+// SessionManager handles in-memory session storage with HMAC-signed cookies.
+type SessionManager struct {
+	mu       sync.RWMutex
+	sessions map[string]time.Time // sessionID -> expiresAt
+	secret   []byte               // 32-byte HMAC signing key
+}
+
+// NewSessionManager creates a session manager with a random signing key.
+func NewSessionManager() *SessionManager {
+	secret := make([]byte, 32)
+	if _, err := rand.Read(secret); err != nil {
+		panic("failed to generate session secret: " + err.Error())
+	}
+
+	sm := &SessionManager{
+		sessions: make(map[string]time.Time),
+		secret:   secret,
+	}
+
+	// Background cleanup of expired sessions
+	go func() {
+		for {
+			time.Sleep(15 * time.Minute)
+			sm.cleanup()
+		}
+	}()
+
+	return sm
+}
+
+// Create generates a new session and returns the signed cookie value.
+func (sm *SessionManager) Create() string {
+	id := make([]byte, 24)
+	if _, err := rand.Read(id); err != nil {
+		return ""
+	}
+
+	sessionID := base64.RawURLEncoding.EncodeToString(id)
+	sig := sm.sign(sessionID)
+
+	sm.mu.Lock()
+	sm.sessions[sessionID] = time.Now().Add(sessionTTL)
+	sm.mu.Unlock()
+
+	return sessionID + "." + sig
+}
+
+// Validate checks if a cookie value contains a valid, non-expired session.
+func (sm *SessionManager) Validate(cookieValue string) bool {
+	parts := strings.SplitN(cookieValue, ".", 2)
+	if len(parts) != 2 {
+		return false
+	}
+
+	sessionID, sig := parts[0], parts[1]
+
+	// Verify HMAC signature
+	expected := sm.sign(sessionID)
+	if !hmac.Equal([]byte(sig), []byte(expected)) {
+		return false
+	}
+
+	// Check session exists and is not expired
+	sm.mu.RLock()
+	expiresAt, exists := sm.sessions[sessionID]
+	sm.mu.RUnlock()
+
+	return exists && time.Now().Before(expiresAt)
+}
+
+// Destroy removes a session.
+func (sm *SessionManager) Destroy(cookieValue string) {
+	parts := strings.SplitN(cookieValue, ".", 2)
+	if len(parts) != 2 {
+		return
+	}
+	sm.mu.Lock()
+	delete(sm.sessions, parts[0])
+	sm.mu.Unlock()
+}
+
+func (sm *SessionManager) sign(data string) string {
+	mac := hmac.New(sha256.New, sm.secret)
+	mac.Write([]byte(data))
+	return base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+}
+
+func (sm *SessionManager) cleanup() {
+	now := time.Now()
+	sm.mu.Lock()
+	for id, expiresAt := range sm.sessions {
+		if now.After(expiresAt) {
+			delete(sm.sessions, id)
+		}
+	}
+	sm.mu.Unlock()
+}

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -37,8 +37,16 @@ class PadApiError extends Error {
 async function request<T>(path: string, options?: RequestInit): Promise<T> {
 	const resp = await fetch(BASE + path, {
 		headers: { 'Content-Type': 'application/json' },
+		credentials: 'same-origin',
 		...options
 	});
+	if (resp.status === 401) {
+		// Redirect to login page (avoid infinite loop)
+		if (typeof window !== 'undefined' && !window.location.pathname.startsWith('/login')) {
+			window.location.href = '/login';
+		}
+		throw new PadApiError({ code: 'unauthorized', message: 'Authentication required' });
+	}
 	if (!resp.ok) {
 		const body = await resp.json().catch(() => null);
 		if (body?.error) throw new PadApiError(body.error);
@@ -314,6 +322,19 @@ export const api = {
 				method: 'POST',
 				body: JSON.stringify(data)
 			})
+	},
+
+	// ── Auth ──────────────────────────────────────────────────────────────────
+
+	auth: {
+		session: (): Promise<{ authenticated: boolean; auth_required: boolean }> =>
+			fetch(BASE + '/auth/session', { credentials: 'same-origin' }).then((r) => r.json()),
+		login: (password: string) =>
+			request<{ ok: boolean }>('/auth/login', {
+				method: 'POST',
+				body: JSON.stringify({ password })
+			}),
+		logout: () => request<{ ok: boolean }>('/auth/logout', { method: 'POST' })
 	}
 };
 

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -2,6 +2,8 @@
 	import '../app.css';
 	import { onMount } from 'svelte';
 	import { goto } from '$app/navigation';
+	import { page } from '$app/state';
+	import { api } from '$lib/api/client';
 	import { workspaceStore } from '$lib/stores/workspace.svelte';
 	import { uiStore } from '$lib/stores/ui.svelte';
 	import Sidebar from '$lib/components/layout/Sidebar.svelte';
@@ -14,9 +16,28 @@
 	let { children } = $props();
 
 	let showShortcuts = $state(false);
+	let authReady = $state(false);
+	let isLoginPage = $derived(page.url.pathname === '/login');
 
 	onMount(async () => {
-		await workspaceStore.loadAll();
+		// Check auth status before loading the app
+		try {
+			const auth = await api.auth.session();
+			if (auth.auth_required && !auth.authenticated) {
+				if (!isLoginPage) {
+					goto('/login', { replaceState: true });
+				}
+				authReady = true;
+				return;
+			}
+		} catch {
+			// If auth check fails, proceed anyway (server may not support it)
+		}
+
+		authReady = true;
+		if (!isLoginPage) {
+			await workspaceStore.loadAll();
+		}
 	});
 
 	function handleKeydown(e: KeyboardEvent) {
@@ -68,29 +89,35 @@
 
 <svelte:window onkeydown={handleKeydown} />
 
-<div class="app-shell">
-	<Sidebar />
-	<main class="main-content">
-		{#if uiStore.isMobile && !uiStore.sidebarOpen}
-			<div class="mobile-header">
-				<button class="hamburger" onclick={() => uiStore.openSidebar()} aria-label="Open sidebar">
-					<svg width="20" height="20" viewBox="0 0 20 20" fill="none">
-						<rect y="3" width="20" height="2" rx="1" fill="currentColor"/>
-						<rect y="9" width="20" height="2" rx="1" fill="currentColor"/>
-						<rect y="15" width="20" height="2" rx="1" fill="currentColor"/>
-					</svg>
-				</button>
-				<a href="/{workspaceStore.current?.slug ?? ''}" class="mobile-title">{workspaceStore.current?.name ?? 'Pad'}</a>
-			</div>
-		{/if}
-		{@render children()}
-	</main>
-</div>
+{#if !authReady}
+	<!-- Auth check in progress — blank screen to avoid flash -->
+{:else if isLoginPage}
+	{@render children()}
+{:else}
+	<div class="app-shell">
+		<Sidebar />
+		<main class="main-content">
+			{#if uiStore.isMobile && !uiStore.sidebarOpen}
+				<div class="mobile-header">
+					<button class="hamburger" onclick={() => uiStore.openSidebar()} aria-label="Open sidebar">
+						<svg width="20" height="20" viewBox="0 0 20 20" fill="none">
+							<rect y="3" width="20" height="2" rx="1" fill="currentColor"/>
+							<rect y="9" width="20" height="2" rx="1" fill="currentColor"/>
+							<rect y="15" width="20" height="2" rx="1" fill="currentColor"/>
+						</svg>
+					</button>
+					<a href="/{workspaceStore.current?.slug ?? ''}" class="mobile-title">{workspaceStore.current?.name ?? 'Pad'}</a>
+				</div>
+			{/if}
+			{@render children()}
+		</main>
+	</div>
 
-<CommandPalette />
-<CreateWorkspaceModal />
-<ToastContainer />
-<KeyboardShortcuts visible={showShortcuts} onclose={() => showShortcuts = false} />
+	<CommandPalette />
+	<CreateWorkspaceModal />
+	<ToastContainer />
+	<KeyboardShortcuts visible={showShortcuts} onclose={() => showShortcuts = false} />
+{/if}
 
 <style>
 	.app-shell {

--- a/web/src/routes/login/+page.svelte
+++ b/web/src/routes/login/+page.svelte
@@ -1,0 +1,161 @@
+<script lang="ts">
+	import { api } from '$lib/api/client';
+	import { goto } from '$app/navigation';
+
+	let password = $state('');
+	let error = $state('');
+	let loading = $state(false);
+
+	async function handleSubmit() {
+		error = '';
+		if (!password) {
+			error = 'Please enter a password.';
+			return;
+		}
+
+		loading = true;
+		try {
+			await api.auth.login(password);
+			await goto('/', { replaceState: true });
+		} catch (err: unknown) {
+			if (err instanceof Error) {
+				error = err.message || 'Invalid password.';
+			} else {
+				error = 'Invalid password.';
+			}
+		} finally {
+			loading = false;
+		}
+	}
+
+	function handleKeydown(event: KeyboardEvent) {
+		if (event.key === 'Enter') {
+			handleSubmit();
+		}
+	}
+</script>
+
+<div class="login-page">
+	<div class="login-card">
+		<h1 class="logo">Pad</h1>
+		<p class="subtitle">Sign in to continue</p>
+
+		<div class="form">
+			<input
+				type="password"
+				placeholder="Password"
+				bind:value={password}
+				onkeydown={handleKeydown}
+				disabled={loading}
+				autocomplete="current-password"
+			/>
+
+			{#if error}
+				<p class="error">{error}</p>
+			{/if}
+
+			<button onclick={handleSubmit} disabled={loading}>
+				{#if loading}
+					Signing in...
+				{:else}
+					Sign in
+				{/if}
+			</button>
+		</div>
+	</div>
+</div>
+
+<style>
+	.login-page {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		min-height: 100vh;
+		background: var(--bg-primary);
+		padding: var(--space-4);
+	}
+
+	.login-card {
+		width: 100%;
+		max-width: 360px;
+		background: var(--bg-secondary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius-lg);
+		padding: var(--space-10) var(--space-8);
+		text-align: center;
+	}
+
+	.logo {
+		font-size: 2rem;
+		font-weight: 700;
+		color: var(--text-primary);
+		letter-spacing: -0.02em;
+		margin-bottom: var(--space-2);
+	}
+
+	.subtitle {
+		color: var(--text-muted);
+		font-size: 0.9rem;
+		margin-bottom: var(--space-8);
+	}
+
+	.form {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-4);
+	}
+
+	input {
+		width: 100%;
+		padding: var(--space-3) var(--space-4);
+		background: var(--bg-tertiary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+		color: var(--text-primary);
+		font-size: 0.95rem;
+		font-family: var(--font-ui);
+		outline: none;
+		transition: border-color 0.15s;
+	}
+
+	input::placeholder {
+		color: var(--text-muted);
+	}
+
+	input:focus {
+		border-color: var(--accent-blue);
+	}
+
+	input:disabled {
+		opacity: 0.6;
+	}
+
+	.error {
+		color: #ef4444;
+		font-size: 0.85rem;
+		text-align: left;
+	}
+
+	button {
+		width: 100%;
+		padding: var(--space-3) var(--space-4);
+		background: var(--accent-blue);
+		color: #fff;
+		border: none;
+		border-radius: var(--radius);
+		font-size: 0.95rem;
+		font-weight: 500;
+		font-family: var(--font-ui);
+		cursor: pointer;
+		transition: opacity 0.15s;
+	}
+
+	button:hover:not(:disabled) {
+		opacity: 0.9;
+	}
+
+	button:disabled {
+		opacity: 0.6;
+		cursor: not-allowed;
+	}
+</style>


### PR DESCRIPTION
## Summary
Adds optional password-based session authentication to Pad. This is a **launch blocker** — without auth, any deployment beyond localhost exposes all project data.

### How it works
- Set `PAD_PASSWORD=mypassword` env var or `password = "mypassword"` in `~/.pad/config.toml`
- Web UI shows a login page, API returns 401 for unauthenticated requests
- Session cookies (HMAC-SHA256 signed, 7-day TTL)
- API tokens still work independently (no CLI change needed)
- **When no password is configured, everything works exactly as before**

### Backend
- `SessionManager` in `internal/server/session.go` — in-memory sessions with HMAC signing
- Auth handlers: `POST /auth/login`, `GET /auth/session`, `POST /auth/logout`
- `PasswordAuth` middleware gates all requests (runs after `TokenAuth`)
- Constant-time password comparison + 500ms delay on wrong password

### Frontend
- Login page at `/login` — clean, dark-themed, centered card
- Root layout checks auth before rendering app shell
- Global 401 handler redirects to login page

## Test plan
- [x] `go test ./...` — all pass
- [x] `npm run build` — web build succeeds
- [x] `npx svelte-check` — 0 errors
- [x] Without password: `GET /auth/session` → `{auth_required: false, authenticated: true}`
- [x] With password: `GET /api/v1/workspaces` → 401
- [x] Login with wrong password → 401 + delay
- [x] Login with correct password → session cookie set → full API access
- [ ] Visual check: login page renders correctly, redirect flow works