### PR TITLE
fix: show item ref in breadcrumb instead of full title

### DIFF
--- a/web/src/routes/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[workspace]/[collection]/[slug]/+page.svelte
@@ -273,7 +273,7 @@
 			<span class="sep">/</span>
 			<a href="/{wsSlug}/{collSlug}">{collection.icon} {collection.name}</a>
 			<span class="sep">/</span>
-			<span class="current">{item.title}</span>
+			<span class="current">{formatItemRef(item) || item.title}</span>
 		</nav>
 
 		<!-- Title -->


### PR DESCRIPTION
## Summary
Breadcrumb now shows `Home / Tasks / TASK-5` instead of `Home / Tasks / Fix the OAuth redirect bug`. Uses existing `formatItemRef()`, falls back to title if no ref.

One-line change. Closes IDEA-64.