### PR TITLE
fix: make adjacent board columns visibly peek on mobile

### DIFF
--- a/web/src/lib/components/collections/BoardView.svelte
+++ b/web/src/lib/components/collections/BoardView.svelte
@@ -440,16 +440,15 @@
 		.board-view {
 			display: flex;
 			overflow-x: auto;
-			scroll-snap-type: x mandatory;
-			scroll-behavior: smooth;
+			scroll-snap-type: x proximity;
 			-webkit-overflow-scrolling: touch;
 			gap: var(--space-3);
 			padding: 0 var(--space-4) var(--space-3);
 		}
 
 		.kanban-column {
-			min-width: 78vw;
-			max-width: 78vw;
+			min-width: 75vw;
+			max-width: 75vw;
 			scroll-snap-align: start;
 			flex-shrink: 0;
 		}


### PR DESCRIPTION
## Summary
Follow-up to #9. The previous fix (78vw + mandatory snap) still hid adjacent columns because `scroll-snap-type: x mandatory` forced the viewport to snap flush against each column edge, hiding the peek at rest.

Changes:
- Column width: 78vw → 75vw (leaves ~25vw visible for the next column)
- Snap type: `mandatory` → `proximity` (peek persists when not actively scrolling)
- Removed `scroll-behavior: smooth` for native momentum feel

Now users see a clear visual hint that more columns exist to the right.

## Test plan
- [ ] Mobile: board view shows partial next column visible at rest
- [ ] Mobile: swiping scrolls between columns with natural momentum
- [x] `npm run build` succeeds