### PR TITLE
fix: center-snap mobile board columns for equal peek

### DIFF
--- a/web/src/lib/components/collections/BoardView.svelte
+++ b/web/src/lib/components/collections/BoardView.svelte
@@ -449,7 +449,7 @@
 		.kanban-column {
 			min-width: 75vw;
 			max-width: 75vw;
-			scroll-snap-align: start;
+			scroll-snap-align: center;
 			flex-shrink: 0;
 		}
 	}


### PR DESCRIPTION
One-line fix: `scroll-snap-align: start → center`. Active column is now centered with equal peek on both sides.