### PR TITLE
feat: sticky column headers on mobile board view

### DIFF
--- a/web/src/lib/components/collections/BoardView.svelte
+++ b/web/src/lib/components/collections/BoardView.svelte
@@ -452,5 +452,18 @@
 			scroll-snap-align: center;
 			flex-shrink: 0;
 		}
+
+		.column-header {
+			position: sticky;
+			top: 0;
+			z-index: 10;
+			background: var(--bg-primary);
+			cursor: default;
+			margin-bottom: var(--space-2);
+		}
+
+		.column-drag-handle {
+			display: none;
+		}
 	}
 </style>


### PR DESCRIPTION
## Summary
On mobile, scrolling down through a long column now keeps the column header (e.g. "Planned (5)") pinned at the top of the viewport. Page title and filters scroll off naturally.

- `position: sticky; top: 0` on `.column-header` inside mobile media query
- Background color set so sticky header doesn't overlap transparent content
- Hides drag handle on mobile (column drag-reorder isn't practical on touch)

## Test plan
- [ ] Mobile: scroll down in a column with many items — header stays pinned
- [ ] Mobile: swipe between columns — each column shows its own sticky header
- [ ] Desktop: no change to existing layout
- [x] `npm run build` succeeds