### PR TITLE
fix: revert sticky column header regression on mobile

### DIFF
--- a/web/src/lib/components/collections/BoardView.svelte
+++ b/web/src/lib/components/collections/BoardView.svelte
@@ -454,12 +454,7 @@
 		}
 
 		.column-header {
-			position: sticky;
-			top: 0;
-			z-index: 10;
-			background: var(--bg-primary);
 			cursor: default;
-			margin-bottom: var(--space-2);
 		}
 
 		.column-drag-handle {


### PR DESCRIPTION
## Summary
Reverts the sticky column header from #12. `position: sticky` doesn't work because `.board-view` has `overflow-x: auto` on mobile, which creates a new scroll context. The sticky header ended up floating over the mobile navbar instead of pinning below it.

Keeps the useful part: hiding the drag handle on mobile (column drag-reorder isn't practical on touch).

The sticky column header idea needs a layout refactor (separating the column headers from the horizontal scroll container) to work properly — tracked as a future improvement.