### PR TITLE
Fix CLI to use issue IDs instead of verbose slugs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,25 +110,28 @@ Roles: `owner` (full access), `editor` (CRUD items), `viewer` (read-only).
 
 ## CLI
 
+Items are referenced by **issue ID** (e.g. `TASK-5`, `BUG-8`) wherever a `<ref>` argument appears.
+Slugs also work but issue IDs are preferred.
+
 ```bash
 pad create <collection> "title" [--status X] [--priority X]
 pad list [collection] [--status X] [--all]
-pad show <slug>
-pad update <slug> [--status X] [--priority X]
-pad delete <slug>
-pad move <slug> <target-collection>
+pad show <ref>                # e.g. pad show TASK-5
+pad update <ref> [--status X] [--priority X]
+pad delete <ref>
+pad move <ref> <target-collection>
 pad search "query"
 pad status                    # Project dashboard
 pad next                      # Recommended next task
 pad standup [--days N]        # Daily standup report
 pad changelog [--days N]      # Release notes from completed items
-pad blocks <source> <target>  # Create dependency
+pad blocks <source> <target>  # e.g. pad blocks TASK-5 TASK-8
 pad blocked-by <item> <blocker>
-pad deps <slug>               # Show dependencies
+pad deps <ref>                # Show dependencies
 pad unblock <source> <target>
 pad collections               # List collections
 pad collections create "Name" --fields "key:type[:opts]; ..."
-pad edit <slug>               # Open in $EDITOR
+pad edit <ref>                # Open in $EDITOR
 pad init [--template X]       # Create workspace
 pad install [tool]            # Install /pad skill for AI tools
 pad onboard                   # Analyze codebase, suggest conventions
@@ -137,8 +140,8 @@ pad watch                     # Real-time activity stream
 pad github link [item-ref]    # Link current branch's PR to item
 pad github status [item-ref]  # Show PR status for linked items
 pad github unlink <item-ref>  # Remove PR link from item
-pad bulk-update --status done SLUG1 SLUG2  # Batch operations
-pad webhooks list/create/delete/test       # Webhook management
+pad bulk-update --status done TASK-5 TASK-8  # Batch operations
+pad webhooks list/create/delete/test         # Webhook management
 pad login                     # Log in (or register if first user)
 pad logout                    # Sign out
 pad whoami                    # Show current user

--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -1557,7 +1557,12 @@ Examples:
 			if icon == "" {
 				icon = "📦"
 			}
-			fmt.Printf("Created %s %s: %q (%s)\n", icon, item.CollectionName, item.Title, item.Slug)
+			ref := cli.ItemRef(*item)
+			if ref != "" {
+				fmt.Printf("Created %s %s %s: %q\n", icon, item.CollectionName, ref, item.Title)
+			} else {
+				fmt.Printf("Created %s %s: %q (%s)\n", icon, item.CollectionName, item.Title, item.Slug)
+			}
 			if summary := cli.FormatFieldSummary(item.Fields); summary != "" {
 				fmt.Printf("  %s\n", summary)
 			}
@@ -1732,7 +1737,7 @@ func printItemsGroupedByCollection(items []models.Item) {
 			ref := cli.ItemRef(item)
 			refStr := ""
 			if ref != "" {
-				refStr = dim.Sprintf("%-9s", ref)
+				refStr = cli.BoldCyan.Sprintf("%-9s", ref)
 			} else {
 				refStr = "         "
 			}
@@ -1759,7 +1764,7 @@ func printItemsGroupedByCollection(items []models.Item) {
 
 func showCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "show <slug>",
+		Use:   "show <ref>",
 		Short: "Show item detail (fields + content)",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -1891,14 +1896,16 @@ func updateCmd() *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:   "update <slug> [--field value...]",
+		Use:   "update <ref> [--field value...]",
 		Short: "Update an item's fields or content",
 		Long: `Update an existing item. Only the specified fields are changed.
 
+Items can be referenced by issue ID (e.g. TASK-5) or slug.
+
 Examples:
-  pad update fix-oauth --status done
-  pad update api-redesign --status active --priority high
-  pad update payment-arch --stdin < updated-doc.md`,
+  pad update TASK-5 --status done
+  pad update PHASE-2 --status active --priority high
+  pad update DOC-3 --stdin < updated-doc.md`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, _ := getClient()
@@ -1984,7 +1991,12 @@ Examples:
 				return cli.PrintJSON(updated)
 			}
 
-			fmt.Printf("Updated %q (%s)\n", updated.Title, updated.Slug)
+			ref := cli.ItemRef(*updated)
+			if ref != "" {
+				fmt.Printf("Updated %s %q\n", ref, updated.Title)
+			} else {
+				fmt.Printf("Updated %q (%s)\n", updated.Title, updated.Slug)
+			}
 			if summary := cli.FormatFieldSummary(updated.Fields); summary != "" {
 				fmt.Printf("  %s\n", summary)
 			}
@@ -2010,7 +2022,7 @@ Examples:
 
 func deleteCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "delete <slug>",
+		Use:   "delete <ref>",
 		Short: "Archive (soft-delete) an item",
 		Aliases: []string{"rm"},
 		Args:  cobra.ExactArgs(1),
@@ -2018,11 +2030,22 @@ func deleteCmd() *cobra.Command {
 			client, _ := getClient()
 			ws := getWorkspace()
 
+			// Get item first so we can show its ref in output
+			item, err := client.GetItem(ws, args[0])
+			if err != nil {
+				return err
+			}
+
 			if err := client.DeleteItem(ws, args[0]); err != nil {
 				return err
 			}
 
-			fmt.Printf("Archived %q\n", args[0])
+			ref := cli.ItemRef(*item)
+			if ref != "" {
+				fmt.Printf("Archived %s %q\n", ref, item.Title)
+			} else {
+				fmt.Printf("Archived %q\n", args[0])
+			}
 			return nil
 		},
 	}
@@ -2032,16 +2055,18 @@ func deleteCmd() *cobra.Command {
 
 func moveCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "move <slug> <target-collection>",
+		Use:   "move <ref> <target-collection>",
 		Short: "Move an item to a different collection",
 		Long: `Move an item to a different collection with automatic field migration.
 
 Fields with matching names and compatible types transfer automatically.
 Incompatible fields are dropped. Use --field to set values for target-specific fields.
 
+Items can be referenced by issue ID (e.g. TASK-5) or slug.
+
 Examples:
-  pad move fix-oauth bugs                      # Move to bugs collection
-  pad move my-idea tasks --field priority=high  # Move idea to tasks with priority`,
+  pad move BUG-3 tasks                         # Move to tasks collection
+  pad move IDEA-7 tasks --field priority=high   # Move idea to tasks with priority`,
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, _ := getClient()
@@ -2083,7 +2108,7 @@ Examples:
 
 func commentCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "comment <slug> <message>",
+		Use:   "comment <ref> <message>",
 		Short: "Add a comment to an item",
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -2111,7 +2136,7 @@ func commentCmd() *cobra.Command {
 
 func commentsCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "comments <slug>",
+		Use:   "comments <ref>",
 		Short: "List comments on an item",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -2137,7 +2162,7 @@ func commentsCmd() *cobra.Command {
 
 func blocksCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "blocks <source-slug> <target-slug>",
+		Use:   "blocks <source-ref> <target-ref>",
 		Short: "Mark that one item blocks another",
 		Long: `Create a blocking dependency between two items.
 
@@ -2192,7 +2217,7 @@ The source item blocks the target item. For example:
 
 func blockedByCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "blocked-by <source-slug> <blocker-slug>",
+		Use:   "blocked-by <source-ref> <blocker-ref>",
 		Short: "Mark that an item is blocked by another",
 		Long: `Create a blocking dependency (reverse direction).
 
@@ -2247,7 +2272,7 @@ The source item is blocked by the blocker item. For example:
 
 func depsCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "deps <slug>",
+		Use:   "deps <ref>",
 		Short: "Show all dependencies for an item",
 		Long: `Display blocking relationships for an item.
 
@@ -2332,7 +2357,7 @@ Example:
 
 func unblockCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "unblock <source-slug> <target-slug>",
+		Use:   "unblock <source-ref> <target-ref>",
 		Short: "Remove a blocking dependency between items",
 		Long: `Remove a "blocks" relationship where source blocks target.
 
@@ -3287,11 +3312,12 @@ Examples:
 
 func editCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "edit <slug>",
+		Use:   "edit <ref>",
 		Short: "Open an item's content in $EDITOR",
 		Long: `Open an item's rich content in your default editor. After editing
 and saving, the content is updated in Pad.
 
+Items can be referenced by issue ID (e.g. TASK-5) or slug.
 Set EDITOR or VISUAL env var to choose your editor (default: vi).`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -3321,7 +3347,12 @@ Set EDITOR or VISUAL env var to choose your editor (default: vi).`,
 				return err
 			}
 
-			fmt.Printf("Updated %q (%s)\n", updated.Title, updated.Slug)
+			ref := cli.ItemRef(*updated)
+			if ref != "" {
+				fmt.Printf("Updated %s %q\n", ref, updated.Title)
+			} else {
+				fmt.Printf("Updated %q (%s)\n", updated.Title, updated.Slug)
+			}
 			return nil
 		},
 	}
@@ -4085,9 +4116,11 @@ func bulkUpdateCmd() *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:   "bulk-update [--status X] [--priority X] <slug>...",
+		Use:   "bulk-update [--status X] [--priority X] <ref>...",
 		Short: "Update multiple items at once",
 		Long: `Update the status or priority of multiple items in a single command.
+
+Items can be referenced by issue ID (e.g. TASK-5) or slug.
 
 Examples:
   pad bulk-update --status done TASK-5 TASK-8 TASK-12

--- a/embed.go
+++ b/embed.go
@@ -8,4 +8,4 @@ var WebUI embed.FS
 //go:embed skills/pad/SKILL.md
 var PadSkill []byte
 
-// embed cache bust: 1774707297
+// embed cache bust: 1774728494

--- a/internal/cli/format.go
+++ b/internal/cli/format.go
@@ -152,7 +152,7 @@ func PrintItemTable(items []models.Item) {
 		ref := ItemRef(item)
 		titlePart := item.Title
 		if ref != "" {
-			titlePart = Dim.Sprint(ref) + "  " + Bold.Sprint(item.Title)
+			titlePart = BoldCyan.Sprint(ref) + "  " + Bold.Sprint(item.Title)
 		} else {
 			titlePart = Bold.Sprint(item.Title)
 		}
@@ -238,7 +238,7 @@ func PrintItemMeta(item *models.Item) {
 	// Item ref + Title
 	ref := ItemRef(*item)
 	if ref != "" {
-		fmt.Printf("%s  %s\n", Dim.Sprint(ref), Bold.Sprint(item.Title))
+		fmt.Printf("%s  %s\n", BoldCyan.Sprint(ref), Bold.Sprint(item.Title))
 	} else {
 		fmt.Printf("%s\n", Bold.Sprint(item.Title))
 	}

--- a/internal/models/item.go
+++ b/internal/models/item.go
@@ -1,6 +1,9 @@
 package models
 
-import "time"
+import (
+	"fmt"
+	"time"
+)
 
 type Item struct {
 	ID             string     `json:"id"`
@@ -8,6 +11,7 @@ type Item struct {
 	CollectionID   string     `json:"collection_id"`
 	Title          string     `json:"title"`
 	Slug           string     `json:"slug"`
+	Ref            string     `json:"ref,omitempty"` // computed: e.g. "TASK-5", "BUG-8"
 	Content        string     `json:"content"`
 	Fields         string     `json:"fields"` // JSON string
 	Tags           string     `json:"tags"`   // JSON array string
@@ -29,6 +33,14 @@ type Item struct {
 	CollectionName   string `json:"collection_name,omitempty"`
 	CollectionIcon   string `json:"collection_icon,omitempty"`
 	CollectionPrefix string `json:"collection_prefix,omitempty"`
+}
+
+// ComputeRef sets the Ref field from CollectionPrefix and ItemNumber.
+// Call this after populating the item from a database query.
+func (item *Item) ComputeRef() {
+	if item.CollectionPrefix != "" && item.ItemNumber != nil {
+		item.Ref = fmt.Sprintf("%s-%d", item.CollectionPrefix, *item.ItemNumber)
+	}
 }
 
 type ItemCreate struct {

--- a/internal/server/handlers_dashboard.go
+++ b/internal/server/handlers_dashboard.go
@@ -51,6 +51,7 @@ type DashboardSummary struct {
 
 type DashboardPhase struct {
 	Slug      string `json:"slug"`
+	Ref       string `json:"ref,omitempty"`
 	Title     string `json:"title"`
 	Progress  int    `json:"progress"`
 	TaskCount int    `json:"task_count"`
@@ -60,6 +61,7 @@ type DashboardPhase struct {
 type DashboardAttention struct {
 	Type       string `json:"type"`
 	ItemSlug   string `json:"item_slug"`
+	ItemRef    string `json:"item_ref,omitempty"`
 	ItemTitle  string `json:"item_title"`
 	Collection string `json:"collection"`
 	Reason     string `json:"reason"`
@@ -67,6 +69,7 @@ type DashboardAttention struct {
 
 type DashboardSuggestion struct {
 	ItemSlug   string `json:"item_slug"`
+	ItemRef    string `json:"item_ref,omitempty"`
 	ItemTitle  string `json:"item_title"`
 	Collection string `json:"collection"`
 	Reason     string `json:"reason"`
@@ -196,6 +199,7 @@ func (s *Server) handleGetDashboard(w http.ResponseWriter, r *http.Request) {
 		for _, phase := range phases {
 			dp := DashboardPhase{
 				Slug:  phase.Slug,
+				Ref:   phase.Ref,
 				Title: phase.Title,
 			}
 
@@ -239,6 +243,7 @@ func (s *Server) handleGetDashboard(w http.ResponseWriter, r *http.Request) {
 				resp.Attention = append(resp.Attention, DashboardAttention{
 					Type:       "stalled",
 					ItemSlug:   item.Slug,
+					ItemRef:    item.Ref,
 					ItemTitle:  item.Title,
 					Collection: item.CollectionSlug,
 					Reason:     "In progress for " + strconv.Itoa(daysSince) + " days with no updates",
@@ -264,6 +269,7 @@ func (s *Server) handleGetDashboard(w http.ResponseWriter, r *http.Request) {
 				resp.Attention = append(resp.Attention, DashboardAttention{
 					Type:       "overdue",
 					ItemSlug:   item.Slug,
+					ItemRef:    item.Ref,
 					ItemTitle:  item.Title,
 					Collection: item.CollectionSlug,
 					Reason:     strings.ReplaceAll(dateField, "_", " ") + " was " + dateVal,
@@ -310,6 +316,7 @@ func (s *Server) handleGetDashboard(w http.ResponseWriter, r *http.Request) {
 					resp.Attention = append(resp.Attention, DashboardAttention{
 						Type:       "orphaned_task",
 						ItemSlug:   task.Slug,
+						ItemRef:    task.Ref,
 						ItemTitle:  task.Title,
 						Collection: "tasks",
 						Reason:     "Task has no phase assigned",
@@ -349,6 +356,7 @@ func (s *Server) handleGetDashboard(w http.ResponseWriter, r *http.Request) {
 			resp.Attention = append(resp.Attention, DashboardAttention{
 				Type:       "blocked",
 				ItemSlug:   item.Slug,
+				ItemRef:    item.Ref,
 				ItemTitle:  item.Title,
 				Collection: item.CollectionSlug,
 				Reason:     "Blocked by " + link.SourceTitle + " (still " + blockerStatus + ")",
@@ -432,6 +440,7 @@ func (s *Server) handleGetDashboard(w http.ResponseWriter, r *http.Request) {
 		}
 		resp.SuggestedNext = append(resp.SuggestedNext, DashboardSuggestion{
 			ItemSlug:   c.item.Slug,
+			ItemRef:    c.item.Ref,
 			ItemTitle:  c.item.Title,
 			Collection: "tasks",
 			Reason:     reason,

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -122,6 +122,7 @@ func (s *Store) GetItem(id string) (*models.Item, error) {
 	item.CreatedAt = parseTime(createdAt)
 	item.UpdatedAt = parseTime(updatedAt)
 	item.DeletedAt = parseTimePtr(deletedAt)
+	item.ComputeRef()
 	return &item, nil
 }
 
@@ -229,6 +230,7 @@ func (s *Store) ResolveItemIncludeDeleted(workspaceID, slugOrRef string) (*model
 			item.CreatedAt = parseTime(createdAt)
 			item.UpdatedAt = parseTime(updatedAt)
 			item.DeletedAt = parseTimePtr(deletedAt)
+			item.ComputeRef()
 			return &item, nil
 		}
 		if err != sql.ErrNoRows {
@@ -300,6 +302,7 @@ func (s *Store) GetItemBySlugIncludeDeleted(workspaceID, slug string) (*models.I
 	item.CreatedAt = parseTime(createdAt)
 	item.UpdatedAt = parseTime(updatedAt)
 	item.DeletedAt = parseTimePtr(deletedAt)
+	item.ComputeRef()
 	return &item, nil
 }
 
@@ -614,6 +617,7 @@ func (s *Store) SearchItems(workspaceID, query string) ([]ItemSearchResult, erro
 		r.Item.Pinned = pinned == 1
 		r.Item.CreatedAt = parseTime(createdAt)
 		r.Item.UpdatedAt = parseTime(updatedAt)
+		r.Item.ComputeRef()
 		r.Item.Content = "" // Don't include full content in search results
 		results = append(results, r)
 	}
@@ -980,6 +984,7 @@ func scanItems(rows *sql.Rows) ([]models.Item, error) {
 		item.Pinned = pinned == 1
 		item.CreatedAt = parseTime(createdAt)
 		item.UpdatedAt = parseTime(updatedAt)
+		item.ComputeRef()
 		items = append(items, item)
 	}
 	return items, rows.Err()

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -21,8 +21,8 @@ func (s *Store) Search(params SearchParams) ([]SearchResult, error) {
 	query := `
 		SELECT i.id, i.workspace_id, i.collection_id, i.title, i.slug, i.content, i.fields, i.tags,
 		       i.pinned, i.sort_order, i.parent_id, i.created_by, i.last_modified_by, i.source,
-		       i.created_at, i.updated_at,
-		       c.slug, c.name, c.icon,
+		       i.item_number, i.created_at, i.updated_at,
+		       c.slug, c.name, c.icon, c.prefix,
 		       snippet(items_fts, 1, '<mark>', '</mark>', '...', 32) as snippet,
 		       rank
 		FROM items_fts fts
@@ -60,8 +60,8 @@ func (s *Store) Search(params SearchParams) ([]SearchResult, error) {
 			&r.Item.ID, &r.Item.WorkspaceID, &r.Item.CollectionID, &r.Item.Title, &r.Item.Slug,
 			&r.Item.Content, &r.Item.Fields, &r.Item.Tags,
 			&pinned, &r.Item.SortOrder, &r.Item.ParentID, &r.Item.CreatedBy, &r.Item.LastModifiedBy,
-			&r.Item.Source, &createdAt, &updatedAt,
-			&r.Item.CollectionSlug, &r.Item.CollectionName, &r.Item.CollectionIcon,
+			&r.Item.Source, &r.Item.ItemNumber, &createdAt, &updatedAt,
+			&r.Item.CollectionSlug, &r.Item.CollectionName, &r.Item.CollectionIcon, &r.Item.CollectionPrefix,
 			&r.Snippet, &r.Rank,
 		); err != nil {
 			return nil, err
@@ -69,6 +69,7 @@ func (s *Store) Search(params SearchParams) ([]SearchResult, error) {
 		r.Item.Pinned = pinned == 1
 		r.Item.CreatedAt = parseTime(createdAt)
 		r.Item.UpdatedAt = parseTime(updatedAt)
+		r.Item.ComputeRef()
 		// Don't include full content in search results
 		r.Item.Content = ""
 		results = append(results, r)

--- a/skills/pad/SKILL.md
+++ b/skills/pad/SKILL.md
@@ -11,6 +11,8 @@ allowed-tools:
 
 You are the interface between the user and their Pad workspace — a project management tool for developers and AI agents. Pad uses **Collections** (Tasks, Ideas, Phases, Docs, and custom types) containing **Items** with structured fields and optional rich content.
 
+Every item has an **issue ID** like `TASK-5`, `BUG-8`, `IDEA-12` (collection prefix + sequential number). **Always use issue IDs to reference items** — never use slugs. Issue IDs are short, stable, and human-readable.
+
 The `pad` CLI must be on PATH. It auto-starts a local server and auto-detects the workspace from `.pad.toml` in the directory tree. If `pad` is not found, tell the user: "Pad CLI not found. Install it or add it to your PATH."
 
 ## How This Works
@@ -53,9 +55,9 @@ Interpret the user's intent and route to the appropriate action. Here are common
 - "find anything about OAuth" → `pad search "OAuth" --format json`
 
 **Updating:**
-- "I finished the OAuth fix" / "mark X as done" → `pad update <slug> --status done`
-- "I'm starting on X" → `pad update <slug> --status in-progress`
-- "deprioritize X" / "X is now low priority" → `pad update <slug> --priority low`
+- "I finished the OAuth fix" / "mark TASK-5 as done" → `pad update TASK-5 --status done`
+- "I'm starting on TASK-3" → `pad update TASK-3 --status in-progress`
+- "deprioritize IDEA-7" → `pad update IDEA-7 --priority low`
 
 **Planning:**
 - "let's plan the next phase" → Multi-step planning workflow (see below)
@@ -67,14 +69,15 @@ Interpret the user's intent and route to the appropriate action. Here are common
 - "what if we added X?" → Discuss, then offer to capture as an Idea
 
 **Dependencies:**
-- "what's blocking X?" / "show deps for X" → `pad deps <slug> --format json`
-- "X blocks Y" / "X depends on Y" → `pad blocks X Y` or `pad blocked-by Y X`
-- "remove the dependency" → `pad unblock <source> <target>`
+- "what's blocking TASK-5?" / "show deps for TASK-5" → `pad deps TASK-5 --format json`
+- "TASK-5 blocks TASK-8" → `pad blocks TASK-5 TASK-8`
+- "TASK-5 depends on TASK-3" → `pad blocked-by TASK-5 TASK-3`
+- "remove the dependency" → `pad unblock TASK-5 TASK-8`
 
 **Reports:**
 - "prep for standup" / "what did we do?" → `pad standup --format json`
 - "generate changelog" / "what shipped?" → `pad changelog --format json`
-- "changelog for this phase" → `pad changelog --phase <slug> --format json`
+- "changelog for this phase" → `pad changelog --phase PHASE-2 --format json`
 - "changelog since Monday" → `pad changelog --since 2026-03-24 --format json`
 
 **Retrospective:**
@@ -110,9 +113,12 @@ Follow ALL returned conventions. If a playbook exists for the action, follow its
 
 ## CLI Reference
 
+**IMPORTANT:** All commands that take an item reference accept issue IDs (e.g. `TASK-5`, `BUG-8`). Always prefer issue IDs over slugs. When you create an item, the CLI prints its issue ID — use that for subsequent commands.
+
 ### Item CRUD
 ```bash
 # Create items (collection accepts singular or plural: task/tasks, idea/ideas, etc.)
+# The CLI prints the new item's issue ID (e.g. "Created TASK-5: ...") — use it for subsequent commands
 pad create <collection> "title" [--status X] [--priority X] [--assignee X] [--category X] [--content "..."] [--stdin]
 pad create task "Fix OAuth redirect" --priority high
 pad create idea "Real-time collaboration" --category infrastructure
@@ -130,16 +136,16 @@ pad list tasks --status done          # completed tasks
 pad list conventions --field trigger=always --field status=active  # filtered by custom fields
 pad list --all                        # everything across all collections
 
-# Show item detail
-pad show <slug> [--format json|markdown]
+# Show item detail — use the issue ID (e.g. TASK-5, BUG-8)
+pad show TASK-5 [--format json|markdown]
 
-# Update items (only specified fields change)
-pad update <slug> [--status X] [--priority X] [--assignee X] [--title "X"] [--field key=value] [--stdin]
-pad update fix-oauth --status done
-pad update some-item --field trigger=on-implement
+# Update items — use the issue ID
+pad update TASK-5 --status done
+pad update IDEA-3 --priority high --assignee dave
+pad update DOC-1 --stdin < updated-doc.md
 
-# Delete (archive)
-pad delete <slug>
+# Delete (archive) — use the issue ID
+pad delete TASK-5
 
 # Search
 pad search "query" [--format json]
@@ -150,15 +156,15 @@ pad search "query" [--format json]
 pad status [--format json]            # Project dashboard
 pad next [--format json]              # Recommended next task
 pad standup [--days N] [--format json]  # Daily standup report (completed/in-progress/blockers)
-pad changelog [--days N] [--since DATE] [--phase SLUG] [--format json|markdown]  # Release notes
+pad changelog [--days N] [--since DATE] [--phase PHASE-2] [--format json|markdown]  # Release notes
 ```
 
 ### Dependencies
 ```bash
-pad blocks <source> <target>          # "TASK-5 blocks TASK-8"
-pad blocked-by <item> <blocker>       # "TASK-5 is blocked by TASK-3"
-pad deps <slug>                       # Show all dependencies for an item
-pad unblock <source> <target>         # Remove a dependency
+pad blocks TASK-5 TASK-8              # "TASK-5 blocks TASK-8"
+pad blocked-by TASK-5 TASK-3          # "TASK-5 is blocked by TASK-3"
+pad deps TASK-5                       # Show all dependencies for an item
+pad unblock TASK-5 TASK-8             # Remove a dependency
 ```
 
 ### Collections
@@ -199,18 +205,18 @@ All commands support `--format json` (for parsing) or `--format table` (default,
 4. **Create the phase:** `pad create phase "Phase N: Title" --status draft --stdin <<< "<plan content>"`
 5. **Decompose into tasks:** For each task in the plan, create a Task item:
    ```bash
-   pad create task "Task description" --phase <phase-slug> --priority medium
+   pad create task "Task description" --phase PHASE-3 --priority medium
    ```
 6. **Each task should be PR-sized** — small enough for one branch, large enough to be meaningful.
 7. **Ask before creating each item.** Don't bulk-create without approval.
 
 ### Decomposition: "Break phase X into tasks"
 
-1. **Load the phase:** `pad show <phase-slug> --format markdown`
+1. **Load the phase:** `pad show PHASE-2 --format markdown`
 2. **Analyze the content** for actionable work items
 3. **Propose task list** with titles and priorities
 4. **Create approved tasks:** One `pad create task` per approved item
-5. **Link tasks to phase** using `--phase <phase-slug>` flag (if the phase collection has a relation field)
+5. **Link tasks to phase** using `--phase PHASE-2` flag (if the phase collection has a relation field)
 
 ### Status Check: "How are we doing?"
 
@@ -250,26 +256,27 @@ All commands support `--format json` (for parsing) or `--format table` (default,
 
 ### Retrospective: "Phase X is done, let's retro"
 
-1. Load the phase: `pad show <phase-slug> --format markdown`
+1. Load the phase: `pad show PHASE-2 --format markdown`
 2. Load tasks: `pad list tasks --all --format json` (filter to phase)
 3. Generate retro: What shipped, what was deferred, lessons learned
 4. Offer to save: `pad create doc "Phase N Retrospective" --category retro --stdin`
-5. Offer to update phase status: `pad update <phase-slug> --status completed`
+5. Offer to update phase status: `pad update PHASE-2 --status completed`
 
 ## Key Principles
 
-1. **Discuss before acting.** Always show what you plan to create/modify and get confirmation.
-2. **Use the CLI.** Every action goes through `pad` commands — don't try to modify the database directly.
-3. **Be conversational.** You're not a command executor. You're a project partner.
-4. **Reference existing items.** Use `[[Item Title]]` links in content to connect items.
-5. **Keep it practical.** Tasks should be PR-sized. Ideas should be actionable. Docs should be concise.
-6. **Attribution matters.** Items you create will have `created_by: agent` and `source: cli` automatically.
-7. **Follow project conventions.** Always load and follow active conventions before performing work. They are project-specific rules that override your defaults.
-8. **Learn and teach.** When the user corrects your behavior or teaches you a project-specific rule, offer to save it as a convention: "Should I save this as a project convention so future agents follow it too?" Use `pad create convention "Title" --field trigger=<inferred> --field scope=<inferred> --field priority=should --stdin` with an appropriate trigger inferred from the context.
+1. **Use issue IDs, not slugs.** Every item has an ID like `TASK-5` or `BUG-8`. Use these in all commands: `pad show TASK-5`, `pad update BUG-8 --status done`. The CLI prints issue IDs in all output — look for them.
+2. **Discuss before acting.** Always show what you plan to create/modify and get confirmation.
+3. **Use the CLI.** Every action goes through `pad` commands — don't try to modify the database directly.
+4. **Be conversational.** You're not a command executor. You're a project partner.
+5. **Reference existing items.** Use `[[Item Title]]` links in content to connect items.
+6. **Keep it practical.** Tasks should be PR-sized. Ideas should be actionable. Docs should be concise.
+7. **Attribution matters.** Items you create will have `created_by: agent` and `source: cli` automatically.
+8. **Follow project conventions.** Always load and follow active conventions before performing work. They are project-specific rules that override your defaults.
+9. **Learn and teach.** When the user corrects your behavior or teaches you a project-specific rule, offer to save it as a convention: "Should I save this as a project convention so future agents follow it too?" Use `pad create convention "Title" --field trigger=<inferred> --field scope=<inferred> --field priority=should --stdin` with an appropriate trigger inferred from the context.
 
 ## Anything Else
 
 If the user's intent doesn't match any pattern above, respond helpfully. You can always:
 - Run `pad list` or `pad search` to find relevant items
-- Run `pad show <slug>` to load any item's detail
+- Run `pad show TASK-5` to load any item's detail (use the issue ID from list output)
 - Suggest the appropriate workflow based on what they're trying to do


### PR DESCRIPTION
## Summary
- Agents were using verbose slugs (e.g., `we-ve-noticed-agents-are-accessing...`) instead of issue IDs (e.g., `BUG-8`) because the CLI output buried IDs, JSON had no `ref` field, and the skill file used slugs in all examples
- Added `Ref` field to the Item model that computes `PREFIX-N` (e.g., `BUG-8`, `TASK-1`)
- Updated all CLI commands to accept issue IDs as arguments and display them prominently
- Rewrote skill file (`SKILL.md`) and `CLAUDE.md` to teach agents to use issue IDs

**Fixes BUG-8**

## Changes
- `internal/models/item.go` — Added `Ref` field + `ComputeRef()` method
- `internal/store/items.go` + `search.go` — Hydrate `Ref` at all query points
- `cmd/pad/main.go` — All commands accept `<ref>`, display issue IDs in output
- `internal/cli/format.go` — Issue IDs shown in bold cyan (not dim)
- `internal/server/handlers_dashboard.go` — Added `ref` to dashboard API
- `skills/pad/SKILL.md` — Rewritten to use issue IDs everywhere
- `CLAUDE.md` — Updated CLI reference

## Test plan
- [ ] `pad show BUG-8` resolves correctly via issue ID
- [ ] `pad update TASK-1 --status done` works with issue ID
- [ ] `pad list tasks --format json` includes `ref` field in output
- [ ] `pad create task "Test" ` prints issue ID prominently
- [ ] `go test ./...` passes
- [ ] `npm run build` passes