### PR TITLE
Fix notification items to be clickable with panel staying open

### DIFF
--- a/web/src/lib/components/common/NotificationPanel.svelte
+++ b/web/src/lib/components/common/NotificationPanel.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { fly, fade } from 'svelte/transition';
-	import { goto } from '$app/navigation';
 	import { toastStore } from '$lib/stores/toast.svelte';
 	import type { HistoryEntry } from '$lib/stores/toast.svelte';
 
@@ -62,11 +61,11 @@
 			{:else}
 				{#each toastStore.history as entry (entry.id)}
 					{#if entry.link}
-						<button class="notification-row clickable" onclick={() => { onclose(); goto(entry.link!); }}>
+						<a href={entry.link} class="notification-row clickable" onclick={(e: MouseEvent) => { e.stopPropagation(); }}>
 							<span class="notification-dot" style="background: {dotColor(entry.type)}"></span>
 							<span class="notification-message">{entry.message}</span>
 							<span class="notification-time">{formatRelativeTime(entry.timestamp)}</span>
-						</button>
+						</a>
 					{:else}
 						<div class="notification-row">
 							<span class="notification-dot" style="background: {dotColor(entry.type)}"></span>
@@ -188,9 +187,12 @@
 	.notification-row.clickable {
 		cursor: pointer;
 		transition: background 0.15s;
+		text-decoration: none;
+		color: inherit;
 	}
 	.notification-row.clickable:hover {
 		background: var(--bg-hover);
+		text-decoration: none;
 	}
 
 	.notification-dot {


### PR DESCRIPTION
## Summary
- Notification rows with links used `<button>` + `goto()` that called `onclose()` first, closing the panel before navigating
- Replaced with `<a href>` tags for proper SvelteKit client-side routing and right-click support
- Removed `onclose()` from click handler so the panel stays open after navigation
- Added `stopPropagation` to prevent backdrop close on click-through

**Fixes BUG-9**

## Changes
- `web/src/lib/components/common/NotificationPanel.svelte` — Replaced button with anchor tag, removed panel close on navigate, styled links to match existing rows

## Test plan
- [ ] Click a notification item → navigates to the item detail page
- [ ] Notification panel remains open after clicking an item
- [ ] Right-click → "Open in new tab" works on notification items
- [ ] Non-linked notifications still display correctly
- [ ] Panel still closes via X button and backdrop click
- [ ] `npm run build` passes