### PR TITLE
Show user names in activity feeds and real-time events

### DIFF
--- a/internal/events/bus.go
+++ b/internal/events/bus.go
@@ -35,6 +35,7 @@ type Event struct {
 	Title       string `json:"title,omitempty"`
 	DocType     string `json:"doc_type,omitempty"`
 	Actor       string `json:"actor,omitempty"`
+	ActorName   string `json:"actor_name,omitempty"`
 	Source      string `json:"source,omitempty"`
 	Timestamp   int64  `json:"timestamp"`
 }

--- a/internal/models/activity.go
+++ b/internal/models/activity.go
@@ -15,12 +15,14 @@ type Activity struct {
 	Actor       string    `json:"actor"`
 	Source      string    `json:"source"`
 	Metadata    string    `json:"metadata,omitempty"` // JSON
+	UserID      string    `json:"user_id,omitempty"`
 	CreatedAt   time.Time `json:"created_at"`
 
 	// Enrichment fields — populated by handlers, not stored in DB
 	ItemTitle      string `json:"item_title,omitempty"`
 	ItemSlug       string `json:"item_slug,omitempty"`
 	CollectionSlug string `json:"collection_slug,omitempty"`
+	ActorName      string `json:"actor_name,omitempty"`
 }
 
 type ActivityListParams struct {

--- a/internal/server/handlers_dashboard.go
+++ b/internal/server/handlers_dashboard.go
@@ -36,6 +36,7 @@ type DashboardActiveItem struct {
 type DashboardActivity struct {
 	Action         string `json:"action"`
 	Actor          string `json:"actor"`
+	ActorName      string `json:"actor_name,omitempty"`
 	Source         string `json:"source"`
 	CreatedAt      string `json:"created_at"`
 	ItemTitle      string `json:"item_title,omitempty"`
@@ -365,7 +366,7 @@ func (s *Server) handleGetDashboard(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Recent activity — enriched with item titles
+	// Recent activity — enriched with item titles and user names
 	activities, err := s.store.ListWorkspaceActivity(workspaceID, models.ActivityListParams{
 		Limit: 10,
 	})
@@ -374,6 +375,7 @@ func (s *Server) handleGetDashboard(w http.ResponseWriter, r *http.Request) {
 			da := DashboardActivity{
 				Action:    a.Action,
 				Actor:     a.Actor,
+				ActorName: a.ActorName,
 				Source:    a.Source,
 				CreatedAt: a.CreatedAt.Format("2006-01-02T15:04:05Z"),
 				Metadata:  a.Metadata,

--- a/internal/server/handlers_documents.go
+++ b/internal/server/handlers_documents.go
@@ -82,7 +82,7 @@ func (s *Server) handleCreateDocument(w http.ResponseWriter, r *http.Request) {
 	// Log activity and publish event
 	actor, source := actorFromRequest(r)
 	s.logActivity(workspaceID, doc.ID, "created", r)
-	s.publishEvent(events.DocumentCreated, workspaceID, doc.ID, doc.Title, doc.DocType, actor, source)
+	s.publishEventWithName(events.DocumentCreated, workspaceID, doc.ID, doc.Title, doc.DocType, actor, actorNameFromRequest(r), source)
 
 	writeJSON(w, http.StatusCreated, doc)
 }
@@ -141,7 +141,7 @@ func (s *Server) handleUpdateDocument(w http.ResponseWriter, r *http.Request) {
 	if !isWebAutoSave {
 		s.logActivity(updated.WorkspaceID, updated.ID, "updated", r)
 	}
-	s.publishEvent(events.DocumentUpdated, updated.WorkspaceID, updated.ID, updated.Title, updated.DocType, actor, source)
+	s.publishEventWithName(events.DocumentUpdated, updated.WorkspaceID, updated.ID, updated.Title, updated.DocType, actor, actorNameFromRequest(r), source)
 
 	writeJSON(w, http.StatusOK, updated)
 }
@@ -159,7 +159,7 @@ func (s *Server) handleDeleteDocument(w http.ResponseWriter, r *http.Request) {
 
 	actor, source := actorFromRequest(r)
 	s.logActivity(doc.WorkspaceID, doc.ID, "archived", r)
-	s.publishEvent(events.DocumentArchived, doc.WorkspaceID, doc.ID, doc.Title, doc.DocType, actor, source)
+	s.publishEventWithName(events.DocumentArchived, doc.WorkspaceID, doc.ID, doc.Title, doc.DocType, actor, actorNameFromRequest(r), source)
 
 	w.WriteHeader(http.StatusNoContent)
 }
@@ -189,7 +189,7 @@ func (s *Server) handleRestoreDocument(w http.ResponseWriter, r *http.Request) {
 
 	actor, source := actorFromRequest(r)
 	s.logActivity(doc.WorkspaceID, doc.ID, "restored", r)
-	s.publishEvent(events.DocumentRestored, doc.WorkspaceID, doc.ID, doc.Title, doc.DocType, actor, source)
+	s.publishEventWithName(events.DocumentRestored, doc.WorkspaceID, doc.ID, doc.Title, doc.DocType, actor, actorNameFromRequest(r), source)
 
 	writeJSON(w, http.StatusOK, doc)
 }
@@ -238,7 +238,7 @@ func (s *Server) handleQuickSave(w http.ResponseWriter, r *http.Request) {
 	if action == "created" {
 		eventType = events.DocumentCreated
 	}
-	s.publishEvent(eventType, workspaceID, doc.ID, doc.Title, doc.DocType, actor, source)
+	s.publishEventWithName(eventType, workspaceID, doc.ID, doc.Title, doc.DocType, actor, actorNameFromRequest(r), source)
 
 	status := http.StatusOK
 	if action == "created" {
@@ -343,6 +343,11 @@ func (s *Server) handleGetContext(w http.ResponseWriter, r *http.Request) {
 
 // publishEvent publishes a real-time event if the event bus is available (best-effort).
 func (s *Server) publishEvent(eventType, workspaceID, documentID, title, docType, actor, source string) {
+	s.publishEventWithName(eventType, workspaceID, documentID, title, docType, actor, "", source)
+}
+
+// publishEventWithName publishes a real-time event with actor name.
+func (s *Server) publishEventWithName(eventType, workspaceID, documentID, title, docType, actor, actorName, source string) {
 	if s.events == nil {
 		return
 	}
@@ -353,8 +358,17 @@ func (s *Server) publishEvent(eventType, workspaceID, documentID, title, docType
 		Title:       title,
 		DocType:     docType,
 		Actor:       actor,
+		ActorName:   actorName,
 		Source:      source,
 	})
+}
+
+// actorNameFromRequest returns the authenticated user's display name, or empty string.
+func actorNameFromRequest(r *http.Request) string {
+	if u := currentUser(r); u != nil {
+		return u.Name
+	}
+	return ""
 }
 
 // actorFromRequest derives actor and source from the request's auth context.
@@ -410,6 +424,7 @@ func (s *Server) logActivityWithMeta(workspaceID, documentID, action string, r *
 		Actor:       actor,
 		Source:      source,
 		Metadata:    metadata,
+		UserID:      currentUserID(r),
 	})
 }
 

--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -145,7 +145,7 @@ func (s *Server) handleCreateItem(w http.ResponseWriter, r *http.Request) {
 
 	actor, source := actorFromRequest(r)
 	s.logActivity(workspaceID, item.ID, "created", r)
-	s.publishItemEvent(events.ItemCreated, workspaceID, item.ID, item.Title, collSlug, actor, source)
+	s.publishItemEventWithName(events.ItemCreated, workspaceID, item.ID, item.Title, collSlug, actor, actorNameFromRequest(r), source)
 	s.dispatchWebhook(workspaceID, "item.created", item)
 
 	writeJSON(w, http.StatusCreated, item)
@@ -261,7 +261,7 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 	}
 	actor, source := actorFromRequest(r)
 	s.logActivityWithMeta(workspaceID, updated.ID, "updated", r, meta)
-	s.publishItemEvent(events.ItemUpdated, workspaceID, updated.ID, updated.Title, updated.CollectionSlug, actor, source)
+	s.publishItemEventWithName(events.ItemUpdated, workspaceID, updated.ID, updated.Title, updated.CollectionSlug, actor, actorNameFromRequest(r), source)
 	s.dispatchWebhook(workspaceID, "item.updated", updated)
 
 	writeJSON(w, http.StatusOK, updated)
@@ -292,7 +292,7 @@ func (s *Server) handleDeleteItem(w http.ResponseWriter, r *http.Request) {
 
 	actor, source := actorFromRequest(r)
 	s.logActivity(workspaceID, item.ID, "archived", r)
-	s.publishItemEvent(events.ItemArchived, workspaceID, item.ID, item.Title, item.CollectionSlug, actor, source)
+	s.publishItemEventWithName(events.ItemArchived, workspaceID, item.ID, item.Title, item.CollectionSlug, actor, actorNameFromRequest(r), source)
 	s.dispatchWebhook(workspaceID, "item.deleted", item)
 
 	w.WriteHeader(http.StatusNoContent)
@@ -330,7 +330,7 @@ func (s *Server) handleRestoreItem(w http.ResponseWriter, r *http.Request) {
 
 	actor, source := actorFromRequest(r)
 	s.logActivity(workspaceID, restored.ID, "restored", r)
-	s.publishItemEvent(events.ItemRestored, workspaceID, restored.ID, restored.Title, restored.CollectionSlug, actor, source)
+	s.publishItemEventWithName(events.ItemRestored, workspaceID, restored.ID, restored.Title, restored.CollectionSlug, actor, actorNameFromRequest(r), source)
 
 	writeJSON(w, http.StatusOK, restored)
 }
@@ -434,7 +434,7 @@ func (s *Server) handleMoveItem(w http.ResponseWriter, r *http.Request) {
 	s.logActivityWithMeta(workspaceID, moved.ID, "moved", r, moveMeta)
 
 	// Publish events for both old and new collections
-	s.publishItemEvent(events.ItemUpdated, workspaceID, moved.ID, moved.Title, targetColl.Slug, actor, source)
+	s.publishItemEventWithName(events.ItemUpdated, workspaceID, moved.ID, moved.Title, targetColl.Slug, actor, actorNameFromRequest(r), source)
 	s.dispatchWebhook(workspaceID, "item.moved", moved)
 
 	writeJSON(w, http.StatusOK, moved)
@@ -442,6 +442,11 @@ func (s *Server) handleMoveItem(w http.ResponseWriter, r *http.Request) {
 
 // publishItemEvent publishes a real-time event for item changes.
 func (s *Server) publishItemEvent(eventType, workspaceID, itemID, title, collection, actor, source string) {
+	s.publishItemEventWithName(eventType, workspaceID, itemID, title, collection, actor, "", source)
+}
+
+// publishItemEventWithName publishes a real-time event for item changes with actor name.
+func (s *Server) publishItemEventWithName(eventType, workspaceID, itemID, title, collection, actor, actorName, source string) {
 	if s.events == nil {
 		return
 	}
@@ -452,6 +457,7 @@ func (s *Server) publishItemEvent(eventType, workspaceID, itemID, title, collect
 		Collection:  collection,
 		Title:       title,
 		Actor:       actor,
+		ActorName:   actorName,
 		Source:      source,
 	})
 }
@@ -649,4 +655,45 @@ func parseItemListParams(r *http.Request) models.ItemListParams {
 	}
 
 	return params
+}
+
+// handleListItemActivity returns the activity feed for a specific item.
+func (s *Server) handleListItemActivity(w http.ResponseWriter, r *http.Request) {
+	workspaceID, ok := s.getWorkspaceID(w, r)
+	if !ok {
+		return
+	}
+
+	itemSlug := chi.URLParam(r, "itemSlug")
+	item, err := s.store.ResolveItem(workspaceID, itemSlug)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", err.Error())
+		return
+	}
+	if item == nil {
+		writeError(w, http.StatusNotFound, "not_found", "Item not found")
+		return
+	}
+
+	params := models.ActivityListParams{
+		Action: r.URL.Query().Get("action"),
+		Actor:  r.URL.Query().Get("actor"),
+		Source: r.URL.Query().Get("source"),
+	}
+	if limitStr := r.URL.Query().Get("limit"); limitStr != "" {
+		if l, err := strconv.Atoi(limitStr); err == nil {
+			params.Limit = l
+		}
+	}
+
+	activities, err := s.store.ListDocumentActivity(item.ID, params)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", err.Error())
+		return
+	}
+	if activities == nil {
+		activities = []models.Activity{}
+	}
+
+	writeJSON(w, http.StatusOK, activities)
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -171,6 +171,7 @@ func (s *Server) setupRouter() {
 					r.Post("/move", s.handleMoveItem)
 					r.Get("/versions", s.handleListItemVersions)
 					r.Post("/versions/{versionID}/restore", s.handleRestoreItemVersion)
+					r.Get("/activity", s.handleListItemActivity)
 					r.Get("/links", s.handleGetItemLinks)
 					r.Post("/links", s.handleCreateItemLink)
 					r.Get("/comments", s.handleListComments)

--- a/internal/store/activities.go
+++ b/internal/store/activities.go
@@ -14,34 +14,35 @@ func (s *Store) CreateActivity(a models.Activity) error {
 	ts := now()
 
 	_, err := s.db.Exec(`
-		INSERT INTO activities (id, workspace_id, document_id, action, actor, source, metadata, created_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-	`, a.ID, a.WorkspaceID, nilIfEmpty(a.DocumentID), a.Action, a.Actor, a.Source, a.Metadata, ts)
+		INSERT INTO activities (id, workspace_id, document_id, action, actor, source, metadata, user_id, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`, a.ID, a.WorkspaceID, nilIfEmpty(a.DocumentID), a.Action, a.Actor, a.Source, a.Metadata, nilIfEmpty(a.UserID), ts)
 	return err
 }
 
 func (s *Store) ListWorkspaceActivity(workspaceID string, params models.ActivityListParams) ([]models.Activity, error) {
 	query := `
-		SELECT id, workspace_id, COALESCE(document_id, ''), action, actor, source, metadata, created_at
-		FROM activities
-		WHERE workspace_id = ?
+		SELECT a.id, a.workspace_id, COALESCE(a.document_id, ''), a.action, a.actor, a.source, a.metadata, COALESCE(a.user_id, ''), a.created_at, COALESCE(u.name, '')
+		FROM activities a
+		LEFT JOIN users u ON a.user_id = u.id
+		WHERE a.workspace_id = ?
 	`
 	args := []interface{}{workspaceID}
 
 	if params.Action != "" {
-		query += " AND action = ?"
+		query += " AND a.action = ?"
 		args = append(args, params.Action)
 	}
 	if params.Actor != "" {
-		query += " AND actor = ?"
+		query += " AND a.actor = ?"
 		args = append(args, params.Actor)
 	}
 	if params.Source != "" {
-		query += " AND source = ?"
+		query += " AND a.source = ?"
 		args = append(args, params.Source)
 	}
 
-	query += " ORDER BY created_at DESC"
+	query += " ORDER BY a.created_at DESC"
 
 	limit := params.Limit
 	if limit <= 0 {
@@ -58,27 +59,28 @@ func (s *Store) ListWorkspaceActivity(workspaceID string, params models.Activity
 	}
 	defer rows.Close()
 
-	return scanActivities(rows)
+	return scanActivitiesWithUser(rows)
 }
 
 func (s *Store) ListDocumentActivity(documentID string, params models.ActivityListParams) ([]models.Activity, error) {
 	query := `
-		SELECT id, workspace_id, COALESCE(document_id, ''), action, actor, source, metadata, created_at
-		FROM activities
-		WHERE document_id = ?
+		SELECT a.id, a.workspace_id, COALESCE(a.document_id, ''), a.action, a.actor, a.source, a.metadata, COALESCE(a.user_id, ''), a.created_at, COALESCE(u.name, '')
+		FROM activities a
+		LEFT JOIN users u ON a.user_id = u.id
+		WHERE a.document_id = ?
 	`
 	args := []interface{}{documentID}
 
 	if params.Action != "" {
-		query += " AND action = ?"
+		query += " AND a.action = ?"
 		args = append(args, params.Action)
 	}
 	if params.Actor != "" {
-		query += " AND actor = ?"
+		query += " AND a.actor = ?"
 		args = append(args, params.Actor)
 	}
 
-	query += " ORDER BY created_at DESC"
+	query += " ORDER BY a.created_at DESC"
 
 	limit := params.Limit
 	if limit <= 0 {
@@ -95,10 +97,10 @@ func (s *Store) ListDocumentActivity(documentID string, params models.ActivityLi
 	}
 	defer rows.Close()
 
-	return scanActivities(rows)
+	return scanActivitiesWithUser(rows)
 }
 
-func scanActivities(rows interface {
+func scanActivitiesWithUser(rows interface {
 	Next() bool
 	Scan(dest ...interface{}) error
 	Err() error
@@ -107,7 +109,7 @@ func scanActivities(rows interface {
 	for rows.Next() {
 		var a models.Activity
 		var createdAt string
-		if err := rows.Scan(&a.ID, &a.WorkspaceID, &a.DocumentID, &a.Action, &a.Actor, &a.Source, &a.Metadata, &createdAt); err != nil {
+		if err := rows.Scan(&a.ID, &a.WorkspaceID, &a.DocumentID, &a.Action, &a.Actor, &a.Source, &a.Metadata, &a.UserID, &createdAt, &a.ActorName); err != nil {
 			return nil, err
 		}
 		a.CreatedAt = parseTime(createdAt)

--- a/web/src/lib/components/activity/ActivityFeed.svelte
+++ b/web/src/lib/components/activity/ActivityFeed.svelte
@@ -16,6 +16,12 @@
 		return actor === 'agent' ? '🤖' : '👤';
 	}
 
+	function actorLabel(a: Activity): string {
+		if (a.actor === 'agent') return 'Agent';
+		if (a.actor_name) return a.actor_name;
+		return 'You';
+	}
+
 	function sourceLabel(source: string): string {
 		const labels: Record<string, string> = {
 			cli: 'CLI', web: 'Web', skill: 'Skill',
@@ -30,7 +36,7 @@
 			<span class="actor">{actorIcon(a.actor)}</span>
 			<div class="info">
 				<span class="action">
-					{actorIcon(a.actor) === '🤖' ? 'Agent' : 'You'} {actionLabel(a.action)}
+					{actorLabel(a)} {actionLabel(a.action)}
 					{#if a.item_id}
 						a document
 					{/if}

--- a/web/src/lib/services/sse.svelte.ts
+++ b/web/src/lib/services/sse.svelte.ts
@@ -9,6 +9,7 @@ export interface ItemEvent {
 	title: string;
 	collection: string;
 	actor: string;
+	actor_name?: string;
 	source: string;
 	timestamp: number;
 }

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -235,6 +235,7 @@ export interface Activity {
 	item_id?: string;
 	action: string;
 	actor: string;
+	actor_name?: string;
 	source: string;
 	metadata: string;
 	created_at: string;
@@ -279,6 +280,7 @@ export interface DashboardResponse {
 	recent_activity: {
 		action: string;
 		actor: string;
+		actor_name?: string;
 		source: string;
 		created_at: string;
 		item_title?: string;

--- a/web/src/routes/[workspace]/+layout.svelte
+++ b/web/src/routes/[workspace]/+layout.svelte
@@ -52,7 +52,7 @@
 						// Item might not be fetchable by event ID, refresh collection
 					}
 					if (isExternal) {
-						const who = event.actor === 'agent' ? 'Agent' : 'CLI';
+						const who = event.actor === 'agent' ? 'Agent' : (event.actor_name || 'CLI');
 						const link = event.collection ? `/${wsSlug}/${event.collection}/${event.item_id}` : undefined;
 						toastStore.show(`${who} created: ${event.title}`, 'info', 4000, link);
 					}

--- a/web/src/routes/[workspace]/+page.svelte
+++ b/web/src/routes/[workspace]/+page.svelte
@@ -366,8 +366,10 @@
 					{#each dashboard.recent_activity.slice(0, 10) as activity, i (i)}
 						{@const changes = parseActivityChanges(activity.metadata)}
 						<div class="activity-row">
-							{#if activity.source === 'cli' && activity.actor === 'agent'}
+							{#if activity.actor === 'agent'}
 								<span class="actor-badge agent">agent</span>
+							{:else if activity.actor_name}
+								<span class="actor-name">{activity.actor_name}</span>
 							{:else if activity.source === 'cli'}
 								<span class="actor-badge cli">cli</span>
 							{/if}
@@ -899,6 +901,13 @@
 	.actor-badge.cli {
 		background: color-mix(in srgb, var(--accent-blue) 15%, transparent);
 		color: var(--accent-blue);
+	}
+	.actor-name {
+		font-size: 0.8em;
+		font-weight: 600;
+		color: var(--text-secondary);
+		white-space: nowrap;
+		flex-shrink: 0;
 	}
 	.activity-changes {
 		font-size: 0.75em;

--- a/web/src/routes/[workspace]/activity/+page.svelte
+++ b/web/src/routes/[workspace]/activity/+page.svelte
@@ -180,8 +180,9 @@
 		}
 	}
 
-	function getSourceLabel(source: string, actor: string): { label: string; kind: string } {
-		if (source === 'cli' && actor === 'agent') return { label: 'agent', kind: 'agent' };
+	function getSourceLabel(source: string, actor: string, actorName?: string): { label: string; kind: string } {
+		if (actor === 'agent') return { label: 'agent', kind: 'agent' };
+		if (actorName) return { label: actorName, kind: source === 'cli' ? 'cli' : 'user' };
 		if (source === 'cli') return { label: 'cli', kind: 'cli' };
 		return { label: 'web', kind: 'web' };
 	}
@@ -303,7 +304,7 @@
 							{@const itemTitle = activity.item_title || meta.item_title || meta.title}
 							{@const itemSlug = activity.item_slug || meta.item_slug}
 							{@const collSlug = activity.collection_slug || meta.collection_slug}
-							{@const src = getSourceLabel(activity.source, activity.actor)}
+							{@const src = getSourceLabel(activity.source, activity.actor, activity.actor_name)}
 							<div class="entry {borderClass(activity.source, activity.actor)}">
 								<span
 									class="entry-icon"
@@ -591,6 +592,12 @@
 	.actor-badge.web {
 		background: var(--bg-tertiary);
 		color: var(--text-muted);
+	}
+	.actor-badge.user {
+		background: color-mix(in srgb, var(--accent-green) 15%, transparent);
+		color: var(--accent-green);
+		text-transform: none;
+		letter-spacing: normal;
 	}
 
 	.entry-time {


### PR DESCRIPTION
## Summary
- Activity feeds previously showed generic "user" or "agent" labels — now they display the actual user's name
- Backend: activity queries JOIN against users table, all activity creation stores `user_id`, SSE events include `actor_name`
- Frontend: dashboard, activity page, notification toasts, and activity feed all render user names with graceful fallback for pre-auth activities or deleted users

**Implements IDEA-73**

## Changes
- `internal/models/activity.go` — Added `UserID` and `ActorName` fields
- `internal/store/activities.go` — LEFT JOIN users on activity queries, persist `user_id` on create
- `internal/server/handlers_documents.go` — Extract user name from auth context, include in events
- `internal/server/handlers_dashboard.go` — Added `ActorName` to dashboard activity response
- `internal/server/handlers_items.go` — Include user name in item SSE events
- `internal/events/bus.go` — Added `ActorName` to SSE Event struct
- `web/src/lib/types/index.ts` — Added `actor_name` to TypeScript types
- `web/src/lib/services/sse.svelte.ts` — Added `actor_name` to SSE event interface
- `web/src/lib/components/activity/ActivityFeed.svelte` — Show user name with fallback logic
- `web/src/routes/[workspace]/+page.svelte` — Dashboard activity shows user names
- `web/src/routes/[workspace]/activity/+page.svelte` — Activity page shows user names
- `web/src/routes/[workspace]/+layout.svelte` — SSE toasts show user names

## Test plan
- [ ] Activity feed on dashboard shows user display names instead of "user"
- [ ] Activity page shows user names with styled badges
- [ ] Real-time SSE toasts show "Dave updated..." instead of "CLI updated..."
- [ ] Pre-auth activities (no user_id) gracefully fall back to actor/source labels
- [ ] `go test ./...` passes
- [ ] `npm run build` passes