### PR TITLE
Fix blank item history by merging activity + content versions

### DIFF
--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -650,3 +650,44 @@ func parseItemListParams(r *http.Request) models.ItemListParams {
 
 	return params
 }
+
+// handleListItemActivity returns the activity feed for a specific item.
+func (s *Server) handleListItemActivity(w http.ResponseWriter, r *http.Request) {
+	workspaceID, ok := s.getWorkspaceID(w, r)
+	if !ok {
+		return
+	}
+
+	itemSlug := chi.URLParam(r, "itemSlug")
+	item, err := s.store.ResolveItem(workspaceID, itemSlug)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", err.Error())
+		return
+	}
+	if item == nil {
+		writeError(w, http.StatusNotFound, "not_found", "Item not found")
+		return
+	}
+
+	params := models.ActivityListParams{
+		Action: r.URL.Query().Get("action"),
+		Actor:  r.URL.Query().Get("actor"),
+		Source: r.URL.Query().Get("source"),
+	}
+	if limitStr := r.URL.Query().Get("limit"); limitStr != "" {
+		if l, err := strconv.Atoi(limitStr); err == nil {
+			params.Limit = l
+		}
+	}
+
+	activities, err := s.store.ListDocumentActivity(item.ID, params)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", err.Error())
+		return
+	}
+	if activities == nil {
+		activities = []models.Activity{}
+	}
+
+	writeJSON(w, http.StatusOK, activities)
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -171,6 +171,7 @@ func (s *Server) setupRouter() {
 					r.Post("/move", s.handleMoveItem)
 					r.Get("/versions", s.handleListItemVersions)
 					r.Post("/versions/{versionID}/restore", s.handleRestoreItemVersion)
+					r.Get("/activity", s.handleListItemActivity)
 					r.Get("/links", s.handleGetItemLinks)
 					r.Post("/links", s.handleCreateItemLink)
 					r.Get("/comments", s.handleListComments)

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -195,7 +195,11 @@ export const api = {
 		restore: (ws: string, itemSlug: string, versionId: string) =>
 			request<Item>(`/workspaces/${ws}/items/${itemSlug}/versions/${versionId}/restore`, {
 				method: 'POST'
-			})
+			}),
+
+		/** Activity feed for a single item (all changes, not just content versions). */
+		activity: (ws: string, itemSlug: string) =>
+			request<Activity[]>(`/workspaces/${ws}/items/${itemSlug}/activity`)
 	},
 
 	// ── Links ─────────────────────────────────────────────────────────────────

--- a/web/src/lib/components/versions/VersionHistory.svelte
+++ b/web/src/lib/components/versions/VersionHistory.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { Version, Item } from '$lib/types';
+	import type { Version, Item, Activity } from '$lib/types';
 	import { api } from '$lib/api/client';
 	import { toastStore } from '$lib/stores/toast.svelte';
 	import DiffView from './DiffView.svelte';
@@ -15,58 +15,165 @@
 
 	let { wsSlug, itemSlug, currentContent, onRestore, onClose }: Props = $props();
 
+	/** A unified timeline entry -- either a content version or an activity event. */
+	interface TimelineEntry {
+		id: string;
+		kind: 'version' | 'activity';
+		created_at: string;
+		actor: string;
+		actor_name: string;
+		source: string;
+		summary: string;
+		/** Only for version entries */
+		version?: Version;
+		/** Only for activity entries */
+		activity?: Activity;
+	}
+
 	let versions = $state<Version[]>([]);
+	let activities = $state<Activity[]>([]);
 	let loading = $state(true);
 	let error = $state('');
-	let selectedVersionId = $state<string | null>(null);
+	let selectedEntryId = $state<string | null>(null);
 	let confirmingRestoreId = $state<string | null>(null);
 	let restoringId = $state<string | null>(null);
 
-	let selectedVersion = $derived(
-		selectedVersionId ? versions.find((v) => v.id === selectedVersionId) ?? null : null
+	/** Merge versions and activities into a single timeline sorted newest-first. */
+	let timeline = $derived.by(() => {
+		const entries: TimelineEntry[] = [];
+
+		// Track version timestamps to avoid showing duplicate activity entries
+		const versionTimestamps = new Set<number>();
+		for (const v of versions) {
+			versionTimestamps.add(Math.floor(new Date(v.created_at).getTime() / 1000));
+		}
+
+		// Add version entries
+		for (const v of versions) {
+			entries.push({
+				id: v.id,
+				kind: 'version',
+				created_at: v.created_at,
+				actor: v.created_by,
+				actor_name: '',
+				source: v.source,
+				summary: v.change_summary || 'Content updated',
+				version: v
+			});
+		}
+
+		// Filter activity entries:
+		// 1. Skip "updated" activities that have a matching version at the same second
+		// 2. Collapse rapid content autosaves (empty-metadata "updated" entries within 5 min)
+		//    into a single entry to reduce noise
+		const sortedActivities = [...activities].sort(
+			(a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+		);
+
+		let lastContentSaveTime = 0;
+		for (const a of sortedActivities) {
+			const aTime = Math.floor(new Date(a.created_at).getTime() / 1000);
+			const hasMatchingVersion = a.action === 'updated' && versionTimestamps.has(aTime);
+			if (hasMatchingVersion) continue;
+
+			// Collapse rapid content autosaves: if this is an "updated" with no meaningful
+			// metadata and is within 5 minutes of the last one we kept, skip it
+			const isEmptyUpdate = a.action === 'updated' && (!a.metadata || a.metadata === '{}');
+			if (isEmptyUpdate) {
+				if (lastContentSaveTime > 0 && (lastContentSaveTime - aTime) < 300) {
+					continue; // Skip -- too close to a newer save we already kept
+				}
+				lastContentSaveTime = aTime;
+			}
+
+			entries.push({
+				id: `activity-${a.id}`,
+				kind: 'activity',
+				created_at: a.created_at,
+				actor: a.actor,
+				actor_name: a.actor_name ?? '',
+				source: a.source,
+				summary: formatActivitySummary(a),
+				activity: a
+			});
+		}
+
+		// Sort newest first
+		entries.sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime());
+		return entries;
+	});
+
+	let selectedEntry = $derived(
+		selectedEntryId ? timeline.find((e) => e.id === selectedEntryId) ?? null : null
 	);
 
 	let diffOldContent = $derived.by(() => {
-		if (!selectedVersion) return '';
-		return selectedVersion.content;
+		if (!selectedEntry?.version) return '';
+		return selectedEntry.version.content;
 	});
 
 	let diffNewContent = $derived.by(() => {
-		if (!selectedVersion) return '';
-		const idx = versions.findIndex((v) => v.id === selectedVersion!.id);
+		if (!selectedEntry?.version) return '';
+		const idx = versions.findIndex((v) => v.id === selectedEntry!.version!.id);
 		if (idx <= 0) {
-			// Newest or only version — diff against current content
 			return currentContent;
 		}
-		// Diff against the next newer version
 		return versions[idx - 1].content;
 	});
 
 	$effect(() => {
-		loadVersions();
+		loadHistory();
 	});
 
-	async function loadVersions() {
+	async function loadHistory() {
 		loading = true;
 		error = '';
 		try {
-			const result = await api.versions.list(wsSlug, itemSlug);
-			// Sort newest first
-			versions = result.sort(
+			const [versionResult, activityResult] = await Promise.all([
+				api.versions.list(wsSlug, itemSlug),
+				api.versions.activity(wsSlug, itemSlug)
+			]);
+			versions = versionResult.sort(
 				(a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
 			);
+			activities = activityResult;
 		} catch (err) {
-			error = err instanceof Error ? err.message : 'Failed to load versions';
+			error = err instanceof Error ? err.message : 'Failed to load history';
 		} finally {
 			loading = false;
 		}
 	}
 
-	function selectVersion(id: string) {
-		if (selectedVersionId === id) {
-			selectedVersionId = null;
+	function formatActivitySummary(a: Activity): string {
+		const actionLabels: Record<string, string> = {
+			created: 'Item created',
+			updated: 'Item updated',
+			archived: 'Item archived',
+			restored: 'Item restored',
+			moved: 'Item moved'
+		};
+		let label = actionLabels[a.action] ?? a.action;
+
+		// Parse metadata for richer descriptions
+		if (a.metadata && a.metadata !== '{}') {
+			try {
+				const meta = JSON.parse(a.metadata);
+				if (meta.changes) {
+					label = meta.changes;
+				}
+				if (meta.from_collection && meta.to_collection) {
+					label = `Moved from ${meta.from_collection} to ${meta.to_collection}`;
+				}
+			} catch { /* ignore parse errors */ }
+		}
+		return label;
+	}
+
+	function selectEntry(id: string) {
+		if (selectedEntryId === id) {
+			selectedEntryId = null;
 		} else {
-			selectedVersionId = id;
+			selectedEntryId = id;
 			confirmingRestoreId = null;
 		}
 	}
@@ -94,8 +201,9 @@
 		}
 	}
 
-	function actorLabel(actor: string): string {
-		return actor === 'agent' ? 'Agent' : 'User';
+	function actorLabel(entry: TimelineEntry): string {
+		if (entry.actor_name) return entry.actor_name;
+		return entry.actor === 'agent' ? 'Agent' : 'User';
 	}
 
 	function sourceLabel(source: string): string {
@@ -110,7 +218,7 @@
 
 <div class="version-panel">
 	<div class="panel-header">
-		<h3>Version History</h3>
+		<h3>History</h3>
 		{#if onClose}
 			<button class="close-btn" type="button" onclick={onClose}>&#10005;</button>
 		{/if}
@@ -120,96 +228,124 @@
 		{#if loading}
 			<div class="loading">
 				<span class="spinner"></span>
-				<span>Loading versions...</span>
+				<span>Loading history...</span>
 			</div>
 		{:else if error}
 			<div class="error-msg">{error}</div>
-		{:else if versions.length === 0}
+		{:else if timeline.length === 0}
 			<div class="empty-state">
 				<span class="empty-icon">&#128196;</span>
-				<p>No version history yet</p>
-				<p class="empty-hint">Versions are created automatically when content is saved.</p>
+				<p>No history yet</p>
+				<p class="empty-hint">Changes to this item will appear here automatically.</p>
 			</div>
 		{:else}
 			<div class="timeline">
-				{#each versions as version, i (version.id)}
-					{@const isSelected = selectedVersionId === version.id}
-					{@const isConfirming = confirmingRestoreId === version.id}
-					{@const isRestoring = restoringId === version.id}
+				{#each timeline as entry, i (entry.id)}
+					{@const isSelected = selectedEntryId === entry.id}
+					{@const isVersion = entry.kind === 'version'}
+					{@const isConfirming = confirmingRestoreId === entry.id}
+					{@const isRestoring = restoringId === entry.id}
 
 					<div class="timeline-entry" class:selected={isSelected}>
 						<div class="timeline-marker">
-							<div class="marker-dot" class:active={isSelected}></div>
-							{#if i < versions.length - 1}
+							<div
+								class="marker-dot"
+								class:active={isSelected}
+								class:marker-version={isVersion}
+							></div>
+							{#if i < timeline.length - 1}
 								<div class="marker-line"></div>
 							{/if}
 						</div>
 
 						<div class="entry-content">
-							<button
-								class="entry-header"
-								type="button"
-								onclick={() => selectVersion(version.id)}
-							>
-								<div class="entry-meta">
-									<span class="entry-time" title={new Date(version.created_at).toLocaleString()}>{relativeTime(version.created_at)}</span>
-									<div class="badges">
-										<span
-											class="badge"
-											class:badge-agent={version.created_by === 'agent'}
-											class:badge-user={version.created_by !== 'agent'}
-										>
-											{actorLabel(version.created_by)}
-										</span>
-										<span class="badge badge-source">
-											{sourceLabel(version.source)}
-										</span>
-									</div>
-								</div>
-								{#if version.change_summary}
-									<p class="change-summary">{version.change_summary}</p>
-								{/if}
-							</button>
-
-							{#if isSelected}
-								<div class="entry-details">
-									<div class="diff-container">
-										<DiffView oldContent={diffOldContent} newContent={diffNewContent} />
-									</div>
-
-									<div class="restore-area">
-										{#if isConfirming}
-											<div class="confirm-prompt">
-												<span class="confirm-text">Restore to this version?</span>
-												<div class="confirm-actions">
-													<button
-														class="btn-cancel"
-														type="button"
-														onclick={cancelRestore}
-														disabled={isRestoring}
-													>
-														Cancel
-													</button>
-													<button
-														class="btn-restore-confirm"
-														type="button"
-														onclick={() => confirmRestore(version.id)}
-														disabled={isRestoring}
-													>
-														{isRestoring ? 'Restoring...' : 'Confirm Restore'}
-													</button>
-												</div>
-											</div>
-										{:else}
-											<button
-												class="btn-restore"
-												type="button"
-												onclick={() => startRestore(version.id)}
+							{#if isVersion}
+								<button
+									class="entry-header"
+									type="button"
+									onclick={() => selectEntry(entry.id)}
+								>
+									<div class="entry-meta">
+										<span class="entry-time" title={new Date(entry.created_at).toLocaleString()}>{relativeTime(entry.created_at)}</span>
+										<div class="badges">
+											<span class="badge badge-version">Content</span>
+											<span
+												class="badge"
+												class:badge-agent={entry.actor === 'agent'}
+												class:badge-user={entry.actor !== 'agent'}
 											>
-												Restore this version
-											</button>
-										{/if}
+												{actorLabel(entry)}
+											</span>
+											<span class="badge badge-source">
+												{sourceLabel(entry.source)}
+											</span>
+										</div>
 									</div>
+									{#if entry.summary}
+										<p class="change-summary">{entry.summary}</p>
+									{/if}
+								</button>
+
+								{#if isSelected}
+									<div class="entry-details">
+										<div class="diff-container">
+											<DiffView oldContent={diffOldContent} newContent={diffNewContent} />
+										</div>
+
+										<div class="restore-area">
+											{#if isConfirming}
+												<div class="confirm-prompt">
+													<span class="confirm-text">Restore to this version?</span>
+													<div class="confirm-actions">
+														<button
+															class="btn-cancel"
+															type="button"
+															onclick={cancelRestore}
+															disabled={isRestoring}
+														>
+															Cancel
+														</button>
+														<button
+															class="btn-restore-confirm"
+															type="button"
+															onclick={() => confirmRestore(entry.version!.id)}
+															disabled={isRestoring}
+														>
+															{isRestoring ? 'Restoring...' : 'Confirm Restore'}
+														</button>
+													</div>
+												</div>
+											{:else}
+												<button
+													class="btn-restore"
+													type="button"
+													onclick={() => startRestore(entry.id)}
+												>
+													Restore this version
+												</button>
+											{/if}
+										</div>
+									</div>
+								{/if}
+							{:else}
+								<!-- Activity entry (non-expandable) -->
+								<div class="entry-header activity-entry">
+									<div class="entry-meta">
+										<span class="entry-time" title={new Date(entry.created_at).toLocaleString()}>{relativeTime(entry.created_at)}</span>
+										<div class="badges">
+											<span
+												class="badge"
+												class:badge-agent={entry.actor === 'agent'}
+												class:badge-user={entry.actor !== 'agent'}
+											>
+												{actorLabel(entry)}
+											</span>
+											<span class="badge badge-source">
+												{sourceLabel(entry.source)}
+											</span>
+										</div>
+									</div>
+									<p class="change-summary">{entry.summary}</p>
 								</div>
 							{/if}
 						</div>
@@ -221,8 +357,6 @@
 </div>
 
 <style>
-	/* ── Panel ──────────────────────────────────────────────────────────────── */
-
 	.version-panel {
 		background: var(--bg-secondary);
 		border: 1px solid var(--border);
@@ -232,8 +366,6 @@
 		flex-direction: column;
 		max-height: 100%;
 	}
-
-	/* ── Header ─────────────────────────────────────────────────────────────── */
 
 	.panel-header {
 		display: flex;
@@ -267,15 +399,11 @@
 		background: var(--bg-tertiary);
 	}
 
-	/* ── Body ───────────────────────────────────────────────────────────────── */
-
 	.panel-body {
 		overflow-y: auto;
 		flex: 1;
 		padding: var(--space-3) var(--space-4);
 	}
-
-	/* ── Loading ─────────────────────────────────────────────────────────────── */
 
 	.loading {
 		display: flex;
@@ -297,12 +425,8 @@
 	}
 
 	@keyframes spin {
-		to {
-			transform: rotate(360deg);
-		}
+		to { transform: rotate(360deg); }
 	}
-
-	/* ── Error ──────────────────────────────────────────────────────────────── */
 
 	.error-msg {
 		padding: var(--space-2) var(--space-3);
@@ -311,8 +435,6 @@
 		border-radius: var(--radius);
 		font-size: 0.85em;
 	}
-
-	/* ── Empty state ────────────────────────────────────────────────────────── */
 
 	.empty-state {
 		text-align: center;
@@ -326,10 +448,7 @@
 		margin-bottom: var(--space-2);
 	}
 
-	.empty-state p {
-		margin: 0;
-		font-size: 0.9em;
-	}
+	.empty-state p { margin: 0; font-size: 0.9em; }
 
 	.empty-hint {
 		margin-top: var(--space-1) !important;
@@ -337,24 +456,13 @@
 		color: var(--text-muted);
 	}
 
-	/* ── Timeline ───────────────────────────────────────────────────────────── */
-
-	.timeline {
-		display: flex;
-		flex-direction: column;
-	}
+	.timeline { display: flex; flex-direction: column; }
 
 	.timeline-entry {
 		display: flex;
 		gap: var(--space-3);
 		position: relative;
 	}
-
-	.timeline-entry.selected {
-		/* subtle highlight */
-	}
-
-	/* ── Timeline marker ────────────────────────────────────────────────────── */
 
 	.timeline-marker {
 		display: flex;
@@ -380,14 +488,19 @@
 		border-color: var(--accent-blue);
 	}
 
+	.marker-dot.marker-version {
+		background: var(--accent-blue);
+		border-color: var(--accent-blue);
+		width: 12px;
+		height: 12px;
+	}
+
 	.marker-line {
 		width: 2px;
 		flex: 1;
 		background: var(--border);
 		min-height: var(--space-2);
 	}
-
-	/* ── Entry content ──────────────────────────────────────────────────────── */
 
 	.entry-content {
 		flex: 1;
@@ -406,9 +519,10 @@
 		color: var(--text-primary);
 	}
 
-	.entry-header:hover {
-		background: var(--bg-tertiary);
-	}
+	.entry-header:hover { background: var(--bg-tertiary); }
+
+	.entry-header.activity-entry { cursor: default; }
+	.entry-header.activity-entry:hover { background: none; }
 
 	.selected .entry-header {
 		background: var(--bg-tertiary);
@@ -428,12 +542,7 @@
 		font-weight: 500;
 	}
 
-	/* ── Badges ──────────────────────────────────────────────────────────────── */
-
-	.badges {
-		display: flex;
-		gap: var(--space-1);
-	}
+	.badges { display: flex; gap: var(--space-1); }
 
 	.badge {
 		display: inline-flex;
@@ -462,7 +571,10 @@
 		color: var(--accent-green);
 	}
 
-	/* ── Change summary ─────────────────────────────────────────────────────── */
+	.badge-version {
+		background: color-mix(in srgb, var(--accent-blue) 15%, transparent);
+		color: var(--accent-blue);
+	}
 
 	.change-summary {
 		margin: var(--space-1) 0 0 0;
@@ -470,8 +582,6 @@
 		color: var(--text-muted);
 		line-height: 1.4;
 	}
-
-	/* ── Entry details (expanded) ───────────────────────────────────────────── */
 
 	.entry-details {
 		margin-top: var(--space-2);
@@ -485,12 +595,7 @@
 		margin-bottom: var(--space-3);
 	}
 
-	/* ── Restore area ───────────────────────────────────────────────────────── */
-
-	.restore-area {
-		display: flex;
-		justify-content: flex-end;
-	}
+	.restore-area { display: flex; justify-content: flex-end; }
 
 	.btn-restore {
 		padding: var(--space-1) var(--space-3);
@@ -525,11 +630,7 @@
 		font-weight: 500;
 	}
 
-	.confirm-actions {
-		display: flex;
-		gap: var(--space-2);
-		margin-left: auto;
-	}
+	.confirm-actions { display: flex; gap: var(--space-2); margin-left: auto; }
 
 	.btn-cancel {
 		padding: var(--space-1) var(--space-3);
@@ -557,9 +658,7 @@
 		cursor: pointer;
 	}
 
-	.btn-restore-confirm:hover:not(:disabled) {
-		filter: brightness(1.1);
-	}
+	.btn-restore-confirm:hover:not(:disabled) { filter: brightness(1.1); }
 
 	.btn-restore-confirm:disabled,
 	.btn-cancel:disabled {


### PR DESCRIPTION
## Summary
- Item History panel only showed content versions (markdown body changes), so items with only field updates (status, priority, etc.) had empty history
- Rewrote VersionHistory to fetch both content versions AND activity entries, merging them into a unified timeline
- Content version entries are expandable with diff view and restore capability
- Activity entries show field changes (e.g., "status: open → done"), title changes, moves
- Collapses rapid autosave bursts and deduplicates overlapping entries

**Fixes IDEA-72**

## Changes
- `internal/server/handlers_items.go` — Added `handleListItemActivity` endpoint
- `internal/server/server.go` — Registered `GET /items/{slug}/activity` route
- `web/src/lib/api/client.ts` — Added `api.versions.activity()` method
- `web/src/lib/components/versions/VersionHistory.svelte` — Rewrote to show unified timeline of content versions + activity

## Test plan
- [ ] Item with only field changes (status, priority) shows those changes in History
- [ ] Item with content changes still shows expandable diffs with restore
- [ ] Mixed items show both types interleaved chronologically
- [ ] Rapid autosave bursts are collapsed into single entries
- [ ] Empty state shows "Changes to this item will appear here automatically"
- [ ] `go test ./...` passes
- [ ] `npm run build` passes