### PR TITLE
Fix mobile layout jump from save status transitions

### DIFF
--- a/embed.go
+++ b/embed.go
@@ -8,4 +8,4 @@ var WebUI embed.FS
 //go:embed skills/pad/SKILL.md
 var PadSkill []byte
 
-// embed cache bust: 1774743626
+// embed cache bust: 1774785399

--- a/web/src/routes/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[workspace]/[collection]/[slug]/+page.svelte
@@ -301,11 +301,9 @@
 			<span title={new Date(item.created_at).toLocaleString()}>Created {relativeTime(item.created_at)} by {item.created_by || 'unknown'}</span>
 			<span class="meta-sep">·</span>
 			<span title={new Date(item.updated_at).toLocaleString()}>Updated {relativeTime(item.updated_at)}</span>
-			{#if saveStatus === 'saving'}
-				<span class="save-status saving">Saving...</span>
-			{:else if saveStatus === 'saved'}
-				<span class="save-status saved">✓ Saved</span>
-			{/if}
+			<span class="save-status" class:saving={saveStatus === 'saving'} class:saved={saveStatus === 'saved'} class:visible={saveStatus !== 'idle'}>
+				{#if saveStatus === 'saving'}Saving...{:else}✓ Saved{/if}
+			</span>
 			<div class="meta-actions">
 				{#if quickActions.length > 0 && collection}
 					<QuickActionsMenu actions={quickActions} {item} {collection} scope="item" />
@@ -569,8 +567,10 @@
 	.save-status {
 		font-size: 0.85em;
 		margin-left: var(--space-2);
+		opacity: 0;
 		transition: opacity 0.2s;
 	}
+	.save-status.visible { opacity: 1; }
 	.save-status.saving { color: var(--text-muted); }
 	.save-status.saved { color: var(--accent-green); }
 


### PR DESCRIPTION
## Summary
- Save status text ("Saving..." / "Saved" / "Updated just now") was conditionally rendered with `{#if}`, removing it from the DOM when idle
- This caused layout reflow in the flex row on mobile, making content jump
- Replaced with always-present `<span>` using `opacity: 0/1` transitions — element stays in flow, no more jumps

**Implements IDEA-70**

## Changes
- `web/src/routes/[workspace]/[collection]/[slug]/+page.svelte` — Replaced conditional rendering with opacity-based visibility

## Test plan
- [ ] On mobile: edit an item, save status appears/disappears without content jumping
- [ ] Transitions fade smoothly between states
- [ ] Desktop behavior unchanged
- [ ] `npm run build` passes