### PR TITLE
feat: account settings, email infrastructure, and UX polish

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,7 @@ internal/
   config/                — Workspace detection, .pad.toml
   diff/                  — Version diff storage
   webhooks/              — Webhook dispatcher with HMAC signing
+  email/                 — Transactional email via Maileroo
   links/                 — Wiki-link parsing
 web/src/
   routes/                — SvelteKit pages
@@ -107,6 +108,17 @@ pad join <code>                     # Accept a workspace invitation
 ```
 
 Roles: `owner` (full access), `editor` (CRUD items), `viewer` (read-only).
+
+### Email (optional)
+
+Transactional email via Maileroo. When configured, workspace invitations are sent by email. Without it, everything works via CLI-based join codes.
+
+```bash
+# Environment variables (or ~/.pad/config.toml)
+PAD_MAILEROO_API_KEY=your-sending-key   # Required to enable email
+PAD_EMAIL_FROM=noreply@yourdomain.com   # Sender address (default: noreply@getpad.dev)
+PAD_EMAIL_FROM_NAME=Pad                 # Sender display name (default: Pad)
+```
 
 ## CLI
 

--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/xarmian/pad/internal/config"
 	"regexp"
 
+	"github.com/xarmian/pad/internal/email"
 	"github.com/xarmian/pad/internal/events"
 	"github.com/xarmian/pad/internal/models"
 	"github.com/xarmian/pad/internal/server"
@@ -207,6 +208,22 @@ func serveCmd() *cobra.Command {
 
 			// Attach webhook dispatcher for outgoing notifications
 			srv.SetWebhookDispatcher(webhooks.NewDispatcher(s))
+
+			// Attach email sender: env vars first, then platform settings overlay
+			if cfg.MailerooAPIKey != "" {
+				fromAddr := cfg.EmailFrom
+				if fromAddr == "" {
+					fromAddr = "noreply@getpad.dev"
+				}
+				fromName := cfg.EmailFromName
+				if fromName == "" {
+					fromName = "Pad"
+				}
+				srv.SetEmailSender(email.NewSender(cfg.MailerooAPIKey, fromAddr, fromName, cfg.BaseURL()))
+				log.Println("Email sending enabled via Maileroo (env)")
+			}
+			// Platform settings can override or provide email config
+			srv.InitEmailFromSettings()
 
 			// Mount embedded web UI if available
 			webFS, err := fs.Sub(pad.WebUI, "web/build")

--- a/embed.go
+++ b/embed.go
@@ -8,4 +8,4 @@ var WebUI embed.FS
 //go:embed skills/pad/SKILL.md
 var PadSkill []byte
 
-// embed cache bust: 1774786532
+// embed cache bust: 1774821189

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,6 +18,11 @@ type Config struct {
 	LogLevel string `toml:"log_level"`
 	DBPath string `toml:"-"` // computed, not from config file
 	DataDir  string `toml:"-"`        // computed
+
+	// Email (Maileroo)
+	MailerooAPIKey string `toml:"maileroo_api_key"`
+	EmailFrom      string `toml:"email_from"`      // Sender address (e.g. noreply@getpad.dev)
+	EmailFromName  string `toml:"email_from_name"`  // Sender display name (e.g. Pad)
 }
 
 func DefaultConfig() *Config {
@@ -74,6 +79,18 @@ func Load() (*Config, error) {
 		cfg.DBPath = v
 		cfg.DataDir = filepath.Dir(cfg.DBPath)
 	}
+
+	// Email (Maileroo)
+	if v := os.Getenv("PAD_MAILEROO_API_KEY"); v != "" {
+		cfg.MailerooAPIKey = v
+	}
+	if v := os.Getenv("PAD_EMAIL_FROM"); v != "" {
+		cfg.EmailFrom = v
+	}
+	if v := os.Getenv("PAD_EMAIL_FROM_NAME"); v != "" {
+		cfg.EmailFromName = v
+	}
+
 	return cfg, nil
 }
 

--- a/internal/email/sender.go
+++ b/internal/email/sender.go
@@ -1,0 +1,162 @@
+// Package email provides transactional email sending via Maileroo.
+// When no API key is configured, the server runs without email —
+// invitations fall back to CLI-based join codes.
+package email
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// Sender sends transactional emails via the Maileroo API.
+// The from address and name are defaults; individual send methods can
+// override them for contextual sender names (e.g. "Dave via Pad").
+type Sender struct {
+	mu       sync.RWMutex
+	apiKey   string
+	fromAddr string
+	fromName string
+	baseURL  string // Pad's public base URL for generating links
+	endpoint string // Maileroo API endpoint (overridable for tests)
+	client   *http.Client
+}
+
+// defaultEndpoint is the Maileroo v2 email sending API.
+const defaultEndpoint = "https://smtp.maileroo.com/api/v2/emails"
+
+// NewSender creates a new email sender.
+func NewSender(apiKey, fromAddr, fromName, baseURL string) *Sender {
+	return &Sender{
+		apiKey:   apiKey,
+		fromAddr: fromAddr,
+		fromName: fromName,
+		baseURL:  baseURL,
+		endpoint: defaultEndpoint,
+		client:   &http.Client{Timeout: 15 * time.Second},
+	}
+}
+
+// Configure updates the sender's settings at runtime (e.g. when an admin
+// changes platform settings). Thread-safe.
+func (s *Sender) Configure(apiKey, fromAddr, fromName, baseURL string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if apiKey != "" {
+		s.apiKey = apiKey
+	}
+	if fromAddr != "" {
+		s.fromAddr = fromAddr
+	}
+	if fromName != "" {
+		s.fromName = fromName
+	}
+	if baseURL != "" {
+		s.baseURL = baseURL
+	}
+}
+
+// BaseURL returns the configured base URL.
+func (s *Sender) BaseURL() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.baseURL
+}
+
+// emailAddress is the Maileroo address format.
+type emailAddress struct {
+	Address     string `json:"address"`
+	DisplayName string `json:"display_name,omitempty"`
+}
+
+// mailerooPayload is the request body for the Maileroo v2 API.
+type mailerooPayload struct {
+	From    emailAddress   `json:"from"`
+	To      []emailAddress `json:"to"`
+	Subject string         `json:"subject"`
+	HTML    string         `json:"html,omitempty"`
+	Plain   string         `json:"plain,omitempty"`
+}
+
+// mailerooResponse is the envelope returned by Maileroo.
+type mailerooResponse struct {
+	Success bool   `json:"success"`
+	Message string `json:"message"`
+}
+
+// Send sends an email using the default from address/name.
+func (s *Sender) Send(ctx context.Context, to, toName, subject, html, plain string) error {
+	s.mu.RLock()
+	fromAddr := s.fromAddr
+	fromName := s.fromName
+	s.mu.RUnlock()
+	return s.sendWith(ctx, s.endpoint, fromAddr, fromName, to, toName, subject, html, plain)
+}
+
+// SendAs sends an email with a custom from name (address stays the same
+// since email providers require verified sender domains).
+func (s *Sender) SendAs(ctx context.Context, fromName, to, toName, subject, html, plain string) error {
+	s.mu.RLock()
+	fromAddr := s.fromAddr
+	s.mu.RUnlock()
+	return s.sendWith(ctx, s.endpoint, fromAddr, fromName, to, toName, subject, html, plain)
+}
+
+// sendWith is the internal send implementation.
+func (s *Sender) sendWith(ctx context.Context, endpoint, fromAddr, fromName, to, toName, subject, html, plain string) error {
+	s.mu.RLock()
+	apiKey := s.apiKey
+	s.mu.RUnlock()
+
+	payload := mailerooPayload{
+		From: emailAddress{
+			Address:     fromAddr,
+			DisplayName: fromName,
+		},
+		To: []emailAddress{
+			{Address: to, DisplayName: toName},
+		},
+		Subject: subject,
+		HTML:    html,
+		Plain:   plain,
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal email payload: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", endpoint, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("send email: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("maileroo returned %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var result mailerooResponse
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return fmt.Errorf("decode maileroo response: %w", err)
+	}
+	if !result.Success {
+		return fmt.Errorf("maileroo error: %s", result.Message)
+	}
+
+	return nil
+}

--- a/internal/email/sender_test.go
+++ b/internal/email/sender_test.go
@@ -1,0 +1,208 @@
+package email
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func newTestSender(ts *httptest.Server) *Sender {
+	s := NewSender("test-api-key", "noreply@test.com", "TestApp", "https://example.com")
+	s.client = ts.Client()
+	s.endpoint = ts.URL
+	return s
+}
+
+func TestSend_Success(t *testing.T) {
+	var received mailerooPayload
+	var authHeader string
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authHeader = r.Header.Get("Authorization")
+		if err := json.NewDecoder(r.Body).Decode(&received); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		json.NewEncoder(w).Encode(mailerooResponse{Success: true, Message: "sent"})
+	}))
+	defer ts.Close()
+
+	s := newTestSender(ts)
+
+	err := s.Send(context.Background(), "user@example.com", "User", "Hello", "<p>Hello</p>", "Hello")
+	if err != nil {
+		t.Fatalf("Send failed: %v", err)
+	}
+
+	if authHeader != "Bearer test-api-key" {
+		t.Errorf("expected Authorization header 'Bearer test-api-key', got %q", authHeader)
+	}
+	if received.From.Address != "noreply@test.com" {
+		t.Errorf("expected from address 'noreply@test.com', got %q", received.From.Address)
+	}
+	if received.From.DisplayName != "TestApp" {
+		t.Errorf("expected from name 'TestApp', got %q", received.From.DisplayName)
+	}
+	if len(received.To) != 1 || received.To[0].Address != "user@example.com" {
+		t.Errorf("unexpected to: %+v", received.To)
+	}
+	if received.To[0].DisplayName != "User" {
+		t.Errorf("expected to name 'User', got %q", received.To[0].DisplayName)
+	}
+	if received.Subject != "Hello" {
+		t.Errorf("expected subject 'Hello', got %q", received.Subject)
+	}
+}
+
+func TestSendAs_CustomFromName(t *testing.T) {
+	var received mailerooPayload
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewDecoder(r.Body).Decode(&received)
+		json.NewEncoder(w).Encode(mailerooResponse{Success: true, Message: "sent"})
+	}))
+	defer ts.Close()
+
+	s := newTestSender(ts)
+
+	err := s.SendAs(context.Background(), "Dave via Pad", "user@example.com", "", "Test", "<p>test</p>", "test")
+	if err != nil {
+		t.Fatalf("SendAs failed: %v", err)
+	}
+
+	// From address should stay the same (verified domain)
+	if received.From.Address != "noreply@test.com" {
+		t.Errorf("expected from address 'noreply@test.com', got %q", received.From.Address)
+	}
+	// But the display name should be custom
+	if received.From.DisplayName != "Dave via Pad" {
+		t.Errorf("expected from name 'Dave via Pad', got %q", received.From.DisplayName)
+	}
+}
+
+func TestSend_APIError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(mailerooResponse{Success: false, Message: "invalid sender"})
+	}))
+	defer ts.Close()
+
+	s := newTestSender(ts)
+
+	err := s.Send(context.Background(), "user@example.com", "", "Test", "<p>test</p>", "test")
+	if err == nil {
+		t.Fatal("expected error for 400 response")
+	}
+}
+
+func TestSend_SuccessFalse(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(mailerooResponse{Success: false, Message: "domain not verified"})
+	}))
+	defer ts.Close()
+
+	s := newTestSender(ts)
+
+	err := s.Send(context.Background(), "user@example.com", "", "Test", "<p>test</p>", "test")
+	if err == nil {
+		t.Fatal("expected error for success=false response")
+	}
+}
+
+func TestConfigure_UpdatesSettings(t *testing.T) {
+	var received mailerooPayload
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewDecoder(r.Body).Decode(&received)
+		json.NewEncoder(w).Encode(mailerooResponse{Success: true, Message: "sent"})
+	}))
+	defer ts.Close()
+
+	s := newTestSender(ts)
+
+	// Reconfigure at runtime
+	s.Configure("new-key", "new@test.com", "NewApp", "https://new.example.com")
+
+	err := s.Send(context.Background(), "user@example.com", "", "Test", "<p>test</p>", "test")
+	if err != nil {
+		t.Fatalf("Send failed: %v", err)
+	}
+
+	if received.From.Address != "new@test.com" {
+		t.Errorf("expected from 'new@test.com', got %q", received.From.Address)
+	}
+	if received.From.DisplayName != "NewApp" {
+		t.Errorf("expected from name 'NewApp', got %q", received.From.DisplayName)
+	}
+}
+
+func TestSendInvitation_ContextualFromName(t *testing.T) {
+	var received mailerooPayload
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewDecoder(r.Body).Decode(&received)
+		json.NewEncoder(w).Encode(mailerooResponse{Success: true, Message: "sent"})
+	}))
+	defer ts.Close()
+
+	s := newTestSender(ts)
+
+	err := s.SendInvitation(context.Background(), "invitee@example.com", "Alice", "My Project", "https://example.com/join/abc123")
+	if err != nil {
+		t.Fatalf("SendInvitation failed: %v", err)
+	}
+
+	if received.Subject != "Alice invited you to My Project on Pad" {
+		t.Errorf("unexpected subject: %q", received.Subject)
+	}
+	// Invitation emails use contextual from name
+	if received.From.DisplayName != "Alice via Pad" {
+		t.Errorf("expected from name 'Alice via Pad', got %q", received.From.DisplayName)
+	}
+}
+
+func TestSendWelcome(t *testing.T) {
+	var received mailerooPayload
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewDecoder(r.Body).Decode(&received)
+		json.NewEncoder(w).Encode(mailerooResponse{Success: true, Message: "sent"})
+	}))
+	defer ts.Close()
+
+	s := newTestSender(ts)
+
+	err := s.SendWelcome(context.Background(), "alice@example.com", "Alice")
+	if err != nil {
+		t.Fatalf("SendWelcome failed: %v", err)
+	}
+
+	if received.Subject != "Welcome to Pad" {
+		t.Errorf("unexpected subject: %q", received.Subject)
+	}
+	if received.To[0].DisplayName != "Alice" {
+		t.Errorf("expected to name 'Alice', got %q", received.To[0].DisplayName)
+	}
+}
+
+func TestSendTest(t *testing.T) {
+	var received mailerooPayload
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewDecoder(r.Body).Decode(&received)
+		json.NewEncoder(w).Encode(mailerooResponse{Success: true, Message: "sent"})
+	}))
+	defer ts.Close()
+
+	s := newTestSender(ts)
+
+	err := s.SendTest(context.Background(), "admin@example.com")
+	if err != nil {
+		t.Fatalf("SendTest failed: %v", err)
+	}
+
+	if received.Subject != "Pad — Test Email" {
+		t.Errorf("unexpected subject: %q", received.Subject)
+	}
+}

--- a/internal/email/templates.go
+++ b/internal/email/templates.go
@@ -1,0 +1,172 @@
+package email
+
+import (
+	"context"
+	"fmt"
+	"html"
+)
+
+// SendInvitation sends a workspace invitation email.
+func (s *Sender) SendInvitation(ctx context.Context, to, inviterName, workspaceName, joinURL string) error {
+	subject := fmt.Sprintf("%s invited you to %s on Pad", inviterName, workspaceName)
+
+	htmlBody := fmt.Sprintf(`<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"></head>
+<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; color: #1a1a1a; max-width: 560px; margin: 0 auto; padding: 40px 20px;">
+  <div style="margin-bottom: 32px;">
+    <strong style="font-size: 18px;">Pad</strong>
+  </div>
+  <p style="font-size: 16px; line-height: 1.5;">
+    <strong>%s</strong> has invited you to join <strong>%s</strong> on Pad.
+  </p>
+  <p style="margin: 32px 0;">
+    <a href="%s" style="display: inline-block; padding: 12px 28px; background: #2563eb; color: #fff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: 500;">
+      Accept Invitation
+    </a>
+  </p>
+  <p style="font-size: 13px; color: #666; line-height: 1.5;">
+    Or copy this link: <a href="%s" style="color: #2563eb;">%s</a>
+  </p>
+  <hr style="border: none; border-top: 1px solid #e5e5e5; margin: 32px 0;" />
+  <p style="font-size: 12px; color: #999;">
+    You received this email because someone invited you to a Pad workspace.
+    If you didn't expect this, you can safely ignore it.
+  </p>
+</body>
+</html>`,
+		html.EscapeString(inviterName),
+		html.EscapeString(workspaceName),
+		joinURL,
+		joinURL,
+		joinURL,
+	)
+
+	plainBody := fmt.Sprintf(`%s has invited you to join %s on Pad.
+
+Accept the invitation: %s
+
+---
+You received this email because someone invited you to a Pad workspace.
+If you didn't expect this, you can safely ignore it.`,
+		inviterName, workspaceName, joinURL,
+	)
+
+	// Use inviter's name as the sender display name: "Dave via Pad"
+	fromName := fmt.Sprintf("%s via Pad", inviterName)
+	return s.SendAs(ctx, fromName, to, "", subject, htmlBody, plainBody)
+}
+
+// SendWelcome sends a welcome email after registration.
+func (s *Sender) SendWelcome(ctx context.Context, to, name string) error {
+	subject := "Welcome to Pad"
+
+	htmlBody := fmt.Sprintf(`<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"></head>
+<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; color: #1a1a1a; max-width: 560px; margin: 0 auto; padding: 40px 20px;">
+  <div style="margin-bottom: 32px;">
+    <strong style="font-size: 18px;">Pad</strong>
+  </div>
+  <p style="font-size: 16px; line-height: 1.5;">
+    Hi %s, welcome to Pad!
+  </p>
+  <p style="font-size: 15px; line-height: 1.5; color: #444;">
+    Your account has been created. You can now create workspaces, manage projects, and collaborate with your team.
+  </p>
+  <p style="margin: 32px 0;">
+    <a href="%s" style="display: inline-block; padding: 12px 28px; background: #2563eb; color: #fff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: 500;">
+      Open Pad
+    </a>
+  </p>
+  <hr style="border: none; border-top: 1px solid #e5e5e5; margin: 32px 0;" />
+  <p style="font-size: 12px; color: #999;">
+    You received this because an account was created with this email address.
+  </p>
+</body>
+</html>`,
+		html.EscapeString(name),
+		s.baseURL,
+	)
+
+	plainBody := fmt.Sprintf(`Hi %s, welcome to Pad!
+
+Your account has been created. You can now create workspaces, manage projects, and collaborate with your team.
+
+Open Pad: %s`,
+		name, s.baseURL,
+	)
+
+	return s.Send(ctx, to, name, subject, htmlBody, plainBody)
+}
+
+// SendPasswordReset sends a password reset email with a token link.
+// This is a placeholder — the password reset flow (IDEA-81) will call this
+// once the reset token endpoint exists.
+func (s *Sender) SendPasswordReset(ctx context.Context, to, name, resetURL string) error {
+	subject := "Reset your Pad password"
+
+	htmlBody := fmt.Sprintf(`<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"></head>
+<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; color: #1a1a1a; max-width: 560px; margin: 0 auto; padding: 40px 20px;">
+  <div style="margin-bottom: 32px;">
+    <strong style="font-size: 18px;">Pad</strong>
+  </div>
+  <p style="font-size: 16px; line-height: 1.5;">
+    Hi %s, we received a request to reset your password.
+  </p>
+  <p style="margin: 32px 0;">
+    <a href="%s" style="display: inline-block; padding: 12px 28px; background: #2563eb; color: #fff; text-decoration: none; border-radius: 6px; font-size: 15px; font-weight: 500;">
+      Reset Password
+    </a>
+  </p>
+  <p style="font-size: 13px; color: #666; line-height: 1.5;">
+    This link expires in 1 hour. If you didn't request a password reset, you can safely ignore this email.
+  </p>
+  <hr style="border: none; border-top: 1px solid #e5e5e5; margin: 32px 0;" />
+  <p style="font-size: 12px; color: #999;">
+    You received this because a password reset was requested for your Pad account.
+  </p>
+</body>
+</html>`,
+		html.EscapeString(name),
+		resetURL,
+	)
+
+	plainBody := fmt.Sprintf(`Hi %s, we received a request to reset your password.
+
+Reset your password: %s
+
+This link expires in 1 hour. If you didn't request a password reset, you can safely ignore this email.`,
+		name, resetURL,
+	)
+
+	return s.Send(ctx, to, name, subject, htmlBody, plainBody)
+}
+
+// SendTest sends a test email to verify the email configuration.
+func (s *Sender) SendTest(ctx context.Context, to string) error {
+	subject := "Pad — Test Email"
+
+	htmlBody := `<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"></head>
+<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; color: #1a1a1a; max-width: 560px; margin: 0 auto; padding: 40px 20px;">
+  <div style="margin-bottom: 32px;">
+    <strong style="font-size: 18px;">Pad</strong>
+  </div>
+  <p style="font-size: 16px; line-height: 1.5;">
+    This is a test email from your Pad instance. If you're reading this, email delivery is working correctly!
+  </p>
+  <hr style="border: none; border-top: 1px solid #e5e5e5; margin: 32px 0;" />
+  <p style="font-size: 12px; color: #999;">
+    Sent from Pad platform settings.
+  </p>
+</body>
+</html>`
+
+	plainBody := "This is a test email from your Pad instance. If you're reading this, email delivery is working correctly!"
+
+	return s.Send(ctx, to, "", subject, htmlBody, plainBody)
+}

--- a/internal/server/handlers_admin.go
+++ b/internal/server/handlers_admin.go
@@ -1,0 +1,112 @@
+package server
+
+import (
+	"net/http"
+)
+
+// Known platform setting keys. Values are stored in the platform_settings table.
+const (
+	settingEmailProvider  = "email_provider"   // "maileroo" or empty
+	settingMailerooAPIKey = "maileroo_api_key"
+	settingEmailFrom      = "email_from"       // Sender address
+	settingEmailFromName  = "email_from_name"  // Sender display name
+	settingPlatformName   = "platform_name"    // Instance name (default: "Pad")
+)
+
+// handleGetPlatformSettings returns all platform settings.
+// Admin-only. Sensitive values (API keys) are masked.
+func (s *Server) handleGetPlatformSettings(w http.ResponseWriter, r *http.Request) {
+	user := currentUser(r)
+	if user == nil || user.Role != "admin" {
+		writeError(w, http.StatusForbidden, "forbidden", "Admin access required")
+		return
+	}
+
+	settings, err := s.store.GetPlatformSettings()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to load settings")
+		return
+	}
+
+	// Mask sensitive values
+	if key, ok := settings[settingMailerooAPIKey]; ok && len(key) > 8 {
+		settings[settingMailerooAPIKey] = key[:4] + "..." + key[len(key)-4:]
+	} else if ok && key != "" {
+		settings[settingMailerooAPIKey] = "****"
+	}
+
+	writeJSON(w, http.StatusOK, settings)
+}
+
+// handleUpdatePlatformSettings updates one or more platform settings.
+// Admin-only. Accepts a JSON object of key-value pairs.
+func (s *Server) handleUpdatePlatformSettings(w http.ResponseWriter, r *http.Request) {
+	user := currentUser(r)
+	if user == nil || user.Role != "admin" {
+		writeError(w, http.StatusForbidden, "forbidden", "Admin access required")
+		return
+	}
+
+	var input map[string]string
+	if err := decodeJSON(r, &input); err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", "Invalid request body")
+		return
+	}
+
+	// Whitelist known settings
+	allowed := map[string]bool{
+		settingEmailProvider:  true,
+		settingMailerooAPIKey: true,
+		settingEmailFrom:      true,
+		settingEmailFromName:  true,
+		settingPlatformName:   true,
+	}
+
+	for key, value := range input {
+		if !allowed[key] {
+			continue
+		}
+		if err := s.store.SetPlatformSetting(key, value); err != nil {
+			writeError(w, http.StatusInternalServerError, "internal_error", "Failed to save setting: "+key)
+			return
+		}
+	}
+
+	// Reconfigure email sender if email settings changed
+	s.reconfigureEmail()
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{"ok": true})
+}
+
+// handleTestEmail sends a test email to verify the email configuration.
+// Admin-only.
+func (s *Server) handleTestEmail(w http.ResponseWriter, r *http.Request) {
+	user := currentUser(r)
+	if user == nil || user.Role != "admin" {
+		writeError(w, http.StatusForbidden, "forbidden", "Admin access required")
+		return
+	}
+
+	if s.email == nil {
+		writeError(w, http.StatusBadRequest, "email_not_configured", "Email is not configured. Set the API key and sender address first.")
+		return
+	}
+
+	var input struct {
+		To string `json:"to"`
+	}
+	if err := decodeJSON(r, &input); err != nil || input.To == "" {
+		// Default to the admin's own email
+		input.To = user.Email
+	}
+
+	if err := s.email.SendTest(r.Context(), input.To); err != nil {
+		writeError(w, http.StatusInternalServerError, "email_failed", "Failed to send test email: "+err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"ok":      true,
+		"sent_to": input.To,
+	})
+}

--- a/internal/server/handlers_auth.go
+++ b/internal/server/handlers_auth.go
@@ -321,3 +321,88 @@ func (s *Server) handleGetCurrentUser(w http.ResponseWriter, r *http.Request) {
 		"updated_at": user.UpdatedAt,
 	})
 }
+
+// handleUpdateCurrentUser updates the authenticated user's profile.
+// Supports updating name and/or password. Password changes require the
+// current password for verification.
+func (s *Server) handleUpdateCurrentUser(w http.ResponseWriter, r *http.Request) {
+	user := currentUser(r)
+	if user == nil {
+		// Try cookie directly (auth endpoints are exempt from middleware)
+		if cookie, err := r.Cookie(sessionCookie); err == nil {
+			user, _ = s.store.ValidateSession(cookie.Value)
+		}
+	}
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, "unauthorized", "Not logged in")
+		return
+	}
+
+	var input struct {
+		Name            *string `json:"name,omitempty"`
+		CurrentPassword string  `json:"current_password,omitempty"`
+		NewPassword     string  `json:"new_password,omitempty"`
+	}
+	if err := decodeJSON(r, &input); err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", "Invalid request body")
+		return
+	}
+
+	// Validate name if provided
+	if input.Name != nil {
+		trimmed := strings.TrimSpace(*input.Name)
+		if trimmed == "" {
+			writeError(w, http.StatusBadRequest, "validation_error", "Name cannot be empty")
+			return
+		}
+		input.Name = &trimmed
+	}
+
+	// Validate password change
+	if input.NewPassword != "" {
+		if input.CurrentPassword == "" {
+			writeError(w, http.StatusBadRequest, "validation_error", "Current password is required to set a new password")
+			return
+		}
+		if len(input.NewPassword) < 8 {
+			writeError(w, http.StatusBadRequest, "validation_error", "New password must be at least 8 characters")
+			return
+		}
+
+		// Verify current password
+		valid, err := s.store.ValidatePassword(user.Email, input.CurrentPassword)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "internal_error", "Failed to validate password")
+			return
+		}
+		if valid == nil {
+			time.Sleep(500 * time.Millisecond) // Slow down brute force
+			writeError(w, http.StatusForbidden, "invalid_password", "Current password is incorrect")
+			return
+		}
+	}
+
+	// Build update
+	update := models.UserUpdate{
+		Name: input.Name,
+	}
+	if input.NewPassword != "" {
+		update.Password = &input.NewPassword
+	}
+
+	updated, err := s.store.UpdateUser(user.ID, update)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to update profile")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"id":         updated.ID,
+		"email":      updated.Email,
+		"name":       updated.Name,
+		"role":       updated.Role,
+		"avatar_url": updated.AvatarURL,
+		"created_at": updated.CreatedAt,
+		"updated_at": updated.UpdatedAt,
+	})
+}

--- a/internal/server/handlers_members.go
+++ b/internal/server/handlers_members.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"context"
+	"log"
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
@@ -127,11 +129,30 @@ func (s *Server) handleInviteMember(w http.ResponseWriter, r *http.Request) {
 		"email":   inv.Email,
 		"role":    inv.Role,
 	}
+	joinURL := ""
 	if s.baseURL != "" {
-		resp["join_url"] = s.baseURL + "/join/" + inv.Code
+		joinURL = s.baseURL + "/join/" + inv.Code
+		resp["join_url"] = joinURL
 	}
 
 	writeJSON(w, http.StatusCreated, resp)
+
+	// Send invitation email asynchronously (fire-and-forget)
+	if s.email != nil && joinURL != "" {
+		go func() {
+			inviterName := "A team member"
+			wsName := "a workspace"
+			if user, err := s.store.GetUser(inviterID); err == nil && user != nil {
+				inviterName = user.Name
+			}
+			if ws, err := s.store.GetWorkspaceByID(workspaceID); err == nil && ws != nil {
+				wsName = ws.Name
+			}
+			if err := s.email.SendInvitation(context.Background(), inv.Email, inviterName, wsName, joinURL); err != nil {
+				log.Printf("Failed to send invitation email to %s: %v", inv.Email, err)
+			}
+		}()
+	}
 }
 
 // handleRemoveMember removes a user from a workspace.
@@ -198,6 +219,27 @@ func (s *Server) handleUpdateMemberRole(w http.ResponseWriter, r *http.Request) 
 		"user_id": userID,
 		"role":    input.Role,
 	})
+}
+
+// handleCancelInvitation deletes a pending invitation.
+func (s *Server) handleCancelInvitation(w http.ResponseWriter, r *http.Request) {
+	workspaceID, ok := s.getWorkspaceID(w, r)
+	if !ok {
+		return
+	}
+
+	if !requireRole(r, "owner") {
+		writeError(w, http.StatusForbidden, "forbidden", "Only workspace owners can cancel invitations")
+		return
+	}
+
+	invID := chi.URLParam(r, "invID")
+	if err := s.store.DeleteInvitation(workspaceID, invID); err != nil {
+		writeError(w, http.StatusNotFound, "not_found", "Invitation not found")
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
 }
 
 // handleAcceptInvitation accepts a workspace invitation by code.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -12,6 +12,7 @@ import (
 	chimiddleware "github.com/go-chi/chi/v5/middleware"
 	"github.com/go-chi/cors"
 
+	"github.com/xarmian/pad/internal/email"
 	"github.com/xarmian/pad/internal/events"
 	"github.com/xarmian/pad/internal/models"
 	"github.com/xarmian/pad/internal/store"
@@ -24,6 +25,7 @@ type Server struct {
 	webFS    fs.FS                // embedded web UI static files (optional)
 	events   *events.Bus          // real-time event bus (optional)
 	webhooks *webhooks.Dispatcher // webhook dispatcher (optional)
+	email    *email.Sender        // transactional email sender (optional)
 	baseURL  string               // public base URL for generating links (e.g. invite URLs)
 }
 
@@ -46,6 +48,37 @@ func (s *Server) SetEventBus(bus *events.Bus) {
 // SetWebhookDispatcher attaches a webhook dispatcher for outgoing notifications.
 func (s *Server) SetWebhookDispatcher(d *webhooks.Dispatcher) {
 	s.webhooks = d
+}
+
+// SetEmailSender attaches a transactional email sender.
+func (s *Server) SetEmailSender(e *email.Sender) {
+	s.email = e
+}
+
+// reconfigureEmail reads email settings from the platform_settings table
+// and updates (or creates) the email sender. Called after admin settings change.
+func (s *Server) reconfigureEmail() {
+	apiKey, _ := s.store.GetPlatformSetting(settingMailerooAPIKey)
+	fromAddr, _ := s.store.GetPlatformSetting(settingEmailFrom)
+	fromName, _ := s.store.GetPlatformSetting(settingEmailFromName)
+
+	if apiKey == "" {
+		return // No API key — leave email as-is (may still have env var config)
+	}
+
+	if s.email == nil {
+		// Create a new sender from platform settings
+		s.email = email.NewSender(apiKey, fromAddr, fromName, s.baseURL)
+	} else {
+		// Update existing sender
+		s.email.Configure(apiKey, fromAddr, fromName, s.baseURL)
+	}
+}
+
+// InitEmailFromSettings loads email config from platform settings on startup,
+// merging with any env-var-based sender that was already attached.
+func (s *Server) InitEmailFromSettings() {
+	s.reconfigureEmail()
 }
 
 func (s *Server) setupRouter() {
@@ -81,11 +114,19 @@ func (s *Server) setupRouter() {
 			r.Post("/login", s.handleLogin)
 			r.Post("/logout", s.handleLogout)
 			r.Get("/me", s.handleGetCurrentUser)
+			r.Patch("/me", s.handleUpdateCurrentUser)
 
 			// User-scoped API tokens
 			r.Get("/tokens", s.handleListUserTokens)
 			r.Post("/tokens", s.handleCreateUserToken)
 			r.Delete("/tokens/{tokenID}", s.handleDeleteUserToken)
+		})
+
+		// Admin endpoints (admin-only, handlers check role internally)
+		r.Route("/admin", func(r chi.Router) {
+			r.Get("/settings", s.handleGetPlatformSettings)
+			r.Patch("/settings", s.handleUpdatePlatformSettings)
+			r.Post("/test-email", s.handleTestEmail)
 		})
 
 		// Templates
@@ -206,6 +247,7 @@ func (s *Server) setupRouter() {
 				r.Route("/members", func(r chi.Router) {
 					r.Get("/", s.handleListMembers)
 					r.Post("/invite", s.handleInviteMember)
+					r.Delete("/invitations/{invID}", s.handleCancelInvitation)
 					r.Delete("/{userID}", s.handleRemoveMember)
 					r.Patch("/{userID}", s.handleUpdateMemberRole)
 				})

--- a/internal/store/migrations/014_platform_settings.sql
+++ b/internal/store/migrations/014_platform_settings.sql
@@ -1,0 +1,6 @@
+-- Platform-wide settings (instance configuration, not workspace-scoped)
+CREATE TABLE IF NOT EXISTS platform_settings (
+    key         TEXT PRIMARY KEY,
+    value       TEXT NOT NULL DEFAULT '',
+    updated_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+);

--- a/internal/store/platform_settings.go
+++ b/internal/store/platform_settings.go
@@ -1,0 +1,47 @@
+package store
+
+import "database/sql"
+
+// GetPlatformSetting returns a single platform setting value, or empty string if not set.
+func (s *Store) GetPlatformSetting(key string) (string, error) {
+	var value string
+	err := s.db.QueryRow("SELECT value FROM platform_settings WHERE key = ?", key).Scan(&value)
+	if err == sql.ErrNoRows {
+		return "", nil
+	}
+	return value, err
+}
+
+// SetPlatformSetting upserts a platform setting.
+func (s *Store) SetPlatformSetting(key, value string) error {
+	_, err := s.db.Exec(`
+		INSERT INTO platform_settings (key, value, updated_at) VALUES (?, ?, ?)
+		ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at
+	`, key, value, now())
+	return err
+}
+
+// GetPlatformSettings returns all platform settings as a map.
+func (s *Store) GetPlatformSettings() (map[string]string, error) {
+	rows, err := s.db.Query("SELECT key, value FROM platform_settings ORDER BY key")
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	settings := make(map[string]string)
+	for rows.Next() {
+		var k, v string
+		if err := rows.Scan(&k, &v); err != nil {
+			return nil, err
+		}
+		settings[k] = v
+	}
+	return settings, rows.Err()
+}
+
+// DeletePlatformSetting removes a platform setting.
+func (s *Store) DeletePlatformSetting(key string) error {
+	_, err := s.db.Exec("DELETE FROM platform_settings WHERE key = ?", key)
+	return err
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -79,6 +79,7 @@ func (s *Store) migrate() error {
 		"011_api_tokens.sql",
 		"012_users.sql",
 		"013_workspace_invitations.sql",
+		"014_platform_settings.sql",
 	}
 
 	for _, name := range migrations {

--- a/internal/store/workspace_members.go
+++ b/internal/store/workspace_members.go
@@ -243,6 +243,22 @@ func (s *Store) AcceptInvitation(id string) error {
 	return nil
 }
 
+// DeleteInvitation removes a pending invitation.
+func (s *Store) DeleteInvitation(workspaceID, invitationID string) error {
+	result, err := s.db.Exec(
+		"DELETE FROM workspace_invitations WHERE id = ? AND workspace_id = ? AND accepted_at IS NULL",
+		invitationID, workspaceID,
+	)
+	if err != nil {
+		return fmt.Errorf("delete invitation: %w", err)
+	}
+	n, _ := result.RowsAffected()
+	if n == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
+}
+
 // ListWorkspaceInvitations returns all invitations for a workspace.
 func (s *Store) ListWorkspaceInvitations(workspaceID string) ([]models.WorkspaceInvitation, error) {
 	rows, err := s.db.Query(`

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -21,7 +21,11 @@ import type {
 	LibraryConvention,
 	PlaybookLibraryResponse,
 	LibraryPlaybook,
-	View
+	View,
+	User,
+	UserProfileUpdate,
+	APIToken,
+	APITokenWithSecret
 } from '$lib/types';
 
 const BASE = '/api/v1';
@@ -348,6 +352,8 @@ export const api = {
 				method: 'PATCH',
 				body: JSON.stringify({ role })
 			}),
+		cancelInvitation: (ws: string, invitationId: string) =>
+			request<void>(`/workspaces/${ws}/members/invitations/${invitationId}`, { method: 'DELETE' }),
 		acceptInvitation: (code: string) =>
 			request<{ accepted: boolean; workspace_id: string; role: string }>(`/invitations/${code}/accept`, {
 				method: 'POST'
@@ -370,7 +376,38 @@ export const api = {
 				body: JSON.stringify({ email, name, password, ...(invitation_code ? { invitation_code } : {}) })
 			}),
 		logout: () => request<{ ok: boolean }>('/auth/logout', { method: 'POST' }),
-		me: () => request<{ id: string; email: string; name: string; role: string }>('/auth/me')
+		me: () => request<User>('/auth/me'),
+		updateProfile: (data: UserProfileUpdate) =>
+			request<User>('/auth/me', {
+				method: 'PATCH',
+				body: JSON.stringify(data)
+			}),
+		tokens: {
+			list: () => request<APIToken[]>('/auth/tokens'),
+			create: (name: string) =>
+				request<APITokenWithSecret>('/auth/tokens', {
+					method: 'POST',
+					body: JSON.stringify({ name })
+				}),
+			delete: (tokenId: string) =>
+				request<void>(`/auth/tokens/${tokenId}`, { method: 'DELETE' })
+		}
+	},
+
+	// ── Admin ────────────────────────────────────────────────────────────────
+
+	admin: {
+		getSettings: () => request<Record<string, string>>('/admin/settings'),
+		updateSettings: (settings: Record<string, string>) =>
+			request<{ ok: boolean }>('/admin/settings', {
+				method: 'PATCH',
+				body: JSON.stringify(settings)
+			}),
+		testEmail: (to?: string) =>
+			request<{ ok: boolean; sent_to: string }>('/admin/test-email', {
+				method: 'POST',
+				body: JSON.stringify(to ? { to } : {})
+			})
 	}
 };
 

--- a/web/src/lib/services/visibility.svelte.ts
+++ b/web/src/lib/services/visibility.svelte.ts
@@ -1,0 +1,43 @@
+/**
+ * Tab visibility service — notifies subscribers when the browser tab
+ * regains focus after being hidden. Used to refresh stale data when
+ * SSE events may have been lost while the tab was in the background.
+ */
+
+type Callback = () => void;
+
+const listeners = new Set<Callback>();
+let initialized = false;
+let lastResumeTime = 0;
+
+const THROTTLE_MS = 2000;
+
+function init() {
+	if (initialized || typeof document === 'undefined') return;
+	initialized = true;
+
+	document.addEventListener('visibilitychange', () => {
+		if (!document.hidden) {
+			const now = Date.now();
+			if (now - lastResumeTime < THROTTLE_MS) return;
+			lastResumeTime = now;
+
+			for (const cb of listeners) {
+				try {
+					cb();
+				} catch {
+					// Don't let one failing callback break others
+				}
+			}
+		}
+	});
+}
+
+function onTabResume(cb: Callback): () => void {
+	listeners.add(cb);
+	return () => {
+		listeners.delete(cb);
+	};
+}
+
+export const visibility = { init, onTabResume };

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -1,3 +1,37 @@
+// ─── User & Auth ──────────────────────────────────────────────────────────────
+
+export interface User {
+	id: string;
+	email: string;
+	name: string;
+	role: string;
+	avatar_url?: string;
+	created_at: string;
+	updated_at: string;
+}
+
+export interface UserProfileUpdate {
+	name?: string;
+	current_password?: string;
+	new_password?: string;
+}
+
+export interface APIToken {
+	id: string;
+	workspace_id: string;
+	user_id?: string;
+	name: string;
+	prefix: string;
+	scopes: string;
+	expires_at?: string;
+	last_used_at?: string;
+	created_at: string;
+}
+
+export interface APITokenWithSecret extends APIToken {
+	token: string;
+}
+
 // ─── Workspace ────────────────────────────────────────────────────────────────
 
 export interface Workspace {

--- a/web/src/routes/[workspace]/+layout.svelte
+++ b/web/src/routes/[workspace]/+layout.svelte
@@ -5,6 +5,7 @@
 	import { collectionStore } from '$lib/stores/collections.svelte';
 	import { editorStore } from '$lib/stores/editor.svelte';
 	import { sseService } from '$lib/services/sse.svelte';
+	import { visibility } from '$lib/services/visibility.svelte';
 	import { api } from '$lib/api/client';
 	import { toastStore } from '$lib/stores/toast.svelte';
 
@@ -12,13 +13,23 @@
 
 	let wsSlug = $derived(page.params.workspace ?? '');
 	let unsubscribeSSE: (() => void) | null = null;
+	let unsubscribeVisibility: (() => void) | null = null;
 
 	onMount(() => {
+		visibility.init();
+		unsubscribeVisibility = visibility.onTabResume(() => {
+			if (!wsSlug) return;
+			// Reconnect SSE — events may have been lost while the tab was hidden
+			sseService.connect(wsSlug);
+			// Refresh collection metadata (counts, etc.)
+			collectionStore.loadCollections(wsSlug);
+		});
 		connectSSE();
 	});
 
 	onDestroy(() => {
 		unsubscribeSSE?.();
+		unsubscribeVisibility?.();
 		sseService.disconnect();
 	});
 

--- a/web/src/routes/[workspace]/+page.svelte
+++ b/web/src/routes/[workspace]/+page.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
 	import { page } from '$app/state';
 	import { goto } from '$app/navigation';
-	import { onMount } from 'svelte';
+	import { onMount, onDestroy } from 'svelte';
 	import { browser } from '$app/environment';
 	import { api } from '$lib/api/client';
 	import { workspaceStore } from '$lib/stores/workspace.svelte';
+	import { visibility } from '$lib/services/visibility.svelte';
 	import { relativeTime } from '$lib/utils/markdown';
 	import { itemUrlId } from '$lib/types';
 	import OnboardingChecklist from '$lib/components/OnboardingChecklist.svelte';
@@ -39,11 +40,20 @@
 		if (wsSlug) load(wsSlug);
 	});
 
+	let unsubscribeVisibility: (() => void) | null = null;
+
 	onMount(() => {
 		pollTimer = setInterval(() => {
 			if (wsSlug) load(wsSlug, true);
 		}, 30000);
+		unsubscribeVisibility = visibility.onTabResume(() => {
+			if (wsSlug) load(wsSlug, true);
+		});
 		return () => clearInterval(pollTimer);
+	});
+
+	onDestroy(() => {
+		unsubscribeVisibility?.();
 	});
 
 	async function load(slug: string, silent = false) {

--- a/web/src/routes/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[workspace]/[collection]/+page.svelte
@@ -9,8 +9,9 @@
 	import TableView from '$lib/components/collections/TableView.svelte';
 	import FilterBar from '$lib/components/collections/FilterBar.svelte';
 	import QuickActionsMenu from '$lib/components/common/QuickActionsMenu.svelte';
-	import { onDestroy } from 'svelte';
+	import { onDestroy, onMount } from 'svelte';
 	import { sseService } from '$lib/services/sse.svelte';
+	import { visibility } from '$lib/services/visibility.svelte';
 	import { toastStore } from '$lib/stores/toast.svelte';
 
 	type ViewMode = 'list' | 'board' | 'table';
@@ -128,8 +129,45 @@
 		});
 	});
 
+	// Silently refresh items when the tab regains focus (SSE events may have been lost)
+	let unsubscribeVisibility: (() => void) | null = null;
+
+	onMount(() => {
+		unsubscribeVisibility = visibility.onTabResume(async () => {
+			if (!wsSlug || !collSlug) return;
+			try {
+				const listParams = showArchived ? { include_archived: true } : undefined;
+				const freshItems = await api.items.listByCollection(wsSlug, collSlug, listParams);
+				items = freshItems;
+
+				// Update progress data without resetting view state
+				if (collSlug === 'phases') {
+					const progress = await api.items.phasesProgress(wsSlug).catch(() => []);
+					const map: Record<string, { total: number; done: number }> = {};
+					for (const p of progress) {
+						map[p.phase_id] = { total: p.total, done: p.done };
+					}
+					itemProgress = map;
+				} else {
+					const map: Record<string, { total: number; done: number }> = {};
+					for (const it of freshItems) {
+						if (!it.content) continue;
+						const total = (it.content.match(/- \[[ x]\]/g) ?? []).length;
+						if (total === 0) continue;
+						const done = (it.content.match(/- \[x\]/g) ?? []).length;
+						map[it.id] = { total, done };
+					}
+					itemProgress = map;
+				}
+			} catch {
+				// Ignore — will catch up on next SSE event
+			}
+		});
+	});
+
 	onDestroy(() => {
 		unsubscribeSSE?.();
+		unsubscribeVisibility?.();
 	});
 
 	async function loadCollection(ws: string, coll: string, includeArchived = false) {
@@ -669,7 +707,7 @@
 						aria-label="Toggle filters"
 						title="Toggle filters"
 					>
-						<span class="filter-icon">&#9697;</span>
+						<svg class="filter-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3"/></svg>
 						<span class="filter-label">Filters</span>
 						{#if hasActiveFilters}
 							<span class="filter-badge"></span>
@@ -1014,8 +1052,7 @@
 	}
 
 	.filter-icon {
-		font-size: 1.1em;
-		line-height: 1;
+		flex-shrink: 0;
 	}
 
 	.filter-badge {

--- a/web/src/routes/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[workspace]/[collection]/[slug]/+page.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
 	import { page } from '$app/state';
-	import { tick } from 'svelte';
+	import { tick, onMount, onDestroy } from 'svelte';
 	import { api } from '$lib/api/client';
 	import { collectionStore } from '$lib/stores/collections.svelte';
+	import { visibility } from '$lib/services/visibility.svelte';
 	import Editor from '$lib/components/editor/Editor.svelte';
 	import EditorBubbleMenu from '$lib/components/editor/EditorBubbleMenu.svelte';
 	import EditorLinkPopover from '$lib/components/editor/EditorLinkPopover.svelte';
@@ -66,6 +67,34 @@
 		if (wsSlug && collSlug && itemSlug) {
 			loadData();
 		}
+	});
+
+	// Refresh item when the tab regains focus (SSE events may have been lost)
+	let unsubscribeVisibility: (() => void) | null = null;
+
+	onMount(() => {
+		unsubscribeVisibility = visibility.onTabResume(async () => {
+			if (!wsSlug || !itemSlug || !item) return;
+			// Don't refresh if the user is actively editing
+			if (saveStatus === 'saving' || editingTitle) return;
+			try {
+				const updated = await api.items.get(wsSlug, itemSlug);
+				// Merge server state without disrupting the editor:
+				// update fields/metadata but preserve local content to avoid resetting the editor
+				item = {
+					...updated,
+					content: item!.content
+				};
+				// Refresh links too
+				itemLinks = await api.links.list(wsSlug, updated.slug).catch(() => []);
+			} catch {
+				// Ignore — will catch up on next event
+			}
+		});
+	});
+
+	onDestroy(() => {
+		unsubscribeVisibility?.();
 	});
 
 	async function loadData() {

--- a/web/src/routes/[workspace]/settings/+page.svelte
+++ b/web/src/routes/[workspace]/settings/+page.svelte
@@ -4,12 +4,13 @@
 	import { onMount } from 'svelte';
 	import { api } from '$lib/api/client';
 	import { workspaceStore } from '$lib/stores/workspace.svelte';
-	import type { Collection } from '$lib/types';
+	import type { Collection, APIToken } from '$lib/types';
 	import { parseSchema } from '$lib/types';
 	import CreateCollectionModal from '$lib/components/collections/CreateCollectionModal.svelte';
 	import EditCollectionModal from '$lib/components/collections/EditCollectionModal.svelte';
 	import { collectionStore } from '$lib/stores/collections.svelte';
 	import { toastStore } from '$lib/stores/toast.svelte';
+	import { copyToClipboard } from '$lib/utils/clipboard';
 
 	let wsSlug = $derived(page.params.workspace ?? '');
 	let loading = $state(true);
@@ -30,15 +31,47 @@
 	let inviteResult = $state<{ message: string; type: 'success' | 'error' } | null>(null);
 	let currentUserRole = $state('');
 
+	// Account
+	let profileName = $state('');
+	let profileEmail = $state('');
+	let profileRole = $state('');
+	let savingProfile = $state(false);
+	let profileStatus = $state<'idle' | 'saved' | 'error'>('idle');
+
+	let currentPassword = $state('');
+	let newPassword = $state('');
+	let confirmPassword = $state('');
+	let changingPassword = $state(false);
+	let passwordStatus = $state<'idle' | 'saved' | 'error'>('idle');
+	let passwordError = $state('');
+
+	let tokens = $state<APIToken[]>([]);
+	let newTokenName = $state('');
+	let creatingToken = $state(false);
+	let newTokenSecret = $state('');
+
+	// Platform (admin-only)
+	let platformSettings = $state<Record<string, string>>({});
+	let savingPlatform = $state(false);
+	let platformStatus = $state<'idle' | 'saved' | 'error'>('idle');
+	let testingEmail = $state(false);
+	let testEmailResult = $state<{ message: string; type: 'success' | 'error' } | null>(null);
+
 	// Tabs
 	let activeTab = $state('general');
-	const tabs = [
+	const baseTabs = [
 		{ id: 'general', label: 'General', icon: '\u2699\uFE0F' },
+		{ id: 'account', label: 'Account', icon: '\uD83D\uDC64' },
 		{ id: 'members', label: 'Members', icon: '\uD83D\uDC65' },
 		{ id: 'collections', label: 'Collections', icon: '\uD83D\uDCC1' },
 		{ id: 'danger', label: 'Danger Zone', icon: '\u26A0\uFE0F' },
 	];
-	const validTabIds = tabs.map(t => t.id);
+	let tabs = $derived(
+		profileRole === 'admin'
+			? [...baseTabs, { id: 'platform', label: 'Platform', icon: '\uD83D\uDD27' }]
+			: baseTabs
+	);
+	let validTabIds = $derived(tabs.map(t => t.id));
 
 	function switchTab(tabId: string) {
 		activeTab = tabId;
@@ -76,6 +109,22 @@
 					currentUserRole = me?.role ?? '';
 				}
 			} catch {}
+		// Load account data
+		try {
+			const me = await api.auth.me();
+			profileName = me.name;
+			profileEmail = me.email;
+			profileRole = me.role;
+		} catch {}
+		try {
+			tokens = await api.auth.tokens.list();
+		} catch {}
+		// Load platform settings (admin only)
+		if (profileRole === 'admin') {
+			try {
+				platformSettings = await api.admin.getSettings();
+			} catch {}
+		}
 		} catch { /* allow partial render */
 		} finally {
 			loading = false;
@@ -120,7 +169,7 @@
 				inviteResult = { message: `Added ${result.name || result.email} as ${result.role}`, type: 'success' };
 			} else if (result.join_url) {
 				inviteResult = { message: `Invitation sent to ${result.email}. Link copied to clipboard!`, type: 'success' };
-				navigator.clipboard.writeText(result.join_url).catch(() => {});
+				copyToClipboard(result.join_url);
 			} else {
 				inviteResult = { message: `Invitation sent to ${result.email}. Join code: ${result.code}`, type: 'success' };
 			}
@@ -145,6 +194,17 @@
 			toastStore.show(`Removed ${name}`, 'success');
 		} catch {
 			toastStore.show('Failed to remove member', 'error');
+		}
+	}
+
+	async function handleCancelInvitation(invId: string, email: string) {
+		if (!confirm(`Cancel invitation for ${email}?`)) return;
+		try {
+			await api.members.cancelInvitation(wsSlug, invId);
+			invitations = invitations.filter(i => i.id !== invId);
+			toastStore.show(`Invitation cancelled for ${email}`, 'success');
+		} catch {
+			toastStore.show('Failed to cancel invitation', 'error');
 		}
 	}
 
@@ -174,6 +234,122 @@
 		} catch {
 			toastStore.show('Failed to archive workspace', 'error');
 			deleting = false;
+		}
+	}
+
+	async function saveProfile() {
+		if (!profileName.trim() || savingProfile) return;
+		savingProfile = true;
+		profileStatus = 'idle';
+		try {
+			await api.auth.updateProfile({ name: profileName.trim() });
+			profileStatus = 'saved';
+			setTimeout(() => (profileStatus = 'idle'), 2000);
+		} catch {
+			profileStatus = 'error';
+		} finally {
+			savingProfile = false;
+		}
+	}
+
+	async function changePassword() {
+		passwordError = '';
+		if (!currentPassword || !newPassword || !confirmPassword) {
+			passwordError = 'All fields are required';
+			return;
+		}
+		if (newPassword.length < 8) {
+			passwordError = 'New password must be at least 8 characters';
+			return;
+		}
+		if (newPassword !== confirmPassword) {
+			passwordError = 'Passwords do not match';
+			return;
+		}
+		changingPassword = true;
+		passwordStatus = 'idle';
+		try {
+			await api.auth.updateProfile({
+				current_password: currentPassword,
+				new_password: newPassword
+			});
+			passwordStatus = 'saved';
+			currentPassword = '';
+			newPassword = '';
+			confirmPassword = '';
+			setTimeout(() => (passwordStatus = 'idle'), 3000);
+		} catch (err: unknown) {
+			passwordStatus = 'error';
+			if (err instanceof Error && err.message.includes('incorrect')) {
+				passwordError = 'Current password is incorrect';
+			} else {
+				passwordError = 'Failed to change password';
+			}
+		} finally {
+			changingPassword = false;
+		}
+	}
+
+	async function createToken() {
+		if (!newTokenName.trim() || creatingToken) return;
+		creatingToken = true;
+		newTokenSecret = '';
+		try {
+			const result = await api.auth.tokens.create(newTokenName.trim());
+			newTokenSecret = result.token;
+			newTokenName = '';
+			tokens = await api.auth.tokens.list();
+		} catch {
+			toastStore.show('Failed to create token', 'error');
+		} finally {
+			creatingToken = false;
+		}
+	}
+
+	async function deleteToken(tokenId: string, name: string) {
+		if (!confirm(`Revoke token "${name}"? This cannot be undone.`)) return;
+		try {
+			await api.auth.tokens.delete(tokenId);
+			tokens = tokens.filter(t => t.id !== tokenId);
+			toastStore.show('Token revoked', 'success');
+		} catch {
+			toastStore.show('Failed to revoke token', 'error');
+		}
+	}
+
+	async function copyToken() {
+		const ok = await copyToClipboard(newTokenSecret);
+		toastStore.show(ok ? 'Token copied to clipboard' : 'Failed to copy token', ok ? 'success' : 'error');
+	}
+
+	async function savePlatformSettings() {
+		if (savingPlatform) return;
+		savingPlatform = true;
+		platformStatus = 'idle';
+		try {
+			await api.admin.updateSettings(platformSettings);
+			platformStatus = 'saved';
+			setTimeout(() => (platformStatus = 'idle'), 2000);
+		} catch {
+			platformStatus = 'error';
+		} finally {
+			savingPlatform = false;
+		}
+	}
+
+	async function sendTestEmail() {
+		testingEmail = true;
+		testEmailResult = null;
+		try {
+			const result = await api.admin.testEmail();
+			testEmailResult = { message: `Test email sent to ${result.sent_to}`, type: 'success' };
+		} catch (err: unknown) {
+			testEmailResult = {
+				message: err instanceof Error ? err.message : 'Failed to send test email',
+				type: 'error'
+			};
+		} finally {
+			testingEmail = false;
 		}
 	}
 
@@ -260,6 +436,118 @@
 					</div>
 				</div>
 			</section>
+		{:else if activeTab === 'account'}
+			<section class="section">
+				<h2>Profile</h2>
+				<div class="card">
+					<div class="field-row">
+						<span class="field-label">Email</span>
+						<span class="field-value">{profileEmail}</span>
+					</div>
+					<div class="field-row">
+						<span class="field-label">Role</span>
+						<span class="field-value"><span class="role-badge">{profileRole}</span></span>
+					</div>
+					<div class="field-row">
+						<label for="profile-name">Name</label>
+						<div class="inline-edit">
+							<input id="profile-name" type="text" bind:value={profileName} onkeydown={(e) => e.key === 'Enter' && saveProfile()} />
+							<button class="btn btn-small" onclick={saveProfile} disabled={savingProfile}>
+								{savingProfile ? 'Saving...' : 'Save'}
+							</button>
+							{#if profileStatus === 'saved'}
+								<span class="status-saved">Saved</span>
+							{:else if profileStatus === 'error'}
+								<span class="status-error">Error</span>
+							{/if}
+						</div>
+					</div>
+				</div>
+			</section>
+
+			<section class="section">
+				<h2>Change Password</h2>
+				<div class="card">
+					<div class="password-form">
+						<div class="password-field">
+							<label for="current-pw">Current password</label>
+							<input id="current-pw" type="password" bind:value={currentPassword} placeholder="Enter current password" />
+						</div>
+						<div class="password-field">
+							<label for="new-pw">New password</label>
+							<input id="new-pw" type="password" bind:value={newPassword} placeholder="At least 8 characters" />
+						</div>
+						<div class="password-field">
+							<label for="confirm-pw">Confirm new password</label>
+							<input id="confirm-pw" type="password" bind:value={confirmPassword} placeholder="Confirm new password"
+								onkeydown={(e) => e.key === 'Enter' && changePassword()} />
+						</div>
+						{#if passwordError}
+							<p class="password-error">{passwordError}</p>
+						{/if}
+						<div class="password-actions">
+							<button class="btn btn-primary" onclick={changePassword} disabled={changingPassword}>
+								{changingPassword ? 'Changing...' : 'Change Password'}
+							</button>
+							{#if passwordStatus === 'saved'}
+								<span class="status-saved">Password updated</span>
+							{/if}
+						</div>
+					</div>
+				</div>
+			</section>
+
+			<section class="section">
+				<h2>API Tokens</h2>
+				<p class="section-desc">Personal tokens for CLI and API access. Tokens are not tied to a specific workspace.</p>
+				{#if tokens.length > 0}
+					<div class="token-list">
+						{#each tokens as token (token.id)}
+							<div class="card token-row">
+								<div class="token-info">
+									<span class="token-name">{token.name}</span>
+									<code class="token-prefix">{token.prefix}...</code>
+									{#if token.last_used_at}
+										<span class="token-meta">Last used {new Date(token.last_used_at).toLocaleDateString()}</span>
+									{:else}
+										<span class="token-meta">Never used</span>
+									{/if}
+								</div>
+								<button class="btn btn-small btn-remove" onclick={() => deleteToken(token.id, token.name)}>
+									Revoke
+								</button>
+							</div>
+						{/each}
+					</div>
+				{:else}
+					<p class="empty-text">No API tokens yet.</p>
+				{/if}
+
+				{#if newTokenSecret}
+					<div class="card token-secret-card">
+						<p class="token-secret-warning">Copy this token now — it won't be shown again.</p>
+						<div class="token-secret-row">
+							<code class="token-secret">{newTokenSecret}</code>
+							<button class="btn btn-small" onclick={copyToken}>Copy</button>
+						</div>
+					</div>
+				{/if}
+
+				<div class="card token-create">
+					<div class="token-create-row">
+						<input
+							type="text"
+							placeholder="Token name (e.g. my-laptop)"
+							bind:value={newTokenName}
+							onkeydown={(e) => e.key === 'Enter' && createToken()}
+							disabled={creatingToken}
+						/>
+						<button class="btn btn-primary btn-small" onclick={createToken} disabled={creatingToken || !newTokenName.trim()}>
+							{creatingToken ? 'Creating...' : 'Create Token'}
+						</button>
+					</div>
+				</div>
+			</section>
 		{:else if activeTab === 'members'}
 			<section class="section">
 				{#if members.length === 0}
@@ -305,12 +593,13 @@
 							<div class="card invitation-row">
 								<span class="inv-email">{inv.email}</span>
 								<span class="role-badge">{inv.role}</span>
-								{#if inv.join_url}
-									<button class="btn btn-small copy-link-btn" onclick={() => { navigator.clipboard.writeText(inv.join_url ?? ''); toastStore.show('Link copied!', 'success'); }}>
-										Copy invite link
+								<button class="btn btn-small copy-link-btn" onclick={async () => { const url = inv.join_url || `${window.location.origin}/join/${inv.code}`; const ok = await copyToClipboard(url); toastStore.show(ok ? 'Link copied!' : 'Failed to copy link', ok ? 'success' : 'error'); }}>
+									Copy invite link
+								</button>
+								{#if isOwner}
+									<button class="btn btn-small btn-remove" onclick={() => handleCancelInvitation(inv.id, inv.email)}>
+										Cancel
 									</button>
-								{:else}
-									<code class="inv-code">{inv.code}</code>
 								{/if}
 							</div>
 						{/each}
@@ -433,6 +722,75 @@
 					{/if}
 				</div>
 			</section>
+		{:else if activeTab === 'platform'}
+			<section class="section">
+				<h2>Email</h2>
+				<p class="section-desc">Configure transactional email for invitations, password resets, and notifications.</p>
+				<div class="card">
+					<div class="field-row">
+						<label for="email-provider">Provider</label>
+						<div class="inline-edit">
+							<select id="email-provider" class="role-select" bind:value={platformSettings['email_provider']}
+								onchange={() => { if (!platformSettings['email_provider']) platformSettings['email_provider'] = ''; }}>
+								<option value="">Disabled</option>
+								<option value="maileroo">Maileroo</option>
+							</select>
+						</div>
+					</div>
+					{#if platformSettings['email_provider'] === 'maileroo'}
+						<div class="field-row">
+							<label for="maileroo-key">API Key</label>
+							<div class="inline-edit">
+								<input id="maileroo-key" type="password" bind:value={platformSettings['maileroo_api_key']}
+									placeholder="Enter Maileroo sending key" />
+							</div>
+						</div>
+					{/if}
+					<div class="field-row">
+						<label for="email-from">From</label>
+						<div class="inline-edit">
+							<input id="email-from" type="email" bind:value={platformSettings['email_from']}
+								placeholder="noreply@yourdomain.com" />
+						</div>
+					</div>
+					<div class="field-row">
+						<label for="email-name">Name</label>
+						<div class="inline-edit">
+							<input id="email-name" type="text" bind:value={platformSettings['email_from_name']}
+								placeholder="Pad" />
+						</div>
+					</div>
+					<div class="platform-actions">
+						<button class="btn btn-primary" onclick={savePlatformSettings} disabled={savingPlatform}>
+							{savingPlatform ? 'Saving...' : 'Save Email Settings'}
+						</button>
+						{#if platformStatus === 'saved'}
+							<span class="status-saved">Saved</span>
+						{:else if platformStatus === 'error'}
+							<span class="status-error">Error</span>
+						{/if}
+					</div>
+				</div>
+			</section>
+
+			{#if platformSettings['email_provider']}
+				<section class="section">
+					<h2>Test Email</h2>
+					<p class="section-desc">Send a test email to verify your configuration is working.</p>
+					<div class="card">
+						<div class="platform-actions">
+							<button class="btn" onclick={sendTestEmail} disabled={testingEmail}>
+								{testingEmail ? 'Sending...' : 'Send Test Email'}
+							</button>
+							{#if testEmailResult}
+								<span class={testEmailResult.type === 'success' ? 'status-saved' : 'status-error'}>
+									{testEmailResult.message}
+								</span>
+							{/if}
+						</div>
+					</div>
+				</section>
+			{/if}
 		{/if}
 	{/if}
 </div>
@@ -535,7 +893,6 @@
 	.invitations-section h3 { font-size: 0.9em; color: var(--text-muted); margin-bottom: var(--space-2); }
 	.invitation-row { display: flex; align-items: center; gap: var(--space-3); padding: var(--space-2) var(--space-4); font-size: 0.85em; }
 	.inv-email { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; }
-	.inv-code { font-family: var(--font-mono); font-size: 0.85em; background: var(--bg-tertiary); padding: 1px 6px; border-radius: var(--radius-sm); color: var(--text-muted); }
 	.copy-link-btn { color: var(--accent-blue); border-color: var(--accent-blue); background: none; }
 	.copy-link-btn:hover { background: color-mix(in srgb, var(--accent-blue) 15%, transparent); }
 	.invite-form { margin-top: var(--space-4); }
@@ -564,4 +921,27 @@
 	.danger-input { flex: 1; min-width: 180px; max-width: 300px; padding: var(--space-2); font-size: 0.88em; background: var(--bg-tertiary); border: 1px solid var(--border); border-radius: var(--radius); color: var(--text-primary); font-family: var(--font-mono); }
 	.danger-input:focus { outline: none; border-color: #ef4444; }
 	.danger-actions { display: flex; gap: var(--space-2); }
+	/* ── Account ──── */
+	.password-form { display: flex; flex-direction: column; gap: var(--space-3); }
+	.password-field { display: flex; flex-direction: column; gap: var(--space-1); }
+	.password-field label { font-size: 0.82em; color: var(--text-secondary); }
+	.password-field input { max-width: 300px; }
+	.password-error { font-size: 0.82em; color: #ef4444; margin: 0; }
+	.password-actions { display: flex; align-items: center; gap: var(--space-3); }
+	.section-desc { font-size: 0.85em; color: var(--text-muted); margin-bottom: var(--space-3); }
+	.token-list { display: flex; flex-direction: column; gap: var(--space-2); margin-bottom: var(--space-3); }
+	.token-row { display: flex; align-items: center; justify-content: space-between; padding: var(--space-3) var(--space-4); gap: var(--space-3); }
+	.token-info { display: flex; align-items: center; gap: var(--space-3); min-width: 0; flex-wrap: wrap; }
+	.token-name { font-weight: 500; font-size: 0.9em; }
+	.token-prefix { font-size: 0.8em; background: var(--bg-tertiary); padding: 1px 6px; border-radius: var(--radius-sm); color: var(--text-muted); }
+	.token-meta { font-size: 0.78em; color: var(--text-muted); }
+	.token-create { margin-top: var(--space-3); }
+	.token-create-row { display: flex; gap: var(--space-2); align-items: center; flex-wrap: wrap; }
+	.token-create-row input { flex: 1; min-width: 180px; max-width: 300px; }
+	.token-secret-card { margin-top: var(--space-3); border-color: var(--accent-green); background: color-mix(in srgb, var(--accent-green) 5%, var(--bg-secondary)); }
+	.token-secret-warning { font-size: 0.82em; color: var(--accent-orange); margin: 0 0 var(--space-2); font-weight: 500; }
+	.token-secret-row { display: flex; align-items: center; gap: var(--space-2); }
+	.token-secret { font-size: 0.82em; background: var(--bg-tertiary); padding: var(--space-2) var(--space-3); border-radius: var(--radius-sm); word-break: break-all; flex: 1; }
+	/* ── Platform ──── */
+	.platform-actions { display: flex; align-items: center; gap: var(--space-3); margin-top: var(--space-3); flex-wrap: wrap; }
 </style>


### PR DESCRIPTION
## Summary

- **Account settings** — new Account tab in settings with profile editing (display name), password change (with current password verification), and API token management (list, create, revoke)
- **Email infrastructure** — transactional email via Maileroo with contextual sender names (e.g. "Dave via Pad" for invitations), welcome emails, password reset template (ready for IDEA-81)
- **Platform settings** — admin-only Platform tab for configuring email provider, API key, sender address/name with test email send. Stored in `platform_settings` DB table, runtime-reconfigurable
- **Tab visibility refresh** — silently syncs stale data when browser tab regains focus (SSE events lost while backgrounded). Covers dashboard, collection list, and item detail without resetting page state
- **UX fixes** — replace broken filter icon (Unicode ◑ → SVG funnel), cancel invitation support

## New backend endpoints

- `PATCH /api/v1/auth/me` — update profile (name, password)
- `GET/PATCH /api/v1/admin/settings` — platform settings (admin-only)
- `POST /api/v1/admin/test-email` — verify email config (admin-only)

## New packages

- `internal/email/` — Maileroo HTTP client, email templates, test coverage
- `internal/store/platform_settings.go` — key/value platform settings CRUD

## Test plan

- [ ] Go tests pass (`go test ./...` — including 8 new email tests)
- [ ] Web build passes (`npm run build`)
- [ ] Account tab: change display name, change password (correct + wrong current password), create/revoke API token
- [ ] Platform tab: configure Maileroo, send test email, verify invite emails arrive
- [ ] Tab visibility: open collection list, switch to another tab, make a change via CLI, switch back — list updates without page flash
- [ ] Filter icon: verify funnel SVG renders correctly on collection pages