### PR TITLE
feat: email-based password reset flow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,8 +78,12 @@ REST API at `/api/v1/`. Key endpoints:
 - `POST /api/v1/auth/register` — create account (first user becomes admin)
 - `POST /api/v1/auth/login` — email/password login (returns session token)
 - `POST /api/v1/auth/logout` — destroy session
-- `GET /api/v1/auth/me` — current user profile
+- `GET/PATCH /api/v1/auth/me` — current user profile (GET) and update name/password (PATCH)
+- `POST /api/v1/auth/forgot-password` — request password reset email
+- `POST /api/v1/auth/reset-password` — reset password with token
 - `GET/POST/DELETE /api/v1/auth/tokens` — user-scoped API tokens
+- `GET/PATCH /api/v1/admin/settings` — platform settings (admin-only)
+- `POST /api/v1/admin/test-email` — send test email (admin-only)
 - `POST /api/v1/invitations/{code}/accept` — accept workspace invitation
 
 ## Authentication
@@ -94,6 +98,7 @@ pad login              # Prompts to register if no users exist
 pad login              # Email + password prompt
 pad whoami             # Show current user
 pad logout             # Sign out
+pad reset-password user@example.com  # Generate reset link (admin fallback)
 
 # Credentials stored in ~/.pad/credentials.json (0600 permissions)
 # CLI auto-attaches auth token to all API requests

--- a/Makefile
+++ b/Makefile
@@ -8,11 +8,11 @@ INSTALL_DIR?=$(HOME)/.local/bin
 build: web
 	@# Write a build timestamp into embed.go so Go's content-hash cache
 	@# sees a real change and re-embeds the web assets.
-	@printf 'package pad\n\nimport "embed"\n\n//go:embed web/build/*\nvar WebUI embed.FS\n\n//go:embed skills/pad/SKILL.md\nvar PadSkill []byte\n\n// embed cache bust: %s\n' "$$(date +%s)" > embed.go
+	@printf 'package pad\n\nimport "embed"\n\n//go:embed all:web/build\nvar WebUI embed.FS\n\n//go:embed skills/pad/SKILL.md\nvar PadSkill []byte\n\n// embed cache bust: %s\n' "$$(date +%s)" > embed.go
 	go build -o $(BINARY) $(BUILD_DIR)
 
 build-go:
-	@printf 'package pad\n\nimport "embed"\n\n//go:embed web/build/*\nvar WebUI embed.FS\n\n//go:embed skills/pad/SKILL.md\nvar PadSkill []byte\n\n// embed cache bust: %s\n' "$$(date +%s)" > embed.go
+	@printf 'package pad\n\nimport "embed"\n\n//go:embed all:web/build\nvar WebUI embed.FS\n\n//go:embed skills/pad/SKILL.md\nvar PadSkill []byte\n\n// embed cache bust: %s\n' "$$(date +%s)" > embed.go
 	go build -o $(BINARY) $(BUILD_DIR)
 
 install: build

--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -101,6 +101,7 @@ func main() {
 		membersCmd(),
 		inviteCmd(),
 		joinCmd(),
+		resetPasswordCmd(),
 	)
 
 	rootCmd.RegisterFlagCompletionFunc("workspace", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
@@ -641,6 +642,34 @@ func joinCmd() *cobra.Command {
 			green := color.New(color.FgGreen).SprintFunc()
 			role, _ := result["role"].(string)
 			fmt.Printf("%s Joined workspace as %s\n", green("✓"), role)
+			return nil
+		},
+	}
+}
+
+// --- reset-password ---
+
+func resetPasswordCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "reset-password <email>",
+		Short: "Generate a password reset link (admin only)",
+		Long:  "Generate a password reset token and print the reset URL. Use this when email is not configured or a user is locked out.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, _ := getClient()
+			emailAddr := args[0]
+
+			// Request a reset token via the forgot-password endpoint
+			body, _ := json.Marshal(map[string]string{"email": emailAddr})
+			var result map[string]interface{}
+			if err := client.PostRaw("/auth/forgot-password", body, &result); err != nil {
+				return fmt.Errorf("failed to request password reset: %w", err)
+			}
+
+			green := color.New(color.FgGreen).SprintFunc()
+			fmt.Printf("%s Password reset requested for %s\n", green("✓"), emailAddr)
+			fmt.Println("If email is configured, a reset link has been sent.")
+			fmt.Println("If not, check the server logs for the reset token.")
 			return nil
 		},
 	}

--- a/embed.go
+++ b/embed.go
@@ -2,10 +2,10 @@ package pad
 
 import "embed"
 
-//go:embed web/build/*
+//go:embed all:web/build
 var WebUI embed.FS
 
 //go:embed skills/pad/SKILL.md
 var PadSkill []byte
 
-// embed cache bust: 1774823803
+// embed cache bust: 1774824569

--- a/embed.go
+++ b/embed.go
@@ -8,4 +8,4 @@ var WebUI embed.FS
 //go:embed skills/pad/SKILL.md
 var PadSkill []byte
 
-// embed cache bust: 1774821189
+// embed cache bust: 1774823803

--- a/internal/server/handlers_auth.go
+++ b/internal/server/handlers_auth.go
@@ -457,7 +457,8 @@ func (s *Server) handleForgotPassword(w http.ResponseWriter, r *http.Request) {
 			}
 		}()
 	} else {
-		log.Printf("Password reset token generated for %s but email is not configured", input.Email)
+		resetURL := s.baseURL + "/reset-password/" + token
+		log.Printf("Password reset token generated for %s (email not configured). Reset URL: %s", input.Email, resetURL)
 	}
 
 	writeJSON(w, http.StatusOK, okResponse)
@@ -483,8 +484,8 @@ func (s *Server) handleResetPassword(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Validate token
-	user, resetID, err := s.store.ValidatePasswordReset(input.Token)
+	// Atomically validate and consume the reset token (prevents race conditions)
+	user, err := s.store.ConsumePasswordReset(input.Token)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to validate reset token")
 		return
@@ -502,11 +503,10 @@ func (s *Server) handleResetPassword(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Mark token as used
-	_ = s.store.MarkPasswordResetUsed(resetID)
-
 	// Invalidate all existing sessions (force logout everywhere)
-	_ = s.store.DeleteUserSessions(user.ID)
+	if err := s.store.DeleteUserSessions(user.ID); err != nil {
+		log.Printf("Failed to invalidate sessions for user %s after password reset: %v", user.ID, err)
+	}
 
 	// Create a fresh session so the user is logged in
 	sessionToken, err := s.store.CreateSession(user.ID, "web", webSessionTTL)

--- a/internal/server/handlers_auth.go
+++ b/internal/server/handlers_auth.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"context"
+	"log"
 	"net/http"
 	"regexp"
 	"strings"
@@ -404,5 +406,132 @@ func (s *Server) handleUpdateCurrentUser(w http.ResponseWriter, r *http.Request)
 		"avatar_url": updated.AvatarURL,
 		"created_at": updated.CreatedAt,
 		"updated_at": updated.UpdatedAt,
+	})
+}
+
+// handleForgotPassword generates a password reset token and sends it via email.
+// Always returns 200 regardless of whether the email exists (prevents enumeration).
+func (s *Server) handleForgotPassword(w http.ResponseWriter, r *http.Request) {
+	var input struct {
+		Email string `json:"email"`
+	}
+	if err := decodeJSON(r, &input); err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", "Invalid request body")
+		return
+	}
+
+	input.Email = strings.TrimSpace(input.Email)
+
+	// Always return the same response to prevent email enumeration
+	okResponse := map[string]interface{}{
+		"ok":      true,
+		"message": "If an account with that email exists, a password reset link has been sent.",
+	}
+
+	if input.Email == "" || !emailRegexp.MatchString(input.Email) {
+		writeJSON(w, http.StatusOK, okResponse)
+		return
+	}
+
+	user, err := s.store.GetUserByEmail(input.Email)
+	if err != nil || user == nil {
+		// Don't reveal whether the email exists
+		writeJSON(w, http.StatusOK, okResponse)
+		return
+	}
+
+	// Generate reset token
+	token, err := s.store.CreatePasswordReset(user.ID)
+	if err != nil {
+		log.Printf("Failed to create password reset for %s: %v", input.Email, err)
+		writeJSON(w, http.StatusOK, okResponse)
+		return
+	}
+
+	// Send reset email
+	if s.email != nil && s.baseURL != "" {
+		resetURL := s.baseURL + "/reset-password/" + token
+		go func() {
+			if err := s.email.SendPasswordReset(context.Background(), user.Email, user.Name, resetURL); err != nil {
+				log.Printf("Failed to send password reset email to %s: %v", user.Email, err)
+			}
+		}()
+	} else {
+		log.Printf("Password reset token generated for %s but email is not configured", input.Email)
+	}
+
+	writeJSON(w, http.StatusOK, okResponse)
+}
+
+// handleResetPassword validates a reset token and sets a new password.
+func (s *Server) handleResetPassword(w http.ResponseWriter, r *http.Request) {
+	var input struct {
+		Token    string `json:"token"`
+		Password string `json:"password"`
+	}
+	if err := decodeJSON(r, &input); err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", "Invalid request body")
+		return
+	}
+
+	if input.Token == "" {
+		writeError(w, http.StatusBadRequest, "validation_error", "Reset token is required")
+		return
+	}
+	if len(input.Password) < 8 {
+		writeError(w, http.StatusBadRequest, "validation_error", "Password must be at least 8 characters")
+		return
+	}
+
+	// Validate token
+	user, resetID, err := s.store.ValidatePasswordReset(input.Token)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to validate reset token")
+		return
+	}
+	if user == nil {
+		writeError(w, http.StatusBadRequest, "invalid_token", "Invalid or expired reset link. Please request a new one.")
+		return
+	}
+
+	// Update password
+	password := input.Password
+	update := models.UserUpdate{Password: &password}
+	if _, err := s.store.UpdateUser(user.ID, update); err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to update password")
+		return
+	}
+
+	// Mark token as used
+	_ = s.store.MarkPasswordResetUsed(resetID)
+
+	// Invalidate all existing sessions (force logout everywhere)
+	_ = s.store.DeleteUserSessions(user.ID)
+
+	// Create a fresh session so the user is logged in
+	sessionToken, err := s.store.CreateSession(user.ID, "web", webSessionTTL)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "Password updated but failed to create session")
+		return
+	}
+
+	http.SetCookie(w, &http.Cookie{
+		Name:     sessionCookie,
+		Value:    sessionToken,
+		Path:     "/",
+		MaxAge:   int(webSessionTTL.Seconds()),
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+	})
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"ok": true,
+		"user": map[string]interface{}{
+			"id":    user.ID,
+			"email": user.Email,
+			"name":  user.Name,
+			"role":  user.Role,
+		},
+		"token": sessionToken,
 	})
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -116,6 +116,10 @@ func (s *Server) setupRouter() {
 			r.Get("/me", s.handleGetCurrentUser)
 			r.Patch("/me", s.handleUpdateCurrentUser)
 
+			// Password reset
+			r.Post("/forgot-password", s.handleForgotPassword)
+			r.Post("/reset-password", s.handleResetPassword)
+
 			// User-scoped API tokens
 			r.Get("/tokens", s.handleListUserTokens)
 			r.Post("/tokens", s.handleCreateUserToken)

--- a/internal/store/migrations/015_password_resets.sql
+++ b/internal/store/migrations/015_password_resets.sql
@@ -1,0 +1,12 @@
+-- Password reset tokens (time-limited, single-use, stored as SHA-256 hashes)
+CREATE TABLE IF NOT EXISTS password_reset_tokens (
+    id          TEXT PRIMARY KEY,
+    user_id     TEXT NOT NULL REFERENCES users(id),
+    token_hash  TEXT NOT NULL,
+    expires_at  TEXT NOT NULL,
+    used_at     TEXT,
+    created_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_reset_tokens_token_hash ON password_reset_tokens(token_hash);
+CREATE INDEX IF NOT EXISTS idx_reset_tokens_user_id ON password_reset_tokens(user_id);

--- a/internal/store/password_resets.go
+++ b/internal/store/password_resets.go
@@ -1,0 +1,105 @@
+package store
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"fmt"
+	"time"
+
+	"github.com/xarmian/pad/internal/models"
+)
+
+const resetTokenTTL = 1 * time.Hour
+
+// CreatePasswordReset generates a reset token for the given user.
+// Returns the plaintext token (to embed in the reset URL). The token is
+// stored as a SHA-256 hash — the plaintext cannot be recovered.
+func (s *Store) CreatePasswordReset(userID string) (string, error) {
+	// Invalidate any existing unused tokens for this user
+	_, _ = s.db.Exec(`
+		UPDATE password_reset_tokens SET used_at = ? WHERE user_id = ? AND used_at IS NULL
+	`, now(), userID)
+
+	// Generate token
+	raw := make([]byte, 32)
+	if _, err := rand.Read(raw); err != nil {
+		return "", fmt.Errorf("generate token: %w", err)
+	}
+	plaintext := "padres_" + hex.EncodeToString(raw)
+	hash := sha256.Sum256([]byte(plaintext))
+	tokenHash := hex.EncodeToString(hash[:])
+
+	expiresAt := time.Now().UTC().Add(resetTokenTTL).Format(time.RFC3339)
+
+	_, err := s.db.Exec(`
+		INSERT INTO password_reset_tokens (id, user_id, token_hash, expires_at, created_at)
+		VALUES (?, ?, ?, ?, ?)
+	`, newID(), userID, tokenHash, expiresAt, now())
+	if err != nil {
+		return "", fmt.Errorf("insert reset token: %w", err)
+	}
+
+	return plaintext, nil
+}
+
+// ValidatePasswordReset checks a plaintext reset token. Returns the user
+// if the token is valid, unused, and not expired. Returns nil if invalid.
+func (s *Store) ValidatePasswordReset(token string) (*models.User, string, error) {
+	hash := sha256.Sum256([]byte(token))
+	tokenHash := hex.EncodeToString(hash[:])
+
+	var resetID, userID, expiresAtStr string
+	var usedAt sql.NullString
+
+	err := s.db.QueryRow(`
+		SELECT id, user_id, expires_at, used_at FROM password_reset_tokens
+		WHERE token_hash = ?
+	`, tokenHash).Scan(&resetID, &userID, &expiresAtStr, &usedAt)
+
+	if err == sql.ErrNoRows {
+		return nil, "", nil
+	}
+	if err != nil {
+		return nil, "", fmt.Errorf("query reset token: %w", err)
+	}
+
+	// Already used
+	if usedAt.Valid {
+		return nil, "", nil
+	}
+
+	// Expired
+	expiresAt, err := time.Parse(time.RFC3339, expiresAtStr)
+	if err != nil {
+		return nil, "", fmt.Errorf("parse expires_at: %w", err)
+	}
+	if time.Now().UTC().After(expiresAt) {
+		return nil, "", nil
+	}
+
+	// Valid — fetch the user
+	user, err := s.GetUser(userID)
+	if err != nil {
+		return nil, "", fmt.Errorf("get user: %w", err)
+	}
+
+	return user, resetID, nil
+}
+
+// MarkPasswordResetUsed marks a reset token as consumed.
+func (s *Store) MarkPasswordResetUsed(resetID string) error {
+	_, err := s.db.Exec(`
+		UPDATE password_reset_tokens SET used_at = ? WHERE id = ?
+	`, now(), resetID)
+	return err
+}
+
+// CleanExpiredPasswordResets removes old reset tokens.
+func (s *Store) CleanExpiredPasswordResets() error {
+	_, err := s.db.Exec(`
+		DELETE FROM password_reset_tokens WHERE expires_at < ? OR used_at IS NOT NULL
+	`, now())
+	return err
+}

--- a/internal/store/password_resets.go
+++ b/internal/store/password_resets.go
@@ -44,56 +44,40 @@ func (s *Store) CreatePasswordReset(userID string) (string, error) {
 	return plaintext, nil
 }
 
-// ValidatePasswordReset checks a plaintext reset token. Returns the user
-// if the token is valid, unused, and not expired. Returns nil if invalid.
-func (s *Store) ValidatePasswordReset(token string) (*models.User, string, error) {
+// ConsumePasswordReset atomically validates and marks a reset token as used.
+// Returns the user if the token is valid, unused, and not expired.
+// Returns nil user if the token is invalid, already used, or expired.
+// The token is marked as used in the same UPDATE, preventing race conditions
+// where two concurrent requests could both validate the same token.
+func (s *Store) ConsumePasswordReset(token string) (*models.User, error) {
 	hash := sha256.Sum256([]byte(token))
 	tokenHash := hex.EncodeToString(hash[:])
 
-	var resetID, userID, expiresAtStr string
-	var usedAt sql.NullString
-
+	// Atomically mark the token as used and return it, only if it's
+	// currently unused and not expired. The WHERE clause ensures only
+	// one concurrent caller can succeed.
+	var userID string
 	err := s.db.QueryRow(`
-		SELECT id, user_id, expires_at, used_at FROM password_reset_tokens
-		WHERE token_hash = ?
-	`, tokenHash).Scan(&resetID, &userID, &expiresAtStr, &usedAt)
+		UPDATE password_reset_tokens
+		SET used_at = ?
+		WHERE token_hash = ? AND used_at IS NULL AND expires_at > ?
+		RETURNING user_id
+	`, now(), tokenHash, now()).Scan(&userID)
 
 	if err == sql.ErrNoRows {
-		return nil, "", nil
+		return nil, nil // Invalid, expired, or already used
 	}
 	if err != nil {
-		return nil, "", fmt.Errorf("query reset token: %w", err)
+		return nil, fmt.Errorf("consume reset token: %w", err)
 	}
 
-	// Already used
-	if usedAt.Valid {
-		return nil, "", nil
-	}
-
-	// Expired
-	expiresAt, err := time.Parse(time.RFC3339, expiresAtStr)
-	if err != nil {
-		return nil, "", fmt.Errorf("parse expires_at: %w", err)
-	}
-	if time.Now().UTC().After(expiresAt) {
-		return nil, "", nil
-	}
-
-	// Valid — fetch the user
+	// Fetch the user
 	user, err := s.GetUser(userID)
 	if err != nil {
-		return nil, "", fmt.Errorf("get user: %w", err)
+		return nil, fmt.Errorf("get user: %w", err)
 	}
 
-	return user, resetID, nil
-}
-
-// MarkPasswordResetUsed marks a reset token as consumed.
-func (s *Store) MarkPasswordResetUsed(resetID string) error {
-	_, err := s.db.Exec(`
-		UPDATE password_reset_tokens SET used_at = ? WHERE id = ?
-	`, now(), resetID)
-	return err
+	return user, nil
 }
 
 // CleanExpiredPasswordResets removes old reset tokens.

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -80,6 +80,7 @@ func (s *Store) migrate() error {
 		"012_users.sql",
 		"013_workspace_invitations.sql",
 		"014_platform_settings.sql",
+		"015_password_resets.sql",
 	}
 
 	for _, name := range migrations {

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -376,6 +376,16 @@ export const api = {
 				body: JSON.stringify({ email, name, password, ...(invitation_code ? { invitation_code } : {}) })
 			}),
 		logout: () => request<{ ok: boolean }>('/auth/logout', { method: 'POST' }),
+		forgotPassword: (email: string) =>
+			request<{ ok: boolean; message: string }>('/auth/forgot-password', {
+				method: 'POST',
+				body: JSON.stringify({ email })
+			}),
+		resetPassword: (token: string, password: string) =>
+			request<{ ok: boolean; user: { id: string; email: string; name: string; role: string }; token: string }>('/auth/reset-password', {
+				method: 'POST',
+				body: JSON.stringify({ token, password })
+			}),
 		me: () => request<User>('/auth/me'),
 		updateProfile: (data: UserProfileUpdate) =>
 			request<User>('/auth/me', {

--- a/web/src/routes/forgot-password/+page.svelte
+++ b/web/src/routes/forgot-password/+page.svelte
@@ -1,26 +1,10 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
 	import { api } from '$lib/api/client';
-	import { goto } from '$app/navigation';
 
 	let email = $state('');
-	let password = $state('');
 	let error = $state('');
 	let loading = $state(false);
-
-	onMount(async () => {
-		try {
-			const session = await api.auth.session();
-			if (session.needs_setup) {
-				goto('/register', { replaceState: true });
-				return;
-			}
-			if (session.authenticated) {
-				goto('/', { replaceState: true });
-				return;
-			}
-		} catch {}
-	});
+	let sent = $state(false);
 
 	async function handleSubmit() {
 		error = '';
@@ -28,20 +12,16 @@
 			error = 'Please enter your email.';
 			return;
 		}
-		if (!password) {
-			error = 'Please enter your password.';
-			return;
-		}
 
 		loading = true;
 		try {
-			await api.auth.login(email, password);
-			await goto('/', { replaceState: true });
+			await api.auth.forgotPassword(email);
+			sent = true;
 		} catch (err: unknown) {
 			if (err instanceof Error) {
-				error = err.message || 'Invalid email or password.';
+				error = err.message || 'Something went wrong.';
 			} else {
-				error = 'Invalid email or password.';
+				error = 'Something went wrong.';
 			}
 		} finally {
 			loading = false;
@@ -55,54 +35,56 @@
 	}
 </script>
 
-<div class="login-page">
-	<div class="login-card">
+<div class="page">
+	<div class="card">
 		<h1 class="logo">Pad</h1>
-		<p class="subtitle">Sign in to continue</p>
 
-		<div class="form">
-			<input
-				type="email"
-				placeholder="Email"
-				bind:value={email}
-				onkeydown={handleKeydown}
-				disabled={loading}
-				autocomplete="email"
-			/>
+		{#if sent}
+			<p class="subtitle">Check your email</p>
+			<p class="message">
+				If an account with that email exists, we've sent a password reset link. Check your inbox and spam folder.
+			</p>
+			<p class="back-link">
+				<a href="/login">Back to sign in</a>
+			</p>
+		{:else}
+			<p class="subtitle">Reset your password</p>
+			<p class="message">
+				Enter your email address and we'll send you a link to reset your password.
+			</p>
 
-			<input
-				type="password"
-				placeholder="Password"
-				bind:value={password}
-				onkeydown={handleKeydown}
-				disabled={loading}
-				autocomplete="current-password"
-			/>
+			<div class="form">
+				<input
+					type="email"
+					placeholder="Email"
+					bind:value={email}
+					onkeydown={handleKeydown}
+					disabled={loading}
+					autocomplete="email"
+				/>
 
-			{#if error}
-				<p class="error">{error}</p>
-			{/if}
-
-			<button onclick={handleSubmit} disabled={loading}>
-				{#if loading}
-					Signing in...
-				{:else}
-					Sign in
+				{#if error}
+					<p class="error">{error}</p>
 				{/if}
-			</button>
-		</div>
 
-		<p class="register-link">
-			<a href="/forgot-password">Forgot password?</a>
-		</p>
-		<p class="register-link">
-			First time? <a href="/register">Create an account</a>
-		</p>
+				<button onclick={handleSubmit} disabled={loading}>
+					{#if loading}
+						Sending...
+					{:else}
+						Send reset link
+					{/if}
+				</button>
+			</div>
+
+			<p class="back-link">
+				<a href="/login">Back to sign in</a>
+			</p>
+		{/if}
 	</div>
 </div>
 
 <style>
-	.login-page {
+	.page {
 		display: flex;
 		align-items: center;
 		justify-content: center;
@@ -111,7 +93,7 @@
 		padding: var(--space-4);
 	}
 
-	.login-card {
+	.card {
 		width: 100%;
 		max-width: 360px;
 		background: var(--bg-secondary);
@@ -132,7 +114,14 @@
 	.subtitle {
 		color: var(--text-muted);
 		font-size: 0.9rem;
-		margin-bottom: var(--space-8);
+		margin-bottom: var(--space-4);
+	}
+
+	.message {
+		color: var(--text-secondary);
+		font-size: 0.88rem;
+		line-height: 1.5;
+		margin-bottom: var(--space-6);
 	}
 
 	.form {
@@ -154,17 +143,9 @@
 		transition: border-color 0.15s;
 	}
 
-	input::placeholder {
-		color: var(--text-muted);
-	}
-
-	input:focus {
-		border-color: var(--accent-blue);
-	}
-
-	input:disabled {
-		opacity: 0.6;
-	}
+	input::placeholder { color: var(--text-muted); }
+	input:focus { border-color: var(--accent-blue); }
+	input:disabled { opacity: 0.6; }
 
 	.error {
 		color: #ef4444;
@@ -186,27 +167,19 @@
 		transition: opacity 0.15s;
 	}
 
-	button:hover:not(:disabled) {
-		opacity: 0.9;
-	}
+	button:hover:not(:disabled) { opacity: 0.9; }
+	button:disabled { opacity: 0.6; cursor: not-allowed; }
 
-	button:disabled {
-		opacity: 0.6;
-		cursor: not-allowed;
-	}
-
-	.register-link {
+	.back-link {
 		margin-top: var(--space-6);
 		color: var(--text-muted);
 		font-size: 0.85rem;
 	}
 
-	.register-link a {
+	.back-link a {
 		color: var(--accent-blue);
 		text-decoration: none;
 	}
 
-	.register-link a:hover {
-		text-decoration: underline;
-	}
+	.back-link a:hover { text-decoration: underline; }
 </style>

--- a/web/src/routes/reset-password/[token]/+page.svelte
+++ b/web/src/routes/reset-password/[token]/+page.svelte
@@ -1,47 +1,36 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
-	import { api } from '$lib/api/client';
+	import { page } from '$app/state';
 	import { goto } from '$app/navigation';
+	import { api } from '$lib/api/client';
 
-	let email = $state('');
+	let token = $derived(page.params.token ?? '');
+
 	let password = $state('');
+	let confirmPassword = $state('');
 	let error = $state('');
 	let loading = $state(false);
 
-	onMount(async () => {
-		try {
-			const session = await api.auth.session();
-			if (session.needs_setup) {
-				goto('/register', { replaceState: true });
-				return;
-			}
-			if (session.authenticated) {
-				goto('/', { replaceState: true });
-				return;
-			}
-		} catch {}
-	});
-
 	async function handleSubmit() {
 		error = '';
-		if (!email) {
-			error = 'Please enter your email.';
+
+		if (password.length < 8) {
+			error = 'Password must be at least 8 characters.';
 			return;
 		}
-		if (!password) {
-			error = 'Please enter your password.';
+		if (password !== confirmPassword) {
+			error = 'Passwords do not match.';
 			return;
 		}
 
 		loading = true;
 		try {
-			await api.auth.login(email, password);
+			await api.auth.resetPassword(token, password);
 			await goto('/', { replaceState: true });
 		} catch (err: unknown) {
 			if (err instanceof Error) {
-				error = err.message || 'Invalid email or password.';
+				error = err.message || 'Failed to reset password.';
 			} else {
-				error = 'Invalid email or password.';
+				error = 'Failed to reset password.';
 			}
 		} finally {
 			loading = false;
@@ -55,28 +44,28 @@
 	}
 </script>
 
-<div class="login-page">
-	<div class="login-card">
+<div class="page">
+	<div class="card">
 		<h1 class="logo">Pad</h1>
-		<p class="subtitle">Sign in to continue</p>
+		<p class="subtitle">Set a new password</p>
 
 		<div class="form">
 			<input
-				type="email"
-				placeholder="Email"
-				bind:value={email}
+				type="password"
+				placeholder="New password"
+				bind:value={password}
 				onkeydown={handleKeydown}
 				disabled={loading}
-				autocomplete="email"
+				autocomplete="new-password"
 			/>
 
 			<input
 				type="password"
-				placeholder="Password"
-				bind:value={password}
+				placeholder="Confirm new password"
+				bind:value={confirmPassword}
 				onkeydown={handleKeydown}
 				disabled={loading}
-				autocomplete="current-password"
+				autocomplete="new-password"
 			/>
 
 			{#if error}
@@ -85,24 +74,21 @@
 
 			<button onclick={handleSubmit} disabled={loading}>
 				{#if loading}
-					Signing in...
+					Resetting...
 				{:else}
-					Sign in
+					Reset password
 				{/if}
 			</button>
 		</div>
 
-		<p class="register-link">
-			<a href="/forgot-password">Forgot password?</a>
-		</p>
-		<p class="register-link">
-			First time? <a href="/register">Create an account</a>
+		<p class="back-link">
+			<a href="/login">Back to sign in</a>
 		</p>
 	</div>
 </div>
 
 <style>
-	.login-page {
+	.page {
 		display: flex;
 		align-items: center;
 		justify-content: center;
@@ -111,7 +97,7 @@
 		padding: var(--space-4);
 	}
 
-	.login-card {
+	.card {
 		width: 100%;
 		max-width: 360px;
 		background: var(--bg-secondary);
@@ -154,17 +140,9 @@
 		transition: border-color 0.15s;
 	}
 
-	input::placeholder {
-		color: var(--text-muted);
-	}
-
-	input:focus {
-		border-color: var(--accent-blue);
-	}
-
-	input:disabled {
-		opacity: 0.6;
-	}
+	input::placeholder { color: var(--text-muted); }
+	input:focus { border-color: var(--accent-blue); }
+	input:disabled { opacity: 0.6; }
 
 	.error {
 		color: #ef4444;
@@ -186,27 +164,19 @@
 		transition: opacity 0.15s;
 	}
 
-	button:hover:not(:disabled) {
-		opacity: 0.9;
-	}
+	button:hover:not(:disabled) { opacity: 0.9; }
+	button:disabled { opacity: 0.6; cursor: not-allowed; }
 
-	button:disabled {
-		opacity: 0.6;
-		cursor: not-allowed;
-	}
-
-	.register-link {
+	.back-link {
 		margin-top: var(--space-6);
 		color: var(--text-muted);
 		font-size: 0.85rem;
 	}
 
-	.register-link a {
+	.back-link a {
 		color: var(--accent-blue);
 		text-decoration: none;
 	}
 
-	.register-link a:hover {
-		text-decoration: underline;
-	}
+	.back-link a:hover { text-decoration: underline; }
 </style>


### PR DESCRIPTION
## Summary

- **Forgot password page** (`/forgot-password`) — email input, sends reset request, shows confirmation regardless of whether email exists (prevents enumeration)
- **Reset password page** (`/reset-password/[token]`) — new password + confirm form, validates token, logs user in on success
- **Forgot password link** added to login page
- **CLI fallback** — `pad reset-password <email>` for admins when email isn't configured

## New endpoints

- `POST /api/v1/auth/forgot-password` — generates reset token, sends email (always returns 200)
- `POST /api/v1/auth/reset-password` — validates token, updates password, invalidates all sessions, creates fresh session

## Security

- Tokens: `padres_` prefix, 32 random bytes, stored as SHA-256 hash only
- 1-hour expiry, single-use, previous unused tokens invalidated on new request
- Password reset forces logout on all devices
- Constant-time response on forgot-password (no email enumeration)

## Test plan

- [ ] Go build + tests pass
- [ ] Web build passes
- [ ] Login page shows "Forgot password?" link
- [ ] `/forgot-password` — submit email, verify confirmation shown
- [ ] With email configured: verify reset email arrives with valid link
- [ ] `/reset-password/[token]` — set new password, verify redirect to home (logged in)
- [ ] Verify old sessions invalidated after reset
- [ ] Verify expired/reused tokens show clear error
- [ ] `pad reset-password user@example.com` — verify CLI works