### PR TITLE
[codex] Fix empty collection new CTA routing (BUG-14)

### DIFF
--- a/web/src/routes/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[workspace]/[collection]/+page.svelte
@@ -817,7 +817,7 @@
 				<div class="empty-icon">{collection.icon || '📦'}</div>
 				<h2>No {collection.name.toLowerCase()} yet</h2>
 				<p>Create your first {singularName().toLowerCase()} to get started.</p>
-				<a href="/{wsSlug}/{collSlug}/new" class="empty-cta">+ Create {singularName()}</a>
+				<a href="/{wsSlug}/new?collection={collSlug}" class="empty-cta">+ Create {singularName()}</a>
 				{#if emptyHint}
 					<p class="empty-hint">Or try: <code>{emptyHint}</code></p>
 				{/if}


### PR DESCRIPTION
## What changed
The empty collection CTA now routes to the shared create page with the collection preselected.

## Why
The empty-state link was pointing at `/{workspace}/{collection}/new`, which the app treats as an item slug route. Clicking `New` in an empty collection therefore loaded the item page for slug `new` and showed `Item not found`.

## User impact
Clicking `New` from an empty collection now opens the create form instead of the item-not-found page.

## Validation
- make install
- go build ./...
- go test ./...