### PR TITLE
[codex] Run npm ci before web build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ restart: build-go
 	./$(BINARY) serve --host $(HOST)
 
 web:
-	cd web && npm run build
+	cd web && npm ci && npm run build
 
 dev-web:
 	cd web && npm run dev


### PR DESCRIPTION
## What changed
Updates the build flow to run `npm ci` before the web build.

## Why
Local `main` had an unpublished build fix commit. Landing it now brings `origin/main` to the state it should have reached before the BUG-14 branch was cut.

## Impact
The web build has dependencies installed before Vite runs, which avoids missing package failures in clean environments.

## Validation
- make install
- go build ./...
- go test ./...