### PR TITLE
[codex] Fix BUG-16 quick-create button behavior and BUG-15 phase task refresh

### DIFF
--- a/web/src/lib/components/phases/PhaseTasks.svelte
+++ b/web/src/lib/components/phases/PhaseTasks.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
 	import { SvelteMap } from 'svelte/reactivity';
+	import { onDestroy, onMount } from 'svelte';
 	import { api } from '$lib/api/client';
+	import { sseService } from '$lib/services/sse.svelte';
+	import { visibility } from '$lib/services/visibility.svelte';
 	import type { Item } from '$lib/types';
 	import { parseFields, formatItemRef } from '$lib/types';
 	import { dndzone, TRIGGERS, SHADOW_ITEM_MARKER_PROPERTY_NAME } from 'svelte-dnd-action';
@@ -12,13 +15,16 @@
 		itemSlug: string;
 		itemId: string;
 		phaseFields?: Record<string, any>;
+		onTasksChange?: (tasks: Item[]) => void;
 	}
 
-	let { wsSlug, itemSlug, itemId, phaseFields }: Props = $props();
+	let { wsSlug, itemSlug, itemId, phaseFields, onTasksChange }: Props = $props();
 
 	let tasks = $state<Item[]>([]);
 	let loading = $state(true);
 	let error = $state('');
+	let unsubscribeSSE: (() => void) | null = null;
+	let unsubscribeVisibility: (() => void) | null = null;
 
 	const statusOrder: string[] = ['in_progress', 'open', 'blocked', 'done'];
 	const flipDurationMs = 200;
@@ -97,8 +103,10 @@
 		error = '';
 		try {
 			tasks = await api.items.tasks(wsSlug, itemSlug);
+			onTasksChange?.(tasks);
 		} catch (err) {
 			error = err instanceof Error ? err.message : 'Failed to load tasks';
+			onTasksChange?.([]);
 		} finally {
 			loading = false;
 		}
@@ -108,6 +116,31 @@
 		void wsSlug;
 		void itemSlug;
 		loadTasks();
+	});
+
+	onMount(() => {
+		unsubscribeVisibility = visibility.onTabResume(() => {
+			if (!wsSlug || !itemSlug) return;
+			loadTasks();
+		});
+	});
+
+	$effect(() => {
+		unsubscribeSSE?.();
+		unsubscribeSSE = null;
+
+		if (!wsSlug || !itemSlug) return;
+
+		unsubscribeSSE = sseService.onItemEvent((event) => {
+			if (event.collection !== 'tasks') return;
+			if (!['item_created', 'item_updated', 'item_archived', 'item_restored'].includes(event.type)) return;
+			loadTasks();
+		});
+	});
+
+	onDestroy(() => {
+		unsubscribeSSE?.();
+		unsubscribeVisibility?.();
 	});
 
 	function formatLabel(value: string): string {

--- a/web/src/routes/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[workspace]/[collection]/+page.svelte
@@ -452,6 +452,14 @@
 		requestAnimationFrame(() => quickCreateInput?.focus());
 	}
 
+	function handleNewButtonClick() {
+		if (quickCreateTitle.trim()) {
+			quickCreate();
+			return;
+		}
+		openQuickCreate();
+	}
+
 	function handleQuickCreateKeydown(e: KeyboardEvent) {
 		if (e.key === 'Enter' && quickCreateTitle.trim()) {
 			e.preventDefault();
@@ -733,7 +741,7 @@
 						<QuickActionsMenu actions={quickActions} {collection} scope="collection" />
 					{/if}
 
-					<button class="new-btn" onclick={openQuickCreate} disabled={creatingNew}>
+					<button class="new-btn" onclick={handleNewButtonClick} disabled={creatingNew}>
 						+ <span class="new-btn-label">New {singularName()}</span>
 					</button>
 				</div>

--- a/web/src/routes/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[workspace]/[collection]/[slug]/+page.svelte
@@ -242,6 +242,14 @@
 
 	let computedOverrides = $state<Record<string, any>>({});
 
+	function handlePhaseTasksChange(tasks: Item[]) {
+		if (collSlug !== 'phases') return;
+		const total = tasks.length;
+		const done = tasks.filter((task) => parseFields(task).status === 'done').length;
+		const progress = total > 0 ? Math.round((done / total) * 100) : 0;
+		computedOverrides = { progress, _progressDone: done, _progressTotal: total };
+	}
+
 	function fieldValue(key: string): any {
 		if (key in computedOverrides) return computedOverrides[key];
 		return fields[key] ?? '';
@@ -483,7 +491,7 @@
 
 		<!-- Phase Tasks (shown only for phases collection) -->
 		{#if collSlug === 'phases' && item}
-			<PhaseTasks {wsSlug} {itemSlug} itemId={item.id} phaseFields={fields} />
+			<PhaseTasks {wsSlug} {itemSlug} itemId={item.id} phaseFields={fields} onTasksChange={handlePhaseTasksChange} />
 		{/if}
 
 		<!-- Comments -->


### PR DESCRIPTION
## What changed

This stacks two frontend bug fixes on the same branch:

- `BUG-16`: on collection pages, clicking the `+ New` button now creates the item when the quick-create input already has a non-empty title, matching the existing Enter-key behavior.
- `BUG-15`: phase detail pages now refresh their linked task list automatically when task items change, and the phase progress display updates from the refreshed task data.

## Why this changed

Both issues were caused by UI state not following the same update path as the underlying data changes:

- For `BUG-16`, the button click path always reopened the quick-create UI instead of reusing the create action already used by Enter.
- For `BUG-15`, the phase detail view loaded linked tasks once but did not subscribe to task update events, so relation changes were only visible after a manual page refresh.

## User impact

- Quick-create on collection pages is now consistent between keyboard and mouse interaction.
- When a task is linked to a phase, the phase page reflects that change live instead of appearing stale until refresh.

## Validation

- `make install`
- `go build ./...`
- `go test ./...`
- `cd web && npm run build`
