### PR TITLE
[codex] Make Docker docs default to localhost publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,8 +161,18 @@ Requires Go 1.25+ and Node.js 22+.
 ### Docker
 
 ```bash
+docker run -p 127.0.0.1:7777:7777 -v pad-data:/data ghcr.io/xarmian/pad
+```
+
+This publishes Pad to `localhost:7777` on the host machine, which is the recommended default for local use.
+
+To expose Pad beyond localhost intentionally, publish the port more broadly:
+
+```bash
 docker run -p 7777:7777 -v pad-data:/data ghcr.io/xarmian/pad
 ```
+
+Use broader publishing only when you intend to make Pad reachable from other machines or interfaces.
 
 ### Binary Download
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -30,7 +30,7 @@ Please include:
 Pad runs as a local server on the user's machine. Security concerns include:
 
 - **Data integrity** — Pad stores project data in SQLite; unauthorized modification or deletion is a security issue
-- **Network exposure** — Pad binds to localhost by default; any vulnerability that exposes the server to the network unintentionally is in scope
+- **Network exposure** — outside Docker, Pad binds to localhost by default; in Docker, exposure depends on host-side port publishing, and any vulnerability that widens access beyond the intended deployment is in scope
 - **Code injection** — Any path where user input (item content, wiki-links, field values) could lead to code execution
 - **Path traversal** — Any way to read or write files outside the workspace directory
 - **Embedded web UI** — XSS or other web vulnerabilities in the SvelteKit frontend


### PR DESCRIPTION
## Summary
- change the default Docker example to publish Pad to host localhost only
- add an explicit example for broader host exposure when intentionally desired
- clarify SECURITY.md so Docker exposure is described in terms of host-side port publishing

## Verification
- go build ./...
- go test ./...
- cd web && npm run build