### PR TITLE
[codex] Clean up static embed build flow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,13 +11,9 @@ BUILD_TIME := $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 LDFLAGS   := -X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.buildTime=$(BUILD_TIME)
 
 build: web
-	@# Write a build timestamp into embed.go so Go's content-hash cache
-	@# sees a real change and re-embeds the web assets.
-	@printf 'package pad\n\nimport "embed"\n\n//go:embed all:web/build\nvar WebUI embed.FS\n\n//go:embed skills/pad/SKILL.md\nvar PadSkill []byte\n\n// embed cache bust: %s\n' "$$(date +%s)" > embed.go
 	go build -ldflags "$(LDFLAGS)" -o $(BINARY) $(BUILD_DIR)
 
 build-go:
-	@printf 'package pad\n\nimport "embed"\n\n//go:embed all:web/build\nvar WebUI embed.FS\n\n//go:embed skills/pad/SKILL.md\nvar PadSkill []byte\n\n// embed cache bust: %s\n' "$$(date +%s)" > embed.go
 	go build -ldflags "$(LDFLAGS)" -o $(BINARY) $(BUILD_DIR)
 
 install: build

--- a/README.md
+++ b/README.md
@@ -141,12 +141,6 @@ Items get reference numbers automatically (`TASK-5`, `BUG-12`) and can be moved 
 brew install xarmian/tap/pad
 ```
 
-### Go Install
-
-```bash
-go install github.com/xarmian/pad/cmd/pad@latest
-```
-
 ### Build from Source
 
 ```bash
@@ -157,6 +151,8 @@ cp pad ~/.local/bin/   # or /usr/local/bin/
 ```
 
 Requires Go 1.25+ and Node.js 22+.
+
+The `go install github.com/xarmian/pad/cmd/pad@latest` path is not supported for the full Pad binary, because the web UI must be built and embedded during the source build.
 
 ### Docker
 

--- a/embed.go
+++ b/embed.go
@@ -2,10 +2,10 @@ package pad
 
 import "embed"
 
+// Embedded frontend and built-in skill assets.
+
 //go:embed all:web/build
 var WebUI embed.FS
 
 //go:embed skills/pad/SKILL.md
 var PadSkill []byte
-
-// embed cache bust: 1774824569


### PR DESCRIPTION
## Summary
- stop rewriting tracked `embed.go` during builds
- keep the embedded asset package static and document its role
- remove the unsupported `go install github.com/xarmian/pad/cmd/pad@latest` path from the public install docs

## Verification
- go build ./...
- go test ./...
- cd web && npm run build
- make install