### PR TITLE
feat(cli): add global client configure flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,12 @@
 ```bash
 brew install xarmian/tap/pad
 cd your-project
+pad configure
 pad init
 pad open
 ```
 
-That's it. Four commands, zero configuration. The server auto-starts, the web UI opens at `localhost:7777`, and you're managing your project.
+For a local install, choose `Local` in `pad configure`. Pad will remember that this client manages a local server, auto-start it when needed, and open the web UI at `localhost:7777`.
 
 ## Why Pad?
 
@@ -37,7 +38,7 @@ Tools like Linear, Jira, and Notion are built for teams on the cloud. Pad is bui
 
 | | Pad | Linear / Jira | Notion |
 |---|---|---|---|
-| **Setup** | `pad init` | Create account, invite team, configure | Create account, pick template |
+| **Setup** | `pad configure` + `pad init` | Create account, invite team, configure | Create account, pick template |
 | **AI agents** | Native `/pad` skill for 7+ tools | Third-party integrations | Third-party integrations |
 | **Data** | Local SQLite, you own it | Their cloud | Their cloud |
 | **Offline** | Full functionality | Read-only cache at best | Limited |
@@ -176,7 +177,15 @@ Pre-built binaries for macOS, Linux, and Windows are available on the [releases 
 
 ## Getting Started
 
-### 1. Initialize a workspace
+### 1. Configure this Pad client
+
+```bash
+pad configure
+```
+
+For most local installs, choose `Local`. If you're connecting to another Pad server, choose `Remote` or `Docker` and enter its base URL.
+
+### 2. Initialize a workspace
 
 ```bash
 cd ~/projects/myapp
@@ -190,7 +199,7 @@ pad init "My App" --template scrum     # Scrum-style with sprints
 pad init "My App" --template product   # Product management focused
 ```
 
-### 2. Install the AI skill
+### 3. Install the AI skill
 
 ```bash
 pad install                  # Auto-detect and install for all found tools
@@ -199,7 +208,7 @@ pad install cursor
 pad install copilot
 ```
 
-### 3. Start working
+### 4. Start working
 
 ```bash
 # From the CLI
@@ -214,7 +223,7 @@ pad open                     # Opens localhost:7777 in your browser
 # Just use /pad in Claude Code, Cursor, etc.
 ```
 
-### 4. Teach your agents the rules
+### 5. Teach your agents the rules
 
 ```bash
 pad onboard                  # Auto-analyze project and suggest conventions
@@ -226,6 +235,7 @@ pad library playbooks        # Pre-built multi-step workflows
 ## CLI Reference
 
 ```
+pad configure                 Configure how this client connects to Pad
 pad init [name]              Initialize workspace in current directory
 pad open                     Open web UI in browser
 pad install [tool]           Install /pad skill for AI coding tools

--- a/cmd/pad/configure.go
+++ b/cmd/pad/configure.go
@@ -1,0 +1,234 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	neturl "net/url"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/xarmian/pad/internal/config"
+	"golang.org/x/term"
+)
+
+type configureValues struct {
+	Mode string
+	URL  string
+	Host string
+	Port int
+}
+
+func configureCmd() *cobra.Command {
+	var values configureValues
+
+	cmd := &cobra.Command{
+		Use:   "configure",
+		Short: "Configure how this Pad client connects to a server",
+		Long: `Configure how this Pad client connects to a server.
+
+Modes:
+  local   This client manages a local Pad server.
+  remote  This client connects to another Pad server by base URL.
+  docker  This client connects to a Docker-managed Pad server, usually at localhost.
+
+Pad Cloud mode is reserved for a future release and is not yet available.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg := getConfig()
+			if err := runConfigureFlow(cfg, values); err != nil {
+				return err
+			}
+
+			fmt.Printf("Configured Pad client mode: %s\n", cfg.Mode)
+			fmt.Printf("  Server URL: %s\n", cfg.BaseURL())
+			if cfg.Mode == config.ModeLocal {
+				fmt.Printf("  Server bind: %s\n", cfg.Addr())
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&values.Mode, "mode", "", "connection mode: local, remote, docker")
+	cmd.Flags().StringVar(&values.URL, "url", "", "server base URL for remote or docker mode")
+	cmd.Flags().StringVar(&values.Host, "host", "", "local server host override for local mode")
+	cmd.Flags().IntVar(&values.Port, "port", 0, "local server port override for local mode")
+
+	return cmd
+}
+
+func getConfiguredConfig() *config.Config {
+	cfg := getConfig()
+	if cfg.IsConfigured() {
+		return cfg
+	}
+
+	if !canPromptForConfig() {
+		fmt.Fprintln(os.Stderr, "Pad is not configured. Run 'pad configure' first.")
+		os.Exit(1)
+	}
+
+	fmt.Println("Pad is not configured yet.")
+	fmt.Println("Let's configure how this client connects to Pad.")
+	fmt.Println()
+	if err := runConfigureFlow(cfg, configureValues{}); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	cfg = getConfig()
+	if !cfg.IsConfigured() {
+		fmt.Fprintln(os.Stderr, "Error: Pad configuration was not saved. Run 'pad configure' again.")
+		os.Exit(1)
+	}
+	return cfg
+}
+
+func runConfigureFlow(cfg *config.Config, values configureValues) error {
+	if values.Mode == "" {
+		if !canPromptForConfig() {
+			return fmt.Errorf("missing --mode and no interactive terminal is available")
+		}
+
+		mode, err := promptForMode()
+		if err != nil {
+			return err
+		}
+		values.Mode = mode
+	}
+
+	if err := applyConfigureValues(cfg, &values); err != nil {
+		return err
+	}
+
+	return cfg.Save()
+}
+
+func applyConfigureValues(cfg *config.Config, values *configureValues) error {
+	mode := strings.ToLower(strings.TrimSpace(values.Mode))
+	if !config.ValidMode(mode) {
+		return fmt.Errorf("invalid mode %q", values.Mode)
+	}
+
+	switch mode {
+	case config.ModeLocal:
+		cfg.Mode = config.ModeLocal
+		cfg.URL = ""
+		if values.Host != "" {
+			cfg.Host = strings.TrimSpace(values.Host)
+		}
+		if values.Port > 0 {
+			cfg.Port = values.Port
+		}
+		if cfg.Host == "" {
+			cfg.Host = "127.0.0.1"
+		}
+		if cfg.Port == 0 {
+			cfg.Port = 7777
+		}
+		return nil
+	case config.ModeRemote, config.ModeDocker:
+		if values.URL == "" {
+			if !canPromptForConfig() {
+				return fmt.Errorf("--url is required for %s mode", mode)
+			}
+			prompt := "Server URL"
+			defaultURL := "http://127.0.0.1:7777"
+			if mode == config.ModeRemote {
+				defaultURL = ""
+			}
+			url, err := promptForValue(prompt, defaultURL)
+			if err != nil {
+				return err
+			}
+			values.URL = url
+		}
+		normalizedURL, err := normalizeBaseURL(values.URL)
+		if err != nil {
+			return err
+		}
+		cfg.Mode = mode
+		cfg.URL = normalizedURL
+		return nil
+	case config.ModeCloud:
+		return fmt.Errorf("Pad Cloud is not available yet")
+	default:
+		return fmt.Errorf("invalid mode %q", values.Mode)
+	}
+}
+
+func promptForMode() (string, error) {
+	reader := bufio.NewReader(os.Stdin)
+
+	fmt.Println("How should this client connect to Pad?")
+	fmt.Println("  1. Local")
+	fmt.Println("  2. Remote")
+	fmt.Println("  3. Docker")
+	fmt.Println()
+
+	for {
+		fmt.Print("Select a mode [1-3]: ")
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			return "", err
+		}
+
+		switch strings.TrimSpace(line) {
+		case "1", "local", "Local":
+			return config.ModeLocal, nil
+		case "2", "remote", "Remote":
+			return config.ModeRemote, nil
+		case "3", "docker", "Docker":
+			return config.ModeDocker, nil
+		default:
+			fmt.Println("Enter 1, 2, or 3.")
+		}
+	}
+}
+
+func promptForValue(label, defaultValue string) (string, error) {
+	reader := bufio.NewReader(os.Stdin)
+
+	if defaultValue != "" {
+		fmt.Printf("%s [%s]: ", label, defaultValue)
+	} else {
+		fmt.Printf("%s: ", label)
+	}
+
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		return "", err
+	}
+
+	value := strings.TrimSpace(line)
+	if value == "" {
+		value = defaultValue
+	}
+	return value, nil
+}
+
+func normalizeBaseURL(raw string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", fmt.Errorf("server URL is required")
+	}
+
+	u, err := neturl.Parse(raw)
+	if err != nil {
+		return "", fmt.Errorf("invalid server URL: %w", err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return "", fmt.Errorf("server URL must use http or https")
+	}
+	if u.Host == "" {
+		return "", fmt.Errorf("server URL must include a host")
+	}
+	if u.RawQuery != "" || u.Fragment != "" {
+		return "", fmt.Errorf("server URL must not include query params or fragments")
+	}
+
+	return strings.TrimRight(u.String(), "/"), nil
+}
+
+func canPromptForConfig() bool {
+	return term.IsTerminal(int(os.Stdin.Fd())) && term.IsTerminal(int(os.Stdout.Fd()))
+}

--- a/cmd/pad/configure_test.go
+++ b/cmd/pad/configure_test.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/xarmian/pad/internal/config"
+)
+
+func TestApplyConfigureValuesLocal(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.URL = "http://example.com"
+
+	err := applyConfigureValues(cfg, &configureValues{
+		Mode: config.ModeLocal,
+		Host: "127.0.0.2",
+		Port: 8787,
+	})
+	if err != nil {
+		t.Fatalf("apply local configure values: %v", err)
+	}
+	if cfg.Mode != config.ModeLocal {
+		t.Fatalf("expected local mode, got %q", cfg.Mode)
+	}
+	if cfg.URL != "" {
+		t.Fatalf("expected local mode to clear URL, got %q", cfg.URL)
+	}
+	if cfg.Host != "127.0.0.2" || cfg.Port != 8787 {
+		t.Fatalf("unexpected local bind %s:%d", cfg.Host, cfg.Port)
+	}
+}
+
+func TestApplyConfigureValuesRemote(t *testing.T) {
+	cfg := config.DefaultConfig()
+
+	err := applyConfigureValues(cfg, &configureValues{
+		Mode: config.ModeRemote,
+		URL:  "https://pad.example.com/",
+	})
+	if err != nil {
+		t.Fatalf("apply remote configure values: %v", err)
+	}
+	if cfg.Mode != config.ModeRemote {
+		t.Fatalf("expected remote mode, got %q", cfg.Mode)
+	}
+	if cfg.URL != "https://pad.example.com" {
+		t.Fatalf("expected normalized URL, got %q", cfg.URL)
+	}
+}
+
+func TestApplyConfigureValuesCloudUnavailable(t *testing.T) {
+	cfg := config.DefaultConfig()
+
+	err := applyConfigureValues(cfg, &configureValues{
+		Mode: config.ModeCloud,
+		URL:  "https://cloud.getpad.dev",
+	})
+	if err == nil {
+		t.Fatal("expected cloud mode to be unavailable")
+	}
+}
+
+func TestNormalizeBaseURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		want    string
+		wantErr bool
+	}{
+		{name: "http", raw: "http://127.0.0.1:7777/", want: "http://127.0.0.1:7777"},
+		{name: "https", raw: "https://pad.example.com", want: "https://pad.example.com"},
+		{name: "missing scheme", raw: "pad.example.com", wantErr: true},
+		{name: "query params", raw: "https://pad.example.com?x=1", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := normalizeBaseURL(tt.raw)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q", tt.raw)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("normalizeBaseURL(%q): %v", tt.raw, err)
+			}
+			if got != tt.want {
+				t.Fatalf("expected %q, got %q", tt.want, got)
+			}
+		})
+	}
+}

--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -75,6 +75,7 @@ func main() {
 	rootCmd.AddCommand(
 		serveCmd(),
 		stopCmd(),
+		configureCmd(),
 		openCmd(),
 		loginCmd(),
 		logoutCmd(),
@@ -153,12 +154,16 @@ func getConfig() *config.Config {
 	// --url flag takes highest precedence
 	if urlFlag != "" {
 		cfg.URL = urlFlag
+		cfg.LoadedFromFlags = true
+		if cfg.Mode == "" {
+			cfg.Mode = config.ModeRemote
+		}
 	}
 	return cfg
 }
 
 func getClient() (*cli.Client, *config.Config) {
-	cfg := getConfig()
+	cfg := getConfiguredConfig()
 	if err := cli.EnsureServer(cfg); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
@@ -286,7 +291,7 @@ func openCmd() *cobra.Command {
 		Use:   "open",
 		Short: "Open the Pad web UI in your browser",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cfg := getConfig()
+			cfg := getConfiguredConfig()
 			if err := cli.EnsureServer(cfg); err != nil {
 				return fmt.Errorf("start server: %w", err)
 			}
@@ -325,7 +330,7 @@ func loginCmd() *cobra.Command {
 		Use:   "login",
 		Short: "Log in to Pad",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cfg := getConfig()
+			cfg := getConfiguredConfig()
 			if err := cli.EnsureServer(cfg); err != nil {
 				return err
 			}
@@ -466,7 +471,7 @@ func logoutCmd() *cobra.Command {
 		Use:   "logout",
 		Short: "Log out of Pad",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cfg := getConfig()
+			cfg := getConfiguredConfig()
 			if err := cli.EnsureServer(cfg); err != nil {
 				return err
 			}
@@ -501,7 +506,7 @@ func whoamiCmd() *cobra.Command {
 				return nil
 			}
 
-			cfg := getConfig()
+			cfg := getConfiguredConfig()
 			if err := cli.EnsureServer(cfg); err != nil {
 				return err
 			}
@@ -741,7 +746,7 @@ Use --list-templates to see available templates.`,
 				}
 			}
 
-			cfg := getConfig()
+			cfg := getConfiguredConfig()
 			if err := cli.EnsureServer(cfg); err != nil {
 				return err
 			}

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -14,6 +14,12 @@ import (
 
 // EnsureServer checks if the pad server is running; if not, starts it in the background.
 func EnsureServer(cfg *config.Config) error {
+	// External modes connect to an already-managed server and must not auto-start
+	// a local background process.
+	if cfg.Mode != "" && cfg.Mode != config.ModeLocal {
+		return nil
+	}
+
 	if isServerHealthy(cfg.Host, cfg.Port) {
 		return nil
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,36 +10,62 @@ import (
 	"github.com/BurntSushi/toml"
 )
 
+const (
+	ModeLocal  = "local"
+	ModeRemote = "remote"
+	ModeDocker = "docker"
+	ModeCloud  = "cloud"
+)
+
 type Config struct {
+	Mode     string `toml:"mode"`
 	Host     string `toml:"host"`
 	Port     int    `toml:"port"`
-	URL      string `toml:"url"`      // Optional: full base URL (e.g., https://api.getpad.dev). Overrides host/port for CLI.
+	URL      string `toml:"url"` // Optional: full base URL (e.g., https://api.getpad.dev). Overrides host/port for CLI.
 	Editor   string `toml:"editor"`
 	LogLevel string `toml:"log_level"`
-	DBPath string `toml:"-"` // computed, not from config file
-	DataDir  string `toml:"-"`        // computed
+	DBPath   string `toml:"-"` // computed, not from config file
+	DataDir  string `toml:"-"` // computed
+
+	ConfigPath      string `toml:"-"`
+	LoadedFromFile  bool   `toml:"-"`
+	LoadedFromEnv   bool   `toml:"-"`
+	LoadedFromFlags bool   `toml:"-"`
 
 	// Email (Maileroo)
 	MailerooAPIKey string `toml:"maileroo_api_key"`
 	EmailFrom      string `toml:"email_from"`      // Sender address (e.g. noreply@getpad.dev)
-	EmailFromName  string `toml:"email_from_name"`  // Sender display name (e.g. Pad)
+	EmailFromName  string `toml:"email_from_name"` // Sender display name (e.g. Pad)
 }
 
 func DefaultConfig() *Config {
 	homeDir, _ := os.UserHomeDir()
 	dataDir := filepath.Join(homeDir, ".pad")
 	return &Config{
-		Host:     "127.0.0.1",
-		Port:     7777,
-		Editor:   "",
-		LogLevel: "info",
-		DBPath:   filepath.Join(dataDir, "pad.db"),
-		DataDir:  dataDir,
+		Host:       "127.0.0.1",
+		Port:       7777,
+		Editor:     "",
+		LogLevel:   "info",
+		DBPath:     filepath.Join(dataDir, "pad.db"),
+		DataDir:    dataDir,
+		ConfigPath: filepath.Join(dataDir, "config.toml"),
 	}
 }
 
 func Load() (*Config, error) {
 	cfg := DefaultConfig()
+
+	// Data-dir overrides affect where config.toml lives, so apply them first.
+	if v := os.Getenv("PAD_DATA_DIR"); v != "" {
+		cfg.DataDir = v
+		cfg.DBPath = filepath.Join(v, "pad.db")
+		cfg.ConfigPath = filepath.Join(v, "config.toml")
+	}
+	if v := os.Getenv("PAD_DB_PATH"); v != "" {
+		cfg.DBPath = v
+		cfg.DataDir = filepath.Dir(cfg.DBPath)
+		cfg.ConfigPath = filepath.Join(cfg.DataDir, "config.toml")
+	}
 
 	// Ensure data directory exists
 	if err := os.MkdirAll(cfg.DataDir, 0755); err != nil {
@@ -52,32 +78,34 @@ func Load() (*Config, error) {
 	}
 
 	// Load config file if it exists
-	configPath := filepath.Join(cfg.DataDir, "config.toml")
-	if _, err := os.Stat(configPath); err == nil {
-		if _, err := toml.DecodeFile(configPath, cfg); err != nil {
+	if _, err := os.Stat(cfg.ConfigPath); err == nil {
+		cfg.LoadedFromFile = true
+		if _, err := toml.DecodeFile(cfg.ConfigPath, cfg); err != nil {
 			return nil, err
 		}
 	}
 
 	// Environment variable overrides
+	if v := os.Getenv("PAD_MODE"); v != "" {
+		cfg.Mode = v
+		cfg.LoadedFromEnv = true
+	}
 	if v := os.Getenv("PAD_HOST"); v != "" {
 		cfg.Host = v
+		cfg.LoadedFromEnv = true
 	}
 	if v := os.Getenv("PAD_PORT"); v != "" {
 		if port, err := strconv.Atoi(v); err == nil {
 			cfg.Port = port
+			cfg.LoadedFromEnv = true
 		}
 	}
 	if v := os.Getenv("PAD_URL"); v != "" {
 		cfg.URL = v
-	}
-	if v := os.Getenv("PAD_DATA_DIR"); v != "" {
-		cfg.DataDir = v
-		cfg.DBPath = filepath.Join(v, "pad.db")
-	}
-	if v := os.Getenv("PAD_DB_PATH"); v != "" {
-		cfg.DBPath = v
-		cfg.DataDir = filepath.Dir(cfg.DBPath)
+		cfg.LoadedFromEnv = true
+		if cfg.Mode == "" {
+			cfg.Mode = ModeRemote
+		}
 	}
 
 	// Email (Maileroo)
@@ -92,6 +120,44 @@ func Load() (*Config, error) {
 	}
 
 	return cfg, nil
+}
+
+// Save writes the persisted Pad config to disk.
+func (c *Config) Save() error {
+	if err := os.MkdirAll(c.DataDir, 0755); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Join(c.DataDir, "logs"), 0755); err != nil {
+		return err
+	}
+
+	f, err := os.Create(c.ConfigPath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	if err := toml.NewEncoder(f).Encode(c); err != nil {
+		return err
+	}
+
+	c.LoadedFromFile = true
+	return nil
+}
+
+// IsConfigured reports whether the client has an explicit global connection
+// configuration, either from config.toml or an environment/flag override.
+func (c *Config) IsConfigured() bool {
+	return c.LoadedFromFile || c.LoadedFromEnv || c.LoadedFromFlags
+}
+
+func ValidMode(mode string) bool {
+	switch mode {
+	case "", ModeLocal, ModeRemote, ModeDocker, ModeCloud:
+		return true
+	default:
+		return false
+	}
 }
 
 // Addr returns the host:port listen address.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,73 @@
+package config
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestSaveAndLoadRoundTrip(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("load default config: %v", err)
+	}
+	if cfg.LoadedFromFile {
+		t.Fatal("expected config to start without a config file")
+	}
+	if cfg.IsConfigured() {
+		t.Fatal("expected config without file or overrides to be unconfigured")
+	}
+
+	cfg.Mode = ModeDocker
+	cfg.URL = "http://127.0.0.1:7777"
+	cfg.Host = "127.0.0.1"
+	cfg.Port = 7777
+	if err := cfg.Save(); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	reloaded, err := Load()
+	if err != nil {
+		t.Fatalf("reload config: %v", err)
+	}
+	if !reloaded.LoadedFromFile {
+		t.Fatal("expected config to load from file after save")
+	}
+	if !reloaded.IsConfigured() {
+		t.Fatal("expected saved config to count as configured")
+	}
+	if reloaded.Mode != ModeDocker {
+		t.Fatalf("expected mode %q, got %q", ModeDocker, reloaded.Mode)
+	}
+	if reloaded.URL != "http://127.0.0.1:7777" {
+		t.Fatalf("expected docker URL to round-trip, got %q", reloaded.URL)
+	}
+	if reloaded.ConfigPath != filepath.Join(home, ".pad", "config.toml") {
+		t.Fatalf("unexpected config path %q", reloaded.ConfigPath)
+	}
+}
+
+func TestLoadWithPadURLMarksConfigConfigured(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("PAD_URL", "https://pad.example.com")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("load config with PAD_URL: %v", err)
+	}
+	if !cfg.LoadedFromEnv {
+		t.Fatal("expected PAD_URL override to mark config as env-loaded")
+	}
+	if !cfg.IsConfigured() {
+		t.Fatal("expected PAD_URL override to count as configured")
+	}
+	if cfg.Mode != ModeRemote {
+		t.Fatalf("expected PAD_URL to imply remote mode, got %q", cfg.Mode)
+	}
+	if cfg.BaseURL() != "https://pad.example.com" {
+		t.Fatalf("unexpected base URL %q", cfg.BaseURL())
+	}
+}


### PR DESCRIPTION
## Summary
- add persisted global client connection mode config with support for local, remote, and docker flows
- add `pad configure` and require client configuration before API-driven commands run
- keep local autostart behavior only for local mode and document the new first-run flow

## Testing
- GOCACHE=/tmp/docapp-go-cache go build ./...
- GOCACHE=/tmp/docapp-go-cache go test ./...
- cd web && npm run build
- make install