### PR TITLE
refactor(cli): limit local server autostart to local mode for TASK-116

### DIFF
--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -123,7 +123,7 @@ func main() {
 
 	rootCmd.RegisterFlagCompletionFunc("workspace", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		cfg, err := config.Load()
-		if err != nil {
+		if err != nil || !cfg.IsConfigured() {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
 		client := cli.NewClientFromURL(cfg.BaseURL())
@@ -3542,7 +3542,7 @@ func completeCollectionNames(cmd *cobra.Command, args []string, toComplete strin
 	names := []string{"task", "tasks", "idea", "ideas", "phase", "phases", "doc", "docs", "bug", "bugs"}
 	// Try to fetch dynamic collections from API
 	cfg, err := config.Load()
-	if err == nil {
+	if err == nil && cfg.IsConfigured() {
 		if cli.EnsureServer(cfg) == nil {
 			client := cli.NewClientFromURL(cfg.BaseURL())
 			if ws, err := cli.DetectWorkspace(workspaceFlag); err == nil {
@@ -3563,7 +3563,7 @@ func completeCollectionNames(cmd *cobra.Command, args []string, toComplete strin
 // Fails silently if the server is unreachable or no workspace is configured.
 func printAvailableCollections() {
 	cfg, err := config.Load()
-	if err != nil {
+	if err != nil || !cfg.IsConfigured() {
 		return
 	}
 	if cli.EnsureServer(cfg) != nil {

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -14,9 +14,10 @@ import (
 
 // EnsureServer checks if the pad server is running; if not, starts it in the background.
 func EnsureServer(cfg *config.Config) error {
-	// External modes connect to an already-managed server and must not auto-start
-	// a local background process.
-	if cfg.Mode != "" && cfg.Mode != config.ModeLocal {
+	// Only an explicitly configured local client should auto-manage a local
+	// background process. Unconfigured or external clients should connect only
+	// to their configured target.
+	if !cfg.ManagesLocalServer() {
 		return nil
 	}
 

--- a/internal/cli/server_test.go
+++ b/internal/cli/server_test.go
@@ -1,0 +1,30 @@
+package cli
+
+import (
+	"os"
+	"testing"
+
+	"github.com/xarmian/pad/internal/config"
+)
+
+func TestEnsureServerSkipsWhenClientDoesNotManageLocalServer(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	cfg := config.DefaultConfig()
+	if err := EnsureServer(cfg); err != nil {
+		t.Fatalf("EnsureServer with default config: %v", err)
+	}
+	if _, err := os.Stat(cfg.PIDFile()); !os.IsNotExist(err) {
+		t.Fatalf("expected no PID file for unconfigured client, got err=%v", err)
+	}
+
+	cfg.Mode = config.ModeRemote
+	cfg.LoadedFromFile = true
+	if err := EnsureServer(cfg); err != nil {
+		t.Fatalf("EnsureServer with remote mode: %v", err)
+	}
+	if _, err := os.Stat(cfg.PIDFile()); !os.IsNotExist(err) {
+		t.Fatalf("expected no PID file for remote client, got err=%v", err)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -151,6 +151,12 @@ func (c *Config) IsConfigured() bool {
 	return c.LoadedFromFile || c.LoadedFromEnv || c.LoadedFromFlags
 }
 
+// ManagesLocalServer reports whether this client configuration should
+// auto-manage a local Pad server process.
+func (c *Config) ManagesLocalServer() bool {
+	return c.IsConfigured() && c.Mode == ModeLocal
+}
+
 func ValidMode(mode string) bool {
 	switch mode {
 	case "", ModeLocal, ModeRemote, ModeDocker, ModeCloud:

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -71,3 +71,25 @@ func TestLoadWithPadURLMarksConfigConfigured(t *testing.T) {
 		t.Fatalf("unexpected base URL %q", cfg.BaseURL())
 	}
 }
+
+func TestManagesLocalServerRequiresConfiguredLocalMode(t *testing.T) {
+	cfg := DefaultConfig()
+	if cfg.ManagesLocalServer() {
+		t.Fatal("expected default config without explicit mode to avoid local server management")
+	}
+
+	cfg.Mode = ModeLocal
+	if cfg.ManagesLocalServer() {
+		t.Fatal("expected local mode without persisted/env config to avoid local server management")
+	}
+
+	cfg.LoadedFromFile = true
+	if !cfg.ManagesLocalServer() {
+		t.Fatal("expected configured local mode to manage a local server")
+	}
+
+	cfg.Mode = ModeDocker
+	if cfg.ManagesLocalServer() {
+		t.Fatal("expected docker mode to avoid local server management")
+	}
+}


### PR DESCRIPTION
## Summary
- require an explicitly configured `local` mode before the CLI auto-manages a Pad server
- skip implicit localhost behavior in CLI helper paths when the client is not configured
- add guardrail tests around local vs external server management

## Test plan
- `go build ./...`
- `GOCACHE=/tmp/docapp-go-cache go test ./...`
- `cd web && npm run build`
- `make install`