### PR TITLE
refactor(auth): make setup state explicit for TASK-117

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,7 @@ REST API at `/api/v1/`. Key endpoints:
 - `GET /api/v1/events?workspace=slug` — SSE real-time events
 - `GET /workspaces/{ws}/members` — list members + pending invitations
 - `POST /workspaces/{ws}/members/invite` — invite user to workspace
-- `GET /api/v1/auth/session` — auth status (needs_setup, authenticated, user)
+- `GET /api/v1/auth/session` — auth status (`setup_required`, `setup_method`, `auth_method`, `authenticated`, `user`)
 - `POST /api/v1/auth/register` — create account (first user becomes admin)
 - `POST /api/v1/auth/login` — email/password login (returns session token)
 - `POST /api/v1/auth/logout` — destroy session

--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -353,7 +353,10 @@ func loginCmd() *cobra.Command {
 				return fmt.Errorf("failed to check server status: %w", err)
 			}
 
-			if session.NeedsSetup {
+			if session.SetupRequired {
+				if session.SetupMethod != "open_register" {
+					return fmt.Errorf("this Pad instance requires setup via %s before login", session.SetupMethod)
+				}
 				fmt.Println("No account found. Let's set you up.")
 				fmt.Println()
 				return doRegister(client, cfg)
@@ -758,7 +761,10 @@ Use --list-templates to see available templates.`,
 			if err != nil {
 				return fmt.Errorf("failed to check auth status: %w", err)
 			}
-			if session.NeedsSetup {
+			if session.SetupRequired {
+				if session.SetupMethod != "open_register" {
+					return fmt.Errorf("this Pad instance requires setup via %s before continuing", session.SetupMethod)
+				}
 				fmt.Println("Welcome to Pad!")
 				fmt.Println()
 				fmt.Println("No account found. Let's set you up.")
@@ -1652,7 +1658,7 @@ Examples:
 
 Run with --help-collections to see available collections and their status values.`,
 		ValidArgsFunction: completeCollectionNames,
-		Args: cobra.ExactArgs(2),
+		Args:              cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, _ := getClient()
 			ws := getWorkspace()
@@ -1703,10 +1709,10 @@ Run with --help-collections to see available collections and their status values
 			}
 
 			input := models.ItemCreate{
-				Title:     title,
-				Content:   body,
-				Fields:    string(fieldsJSON),
-				Tags:      tags,
+				Title:   title,
+				Content: body,
+				Fields:  string(fieldsJSON),
+				Tags:    tags,
 			}
 
 			item, err := client.CreateItem(ws, collSlug, input)
@@ -2091,8 +2097,7 @@ Examples:
 				return err
 			}
 
-			input := models.ItemUpdate{
-			}
+			input := models.ItemUpdate{}
 
 			if title != "" {
 				input.Title = &title
@@ -2195,10 +2200,10 @@ Examples:
 
 func deleteCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "delete <ref>",
-		Short: "Archive (soft-delete) an item",
+		Use:     "delete <ref>",
+		Short:   "Archive (soft-delete) an item",
 		Aliases: []string{"rm"},
-		Args:  cobra.ExactArgs(1),
+		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, _ := getClient()
 			ws := getWorkspace()
@@ -2289,7 +2294,7 @@ func commentCmd() *cobra.Command {
 			ws := getWorkspace()
 
 			input := models.CommentCreate{
-				Body:      args[1],
+				Body: args[1],
 			}
 
 			comment, err := client.CreateComment(ws, args[0], input)
@@ -2841,10 +2846,10 @@ func nextCmd() *cobra.Command {
 
 			var dash struct {
 				SuggestedNext []struct {
-					ItemSlug  string `json:"item_slug"`
-					ItemTitle string `json:"item_title"`
+					ItemSlug   string `json:"item_slug"`
+					ItemTitle  string `json:"item_title"`
 					Collection string `json:"collection"`
-					Reason    string `json:"reason"`
+					Reason     string `json:"reason"`
 				} `json:"suggested_next"`
 			}
 
@@ -2957,8 +2962,8 @@ func standupCmd() *cobra.Command {
 				}
 
 				type standupJSON struct {
-					Date          string       `json:"date"`
-					Days          int          `json:"days"`
+					Date          string        `json:"date"`
+					Days          int           `json:"days"`
 					Completed     []standupItem `json:"completed"`
 					InProgress    []standupItem `json:"in_progress"`
 					Blockers      []standupItem `json:"blockers"`
@@ -3344,8 +3349,8 @@ func collectionDefaultIcon(slug string) string {
 
 func collectionsCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "collections",
-		Short: "List and manage collections",
+		Use:     "collections",
+		Short:   "List and manage collections",
 		Aliases: []string{"coll"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, _ := getClient()
@@ -3446,11 +3451,11 @@ Examples:
 			settingsJSON, _ := json.Marshal(settings)
 
 			input := models.CollectionCreate{
-				Name:     name,
-				Icon:     icon,
+				Name:        name,
+				Icon:        icon,
 				Description: description,
-				Schema:   string(schemaJSON),
-				Settings: string(settingsJSON),
+				Schema:      string(schemaJSON),
+				Settings:    string(settingsJSON),
 			}
 
 			coll, err := client.CreateCollection(ws, input)
@@ -3514,7 +3519,7 @@ Set EDITOR or VISUAL env var to choose your editor (default: vi).`,
 			}
 
 			updated, err := client.UpdateItem(ws, slug, models.ItemUpdate{
-				Content:        &edited,
+				Content: &edited,
 			})
 			if err != nil {
 				return err
@@ -3618,9 +3623,9 @@ func normalizeCollectionSlug(input string) string {
 		"idea": "ideas", "i": "ideas",
 		"phase": "phases", "p": "phases",
 		"doc": "docs", "d": "docs",
-		"bug": "bugs",
+		"bug":        "bugs",
 		"convention": "conventions",
-		"playbook": "playbooks",
+		"playbook":   "playbooks",
 	}
 	if mapped, ok := aliases[input]; ok {
 		return mapped
@@ -3777,9 +3782,9 @@ Examples:
 				fieldsJSON, _ := json.Marshal(fields)
 
 				input := models.ItemCreate{
-					Title:     foundConvention.Title,
-					Content:   foundConvention.Content,
-					Fields:    string(fieldsJSON),
+					Title:   foundConvention.Title,
+					Content: foundConvention.Content,
+					Fields:  string(fieldsJSON),
 				}
 
 				item, err := client.CreateItem(ws, "conventions", input)
@@ -3824,9 +3829,9 @@ Examples:
 				fieldsJSON, _ := json.Marshal(fields)
 
 				input := models.ItemCreate{
-					Title:     foundPlaybook.Title,
-					Content:   foundPlaybook.Content,
-					Fields:    string(fieldsJSON),
+					Title:   foundPlaybook.Title,
+					Content: foundPlaybook.Content,
+					Fields:  string(fieldsJSON),
 				}
 
 				item, err := client.CreateItem(ws, "playbooks", input)
@@ -4396,7 +4401,7 @@ Examples:
 				fieldsStr := string(fieldsJSON)
 
 				input := models.ItemUpdate{
-					Fields:         &fieldsStr,
+					Fields: &fieldsStr,
 				}
 
 				_, err = client.UpdateItem(ws, slug, input)
@@ -4440,8 +4445,8 @@ type GitHubPR struct {
 
 func githubCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "github",
-		Short: "Link GitHub pull requests to Pad items",
+		Use:     "github",
+		Short:   "Link GitHub pull requests to Pad items",
 		Aliases: []string{"gh"},
 		Long: `Link GitHub pull requests to Pad items and view their status.
 
@@ -4607,7 +4612,7 @@ Examples:
 			fields := string(fieldsJSON)
 
 			_, err = client.UpdateItem(ws, item.Slug, models.ItemUpdate{
-				Fields:         &fields,
+				Fields: &fields,
 			})
 			if err != nil {
 				return fmt.Errorf("failed to update item: %w", err)
@@ -4665,9 +4670,9 @@ Examples:
 
 			if formatFlag == "json" {
 				type prStatus struct {
-					Ref    string    `json:"ref"`
-					Title  string    `json:"title"`
-					PR     GitHubPR  `json:"github_pr"`
+					Ref   string   `json:"ref"`
+					Title string   `json:"title"`
+					PR    GitHubPR `json:"github_pr"`
 				}
 				var results []prStatus
 				for _, item := range items {
@@ -4753,7 +4758,7 @@ func githubUnlinkCmd() *cobra.Command {
 			fields := string(fieldsJSON)
 
 			_, err = client.UpdateItem(ws, item.Slug, models.ItemUpdate{
-				Fields:         &fields,
+				Fields: &fields,
 			})
 			if err != nil {
 				return err

--- a/internal/cli/client.go
+++ b/internal/cli/client.go
@@ -361,7 +361,9 @@ type LoginUser struct {
 // SessionResponse is the response from GET /auth/session.
 type SessionResponse struct {
 	Authenticated bool      `json:"authenticated"`
-	NeedsSetup    bool      `json:"needs_setup"`
+	SetupRequired bool      `json:"setup_required"`
+	SetupMethod   string    `json:"setup_method"`
+	AuthMethod    string    `json:"auth_method"`
 	User          LoginUser `json:"user"`
 }
 

--- a/internal/server/handlers_auth.go
+++ b/internal/server/handlers_auth.go
@@ -12,12 +12,52 @@ import (
 )
 
 const (
-	sessionCookie  = "pad_session"
-	webSessionTTL  = 7 * 24 * time.Hour  // 7 days for web sessions
-	cliSessionTTL  = 30 * 24 * time.Hour // 30 days for CLI tokens
+	sessionCookie = "pad_session"
+	webSessionTTL = 7 * 24 * time.Hour  // 7 days for web sessions
+	cliSessionTTL = 30 * 24 * time.Hour // 30 days for CLI tokens
+
+	authMethodPassword      = "password"
+	authMethodCloud         = "cloud"
+	setupMethodOpenRegister = "open_register"
+	setupMethodLocalCLI     = "local_cli"
+	setupMethodDockerExec   = "docker_exec"
+	setupMethodCloud        = "cloud"
 )
 
 var emailRegexp = regexp.MustCompile(`^[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}$`)
+
+func sessionUserPayload(user *models.User) map[string]interface{} {
+	if user == nil {
+		return nil
+	}
+	return map[string]interface{}{
+		"id":    user.ID,
+		"email": user.Email,
+		"name":  user.Name,
+		"role":  user.Role,
+	}
+}
+
+func setupStatePayload(setupMethod string) map[string]interface{} {
+	return map[string]interface{}{
+		"authenticated":  false,
+		"setup_required": true,
+		"setup_method":   setupMethod,
+		"auth_method":    authMethodPassword,
+	}
+}
+
+func sessionStatePayload(authenticated bool, user *models.User) map[string]interface{} {
+	payload := map[string]interface{}{
+		"authenticated":  authenticated,
+		"setup_required": false,
+		"auth_method":    authMethodPassword,
+	}
+	if authenticated {
+		payload["user"] = sessionUserPayload(user)
+	}
+	return payload
+}
 
 // handleRegister creates a new user account.
 // When no users exist, anyone can register (first user becomes admin).
@@ -159,10 +199,7 @@ func (s *Server) handleLogin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if count == 0 {
-		writeJSON(w, http.StatusOK, map[string]interface{}{
-			"authenticated": false,
-			"needs_setup":   true,
-		})
+		writeJSON(w, http.StatusOK, setupStatePayload(setupMethodOpenRegister))
 		return
 	}
 
@@ -204,12 +241,7 @@ func (s *Server) handleLogin(w http.ResponseWriter, r *http.Request) {
 	})
 
 	writeJSON(w, http.StatusOK, map[string]interface{}{
-		"user": map[string]interface{}{
-			"id":    user.ID,
-			"email": user.Email,
-			"name":  user.Name,
-			"role":  user.Role,
-		},
+		"user":  sessionUserPayload(user),
 		"token": token,
 	})
 }
@@ -225,25 +257,14 @@ func (s *Server) handleSessionCheck(w http.ResponseWriter, r *http.Request) {
 
 	// No users → needs setup (first-time experience)
 	if count == 0 {
-		writeJSON(w, http.StatusOK, map[string]interface{}{
-			"authenticated": false,
-			"needs_setup":   true,
-		})
+		writeJSON(w, http.StatusOK, setupStatePayload(setupMethodOpenRegister))
 		return
 	}
 
 	// Try to resolve user from context (set by middleware)
 	user := currentUser(r)
 	if user != nil {
-		writeJSON(w, http.StatusOK, map[string]interface{}{
-			"authenticated": true,
-			"user": map[string]interface{}{
-				"id":    user.ID,
-				"email": user.Email,
-				"name":  user.Name,
-				"role":  user.Role,
-			},
-		})
+		writeJSON(w, http.StatusOK, sessionStatePayload(true, user))
 		return
 	}
 
@@ -251,22 +272,12 @@ func (s *Server) handleSessionCheck(w http.ResponseWriter, r *http.Request) {
 	if cookie, err := r.Cookie(sessionCookie); err == nil {
 		user, _ := s.store.ValidateSession(cookie.Value)
 		if user != nil {
-			writeJSON(w, http.StatusOK, map[string]interface{}{
-				"authenticated": true,
-				"user": map[string]interface{}{
-					"id":    user.ID,
-					"email": user.Email,
-					"name":  user.Name,
-					"role":  user.Role,
-				},
-			})
+			writeJSON(w, http.StatusOK, sessionStatePayload(true, user))
 			return
 		}
 	}
 
-	writeJSON(w, http.StatusOK, map[string]interface{}{
-		"authenticated": false,
-	})
+	writeJSON(w, http.StatusOK, sessionStatePayload(false, nil))
 }
 
 // handleLogout destroys the session and clears the cookie.

--- a/internal/server/handlers_auth_test.go
+++ b/internal/server/handlers_auth_test.go
@@ -12,18 +12,27 @@ import (
 func TestAuthRegistrationFlow(t *testing.T) {
 	srv := testServer(t)
 
-	// Session check before any users — should indicate needs_setup
+	// Session check before any users — should indicate explicit setup state
 	rr := doRequest(srv, "GET", "/api/v1/auth/session", nil)
 	if rr.Code != http.StatusOK {
 		t.Fatalf("session check: expected 200, got %d", rr.Code)
 	}
 	var session map[string]interface{}
 	parseJSON(t, rr, &session)
-	if session["needs_setup"] != true {
-		t.Error("expected needs_setup=true when no users exist")
+	if session["setup_required"] != true {
+		t.Error("expected setup_required=true when no users exist")
 	}
 	if session["authenticated"] != false {
 		t.Error("expected authenticated=false when no users exist")
+	}
+	if session["setup_method"] != "open_register" {
+		t.Errorf("expected setup_method=open_register, got %v", session["setup_method"])
+	}
+	if session["auth_method"] != "password" {
+		t.Errorf("expected auth_method=password, got %v", session["auth_method"])
+	}
+	if _, ok := session["needs_setup"]; ok {
+		t.Error("did not expect deprecated needs_setup field")
 	}
 
 	// Register first user — should become admin
@@ -62,6 +71,12 @@ func TestAuthRegistrationFlow(t *testing.T) {
 		t.Error("expected user object in authenticated session response")
 	} else if authUser["email"] != "admin@test.com" {
 		t.Errorf("expected email admin@test.com in session user, got %v", authUser["email"])
+	}
+	if session["setup_required"] != false {
+		t.Errorf("expected setup_required=false after registration, got %v", session["setup_required"])
+	}
+	if session["auth_method"] != "password" {
+		t.Errorf("expected auth_method=password after registration, got %v", session["auth_method"])
 	}
 }
 
@@ -107,6 +122,33 @@ func TestAuthLoginFlow(t *testing.T) {
 	})
 	if rr.Code != http.StatusUnauthorized {
 		t.Errorf("non-existent email: expected 401, got %d", rr.Code)
+	}
+}
+
+func TestAuthLoginReturnsExplicitSetupStateWhenNoUsers(t *testing.T) {
+	srv := testServer(t)
+
+	rr := doRequest(srv, "POST", "/api/v1/auth/login", map[string]string{
+		"email":    "nobody@test.com",
+		"password": "password123",
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("login without users: expected 200, got %d", rr.Code)
+	}
+
+	var resp map[string]interface{}
+	parseJSON(t, rr, &resp)
+	if resp["setup_required"] != true {
+		t.Errorf("expected setup_required=true, got %v", resp["setup_required"])
+	}
+	if resp["setup_method"] != "open_register" {
+		t.Errorf("expected setup_method=open_register, got %v", resp["setup_method"])
+	}
+	if resp["auth_method"] != "password" {
+		t.Errorf("expected auth_method=password, got %v", resp["auth_method"])
+	}
+	if _, ok := resp["needs_setup"]; ok {
+		t.Error("did not expect deprecated needs_setup field")
 	}
 }
 

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -77,6 +77,14 @@ export interface HealthResponse {
 	build_time?: string;
 }
 
+export interface AuthSession {
+	authenticated: boolean;
+	setup_required: boolean;
+	setup_method?: 'open_register' | 'local_cli' | 'docker_exec' | 'cloud';
+	auth_method: 'password' | 'cloud';
+	user?: { id: string; email: string; name: string; role: string };
+}
+
 export const api = {
 	// ── Health / Version ──────────────────────────────────────────────────────
 
@@ -374,8 +382,7 @@ export const api = {
 	// ── Auth ──────────────────────────────────────────────────────────────────
 
 	auth: {
-		session: (): Promise<{ authenticated: boolean; needs_setup?: boolean; user?: { id: string; email: string; name: string; role: string } }> =>
-			fetch(BASE + '/auth/session', { credentials: 'same-origin' }).then((r) => r.json()),
+		session: (): Promise<AuthSession> => fetch(BASE + '/auth/session', { credentials: 'same-origin' }).then((r) => r.json()),
 		login: (email: string, password: string) =>
 			request<{ user: { id: string; email: string; name: string; role: string }; token: string }>('/auth/login', {
 				method: 'POST',

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -23,7 +23,7 @@
 		// Check auth status before loading the app
 		try {
 			const auth = await api.auth.session();
-			if (auth.needs_setup) {
+			if (auth.setup_required && auth.setup_method === 'open_register') {
 				if (page.url.pathname !== '/register') {
 					goto('/register', { replaceState: true });
 				}

--- a/web/src/routes/join/[code]/+page.svelte
+++ b/web/src/routes/join/[code]/+page.svelte
@@ -23,7 +23,7 @@
 			if (session.authenticated) {
 				// Already logged in — try to accept directly
 				await acceptInvitation();
-			} else if (session.needs_setup) {
+			} else if (session.setup_required && session.setup_method === 'open_register') {
 				// No users yet — show register form
 				mode = 'register';
 				status = 'register';

--- a/web/src/routes/login/+page.svelte
+++ b/web/src/routes/login/+page.svelte
@@ -11,7 +11,7 @@
 	onMount(async () => {
 		try {
 			const session = await api.auth.session();
-			if (session.needs_setup) {
+			if (session.setup_required && session.setup_method === 'open_register') {
 				goto('/register', { replaceState: true });
 				return;
 			}


### PR DESCRIPTION
## Summary
- replace the vague `needs_setup` auth/session flag with explicit `setup_required`, `setup_method`, and `auth_method` fields
- update the CLI and web auth flows to consume the new session contract
- add server auth tests covering the explicit setup-state responses

## Test plan
- `go build ./...`
- `GOCACHE=/tmp/docapp-go-cache go test ./...`
- `cd web && npm run build`
- `make install`