### PR TITLE
feat(auth): add local bootstrap setup for TASK-118

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,8 @@ REST API at `/api/v1/`. Key endpoints:
 - `GET /workspaces/{ws}/members` — list members + pending invitations
 - `POST /workspaces/{ws}/members/invite` — invite user to workspace
 - `GET /api/v1/auth/session` — auth status (`setup_required`, `setup_method`, `auth_method`, `authenticated`, `user`)
-- `POST /api/v1/auth/register` — create account (first user becomes admin)
+- `POST /api/v1/auth/bootstrap` — create the first admin account from localhost on a fresh instance
+- `POST /api/v1/auth/register` — create account (admin-created or invitation-based after setup)
 - `POST /api/v1/auth/login` — email/password login (returns session token)
 - `POST /api/v1/auth/logout` — destroy session
 - `GET/PATCH /api/v1/auth/me` — current user profile (GET) and update name/password (PATCH)
@@ -88,11 +89,11 @@ REST API at `/api/v1/`. Key endpoints:
 
 ## Authentication
 
-User-based authentication with email/password. When no users exist (fresh install), everything works without auth. Once a user registers, all API requests require authentication.
+User-based authentication with email/password. When no users exist (fresh install), everything works without auth until the instance is initialized with `pad setup`. Once the first admin exists, all API requests require authentication.
 
 ```bash
-# First-time setup: register creates the admin account
-pad login              # Prompts to register if no users exist
+# First-time setup
+pad setup              # Create the first admin account on the server host
 
 # Subsequent logins
 pad login              # Email + password prompt
@@ -159,7 +160,8 @@ pad github status [item-ref]  # Show PR status for linked items
 pad github unlink <item-ref>  # Remove PR link from item
 pad bulk-update --status done TASK-5 TASK-8  # Batch operations
 pad webhooks list/create/delete/test         # Webhook management
-pad login                     # Log in (or register if first user)
+pad setup                     # Initialize a fresh instance with the first admin
+pad login                     # Log in
 pad logout                    # Sign out
 pad whoami                    # Show current user
 pad members                   # List workspace members

--- a/README.md
+++ b/README.md
@@ -285,10 +285,11 @@ All commands accept `--format json` for machine-readable output and `--workspace
 
 ### Authentication
 
-Pad runs without authentication by default for frictionless local use. On first `pad login`, you'll be prompted to create an account:
+Pad runs without authentication by default for frictionless local use. On a fresh instance, run `pad setup` on the server host to create the first admin account:
 
 ```bash
-pad login              # Register (first time) or sign in
+pad setup              # Initialize the first admin account
+pad login              # Sign in
 pad whoami             # Show current user
 pad logout             # Sign out
 ```

--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -332,6 +332,11 @@ func setupCmd() *cobra.Command {
 		Short: "Initialize a fresh Pad instance with the first admin account",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg := getConfig()
+			if !cfg.IsConfigured() {
+				// Allow host-local bootstrap on a pristine machine before the
+				// client has been explicitly configured.
+				cfg.Mode = config.ModeLocal
+			}
 
 			if cfg.IsConfigured() {
 				switch cfg.Mode {

--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -76,6 +76,7 @@ func main() {
 		serveCmd(),
 		stopCmd(),
 		configureCmd(),
+		setupCmd(),
 		openCmd(),
 		loginCmd(),
 		logoutCmd(),
@@ -325,6 +326,61 @@ func openBrowser(url string) error {
 
 // --- auth commands ---
 
+func setupCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "setup",
+		Short: "Initialize a fresh Pad instance with the first admin account",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg := getConfig()
+
+			if cfg.IsConfigured() {
+				switch cfg.Mode {
+				case config.ModeDocker:
+					return fmt.Errorf("docker-managed Pad must be initialized from inside the container; run 'docker exec -it <container> pad setup'")
+				case config.ModeRemote, config.ModeCloud:
+					return fmt.Errorf("remote Pad instances must be initialized on the server host with 'pad setup'")
+				}
+			}
+
+			if err := cli.EnsureServer(cfg); err != nil {
+				return err
+			}
+
+			client := cli.NewClientFromURL(cfg.BaseURL())
+			session, err := client.CheckSession()
+			if err != nil {
+				return fmt.Errorf("failed to check server status: %w", err)
+			}
+			if !session.SetupRequired {
+				if session.Authenticated {
+					fmt.Println("Pad is already initialized and you are logged in.")
+					return nil
+				}
+				fmt.Println("Pad is already initialized. Run 'pad login' to sign in.")
+				return nil
+			}
+
+			email, name, password, err := promptForAccountDetails()
+			if err != nil {
+				return err
+			}
+
+			resp, err := client.Bootstrap(email, name, password)
+			if err != nil {
+				return fmt.Errorf("setup failed: %w", err)
+			}
+			if err := saveCredentials(cfg, resp); err != nil {
+				return err
+			}
+
+			green := color.New(color.FgGreen).SprintFunc()
+			fmt.Printf("%s First admin account created\n", green("✓"))
+			fmt.Printf("%s Logged in as %s (%s)\n", green("✓"), resp.User.Name, resp.User.Email)
+			return nil
+		},
+	}
+}
+
 func loginCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "login",
@@ -354,12 +410,8 @@ func loginCmd() *cobra.Command {
 			}
 
 			if session.SetupRequired {
-				if session.SetupMethod != "open_register" {
-					return fmt.Errorf("this Pad instance requires setup via %s before login", session.SetupMethod)
-				}
-				fmt.Println("No account found. Let's set you up.")
-				fmt.Println()
-				return doRegister(client, cfg)
+				printSetupRequiredHint(cfg)
+				return fmt.Errorf("this Pad instance has not been initialized yet")
 			}
 
 			// Prompt for login
@@ -387,15 +439,8 @@ func doLogin(client *cli.Client, cfg *config.Config) error {
 		return fmt.Errorf("login failed: %w", err)
 	}
 
-	// Save credentials
-	if err := cli.SaveCredentials(&cli.Credentials{
-		ServerURL: cfg.BaseURL(),
-		Token:     resp.Token,
-		UserID:    resp.User.ID,
-		Email:     resp.User.Email,
-		Name:      resp.User.Name,
-	}); err != nil {
-		return fmt.Errorf("save credentials: %w", err)
+	if err := saveCredentials(cfg, resp); err != nil {
+		return err
 	}
 
 	green := color.New(color.FgGreen).SprintFunc()
@@ -403,7 +448,7 @@ func doLogin(client *cli.Client, cfg *config.Config) error {
 	return nil
 }
 
-func doRegister(client *cli.Client, cfg *config.Config) error {
+func promptForAccountDetails() (string, string, string, error) {
 	reader := bufio.NewReader(os.Stdin)
 
 	fmt.Print("  Email: ")
@@ -417,27 +462,25 @@ func doRegister(client *cli.Client, cfg *config.Config) error {
 	fmt.Print("  Password: ")
 	password, err := readPassword()
 	if err != nil {
-		return fmt.Errorf("read password: %w", err)
+		return "", "", "", fmt.Errorf("read password: %w", err)
 	}
 	fmt.Println()
 
 	fmt.Print("  Confirm: ")
 	confirm, err := readPassword()
 	if err != nil {
-		return fmt.Errorf("read password confirmation: %w", err)
+		return "", "", "", fmt.Errorf("read password confirmation: %w", err)
 	}
 	fmt.Println()
 
 	if password != confirm {
-		return fmt.Errorf("passwords do not match")
+		return "", "", "", fmt.Errorf("passwords do not match")
 	}
 
-	resp, err := client.Register(email, name, password)
-	if err != nil {
-		return fmt.Errorf("registration failed: %w", err)
-	}
+	return email, name, password, nil
+}
 
-	// Save credentials
+func saveCredentials(cfg *config.Config, resp *cli.LoginResponse) error {
 	if err := cli.SaveCredentials(&cli.Credentials{
 		ServerURL: cfg.BaseURL(),
 		Token:     resp.Token,
@@ -447,11 +490,19 @@ func doRegister(client *cli.Client, cfg *config.Config) error {
 	}); err != nil {
 		return fmt.Errorf("save credentials: %w", err)
 	}
-
-	green := color.New(color.FgGreen).SprintFunc()
-	fmt.Printf("%s Account created\n", green("✓"))
-	fmt.Printf("%s Logged in as %s (%s)\n", green("✓"), resp.User.Name, resp.User.Email)
 	return nil
+}
+
+func printSetupRequiredHint(cfg *config.Config) {
+	fmt.Println("This Pad instance has not been initialized yet.")
+	switch cfg.Mode {
+	case config.ModeDocker:
+		fmt.Println("Run 'pad setup' inside the container, for example: docker exec -it <container> pad setup")
+	case config.ModeRemote, config.ModeCloud:
+		fmt.Println("Run 'pad setup' on the machine or container running the Pad server, then try again.")
+	default:
+		fmt.Println("Run 'pad setup' to create the first admin account, then try again.")
+	}
 }
 
 func readPassword() (string, error) {
@@ -762,19 +813,8 @@ Use --list-templates to see available templates.`,
 				return fmt.Errorf("failed to check auth status: %w", err)
 			}
 			if session.SetupRequired {
-				if session.SetupMethod != "open_register" {
-					return fmt.Errorf("this Pad instance requires setup via %s before continuing", session.SetupMethod)
-				}
-				fmt.Println("Welcome to Pad!")
-				fmt.Println()
-				fmt.Println("No account found. Let's set you up.")
-				fmt.Println()
-				if err := doRegister(client, cfg); err != nil {
-					return err
-				}
-				fmt.Println()
-				// Recreate client so it picks up the new credentials
-				client = cli.NewClientFromURL(cfg.BaseURL())
+				printSetupRequiredHint(cfg)
+				return fmt.Errorf("this Pad instance has not been initialized yet")
 			} else if !session.Authenticated {
 				fmt.Println("Log in to continue.")
 				fmt.Println()

--- a/internal/cli/client.go
+++ b/internal/cli/client.go
@@ -388,6 +388,17 @@ func (c *Client) Register(email, name, password string) (*LoginResponse, error) 
 	return &result, err
 }
 
+// Bootstrap creates the first admin account on a fresh instance.
+func (c *Client) Bootstrap(email, name, password string) (*LoginResponse, error) {
+	var result LoginResponse
+	err := c.post("/auth/bootstrap", map[string]string{
+		"email":    email,
+		"name":     name,
+		"password": password,
+	}, &result)
+	return &result, err
+}
+
 // Logout destroys the current session.
 func (c *Client) Logout() error {
 	return c.post("/auth/logout", nil, nil)

--- a/internal/server/handlers_auth.go
+++ b/internal/server/handlers_auth.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"log"
+	"net"
 	"net/http"
 	"regexp"
 	"strings"
@@ -16,12 +17,11 @@ const (
 	webSessionTTL = 7 * 24 * time.Hour  // 7 days for web sessions
 	cliSessionTTL = 30 * 24 * time.Hour // 30 days for CLI tokens
 
-	authMethodPassword      = "password"
-	authMethodCloud         = "cloud"
-	setupMethodOpenRegister = "open_register"
-	setupMethodLocalCLI     = "local_cli"
-	setupMethodDockerExec   = "docker_exec"
-	setupMethodCloud        = "cloud"
+	authMethodPassword    = "password"
+	authMethodCloud       = "cloud"
+	setupMethodLocalCLI   = "local_cli"
+	setupMethodDockerExec = "docker_exec"
+	setupMethodCloud      = "cloud"
 )
 
 var emailRegexp = regexp.MustCompile(`^[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}$`)
@@ -59,11 +59,114 @@ func sessionStatePayload(authenticated bool, user *models.User) map[string]inter
 	return payload
 }
 
+func requestIsLoopback(r *http.Request) bool {
+	host := r.RemoteAddr
+	if parsedHost, _, err := net.SplitHostPort(r.RemoteAddr); err == nil {
+		host = parsedHost
+	}
+	ip := net.ParseIP(strings.Trim(host, "[]"))
+	return ip != nil && ip.IsLoopback()
+}
+
+func (s *Server) createAuthSession(w http.ResponseWriter, user *models.User, ttl time.Duration) (string, error) {
+	token, err := s.store.CreateSession(user.ID, "web", ttl)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to create session")
+		return "", err
+	}
+
+	http.SetCookie(w, &http.Cookie{
+		Name:     sessionCookie,
+		Value:    token,
+		Path:     "/",
+		MaxAge:   int(ttl.Seconds()),
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+	})
+
+	return token, nil
+}
+
+// handleBootstrap creates the first admin account for a fresh instance.
+// It is only allowed from loopback-local requests so setup must happen
+// on the server host or from inside the container.
+func (s *Server) handleBootstrap(w http.ResponseWriter, r *http.Request) {
+	if !requestIsLoopback(r) {
+		writeError(w, http.StatusForbidden, "forbidden", "Bootstrap is only allowed from localhost on the server host")
+		return
+	}
+
+	var input struct {
+		Email    string `json:"email"`
+		Name     string `json:"name"`
+		Password string `json:"password"`
+	}
+	if err := decodeJSON(r, &input); err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", "Invalid request body")
+		return
+	}
+
+	input.Email = strings.TrimSpace(input.Email)
+	input.Name = strings.TrimSpace(input.Name)
+
+	if input.Email == "" || !emailRegexp.MatchString(input.Email) {
+		writeError(w, http.StatusBadRequest, "validation_error", "Valid email is required")
+		return
+	}
+	if input.Name == "" {
+		writeError(w, http.StatusBadRequest, "validation_error", "Name is required")
+		return
+	}
+	if len(input.Password) < 8 {
+		writeError(w, http.StatusBadRequest, "validation_error", "Password must be at least 8 characters")
+		return
+	}
+
+	count, err := s.store.UserCount()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to check user count")
+		return
+	}
+	if count > 0 {
+		writeError(w, http.StatusConflict, "conflict", "This Pad instance has already been initialized")
+		return
+	}
+
+	existing, err := s.store.GetUserByEmail(input.Email)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to check email")
+		return
+	}
+	if existing != nil {
+		writeError(w, http.StatusConflict, "conflict", "A user with this email already exists")
+		return
+	}
+
+	user, err := s.store.CreateUser(models.UserCreate{
+		Email:    input.Email,
+		Name:     input.Name,
+		Password: input.Password,
+		Role:     "admin",
+	})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to create user")
+		return
+	}
+
+	token, err := s.createAuthSession(w, user, cliSessionTTL)
+	if err != nil {
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, map[string]interface{}{
+		"user":  sessionUserPayload(user),
+		"token": token,
+	})
+}
+
 // handleRegister creates a new user account.
-// When no users exist, anyone can register (first user becomes admin).
-// When users exist, registration is restricted to admins or users with a
-// valid invitation code (so that invitees can create an account via the
-// /join/[code] flow).
+// Registration is restricted to admins or users with a valid invitation code
+// so invitees can create an account via the /join/[code] flow.
 func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 	var input struct {
 		Email          string `json:"email"`
@@ -94,7 +197,6 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Check if this is the first user (becomes admin)
 	count, err := s.store.UserCount()
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to check user count")
@@ -117,19 +219,19 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 		invitation = inv
 	}
 
-	role := "member"
 	if count == 0 {
-		role = "admin"
-	} else {
-		// When users exist, allow registration if:
-		// 1. The requester is an admin, OR
-		// 2. A valid invitation code was provided
-		if invitation == nil {
-			reqUser := currentUser(r)
-			if reqUser == nil || reqUser.Role != "admin" {
-				writeError(w, http.StatusForbidden, "forbidden", "Registration is restricted")
-				return
-			}
+		writeError(w, http.StatusForbidden, "forbidden", "This Pad instance must be initialized with pad setup")
+		return
+	}
+
+	// When users exist, allow registration if:
+	// 1. The requester is an admin, OR
+	// 2. A valid invitation code was provided
+	if invitation == nil {
+		reqUser := currentUser(r)
+		if reqUser == nil || reqUser.Role != "admin" {
+			writeError(w, http.StatusForbidden, "forbidden", "Registration is restricted")
+			return
 		}
 	}
 
@@ -149,7 +251,7 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 		Email:    input.Email,
 		Name:     input.Name,
 		Password: input.Password,
-		Role:     role,
+		Role:     "member",
 	})
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to create user")
@@ -163,29 +265,13 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 		_ = s.store.AcceptInvitation(invitation.ID)
 	}
 
-	// Create session and set cookie
-	token, err := s.store.CreateSession(user.ID, "web", webSessionTTL)
+	token, err := s.createAuthSession(w, user, webSessionTTL)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to create session")
 		return
 	}
 
-	http.SetCookie(w, &http.Cookie{
-		Name:     sessionCookie,
-		Value:    token,
-		Path:     "/",
-		MaxAge:   int(webSessionTTL.Seconds()),
-		HttpOnly: true,
-		SameSite: http.SameSiteLaxMode,
-	})
-
 	writeJSON(w, http.StatusCreated, map[string]interface{}{
-		"user": map[string]interface{}{
-			"id":    user.ID,
-			"email": user.Email,
-			"name":  user.Name,
-			"role":  user.Role,
-		},
+		"user":  sessionUserPayload(user),
 		"token": token,
 	})
 }
@@ -199,7 +285,7 @@ func (s *Server) handleLogin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if count == 0 {
-		writeJSON(w, http.StatusOK, setupStatePayload(setupMethodOpenRegister))
+		writeError(w, http.StatusConflict, "setup_required", "This Pad instance must be initialized with pad setup")
 		return
 	}
 
@@ -224,21 +310,10 @@ func (s *Server) handleLogin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Create session
-	token, err := s.store.CreateSession(user.ID, "web", webSessionTTL)
+	token, err := s.createAuthSession(w, user, webSessionTTL)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to create session")
 		return
 	}
-
-	http.SetCookie(w, &http.Cookie{
-		Name:     sessionCookie,
-		Value:    token,
-		Path:     "/",
-		MaxAge:   int(webSessionTTL.Seconds()),
-		HttpOnly: true,
-		SameSite: http.SameSiteLaxMode,
-	})
 
 	writeJSON(w, http.StatusOK, map[string]interface{}{
 		"user":  sessionUserPayload(user),
@@ -257,7 +332,7 @@ func (s *Server) handleSessionCheck(w http.ResponseWriter, r *http.Request) {
 
 	// No users → needs setup (first-time experience)
 	if count == 0 {
-		writeJSON(w, http.StatusOK, setupStatePayload(setupMethodOpenRegister))
+		writeJSON(w, http.StatusOK, setupStatePayload(setupMethodLocalCLI))
 		return
 	}
 

--- a/internal/server/handlers_auth_test.go
+++ b/internal/server/handlers_auth_test.go
@@ -7,90 +7,91 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/xarmian/pad/internal/models"
 )
 
-func TestAuthRegistrationFlow(t *testing.T) {
+func bootstrapFirstUser(t *testing.T, srv *Server, email, name string) string {
+	t.Helper()
+
+	rr := doLoopbackRequest(srv, "POST", "/api/v1/auth/bootstrap", map[string]string{
+		"email":    email,
+		"name":     name,
+		"password": "password123",
+	})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("bootstrap: expected 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var resp map[string]interface{}
+	parseJSON(t, rr, &resp)
+	token, _ := resp["token"].(string)
+	if token == "" {
+		t.Fatal("expected bootstrap to return a session token")
+	}
+	return token
+}
+
+func TestAuthBootstrapFlow(t *testing.T) {
 	srv := testServer(t)
 
-	// Session check before any users — should indicate explicit setup state
 	rr := doRequest(srv, "GET", "/api/v1/auth/session", nil)
 	if rr.Code != http.StatusOK {
 		t.Fatalf("session check: expected 200, got %d", rr.Code)
 	}
+
 	var session map[string]interface{}
 	parseJSON(t, rr, &session)
 	if session["setup_required"] != true {
 		t.Error("expected setup_required=true when no users exist")
 	}
-	if session["authenticated"] != false {
-		t.Error("expected authenticated=false when no users exist")
-	}
-	if session["setup_method"] != "open_register" {
-		t.Errorf("expected setup_method=open_register, got %v", session["setup_method"])
-	}
-	if session["auth_method"] != "password" {
-		t.Errorf("expected auth_method=password, got %v", session["auth_method"])
+	if session["setup_method"] != "local_cli" {
+		t.Errorf("expected setup_method=local_cli, got %v", session["setup_method"])
 	}
 	if _, ok := session["needs_setup"]; ok {
 		t.Error("did not expect deprecated needs_setup field")
 	}
 
-	// Register first user — should become admin
-	rr = doRequest(srv, "POST", "/api/v1/auth/register", map[string]string{
+	token := bootstrapFirstUser(t, srv, "admin@test.com", "Admin")
+
+	rr = doRequestWithCookie(srv, "GET", "/api/v1/auth/session", nil, token)
+	parseJSON(t, rr, &session)
+	if session["authenticated"] != true {
+		t.Error("expected authenticated=true after bootstrap")
+	}
+	authUser, ok := session["user"].(map[string]interface{})
+	if !ok || authUser == nil {
+		t.Error("expected authenticated session user payload")
+	} else {
+		if authUser["email"] != "admin@test.com" {
+			t.Errorf("expected email admin@test.com, got %v", authUser["email"])
+		}
+		if authUser["role"] != "admin" {
+			t.Errorf("expected admin role after bootstrap, got %v", authUser["role"])
+		}
+	}
+	if session["setup_required"] != false {
+		t.Errorf("expected setup_required=false after bootstrap, got %v", session["setup_required"])
+	}
+}
+
+func TestAuthBootstrapRequiresLoopback(t *testing.T) {
+	srv := testServer(t)
+
+	rr := doRequest(srv, "POST", "/api/v1/auth/bootstrap", map[string]string{
 		"email":    "admin@test.com",
 		"name":     "Admin",
 		"password": "password123",
 	})
-	if rr.Code != http.StatusCreated {
-		t.Fatalf("register: expected 201, got %d: %s", rr.Code, rr.Body.String())
-	}
-
-	var regResp map[string]interface{}
-	parseJSON(t, rr, &regResp)
-	user := regResp["user"].(map[string]interface{})
-	if user["role"] != "admin" {
-		t.Errorf("first user should be admin, got %v", user["role"])
-	}
-	if user["email"] != "admin@test.com" {
-		t.Errorf("expected email admin@test.com, got %v", user["email"])
-	}
-	token := regResp["token"].(string)
-	if token == "" {
-		t.Error("expected non-empty token")
-	}
-
-	// Session check after registration — should be authenticated (cookie set)
-	// Use the token from registration response via cookie
-	rr = doRequestWithCookie(srv, "GET", "/api/v1/auth/session", nil, token)
-	parseJSON(t, rr, &session)
-	if session["authenticated"] != true {
-		t.Error("expected authenticated=true after registration")
-	}
-	authUser, ok := session["user"].(map[string]interface{})
-	if !ok || authUser == nil {
-		t.Error("expected user object in authenticated session response")
-	} else if authUser["email"] != "admin@test.com" {
-		t.Errorf("expected email admin@test.com in session user, got %v", authUser["email"])
-	}
-	if session["setup_required"] != false {
-		t.Errorf("expected setup_required=false after registration, got %v", session["setup_required"])
-	}
-	if session["auth_method"] != "password" {
-		t.Errorf("expected auth_method=password after registration, got %v", session["auth_method"])
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("remote bootstrap: expected 403, got %d: %s", rr.Code, rr.Body.String())
 	}
 }
 
 func TestAuthLoginFlow(t *testing.T) {
 	srv := testServer(t)
+	bootstrapFirstUser(t, srv, "user@test.com", "Test User")
 
-	// Register a user first
-	doRequest(srv, "POST", "/api/v1/auth/register", map[string]string{
-		"email":    "user@test.com",
-		"name":     "Test User",
-		"password": "password123",
-	})
-
-	// Login with correct credentials
 	rr := doRequest(srv, "POST", "/api/v1/auth/login", map[string]string{
 		"email":    "user@test.com",
 		"password": "password123",
@@ -106,7 +107,6 @@ func TestAuthLoginFlow(t *testing.T) {
 		t.Errorf("expected name 'Test User', got %v", user["name"])
 	}
 
-	// Login with wrong password
 	rr = doRequest(srv, "POST", "/api/v1/auth/login", map[string]string{
 		"email":    "user@test.com",
 		"password": "wrongpassword",
@@ -115,7 +115,6 @@ func TestAuthLoginFlow(t *testing.T) {
 		t.Errorf("wrong password: expected 401, got %d", rr.Code)
 	}
 
-	// Login with non-existent email
 	rr = doRequest(srv, "POST", "/api/v1/auth/login", map[string]string{
 		"email":    "nobody@test.com",
 		"password": "anything",
@@ -125,37 +124,89 @@ func TestAuthLoginFlow(t *testing.T) {
 	}
 }
 
-func TestAuthLoginReturnsExplicitSetupStateWhenNoUsers(t *testing.T) {
+func TestAuthLoginRequiresSetupWhenNoUsers(t *testing.T) {
 	srv := testServer(t)
 
 	rr := doRequest(srv, "POST", "/api/v1/auth/login", map[string]string{
 		"email":    "nobody@test.com",
 		"password": "password123",
 	})
-	if rr.Code != http.StatusOK {
-		t.Fatalf("login without users: expected 200, got %d", rr.Code)
+	if rr.Code != http.StatusConflict {
+		t.Fatalf("login without users: expected 409, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestFreshInstanceRegistrationIsForbidden(t *testing.T) {
+	srv := testServer(t)
+
+	rr := doRequest(srv, "POST", "/api/v1/auth/register", map[string]string{
+		"email":    "admin@test.com",
+		"name":     "Admin",
+		"password": "password123",
+	})
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("fresh registration: expected 403, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestInvitationRegistrationFlow(t *testing.T) {
+	srv := testServer(t)
+	adminToken := bootstrapFirstUser(t, srv, "admin@test.com", "Admin")
+
+	ws, err := srv.store.CreateWorkspace(models.WorkspaceCreate{Name: "Test"})
+	if err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	admin, err := srv.store.GetUserByEmail("admin@test.com")
+	if err != nil || admin == nil {
+		t.Fatalf("load admin user: %v", err)
+	}
+	if err := srv.store.AddWorkspaceMember(ws.ID, admin.ID, "owner"); err != nil {
+		t.Fatalf("add admin workspace membership: %v", err)
+	}
+	inv, err := srv.store.CreateInvitation(ws.ID, "invitee@test.com", "viewer", admin.ID)
+	if err != nil {
+		t.Fatalf("create invitation: %v", err)
+	}
+
+	rr := doRequest(srv, "POST", "/api/v1/auth/register", map[string]string{
+		"email":           "invitee@test.com",
+		"name":            "Invitee",
+		"password":        "password123",
+		"invitation_code": inv.Code,
+	})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("invitation registration: expected 201, got %d: %s", rr.Code, rr.Body.String())
 	}
 
 	var resp map[string]interface{}
 	parseJSON(t, rr, &resp)
-	if resp["setup_required"] != true {
-		t.Errorf("expected setup_required=true, got %v", resp["setup_required"])
+	user := resp["user"].(map[string]interface{})
+	if user["role"] != "member" {
+		t.Errorf("expected invitation signup to create member role, got %v", user["role"])
 	}
-	if resp["setup_method"] != "open_register" {
-		t.Errorf("expected setup_method=open_register, got %v", resp["setup_method"])
+
+	invitee, err := srv.store.GetUserByEmail("invitee@test.com")
+	if err != nil || invitee == nil {
+		t.Fatalf("load invitee: %v", err)
 	}
-	if resp["auth_method"] != "password" {
-		t.Errorf("expected auth_method=password, got %v", resp["auth_method"])
+	member, err := srv.store.GetWorkspaceMember(ws.ID, invitee.ID)
+	if err != nil {
+		t.Fatalf("get workspace member: %v", err)
 	}
-	if _, ok := resp["needs_setup"]; ok {
-		t.Error("did not expect deprecated needs_setup field")
+	if member == nil || member.Role != "viewer" {
+		t.Fatalf("expected invitee to be added to workspace as viewer, got %#v", member)
+	}
+
+	rr = doRequestWithCookie(srv, "POST", "/api/v1/auth/logout", nil, adminToken)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("logout admin: expected 200, got %d", rr.Code)
 	}
 }
 
 func TestAuthRegistrationValidation(t *testing.T) {
 	srv := testServer(t)
 
-	// Missing email
 	rr := doRequest(srv, "POST", "/api/v1/auth/register", map[string]string{
 		"name":     "Test",
 		"password": "password123",
@@ -164,7 +215,6 @@ func TestAuthRegistrationValidation(t *testing.T) {
 		t.Errorf("missing email: expected 400, got %d", rr.Code)
 	}
 
-	// Invalid email
 	rr = doRequest(srv, "POST", "/api/v1/auth/register", map[string]string{
 		"email":    "not-an-email",
 		"name":     "Test",
@@ -174,7 +224,6 @@ func TestAuthRegistrationValidation(t *testing.T) {
 		t.Errorf("invalid email: expected 400, got %d", rr.Code)
 	}
 
-	// Short password
 	rr = doRequest(srv, "POST", "/api/v1/auth/register", map[string]string{
 		"email":    "test@test.com",
 		"name":     "Test",
@@ -184,7 +233,6 @@ func TestAuthRegistrationValidation(t *testing.T) {
 		t.Errorf("short password: expected 400, got %d", rr.Code)
 	}
 
-	// Missing name
 	rr = doRequest(srv, "POST", "/api/v1/auth/register", map[string]string{
 		"email":    "test@test.com",
 		"password": "password123",
@@ -196,24 +244,13 @@ func TestAuthRegistrationValidation(t *testing.T) {
 
 func TestAuthLogout(t *testing.T) {
 	srv := testServer(t)
+	token := bootstrapFirstUser(t, srv, "user@test.com", "Test")
 
-	// Register and get token
-	rr := doRequest(srv, "POST", "/api/v1/auth/register", map[string]string{
-		"email":    "user@test.com",
-		"name":     "Test",
-		"password": "password123",
-	})
-	var regResp map[string]interface{}
-	parseJSON(t, rr, &regResp)
-	token := regResp["token"].(string)
-
-	// Logout
-	rr = doRequestWithCookie(srv, "POST", "/api/v1/auth/logout", nil, token)
+	rr := doRequestWithCookie(srv, "POST", "/api/v1/auth/logout", nil, token)
 	if rr.Code != http.StatusOK {
 		t.Fatalf("logout: expected 200, got %d", rr.Code)
 	}
 
-	// Session should no longer be valid
 	rr = doRequestWithCookie(srv, "GET", "/api/v1/auth/session", nil, token)
 	var session map[string]interface{}
 	parseJSON(t, rr, &session)
@@ -225,32 +262,23 @@ func TestAuthLogout(t *testing.T) {
 func TestAuthRequiredWhenUsersExist(t *testing.T) {
 	srv := testServer(t)
 
-	// Before registration — API should work without auth
 	rr := doRequest(srv, "GET", "/api/v1/workspaces", nil)
 	if rr.Code != http.StatusOK {
 		t.Errorf("no users: expected 200, got %d", rr.Code)
 	}
 
-	// Register a user
-	doRequest(srv, "POST", "/api/v1/auth/register", map[string]string{
-		"email":    "admin@test.com",
-		"name":     "Admin",
-		"password": "password123",
-	})
+	bootstrapFirstUser(t, srv, "admin@test.com", "Admin")
 
-	// After registration — unauthenticated API requests should get 401
 	rr = doRequest(srv, "GET", "/api/v1/workspaces", nil)
 	if rr.Code != http.StatusUnauthorized {
 		t.Errorf("with users: expected 401, got %d: %s", rr.Code, rr.Body.String())
 	}
 
-	// Auth endpoints should still be accessible
 	rr = doRequest(srv, "GET", "/api/v1/auth/session", nil)
 	if rr.Code != http.StatusOK {
 		t.Errorf("auth/session should be exempt: expected 200, got %d", rr.Code)
 	}
 
-	// Health should be accessible
 	rr = doRequest(srv, "GET", "/api/v1/health", nil)
 	if rr.Code != http.StatusOK {
 		t.Errorf("health should be exempt: expected 200, got %d", rr.Code)
@@ -259,19 +287,9 @@ func TestAuthRequiredWhenUsersExist(t *testing.T) {
 
 func TestAuthMeEndpoint(t *testing.T) {
 	srv := testServer(t)
+	token := bootstrapFirstUser(t, srv, "me@test.com", "Me Test")
 
-	// Register
-	rr := doRequest(srv, "POST", "/api/v1/auth/register", map[string]string{
-		"email":    "me@test.com",
-		"name":     "Me Test",
-		"password": "password123",
-	})
-	var regResp map[string]interface{}
-	parseJSON(t, rr, &regResp)
-	token := regResp["token"].(string)
-
-	// Get current user
-	rr = doRequestWithCookie(srv, "GET", "/api/v1/auth/me", nil, token)
+	rr := doRequestWithCookie(srv, "GET", "/api/v1/auth/me", nil, token)
 	if rr.Code != http.StatusOK {
 		t.Fatalf("me: expected 200, got %d: %s", rr.Code, rr.Body.String())
 	}
@@ -288,23 +306,22 @@ func TestAuthMeEndpoint(t *testing.T) {
 
 func TestDuplicateRegistration(t *testing.T) {
 	srv := testServer(t)
+	adminToken := bootstrapFirstUser(t, srv, "admin@test.com", "Admin")
 
-	// Register first user
-	rr := doRequest(srv, "POST", "/api/v1/auth/register", map[string]string{
+	rr := doRequestWithCookie(srv, "POST", "/api/v1/auth/register", map[string]string{
 		"email":    "dup@test.com",
 		"name":     "First",
 		"password": "password123",
-	})
+	}, adminToken)
 	if rr.Code != http.StatusCreated {
-		t.Fatalf("first register: expected 201, got %d", rr.Code)
+		t.Fatalf("admin register: expected 201, got %d: %s", rr.Code, rr.Body.String())
 	}
 
-	// Try to register same email again (unauthenticated — should be forbidden since users exist)
-	rr = doRequest(srv, "POST", "/api/v1/auth/register", map[string]string{
+	rr = doRequestWithCookie(srv, "POST", "/api/v1/auth/register", map[string]string{
 		"email":    "dup@test.com",
 		"name":     "Second",
 		"password": "password456",
-	})
+	}, adminToken)
 	if rr.Code == http.StatusCreated {
 		t.Error("duplicate registration should not succeed")
 	}
@@ -321,6 +338,7 @@ func doRequestWithCookie(srv *Server, method, path string, body interface{}, tok
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
+	req.RemoteAddr = "192.0.2.1:1234"
 	req.AddCookie(&http.Cookie{
 		Name:  "pad_session",
 		Value: token,

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -120,6 +120,7 @@ func (s *Server) setupRouter() {
 		// Auth endpoints (exempt from auth middleware)
 		r.Route("/auth", func(r chi.Router) {
 			r.Get("/session", s.handleSessionCheck)
+			r.Post("/bootstrap", s.handleBootstrap)
 			r.Post("/register", s.handleRegister)
 			r.Post("/login", s.handleLogin)
 			r.Post("/logout", s.handleLogout)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -26,6 +26,14 @@ func testServer(t *testing.T) *Server {
 }
 
 func doRequest(srv *Server, method, path string, body interface{}) *httptest.ResponseRecorder {
+	return doRequestFromRemoteAddr(srv, method, path, body, "192.0.2.1:1234")
+}
+
+func doLoopbackRequest(srv *Server, method, path string, body interface{}) *httptest.ResponseRecorder {
+	return doRequestFromRemoteAddr(srv, method, path, body, "127.0.0.1:1234")
+}
+
+func doRequestFromRemoteAddr(srv *Server, method, path string, body interface{}, remoteAddr string) *httptest.ResponseRecorder {
 	var bodyReader io.Reader
 	if body != nil {
 		data, _ := json.Marshal(body)
@@ -35,6 +43,7 @@ func doRequest(srv *Server, method, path string, body interface{}) *httptest.Res
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
+	req.RemoteAddr = remoteAddr
 	rr := httptest.NewRecorder()
 	srv.ServeHTTP(rr, req)
 	return rr

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -80,7 +80,7 @@ export interface HealthResponse {
 export interface AuthSession {
 	authenticated: boolean;
 	setup_required: boolean;
-	setup_method?: 'open_register' | 'local_cli' | 'docker_exec' | 'cloud';
+	setup_method?: 'local_cli' | 'docker_exec' | 'cloud';
 	auth_method: 'password' | 'cloud';
 	user?: { id: string; email: string; name: string; role: string };
 }

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -23,9 +23,9 @@
 		// Check auth status before loading the app
 		try {
 			const auth = await api.auth.session();
-			if (auth.setup_required && auth.setup_method === 'open_register') {
-				if (page.url.pathname !== '/register') {
-					goto('/register', { replaceState: true });
+			if (auth.setup_required) {
+				if (!isAuthPage) {
+					goto('/login', { replaceState: true });
 				}
 				authReady = true;
 				return;

--- a/web/src/routes/join/[code]/+page.svelte
+++ b/web/src/routes/join/[code]/+page.svelte
@@ -23,10 +23,9 @@
 			if (session.authenticated) {
 				// Already logged in — try to accept directly
 				await acceptInvitation();
-			} else if (session.setup_required && session.setup_method === 'open_register') {
-				// No users yet — show register form
-				mode = 'register';
-				status = 'register';
+			} else if (session.setup_required) {
+				errorMsg = 'This Pad instance has not been initialized yet. Ask the server admin to run pad setup before accepting invitations.';
+				status = 'error';
 			} else {
 				// Users exist, not logged in — show login (with option to register)
 				mode = 'login';

--- a/web/src/routes/login/+page.svelte
+++ b/web/src/routes/login/+page.svelte
@@ -96,7 +96,7 @@
 			<a href="/forgot-password">Forgot password?</a>
 		</p>
 		<p class="register-link">
-			First time? <a href="/register">Create an account</a>
+			Need an account? Ask your admin for an invitation link.
 		</p>
 	</div>
 </div>

--- a/web/src/routes/login/+page.svelte
+++ b/web/src/routes/login/+page.svelte
@@ -6,13 +6,16 @@
 	let email = $state('');
 	let password = $state('');
 	let error = $state('');
+	let setupRequired = $state(false);
+	let setupMethod = $state<'local_cli' | 'docker_exec' | 'cloud' | undefined>(undefined);
 	let loading = $state(false);
 
 	onMount(async () => {
 		try {
 			const session = await api.auth.session();
-			if (session.setup_required && session.setup_method === 'open_register') {
-				goto('/register', { replaceState: true });
+			if (session.setup_required) {
+				setupRequired = true;
+				setupMethod = session.setup_method;
 				return;
 			}
 			if (session.authenticated) {
@@ -53,51 +56,67 @@
 			handleSubmit();
 		}
 	}
+
+	function setupHint(method: typeof setupMethod): string {
+		switch (method) {
+			case 'docker_exec':
+				return "Run 'pad setup' inside the container, for example: docker exec -it <container> pad setup";
+			case 'cloud':
+				return 'This Pad Cloud instance must be initialized through the cloud setup flow.';
+			default:
+				return "Run 'pad setup' on the machine or container running the Pad server.";
+		}
+	}
 </script>
 
 <div class="login-page">
 	<div class="login-card">
 		<h1 class="logo">Pad</h1>
-		<p class="subtitle">Sign in to continue</p>
+		{#if setupRequired}
+			<p class="subtitle">This Pad instance has not been initialized yet.</p>
+			<p class="register-link">{setupHint(setupMethod)}</p>
+		{:else}
+			<p class="subtitle">Sign in to continue</p>
 
-		<div class="form">
-			<input
-				type="email"
-				placeholder="Email"
-				bind:value={email}
-				onkeydown={handleKeydown}
-				disabled={loading}
-				autocomplete="email"
-			/>
+			<div class="form">
+				<input
+					type="email"
+					placeholder="Email"
+					bind:value={email}
+					onkeydown={handleKeydown}
+					disabled={loading}
+					autocomplete="email"
+				/>
 
-			<input
-				type="password"
-				placeholder="Password"
-				bind:value={password}
-				onkeydown={handleKeydown}
-				disabled={loading}
-				autocomplete="current-password"
-			/>
+				<input
+					type="password"
+					placeholder="Password"
+					bind:value={password}
+					onkeydown={handleKeydown}
+					disabled={loading}
+					autocomplete="current-password"
+				/>
 
-			{#if error}
-				<p class="error">{error}</p>
-			{/if}
-
-			<button onclick={handleSubmit} disabled={loading}>
-				{#if loading}
-					Signing in...
-				{:else}
-					Sign in
+				{#if error}
+					<p class="error">{error}</p>
 				{/if}
-			</button>
-		</div>
 
-		<p class="register-link">
-			<a href="/forgot-password">Forgot password?</a>
-		</p>
-		<p class="register-link">
-			Need an account? Ask your admin for an invitation link.
-		</p>
+				<button onclick={handleSubmit} disabled={loading}>
+					{#if loading}
+						Signing in...
+					{:else}
+						Sign in
+					{/if}
+				</button>
+			</div>
+
+			<p class="register-link">
+				<a href="/forgot-password">Forgot password?</a>
+			</p>
+			<p class="register-link">
+				Need an account? Ask your admin for an invitation link.
+			</p>
+		{/if}
 	</div>
 </div>
 

--- a/web/src/routes/register/+page.svelte
+++ b/web/src/routes/register/+page.svelte
@@ -8,11 +8,16 @@
 	let password = $state('');
 	let confirmPassword = $state('');
 	let error = $state('');
+	let setupRequired = $state(false);
 	let loading = $state(false);
 
 	onMount(async () => {
 		try {
 			const session = await api.auth.session();
+			if (session.setup_required) {
+				setupRequired = true;
+				return;
+			}
 			if (session.authenticated) {
 				goto('/', { replaceState: true });
 				return;
@@ -63,61 +68,66 @@
 <div class="register-page">
 	<div class="register-card">
 		<h1 class="logo">Pad</h1>
-		<p class="subtitle">Create your account</p>
+		{#if setupRequired}
+			<p class="subtitle">This Pad instance has not been initialized yet.</p>
+			<p class="login-link">Run <code>pad setup</code> on the machine or container running the Pad server.</p>
+		{:else}
+			<p class="subtitle">Create your account</p>
 
-		<div class="form">
-			<input
-				type="text"
-				placeholder="Name"
-				bind:value={name}
-				onkeydown={handleKeydown}
-				disabled={loading}
-				autocomplete="name"
-			/>
+			<div class="form">
+				<input
+					type="text"
+					placeholder="Name"
+					bind:value={name}
+					onkeydown={handleKeydown}
+					disabled={loading}
+					autocomplete="name"
+				/>
 
-			<input
-				type="email"
-				placeholder="Email"
-				bind:value={email}
-				onkeydown={handleKeydown}
-				disabled={loading}
-				autocomplete="email"
-			/>
+				<input
+					type="email"
+					placeholder="Email"
+					bind:value={email}
+					onkeydown={handleKeydown}
+					disabled={loading}
+					autocomplete="email"
+				/>
 
-			<input
-				type="password"
-				placeholder="Password"
-				bind:value={password}
-				onkeydown={handleKeydown}
-				disabled={loading}
-				autocomplete="new-password"
-			/>
+				<input
+					type="password"
+					placeholder="Password"
+					bind:value={password}
+					onkeydown={handleKeydown}
+					disabled={loading}
+					autocomplete="new-password"
+				/>
 
-			<input
-				type="password"
-				placeholder="Confirm password"
-				bind:value={confirmPassword}
-				onkeydown={handleKeydown}
-				disabled={loading}
-				autocomplete="new-password"
-			/>
+				<input
+					type="password"
+					placeholder="Confirm password"
+					bind:value={confirmPassword}
+					onkeydown={handleKeydown}
+					disabled={loading}
+					autocomplete="new-password"
+				/>
 
-			{#if error}
-				<p class="error">{error}</p>
-			{/if}
-
-			<button onclick={handleSubmit} disabled={loading}>
-				{#if loading}
-					Creating account...
-				{:else}
-					Create account
+				{#if error}
+					<p class="error">{error}</p>
 				{/if}
-			</button>
-		</div>
 
-		<p class="login-link">
-			Already have an account? <a href="/login">Sign in</a>
-		</p>
+				<button onclick={handleSubmit} disabled={loading}>
+					{#if loading}
+						Creating account...
+					{:else}
+						Create account
+					{/if}
+				</button>
+			</div>
+
+			<p class="login-link">
+				Already have an account? <a href="/login">Sign in</a>
+			</p>
+		{/if}
 	</div>
 </div>
 


### PR DESCRIPTION
## Summary
- add `pad setup` and a localhost-only `/api/v1/auth/bootstrap` flow for first-admin bootstrap
- remove first-admin creation from the implicit login/init registration path
- update the web auth flow to honor explicit `setup_required` state and show setup guidance instead of dead-end registration

## Verification
- `go build ./...`
- `GOCACHE=/tmp/docapp-go-cache go test ./...`
- `cd web && npm run build`
- `make install`