### PR TITLE
feat(web): unify setup-required auth guidance for TASK-119

### DIFF
--- a/web/src/lib/components/auth/SetupRequiredNotice.svelte
+++ b/web/src/lib/components/auth/SetupRequiredNotice.svelte
@@ -1,0 +1,111 @@
+<script lang="ts">
+	type SetupMethod = 'local_cli' | 'docker_exec' | 'cloud' | undefined;
+
+	let {
+		setupMethod,
+		nextStep,
+		actionHref,
+		actionLabel
+	}: {
+		setupMethod?: SetupMethod;
+		nextStep?: string;
+		actionHref?: string;
+		actionLabel?: string;
+	} = $props();
+</script>
+
+<div class="setup-required">
+	<p class="subtitle">This Pad instance has not been initialized yet.</p>
+
+	{#if setupMethod === 'cloud'}
+		<p class="body">Finish the hosted Pad Cloud setup flow before signing in.</p>
+	{:else}
+		<p class="body">Initialize Pad on the server host first, then come back here.</p>
+
+		<div class="instructions">
+			<div class="instruction">
+				<p class="instruction-label">Local server</p>
+				<code>pad setup</code>
+			</div>
+
+			<div class="instruction">
+				<p class="instruction-label">Docker</p>
+				<code>docker exec -it &lt;container&gt; pad setup</code>
+			</div>
+		</div>
+
+		<p class="hint">If this Pad server runs on another machine, run <code>pad setup</code> there instead.</p>
+	{/if}
+
+	{#if nextStep}
+		<p class="next-step">{nextStep}</p>
+	{/if}
+
+	{#if actionHref && actionLabel}
+		<p class="action">
+			<a href={actionHref}>{actionLabel}</a>
+		</p>
+	{/if}
+</div>
+
+<style>
+	.setup-required {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-4);
+	}
+
+	.subtitle {
+		color: var(--text-muted);
+		font-size: 0.95rem;
+		margin: 0;
+	}
+
+	.body,
+	.hint,
+	.next-step,
+	.action {
+		margin: 0;
+		color: var(--text-secondary);
+		font-size: 0.9rem;
+		line-height: 1.5;
+	}
+
+	.instructions {
+		display: grid;
+		gap: var(--space-3);
+		text-align: left;
+	}
+
+	.instruction {
+		padding: var(--space-3);
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+		background: var(--bg-tertiary);
+	}
+
+	.instruction-label {
+		margin: 0 0 var(--space-2);
+		color: var(--text-muted);
+		font-size: 0.8rem;
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+	}
+
+	code {
+		display: block;
+		font-family: var(--font-mono);
+		font-size: 0.85rem;
+		color: var(--text-primary);
+		word-break: break-word;
+	}
+
+	.action a {
+		color: var(--accent-blue);
+		text-decoration: none;
+	}
+
+	.action a:hover {
+		text-decoration: underline;
+	}
+</style>

--- a/web/src/routes/join/[code]/+page.svelte
+++ b/web/src/routes/join/[code]/+page.svelte
@@ -3,10 +3,12 @@
 	import { goto } from '$app/navigation';
 	import { page } from '$app/state';
 	import { api } from '$lib/api/client';
+	import SetupRequiredNotice from '$lib/components/auth/SetupRequiredNotice.svelte';
 
 	let code = $derived(page.params.code ?? '');
-	let status = $state<'loading' | 'login' | 'register' | 'accepting' | 'error'>('loading');
+	let status = $state<'loading' | 'login' | 'register' | 'accepting' | 'error' | 'setup'>('loading');
 	let errorMsg = $state('');
+	let setupMethod = $state<'local_cli' | 'docker_exec' | 'cloud' | undefined>(undefined);
 
 	// Auth form state
 	let mode = $state<'login' | 'register'>('register');
@@ -24,8 +26,8 @@
 				// Already logged in — try to accept directly
 				await acceptInvitation();
 			} else if (session.setup_required) {
-				errorMsg = 'This Pad instance has not been initialized yet. Ask the server admin to run pad setup before accepting invitations.';
-				status = 'error';
+				setupMethod = session.setup_method;
+				status = 'setup';
 			} else {
 				// Users exist, not logged in — show login (with option to register)
 				mode = 'login';
@@ -93,6 +95,13 @@
 			<p class="subtitle">Checking invitation...</p>
 		{:else if status === 'accepting'}
 			<p class="subtitle">Joining workspace...</p>
+		{:else if status === 'setup'}
+			<SetupRequiredNotice
+				{setupMethod}
+				nextStep="An admin must finish setup before invitation links can be accepted."
+				actionHref="/login"
+				actionLabel="Go to login"
+			/>
 		{:else if status === 'error'}
 			<p class="subtitle error-text">{errorMsg}</p>
 			<a href="/login" class="link">Go to login</a>

--- a/web/src/routes/login/+page.svelte
+++ b/web/src/routes/login/+page.svelte
@@ -2,6 +2,7 @@
 	import { onMount } from 'svelte';
 	import { api } from '$lib/api/client';
 	import { goto } from '$app/navigation';
+	import SetupRequiredNotice from '$lib/components/auth/SetupRequiredNotice.svelte';
 
 	let email = $state('');
 	let password = $state('');
@@ -56,25 +57,16 @@
 			handleSubmit();
 		}
 	}
-
-	function setupHint(method: typeof setupMethod): string {
-		switch (method) {
-			case 'docker_exec':
-				return "Run 'pad setup' inside the container, for example: docker exec -it <container> pad setup";
-			case 'cloud':
-				return 'This Pad Cloud instance must be initialized through the cloud setup flow.';
-			default:
-				return "Run 'pad setup' on the machine or container running the Pad server.";
-		}
-	}
 </script>
 
 <div class="login-page">
 	<div class="login-card">
 		<h1 class="logo">Pad</h1>
 		{#if setupRequired}
-			<p class="subtitle">This Pad instance has not been initialized yet.</p>
-			<p class="register-link">{setupHint(setupMethod)}</p>
+			<SetupRequiredNotice
+				{setupMethod}
+				nextStep="Once setup is complete, return here to sign in."
+			/>
 		{:else}
 			<p class="subtitle">Sign in to continue</p>
 

--- a/web/src/routes/register/+page.svelte
+++ b/web/src/routes/register/+page.svelte
@@ -2,6 +2,7 @@
 	import { onMount } from 'svelte';
 	import { api } from '$lib/api/client';
 	import { goto } from '$app/navigation';
+	import SetupRequiredNotice from '$lib/components/auth/SetupRequiredNotice.svelte';
 
 	let name = $state('');
 	let email = $state('');
@@ -9,6 +10,7 @@
 	let confirmPassword = $state('');
 	let error = $state('');
 	let setupRequired = $state(false);
+	let setupMethod = $state<'local_cli' | 'docker_exec' | 'cloud' | undefined>(undefined);
 	let loading = $state(false);
 
 	onMount(async () => {
@@ -16,6 +18,7 @@
 			const session = await api.auth.session();
 			if (session.setup_required) {
 				setupRequired = true;
+				setupMethod = session.setup_method;
 				return;
 			}
 			if (session.authenticated) {
@@ -69,8 +72,12 @@
 	<div class="register-card">
 		<h1 class="logo">Pad</h1>
 		{#if setupRequired}
-			<p class="subtitle">This Pad instance has not been initialized yet.</p>
-			<p class="login-link">Run <code>pad setup</code> on the machine or container running the Pad server.</p>
+			<SetupRequiredNotice
+				{setupMethod}
+				nextStep="After the first admin is created, invitation-based registration will work here."
+				actionHref="/login"
+				actionLabel="Back to login"
+			/>
 		{:else}
 			<p class="subtitle">Create your account</p>
 


### PR DESCRIPTION
## Summary
- add a shared setup-required notice component for auth pages
- show consistent local, Docker, and remote-host setup guidance across login, register, and invitation join flows
- keep invitation-based registration working once setup is complete

## Verification
- `go build ./...`
- `GOCACHE=/tmp/docapp-go-cache go test ./...`
- `cd web && npm run build`
- `make install`