### PR TITLE
[codex] Surface lineage relationships and derived closure for TASK-122

### DIFF
--- a/cmd/pad/lineage.go
+++ b/cmd/pad/lineage.go
@@ -209,3 +209,78 @@ func itemDisplayLabel(item *models.Item) string {
 	}
 	return ref + " " + item.Title
 }
+
+type relationshipSection struct {
+	Title   string
+	Entries []string
+}
+
+func buildLineageSections(item *models.Item, links []models.ItemLink) []relationshipSection {
+	groups := map[string][]string{}
+	order := []string{"Split from", "Split into", "Supersedes", "Superseded by", "Implements", "Implemented by"}
+
+	for _, link := range links {
+		linkType, err := models.NormalizeItemLinkType(link.LinkType)
+		if err != nil {
+			continue
+		}
+		isSource := link.SourceID == item.ID
+		switch linkType {
+		case models.ItemLinkTypeSplitFrom:
+			if isSource {
+				groups["Split from"] = append(groups["Split from"], linkEndpointDisplay(link, false))
+			} else if link.TargetID == item.ID {
+				groups["Split into"] = append(groups["Split into"], linkEndpointDisplay(link, true))
+			}
+		case models.ItemLinkTypeSupersedes:
+			if isSource {
+				groups["Supersedes"] = append(groups["Supersedes"], linkEndpointDisplay(link, false))
+			} else if link.TargetID == item.ID {
+				groups["Superseded by"] = append(groups["Superseded by"], linkEndpointDisplay(link, true))
+			}
+		case models.ItemLinkTypeImplements:
+			if isSource {
+				groups["Implements"] = append(groups["Implements"], linkEndpointDisplay(link, false))
+			} else if link.TargetID == item.ID {
+				groups["Implemented by"] = append(groups["Implemented by"], linkEndpointDisplay(link, true))
+			}
+		}
+	}
+
+	sections := make([]relationshipSection, 0, len(order))
+	for _, title := range order {
+		entries := groups[title]
+		if len(entries) == 0 {
+			continue
+		}
+		sections = append(sections, relationshipSection{Title: title, Entries: entries})
+	}
+	return sections
+}
+
+func linkEndpointDisplay(link models.ItemLink, useSource bool) string {
+	var ref, title, status, id string
+	if useSource {
+		ref = link.SourceRef
+		title = link.SourceTitle
+		status = link.SourceStatus
+		id = link.SourceID
+	} else {
+		ref = link.TargetRef
+		title = link.TargetTitle
+		status = link.TargetStatus
+		id = link.TargetID
+	}
+	label := title
+	if ref != "" && title != "" {
+		label = ref + " " + title
+	} else if ref != "" {
+		label = ref
+	} else if label == "" {
+		label = id
+	}
+	if status != "" {
+		label += " (" + status + ")"
+	}
+	return label
+}

--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -2065,19 +2065,19 @@ func showCmd() *cobra.Command {
 				}
 			}
 
-			// Show dependencies (blocks / blocked by)
+			// Show dependencies and lineage relationships
 			links, err := client.GetItemLinks(ws, item.Slug)
 			if err == nil && len(links) > 0 {
 				var blocks []string
 				var blockedBy []string
 				for _, link := range links {
-					if link.LinkType != "blocks" {
+					if link.LinkType != models.ItemLinkTypeBlocks {
 						continue
 					}
 					if link.SourceID == item.ID {
-						blocks = append(blocks, link.TargetTitle)
+						blocks = append(blocks, linkEndpointDisplay(link, false))
 					} else if link.TargetID == item.ID {
-						blockedBy = append(blockedBy, link.SourceTitle)
+						blockedBy = append(blockedBy, linkEndpointDisplay(link, true))
 					}
 				}
 				if len(blocks) > 0 || len(blockedBy) > 0 {
@@ -2089,6 +2089,19 @@ func showCmd() *cobra.Command {
 						fmt.Printf("%s %s\n", color.New(color.FgRed, color.Bold).Sprint("Blocked by:"), strings.Join(blockedBy, ", "))
 					}
 				}
+
+				lineageSections := buildLineageSections(item, links)
+				if len(lineageSections) > 0 {
+					fmt.Println("\n--- Lineage ---")
+					for _, section := range lineageSections {
+						fmt.Printf("%s %s\n", color.New(color.FgCyan, color.Bold).Sprint(section.Title+":"), strings.Join(section.Entries, ", "))
+					}
+				}
+			}
+
+			if item.DerivedClosure != nil {
+				fmt.Println("\n--- Derived Closure ---")
+				fmt.Println(item.DerivedClosure.Summary)
 			}
 
 			// Show recent comments

--- a/internal/models/item.go
+++ b/internal/models/item.go
@@ -29,10 +29,11 @@ type Item struct {
 	ItemNumber *int `json:"item_number,omitempty"`
 
 	// Populated by joins (not stored)
-	CollectionSlug   string `json:"collection_slug,omitempty"`
-	CollectionName   string `json:"collection_name,omitempty"`
-	CollectionIcon   string `json:"collection_icon,omitempty"`
-	CollectionPrefix string `json:"collection_prefix,omitempty"`
+	CollectionSlug   string              `json:"collection_slug,omitempty"`
+	CollectionName   string              `json:"collection_name,omitempty"`
+	CollectionIcon   string              `json:"collection_icon,omitempty"`
+	CollectionPrefix string              `json:"collection_prefix,omitempty"`
+	DerivedClosure   *ItemDerivedClosure `json:"derived_closure,omitempty"`
 }
 
 // ComputeRef sets the Ref field from CollectionPrefix and ItemNumber.
@@ -41,6 +42,22 @@ func (item *Item) ComputeRef() {
 	if item.CollectionPrefix != "" && item.ItemNumber != nil {
 		item.Ref = fmt.Sprintf("%s-%d", item.CollectionPrefix, *item.ItemNumber)
 	}
+}
+
+type ItemRelationRef struct {
+	ID             string `json:"id"`
+	Slug           string `json:"slug,omitempty"`
+	Ref            string `json:"ref,omitempty"`
+	Title          string `json:"title"`
+	CollectionSlug string `json:"collection_slug,omitempty"`
+	Status         string `json:"status,omitempty"`
+}
+
+type ItemDerivedClosure struct {
+	IsClosed     bool              `json:"is_closed"`
+	Kind         string            `json:"kind"`
+	Summary      string            `json:"summary"`
+	RelatedItems []ItemRelationRef `json:"related_items,omitempty"`
 }
 
 type ItemCreate struct {
@@ -90,8 +107,16 @@ type ItemLink struct {
 	CreatedAt   time.Time `json:"created_at"`
 
 	// Populated by joins
-	SourceTitle string `json:"source_title,omitempty"`
-	TargetTitle string `json:"target_title,omitempty"`
+	SourceTitle          string `json:"source_title,omitempty"`
+	TargetTitle          string `json:"target_title,omitempty"`
+	SourceSlug           string `json:"source_slug,omitempty"`
+	TargetSlug           string `json:"target_slug,omitempty"`
+	SourceRef            string `json:"source_ref,omitempty"`
+	TargetRef            string `json:"target_ref,omitempty"`
+	SourceCollectionSlug string `json:"source_collection_slug,omitempty"`
+	TargetCollectionSlug string `json:"target_collection_slug,omitempty"`
+	SourceStatus         string `json:"source_status,omitempty"`
+	TargetStatus         string `json:"target_status,omitempty"`
 }
 
 type ItemLinkCreate struct {

--- a/internal/server/handlers_item_links_test.go
+++ b/internal/server/handlers_item_links_test.go
@@ -109,3 +109,64 @@ func TestCreateItemLinkRejectsDuplicatesAndSelfLinks(t *testing.T) {
 		t.Fatalf("expected self-link to return 400, got %d: %s", rr.Code, rr.Body.String())
 	}
 }
+
+func TestGetItemLinksIncludesEnrichedMetadata(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	rr := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections/tasks/items", map[string]interface{}{
+		"title":  "Replacement Task",
+		"fields": `{"status":"done"}`,
+	})
+	var replacement models.Item
+	parseJSON(t, rr, &replacement)
+
+	rr = doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections/tasks/items", map[string]interface{}{
+		"title":  "Legacy Task",
+		"fields": `{"status":"open"}`,
+	})
+	var legacy models.Item
+	parseJSON(t, rr, &legacy)
+
+	rr = doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/items/"+replacement.Slug+"/links", map[string]interface{}{
+		"target_id": legacy.ID,
+		"link_type": models.ItemLinkTypeSupersedes,
+	})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create supersedes link: expected 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	rr = doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/items/"+legacy.Slug+"/links", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("list links: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var links []models.ItemLink
+	parseJSON(t, rr, &links)
+	if len(links) != 1 {
+		t.Fatalf("expected 1 link, got %d", len(links))
+	}
+
+	link := links[0]
+	if link.SourceSlug != replacement.Slug {
+		t.Fatalf("expected source slug %q, got %q", replacement.Slug, link.SourceSlug)
+	}
+	if link.TargetSlug != legacy.Slug {
+		t.Fatalf("expected target slug %q, got %q", legacy.Slug, link.TargetSlug)
+	}
+	if link.SourceCollectionSlug != "tasks" || link.TargetCollectionSlug != "tasks" {
+		t.Fatalf("expected tasks collection slugs, got source=%q target=%q", link.SourceCollectionSlug, link.TargetCollectionSlug)
+	}
+	if link.SourceRef != "TASK-1" {
+		t.Fatalf("expected source ref TASK-1, got %q", link.SourceRef)
+	}
+	if link.TargetRef != "TASK-2" {
+		t.Fatalf("expected target ref TASK-2, got %q", link.TargetRef)
+	}
+	if link.SourceStatus != "done" {
+		t.Fatalf("expected source status done, got %q", link.SourceStatus)
+	}
+	if link.TargetStatus != "open" {
+		t.Fatalf("expected target status open, got %q", link.TargetStatus)
+	}
+}

--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -148,6 +148,11 @@ func (s *Server) handleCreateItem(w http.ResponseWriter, r *http.Request) {
 	s.publishItemEventWithName(events.ItemCreated, workspaceID, item.ID, item.Title, collSlug, actor, actorNameFromRequest(r), source)
 	s.dispatchWebhook(workspaceID, "item.created", item)
 
+	if err := s.enrichItemForResponse(item); err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", err.Error())
+		return
+	}
+
 	writeJSON(w, http.StatusCreated, item)
 }
 
@@ -166,6 +171,11 @@ func (s *Server) handleGetItem(w http.ResponseWriter, r *http.Request) {
 	}
 	if item == nil {
 		writeError(w, http.StatusNotFound, "not_found", "Item not found")
+		return
+	}
+
+	if err := s.enrichItemForResponse(item); err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", err.Error())
 		return
 	}
 
@@ -264,6 +274,11 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 	s.publishItemEventWithName(events.ItemUpdated, workspaceID, updated.ID, updated.Title, updated.CollectionSlug, actor, actorNameFromRequest(r), source)
 	s.dispatchWebhook(workspaceID, "item.updated", updated)
 
+	if err := s.enrichItemForResponse(updated); err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", err.Error())
+		return
+	}
+
 	writeJSON(w, http.StatusOK, updated)
 }
 
@@ -331,6 +346,11 @@ func (s *Server) handleRestoreItem(w http.ResponseWriter, r *http.Request) {
 	actor, source := actorFromRequest(r)
 	s.logActivity(workspaceID, restored.ID, "restored", r)
 	s.publishItemEventWithName(events.ItemRestored, workspaceID, restored.ID, restored.Title, restored.CollectionSlug, actor, actorNameFromRequest(r), source)
+
+	if err := s.enrichItemForResponse(restored); err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", err.Error())
+		return
+	}
 
 	writeJSON(w, http.StatusOK, restored)
 }
@@ -436,6 +456,11 @@ func (s *Server) handleMoveItem(w http.ResponseWriter, r *http.Request) {
 	// Publish events for both old and new collections
 	s.publishItemEventWithName(events.ItemUpdated, workspaceID, moved.ID, moved.Title, targetColl.Slug, actor, actorNameFromRequest(r), source)
 	s.dispatchWebhook(workspaceID, "item.moved", moved)
+
+	if err := s.enrichItemForResponse(moved); err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", err.Error())
+		return
+	}
 
 	writeJSON(w, http.StatusOK, moved)
 }

--- a/internal/server/handlers_items_test.go
+++ b/internal/server/handlers_items_test.go
@@ -474,6 +474,156 @@ func TestItemLinks(t *testing.T) {
 	}
 }
 
+func TestGetItemIncludesDerivedClosureForSupersededItems(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	rr := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections/tasks/items", map[string]interface{}{
+		"title":  "Replacement Task",
+		"fields": `{"status":"done"}`,
+	})
+	var replacement models.Item
+	parseJSON(t, rr, &replacement)
+
+	rr = doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections/tasks/items", map[string]interface{}{
+		"title":  "Legacy Task",
+		"fields": `{"status":"open"}`,
+	})
+	var legacy models.Item
+	parseJSON(t, rr, &legacy)
+
+	rr = doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/items/"+replacement.Slug+"/links", map[string]interface{}{
+		"target_id": legacy.ID,
+		"link_type": models.ItemLinkTypeSupersedes,
+	})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create supersedes link: expected 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	rr = doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/items/"+legacy.Slug, nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("get legacy item: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var fetched models.Item
+	parseJSON(t, rr, &fetched)
+	if fetched.DerivedClosure == nil {
+		t.Fatal("expected derived closure for superseded item")
+	}
+	if fetched.DerivedClosure.Kind != "superseded_by" {
+		t.Fatalf("expected superseded_by closure, got %q", fetched.DerivedClosure.Kind)
+	}
+	if !fetched.DerivedClosure.IsClosed {
+		t.Fatal("expected derived closure to mark item closed")
+	}
+	if len(fetched.DerivedClosure.RelatedItems) != 1 {
+		t.Fatalf("expected 1 related item, got %d", len(fetched.DerivedClosure.RelatedItems))
+	}
+	if fetched.DerivedClosure.RelatedItems[0].Ref != "TASK-1" {
+		t.Fatalf("expected related ref TASK-1, got %q", fetched.DerivedClosure.RelatedItems[0].Ref)
+	}
+}
+
+func TestGetItemIncludesDerivedClosureWhenSplitChildrenAreDone(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	rr := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections/tasks/items", map[string]interface{}{
+		"title":  "Parent Task",
+		"fields": `{"status":"open"}`,
+	})
+	var parent models.Item
+	parseJSON(t, rr, &parent)
+
+	rr = doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections/tasks/items", map[string]interface{}{
+		"title":  "Child One",
+		"fields": `{"status":"done"}`,
+	})
+	var childOne models.Item
+	parseJSON(t, rr, &childOne)
+
+	rr = doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections/tasks/items", map[string]interface{}{
+		"title":  "Child Two",
+		"fields": `{"status":"done"}`,
+	})
+	var childTwo models.Item
+	parseJSON(t, rr, &childTwo)
+
+	for _, child := range []models.Item{childOne, childTwo} {
+		rr = doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/items/"+child.Slug+"/links", map[string]interface{}{
+			"target_id": parent.ID,
+			"link_type": models.ItemLinkTypeSplitFrom,
+		})
+		if rr.Code != http.StatusCreated {
+			t.Fatalf("create split_from link for %s: expected 201, got %d: %s", child.Title, rr.Code, rr.Body.String())
+		}
+	}
+
+	rr = doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/items/"+parent.Slug, nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("get parent item: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var fetched models.Item
+	parseJSON(t, rr, &fetched)
+	if fetched.DerivedClosure == nil {
+		t.Fatal("expected derived closure for split parent")
+	}
+	if fetched.DerivedClosure.Kind != "split_into" {
+		t.Fatalf("expected split_into closure, got %q", fetched.DerivedClosure.Kind)
+	}
+	if len(fetched.DerivedClosure.RelatedItems) != 2 {
+		t.Fatalf("expected 2 related split children, got %d", len(fetched.DerivedClosure.RelatedItems))
+	}
+}
+
+func TestGetItemIncludesDerivedClosureForImplementedItems(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	rr := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections/tasks/items", map[string]interface{}{
+		"title":  "Implementation Task",
+		"fields": `{"status":"done"}`,
+	})
+	var implementer models.Item
+	parseJSON(t, rr, &implementer)
+
+	rr = doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections/ideas/items", map[string]interface{}{
+		"title":  "Search UX Idea",
+		"fields": `{"status":"planned"}`,
+	})
+	var idea models.Item
+	parseJSON(t, rr, &idea)
+
+	rr = doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/items/"+implementer.Slug+"/links", map[string]interface{}{
+		"target_id": idea.ID,
+		"link_type": models.ItemLinkTypeImplements,
+	})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create implements link: expected 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	rr = doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/items/"+idea.Slug, nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("get implemented item: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var fetched models.Item
+	parseJSON(t, rr, &fetched)
+	if fetched.DerivedClosure == nil {
+		t.Fatal("expected derived closure for implemented item")
+	}
+	if fetched.DerivedClosure.Kind != "implemented_by" {
+		t.Fatalf("expected implemented_by closure, got %q", fetched.DerivedClosure.Kind)
+	}
+	if len(fetched.DerivedClosure.RelatedItems) != 1 {
+		t.Fatalf("expected 1 implementing item, got %d", len(fetched.DerivedClosure.RelatedItems))
+	}
+	if fetched.DerivedClosure.RelatedItems[0].CollectionSlug != "tasks" {
+		t.Fatalf("expected implementing item collection slug tasks, got %q", fetched.DerivedClosure.RelatedItems[0].CollectionSlug)
+	}
+}
+
 func TestItemVersions(t *testing.T) {
 	srv := testServer(t)
 	slug := createWSWithCollections(t, srv)

--- a/internal/server/item_lineage.go
+++ b/internal/server/item_lineage.go
@@ -1,0 +1,134 @@
+package server
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/xarmian/pad/internal/models"
+)
+
+func (s *Server) enrichItemForResponse(item *models.Item) error {
+	if item == nil {
+		return nil
+	}
+	closure, err := s.deriveItemClosure(item)
+	if err != nil {
+		return err
+	}
+	item.DerivedClosure = closure
+	return nil
+}
+
+func (s *Server) deriveItemClosure(item *models.Item) (*models.ItemDerivedClosure, error) {
+	links, err := s.store.GetItemLinks(item.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	var supersededBy []models.ItemRelationRef
+	var implementedBy []models.ItemRelationRef
+	var splitChildren []models.ItemRelationRef
+	allSplitChildrenDone := true
+
+	for _, link := range links {
+		linkType, err := models.NormalizeItemLinkType(link.LinkType)
+		if err != nil {
+			continue
+		}
+		switch linkType {
+		case models.ItemLinkTypeSupersedes:
+			if link.TargetID == item.ID && isDoneStatus(link.SourceStatus) {
+				supersededBy = append(supersededBy, relationRefFromLink(link, true))
+			}
+		case models.ItemLinkTypeImplements:
+			if link.TargetID == item.ID && isDoneStatus(link.SourceStatus) {
+				implementedBy = append(implementedBy, relationRefFromLink(link, true))
+			}
+		case models.ItemLinkTypeSplitFrom:
+			if link.TargetID == item.ID {
+				splitChildren = append(splitChildren, relationRefFromLink(link, true))
+				if !isDoneStatus(link.SourceStatus) {
+					allSplitChildrenDone = false
+				}
+			}
+		}
+	}
+
+	if len(supersededBy) > 0 {
+		return &models.ItemDerivedClosure{
+			IsClosed:     true,
+			Kind:         "superseded_by",
+			Summary:      "Superseded by " + summarizeRelationRefs(supersededBy),
+			RelatedItems: supersededBy,
+		}, nil
+	}
+	if len(implementedBy) > 0 {
+		return &models.ItemDerivedClosure{
+			IsClosed:     true,
+			Kind:         "implemented_by",
+			Summary:      "Implemented by " + summarizeRelationRefs(implementedBy),
+			RelatedItems: implementedBy,
+		}, nil
+	}
+	if len(splitChildren) > 0 && allSplitChildrenDone {
+		return &models.ItemDerivedClosure{
+			IsClosed:     true,
+			Kind:         "split_into",
+			Summary:      "Split into completed items " + summarizeRelationRefs(splitChildren),
+			RelatedItems: splitChildren,
+		}, nil
+	}
+
+	return nil, nil
+}
+
+func relationRefFromLink(link models.ItemLink, useSource bool) models.ItemRelationRef {
+	if useSource {
+		return models.ItemRelationRef{
+			ID:             link.SourceID,
+			Slug:           link.SourceSlug,
+			Ref:            link.SourceRef,
+			Title:          link.SourceTitle,
+			CollectionSlug: link.SourceCollectionSlug,
+			Status:         link.SourceStatus,
+		}
+	}
+	return models.ItemRelationRef{
+		ID:             link.TargetID,
+		Slug:           link.TargetSlug,
+		Ref:            link.TargetRef,
+		Title:          link.TargetTitle,
+		CollectionSlug: link.TargetCollectionSlug,
+		Status:         link.TargetStatus,
+	}
+}
+
+func summarizeRelationRefs(items []models.ItemRelationRef) string {
+	labels := make([]string, 0, len(items))
+	for _, item := range items {
+		labels = append(labels, relationRefLabel(item))
+	}
+	switch len(labels) {
+	case 0:
+		return ""
+	case 1:
+		return labels[0]
+	case 2:
+		return labels[0] + " and " + labels[1]
+	default:
+		return fmt.Sprintf("%s and %d more", strings.Join(labels[:2], ", "), len(labels)-2)
+	}
+}
+
+func relationRefLabel(item models.ItemRelationRef) string {
+	if item.Ref != "" && item.Title != "" {
+		return item.Ref + " " + item.Title
+	}
+	if item.Ref != "" {
+		return item.Ref
+	}
+	if item.Title != "" {
+		return item.Title
+	}
+	return item.ID
+}

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -657,17 +657,30 @@ func (s *Store) getItemLink(id string) (*models.ItemLink, error) {
 	var link models.ItemLink
 	var createdAt string
 
+	var sourcePrefix, targetPrefix string
+	var sourceItemNumber, targetItemNumber sql.NullInt64
+	var sourceStatus, targetStatus sql.NullString
+
 	err := s.db.QueryRow(`
 		SELECT l.id, l.workspace_id, l.source_id, l.target_id, l.link_type, l.created_by, l.created_at,
-		       s.title, t.title
+		       s.title, t.title, s.slug, t.slug, sc.slug, tc.slug, sc.prefix, tc.prefix,
+		       s.item_number, t.item_number,
+		       json_extract(s.fields, '$.status'), json_extract(t.fields, '$.status')
 		FROM item_links l
 		JOIN items s ON s.id = l.source_id
 		JOIN items t ON t.id = l.target_id
+		JOIN collections sc ON sc.id = s.collection_id
+		JOIN collections tc ON tc.id = t.collection_id
 		WHERE l.id = ?
 	`, id).Scan(
 		&link.ID, &link.WorkspaceID, &link.SourceID, &link.TargetID,
 		&link.LinkType, &link.CreatedBy, &createdAt,
 		&link.SourceTitle, &link.TargetTitle,
+		&link.SourceSlug, &link.TargetSlug,
+		&link.SourceCollectionSlug, &link.TargetCollectionSlug,
+		&sourcePrefix, &targetPrefix,
+		&sourceItemNumber, &targetItemNumber,
+		&sourceStatus, &targetStatus,
 	)
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -676,16 +689,32 @@ func (s *Store) getItemLink(id string) (*models.ItemLink, error) {
 		return nil, fmt.Errorf("get item link: %w", err)
 	}
 	link.CreatedAt = parseTime(createdAt)
+	if sourceItemNumber.Valid && sourcePrefix != "" {
+		link.SourceRef = fmt.Sprintf("%s-%d", sourcePrefix, sourceItemNumber.Int64)
+	}
+	if targetItemNumber.Valid && targetPrefix != "" {
+		link.TargetRef = fmt.Sprintf("%s-%d", targetPrefix, targetItemNumber.Int64)
+	}
+	if sourceStatus.Valid {
+		link.SourceStatus = sourceStatus.String
+	}
+	if targetStatus.Valid {
+		link.TargetStatus = targetStatus.String
+	}
 	return &link, nil
 }
 
 func (s *Store) GetItemLinks(itemID string) ([]models.ItemLink, error) {
 	rows, err := s.db.Query(`
 		SELECT l.id, l.workspace_id, l.source_id, l.target_id, l.link_type, l.created_by, l.created_at,
-		       s.title, t.title
+		       s.title, t.title, s.slug, t.slug, sc.slug, tc.slug, sc.prefix, tc.prefix,
+		       s.item_number, t.item_number,
+		       json_extract(s.fields, '$.status'), json_extract(t.fields, '$.status')
 		FROM item_links l
 		JOIN items s ON s.id = l.source_id
 		JOIN items t ON t.id = l.target_id
+		JOIN collections sc ON sc.id = s.collection_id
+		JOIN collections tc ON tc.id = t.collection_id
 		WHERE l.source_id = ? OR l.target_id = ?
 		ORDER BY l.created_at DESC
 	`, itemID, itemID)
@@ -698,14 +727,34 @@ func (s *Store) GetItemLinks(itemID string) ([]models.ItemLink, error) {
 	for rows.Next() {
 		var link models.ItemLink
 		var createdAt string
+		var sourcePrefix, targetPrefix string
+		var sourceItemNumber, targetItemNumber sql.NullInt64
+		var sourceStatus, targetStatus sql.NullString
 		if err := rows.Scan(
 			&link.ID, &link.WorkspaceID, &link.SourceID, &link.TargetID,
 			&link.LinkType, &link.CreatedBy, &createdAt,
 			&link.SourceTitle, &link.TargetTitle,
+			&link.SourceSlug, &link.TargetSlug,
+			&link.SourceCollectionSlug, &link.TargetCollectionSlug,
+			&sourcePrefix, &targetPrefix,
+			&sourceItemNumber, &targetItemNumber,
+			&sourceStatus, &targetStatus,
 		); err != nil {
 			return nil, err
 		}
 		link.CreatedAt = parseTime(createdAt)
+		if sourceItemNumber.Valid && sourcePrefix != "" {
+			link.SourceRef = fmt.Sprintf("%s-%d", sourcePrefix, sourceItemNumber.Int64)
+		}
+		if targetItemNumber.Valid && targetPrefix != "" {
+			link.TargetRef = fmt.Sprintf("%s-%d", targetPrefix, targetItemNumber.Int64)
+		}
+		if sourceStatus.Valid {
+			link.SourceStatus = sourceStatus.String
+		}
+		if targetStatus.Valid {
+			link.TargetStatus = targetStatus.String
+		}
 		links = append(links, link)
 	}
 	return links, rows.Err()

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -135,6 +135,22 @@ export interface CollectionUpdate {
 
 // ─── Items ───────────────────────────────────────────────────────────────────
 
+export interface ItemRelationRef {
+	id: string;
+	slug?: string;
+	ref?: string;
+	title: string;
+	collection_slug?: string;
+	status?: string;
+}
+
+export interface ItemDerivedClosure {
+	is_closed: boolean;
+	kind: string;
+	summary: string;
+	related_items?: ItemRelationRef[];
+}
+
 export interface Item {
 	id: string;
 	workspace_id: string;
@@ -157,6 +173,7 @@ export interface Item {
 	collection_icon?: string;
 	collection_prefix?: string;
 	item_number?: number;
+	derived_closure?: ItemDerivedClosure;
 }
 
 export interface ItemCreate {
@@ -207,6 +224,14 @@ export interface ItemLink {
 	created_at: string;
 	source_title?: string;
 	target_title?: string;
+	source_slug?: string;
+	target_slug?: string;
+	source_ref?: string;
+	target_ref?: string;
+	source_collection_slug?: string;
+	target_collection_slug?: string;
+	source_status?: string;
+	target_status?: string;
 }
 
 export interface ItemLinkCreate {

--- a/web/src/routes/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[workspace]/[collection]/[slug]/+page.svelte
@@ -16,9 +16,22 @@
 	import { goto } from '$app/navigation';
 	import { relativeTime, wikiLinksToMarkdown, markdownToWikiLinks, cleanBrokenLinks } from '$lib/utils/markdown';
 	import { toastStore } from '$lib/stores/toast.svelte';
-	import type { Item, Collection, CollectionSettings, QuickAction } from '$lib/types';
+	import type { Item, Collection, CollectionSettings, QuickAction, ItemLink, ItemRelationRef } from '$lib/types';
 	import { parseFields, parseSchema, parseSettings, formatItemRef } from '$lib/types';
 	import QuickActionsMenu from '$lib/components/common/QuickActionsMenu.svelte';
+
+	type RelationshipEntry = {
+		key: string;
+		label: string;
+		href: string | null;
+		status?: string;
+	};
+
+	type RelationshipGroup = {
+		label: string;
+		tone: 'default' | 'blocks' | 'wiki' | 'lineage';
+		entries: RelationshipEntry[];
+	};
 
 	let wsSlug = $derived(page.params.workspace ?? '');
 	let collSlug = $derived(page.params.collection ?? '');
@@ -61,7 +74,9 @@
 	let rawMode = $state(false);
 	let showMoveMenu = $state(false);
 	let moving = $state(false);
-	let itemLinks = $state<import('$lib/types').ItemLink[]>([]);
+	let itemLinks = $state<ItemLink[]>([]);
+	let relationshipGroups = $derived(item ? buildRelationshipGroups(item, itemLinks) : []);
+	let closureEntries = $derived(item?.derived_closure?.related_items?.map((related) => relationRefEntry(related)) ?? []);
 
 	$effect(() => {
 		if (wsSlug && collSlug && itemSlug) {
@@ -258,6 +273,98 @@
 	function formatFieldDisplay(value: any): string {
 		if (value === null || value === undefined || value === '') return '—';
 		return String(value).replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+	}
+
+	function relationLabel(ref?: string, title?: string, fallback?: string): string {
+		if (ref && title) return `${ref} ${title}`;
+		if (ref) return ref;
+		if (title) return title;
+		return fallback || 'Unknown item';
+	}
+
+	function relationHref(collectionSlug?: string, refOrSlug?: string): string | null {
+		if (!collectionSlug || !refOrSlug) return null;
+		return `/${wsSlug}/${collectionSlug}/${refOrSlug}`;
+	}
+
+	function relationRefEntry(related: ItemRelationRef): RelationshipEntry {
+		return {
+			key: related.id,
+			label: relationLabel(related.ref, related.title, related.id),
+			href: relationHref(related.collection_slug, related.ref ?? related.slug),
+			status: related.status
+		};
+	}
+
+	function linkEntry(link: ItemLink, useSource: boolean): RelationshipEntry {
+		const ref = useSource ? link.source_ref : link.target_ref;
+		const title = useSource ? link.source_title : link.target_title;
+		const status = useSource ? link.source_status : link.target_status;
+		const id = useSource ? link.source_id : link.target_id;
+		const slug = useSource ? link.source_slug : link.target_slug;
+		const collectionSlug = useSource ? link.source_collection_slug : link.target_collection_slug;
+		const href = relationHref(collectionSlug, ref ?? slug);
+		return {
+			key: `${link.id}:${useSource ? 'source' : 'target'}`,
+			label: relationLabel(ref, title, id),
+			href,
+			status
+		};
+	}
+
+	function buildRelationshipGroups(currentItem: Item, links: ItemLink[]): RelationshipGroup[] {
+		const grouped = new Map<string, RelationshipGroup>();
+		const definitions: Record<string, { label: string; tone: RelationshipGroup['tone'] }> = {
+			blocks: { label: 'Blocks', tone: 'blocks' },
+			blocked_by: { label: 'Blocked by', tone: 'blocks' },
+			links_to: { label: 'Links to', tone: 'wiki' },
+			referenced_by: { label: 'Referenced by', tone: 'wiki' },
+			split_from: { label: 'Split from', tone: 'lineage' },
+			split_into: { label: 'Split into', tone: 'lineage' },
+			supersedes: { label: 'Supersedes', tone: 'lineage' },
+			superseded_by: { label: 'Superseded by', tone: 'lineage' },
+			implements: { label: 'Implements', tone: 'lineage' },
+			implemented_by: { label: 'Implemented by', tone: 'lineage' },
+			related: { label: 'Related', tone: 'default' }
+		};
+		const order = ['blocks', 'blocked_by', 'links_to', 'referenced_by', 'split_from', 'split_into', 'supersedes', 'superseded_by', 'implements', 'implemented_by', 'related'];
+
+		function addEntry(groupKey: string, entry: RelationshipEntry) {
+			const definition = definitions[groupKey];
+			if (!definition) return;
+			if (!grouped.has(groupKey)) {
+				grouped.set(groupKey, { label: definition.label, tone: definition.tone, entries: [] });
+			}
+			grouped.get(groupKey)?.entries.push(entry);
+		}
+
+		for (const link of links) {
+			const isSource = link.source_id === currentItem.id;
+			switch (link.link_type) {
+				case 'blocks':
+					addEntry(isSource ? 'blocks' : 'blocked_by', linkEntry(link, !isSource));
+					break;
+				case 'wiki_link':
+					addEntry(isSource ? 'links_to' : 'referenced_by', linkEntry(link, !isSource));
+					break;
+				case 'split_from':
+					addEntry(isSource ? 'split_from' : 'split_into', linkEntry(link, !isSource));
+					break;
+				case 'supersedes':
+					addEntry(isSource ? 'supersedes' : 'superseded_by', linkEntry(link, !isSource));
+					break;
+				case 'implements':
+					addEntry(isSource ? 'implements' : 'implemented_by', linkEntry(link, !isSource));
+					break;
+				default:
+					addEntry('related', linkEntry(link, !isSource));
+					break;
+			}
+		}
+
+		return order
+			.map((key) => grouped.get(key))
+			.filter((group): group is RelationshipGroup => Boolean(group && group.entries.length > 0));
 	}
 
 	function handleVersionRestore(updatedItem: Item) {
@@ -468,21 +575,53 @@
 		</div>
 
 		<!-- Relationships -->
-		{#if itemLinks.length > 0}
+		{#if item.derived_closure}
+			<div class="closure-notice">
+				<div class="closure-notice-header">
+					<h3 class="section-title">Derived Closure</h3>
+					<span class="closure-kind">{formatFieldDisplay(item.derived_closure.kind)}</span>
+				</div>
+				<p class="closure-summary">{item.derived_closure.summary}</p>
+				{#if closureEntries.length > 0}
+					<div class="closure-related-list">
+						{#each closureEntries as related (related.key)}
+							<div class="closure-related-item">
+								{#if related.href}
+									<a href={related.href} class="closure-related-link">{related.label}</a>
+								{:else}
+									<span class="closure-related-link">{related.label}</span>
+								{/if}
+								{#if related.status}
+									<span class="link-status">{formatFieldDisplay(related.status)}</span>
+								{/if}
+							</div>
+						{/each}
+					</div>
+				{/if}
+			</div>
+		{/if}
+
+		{#if relationshipGroups.length > 0}
 			<div class="relationships-section">
 				<h3 class="section-title">Relationships</h3>
-				<div class="links-list">
-					{#each itemLinks as link (link.id)}
-						{@const isSource = link.source_id === item?.id}
-						{@const targetTitle = isSource ? link.target_title : link.source_title}
-						{@const linkLabel = link.link_type === 'blocks'
-							? (isSource ? 'Blocks' : 'Blocked by')
-							: link.link_type === 'wiki_link'
-								? (isSource ? 'Links to' : 'Referenced by')
-								: link.link_type || 'Related to'}
-						<div class="link-row" class:blocking={link.link_type === 'blocks' && !isSource}>
-							<span class="link-type" class:type-blocks={link.link_type === 'blocks'} class:type-wiki={link.link_type === 'wiki_link'}>{linkLabel}</span>
-							<a href="/{wsSlug}/{link.link_type === 'blocks' ? 'tasks' : collSlug}/{isSource ? link.target_title : link.source_title}" class="link-target">{targetTitle || 'Unknown item'}</a>
+				<div class="relationship-groups">
+					{#each relationshipGroups as group (group.label)}
+						<div class="relationship-group">
+							<h4 class="relationship-group-title">{group.label}</h4>
+							<div class="links-list">
+								{#each group.entries as entry (entry.key)}
+									<div class="link-row" class:tone-blocks={group.tone === 'blocks'} class:tone-wiki={group.tone === 'wiki'} class:tone-lineage={group.tone === 'lineage'}>
+										{#if entry.href}
+											<a href={entry.href} class="link-target">{entry.label}</a>
+										{:else}
+											<span class="link-target">{entry.label}</span>
+										{/if}
+										{#if entry.status}
+											<span class="link-status">{formatFieldDisplay(entry.status)}</span>
+										{/if}
+									</div>
+								{/each}
+							</div>
 						</div>
 					{/each}
 				</div>
@@ -765,6 +904,58 @@
 		box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
 	}
 
+	/* Derived closure */
+	.closure-notice {
+		margin-top: var(--space-6);
+		padding: var(--space-4);
+		background: color-mix(in srgb, var(--accent-green) 10%, var(--bg-secondary));
+		border: 1px solid color-mix(in srgb, var(--accent-green) 35%, var(--border));
+		border-radius: var(--radius);
+	}
+	.closure-notice-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: var(--space-3);
+		margin-bottom: var(--space-2);
+		flex-wrap: wrap;
+	}
+	.closure-kind {
+		font-size: 0.75em;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+		color: var(--accent-green);
+	}
+	.closure-summary {
+		margin: 0;
+		color: var(--text-primary);
+	}
+	.closure-related-list {
+		display: flex;
+		flex-wrap: wrap;
+		gap: var(--space-2);
+		margin-top: var(--space-3);
+	}
+	.closure-related-item {
+		display: inline-flex;
+		align-items: center;
+		gap: var(--space-2);
+		padding: var(--space-2) var(--space-3);
+		background: var(--bg-primary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+	}
+	.closure-related-link {
+		font-weight: 500;
+		color: var(--text-primary);
+		text-decoration: none;
+	}
+	.closure-related-link:hover {
+		color: var(--accent-blue);
+		text-decoration: underline;
+	}
+
 	/* Relationships */
 	.relationships-section {
 		margin-top: var(--space-6);
@@ -784,29 +975,43 @@
 		flex-direction: column;
 		gap: var(--space-2);
 	}
+	.relationship-groups {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-4);
+	}
+	.relationship-group {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-2);
+	}
+	.relationship-group-title {
+		margin: 0;
+		font-size: 0.95em;
+		font-weight: 600;
+		color: var(--text-secondary);
+	}
 	.link-row {
 		display: flex;
 		align-items: center;
+		justify-content: space-between;
 		gap: var(--space-3);
 		padding: var(--space-2) var(--space-3);
 		background: var(--bg-secondary);
 		border: 1px solid var(--border);
 		border-radius: var(--radius);
 		font-size: 0.9em;
+		flex-wrap: wrap;
 	}
-	.link-row.blocking {
+	.link-row.tone-blocks {
 		border-left: 3px solid var(--accent-orange);
 	}
-	.link-type {
-		font-size: 0.75em;
-		font-weight: 600;
-		text-transform: uppercase;
-		letter-spacing: 0.04em;
-		color: var(--text-muted);
-		min-width: 80px;
+	.link-row.tone-wiki {
+		border-left: 3px solid var(--accent-blue);
 	}
-	.link-type.type-blocks { color: var(--accent-orange); }
-	.link-type.type-wiki { color: var(--accent-blue); }
+	.link-row.tone-lineage {
+		border-left: 3px solid var(--accent-green);
+	}
 	.link-target {
 		font-weight: 500;
 		color: var(--text-primary);
@@ -815,6 +1020,15 @@
 	.link-target:hover {
 		color: var(--accent-blue);
 		text-decoration: underline;
+	}
+	.link-status {
+		font-size: 0.75em;
+		font-weight: 600;
+		color: var(--text-muted);
+		background: var(--bg-tertiary);
+		padding: 2px 8px;
+		border-radius: 999px;
+		white-space: nowrap;
 	}
 
 	/* Comments */


### PR DESCRIPTION
## Summary
- enrich item and item-link responses with lineage metadata and computed `derived_closure` state
- surface dependencies, lineage relationships, and derived closure in `pad show`
- render grouped relationship sections and derived-closure guidance on the item page

## Why
`TASK-121` added the lineage relationship primitives, but Pad still treated them as low-level links. This change makes lineage and closure semantics visible across the API, CLI, and web so items can show when they are effectively closed by superseding, implementation, or split work.

## Impact
- item detail responses now include a computed `derived_closure` summary without mutating stored status
- item-link responses now include source/target refs, slugs, collection slugs, and statuses for richer consumers
- CLI users can see dependency and lineage state directly in `pad show`
- web users now get grouped relationship rendering and a derived closure notice on item pages

## Validation
- `go build ./...`
- `go test ./...`
- `cd web && npm run build`
- `make install`