### PR TITLE
feat(workspaces): add CLI and API context support for TASK-130

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,8 @@ pad workspace init [name]             Initialize workspace in current directory
 pad workspace link <workspace>        Link current directory to an existing workspace
 pad workspace list                    List all workspaces
 pad workspace switch <workspace>      Switch active workspace
+pad workspace context                 Show structured workspace context
+pad workspace context set --file X    Update structured workspace context from JSON
 pad workspace onboard                 Analyze project and suggest conventions
 pad workspace members                 List workspace members
 pad workspace invite <email>          Invite a workspace member

--- a/cmd/pad/groups.go
+++ b/cmd/pad/groups.go
@@ -41,6 +41,7 @@ func workspaceCmd() *cobra.Command {
 		linkCmd(),
 		switchCmd(),
 		workspacesCmd(),
+		workspaceContextCmd(),
 		onboardCmd(),
 		membersCmd(),
 		inviteCmd(),

--- a/cmd/pad/workspace_context.go
+++ b/cmd/pad/workspace_context.go
@@ -1,0 +1,218 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+
+	"github.com/xarmian/pad/internal/cli"
+	"github.com/xarmian/pad/internal/models"
+)
+
+func workspaceContextCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "context",
+		Short: "Show or update machine-readable workspace context",
+		Long: `Show or update the structured workspace context stored in the current workspace.
+
+Examples:
+  pad workspace context --format json
+  pad workspace context
+  pad workspace context set --file workspace-context.json
+  cat workspace-context.json | pad workspace context set --stdin`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, _ := getClient()
+			ws := getWorkspace()
+
+			workspace, err := client.GetWorkspace(ws)
+			if err != nil {
+				return err
+			}
+
+			if formatFlag == "json" {
+				if workspace.Context == nil {
+					return cli.PrintJSON(map[string]any{})
+				}
+				return cli.PrintJSON(workspace.Context)
+			}
+
+			printWorkspaceContext(workspace)
+			return nil
+		},
+	}
+
+	cmd.AddCommand(
+		workspaceContextSetCmd(),
+	)
+
+	return cmd
+}
+
+func workspaceContextSetCmd() *cobra.Command {
+	var (
+		filePath string
+		useStdin bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "set",
+		Short: "Replace the structured workspace context from JSON input",
+		Long: `Replace the structured workspace context using a JSON object.
+
+The JSON must match the workspace context schema, including optional sections like
+repositories, paths, commands, stack, deployment, and assumptions.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			context, err := readWorkspaceContextInput(filePath, useStdin)
+			if err != nil {
+				return err
+			}
+
+			client, _ := getClient()
+			ws := getWorkspace()
+			updated, err := client.UpdateWorkspace(ws, models.WorkspaceUpdate{
+				Context: context,
+			})
+			if err != nil {
+				return err
+			}
+
+			if formatFlag == "json" {
+				if updated.Context == nil {
+					return cli.PrintJSON(map[string]any{})
+				}
+				return cli.PrintJSON(updated.Context)
+			}
+
+			fmt.Printf("Updated workspace context for %s (%s)\n", updated.Name, updated.Slug)
+			printWorkspaceContext(updated)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&filePath, "file", "", "path to a JSON file containing workspace context")
+	cmd.Flags().BoolVar(&useStdin, "stdin", false, "read workspace context JSON from stdin")
+	return cmd
+}
+
+func readWorkspaceContextInput(filePath string, useStdin bool) (*models.WorkspaceContext, error) {
+	if filePath == "" && !useStdin {
+		return nil, fmt.Errorf("provide --file or --stdin")
+	}
+	if filePath != "" && useStdin {
+		return nil, fmt.Errorf("use either --file or --stdin, not both")
+	}
+
+	var data []byte
+	var err error
+	if filePath != "" {
+		data, err = os.ReadFile(filePath)
+		if err != nil {
+			return nil, fmt.Errorf("read %s: %w", filePath, err)
+		}
+	} else {
+		data, err = io.ReadAll(os.Stdin)
+		if err != nil {
+			return nil, fmt.Errorf("read stdin: %w", err)
+		}
+	}
+
+	var context models.WorkspaceContext
+	if err := json.Unmarshal(data, &context); err != nil {
+		return nil, fmt.Errorf("parse workspace context JSON: %w", err)
+	}
+	return &context, nil
+}
+
+func printWorkspaceContext(workspace *models.Workspace) {
+	if workspace == nil {
+		return
+	}
+
+	fmt.Printf("Workspace context for %s (%s)\n", workspace.Name, workspace.Slug)
+	if workspace.Context == nil {
+		fmt.Println("  No structured context configured.")
+		return
+	}
+
+	tw := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+
+	if len(workspace.Context.Repositories) > 0 {
+		fmt.Fprintln(tw, "Repositories")
+		for _, repo := range workspace.Context.Repositories {
+			label := strings.TrimSpace(strings.Join([]string{repo.Role, repo.Name}, " "))
+			fmt.Fprintf(tw, "  %s\tpath=%s\trepo=%s\n", strings.TrimSpace(label), repo.Path, repo.Repo)
+		}
+	}
+
+	if paths := workspace.Context.Paths; paths != nil {
+		printContextSection(tw, "Paths", [][2]string{
+			{"root", paths.Root},
+			{"docs_repo", paths.DocsRepo},
+			{"web", paths.Web},
+			{"server", paths.Server},
+			{"skills", paths.Skills},
+			{"config", paths.Config},
+			{"install_root", paths.InstallRoot},
+		})
+	}
+
+	if commands := workspace.Context.Commands; commands != nil {
+		printContextSection(tw, "Commands", [][2]string{
+			{"setup", commands.Setup},
+			{"build", commands.Build},
+			{"test", commands.Test},
+			{"lint", commands.Lint},
+			{"format", commands.Format},
+			{"dev", commands.Dev},
+			{"start", commands.Start},
+			{"web", commands.Web},
+		})
+	}
+
+	if stack := workspace.Context.Stack; stack != nil {
+		printContextSection(tw, "Stack", [][2]string{
+			{"languages", strings.Join(stack.Languages, ", ")},
+			{"frameworks", strings.Join(stack.Frameworks, ", ")},
+			{"package_managers", strings.Join(stack.PackageManagers, ", ")},
+		})
+	}
+
+	if deployment := workspace.Context.Deployment; deployment != nil {
+		printContextSection(tw, "Deployment", [][2]string{
+			{"mode", deployment.Mode},
+			{"base_url", deployment.BaseURL},
+			{"host", deployment.Host},
+		})
+	}
+
+	if len(workspace.Context.Assumptions) > 0 {
+		fmt.Fprintln(tw, "Assumptions")
+		for _, assumption := range workspace.Context.Assumptions {
+			if strings.TrimSpace(assumption) == "" {
+				continue
+			}
+			fmt.Fprintf(tw, "  -\t%s\n", assumption)
+		}
+	}
+
+	_ = tw.Flush()
+}
+
+func printContextSection(tw *tabwriter.Writer, section string, fields [][2]string) {
+	var printed bool
+	for _, field := range fields {
+		if strings.TrimSpace(field[1]) == "" {
+			continue
+		}
+		if !printed {
+			fmt.Fprintln(tw, section)
+			printed = true
+		}
+		fmt.Fprintf(tw, "  %s\t%s\n", field[0], field[1])
+	}
+}

--- a/cmd/pad/workspace_context_test.go
+++ b/cmd/pad/workspace_context_test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReadWorkspaceContextInputFromFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "context.json")
+	if err := os.WriteFile(path, []byte(`{"commands":{"build":"make install"},"assumptions":["Tasks should be PR-sized"]}`), 0644); err != nil {
+		t.Fatalf("WriteFile error: %v", err)
+	}
+
+	context, err := readWorkspaceContextInput(path, false)
+	if err != nil {
+		t.Fatalf("readWorkspaceContextInput error: %v", err)
+	}
+	if context.Commands == nil || context.Commands.Build != "make install" {
+		t.Fatalf("expected build command from file, got %#v", context.Commands)
+	}
+	if len(context.Assumptions) != 1 {
+		t.Fatalf("expected assumptions from file, got %#v", context.Assumptions)
+	}
+}
+
+func TestReadWorkspaceContextInputRequiresSingleSource(t *testing.T) {
+	if _, err := readWorkspaceContextInput("", false); err == nil {
+		t.Fatal("expected missing input source to fail")
+	}
+	if _, err := readWorkspaceContextInput("context.json", true); err == nil {
+		t.Fatal("expected conflicting input sources to fail")
+	}
+}

--- a/internal/models/workspace.go
+++ b/internal/models/workspace.go
@@ -15,15 +15,17 @@ type Workspace struct {
 }
 
 type WorkspaceCreate struct {
-	Name        string `json:"name"`
-	Slug        string `json:"slug,omitempty"` // auto-generated if empty
-	Description string `json:"description,omitempty"`
-	Settings    string `json:"settings,omitempty"`
-	Template    string `json:"template,omitempty"` // workspace template name (e.g. "startup", "scrum", "product")
+	Name        string            `json:"name"`
+	Slug        string            `json:"slug,omitempty"` // auto-generated if empty
+	Description string            `json:"description,omitempty"`
+	Settings    string            `json:"settings,omitempty"`
+	Context     *WorkspaceContext `json:"context,omitempty"`
+	Template    string            `json:"template,omitempty"` // workspace template name (e.g. "startup", "scrum", "product")
 }
 
 type WorkspaceUpdate struct {
-	Name        *string `json:"name,omitempty"`
-	Description *string `json:"description,omitempty"`
-	Settings    *string `json:"settings,omitempty"`
+	Name        *string           `json:"name,omitempty"`
+	Description *string           `json:"description,omitempty"`
+	Settings    *string           `json:"settings,omitempty"`
+	Context     *WorkspaceContext `json:"context,omitempty"`
 }

--- a/internal/models/workspace_settings.go
+++ b/internal/models/workspace_settings.go
@@ -79,12 +79,63 @@ func SerializeWorkspaceSettings(settings *WorkspaceSettings) (string, error) {
 	return string(payload), nil
 }
 
+func NormalizeWorkspaceSettings(raw string) (string, error) {
+	if raw == "" {
+		return "{}", nil
+	}
+
+	settingsMap, err := parseWorkspaceSettingsMap(raw)
+	if err != nil {
+		return "", err
+	}
+
+	payload, err := json.Marshal(settingsMap)
+	if err != nil {
+		return "", err
+	}
+	return string(payload), nil
+}
+
+func ApplyWorkspaceContext(raw string, context *WorkspaceContext) (string, error) {
+	settingsMap, err := parseWorkspaceSettingsMap(raw)
+	if err != nil {
+		return "", err
+	}
+
+	if context == nil {
+		delete(settingsMap, "context")
+	} else {
+		settingsMap["context"] = context
+	}
+
+	payload, err := json.Marshal(settingsMap)
+	if err != nil {
+		return "", err
+	}
+	return string(payload), nil
+}
+
 func ExtractWorkspaceContext(raw string) *WorkspaceContext {
-	settings, err := ParseWorkspaceSettings(raw)
+	settingsMap, err := parseWorkspaceSettingsMap(raw)
 	if err != nil {
 		return nil
 	}
-	return settings.Context
+
+	rawContext, ok := settingsMap["context"]
+	if !ok {
+		return nil
+	}
+
+	payload, err := json.Marshal(rawContext)
+	if err != nil {
+		return nil
+	}
+
+	var context WorkspaceContext
+	if err := json.Unmarshal(payload, &context); err != nil {
+		return nil
+	}
+	return &context
 }
 
 func (w *Workspace) HydrateDerivedFields() {
@@ -92,4 +143,19 @@ func (w *Workspace) HydrateDerivedFields() {
 		return
 	}
 	w.Context = ExtractWorkspaceContext(w.Settings)
+}
+
+func parseWorkspaceSettingsMap(raw string) (map[string]any, error) {
+	if raw == "" {
+		return map[string]any{}, nil
+	}
+
+	var settingsMap map[string]any
+	if err := json.Unmarshal([]byte(raw), &settingsMap); err != nil {
+		return nil, err
+	}
+	if settingsMap == nil {
+		settingsMap = map[string]any{}
+	}
+	return settingsMap, nil
 }

--- a/internal/models/workspace_settings_test.go
+++ b/internal/models/workspace_settings_test.go
@@ -66,6 +66,35 @@ func TestSerializeWorkspaceSettingsRoundTrip(t *testing.T) {
 	}
 }
 
+func TestApplyWorkspaceContextPreservesUnknownSettings(t *testing.T) {
+	raw, err := ApplyWorkspaceContext(`{"theme":"dark","context":{"assumptions":["old"]}}`, &WorkspaceContext{
+		Assumptions: []string{"new"},
+		Commands:    &WorkspaceCommands{Build: "make install"},
+	})
+	if err != nil {
+		t.Fatalf("ApplyWorkspaceContext error: %v", err)
+	}
+
+	settingsMap, err := parseWorkspaceSettingsMap(raw)
+	if err != nil {
+		t.Fatalf("parseWorkspaceSettingsMap error: %v", err)
+	}
+	if settingsMap["theme"] != "dark" {
+		t.Fatalf("expected unknown settings to be preserved, got %#v", settingsMap)
+	}
+
+	context := ExtractWorkspaceContext(raw)
+	if context == nil || context.Commands == nil || context.Commands.Build != "make install" {
+		t.Fatalf("expected context update to apply, got %#v", context)
+	}
+}
+
+func TestNormalizeWorkspaceSettingsRejectsInvalidJSON(t *testing.T) {
+	if _, err := NormalizeWorkspaceSettings(`{"context":`); err == nil {
+		t.Fatal("expected invalid JSON to fail normalization")
+	}
+}
+
 func TestExtractWorkspaceContextIgnoresInvalidSettings(t *testing.T) {
 	if got := ExtractWorkspaceContext(`{"context":`); got != nil {
 		t.Fatalf("expected invalid settings to return nil context, got %#v", got)

--- a/internal/server/handlers_workspaces.go
+++ b/internal/server/handlers_workspaces.go
@@ -11,6 +11,53 @@ import (
 	"github.com/xarmian/pad/internal/models"
 )
 
+func normalizeWorkspaceInput(input *models.WorkspaceCreate) error {
+	if input == nil {
+		return nil
+	}
+
+	settings, err := models.NormalizeWorkspaceSettings(input.Settings)
+	if err != nil {
+		return fmt.Errorf("invalid settings JSON: %w", err)
+	}
+	if input.Context != nil {
+		settings, err = models.ApplyWorkspaceContext(settings, input.Context)
+		if err != nil {
+			return fmt.Errorf("invalid workspace context: %w", err)
+		}
+	}
+	input.Settings = settings
+	return nil
+}
+
+func normalizeWorkspaceUpdateInput(input *models.WorkspaceUpdate) error {
+	if input == nil {
+		return nil
+	}
+
+	if input.Settings != nil {
+		settings, err := models.NormalizeWorkspaceSettings(*input.Settings)
+		if err != nil {
+			return fmt.Errorf("invalid settings JSON: %w", err)
+		}
+		input.Settings = &settings
+	}
+
+	if input.Context != nil {
+		base := "{}"
+		if input.Settings != nil {
+			base = *input.Settings
+		}
+		settings, err := models.ApplyWorkspaceContext(base, input.Context)
+		if err != nil {
+			return fmt.Errorf("invalid workspace context: %w", err)
+		}
+		input.Settings = &settings
+	}
+
+	return nil
+}
+
 func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 	resp := map[string]string{"status": "ok"}
 	if s.version != "" {
@@ -87,6 +134,10 @@ func (s *Server) handleCreateWorkspace(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "bad_request", "Name is required")
 		return
 	}
+	if err := normalizeWorkspaceInput(&input); err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", err.Error())
+		return
+	}
 
 	ws, err := s.store.CreateWorkspace(input)
 	if err != nil {
@@ -127,6 +178,10 @@ func (s *Server) handleUpdateWorkspace(w http.ResponseWriter, r *http.Request) {
 
 	var input models.WorkspaceUpdate
 	if err := decodeJSON(r, &input); err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", err.Error())
+		return
+	}
+	if err := normalizeWorkspaceUpdateInput(&input); err != nil {
 		writeError(w, http.StatusBadRequest, "bad_request", err.Error())
 		return
 	}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -87,6 +87,9 @@ func TestWorkspaceEndpoints(t *testing.T) {
 	if ws.Slug != "my-project" {
 		t.Errorf("expected slug 'my-project', got %q", ws.Slug)
 	}
+	if ws.Context != nil {
+		t.Fatalf("did not expect structured context on a default workspace, got %#v", ws.Context)
+	}
 
 	// List
 	rr = doRequest(srv, "GET", "/api/v1/workspaces", nil)
@@ -140,6 +143,68 @@ func TestWorkspaceValidation(t *testing.T) {
 	rr = doRequest(srv, "GET", "/api/v1/workspaces/nonexistent", nil)
 	if rr.Code != http.StatusNotFound {
 		t.Errorf("expected 404, got %d", rr.Code)
+	}
+
+	rr = doRequest(srv, "POST", "/api/v1/workspaces", map[string]interface{}{
+		"name":     "Bad Settings",
+		"settings": `{"context":`,
+	})
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid settings JSON, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestWorkspaceContextAPI(t *testing.T) {
+	srv := testServer(t)
+
+	rr := doRequest(srv, "POST", "/api/v1/workspaces", map[string]interface{}{
+		"name": "Contextual",
+		"context": map[string]interface{}{
+			"repositories": []map[string]string{
+				{"name": "docapp", "role": "primary", "path": ".", "repo": "xarmian/pad"},
+			},
+			"commands": map[string]string{
+				"build": "make install",
+				"test":  "go test ./...",
+			},
+			"deployment": map[string]string{
+				"mode":     "local",
+				"base_url": "http://127.0.0.1:7777",
+			},
+		},
+	})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create workspace with context: expected 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var ws models.Workspace
+	parseJSON(t, rr, &ws)
+	if ws.Context == nil || ws.Context.Commands == nil {
+		t.Fatalf("expected workspace context in create response, got %#v", ws.Context)
+	}
+	if ws.Context.Commands.Build != "make install" {
+		t.Fatalf("expected build command in context, got %#v", ws.Context.Commands)
+	}
+
+	rr = doRequest(srv, "PATCH", "/api/v1/workspaces/contextual", map[string]interface{}{
+		"context": map[string]interface{}{
+			"assumptions": []string{"pad-web lives at ../pad-web"},
+		},
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("update workspace context: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var updated models.Workspace
+	parseJSON(t, rr, &updated)
+	if updated.Context == nil {
+		t.Fatal("expected context after update")
+	}
+	if len(updated.Context.Assumptions) != 1 {
+		t.Fatalf("expected assumptions after update, got %#v", updated.Context.Assumptions)
+	}
+	if updated.Context.Commands != nil {
+		t.Fatalf("expected context replacement semantics on update, got %#v", updated.Context.Commands)
 	}
 }
 

--- a/internal/store/workspaces.go
+++ b/internal/store/workspaces.go
@@ -58,6 +58,16 @@ func (s *Store) CreateWorkspace(input models.WorkspaceCreate) (*models.Workspace
 	if settings == "" {
 		settings = "{}"
 	}
+	settings, err = models.NormalizeWorkspaceSettings(settings)
+	if err != nil {
+		return nil, fmt.Errorf("normalize workspace settings: %w", err)
+	}
+	if input.Context != nil {
+		settings, err = models.ApplyWorkspaceContext(settings, input.Context)
+		if err != nil {
+			return nil, fmt.Errorf("apply workspace context: %w", err)
+		}
+	}
 
 	_, err = s.db.Exec(`
 		INSERT INTO workspaces (id, name, slug, description, settings, created_at, updated_at)
@@ -152,6 +162,20 @@ func (s *Store) UpdateWorkspace(slug string, input models.WorkspaceUpdate) (*mod
 	}
 	if input.Settings != nil {
 		w.Settings = *input.Settings
+	}
+	if input.Context != nil {
+		settings, err := models.ApplyWorkspaceContext(w.Settings, input.Context)
+		if err != nil {
+			return nil, fmt.Errorf("apply workspace context: %w", err)
+		}
+		w.Settings = settings
+	}
+	if w.Settings != "" {
+		settings, err := models.NormalizeWorkspaceSettings(w.Settings)
+		if err != nil {
+			return nil, fmt.Errorf("normalize workspace settings: %w", err)
+		}
+		w.Settings = settings
 	}
 
 	_, err = s.db.Exec(`

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -40,14 +40,65 @@ export interface Workspace {
 	slug: string;
 	description: string;
 	settings: string;
+	context?: WorkspaceContext;
 	created_at: string;
 	updated_at: string;
+}
+
+export interface WorkspaceRepository {
+	name?: string;
+	role?: string;
+	path?: string;
+	repo?: string;
+}
+
+export interface WorkspacePaths {
+	root?: string;
+	docs_repo?: string;
+	web?: string;
+	server?: string;
+	skills?: string;
+	config?: string;
+	install_root?: string;
+}
+
+export interface WorkspaceCommands {
+	setup?: string;
+	build?: string;
+	test?: string;
+	lint?: string;
+	format?: string;
+	dev?: string;
+	start?: string;
+	web?: string;
+}
+
+export interface WorkspaceStack {
+	languages?: string[];
+	frameworks?: string[];
+	package_managers?: string[];
+}
+
+export interface WorkspaceDeployment {
+	mode?: string;
+	base_url?: string;
+	host?: string;
+}
+
+export interface WorkspaceContext {
+	repositories?: WorkspaceRepository[];
+	paths?: WorkspacePaths;
+	commands?: WorkspaceCommands;
+	stack?: WorkspaceStack;
+	deployment?: WorkspaceDeployment;
+	assumptions?: string[];
 }
 
 export interface WorkspaceCreate {
 	name: string;
 	description?: string;
 	template?: string;
+	context?: WorkspaceContext;
 }
 
 export interface WorkspaceTemplate {


### PR DESCRIPTION
## Summary
- add first-class workspace context support to workspace create and update APIs
- add grouped CLI commands for showing and replacing workspace context
- sync README and type definitions with the new workspace context command surface

## Testing
- go build ./...
- go test ./...
- cd web && npm run build
- make install