### PR TITLE
feat(workspaces): add typed context schema for TASK-129

### DIFF
--- a/internal/models/workspace.go
+++ b/internal/models/workspace.go
@@ -3,14 +3,15 @@ package models
 import "time"
 
 type Workspace struct {
-	ID          string     `json:"id"`
-	Name        string     `json:"name"`
-	Slug        string     `json:"slug"`
-	Description string     `json:"description"`
-	Settings    string     `json:"settings"` // JSON
-	CreatedAt   time.Time  `json:"created_at"`
-	UpdatedAt   time.Time  `json:"updated_at"`
-	DeletedAt   *time.Time `json:"deleted_at,omitempty"`
+	ID          string            `json:"id"`
+	Name        string            `json:"name"`
+	Slug        string            `json:"slug"`
+	Description string            `json:"description"`
+	Settings    string            `json:"settings"` // JSON
+	Context     *WorkspaceContext `json:"context,omitempty"`
+	CreatedAt   time.Time         `json:"created_at"`
+	UpdatedAt   time.Time         `json:"updated_at"`
+	DeletedAt   *time.Time        `json:"deleted_at,omitempty"`
 }
 
 type WorkspaceCreate struct {

--- a/internal/models/workspace_settings.go
+++ b/internal/models/workspace_settings.go
@@ -1,0 +1,95 @@
+package models
+
+import "encoding/json"
+
+type WorkspaceSettings struct {
+	Context *WorkspaceContext `json:"context,omitempty"`
+}
+
+type WorkspaceContext struct {
+	Repositories []WorkspaceRepository `json:"repositories,omitempty"`
+	Paths        *WorkspacePaths       `json:"paths,omitempty"`
+	Commands     *WorkspaceCommands    `json:"commands,omitempty"`
+	Stack        *WorkspaceStack       `json:"stack,omitempty"`
+	Deployment   *WorkspaceDeployment  `json:"deployment,omitempty"`
+	Assumptions  []string              `json:"assumptions,omitempty"`
+}
+
+type WorkspaceRepository struct {
+	Name string `json:"name,omitempty"`
+	Role string `json:"role,omitempty"`
+	Path string `json:"path,omitempty"`
+	Repo string `json:"repo,omitempty"`
+}
+
+type WorkspacePaths struct {
+	Root        string `json:"root,omitempty"`
+	DocsRepo    string `json:"docs_repo,omitempty"`
+	Web         string `json:"web,omitempty"`
+	Server      string `json:"server,omitempty"`
+	Skills      string `json:"skills,omitempty"`
+	Config      string `json:"config,omitempty"`
+	InstallRoot string `json:"install_root,omitempty"`
+}
+
+type WorkspaceCommands struct {
+	Setup  string `json:"setup,omitempty"`
+	Build  string `json:"build,omitempty"`
+	Test   string `json:"test,omitempty"`
+	Lint   string `json:"lint,omitempty"`
+	Format string `json:"format,omitempty"`
+	Dev    string `json:"dev,omitempty"`
+	Start  string `json:"start,omitempty"`
+	Web    string `json:"web,omitempty"`
+}
+
+type WorkspaceStack struct {
+	Languages       []string `json:"languages,omitempty"`
+	Frameworks      []string `json:"frameworks,omitempty"`
+	PackageManagers []string `json:"package_managers,omitempty"`
+}
+
+type WorkspaceDeployment struct {
+	Mode    string `json:"mode,omitempty"`
+	BaseURL string `json:"base_url,omitempty"`
+	Host    string `json:"host,omitempty"`
+}
+
+func ParseWorkspaceSettings(raw string) (*WorkspaceSettings, error) {
+	if raw == "" {
+		return &WorkspaceSettings{}, nil
+	}
+
+	var settings WorkspaceSettings
+	if err := json.Unmarshal([]byte(raw), &settings); err != nil {
+		return nil, err
+	}
+	return &settings, nil
+}
+
+func SerializeWorkspaceSettings(settings *WorkspaceSettings) (string, error) {
+	if settings == nil {
+		settings = &WorkspaceSettings{}
+	}
+
+	payload, err := json.Marshal(settings)
+	if err != nil {
+		return "", err
+	}
+	return string(payload), nil
+}
+
+func ExtractWorkspaceContext(raw string) *WorkspaceContext {
+	settings, err := ParseWorkspaceSettings(raw)
+	if err != nil {
+		return nil
+	}
+	return settings.Context
+}
+
+func (w *Workspace) HydrateDerivedFields() {
+	if w == nil {
+		return
+	}
+	w.Context = ExtractWorkspaceContext(w.Settings)
+}

--- a/internal/models/workspace_settings_test.go
+++ b/internal/models/workspace_settings_test.go
@@ -1,0 +1,73 @@
+package models
+
+import "testing"
+
+func TestParseWorkspaceSettingsEmpty(t *testing.T) {
+	settings, err := ParseWorkspaceSettings("")
+	if err != nil {
+		t.Fatalf("ParseWorkspaceSettings error: %v", err)
+	}
+	if settings == nil {
+		t.Fatal("expected settings struct")
+	}
+	if settings.Context != nil {
+		t.Fatalf("expected nil context for empty settings, got %#v", settings.Context)
+	}
+}
+
+func TestParseWorkspaceSettingsExtractsStructuredContext(t *testing.T) {
+	settings, err := ParseWorkspaceSettings(`{"context":{"repositories":[{"name":"docapp","role":"primary","path":".","repo":"xarmian/pad"}],"paths":{"docs_repo":"../pad-web"},"commands":{"build":"make install","test":"go test ./..."},"stack":{"languages":["go","typescript"],"frameworks":["sveltekit"],"package_managers":["npm"]},"deployment":{"mode":"docker","base_url":"http://127.0.0.1:7777"},"assumptions":["pad-web lives at ../pad-web"]}}`)
+	if err != nil {
+		t.Fatalf("ParseWorkspaceSettings error: %v", err)
+	}
+	if settings.Context == nil {
+		t.Fatal("expected context")
+	}
+	if len(settings.Context.Repositories) != 1 {
+		t.Fatalf("expected 1 repository, got %#v", settings.Context.Repositories)
+	}
+	if settings.Context.Paths == nil || settings.Context.Paths.DocsRepo != "../pad-web" {
+		t.Fatalf("expected docs repo path, got %#v", settings.Context.Paths)
+	}
+	if settings.Context.Commands == nil || settings.Context.Commands.Test != "go test ./..." {
+		t.Fatalf("expected test command, got %#v", settings.Context.Commands)
+	}
+	if settings.Context.Stack == nil || len(settings.Context.Stack.Languages) != 2 {
+		t.Fatalf("expected stack languages, got %#v", settings.Context.Stack)
+	}
+	if settings.Context.Deployment == nil || settings.Context.Deployment.Mode != "docker" {
+		t.Fatalf("expected deployment mode docker, got %#v", settings.Context.Deployment)
+	}
+}
+
+func TestSerializeWorkspaceSettingsRoundTrip(t *testing.T) {
+	raw, err := SerializeWorkspaceSettings(&WorkspaceSettings{
+		Context: &WorkspaceContext{
+			Commands: &WorkspaceCommands{
+				Build: "make install",
+				Test:  "go test ./...",
+			},
+			Assumptions: []string{"Tasks should be PR-sized"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("SerializeWorkspaceSettings error: %v", err)
+	}
+
+	context := ExtractWorkspaceContext(raw)
+	if context == nil {
+		t.Fatal("expected extracted context")
+	}
+	if context.Commands == nil || context.Commands.Build != "make install" {
+		t.Fatalf("expected build command to survive round trip, got %#v", context.Commands)
+	}
+	if len(context.Assumptions) != 1 {
+		t.Fatalf("expected assumptions to survive round trip, got %#v", context.Assumptions)
+	}
+}
+
+func TestExtractWorkspaceContextIgnoresInvalidSettings(t *testing.T) {
+	if got := ExtractWorkspaceContext(`{"context":`); got != nil {
+		t.Fatalf("expected invalid settings to return nil context, got %#v", got)
+	}
+}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -136,6 +136,59 @@ func TestWorkspaceUniqueSlug(t *testing.T) {
 	}
 }
 
+func TestWorkspaceSettingsHydrateStructuredContext(t *testing.T) {
+	s := testStore(t)
+
+	settings, err := models.SerializeWorkspaceSettings(&models.WorkspaceSettings{
+		Context: &models.WorkspaceContext{
+			Repositories: []models.WorkspaceRepository{
+				{Name: "docapp", Role: "primary", Path: ".", Repo: "xarmian/pad"},
+				{Name: "pad-web", Role: "docs", Path: "../pad-web", Repo: "xarmian/pad-web"},
+			},
+			Commands: &models.WorkspaceCommands{
+				Build: "make install",
+				Test:  "go test ./...",
+				Web:   "cd web && npm run build",
+			},
+			Deployment: &models.WorkspaceDeployment{
+				Mode:    "local",
+				BaseURL: "http://127.0.0.1:7777",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("SerializeWorkspaceSettings error: %v", err)
+	}
+
+	ws, err := s.CreateWorkspace(models.WorkspaceCreate{
+		Name:     "Machine Readable",
+		Settings: settings,
+	})
+	if err != nil {
+		t.Fatalf("CreateWorkspace error: %v", err)
+	}
+	if ws.Context == nil {
+		t.Fatal("expected created workspace to expose structured context")
+	}
+	if len(ws.Context.Repositories) != 2 {
+		t.Fatalf("expected 2 repositories in context, got %#v", ws.Context.Repositories)
+	}
+
+	got, err := s.GetWorkspaceBySlug(ws.Slug)
+	if err != nil {
+		t.Fatalf("GetWorkspaceBySlug error: %v", err)
+	}
+	if got.Context == nil || got.Context.Commands == nil {
+		t.Fatalf("expected hydrated commands, got %#v", got.Context)
+	}
+	if got.Context.Commands.Build != "make install" {
+		t.Fatalf("expected build command make install, got %q", got.Context.Commands.Build)
+	}
+	if got.Context.Deployment == nil || got.Context.Deployment.BaseURL != "http://127.0.0.1:7777" {
+		t.Fatalf("expected deployment base URL to round-trip, got %#v", got.Context.Deployment)
+	}
+}
+
 // --- Document Tests ---
 
 func TestDocumentCRUD(t *testing.T) {
@@ -498,8 +551,8 @@ func TestContext(t *testing.T) {
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
 
-	createTestDoc(t, s, ws.ID, "Active Doc", "content")     // active
-	s.CreateDocument(ws.ID, models.DocumentCreate{Title: "Draft Doc", Status: "draft"})  // draft
+	createTestDoc(t, s, ws.ID, "Active Doc", "content")                                 // active
+	s.CreateDocument(ws.ID, models.DocumentCreate{Title: "Draft Doc", Status: "draft"}) // draft
 
 	// Pin one doc
 	draftDocs, _ := s.ListDocuments(ws.ID, models.DocumentListParams{Status: "draft"})

--- a/internal/store/workspaces.go
+++ b/internal/store/workspaces.go
@@ -28,6 +28,7 @@ func (s *Store) ListWorkspaces() ([]models.Workspace, error) {
 		}
 		w.CreatedAt = parseTime(createdAt)
 		w.UpdatedAt = parseTime(updatedAt)
+		w.HydrateDerivedFields()
 		workspaces = append(workspaces, w)
 	}
 	return workspaces, rows.Err()
@@ -104,6 +105,7 @@ func (s *Store) GetWorkspaceBySlug(slug string) (*models.Workspace, error) {
 	w.CreatedAt = parseTime(createdAt)
 	w.UpdatedAt = parseTime(updatedAt)
 	w.DeletedAt = parseTimePtr(deletedAt)
+	w.HydrateDerivedFields()
 	return &w, nil
 }
 
@@ -127,6 +129,7 @@ func (s *Store) GetWorkspaceByID(id string) (*models.Workspace, error) {
 	w.CreatedAt = parseTime(createdAt)
 	w.UpdatedAt = parseTime(updatedAt)
 	w.DeletedAt = parseTimePtr(deletedAt)
+	w.HydrateDerivedFields()
 	return &w, nil
 }
 


### PR DESCRIPTION
## Summary
- add a typed workspace context schema on top of workspaces.settings
- hydrate structured context on workspace reads
- add model and store coverage for context parsing and round-tripping

## Testing
- go test ./internal/models ./internal/store
- go build ./...