### PR TITLE
feat(workspaces): populate context during onboarding for TASK-132

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Agents load relevant conventions automatically. All agent actions are attributed
 **Onboard agents to a new codebase:**
 
 ```bash
-pad workspace onboard    # Analyzes project structure and suggests conventions
+pad workspace onboard    # Analyzes project structure, saves workspace context, and suggests conventions
 ```
 
 ### Collections & Custom Fields
@@ -226,7 +226,7 @@ pad server open              # Opens localhost:7777 in your browser
 ### 5. Teach your agents the rules
 
 ```bash
-pad workspace onboard        # Auto-analyze project and suggest conventions
+pad workspace onboard        # Auto-analyze project, save workspace context, and suggest conventions
 # Or browse the convention library
 pad library list --type conventions  # Pre-built conventions you can adopt
 pad library list --type playbooks    # Pre-built multi-step workflows
@@ -250,7 +250,7 @@ pad workspace list                    List all workspaces
 pad workspace switch <workspace>      Switch active workspace
 pad workspace context                 Show structured workspace context
 pad workspace context set --file X    Update structured workspace context from JSON
-pad workspace onboard                 Analyze project and suggest conventions
+pad workspace onboard                 Analyze project, save workspace context, and suggest conventions
 pad workspace members                 List workspace members
 pad workspace invite <email>          Invite a workspace member
 pad workspace join <code>             Accept an invitation

--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -1058,18 +1058,19 @@ func printOnboardingHints() {
 func onboardCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "onboard",
-		Short: "Analyze the project and suggest items to populate the workspace",
-		Long: `Analyze the current project directory to detect tooling and suggest
-conventions, then optionally create them in the workspace.
+		Short: "Analyze the project, save workspace context, and suggest items",
+		Long: `Analyze the current project directory to detect tooling, save
+machine-readable workspace context, and suggest conventions.
 
 This scans for build config, CI setup, linters, and project structure to
 recommend conventions from the built-in library.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			client, _ := getClient()
+			client, cfg := getClient()
 			ws := getWorkspace()
 
 			cwd, _ := os.Getwd()
 			info := cli.DetectProject(cwd)
+			context := cli.BuildWorkspaceContext(cwd, info, cfg)
 
 			// Print detection results
 			bold := color.New(color.Bold)
@@ -1093,6 +1094,14 @@ recommend conventions from the built-in library.`,
 			if info.HasLinter {
 				fmt.Printf("  %s     %s\n", dim.Sprint("Linter:"), green.Sprint("detected"))
 			}
+			if context != nil {
+				if context.Paths != nil && context.Paths.Web != "" {
+					fmt.Printf("  %s        %s\n", dim.Sprint("Web:"), context.Paths.Web)
+				}
+				if len(context.Repositories) > 1 {
+					fmt.Printf("  %s  %d repos\n", dim.Sprint("Repos:"), len(context.Repositories))
+				}
+			}
 			if info.Language == "" && info.BuildTool == "" {
 				fmt.Println(dim.Sprint("  Could not detect project type."))
 				fmt.Println()
@@ -1102,6 +1111,13 @@ recommend conventions from the built-in library.`,
 			}
 
 			fmt.Println()
+
+			if _, err := client.UpdateWorkspace(ws, models.WorkspaceUpdate{Context: context}); err != nil {
+				fmt.Fprintf(os.Stderr, "Warning: failed to save workspace context: %v\n\n", err)
+			} else {
+				fmt.Println(green.Sprint("Saved machine-readable workspace context."))
+				fmt.Println()
+			}
 
 			// Get suggested conventions
 			suggestions := cli.SuggestedConventions(info)

--- a/internal/cli/detect.go
+++ b/internal/cli/detect.go
@@ -1,20 +1,28 @@
 package cli
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 )
 
 // ProjectInfo holds detected project metadata.
 type ProjectInfo struct {
-	Language   string   // go, node, rust, python, java, etc.
-	BuildTool  string   // make, npm, cargo, pip, maven, etc.
-	TestCmd    string   // detected test command
-	HasCI      bool     // CI config detected
-	CIProvider string   // github-actions, gitlab, circleci, etc.
-	HasLinter  bool     // linter config detected
-	Frameworks []string // detected frameworks (e.g., svelte, react, chi)
+	Language        string   // go, node, rust, python, java, etc.
+	BuildTool       string   // make, npm, cargo, pip, maven, etc.
+	BuildCmd        string   // detected build command
+	SetupCmd        string   // detected setup/install command
+	TestCmd         string   // detected test command
+	LintCmd         string   // detected lint/format command
+	DevCmd          string   // detected dev/run command
+	WebBuildCmd     string   // detected frontend build command
+	PackageManagers []string // detected package managers (e.g., npm, go)
+	HasCI           bool     // CI config detected
+	CIProvider      string   // github-actions, gitlab, circleci, etc.
+	HasLinter       bool     // linter config detected
+	Frameworks      []string // detected frameworks (e.g., svelte, react, chi)
 }
 
 // DetectProject analyzes the current directory to determine project type,
@@ -25,23 +33,37 @@ func DetectProject(dir string) ProjectInfo {
 	// Detect language and build tool
 	if fileExists(dir, "go.mod") {
 		info.Language = "go"
+		info.PackageManagers = append(info.PackageManagers, "go")
 		if fileExists(dir, "Makefile") {
 			info.BuildTool = "make"
+			info.BuildCmd = detectMakeBuildCmd(dir)
+			info.SetupCmd = detectMakeSetupCmd(dir)
 			info.TestCmd = detectMakeTestCmd(dir)
+			info.DevCmd = detectMakeDevCmd(dir)
 		} else {
 			info.BuildTool = "go"
+			info.BuildCmd = "go build ./..."
 			info.TestCmd = "go test ./..."
 		}
 	} else if fileExists(dir, "package.json") {
 		info.Language = "node"
 		info.BuildTool = "npm"
+		info.BuildCmd = "npm run build"
+		info.SetupCmd = "npm install"
 		info.TestCmd = "npm test"
+		info.PackageManagers = append(info.PackageManagers, "npm")
 		if fileExists(dir, "yarn.lock") {
 			info.BuildTool = "yarn"
+			info.BuildCmd = "yarn build"
+			info.SetupCmd = "yarn install"
 			info.TestCmd = "yarn test"
+			info.PackageManagers = []string{"yarn"}
 		} else if fileExists(dir, "pnpm-lock.yaml") {
 			info.BuildTool = "pnpm"
+			info.BuildCmd = "pnpm build"
+			info.SetupCmd = "pnpm install"
 			info.TestCmd = "pnpm test"
+			info.PackageManagers = []string{"pnpm"}
 		}
 		// Check for TypeScript
 		if fileExists(dir, "tsconfig.json") {
@@ -50,27 +72,42 @@ func DetectProject(dir string) ProjectInfo {
 	} else if fileExists(dir, "Cargo.toml") {
 		info.Language = "rust"
 		info.BuildTool = "cargo"
+		info.BuildCmd = "cargo build"
+		info.SetupCmd = "cargo fetch"
 		info.TestCmd = "cargo test"
+		info.PackageManagers = append(info.PackageManagers, "cargo")
 	} else if fileExists(dir, "pyproject.toml") || fileExists(dir, "setup.py") || fileExists(dir, "requirements.txt") {
 		info.Language = "python"
 		if fileExists(dir, "pyproject.toml") {
 			info.BuildTool = "pip"
+			info.SetupCmd = "pip install -e ."
 			info.TestCmd = "pytest"
 		} else {
 			info.BuildTool = "pip"
+			info.SetupCmd = "pip install -r requirements.txt"
 			info.TestCmd = "python -m pytest"
 		}
+		info.PackageManagers = append(info.PackageManagers, "pip")
 	} else if fileExists(dir, "pom.xml") {
 		info.Language = "java"
 		info.BuildTool = "maven"
+		info.BuildCmd = "mvn compile"
+		info.SetupCmd = "mvn dependency:resolve"
 		info.TestCmd = "mvn test"
+		info.PackageManagers = append(info.PackageManagers, "maven")
 	} else if fileExists(dir, "build.gradle") || fileExists(dir, "build.gradle.kts") {
 		info.Language = "java"
 		info.BuildTool = "gradle"
+		info.BuildCmd = "gradle build"
+		info.SetupCmd = "gradle dependencies"
 		info.TestCmd = "gradle test"
+		info.PackageManagers = append(info.PackageManagers, "gradle")
 	} else if fileExists(dir, "Makefile") {
 		info.BuildTool = "make"
+		info.BuildCmd = detectMakeBuildCmd(dir)
+		info.SetupCmd = detectMakeSetupCmd(dir)
 		info.TestCmd = detectMakeTestCmd(dir)
+		info.DevCmd = detectMakeDevCmd(dir)
 	}
 
 	// Detect CI
@@ -88,15 +125,24 @@ func DetectProject(dir string) ProjectInfo {
 	// Detect linter
 	if fileExists(dir, ".eslintrc.json") || fileExists(dir, ".eslintrc.js") || fileExists(dir, "eslint.config.js") || fileExists(dir, "eslint.config.mjs") {
 		info.HasLinter = true
+		info.LintCmd = "npm run lint"
 	} else if fileExists(dir, ".golangci.yml") || fileExists(dir, ".golangci.yaml") {
 		info.HasLinter = true
+		info.LintCmd = "golangci-lint run"
 	} else if fileExists(dir, ".prettierrc") || fileExists(dir, ".prettierrc.json") {
 		info.HasLinter = true
+		info.LintCmd = "prettier --check ."
 	} else if fileExists(dir, "rustfmt.toml") || fileExists(dir, ".rustfmt.toml") {
 		info.HasLinter = true
+		info.LintCmd = "cargo fmt --check"
 	} else if fileExists(dir, ".flake8") || fileExists(dir, "ruff.toml") || fileExists(dir, ".ruff.toml") {
 		info.HasLinter = true
+		info.LintCmd = "ruff check ."
 	}
+
+	detectFrontendProject(dir, &info)
+	info.PackageManagers = uniqueNonEmpty(info.PackageManagers)
+	info.Frameworks = uniqueNonEmpty(info.Frameworks)
 
 	return info
 }
@@ -179,4 +225,159 @@ func detectMakeTestCmd(dir string) string {
 		return "go test ./..."
 	}
 	return "make test"
+}
+
+func detectMakeBuildCmd(dir string) string {
+	data, err := os.ReadFile(filepath.Join(dir, "Makefile"))
+	if err != nil {
+		return "make build"
+	}
+	content := string(data)
+	if strings.Contains(content, "build:") || strings.Contains(content, "build :") {
+		return "make build"
+	}
+	if strings.Contains(content, "go build") {
+		return "go build ./..."
+	}
+	return "make build"
+}
+
+func detectMakeSetupCmd(dir string) string {
+	data, err := os.ReadFile(filepath.Join(dir, "Makefile"))
+	if err != nil {
+		return ""
+	}
+	content := string(data)
+	if strings.Contains(content, "install:") || strings.Contains(content, "install :") {
+		return "make install"
+	}
+	return ""
+}
+
+func detectMakeDevCmd(dir string) string {
+	data, err := os.ReadFile(filepath.Join(dir, "Makefile"))
+	if err != nil {
+		return ""
+	}
+	content := string(data)
+	if strings.Contains(content, "dev:") || strings.Contains(content, "dev :") {
+		return "make dev"
+	}
+	if strings.Contains(content, "serve:") || strings.Contains(content, "serve :") {
+		return "make serve"
+	}
+	return ""
+}
+
+type packageManifest struct {
+	Dependencies    map[string]string `json:"dependencies"`
+	DevDependencies map[string]string `json:"devDependencies"`
+	Scripts         map[string]string `json:"scripts"`
+}
+
+func detectFrontendProject(dir string, info *ProjectInfo) {
+	webDir := filepath.Join(dir, "web")
+	if !fileExists(webDir, "package.json") {
+		return
+	}
+
+	info.PackageManagers = append(info.PackageManagers, detectNodePackageManager(webDir))
+
+	manifest, err := readPackageManifest(filepath.Join(webDir, "package.json"))
+	if err != nil {
+		return
+	}
+
+	deps := map[string]string{}
+	for name, version := range manifest.Dependencies {
+		deps[name] = version
+	}
+	for name, version := range manifest.DevDependencies {
+		deps[name] = version
+	}
+
+	if _, ok := deps["@sveltejs/kit"]; ok {
+		info.Frameworks = append(info.Frameworks, "sveltekit")
+		info.PackageManagers = append(info.PackageManagers, "npm")
+		if info.Language == "" {
+			info.Language = "typescript"
+		}
+	}
+	if _, ok := deps["react"]; ok {
+		info.Frameworks = append(info.Frameworks, "react")
+	}
+	if _, ok := deps["vue"]; ok {
+		info.Frameworks = append(info.Frameworks, "vue")
+	}
+
+	pm := detectNodePackageManager(webDir)
+	if scriptExists(manifest.Scripts, "build") {
+		info.WebBuildCmd = nodeScriptCmd(pm, "build")
+	}
+	if scriptExists(manifest.Scripts, "lint") && info.LintCmd == "" {
+		info.LintCmd = nodeScriptCmd(pm, "lint")
+		info.HasLinter = true
+	}
+	if scriptExists(manifest.Scripts, "dev") && info.DevCmd == "" {
+		info.DevCmd = "cd web && " + nodeScriptCmd(pm, "dev")
+	}
+}
+
+func detectNodePackageManager(dir string) string {
+	if fileExists(dir, "yarn.lock") {
+		return "yarn"
+	}
+	if fileExists(dir, "pnpm-lock.yaml") {
+		return "pnpm"
+	}
+	return "npm"
+}
+
+func nodeScriptCmd(pm, script string) string {
+	switch pm {
+	case "yarn":
+		return "yarn " + script
+	case "pnpm":
+		return "pnpm " + script
+	default:
+		return "npm run " + script
+	}
+}
+
+func scriptExists(scripts map[string]string, key string) bool {
+	if scripts == nil {
+		return false
+	}
+	_, ok := scripts[key]
+	return ok
+}
+
+func readPackageManifest(path string) (*packageManifest, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var manifest packageManifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return nil, err
+	}
+	return &manifest, nil
+}
+
+func uniqueNonEmpty(values []string) []string {
+	seen := map[string]struct{}{}
+	var out []string
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
 }

--- a/internal/cli/workspace_context_detect.go
+++ b/internal/cli/workspace_context_detect.go
@@ -1,0 +1,167 @@
+package cli
+
+import (
+	"bytes"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/xarmian/pad/internal/config"
+	"github.com/xarmian/pad/internal/models"
+)
+
+// BuildWorkspaceContext converts detected project metadata plus the current Pad
+// client configuration into a machine-readable workspace context.
+func BuildWorkspaceContext(dir string, info ProjectInfo, cfg *config.Config) *models.WorkspaceContext {
+	context := &models.WorkspaceContext{
+		Repositories: detectWorkspaceRepositories(dir),
+		Paths:        detectWorkspacePaths(dir),
+		Commands:     detectWorkspaceCommands(info),
+		Stack: &models.WorkspaceStack{
+			Languages:       uniqueNonEmpty([]string{info.Language}),
+			Frameworks:      uniqueNonEmpty(info.Frameworks),
+			PackageManagers: uniqueNonEmpty(info.PackageManagers),
+		},
+		Deployment:  detectWorkspaceDeployment(cfg),
+		Assumptions: detectWorkspaceAssumptions(dir, cfg),
+	}
+
+	if len(context.Repositories) == 0 {
+		context.Repositories = nil
+	}
+	if context.Paths != nil && *context.Paths == (models.WorkspacePaths{}) {
+		context.Paths = nil
+	}
+	if context.Commands != nil && *context.Commands == (models.WorkspaceCommands{}) {
+		context.Commands = nil
+	}
+	if context.Stack != nil && len(context.Stack.Languages) == 0 && len(context.Stack.Frameworks) == 0 && len(context.Stack.PackageManagers) == 0 {
+		context.Stack = nil
+	}
+	if context.Deployment != nil && *context.Deployment == (models.WorkspaceDeployment{}) {
+		context.Deployment = nil
+	}
+	if len(context.Assumptions) == 0 {
+		context.Assumptions = nil
+	}
+
+	return context
+}
+
+func detectWorkspaceRepositories(dir string) []models.WorkspaceRepository {
+	var repos []models.WorkspaceRepository
+	repos = append(repos, models.WorkspaceRepository{
+		Name: filepath.Base(dir),
+		Role: "primary",
+		Path: ".",
+		Repo: detectGitRemoteSlug(dir),
+	})
+
+	docsPath := filepath.Join(dir, "..", "pad-web")
+	if fileExists(docsPath, "package.json") {
+		repos = append(repos, models.WorkspaceRepository{
+			Name: filepath.Base(docsPath),
+			Role: "docs",
+			Path: "../pad-web",
+			Repo: detectGitRemoteSlug(docsPath),
+		})
+	}
+
+	return repos
+}
+
+func detectWorkspacePaths(dir string) *models.WorkspacePaths {
+	paths := &models.WorkspacePaths{
+		Root: ".",
+	}
+	if fileExists(filepath.Join(dir, "..", "pad-web"), "package.json") {
+		paths.DocsRepo = "../pad-web"
+	}
+	if fileExists(dir, "package.json") {
+		paths.Web = "."
+	} else if dirExists(dir, "web") {
+		paths.Web = "web"
+	}
+	if dirExists(dir, "internal", "server") {
+		paths.Server = "internal/server"
+	}
+	if dirExists(dir, "skills") {
+		paths.Skills = "skills"
+	}
+	if fileExists(dir, ".pad.toml") {
+		paths.Config = ".pad.toml"
+	}
+	return paths
+}
+
+func detectWorkspaceCommands(info ProjectInfo) *models.WorkspaceCommands {
+	return &models.WorkspaceCommands{
+		Setup:  info.SetupCmd,
+		Build:  info.BuildCmd,
+		Test:   info.TestCmd,
+		Lint:   info.LintCmd,
+		Dev:    info.DevCmd,
+		Start:  info.DevCmd,
+		Web:    info.WebBuildCmd,
+		Format: "",
+	}
+}
+
+func detectWorkspaceDeployment(cfg *config.Config) *models.WorkspaceDeployment {
+	if cfg == nil {
+		return nil
+	}
+
+	deployment := &models.WorkspaceDeployment{
+		Mode:    cfg.Mode,
+		BaseURL: cfg.BaseURL(),
+	}
+	if cfg.Mode == config.ModeLocal {
+		deployment.Host = cfg.Host
+	}
+	return deployment
+}
+
+func detectWorkspaceAssumptions(dir string, cfg *config.Config) []string {
+	var assumptions []string
+	if fileExists(filepath.Join(dir, "..", "pad-web"), "package.json") {
+		assumptions = append(assumptions, "A companion docs or marketing repo lives at ../pad-web")
+	}
+	if cfg != nil {
+		switch cfg.Mode {
+		case config.ModeDocker:
+			assumptions = append(assumptions, "This client is configured for a docker-managed Pad instance")
+		case config.ModeRemote:
+			assumptions = append(assumptions, "This client connects to a remote-managed Pad server")
+		case config.ModeLocal:
+			assumptions = append(assumptions, "This client manages a local Pad server by default")
+		}
+	}
+	if dirExists(dir, "web") && dirExists(dir, "internal", "server") {
+		assumptions = append(assumptions, "This repository contains both server and web application surfaces")
+	}
+	return uniqueNonEmpty(assumptions)
+}
+
+func detectGitRemoteSlug(dir string) string {
+	cmd := exec.Command("git", "-C", dir, "remote", "get-url", "origin")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	if err := cmd.Run(); err != nil {
+		return ""
+	}
+	return normalizeGitRemoteSlug(out.String())
+}
+
+func normalizeGitRemoteSlug(raw string) string {
+	raw = strings.TrimSpace(raw)
+	raw = strings.TrimSuffix(raw, ".git")
+	switch {
+	case strings.HasPrefix(raw, "git@github.com:"):
+		return strings.TrimPrefix(raw, "git@github.com:")
+	case strings.HasPrefix(raw, "https://github.com/"):
+		return strings.TrimPrefix(raw, "https://github.com/")
+	default:
+		return ""
+	}
+}

--- a/internal/cli/workspace_context_detect_test.go
+++ b/internal/cli/workspace_context_detect_test.go
@@ -1,0 +1,107 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/xarmian/pad/internal/config"
+)
+
+func TestDetectProjectCapturesMakeAndNestedWebSignals(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/test\n"), 0644); err != nil {
+		t.Fatalf("write go.mod: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "Makefile"), []byte("install:\n\tgo build ./...\n\nbuild:\n\tgo build ./...\n\ntest:\n\tgo test ./...\n\ndev:\n\tgo run ./cmd/pad\n"), 0644); err != nil {
+		t.Fatalf("write Makefile: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "web"), 0755); err != nil {
+		t.Fatalf("mkdir web: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "web", "package.json"), []byte(`{"dependencies":{"@sveltejs/kit":"^2.0.0"},"scripts":{"build":"vite build","dev":"vite dev","lint":"eslint ."}}`), 0644); err != nil {
+		t.Fatalf("write package.json: %v", err)
+	}
+
+	info := DetectProject(dir)
+	if info.Language != "go" {
+		t.Fatalf("expected language go, got %q", info.Language)
+	}
+	if info.BuildCmd != "make build" {
+		t.Fatalf("expected build command make build, got %q", info.BuildCmd)
+	}
+	if info.SetupCmd != "make install" {
+		t.Fatalf("expected setup command make install, got %q", info.SetupCmd)
+	}
+	if info.DevCmd != "make dev" {
+		t.Fatalf("expected dev command make dev, got %q", info.DevCmd)
+	}
+	if info.WebBuildCmd != "npm run build" {
+		t.Fatalf("expected web build command npm run build, got %q", info.WebBuildCmd)
+	}
+	if len(info.Frameworks) == 0 || info.Frameworks[0] != "sveltekit" {
+		t.Fatalf("expected sveltekit framework detection, got %#v", info.Frameworks)
+	}
+}
+
+func TestBuildWorkspaceContext(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "web"), 0755); err != nil {
+		t.Fatalf("mkdir web: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "internal", "server"), 0755); err != nil {
+		t.Fatalf("mkdir server: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "skills"), 0755); err != nil {
+		t.Fatalf("mkdir skills: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "..", "pad-web"), 0755); err != nil {
+		t.Fatalf("mkdir docs repo: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "..", "pad-web", "package.json"), []byte(`{}`), 0644); err != nil {
+		t.Fatalf("write sibling package.json: %v", err)
+	}
+
+	info := ProjectInfo{
+		Language:        "go",
+		BuildCmd:        "make build",
+		SetupCmd:        "make install",
+		TestCmd:         "go test ./...",
+		WebBuildCmd:     "npm run build",
+		PackageManagers: []string{"go", "npm"},
+		Frameworks:      []string{"sveltekit"},
+	}
+	cfg := &config.Config{Mode: config.ModeLocal, URL: "http://127.0.0.1:7777", Host: "127.0.0.1"}
+
+	context := BuildWorkspaceContext(dir, info, cfg)
+	if context.Paths == nil || context.Paths.Web != "web" {
+		t.Fatalf("expected web path, got %#v", context.Paths)
+	}
+	if context.Paths == nil || context.Paths.DocsRepo != "../pad-web" {
+		t.Fatalf("expected docs repo path, got %#v", context.Paths)
+	}
+	if context.Commands == nil || context.Commands.Setup != "make install" {
+		t.Fatalf("expected setup command, got %#v", context.Commands)
+	}
+	if context.Stack == nil || len(context.Stack.PackageManagers) != 2 {
+		t.Fatalf("expected package managers, got %#v", context.Stack)
+	}
+	if context.Deployment == nil || context.Deployment.Mode != config.ModeLocal {
+		t.Fatalf("expected local deployment, got %#v", context.Deployment)
+	}
+	if len(context.Repositories) < 2 {
+		t.Fatalf("expected primary and docs repositories, got %#v", context.Repositories)
+	}
+}
+
+func TestNormalizeGitRemoteSlug(t *testing.T) {
+	if got := normalizeGitRemoteSlug("git@github.com:xarmian/pad.git\n"); got != "xarmian/pad" {
+		t.Fatalf("expected SSH slug xarmian/pad, got %q", got)
+	}
+	if got := normalizeGitRemoteSlug("https://github.com/xarmian/pad.git"); got != "xarmian/pad" {
+		t.Fatalf("expected HTTPS slug xarmian/pad, got %q", got)
+	}
+	if got := normalizeGitRemoteSlug("ssh://git@example.com/foo"); got != "" {
+		t.Fatalf("expected unsupported remote to be blank, got %q", got)
+	}
+}

--- a/web/src/routes/[workspace]/settings/+page.svelte
+++ b/web/src/routes/[workspace]/settings/+page.svelte
@@ -4,7 +4,7 @@
 	import { onMount } from 'svelte';
 	import { api } from '$lib/api/client';
 	import { workspaceStore } from '$lib/stores/workspace.svelte';
-	import type { Collection, APIToken } from '$lib/types';
+	import type { Collection, APIToken, WorkspaceContext } from '$lib/types';
 	import { parseSchema } from '$lib/types';
 	import CreateCollectionModal from '$lib/components/collections/CreateCollectionModal.svelte';
 	import EditCollectionModal from '$lib/components/collections/EditCollectionModal.svelte';
@@ -21,6 +21,10 @@
 	let theme = $state<'light' | 'dark'>('dark');
 	let showCreateModal = $state(false);
 	let editingCollection = $state<Collection | null>(null);
+	let contextEditor = $state('{}');
+	let savingContext = $state(false);
+	let contextStatus = $state<'idle' | 'saved' | 'error'>('idle');
+	let contextError = $state('');
 
 	// Members
 	let members = $state<{ user_id: string; user_name: string; user_email: string; role: string }[]>([]);
@@ -97,6 +101,7 @@
 		try {
 			await workspaceStore.setCurrent(slug);
 			wsName = workspaceStore.current?.name ?? '';
+			contextEditor = JSON.stringify(workspaceStore.current?.context ?? {}, null, 2);
 			collections = await api.collections.list(slug);
 			try {
 				const memberData = await api.members.list(slug);
@@ -142,6 +147,76 @@
 			nameStatus = 'error';
 		} finally {
 			savingName = false;
+		}
+	}
+
+	function formatContextEditor(value: WorkspaceContext | null | undefined) {
+		return JSON.stringify(value ?? {}, null, 2);
+	}
+
+	function resetContextEditor() {
+		contextEditor = formatContextEditor(workspaceStore.current?.context);
+		contextError = '';
+		contextStatus = 'idle';
+	}
+
+	function clearContextEditor() {
+		contextEditor = '{}';
+		contextError = '';
+		contextStatus = 'idle';
+	}
+
+	function stripContextFromSettings(raw: string | undefined) {
+		if (!raw) return '{}';
+		try {
+			const parsed = JSON.parse(raw) as Record<string, unknown>;
+			delete parsed.context;
+			return JSON.stringify(parsed);
+		} catch {
+			return '{}';
+		}
+	}
+
+	async function saveContext() {
+		if (savingContext) return;
+		contextError = '';
+		contextStatus = 'idle';
+
+		let parsed: unknown;
+		try {
+			parsed = JSON.parse(contextEditor.trim() || '{}');
+		} catch {
+			contextError = 'Context must be valid JSON.';
+			contextStatus = 'error';
+			return;
+		}
+
+		if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+			contextError = 'Context must be a JSON object.';
+			contextStatus = 'error';
+			return;
+		}
+
+		savingContext = true;
+		try {
+			const hasKeys = Object.keys(parsed as Record<string, unknown>).length > 0;
+			const updated = hasKeys
+				? await api.workspaces.update(wsSlug, { context: parsed as WorkspaceContext })
+				: await api.workspaces.update(wsSlug, {
+					settings: stripContextFromSettings(workspaceStore.current?.settings)
+				});
+
+			await workspaceStore.setCurrent(updated);
+			contextEditor = formatContextEditor(updated.context);
+			contextStatus = 'saved';
+			setTimeout(() => {
+				if (contextStatus === 'saved') contextStatus = 'idle';
+			}, 2000);
+		} catch (err: unknown) {
+			contextError = err instanceof Error ? err.message : 'Failed to save workspace context';
+			contextStatus = 'error';
+		} finally {
+			savingContext = false;
 		}
 	}
 	function toggleTheme() {
@@ -362,6 +437,22 @@
 				})
 			: ''
 	);
+
+	let contextSummary = $derived.by(() => {
+		const context = workspaceStore.current?.context;
+		if (!context) return [] as { label: string; value: string }[];
+
+		const summary: { label: string; value: string }[] = [];
+		if (context.repositories?.length) summary.push({ label: 'Repositories', value: String(context.repositories.length) });
+		if (context.commands) {
+			const configured = Object.entries(context.commands).filter(([, value]) => Boolean(value)).length;
+			if (configured) summary.push({ label: 'Commands', value: String(configured) });
+		}
+		if (context.stack?.languages?.length) summary.push({ label: 'Languages', value: context.stack.languages.join(', ') });
+		if (context.deployment?.mode) summary.push({ label: 'Deployment', value: context.deployment.mode });
+		if (context.assumptions?.length) summary.push({ label: 'Assumptions', value: String(context.assumptions.length) });
+		return summary;
+	});
 </script>
 
 <div class="settings">
@@ -433,6 +524,50 @@
 							<span class="theme-option" class:active={theme === 'light'}>Light</span>
 							<span class="theme-option" class:active={theme === 'dark'}>Dark</span>
 						</button>
+					</div>
+				</div>
+			</section>
+			<section class="section">
+				<h2>Workspace Context</h2>
+				<p class="section-desc">Machine-readable metadata for repos, commands, stack, deployment, and agent-facing assumptions.</p>
+				<div class="card context-card">
+					{#if contextSummary.length > 0}
+						<div class="context-summary">
+							{#each contextSummary as entry (entry.label)}
+								<div class="context-chip">
+									<span class="context-chip-label">{entry.label}</span>
+									<span class="context-chip-value">{entry.value}</span>
+								</div>
+							{/each}
+						</div>
+					{/if}
+					<label class="context-label" for="workspace-context">Context JSON</label>
+					<textarea
+						id="workspace-context"
+						class="context-editor mono"
+						bind:value={contextEditor}
+						spellcheck="false"
+						rows="18"
+					></textarea>
+					<p class="context-help">Use a JSON object with keys like <code>repositories</code>, <code>paths</code>, <code>commands</code>, <code>stack</code>, <code>deployment</code>, and <code>assumptions</code>.</p>
+					{#if contextError}
+						<p class="context-error">{contextError}</p>
+					{/if}
+					<div class="context-actions">
+						<button class="btn btn-primary" onclick={saveContext} disabled={savingContext}>
+							{savingContext ? 'Saving...' : 'Save Context'}
+						</button>
+						<button class="btn" onclick={resetContextEditor} disabled={savingContext}>
+							Reset
+						</button>
+						<button class="btn" onclick={clearContextEditor} disabled={savingContext}>
+							Clear
+						</button>
+						{#if contextStatus === 'saved'}
+							<span class="status-saved">Saved</span>
+						{:else if contextStatus === 'error' && !contextError}
+							<span class="status-error">Error</span>
+						{/if}
 					</div>
 				</div>
 			</section>
@@ -876,6 +1011,18 @@
 	.theme-toggle { display: flex; background: var(--bg-tertiary); border: 1px solid var(--border); border-radius: var(--radius); overflow: hidden; cursor: pointer; }
 	.theme-option { padding: var(--space-1) var(--space-4); font-size: 0.85em; transition: background 0.15s, color 0.15s; }
 	.theme-option.active { background: var(--accent-blue); color: #fff; }
+	.context-card { display: flex; flex-direction: column; gap: var(--space-3); }
+	.context-summary { display: flex; flex-wrap: wrap; gap: var(--space-2); }
+	.context-chip { display: inline-flex; align-items: center; gap: var(--space-2); background: var(--bg-tertiary); border: 1px solid var(--border-subtle); border-radius: 999px; padding: var(--space-1) var(--space-3); font-size: 0.78em; }
+	.context-chip-label { color: var(--text-muted); }
+	.context-chip-value { color: var(--text-primary); font-weight: 600; }
+	.context-label { font-size: 0.82em; color: var(--text-secondary); }
+	.context-editor { width: 100%; min-height: 320px; resize: vertical; padding: var(--space-3); background: var(--bg-tertiary); border: 1px solid var(--border); border-radius: var(--radius); color: var(--text-primary); line-height: 1.5; }
+	.context-editor:focus { outline: none; border-color: var(--accent-blue); }
+	.context-help { margin: 0; font-size: 0.8em; color: var(--text-muted); }
+	.context-help code { font-family: var(--font-mono); font-size: 0.95em; }
+	.context-error { margin: 0; font-size: 0.82em; color: #ef4444; }
+	.context-actions { display: flex; flex-wrap: wrap; align-items: center; gap: var(--space-2); }
 	/* ── Members ──── */
 	.members-list { display: flex; flex-direction: column; gap: var(--space-3); }
 	.member-row { display: flex; align-items: center; justify-content: space-between; padding: var(--space-3) var(--space-4); gap: var(--space-3); }


### PR DESCRIPTION
## Summary
- extend project detection to infer structured workspace context signals
- save machine-readable workspace context during pad workspace onboard
- surface the updated onboarding behavior in CLI docs

## Verification
- go build ./...
- go test ./...
- make install