### PR TITLE
[codex] Add pad server info for TASK-134

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ pad item list tasks --status in-progress
 pad item search "authentication"
 pad project dashboard                   # Project dashboard
 pad project next                        # What should I work on?
+pad server info                         # How this client is connected to Pad
 ```
 
 **Web UI that stays out of your way.** A clean, dark-themed interface at `localhost:7777` with:
@@ -242,6 +243,7 @@ pad auth whoami                       Show current user
 
 pad server start                      Start the Pad API server
 pad server stop                       Stop the Pad server
+pad server info                       Show client, connection, and local server status
 pad server open                       Open web UI in browser
 
 pad workspace init [name]             Initialize workspace in current directory

--- a/cmd/pad/groups.go
+++ b/cmd/pad/groups.go
@@ -26,6 +26,7 @@ func serverCmd() *cobra.Command {
 	cmd.AddCommand(
 		serveCmd(),
 		stopCmd(),
+		infoCmd(),
 		openCmd(),
 	)
 	return cmd

--- a/cmd/pad/server_info.go
+++ b/cmd/pad/server_info.go
@@ -1,0 +1,322 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+
+	"github.com/xarmian/pad/internal/cli"
+	"github.com/xarmian/pad/internal/config"
+)
+
+type serverInfoReport struct {
+	Config     serverInfoConfig     `json:"config"`
+	Connection serverInfoConnection `json:"connection"`
+	Auth       serverInfoAuth       `json:"auth"`
+	Workspace  serverInfoWorkspace  `json:"workspace"`
+	Local      *serverInfoLocal     `json:"local,omitempty"`
+}
+
+type serverInfoConfig struct {
+	Configured         bool   `json:"configured"`
+	Mode               string `json:"mode,omitempty"`
+	ConfigPath         string `json:"config_path"`
+	DataDir            string `json:"data_dir"`
+	BaseURL            string `json:"base_url"`
+	Host               string `json:"host,omitempty"`
+	Port               int    `json:"port,omitempty"`
+	ManagesLocalServer bool   `json:"manages_local_server"`
+	LoadedFromFile     bool   `json:"loaded_from_file"`
+	LoadedFromEnv      bool   `json:"loaded_from_env"`
+	LoadedFromFlags    bool   `json:"loaded_from_flags"`
+}
+
+type serverInfoConnection struct {
+	Reachable bool   `json:"reachable"`
+	Error     string `json:"error,omitempty"`
+}
+
+type serverInfoAuth struct {
+	CredentialsPath        string         `json:"credentials_path"`
+	CredentialsPresent     bool           `json:"credentials_present"`
+	CredentialsServerURL   string         `json:"credentials_server_url,omitempty"`
+	CredentialsMatchServer bool           `json:"credentials_match_server"`
+	Authenticated          bool           `json:"authenticated"`
+	SessionValid           bool           `json:"session_valid"`
+	SetupRequired          bool           `json:"setup_required"`
+	SetupMethod            string         `json:"setup_method,omitempty"`
+	User                   *cli.LoginUser `json:"user,omitempty"`
+}
+
+type serverInfoWorkspace struct {
+	Current string `json:"current,omitempty"`
+}
+
+type serverInfoLocal struct {
+	BindAddr    string `json:"bind_addr"`
+	ServerRunning bool `json:"server_running"`
+	PID         *int   `json:"pid,omitempty"`
+	PIDFile     string `json:"pid_file"`
+	LogFile     string `json:"log_file"`
+	DBPath      string `json:"db_path"`
+	DBExists    bool   `json:"db_exists"`
+	DBSizeBytes int64  `json:"db_size_bytes"`
+}
+
+func infoCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "info",
+		Short: "Show local Pad client, connection, and server status",
+		Long: `Show a client-oriented snapshot of this Pad installation and connection state.
+
+This command reports local configuration, reachability, auth/session state, and
+local runtime details when applicable. It does not auto-start the server and it
+does not inspect remote server internals.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			report, err := collectServerInfo(getConfig())
+			if err != nil {
+				return err
+			}
+
+			if formatFlag == "json" {
+				outputJSON(report)
+				return nil
+			}
+
+			printServerInfo(report)
+			return nil
+		},
+	}
+}
+
+func collectServerInfo(cfg *config.Config) (*serverInfoReport, error) {
+	report := &serverInfoReport{
+		Config: serverInfoConfig{
+			Configured:         cfg.IsConfigured(),
+			Mode:               cfg.Mode,
+			ConfigPath:         cfg.ConfigPath,
+			DataDir:            cfg.DataDir,
+			BaseURL:            cfg.BaseURL(),
+			Host:               cfg.Host,
+			Port:               cfg.Port,
+			ManagesLocalServer: cfg.ManagesLocalServer(),
+			LoadedFromFile:     cfg.LoadedFromFile,
+			LoadedFromEnv:      cfg.LoadedFromEnv,
+			LoadedFromFlags:    cfg.LoadedFromFlags,
+		},
+	}
+
+	if ws, err := cli.DetectWorkspace(workspaceFlag); err == nil {
+		report.Workspace.Current = ws
+	}
+
+	credsPath, err := cli.CredentialsPath()
+	if err != nil {
+		return nil, err
+	}
+	report.Auth.CredentialsPath = credsPath
+
+	creds, err := cli.LoadCredentials()
+	if err != nil {
+		return nil, fmt.Errorf("load credentials: %w", err)
+	}
+	if creds != nil {
+		report.Auth.CredentialsPresent = true
+		report.Auth.CredentialsServerURL = creds.ServerURL
+		report.Auth.CredentialsMatchServer = normalizeURL(creds.ServerURL) == normalizeURL(cfg.BaseURL())
+	}
+
+	client := cli.NewClientFromURL(cfg.BaseURL())
+	client.SetAuthToken("")
+
+	if err := client.Health(); err != nil {
+		report.Connection.Error = err.Error()
+	} else {
+		report.Connection.Reachable = true
+		if creds != nil && creds.Token != "" && report.Auth.CredentialsMatchServer {
+			client.SetAuthToken(creds.Token)
+		}
+		session, err := client.CheckSession()
+		if err != nil {
+			report.Connection.Error = err.Error()
+		} else {
+			report.Auth.SetupRequired = session.SetupRequired
+			report.Auth.SetupMethod = session.SetupMethod
+			report.Auth.Authenticated = session.Authenticated
+			report.Auth.SessionValid = session.Authenticated
+			if session.Authenticated {
+				user := session.User
+				report.Auth.User = &user
+			}
+		}
+	}
+
+	if includeLocalRuntime(cfg) {
+		report.Local = collectLocalInfo(cfg)
+	}
+
+	return report, nil
+}
+
+func includeLocalRuntime(cfg *config.Config) bool {
+	if cfg.Mode == config.ModeLocal {
+		return true
+	}
+	return !cfg.IsConfigured() && cfg.URL == ""
+}
+
+func collectLocalInfo(cfg *config.Config) *serverInfoLocal {
+	info := &serverInfoLocal{
+		BindAddr:    cfg.Addr(),
+		ServerRunning: cli.IsServerRunning(cfg),
+		PIDFile:     cfg.PIDFile(),
+		LogFile:     cfg.LogFile(),
+		DBPath:      cfg.DBPath,
+	}
+
+	if pid, ok := readPID(cfg.PIDFile()); ok {
+		info.PID = &pid
+	}
+
+	if stat, err := os.Stat(cfg.DBPath); err == nil {
+		info.DBExists = true
+		info.DBSizeBytes = stat.Size()
+	}
+
+	return info
+}
+
+func readPID(path string) (int, bool) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0, false
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil || pid <= 0 {
+		return 0, false
+	}
+	return pid, true
+}
+
+func normalizeURL(raw string) string {
+	return strings.TrimRight(strings.TrimSpace(raw), "/")
+}
+
+func printServerInfo(report *serverInfoReport) {
+	mode := report.Config.Mode
+	if mode == "" {
+		mode = "not configured"
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+
+	fmt.Println("Client")
+	fmt.Fprintf(w, "Configured:\t%s\n", yesNo(report.Config.Configured))
+	fmt.Fprintf(w, "Mode:\t%s\n", mode)
+	fmt.Fprintf(w, "Server URL:\t%s\n", report.Config.BaseURL)
+	fmt.Fprintf(w, "Auto-manage local server:\t%s\n", yesNo(report.Config.ManagesLocalServer))
+	fmt.Fprintf(w, "Config path:\t%s\n", report.Config.ConfigPath)
+	fmt.Fprintf(w, "Data dir:\t%s\n", report.Config.DataDir)
+	if report.Config.Host != "" {
+		fmt.Fprintf(w, "Host:\t%s\n", report.Config.Host)
+	}
+	if report.Config.Port != 0 {
+		fmt.Fprintf(w, "Port:\t%d\n", report.Config.Port)
+	}
+	fmt.Fprintf(w, "Config source:\t%s\n", configSource(report.Config))
+
+	fmt.Println()
+	fmt.Println("Connection")
+	fmt.Fprintf(w, "Reachable:\t%s\n", yesNo(report.Connection.Reachable))
+	if report.Connection.Error != "" {
+		fmt.Fprintf(w, "Last error:\t%s\n", report.Connection.Error)
+	}
+
+	fmt.Println()
+	fmt.Println("Auth")
+	fmt.Fprintf(w, "Credentials file:\t%s\n", report.Auth.CredentialsPath)
+	fmt.Fprintf(w, "Credentials present:\t%s\n", yesNo(report.Auth.CredentialsPresent))
+	if report.Auth.CredentialsPresent {
+		fmt.Fprintf(w, "Credentials server:\t%s\n", report.Auth.CredentialsServerURL)
+		fmt.Fprintf(w, "Credentials match current server:\t%s\n", yesNo(report.Auth.CredentialsMatchServer))
+	}
+	fmt.Fprintf(w, "Session valid:\t%s\n", yesNo(report.Auth.SessionValid))
+	fmt.Fprintf(w, "Authenticated:\t%s\n", yesNo(report.Auth.Authenticated))
+	fmt.Fprintf(w, "Setup required:\t%s\n", yesNo(report.Auth.SetupRequired))
+	if report.Auth.SetupMethod != "" {
+		fmt.Fprintf(w, "Setup method:\t%s\n", report.Auth.SetupMethod)
+	}
+	if report.Auth.User != nil {
+		fmt.Fprintf(w, "User:\t%s <%s>\n", report.Auth.User.Name, report.Auth.User.Email)
+	}
+
+	fmt.Println()
+	fmt.Println("Workspace")
+	currentWorkspace := report.Workspace.Current
+	if currentWorkspace == "" {
+		currentWorkspace = "(none linked)"
+	}
+	fmt.Fprintf(w, "Current workspace:\t%s\n", currentWorkspace)
+
+	if report.Local != nil {
+		fmt.Println()
+		fmt.Println("Local Runtime")
+		fmt.Fprintf(w, "Bind address:\t%s\n", report.Local.BindAddr)
+		fmt.Fprintf(w, "Server running:\t%s\n", yesNo(report.Local.ServerRunning))
+		if report.Local.PID != nil {
+			fmt.Fprintf(w, "PID:\t%d\n", *report.Local.PID)
+		}
+		fmt.Fprintf(w, "PID file:\t%s\n", report.Local.PIDFile)
+		fmt.Fprintf(w, "Log file:\t%s\n", report.Local.LogFile)
+		fmt.Fprintf(w, "Database path:\t%s\n", report.Local.DBPath)
+		fmt.Fprintf(w, "Database exists:\t%s\n", yesNo(report.Local.DBExists))
+		if report.Local.DBExists {
+			fmt.Fprintf(w, "Database size:\t%s\n", humanizeBytes(report.Local.DBSizeBytes))
+		}
+	}
+
+	w.Flush()
+}
+
+func configSource(cfg serverInfoConfig) string {
+	var sources []string
+	if cfg.LoadedFromFile {
+		sources = append(sources, "file")
+	}
+	if cfg.LoadedFromEnv {
+		sources = append(sources, "env")
+	}
+	if cfg.LoadedFromFlags {
+		sources = append(sources, "flags")
+	}
+	if len(sources) == 0 {
+		return "defaults"
+	}
+	return strings.Join(sources, ", ")
+}
+
+func yesNo(v bool) string {
+	if v {
+		return "yes"
+	}
+	return "no"
+}
+
+func humanizeBytes(size int64) string {
+	if size < 1024 {
+		return fmt.Sprintf("%d B", size)
+	}
+	units := []string{"KB", "MB", "GB", "TB"}
+	value := float64(size)
+	for _, unit := range units {
+		value /= 1024
+		if value < 1024 {
+			return fmt.Sprintf("%.1f %s", value, unit)
+		}
+	}
+	return fmt.Sprintf("%.1f PB", value/1024)
+}

--- a/cmd/pad/server_info_test.go
+++ b/cmd/pad/server_info_test.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/xarmian/pad/internal/cli"
+	"github.com/xarmian/pad/internal/config"
+)
+
+func TestCollectServerInfoRemoteAuthenticated(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	prevWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	projectDir := t.TempDir()
+	if err := os.Chdir(projectDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(prevWD) })
+
+	if err := cli.WriteWorkspaceLink(projectDir, "pad"); err != nil {
+		t.Fatalf("write workspace link: %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/health":
+			w.WriteHeader(http.StatusOK)
+		case "/api/v1/auth/session":
+			if got := r.Header.Get("Authorization"); got != "Bearer padsess_test" {
+				t.Fatalf("unexpected auth header %q", got)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"authenticated": true,
+				"setup_required": false,
+				"auth_method": "password",
+				"user": map[string]any{
+					"id":    "user-1",
+					"email": "dave@example.com",
+					"name":  "Dave",
+					"role":  "owner",
+				},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	if err := cli.SaveCredentials(&cli.Credentials{
+		ServerURL: server.URL,
+		Token:     "padsess_test",
+		UserID:    "user-1",
+		Email:     "dave@example.com",
+		Name:      "Dave",
+	}); err != nil {
+		t.Fatalf("save credentials: %v", err)
+	}
+
+	cfg := config.DefaultConfig()
+	cfg.Mode = config.ModeRemote
+	cfg.URL = server.URL
+	cfg.LoadedFromFile = true
+
+	report, err := collectServerInfo(cfg)
+	if err != nil {
+		t.Fatalf("collectServerInfo: %v", err)
+	}
+
+	if !report.Connection.Reachable {
+		t.Fatal("expected server to be reachable")
+	}
+	if !report.Auth.CredentialsPresent {
+		t.Fatal("expected credentials to be present")
+	}
+	if !report.Auth.CredentialsMatchServer {
+		t.Fatal("expected credentials to match configured server")
+	}
+	if !report.Auth.Authenticated || !report.Auth.SessionValid {
+		t.Fatalf("expected authenticated valid session, got auth=%v valid=%v", report.Auth.Authenticated, report.Auth.SessionValid)
+	}
+	if report.Auth.User == nil || report.Auth.User.Email != "dave@example.com" {
+		t.Fatalf("expected authenticated user info, got %#v", report.Auth.User)
+	}
+	if report.Workspace.Current != "pad" {
+		t.Fatalf("expected workspace pad, got %q", report.Workspace.Current)
+	}
+	if report.Local != nil {
+		t.Fatal("expected no local runtime section for remote mode")
+	}
+}
+
+func TestCollectServerInfoLocalRuntime(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	cfg := config.DefaultConfig()
+	cfg.Mode = config.ModeLocal
+	cfg.LoadedFromFile = true
+	cfg.Port = 65530
+
+	if err := os.MkdirAll(filepath.Dir(cfg.DBPath), 0o755); err != nil {
+		t.Fatalf("mkdir db dir: %v", err)
+	}
+	if err := os.WriteFile(cfg.DBPath, []byte("sqlite-data"), 0o644); err != nil {
+		t.Fatalf("write db: %v", err)
+	}
+	if err := os.WriteFile(cfg.PIDFile(), []byte("4321"), 0o644); err != nil {
+		t.Fatalf("write pid: %v", err)
+	}
+
+	report, err := collectServerInfo(cfg)
+	if err != nil {
+		t.Fatalf("collectServerInfo: %v", err)
+	}
+
+	if report.Local == nil {
+		t.Fatal("expected local runtime info")
+	}
+	if report.Local.BindAddr != "127.0.0.1:65530" {
+		t.Fatalf("unexpected bind addr %q", report.Local.BindAddr)
+	}
+	if report.Local.PID == nil || *report.Local.PID != 4321 {
+		t.Fatalf("expected pid 4321, got %#v", report.Local.PID)
+	}
+	if !report.Local.DBExists {
+		t.Fatal("expected DB to exist")
+	}
+	if report.Local.DBSizeBytes != int64(len("sqlite-data")) {
+		t.Fatalf("unexpected db size %d", report.Local.DBSizeBytes)
+	}
+	if report.Connection.Reachable {
+		t.Fatal("expected local server to be unreachable in test")
+	}
+}
+
+func TestIncludeLocalRuntimeWhenUnconfigured(t *testing.T) {
+	cfg := config.DefaultConfig()
+	if !includeLocalRuntime(cfg) {
+		t.Fatal("expected unconfigured default client to include local runtime defaults")
+	}
+
+	cfg.URL = "https://pad.example.com"
+	if includeLocalRuntime(cfg) {
+		t.Fatal("expected URL-configured client to skip local runtime")
+	}
+}

--- a/internal/cli/credentials.go
+++ b/internal/cli/credentials.go
@@ -16,13 +16,18 @@ type Credentials struct {
 	Name      string `json:"name"`
 }
 
-// credentialsPath returns ~/.pad/credentials.json.
-func credentialsPath() (string, error) {
+// CredentialsPath returns ~/.pad/credentials.json.
+func CredentialsPath() (string, error) {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("get home directory: %w", err)
 	}
 	return filepath.Join(homeDir, ".pad", "credentials.json"), nil
+}
+
+// credentialsPath is retained for internal call sites.
+func credentialsPath() (string, error) {
+	return CredentialsPath()
 }
 
 // LoadCredentials reads the credentials file. Returns nil if the file

--- a/skills/pad/SKILL.md
+++ b/skills/pad/SKILL.md
@@ -51,6 +51,7 @@ Interpret the user's intent and route to the appropriate action. Here are common
 **Querying:**
 - "what's on my plate?" / "what should I work on?" → `pad project next --format json`
 - "how far along are we?" / "show me status" → `pad project dashboard --format json`
+- "what server am I connected to?" / "show my Pad connection info" → `pad server info --format json`
 - "show me all tasks" / "list bugs" → `pad item list <collection> --format json`
 - "find anything about OAuth" → `pad item search "OAuth" --format json`
 
@@ -157,6 +158,12 @@ pad project dashboard [--format json]  # Project dashboard
 pad project next [--format json]       # Recommended next task
 pad project standup [--days N] [--format json]  # Daily standup report (completed/in-progress/blockers)
 pad project changelog [--days N] [--since DATE] [--phase PHASE-2] [--format json|markdown]  # Release notes
+```
+
+### Server
+```bash
+pad server info [--format json]        # Show local client, connection, and local server status
+pad server open                        # Open the Pad web UI in your browser
 ```
 
 ### Dependencies


### PR DESCRIPTION
## Summary
- add `pad server info` under the grouped `server` commands
- report local client configuration, effective URL, reachability, auth/session state, current workspace, and local runtime details when applicable
- keep the command read-only with no remote introspection and no implicit server startup

## Why
`TASK-134` implements `IDEA-116` by giving users and agents a quick way to understand how the local CLI is configured to connect to Pad and whether that connection is healthy.

## Impact
Users can now run `pad server info` or `pad server info --format json` to see:
- configured mode and effective URL
- whether Pad auto-manages a local server
- credential/session status and current authenticated user
- linked workspace
- local DB path/size and PID/runtime details in local mode

## Validation
- `go build ./...`
- `go test ./...`
- `cd web && npm run build`
- `make install`