### PR TITLE
[codex] Fix relation field filter resolution for BUG-19

### DIFF
--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -24,6 +24,10 @@ func (s *Server) handleListItems(w http.ResponseWriter, r *http.Request) {
 	}
 
 	params := parseItemListParams(r)
+	if err := s.resolveRelationFieldFiltersForWorkspace(workspaceID, &params); err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", err.Error())
+		return
+	}
 	result, err := s.store.ListItems(workspaceID, params)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "internal_error", err.Error())
@@ -56,6 +60,10 @@ func (s *Server) handleListCollectionItems(w http.ResponseWriter, r *http.Reques
 
 	params := parseItemListParams(r)
 	params.CollectionSlug = collSlug
+	if err := s.resolveRelationFieldFilters(workspaceID, &params, coll.Schema); err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", err.Error())
+		return
+	}
 
 	result, err := s.store.ListItems(workspaceID, params)
 	if err != nil {
@@ -563,6 +571,110 @@ func (s *Server) resolveRelationFields(workspaceID string, fields map[string]any
 		fields[def.Key] = item.ID
 	}
 	return nil
+}
+
+func (s *Server) resolveRelationFieldFiltersForWorkspace(workspaceID string, params *models.ItemListParams) error {
+	if len(params.Fields) == 0 {
+		return nil
+	}
+
+	colls, err := s.store.ListCollections(workspaceID)
+	if err != nil {
+		return fmt.Errorf("list collections: %w", err)
+	}
+
+	schemas := make([]string, 0, len(colls))
+	for _, coll := range colls {
+		schemas = append(schemas, coll.Schema)
+	}
+
+	return s.resolveRelationFieldFilters(workspaceID, params, schemas...)
+}
+
+func (s *Server) resolveRelationFieldFilters(workspaceID string, params *models.ItemListParams, schemaJSONs ...string) error {
+	if len(params.Fields) == 0 || len(schemaJSONs) == 0 {
+		return nil
+	}
+
+	relationKeys := relationFilterKeys(schemaJSONs...)
+	if len(relationKeys) == 0 {
+		return nil
+	}
+
+	for key, rawValue := range params.Fields {
+		if !relationKeys[key] {
+			continue
+		}
+		resolvedValue, err := s.resolveRelationFilterValue(workspaceID, key, rawValue)
+		if err != nil {
+			return err
+		}
+		params.Fields[key] = resolvedValue
+	}
+
+	return nil
+}
+
+func relationFilterKeys(schemaJSONs ...string) map[string]bool {
+	type fieldState struct {
+		relation    bool
+		nonRelation bool
+	}
+
+	states := make(map[string]*fieldState)
+	for _, schemaJSON := range schemaJSONs {
+		if strings.TrimSpace(schemaJSON) == "" {
+			continue
+		}
+		var schema models.CollectionSchema
+		if err := json.Unmarshal([]byte(schemaJSON), &schema); err != nil {
+			continue
+		}
+		for _, def := range schema.Fields {
+			state := states[def.Key]
+			if state == nil {
+				state = &fieldState{}
+				states[def.Key] = state
+			}
+			if def.Type == "relation" {
+				state.relation = true
+			} else {
+				state.nonRelation = true
+			}
+		}
+	}
+
+	result := make(map[string]bool)
+	for key, state := range states {
+		if state.relation && !state.nonRelation {
+			result[key] = true
+		}
+	}
+	return result
+}
+
+func (s *Server) resolveRelationFilterValue(workspaceID, key, rawValue string) (string, error) {
+	parts := strings.Split(rawValue, ",")
+	resolved := make([]string, 0, len(parts))
+	for _, part := range parts {
+		candidate := strings.TrimSpace(part)
+		if candidate == "" {
+			continue
+		}
+		if isUUID(candidate) {
+			resolved = append(resolved, candidate)
+			continue
+		}
+		item, err := s.store.ResolveItem(workspaceID, candidate)
+		if err != nil {
+			return "", fmt.Errorf("field %q: failed to resolve %q: %w", key, candidate, err)
+		}
+		if item == nil {
+			return "", fmt.Errorf("field %q: item %q not found", key, candidate)
+		}
+		resolved = append(resolved, item.ID)
+	}
+	return strings.Join(resolved, ","), nil
 }
 
 // isUUID checks if a string looks like a UUID (8-4-4-4-12 hex).

--- a/internal/server/handlers_items_test.go
+++ b/internal/server/handlers_items_test.go
@@ -230,6 +230,101 @@ func TestItemCRUD(t *testing.T) {
 	}
 }
 
+func TestListCollectionItemsResolvesRelationFieldFilterRefs(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	phaseResp := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections/phases/items", map[string]interface{}{
+		"title":  "Agent Workflow Intelligence",
+		"fields": `{"status":"active"}`,
+	})
+	if phaseResp.Code != http.StatusCreated {
+		t.Fatalf("create phase: expected 201, got %d: %s", phaseResp.Code, phaseResp.Body.String())
+	}
+
+	var phase models.Item
+	parseJSON(t, phaseResp, &phase)
+	if phase.Ref == "" {
+		t.Fatal("expected phase ref to be populated")
+	}
+
+	taskResp := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections/tasks/items", map[string]interface{}{
+		"title":  "Add relation filter resolution",
+		"fields": `{"status":"open","phase":"` + phase.Ref + `"}`,
+	})
+	if taskResp.Code != http.StatusCreated {
+		t.Fatalf("create task: expected 201, got %d: %s", taskResp.Code, taskResp.Body.String())
+	}
+
+	otherTaskResp := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections/tasks/items", map[string]interface{}{
+		"title":  "Unrelated task",
+		"fields": `{"status":"open"}`,
+	})
+	if otherTaskResp.Code != http.StatusCreated {
+		t.Fatalf("create unrelated task: expected 201, got %d: %s", otherTaskResp.Code, otherTaskResp.Body.String())
+	}
+
+	rr := doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/collections/tasks/items?phase="+phase.Ref, nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("list tasks by phase ref: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var items []models.Item
+	parseJSON(t, rr, &items)
+	if len(items) != 1 {
+		t.Fatalf("expected 1 task for phase ref filter, got %d", len(items))
+	}
+	if items[0].Title != "Add relation filter resolution" {
+		t.Fatalf("unexpected task returned: %q", items[0].Title)
+	}
+}
+
+func TestListItemsResolvesRelationFieldFilterRefsAcrossCollections(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	phaseResp := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections/phases/items", map[string]interface{}{
+		"title":  "Open Source Launch",
+		"fields": `{"status":"active"}`,
+	})
+	if phaseResp.Code != http.StatusCreated {
+		t.Fatalf("create phase: expected 201, got %d: %s", phaseResp.Code, phaseResp.Body.String())
+	}
+
+	var phase models.Item
+	parseJSON(t, phaseResp, &phase)
+
+	taskResp := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections/tasks/items", map[string]interface{}{
+		"title":  "Document release filters",
+		"fields": `{"status":"open","phase":"` + phase.Ref + `"}`,
+	})
+	if taskResp.Code != http.StatusCreated {
+		t.Fatalf("create task: expected 201, got %d: %s", taskResp.Code, taskResp.Body.String())
+	}
+
+	docResp := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections/docs/items", map[string]interface{}{
+		"title":  "Release Notes",
+		"fields": `{"status":"draft","category":"launch"}`,
+	})
+	if docResp.Code != http.StatusCreated {
+		t.Fatalf("create doc: expected 201, got %d: %s", docResp.Code, docResp.Body.String())
+	}
+
+	rr := doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/items?phase="+phase.Ref, nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("list items by phase ref: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var items []models.Item
+	parseJSON(t, rr, &items)
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item for cross-collection phase ref filter, got %d", len(items))
+	}
+	if items[0].CollectionSlug != "tasks" {
+		t.Fatalf("expected task item, got collection %q", items[0].CollectionSlug)
+	}
+}
+
 func TestItemCreateValidation(t *testing.T) {
 	srv := testServer(t)
 	slug := createWSWithCollections(t, srv)


### PR DESCRIPTION
## Summary
- resolve relation-valued field filters like `phase=PHASE-8` before list queries hit the store
- apply the fix to both collection-scoped and cross-collection item list endpoints
- add regression coverage for ref-based relation filters on list endpoints

## Root Cause
The list/filter path passed `--field` values directly into `json_extract(i.fields, ...) = ?` comparisons. Relation fields store UUIDs, so filters like `phase=PHASE-8` never matched because create/update resolved refs to UUIDs but list queries did not.

## Impact
Ref-based relation filters now work consistently across item create, update, and list flows.

One nuance from the real workspace: `pad item list tasks --field phase=PHASE-8` still returns no rows unless `--all` is used, because `PHASE-8` only has `done` tasks and terminal statuses are hidden by default. The underlying relation resolution bug is fixed.

## Validation
- `go test ./internal/server -run 'TestList(CollectionItemsResolvesRelationFieldFilterRefs|ItemsResolvesRelationFieldFilterRefsAcrossCollections)$'`
- `go build ./...`
- `go test ./...`
- `cd web && npm run build`
- `make install`
- `pad item list tasks --all --field phase=PHASE-8 --format json`