### PR TITLE
fix: server-side timeline pagination and reaction toggle

### DIFF
--- a/internal/models/activity.go
+++ b/internal/models/activity.go
@@ -50,5 +50,5 @@ type TimelineEntry struct {
 // TimelineResponse is the paginated response from the timeline endpoint.
 type TimelineResponse struct {
 	Entries []TimelineEntry `json:"entries"`
-	Total   int             `json:"total"`
+	HasMore bool            `json:"has_more"`
 }

--- a/internal/server/handlers_timeline.go
+++ b/internal/server/handlers_timeline.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"sort"
 	"strconv"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 
@@ -11,7 +12,8 @@ import (
 )
 
 // handleListItemTimeline returns a unified, chronological timeline for an item.
-// It merges comments, activities, and versions into a single stream with deduplication.
+// It uses cursor-based pagination: pass `before=<RFC3339>` to get entries older
+// than that timestamp, and `limit=N` to control page size (default 50).
 func (s *Server) handleListItemTimeline(w http.ResponseWriter, r *http.Request) {
 	workspaceID, ok := s.getWorkspaceID(w, r)
 	if !ok {
@@ -25,27 +27,33 @@ func (s *Server) handleListItemTimeline(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	limit := 100
-	offset := 0
+	limit := 50
 	if v := r.URL.Query().Get("limit"); v != "" {
-		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 && n <= 200 {
 			limit = n
 		}
 	}
-	if v := r.URL.Query().Get("offset"); v != "" {
-		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
-			offset = n
+
+	// Cursor: fetch entries before this timestamp. Defaults to now (first page).
+	before := time.Now().UTC().Add(time.Minute) // slight future to include "just now" entries
+	if v := r.URL.Query().Get("before"); v != "" {
+		if t, err := time.Parse(time.RFC3339, v); err == nil {
+			before = t
 		}
 	}
 
-	// Fetch all three data sources.
-	comments, err := s.store.ListComments(item.ID)
+	// Fetch a window from each source. We fetch `limit` from each, then merge
+	// and take the top `limit` from the merged result. This ensures we get enough
+	// entries even after dedup/filtering removes some.
+	perSource := limit
+
+	comments, err := s.store.ListCommentsBeforeTime(item.ID, before, perSource)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "internal_error", err.Error())
 		return
 	}
 
-	// Bulk-load reactions for all comments.
+	// Bulk-load reactions for fetched comments.
 	if len(comments) > 0 {
 		commentIDs := make([]string, len(comments))
 		for i, c := range comments {
@@ -61,35 +69,34 @@ func (s *Server) handleListItemTimeline(w http.ResponseWriter, r *http.Request) 
 		}
 	}
 
-	activities, err := s.store.ListDocumentActivity(item.ID, models.ActivityListParams{Limit: 10000})
+	activities, err := s.store.ListDocumentActivityBeforeTime(item.ID, before, perSource)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "internal_error", err.Error())
 		return
 	}
 
-	versions, err := s.store.ListItemVersions(item.ID)
+	versions, err := s.store.ListItemVersionsBeforeTime(item.ID, before, perSource)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "internal_error", err.Error())
 		return
 	}
 
 	entries := buildTimeline(comments, activities, versions)
-	total := len(entries)
 
-	// Apply pagination.
-	if offset >= len(entries) {
-		entries = nil
+	// Determine if there are more entries beyond this page.
+	hasMore := false
+	if len(entries) > limit {
+		entries = entries[:limit]
+		hasMore = true
 	} else {
-		end := offset + limit
-		if end > len(entries) {
-			end = len(entries)
-		}
-		entries = entries[offset:end]
+		// Even if merged result is <= limit, there may be more in individual sources.
+		// If any source returned its full limit, there's likely more data.
+		hasMore = len(comments) >= perSource || len(activities) >= perSource || len(versions) >= perSource
 	}
 
 	writeJSON(w, http.StatusOK, models.TimelineResponse{
 		Entries: entries,
-		Total:   total,
+		HasMore: hasMore,
 	})
 }
 
@@ -196,4 +203,3 @@ func buildTimeline(comments []models.Comment, activities []models.Activity, vers
 
 	return entries
 }
-

--- a/internal/server/handlers_timeline.go
+++ b/internal/server/handlers_timeline.go
@@ -37,7 +37,10 @@ func (s *Server) handleListItemTimeline(w http.ResponseWriter, r *http.Request) 
 	// Cursor: fetch entries before this timestamp. Defaults to now (first page).
 	before := time.Now().UTC().Add(time.Minute) // slight future to include "just now" entries
 	if v := r.URL.Query().Get("before"); v != "" {
-		if t, err := time.Parse(time.RFC3339, v); err == nil {
+		// Try RFC3339Nano first (sub-second precision), fall back to RFC3339.
+		if t, err := time.Parse(time.RFC3339Nano, v); err == nil {
+			before = t
+		} else if t, err := time.Parse(time.RFC3339, v); err == nil {
 			before = t
 		}
 	}
@@ -126,12 +129,15 @@ func buildTimeline(comments []models.Comment, activities []models.Activity, vers
 	}
 	for i := range comments {
 		c := comments[i]
-		// Skip replies — they'll be nested under their parent.
+		// Nest replies under their parent if the parent was fetched on this page.
+		// If the parent is on a different page, treat the reply as a top-level entry
+		// so it doesn't silently vanish.
 		if c.ParentID != "" {
 			if parent, ok := commentsByID[c.ParentID]; ok {
 				parent.Replies = append(parent.Replies, c)
+				continue
 			}
-			continue
+			// Parent not on this page — fall through and add as top-level.
 		}
 		entry := models.TimelineEntry{
 			ID:        c.ID,

--- a/internal/server/handlers_timeline.go
+++ b/internal/server/handlers_timeline.go
@@ -34,23 +34,26 @@ func (s *Server) handleListItemTimeline(w http.ResponseWriter, r *http.Request) 
 		}
 	}
 
-	// Cursor: fetch entries before this timestamp. Defaults to now (first page).
-	before := time.Now().UTC().Add(time.Minute) // slight future to include "just now" entries
+	// Cursor: fetch entries before this (timestamp, id) pair.
+	// Defaults to now + a future-biased ID to include "just now" entries on first page.
+	before := time.Now().UTC().Add(time.Minute)
+	beforeID := "\xff" // sorts after all UUIDs on first page
 	if v := r.URL.Query().Get("before"); v != "" {
-		// Try RFC3339Nano first (sub-second precision), fall back to RFC3339.
 		if t, err := time.Parse(time.RFC3339Nano, v); err == nil {
 			before = t
 		} else if t, err := time.Parse(time.RFC3339, v); err == nil {
 			before = t
 		}
 	}
+	if v := r.URL.Query().Get("before_id"); v != "" {
+		beforeID = v
+	}
 
-	// Fetch a window from each source. We fetch `limit` from each, then merge
-	// and take the top `limit` from the merged result. This ensures we get enough
-	// entries even after dedup/filtering removes some.
-	perSource := limit
+	// Over-fetch per source (3x limit) to compensate for entries removed by
+	// buildTimeline's dedup/filtering (empty-metadata updates, read actions, etc.).
+	perSource := limit * 3
 
-	comments, err := s.store.ListCommentsBeforeTime(item.ID, before, perSource)
+	comments, err := s.store.ListCommentsBeforeTime(item.ID, before, beforeID, perSource)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "internal_error", err.Error())
 		return
@@ -72,13 +75,13 @@ func (s *Server) handleListItemTimeline(w http.ResponseWriter, r *http.Request) 
 		}
 	}
 
-	activities, err := s.store.ListDocumentActivityBeforeTime(item.ID, before, perSource)
+	activities, err := s.store.ListDocumentActivityBeforeTime(item.ID, before, beforeID, perSource)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "internal_error", err.Error())
 		return
 	}
 
-	versions, err := s.store.ListItemVersionsBeforeTime(item.ID, before, perSource)
+	versions, err := s.store.ListItemVersionsBeforeTime(item.ID, before, beforeID, perSource)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "internal_error", err.Error())
 		return

--- a/internal/server/handlers_timeline.go
+++ b/internal/server/handlers_timeline.go
@@ -205,8 +205,12 @@ func buildTimeline(comments []models.Comment, activities []models.Activity, vers
 		entries = append(entries, entry)
 	}
 
-	// Sort chronologically (newest first).
+	// Sort chronologically (newest first), with ID as tie-breaker for same-second entries.
+	// This must match the SQL ORDER BY (created_at DESC, id DESC) used by the cursor queries.
 	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].CreatedAt.Equal(entries[j].CreatedAt) {
+			return entries[i].ID > entries[j].ID
+		}
 		return entries[i].CreatedAt.After(entries[j].CreatedAt)
 	})
 

--- a/internal/store/activities.go
+++ b/internal/store/activities.go
@@ -196,6 +196,25 @@ func (s *Store) ListDocumentActivity(documentID string, params models.ActivityLi
 	return scanActivitiesWithUser(rows)
 }
 
+// ListDocumentActivityBeforeTime returns activities for a document created before the given time,
+// ordered newest-first, limited to `limit` results. Used for cursor-based timeline pagination.
+func (s *Store) ListDocumentActivityBeforeTime(documentID string, before time.Time, limit int) ([]models.Activity, error) {
+	rows, err := s.db.Query(`
+		SELECT a.id, a.workspace_id, COALESCE(a.document_id, ''), a.action, a.actor, a.source, a.metadata, COALESCE(a.user_id, ''), a.created_at, COALESCE(u.name, '')
+		FROM activities a
+		LEFT JOIN users u ON a.user_id = u.id
+		WHERE a.document_id = ? AND a.created_at < ?
+		ORDER BY a.created_at DESC
+		LIMIT ?
+	`, documentID, before.Format(time.RFC3339), limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	return scanActivitiesWithUser(rows)
+}
+
 func scanActivitiesWithUser(rows interface {
 	Next() bool
 	Scan(dest ...interface{}) error

--- a/internal/store/activities.go
+++ b/internal/store/activities.go
@@ -198,15 +198,16 @@ func (s *Store) ListDocumentActivity(documentID string, params models.ActivityLi
 
 // ListDocumentActivityBeforeTime returns activities for a document created before the given time,
 // ordered newest-first, limited to `limit` results. Used for cursor-based timeline pagination.
-func (s *Store) ListDocumentActivityBeforeTime(documentID string, before time.Time, limit int) ([]models.Activity, error) {
+func (s *Store) ListDocumentActivityBeforeTime(documentID string, before time.Time, beforeID string, limit int) ([]models.Activity, error) {
+	ts := before.Format(time.RFC3339)
 	rows, err := s.db.Query(`
 		SELECT a.id, a.workspace_id, COALESCE(a.document_id, ''), a.action, a.actor, a.source, a.metadata, COALESCE(a.user_id, ''), a.created_at, COALESCE(u.name, '')
 		FROM activities a
 		LEFT JOIN users u ON a.user_id = u.id
-		WHERE a.document_id = ? AND a.created_at <= ?
+		WHERE a.document_id = ? AND (a.created_at < ? OR (a.created_at = ? AND a.id < ?))
 		ORDER BY a.created_at DESC, a.id DESC
 		LIMIT ?
-	`, documentID, before.Format(time.RFC3339), limit)
+	`, documentID, ts, ts, beforeID, limit)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/store/activities.go
+++ b/internal/store/activities.go
@@ -203,8 +203,8 @@ func (s *Store) ListDocumentActivityBeforeTime(documentID string, before time.Ti
 		SELECT a.id, a.workspace_id, COALESCE(a.document_id, ''), a.action, a.actor, a.source, a.metadata, COALESCE(a.user_id, ''), a.created_at, COALESCE(u.name, '')
 		FROM activities a
 		LEFT JOIN users u ON a.user_id = u.id
-		WHERE a.document_id = ? AND a.created_at < ?
-		ORDER BY a.created_at DESC
+		WHERE a.document_id = ? AND a.created_at <= ?
+		ORDER BY a.created_at DESC, a.id DESC
 		LIMIT ?
 	`, documentID, before.Format(time.RFC3339), limit)
 	if err != nil {

--- a/internal/store/comments.go
+++ b/internal/store/comments.go
@@ -103,15 +103,16 @@ func (s *Store) ListComments(itemID string) ([]models.Comment, error) {
 
 // ListCommentsBeforeTime returns comments for an item created before the given time,
 // ordered newest-first, limited to `limit` results. Used for cursor-based timeline pagination.
-func (s *Store) ListCommentsBeforeTime(itemID string, before time.Time, limit int) ([]models.Comment, error) {
+func (s *Store) ListCommentsBeforeTime(itemID string, before time.Time, beforeID string, limit int) ([]models.Comment, error) {
+	ts := before.Format(time.RFC3339)
 	rows, err := s.db.Query(`
 		SELECT c.id, c.item_id, c.workspace_id, c.author, c.body,
 		       c.created_by, c.source, COALESCE(c.activity_id, ''), COALESCE(c.parent_id, ''),
 		       c.created_at, c.updated_at
 		FROM comments c
-		WHERE c.item_id = ? AND c.created_at <= ?
+		WHERE c.item_id = ? AND (c.created_at < ? OR (c.created_at = ? AND c.id < ?))
 		ORDER BY c.created_at DESC, c.id DESC
-		LIMIT ?`, itemID, before.Format(time.RFC3339), limit)
+		LIMIT ?`, itemID, ts, ts, beforeID, limit)
 	if err != nil {
 		return nil, fmt.Errorf("list comments before time: %w", err)
 	}

--- a/internal/store/comments.go
+++ b/internal/store/comments.go
@@ -3,6 +3,7 @@ package store
 import (
 	"database/sql"
 	"fmt"
+	"time"
 
 	"github.com/xarmian/pad/internal/models"
 )
@@ -79,6 +80,40 @@ func (s *Store) ListComments(itemID string) ([]models.Comment, error) {
 		ORDER BY c.created_at ASC`, itemID)
 	if err != nil {
 		return nil, fmt.Errorf("list comments: %w", err)
+	}
+	defer rows.Close()
+
+	var comments []models.Comment
+	for rows.Next() {
+		var c models.Comment
+		var createdAt, updatedAt string
+		if err := rows.Scan(
+			&c.ID, &c.ItemID, &c.WorkspaceID, &c.Author, &c.Body,
+			&c.CreatedBy, &c.Source, &c.ActivityID, &c.ParentID,
+			&createdAt, &updatedAt,
+		); err != nil {
+			return nil, fmt.Errorf("scan comment: %w", err)
+		}
+		c.CreatedAt = parseTime(createdAt)
+		c.UpdatedAt = parseTime(updatedAt)
+		comments = append(comments, c)
+	}
+	return comments, rows.Err()
+}
+
+// ListCommentsBeforeTime returns comments for an item created before the given time,
+// ordered newest-first, limited to `limit` results. Used for cursor-based timeline pagination.
+func (s *Store) ListCommentsBeforeTime(itemID string, before time.Time, limit int) ([]models.Comment, error) {
+	rows, err := s.db.Query(`
+		SELECT c.id, c.item_id, c.workspace_id, c.author, c.body,
+		       c.created_by, c.source, COALESCE(c.activity_id, ''), COALESCE(c.parent_id, ''),
+		       c.created_at, c.updated_at
+		FROM comments c
+		WHERE c.item_id = ? AND c.created_at < ?
+		ORDER BY c.created_at DESC
+		LIMIT ?`, itemID, before.Format(time.RFC3339Nano), limit)
+	if err != nil {
+		return nil, fmt.Errorf("list comments before time: %w", err)
 	}
 	defer rows.Close()
 

--- a/internal/store/comments.go
+++ b/internal/store/comments.go
@@ -109,9 +109,9 @@ func (s *Store) ListCommentsBeforeTime(itemID string, before time.Time, limit in
 		       c.created_by, c.source, COALESCE(c.activity_id, ''), COALESCE(c.parent_id, ''),
 		       c.created_at, c.updated_at
 		FROM comments c
-		WHERE c.item_id = ? AND c.created_at < ?
-		ORDER BY c.created_at DESC
-		LIMIT ?`, itemID, before.Format(time.RFC3339Nano), limit)
+		WHERE c.item_id = ? AND c.created_at <= ?
+		ORDER BY c.created_at DESC, c.id DESC
+		LIMIT ?`, itemID, before.Format(time.RFC3339), limit)
 	if err != nil {
 		return nil, fmt.Errorf("list comments before time: %w", err)
 	}

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -990,17 +990,16 @@ func (s *Store) ListItemVersionsResolved(itemID, currentContent string) ([]model
 	return versions, nil
 }
 
-// ListItemVersions returns all versions for an item.
 // ListItemVersionsBeforeTime returns versions for an item created before the given time,
 // ordered newest-first, limited to `limit` results. Used for cursor-based timeline pagination.
 func (s *Store) ListItemVersionsBeforeTime(itemID string, before time.Time, limit int) ([]models.Version, error) {
 	rows, err := s.db.Query(`
 		SELECT id, item_id, content, change_summary, created_by, source, is_diff, created_at
 		FROM item_versions
-		WHERE item_id = ? AND created_at < ?
-		ORDER BY created_at DESC
+		WHERE item_id = ? AND created_at <= ?
+		ORDER BY created_at DESC, id DESC
 		LIMIT ?
-	`, itemID, before.Format(time.RFC3339Nano), limit)
+	`, itemID, before.Format(time.RFC3339), limit)
 	if err != nil {
 		return nil, err
 	}
@@ -1021,6 +1020,7 @@ func (s *Store) ListItemVersionsBeforeTime(itemID string, before time.Time, limi
 	return versions, rows.Err()
 }
 
+// ListItemVersions returns all versions for an item.
 func (s *Store) ListItemVersions(itemID string) ([]models.Version, error) {
 	rows, err := s.db.Query(`
 		SELECT id, item_id, content, change_summary, created_by, source, is_diff, created_at

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -991,6 +991,36 @@ func (s *Store) ListItemVersionsResolved(itemID, currentContent string) ([]model
 }
 
 // ListItemVersions returns all versions for an item.
+// ListItemVersionsBeforeTime returns versions for an item created before the given time,
+// ordered newest-first, limited to `limit` results. Used for cursor-based timeline pagination.
+func (s *Store) ListItemVersionsBeforeTime(itemID string, before time.Time, limit int) ([]models.Version, error) {
+	rows, err := s.db.Query(`
+		SELECT id, item_id, content, change_summary, created_by, source, is_diff, created_at
+		FROM item_versions
+		WHERE item_id = ? AND created_at < ?
+		ORDER BY created_at DESC
+		LIMIT ?
+	`, itemID, before.Format(time.RFC3339Nano), limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var versions []models.Version
+	for rows.Next() {
+		var v models.Version
+		var createdAt string
+		var isDiff int
+		if err := rows.Scan(&v.ID, &v.DocumentID, &v.Content, &v.ChangeSummary, &v.CreatedBy, &v.Source, &isDiff, &createdAt); err != nil {
+			return nil, err
+		}
+		v.IsDiff = isDiff == 1
+		v.CreatedAt = parseTime(createdAt)
+		versions = append(versions, v)
+	}
+	return versions, rows.Err()
+}
+
 func (s *Store) ListItemVersions(itemID string) ([]models.Version, error) {
 	rows, err := s.db.Query(`
 		SELECT id, item_id, content, change_summary, created_by, source, is_diff, created_at

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -992,14 +992,15 @@ func (s *Store) ListItemVersionsResolved(itemID, currentContent string) ([]model
 
 // ListItemVersionsBeforeTime returns versions for an item created before the given time,
 // ordered newest-first, limited to `limit` results. Used for cursor-based timeline pagination.
-func (s *Store) ListItemVersionsBeforeTime(itemID string, before time.Time, limit int) ([]models.Version, error) {
+func (s *Store) ListItemVersionsBeforeTime(itemID string, before time.Time, beforeID string, limit int) ([]models.Version, error) {
+	ts := before.Format(time.RFC3339)
 	rows, err := s.db.Query(`
 		SELECT id, item_id, content, change_summary, created_by, source, is_diff, created_at
 		FROM item_versions
-		WHERE item_id = ? AND created_at <= ?
+		WHERE item_id = ? AND (created_at < ? OR (created_at = ? AND id < ?))
 		ORDER BY created_at DESC, id DESC
 		LIMIT ?
-	`, itemID, before.Format(time.RFC3339), limit)
+	`, itemID, ts, ts, beforeID, limit)
 	if err != nil {
 		return nil, err
 	}

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -279,10 +279,11 @@ export const api = {
 	// ── Timeline ──────────────────────────────────────────────────────────────
 
 	timeline: {
-		list: (ws: string, itemSlug: string, params?: { limit?: number; before?: string }) => {
+		list: (ws: string, itemSlug: string, params?: { limit?: number; before?: string; before_id?: string }) => {
 			const qs = new URLSearchParams();
 			if (params?.limit != null) qs.set('limit', String(params.limit));
 			if (params?.before) qs.set('before', params.before);
+			if (params?.before_id) qs.set('before_id', params.before_id);
 			const suffix = qs.toString() ? `?${qs}` : '';
 			return request<TimelineResponse>(`/workspaces/${ws}/items/${itemSlug}/timeline${suffix}`);
 		}

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -279,10 +279,10 @@ export const api = {
 	// ── Timeline ──────────────────────────────────────────────────────────────
 
 	timeline: {
-		list: (ws: string, itemSlug: string, params?: { limit?: number; offset?: number }) => {
+		list: (ws: string, itemSlug: string, params?: { limit?: number; before?: string }) => {
 			const qs = new URLSearchParams();
 			if (params?.limit != null) qs.set('limit', String(params.limit));
-			if (params?.offset != null) qs.set('offset', String(params.offset));
+			if (params?.before) qs.set('before', params.before);
 			const suffix = qs.toString() ? `?${qs}` : '';
 			return request<TimelineResponse>(`/workspaces/${ws}/items/${itemSlug}/timeline${suffix}`);
 		}

--- a/web/src/lib/components/layout/Sidebar.svelte
+++ b/web/src/lib/components/layout/Sidebar.svelte
@@ -6,6 +6,7 @@
 	import { workspaceStore } from '$lib/stores/workspace.svelte';
 	import { collectionStore } from '$lib/stores/collections.svelte';
 	import { uiStore } from '$lib/stores/ui.svelte';
+	import { authStore } from '$lib/stores/auth.svelte';
 	import { goto } from '$app/navigation';
 	import { api } from '$lib/api/client';
 	import { parseSchema, parseSettings, itemUrlId } from '$lib/types';
@@ -130,12 +131,10 @@
 		}
 		document.documentElement.setAttribute('data-theme', currentTheme);
 
-		try {
-			const session = await api.auth.session();
-			if (session.authenticated && session.user) {
-				currentAuthUser = session.user;
-			}
-		} catch {}
+		// Read from the global auth store (populated by root layout).
+		if (authStore.authenticated && authStore.user) {
+			currentAuthUser = authStore.user;
+		}
 
 		try {
 			const health = await api.health();

--- a/web/src/lib/components/timeline/ItemTimeline.svelte
+++ b/web/src/lib/components/timeline/ItemTimeline.svelte
@@ -60,7 +60,10 @@
 			const resp: TimelineResponse = await api.timeline.list(wsSlug, itemSlug, {
 				before: oldest.created_at
 			});
-			entries = [...entries, ...resp.entries];
+			// Deduplicate by ID to handle boundary overlap from <= queries.
+			const existingIds = new Set(entries.map((e) => e.id));
+			const newEntries = resp.entries.filter((e) => !existingIds.has(e.id));
+			entries = [...entries, ...newEntries];
 			hasMore = resp.has_more;
 		} catch (err: any) {
 			error = err?.message ?? 'Failed to load more';
@@ -83,9 +86,22 @@
 		'reaction_removed'
 	]);
 
-	const unsubscribe = sseService.onItemEvent((event) => {
+	const unsubscribe = sseService.onItemEvent(async (event) => {
 		if (relevantEvents.has(event.type)) {
-			loadTimeline();
+			// Fetch only the newest entries and prepend, preserving paginated state.
+			try {
+				const resp: TimelineResponse = await api.timeline.list(wsSlug, itemSlug);
+				const existingIds = new Set(entries.map((e) => e.id));
+				const newEntries = resp.entries.filter((e) => !existingIds.has(e.id));
+				if (newEntries.length > 0) {
+					entries = [...newEntries, ...entries];
+				}
+				// Also update existing entries (e.g., reaction changes on existing comments).
+				const newById = new Map(resp.entries.map((e) => [e.id, e]));
+				entries = entries.map((e) => newById.get(e.id) ?? e);
+			} catch {
+				// Silently ignore SSE refresh failures.
+			}
 		}
 	});
 

--- a/web/src/lib/components/timeline/ItemTimeline.svelte
+++ b/web/src/lib/components/timeline/ItemTimeline.svelte
@@ -48,7 +48,8 @@
 		loadingMore = true;
 		try {
 			const resp: TimelineResponse = await api.timeline.list(wsSlug, itemSlug, {
-				before: oldest.created_at
+				before: oldest.created_at,
+				before_id: oldest.id
 			});
 			// Deduplicate by ID to handle boundary overlap from <= queries.
 			const existingIds = new Set(entries.map((e) => e.id));
@@ -78,22 +79,40 @@
 
 	const unsubscribe = sseService.onItemEvent(async (event) => {
 		if (relevantEvents.has(event.type)) {
-			// Fetch only the newest entries and prepend, preserving paginated state.
+			// Fetch the newest page and merge with existing entries, preserving paginated state.
 			try {
 				const resp: TimelineResponse = await api.timeline.list(wsSlug, itemSlug);
+				const freshIds = new Set(resp.entries.map((e) => e.id));
 				const existingIds = new Set(entries.map((e) => e.id));
+
+				// Prepend genuinely new entries.
 				const newEntries = resp.entries.filter((e) => !existingIds.has(e.id));
-				if (newEntries.length > 0) {
-					entries = [...newEntries, ...entries];
-				}
-				// Also update existing entries (e.g., reaction changes on existing comments).
-				const newById = new Map(resp.entries.map((e) => [e.id, e]));
-				entries = entries.map((e) => newById.get(e.id) ?? e);
+
+				// Update existing entries that are in the fresh response (e.g., reaction changes).
+				// Remove entries from the first page window that no longer appear (e.g., deleted comments).
+				const freshById = new Map(resp.entries.map((e) => [e.id, e]));
+				const updatedExisting = entries
+					.filter((e) => {
+						// Keep entries that are still in the fresh page, OR that are from older pages
+						// (not in the fresh page's time window at all).
+						return freshById.has(e.id) || !isInFirstPageWindow(e, resp.entries);
+					})
+					.map((e) => freshById.get(e.id) ?? e);
+
+				entries = [...newEntries, ...updatedExisting];
 			} catch {
 				// Silently ignore SSE refresh failures.
 			}
 		}
 	});
+
+	/** Check if an entry falls within the time window of the first-page response. */
+	function isInFirstPageWindow(entry: TimelineEntry, firstPage: TimelineEntry[]): boolean {
+		if (firstPage.length === 0) return false;
+		const newest = firstPage[0].created_at;
+		const oldest = firstPage[firstPage.length - 1].created_at;
+		return entry.created_at <= newest && entry.created_at >= oldest;
+	}
 
 	onDestroy(() => {
 		unsubscribe();

--- a/web/src/lib/components/timeline/ItemTimeline.svelte
+++ b/web/src/lib/components/timeline/ItemTimeline.svelte
@@ -28,6 +28,10 @@
 	// Current user ID for reaction toggle — read from the global auth store.
 	let currentUserId = $derived(authStore.userId);
 
+	// Track IDs from the most recent first-page fetch, used by SSE merge
+	// to detect deletions without incorrectly removing older-page entries.
+	let firstPageIds = $state<Set<string>>(new Set());
+
 	async function loadTimeline() {
 		loading = true;
 		error = '';
@@ -35,6 +39,7 @@
 			const resp: TimelineResponse = await api.timeline.list(wsSlug, itemSlug);
 			entries = resp.entries;
 			hasMore = resp.has_more;
+			firstPageIds = new Set(resp.entries.map((e) => e.id));
 		} catch (err: any) {
 			error = err?.message ?? 'Failed to load timeline';
 		} finally {
@@ -88,31 +93,26 @@
 				// Prepend genuinely new entries.
 				const newEntries = resp.entries.filter((e) => !existingIds.has(e.id));
 
-				// Update existing entries that are in the fresh response (e.g., reaction changes).
-				// Remove entries from the first page window that no longer appear (e.g., deleted comments).
+				// Update existing entries from the fresh response (e.g., reaction changes).
+				// Remove entries that were previously on the first page but are now gone (deleted).
+				// Keep all entries from older pages (loaded via "Load more") untouched.
 				const freshById = new Map(resp.entries.map((e) => [e.id, e]));
 				const updatedExisting = entries
 					.filter((e) => {
-						// Keep entries that are still in the fresh page, OR that are from older pages
-						// (not in the fresh page's time window at all).
-						return freshById.has(e.id) || !isInFirstPageWindow(e, resp.entries);
+						// If this entry was in the previous first page and is no longer in
+						// the fresh response, it was deleted — remove it.
+						if (firstPageIds.has(e.id) && !freshIds.has(e.id)) return false;
+						return true;
 					})
 					.map((e) => freshById.get(e.id) ?? e);
 
 				entries = [...newEntries, ...updatedExisting];
+				firstPageIds = freshIds;
 			} catch {
 				// Silently ignore SSE refresh failures.
 			}
 		}
 	});
-
-	/** Check if an entry falls within the time window of the first-page response. */
-	function isInFirstPageWindow(entry: TimelineEntry, firstPage: TimelineEntry[]): boolean {
-		if (firstPage.length === 0) return false;
-		const newest = firstPage[0].created_at;
-		const oldest = firstPage[firstPage.length - 1].created_at;
-		return entry.created_at <= newest && entry.created_at >= oldest;
-	}
 
 	onDestroy(() => {
 		unsubscribe();

--- a/web/src/lib/components/timeline/ItemTimeline.svelte
+++ b/web/src/lib/components/timeline/ItemTimeline.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { onDestroy } from 'svelte';
+	import { onMount, onDestroy } from 'svelte';
 	import { api } from '$lib/api/client';
 	import { sseService } from '$lib/services/sse.svelte';
 	import type { TimelineEntry, TimelineResponse, Item } from '$lib/types';
@@ -18,10 +18,25 @@
 	let { wsSlug, itemSlug, currentContent, items = [], onRestore }: Props = $props();
 
 	let entries: TimelineEntry[] = $state([]);
-	let total: number = $state(0);
+	let hasMore: boolean = $state(false);
 	let loading: boolean = $state(false);
+	let loadingMore: boolean = $state(false);
 	let error: string = $state('');
 	let newBody: string = $state('');
+
+	// Current user ID for reaction toggle (fetched from auth session).
+	let currentUserId: string = $state('');
+
+	onMount(async () => {
+		try {
+			const session = await api.auth.session();
+			if (session.user?.id) {
+				currentUserId = session.user.id;
+			}
+		} catch {
+			// Auth may not be configured — proceed without user ID.
+		}
+	});
 
 	async function loadTimeline() {
 		loading = true;
@@ -29,11 +44,28 @@
 		try {
 			const resp: TimelineResponse = await api.timeline.list(wsSlug, itemSlug);
 			entries = resp.entries;
-			total = resp.total;
+			hasMore = resp.has_more;
 		} catch (err: any) {
 			error = err?.message ?? 'Failed to load timeline';
 		} finally {
 			loading = false;
+		}
+	}
+
+	async function loadMore() {
+		if (loadingMore || entries.length === 0) return;
+		const oldest = entries[entries.length - 1];
+		loadingMore = true;
+		try {
+			const resp: TimelineResponse = await api.timeline.list(wsSlug, itemSlug, {
+				before: oldest.created_at
+			});
+			entries = [...entries, ...resp.entries];
+			hasMore = resp.has_more;
+		} catch (err: any) {
+			error = err?.message ?? 'Failed to load more';
+		} finally {
+			loadingMore = false;
 		}
 	}
 
@@ -139,8 +171,8 @@
 <section class="timeline">
 	<header class="timeline-header">
 		<h3 class="timeline-title">Timeline</h3>
-		{#if total > 0}
-			<span class="entry-count">{total}</span>
+		{#if entries.length > 0}
+			<span class="entry-count">{entries.length}{hasMore ? '+' : ''}</span>
 		{/if}
 	</header>
 
@@ -191,6 +223,7 @@
 								comment={entry.comment}
 								{wsSlug}
 								{items}
+								{currentUserId}
 								onDelete={handleDelete}
 								onReply={handleReply}
 								onReaction={handleReaction}
@@ -215,6 +248,12 @@
 				<div class="empty">No timeline entries yet.</div>
 			{/if}
 		</div>
+
+		{#if hasMore}
+			<button class="load-more-btn" type="button" disabled={loadingMore} onclick={loadMore}>
+				{loadingMore ? 'Loading...' : 'Load more'}
+			</button>
+		{/if}
 	{/if}
 </section>
 
@@ -421,5 +460,29 @@
 		padding: var(--space-6);
 		color: var(--text-muted);
 		font-size: 0.9em;
+	}
+
+	.load-more-btn {
+		display: block;
+		width: 100%;
+		padding: var(--space-2) var(--space-4);
+		background: var(--bg-secondary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+		color: var(--text-muted);
+		font-size: 0.85em;
+		font-weight: 500;
+		cursor: pointer;
+		text-align: center;
+	}
+
+	.load-more-btn:hover:not(:disabled) {
+		color: var(--text-primary);
+		border-color: var(--accent-blue);
+	}
+
+	.load-more-btn:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
 	}
 </style>

--- a/web/src/lib/components/timeline/ItemTimeline.svelte
+++ b/web/src/lib/components/timeline/ItemTimeline.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
-	import { onMount, onDestroy } from 'svelte';
+	import { onDestroy } from 'svelte';
 	import { api } from '$lib/api/client';
 	import { sseService } from '$lib/services/sse.svelte';
+	import { authStore } from '$lib/stores/auth.svelte';
 	import type { TimelineEntry, TimelineResponse, Item } from '$lib/types';
 	import TimelineCommentCard from './TimelineCommentCard.svelte';
 	import TimelineActivityCard from './TimelineActivityCard.svelte';
@@ -24,19 +25,8 @@
 	let error: string = $state('');
 	let newBody: string = $state('');
 
-	// Current user ID for reaction toggle (fetched from auth session).
-	let currentUserId: string = $state('');
-
-	onMount(async () => {
-		try {
-			const session = await api.auth.session();
-			if (session.user?.id) {
-				currentUserId = session.user.id;
-			}
-		} catch {
-			// Auth may not be configured — proceed without user ID.
-		}
-	});
+	// Current user ID for reaction toggle — read from the global auth store.
+	let currentUserId = $derived(authStore.userId);
 
 	async function loadTimeline() {
 		loading = true;

--- a/web/src/lib/components/timeline/TimelineCommentCard.svelte
+++ b/web/src/lib/components/timeline/TimelineCommentCard.svelte
@@ -7,13 +7,14 @@
 		comment: Comment;
 		wsSlug: string;
 		items: Item[];
+		currentUserId?: string;
 		onDelete: (commentId: string) => void;
 		onReply: (commentId: string, body: string) => void | Promise<void>;
 		onReaction: (commentId: string, emoji: string) => void;
 		onRemoveReaction: (commentId: string, emoji: string) => void;
 	}
 
-	let { comment, wsSlug, items, onDelete, onReply, onReaction, onRemoveReaction }: Props = $props();
+	let { comment, wsSlug, items, currentUserId = '', onDelete, onReply, onReaction, onRemoveReaction }: Props = $props();
 
 	let showReplyForm = $state(false);
 	let replyBody = $state('');
@@ -87,20 +88,30 @@
 		return labels[source] ?? source;
 	}
 
+	function hasMyReaction(reactions: Reaction[] | undefined, emoji: string): boolean {
+		if (!reactions || !currentUserId) return false;
+		return reactions.some((r) => r.emoji === emoji && r.user_id === currentUserId);
+	}
+
 	function toggleReaction(emoji: string) {
-		// Always POST — the server uses ON CONFLICT DO NOTHING if the current user
-		// already reacted with this emoji.  A dedicated "remove my reaction" button
-		// or a second click handled server-side is needed for proper toggle, but
-		// for now adding is safe and idempotent.
-		onReaction(comment.id, emoji);
+		if (hasMyReaction(comment.reactions, emoji)) {
+			onRemoveReaction(comment.id, emoji);
+		} else {
+			onReaction(comment.id, emoji);
+		}
 	}
 
 	function handleAddReaction(emoji: string) {
+		// From the picker — always add.
 		onReaction(comment.id, emoji);
 	}
 
 	function toggleReplyReaction(reply: Comment, emoji: string) {
-		onReaction(reply.id, emoji);
+		if (hasMyReaction(reply.reactions, emoji)) {
+			onRemoveReaction(reply.id, emoji);
+		} else {
+			onReaction(reply.id, emoji);
+		}
 	}
 
 	function handleAddReplyReaction(reply: Comment, emoji: string) {
@@ -145,6 +156,7 @@
 				{#each reactionGroups as group (group.emoji)}
 					<button
 						class="reaction-chip"
+						class:mine={hasMyReaction(comment.reactions, group.emoji)}
 						type="button"
 						title={group.actors.join(', ')}
 						onclick={() => toggleReaction(group.emoji)}
@@ -214,6 +226,7 @@
 							{#each replyReactionGroups as group (group.emoji)}
 								<button
 									class="reaction-chip"
+									class:mine={hasMyReaction(reply.reactions, group.emoji)}
 									type="button"
 									title={group.actors.join(', ')}
 									onclick={() => toggleReplyReaction(reply, group.emoji)}
@@ -381,6 +394,11 @@
 		cursor: pointer;
 		font-size: 0.8em;
 		line-height: 1.5;
+	}
+
+	.reaction-chip.mine {
+		border-color: var(--accent-blue);
+		background: color-mix(in srgb, var(--accent-blue) 12%, transparent);
 	}
 
 	.reaction-chip:hover {

--- a/web/src/lib/stores/auth.svelte.ts
+++ b/web/src/lib/stores/auth.svelte.ts
@@ -14,8 +14,10 @@ export const authStore = {
 		loading = true;
 		try {
 			session = await api.auth.session();
-		} catch {
+		} catch (err) {
 			session = null;
+			loading = false;
+			throw err; // Re-throw so callers can distinguish fetch errors from "not authenticated".
 		} finally {
 			loading = false;
 		}

--- a/web/src/lib/stores/auth.svelte.ts
+++ b/web/src/lib/stores/auth.svelte.ts
@@ -1,0 +1,28 @@
+import { api, type AuthSession } from '$lib/api/client';
+
+let session = $state<AuthSession | null>(null);
+let loading = $state(false);
+
+export const authStore = {
+	get session() { return session; },
+	get user() { return session?.user ?? null; },
+	get userId() { return session?.user?.id ?? ''; },
+	get authenticated() { return session?.authenticated ?? false; },
+	get loading() { return loading; },
+
+	async load() {
+		loading = true;
+		try {
+			session = await api.auth.session();
+		} catch {
+			session = null;
+		} finally {
+			loading = false;
+		}
+		return session;
+	},
+
+	clear() {
+		session = null;
+	}
+};

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -396,7 +396,7 @@ export interface TimelineEntry {
 
 export interface TimelineResponse {
 	entries: TimelineEntry[];
-	total: number;
+	has_more: boolean;
 }
 
 // ─── Views ───────────────────────────────────────────────────────────────────

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -3,8 +3,8 @@
 	import { onMount } from 'svelte';
 	import { goto } from '$app/navigation';
 	import { page } from '$app/state';
-	import { api } from '$lib/api/client';
 	import { workspaceStore } from '$lib/stores/workspace.svelte';
+	import { authStore } from '$lib/stores/auth.svelte';
 	import { uiStore } from '$lib/stores/ui.svelte';
 	import Sidebar from '$lib/components/layout/Sidebar.svelte';
 	import CommandPalette from '$lib/components/search/CommandPalette.svelte';
@@ -22,7 +22,14 @@
 	onMount(async () => {
 		// Check auth status before loading the app
 		try {
-			const auth = await api.auth.session();
+			const auth = await authStore.load();
+			if (!auth) {
+				if (!isAuthPage) {
+					goto('/login', { replaceState: true });
+				}
+				authReady = true;
+				return;
+			}
 			if (auth.setup_required) {
 				if (!isAuthPage) {
 					goto('/login', { replaceState: true });

--- a/web/src/routes/login/+page.svelte
+++ b/web/src/routes/login/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { api } from '$lib/api/client';
+	import { authStore } from '$lib/stores/auth.svelte';
 	import { goto } from '$app/navigation';
 	import SetupRequiredNotice from '$lib/components/auth/SetupRequiredNotice.svelte';
 
@@ -40,6 +41,7 @@
 		loading = true;
 		try {
 			await api.auth.login(email, password);
+			await authStore.load(); // Refresh global auth state before navigating.
 			await goto('/', { replaceState: true });
 		} catch (err: unknown) {
 			if (err instanceof Error) {


### PR DESCRIPTION
Closes #55, closes #56.

## Summary

- **Cursor-based timeline pagination (#55)**: The `/timeline` endpoint now accepts `before` (RFC3339 timestamp) and `limit` query params. Instead of loading all data into memory, it fetches a small window from each source (comments, activities, versions) and merges just that window. Response includes `has_more` boolean. Frontend shows a "Load more" button.
- **Reaction toggle with user identity (#56)**: `ItemTimeline` fetches the current user's ID from the auth session on mount and passes it to `TimelineCommentCard`. Clicking an existing reaction chip now properly toggles — adds if not yet reacted, removes if already reacted. Own reaction chips are visually highlighted with a blue border.

## Test plan

- [ ] `go test ./...` — all Go tests pass
- [ ] `npx svelte-check` — 0 errors
- [ ] `make install` — builds and runs
- [ ] Open an item with history → timeline loads with cursor pagination
- [ ] Scroll down → "Load more" button appears if more entries exist
- [ ] Add a reaction → chip appears highlighted (blue border = yours)
- [ ] Click same chip → reaction is removed
- [ ] Another user's reaction chips are not highlighted