### PR TITLE
feat: agent roles — role-based (user, role) assignment for items

### DIFF
--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -82,6 +82,7 @@ func main() {
 		libraryGroupCmd(),
 		agentCmd(),
 		githubCmd(),
+		roleCmd(),
 		webhooksCmd(),
 		completionCmd(),
 	)
@@ -1623,6 +1624,7 @@ func createCmd() *cobra.Command {
 		priority   string
 		status     string
 		assignee   string
+		roleFlag   string
 		phase      string
 		category   string
 		parentSlug string
@@ -1659,9 +1661,6 @@ Run with --help-collections to see available collections and their status values
 			}
 			if priority != "" {
 				fields["priority"] = priority
-			}
-			if assignee != "" {
-				fields["assignee"] = assignee
 			}
 			if phase != "" {
 				// Resolve phase slug to item ID
@@ -1701,6 +1700,42 @@ Run with --help-collections to see available collections and their status values
 				Tags:    tags,
 			}
 
+			// Resolve --assign (user name/email → user ID)
+			if assignee != "" {
+				members, merr := client.ListWorkspaceMembers(ws)
+				if merr != nil {
+					return fmt.Errorf("resolve assignee: %w", merr)
+				}
+				var found bool
+				for _, m := range members {
+					if strings.EqualFold(m.UserName, assignee) || strings.EqualFold(m.UserEmail, assignee) {
+						input.AssignedUserID = &m.UserID
+						found = true
+						break
+					}
+				}
+				if !found {
+					return fmt.Errorf("user %q not found in workspace members", assignee)
+				}
+			}
+
+			// Resolve --role (role slug → role ID)
+			if roleFlag != "" {
+				role, rerr := client.GetAgentRole(ws, roleFlag)
+				if rerr != nil {
+					return fmt.Errorf("resolve role: %w", rerr)
+				}
+				if role == nil || role.ID == "" {
+					// Check if any roles exist
+					roles, _ := client.ListAgentRoles(ws)
+					if len(roles) == 0 {
+						fmt.Fprintf(os.Stderr, "No roles found. Create one with: pad role create 'Implementer' --description 'Writes code, builds features'\n")
+					}
+					return fmt.Errorf("role %q not found", roleFlag)
+				}
+				input.AgentRoleID = &role.ID
+			}
+
 			item, err := client.CreateItem(ws, collSlug, input)
 			if err != nil {
 				return err
@@ -1731,7 +1766,8 @@ Run with --help-collections to see available collections and their status values
 	cmd.Flags().BoolVar(&useStdin, "stdin", false, "read content from stdin")
 	cmd.Flags().StringVar(&priority, "priority", "", "priority field value")
 	cmd.Flags().StringVar(&status, "status", "", "status field value")
-	cmd.Flags().StringVar(&assignee, "assignee", "", "assignee field value")
+	cmd.Flags().StringVar(&assignee, "assign", "", "assign to user (name or email)")
+	cmd.Flags().StringVar(&roleFlag, "role", "", "assign agent role (slug)")
 	cmd.Flags().StringVar(&phase, "phase", "", "phase relation (slug or ID)")
 	cmd.Flags().StringVar(&category, "category", "", "category field value")
 	cmd.Flags().StringVar(&parentSlug, "parent", "", "parent item slug for nesting")
@@ -1763,6 +1799,7 @@ func listCmd() *cobra.Command {
 		statusFilter   string
 		priorityFilter string
 		assigneeFilter string
+		roleFilter     string
 		sortBy         string
 		groupBy        string
 		limitNum       int
@@ -1805,7 +1842,19 @@ Examples:
 				params.Set("priority", priorityFilter)
 			}
 			if assigneeFilter != "" {
-				params.Set("assignee", assigneeFilter)
+				// Resolve user name to ID for the API filter
+				members, merr := client.ListWorkspaceMembers(ws)
+				if merr == nil {
+					for _, m := range members {
+						if strings.EqualFold(m.UserName, assigneeFilter) || strings.EqualFold(m.UserEmail, assigneeFilter) {
+							params.Set("assigned_user_id", m.UserID)
+							break
+						}
+					}
+				}
+			}
+			if roleFilter != "" {
+				params.Set("agent_role_id", roleFilter)
 			}
 			if sortBy != "" {
 				params.Set("sort", sortBy)
@@ -1857,7 +1906,8 @@ Examples:
 
 	cmd.Flags().StringVar(&statusFilter, "status", "", "filter by status (comma-separated)")
 	cmd.Flags().StringVar(&priorityFilter, "priority", "", "filter by priority")
-	cmd.Flags().StringVar(&assigneeFilter, "assignee", "", "filter by assignee")
+	cmd.Flags().StringVar(&assigneeFilter, "assign", "", "filter by assigned user (name or email)")
+	cmd.Flags().StringVar(&roleFilter, "role", "", "filter by agent role (slug)")
 	cmd.Flags().StringVar(&sortBy, "sort", "", "sort order (e.g. priority:desc,created_at:asc)")
 	cmd.Flags().StringVar(&groupBy, "group-by", "", "group results by field")
 	cmd.Flags().IntVar(&limitNum, "limit", 0, "max number of items to return")
@@ -2097,6 +2147,7 @@ func updateCmd() *cobra.Command {
 		status     string
 		priority   string
 		assignee   string
+		roleFlag   string
 		phase      string
 		category   string
 		tags       string
@@ -2167,9 +2218,6 @@ Examples:
 				if priority != "" {
 					existingFields["priority"] = priority
 				}
-				if assignee != "" {
-					existingFields["assignee"] = assignee
-				}
 				if phase != "" {
 					// Resolve phase slug to item ID
 					phaseItem, err := client.GetItem(ws, phase)
@@ -2192,6 +2240,41 @@ Examples:
 				fieldsJSON, _ := json.Marshal(existingFields)
 				fieldsStr := string(fieldsJSON)
 				input.Fields = &fieldsStr
+			}
+
+			// Resolve --assign (user name/email → user ID)
+			if assignee != "" {
+				members, merr := client.ListWorkspaceMembers(ws)
+				if merr != nil {
+					return fmt.Errorf("resolve assignee: %w", merr)
+				}
+				var found bool
+				for _, m := range members {
+					if strings.EqualFold(m.UserName, assignee) || strings.EqualFold(m.UserEmail, assignee) {
+						input.AssignedUserID = &m.UserID
+						found = true
+						break
+					}
+				}
+				if !found {
+					return fmt.Errorf("user %q not found in workspace members", assignee)
+				}
+			}
+
+			// Resolve --role (role slug → role ID)
+			if roleFlag != "" {
+				role, rerr := client.GetAgentRole(ws, roleFlag)
+				if rerr != nil {
+					return fmt.Errorf("resolve role: %w", rerr)
+				}
+				if role == nil || role.ID == "" {
+					roles, _ := client.ListAgentRoles(ws)
+					if len(roles) == 0 {
+						fmt.Fprintf(os.Stderr, "No roles found. Create one with: pad role create 'Implementer' --description 'Writes code, builds features'\n")
+					}
+					return fmt.Errorf("role %q not found", roleFlag)
+				}
+				input.AgentRoleID = &role.ID
 			}
 
 			updated, err := client.UpdateItem(ws, slug, input)
@@ -2221,7 +2304,8 @@ Examples:
 	cmd.Flags().BoolVar(&useStdin, "stdin", false, "read content from stdin")
 	cmd.Flags().StringVar(&status, "status", "", "update status field")
 	cmd.Flags().StringVar(&priority, "priority", "", "update priority field")
-	cmd.Flags().StringVar(&assignee, "assignee", "", "update assignee field")
+	cmd.Flags().StringVar(&assignee, "assign", "", "assign to user (name or email)")
+	cmd.Flags().StringVar(&roleFlag, "role", "", "assign agent role (slug)")
 	cmd.Flags().StringVar(&phase, "phase", "", "update phase relation")
 	cmd.Flags().StringVar(&category, "category", "", "update category field")
 	cmd.Flags().StringVar(&tags, "tags", "", "update tags (JSON array)")
@@ -4176,6 +4260,104 @@ func watchCmd() *cobra.Command {
 				return fmt.Errorf("reading event stream: %w", err)
 			}
 
+			return nil
+		},
+	}
+}
+
+// --- agent roles ---
+
+func roleCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "role",
+		Short: "Manage agent roles",
+		Long:  "Agent roles define capability specializations (e.g. Planner, Implementer, Reviewer) for human-agent work assignment.",
+	}
+	cmd.AddCommand(roleListCmd(), roleCreateCmd(), roleDeleteCmd())
+	return cmd
+}
+
+func roleListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List agent roles in the workspace",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, _ := getClient()
+			ws := getWorkspace()
+			roles, err := client.ListAgentRoles(ws)
+			if err != nil {
+				return err
+			}
+			if formatFlag == "json" {
+				return cli.PrintJSON(roles)
+			}
+			if len(roles) == 0 {
+				fmt.Println("No roles defined yet.")
+				fmt.Println("Create one with: pad role create 'Implementer' --description 'Writes code, builds features'")
+				return nil
+			}
+			w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+			fmt.Fprintln(w, "SLUG\tNAME\tDESCRIPTION\tITEMS")
+			for _, r := range roles {
+				icon := r.Icon
+				if icon != "" {
+					icon += " "
+				}
+				fmt.Fprintf(w, "%s\t%s%s\t%s\t%d\n", r.Slug, icon, r.Name, r.Description, r.ItemCount)
+			}
+			w.Flush()
+			return nil
+		},
+	}
+}
+
+func roleCreateCmd() *cobra.Command {
+	var description, icon string
+
+	cmd := &cobra.Command{
+		Use:   "create <name>",
+		Short: "Create a new agent role",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, _ := getClient()
+			ws := getWorkspace()
+			input := models.AgentRoleCreate{
+				Name:        args[0],
+				Description: description,
+				Icon:        icon,
+			}
+			role, err := client.CreateAgentRole(ws, input)
+			if err != nil {
+				return err
+			}
+			if formatFlag == "json" {
+				return cli.PrintJSON(role)
+			}
+			iconStr := ""
+			if role.Icon != "" {
+				iconStr = role.Icon + " "
+			}
+			fmt.Printf("Created role %s%s (%s)\n", iconStr, role.Name, role.Slug)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&description, "description", "", "role description")
+	cmd.Flags().StringVar(&icon, "icon", "", "role icon (emoji)")
+	return cmd
+}
+
+func roleDeleteCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "delete <slug>",
+		Short: "Delete an agent role",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, _ := getClient()
+			ws := getWorkspace()
+			if err := client.DeleteAgentRole(ws, args[0]); err != nil {
+				return err
+			}
+			fmt.Printf("Deleted role %s\n", args[0])
 			return nil
 		},
 	}

--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -1844,13 +1844,19 @@ Examples:
 			if assigneeFilter != "" {
 				// Resolve user name to ID for the API filter
 				members, merr := client.ListWorkspaceMembers(ws)
-				if merr == nil {
-					for _, m := range members {
-						if strings.EqualFold(m.UserName, assigneeFilter) || strings.EqualFold(m.UserEmail, assigneeFilter) {
-							params.Set("assigned_user_id", m.UserID)
-							break
-						}
+				if merr != nil {
+					return fmt.Errorf("failed to resolve --assign filter: %w", merr)
+				}
+				var resolved bool
+				for _, m := range members {
+					if strings.EqualFold(m.UserName, assigneeFilter) || strings.EqualFold(m.UserEmail, assigneeFilter) {
+						params.Set("assigned_user_id", m.UserID)
+						resolved = true
+						break
 					}
+				}
+				if !resolved {
+					return fmt.Errorf("no workspace member matches --assign %q", assigneeFilter)
 				}
 			}
 			if roleFilter != "" {

--- a/internal/cli/client.go
+++ b/internal/cli/client.go
@@ -309,6 +309,50 @@ func (c *Client) TestWebhook(wsSlug, webhookID string) error {
 	return c.post("/workspaces/"+wsSlug+"/webhooks/"+webhookID+"/test", nil, nil)
 }
 
+// --- Workspace Members ---
+
+// ListWorkspaceMembers returns all members of a workspace.
+func (c *Client) ListWorkspaceMembers(wsSlug string) ([]models.WorkspaceMember, error) {
+	var result struct {
+		Members []models.WorkspaceMember `json:"members"`
+	}
+	if err := c.get("/workspaces/"+wsSlug+"/members", &result); err != nil {
+		return nil, err
+	}
+	return result.Members, nil
+}
+
+// --- Agent Roles ---
+
+// ListAgentRoles returns all agent roles for a workspace.
+func (c *Client) ListAgentRoles(wsSlug string) ([]models.AgentRole, error) {
+	var result []models.AgentRole
+	return result, c.get("/workspaces/"+wsSlug+"/agent-roles", &result)
+}
+
+// CreateAgentRole creates a new agent role in a workspace.
+func (c *Client) CreateAgentRole(wsSlug string, input models.AgentRoleCreate) (*models.AgentRole, error) {
+	var result models.AgentRole
+	return &result, c.post("/workspaces/"+wsSlug+"/agent-roles", input, &result)
+}
+
+// GetAgentRole gets a single agent role by ID or slug.
+func (c *Client) GetAgentRole(wsSlug, idOrSlug string) (*models.AgentRole, error) {
+	var result models.AgentRole
+	return &result, c.get("/workspaces/"+wsSlug+"/agent-roles/"+idOrSlug, &result)
+}
+
+// UpdateAgentRole updates an existing agent role.
+func (c *Client) UpdateAgentRole(wsSlug, idOrSlug string, input models.AgentRoleUpdate) (*models.AgentRole, error) {
+	var result models.AgentRole
+	return &result, c.patch("/workspaces/"+wsSlug+"/agent-roles/"+idOrSlug, input, &result)
+}
+
+// DeleteAgentRole removes an agent role from a workspace.
+func (c *Client) DeleteAgentRole(wsSlug, idOrSlug string) error {
+	return c.delete("/workspaces/" + wsSlug + "/agent-roles/" + idOrSlug)
+}
+
 // --- Export / Import ---
 
 // RawGet fetches raw bytes from the API.

--- a/internal/cli/format.go
+++ b/internal/cli/format.go
@@ -250,6 +250,27 @@ func PrintItemMeta(item *models.Item) {
 		}
 		fmt.Printf("%s %s\n", label.Sprint("Collection:"), collLabel)
 	}
+	// Assignment: user + role
+	if item.AssignedUserName != "" || item.AgentRoleName != "" {
+		assignStr := ""
+		if item.AssignedUserName != "" && item.AgentRoleName != "" {
+			roleLabel := item.AgentRoleName
+			if item.AgentRoleIcon != "" {
+				roleLabel = item.AgentRoleIcon + " " + roleLabel
+			}
+			assignStr = fmt.Sprintf("%s (%s)", item.AssignedUserName, roleLabel)
+		} else if item.AssignedUserName != "" {
+			assignStr = item.AssignedUserName
+		} else {
+			roleLabel := item.AgentRoleName
+			if item.AgentRoleIcon != "" {
+				roleLabel = item.AgentRoleIcon + " " + roleLabel
+			}
+			assignStr = roleLabel
+		}
+		fmt.Printf("%s %s\n", label.Sprint("Assigned:  "), assignStr)
+	}
+
 	tags := item.Tags
 	if tags == "[]" || tags == "" || tags == "null" {
 		tags = Dim.Sprint("(none)")

--- a/internal/collections/defaults.go
+++ b/internal/collections/defaults.go
@@ -41,11 +41,6 @@ func Defaults() []DefaultCollection {
 						Default: "medium",
 					},
 					{
-						Key:   "assignee",
-						Label: "Assignee",
-						Type:  "text",
-					},
-					{
 						Key:   "due_date",
 						Label: "Due Date",
 						Type:  "date",

--- a/internal/models/agent_role.go
+++ b/internal/models/agent_role.go
@@ -1,0 +1,38 @@
+package models
+
+import "time"
+
+// AgentRole represents a workspace-scoped capability role for human-agent assignment.
+// Roles describe what kind of work gets done (e.g. "Planner", "Implementer", "Reviewer"),
+// not who or what tool does it. Items are assigned to a (user, role) pair.
+type AgentRole struct {
+	ID          string    `json:"id"`
+	WorkspaceID string    `json:"workspace_id"`
+	Slug        string    `json:"slug"`
+	Name        string    `json:"name"`
+	Description string    `json:"description"`
+	Icon        string    `json:"icon"`
+	SortOrder   int       `json:"sort_order"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+
+	// Computed (not stored)
+	ItemCount int `json:"item_count,omitempty"`
+}
+
+// AgentRoleCreate is the input for creating a new agent role.
+type AgentRoleCreate struct {
+	Name        string `json:"name"`
+	Slug        string `json:"slug,omitempty"`        // auto-generated from name if empty
+	Description string `json:"description,omitempty"`
+	Icon        string `json:"icon,omitempty"`
+}
+
+// AgentRoleUpdate is the input for updating an existing agent role.
+type AgentRoleUpdate struct {
+	Name        *string `json:"name,omitempty"`
+	Slug        *string `json:"slug,omitempty"`
+	Description *string `json:"description,omitempty"`
+	Icon        *string `json:"icon,omitempty"`
+	SortOrder   *int    `json:"sort_order,omitempty"`
+}

--- a/internal/models/item.go
+++ b/internal/models/item.go
@@ -33,10 +33,19 @@ type Item struct {
 	UpdatedAt      time.Time  `json:"updated_at"`
 	DeletedAt      *time.Time `json:"deleted_at,omitempty"`
 
+	// Assignment: (user, role) pair
+	AssignedUserID *string `json:"assigned_user_id,omitempty"`
+	AgentRoleID    *string `json:"agent_role_id,omitempty"`
+
 	// Auto-assigned sequential number within collection
 	ItemNumber *int `json:"item_number,omitempty"`
 
 	// Populated by joins (not stored)
+	AssignedUserName  string `json:"assigned_user_name,omitempty"`
+	AssignedUserEmail string `json:"assigned_user_email,omitempty"`
+	AgentRoleName     string `json:"agent_role_name,omitempty"`
+	AgentRoleSlug     string `json:"agent_role_slug,omitempty"`
+	AgentRoleIcon     string `json:"agent_role_icon,omitempty"`
 	CollectionSlug      string                   `json:"collection_slug,omitempty"`
 	CollectionName      string                   `json:"collection_name,omitempty"`
 	CollectionIcon      string                   `json:"collection_icon,omitempty"`
@@ -452,14 +461,16 @@ func uniqueStrings(values []string) []string {
 }
 
 type ItemCreate struct {
-	Title     string  `json:"title"`
-	Content   string  `json:"content,omitempty"`
-	Fields    string  `json:"fields,omitempty"`
-	Tags      string  `json:"tags,omitempty"`
-	Pinned    bool    `json:"pinned,omitempty"`
-	ParentID  *string `json:"parent_id,omitempty"`
-	CreatedBy string  `json:"created_by,omitempty"`
-	Source    string  `json:"source,omitempty"`
+	Title          string  `json:"title"`
+	Content        string  `json:"content,omitempty"`
+	Fields         string  `json:"fields,omitempty"`
+	Tags           string  `json:"tags,omitempty"`
+	Pinned         bool    `json:"pinned,omitempty"`
+	ParentID       *string `json:"parent_id,omitempty"`
+	AssignedUserID *string `json:"assigned_user_id,omitempty"`
+	AgentRoleID    *string `json:"agent_role_id,omitempty"`
+	CreatedBy      string  `json:"created_by,omitempty"`
+	Source         string  `json:"source,omitempty"`
 }
 
 type ItemUpdate struct {
@@ -470,10 +481,16 @@ type ItemUpdate struct {
 	Pinned         *bool   `json:"pinned,omitempty"`
 	SortOrder      *int    `json:"sort_order,omitempty"`
 	ParentID       *string `json:"parent_id,omitempty"`
+	AssignedUserID *string `json:"assigned_user_id,omitempty"`
+	AgentRoleID    *string `json:"agent_role_id,omitempty"`
 	LastModifiedBy string  `json:"last_modified_by,omitempty"`
 	Source         string  `json:"source,omitempty"`
 	ChangeSummary  string  `json:"change_summary,omitempty"`
 	Comment        *string `json:"comment,omitempty"`
+	// ClearAssignedUser / ClearAgentRole allow explicitly setting to NULL
+	// (since nil pointer means "don't change" in partial updates)
+	ClearAssignedUser bool `json:"clear_assigned_user,omitempty"`
+	ClearAgentRole    bool `json:"clear_agent_role,omitempty"`
 }
 
 type ItemListParams struct {
@@ -484,6 +501,8 @@ type ItemListParams struct {
 	Search          string // FTS query
 	ParentID        string
 	Tag             string
+	AssignedUserID  string // filter by assigned user
+	AgentRoleID     string // filter by agent role (ID or slug)
 	IncludeArchived bool
 	Limit           int
 	Offset          int

--- a/internal/server/handlers_agent_roles.go
+++ b/internal/server/handlers_agent_roles.go
@@ -1,0 +1,121 @@
+package server
+
+import (
+	"database/sql"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/xarmian/pad/internal/models"
+)
+
+// handleListAgentRoles returns all agent roles for a workspace.
+func (s *Server) handleListAgentRoles(w http.ResponseWriter, r *http.Request) {
+	workspaceID, ok := s.getWorkspaceID(w, r)
+	if !ok {
+		return
+	}
+
+	roles, err := s.store.ListAgentRoles(workspaceID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, roles)
+}
+
+// handleCreateAgentRole creates a new agent role in a workspace.
+func (s *Server) handleCreateAgentRole(w http.ResponseWriter, r *http.Request) {
+	workspaceID, ok := s.getWorkspaceID(w, r)
+	if !ok {
+		return
+	}
+
+	var input models.AgentRoleCreate
+	if err := decodeJSON(r, &input); err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", err.Error())
+		return
+	}
+
+	if input.Name == "" {
+		writeError(w, http.StatusBadRequest, "bad_request", "name is required")
+		return
+	}
+
+	role, err := s.store.CreateAgentRole(workspaceID, input)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, role)
+}
+
+// handleGetAgentRole returns a single agent role by ID or slug.
+func (s *Server) handleGetAgentRole(w http.ResponseWriter, r *http.Request) {
+	workspaceID, ok := s.getWorkspaceID(w, r)
+	if !ok {
+		return
+	}
+
+	roleID := chi.URLParam(r, "roleID")
+	role, err := s.store.GetAgentRole(workspaceID, roleID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", err.Error())
+		return
+	}
+	if role == nil {
+		writeError(w, http.StatusNotFound, "not_found", "Agent role not found")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, role)
+}
+
+// handleUpdateAgentRole updates an existing agent role.
+func (s *Server) handleUpdateAgentRole(w http.ResponseWriter, r *http.Request) {
+	workspaceID, ok := s.getWorkspaceID(w, r)
+	if !ok {
+		return
+	}
+
+	roleID := chi.URLParam(r, "roleID")
+	var input models.AgentRoleUpdate
+	if err := decodeJSON(r, &input); err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", err.Error())
+		return
+	}
+
+	role, err := s.store.UpdateAgentRole(workspaceID, roleID, input)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", err.Error())
+		return
+	}
+	if role == nil {
+		writeError(w, http.StatusNotFound, "not_found", "Agent role not found")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, role)
+}
+
+// handleDeleteAgentRole removes an agent role from a workspace.
+func (s *Server) handleDeleteAgentRole(w http.ResponseWriter, r *http.Request) {
+	workspaceID, ok := s.getWorkspaceID(w, r)
+	if !ok {
+		return
+	}
+
+	roleID := chi.URLParam(r, "roleID")
+	if err := s.store.DeleteAgentRole(workspaceID, roleID); err != nil {
+		if err == sql.ErrNoRows {
+			writeError(w, http.StatusNotFound, "not_found", "Agent role not found")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "internal_error", err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{"status": "deleted"})
+}

--- a/internal/server/handlers_documents.go
+++ b/internal/server/handlers_documents.go
@@ -438,6 +438,33 @@ func (s *Server) logActivityWithMetaReturningID(workspaceID, documentID, action 
 
 // diffFields compares old and new field JSON strings and returns a human-readable
 // summary of changes (e.g. "status: open → done, priority: medium → high").
+// valueOrEmpty returns the string or "(none)" if empty.
+func valueOrEmpty(s string) string {
+	if s == "" {
+		return "(none)"
+	}
+	return s
+}
+
+// appendChange adds a change description to existing metadata JSON.
+func appendChange(meta, change string) string {
+	if meta == "" {
+		return fmt.Sprintf(`{"changes":%q}`, change)
+	}
+	// Parse existing changes and append
+	var m map[string]string
+	if err := json.Unmarshal([]byte(meta), &m); err != nil {
+		return fmt.Sprintf(`{"changes":%q}`, change)
+	}
+	if existing, ok := m["changes"]; ok {
+		m["changes"] = existing + "; " + change
+	} else {
+		m["changes"] = change
+	}
+	b, _ := json.Marshal(m)
+	return string(b)
+}
+
 func diffFields(oldFields, newFields string) string {
 	var oldMap, newMap map[string]any
 	if err := json.Unmarshal([]byte(oldFields), &oldMap); err != nil {

--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -278,6 +278,15 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 			meta = fmt.Sprintf(`{"changes":"title: %s → %s"}`, item.Title, *input.Title)
 		}
 	}
+	// Track role and assignment changes
+	if updated.AgentRoleSlug != item.AgentRoleSlug {
+		roleChange := fmt.Sprintf("role: %s → %s", valueOrEmpty(item.AgentRoleName), valueOrEmpty(updated.AgentRoleName))
+		meta = appendChange(meta, roleChange)
+	}
+	if updated.AssignedUserName != item.AssignedUserName {
+		assignChange := fmt.Sprintf("assigned: %s → %s", valueOrEmpty(item.AssignedUserName), valueOrEmpty(updated.AssignedUserName))
+		meta = appendChange(meta, assignChange)
+	}
 	actor, source := actorFromRequest(r)
 	activityID, _ := s.logActivityWithMetaReturningID(workspaceID, updated.ID, "updated", r, meta)
 	s.publishItemEventWithName(events.ItemUpdated, workspaceID, updated.ID, updated.Title, updated.CollectionSlug, actor, actorNameFromRequest(r), source)
@@ -777,11 +786,13 @@ func autoPopulateDates(newFields map[string]any, existingFieldsJSON string, sche
 // parseItemListParams extracts item list parameters from the request query string.
 func parseItemListParams(r *http.Request) models.ItemListParams {
 	params := models.ItemListParams{
-		Sort:     r.URL.Query().Get("sort"),
-		GroupBy:  r.URL.Query().Get("group_by"),
-		Search:   r.URL.Query().Get("search"),
-		ParentID: r.URL.Query().Get("parent_id"),
-		Tag:      r.URL.Query().Get("tag"),
+		Sort:           r.URL.Query().Get("sort"),
+		GroupBy:        r.URL.Query().Get("group_by"),
+		Search:         r.URL.Query().Get("search"),
+		ParentID:       r.URL.Query().Get("parent_id"),
+		Tag:            r.URL.Query().Get("tag"),
+		AssignedUserID: r.URL.Query().Get("assigned_user_id"),
+		AgentRoleID:    r.URL.Query().Get("agent_role_id"),
 	}
 
 	if r.URL.Query().Get("include_archived") == "true" {
@@ -803,6 +814,7 @@ func parseItemListParams(r *http.Request) models.ItemListParams {
 	knownParams := map[string]bool{
 		"sort": true, "group_by": true, "search": true, "parent_id": true,
 		"tag": true, "include_archived": true, "limit": true, "offset": true,
+		"assigned_user_id": true, "agent_role_id": true,
 	}
 
 	fields := make(map[string]string)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -247,6 +247,17 @@ func (s *Server) setupRouter() {
 					r.Delete("/reactions/{emoji}", s.handleRemoveReaction)
 				})
 
+				// Agent Roles
+				r.Route("/agent-roles", func(r chi.Router) {
+					r.Get("/", s.handleListAgentRoles)
+					r.Post("/", s.handleCreateAgentRole)
+					r.Route("/{roleID}", func(r chi.Router) {
+						r.Get("/", s.handleGetAgentRole)
+						r.Patch("/", s.handleUpdateAgentRole)
+						r.Delete("/", s.handleDeleteAgentRole)
+					})
+				})
+
 				// Webhooks
 				r.Route("/webhooks", func(r chi.Router) {
 					r.Get("/", s.handleListWebhooks)

--- a/internal/store/agent_roles.go
+++ b/internal/store/agent_roles.go
@@ -1,0 +1,168 @@
+package store
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+
+	"github.com/xarmian/pad/internal/models"
+)
+
+func (s *Store) CreateAgentRole(workspaceID string, input models.AgentRoleCreate) (*models.AgentRole, error) {
+	id := newID()
+	ts := now()
+
+	slug := input.Slug
+	if slug == "" {
+		slug = slugify(input.Name)
+	}
+	if slug == "" {
+		slug = "role"
+	}
+	slug, err := s.uniqueSlug("agent_roles", "workspace_id", workspaceID, slug)
+	if err != nil {
+		return nil, fmt.Errorf("unique slug: %w", err)
+	}
+
+	_, err = s.db.Exec(`
+		INSERT INTO agent_roles (id, workspace_id, slug, name, description, icon, sort_order, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, 0, ?, ?)
+	`, id, workspaceID, slug, input.Name, input.Description, input.Icon, ts, ts)
+	if err != nil {
+		return nil, fmt.Errorf("create agent role: %w", err)
+	}
+
+	return s.GetAgentRole(workspaceID, id)
+}
+
+func (s *Store) GetAgentRole(workspaceID, idOrSlug string) (*models.AgentRole, error) {
+	var role models.AgentRole
+	var createdAt, updatedAt string
+
+	err := s.db.QueryRow(`
+		SELECT id, workspace_id, slug, name, description, icon, sort_order, created_at, updated_at
+		FROM agent_roles
+		WHERE workspace_id = ? AND (id = ? OR slug = ?)
+	`, workspaceID, idOrSlug, idOrSlug).Scan(
+		&role.ID, &role.WorkspaceID, &role.Slug, &role.Name, &role.Description,
+		&role.Icon, &role.SortOrder, &createdAt, &updatedAt,
+	)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get agent role: %w", err)
+	}
+
+	role.CreatedAt = parseTime(createdAt)
+	role.UpdatedAt = parseTime(updatedAt)
+	return &role, nil
+}
+
+func (s *Store) ListAgentRoles(workspaceID string) ([]models.AgentRole, error) {
+	rows, err := s.db.Query(`
+		SELECT r.id, r.workspace_id, r.slug, r.name, r.description, r.icon, r.sort_order,
+		       r.created_at, r.updated_at,
+		       COUNT(i.id) as item_count
+		FROM agent_roles r
+		LEFT JOIN items i ON i.agent_role_id = r.id AND i.deleted_at IS NULL
+		WHERE r.workspace_id = ?
+		GROUP BY r.id
+		ORDER BY r.sort_order ASC, r.name ASC
+	`, workspaceID)
+	if err != nil {
+		return nil, fmt.Errorf("list agent roles: %w", err)
+	}
+	defer rows.Close()
+
+	var roles []models.AgentRole
+	for rows.Next() {
+		var role models.AgentRole
+		var createdAt, updatedAt string
+		if err := rows.Scan(
+			&role.ID, &role.WorkspaceID, &role.Slug, &role.Name, &role.Description,
+			&role.Icon, &role.SortOrder, &createdAt, &updatedAt, &role.ItemCount,
+		); err != nil {
+			return nil, err
+		}
+		role.CreatedAt = parseTime(createdAt)
+		role.UpdatedAt = parseTime(updatedAt)
+		roles = append(roles, role)
+	}
+	if roles == nil {
+		roles = []models.AgentRole{}
+	}
+	return roles, rows.Err()
+}
+
+func (s *Store) UpdateAgentRole(workspaceID, id string, input models.AgentRoleUpdate) (*models.AgentRole, error) {
+	existing, err := s.GetAgentRole(workspaceID, id)
+	if err != nil {
+		return nil, err
+	}
+	if existing == nil {
+		return nil, nil
+	}
+
+	ts := now()
+	sets := []string{"updated_at = ?"}
+	args := []interface{}{ts}
+
+	if input.Name != nil {
+		sets = append(sets, "name = ?")
+		args = append(args, *input.Name)
+	}
+	if input.Slug != nil {
+		sets = append(sets, "slug = ?")
+		args = append(args, *input.Slug)
+	}
+	if input.Description != nil {
+		sets = append(sets, "description = ?")
+		args = append(args, *input.Description)
+	}
+	if input.Icon != nil {
+		sets = append(sets, "icon = ?")
+		args = append(args, *input.Icon)
+	}
+	if input.SortOrder != nil {
+		sets = append(sets, "sort_order = ?")
+		args = append(args, *input.SortOrder)
+	}
+
+	args = append(args, existing.ID)
+	query := fmt.Sprintf("UPDATE agent_roles SET %s WHERE id = ?", strings.Join(sets, ", "))
+	_, err = s.db.Exec(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("update agent role: %w", err)
+	}
+
+	return s.GetAgentRole(workspaceID, existing.ID)
+}
+
+func (s *Store) DeleteAgentRole(workspaceID, id string) error {
+	result, err := s.db.Exec(`
+		DELETE FROM agent_roles WHERE workspace_id = ? AND (id = ? OR slug = ?)
+	`, workspaceID, id, id)
+	if err != nil {
+		return fmt.Errorf("delete agent role: %w", err)
+	}
+	rows, _ := result.RowsAffected()
+	if rows == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
+}
+
+// ResolveAgentRoleID resolves a role identifier (ID or slug) to its UUID.
+// Returns empty string if the role doesn't exist.
+func (s *Store) ResolveAgentRoleID(workspaceID, idOrSlug string) (string, error) {
+	role, err := s.GetAgentRole(workspaceID, idOrSlug)
+	if err != nil {
+		return "", err
+	}
+	if role == nil {
+		return "", nil
+	}
+	return role.ID, nil
+}
+

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -18,7 +18,36 @@ type ItemSearchResult struct {
 	Rank    float64     `json:"rank"`
 }
 
+// validateAssignmentScope checks that the assigned user and agent role belong to the
+// same workspace as the item. This prevents cross-workspace assignment leaks.
+func (s *Store) validateAssignmentScope(workspaceID string, assignedUserID, agentRoleID *string) error {
+	if assignedUserID != nil && *assignedUserID != "" {
+		isMember, err := s.IsWorkspaceMember(workspaceID, *assignedUserID)
+		if err != nil {
+			return fmt.Errorf("validate assigned user: %w", err)
+		}
+		if !isMember {
+			return fmt.Errorf("assigned user is not a member of this workspace")
+		}
+	}
+	if agentRoleID != nil && *agentRoleID != "" {
+		role, err := s.GetAgentRole(workspaceID, *agentRoleID)
+		if err != nil {
+			return fmt.Errorf("validate agent role: %w", err)
+		}
+		if role == nil {
+			return fmt.Errorf("agent role does not belong to this workspace")
+		}
+	}
+	return nil
+}
+
 func (s *Store) CreateItem(workspaceID, collectionID string, input models.ItemCreate) (*models.Item, error) {
+	// Validate assignment scope before writing
+	if err := s.validateAssignmentScope(workspaceID, input.AssignedUserID, input.AgentRoleID); err != nil {
+		return nil, err
+	}
+
 	id := newID()
 	ts := now()
 
@@ -469,6 +498,11 @@ func (s *Store) UpdateItem(id string, input models.ItemUpdate) (*models.Item, er
 	}
 	if existing == nil {
 		return nil, nil
+	}
+
+	// Validate assignment scope before writing
+	if err := s.validateAssignmentScope(existing.WorkspaceID, input.AssignedUserID, input.AgentRoleID); err != nil {
+		return nil, err
 	}
 
 	tx, err := s.db.Begin()

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -63,10 +63,12 @@ func (s *Store) CreateItem(workspaceID, collectionID string, input models.ItemCr
 
 	_, err = tx.Exec(`
 		INSERT INTO items (id, workspace_id, collection_id, title, slug, content, fields, tags,
-		                   pinned, sort_order, parent_id, created_by, last_modified_by, source, item_number, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?, ?, ?, ?, ?, ?)
+		                   pinned, sort_order, parent_id, assigned_user_id, agent_role_id,
+		                   created_by, last_modified_by, source, item_number, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`, id, workspaceID, collectionID, input.Title, slug, input.Content, fields, tags,
-		boolToInt(input.Pinned), input.ParentID, createdBy, createdBy, source, nextNum, ts, ts)
+		boolToInt(input.Pinned), input.ParentID, input.AssignedUserID, input.AgentRoleID,
+		createdBy, createdBy, source, nextNum, ts, ts)
 	if err != nil {
 		return nil, fmt.Errorf("insert item: %w", err)
 	}
@@ -98,18 +100,26 @@ func (s *Store) GetItem(id string) (*models.Item, error) {
 
 	err := s.db.QueryRow(`
 		SELECT i.id, i.workspace_id, i.collection_id, i.title, i.slug, i.content, i.fields, i.tags,
-		       i.pinned, i.sort_order, i.parent_id, i.created_by, i.last_modified_by, i.source,
+		       i.pinned, i.sort_order, i.parent_id, i.assigned_user_id, i.agent_role_id,
+		       i.created_by, i.last_modified_by, i.source,
 		       i.item_number, i.created_at, i.updated_at, i.deleted_at,
-		       c.slug, c.name, c.icon, c.prefix
+		       c.slug, c.name, c.icon, c.prefix,
+		       COALESCE(au.name, ''), COALESCE(au.email, ''),
+		       COALESCE(ar.name, ''), COALESCE(ar.slug, ''), COALESCE(ar.icon, '')
 		FROM items i
 		JOIN collections c ON c.id = i.collection_id
+		LEFT JOIN users au ON au.id = i.assigned_user_id
+		LEFT JOIN agent_roles ar ON ar.id = i.agent_role_id
 		WHERE i.id = ? AND i.deleted_at IS NULL
 	`, id).Scan(
 		&item.ID, &item.WorkspaceID, &item.CollectionID, &item.Title, &item.Slug,
 		&item.Content, &item.Fields, &item.Tags,
-		&pinned, &item.SortOrder, &item.ParentID, &item.CreatedBy, &item.LastModifiedBy, &item.Source,
+		&pinned, &item.SortOrder, &item.ParentID, &item.AssignedUserID, &item.AgentRoleID,
+		&item.CreatedBy, &item.LastModifiedBy, &item.Source,
 		&item.ItemNumber, &createdAt, &updatedAt, &deletedAt,
 		&item.CollectionSlug, &item.CollectionName, &item.CollectionIcon, &item.CollectionPrefix,
+		&item.AssignedUserName, &item.AssignedUserEmail,
+		&item.AgentRoleName, &item.AgentRoleSlug, &item.AgentRoleIcon,
 	)
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -212,18 +222,26 @@ func (s *Store) ResolveItemIncludeDeleted(workspaceID, slugOrRef string) (*model
 
 		err := s.db.QueryRow(`
 			SELECT i.id, i.workspace_id, i.collection_id, i.title, i.slug, i.content, i.fields, i.tags,
-			       i.pinned, i.sort_order, i.parent_id, i.created_by, i.last_modified_by, i.source,
+			       i.pinned, i.sort_order, i.parent_id, i.assigned_user_id, i.agent_role_id,
+			       i.created_by, i.last_modified_by, i.source,
 			       i.item_number, i.created_at, i.updated_at, i.deleted_at,
-			       c.slug, c.name, c.icon, c.prefix
+			       c.slug, c.name, c.icon, c.prefix,
+			       COALESCE(au.name, ''), COALESCE(au.email, ''),
+			       COALESCE(ar.name, ''), COALESCE(ar.slug, ''), COALESCE(ar.icon, '')
 			FROM items i
 			JOIN collections c ON c.id = i.collection_id
+			LEFT JOIN users au ON au.id = i.assigned_user_id
+			LEFT JOIN agent_roles ar ON ar.id = i.agent_role_id
 			WHERE i.workspace_id = ? AND c.prefix = ? AND i.item_number = ?
 		`, workspaceID, prefix, number).Scan(
 			&item.ID, &item.WorkspaceID, &item.CollectionID, &item.Title, &item.Slug,
 			&item.Content, &item.Fields, &item.Tags,
-			&pinned, &item.SortOrder, &item.ParentID, &item.CreatedBy, &item.LastModifiedBy, &item.Source,
+			&pinned, &item.SortOrder, &item.ParentID, &item.AssignedUserID, &item.AgentRoleID,
+			&item.CreatedBy, &item.LastModifiedBy, &item.Source,
 			&item.ItemNumber, &createdAt, &updatedAt, &deletedAt,
 			&item.CollectionSlug, &item.CollectionName, &item.CollectionIcon, &item.CollectionPrefix,
+			&item.AssignedUserName, &item.AssignedUserEmail,
+			&item.AgentRoleName, &item.AgentRoleSlug, &item.AgentRoleIcon,
 		)
 		if err == nil {
 			item.Pinned = pinned == 1
@@ -278,18 +296,26 @@ func (s *Store) GetItemBySlugIncludeDeleted(workspaceID, slug string) (*models.I
 
 	err := s.db.QueryRow(`
 		SELECT i.id, i.workspace_id, i.collection_id, i.title, i.slug, i.content, i.fields, i.tags,
-		       i.pinned, i.sort_order, i.parent_id, i.created_by, i.last_modified_by, i.source,
+		       i.pinned, i.sort_order, i.parent_id, i.assigned_user_id, i.agent_role_id,
+		       i.created_by, i.last_modified_by, i.source,
 		       i.item_number, i.created_at, i.updated_at, i.deleted_at,
-		       c.slug, c.name, c.icon, c.prefix
+		       c.slug, c.name, c.icon, c.prefix,
+		       COALESCE(au.name, ''), COALESCE(au.email, ''),
+		       COALESCE(ar.name, ''), COALESCE(ar.slug, ''), COALESCE(ar.icon, '')
 		FROM items i
 		JOIN collections c ON c.id = i.collection_id
+		LEFT JOIN users au ON au.id = i.assigned_user_id
+		LEFT JOIN agent_roles ar ON ar.id = i.agent_role_id
 		WHERE i.workspace_id = ? AND i.slug = ?
 	`, workspaceID, slug).Scan(
 		&item.ID, &item.WorkspaceID, &item.CollectionID, &item.Title, &item.Slug,
 		&item.Content, &item.Fields, &item.Tags,
-		&pinned, &item.SortOrder, &item.ParentID, &item.CreatedBy, &item.LastModifiedBy, &item.Source,
+		&pinned, &item.SortOrder, &item.ParentID, &item.AssignedUserID, &item.AgentRoleID,
+		&item.CreatedBy, &item.LastModifiedBy, &item.Source,
 		&item.ItemNumber, &createdAt, &updatedAt, &deletedAt,
 		&item.CollectionSlug, &item.CollectionName, &item.CollectionIcon, &item.CollectionPrefix,
+		&item.AssignedUserName, &item.AssignedUserEmail,
+		&item.AgentRoleName, &item.AgentRoleSlug, &item.AgentRoleIcon,
 	)
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -314,11 +340,16 @@ func (s *Store) ListItems(workspaceID string, params models.ItemListParams) ([]m
 
 	query := `
 		SELECT i.id, i.workspace_id, i.collection_id, i.title, i.slug, i.content, i.fields, i.tags,
-		       i.pinned, i.sort_order, i.parent_id, i.created_by, i.last_modified_by, i.source,
+		       i.pinned, i.sort_order, i.parent_id, i.assigned_user_id, i.agent_role_id,
+		       i.created_by, i.last_modified_by, i.source,
 		       i.item_number, i.created_at, i.updated_at,
-		       c.slug, c.name, c.icon, c.prefix
+		       c.slug, c.name, c.icon, c.prefix,
+		       COALESCE(au.name, ''), COALESCE(au.email, ''),
+		       COALESCE(ar.name, ''), COALESCE(ar.slug, ''), COALESCE(ar.icon, '')
 		FROM items i
 		JOIN collections c ON c.id = i.collection_id
+		LEFT JOIN users au ON au.id = i.assigned_user_id
+		LEFT JOIN agent_roles ar ON ar.id = i.agent_role_id
 		WHERE i.workspace_id = ?
 	`
 	args := []interface{}{workspaceID}
@@ -340,6 +371,16 @@ func (s *Store) ListItems(workspaceID string, params models.ItemListParams) ([]m
 	if params.ParentID != "" {
 		query += " AND i.parent_id = ?"
 		args = append(args, params.ParentID)
+	}
+
+	if params.AssignedUserID != "" {
+		query += " AND i.assigned_user_id = ?"
+		args = append(args, params.AssignedUserID)
+	}
+
+	if params.AgentRoleID != "" {
+		query += " AND (i.agent_role_id = ? OR ar.slug = ?)"
+		args = append(args, params.AgentRoleID, params.AgentRoleID)
 	}
 
 	// Field filters using json_extract — supports comma-separated values as OR
@@ -384,12 +425,17 @@ func (s *Store) ListItems(workspaceID string, params models.ItemListParams) ([]m
 func (s *Store) listItemsFTS(workspaceID string, params models.ItemListParams) ([]models.Item, error) {
 	query := `
 		SELECT i.id, i.workspace_id, i.collection_id, i.title, i.slug, i.content, i.fields, i.tags,
-		       i.pinned, i.sort_order, i.parent_id, i.created_by, i.last_modified_by, i.source,
+		       i.pinned, i.sort_order, i.parent_id, i.assigned_user_id, i.agent_role_id,
+		       i.created_by, i.last_modified_by, i.source,
 		       i.item_number, i.created_at, i.updated_at,
-		       c.slug, c.name, c.icon, c.prefix
+		       c.slug, c.name, c.icon, c.prefix,
+		       COALESCE(au.name, ''), COALESCE(au.email, ''),
+		       COALESCE(ar.name, ''), COALESCE(ar.slug, ''), COALESCE(ar.icon, '')
 		FROM items i
 		JOIN items_fts fts ON i.rowid = fts.rowid
 		JOIN collections c ON c.id = i.collection_id
+		LEFT JOIN users au ON au.id = i.assigned_user_id
+		LEFT JOIN agent_roles ar ON ar.id = i.agent_role_id
 		WHERE i.workspace_id = ? AND i.deleted_at IS NULL
 		AND items_fts MATCH ?
 	`
@@ -515,6 +561,18 @@ func (s *Store) UpdateItem(id string, input models.ItemUpdate) (*models.Item, er
 		sets = append(sets, "parent_id = ?")
 		args = append(args, *input.ParentID)
 	}
+	if input.AssignedUserID != nil {
+		sets = append(sets, "assigned_user_id = ?")
+		args = append(args, *input.AssignedUserID)
+	} else if input.ClearAssignedUser {
+		sets = append(sets, "assigned_user_id = NULL")
+	}
+	if input.AgentRoleID != nil {
+		sets = append(sets, "agent_role_id = ?")
+		args = append(args, *input.AgentRoleID)
+	} else if input.ClearAgentRole {
+		sets = append(sets, "agent_role_id = NULL")
+	}
 	if input.LastModifiedBy != "" {
 		sets = append(sets, "last_modified_by = ?")
 		args = append(args, input.LastModifiedBy)
@@ -573,14 +631,19 @@ func (s *Store) RestoreItem(id string) (*models.Item, error) {
 func (s *Store) SearchItems(workspaceID, query string) ([]ItemSearchResult, error) {
 	sqlQuery := `
 		SELECT i.id, i.workspace_id, i.collection_id, i.title, i.slug, i.content, i.fields, i.tags,
-		       i.pinned, i.sort_order, i.parent_id, i.created_by, i.last_modified_by, i.source,
+		       i.pinned, i.sort_order, i.parent_id, i.assigned_user_id, i.agent_role_id,
+		       i.created_by, i.last_modified_by, i.source,
 		       i.item_number, i.created_at, i.updated_at,
 		       c.slug, c.name, c.icon, c.prefix,
+		       COALESCE(au.name, ''), COALESCE(au.email, ''),
+		       COALESCE(ar.name, ''), COALESCE(ar.slug, ''), COALESCE(ar.icon, ''),
 		       snippet(items_fts, 1, '<mark>', '</mark>', '...', 32) as snippet,
 		       rank
 		FROM items_fts fts
 		JOIN items i ON i.rowid = fts.rowid
 		JOIN collections c ON c.id = i.collection_id
+		LEFT JOIN users au ON au.id = i.assigned_user_id
+		LEFT JOIN agent_roles ar ON ar.id = i.agent_role_id
 		WHERE items_fts MATCH ?
 		AND i.deleted_at IS NULL
 	`
@@ -607,9 +670,12 @@ func (s *Store) SearchItems(workspaceID, query string) ([]ItemSearchResult, erro
 		if err := rows.Scan(
 			&r.Item.ID, &r.Item.WorkspaceID, &r.Item.CollectionID, &r.Item.Title, &r.Item.Slug,
 			&r.Item.Content, &r.Item.Fields, &r.Item.Tags,
-			&pinned, &r.Item.SortOrder, &r.Item.ParentID, &r.Item.CreatedBy, &r.Item.LastModifiedBy,
+			&pinned, &r.Item.SortOrder, &r.Item.ParentID, &r.Item.AssignedUserID, &r.Item.AgentRoleID,
+			&r.Item.CreatedBy, &r.Item.LastModifiedBy,
 			&r.Item.Source, &r.Item.ItemNumber, &createdAt, &updatedAt,
 			&r.Item.CollectionSlug, &r.Item.CollectionName, &r.Item.CollectionIcon, &r.Item.CollectionPrefix,
+			&r.Item.AssignedUserName, &r.Item.AssignedUserEmail,
+			&r.Item.AgentRoleName, &r.Item.AgentRoleSlug, &r.Item.AgentRoleIcon,
 			&r.Snippet, &r.Rank,
 		); err != nil {
 			return nil, err
@@ -838,11 +904,16 @@ func (s *Store) GetAllPhasesProgress(workspaceID string) ([]PhaseProgress, error
 func (s *Store) GetTasksForPhase(phaseItemID string) ([]models.Item, error) {
 	rows, err := s.db.Query(`
 		SELECT i.id, i.workspace_id, i.collection_id, i.title, i.slug, i.content, i.fields, i.tags,
-		       i.pinned, i.sort_order, i.parent_id, i.created_by, i.last_modified_by, i.source,
+		       i.pinned, i.sort_order, i.parent_id, i.assigned_user_id, i.agent_role_id,
+		       i.created_by, i.last_modified_by, i.source,
 		       i.item_number, i.created_at, i.updated_at,
-		       c.slug, c.name, c.icon, c.prefix
+		       c.slug, c.name, c.icon, c.prefix,
+		       COALESCE(au.name, ''), COALESCE(au.email, ''),
+		       COALESCE(ar.name, ''), COALESCE(ar.slug, ''), COALESCE(ar.icon, '')
 		FROM items i
 		JOIN collections c ON c.id = i.collection_id
+		LEFT JOIN users au ON au.id = i.assigned_user_id
+		LEFT JOIN agent_roles ar ON ar.id = i.agent_role_id
 		WHERE c.slug = 'tasks'
 		  AND i.deleted_at IS NULL
 		  AND json_extract(i.fields, '$.phase') = ?
@@ -1058,9 +1129,12 @@ func scanItems(rows *sql.Rows) ([]models.Item, error) {
 		if err := rows.Scan(
 			&item.ID, &item.WorkspaceID, &item.CollectionID, &item.Title, &item.Slug,
 			&item.Content, &item.Fields, &item.Tags,
-			&pinned, &item.SortOrder, &item.ParentID, &item.CreatedBy, &item.LastModifiedBy, &item.Source,
+			&pinned, &item.SortOrder, &item.ParentID, &item.AssignedUserID, &item.AgentRoleID,
+			&item.CreatedBy, &item.LastModifiedBy, &item.Source,
 			&item.ItemNumber, &createdAt, &updatedAt,
 			&item.CollectionSlug, &item.CollectionName, &item.CollectionIcon, &item.CollectionPrefix,
+			&item.AssignedUserName, &item.AssignedUserEmail,
+			&item.AgentRoleName, &item.AgentRoleSlug, &item.AgentRoleIcon,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/store/migrations/017_agent_roles.sql
+++ b/internal/store/migrations/017_agent_roles.sql
@@ -1,0 +1,36 @@
+-- Agent roles: workspace-scoped capability roles for human-agent assignment
+
+CREATE TABLE IF NOT EXISTS agent_roles (
+    id           TEXT PRIMARY KEY,
+    workspace_id TEXT NOT NULL REFERENCES workspaces(id),
+    slug         TEXT NOT NULL,
+    name         TEXT NOT NULL,
+    description  TEXT NOT NULL DEFAULT '',
+    icon         TEXT NOT NULL DEFAULT '',
+    sort_order   INTEGER NOT NULL DEFAULT 0,
+    created_at   TEXT NOT NULL,
+    updated_at   TEXT NOT NULL,
+    UNIQUE(workspace_id, slug)
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_roles_workspace ON agent_roles(workspace_id);
+
+-- Assignment columns on items: (user, role) pairs
+ALTER TABLE items ADD COLUMN assigned_user_id TEXT REFERENCES users(id) ON DELETE SET NULL;
+ALTER TABLE items ADD COLUMN agent_role_id TEXT REFERENCES agent_roles(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_items_assigned_user ON items(assigned_user_id) WHERE deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_items_agent_role ON items(agent_role_id) WHERE deleted_at IS NULL;
+
+-- Remove assignee text field from existing Tasks collection schemas.
+-- This replaces the free-text assignee with the structured (user, role) assignment above.
+UPDATE collections
+SET schema = REPLACE(schema, '{"key":"assignee","label":"Assignee","type":"text"},', '')
+WHERE slug = 'tasks'
+  AND schema LIKE '%"assignee"%';
+
+-- Handle alternate JSON formatting (with spaces)
+UPDATE collections
+SET schema = REPLACE(schema, '{"key": "assignee", "label": "Assignee", "type": "text"},', '')
+WHERE slug = 'tasks'
+  AND schema LIKE '%"assignee"%';

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -20,14 +20,19 @@ type SearchParams struct {
 func (s *Store) Search(params SearchParams) ([]SearchResult, error) {
 	query := `
 		SELECT i.id, i.workspace_id, i.collection_id, i.title, i.slug, i.content, i.fields, i.tags,
-		       i.pinned, i.sort_order, i.parent_id, i.created_by, i.last_modified_by, i.source,
+		       i.pinned, i.sort_order, i.parent_id, i.assigned_user_id, i.agent_role_id,
+		       i.created_by, i.last_modified_by, i.source,
 		       i.item_number, i.created_at, i.updated_at,
 		       c.slug, c.name, c.icon, c.prefix,
+		       COALESCE(au.name, ''), COALESCE(au.email, ''),
+		       COALESCE(ar.name, ''), COALESCE(ar.slug, ''), COALESCE(ar.icon, ''),
 		       snippet(items_fts, 1, '<mark>', '</mark>', '...', 32) as snippet,
 		       rank
 		FROM items_fts fts
 		JOIN items i ON i.rowid = fts.rowid
 		JOIN collections c ON c.id = i.collection_id
+		LEFT JOIN users au ON au.id = i.assigned_user_id
+		LEFT JOIN agent_roles ar ON ar.id = i.agent_role_id
 		WHERE items_fts MATCH ?
 		AND i.deleted_at IS NULL
 	`
@@ -59,9 +64,12 @@ func (s *Store) Search(params SearchParams) ([]SearchResult, error) {
 		if err := rows.Scan(
 			&r.Item.ID, &r.Item.WorkspaceID, &r.Item.CollectionID, &r.Item.Title, &r.Item.Slug,
 			&r.Item.Content, &r.Item.Fields, &r.Item.Tags,
-			&pinned, &r.Item.SortOrder, &r.Item.ParentID, &r.Item.CreatedBy, &r.Item.LastModifiedBy,
+			&pinned, &r.Item.SortOrder, &r.Item.ParentID, &r.Item.AssignedUserID, &r.Item.AgentRoleID,
+			&r.Item.CreatedBy, &r.Item.LastModifiedBy,
 			&r.Item.Source, &r.Item.ItemNumber, &createdAt, &updatedAt,
 			&r.Item.CollectionSlug, &r.Item.CollectionName, &r.Item.CollectionIcon, &r.Item.CollectionPrefix,
+			&r.Item.AssignedUserName, &r.Item.AssignedUserEmail,
+			&r.Item.AgentRoleName, &r.Item.AgentRoleSlug, &r.Item.AgentRoleIcon,
 			&r.Snippet, &r.Rank,
 		); err != nil {
 			return nil, err

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -82,6 +82,7 @@ func (s *Store) migrate() error {
 		"014_platform_settings.sql",
 		"015_password_resets.sql",
 		"016_timeline.sql",
+		"017_agent_roles.sql",
 	}
 
 	for _, name := range migrations {

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -28,7 +28,10 @@ import type {
 	APIToken,
 	APITokenWithSecret,
 	Reaction,
-	TimelineResponse
+	TimelineResponse,
+	AgentRole,
+	AgentRoleCreate,
+	AgentRoleUpdate
 } from '$lib/types';
 
 const BASE = '/api/v1';
@@ -145,6 +148,33 @@ export const api = {
 
 		delete: (ws: string, slug: string) =>
 			request<void>(`/workspaces/${ws}/collections/${slug}`, {
+				method: 'DELETE'
+			})
+	},
+
+	// ── Agent Roles ──────────────────────────────────────────────────────────
+
+	agentRoles: {
+		list: (ws: string) =>
+			request<AgentRole[]>(`/workspaces/${ws}/agent-roles`),
+
+		create: (ws: string, data: AgentRoleCreate) =>
+			request<AgentRole>(`/workspaces/${ws}/agent-roles`, {
+				method: 'POST',
+				body: JSON.stringify(data)
+			}),
+
+		get: (ws: string, idOrSlug: string) =>
+			request<AgentRole>(`/workspaces/${ws}/agent-roles/${idOrSlug}`),
+
+		update: (ws: string, idOrSlug: string, data: AgentRoleUpdate) =>
+			request<AgentRole>(`/workspaces/${ws}/agent-roles/${idOrSlug}`, {
+				method: 'PATCH',
+				body: JSON.stringify(data)
+			}),
+
+		delete: (ws: string, idOrSlug: string) =>
+			request<void>(`/workspaces/${ws}/agent-roles/${idOrSlug}`, {
 				method: 'DELETE'
 			})
 	},

--- a/web/src/lib/components/collections/ItemCard.svelte
+++ b/web/src/lib/components/collections/ItemCard.svelte
@@ -23,8 +23,6 @@
 
 	let statusField = $derived(schema.fields.find((f) => f.key === 'status'));
 	let priorityField = $derived(schema.fields.find((f) => f.key === 'priority'));
-	let assigneeField = $derived(schema.fields.find((f) => f.key === 'assignee'));
-
 	let itemUrl = $derived(`/${wsSlug}/${collection.slug}/${itemUrlId(item)}`);
 	let itemRef = $derived(formatItemRef(item));
 
@@ -121,6 +119,11 @@
 				{relationLabels[fields.phase]}
 			</span>
 		{/if}
+		{#if item.agent_role_name}
+			<span class="badge role-badge">
+				{#if item.agent_role_icon}{item.agent_role_icon} {/if}{item.agent_role_name}
+			</span>
+		{/if}
 	</div>
 
 	{#if progress && progress.total > 0}
@@ -133,8 +136,8 @@
 	{/if}
 
 	<div class="card-footer">
-		{#if assigneeField && fields.assignee}
-			<span class="assignee">{fields.assignee}</span>
+		{#if item.assigned_user_name}
+			<span class="assignee">{item.assigned_user_name}</span>
 		{/if}
 		<span class="updated" title={new Date(item.updated_at).toLocaleString()}>{relativeTime(item.updated_at)}</span>
 	</div>
@@ -238,6 +241,15 @@
 		100% {
 			box-shadow: 0 0 0 0 color-mix(in srgb, var(--badge-color) 0%, transparent);
 		}
+	}
+
+	.role-badge {
+		font-size: 0.8em;
+		color: var(--accent-teal, var(--accent-blue));
+		background: color-mix(in srgb, var(--accent-teal, var(--accent-blue)) 12%, transparent);
+		padding: 3px 10px;
+		border-radius: var(--radius-sm);
+		white-space: nowrap;
 	}
 
 	.phase-badge {

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -191,6 +191,36 @@ export interface CollectionUpdate {
 	migrations?: FieldMigration[];
 }
 
+// ─── Agent Roles ─────────────────────────────────────────────────────────────
+
+export interface AgentRole {
+	id: string;
+	workspace_id: string;
+	slug: string;
+	name: string;
+	description: string;
+	icon: string;
+	sort_order: number;
+	created_at: string;
+	updated_at: string;
+	item_count?: number;
+}
+
+export interface AgentRoleCreate {
+	name: string;
+	slug?: string;
+	description?: string;
+	icon?: string;
+}
+
+export interface AgentRoleUpdate {
+	name?: string;
+	slug?: string;
+	description?: string;
+	icon?: string;
+	sort_order?: number;
+}
+
 // ─── Items ───────────────────────────────────────────────────────────────────
 
 export interface ItemRelationRef {
@@ -260,6 +290,13 @@ export interface Item {
 	pinned: boolean;
 	sort_order: number;
 	parent_id?: string;
+	assigned_user_id?: string | null;
+	agent_role_id?: string | null;
+	assigned_user_name?: string;
+	assigned_user_email?: string;
+	agent_role_name?: string;
+	agent_role_slug?: string;
+	agent_role_icon?: string;
 	created_by: string;
 	last_modified_by: string;
 	source: string;

--- a/web/src/routes/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[workspace]/[collection]/[slug]/+page.svelte
@@ -563,6 +563,29 @@
 						</div>
 					{/if}
 				{/each}
+
+				<!-- Assignment: user + role -->
+				{#if item.assigned_user_name || item.agent_role_name}
+					<div class="fields-header" style="margin-top: var(--space-4)">Assignment</div>
+				{/if}
+				{#if item.assigned_user_name}
+					<div class="field-row">
+						<span class="field-label">Assigned to</span>
+						<div class="field-value">
+							<span class="assignment-value">{item.assigned_user_name}</span>
+						</div>
+					</div>
+				{/if}
+				{#if item.agent_role_name}
+					<div class="field-row">
+						<span class="field-label">Role</span>
+						<div class="field-value">
+							<span class="assignment-value">
+								{#if item.agent_role_icon}{item.agent_role_icon} {/if}{item.agent_role_name}
+							</span>
+						</div>
+					</div>
+				{/if}
 			</div>
 
 			<!-- Content editor -->


### PR DESCRIPTION
## Summary

- Introduces **agent roles** as a first-class concept for human-agent work assignment (PHASE-9)
- Items can be assigned to a **(user, role) pair** — e.g. "Dave as Implementer" — enabling natural handoff workflows between different AI tools and capabilities
- Roles are workspace-scoped, user-defined capability profiles (Planner, Implementer, Reviewer, Researcher, or anything the team needs)

### What's included

**Database:** New `agent_roles` table + `assigned_user_id`/`agent_role_id` columns on `items` with FK constraints. Removes legacy `assignee` text field from Tasks schema (breaking change, acceptable for beta).

**Backend:** Full CRUD for agent roles, all item queries updated with LEFT JOINs to resolve assignment names, list filtering by user/role, role transitions tracked in activity feed.

**CLI:**
```bash
pad role create "Implementer" --description "Writes code" --icon "🔨"
pad item update TASK-5 --role implementer --assign Dave
pad item show TASK-5  # → "Assigned: Dave (🔨 Implementer)"
pad item list tasks --role implementer
```

**Web:** Role badge on item cards, assignment display on item detail page, TypeScript types + API client for role CRUD.

### What's deferred (later phases)
- Interactive assignment picker (dropdowns) in web UI
- Session identity (`pad agent start --role implementer`)
- Role-specific conventions
- Agent bindings (role → tool/model mapping)

## Test plan
- [x] All Go tests pass (`go test ./...`)
- [x] Web UI builds (`npm run build`)
- [x] `make install` succeeds
- [x] Smoke tested: `pad role list/create`, `pad item update --role --assign`, `pad item show` displays assignment
- [ ] Verify web UI shows role badges on item cards
- [ ] Verify item detail page shows assignment section