### PR TITLE
feat: role board — cross-collection view, dashboard breakdown, agent bindings

### DIFF
--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -2841,6 +2841,14 @@ func statusCmd() *cobra.Command {
 					TaskCount int    `json:"task_count"`
 					DoneCount int    `json:"done_count"`
 				} `json:"active_phases"`
+				ByRole []struct {
+					RoleName  string   `json:"role_name"`
+					RoleSlug  string   `json:"role_slug"`
+					RoleIcon  string   `json:"role_icon"`
+					Tools     string   `json:"tools"`
+					ItemCount int      `json:"item_count"`
+					Users     []string `json:"assigned_users"`
+				} `json:"by_role"`
 				Attention []struct {
 					Type      string `json:"type"`
 					ItemSlug  string `json:"item_slug"`
@@ -2912,6 +2920,31 @@ func statusCmd() *cobra.Command {
 						color.New(color.FgGreen).Sprintf("%d%%", p.Progress),
 						dim.Sprintf("(%d/%d tasks)", p.DoneCount, p.TaskCount),
 					)
+				}
+			}
+
+			// Role breakdown
+			if len(dash.ByRole) > 0 {
+				fmt.Println()
+				bold.Println("🎭 Roles")
+				for _, r := range dash.ByRole {
+					icon := r.RoleIcon
+					if icon != "" {
+						icon += " "
+					}
+					name := r.RoleName
+					if name == "" {
+						name = "Unassigned"
+					}
+					users := ""
+					if len(r.Users) > 0 {
+						users = "  (" + strings.Join(r.Users, ", ") + ")"
+					}
+					tools := ""
+					if r.Tools != "" {
+						tools = "  [" + r.Tools + "]"
+					}
+					fmt.Printf("  %s%-14s %d items%s%s\n", icon, name, r.ItemCount, users, tools)
 				}
 			}
 
@@ -4303,13 +4336,13 @@ func roleListCmd() *cobra.Command {
 				return nil
 			}
 			w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-			fmt.Fprintln(w, "SLUG\tNAME\tDESCRIPTION\tITEMS")
+			fmt.Fprintln(w, "SLUG\tNAME\tDESCRIPTION\tTOOLS\tITEMS")
 			for _, r := range roles {
 				icon := r.Icon
 				if icon != "" {
 					icon += " "
 				}
-				fmt.Fprintf(w, "%s\t%s%s\t%s\t%d\n", r.Slug, icon, r.Name, r.Description, r.ItemCount)
+				fmt.Fprintf(w, "%s\t%s%s\t%s\t%s\t%d\n", r.Slug, icon, r.Name, r.Description, r.Tools, r.ItemCount)
 			}
 			w.Flush()
 			return nil
@@ -4318,7 +4351,7 @@ func roleListCmd() *cobra.Command {
 }
 
 func roleCreateCmd() *cobra.Command {
-	var description, icon string
+	var description, icon, tools string
 
 	cmd := &cobra.Command{
 		Use:   "create <name>",
@@ -4331,6 +4364,7 @@ func roleCreateCmd() *cobra.Command {
 				Name:        args[0],
 				Description: description,
 				Icon:        icon,
+				Tools:       tools,
 			}
 			role, err := client.CreateAgentRole(ws, input)
 			if err != nil {
@@ -4349,6 +4383,7 @@ func roleCreateCmd() *cobra.Command {
 	}
 	cmd.Flags().StringVar(&description, "description", "", "role description")
 	cmd.Flags().StringVar(&icon, "icon", "", "role icon (emoji)")
+	cmd.Flags().StringVar(&tools, "tools", "", "preferred tools/models (e.g. 'Claude Code + Sonnet 4.6')")
 	return cmd
 }
 

--- a/internal/models/agent_role.go
+++ b/internal/models/agent_role.go
@@ -12,6 +12,7 @@ type AgentRole struct {
 	Name        string    `json:"name"`
 	Description string    `json:"description"`
 	Icon        string    `json:"icon"`
+	Tools       string    `json:"tools"`
 	SortOrder   int       `json:"sort_order"`
 	CreatedAt   time.Time `json:"created_at"`
 	UpdatedAt   time.Time `json:"updated_at"`
@@ -26,6 +27,7 @@ type AgentRoleCreate struct {
 	Slug        string `json:"slug,omitempty"`        // auto-generated from name if empty
 	Description string `json:"description,omitempty"`
 	Icon        string `json:"icon,omitempty"`
+	Tools       string `json:"tools,omitempty"`
 }
 
 // AgentRoleUpdate is the input for updating an existing agent role.
@@ -34,5 +36,6 @@ type AgentRoleUpdate struct {
 	Slug        *string `json:"slug,omitempty"`
 	Description *string `json:"description,omitempty"`
 	Icon        *string `json:"icon,omitempty"`
+	Tools       *string `json:"tools,omitempty"`
 	SortOrder   *int    `json:"sort_order,omitempty"`
 }

--- a/internal/server/handlers_dashboard.go
+++ b/internal/server/handlers_dashboard.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/xarmian/pad/internal/models"
+	"github.com/xarmian/pad/internal/store"
 )
 
 // Dashboard response types
@@ -17,6 +18,7 @@ type DashboardResponse struct {
 	Summary        DashboardSummary       `json:"summary"`
 	ActiveItems    []DashboardActiveItem  `json:"active_items"`
 	ActivePhases   []DashboardPhase       `json:"active_phases"`
+	ByRole         []store.RoleBreakdown  `json:"by_role,omitempty"`
 	Attention      []DashboardAttention   `json:"attention"`
 	RecentActivity []DashboardActivity    `json:"recent_activity"`
 	SuggestedNext  []DashboardSuggestion  `json:"suggested_next"`
@@ -447,6 +449,12 @@ func (s *Server) handleGetDashboard(w http.ResponseWriter, r *http.Request) {
 			Collection: "tasks",
 			Reason:     reason,
 		})
+	}
+
+	// Role breakdown: items per role with assigned users
+	roleBreakdown, err := s.store.GetRoleBreakdown(workspaceID)
+	if err == nil && len(roleBreakdown) > 0 {
+		resp.ByRole = roleBreakdown
 	}
 
 	writeJSON(w, http.StatusOK, resp)

--- a/internal/server/handlers_role_board.go
+++ b/internal/server/handlers_role_board.go
@@ -1,0 +1,30 @@
+package server
+
+import (
+	"net/http"
+
+	"github.com/xarmian/pad/internal/store"
+)
+
+// handleRoleBoard returns items across all collections grouped by agent role.
+// This powers the standalone role board page in the web UI.
+func (s *Server) handleRoleBoard(w http.ResponseWriter, r *http.Request) {
+	workspaceID, ok := s.getWorkspaceID(w, r)
+	if !ok {
+		return
+	}
+
+	params := store.RoleBoardParams{
+		AssignedUserID: r.URL.Query().Get("assigned_user_id"),
+	}
+
+	lanes, err := s.store.GetRoleBoardItems(workspaceID, params)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"lanes": lanes,
+	})
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -247,6 +247,9 @@ func (s *Server) setupRouter() {
 					r.Delete("/reactions/{emoji}", s.handleRemoveReaction)
 				})
 
+				// Role Board (cross-collection role-based view)
+				r.Get("/roles/board", s.handleRoleBoard)
+
 				// Agent Roles
 				r.Route("/agent-roles", func(r chi.Router) {
 					r.Get("/", s.handleListAgentRoles)

--- a/internal/store/agent_roles.go
+++ b/internal/store/agent_roles.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -25,9 +26,9 @@ func (s *Store) CreateAgentRole(workspaceID string, input models.AgentRoleCreate
 	}
 
 	_, err = s.db.Exec(`
-		INSERT INTO agent_roles (id, workspace_id, slug, name, description, icon, sort_order, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, 0, ?, ?)
-	`, id, workspaceID, slug, input.Name, input.Description, input.Icon, ts, ts)
+		INSERT INTO agent_roles (id, workspace_id, slug, name, description, icon, tools, sort_order, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, 0, ?, ?)
+	`, id, workspaceID, slug, input.Name, input.Description, input.Icon, input.Tools, ts, ts)
 	if err != nil {
 		return nil, fmt.Errorf("create agent role: %w", err)
 	}
@@ -40,12 +41,12 @@ func (s *Store) GetAgentRole(workspaceID, idOrSlug string) (*models.AgentRole, e
 	var createdAt, updatedAt string
 
 	err := s.db.QueryRow(`
-		SELECT id, workspace_id, slug, name, description, icon, sort_order, created_at, updated_at
+		SELECT id, workspace_id, slug, name, description, icon, tools, sort_order, created_at, updated_at
 		FROM agent_roles
 		WHERE workspace_id = ? AND (id = ? OR slug = ?)
 	`, workspaceID, idOrSlug, idOrSlug).Scan(
 		&role.ID, &role.WorkspaceID, &role.Slug, &role.Name, &role.Description,
-		&role.Icon, &role.SortOrder, &createdAt, &updatedAt,
+		&role.Icon, &role.Tools, &role.SortOrder, &createdAt, &updatedAt,
 	)
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -61,7 +62,7 @@ func (s *Store) GetAgentRole(workspaceID, idOrSlug string) (*models.AgentRole, e
 
 func (s *Store) ListAgentRoles(workspaceID string) ([]models.AgentRole, error) {
 	rows, err := s.db.Query(`
-		SELECT r.id, r.workspace_id, r.slug, r.name, r.description, r.icon, r.sort_order,
+		SELECT r.id, r.workspace_id, r.slug, r.name, r.description, r.icon, r.tools, r.sort_order,
 		       r.created_at, r.updated_at,
 		       COUNT(i.id) as item_count
 		FROM agent_roles r
@@ -81,7 +82,7 @@ func (s *Store) ListAgentRoles(workspaceID string) ([]models.AgentRole, error) {
 		var createdAt, updatedAt string
 		if err := rows.Scan(
 			&role.ID, &role.WorkspaceID, &role.Slug, &role.Name, &role.Description,
-			&role.Icon, &role.SortOrder, &createdAt, &updatedAt, &role.ItemCount,
+			&role.Icon, &role.Tools, &role.SortOrder, &createdAt, &updatedAt, &role.ItemCount,
 		); err != nil {
 			return nil, err
 		}
@@ -124,6 +125,10 @@ func (s *Store) UpdateAgentRole(workspaceID, id string, input models.AgentRoleUp
 		sets = append(sets, "icon = ?")
 		args = append(args, *input.Icon)
 	}
+	if input.Tools != nil {
+		sets = append(sets, "tools = ?")
+		args = append(args, *input.Tools)
+	}
 	if input.SortOrder != nil {
 		sets = append(sets, "sort_order = ?")
 		args = append(args, *input.SortOrder)
@@ -151,6 +156,233 @@ func (s *Store) DeleteAgentRole(workspaceID, id string) error {
 		return sql.ErrNoRows
 	}
 	return nil
+}
+
+// RoleBreakdown is a summary of items per role for the dashboard.
+type RoleBreakdown struct {
+	RoleID    *string  `json:"role_id"`
+	RoleName  string   `json:"role_name"`
+	RoleSlug  string   `json:"role_slug"`
+	RoleIcon  string   `json:"role_icon"`
+	Tools     string   `json:"tools"`
+	ItemCount int      `json:"item_count"`
+	Users     []string `json:"assigned_users"`
+}
+
+// GetRoleBreakdown returns item counts and assigned users grouped by agent role.
+// Includes an entry for unassigned items (role_id = nil).
+func (s *Store) GetRoleBreakdown(workspaceID string) ([]RoleBreakdown, error) {
+	// Get all roles first (even those with 0 items)
+	roles, err := s.ListAgentRoles(workspaceID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Count non-terminal items per role
+	rows, err := s.db.Query(`
+		SELECT i.agent_role_id, COUNT(*) as cnt, GROUP_CONCAT(DISTINCT u.name) as users
+		FROM items i
+		LEFT JOIN users u ON u.id = i.assigned_user_id
+		WHERE i.workspace_id = ? AND i.deleted_at IS NULL
+		GROUP BY i.agent_role_id
+	`, workspaceID)
+	if err != nil {
+		return nil, fmt.Errorf("role breakdown: %w", err)
+	}
+	defer rows.Close()
+
+	type countRow struct {
+		roleID *string
+		count  int
+		users  string
+	}
+	counts := make(map[string]countRow) // key: role ID or ""
+	var unassigned countRow
+
+	for rows.Next() {
+		var roleID *string
+		var cnt int
+		var users *string
+		if err := rows.Scan(&roleID, &cnt, &users); err != nil {
+			return nil, err
+		}
+		u := ""
+		if users != nil {
+			u = *users
+		}
+		if roleID == nil {
+			unassigned = countRow{nil, cnt, u}
+		} else {
+			counts[*roleID] = countRow{roleID, cnt, u}
+		}
+	}
+
+	var result []RoleBreakdown
+	for _, role := range roles {
+		cr := counts[role.ID]
+		var userList []string
+		if cr.users != "" {
+			userList = strings.Split(cr.users, ",")
+		}
+		result = append(result, RoleBreakdown{
+			RoleID:    &role.ID,
+			RoleName:  role.Name,
+			RoleSlug:  role.Slug,
+			RoleIcon:  role.Icon,
+			Tools:     role.Tools,
+			ItemCount: cr.count,
+			Users:     userList,
+		})
+	}
+
+	// Add unassigned
+	if unassigned.count > 0 {
+		var userList []string
+		if unassigned.users != "" {
+			userList = strings.Split(unassigned.users, ",")
+		}
+		result = append(result, RoleBreakdown{
+			RoleID:    nil,
+			RoleName:  "",
+			RoleSlug:  "",
+			RoleIcon:  "",
+			ItemCount: unassigned.count,
+			Users:     userList,
+		})
+	}
+
+	return result, rows.Err()
+}
+
+// RoleBoardLane represents a single lane in the role board view.
+type RoleBoardLane struct {
+	Role  *models.AgentRole `json:"role"` // nil for unassigned
+	Items []models.Item     `json:"items"`
+	Users []string          `json:"assigned_users"`
+}
+
+// RoleBoardParams configures the role board query.
+type RoleBoardParams struct {
+	AssignedUserID string
+}
+
+// GetRoleBoardItems returns non-terminal items across all collections, grouped by role.
+func (s *Store) GetRoleBoardItems(workspaceID string, params RoleBoardParams) ([]RoleBoardLane, error) {
+	// Get all roles
+	roles, err := s.ListAgentRoles(workspaceID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Fetch all non-archived items
+	listParams := models.ItemListParams{
+		IncludeArchived: false,
+	}
+	if params.AssignedUserID != "" {
+		listParams.AssignedUserID = params.AssignedUserID
+	}
+	allItems, err := s.ListItems(workspaceID, listParams)
+	if err != nil {
+		return nil, err
+	}
+
+	// Filter out terminal-status items
+	var activeItems []models.Item
+	for _, item := range allItems {
+		status := ""
+		if item.Fields != "" && item.Fields != "{}" {
+			var fields map[string]interface{}
+			if err := json.Unmarshal([]byte(item.Fields), &fields); err == nil {
+				if v, ok := fields["status"].(string); ok {
+					status = v
+				}
+			}
+		}
+		if !isDoneStatus(status) {
+			activeItems = append(activeItems, item)
+		}
+	}
+
+	// Group by role
+	roleMap := make(map[string]*RoleBoardLane) // role ID → lane
+	var unassignedLane RoleBoardLane
+
+	for _, role := range roles {
+		r := role // copy
+		roleMap[role.ID] = &RoleBoardLane{
+			Role:  &r,
+			Items: []models.Item{},
+			Users: []string{},
+		}
+	}
+
+	userSets := make(map[string]map[string]bool) // role ID → set of user names
+
+	for _, item := range activeItems {
+		var lane *RoleBoardLane
+		roleKey := ""
+		if item.AgentRoleID != nil && *item.AgentRoleID != "" {
+			roleKey = *item.AgentRoleID
+			lane = roleMap[roleKey]
+		}
+		if lane == nil {
+			roleKey = ""
+			unassignedLane.Items = append(unassignedLane.Items, item)
+			if item.AssignedUserName != "" {
+				if unassignedLane.Users == nil {
+					unassignedLane.Users = []string{}
+				}
+			}
+			continue
+		}
+		lane.Items = append(lane.Items, item)
+		if item.AssignedUserName != "" {
+			if userSets[roleKey] == nil {
+				userSets[roleKey] = make(map[string]bool)
+			}
+			userSets[roleKey][item.AssignedUserName] = true
+		}
+	}
+
+	// Build result in role order
+	var result []RoleBoardLane
+	for _, role := range roles {
+		lane := roleMap[role.ID]
+		if us, ok := userSets[role.ID]; ok {
+			for u := range us {
+				lane.Users = append(lane.Users, u)
+			}
+		}
+		result = append(result, *lane)
+	}
+
+	// Add unassigned lane
+	if len(unassignedLane.Items) > 0 {
+		// Dedupe users
+		userSet := make(map[string]bool)
+		for _, item := range unassignedLane.Items {
+			if item.AssignedUserName != "" {
+				userSet[item.AssignedUserName] = true
+			}
+		}
+		unassignedLane.Users = []string{}
+		for u := range userSet {
+			unassignedLane.Users = append(unassignedLane.Users, u)
+		}
+		result = append(result, unassignedLane)
+	}
+
+	return result, nil
+}
+
+// isDoneStatus returns true if the status indicates a terminal/completed item.
+func isDoneStatus(status string) bool {
+	switch strings.ToLower(status) {
+	case "done", "completed", "resolved", "cancelled", "rejected", "wontfix", "fixed", "implemented", "archived", "disabled":
+		return true
+	default:
+		return false
+	}
 }
 
 // ResolveAgentRoleID resolves a role identifier (ID or slug) to its UUID.

--- a/internal/store/agent_roles.go
+++ b/internal/store/agent_roles.go
@@ -178,12 +178,14 @@ func (s *Store) GetRoleBreakdown(workspaceID string) ([]RoleBreakdown, error) {
 		return nil, err
 	}
 
-	// Count non-terminal items per role
+	// Count non-terminal items per role (exclude done/completed/etc. to match board view)
 	rows, err := s.db.Query(`
 		SELECT i.agent_role_id, COUNT(*) as cnt, GROUP_CONCAT(DISTINCT u.name) as users
 		FROM items i
 		LEFT JOIN users u ON u.id = i.assigned_user_id
 		WHERE i.workspace_id = ? AND i.deleted_at IS NULL
+		  AND LOWER(COALESCE(json_extract(i.fields, '$.status'), '')) NOT IN
+		      ('done','completed','resolved','cancelled','rejected','wontfix','fixed','implemented','archived','disabled')
 		GROUP BY i.agent_role_id
 	`, workspaceID)
 	if err != nil {
@@ -224,8 +226,9 @@ func (s *Store) GetRoleBreakdown(workspaceID string) ([]RoleBreakdown, error) {
 		if cr.users != "" {
 			userList = strings.Split(cr.users, ",")
 		}
+		roleID := role.ID // local copy to avoid pointer to range variable
 		result = append(result, RoleBreakdown{
-			RoleID:    &role.ID,
+			RoleID:    &roleID,
 			RoleName:  role.Name,
 			RoleSlug:  role.Slug,
 			RoleIcon:  role.Icon,

--- a/internal/store/migrations/019_agent_roles_tools.sql
+++ b/internal/store/migrations/019_agent_roles_tools.sql
@@ -1,0 +1,3 @@
+-- Add tools text field to agent_roles for free-text notes about preferred tools/models.
+-- e.g. "Claude Code + Sonnet 4.6", "Codex CLI", "Cursor with GPT-4"
+ALTER TABLE agent_roles ADD COLUMN tools TEXT NOT NULL DEFAULT '';

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -84,6 +84,7 @@ func (s *Store) migrate() error {
 		"016_timeline.sql",
 		"017_agent_roles.sql",
 		"018_conventions_role_field.sql",
+		"019_agent_roles_tools.sql",
 	}
 
 	for _, name := range migrations {

--- a/skills/pad/SKILL.md
+++ b/skills/pad/SKILL.md
@@ -68,6 +68,7 @@ Once a role is active, adjust your behavior:
 
 **Greeting:** When presenting status or responding to queries, lead with the role context:
 - *"Working as 🔨 Implementer. You have 3 items in your queue."*
+- Mention the role board for visual overview: *"See the full role board at the web UI → Roles page, or run `pad server open`."*
 
 **Querying "what's on my plate" / "what should I work on":**
 ```bash
@@ -106,7 +107,8 @@ Interpret the user's intent and route to the appropriate action. Here are common
 - "create a role called Designer" → `pad role create "Designer" --description "..." --icon "🎨"`
 - "assign TASK-5 to Dave as reviewer" → `pad item update TASK-5 --role reviewer --assign Dave`
 - "what's on Dave's plate as implementer?" → `pad item list tasks --role implementer --assign Dave --format json`
-- "who's working on what?" → Show items grouped by role assignment
+- "who's working on what?" → Show items grouped by role assignment, or suggest the role board: *"Check the role board in the web UI for a visual overview — `pad server open`"*
+- "show me the role board" → Suggest opening the web UI: `pad server open` (the role board is at /{workspace}/roles)
 
 **Creating items:**
 - "I have an idea for X" → Create an Idea item

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -31,7 +31,8 @@ import type {
 	TimelineResponse,
 	AgentRole,
 	AgentRoleCreate,
-	AgentRoleUpdate
+	AgentRoleUpdate,
+	RoleBoardLane
 } from '$lib/types';
 
 const BASE = '/api/v1';
@@ -176,7 +177,12 @@ export const api = {
 		delete: (ws: string, idOrSlug: string) =>
 			request<void>(`/workspaces/${ws}/agent-roles/${idOrSlug}`, {
 				method: 'DELETE'
-			})
+			}),
+
+		board: (ws: string, assignedUserId?: string) => {
+			const params = assignedUserId ? `?assigned_user_id=${assignedUserId}` : '';
+			return request<{ lanes: RoleBoardLane[] }>(`/workspaces/${ws}/roles/board${params}`);
+		}
 	},
 
 	// ── Items ─────────────────────────────────────────────────────────────────

--- a/web/src/lib/components/layout/Sidebar.svelte
+++ b/web/src/lib/components/layout/Sidebar.svelte
@@ -20,6 +20,7 @@
 
 	let wsSlug = $derived(workspaceStore.current?.slug);
 	let isDashboardPage = $derived(wsSlug ? page.url.pathname === `/${wsSlug}` : false);
+	let isRolesPage = $derived(wsSlug ? page.url.pathname === `/${wsSlug}/roles` : false);
 	let isActivityPage = $derived(wsSlug ? page.url.pathname === `/${wsSlug}/activity` : false);
 
 	let activeCollectionSlug = $derived.by(() => {
@@ -273,6 +274,15 @@
 				>
 					<span class="nav-icon">📊</span>
 					<span class="nav-label">Dashboard</span>
+				</a>
+				<a
+					href="/{wsSlug}/roles"
+					class="nav-item"
+					class:active={isRolesPage}
+					onclick={() => uiStore.onNavigate()}
+				>
+					<span class="nav-icon">🎭</span>
+					<span class="nav-label">Roles</span>
 				</a>
 				<a
 					href="/{wsSlug}/activity"

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -200,6 +200,7 @@ export interface AgentRole {
 	name: string;
 	description: string;
 	icon: string;
+	tools: string;
 	sort_order: number;
 	created_at: string;
 	updated_at: string;
@@ -211,6 +212,7 @@ export interface AgentRoleCreate {
 	slug?: string;
 	description?: string;
 	icon?: string;
+	tools?: string;
 }
 
 export interface AgentRoleUpdate {
@@ -218,7 +220,14 @@ export interface AgentRoleUpdate {
 	slug?: string;
 	description?: string;
 	icon?: string;
+	tools?: string;
 	sort_order?: number;
+}
+
+export interface RoleBoardLane {
+	role: AgentRole | null;
+	items: Item[];
+	assigned_users: string[];
 }
 
 // ─── Items ───────────────────────────────────────────────────────────────────

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -342,6 +342,10 @@ export interface ItemUpdate {
 	pinned?: boolean;
 	sort_order?: number;
 	parent_id?: string;
+	assigned_user_id?: string;
+	agent_role_id?: string;
+	clear_assigned_user?: boolean;
+	clear_agent_role?: boolean;
 	last_modified_by?: string;
 	source?: string;
 	comment?: string;

--- a/web/src/routes/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[workspace]/[collection]/[slug]/+page.svelte
@@ -15,7 +15,7 @@
 	import { goto } from '$app/navigation';
 	import { relativeTime, wikiLinksToMarkdown, markdownToWikiLinks, cleanBrokenLinks } from '$lib/utils/markdown';
 	import { toastStore } from '$lib/stores/toast.svelte';
-	import type { Item, Collection, CollectionSettings, QuickAction, ItemLink, ItemRelationRef } from '$lib/types';
+	import type { Item, Collection, CollectionSettings, QuickAction, ItemLink, ItemRelationRef, AgentRole } from '$lib/types';
 	import { parseFields, parseSchema, parseSettings, formatItemRef } from '$lib/types';
 	import QuickActionsMenu from '$lib/components/common/QuickActionsMenu.svelte';
 
@@ -73,6 +73,8 @@
 	let showMoveMenu = $state(false);
 	let moving = $state(false);
 	let itemLinks = $state<ItemLink[]>([]);
+	let workspaceMembers = $state<{ user_id: string; user_name: string; user_email: string }[]>([]);
+	let agentRoles = $state<AgentRole[]>([]);
 	let relationshipGroups = $derived(item ? buildRelationshipGroups(item, itemLinks) : []);
 	let closureEntries = $derived(item?.derived_closure?.related_items?.map((related) => relationRefEntry(related)) ?? []);
 	let codeContext = $derived(item?.code_context ?? null);
@@ -148,6 +150,15 @@
 			try {
 				itemLinks = await api.links.list(wsSlug, itemData.slug);
 			} catch { itemLinks = []; }
+
+			// Load workspace members and agent roles for assignment picker
+			try {
+				const membersData = await api.members.list(wsSlug);
+				workspaceMembers = membersData.members ?? [];
+			} catch { workspaceMembers = []; }
+			try {
+				agentRoles = await api.agentRoles.list(wsSlug);
+			} catch { agentRoles = []; }
 		} catch (e: any) {
 			error = e.message ?? 'Failed to load item';
 		} finally {
@@ -212,6 +223,42 @@
 		} catch {
 			saveStatus = 'idle';
 			toastStore.show('Failed to save', 'error');
+		}
+	}
+
+	async function updateAssignedUser(userId: string | null) {
+		if (!item) return;
+		saveStatus = 'saving';
+		try {
+			const update: Record<string, any> = {};
+			if (userId) {
+				update.assigned_user_id = userId;
+			} else {
+				update.clear_assigned_user = true;
+			}
+			item = await api.items.update(wsSlug, item.id, update);
+			showSaved();
+		} catch {
+			saveStatus = 'idle';
+			toastStore.show('Failed to update assignment', 'error');
+		}
+	}
+
+	async function updateAgentRole(roleId: string | null) {
+		if (!item) return;
+		saveStatus = 'saving';
+		try {
+			const update: Record<string, any> = {};
+			if (roleId) {
+				update.agent_role_id = roleId;
+			} else {
+				update.clear_agent_role = true;
+			}
+			item = await api.items.update(wsSlug, item.id, update);
+			showSaved();
+		} catch {
+			saveStatus = 'idle';
+			toastStore.show('Failed to update role', 'error');
 		}
 	}
 
@@ -565,24 +612,46 @@
 				{/each}
 
 				<!-- Assignment: user + role -->
-				{#if item.assigned_user_name || item.agent_role_name}
+				{#if workspaceMembers.length > 0 || agentRoles.length > 0}
 					<div class="fields-header" style="margin-top: var(--space-4)">Assignment</div>
 				{/if}
-				{#if item.assigned_user_name}
+				{#if workspaceMembers.length > 0}
 					<div class="field-row">
 						<span class="field-label">Assigned to</span>
 						<div class="field-value">
-							<span class="assignment-value">{item.assigned_user_name}</span>
+							<select
+								class="assignment-select"
+								value={item.assigned_user_id ?? ''}
+								onchange={(e) => {
+									const val = (e.target as HTMLSelectElement).value;
+									updateAssignedUser(val || null);
+								}}
+							>
+								<option value="">Unassigned</option>
+								{#each workspaceMembers as member (member.user_id)}
+									<option value={member.user_id}>{member.user_name}</option>
+								{/each}
+							</select>
 						</div>
 					</div>
 				{/if}
-				{#if item.agent_role_name}
+				{#if agentRoles.length > 0}
 					<div class="field-row">
 						<span class="field-label">Role</span>
 						<div class="field-value">
-							<span class="assignment-value">
-								{#if item.agent_role_icon}{item.agent_role_icon} {/if}{item.agent_role_name}
-							</span>
+							<select
+								class="assignment-select"
+								value={item.agent_role_id ?? ''}
+								onchange={(e) => {
+									const val = (e.target as HTMLSelectElement).value;
+									updateAgentRole(val || null);
+								}}
+							>
+								<option value="">No role</option>
+								{#each agentRoles as role (role.id)}
+									<option value={role.id}>{role.icon ? role.icon + ' ' : ''}{role.name}</option>
+								{/each}
+							</select>
 						</div>
 					</div>
 				{/if}
@@ -878,6 +947,25 @@
 	.computed-value {
 		font-size: 0.88em;
 		color: var(--text-secondary);
+	}
+	.assignment-select {
+		width: 100%;
+		padding: 5px 8px;
+		font-size: 0.88em;
+		font-family: inherit;
+		color: var(--text-primary);
+		background: var(--bg-tertiary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius-sm);
+		cursor: pointer;
+		appearance: auto;
+	}
+	.assignment-select:hover {
+		border-color: var(--accent-blue);
+	}
+	.assignment-select:focus {
+		outline: 2px solid var(--accent-blue);
+		outline-offset: -1px;
 	}
 	.progress-bar {
 		position: relative;

--- a/web/src/routes/[workspace]/roles/+page.svelte
+++ b/web/src/routes/[workspace]/roles/+page.svelte
@@ -1,0 +1,572 @@
+<script lang="ts">
+	import { page } from '$app/state';
+	import { onMount } from 'svelte';
+	import { api } from '$lib/api/client';
+	import { workspaceStore } from '$lib/stores/workspace.svelte';
+	import { uiStore } from '$lib/stores/ui.svelte';
+	import { parseFields, formatItemRef, itemUrlId } from '$lib/types';
+	import type { RoleBoardLane } from '$lib/types';
+
+	let wsSlug = $derived(page.params.workspace ?? '');
+
+	// Data
+	let lanes = $state<RoleBoardLane[]>([]);
+	let loading = $state(true);
+	let error = $state('');
+
+	// Filter: "My Work" toggle
+	let myWorkOnly = $state(false);
+	let currentUserId = $state('');
+
+	// Filtered lanes based on "My Work" toggle
+	let filteredLanes = $derived.by(() => {
+		if (!myWorkOnly || !currentUserId) return lanes;
+		return lanes
+			.map((lane) => ({
+				...lane,
+				items: lane.items.filter((item) => item.assigned_user_id === currentUserId)
+			}))
+			.filter((lane) => lane.items.length > 0);
+	});
+
+	// Total item count
+	let totalItems = $derived(filteredLanes.reduce((sum, lane) => sum + lane.items.length, 0));
+
+	onMount(() => {
+		workspaceStore.setCurrent(wsSlug);
+		uiStore.onNavigate();
+		loadData();
+	});
+
+	async function loadData() {
+		loading = true;
+		error = '';
+		try {
+			const [boardResult, session] = await Promise.all([
+				api.agentRoles.board(wsSlug),
+				api.auth.session()
+			]);
+			lanes = boardResult.lanes;
+			if (session.authenticated && session.user) {
+				currentUserId = session.user.id;
+			}
+		} catch (err) {
+			error = err instanceof Error ? err.message : 'Failed to load role board';
+		} finally {
+			loading = false;
+		}
+	}
+
+	function statusColor(status: string): string {
+		const s = status.toLowerCase();
+		if (s === 'done' || s === 'completed' || s === 'closed') return 'var(--accent-green)';
+		if (s === 'in progress' || s === 'in_progress' || s === 'active') return 'var(--accent-blue)';
+		if (s === 'blocked') return 'var(--accent-orange)';
+		if (s === 'todo' || s === 'open' || s === 'backlog') return 'var(--text-muted)';
+		return 'var(--text-secondary)';
+	}
+
+	function priorityColor(priority: string): string {
+		const p = priority.toLowerCase();
+		if (p === 'critical' || p === 'urgent') return 'var(--accent-orange)';
+		if (p === 'high') return 'var(--accent-amber)';
+		if (p === 'medium') return 'var(--accent-blue)';
+		if (p === 'low') return 'var(--accent-teal)';
+		return 'var(--text-muted)';
+	}
+</script>
+
+<svelte:head>
+	<title>Role Board - {workspaceStore.current?.name ?? wsSlug} | Pad</title>
+</svelte:head>
+
+<div class="role-board-page">
+	<header class="page-header">
+		<div class="page-header-left">
+			<h1><span class="page-icon" aria-hidden="true">&#127917;</span> Role Board</h1>
+			{#if !loading}
+				<span class="item-count">{totalItems} item{totalItems === 1 ? '' : 's'}</span>
+			{/if}
+		</div>
+		<div class="page-header-right">
+			<button
+				class="toggle-btn"
+				class:active={myWorkOnly}
+				onclick={() => (myWorkOnly = !myWorkOnly)}
+			>
+				My Work
+			</button>
+		</div>
+	</header>
+
+	{#if loading}
+		<div class="skeleton-board">
+			{#each Array(4) as _, i (i)}
+				<div class="skeleton-lane">
+					<div class="skeleton-lane-header"></div>
+					{#each Array(3) as _, j (j)}
+						<div class="skeleton-card"></div>
+					{/each}
+				</div>
+			{/each}
+		</div>
+	{:else if error}
+		<div class="empty-state">
+			<div class="empty-icon">!</div>
+			<p class="empty-title">Failed to load</p>
+			<p class="empty-desc">{error}</p>
+			<button class="retry-btn" onclick={loadData}>Retry</button>
+		</div>
+	{:else if filteredLanes.length === 0}
+		<div class="empty-state">
+			{#if myWorkOnly}
+				<div class="empty-icon">&#128100;</div>
+				<p class="empty-title">No items assigned to you</p>
+				<p class="empty-desc">
+					Turn off "My Work" to see all items, or assign items to yourself from the item detail page.
+				</p>
+			{:else}
+				<div class="empty-icon">&#127917;</div>
+				<p class="empty-title">No roles configured</p>
+				<p class="empty-desc">
+					Agent roles let you partition work across different AI agents or team members.
+					Create roles in workspace settings, then assign items to roles from the item detail page.
+				</p>
+			{/if}
+		</div>
+	{:else}
+		<div class="lanes-container">
+			{#each filteredLanes as lane (lane.role?.id ?? '__unassigned')}
+				{@const isUnassigned = !lane.role}
+				<div class="lane" class:unassigned={isUnassigned}>
+					<div class="lane-header">
+						<div class="lane-title-row">
+							{#if lane.role}
+								<span class="lane-icon">{lane.role.icon || '&#129302;'}</span>
+								<span class="lane-name">{lane.role.name}</span>
+							{:else}
+								<span class="lane-name unassigned-name">Unassigned</span>
+							{/if}
+							<span class="lane-count">{lane.items.length}</span>
+						</div>
+						{#if lane.role?.tools}
+							<div class="lane-tools">{lane.role.tools}</div>
+						{/if}
+						{#if lane.assigned_users.length > 0}
+							<div class="lane-users">
+								{#each lane.assigned_users as user (user)}
+									<span class="user-pill">{user}</span>
+								{/each}
+							</div>
+						{/if}
+					</div>
+
+					<div class="lane-items">
+						{#each lane.items as item (item.id)}
+							{@const fields = parseFields(item)}
+							{@const ref = formatItemRef(item)}
+							{@const status = fields.status ?? ''}
+							{@const priority = fields.priority ?? ''}
+							<a
+								href="/{wsSlug}/{item.collection_slug}/{itemUrlId(item)}"
+								class="item-card"
+							>
+								<div class="card-top-row">
+									{#if item.collection_icon || item.collection_name}
+										<span class="collection-badge">
+											{#if item.collection_icon}<span class="coll-icon">{item.collection_icon}</span>{/if}
+											{#if item.collection_name}<span class="coll-name">{item.collection_name}</span>{/if}
+										</span>
+									{/if}
+									{#if ref}
+										<span class="item-ref">{ref}</span>
+									{/if}
+								</div>
+
+								<div class="card-title">{item.title}</div>
+
+								<div class="card-meta">
+									{#if status}
+										<span class="status-badge" style="color: {statusColor(status)}">
+											{status}
+										</span>
+									{/if}
+									{#if priority}
+										<span class="priority-badge" style="color: {priorityColor(priority)}">
+											{priority}
+										</span>
+									{/if}
+									{#if item.assigned_user_name}
+										<span class="assigned-user">{item.assigned_user_name}</span>
+									{/if}
+								</div>
+							</a>
+						{/each}
+						{#if lane.items.length === 0}
+							<div class="lane-empty">No items</div>
+						{/if}
+					</div>
+				</div>
+			{/each}
+		</div>
+	{/if}
+</div>
+
+<style>
+	/* ── Page Layout ──────────────────────────────────────────────────── */
+	.role-board-page {
+		padding: var(--space-6);
+		height: 100%;
+		display: flex;
+		flex-direction: column;
+	}
+
+	/* ── Header ───────────────────────────────────────────────────────── */
+	.page-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: var(--space-4);
+		margin-bottom: var(--space-5);
+		flex-shrink: 0;
+	}
+	.page-header-left {
+		display: flex;
+		align-items: baseline;
+		gap: var(--space-3);
+	}
+	.page-header h1 {
+		font-size: 1.6em;
+		font-weight: 700;
+		display: flex;
+		align-items: center;
+		gap: var(--space-2);
+	}
+	.page-icon {
+		font-size: 0.85em;
+	}
+	.item-count {
+		font-size: 0.9em;
+		color: var(--text-muted);
+	}
+	.page-header-right {
+		display: flex;
+		align-items: center;
+		gap: var(--space-3);
+	}
+
+	/* ── Toggle Button ────────────────────────────────────────────────── */
+	.toggle-btn {
+		background: var(--bg-secondary);
+		color: var(--text-secondary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+		padding: var(--space-2) var(--space-4);
+		font-size: 0.85em;
+		font-weight: 600;
+		cursor: pointer;
+		transition: background 0.15s, border-color 0.15s, color 0.15s;
+	}
+	.toggle-btn:hover {
+		border-color: var(--text-muted);
+		color: var(--text-primary);
+	}
+	.toggle-btn.active {
+		background: color-mix(in srgb, var(--accent-blue) 15%, transparent);
+		color: var(--accent-blue);
+		border-color: var(--accent-blue);
+	}
+
+	/* ── Lanes Container ──────────────────────────────────────────────── */
+	.lanes-container {
+		display: flex;
+		gap: var(--space-4);
+		overflow-x: auto;
+		flex: 1;
+		align-items: flex-start;
+		padding-bottom: var(--space-4);
+	}
+
+	/* ── Lane ─────────────────────────────────────────────────────────── */
+	.lane {
+		flex: 0 0 280px;
+		min-width: 280px;
+		background: var(--bg-secondary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius-lg);
+		display: flex;
+		flex-direction: column;
+		max-height: 100%;
+	}
+
+	.lane-header {
+		padding: var(--space-4) var(--space-4) var(--space-3);
+		border-bottom: 1px solid var(--border);
+		position: sticky;
+		top: 0;
+		background: var(--bg-secondary);
+		border-radius: var(--radius-lg) var(--radius-lg) 0 0;
+		z-index: 1;
+	}
+
+	.lane-title-row {
+		display: flex;
+		align-items: center;
+		gap: var(--space-2);
+	}
+	.lane-icon {
+		font-size: 1.1em;
+		flex-shrink: 0;
+	}
+	.lane-name {
+		font-weight: 700;
+		font-size: 0.95em;
+		color: var(--text-primary);
+		flex: 1;
+		min-width: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+	.unassigned-name {
+		color: var(--text-muted);
+	}
+	.lane-count {
+		font-size: 0.75em;
+		font-weight: 700;
+		background: var(--bg-tertiary);
+		color: var(--text-muted);
+		padding: 1px 8px;
+		border-radius: 10px;
+		flex-shrink: 0;
+	}
+
+	.lane-tools {
+		font-size: 0.75em;
+		color: var(--text-muted);
+		margin-top: var(--space-1);
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.lane-users {
+		display: flex;
+		flex-wrap: wrap;
+		gap: var(--space-1);
+		margin-top: var(--space-2);
+	}
+	.user-pill {
+		font-size: 0.7em;
+		font-weight: 600;
+		background: color-mix(in srgb, var(--accent-teal) 15%, transparent);
+		color: var(--accent-teal);
+		padding: 1px 8px;
+		border-radius: 10px;
+		white-space: nowrap;
+	}
+
+	/* ── Lane Items ───────────────────────────────────────────────────── */
+	.lane-items {
+		padding: var(--space-2);
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-2);
+		overflow-y: auto;
+		flex: 1;
+	}
+
+	.lane-empty {
+		text-align: center;
+		padding: var(--space-4);
+		color: var(--text-muted);
+		font-size: 0.85em;
+	}
+
+	/* ── Item Card ────────────────────────────────────────────────────── */
+	.item-card {
+		display: block;
+		padding: var(--space-3);
+		background: var(--bg-primary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+		text-decoration: none;
+		color: inherit;
+		transition: border-color 0.15s, background 0.15s;
+	}
+	.item-card:hover {
+		border-color: var(--text-muted);
+		background: var(--bg-hover);
+	}
+
+	.card-top-row {
+		display: flex;
+		align-items: center;
+		gap: var(--space-2);
+		margin-bottom: var(--space-1);
+		flex-wrap: wrap;
+	}
+
+	.collection-badge {
+		display: inline-flex;
+		align-items: center;
+		gap: 3px;
+		font-size: 0.7em;
+		background: var(--bg-tertiary);
+		padding: 1px 7px;
+		border-radius: 10px;
+		color: var(--text-muted);
+		white-space: nowrap;
+	}
+	.coll-icon {
+		font-size: 1em;
+	}
+	.coll-name {
+		font-weight: 600;
+	}
+
+	.item-ref {
+		font-family: var(--font-mono);
+		font-size: 0.7em;
+		color: var(--text-muted);
+		white-space: nowrap;
+	}
+
+	.card-title {
+		font-size: 0.875em;
+		font-weight: 600;
+		color: var(--text-primary);
+		line-height: 1.35;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		display: -webkit-box;
+		-webkit-line-clamp: 2;
+		-webkit-box-orient: vertical;
+	}
+
+	.card-meta {
+		display: flex;
+		align-items: center;
+		gap: var(--space-2);
+		flex-wrap: wrap;
+		margin-top: var(--space-2);
+	}
+
+	.status-badge {
+		font-size: 0.7em;
+		font-weight: 700;
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+	}
+
+	.priority-badge {
+		font-size: 0.7em;
+		font-weight: 600;
+		text-transform: capitalize;
+	}
+
+	.assigned-user {
+		font-size: 0.7em;
+		color: var(--text-muted);
+		margin-left: auto;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		max-width: 100px;
+	}
+
+	/* ── Empty State ──────────────────────────────────────────────────── */
+	.empty-state {
+		text-align: center;
+		padding: var(--space-10) var(--space-4);
+		color: var(--text-muted);
+	}
+	.empty-icon {
+		font-size: 2em;
+		margin-bottom: var(--space-3);
+		opacity: 0.5;
+	}
+	.empty-title {
+		font-size: 1.1em;
+		font-weight: 600;
+		color: var(--text-secondary);
+		margin-bottom: var(--space-2);
+	}
+	.empty-desc {
+		font-size: 0.9em;
+		max-width: 400px;
+		margin: 0 auto;
+		line-height: 1.5;
+	}
+	.retry-btn {
+		margin-top: var(--space-4);
+		background: var(--bg-secondary);
+		color: var(--text-secondary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+		padding: var(--space-2) var(--space-5);
+		font-size: 0.85em;
+		font-weight: 600;
+		cursor: pointer;
+		transition: background 0.15s, border-color 0.15s;
+	}
+	.retry-btn:hover {
+		border-color: var(--text-muted);
+		background: var(--bg-hover);
+	}
+
+	/* ── Skeleton ─────────────────────────────────────────────────────── */
+	.skeleton-board {
+		display: flex;
+		gap: var(--space-4);
+		flex: 1;
+	}
+	.skeleton-lane {
+		flex: 0 0 280px;
+		background: var(--bg-secondary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius-lg);
+		padding: var(--space-4);
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-3);
+	}
+	.skeleton-lane-header {
+		height: 24px;
+		width: 60%;
+		background: var(--bg-tertiary);
+		border-radius: var(--radius-sm);
+		animation: skeleton-pulse 1.5s ease-in-out infinite;
+	}
+	.skeleton-card {
+		height: 80px;
+		background: var(--bg-tertiary);
+		border-radius: var(--radius);
+		animation: skeleton-pulse 1.5s ease-in-out infinite;
+	}
+	@keyframes skeleton-pulse {
+		0%,
+		100% {
+			opacity: 0.5;
+		}
+		50% {
+			opacity: 1;
+		}
+	}
+
+	/* ── Responsive ───────────────────────────────────────────────────── */
+	@media (max-width: 768px) {
+		.role-board-page {
+			padding: var(--space-4);
+		}
+		.lanes-container {
+			flex-direction: column;
+		}
+		.lane {
+			flex: 0 0 auto;
+			min-width: unset;
+			width: 100%;
+			max-height: none;
+		}
+	}
+</style>

--- a/web/src/routes/[workspace]/roles/+page.svelte
+++ b/web/src/routes/[workspace]/roles/+page.svelte
@@ -5,7 +5,7 @@
 	import { workspaceStore } from '$lib/stores/workspace.svelte';
 	import { uiStore } from '$lib/stores/ui.svelte';
 	import { parseFields, formatItemRef, itemUrlId } from '$lib/types';
-	import type { RoleBoardLane } from '$lib/types';
+	import type { RoleBoardLane, AgentRole } from '$lib/types';
 
 	let wsSlug = $derived(page.params.workspace ?? '');
 
@@ -16,6 +16,19 @@
 
 	// Filter: "My Work" toggle
 	let myWorkOnly = $state(false);
+
+	// Role management state
+	let showManageRoles = $state(false);
+	let allRoles = $state<AgentRole[]>([]);
+	let newRoleName = $state('');
+	let newRoleDescription = $state('');
+	let newRoleIcon = $state('');
+	let newRoleTools = $state('');
+	let editingRoleId = $state<string | null>(null);
+	let editName = $state('');
+	let editDescription = $state('');
+	let editIcon = $state('');
+	let editTools = $state('');
 	let currentUserId = $state('');
 
 	// Filtered lanes based on "My Work" toggle
@@ -36,6 +49,7 @@
 		workspaceStore.setCurrent(wsSlug);
 		uiStore.onNavigate();
 		loadData();
+		loadRoles();
 	});
 
 	async function loadData() {
@@ -54,6 +68,72 @@
 			error = err instanceof Error ? err.message : 'Failed to load role board';
 		} finally {
 			loading = false;
+		}
+	}
+
+	async function loadRoles() {
+		try {
+			allRoles = await api.agentRoles.list(wsSlug);
+		} catch { allRoles = []; }
+	}
+
+	async function createRole() {
+		if (!newRoleName.trim()) return;
+		try {
+			await api.agentRoles.create(wsSlug, {
+				name: newRoleName.trim(),
+				description: newRoleDescription.trim(),
+				icon: newRoleIcon.trim(),
+				tools: newRoleTools.trim()
+			});
+			newRoleName = '';
+			newRoleDescription = '';
+			newRoleIcon = '';
+			newRoleTools = '';
+			await loadRoles();
+			await loadBoard();
+		} catch (e) {
+			console.error('Failed to create role:', e);
+		}
+	}
+
+	function startEdit(role: AgentRole) {
+		editingRoleId = role.id;
+		editName = role.name;
+		editDescription = role.description;
+		editIcon = role.icon;
+		editTools = role.tools;
+	}
+
+	async function saveEdit() {
+		if (!editingRoleId || !editName.trim()) return;
+		try {
+			await api.agentRoles.update(wsSlug, editingRoleId, {
+				name: editName.trim(),
+				description: editDescription.trim(),
+				icon: editIcon.trim(),
+				tools: editTools.trim()
+			});
+			editingRoleId = null;
+			await loadRoles();
+			await loadBoard();
+		} catch (e) {
+			console.error('Failed to update role:', e);
+		}
+	}
+
+	function cancelEdit() {
+		editingRoleId = null;
+	}
+
+	async function deleteRole(roleId: string, roleName: string) {
+		if (!confirm(`Delete role "${roleName}"? Items assigned to this role will become unassigned.`)) return;
+		try {
+			await api.agentRoles.delete(wsSlug, roleId);
+			await loadRoles();
+			await loadBoard();
+		} catch (e) {
+			console.error('Failed to delete role:', e);
 		}
 	}
 
@@ -96,8 +176,75 @@
 			>
 				My Work
 			</button>
+			<button
+				class="toggle-btn"
+				class:active={showManageRoles}
+				onclick={() => (showManageRoles = !showManageRoles)}
+			>
+				⚙ Manage
+			</button>
 		</div>
 	</header>
+
+	{#if showManageRoles}
+		<div class="manage-roles-panel">
+			<div class="manage-roles-grid">
+				{#each allRoles as role (role.id)}
+					<div class="role-card">
+						{#if editingRoleId === role.id}
+							<div class="role-edit-form">
+								<div class="role-edit-row">
+									<input class="role-input role-input-icon" type="text" bind:value={editIcon} placeholder="🔨" />
+									<input class="role-input role-input-name" type="text" bind:value={editName} placeholder="Name" />
+								</div>
+								<input class="role-input" type="text" bind:value={editDescription} placeholder="Description" />
+								<input class="role-input" type="text" bind:value={editTools} placeholder="Tools (e.g. Claude Code + Sonnet 4.6)" />
+								<div class="role-edit-actions">
+									<button class="role-btn role-btn-save" onclick={saveEdit}>Save</button>
+									<button class="role-btn role-btn-cancel" onclick={cancelEdit}>Cancel</button>
+								</div>
+							</div>
+						{:else}
+							<div class="role-card-header">
+								<span class="role-card-icon">{role.icon || '🎭'}</span>
+								<span class="role-card-name">{role.name}</span>
+								<span class="role-card-count">{role.item_count ?? 0}</span>
+							</div>
+							{#if role.description}
+								<div class="role-card-desc">{role.description}</div>
+							{/if}
+							{#if role.tools}
+								<div class="role-card-tools">{role.tools}</div>
+							{/if}
+							<div class="role-card-actions">
+								<button class="role-btn" onclick={() => startEdit(role)}>Edit</button>
+								<button class="role-btn role-btn-danger" onclick={() => deleteRole(role.id, role.name)}>Delete</button>
+							</div>
+						{/if}
+					</div>
+				{/each}
+
+				<!-- New role form -->
+				<div class="role-card role-card-new">
+					<div class="role-edit-form">
+						<div class="role-edit-row">
+							<input class="role-input role-input-icon" type="text" bind:value={newRoleIcon} placeholder="🔨" />
+							<input class="role-input role-input-name" type="text" bind:value={newRoleName} placeholder="Role name" />
+						</div>
+						<input class="role-input" type="text" bind:value={newRoleDescription} placeholder="Description" />
+						<input class="role-input" type="text" bind:value={newRoleTools} placeholder="Tools (e.g. Claude Code + Sonnet 4.6)" />
+						<button
+							class="role-btn role-btn-create"
+							disabled={!newRoleName.trim()}
+							onclick={createRole}
+						>
+							+ Create Role
+						</button>
+					</div>
+				</div>
+			</div>
+		</div>
+	{/if}
 
 	{#if loading}
 		<div class="skeleton-board">
@@ -568,5 +715,147 @@
 			width: 100%;
 			max-height: none;
 		}
+	}
+
+	/* ── Manage Roles Panel ─────────────────────────────────── */
+	.manage-roles-panel {
+		padding: 0 var(--space-5) var(--space-4);
+		border-bottom: 1px solid var(--border);
+		background: var(--bg-secondary);
+	}
+	.manage-roles-grid {
+		display: flex;
+		gap: var(--space-3);
+		overflow-x: auto;
+		padding: var(--space-2) 0;
+	}
+	.role-card {
+		flex-shrink: 0;
+		width: 220px;
+		background: var(--bg-primary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius-lg);
+		padding: var(--space-3);
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-2);
+	}
+	.role-card-new {
+		border-style: dashed;
+		border-color: var(--text-muted);
+	}
+	.role-card-header {
+		display: flex;
+		align-items: center;
+		gap: var(--space-2);
+	}
+	.role-card-icon {
+		font-size: 1.2em;
+	}
+	.role-card-name {
+		font-weight: 600;
+		font-size: 0.92em;
+		flex: 1;
+	}
+	.role-card-count {
+		font-size: 0.75em;
+		color: var(--text-muted);
+		background: var(--bg-tertiary);
+		padding: 1px 6px;
+		border-radius: var(--radius-sm);
+	}
+	.role-card-desc {
+		font-size: 0.82em;
+		color: var(--text-secondary);
+		line-height: 1.3;
+	}
+	.role-card-tools {
+		font-size: 0.78em;
+		color: var(--text-muted);
+		font-style: italic;
+	}
+	.role-card-actions {
+		display: flex;
+		gap: var(--space-2);
+		margin-top: auto;
+	}
+	.role-edit-form {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-2);
+	}
+	.role-edit-row {
+		display: flex;
+		gap: var(--space-2);
+	}
+	.role-input {
+		width: 100%;
+		padding: 4px 8px;
+		font-size: 0.85em;
+		font-family: inherit;
+		color: var(--text-primary);
+		background: var(--bg-tertiary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius-sm);
+	}
+	.role-input:focus {
+		outline: 2px solid var(--accent-blue);
+		outline-offset: -1px;
+	}
+	.role-input-icon {
+		width: 40px;
+		flex-shrink: 0;
+		text-align: center;
+	}
+	.role-input-name {
+		flex: 1;
+	}
+	.role-edit-actions {
+		display: flex;
+		gap: var(--space-2);
+	}
+	.role-btn {
+		padding: 4px 10px;
+		font-size: 0.8em;
+		font-family: inherit;
+		border: 1px solid var(--border);
+		border-radius: var(--radius-sm);
+		background: var(--bg-tertiary);
+		color: var(--text-secondary);
+		cursor: pointer;
+	}
+	.role-btn:hover {
+		background: var(--bg-hover);
+		color: var(--text-primary);
+	}
+	.role-btn-save {
+		background: var(--accent-blue);
+		color: white;
+		border-color: var(--accent-blue);
+	}
+	.role-btn-save:hover {
+		filter: brightness(1.1);
+	}
+	.role-btn-create {
+		width: 100%;
+		background: var(--accent-blue);
+		color: white;
+		border-color: var(--accent-blue);
+	}
+	.role-btn-create:hover:not(:disabled) {
+		filter: brightness(1.1);
+	}
+	.role-btn-create:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+	.role-btn-cancel {
+		color: var(--text-muted);
+	}
+	.role-btn-danger {
+		color: var(--accent-orange);
+	}
+	.role-btn-danger:hover {
+		background: color-mix(in srgb, var(--accent-orange) 15%, transparent);
 	}
 </style>

--- a/web/src/routes/[workspace]/roles/+page.svelte
+++ b/web/src/routes/[workspace]/roles/+page.svelte
@@ -16,8 +16,8 @@
 	let loading = $state(true);
 	let error = $state('');
 
-	// Filter: 'all' | 'mine' | 'unassigned'
-	let filterMode = $state<'all' | 'mine' | 'unassigned'>('all');
+	// Highlight: dim cards not assigned to current user
+	let highlightMine = $state(false);
 
 	// Role management state
 	let allRoles = $state<AgentRole[]>([]);
@@ -51,23 +51,7 @@
 		return [...unassigned, ...assigned];
 	});
 
-	// Filtered lanes based on filter mode
-	let filteredLanes = $derived.by(() => {
-		if (filterMode === 'all') return orderedLanes;
-		return orderedLanes
-			.map((lane) => ({
-				...lane,
-				items: lane.items.filter((item) => {
-					if (filterMode === 'mine') return item.assigned_user_id === currentUserId;
-					if (filterMode === 'unassigned') return !item.assigned_user_id;
-					return true;
-				})
-			}))
-			.filter((lane) => lane.items.length > 0);
-	});
-
-	// Total item count
-	let totalItems = $derived(filteredLanes.reduce((sum, lane) => sum + lane.items.length, 0));
+	let totalItems = $derived(orderedLanes.reduce((sum, lane) => sum + lane.items.length, 0));
 
 	// Drag-and-drop state
 	const flipDurationMs = 200;
@@ -77,11 +61,11 @@
 	// Mutable lane data for DnD — keyed by role ID (or '__unassigned')
 	let laneData = $state<Record<string, Item[]>>({});
 
-	// Sync from filteredLanes when not dragging
+	// Sync from orderedLanes when not dragging
 	$effect(() => {
 		if (!isDragging) {
 			const data: Record<string, Item[]> = {};
-			for (const lane of filteredLanes) {
+			for (const lane of orderedLanes) {
 				const key = lane.role?.id ?? '__unassigned';
 				data[key] = [...lane.items];
 			}
@@ -111,7 +95,7 @@
 
 		if (trigger === TRIGGERS.DROPPED_INTO_ZONE) {
 			// Item was dropped into a different lane — update its role
-			const originalItem = filteredLanes.flatMap((l) => l.items).find((i) => i.id === itemId);
+			const originalItem = orderedLanes.flatMap((l) => l.items).find((i) => i.id === itemId);
 			if (originalItem) {
 				const oldKey = originalItem.agent_role_id ?? '__unassigned';
 				if (oldKey !== key) {
@@ -262,11 +246,13 @@
 			{/if}
 		</div>
 		<div class="page-header-right">
-			<div class="filter-group">
-				<button class="toggle-btn" class:active={filterMode === 'all'} onclick={() => filterMode = 'all'}>All</button>
-				<button class="toggle-btn" class:active={filterMode === 'mine'} onclick={() => filterMode = 'mine'}>My Work</button>
-				<button class="toggle-btn" class:active={filterMode === 'unassigned'} onclick={() => filterMode = 'unassigned'}>Unassigned</button>
-			</div>
+			<button
+				class="toggle-btn"
+				class:active={highlightMine}
+				onclick={() => highlightMine = !highlightMine}
+			>
+				Highlight Mine
+			</button>
 			<button class="toggle-btn" onclick={openManageModal}>
 				⚙ Manage
 			</button>
@@ -392,7 +378,7 @@
 			<p class="empty-desc">{error}</p>
 			<button class="retry-btn" onclick={loadData}>Retry</button>
 		</div>
-	{:else if filteredLanes.length === 0}
+	{:else if orderedLanes.length === 0}
 		<div class="empty-state">
 			{#if myWorkOnly}
 				<div class="empty-icon">&#128100;</div>
@@ -411,7 +397,7 @@
 		</div>
 	{:else}
 		<div class="lanes-container">
-			{#each filteredLanes as lane (lane.role?.id ?? '__unassigned')}
+			{#each orderedLanes as lane (lane.role?.id ?? '__unassigned')}
 				{@const isUnassigned = !lane.role}
 				<div class="lane" class:unassigned={isUnassigned}>
 					<div class="lane-header">
@@ -455,7 +441,7 @@
 							{@const ref = formatItemRef(item)}
 							{@const status = fields.status ?? ''}
 							{@const priority = fields.priority ?? ''}
-							<div class="card-wrapper">
+							<div class="card-wrapper" class:dimmed={highlightMine && currentUserId && item.assigned_user_id !== currentUserId}>
 								<a
 									href="/{wsSlug}/{item.collection_slug}/{itemUrlId(item)}"
 									class="item-card"
@@ -543,23 +529,6 @@
 		display: flex;
 		align-items: center;
 		gap: var(--space-3);
-	}
-	.filter-group {
-		display: flex;
-		gap: 1px;
-		background: var(--border);
-		border-radius: var(--radius-sm);
-		overflow: hidden;
-	}
-	.filter-group .toggle-btn {
-		border-radius: 0;
-		border: none;
-	}
-	.filter-group .toggle-btn:first-child {
-		border-radius: var(--radius-sm) 0 0 var(--radius-sm);
-	}
-	.filter-group .toggle-btn:last-child {
-		border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
 	}
 
 	/* ── Toggle Button ────────────────────────────────────────────────── */
@@ -694,6 +663,13 @@
 	}
 	.card-wrapper:active {
 		cursor: grabbing;
+	}
+	.card-wrapper.dimmed {
+		opacity: 0.35;
+		transition: opacity 0.15s;
+	}
+	.card-wrapper.dimmed:hover {
+		opacity: 0.7;
 	}
 	.lane-empty {
 		text-align: center;

--- a/web/src/routes/[workspace]/roles/+page.svelte
+++ b/web/src/routes/[workspace]/roles/+page.svelte
@@ -42,10 +42,17 @@
 	}
 	let currentUserId = $state('');
 
+	// Reorder lanes: unassigned first, then roles in order
+	let orderedLanes = $derived.by(() => {
+		const unassigned = lanes.filter((l) => !l.role);
+		const assigned = lanes.filter((l) => l.role);
+		return [...unassigned, ...assigned];
+	});
+
 	// Filtered lanes based on "My Work" toggle
 	let filteredLanes = $derived.by(() => {
-		if (!myWorkOnly || !currentUserId) return lanes;
-		return lanes
+		if (!myWorkOnly || !currentUserId) return orderedLanes;
+		return orderedLanes
 			.map((lane) => ({
 				...lane,
 				items: lane.items.filter((item) => item.assigned_user_id === currentUserId)
@@ -752,15 +759,23 @@
 	/* ── Responsive ───────────────────────────────────────────────────── */
 	@media (max-width: 768px) {
 		.role-board-page {
-			padding: var(--space-4);
+			padding: 0;
+		}
+		.page-header {
+			padding: var(--space-3) var(--space-4);
 		}
 		.lanes-container {
-			flex-direction: column;
+			overflow-x: auto;
+			scroll-snap-type: x proximity;
+			-webkit-overflow-scrolling: touch;
+			gap: var(--space-3);
+			padding: 0 var(--space-4) var(--space-3);
 		}
 		.lane {
-			flex: 0 0 auto;
-			min-width: unset;
-			width: 100%;
+			min-width: 75vw;
+			max-width: 75vw;
+			scroll-snap-align: center;
+			flex-shrink: 0;
 			max-height: none;
 		}
 	}

--- a/web/src/routes/[workspace]/roles/+page.svelte
+++ b/web/src/routes/[workspace]/roles/+page.svelte
@@ -16,8 +16,8 @@
 	let loading = $state(true);
 	let error = $state('');
 
-	// Filter: "My Work" toggle
-	let myWorkOnly = $state(false);
+	// Filter: 'all' | 'mine' | 'unassigned'
+	let filterMode = $state<'all' | 'mine' | 'unassigned'>('all');
 
 	// Role management state
 	let allRoles = $state<AgentRole[]>([]);
@@ -51,14 +51,17 @@
 		return [...unassigned, ...assigned];
 	});
 
-	// Filtered lanes based on "My Work" toggle
-	// Shows items assigned to me OR items with no user assignment (so you can claim them)
+	// Filtered lanes based on filter mode
 	let filteredLanes = $derived.by(() => {
-		if (!myWorkOnly || !currentUserId) return orderedLanes;
+		if (filterMode === 'all') return orderedLanes;
 		return orderedLanes
 			.map((lane) => ({
 				...lane,
-				items: lane.items.filter((item) => item.assigned_user_id === currentUserId || !item.assigned_user_id)
+				items: lane.items.filter((item) => {
+					if (filterMode === 'mine') return item.assigned_user_id === currentUserId;
+					if (filterMode === 'unassigned') return !item.assigned_user_id;
+					return true;
+				})
 			}))
 			.filter((lane) => lane.items.length > 0);
 	});
@@ -259,13 +262,11 @@
 			{/if}
 		</div>
 		<div class="page-header-right">
-			<button
-				class="toggle-btn"
-				class:active={myWorkOnly}
-				onclick={() => (myWorkOnly = !myWorkOnly)}
-			>
-				My Work
-			</button>
+			<div class="filter-group">
+				<button class="toggle-btn" class:active={filterMode === 'all'} onclick={() => filterMode = 'all'}>All</button>
+				<button class="toggle-btn" class:active={filterMode === 'mine'} onclick={() => filterMode = 'mine'}>My Work</button>
+				<button class="toggle-btn" class:active={filterMode === 'unassigned'} onclick={() => filterMode = 'unassigned'}>Unassigned</button>
+			</div>
 			<button class="toggle-btn" onclick={openManageModal}>
 				⚙ Manage
 			</button>
@@ -542,6 +543,23 @@
 		display: flex;
 		align-items: center;
 		gap: var(--space-3);
+	}
+	.filter-group {
+		display: flex;
+		gap: 1px;
+		background: var(--border);
+		border-radius: var(--radius-sm);
+		overflow: hidden;
+	}
+	.filter-group .toggle-btn {
+		border-radius: 0;
+		border: none;
+	}
+	.filter-group .toggle-btn:first-child {
+		border-radius: var(--radius-sm) 0 0 var(--radius-sm);
+	}
+	.filter-group .toggle-btn:last-child {
+		border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
 	}
 
 	/* ── Toggle Button ────────────────────────────────────────────────── */

--- a/web/src/routes/[workspace]/roles/+page.svelte
+++ b/web/src/routes/[workspace]/roles/+page.svelte
@@ -52,12 +52,13 @@
 	});
 
 	// Filtered lanes based on "My Work" toggle
+	// Shows items assigned to me OR items with no user assignment (so you can claim them)
 	let filteredLanes = $derived.by(() => {
 		if (!myWorkOnly || !currentUserId) return orderedLanes;
 		return orderedLanes
 			.map((lane) => ({
 				...lane,
-				items: lane.items.filter((item) => item.assigned_user_id === currentUserId)
+				items: lane.items.filter((item) => item.assigned_user_id === currentUserId || !item.assigned_user_id)
 			}))
 			.filter((lane) => lane.items.length > 0);
 	});
@@ -117,6 +118,10 @@
 							update.clear_agent_role = true;
 						} else {
 							update.agent_role_id = key;
+							// Auto-assign current user if the item has no user assignment
+							if (!originalItem.assigned_user_id && currentUserId) {
+								update.assigned_user_id = currentUserId;
+							}
 						}
 						await api.items.update(wsSlug, originalItem.id, update);
 						// Refresh board data

--- a/web/src/routes/[workspace]/roles/+page.svelte
+++ b/web/src/routes/[workspace]/roles/+page.svelte
@@ -5,7 +5,9 @@
 	import { workspaceStore } from '$lib/stores/workspace.svelte';
 	import { uiStore } from '$lib/stores/ui.svelte';
 	import { parseFields, formatItemRef, itemUrlId } from '$lib/types';
-	import type { RoleBoardLane, AgentRole } from '$lib/types';
+	import type { Item, RoleBoardLane, AgentRole } from '$lib/types';
+	import { dndzone, TRIGGERS, SHADOW_ITEM_MARKER_PROPERTY_NAME } from 'svelte-dnd-action';
+	import type { DndEvent } from 'svelte-dnd-action';
 
 	let wsSlug = $derived(page.params.workspace ?? '');
 
@@ -62,6 +64,71 @@
 
 	// Total item count
 	let totalItems = $derived(filteredLanes.reduce((sum, lane) => sum + lane.items.length, 0));
+
+	// Drag-and-drop state
+	const flipDurationMs = 200;
+	const touchDragDelayMs = 500;
+	let isDragging = $state(false);
+
+	// Mutable lane data for DnD — keyed by role ID (or '__unassigned')
+	let laneData = $state<Record<string, Item[]>>({});
+
+	// Sync from filteredLanes when not dragging
+	$effect(() => {
+		if (!isDragging) {
+			const data: Record<string, Item[]> = {};
+			for (const lane of filteredLanes) {
+				const key = lane.role?.id ?? '__unassigned';
+				data[key] = [...lane.items];
+			}
+			laneData = data;
+		}
+	});
+
+	function laneKey(lane: RoleBoardLane): string {
+		return lane.role?.id ?? '__unassigned';
+	}
+
+	function handleDndConsider(key: string, e: CustomEvent<DndEvent<Item>>) {
+		laneData[key] = e.detail.items;
+		if (!isDragging && e.detail.info.trigger === TRIGGERS.DRAG_STARTED) {
+			if (typeof navigator !== 'undefined' && navigator.vibrate) {
+				navigator.vibrate(50);
+			}
+		}
+		isDragging = true;
+	}
+
+	async function handleDndFinalize(key: string, e: CustomEvent<DndEvent<Item>>) {
+		laneData[key] = e.detail.items;
+		isDragging = false;
+
+		const { id: itemId, trigger } = e.detail.info;
+
+		if (trigger === TRIGGERS.DROPPED_INTO_ZONE) {
+			// Item was dropped into a different lane — update its role
+			const originalItem = filteredLanes.flatMap((l) => l.items).find((i) => i.id === itemId);
+			if (originalItem) {
+				const oldKey = originalItem.agent_role_id ?? '__unassigned';
+				if (oldKey !== key) {
+					try {
+						const update: Record<string, any> = {};
+						if (key === '__unassigned') {
+							update.clear_agent_role = true;
+						} else {
+							update.agent_role_id = key;
+						}
+						await api.items.update(wsSlug, originalItem.id, update);
+						// Refresh board data
+						await loadBoard();
+					} catch (err) {
+						console.error('Failed to update role:', err);
+						await loadBoard();
+					}
+				}
+			}
+		}
+	}
 
 	onMount(() => {
 		workspaceStore.setCurrent(wsSlug);
@@ -363,48 +430,63 @@
 						{/if}
 					</div>
 
-					<div class="lane-items">
-						{#each lane.items as item (item.id)}
+					<!-- svelte-ignore a11y_no_static_element_interactions -->
+					<div
+						class="lane-items"
+						use:dndzone={{
+							items: laneData[laneKey(lane)] ?? [],
+							flipDurationMs,
+							type: 'role-board-card',
+							dropTargetClasses: ['drop-target'],
+							delayTouchStart: touchDragDelayMs
+						}}
+						onconsider={(e) => handleDndConsider(laneKey(lane), e)}
+						onfinalize={(e) => handleDndFinalize(laneKey(lane), e)}
+						oncontextmenu={(e) => e.preventDefault()}
+					>
+						{#each (laneData[laneKey(lane)] ?? []) as item (item.id)}
 							{@const fields = parseFields(item)}
 							{@const ref = formatItemRef(item)}
 							{@const status = fields.status ?? ''}
 							{@const priority = fields.priority ?? ''}
-							<a
-								href="/{wsSlug}/{item.collection_slug}/{itemUrlId(item)}"
-								class="item-card"
-							>
-								<div class="card-top-row">
-									{#if item.collection_icon || item.collection_name}
-										<span class="collection-badge">
-											{#if item.collection_icon}<span class="coll-icon">{item.collection_icon}</span>{/if}
-											{#if item.collection_name}<span class="coll-name">{item.collection_name}</span>{/if}
-										</span>
-									{/if}
-									{#if ref}
-										<span class="item-ref">{ref}</span>
-									{/if}
-								</div>
+							<div class="card-wrapper">
+								<a
+									href="/{wsSlug}/{item.collection_slug}/{itemUrlId(item)}"
+									class="item-card"
+								>
+									<div class="card-top-row">
+										{#if item.collection_icon || item.collection_name}
+											<span class="collection-badge">
+												{#if item.collection_icon}<span class="coll-icon">{item.collection_icon}</span>{/if}
+												{#if item.collection_name}<span class="coll-name">{item.collection_name}</span>{/if}
+											</span>
+										{/if}
+										{#if ref}
+											<span class="item-ref">{ref}</span>
+										{/if}
+									</div>
 
-								<div class="card-title">{item.title}</div>
+									<div class="card-title">{item.title}</div>
 
-								<div class="card-meta">
-									{#if status}
-										<span class="status-badge" style="color: {statusColor(status)}">
-											{status}
-										</span>
-									{/if}
-									{#if priority}
-										<span class="priority-badge" style="color: {priorityColor(priority)}">
-											{priority}
-										</span>
-									{/if}
-									{#if item.assigned_user_name}
-										<span class="assigned-user">{item.assigned_user_name}</span>
-									{/if}
-								</div>
-							</a>
+									<div class="card-meta">
+										{#if status}
+											<span class="status-badge" style="color: {statusColor(status)}">
+												{status}
+											</span>
+										{/if}
+										{#if priority}
+											<span class="priority-badge" style="color: {priorityColor(priority)}">
+												{priority}
+											</span>
+										{/if}
+										{#if item.assigned_user_name}
+											<span class="assigned-user">{item.assigned_user_name}</span>
+										{/if}
+									</div>
+								</a>
+							</div>
 						{/each}
-						{#if lane.items.length === 0}
+						{#if (laneData[laneKey(lane)] ?? []).length === 0 && !isDragging}
 							<div class="lane-empty">No items</div>
 						{/if}
 					</div>
@@ -578,6 +660,18 @@
 		flex: 1;
 	}
 
+	.lane-items:global(.drop-target) {
+		background: color-mix(in srgb, var(--accent-blue) 6%, transparent);
+	}
+	.card-wrapper {
+		cursor: grab;
+		-webkit-touch-callout: none;
+		-webkit-user-select: none;
+		user-select: none;
+	}
+	.card-wrapper:active {
+		cursor: grabbing;
+	}
 	.lane-empty {
 		text-align: center;
 		padding: var(--space-4);

--- a/web/src/routes/[workspace]/roles/+page.svelte
+++ b/web/src/routes/[workspace]/roles/+page.svelte
@@ -40,7 +40,7 @@
 	function closeManageModal() {
 		editingRoleId = null;
 		dialogEl?.close();
-		loadBoard();
+		loadData();
 	}
 	let currentUserId = $state('');
 
@@ -112,10 +112,10 @@
 						}
 						await api.items.update(wsSlug, originalItem.id, update);
 						// Refresh board data
-						await loadBoard();
+						await loadData();
 					} catch (err) {
 						console.error('Failed to update role:', err);
-						await loadBoard();
+						await loadData();
 					}
 				}
 			}
@@ -168,7 +168,7 @@
 			newRoleIcon = '';
 			newRoleTools = '';
 			await loadRoles();
-			await loadBoard();
+			await loadData();
 		} catch (e) {
 			console.error('Failed to create role:', e);
 		}
@@ -193,7 +193,7 @@
 			});
 			editingRoleId = null;
 			await loadRoles();
-			await loadBoard();
+			await loadData();
 		} catch (e) {
 			console.error('Failed to update role:', e);
 		}
@@ -208,7 +208,7 @@
 		try {
 			await api.agentRoles.delete(wsSlug, roleId);
 			await loadRoles();
-			await loadBoard();
+			await loadData();
 		} catch (e) {
 			console.error('Failed to delete role:', e);
 		}
@@ -380,7 +380,7 @@
 		</div>
 	{:else if orderedLanes.length === 0}
 		<div class="empty-state">
-			{#if myWorkOnly}
+			{#if highlightMine}
 				<div class="empty-icon">&#128100;</div>
 				<p class="empty-title">No items assigned to you</p>
 				<p class="empty-desc">

--- a/web/src/routes/[workspace]/roles/+page.svelte
+++ b/web/src/routes/[workspace]/roles/+page.svelte
@@ -18,17 +18,28 @@
 	let myWorkOnly = $state(false);
 
 	// Role management state
-	let showManageRoles = $state(false);
 	let allRoles = $state<AgentRole[]>([]);
 	let newRoleName = $state('');
 	let newRoleDescription = $state('');
 	let newRoleIcon = $state('');
 	let newRoleTools = $state('');
+	let dialogEl = $state<HTMLDialogElement | null>(null);
 	let editingRoleId = $state<string | null>(null);
 	let editName = $state('');
 	let editDescription = $state('');
 	let editIcon = $state('');
 	let editTools = $state('');
+
+	function openManageModal() {
+		loadRoles();
+		dialogEl?.showModal();
+	}
+
+	function closeManageModal() {
+		editingRoleId = null;
+		dialogEl?.close();
+		loadBoard();
+	}
 	let currentUserId = $state('');
 
 	// Filtered lanes based on "My Work" toggle
@@ -176,63 +187,100 @@
 			>
 				My Work
 			</button>
-			<button
-				class="toggle-btn"
-				class:active={showManageRoles}
-				onclick={() => (showManageRoles = !showManageRoles)}
-			>
+			<button class="toggle-btn" onclick={openManageModal}>
 				⚙ Manage
 			</button>
 		</div>
 	</header>
 
-	{#if showManageRoles}
-		<div class="manage-roles-panel">
-			<div class="manage-roles-grid">
+	<!-- Role management modal -->
+	<dialog class="roles-dialog" bind:this={dialogEl} onclick={(e) => { if (e.target === dialogEl) closeManageModal(); }}>
+		<div class="dialog-content">
+			<div class="dialog-header">
+				<h2>Manage Roles</h2>
+				<button class="dialog-close" onclick={closeManageModal}>✕</button>
+			</div>
+
+			<div class="dialog-body">
+				<!-- Existing roles -->
 				{#each allRoles as role (role.id)}
-					<div class="role-card">
+					<div class="role-row">
 						{#if editingRoleId === role.id}
 							<div class="role-edit-form">
-								<div class="role-edit-row">
-									<input class="role-input role-input-icon" type="text" bind:value={editIcon} placeholder="🔨" />
-									<input class="role-input role-input-name" type="text" bind:value={editName} placeholder="Name" />
+								<div class="role-field-group">
+									<label class="role-field-label">Icon & Name</label>
+									<div class="role-edit-row">
+										<input class="role-input role-input-icon" type="text" bind:value={editIcon} placeholder="🔨" />
+										<input class="role-input" type="text" bind:value={editName} placeholder="Name" />
+									</div>
 								</div>
-								<input class="role-input" type="text" bind:value={editDescription} placeholder="Description" />
-								<input class="role-input" type="text" bind:value={editTools} placeholder="Tools (e.g. Claude Code + Sonnet 4.6)" />
+								<div class="role-field-group">
+									<label class="role-field-label">Description</label>
+									<input class="role-input" type="text" bind:value={editDescription} placeholder="What does this role do?" />
+								</div>
+								<div class="role-field-group">
+									<label class="role-field-label">Tools</label>
+									<input class="role-input" type="text" bind:value={editTools} placeholder="e.g. Claude Code + Sonnet 4.6" />
+								</div>
 								<div class="role-edit-actions">
 									<button class="role-btn role-btn-save" onclick={saveEdit}>Save</button>
 									<button class="role-btn role-btn-cancel" onclick={cancelEdit}>Cancel</button>
 								</div>
 							</div>
 						{:else}
-							<div class="role-card-header">
-								<span class="role-card-icon">{role.icon || '🎭'}</span>
-								<span class="role-card-name">{role.name}</span>
-								<span class="role-card-count">{role.item_count ?? 0}</span>
-							</div>
-							{#if role.description}
-								<div class="role-card-desc">{role.description}</div>
-							{/if}
-							{#if role.tools}
-								<div class="role-card-tools">{role.tools}</div>
-							{/if}
-							<div class="role-card-actions">
-								<button class="role-btn" onclick={() => startEdit(role)}>Edit</button>
-								<button class="role-btn role-btn-danger" onclick={() => deleteRole(role.id, role.name)}>Delete</button>
+							<div class="role-row-display">
+								<div class="role-row-info">
+									<span class="role-row-icon">{role.icon || '🎭'}</span>
+									<div class="role-row-details">
+										<div class="role-row-name">
+											{role.name}
+											<span class="role-row-count">{role.item_count ?? 0} items</span>
+										</div>
+										{#if role.description}
+											<div class="role-row-desc">{role.description}</div>
+										{/if}
+										{#if role.tools}
+											<div class="role-row-tools">{role.tools}</div>
+										{/if}
+									</div>
+								</div>
+								<div class="role-row-actions">
+									<button class="role-btn" onclick={() => startEdit(role)}>Edit</button>
+									<button class="role-btn role-btn-danger" onclick={() => deleteRole(role.id, role.name)}>Delete</button>
+								</div>
 							</div>
 						{/if}
 					</div>
 				{/each}
 
-				<!-- New role form -->
-				<div class="role-card role-card-new">
+				{#if allRoles.length === 0}
+					<div class="dialog-empty">
+						No roles yet. Create your first role below.
+					</div>
+				{/if}
+
+				<!-- Divider -->
+				<div class="dialog-divider"></div>
+
+				<!-- Create new role form -->
+				<div class="role-create-section">
+					<h3 class="role-create-heading">Create a new role</h3>
 					<div class="role-edit-form">
-						<div class="role-edit-row">
-							<input class="role-input role-input-icon" type="text" bind:value={newRoleIcon} placeholder="🔨" />
-							<input class="role-input role-input-name" type="text" bind:value={newRoleName} placeholder="Role name" />
+						<div class="role-field-group">
+							<label class="role-field-label">Icon & Name</label>
+							<div class="role-edit-row">
+								<input class="role-input role-input-icon" type="text" bind:value={newRoleIcon} placeholder="🔨" />
+								<input class="role-input" type="text" bind:value={newRoleName} placeholder="Role name" />
+							</div>
 						</div>
-						<input class="role-input" type="text" bind:value={newRoleDescription} placeholder="Description" />
-						<input class="role-input" type="text" bind:value={newRoleTools} placeholder="Tools (e.g. Claude Code + Sonnet 4.6)" />
+						<div class="role-field-group">
+							<label class="role-field-label">Description</label>
+							<input class="role-input" type="text" bind:value={newRoleDescription} placeholder="What does this role do?" />
+						</div>
+						<div class="role-field-group">
+							<label class="role-field-label">Tools</label>
+							<input class="role-input" type="text" bind:value={newRoleTools} placeholder="e.g. Claude Code + Sonnet 4.6" />
+						</div>
 						<button
 							class="role-btn role-btn-create"
 							disabled={!newRoleName.trim()}
@@ -244,7 +292,7 @@
 				</div>
 			</div>
 		</div>
-	{/if}
+	</dialog>
 
 	{#if loading}
 		<div class="skeleton-board">
@@ -717,72 +765,156 @@
 		}
 	}
 
-	/* ── Manage Roles Panel ─────────────────────────────────── */
-	.manage-roles-panel {
-		padding: 0 var(--space-5) var(--space-4);
-		border-bottom: 1px solid var(--border);
-		background: var(--bg-secondary);
-	}
-	.manage-roles-grid {
-		display: flex;
-		gap: var(--space-3);
-		overflow-x: auto;
-		padding: var(--space-2) 0;
-	}
-	.role-card {
-		flex-shrink: 0;
-		width: 220px;
-		background: var(--bg-primary);
-		border: 1px solid var(--border);
+	/* ── Roles Dialog ─────────────────────────────────── */
+	.roles-dialog {
+		border: none;
 		border-radius: var(--radius-lg);
-		padding: var(--space-3);
+		padding: 0;
+		max-width: 520px;
+		width: 90vw;
+		max-height: 80vh;
+		background: var(--bg-primary);
+		color: var(--text-primary);
+		box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+	}
+	.roles-dialog::backdrop {
+		background: rgba(0, 0, 0, 0.5);
+	}
+	.dialog-content {
 		display: flex;
 		flex-direction: column;
-		gap: var(--space-2);
+		max-height: 80vh;
 	}
-	.role-card-new {
-		border-style: dashed;
-		border-color: var(--text-muted);
+	.dialog-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: var(--space-4) var(--space-5);
+		border-bottom: 1px solid var(--border);
 	}
-	.role-card-header {
+	.dialog-header h2 {
+		margin: 0;
+		font-size: 1.1em;
+		font-weight: 600;
+	}
+	.dialog-close {
+		background: none;
+		border: none;
+		font-size: 1.2em;
+		color: var(--text-muted);
+		cursor: pointer;
+		padding: 4px 8px;
+		border-radius: var(--radius-sm);
+	}
+	.dialog-close:hover {
+		background: var(--bg-hover);
+		color: var(--text-primary);
+	}
+	.dialog-body {
+		padding: var(--space-4) var(--space-5);
+		overflow-y: auto;
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-3);
+	}
+	.dialog-empty {
+		text-align: center;
+		color: var(--text-muted);
+		padding: var(--space-4) 0;
+		font-size: 0.9em;
+	}
+	.dialog-divider {
+		border-top: 1px solid var(--border);
+		margin: var(--space-2) 0;
+	}
+
+	/* ── Role rows ─────────────────────────────────── */
+	.role-row {
+		padding: var(--space-3);
+		background: var(--bg-secondary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+	}
+	.role-row-display {
+		display: flex;
+		align-items: flex-start;
+		justify-content: space-between;
+		gap: var(--space-3);
+	}
+	.role-row-info {
+		display: flex;
+		gap: var(--space-3);
+		flex: 1;
+		min-width: 0;
+	}
+	.role-row-icon {
+		font-size: 1.3em;
+		flex-shrink: 0;
+		margin-top: 1px;
+	}
+	.role-row-details {
+		flex: 1;
+		min-width: 0;
+	}
+	.role-row-name {
+		font-weight: 600;
+		font-size: 0.95em;
 		display: flex;
 		align-items: center;
 		gap: var(--space-2);
 	}
-	.role-card-icon {
-		font-size: 1.2em;
-	}
-	.role-card-name {
-		font-weight: 600;
-		font-size: 0.92em;
-		flex: 1;
-	}
-	.role-card-count {
-		font-size: 0.75em;
+	.role-row-count {
+		font-weight: 400;
+		font-size: 0.8em;
 		color: var(--text-muted);
-		background: var(--bg-tertiary);
-		padding: 1px 6px;
-		border-radius: var(--radius-sm);
 	}
-	.role-card-desc {
-		font-size: 0.82em;
+	.role-row-desc {
+		font-size: 0.85em;
 		color: var(--text-secondary);
-		line-height: 1.3;
+		margin-top: 2px;
 	}
-	.role-card-tools {
-		font-size: 0.78em;
+	.role-row-tools {
+		font-size: 0.8em;
 		color: var(--text-muted);
 		font-style: italic;
+		margin-top: 2px;
 	}
-	.role-card-actions {
+	.role-row-actions {
 		display: flex;
 		gap: var(--space-2);
-		margin-top: auto;
+		flex-shrink: 0;
 	}
+
+	/* ── Create section ─────────────────────────────── */
+	.role-create-section {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-3);
+	}
+	.role-create-heading {
+		margin: 0;
+		font-size: 0.92em;
+		font-weight: 600;
+		color: var(--text-secondary);
+	}
+
+	/* ── Shared form elements ─────────────────────────── */
 	.role-edit-form {
 		display: flex;
 		flex-direction: column;
-		gap: var(--space-2);
+		gap: var(--space-3);
+	}
+	.role-field-group {
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+	}
+	.role-field-label {
+		font-size: 0.78em;
+		font-weight: 500;
+		color: var(--text-muted);
+		text-transform: uppercase;
+		letter-spacing: 0.03em;
 	}
 	.role-edit-row {
 		display: flex;
@@ -790,8 +922,8 @@
 	}
 	.role-input {
 		width: 100%;
-		padding: 4px 8px;
-		font-size: 0.85em;
+		padding: 7px 10px;
+		font-size: 0.88em;
 		font-family: inherit;
 		color: var(--text-primary);
 		background: var(--bg-tertiary);
@@ -803,20 +935,17 @@
 		outline-offset: -1px;
 	}
 	.role-input-icon {
-		width: 40px;
+		width: 48px;
 		flex-shrink: 0;
 		text-align: center;
-	}
-	.role-input-name {
-		flex: 1;
 	}
 	.role-edit-actions {
 		display: flex;
 		gap: var(--space-2);
 	}
 	.role-btn {
-		padding: 4px 10px;
-		font-size: 0.8em;
+		padding: 5px 12px;
+		font-size: 0.82em;
 		font-family: inherit;
 		border: 1px solid var(--border);
 		border-radius: var(--radius-sm);
@@ -838,9 +967,11 @@
 	}
 	.role-btn-create {
 		width: 100%;
+		padding: 8px;
 		background: var(--accent-blue);
 		color: white;
 		border-color: var(--accent-blue);
+		font-weight: 500;
 	}
 	.role-btn-create:hover:not(:disabled) {
 		filter: brightness(1.1);


### PR DESCRIPTION
## Summary

- **Standalone role board page** at `/{workspace}/roles` — cross-collection view showing all work organized by agent role (PHASE-11)
- **Dashboard role breakdown** — `pad project dashboard` now shows item counts per role with assigned users
- **Agent bindings** (lightweight) — `tools` text field on roles for notes about preferred tools/models
- **Board API** — `GET /workspaces/{ws}/roles/board` returns items from all collections grouped by role

### The role board

This is the "human orchestrator" view. Instead of looking at tasks by status, you see work organized by **what kind of thinking it requires**:

```
🧠 Planner      🔨 Implementer     👁️ Reviewer      Unassigned
──────────       ──────────────      ────────────     ──────────
IDEA-120         TASK-145            (empty)          BUG-10
                 TASK-146                             BUG-11
                 TASK-147                             TASK-120
                                                     ...
```

Items from ALL collections appear in the same view — Tasks, Bugs, Ideas — with collection badges to identify them. "My Work" toggle filters to the current user's assignments.

### Dashboard breakdown

```
🎭 Roles
  🧠 Planner        2 items  (Dave)
  🔨 Implementer    5 items  (Dave, Alice)
  👁️ Reviewer       3 items  (Alice)
  Unassigned        98 items
```

### Changes

| Area | Files | What |
|------|-------|------|
| Migration | `019_agent_roles_tools.sql` | Add `tools` field to agent_roles |
| Models | `agent_role.go` | Tools field on AgentRole structs |
| Store | `agent_roles.go` | GetRoleBreakdown, GetRoleBoardItems, isDoneStatus |
| API | `handlers_role_board.go`, `handlers_dashboard.go` | Board endpoint, dashboard by_role |
| CLI | `main.go` | Role breakdown rendering, --tools flag |
| Web | `roles/+page.svelte`, `Sidebar.svelte` | Role board page, nav link |
| Types | `types/index.ts`, `client.ts` | RoleBoardLane type, board API method |
| Skill | `SKILL.md` | Role board references |

## Test plan
- [x] All Go tests pass (`go test ./...`)
- [x] Web UI builds (`npm run build`)
- [x] `make install` succeeds
- [x] `pad project dashboard` shows role breakdown
- [x] Board API returns correct lanes with items grouped by role
- [x] Verified: items assigned to Implementer role appear in Implementer lane
- [ ] Verify role board page renders in browser
- [ ] Verify "My Work" filter works
- [ ] Verify Sidebar shows Roles nav link