### PR TITLE
fix: relation field UUID display + link bubble auto-show (BUG-18, BUG-10)

### DIFF
--- a/web/src/lib/components/editor/EditorLinkPopover.svelte
+++ b/web/src/lib/components/editor/EditorLinkPopover.svelte
@@ -144,16 +144,17 @@
 		if (!editor) return;
 
 		const onSelectionUpdate = handleUpdate;
-		const onTransaction = handleUpdate;
 		const onBlur = handleBlur;
 
+		// Only listen for selectionUpdate (user-initiated cursor changes), not
+		// transaction — the transaction event fires during initial document load
+		// and programmatic edits, causing the popover to appear without user
+		// interaction when the cursor lands inside a link.
 		editor.on('selectionUpdate', onSelectionUpdate);
-		editor.on('transaction', onTransaction);
 		editor.on('blur', onBlur);
 
 		return () => {
 			editor.off('selectionUpdate', onSelectionUpdate);
-			editor.off('transaction', onTransaction);
 			editor.off('blur', onBlur);
 		};
 	});

--- a/web/src/lib/components/fields/FieldEditor.svelte
+++ b/web/src/lib/components/fields/FieldEditor.svelte
@@ -67,22 +67,31 @@ Usage:
 		);
 	});
 
+	// Eagerly load relation items when the field has a value so we can
+	// display the title instead of a raw UUID on initial render.
+	$effect(() => {
+		if (field.type === 'relation' && value && relationItems.length === 0 && wsSlug && field.collection) {
+			loadRelationItems();
+		}
+	});
+
+	async function loadRelationItems() {
+		if (relationItems.length > 0 || !wsSlug || !field.collection) return;
+		relationLoading = true;
+		try {
+			relationItems = await api.items.listByCollection(wsSlug, field.collection);
+		} catch {
+			relationItems = [];
+		} finally {
+			relationLoading = false;
+		}
+	}
+
 	async function openRelationPicker() {
 		relationOpen = true;
 		relationSearch = '';
 		relationFocusedIndex = -1;
-		if (relationItems.length === 0 && field.collection) {
-			relationLoading = true;
-			try {
-				if (wsSlug && field.collection) {
-					relationItems = await api.items.listByCollection(wsSlug, field.collection);
-				}
-			} catch {
-				relationItems = [];
-			} finally {
-				relationLoading = false;
-			}
-		}
+		await loadRelationItems();
 	}
 
 	function selectRelation(item: Item) {
@@ -411,6 +420,8 @@ Usage:
 						<span class="relation-ref">{formatItemRef(selectedRelationItem)}</span>
 					{/if}
 					{selectedRelationItem.title}
+				{:else if value && relationLoading}
+					<span style="color: var(--text-muted)">Loading...</span>
 				{:else if value}
 					{value}
 				{:else}


### PR DESCRIPTION
## Summary
- **BUG-18:** Relation fields (e.g. Phase on a Task) showed raw UUIDs on initial render because items were only fetched when the dropdown opened. Now eagerly loads relation items on mount.
- **BUG-10:** Link bubble popover auto-appeared on page load when cursor landed inside a link. Removed the `transaction` event listener — `selectionUpdate` alone handles user-initiated cursor changes.

## Test plan
- [ ] Open a task with a Phase field — should show phase title, not UUID
- [ ] Open a doc/item containing a link — link bubble should NOT appear automatically
- [ ] Click on a link in the editor — link bubble should appear correctly
- [ ] Open the Phase dropdown on a task — should still load and display phases
- [ ] Test on mobile — link bubble should not auto-show