### PR TITLE
fix: schema-driven terminal statuses (BUG-17)

### DIFF
--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -3085,8 +3085,8 @@ func standupCmd() *cobra.Command {
 				return fmt.Errorf("parsing dashboard: %w", err)
 			}
 
-			// Fetch recently completed items (done statuses)
-			doneStatuses := []string{"done", "completed", "fixed", "implemented", "resolved"}
+			// Fetch recently completed items (terminal statuses)
+			doneStatuses := models.DefaultTerminalStatuses
 			var completedItems []models.Item
 			cutoff := time.Now().AddDate(0, 0, -days)
 
@@ -3298,8 +3298,8 @@ func changelogCmd() *cobra.Command {
 				cutoff = time.Now().AddDate(0, 0, -days)
 			}
 
-			// Fetch completed items across all done-like statuses
-			doneStatuses := []string{"done", "completed", "fixed", "implemented", "resolved"}
+			// Fetch completed items across all terminal statuses
+			doneStatuses := models.DefaultTerminalStatuses
 			var allItems []models.Item
 
 			for _, status := range doneStatuses {

--- a/cmd/pad/reconcile.go
+++ b/cmd/pad/reconcile.go
@@ -359,12 +359,7 @@ func extractItemStatus(fieldsJSON string) string {
 }
 
 func isTerminalItemStatus(status string) bool {
-	switch strings.ToLower(status) {
-	case "done", "completed", "resolved", "cancelled", "rejected", "wontfix", "fixed", "implemented":
-		return true
-	default:
-		return false
-	}
+	return models.IsTerminalStatusDefault(status)
 }
 
 func needsPRMetadataRefresh(item *models.Item, livePR *GitHubPR) bool {

--- a/internal/collections/defaults.go
+++ b/internal/collections/defaults.go
@@ -26,12 +26,13 @@ func Defaults() []DefaultCollection {
 			Schema: models.CollectionSchema{
 				Fields: []models.FieldDef{
 					{
-						Key:      "status",
-						Label:    "Status",
-						Type:     "select",
-						Options:  []string{"open", "in-progress", "done", "cancelled"},
-						Default:  "open",
-						Required: true,
+						Key:             "status",
+						Label:           "Status",
+						Type:            "select",
+						Options:         []string{"open", "in-progress", "done", "cancelled"},
+						TerminalOptions: []string{"done", "cancelled"},
+						Default:         "open",
+						Required:        true,
 					},
 					{
 						Key:     "priority",
@@ -82,12 +83,13 @@ func Defaults() []DefaultCollection {
 			Schema: models.CollectionSchema{
 				Fields: []models.FieldDef{
 					{
-						Key:      "status",
-						Label:    "Status",
-						Type:     "select",
-						Options:  []string{"new", "exploring", "planned", "implemented", "rejected"},
-						Default:  "new",
-						Required: true,
+						Key:             "status",
+						Label:           "Status",
+						Type:            "select",
+						Options:         []string{"new", "exploring", "planned", "implemented", "rejected"},
+						TerminalOptions: []string{"implemented", "rejected"},
+						Default:         "new",
+						Required:        true,
 					},
 					{
 						Key:     "impact",
@@ -124,12 +126,13 @@ func Defaults() []DefaultCollection {
 			Schema: models.CollectionSchema{
 				Fields: []models.FieldDef{
 					{
-						Key:      "status",
-						Label:    "Status",
-						Type:     "select",
-						Options:  []string{"planned", "active", "completed", "paused"},
-						Default:  "planned",
-						Required: true,
+						Key:             "status",
+						Label:           "Status",
+						Type:            "select",
+						Options:         []string{"planned", "active", "completed", "paused"},
+						TerminalOptions: []string{"completed"},
+						Default:         "planned",
+						Required:        true,
 					},
 					{
 						Key:   "start_date",
@@ -171,12 +174,13 @@ func Defaults() []DefaultCollection {
 			Schema: models.CollectionSchema{
 				Fields: []models.FieldDef{
 					{
-						Key:      "status",
-						Label:    "Status",
-						Type:     "select",
-						Options:  []string{"draft", "published", "archived"},
-						Default:  "draft",
-						Required: true,
+						Key:             "status",
+						Label:           "Status",
+						Type:            "select",
+						Options:         []string{"draft", "published", "archived"},
+						TerminalOptions: []string{"archived"},
+						Default:         "draft",
+						Required:        true,
 					},
 					{
 						Key:   "category",
@@ -207,12 +211,13 @@ func Defaults() []DefaultCollection {
 			Schema: models.CollectionSchema{
 				Fields: []models.FieldDef{
 					{
-						Key:      "status",
-						Label:    "Status",
-						Type:     "select",
-						Options:  []string{"active", "draft", "disabled"},
-						Default:  "active",
-						Required: true,
+						Key:             "status",
+						Label:           "Status",
+						Type:            "select",
+						Options:         []string{"active", "draft", "disabled"},
+						TerminalOptions: []string{"disabled"},
+						Default:         "active",
+						Required:        true,
 					},
 					{
 						Key:     "trigger",
@@ -255,12 +260,13 @@ func Defaults() []DefaultCollection {
 			Schema: models.CollectionSchema{
 				Fields: []models.FieldDef{
 					{
-						Key:      "status",
-						Label:    "Status",
-						Type:     "select",
-						Options:  []string{"active", "draft", "deprecated"},
-						Default:  "draft",
-						Required: true,
+						Key:             "status",
+						Label:           "Status",
+						Type:            "select",
+						Options:         []string{"active", "draft", "deprecated"},
+						TerminalOptions: []string{"deprecated"},
+						Default:         "draft",
+						Required:        true,
 					},
 					{
 						Key:     "trigger",

--- a/internal/collections/templates.go
+++ b/internal/collections/templates.go
@@ -30,12 +30,13 @@ func docsCollection(sortOrder int) DefaultCollection {
 		Schema: models.CollectionSchema{
 			Fields: []models.FieldDef{
 				{
-					Key:      "status",
-					Label:    "Status",
-					Type:     "select",
-					Options:  []string{"draft", "published", "archived"},
-					Default:  "draft",
-					Required: true,
+					Key:             "status",
+					Label:           "Status",
+					Type:            "select",
+					Options:         []string{"draft", "published", "archived"},
+					TerminalOptions: []string{"archived"},
+					Default:         "draft",
+					Required:        true,
 				},
 				{
 					Key:   "category",
@@ -64,12 +65,13 @@ func conventionsCollection(sortOrder int) DefaultCollection {
 		Schema: models.CollectionSchema{
 			Fields: []models.FieldDef{
 				{
-					Key:      "status",
-					Label:    "Status",
-					Type:     "select",
-					Options:  []string{"active", "draft", "disabled"},
-					Default:  "active",
-					Required: true,
+					Key:             "status",
+					Label:           "Status",
+					Type:            "select",
+					Options:         []string{"active", "draft", "disabled"},
+					TerminalOptions: []string{"disabled"},
+					Default:         "active",
+					Required:        true,
 				},
 				{
 					Key:     "trigger",
@@ -116,12 +118,13 @@ func playbooksCollection(sortOrder int) DefaultCollection {
 		Schema: models.CollectionSchema{
 			Fields: []models.FieldDef{
 				{
-					Key:      "status",
-					Label:    "Status",
-					Type:     "select",
-					Options:  []string{"active", "draft", "deprecated"},
-					Default:  "draft",
-					Required: true,
+					Key:             "status",
+					Label:           "Status",
+					Type:            "select",
+					Options:         []string{"active", "draft", "deprecated"},
+					TerminalOptions: []string{"deprecated"},
+					Default:         "draft",
+					Required:        true,
 				},
 				{
 					Key:     "trigger",
@@ -166,12 +169,13 @@ var templates = []WorkspaceTemplate{
 				Schema: models.CollectionSchema{
 					Fields: []models.FieldDef{
 						{
-							Key:      "status",
-							Label:    "Status",
-							Type:     "select",
-							Options:  []string{"new", "ready", "in_sprint", "done"},
-							Default:  "new",
-							Required: true,
+							Key:             "status",
+							Label:           "Status",
+							Type:            "select",
+							Options:         []string{"new", "ready", "in_sprint", "done"},
+							TerminalOptions: []string{"done"},
+							Default:         "new",
+							Required:        true,
 						},
 						{
 							Key:     "priority",
@@ -208,12 +212,13 @@ var templates = []WorkspaceTemplate{
 				Schema: models.CollectionSchema{
 					Fields: []models.FieldDef{
 						{
-							Key:      "status",
-							Label:    "Status",
-							Type:     "select",
-							Options:  []string{"planning", "active", "completed"},
-							Default:  "planning",
-							Required: true,
+							Key:             "status",
+							Label:           "Status",
+							Type:            "select",
+							Options:         []string{"planning", "active", "completed"},
+							TerminalOptions: []string{"completed"},
+							Default:         "planning",
+							Required:        true,
 						},
 						{
 							Key:   "start_date",
@@ -248,12 +253,13 @@ var templates = []WorkspaceTemplate{
 				Schema: models.CollectionSchema{
 					Fields: []models.FieldDef{
 						{
-							Key:      "status",
-							Label:    "Status",
-							Type:     "select",
-							Options:  []string{"new", "triaged", "fixing", "resolved", "wontfix"},
-							Default:  "new",
-							Required: true,
+							Key:             "status",
+							Label:           "Status",
+							Type:            "select",
+							Options:         []string{"new", "triaged", "fixing", "resolved", "wontfix"},
+							TerminalOptions: []string{"resolved", "wontfix"},
+							Default:         "new",
+							Required:        true,
 						},
 						{
 							Key:     "severity",
@@ -294,12 +300,13 @@ var templates = []WorkspaceTemplate{
 				Schema: models.CollectionSchema{
 					Fields: []models.FieldDef{
 						{
-							Key:      "status",
-							Label:    "Status",
-							Type:     "select",
-							Options:  []string{"proposed", "researching", "planned", "building", "shipped"},
-							Default:  "proposed",
-							Required: true,
+							Key:             "status",
+							Label:           "Status",
+							Type:            "select",
+							Options:         []string{"proposed", "researching", "planned", "building", "shipped"},
+							TerminalOptions: []string{"shipped"},
+							Default:         "proposed",
+							Required:        true,
 						},
 						{
 							Key:     "priority",
@@ -331,12 +338,13 @@ var templates = []WorkspaceTemplate{
 				Schema: models.CollectionSchema{
 					Fields: []models.FieldDef{
 						{
-							Key:      "status",
-							Label:    "Status",
-							Type:     "select",
-							Options:  []string{"new", "reviewed", "planned", "shipped"},
-							Default:  "new",
-							Required: true,
+							Key:             "status",
+							Label:           "Status",
+							Type:            "select",
+							Options:         []string{"new", "reviewed", "planned", "shipped"},
+							TerminalOptions: []string{"shipped"},
+							Default:         "new",
+							Required:        true,
 						},
 						{
 							Key:   "source",
@@ -373,12 +381,13 @@ var templates = []WorkspaceTemplate{
 				Schema: models.CollectionSchema{
 					Fields: []models.FieldDef{
 						{
-							Key:      "status",
-							Label:    "Status",
-							Type:     "select",
-							Options:  []string{"planned", "in_progress", "completed"},
-							Default:  "planned",
-							Required: true,
+							Key:             "status",
+							Label:           "Status",
+							Type:            "select",
+							Options:         []string{"planned", "in_progress", "completed"},
+							TerminalOptions: []string{"completed"},
+							Default:         "planned",
+							Required:        true,
 						},
 						{
 							Key:   "quarter",

--- a/internal/models/collection.go
+++ b/internal/models/collection.go
@@ -3,15 +3,16 @@ package models
 import "time"
 
 type FieldDef struct {
-	Key        string   `json:"key"`
-	Label      string   `json:"label"`
-	Type       string   `json:"type"`                 // text, number, select, multi_select, date, checkbox, url, relation
-	Options    []string `json:"options,omitempty"`
-	Default    any      `json:"default,omitempty"`
-	Required   bool     `json:"required,omitempty"`
-	Computed   bool     `json:"computed,omitempty"`
-	Collection string   `json:"collection,omitempty"` // for relation type
-	Suffix     string   `json:"suffix,omitempty"`     // for number type display
+	Key             string   `json:"key"`
+	Label           string   `json:"label"`
+	Type            string   `json:"type"`                      // text, number, select, multi_select, date, checkbox, url, relation
+	Options         []string `json:"options,omitempty"`
+	TerminalOptions []string `json:"terminal_options,omitempty"` // for select fields: which options represent a terminal/finalized state
+	Default         any      `json:"default,omitempty"`
+	Required        bool     `json:"required,omitempty"`
+	Computed        bool     `json:"computed,omitempty"`
+	Collection      string   `json:"collection,omitempty"`      // for relation type
+	Suffix          string   `json:"suffix,omitempty"`          // for number type display
 }
 
 type CollectionSchema struct {

--- a/internal/models/terminal.go
+++ b/internal/models/terminal.go
@@ -1,0 +1,75 @@
+package models
+
+import "strings"
+
+// DefaultTerminalStatuses is the fallback list used when a collection schema
+// does not declare terminal_options on its status field. This is the union of
+// all historically hardcoded terminal status values across the codebase.
+var DefaultTerminalStatuses = []string{
+	"done", "completed", "resolved", "cancelled", "rejected",
+	"wontfix", "fixed", "implemented", "archived", "disabled", "deprecated",
+}
+
+// TerminalStatusesFromSchema extracts terminal status options from a
+// CollectionSchema. If the status field has TerminalOptions set, returns
+// those. Otherwise returns DefaultTerminalStatuses.
+func TerminalStatusesFromSchema(schema CollectionSchema) []string {
+	for _, f := range schema.Fields {
+		if f.Key == "status" && (f.Type == "select" || f.Type == "multi_select") {
+			if len(f.TerminalOptions) > 0 {
+				return f.TerminalOptions
+			}
+			break
+		}
+	}
+	return DefaultTerminalStatuses
+}
+
+// IsTerminalStatus checks whether a status string is terminal given a schema.
+func IsTerminalStatus(status string, schema CollectionSchema) bool {
+	lower := strings.ToLower(status)
+	for _, ts := range TerminalStatusesFromSchema(schema) {
+		if strings.ToLower(ts) == lower {
+			return true
+		}
+	}
+	return false
+}
+
+// IsTerminalStatusDefault checks using the default fallback list (for cases
+// where no collection schema is available).
+func IsTerminalStatusDefault(status string) bool {
+	lower := strings.ToLower(status)
+	for _, ts := range DefaultTerminalStatuses {
+		if ts == lower {
+			return true
+		}
+	}
+	return false
+}
+
+// TerminalStatusPlaceholders returns a comma-separated placeholder string
+// and the corresponding args slice for use in SQL IN clauses.
+// Example: TerminalStatusPlaceholders(schema) might return ("?,?,?", ["done","cancelled","rejected"])
+func TerminalStatusPlaceholders(schema CollectionSchema) (string, []any) {
+	statuses := TerminalStatusesFromSchema(schema)
+	placeholders := make([]string, len(statuses))
+	args := make([]any, len(statuses))
+	for i, s := range statuses {
+		placeholders[i] = "?"
+		args[i] = strings.ToLower(s)
+	}
+	return strings.Join(placeholders, ","), args
+}
+
+// DefaultTerminalStatusPlaceholders returns placeholders and args for the
+// default terminal statuses list.
+func DefaultTerminalStatusPlaceholders() (string, []any) {
+	placeholders := make([]string, len(DefaultTerminalStatuses))
+	args := make([]any, len(DefaultTerminalStatuses))
+	for i, s := range DefaultTerminalStatuses {
+		placeholders[i] = "?"
+		args[i] = s
+	}
+	return strings.Join(placeholders, ","), args
+}

--- a/internal/server/handlers_dashboard.go
+++ b/internal/server/handlers_dashboard.go
@@ -94,16 +94,6 @@ func priorityRank(priority string) int {
 	}
 }
 
-// isDoneStatus returns true if the status indicates a completed or terminal item.
-func isDoneStatus(status string) bool {
-	switch strings.ToLower(status) {
-	case "done", "completed", "resolved", "cancelled", "rejected", "wontfix", "fixed", "implemented":
-		return true
-	default:
-		return false
-	}
-}
-
 // isActiveStatus returns true if the status indicates work actively in progress.
 // It excludes both initial/queued states and terminal/completed states.
 func isActiveStatus(status string) bool {
@@ -117,11 +107,40 @@ func isActiveStatus(status string) bool {
 	}
 }
 
+// buildSchemaMap builds a map of collection ID → parsed CollectionSchema for quick lookups.
+func buildSchemaMap(collections []models.Collection) map[string]models.CollectionSchema {
+	m := make(map[string]models.CollectionSchema, len(collections))
+	for _, c := range collections {
+		var schema models.CollectionSchema
+		if err := json.Unmarshal([]byte(c.Schema), &schema); err == nil {
+			m[c.ID] = schema
+		}
+	}
+	return m
+}
+
+// isItemTerminal checks if an item's status is terminal using its collection's schema.
+// Falls back to default terminal statuses if the collection is not in the schema map.
+func isItemTerminal(status, collectionID string, schemaMap map[string]models.CollectionSchema) bool {
+	if schema, ok := schemaMap[collectionID]; ok {
+		return models.IsTerminalStatus(status, schema)
+	}
+	return models.IsTerminalStatusDefault(status)
+}
+
 func (s *Server) handleGetDashboard(w http.ResponseWriter, r *http.Request) {
 	workspaceID, ok := s.getWorkspaceID(w, r)
 	if !ok {
 		return
 	}
+
+	// Build a schema map for terminal status lookups
+	collections, err := s.store.ListCollections(workspaceID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", err.Error())
+		return
+	}
+	schemaMap := buildSchemaMap(collections)
 
 	resp := DashboardResponse{
 		Summary: DashboardSummary{
@@ -259,7 +278,7 @@ func (s *Server) handleGetDashboard(w http.ResponseWriter, r *http.Request) {
 	todayStr := now.Format("2006-01-02")
 	for _, item := range allItems {
 		status := extractFieldValue(item.Fields, "status")
-		if isDoneStatus(status) {
+		if isItemTerminal(status, item.CollectionID, schemaMap) {
 			continue
 		}
 		for _, dateField := range []string{"due_date", "end_date"} {
@@ -311,7 +330,7 @@ func (s *Server) handleGetDashboard(w http.ResponseWriter, r *http.Request) {
 		if err == nil {
 			for _, task := range allTasks {
 				status := extractFieldValue(task.Fields, "status")
-				if isDoneStatus(status) {
+				if isItemTerminal(status, task.CollectionID, schemaMap) {
 					continue
 				}
 				phaseRef := extractFieldValue(task.Fields, "phase")
@@ -332,7 +351,7 @@ func (s *Server) handleGetDashboard(w http.ResponseWriter, r *http.Request) {
 	// (e) Blocked: non-done items that are blocked by other non-done items
 	for _, item := range allItems {
 		status := extractFieldValue(item.Fields, "status")
-		if isDoneStatus(status) {
+		if isItemTerminal(status, item.CollectionID, schemaMap) {
 			continue
 		}
 		links, err := s.store.GetItemLinks(item.ID)
@@ -353,7 +372,7 @@ func (s *Server) handleGetDashboard(w http.ResponseWriter, r *http.Request) {
 				continue
 			}
 			blockerStatus := extractFieldValue(blocker.Fields, "status")
-			if isDoneStatus(blockerStatus) {
+			if isItemTerminal(blockerStatus, blocker.CollectionID, schemaMap) {
 				continue
 			}
 			resp.Attention = append(resp.Attention, DashboardAttention{

--- a/internal/server/item_lineage.go
+++ b/internal/server/item_lineage.go
@@ -37,17 +37,17 @@ func (s *Server) deriveItemClosure(item *models.Item) (*models.ItemDerivedClosur
 		}
 		switch linkType {
 		case models.ItemLinkTypeSupersedes:
-			if link.TargetID == item.ID && isDoneStatus(link.SourceStatus) {
+			if link.TargetID == item.ID && models.IsTerminalStatusDefault(link.SourceStatus) {
 				supersededBy = append(supersededBy, relationRefFromLink(link, true))
 			}
 		case models.ItemLinkTypeImplements:
-			if link.TargetID == item.ID && isDoneStatus(link.SourceStatus) {
+			if link.TargetID == item.ID && models.IsTerminalStatusDefault(link.SourceStatus) {
 				implementedBy = append(implementedBy, relationRefFromLink(link, true))
 			}
 		case models.ItemLinkTypeSplitFrom:
 			if link.TargetID == item.ID {
 				splitChildren = append(splitChildren, relationRefFromLink(link, true))
-				if !isDoneStatus(link.SourceStatus) {
+				if !models.IsTerminalStatusDefault(link.SourceStatus) {
 					allSplitChildrenDone = false
 				}
 			}

--- a/internal/store/agent_roles.go
+++ b/internal/store/agent_roles.go
@@ -180,15 +180,17 @@ func (s *Store) GetRoleBreakdown(workspaceID string) ([]RoleBreakdown, error) {
 	}
 
 	// Count non-terminal items per role (exclude done/completed/etc. to match board view)
+	termPlaceholders, termArgs := models.DefaultTerminalStatusPlaceholders()
+	roleCountArgs := append([]any{workspaceID}, termArgs...)
 	rows, err := s.db.Query(`
 		SELECT i.agent_role_id, COUNT(*) as cnt, GROUP_CONCAT(DISTINCT u.name) as users
 		FROM items i
 		LEFT JOIN users u ON u.id = i.assigned_user_id
 		WHERE i.workspace_id = ? AND i.deleted_at IS NULL
 		  AND LOWER(COALESCE(json_extract(i.fields, '$.status'), '')) NOT IN
-		      ('done','completed','resolved','cancelled','rejected','wontfix','fixed','implemented','archived','disabled')
+		      (`+termPlaceholders+`)
 		GROUP BY i.agent_role_id
-	`, workspaceID)
+	`, roleCountArgs...)
 	if err != nil {
 		return nil, fmt.Errorf("role breakdown: %w", err)
 	}
@@ -302,7 +304,7 @@ func (s *Store) GetRoleBoardItems(workspaceID string, params RoleBoardParams) ([
 				}
 			}
 		}
-		if !isDoneStatus(status) {
+		if !models.IsTerminalStatusDefault(status) {
 			activeItems = append(activeItems, item)
 		}
 	}
@@ -442,16 +444,6 @@ func (s *Store) UpdateRoleSortOrder(workspaceID string, updates []RoleSortUpdate
 	}
 
 	return tx.Commit()
-}
-
-// isDoneStatus returns true if the status indicates a terminal/completed item.
-func isDoneStatus(status string) bool {
-	switch strings.ToLower(status) {
-	case "done", "completed", "resolved", "cancelled", "rejected", "wontfix", "fixed", "implemented", "archived", "disabled":
-		return true
-	default:
-		return false
-	}
 }
 
 // ResolveAgentRoleID resolves a role identifier (ID or slug) to its UUID.

--- a/internal/store/collections.go
+++ b/internal/store/collections.go
@@ -101,19 +101,21 @@ func (s *Store) GetCollectionBySlug(workspaceID, slug string) (*models.Collectio
 }
 
 func (s *Store) ListCollections(workspaceID string) ([]models.Collection, error) {
+	termPlaceholders, termArgs := models.DefaultTerminalStatusPlaceholders()
+	queryArgs := append(termArgs, workspaceID)
 	rows, err := s.db.Query(`
 		SELECT c.id, c.workspace_id, c.name, c.slug, c.prefix, c.icon, c.description,
 		       c.schema, c.settings, c.sort_order, c.is_default, c.created_at, c.updated_at,
 		       COUNT(i.id) as item_count,
 		       COUNT(CASE WHEN LOWER(json_extract(i.fields, '$.status')) NOT IN
-		           ('done','completed','resolved','cancelled','rejected','wontfix','fixed','implemented','archived','disabled','deprecated')
+		           (`+termPlaceholders+`)
 		           THEN i.id END) as active_item_count
 		FROM collections c
 		LEFT JOIN items i ON i.collection_id = c.id AND i.deleted_at IS NULL
 		WHERE c.workspace_id = ? AND c.deleted_at IS NULL
 		GROUP BY c.id
 		ORDER BY c.sort_order ASC, c.created_at ASC
-	`, workspaceID)
+	`, queryArgs...)
 	if err != nil {
 		return nil, fmt.Errorf("list collections: %w", err)
 	}

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"strings"
@@ -876,20 +877,39 @@ func (s *Store) DeleteItemLink(id string) error {
 
 // GetPhaseProgress counts total and done tasks linked to a phase via the
 // relation field json_extract(fields, '$.phase') = phaseItemID.
+// "Done" means any terminal status as defined by the tasks collection's schema.
 func (s *Store) GetPhaseProgress(phaseItemID string) (total int, done int, err error) {
+	termPlaceholders, termArgs := s.getTasksTerminalPlaceholders()
+	args := append(termArgs, phaseItemID)
 	err = s.db.QueryRow(`
 		SELECT COUNT(*),
-		       COUNT(CASE WHEN json_extract(i.fields, '$.status') = 'done' THEN 1 END)
+		       COUNT(CASE WHEN LOWER(json_extract(i.fields, '$.status')) IN (`+termPlaceholders+`) THEN 1 END)
 		FROM items i
 		JOIN collections c ON c.id = i.collection_id
 		WHERE c.slug = 'tasks'
 		  AND i.deleted_at IS NULL
 		  AND json_extract(i.fields, '$.phase') = ?
-	`, phaseItemID).Scan(&total, &done)
+	`, args...).Scan(&total, &done)
 	if err != nil {
 		return 0, 0, fmt.Errorf("get phase progress: %w", err)
 	}
 	return total, done, nil
+}
+
+// getTasksTerminalPlaceholders returns SQL placeholders and args for the
+// terminal statuses of the tasks collection. Falls back to defaults if the
+// tasks collection schema is not found.
+func (s *Store) getTasksTerminalPlaceholders() (string, []any) {
+	// Try to find the tasks collection schema in any workspace
+	var schemaJSON sql.NullString
+	_ = s.db.QueryRow(`SELECT schema FROM collections WHERE slug = 'tasks' AND deleted_at IS NULL LIMIT 1`).Scan(&schemaJSON)
+	if schemaJSON.Valid {
+		var schema models.CollectionSchema
+		if err := json.Unmarshal([]byte(schemaJSON.String), &schema); err == nil {
+			return models.TerminalStatusPlaceholders(schema)
+		}
+	}
+	return models.DefaultTerminalStatusPlaceholders()
 }
 
 // PhaseProgress holds task completion counts for a single phase.
@@ -901,10 +921,12 @@ type PhaseProgress struct {
 
 // GetAllPhasesProgress returns task completion counts for every non-deleted phase in a workspace.
 func (s *Store) GetAllPhasesProgress(workspaceID string) ([]PhaseProgress, error) {
+	termPlaceholders, termArgs := s.getTasksTerminalPlaceholders()
+	args := append(termArgs, workspaceID)
 	rows, err := s.db.Query(`
 		SELECT p.id,
 		       COUNT(t.id),
-		       COUNT(CASE WHEN json_extract(t.fields, '$.status') = 'done' THEN 1 END)
+		       COUNT(CASE WHEN LOWER(json_extract(t.fields, '$.status')) IN (`+termPlaceholders+`) THEN 1 END)
 		FROM items p
 		JOIN collections pc ON pc.id = p.collection_id AND pc.slug = 'phases'
 		LEFT JOIN items t ON json_extract(t.fields, '$.phase') = p.id
@@ -913,7 +935,7 @@ func (s *Store) GetAllPhasesProgress(workspaceID string) ([]PhaseProgress, error
 		WHERE p.workspace_id = ?
 		  AND p.deleted_at IS NULL
 		GROUP BY p.id
-	`, workspaceID)
+	`, args...)
 	if err != nil {
 		return nil, fmt.Errorf("get all phases progress: %w", err)
 	}

--- a/web/src/lib/components/collections/EditCollectionModal.svelte
+++ b/web/src/lib/components/collections/EditCollectionModal.svelte
@@ -68,6 +68,7 @@
 		type: FieldDef['type'];
 		options: string[];
 		originalOptions: string[];
+		terminalOptions: string[];
 		required?: boolean;
 		computed?: boolean;
 		collection?: string;
@@ -153,6 +154,7 @@
 				type: f.type,
 				options: f.options ? [...f.options] : [],
 				originalOptions: f.options ? [...f.options] : [],
+				terminalOptions: f.terminal_options ? [...f.terminal_options] : [],
 				required: f.required,
 				computed: f.computed,
 				collection: f.collection,
@@ -207,6 +209,19 @@
 		field.options.push('');
 	}
 
+	function toggleTerminal(field: EditableField, option: string) {
+		const idx = field.terminalOptions.indexOf(option);
+		if (idx >= 0) {
+			field.terminalOptions.splice(idx, 1);
+		} else {
+			field.terminalOptions.push(option);
+		}
+	}
+
+	function isTerminal(field: EditableField, option: string): boolean {
+		return field.terminalOptions.includes(option);
+	}
+
 	// ── New field actions ────────────────────────────────────────────────────
 
 	function addField() {
@@ -259,6 +274,10 @@
 				};
 				if ((f.type === 'select' || f.type === 'multi_select') && f.options.length > 0) {
 					def.options = f.options.map((o) => o.trim()).filter(Boolean);
+				}
+				if (f.key === 'status' && f.terminalOptions.length > 0) {
+					// Only include terminal options that still exist in the options list
+					def.terminal_options = f.terminalOptions.filter(t => def.options?.includes(t));
 				}
 				if (f.required) def.required = true;
 				if (f.computed) def.computed = true;
@@ -435,71 +454,55 @@
 							<div class="fields-list">
 								{#each existingFields as field, i (field.key)}
 									<div class="field-card">
-										<div class="field-card-main">
-											<div class="field-reorder">
-												<button
-													class="reorder-btn"
-													type="button"
-													disabled={i === 0}
-													onclick={() => moveField(i, -1)}
-													title="Move up"
-												>&#9650;</button>
-												<button
-													class="reorder-btn"
-													type="button"
-													disabled={i === existingFields.length - 1}
-													onclick={() => moveField(i, 1)}
-													title="Move down"
-												>&#9660;</button>
+										<div class="field-card-header">
+											<div class="field-drag-handle">
+												<button class="reorder-btn" type="button" disabled={i === 0} onclick={() => moveField(i, -1)} title="Move up">&#9650;</button>
+												<button class="reorder-btn" type="button" disabled={i === existingFields.length - 1} onclick={() => moveField(i, 1)} title="Move down">&#9660;</button>
 											</div>
-											<div class="field-info">
-												<input
-													class="field-label-input"
-													type="text"
-													bind:value={field.label}
-													placeholder="Field label"
-												/>
-												<span class="field-key">{field.key}</span>
+											<div class="field-header-left">
+												<input class="field-label-input" type="text" bind:value={field.label} placeholder="Field label" />
 											</div>
-											<select class="field-type-select" bind:value={field.type}>
+											<select class="field-type-select" bind:value={field.type} title="Field type">
 												{#each FIELD_TYPES as ft (ft)}
 													<option value={ft}>{ft.replace('_', ' ')}</option>
 												{/each}
 											</select>
-											<button
-												class="remove-field-btn"
-												type="button"
-												onclick={() => removeExistingField(i)}
-												title="Remove field"
-											>&#10005;</button>
+											<button class="field-remove-btn" type="button" onclick={() => removeExistingField(i)} title="Remove field">&#10005;</button>
 										</div>
 
 										{#if field.type === 'select' || field.type === 'multi_select'}
-											<div class="options-area">
-												<div class="options-list">
+											<div class="field-options">
+												{#if field.key === 'status' && field.options.length > 0}
+													<div class="options-col-headers">
+														<span class="options-col-label">Options</span>
+														<span class="options-col-terminal" title="Terminal statuses are treated as done/closed">Done?</span>
+														<span class="options-col-spacer"></span>
+													</div>
+												{/if}
+												<div class="options-rows">
 													{#each field.options as _opt, oi (oi)}
-														<div class="option-chip">
-															<input
-																class="option-input"
-																type="text"
-																bind:value={field.options[oi]}
-																placeholder="option"
-															/>
-															<button
-																class="option-remove"
-																type="button"
-																onclick={() => removeOption(field, oi)}
-																title="Remove option"
-															>&#10005;</button>
+														<div class="option-row" class:option-terminal={field.key === 'status' && isTerminal(field, field.options[oi])}>
+															<input class="option-name-input" type="text" bind:value={field.options[oi]} placeholder="option name" />
+															{#if field.key === 'status'}
+																<button
+																	class="option-done-toggle"
+																	class:active={isTerminal(field, field.options[oi])}
+																	type="button"
+																	onclick={() => toggleTerminal(field, field.options[oi])}
+																	title={isTerminal(field, field.options[oi]) ? 'Marked as terminal (click to unmark)' : 'Mark as terminal — items with this status are considered done'}
+																>
+																	{#if isTerminal(field, field.options[oi])}
+																		<svg width="16" height="16" viewBox="0 0 16 16" fill="none"><rect x="1" y="1" width="14" height="14" rx="3" fill="currentColor" opacity="0.15" stroke="currentColor" stroke-width="1.5"/><path d="M4.5 8L7 10.5L11.5 5.5" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/></svg>
+																	{:else}
+																		<svg width="16" height="16" viewBox="0 0 16 16" fill="none"><rect x="1.5" y="1.5" width="13" height="13" rx="2.5" stroke="currentColor" stroke-width="1" opacity="0.4"/></svg>
+																	{/if}
+																</button>
+															{/if}
+															<button class="option-remove-btn" type="button" onclick={() => removeOption(field, oi)} title="Remove option">&#10005;</button>
 														</div>
 													{/each}
-													<button
-														class="option-add-btn"
-														type="button"
-														onclick={() => addOption(field)}
-														title="Add option"
-													>+</button>
 												</div>
+												<button class="option-add-btn" type="button" onclick={() => addOption(field)}>+ Add option</button>
 											</div>
 										{/if}
 									</div>
@@ -510,38 +513,23 @@
 						{/if}
 
 						<div class="add-field-section">
-							<div class="add-field-header">
-								<button class="add-field-btn" type="button" onclick={addField}>+ Add field</button>
-							</div>
-
 							{#each newFields as field, i (i)}
-								<div class="new-field-row">
-									<input
-										class="field-name-input"
-										type="text"
-										placeholder="Field name"
-										bind:value={field.key}
-									/>
-									<select class="field-type-select" bind:value={field.type}>
-										{#each FIELD_TYPES as ft (ft)}
-											<option value={ft}>{ft.replace('_', ' ')}</option>
-										{/each}
-									</select>
+								<div class="new-field-card">
+									<div class="new-field-top">
+										<input class="new-field-name" type="text" placeholder="Field name" bind:value={field.key} />
+										<select class="field-type-select" bind:value={field.type}>
+											{#each FIELD_TYPES as ft (ft)}
+												<option value={ft}>{ft.replace('_', ' ')}</option>
+											{/each}
+										</select>
+										<button class="field-remove-btn" type="button" onclick={() => removeNewField(i)}>&#10005;</button>
+									</div>
 									{#if field.type === 'select' || field.type === 'multi_select'}
-										<input
-											class="field-options-input"
-											type="text"
-											placeholder="option1, option2, ..."
-											bind:value={field.options}
-										/>
+										<input class="new-field-options" type="text" placeholder="option1, option2, ..." bind:value={field.options} />
 									{/if}
-									<button
-										class="remove-field-btn"
-										type="button"
-										onclick={() => removeNewField(i)}
-									>&#10005;</button>
 								</div>
 							{/each}
+							<button class="add-field-btn" type="button" onclick={addField}>+ Add field</button>
 						</div>
 					</div>
 				{:else if activeTab === 'display'}
@@ -947,26 +935,24 @@
 	.fields-list {
 		display: flex;
 		flex-direction: column;
-		gap: var(--space-2);
+		gap: var(--space-3);
 	}
 
 	.field-card {
 		background: var(--bg-tertiary);
 		border: 1px solid var(--border);
 		border-radius: var(--radius);
-		padding: var(--space-3);
-		display: flex;
-		flex-direction: column;
-		gap: var(--space-3);
+		overflow: hidden;
 	}
 
-	.field-card-main {
+	.field-card-header {
 		display: flex;
 		align-items: center;
-		gap: var(--space-3);
+		gap: var(--space-2);
+		padding: var(--space-3) var(--space-3);
 	}
 
-	.field-reorder {
+	.field-drag-handle {
 		display: flex;
 		flex-direction: column;
 		gap: 1px;
@@ -994,7 +980,7 @@
 		cursor: default;
 	}
 
-	.field-info {
+	.field-header-left {
 		flex: 1;
 		min-width: 0;
 		display: flex;
@@ -1023,7 +1009,7 @@
 	}
 
 	.field-key {
-		font-size: 0.75em;
+		font-size: 0.72em;
 		color: var(--text-muted);
 		padding-left: var(--space-2);
 		font-family: var(--font-mono);
@@ -1049,11 +1035,11 @@
 		outline: none;
 	}
 
-	.remove-field-btn {
+	.field-remove-btn {
 		background: none;
 		border: none;
 		color: var(--text-muted);
-		font-size: 0.85em;
+		font-size: 0.82em;
 		cursor: pointer;
 		padding: var(--space-1);
 		border-radius: var(--radius-sm);
@@ -1061,78 +1047,150 @@
 		flex-shrink: 0;
 	}
 
-	.remove-field-btn:hover {
+	.field-remove-btn:hover {
 		color: var(--accent-red, #ef4444);
 		background: color-mix(in srgb, var(--accent-red, #ef4444) 10%, transparent);
 	}
 
 	/* ── Options area (select / multi_select) ──────────────────────────────── */
 
-	.options-area {
-		padding-left: 32px;
+	.field-options {
+		border-top: 1px solid var(--border);
+		padding: var(--space-3) var(--space-3) var(--space-3) calc(var(--space-3) + 28px);
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-2);
 	}
 
-	.options-list {
+	.options-col-headers {
 		display: flex;
-		flex-wrap: wrap;
+		align-items: center;
+		gap: var(--space-2);
+		padding-bottom: var(--space-1);
+	}
+
+	.options-col-label {
+		flex: 1;
+		font-size: 0.72em;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		color: var(--text-muted);
+	}
+
+	.options-col-terminal {
+		width: 40px;
+		text-align: center;
+		font-size: 0.72em;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		color: var(--text-muted);
+	}
+
+	.options-col-spacer {
+		width: 22px;
+		flex-shrink: 0;
+	}
+
+	.options-rows {
+		display: flex;
+		flex-direction: column;
 		gap: var(--space-1);
-		align-items: center;
 	}
 
-	.option-chip {
+	.option-row {
 		display: flex;
 		align-items: center;
-		gap: 2px;
+		gap: var(--space-2);
+	}
+
+	.option-row.option-terminal .option-name-input {
+		border-color: color-mix(in srgb, var(--accent-green, #22c55e) 30%, var(--border));
+		background: color-mix(in srgb, var(--accent-green, #22c55e) 4%, var(--bg-secondary));
+	}
+
+	.option-name-input {
+		flex: 1;
+		min-width: 0;
+		padding: var(--space-1) var(--space-2);
 		background: var(--bg-secondary);
-		border: 1px solid var(--border);
-		border-radius: 12px;
-		padding: 1px 4px 1px 8px;
-	}
-
-	.option-input {
-		background: transparent;
-		border: none;
-		outline: none;
+		border: 1px solid transparent;
+		border-radius: var(--radius-sm);
+		font-size: 0.85em;
 		color: var(--text-primary);
-		font-size: 0.8em;
-		width: 72px;
-		padding: 2px 0;
 	}
 
-	.option-input:focus {
-		color: var(--accent-blue);
+	.option-name-input:hover {
+		border-color: var(--border);
 	}
 
-	.option-remove {
+	.option-name-input:focus {
+		border-color: var(--accent-blue);
+		outline: none;
+	}
+
+	.option-done-toggle {
+		width: 40px;
+		display: flex;
+		align-items: center;
+		justify-content: center;
 		background: none;
 		border: none;
 		color: var(--text-muted);
-		font-size: 0.7em;
 		cursor: pointer;
-		padding: 2px 4px;
-		border-radius: 50%;
-		line-height: 1;
+		padding: var(--space-1);
+		border-radius: var(--radius-sm);
+		flex-shrink: 0;
+		transition: color 0.15s;
 	}
 
-	.option-remove:hover {
+	.option-done-toggle:hover {
+		color: var(--text-secondary);
+	}
+
+	.option-done-toggle.active {
+		color: var(--accent-green, #22c55e);
+	}
+
+	.option-remove-btn {
+		background: none;
+		border: none;
+		color: var(--text-muted);
+		font-size: 0.75em;
+		cursor: pointer;
+		padding: var(--space-1);
+		border-radius: var(--radius-sm);
+		line-height: 1;
+		flex-shrink: 0;
+		opacity: 0;
+		transition: opacity 0.1s;
+	}
+
+	.option-row:hover .option-remove-btn {
+		opacity: 1;
+	}
+
+	.option-remove-btn:hover {
 		color: var(--accent-red, #ef4444);
-		background: color-mix(in srgb, var(--accent-red, #ef4444) 12%, transparent);
+		background: color-mix(in srgb, var(--accent-red, #ef4444) 10%, transparent);
 	}
 
 	.option-add-btn {
 		background: none;
-		border: 1px dashed var(--border);
+		border: none;
 		color: var(--text-muted);
 		font-size: 0.82em;
 		cursor: pointer;
-		padding: 2px 10px;
-		border-radius: 12px;
-		line-height: 1.4;
+		padding: var(--space-1) var(--space-2);
+		border-radius: var(--radius-sm);
+		text-align: left;
+		width: fit-content;
 	}
 
 	.option-add-btn:hover {
 		color: var(--accent-blue);
-		border-color: var(--accent-blue);
+		background: color-mix(in srgb, var(--accent-blue) 6%, transparent);
 	}
 
 	.empty-state {
@@ -1147,14 +1205,9 @@
 	.add-field-section {
 		display: flex;
 		flex-direction: column;
-		gap: var(--space-2);
+		gap: var(--space-3);
 		border-top: 1px solid var(--border);
 		padding-top: var(--space-4);
-	}
-
-	.add-field-header {
-		display: flex;
-		align-items: center;
 	}
 
 	.add-field-btn {
@@ -1175,48 +1228,57 @@
 		border-color: var(--accent-blue);
 	}
 
-	.new-field-row {
-		display: flex;
-		align-items: center;
-		gap: var(--space-2);
-		flex-wrap: wrap;
-	}
-
-	.field-name-input {
-		flex: 1;
-		min-width: 120px;
-		padding: var(--space-2) var(--space-3);
+	.new-field-card {
 		background: var(--bg-tertiary);
 		border: 1px solid var(--border);
 		border-radius: var(--radius);
+		padding: var(--space-3);
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-2);
+	}
+
+	.new-field-top {
+		display: flex;
+		align-items: center;
+		gap: var(--space-2);
+	}
+
+	.new-field-name {
+		flex: 1;
+		min-width: 120px;
+		padding: var(--space-1) var(--space-2);
+		background: var(--bg-secondary);
+		border: 1px solid transparent;
+		border-radius: var(--radius-sm);
 		font-size: 0.85em;
 		color: var(--text-primary);
 	}
 
-	.field-name-input:hover {
-		border-color: var(--text-muted);
+	.new-field-name:hover {
+		border-color: var(--border);
 	}
 
-	.field-name-input:focus {
+	.new-field-name:focus {
 		border-color: var(--accent-blue);
 		outline: none;
 	}
 
-	.field-options-input {
-		flex: 1 1 100%;
-		padding: var(--space-2) var(--space-3);
-		background: var(--bg-tertiary);
-		border: 1px solid var(--border);
-		border-radius: var(--radius);
+	.new-field-options {
+		width: 100%;
+		padding: var(--space-1) var(--space-2);
+		background: var(--bg-secondary);
+		border: 1px solid transparent;
+		border-radius: var(--radius-sm);
 		font-size: 0.85em;
 		color: var(--text-primary);
 	}
 
-	.field-options-input:hover {
-		border-color: var(--text-muted);
+	.new-field-options:hover {
+		border-color: var(--border);
 	}
 
-	.field-options-input:focus {
+	.new-field-options:focus {
 		border-color: var(--accent-blue);
 		outline: none;
 	}

--- a/web/src/lib/components/phases/PhaseChart.svelte
+++ b/web/src/lib/components/phases/PhaseChart.svelte
@@ -6,9 +6,12 @@
 		tasks: Item[];
 		startDate: string;
 		endDate?: string;
+		terminalStatuses?: string[];
 	}
 
-	let { tasks, startDate, endDate }: Props = $props();
+	let { tasks, startDate, endDate, terminalStatuses }: Props = $props();
+	const defaultTerminal = ['done', 'completed', 'resolved', 'cancelled', 'rejected', 'wontfix', 'fixed', 'implemented', 'archived', 'disabled', 'deprecated'];
+	const terminal = $derived(terminalStatuses ?? defaultTerminal);
 
 	// Chart dimensions
 	const padding = { top: 20, right: 20, bottom: 30, left: 40 };
@@ -39,7 +42,7 @@
 		const completions: { date: Date; count: number }[] = [];
 		for (const task of tasks) {
 			const f = parseFields(task);
-			if (f.status === 'done') {
+			if (terminal.includes(f.status)) {
 				const completedAt = new Date(task.updated_at);
 				completions.push({ date: completedAt, count: 1 });
 			}

--- a/web/src/lib/components/phases/PhaseTasks.svelte
+++ b/web/src/lib/components/phases/PhaseTasks.svelte
@@ -15,10 +15,14 @@
 		itemSlug: string;
 		itemId: string;
 		phaseFields?: Record<string, any>;
+		terminalStatuses?: string[];
 		onTasksChange?: (tasks: Item[]) => void;
 	}
 
-	let { wsSlug, itemSlug, itemId, phaseFields, onTasksChange }: Props = $props();
+	let { wsSlug, itemSlug, itemId, phaseFields, terminalStatuses, onTasksChange }: Props = $props();
+
+	const defaultTerminal = ['done', 'completed', 'resolved', 'cancelled', 'rejected', 'wontfix', 'fixed', 'implemented', 'archived', 'disabled', 'deprecated'];
+	const terminal = $derived(terminalStatuses ?? defaultTerminal);
 
 	let tasks = $state<Item[]>([]);
 	let loading = $state(true);
@@ -30,7 +34,7 @@
 	const flipDurationMs = 200;
 	const touchDragDelayMs = 500;
 
-	let doneCount = $derived(tasks.filter((t) => parseFields(t).status === 'done').length);
+	let doneCount = $derived(tasks.filter((t) => terminal.includes(parseFields(t).status)).length);
 	let totalCount = $derived(tasks.length);
 	let percentage = $derived(totalCount > 0 ? Math.round((doneCount / totalCount) * 100) : 0);
 
@@ -159,7 +163,7 @@
 	</div>
 
 	{#if !loading && tasks.length > 0 && phaseFields?.start_date}
-		<PhaseChart {tasks} startDate={phaseFields.start_date} endDate={phaseFields.end_date} />
+		<PhaseChart {tasks} startDate={phaseFields.start_date} endDate={phaseFields.end_date} {terminalStatuses} />
 	{/if}
 
 	{#if loading}
@@ -187,7 +191,7 @@
 				>
 					{#each groupData[status] ?? [] as task (task.id)}
 						{@const fields = parseFields(task)}
-						{@const isDone = fields.status === 'done'}
+						{@const isDone = terminal.includes(fields.status)}
 						<a href="/{wsSlug}/tasks/{task.slug}" class="task-row">
 							<span class="task-ref">{formatItemRef(task) ?? ''}</span>
 							<span class="task-title" class:done={isDone}>{task.title}</span>

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -121,6 +121,7 @@ export interface FieldDef {
 	label: string;
 	type: 'text' | 'number' | 'select' | 'multi_select' | 'date' | 'checkbox' | 'url' | 'relation';
 	options?: string[];
+	terminal_options?: string[];
 	default?: any;
 	required?: boolean;
 	computed?: boolean;
@@ -639,6 +640,32 @@ export function getStatusOptions(collection: Collection): string[] {
 	const schema = parseSchema(collection);
 	const statusField = schema.fields.find((f) => f.key === 'status');
 	return statusField?.options ?? [];
+}
+
+/** Default terminal statuses used as a fallback when a collection's schema
+ * doesn't declare terminal_options. */
+const DEFAULT_TERMINAL_STATUSES = [
+	'done', 'completed', 'resolved', 'cancelled', 'rejected',
+	'wontfix', 'fixed', 'implemented', 'archived', 'disabled', 'deprecated'
+];
+
+/** Get the terminal status options for a collection. Uses the schema's
+ * terminal_options if defined, otherwise falls back to defaults. */
+export function getTerminalOptions(collection: Collection): string[] {
+	const schema = parseSchema(collection);
+	const statusField = schema.fields.find((f) => f.key === 'status');
+	return statusField?.terminal_options ?? DEFAULT_TERMINAL_STATUSES;
+}
+
+/** Check if a status value is terminal (finalized) for a given collection. */
+export function isTerminalStatus(status: string, collection: Collection): boolean {
+	return getTerminalOptions(collection).includes(status);
+}
+
+/** Check if a status value is terminal using the default fallback list.
+ * Use when no collection context is available. */
+export function isTerminalStatusDefault(status: string): boolean {
+	return DEFAULT_TERMINAL_STATUSES.includes(status);
 }
 
 export function formatItemRef(item: Item): string | null {

--- a/web/src/routes/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[workspace]/[collection]/[slug]/+page.svelte
@@ -16,7 +16,7 @@
 	import { relativeTime, wikiLinksToMarkdown, markdownToWikiLinks, cleanBrokenLinks } from '$lib/utils/markdown';
 	import { toastStore } from '$lib/stores/toast.svelte';
 	import type { Item, Collection, CollectionSettings, QuickAction, ItemLink, ItemRelationRef, AgentRole } from '$lib/types';
-	import { parseFields, parseSchema, parseSettings, formatItemRef } from '$lib/types';
+	import { parseFields, parseSchema, parseSettings, formatItemRef, getTerminalOptions } from '$lib/types';
 	import QuickActionsMenu from '$lib/components/common/QuickActionsMenu.svelte';
 
 	type RelationshipEntry = {
@@ -305,7 +305,9 @@
 	function handlePhaseTasksChange(tasks: Item[]) {
 		if (collSlug !== 'phases') return;
 		const total = tasks.length;
-		const done = tasks.filter((task) => parseFields(task).status === 'done').length;
+		const tasksCollection = (collectionStore.collections ?? []).find(c => c.slug === 'tasks');
+		const termOpts = tasksCollection ? getTerminalOptions(tasksCollection) : ['done', 'cancelled'];
+		const done = tasks.filter((task) => termOpts.includes(parseFields(task).status)).length;
 		const progress = total > 0 ? Math.round((done / total) * 100) : 0;
 		computedOverrides = { progress, _progressDone: done, _progressTotal: total };
 	}
@@ -748,7 +750,8 @@
 
 		<!-- Phase Tasks (shown only for phases collection) -->
 		{#if collSlug === 'phases' && item}
-			<PhaseTasks {wsSlug} {itemSlug} itemId={item.id} phaseFields={fields} onTasksChange={handlePhaseTasksChange} />
+			{@const tasksCol = (collectionStore.collections ?? []).find(c => c.slug === 'tasks')}
+			<PhaseTasks {wsSlug} {itemSlug} itemId={item.id} phaseFields={fields} terminalStatuses={tasksCol ? getTerminalOptions(tasksCol) : undefined} onTasksChange={handlePhaseTasksChange} />
 		{/if}
 
 		<!-- Unified Timeline (comments + activity + versions) -->

--- a/web/src/routes/[workspace]/settings/+page.svelte
+++ b/web/src/routes/[workspace]/settings/+page.svelte
@@ -68,12 +68,12 @@
 		{ id: 'account', label: 'Account', icon: '\uD83D\uDC64' },
 		{ id: 'members', label: 'Members', icon: '\uD83D\uDC65' },
 		{ id: 'collections', label: 'Collections', icon: '\uD83D\uDCC1' },
-		{ id: 'danger', label: 'Danger Zone', icon: '\u26A0\uFE0F' },
 	];
+	const dangerTab = { id: 'danger', label: 'Danger Zone', icon: '\u26A0\uFE0F' };
 	let tabs = $derived(
 		profileRole === 'admin'
-			? [...baseTabs, { id: 'platform', label: 'Platform', icon: '\uD83D\uDD27' }]
-			: baseTabs
+			? [...baseTabs, { id: 'platform', label: 'Platform', icon: '\uD83D\uDD27' }, dangerTab]
+			: [...baseTabs, dangerTab]
 	);
 	let validTabIds = $derived(tabs.map(t => t.id));
 


### PR DESCRIPTION
## Summary

- **Schema-driven terminal statuses**: Each collection's schema now declares which status options are terminal via `terminal_options` on the status `FieldDef`. Replaces 10+ inconsistent hardcoded lists across Go backend, CLI, and frontend.
- **Collection field editor redesign**: Cleaner vertical layout for options, checkbox-style terminal toggle with "Done?" column header, hidden remove buttons until hover.
- **Settings tab reorder**: Platform tab now appears before Danger Zone.

## What changed

**New**: `internal/models/terminal.go` — centralized `IsTerminalStatus()`, `DefaultTerminalStatuses`, SQL placeholder helpers

**Backend** (7 locations fixed):
- `handlers_dashboard.go` — schema-aware `isItemTerminal()` replaces hardcoded `isDoneStatus()`
- `store/items.go` — phase progress counts all terminal statuses, not just `"done"`
- `store/collections.go` — `active_item_count` uses dynamic SQL placeholders
- `store/agent_roles.go` — dynamic terminal status filtering
- `item_lineage.go`, `cmd/pad/main.go`, `cmd/pad/reconcile.go` — use centralized helpers

**Frontend** (5 files):
- `types/index.ts` — `terminal_options` on `FieldDef`, `isTerminalStatus()` helper
- `PhaseTasks.svelte`, `PhaseChart.svelte`, `+page.svelte` — use terminal options for done counts
- `EditCollectionModal.svelte` — redesigned Fields tab with terminal toggle UI
- `settings/+page.svelte` — Platform tab before Danger Zone

**Backward compatible**: Existing schemas without `terminal_options` fall back to `DefaultTerminalStatuses`. No migration needed.

## Test plan

- [ ] `go test ./...` passes
- [ ] `npm run build` succeeds
- [ ] Create a task, set status to "cancelled" → verify dashboard doesn't show it as active
- [ ] Verify `active_item_count` in sidebar excludes cancelled items
- [ ] Verify phase progress counts cancelled tasks as done
- [ ] Open Settings → Collections → edit a collection → Fields tab → verify terminal toggles work
- [ ] Verify Platform tab appears before Danger Zone in settings