### PR TITLE
Unify relation fields and item links into single dependency system

### DIFF
--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -3322,8 +3322,10 @@ func changelogCmd() *cobra.Command {
 			if phase != "" {
 				var filtered []models.Item
 				for _, item := range allItems {
-					itemPhase := extractFieldFromJSON(item.Fields, "phase")
-					if strings.EqualFold(itemPhase, phase) {
+					// Check phase link (populated by API enrichment)
+					if strings.EqualFold(item.PhaseID, phase) ||
+						strings.EqualFold(item.PhaseRef, phase) ||
+						strings.EqualFold(item.PhaseTitle, phase) {
 						filtered = append(filtered, item)
 					}
 				}

--- a/internal/collections/defaults.go
+++ b/internal/collections/defaults.go
@@ -52,13 +52,7 @@ func Defaults() []DefaultCollection {
 						Type:    "select",
 						Options: []string{"xs", "s", "m", "l", "xl"},
 					},
-					{
-						Key:        "phase",
-						Label:      "Phase",
-						Type:       "relation",
-						Collection: "phases",
 					},
-				},
 			},
 			Settings: models.CollectionSettings{
 				Layout:       "fields-primary",

--- a/internal/models/item.go
+++ b/internal/models/item.go
@@ -51,6 +51,12 @@ type Item struct {
 	CollectionName      string                   `json:"collection_name,omitempty"`
 	CollectionIcon      string                   `json:"collection_icon,omitempty"`
 	CollectionPrefix    string                   `json:"collection_prefix,omitempty"`
+
+	// Phase link (populated by enrichItemForResponse)
+	PhaseID    string `json:"phase_id,omitempty"`
+	PhaseRef   string `json:"phase_ref,omitempty"`
+	PhaseTitle string `json:"phase_title,omitempty"`
+
 	DerivedClosure      *ItemDerivedClosure      `json:"derived_closure,omitempty"`
 	CodeContext         *ItemCodeContext         `json:"code_context,omitempty"`
 	Convention          *ItemConventionMetadata  `json:"convention,omitempty"`
@@ -504,6 +510,7 @@ type ItemListParams struct {
 	Tag             string
 	AssignedUserID  string // filter by assigned user
 	AgentRoleID     string // filter by agent role (ID or slug)
+	PhaseID         string // filter by phase link (item ID of the phase)
 	IncludeArchived bool
 	Limit           int
 	Offset          int

--- a/internal/models/item_links.go
+++ b/internal/models/item_links.go
@@ -12,6 +12,7 @@ const (
 	ItemLinkTypeSplitFrom  = "split_from"
 	ItemLinkTypeSupersedes = "supersedes"
 	ItemLinkTypeImplements = "implements"
+	ItemLinkTypePhase     = "phase"
 )
 
 var itemLinkTypeAliases = map[string]string{
@@ -24,6 +25,7 @@ var itemLinkTypeAliases = map[string]string{
 	"split-from": ItemLinkTypeSplitFrom,
 	"supersedes": ItemLinkTypeSupersedes,
 	"implements": ItemLinkTypeImplements,
+	"phase":      ItemLinkTypePhase,
 }
 
 // NormalizeItemLinkType canonicalizes supported link types and returns an error

--- a/internal/server/handlers_dashboard.go
+++ b/internal/server/handlers_dashboard.go
@@ -314,7 +314,7 @@ func (s *Server) handleGetDashboard(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// (d) Orphaned tasks: tasks with no phase relation set
+	// (d) Orphaned tasks: tasks with no phase link set
 	//     Only flag these if the workspace actually has phases with tasks linked to them.
 	hasPhaseWithTasks := false
 	for _, dp := range resp.ActivePhases {
@@ -324,6 +324,11 @@ func (s *Server) handleGetDashboard(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	if hasPhaseWithTasks {
+		// Batch-fetch all task→phase mappings for efficiency
+		taskPhaseMap, err := s.store.GetTaskPhaseMap(workspaceID)
+		if err != nil {
+			taskPhaseMap = map[string]string{}
+		}
 		allTasks, err := s.store.ListItems(workspaceID, models.ItemListParams{
 			CollectionSlug: "tasks",
 		})
@@ -333,8 +338,7 @@ func (s *Server) handleGetDashboard(w http.ResponseWriter, r *http.Request) {
 				if isItemTerminal(status, task.CollectionID, schemaMap) {
 					continue
 				}
-				phaseRef := extractFieldValue(task.Fields, "phase")
-				if phaseRef == "" {
+				if _, hasPhase := taskPhaseMap[task.ID]; !hasPhase {
 					resp.Attention = append(resp.Attention, DashboardAttention{
 						Type:       "orphaned_task",
 						ItemSlug:   task.Slug,

--- a/internal/server/handlers_item_links.go
+++ b/internal/server/handlers_item_links.go
@@ -91,6 +91,19 @@ func (s *Server) handleCreateItemLink(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Phase links enforce single-phase: an item can only belong to one phase.
+	// Use SetPhaseLink which handles the upsert automatically.
+	if input.LinkType == models.ItemLinkTypePhase {
+		actor, _ := actorFromRequest(r)
+		link, err := s.store.SetPhaseLink(workspaceID, item.ID, target.ID, actor)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "internal_error", err.Error())
+			return
+		}
+		writeJSON(w, http.StatusCreated, link)
+		return
+	}
+
 	link, err := s.store.CreateItemLink(workspaceID, input, item.ID)
 	if err != nil {
 		if strings.Contains(err.Error(), "UNIQUE constraint") {

--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -25,7 +25,7 @@ func (s *Server) handleListItems(w http.ResponseWriter, r *http.Request) {
 	}
 
 	params := parseItemListParams(r)
-	if err := s.resolveRelationFieldFiltersForWorkspace(workspaceID, &params); err != nil {
+	if err := s.resolvePhaseFilter(workspaceID, &params); err != nil {
 		writeError(w, http.StatusBadRequest, "bad_request", err.Error())
 		return
 	}
@@ -37,6 +37,7 @@ func (s *Server) handleListItems(w http.ResponseWriter, r *http.Request) {
 	if result == nil {
 		result = []models.Item{}
 	}
+	s.enrichItemsWithPhase(workspaceID, result)
 
 	writeJSON(w, http.StatusOK, result)
 }
@@ -61,7 +62,7 @@ func (s *Server) handleListCollectionItems(w http.ResponseWriter, r *http.Reques
 
 	params := parseItemListParams(r)
 	params.CollectionSlug = collSlug
-	if err := s.resolveRelationFieldFilters(workspaceID, &params, coll.Schema); err != nil {
+	if err := s.resolvePhaseFilter(workspaceID, &params); err != nil {
 		writeError(w, http.StatusBadRequest, "bad_request", err.Error())
 		return
 	}
@@ -74,6 +75,7 @@ func (s *Server) handleListCollectionItems(w http.ResponseWriter, r *http.Reques
 	if result == nil {
 		result = []models.Item{}
 	}
+	s.enrichItemsWithPhase(workspaceID, result)
 
 	writeJSON(w, http.StatusOK, result)
 }
@@ -123,10 +125,23 @@ func (s *Server) handleCreateItem(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Resolve relation fields (slugs/refs → UUIDs) before validation
-	if err := s.resolveRelationFields(workspaceID, fieldMap, schema); err != nil {
-		writeError(w, http.StatusBadRequest, "bad_request", err.Error())
-		return
+	// Extract phase from fields — it's managed via item_links, not stored in fields JSON
+	var phaseValue string
+	if pv, ok := fieldMap["phase"]; ok && pv != nil {
+		if pvStr, ok := pv.(string); ok && pvStr != "" {
+			// Resolve slug/ref to UUID if needed
+			if !isUUID(pvStr) {
+				resolved, err := s.store.ResolveItem(workspaceID, pvStr)
+				if err != nil || resolved == nil {
+					writeError(w, http.StatusBadRequest, "bad_request", fmt.Sprintf("phase %q not found", pvStr))
+					return
+				}
+				phaseValue = resolved.ID
+			} else {
+				phaseValue = pvStr
+			}
+		}
+		delete(fieldMap, "phase")
 	}
 
 	if err := items.ValidateFields(fieldMap, schema); err != nil {
@@ -150,6 +165,15 @@ func (s *Server) handleCreateItem(w http.ResponseWriter, r *http.Request) {
 		}
 		writeError(w, http.StatusInternalServerError, "internal_error", err.Error())
 		return
+	}
+
+	// Create phase link if specified
+	if phaseValue != "" {
+		actor, _ := actorFromRequest(r)
+		if _, err := s.store.SetPhaseLink(workspaceID, item.ID, phaseValue, actor); err != nil {
+			// Item was created but phase link failed — log but don't fail the whole request
+			fmt.Printf("warning: failed to create phase link for %s: %v\n", item.ID, err)
+		}
 	}
 
 	actor, source := actorFromRequest(r)
@@ -235,10 +259,26 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		// Resolve relation fields (slugs/refs → UUIDs) before validation
-		if err := s.resolveRelationFields(workspaceID, fieldMap, schema); err != nil {
-			writeError(w, http.StatusBadRequest, "bad_request", err.Error())
-			return
+		// Extract phase from fields — it's managed via item_links, not stored in fields JSON
+		var phaseValue string
+		var phaseProvided bool
+		if pv, ok := fieldMap["phase"]; ok {
+			phaseProvided = true
+			if pv != nil {
+				if pvStr, ok := pv.(string); ok && pvStr != "" {
+					if !isUUID(pvStr) {
+						resolved, err := s.store.ResolveItem(workspaceID, pvStr)
+						if err != nil || resolved == nil {
+							writeError(w, http.StatusBadRequest, "bad_request", fmt.Sprintf("phase %q not found", pvStr))
+							return
+						}
+						phaseValue = resolved.ID
+					} else {
+						phaseValue = pvStr
+					}
+				}
+			}
+			delete(fieldMap, "phase")
 		}
 
 		if err := items.ValidateFields(fieldMap, schema); err != nil {
@@ -256,6 +296,21 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 		}
 		validated := string(validatedFields)
 		input.Fields = &validated
+
+		// Update phase link if phase was provided in the update
+		if phaseProvided {
+			if phaseValue != "" {
+				actor, _ := actorFromRequest(r)
+				if _, err := s.store.SetPhaseLink(workspaceID, item.ID, phaseValue, actor); err != nil {
+					fmt.Printf("warning: failed to update phase link for %s: %v\n", item.ID, err)
+				}
+			} else {
+				// Phase was explicitly set to empty/null — clear the link
+				if err := s.store.ClearPhaseLink(item.ID); err != nil {
+					fmt.Printf("warning: failed to clear phase link for %s: %v\n", item.ID, err)
+				}
+			}
+		}
 	}
 
 	updated, err := s.store.UpdateItem(item.ID, input)
@@ -572,7 +627,33 @@ func (s *Server) handleGetItemTasks(w http.ResponseWriter, r *http.Request) {
 	if tasks == nil {
 		tasks = []models.Item{}
 	}
+	s.enrichItemsWithPhase(workspaceID, tasks)
 	writeJSON(w, http.StatusOK, tasks)
+}
+
+// resolvePhaseFilter extracts a "phase" key from the field filters and converts
+// it to a PhaseID filter (which uses item_links instead of json_extract).
+func (s *Server) resolvePhaseFilter(workspaceID string, params *models.ItemListParams) error {
+	if params.Fields == nil {
+		return nil
+	}
+	phaseVal, ok := params.Fields["phase"]
+	if !ok || phaseVal == "" {
+		return nil
+	}
+	delete(params.Fields, "phase")
+
+	// Resolve slug/ref to UUID
+	if !isUUID(phaseVal) {
+		resolved, err := s.store.ResolveItem(workspaceID, phaseVal)
+		if err != nil || resolved == nil {
+			return fmt.Errorf("phase %q not found", phaseVal)
+		}
+		params.PhaseID = resolved.ID
+	} else {
+		params.PhaseID = phaseVal
+	}
+	return nil
 }
 
 // resolveRelationFields resolves slugs, PREFIX-NUMBER refs, and other identifiers

--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -171,8 +171,8 @@ func (s *Server) handleCreateItem(w http.ResponseWriter, r *http.Request) {
 	if phaseValue != "" {
 		actor, _ := actorFromRequest(r)
 		if _, err := s.store.SetPhaseLink(workspaceID, item.ID, phaseValue, actor); err != nil {
-			// Item was created but phase link failed — log but don't fail the whole request
-			fmt.Printf("warning: failed to create phase link for %s: %v\n", item.ID, err)
+			writeError(w, http.StatusInternalServerError, "internal_error", fmt.Sprintf("item created but phase link failed: %v", err))
+			return
 		}
 	}
 
@@ -302,12 +302,14 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 			if phaseValue != "" {
 				actor, _ := actorFromRequest(r)
 				if _, err := s.store.SetPhaseLink(workspaceID, item.ID, phaseValue, actor); err != nil {
-					fmt.Printf("warning: failed to update phase link for %s: %v\n", item.ID, err)
+					writeError(w, http.StatusInternalServerError, "internal_error", fmt.Sprintf("failed to update phase link: %v", err))
+					return
 				}
 			} else {
 				// Phase was explicitly set to empty/null — clear the link
 				if err := s.store.ClearPhaseLink(item.ID); err != nil {
-					fmt.Printf("warning: failed to clear phase link for %s: %v\n", item.ID, err)
+					writeError(w, http.StatusInternalServerError, "internal_error", fmt.Sprintf("failed to clear phase link: %v", err))
+					return
 				}
 			}
 		}

--- a/internal/server/item_lineage.go
+++ b/internal/server/item_lineage.go
@@ -7,6 +7,52 @@ import (
 	"github.com/xarmian/pad/internal/models"
 )
 
+// enrichItemsWithPhase batch-populates phase link info on a slice of items.
+// Used by list endpoints where calling enrichItemForResponse per-item is too expensive.
+func (s *Server) enrichItemsWithPhase(workspaceID string, items []models.Item) {
+	if len(items) == 0 {
+		return
+	}
+	phaseMap, err := s.store.GetTaskPhaseMap(workspaceID)
+	if err != nil || len(phaseMap) == 0 {
+		return
+	}
+	// Collect unique phase IDs
+	phaseIDs := make(map[string]bool)
+	for _, pid := range phaseMap {
+		phaseIDs[pid] = true
+	}
+	// Fetch phase item details (title, ref) in bulk
+	type phaseInfo struct {
+		title string
+		ref   string
+	}
+	phases := make(map[string]phaseInfo)
+	for pid := range phaseIDs {
+		item, err := s.store.GetItem(pid)
+		if err != nil || item == nil {
+			continue
+		}
+		ref := ""
+		if item.CollectionPrefix != "" && item.ItemNumber != nil {
+			ref = fmt.Sprintf("%s-%d", item.CollectionPrefix, *item.ItemNumber)
+		}
+		phases[pid] = phaseInfo{title: item.Title, ref: ref}
+	}
+	// Populate items
+	for i := range items {
+		pid, ok := phaseMap[items[i].ID]
+		if !ok {
+			continue
+		}
+		items[i].PhaseID = pid
+		if info, ok := phases[pid]; ok {
+			items[i].PhaseTitle = info.title
+			items[i].PhaseRef = info.ref
+		}
+	}
+}
+
 func (s *Server) enrichItemForResponse(item *models.Item) error {
 	if item == nil {
 		return nil
@@ -16,6 +62,18 @@ func (s *Server) enrichItemForResponse(item *models.Item) error {
 		return err
 	}
 	item.DerivedClosure = closure
+
+	// Populate phase link info
+	phaseLink, err := s.store.GetPhaseForItem(item.ID)
+	if err != nil {
+		return err
+	}
+	if phaseLink != nil {
+		item.PhaseID = phaseLink.TargetID
+		item.PhaseRef = phaseLink.TargetRef
+		item.PhaseTitle = phaseLink.TargetTitle
+	}
+
 	return nil
 }
 

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -884,15 +884,42 @@ func (s *Store) DeleteItemLink(id string) error {
 // SetPhaseLink sets the phase for an item. Since an item can belong to at most
 // one phase, this deletes any existing phase link for the item first.
 func (s *Store) SetPhaseLink(workspaceID, itemID, phaseID, createdBy string) (*models.ItemLink, error) {
-	// Delete existing phase link for this item (if any)
-	_, _ = s.db.Exec(`DELETE FROM item_links WHERE source_id = ? AND link_type = 'phase'`, itemID)
+	tx, err := s.db.Begin()
+	if err != nil {
+		return nil, fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback()
 
-	// Create new phase link
-	return s.CreateItemLink(workspaceID, models.ItemLinkCreate{
-		TargetID:  phaseID,
-		LinkType:  models.ItemLinkTypePhase,
-		CreatedBy: createdBy,
-	}, itemID)
+	// Delete existing phase link for this item (if any)
+	if _, err := tx.Exec(`DELETE FROM item_links WHERE source_id = ? AND link_type = 'phase'`, itemID); err != nil {
+		return nil, fmt.Errorf("delete existing phase link: %w", err)
+	}
+
+	// Insert new phase link
+	id := newID()
+	now := time.Now().UTC().Format(time.RFC3339)
+	if _, err := tx.Exec(`
+		INSERT INTO item_links (id, workspace_id, source_id, target_id, link_type, created_by, created_at)
+		VALUES (?, ?, ?, ?, 'phase', ?, ?)
+	`, id, workspaceID, itemID, phaseID, createdBy, now); err != nil {
+		return nil, fmt.Errorf("insert phase link: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit phase link: %w", err)
+	}
+
+	// Return the full link with enriched fields
+	links, err := s.GetItemLinks(itemID)
+	if err != nil {
+		return nil, err
+	}
+	for _, link := range links {
+		if link.ID == id {
+			return &link, nil
+		}
+	}
+	return nil, fmt.Errorf("phase link created but not found")
 }
 
 // ClearPhaseLink removes the phase link for an item.

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -413,6 +413,12 @@ func (s *Store) ListItems(workspaceID string, params models.ItemListParams) ([]m
 		args = append(args, params.AgentRoleID, params.AgentRoleID)
 	}
 
+	// Phase filter via item_links
+	if params.PhaseID != "" {
+		query += " AND EXISTS (SELECT 1 FROM item_links il WHERE il.source_id = i.id AND il.link_type = 'phase' AND il.target_id = ?)"
+		args = append(args, params.PhaseID)
+	}
+
 	// Field filters using json_extract — supports comma-separated values as OR
 	for key, value := range params.Fields {
 		if strings.Contains(value, ",") {
@@ -873,10 +879,113 @@ func (s *Store) DeleteItemLink(id string) error {
 	return nil
 }
 
+// --- Phase Links ---
+
+// SetPhaseLink sets the phase for an item. Since an item can belong to at most
+// one phase, this deletes any existing phase link for the item first.
+func (s *Store) SetPhaseLink(workspaceID, itemID, phaseID, createdBy string) (*models.ItemLink, error) {
+	// Delete existing phase link for this item (if any)
+	_, _ = s.db.Exec(`DELETE FROM item_links WHERE source_id = ? AND link_type = 'phase'`, itemID)
+
+	// Create new phase link
+	return s.CreateItemLink(workspaceID, models.ItemLinkCreate{
+		TargetID:  phaseID,
+		LinkType:  models.ItemLinkTypePhase,
+		CreatedBy: createdBy,
+	}, itemID)
+}
+
+// ClearPhaseLink removes the phase link for an item.
+func (s *Store) ClearPhaseLink(itemID string) error {
+	_, err := s.db.Exec(`DELETE FROM item_links WHERE source_id = ? AND link_type = 'phase'`, itemID)
+	if err != nil {
+		return fmt.Errorf("clear phase link: %w", err)
+	}
+	return nil
+}
+
+// GetPhaseForItem returns the phase link for an item, or nil if not in a phase.
+func (s *Store) GetPhaseForItem(itemID string) (*models.ItemLink, error) {
+	rows, err := s.db.Query(`
+		SELECT l.id, l.workspace_id, l.source_id, l.target_id, l.link_type, l.created_by, l.created_at,
+		       s.title, t.title, s.slug, t.slug, sc.slug, tc.slug, sc.prefix, tc.prefix,
+		       s.item_number, t.item_number,
+		       json_extract(s.fields, '$.status'), json_extract(t.fields, '$.status')
+		FROM item_links l
+		JOIN items s ON s.id = l.source_id
+		JOIN items t ON t.id = l.target_id
+		JOIN collections sc ON sc.id = s.collection_id
+		JOIN collections tc ON tc.id = t.collection_id
+		WHERE l.source_id = ? AND l.link_type = 'phase'
+	`, itemID)
+	if err != nil {
+		return nil, fmt.Errorf("get phase for item: %w", err)
+	}
+	defer rows.Close()
+
+	if !rows.Next() {
+		return nil, nil
+	}
+
+	var link models.ItemLink
+	var createdAt string
+	var sourcePrefix, targetPrefix string
+	var sourceItemNumber, targetItemNumber sql.NullInt64
+	var sourceStatus, targetStatus sql.NullString
+	if err := rows.Scan(
+		&link.ID, &link.WorkspaceID, &link.SourceID, &link.TargetID,
+		&link.LinkType, &link.CreatedBy, &createdAt,
+		&link.SourceTitle, &link.TargetTitle,
+		&link.SourceSlug, &link.TargetSlug,
+		&link.SourceCollectionSlug, &link.TargetCollectionSlug,
+		&sourcePrefix, &targetPrefix,
+		&sourceItemNumber, &targetItemNumber,
+		&sourceStatus, &targetStatus,
+	); err != nil {
+		return nil, fmt.Errorf("scan phase link: %w", err)
+	}
+	link.CreatedAt = parseTime(createdAt)
+	if sourceItemNumber.Valid && sourcePrefix != "" {
+		link.SourceRef = fmt.Sprintf("%s-%d", sourcePrefix, sourceItemNumber.Int64)
+	}
+	if targetItemNumber.Valid && targetPrefix != "" {
+		link.TargetRef = fmt.Sprintf("%s-%d", targetPrefix, targetItemNumber.Int64)
+	}
+	if sourceStatus.Valid {
+		link.SourceStatus = sourceStatus.String
+	}
+	if targetStatus.Valid {
+		link.TargetStatus = targetStatus.String
+	}
+	return &link, nil
+}
+
+// GetTaskPhaseMap returns a map of item ID -> phase item ID for all phase links
+// in a workspace. Used for efficient batch lookups (e.g., dashboard).
+func (s *Store) GetTaskPhaseMap(workspaceID string) (map[string]string, error) {
+	rows, err := s.db.Query(`
+		SELECT source_id, target_id FROM item_links
+		WHERE workspace_id = ? AND link_type = 'phase'
+	`, workspaceID)
+	if err != nil {
+		return nil, fmt.Errorf("get task phase map: %w", err)
+	}
+	defer rows.Close()
+
+	m := make(map[string]string)
+	for rows.Next() {
+		var sourceID, targetID string
+		if err := rows.Scan(&sourceID, &targetID); err != nil {
+			return nil, err
+		}
+		m[sourceID] = targetID
+	}
+	return m, rows.Err()
+}
+
 // --- Phase Progress ---
 
-// GetPhaseProgress counts total and done tasks linked to a phase via the
-// relation field json_extract(fields, '$.phase') = phaseItemID.
+// GetPhaseProgress counts total and done tasks linked to a phase via item_links.
 // "Done" means any terminal status as defined by the tasks collection's schema.
 func (s *Store) GetPhaseProgress(phaseItemID string) (total int, done int, err error) {
 	termPlaceholders, termArgs := s.getTasksTerminalPlaceholders()
@@ -886,9 +995,9 @@ func (s *Store) GetPhaseProgress(phaseItemID string) (total int, done int, err e
 		       COUNT(CASE WHEN LOWER(json_extract(i.fields, '$.status')) IN (`+termPlaceholders+`) THEN 1 END)
 		FROM items i
 		JOIN collections c ON c.id = i.collection_id
+		JOIN item_links il ON il.source_id = i.id AND il.link_type = 'phase' AND il.target_id = ?
 		WHERE c.slug = 'tasks'
 		  AND i.deleted_at IS NULL
-		  AND json_extract(i.fields, '$.phase') = ?
 	`, args...).Scan(&total, &done)
 	if err != nil {
 		return 0, 0, fmt.Errorf("get phase progress: %w", err)
@@ -929,7 +1038,8 @@ func (s *Store) GetAllPhasesProgress(workspaceID string) ([]PhaseProgress, error
 		       COUNT(CASE WHEN LOWER(json_extract(t.fields, '$.status')) IN (`+termPlaceholders+`) THEN 1 END)
 		FROM items p
 		JOIN collections pc ON pc.id = p.collection_id AND pc.slug = 'phases'
-		LEFT JOIN items t ON json_extract(t.fields, '$.phase') = p.id
+		LEFT JOIN item_links il ON il.link_type = 'phase' AND il.target_id = p.id
+		LEFT JOIN items t ON t.id = il.source_id
 		                  AND t.deleted_at IS NULL
 		LEFT JOIN collections tc ON tc.id = t.collection_id AND tc.slug = 'tasks'
 		WHERE p.workspace_id = ?
@@ -955,8 +1065,7 @@ func (s *Store) GetAllPhasesProgress(workspaceID string) ([]PhaseProgress, error
 	return result, rows.Err()
 }
 
-// GetTasksForPhase returns all non-deleted tasks whose phase relation field
-// points to the given phase item ID.
+// GetTasksForPhase returns all non-deleted tasks linked to the given phase via item_links.
 func (s *Store) GetTasksForPhase(phaseItemID string) ([]models.Item, error) {
 	rows, err := s.db.Query(`
 		SELECT i.id, i.workspace_id, i.collection_id, i.title, i.slug, i.content, i.fields, i.tags,
@@ -968,11 +1077,11 @@ func (s *Store) GetTasksForPhase(phaseItemID string) ([]models.Item, error) {
 		       COALESCE(ar.name, ''), COALESCE(ar.slug, ''), COALESCE(ar.icon, '')
 		FROM items i
 		JOIN collections c ON c.id = i.collection_id
+		JOIN item_links il ON il.source_id = i.id AND il.link_type = 'phase' AND il.target_id = ?
 		LEFT JOIN users au ON au.id = i.assigned_user_id
 		LEFT JOIN agent_roles ar ON ar.id = i.agent_role_id
 		WHERE c.slug = 'tasks'
 		  AND i.deleted_at IS NULL
-		  AND json_extract(i.fields, '$.phase') = ?
 		ORDER BY i.sort_order ASC, i.created_at ASC
 	`, phaseItemID)
 	if err != nil {

--- a/internal/store/migrations/021_phase_to_links.sql
+++ b/internal/store/migrations/021_phase_to_links.sql
@@ -5,7 +5,7 @@
 -- the item_links table with link_type='phase', unifying all item relationships
 -- under one system.
 
--- 1. Migrate existing phase field values to item_links
+-- 1. Migrate existing phase field values to item_links (including archived tasks/phases)
 INSERT OR IGNORE INTO item_links (id, workspace_id, source_id, target_id, link_type, created_by, created_at)
 SELECT
   lower(hex(randomblob(4)) || '-' || hex(randomblob(2)) || '-4' || substr(hex(randomblob(2)),2) || '-' || substr('89ab', abs(random()) % 4 + 1, 1) || substr(hex(randomblob(2)),2) || '-' || hex(randomblob(6))),
@@ -17,10 +17,9 @@ SELECT
   COALESCE(i.updated_at, i.created_at)
 FROM items i
 JOIN collections c ON c.id = i.collection_id AND c.slug = 'tasks'
-WHERE i.deleted_at IS NULL
-  AND json_extract(i.fields, '$.phase') IS NOT NULL
+WHERE json_extract(i.fields, '$.phase') IS NOT NULL
   AND json_extract(i.fields, '$.phase') != ''
-  AND json_extract(i.fields, '$.phase') IN (SELECT id FROM items WHERE deleted_at IS NULL);
+  AND json_extract(i.fields, '$.phase') IN (SELECT id FROM items);
 
 -- 2. Strip the phase key from task fields JSON
 UPDATE items SET fields = json_remove(fields, '$.phase')

--- a/internal/store/migrations/021_phase_to_links.sql
+++ b/internal/store/migrations/021_phase_to_links.sql
@@ -1,0 +1,36 @@
+-- Migration 021: Move phase relations from fields JSON to item_links table
+--
+-- Previously, Task→Phase membership was stored as a UUID in
+-- json_extract(items.fields, '$.phase'). This migration moves that data into
+-- the item_links table with link_type='phase', unifying all item relationships
+-- under one system.
+
+-- 1. Migrate existing phase field values to item_links
+INSERT OR IGNORE INTO item_links (id, workspace_id, source_id, target_id, link_type, created_by, created_at)
+SELECT
+  lower(hex(randomblob(4)) || '-' || hex(randomblob(2)) || '-4' || substr(hex(randomblob(2)),2) || '-' || substr('89ab', abs(random()) % 4 + 1, 1) || substr(hex(randomblob(2)),2) || '-' || hex(randomblob(6))),
+  i.workspace_id,
+  i.id,
+  json_extract(i.fields, '$.phase'),
+  'phase',
+  COALESCE(i.created_by, 'system'),
+  COALESCE(i.updated_at, i.created_at)
+FROM items i
+JOIN collections c ON c.id = i.collection_id AND c.slug = 'tasks'
+WHERE i.deleted_at IS NULL
+  AND json_extract(i.fields, '$.phase') IS NOT NULL
+  AND json_extract(i.fields, '$.phase') != ''
+  AND json_extract(i.fields, '$.phase') IN (SELECT id FROM items WHERE deleted_at IS NULL);
+
+-- 2. Strip the phase key from task fields JSON
+UPDATE items SET fields = json_remove(fields, '$.phase')
+WHERE collection_id IN (SELECT id FROM collections WHERE slug = 'tasks')
+  AND json_extract(fields, '$.phase') IS NOT NULL;
+
+-- 3. Remove the phase field definition from tasks collection schema
+UPDATE collections SET schema = json_set(schema, '$.fields',
+  (SELECT json_group_array(json(value))
+   FROM json_each(json_extract(collections.schema, '$.fields'))
+   WHERE json_extract(value, '$.key') != 'phase'))
+WHERE slug = 'tasks'
+  AND json_extract(schema, '$.fields') LIKE '%"key":"phase"%';

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -86,6 +86,7 @@ func (s *Store) migrate() error {
 		"018_conventions_role_field.sql",
 		"019_agent_roles_tools.sql",
 		"020_role_sort_order.sql",
+		"021_phase_to_links.sql",
 	}
 
 	for _, name := range migrations {

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -285,6 +285,11 @@ export const api = {
 			request<ItemLink>(`/workspaces/${ws}/items/${itemSlug}/links`, {
 				method: 'POST',
 				body: JSON.stringify(data)
+			}),
+
+		delete: (ws: string, linkId: string) =>
+			request<void>(`/workspaces/${ws}/links/${linkId}`, {
+				method: 'DELETE'
 			})
 	},
 

--- a/web/src/lib/components/collections/BoardView.svelte
+++ b/web/src/lib/components/collections/BoardView.svelte
@@ -20,10 +20,9 @@
 		oncreate?: () => void;
 		itemProgress?: Record<string, { total: number; done: number }>;
 		progressLabel?: string;
-		relationLabels?: Record<string, string>;
 	}
 
-	let { items, collection, wsSlug = '', groupField = 'status', focusedItemId = null, onStatusChange, onReorder, onArchiveColumn, onGroupReorder, oncreate, itemProgress, progressLabel = 'tasks', relationLabels }: Props = $props();
+	let { items, collection, wsSlug = '', groupField = 'status', focusedItemId = null, onStatusChange, onReorder, onArchiveColumn, onGroupReorder, oncreate, itemProgress, progressLabel = 'tasks' }: Props = $props();
 
 	let confirmArchiveColumn = $state<string | null>(null);
 
@@ -244,7 +243,6 @@
 							onStatusClick={onStatusChange}
 							progress={itemProgress?.[item.id] ?? null}
 							{progressLabel}
-							{relationLabels}
 						/>
 					</div>
 				{/each}

--- a/web/src/lib/components/collections/ItemCard.svelte
+++ b/web/src/lib/components/collections/ItemCard.svelte
@@ -13,10 +13,9 @@
 		onStatusClick?: (item: Item, newStatus: string) => void;
 		progress?: { total: number; done: number } | null;
 		progressLabel?: string;
-		relationLabels?: Record<string, string>;
 	}
 
-	let { item, collection, compact = false, focused = false, showCollection = false, statusOptions, onStatusClick, progress = null, progressLabel = 'tasks', relationLabels = {} }: Props = $props();
+	let { item, collection, compact = false, focused = false, showCollection = false, statusOptions, onStatusClick, progress = null, progressLabel = 'tasks' }: Props = $props();
 
 	let wsSlug = $derived(page.params.workspace ?? '');
 	let fields = $derived(parseFields(item));
@@ -110,9 +109,9 @@
 				{formatLabel(fields.priority)}
 			</span>
 		{/if}
-		{#if fields.phase && relationLabels[fields.phase]}
+		{#if item.phase_title}
 			<span class="meta-sep">&middot;</span>
-			<span class="meta-phase">{relationLabels[fields.phase]}</span>
+			<span class="meta-phase">{item.phase_ref ? `${item.phase_ref}: ${item.phase_title}` : item.phase_title}</span>
 		{/if}
 		{#if item.agent_role_name}
 			<span class="meta-sep">&middot;</span>

--- a/web/src/lib/components/collections/ListView.svelte
+++ b/web/src/lib/components/collections/ListView.svelte
@@ -22,7 +22,6 @@
 		oncreate?: () => void;
 		itemProgress?: Record<string, { total: number; done: number }>;
 		progressLabel?: string;
-		relationLabels?: Record<string, string>;
 	}
 
 	let {
@@ -38,8 +37,7 @@
 		onGroupReorder,
 		oncreate,
 		itemProgress,
-		progressLabel = 'tasks',
-		relationLabels
+		progressLabel = 'tasks'
 	}: Props = $props();
 
 	let confirmArchiveGroup = $state<string | null>(null);
@@ -275,7 +273,6 @@
 									onStatusClick={onStatusChange}
 									progress={itemProgress?.[item.id] ?? null}
 									{progressLabel}
-									{relationLabels}
 								/>
 							</div>
 						{/each}

--- a/web/src/lib/components/collections/TableView.svelte
+++ b/web/src/lib/components/collections/TableView.svelte
@@ -144,8 +144,6 @@
 								<button class="cell-status" onclick={() => cycleStatus(item, field.options!)} title="Click to cycle">
 									{formatLabel(fields[field.key] ?? '')}
 								</button>
-							{:else if field.key === 'phase' && fields[field.key] && relationLabels?.[fields[field.key]]}
-								<span class="cell-relation">{relationLabels[fields[field.key]]}</span>
 							{:else}
 								<span class="cell-value">{fields[field.key] ?? ''}</span>
 							{/if}

--- a/web/src/lib/components/collections/TableView.svelte
+++ b/web/src/lib/components/collections/TableView.svelte
@@ -12,7 +12,6 @@
 		oncreate?: () => void;
 		itemProgress?: Record<string, { total: number; done: number }>;
 		progressLabel?: string;
-		relationLabels?: Record<string, string>;
 	}
 
 	let {
@@ -22,8 +21,7 @@
 		onStatusChange,
 		oncreate,
 		itemProgress,
-		progressLabel,
-		relationLabels
+		progressLabel
 	}: Props = $props();
 
 	let resolvedWsSlug = $derived(wsSlug || page.params.workspace || '');
@@ -248,11 +246,6 @@
 	.cell-status:hover {
 		background: var(--bg-hover);
 		color: var(--text-primary);
-	}
-
-	.cell-relation {
-		font-size: 0.85em;
-		color: var(--accent-purple, var(--text-secondary));
 	}
 
 	.cell-date {

--- a/web/src/lib/components/fields/FieldEditor.svelte
+++ b/web/src/lib/components/fields/FieldEditor.svelte
@@ -1,27 +1,23 @@
 <!--
 @component
 Custom-styled field editor for item detail pages.
-Supports text, number, select, multi_select, date, checkbox, url, and relation field types.
+Supports text, number, select, multi_select, date, checkbox, and url field types.
 
 Usage:
 ```svelte
-<FieldEditor {field} {value} onchange={(v) => handleChange(v)} wsSlug="my-workspace" />
+<FieldEditor {field} {value} onchange={(v) => handleChange(v)} />
 ```
 -->
 <script lang="ts">
 	import type { FieldDef } from '$lib/types';
-	import { api } from '$lib/api/client';
-	import { formatItemRef } from '$lib/types';
-	import type { Item } from '$lib/types';
 
 	interface Props {
 		field: FieldDef;
 		value: any;
 		onchange: (value: any) => void;
-		wsSlug?: string;
 	}
 
-	let { field, value, onchange, wsSlug }: Props = $props();
+	let { field, value, onchange }: Props = $props();
 
 	// ── Date input state ──────────────────────────────────────────────────
 
@@ -42,94 +38,6 @@ Usage:
 	let focusedIndex = $state(-1);
 	let triggerEl: HTMLButtonElement | undefined = $state(undefined);
 	let dropdownEl: HTMLDivElement | undefined = $state(undefined);
-
-	// ── Relation picker state ─────────────────────────────────────────────
-
-	let relationOpen = $state(false);
-	let relationItems = $state<Item[]>([]);
-	let relationLoading = $state(false);
-	let relationSearch = $state('');
-	let relationFocusedIndex = $state(-1);
-	let relationTriggerEl: HTMLButtonElement | undefined = $state(undefined);
-	let relationDropdownEl: HTMLDivElement | undefined = $state(undefined);
-
-	let selectedRelationItem = $derived(
-		value ? relationItems.find((i) => i.id === value) : null
-	);
-
-	let filteredRelationItems = $derived.by(() => {
-		if (!relationSearch.trim()) return relationItems;
-		const q = relationSearch.toLowerCase();
-		return relationItems.filter(
-			(i) =>
-				i.title.toLowerCase().includes(q) ||
-				(formatItemRef(i) ?? '').toLowerCase().includes(q)
-		);
-	});
-
-	// Eagerly load relation items when the field has a value so we can
-	// display the title instead of a raw UUID on initial render.
-	$effect(() => {
-		if (field.type === 'relation' && value && relationItems.length === 0 && wsSlug && field.collection) {
-			loadRelationItems();
-		}
-	});
-
-	async function loadRelationItems() {
-		if (relationItems.length > 0 || !wsSlug || !field.collection) return;
-		relationLoading = true;
-		try {
-			relationItems = await api.items.listByCollection(wsSlug, field.collection);
-		} catch {
-			relationItems = [];
-		} finally {
-			relationLoading = false;
-		}
-	}
-
-	async function openRelationPicker() {
-		relationOpen = true;
-		relationSearch = '';
-		relationFocusedIndex = -1;
-		await loadRelationItems();
-	}
-
-	function selectRelation(item: Item) {
-		onchange(item.id);
-		relationOpen = false;
-		relationTriggerEl?.focus();
-	}
-
-	function clearRelation() {
-		onchange('');
-		relationOpen = false;
-	}
-
-	function handleRelationKeydown(e: KeyboardEvent) {
-		if (!relationOpen) return;
-		const items = filteredRelationItems;
-
-		if (e.key === 'ArrowDown') {
-			e.preventDefault();
-			relationFocusedIndex =
-				items.length > 0 ? (relationFocusedIndex + 1) % items.length : -1;
-		} else if (e.key === 'ArrowUp') {
-			e.preventDefault();
-			relationFocusedIndex =
-				items.length > 0
-					? (relationFocusedIndex - 1 + items.length) % items.length
-					: -1;
-		} else if (e.key === 'Enter') {
-			e.preventDefault();
-			if (relationFocusedIndex >= 0 && relationFocusedIndex < items.length) {
-				selectRelation(items[relationFocusedIndex]);
-			}
-		} else if (e.key === 'Escape') {
-			e.preventDefault();
-			relationOpen = false;
-			relationTriggerEl?.focus();
-		}
-	}
 
 	const STATUS_COLORS: Record<string, string> = {
 		open: 'var(--accent-blue)',
@@ -205,15 +113,6 @@ Usage:
 		) {
 			dropdownOpen = false;
 		}
-		if (
-			relationOpen &&
-			relationTriggerEl &&
-			relationDropdownEl &&
-			!relationTriggerEl.contains(e.target as Node) &&
-			!relationDropdownEl.contains(e.target as Node)
-		) {
-			relationOpen = false;
-		}
 	}
 
 	// ── Input handlers ─────────────────────────────────────────────────────
@@ -249,13 +148,6 @@ Usage:
 		}
 	});
 
-	$effect(() => {
-		if (relationOpen && relationFocusedIndex >= 0 && relationDropdownEl) {
-			const items = relationDropdownEl.querySelectorAll('[role="option"]');
-			const item = items[relationFocusedIndex] as HTMLElement | undefined;
-			item?.scrollIntoView({ block: 'nearest' });
-		}
-	});
 </script>
 
 <svelte:window onclick={handleWindowClick} />
@@ -400,97 +292,6 @@ Usage:
 				<line x1="5" y1="2" x2="5" y2="8" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" />
 			</svg>
 		</button>
-	</div>
-
-{:else if field.type === 'relation'}
-	<!-- Relation picker dropdown -->
-	<div class="select-wrapper">
-		<button
-			bind:this={relationTriggerEl}
-			class="select-trigger"
-			type="button"
-			aria-haspopup="listbox"
-			aria-expanded={relationOpen}
-			onclick={openRelationPicker}
-			onkeydown={handleRelationKeydown}
-		>
-			<span class="select-label">
-				{#if selectedRelationItem}
-					{#if formatItemRef(selectedRelationItem)}
-						<span class="relation-ref">{formatItemRef(selectedRelationItem)}</span>
-					{/if}
-					{selectedRelationItem.title}
-				{:else if value && relationLoading}
-					<span style="color: var(--text-muted)">Loading...</span>
-				{:else if value}
-					{value}
-				{:else}
-					<span style="color: var(--text-muted)">Select {field.label}...</span>
-				{/if}
-			</span>
-			{#if value}
-				<!-- Use span instead of button to avoid nesting <button> inside <button> -->
-				<span
-					class="clear-btn"
-					role="button"
-					tabindex="0"
-					onclick={(e) => {
-						e.stopPropagation();
-						clearRelation();
-					}}
-					onkeydown={(e) => {
-						if (e.key === 'Enter' || e.key === ' ') {
-							e.preventDefault();
-							e.stopPropagation();
-							clearRelation();
-						}
-					}}
-				>&#x2715;</span>
-			{/if}
-			<svg class="select-chevron" width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true">
-				<path d="M3 4.5L6 7.5L9 4.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
-			</svg>
-		</button>
-
-		{#if relationOpen}
-			<div
-				bind:this={relationDropdownEl}
-				class="select-dropdown relation-dropdown"
-				role="listbox"
-				aria-label="{field.label} options"
-			>
-				<input
-					class="relation-search"
-					type="text"
-					placeholder="Search..."
-					bind:value={relationSearch}
-					onkeydown={handleRelationKeydown}
-				/>
-				{#if relationLoading}
-					<div class="relation-loading">Loading...</div>
-				{:else if filteredRelationItems.length === 0}
-					<div class="relation-empty">No items found</div>
-				{:else}
-					{#each filteredRelationItems as item, i (item.id)}
-						<button
-							class="select-option"
-							class:selected={item.id === value}
-							class:focused={i === relationFocusedIndex}
-							type="button"
-							role="option"
-							aria-selected={item.id === value}
-							onclick={() => selectRelation(item)}
-							onmouseenter={() => (relationFocusedIndex = i)}
-						>
-							{#if formatItemRef(item)}
-								<span class="relation-ref">{formatItemRef(item)}</span>
-							{/if}
-							<span>{item.title}</span>
-						</button>
-					{/each}
-				{/if}
-			</div>
-		{/if}
 	</div>
 
 {:else if field.type === 'url'}
@@ -795,45 +596,6 @@ Usage:
 
 	.toggle.on .toggle-knob {
 		transform: translateX(16px);
-	}
-
-	/* ── Relation picker ──────────────────────────────────────────────── */
-
-	.relation-dropdown {
-		max-height: 280px;
-	}
-
-	.relation-search {
-		width: 100%;
-		padding: var(--space-1) var(--space-2);
-		font-size: 0.85em;
-		font-family: inherit;
-		color: var(--text-primary);
-		background: var(--bg-tertiary);
-		border: none;
-		border-bottom: 1px solid var(--border);
-		outline: none;
-		box-sizing: border-box;
-	}
-
-	.relation-search:focus {
-		background: var(--bg-primary);
-	}
-
-	.relation-ref {
-		font-family: var(--font-mono);
-		font-size: 0.85em;
-		color: var(--text-muted);
-		margin-right: 4px;
-		flex-shrink: 0;
-	}
-
-	.relation-loading,
-	.relation-empty {
-		padding: var(--space-2) var(--space-3);
-		font-size: 0.85em;
-		color: var(--text-muted);
-		text-align: center;
 	}
 
 	.clear-btn {

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -318,6 +318,9 @@ export interface Item {
 	collection_icon?: string;
 	collection_prefix?: string;
 	item_number?: number;
+	phase_id?: string;
+	phase_ref?: string;
+	phase_title?: string;
 	derived_closure?: ItemDerivedClosure;
 	code_context?: ItemCodeContext;
 	convention?: ItemConventionMetadata;

--- a/web/src/routes/[workspace]/+page.svelte
+++ b/web/src/routes/[workspace]/+page.svelte
@@ -332,7 +332,7 @@
 							<span class="section-badge">{dashboard.attention.length}</span>
 						</div>
 						<div class="attention-list">
-							{#each dashboard.attention as alert (alert.item_slug)}
+							{#each dashboard.attention as alert (`${alert.type}:${alert.item_slug}`)}
 								<div class="attention-card">
 									<span class="attention-icon">{attentionIcon(alert.type)}</span>
 									<div class="attention-content">

--- a/web/src/routes/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[workspace]/[collection]/+page.svelte
@@ -856,7 +856,6 @@
 				oncreate={openQuickCreate}
 				{itemProgress}
 				{progressLabel}
-				{relationLabels}
 			/>
 		{:else if viewMode === 'table'}
 			<TableView
@@ -867,7 +866,6 @@
 				oncreate={openQuickCreate}
 				{itemProgress}
 				{progressLabel}
-				{relationLabels}
 			/>
 		{:else}
 			<ListView
@@ -884,7 +882,6 @@
 				oncreate={openQuickCreate}
 				{itemProgress}
 				{progressLabel}
-				{relationLabels}
 			/>
 		{/if}
 	{/if}

--- a/web/src/routes/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[workspace]/[collection]/+page.svelte
@@ -260,6 +260,10 @@
 		// Apply field filters
 		for (const [key, value] of Object.entries(activeFilters)) {
 			result = result.filter((item) => {
+				// Phase filter uses the phase link, not fields JSON
+				if (key === 'phase') {
+					return item.phase_id === value;
+				}
 				const fields = parseFields(item);
 				return fields[key] === value;
 			});

--- a/web/src/routes/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[workspace]/[collection]/[slug]/+page.svelte
@@ -24,6 +24,7 @@
 		label: string;
 		href: string | null;
 		status?: string;
+		linkId?: string;
 	};
 
 	type RelationshipGroup = {
@@ -355,13 +356,16 @@
 			key: `${link.id}:${useSource ? 'source' : 'target'}`,
 			label: relationLabel(ref, title, id),
 			href,
-			status
+			status,
+			linkId: link.id
 		};
 	}
 
 	function buildRelationshipGroups(currentItem: Item, links: ItemLink[]): RelationshipGroup[] {
 		const grouped = new Map<string, RelationshipGroup>();
 		const definitions: Record<string, { label: string; tone: RelationshipGroup['tone'] }> = {
+			phase: { label: 'Phase', tone: 'default' },
+			in_phase: { label: 'In phase', tone: 'default' },
 			blocks: { label: 'Blocks', tone: 'blocks' },
 			blocked_by: { label: 'Blocked by', tone: 'blocks' },
 			links_to: { label: 'Links to', tone: 'wiki' },
@@ -374,7 +378,7 @@
 			implemented_by: { label: 'Implemented by', tone: 'lineage' },
 			related: { label: 'Related', tone: 'default' }
 		};
-		const order = ['blocks', 'blocked_by', 'links_to', 'referenced_by', 'split_from', 'split_into', 'supersedes', 'superseded_by', 'implements', 'implemented_by', 'related'];
+		const order = ['phase', 'in_phase', 'blocks', 'blocked_by', 'links_to', 'referenced_by', 'split_from', 'split_into', 'supersedes', 'superseded_by', 'implements', 'implemented_by', 'related'];
 
 		function addEntry(groupKey: string, entry: RelationshipEntry) {
 			const definition = definitions[groupKey];
@@ -388,6 +392,9 @@
 		for (const link of links) {
 			const isSource = link.source_id === currentItem.id;
 			switch (link.link_type) {
+				case 'phase':
+					addEntry(isSource ? 'in_phase' : 'phase', linkEntry(link, !isSource));
+					break;
 				case 'blocks':
 					addEntry(isSource ? 'blocks' : 'blocked_by', linkEntry(link, !isSource));
 					break;
@@ -434,6 +441,68 @@
 
 	let allCollections = $derived(collectionStore.collections ?? []);
 	let moveTargets = $derived(allCollections.filter(c => c.slug !== collSlug));
+
+	async function handleDeleteLink(linkId?: string) {
+		if (!linkId || !item) return;
+		try {
+			await api.links.delete(wsSlug, linkId);
+			itemLinks = itemLinks.filter(l => l.id !== linkId);
+			// Refresh item to update phase info
+			const refreshed = await api.items.get(wsSlug, itemSlug);
+			item = { ...refreshed, content: item.content };
+			toastStore.show('Relationship removed', 'success');
+		} catch (e: any) {
+			toastStore.show(e.message ?? 'Failed to remove relationship', 'error');
+		}
+	}
+
+	// ── Add Relationship ─────────────────────────────────────────────────────
+	let showAddLink = $state(false);
+	let addLinkType = $state('related');
+	let addLinkSearch = $state('');
+	let addLinkResults = $state<Item[]>([]);
+	let addLinkLoading = $state(false);
+
+	async function searchItemsForLink() {
+		if (!addLinkSearch.trim()) {
+			addLinkResults = [];
+			return;
+		}
+		addLinkLoading = true;
+		try {
+			const results = await api.search(addLinkSearch, wsSlug);
+			// Filter out self and items already linked
+			const linkedIds = new Set(itemLinks.flatMap(l => [l.source_id, l.target_id]));
+			addLinkResults = (results.results || [])
+				.map((r) => r.item)
+				.filter((i: Item) => i.id !== item?.id && !linkedIds.has(i.id))
+				.slice(0, 10);
+		} catch {
+			addLinkResults = [];
+		} finally {
+			addLinkLoading = false;
+		}
+	}
+
+	async function handleCreateLink(targetItem: Item) {
+		if (!item) return;
+		try {
+			const newLink = await api.links.create(wsSlug, item.slug, {
+				target_id: targetItem.id,
+				link_type: addLinkType
+			});
+			itemLinks = [...itemLinks, newLink];
+			showAddLink = false;
+			addLinkSearch = '';
+			addLinkResults = [];
+			// Refresh item to update phase info
+			const refreshed = await api.items.get(wsSlug, itemSlug);
+			item = { ...refreshed, content: item.content };
+			toastStore.show('Relationship added', 'success');
+		} catch (e: any) {
+			toastStore.show(e.message ?? 'Failed to add relationship', 'error');
+		}
+	}
 
 	async function handleMove(targetSlug: string) {
 		if (!item || moving) return;
@@ -606,7 +675,6 @@
 									{field}
 									value={fieldValue(field.key)}
 									onchange={(v) => updateField(field.key, v)}
-									{wsSlug}
 								/>
 							</div>
 						</div>
@@ -736,15 +804,71 @@
 										{:else}
 											<span class="link-target">{entry.label}</span>
 										{/if}
-										{#if entry.status}
-											<span class="link-status">{formatFieldDisplay(entry.status)}</span>
-										{/if}
+										<span class="link-row-actions">
+											{#if entry.status}
+												<span class="link-status">{formatFieldDisplay(entry.status)}</span>
+											{/if}
+											{#if entry.linkId}
+												<button class="link-delete-btn" title="Remove relationship" onclick={() => handleDeleteLink(entry.linkId)}>×</button>
+											{/if}
+										</span>
 									</div>
 								{/each}
 							</div>
 						</div>
 					{/each}
 				</div>
+			</div>
+		{/if}
+
+		<!-- Add Relationship -->
+		{#if item}
+			<div class="add-relationship-section">
+				{#if !showAddLink}
+					<button class="add-relationship-btn" onclick={() => { showAddLink = true; }}>
+						+ Add relationship
+					</button>
+				{:else}
+					<div class="add-link-form">
+						<div class="add-link-header">
+							<h4>Add Relationship</h4>
+							<button class="add-link-close" onclick={() => { showAddLink = false; addLinkSearch = ''; addLinkResults = []; }}>×</button>
+						</div>
+						<div class="add-link-controls">
+							<select bind:value={addLinkType} class="add-link-type-select">
+								<option value="related">Related</option>
+								<option value="blocks">Blocks</option>
+								<option value="implements">Implements</option>
+								<option value="split_from">Split from</option>
+								<option value="supersedes">Supersedes</option>
+								<option value="phase">Phase</option>
+							</select>
+							<input
+								type="text"
+								class="add-link-search"
+								placeholder="Search items..."
+								bind:value={addLinkSearch}
+								oninput={() => searchItemsForLink()}
+							/>
+						</div>
+						{#if addLinkLoading}
+							<div class="add-link-loading">Searching...</div>
+						{:else if addLinkResults.length > 0}
+							<div class="add-link-results">
+								{#each addLinkResults as result (result.id)}
+									<button class="add-link-result" onclick={() => handleCreateLink(result)}>
+										{#if formatItemRef(result)}
+											<span class="add-link-ref">{formatItemRef(result)}</span>
+										{/if}
+										<span class="add-link-title">{result.title}</span>
+									</button>
+								{/each}
+							</div>
+						{:else if addLinkSearch.trim().length > 0}
+							<div class="add-link-loading">No results</div>
+						{/if}
+					</div>
+				{/if}
 			</div>
 		{/if}
 
@@ -1220,6 +1344,135 @@
 		padding: 2px 8px;
 		border-radius: 999px;
 		white-space: nowrap;
+	}
+	.link-row-actions {
+		display: flex;
+		align-items: center;
+		gap: var(--space-2);
+	}
+	.link-delete-btn {
+		display: none;
+		background: none;
+		border: none;
+		color: var(--text-muted);
+		cursor: pointer;
+		padding: 0 var(--space-1);
+		font-size: 1rem;
+		line-height: 1;
+	}
+	.link-delete-btn:hover {
+		color: var(--danger);
+	}
+	.link-row:hover .link-delete-btn {
+		display: inline;
+	}
+
+	/* Add Relationship */
+	.add-relationship-section {
+		margin-top: var(--space-4);
+	}
+	.add-relationship-btn {
+		background: none;
+		border: 1px dashed var(--border-color);
+		color: var(--text-muted);
+		padding: var(--space-2) var(--space-3);
+		border-radius: var(--radius-md);
+		cursor: pointer;
+		font-size: 0.85rem;
+		width: 100%;
+		text-align: left;
+	}
+	.add-relationship-btn:hover {
+		color: var(--text-primary);
+		border-color: var(--text-muted);
+	}
+	.add-link-form {
+		border: 1px solid var(--border-color);
+		border-radius: var(--radius-md);
+		padding: var(--space-3);
+		background: var(--bg-secondary);
+	}
+	.add-link-header {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		margin-bottom: var(--space-2);
+	}
+	.add-link-header h4 {
+		margin: 0;
+		font-size: 0.85rem;
+		font-weight: 600;
+	}
+	.add-link-close {
+		background: none;
+		border: none;
+		color: var(--text-muted);
+		cursor: pointer;
+		font-size: 1.2rem;
+		padding: 0;
+		line-height: 1;
+	}
+	.add-link-controls {
+		display: flex;
+		gap: var(--space-2);
+		margin-bottom: var(--space-2);
+	}
+	.add-link-type-select {
+		padding: var(--space-1) var(--space-2);
+		border: 1px solid var(--border-color);
+		border-radius: var(--radius-sm);
+		background: var(--bg-primary);
+		color: var(--text-primary);
+		font-size: 0.8rem;
+		min-width: 120px;
+	}
+	.add-link-search {
+		flex: 1;
+		padding: var(--space-1) var(--space-2);
+		border: 1px solid var(--border-color);
+		border-radius: var(--radius-sm);
+		background: var(--bg-primary);
+		color: var(--text-primary);
+		font-size: 0.8rem;
+	}
+	.add-link-results {
+		display: flex;
+		flex-direction: column;
+		gap: 1px;
+		max-height: 200px;
+		overflow-y: auto;
+	}
+	.add-link-result {
+		display: flex;
+		align-items: center;
+		gap: var(--space-2);
+		padding: var(--space-2);
+		background: var(--bg-primary);
+		border: none;
+		border-radius: var(--radius-sm);
+		cursor: pointer;
+		text-align: left;
+		color: var(--text-primary);
+		font-size: 0.8rem;
+	}
+	.add-link-result:hover {
+		background: var(--bg-hover);
+	}
+	.add-link-ref {
+		color: var(--text-muted);
+		font-family: var(--font-mono);
+		font-size: 0.75rem;
+		flex-shrink: 0;
+	}
+	.add-link-title {
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+	.add-link-loading {
+		padding: var(--space-2);
+		color: var(--text-muted);
+		font-size: 0.8rem;
 	}
 
 	/* Timeline */

--- a/web/src/routes/[workspace]/new/+page.svelte
+++ b/web/src/routes/[workspace]/new/+page.svelte
@@ -114,7 +114,6 @@
 					{field}
 					value={extraFields[field.key] ?? ''}
 					onchange={(v) => { extraFields[field.key] = v; }}
-					wsSlug={wsSlug}
 				/>
 			</label>
 		{/each}


### PR DESCRIPTION
## Summary

- **Unifies the two separate item relationship systems** (relation fields stored in JSON vs. item_links table) into a single `item_links`-based system. Phase membership is now just another link type (`phase`) alongside `blocks`, `related`, `implements`, etc.
- **Adds full link CRUD in the web UI** — users can now add and remove any relationship type (blocks, related, implements, phase, etc.) directly from the item detail page
- **Fixes duplicate `{#each}` key error** on the dashboard attention list (pre-existing bug surfaced by this work)

### Backend
- New `phase` link type + SQL migration 021 migrating 75 existing phase field values → `item_links` rows
- Store queries (`GetPhaseProgress`, `GetAllPhasesProgress`, `GetTasksForPhase`) rewritten to JOIN on `item_links`
- Create/update handlers intercept `phase` in fields and route through links system
- Single-phase constraint enforced (a task can only belong to one phase)
- Items enriched with `phase_id`, `phase_ref`, `phase_title` in API responses

### Frontend
- Relation field editor removed from `FieldEditor.svelte`
- "Add relationship" UI on item detail page with link type selector + item search
- Delete buttons on existing relationship entries
- `api.links.delete` added to API client
- ItemCard, FilterBar, TableView updated to use link-based phase data

### CLI
- `--phase` flag on create/update still works (API intercepts and creates links)
- Changelog `--phase` filter uses enriched phase fields

Implements IDEA-106.

## Test plan
- [x] `make test` — all Go tests pass
- [x] `make install` — full build succeeds, migration runs automatically
- [x] Verified 75 phase links migrated correctly, no old phase fields remain
- [x] Dashboard shows correct phase progress and orphaned task detection
- [x] `pad item create task "X" --phase PHASE-N` creates phase link (not field)
- [x] `pad item show TASK-X` shows phase_id, phase_ref, phase_title
- [ ] Web UI: open a task → verify phase appears in Relationships section
- [ ] Web UI: "Add relationship" → search for item → create link → verify it appears
- [ ] Web UI: delete a relationship → verify it's removed
- [ ] Web UI: dashboard loads without console errors