### PR TITLE
feat: generalized parent/child items with progress tracking

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,9 @@ REST API at `/api/v1/`. Key endpoints:
 - `GET /workspaces/{ws}/dashboard` — computed project overview (active items, phases, attention, blockers)
 - `GET /workspaces/{ws}/activity` — workspace activity feed (enriched with item titles + change details)
 - `GET/POST/DELETE /workspaces/{ws}/webhooks` — webhook management
-- `GET/POST /workspaces/{ws}/items/{slug}/links` — item relationships (blocks/blocked-by)
+- `GET /workspaces/{ws}/items/{slug}/children` — child items linked to a parent
+- `GET /workspaces/{ws}/items/{slug}/progress` — child item completion progress
+- `GET/POST /workspaces/{ws}/items/{slug}/links` — item relationships (blocks/blocked-by, parent/child)
 - `GET /search?q=query&workspace=slug` — full-text search
 - `GET /api/v1/events?workspace=slug` — SSE real-time events
 - `GET /workspaces/{ws}/members` — list members + pending invitations
@@ -132,8 +134,8 @@ Items are referenced by **issue ID** (e.g. `TASK-5`, `BUG-8`) wherever a `<ref>`
 Slugs also work but issue IDs are preferred.
 
 ```bash
-pad item create <collection> "title" [--status X] [--priority X]
-pad item list [collection] [--status X] [--all]
+pad item create <collection> "title" [--status X] [--priority X] [--parent REF]
+pad item list [collection] [--status X] [--parent REF] [--all]
 pad item show <ref>           # e.g. pad item show TASK-5
 pad item update <ref> [--status X] [--priority X]
 pad item delete <ref>
@@ -142,7 +144,7 @@ pad item search "query"
 pad project dashboard         # Project dashboard
 pad project next              # Recommended next task
 pad project standup [--days N]  # Daily standup report
-pad project changelog [--days N]  # Release notes from completed items
+pad project changelog [--days N] [--parent REF]  # Release notes from completed items
 pad item block <source> <target>  # e.g. pad item block TASK-5 TASK-8
 pad item blocked-by <item> <blocker>
 pad item deps <ref>           # Show dependencies
@@ -175,6 +177,7 @@ Collection names accept singular forms: `task`→`tasks`, `idea`→`ideas`, `doc
 
 - **Collections** have JSON schemas defining typed fields (select, text, date, number, etc.)
 - **Items** have structured `fields` JSON + optional rich `content` (markdown)
+- **Parent/child links:** Any item can be a parent of child items (`--parent REF`). Children get progress tracking, burndown charts, and nested rendering. Phases are the most common parent, but Ideas, Docs, or Tasks can also have children.
 - **Wiki-links** `[[Title]]` resolve across all items, rendered as clickable links
 - **Default collections:** Tasks, Ideas, Phases, Docs
 - **Templates:** startup (default), scrum, product — set via `pad workspace init --template`

--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -1757,13 +1757,17 @@ Run with --help-collections to see available collections and their status values
 			if priority != "" {
 				fields["priority"] = priority
 			}
-			if phase != "" {
-				// Resolve phase slug to item ID
-				phaseItem, err := client.GetItem(ws, phase)
+			// --parent takes precedence; --phase is a backward-compat alias
+			parentRef := parentSlug
+			if parentRef == "" {
+				parentRef = phase
+			}
+			if parentRef != "" {
+				parentItem, err := client.GetItem(ws, parentRef)
 				if err != nil {
-					return fmt.Errorf("phase %q not found: %w", phase, err)
+					return fmt.Errorf("parent %q not found: %w", parentRef, err)
 				}
-				fields["phase"] = phaseItem.ID
+				fields["parent"] = parentItem.ID
 			}
 			if category != "" {
 				fields["category"] = category
@@ -1863,9 +1867,10 @@ Run with --help-collections to see available collections and their status values
 	cmd.Flags().StringVar(&status, "status", "", "status field value")
 	cmd.Flags().StringVar(&assignee, "assign", "", "assign to user (name or email)")
 	cmd.Flags().StringVar(&roleFlag, "role", "", "assign agent role (slug)")
-	cmd.Flags().StringVar(&phase, "phase", "", "phase relation (slug or ID)")
+	cmd.Flags().StringVar(&parentSlug, "parent", "", "parent item (ref, slug, or ID)")
+	cmd.Flags().StringVar(&phase, "phase", "", "parent item (deprecated alias for --parent)")
+	cmd.Flags().Lookup("phase").Hidden = true
 	cmd.Flags().StringVar(&category, "category", "", "category field value")
-	cmd.Flags().StringVar(&parentSlug, "parent", "", "parent item slug for nesting")
 	cmd.Flags().StringVar(&tags, "tags", "", "JSON array of tags")
 	cmd.Flags().StringArrayVarP(&fieldFlags, "field", "f", nil, "set arbitrary field (repeatable): --field key=value")
 
@@ -1895,6 +1900,7 @@ func listCmd() *cobra.Command {
 		priorityFilter string
 		assigneeFilter string
 		roleFilter     string
+		parentFilter   string
 		sortBy         string
 		groupBy        string
 		limitNum       int
@@ -1957,6 +1963,9 @@ Examples:
 			if roleFilter != "" {
 				params.Set("agent_role_id", roleFilter)
 			}
+			if parentFilter != "" {
+				params.Set("parent", parentFilter)
+			}
 			if sortBy != "" {
 				params.Set("sort", sortBy)
 			}
@@ -2009,6 +2018,7 @@ Examples:
 	cmd.Flags().StringVar(&priorityFilter, "priority", "", "filter by priority")
 	cmd.Flags().StringVar(&assigneeFilter, "assign", "", "filter by assigned user (name or email)")
 	cmd.Flags().StringVar(&roleFilter, "role", "", "filter by agent role (slug)")
+	cmd.Flags().StringVar(&parentFilter, "parent", "", "filter by parent item (ref, slug, or ID)")
 	cmd.Flags().StringVar(&sortBy, "sort", "", "sort order (e.g. priority:desc,created_at:asc)")
 	cmd.Flags().StringVar(&groupBy, "group-by", "", "group results by field")
 	cmd.Flags().IntVar(&limitNum, "limit", 0, "max number of items to return")
@@ -2250,6 +2260,7 @@ func updateCmd() *cobra.Command {
 		assignee   string
 		roleFlag   string
 		phase      string
+		parentFlag string
 		category   string
 		tags       string
 		fieldFlags []string
@@ -2306,7 +2317,13 @@ Examples:
 			}
 
 			// Merge field changes with existing fields
-			hasFieldChanges := status != "" || priority != "" || assignee != "" || phase != "" || category != "" || len(fieldFlags) > 0
+			// --parent takes precedence; --phase is a backward-compat alias
+			parentRef := parentFlag
+			if parentRef == "" {
+				parentRef = phase
+			}
+
+			hasFieldChanges := status != "" || priority != "" || assignee != "" || parentRef != "" || category != "" || len(fieldFlags) > 0
 			if hasFieldChanges {
 				existingFields := make(map[string]interface{})
 				if item.Fields != "" && item.Fields != "{}" {
@@ -2319,13 +2336,12 @@ Examples:
 				if priority != "" {
 					existingFields["priority"] = priority
 				}
-				if phase != "" {
-					// Resolve phase slug to item ID
-					phaseItem, err := client.GetItem(ws, phase)
+				if parentRef != "" {
+					parentItem, err := client.GetItem(ws, parentRef)
 					if err != nil {
-						return fmt.Errorf("phase %q not found: %w", phase, err)
+						return fmt.Errorf("parent %q not found: %w", parentRef, err)
 					}
-					existingFields["phase"] = phaseItem.ID
+					existingFields["parent"] = parentItem.ID
 				}
 				if category != "" {
 					existingFields["category"] = category
@@ -2407,7 +2423,9 @@ Examples:
 	cmd.Flags().StringVar(&priority, "priority", "", "update priority field")
 	cmd.Flags().StringVar(&assignee, "assign", "", "assign to user (name or email)")
 	cmd.Flags().StringVar(&roleFlag, "role", "", "assign agent role (slug)")
-	cmd.Flags().StringVar(&phase, "phase", "", "update phase relation")
+	cmd.Flags().StringVar(&parentFlag, "parent", "", "update parent item (ref, slug, or ID)")
+	cmd.Flags().StringVar(&phase, "phase", "", "update parent item (deprecated alias for --parent)")
+	cmd.Flags().Lookup("phase").Hidden = true
 	cmd.Flags().StringVar(&category, "category", "", "update category field")
 	cmd.Flags().StringVar(&tags, "tags", "", "update tags (JSON array)")
 	cmd.Flags().StringArrayVarP(&fieldFlags, "field", "f", nil, "set arbitrary field (repeatable): --field key=value")
@@ -3373,6 +3391,7 @@ func changelogCmd() *cobra.Command {
 	var days int
 	var since string
 	var phase string
+	var parentRef string
 
 	cmd := &cobra.Command{
 		Use:   "changelog",
@@ -3413,14 +3432,20 @@ func changelogCmd() *cobra.Command {
 				}
 			}
 
-			// Filter by phase if specified
-			if phase != "" {
+			// Filter by parent if specified (--parent or --phase)
+			filterParent := parentRef
+			if filterParent == "" {
+				filterParent = phase
+			}
+			if filterParent != "" {
 				var filtered []models.Item
 				for _, item := range allItems {
-					// Check phase link (populated by API enrichment)
-					if strings.EqualFold(item.PhaseID, phase) ||
-						strings.EqualFold(item.PhaseRef, phase) ||
-						strings.EqualFold(item.PhaseTitle, phase) {
+					// Check parent link (populated by API enrichment)
+					if strings.EqualFold(item.ParentLinkID, filterParent) ||
+						strings.EqualFold(item.ParentRef, filterParent) ||
+						strings.EqualFold(item.ParentTitle, filterParent) ||
+						strings.EqualFold(item.PhaseID, filterParent) ||
+						strings.EqualFold(item.PhaseRef, filterParent) {
 						filtered = append(filtered, item)
 					}
 				}
@@ -3460,8 +3485,8 @@ func changelogCmd() *cobra.Command {
 			if since != "" {
 				periodLabel = "since " + since
 			}
-			if phase != "" {
-				periodLabel += " (phase: " + phase + ")"
+			if filterParent != "" {
+				periodLabel += " (parent: " + filterParent + ")"
 			}
 
 			// JSON output
@@ -3583,7 +3608,9 @@ func changelogCmd() *cobra.Command {
 
 	cmd.Flags().IntVar(&days, "days", 7, "show items completed in last N days")
 	cmd.Flags().StringVar(&since, "since", "", "only show items completed after this date (YYYY-MM-DD)")
-	cmd.Flags().StringVar(&phase, "phase", "", "only show items from a specific phase")
+	cmd.Flags().StringVar(&parentRef, "parent", "", "only show items under a specific parent (ref, slug, or title)")
+	cmd.Flags().StringVar(&phase, "phase", "", "only show items under a specific parent (deprecated alias for --parent)")
+	cmd.Flags().Lookup("phase").Hidden = true
 
 	return cmd
 }

--- a/internal/cli/format.go
+++ b/internal/cli/format.go
@@ -250,6 +250,20 @@ func PrintItemMeta(item *models.Item) {
 		}
 		fmt.Printf("%s %s\n", label.Sprint("Collection:"), collLabel)
 	}
+	// Parent link
+	if item.ParentRef != "" || item.PhaseRef != "" {
+		ref := item.ParentRef
+		title := item.ParentTitle
+		if ref == "" {
+			ref = item.PhaseRef
+			title = item.PhaseTitle
+		}
+		parentStr := ref
+		if title != "" {
+			parentStr = ref + " " + title
+		}
+		fmt.Printf("%s %s\n", label.Sprint("Parent:    "), parentStr)
+	}
 	// Assignment: user + role
 	if item.AssignedUserName != "" || item.AgentRoleName != "" {
 		assignStr := ""

--- a/internal/models/item.go
+++ b/internal/models/item.go
@@ -52,10 +52,19 @@ type Item struct {
 	CollectionIcon      string                   `json:"collection_icon,omitempty"`
 	CollectionPrefix    string                   `json:"collection_prefix,omitempty"`
 
-	// Phase link (populated by enrichItemForResponse)
+	// Parent link (populated by enrichItemForResponse / enrichItemsWithParent)
+	ParentLinkID string `json:"parent_link_id,omitempty"`
+	ParentRef    string `json:"parent_ref,omitempty"`
+	ParentTitle  string `json:"parent_title,omitempty"`
+
+	// Deprecated aliases — kept for API backward compatibility
 	PhaseID    string `json:"phase_id,omitempty"`
 	PhaseRef   string `json:"phase_ref,omitempty"`
 	PhaseTitle string `json:"phase_title,omitempty"`
+
+	// HasChildren is true if this item has child items linked to it.
+	// Populated by enrichment, not stored in the DB.
+	HasChildren bool `json:"has_children,omitempty"`
 
 	DerivedClosure      *ItemDerivedClosure      `json:"derived_closure,omitempty"`
 	CodeContext         *ItemCodeContext         `json:"code_context,omitempty"`
@@ -510,7 +519,8 @@ type ItemListParams struct {
 	Tag             string
 	AssignedUserID  string // filter by assigned user
 	AgentRoleID     string // filter by agent role (ID or slug)
-	PhaseID         string // filter by phase link (item ID of the phase)
+	ParentLinkID    string // filter by parent link (item ID of the parent)
+	PhaseID         string // deprecated alias for ParentLinkID
 	IncludeArchived bool
 	Limit           int
 	Offset          int

--- a/internal/models/item_links.go
+++ b/internal/models/item_links.go
@@ -12,7 +12,8 @@ const (
 	ItemLinkTypeSplitFrom  = "split_from"
 	ItemLinkTypeSupersedes = "supersedes"
 	ItemLinkTypeImplements = "implements"
-	ItemLinkTypePhase     = "phase"
+	ItemLinkTypeParent    = "parent"
+	ItemLinkTypePhase     = "parent" // Deprecated alias — use ItemLinkTypeParent
 )
 
 var itemLinkTypeAliases = map[string]string{
@@ -25,7 +26,8 @@ var itemLinkTypeAliases = map[string]string{
 	"split-from": ItemLinkTypeSplitFrom,
 	"supersedes": ItemLinkTypeSupersedes,
 	"implements": ItemLinkTypeImplements,
-	"phase":      ItemLinkTypePhase,
+	"parent":     ItemLinkTypeParent,
+	"phase":      ItemLinkTypeParent, // backward compat
 }
 
 // NormalizeItemLinkType canonicalizes supported link types and returns an error

--- a/internal/server/handlers_dashboard.go
+++ b/internal/server/handlers_dashboard.go
@@ -225,8 +225,8 @@ func (s *Server) handleGetDashboard(w http.ResponseWriter, r *http.Request) {
 				Title: phase.Title,
 			}
 
-			// Compute progress from tasks linked via relation field
-			total, done, err := s.store.GetPhaseProgress(phase.ID)
+			// Compute progress from child items linked via parent link
+			total, done, err := s.store.GetItemProgress(phase.ID)
 			if err == nil && total > 0 {
 				dp.TaskCount = total
 				dp.DoneCount = done
@@ -301,7 +301,7 @@ func (s *Server) handleGetDashboard(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// (c) Phase completion: phases where ALL linked tasks are done
+	// (c) Phase completion: phases where ALL child items are done
 	for _, dp := range resp.ActivePhases {
 		if dp.TaskCount > 0 && dp.DoneCount == dp.TaskCount {
 			resp.Attention = append(resp.Attention, DashboardAttention{
@@ -314,20 +314,20 @@ func (s *Server) handleGetDashboard(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// (d) Orphaned tasks: tasks with no phase link set
-	//     Only flag these if the workspace actually has phases with tasks linked to them.
-	hasPhaseWithTasks := false
+	// (d) Orphaned tasks: tasks with no parent link set
+	//     Only flag these if the workspace has active phases with children linked to them.
+	hasParentWithChildren := false
 	for _, dp := range resp.ActivePhases {
 		if dp.TaskCount > 0 {
-			hasPhaseWithTasks = true
+			hasParentWithChildren = true
 			break
 		}
 	}
-	if hasPhaseWithTasks {
-		// Batch-fetch all task→phase mappings for efficiency
-		taskPhaseMap, err := s.store.GetTaskPhaseMap(workspaceID)
+	if hasParentWithChildren {
+		// Batch-fetch all child→parent mappings for efficiency
+		parentMap, err := s.store.GetParentMap(workspaceID)
 		if err != nil {
-			taskPhaseMap = map[string]string{}
+			parentMap = map[string]string{}
 		}
 		allTasks, err := s.store.ListItems(workspaceID, models.ItemListParams{
 			CollectionSlug: "tasks",
@@ -338,7 +338,7 @@ func (s *Server) handleGetDashboard(w http.ResponseWriter, r *http.Request) {
 				if isItemTerminal(status, task.CollectionID, schemaMap) {
 					continue
 				}
-				if _, hasPhase := taskPhaseMap[task.ID]; !hasPhase {
+				if _, hasParent := parentMap[task.ID]; !hasParent {
 					resp.Attention = append(resp.Attention, DashboardAttention{
 						Type:       "orphaned_task",
 						ItemSlug:   task.Slug,
@@ -419,7 +419,7 @@ func (s *Server) handleGetDashboard(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// --- Suggested Next ---
-	// Find open tasks in active phases, sorted by priority, top 3
+	// Find open child items in active phases, sorted by priority, top 3
 	type suggestion struct {
 		item     models.Item
 		phase    string
@@ -428,11 +428,11 @@ func (s *Server) handleGetDashboard(w http.ResponseWriter, r *http.Request) {
 	var candidates []suggestion
 
 	for _, dp := range resp.ActivePhases {
-		phaseItem, err := s.store.ResolveItem(workspaceID, dp.Slug)
-		if err != nil || phaseItem == nil {
+		parentItem, err := s.store.ResolveItem(workspaceID, dp.Slug)
+		if err != nil || parentItem == nil {
 			continue
 		}
-		tasks, err := s.store.GetTasksForPhase(phaseItem.ID)
+		tasks, err := s.store.GetChildItems(parentItem.ID)
 		if err != nil {
 			continue
 		}

--- a/internal/server/handlers_item_links.go
+++ b/internal/server/handlers_item_links.go
@@ -94,12 +94,16 @@ func (s *Server) handleCreateItemLink(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Phase links enforce single-phase: an item can only belong to one phase.
-	// Use SetPhaseLink which handles the upsert automatically.
-	if input.LinkType == models.ItemLinkTypePhase {
+	// Parent links enforce single-parent: an item can only belong to one parent.
+	// Use SetParentLink which handles upsert and cycle detection.
+	if input.LinkType == models.ItemLinkTypeParent {
 		actor, _ := actorFromRequest(r)
-		link, err := s.store.SetPhaseLink(workspaceID, item.ID, target.ID, actor)
+		link, err := s.store.SetParentLink(workspaceID, item.ID, target.ID, actor)
 		if err != nil {
+			if strings.Contains(err.Error(), "cycle") {
+				writeError(w, http.StatusBadRequest, "bad_request", err.Error())
+				return
+			}
 			writeInternalError(w, err)
 			return
 		}

--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -62,7 +62,12 @@ func (s *Server) handleListCollectionItems(w http.ResponseWriter, r *http.Reques
 
 	params := parseItemListParams(r)
 	params.CollectionSlug = collSlug
-	if err := s.resolveParentFilter(workspaceID, &params); err != nil {
+
+	var collSchema models.CollectionSchema
+	if coll.Schema != "" {
+		_ = json.Unmarshal([]byte(coll.Schema), &collSchema)
+	}
+	if err := s.resolveParentFilter(workspaceID, &params, collSchema); err != nil {
 		writeError(w, http.StatusBadRequest, "bad_request", err.Error())
 		return
 	}
@@ -130,8 +135,12 @@ func (s *Server) handleCreateItem(w http.ResponseWriter, r *http.Request) {
 
 	// Extract parent from fields — it's managed via item_links, not stored in fields JSON.
 	// Accepts both "parent" and "phase" (backward compat) as the field key.
+	// Skip this if the schema actually defines a field with that key.
 	var parentValue string
 	for _, key := range []string{"parent", "phase"} {
+		if schemaHasField(schema, key) {
+			continue
+		}
 		if pv, ok := fieldMap[key]; ok && pv != nil {
 			if pvStr, ok := pv.(string); ok && pvStr != "" {
 				if !isUUID(pvStr) {
@@ -269,9 +278,13 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 
 		// Extract parent from fields — it's managed via item_links, not stored in fields JSON.
 		// Accepts both "parent" and "phase" (backward compat) as the field key.
+		// Skip this if the schema actually defines a field with that key.
 		var parentValue string
 		var parentProvided bool
 		for _, key := range []string{"parent", "phase"} {
+			if schemaHasField(schema, key) {
+				continue
+			}
 			if pv, ok := fieldMap[key]; ok {
 				parentProvided = true
 				if pv != nil {
@@ -696,14 +709,24 @@ func (s *Server) handleGetItemProgress(w http.ResponseWriter, r *http.Request) {
 
 // resolveParentFilter extracts a "parent" (or legacy "phase") key from the field
 // filters and converts it to a ParentLinkID filter (which uses item_links instead of json_extract).
-func (s *Server) resolveParentFilter(workspaceID string, params *models.ItemListParams) error {
+// An optional schema can be passed; if the schema defines a field with the key,
+// that key is left as a normal field filter instead of being treated as a parent link.
+func (s *Server) resolveParentFilter(workspaceID string, params *models.ItemListParams, schemas ...models.CollectionSchema) error {
 	if params.Fields == nil {
 		return nil
 	}
 
 	// Accept both "parent" and "phase" (backward compat)
+	// but skip if the schema defines a real field with that key
+	var schema *models.CollectionSchema
+	if len(schemas) > 0 {
+		schema = &schemas[0]
+	}
 	var val string
 	for _, key := range []string{"parent", "phase"} {
+		if schema != nil && schemaHasField(*schema, key) {
+			continue
+		}
 		if v, ok := params.Fields[key]; ok && v != "" {
 			val = v
 			delete(params.Fields, key)
@@ -866,6 +889,16 @@ func (s *Server) resolveRelationFilterValue(workspaceID, key, rawValue string) (
 }
 
 // isUUID checks if a string looks like a UUID (8-4-4-4-12 hex).
+// schemaHasField returns true if the collection schema defines a field with the given key.
+func schemaHasField(schema models.CollectionSchema, key string) bool {
+	for _, f := range schema.Fields {
+		if f.Key == key {
+			return true
+		}
+	}
+	return false
+}
+
 func isUUID(s string) bool {
 	if len(s) != 36 {
 		return false

--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -25,7 +25,7 @@ func (s *Server) handleListItems(w http.ResponseWriter, r *http.Request) {
 	}
 
 	params := parseItemListParams(r)
-	if err := s.resolvePhaseFilter(workspaceID, &params); err != nil {
+	if err := s.resolveParentFilter(workspaceID, &params); err != nil {
 		writeError(w, http.StatusBadRequest, "bad_request", err.Error())
 		return
 	}
@@ -37,7 +37,7 @@ func (s *Server) handleListItems(w http.ResponseWriter, r *http.Request) {
 	if result == nil {
 		result = []models.Item{}
 	}
-	s.enrichItemsWithPhase(workspaceID, result)
+	s.enrichItemsWithParent(workspaceID, result)
 
 	writeJSON(w, http.StatusOK, result)
 }
@@ -62,7 +62,7 @@ func (s *Server) handleListCollectionItems(w http.ResponseWriter, r *http.Reques
 
 	params := parseItemListParams(r)
 	params.CollectionSlug = collSlug
-	if err := s.resolvePhaseFilter(workspaceID, &params); err != nil {
+	if err := s.resolveParentFilter(workspaceID, &params); err != nil {
 		writeError(w, http.StatusBadRequest, "bad_request", err.Error())
 		return
 	}
@@ -75,7 +75,7 @@ func (s *Server) handleListCollectionItems(w http.ResponseWriter, r *http.Reques
 	if result == nil {
 		result = []models.Item{}
 	}
-	s.enrichItemsWithPhase(workspaceID, result)
+	s.enrichItemsWithParent(workspaceID, result)
 
 	writeJSON(w, http.StatusOK, result)
 }
@@ -128,23 +128,25 @@ func (s *Server) handleCreateItem(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Extract phase from fields — it's managed via item_links, not stored in fields JSON
-	var phaseValue string
-	if pv, ok := fieldMap["phase"]; ok && pv != nil {
-		if pvStr, ok := pv.(string); ok && pvStr != "" {
-			// Resolve slug/ref to UUID if needed
-			if !isUUID(pvStr) {
-				resolved, err := s.store.ResolveItem(workspaceID, pvStr)
-				if err != nil || resolved == nil {
-					writeError(w, http.StatusBadRequest, "bad_request", fmt.Sprintf("phase %q not found", pvStr))
-					return
+	// Extract parent from fields — it's managed via item_links, not stored in fields JSON.
+	// Accepts both "parent" and "phase" (backward compat) as the field key.
+	var parentValue string
+	for _, key := range []string{"parent", "phase"} {
+		if pv, ok := fieldMap[key]; ok && pv != nil {
+			if pvStr, ok := pv.(string); ok && pvStr != "" {
+				if !isUUID(pvStr) {
+					resolved, err := s.store.ResolveItem(workspaceID, pvStr)
+					if err != nil || resolved == nil {
+						writeError(w, http.StatusBadRequest, "bad_request", fmt.Sprintf("parent %q not found", pvStr))
+						return
+					}
+					parentValue = resolved.ID
+				} else {
+					parentValue = pvStr
 				}
-				phaseValue = resolved.ID
-			} else {
-				phaseValue = pvStr
 			}
+			delete(fieldMap, key)
 		}
-		delete(fieldMap, "phase")
 	}
 
 	if err := items.ValidateFields(fieldMap, schema); err != nil {
@@ -170,11 +172,11 @@ func (s *Server) handleCreateItem(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Create phase link if specified
-	if phaseValue != "" {
+	// Create parent link if specified
+	if parentValue != "" {
 		actor, _ := actorFromRequest(r)
-		if _, err := s.store.SetPhaseLink(workspaceID, item.ID, phaseValue, actor); err != nil {
-			writeError(w, http.StatusInternalServerError, "internal_error", fmt.Sprintf("item created but phase link failed: %v", err))
+		if _, err := s.store.SetParentLink(workspaceID, item.ID, parentValue, actor); err != nil {
+			writeError(w, http.StatusInternalServerError, "internal_error", fmt.Sprintf("item created but parent link failed: %v", err))
 			return
 		}
 	}
@@ -265,26 +267,29 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		// Extract phase from fields — it's managed via item_links, not stored in fields JSON
-		var phaseValue string
-		var phaseProvided bool
-		if pv, ok := fieldMap["phase"]; ok {
-			phaseProvided = true
-			if pv != nil {
-				if pvStr, ok := pv.(string); ok && pvStr != "" {
-					if !isUUID(pvStr) {
-						resolved, err := s.store.ResolveItem(workspaceID, pvStr)
-						if err != nil || resolved == nil {
-							writeError(w, http.StatusBadRequest, "bad_request", fmt.Sprintf("phase %q not found", pvStr))
-							return
+		// Extract parent from fields — it's managed via item_links, not stored in fields JSON.
+		// Accepts both "parent" and "phase" (backward compat) as the field key.
+		var parentValue string
+		var parentProvided bool
+		for _, key := range []string{"parent", "phase"} {
+			if pv, ok := fieldMap[key]; ok {
+				parentProvided = true
+				if pv != nil {
+					if pvStr, ok := pv.(string); ok && pvStr != "" {
+						if !isUUID(pvStr) {
+							resolved, err := s.store.ResolveItem(workspaceID, pvStr)
+							if err != nil || resolved == nil {
+								writeError(w, http.StatusBadRequest, "bad_request", fmt.Sprintf("parent %q not found", pvStr))
+								return
+							}
+							parentValue = resolved.ID
+						} else {
+							parentValue = pvStr
 						}
-						phaseValue = resolved.ID
-					} else {
-						phaseValue = pvStr
 					}
 				}
+				delete(fieldMap, key)
 			}
-			delete(fieldMap, "phase")
 		}
 
 		if err := items.ValidateFields(fieldMap, schema); err != nil {
@@ -303,18 +308,18 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 		validated := string(validatedFields)
 		input.Fields = &validated
 
-		// Update phase link if phase was provided in the update
-		if phaseProvided {
-			if phaseValue != "" {
+		// Update parent link if parent was provided in the update
+		if parentProvided {
+			if parentValue != "" {
 				actor, _ := actorFromRequest(r)
-				if _, err := s.store.SetPhaseLink(workspaceID, item.ID, phaseValue, actor); err != nil {
-					writeError(w, http.StatusInternalServerError, "internal_error", fmt.Sprintf("failed to update phase link: %v", err))
+				if _, err := s.store.SetParentLink(workspaceID, item.ID, parentValue, actor); err != nil {
+					writeError(w, http.StatusInternalServerError, "internal_error", fmt.Sprintf("failed to update parent link: %v", err))
 					return
 				}
 			} else {
-				// Phase was explicitly set to empty/null — clear the link
-				if err := s.store.ClearPhaseLink(item.ID); err != nil {
-					writeError(w, http.StatusInternalServerError, "internal_error", fmt.Sprintf("failed to clear phase link: %v", err))
+				// Parent was explicitly set to empty/null — clear the link
+				if err := s.store.ClearParentLink(item.ID); err != nil {
+					writeError(w, http.StatusInternalServerError, "internal_error", fmt.Sprintf("failed to clear parent link: %v", err))
 					return
 				}
 			}
@@ -604,14 +609,15 @@ func (s *Server) publishItemEventWithName(eventType, workspaceID, itemID, title,
 	})
 }
 
-// handlePhasesProgress returns task completion progress for all non-deleted phases.
+// handlePhasesProgress returns child item completion progress for all non-deleted phases.
+// This is a backward-compat endpoint; the general form is per-item via /items/{slug}/children.
 func (s *Server) handlePhasesProgress(w http.ResponseWriter, r *http.Request) {
 	workspaceID, ok := s.getWorkspaceID(w, r)
 	if !ok {
 		return
 	}
 
-	progress, err := s.store.GetAllPhasesProgress(workspaceID)
+	progress, err := s.store.GetAllItemProgress(workspaceID, "phases")
 	if err != nil {
 		writeInternalError(w, err)
 		return
@@ -619,8 +625,9 @@ func (s *Server) handlePhasesProgress(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, progress)
 }
 
-// handleGetItemTasks returns tasks linked to a phase item via the phase relation field.
-func (s *Server) handleGetItemTasks(w http.ResponseWriter, r *http.Request) {
+// handleGetItemChildren returns all child items linked to a parent item.
+// This is the generalized version — children can come from any collection.
+func (s *Server) handleGetItemChildren(w http.ResponseWriter, r *http.Request) {
 	workspaceID, ok := s.getWorkspaceID(w, r)
 	if !ok {
 		return
@@ -637,39 +644,85 @@ func (s *Server) handleGetItemTasks(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	tasks, err := s.store.GetTasksForPhase(item.ID)
+	children, err := s.store.GetChildItems(item.ID)
 	if err != nil {
 		writeInternalError(w, err)
 		return
 	}
-	if tasks == nil {
-		tasks = []models.Item{}
+	if children == nil {
+		children = []models.Item{}
 	}
-	s.enrichItemsWithPhase(workspaceID, tasks)
-	writeJSON(w, http.StatusOK, tasks)
+	s.enrichItemsWithParent(workspaceID, children)
+	s.store.PopulateHasChildren(children)
+	writeJSON(w, http.StatusOK, children)
 }
 
-// resolvePhaseFilter extracts a "phase" key from the field filters and converts
-// it to a PhaseID filter (which uses item_links instead of json_extract).
-func (s *Server) resolvePhaseFilter(workspaceID string, params *models.ItemListParams) error {
+// handleGetItemProgress returns completion progress for an item's children.
+// Response: {"total": N, "done": N, "percentage": N}
+func (s *Server) handleGetItemProgress(w http.ResponseWriter, r *http.Request) {
+	workspaceID, ok := s.getWorkspaceID(w, r)
+	if !ok {
+		return
+	}
+
+	itemSlug := chi.URLParam(r, "itemSlug")
+	item, err := s.store.ResolveItem(workspaceID, itemSlug)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	if item == nil {
+		writeError(w, http.StatusNotFound, "not_found", "Item not found")
+		return
+	}
+
+	total, done, err := s.store.GetItemProgress(item.ID)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+
+	pct := 0
+	if total > 0 {
+		pct = (done * 100) / total
+	}
+
+	writeJSON(w, http.StatusOK, map[string]int{
+		"total":      total,
+		"done":       done,
+		"percentage": pct,
+	})
+}
+
+// resolveParentFilter extracts a "parent" (or legacy "phase") key from the field
+// filters and converts it to a ParentLinkID filter (which uses item_links instead of json_extract).
+func (s *Server) resolveParentFilter(workspaceID string, params *models.ItemListParams) error {
 	if params.Fields == nil {
 		return nil
 	}
-	phaseVal, ok := params.Fields["phase"]
-	if !ok || phaseVal == "" {
+
+	// Accept both "parent" and "phase" (backward compat)
+	var val string
+	for _, key := range []string{"parent", "phase"} {
+		if v, ok := params.Fields[key]; ok && v != "" {
+			val = v
+			delete(params.Fields, key)
+			break
+		}
+	}
+	if val == "" {
 		return nil
 	}
-	delete(params.Fields, "phase")
 
 	// Resolve slug/ref to UUID
-	if !isUUID(phaseVal) {
-		resolved, err := s.store.ResolveItem(workspaceID, phaseVal)
+	if !isUUID(val) {
+		resolved, err := s.store.ResolveItem(workspaceID, val)
 		if err != nil || resolved == nil {
-			return fmt.Errorf("phase %q not found", phaseVal)
+			return fmt.Errorf("parent %q not found", val)
 		}
-		params.PhaseID = resolved.ID
+		params.ParentLinkID = resolved.ID
 	} else {
-		params.PhaseID = phaseVal
+		params.ParentLinkID = val
 	}
 	return nil
 }

--- a/internal/server/item_lineage.go
+++ b/internal/server/item_lineage.go
@@ -7,28 +7,28 @@ import (
 	"github.com/xarmian/pad/internal/models"
 )
 
-// enrichItemsWithPhase batch-populates phase link info on a slice of items.
+// enrichItemsWithParent batch-populates parent link info on a slice of items.
 // Used by list endpoints where calling enrichItemForResponse per-item is too expensive.
-func (s *Server) enrichItemsWithPhase(workspaceID string, items []models.Item) {
+func (s *Server) enrichItemsWithParent(workspaceID string, items []models.Item) {
 	if len(items) == 0 {
 		return
 	}
-	phaseMap, err := s.store.GetTaskPhaseMap(workspaceID)
-	if err != nil || len(phaseMap) == 0 {
+	parentMap, err := s.store.GetParentMap(workspaceID)
+	if err != nil || len(parentMap) == 0 {
 		return
 	}
-	// Collect unique phase IDs
-	phaseIDs := make(map[string]bool)
-	for _, pid := range phaseMap {
-		phaseIDs[pid] = true
+	// Collect unique parent IDs
+	parentIDs := make(map[string]bool)
+	for _, pid := range parentMap {
+		parentIDs[pid] = true
 	}
-	// Fetch phase item details (title, ref) in bulk
-	type phaseInfo struct {
+	// Fetch parent item details (title, ref) in bulk
+	type parentInfo struct {
 		title string
 		ref   string
 	}
-	phases := make(map[string]phaseInfo)
-	for pid := range phaseIDs {
+	parents := make(map[string]parentInfo)
+	for pid := range parentIDs {
 		item, err := s.store.GetItem(pid)
 		if err != nil || item == nil {
 			continue
@@ -37,20 +37,28 @@ func (s *Server) enrichItemsWithPhase(workspaceID string, items []models.Item) {
 		if item.CollectionPrefix != "" && item.ItemNumber != nil {
 			ref = fmt.Sprintf("%s-%d", item.CollectionPrefix, *item.ItemNumber)
 		}
-		phases[pid] = phaseInfo{title: item.Title, ref: ref}
+		parents[pid] = parentInfo{title: item.Title, ref: ref}
 	}
 	// Populate items
 	for i := range items {
-		pid, ok := phaseMap[items[i].ID]
+		pid, ok := parentMap[items[i].ID]
 		if !ok {
 			continue
 		}
-		items[i].PhaseID = pid
-		if info, ok := phases[pid]; ok {
-			items[i].PhaseTitle = info.title
-			items[i].PhaseRef = info.ref
+		items[i].ParentLinkID = pid
+		items[i].PhaseID = pid // backward compat
+		if info, ok := parents[pid]; ok {
+			items[i].ParentTitle = info.title
+			items[i].ParentRef = info.ref
+			items[i].PhaseTitle = info.title // backward compat
+			items[i].PhaseRef = info.ref     // backward compat
 		}
 	}
+}
+
+// enrichItemsWithPhase is a deprecated alias for enrichItemsWithParent.
+func (s *Server) enrichItemsWithPhase(workspaceID string, items []models.Item) {
+	s.enrichItemsWithParent(workspaceID, items)
 }
 
 func (s *Server) enrichItemForResponse(item *models.Item) error {
@@ -63,15 +71,19 @@ func (s *Server) enrichItemForResponse(item *models.Item) error {
 	}
 	item.DerivedClosure = closure
 
-	// Populate phase link info
-	phaseLink, err := s.store.GetPhaseForItem(item.ID)
+	// Populate parent link info
+	parentLink, err := s.store.GetParentForItem(item.ID)
 	if err != nil {
 		return err
 	}
-	if phaseLink != nil {
-		item.PhaseID = phaseLink.TargetID
-		item.PhaseRef = phaseLink.TargetRef
-		item.PhaseTitle = phaseLink.TargetTitle
+	if parentLink != nil {
+		item.ParentLinkID = parentLink.TargetID
+		item.ParentRef = parentLink.TargetRef
+		item.ParentTitle = parentLink.TargetTitle
+		// Backward compat
+		item.PhaseID = parentLink.TargetID
+		item.PhaseRef = parentLink.TargetRef
+		item.PhaseTitle = parentLink.TargetTitle
 	}
 
 	return nil

--- a/internal/server/middleware_auth.go
+++ b/internal/server/middleware_auth.go
@@ -117,6 +117,12 @@ func (s *Server) SessionAuth(next http.Handler) http.Handler {
 			return
 		}
 
+		// Re-issue CSRF cookie if the session is valid but the cookie is missing.
+		// This can happen when cookies expire at different times or are selectively cleared.
+		if _, csrfErr := r.Cookie(csrfCookie); csrfErr != nil {
+			setCSRFCookie(w, 7*24*60*60, s.secureCookies)
+		}
+
 		ctx := context.WithValue(r.Context(), ctxCurrentUser, user)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -295,7 +295,9 @@ func (s *Server) setupRouter() {
 					r.Get("/comments", s.handleListComments)
 					r.Post("/comments", s.handleCreateComment)
 					r.Get("/timeline", s.handleListItemTimeline)
-					r.Get("/tasks", s.handleGetItemTasks)
+					r.Get("/children", s.handleGetItemChildren)
+					r.Get("/progress", s.handleGetItemProgress)
+					r.Get("/tasks", s.handleGetItemChildren) // deprecated alias
 				})
 
 				// Links (v2)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -135,10 +135,10 @@ func (s *Server) setupRouter() {
 	r.Use(chimiddleware.RealIP)
 	r.Use(chimiddleware.RequestID)
 	r.Use(StructuredLogger)
-	r.Use(chimiddleware.Recoverer)
 	if s.metrics != nil {
 		r.Use(MetricsMiddleware(s.metrics))
 	}
+	r.Use(chimiddleware.Recoverer)
 
 	// Prometheus scrape endpoint — no auth/CSRF/security headers
 	if s.metrics != nil {

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -1229,6 +1229,58 @@ func (s *Store) getChildTerminalPlaceholders(parentItemID string) (string, []any
 	return strings.Join(placeholders, ","), args
 }
 
+// getCollectionChildTerminalPlaceholders returns SQL placeholders and args for the
+// terminal statuses of all child collections linked to parents in the given collection.
+// This is the batch version of getChildTerminalPlaceholders — instead of querying for
+// a single parent, it gathers terminal statuses across all parent→child links in a
+// workspace/collection pair.
+func (s *Store) getCollectionChildTerminalPlaceholders(workspaceID, collectionSlug string) (string, []any) {
+	rows, err := s.db.Query(s.q(`
+		SELECT DISTINCT c.schema
+		FROM items t
+		JOIN collections c ON c.id = t.collection_id
+		JOIN item_links il ON il.source_id = t.id AND il.link_type = 'parent'
+		JOIN items p ON p.id = il.target_id AND p.deleted_at IS NULL
+		JOIN collections pc ON pc.id = p.collection_id AND pc.slug = ?
+		WHERE p.workspace_id = ?
+		  AND t.deleted_at IS NULL
+		  AND c.deleted_at IS NULL
+	`), collectionSlug, workspaceID)
+	if err != nil {
+		return models.DefaultTerminalStatusPlaceholders()
+	}
+	defer rows.Close()
+
+	terminalSet := make(map[string]bool)
+	found := false
+	for rows.Next() {
+		var schemaJSON string
+		if err := rows.Scan(&schemaJSON); err != nil {
+			continue
+		}
+		found = true
+		var schema models.CollectionSchema
+		if err := json.Unmarshal([]byte(schemaJSON), &schema); err != nil {
+			continue
+		}
+		for _, ts := range models.TerminalStatusesFromSchema(schema) {
+			terminalSet[strings.ToLower(ts)] = true
+		}
+	}
+
+	if !found || len(terminalSet) == 0 {
+		return models.DefaultTerminalStatusPlaceholders()
+	}
+
+	placeholders := make([]string, 0, len(terminalSet))
+	args := make([]any, 0, len(terminalSet))
+	for ts := range terminalSet {
+		placeholders = append(placeholders, "?")
+		args = append(args, ts)
+	}
+	return strings.Join(placeholders, ","), args
+}
+
 // ItemProgress holds child item completion counts for a single parent item.
 type ItemProgress struct {
 	ItemID string `json:"item_id"`
@@ -1243,7 +1295,7 @@ type PhaseProgress = ItemProgress
 // item in the given collection within a workspace. This generalizes
 // GetAllPhasesProgress — any collection can be queried, not just phases.
 func (s *Store) GetAllItemProgress(workspaceID, collectionSlug string) ([]ItemProgress, error) {
-	termPlaceholders, termArgs := models.DefaultTerminalStatusPlaceholders()
+	termPlaceholders, termArgs := s.getCollectionChildTerminalPlaceholders(workspaceID, collectionSlug)
 	args := append(termArgs, workspaceID, collectionSlug)
 	tStatusExpr := s.dialect.JSONExtractText("t.fields", "status")
 	rows, err := s.db.Query(s.q(fmt.Sprintf(`
@@ -1335,8 +1387,9 @@ func (s *Store) PopulateHasChildren(items []models.Item) {
 		args[i] = id
 	}
 	query := fmt.Sprintf(`
-		SELECT DISTINCT target_id FROM item_links
-		WHERE link_type = 'parent' AND target_id IN (%s)
+		SELECT DISTINCT il.target_id FROM item_links il
+		JOIN items child ON child.id = il.source_id AND child.deleted_at IS NULL
+		WHERE il.link_type = 'parent' AND il.target_id IN (%s)
 	`, strings.Join(placeholders, ","))
 
 	rows, err := s.db.Query(s.q(query), args...)

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -414,10 +414,14 @@ func (s *Store) ListItems(workspaceID string, params models.ItemListParams) ([]m
 		args = append(args, params.AgentRoleID, params.AgentRoleID)
 	}
 
-	// Phase filter via item_links
-	if params.PhaseID != "" {
-		query += " AND EXISTS (SELECT 1 FROM item_links il WHERE il.source_id = i.id AND il.link_type = 'phase' AND il.target_id = ?)"
-		args = append(args, params.PhaseID)
+	// Parent link filter via item_links
+	parentFilter := params.ParentLinkID
+	if parentFilter == "" {
+		parentFilter = params.PhaseID // deprecated alias
+	}
+	if parentFilter != "" {
+		query += " AND EXISTS (SELECT 1 FROM item_links il WHERE il.source_id = i.id AND il.link_type = 'parent' AND il.target_id = ?)"
+		args = append(args, parentFilter)
 	}
 
 	// Field filters — supports comma-separated values as OR
@@ -967,32 +971,38 @@ func (s *Store) DeleteItemLink(id string) error {
 
 // --- Phase Links ---
 
-// SetPhaseLink sets the phase for an item. Since an item can belong to at most
-// one phase, this deletes any existing phase link for the item first.
-func (s *Store) SetPhaseLink(workspaceID, itemID, phaseID, createdBy string) (*models.ItemLink, error) {
+// SetParentLink sets the parent for an item. Since an item can belong to at most
+// one parent, this deletes any existing parent link for the item first.
+// Includes cycle detection to prevent A→B→A or deeper ancestor loops.
+func (s *Store) SetParentLink(workspaceID, itemID, parentID, createdBy string) (*models.ItemLink, error) {
+	// Cycle detection: walk the ancestor chain from parentID to ensure itemID is not an ancestor.
+	if err := s.checkParentCycle(itemID, parentID); err != nil {
+		return nil, err
+	}
+
 	tx, err := s.db.Begin()
 	if err != nil {
 		return nil, fmt.Errorf("begin tx: %w", err)
 	}
 	defer tx.Rollback()
 
-	// Delete existing phase link for this item (if any)
-	if _, err := tx.Exec(s.q(`DELETE FROM item_links WHERE source_id = ? AND link_type = 'phase'`), itemID); err != nil {
-		return nil, fmt.Errorf("delete existing phase link: %w", err)
+	// Delete existing parent link for this item (if any)
+	if _, err := tx.Exec(s.q(`DELETE FROM item_links WHERE source_id = ? AND link_type = 'parent'`), itemID); err != nil {
+		return nil, fmt.Errorf("delete existing parent link: %w", err)
 	}
 
-	// Insert new phase link
+	// Insert new parent link
 	id := newID()
 	now := time.Now().UTC().Format(time.RFC3339)
 	if _, err := tx.Exec(s.q(`
 		INSERT INTO item_links (id, workspace_id, source_id, target_id, link_type, created_by, created_at)
-		VALUES (?, ?, ?, ?, 'phase', ?, ?)
-	`), id, workspaceID, itemID, phaseID, createdBy, now); err != nil {
-		return nil, fmt.Errorf("insert phase link: %w", err)
+		VALUES (?, ?, ?, ?, 'parent', ?, ?)
+	`), id, workspaceID, itemID, parentID, createdBy, now); err != nil {
+		return nil, fmt.Errorf("insert parent link: %w", err)
 	}
 
 	if err := tx.Commit(); err != nil {
-		return nil, fmt.Errorf("commit phase link: %w", err)
+		return nil, fmt.Errorf("commit parent link: %w", err)
 	}
 
 	// Return the full link with enriched fields
@@ -1005,20 +1015,55 @@ func (s *Store) SetPhaseLink(workspaceID, itemID, phaseID, createdBy string) (*m
 			return &link, nil
 		}
 	}
-	return nil, fmt.Errorf("phase link created but not found")
+	return nil, fmt.Errorf("parent link created but not found")
 }
 
-// ClearPhaseLink removes the phase link for an item.
-func (s *Store) ClearPhaseLink(itemID string) error {
-	_, err := s.db.Exec(s.q(`DELETE FROM item_links WHERE source_id = ? AND link_type = 'phase'`), itemID)
-	if err != nil {
-		return fmt.Errorf("clear phase link: %w", err)
+// SetPhaseLink is a deprecated alias for SetParentLink.
+func (s *Store) SetPhaseLink(workspaceID, itemID, parentID, createdBy string) (*models.ItemLink, error) {
+	return s.SetParentLink(workspaceID, itemID, parentID, createdBy)
+}
+
+// checkParentCycle walks the ancestor chain from parentID and returns an error
+// if itemID is found (which would create a cycle).
+func (s *Store) checkParentCycle(itemID, parentID string) error {
+	visited := map[string]bool{itemID: true}
+	current := parentID
+	for {
+		if visited[current] {
+			return fmt.Errorf("cannot set parent: would create a cycle")
+		}
+		visited[current] = true
+
+		// Look up the parent of current
+		var targetID sql.NullString
+		err := s.db.QueryRow(s.q(`
+			SELECT target_id FROM item_links
+			WHERE source_id = ? AND link_type = 'parent'
+		`), current).Scan(&targetID)
+		if err != nil || !targetID.Valid {
+			break // no parent — no cycle
+		}
+		current = targetID.String
 	}
 	return nil
 }
 
-// GetPhaseForItem returns the phase link for an item, or nil if not in a phase.
-func (s *Store) GetPhaseForItem(itemID string) (*models.ItemLink, error) {
+// ClearParentLink removes the parent link for an item.
+func (s *Store) ClearParentLink(itemID string) error {
+	_, err := s.db.Exec(s.q(`DELETE FROM item_links WHERE source_id = ? AND link_type = 'parent'`), itemID)
+	if err != nil {
+		return fmt.Errorf("clear parent link: %w", err)
+	}
+	return nil
+}
+
+// ClearPhaseLink is a deprecated alias for ClearParentLink.
+func (s *Store) ClearPhaseLink(itemID string) error {
+	return s.ClearParentLink(itemID)
+}
+
+// GetParentForItem returns the parent link for an item, or nil if it has no parent.
+func (s *Store) GetParentForItem(itemID string) (*models.ItemLink, error) {
 	sStatusExpr := s.dialect.JSONExtractText("s.fields", "status")
 	tStatusExpr := s.dialect.JSONExtractText("t.fields", "status")
 	rows, err := s.db.Query(s.q(fmt.Sprintf(`
@@ -1031,10 +1076,10 @@ func (s *Store) GetPhaseForItem(itemID string) (*models.ItemLink, error) {
 		JOIN items t ON t.id = l.target_id
 		JOIN collections sc ON sc.id = s.collection_id
 		JOIN collections tc ON tc.id = t.collection_id
-		WHERE l.source_id = ? AND l.link_type = 'phase'
+		WHERE l.source_id = ? AND l.link_type = 'parent'
 	`, sStatusExpr, tStatusExpr)), itemID)
 	if err != nil {
-		return nil, fmt.Errorf("get phase for item: %w", err)
+		return nil, fmt.Errorf("get parent for item: %w", err)
 	}
 	defer rows.Close()
 
@@ -1057,7 +1102,7 @@ func (s *Store) GetPhaseForItem(itemID string) (*models.ItemLink, error) {
 		&sourceItemNumber, &targetItemNumber,
 		&sourceStatus, &targetStatus,
 	); err != nil {
-		return nil, fmt.Errorf("scan phase link: %w", err)
+		return nil, fmt.Errorf("scan parent link: %w", err)
 	}
 	link.CreatedAt = parseTime(createdAt)
 	if sourceItemNumber.Valid && sourcePrefix != "" {
@@ -1075,15 +1120,20 @@ func (s *Store) GetPhaseForItem(itemID string) (*models.ItemLink, error) {
 	return &link, nil
 }
 
-// GetTaskPhaseMap returns a map of item ID -> phase item ID for all phase links
-// in a workspace. Used for efficient batch lookups (e.g., dashboard).
-func (s *Store) GetTaskPhaseMap(workspaceID string) (map[string]string, error) {
+// GetPhaseForItem is a deprecated alias for GetParentForItem.
+func (s *Store) GetPhaseForItem(itemID string) (*models.ItemLink, error) {
+	return s.GetParentForItem(itemID)
+}
+
+// GetParentMap returns a map of item ID -> parent item ID for all parent links
+// in a workspace. Used for efficient batch lookups (e.g., dashboard, list enrichment).
+func (s *Store) GetParentMap(workspaceID string) (map[string]string, error) {
 	rows, err := s.db.Query(s.q(`
 		SELECT source_id, target_id FROM item_links
-		WHERE workspace_id = ? AND link_type = 'phase'
+		WHERE workspace_id = ? AND link_type = 'parent'
 	`), workspaceID)
 	if err != nil {
-		return nil, fmt.Errorf("get task phase map: %w", err)
+		return nil, fmt.Errorf("get parent map: %w", err)
 	}
 	defer rows.Close()
 
@@ -1098,92 +1148,146 @@ func (s *Store) GetTaskPhaseMap(workspaceID string) (map[string]string, error) {
 	return m, rows.Err()
 }
 
-// --- Phase Progress ---
+// GetTaskPhaseMap is a deprecated alias for GetParentMap.
+func (s *Store) GetTaskPhaseMap(workspaceID string) (map[string]string, error) {
+	return s.GetParentMap(workspaceID)
+}
 
-// GetPhaseProgress counts total and done tasks linked to a phase via item_links.
-// "Done" means any terminal status as defined by the tasks collection's schema.
-func (s *Store) GetPhaseProgress(phaseItemID string) (total int, done int, err error) {
-	termPlaceholders, termArgs := s.getTasksTerminalPlaceholders()
-	args := append(termArgs, phaseItemID)
+// --- Child Item Progress ---
+
+// GetItemProgress counts total and done child items linked to a parent via item_links.
+// "Done" means any terminal status as defined by the child items' collection schemas.
+// Unlike the old GetPhaseProgress, this is not filtered to a specific collection —
+// children from any collection count toward progress.
+func (s *Store) GetItemProgress(parentItemID string) (total int, done int, err error) {
+	termPlaceholders, termArgs := s.getChildTerminalPlaceholders(parentItemID)
+	args := append(termArgs, parentItemID)
 	statusExpr := s.dialect.JSONExtractText("i.fields", "status")
 	err = s.db.QueryRow(s.q(fmt.Sprintf(`
 		SELECT COUNT(*),
 		       COUNT(CASE WHEN LOWER(%s) IN (%s) THEN 1 END)
 		FROM items i
-		JOIN collections c ON c.id = i.collection_id
-		JOIN item_links il ON il.source_id = i.id AND il.link_type = 'phase' AND il.target_id = ?
-		WHERE c.slug = 'tasks'
-		  AND i.deleted_at IS NULL
+		JOIN item_links il ON il.source_id = i.id AND il.link_type = 'parent' AND il.target_id = ?
+		WHERE i.deleted_at IS NULL
 	`, statusExpr, termPlaceholders)), args...).Scan(&total, &done)
 	if err != nil {
-		return 0, 0, fmt.Errorf("get phase progress: %w", err)
+		return 0, 0, fmt.Errorf("get item progress: %w", err)
 	}
 	return total, done, nil
 }
 
-// getTasksTerminalPlaceholders returns SQL placeholders and args for the
-// terminal statuses of the tasks collection. Falls back to defaults if the
-// tasks collection schema is not found.
-func (s *Store) getTasksTerminalPlaceholders() (string, []any) {
-	// Try to find the tasks collection schema in any workspace
-	var schemaJSON sql.NullString
-	_ = s.db.QueryRow(s.q(`SELECT schema FROM collections WHERE slug = 'tasks' AND deleted_at IS NULL LIMIT 1`)).Scan(&schemaJSON)
-	if schemaJSON.Valid {
+// GetPhaseProgress is a deprecated alias for GetItemProgress.
+func (s *Store) GetPhaseProgress(parentItemID string) (total int, done int, err error) {
+	return s.GetItemProgress(parentItemID)
+}
+
+// getChildTerminalPlaceholders returns SQL placeholders and args for the terminal
+// statuses of the collections that a parent item's children belong to.
+// It queries the actual child items' collection schemas rather than hardcoding 'tasks'.
+func (s *Store) getChildTerminalPlaceholders(parentItemID string) (string, []any) {
+	// Find distinct collection IDs of child items
+	rows, err := s.db.Query(s.q(`
+		SELECT DISTINCT c.schema
+		FROM items i
+		JOIN collections c ON c.id = i.collection_id
+		JOIN item_links il ON il.source_id = i.id AND il.link_type = 'parent' AND il.target_id = ?
+		WHERE i.deleted_at IS NULL AND c.deleted_at IS NULL
+	`), parentItemID)
+	if err != nil {
+		return models.DefaultTerminalStatusPlaceholders()
+	}
+	defer rows.Close()
+
+	// Collect terminal statuses from all child collections
+	terminalSet := make(map[string]bool)
+	found := false
+	for rows.Next() {
+		var schemaJSON string
+		if err := rows.Scan(&schemaJSON); err != nil {
+			continue
+		}
+		found = true
 		var schema models.CollectionSchema
-		if err := json.Unmarshal([]byte(schemaJSON.String), &schema); err == nil {
-			return models.TerminalStatusPlaceholders(schema)
+		if err := json.Unmarshal([]byte(schemaJSON), &schema); err != nil {
+			continue
+		}
+		for _, ts := range models.TerminalStatusesFromSchema(schema) {
+			terminalSet[strings.ToLower(ts)] = true
 		}
 	}
-	return models.DefaultTerminalStatusPlaceholders()
+
+	if !found || len(terminalSet) == 0 {
+		return models.DefaultTerminalStatusPlaceholders()
+	}
+
+	placeholders := make([]string, 0, len(terminalSet))
+	args := make([]any, 0, len(terminalSet))
+	for ts := range terminalSet {
+		placeholders = append(placeholders, "?")
+		args = append(args, ts)
+	}
+	return strings.Join(placeholders, ","), args
 }
 
-// PhaseProgress holds task completion counts for a single phase.
-type PhaseProgress struct {
-	PhaseID string `json:"phase_id"`
-	Total   int    `json:"total"`
-	Done    int    `json:"done"`
+// ItemProgress holds child item completion counts for a single parent item.
+type ItemProgress struct {
+	ItemID string `json:"item_id"`
+	Total  int    `json:"total"`
+	Done   int    `json:"done"`
 }
 
-// GetAllPhasesProgress returns task completion counts for every non-deleted phase in a workspace.
-func (s *Store) GetAllPhasesProgress(workspaceID string) ([]PhaseProgress, error) {
-	termPlaceholders, termArgs := s.getTasksTerminalPlaceholders()
-	args := append(termArgs, workspaceID)
-	tStatusExpr2 := s.dialect.JSONExtractText("t.fields", "status")
+// PhaseProgress is a deprecated alias for ItemProgress.
+type PhaseProgress = ItemProgress
+
+// GetAllItemProgress returns child item completion counts for every non-deleted
+// item in the given collection within a workspace. This generalizes
+// GetAllPhasesProgress — any collection can be queried, not just phases.
+func (s *Store) GetAllItemProgress(workspaceID, collectionSlug string) ([]ItemProgress, error) {
+	termPlaceholders, termArgs := models.DefaultTerminalStatusPlaceholders()
+	args := append(termArgs, workspaceID, collectionSlug)
+	tStatusExpr := s.dialect.JSONExtractText("t.fields", "status")
 	rows, err := s.db.Query(s.q(fmt.Sprintf(`
 		SELECT p.id,
 		       COUNT(t.id),
 		       COUNT(CASE WHEN LOWER(%s) IN (%s) THEN 1 END)
 		FROM items p
-		JOIN collections pc ON pc.id = p.collection_id AND pc.slug = 'phases'
-		LEFT JOIN item_links il ON il.link_type = 'phase' AND il.target_id = p.id
+		JOIN collections pc ON pc.id = p.collection_id
+		LEFT JOIN item_links il ON il.link_type = 'parent' AND il.target_id = p.id
 		LEFT JOIN items t ON t.id = il.source_id
 		                  AND t.deleted_at IS NULL
-		LEFT JOIN collections tc ON tc.id = t.collection_id AND tc.slug = 'tasks'
 		WHERE p.workspace_id = ?
+		  AND pc.slug = ?
 		  AND p.deleted_at IS NULL
 		GROUP BY p.id
-	`, tStatusExpr2, termPlaceholders)), args...)
+	`, tStatusExpr, termPlaceholders)), args...)
 	if err != nil {
-		return nil, fmt.Errorf("get all phases progress: %w", err)
+		return nil, fmt.Errorf("get all item progress: %w", err)
 	}
 	defer rows.Close()
 
-	var result []PhaseProgress
+	var result []ItemProgress
 	for rows.Next() {
-		var pp PhaseProgress
-		if err := rows.Scan(&pp.PhaseID, &pp.Total, &pp.Done); err != nil {
-			return nil, fmt.Errorf("scan phase progress: %w", err)
+		var ip ItemProgress
+		if err := rows.Scan(&ip.ItemID, &ip.Total, &ip.Done); err != nil {
+			return nil, fmt.Errorf("scan item progress: %w", err)
 		}
-		result = append(result, pp)
+		result = append(result, ip)
 	}
 	if result == nil {
-		result = []PhaseProgress{}
+		result = []ItemProgress{}
 	}
 	return result, rows.Err()
 }
 
-// GetTasksForPhase returns all non-deleted tasks linked to the given phase via item_links.
-func (s *Store) GetTasksForPhase(phaseItemID string) ([]models.Item, error) {
+// GetAllPhasesProgress is a deprecated alias that calls GetAllItemProgress for the "phases" collection.
+func (s *Store) GetAllPhasesProgress(workspaceID string) ([]ItemProgress, error) {
+	return s.GetAllItemProgress(workspaceID, "phases")
+}
+
+// GetChildItems returns all non-deleted child items linked to the given parent
+// via item_links. Unlike the old GetTasksForPhase, this returns children from
+// any collection, not just tasks.
+func (s *Store) GetChildItems(parentItemID string) ([]models.Item, error) {
 	rows, err := s.db.Query(s.q(`
 		SELECT i.id, i.workspace_id, i.collection_id, i.title, i.slug, i.content, i.fields, i.tags,
 		       i.pinned, i.sort_order, i.parent_id, i.assigned_user_id, i.agent_role_id, i.role_sort_order,
@@ -1194,19 +1298,67 @@ func (s *Store) GetTasksForPhase(phaseItemID string) ([]models.Item, error) {
 		       COALESCE(ar.name, ''), COALESCE(ar.slug, ''), COALESCE(ar.icon, '')
 		FROM items i
 		JOIN collections c ON c.id = i.collection_id
-		JOIN item_links il ON il.source_id = i.id AND il.link_type = 'phase' AND il.target_id = ?
+		JOIN item_links il ON il.source_id = i.id AND il.link_type = 'parent' AND il.target_id = ?
 		LEFT JOIN users au ON au.id = i.assigned_user_id
 		LEFT JOIN agent_roles ar ON ar.id = i.agent_role_id
-		WHERE c.slug = 'tasks'
-		  AND i.deleted_at IS NULL
+		WHERE i.deleted_at IS NULL
 		ORDER BY i.sort_order ASC, i.created_at ASC
-	`), phaseItemID)
+	`), parentItemID)
 	if err != nil {
-		return nil, fmt.Errorf("get tasks for phase: %w", err)
+		return nil, fmt.Errorf("get child items: %w", err)
 	}
 	defer rows.Close()
 
 	return scanItems(rows)
+}
+
+// PopulateHasChildren sets HasChildren=true on items that have at least one
+// child linked via parent link_type. Operates in-place on the slice.
+func (s *Store) PopulateHasChildren(items []models.Item) {
+	if len(items) == 0 {
+		return
+	}
+
+	// Build ID list and index
+	ids := make([]string, len(items))
+	idx := make(map[string]int, len(items))
+	for i, item := range items {
+		ids[i] = item.ID
+		idx[item.ID] = i
+	}
+
+	// Batch query: which of these IDs are targets of a parent link?
+	placeholders := make([]string, len(ids))
+	args := make([]any, len(ids))
+	for i, id := range ids {
+		placeholders[i] = "?"
+		args[i] = id
+	}
+	query := fmt.Sprintf(`
+		SELECT DISTINCT target_id FROM item_links
+		WHERE link_type = 'parent' AND target_id IN (%s)
+	`, strings.Join(placeholders, ","))
+
+	rows, err := s.db.Query(s.q(query), args...)
+	if err != nil {
+		return // best-effort; don't fail the whole request
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var targetID string
+		if err := rows.Scan(&targetID); err != nil {
+			continue
+		}
+		if i, ok := idx[targetID]; ok {
+			items[i].HasChildren = true
+		}
+	}
+}
+
+// GetTasksForPhase is a deprecated alias for GetChildItems.
+func (s *Store) GetTasksForPhase(parentItemID string) ([]models.Item, error) {
+	return s.GetChildItems(parentItemID)
 }
 
 // MoveItem moves an item to a different collection within the same workspace.

--- a/internal/store/migrations/023_parent_link_type.sql
+++ b/internal/store/migrations/023_parent_link_type.sql
@@ -1,0 +1,7 @@
+-- Migration 023: Rename link_type 'phase' → 'parent'
+--
+-- Generalizes the phase→task relationship so any item can be a parent of
+-- child items with progress tracking, burndown charts, and dependency graphs.
+-- The 'parent' link_type means: source_id is a child of target_id.
+
+UPDATE item_links SET link_type = 'parent' WHERE link_type = 'phase';

--- a/internal/store/pgmigrations/003_parent_link_type.sql
+++ b/internal/store/pgmigrations/003_parent_link_type.sql
@@ -1,0 +1,8 @@
+-- Migration 003: Rename link_type 'phase' → 'parent'
+--
+-- Mirrors SQLite migration 023_parent_link_type.sql.
+-- Generalizes the phase→task relationship so any item can be a parent of
+-- child items with progress tracking, burndown charts, and dependency graphs.
+-- The 'parent' link_type means: source_id is a child of target_id.
+
+UPDATE item_links SET link_type = 'parent' WHERE link_type = 'phase';

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -139,6 +139,7 @@ func (s *Store) migrate() error {
 		"020_role_sort_order.sql",
 		"021_phase_to_links.sql",
 		"022_audit_trail.sql",
+		"023_parent_link_type.sql",
 	}
 
 	for _, name := range migrations {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -186,6 +186,7 @@ func (s *Store) migratePostgres() error {
 	migrations := []string{
 		"001_initial.sql",
 		"002_audit_trail.sql",
+		"003_parent_link_type.sql",
 	}
 
 	for _, name := range migrations {

--- a/skills/pad/SKILL.md
+++ b/skills/pad/SKILL.md
@@ -148,7 +148,7 @@ Interpret the user's intent and route to the appropriate action. Here are common
 **Reports:**
 - "prep for standup" / "what did we do?" → `pad project standup --format json`
 - "generate changelog" / "what shipped?" → `pad project changelog --format json`
-- "changelog for this phase" → `pad project changelog --phase PHASE-2 --format json`
+- "changelog for this phase" → `pad project changelog --parent PHASE-2 --format json`
 - "changelog since Monday" → `pad project changelog --since 2026-03-24 --format json`
 
 **Retrospective:**
@@ -203,8 +203,8 @@ pad role delete <slug>                                              # Delete a r
 ```bash
 # Create items (collection accepts singular or plural: task/tasks, idea/ideas, etc.)
 # The CLI prints the new item's issue ID (e.g. "Created TASK-5: ...") — use it for subsequent commands
-pad item create <collection> "title" [--status X] [--priority X] [--role X] [--assign X] [--category X] [--content "..."] [--stdin]
-pad item create task "Fix OAuth redirect" --priority high --role implementer --assign Dave
+pad item create <collection> "title" [--status X] [--priority X] [--parent REF] [--role X] [--assign X] [--category X] [--content "..."] [--stdin]
+pad item create task "Fix OAuth redirect" --priority high --parent PHASE-3 --role implementer --assign Dave
 pad item create idea "Real-time collaboration" --category infrastructure
 pad item create phase "API Redesign" --status active
 pad item create doc "Auth Architecture" --category architecture --stdin <<< "# Auth Architecture\n\n..."
@@ -215,7 +215,7 @@ pad item create convention "Always review with linter" --field trigger=on-implem
 pad item create roadmap "Feature X" --field quarter=2026-Q3
 
 # List items (defaults to non-done items)
-pad item list [collection] [--status X] [--priority X] [--role X] [--assign X] [--all] [--field key=value] [--format json]
+pad item list [collection] [--status X] [--priority X] [--parent REF] [--role X] [--assign X] [--all] [--field key=value] [--format json]
 pad item list tasks                            # open + in_progress tasks
 pad item list tasks --role implementer         # tasks assigned to the implementer role
 pad item list tasks --role implementer --assign Dave  # Dave's implementer queue
@@ -248,7 +248,7 @@ pad item search "query" [--format json]
 pad project dashboard [--format json]  # Project dashboard
 pad project next [--format json]       # Recommended next task
 pad project standup [--days N] [--format json]  # Daily standup report (completed/in-progress/blockers)
-pad project changelog [--days N] [--since DATE] [--phase PHASE-2] [--format json|markdown]  # Release notes
+pad project changelog [--days N] [--since DATE] [--parent PHASE-2] [--format json|markdown]  # Release notes
 ```
 
 ### Server
@@ -303,7 +303,7 @@ All commands support `--format json` (for parsing) or `--format table` (default,
 4. **Create the phase:** `pad item create phase "Phase N: Title" --status draft --stdin <<< "<plan content>"`
 5. **Decompose into tasks:** For each task in the plan, create a Task item:
    ```bash
-   pad item create task "Task description" --phase PHASE-3 --priority medium
+   pad item create task "Task description" --parent PHASE-3 --priority medium
    ```
 6. **If roles exist, suggest role assignments** for each task: "This looks like Implementer work — assign to Implementer?"
 7. **Each task should be PR-sized** — small enough for one branch, large enough to be meaningful.
@@ -315,7 +315,7 @@ All commands support `--format json` (for parsing) or `--format table` (default,
 2. **Analyze the content** for actionable work items
 3. **Propose task list** with titles, priorities, and suggested role assignments
 4. **Create approved tasks:** One `pad item create task` per approved item
-5. **Link tasks to phase** using `--phase PHASE-2` flag (if the phase collection has a relation field)
+5. **Link tasks to phase** using `--parent PHASE-2` flag
 
 ### Status Check: "How are we doing?"
 

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -265,13 +265,21 @@ export const api = {
 				})
 			}),
 
-		/** Get tasks linked to a phase item */
-		tasks: (ws: string, slug: string) =>
-			request<Item[]>(`/workspaces/${ws}/items/${slug}/tasks`),
+		/** Get child items linked to a parent item */
+		children: (ws: string, slug: string) =>
+			request<Item[]>(`/workspaces/${ws}/items/${slug}/children`),
 
-		/** Get task progress for all phases in a workspace */
+		/** Get completion progress for an item's children */
+		progress: (ws: string, slug: string) =>
+			request<{total: number; done: number; percentage: number}>(`/workspaces/${ws}/items/${slug}/progress`),
+
+		/** @deprecated Use children() */
+		tasks: (ws: string, slug: string) =>
+			request<Item[]>(`/workspaces/${ws}/items/${slug}/children`),
+
+		/** @deprecated Use progress() per-item instead */
 		phasesProgress: (ws: string) =>
-			request<{phase_id: string; total: number; done: number}[]>(`/workspaces/${ws}/phases-progress`)
+			request<{item_id: string; total: number; done: number}[]>(`/workspaces/${ws}/phases-progress`)
 	},
 
 	// ── Versions ──────────────────────────────────────────────────────────────

--- a/web/src/lib/components/ChildChart.svelte
+++ b/web/src/lib/components/ChildChart.svelte
@@ -3,13 +3,13 @@
 	import { parseFields } from '$lib/types';
 
 	interface Props {
-		tasks: Item[];
-		startDate: string;
+		children: Item[];
+		startDate?: string;
 		endDate?: string;
 		terminalStatuses?: string[];
 	}
 
-	let { tasks, startDate, endDate, terminalStatuses }: Props = $props();
+	let { children, startDate, endDate, terminalStatuses }: Props = $props();
 	const defaultTerminal = ['done', 'completed', 'resolved', 'cancelled', 'rejected', 'wontfix', 'fixed', 'implemented', 'archived', 'disabled', 'deprecated'];
 	const terminal = $derived(terminalStatuses ?? defaultTerminal);
 
@@ -21,33 +21,55 @@
 	const chartH = height - padding.top - padding.bottom;
 
 	let chartData = $derived.by(() => {
-		const total = tasks.length;
-		if (total === 0) return null;
+		const total = children.length;
+		if (total < 2) return null;
 
-		const start = new Date(startDate);
-		start.setHours(0, 0, 0, 0);
+		// Identify completed children
+		const completions: { date: Date; count: number }[] = [];
+		for (const child of children) {
+			const f = parseFields(child);
+			if (terminal.includes(f.status)) {
+				completions.push({ date: new Date(child.updated_at), count: 1 });
+			}
+		}
+		completions.sort((a, b) => a.date.getTime() - b.date.getTime());
 
+		const allDone = completions.length === total;
 		const now = new Date();
 		now.setHours(23, 59, 59, 999);
 
-		const end = endDate ? new Date(endDate) : now;
+		// ── Determine start date ──────────────────────────────────────────
+		let start: Date;
+		if (startDate) {
+			start = new Date(startDate);
+		} else {
+			// Infer: earliest created_at among children
+			let earliest = new Date(children[0].created_at);
+			for (const child of children) {
+				const d = new Date(child.created_at);
+				if (d < earliest) earliest = d;
+			}
+			start = earliest;
+		}
+		start.setHours(0, 0, 0, 0);
+
+		// ── Determine end date ────────────────────────────────────────────
+		let end: Date;
+		if (endDate) {
+			end = new Date(endDate);
+		} else if (allDone && completions.length > 0) {
+			// All children done → last completion date
+			end = new Date(completions[completions.length - 1].date);
+		} else {
+			// Open-ended → today
+			end = new Date(now);
+		}
 		end.setHours(23, 59, 59, 999);
 
 		// Use the later of end date or today for display range
 		const displayEnd = end > now ? end : now;
 		const totalMs = displayEnd.getTime() - start.getTime();
 		if (totalMs <= 0) return null;
-
-		// Build completion events: when each done task was completed
-		const completions: { date: Date; count: number }[] = [];
-		for (const task of tasks) {
-			const f = parseFields(task);
-			if (terminal.includes(f.status)) {
-				const completedAt = new Date(task.updated_at);
-				completions.push({ date: completedAt, count: 1 });
-			}
-		}
-		completions.sort((a, b) => a.date.getTime() - b.date.getTime());
 
 		// Build actual line points (step chart)
 		const actualPoints: { x: number; y: number }[] = [];
@@ -129,7 +151,7 @@
 </script>
 
 {#if chartData}
-	<div class="phase-chart">
+	<div class="child-chart">
 		<svg viewBox="0 0 {width} {height}" preserveAspectRatio="xMidYMid meet">
 			<g transform="translate({padding.left},{padding.top})">
 				<!-- Y axis gridlines -->
@@ -241,12 +263,12 @@
 {/if}
 
 <style>
-	.phase-chart {
+	.child-chart {
 		width: 100%;
 		margin: var(--space-3) 0;
 	}
 
-	.phase-chart svg {
+	.child-chart svg {
 		width: 100%;
 		height: 200px;
 		display: block;

--- a/web/src/lib/components/ChildItems.svelte
+++ b/web/src/lib/components/ChildItems.svelte
@@ -166,6 +166,7 @@
 	}
 </script>
 
+{#if loading || children.length > 0}
 <div class="child-items">
 	<div class="section-header">
 		<h3>Children</h3>
@@ -238,11 +239,9 @@
 			</div>
 		{/each}
 
-		{#if children.length === 0}
-			<div class="empty">No child items yet</div>
-		{/if}
 	{/if}
 </div>
+{/if}
 
 <style>
 	.child-items {
@@ -447,10 +446,4 @@
 		font-size: 0.85em;
 	}
 
-	.empty {
-		text-align: center;
-		color: var(--text-muted);
-		font-size: 0.9em;
-		padding: var(--space-4) 0;
-	}
 </style>

--- a/web/src/lib/components/ChildItems.svelte
+++ b/web/src/lib/components/ChildItems.svelte
@@ -8,48 +8,65 @@
 	import { parseFields, formatItemRef } from '$lib/types';
 	import { dndzone, TRIGGERS, SHADOW_ITEM_MARKER_PROPERTY_NAME } from 'svelte-dnd-action';
 	import type { DndEvent } from 'svelte-dnd-action';
-	import PhaseChart from './PhaseChart.svelte';
+	import ChildChart from './ChildChart.svelte';
+	import NestedChildren from './NestedChildren.svelte';
 
 	interface Props {
 		wsSlug: string;
 		itemSlug: string;
 		itemId: string;
-		phaseFields?: Record<string, any>;
+		parentFields?: Record<string, any>;
 		terminalStatuses?: string[];
-		onTasksChange?: (tasks: Item[]) => void;
+		onChildrenChange?: (children: Item[]) => void;
 	}
 
-	let { wsSlug, itemSlug, itemId, phaseFields, terminalStatuses, onTasksChange }: Props = $props();
+	let { wsSlug, itemSlug, itemId, parentFields, terminalStatuses, onChildrenChange }: Props = $props();
 
 	const defaultTerminal = ['done', 'completed', 'resolved', 'cancelled', 'rejected', 'wontfix', 'fixed', 'implemented', 'archived', 'disabled', 'deprecated'];
 	const terminal = $derived(terminalStatuses ?? defaultTerminal);
 
-	let tasks = $state<Item[]>([]);
+	let children = $state<Item[]>([]);
 	let loading = $state(true);
 	let error = $state('');
 	let unsubscribeSSE: (() => void) | null = null;
 	let unsubscribeVisibility: (() => void) | null = null;
 
+	let expandedIds = $state<Set<string>>(new Set());
+
+	function toggleExpand(child: Item) {
+		const next = new Set(expandedIds);
+		if (next.has(child.id)) {
+			next.delete(child.id);
+		} else {
+			next.add(child.id);
+		}
+		expandedIds = next;
+	}
+
 	const statusOrder: string[] = ['in_progress', 'open', 'blocked', 'done'];
 	const flipDurationMs = 200;
 	const touchDragDelayMs = 500;
 
-	let doneCount = $derived(tasks.filter((t) => terminal.includes(parseFields(t).status)).length);
-	let totalCount = $derived(tasks.length);
+	let doneCount = $derived(children.filter((t) => terminal.includes(parseFields(t).status)).length);
+	let totalCount = $derived(children.length);
 	let percentage = $derived(totalCount > 0 ? Math.round((doneCount / totalCount) * 100) : 0);
+
+	/** Set of child item IDs — exposed for deduplication by the parent page */
+	export function getChildIds(): Set<string> {
+		return new Set(children.map(c => c.id));
+	}
 
 	let groups = $derived.by(() => {
 		const map = new SvelteMap<string, Item[]>();
-		for (const task of tasks) {
-			const status = parseFields(task).status ?? 'open';
+		for (const child of children) {
+			const status = parseFields(child).status ?? 'open';
 			if (!map.has(status)) map.set(status, []);
-			map.get(status)!.push(task);
+			map.get(status)!.push(child);
 		}
 		const sorted: [string, Item[]][] = [];
 		for (const s of statusOrder) {
 			if (map.has(s)) sorted.push([s, map.get(s)!]);
 		}
-		// Include any statuses not in the predefined order
 		for (const [s, items] of map) {
 			if (!statusOrder.includes(s)) sorted.push([s, items]);
 		}
@@ -60,13 +77,12 @@
 	let isDragging = $state(false);
 	let groupData: Record<string, Item[]> = $state({});
 
-	/** Sync groupData from derived groups, but only when not actively dragging */
 	$effect(() => {
 		const g = groups;
 		if (!isDragging) {
 			const data: Record<string, Item[]> = {};
-			for (const [status, statusTasks] of g) {
-				data[status] = [...statusTasks];
+			for (const [status, statusChildren] of g) {
+				data[status] = [...statusChildren];
 			}
 			groupData = data;
 		}
@@ -90,7 +106,6 @@
 			.filter((i: any) => !i[SHADOW_ITEM_MARKER_PROPERTY_NAME])
 			.map((item, index) => ({ id: item.id, sort_order: index }));
 
-		// Persist sequentially (SQLite)
 		try {
 			for (const { id, sort_order } of updates) {
 				await api.items.update(wsSlug, id, { sort_order });
@@ -102,15 +117,15 @@
 
 	// ── Data loading ─────────────────────────────────────────────────────────
 
-	async function loadTasks() {
+	async function loadChildren() {
 		loading = true;
 		error = '';
 		try {
-			tasks = await api.items.tasks(wsSlug, itemSlug);
-			onTasksChange?.(tasks);
+			children = await api.items.children(wsSlug, itemSlug);
+			onChildrenChange?.(children);
 		} catch (err) {
-			error = err instanceof Error ? err.message : 'Failed to load tasks';
-			onTasksChange?.([]);
+			error = err instanceof Error ? err.message : 'Failed to load children';
+			onChildrenChange?.([]);
 		} finally {
 			loading = false;
 		}
@@ -119,13 +134,13 @@
 	$effect(() => {
 		void wsSlug;
 		void itemSlug;
-		loadTasks();
+		loadChildren();
 	});
 
 	onMount(() => {
 		unsubscribeVisibility = visibility.onTabResume(() => {
 			if (!wsSlug || !itemSlug) return;
-			loadTasks();
+			loadChildren();
 		});
 	});
 
@@ -136,9 +151,8 @@
 		if (!wsSlug || !itemSlug) return;
 
 		unsubscribeSSE = sseService.onItemEvent((event) => {
-			if (event.collection !== 'tasks') return;
 			if (!['item_created', 'item_updated', 'item_archived', 'item_restored'].includes(event.type)) return;
-			loadTasks();
+			loadChildren();
 		});
 	});
 
@@ -152,79 +166,89 @@
 	}
 </script>
 
-<div class="phase-tasks">
+<div class="child-items">
 	<div class="section-header">
-		<h3>Tasks</h3>
-		<span class="task-count">{doneCount}/{totalCount} done</span>
+		<h3>Children</h3>
+		<span class="child-count">{doneCount}/{totalCount} done</span>
 	</div>
 
 	<div class="progress-bar">
 		<div class="progress-fill" style:width="{percentage}%"></div>
 	</div>
 
-	{#if !loading && tasks.length > 0 && phaseFields?.start_date}
-		<PhaseChart {tasks} startDate={phaseFields.start_date} endDate={phaseFields.end_date} {terminalStatuses} />
+	{#if !loading && children.length >= 2}
+		<ChildChart {children} startDate={parentFields?.start_date} endDate={parentFields?.end_date} {terminalStatuses} />
 	{/if}
 
 	{#if loading}
 		<div class="loading">
 			<span class="spinner"></span>
-			<span>Loading tasks...</span>
+			<span>Loading children...</span>
 		</div>
 	{:else if error}
 		<div class="error-msg">{error}</div>
 	{:else}
-		{#each groups as [status, _statusTasks] (status)}
-			<div class="task-group">
+		{#each groups as [status, _statusChildren] (status)}
+			<div class="child-group">
 				<div class="group-label">{formatLabel(status)} ({(groupData[status] ?? []).length})</div>
 				<div
-					class="task-list"
+					class="child-list"
 					use:dndzone={{
 						items: groupData[status] ?? [],
 						flipDurationMs,
-						type: 'phase-task',
+						type: 'child-item',
 						dropTargetClasses: ['drop-target'],
 						delayTouchStart: touchDragDelayMs
 					}}
 					onconsider={(e) => handleConsider(status, e)}
 					onfinalize={(e) => handleFinalize(status, e)}
 				>
-					{#each groupData[status] ?? [] as task (task.id)}
-						{@const fields = parseFields(task)}
+					{#each groupData[status] ?? [] as child (child.id)}
+						{@const fields = parseFields(child)}
 						{@const isDone = terminal.includes(fields.status)}
-						<a href="/{wsSlug}/tasks/{task.slug}" class="task-row">
-							<span class="task-ref">{formatItemRef(task) ?? ''}</span>
-							<span class="task-title" class:done={isDone}>{task.title}</span>
-							{#if fields.priority}
-								<span
-									class="task-priority"
-									class:high={fields.priority === 'high'}
-									class:critical={fields.priority === 'critical'}
-								>
-									{fields.priority}
-								</span>
+						{@const isExpanded = expandedIds.has(child.id)}
+						{@const canExpand = child.has_children}
+						<div class="child-item-wrapper">
+							<div class="child-row-container">
+								{#if canExpand}
+									<button class="expand-toggle" onclick={(e) => { e.preventDefault(); toggleExpand(child); }} title={isExpanded ? 'Collapse' : 'Expand'}>
+										<span class="expand-icon" class:expanded={isExpanded}>▸</span>
+									</button>
+								{/if}
+								<a href="/{wsSlug}/{child.collection_slug}/{child.slug}" class="child-row" class:has-toggle={canExpand}>
+									<span class="child-ref">{formatItemRef(child) ?? ''}</span>
+									<span class="child-title" class:done={isDone}>{child.title}</span>
+									{#if fields.priority}
+										<span
+											class="child-priority"
+											class:high={fields.priority === 'high'}
+											class:critical={fields.priority === 'critical'}
+										>
+											{fields.priority}
+										</span>
+									{/if}
+								</a>
+							</div>
+							{#if canExpand && isExpanded}
+								<NestedChildren {wsSlug} parentSlug={child.slug} depth={1} maxDepth={3} {terminalStatuses} />
 							{/if}
-						</a>
+						</div>
 					{/each}
 				</div>
 			</div>
 		{/each}
 
-		{#if tasks.length === 0}
-			<div class="empty">No tasks linked to this phase yet</div>
+		{#if children.length === 0}
+			<div class="empty">No child items yet</div>
 		{/if}
 	{/if}
 </div>
 
 <style>
-	/* ── Container ──────────────────────────────────────────────────────────── */
-
-	.phase-tasks {
+	.child-items {
 		padding: var(--space-4) 0;
 		border-top: 1px solid var(--border);
 	}
-
-	/* ── Header ─────────────────────────────────────────────────────────────── */
 
 	.section-header {
 		display: flex;
@@ -240,13 +264,11 @@
 		color: var(--text-primary);
 	}
 
-	.task-count {
+	.child-count {
 		font-size: 0.8em;
 		color: var(--text-muted);
 		font-weight: 400;
 	}
-
-	/* ── Progress bar ──────────────────────────────────────────────────────── */
 
 	.progress-bar {
 		height: 6px;
@@ -263,9 +285,7 @@
 		transition: width 0.3s ease;
 	}
 
-	/* ── Task groups ───────────────────────────────────────────────────────── */
-
-	.task-group {
+	.child-group {
 		margin-top: var(--space-3);
 	}
 
@@ -278,9 +298,42 @@
 		margin-bottom: var(--space-2);
 	}
 
-	/* ── Task list (dnd container) ─────────────────────────────────────────── */
+	.child-item-wrapper {
+		/* container for row + nested children */
+	}
 
-	.task-list {
+	.child-row-container {
+		display: flex;
+		align-items: center;
+	}
+
+	.expand-toggle {
+		background: none;
+		border: none;
+		cursor: pointer;
+		padding: 0 2px;
+		color: var(--text-muted);
+		font-size: 0.8em;
+		line-height: 1;
+		flex-shrink: 0;
+		width: 20px;
+		text-align: center;
+	}
+
+	.expand-toggle:hover {
+		color: var(--text-primary);
+	}
+
+	.expand-icon {
+		display: inline-block;
+		transition: transform 0.15s ease;
+	}
+
+	.expand-icon.expanded {
+		transform: rotate(90deg);
+	}
+
+	.child-list {
 		min-height: 4px;
 	}
 
@@ -290,9 +343,7 @@
 		border-radius: var(--radius-sm);
 	}
 
-	/* ── Task row ──────────────────────────────────────────────────────────── */
-
-	.task-row {
+	.child-row {
 		display: flex;
 		align-items: center;
 		gap: var(--space-2);
@@ -307,19 +358,19 @@
 		user-select: none;
 	}
 
-	.task-row:hover {
+	.child-row:hover {
 		background: var(--bg-hover);
 	}
 
-	.task-row:active {
+	.child-row:active {
 		cursor: grabbing;
 	}
 
-	.task-row:last-child {
+	.child-row:last-child {
 		border-bottom: none;
 	}
 
-	.task-ref {
+	.child-ref {
 		font-family: var(--font-mono);
 		font-size: 0.78em;
 		color: var(--text-muted);
@@ -327,7 +378,7 @@
 		flex-shrink: 0;
 	}
 
-	.task-title {
+	.child-title {
 		flex: 1;
 		font-size: 0.88em;
 		color: var(--text-primary);
@@ -337,14 +388,12 @@
 		white-space: nowrap;
 	}
 
-	.task-title.done {
+	.child-title.done {
 		text-decoration: line-through;
 		color: var(--text-muted);
 	}
 
-	/* ── Priority badge ────────────────────────────────────────────────────── */
-
-	.task-priority {
+	.child-priority {
 		font-size: 0.72em;
 		padding: 1px 6px;
 		border-radius: 3px;
@@ -355,17 +404,15 @@
 		flex-shrink: 0;
 	}
 
-	.task-priority.high {
+	.child-priority.high {
 		color: var(--accent-amber);
 		background: color-mix(in srgb, var(--accent-amber) 15%, transparent);
 	}
 
-	.task-priority.critical {
+	.child-priority.critical {
 		color: var(--accent-orange);
 		background: color-mix(in srgb, var(--accent-orange) 15%, transparent);
 	}
-
-	/* ── Loading ────────────────────────────────────────────────────────────── */
 
 	.loading {
 		display: flex;
@@ -392,8 +439,6 @@
 		}
 	}
 
-	/* ── Error ──────────────────────────────────────────────────────────────── */
-
 	.error-msg {
 		padding: var(--space-2) var(--space-3);
 		background: color-mix(in srgb, var(--accent-red, #ef4444) 12%, transparent);
@@ -401,8 +446,6 @@
 		border-radius: var(--radius);
 		font-size: 0.85em;
 	}
-
-	/* ── Empty state ───────────────────────────────────────────────────────── */
 
 	.empty {
 		text-align: center;

--- a/web/src/lib/components/NestedChildren.svelte
+++ b/web/src/lib/components/NestedChildren.svelte
@@ -1,0 +1,240 @@
+<script lang="ts">
+	import { api } from '$lib/api/client';
+	import type { Item } from '$lib/types';
+	import { parseFields, formatItemRef } from '$lib/types';
+
+	interface Props {
+		wsSlug: string;
+		parentSlug: string;
+		depth?: number;
+		maxDepth?: number;
+		terminalStatuses?: string[];
+	}
+
+	let { wsSlug, parentSlug, depth = 1, maxDepth = 3, terminalStatuses }: Props = $props();
+
+	const defaultTerminal = ['done', 'completed', 'resolved', 'cancelled', 'rejected', 'wontfix', 'fixed', 'implemented', 'archived', 'disabled', 'deprecated'];
+	const terminal = $derived(terminalStatuses ?? defaultTerminal);
+
+	let children = $state<Item[]>([]);
+	let loading = $state(true);
+	let expandedIds = $state<Set<string>>(new Set());
+
+	$effect(() => {
+		void parentSlug;
+		loadChildren();
+	});
+
+	async function loadChildren() {
+		loading = true;
+		try {
+			children = await api.items.children(wsSlug, parentSlug);
+		} catch {
+			children = [];
+		} finally {
+			loading = false;
+		}
+	}
+
+	function toggleExpand(child: Item) {
+		const next = new Set(expandedIds);
+		if (next.has(child.id)) {
+			next.delete(child.id);
+		} else {
+			next.add(child.id);
+		}
+		expandedIds = next;
+	}
+
+	let doneCount = $derived(children.filter(c => terminal.includes(parseFields(c).status)).length);
+</script>
+
+{#if loading}
+	<div class="nested-loading">Loading...</div>
+{:else if children.length > 0}
+	<div class="nested-children" style:--depth={depth}>
+		<div class="nested-progress">
+			<span class="nested-count">{doneCount}/{children.length}</span>
+			<div class="nested-bar">
+				<div class="nested-bar-fill" style:width="{children.length > 0 ? Math.round((doneCount / children.length) * 100) : 0}%"></div>
+			</div>
+		</div>
+		{#each children as child (child.id)}
+			{@const fields = parseFields(child)}
+			{@const isDone = terminal.includes(fields.status)}
+			{@const isExpanded = expandedIds.has(child.id)}
+			{@const canExpand = child.has_children && depth < maxDepth}
+			<div class="nested-item">
+				<div class="nested-row">
+					{#if canExpand}
+						<button class="expand-toggle" onclick={() => toggleExpand(child)} title={isExpanded ? 'Collapse' : 'Expand'}>
+							<span class="expand-icon" class:expanded={isExpanded}>▸</span>
+						</button>
+					{:else}
+						<span class="expand-spacer"></span>
+					{/if}
+					<a href="/{wsSlug}/{child.collection_slug}/{child.slug}" class="nested-link">
+						<span class="nested-ref">{formatItemRef(child) ?? ''}</span>
+						<span class="nested-title" class:done={isDone}>{child.title}</span>
+					</a>
+					{#if fields.priority}
+						<span
+							class="nested-priority"
+							class:high={fields.priority === 'high'}
+							class:critical={fields.priority === 'critical'}
+						>
+							{fields.priority}
+						</span>
+					{/if}
+				</div>
+				{#if canExpand && isExpanded}
+					<svelte:self wsSlug={wsSlug} parentSlug={child.slug} depth={depth + 1} {maxDepth} {terminalStatuses} />
+				{/if}
+			</div>
+		{/each}
+	</div>
+{/if}
+
+<style>
+	.nested-children {
+		margin-left: calc(var(--space-3) + 2px);
+		padding-left: var(--space-3);
+		border-left: 2px solid var(--border);
+	}
+
+	.nested-progress {
+		display: flex;
+		align-items: center;
+		gap: var(--space-2);
+		margin-bottom: var(--space-2);
+		padding-top: var(--space-1);
+	}
+
+	.nested-count {
+		font-size: 0.7em;
+		color: var(--text-muted);
+		white-space: nowrap;
+	}
+
+	.nested-bar {
+		flex: 1;
+		height: 3px;
+		background: var(--bg-tertiary);
+		border-radius: 2px;
+		overflow: hidden;
+		max-width: 80px;
+	}
+
+	.nested-bar-fill {
+		height: 100%;
+		background: var(--accent-green);
+		border-radius: 2px;
+		transition: width 0.3s ease;
+	}
+
+	.nested-item {
+		/* container for row + recursive children */
+	}
+
+	.nested-row {
+		display: flex;
+		align-items: center;
+		gap: var(--space-1);
+		padding: 3px 0;
+	}
+
+	.expand-toggle {
+		background: none;
+		border: none;
+		cursor: pointer;
+		padding: 0 2px;
+		color: var(--text-muted);
+		font-size: 0.75em;
+		line-height: 1;
+		flex-shrink: 0;
+		width: 16px;
+		text-align: center;
+	}
+
+	.expand-toggle:hover {
+		color: var(--text-primary);
+	}
+
+	.expand-icon {
+		display: inline-block;
+		transition: transform 0.15s ease;
+	}
+
+	.expand-icon.expanded {
+		transform: rotate(90deg);
+	}
+
+	.expand-spacer {
+		width: 16px;
+		flex-shrink: 0;
+	}
+
+	.nested-link {
+		display: flex;
+		align-items: center;
+		gap: var(--space-1);
+		text-decoration: none;
+		color: inherit;
+		flex: 1;
+		min-width: 0;
+		border-radius: var(--radius-sm);
+		padding: 1px 4px;
+	}
+
+	.nested-link:hover {
+		background: var(--bg-hover);
+	}
+
+	.nested-ref {
+		font-family: var(--font-mono);
+		font-size: 0.72em;
+		color: var(--text-muted);
+		white-space: nowrap;
+		flex-shrink: 0;
+	}
+
+	.nested-title {
+		font-size: 0.82em;
+		color: var(--text-primary);
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.nested-title.done {
+		text-decoration: line-through;
+		color: var(--text-muted);
+	}
+
+	.nested-priority {
+		font-size: 0.66em;
+		padding: 0 4px;
+		border-radius: 2px;
+		white-space: nowrap;
+		font-weight: 500;
+		color: var(--text-muted);
+		background: var(--bg-tertiary);
+		flex-shrink: 0;
+	}
+
+	.nested-priority.high {
+		color: var(--accent-amber);
+		background: color-mix(in srgb, var(--accent-amber) 15%, transparent);
+	}
+
+	.nested-priority.critical {
+		color: var(--accent-orange);
+		background: color-mix(in srgb, var(--accent-orange) 15%, transparent);
+	}
+
+	.nested-loading {
+		font-size: 0.78em;
+		color: var(--text-muted);
+		padding: var(--space-2) 0 var(--space-2) var(--space-4);
+	}
+</style>

--- a/web/src/lib/components/layout/Sidebar.svelte
+++ b/web/src/lib/components/layout/Sidebar.svelte
@@ -116,8 +116,8 @@
 			});
 			uiStore.onNavigate();
 			goto(`/${wsSlug}/${activeCollectionSlug}/${itemUrlId(item)}?new=1`);
-		} catch {
-			toastStore.show('Failed to create item', 'error');
+		} catch (err: any) {
+			toastStore.show(err?.message || 'Failed to create item', 'error');
 		}
 	}
 

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -318,9 +318,16 @@ export interface Item {
 	collection_icon?: string;
 	collection_prefix?: string;
 	item_number?: number;
+	parent_link_id?: string;
+	parent_ref?: string;
+	parent_title?: string;
+	/** @deprecated Use parent_id */
 	phase_id?: string;
+	/** @deprecated Use parent_ref */
 	phase_ref?: string;
+	/** @deprecated Use parent_title */
 	phase_title?: string;
+	has_children?: boolean;
 	derived_closure?: ItemDerivedClosure;
 	code_context?: ItemCodeContext;
 	convention?: ItemConventionMetadata;

--- a/web/src/routes/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[workspace]/[collection]/+page.svelte
@@ -145,7 +145,7 @@
 					const progress = await api.items.phasesProgress(wsSlug).catch(() => []);
 					const map: Record<string, { total: number; done: number }> = {};
 					for (const p of progress) {
-						map[p.phase_id] = { total: p.total, done: p.done };
+						map[p.item_id] = { total: p.total, done: p.done };
 					}
 					itemProgress = map;
 				} else {
@@ -190,7 +190,7 @@
 					const progress = await api.items.phasesProgress(ws);
 					const map: Record<string, { total: number; done: number }> = {};
 					for (const p of progress) {
-						map[p.phase_id] = { total: p.total, done: p.done };
+						map[p.item_id] = { total: p.total, done: p.done };
 					}
 					itemProgress = map;
 					progressLabel = 'tasks';

--- a/web/src/routes/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[workspace]/[collection]/+page.svelte
@@ -417,8 +417,8 @@
 				source: 'web'
 			});
 			goto(`/${wsSlug}/${collSlug}/${itemUrlId(item)}?new=1`);
-		} catch {
-			toastStore.show('Failed to create item', 'error');
+		} catch (err: any) {
+			toastStore.show(err?.message || 'Failed to create item', 'error');
 		} finally {
 			creatingNew = false;
 		}
@@ -444,8 +444,8 @@
 			items = [...items, item];
 			quickCreateTitle = '';
 			toastStore.show(`Created "${title}"`, 'success');
-		} catch {
-			toastStore.show('Failed to create item', 'error');
+		} catch (err: any) {
+			toastStore.show(err?.message || 'Failed to create item', 'error');
 		} finally {
 			creatingNew = false;
 		}

--- a/web/src/routes/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[workspace]/[collection]/[slug]/+page.svelte
@@ -11,7 +11,7 @@
 	import type { Editor as EditorType } from '@tiptap/core';
 	import FieldEditor from '$lib/components/fields/FieldEditor.svelte';
 	import ItemTimeline from '$lib/components/timeline/ItemTimeline.svelte';
-	import PhaseTasks from '$lib/components/phases/PhaseTasks.svelte';
+	import ChildItems from '$lib/components/ChildItems.svelte';
 	import { goto } from '$app/navigation';
 	import { relativeTime, wikiLinksToMarkdown, markdownToWikiLinks, cleanBrokenLinks } from '$lib/utils/markdown';
 	import { toastStore } from '$lib/stores/toast.svelte';
@@ -76,7 +76,9 @@
 	let itemLinks = $state<ItemLink[]>([]);
 	let workspaceMembers = $state<{ user_id: string; user_name: string; user_email: string }[]>([]);
 	let agentRoles = $state<AgentRole[]>([]);
-	let relationshipGroups = $derived(item ? buildRelationshipGroups(item, itemLinks) : []);
+	let childItemIds = $state<Set<string>>(new Set());
+	let hasChildren = $state(false);
+	let relationshipGroups = $derived(item ? buildRelationshipGroups(item, itemLinks, childItemIds) : []);
 	let closureEntries = $derived(item?.derived_closure?.related_items?.map((related) => relationRefEntry(related)) ?? []);
 	let codeContext = $derived(item?.code_context ?? null);
 	$effect(() => {
@@ -124,21 +126,18 @@
 			item = itemData;
 			collection = collData;
 
-			// Fetch real progress for phases
-			if (collSlug === 'phases' && itemData) {
-				try {
-					const progress = await api.items.phasesProgress(wsSlug);
-					const match = progress.find(p => p.phase_id === itemData.id);
-					if (match) {
-						const pct = match.total > 0 ? Math.round((match.done / match.total) * 100) : 0;
-						computedOverrides = { progress: pct, _progressDone: match.done, _progressTotal: match.total };
-					} else {
-						computedOverrides = { progress: 0, _progressDone: 0, _progressTotal: 0 };
-					}
-				} catch {
+			// Fetch child item progress for any item (generalized from phases-only)
+			try {
+				const progress = await api.items.progress(wsSlug, itemData.slug);
+				if (progress.total > 0) {
+					hasChildren = true;
+					computedOverrides = { progress: progress.percentage, _progressDone: progress.done, _progressTotal: progress.total };
+				} else {
+					hasChildren = false;
 					computedOverrides = {};
 				}
-			} else {
+			} catch {
+				hasChildren = false;
 				computedOverrides = {};
 			}
 
@@ -303,12 +302,24 @@
 
 	let computedOverrides = $state<Record<string, any>>({});
 
-	function handlePhaseTasksChange(tasks: Item[]) {
-		if (collSlug !== 'phases') return;
-		const total = tasks.length;
-		const tasksCollection = (collectionStore.collections ?? []).find(c => c.slug === 'tasks');
-		const termOpts = tasksCollection ? getTerminalOptions(tasksCollection) : ['done', 'cancelled'];
-		const done = tasks.filter((task) => termOpts.includes(parseFields(task).status)).length;
+	function handleChildrenChange(items: Item[]) {
+		// Track child IDs for deduplication in the relationships section
+		childItemIds = new Set(items.map(i => i.id));
+		hasChildren = items.length > 0;
+
+		// Recompute progress from the actual children
+		const total = items.length;
+		const allCollections = collectionStore.collections ?? [];
+		// Gather terminal statuses from all collections the children belong to
+		const termSet = new Set<string>();
+		for (const child of items) {
+			const col = allCollections.find(c => c.slug === child.collection_slug);
+			if (col) {
+				for (const ts of getTerminalOptions(col)) termSet.add(ts);
+			}
+		}
+		const termOpts = termSet.size > 0 ? [...termSet] : ['done', 'cancelled'];
+		const done = items.filter((i) => termOpts.includes(parseFields(i).status)).length;
 		const progress = total > 0 ? Math.round((done / total) * 100) : 0;
 		computedOverrides = { progress, _progressDone: done, _progressTotal: total };
 	}
@@ -361,11 +372,11 @@
 		};
 	}
 
-	function buildRelationshipGroups(currentItem: Item, links: ItemLink[]): RelationshipGroup[] {
+	function buildRelationshipGroups(currentItem: Item, links: ItemLink[], excludeChildIds: Set<string> = new Set()): RelationshipGroup[] {
 		const grouped = new Map<string, RelationshipGroup>();
 		const definitions: Record<string, { label: string; tone: RelationshipGroup['tone'] }> = {
-			phase: { label: 'Phase', tone: 'default' },
-			in_phase: { label: 'In phase', tone: 'default' },
+			parent_of: { label: 'Children', tone: 'default' },
+			child_of: { label: 'Child of', tone: 'default' },
 			blocks: { label: 'Blocks', tone: 'blocks' },
 			blocked_by: { label: 'Blocked by', tone: 'blocks' },
 			links_to: { label: 'Links to', tone: 'wiki' },
@@ -378,7 +389,7 @@
 			implemented_by: { label: 'Implemented by', tone: 'lineage' },
 			related: { label: 'Related', tone: 'default' }
 		};
-		const order = ['phase', 'in_phase', 'blocks', 'blocked_by', 'links_to', 'referenced_by', 'split_from', 'split_into', 'supersedes', 'superseded_by', 'implements', 'implemented_by', 'related'];
+		const order = ['parent_of', 'child_of', 'blocks', 'blocked_by', 'links_to', 'referenced_by', 'split_from', 'split_into', 'supersedes', 'superseded_by', 'implements', 'implemented_by', 'related'];
 
 		function addEntry(groupKey: string, entry: RelationshipEntry) {
 			const definition = definitions[groupKey];
@@ -392,9 +403,13 @@
 		for (const link of links) {
 			const isSource = link.source_id === currentItem.id;
 			switch (link.link_type) {
-				case 'phase':
-					addEntry(isSource ? 'in_phase' : 'phase', linkEntry(link, !isSource));
+				case 'parent':
+				case 'phase': {
+					// If this item is the parent and the child is already shown in ChildItems, skip it
+					if (!isSource && excludeChildIds.has(link.source_id)) break;
+					addEntry(isSource ? 'child_of' : 'parent_of', linkEntry(link, !isSource));
 					break;
+				}
 				case 'blocks':
 					addEntry(isSource ? 'blocks' : 'blocked_by', linkEntry(link, !isSource));
 					break;
@@ -841,7 +856,7 @@
 								<option value="implements">Implements</option>
 								<option value="split_from">Split from</option>
 								<option value="supersedes">Supersedes</option>
-								<option value="phase">Phase</option>
+								<option value="parent">Parent</option>
 							</select>
 							<input
 								type="text"
@@ -872,10 +887,9 @@
 			</div>
 		{/if}
 
-		<!-- Phase Tasks (shown only for phases collection) -->
-		{#if collSlug === 'phases' && item}
-			{@const tasksCol = (collectionStore.collections ?? []).find(c => c.slug === 'tasks')}
-			<PhaseTasks {wsSlug} {itemSlug} itemId={item.id} phaseFields={fields} terminalStatuses={tasksCol ? getTerminalOptions(tasksCol) : undefined} onTasksChange={handlePhaseTasksChange} />
+		<!-- Child Items (shown for any item that has children) -->
+		{#if hasChildren && item}
+			<ChildItems {wsSlug} {itemSlug} itemId={item.id} parentFields={fields} onChildrenChange={handleChildrenChange} />
 		{/if}
 
 		<!-- Unified Timeline (comments + activity + versions) -->

--- a/web/src/routes/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[workspace]/[collection]/[slug]/+page.svelte
@@ -301,6 +301,7 @@
 	}
 
 	let computedOverrides = $state<Record<string, any>>({});
+	let childTerminalStatuses = $state<string[] | undefined>(undefined);
 
 	function handleChildrenChange(items: Item[]) {
 		// Track child IDs for deduplication in the relationships section
@@ -319,6 +320,7 @@
 			}
 		}
 		const termOpts = termSet.size > 0 ? [...termSet] : ['done', 'cancelled'];
+		childTerminalStatuses = termOpts;
 		const done = items.filter((i) => termOpts.includes(parseFields(i).status)).length;
 		const progress = total > 0 ? Math.round((done / total) * 100) : 0;
 		computedOverrides = { progress, _progressDone: done, _progressTotal: total };
@@ -887,9 +889,9 @@
 			</div>
 		{/if}
 
-		<!-- Child Items (shown for any item that has children) -->
-		{#if hasChildren && item}
-			<ChildItems {wsSlug} {itemSlug} itemId={item.id} parentFields={fields} onChildrenChange={handleChildrenChange} />
+		<!-- Child Items: always mounted so SSE subscriptions stay active even when starting with 0 children -->
+		{#if item}
+			<ChildItems {wsSlug} {itemSlug} itemId={item.id} parentFields={fields} terminalStatuses={childTerminalStatuses} onChildrenChange={handleChildrenChange} />
 		{/if}
 
 		<!-- Unified Timeline (comments + activity + versions) -->

--- a/web/src/routes/[workspace]/new/+page.svelte
+++ b/web/src/routes/[workspace]/new/+page.svelte
@@ -69,9 +69,9 @@
 				source: 'web'
 			});
 			goto(`/${wsSlug}/${selectedColl}/${itemUrlId(item)}?new=1`);
-		} catch {
+		} catch (err: any) {
 			creating = false;
-			toastStore.show('Failed to create item', 'error');
+			toastStore.show(err?.message || 'Failed to create item', 'error');
 		}
 	}
 </script>


### PR DESCRIPTION
## Summary

- **Any item can now be a parent** of child items — not just phases. Tasks, Ideas, Docs, Bugs, and custom collections all support children with automatic progress bars, burndown charts, and nested rendering.
- **DB migration** renames `link_type='phase'` → `'parent'` with full backward compatibility (old `--phase` flags, `phase_id` JSON fields, and `'phase'` link type all still work as deprecated aliases).
- **Cycle detection** prevents circular parent links (A→B→A).
- **Recursive nesting** up to 3 levels deep with expand/collapse, lazy loading, and per-level progress bars.
- **Self-constructing burndown charts** that infer start/end dates from child activity when the parent has no explicit date fields.

## Changes

**Backend (Go):**
- Migration 023: `phase` → `parent` link type
- Generalized store methods: `GetChildItems`, `GetItemProgress`, `SetParentLink` (with cycle detection), `GetParentMap`, `PopulateHasChildren`
- New API endpoints: `GET /items/{slug}/children`, `GET /items/{slug}/progress`
- All old method names kept as thin deprecated aliases

**Frontend (Svelte):**
- `ChildItems.svelte` — replaces `PhaseTasks.svelte`, works for any parent item
- `ChildChart.svelte` — replaces `PhaseChart.svelte`, infers dates when not provided
- `NestedChildren.svelte` — recursive expand/collapse component
- Item detail page: removed `collSlug === 'phases'` gate, deduplicates children from relationships section

**CLI:**
- `--parent` flag on `create`, `update`, `list`, and `changelog` commands
- `--phase` kept as hidden backward-compat alias
- `pad item show` displays parent info in metadata header

**Docs:** CLAUDE.md, SKILL.md, and pad-web marketing site updated.

## Test plan

- [x] `go test ./...` — all pass (including dashboard, store, and server tests)
- [x] `make web` — frontend builds clean
- [x] `make install` — full binary builds and runs
- [x] Smoke tested: `--parent` flag, `/children` endpoint, `/progress` endpoint, cycle detection, `has_children` flag, nested fetch