### PR TITLE
fix: make item ref parsing case-insensitive (BUG-22)

### DIFF
--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -290,7 +290,9 @@ func (s *Store) ResolveItemIncludeDeleted(workspaceID, slugOrRef string) (*model
 
 // parseItemRef parses "PREFIX-123" into ("PREFIX", 123, true).
 // Returns false if the string is not a valid item ref.
+// Case-insensitive: "task-5", "Task-5", and "TASK-5" all parse to ("TASK", 5, true).
 func parseItemRef(s string) (string, int, bool) {
+	s = strings.ToUpper(s)
 	idx := strings.LastIndex(s, "-")
 	if idx <= 0 || idx == len(s)-1 {
 		return "", 0, false


### PR DESCRIPTION
## Summary
- Uppercases input in `parseItemRef()` so item references like `task-5`, `Task-5`, and `TASK-5` all resolve correctly
- Fixes CLI lookups (`pad item show task-5`), API resolution, and search matching — all paths flow through this one parser
- One-line fix in `internal/store/items.go`

## Test plan
- [x] `pad item show bug-22` (lowercase) → resolves BUG-22
- [x] `pad item show Bug-22` (mixed case) → resolves BUG-22
- [x] `pad item search "task-183"` (lowercase) → finds TASK-183
- [x] `go test ./...` — all tests pass