### PR TITLE
fix: count implements links as children for progress tracking

### DIFF
--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -12,6 +12,20 @@ import (
 	"github.com/xarmian/pad/internal/models"
 )
 
+// childLinkTypes lists the link types that establish a parent→child relationship
+// for progress tracking. Both 'parent' and 'implements' links count as children.
+var childLinkTypes = []string{"parent", "implements"}
+
+// childLinkTypeSQL returns a SQL IN clause fragment like "'parent','implements'"
+// for filtering item_links by child relationship types.
+func childLinkTypeSQL() string {
+	quoted := make([]string, len(childLinkTypes))
+	for i, t := range childLinkTypes {
+		quoted[i] = "'" + t + "'"
+	}
+	return strings.Join(quoted, ",")
+}
+
 // ItemSearchResult holds FTS search results for items.
 type ItemSearchResult struct {
 	Item    models.Item `json:"item"`
@@ -1064,8 +1078,8 @@ func (s *Store) GetParentForItem(itemID string) (*models.ItemLink, error) {
 		JOIN items t ON t.id = l.target_id
 		JOIN collections sc ON sc.id = s.collection_id
 		JOIN collections tc ON tc.id = t.collection_id
-		WHERE l.source_id = ? AND l.link_type = 'parent'
-	`, sStatusExpr, tStatusExpr)), itemID)
+		WHERE l.source_id = ? AND l.link_type IN (%s)
+	`, sStatusExpr, tStatusExpr, childLinkTypeSQL())), itemID)
 	if err != nil {
 		return nil, fmt.Errorf("get parent for item: %w", err)
 	}
@@ -1111,10 +1125,10 @@ func (s *Store) GetParentForItem(itemID string) (*models.ItemLink, error) {
 // GetParentMap returns a map of item ID -> parent item ID for all parent links
 // in a workspace. Used for efficient batch lookups (e.g., dashboard, list enrichment).
 func (s *Store) GetParentMap(workspaceID string) (map[string]string, error) {
-	rows, err := s.db.Query(s.q(`
+	rows, err := s.db.Query(s.q(fmt.Sprintf(`
 		SELECT source_id, target_id FROM item_links
-		WHERE workspace_id = ? AND link_type = 'parent'
-	`), workspaceID)
+		WHERE workspace_id = ? AND link_type IN (%s)
+	`, childLinkTypeSQL())), workspaceID)
 	if err != nil {
 		return nil, fmt.Errorf("get parent map: %w", err)
 	}
@@ -1144,9 +1158,9 @@ func (s *Store) GetItemProgress(parentItemID string) (total int, done int, err e
 		SELECT COUNT(*),
 		       COUNT(CASE WHEN LOWER(%s) IN (%s) THEN 1 END)
 		FROM items i
-		JOIN item_links il ON il.source_id = i.id AND il.link_type = 'parent' AND il.target_id = ?
+		JOIN item_links il ON il.source_id = i.id AND il.link_type IN (%s) AND il.target_id = ?
 		WHERE i.deleted_at IS NULL
-	`, statusExpr, termPlaceholders)), args...).Scan(&total, &done)
+	`, statusExpr, termPlaceholders, childLinkTypeSQL())), args...).Scan(&total, &done)
 	if err != nil {
 		return 0, 0, fmt.Errorf("get item progress: %w", err)
 	}
@@ -1158,13 +1172,13 @@ func (s *Store) GetItemProgress(parentItemID string) (total int, done int, err e
 // It queries the actual child items' collection schemas rather than hardcoding 'tasks'.
 func (s *Store) getChildTerminalPlaceholders(parentItemID string) (string, []any) {
 	// Find distinct collection IDs of child items
-	rows, err := s.db.Query(s.q(`
+	rows, err := s.db.Query(s.q(fmt.Sprintf(`
 		SELECT DISTINCT c.schema
 		FROM items i
 		JOIN collections c ON c.id = i.collection_id
-		JOIN item_links il ON il.source_id = i.id AND il.link_type = 'parent' AND il.target_id = ?
+		JOIN item_links il ON il.source_id = i.id AND il.link_type IN (%s) AND il.target_id = ?
 		WHERE i.deleted_at IS NULL AND c.deleted_at IS NULL
-	`), parentItemID)
+	`, childLinkTypeSQL())), parentItemID)
 	if err != nil {
 		return models.DefaultTerminalStatusPlaceholders()
 	}
@@ -1207,17 +1221,17 @@ func (s *Store) getChildTerminalPlaceholders(parentItemID string) (string, []any
 // a single parent, it gathers terminal statuses across all parent→child links in a
 // workspace/collection pair.
 func (s *Store) getCollectionChildTerminalPlaceholders(workspaceID, collectionSlug string) (string, []any) {
-	rows, err := s.db.Query(s.q(`
+	rows, err := s.db.Query(s.q(fmt.Sprintf(`
 		SELECT DISTINCT c.schema
 		FROM items t
 		JOIN collections c ON c.id = t.collection_id
-		JOIN item_links il ON il.source_id = t.id AND il.link_type = 'parent'
+		JOIN item_links il ON il.source_id = t.id AND il.link_type IN (%s)
 		JOIN items p ON p.id = il.target_id AND p.deleted_at IS NULL
 		JOIN collections pc ON pc.id = p.collection_id AND pc.slug = ?
 		WHERE p.workspace_id = ?
 		  AND t.deleted_at IS NULL
 		  AND c.deleted_at IS NULL
-	`), collectionSlug, workspaceID)
+	`, childLinkTypeSQL())), collectionSlug, workspaceID)
 	if err != nil {
 		return models.DefaultTerminalStatusPlaceholders()
 	}
@@ -1272,14 +1286,14 @@ func (s *Store) GetAllItemProgress(workspaceID, collectionSlug string) ([]ItemPr
 		       COUNT(CASE WHEN LOWER(%s) IN (%s) THEN 1 END)
 		FROM items p
 		JOIN collections pc ON pc.id = p.collection_id
-		LEFT JOIN item_links il ON il.link_type = 'parent' AND il.target_id = p.id
+		LEFT JOIN item_links il ON il.link_type IN (%s) AND il.target_id = p.id
 		LEFT JOIN items t ON t.id = il.source_id
 		                  AND t.deleted_at IS NULL
 		WHERE p.workspace_id = ?
 		  AND pc.slug = ?
 		  AND p.deleted_at IS NULL
 		GROUP BY p.id
-	`, tStatusExpr, termPlaceholders)), args...)
+	`, tStatusExpr, termPlaceholders, childLinkTypeSQL())), args...)
 	if err != nil {
 		return nil, fmt.Errorf("get all item progress: %w", err)
 	}
@@ -1302,7 +1316,7 @@ func (s *Store) GetAllItemProgress(workspaceID, collectionSlug string) ([]ItemPr
 // GetChildItems returns all non-deleted child items linked to the given parent
 // via item_links. Returns children from any collection.
 func (s *Store) GetChildItems(parentItemID string) ([]models.Item, error) {
-	rows, err := s.db.Query(s.q(`
+	rows, err := s.db.Query(s.q(fmt.Sprintf(`
 		SELECT i.id, i.workspace_id, i.collection_id, i.title, i.slug, i.content, i.fields, i.tags,
 		       i.pinned, i.sort_order, i.parent_id, i.assigned_user_id, i.agent_role_id, i.role_sort_order,
 		       i.created_by, i.last_modified_by, i.source,
@@ -1312,12 +1326,12 @@ func (s *Store) GetChildItems(parentItemID string) ([]models.Item, error) {
 		       COALESCE(ar.name, ''), COALESCE(ar.slug, ''), COALESCE(ar.icon, '')
 		FROM items i
 		JOIN collections c ON c.id = i.collection_id
-		JOIN item_links il ON il.source_id = i.id AND il.link_type = 'parent' AND il.target_id = ?
+		JOIN item_links il ON il.source_id = i.id AND il.link_type IN (%s) AND il.target_id = ?
 		LEFT JOIN users au ON au.id = i.assigned_user_id
 		LEFT JOIN agent_roles ar ON ar.id = i.agent_role_id
 		WHERE i.deleted_at IS NULL
 		ORDER BY i.sort_order ASC, i.created_at ASC
-	`), parentItemID)
+	`, childLinkTypeSQL())), parentItemID)
 	if err != nil {
 		return nil, fmt.Errorf("get child items: %w", err)
 	}
@@ -1351,8 +1365,8 @@ func (s *Store) PopulateHasChildren(items []models.Item) {
 	query := fmt.Sprintf(`
 		SELECT DISTINCT il.target_id FROM item_links il
 		JOIN items child ON child.id = il.source_id AND child.deleted_at IS NULL
-		WHERE il.link_type = 'parent' AND il.target_id IN (%s)
-	`, strings.Join(placeholders, ","))
+		WHERE il.link_type IN (%s) AND il.target_id IN (%s)
+	`, childLinkTypeSQL(), strings.Join(placeholders, ","))
 
 	rows, err := s.db.Query(s.q(query), args...)
 	if err != nil {

--- a/web/src/routes/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[workspace]/[collection]/[slug]/+page.svelte
@@ -15,7 +15,7 @@
 	import { goto } from '$app/navigation';
 	import { relativeTime, wikiLinksToMarkdown, markdownToWikiLinks, cleanBrokenLinks } from '$lib/utils/markdown';
 	import { toastStore } from '$lib/stores/toast.svelte';
-	import type { Item, Collection, CollectionSettings, QuickAction, ItemLink, ItemRelationRef, AgentRole } from '$lib/types';
+	import type { Item, Collection, CollectionSettings, QuickAction, ItemLink, AgentRole } from '$lib/types';
 	import { parseFields, parseSchema, parseSettings, formatItemRef, getTerminalOptions } from '$lib/types';
 	import QuickActionsMenu from '$lib/components/common/QuickActionsMenu.svelte';
 
@@ -31,6 +31,7 @@
 		label: string;
 		tone: 'default' | 'blocks' | 'wiki' | 'lineage';
 		entries: RelationshipEntry[];
+		closureSummary?: string;
 	};
 
 	let wsSlug = $derived(page.params.workspace ?? '');
@@ -79,7 +80,6 @@
 	let childItemIds = $state<Set<string>>(new Set());
 	let hasChildren = $state(false);
 	let relationshipGroups = $derived(item ? buildRelationshipGroups(item, itemLinks, childItemIds) : []);
-	let closureEntries = $derived(item?.derived_closure?.related_items?.map((related) => relationRefEntry(related)) ?? []);
 	let codeContext = $derived(item?.code_context ?? null);
 	$effect(() => {
 		if (wsSlug && collSlug && itemSlug) {
@@ -348,15 +348,6 @@
 		return `/${wsSlug}/${collectionSlug}/${refOrSlug}`;
 	}
 
-	function relationRefEntry(related: ItemRelationRef): RelationshipEntry {
-		return {
-			key: related.id,
-			label: relationLabel(related.ref, related.title, related.id),
-			href: relationHref(related.collection_slug, related.ref ?? related.slug),
-			status: related.status
-		};
-	}
-
 	function linkEntry(link: ItemLink, useSource: boolean): RelationshipEntry {
 		const ref = useSource ? link.source_ref : link.target_ref;
 		const title = useSource ? link.source_title : link.target_title;
@@ -424,12 +415,28 @@
 				case 'supersedes':
 					addEntry(isSource ? 'supersedes' : 'superseded_by', linkEntry(link, !isSource));
 					break;
-				case 'implements':
+				case 'implements': {
+					// If this item is the target (implemented by) and the source is already shown in ChildItems, skip it
+					if (!isSource && excludeChildIds.has(link.source_id)) break;
 					addEntry(isSource ? 'implements' : 'implemented_by', linkEntry(link, !isSource));
 					break;
+				}
 				default:
 					addEntry('related', linkEntry(link, !isSource));
 					break;
+			}
+		}
+
+		// Annotate the matching relationship group with closure summary
+		if (currentItem.derived_closure) {
+			const closureGroupKey: Record<string, string> = {
+				superseded_by: 'superseded_by',
+				implemented_by: 'implemented_by',
+				split_into: 'split_into'
+			};
+			const key = closureGroupKey[currentItem.derived_closure.kind];
+			if (key && grouped.has(key)) {
+				grouped.get(key)!.closureSummary = currentItem.derived_closure.summary;
 			}
 		}
 
@@ -779,33 +786,6 @@
 			</div>
 		</div>
 
-		<!-- Relationships -->
-		{#if item.derived_closure}
-			<div class="closure-notice">
-				<div class="closure-notice-header">
-					<h3 class="section-title">Derived Closure</h3>
-					<span class="closure-kind">{formatFieldDisplay(item.derived_closure.kind)}</span>
-				</div>
-				<p class="closure-summary">{item.derived_closure.summary}</p>
-				{#if closureEntries.length > 0}
-					<div class="closure-related-list">
-						{#each closureEntries as related (related.key)}
-							<div class="closure-related-item">
-								{#if related.href}
-									<a href={related.href} class="closure-related-link">{related.label}</a>
-								{:else}
-									<span class="closure-related-link">{related.label}</span>
-								{/if}
-								{#if related.status}
-									<span class="link-status">{formatFieldDisplay(related.status)}</span>
-								{/if}
-							</div>
-						{/each}
-					</div>
-				{/if}
-			</div>
-		{/if}
-
 		{#if relationshipGroups.length > 0}
 			<div class="relationships-section">
 				<h3 class="section-title">Relationships</h3>
@@ -813,6 +793,9 @@
 					{#each relationshipGroups as group (group.label)}
 						<div class="relationship-group">
 							<h4 class="relationship-group-title">{group.label}</h4>
+							{#if group.closureSummary}
+								<p class="closure-inline-summary">✓ {group.closureSummary}</p>
+							{/if}
 							<div class="links-list">
 								{#each group.entries as entry (entry.key)}
 									<div class="link-row" class:tone-blocks={group.tone === 'blocks'} class:tone-wiki={group.tone === 'wiki'} class:tone-lineage={group.tone === 'lineage'}>
@@ -1235,56 +1218,11 @@
 		color: var(--text-muted);
 	}
 
-	/* Derived closure */
-	.closure-notice {
-		margin-top: var(--space-6);
-		padding: var(--space-4);
-		background: color-mix(in srgb, var(--accent-green) 10%, var(--bg-secondary));
-		border: 1px solid color-mix(in srgb, var(--accent-green) 35%, var(--border));
-		border-radius: var(--radius);
-	}
-	.closure-notice-header {
-		display: flex;
-		align-items: center;
-		justify-content: space-between;
-		gap: var(--space-3);
-		margin-bottom: var(--space-2);
-		flex-wrap: wrap;
-	}
-	.closure-kind {
-		font-size: 0.75em;
-		font-weight: 600;
-		text-transform: uppercase;
-		letter-spacing: 0.04em;
+	.closure-inline-summary {
+		margin: 0 0 var(--space-2) 0;
+		font-size: 0.8em;
 		color: var(--accent-green);
-	}
-	.closure-summary {
-		margin: 0;
-		color: var(--text-primary);
-	}
-	.closure-related-list {
-		display: flex;
-		flex-wrap: wrap;
-		gap: var(--space-2);
-		margin-top: var(--space-3);
-	}
-	.closure-related-item {
-		display: inline-flex;
-		align-items: center;
-		gap: var(--space-2);
-		padding: var(--space-2) var(--space-3);
-		background: var(--bg-primary);
-		border: 1px solid var(--border);
-		border-radius: var(--radius);
-	}
-	.closure-related-link {
 		font-weight: 500;
-		color: var(--text-primary);
-		text-decoration: none;
-	}
-	.closure-related-link:hover {
-		color: var(--accent-blue);
-		text-decoration: underline;
 	}
 
 	/* Relationships */


### PR DESCRIPTION
## Summary
- Progress bars showed 0/0 for items with children connected via `implements` links (e.g. tasks implementing a plan in fhir-core). Only `parent` link types were counted.
- Defined `childLinkTypes` constant (`parent` + `implements`) and updated all 8 SQL queries in `internal/store/items.go` to use `IN ('parent','implements')` instead of `= 'parent'`
- Removed the standalone "Derived Closure" banner on the item detail page that duplicated relationship info. Closure summary now appears as an inline annotation on the matching relationship group.
- Added `implements` link dedup so items shown in ChildItems aren't repeated in Relationships section

## Test plan
- [x] `GET /workspaces/fhir-core/items/PLAN-8/progress` returns `10/10, 100%` (was `0/0, 0%`)
- [x] `GET /workspaces/fhir-core/items/PLAN-8/children` returns all 10 implementing tasks
- [x] Batch `/plans-progress` returns correct counts for all plans
- [x] `go test ./...` — all tests pass
- [x] Frontend builds clean