### PR TITLE
feat: session binding, nonce-based CSP, and auth hardening

### DIFF
--- a/internal/server/handlers_auth.go
+++ b/internal/server/handlers_auth.go
@@ -68,8 +68,8 @@ func requestIsLoopback(r *http.Request) bool {
 	return ip != nil && ip.IsLoopback()
 }
 
-func (s *Server) createAuthSession(w http.ResponseWriter, user *models.User, ttl time.Duration) (string, error) {
-	token, err := s.store.CreateSession(user.ID, "web", ttl)
+func (s *Server) createAuthSession(w http.ResponseWriter, r *http.Request, user *models.User, ttl time.Duration) (string, error) {
+	token, err := s.store.CreateSession(user.ID, "web", clientIP(r), r.UserAgent(), ttl)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to create session")
 		return "", err
@@ -157,7 +157,7 @@ func (s *Server) handleBootstrap(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	token, err := s.createAuthSession(w, user, cliSessionTTL)
+	token, err := s.createAuthSession(w, r, user, cliSessionTTL)
 	if err != nil {
 		return
 	}
@@ -271,7 +271,7 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 		_ = s.store.AcceptInvitation(invitation.ID)
 	}
 
-	token, err := s.createAuthSession(w, user, webSessionTTL)
+	token, err := s.createAuthSession(w, r, user, webSessionTTL)
 	if err != nil {
 		return
 	}
@@ -319,7 +319,7 @@ func (s *Server) handleLogin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	token, err := s.createAuthSession(w, user, webSessionTTL)
+	token, err := s.createAuthSession(w, r, user, webSessionTTL)
 	if err != nil {
 		return
 	}
@@ -356,9 +356,9 @@ func (s *Server) handleSessionCheck(w http.ResponseWriter, r *http.Request) {
 
 	// Try session cookie directly (since auth endpoints are exempt from middleware)
 	if cookie, err := r.Cookie(sessionCookie); err == nil {
-		user, _ := s.store.ValidateSession(cookie.Value)
-		if user != nil {
-			writeJSON(w, http.StatusOK, sessionStatePayload(true, user))
+		session, _ := s.store.ValidateSession(cookie.Value)
+		if session != nil && session.User != nil {
+			writeJSON(w, http.StatusOK, sessionStatePayload(true, session.User))
 			return
 		}
 	}
@@ -408,7 +408,9 @@ func (s *Server) handleGetCurrentUser(w http.ResponseWriter, r *http.Request) {
 	if user == nil {
 		// Try cookie directly
 		if cookie, err := r.Cookie(sessionCookie); err == nil {
-			user, _ = s.store.ValidateSession(cookie.Value)
+			if session, _ := s.store.ValidateSession(cookie.Value); session != nil {
+				user = session.User
+			}
 		}
 	}
 	if user == nil {
@@ -435,7 +437,9 @@ func (s *Server) handleUpdateCurrentUser(w http.ResponseWriter, r *http.Request)
 	if user == nil {
 		// Try cookie directly (auth endpoints are exempt from middleware)
 		if cookie, err := r.Cookie(sessionCookie); err == nil {
-			user, _ = s.store.ValidateSession(cookie.Value)
+			if session, _ := s.store.ValidateSession(cookie.Value); session != nil {
+				user = session.User
+			}
 		}
 	}
 	if user == nil {
@@ -615,7 +619,7 @@ func (s *Server) handleResetPassword(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Create a fresh session so the user is logged in
-	sessionToken, err := s.store.CreateSession(user.ID, "web", webSessionTTL)
+	sessionToken, err := s.store.CreateSession(user.ID, "web", clientIP(r), r.UserAgent(), webSessionTTL)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "internal_error", "Password updated but failed to create session")
 		return

--- a/internal/server/handlers_auth.go
+++ b/internal/server/handlers_auth.go
@@ -68,6 +68,25 @@ func requestIsLoopback(r *http.Request) bool {
 	return ip != nil && ip.IsLoopback()
 }
 
+// validateSessionCookie validates a session cookie including session binding
+// (User-Agent check). Returns the user if valid, nil otherwise. This must be
+// used instead of calling ValidateSession directly to ensure binding is enforced.
+func (s *Server) validateSessionCookie(r *http.Request) *models.User {
+	cookie, err := r.Cookie(sessionCookie)
+	if err != nil {
+		return nil
+	}
+	session, _ := s.store.ValidateSession(cookie.Value)
+	if session == nil || session.User == nil {
+		return nil
+	}
+	// Session binding: reject if User-Agent has changed
+	if session.UAHash != "" && sha256hex(r.UserAgent()) != session.UAHash {
+		return nil
+	}
+	return session.User
+}
+
 func (s *Server) createAuthSession(w http.ResponseWriter, r *http.Request, user *models.User, ttl time.Duration) (string, error) {
 	token, err := s.store.CreateSession(user.ID, "web", clientIP(r), r.UserAgent(), ttl)
 	if err != nil {
@@ -355,12 +374,9 @@ func (s *Server) handleSessionCheck(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Try session cookie directly (since auth endpoints are exempt from middleware)
-	if cookie, err := r.Cookie(sessionCookie); err == nil {
-		session, _ := s.store.ValidateSession(cookie.Value)
-		if session != nil && session.User != nil {
-			writeJSON(w, http.StatusOK, sessionStatePayload(true, session.User))
-			return
-		}
+	if user := s.validateSessionCookie(r); user != nil {
+		writeJSON(w, http.StatusOK, sessionStatePayload(true, user))
+		return
 	}
 
 	writeJSON(w, http.StatusOK, sessionStatePayload(false, nil))
@@ -406,12 +422,8 @@ func (s *Server) handleLogout(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleGetCurrentUser(w http.ResponseWriter, r *http.Request) {
 	user := currentUser(r)
 	if user == nil {
-		// Try cookie directly
-		if cookie, err := r.Cookie(sessionCookie); err == nil {
-			if session, _ := s.store.ValidateSession(cookie.Value); session != nil {
-				user = session.User
-			}
-		}
+		// Try cookie directly (auth endpoints are exempt from middleware)
+		user = s.validateSessionCookie(r)
 	}
 	if user == nil {
 		writeError(w, http.StatusUnauthorized, "unauthorized", "Not logged in")
@@ -436,11 +448,7 @@ func (s *Server) handleUpdateCurrentUser(w http.ResponseWriter, r *http.Request)
 	user := currentUser(r)
 	if user == nil {
 		// Try cookie directly (auth endpoints are exempt from middleware)
-		if cookie, err := r.Cookie(sessionCookie); err == nil {
-			if session, _ := s.store.ValidateSession(cookie.Value); session != nil {
-				user = session.User
-			}
-		}
+		user = s.validateSessionCookie(r)
 	}
 	if user == nil {
 		writeError(w, http.StatusUnauthorized, "unauthorized", "Not logged in")

--- a/internal/server/handlers_members.go
+++ b/internal/server/handlers_members.go
@@ -40,15 +40,21 @@ func (s *Server) handleListMembers(w http.ResponseWriter, r *http.Request) {
 	}
 	enrichedInvs := make([]invWithURL, len(invitations))
 	for i, inv := range invitations {
+		// For hashed invitations (code == id placeholder), the plaintext
+		// code is not recoverable — only show code/join_url for legacy invites.
+		code := inv.Code
+		if code == inv.ID {
+			code = ""
+		}
 		enrichedInvs[i] = invWithURL{
 			ID:        inv.ID,
 			Email:     inv.Email,
 			Role:      inv.Role,
-			Code:      inv.Code,
+			Code:      code,
 			CreatedAt: inv.CreatedAt.Format("2006-01-02T15:04:05Z"),
 		}
-		if s.baseURL != "" {
-			enrichedInvs[i].JoinURL = s.baseURL + "/join/" + inv.Code
+		if s.baseURL != "" && code != "" {
+			enrichedInvs[i].JoinURL = s.baseURL + "/join/" + code
 		}
 	}
 

--- a/internal/server/middleware_auth.go
+++ b/internal/server/middleware_auth.go
@@ -2,6 +2,9 @@ package server
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"log/slog"
 	"net/http"
 	"strings"
 
@@ -45,16 +48,24 @@ func (s *Server) TokenAuth(next http.Handler) http.Handler {
 
 		// Session token (from CLI login)
 		if strings.HasPrefix(token, "padsess_") {
-			user, err := s.store.ValidateSession(token)
+			session, err := s.store.ValidateSession(token)
 			if err != nil {
 				writeError(w, http.StatusInternalServerError, "internal_error", "Session validation failed")
 				return
 			}
-			if user == nil {
+			if session == nil {
 				writeError(w, http.StatusUnauthorized, "unauthorized", "Invalid or expired session")
 				return
 			}
-			ctx := context.WithValue(r.Context(), ctxCurrentUser, user)
+			// Session binding: validate User-Agent hasn't changed
+			if session.UAHash != "" && sha256hex(r.UserAgent()) != session.UAHash {
+				slog.Warn("session binding mismatch: User-Agent changed",
+					"session_ip", session.IPAddress,
+					"client_ip", clientIP(r))
+				writeError(w, http.StatusUnauthorized, "unauthorized", "Session expired")
+				return
+			}
+			ctx := context.WithValue(r.Context(), ctxCurrentUser, session.User)
 			next.ServeHTTP(w, r.WithContext(ctx))
 			return
 		}
@@ -111,8 +122,17 @@ func (s *Server) SessionAuth(next http.Handler) http.Handler {
 			return
 		}
 
-		user, err := s.store.ValidateSession(cookie.Value)
-		if err != nil || user == nil {
+		session, err := s.store.ValidateSession(cookie.Value)
+		if err != nil || session == nil {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		// Session binding: validate User-Agent hasn't changed
+		if session.UAHash != "" && sha256hex(r.UserAgent()) != session.UAHash {
+			slog.Warn("session binding mismatch: User-Agent changed",
+				"session_ip", session.IPAddress,
+				"client_ip", clientIP(r))
 			next.ServeHTTP(w, r)
 			return
 		}
@@ -126,7 +146,7 @@ func (s *Server) SessionAuth(next http.Handler) http.Handler {
 			}
 		}
 
-		ctx := context.WithValue(r.Context(), ctxCurrentUser, user)
+		ctx := context.WithValue(r.Context(), ctxCurrentUser, session.User)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }
@@ -315,4 +335,10 @@ func roleLevel(role string) int {
 	default:
 		return 0
 	}
+}
+
+// sha256hex returns the SHA-256 hex digest of a string.
+func sha256hex(s string) string {
+	h := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(h[:])
 }

--- a/internal/server/middleware_security.go
+++ b/internal/server/middleware_security.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"crypto/rand"
+	"encoding/base64"
 	"net/http"
 	"strings"
 )
@@ -24,12 +26,10 @@ func SecurityHeaders(next http.Handler) http.Handler {
 		// Restrict browser features the app doesn't need
 		h.Set("Permissions-Policy", "camera=(), microphone=(), geolocation=()")
 
-		// CSP: allow self-sourced content, inline styles for Svelte component scoping,
-		// and inline scripts for SvelteKit's module bootstrap/hydration.
-		// Without 'unsafe-inline' on script-src, SvelteKit's generated inline <script>
-		// tags are blocked, causing a white screen (especially on mobile browsers).
+		// CSP: strict policy for API responses. HTML pages served by spaHandler
+		// override this with a nonce-based script-src for SvelteKit inline scripts.
 		h.Set("Content-Security-Policy",
-			"default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'")
+			"default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'")
 
 		next.ServeHTTP(w, r)
 	})
@@ -42,6 +42,14 @@ func StrictTransportSecurity(next http.Handler) http.Handler {
 		w.Header().Set("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
 		next.ServeHTTP(w, r)
 	})
+}
+
+// generateCSPNonce generates a cryptographically random nonce for
+// Content-Security-Policy headers. Returns a 16-byte base64-encoded string.
+func generateCSPNonce() string {
+	b := make([]byte, 16)
+	_, _ = rand.Read(b)
+	return base64.StdEncoding.EncodeToString(b)
 }
 
 // parseCORSOrigins parses a comma-separated list of origins into a slice.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"bytes"
 	"fmt"
 	"io/fs"
 	"log/slog"
@@ -140,7 +141,13 @@ func (s *Server) setupRouter() {
 	}
 	r.Use(chimiddleware.Recoverer)
 
-	// Prometheus scrape endpoint — no auth/CSRF/security headers
+	// Security headers (applies to all routes)
+	r.Use(SecurityHeaders)
+	if s.secureCookies {
+		r.Use(StrictTransportSecurity)
+	}
+
+	// Prometheus scrape endpoint — no auth/CSRF
 	if s.metrics != nil {
 		r.Group(func(r chi.Router) {
 			r.Handle("/metrics", promhttp.HandlerFor(s.metrics.Registry, promhttp.HandlerOpts{}))
@@ -149,10 +156,6 @@ func (s *Server) setupRouter() {
 
 	// All other routes — full middleware stack
 	r.Group(func(r chi.Router) {
-		r.Use(SecurityHeaders)
-		if s.secureCookies {
-			r.Use(StrictTransportSecurity)
-		}
 		r.Use(cors.Handler(cors.Options{
 			AllowedOrigins:   parseCORSOrigins(s.corsOrigins),
 			AllowedMethods:   []string{"GET", "POST", "PATCH", "PUT", "DELETE", "OPTIONS"},
@@ -397,10 +400,21 @@ func (s *Server) spaHandler() http.Handler {
 			}
 		}
 
+		// Generate per-request nonce for inline script CSP
+		nonce := generateCSPNonce()
+
+		// Inject nonce into inline <script> tags (SvelteKit bootstrap)
+		html := bytes.Replace(indexHTML, []byte("<script>"), []byte(fmt.Sprintf(`<script nonce="%s">`, nonce)), -1)
+
+		// Set nonce-based CSP (overrides the strict default from SecurityHeaders)
+		w.Header().Set("Content-Security-Policy", fmt.Sprintf(
+			"default-src 'self'; script-src 'self' 'nonce-%s'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'",
+			nonce))
+
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
 		w.WriteHeader(http.StatusOK)
-		w.Write(indexHTML)
+		w.Write(html)
 	})
 }
 

--- a/internal/store/migrations/026_session_binding.sql
+++ b/internal/store/migrations/026_session_binding.sql
@@ -1,0 +1,7 @@
+-- Session binding: store IP address and User-Agent hash for session theft detection
+ALTER TABLE sessions ADD COLUMN ip_address TEXT DEFAULT '';
+ALTER TABLE sessions ADD COLUMN ua_hash TEXT DEFAULT '';
+
+-- Invitation code hardening: store hashed codes (128-bit entropy)
+ALTER TABLE workspace_invitations ADD COLUMN code_hash TEXT DEFAULT '';
+CREATE INDEX IF NOT EXISTS idx_invitations_code_hash ON workspace_invitations(code_hash);

--- a/internal/store/pgmigrations/006_session_binding.sql
+++ b/internal/store/pgmigrations/006_session_binding.sql
@@ -1,0 +1,7 @@
+-- Session binding: store IP address and User-Agent hash for session theft detection
+ALTER TABLE sessions ADD COLUMN IF NOT EXISTS ip_address TEXT DEFAULT '';
+ALTER TABLE sessions ADD COLUMN IF NOT EXISTS ua_hash TEXT DEFAULT '';
+
+-- Invitation code hardening: store hashed codes (128-bit entropy)
+ALTER TABLE workspace_invitations ADD COLUMN IF NOT EXISTS code_hash TEXT DEFAULT '';
+CREATE INDEX IF NOT EXISTS idx_invitations_code_hash ON workspace_invitations(code_hash);

--- a/internal/store/sessions.go
+++ b/internal/store/sessions.go
@@ -11,10 +11,19 @@ import (
 	"github.com/xarmian/pad/internal/models"
 )
 
+// SessionInfo holds the result of session validation, including the
+// authenticated user and session binding metadata for IP/UA verification.
+type SessionInfo struct {
+	User      *models.User
+	IPAddress string
+	UAHash    string
+}
+
 // CreateSession generates a random session token, stores its SHA-256 hash,
 // and returns the plaintext token (prefixed with "padsess_"). The plaintext
-// is returned exactly once and never stored.
-func (s *Store) CreateSession(userID, deviceInfo string, ttl time.Duration) (string, error) {
+// is returned exactly once and never stored. IP address and User-Agent hash
+// are stored for session binding validation.
+func (s *Store) CreateSession(userID, deviceInfo, ipAddress, userAgent string, ttl time.Duration) (string, error) {
 	// Generate 32 random bytes → hex → prefix
 	raw := make([]byte, 32)
 	if _, err := rand.Read(raw); err != nil {
@@ -25,14 +34,21 @@ func (s *Store) CreateSession(userID, deviceInfo string, ttl time.Duration) (str
 	hash := sha256.Sum256([]byte(plaintext))
 	tokenHash := hex.EncodeToString(hash[:])
 
+	// Hash the User-Agent for storage (we don't need the original)
+	uaHash := ""
+	if userAgent != "" {
+		h := sha256.Sum256([]byte(userAgent))
+		uaHash = hex.EncodeToString(h[:])
+	}
+
 	id := newID()
 	ts := now()
 	expiresAt := time.Now().UTC().Add(ttl).Format(time.RFC3339)
 
 	_, err := s.db.Exec(s.q(`
-		INSERT INTO sessions (id, user_id, token_hash, device_info, expires_at, created_at)
-		VALUES (?, ?, ?, ?, ?, ?)
-	`), id, userID, tokenHash, deviceInfo, expiresAt, ts)
+		INSERT INTO sessions (id, user_id, token_hash, device_info, ip_address, ua_hash, expires_at, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+	`), id, userID, tokenHash, deviceInfo, ipAddress, uaHash, expiresAt, ts)
 	if err != nil {
 		return "", fmt.Errorf("insert session: %w", err)
 	}
@@ -41,15 +57,16 @@ func (s *Store) CreateSession(userID, deviceInfo string, ttl time.Duration) (str
 }
 
 // ValidateSession hashes the provided token, looks it up, checks expiry,
-// and returns the associated user. Returns nil if invalid or expired.
-func (s *Store) ValidateSession(token string) (*models.User, error) {
+// and returns the session info including the associated user and binding
+// metadata (IP/UA). Returns nil if invalid or expired.
+func (s *Store) ValidateSession(token string) (*SessionInfo, error) {
 	hash := sha256.Sum256([]byte(token))
 	tokenHash := hex.EncodeToString(hash[:])
 
-	var userID, expiresAt string
+	var userID, expiresAt, ipAddress, uaHash string
 	err := s.db.QueryRow(s.q(`
-		SELECT user_id, expires_at FROM sessions WHERE token_hash = ?
-	`), tokenHash).Scan(&userID, &expiresAt)
+		SELECT user_id, expires_at, ip_address, ua_hash FROM sessions WHERE token_hash = ?
+	`), tokenHash).Scan(&userID, &expiresAt, &ipAddress, &uaHash)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -62,7 +79,19 @@ func (s *Store) ValidateSession(token string) (*models.User, error) {
 		return nil, nil
 	}
 
-	return s.GetUser(userID)
+	user, err := s.GetUser(userID)
+	if err != nil {
+		return nil, err
+	}
+	if user == nil {
+		return nil, nil
+	}
+
+	return &SessionInfo{
+		User:      user,
+		IPAddress: ipAddress,
+		UAHash:    uaHash,
+	}, nil
 }
 
 // DeleteSession destroys a session by its plaintext token.

--- a/internal/store/sessions_test.go
+++ b/internal/store/sessions_test.go
@@ -12,8 +12,8 @@ func TestSessionCreateAndValidate(t *testing.T) {
 	s := testStore(t)
 	u := createTestUser(t, s, "test@test.com", "Test", "password123")
 
-	// Create session
-	token, err := s.CreateSession(u.ID, "cli", 30*24*time.Hour)
+	// Create session with binding metadata
+	token, err := s.CreateSession(u.ID, "cli", "127.0.0.1", "TestAgent/1.0", 30*24*time.Hour)
 	if err != nil {
 		t.Fatalf("CreateSession error: %v", err)
 	}
@@ -25,29 +25,38 @@ func TestSessionCreateAndValidate(t *testing.T) {
 	}
 
 	// Validate session
-	user, err := s.ValidateSession(token)
+	session, err := s.ValidateSession(token)
 	if err != nil {
 		t.Fatalf("ValidateSession error: %v", err)
 	}
-	if user == nil {
+	if session == nil {
+		t.Fatal("expected session from valid token")
+	}
+	if session.User == nil {
 		t.Fatal("expected user from valid session")
 	}
-	if user.ID != u.ID {
-		t.Errorf("expected user ID %q, got %q", u.ID, user.ID)
+	if session.User.ID != u.ID {
+		t.Errorf("expected user ID %q, got %q", u.ID, session.User.ID)
 	}
-	if user.Email != "test@test.com" {
-		t.Errorf("expected email 'test@test.com', got %q", user.Email)
+	if session.User.Email != "test@test.com" {
+		t.Errorf("expected email 'test@test.com', got %q", session.User.Email)
+	}
+	if session.IPAddress != "127.0.0.1" {
+		t.Errorf("expected IP '127.0.0.1', got %q", session.IPAddress)
+	}
+	if session.UAHash == "" {
+		t.Error("expected non-empty UA hash")
 	}
 }
 
 func TestSessionInvalidToken(t *testing.T) {
 	s := testStore(t)
 
-	user, err := s.ValidateSession("padsess_invalidtoken")
+	session, err := s.ValidateSession("padsess_invalidtoken")
 	if err != nil {
 		t.Fatalf("ValidateSession error: %v", err)
 	}
-	if user != nil {
+	if session != nil {
 		t.Error("expected nil for invalid token")
 	}
 }
@@ -57,17 +66,17 @@ func TestSessionExpired(t *testing.T) {
 	u := createTestUser(t, s, "test@test.com", "Test", "password123")
 
 	// Create session with 0 TTL (already expired)
-	token, err := s.CreateSession(u.ID, "cli", 0)
+	token, err := s.CreateSession(u.ID, "cli", "127.0.0.1", "", 0)
 	if err != nil {
 		t.Fatalf("CreateSession error: %v", err)
 	}
 
 	// Should not validate
-	user, err := s.ValidateSession(token)
+	session, err := s.ValidateSession(token)
 	if err != nil {
 		t.Fatalf("ValidateSession error: %v", err)
 	}
-	if user != nil {
+	if session != nil {
 		t.Error("expected nil for expired session")
 	}
 }
@@ -76,7 +85,7 @@ func TestSessionDelete(t *testing.T) {
 	s := testStore(t)
 	u := createTestUser(t, s, "test@test.com", "Test", "password123")
 
-	token, _ := s.CreateSession(u.ID, "web", 7*24*time.Hour)
+	token, _ := s.CreateSession(u.ID, "web", "127.0.0.1", "Browser/1.0", 7*24*time.Hour)
 
 	// Delete session
 	err := s.DeleteSession(token)
@@ -85,8 +94,8 @@ func TestSessionDelete(t *testing.T) {
 	}
 
 	// Should no longer validate
-	user, _ := s.ValidateSession(token)
-	if user != nil {
+	session, _ := s.ValidateSession(token)
+	if session != nil {
 		t.Error("session should not validate after deletion")
 	}
 }
@@ -95,8 +104,8 @@ func TestDeleteUserSessions(t *testing.T) {
 	s := testStore(t)
 	u := createTestUser(t, s, "test@test.com", "Test", "password123")
 
-	token1, _ := s.CreateSession(u.ID, "web", 7*24*time.Hour)
-	token2, _ := s.CreateSession(u.ID, "cli", 30*24*time.Hour)
+	token1, _ := s.CreateSession(u.ID, "web", "127.0.0.1", "Browser/1.0", 7*24*time.Hour)
+	token2, _ := s.CreateSession(u.ID, "cli", "127.0.0.1", "CLI/1.0", 30*24*time.Hour)
 
 	// Delete all user sessions
 	err := s.DeleteUserSessions(u.ID)
@@ -105,9 +114,9 @@ func TestDeleteUserSessions(t *testing.T) {
 	}
 
 	// Neither should validate
-	user1, _ := s.ValidateSession(token1)
-	user2, _ := s.ValidateSession(token2)
-	if user1 != nil || user2 != nil {
+	s1, _ := s.ValidateSession(token1)
+	s2, _ := s.ValidateSession(token2)
+	if s1 != nil || s2 != nil {
 		t.Error("no sessions should validate after DeleteUserSessions")
 	}
 }
@@ -117,8 +126,8 @@ func TestCleanExpiredSessions(t *testing.T) {
 	u := createTestUser(t, s, "test@test.com", "Test", "password123")
 
 	// Create one expired and one valid session
-	s.CreateSession(u.ID, "expired", 0)
-	validToken, _ := s.CreateSession(u.ID, "valid", 7*24*time.Hour)
+	s.CreateSession(u.ID, "expired", "", "", 0)
+	validToken, _ := s.CreateSession(u.ID, "valid", "127.0.0.1", "", 7*24*time.Hour)
 
 	// Clean expired
 	err := s.CleanExpiredSessions()
@@ -127,9 +136,40 @@ func TestCleanExpiredSessions(t *testing.T) {
 	}
 
 	// Valid session should still work
-	user, _ := s.ValidateSession(validToken)
-	if user == nil {
+	session, _ := s.ValidateSession(validToken)
+	if session == nil {
 		t.Error("valid session should survive cleanup")
+	}
+}
+
+func TestSessionBindingMetadata(t *testing.T) {
+	s := testStore(t)
+	u := createTestUser(t, s, "test@test.com", "Test", "password123")
+
+	// Create session without binding metadata
+	token, _ := s.CreateSession(u.ID, "cli", "", "", 1*time.Hour)
+	session, _ := s.ValidateSession(token)
+	if session == nil {
+		t.Fatal("expected valid session")
+	}
+	if session.IPAddress != "" {
+		t.Errorf("expected empty IP, got %q", session.IPAddress)
+	}
+	if session.UAHash != "" {
+		t.Errorf("expected empty UA hash, got %q", session.UAHash)
+	}
+
+	// Create session with binding metadata
+	token2, _ := s.CreateSession(u.ID, "web", "192.168.1.1", "Mozilla/5.0", 1*time.Hour)
+	session2, _ := s.ValidateSession(token2)
+	if session2 == nil {
+		t.Fatal("expected valid session")
+	}
+	if session2.IPAddress != "192.168.1.1" {
+		t.Errorf("expected IP '192.168.1.1', got %q", session2.IPAddress)
+	}
+	if session2.UAHash == "" {
+		t.Error("expected non-empty UA hash for session with User-Agent")
 	}
 }
 
@@ -249,17 +289,17 @@ func TestCreateTestUserHelper(t *testing.T) {
 	}
 
 	// Should be reusable for sessions
-	token, err := s.CreateSession(u.ID, "test", 1*time.Hour)
+	token, err := s.CreateSession(u.ID, "test", "127.0.0.1", "TestAgent", 1*time.Hour)
 	if err != nil {
 		t.Fatalf("CreateSession with test user error: %v", err)
 	}
 
-	user, err := s.ValidateSession(token)
+	session, err := s.ValidateSession(token)
 	if err != nil {
 		t.Fatalf("ValidateSession error: %v", err)
 	}
-	if user.Email != "helper@test.com" {
-		t.Errorf("expected email 'helper@test.com', got %q", user.Email)
+	if session.User.Email != "helper@test.com" {
+		t.Errorf("expected email 'helper@test.com', got %q", session.User.Email)
 	}
 }
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -142,6 +142,7 @@ func (s *Store) migrate() error {
 		"023_parent_link_type.sql",
 		"024_phases_to_plans.sql",
 		"025_doc_type_plan.sql",
+		"026_session_binding.sql",
 	}
 
 	for _, name := range migrations {
@@ -191,6 +192,7 @@ func (s *Store) migratePostgres() error {
 		"003_parent_link_type.sql",
 		"004_doc_type_plan.sql",
 		"005_phases_to_plans.sql",
+		"006_session_binding.sql",
 	}
 
 	for _, name := range migrations {

--- a/internal/store/users.go
+++ b/internal/store/users.go
@@ -9,7 +9,7 @@ import (
 	"golang.org/x/crypto/bcrypt"
 )
 
-const bcryptCost = 10
+const bcryptCost = 12
 
 // CreateUser creates a new user with a hashed password.
 func (s *Store) CreateUser(input models.UserCreate) (*models.User, error) {

--- a/internal/store/workspace_members.go
+++ b/internal/store/workspace_members.go
@@ -180,7 +180,7 @@ func (s *Store) CreateInvitation(workspaceID, email, role, invitedBy string) (*m
 	_, err := s.db.Exec(s.q(`
 		INSERT INTO workspace_invitations (id, workspace_id, email, role, invited_by, code, code_hash, created_at)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-	`), id, workspaceID, strings.ToLower(strings.TrimSpace(email)), role, invitedBy, "", codeHash, ts)
+	`), id, workspaceID, strings.ToLower(strings.TrimSpace(email)), role, invitedBy, id, codeHash, ts)
 	if err != nil {
 		return nil, fmt.Errorf("insert invitation: %w", err)
 	}

--- a/internal/store/workspace_members.go
+++ b/internal/store/workspace_members.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"crypto/rand"
+	"crypto/sha256"
 	"database/sql"
 	"encoding/hex"
 	"fmt"
@@ -159,26 +160,38 @@ func (s *Store) UpdateWorkspaceMemberRole(workspaceID, userID, role string) erro
 // --- Invitations ---
 
 // CreateInvitation creates a pending workspace invitation.
+// Generates a 128-bit (16-byte) random code and stores only its SHA-256 hash.
+// The plaintext code is returned once to be shared with the invitee.
 func (s *Store) CreateInvitation(workspaceID, email, role, invitedBy string) (*models.WorkspaceInvitation, error) {
-	// Generate a random 8-char join code
-	raw := make([]byte, 4)
+	// Generate a random 128-bit join code (32 hex chars)
+	raw := make([]byte, 16)
 	if _, err := rand.Read(raw); err != nil {
 		return nil, fmt.Errorf("generate invitation code: %w", err)
 	}
 	code := hex.EncodeToString(raw)
 
+	// Store SHA-256 hash of the code (plaintext never stored)
+	hash := sha256.Sum256([]byte(code))
+	codeHash := hex.EncodeToString(hash[:])
+
 	id := newID()
 	ts := now()
 
 	_, err := s.db.Exec(s.q(`
-		INSERT INTO workspace_invitations (id, workspace_id, email, role, invited_by, code, created_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?)
-	`), id, workspaceID, strings.ToLower(strings.TrimSpace(email)), role, invitedBy, code, ts)
+		INSERT INTO workspace_invitations (id, workspace_id, email, role, invited_by, code, code_hash, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+	`), id, workspaceID, strings.ToLower(strings.TrimSpace(email)), role, invitedBy, "", codeHash, ts)
 	if err != nil {
 		return nil, fmt.Errorf("insert invitation: %w", err)
 	}
 
-	return s.GetInvitation(id)
+	inv, err := s.GetInvitation(id)
+	if err != nil {
+		return nil, err
+	}
+	// Return the plaintext code to the caller (not stored in DB)
+	inv.Code = code
+	return inv, nil
 }
 
 // GetInvitation retrieves an invitation by ID.
@@ -207,12 +220,36 @@ func (s *Store) GetInvitation(id string) (*models.WorkspaceInvitation, error) {
 }
 
 // GetInvitationByCode retrieves a pending invitation by its join code.
+// Looks up by SHA-256 hash first (new invitations), then falls back to
+// plaintext lookup for legacy invitations created before hashing.
 func (s *Store) GetInvitationByCode(code string) (*models.WorkspaceInvitation, error) {
+	// Hash the provided code for lookup
+	hash := sha256.Sum256([]byte(code))
+	codeHash := hex.EncodeToString(hash[:])
+
 	var inv models.WorkspaceInvitation
 	var acceptedAt *string
 	var createdAt string
 
+	// Try hashed lookup first (new invitations)
 	err := s.db.QueryRow(s.q(`
+		SELECT id, workspace_id, email, role, invited_by, code, accepted_at, created_at
+		FROM workspace_invitations WHERE code_hash = ? AND accepted_at IS NULL
+	`), codeHash).Scan(
+		&inv.ID, &inv.WorkspaceID, &inv.Email, &inv.Role, &inv.InvitedBy,
+		&inv.Code, &acceptedAt, &createdAt,
+	)
+	if err == nil {
+		inv.CreatedAt = parseTime(createdAt)
+		inv.AcceptedAt = parseTimePtr(acceptedAt)
+		return &inv, nil
+	}
+	if err != sql.ErrNoRows {
+		return nil, fmt.Errorf("get invitation by code hash: %w", err)
+	}
+
+	// Fall back to plaintext lookup (legacy invitations)
+	err = s.db.QueryRow(s.q(`
 		SELECT id, workspace_id, email, role, invited_by, code, accepted_at, created_at
 		FROM workspace_invitations WHERE code = ? AND accepted_at IS NULL
 	`), code).Scan(


### PR DESCRIPTION
## Summary
- **Session binding:** Sessions are bound to the User-Agent hash at creation; requests from a different UA invalidate the session (prevents session theft). Client IP is stored for audit trail.
- **Bcrypt cost 10 → 12:** ~4x slower brute-force for new passwords. Existing hashes continue to work transparently.
- **Invitation codes upgraded:** 128-bit entropy (was 32-bit), stored as SHA-256 hash (was plaintext). Legacy plaintext codes still work via fallback lookup.
- **Nonce-based CSP:** Replaces `'unsafe-inline'` in `script-src` with per-request cryptographic nonces injected into SvelteKit's inline `<script>` tags. API routes get strict `script-src 'self'`.
- **SecurityHeaders moved to main router:** SPA responses now receive all security headers (X-Frame-Options, X-Content-Type-Options, etc.) — previously they were only applied to API routes.

Implements TASK-171 under PLAN-15 (Pad Cloud: Hardening).

## Test plan
- [x] All Go tests pass (`go test ./...`)
- [x] Web UI builds cleanly (`npm run build`)
- [x] Verified nonce injection: each HTML response has a unique nonce matching the CSP header
- [x] Verified API routes get strict CSP without `unsafe-inline`
- [x] Verified existing sessions continue to work (migration adds columns with defaults)
- [ ] Manual: log in via web, verify session persists across page reloads
- [ ] Manual: log in via CLI (`pad auth login`), verify commands work
- [ ] Manual: create a workspace invitation, accept it with the new 32-char code