### PR TITLE
feat: add TOTP two-factor authentication

### DIFF
--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -504,6 +504,30 @@ func doLogin(client *cli.Client, cfg *config.Config) error {
 		return fmt.Errorf("login failed: %w", err)
 	}
 
+	// Handle 2FA challenge
+	if resp.Requires2FA {
+		fmt.Println("  Two-factor authentication is required.")
+		fmt.Print("  TOTP code (or recovery code): ")
+		codeInput, _ := reader.ReadString('\n')
+		codeInput = strings.TrimSpace(codeInput)
+		if codeInput == "" {
+			return fmt.Errorf("2FA code is required")
+		}
+
+		// Determine if this is a TOTP code (6 digits) or a recovery code
+		var totpCode, recoveryCode string
+		if len(codeInput) == 6 && isAllDigits(codeInput) {
+			totpCode = codeInput
+		} else {
+			recoveryCode = codeInput
+		}
+
+		resp, err = client.LoginVerify2FA(resp.ChallengeToken, totpCode, recoveryCode)
+		if err != nil {
+			return fmt.Errorf("2FA verification failed: %w", err)
+		}
+	}
+
 	if err := saveCredentials(cfg, resp); err != nil {
 		return err
 	}
@@ -511,6 +535,15 @@ func doLogin(client *cli.Client, cfg *config.Config) error {
 	green := color.New(color.FgGreen).SprintFunc()
 	fmt.Printf("%s Logged in as %s (%s)\n", green("✓"), resp.User.Name, resp.User.Email)
 	return nil
+}
+
+func isAllDigits(s string) bool {
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			return false
+		}
+	}
+	return len(s) > 0
 }
 
 func promptForAccountDetails() (string, string, string, error) {

--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -273,6 +273,11 @@ func serveCmd() *cobra.Command {
 			// Platform settings can override or provide email config
 			srv.InitEmailFromSettings()
 
+			// Initialize 2FA challenge signing key (persisted in platform_settings)
+			if err := srv.Init2FASecret(); err != nil {
+				return fmt.Errorf("init 2FA secret: %w", err)
+			}
+
 			// Mount embedded web UI if available
 			webFS, err := fs.Sub(pad.WebUI, "web/build")
 			if err == nil {

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
@@ -31,6 +32,7 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
+	github.com/pquerna/otp v1.5.0 // indirect
 	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc h1:biVzkmvwrH8WK8raXaxBx6fRVTlJILwEwQGL1I/ByEI=
+github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
 github.com/bsm/ginkgo/v2 v2.12.0/go.mod h1:SwYbGRRDovPVboqFv0tPTcG1sN61LM1Z4ARdbAV9g4c=
 github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=
@@ -53,6 +55,8 @@ github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOF
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/pquerna/otp v1.5.0 h1:NMMR+WrmaqXU4EzdGJEE1aUUI0AMRzsp96fFFWNPwxs=
+github.com/pquerna/otp v1.5.0/go.mod h1:dkJfzwRKNiegxyNb54X/3fLwhCynbMspSyWKnvi1AEg=
 github.com/prometheus/client_golang v1.23.2 h1:Je96obch5RDVy3FDMndoUsjAhG5Edi49h0RJWRi/o0o=
 github.com/prometheus/client_golang v1.23.2/go.mod h1:Tb1a6LWHB3/SPIzCoaDXI4I8UHKeFTEQ1YCr+0Gyqmg=
 github.com/prometheus/client_model v0.6.2 h1:oBsgwpGs7iVziMvrGhE53c/GrLUsZdHnqNwqPLxwZyk=

--- a/internal/cli/client.go
+++ b/internal/cli/client.go
@@ -391,8 +391,10 @@ func (c *Client) PostRaw(path string, data []byte, result interface{}) error {
 
 // LoginResponse is the response from POST /auth/login.
 type LoginResponse struct {
-	User  LoginUser `json:"user"`
-	Token string    `json:"token"`
+	User           LoginUser `json:"user"`
+	Token          string    `json:"token"`
+	Requires2FA    bool      `json:"requires_2fa,omitempty"`
+	ChallengeToken string    `json:"challenge_token,omitempty"`
 }
 
 // LoginUser is the user info returned from auth endpoints.
@@ -419,6 +421,22 @@ func (c *Client) Login(email, password string) (*LoginResponse, error) {
 		"email":    email,
 		"password": password,
 	}, &result)
+	return &result, err
+}
+
+// LoginVerify2FA completes a 2FA login by submitting a TOTP or recovery code.
+func (c *Client) LoginVerify2FA(challengeToken, code, recoveryCode string) (*LoginResponse, error) {
+	var result LoginResponse
+	body := map[string]string{
+		"challenge_token": challengeToken,
+	}
+	if code != "" {
+		body["code"] = code
+	}
+	if recoveryCode != "" {
+		body["recovery_code"] = recoveryCode
+	}
+	err := c.post("/auth/2fa/login-verify", body, &result)
 	return &result, err
 }
 

--- a/internal/models/activity.go
+++ b/internal/models/activity.go
@@ -19,6 +19,8 @@ const (
 	ActionTokenCreated    = "token_created"
 	ActionTokenRevoked    = "token_revoked"
 	ActionTokenRotated    = "token_rotated"
+	ActionTOTPEnabled     = "totp_enabled"
+	ActionTOTPDisabled    = "totp_disabled"
 	ActionMemberInvited   = "member_invited"
 	ActionMemberRemoved   = "member_removed"
 	ActionRoleChanged     = "role_changed"

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -4,14 +4,17 @@ import "time"
 
 // User represents a registered user in the system.
 type User struct {
-	ID           string    `json:"id"`
-	Email        string    `json:"email"`
-	Name         string    `json:"name"`
-	PasswordHash string    `json:"-"` // Never serialized
-	Role         string    `json:"role"` // "admin" or "member"
-	AvatarURL    string    `json:"avatar_url,omitempty"`
-	CreatedAt    time.Time `json:"created_at"`
-	UpdatedAt    time.Time `json:"updated_at"`
+	ID             string    `json:"id"`
+	Email          string    `json:"email"`
+	Name           string    `json:"name"`
+	PasswordHash   string    `json:"-"`                       // Never serialized
+	Role           string    `json:"role"`                    // "admin" or "member"
+	AvatarURL      string    `json:"avatar_url,omitempty"`
+	TOTPSecret     string    `json:"-"`                       // Never serialized
+	TOTPEnabled    bool      `json:"totp_enabled"`
+	RecoveryCodes  string    `json:"-"`                       // Never serialized
+	CreatedAt      time.Time `json:"created_at"`
+	UpdatedAt      time.Time `json:"updated_at"`
 }
 
 // UserCreate is the input for registering a new user.

--- a/internal/server/handlers_2fa.go
+++ b/internal/server/handlers_2fa.go
@@ -26,6 +26,11 @@ const (
 // for the user to scan with their authenticator app. The secret is stored
 // but 2FA is not enabled until verified via /auth/2fa/verify.
 func (s *Server) handleTOTPSetup(w http.ResponseWriter, r *http.Request) {
+	if isAPITokenAuth(r) {
+		writeError(w, http.StatusForbidden, "forbidden", "2FA management requires an interactive session, not an API token")
+		return
+	}
+
 	user := currentUser(r)
 	if user == nil {
 		writeError(w, http.StatusUnauthorized, "unauthorized", "Not logged in")
@@ -63,6 +68,11 @@ func (s *Server) handleTOTPSetup(w http.ResponseWriter, r *http.Request) {
 // enables 2FA if valid. The secret must match the one stored in the database
 // (set during setup) to prevent TOCTOU races. Returns recovery codes.
 func (s *Server) handleTOTPVerify(w http.ResponseWriter, r *http.Request) {
+	if isAPITokenAuth(r) {
+		writeError(w, http.StatusForbidden, "forbidden", "2FA management requires an interactive session, not an API token")
+		return
+	}
+
 	user := currentUser(r)
 	if user == nil {
 		writeError(w, http.StatusUnauthorized, "unauthorized", "Not logged in")
@@ -126,6 +136,11 @@ func (s *Server) handleTOTPVerify(w http.ResponseWriter, r *http.Request) {
 // handleTOTPDisable disables 2FA for the current user. Requires the
 // current password for verification.
 func (s *Server) handleTOTPDisable(w http.ResponseWriter, r *http.Request) {
+	if isAPITokenAuth(r) {
+		writeError(w, http.StatusForbidden, "forbidden", "2FA management requires an interactive session, not an API token")
+		return
+	}
+
 	user := currentUser(r)
 	if user == nil {
 		writeError(w, http.StatusUnauthorized, "unauthorized", "Not logged in")

--- a/internal/server/handlers_2fa.go
+++ b/internal/server/handlers_2fa.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
 	"net/http"
@@ -58,8 +59,9 @@ func (s *Server) handleTOTPSetup(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// handleTOTPVerify verifies a TOTP code against the stored secret and
-// enables 2FA if valid. Returns recovery codes.
+// handleTOTPVerify verifies a TOTP code against the provided secret and
+// enables 2FA if valid. The secret must match the one stored in the database
+// (set during setup) to prevent TOCTOU races. Returns recovery codes.
 func (s *Server) handleTOTPVerify(w http.ResponseWriter, r *http.Request) {
 	user := currentUser(r)
 	if user == nil {
@@ -72,20 +74,9 @@ func (s *Server) handleTOTPVerify(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Re-fetch user to get the latest secret (may have been set in setup)
-	user, err := s.store.GetUser(user.ID)
-	if err != nil || user == nil {
-		writeInternalError(w, fmt.Errorf("fetch user: %w", err))
-		return
-	}
-
-	if user.TOTPSecret == "" {
-		writeError(w, http.StatusBadRequest, "bad_request", "Call /auth/2fa/setup first to generate a secret")
-		return
-	}
-
 	var input struct {
-		Code string `json:"code"`
+		Code   string `json:"code"`
+		Secret string `json:"secret"`
 	}
 	if err := decodeJSON(r, &input); err != nil {
 		writeError(w, http.StatusBadRequest, "bad_request", "Invalid request body")
@@ -93,27 +84,34 @@ func (s *Server) handleTOTPVerify(w http.ResponseWriter, r *http.Request) {
 	}
 
 	input.Code = strings.TrimSpace(input.Code)
+	input.Secret = strings.TrimSpace(input.Secret)
+
 	if input.Code == "" {
 		writeError(w, http.StatusBadRequest, "validation_error", "TOTP code is required")
 		return
 	}
+	if input.Secret == "" {
+		writeError(w, http.StatusBadRequest, "validation_error", "Secret is required (from /auth/2fa/setup)")
+		return
+	}
 
-	// Validate the code
-	if !totp.Validate(input.Code, user.TOTPSecret) {
+	// Validate the code against the secret the client has
+	if !totp.Validate(input.Code, input.Secret) {
 		writeError(w, http.StatusUnauthorized, "invalid_code", "Invalid TOTP code. Please try again.")
 		return
 	}
 
-	// Generate recovery codes
+	// Generate recovery codes (plaintext for the user, hashed for storage)
 	codes, err := generateRecoveryCodes(recoveryCodeCount)
 	if err != nil {
 		writeInternalError(w, fmt.Errorf("generate recovery codes: %w", err))
 		return
 	}
+	hashedCodes := hashRecoveryCodes(codes)
 
-	// Enable 2FA
-	if err := s.store.EnableTOTP(user.ID, strings.Join(codes, "\n")); err != nil {
-		writeInternalError(w, err)
+	// Atomically enable 2FA only if the DB secret still matches (prevents TOCTOU race)
+	if err := s.store.EnableTOTP(user.ID, input.Secret, strings.Join(hashedCodes, "\n")); err != nil {
+		writeError(w, http.StatusConflict, "conflict", "TOTP secret changed during verification. Please run setup again.")
 		return
 	}
 
@@ -177,20 +175,22 @@ func (s *Server) handleTOTPDisable(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleTOTPLoginVerify completes a login that requires 2FA verification.
-// Accepts a TOTP code or a recovery code and returns a full session.
+// Requires a valid challenge token (from the login response) plus a TOTP
+// code or recovery code. The challenge token is HMAC-signed, IP-bound,
+// and short-lived to prove the user already passed password verification.
 func (s *Server) handleTOTPLoginVerify(w http.ResponseWriter, r *http.Request) {
 	var input struct {
-		UserID       string `json:"user_id"`
-		Code         string `json:"code"`
-		RecoveryCode string `json:"recovery_code"`
+		ChallengeToken string `json:"challenge_token"`
+		Code           string `json:"code"`
+		RecoveryCode   string `json:"recovery_code"`
 	}
 	if err := decodeJSON(r, &input); err != nil {
 		writeError(w, http.StatusBadRequest, "bad_request", "Invalid request body")
 		return
 	}
 
-	if input.UserID == "" {
-		writeError(w, http.StatusBadRequest, "validation_error", "user_id is required")
+	if input.ChallengeToken == "" {
+		writeError(w, http.StatusBadRequest, "validation_error", "challenge_token is required")
 		return
 	}
 
@@ -202,7 +202,15 @@ func (s *Server) handleTOTPLoginVerify(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	user, err := s.store.GetUser(input.UserID)
+	// Validate the challenge token (proves password was verified, checks IP + expiry)
+	userID, err := validateTwoFAChallenge(input.ChallengeToken, clientIP(r), s.twoFAChallengeSecret)
+	if err != nil {
+		time.Sleep(500 * time.Millisecond)
+		writeError(w, http.StatusUnauthorized, "unauthorized", "Invalid or expired 2FA challenge")
+		return
+	}
+
+	user, err := s.store.GetUser(userID)
 	if err != nil {
 		writeInternalError(w, err)
 		return
@@ -222,7 +230,7 @@ func (s *Server) handleTOTPLoginVerify(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Try recovery code
+	// Try recovery code (hashed comparison)
 	if !verified && input.RecoveryCode != "" {
 		consumed, err := s.store.ConsumeRecoveryCode(user.ID, input.RecoveryCode)
 		if err != nil {
@@ -263,4 +271,14 @@ func generateRecoveryCodes(n int) ([]string, error) {
 		codes[i] = hex.EncodeToString(b)
 	}
 	return codes, nil
+}
+
+// hashRecoveryCodes returns SHA-256 hex hashes of the given plaintext codes.
+func hashRecoveryCodes(codes []string) []string {
+	hashed := make([]string, len(codes))
+	for i, c := range codes {
+		h := sha256.Sum256([]byte(c))
+		hashed[i] = hex.EncodeToString(h[:])
+	}
+	return hashed
 }

--- a/internal/server/handlers_2fa.go
+++ b/internal/server/handlers_2fa.go
@@ -1,0 +1,266 @@
+package server
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/pquerna/otp/totp"
+
+	"github.com/xarmian/pad/internal/models"
+)
+
+const (
+	// totpIssuer is the issuer name shown in authenticator apps.
+	totpIssuer = "Pad"
+
+	// recoveryCodeCount is the number of recovery codes generated.
+	recoveryCodeCount = 8
+)
+
+// handleTOTPSetup generates a TOTP secret and returns the provisioning URI
+// for the user to scan with their authenticator app. The secret is stored
+// but 2FA is not enabled until verified via /auth/2fa/verify.
+func (s *Server) handleTOTPSetup(w http.ResponseWriter, r *http.Request) {
+	user := currentUser(r)
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, "unauthorized", "Not logged in")
+		return
+	}
+
+	if user.TOTPEnabled {
+		writeError(w, http.StatusConflict, "conflict", "2FA is already enabled. Disable it first to reconfigure.")
+		return
+	}
+
+	// Generate TOTP key
+	key, err := totp.Generate(totp.GenerateOpts{
+		Issuer:      totpIssuer,
+		AccountName: user.Email,
+	})
+	if err != nil {
+		writeInternalError(w, fmt.Errorf("generate totp key: %w", err))
+		return
+	}
+
+	// Store the secret (not yet enabled)
+	if err := s.store.SetTOTPSecret(user.ID, key.Secret()); err != nil {
+		writeInternalError(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"secret": key.Secret(),
+		"url":    key.URL(),
+	})
+}
+
+// handleTOTPVerify verifies a TOTP code against the stored secret and
+// enables 2FA if valid. Returns recovery codes.
+func (s *Server) handleTOTPVerify(w http.ResponseWriter, r *http.Request) {
+	user := currentUser(r)
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, "unauthorized", "Not logged in")
+		return
+	}
+
+	if user.TOTPEnabled {
+		writeError(w, http.StatusConflict, "conflict", "2FA is already enabled")
+		return
+	}
+
+	// Re-fetch user to get the latest secret (may have been set in setup)
+	user, err := s.store.GetUser(user.ID)
+	if err != nil || user == nil {
+		writeInternalError(w, fmt.Errorf("fetch user: %w", err))
+		return
+	}
+
+	if user.TOTPSecret == "" {
+		writeError(w, http.StatusBadRequest, "bad_request", "Call /auth/2fa/setup first to generate a secret")
+		return
+	}
+
+	var input struct {
+		Code string `json:"code"`
+	}
+	if err := decodeJSON(r, &input); err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", "Invalid request body")
+		return
+	}
+
+	input.Code = strings.TrimSpace(input.Code)
+	if input.Code == "" {
+		writeError(w, http.StatusBadRequest, "validation_error", "TOTP code is required")
+		return
+	}
+
+	// Validate the code
+	if !totp.Validate(input.Code, user.TOTPSecret) {
+		writeError(w, http.StatusUnauthorized, "invalid_code", "Invalid TOTP code. Please try again.")
+		return
+	}
+
+	// Generate recovery codes
+	codes, err := generateRecoveryCodes(recoveryCodeCount)
+	if err != nil {
+		writeInternalError(w, fmt.Errorf("generate recovery codes: %w", err))
+		return
+	}
+
+	// Enable 2FA
+	if err := s.store.EnableTOTP(user.ID, strings.Join(codes, "\n")); err != nil {
+		writeInternalError(w, err)
+		return
+	}
+
+	s.logAuditEvent(models.ActionTOTPEnabled, r, "")
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"enabled":        true,
+		"recovery_codes": codes,
+	})
+}
+
+// handleTOTPDisable disables 2FA for the current user. Requires the
+// current password for verification.
+func (s *Server) handleTOTPDisable(w http.ResponseWriter, r *http.Request) {
+	user := currentUser(r)
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, "unauthorized", "Not logged in")
+		return
+	}
+
+	if !user.TOTPEnabled {
+		writeError(w, http.StatusBadRequest, "bad_request", "2FA is not enabled")
+		return
+	}
+
+	var input struct {
+		Password string `json:"password"`
+	}
+	if err := decodeJSON(r, &input); err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", "Invalid request body")
+		return
+	}
+
+	if input.Password == "" {
+		writeError(w, http.StatusBadRequest, "validation_error", "Password is required to disable 2FA")
+		return
+	}
+
+	// Verify password
+	valid, err := s.store.ValidatePassword(user.Email, input.Password)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	if valid == nil {
+		time.Sleep(500 * time.Millisecond)
+		writeError(w, http.StatusForbidden, "invalid_password", "Incorrect password")
+		return
+	}
+
+	if err := s.store.DisableTOTP(user.ID); err != nil {
+		writeInternalError(w, err)
+		return
+	}
+
+	s.logAuditEvent(models.ActionTOTPDisabled, r, "")
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"enabled": false,
+	})
+}
+
+// handleTOTPLoginVerify completes a login that requires 2FA verification.
+// Accepts a TOTP code or a recovery code and returns a full session.
+func (s *Server) handleTOTPLoginVerify(w http.ResponseWriter, r *http.Request) {
+	var input struct {
+		UserID       string `json:"user_id"`
+		Code         string `json:"code"`
+		RecoveryCode string `json:"recovery_code"`
+	}
+	if err := decodeJSON(r, &input); err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", "Invalid request body")
+		return
+	}
+
+	if input.UserID == "" {
+		writeError(w, http.StatusBadRequest, "validation_error", "user_id is required")
+		return
+	}
+
+	input.Code = strings.TrimSpace(input.Code)
+	input.RecoveryCode = strings.TrimSpace(input.RecoveryCode)
+
+	if input.Code == "" && input.RecoveryCode == "" {
+		writeError(w, http.StatusBadRequest, "validation_error", "A TOTP code or recovery code is required")
+		return
+	}
+
+	user, err := s.store.GetUser(input.UserID)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	if user == nil || !user.TOTPEnabled {
+		time.Sleep(500 * time.Millisecond)
+		writeError(w, http.StatusUnauthorized, "unauthorized", "Invalid 2FA verification")
+		return
+	}
+
+	verified := false
+
+	// Try TOTP code first
+	if input.Code != "" {
+		if totp.Validate(input.Code, user.TOTPSecret) {
+			verified = true
+		}
+	}
+
+	// Try recovery code
+	if !verified && input.RecoveryCode != "" {
+		consumed, err := s.store.ConsumeRecoveryCode(user.ID, input.RecoveryCode)
+		if err != nil {
+			writeInternalError(w, err)
+			return
+		}
+		verified = consumed
+	}
+
+	if !verified {
+		time.Sleep(500 * time.Millisecond)
+		writeError(w, http.StatusUnauthorized, "invalid_code", "Invalid verification code")
+		return
+	}
+
+	// Create full session
+	token, err := s.createAuthSession(w, r, user, webSessionTTL)
+	if err != nil {
+		return
+	}
+
+	s.logAuditEventForUser(models.ActionLogin, r, user.ID, auditMeta(map[string]string{"email": user.Email, "2fa": "verified"}))
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"user":  sessionUserPayload(user),
+		"token": token,
+	})
+}
+
+// generateRecoveryCodes produces n random recovery codes (8-char hex each).
+func generateRecoveryCodes(n int) ([]string, error) {
+	codes := make([]string, n)
+	for i := 0; i < n; i++ {
+		b := make([]byte, 4)
+		if _, err := rand.Read(b); err != nil {
+			return nil, err
+		}
+		codes[i] = hex.EncodeToString(b)
+	}
+	return codes, nil
+}

--- a/internal/server/handlers_auth.go
+++ b/internal/server/handlers_auth.go
@@ -339,11 +339,13 @@ func (s *Server) handleLogin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// If 2FA is enabled, return a challenge instead of a full session
+	// If 2FA is enabled, return a challenge token instead of a full session.
+	// The challenge token is HMAC-signed, IP-bound, and expires in 5 minutes.
 	if user.TOTPEnabled {
+		challenge := generateTwoFAChallenge(user.ID, clientIP(r), s.twoFAChallengeSecret)
 		writeJSON(w, http.StatusOK, map[string]interface{}{
-			"requires_2fa": true,
-			"user_id":      user.ID,
+			"requires_2fa":    true,
+			"challenge_token": challenge,
 		})
 		return
 	}

--- a/internal/server/handlers_auth.go
+++ b/internal/server/handlers_auth.go
@@ -31,10 +31,11 @@ func sessionUserPayload(user *models.User) map[string]interface{} {
 		return nil
 	}
 	return map[string]interface{}{
-		"id":    user.ID,
-		"email": user.Email,
-		"name":  user.Name,
-		"role":  user.Role,
+		"id":           user.ID,
+		"email":        user.Email,
+		"name":         user.Name,
+		"role":         user.Role,
+		"totp_enabled": user.TOTPEnabled,
 	}
 }
 
@@ -335,6 +336,15 @@ func (s *Server) handleLogin(w http.ResponseWriter, r *http.Request) {
 		time.Sleep(500 * time.Millisecond)
 		s.logAuditEvent(models.ActionLoginFailed, r, auditMeta(map[string]string{"email": input.Email}))
 		writeError(w, http.StatusUnauthorized, "unauthorized", "Invalid email or password")
+		return
+	}
+
+	// If 2FA is enabled, return a challenge instead of a full session
+	if user.TOTPEnabled {
+		writeJSON(w, http.StatusOK, map[string]interface{}{
+			"requires_2fa": true,
+			"user_id":      user.ID,
+		})
 		return
 	}
 

--- a/internal/server/middleware_auth.go
+++ b/internal/server/middleware_auth.go
@@ -22,6 +22,9 @@ const (
 	ctxCurrentUser contextKey = "current_user"
 	// ctxWorkspaceRole is set by RequireWorkspaceAccess with the user's role.
 	ctxWorkspaceRole contextKey = "workspace_role"
+	// ctxIsAPIToken is set to true when the request is authenticated via an API token
+	// (as opposed to a session cookie or CLI session token).
+	ctxIsAPIToken contextKey = "is_api_token"
 )
 
 // TokenAuth middleware checks for an Authorization: Bearer pad_xxx header.
@@ -96,7 +99,7 @@ func (s *Server) TokenAuth(next http.Handler) http.Handler {
 		// Add near-expiry warning headers
 		setTokenExpiryWarning(w, apiToken)
 
-		ctx := r.Context()
+		ctx := context.WithValue(r.Context(), ctxIsAPIToken, true)
 
 		// Resolve user from token's user_id (new user-owned tokens)
 		if apiToken.UserID != "" {
@@ -222,6 +225,14 @@ func tokenWorkspaceID(r *http.Request) string {
 func currentUser(r *http.Request) *models.User {
 	u, _ := r.Context().Value(ctxCurrentUser).(*models.User)
 	return u
+}
+
+// isAPITokenAuth returns true if the request was authenticated via an API token
+// (not a session cookie or CLI session). Use this to gate sensitive operations
+// like 2FA enrollment that should require an interactive session.
+func isAPITokenAuth(r *http.Request) bool {
+	v, _ := r.Context().Value(ctxIsAPIToken).(bool)
+	return v
 }
 
 // currentUserID returns the authenticated user's ID, or empty string.

--- a/internal/server/middleware_ratelimit.go
+++ b/internal/server/middleware_ratelimit.go
@@ -136,7 +136,7 @@ func (s *Server) RateLimit(next http.Handler) http.Handler {
 		if strings.HasPrefix(path, "/api/v1/auth/") {
 			var limiter *ipRateLimiter
 			switch {
-			case path == "/api/v1/auth/login" || path == "/api/v1/auth/bootstrap":
+			case path == "/api/v1/auth/login" || path == "/api/v1/auth/bootstrap" || path == "/api/v1/auth/2fa/login-verify":
 				limiter = s.rateLimiters.Auth
 			case path == "/api/v1/auth/forgot-password" || path == "/api/v1/auth/reset-password":
 				limiter = s.rateLimiters.PasswordReset

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -42,14 +42,16 @@ type Server struct {
 	sseMaxConnections  int                   // global SSE connection limit (0 = unlimited)
 	sseMaxPerWorkspace int                   // per-workspace SSE connection limit (0 = unlimited)
 	version            string               // release version (e.g. "dev", "1.2.3")
-	commit        string               // git commit hash
-	buildTime     string               // build timestamp
+	commit              string               // git commit hash
+	buildTime           string               // build timestamp
+	twoFAChallengeSecret []byte              // HMAC key for 2FA challenge tokens
 }
 
 func New(s *store.Store) *Server {
 	return &Server{
-		store:        s,
-		rateLimiters: NewRateLimiters(),
+		store:                s,
+		rateLimiters:         NewRateLimiters(),
+		twoFAChallengeSecret: generateTwoFASecret(),
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"bytes"
 	"fmt"
@@ -49,10 +50,44 @@ type Server struct {
 
 func New(s *store.Store) *Server {
 	return &Server{
-		store:                s,
-		rateLimiters:         NewRateLimiters(),
-		twoFAChallengeSecret: generateTwoFASecret(),
+		store:        s,
+		rateLimiters: NewRateLimiters(),
 	}
+}
+
+// Init2FASecret loads the 2FA challenge signing key from platform_settings.
+// If no key exists (first run), a new random key is generated and persisted.
+// This must be called before the server handles requests so that challenge
+// tokens survive process restarts and work across multiple instances.
+func (s *Server) Init2FASecret() error {
+	const settingKey = "2fa_challenge_secret"
+
+	existing, err := s.store.GetPlatformSetting(settingKey)
+	if err != nil {
+		return fmt.Errorf("load 2FA secret: %w", err)
+	}
+
+	if existing != "" {
+		decoded, err := base64.StdEncoding.DecodeString(existing)
+		if err != nil {
+			return fmt.Errorf("decode 2FA secret: %w", err)
+		}
+		s.twoFAChallengeSecret = decoded
+		return nil
+	}
+
+	// First run — generate and persist a new secret
+	secret, err := generateTwoFASecret()
+	if err != nil {
+		return err
+	}
+	encoded := base64.StdEncoding.EncodeToString(secret)
+	if err := s.store.SetPlatformSetting(settingKey, encoded); err != nil {
+		return fmt.Errorf("persist 2FA secret: %w", err)
+	}
+	s.twoFAChallengeSecret = secret
+	slog.Info("generated and persisted 2FA challenge signing key")
+	return nil
 }
 
 // SetVersion stores the build version info for the health endpoint.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -76,7 +76,9 @@ func (s *Server) Init2FASecret() error {
 		return nil
 	}
 
-	// First run — generate and persist a new secret
+	// First run — generate and persist a new secret.
+	// Multiple instances may race here on a fresh database; after persisting,
+	// re-read the winning value so all instances converge on the same key.
 	secret, err := generateTwoFASecret()
 	if err != nil {
 		return err
@@ -85,8 +87,19 @@ func (s *Server) Init2FASecret() error {
 	if err := s.store.SetPlatformSetting(settingKey, encoded); err != nil {
 		return fmt.Errorf("persist 2FA secret: %w", err)
 	}
-	s.twoFAChallengeSecret = secret
-	slog.Info("generated and persisted 2FA challenge signing key")
+
+	// Re-read to pick up whichever instance won the race (upsert may have
+	// been overwritten by a concurrent instance between our check and write).
+	final, err := s.store.GetPlatformSetting(settingKey)
+	if err != nil {
+		return fmt.Errorf("re-read 2FA secret: %w", err)
+	}
+	decoded, err := base64.StdEncoding.DecodeString(final)
+	if err != nil {
+		return fmt.Errorf("decode 2FA secret after re-read: %w", err)
+	}
+	s.twoFAChallengeSecret = decoded
+	slog.Info("initialized 2FA challenge signing key")
 	return nil
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -193,6 +193,12 @@ func (s *Server) setupRouter() {
 			r.Post("/forgot-password", s.handleForgotPassword)
 			r.Post("/reset-password", s.handleResetPassword)
 
+			// Two-factor authentication
+			r.Post("/2fa/setup", s.handleTOTPSetup)
+			r.Post("/2fa/verify", s.handleTOTPVerify)
+			r.Post("/2fa/disable", s.handleTOTPDisable)
+			r.Post("/2fa/login-verify", s.handleTOTPLoginVerify)
+
 			// User-scoped API tokens
 			r.Get("/tokens", s.handleListUserTokens)
 			r.Post("/tokens", s.handleCreateUserToken)

--- a/internal/server/twofactor_challenge.go
+++ b/internal/server/twofactor_challenge.go
@@ -14,10 +14,12 @@ import (
 const twoFAChallengeExpiry = 5 * time.Minute
 
 // generateTwoFASecret creates a random 32-byte secret for signing 2FA challenge tokens.
-func generateTwoFASecret() []byte {
+func generateTwoFASecret() ([]byte, error) {
 	b := make([]byte, 32)
-	_, _ = rand.Read(b)
-	return b
+	if _, err := rand.Read(b); err != nil {
+		return nil, fmt.Errorf("generate 2FA secret: %w", err)
+	}
+	return b, nil
 }
 
 // generateTwoFAChallenge creates a short-lived, HMAC-signed challenge token

--- a/internal/server/twofactor_challenge.go
+++ b/internal/server/twofactor_challenge.go
@@ -1,0 +1,87 @@
+package server
+
+import (
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const twoFAChallengeExpiry = 5 * time.Minute
+
+// generateTwoFASecret creates a random 32-byte secret for signing 2FA challenge tokens.
+func generateTwoFASecret() []byte {
+	b := make([]byte, 32)
+	_, _ = rand.Read(b)
+	return b
+}
+
+// generateTwoFAChallenge creates a short-lived, HMAC-signed challenge token
+// that proves the user already passed password verification. The token is
+// bound to the user ID and client IP, and expires after 5 minutes.
+func generateTwoFAChallenge(userID, clientIP string, secret []byte) string {
+	expires := time.Now().UTC().Add(twoFAChallengeExpiry).Unix()
+	payload := fmt.Sprintf("%s|%s|%d", userID, clientIP, expires)
+	encoded := base64.RawURLEncoding.EncodeToString([]byte(payload))
+
+	mac := hmac.New(sha256.New, secret)
+	mac.Write([]byte(encoded))
+	sig := base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+
+	return encoded + "." + sig
+}
+
+// validateTwoFAChallenge verifies a challenge token's signature, expiry, and
+// IP binding. Returns the user ID if valid, or an error describing the failure.
+func validateTwoFAChallenge(token, clientIP string, secret []byte) (string, error) {
+	parts := strings.SplitN(token, ".", 2)
+	if len(parts) != 2 {
+		return "", fmt.Errorf("malformed challenge token")
+	}
+
+	encoded, sig := parts[0], parts[1]
+
+	// Verify HMAC
+	mac := hmac.New(sha256.New, secret)
+	mac.Write([]byte(encoded))
+	expectedSig := base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+	if !hmac.Equal([]byte(sig), []byte(expectedSig)) {
+		return "", fmt.Errorf("invalid challenge signature")
+	}
+
+	// Decode payload
+	payloadBytes, err := base64.RawURLEncoding.DecodeString(encoded)
+	if err != nil {
+		return "", fmt.Errorf("invalid challenge encoding")
+	}
+	payload := string(payloadBytes)
+
+	fields := strings.SplitN(payload, "|", 3)
+	if len(fields) != 3 {
+		return "", fmt.Errorf("invalid challenge payload")
+	}
+
+	userID := fields[0]
+	tokenIP := fields[1]
+	expiryStr := fields[2]
+
+	// Check expiry
+	expiryUnix, err := strconv.ParseInt(expiryStr, 10, 64)
+	if err != nil {
+		return "", fmt.Errorf("invalid challenge expiry")
+	}
+	if time.Now().UTC().Unix() > expiryUnix {
+		return "", fmt.Errorf("challenge token expired")
+	}
+
+	// Check IP binding
+	if tokenIP != clientIP {
+		return "", fmt.Errorf("challenge IP mismatch")
+	}
+
+	return userID, nil
+}

--- a/internal/store/migrations/027_totp.sql
+++ b/internal/store/migrations/027_totp.sql
@@ -1,0 +1,4 @@
+-- TOTP two-factor authentication
+ALTER TABLE users ADD COLUMN totp_secret TEXT DEFAULT '';
+ALTER TABLE users ADD COLUMN totp_enabled INTEGER DEFAULT 0;
+ALTER TABLE users ADD COLUMN recovery_codes TEXT DEFAULT '';

--- a/internal/store/pgmigrations/007_totp.sql
+++ b/internal/store/pgmigrations/007_totp.sql
@@ -1,0 +1,4 @@
+-- TOTP two-factor authentication
+ALTER TABLE users ADD COLUMN IF NOT EXISTS totp_secret TEXT DEFAULT '';
+ALTER TABLE users ADD COLUMN IF NOT EXISTS totp_enabled BOOLEAN DEFAULT FALSE;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS recovery_codes TEXT DEFAULT '';

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -143,6 +143,7 @@ func (s *Store) migrate() error {
 		"024_phases_to_plans.sql",
 		"025_doc_type_plan.sql",
 		"026_session_binding.sql",
+		"027_totp.sql",
 	}
 
 	for _, name := range migrations {
@@ -193,6 +194,7 @@ func (s *Store) migratePostgres() error {
 		"004_doc_type_plan.sql",
 		"005_phases_to_plans.sql",
 		"006_session_binding.sql",
+		"007_totp.sql",
 	}
 
 	for _, name := range migrations {

--- a/internal/store/totp_test.go
+++ b/internal/store/totp_test.go
@@ -1,9 +1,16 @@
 package store
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"strings"
 	"testing"
 )
+
+func hashCode(code string) string {
+	h := sha256.Sum256([]byte(code))
+	return hex.EncodeToString(h[:])
+}
 
 func TestTOTPSetupAndEnable(t *testing.T) {
 	s := testStore(t)
@@ -32,9 +39,9 @@ func TestTOTPSetupAndEnable(t *testing.T) {
 		t.Error("TOTP should still be disabled after setting secret")
 	}
 
-	// Enable with recovery codes
-	codes := "abcd1234\nefgh5678\nijkl9012"
-	err = s.EnableTOTP(u.ID, codes)
+	// Enable with hashed recovery codes (matching the real flow)
+	hashedCodes := hashCode("abcd1234") + "\n" + hashCode("efgh5678") + "\n" + hashCode("ijkl9012")
+	err = s.EnableTOTP(u.ID, "JBSWY3DPEHPK3PXP", hashedCodes)
 	if err != nil {
 		t.Fatalf("EnableTOTP error: %v", err)
 	}
@@ -43,8 +50,27 @@ func TestTOTPSetupAndEnable(t *testing.T) {
 	if !user.TOTPEnabled {
 		t.Error("TOTP should be enabled after EnableTOTP")
 	}
-	if user.RecoveryCodes != codes {
-		t.Errorf("expected recovery codes to be stored")
+	if user.RecoveryCodes != hashedCodes {
+		t.Errorf("expected hashed recovery codes to be stored")
+	}
+}
+
+func TestTOTPEnableSecretMismatch(t *testing.T) {
+	s := testStore(t)
+	u := createTestUser(t, s, "test@test.com", "Test", "password123")
+
+	s.SetTOTPSecret(u.ID, "REALKEY123")
+
+	// Try to enable with wrong expected secret
+	err := s.EnableTOTP(u.ID, "WRONGKEY", "codes")
+	if err == nil {
+		t.Error("expected error when secret doesn't match")
+	}
+
+	// Should still be disabled
+	user, _ := s.GetUser(u.ID)
+	if user.TOTPEnabled {
+		t.Error("TOTP should not be enabled after secret mismatch")
 	}
 }
 
@@ -54,7 +80,7 @@ func TestTOTPDisable(t *testing.T) {
 
 	// Enable 2FA
 	s.SetTOTPSecret(u.ID, "JBSWY3DPEHPK3PXP")
-	s.EnableTOTP(u.ID, "code1\ncode2")
+	s.EnableTOTP(u.ID, "JBSWY3DPEHPK3PXP", "code1\ncode2")
 
 	user, _ := s.GetUser(u.ID)
 	if !user.TOTPEnabled {
@@ -83,11 +109,12 @@ func TestConsumeRecoveryCode(t *testing.T) {
 	s := testStore(t)
 	u := createTestUser(t, s, "test@test.com", "Test", "password123")
 
-	codes := "aaaa1111\nbbbb2222\ncccc3333"
+	// Store hashed codes (matching the real flow)
+	hashedCodes := hashCode("aaaa1111") + "\n" + hashCode("bbbb2222") + "\n" + hashCode("cccc3333")
 	s.SetTOTPSecret(u.ID, "JBSWY3DPEHPK3PXP")
-	s.EnableTOTP(u.ID, codes)
+	s.EnableTOTP(u.ID, "JBSWY3DPEHPK3PXP", hashedCodes)
 
-	// Consume a valid code
+	// Consume a valid code (provide plaintext, store has hash)
 	consumed, err := s.ConsumeRecoveryCode(u.ID, "bbbb2222")
 	if err != nil {
 		t.Fatalf("ConsumeRecoveryCode error: %v", err)
@@ -99,8 +126,14 @@ func TestConsumeRecoveryCode(t *testing.T) {
 	// Verify it was removed
 	user, _ := s.GetUser(u.ID)
 	remaining := strings.Split(user.RecoveryCodes, "\n")
-	if len(remaining) != 2 {
-		t.Errorf("expected 2 remaining codes, got %d: %v", len(remaining), remaining)
+	var nonEmpty int
+	for _, c := range remaining {
+		if strings.TrimSpace(c) != "" {
+			nonEmpty++
+		}
+	}
+	if nonEmpty != 2 {
+		t.Errorf("expected 2 remaining codes, got %d", nonEmpty)
 	}
 
 	// Try to consume the same code again — should fail
@@ -123,7 +156,6 @@ func TestUserFieldsSurviveTOTP(t *testing.T) {
 	s := testStore(t)
 	u := createTestUser(t, s, "test@test.com", "Test", "password123")
 
-	// Verify basic user fields still work after migration
 	user, err := s.GetUser(u.ID)
 	if err != nil {
 		t.Fatalf("GetUser error: %v", err)
@@ -131,11 +163,7 @@ func TestUserFieldsSurviveTOTP(t *testing.T) {
 	if user.Email != "test@test.com" {
 		t.Errorf("expected email 'test@test.com', got %q", user.Email)
 	}
-	if user.Name != "Test" {
-		t.Errorf("expected name 'Test', got %q", user.Name)
-	}
 
-	// GetUserByEmail should also work
 	user, err = s.GetUserByEmail("test@test.com")
 	if err != nil {
 		t.Fatalf("GetUserByEmail error: %v", err)
@@ -143,11 +171,7 @@ func TestUserFieldsSurviveTOTP(t *testing.T) {
 	if user == nil {
 		t.Fatal("expected user from GetUserByEmail")
 	}
-	if user.ID != u.ID {
-		t.Errorf("expected same user ID")
-	}
 
-	// ValidatePassword should still work
 	valid, err := s.ValidatePassword("test@test.com", "password123")
 	if err != nil {
 		t.Fatalf("ValidatePassword error: %v", err)

--- a/internal/store/totp_test.go
+++ b/internal/store/totp_test.go
@@ -1,0 +1,158 @@
+package store
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTOTPSetupAndEnable(t *testing.T) {
+	s := testStore(t)
+	u := createTestUser(t, s, "test@test.com", "Test", "password123")
+
+	// Initially TOTP is disabled
+	user, _ := s.GetUser(u.ID)
+	if user.TOTPEnabled {
+		t.Error("TOTP should be disabled initially")
+	}
+	if user.TOTPSecret != "" {
+		t.Error("TOTP secret should be empty initially")
+	}
+
+	// Set secret (setup phase)
+	err := s.SetTOTPSecret(u.ID, "JBSWY3DPEHPK3PXP")
+	if err != nil {
+		t.Fatalf("SetTOTPSecret error: %v", err)
+	}
+
+	user, _ = s.GetUser(u.ID)
+	if user.TOTPSecret != "JBSWY3DPEHPK3PXP" {
+		t.Errorf("expected secret to be stored, got %q", user.TOTPSecret)
+	}
+	if user.TOTPEnabled {
+		t.Error("TOTP should still be disabled after setting secret")
+	}
+
+	// Enable with recovery codes
+	codes := "abcd1234\nefgh5678\nijkl9012"
+	err = s.EnableTOTP(u.ID, codes)
+	if err != nil {
+		t.Fatalf("EnableTOTP error: %v", err)
+	}
+
+	user, _ = s.GetUser(u.ID)
+	if !user.TOTPEnabled {
+		t.Error("TOTP should be enabled after EnableTOTP")
+	}
+	if user.RecoveryCodes != codes {
+		t.Errorf("expected recovery codes to be stored")
+	}
+}
+
+func TestTOTPDisable(t *testing.T) {
+	s := testStore(t)
+	u := createTestUser(t, s, "test@test.com", "Test", "password123")
+
+	// Enable 2FA
+	s.SetTOTPSecret(u.ID, "JBSWY3DPEHPK3PXP")
+	s.EnableTOTP(u.ID, "code1\ncode2")
+
+	user, _ := s.GetUser(u.ID)
+	if !user.TOTPEnabled {
+		t.Fatal("TOTP should be enabled")
+	}
+
+	// Disable
+	err := s.DisableTOTP(u.ID)
+	if err != nil {
+		t.Fatalf("DisableTOTP error: %v", err)
+	}
+
+	user, _ = s.GetUser(u.ID)
+	if user.TOTPEnabled {
+		t.Error("TOTP should be disabled")
+	}
+	if user.TOTPSecret != "" {
+		t.Error("TOTP secret should be cleared")
+	}
+	if user.RecoveryCodes != "" {
+		t.Error("recovery codes should be cleared")
+	}
+}
+
+func TestConsumeRecoveryCode(t *testing.T) {
+	s := testStore(t)
+	u := createTestUser(t, s, "test@test.com", "Test", "password123")
+
+	codes := "aaaa1111\nbbbb2222\ncccc3333"
+	s.SetTOTPSecret(u.ID, "JBSWY3DPEHPK3PXP")
+	s.EnableTOTP(u.ID, codes)
+
+	// Consume a valid code
+	consumed, err := s.ConsumeRecoveryCode(u.ID, "bbbb2222")
+	if err != nil {
+		t.Fatalf("ConsumeRecoveryCode error: %v", err)
+	}
+	if !consumed {
+		t.Error("expected code to be consumed")
+	}
+
+	// Verify it was removed
+	user, _ := s.GetUser(u.ID)
+	remaining := strings.Split(user.RecoveryCodes, "\n")
+	if len(remaining) != 2 {
+		t.Errorf("expected 2 remaining codes, got %d: %v", len(remaining), remaining)
+	}
+
+	// Try to consume the same code again — should fail
+	consumed, err = s.ConsumeRecoveryCode(u.ID, "bbbb2222")
+	if err != nil {
+		t.Fatalf("ConsumeRecoveryCode error: %v", err)
+	}
+	if consumed {
+		t.Error("should not be able to consume the same code twice")
+	}
+
+	// Invalid code
+	consumed, _ = s.ConsumeRecoveryCode(u.ID, "invalid")
+	if consumed {
+		t.Error("should not consume an invalid code")
+	}
+}
+
+func TestUserFieldsSurviveTOTP(t *testing.T) {
+	s := testStore(t)
+	u := createTestUser(t, s, "test@test.com", "Test", "password123")
+
+	// Verify basic user fields still work after migration
+	user, err := s.GetUser(u.ID)
+	if err != nil {
+		t.Fatalf("GetUser error: %v", err)
+	}
+	if user.Email != "test@test.com" {
+		t.Errorf("expected email 'test@test.com', got %q", user.Email)
+	}
+	if user.Name != "Test" {
+		t.Errorf("expected name 'Test', got %q", user.Name)
+	}
+
+	// GetUserByEmail should also work
+	user, err = s.GetUserByEmail("test@test.com")
+	if err != nil {
+		t.Fatalf("GetUserByEmail error: %v", err)
+	}
+	if user == nil {
+		t.Fatal("expected user from GetUserByEmail")
+	}
+	if user.ID != u.ID {
+		t.Errorf("expected same user ID")
+	}
+
+	// ValidatePassword should still work
+	valid, err := s.ValidatePassword("test@test.com", "password123")
+	if err != nil {
+		t.Fatalf("ValidatePassword error: %v", err)
+	}
+	if valid == nil {
+		t.Error("expected valid password check")
+	}
+}

--- a/internal/store/users.go
+++ b/internal/store/users.go
@@ -1,7 +1,9 @@
 package store
 
 import (
+	"crypto/sha256"
 	"database/sql"
+	"encoding/hex"
 	"fmt"
 	"strings"
 
@@ -173,6 +175,11 @@ func (s *Store) UserCount() (int, error) {
 
 // --- TOTP 2FA ---
 
+// TODO: Encrypt TOTP secret at rest using an app-level encryption key
+// (e.g., AES-256-GCM with a key from PAD_ENCRYPTION_KEY env var).
+// The secret must remain decryptable for TOTP validation, so hashing
+// is not an option here. For now, it is stored as plaintext.
+
 // SetTOTPSecret stores the TOTP secret for a user (before 2FA is verified).
 func (s *Store) SetTOTPSecret(userID, secret string) error {
 	_, err := s.db.Exec(s.q(`UPDATE users SET totp_secret = ?, updated_at = ? WHERE id = ?`), secret, now(), userID)
@@ -182,12 +189,20 @@ func (s *Store) SetTOTPSecret(userID, secret string) error {
 	return nil
 }
 
-// EnableTOTP enables 2FA for a user and stores recovery codes.
-func (s *Store) EnableTOTP(userID, recoveryCodes string) error {
-	_, err := s.db.Exec(s.q(`UPDATE users SET totp_enabled = 1, recovery_codes = ?, updated_at = ? WHERE id = ?`),
-		recoveryCodes, now(), userID)
+// EnableTOTP atomically enables 2FA for a user and stores hashed recovery codes.
+// The expectedSecret must match the currently stored totp_secret to prevent
+// TOCTOU races (e.g., a concurrent setup call overwriting the secret).
+func (s *Store) EnableTOTP(userID, expectedSecret, hashedRecoveryCodes string) error {
+	result, err := s.db.Exec(s.q(
+		`UPDATE users SET totp_enabled = 1, recovery_codes = ?, updated_at = ?
+		 WHERE id = ? AND totp_secret = ?`),
+		hashedRecoveryCodes, now(), userID, expectedSecret)
 	if err != nil {
 		return fmt.Errorf("enable totp: %w", err)
+	}
+	n, _ := result.RowsAffected()
+	if n == 0 {
+		return fmt.Errorf("enable totp: secret mismatch or user not found")
 	}
 	return nil
 }
@@ -203,14 +218,30 @@ func (s *Store) DisableTOTP(userID string) error {
 }
 
 // ConsumeRecoveryCode validates and removes a single recovery code.
-// Returns true if the code was valid and consumed.
+// Recovery codes are stored as SHA-256 hashes. The provided plaintext
+// code is hashed before comparison. Uses a transaction to prevent
+// concurrent consumption of the same code.
 func (s *Store) ConsumeRecoveryCode(userID, code string) (bool, error) {
-	u, err := s.GetUser(userID)
-	if err != nil || u == nil {
-		return false, err
+	// Hash the input code for comparison against stored hashes
+	inputHash := sha256.Sum256([]byte(code))
+	inputHashStr := hex.EncodeToString(inputHash[:])
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return false, fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback()
+
+	var recoveryCodes string
+	err = tx.QueryRow(s.q(`SELECT recovery_codes FROM users WHERE id = ?`), userID).Scan(&recoveryCodes)
+	if err == sql.ErrNoRows {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("select recovery codes: %w", err)
 	}
 
-	codes := strings.Split(u.RecoveryCodes, "\n")
+	codes := strings.Split(recoveryCodes, "\n")
 	var remaining []string
 	found := false
 	for _, c := range codes {
@@ -218,7 +249,7 @@ func (s *Store) ConsumeRecoveryCode(userID, code string) (bool, error) {
 		if c == "" {
 			continue
 		}
-		if !found && c == code {
+		if !found && c == inputHashStr {
 			found = true
 			continue // consume this one
 		}
@@ -229,10 +260,10 @@ func (s *Store) ConsumeRecoveryCode(userID, code string) (bool, error) {
 		return false, nil
 	}
 
-	_, err = s.db.Exec(s.q(`UPDATE users SET recovery_codes = ?, updated_at = ? WHERE id = ?`),
+	_, err = tx.Exec(s.q(`UPDATE users SET recovery_codes = ?, updated_at = ? WHERE id = ?`),
 		strings.Join(remaining, "\n"), now(), userID)
 	if err != nil {
 		return false, fmt.Errorf("consume recovery code: %w", err)
 	}
-	return true, nil
+	return true, tx.Commit()
 }

--- a/internal/store/users.go
+++ b/internal/store/users.go
@@ -11,6 +11,31 @@ import (
 
 const bcryptCost = 12
 
+// user SELECT columns — used by all user queries.
+const userColumns = `id, email, name, password_hash, role, avatar_url, totp_secret, totp_enabled, recovery_codes, created_at, updated_at`
+
+// scanUser scans a user row into a User struct.
+func scanUser(row interface{ Scan(...interface{}) error }) (*models.User, error) {
+	var u models.User
+	var createdAt, updatedAt string
+
+	err := row.Scan(
+		&u.ID, &u.Email, &u.Name, &u.PasswordHash, &u.Role, &u.AvatarURL,
+		&u.TOTPSecret, &u.TOTPEnabled, &u.RecoveryCodes,
+		&createdAt, &updatedAt,
+	)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	u.CreatedAt = parseTime(createdAt)
+	u.UpdatedAt = parseTime(updatedAt)
+	return &u, nil
+}
+
 // CreateUser creates a new user with a hashed password.
 func (s *Store) CreateUser(input models.UserCreate) (*models.User, error) {
 	hash, err := bcrypt.GenerateFromPassword([]byte(input.Password), bcryptCost)
@@ -39,50 +64,21 @@ func (s *Store) CreateUser(input models.UserCreate) (*models.User, error) {
 
 // GetUser retrieves a user by ID.
 func (s *Store) GetUser(id string) (*models.User, error) {
-	var u models.User
-	var createdAt, updatedAt string
-
-	err := s.db.QueryRow(s.q(`
-		SELECT id, email, name, password_hash, role, avatar_url, created_at, updated_at
-		FROM users WHERE id = ?
-	`), id).Scan(
-		&u.ID, &u.Email, &u.Name, &u.PasswordHash, &u.Role, &u.AvatarURL,
-		&createdAt, &updatedAt,
-	)
-	if err == sql.ErrNoRows {
-		return nil, nil
-	}
+	u, err := scanUser(s.db.QueryRow(s.q(`SELECT `+userColumns+` FROM users WHERE id = ?`), id))
 	if err != nil {
 		return nil, fmt.Errorf("get user: %w", err)
 	}
-
-	u.CreatedAt = parseTime(createdAt)
-	u.UpdatedAt = parseTime(updatedAt)
-	return &u, nil
+	return u, nil
 }
 
 // GetUserByEmail retrieves a user by email address (case-insensitive).
 func (s *Store) GetUserByEmail(email string) (*models.User, error) {
-	var u models.User
-	var createdAt, updatedAt string
-
-	err := s.db.QueryRow(s.q(`
-		SELECT id, email, name, password_hash, role, avatar_url, created_at, updated_at
-		FROM users WHERE email = ?
-	`), strings.ToLower(strings.TrimSpace(email))).Scan(
-		&u.ID, &u.Email, &u.Name, &u.PasswordHash, &u.Role, &u.AvatarURL,
-		&createdAt, &updatedAt,
-	)
-	if err == sql.ErrNoRows {
-		return nil, nil
-	}
+	u, err := scanUser(s.db.QueryRow(s.q(`SELECT `+userColumns+` FROM users WHERE email = ?`),
+		strings.ToLower(strings.TrimSpace(email))))
 	if err != nil {
 		return nil, fmt.Errorf("get user by email: %w", err)
 	}
-
-	u.CreatedAt = parseTime(createdAt)
-	u.UpdatedAt = parseTime(updatedAt)
-	return &u, nil
+	return u, nil
 }
 
 // UpdateUser updates mutable user fields.
@@ -148,10 +144,7 @@ func (s *Store) ValidatePassword(email, password string) (*models.User, error) {
 
 // ListUsers returns all users.
 func (s *Store) ListUsers() ([]models.User, error) {
-	rows, err := s.db.Query(s.q(`
-		SELECT id, email, name, password_hash, role, avatar_url, created_at, updated_at
-		FROM users ORDER BY created_at ASC
-	`))
+	rows, err := s.db.Query(s.q(`SELECT ` + userColumns + ` FROM users ORDER BY created_at ASC`))
 	if err != nil {
 		return nil, fmt.Errorf("list users: %w", err)
 	}
@@ -159,17 +152,11 @@ func (s *Store) ListUsers() ([]models.User, error) {
 
 	var result []models.User
 	for rows.Next() {
-		var u models.User
-		var createdAt, updatedAt string
-		if err := rows.Scan(
-			&u.ID, &u.Email, &u.Name, &u.PasswordHash, &u.Role, &u.AvatarURL,
-			&createdAt, &updatedAt,
-		); err != nil {
+		u, err := scanUser(rows)
+		if err != nil {
 			return nil, fmt.Errorf("scan user: %w", err)
 		}
-		u.CreatedAt = parseTime(createdAt)
-		u.UpdatedAt = parseTime(updatedAt)
-		result = append(result, u)
+		result = append(result, *u)
 	}
 	return result, rows.Err()
 }
@@ -182,4 +169,70 @@ func (s *Store) UserCount() (int, error) {
 		return 0, fmt.Errorf("count users: %w", err)
 	}
 	return count, nil
+}
+
+// --- TOTP 2FA ---
+
+// SetTOTPSecret stores the TOTP secret for a user (before 2FA is verified).
+func (s *Store) SetTOTPSecret(userID, secret string) error {
+	_, err := s.db.Exec(s.q(`UPDATE users SET totp_secret = ?, updated_at = ? WHERE id = ?`), secret, now(), userID)
+	if err != nil {
+		return fmt.Errorf("set totp secret: %w", err)
+	}
+	return nil
+}
+
+// EnableTOTP enables 2FA for a user and stores recovery codes.
+func (s *Store) EnableTOTP(userID, recoveryCodes string) error {
+	_, err := s.db.Exec(s.q(`UPDATE users SET totp_enabled = 1, recovery_codes = ?, updated_at = ? WHERE id = ?`),
+		recoveryCodes, now(), userID)
+	if err != nil {
+		return fmt.Errorf("enable totp: %w", err)
+	}
+	return nil
+}
+
+// DisableTOTP disables 2FA and clears the secret and recovery codes.
+func (s *Store) DisableTOTP(userID string) error {
+	_, err := s.db.Exec(s.q(`UPDATE users SET totp_enabled = 0, totp_secret = '', recovery_codes = '', updated_at = ? WHERE id = ?`),
+		now(), userID)
+	if err != nil {
+		return fmt.Errorf("disable totp: %w", err)
+	}
+	return nil
+}
+
+// ConsumeRecoveryCode validates and removes a single recovery code.
+// Returns true if the code was valid and consumed.
+func (s *Store) ConsumeRecoveryCode(userID, code string) (bool, error) {
+	u, err := s.GetUser(userID)
+	if err != nil || u == nil {
+		return false, err
+	}
+
+	codes := strings.Split(u.RecoveryCodes, "\n")
+	var remaining []string
+	found := false
+	for _, c := range codes {
+		c = strings.TrimSpace(c)
+		if c == "" {
+			continue
+		}
+		if !found && c == code {
+			found = true
+			continue // consume this one
+		}
+		remaining = append(remaining, c)
+	}
+
+	if !found {
+		return false, nil
+	}
+
+	_, err = s.db.Exec(s.q(`UPDATE users SET recovery_codes = ?, updated_at = ? WHERE id = ?`),
+		strings.Join(remaining, "\n"), now(), userID)
+	if err != nil {
+		return false, fmt.Errorf("consume recovery code: %w", err)
+	}
+	return true, nil
 }

--- a/internal/store/users.go
+++ b/internal/store/users.go
@@ -194,9 +194,9 @@ func (s *Store) SetTOTPSecret(userID, secret string) error {
 // TOCTOU races (e.g., a concurrent setup call overwriting the secret).
 func (s *Store) EnableTOTP(userID, expectedSecret, hashedRecoveryCodes string) error {
 	result, err := s.db.Exec(s.q(
-		`UPDATE users SET totp_enabled = 1, recovery_codes = ?, updated_at = ?
+		`UPDATE users SET totp_enabled = ?, recovery_codes = ?, updated_at = ?
 		 WHERE id = ? AND totp_secret = ?`),
-		hashedRecoveryCodes, now(), userID, expectedSecret)
+		s.dialect.BoolToInt(true), hashedRecoveryCodes, now(), userID, expectedSecret)
 	if err != nil {
 		return fmt.Errorf("enable totp: %w", err)
 	}
@@ -209,8 +209,8 @@ func (s *Store) EnableTOTP(userID, expectedSecret, hashedRecoveryCodes string) e
 
 // DisableTOTP disables 2FA and clears the secret and recovery codes.
 func (s *Store) DisableTOTP(userID string) error {
-	_, err := s.db.Exec(s.q(`UPDATE users SET totp_enabled = 0, totp_secret = '', recovery_codes = '', updated_at = ? WHERE id = ?`),
-		now(), userID)
+	_, err := s.db.Exec(s.q(`UPDATE users SET totp_enabled = ?, totp_secret = '', recovery_codes = '', updated_at = ? WHERE id = ?`),
+		s.dialect.BoolToInt(false), now(), userID)
 	if err != nil {
 		return fmt.Errorf("disable totp: %w", err)
 	}
@@ -260,10 +260,18 @@ func (s *Store) ConsumeRecoveryCode(userID, code string) (bool, error) {
 		return false, nil
 	}
 
-	_, err = tx.Exec(s.q(`UPDATE users SET recovery_codes = ?, updated_at = ? WHERE id = ?`),
-		strings.Join(remaining, "\n"), now(), userID)
+	// Use optimistic locking: include the original recovery_codes in the WHERE
+	// clause so a concurrent transaction that already consumed a code will cause
+	// this UPDATE to match 0 rows, preventing double-spend.
+	result, err := tx.Exec(s.q(`UPDATE users SET recovery_codes = ?, updated_at = ? WHERE id = ? AND recovery_codes = ?`),
+		strings.Join(remaining, "\n"), now(), userID, recoveryCodes)
 	if err != nil {
 		return false, fmt.Errorf("consume recovery code: %w", err)
+	}
+	n, _ := result.RowsAffected()
+	if n == 0 {
+		// Another request consumed or modified the codes concurrently
+		return false, nil
 	}
 	return true, tx.Commit()
 }

--- a/internal/store/users.go
+++ b/internal/store/users.go
@@ -195,8 +195,8 @@ func (s *Store) SetTOTPSecret(userID, secret string) error {
 func (s *Store) EnableTOTP(userID, expectedSecret, hashedRecoveryCodes string) error {
 	result, err := s.db.Exec(s.q(
 		`UPDATE users SET totp_enabled = ?, recovery_codes = ?, updated_at = ?
-		 WHERE id = ? AND totp_secret = ?`),
-		s.dialect.BoolToInt(true), hashedRecoveryCodes, now(), userID, expectedSecret)
+		 WHERE id = ? AND totp_secret = ? AND totp_enabled = ?`),
+		s.dialect.BoolToInt(true), hashedRecoveryCodes, now(), userID, expectedSecret, s.dialect.BoolToInt(false))
 	if err != nil {
 		return fmt.Errorf("enable totp: %w", err)
 	}

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -107,6 +107,13 @@ export interface AuthSession {
 	user?: { id: string; email: string; name: string; role: string };
 }
 
+export interface LoginResponse {
+	user?: { id: string; email: string; name: string; role: string };
+	token?: string;
+	requires_2fa?: boolean;
+	challenge_token?: string;
+}
+
 export const api = {
 	// ── Health / Version ──────────────────────────────────────────────────────
 
@@ -503,9 +510,14 @@ export const api = {
 	auth: {
 		session: (): Promise<AuthSession> => fetch(BASE + '/auth/session', { credentials: 'same-origin' }).then((r) => r.json()),
 		login: (email: string, password: string) =>
-			request<{ user: { id: string; email: string; name: string; role: string }; token: string }>('/auth/login', {
+			request<LoginResponse>('/auth/login', {
 				method: 'POST',
 				body: JSON.stringify({ email, password })
+			}),
+		verify2FA: (challengeToken: string, code?: string, recoveryCode?: string) =>
+			request<{ user: { id: string; email: string; name: string; role: string }; token: string }>('/auth/2fa/login-verify', {
+				method: 'POST',
+				body: JSON.stringify({ challenge_token: challengeToken, code: code || undefined, recovery_code: recoveryCode || undefined })
 			}),
 		register: (email: string, name: string, password: string, invitation_code?: string) =>
 			request<{ user: { id: string; email: string; name: string; role: string }; token: string }>('/auth/register', {

--- a/web/src/routes/join/[code]/+page.svelte
+++ b/web/src/routes/join/[code]/+page.svelte
@@ -6,7 +6,7 @@
 	import SetupRequiredNotice from '$lib/components/auth/SetupRequiredNotice.svelte';
 
 	let code = $derived(page.params.code ?? '');
-	let status = $state<'loading' | 'login' | 'register' | 'accepting' | 'error' | 'setup'>('loading');
+	let status = $state<'loading' | 'login' | 'register' | 'accepting' | 'error' | 'setup' | '2fa'>('loading');
 	let errorMsg = $state('');
 	let setupMethod = $state<'local_cli' | 'docker_exec' | 'cloud' | undefined>(undefined);
 
@@ -18,6 +18,8 @@
 	let confirmPassword = $state('');
 	let formError = $state('');
 	let submitting = $state(false);
+	let challengeToken = $state('');
+	let totpCode = $state('');
 
 	onMount(async () => {
 		try {
@@ -72,7 +74,14 @@
 			} else {
 				if (!email.trim()) { formError = 'Email is required'; submitting = false; return; }
 				if (!password) { formError = 'Password is required'; submitting = false; return; }
-				await api.auth.login(email.trim(), password);
+				const response = await api.auth.login(email.trim(), password);
+
+				if (response.requires_2fa && response.challenge_token) {
+					challengeToken = response.challenge_token;
+					status = '2fa';
+					submitting = false;
+					return;
+				}
 			}
 			// Logged in via login — now accept the invitation
 			await acceptInvitation();
@@ -82,8 +91,49 @@
 		}
 	}
 
+	async function handleVerify2FA() {
+		formError = '';
+		const code = totpCode.trim();
+
+		if (!code) {
+			formError = 'Please enter your authentication code.';
+			return;
+		}
+
+		submitting = true;
+		try {
+			const isTotp = /^\d{6}$/.test(code);
+
+			if (isTotp) {
+				await api.auth.verify2FA(challengeToken, code, undefined);
+			} else {
+				await api.auth.verify2FA(challengeToken, undefined, code);
+			}
+
+			// 2FA verified — now accept the invitation
+			await acceptInvitation();
+		} catch (err: unknown) {
+			formError = err instanceof Error ? err.message : 'Invalid code. Please try again.';
+			submitting = false;
+		}
+	}
+
+	function handleBack2FA() {
+		status = 'login';
+		challengeToken = '';
+		totpCode = '';
+		formError = '';
+		submitting = false;
+	}
+
 	function handleKeydown(event: KeyboardEvent) {
-		if (event.key === 'Enter') handleSubmit();
+		if (event.key === 'Enter') {
+			if (status === '2fa') {
+				handleVerify2FA();
+			} else {
+				handleSubmit();
+			}
+		}
 	}
 </script>
 
@@ -105,6 +155,38 @@
 		{:else if status === 'error'}
 			<p class="subtitle error-text">{errorMsg}</p>
 			<a href="/login" class="link">Go to login</a>
+		{:else if status === '2fa'}
+			<p class="subtitle">Two-factor authentication</p>
+
+			<div class="form">
+				<p class="hint">Enter the 6-digit code from your authenticator app, or a recovery code.</p>
+
+				<input
+					type="text"
+					placeholder="Authentication code"
+					bind:value={totpCode}
+					onkeydown={handleKeydown}
+					disabled={submitting}
+					autocomplete="one-time-code"
+					inputmode="numeric"
+				/>
+
+				{#if formError}
+					<p class="error">{formError}</p>
+				{/if}
+
+				<button onclick={handleVerify2FA} disabled={submitting}>
+					{#if submitting}
+						Verifying...
+					{:else}
+						Verify & join
+					{/if}
+				</button>
+
+				<button class="back-button" onclick={handleBack2FA} disabled={submitting} type="button">
+					Back to sign in
+				</button>
+			</div>
 		{:else}
 			<p class="subtitle">You've been invited to a workspace</p>
 			<p class="hint">{mode === 'register' ? 'Create an account' : 'Sign in'} to accept</p>
@@ -209,6 +291,7 @@
 		color: var(--text-muted);
 		font-size: 0.85rem;
 		margin-bottom: var(--space-6);
+		line-height: 1.4;
 	}
 
 	.error-text {
@@ -258,6 +341,18 @@
 	}
 	button:hover:not(:disabled) { opacity: 0.9; }
 	button:disabled { opacity: 0.6; cursor: not-allowed; }
+
+	.back-button {
+		background: transparent;
+		color: var(--text-muted);
+		font-size: 0.85rem;
+		font-weight: 400;
+		padding: var(--space-2) var(--space-4);
+	}
+	.back-button:hover:not(:disabled) {
+		color: var(--text-primary);
+		opacity: 1;
+	}
 
 	.switch-mode {
 		margin-top: var(--space-6);

--- a/web/src/routes/login/+page.svelte
+++ b/web/src/routes/login/+page.svelte
@@ -12,6 +12,10 @@
 	let setupMethod = $state<'local_cli' | 'docker_exec' | 'cloud' | undefined>(undefined);
 	let loading = $state(false);
 
+	let step = $state<'credentials' | '2fa'>('credentials');
+	let challengeToken = $state('');
+	let totpCode = $state('');
+
 	onMount(async () => {
 		try {
 			const session = await api.auth.session();
@@ -40,8 +44,16 @@
 
 		loading = true;
 		try {
-			await api.auth.login(email, password);
-			await authStore.load(); // Refresh global auth state before navigating.
+			const response = await api.auth.login(email, password);
+
+			if (response.requires_2fa && response.challenge_token) {
+				challengeToken = response.challenge_token;
+				step = '2fa';
+				error = '';
+				return;
+			}
+
+			await authStore.load();
 			await goto('/', { replaceState: true });
 		} catch (err: unknown) {
 			if (err instanceof Error) {
@@ -54,9 +66,52 @@
 		}
 	}
 
+	async function handleVerify2FA() {
+		error = '';
+		const code = totpCode.trim();
+
+		if (!code) {
+			error = 'Please enter your authentication code.';
+			return;
+		}
+
+		loading = true;
+		try {
+			const isTotp = /^\d{6}$/.test(code);
+
+			if (isTotp) {
+				await api.auth.verify2FA(challengeToken, code, undefined);
+			} else {
+				await api.auth.verify2FA(challengeToken, undefined, code);
+			}
+
+			await authStore.load();
+			await goto('/', { replaceState: true });
+		} catch (err: unknown) {
+			if (err instanceof Error) {
+				error = err.message || 'Invalid code. Please try again.';
+			} else {
+				error = 'Invalid code. Please try again.';
+			}
+		} finally {
+			loading = false;
+		}
+	}
+
+	function handleBack() {
+		step = 'credentials';
+		challengeToken = '';
+		totpCode = '';
+		error = '';
+	}
+
 	function handleKeydown(event: KeyboardEvent) {
 		if (event.key === 'Enter') {
-			handleSubmit();
+			if (step === 'credentials') {
+				handleSubmit();
+			} else {
+				handleVerify2FA();
+			}
 		}
 	}
 </script>
@@ -69,6 +124,38 @@
 				{setupMethod}
 				nextStep="Once setup is complete, return here to sign in."
 			/>
+		{:else if step === '2fa'}
+			<p class="subtitle">Two-factor authentication</p>
+
+			<div class="form">
+				<p class="hint">Enter the 6-digit code from your authenticator app, or a recovery code.</p>
+
+				<input
+					type="text"
+					placeholder="Authentication code"
+					bind:value={totpCode}
+					onkeydown={handleKeydown}
+					disabled={loading}
+					autocomplete="one-time-code"
+					inputmode="numeric"
+				/>
+
+				{#if error}
+					<p class="error">{error}</p>
+				{/if}
+
+				<button onclick={handleVerify2FA} disabled={loading}>
+					{#if loading}
+						Verifying...
+					{:else}
+						Verify
+					{/if}
+				</button>
+
+				<button class="back-button" onclick={handleBack} disabled={loading} type="button">
+					Back to sign in
+				</button>
+			</div>
 		{:else}
 			<p class="subtitle">Sign in to continue</p>
 
@@ -154,6 +241,13 @@
 		gap: var(--space-4);
 	}
 
+	.hint {
+		color: var(--text-muted);
+		font-size: 0.85rem;
+		text-align: left;
+		line-height: 1.4;
+	}
+
 	input {
 		width: 100%;
 		padding: var(--space-3) var(--space-4);
@@ -206,6 +300,19 @@
 	button:disabled {
 		opacity: 0.6;
 		cursor: not-allowed;
+	}
+
+	.back-button {
+		background: transparent;
+		color: var(--text-muted);
+		font-size: 0.85rem;
+		font-weight: 400;
+		padding: var(--space-2) var(--space-4);
+	}
+
+	.back-button:hover:not(:disabled) {
+		color: var(--text-primary);
+		opacity: 1;
 	}
 
 	.register-link {


### PR DESCRIPTION
## Summary
- **TOTP 2FA:** Users can optionally enable TOTP-based two-factor authentication via any authenticator app (Google Authenticator, Authy, 1Password, etc.)
- **Setup flow:** `POST /auth/2fa/setup` generates a TOTP secret and returns a `otpauth://` URI for QR code scanning. `POST /auth/2fa/verify` validates a code and enables 2FA, returning 8 recovery codes.
- **Login flow modified:** When a user with 2FA enabled logs in, the server returns `{requires_2fa: true, user_id: "..."}` instead of a session token. The client then calls `POST /auth/2fa/login-verify` with a TOTP code or recovery code to complete authentication.
- **Recovery codes:** 8 hex codes generated on setup. Each can be used once as a TOTP fallback. Consumed codes are permanently removed.
- **Disable:** `POST /auth/2fa/disable` requires current password for security. Clears secret and recovery codes.
- **User model refactored:** Added `totp_secret`, `totp_enabled`, `recovery_codes` columns. Consolidated all user SELECT queries into a shared `scanUser`/`userColumns` pattern for maintainability.
- **Session payload updated:** `totp_enabled` is now included in user payloads so the frontend can show 2FA status.

Implements TASK-169 under PLAN-15 (Pad Cloud: Hardening).

## Test plan
- [x] All Go tests pass (`go test ./...`) — 4 new tests for TOTP store operations
- [x] Web UI builds cleanly (`npm run build`)
- [x] `make install` succeeds, server starts, existing sessions work
- [x] 2FA endpoints return proper auth errors when not logged in
- [ ] Manual: enable 2FA via setup → verify flow, confirm authenticator app works
- [ ] Manual: log in with 2FA enabled, verify two-step flow
- [ ] Manual: use a recovery code to log in, verify it gets consumed
- [ ] Manual: disable 2FA, confirm login reverts to single-step
- [ ] Frontend: 2FA setup UI in user settings (separate PR)
- [ ] CLI: `pad auth 2fa setup` and `pad auth 2fa disable` commands (separate PR)