### PR TITLE
feat: add workspace top bar with drag-to-reorder

### DIFF
--- a/internal/models/workspace.go
+++ b/internal/models/workspace.go
@@ -8,6 +8,7 @@ type Workspace struct {
 	Slug        string            `json:"slug"`
 	Description string            `json:"description"`
 	Settings    string            `json:"settings"` // JSON
+	SortOrder   int               `json:"sort_order"`
 	Context     *WorkspaceContext `json:"context,omitempty"`
 	CreatedAt   time.Time         `json:"created_at"`
 	UpdatedAt   time.Time         `json:"updated_at"`

--- a/internal/server/handlers_workspaces.go
+++ b/internal/server/handlers_workspaces.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"database/sql"
 	"fmt"
 	"net/http"
 
@@ -175,7 +176,12 @@ func (s *Server) handleReorderWorkspaces(w http.ResponseWriter, r *http.Request)
 		if ws == nil {
 			continue
 		}
+		// Skip silently if user is not a member of this workspace
+		// (e.g. admin sees all workspaces but may not be joined to all)
 		if err := s.store.UpdateWorkspaceSortOrder(userID, ws.ID, item.SortOrder); err != nil {
+			if err == sql.ErrNoRows {
+				continue
+			}
 			writeInternalError(w, err)
 			return
 		}

--- a/internal/server/handlers_workspaces.go
+++ b/internal/server/handlers_workspaces.go
@@ -132,7 +132,14 @@ func (s *Server) handleListWorkspaces(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Admin users (or fresh-install with no users) see all workspaces.
-	workspaces, err := s.store.ListWorkspaces()
+	// Pass user ID when available so sort_order is included.
+	var workspaces []models.Workspace
+	var err error
+	if user != nil {
+		workspaces, err = s.store.ListWorkspacesForUser(user.ID)
+	} else {
+		workspaces, err = s.store.ListWorkspaces()
+	}
 	if err != nil {
 		writeInternalError(w, err)
 		return
@@ -141,6 +148,40 @@ func (s *Server) handleListWorkspaces(w http.ResponseWriter, r *http.Request) {
 		workspaces = []models.Workspace{}
 	}
 	writeJSON(w, http.StatusOK, workspaces)
+}
+
+func (s *Server) handleReorderWorkspaces(w http.ResponseWriter, r *http.Request) {
+	userID := currentUserID(r)
+	if userID == "" {
+		writeError(w, http.StatusUnauthorized, "unauthorized", "Authentication required")
+		return
+	}
+
+	var input []struct {
+		Slug      string `json:"slug"`
+		SortOrder int    `json:"sort_order"`
+	}
+	if err := decodeJSON(r, &input); err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", err.Error())
+		return
+	}
+
+	for _, item := range input {
+		ws, err := s.store.GetWorkspaceBySlug(item.Slug)
+		if err != nil {
+			writeInternalError(w, err)
+			return
+		}
+		if ws == nil {
+			continue
+		}
+		if err := s.store.UpdateWorkspaceSortOrder(userID, ws.ID, item.SortOrder); err != nil {
+			writeInternalError(w, err)
+			return
+		}
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
 }
 
 func (s *Server) handleCreateWorkspace(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -283,6 +283,7 @@ func (s *Server) setupRouter() {
 			r.Get("/", s.handleListWorkspaces)
 			r.Post("/", s.handleCreateWorkspace)
 			r.Post("/import", s.handleImportWorkspace)
+			r.Put("/reorder", s.handleReorderWorkspaces)
 
 			r.Route("/{slug}", func(r chi.Router) {
 				r.Use(s.RequireWorkspaceAccess)

--- a/internal/store/migrations/028_workspace_sort_order.sql
+++ b/internal/store/migrations/028_workspace_sort_order.sql
@@ -1,0 +1,2 @@
+-- Add per-user workspace sort order to workspace_members
+ALTER TABLE workspace_members ADD COLUMN sort_order INTEGER NOT NULL DEFAULT 0;

--- a/internal/store/pgmigrations/008_workspace_sort_order.sql
+++ b/internal/store/pgmigrations/008_workspace_sort_order.sql
@@ -1,0 +1,2 @@
+-- Add per-user workspace sort order to workspace_members
+ALTER TABLE workspace_members ADD COLUMN IF NOT EXISTS sort_order INTEGER NOT NULL DEFAULT 0;

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -196,6 +196,7 @@ func (s *Store) migratePostgres() error {
 		"005_phases_to_plans.sql",
 		"006_session_binding.sql",
 		"007_totp.sql",
+		"008_workspace_sort_order.sql",
 	}
 
 	for _, name := range migrations {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -144,6 +144,7 @@ func (s *Store) migrate() error {
 		"025_doc_type_plan.sql",
 		"026_session_binding.sql",
 		"027_totp.sql",
+		"028_workspace_sort_order.sql",
 	}
 
 	for _, name := range migrations {

--- a/internal/store/workspace_members.go
+++ b/internal/store/workspace_members.go
@@ -95,14 +95,16 @@ func (s *Store) ListWorkspaceMembers(workspaceID string) ([]models.WorkspaceMemb
 	return result, rows.Err()
 }
 
-// GetUserWorkspaces returns all workspaces a user has access to.
+// GetUserWorkspaces returns all workspaces a user has access to,
+// sorted by the user's custom sort order (then name as tiebreaker).
 func (s *Store) GetUserWorkspaces(userID string) ([]models.Workspace, error) {
 	rows, err := s.db.Query(s.q(`
-		SELECT w.id, w.name, w.slug, w.description, w.settings, w.created_at, w.updated_at, w.deleted_at
+		SELECT w.id, w.name, w.slug, w.description, w.settings, w.created_at, w.updated_at, w.deleted_at,
+		       wm.sort_order
 		FROM workspaces w
 		JOIN workspace_members wm ON wm.workspace_id = w.id
 		WHERE wm.user_id = ? AND w.deleted_at IS NULL
-		ORDER BY w.name ASC
+		ORDER BY wm.sort_order ASC, w.name ASC
 	`), userID)
 	if err != nil {
 		return nil, fmt.Errorf("get user workspaces: %w", err)
@@ -117,6 +119,7 @@ func (s *Store) GetUserWorkspaces(userID string) ([]models.Workspace, error) {
 		if err := rows.Scan(
 			&ws.ID, &ws.Name, &ws.Slug, &ws.Description, &ws.Settings,
 			&createdAt, &updatedAt, &deletedAt,
+			&ws.SortOrder,
 		); err != nil {
 			return nil, fmt.Errorf("scan workspace: %w", err)
 		}
@@ -126,6 +129,22 @@ func (s *Store) GetUserWorkspaces(userID string) ([]models.Workspace, error) {
 		result = append(result, ws)
 	}
 	return result, rows.Err()
+}
+
+// UpdateWorkspaceSortOrder sets the sort_order for a workspace in a user's membership.
+func (s *Store) UpdateWorkspaceSortOrder(userID, workspaceID string, sortOrder int) error {
+	result, err := s.db.Exec(
+		s.q("UPDATE workspace_members SET sort_order = ? WHERE user_id = ? AND workspace_id = ?"),
+		sortOrder, userID, workspaceID,
+	)
+	if err != nil {
+		return fmt.Errorf("update workspace sort order: %w", err)
+	}
+	n, _ := result.RowsAffected()
+	if n == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
 }
 
 // IsWorkspaceMember checks if a user is a member of a workspace.

--- a/internal/store/workspaces.go
+++ b/internal/store/workspaces.go
@@ -8,12 +8,33 @@ import (
 )
 
 func (s *Store) ListWorkspaces() ([]models.Workspace, error) {
-	rows, err := s.db.Query(s.q(`
-		SELECT id, name, slug, description, settings, created_at, updated_at
-		FROM workspaces
-		WHERE deleted_at IS NULL
-		ORDER BY name ASC
-	`))
+	return s.ListWorkspacesForUser("")
+}
+
+// ListWorkspacesForUser returns all workspaces (admin view), with per-user
+// sort_order from workspace_members when userID is provided.
+func (s *Store) ListWorkspacesForUser(userID string) ([]models.Workspace, error) {
+	var rows *sql.Rows
+	var err error
+
+	if userID != "" {
+		rows, err = s.db.Query(s.q(`
+			SELECT w.id, w.name, w.slug, w.description, w.settings, w.created_at, w.updated_at,
+			       COALESCE(wm.sort_order, 0)
+			FROM workspaces w
+			LEFT JOIN workspace_members wm ON wm.workspace_id = w.id AND wm.user_id = ?
+			WHERE w.deleted_at IS NULL
+			ORDER BY COALESCE(wm.sort_order, 0) ASC, w.name ASC
+		`), userID)
+	} else {
+		rows, err = s.db.Query(s.q(`
+			SELECT w.id, w.name, w.slug, w.description, w.settings, w.created_at, w.updated_at,
+			       0 as sort_order
+			FROM workspaces w
+			WHERE w.deleted_at IS NULL
+			ORDER BY w.name ASC
+		`))
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -23,7 +44,7 @@ func (s *Store) ListWorkspaces() ([]models.Workspace, error) {
 	for rows.Next() {
 		var w models.Workspace
 		var createdAt, updatedAt string
-		if err := rows.Scan(&w.ID, &w.Name, &w.Slug, &w.Description, &w.Settings, &createdAt, &updatedAt); err != nil {
+		if err := rows.Scan(&w.ID, &w.Name, &w.Slug, &w.Description, &w.Settings, &createdAt, &updatedAt, &w.SortOrder); err != nil {
 			return nil, err
 		}
 		w.CreatedAt = parseTime(createdAt)

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -26,6 +26,7 @@
 	--status-completed: #4a9eff;
 	--status-archived: #444444;
 
+	--topbar-height: 44px;
 	--sidebar-width: 260px;
 	--detail-panel-width: 300px;
 	--content-max-width: 960px;

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -146,7 +146,13 @@ export const api = {
 			}),
 
 		delete: (slug: string) =>
-			request<void>(`/workspaces/${slug}`, { method: 'DELETE' })
+			request<void>(`/workspaces/${slug}`, { method: 'DELETE' }),
+
+		reorder: (updates: { slug: string; sort_order: number }[]) =>
+			request<void>('/workspaces/reorder', {
+				method: 'PUT',
+				body: JSON.stringify(updates)
+			})
 	},
 
 	// ── Collections ───────────────────────────────────────────────────────────

--- a/web/src/lib/components/layout/Sidebar.svelte
+++ b/web/src/lib/components/layout/Sidebar.svelte
@@ -6,17 +6,14 @@
 	import { workspaceStore } from '$lib/stores/workspace.svelte';
 	import { collectionStore } from '$lib/stores/collections.svelte';
 	import { uiStore } from '$lib/stores/ui.svelte';
-	import { authStore } from '$lib/stores/auth.svelte';
 	import { goto } from '$app/navigation';
 	import { api } from '$lib/api/client';
 	import { parseSchema, parseSettings, itemUrlId } from '$lib/types';
 	import type { Collection } from '$lib/types';
 	import { toastStore } from '$lib/stores/toast.svelte';
-	import WorkspaceSwitcher from './WorkspaceSwitcher.svelte';
 	import NotificationPanel from '$lib/components/common/NotificationPanel.svelte';
 
 	let notificationPanelOpen = $state(false);
-	let currentAuthUser = $state<{ name: string; email: string; role: string } | null>(null);
 
 	let wsSlug = $derived(workspaceStore.current?.slug);
 	let isDashboardPage = $derived(wsSlug ? page.url.pathname === `/${wsSlug}` : false);
@@ -39,8 +36,6 @@
 			? collectionStore.collections.find(c => c.slug === activeCollectionSlug)
 			: null
 	);
-
-	let currentTheme = $state<'dark' | 'light'>('dark');
 
 	// Swipe tracking for mobile
 	let touchStartX = $state(0);
@@ -124,19 +119,6 @@
 	let versionLabel = $state('');
 
 	onMount(async () => {
-		const saved = localStorage.getItem('pad-theme');
-		if (saved === 'light' || saved === 'dark') {
-			currentTheme = saved;
-		} else if (window.matchMedia('(prefers-color-scheme: light)').matches) {
-			currentTheme = 'light';
-		}
-		document.documentElement.setAttribute('data-theme', currentTheme);
-
-		// Read from the global auth store (populated by root layout).
-		if (authStore.authenticated && authStore.user) {
-			currentAuthUser = authStore.user;
-		}
-
 		try {
 			const health = await api.health();
 			if (health.version) {
@@ -146,20 +128,14 @@
 		} catch {}
 	});
 
-	async function handleLogout() {
-		try {
-			await api.auth.logout();
-			window.location.href = '/login';
-		} catch {}
-	}
-
-	function toggleTheme() {
-		currentTheme = currentTheme === 'dark' ? 'light' : 'dark';
-		document.documentElement.setAttribute('data-theme', currentTheme);
-		localStorage.setItem('pad-theme', currentTheme);
-	}
-
 	function handleTouchStart(e: TouchEvent) {
+		// Don't initiate swipe-to-close if the touch started inside a
+		// horizontally scrollable element (e.g. the mobile workspace list)
+		let el = e.target as HTMLElement | null;
+		while (el && el !== sidebarEl) {
+			if (el.scrollWidth > el.clientWidth + 1) return;
+			el = el.parentElement;
+		}
 		touchStartX = e.touches[0].clientX;
 		touchCurrentX = touchStartX;
 		isSwiping = true;
@@ -260,10 +236,6 @@
 	ontouchend={handleTouchEnd}
 >
 	<div class="sidebar-inner">
-		<div class="sidebar-header">
-			<WorkspaceSwitcher />
-		</div>
-
 		{#if wsSlug}
 			<nav class="collection-nav">
 				<a
@@ -358,26 +330,16 @@
 			{/if}
 		{/if}
 
-		{#if currentAuthUser}
-			<div class="user-section">
-				<span class="user-name">{currentAuthUser.name}</span>
-				<button class="logout-btn" onclick={handleLogout}>Sign out</button>
-			</div>
-		{/if}
-
 		<div class="sidebar-footer">
 			<button class="search-btn" onclick={() => { uiStore.openSearch(); uiStore.onNavigate(); }}>
 				🔍 Search <kbd>⌘K</kbd>
 			</button>
-			{#if wsSlug}
-				<a href="/{wsSlug}/settings" class="settings-btn" onclick={() => uiStore.onNavigate()}>
-					⚙ Settings
-				</a>
-			{/if}
 			<div class="footer-row">
-				<button class="theme-btn" onclick={toggleTheme}>
-					{currentTheme === 'dark' ? '☀️ Light' : '🌙 Dark'}
-				</button>
+				{#if wsSlug}
+					<a href="/{wsSlug}/settings" class="settings-btn" onclick={() => uiStore.onNavigate()}>
+						⚙ Settings
+					</a>
+				{/if}
 				<button
 					class="bell-btn"
 					onclick={() => { notificationPanelOpen = !notificationPanelOpen; }}
@@ -409,8 +371,7 @@
 		border-right: 1px solid var(--border);
 		display: flex;
 		flex-direction: column;
-		height: 100vh;
-		height: 100dvh;
+		height: 100%;
 		overflow: hidden;
 		transition: transform 0.25s ease;
 		transform: translateX(0);
@@ -423,7 +384,9 @@
 		position: fixed;
 		z-index: 30;
 		left: 0;
-		top: 0;
+		top: var(--topbar-height);
+		height: calc(100vh - var(--topbar-height));
+		height: calc(100dvh - var(--topbar-height));
 		box-shadow: 4px 0 24px rgba(0, 0, 0, 0.3);
 	}
 	.sidebar.mobile.collapsed {
@@ -431,7 +394,10 @@
 	}
 	.backdrop {
 		position: fixed;
-		inset: 0;
+		top: var(--topbar-height);
+		left: 0;
+		right: 0;
+		bottom: 0;
 		background: rgba(0, 0, 0, 0.4);
 		z-index: 25;
 	}
@@ -443,15 +409,6 @@
 		gap: var(--space-3);
 		overflow: hidden;
 		min-height: 0;
-	}
-	.sidebar-header {
-		display: flex;
-		align-items: center;
-		gap: var(--space-2);
-		flex-shrink: 0;
-	}
-	.sidebar-header :global(.workspace-switcher) {
-		flex: 1;
 	}
 
 	/* Collection navigation */
@@ -596,23 +553,24 @@
 		font-size: 0.85em;
 	}
 	.search-btn:hover { background: var(--bg-hover); color: var(--text-secondary); }
-	.settings-btn {
-		display: block;
-		width: 100%;
-		padding: var(--space-2) var(--space-3);
-		border-radius: var(--radius);
-		color: var(--text-muted);
-		font-size: 0.85em;
-		text-decoration: none;
-		margin-top: var(--space-2);
-	}
-	.settings-btn:hover { background: var(--bg-hover); color: var(--text-secondary); text-decoration: none; }
 	.footer-row {
 		display: flex;
 		align-items: center;
 		gap: var(--space-2);
 		margin-top: var(--space-2);
 	}
+	.settings-btn {
+		flex: 1;
+		display: flex;
+		align-items: center;
+		gap: var(--space-2);
+		padding: var(--space-2) var(--space-3);
+		border-radius: var(--radius);
+		color: var(--text-muted);
+		font-size: 0.85em;
+		text-decoration: none;
+	}
+	.settings-btn:hover { background: var(--bg-hover); color: var(--text-secondary); text-decoration: none; }
 	.version-label {
 		display: block;
 		text-align: center;
@@ -622,17 +580,6 @@
 		margin-top: var(--space-2);
 		user-select: text;
 	}
-	.theme-btn {
-		flex: 1;
-		display: flex;
-		align-items: center;
-		gap: var(--space-2);
-		padding: var(--space-2) var(--space-3);
-		border-radius: var(--radius);
-		color: var(--text-muted);
-		font-size: 0.85em;
-	}
-	.theme-btn:hover { background: var(--bg-hover); color: var(--text-secondary); }
 	.bell-btn {
 		position: relative;
 		display: flex;
@@ -666,30 +613,6 @@
 		text-align: center;
 		border-radius: 8px;
 		pointer-events: none;
-	}
-	/* User section */
-	.user-section {
-		display: flex;
-		align-items: center;
-		justify-content: space-between;
-		padding: var(--space-2) var(--space-4);
-		border-top: 1px solid var(--border);
-		font-size: 0.8em;
-		color: var(--text-muted);
-	}
-	.user-name {
-		overflow: hidden;
-		text-overflow: ellipsis;
-		white-space: nowrap;
-	}
-	.logout-btn {
-		color: var(--text-muted);
-		font-size: 0.85em;
-		cursor: pointer;
-		flex-shrink: 0;
-	}
-	.logout-btn:hover {
-		color: var(--text-secondary);
 	}
 	kbd {
 		background: var(--bg-primary);

--- a/web/src/lib/components/layout/Sidebar.svelte
+++ b/web/src/lib/components/layout/Sidebar.svelte
@@ -6,6 +6,7 @@
 	import { workspaceStore } from '$lib/stores/workspace.svelte';
 	import { collectionStore } from '$lib/stores/collections.svelte';
 	import { uiStore } from '$lib/stores/ui.svelte';
+	import { authStore } from '$lib/stores/auth.svelte';
 	import { goto } from '$app/navigation';
 	import { api } from '$lib/api/client';
 	import { parseSchema, parseSettings, itemUrlId } from '$lib/types';
@@ -117,6 +118,13 @@
 	}
 
 	let versionLabel = $state('');
+
+	async function handleLogout() {
+		try {
+			await api.auth.logout();
+			window.location.href = '/login';
+		} catch {}
+	}
 
 	onMount(async () => {
 		try {
@@ -354,6 +362,12 @@
 					{/if}
 				</button>
 			</div>
+			{#if uiStore.isMobile && authStore.user}
+				<div class="mobile-user-row">
+					<span class="mobile-user-name">{authStore.user.name}</span>
+					<button class="mobile-logout-btn" onclick={handleLogout}>Sign out</button>
+				</div>
+			{/if}
 			{#if versionLabel}
 				<span class="version-label">{versionLabel}</span>
 			{/if}
@@ -613,6 +627,30 @@
 		text-align: center;
 		border-radius: 8px;
 		pointer-events: none;
+	}
+	/* Mobile sign-out row */
+	.mobile-user-row {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: var(--space-2) var(--space-3);
+		margin-top: var(--space-2);
+		border-top: 1px solid var(--border);
+		font-size: 0.8em;
+		color: var(--text-muted);
+	}
+	.mobile-user-name {
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+	.mobile-logout-btn {
+		color: var(--text-muted);
+		font-size: 0.85em;
+		flex-shrink: 0;
+	}
+	.mobile-logout-btn:hover {
+		color: var(--text-secondary);
 	}
 	kbd {
 		background: var(--bg-primary);

--- a/web/src/lib/components/layout/TopBar.svelte
+++ b/web/src/lib/components/layout/TopBar.svelte
@@ -135,7 +135,7 @@
 		<!-- svelte-ignore a11y_no_static_element_interactions -->
 		<div
 			class="workspace-list"
-			use:dndzone={{items: dndWorkspaces, flipDurationMs, type: 'topbar-workspace', direction: 'horizontal', dragDisabled: uiStore.isTouch}}
+			use:dndzone={{items: dndWorkspaces, flipDurationMs, type: 'topbar-workspace', dragDisabled: uiStore.isTouch}}
 			onconsider={handleConsider}
 			onfinalize={handleFinalize}
 		>

--- a/web/src/lib/components/layout/TopBar.svelte
+++ b/web/src/lib/components/layout/TopBar.svelte
@@ -1,0 +1,601 @@
+<script lang="ts">
+	import { dndzone } from 'svelte-dnd-action';
+	import type { DndEvent } from 'svelte-dnd-action';
+	import { workspaceStore } from '$lib/stores/workspace.svelte';
+	import { authStore } from '$lib/stores/auth.svelte';
+	import { uiStore } from '$lib/stores/ui.svelte';
+	import { api } from '$lib/api/client';
+	import type { Workspace } from '$lib/types';
+	import { onMount } from 'svelte';
+
+	let { mobile = false }: { mobile?: boolean } = $props();
+
+	let userMenuOpen = $state(false);
+	let currentTheme = $state<'dark' | 'light'>('dark');
+
+	let currentSlug = $derived(workspaceStore.current?.slug ?? '');
+
+	// DnD state — local copy of workspaces for reordering
+	let dndWorkspaces: Workspace[] = $state([]);
+	let isDragging = $state(false);
+	const flipDurationMs = 150;
+
+	// Mobile edit mode
+	let mobileEditMode = $state(false);
+
+	// Sync from store when not actively reordering
+	$effect(() => {
+		if (!isDragging && !mobileEditMode) {
+			dndWorkspaces = [...workspaceStore.workspaces];
+		}
+	});
+
+	// Desktop: svelte-dnd-action handlers
+	function handleConsider(e: CustomEvent<DndEvent<Workspace>>) {
+		dndWorkspaces = e.detail.items;
+		isDragging = true;
+	}
+
+	async function handleFinalize(e: CustomEvent<DndEvent<Workspace>>) {
+		dndWorkspaces = e.detail.items;
+		isDragging = false;
+		await saveOrder();
+	}
+
+	// Mobile edit mode: svelte-dnd-action handlers (touch drag works fine
+	// when items are buttons, not links)
+	function handleMobileConsider(e: CustomEvent<DndEvent<Workspace>>) {
+		dndWorkspaces = e.detail.items;
+	}
+
+	async function handleMobileFinalize(e: CustomEvent<DndEvent<Workspace>>) {
+		dndWorkspaces = e.detail.items;
+	}
+
+	async function saveOrder() {
+		const updates = dndWorkspaces.map((ws, i) => ({
+			slug: ws.slug,
+			sort_order: i
+		}));
+		try {
+			await api.workspaces.reorder(updates);
+			await workspaceStore.loadAll();
+		} catch {
+			dndWorkspaces = [...workspaceStore.workspaces];
+		}
+	}
+
+	function enterEditMode() {
+		mobileEditMode = true;
+		dndWorkspaces = [...workspaceStore.workspaces];
+	}
+
+	async function exitEditMode() {
+		mobileEditMode = false;
+		await saveOrder();
+	}
+
+	// Color palette for workspace circles
+	const colors = [
+		'#4a9eff', '#4ade80', '#a78bfa', '#fbbf24',
+		'#22d3ee', '#fb923c', '#f472b6', '#34d399',
+	];
+
+	function wsColor(name: string): string {
+		let hash = 0;
+		for (let i = 0; i < name.length; i++) {
+			hash = name.charCodeAt(i) + ((hash << 5) - hash);
+		}
+		return colors[Math.abs(hash) % colors.length];
+	}
+
+	function wsInitial(name: string): string {
+		return name.charAt(0).toUpperCase();
+	}
+
+	onMount(() => {
+		const saved = localStorage.getItem('pad-theme');
+		if (saved === 'light' || saved === 'dark') {
+			currentTheme = saved;
+		} else if (window.matchMedia('(prefers-color-scheme: light)').matches) {
+			currentTheme = 'light';
+		}
+	});
+
+	function toggleTheme() {
+		currentTheme = currentTheme === 'dark' ? 'light' : 'dark';
+		document.documentElement.setAttribute('data-theme', currentTheme);
+		localStorage.setItem('pad-theme', currentTheme);
+	}
+
+	async function handleLogout() {
+		try {
+			await api.auth.logout();
+			window.location.href = '/login';
+		} catch {}
+	}
+
+	function closeUserMenu() {
+		userMenuOpen = false;
+	}
+</script>
+
+<svelte:window onclick={(e) => {
+	if (userMenuOpen) {
+		const target = e.target as HTMLElement;
+		if (!target.closest('.user-menu-container')) {
+			closeUserMenu();
+		}
+	}
+}} />
+
+{#if !mobile}
+	<!-- ── Desktop ────────────────────────────────────────────────────────── -->
+	<header class="topbar">
+		<!-- svelte-ignore a11y_no_static_element_interactions -->
+		<div
+			class="workspace-list"
+			use:dndzone={{items: dndWorkspaces, flipDurationMs, type: 'topbar-workspace', direction: 'horizontal', dragDisabled: uiStore.isTouch}}
+			onconsider={handleConsider}
+			onfinalize={handleFinalize}
+		>
+			{#each dndWorkspaces as ws (ws.id)}
+				<a
+					href="/{ws.slug}"
+					class="workspace-item"
+					class:active={ws.slug === currentSlug}
+					title={ws.name}
+				>
+					<span
+						class="workspace-icon"
+						style="background: {ws.slug === currentSlug ? wsColor(ws.name) : 'transparent'}; color: {ws.slug === currentSlug ? '#fff' : 'var(--text-secondary)'}; border-color: {wsColor(ws.name)}"
+					>
+						{wsInitial(ws.name)}
+					</span>
+					<span class="workspace-name">{ws.name}</span>
+				</a>
+			{/each}
+		</div>
+		<button
+			class="workspace-add"
+			onclick={() => uiStore.openCreateWorkspace()}
+			title="New workspace"
+		>
+			<span class="add-icon">+</span>
+		</button>
+
+		<div class="topbar-right">
+			{#if authStore.user}
+				<div class="user-menu-container">
+					<button
+						class="user-trigger"
+						onclick={() => userMenuOpen = !userMenuOpen}
+					>
+						<span class="user-avatar" style="background: {wsColor(authStore.user.name || authStore.user.email)}">
+							{(authStore.user.name || authStore.user.email).charAt(0).toUpperCase()}
+						</span>
+					</button>
+
+					{#if userMenuOpen}
+						<div class="user-dropdown">
+							<div class="user-info">
+								<span class="user-dropdown-name">{authStore.user.name}</span>
+								<span class="user-dropdown-email">{authStore.user.email}</span>
+							</div>
+							<div class="dropdown-divider"></div>
+							{#if currentSlug}
+								<a href="/{currentSlug}/settings" class="dropdown-item" onclick={closeUserMenu}>
+									Settings
+								</a>
+							{/if}
+							<button class="dropdown-item" onclick={toggleTheme}>
+								{currentTheme === 'dark' ? 'Light mode' : 'Dark mode'}
+							</button>
+							<div class="dropdown-divider"></div>
+							<button class="dropdown-item logout" onclick={handleLogout}>
+								Sign out
+							</button>
+						</div>
+					{/if}
+				</div>
+			{/if}
+		</div>
+	</header>
+{:else}
+	<!-- ── Mobile ─────────────────────────────────────────────────────────── -->
+	<header class="topbar topbar-mobile">
+		<div class="workspace-list">
+			{#each workspaceStore.workspaces as ws (ws.id)}
+				<a
+					href="/{ws.slug}"
+					class="workspace-item"
+					class:active={ws.slug === currentSlug}
+					onclick={() => uiStore.onNavigate()}
+				>
+					<span
+						class="workspace-icon"
+						style="background: {ws.slug === currentSlug ? wsColor(ws.name) : 'transparent'}; color: {ws.slug === currentSlug ? '#fff' : 'var(--text-secondary)'}; border-color: {wsColor(ws.name)}"
+					>
+						{wsInitial(ws.name)}
+					</span>
+					<span class="workspace-name">{ws.name}</span>
+				</a>
+			{/each}
+		</div>
+		<button
+			class="workspace-add"
+			onclick={() => { uiStore.onNavigate(); uiStore.openCreateWorkspace(); }}
+			title="New workspace"
+		>
+			<span class="add-icon">+</span>
+		</button>
+		{#if workspaceStore.workspaces.length > 1}
+			<button
+				class="edit-btn"
+				onclick={enterEditMode}
+				title="Reorder workspaces"
+			>
+				<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round">
+					<line x1="4" y1="9" x2="20" y2="9" /><line x1="4" y1="15" x2="20" y2="15" />
+					<polyline points="8 5 4 9 8 13" /><polyline points="16 11 20 15 16 19" />
+				</svg>
+			</button>
+		{/if}
+	</header>
+
+	<!-- Full-screen reorder overlay -->
+	{#if mobileEditMode}
+		<div class="reorder-overlay">
+			<div class="reorder-header">
+				<h3 class="reorder-title">Reorder Workspaces</h3>
+				<button class="done-btn" onclick={exitEditMode}>Done</button>
+			</div>
+			<!-- svelte-ignore a11y_no_static_element_interactions -->
+			<div
+				class="reorder-list"
+				use:dndzone={{items: dndWorkspaces, flipDurationMs, type: 'mobile-reorder'}}
+				onconsider={handleMobileConsider}
+				onfinalize={handleMobileFinalize}
+			>
+				{#each dndWorkspaces as ws (ws.id)}
+					<div class="reorder-item" class:active={ws.slug === currentSlug}>
+						<span class="drag-grip">⠿</span>
+						<span
+							class="reorder-icon"
+							style="background: {wsColor(ws.name)}; border-color: {wsColor(ws.name)}"
+						>
+							{wsInitial(ws.name)}
+						</span>
+						<span class="reorder-name">{ws.name}</span>
+					</div>
+				{/each}
+			</div>
+		</div>
+	{/if}
+{/if}
+
+<style>
+	.topbar {
+		display: flex;
+		align-items: center;
+		height: var(--topbar-height);
+		min-height: var(--topbar-height);
+		background: var(--bg-secondary);
+		border-bottom: 1px solid var(--border);
+		padding: 0 var(--space-3);
+		gap: var(--space-2);
+		z-index: 20;
+	}
+
+	/* Mobile: fixed at top, full viewport width, above sidebar + backdrop */
+	.topbar-mobile {
+		position: fixed;
+		top: 0;
+		left: 0;
+		right: 0;
+		z-index: 35;
+	}
+
+	/* Workspace list — scrollable horizontally */
+	.workspace-list {
+		display: flex;
+		align-items: center;
+		gap: 2px;
+		flex: 1;
+		min-width: 0;
+		overflow-x: auto;
+		scrollbar-width: none;
+		-ms-overflow-style: none;
+		padding-right: var(--space-2);
+	}
+	.workspace-list::-webkit-scrollbar {
+		display: none;
+	}
+
+	.workspace-item {
+		display: flex;
+		align-items: center;
+		gap: var(--space-2);
+		padding: var(--space-1) var(--space-2);
+		border-radius: var(--radius);
+		text-decoration: none;
+		color: var(--text-secondary);
+		white-space: nowrap;
+		flex-shrink: 0;
+		transition: background 0.15s, color 0.15s;
+	}
+	/* Grab cursor on desktop only */
+	.topbar:not(.topbar-mobile) .workspace-item {
+		cursor: grab;
+	}
+	.topbar:not(.topbar-mobile) .workspace-item:active {
+		cursor: grabbing;
+	}
+	.workspace-item:hover {
+		background: var(--bg-hover);
+		color: var(--text-primary);
+		text-decoration: none;
+	}
+	.workspace-item.active {
+		background: var(--bg-hover);
+		color: var(--text-primary);
+	}
+
+	.workspace-icon {
+		width: 24px;
+		height: 24px;
+		border-radius: 50%;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		font-size: 0.75em;
+		font-weight: 700;
+		flex-shrink: 0;
+		border: 2px solid;
+		transition: background 0.15s, color 0.15s;
+	}
+
+	.workspace-name {
+		font-size: 0.82em;
+		font-weight: 500;
+	}
+
+	.workspace-add {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 24px;
+		height: 24px;
+		border-radius: 50%;
+		flex-shrink: 0;
+		color: var(--text-muted);
+		border: 2px dashed var(--border);
+		transition: border-color 0.15s, color 0.15s;
+	}
+	.workspace-add:hover {
+		border-color: var(--text-secondary);
+		color: var(--text-secondary);
+	}
+	.add-icon {
+		font-size: 0.85em;
+		font-weight: 600;
+		line-height: 1;
+	}
+
+	/* Edit / Done buttons for mobile reorder */
+	.edit-btn {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 28px;
+		height: 28px;
+		flex-shrink: 0;
+		border-radius: var(--radius);
+		color: var(--text-muted);
+		transition: background 0.15s, color 0.15s;
+	}
+	.edit-btn:hover {
+		background: var(--bg-hover);
+		color: var(--text-secondary);
+	}
+
+	.done-btn {
+		flex-shrink: 0;
+		padding: var(--space-1) var(--space-3);
+		border-radius: var(--radius);
+		font-size: 0.78em;
+		font-weight: 600;
+		color: var(--accent-blue);
+		background: color-mix(in srgb, var(--accent-blue) 15%, transparent);
+		transition: background 0.15s;
+	}
+	.done-btn:hover {
+		background: color-mix(in srgb, var(--accent-blue) 25%, transparent);
+	}
+
+	/* Right side — user menu (desktop only) */
+	.topbar-right {
+		display: flex;
+		align-items: center;
+		flex-shrink: 0;
+	}
+
+	.user-menu-container {
+		position: relative;
+	}
+
+	.user-trigger {
+		display: flex;
+		align-items: center;
+		padding: 2px;
+		border-radius: 50%;
+		transition: opacity 0.15s;
+	}
+	.user-trigger:hover {
+		opacity: 0.8;
+	}
+
+	.user-avatar {
+		width: 28px;
+		height: 28px;
+		border-radius: 50%;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		font-size: 0.78em;
+		font-weight: 700;
+		color: #fff;
+	}
+
+	.user-dropdown {
+		position: absolute;
+		top: calc(100% + 6px);
+		right: 0;
+		min-width: 200px;
+		background: var(--bg-secondary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius-lg);
+		box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
+		z-index: 50;
+		overflow: hidden;
+		animation: dropdown-in 0.12s ease-out;
+	}
+	@keyframes dropdown-in {
+		from { opacity: 0; transform: translateY(-4px); }
+		to { opacity: 1; transform: translateY(0); }
+	}
+
+	.user-info {
+		padding: var(--space-3) var(--space-4);
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+	}
+	.user-dropdown-name {
+		font-size: 0.88em;
+		font-weight: 600;
+		color: var(--text-primary);
+	}
+	.user-dropdown-email {
+		font-size: 0.78em;
+		color: var(--text-muted);
+	}
+
+	.dropdown-divider {
+		height: 1px;
+		background: var(--border);
+	}
+
+	.dropdown-item {
+		display: block;
+		width: 100%;
+		text-align: left;
+		padding: var(--space-2) var(--space-4);
+		font-size: 0.85em;
+		color: var(--text-secondary);
+		text-decoration: none;
+		transition: background 0.1s, color 0.1s;
+	}
+	.dropdown-item:hover {
+		background: var(--bg-hover);
+		color: var(--text-primary);
+		text-decoration: none;
+	}
+	.dropdown-item.logout {
+		color: var(--accent-orange);
+	}
+	.dropdown-item.logout:hover {
+		background: color-mix(in srgb, var(--accent-orange) 10%, var(--bg-hover));
+	}
+
+	/* ── Mobile reorder overlay ──────────────────────────────────────────── */
+	.reorder-overlay {
+		position: fixed;
+		inset: 0;
+		z-index: 40;
+		background: var(--bg-primary);
+		display: flex;
+		flex-direction: column;
+		animation: overlay-in 0.15s ease-out;
+	}
+	@keyframes overlay-in {
+		from { opacity: 0; }
+		to { opacity: 1; }
+	}
+
+	.reorder-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: var(--space-4) var(--space-4);
+		border-bottom: 1px solid var(--border);
+		background: var(--bg-secondary);
+		flex-shrink: 0;
+	}
+	.reorder-title {
+		font-size: 1em;
+		font-weight: 600;
+		color: var(--text-primary);
+		margin: 0;
+	}
+
+	.reorder-list {
+		flex: 1;
+		overflow-y: auto;
+		padding: var(--space-3);
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+	}
+
+	.reorder-item {
+		display: flex;
+		align-items: center;
+		gap: var(--space-3);
+		padding: var(--space-3) var(--space-3);
+		background: var(--bg-secondary);
+		border-radius: var(--radius);
+		border: 1px solid var(--border);
+		cursor: grab;
+		touch-action: none;
+		user-select: none;
+		transition: box-shadow 0.15s, border-color 0.15s;
+	}
+	.reorder-item:active {
+		cursor: grabbing;
+		box-shadow: 0 4px 16px rgba(0, 0, 0, 0.25);
+		border-color: var(--accent-blue);
+	}
+	.reorder-item.active {
+		border-color: color-mix(in srgb, var(--accent-blue) 40%, var(--border));
+	}
+
+	.drag-grip {
+		color: var(--text-muted);
+		font-size: 1em;
+		line-height: 1;
+		flex-shrink: 0;
+		user-select: none;
+	}
+
+	.reorder-icon {
+		width: 28px;
+		height: 28px;
+		border-radius: 50%;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		font-size: 0.8em;
+		font-weight: 700;
+		color: #fff;
+		flex-shrink: 0;
+		border: 2px solid;
+	}
+
+	.reorder-name {
+		font-size: 0.92em;
+		font-weight: 500;
+		color: var(--text-primary);
+		flex: 1;
+	}
+</style>

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -40,6 +40,7 @@ export interface Workspace {
 	slug: string;
 	description: string;
 	settings: string;
+	sort_order: number;
 	context?: WorkspaceContext;
 	created_at: string;
 	updated_at: string;

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -7,6 +7,7 @@
 	import { authStore } from '$lib/stores/auth.svelte';
 	import { uiStore } from '$lib/stores/ui.svelte';
 	import Sidebar from '$lib/components/layout/Sidebar.svelte';
+	import TopBar from '$lib/components/layout/TopBar.svelte';
 	import CommandPalette from '$lib/components/search/CommandPalette.svelte';
 	import ToastContainer from '$lib/components/common/ToastContainer.svelte';
 	import CreateWorkspaceModal from '$lib/components/layout/CreateWorkspaceModal.svelte';
@@ -20,6 +21,14 @@
 	let isAuthPage = $derived(page.url.pathname === '/login' || page.url.pathname === '/register' || page.url.pathname.startsWith('/join/'));
 
 	onMount(async () => {
+		// Initialize theme
+		const savedTheme = localStorage.getItem('pad-theme');
+		if (savedTheme === 'light' || savedTheme === 'dark') {
+			document.documentElement.setAttribute('data-theme', savedTheme);
+		} else if (window.matchMedia('(prefers-color-scheme: light)').matches) {
+			document.documentElement.setAttribute('data-theme', 'light');
+		}
+
 		// Check auth status before loading the app
 		try {
 			const auth = await authStore.load();
@@ -108,23 +117,31 @@
 {:else if isAuthPage}
 	{@render children()}
 {:else}
-	<div class="app-shell">
-		<Sidebar />
-		<main class="main-content">
-			{#if uiStore.isMobile && !uiStore.sidebarOpen}
-				<div class="mobile-header">
-					<button class="hamburger" onclick={() => uiStore.openSidebar()} aria-label="Open sidebar">
-						<svg width="20" height="20" viewBox="0 0 20 20" fill="none">
-							<rect y="3" width="20" height="2" rx="1" fill="currentColor"/>
-							<rect y="9" width="20" height="2" rx="1" fill="currentColor"/>
-							<rect y="15" width="20" height="2" rx="1" fill="currentColor"/>
-						</svg>
-					</button>
-					<a href="/{workspaceStore.current?.slug ?? ''}" class="mobile-title">{workspaceStore.current?.name ?? 'Pad'}</a>
-				</div>
-			{/if}
-			{@render children()}
-		</main>
+	{#if uiStore.isMobile && uiStore.sidebarOpen}
+		<TopBar mobile />
+	{/if}
+	<div class="app-layout">
+		{#if !uiStore.isMobile}
+			<TopBar />
+		{/if}
+		<div class="app-shell">
+			<Sidebar />
+			<main class="main-content">
+				{#if uiStore.isMobile && !uiStore.sidebarOpen}
+					<div class="mobile-header">
+						<button class="hamburger" onclick={() => uiStore.openSidebar()} aria-label="Open sidebar">
+							<svg width="20" height="20" viewBox="0 0 20 20" fill="none">
+								<rect y="3" width="20" height="2" rx="1" fill="currentColor"/>
+								<rect y="9" width="20" height="2" rx="1" fill="currentColor"/>
+								<rect y="15" width="20" height="2" rx="1" fill="currentColor"/>
+							</svg>
+						</button>
+						<a href="/{workspaceStore.current?.slug ?? ''}" class="mobile-title">{workspaceStore.current?.name ?? 'Pad'}</a>
+					</div>
+				{/if}
+				{@render children()}
+			</main>
+		</div>
 	</div>
 
 	<CommandPalette />
@@ -134,9 +151,16 @@
 {/if}
 
 <style>
+	.app-layout {
+		display: flex;
+		flex-direction: column;
+		height: 100vh;
+		overflow: hidden;
+	}
 	.app-shell {
 		display: flex;
-		height: 100vh;
+		flex: 1;
+		min-height: 0;
 		overflow: hidden;
 	}
 	.main-content {


### PR DESCRIPTION
## Summary

- **New TopBar component** replaces the sidebar WorkspaceSwitcher with a persistent horizontal bar above the sidebar + content area
- **Workspace icons** (colored first-letter circles) + names as real `<a>` links — right-click "open in new tab" works naturally
- **Drag-to-reorder** on desktop (svelte-dnd-action) and mobile (full-screen vertical reorder overlay)
- **User menu** on the right side with settings, theme toggle, and sign out
- **Per-user sort order** persisted via `workspace_members.sort_order` column

### Desktop
- Horizontal bar with draggable workspace items + "+" button + user avatar dropdown
- Mouse drag to reorder, click to navigate

### Mobile
- Full-width fixed bar appears at the top when sidebar opens
- Tap to navigate (closes sidebar), "+" to create workspace
- `⇅` button opens a full-screen vertical reorder view with drag handles

### Backend
- Migration 028: `sort_order` on `workspace_members`
- `GET /workspaces` returns user's custom sort order
- `PUT /workspaces/reorder` saves `[{slug, sort_order}]`

### Sidebar cleanup
- Removed: WorkspaceSwitcher, user section, theme toggle (all moved to TopBar)
- Theme init moved to root layout
- Mobile sidebar offset to sit below the top bar

Implements IDEA-129, relates to IDEA-126.

## Test plan

- [ ] Desktop: workspaces render in top bar, click navigates, drag reorders (persists on reload)
- [ ] Desktop: user menu opens with settings/theme/logout, all work correctly
- [ ] Desktop: "+" button opens create workspace modal
- [ ] Desktop: right-click workspace → "open in new tab" works
- [ ] Mobile: top bar appears when sidebar opens, full viewport width
- [ ] Mobile: tap workspace navigates and closes sidebar
- [ ] Mobile: reorder button → full-screen overlay, drag to reorder, Done saves
- [ ] Mobile: swipe-to-close sidebar still works (not intercepted by workspace list)
- [ ] Multi-user: each user's workspace order is independent
- [ ] Light mode + dark mode both render correctly
- [ ] Fresh install: migration 028 applies cleanly