### PR TITLE
feat: workspace-global item numbering

### DIFF
--- a/internal/store/export.go
+++ b/internal/store/export.go
@@ -56,7 +56,7 @@ func (s *Store) ExportWorkspace(slug string) (*models.WorkspaceExport, error) {
 		SELECT id, collection_id, title, slug, content, fields, tags, pinned, sort_order,
 		       COALESCE(parent_id, ''), created_by, last_modified_by, source, COALESCE(item_number, 0), created_at, updated_at
 		FROM items WHERE workspace_id = ? AND deleted_at IS NULL
-		ORDER BY collection_id, sort_order, created_at`), ws.ID)
+		ORDER BY created_at, id`), ws.ID)
 	if err != nil {
 		return nil, fmt.Errorf("export items: %w", err)
 	}
@@ -196,6 +196,11 @@ func (s *Store) ImportWorkspace(data *models.WorkspaceExport, newName string) (*
 	}
 
 	// Import items (first pass: create items, remap collection_id)
+	// Item numbers are assigned sequentially in created_at order to produce
+	// workspace-global numbering. Exported item_number values are ignored
+	// because old exports used per-collection numbering which can have
+	// duplicates within a workspace.
+	var nextItemNumber int
 	for _, it := range data.Items {
 		newItemID := newID()
 		itemMap[it.ID] = newItemID
@@ -212,11 +217,12 @@ func (s *Store) ImportWorkspace(data *models.WorkspaceExport, newName string) (*
 			}
 		}
 
+		nextItemNumber++
 		_, err := tx.Exec(s.q(`
 			INSERT INTO items (id, workspace_id, collection_id, title, slug, content, fields, tags, pinned, sort_order, parent_id, created_by, last_modified_by, source, item_number, created_at, updated_at)
 			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULLIF(?, ''), ?, ?, ?, ?, ?, ?)`),
 			newItemID, ws.ID, newCollID, it.Title, it.Slug, it.Content, it.Fields, it.Tags, s.dialect.BoolToInt(it.Pinned), it.SortOrder,
-			parentID, it.CreatedBy, it.LastModifiedBy, it.Source, it.ItemNumber,
+			parentID, it.CreatedBy, it.LastModifiedBy, it.Source, nextItemNumber,
 			it.CreatedAt, it.UpdatedAt)
 		if err != nil {
 			return nil, fmt.Errorf("import item %s: %w", it.Title, err)

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -57,6 +57,10 @@ func (s *Store) validateAssignmentScope(workspaceID string, assignedUserID, agen
 	return nil
 }
 
+// maxItemNumberRetries is the number of times CreateItem will retry when a
+// concurrent insert claims the same workspace-global item_number.
+const maxItemNumberRetries = 3
+
 func (s *Store) CreateItem(workspaceID, collectionID string, input models.ItemCreate) (*models.Item, error) {
 	// Validate assignment scope before writing
 	if err := s.validateAssignmentScope(workspaceID, input.AssignedUserID, input.AgentRoleID); err != nil {
@@ -92,17 +96,36 @@ func (s *Store) CreateItem(workspaceID, collectionID string, input models.ItemCr
 		return nil, fmt.Errorf("unique slug: %w", err)
 	}
 
+	// Retry loop: if a concurrent insert claims the same item_number we
+	// roll back and re-read MAX(item_number) on the next attempt.
+	var lastErr error
+	for attempt := 0; attempt < maxItemNumberRetries; attempt++ {
+		lastErr = s.tryCreateItem(id, workspaceID, collectionID, slug, ts, fields, tags, createdBy, source, input)
+		if lastErr == nil {
+			return s.GetItem(id)
+		}
+		// Only retry on unique-constraint violations (item_number conflict)
+		if !isUniqueViolation(lastErr) {
+			return nil, fmt.Errorf("insert item: %w", lastErr)
+		}
+	}
+	return nil, fmt.Errorf("insert item after %d retries: %w", maxItemNumberRetries, lastErr)
+}
+
+// tryCreateItem attempts a single transactional insert of an item with the
+// next available workspace-global item_number.
+func (s *Store) tryCreateItem(id, workspaceID, collectionID, slug, ts, fields, tags, createdBy, source string, input models.ItemCreate) error {
 	tx, err := s.db.Begin()
 	if err != nil {
-		return nil, err
+		return err
 	}
 	defer tx.Rollback()
 
-	// Assign the next item_number within this collection
+	// Assign the next item_number within this workspace (global counter)
 	var nextNum int
-	err = tx.QueryRow(s.q("SELECT COALESCE(MAX(item_number), 0) + 1 FROM items WHERE collection_id = ?"), collectionID).Scan(&nextNum)
+	err = tx.QueryRow(s.q("SELECT COALESCE(MAX(item_number), 0) + 1 FROM items WHERE workspace_id = ?"), workspaceID).Scan(&nextNum)
 	if err != nil {
-		return nil, fmt.Errorf("get next item number: %w", err)
+		return fmt.Errorf("get next item number: %w", err)
 	}
 
 	_, err = tx.Exec(s.q(`
@@ -114,7 +137,7 @@ func (s *Store) CreateItem(workspaceID, collectionID string, input models.ItemCr
 		s.dialect.BoolToInt(input.Pinned), input.ParentID, input.AssignedUserID, input.AgentRoleID,
 		createdBy, createdBy, source, nextNum, ts, ts)
 	if err != nil {
-		return nil, fmt.Errorf("insert item: %w", err)
+		return err
 	}
 
 	// Create initial version if there's content
@@ -125,15 +148,22 @@ func (s *Store) CreateItem(workspaceID, collectionID string, input models.ItemCr
 			VALUES (?, ?, ?, '', ?, ?, ?, ?)
 		`), vid, id, input.Content, createdBy, source, s.dialect.BoolToInt(false), ts)
 		if err != nil {
-			return nil, fmt.Errorf("create initial version: %w", err)
+			return fmt.Errorf("create initial version: %w", err)
 		}
 	}
 
-	if err := tx.Commit(); err != nil {
-		return nil, err
-	}
+	return tx.Commit()
+}
 
-	return s.GetItem(id)
+// isUniqueViolation checks whether an error is a unique constraint violation.
+// Works for both SQLite (UNIQUE constraint failed) and PostgreSQL (duplicate key).
+func isUniqueViolation(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "UNIQUE constraint failed") ||
+		strings.Contains(msg, "duplicate key value violates unique constraint")
 }
 
 func (s *Store) GetItem(id string) (*models.Item, error) {
@@ -1386,34 +1416,17 @@ func (s *Store) PopulateHasChildren(items []models.Item) {
 }
 
 // MoveItem moves an item to a different collection within the same workspace.
-// It updates the collection_id, assigns a new item_number in the target collection,
-// and updates the fields JSON.
+// It updates the collection_id and fields JSON. The item_number is preserved
+// because numbering is workspace-global — the number stays the same, only the
+// collection prefix changes (e.g. IDEA-42 → BUG-42).
 func (s *Store) MoveItem(itemID, targetCollectionID, newFieldsJSON string) (*models.Item, error) {
-	tx, err := s.db.Begin()
-	if err != nil {
-		return nil, err
-	}
-	defer tx.Rollback()
-
-	// Get next item_number in the target collection
-	var nextNumber int
-	err = tx.QueryRow(s.q(`SELECT COALESCE(MAX(item_number), 0) + 1 FROM items WHERE collection_id = ?`), targetCollectionID).Scan(&nextNumber)
-	if err != nil {
-		return nil, fmt.Errorf("get next item number: %w", err)
-	}
-
-	// Update the item
-	_, err = tx.Exec(s.q(`
+	_, err := s.db.Exec(s.q(`
 		UPDATE items
-		SET collection_id = ?, fields = ?, item_number = ?, updated_at = ?
+		SET collection_id = ?, fields = ?, updated_at = ?
 		WHERE id = ? AND deleted_at IS NULL`),
-		targetCollectionID, newFieldsJSON, nextNumber, time.Now().UTC().Format(time.RFC3339), itemID)
+		targetCollectionID, newFieldsJSON, time.Now().UTC().Format(time.RFC3339), itemID)
 	if err != nil {
 		return nil, fmt.Errorf("move item: %w", err)
-	}
-
-	if err := tx.Commit(); err != nil {
-		return nil, err
 	}
 
 	return s.GetItem(itemID)

--- a/internal/store/items_test.go
+++ b/internal/store/items_test.go
@@ -752,6 +752,81 @@ func TestItemLinkDefaultType(t *testing.T) {
 	}
 }
 
+// --- Workspace-Global Item Numbering Tests ---
+
+func TestItemNumbersAreWorkspaceGlobal(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Test")
+	tasks := createTestCollection(t, s, ws.ID, "Tasks")
+	ideas := createTestCollection(t, s, ws.ID, "Ideas")
+
+	// Create items across two collections — numbers should be globally sequential
+	t1 := createTestItem(t, s, ws.ID, tasks.ID, "Task 1", "")
+	i1 := createTestItem(t, s, ws.ID, ideas.ID, "Idea 1", "")
+	t2 := createTestItem(t, s, ws.ID, tasks.ID, "Task 2", "")
+	i2 := createTestItem(t, s, ws.ID, ideas.ID, "Idea 2", "")
+
+	if *t1.ItemNumber != 1 {
+		t.Errorf("expected Task 1 to be #1, got #%d", *t1.ItemNumber)
+	}
+	if *i1.ItemNumber != 2 {
+		t.Errorf("expected Idea 1 to be #2, got #%d", *i1.ItemNumber)
+	}
+	if *t2.ItemNumber != 3 {
+		t.Errorf("expected Task 2 to be #3, got #%d", *t2.ItemNumber)
+	}
+	if *i2.ItemNumber != 4 {
+		t.Errorf("expected Idea 2 to be #4, got #%d", *i2.ItemNumber)
+	}
+}
+
+func TestMoveItemPreservesNumber(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Test")
+	tasks := createTestCollection(t, s, ws.ID, "Tasks")
+	bugs := createTestCollection(t, s, ws.ID, "Bugs")
+
+	item := createTestItem(t, s, ws.ID, tasks.ID, "Fix something", "")
+	originalNumber := *item.ItemNumber
+
+	// Move from Tasks to Bugs
+	moved, err := s.MoveItem(item.ID, bugs.ID, `{"status":"open"}`)
+	if err != nil {
+		t.Fatalf("MoveItem error: %v", err)
+	}
+
+	if moved.CollectionID != bugs.ID {
+		t.Error("item should be in bugs collection after move")
+	}
+	if *moved.ItemNumber != originalNumber {
+		t.Errorf("item number should be preserved after move: expected %d, got %d", originalNumber, *moved.ItemNumber)
+	}
+
+	// Verify the ref changed prefix but kept the number
+	if moved.Ref != fmt.Sprintf("%s-%d", bugs.Prefix, originalNumber) {
+		t.Errorf("expected ref %s-%d, got %s", bugs.Prefix, originalNumber, moved.Ref)
+	}
+}
+
+func TestWorkspaceNumberingIsolation(t *testing.T) {
+	s := testStore(t)
+	ws1 := createTestWorkspace(t, s, "Workspace 1")
+	ws2 := createTestWorkspace(t, s, "Workspace 2")
+	col1 := createTestCollection(t, s, ws1.ID, "Tasks")
+	col2 := createTestCollection(t, s, ws2.ID, "Tasks")
+
+	// Each workspace has its own counter starting at 1
+	item1 := createTestItem(t, s, ws1.ID, col1.ID, "WS1 Task", "")
+	item2 := createTestItem(t, s, ws2.ID, col2.ID, "WS2 Task", "")
+
+	if *item1.ItemNumber != 1 {
+		t.Errorf("expected WS1 item to be #1, got #%d", *item1.ItemNumber)
+	}
+	if *item2.ItemNumber != 1 {
+		t.Errorf("expected WS2 item to be #1, got #%d", *item2.ItemNumber)
+	}
+}
+
 func TestItemVersionCreation(t *testing.T) {
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -417,8 +417,13 @@ func slugify(s string) string {
 }
 
 // backfillItemNumbers assigns prefixes to collections that lack them and
-// sequential item_number values to items that don't have one yet. It also
-// ensures the unique index on (collection_id, item_number) exists.
+// sequential item_number values to items that don't have one yet.
+//
+// On first run after the workspace-global numbering migration, this function
+// detects the old per-collection unique index and performs a one-time
+// renumbering of all items so that item_number is unique per workspace
+// (not per collection). This allows items to keep their number when moved
+// between collections (e.g. IDEA-42 → BUG-42).
 func (s *Store) backfillItemNumbers() error {
 	// 1. Backfill collection prefixes
 	rows, err := s.db.Query(s.q("SELECT id, name FROM collections WHERE prefix = ''"))
@@ -452,32 +457,158 @@ func (s *Store) backfillItemNumbers() error {
 		}
 	}
 
-	// 2. Backfill item numbers per collection
-	collRows, err := s.db.Query(s.q("SELECT id FROM collections"))
-	if err != nil {
-		return fmt.Errorf("query collections for item number backfill: %w", err)
+	// 2. Migrate from per-collection to per-workspace numbering (one-time)
+	if err := s.migrateToWorkspaceNumbering(); err != nil {
+		return fmt.Errorf("migrate to workspace numbering: %w", err)
 	}
-	defer collRows.Close()
 
-	var collIDs []string
-	for collRows.Next() {
+	// 3. Backfill NULL item_numbers for any new items (per workspace)
+	if err := s.backfillNullItemNumbers(); err != nil {
+		return fmt.Errorf("backfill null item numbers: %w", err)
+	}
+
+	// 4. Ensure the workspace-level unique index exists
+	_, err = s.db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS idx_items_workspace_number ON items(workspace_id, item_number)")
+	if err != nil {
+		return fmt.Errorf("create workspace number index: %w", err)
+	}
+
+	return nil
+}
+
+// indexExists checks whether the named index exists in the database.
+func (s *Store) indexExists(name string) bool {
+	var query string
+	switch s.dialect.Driver() {
+	case DriverPostgres:
+		query = "SELECT 1 FROM pg_indexes WHERE indexname = $1"
+	default: // SQLite
+		query = "SELECT 1 FROM sqlite_master WHERE type='index' AND name=?"
+	}
+	var one int
+	err := s.db.QueryRow(query, name).Scan(&one)
+	return err == nil
+}
+
+// migrateToWorkspaceNumbering performs a one-time migration from per-collection
+// item numbering to per-workspace item numbering. It detects the old index
+// (collection_id, item_number) and, if present, renumbers all items within each
+// workspace using a single sequential counter ordered by created_at.
+//
+// The entire operation runs in a single transaction — if anything fails the
+// database is left unchanged and the migration will be retried on next startup.
+func (s *Store) migrateToWorkspaceNumbering() error {
+	// Nothing to migrate if the old index doesn't exist
+	if !s.indexExists("idx_items_collection_number") {
+		return nil
+	}
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin transaction: %w", err)
+	}
+	defer tx.Rollback()
+
+	// Drop the old per-collection unique index
+	if _, err := tx.Exec("DROP INDEX IF EXISTS idx_items_collection_number"); err != nil {
+		return fmt.Errorf("drop old index: %w", err)
+	}
+
+	// Get all workspace IDs
+	wsRows, err := tx.Query(s.q("SELECT id FROM workspaces"))
+	if err != nil {
+		return fmt.Errorf("query workspaces: %w", err)
+	}
+	var wsIDs []string
+	for wsRows.Next() {
 		var id string
-		if err := collRows.Scan(&id); err != nil {
+		if err := wsRows.Scan(&id); err != nil {
+			wsRows.Close()
 			return err
 		}
-		collIDs = append(collIDs, id)
+		wsIDs = append(wsIDs, id)
 	}
-	if err := collRows.Err(); err != nil {
+	wsRows.Close()
+	if err := wsRows.Err(); err != nil {
 		return err
 	}
 
-	for _, collID := range collIDs {
-		itemRows, err := s.db.Query(
-			s.q("SELECT id FROM items WHERE collection_id = ? AND item_number IS NULL ORDER BY created_at ASC, id ASC"),
-			collID,
+	// Renumber items per workspace: assign 1, 2, 3… ordered by created_at, id
+	for _, wsID := range wsIDs {
+		itemRows, err := tx.Query(s.q(
+			"SELECT id FROM items WHERE workspace_id = ? ORDER BY created_at ASC, id ASC"),
+			wsID,
 		)
 		if err != nil {
-			return fmt.Errorf("query items for backfill in collection %s: %w", collID, err)
+			return fmt.Errorf("query items for workspace %s: %w", wsID, err)
+		}
+
+		var itemIDs []string
+		for itemRows.Next() {
+			var id string
+			if err := itemRows.Scan(&id); err != nil {
+				itemRows.Close()
+				return err
+			}
+			itemIDs = append(itemIDs, id)
+		}
+		itemRows.Close()
+		if err := itemRows.Err(); err != nil {
+			return err
+		}
+
+		// Assign sequential numbers across the entire workspace
+		for i, itemID := range itemIDs {
+			num := i + 1
+			if _, err := tx.Exec(s.q("UPDATE items SET item_number = ? WHERE id = ?"), num, itemID); err != nil {
+				return fmt.Errorf("renumber item %s to %d: %w", itemID, num, err)
+			}
+		}
+	}
+
+	// Create the new workspace-level unique index inside the transaction
+	if _, err := tx.Exec("CREATE UNIQUE INDEX IF NOT EXISTS idx_items_workspace_number ON items(workspace_id, item_number)"); err != nil {
+		return fmt.Errorf("create workspace number index: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit migration: %w", err)
+	}
+
+	return nil
+}
+
+// backfillNullItemNumbers assigns the next workspace-global item_number to any
+// items that have a NULL item_number (e.g. from interrupted inserts or pre-
+// migration data).
+func (s *Store) backfillNullItemNumbers() error {
+	// Get workspaces that have items with NULL item_number
+	wsRows, err := s.db.Query(s.q(
+		"SELECT DISTINCT workspace_id FROM items WHERE item_number IS NULL"))
+	if err != nil {
+		return fmt.Errorf("query workspaces with null item numbers: %w", err)
+	}
+	var wsIDs []string
+	for wsRows.Next() {
+		var id string
+		if err := wsRows.Scan(&id); err != nil {
+			wsRows.Close()
+			return err
+		}
+		wsIDs = append(wsIDs, id)
+	}
+	wsRows.Close()
+	if err := wsRows.Err(); err != nil {
+		return err
+	}
+
+	for _, wsID := range wsIDs {
+		itemRows, err := s.db.Query(
+			s.q("SELECT id FROM items WHERE workspace_id = ? AND item_number IS NULL ORDER BY created_at ASC, id ASC"),
+			wsID,
+		)
+		if err != nil {
+			return fmt.Errorf("query null-numbered items for workspace %s: %w", wsID, err)
 		}
 
 		var itemIDs []string
@@ -494,10 +625,10 @@ func (s *Store) backfillItemNumbers() error {
 			continue
 		}
 
-		// Get current max
+		// Get current max in this workspace
 		var maxNum int
-		if err := s.db.QueryRow(s.q("SELECT COALESCE(MAX(item_number), 0) FROM items WHERE collection_id = ?"), collID).Scan(&maxNum); err != nil {
-			return fmt.Errorf("get max item_number for collection %s: %w", collID, err)
+		if err := s.db.QueryRow(s.q("SELECT COALESCE(MAX(item_number), 0) FROM items WHERE workspace_id = ?"), wsID).Scan(&maxNum); err != nil {
+			return fmt.Errorf("get max item_number for workspace %s: %w", wsID, err)
 		}
 
 		for _, itemID := range itemIDs {
@@ -506,12 +637,6 @@ func (s *Store) backfillItemNumbers() error {
 				return fmt.Errorf("update item_number for item %s: %w", itemID, err)
 			}
 		}
-	}
-
-	// 3. Create unique index (safe now that all items have numbers)
-	_, err = s.db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS idx_items_collection_number ON items(collection_id, item_number)")
-	if err != nil {
-		return fmt.Errorf("create unique index: %w", err)
 	}
 
 	return nil

--- a/web/src/lib/components/collections/EditCollectionModal.svelte
+++ b/web/src/lib/components/collections/EditCollectionModal.svelte
@@ -3,6 +3,7 @@
 	import type { Collection, CollectionUpdate, CollectionSettings, FieldDef, FieldMigration, QuickAction } from '$lib/types';
 	import { parseSchema, parseSettings } from '$lib/types';
 	import EmojiPicker from '$lib/components/common/EmojiPicker.svelte';
+	import EmojiPickerButton from '$lib/components/common/EmojiPickerButton.svelte';
 	import { toastStore } from '$lib/stores/toast.svelte';
 
 	interface Props {
@@ -602,14 +603,7 @@
 								{#each itemActions as { action, index } (index)}
 									<div class="action-card">
 										<div class="action-card-top">
-											<input
-												class="action-icon-input"
-												type="text"
-												placeholder="⚡"
-												bind:value={action.icon}
-												maxlength="2"
-												title="Icon (emoji)"
-											/>
+											<EmojiPickerButton bind:value={action.icon} placeholder="⚡" />
 											<input
 												class="action-label-input"
 												type="text"
@@ -644,14 +638,7 @@
 								{#each collectionActions as { action, index } (index)}
 									<div class="action-card">
 										<div class="action-card-top">
-											<input
-												class="action-icon-input"
-												type="text"
-												placeholder="⚡"
-												bind:value={action.icon}
-												maxlength="2"
-												title="Icon (emoji)"
-											/>
+											<EmojiPickerButton bind:value={action.icon} placeholder="⚡" />
 											<input
 												class="action-label-input"
 												type="text"

--- a/web/src/lib/components/common/EmojiPickerButton.svelte
+++ b/web/src/lib/components/common/EmojiPickerButton.svelte
@@ -10,11 +10,60 @@
 	let { value = $bindable(), placeholder = '⚡', size = 'sm' }: Props = $props();
 
 	let open = $state(false);
+	let triggerEl = $state<HTMLButtonElement>();
+	let dropdownX = $state(0);
+	let dropdownY = $state(0);
+
+	/**
+	 * Portal into the nearest <dialog> (stays in top-layer, escapes overflow
+	 * children like .dialog-body), or document.body if not inside a dialog.
+	 */
+	function portal(node: HTMLElement) {
+		const dialog = triggerEl?.closest('dialog');
+		const target = dialog || document.body;
+		target.appendChild(node);
+
+		// <dialog> has browser-default overflow:auto which clips children.
+		// Temporarily override while the dropdown is mounted.
+		if (dialog) {
+			dialog.style.overflow = 'visible';
+		}
+
+		return {
+			destroy() {
+				node.remove();
+				if (dialog) {
+					dialog.style.overflow = '';
+				}
+			}
+		};
+	}
 
 	function handleWindowClick(e: MouseEvent) {
-		if (open && !(e.target as HTMLElement)?.closest('.emoji-picker-button')) {
-			open = false;
+		if (open) {
+			const target = e.target as HTMLElement;
+			if (!target?.closest('.emoji-picker-button') && !target?.closest('.epb-dropdown')) {
+				open = false;
+			}
 		}
+	}
+
+	function toggleOpen() {
+		if (!open && triggerEl) {
+			const triggerRect = triggerEl.getBoundingClientRect();
+			const dialog = triggerEl.closest('dialog');
+			if (dialog) {
+				// dialog with transform creates a containing block —
+				// position: absolute is relative to it, so offset accordingly
+				const dialogRect = dialog.getBoundingClientRect();
+				dropdownX = triggerRect.left - dialogRect.left;
+				dropdownY = triggerRect.bottom - dialogRect.top + 4;
+			} else {
+				dropdownX = triggerRect.left;
+				dropdownY = triggerRect.bottom + 4;
+			}
+		}
+		open = !open;
 	}
 
 	function handleSelect(emoji: string) {
@@ -27,17 +76,18 @@
 
 <div class="emoji-picker-button" class:size-md={size === 'md'}>
 	<button
+		bind:this={triggerEl}
 		type="button"
 		class="trigger"
 		class:open
 		class:empty={!value}
-		onclick={() => (open = !open)}
+		onclick={toggleOpen}
 	>
 		{value || placeholder}
 	</button>
 
 	{#if open}
-		<div class="dropdown">
+		<div class="epb-dropdown" use:portal style="position:absolute; z-index:99999; left:{dropdownX}px; top:{dropdownY}px;">
 			<EmojiPicker selected={value} onselect={handleSelect} />
 		</div>
 	{/if}
@@ -79,12 +129,5 @@
 
 	.trigger.empty {
 		color: var(--text-muted);
-	}
-
-	.dropdown {
-		position: absolute;
-		z-index: 50;
-		top: calc(100% + 4px);
-		left: 0;
 	}
 </style>

--- a/web/src/lib/components/common/EmojiPickerButton.svelte
+++ b/web/src/lib/components/common/EmojiPickerButton.svelte
@@ -1,0 +1,90 @@
+<script lang="ts">
+	import EmojiPicker from '$lib/components/common/EmojiPicker.svelte';
+
+	interface Props {
+		value: string;
+		placeholder?: string;
+		size?: 'sm' | 'md';
+	}
+
+	let { value = $bindable(), placeholder = '⚡', size = 'sm' }: Props = $props();
+
+	let open = $state(false);
+
+	function handleWindowClick(e: MouseEvent) {
+		if (open && !(e.target as HTMLElement)?.closest('.emoji-picker-button')) {
+			open = false;
+		}
+	}
+
+	function handleSelect(emoji: string) {
+		value = emoji;
+		open = false;
+	}
+</script>
+
+<svelte:window onclick={handleWindowClick} />
+
+<div class="emoji-picker-button" class:size-md={size === 'md'}>
+	<button
+		type="button"
+		class="trigger"
+		class:open
+		class:empty={!value}
+		onclick={() => (open = !open)}
+	>
+		{value || placeholder}
+	</button>
+
+	{#if open}
+		<div class="dropdown">
+			<EmojiPicker selected={value} onselect={handleSelect} />
+		</div>
+	{/if}
+</div>
+
+<style>
+	.emoji-picker-button {
+		position: relative;
+		display: inline-flex;
+	}
+
+	.trigger {
+		width: 36px;
+		height: 36px;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		background: var(--bg-secondary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius-sm);
+		cursor: pointer;
+		font-size: 1.1em;
+		line-height: 1;
+		padding: 0;
+	}
+
+	.size-md .trigger {
+		width: 42px;
+		height: 42px;
+	}
+
+	.trigger:hover {
+		border-color: var(--text-muted);
+	}
+
+	.trigger.open {
+		border-color: var(--accent-blue);
+	}
+
+	.trigger.empty {
+		color: var(--text-muted);
+	}
+
+	.dropdown {
+		position: absolute;
+		z-index: 50;
+		top: calc(100% + 4px);
+		left: 0;
+	}
+</style>

--- a/web/src/lib/components/layout/PadLogo.svelte
+++ b/web/src/lib/components/layout/PadLogo.svelte
@@ -1,0 +1,63 @@
+<script lang="ts">
+	let { cloud = false }: { cloud?: boolean } = $props();
+</script>
+
+<a href="/" class="pad-logo" class:has-cloud={cloud}>
+	<span class="wordmark">Pad</span>
+	{#if cloud}
+		<span class="cloud-badge">Cloud</span>
+	{/if}
+</a>
+
+<style>
+	.pad-logo {
+		display: inline-flex;
+		align-items: baseline;
+		position: relative;
+		text-decoration: none;
+		height: 44px;
+		line-height: 44px;
+		flex-shrink: 0;
+		user-select: none;
+		-webkit-user-select: none;
+	}
+
+	.pad-logo:hover {
+		text-decoration: none;
+	}
+
+	.wordmark {
+		font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+		font-size: 1.35rem;
+		font-weight: 800;
+		letter-spacing: -0.03em;
+		color: var(--accent-blue);
+		line-height: 44px;
+		transition: opacity 0.15s;
+	}
+
+	.pad-logo:hover .wordmark {
+		opacity: 0.85;
+	}
+
+	.cloud-badge {
+		position: absolute;
+		right: -22px;
+		bottom: 6px;
+		font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+		font-size: 0.6rem;
+		font-weight: 600;
+		font-style: italic;
+		letter-spacing: 0.04em;
+		color: color-mix(in srgb, var(--accent-blue) 65%, var(--text-secondary));
+		transform: rotate(-5deg);
+		transform-origin: left center;
+		line-height: 1;
+		pointer-events: none;
+		white-space: nowrap;
+	}
+
+	.has-cloud {
+		margin-right: 24px;
+	}
+</style>

--- a/web/src/lib/components/layout/TopBar.svelte
+++ b/web/src/lib/components/layout/TopBar.svelte
@@ -7,6 +7,7 @@
 	import { api } from '$lib/api/client';
 	import type { Workspace } from '$lib/types';
 	import { onMount } from 'svelte';
+	import PadLogo from '$lib/components/layout/PadLogo.svelte';
 
 	let { mobile = false }: { mobile?: boolean } = $props();
 
@@ -132,6 +133,9 @@
 {#if !mobile}
 	<!-- ── Desktop ────────────────────────────────────────────────────────── -->
 	<header class="topbar">
+		<div class="topbar-left">
+			<PadLogo />
+		</div>
 		<!-- svelte-ignore a11y_no_static_element_interactions -->
 		<div
 			class="workspace-list"
@@ -214,6 +218,9 @@
 {:else}
 	<!-- ── Mobile ─────────────────────────────────────────────────────────── -->
 	<header class="topbar topbar-mobile">
+		<div class="topbar-left">
+			<PadLogo />
+		</div>
 		<div class="workspace-list">
 			{#each workspaceStore.workspaces as ws (ws.id)}
 				<a
@@ -294,7 +301,7 @@
 		min-height: var(--topbar-height);
 		background: var(--bg-secondary);
 		border-bottom: 1px solid var(--border);
-		padding: 0 var(--space-3);
+		padding: 0 72px 0 56px; /* clear absolute-positioned logo (left) and user menu (right) */
 		gap: var(--space-2);
 		z-index: 20;
 	}
@@ -423,6 +430,16 @@
 	}
 	.done-btn:hover {
 		background: color-mix(in srgb, var(--accent-blue) 25%, transparent);
+	}
+
+	/* Left side — logo */
+	.topbar-left {
+		position: absolute;
+		left: var(--space-3);
+		display: flex;
+		align-items: center;
+		flex-shrink: 0;
+		z-index: 1;
 	}
 
 	/* Right side — user menu (desktop only) */

--- a/web/src/routes/[workspace]/roles/+page.svelte
+++ b/web/src/routes/[workspace]/roles/+page.svelte
@@ -8,6 +8,7 @@
 	import { itemUrlId } from '$lib/types';
 	import type { Item, Collection, RoleBoardLane, AgentRole } from '$lib/types';
 	import ItemCard from '$lib/components/collections/ItemCard.svelte';
+	import EmojiPickerButton from '$lib/components/common/EmojiPickerButton.svelte';
 	import { dndzone, TRIGGERS, SHADOW_ITEM_MARKER_PROPERTY_NAME } from 'svelte-dnd-action';
 	import type { DndEvent } from 'svelte-dnd-action';
 
@@ -449,7 +450,7 @@
 				<div class="role-field-group">
 					<label class="role-field-label">Icon & Name</label>
 					<div class="role-edit-row">
-						<input class="role-input role-input-icon" type="text" bind:value={editIcon} placeholder="🔨" />
+						<EmojiPickerButton bind:value={editIcon} placeholder="🔨" size="md" />
 						<input class="role-input" type="text" bind:value={editName} placeholder="Role name" />
 					</div>
 				</div>


### PR DESCRIPTION
## Summary

- **Switches item numbering from per-collection to per-workspace scope** so items keep their number when moved between collections (e.g. IDEA-42 → BUG-42)
- **Automatic one-time migration** detects the old index, renumbers all items per-workspace in a single transaction, and swaps to a new `UNIQUE(workspace_id, item_number)` index. Fully transactional — rolls back on failure, retries on next startup.
- **Fixes import compatibility** — assigns fresh sequential numbers on import instead of using exported values, preventing duplicate conflicts from old per-collection exports
- **Adds concurrent create safety** — retry loop (up to 3 attempts) on unique constraint violation for parallel inserts in the same workspace

### Files changed
| File | Change |
|------|--------|
| `internal/store/store.go` | Migration logic: `migrateToWorkspaceNumbering()`, `backfillNullItemNumbers()`, `indexExists()` |
| `internal/store/items.go` | `CreateItem` uses workspace counter + retry; `MoveItem` preserves number; `isUniqueViolation()` helper |
| `internal/store/items_test.go` | 3 new tests: global numbering, move preserves number, workspace isolation |
| `internal/store/export.go` | Import assigns fresh sequential numbers; export orders by `created_at` |

Closes IDEA-330.

## Test plan
- [x] `TestItemNumbersAreWorkspaceGlobal` — numbers are sequential across collections
- [x] `TestMoveItemPreservesNumber` — moving keeps same number, changes prefix
- [x] `TestWorkspaceNumberingIsolation` — each workspace has its own counter
- [x] Full test suite passes (`go test ./...`)
- [x] `make install` succeeds, migration ran on live database with zero duplicate numbers
- [x] Codex review passed — both findings (P1: import compat, P2: concurrency race) addressed