### PR TITLE
fix: resolve old item refs after collection move

### DIFF
--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -226,18 +226,37 @@ func (s *Store) GetItemBySlug(workspaceID, slug string) (*models.Item, error) {
 }
 
 // GetItemByRef looks up an item by its PREFIX-NUMBER reference (e.g. "IDEA-15").
+// Since item numbers are workspace-unique, this first tries an exact prefix match
+// and falls back to a number-only lookup. This allows old refs to still resolve
+// after an item has been moved to a different collection (e.g. PLAN-42 still
+// finds the item even after it became TASK-42).
 func (s *Store) GetItemByRef(workspaceID, prefix string, number int) (*models.Item, error) {
 	var id string
+	// Try exact prefix + number match first
 	err := s.db.QueryRow(s.q(`
 		SELECT i.id FROM items i
 		JOIN collections c ON c.id = i.collection_id
 		WHERE i.workspace_id = ? AND c.prefix = ? AND i.item_number = ? AND i.deleted_at IS NULL
 	`), workspaceID, prefix, number).Scan(&id)
+	if err == nil {
+		return s.GetItem(id)
+	}
+	if err != nil && err != sql.ErrNoRows {
+		return nil, fmt.Errorf("get item by ref: %w", err)
+	}
+
+	// Fallback: item numbers are workspace-unique, so look up by number alone.
+	// This handles the case where an item was moved to a different collection
+	// but is still being referenced by its old prefix.
+	err = s.db.QueryRow(s.q(`
+		SELECT id FROM items
+		WHERE workspace_id = ? AND item_number = ? AND deleted_at IS NULL
+	`), workspaceID, number).Scan(&id)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
 	if err != nil {
-		return nil, fmt.Errorf("get item by ref: %w", err)
+		return nil, fmt.Errorf("get item by number: %w", err)
 	}
 	return s.GetItem(id)
 }

--- a/internal/store/items_test.go
+++ b/internal/store/items_test.go
@@ -808,6 +808,55 @@ func TestMoveItemPreservesNumber(t *testing.T) {
 	}
 }
 
+func TestOldRefResolvesAfterMove(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Test")
+	plans := createTestCollection(t, s, ws.ID, "Plans")
+	tasks := createTestCollection(t, s, ws.ID, "Tasks")
+
+	item := createTestItem(t, s, ws.ID, plans.ID, "My Plan", "")
+	originalNumber := *item.ItemNumber
+
+	// Item is currently PLAN-1
+	found, err := s.GetItemByRef(ws.ID, "PLAN", originalNumber)
+	if err != nil {
+		t.Fatalf("GetItemByRef error: %v", err)
+	}
+	if found == nil || found.ID != item.ID {
+		t.Fatal("expected to find item by PLAN ref before move")
+	}
+
+	// Move to Tasks — becomes TASK-1
+	moved, err := s.MoveItem(item.ID, tasks.ID, `{"status":"open"}`)
+	if err != nil {
+		t.Fatalf("MoveItem error: %v", err)
+	}
+	if moved.Ref != fmt.Sprintf("TASK-%d", originalNumber) {
+		t.Fatalf("expected ref TASK-%d after move, got %s", originalNumber, moved.Ref)
+	}
+
+	// Old ref PLAN-1 should STILL resolve to the same item (fallback by number)
+	found, err = s.GetItemByRef(ws.ID, "PLAN", originalNumber)
+	if err != nil {
+		t.Fatalf("GetItemByRef (old ref) error: %v", err)
+	}
+	if found == nil {
+		t.Fatal("old ref PLAN-N should still resolve after move")
+	}
+	if found.ID != item.ID {
+		t.Error("old ref resolved to wrong item")
+	}
+
+	// New ref TASK-1 should also work
+	found, err = s.GetItemByRef(ws.ID, "TASK", originalNumber)
+	if err != nil {
+		t.Fatalf("GetItemByRef (new ref) error: %v", err)
+	}
+	if found == nil || found.ID != item.ID {
+		t.Fatal("new ref TASK-N should resolve after move")
+	}
+}
+
 func TestWorkspaceNumberingIsolation(t *testing.T) {
 	s := testStore(t)
 	ws1 := createTestWorkspace(t, s, "Workspace 1")


### PR DESCRIPTION
## Summary

- After moving an item between collections, the old ref (e.g. `PLAN-382`) would 404 because the collection prefix no longer matched
- `GetItemByRef` now falls back to a number-only lookup when the prefix+number combo doesn't find anything — since numbers are workspace-unique, there's no ambiguity
- Fixes the frontend 404 cascade (`/items/PLAN-382/children` failing) and subsequent `each_key_duplicate` Svelte error during collection moves

Follow-up to #82 (workspace-global item numbering).

## Test plan
- [x] `TestOldRefResolvesAfterMove` — old prefix still finds the item after move
- [x] Full test suite passes