### PR TITLE
fix: timeline duplicate field key crash

### DIFF
--- a/web/src/lib/components/timeline/TimelineActivityCard.svelte
+++ b/web/src/lib/components/timeline/TimelineActivityCard.svelte
@@ -92,7 +92,7 @@
 	</div>
 	{#if changes.length > 0}
 		<div class="changes">
-			{#each changes as change (change.field)}
+			{#each changes as change, i (i)}
 				<span class="change-pill">
 					<span class="change-field">{change.field}:</span>
 					<span class="change-from">{change.from}</span>


### PR DESCRIPTION
## Summary

- Activity entries can have the same field changed multiple times in one update (e.g. `status: active → completed; status: completed → planned`)
- The `{#each}` block in `TimelineActivityCard` was keyed by `change.field`, causing Svelte's `each_key_duplicate` error when a field appeared twice
- Switched to array index key since duplicate field names are legitimate data

## Test plan
- [x] Confirmed fix on `http://192.168.1.89:7777/docapp/ideas/IDEA-382` — page loads cleanly with no console errors