### PR TITLE
feat: username system + web URL redesign (PLAN-407 Phase 1)

### DIFF
--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -5469,7 +5469,7 @@ Steps:
 				stats := fmt.Sprintf("%d collections, %d items, %d comments",
 					len(data.Collections), len(data.Items), len(data.Comments))
 
-				if _, err := dstStore.ImportWorkspace(data, ""); err != nil {
+				if _, err := dstStore.ImportWorkspace(data, "", ""); err != nil {
 					fmt.Fprintf(os.Stderr, "  ERROR importing %s: %v (skipping)\n", ws.Slug, err)
 					continue
 				}

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -6,6 +6,7 @@ import "time"
 type User struct {
 	ID             string    `json:"id"`
 	Email          string    `json:"email"`
+	Username       string    `json:"username"`                // Unique handle; empty until set
 	Name           string    `json:"name"`
 	PasswordHash   string    `json:"-"`                       // Never serialized
 	Role           string    `json:"role"`                    // "admin" or "member"
@@ -20,14 +21,16 @@ type User struct {
 // UserCreate is the input for registering a new user.
 type UserCreate struct {
 	Email    string `json:"email"`
+	Username string `json:"username,omitempty"` // Optional; auto-generated if empty
 	Name     string `json:"name"`
-	Password string `json:"password"` // Plaintext, will be hashed
-	Role     string `json:"role,omitempty"` // Defaults to "member"
+	Password string `json:"password"`          // Plaintext, will be hashed
+	Role     string `json:"role,omitempty"`     // Defaults to "member"
 }
 
 // UserUpdate is the input for updating user profile fields.
 type UserUpdate struct {
 	Name      *string `json:"name,omitempty"`
+	Username  *string `json:"username,omitempty"`
 	Password  *string `json:"password,omitempty"` // Plaintext, will be hashed
 	AvatarURL *string `json:"avatar_url,omitempty"`
 }
@@ -62,6 +65,7 @@ type WorkspaceMember struct {
 	CreatedAt   time.Time `json:"created_at"`
 
 	// Populated by joins (not stored)
-	UserName  string `json:"user_name,omitempty"`
-	UserEmail string `json:"user_email,omitempty"`
+	UserName     string `json:"user_name,omitempty"`
+	UserEmail    string `json:"user_email,omitempty"`
+	UserUsername string `json:"user_username,omitempty"`
 }

--- a/internal/models/workspace.go
+++ b/internal/models/workspace.go
@@ -6,8 +6,9 @@ type Workspace struct {
 	ID          string            `json:"id"`
 	Name        string            `json:"name"`
 	Slug        string            `json:"slug"`
+	OwnerID     string            `json:"owner_id,omitempty"` // User ID of workspace owner
 	Description string            `json:"description"`
-	Settings    string            `json:"settings"` // JSON
+	Settings    string            `json:"settings"`           // JSON
 	SortOrder   int               `json:"sort_order"`
 	Context     *WorkspaceContext `json:"context,omitempty"`
 	CreatedAt   time.Time         `json:"created_at"`
@@ -17,7 +18,8 @@ type Workspace struct {
 
 type WorkspaceCreate struct {
 	Name        string            `json:"name"`
-	Slug        string            `json:"slug,omitempty"` // auto-generated if empty
+	Slug        string            `json:"slug,omitempty"`     // auto-generated if empty
+	OwnerID     string            `json:"owner_id,omitempty"` // set by server from authenticated user
 	Description string            `json:"description,omitempty"`
 	Settings    string            `json:"settings,omitempty"`
 	Context     *WorkspaceContext `json:"context,omitempty"`

--- a/internal/models/workspace.go
+++ b/internal/models/workspace.go
@@ -6,7 +6,8 @@ type Workspace struct {
 	ID          string            `json:"id"`
 	Name        string            `json:"name"`
 	Slug        string            `json:"slug"`
-	OwnerID     string            `json:"owner_id,omitempty"` // User ID of workspace owner
+	OwnerID       string            `json:"owner_id,omitempty"`       // User ID of workspace owner
+	OwnerUsername string            `json:"owner_username,omitempty"` // Populated by JOIN (not stored)
 	Description string            `json:"description"`
 	Settings    string            `json:"settings"`           // JSON
 	SortOrder   int               `json:"sort_order"`

--- a/internal/server/handlers_auth.go
+++ b/internal/server/handlers_auth.go
@@ -548,6 +548,7 @@ func (s *Server) handleUpdateCurrentUser(w http.ResponseWriter, r *http.Request)
 
 	var input struct {
 		Name            *string `json:"name,omitempty"`
+		Username        *string `json:"username,omitempty"`
 		CurrentPassword string  `json:"current_password,omitempty"`
 		NewPassword     string  `json:"new_password,omitempty"`
 	}
@@ -564,6 +565,29 @@ func (s *Server) handleUpdateCurrentUser(w http.ResponseWriter, r *http.Request)
 			return
 		}
 		input.Name = &trimmed
+	}
+
+	// Validate username if provided
+	if input.Username != nil {
+		trimmed := strings.ToLower(strings.TrimSpace(*input.Username))
+		input.Username = &trimmed
+
+		if err := ValidateUsername(trimmed); err != nil {
+			writeError(w, http.StatusBadRequest, "validation_error", err.Error())
+			return
+		}
+		// Check uniqueness (skip if unchanged)
+		if trimmed != user.Username {
+			existing, err := s.store.GetUserByUsername(trimmed)
+			if err != nil {
+				writeError(w, http.StatusInternalServerError, "internal_error", "Failed to check username")
+				return
+			}
+			if existing != nil {
+				writeError(w, http.StatusConflict, "conflict", "Username is already taken")
+				return
+			}
+		}
 	}
 
 	// Validate password change
@@ -592,7 +616,8 @@ func (s *Server) handleUpdateCurrentUser(w http.ResponseWriter, r *http.Request)
 
 	// Build update
 	update := models.UserUpdate{
-		Name: input.Name,
+		Name:     input.Name,
+		Username: input.Username,
 	}
 	if input.NewPassword != "" {
 		update.Password = &input.NewPassword

--- a/internal/server/handlers_auth.go
+++ b/internal/server/handlers_auth.go
@@ -219,7 +219,11 @@ func (s *Server) handleBootstrap(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Auto-generate username from name (D1: no prompt for bootstrap)
-	username := store.GenerateUsername(input.Name, input.Email)
+	username, err := s.store.EnsureUniqueUsername(store.GenerateUsername(input.Name, input.Email))
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to generate username")
+		return
+	}
 
 	user, err := s.store.CreateUser(models.UserCreate{
 		Email:    input.Email,
@@ -346,7 +350,13 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	} else {
-		input.Username = store.GenerateUsername(input.Name, input.Email)
+		candidate := store.GenerateUsername(input.Name, input.Email)
+		unique, err := s.store.EnsureUniqueUsername(candidate)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "internal_error", "Failed to generate username")
+			return
+		}
+		input.Username = unique
 	}
 
 	// Create user

--- a/internal/server/handlers_auth.go
+++ b/internal/server/handlers_auth.go
@@ -33,6 +33,7 @@ func sessionUserPayload(user *models.User) map[string]interface{} {
 	return map[string]interface{}{
 		"id":           user.ID,
 		"email":        user.Email,
+		"username":     user.Username,
 		"name":         user.Name,
 		"role":         user.Role,
 		"totp_enabled": user.TOTPEnabled,
@@ -445,6 +446,7 @@ func (s *Server) handleGetCurrentUser(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]interface{}{
 		"id":         user.ID,
 		"email":      user.Email,
+		"username":   user.Username,
 		"name":       user.Name,
 		"role":       user.Role,
 		"avatar_url": user.AvatarURL,
@@ -532,6 +534,7 @@ func (s *Server) handleUpdateCurrentUser(w http.ResponseWriter, r *http.Request)
 	writeJSON(w, http.StatusOK, map[string]interface{}{
 		"id":         updated.ID,
 		"email":      updated.Email,
+		"username":   updated.Username,
 		"name":       updated.Name,
 		"role":       updated.Role,
 		"avatar_url": updated.AvatarURL,
@@ -663,10 +666,11 @@ func (s *Server) handleResetPassword(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]interface{}{
 		"ok": true,
 		"user": map[string]interface{}{
-			"id":    user.ID,
-			"email": user.Email,
-			"name":  user.Name,
-			"role":  user.Role,
+			"id":       user.ID,
+			"email":    user.Email,
+			"username": user.Username,
+			"name":     user.Name,
+			"role":     user.Role,
 		},
 		"token": sessionToken,
 	})

--- a/internal/server/handlers_auth.go
+++ b/internal/server/handlers_auth.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/xarmian/pad/internal/models"
+	"github.com/xarmian/pad/internal/store"
 )
 
 const (
@@ -38,6 +39,56 @@ func sessionUserPayload(user *models.User) map[string]interface{} {
 		"role":         user.Role,
 		"totp_enabled": user.TOTPEnabled,
 	}
+}
+
+// handleCheckUsername checks if a username is available for registration.
+// GET /api/v1/auth/check-username?username=foo
+func (s *Server) handleCheckUsername(w http.ResponseWriter, r *http.Request) {
+	username := strings.ToLower(strings.TrimSpace(r.URL.Query().Get("username")))
+
+	if username == "" {
+		writeJSON(w, http.StatusOK, map[string]interface{}{
+			"available": false,
+			"reason":    "invalid",
+			"message":   "Username is required",
+		})
+		return
+	}
+
+	// Format/reserved validation
+	if err := ValidateUsername(username); err != nil {
+		reason := "invalid"
+		if IsReservedUsername(username) {
+			reason = "reserved"
+		}
+		writeJSON(w, http.StatusOK, map[string]interface{}{
+			"available": false,
+			"reason":    reason,
+			"message":   err.Error(),
+		})
+		return
+	}
+
+	// Uniqueness check
+	existing, err := s.store.GetUserByUsername(username)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	if existing != nil {
+		writeJSON(w, http.StatusOK, map[string]interface{}{
+			"available": false,
+			"reason":    "taken",
+			"message":   "Username is already taken",
+		})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"available": true,
+		"reason":    nil,
+		"message":   nil,
+	})
 }
 
 func setupStatePayload(setupMethod string) map[string]interface{} {
@@ -167,8 +218,12 @@ func (s *Server) handleBootstrap(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Auto-generate username from name (D1: no prompt for bootstrap)
+	username := store.GenerateUsername(input.Name, input.Email)
+
 	user, err := s.store.CreateUser(models.UserCreate{
 		Email:    input.Email,
+		Username: username,
 		Name:     input.Name,
 		Password: input.Password,
 		Role:     "admin",
@@ -197,6 +252,7 @@ func (s *Server) handleBootstrap(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 	var input struct {
 		Email          string `json:"email"`
+		Username       string `json:"username"`
 		Name           string `json:"name"`
 		Password       string `json:"password"`
 		InvitationCode string `json:"invitation_code"`
@@ -208,6 +264,7 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 
 	// Validate
 	input.Email = strings.TrimSpace(input.Email)
+	input.Username = strings.TrimSpace(strings.ToLower(input.Username))
 	input.Name = strings.TrimSpace(input.Name)
 	input.InvitationCode = strings.TrimSpace(input.InvitationCode)
 
@@ -273,9 +330,29 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Username: validate if provided, auto-generate if not
+	if input.Username != "" {
+		if err := ValidateUsername(input.Username); err != nil {
+			writeError(w, http.StatusBadRequest, "validation_error", err.Error())
+			return
+		}
+		existingUser, err := s.store.GetUserByUsername(input.Username)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "internal_error", "Failed to check username")
+			return
+		}
+		if existingUser != nil {
+			writeError(w, http.StatusConflict, "conflict", "Username is already taken")
+			return
+		}
+	} else {
+		input.Username = store.GenerateUsername(input.Name, input.Email)
+	}
+
 	// Create user
 	user, err := s.store.CreateUser(models.UserCreate{
 		Email:    input.Email,
+		Username: input.Username,
 		Name:     input.Name,
 		Password: input.Password,
 		Role:     "member",

--- a/internal/server/handlers_workspaces.go
+++ b/internal/server/handlers_workspaces.go
@@ -206,6 +206,11 @@ func (s *Server) handleCreateWorkspace(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Set owner to the authenticated user
+	if userID := currentUserID(r); userID != "" {
+		input.OwnerID = userID
+	}
+
 	ws, err := s.store.CreateWorkspace(input)
 	if err != nil {
 		writeInternalError(w, err)

--- a/internal/server/handlers_workspaces.go
+++ b/internal/server/handlers_workspaces.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/go-chi/chi/v5"
-
 	"github.com/xarmian/pad/internal/collections"
 	"github.com/xarmian/pad/internal/events"
 	"github.com/xarmian/pad/internal/models"
@@ -232,14 +230,8 @@ func (s *Server) handleCreateWorkspace(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleGetWorkspace(w http.ResponseWriter, r *http.Request) {
-	slug := chi.URLParam(r, "slug")
-	ws, err := s.store.GetWorkspaceBySlug(slug)
-	if err != nil {
-		writeInternalError(w, err)
-		return
-	}
-	if ws == nil {
-		writeError(w, http.StatusNotFound, "not_found", "Workspace not found")
+	ws, ok := s.getWorkspace(w, r)
+	if !ok {
 		return
 	}
 	writeJSON(w, http.StatusOK, ws)
@@ -249,7 +241,10 @@ func (s *Server) handleUpdateWorkspace(w http.ResponseWriter, r *http.Request) {
 	if !requireMinRole(w, r, "owner") {
 		return
 	}
-	slug := chi.URLParam(r, "slug")
+	existing, ok := s.getWorkspace(w, r)
+	if !ok {
+		return
+	}
 
 	var input models.WorkspaceUpdate
 	if err := decodeJSON(r, &input); err != nil {
@@ -261,7 +256,7 @@ func (s *Server) handleUpdateWorkspace(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ws, err := s.store.UpdateWorkspace(slug, input)
+	ws, err := s.store.UpdateWorkspace(existing.Slug, input)
 	if err != nil {
 		writeInternalError(w, err)
 		return
@@ -280,8 +275,11 @@ func (s *Server) handleDeleteWorkspace(w http.ResponseWriter, r *http.Request) {
 	if !requireMinRole(w, r, "owner") {
 		return
 	}
-	slug := chi.URLParam(r, "slug")
-	err := s.store.DeleteWorkspace(slug)
+	ws, ok := s.getWorkspace(w, r)
+	if !ok {
+		return
+	}
+	err := s.store.DeleteWorkspace(ws.Slug)
 	if err != nil {
 		writeError(w, http.StatusNotFound, "not_found", "Workspace not found")
 		return
@@ -293,14 +291,17 @@ func (s *Server) handleExportWorkspace(w http.ResponseWriter, r *http.Request) {
 	if !requireMinRole(w, r, "owner") {
 		return
 	}
-	slug := chi.URLParam(r, "slug")
-	export, err := s.store.ExportWorkspace(slug)
+	ws, ok := s.getWorkspace(w, r)
+	if !ok {
+		return
+	}
+	export, err := s.store.ExportWorkspace(ws.Slug)
 	if err != nil {
 		writeError(w, http.StatusNotFound, "not_found", err.Error())
 		return
 	}
 
-	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s-export.json"`, slug))
+	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s-export.json"`, ws.Slug))
 	writeJSON(w, http.StatusOK, export)
 }
 
@@ -314,10 +315,18 @@ func (s *Server) handleImportWorkspace(w http.ResponseWriter, r *http.Request) {
 	// Optional: override workspace name via query param
 	newName := r.URL.Query().Get("name")
 
-	ws, err := s.store.ImportWorkspace(&data, newName)
+	// Set the authenticated user as owner so the imported workspace is
+	// accessible and has correct owner_username for URL routing.
+	userID := currentUserID(r)
+	ws, err := s.store.ImportWorkspace(&data, newName, userID)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "import_failed", err.Error())
 		return
+	}
+
+	// Add the importer as workspace owner (mirrors handleCreateWorkspace)
+	if userID != "" {
+		_ = s.store.AddWorkspaceMember(ws.ID, userID, "owner")
 	}
 
 	writeJSON(w, http.StatusCreated, ws)

--- a/internal/server/middleware_auth.go
+++ b/internal/server/middleware_auth.go
@@ -25,6 +25,9 @@ const (
 	// ctxIsAPIToken is set to true when the request is authenticated via an API token
 	// (as opposed to a session cookie or CLI session token).
 	ctxIsAPIToken contextKey = "is_api_token"
+	// ctxResolvedWorkspaceID is set by RequireWorkspaceAccess after resolving
+	// the workspace slug/ID. Avoids redundant lookups in handlers.
+	ctxResolvedWorkspaceID contextKey = "resolved_workspace_id"
 )
 
 // TokenAuth middleware checks for an Authorization: Bearer pad_xxx header.
@@ -252,13 +255,14 @@ func currentUserID(r *http.Request) string {
 // if the token's workspace matches the requested workspace.
 func (s *Server) RequireWorkspaceAccess(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		slug := chi.URLParam(r, "slug")
-		if slug == "" {
+		slugOrID := chi.URLParam(r, "slug")
+		if slugOrID == "" {
 			next.ServeHTTP(w, r)
 			return
 		}
 
-		ws, err := s.store.GetWorkspaceBySlug(slug)
+		// Resolve workspace: supports both UUID and slug.
+		ws, err := s.resolveWorkspace(slugOrID, currentUser(r))
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "internal_error", "Failed to resolve workspace")
 			return
@@ -268,10 +272,13 @@ func (s *Server) RequireWorkspaceAccess(next http.Handler) http.Handler {
 			return
 		}
 
+		// Store resolved workspace ID in context for downstream handlers
+		ctx := context.WithValue(r.Context(), ctxResolvedWorkspaceID, ws.ID)
+
 		// Fresh install: no users → everyone gets owner access
 		count, _ := s.store.UserCount()
 		if count == 0 {
-			ctx := context.WithValue(r.Context(), ctxWorkspaceRole, "owner")
+			ctx = context.WithValue(ctx, ctxWorkspaceRole, "owner")
 			next.ServeHTTP(w, r.WithContext(ctx))
 			return
 		}
@@ -279,7 +286,7 @@ func (s *Server) RequireWorkspaceAccess(next http.Handler) http.Handler {
 		// Legacy API token: workspace-scoped token without user context
 		if tokenWsID := tokenWorkspaceID(r); tokenWsID != "" && currentUser(r) == nil {
 			if tokenWsID == ws.ID {
-				ctx := context.WithValue(r.Context(), ctxWorkspaceRole, "editor")
+				ctx = context.WithValue(ctx, ctxWorkspaceRole, "editor")
 				next.ServeHTTP(w, r.WithContext(ctx))
 				return
 			}
@@ -296,7 +303,7 @@ func (s *Server) RequireWorkspaceAccess(next http.Handler) http.Handler {
 
 		// Admin users get owner access to all workspaces
 		if user.Role == "admin" {
-			ctx := context.WithValue(r.Context(), ctxWorkspaceRole, "owner")
+			ctx = context.WithValue(ctx, ctxWorkspaceRole, "owner")
 			next.ServeHTTP(w, r.WithContext(ctx))
 			return
 		}
@@ -311,7 +318,7 @@ func (s *Server) RequireWorkspaceAccess(next http.Handler) http.Handler {
 			return
 		}
 
-		ctx := context.WithValue(r.Context(), ctxWorkspaceRole, member.Role)
+		ctx = context.WithValue(ctx, ctxWorkspaceRole, member.Role)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -592,13 +592,48 @@ func (s *Server) getWorkspaceID(w http.ResponseWriter, r *http.Request) (string,
 	return ws.ID, true
 }
 
+// getWorkspace returns the full workspace object resolved by middleware.
+// Falls back to direct resolution for routes without RequireWorkspaceAccess.
+func (s *Server) getWorkspace(w http.ResponseWriter, r *http.Request) (*models.Workspace, bool) {
+	// Fast path: use middleware-resolved ID
+	if wsID, ok := r.Context().Value(ctxResolvedWorkspaceID).(string); ok && wsID != "" {
+		ws, err := s.store.GetWorkspaceByID(wsID)
+		if err != nil {
+			writeInternalError(w, err)
+			return nil, false
+		}
+		if ws != nil {
+			return ws, true
+		}
+	}
+
+	// Slow path: resolve from URL param
+	slugOrID := chi.URLParam(r, "slug")
+	ws, err := s.resolveWorkspace(slugOrID, currentUser(r))
+	if err != nil {
+		writeInternalError(w, err)
+		return nil, false
+	}
+	if ws == nil {
+		writeError(w, http.StatusNotFound, "not_found", "Workspace not found")
+		return nil, false
+	}
+	return ws, true
+}
+
 // resolveWorkspace resolves a workspace by slug or UUID, scoped to the
 // authenticated user's accessible workspaces when a user context is present.
 // Returns nil (not an error) if no workspace is found.
 func (s *Server) resolveWorkspace(slugOrID string, user *models.User) (*models.Workspace, error) {
-	// 1. Is it a UUID? Resolve by ID directly.
+	// 1. Is it a UUID? Try resolving by ID first, then fall back to slug.
+	//    A workspace slug could be UUID-shaped (e.g. imported data), so we
+	//    can't short-circuit here.
 	if isUUID(slugOrID) {
-		return s.store.GetWorkspaceByID(slugOrID)
+		ws, err := s.store.GetWorkspaceByID(slugOrID)
+		if ws != nil || err != nil {
+			return ws, err
+		}
+		// Not found by ID — fall through to slug-based resolution
 	}
 
 	// 2. No authenticated user — fall back to global slug lookup

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -568,10 +568,19 @@ func decodeJSON(r *http.Request, v interface{}) error {
 	return nil
 }
 
-// getWorkspaceID resolves workspace slug to ID.
+// getWorkspaceID resolves workspace slug/ID from the request.
+// If RequireWorkspaceAccess already resolved the workspace, reads from context.
+// Otherwise falls back to direct resolution (for unauthenticated paths).
 func (s *Server) getWorkspaceID(w http.ResponseWriter, r *http.Request) (string, bool) {
-	slug := chi.URLParam(r, "slug")
-	ws, err := s.store.GetWorkspaceBySlug(slug)
+	// Fast path: already resolved by RequireWorkspaceAccess middleware
+	if wsID, ok := r.Context().Value(ctxResolvedWorkspaceID).(string); ok && wsID != "" {
+		return wsID, true
+	}
+
+	// Slow path: resolve directly (should rarely happen — only for routes
+	// that don't go through RequireWorkspaceAccess)
+	slugOrID := chi.URLParam(r, "slug")
+	ws, err := s.resolveWorkspace(slugOrID, currentUser(r))
 	if err != nil {
 		writeInternalError(w, err)
 		return "", false
@@ -582,6 +591,48 @@ func (s *Server) getWorkspaceID(w http.ResponseWriter, r *http.Request) (string,
 	}
 	return ws.ID, true
 }
+
+// resolveWorkspace resolves a workspace by slug or UUID, scoped to the
+// authenticated user's accessible workspaces when a user context is present.
+// Returns nil (not an error) if no workspace is found.
+func (s *Server) resolveWorkspace(slugOrID string, user *models.User) (*models.Workspace, error) {
+	// 1. Is it a UUID? Resolve by ID directly.
+	if isUUID(slugOrID) {
+		return s.store.GetWorkspaceByID(slugOrID)
+	}
+
+	// 2. No authenticated user — fall back to global slug lookup
+	//    (fresh install, or pre-auth paths)
+	if user == nil {
+		return s.store.GetWorkspaceBySlug(slugOrID)
+	}
+
+	// 3. Admin users — global slug lookup (admins can see all workspaces)
+	if user.Role == "admin" {
+		return s.store.GetWorkspaceBySlug(slugOrID)
+	}
+
+	// 4. Auth-scoped slug resolution: find workspaces where user is owner or member
+	workspaces, err := s.store.GetWorkspacesBySlugForUser(slugOrID, user.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(workspaces) == 1 {
+		return &workspaces[0], nil
+	}
+	if len(workspaces) == 0 {
+		return nil, nil
+	}
+
+	// Ambiguous: multiple workspaces match — this should be rare.
+	// For now, return the first one. The 409 disambiguation is only needed
+	// when we actually have per-owner slug uniqueness (after the unique
+	// constraint is changed). Currently slugs are globally unique.
+	return &workspaces[0], nil
+}
+
+// isUUID is defined in handlers_items.go
 
 // getWorkspaceDocument resolves workspace slug and document ID from URL params.
 func (s *Server) getWorkspaceDocument(w http.ResponseWriter, r *http.Request) (string, *models.Document, bool) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -234,6 +234,7 @@ func (s *Server) setupRouter() {
 			r.Get("/session", s.handleSessionCheck)
 			r.Post("/bootstrap", s.handleBootstrap)
 			r.Post("/register", s.handleRegister)
+			r.Get("/check-username", s.handleCheckUsername)
 			r.Post("/login", s.handleLogin)
 			r.Post("/logout", s.handleLogout)
 			r.Get("/me", s.handleGetCurrentUser)

--- a/internal/server/username.go
+++ b/internal/server/username.go
@@ -1,0 +1,94 @@
+package server
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+var usernameRe = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*[a-z0-9]$`)
+var usernameShortRe = regexp.MustCompile(`^[a-z0-9]$`)
+
+// reservedUsernames contains words that cannot be used as usernames because they
+// conflict with existing or planned URL routes, system paths, or common terms.
+// Decision D11: "be generous — better to reserve too many than too few."
+var reservedUsernames = map[string]bool{
+	// Auth routes
+	"login": true, "register": true, "join": true, "signup": true, "signin": true,
+	"forgot-password": true, "reset-password": true,
+	"logout": true, "auth": true, "oauth": true, "sso": true,
+
+	// App routes
+	"settings": true, "admin": true, "console": true,
+	"dashboard": true, "api": true, "health": true,
+	"new": true, "create": true, "edit": true, "delete": true,
+
+	// Share/special routes
+	"s": true, "share": true, "shared": true,
+	"invite": true, "invitations": true,
+
+	// System
+	"app": true, "www": true, "mail": true, "ftp": true, "smtp": true,
+	"static": true, "assets": true, "public": true, "cdn": true,
+	"pad": true, "system": true, "root": true, "server": true,
+	"null": true, "undefined": true, "nan": true, "true": true, "false": true,
+
+	// Common reserved
+	"about": true, "help": true, "support": true, "contact": true,
+	"docs": true, "blog": true, "pricing": true, "plans": true,
+	"terms": true, "privacy": true, "security": true, "legal": true,
+	"status": true, "changelog": true, "updates": true,
+	"home": true, "index": true, "search": true, "explore": true,
+	"notifications": true, "messages": true, "feed": true,
+	"account": true, "profile": true, "user": true, "users": true,
+	"org": true, "orgs": true, "team": true, "teams": true,
+	"workspace": true, "workspaces": true,
+	"project": true, "projects": true,
+}
+
+// ValidateUsername checks a username for format, length, and reserved word violations.
+// It does NOT check uniqueness (that requires a store call).
+func ValidateUsername(username string) error {
+	if username == "" {
+		return fmt.Errorf("username is required")
+	}
+
+	// Must be lowercase
+	if username != strings.ToLower(username) {
+		return fmt.Errorf("username must be lowercase")
+	}
+
+	// Length check
+	if len(username) < 3 {
+		return fmt.Errorf("username must be at least 3 characters")
+	}
+	if len(username) > 39 {
+		return fmt.Errorf("username must be at most 39 characters")
+	}
+
+	// Format check
+	if len(username) == 1 {
+		if !usernameShortRe.MatchString(username) {
+			return fmt.Errorf("username must contain only lowercase letters, numbers, and hyphens")
+		}
+	} else if !usernameRe.MatchString(username) {
+		return fmt.Errorf("username must contain only lowercase letters, numbers, and hyphens, and cannot start or end with a hyphen")
+	}
+
+	// No consecutive hyphens
+	if strings.Contains(username, "--") {
+		return fmt.Errorf("username cannot contain consecutive hyphens")
+	}
+
+	// Reserved words
+	if reservedUsernames[username] {
+		return fmt.Errorf("username %q is reserved", username)
+	}
+
+	return nil
+}
+
+// IsReservedUsername checks if a username is in the reserved list.
+func IsReservedUsername(username string) bool {
+	return reservedUsernames[strings.ToLower(username)]
+}

--- a/internal/store/export.go
+++ b/internal/store/export.go
@@ -146,7 +146,7 @@ func (s *Store) ExportWorkspace(slug string) (*models.WorkspaceExport, error) {
 // ImportWorkspace imports a workspace from an exported data structure.
 // It creates a new workspace with regenerated IDs, remapping all references.
 // If newName is non-empty, it overrides the workspace name and slug.
-func (s *Store) ImportWorkspace(data *models.WorkspaceExport, newName string) (*models.Workspace, error) {
+func (s *Store) ImportWorkspace(data *models.WorkspaceExport, newName string, ownerID string) (*models.Workspace, error) {
 	if data.Version != 1 {
 		return nil, fmt.Errorf("unsupported export version: %d", data.Version)
 	}
@@ -164,6 +164,7 @@ func (s *Store) ImportWorkspace(data *models.WorkspaceExport, newName string) (*
 		Slug:        wsSlug,
 		Description: data.Workspace.Description,
 		Settings:    data.Workspace.Settings,
+		OwnerID:     ownerID,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("create workspace: %w", err)

--- a/internal/store/migrations/029_username.sql
+++ b/internal/store/migrations/029_username.sql
@@ -1,0 +1,5 @@
+-- Add username column to users table.
+-- Nullable initially (empty string = not yet set).
+-- TASK-482 will backfill existing users and add NOT NULL constraint.
+ALTER TABLE users ADD COLUMN username TEXT DEFAULT '';
+CREATE UNIQUE INDEX IF NOT EXISTS idx_users_username ON users(username) WHERE username != '';

--- a/internal/store/migrations/030_workspace_owner.sql
+++ b/internal/store/migrations/030_workspace_owner.sql
@@ -1,0 +1,7 @@
+-- Add owner_id column to workspaces.
+-- Backfilled on startup by backfillWorkspaceOwners() with the earliest owner member.
+-- The global UNIQUE(slug) constraint remains until TASK-412 replaces it
+-- with UNIQUE(owner_id, slug) via table recreation.
+ALTER TABLE workspaces ADD COLUMN owner_id TEXT DEFAULT '';
+CREATE INDEX IF NOT EXISTS idx_workspaces_owner ON workspaces(owner_id);
+CREATE INDEX IF NOT EXISTS idx_workspaces_owner_slug ON workspaces(owner_id, slug);

--- a/internal/store/pgmigrations/009_username.sql
+++ b/internal/store/pgmigrations/009_username.sql
@@ -1,0 +1,5 @@
+-- Add username column to users table.
+-- Nullable initially (empty string = not yet set).
+-- TASK-482 will backfill existing users and add NOT NULL constraint.
+ALTER TABLE users ADD COLUMN IF NOT EXISTS username TEXT DEFAULT '';
+CREATE UNIQUE INDEX IF NOT EXISTS idx_users_username ON users(username) WHERE username != '';

--- a/internal/store/pgmigrations/010_workspace_owner.sql
+++ b/internal/store/pgmigrations/010_workspace_owner.sql
@@ -1,0 +1,5 @@
+-- Add owner_id column to workspaces.
+-- Backfilled on startup by backfillWorkspaceOwners() with the earliest owner member.
+ALTER TABLE workspaces ADD COLUMN IF NOT EXISTS owner_id TEXT DEFAULT '';
+CREATE INDEX IF NOT EXISTS idx_workspaces_owner ON workspaces(owner_id);
+CREATE INDEX IF NOT EXISTS idx_workspaces_owner_slug ON workspaces(owner_id, slug);

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -145,6 +145,7 @@ func (s *Store) migrate() error {
 		"026_session_binding.sql",
 		"027_totp.sql",
 		"028_workspace_sort_order.sql",
+		"029_username.sql",
 	}
 
 	for _, name := range migrations {
@@ -197,6 +198,7 @@ func (s *Store) migratePostgres() error {
 		"006_session_binding.sql",
 		"007_totp.sql",
 		"008_workspace_sort_order.sql",
+		"009_username.sql",
 	}
 
 	for _, name := range migrations {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -60,6 +60,10 @@ func New(dbPath string) (*Store, error) {
 		return nil, fmt.Errorf("backfill workspace owners: %w", err)
 	}
 
+	if err := s.backfillUsernames(); err != nil {
+		return nil, fmt.Errorf("backfill usernames: %w", err)
+	}
+
 	return s, nil
 }
 
@@ -92,6 +96,10 @@ func NewPostgres(connStr string) (*Store, error) {
 
 	if err := s.backfillWorkspaceOwners(); err != nil {
 		return nil, fmt.Errorf("backfill workspace owners: %w", err)
+	}
+
+	if err := s.backfillUsernames(); err != nil {
+		return nil, fmt.Errorf("backfill usernames: %w", err)
 	}
 
 	return s, nil

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -154,6 +154,7 @@ func (s *Store) migrate() error {
 		"027_totp.sql",
 		"028_workspace_sort_order.sql",
 		"029_username.sql",
+		"030_workspace_owner.sql",
 	}
 
 	for _, name := range migrations {
@@ -207,6 +208,7 @@ func (s *Store) migratePostgres() error {
 		"007_totp.sql",
 		"008_workspace_sort_order.sql",
 		"009_username.sql",
+		"010_workspace_owner.sql",
 	}
 
 	for _, name := range migrations {

--- a/internal/store/users.go
+++ b/internal/store/users.go
@@ -14,7 +14,7 @@ import (
 const bcryptCost = 12
 
 // user SELECT columns — used by all user queries.
-const userColumns = `id, email, name, password_hash, role, avatar_url, totp_secret, totp_enabled, recovery_codes, created_at, updated_at`
+const userColumns = `id, email, username, name, password_hash, role, avatar_url, totp_secret, totp_enabled, recovery_codes, created_at, updated_at`
 
 // scanUser scans a user row into a User struct.
 func scanUser(row interface{ Scan(...interface{}) error }) (*models.User, error) {
@@ -22,7 +22,7 @@ func scanUser(row interface{ Scan(...interface{}) error }) (*models.User, error)
 	var createdAt, updatedAt string
 
 	err := row.Scan(
-		&u.ID, &u.Email, &u.Name, &u.PasswordHash, &u.Role, &u.AvatarURL,
+		&u.ID, &u.Email, &u.Username, &u.Name, &u.PasswordHash, &u.Role, &u.AvatarURL,
 		&u.TOTPSecret, &u.TOTPEnabled, &u.RecoveryCodes,
 		&createdAt, &updatedAt,
 	)
@@ -54,9 +54,9 @@ func (s *Store) CreateUser(input models.UserCreate) (*models.User, error) {
 	ts := now()
 
 	_, err = s.db.Exec(s.q(`
-		INSERT INTO users (id, email, name, password_hash, role, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?)
-	`), id, strings.ToLower(strings.TrimSpace(input.Email)), strings.TrimSpace(input.Name), string(hash), role, ts, ts)
+		INSERT INTO users (id, email, username, name, password_hash, role, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+	`), id, strings.ToLower(strings.TrimSpace(input.Email)), strings.TrimSpace(input.Username), strings.TrimSpace(input.Name), string(hash), role, ts, ts)
 	if err != nil {
 		return nil, fmt.Errorf("insert user: %w", err)
 	}
@@ -83,6 +83,19 @@ func (s *Store) GetUserByEmail(email string) (*models.User, error) {
 	return u, nil
 }
 
+// GetUserByUsername retrieves a user by username (case-insensitive).
+func (s *Store) GetUserByUsername(username string) (*models.User, error) {
+	username = strings.ToLower(strings.TrimSpace(username))
+	if username == "" {
+		return nil, nil
+	}
+	u, err := scanUser(s.db.QueryRow(s.q(`SELECT `+userColumns+` FROM users WHERE LOWER(username) = ?`), username))
+	if err != nil {
+		return nil, fmt.Errorf("get user by username: %w", err)
+	}
+	return u, nil
+}
+
 // UpdateUser updates mutable user fields.
 func (s *Store) UpdateUser(id string, input models.UserUpdate) (*models.User, error) {
 	var sets []string
@@ -91,6 +104,10 @@ func (s *Store) UpdateUser(id string, input models.UserUpdate) (*models.User, er
 	if input.Name != nil {
 		sets = append(sets, "name = ?")
 		args = append(args, strings.TrimSpace(*input.Name))
+	}
+	if input.Username != nil {
+		sets = append(sets, "username = ?")
+		args = append(args, strings.TrimSpace(*input.Username))
 	}
 	if input.Password != nil {
 		hash, err := bcrypt.GenerateFromPassword([]byte(*input.Password), bcryptCost)

--- a/internal/store/users.go
+++ b/internal/store/users.go
@@ -5,11 +5,14 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/xarmian/pad/internal/models"
 	"golang.org/x/crypto/bcrypt"
 )
+
+var usernameCleanRe = regexp.MustCompile(`[^a-z0-9-]+`)
 
 const bcryptCost = 12
 
@@ -188,6 +191,112 @@ func (s *Store) UserCount() (int, error) {
 		return 0, fmt.Errorf("count users: %w", err)
 	}
 	return count, nil
+}
+
+// --- Username backfill ---
+
+// GenerateUsername derives a URL-safe username from a display name.
+// Falls back to the email local part if the name produces an empty result.
+func GenerateUsername(name, email string) string {
+	// Lowercase and replace spaces/special chars with hyphens
+	u := strings.ToLower(strings.TrimSpace(name))
+	u = usernameCleanRe.ReplaceAllString(u, "-")
+
+	// Collapse consecutive hyphens, strip leading/trailing
+	for strings.Contains(u, "--") {
+		u = strings.ReplaceAll(u, "--", "-")
+	}
+	u = strings.Trim(u, "-")
+
+	// Truncate to 39 chars (GitHub-style limit)
+	if len(u) > 39 {
+		u = u[:39]
+		u = strings.TrimRight(u, "-")
+	}
+
+	// Fall back to email local part
+	if u == "" && email != "" {
+		local := strings.Split(email, "@")[0]
+		u = strings.ToLower(local)
+		u = usernameCleanRe.ReplaceAllString(u, "-")
+		u = strings.Trim(u, "-")
+		if len(u) > 39 {
+			u = u[:39]
+			u = strings.TrimRight(u, "-")
+		}
+	}
+
+	if u == "" {
+		u = "user"
+	}
+	return u
+}
+
+// backfillUsernames generates usernames for existing users that don't have one.
+// Idempotent: skips users who already have a non-empty username.
+func (s *Store) backfillUsernames() error {
+	// Find users with empty username
+	rows, err := s.db.Query(s.q(`SELECT id, name, email FROM users WHERE username = '' OR username IS NULL`))
+	if err != nil {
+		return fmt.Errorf("find users without username: %w", err)
+	}
+	defer rows.Close()
+
+	type userRow struct {
+		id, name, email string
+	}
+	var users []userRow
+	for rows.Next() {
+		var u userRow
+		if err := rows.Scan(&u.id, &u.name, &u.email); err != nil {
+			return fmt.Errorf("scan user: %w", err)
+		}
+		users = append(users, u)
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+
+	if len(users) == 0 {
+		return nil // Nothing to backfill
+	}
+
+	// Collect all existing usernames to detect collisions
+	existing := make(map[string]bool)
+	existingRows, err := s.db.Query(s.q(`SELECT username FROM users WHERE username != ''`))
+	if err != nil {
+		return fmt.Errorf("list existing usernames: %w", err)
+	}
+	defer existingRows.Close()
+	for existingRows.Next() {
+		var u string
+		if err := existingRows.Scan(&u); err != nil {
+			return err
+		}
+		existing[strings.ToLower(u)] = true
+	}
+
+	for _, u := range users {
+		base := GenerateUsername(u.name, u.email)
+		username := base
+
+		// Handle collisions: append -2, -3, etc.
+		suffix := 2
+		for existing[username] {
+			username = fmt.Sprintf("%s-%d", base, suffix)
+			suffix++
+		}
+
+		existing[username] = true
+
+		_, err := s.db.Exec(s.q(`UPDATE users SET username = ?, updated_at = ? WHERE id = ?`),
+			username, now(), u.id)
+		if err != nil {
+			return fmt.Errorf("set username for user %s: %w", u.id, err)
+		}
+	}
+
+	return nil
 }
 
 // --- TOTP 2FA ---

--- a/internal/store/users.go
+++ b/internal/store/users.go
@@ -232,6 +232,24 @@ func GenerateUsername(name, email string) string {
 	return u
 }
 
+// EnsureUniqueUsername takes a candidate username and returns a unique variant
+// by appending -2, -3, etc. if the candidate already exists in the database.
+func (s *Store) EnsureUniqueUsername(base string) (string, error) {
+	username := base
+	suffix := 2
+	for {
+		existing, err := s.GetUserByUsername(username)
+		if err != nil {
+			return "", fmt.Errorf("check username uniqueness: %w", err)
+		}
+		if existing == nil {
+			return username, nil
+		}
+		username = fmt.Sprintf("%s-%d", base, suffix)
+		suffix++
+	}
+}
+
 // backfillUsernames generates usernames for existing users that don't have one.
 // Idempotent: skips users who already have a non-empty username.
 func (s *Store) backfillUsernames() error {

--- a/internal/store/workspace_members.go
+++ b/internal/store/workspace_members.go
@@ -99,10 +99,11 @@ func (s *Store) ListWorkspaceMembers(workspaceID string) ([]models.WorkspaceMemb
 // sorted by the user's custom sort order (then name as tiebreaker).
 func (s *Store) GetUserWorkspaces(userID string) ([]models.Workspace, error) {
 	rows, err := s.db.Query(s.q(`
-		SELECT w.id, w.name, w.slug, w.owner_id, w.description, w.settings, w.created_at, w.updated_at, w.deleted_at,
+		SELECT w.id, w.name, w.slug, w.owner_id, COALESCE(ou.username, ''), w.description, w.settings, w.created_at, w.updated_at, w.deleted_at,
 		       wm.sort_order
 		FROM workspaces w
 		JOIN workspace_members wm ON wm.workspace_id = w.id
+		LEFT JOIN users ou ON ou.id = w.owner_id
 		WHERE wm.user_id = ? AND w.deleted_at IS NULL
 		ORDER BY wm.sort_order ASC, w.name ASC
 	`), userID)
@@ -117,7 +118,7 @@ func (s *Store) GetUserWorkspaces(userID string) ([]models.Workspace, error) {
 		var createdAt, updatedAt string
 		var deletedAt *string
 		if err := rows.Scan(
-			&ws.ID, &ws.Name, &ws.Slug, &ws.OwnerID, &ws.Description, &ws.Settings,
+			&ws.ID, &ws.Name, &ws.Slug, &ws.OwnerID, &ws.OwnerUsername, &ws.Description, &ws.Settings,
 			&createdAt, &updatedAt, &deletedAt,
 			&ws.SortOrder,
 		); err != nil {

--- a/internal/store/workspace_members.go
+++ b/internal/store/workspace_members.go
@@ -99,7 +99,7 @@ func (s *Store) ListWorkspaceMembers(workspaceID string) ([]models.WorkspaceMemb
 // sorted by the user's custom sort order (then name as tiebreaker).
 func (s *Store) GetUserWorkspaces(userID string) ([]models.Workspace, error) {
 	rows, err := s.db.Query(s.q(`
-		SELECT w.id, w.name, w.slug, w.description, w.settings, w.created_at, w.updated_at, w.deleted_at,
+		SELECT w.id, w.name, w.slug, w.owner_id, w.description, w.settings, w.created_at, w.updated_at, w.deleted_at,
 		       wm.sort_order
 		FROM workspaces w
 		JOIN workspace_members wm ON wm.workspace_id = w.id
@@ -117,7 +117,7 @@ func (s *Store) GetUserWorkspaces(userID string) ([]models.Workspace, error) {
 		var createdAt, updatedAt string
 		var deletedAt *string
 		if err := rows.Scan(
-			&ws.ID, &ws.Name, &ws.Slug, &ws.Description, &ws.Settings,
+			&ws.ID, &ws.Name, &ws.Slug, &ws.OwnerID, &ws.Description, &ws.Settings,
 			&createdAt, &updatedAt, &deletedAt,
 			&ws.SortOrder,
 		); err != nil {
@@ -388,6 +388,60 @@ func (s *Store) backfillWorkspaceOwners() error {
 	for _, wsID := range wsIDs {
 		if err := s.AddWorkspaceMember(wsID, adminID, "owner"); err != nil {
 			return fmt.Errorf("add owner to workspace %s: %w", wsID, err)
+		}
+	}
+
+	// Backfill owner_id column on workspaces that don't have one set.
+	// Uses D3 logic: earliest owner member → earliest member → first admin.
+	ownerlessRows, err := s.db.Query(s.q(`
+		SELECT id FROM workspaces WHERE (owner_id = '' OR owner_id IS NULL) AND deleted_at IS NULL
+	`))
+	if err != nil {
+		return fmt.Errorf("find workspaces without owner_id: %w", err)
+	}
+	defer ownerlessRows.Close()
+
+	var ownerlessIDs []string
+	for ownerlessRows.Next() {
+		var id string
+		if err := ownerlessRows.Scan(&id); err != nil {
+			return err
+		}
+		ownerlessIDs = append(ownerlessIDs, id)
+	}
+	if err := ownerlessRows.Err(); err != nil {
+		return err
+	}
+
+	for _, wsID := range ownerlessIDs {
+		var ownerID string
+
+		// Try: earliest member with "owner" role
+		err := s.db.QueryRow(s.q(`
+			SELECT user_id FROM workspace_members
+			WHERE workspace_id = ? AND role = 'owner'
+			ORDER BY created_at ASC LIMIT 1
+		`), wsID).Scan(&ownerID)
+
+		if err == sql.ErrNoRows {
+			// Try: earliest member regardless of role
+			err = s.db.QueryRow(s.q(`
+				SELECT user_id FROM workspace_members
+				WHERE workspace_id = ?
+				ORDER BY created_at ASC LIMIT 1
+			`), wsID).Scan(&ownerID)
+		}
+
+		if err == sql.ErrNoRows {
+			// Fall back to first admin
+			ownerID = adminID
+		} else if err != nil {
+			return fmt.Errorf("find owner for workspace %s: %w", wsID, err)
+		}
+
+		_, err = s.db.Exec(s.q(`UPDATE workspaces SET owner_id = ? WHERE id = ?`), ownerID, wsID)
+		if err != nil {
+			return fmt.Errorf("set owner_id for workspace %s: %w", wsID, err)
 		}
 	}
 

--- a/internal/store/workspace_members.go
+++ b/internal/store/workspace_members.go
@@ -68,7 +68,7 @@ func (s *Store) GetWorkspaceMember(workspaceID, userID string) (*models.Workspac
 func (s *Store) ListWorkspaceMembers(workspaceID string) ([]models.WorkspaceMember, error) {
 	rows, err := s.db.Query(s.q(`
 		SELECT wm.workspace_id, wm.user_id, wm.role, wm.created_at,
-		       u.name, u.email
+		       u.name, u.email, u.username
 		FROM workspace_members wm
 		JOIN users u ON u.id = wm.user_id
 		WHERE wm.workspace_id = ?
@@ -85,7 +85,7 @@ func (s *Store) ListWorkspaceMembers(workspaceID string) ([]models.WorkspaceMemb
 		var createdAt string
 		if err := rows.Scan(
 			&m.WorkspaceID, &m.UserID, &m.Role, &createdAt,
-			&m.UserName, &m.UserEmail,
+			&m.UserName, &m.UserEmail, &m.UserUsername,
 		); err != nil {
 			return nil, fmt.Errorf("scan workspace member: %w", err)
 		}

--- a/internal/store/workspaces.go
+++ b/internal/store/workspaces.go
@@ -164,6 +164,36 @@ func (s *Store) GetWorkspaceByID(id string) (*models.Workspace, error) {
 	return &w, nil
 }
 
+// GetWorkspacesBySlugForUser finds workspaces matching a slug that are accessible
+// to the given user (owned by them or where they are a member).
+func (s *Store) GetWorkspacesBySlugForUser(slug, userID string) ([]models.Workspace, error) {
+	rows, err := s.db.Query(s.q(`
+		SELECT DISTINCT w.id, w.name, w.slug, w.owner_id, w.description, w.settings, w.created_at, w.updated_at
+		FROM workspaces w
+		LEFT JOIN workspace_members wm ON wm.workspace_id = w.id AND wm.user_id = ?
+		WHERE w.slug = ? AND w.deleted_at IS NULL
+		AND (w.owner_id = ? OR wm.user_id IS NOT NULL)
+	`), userID, slug, userID)
+	if err != nil {
+		return nil, fmt.Errorf("get workspaces by slug for user: %w", err)
+	}
+	defer rows.Close()
+
+	var result []models.Workspace
+	for rows.Next() {
+		var w models.Workspace
+		var createdAt, updatedAt string
+		if err := rows.Scan(&w.ID, &w.Name, &w.Slug, &w.OwnerID, &w.Description, &w.Settings, &createdAt, &updatedAt); err != nil {
+			return nil, err
+		}
+		w.CreatedAt = parseTime(createdAt)
+		w.UpdatedAt = parseTime(updatedAt)
+		w.HydrateDerivedFields()
+		result = append(result, w)
+	}
+	return result, rows.Err()
+}
+
 func (s *Store) UpdateWorkspace(slug string, input models.WorkspaceUpdate) (*models.Workspace, error) {
 	w, err := s.GetWorkspaceBySlug(slug)
 	if err != nil {

--- a/internal/store/workspaces.go
+++ b/internal/store/workspaces.go
@@ -19,18 +19,20 @@ func (s *Store) ListWorkspacesForUser(userID string) ([]models.Workspace, error)
 
 	if userID != "" {
 		rows, err = s.db.Query(s.q(`
-			SELECT w.id, w.name, w.slug, w.owner_id, w.description, w.settings, w.created_at, w.updated_at,
+			SELECT w.id, w.name, w.slug, w.owner_id, COALESCE(ou.username, ''), w.description, w.settings, w.created_at, w.updated_at,
 			       COALESCE(wm.sort_order, 0)
 			FROM workspaces w
 			LEFT JOIN workspace_members wm ON wm.workspace_id = w.id AND wm.user_id = ?
+			LEFT JOIN users ou ON ou.id = w.owner_id
 			WHERE w.deleted_at IS NULL
 			ORDER BY COALESCE(wm.sort_order, 0) ASC, w.name ASC
 		`), userID)
 	} else {
 		rows, err = s.db.Query(s.q(`
-			SELECT w.id, w.name, w.slug, w.owner_id, w.description, w.settings, w.created_at, w.updated_at,
+			SELECT w.id, w.name, w.slug, w.owner_id, COALESCE(ou.username, ''), w.description, w.settings, w.created_at, w.updated_at,
 			       0 as sort_order
 			FROM workspaces w
+			LEFT JOIN users ou ON ou.id = w.owner_id
 			WHERE w.deleted_at IS NULL
 			ORDER BY w.name ASC
 		`))
@@ -44,7 +46,7 @@ func (s *Store) ListWorkspacesForUser(userID string) ([]models.Workspace, error)
 	for rows.Next() {
 		var w models.Workspace
 		var createdAt, updatedAt string
-		if err := rows.Scan(&w.ID, &w.Name, &w.Slug, &w.OwnerID, &w.Description, &w.Settings, &createdAt, &updatedAt, &w.SortOrder); err != nil {
+		if err := rows.Scan(&w.ID, &w.Name, &w.Slug, &w.OwnerID, &w.OwnerUsername, &w.Description, &w.Settings, &createdAt, &updatedAt, &w.SortOrder); err != nil {
 			return nil, err
 		}
 		w.CreatedAt = parseTime(createdAt)
@@ -122,10 +124,11 @@ func (s *Store) GetWorkspaceBySlug(slug string) (*models.Workspace, error) {
 	var deletedAt *string
 
 	err := s.db.QueryRow(s.q(`
-		SELECT id, name, slug, owner_id, description, settings, created_at, updated_at, deleted_at
-		FROM workspaces
-		WHERE slug = ? AND deleted_at IS NULL
-	`), slug).Scan(&w.ID, &w.Name, &w.Slug, &w.OwnerID, &w.Description, &w.Settings, &createdAt, &updatedAt, &deletedAt)
+		SELECT w.id, w.name, w.slug, w.owner_id, COALESCE(ou.username, ''), w.description, w.settings, w.created_at, w.updated_at, w.deleted_at
+		FROM workspaces w
+		LEFT JOIN users ou ON ou.id = w.owner_id
+		WHERE w.slug = ? AND w.deleted_at IS NULL
+	`), slug).Scan(&w.ID, &w.Name, &w.Slug, &w.OwnerID, &w.OwnerUsername, &w.Description, &w.Settings, &createdAt, &updatedAt, &deletedAt)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -146,10 +149,11 @@ func (s *Store) GetWorkspaceByID(id string) (*models.Workspace, error) {
 	var deletedAt *string
 
 	err := s.db.QueryRow(s.q(`
-		SELECT id, name, slug, owner_id, description, settings, created_at, updated_at, deleted_at
-		FROM workspaces
-		WHERE id = ? AND deleted_at IS NULL
-	`), id).Scan(&w.ID, &w.Name, &w.Slug, &w.OwnerID, &w.Description, &w.Settings, &createdAt, &updatedAt, &deletedAt)
+		SELECT w.id, w.name, w.slug, w.owner_id, COALESCE(ou.username, ''), w.description, w.settings, w.created_at, w.updated_at, w.deleted_at
+		FROM workspaces w
+		LEFT JOIN users ou ON ou.id = w.owner_id
+		WHERE w.id = ? AND w.deleted_at IS NULL
+	`), id).Scan(&w.ID, &w.Name, &w.Slug, &w.OwnerID, &w.OwnerUsername, &w.Description, &w.Settings, &createdAt, &updatedAt, &deletedAt)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -168,9 +172,10 @@ func (s *Store) GetWorkspaceByID(id string) (*models.Workspace, error) {
 // to the given user (owned by them or where they are a member).
 func (s *Store) GetWorkspacesBySlugForUser(slug, userID string) ([]models.Workspace, error) {
 	rows, err := s.db.Query(s.q(`
-		SELECT DISTINCT w.id, w.name, w.slug, w.owner_id, w.description, w.settings, w.created_at, w.updated_at
+		SELECT DISTINCT w.id, w.name, w.slug, w.owner_id, COALESCE(ou.username, ''), w.description, w.settings, w.created_at, w.updated_at
 		FROM workspaces w
 		LEFT JOIN workspace_members wm ON wm.workspace_id = w.id AND wm.user_id = ?
+		LEFT JOIN users ou ON ou.id = w.owner_id
 		WHERE w.slug = ? AND w.deleted_at IS NULL
 		AND (w.owner_id = ? OR wm.user_id IS NOT NULL)
 	`), userID, slug, userID)
@@ -183,7 +188,7 @@ func (s *Store) GetWorkspacesBySlugForUser(slug, userID string) ([]models.Worksp
 	for rows.Next() {
 		var w models.Workspace
 		var createdAt, updatedAt string
-		if err := rows.Scan(&w.ID, &w.Name, &w.Slug, &w.OwnerID, &w.Description, &w.Settings, &createdAt, &updatedAt); err != nil {
+		if err := rows.Scan(&w.ID, &w.Name, &w.Slug, &w.OwnerID, &w.OwnerUsername, &w.Description, &w.Settings, &createdAt, &updatedAt); err != nil {
 			return nil, err
 		}
 		w.CreatedAt = parseTime(createdAt)

--- a/internal/store/workspaces.go
+++ b/internal/store/workspaces.go
@@ -19,7 +19,7 @@ func (s *Store) ListWorkspacesForUser(userID string) ([]models.Workspace, error)
 
 	if userID != "" {
 		rows, err = s.db.Query(s.q(`
-			SELECT w.id, w.name, w.slug, w.description, w.settings, w.created_at, w.updated_at,
+			SELECT w.id, w.name, w.slug, w.owner_id, w.description, w.settings, w.created_at, w.updated_at,
 			       COALESCE(wm.sort_order, 0)
 			FROM workspaces w
 			LEFT JOIN workspace_members wm ON wm.workspace_id = w.id AND wm.user_id = ?
@@ -28,7 +28,7 @@ func (s *Store) ListWorkspacesForUser(userID string) ([]models.Workspace, error)
 		`), userID)
 	} else {
 		rows, err = s.db.Query(s.q(`
-			SELECT w.id, w.name, w.slug, w.description, w.settings, w.created_at, w.updated_at,
+			SELECT w.id, w.name, w.slug, w.owner_id, w.description, w.settings, w.created_at, w.updated_at,
 			       0 as sort_order
 			FROM workspaces w
 			WHERE w.deleted_at IS NULL
@@ -44,7 +44,7 @@ func (s *Store) ListWorkspacesForUser(userID string) ([]models.Workspace, error)
 	for rows.Next() {
 		var w models.Workspace
 		var createdAt, updatedAt string
-		if err := rows.Scan(&w.ID, &w.Name, &w.Slug, &w.Description, &w.Settings, &createdAt, &updatedAt, &w.SortOrder); err != nil {
+		if err := rows.Scan(&w.ID, &w.Name, &w.Slug, &w.OwnerID, &w.Description, &w.Settings, &createdAt, &updatedAt, &w.SortOrder); err != nil {
 			return nil, err
 		}
 		w.CreatedAt = parseTime(createdAt)
@@ -91,9 +91,9 @@ func (s *Store) CreateWorkspace(input models.WorkspaceCreate) (*models.Workspace
 	}
 
 	_, err = s.db.Exec(s.q(`
-		INSERT INTO workspaces (id, name, slug, description, settings, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?)
-	`), id, input.Name, finalSlug, input.Description, settings, ts, ts)
+		INSERT INTO workspaces (id, name, slug, owner_id, description, settings, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+	`), id, input.Name, finalSlug, input.OwnerID, input.Description, settings, ts, ts)
 	if err != nil {
 		return nil, fmt.Errorf("insert workspace: %w", err)
 	}
@@ -122,10 +122,10 @@ func (s *Store) GetWorkspaceBySlug(slug string) (*models.Workspace, error) {
 	var deletedAt *string
 
 	err := s.db.QueryRow(s.q(`
-		SELECT id, name, slug, description, settings, created_at, updated_at, deleted_at
+		SELECT id, name, slug, owner_id, description, settings, created_at, updated_at, deleted_at
 		FROM workspaces
 		WHERE slug = ? AND deleted_at IS NULL
-	`), slug).Scan(&w.ID, &w.Name, &w.Slug, &w.Description, &w.Settings, &createdAt, &updatedAt, &deletedAt)
+	`), slug).Scan(&w.ID, &w.Name, &w.Slug, &w.OwnerID, &w.Description, &w.Settings, &createdAt, &updatedAt, &deletedAt)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -146,10 +146,10 @@ func (s *Store) GetWorkspaceByID(id string) (*models.Workspace, error) {
 	var deletedAt *string
 
 	err := s.db.QueryRow(s.q(`
-		SELECT id, name, slug, description, settings, created_at, updated_at, deleted_at
+		SELECT id, name, slug, owner_id, description, settings, created_at, updated_at, deleted_at
 		FROM workspaces
 		WHERE id = ? AND deleted_at IS NULL
-	`), id).Scan(&w.ID, &w.Name, &w.Slug, &w.Description, &w.Settings, &createdAt, &updatedAt, &deletedAt)
+	`), id).Scan(&w.ID, &w.Name, &w.Slug, &w.OwnerID, &w.Description, &w.Settings, &createdAt, &updatedAt, &deletedAt)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -534,11 +534,13 @@ export const api = {
 				method: 'POST',
 				body: JSON.stringify({ challenge_token: challengeToken, code: code || undefined, recovery_code: recoveryCode || undefined })
 			}),
-		register: (email: string, name: string, password: string, invitation_code?: string) =>
+		register: (email: string, name: string, password: string, username?: string, invitation_code?: string) =>
 			request<{ user: { id: string; email: string; username: string; name: string; role: string }; token: string }>('/auth/register', {
 				method: 'POST',
-				body: JSON.stringify({ email, name, password, ...(invitation_code ? { invitation_code } : {}) })
+				body: JSON.stringify({ email, name, password, ...(username ? { username } : {}), ...(invitation_code ? { invitation_code } : {}) })
 			}),
+		checkUsername: (username: string) =>
+			request<{ available: boolean; reason: string | null; message: string | null }>(`/auth/check-username?username=${encodeURIComponent(username)}`),
 		logout: () => request<{ ok: boolean }>('/auth/logout', { method: 'POST' }),
 		forgotPassword: (email: string) =>
 			request<{ ok: boolean; message: string }>('/auth/forgot-password', {

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -105,11 +105,11 @@ export interface AuthSession {
 	setup_required: boolean;
 	setup_method?: 'local_cli' | 'docker_exec' | 'cloud';
 	auth_method: 'password' | 'cloud';
-	user?: { id: string; email: string; name: string; role: string };
+	user?: { id: string; email: string; username: string; name: string; role: string };
 }
 
 export interface LoginResponse {
-	user?: { id: string; email: string; name: string; role: string };
+	user?: { id: string; email: string; username: string; name: string; role: string };
 	token?: string;
 	requires_2fa?: boolean;
 	challenge_token?: string;
@@ -530,12 +530,12 @@ export const api = {
 				body: JSON.stringify({ email, password })
 			}),
 		verify2FA: (challengeToken: string, code?: string, recoveryCode?: string) =>
-			request<{ user: { id: string; email: string; name: string; role: string }; token: string }>('/auth/2fa/login-verify', {
+			request<{ user: { id: string; email: string; username: string; name: string; role: string }; token: string }>('/auth/2fa/login-verify', {
 				method: 'POST',
 				body: JSON.stringify({ challenge_token: challengeToken, code: code || undefined, recovery_code: recoveryCode || undefined })
 			}),
 		register: (email: string, name: string, password: string, invitation_code?: string) =>
-			request<{ user: { id: string; email: string; name: string; role: string }; token: string }>('/auth/register', {
+			request<{ user: { id: string; email: string; username: string; name: string; role: string }; token: string }>('/auth/register', {
 				method: 'POST',
 				body: JSON.stringify({ email, name, password, ...(invitation_code ? { invitation_code } : {}) })
 			}),
@@ -546,7 +546,7 @@ export const api = {
 				body: JSON.stringify({ email })
 			}),
 		resetPassword: (token: string, password: string) =>
-			request<{ ok: boolean; user: { id: string; email: string; name: string; role: string }; token: string }>('/auth/reset-password', {
+			request<{ ok: boolean; user: { id: string; email: string; username: string; name: string; role: string }; token: string }>('/auth/reset-password', {
 				method: 'POST',
 				body: JSON.stringify({ token, password })
 			}),

--- a/web/src/lib/components/ChildItems.svelte
+++ b/web/src/lib/components/ChildItems.svelte
@@ -14,6 +14,7 @@
 
 	interface Props {
 		wsSlug: string;
+		username?: string;
 		itemSlug: string;
 		itemId: string;
 		parentFields?: Record<string, any>;
@@ -21,7 +22,7 @@
 		onChildrenChange?: (children: Item[]) => void;
 	}
 
-	let { wsSlug, itemSlug, itemId, parentFields, terminalStatuses, onChildrenChange }: Props = $props();
+	let { wsSlug, username = '', itemSlug, itemId, parentFields, terminalStatuses, onChildrenChange }: Props = $props();
 
 	const defaultTerminal = ['done', 'completed', 'resolved', 'cancelled', 'rejected', 'wontfix', 'fixed', 'implemented', 'archived', 'disabled', 'deprecated'];
 	const terminal = $derived(terminalStatuses ?? defaultTerminal);
@@ -222,7 +223,7 @@
 										<span class="expand-icon" class:expanded={isExpanded}>▸</span>
 									</button>
 								{/if}
-								<a href="/{wsSlug}/{child.collection_slug}/{child.slug}" class="child-row" class:has-toggle={canExpand}>
+								<a href="/{username}/{wsSlug}/{child.collection_slug}/{child.slug}" class="child-row" class:has-toggle={canExpand}>
 									<span class="child-ref">{formatItemRef(child) ?? ''}</span>
 									<span class="child-title" class:done={isDone}>{child.title}</span>
 									{#if fields.priority}
@@ -237,7 +238,7 @@
 								</a>
 							</div>
 							{#if canExpand && isExpanded}
-								<NestedChildren {wsSlug} parentSlug={child.slug} depth={1} maxDepth={3} {terminalStatuses} />
+								<NestedChildren {wsSlug} {username} parentSlug={child.slug} depth={1} maxDepth={3} {terminalStatuses} />
 							{/if}
 						</div>
 					{/each}

--- a/web/src/lib/components/NestedChildren.svelte
+++ b/web/src/lib/components/NestedChildren.svelte
@@ -5,13 +5,14 @@
 
 	interface Props {
 		wsSlug: string;
+		username?: string;
 		parentSlug: string;
 		depth?: number;
 		maxDepth?: number;
 		terminalStatuses?: string[];
 	}
 
-	let { wsSlug, parentSlug, depth = 1, maxDepth = 3, terminalStatuses }: Props = $props();
+	let { wsSlug, username = '', parentSlug, depth = 1, maxDepth = 3, terminalStatuses }: Props = $props();
 
 	const defaultTerminal = ['done', 'completed', 'resolved', 'cancelled', 'rejected', 'wontfix', 'fixed', 'implemented', 'archived', 'disabled', 'deprecated'];
 	const terminal = $derived(terminalStatuses ?? defaultTerminal);
@@ -73,7 +74,7 @@
 					{:else}
 						<span class="expand-spacer"></span>
 					{/if}
-					<a href="/{wsSlug}/{child.collection_slug}/{child.slug}" class="nested-link">
+					<a href="/{username}/{wsSlug}/{child.collection_slug}/{child.slug}" class="nested-link">
 						<span class="nested-ref">{formatItemRef(child) ?? ''}</span>
 						<span class="nested-title" class:done={isDone}>{child.title}</span>
 					</a>
@@ -88,7 +89,7 @@
 					{/if}
 				</div>
 				{#if canExpand && isExpanded}
-					<svelte:self wsSlug={wsSlug} parentSlug={child.slug} depth={depth + 1} {maxDepth} {terminalStatuses} />
+					<svelte:self wsSlug={wsSlug} {username} parentSlug={child.slug} depth={depth + 1} {maxDepth} {terminalStatuses} />
 				{/if}
 			</div>
 		{/each}

--- a/web/src/lib/components/OnboardingChecklist.svelte
+++ b/web/src/lib/components/OnboardingChecklist.svelte
@@ -3,11 +3,12 @@
 
 	interface Props {
 		wsSlug: string;
+		username?: string;
 		byCollection: Record<string, Record<string, number>>;
 		ondismiss?: () => void;
 	}
 
-	let { wsSlug, byCollection, ondismiss }: Props = $props();
+	let { wsSlug, username = '', byCollection, ondismiss }: Props = $props();
 
 	let copiedHint = $state<string | null>(null);
 
@@ -33,25 +34,25 @@
 	let steps = $derived<Step[]>([
 		{
 			title: 'Add project conventions',
-			href: `/${wsSlug}/library`,
+			href: `/${username}/${wsSlug}/library`,
 			done: collectionHasItems('conventions'),
 			hint: '/pad what conventions should this project follow?'
 		},
 		{
 			title: 'Create your first plan',
-			href: `/${wsSlug}/plans`,
+			href: `/${username}/${wsSlug}/plans`,
 			done: collectionHasItems('plans'),
 			hint: '/pad create a plan for what I\'m working on'
 		},
 		{
 			title: 'Add a few tasks',
-			href: `/${wsSlug}/tasks`,
+			href: `/${username}/${wsSlug}/tasks`,
 			done: collectionItemCount('tasks') >= 3,
 			hint: '/pad break down my current work into tasks'
 		},
 		{
 			title: 'Write an architecture doc',
-			href: `/${wsSlug}/docs`,
+			href: `/${username}/${wsSlug}/docs`,
 			done: collectionHasItems('docs'),
 			hint: '/pad document the architecture of this project'
 		}
@@ -129,7 +130,7 @@
 		<p class="footer-instructions">
 			Install the Pad skill in your project with <code>pad agent install</code>, then paste a prompt above into Claude Code or your favorite AI agent.
 		</p>
-		<a href="/{wsSlug}/library" class="footer-link">Or browse the library for conventions and playbooks</a>
+		<a href="/{username}/{wsSlug}/library" class="footer-link">Or browse the library for conventions and playbooks</a>
 	</div>
 </div>
 

--- a/web/src/lib/components/collections/BoardView.svelte
+++ b/web/src/lib/components/collections/BoardView.svelte
@@ -25,6 +25,7 @@
 	let { items, collection, wsSlug = '', groupField = 'status', focusedItemId = null, onStatusChange, onReorder, onArchiveColumn, onGroupReorder, oncreate, itemProgress, progressLabel = 'tasks' }: Props = $props();
 
 	let confirmArchiveColumn = $state<string | null>(null);
+	let isMobile = $state(false);
 
 	const flipDurationMs = 200;
 	const touchDragDelayMs = 500;
@@ -38,6 +39,18 @@
 
 	$effect(() => {
 		columnOrder = [...columns];
+	});
+
+	$effect(() => {
+		const mql = window.matchMedia('(max-width: 768px)');
+		isMobile = mql.matches;
+		function onChange(e: MediaQueryListEvent) {
+			isMobile = e.matches;
+		}
+		mql.addEventListener('change', onChange);
+		return () => {
+			mql.removeEventListener('change', onChange);
+		};
 	});
 
 	// Native HTML5 drag-and-drop for column reordering
@@ -242,14 +255,15 @@
 					flipDurationMs,
 					type: 'board-card',
 					dropTargetClasses: ['drop-target'],
-					delayTouchStart: touchDragDelayMs
+					delayTouchStart: touchDragDelayMs,
+					dragDisabled: isMobile
 				}}
 				onconsider={(e) => handleConsider(colValue, e)}
 				onfinalize={(e) => handleFinalize(colValue, e)}
 				oncontextmenu={(e) => e.preventDefault()}
 			>
 				{#each colItems as item (item.id)}
-					<div class="card-wrapper">
+					<div class="card-wrapper" class:no-drag={isMobile}>
 						<ItemCard
 							{item}
 							{collection}
@@ -449,6 +463,14 @@
 
 	.card-wrapper:active {
 		cursor: grabbing;
+	}
+
+	.card-wrapper.no-drag {
+		cursor: default;
+	}
+
+	.card-wrapper.no-drag:active {
+		cursor: default;
 	}
 
 	.column-empty {

--- a/web/src/lib/components/collections/ItemCard.svelte
+++ b/web/src/lib/components/collections/ItemCard.svelte
@@ -18,12 +18,13 @@
 	let { item, collection, compact = false, focused = false, showCollection = false, statusOptions, onStatusClick, progress = null, progressLabel = 'tasks' }: Props = $props();
 
 	let wsSlug = $derived(page.params.workspace ?? '');
+	let username = $derived(page.params.username ?? '');
 	let fields = $derived(parseFields(item));
 	let schema = $derived(parseSchema(collection));
 
 	let statusField = $derived(schema.fields.find((f) => f.key === 'status'));
 	let priorityField = $derived(schema.fields.find((f) => f.key === 'priority'));
-	let itemUrl = $derived(`/${wsSlug}/${collection.slug}/${itemUrlId(item)}`);
+	let itemUrl = $derived(`/${username}/${wsSlug}/${collection.slug}/${itemUrlId(item)}`);
 	let itemRef = $derived(formatItemRef(item));
 
 	let statusCyclable = $derived(

--- a/web/src/lib/components/collections/TableView.svelte
+++ b/web/src/lib/components/collections/TableView.svelte
@@ -25,6 +25,7 @@
 	}: Props = $props();
 
 	let resolvedWsSlug = $derived(wsSlug || page.params.workspace || '');
+	let resolvedUsername = $derived(page.params.username || '');
 	let schema = $derived(parseSchema(collection));
 	let visibleFields = $derived(schema.fields.filter((f) => !f.computed));
 
@@ -127,7 +128,7 @@
 				<tr>
 					<td class="col-ref"><span class="ref">{formatItemRef(item) ?? ''}</span></td>
 					<td class="col-title">
-						<a href="/{resolvedWsSlug}/{collection.slug}/{itemUrlId(item)}" class="title-link">{item.title}</a>
+						<a href="/{resolvedUsername}/{resolvedWsSlug}/{collection.slug}/{itemUrlId(item)}" class="title-link">{item.title}</a>
 						{#if itemProgress?.[item.id]}
 							{@const p = itemProgress[item.id]}
 							<div class="cell-progress">

--- a/web/src/lib/components/layout/CreateWorkspaceModal.svelte
+++ b/web/src/lib/components/layout/CreateWorkspaceModal.svelte
@@ -48,7 +48,7 @@
 				template: selectedTemplate || undefined
 			});
 			close();
-			goto(`/${ws.slug}`);
+			goto(`/${ws.owner_username}/${ws.slug}`);
 		} catch {
 			toastStore.show('Failed to create workspace', 'error');
 		}
@@ -68,7 +68,7 @@
 			await workspaceStore.loadAll();
 			close();
 			toastStore.show(`Imported workspace "${ws.name}"`, 'success');
-			goto(`/${ws.slug}`);
+			goto(`/${ws.owner_username}/${ws.slug}`);
 		} catch (err) {
 			toastStore.show(`Import failed: ${err instanceof Error ? err.message : 'Unknown error'}`, 'error');
 		} finally {

--- a/web/src/lib/components/layout/Sidebar.svelte
+++ b/web/src/lib/components/layout/Sidebar.svelte
@@ -22,13 +22,15 @@
 	let quickAddInputEl = $state<HTMLTextAreaElement>();
 
 	let wsSlug = $derived(workspaceStore.current?.slug);
-	let isDashboardPage = $derived(wsSlug ? page.url.pathname === `/${wsSlug}` : false);
-	let isRolesPage = $derived(wsSlug ? page.url.pathname === `/${wsSlug}/roles` : false);
-	let isActivityPage = $derived(wsSlug ? page.url.pathname === `/${wsSlug}/activity` : false);
+	let wsUsername = $derived(workspaceStore.current?.owner_username ?? '');
+	let wsPrefix = $derived(wsUsername && wsSlug ? `/${wsUsername}/${wsSlug}` : '');
+	let isDashboardPage = $derived(wsPrefix ? page.url.pathname === wsPrefix : false);
+	let isRolesPage = $derived(wsPrefix ? page.url.pathname === `${wsPrefix}/roles` : false);
+	let isActivityPage = $derived(wsPrefix ? page.url.pathname === `${wsPrefix}/activity` : false);
 
 	let activeCollectionSlug = $derived.by(() => {
-		if (!wsSlug) return null;
-		const prefix = `/${wsSlug}/`;
+		if (!wsPrefix) return null;
+		const prefix = `${wsPrefix}/`;
 		const path = page.url.pathname;
 		if (!path.startsWith(prefix)) return null;
 		const rest = path.slice(prefix.length);
@@ -142,7 +144,7 @@
 				source: 'web'
 			});
 			uiStore.onNavigate();
-			goto(`/${wsSlug}/${coll.slug}/${itemUrlId(item)}?new=1`);
+			goto(`${wsPrefix}/${coll.slug}/${itemUrlId(item)}?new=1`);
 		} catch (err: any) {
 			toastStore.show(err?.message || 'Failed to create item', 'error');
 		}
@@ -302,7 +304,7 @@
 		{#if wsSlug}
 			<nav class="collection-nav">
 				<a
-					href="/{wsSlug}"
+					href="{wsPrefix}"
 					class="nav-item dashboard"
 					class:active={isDashboardPage}
 					onclick={() => uiStore.onNavigate()}
@@ -311,7 +313,7 @@
 					<span class="nav-label">Dashboard</span>
 				</a>
 				<a
-					href="/{wsSlug}/roles"
+					href="{wsPrefix}/roles"
 					class="nav-item"
 					class:active={isRolesPage}
 					onclick={() => uiStore.onNavigate()}
@@ -320,7 +322,7 @@
 					<span class="nav-label">Roles</span>
 				</a>
 				<a
-					href="/{wsSlug}/activity"
+					href="{wsPrefix}/activity"
 					class="nav-item"
 					class:active={isActivityPage}
 					onclick={() => uiStore.onNavigate()}
@@ -348,7 +350,7 @@
 					>
 						{#each sidebarCollections as collection (collection.id)}
 							<a
-								href="/{wsSlug}/{collection.slug}"
+								href="{wsPrefix}/{collection.slug}"
 								class="nav-item draggable"
 								class:active={activeCollectionSlug === collection.slug}
 								onclick={() => uiStore.onNavigate()}
@@ -377,7 +379,7 @@
 					</div>
 					{#each agentCollections as collection (collection.id)}
 						<a
-							href="/{wsSlug}/{collection.slug}"
+							href="{wsPrefix}/{collection.slug}"
 							class="nav-item"
 							class:active={activeCollectionSlug === collection.slug}
 							onclick={() => uiStore.onNavigate()}
@@ -410,7 +412,7 @@
 			</button>
 			<div class="footer-row">
 				{#if wsSlug}
-					<a href="/{wsSlug}/settings" class="settings-btn" onclick={() => uiStore.onNavigate()}>
+					<a href="{wsPrefix}/settings" class="settings-btn" onclick={() => uiStore.onNavigate()}>
 						⚙ Settings
 					</a>
 				{/if}

--- a/web/src/lib/components/layout/TopBar.svelte
+++ b/web/src/lib/components/layout/TopBar.svelte
@@ -15,6 +15,7 @@
 	let currentTheme = $state<'dark' | 'light'>('dark');
 
 	let currentSlug = $derived(workspaceStore.current?.slug ?? '');
+	let currentUsername = $derived(workspaceStore.current?.owner_username ?? '');
 
 	// DnD state — local copy of workspaces for reordering
 	let dndWorkspaces: Workspace[] = $state([]);
@@ -145,7 +146,7 @@
 		>
 			{#each dndWorkspaces as ws (ws.id)}
 				<a
-					href="/{ws.slug}"
+					href="/{ws.owner_username}/{ws.slug}"
 					class="workspace-item"
 					class:active={ws.slug === currentSlug}
 					title={ws.name}
@@ -198,7 +199,7 @@
 							</div>
 							<div class="dropdown-divider"></div>
 							{#if currentSlug}
-								<a href="/{currentSlug}/settings" class="dropdown-item" onclick={closeUserMenu}>
+								<a href="/{currentUsername}/{currentSlug}/settings" class="dropdown-item" onclick={closeUserMenu}>
 									Settings
 								</a>
 							{/if}
@@ -224,7 +225,7 @@
 		<div class="workspace-list">
 			{#each workspaceStore.workspaces as ws (ws.id)}
 				<a
-					href="/{ws.slug}"
+					href="/{ws.owner_username}/{ws.slug}"
 					class="workspace-item"
 					class:active={ws.slug === currentSlug}
 					onclick={() => uiStore.onNavigate()}

--- a/web/src/lib/components/layout/WorkspaceSwitcher.svelte
+++ b/web/src/lib/components/layout/WorkspaceSwitcher.svelte
@@ -5,9 +5,9 @@
 
 	let open = $state(false);
 
-	function select(slug: string) {
+	function select(ws: { slug: string; owner_username?: string }) {
 		open = false;
-		goto(`/${slug}`);
+		goto(`/${ws.owner_username}/${ws.slug}`);
 	}
 
 	function openCreateModal() {
@@ -31,7 +31,7 @@
 				<button
 					class="item"
 					class:active={ws.slug === workspaceStore.current?.slug}
-					onclick={() => select(ws.slug)}
+					onclick={() => select(ws)}
 				>
 					{ws.name}
 				</button>

--- a/web/src/lib/components/search/CommandPalette.svelte
+++ b/web/src/lib/components/search/CommandPalette.svelte
@@ -57,9 +57,10 @@
 
 	function selectResult(r: SearchResult) {
 		const ws = workspaceStore.current?.slug;
+		const wsUsername = workspaceStore.current?.owner_username;
 		const collSlug = r.item.collection_slug;
-		if (ws && collSlug) {
-			goto(`/${ws}/${collSlug}/${itemUrlId(r.item)}`);
+		if (ws && wsUsername && collSlug) {
+			goto(`/${wsUsername}/${ws}/${collSlug}/${itemUrlId(r.item)}`);
 		}
 		uiStore.closeSearch();
 	}

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -40,6 +40,7 @@ export interface Workspace {
 	id: string;
 	name: string;
 	slug: string;
+	owner_id?: string;
 	description: string;
 	settings: string;
 	sort_order: number;

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -3,6 +3,7 @@
 export interface User {
 	id: string;
 	email: string;
+	username: string;
 	name: string;
 	role: string;
 	avatar_url?: string;
@@ -12,6 +13,7 @@ export interface User {
 
 export interface UserProfileUpdate {
 	name?: string;
+	username?: string;
 	current_password?: string;
 	new_password?: string;
 }

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -41,6 +41,7 @@ export interface Workspace {
 	name: string;
 	slug: string;
 	owner_id?: string;
+	owner_username?: string;
 	description: string;
 	settings: string;
 	sort_order: number;

--- a/web/src/lib/utils/markdown.ts
+++ b/web/src/lib/utils/markdown.ts
@@ -59,7 +59,7 @@ export function unescapeDocLinks(markdown: string): string {
  * Tiptap doesn't understand [[]] syntax, so we convert to standard
  * markdown links before feeding content to the editor.
  */
-export function wikiLinksToMarkdown(content: string, items: Item[], workspaceSlug: string): string {
+export function wikiLinksToMarkdown(content: string, items: Item[], workspaceSlug: string, username?: string): string {
 	return content.replace(/\[\[([^\]]+)\]\]/g, (_match, title: string) => {
 		// Support optional collection/ prefix: [[tasks/My Task]]
 		let searchTitle = title;
@@ -79,7 +79,8 @@ export function wikiLinksToMarkdown(content: string, items: Item[], workspaceSlu
 		});
 
 		if (item && item.collection_slug) {
-			return `[${searchTitle}](/${workspaceSlug}/${item.collection_slug}/${itemUrlId(item)})`;
+			const prefix = username ? `/${username}/${workspaceSlug}` : `/${workspaceSlug}`;
+				return `[${searchTitle}](${prefix}/${item.collection_slug}/${itemUrlId(item)})`;
 		}
 		// Unresolved — render as styled text (editor will show it as plain text)
 		return `[${searchTitle}](broken)`;
@@ -91,8 +92,8 @@ export function wikiLinksToMarkdown(content: string, items: Item[], workspaceSlu
  * Reverses wikiLinksToMarkdown() so we store [[]] not []() in the database.
  */
 export function markdownToWikiLinks(markdown: string, items: Item[]): string {
-	// Match [Title](/workspace/collection/slug-or-REF) pattern
-	return markdown.replace(/\[([^\]]+)\]\(\/[^/]+\/[^/]+\/([^)]+)\)/g, (_match, title: string, slugOrRef: string) => {
+	// Match [Title](/username/workspace/collection/slug-or-REF) or [Title](/workspace/collection/slug-or-REF) pattern
+	return markdown.replace(/\[([^\]]+)\]\(\/(?:[^/]+\/){2,3}([^)]+)\)/g, (_match, title: string, slugOrRef: string) => {
 		const item = items.find(i => {
 			if (i.slug === slugOrRef) return true;
 			// Also match PREFIX-NUMBER refs

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -159,7 +159,7 @@
 								<rect y="15" width="20" height="2" rx="1" fill="currentColor"/>
 							</svg>
 						</button>
-						<a href="/{workspaceStore.current?.slug ?? ''}" class="mobile-title">{workspaceStore.current?.name ?? 'Pad'}</a>
+						<a href="/{workspaceStore.current?.owner_username ?? ''}/${workspaceStore.current?.slug ?? ''}" class="mobile-title">{workspaceStore.current?.name ?? 'Pad'}</a>
 					</div>
 				{/if}
 				{@render children()}

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -11,7 +11,7 @@
 			const sorted = [...ws].sort((a, b) =>
 				new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime()
 			);
-			goto(`/${sorted[0].slug}`, { replaceState: true });
+			goto(`/${sorted[0].owner_username}/${sorted[0].slug}`, { replaceState: true });
 		}
 	});
 </script>

--- a/web/src/routes/[username]/[workspace]/+layout.svelte
+++ b/web/src/routes/[username]/[workspace]/+layout.svelte
@@ -12,6 +12,7 @@
 	let { children } = $props();
 
 	let wsSlug = $derived(page.params.workspace ?? '');
+	let username = $derived(page.params.username ?? '');
 	let unsubscribeSSE: (() => void) | null = null;
 	let unsubscribeSync: (() => void) | null = null;
 
@@ -68,7 +69,7 @@
 					}
 					if (isExternal) {
 						const who = event.actor === 'agent' ? 'Agent' : (event.actor_name || 'CLI');
-						const link = event.collection ? `/${wsSlug}/${event.collection}/${event.item_id}` : undefined;
+						const link = event.collection ? `/${username}/${wsSlug}/${event.collection}/${event.item_id}` : undefined;
 						toastStore.show(`${who} created: ${event.title}`, 'info', 4000, link);
 					}
 					break;

--- a/web/src/routes/[username]/[workspace]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/+page.svelte
@@ -11,6 +11,7 @@
 	import type { DashboardResponse, Collection } from '$lib/types';
 
 	let wsSlug = $derived(page.params.workspace ?? '');
+	let username = $derived(page.params.username ?? '');
 
 	let loading = $state(true);
 	let dashboard = $state<DashboardResponse | null>(null);
@@ -183,7 +184,7 @@
 		<!-- 2. Onboarding -->
 		{#if totalItems === 0 && !onboardingDismissed}
 			<div class="onboarding-wrapper">
-				<OnboardingChecklist {wsSlug} byCollection={dashboard.summary.by_collection} ondismiss={dismissOnboarding} />
+				<OnboardingChecklist {wsSlug} {username} byCollection={dashboard.summary.by_collection} ondismiss={dismissOnboarding} />
 			</div>
 		{:else if totalItems === 0 && onboardingDismissed}
 			<div class="onboarding-reshow">
@@ -200,7 +201,7 @@
 				</div>
 				<div class="active-grid">
 					{#each dashboard.active_items as item (item.slug)}
-						<a href="/{wsSlug}/{item.collection_slug}/{item.slug}" class="active-card">
+						<a href="/{username}/{wsSlug}/{item.collection_slug}/{item.slug}" class="active-card">
 							<div class="active-card-top">
 								{#if item.item_ref}
 									<span class="active-ref">{item.item_ref}</span>
@@ -231,7 +232,7 @@
 				</div>
 				<div class="plan-list">
 					{#each dashboard.active_plans as plan (plan.slug)}
-						<a href="/{wsSlug}/plans/{plan.slug}" class="plan-row">
+						<a href="/{username}/{wsSlug}/plans/{plan.slug}" class="plan-row">
 							<span class="plan-title">{plan.title}</span>
 							<div class="progress-bar">
 								<div class="progress-fill" style="width: {plan.progress}%"></div>
@@ -252,7 +253,7 @@
 				{#each collections as coll (coll.slug)}
 					{@const breakdown = dashboard.summary.by_collection[coll.name] ?? dashboard.summary.by_collection[coll.slug] ?? {}}
 					{@const prog = collProgress(coll)}
-					<a href="/{wsSlug}/{coll.slug}" class="coll-card">
+					<a href="/{username}/{wsSlug}/{coll.slug}" class="coll-card">
 						<div class="coll-card-header">
 							<span class="coll-card-name">
 								{#if coll.icon}<span class="coll-icon">{coll.icon}</span>{/if}
@@ -278,7 +279,7 @@
 						</div>
 					</a>
 				{/each}
-				<a href="/{wsSlug}/settings" class="coll-card coll-card-new">
+				<a href="/{username}/{wsSlug}/settings" class="coll-card coll-card-new">
 					<div class="coll-card-header">
 						<span class="coll-card-name">
 							<span class="coll-icon">+</span>
@@ -306,7 +307,7 @@
 								<div class="attention-card">
 									<span class="attention-icon">{attentionIcon(alert.type)}</span>
 									<div class="attention-content">
-										<a href="/{wsSlug}/{alert.collection}/{alert.item_slug}" class="attention-title">{alert.item_title}</a>
+										<a href="/{username}/{wsSlug}/{alert.collection}/{alert.item_slug}" class="attention-title">{alert.item_title}</a>
 										<span class="attention-reason">{alert.reason}</span>
 									</div>
 								</div>
@@ -324,7 +325,7 @@
 								<div class="suggested-card">
 									<span class="sug-num">{i + 1}</span>
 									<div class="sug-content">
-										<a href="/{wsSlug}/{sug.collection}/{sug.item_slug}" class="sug-title">{sug.item_title}</a>
+										<a href="/{username}/{wsSlug}/{sug.collection}/{sug.item_slug}" class="sug-title">{sug.item_title}</a>
 										<span class="sug-reason">{sug.reason}</span>
 									</div>
 								</div>
@@ -340,7 +341,7 @@
 			<section class="section">
 				<div class="section-header">
 					<span class="section-label">Recent Activity</span>
-					<a href="/{wsSlug}/activity" class="section-link">View all</a>
+					<a href="/{username}/{wsSlug}/activity" class="section-link">View all</a>
 				</div>
 				<div class="activity-list">
 					{#each dashboard.recent_activity.slice(0, 10) as activity, i (i)}
@@ -356,7 +357,7 @@
 							<span class="activity-dot" style="color: {activity.action === 'created' ? 'var(--accent-green)' : activity.action === 'archived' ? 'var(--text-muted)' : 'var(--accent-blue)'};">{activityIcon(activity.action)}</span>
 							<span class="activity-verb">{activityVerb(activity.action)}</span>
 							{#if activity.item_title}
-								<a href="/{wsSlug}/{activity.collection_slug}/{activity.item_slug}" class="activity-item">{activity.item_title}</a>
+								<a href="/{username}/{wsSlug}/{activity.collection_slug}/{activity.item_slug}" class="activity-item">{activity.item_title}</a>
 							{/if}
 							{#if changes}
 								<span class="activity-changes">{changes}</span>

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -36,6 +36,7 @@
 	let saveViewInput = $state<HTMLInputElement>();
 
 	let wsSlug = $derived(page.params.workspace ?? '');
+	let username = $derived(page.params.username ?? '');
 	let collSlug = $derived(page.params.collection ?? '');
 
 	// Persist view mode to localStorage per collection
@@ -64,7 +65,7 @@
 		}
 		if (searchQuery) params.set('q', searchQuery);
 		const qs = params.toString();
-		const newUrl = `/${wsSlug}/${collSlug}${qs ? '?' + qs : ''}`;
+		const newUrl = `/${username}/${wsSlug}/${collSlug}${qs ? '?' + qs : ''}`;
 		goto(newUrl, { replaceState: true, noScroll: true, keepFocus: true });
 	}
 
@@ -465,7 +466,7 @@
 				fields: JSON.stringify(defaultFields),
 				source: 'web'
 			});
-			goto(`/${wsSlug}/${collSlug}/${itemUrlId(item)}?new=1`);
+			goto(`/${username}/${wsSlug}/${collSlug}/${itemUrlId(item)}?new=1`);
 		} catch (err: any) {
 			toastStore.show(err?.message || 'Failed to create item', 'error');
 		} finally {
@@ -564,7 +565,7 @@
 				if (focusedIndex >= 0 && focusedIndex < filteredItems.length) {
 					e.preventDefault();
 					const item = filteredItems[focusedIndex];
-					goto(`/${wsSlug}/${collSlug}/${itemUrlId(item)}`);
+					goto(`/${username}/${wsSlug}/${collSlug}/${itemUrlId(item)}`);
 				}
 				break;
 			case 'Escape':

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -36,6 +36,7 @@
 	};
 
 	let wsSlug = $derived(page.params.workspace ?? '');
+	let username = $derived(page.params.username ?? '');
 	let collSlug = $derived(page.params.collection ?? '');
 	let itemSlug = $derived(page.params.slug ?? '');
 
@@ -62,7 +63,7 @@
 		const raw = item.content ?? '';
 		const allItems = collectionStore.items ?? [];
 		if (allItems.length > 0 && raw.includes('[[')) {
-			return wikiLinksToMarkdown(raw, allItems, wsSlug);
+			return wikiLinksToMarkdown(raw, allItems, wsSlug, username);
 		}
 		return raw;
 	});
@@ -113,8 +114,8 @@
 				// Check if our item was deleted
 				if (result.changes.deleted.includes(item!.id)) {
 					// Item was deleted — navigate back to collection
-					goto(`/${wsSlug}/${collSlug}`);
-				}
+					goto(`/${username}/${wsSlug}/${collSlug}`);
+}
 				return;
 			}
 
@@ -193,7 +194,7 @@
 			// Auto-start title editing for newly created items
 			if (page.url.searchParams.get('new') === '1' && item) {
 				// Clean up the URL param first, then focus title after DOM settles
-				goto(`/${wsSlug}/${collSlug}/${itemSlug}`, { replaceState: true, noScroll: true });
+				goto(`/${username}/${wsSlug}/${collSlug}/${itemSlug}`, { replaceState: true, noScroll: true });
 				await startEditTitle();
 			}
 		}
@@ -389,7 +390,7 @@
 
 	function relationHref(collectionSlug?: string, refOrSlug?: string): string | null {
 		if (!collectionSlug || !refOrSlug) return null;
-		return `/${wsSlug}/${collectionSlug}/${refOrSlug}`;
+		return `/${username}/${wsSlug}/${collectionSlug}/${refOrSlug}`;
 	}
 
 	function linkEntry(link: ItemLink, useSource: boolean): RelationshipEntry {
@@ -499,7 +500,7 @@
 		try {
 			await api.items.delete(wsSlug, item.id);
 			toastStore.show('Item deleted', 'success');
-			goto(`/${wsSlug}/${collSlug}`);
+			goto(`/${username}/${wsSlug}/${collSlug}`);
 		} catch {
 			toastStore.show('Failed to delete item', 'error');
 			deleting = false;
@@ -579,7 +580,7 @@
 		try {
 			const moved = await api.items.move(wsSlug, item.slug, targetSlug);
 			toastStore.show(`Moved to ${targetSlug}`, 'success');
-			goto(`/${wsSlug}/${targetSlug}/${moved.slug}`);
+			goto(`/${username}/${wsSlug}/${targetSlug}/${moved.slug}`);
 		} catch (e: any) {
 			toastStore.show(e.message ?? 'Failed to move item', 'error');
 		} finally {
@@ -596,9 +597,9 @@
 	<div class="item-page">
 		<!-- Breadcrumb -->
 		<nav class="breadcrumb">
-			<a href="/{wsSlug}">Home</a>
+			<a href="/{username}/{wsSlug}">Home</a>
 			<span class="sep">/</span>
-			<a href="/{wsSlug}/{collSlug}">{collection.icon} {collection.name}</a>
+			<a href="/{username}/{wsSlug}/{collSlug}">{collection.icon} {collection.name}</a>
 			<span class="sep">/</span>
 			<span class="current">{formatItemRef(item) || item.title}</span>
 		</nav>
@@ -920,7 +921,7 @@
 
 		<!-- Child Items: always mounted so SSE subscriptions stay active even when starting with 0 children -->
 		{#if item}
-			<ChildItems {wsSlug} {itemSlug} itemId={item.id} parentFields={fields} terminalStatuses={childTerminalStatuses} onChildrenChange={handleChildrenChange} />
+			<ChildItems {wsSlug} {username} {itemSlug} itemId={item.id} parentFields={fields} terminalStatuses={childTerminalStatuses} onChildrenChange={handleChildrenChange} />
 		{/if}
 
 		<!-- Unified Timeline (comments + activity + versions) -->

--- a/web/src/routes/[username]/[workspace]/activity/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/activity/+page.svelte
@@ -7,6 +7,7 @@
 	import type { Activity, Collection } from '$lib/types';
 
 	let wsSlug = $derived(page.params.workspace ?? '');
+	let username = $derived(page.params.username ?? '');
 
 	// Data
 	let activities = $state<Activity[]>([]);
@@ -317,7 +318,7 @@
 										<span class="entry-verb">{activityVerb(activity.action)}</span>
 										{#if itemTitle && itemSlug && collSlug}
 											<a
-												href="/{wsSlug}/{collSlug}/{itemSlug}"
+												href="/{username}/{wsSlug}/{collSlug}/{itemSlug}"
 												class="entry-item-link">{itemTitle}</a
 											>
 										{:else if itemTitle}

--- a/web/src/routes/[username]/[workspace]/conventions/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/conventions/+page.svelte
@@ -26,6 +26,7 @@
 	const ENFORCEMENT_LEVELS = ['must','should','nice-to-have'] as const;
 
 	let workspace = $derived(page.params.workspace ?? '');
+	let username = $derived(page.params.username ?? '');
 	let conventions = $state<Item[]>([]);
 	let loading = $state(true);
 	let expandedSlug = $state<string | null>(null);
@@ -301,7 +302,7 @@
 				<p class="subtitle">Rules that guide agent behavior in this project</p>
 			</div>
 			<div class="header-actions">
-				<a href="/{workspace}/library" class="btn btn-secondary">Browse Library</a>
+				<a href="/{username}/{workspace}/library" class="btn btn-secondary">Browse Library</a>
 				<button class="btn btn-primary" onclick={() => (showCreate = !showCreate)}>
 					{showCreate ? 'Cancel' : '+ New Convention'}
 				</button>

--- a/web/src/routes/[username]/[workspace]/dashboard/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/dashboard/+page.svelte
@@ -4,8 +4,9 @@
 
 	// Dashboard is now the workspace home page — redirect there
 	let wsSlug = $derived(page.params.workspace ?? '');
+	let username = $derived(page.params.username ?? '');
 
 	$effect(() => {
-		if (wsSlug) goto(`/${wsSlug}`, { replaceState: true });
+		if (wsSlug) goto(`/${username}/${wsSlug}`, { replaceState: true });
 	});
 </script>

--- a/web/src/routes/[username]/[workspace]/library/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/library/+page.svelte
@@ -4,6 +4,7 @@
 	import type { LibraryCategory, LibraryConvention, PlaybookCategory, LibraryPlaybook, Item } from '$lib/types';
 
 	let wsSlug = $derived(page.params.workspace ?? '');
+	let username = $derived(page.params.username ?? '');
 
 	let categories = $state<LibraryCategory[]>([]);
 	let playbookCategories = $state<PlaybookCategory[]>([]);

--- a/web/src/routes/[username]/[workspace]/playbooks/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/playbooks/+page.svelte
@@ -9,6 +9,7 @@
 	const SCOPES = ['all', 'backend', 'frontend', 'mobile', 'devops'] as const;
 	const STATUS_ORDER: Record<string, number> = { active: 0, draft: 1, deprecated: 2 };
 	let wsSlug = $derived(page.params.workspace ?? '');
+	let username = $derived(page.params.username ?? '');
 	let playbooks = $state<Item[]>([]);
 	let loading = $state(true);
 	let expandedId = $state<string | null>(null);
@@ -145,7 +146,7 @@
 			</div>
 			{#if !showNewForm}
 				<div style="display:flex;gap:var(--space-2);align-items:center;">
-					<a href="/{wsSlug}/library?tab=playbooks" class="new-btn" style="background:var(--bg-secondary);color:var(--text-primary);border:1px solid var(--border);">📚 Browse Library</a>
+					<a href="/{username}/{wsSlug}/library?tab=playbooks" class="new-btn" style="background:var(--bg-secondary);color:var(--text-primary);border:1px solid var(--border);">📚 Browse Library</a>
 					<button class="new-btn" onclick={() => (showNewForm = true)}>+ New Playbook</button>
 				</div>
 			{/if}
@@ -264,7 +265,7 @@
 								</div>
 								<div class="card-divider"></div>
 								<div class="card-actions">
-									<button class="action-btn" onclick={() => goto(`/${wsSlug}/playbooks/${itemUrlId(item)}`)}>Edit</button>
+									<button class="action-btn" onclick={() => goto(`/${username}/${wsSlug}/playbooks/${itemUrlId(item)}`)}>Edit</button>
 									<button class="action-btn" disabled={togglingStatus === item.slug} onclick={() => toggleStatus(item)}>
 										{togglingStatus === item.slug ? '...' : nextStatusLabel(status)}
 									</button>

--- a/web/src/routes/[username]/[workspace]/roles/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/roles/+page.svelte
@@ -13,6 +13,7 @@
 	import type { DndEvent } from 'svelte-dnd-action';
 
 	let wsSlug = $derived(page.params.workspace ?? '');
+	let username = $derived(page.params.username ?? '');
 
 	// Data
 	let lanes = $state<RoleBoardLane[]>([]);
@@ -577,7 +578,7 @@
 								{#if coll}
 									<ItemCard {item} collection={coll} compact={true} showCollection={true} />
 								{:else}
-									<a href="/{wsSlug}/{item.collection_slug}/{itemUrlId(item)}" class="fallback-card">
+									<a href="/{username}/{wsSlug}/{item.collection_slug}/{itemUrlId(item)}" class="fallback-card">
 										<span class="card-title">{item.title}</span>
 									</a>
 								{/if}

--- a/web/src/routes/[username]/[workspace]/settings/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/settings/+page.svelte
@@ -13,6 +13,7 @@
 	import { copyToClipboard } from '$lib/utils/clipboard';
 
 	let wsSlug = $derived(page.params.workspace ?? '');
+	let username = $derived(page.params.username ?? '');
 	let loading = $state(true);
 	let collections = $state<Collection[]>([]);
 	let wsName = $state('');

--- a/web/src/routes/[username]/[workspace]/settings/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/settings/+page.svelte
@@ -39,9 +39,19 @@
 	// Account
 	let profileName = $state('');
 	let profileEmail = $state('');
+	let profileUsername = $state('');
+	let originalUsername = $state('');
 	let profileRole = $state('');
 	let savingProfile = $state(false);
 	let profileStatus = $state<'idle' | 'saved' | 'error'>('idle');
+	let profileError = $state('');
+
+	// Username availability checking
+	let usernameChecking = $state(false);
+	let usernameAvailable = $state<boolean | null>(null);
+	let usernameError = $state('');
+	let usernameCheckTimeout = $state<ReturnType<typeof setTimeout> | null>(null);
+	let usernameChanged = $derived(profileUsername !== originalUsername);
 
 	let currentPassword = $state('');
 	let newPassword = $state('');
@@ -120,6 +130,8 @@
 			const me = await api.auth.me();
 			profileName = me.name;
 			profileEmail = me.email;
+			profileUsername = me.username;
+			originalUsername = me.username;
 			profileRole = me.role;
 		} catch {}
 		try {
@@ -313,16 +325,62 @@
 		}
 	}
 
+	function checkUsernameAvailability() {
+		if (usernameCheckTimeout) clearTimeout(usernameCheckTimeout);
+		usernameAvailable = null;
+		usernameError = '';
+
+		if (!usernameChanged) {
+			usernameChecking = false;
+			return;
+		}
+
+		if (!profileUsername || profileUsername.length < 3) {
+			usernameChecking = false;
+			if (profileUsername.length > 0) {
+				usernameError = 'Username must be at least 3 characters';
+			}
+			return;
+		}
+
+		usernameChecking = true;
+		usernameCheckTimeout = setTimeout(async () => {
+			try {
+				const result = await api.auth.checkUsername(profileUsername);
+				usernameAvailable = result.available;
+				usernameError = result.message || '';
+			} catch {
+				usernameError = '';
+				usernameAvailable = null;
+			} finally {
+				usernameChecking = false;
+			}
+		}, 400);
+	}
+
 	async function saveProfile() {
 		if (!profileName.trim() || savingProfile) return;
+		if (usernameChanged && usernameAvailable === false) return;
+		if (usernameChanged && profileUsername.length > 0 && profileUsername.length < 3) return;
 		savingProfile = true;
 		profileStatus = 'idle';
+		profileError = '';
 		try {
-			await api.auth.updateProfile({ name: profileName.trim() });
+			const update: { name: string; username?: string } = { name: profileName.trim() };
+			if (usernameChanged) {
+				update.username = profileUsername.trim();
+			}
+			await api.auth.updateProfile(update);
+			if (usernameChanged) {
+				originalUsername = profileUsername.trim();
+				usernameAvailable = null;
+				usernameError = '';
+			}
 			profileStatus = 'saved';
 			setTimeout(() => (profileStatus = 'idle'), 2000);
-		} catch {
+		} catch (err: unknown) {
 			profileStatus = 'error';
+			profileError = err instanceof Error ? err.message : 'Failed to save profile';
 		} finally {
 			savingProfile = false;
 		}
@@ -588,13 +646,46 @@
 						<label for="profile-name">Name</label>
 						<div class="inline-edit">
 							<input id="profile-name" type="text" bind:value={profileName} onkeydown={(e) => e.key === 'Enter' && saveProfile()} />
-							<button class="btn btn-small" onclick={saveProfile} disabled={savingProfile}>
+						</div>
+					</div>
+					<div class="field-row">
+						<label for="profile-username">Username</label>
+						<div class="inline-edit">
+							<div class="username-input-wrapper">
+								<span class="username-prefix">@</span>
+								<input
+									id="profile-username"
+									type="text"
+									bind:value={profileUsername}
+									oninput={checkUsernameAvailability}
+									onkeydown={(e) => e.key === 'Enter' && saveProfile()}
+									placeholder="username"
+									autocomplete="username"
+								/>
+							</div>
+							{#if usernameChanged}
+								{#if usernameChecking}
+									<span class="username-status checking">checking...</span>
+								{:else if usernameAvailable === true}
+									<span class="username-status available">available</span>
+								{:else if usernameAvailable === false}
+									<span class="username-status taken">{usernameError || 'not available'}</span>
+								{:else if usernameError}
+									<span class="username-status taken">{usernameError}</span>
+								{/if}
+							{/if}
+						</div>
+					</div>
+					<div class="field-row profile-actions-row">
+						<span class="field-label"></span>
+						<div class="inline-edit">
+							<button class="btn btn-small" onclick={saveProfile} disabled={savingProfile || (usernameChanged && usernameAvailable === false) || (usernameChanged && profileUsername.length > 0 && profileUsername.length < 3)}>
 								{savingProfile ? 'Saving...' : 'Save'}
 							</button>
 							{#if profileStatus === 'saved'}
 								<span class="status-saved">Saved</span>
 							{:else if profileStatus === 'error'}
-								<span class="status-error">Error</span>
+								<span class="status-error">{profileError || 'Error'}</span>
 							{/if}
 						</div>
 					</div>
@@ -1090,6 +1181,17 @@
 	.token-secret-warning { font-size: 0.82em; color: var(--accent-orange); margin: 0 0 var(--space-2); font-weight: 500; }
 	.token-secret-row { display: flex; align-items: center; gap: var(--space-2); }
 	.token-secret { font-size: 0.82em; background: var(--bg-tertiary); padding: var(--space-2) var(--space-3); border-radius: var(--radius-sm); word-break: break-all; flex: 1; }
+	/* ── Username field ──── */
+	.username-input-wrapper { display: flex; align-items: center; flex: 1; min-width: 120px; max-width: 300px; background: var(--bg-tertiary); border: 1px solid var(--border); border-radius: var(--radius); overflow: hidden; }
+	.username-input-wrapper:focus-within { border-color: var(--accent-blue); }
+	.username-prefix { padding: var(--space-1) 0 var(--space-1) var(--space-2); font-size: 0.9em; color: var(--text-muted); flex-shrink: 0; user-select: none; }
+	.username-input-wrapper input { border: none; background: none; padding-left: var(--space-1); min-width: 0; flex: 1; }
+	.username-input-wrapper input:focus { outline: none; box-shadow: none; }
+	.username-status { font-size: 0.78em; white-space: nowrap; }
+	.username-status.checking { color: var(--text-muted); }
+	.username-status.available { color: var(--accent-green); }
+	.username-status.taken { color: #ef4444; }
+	.profile-actions-row { border-top: none !important; padding-top: 0; }
 	/* ── Platform ──── */
 	.platform-actions { display: flex; align-items: center; gap: var(--space-3); margin-top: var(--space-3); flex-wrap: wrap; }
 </style>

--- a/web/src/routes/join/[code]/+page.svelte
+++ b/web/src/routes/join/[code]/+page.svelte
@@ -14,12 +14,19 @@
 	let mode = $state<'login' | 'register'>('register');
 	let email = $state('');
 	let name = $state('');
+	let username = $state('');
 	let password = $state('');
 	let confirmPassword = $state('');
 	let formError = $state('');
 	let submitting = $state(false);
 	let challengeToken = $state('');
 	let totpCode = $state('');
+
+	let usernameManuallyEdited = $state(false);
+	let usernameChecking = $state(false);
+	let usernameAvailable = $state<boolean | null>(null);
+	let usernameError = $state('');
+	let checkTimeout: ReturnType<typeof setTimeout> | null = null;
 
 	onMount(async () => {
 		try {
@@ -54,6 +61,52 @@
 		}
 	}
 
+	function generateUsername(name: string): string {
+		let u = name.toLowerCase().trim();
+		u = u.replace(/[^a-z0-9-]+/g, '-');
+		u = u.replace(/-{2,}/g, '-');
+		u = u.replace(/^-|-$/g, '');
+		if (u.length > 39) u = u.substring(0, 39).replace(/-$/, '');
+		return u;
+	}
+
+	function handleNameInput() {
+		if (!usernameManuallyEdited) {
+			username = generateUsername(name);
+			checkUsernameAvailability();
+		}
+	}
+
+	function handleUsernameInput() {
+		usernameManuallyEdited = username !== '' && username !== generateUsername(name);
+		checkUsernameAvailability();
+	}
+
+	function checkUsernameAvailability() {
+		if (checkTimeout) clearTimeout(checkTimeout);
+		usernameAvailable = null;
+		usernameError = '';
+
+		if (!username || username.length < 3) {
+			usernameChecking = false;
+			return;
+		}
+
+		usernameChecking = true;
+		checkTimeout = setTimeout(async () => {
+			try {
+				const result = await api.auth.checkUsername(username);
+				usernameAvailable = result.available;
+				usernameError = result.message || '';
+			} catch {
+				usernameError = '';
+				usernameAvailable = null;
+			} finally {
+				usernameChecking = false;
+			}
+		}, 400);
+	}
+
 	async function handleSubmit() {
 		formError = '';
 		submitting = true;
@@ -61,12 +114,14 @@
 		try {
 			if (mode === 'register') {
 				if (!name.trim()) { formError = 'Name is required'; submitting = false; return; }
+				if (username && username.length < 3) { formError = 'Username must be at least 3 characters'; submitting = false; return; }
+				if (usernameAvailable === false) { formError = usernameError || 'Username is not available'; submitting = false; return; }
 				if (!email.trim()) { formError = 'Email is required'; submitting = false; return; }
 				if (password.length < 8) { formError = 'Password must be at least 8 characters'; submitting = false; return; }
 				if (password !== confirmPassword) { formError = 'Passwords do not match'; submitting = false; return; }
 				// Pass the invitation code so the backend allows registration
 				// and auto-accepts the invitation in one step.
-				await api.auth.register(email.trim(), name.trim(), password, code);
+				await api.auth.register(email.trim(), name.trim(), password, username || undefined, code);
 				// Registration with invitation_code already accepted the invite,
 				// so redirect directly instead of calling acceptInvitation().
 				await goto('/', { replaceState: true });
@@ -197,10 +252,30 @@
 						type="text"
 						placeholder="Name"
 						bind:value={name}
+						oninput={handleNameInput}
 						onkeydown={handleKeydown}
 						disabled={submitting}
 						autocomplete="name"
 					/>
+
+					<div class="username-field">
+						<input
+							type="text"
+							placeholder="Username"
+							bind:value={username}
+							oninput={handleUsernameInput}
+							onkeydown={handleKeydown}
+							disabled={submitting}
+							autocomplete="username"
+						/>
+						{#if usernameChecking}
+							<span class="username-status checking">checking...</span>
+						{:else if usernameAvailable === true}
+							<span class="username-status available">available</span>
+						{:else if usernameAvailable === false}
+							<span class="username-status taken">{usernameError || 'not available'}</span>
+						{/if}
+					</div>
 				{/if}
 				<input
 					type="email"
@@ -378,4 +453,29 @@
 		text-decoration: none;
 	}
 	.link:hover { text-decoration: underline; }
+
+	.username-field {
+		position: relative;
+	}
+
+	.username-status {
+		position: absolute;
+		right: var(--space-3);
+		top: 50%;
+		transform: translateY(-50%);
+		font-size: 0.75rem;
+		pointer-events: none;
+	}
+
+	.username-status.checking {
+		color: var(--text-muted);
+	}
+
+	.username-status.available {
+		color: #22c55e;
+	}
+
+	.username-status.taken {
+		color: #ef4444;
+	}
 </style>

--- a/web/src/routes/register/+page.svelte
+++ b/web/src/routes/register/+page.svelte
@@ -5,6 +5,7 @@
 	import SetupRequiredNotice from '$lib/components/auth/SetupRequiredNotice.svelte';
 
 	let name = $state('');
+	let username = $state('');
 	let email = $state('');
 	let password = $state('');
 	let confirmPassword = $state('');
@@ -12,6 +13,12 @@
 	let setupRequired = $state(false);
 	let setupMethod = $state<'local_cli' | 'docker_exec' | 'cloud' | undefined>(undefined);
 	let loading = $state(false);
+
+	let usernameManuallyEdited = $state(false);
+	let usernameChecking = $state(false);
+	let usernameAvailable = $state<boolean | null>(null);
+	let usernameError = $state('');
+	let checkTimeout: ReturnType<typeof setTimeout> | null = null;
 
 	onMount(async () => {
 		try {
@@ -28,8 +35,56 @@
 		} catch {}
 	});
 
+	function generateUsername(name: string): string {
+		let u = name.toLowerCase().trim();
+		u = u.replace(/[^a-z0-9-]+/g, '-');
+		u = u.replace(/-{2,}/g, '-');
+		u = u.replace(/^-|-$/g, '');
+		if (u.length > 39) u = u.substring(0, 39).replace(/-$/, '');
+		return u;
+	}
+
+	function handleNameInput() {
+		if (!usernameManuallyEdited) {
+			username = generateUsername(name);
+			checkUsernameAvailability();
+		}
+	}
+
+	function handleUsernameInput() {
+		usernameManuallyEdited = username !== '' && username !== generateUsername(name);
+		checkUsernameAvailability();
+	}
+
+	function checkUsernameAvailability() {
+		if (checkTimeout) clearTimeout(checkTimeout);
+		usernameAvailable = null;
+		usernameError = '';
+
+		if (!username || username.length < 3) {
+			usernameChecking = false;
+			return;
+		}
+
+		usernameChecking = true;
+		checkTimeout = setTimeout(async () => {
+			try {
+				const result = await api.auth.checkUsername(username);
+				usernameAvailable = result.available;
+				usernameError = result.message || '';
+			} catch {
+				usernameError = '';
+				usernameAvailable = null;
+			} finally {
+				usernameChecking = false;
+			}
+		}, 400);
+	}
+
 	function validate(): string | null {
 		if (!name.trim()) return 'Please enter your name.';
+		if (username && username.length < 3) return 'Username must be at least 3 characters.';
+		if (usernameAvailable === false) return usernameError || 'Username is not available.';
 		if (!email.trim()) return 'Please enter your email.';
 		const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 		if (!emailRegex.test(email)) return 'Please enter a valid email address.';
@@ -48,7 +103,7 @@
 
 		loading = true;
 		try {
-			await api.auth.register(email, name, password);
+			await api.auth.register(email, name, password, username || undefined);
 			await goto('/', { replaceState: true });
 		} catch (err: unknown) {
 			if (err instanceof Error) {
@@ -86,10 +141,30 @@
 					type="text"
 					placeholder="Name"
 					bind:value={name}
+					oninput={handleNameInput}
 					onkeydown={handleKeydown}
 					disabled={loading}
 					autocomplete="name"
 				/>
+
+				<div class="username-field">
+					<input
+						type="text"
+						placeholder="Username"
+						bind:value={username}
+						oninput={handleUsernameInput}
+						onkeydown={handleKeydown}
+						disabled={loading}
+						autocomplete="username"
+					/>
+					{#if usernameChecking}
+						<span class="username-status checking">checking...</span>
+					{:else if usernameAvailable === true}
+						<span class="username-status available">available</span>
+					{:else if usernameAvailable === false}
+						<span class="username-status taken">{usernameError || 'not available'}</span>
+					{/if}
+				</div>
 
 				<input
 					type="email"
@@ -245,5 +320,30 @@
 
 	.login-link a:hover {
 		text-decoration: underline;
+	}
+
+	.username-field {
+		position: relative;
+	}
+
+	.username-status {
+		position: absolute;
+		right: var(--space-3);
+		top: 50%;
+		transform: translateY(-50%);
+		font-size: 0.75rem;
+		pointer-events: none;
+	}
+
+	.username-status.checking {
+		color: var(--text-muted);
+	}
+
+	.username-status.available {
+		color: #22c55e;
+	}
+
+	.username-status.taken {
+		color: #ef4444;
 	}
 </style>


### PR DESCRIPTION
## Summary

Implements Phase 1 of PLAN-407 (Multi-User Permissions & Sharing): the username system and web URL redesign.

- **Username column + migration**: `username` field on users with partial unique index, auto-backfill from display name on startup
- **Workspace owner_id**: `owner_id` column on workspaces with backfill (earliest owner member → earliest member → first admin)
- **Username validation**: format rules, 35+ reserved words, `/auth/check-username` availability endpoint
- **Registration flow**: bootstrap auto-generates username; register accepts optional username with auto-generation fallback; real-time validation on register + join pages
- **Auth-scoped workspace resolver**: `getWorkspaceID()` accepts both slug and UUID, resolves slugs in user's auth context for non-admins
- **Web URL redesign**: all workspace routes moved from `/[workspace]/...` to `/[username]/[workspace]/...` — 24 frontend files updated
- **Username editing**: account settings page with debounced availability checking
- **`owner_username` on workspace API responses**: all workspace queries JOIN users table

### What did NOT change
- API URL pattern (`/api/v1/workspaces/{ws}/...`) — unchanged
- CLI — unchanged
- Agent skills — unchanged
- `client.ts` API calls — still use workspace slug

### Tasks completed (9)
- TASK-408: Add username column to users table + migration
- TASK-482: Username migration strategy for existing users
- TASK-409: Username validation, reserved words, and registration flow updates
- TASK-410: Add owner_id to workspaces, change slug uniqueness to per-owner
- TASK-480: owner_id backfill migration for existing workspaces
- TASK-412: Auth-scoped workspace resolver (slug + ID support)
- TASK-411: Rewrite web UI routing to /{username}/{workspace}/...
- TASK-484: Self-hosted URL ergonomics
- TASK-496: Username editing in account settings (web UI)

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./...` passes (all 28+ second server test suite included)
- [ ] `npm run build` passes (SvelteKit static build)
- [ ] `make install` succeeds — binary builds, server restarts
- [ ] Existing user gets auto-generated username on first startup (`/api/v1/auth/me` returns `username: "dave"`)
- [ ] All workspaces get `owner_id` backfilled (`/api/v1/workspaces` shows `owner_id` + `owner_username`)
- [ ] Web UI loads at `/{username}/{workspace}/...` (e.g. `/dave/docapp`)
- [ ] Auth pages unchanged: `/login`, `/register`, `/join/{code}`
- [ ] Workspace resolver accepts UUID: `/api/v1/workspaces/{uuid}/collections` works
- [ ] `/auth/check-username?username=admin` → reserved; `?username=dave` → taken; `?username=alice` → available
- [ ] Registration page shows username field with auto-generation from name + live validation
- [ ] Account settings shows username field with editing + availability check
- [ ] `PATCH /auth/me` with `{"username": "admin"}` → validation error; with taken username → conflict
- [ ] CLI commands (`pad item list`, `pad project dashboard`) work unchanged
- [ ] Navigation links (sidebar, topbar, breadcrumbs, item cards) use `/{username}/{workspace}/...` URLs