### PR TITLE
feat: collection-level visibility + permission filtering (PLAN-407 Phase 2)

### DIFF
--- a/internal/collections/defaults.go
+++ b/internal/collections/defaults.go
@@ -203,6 +203,7 @@ func Defaults() []DefaultCollection {
 			Icon:        "📏",
 			Description: "Project rules and conventions that guide agent behavior",
 			SortOrder:   4,
+			IsSystem:    true,
 			Schema: models.CollectionSchema{
 				Fields: []models.FieldDef{
 					{
@@ -252,6 +253,7 @@ func Defaults() []DefaultCollection {
 			Icon:        "📘",
 			Description: "Multi-step workflows that agents follow for specific actions",
 			SortOrder:   5,
+			IsSystem:    true,
 			Schema: models.CollectionSchema{
 				Fields: []models.FieldDef{
 					{

--- a/internal/collections/defaults.go
+++ b/internal/collections/defaults.go
@@ -12,6 +12,7 @@ type DefaultCollection struct {
 	Schema      models.CollectionSchema
 	Settings    models.CollectionSettings
 	SortOrder   int
+	IsSystem    bool // System collections (conventions, playbooks) are always visible to members
 }
 
 // Defaults returns the six default collections for a new workspace.

--- a/internal/collections/templates.go
+++ b/internal/collections/templates.go
@@ -104,6 +104,7 @@ func conventionsCollection(sortOrder int) DefaultCollection {
 			ListSortBy:  "trigger",
 			ListGroupBy: "trigger",
 		},
+		IsSystem: true,
 	}
 }
 
@@ -146,6 +147,7 @@ func playbooksCollection(sortOrder int) DefaultCollection {
 			ListSortBy:  "updated_at",
 			ListGroupBy: "trigger",
 		},
+		IsSystem: true,
 	}
 }
 

--- a/internal/models/collection.go
+++ b/internal/models/collection.go
@@ -49,6 +49,7 @@ type Collection struct {
 	Prefix      string     `json:"prefix"`
 	SortOrder   int        `json:"sort_order"`
 	IsDefault   bool       `json:"is_default"`
+	IsSystem    bool       `json:"is_system"`
 	CreatedAt   time.Time  `json:"created_at"`
 	UpdatedAt   time.Time  `json:"updated_at"`
 	DeletedAt   *time.Time `json:"deleted_at,omitempty"`
@@ -67,6 +68,7 @@ type CollectionCreate struct {
 	Schema      string `json:"schema,omitempty"`
 	Settings    string `json:"settings,omitempty"`
 	IsDefault   bool   `json:"is_default,omitempty"`
+	IsSystem    bool   `json:"is_system,omitempty"`
 }
 
 // FieldMigration describes a bulk update to apply to existing items when

--- a/internal/models/export.go
+++ b/internal/models/export.go
@@ -32,6 +32,7 @@ type CollectionExport struct {
 	Prefix      string `json:"prefix"`
 	SortOrder   int    `json:"sort_order"`
 	IsDefault   bool   `json:"is_default"`
+	IsSystem    bool   `json:"is_system"`
 	CreatedAt   string `json:"created_at"`
 	UpdatedAt   string `json:"updated_at"`
 }

--- a/internal/models/item.go
+++ b/internal/models/item.go
@@ -506,6 +506,7 @@ type ItemUpdate struct {
 
 type ItemListParams struct {
 	CollectionSlug  string
+	CollectionIDs   []string          // permission filter: restrict to these collection IDs (nil = no filter)
 	Fields          map[string]string // field filters: key=value
 	Sort            string            // e.g. "priority:desc,created_at:asc"
 	GroupBy         string

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -59,10 +59,11 @@ type WorkspaceInvitation struct {
 
 // WorkspaceMember represents a user's membership in a workspace.
 type WorkspaceMember struct {
-	WorkspaceID string    `json:"workspace_id"`
-	UserID      string    `json:"user_id"`
-	Role        string    `json:"role"` // "owner", "editor", or "viewer"
-	CreatedAt   time.Time `json:"created_at"`
+	WorkspaceID      string    `json:"workspace_id"`
+	UserID           string    `json:"user_id"`
+	Role             string    `json:"role"`              // "owner", "editor", or "viewer"
+	CollectionAccess string    `json:"collection_access"` // "all" or "specific"
+	CreatedAt        time.Time `json:"created_at"`
 
 	// Populated by joins (not stored)
 	UserName     string `json:"user_name,omitempty"`

--- a/internal/server/handlers_activity.go
+++ b/internal/server/handlers_activity.go
@@ -42,6 +42,30 @@ func (s *Server) handleListWorkspaceActivity(w http.ResponseWriter, r *http.Requ
 	// Enrich activities with item titles and collection info
 	s.enrichActivities(activities)
 
+	// Filter by collection visibility
+	visibleIDs, err := s.visibleCollectionIDs(r, workspaceID)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	if visibleIDs != nil {
+		// Build slug lookup from visible collection IDs
+		visibleSlugs := make(map[string]bool)
+		for _, id := range visibleIDs {
+			coll, _ := s.store.GetCollection(id)
+			if coll != nil {
+				visibleSlugs[coll.Slug] = true
+			}
+		}
+		filtered := make([]models.Activity, 0, len(activities))
+		for _, a := range activities {
+			if a.CollectionSlug == "" || visibleSlugs[a.CollectionSlug] {
+				filtered = append(filtered, a)
+			}
+		}
+		activities = filtered
+	}
+
 	writeJSON(w, http.StatusOK, activities)
 }
 

--- a/internal/server/handlers_activity.go
+++ b/internal/server/handlers_activity.go
@@ -59,9 +59,15 @@ func (s *Server) handleListWorkspaceActivity(w http.ResponseWriter, r *http.Requ
 		}
 		filtered := make([]models.Activity, 0, len(activities))
 		for _, a := range activities {
-			if a.CollectionSlug == "" || visibleSlugs[a.CollectionSlug] {
+			if a.CollectionSlug != "" && visibleSlugs[a.CollectionSlug] {
+				// Known collection that's visible — include
+				filtered = append(filtered, a)
+			} else if a.CollectionSlug == "" && a.ItemSlug == "" {
+				// Workspace-level activity (no item) — include
 				filtered = append(filtered, a)
 			}
+			// Drop: empty collection slug with an item (unresolved hidden item),
+			// or known collection slug that's not visible.
 		}
 		activities = filtered
 	}

--- a/internal/server/handlers_agent_roles.go
+++ b/internal/server/handlers_agent_roles.go
@@ -23,7 +23,11 @@ func (s *Server) handleListAgentRoles(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// When visibility is restricted, recompute item counts from visible items only
-	visibleIDs, _ := s.visibleCollectionIDs(r, workspaceID)
+	visibleIDs, visErr := s.visibleCollectionIDs(r, workspaceID)
+	if visErr != nil {
+		writeInternalError(w, visErr)
+		return
+	}
 	if visibleIDs != nil {
 		visibleItems, _ := s.store.ListItems(workspaceID, models.ItemListParams{CollectionIDs: visibleIDs})
 		// Build role → count map from visible items

--- a/internal/server/handlers_agent_roles.go
+++ b/internal/server/handlers_agent_roles.go
@@ -22,6 +22,22 @@ func (s *Server) handleListAgentRoles(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// When visibility is restricted, recompute item counts from visible items only
+	visibleIDs, _ := s.visibleCollectionIDs(r, workspaceID)
+	if visibleIDs != nil {
+		visibleItems, _ := s.store.ListItems(workspaceID, models.ItemListParams{CollectionIDs: visibleIDs})
+		// Build role → count map from visible items
+		roleCounts := make(map[string]int)
+		for _, item := range visibleItems {
+			if item.AgentRoleID != nil && *item.AgentRoleID != "" {
+				roleCounts[*item.AgentRoleID]++
+			}
+		}
+		for i := range roles {
+			roles[i].ItemCount = roleCounts[roles[i].ID]
+		}
+	}
+
 	writeJSON(w, http.StatusOK, roles)
 }
 

--- a/internal/server/handlers_changes.go
+++ b/internal/server/handlers_changes.go
@@ -54,6 +54,43 @@ func (s *Server) handleGetChanges(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Filter by collection visibility so restricted members only see
+	// changes from collections they have access to.
+	visibleIDs, visErr := s.visibleCollectionIDs(r, workspaceID)
+	if visErr != nil {
+		writeInternalError(w, visErr)
+		return
+	}
+	if visibleIDs != nil {
+		filtered := updated[:0]
+		allowedDeleted := deletedIDs[:0]
+		visibleSet := make(map[string]bool, len(visibleIDs))
+		for _, id := range visibleIDs {
+			visibleSet[id] = true
+		}
+		for _, item := range updated {
+			if visibleSet[item.CollectionID] {
+				filtered = append(filtered, item)
+			}
+		}
+		updated = filtered
+		// For deleted items, re-query with collection filter since we
+		// only have IDs. Fetch their collection_ids from the soft-deleted rows.
+		if len(deletedIDs) > 0 {
+			delItems, delErr := s.store.GetDeletedItemsWithCollection(workspaceID, deletedIDs)
+			if delErr != nil {
+				writeInternalError(w, delErr)
+				return
+			}
+			for _, item := range delItems {
+				if visibleSet[item.CollectionID] {
+					allowedDeleted = append(allowedDeleted, item.ID)
+				}
+			}
+			deletedIDs = allowedDeleted
+		}
+	}
+
 	// Convert to interface slice for JSON marshaling.
 	updatedItems := make([]interface{}, len(updated))
 	for i, item := range updated {

--- a/internal/server/handlers_collections.go
+++ b/internal/server/handlers_collections.go
@@ -94,6 +94,17 @@ func (s *Server) handleGetCollection(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Check collection visibility
+	visibleIDs, visErr := s.visibleCollectionIDs(r, workspaceID)
+	if visErr != nil {
+		writeInternalError(w, visErr)
+		return
+	}
+	if !isCollectionVisible(coll.ID, visibleIDs) {
+		writeError(w, http.StatusNotFound, "not_found", "Collection not found")
+		return
+	}
+
 	writeJSON(w, http.StatusOK, coll)
 }
 

--- a/internal/server/handlers_collections.go
+++ b/internal/server/handlers_collections.go
@@ -24,6 +24,23 @@ func (s *Server) handleListCollections(w http.ResponseWriter, r *http.Request) {
 	if colls == nil {
 		colls = []models.Collection{}
 	}
+
+	// Filter by collection visibility
+	visibleIDs, err := s.visibleCollectionIDs(r, workspaceID)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	if visibleIDs != nil {
+		filtered := make([]models.Collection, 0, len(colls))
+		for _, c := range colls {
+			if isCollectionVisible(c.ID, visibleIDs) {
+				filtered = append(filtered, c)
+			}
+		}
+		colls = filtered
+	}
+
 	writeJSON(w, http.StatusOK, colls)
 }
 

--- a/internal/server/handlers_comments.go
+++ b/internal/server/handlers_comments.go
@@ -29,6 +29,9 @@ func (s *Server) handleListComments(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, "not_found", "Item not found")
 		return
 	}
+	if !s.requireItemVisible(w, r, workspaceID, item) {
+		return
+	}
 
 	comments, err := s.store.ListComments(item.ID)
 	if err != nil {
@@ -76,6 +79,9 @@ func (s *Server) handleCreateComment(w http.ResponseWriter, r *http.Request) {
 	}
 	if item == nil {
 		writeError(w, http.StatusNotFound, "not_found", "Item not found")
+		return
+	}
+	if !s.requireItemVisible(w, r, workspaceID, item) {
 		return
 	}
 
@@ -138,6 +144,9 @@ func (s *Server) handleDeleteComment(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, "not_found", "Comment not found")
 		return
 	}
+	if !s.requireCommentVisible(w, r, workspaceID, comment) {
+		return
+	}
 
 	if err := s.store.DeleteComment(commentID); err != nil {
 		if err == sql.ErrNoRows {
@@ -169,6 +178,9 @@ func (s *Server) handleCreateReply(w http.ResponseWriter, r *http.Request) {
 	}
 	if parentComment.WorkspaceID != workspaceID {
 		writeError(w, http.StatusNotFound, "not_found", "Parent comment not found")
+		return
+	}
+	if !s.requireCommentVisible(w, r, workspaceID, parentComment) {
 		return
 	}
 
@@ -204,7 +216,12 @@ func (s *Server) handleCreateReply(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	s.publishCommentEvent(events.CommentCreated, workspaceID, parentComment.ItemID, comment.ID, parentComment.ItemTitle, "", actor, source)
+	// Resolve the item's collection slug for SSE filtering
+	replyCollSlug := ""
+	if replyItem, err := s.store.GetItem(parentComment.ItemID); err == nil && replyItem != nil {
+		replyCollSlug = replyItem.CollectionSlug
+	}
+	s.publishCommentEvent(events.CommentCreated, workspaceID, parentComment.ItemID, comment.ID, parentComment.ItemTitle, replyCollSlug, actor, source)
 
 	writeJSON(w, http.StatusCreated, comment)
 }
@@ -225,6 +242,9 @@ func (s *Server) handleAddReaction(w http.ResponseWriter, r *http.Request) {
 	comment, err := s.store.GetComment(commentID)
 	if err != nil || comment == nil || comment.WorkspaceID != workspaceID {
 		writeError(w, http.StatusNotFound, "not_found", "Comment not found")
+		return
+	}
+	if !s.requireCommentVisible(w, r, workspaceID, comment) {
 		return
 	}
 
@@ -276,6 +296,9 @@ func (s *Server) handleRemoveReaction(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, "not_found", "Comment not found")
 		return
 	}
+	if !s.requireCommentVisible(w, r, workspaceID, commentObj) {
+		return
+	}
 
 	userID := currentUserID(r)
 
@@ -290,6 +313,17 @@ func (s *Server) handleRemoveReaction(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// requireCommentVisible checks that a comment's underlying item is in a visible
+// collection. Writes a 404 and returns false if not.
+func (s *Server) requireCommentVisible(w http.ResponseWriter, r *http.Request, workspaceID string, comment *models.Comment) bool {
+	item, err := s.store.GetItem(comment.ItemID)
+	if err != nil || item == nil {
+		writeError(w, http.StatusNotFound, "not_found", "Comment not found")
+		return false
+	}
+	return s.requireItemVisible(w, r, workspaceID, item)
 }
 
 // publishCommentEvent publishes a real-time event for comment changes.
@@ -313,9 +347,15 @@ func (s *Server) publishReactionEvent(eventType string, comment *models.Comment)
 	if s.events == nil || comment == nil {
 		return
 	}
+	// Resolve the item's collection slug so SSE filtering can scope this event
+	collSlug := ""
+	if item, err := s.store.GetItem(comment.ItemID); err == nil && item != nil {
+		collSlug = item.CollectionSlug
+	}
 	s.events.Publish(events.Event{
 		Type:        eventType,
 		WorkspaceID: comment.WorkspaceID,
 		ItemID:      comment.ItemID,
+		Collection:  collSlug,
 	})
 }

--- a/internal/server/handlers_dashboard.go
+++ b/internal/server/handlers_dashboard.go
@@ -134,11 +134,28 @@ func (s *Server) handleGetDashboard(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Compute collection visibility once for the entire dashboard
+	visibleIDs, err := s.visibleCollectionIDs(r, workspaceID)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+
 	// Build a schema map for terminal status lookups
 	collections, err := s.store.ListCollections(workspaceID)
 	if err != nil {
 		writeInternalError(w, err)
 		return
+	}
+	// Filter collections by visibility
+	if visibleIDs != nil {
+		filtered := make([]models.Collection, 0, len(collections))
+		for _, c := range collections {
+			if isCollectionVisible(c.ID, visibleIDs) {
+				filtered = append(filtered, c)
+			}
+		}
+		collections = filtered
 	}
 	schemaMap := buildSchemaMap(collections)
 
@@ -154,7 +171,7 @@ func (s *Server) handleGetDashboard(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Summary: items grouped by collection slug and status field
-	allItems, err := s.store.ListItems(workspaceID, models.ItemListParams{})
+	allItems, err := s.store.ListItems(workspaceID, models.ItemListParams{CollectionIDs: visibleIDs})
 	if err != nil {
 		writeInternalError(w, err)
 		return
@@ -215,6 +232,7 @@ func (s *Server) handleGetDashboard(w http.ResponseWriter, r *http.Request) {
 	// Active plans: items in "plans" collection where status=active
 	plans, err := s.store.ListItems(workspaceID, models.ItemListParams{
 		CollectionSlug: "plans",
+		CollectionIDs:  visibleIDs,
 		Fields:         map[string]string{"status": "active"},
 	})
 	if err == nil {
@@ -254,7 +272,8 @@ func (s *Server) handleGetDashboard(w http.ResponseWriter, r *http.Request) {
 	// (a) Stalled: status is in-progress or in_progress, updated_at older than 3 days
 	for _, statusVal := range []string{"in-progress", "in_progress"} {
 		items, err := s.store.ListItems(workspaceID, models.ItemListParams{
-			Fields: map[string]string{"status": statusVal},
+			CollectionIDs: visibleIDs,
+			Fields:        map[string]string{"status": statusVal},
 		})
 		if err != nil {
 			continue
@@ -331,6 +350,7 @@ func (s *Server) handleGetDashboard(w http.ResponseWriter, r *http.Request) {
 		}
 		allTasks, err := s.store.ListItems(workspaceID, models.ItemListParams{
 			CollectionSlug: "tasks",
+			CollectionIDs:  visibleIDs,
 		})
 		if err == nil {
 			for _, task := range allTasks {
@@ -392,11 +412,27 @@ func (s *Server) handleGetDashboard(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Recent activity — enriched with item titles and user names
+	// Fetch more than needed since some may be filtered out by visibility
 	activities, err := s.store.ListWorkspaceActivity(workspaceID, models.ActivityListParams{
-		Limit: 10,
+		Limit: 30,
 	})
 	if err == nil && activities != nil {
+		// Build visible slug set for filtering
+		var visibleSlugSet map[string]bool
+		if visibleIDs != nil {
+			visibleSlugSet = make(map[string]bool)
+			for _, id := range visibleIDs {
+				coll, _ := s.store.GetCollection(id)
+				if coll != nil {
+					visibleSlugSet[coll.Slug] = true
+				}
+			}
+		}
+
 		for _, a := range activities {
+			if len(resp.RecentActivity) >= 10 {
+				break
+			}
 			da := DashboardActivity{
 				Action:    a.Action,
 				Actor:     a.Actor,
@@ -409,6 +445,10 @@ func (s *Server) handleGetDashboard(w http.ResponseWriter, r *http.Request) {
 			if a.DocumentID != "" {
 				item, err := s.store.GetItem(a.DocumentID)
 				if err == nil && item != nil {
+					// Skip items in hidden collections
+					if visibleSlugSet != nil && !visibleSlugSet[item.CollectionSlug] {
+						continue
+					}
 					da.ItemTitle = item.Title
 					da.ItemSlug = item.Slug
 					da.CollectionSlug = item.CollectionSlug

--- a/internal/server/handlers_dashboard.go
+++ b/internal/server/handlers_dashboard.go
@@ -534,10 +534,52 @@ func (s *Server) handleGetDashboard(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 
-	// Role breakdown: items per role with assigned users
-	roleBreakdown, err := s.store.GetRoleBreakdown(workspaceID)
-	if err == nil && len(roleBreakdown) > 0 {
-		resp.ByRole = roleBreakdown
+	// Role breakdown: items per role with assigned users.
+	// When visibility is restricted, recompute from visible items only.
+	if visibleIDs != nil {
+		roleBreakdown, err := s.store.GetRoleBreakdown(workspaceID)
+		if err == nil {
+			// Recount from visible items
+			roleCounts := make(map[string]int)
+			roleUsers := make(map[string]map[string]bool)
+			for _, item := range allItems {
+				roleID := ""
+				if item.AgentRoleID != nil {
+					roleID = *item.AgentRoleID
+				}
+				status := extractFieldValue(item.Fields, "status")
+				if isItemTerminal(status, item.CollectionID, schemaMap) {
+					continue
+				}
+				roleCounts[roleID]++
+				if item.AssignedUserName != "" {
+					if roleUsers[roleID] == nil {
+						roleUsers[roleID] = make(map[string]bool)
+					}
+					roleUsers[roleID][item.AssignedUserName] = true
+				}
+			}
+			for i := range roleBreakdown {
+				rid := ""
+				if roleBreakdown[i].RoleID != nil {
+					rid = *roleBreakdown[i].RoleID
+				}
+				roleBreakdown[i].ItemCount = roleCounts[rid]
+				users := make([]string, 0)
+				for u := range roleUsers[rid] {
+					users = append(users, u)
+				}
+				roleBreakdown[i].Users = users
+			}
+			if len(roleBreakdown) > 0 {
+				resp.ByRole = roleBreakdown
+			}
+		}
+	} else {
+		roleBreakdown, err := s.store.GetRoleBreakdown(workspaceID)
+		if err == nil && len(roleBreakdown) > 0 {
+			resp.ByRole = roleBreakdown
+		}
 	}
 
 	writeJSON(w, http.StatusOK, resp)

--- a/internal/server/handlers_dashboard.go
+++ b/internal/server/handlers_dashboard.go
@@ -395,6 +395,10 @@ func (s *Server) handleGetDashboard(w http.ResponseWriter, r *http.Request) {
 			if err != nil || blocker == nil {
 				continue
 			}
+			// Skip blockers from hidden collections
+			if !isCollectionVisible(blocker.CollectionID, visibleIDs) {
+				continue
+			}
 			blockerStatus := extractFieldValue(blocker.Fields, "status")
 			if isItemTerminal(blockerStatus, blocker.CollectionID, schemaMap) {
 				continue

--- a/internal/server/handlers_dashboard.go
+++ b/internal/server/handlers_dashboard.go
@@ -243,9 +243,21 @@ func (s *Server) handleGetDashboard(w http.ResponseWriter, r *http.Request) {
 				Title: plan.Title,
 			}
 
-			// Compute progress from child items linked via parent link
-			total, done, err := s.store.GetItemProgress(plan.ID)
-			if err == nil && total > 0 {
+			// Compute progress from visible child items only
+			total, done := 0, 0
+			if planChildren, cerr := s.store.GetChildItems(plan.ID); cerr == nil {
+				for _, child := range planChildren {
+					if !isCollectionVisible(child.CollectionID, visibleIDs) {
+						continue
+					}
+					total++
+					childStatus := extractFieldValue(child.Fields, "status")
+					if isItemTerminal(childStatus, child.CollectionID, schemaMap) {
+						done++
+					}
+				}
+			}
+			if total > 0 {
 				dp.TaskCount = total
 				dp.DoneCount = done
 				dp.Progress = (done * 100) / total
@@ -481,6 +493,10 @@ func (s *Server) handleGetDashboard(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 		for _, task := range tasks {
+			// Skip tasks from hidden collections
+			if !isCollectionVisible(task.CollectionID, visibleIDs) {
+				continue
+			}
 			taskStatus := extractFieldValue(task.Fields, "status")
 			if taskStatus == "open" {
 				pri := extractFieldValue(task.Fields, "priority")

--- a/internal/server/handlers_events.go
+++ b/internal/server/handlers_events.go
@@ -31,7 +31,7 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ws, err := s.store.GetWorkspaceBySlug(slug)
+	ws, err := s.resolveWorkspace(slug, currentUser(r))
 	if err != nil {
 		writeInternalError(w, err)
 		return
@@ -39,6 +39,17 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 	if ws == nil {
 		writeError(w, http.StatusNotFound, "not_found", "Workspace not found")
 		return
+	}
+
+	// Verify workspace access for legacy API tokens (no user context).
+	// User-based access is checked by resolveWorkspace above, but
+	// legacy tokens store the workspace ID in context — verify it matches.
+	if currentUser(r) == nil {
+		tokenWsID := tokenWorkspaceID(r)
+		if tokenWsID != "" && tokenWsID != ws.ID {
+			writeError(w, http.StatusForbidden, "forbidden", "Token not authorized for this workspace")
+			return
+		}
 	}
 
 	// Verify streaming support

--- a/internal/server/handlers_events.go
+++ b/internal/server/handlers_events.go
@@ -80,7 +80,10 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 	var visibleSlugSet map[string]bool // nil = all access (no filtering)
 	visibleIDs, err := s.visibleCollectionIDs(r, ws.ID)
 	if err != nil {
-		slog.Warn("SSE: failed to resolve visible collections, allowing all", "error", err)
+		// Fail closed: if we can't determine visibility, deny all
+		// collection-scoped events rather than leaking hidden data.
+		slog.Warn("SSE: failed to resolve visible collections, denying all", "error", err)
+		visibleSlugSet = make(map[string]bool) // empty set = deny all
 	} else if visibleIDs != nil {
 		visibleSlugSet = make(map[string]bool, len(visibleIDs))
 		for _, id := range visibleIDs {

--- a/internal/server/handlers_events.go
+++ b/internal/server/handlers_events.go
@@ -75,6 +75,33 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Compute the user's visible collection set for event filtering.
+	// Build a slug-based set since events carry collection slugs, not IDs.
+	var visibleSlugSet map[string]bool // nil = all access (no filtering)
+	visibleIDs, err := s.visibleCollectionIDs(r, ws.ID)
+	if err != nil {
+		slog.Warn("SSE: failed to resolve visible collections, allowing all", "error", err)
+	} else if visibleIDs != nil {
+		visibleSlugSet = make(map[string]bool, len(visibleIDs))
+		for _, id := range visibleIDs {
+			coll, _ := s.store.GetCollection(id)
+			if coll != nil {
+				visibleSlugSet[coll.Slug] = true
+			}
+		}
+	}
+
+	// sseEventVisible checks if an event should be sent to this client.
+	sseEventVisible := func(collection string) bool {
+		if visibleSlugSet == nil {
+			return true // all access
+		}
+		if collection == "" {
+			return true // events without a collection are always sent
+		}
+		return visibleSlugSet[collection]
+	}
+
 	// Send initial connected event
 	writeSSEEvent(w, "connected", 0, map[string]string{
 		"workspace_id": ws.ID,
@@ -100,8 +127,10 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 				slog.Info("SSE replaying missed events",
 					"workspace", ws.Slug, "last_event_id", lastID, "count", len(missed))
 				for _, event := range missed {
-					writeSSEEvent(w, event.Type, event.ID, event)
-					flusher.Flush()
+					if sseEventVisible(event.Collection) {
+						writeSSEEvent(w, event.Type, event.ID, event)
+						flusher.Flush()
+					}
 				}
 			}
 			// If len(missed) == 0: client is caught up, nothing to replay.
@@ -124,8 +153,10 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 				// Channel closed (unsubscribed)
 				return
 			}
-			writeSSEEvent(w, event.Type, event.ID, event)
-			flusher.Flush()
+			if sseEventVisible(event.Collection) {
+				writeSSEEvent(w, event.Type, event.ID, event)
+				flusher.Flush()
+			}
 
 		case <-keepalive.C:
 			// Send keepalive comment to prevent proxy/LB timeouts

--- a/internal/server/handlers_item_links.go
+++ b/internal/server/handlers_item_links.go
@@ -41,7 +41,11 @@ func (s *Server) handleGetItemLinks(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Filter out links where the linked item is in a hidden collection
-	visibleIDs, _ := s.visibleCollectionIDs(r, workspaceID)
+	visibleIDs, visErr := s.visibleCollectionIDs(r, workspaceID)
+	if visErr != nil {
+		writeInternalError(w, visErr)
+		return
+	}
 	if visibleIDs != nil {
 		filtered := links[:0]
 		for _, link := range links {

--- a/internal/server/handlers_item_links.go
+++ b/internal/server/handlers_item_links.go
@@ -27,6 +27,9 @@ func (s *Server) handleGetItemLinks(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, "not_found", "Item not found")
 		return
 	}
+	if !s.requireItemVisible(w, r, workspaceID, item) {
+		return
+	}
 
 	links, err := s.store.GetItemLinks(item.ID)
 	if err != nil {
@@ -35,6 +38,25 @@ func (s *Server) handleGetItemLinks(w http.ResponseWriter, r *http.Request) {
 	}
 	if links == nil {
 		links = []models.ItemLink{}
+	}
+
+	// Filter out links where the linked item is in a hidden collection
+	visibleIDs, _ := s.visibleCollectionIDs(r, workspaceID)
+	if visibleIDs != nil {
+		filtered := links[:0]
+		for _, link := range links {
+			// Check the "other side" of the link
+			otherID := link.TargetID
+			if otherID == item.ID {
+				otherID = link.SourceID
+			}
+			if other, err := s.store.GetItem(otherID); err == nil && other != nil {
+				if isCollectionVisible(other.CollectionID, visibleIDs) {
+					filtered = append(filtered, link)
+				}
+			}
+		}
+		links = filtered
 	}
 
 	writeJSON(w, http.StatusOK, links)
@@ -60,6 +82,9 @@ func (s *Server) handleCreateItemLink(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, "not_found", "Item not found")
 		return
 	}
+	if !s.requireItemVisible(w, r, workspaceID, item) {
+		return
+	}
 
 	var input models.ItemLinkCreate
 	if err := decodeJSON(r, &input); err != nil {
@@ -79,7 +104,7 @@ func (s *Server) handleCreateItemLink(w http.ResponseWriter, r *http.Request) {
 	}
 	input.LinkType = linkType
 
-	// Verify target item exists
+	// Verify target item exists and is in a visible collection
 	target, err := s.store.GetItem(input.TargetID)
 	if err != nil {
 		writeInternalError(w, err)
@@ -87,6 +112,9 @@ func (s *Server) handleCreateItemLink(w http.ResponseWriter, r *http.Request) {
 	}
 	if target == nil || target.WorkspaceID != workspaceID {
 		writeError(w, http.StatusBadRequest, "bad_request", "Target item not found")
+		return
+	}
+	if !s.requireItemVisible(w, r, workspaceID, target) {
 		return
 	}
 	if target.ID == item.ID {

--- a/internal/server/handlers_item_links.go
+++ b/internal/server/handlers_item_links.go
@@ -161,12 +161,36 @@ func (s *Server) handleDeleteItemLink(w http.ResponseWriter, r *http.Request) {
 	if !requireMinRole(w, r, "editor") {
 		return
 	}
-	_, ok := s.getWorkspaceID(w, r)
+	workspaceID, ok := s.getWorkspaceID(w, r)
 	if !ok {
 		return
 	}
 
 	linkID := chi.URLParam(r, "linkID")
+
+	// Look up the link and verify it belongs to this workspace
+	link, err := s.store.GetItemLinkByID(linkID)
+	if err != nil || link == nil || link.WorkspaceID != workspaceID {
+		writeError(w, http.StatusNotFound, "not_found", "Link not found")
+		return
+	}
+
+	// Verify both linked items are in visible collections
+	visibleIDs, visErr := s.visibleCollectionIDs(r, workspaceID)
+	if visErr != nil {
+		writeInternalError(w, visErr)
+		return
+	}
+	if visibleIDs != nil {
+		for _, itemID := range []string{link.SourceID, link.TargetID} {
+			item, ierr := s.store.GetItem(itemID)
+			if ierr != nil || item == nil || !isCollectionVisible(item.CollectionID, visibleIDs) {
+				writeError(w, http.StatusNotFound, "not_found", "Link not found")
+				return
+			}
+		}
+	}
+
 	if err := s.store.DeleteItemLink(linkID); err != nil {
 		if err == sql.ErrNoRows {
 			writeError(w, http.StatusNotFound, "not_found", "Link not found")

--- a/internal/server/handlers_item_versions.go
+++ b/internal/server/handlers_item_versions.go
@@ -26,6 +26,9 @@ func (s *Server) handleListItemVersions(w http.ResponseWriter, r *http.Request) 
 		writeError(w, http.StatusNotFound, "not_found", "Item not found")
 		return
 	}
+	if !s.requireItemVisible(w, r, workspaceID, item) {
+		return
+	}
 
 	versions, err := s.store.ListItemVersionsResolved(item.ID, item.Content)
 	if err != nil {
@@ -59,6 +62,9 @@ func (s *Server) handleRestoreItemVersion(w http.ResponseWriter, r *http.Request
 	}
 	if item == nil {
 		writeError(w, http.StatusNotFound, "not_found", "Item not found")
+		return
+	}
+	if !s.requireItemVisible(w, r, workspaceID, item) {
 		return
 	}
 

--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -46,7 +46,7 @@ func (s *Server) handleListItems(w http.ResponseWriter, r *http.Request) {
 	if result == nil {
 		result = []models.Item{}
 	}
-	s.enrichItemsWithParent(workspaceID, result)
+	s.enrichItemsWithParent(workspaceID, result, visibleIDs)
 
 	writeJSON(w, http.StatusOK, result)
 }
@@ -100,7 +100,7 @@ func (s *Server) handleListCollectionItems(w http.ResponseWriter, r *http.Reques
 	if result == nil {
 		result = []models.Item{}
 	}
-	s.enrichItemsWithParent(workspaceID, result)
+	s.enrichItemsWithParent(workspaceID, result, visibleIDs)
 
 	writeJSON(w, http.StatusOK, result)
 }
@@ -122,6 +122,17 @@ func (s *Server) handleCreateItem(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if coll == nil {
+		writeError(w, http.StatusNotFound, "not_found", "Collection not found")
+		return
+	}
+
+	// Check collection visibility
+	visibleIDs, visErr := s.visibleCollectionIDs(r, workspaceID)
+	if visErr != nil {
+		writeInternalError(w, visErr)
+		return
+	}
+	if !isCollectionVisible(coll.ID, visibleIDs) {
 		writeError(w, http.StatusNotFound, "not_found", "Collection not found")
 		return
 	}
@@ -163,15 +174,21 @@ func (s *Server) handleCreateItem(w http.ResponseWriter, r *http.Request) {
 		}
 		if pv, ok := fieldMap[key]; ok && pv != nil {
 			if pvStr, ok := pv.(string); ok && pvStr != "" {
+				var resolvedParent *models.Item
 				if !isUUID(pvStr) {
-					resolved, err := s.store.ResolveItem(workspaceID, pvStr)
-					if err != nil || resolved == nil {
+					resolvedParent, err = s.store.ResolveItem(workspaceID, pvStr)
+					if err != nil || resolvedParent == nil {
 						writeError(w, http.StatusBadRequest, "bad_request", fmt.Sprintf("parent %q not found", pvStr))
 						return
 					}
-					parentValue = resolved.ID
+					parentValue = resolvedParent.ID
 				} else {
 					parentValue = pvStr
+					resolvedParent, _ = s.store.GetItem(pvStr)
+				}
+				// Ensure parent item is in a visible collection
+				if resolvedParent != nil && !s.requireItemVisible(w, r, workspaceID, resolvedParent) {
+					return
 				}
 			}
 			delete(fieldMap, key)
@@ -240,6 +257,9 @@ func (s *Server) handleGetItem(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, "not_found", "Item not found")
 		return
 	}
+	if !s.requireItemVisible(w, r, workspaceID, item) {
+		return
+	}
 
 	if err := s.enrichItemForResponse(item); err != nil {
 		writeInternalError(w, err)
@@ -267,6 +287,9 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 	}
 	if item == nil {
 		writeError(w, http.StatusNotFound, "not_found", "Item not found")
+		return
+	}
+	if !s.requireItemVisible(w, r, workspaceID, item) {
 		return
 	}
 
@@ -309,15 +332,21 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 				parentProvided = true
 				if pv != nil {
 					if pvStr, ok := pv.(string); ok && pvStr != "" {
+						var resolvedParent *models.Item
 						if !isUUID(pvStr) {
-							resolved, err := s.store.ResolveItem(workspaceID, pvStr)
-							if err != nil || resolved == nil {
+							resolvedParent, err = s.store.ResolveItem(workspaceID, pvStr)
+							if err != nil || resolvedParent == nil {
 								writeError(w, http.StatusBadRequest, "bad_request", fmt.Sprintf("parent %q not found", pvStr))
 								return
 							}
-							parentValue = resolved.ID
+							parentValue = resolvedParent.ID
 						} else {
 							parentValue = pvStr
+							resolvedParent, _ = s.store.GetItem(pvStr)
+						}
+						// Ensure parent item is in a visible collection
+						if resolvedParent != nil && !s.requireItemVisible(w, r, workspaceID, resolvedParent) {
+							return
 						}
 					}
 				}
@@ -448,6 +477,9 @@ func (s *Server) handleDeleteItem(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, "not_found", "Item not found")
 		return
 	}
+	if !s.requireItemVisible(w, r, workspaceID, item) {
+		return
+	}
 
 	if err := s.store.DeleteItem(item.ID); err != nil {
 		writeInternalError(w, err)
@@ -482,6 +514,9 @@ func (s *Server) handleRestoreItem(w http.ResponseWriter, r *http.Request) {
 	}
 	if item == nil {
 		writeError(w, http.StatusNotFound, "not_found", "Item not found or not archived")
+		return
+	}
+	if !s.requireItemVisible(w, r, workspaceID, item) {
 		return
 	}
 
@@ -523,6 +558,9 @@ func (s *Server) handleMoveItem(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, "not_found", "Item not found")
 		return
 	}
+	if !s.requireItemVisible(w, r, workspaceID, item) {
+		return
+	}
 
 	var input struct {
 		TargetCollection string         `json:"target_collection"`
@@ -537,9 +575,18 @@ func (s *Server) handleMoveItem(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Get target collection
+	// Get target collection and verify it's visible to the user
 	targetColl, err := s.store.GetCollectionBySlug(workspaceID, input.TargetCollection)
 	if err != nil || targetColl == nil {
+		writeError(w, http.StatusBadRequest, "invalid_collection", "Target collection not found")
+		return
+	}
+	targetVisibleIDs, visErr := s.visibleCollectionIDs(r, workspaceID)
+	if visErr != nil {
+		writeInternalError(w, visErr)
+		return
+	}
+	if !isCollectionVisible(targetColl.ID, targetVisibleIDs) {
 		writeError(w, http.StatusBadRequest, "invalid_collection", "Target collection not found")
 		return
 	}
@@ -650,6 +697,20 @@ func (s *Server) handlePlansProgress(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Check that the plans collection is visible to this user
+	visibleIDs, err := s.visibleCollectionIDs(r, workspaceID)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	if visibleIDs != nil {
+		plansColl, _ := s.store.GetCollectionBySlug(workspaceID, "plans")
+		if plansColl == nil || !isCollectionVisible(plansColl.ID, visibleIDs) {
+			writeJSON(w, http.StatusOK, []interface{}{})
+			return
+		}
+	}
+
 	progress, err := s.store.GetAllItemProgress(workspaceID, "plans")
 	if err != nil {
 		writeInternalError(w, err)
@@ -676,6 +737,9 @@ func (s *Server) handleGetItemChildren(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, "not_found", "Item not found")
 		return
 	}
+	if !s.requireItemVisible(w, r, workspaceID, item) {
+		return
+	}
 
 	children, err := s.store.GetChildItems(item.ID)
 	if err != nil {
@@ -685,7 +749,24 @@ func (s *Server) handleGetItemChildren(w http.ResponseWriter, r *http.Request) {
 	if children == nil {
 		children = []models.Item{}
 	}
-	s.enrichItemsWithParent(workspaceID, children)
+
+	// Filter children by collection visibility
+	visibleIDs, visErr := s.visibleCollectionIDs(r, workspaceID)
+	if visErr != nil {
+		writeInternalError(w, visErr)
+		return
+	}
+	if visibleIDs != nil {
+		filtered := children[:0]
+		for _, child := range children {
+			if isCollectionVisible(child.CollectionID, visibleIDs) {
+				filtered = append(filtered, child)
+			}
+		}
+		children = filtered
+	}
+
+	s.enrichItemsWithParent(workspaceID, children, visibleIDs)
 	s.store.PopulateHasChildren(children)
 	writeJSON(w, http.StatusOK, children)
 }
@@ -706,6 +787,42 @@ func (s *Server) handleGetItemProgress(w http.ResponseWriter, r *http.Request) {
 	}
 	if item == nil {
 		writeError(w, http.StatusNotFound, "not_found", "Item not found")
+		return
+	}
+	if !s.requireItemVisible(w, r, workspaceID, item) {
+		return
+	}
+
+	// Get visibility filter; when restricted, compute progress from
+	// visible children only so hidden child counts don't leak.
+	progVisIDs, _ := s.visibleCollectionIDs(r, workspaceID)
+	if progVisIDs != nil {
+		// Restricted: compute from visible children in Go
+		children, cerr := s.store.GetChildItems(item.ID)
+		if cerr != nil {
+			writeInternalError(w, cerr)
+			return
+		}
+		total, done := 0, 0
+		for _, child := range children {
+			if !isCollectionVisible(child.CollectionID, progVisIDs) {
+				continue
+			}
+			total++
+			status := extractStatus(child.Fields)
+			if models.IsTerminalStatusDefault(status) {
+				done++
+			}
+		}
+		pct := 0
+		if total > 0 {
+			pct = (done * 100) / total
+		}
+		writeJSON(w, http.StatusOK, map[string]int{
+			"total":      total,
+			"done":       done,
+			"percentage": pct,
+		})
 		return
 	}
 
@@ -1055,6 +1172,9 @@ func (s *Server) handleListItemActivity(w http.ResponseWriter, r *http.Request) 
 		writeError(w, http.StatusNotFound, "not_found", "Item not found")
 		return
 	}
+	if !s.requireItemVisible(w, r, workspaceID, item) {
+		return
+	}
 
 	params := models.ActivityListParams{
 		Action: r.URL.Query().Get("action"),
@@ -1077,4 +1197,19 @@ func (s *Server) handleListItemActivity(w http.ResponseWriter, r *http.Request) 
 	}
 
 	writeJSON(w, http.StatusOK, activities)
+}
+
+// extractStatus extracts the "status" field from an item's JSON fields string.
+func extractStatus(fields string) string {
+	if fields == "" || fields == "{}" {
+		return ""
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal([]byte(fields), &m); err != nil {
+		return ""
+	}
+	if v, ok := m["status"].(string); ok {
+		return v
+	}
+	return ""
 }

--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -25,7 +25,7 @@ func (s *Server) handleListItems(w http.ResponseWriter, r *http.Request) {
 	}
 
 	params := parseItemListParams(r)
-	if err := s.resolveParentFilter(workspaceID, &params); err != nil {
+	if err := s.resolveParentFilter(r, workspaceID, &params); err != nil {
 		writeError(w, http.StatusBadRequest, "bad_request", err.Error())
 		return
 	}
@@ -87,7 +87,7 @@ func (s *Server) handleListCollectionItems(w http.ResponseWriter, r *http.Reques
 	if coll.Schema != "" {
 		_ = json.Unmarshal([]byte(coll.Schema), &collSchema)
 	}
-	if err := s.resolveParentFilter(workspaceID, &params, collSchema); err != nil {
+	if err := s.resolveParentFilter(r, workspaceID, &params, collSchema); err != nil {
 		writeError(w, http.StatusBadRequest, "bad_request", err.Error())
 		return
 	}
@@ -183,18 +183,20 @@ func (s *Server) handleCreateItem(w http.ResponseWriter, r *http.Request) {
 					}
 					parentValue = resolvedParent.ID
 				} else {
-					parentValue = pvStr
 					resolvedParent, _ = s.store.GetItem(pvStr)
-				}
-				// Ensure parent item belongs to this workspace and is visible
-				if resolvedParent != nil {
-					if resolvedParent.WorkspaceID != workspaceID {
+					if resolvedParent == nil {
 						writeError(w, http.StatusBadRequest, "bad_request", fmt.Sprintf("parent %q not found", pvStr))
 						return
 					}
-					if !s.requireItemVisible(w, r, workspaceID, resolvedParent) {
-						return
-					}
+					parentValue = resolvedParent.ID
+				}
+				// Ensure parent item belongs to this workspace and is visible
+				if resolvedParent.WorkspaceID != workspaceID {
+					writeError(w, http.StatusBadRequest, "bad_request", fmt.Sprintf("parent %q not found", pvStr))
+					return
+				}
+				if !s.requireItemVisible(w, r, workspaceID, resolvedParent) {
+					return
 				}
 			}
 			delete(fieldMap, key)
@@ -349,18 +351,20 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 							}
 							parentValue = resolvedParent.ID
 						} else {
-							parentValue = pvStr
 							resolvedParent, _ = s.store.GetItem(pvStr)
-						}
-						// Ensure parent item belongs to this workspace and is visible
-						if resolvedParent != nil {
-							if resolvedParent.WorkspaceID != workspaceID {
+							if resolvedParent == nil {
 								writeError(w, http.StatusBadRequest, "bad_request", fmt.Sprintf("parent %q not found", pvStr))
 								return
 							}
-							if !s.requireItemVisible(w, r, workspaceID, resolvedParent) {
-								return
-							}
+							parentValue = resolvedParent.ID
+						}
+						// Ensure parent item belongs to this workspace and is visible
+						if resolvedParent.WorkspaceID != workspaceID {
+							writeError(w, http.StatusBadRequest, "bad_request", fmt.Sprintf("parent %q not found", pvStr))
+							return
+						}
+						if !s.requireItemVisible(w, r, workspaceID, resolvedParent) {
+							return
 						}
 					}
 				}
@@ -728,6 +732,38 @@ func (s *Server) handlePlansProgress(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// When user has restricted visibility, compute progress from visible
+	// children only so hidden child counts don't leak.
+	if visibleIDs != nil {
+		allProgress, err := s.store.GetAllItemProgress(workspaceID, "plans")
+		if err != nil {
+			writeInternalError(w, err)
+			return
+		}
+		// Recompute each plan's progress using only visible children
+		for i, p := range allProgress {
+			children, cerr := s.store.GetChildItems(p.ItemID)
+			if cerr != nil {
+				continue
+			}
+			total, done := 0, 0
+			for _, child := range children {
+				if !isCollectionVisible(child.CollectionID, visibleIDs) {
+					continue
+				}
+				total++
+				status := extractStatus(child.Fields)
+				if models.IsTerminalStatusDefault(status) {
+					done++
+				}
+			}
+			allProgress[i].Total = total
+			allProgress[i].Done = done
+		}
+		writeJSON(w, http.StatusOK, allProgress)
+		return
+	}
+
 	progress, err := s.store.GetAllItemProgress(workspaceID, "plans")
 	if err != nil {
 		writeInternalError(w, err)
@@ -814,12 +850,15 @@ func (s *Server) handleGetItemProgress(w http.ResponseWriter, r *http.Request) {
 	// visible children only so hidden child counts don't leak.
 	progVisIDs, _ := s.visibleCollectionIDs(r, workspaceID)
 	if progVisIDs != nil {
-		// Restricted: compute from visible children in Go
+		// Restricted: compute from visible children in Go using per-collection
+		// schemas to determine terminal statuses correctly.
 		children, cerr := s.store.GetChildItems(item.ID)
 		if cerr != nil {
 			writeInternalError(w, cerr)
 			return
 		}
+		// Cache collection schemas for terminal status lookup
+		schemaCache := make(map[string]models.CollectionSchema)
 		total, done := 0, 0
 		for _, child := range children {
 			if !isCollectionVisible(child.CollectionID, progVisIDs) {
@@ -827,7 +866,14 @@ func (s *Server) handleGetItemProgress(w http.ResponseWriter, r *http.Request) {
 			}
 			total++
 			status := extractStatus(child.Fields)
-			if models.IsTerminalStatusDefault(status) {
+			schema, cached := schemaCache[child.CollectionID]
+			if !cached {
+				if coll, cerr := s.store.GetCollection(child.CollectionID); cerr == nil && coll != nil {
+					_ = json.Unmarshal([]byte(coll.Schema), &schema)
+				}
+				schemaCache[child.CollectionID] = schema
+			}
+			if models.IsTerminalStatus(status, schema) {
 				done++
 			}
 		}
@@ -865,7 +911,7 @@ func (s *Server) handleGetItemProgress(w http.ResponseWriter, r *http.Request) {
 // filters and converts it to a ParentLinkID filter (which uses item_links instead of json_extract).
 // An optional schema can be passed; if the schema defines a field with the key,
 // that key is left as a normal field filter instead of being treated as a parent link.
-func (s *Server) resolveParentFilter(workspaceID string, params *models.ItemListParams, schemas ...models.CollectionSchema) error {
+func (s *Server) resolveParentFilter(r *http.Request, workspaceID string, params *models.ItemListParams, schemas ...models.CollectionSchema) error {
 	if params.Fields == nil {
 		return nil
 	}
@@ -892,15 +938,31 @@ func (s *Server) resolveParentFilter(workspaceID string, params *models.ItemList
 	}
 
 	// Resolve slug/ref to UUID
+	var resolved *models.Item
 	if !isUUID(val) {
-		resolved, err := s.store.ResolveItem(workspaceID, val)
-		if err != nil || resolved == nil {
+		var rerr error
+		resolved, rerr = s.store.ResolveItem(workspaceID, val)
+		if rerr != nil || resolved == nil {
 			return fmt.Errorf("parent %q not found", val)
 		}
 		params.ParentLinkID = resolved.ID
 	} else {
 		params.ParentLinkID = val
+		resolved, _ = s.store.GetItem(val)
 	}
+
+	// Ensure the parent is visible — return the same not-found error for
+	// hidden parents so restricted users can't probe hidden item existence.
+	if resolved != nil {
+		visIDs, verr := s.visibleCollectionIDs(r, workspaceID)
+		if verr != nil {
+			return verr
+		}
+		if !isCollectionVisible(resolved.CollectionID, visIDs) {
+			return fmt.Errorf("parent %q not found", val)
+		}
+	}
+
 	return nil
 }
 

--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -820,7 +820,21 @@ func (s *Server) handleGetItemChildren(w http.ResponseWriter, r *http.Request) {
 	}
 
 	s.enrichItemsWithParent(workspaceID, children, visibleIDs)
-	s.store.PopulateHasChildren(children)
+	if visibleIDs != nil {
+		// Visibility-aware has_children: only count visible grandchildren
+		for i := range children {
+			grandchildren, _ := s.store.GetChildItems(children[i].ID)
+			children[i].HasChildren = false
+			for _, gc := range grandchildren {
+				if isCollectionVisible(gc.CollectionID, visibleIDs) {
+					children[i].HasChildren = true
+					break
+				}
+			}
+		}
+	} else {
+		s.store.PopulateHasChildren(children)
+	}
 	writeJSON(w, http.StatusOK, children)
 }
 

--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -29,6 +29,15 @@ func (s *Server) handleListItems(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "bad_request", err.Error())
 		return
 	}
+
+	// Apply collection visibility filter
+	visibleIDs, err := s.visibleCollectionIDs(r, workspaceID)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	params.CollectionIDs = visibleIDs
+
 	result, err := s.store.ListItems(workspaceID, params)
 	if err != nil {
 		writeInternalError(w, err)
@@ -56,6 +65,17 @@ func (s *Server) handleListCollectionItems(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	if coll == nil {
+		writeError(w, http.StatusNotFound, "not_found", "Collection not found")
+		return
+	}
+
+	// Gate check: is this collection visible to the user?
+	visibleIDs, err := s.visibleCollectionIDs(r, workspaceID)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	if !isCollectionVisible(coll.ID, visibleIDs) {
 		writeError(w, http.StatusNotFound, "not_found", "Collection not found")
 		return
 	}

--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -186,9 +186,15 @@ func (s *Server) handleCreateItem(w http.ResponseWriter, r *http.Request) {
 					parentValue = pvStr
 					resolvedParent, _ = s.store.GetItem(pvStr)
 				}
-				// Ensure parent item is in a visible collection
-				if resolvedParent != nil && !s.requireItemVisible(w, r, workspaceID, resolvedParent) {
-					return
+				// Ensure parent item belongs to this workspace and is visible
+				if resolvedParent != nil {
+					if resolvedParent.WorkspaceID != workspaceID {
+						writeError(w, http.StatusBadRequest, "bad_request", fmt.Sprintf("parent %q not found", pvStr))
+						return
+					}
+					if !s.requireItemVisible(w, r, workspaceID, resolvedParent) {
+						return
+					}
 				}
 			}
 			delete(fieldMap, key)
@@ -232,7 +238,8 @@ func (s *Server) handleCreateItem(w http.ResponseWriter, r *http.Request) {
 	s.publishItemEventWithName(events.ItemCreated, workspaceID, item.ID, item.Title, collSlug, actor, actorNameFromRequest(r), source)
 	s.dispatchWebhook(workspaceID, "item.created", item)
 
-	if err := s.enrichItemForResponse(item); err != nil {
+	createVisIDs, _ := s.visibleCollectionIDs(r, workspaceID)
+	if err := s.enrichItemForResponse(item, createVisIDs); err != nil {
 		writeInternalError(w, err)
 		return
 	}
@@ -261,7 +268,8 @@ func (s *Server) handleGetItem(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := s.enrichItemForResponse(item); err != nil {
+	enrichVisIDs, _ := s.visibleCollectionIDs(r, workspaceID)
+	if err := s.enrichItemForResponse(item, enrichVisIDs); err != nil {
 		writeInternalError(w, err)
 		return
 	}
@@ -344,9 +352,15 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 							parentValue = pvStr
 							resolvedParent, _ = s.store.GetItem(pvStr)
 						}
-						// Ensure parent item is in a visible collection
-						if resolvedParent != nil && !s.requireItemVisible(w, r, workspaceID, resolvedParent) {
-							return
+						// Ensure parent item belongs to this workspace and is visible
+						if resolvedParent != nil {
+							if resolvedParent.WorkspaceID != workspaceID {
+								writeError(w, http.StatusBadRequest, "bad_request", fmt.Sprintf("parent %q not found", pvStr))
+								return
+							}
+							if !s.requireItemVisible(w, r, workspaceID, resolvedParent) {
+								return
+							}
 						}
 					}
 				}
@@ -449,7 +463,8 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if err := s.enrichItemForResponse(updated); err != nil {
+	updateVisIDs, _ := s.visibleCollectionIDs(r, workspaceID)
+	if err := s.enrichItemForResponse(updated, updateVisIDs); err != nil {
 		writeInternalError(w, err)
 		return
 	}
@@ -534,7 +549,8 @@ func (s *Server) handleRestoreItem(w http.ResponseWriter, r *http.Request) {
 	s.logActivity(workspaceID, restored.ID, "restored", r)
 	s.publishItemEventWithName(events.ItemRestored, workspaceID, restored.ID, restored.Title, restored.CollectionSlug, actor, actorNameFromRequest(r), source)
 
-	if err := s.enrichItemForResponse(restored); err != nil {
+	restoreVisIDs, _ := s.visibleCollectionIDs(r, workspaceID)
+	if err := s.enrichItemForResponse(restored, restoreVisIDs); err != nil {
 		writeInternalError(w, err)
 		return
 	}
@@ -659,7 +675,8 @@ func (s *Server) handleMoveItem(w http.ResponseWriter, r *http.Request) {
 	s.publishItemEventWithName(events.ItemUpdated, workspaceID, moved.ID, moved.Title, targetColl.Slug, actor, actorNameFromRequest(r), source)
 	s.dispatchWebhook(workspaceID, "item.moved", moved)
 
-	if err := s.enrichItemForResponse(moved); err != nil {
+	moveVisIDs, _ := s.visibleCollectionIDs(r, workspaceID)
+	if err := s.enrichItemForResponse(moved, moveVisIDs); err != nil {
 		writeInternalError(w, err)
 		return
 	}

--- a/internal/server/handlers_members.go
+++ b/internal/server/handlers_members.go
@@ -295,3 +295,82 @@ func (s *Server) handleAcceptInvitation(w http.ResponseWriter, r *http.Request) 
 		"role":         inv.Role,
 	})
 }
+
+// handleGetMemberCollectionAccess returns a member's collection access mode and granted IDs.
+func (s *Server) handleGetMemberCollectionAccess(w http.ResponseWriter, r *http.Request) {
+	workspaceID, ok := s.getWorkspaceID(w, r)
+	if !ok {
+		return
+	}
+
+	userID := chi.URLParam(r, "userID")
+	member, err := s.store.GetWorkspaceMember(workspaceID, userID)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	if member == nil {
+		writeError(w, http.StatusNotFound, "not_found", "Member not found")
+		return
+	}
+
+	grants, err := s.store.GetMemberCollectionAccess(workspaceID, userID)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"collection_access": member.CollectionAccess,
+		"collection_ids":    grants,
+	})
+}
+
+// handleSetMemberCollectionAccess updates a member's collection visibility.
+// Only workspace owners can change other members' access.
+func (s *Server) handleSetMemberCollectionAccess(w http.ResponseWriter, r *http.Request) {
+	workspaceID, ok := s.getWorkspaceID(w, r)
+	if !ok {
+		return
+	}
+
+	if !requireRole(r, "owner") {
+		writeError(w, http.StatusForbidden, "forbidden", "Only workspace owners can manage collection access")
+		return
+	}
+
+	userID := chi.URLParam(r, "userID")
+	member, err := s.store.GetWorkspaceMember(workspaceID, userID)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	if member == nil {
+		writeError(w, http.StatusNotFound, "not_found", "Member not found")
+		return
+	}
+
+	var input struct {
+		Mode          string   `json:"mode"`           // "all" or "specific"
+		CollectionIDs []string `json:"collection_ids"` // only for "specific"
+	}
+	if err := decodeJSON(r, &input); err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", err.Error())
+		return
+	}
+
+	if input.Mode != "all" && input.Mode != "specific" {
+		writeError(w, http.StatusBadRequest, "validation_error", "Mode must be 'all' or 'specific'")
+		return
+	}
+
+	if err := s.store.SetMemberCollectionAccess(workspaceID, userID, input.Mode, input.CollectionIDs); err != nil {
+		writeInternalError(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"collection_access": input.Mode,
+		"collection_ids":    input.CollectionIDs,
+	})
+}

--- a/internal/server/handlers_members.go
+++ b/internal/server/handlers_members.go
@@ -303,7 +303,12 @@ func (s *Server) handleGetMemberCollectionAccess(w http.ResponseWriter, r *http.
 		return
 	}
 
+	// Only workspace owners or the user themselves can view collection access
 	userID := chi.URLParam(r, "userID")
+	if !requireRole(r, "owner") && currentUserID(r) != userID {
+		writeError(w, http.StatusForbidden, "forbidden", "Only workspace owners can view other members' collection access")
+		return
+	}
 	member, err := s.store.GetWorkspaceMember(workspaceID, userID)
 	if err != nil {
 		writeInternalError(w, err)

--- a/internal/server/handlers_role_board.go
+++ b/internal/server/handlers_role_board.go
@@ -22,6 +22,22 @@ func (s *Server) handleRoleBoardReorder(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	// Verify all items being reordered are in visible collections
+	visibleIDs, visErr := s.visibleCollectionIDs(r, workspaceID)
+	if visErr != nil {
+		writeInternalError(w, visErr)
+		return
+	}
+	if visibleIDs != nil {
+		for _, u := range updates {
+			item, err := s.store.GetItem(u.ItemID)
+			if err != nil || item == nil || !isCollectionVisible(item.CollectionID, visibleIDs) {
+				writeError(w, http.StatusForbidden, "forbidden", "Cannot reorder items in hidden collections")
+				return
+			}
+		}
+	}
+
 	if err := s.store.UpdateRoleSortOrder(workspaceID, updates); err != nil {
 		writeInternalError(w, err)
 		return
@@ -62,8 +78,15 @@ func (s *Server) handleRoleBoard(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	visibleIDs, visErr := s.visibleCollectionIDs(r, workspaceID)
+	if visErr != nil {
+		writeInternalError(w, visErr)
+		return
+	}
+
 	params := store.RoleBoardParams{
 		AssignedUserID: r.URL.Query().Get("assigned_user_id"),
+		CollectionIDs:  visibleIDs,
 	}
 
 	lanes, err := s.store.GetRoleBoardItems(workspaceID, params)

--- a/internal/server/handlers_search.go
+++ b/internal/server/handlers_search.go
@@ -41,7 +41,7 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 			}
 			// Apply per-workspace collection visibility filtering.
 			// Collect all visible collection IDs across user's workspaces.
-			var allVisibleCollIDs []string
+			allVisibleCollIDs := []string{} // non-nil empty = "no access" by default
 			needsCollFilter := false
 			for _, ws := range workspaces {
 				visIDs, err := s.store.VisibleCollectionIDs(ws.ID, user.ID)

--- a/internal/server/handlers_search.go
+++ b/internal/server/handlers_search.go
@@ -39,6 +39,32 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 				})
 				return
 			}
+			// Apply per-workspace collection visibility filtering.
+			// Collect all visible collection IDs across user's workspaces.
+			var allVisibleCollIDs []string
+			needsCollFilter := false
+			for _, ws := range workspaces {
+				visIDs, err := s.store.VisibleCollectionIDs(ws.ID, user.ID)
+				if err != nil {
+					// Fail closed: skip this workspace entirely on error
+					// rather than searching it without a collection filter.
+					params.WorkspaceIDs = removeString(params.WorkspaceIDs, ws.ID)
+					continue
+				}
+				if visIDs != nil {
+					needsCollFilter = true
+					allVisibleCollIDs = append(allVisibleCollIDs, visIDs...)
+				} else {
+					// "all" access — include all collections from this workspace
+					colls, _ := s.store.ListCollections(ws.ID)
+					for _, c := range colls {
+						allVisibleCollIDs = append(allVisibleCollIDs, c.ID)
+					}
+				}
+			}
+			if needsCollFilter {
+				params.CollectionIDs = allVisibleCollIDs
+			}
 		}
 		// If no user (fresh install, no auth), allow unscoped search
 	}
@@ -48,9 +74,11 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 		ws, _ := s.store.GetWorkspaceBySlug(params.Workspace)
 		if ws != nil {
 			visibleIDs, visErr := s.visibleCollectionIDs(r, ws.ID)
-			if visErr == nil {
-				params.CollectionIDs = visibleIDs
+			if visErr != nil {
+				writeInternalError(w, visErr)
+				return
 			}
+			params.CollectionIDs = visibleIDs
 		}
 	}
 
@@ -67,4 +95,14 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 		"results": results,
 		"total":   len(results),
 	})
+}
+
+func removeString(ss []string, s string) []string {
+	result := ss[:0]
+	for _, v := range ss {
+		if v != s {
+			result = append(result, v)
+		}
+	}
+	return result
 }

--- a/internal/server/handlers_search.go
+++ b/internal/server/handlers_search.go
@@ -43,6 +43,17 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 		// If no user (fresh install, no auth), allow unscoped search
 	}
 
+	// Apply collection visibility filter when searching a specific workspace
+	if params.Workspace != "" {
+		ws, _ := s.store.GetWorkspaceBySlug(params.Workspace)
+		if ws != nil {
+			visibleIDs, visErr := s.visibleCollectionIDs(r, ws.ID)
+			if visErr == nil {
+				params.CollectionIDs = visibleIDs
+			}
+		}
+	}
+
 	results, err := s.store.Search(params)
 	if err != nil {
 		writeInternalError(w, err)

--- a/internal/server/handlers_timeline.go
+++ b/internal/server/handlers_timeline.go
@@ -26,6 +26,9 @@ func (s *Server) handleListItemTimeline(w http.ResponseWriter, r *http.Request) 
 		writeError(w, http.StatusNotFound, "not_found", "Item not found")
 		return
 	}
+	if !s.requireItemVisible(w, r, workspaceID, item) {
+		return
+	}
 
 	limit := 50
 	if v := r.URL.Query().Get("limit"); v != "" {

--- a/internal/server/handlers_views.go
+++ b/internal/server/handlers_views.go
@@ -27,6 +27,17 @@ func (s *Server) handleListViews(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Check collection visibility
+	visibleIDs, visErr := s.visibleCollectionIDs(r, workspaceID)
+	if visErr != nil {
+		writeInternalError(w, visErr)
+		return
+	}
+	if !isCollectionVisible(coll.ID, visibleIDs) {
+		writeError(w, http.StatusNotFound, "not_found", "Collection not found")
+		return
+	}
+
 	views, err := s.store.ListViews(workspaceID, coll.ID)
 	if err != nil {
 		writeInternalError(w, err)
@@ -60,6 +71,17 @@ func (s *Server) handleCreateView(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Check collection visibility
+	visibleIDs, visErr := s.visibleCollectionIDs(r, workspaceID)
+	if visErr != nil {
+		writeInternalError(w, visErr)
+		return
+	}
+	if !isCollectionVisible(coll.ID, visibleIDs) {
+		writeError(w, http.StatusNotFound, "not_found", "Collection not found")
+		return
+	}
+
 	var input models.ViewCreate
 	if err := decodeJSON(r, &input); err != nil {
 		writeError(w, http.StatusBadRequest, "bad_request", err.Error())
@@ -82,17 +104,43 @@ func (s *Server) handleCreateView(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusCreated, view)
 }
 
+// requireViewVisible looks up a view by ID, verifies it belongs to the
+// workspace, and checks that its collection is visible. Returns the view
+// or writes an error and returns nil.
+func (s *Server) requireViewVisible(w http.ResponseWriter, r *http.Request, workspaceID, viewID string) *models.View {
+	view, err := s.store.GetView(viewID)
+	if err != nil || view == nil || view.WorkspaceID != workspaceID {
+		writeError(w, http.StatusNotFound, "not_found", "View not found")
+		return nil
+	}
+	if view.CollectionID != nil {
+		visibleIDs, visErr := s.visibleCollectionIDs(r, workspaceID)
+		if visErr != nil {
+			writeInternalError(w, visErr)
+			return nil
+		}
+		if !isCollectionVisible(*view.CollectionID, visibleIDs) {
+			writeError(w, http.StatusNotFound, "not_found", "View not found")
+			return nil
+		}
+	}
+	return view
+}
+
 // handleUpdateView modifies an existing saved view.
 func (s *Server) handleUpdateView(w http.ResponseWriter, r *http.Request) {
 	if !requireMinRole(w, r, "editor") {
 		return
 	}
-	_, ok := s.getWorkspaceID(w, r)
+	workspaceID, ok := s.getWorkspaceID(w, r)
 	if !ok {
 		return
 	}
 
 	viewID := chi.URLParam(r, "viewID")
+	if s.requireViewVisible(w, r, workspaceID, viewID) == nil {
+		return
+	}
 
 	var input models.ViewUpdate
 	if err := decodeJSON(r, &input); err != nil {
@@ -118,12 +166,15 @@ func (s *Server) handleDeleteView(w http.ResponseWriter, r *http.Request) {
 	if !requireMinRole(w, r, "editor") {
 		return
 	}
-	_, ok := s.getWorkspaceID(w, r)
+	workspaceID, ok := s.getWorkspaceID(w, r)
 	if !ok {
 		return
 	}
 
 	viewID := chi.URLParam(r, "viewID")
+	if s.requireViewVisible(w, r, workspaceID, viewID) == nil {
+		return
+	}
 
 	if err := s.store.DeleteView(viewID); err != nil {
 		if err == sql.ErrNoRows {

--- a/internal/server/item_lineage.go
+++ b/internal/server/item_lineage.go
@@ -9,10 +9,19 @@ import (
 
 // enrichItemsWithParent batch-populates parent link info on a slice of items.
 // Used by list endpoints where calling enrichItemForResponse per-item is too expensive.
-func (s *Server) enrichItemsWithParent(workspaceID string, items []models.Item) {
+// visibleIDs controls which parent collections are allowed; nil means all visible.
+func (s *Server) enrichItemsWithParent(workspaceID string, items []models.Item, visibleIDs ...[]string) {
 	if len(items) == 0 {
 		return
 	}
+	// Extract the optional visibility filter
+	var vis []string
+	hasVis := false
+	if len(visibleIDs) > 0 && visibleIDs[0] != nil {
+		vis = visibleIDs[0]
+		hasVis = true
+	}
+
 	parentMap, err := s.store.GetParentMap(workspaceID)
 	if err != nil || len(parentMap) == 0 {
 		return
@@ -31,6 +40,10 @@ func (s *Server) enrichItemsWithParent(workspaceID string, items []models.Item) 
 	for pid := range parentIDs {
 		item, err := s.store.GetItem(pid)
 		if err != nil || item == nil {
+			continue
+		}
+		// Skip parents from hidden collections
+		if hasVis && !isCollectionVisible(item.CollectionID, vis) {
 			continue
 		}
 		ref := ""

--- a/internal/server/item_lineage.go
+++ b/internal/server/item_lineage.go
@@ -52,14 +52,15 @@ func (s *Server) enrichItemsWithParent(workspaceID string, items []models.Item, 
 		}
 		parents[pid] = parentInfo{title: item.Title, ref: ref}
 	}
-	// Populate items
+	// Populate items — only set parent fields when the parent passed
+	// the visibility filter (i.e. is in the parents map)
 	for i := range items {
 		pid, ok := parentMap[items[i].ID]
 		if !ok {
 			continue
 		}
-		items[i].ParentLinkID = pid
 		if info, ok := parents[pid]; ok {
+			items[i].ParentLinkID = pid
 			items[i].ParentTitle = info.title
 			items[i].ParentRef = info.ref
 		}

--- a/internal/server/item_lineage.go
+++ b/internal/server/item_lineage.go
@@ -66,31 +66,52 @@ func (s *Server) enrichItemsWithParent(workspaceID string, items []models.Item, 
 	}
 }
 
-func (s *Server) enrichItemForResponse(item *models.Item) error {
+// enrichItemForResponse populates derived closure and parent info on a single item.
+// An optional visibleIDs slice filters related items so hidden-collection metadata
+// is not leaked. Pass nil (or omit) for full access.
+func (s *Server) enrichItemForResponse(item *models.Item, visibleIDs ...[]string) error {
 	if item == nil {
 		return nil
 	}
-	closure, err := s.deriveItemClosure(item)
+
+	var vis []string
+	hasVis := len(visibleIDs) > 0 && visibleIDs[0] != nil
+	if hasVis {
+		vis = visibleIDs[0]
+	}
+
+	closure, err := s.deriveItemClosure(item, vis)
 	if err != nil {
 		return err
 	}
 	item.DerivedClosure = closure
 
-	// Populate parent link info
+	// Populate parent link info — skip if parent is in a hidden collection
 	parentLink, err := s.store.GetParentForItem(item.ID)
 	if err != nil {
 		return err
 	}
 	if parentLink != nil {
-		item.ParentLinkID = parentLink.TargetID
-		item.ParentRef = parentLink.TargetRef
-		item.ParentTitle = parentLink.TargetTitle
+		parentVisible := true
+		if hasVis {
+			if parent, perr := s.store.GetItem(parentLink.TargetID); perr == nil && parent != nil {
+				parentVisible = isCollectionVisible(parent.CollectionID, vis)
+			}
+		}
+		if parentVisible {
+			item.ParentLinkID = parentLink.TargetID
+			item.ParentRef = parentLink.TargetRef
+			item.ParentTitle = parentLink.TargetTitle
+		}
 	}
 
 	return nil
 }
 
-func (s *Server) deriveItemClosure(item *models.Item) (*models.ItemDerivedClosure, error) {
+// deriveItemClosure computes derived closure (superseded, implemented, split)
+// from item links. When vis is non-nil, links to items in hidden collections
+// are excluded.
+func (s *Server) deriveItemClosure(item *models.Item, vis []string) (*models.ItemDerivedClosure, error) {
 	links, err := s.store.GetItemLinks(item.ID)
 	if err != nil {
 		return nil, err
@@ -102,6 +123,19 @@ func (s *Server) deriveItemClosure(item *models.Item) (*models.ItemDerivedClosur
 	allSplitChildrenDone := true
 
 	for _, link := range links {
+		// If visibility is restricted, check that the "other side" is visible
+		if vis != nil {
+			otherID := link.SourceID
+			if otherID == item.ID {
+				otherID = link.TargetID
+			}
+			if other, oerr := s.store.GetItem(otherID); oerr == nil && other != nil {
+				if !isCollectionVisible(other.CollectionID, vis) {
+					continue
+				}
+			}
+		}
+
 		linkType, err := models.NormalizeItemLinkType(link.LinkType)
 		if err != nil {
 			continue

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -621,6 +621,32 @@ func (s *Server) getWorkspace(w http.ResponseWriter, r *http.Request) (*models.W
 	return ws, true
 }
 
+// visibleCollectionIDs returns the set of collection IDs the current user can
+// see in the given workspace. Returns nil if the user has "all" access (no
+// filtering needed), or a non-nil slice for "specific" access. Admins and
+// unauthenticated users (fresh install) always get nil (all access).
+func (s *Server) visibleCollectionIDs(r *http.Request, workspaceID string) ([]string, error) {
+	user := currentUser(r)
+	if user == nil || user.Role == "admin" {
+		return nil, nil // No filtering for admins or unauthenticated
+	}
+	return s.store.VisibleCollectionIDs(workspaceID, user.ID)
+}
+
+// isCollectionVisible checks if a collection ID is in the visible set.
+// If visibleIDs is nil, all collections are visible.
+func isCollectionVisible(collectionID string, visibleIDs []string) bool {
+	if visibleIDs == nil {
+		return true
+	}
+	for _, id := range visibleIDs {
+		if id == collectionID {
+			return true
+		}
+	}
+	return false
+}
+
 // resolveWorkspace resolves a workspace by slug or UUID, scoped to the
 // authenticated user's accessible workspaces when a user context is present.
 // Returns nil (not an error) if no workspace is found.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -635,6 +635,22 @@ func (s *Server) visibleCollectionIDs(r *http.Request, workspaceID string) ([]st
 	return s.store.VisibleCollectionIDs(workspaceID, user.ID)
 }
 
+// requireItemVisible checks that the item's collection is visible to the
+// requesting user. Writes a 404 and returns false if not. Callers should
+// invoke this immediately after resolving an item by slug/ID.
+func (s *Server) requireItemVisible(w http.ResponseWriter, r *http.Request, workspaceID string, item *models.Item) bool {
+	visibleIDs, err := s.visibleCollectionIDs(r, workspaceID)
+	if err != nil {
+		writeInternalError(w, err)
+		return false
+	}
+	if !isCollectionVisible(item.CollectionID, visibleIDs) {
+		writeError(w, http.StatusNotFound, "not_found", "Item not found")
+		return false
+	}
+	return true
+}
+
 // isCollectionVisible checks if a collection ID is in the visible set.
 // If visibleIDs is nil, all collections are visible.
 func isCollectionVisible(collectionID string, visibleIDs []string) bool {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -413,6 +413,8 @@ func (s *Server) setupRouter() {
 					r.Delete("/invitations/{invID}", s.handleCancelInvitation)
 					r.Delete("/{userID}", s.handleRemoveMember)
 					r.Patch("/{userID}", s.handleUpdateMemberRole)
+					r.Get("/{userID}/collection-access", s.handleGetMemberCollectionAccess)
+					r.Put("/{userID}/collection-access", s.handleSetMemberCollectionAccess)
 				})
 
 				// Dashboard (v2)

--- a/internal/store/agent_roles.go
+++ b/internal/store/agent_roles.go
@@ -272,6 +272,7 @@ type RoleBoardLane struct {
 // RoleBoardParams configures the role board query.
 type RoleBoardParams struct {
 	AssignedUserID string
+	CollectionIDs  []string // permission filter: restrict to these collection IDs (nil = no filter)
 }
 
 // GetRoleBoardItems returns non-terminal items across all collections, grouped by role.
@@ -285,6 +286,7 @@ func (s *Store) GetRoleBoardItems(workspaceID string, params RoleBoardParams) ([
 	// Fetch all non-archived items
 	listParams := models.ItemListParams{
 		IncludeArchived: false,
+		CollectionIDs:   params.CollectionIDs,
 	}
 	if params.AssignedUserID != "" {
 		listParams.AssignedUserID = params.AssignedUserID

--- a/internal/store/collections.go
+++ b/internal/store/collections.go
@@ -46,9 +46,9 @@ func (s *Store) CreateCollection(workspaceID string, input models.CollectionCrea
 	}
 
 	_, err = s.db.Exec(s.q(`
-		INSERT INTO collections (id, workspace_id, name, slug, prefix, icon, description, schema, settings, sort_order, is_default, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-	`), id, workspaceID, input.Name, slug, prefix, icon, description, schema, settings, 0, s.dialect.BoolToInt(input.IsDefault), ts, ts)
+		INSERT INTO collections (id, workspace_id, name, slug, prefix, icon, description, schema, settings, sort_order, is_default, is_system, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`), id, workspaceID, input.Name, slug, prefix, icon, description, schema, settings, 0, s.dialect.BoolToInt(input.IsDefault), s.dialect.BoolToInt(input.IsSystem), ts, ts)
 	if err != nil {
 		return nil, fmt.Errorf("insert collection: %w", err)
 	}
@@ -63,12 +63,12 @@ func (s *Store) GetCollection(id string) (*models.Collection, error) {
 	var isDefault bool
 
 	err := s.db.QueryRow(s.q(`
-		SELECT id, workspace_id, name, slug, prefix, icon, description, schema, settings, sort_order, is_default, created_at, updated_at, deleted_at
+		SELECT id, workspace_id, name, slug, prefix, icon, description, schema, settings, sort_order, is_default, is_system, created_at, updated_at, deleted_at
 		FROM collections
 		WHERE id = ? AND deleted_at IS NULL
 	`), id).Scan(
 		&c.ID, &c.WorkspaceID, &c.Name, &c.Slug, &c.Prefix, &c.Icon, &c.Description,
-		&c.Schema, &c.Settings, &c.SortOrder, &isDefault,
+		&c.Schema, &c.Settings, &c.SortOrder, &isDefault, &c.IsSystem,
 		&createdAt, &updatedAt, &deletedAt,
 	)
 	if err == sql.ErrNoRows {
@@ -106,7 +106,7 @@ func (s *Store) ListCollections(workspaceID string) ([]models.Collection, error)
 	jsonExtractStatus := s.dialect.JSONExtractText("i.fields", "status")
 	rows, err := s.db.Query(s.q(fmt.Sprintf(`
 		SELECT c.id, c.workspace_id, c.name, c.slug, c.prefix, c.icon, c.description,
-		       c.schema, c.settings, c.sort_order, c.is_default, c.created_at, c.updated_at,
+		       c.schema, c.settings, c.sort_order, c.is_default, c.is_system, c.created_at, c.updated_at,
 		       COUNT(i.id) as item_count,
 		       COUNT(CASE WHEN LOWER(COALESCE(%s, '')) NOT IN
 		           (%s)
@@ -129,7 +129,7 @@ func (s *Store) ListCollections(workspaceID string) ([]models.Collection, error)
 		var isDefault bool
 		if err := rows.Scan(
 			&c.ID, &c.WorkspaceID, &c.Name, &c.Slug, &c.Prefix, &c.Icon, &c.Description,
-			&c.Schema, &c.Settings, &c.SortOrder, &isDefault,
+			&c.Schema, &c.Settings, &c.SortOrder, &isDefault, &c.IsSystem,
 			&createdAt, &updatedAt, &c.ItemCount, &c.ActiveItemCount,
 		); err != nil {
 			return nil, err
@@ -320,6 +320,7 @@ func (s *Store) SeedCollectionsFromTemplate(workspaceID string, templateName str
 			Schema:      string(schemaJSON),
 			Settings:    string(settingsJSON),
 			IsDefault:   true,
+			IsSystem:    def.IsSystem,
 		})
 		if err != nil {
 			return fmt.Errorf("create default collection %s: %w", def.Slug, err)

--- a/internal/store/export.go
+++ b/internal/store/export.go
@@ -31,7 +31,7 @@ func (s *Store) ExportWorkspace(slug string) (*models.WorkspaceExport, error) {
 
 	// Collections
 	rows, err := s.db.Query(s.q(`
-		SELECT id, name, slug, icon, description, schema, settings, prefix, sort_order, is_default, created_at, updated_at
+		SELECT id, name, slug, icon, description, schema, settings, prefix, sort_order, is_default, is_system, created_at, updated_at
 		FROM collections WHERE workspace_id = ? AND deleted_at IS NULL
 		ORDER BY sort_order, name`), ws.ID)
 	if err != nil {
@@ -40,11 +40,12 @@ func (s *Store) ExportWorkspace(slug string) (*models.WorkspaceExport, error) {
 	defer rows.Close()
 	for rows.Next() {
 		var c models.CollectionExport
-		var isDefault bool
-		if err := rows.Scan(&c.ID, &c.Name, &c.Slug, &c.Icon, &c.Description, &c.Schema, &c.Settings, &c.Prefix, &c.SortOrder, &isDefault, &c.CreatedAt, &c.UpdatedAt); err != nil {
+		var isDefault, isSystem bool
+		if err := rows.Scan(&c.ID, &c.Name, &c.Slug, &c.Icon, &c.Description, &c.Schema, &c.Settings, &c.Prefix, &c.SortOrder, &isDefault, &isSystem, &c.CreatedAt, &c.UpdatedAt); err != nil {
 			return nil, fmt.Errorf("scan collection: %w", err)
 		}
 		c.IsDefault = isDefault
+		c.IsSystem = isSystem
 		export.Collections = append(export.Collections, c)
 	}
 	if err := rows.Err(); err != nil {
@@ -187,9 +188,9 @@ func (s *Store) ImportWorkspace(data *models.WorkspaceExport, newName string, ow
 		collMap[c.ID] = newCollID
 
 		_, err := tx.Exec(s.q(`
-			INSERT INTO collections (id, workspace_id, name, slug, icon, description, schema, settings, prefix, sort_order, is_default, created_at, updated_at)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`),
-			newCollID, ws.ID, c.Name, c.Slug, c.Icon, c.Description, c.Schema, c.Settings, c.Prefix, c.SortOrder, s.dialect.BoolToInt(c.IsDefault),
+			INSERT INTO collections (id, workspace_id, name, slug, icon, description, schema, settings, prefix, sort_order, is_default, is_system, created_at, updated_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`),
+			newCollID, ws.ID, c.Name, c.Slug, c.Icon, c.Description, c.Schema, c.Settings, c.Prefix, c.SortOrder, s.dialect.BoolToInt(c.IsDefault), s.dialect.BoolToInt(c.IsSystem),
 			c.CreatedAt, c.UpdatedAt)
 		if err != nil {
 			return nil, fmt.Errorf("import collection %s: %w", c.Name, err)

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -458,6 +458,15 @@ func (s *Store) ListItems(workspaceID string, params models.ItemListParams) ([]m
 		args = append(args, params.CollectionSlug)
 	}
 
+	if len(params.CollectionIDs) > 0 {
+		placeholders := make([]string, len(params.CollectionIDs))
+		for i, id := range params.CollectionIDs {
+			placeholders[i] = "?"
+			args = append(args, id)
+		}
+		query += " AND i.collection_id IN (" + strings.Join(placeholders, ",") + ")"
+	}
+
 	if params.Tag != "" {
 		tagExpr, tagArg := s.dialect.JSONArrayContains("i.tags", params.Tag)
 		query += " AND " + tagExpr
@@ -582,6 +591,15 @@ func (s *Store) listItemsFTS(workspaceID string, params models.ItemListParams) (
 	if params.CollectionSlug != "" {
 		query += " AND c.slug = ?"
 		args = append(args, params.CollectionSlug)
+	}
+
+	if len(params.CollectionIDs) > 0 {
+		placeholders := make([]string, len(params.CollectionIDs))
+		for i, id := range params.CollectionIDs {
+			placeholders[i] = "?"
+			args = append(args, id)
+		}
+		query += " AND i.collection_id IN (" + strings.Join(placeholders, ",") + ")"
 	}
 
 	// SQLite bm25(): more negative = more relevant → ASC (default).

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -428,6 +428,12 @@ func (s *Store) GetItemBySlugIncludeDeleted(workspaceID, slug string) (*models.I
 }
 
 func (s *Store) ListItems(workspaceID string, params models.ItemListParams) ([]models.Item, error) {
+	// Non-nil empty CollectionIDs means "no visible collections" — return
+	// empty results immediately rather than skipping the filter clause.
+	if params.CollectionIDs != nil && len(params.CollectionIDs) == 0 {
+		return nil, nil
+	}
+
 	// When search is specified, use FTS
 	if params.Search != "" {
 		return s.listItemsFTS(workspaceID, params)
@@ -1717,6 +1723,44 @@ func (s *Store) ItemsModifiedSince(workspaceID string, since time.Time) (updated
 	}
 
 	return updated, deletedIDs, delRows.Err()
+}
+
+// ItemCollectionRef is a minimal item reference with collection ID, used for
+// filtering deleted items by collection visibility.
+type ItemCollectionRef struct {
+	ID           string
+	CollectionID string
+}
+
+// GetDeletedItemsWithCollection returns minimal item info (ID + CollectionID)
+// for soft-deleted items, used to filter deleted item IDs by collection visibility.
+func (s *Store) GetDeletedItemsWithCollection(workspaceID string, itemIDs []string) ([]ItemCollectionRef, error) {
+	if len(itemIDs) == 0 {
+		return nil, nil
+	}
+	placeholders := make([]string, len(itemIDs))
+	args := []interface{}{workspaceID}
+	for i, id := range itemIDs {
+		placeholders[i] = "?"
+		args = append(args, id)
+	}
+	rows, err := s.db.Query(s.q(fmt.Sprintf(`
+		SELECT id, collection_id FROM items
+		WHERE workspace_id = ? AND id IN (%s)
+	`, strings.Join(placeholders, ","))), args...)
+	if err != nil {
+		return nil, fmt.Errorf("get deleted items with collection: %w", err)
+	}
+	defer rows.Close()
+	var results []ItemCollectionRef
+	for rows.Next() {
+		var r ItemCollectionRef
+		if err := rows.Scan(&r.ID, &r.CollectionID); err != nil {
+			return nil, fmt.Errorf("scan deleted item: %w", err)
+		}
+		results = append(results, r)
+	}
+	return results, rows.Err()
 }
 
 func hydrateItemComputedMetadata(item *models.Item) {

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -1042,6 +1042,25 @@ func (s *Store) GetItemLinks(itemID string) ([]models.ItemLink, error) {
 	return links, rows.Err()
 }
 
+// GetItemLinkByID returns a single item link by its ID, or nil if not found.
+func (s *Store) GetItemLinkByID(id string) (*models.ItemLink, error) {
+	var link models.ItemLink
+	var createdAt string
+	err := s.db.QueryRow(s.q(`
+		SELECT id, workspace_id, source_id, target_id, link_type, created_by, created_at
+		FROM item_links WHERE id = ?
+	`), id).Scan(&link.ID, &link.WorkspaceID, &link.SourceID, &link.TargetID,
+		&link.LinkType, &link.CreatedBy, &createdAt)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get item link by id: %w", err)
+	}
+	link.CreatedAt = parseTime(createdAt)
+	return &link, nil
+}
+
 func (s *Store) DeleteItemLink(id string) error {
 	result, err := s.db.Exec(s.q("DELETE FROM item_links WHERE id = ?"), id)
 	if err != nil {

--- a/internal/store/migrations/031_collection_access.sql
+++ b/internal/store/migrations/031_collection_access.sql
@@ -1,0 +1,22 @@
+-- Add per-member collection visibility.
+-- collection_access: 'all' (default) = see everything, 'specific' = see only granted collections.
+-- Decision D7: default is "all" — absence of restrictions means full access.
+
+ALTER TABLE workspace_members ADD COLUMN collection_access TEXT NOT NULL DEFAULT 'all';
+
+-- Join table for the "specific" case: which collections a member can see.
+CREATE TABLE IF NOT EXISTS member_collection_access (
+    workspace_id  TEXT NOT NULL,
+    user_id       TEXT NOT NULL,
+    collection_id TEXT NOT NULL REFERENCES collections(id) ON DELETE CASCADE,
+    created_at    TEXT NOT NULL,
+    PRIMARY KEY (workspace_id, user_id, collection_id),
+    FOREIGN KEY (workspace_id, user_id) REFERENCES workspace_members(workspace_id, user_id) ON DELETE CASCADE
+);
+
+-- Add is_system flag to collections for conventions/playbooks exemption.
+-- System collections are always visible to members regardless of collection_access.
+ALTER TABLE collections ADD COLUMN is_system INTEGER NOT NULL DEFAULT 0;
+
+-- Mark conventions and playbooks as system collections.
+UPDATE collections SET is_system = 1 WHERE slug IN ('conventions', 'playbooks');

--- a/internal/store/migrations/032_permission_indexes.sql
+++ b/internal/store/migrations/032_permission_indexes.sql
@@ -1,0 +1,10 @@
+-- Indexes for permission table query performance (TASK-486).
+
+-- member_collection_access: reverse lookup by collection (for cascade cleanup on collection delete)
+CREATE INDEX IF NOT EXISTS idx_mca_collection ON member_collection_access(collection_id);
+
+-- collections: fast lookup of system collections per workspace
+CREATE INDEX IF NOT EXISTS idx_collections_system ON collections(workspace_id, is_system) WHERE is_system = 1 AND deleted_at IS NULL;
+
+-- workspace_members: fast lookup by user across workspaces (for user deletion cascade)
+CREATE INDEX IF NOT EXISTS idx_wm_user ON workspace_members(user_id);

--- a/internal/store/permissions_test.go
+++ b/internal/store/permissions_test.go
@@ -1,0 +1,317 @@
+package store
+
+import (
+	"testing"
+
+	"github.com/xarmian/pad/internal/models"
+)
+
+// Phase 2 permission test suite (TASK-488).
+// Tests collection-level visibility, system collection exemptions,
+// and the VisibleCollectionIDs resolution logic.
+
+func setupPermissionTest(t *testing.T) (*Store, *models.Workspace, *models.User, *models.User) {
+	t.Helper()
+	s := testStore(t)
+
+	// Create owner and member users
+	owner := createTestUser(t, s, "owner@test.com", "Owner", "password123")
+	member := createTestUser(t, s, "member@test.com", "Member", "password123")
+
+	// Create workspace with owner
+	ws := createTestWorkspace(t, s, "Test Workspace")
+	if err := s.AddWorkspaceMember(ws.ID, owner.ID, "owner"); err != nil {
+		t.Fatalf("add owner: %v", err)
+	}
+	if err := s.AddWorkspaceMember(ws.ID, member.ID, "editor"); err != nil {
+		t.Fatalf("add member: %v", err)
+	}
+
+	// Create collections: tasks (regular), conventions (system), ideas (regular)
+	_, err := s.CreateCollection(ws.ID, models.CollectionCreate{
+		Name: "Tasks", Slug: "tasks", IsDefault: true,
+	})
+	if err != nil {
+		t.Fatalf("create tasks: %v", err)
+	}
+
+	_, err = s.CreateCollection(ws.ID, models.CollectionCreate{
+		Name: "Conventions", Slug: "conventions", IsDefault: true, IsSystem: true,
+	})
+	if err != nil {
+		t.Fatalf("create conventions: %v", err)
+	}
+
+	_, err = s.CreateCollection(ws.ID, models.CollectionCreate{
+		Name: "Ideas", Slug: "ideas", IsDefault: true,
+	})
+	if err != nil {
+		t.Fatalf("create ideas: %v", err)
+	}
+
+	return s, ws, owner, member
+}
+
+func TestVisibleCollectionIDs_AllAccess(t *testing.T) {
+	s, ws, _, member := setupPermissionTest(t)
+
+	// Default: member has "all" access
+	ids, err := s.VisibleCollectionIDs(ws.ID, member.ID)
+	if err != nil {
+		t.Fatalf("VisibleCollectionIDs: %v", err)
+	}
+	if ids != nil {
+		t.Errorf("expected nil (all access), got %v", ids)
+	}
+}
+
+func TestVisibleCollectionIDs_SpecificAccess(t *testing.T) {
+	s, ws, _, member := setupPermissionTest(t)
+
+	// Get collection IDs
+	colls, _ := s.ListCollections(ws.ID)
+	var tasksID, ideasID string
+	for _, c := range colls {
+		switch c.Slug {
+		case "tasks":
+			tasksID = c.ID
+		case "ideas":
+			ideasID = c.ID
+		}
+	}
+
+	// Set member to specific access with only "tasks"
+	err := s.SetMemberCollectionAccess(ws.ID, member.ID, "specific", []string{tasksID})
+	if err != nil {
+		t.Fatalf("SetMemberCollectionAccess: %v", err)
+	}
+
+	ids, err := s.VisibleCollectionIDs(ws.ID, member.ID)
+	if err != nil {
+		t.Fatalf("VisibleCollectionIDs: %v", err)
+	}
+	if ids == nil {
+		t.Fatal("expected non-nil IDs for specific access")
+	}
+
+	// Should include tasks (granted) and conventions (system), but NOT ideas
+	idSet := make(map[string]bool)
+	for _, id := range ids {
+		idSet[id] = true
+	}
+
+	if !idSet[tasksID] {
+		t.Error("expected tasks collection to be visible")
+	}
+	if idSet[ideasID] {
+		t.Error("expected ideas collection to NOT be visible")
+	}
+}
+
+func TestVisibleCollectionIDs_SystemCollectionsAlwaysVisible(t *testing.T) {
+	s, ws, _, member := setupPermissionTest(t)
+
+	colls, _ := s.ListCollections(ws.ID)
+	var tasksID, conventionsID string
+	for _, c := range colls {
+		switch c.Slug {
+		case "tasks":
+			tasksID = c.ID
+		case "conventions":
+			conventionsID = c.ID
+		}
+	}
+
+	// Set member to specific access with only "tasks"
+	_ = s.SetMemberCollectionAccess(ws.ID, member.ID, "specific", []string{tasksID})
+
+	ids, err := s.VisibleCollectionIDs(ws.ID, member.ID)
+	if err != nil {
+		t.Fatalf("VisibleCollectionIDs: %v", err)
+	}
+
+	idSet := make(map[string]bool)
+	for _, id := range ids {
+		idSet[id] = true
+	}
+
+	// Conventions is system → always visible even though not explicitly granted
+	if !idSet[conventionsID] {
+		t.Error("expected conventions (system) collection to always be visible")
+	}
+}
+
+func TestVisibleCollectionIDs_NonMember(t *testing.T) {
+	s, ws, _, _ := setupPermissionTest(t)
+
+	// Create a user who is NOT a member
+	outsider := createTestUser(t, s, "outsider@test.com", "Outsider", "password123")
+
+	ids, err := s.VisibleCollectionIDs(ws.ID, outsider.ID)
+	if err != nil {
+		t.Fatalf("VisibleCollectionIDs: %v", err)
+	}
+	// Non-member should get empty list (not nil!)
+	if ids == nil {
+		t.Error("expected empty list for non-member, got nil (all access)")
+	}
+	if len(ids) != 0 {
+		t.Errorf("expected 0 visible collections for non-member, got %d", len(ids))
+	}
+}
+
+func TestSetMemberCollectionAccess_ReplaceGrants(t *testing.T) {
+	s, ws, _, member := setupPermissionTest(t)
+
+	colls, _ := s.ListCollections(ws.ID)
+	var tasksID, ideasID string
+	for _, c := range colls {
+		switch c.Slug {
+		case "tasks":
+			tasksID = c.ID
+		case "ideas":
+			ideasID = c.ID
+		}
+	}
+
+	// Set to tasks only
+	_ = s.SetMemberCollectionAccess(ws.ID, member.ID, "specific", []string{tasksID})
+
+	grants, _ := s.GetMemberCollectionAccess(ws.ID, member.ID)
+	if len(grants) != 1 || grants[0] != tasksID {
+		t.Errorf("expected [tasks], got %v", grants)
+	}
+
+	// Replace with ideas only
+	_ = s.SetMemberCollectionAccess(ws.ID, member.ID, "specific", []string{ideasID})
+
+	grants, _ = s.GetMemberCollectionAccess(ws.ID, member.ID)
+	if len(grants) != 1 || grants[0] != ideasID {
+		t.Errorf("expected [ideas], got %v", grants)
+	}
+}
+
+func TestSetMemberCollectionAccess_BackToAll(t *testing.T) {
+	s, ws, _, member := setupPermissionTest(t)
+
+	colls, _ := s.ListCollections(ws.ID)
+	var tasksID string
+	for _, c := range colls {
+		if c.Slug == "tasks" {
+			tasksID = c.ID
+		}
+	}
+
+	// Set to specific
+	_ = s.SetMemberCollectionAccess(ws.ID, member.ID, "specific", []string{tasksID})
+
+	// Verify specific
+	m, _ := s.GetWorkspaceMember(ws.ID, member.ID)
+	if m.CollectionAccess != "specific" {
+		t.Errorf("expected 'specific', got %q", m.CollectionAccess)
+	}
+
+	// Set back to all
+	_ = s.SetMemberCollectionAccess(ws.ID, member.ID, "all", nil)
+
+	m, _ = s.GetWorkspaceMember(ws.ID, member.ID)
+	if m.CollectionAccess != "all" {
+		t.Errorf("expected 'all', got %q", m.CollectionAccess)
+	}
+
+	// Grants should be cleared
+	grants, _ := s.GetMemberCollectionAccess(ws.ID, member.ID)
+	if len(grants) != 0 {
+		t.Errorf("expected 0 grants after switching to 'all', got %d", len(grants))
+	}
+
+	// VisibleCollectionIDs should return nil (all access)
+	ids, _ := s.VisibleCollectionIDs(ws.ID, member.ID)
+	if ids != nil {
+		t.Error("expected nil (all access) after switching back to 'all'")
+	}
+}
+
+func TestListItems_FilteredByCollectionIDs(t *testing.T) {
+	s, ws, _, _ := setupPermissionTest(t)
+
+	colls, _ := s.ListCollections(ws.ID)
+	var tasksID, ideasID string
+	for _, c := range colls {
+		switch c.Slug {
+		case "tasks":
+			tasksID = c.ID
+		case "ideas":
+			ideasID = c.ID
+		}
+	}
+
+	// Create items in different collections
+	_, _ = s.CreateItem(ws.ID, tasksID, models.ItemCreate{Title: "Task 1"})
+	_, _ = s.CreateItem(ws.ID, tasksID, models.ItemCreate{Title: "Task 2"})
+	_, _ = s.CreateItem(ws.ID, ideasID, models.ItemCreate{Title: "Idea 1"})
+
+	// No filter: all items
+	all, _ := s.ListItems(ws.ID, models.ItemListParams{})
+	if len(all) != 3 {
+		t.Errorf("expected 3 items with no filter, got %d", len(all))
+	}
+
+	// Filter to tasks only
+	tasksOnly, _ := s.ListItems(ws.ID, models.ItemListParams{
+		CollectionIDs: []string{tasksID},
+	})
+	if len(tasksOnly) != 2 {
+		t.Errorf("expected 2 tasks, got %d", len(tasksOnly))
+	}
+
+	// Filter to ideas only
+	ideasOnly, _ := s.ListItems(ws.ID, models.ItemListParams{
+		CollectionIDs: []string{ideasID},
+	})
+	if len(ideasOnly) != 1 {
+		t.Errorf("expected 1 idea, got %d", len(ideasOnly))
+	}
+
+	// Filter to empty set
+	empty, _ := s.ListItems(ws.ID, models.ItemListParams{
+		CollectionIDs: []string{"nonexistent-id"},
+	})
+	if len(empty) != 0 {
+		t.Errorf("expected 0 items for nonexistent collection, got %d", len(empty))
+	}
+}
+
+func TestCollectionAccess_DefaultIsAll(t *testing.T) {
+	s, ws, _, member := setupPermissionTest(t)
+
+	m, err := s.GetWorkspaceMember(ws.ID, member.ID)
+	if err != nil {
+		t.Fatalf("GetWorkspaceMember: %v", err)
+	}
+	if m.CollectionAccess != "all" {
+		t.Errorf("D7: default collection_access should be 'all', got %q", m.CollectionAccess)
+	}
+}
+
+func TestIsSystemCollection(t *testing.T) {
+	s, ws, _, _ := setupPermissionTest(t)
+
+	colls, _ := s.ListCollections(ws.ID)
+	for _, c := range colls {
+		switch c.Slug {
+		case "conventions":
+			if !c.IsSystem {
+				t.Error("conventions should be a system collection")
+			}
+		case "tasks":
+			if c.IsSystem {
+				t.Error("tasks should NOT be a system collection")
+			}
+		case "ideas":
+			if c.IsSystem {
+				t.Error("ideas should NOT be a system collection")
+			}
+		}
+	}
+}

--- a/internal/store/pgmigrations/011_collection_access.sql
+++ b/internal/store/pgmigrations/011_collection_access.sql
@@ -1,0 +1,17 @@
+-- Add per-member collection visibility.
+ALTER TABLE workspace_members ADD COLUMN IF NOT EXISTS collection_access TEXT NOT NULL DEFAULT 'all';
+
+CREATE TABLE IF NOT EXISTS member_collection_access (
+    workspace_id  TEXT NOT NULL,
+    user_id       TEXT NOT NULL,
+    collection_id TEXT NOT NULL REFERENCES collections(id) ON DELETE CASCADE,
+    created_at    TEXT NOT NULL,
+    PRIMARY KEY (workspace_id, user_id, collection_id),
+    FOREIGN KEY (workspace_id, user_id) REFERENCES workspace_members(workspace_id, user_id) ON DELETE CASCADE
+);
+
+-- Add is_system flag to collections.
+ALTER TABLE collections ADD COLUMN IF NOT EXISTS is_system BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- Mark conventions and playbooks as system collections.
+UPDATE collections SET is_system = TRUE WHERE slug IN ('conventions', 'playbooks');

--- a/internal/store/pgmigrations/012_permission_indexes.sql
+++ b/internal/store/pgmigrations/012_permission_indexes.sql
@@ -1,0 +1,5 @@
+-- Indexes for permission table query performance (TASK-486).
+
+CREATE INDEX IF NOT EXISTS idx_mca_collection ON member_collection_access(collection_id);
+CREATE INDEX IF NOT EXISTS idx_collections_system ON collections(workspace_id, is_system) WHERE is_system = TRUE AND deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_wm_user ON workspace_members(user_id);

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -30,6 +30,12 @@ type SearchParams struct {
 }
 
 func (s *Store) Search(params SearchParams) ([]SearchResult, error) {
+	// Non-nil empty CollectionIDs means "no visible collections" — return
+	// empty results immediately rather than skipping the filter clause.
+	if params.CollectionIDs != nil && len(params.CollectionIDs) == 0 {
+		return nil, nil
+	}
+
 	var results []SearchResult
 
 	// Check if the query looks like an item ref (e.g. "TASK-5", "BUG-8")

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -23,9 +23,10 @@ func placeholders(n int) string {
 }
 
 type SearchParams struct {
-	Query        string
-	Workspace    string   // workspace slug, optional — scopes to single workspace
-	WorkspaceIDs []string // workspace IDs to scope results to (used when no specific workspace is given)
+	Query         string
+	Workspace     string   // workspace slug, optional — scopes to single workspace
+	WorkspaceIDs  []string // workspace IDs to scope results to (used when no specific workspace is given)
+	CollectionIDs []string // permission filter: restrict to these collection IDs (nil = no filter)
 }
 
 func (s *Store) Search(params SearchParams) ([]SearchResult, error) {
@@ -56,6 +57,13 @@ func (s *Store) Search(params SearchParams) ([]SearchResult, error) {
 		} else if len(params.WorkspaceIDs) > 0 {
 			refQuery += ` AND i.workspace_id IN (` + placeholders(len(params.WorkspaceIDs)) + `)`
 			for _, id := range params.WorkspaceIDs {
+				refArgs = append(refArgs, id)
+			}
+		}
+
+		if len(params.CollectionIDs) > 0 {
+			refQuery += ` AND i.collection_id IN (` + placeholders(len(params.CollectionIDs)) + `)`
+			for _, id := range params.CollectionIDs {
 				refArgs = append(refArgs, id)
 			}
 		}
@@ -161,6 +169,13 @@ func (s *Store) Search(params SearchParams) ([]SearchResult, error) {
 	} else if len(params.WorkspaceIDs) > 0 {
 		query += ` AND i.workspace_id IN (` + placeholders(len(params.WorkspaceIDs)) + `)`
 		for _, id := range params.WorkspaceIDs {
+			args = append(args, id)
+		}
+	}
+
+	if len(params.CollectionIDs) > 0 {
+		query += ` AND i.collection_id IN (` + placeholders(len(params.CollectionIDs)) + `)`
+		for _, id := range params.CollectionIDs {
 			args = append(args, id)
 		}
 	}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -156,6 +156,7 @@ func (s *Store) migrate() error {
 		"029_username.sql",
 		"030_workspace_owner.sql",
 		"031_collection_access.sql",
+		"032_permission_indexes.sql",
 	}
 
 	for _, name := range migrations {
@@ -211,6 +212,7 @@ func (s *Store) migratePostgres() error {
 		"009_username.sql",
 		"010_workspace_owner.sql",
 		"011_collection_access.sql",
+		"012_permission_indexes.sql",
 	}
 
 	for _, name := range migrations {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -155,6 +155,7 @@ func (s *Store) migrate() error {
 		"028_workspace_sort_order.sql",
 		"029_username.sql",
 		"030_workspace_owner.sql",
+		"031_collection_access.sql",
 	}
 
 	for _, name := range migrations {
@@ -209,6 +210,7 @@ func (s *Store) migratePostgres() error {
 		"008_workspace_sort_order.sql",
 		"009_username.sql",
 		"010_workspace_owner.sql",
+		"011_collection_access.sql",
 	}
 
 	for _, name := range migrations {

--- a/internal/store/workspace_members.go
+++ b/internal/store/workspace_members.go
@@ -46,11 +46,11 @@ func (s *Store) GetWorkspaceMember(workspaceID, userID string) (*models.Workspac
 	var createdAt string
 
 	err := s.db.QueryRow(s.q(`
-		SELECT workspace_id, user_id, role, created_at
+		SELECT workspace_id, user_id, role, collection_access, created_at
 		FROM workspace_members
 		WHERE workspace_id = ? AND user_id = ?
 	`), workspaceID, userID).Scan(
-		&m.WorkspaceID, &m.UserID, &m.Role, &createdAt,
+		&m.WorkspaceID, &m.UserID, &m.Role, &m.CollectionAccess, &createdAt,
 	)
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -67,7 +67,7 @@ func (s *Store) GetWorkspaceMember(workspaceID, userID string) (*models.Workspac
 // user name and email from a join.
 func (s *Store) ListWorkspaceMembers(workspaceID string) ([]models.WorkspaceMember, error) {
 	rows, err := s.db.Query(s.q(`
-		SELECT wm.workspace_id, wm.user_id, wm.role, wm.created_at,
+		SELECT wm.workspace_id, wm.user_id, wm.role, wm.collection_access, wm.created_at,
 		       u.name, u.email, u.username
 		FROM workspace_members wm
 		JOIN users u ON u.id = wm.user_id
@@ -84,7 +84,7 @@ func (s *Store) ListWorkspaceMembers(workspaceID string) ([]models.WorkspaceMemb
 		var m models.WorkspaceMember
 		var createdAt string
 		if err := rows.Scan(
-			&m.WorkspaceID, &m.UserID, &m.Role, &createdAt,
+			&m.WorkspaceID, &m.UserID, &m.Role, &m.CollectionAccess, &createdAt,
 			&m.UserName, &m.UserEmail, &m.UserUsername,
 		); err != nil {
 			return nil, fmt.Errorf("scan workspace member: %w", err)
@@ -93,6 +93,132 @@ func (s *Store) ListWorkspaceMembers(workspaceID string) ([]models.WorkspaceMemb
 		result = append(result, m)
 	}
 	return result, rows.Err()
+}
+
+// VisibleCollectionIDs returns the set of collection IDs a member can see.
+// Returns nil if the member has "all" access (meaning no filtering needed).
+// System collections (conventions, playbooks) are always included for members.
+func (s *Store) VisibleCollectionIDs(workspaceID, userID string) ([]string, error) {
+	member, err := s.GetWorkspaceMember(workspaceID, userID)
+	if err != nil {
+		return nil, err
+	}
+	if member == nil {
+		return []string{}, nil // Not a member — no access
+	}
+
+	// "all" access — return nil to indicate no filtering needed
+	if member.CollectionAccess == "all" || member.CollectionAccess == "" {
+		return nil, nil
+	}
+
+	// "specific" access — get the granted collection IDs + system collections
+	rows, err := s.db.Query(s.q(`
+		SELECT collection_id FROM member_collection_access
+		WHERE workspace_id = ? AND user_id = ?
+	`), workspaceID, userID)
+	if err != nil {
+		return nil, fmt.Errorf("get member collection access: %w", err)
+	}
+	defer rows.Close()
+
+	ids := make(map[string]bool)
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids[id] = true
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	// Always include system collections for members
+	sysRows, err := s.db.Query(s.q(`
+		SELECT id FROM collections
+		WHERE workspace_id = ? AND is_system = ? AND deleted_at IS NULL
+	`), workspaceID, s.dialect.BoolToInt(true))
+	if err != nil {
+		return nil, fmt.Errorf("get system collections: %w", err)
+	}
+	defer sysRows.Close()
+
+	for sysRows.Next() {
+		var id string
+		if err := sysRows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids[id] = true
+	}
+
+	result := make([]string, 0, len(ids))
+	for id := range ids {
+		result = append(result, id)
+	}
+	return result, nil
+}
+
+// SetMemberCollectionAccess updates a member's collection_access mode and
+// replaces their specific collection grants.
+func (s *Store) SetMemberCollectionAccess(workspaceID, userID, mode string, collectionIDs []string) error {
+	ts := now()
+
+	// Update the mode on workspace_members
+	_, err := s.db.Exec(s.q(`
+		UPDATE workspace_members SET collection_access = ?
+		WHERE workspace_id = ? AND user_id = ?
+	`), mode, workspaceID, userID)
+	if err != nil {
+		return fmt.Errorf("update collection_access: %w", err)
+	}
+
+	// Clear existing grants
+	_, err = s.db.Exec(s.q(`
+		DELETE FROM member_collection_access
+		WHERE workspace_id = ? AND user_id = ?
+	`), workspaceID, userID)
+	if err != nil {
+		return fmt.Errorf("clear collection access: %w", err)
+	}
+
+	// Insert new grants (only if mode is "specific")
+	if mode == "specific" {
+		for _, collID := range collectionIDs {
+			_, err := s.db.Exec(s.q(`
+				INSERT INTO member_collection_access (workspace_id, user_id, collection_id, created_at)
+				VALUES (?, ?, ?, ?)
+			`), workspaceID, userID, collID, ts)
+			if err != nil {
+				return fmt.Errorf("insert collection access: %w", err)
+			}
+		}
+	}
+
+	return nil
+}
+
+// GetMemberCollectionAccess returns the collection IDs a member has been
+// explicitly granted access to (only meaningful when collection_access = "specific").
+func (s *Store) GetMemberCollectionAccess(workspaceID, userID string) ([]string, error) {
+	rows, err := s.db.Query(s.q(`
+		SELECT collection_id FROM member_collection_access
+		WHERE workspace_id = ? AND user_id = ?
+	`), workspaceID, userID)
+	if err != nil {
+		return nil, fmt.Errorf("get member collection access: %w", err)
+	}
+	defer rows.Close()
+
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
 }
 
 // GetUserWorkspaces returns all workspaces a user has access to,

--- a/internal/store/workspace_members.go
+++ b/internal/store/workspace_members.go
@@ -160,12 +160,31 @@ func (s *Store) VisibleCollectionIDs(workspaceID, userID string) ([]string, erro
 }
 
 // SetMemberCollectionAccess updates a member's collection_access mode and
-// replaces their specific collection grants.
+// replaces their specific collection grants atomically.
 func (s *Store) SetMemberCollectionAccess(workspaceID, userID, mode string, collectionIDs []string) error {
 	ts := now()
 
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin transaction: %w", err)
+	}
+	defer tx.Rollback()
+
+	// Validate that all collection IDs belong to this workspace
+	if mode == "specific" && len(collectionIDs) > 0 {
+		for _, collID := range collectionIDs {
+			var count int
+			if err := tx.QueryRow(s.q(`SELECT COUNT(*) FROM collections WHERE id = ? AND workspace_id = ?`), collID, workspaceID).Scan(&count); err != nil {
+				return fmt.Errorf("validate collection: %w", err)
+			}
+			if count == 0 {
+				return fmt.Errorf("collection %s does not belong to workspace", collID)
+			}
+		}
+	}
+
 	// Update the mode on workspace_members
-	_, err := s.db.Exec(s.q(`
+	_, err = tx.Exec(s.q(`
 		UPDATE workspace_members SET collection_access = ?
 		WHERE workspace_id = ? AND user_id = ?
 	`), mode, workspaceID, userID)
@@ -174,7 +193,7 @@ func (s *Store) SetMemberCollectionAccess(workspaceID, userID, mode string, coll
 	}
 
 	// Clear existing grants
-	_, err = s.db.Exec(s.q(`
+	_, err = tx.Exec(s.q(`
 		DELETE FROM member_collection_access
 		WHERE workspace_id = ? AND user_id = ?
 	`), workspaceID, userID)
@@ -185,7 +204,7 @@ func (s *Store) SetMemberCollectionAccess(workspaceID, userID, mode string, coll
 	// Insert new grants (only if mode is "specific")
 	if mode == "specific" {
 		for _, collID := range collectionIDs {
-			_, err := s.db.Exec(s.q(`
+			_, err := tx.Exec(s.q(`
 				INSERT INTO member_collection_access (workspace_id, user_id, collection_id, created_at)
 				VALUES (?, ?, ?, ?)
 			`), workspaceID, userID, collID, ts)
@@ -195,7 +214,7 @@ func (s *Store) SetMemberCollectionAccess(workspaceID, userID, mode string, coll
 		}
 	}
 
-	return nil
+	return tx.Commit()
 }
 
 // GetMemberCollectionAccess returns the collection IDs a member has been

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -517,6 +517,13 @@ export const api = {
 		acceptInvitation: (code: string) =>
 			request<{ accepted: boolean; workspace_id: string; role: string }>(`/invitations/${code}/accept`, {
 				method: 'POST'
+			}),
+		getMemberCollectionAccess: (ws: string, userId: string) =>
+			request<{ collection_access: string; collection_ids: string[] }>(`/workspaces/${ws}/members/${userId}/collection-access`),
+		setMemberCollectionAccess: (ws: string, userId: string, mode: string, collectionIDs: string[]) =>
+			request<{ collection_access: string; collection_ids: string[] }>(`/workspaces/${ws}/members/${userId}/collection-access`, {
+				method: 'PUT',
+				body: JSON.stringify({ mode, collection_ids: collectionIDs })
 			})
 	},
 

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -166,6 +166,7 @@ export interface Collection {
 	settings: string;
 	sort_order: number;
 	is_default: boolean;
+	is_system: boolean;
 	created_at: string;
 	updated_at: string;
 	item_count?: number;

--- a/web/src/routes/[username]/[workspace]/settings/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/settings/+page.svelte
@@ -36,6 +36,13 @@
 	let inviteResult = $state<{ message: string; type: 'success' | 'error' } | null>(null);
 	let currentUserRole = $state('');
 
+	// Collection Access
+	let expandedAccessUserId = $state<string | null>(null);
+	let accessMode = $state<'all' | 'specific'>('all');
+	let accessCollectionIds = $state<string[]>([]);
+	let accessLoading = $state(false);
+	let accessSaving = $state(false);
+
 	// Account
 	let profileName = $state('');
 	let profileEmail = $state('');
@@ -303,6 +310,64 @@
 			toastStore.show('Role updated', 'success');
 		} catch {
 			toastStore.show('Failed to update role', 'error');
+		}
+	}
+
+	let nonSystemCollections = $derived(collections.filter(c => !c.is_system));
+	let systemCollections = $derived(collections.filter(c => c.is_system));
+
+	async function toggleAccessPanel(userId: string) {
+		if (expandedAccessUserId === userId) {
+			expandedAccessUserId = null;
+			return;
+		}
+		expandedAccessUserId = userId;
+		accessLoading = true;
+		accessMode = 'all';
+		accessCollectionIds = [];
+		try {
+			const data = await api.members.getMemberCollectionAccess(wsSlug, userId);
+			accessMode = data.collection_access === 'specific' ? 'specific' : 'all';
+			accessCollectionIds = data.collection_ids ?? [];
+		} catch {
+			accessMode = 'all';
+			accessCollectionIds = [];
+		} finally {
+			accessLoading = false;
+		}
+	}
+
+	function toggleAccessCollection(collId: string) {
+		if (accessCollectionIds.includes(collId)) {
+			accessCollectionIds = accessCollectionIds.filter(id => id !== collId);
+		} else {
+			accessCollectionIds = [...accessCollectionIds, collId];
+		}
+	}
+
+	async function saveCollectionAccess() {
+		if (!expandedAccessUserId || accessSaving) return;
+		accessSaving = true;
+		const userId = expandedAccessUserId;
+		const prevMode = accessMode;
+		const prevIds = [...accessCollectionIds];
+		try {
+			const result = await api.members.setMemberCollectionAccess(
+				wsSlug,
+				userId,
+				accessMode,
+				accessMode === 'specific' ? accessCollectionIds : []
+			);
+			accessMode = result.collection_access === 'specific' ? 'specific' : 'all';
+			accessCollectionIds = result.collection_ids ?? [];
+			toastStore.show('Collection access updated', 'success');
+		} catch {
+			// Revert on error
+			accessMode = prevMode;
+			accessCollectionIds = prevIds;
+			toastStore.show('Failed to update collection access', 'error');
+		} finally {
+			accessSaving = false;
 		}
 	}
 
@@ -782,32 +847,97 @@
 				{:else}
 					<div class="members-list">
 						{#each members as member (member.user_id)}
-							<div class="card member-row">
-								<div class="member-info">
-									<span class="member-avatar">{member.user_name.charAt(0).toUpperCase()}</span>
-									<div class="member-details">
-										<span class="member-name">{member.user_name}</span>
-										<span class="member-email">{member.user_email}</span>
+							<div class="member-card-wrapper">
+								<div class="card member-row">
+									<div class="member-info">
+										<span class="member-avatar">{member.user_name.charAt(0).toUpperCase()}</span>
+										<div class="member-details">
+											<span class="member-name">{member.user_name}</span>
+											<span class="member-email">{member.user_email}</span>
+										</div>
+										{#if expandedAccessUserId === member.user_id && !accessLoading}
+											<span class="access-badge" class:access-badge-specific={accessMode === 'specific'}>
+												{accessMode === 'all' ? 'All collections' : `${accessCollectionIds.length} collection${accessCollectionIds.length !== 1 ? 's' : ''}`}
+											</span>
+										{/if}
+									</div>
+									<div class="member-actions">
+										{#if isOwner}
+											<button
+												class="btn btn-small btn-access"
+												class:btn-access-active={expandedAccessUserId === member.user_id}
+												onclick={() => toggleAccessPanel(member.user_id)}
+											>
+												Manage access
+											</button>
+											<select
+												class="role-select"
+												value={member.role}
+												onchange={(e) => handleChangeRole(member.user_id, (e.target as HTMLSelectElement).value)}
+											>
+												<option value="owner">Owner</option>
+												<option value="editor">Editor</option>
+												<option value="viewer">Viewer</option>
+											</select>
+											<button class="btn btn-small btn-remove" onclick={() => handleRemoveMember(member.user_id, member.user_name)}>
+												Remove
+											</button>
+										{:else}
+											<span class="role-badge">{member.role}</span>
+										{/if}
 									</div>
 								</div>
-								<div class="member-actions">
-									{#if isOwner}
-										<select
-											class="role-select"
-											value={member.role}
-											onchange={(e) => handleChangeRole(member.user_id, (e.target as HTMLSelectElement).value)}
-										>
-											<option value="owner">Owner</option>
-											<option value="editor">Editor</option>
-											<option value="viewer">Viewer</option>
-										</select>
-										<button class="btn btn-small btn-remove" onclick={() => handleRemoveMember(member.user_id, member.user_name)}>
-											Remove
-										</button>
-									{:else}
-										<span class="role-badge">{member.role}</span>
-									{/if}
-								</div>
+								{#if isOwner && expandedAccessUserId === member.user_id}
+									<div class="access-panel">
+										{#if accessLoading}
+											<p class="access-loading">Loading collection access...</p>
+										{:else}
+											<div class="access-mode-row">
+												<label class="access-mode-label" for="access-mode-{member.user_id}">Collection visibility</label>
+												<select
+													id="access-mode-{member.user_id}"
+													class="role-select"
+													value={accessMode}
+													onchange={(e) => { accessMode = (e.target as HTMLSelectElement).value as 'all' | 'specific'; }}
+												>
+													<option value="all">All collections</option>
+													<option value="specific">Specific collections</option>
+												</select>
+											</div>
+											{#if accessMode === 'specific'}
+												<div class="access-coll-list">
+													{#each nonSystemCollections as coll (coll.id)}
+														<label class="access-coll-item">
+															<input
+																type="checkbox"
+																checked={accessCollectionIds.includes(coll.id)}
+																onchange={() => toggleAccessCollection(coll.id)}
+															/>
+															<span class="access-coll-icon">{coll.icon || '#'}</span>
+															<span class="access-coll-name">{coll.name}</span>
+														</label>
+													{/each}
+													{#each systemCollections as coll (coll.id)}
+														<label class="access-coll-item access-coll-system" title="System collection — always visible">
+															<input type="checkbox" checked disabled />
+															<span class="access-coll-icon">{coll.icon || '#'}</span>
+															<span class="access-coll-name">{coll.name}</span>
+															<span class="access-system-tag">system</span>
+														</label>
+													{/each}
+												</div>
+											{/if}
+											<div class="access-actions">
+												<button class="btn btn-primary btn-small" onclick={saveCollectionAccess} disabled={accessSaving}>
+													{accessSaving ? 'Saving...' : 'Save'}
+												</button>
+												<button class="btn btn-small" onclick={() => { expandedAccessUserId = null; }}>
+													Cancel
+												</button>
+											</div>
+										{/if}
+									</div>
+								{/if}
 							</div>
 						{/each}
 					</div>
@@ -1116,7 +1246,7 @@
 	.context-error { margin: 0; font-size: 0.82em; color: #ef4444; }
 	.context-actions { display: flex; flex-wrap: wrap; align-items: center; gap: var(--space-2); }
 	/* ── Members ──── */
-	.members-list { display: flex; flex-direction: column; gap: var(--space-3); }
+	.members-list { display: flex; flex-direction: column; }
 	.member-row { display: flex; align-items: center; justify-content: space-between; padding: var(--space-3) var(--space-4); gap: var(--space-3); }
 	.member-info { display: flex; align-items: center; gap: var(--space-3); min-width: 0; }
 	.member-avatar { width: 32px; height: 32px; border-radius: 50%; background: var(--accent-blue); color: #fff; display: flex; align-items: center; justify-content: center; font-weight: 600; font-size: 0.85em; flex-shrink: 0; }
@@ -1128,6 +1258,30 @@
 	.role-badge { font-size: 0.8em; background: var(--bg-tertiary); color: var(--text-secondary); padding: 2px 10px; border-radius: 10px; }
 	.btn-remove { color: #ef4444; border-color: transparent; background: none; }
 	.btn-remove:hover { background: color-mix(in srgb, #ef4444 15%, transparent); }
+	/* ── Collection Access ──── */
+	.member-card-wrapper { display: flex; flex-direction: column; }
+	.member-card-wrapper + .member-card-wrapper { margin-top: var(--space-3); }
+	.member-card-wrapper .card.member-row { border-radius: var(--radius); }
+	.member-card-wrapper:has(.access-panel) .card.member-row { border-bottom-left-radius: 0; border-bottom-right-radius: 0; border-bottom-color: transparent; }
+	.access-badge { font-size: 0.72em; padding: 2px 8px; border-radius: 10px; background: var(--bg-tertiary); color: var(--text-muted); white-space: nowrap; margin-left: var(--space-2); }
+	.access-badge-specific { background: color-mix(in srgb, var(--accent-blue) 15%, transparent); color: var(--accent-blue); }
+	.btn-access { color: var(--accent-blue); border-color: var(--accent-blue); background: none; }
+	.btn-access:hover { background: color-mix(in srgb, var(--accent-blue) 10%, transparent); }
+	.btn-access-active { background: color-mix(in srgb, var(--accent-blue) 15%, transparent); }
+	.access-panel { background: color-mix(in srgb, var(--bg-secondary) 80%, var(--bg-tertiary)); border: 1px solid var(--border); border-top: none; border-bottom-left-radius: var(--radius); border-bottom-right-radius: var(--radius); padding: var(--space-4); display: flex; flex-direction: column; gap: var(--space-3); }
+	.access-loading { font-size: 0.85em; color: var(--text-muted); margin: 0; }
+	.access-mode-row { display: flex; align-items: center; gap: var(--space-3); }
+	.access-mode-label { font-size: 0.85em; color: var(--text-secondary); white-space: nowrap; }
+	.access-coll-list { display: flex; flex-direction: column; gap: var(--space-1); max-height: 240px; overflow-y: auto; padding: var(--space-2); background: var(--bg-tertiary); border: 1px solid var(--border-subtle); border-radius: var(--radius); }
+	.access-coll-item { display: flex; align-items: center; gap: var(--space-2); padding: var(--space-1) var(--space-2); border-radius: var(--radius-sm); cursor: pointer; font-size: 0.85em; }
+	.access-coll-item:hover { background: var(--bg-hover); }
+	.access-coll-item input[type="checkbox"] { margin: 0; cursor: pointer; }
+	.access-coll-icon { font-size: 0.95em; }
+	.access-coll-name { flex: 1; }
+	.access-coll-system { opacity: 0.6; cursor: default; }
+	.access-coll-system:hover { background: none; }
+	.access-system-tag { font-size: 0.7em; background: var(--bg-secondary); color: var(--text-muted); padding: 1px 5px; border-radius: 8px; }
+	.access-actions { display: flex; align-items: center; gap: var(--space-2); }
 	.invitations-section { margin-top: var(--space-4); }
 	.invitations-section h3 { font-size: 0.9em; color: var(--text-muted); margin-bottom: var(--space-2); }
 	.invitation-row { display: flex; align-items: center; gap: var(--space-3); padding: var(--space-2) var(--space-4); font-size: 0.85em; }


### PR DESCRIPTION
## Summary

Implements Phase 2 of PLAN-407 (Multi-User Permissions & Sharing): collection-level visibility with permission-filtered aggregates.

- **Per-member collection access**: new `collection_access` column on `workspace_members` ("all" or "specific") with `member_collection_access` join table for granted collection IDs
- **System collections**: conventions and playbooks marked `is_system`, always visible to members regardless of collection access settings
- **Permission-filtered aggregates**: dashboard, item listing, search, activity feed, and collection listing all respect the user's visible collection set
- **SSE event filtering**: real-time events for hidden collections are silently dropped per-connection
- **Database indexes**: `idx_mca_collection`, `idx_collections_system`, `idx_wm_user` for query performance
- **Permission test suite**: 9 tests covering visibility resolution, system exemptions, grant CRUD, item filtering, and D7 default behavior
- **Management UI**: workspace settings Members tab with inline "Manage access" panel — all/specific toggle, collection checkbox list, system collections shown as always-on

### Key design decisions
- **D7**: Default `collection_access` is "all" — no restrictions until explicitly set
- System collections (conventions, playbooks) always visible to members, never toggleable
- `VisibleCollectionIDs()` returns `nil` for "all access" (no SQL filtering) or a specific ID list
- Admins always have full access regardless of collection_access setting
- Filtering is a no-op for existing single-user installs — zero behavioral change

### Tasks completed (7)
- TASK-413: Add collection_access to workspace_members + member_collection_access table
- TASK-415: Mark conventions and playbooks as system collections
- TASK-414: Permission-filtered aggregates: dashboard, search, activity feed
- TASK-487: SSE event permission filtering
- TASK-486: Database indexes for permission tables and query performance
- TASK-488: Comprehensive permission resolution test suite (Phase 2 increment)
- TASK-416: UI for managing member collection visibility

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./...` passes — includes 9 new permission tests
- [ ] `npm run build` passes
- [ ] `make install` succeeds
- [ ] Collections API returns `is_system: true` for conventions/playbooks, `false` for others
- [ ] Members API returns `collection_access: "all"` for existing members (D7 default)
- [ ] `GET /members/{id}/collection-access` returns access mode and granted IDs
- [ ] `PUT /members/{id}/collection-access` with `{"mode":"specific","collection_ids":[...]}` restricts visibility
- [ ] After setting specific access: ListCollections, ListItems, Search, Dashboard, Activity all filter correctly
- [ ] System collections (conventions, playbooks) remain visible even with specific access
- [ ] Reverting to `{"mode":"all"}` restores full visibility
- [ ] Settings UI: "Manage access" button visible for owners, inline panel works, save persists
- [ ] SSE events for hidden collections are not delivered
- [ ] CLI commands work unchanged (admin user = all access)
- [ ] No behavioral change for single-user installs or members with default "all" access