### PR TITLE
feat: collection & item grants, guest access, share dialog (PLAN-407 Phase 3)

### DIFF
--- a/internal/models/grant.go
+++ b/internal/models/grant.go
@@ -1,0 +1,37 @@
+package models
+
+import "time"
+
+// CollectionGrant represents a user's direct access to a collection
+// (for guests or member overrides).
+type CollectionGrant struct {
+	ID           string    `json:"id"`
+	CollectionID string    `json:"collection_id"`
+	WorkspaceID  string    `json:"workspace_id"`
+	UserID       string    `json:"user_id"`
+	Permission   string    `json:"permission"` // "view" or "edit"
+	GrantedBy    string    `json:"granted_by"`
+	CreatedAt    time.Time `json:"created_at"`
+
+	// Populated by JOINs (not stored)
+	UserName     string `json:"user_name,omitempty"`
+	UserEmail    string `json:"user_email,omitempty"`
+	UserUsername string `json:"user_username,omitempty"`
+}
+
+// ItemGrant represents a user's direct access to a specific item
+// (for guests or member overrides).
+type ItemGrant struct {
+	ID          string    `json:"id"`
+	ItemID      string    `json:"item_id"`
+	WorkspaceID string    `json:"workspace_id"`
+	UserID      string    `json:"user_id"`
+	Permission  string    `json:"permission"` // "view" or "edit"
+	GrantedBy   string    `json:"granted_by"`
+	CreatedAt   time.Time `json:"created_at"`
+
+	// Populated by JOINs (not stored)
+	UserName     string `json:"user_name,omitempty"`
+	UserEmail    string `json:"user_email,omitempty"`
+	UserUsername string `json:"user_username,omitempty"`
+}

--- a/internal/models/item.go
+++ b/internal/models/item.go
@@ -507,6 +507,7 @@ type ItemUpdate struct {
 type ItemListParams struct {
 	CollectionSlug  string
 	CollectionIDs   []string          // permission filter: restrict to these collection IDs (nil = no filter)
+	ItemIDs         []string          // permission filter: additionally restrict to these item IDs (for item-level grants)
 	Fields          map[string]string // field filters: key=value
 	Sort            string            // e.g. "priority:desc,created_at:asc"
 	GroupBy         string

--- a/internal/models/workspace.go
+++ b/internal/models/workspace.go
@@ -8,6 +8,7 @@ type Workspace struct {
 	Slug        string            `json:"slug"`
 	OwnerID       string            `json:"owner_id,omitempty"`       // User ID of workspace owner
 	OwnerUsername string            `json:"owner_username,omitempty"` // Populated by JOIN (not stored)
+	IsGuest       bool              `json:"is_guest,omitempty"`       // True when user has grants but no membership
 	Description string            `json:"description"`
 	Settings    string            `json:"settings"`           // JSON
 	SortOrder   int               `json:"sort_order"`

--- a/internal/server/handlers_activity.go
+++ b/internal/server/handlers_activity.go
@@ -42,25 +42,46 @@ func (s *Server) handleListWorkspaceActivity(w http.ResponseWriter, r *http.Requ
 	// Enrich activities with item titles and collection info
 	s.enrichActivities(activities)
 
-	// Filter by collection visibility
+	// Filter by collection visibility and item-level grants
 	visibleIDs, err := s.visibleCollectionIDs(r, workspaceID)
 	if err != nil {
 		writeInternalError(w, err)
 		return
 	}
+	fullCollIDs, grantedItemIDs, grantErr := s.guestResourceFilter(r, workspaceID)
+	if grantErr != nil {
+		writeInternalError(w, grantErr)
+		return
+	}
+	grantedItemSet := make(map[string]bool, len(grantedItemIDs))
+	for _, id := range grantedItemIDs {
+		grantedItemSet[id] = true
+	}
+	fullCollSet := make(map[string]bool, len(fullCollIDs))
+	for _, id := range fullCollIDs {
+		fullCollSet[id] = true
+	}
 	if visibleIDs != nil {
 		// Build slug lookup from visible collection IDs
 		visibleSlugs := make(map[string]bool)
+		// Also build collSlug→collID map for item-level checks
+		slugToID := make(map[string]string)
 		for _, id := range visibleIDs {
 			coll, _ := s.store.GetCollection(id)
 			if coll != nil {
 				visibleSlugs[coll.Slug] = true
+				slugToID[coll.Slug] = id
 			}
 		}
 		filtered := make([]models.Activity, 0, len(activities))
 		for _, a := range activities {
 			if a.CollectionSlug != "" && visibleSlugs[a.CollectionSlug] {
-				// Known collection that's visible — include
+				// For guests with item-level grants, check the specific item
+				if len(grantedItemIDs) > 0 && !fullCollSet[slugToID[a.CollectionSlug]] && a.DocumentID != "" {
+					if !grantedItemSet[a.DocumentID] {
+						continue
+					}
+				}
 				filtered = append(filtered, a)
 			} else if a.CollectionSlug == "" && a.ItemSlug == "" {
 				// Workspace-level activity (no item) — include

--- a/internal/server/handlers_activity.go
+++ b/internal/server/handlers_activity.go
@@ -8,6 +8,11 @@ import (
 )
 
 func (s *Server) handleListWorkspaceActivity(w http.ResponseWriter, r *http.Request) {
+	// Guests should not see workspace-level activity, which includes
+	// audit events (member invites, role changes, etc.) with operational metadata.
+	if !requireMinRole(w, r, "viewer") {
+		return
+	}
 	workspaceID, ok := s.getWorkspaceID(w, r)
 	if !ok {
 		return

--- a/internal/server/handlers_activity.go
+++ b/internal/server/handlers_activity.go
@@ -102,6 +102,10 @@ func (s *Server) handleListWorkspaceActivity(w http.ResponseWriter, r *http.Requ
 }
 
 func (s *Server) handleListDocumentActivity(w http.ResponseWriter, r *http.Request) {
+	// Legacy documents are not covered by the grants model — block guests.
+	if !requireMinRole(w, r, "viewer") {
+		return
+	}
 	_, doc, ok := s.getWorkspaceDocument(w, r)
 	if !ok {
 		return

--- a/internal/server/handlers_agent_roles.go
+++ b/internal/server/handlers_agent_roles.go
@@ -29,7 +29,21 @@ func (s *Server) handleListAgentRoles(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if visibleIDs != nil {
-		visibleItems, _ := s.store.ListItems(workspaceID, models.ItemListParams{CollectionIDs: visibleIDs})
+		// For guests, use item-level filtering
+		arCollIDs := visibleIDs
+		var arItemIDs []string
+		if workspaceRole(r) == "guest" {
+			if user := currentUser(r); user != nil {
+				fullCollIDs, grantedItemIDs, grantErr := s.store.GuestVisibleResources(workspaceID, user.ID)
+				if grantErr != nil {
+					writeInternalError(w, grantErr)
+					return
+				}
+				arCollIDs = fullCollIDs
+				arItemIDs = grantedItemIDs
+			}
+		}
+		visibleItems, _ := s.store.ListItems(workspaceID, models.ItemListParams{CollectionIDs: arCollIDs, ItemIDs: arItemIDs})
 		// Build role → count map from visible items
 		roleCounts := make(map[string]int)
 		for _, item := range visibleItems {

--- a/internal/server/handlers_agent_roles.go
+++ b/internal/server/handlers_agent_roles.go
@@ -29,19 +29,17 @@ func (s *Server) handleListAgentRoles(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if visibleIDs != nil {
-		// For guests, use item-level filtering
+		// For users with item-level grants, use item-level filtering
 		arCollIDs := visibleIDs
 		var arItemIDs []string
-		if workspaceRole(r) == "guest" {
-			if user := currentUser(r); user != nil {
-				fullCollIDs, grantedItemIDs, grantErr := s.store.GuestVisibleResources(workspaceID, user.ID)
-				if grantErr != nil {
-					writeInternalError(w, grantErr)
-					return
-				}
-				arCollIDs = fullCollIDs
-				arItemIDs = grantedItemIDs
-			}
+		arFullCollIDs, arGrantedItemIDs, arGrantErr := s.guestResourceFilter(r, workspaceID)
+		if arGrantErr != nil {
+			writeInternalError(w, arGrantErr)
+			return
+		}
+		if len(arGrantedItemIDs) > 0 {
+			arCollIDs = arFullCollIDs
+			arItemIDs = arGrantedItemIDs
 		}
 		visibleItems, _ := s.store.ListItems(workspaceID, models.ItemListParams{CollectionIDs: arCollIDs, ItemIDs: arItemIDs})
 		// Build role → count map from visible items

--- a/internal/server/handlers_changes.go
+++ b/internal/server/handlers_changes.go
@@ -61,6 +61,19 @@ func (s *Server) handleGetChanges(w http.ResponseWriter, r *http.Request) {
 		writeInternalError(w, visErr)
 		return
 	}
+
+	// For guests with item-level grants, apply item-level filtering
+	// so they only see changes to items they actually have grants on.
+	fullCollIDs, grantedItemIDs, grantErr := s.guestResourceFilter(r, workspaceID)
+	if grantErr != nil {
+		writeInternalError(w, grantErr)
+		return
+	}
+	grantedItemSet := make(map[string]bool, len(grantedItemIDs))
+	for _, id := range grantedItemIDs {
+		grantedItemSet[id] = true
+	}
+
 	if visibleIDs != nil {
 		filtered := updated[:0]
 		allowedDeleted := deletedIDs[:0]
@@ -68,10 +81,24 @@ func (s *Server) handleGetChanges(w http.ResponseWriter, r *http.Request) {
 		for _, id := range visibleIDs {
 			visibleSet[id] = true
 		}
+
+		// For guests, build a set of full-collection-grant IDs to distinguish
+		// between full-collection access and item-only access.
+		fullCollSet := make(map[string]bool, len(fullCollIDs))
+		for _, id := range fullCollIDs {
+			fullCollSet[id] = true
+		}
+
 		for _, item := range updated {
-			if visibleSet[item.CollectionID] {
-				filtered = append(filtered, item)
+			if !visibleSet[item.CollectionID] {
+				continue
 			}
+			// For guests: if the collection is only visible via item grants,
+			// check the specific item is granted.
+			if len(grantedItemIDs) > 0 && !fullCollSet[item.CollectionID] && !grantedItemSet[item.ID] {
+				continue
+			}
+			filtered = append(filtered, item)
 		}
 		updated = filtered
 		// For deleted items, re-query with collection filter since we
@@ -83,9 +110,13 @@ func (s *Server) handleGetChanges(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 			for _, item := range delItems {
-				if visibleSet[item.CollectionID] {
-					allowedDeleted = append(allowedDeleted, item.ID)
+				if !visibleSet[item.CollectionID] {
+					continue
 				}
+				if len(grantedItemIDs) > 0 && !fullCollSet[item.CollectionID] && !grantedItemSet[item.ID] {
+					continue
+				}
+				allowedDeleted = append(allowedDeleted, item.ID)
 			}
 			deletedIDs = allowedDeleted
 		}

--- a/internal/server/handlers_comments.go
+++ b/internal/server/handlers_comments.go
@@ -63,9 +63,6 @@ func (s *Server) handleListComments(w http.ResponseWriter, r *http.Request) {
 
 // handleCreateComment adds a new comment to an item.
 func (s *Server) handleCreateComment(w http.ResponseWriter, r *http.Request) {
-	if !requireMinRole(w, r, "editor") {
-		return
-	}
 	workspaceID, ok := s.getWorkspaceID(w, r)
 	if !ok {
 		return
@@ -82,6 +79,10 @@ func (s *Server) handleCreateComment(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if !s.requireItemVisible(w, r, workspaceID, item) {
+		return
+	}
+	// Check edit permission (grant-aware for guests)
+	if !s.requireEditPermission(w, r, workspaceID, item.ID, item.CollectionID) {
 		return
 	}
 
@@ -128,9 +129,6 @@ func (s *Server) handleCreateComment(w http.ResponseWriter, r *http.Request) {
 
 // handleDeleteComment removes a comment.
 func (s *Server) handleDeleteComment(w http.ResponseWriter, r *http.Request) {
-	if !requireMinRole(w, r, "editor") {
-		return
-	}
 	workspaceID, ok := s.getWorkspaceID(w, r)
 	if !ok {
 		return
@@ -145,6 +143,14 @@ func (s *Server) handleDeleteComment(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if !s.requireCommentVisible(w, r, workspaceID, comment) {
+		return
+	}
+	// Check edit permission on the comment's item (grant-aware for guests)
+	if commentItem, ierr := s.store.GetItem(comment.ItemID); ierr == nil && commentItem != nil {
+		if !s.requireEditPermission(w, r, workspaceID, commentItem.ID, commentItem.CollectionID) {
+			return
+		}
+	} else if !requireMinRole(w, r, "editor") {
 		return
 	}
 
@@ -162,9 +168,6 @@ func (s *Server) handleDeleteComment(w http.ResponseWriter, r *http.Request) {
 
 // handleCreateReply creates a reply to an existing comment.
 func (s *Server) handleCreateReply(w http.ResponseWriter, r *http.Request) {
-	if !requireMinRole(w, r, "editor") {
-		return
-	}
 	workspaceID, ok := s.getWorkspaceID(w, r)
 	if !ok {
 		return
@@ -181,6 +184,14 @@ func (s *Server) handleCreateReply(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if !s.requireCommentVisible(w, r, workspaceID, parentComment) {
+		return
+	}
+	// Check edit permission on the parent comment's item (grant-aware for guests)
+	if commentItem, ierr := s.store.GetItem(parentComment.ItemID); ierr == nil && commentItem != nil {
+		if !s.requireEditPermission(w, r, workspaceID, commentItem.ID, commentItem.CollectionID) {
+			return
+		}
+	} else if !requireMinRole(w, r, "editor") {
 		return
 	}
 
@@ -228,9 +239,6 @@ func (s *Server) handleCreateReply(w http.ResponseWriter, r *http.Request) {
 
 // handleAddReaction adds an emoji reaction to a comment.
 func (s *Server) handleAddReaction(w http.ResponseWriter, r *http.Request) {
-	if !requireMinRole(w, r, "editor") {
-		return
-	}
 	workspaceID, ok := s.getWorkspaceID(w, r)
 	if !ok {
 		return
@@ -245,6 +253,14 @@ func (s *Server) handleAddReaction(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if !s.requireCommentVisible(w, r, workspaceID, comment) {
+		return
+	}
+	// Check edit permission on the comment's item (grant-aware for guests)
+	if commentItem, ierr := s.store.GetItem(comment.ItemID); ierr == nil && commentItem != nil {
+		if !s.requireEditPermission(w, r, workspaceID, commentItem.ID, commentItem.CollectionID) {
+			return
+		}
+	} else if !requireMinRole(w, r, "editor") {
 		return
 	}
 
@@ -279,9 +295,6 @@ func (s *Server) handleAddReaction(w http.ResponseWriter, r *http.Request) {
 
 // handleRemoveReaction removes an emoji reaction from a comment.
 func (s *Server) handleRemoveReaction(w http.ResponseWriter, r *http.Request) {
-	if !requireMinRole(w, r, "editor") {
-		return
-	}
 	workspaceID, ok := s.getWorkspaceID(w, r)
 	if !ok {
 		return
@@ -297,6 +310,14 @@ func (s *Server) handleRemoveReaction(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if !s.requireCommentVisible(w, r, workspaceID, commentObj) {
+		return
+	}
+	// Check edit permission on the comment's item (grant-aware for guests)
+	if commentItem, ierr := s.store.GetItem(commentObj.ItemID); ierr == nil && commentItem != nil {
+		if !s.requireEditPermission(w, r, workspaceID, commentItem.ID, commentItem.CollectionID) {
+			return
+		}
+	} else if !requireMinRole(w, r, "editor") {
 		return
 	}
 

--- a/internal/server/handlers_dashboard.go
+++ b/internal/server/handlers_dashboard.go
@@ -497,7 +497,7 @@ func (s *Server) handleGetDashboard(w http.ResponseWriter, r *http.Request) {
 					if visibleSlugSet != nil && !visibleSlugSet[item.CollectionSlug] {
 						continue
 					}
-					// For guests: skip items not directly granted
+					// For users with item grants: skip items not directly granted
 					if !s.isItemVisibleToGuest(r, workspaceID, item, dashFullCollIDs, dashGrantedItemIDs) {
 						continue
 					}
@@ -505,6 +505,10 @@ func (s *Server) handleGetDashboard(w http.ResponseWriter, r *http.Request) {
 					da.ItemSlug = item.Slug
 					da.CollectionSlug = item.CollectionSlug
 				}
+			} else if workspaceRole(r) == "guest" {
+				// Workspace-level activity (no item) — skip for guests since
+				// it may contain audit metadata (member invites, role changes).
+				continue
 			}
 			resp.RecentActivity = append(resp.RecentActivity, da)
 		}

--- a/internal/server/handlers_dashboard.go
+++ b/internal/server/handlers_dashboard.go
@@ -141,6 +141,29 @@ func (s *Server) handleGetDashboard(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// For guests, compute item-level grant filtering
+	dashFullCollIDs, dashGrantedItemIDs, dashGrantErr := s.guestResourceFilter(r, workspaceID)
+	if dashGrantErr != nil {
+		writeInternalError(w, dashGrantErr)
+		return
+	}
+	dashGrantedItemSet := make(map[string]bool, len(dashGrantedItemIDs))
+	for _, id := range dashGrantedItemIDs {
+		dashGrantedItemSet[id] = true
+	}
+	dashFullCollSet := make(map[string]bool, len(dashFullCollIDs))
+	for _, id := range dashFullCollIDs {
+		dashFullCollSet[id] = true
+	}
+
+	// For guests, use item-level filtering in ListItems queries
+	dashCollIDs := visibleIDs
+	var dashItemIDs []string
+	if workspaceRole(r) == "guest" {
+		dashCollIDs = dashFullCollIDs
+		dashItemIDs = dashGrantedItemIDs
+	}
+
 	// Build a schema map for terminal status lookups
 	collections, err := s.store.ListCollections(workspaceID)
 	if err != nil {
@@ -171,7 +194,7 @@ func (s *Server) handleGetDashboard(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Summary: items grouped by collection slug and status field
-	allItems, err := s.store.ListItems(workspaceID, models.ItemListParams{CollectionIDs: visibleIDs})
+	allItems, err := s.store.ListItems(workspaceID, models.ItemListParams{CollectionIDs: dashCollIDs, ItemIDs: dashItemIDs})
 	if err != nil {
 		writeInternalError(w, err)
 		return
@@ -232,7 +255,8 @@ func (s *Server) handleGetDashboard(w http.ResponseWriter, r *http.Request) {
 	// Active plans: items in "plans" collection where status=active
 	plans, err := s.store.ListItems(workspaceID, models.ItemListParams{
 		CollectionSlug: "plans",
-		CollectionIDs:  visibleIDs,
+		CollectionIDs:  dashCollIDs,
+		ItemIDs:        dashItemIDs,
 		Fields:         map[string]string{"status": "active"},
 	})
 	if err == nil {
@@ -248,6 +272,9 @@ func (s *Server) handleGetDashboard(w http.ResponseWriter, r *http.Request) {
 			if planChildren, cerr := s.store.GetChildItems(plan.ID); cerr == nil {
 				for _, child := range planChildren {
 					if !isCollectionVisible(child.CollectionID, visibleIDs) {
+						continue
+					}
+					if !s.isItemVisibleToGuest(r, workspaceID, &child, dashFullCollIDs, dashGrantedItemIDs) {
 						continue
 					}
 					total++
@@ -284,7 +311,8 @@ func (s *Server) handleGetDashboard(w http.ResponseWriter, r *http.Request) {
 	// (a) Stalled: status is in-progress or in_progress, updated_at older than 3 days
 	for _, statusVal := range []string{"in-progress", "in_progress"} {
 		items, err := s.store.ListItems(workspaceID, models.ItemListParams{
-			CollectionIDs: visibleIDs,
+			CollectionIDs: dashCollIDs,
+			ItemIDs:       dashItemIDs,
 			Fields:        map[string]string{"status": statusVal},
 		})
 		if err != nil {
@@ -362,7 +390,8 @@ func (s *Server) handleGetDashboard(w http.ResponseWriter, r *http.Request) {
 		}
 		allTasks, err := s.store.ListItems(workspaceID, models.ItemListParams{
 			CollectionSlug: "tasks",
-			CollectionIDs:  visibleIDs,
+			CollectionIDs:  dashCollIDs,
+			ItemIDs:        dashItemIDs,
 		})
 		if err == nil {
 			for _, task := range allTasks {
@@ -407,8 +436,11 @@ func (s *Server) handleGetDashboard(w http.ResponseWriter, r *http.Request) {
 			if err != nil || blocker == nil {
 				continue
 			}
-			// Skip blockers from hidden collections
+			// Skip blockers from hidden collections or ungrantable items
 			if !isCollectionVisible(blocker.CollectionID, visibleIDs) {
+				continue
+			}
+			if !s.isItemVisibleToGuest(r, workspaceID, blocker, dashFullCollIDs, dashGrantedItemIDs) {
 				continue
 			}
 			blockerStatus := extractFieldValue(blocker.Fields, "status")
@@ -465,6 +497,10 @@ func (s *Server) handleGetDashboard(w http.ResponseWriter, r *http.Request) {
 					if visibleSlugSet != nil && !visibleSlugSet[item.CollectionSlug] {
 						continue
 					}
+					// For guests: skip items not directly granted
+					if !s.isItemVisibleToGuest(r, workspaceID, item, dashFullCollIDs, dashGrantedItemIDs) {
+						continue
+					}
 					da.ItemTitle = item.Title
 					da.ItemSlug = item.Slug
 					da.CollectionSlug = item.CollectionSlug
@@ -495,6 +531,9 @@ func (s *Server) handleGetDashboard(w http.ResponseWriter, r *http.Request) {
 		for _, task := range tasks {
 			// Skip tasks from hidden collections
 			if !isCollectionVisible(task.CollectionID, visibleIDs) {
+				continue
+			}
+			if !s.isItemVisibleToGuest(r, workspaceID, &task, dashFullCollIDs, dashGrantedItemIDs) {
 				continue
 			}
 			taskStatus := extractFieldValue(task.Fields, "status")

--- a/internal/server/handlers_dashboard.go
+++ b/internal/server/handlers_dashboard.go
@@ -156,10 +156,10 @@ func (s *Server) handleGetDashboard(w http.ResponseWriter, r *http.Request) {
 		dashFullCollSet[id] = true
 	}
 
-	// For guests, use item-level filtering in ListItems queries
+	// For users with item-level grants, use item-level filtering in ListItems queries
 	dashCollIDs := visibleIDs
 	var dashItemIDs []string
-	if workspaceRole(r) == "guest" {
+	if len(dashGrantedItemIDs) > 0 {
 		dashCollIDs = dashFullCollIDs
 		dashItemIDs = dashGrantedItemIDs
 	}

--- a/internal/server/handlers_documents.go
+++ b/internal/server/handlers_documents.go
@@ -14,6 +14,10 @@ import (
 )
 
 func (s *Server) handleListDocuments(w http.ResponseWriter, r *http.Request) {
+	// Legacy documents are not covered by the grants model — block guests.
+	if !requireMinRole(w, r, "viewer") {
+		return
+	}
 	workspaceID, ok := s.getWorkspaceID(w, r)
 	if !ok {
 		return
@@ -91,6 +95,9 @@ func (s *Server) handleCreateDocument(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleGetDocument(w http.ResponseWriter, r *http.Request) {
+	if !requireMinRole(w, r, "viewer") {
+		return
+	}
 	_, doc, ok := s.getWorkspaceDocument(w, r)
 	if !ok {
 		return
@@ -263,6 +270,9 @@ func (s *Server) handleQuickSave(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleBulkRead(w http.ResponseWriter, r *http.Request) {
+	if !requireMinRole(w, r, "viewer") {
+		return
+	}
 	var input struct {
 		IDs []string `json:"ids"`
 	}
@@ -283,6 +293,9 @@ func (s *Server) handleBulkRead(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleGetBacklinks(w http.ResponseWriter, r *http.Request) {
+	if !requireMinRole(w, r, "viewer") {
+		return
+	}
 	workspaceID, doc, ok := s.getWorkspaceDocument(w, r)
 	if !ok {
 		return
@@ -312,6 +325,9 @@ func (s *Server) handleGetBacklinks(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleGetLinks(w http.ResponseWriter, r *http.Request) {
+	if !requireMinRole(w, r, "viewer") {
+		return
+	}
 	workspaceID, doc, ok := s.getWorkspaceDocument(w, r)
 	if !ok {
 		return
@@ -329,6 +345,9 @@ func (s *Server) handleGetLinks(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleGetContext(w http.ResponseWriter, r *http.Request) {
+	if !requireMinRole(w, r, "viewer") {
+		return
+	}
 	workspaceID, ok := s.getWorkspaceID(w, r)
 	if !ok {
 		return

--- a/internal/server/handlers_events.go
+++ b/internal/server/handlers_events.go
@@ -105,21 +105,51 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// For guests with item-level grants, build a set of granted item IDs
-	// so we can filter events at item granularity, not just collection.
+	// For users with item-level grants (guests or restricted members), build
+	// a set of granted item IDs for event filtering at item granularity.
 	var sseGrantedItemSet map[string]bool // nil = no item-level filtering
 	var sseFullCollSet map[string]bool    // collection slugs with full grants
+	isGuestSSE := false
 	if user := currentUser(r); user != nil {
-		isMember, _ := s.store.IsWorkspaceMember(ws.ID, user.ID)
-		if !isMember {
+		member, _ := s.store.GetWorkspaceMember(ws.ID, user.ID)
+		if member == nil {
+			isGuestSSE = true
+		}
+
+		// Determine if this user needs item-level filtering:
+		// - guests always do
+		// - restricted members only if they have item grants
+		needsItemFilter := member == nil // guest
+		if member != nil && member.CollectionAccess == "specific" {
+			_, itemGrants, _ := s.store.GuestVisibleResources(ws.ID, user.ID)
+			needsItemFilter = len(itemGrants) > 0
+		}
+
+		if needsItemFilter {
 			fullCollIDs, grantedItemIDs, grantErr := s.store.GuestVisibleResources(ws.ID, user.ID)
 			if grantErr == nil && len(grantedItemIDs) > 0 {
 				sseGrantedItemSet = make(map[string]bool, len(grantedItemIDs))
 				for _, id := range grantedItemIDs {
 					sseGrantedItemSet[id] = true
 				}
-				sseFullCollSet = make(map[string]bool, len(fullCollIDs))
+				// Build the full-access collection slug set. For restricted members,
+				// include their member_collection_access + system collections too.
+				fullCollIDSet := make(map[string]bool)
 				for _, id := range fullCollIDs {
+					fullCollIDSet[id] = true
+				}
+				if member != nil {
+					memberColls, _ := s.store.GetMemberCollectionAccess(ws.ID, user.ID)
+					sysColls, _ := s.store.ListSystemCollectionIDs(ws.ID)
+					for _, id := range memberColls {
+						fullCollIDSet[id] = true
+					}
+					for _, id := range sysColls {
+						fullCollIDSet[id] = true
+					}
+				}
+				sseFullCollSet = make(map[string]bool, len(fullCollIDSet))
+				for id := range fullCollIDSet {
 					coll, _ := s.store.GetCollection(id)
 					if coll != nil {
 						sseFullCollSet[coll.Slug] = true
@@ -127,13 +157,6 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 				}
 			}
 		}
-	}
-
-	// isGuestSSE is true when the connected user is a guest (non-member with grants).
-	isGuestSSE := false
-	if user := currentUser(r); user != nil {
-		isMem, _ := s.store.IsWorkspaceMember(ws.ID, user.ID)
-		isGuestSSE = !isMem
 	}
 
 	// sseEventVisible checks if an event should be sent to this client.

--- a/internal/server/handlers_events.go
+++ b/internal/server/handlers_events.go
@@ -127,7 +127,13 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 
 		if needsItemFilter {
 			fullCollIDs, grantedItemIDs, grantErr := s.store.GuestVisibleResources(ws.ID, user.ID)
-			if grantErr == nil && len(grantedItemIDs) > 0 {
+			if grantErr != nil {
+				// Fail closed: if we can't resolve grants, install an empty
+				// item filter so no collection-scoped events leak through.
+				slog.Warn("SSE: failed to resolve item grants, denying item-scoped events", "error", grantErr)
+				sseGrantedItemSet = make(map[string]bool) // empty = deny all
+				sseFullCollSet = make(map[string]bool)    // empty = no full-access collections
+			} else if len(grantedItemIDs) > 0 {
 				sseGrantedItemSet = make(map[string]bool, len(grantedItemIDs))
 				for _, id := range grantedItemIDs {
 					sseGrantedItemSet[id] = true

--- a/internal/server/handlers_events.go
+++ b/internal/server/handlers_events.go
@@ -105,15 +105,46 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// For guests with item-level grants, build a set of granted item IDs
+	// so we can filter events at item granularity, not just collection.
+	var sseGrantedItemSet map[string]bool // nil = no item-level filtering
+	var sseFullCollSet map[string]bool    // collection slugs with full grants
+	if user := currentUser(r); user != nil {
+		isMember, _ := s.store.IsWorkspaceMember(ws.ID, user.ID)
+		if !isMember {
+			fullCollIDs, grantedItemIDs, grantErr := s.store.GuestVisibleResources(ws.ID, user.ID)
+			if grantErr == nil && len(grantedItemIDs) > 0 {
+				sseGrantedItemSet = make(map[string]bool, len(grantedItemIDs))
+				for _, id := range grantedItemIDs {
+					sseGrantedItemSet[id] = true
+				}
+				sseFullCollSet = make(map[string]bool, len(fullCollIDs))
+				for _, id := range fullCollIDs {
+					coll, _ := s.store.GetCollection(id)
+					if coll != nil {
+						sseFullCollSet[coll.Slug] = true
+					}
+				}
+			}
+		}
+	}
+
 	// sseEventVisible checks if an event should be sent to this client.
-	sseEventVisible := func(collection string) bool {
+	sseEventVisible := func(collection, itemID string) bool {
 		if visibleSlugSet == nil {
 			return true // all access
 		}
 		if collection == "" {
 			return true // events without a collection are always sent
 		}
-		return visibleSlugSet[collection]
+		if !visibleSlugSet[collection] {
+			return false
+		}
+		// For guests with item-level grants, additionally check the item ID
+		if sseGrantedItemSet != nil && !sseFullCollSet[collection] && itemID != "" {
+			return sseGrantedItemSet[itemID]
+		}
+		return true
 	}
 
 	// Send initial connected event
@@ -141,7 +172,7 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 				slog.Info("SSE replaying missed events",
 					"workspace", ws.Slug, "last_event_id", lastID, "count", len(missed))
 				for _, event := range missed {
-					if sseEventVisible(event.Collection) {
+					if sseEventVisible(event.Collection, event.ItemID) {
 						writeSSEEvent(w, event.Type, event.ID, event)
 						flusher.Flush()
 					}
@@ -167,7 +198,7 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 				// Channel closed (unsubscribed)
 				return
 			}
-			if sseEventVisible(event.Collection) {
+			if sseEventVisible(event.Collection, event.ItemID) {
 				writeSSEEvent(w, event.Type, event.ID, event)
 				flusher.Flush()
 			}

--- a/internal/server/handlers_events.go
+++ b/internal/server/handlers_events.go
@@ -129,13 +129,26 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// isGuestSSE is true when the connected user is a guest (non-member with grants).
+	isGuestSSE := false
+	if user := currentUser(r); user != nil {
+		isMem, _ := s.store.IsWorkspaceMember(ws.ID, user.ID)
+		isGuestSSE = !isMem
+	}
+
 	// sseEventVisible checks if an event should be sent to this client.
 	sseEventVisible := func(collection, itemID string) bool {
 		if visibleSlugSet == nil {
 			return true // all access
 		}
 		if collection == "" {
-			return true // events without a collection are always sent
+			// Events without a collection (workspace-level, legacy docs) are
+			// only sent to actual members, not guests — they may contain
+			// operational metadata like member invites, role changes, etc.
+			if isGuestSSE {
+				return false
+			}
+			return true
 		}
 		if !visibleSlugSet[collection] {
 			return false

--- a/internal/server/handlers_grants.go
+++ b/internal/server/handlers_grants.go
@@ -10,6 +10,9 @@ import (
 // --- Collection Grant handlers ---
 
 func (s *Server) handleListCollectionGrants(w http.ResponseWriter, r *http.Request) {
+	if !requireMinRole(w, r, "owner") {
+		return
+	}
 	workspaceID, ok := s.getWorkspaceID(w, r)
 	if !ok {
 		return
@@ -104,9 +107,13 @@ func (s *Server) handleDeleteCollectionGrant(w http.ResponseWriter, r *http.Requ
 	if !requireMinRole(w, r, "owner") {
 		return
 	}
+	workspaceID, ok := s.getWorkspaceID(w, r)
+	if !ok {
+		return
+	}
 
 	grantID := chi.URLParam(r, "grantID")
-	if err := s.store.DeleteCollectionGrant(grantID); err != nil {
+	if err := s.store.DeleteCollectionGrant(grantID, workspaceID); err != nil {
 		writeError(w, http.StatusNotFound, "not_found", "Grant not found")
 		return
 	}
@@ -116,6 +123,9 @@ func (s *Server) handleDeleteCollectionGrant(w http.ResponseWriter, r *http.Requ
 // --- Item Grant handlers ---
 
 func (s *Server) handleListItemGrants(w http.ResponseWriter, r *http.Request) {
+	if !requireMinRole(w, r, "owner") {
+		return
+	}
 	workspaceID, ok := s.getWorkspaceID(w, r)
 	if !ok {
 		return
@@ -209,9 +219,13 @@ func (s *Server) handleDeleteItemGrant(w http.ResponseWriter, r *http.Request) {
 	if !requireMinRole(w, r, "owner") {
 		return
 	}
+	workspaceID, ok := s.getWorkspaceID(w, r)
+	if !ok {
+		return
+	}
 
 	grantID := chi.URLParam(r, "grantID")
-	if err := s.store.DeleteItemGrant(grantID); err != nil {
+	if err := s.store.DeleteItemGrant(grantID, workspaceID); err != nil {
 		writeError(w, http.StatusNotFound, "not_found", "Grant not found")
 		return
 	}
@@ -227,6 +241,13 @@ func (s *Server) handleListUserGrants(w http.ResponseWriter, r *http.Request) {
 	}
 
 	userID := chi.URLParam(r, "userID")
+
+	// Only workspace owners or the user themselves can view grants
+	if !requireRole(r, "owner") && currentUserID(r) != userID {
+		writeError(w, http.StatusForbidden, "forbidden", "Insufficient permissions")
+		return
+	}
+
 	collGrants, itemGrants, err := s.store.ListUserGrants(workspaceID, userID)
 	if err != nil {
 		writeInternalError(w, err)

--- a/internal/server/handlers_grants.go
+++ b/internal/server/handlers_grants.go
@@ -1,0 +1,246 @@
+package server
+
+import (
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/xarmian/pad/internal/models"
+)
+
+// --- Collection Grant handlers ---
+
+func (s *Server) handleListCollectionGrants(w http.ResponseWriter, r *http.Request) {
+	workspaceID, ok := s.getWorkspaceID(w, r)
+	if !ok {
+		return
+	}
+
+	collSlug := chi.URLParam(r, "collSlug")
+	coll, err := s.store.GetCollectionBySlug(workspaceID, collSlug)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	if coll == nil {
+		writeError(w, http.StatusNotFound, "not_found", "Collection not found")
+		return
+	}
+
+	grants, err := s.store.ListCollectionGrants(coll.ID)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, grants)
+}
+
+func (s *Server) handleCreateCollectionGrant(w http.ResponseWriter, r *http.Request) {
+	if !requireMinRole(w, r, "owner") {
+		return
+	}
+	workspaceID, ok := s.getWorkspaceID(w, r)
+	if !ok {
+		return
+	}
+
+	collSlug := chi.URLParam(r, "collSlug")
+	coll, err := s.store.GetCollectionBySlug(workspaceID, collSlug)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	if coll == nil {
+		writeError(w, http.StatusNotFound, "not_found", "Collection not found")
+		return
+	}
+
+	var input struct {
+		UserID     string `json:"user_id"`
+		Email      string `json:"email"`
+		Permission string `json:"permission"`
+	}
+	if err := decodeJSON(r, &input); err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", err.Error())
+		return
+	}
+
+	if input.Permission == "" {
+		input.Permission = "view"
+	}
+	if input.Permission != "view" && input.Permission != "edit" {
+		writeError(w, http.StatusBadRequest, "validation_error", "Permission must be 'view' or 'edit'")
+		return
+	}
+
+	// Resolve user by ID or email
+	userID := input.UserID
+	if userID == "" && input.Email != "" {
+		user, err := s.store.GetUserByEmail(input.Email)
+		if err != nil {
+			writeInternalError(w, err)
+			return
+		}
+		if user == nil {
+			writeError(w, http.StatusNotFound, "not_found", "User not found")
+			return
+		}
+		userID = user.ID
+	}
+	if userID == "" {
+		writeError(w, http.StatusBadRequest, "validation_error", "user_id or email is required")
+		return
+	}
+
+	grant, err := s.store.CreateCollectionGrant(workspaceID, coll.ID, userID, input.Permission, currentUserID(r))
+	if err != nil {
+		writeError(w, http.StatusConflict, "conflict", "Grant already exists or failed to create")
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, grant)
+}
+
+func (s *Server) handleDeleteCollectionGrant(w http.ResponseWriter, r *http.Request) {
+	if !requireMinRole(w, r, "owner") {
+		return
+	}
+
+	grantID := chi.URLParam(r, "grantID")
+	if err := s.store.DeleteCollectionGrant(grantID); err != nil {
+		writeError(w, http.StatusNotFound, "not_found", "Grant not found")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// --- Item Grant handlers ---
+
+func (s *Server) handleListItemGrants(w http.ResponseWriter, r *http.Request) {
+	workspaceID, ok := s.getWorkspaceID(w, r)
+	if !ok {
+		return
+	}
+
+	itemSlug := chi.URLParam(r, "itemSlug")
+	item, err := s.store.ResolveItem(workspaceID, itemSlug)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	if item == nil {
+		writeError(w, http.StatusNotFound, "not_found", "Item not found")
+		return
+	}
+
+	grants, err := s.store.ListItemGrants(item.ID)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, grants)
+}
+
+func (s *Server) handleCreateItemGrant(w http.ResponseWriter, r *http.Request) {
+	if !requireMinRole(w, r, "owner") {
+		return
+	}
+	workspaceID, ok := s.getWorkspaceID(w, r)
+	if !ok {
+		return
+	}
+
+	itemSlug := chi.URLParam(r, "itemSlug")
+	item, err := s.store.ResolveItem(workspaceID, itemSlug)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	if item == nil {
+		writeError(w, http.StatusNotFound, "not_found", "Item not found")
+		return
+	}
+
+	var input struct {
+		UserID     string `json:"user_id"`
+		Email      string `json:"email"`
+		Permission string `json:"permission"`
+	}
+	if err := decodeJSON(r, &input); err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", err.Error())
+		return
+	}
+
+	if input.Permission == "" {
+		input.Permission = "view"
+	}
+	if input.Permission != "view" && input.Permission != "edit" {
+		writeError(w, http.StatusBadRequest, "validation_error", "Permission must be 'view' or 'edit'")
+		return
+	}
+
+	userID := input.UserID
+	if userID == "" && input.Email != "" {
+		user, err := s.store.GetUserByEmail(input.Email)
+		if err != nil {
+			writeInternalError(w, err)
+			return
+		}
+		if user == nil {
+			writeError(w, http.StatusNotFound, "not_found", "User not found")
+			return
+		}
+		userID = user.ID
+	}
+	if userID == "" {
+		writeError(w, http.StatusBadRequest, "validation_error", "user_id or email is required")
+		return
+	}
+
+	grant, err := s.store.CreateItemGrant(workspaceID, item.ID, userID, input.Permission, currentUserID(r))
+	if err != nil {
+		writeError(w, http.StatusConflict, "conflict", "Grant already exists or failed to create")
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, grant)
+}
+
+func (s *Server) handleDeleteItemGrant(w http.ResponseWriter, r *http.Request) {
+	if !requireMinRole(w, r, "owner") {
+		return
+	}
+
+	grantID := chi.URLParam(r, "grantID")
+	if err := s.store.DeleteItemGrant(grantID); err != nil {
+		writeError(w, http.StatusNotFound, "not_found", "Grant not found")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// --- User grants (cross-cutting) ---
+
+func (s *Server) handleListUserGrants(w http.ResponseWriter, r *http.Request) {
+	workspaceID, ok := s.getWorkspaceID(w, r)
+	if !ok {
+		return
+	}
+
+	userID := chi.URLParam(r, "userID")
+	collGrants, itemGrants, err := s.store.ListUserGrants(workspaceID, userID)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	if collGrants == nil {
+		collGrants = []models.CollectionGrant{}
+	}
+	if itemGrants == nil {
+		itemGrants = []models.ItemGrant{}
+	}
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"collection_grants": collGrants,
+		"item_grants":       itemGrants,
+	})
+}

--- a/internal/server/handlers_item_links.go
+++ b/internal/server/handlers_item_links.go
@@ -198,16 +198,25 @@ func (s *Server) handleDeleteItemLink(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Verify both linked items are in visible collections
+	// Verify both linked items are in visible collections (with item-level checks for guests)
 	visibleIDs, visErr := s.visibleCollectionIDs(r, workspaceID)
 	if visErr != nil {
 		writeInternalError(w, visErr)
+		return
+	}
+	delFullCollIDs, delGrantedItemIDs, delGrantErr := s.guestResourceFilter(r, workspaceID)
+	if delGrantErr != nil {
+		writeInternalError(w, delGrantErr)
 		return
 	}
 	if visibleIDs != nil {
 		for _, itemID := range []string{link.SourceID, link.TargetID} {
 			item, ierr := s.store.GetItem(itemID)
 			if ierr != nil || item == nil || !isCollectionVisible(item.CollectionID, visibleIDs) {
+				writeError(w, http.StatusNotFound, "not_found", "Link not found")
+				return
+			}
+			if !s.isItemVisibleToGuest(r, workspaceID, item, delFullCollIDs, delGrantedItemIDs) {
 				writeError(w, http.StatusNotFound, "not_found", "Link not found")
 				return
 			}

--- a/internal/server/handlers_item_links.go
+++ b/internal/server/handlers_item_links.go
@@ -68,9 +68,6 @@ func (s *Server) handleGetItemLinks(w http.ResponseWriter, r *http.Request) {
 
 // handleCreateItemLink creates a new link between two items.
 func (s *Server) handleCreateItemLink(w http.ResponseWriter, r *http.Request) {
-	if !requireMinRole(w, r, "editor") {
-		return
-	}
 	workspaceID, ok := s.getWorkspaceID(w, r)
 	if !ok {
 		return
@@ -87,6 +84,10 @@ func (s *Server) handleCreateItemLink(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if !s.requireItemVisible(w, r, workspaceID, item) {
+		return
+	}
+	// Check edit permission (grant-aware for guests)
+	if !s.requireEditPermission(w, r, workspaceID, item.ID, item.CollectionID) {
 		return
 	}
 
@@ -162,9 +163,6 @@ func (s *Server) handleCreateItemLink(w http.ResponseWriter, r *http.Request) {
 
 // handleDeleteItemLink removes a link between items.
 func (s *Server) handleDeleteItemLink(w http.ResponseWriter, r *http.Request) {
-	if !requireMinRole(w, r, "editor") {
-		return
-	}
 	workspaceID, ok := s.getWorkspaceID(w, r)
 	if !ok {
 		return
@@ -176,6 +174,15 @@ func (s *Server) handleDeleteItemLink(w http.ResponseWriter, r *http.Request) {
 	link, err := s.store.GetItemLinkByID(linkID)
 	if err != nil || link == nil || link.WorkspaceID != workspaceID {
 		writeError(w, http.StatusNotFound, "not_found", "Link not found")
+		return
+	}
+
+	// Check edit permission on the source item (grant-aware for guests)
+	if sourceItem, ierr := s.store.GetItem(link.SourceID); ierr == nil && sourceItem != nil {
+		if !s.requireEditPermission(w, r, workspaceID, sourceItem.ID, sourceItem.CollectionID) {
+			return
+		}
+	} else if !requireMinRole(w, r, "editor") {
 		return
 	}
 

--- a/internal/server/handlers_item_links.go
+++ b/internal/server/handlers_item_links.go
@@ -41,9 +41,15 @@ func (s *Server) handleGetItemLinks(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Filter out links where the linked item is in a hidden collection
+	// or (for guests with item-level grants) the linked item is not granted.
 	visibleIDs, visErr := s.visibleCollectionIDs(r, workspaceID)
 	if visErr != nil {
 		writeInternalError(w, visErr)
+		return
+	}
+	fullCollIDs, grantedItemIDs, grantErr := s.guestResourceFilter(r, workspaceID)
+	if grantErr != nil {
+		writeInternalError(w, grantErr)
 		return
 	}
 	if visibleIDs != nil {
@@ -55,9 +61,15 @@ func (s *Server) handleGetItemLinks(w http.ResponseWriter, r *http.Request) {
 				otherID = link.SourceID
 			}
 			if other, err := s.store.GetItem(otherID); err == nil && other != nil {
-				if isCollectionVisible(other.CollectionID, visibleIDs) {
-					filtered = append(filtered, link)
+				if !isCollectionVisible(other.CollectionID, visibleIDs) {
+					continue
 				}
+				// For guests: if the collection is only visible via item grants,
+				// check the specific item is granted.
+				if !s.isItemVisibleToGuest(r, workspaceID, other, fullCollIDs, grantedItemIDs) {
+					continue
+				}
+				filtered = append(filtered, link)
 			}
 		}
 		links = filtered

--- a/internal/server/handlers_item_versions.go
+++ b/internal/server/handlers_item_versions.go
@@ -44,9 +44,6 @@ func (s *Server) handleListItemVersions(w http.ResponseWriter, r *http.Request) 
 
 // handleRestoreItemVersion restores an item's content from a specific version.
 func (s *Server) handleRestoreItemVersion(w http.ResponseWriter, r *http.Request) {
-	if !requireMinRole(w, r, "editor") {
-		return
-	}
 	workspaceID, ok := s.getWorkspaceID(w, r)
 	if !ok {
 		return
@@ -65,6 +62,10 @@ func (s *Server) handleRestoreItemVersion(w http.ResponseWriter, r *http.Request
 		return
 	}
 	if !s.requireItemVisible(w, r, workspaceID, item) {
+		return
+	}
+	// Check edit permission (grant-aware for guests)
+	if !s.requireEditPermission(w, r, workspaceID, item.ID, item.CollectionID) {
 		return
 	}
 

--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -38,20 +38,16 @@ func (s *Server) handleListItems(w http.ResponseWriter, r *http.Request) {
 	}
 	params.CollectionIDs = visibleIDs
 
-	// For guests, apply item-level filtering so item grants don't leak
-	// entire collections. GuestVisibleResources returns both full-collection
-	// IDs and individual item IDs; we set CollectionIDs to only the
-	// full-collection grants and add ItemIDs for specific item grants.
-	if workspaceRole(r) == "guest" {
-		if user := currentUser(r); user != nil {
-			fullCollIDs, grantedItemIDs, grantErr := s.store.GuestVisibleResources(workspaceID, user.ID)
-			if grantErr != nil {
-				writeInternalError(w, grantErr)
-				return
-			}
-			params.CollectionIDs = fullCollIDs
-			params.ItemIDs = grantedItemIDs
-		}
+	// Apply item-level filtering for users with item grants (guests or
+	// restricted members) so item grants don't leak entire collections.
+	fullCollIDs, grantedItemIDs, grantErr := s.guestResourceFilter(r, workspaceID)
+	if grantErr != nil {
+		writeInternalError(w, grantErr)
+		return
+	}
+	if len(grantedItemIDs) > 0 {
+		params.CollectionIDs = fullCollIDs
+		params.ItemIDs = grantedItemIDs
 	}
 
 	result, err := s.store.ListItems(workspaceID, params)
@@ -99,26 +95,34 @@ func (s *Server) handleListCollectionItems(w http.ResponseWriter, r *http.Reques
 	params := parseItemListParams(r)
 	params.CollectionSlug = collSlug
 
-	// For guests, if this collection's visibility comes from item-level grants
-	// (not a full collection grant), restrict to only the granted items.
-	if workspaceRole(r) == "guest" {
-		if user := currentUser(r); user != nil {
-			fullCollIDs, grantedItemIDs, grantErr := s.store.GuestVisibleResources(workspaceID, user.ID)
-			if grantErr != nil {
-				writeInternalError(w, grantErr)
-				return
+	// For users with item-level grants, if this collection's visibility comes
+	// from item-level grants (not a full collection grant), restrict to only
+	// the granted items. Applies to both guests and restricted members.
+	lcFullCollIDs, lcGrantedItemIDs, lcGrantErr := s.guestResourceFilter(r, workspaceID)
+	if lcGrantErr != nil {
+		writeInternalError(w, lcGrantErr)
+		return
+	}
+	if len(lcGrantedItemIDs) > 0 {
+		hasFullCollectionGrant := false
+		for _, id := range lcFullCollIDs {
+			if id == coll.ID {
+				hasFullCollectionGrant = true
+				break
 			}
-			hasFullCollectionGrant := false
-			for _, id := range fullCollIDs {
+		}
+		// Also check member_collection_access for restricted members
+		if !hasFullCollectionGrant && workspaceRole(r) != "guest" {
+			memberColls, _ := s.store.GetMemberCollectionAccess(workspaceID, currentUserID(r))
+			for _, id := range memberColls {
 				if id == coll.ID {
 					hasFullCollectionGrant = true
 					break
 				}
 			}
-			if !hasFullCollectionGrant {
-				// Only show the specific items the guest has grants on
-				params.ItemIDs = grantedItemIDs
-			}
+		}
+		if !hasFullCollectionGrant {
+			params.ItemIDs = lcGrantedItemIDs
 		}
 	}
 

--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -38,6 +38,22 @@ func (s *Server) handleListItems(w http.ResponseWriter, r *http.Request) {
 	}
 	params.CollectionIDs = visibleIDs
 
+	// For guests, apply item-level filtering so item grants don't leak
+	// entire collections. GuestVisibleResources returns both full-collection
+	// IDs and individual item IDs; we set CollectionIDs to only the
+	// full-collection grants and add ItemIDs for specific item grants.
+	if workspaceRole(r) == "guest" {
+		if user := currentUser(r); user != nil {
+			fullCollIDs, grantedItemIDs, grantErr := s.store.GuestVisibleResources(workspaceID, user.ID)
+			if grantErr != nil {
+				writeInternalError(w, grantErr)
+				return
+			}
+			params.CollectionIDs = fullCollIDs
+			params.ItemIDs = grantedItemIDs
+		}
+	}
+
 	result, err := s.store.ListItems(workspaceID, params)
 	if err != nil {
 		writeInternalError(w, err)
@@ -83,6 +99,29 @@ func (s *Server) handleListCollectionItems(w http.ResponseWriter, r *http.Reques
 	params := parseItemListParams(r)
 	params.CollectionSlug = collSlug
 
+	// For guests, if this collection's visibility comes from item-level grants
+	// (not a full collection grant), restrict to only the granted items.
+	if workspaceRole(r) == "guest" {
+		if user := currentUser(r); user != nil {
+			fullCollIDs, grantedItemIDs, grantErr := s.store.GuestVisibleResources(workspaceID, user.ID)
+			if grantErr != nil {
+				writeInternalError(w, grantErr)
+				return
+			}
+			hasFullCollectionGrant := false
+			for _, id := range fullCollIDs {
+				if id == coll.ID {
+					hasFullCollectionGrant = true
+					break
+				}
+			}
+			if !hasFullCollectionGrant {
+				// Only show the specific items the guest has grants on
+				params.ItemIDs = grantedItemIDs
+			}
+		}
+	}
+
 	var collSchema models.CollectionSchema
 	if coll.Schema != "" {
 		_ = json.Unmarshal([]byte(coll.Schema), &collSchema)
@@ -107,9 +146,6 @@ func (s *Server) handleListCollectionItems(w http.ResponseWriter, r *http.Reques
 
 // handleCreateItem creates a new item in a collection, validating fields against the schema.
 func (s *Server) handleCreateItem(w http.ResponseWriter, r *http.Request) {
-	if !requireMinRole(w, r, "editor") {
-		return
-	}
 	workspaceID, ok := s.getWorkspaceID(w, r)
 	if !ok {
 		return
@@ -123,6 +159,11 @@ func (s *Server) handleCreateItem(w http.ResponseWriter, r *http.Request) {
 	}
 	if coll == nil {
 		writeError(w, http.StatusNotFound, "not_found", "Collection not found")
+		return
+	}
+
+	// Check edit permission (grant-aware for guests)
+	if !s.requireEditPermission(w, r, workspaceID, "", coll.ID) {
 		return
 	}
 
@@ -281,9 +322,6 @@ func (s *Server) handleGetItem(w http.ResponseWriter, r *http.Request) {
 
 // handleUpdateItem updates an existing item (fields, content, or both).
 func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
-	if !requireMinRole(w, r, "editor") {
-		return
-	}
 	workspaceID, ok := s.getWorkspaceID(w, r)
 	if !ok {
 		return
@@ -300,6 +338,10 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if !s.requireItemVisible(w, r, workspaceID, item) {
+		return
+	}
+	// Check edit permission (grant-aware for guests)
+	if !s.requireEditPermission(w, r, workspaceID, item.ID, item.CollectionID) {
 		return
 	}
 
@@ -478,9 +520,6 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 
 // handleDeleteItem archives (soft-deletes) an item.
 func (s *Server) handleDeleteItem(w http.ResponseWriter, r *http.Request) {
-	if !requireMinRole(w, r, "editor") {
-		return
-	}
 	workspaceID, ok := s.getWorkspaceID(w, r)
 	if !ok {
 		return
@@ -499,6 +538,10 @@ func (s *Server) handleDeleteItem(w http.ResponseWriter, r *http.Request) {
 	if !s.requireItemVisible(w, r, workspaceID, item) {
 		return
 	}
+	// Check edit permission (grant-aware for guests)
+	if !s.requireEditPermission(w, r, workspaceID, item.ID, item.CollectionID) {
+		return
+	}
 
 	if err := s.store.DeleteItem(item.ID); err != nil {
 		writeInternalError(w, err)
@@ -515,9 +558,6 @@ func (s *Server) handleDeleteItem(w http.ResponseWriter, r *http.Request) {
 
 // handleRestoreItem restores an archived item.
 func (s *Server) handleRestoreItem(w http.ResponseWriter, r *http.Request) {
-	if !requireMinRole(w, r, "editor") {
-		return
-	}
 	workspaceID, ok := s.getWorkspaceID(w, r)
 	if !ok {
 		return
@@ -536,6 +576,10 @@ func (s *Server) handleRestoreItem(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if !s.requireItemVisible(w, r, workspaceID, item) {
+		return
+	}
+	// Check edit permission (grant-aware for guests)
+	if !s.requireEditPermission(w, r, workspaceID, item.ID, item.CollectionID) {
 		return
 	}
 
@@ -564,9 +608,6 @@ func (s *Server) handleRestoreItem(w http.ResponseWriter, r *http.Request) {
 
 // handleMoveItem moves an item to a different collection with field migration.
 func (s *Server) handleMoveItem(w http.ResponseWriter, r *http.Request) {
-	if !requireMinRole(w, r, "editor") {
-		return
-	}
 	workspaceID, ok := s.getWorkspaceID(w, r)
 	if !ok {
 		return
@@ -579,6 +620,10 @@ func (s *Server) handleMoveItem(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if !s.requireItemVisible(w, r, workspaceID, item) {
+		return
+	}
+	// Check edit permission (grant-aware for guests)
+	if !s.requireEditPermission(w, r, workspaceID, item.ID, item.CollectionID) {
 		return
 	}
 

--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -640,7 +640,7 @@ func (s *Server) handleMoveItem(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Get target collection and verify it's visible to the user
+	// Get target collection, verify it's visible, and check edit permission
 	targetColl, err := s.store.GetCollectionBySlug(workspaceID, input.TargetCollection)
 	if err != nil || targetColl == nil {
 		writeError(w, http.StatusBadRequest, "invalid_collection", "Target collection not found")
@@ -653,6 +653,10 @@ func (s *Server) handleMoveItem(w http.ResponseWriter, r *http.Request) {
 	}
 	if !isCollectionVisible(targetColl.ID, targetVisibleIDs) {
 		writeError(w, http.StatusBadRequest, "invalid_collection", "Target collection not found")
+		return
+	}
+	// Require edit permission on the target collection (not just visibility)
+	if !s.requireEditPermission(w, r, workspaceID, "", targetColl.ID) {
 		return
 	}
 
@@ -848,18 +852,27 @@ func (s *Server) handleGetItemChildren(w http.ResponseWriter, r *http.Request) {
 		children = []models.Item{}
 	}
 
-	// Filter children by collection visibility
+	// Filter children by collection visibility and item-level grants
 	visibleIDs, visErr := s.visibleCollectionIDs(r, workspaceID)
 	if visErr != nil {
 		writeInternalError(w, visErr)
 		return
 	}
+	fullCollIDs, grantedItemIDs, grantErr := s.guestResourceFilter(r, workspaceID)
+	if grantErr != nil {
+		writeInternalError(w, grantErr)
+		return
+	}
 	if visibleIDs != nil {
 		filtered := children[:0]
 		for _, child := range children {
-			if isCollectionVisible(child.CollectionID, visibleIDs) {
-				filtered = append(filtered, child)
+			if !isCollectionVisible(child.CollectionID, visibleIDs) {
+				continue
 			}
+			if !s.isItemVisibleToGuest(r, workspaceID, &child, fullCollIDs, grantedItemIDs) {
+				continue
+			}
+			filtered = append(filtered, child)
 		}
 		children = filtered
 	}
@@ -871,10 +884,14 @@ func (s *Server) handleGetItemChildren(w http.ResponseWriter, r *http.Request) {
 			grandchildren, _ := s.store.GetChildItems(children[i].ID)
 			children[i].HasChildren = false
 			for _, gc := range grandchildren {
-				if isCollectionVisible(gc.CollectionID, visibleIDs) {
-					children[i].HasChildren = true
-					break
+				if !isCollectionVisible(gc.CollectionID, visibleIDs) {
+					continue
 				}
+				if !s.isItemVisibleToGuest(r, workspaceID, &gc, fullCollIDs, grantedItemIDs) {
+					continue
+				}
+				children[i].HasChildren = true
+				break
 			}
 		}
 	} else {
@@ -908,6 +925,11 @@ func (s *Server) handleGetItemProgress(w http.ResponseWriter, r *http.Request) {
 	// Get visibility filter; when restricted, compute progress from
 	// visible children only so hidden child counts don't leak.
 	progVisIDs, _ := s.visibleCollectionIDs(r, workspaceID)
+	progFullCollIDs, progGrantedItemIDs, progGrantErr := s.guestResourceFilter(r, workspaceID)
+	if progGrantErr != nil {
+		writeInternalError(w, progGrantErr)
+		return
+	}
 	if progVisIDs != nil {
 		// Restricted: compute from visible children in Go using per-collection
 		// schemas to determine terminal statuses correctly.
@@ -921,6 +943,9 @@ func (s *Server) handleGetItemProgress(w http.ResponseWriter, r *http.Request) {
 		total, done := 0, 0
 		for _, child := range children {
 			if !isCollectionVisible(child.CollectionID, progVisIDs) {
+				continue
+			}
+			if !s.isItemVisibleToGuest(r, workspaceID, &child, progFullCollIDs, progGrantedItemIDs) {
 				continue
 			}
 			total++

--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -773,6 +773,11 @@ func (s *Server) handlePlansProgress(w http.ResponseWriter, r *http.Request) {
 		writeInternalError(w, err)
 		return
 	}
+	ppFullCollIDs, ppGrantedItemIDs, ppGrantErr := s.guestResourceFilter(r, workspaceID)
+	if ppGrantErr != nil {
+		writeInternalError(w, ppGrantErr)
+		return
+	}
 	if visibleIDs != nil {
 		plansColl, _ := s.store.GetCollectionBySlug(workspaceID, "plans")
 		if plansColl == nil || !isCollectionVisible(plansColl.ID, visibleIDs) {
@@ -789,6 +794,30 @@ func (s *Server) handlePlansProgress(w http.ResponseWriter, r *http.Request) {
 			writeInternalError(w, err)
 			return
 		}
+
+		// For guests with item-level grants, filter plans themselves
+		if len(ppGrantedItemIDs) > 0 {
+			ppGrantedSet := make(map[string]bool, len(ppGrantedItemIDs))
+			for _, id := range ppGrantedItemIDs {
+				ppGrantedSet[id] = true
+			}
+			ppFullSet := make(map[string]bool, len(ppFullCollIDs))
+			for _, id := range ppFullCollIDs {
+				ppFullSet[id] = true
+			}
+			// Check if plans collection has a full grant
+			plansColl, _ := s.store.GetCollectionBySlug(workspaceID, "plans")
+			if plansColl != nil && !ppFullSet[plansColl.ID] {
+				filtered := allProgress[:0]
+				for _, p := range allProgress {
+					if ppGrantedSet[p.ItemID] {
+						filtered = append(filtered, p)
+					}
+				}
+				allProgress = filtered
+			}
+		}
+
 		// Recompute each plan's progress using only visible children
 		for i, p := range allProgress {
 			children, cerr := s.store.GetChildItems(p.ItemID)
@@ -798,6 +827,9 @@ func (s *Server) handlePlansProgress(w http.ResponseWriter, r *http.Request) {
 			total, done := 0, 0
 			for _, child := range children {
 				if !isCollectionVisible(child.CollectionID, visibleIDs) {
+					continue
+				}
+				if !s.isItemVisibleToGuest(r, workspaceID, &child, ppFullCollIDs, ppGrantedItemIDs) {
 					continue
 				}
 				total++

--- a/internal/server/handlers_members.go
+++ b/internal/server/handlers_members.go
@@ -199,22 +199,20 @@ func (s *Server) handleRemoveMember(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := s.store.RemoveWorkspaceMember(workspaceID, userID); err != nil {
-		writeError(w, http.StatusNotFound, "not_found", "Member not found")
-		return
-	}
-
 	// Default to revoking grants on member removal to prevent the removed user
 	// from silently becoming a guest with continued access.
 	// ?revoke_grants=false → explicitly keep grants (user becomes a guest)
 	// ?revoke_grants=true or omitted → delete all grants (full removal)
 	revokeGrants := r.URL.Query().Get("revoke_grants") != "false"
 	if revokeGrants {
-		if err := s.store.RevokeAllUserGrants(workspaceID, userID); err != nil {
-			// Member was already removed but grant revocation failed.
-			// Return an error so the caller knows the operation was partial.
-			slog.Error("failed to revoke grants on member removal", "workspace_id", workspaceID, "user_id", userID, "error", err)
-			writeError(w, http.StatusInternalServerError, "internal_error", "Member removed but failed to revoke grants")
+		// Atomic: remove member and revoke all grants in one transaction
+		if err := s.store.RemoveWorkspaceMemberAndRevokeGrants(workspaceID, userID); err != nil {
+			writeError(w, http.StatusNotFound, "not_found", "Member not found")
+			return
+		}
+	} else {
+		if err := s.store.RemoveWorkspaceMember(workspaceID, userID); err != nil {
+			writeError(w, http.StatusNotFound, "not_found", "Member not found")
 			return
 		}
 	}

--- a/internal/server/handlers_members.go
+++ b/internal/server/handlers_members.go
@@ -11,20 +11,18 @@ import (
 )
 
 // handleListMembers returns all members of a workspace.
+// Requires at least viewer role (guests are blocked).
+// Invitation details are only included for workspace owners.
 func (s *Server) handleListMembers(w http.ResponseWriter, r *http.Request) {
+	if !requireMinRole(w, r, "viewer") {
+		return
+	}
 	workspaceID, ok := s.getWorkspaceID(w, r)
 	if !ok {
 		return
 	}
 
 	members, err := s.store.ListWorkspaceMembers(workspaceID)
-	if err != nil {
-		writeInternalError(w, err)
-		return
-	}
-
-	// Include pending invitations, enriched with join URLs
-	invitations, err := s.store.ListWorkspaceInvitations(workspaceID)
 	if err != nil {
 		writeInternalError(w, err)
 		return
@@ -38,24 +36,39 @@ func (s *Server) handleListMembers(w http.ResponseWriter, r *http.Request) {
 		JoinURL   string `json:"join_url,omitempty"`
 		CreatedAt string `json:"created_at"`
 	}
-	enrichedInvs := make([]invWithURL, len(invitations))
-	for i, inv := range invitations {
-		// For hashed invitations (code == id placeholder), the plaintext
-		// code is not recoverable — only show code/join_url for legacy invites.
-		code := inv.Code
-		if code == inv.ID {
-			code = ""
+
+	// Only owners can see pending invitations (which contain emails and join codes)
+	var enrichedInvs []invWithURL
+	if requireRole(r, "owner") {
+		invitations, err := s.store.ListWorkspaceInvitations(workspaceID)
+		if err != nil {
+			writeInternalError(w, err)
+			return
 		}
-		enrichedInvs[i] = invWithURL{
-			ID:        inv.ID,
-			Email:     inv.Email,
-			Role:      inv.Role,
-			Code:      code,
-			CreatedAt: inv.CreatedAt.Format("2006-01-02T15:04:05Z"),
+
+		enrichedInvs = make([]invWithURL, len(invitations))
+		for i, inv := range invitations {
+			// For hashed invitations (code == id placeholder), the plaintext
+			// code is not recoverable — only show code/join_url for legacy invites.
+			code := inv.Code
+			if code == inv.ID {
+				code = ""
+			}
+			enrichedInvs[i] = invWithURL{
+				ID:        inv.ID,
+				Email:     inv.Email,
+				Role:      inv.Role,
+				Code:      code,
+				CreatedAt: inv.CreatedAt.Format("2006-01-02T15:04:05Z"),
+			}
+			if s.baseURL != "" && code != "" {
+				enrichedInvs[i].JoinURL = s.baseURL + "/join/" + code
+			}
 		}
-		if s.baseURL != "" && code != "" {
-			enrichedInvs[i].JoinURL = s.baseURL + "/join/" + code
-		}
+	}
+
+	if enrichedInvs == nil {
+		enrichedInvs = []invWithURL{}
 	}
 
 	writeJSON(w, http.StatusOK, map[string]interface{}{
@@ -191,12 +204,19 @@ func (s *Server) handleRemoveMember(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// D4: Owner chooses at member removal time.
-	// ?revoke_grants=true → delete all collection/item grants (full removal)
-	// ?revoke_grants=false or omitted → keep grants (user becomes a guest)
-	revokeGrants := r.URL.Query().Get("revoke_grants") == "true"
+	// Default to revoking grants on member removal to prevent the removed user
+	// from silently becoming a guest with continued access.
+	// ?revoke_grants=false → explicitly keep grants (user becomes a guest)
+	// ?revoke_grants=true or omitted → delete all grants (full removal)
+	revokeGrants := r.URL.Query().Get("revoke_grants") != "false"
 	if revokeGrants {
-		_ = s.store.RevokeAllUserGrants(workspaceID, userID)
+		if err := s.store.RevokeAllUserGrants(workspaceID, userID); err != nil {
+			// Member was already removed but grant revocation failed.
+			// Return an error so the caller knows the operation was partial.
+			slog.Error("failed to revoke grants on member removal", "workspace_id", workspaceID, "user_id", userID, "error", err)
+			writeError(w, http.StatusInternalServerError, "internal_error", "Member removed but failed to revoke grants")
+			return
+		}
 	}
 
 	meta := map[string]string{"user_id": userID}

--- a/internal/server/handlers_members.go
+++ b/internal/server/handlers_members.go
@@ -191,7 +191,19 @@ func (s *Server) handleRemoveMember(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	s.logWorkspaceAuditEvent(workspaceID, models.ActionMemberRemoved, r, auditMeta(map[string]string{"user_id": userID}))
+	// D4: Owner chooses at member removal time.
+	// ?revoke_grants=true → delete all collection/item grants (full removal)
+	// ?revoke_grants=false or omitted → keep grants (user becomes a guest)
+	revokeGrants := r.URL.Query().Get("revoke_grants") == "true"
+	if revokeGrants {
+		_ = s.store.RevokeAllUserGrants(workspaceID, userID)
+	}
+
+	meta := map[string]string{"user_id": userID}
+	if revokeGrants {
+		meta["revoked_grants"] = "true"
+	}
+	s.logWorkspaceAuditEvent(workspaceID, models.ActionMemberRemoved, r, auditMeta(meta))
 
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/internal/server/handlers_role_board.go
+++ b/internal/server/handlers_role_board.go
@@ -7,10 +7,9 @@ import (
 )
 
 // handleRoleBoardReorder updates role_sort_order for items within a lane.
+// Permission is checked per-item via requireEditPermission (grant-aware),
+// so guests/viewers with edit grants can reorder their granted items.
 func (s *Server) handleRoleBoardReorder(w http.ResponseWriter, r *http.Request) {
-	if !requireMinRole(w, r, "editor") {
-		return
-	}
 	workspaceID, ok := s.getWorkspaceID(w, r)
 	if !ok {
 		return

--- a/internal/server/handlers_role_board.go
+++ b/internal/server/handlers_role_board.go
@@ -84,19 +84,17 @@ func (s *Server) handleRoleBoard(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// For guests, use item-level filtering
+	// For users with item-level grants, use item-level filtering
 	rbCollIDs := visibleIDs
 	var rbItemIDs []string
-	if workspaceRole(r) == "guest" {
-		if user := currentUser(r); user != nil {
-			fullCollIDs, grantedItemIDs, grantErr := s.store.GuestVisibleResources(workspaceID, user.ID)
-			if grantErr != nil {
-				writeInternalError(w, grantErr)
-				return
-			}
-			rbCollIDs = fullCollIDs
-			rbItemIDs = grantedItemIDs
-		}
+	rbFullCollIDs, rbGrantedItemIDs, rbGrantErr := s.guestResourceFilter(r, workspaceID)
+	if rbGrantErr != nil {
+		writeInternalError(w, rbGrantErr)
+		return
+	}
+	if len(rbGrantedItemIDs) > 0 {
+		rbCollIDs = rbFullCollIDs
+		rbItemIDs = rbGrantedItemIDs
 	}
 
 	params := store.RoleBoardParams{

--- a/internal/server/handlers_role_board.go
+++ b/internal/server/handlers_role_board.go
@@ -84,9 +84,25 @@ func (s *Server) handleRoleBoard(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// For guests, use item-level filtering
+	rbCollIDs := visibleIDs
+	var rbItemIDs []string
+	if workspaceRole(r) == "guest" {
+		if user := currentUser(r); user != nil {
+			fullCollIDs, grantedItemIDs, grantErr := s.store.GuestVisibleResources(workspaceID, user.ID)
+			if grantErr != nil {
+				writeInternalError(w, grantErr)
+				return
+			}
+			rbCollIDs = fullCollIDs
+			rbItemIDs = grantedItemIDs
+		}
+	}
+
 	params := store.RoleBoardParams{
 		AssignedUserID: r.URL.Query().Get("assigned_user_id"),
-		CollectionIDs:  visibleIDs,
+		CollectionIDs:  rbCollIDs,
+		ItemIDs:        rbItemIDs,
 	}
 
 	lanes, err := s.store.GetRoleBoardItems(workspaceID, params)

--- a/internal/server/handlers_role_board.go
+++ b/internal/server/handlers_role_board.go
@@ -22,19 +22,20 @@ func (s *Server) handleRoleBoardReorder(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	// Verify all items being reordered are in visible collections
-	visibleIDs, visErr := s.visibleCollectionIDs(r, workspaceID)
-	if visErr != nil {
-		writeInternalError(w, visErr)
-		return
-	}
-	if visibleIDs != nil {
-		for _, u := range updates {
-			item, err := s.store.GetItem(u.ItemID)
-			if err != nil || item == nil || !isCollectionVisible(item.CollectionID, visibleIDs) {
-				writeError(w, http.StatusForbidden, "forbidden", "Cannot reorder items in hidden collections")
-				return
-			}
+	// Verify all items being reordered are visible and editable.
+	// Uses grant-aware edit check so restricted members/guests with
+	// item-only grants can't reorder items they don't have edit access to.
+	for _, u := range updates {
+		item, err := s.store.GetItem(u.ItemID)
+		if err != nil || item == nil {
+			writeError(w, http.StatusForbidden, "forbidden", "Cannot reorder items in hidden collections")
+			return
+		}
+		if !s.requireItemVisible(w, r, workspaceID, item) {
+			return
+		}
+		if !s.requireEditPermission(w, r, workspaceID, item.ID, item.CollectionID) {
+			return
 		}
 	}
 

--- a/internal/server/handlers_search.go
+++ b/internal/server/handlers_search.go
@@ -60,14 +60,35 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 				}
 				visIDs, err := s.store.VisibleCollectionIDs(ws.ID, user.ID)
 				if err != nil {
-					// Fail closed: skip this workspace entirely on error
-					// rather than searching it without a collection filter.
 					params.WorkspaceIDs = removeString(params.WorkspaceIDs, ws.ID)
 					continue
 				}
 				if visIDs != nil {
 					needsCollFilter = true
-					allVisibleCollIDs = append(allVisibleCollIDs, visIDs...)
+					// For restricted members with item grants, separate full-access
+					// collections from item-granted collections
+					_, itemGrants, _ := s.store.GuestVisibleResources(ws.ID, user.ID)
+					if len(itemGrants) > 0 {
+						memberColls, _ := s.store.GetMemberCollectionAccess(ws.ID, user.ID)
+						sysColls, _ := s.store.ListSystemCollectionIDs(ws.ID)
+						collGrants, _, _ := s.store.GuestVisibleResources(ws.ID, user.ID)
+						fullSet := make(map[string]bool)
+						for _, id := range memberColls {
+							fullSet[id] = true
+						}
+						for _, id := range sysColls {
+							fullSet[id] = true
+						}
+						for _, id := range collGrants {
+							fullSet[id] = true
+						}
+						for id := range fullSet {
+							allVisibleCollIDs = append(allVisibleCollIDs, id)
+						}
+						allVisibleItemIDs = append(allVisibleItemIDs, itemGrants...)
+					} else {
+						allVisibleCollIDs = append(allVisibleCollIDs, visIDs...)
+					}
 				} else {
 					// "all" access — include all collections from this workspace
 					colls, _ := s.store.ListCollections(ws.ID)
@@ -98,17 +119,49 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 			}
 			params.CollectionIDs = visibleIDs
 
-			// For guests (non-members with grants), use item-level filtering
-			// so item grants don't leak entire collections in search results.
-			// Note: /search is not behind RequireWorkspaceAccess, so we check
-			// membership directly instead of relying on workspaceRole().
+			// For users with item grants (guests or restricted members),
+			// apply item-level filtering so item grants don't leak entire
+			// collections in search results.
+			// Note: /search is not behind RequireWorkspaceAccess, so we
+			// can't use guestResourceFilter (needs workspaceRole). We check
+			// membership and collection access directly.
 			if user != nil {
-				isMember, _ := s.store.IsWorkspaceMember(ws.ID, user.ID)
-				if !isMember {
-					fullCollIDs, grantedItemIDs, grantErr := s.store.GuestVisibleResources(ws.ID, user.ID)
+				needsItemFilter := false
+				member, _ := s.store.GetWorkspaceMember(ws.ID, user.ID)
+				if member == nil {
+					// Guest (non-member)
+					needsItemFilter = true
+				} else if member.CollectionAccess == "specific" {
+					// Restricted member — check if they have item grants
+					_, itemGrants, _ := s.store.GuestVisibleResources(ws.ID, user.ID)
+					needsItemFilter = len(itemGrants) > 0
+				}
+
+				if needsItemFilter {
+					grantCollIDs, grantedItemIDs, grantErr := s.store.GuestVisibleResources(ws.ID, user.ID)
 					if grantErr != nil {
 						writeInternalError(w, grantErr)
 						return
+					}
+					// For restricted members, merge member collections into full access set
+					fullCollIDs := grantCollIDs
+					if member != nil {
+						memberColls, _ := s.store.GetMemberCollectionAccess(ws.ID, user.ID)
+						sysColls, _ := s.store.ListSystemCollectionIDs(ws.ID)
+						fullSet := make(map[string]bool)
+						for _, id := range grantCollIDs {
+							fullSet[id] = true
+						}
+						for _, id := range memberColls {
+							fullSet[id] = true
+						}
+						for _, id := range sysColls {
+							fullSet[id] = true
+						}
+						fullCollIDs = make([]string, 0, len(fullSet))
+						for id := range fullSet {
+							fullCollIDs = append(fullCollIDs, id)
+						}
 					}
 					params.CollectionIDs = fullCollIDs
 					params.ItemIDs = grantedItemIDs

--- a/internal/server/handlers_search.go
+++ b/internal/server/handlers_search.go
@@ -79,6 +79,20 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 			params.CollectionIDs = visibleIDs
+
+			// For guests, use item-level filtering so item grants don't
+			// leak the entire collection's items in search results.
+			if workspaceRole(r) == "guest" {
+				if user := currentUser(r); user != nil {
+					fullCollIDs, grantedItemIDs, grantErr := s.store.GuestVisibleResources(ws.ID, user.ID)
+					if grantErr != nil {
+						writeInternalError(w, grantErr)
+						return
+					}
+					params.CollectionIDs = fullCollIDs
+					params.ItemIDs = grantedItemIDs
+				}
+			}
 		}
 	}
 

--- a/internal/server/handlers_search.go
+++ b/internal/server/handlers_search.go
@@ -41,9 +41,23 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 			}
 			// Apply per-workspace collection visibility filtering.
 			// Collect all visible collection IDs across user's workspaces.
+			// For guest workspaces, also collect item-level grants.
 			allVisibleCollIDs := []string{} // non-nil empty = "no access" by default
+			var allVisibleItemIDs []string
 			needsCollFilter := false
 			for _, ws := range workspaces {
+				if ws.IsGuest {
+					// Guest workspace: use item-level filtering
+					fullCollIDs, grantedItemIDs, grantErr := s.store.GuestVisibleResources(ws.ID, user.ID)
+					if grantErr != nil {
+						params.WorkspaceIDs = removeString(params.WorkspaceIDs, ws.ID)
+						continue
+					}
+					needsCollFilter = true
+					allVisibleCollIDs = append(allVisibleCollIDs, fullCollIDs...)
+					allVisibleItemIDs = append(allVisibleItemIDs, grantedItemIDs...)
+					continue
+				}
 				visIDs, err := s.store.VisibleCollectionIDs(ws.ID, user.ID)
 				if err != nil {
 					// Fail closed: skip this workspace entirely on error
@@ -65,6 +79,9 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 			if needsCollFilter {
 				params.CollectionIDs = allVisibleCollIDs
 			}
+			if len(allVisibleItemIDs) > 0 {
+				params.ItemIDs = allVisibleItemIDs
+			}
 		}
 		// If no user (fresh install, no auth), allow unscoped search
 	}
@@ -73,6 +90,7 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 	if params.Workspace != "" {
 		ws, _ := s.store.GetWorkspaceBySlug(params.Workspace)
 		if ws != nil {
+			user := currentUser(r)
 			visibleIDs, visErr := s.visibleCollectionIDs(r, ws.ID)
 			if visErr != nil {
 				writeInternalError(w, visErr)
@@ -80,10 +98,13 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 			}
 			params.CollectionIDs = visibleIDs
 
-			// For guests, use item-level filtering so item grants don't
-			// leak the entire collection's items in search results.
-			if workspaceRole(r) == "guest" {
-				if user := currentUser(r); user != nil {
+			// For guests (non-members with grants), use item-level filtering
+			// so item grants don't leak entire collections in search results.
+			// Note: /search is not behind RequireWorkspaceAccess, so we check
+			// membership directly instead of relying on workspaceRole().
+			if user != nil {
+				isMember, _ := s.store.IsWorkspaceMember(ws.ID, user.ID)
+				if !isMember {
 					fullCollIDs, grantedItemIDs, grantErr := s.store.GuestVisibleResources(ws.ID, user.ID)
 					if grantErr != nil {
 						writeInternalError(w, grantErr)

--- a/internal/server/handlers_tokens.go
+++ b/internal/server/handlers_tokens.go
@@ -35,6 +35,9 @@ func (s *Server) getTokenExpirySettings() (defaultDays, maxDays int) {
 // handleCreateToken creates a new API token scoped to a workspace.
 // The token is owned by the authenticated user (if any).
 func (s *Server) handleCreateToken(w http.ResponseWriter, r *http.Request) {
+	if !requireMinRole(w, r, "owner") {
+		return
+	}
 	workspaceID, ok := s.getWorkspaceID(w, r)
 	if !ok {
 		return
@@ -68,6 +71,9 @@ func (s *Server) handleCreateToken(w http.ResponseWriter, r *http.Request) {
 
 // handleListTokens returns all API tokens for a workspace (without secrets).
 func (s *Server) handleListTokens(w http.ResponseWriter, r *http.Request) {
+	if !requireMinRole(w, r, "owner") {
+		return
+	}
 	workspaceID, ok := s.getWorkspaceID(w, r)
 	if !ok {
 		return
@@ -87,6 +93,9 @@ func (s *Server) handleListTokens(w http.ResponseWriter, r *http.Request) {
 
 // handleDeleteToken revokes an API token by ID.
 func (s *Server) handleDeleteToken(w http.ResponseWriter, r *http.Request) {
+	if !requireMinRole(w, r, "owner") {
+		return
+	}
 	_, ok := s.getWorkspaceID(w, r)
 	if !ok {
 		return

--- a/internal/server/handlers_versions.go
+++ b/internal/server/handlers_versions.go
@@ -11,6 +11,9 @@ import (
 )
 
 func (s *Server) handleListVersions(w http.ResponseWriter, r *http.Request) {
+	if !requireMinRole(w, r, "viewer") {
+		return
+	}
 	_, doc, ok := s.getWorkspaceDocument(w, r)
 	if !ok {
 		return
@@ -30,6 +33,9 @@ func (s *Server) handleListVersions(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleGetVersion(w http.ResponseWriter, r *http.Request) {
+	if !requireMinRole(w, r, "viewer") {
+		return
+	}
 	_, doc, ok := s.getWorkspaceDocument(w, r)
 	if !ok {
 		return

--- a/internal/server/handlers_views.go
+++ b/internal/server/handlers_views.go
@@ -71,7 +71,7 @@ func (s *Server) handleCreateView(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Check collection visibility
+	// Check collection visibility and edit permission (grant-aware)
 	visibleIDs, visErr := s.visibleCollectionIDs(r, workspaceID)
 	if visErr != nil {
 		writeInternalError(w, visErr)
@@ -79,6 +79,9 @@ func (s *Server) handleCreateView(w http.ResponseWriter, r *http.Request) {
 	}
 	if !isCollectionVisible(coll.ID, visibleIDs) {
 		writeError(w, http.StatusNotFound, "not_found", "Collection not found")
+		return
+	}
+	if !s.requireEditPermission(w, r, workspaceID, "", coll.ID) {
 		return
 	}
 
@@ -127,18 +130,30 @@ func (s *Server) requireViewVisible(w http.ResponseWriter, r *http.Request, work
 	return view
 }
 
+// requireViewEditable is like requireViewVisible but also checks edit permission
+// on the view's collection (grant-aware for guests/restricted members).
+func (s *Server) requireViewEditable(w http.ResponseWriter, r *http.Request, workspaceID, viewID string) *models.View {
+	view := s.requireViewVisible(w, r, workspaceID, viewID)
+	if view == nil {
+		return nil
+	}
+	if view.CollectionID != nil {
+		if !s.requireEditPermission(w, r, workspaceID, "", *view.CollectionID) {
+			return nil
+		}
+	}
+	return view
+}
+
 // handleUpdateView modifies an existing saved view.
 func (s *Server) handleUpdateView(w http.ResponseWriter, r *http.Request) {
-	if !requireMinRole(w, r, "editor") {
-		return
-	}
 	workspaceID, ok := s.getWorkspaceID(w, r)
 	if !ok {
 		return
 	}
 
 	viewID := chi.URLParam(r, "viewID")
-	if s.requireViewVisible(w, r, workspaceID, viewID) == nil {
+	if s.requireViewEditable(w, r, workspaceID, viewID) == nil {
 		return
 	}
 
@@ -163,16 +178,13 @@ func (s *Server) handleUpdateView(w http.ResponseWriter, r *http.Request) {
 
 // handleDeleteView removes a saved view.
 func (s *Server) handleDeleteView(w http.ResponseWriter, r *http.Request) {
-	if !requireMinRole(w, r, "editor") {
-		return
-	}
 	workspaceID, ok := s.getWorkspaceID(w, r)
 	if !ok {
 		return
 	}
 
 	viewID := chi.URLParam(r, "viewID")
-	if s.requireViewVisible(w, r, workspaceID, viewID) == nil {
+	if s.requireViewEditable(w, r, workspaceID, viewID) == nil {
 		return
 	}
 

--- a/internal/server/handlers_webhooks.go
+++ b/internal/server/handlers_webhooks.go
@@ -56,7 +56,11 @@ func (s *Server) handleCreateWebhook(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleListWebhooks returns all webhooks for a workspace.
+// Restricted to owners since webhook URLs may contain secret tokens.
 func (s *Server) handleListWebhooks(w http.ResponseWriter, r *http.Request) {
+	if !requireMinRole(w, r, "owner") {
+		return
+	}
 	workspaceID, ok := s.getWorkspaceID(w, r)
 	if !ok {
 		return

--- a/internal/server/middleware_auth.go
+++ b/internal/server/middleware_auth.go
@@ -314,7 +314,14 @@ func (s *Server) RequireWorkspaceAccess(next http.Handler) http.Handler {
 			return
 		}
 		if member == nil {
-			writeError(w, http.StatusForbidden, "forbidden", "You are not a member of this workspace")
+			// Not a member — check for guest access via grants
+			hasGrants, grantErr := s.store.UserHasGrantsInWorkspace(ws.ID, user.ID)
+			if grantErr != nil || !hasGrants {
+				writeError(w, http.StatusForbidden, "forbidden", "You are not a member of this workspace")
+				return
+			}
+			ctx = context.WithValue(ctx, ctxWorkspaceRole, "guest")
+			next.ServeHTTP(w, r.WithContext(ctx))
 			return
 		}
 
@@ -360,6 +367,8 @@ func roleLevel(role string) int {
 		return 2
 	case "viewer":
 		return 1
+	case "guest":
+		return 0 // Guests have grant-based access only, no role-based permissions
 	default:
 		return 0
 	}

--- a/internal/server/middleware_auth.go
+++ b/internal/server/middleware_auth.go
@@ -316,7 +316,12 @@ func (s *Server) RequireWorkspaceAccess(next http.Handler) http.Handler {
 		if member == nil {
 			// Not a member — check for guest access via grants
 			hasGrants, grantErr := s.store.UserHasGrantsInWorkspace(ws.ID, user.ID)
-			if grantErr != nil || !hasGrants {
+			if grantErr != nil {
+				slog.Error("failed to check guest grants", "workspace_id", ws.ID, "user_id", user.ID, "error", grantErr)
+				writeError(w, http.StatusInternalServerError, "internal_error", "Failed to check workspace access")
+				return
+			}
+			if !hasGrants {
 				writeError(w, http.StatusForbidden, "forbidden", "You are not a member of this workspace")
 				return
 			}

--- a/internal/server/middleware_auth.go
+++ b/internal/server/middleware_auth.go
@@ -374,6 +374,26 @@ func roleLevel(role string) int {
 	}
 }
 
+// permissionLevel returns a numeric level for grant permission comparison.
+func permissionLevel(perm string) int {
+	switch perm {
+	case "owner":
+		return 4
+	case "admin":
+		return 3
+	case "editor":
+		return 2
+	case "edit":
+		return 2
+	case "viewer":
+		return 1
+	case "view":
+		return 1
+	default:
+		return 0
+	}
+}
+
 // sha256hex returns the SHA-256 hex digest of a string.
 func sha256hex(s string) string {
 	h := sha256.Sum256([]byte(s))

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -679,39 +679,36 @@ func (s *Server) requireItemVisible(w http.ResponseWriter, r *http.Request, work
 	// collection visibility may come from item-level grants.
 	// We need to verify the user actually has a grant on this specific item
 	// (not just another item in the same collection).
-	user := currentUser(r)
-	if user != nil {
-		_, grantedItemIDs, err := s.store.GuestVisibleResources(workspaceID, user.ID)
-		if err != nil {
-			writeInternalError(w, err)
-			return false
+	// Uses guestResourceFilter which skips this check for members with "all" access.
+	fullCollIDs, grantedItemIDs, grantErr := s.guestResourceFilter(r, workspaceID)
+	if grantErr != nil {
+		writeInternalError(w, grantErr)
+		return false
+	}
+	if len(grantedItemIDs) > 0 {
+		// If the collection has a full collection grant, the item is visible
+		for _, id := range fullCollIDs {
+			if id == item.CollectionID {
+				return true
+			}
 		}
-		if len(grantedItemIDs) > 0 {
-			fullCollIDs, _, _ := s.store.GuestVisibleResources(workspaceID, user.ID)
-			// If the collection has a full collection grant, the item is visible
-			for _, id := range fullCollIDs {
+		// Check if this collection came from member_collection_access (not grants)
+		if workspaceRole(r) != "guest" {
+			memberColls, _ := s.store.GetMemberCollectionAccess(workspaceID, currentUserID(r))
+			for _, id := range memberColls {
 				if id == item.CollectionID {
 					return true
 				}
 			}
-			// Check if this collection came from member_collection_access (not grants)
-			if workspaceRole(r) != "guest" {
-				memberColls, _ := s.store.GetMemberCollectionAccess(workspaceID, user.ID)
-				for _, id := range memberColls {
-					if id == item.CollectionID {
-						return true
-					}
-				}
-			}
-			// Otherwise, the specific item must be in the granted items list
-			for _, id := range grantedItemIDs {
-				if id == item.ID {
-					return true
-				}
-			}
-			writeError(w, http.StatusNotFound, "not_found", "Item not found")
-			return false
 		}
+		// Otherwise, the specific item must be in the granted items list
+		for _, id := range grantedItemIDs {
+			if id == item.ID {
+				return true
+			}
+		}
+		writeError(w, http.StatusNotFound, "not_found", "Item not found")
+		return false
 	}
 
 	return true
@@ -740,13 +737,31 @@ func (s *Server) isItemVisibleToGuest(r *http.Request, workspaceID string, item 
 }
 
 // guestResourceFilter returns the full-collection IDs and granted item IDs for
-// the current user if they have item-level grants. For users with no item grants,
-// both slices are nil. Works for both guests and restricted members.
+// the current user if they need item-level grant filtering. Returns nil/nil for:
+// - unauthenticated users
+// - admin users
+// - members with "all" collection access (grants should merge, not replace)
+// Returns grant resources for guests and members with "specific" collection access.
 func (s *Server) guestResourceFilter(r *http.Request, workspaceID string) (fullCollIDs, grantedItemIDs []string, err error) {
 	user := currentUser(r)
-	if user == nil {
+	if user == nil || user.Role == "admin" {
 		return nil, nil, nil
 	}
+
+	// For workspace members with "all" collection access, item grants should
+	// not restrict their existing full visibility. Only guests and members
+	// with "specific" access need item-level filtering.
+	role := workspaceRole(r)
+	if role != "guest" {
+		member, err := s.store.GetWorkspaceMember(workspaceID, user.ID)
+		if err != nil {
+			return nil, nil, err
+		}
+		if member != nil && (member.CollectionAccess == "all" || member.CollectionAccess == "") {
+			return nil, nil, nil
+		}
+	}
+
 	return s.store.GuestVisibleResources(workspaceID, user.ID)
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -741,17 +741,20 @@ func (s *Server) isItemVisibleToGuest(r *http.Request, workspaceID string, item 
 // - unauthenticated users
 // - admin users
 // - members with "all" collection access (grants should merge, not replace)
-// Returns grant resources for guests and members with "specific" collection access.
+// For guests: returns direct collection grants as fullCollIDs + item grants.
+// For restricted members: returns member_collection_access + system collections
+// + direct collection grants as fullCollIDs, plus item grants as grantedItemIDs.
+// This ensures item grants are additive to the member's existing access.
 func (s *Server) guestResourceFilter(r *http.Request, workspaceID string) (fullCollIDs, grantedItemIDs []string, err error) {
 	user := currentUser(r)
 	if user == nil || user.Role == "admin" {
 		return nil, nil, nil
 	}
 
-	// For workspace members with "all" collection access, item grants should
-	// not restrict their existing full visibility. Only guests and members
-	// with "specific" access need item-level filtering.
 	role := workspaceRole(r)
+
+	// For workspace members with "all" collection access, item grants should
+	// not restrict their existing full visibility.
 	if role != "guest" {
 		member, err := s.store.GetWorkspaceMember(workspaceID, user.ID)
 		if err != nil {
@@ -762,7 +765,52 @@ func (s *Server) guestResourceFilter(r *http.Request, workspaceID string) (fullC
 		}
 	}
 
-	return s.store.GuestVisibleResources(workspaceID, user.ID)
+	// Get grant-based resources
+	grantCollIDs, grantedItemIDs, err := s.store.GuestVisibleResources(workspaceID, user.ID)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// For guests, grant resources are the only source of access
+	if role == "guest" {
+		return grantCollIDs, grantedItemIDs, nil
+	}
+
+	// For restricted members ("specific" access), merge their normal
+	// member_collection_access + system collections into fullCollIDs so
+	// item grants are additive, not a replacement. This is critical:
+	// without this merge, a member with access to collection A plus one
+	// item grant in collection B would lose collection A in cross-collection
+	// queries that use these IDs.
+	fullCollSet := make(map[string]bool)
+	for _, id := range grantCollIDs {
+		fullCollSet[id] = true
+	}
+
+	// Add member_collection_access collections
+	memberColls, err := s.store.GetMemberCollectionAccess(workspaceID, user.ID)
+	if err != nil {
+		return nil, nil, err
+	}
+	for _, id := range memberColls {
+		fullCollSet[id] = true
+	}
+
+	// Add system collections (always visible to members)
+	sysColls, err := s.store.ListSystemCollectionIDs(workspaceID)
+	if err != nil {
+		return nil, nil, err
+	}
+	for _, id := range sysColls {
+		fullCollSet[id] = true
+	}
+
+	fullCollIDs = make([]string, 0, len(fullCollSet))
+	for id := range fullCollSet {
+		fullCollIDs = append(fullCollIDs, id)
+	}
+
+	return fullCollIDs, grantedItemIDs, nil
 }
 
 // isCollectionVisible checks if a collection ID is in the visible set.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -328,6 +328,10 @@ func (s *Server) setupRouter() {
 						// Items within collection
 						r.Get("/items", s.handleListCollectionItems)
 						r.Post("/items", s.handleCreateItem)
+						// Collection grants
+						r.Get("/grants", s.handleListCollectionGrants)
+						r.Post("/grants", s.handleCreateCollectionGrant)
+						r.Delete("/grants/{grantID}", s.handleDeleteCollectionGrant)
 						// Saved views within collection
 						r.Get("/views", s.handleListViews)
 						r.Post("/views", s.handleCreateView)
@@ -340,6 +344,9 @@ func (s *Server) setupRouter() {
 
 				// Plans progress
 				r.Get("/plans-progress", s.handlePlansProgress)
+
+				// User grants (all grants for a specific user in this workspace)
+				r.Get("/users/{userID}/grants", s.handleListUserGrants)
 
 				// Items (cross-collection, v2)
 				r.Get("/items", s.handleListItems)
@@ -360,6 +367,9 @@ func (s *Server) setupRouter() {
 					r.Get("/children", s.handleGetItemChildren)
 					r.Get("/progress", s.handleGetItemProgress)
 					r.Get("/tasks", s.handleGetItemChildren) // deprecated alias
+					r.Get("/grants", s.handleListItemGrants)
+					r.Post("/grants", s.handleCreateItemGrant)
+					r.Delete("/grants/{grantID}", s.handleDeleteItemGrant)
 				})
 
 				// Links (v2)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -706,6 +706,41 @@ func (s *Server) requireItemVisible(w http.ResponseWriter, r *http.Request, work
 	return true
 }
 
+// isItemVisibleToGuest checks if an item is visible to a guest, considering both
+// full-collection grants and individual item grants. For non-guests, always returns true.
+func (s *Server) isItemVisibleToGuest(r *http.Request, workspaceID string, item *models.Item, fullCollIDs, grantedItemIDs []string) bool {
+	if workspaceRole(r) != "guest" {
+		return true
+	}
+	// Full collection grant covers all items in the collection
+	for _, id := range fullCollIDs {
+		if id == item.CollectionID {
+			return true
+		}
+	}
+	// Otherwise, the specific item must be in the granted items list
+	for _, id := range grantedItemIDs {
+		if id == item.ID {
+			return true
+		}
+	}
+	return false
+}
+
+// guestResourceFilter returns the full-collection IDs and granted item IDs for
+// the current user if they are a guest. For non-guests both slices are nil.
+// This is a convenience method for handlers that need to post-filter items.
+func (s *Server) guestResourceFilter(r *http.Request, workspaceID string) (fullCollIDs, grantedItemIDs []string, err error) {
+	if workspaceRole(r) != "guest" {
+		return nil, nil, nil
+	}
+	user := currentUser(r)
+	if user == nil {
+		return nil, nil, nil
+	}
+	return s.store.GuestVisibleResources(workspaceID, user.ID)
+}
+
 // isCollectionVisible checks if a collection ID is in the visible set.
 // If visibleIDs is nil, all collections are visible.
 func isCollectionVisible(collectionID string, visibleIDs []string) bool {
@@ -722,16 +757,20 @@ func isCollectionVisible(collectionID string, visibleIDs []string) bool {
 
 // requireEditPermission checks if the user has edit access to the given item.
 // For regular members (editor/owner), this uses the standard role check.
-// For guests, it resolves the effective permission from grants and checks
-// whether the resolved permission is at least "edit".
+// For members with insufficient roles (e.g., viewers), it falls back to
+// grant-based permissions so grants can override the base role.
+// For guests, it resolves the effective permission from grants directly.
 // Returns true if the request should continue, false if it was rejected with a 403.
 func (s *Server) requireEditPermission(w http.ResponseWriter, r *http.Request, workspaceID string, itemID, collectionID string) bool {
-	// Non-guest users: standard role check
-	if workspaceRole(r) != "guest" {
-		return requireMinRole(w, r, "editor")
+	role := workspaceRole(r)
+
+	// Editors and owners always have edit access
+	if role != "guest" && requireRole(r, "editor") {
+		return true
 	}
 
-	// Guest users: check grant-based permissions
+	// For guests and members with insufficient role (e.g., viewers),
+	// check grant-based permissions as an override.
 	user := currentUser(r)
 	if user == nil {
 		writeError(w, http.StatusForbidden, "forbidden", "Insufficient permissions")

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -675,21 +675,32 @@ func (s *Server) requireItemVisible(w http.ResponseWriter, r *http.Request, work
 		return false
 	}
 
-	// For guests, collection visibility may come from item-level grants.
+	// For users with item-level grants (guests or restricted members),
+	// collection visibility may come from item-level grants.
 	// We need to verify the user actually has a grant on this specific item
 	// (not just another item in the same collection).
-	if workspaceRole(r) == "guest" {
-		user := currentUser(r)
-		if user != nil {
-			fullCollIDs, grantedItemIDs, err := s.store.GuestVisibleResources(workspaceID, user.ID)
-			if err != nil {
-				writeInternalError(w, err)
-				return false
-			}
+	user := currentUser(r)
+	if user != nil {
+		_, grantedItemIDs, err := s.store.GuestVisibleResources(workspaceID, user.ID)
+		if err != nil {
+			writeInternalError(w, err)
+			return false
+		}
+		if len(grantedItemIDs) > 0 {
+			fullCollIDs, _, _ := s.store.GuestVisibleResources(workspaceID, user.ID)
 			// If the collection has a full collection grant, the item is visible
 			for _, id := range fullCollIDs {
 				if id == item.CollectionID {
 					return true
+				}
+			}
+			// Check if this collection came from member_collection_access (not grants)
+			if workspaceRole(r) != "guest" {
+				memberColls, _ := s.store.GetMemberCollectionAccess(workspaceID, user.ID)
+				for _, id := range memberColls {
+					if id == item.CollectionID {
+						return true
+					}
 				}
 			}
 			// Otherwise, the specific item must be in the granted items list
@@ -706,10 +717,11 @@ func (s *Server) requireItemVisible(w http.ResponseWriter, r *http.Request, work
 	return true
 }
 
-// isItemVisibleToGuest checks if an item is visible to a guest, considering both
-// full-collection grants and individual item grants. For non-guests, always returns true.
+// isItemVisibleToGuest checks if an item is visible given grant-based access,
+// considering both full-collection grants and individual item grants.
+// When fullCollIDs and grantedItemIDs are both nil, always returns true (no grant filtering).
 func (s *Server) isItemVisibleToGuest(r *http.Request, workspaceID string, item *models.Item, fullCollIDs, grantedItemIDs []string) bool {
-	if workspaceRole(r) != "guest" {
+	if fullCollIDs == nil && grantedItemIDs == nil {
 		return true
 	}
 	// Full collection grant covers all items in the collection
@@ -728,12 +740,9 @@ func (s *Server) isItemVisibleToGuest(r *http.Request, workspaceID string, item 
 }
 
 // guestResourceFilter returns the full-collection IDs and granted item IDs for
-// the current user if they are a guest. For non-guests both slices are nil.
-// This is a convenience method for handlers that need to post-filter items.
+// the current user if they have item-level grants. For users with no item grants,
+// both slices are nil. Works for both guests and restricted members.
 func (s *Server) guestResourceFilter(r *http.Request, workspaceID string) (fullCollIDs, grantedItemIDs []string, err error) {
-	if workspaceRole(r) != "guest" {
-		return nil, nil, nil
-	}
 	user := currentUser(r)
 	if user == nil {
 		return nil, nil, nil

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -645,9 +645,25 @@ func (s *Server) visibleCollectionIDs(r *http.Request, workspaceID string) ([]st
 	return s.store.VisibleCollectionIDs(workspaceID, user.ID)
 }
 
+// guestVisibleItemIDs returns the item IDs a guest has item-level grants on.
+// Returns nil for non-guests or if the guest has no item-level grants.
+func (s *Server) guestVisibleItemIDs(r *http.Request, workspaceID string) ([]string, error) {
+	if workspaceRole(r) != "guest" {
+		return nil, nil
+	}
+	user := currentUser(r)
+	if user == nil {
+		return nil, nil
+	}
+	_, itemIDs, err := s.store.GuestVisibleResources(workspaceID, user.ID)
+	return itemIDs, err
+}
+
 // requireItemVisible checks that the item's collection is visible to the
-// requesting user. Writes a 404 and returns false if not. Callers should
-// invoke this immediately after resolving an item by slug/ID.
+// requesting user. For guests with item-level grants, also verifies that the
+// specific item is granted (not just the collection). Writes a 404 and returns
+// false if not. Callers should invoke this immediately after resolving an item
+// by slug/ID.
 func (s *Server) requireItemVisible(w http.ResponseWriter, r *http.Request, workspaceID string, item *models.Item) bool {
 	visibleIDs, err := s.visibleCollectionIDs(r, workspaceID)
 	if err != nil {
@@ -658,6 +674,35 @@ func (s *Server) requireItemVisible(w http.ResponseWriter, r *http.Request, work
 		writeError(w, http.StatusNotFound, "not_found", "Item not found")
 		return false
 	}
+
+	// For guests, collection visibility may come from item-level grants.
+	// We need to verify the user actually has a grant on this specific item
+	// (not just another item in the same collection).
+	if workspaceRole(r) == "guest" {
+		user := currentUser(r)
+		if user != nil {
+			fullCollIDs, grantedItemIDs, err := s.store.GuestVisibleResources(workspaceID, user.ID)
+			if err != nil {
+				writeInternalError(w, err)
+				return false
+			}
+			// If the collection has a full collection grant, the item is visible
+			for _, id := range fullCollIDs {
+				if id == item.CollectionID {
+					return true
+				}
+			}
+			// Otherwise, the specific item must be in the granted items list
+			for _, id := range grantedItemIDs {
+				if id == item.ID {
+					return true
+				}
+			}
+			writeError(w, http.StatusNotFound, "not_found", "Item not found")
+			return false
+		}
+	}
+
 	return true
 }
 
@@ -673,6 +718,36 @@ func isCollectionVisible(collectionID string, visibleIDs []string) bool {
 		}
 	}
 	return false
+}
+
+// requireEditPermission checks if the user has edit access to the given item.
+// For regular members (editor/owner), this uses the standard role check.
+// For guests, it resolves the effective permission from grants and checks
+// whether the resolved permission is at least "edit".
+// Returns true if the request should continue, false if it was rejected with a 403.
+func (s *Server) requireEditPermission(w http.ResponseWriter, r *http.Request, workspaceID string, itemID, collectionID string) bool {
+	// Non-guest users: standard role check
+	if workspaceRole(r) != "guest" {
+		return requireMinRole(w, r, "editor")
+	}
+
+	// Guest users: check grant-based permissions
+	user := currentUser(r)
+	if user == nil {
+		writeError(w, http.StatusForbidden, "forbidden", "Insufficient permissions")
+		return false
+	}
+
+	perm, err := s.store.ResolveUserPermission(workspaceID, user.ID, itemID, collectionID)
+	if err != nil {
+		writeInternalError(w, err)
+		return false
+	}
+	if permissionLevel(perm) < permissionLevel("edit") {
+		writeError(w, http.StatusForbidden, "forbidden", "Insufficient permissions")
+		return false
+	}
+	return true
 }
 
 // resolveWorkspace resolves a workspace by slug or UUID, scoped to the

--- a/internal/store/agent_roles.go
+++ b/internal/store/agent_roles.go
@@ -273,6 +273,7 @@ type RoleBoardLane struct {
 type RoleBoardParams struct {
 	AssignedUserID string
 	CollectionIDs  []string // permission filter: restrict to these collection IDs (nil = no filter)
+	ItemIDs        []string // permission filter: additionally allow these specific item IDs (for item-level grants)
 }
 
 // GetRoleBoardItems returns non-terminal items across all collections, grouped by role.
@@ -287,6 +288,7 @@ func (s *Store) GetRoleBoardItems(workspaceID string, params RoleBoardParams) ([
 	listParams := models.ItemListParams{
 		IncludeArchived: false,
 		CollectionIDs:   params.CollectionIDs,
+		ItemIDs:         params.ItemIDs,
 	}
 	if params.AssignedUserID != "" {
 		listParams.AssignedUserID = params.AssignedUserID

--- a/internal/store/grants.go
+++ b/internal/store/grants.go
@@ -1,0 +1,346 @@
+package store
+
+import (
+	"database/sql"
+	"fmt"
+
+	"github.com/xarmian/pad/internal/models"
+)
+
+// --- Collection Grants ---
+
+// CreateCollectionGrant creates a direct grant on a collection for a user.
+func (s *Store) CreateCollectionGrant(workspaceID, collectionID, userID, permission, grantedBy string) (*models.CollectionGrant, error) {
+	id := newID()
+	ts := now()
+
+	_, err := s.db.Exec(s.q(`
+		INSERT INTO collection_grants (id, collection_id, workspace_id, user_id, permission, granted_by, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?)
+	`), id, collectionID, workspaceID, userID, permission, grantedBy, ts)
+	if err != nil {
+		return nil, fmt.Errorf("create collection grant: %w", err)
+	}
+
+	return s.GetCollectionGrant(id)
+}
+
+// GetCollectionGrant retrieves a collection grant by ID.
+func (s *Store) GetCollectionGrant(id string) (*models.CollectionGrant, error) {
+	var g models.CollectionGrant
+	var createdAt string
+
+	err := s.db.QueryRow(s.q(`
+		SELECT cg.id, cg.collection_id, cg.workspace_id, cg.user_id, cg.permission, cg.granted_by, cg.created_at,
+		       COALESCE(u.name, ''), COALESCE(u.email, ''), COALESCE(u.username, '')
+		FROM collection_grants cg
+		LEFT JOIN users u ON u.id = cg.user_id
+		WHERE cg.id = ?
+	`), id).Scan(
+		&g.ID, &g.CollectionID, &g.WorkspaceID, &g.UserID, &g.Permission, &g.GrantedBy, &createdAt,
+		&g.UserName, &g.UserEmail, &g.UserUsername,
+	)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get collection grant: %w", err)
+	}
+
+	g.CreatedAt = parseTime(createdAt)
+	return &g, nil
+}
+
+// ListCollectionGrants returns all grants on a collection.
+func (s *Store) ListCollectionGrants(collectionID string) ([]models.CollectionGrant, error) {
+	rows, err := s.db.Query(s.q(`
+		SELECT cg.id, cg.collection_id, cg.workspace_id, cg.user_id, cg.permission, cg.granted_by, cg.created_at,
+		       COALESCE(u.name, ''), COALESCE(u.email, ''), COALESCE(u.username, '')
+		FROM collection_grants cg
+		LEFT JOIN users u ON u.id = cg.user_id
+		WHERE cg.collection_id = ?
+		ORDER BY cg.created_at ASC
+	`), collectionID)
+	if err != nil {
+		return nil, fmt.Errorf("list collection grants: %w", err)
+	}
+	defer rows.Close()
+
+	var result []models.CollectionGrant
+	for rows.Next() {
+		var g models.CollectionGrant
+		var createdAt string
+		if err := rows.Scan(
+			&g.ID, &g.CollectionID, &g.WorkspaceID, &g.UserID, &g.Permission, &g.GrantedBy, &createdAt,
+			&g.UserName, &g.UserEmail, &g.UserUsername,
+		); err != nil {
+			return nil, err
+		}
+		g.CreatedAt = parseTime(createdAt)
+		result = append(result, g)
+	}
+	return result, rows.Err()
+}
+
+// DeleteCollectionGrant revokes a collection grant by ID.
+func (s *Store) DeleteCollectionGrant(id string) error {
+	result, err := s.db.Exec(s.q("DELETE FROM collection_grants WHERE id = ?"), id)
+	if err != nil {
+		return fmt.Errorf("delete collection grant: %w", err)
+	}
+	n, _ := result.RowsAffected()
+	if n == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
+}
+
+// --- Item Grants ---
+
+// CreateItemGrant creates a direct grant on an item for a user.
+func (s *Store) CreateItemGrant(workspaceID, itemID, userID, permission, grantedBy string) (*models.ItemGrant, error) {
+	id := newID()
+	ts := now()
+
+	_, err := s.db.Exec(s.q(`
+		INSERT INTO item_grants (id, item_id, workspace_id, user_id, permission, granted_by, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?)
+	`), id, itemID, workspaceID, userID, permission, grantedBy, ts)
+	if err != nil {
+		return nil, fmt.Errorf("create item grant: %w", err)
+	}
+
+	return s.GetItemGrant(id)
+}
+
+// GetItemGrant retrieves an item grant by ID.
+func (s *Store) GetItemGrant(id string) (*models.ItemGrant, error) {
+	var g models.ItemGrant
+	var createdAt string
+
+	err := s.db.QueryRow(s.q(`
+		SELECT ig.id, ig.item_id, ig.workspace_id, ig.user_id, ig.permission, ig.granted_by, ig.created_at,
+		       COALESCE(u.name, ''), COALESCE(u.email, ''), COALESCE(u.username, '')
+		FROM item_grants ig
+		LEFT JOIN users u ON u.id = ig.user_id
+		WHERE ig.id = ?
+	`), id).Scan(
+		&g.ID, &g.ItemID, &g.WorkspaceID, &g.UserID, &g.Permission, &g.GrantedBy, &createdAt,
+		&g.UserName, &g.UserEmail, &g.UserUsername,
+	)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get item grant: %w", err)
+	}
+
+	g.CreatedAt = parseTime(createdAt)
+	return &g, nil
+}
+
+// ListItemGrants returns all grants on an item.
+func (s *Store) ListItemGrants(itemID string) ([]models.ItemGrant, error) {
+	rows, err := s.db.Query(s.q(`
+		SELECT ig.id, ig.item_id, ig.workspace_id, ig.user_id, ig.permission, ig.granted_by, ig.created_at,
+		       COALESCE(u.name, ''), COALESCE(u.email, ''), COALESCE(u.username, '')
+		FROM item_grants ig
+		LEFT JOIN users u ON u.id = ig.user_id
+		WHERE ig.item_id = ?
+		ORDER BY ig.created_at ASC
+	`), itemID)
+	if err != nil {
+		return nil, fmt.Errorf("list item grants: %w", err)
+	}
+	defer rows.Close()
+
+	var result []models.ItemGrant
+	for rows.Next() {
+		var g models.ItemGrant
+		var createdAt string
+		if err := rows.Scan(
+			&g.ID, &g.ItemID, &g.WorkspaceID, &g.UserID, &g.Permission, &g.GrantedBy, &createdAt,
+			&g.UserName, &g.UserEmail, &g.UserUsername,
+		); err != nil {
+			return nil, err
+		}
+		g.CreatedAt = parseTime(createdAt)
+		result = append(result, g)
+	}
+	return result, rows.Err()
+}
+
+// DeleteItemGrant revokes an item grant by ID.
+func (s *Store) DeleteItemGrant(id string) error {
+	result, err := s.db.Exec(s.q("DELETE FROM item_grants WHERE id = ?"), id)
+	if err != nil {
+		return fmt.Errorf("delete item grant: %w", err)
+	}
+	n, _ := result.RowsAffected()
+	if n == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
+}
+
+// --- Cross-cutting queries ---
+
+// ListUserGrants returns all collection and item grants for a user in a workspace.
+func (s *Store) ListUserGrants(workspaceID, userID string) ([]models.CollectionGrant, []models.ItemGrant, error) {
+	collGrants, err := s.listUserCollectionGrants(workspaceID, userID)
+	if err != nil {
+		return nil, nil, err
+	}
+	itemGrants, err := s.listUserItemGrants(workspaceID, userID)
+	if err != nil {
+		return nil, nil, err
+	}
+	return collGrants, itemGrants, nil
+}
+
+func (s *Store) listUserCollectionGrants(workspaceID, userID string) ([]models.CollectionGrant, error) {
+	rows, err := s.db.Query(s.q(`
+		SELECT cg.id, cg.collection_id, cg.workspace_id, cg.user_id, cg.permission, cg.granted_by, cg.created_at,
+		       COALESCE(u.name, ''), COALESCE(u.email, ''), COALESCE(u.username, '')
+		FROM collection_grants cg
+		LEFT JOIN users u ON u.id = cg.user_id
+		WHERE cg.workspace_id = ? AND cg.user_id = ?
+		ORDER BY cg.created_at ASC
+	`), workspaceID, userID)
+	if err != nil {
+		return nil, fmt.Errorf("list user collection grants: %w", err)
+	}
+	defer rows.Close()
+
+	var result []models.CollectionGrant
+	for rows.Next() {
+		var g models.CollectionGrant
+		var createdAt string
+		if err := rows.Scan(
+			&g.ID, &g.CollectionID, &g.WorkspaceID, &g.UserID, &g.Permission, &g.GrantedBy, &createdAt,
+			&g.UserName, &g.UserEmail, &g.UserUsername,
+		); err != nil {
+			return nil, err
+		}
+		g.CreatedAt = parseTime(createdAt)
+		result = append(result, g)
+	}
+	return result, rows.Err()
+}
+
+func (s *Store) listUserItemGrants(workspaceID, userID string) ([]models.ItemGrant, error) {
+	rows, err := s.db.Query(s.q(`
+		SELECT ig.id, ig.item_id, ig.workspace_id, ig.user_id, ig.permission, ig.granted_by, ig.created_at,
+		       COALESCE(u.name, ''), COALESCE(u.email, ''), COALESCE(u.username, '')
+		FROM item_grants ig
+		LEFT JOIN users u ON u.id = ig.user_id
+		WHERE ig.workspace_id = ? AND ig.user_id = ?
+		ORDER BY ig.created_at ASC
+	`), workspaceID, userID)
+	if err != nil {
+		return nil, fmt.Errorf("list user item grants: %w", err)
+	}
+	defer rows.Close()
+
+	var result []models.ItemGrant
+	for rows.Next() {
+		var g models.ItemGrant
+		var createdAt string
+		if err := rows.Scan(
+			&g.ID, &g.ItemID, &g.WorkspaceID, &g.UserID, &g.Permission, &g.GrantedBy, &createdAt,
+			&g.UserName, &g.UserEmail, &g.UserUsername,
+		); err != nil {
+			return nil, err
+		}
+		g.CreatedAt = parseTime(createdAt)
+		result = append(result, g)
+	}
+	return result, rows.Err()
+}
+
+// RevokeAllUserGrants deletes all collection and item grants for a user in a workspace.
+// Used when removing a member with "revoke all access" option.
+func (s *Store) RevokeAllUserGrants(workspaceID, userID string) error {
+	_, err := s.db.Exec(s.q("DELETE FROM collection_grants WHERE workspace_id = ? AND user_id = ?"), workspaceID, userID)
+	if err != nil {
+		return fmt.Errorf("revoke collection grants: %w", err)
+	}
+	_, err = s.db.Exec(s.q("DELETE FROM item_grants WHERE workspace_id = ? AND user_id = ?"), workspaceID, userID)
+	if err != nil {
+		return fmt.Errorf("revoke item grants: %w", err)
+	}
+	return nil
+}
+
+// ResolveUserPermission resolves the effective permission for a user on a specific
+// item, following the permission resolution order from DOC-406:
+// 1. Owner bypass → 2. Item grant → 3. Collection grant → 4. Membership → 5. Deny
+// Returns the permission string ("view", "edit", "admin", "owner") or "" if denied.
+func (s *Store) ResolveUserPermission(workspaceID, userID, itemID, collectionID string) (string, error) {
+	// 1. Is user the workspace owner?
+	var ownerID string
+	err := s.db.QueryRow(s.q("SELECT owner_id FROM workspaces WHERE id = ?"), workspaceID).Scan(&ownerID)
+	if err != nil {
+		return "", fmt.Errorf("check workspace owner: %w", err)
+	}
+	if ownerID == userID {
+		return "owner", nil
+	}
+
+	// 2. Item-level grant?
+	if itemID != "" {
+		var perm string
+		err := s.db.QueryRow(s.q(
+			"SELECT permission FROM item_grants WHERE item_id = ? AND user_id = ?"),
+			itemID, userID).Scan(&perm)
+		if err == nil {
+			return perm, nil
+		}
+		if err != sql.ErrNoRows {
+			return "", fmt.Errorf("check item grant: %w", err)
+		}
+	}
+
+	// 3. Collection-level grant?
+	if collectionID != "" {
+		var perm string
+		err := s.db.QueryRow(s.q(
+			"SELECT permission FROM collection_grants WHERE collection_id = ? AND user_id = ?"),
+			collectionID, userID).Scan(&perm)
+		if err == nil {
+			return perm, nil
+		}
+		if err != sql.ErrNoRows {
+			return "", fmt.Errorf("check collection grant: %w", err)
+		}
+	}
+
+	// 4. Workspace membership?
+	member, err := s.GetWorkspaceMember(workspaceID, userID)
+	if err != nil {
+		return "", fmt.Errorf("check membership: %w", err)
+	}
+	if member != nil {
+		// Check collection visibility for members with "specific" access
+		if collectionID != "" && member.CollectionAccess == "specific" {
+			visIDs, err := s.VisibleCollectionIDs(workspaceID, userID)
+			if err != nil {
+				return "", err
+			}
+			visible := false
+			for _, id := range visIDs {
+				if id == collectionID {
+					visible = true
+					break
+				}
+			}
+			if !visible {
+				return "", nil // Collection not visible → deny
+			}
+		}
+		return member.Role, nil // "owner", "editor", or "viewer"
+	}
+
+	// 5. Deny
+	return "", nil
+}

--- a/internal/store/grants.go
+++ b/internal/store/grants.go
@@ -345,15 +345,19 @@ func (s *Store) ResolveUserPermission(workspaceID, userID, itemID, collectionID 
 	return "", nil
 }
 
-// UserHasGrantsInWorkspace checks if a user has any collection or item grants
-// in a workspace (even though they are not a member). Used to detect guests.
+// UserHasGrantsInWorkspace checks if a user has any active collection or item
+// grants in a workspace (even though they are not a member). Used to detect guests.
+// Item grants on soft-deleted items are excluded so archived items don't create
+// phantom guest access to a workspace shell with no visible content.
 func (s *Store) UserHasGrantsInWorkspace(workspaceID, userID string) (bool, error) {
 	var count int
 	err := s.db.QueryRow(s.q(`
 		SELECT COUNT(*) FROM (
 			SELECT 1 FROM collection_grants WHERE workspace_id = ? AND user_id = ?
 			UNION ALL
-			SELECT 1 FROM item_grants WHERE workspace_id = ? AND user_id = ?
+			SELECT 1 FROM item_grants ig
+			JOIN items i ON i.id = ig.item_id
+			WHERE ig.workspace_id = ? AND ig.user_id = ? AND i.deleted_at IS NULL
 			LIMIT 1
 		) AS grant_check
 	`), workspaceID, userID, workspaceID, userID).Scan(&count)

--- a/internal/store/grants.go
+++ b/internal/store/grants.go
@@ -82,9 +82,9 @@ func (s *Store) ListCollectionGrants(collectionID string) ([]models.CollectionGr
 	return result, rows.Err()
 }
 
-// DeleteCollectionGrant revokes a collection grant by ID.
-func (s *Store) DeleteCollectionGrant(id string) error {
-	result, err := s.db.Exec(s.q("DELETE FROM collection_grants WHERE id = ?"), id)
+// DeleteCollectionGrant revokes a collection grant by ID, scoped to a workspace.
+func (s *Store) DeleteCollectionGrant(id, workspaceID string) error {
+	result, err := s.db.Exec(s.q("DELETE FROM collection_grants WHERE id = ? AND workspace_id = ?"), id, workspaceID)
 	if err != nil {
 		return fmt.Errorf("delete collection grant: %w", err)
 	}
@@ -170,9 +170,9 @@ func (s *Store) ListItemGrants(itemID string) ([]models.ItemGrant, error) {
 	return result, rows.Err()
 }
 
-// DeleteItemGrant revokes an item grant by ID.
-func (s *Store) DeleteItemGrant(id string) error {
-	result, err := s.db.Exec(s.q("DELETE FROM item_grants WHERE id = ?"), id)
+// DeleteItemGrant revokes an item grant by ID, scoped to a workspace.
+func (s *Store) DeleteItemGrant(id, workspaceID string) error {
+	result, err := s.db.Exec(s.q("DELETE FROM item_grants WHERE id = ? AND workspace_id = ?"), id, workspaceID)
 	if err != nil {
 		return fmt.Errorf("delete item grant: %w", err)
 	}
@@ -355,7 +355,7 @@ func (s *Store) UserHasGrantsInWorkspace(workspaceID, userID string) (bool, erro
 			UNION ALL
 			SELECT 1 FROM item_grants WHERE workspace_id = ? AND user_id = ?
 			LIMIT 1
-		)
+		) AS grant_check
 	`), workspaceID, userID, workspaceID, userID).Scan(&count)
 	if err != nil {
 		return false, fmt.Errorf("check user grants: %w", err)
@@ -410,4 +410,54 @@ func (s *Store) GuestVisibleCollectionIDs(workspaceID, userID string) ([]string,
 		result = append(result, id)
 	}
 	return result, nil
+}
+
+// GuestVisibleResources returns the two-level visibility for a guest:
+// - fullCollectionIDs: collections where the user has a direct collection grant (full access)
+// - grantedItemIDs: specific item IDs the user has item-level grants on
+// This allows callers to distinguish between full-collection access and item-only access.
+func (s *Store) GuestVisibleResources(workspaceID, userID string) (fullCollectionIDs []string, grantedItemIDs []string, err error) {
+	// Collections with direct grants (full collection access)
+	rows, err := s.db.Query(s.q(`
+		SELECT DISTINCT collection_id FROM collection_grants
+		WHERE workspace_id = ? AND user_id = ?
+	`), workspaceID, userID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("guest collection grants: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, nil, err
+		}
+		fullCollectionIDs = append(fullCollectionIDs, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, nil, err
+	}
+
+	// Individual item IDs with direct grants
+	itemRows, err := s.db.Query(s.q(`
+		SELECT DISTINCT ig.item_id
+		FROM item_grants ig
+		JOIN items i ON i.id = ig.item_id
+		WHERE ig.workspace_id = ? AND ig.user_id = ? AND i.deleted_at IS NULL
+	`), workspaceID, userID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("guest item grants: %w", err)
+	}
+	defer itemRows.Close()
+	for itemRows.Next() {
+		var id string
+		if err := itemRows.Scan(&id); err != nil {
+			return nil, nil, err
+		}
+		grantedItemIDs = append(grantedItemIDs, id)
+	}
+	if err := itemRows.Err(); err != nil {
+		return nil, nil, err
+	}
+
+	return fullCollectionIDs, grantedItemIDs, nil
 }

--- a/internal/store/grants.go
+++ b/internal/store/grants.go
@@ -344,3 +344,70 @@ func (s *Store) ResolveUserPermission(workspaceID, userID, itemID, collectionID 
 	// 5. Deny
 	return "", nil
 }
+
+// UserHasGrantsInWorkspace checks if a user has any collection or item grants
+// in a workspace (even though they are not a member). Used to detect guests.
+func (s *Store) UserHasGrantsInWorkspace(workspaceID, userID string) (bool, error) {
+	var count int
+	err := s.db.QueryRow(s.q(`
+		SELECT COUNT(*) FROM (
+			SELECT 1 FROM collection_grants WHERE workspace_id = ? AND user_id = ?
+			UNION ALL
+			SELECT 1 FROM item_grants WHERE workspace_id = ? AND user_id = ?
+			LIMIT 1
+		)
+	`), workspaceID, userID, workspaceID, userID).Scan(&count)
+	if err != nil {
+		return false, fmt.Errorf("check user grants: %w", err)
+	}
+	return count > 0, nil
+}
+
+// GuestVisibleCollectionIDs returns the collection IDs a guest (non-member with
+// grants) can see. Includes collections with direct collection_grants and
+// collections that contain items the user has item_grants on.
+func (s *Store) GuestVisibleCollectionIDs(workspaceID, userID string) ([]string, error) {
+	ids := make(map[string]bool)
+
+	// Collections with direct grants
+	rows, err := s.db.Query(s.q(`
+		SELECT DISTINCT collection_id FROM collection_grants
+		WHERE workspace_id = ? AND user_id = ?
+	`), workspaceID, userID)
+	if err != nil {
+		return nil, fmt.Errorf("guest collection grants: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids[id] = true
+	}
+
+	// Collections containing items with direct grants
+	itemRows, err := s.db.Query(s.q(`
+		SELECT DISTINCT i.collection_id
+		FROM item_grants ig
+		JOIN items i ON i.id = ig.item_id
+		WHERE ig.workspace_id = ? AND ig.user_id = ? AND i.deleted_at IS NULL
+	`), workspaceID, userID)
+	if err != nil {
+		return nil, fmt.Errorf("guest item grant collections: %w", err)
+	}
+	defer itemRows.Close()
+	for itemRows.Next() {
+		var id string
+		if err := itemRows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids[id] = true
+	}
+
+	result := make([]string, 0, len(ids))
+	for id := range ids {
+		result = append(result, id)
+	}
+	return result, nil
+}

--- a/internal/store/grants.go
+++ b/internal/store/grants.go
@@ -347,17 +347,20 @@ func (s *Store) ResolveUserPermission(workspaceID, userID, itemID, collectionID 
 
 // UserHasGrantsInWorkspace checks if a user has any active collection or item
 // grants in a workspace (even though they are not a member). Used to detect guests.
-// Item grants on soft-deleted items are excluded so archived items don't create
-// phantom guest access to a workspace shell with no visible content.
+// Grants on soft-deleted items or soft-deleted collections are excluded so
+// archived resources don't create phantom guest access.
 func (s *Store) UserHasGrantsInWorkspace(workspaceID, userID string) (bool, error) {
 	var count int
 	err := s.db.QueryRow(s.q(`
 		SELECT COUNT(*) FROM (
-			SELECT 1 FROM collection_grants WHERE workspace_id = ? AND user_id = ?
+			SELECT 1 FROM collection_grants cg
+			JOIN collections c ON c.id = cg.collection_id
+			WHERE cg.workspace_id = ? AND cg.user_id = ? AND c.deleted_at IS NULL
 			UNION ALL
 			SELECT 1 FROM item_grants ig
 			JOIN items i ON i.id = ig.item_id
-			WHERE ig.workspace_id = ? AND ig.user_id = ? AND i.deleted_at IS NULL
+			JOIN collections c ON c.id = i.collection_id
+			WHERE ig.workspace_id = ? AND ig.user_id = ? AND i.deleted_at IS NULL AND c.deleted_at IS NULL
 			LIMIT 1
 		) AS grant_check
 	`), workspaceID, userID, workspaceID, userID).Scan(&count)
@@ -373,10 +376,11 @@ func (s *Store) UserHasGrantsInWorkspace(workspaceID, userID string) (bool, erro
 func (s *Store) GuestVisibleCollectionIDs(workspaceID, userID string) ([]string, error) {
 	ids := make(map[string]bool)
 
-	// Collections with direct grants
+	// Collections with direct grants (excluding soft-deleted collections)
 	rows, err := s.db.Query(s.q(`
-		SELECT DISTINCT collection_id FROM collection_grants
-		WHERE workspace_id = ? AND user_id = ?
+		SELECT DISTINCT cg.collection_id FROM collection_grants cg
+		JOIN collections c ON c.id = cg.collection_id
+		WHERE cg.workspace_id = ? AND cg.user_id = ? AND c.deleted_at IS NULL
 	`), workspaceID, userID)
 	if err != nil {
 		return nil, fmt.Errorf("guest collection grants: %w", err)
@@ -390,12 +394,13 @@ func (s *Store) GuestVisibleCollectionIDs(workspaceID, userID string) ([]string,
 		ids[id] = true
 	}
 
-	// Collections containing items with direct grants
+	// Collections containing items with direct grants (excluding soft-deleted)
 	itemRows, err := s.db.Query(s.q(`
 		SELECT DISTINCT i.collection_id
 		FROM item_grants ig
 		JOIN items i ON i.id = ig.item_id
-		WHERE ig.workspace_id = ? AND ig.user_id = ? AND i.deleted_at IS NULL
+		JOIN collections c ON c.id = i.collection_id
+		WHERE ig.workspace_id = ? AND ig.user_id = ? AND i.deleted_at IS NULL AND c.deleted_at IS NULL
 	`), workspaceID, userID)
 	if err != nil {
 		return nil, fmt.Errorf("guest item grant collections: %w", err)
@@ -421,10 +426,11 @@ func (s *Store) GuestVisibleCollectionIDs(workspaceID, userID string) ([]string,
 // - grantedItemIDs: specific item IDs the user has item-level grants on
 // This allows callers to distinguish between full-collection access and item-only access.
 func (s *Store) GuestVisibleResources(workspaceID, userID string) (fullCollectionIDs []string, grantedItemIDs []string, err error) {
-	// Collections with direct grants (full collection access)
+	// Collections with direct grants (full collection access, excluding soft-deleted)
 	rows, err := s.db.Query(s.q(`
-		SELECT DISTINCT collection_id FROM collection_grants
-		WHERE workspace_id = ? AND user_id = ?
+		SELECT DISTINCT cg.collection_id FROM collection_grants cg
+		JOIN collections c ON c.id = cg.collection_id
+		WHERE cg.workspace_id = ? AND cg.user_id = ? AND c.deleted_at IS NULL
 	`), workspaceID, userID)
 	if err != nil {
 		return nil, nil, fmt.Errorf("guest collection grants: %w", err)
@@ -441,12 +447,13 @@ func (s *Store) GuestVisibleResources(workspaceID, userID string) (fullCollectio
 		return nil, nil, err
 	}
 
-	// Individual item IDs with direct grants
+	// Individual item IDs with direct grants (excluding soft-deleted items/collections)
 	itemRows, err := s.db.Query(s.q(`
 		SELECT DISTINCT ig.item_id
 		FROM item_grants ig
 		JOIN items i ON i.id = ig.item_id
-		WHERE ig.workspace_id = ? AND ig.user_id = ? AND i.deleted_at IS NULL
+		JOIN collections c ON c.id = i.collection_id
+		WHERE ig.workspace_id = ? AND ig.user_id = ? AND i.deleted_at IS NULL AND c.deleted_at IS NULL
 	`), workspaceID, userID)
 	if err != nil {
 		return nil, nil, fmt.Errorf("guest item grants: %w", err)

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -464,13 +464,35 @@ func (s *Store) ListItems(workspaceID string, params models.ItemListParams) ([]m
 		args = append(args, params.CollectionSlug)
 	}
 
-	if len(params.CollectionIDs) > 0 {
+	if len(params.CollectionIDs) > 0 && len(params.ItemIDs) > 0 {
+		// Guest with both collection-level and item-level grants:
+		// item must be in a fully-granted collection OR be a specifically granted item
+		collPlaceholders := make([]string, len(params.CollectionIDs))
+		for i, id := range params.CollectionIDs {
+			collPlaceholders[i] = "?"
+			args = append(args, id)
+		}
+		itemPlaceholders := make([]string, len(params.ItemIDs))
+		for i, id := range params.ItemIDs {
+			itemPlaceholders[i] = "?"
+			args = append(args, id)
+		}
+		query += " AND (i.collection_id IN (" + strings.Join(collPlaceholders, ",") + ") OR i.id IN (" + strings.Join(itemPlaceholders, ",") + "))"
+	} else if len(params.CollectionIDs) > 0 {
 		placeholders := make([]string, len(params.CollectionIDs))
 		for i, id := range params.CollectionIDs {
 			placeholders[i] = "?"
 			args = append(args, id)
 		}
 		query += " AND i.collection_id IN (" + strings.Join(placeholders, ",") + ")"
+	} else if len(params.ItemIDs) > 0 {
+		// Guest with only item-level grants (no collection-level grants)
+		placeholders := make([]string, len(params.ItemIDs))
+		for i, id := range params.ItemIDs {
+			placeholders[i] = "?"
+			args = append(args, id)
+		}
+		query += " AND i.id IN (" + strings.Join(placeholders, ",") + ")"
 	}
 
 	if params.Tag != "" {
@@ -599,13 +621,32 @@ func (s *Store) listItemsFTS(workspaceID string, params models.ItemListParams) (
 		args = append(args, params.CollectionSlug)
 	}
 
-	if len(params.CollectionIDs) > 0 {
+	if len(params.CollectionIDs) > 0 && len(params.ItemIDs) > 0 {
+		collPlaceholders := make([]string, len(params.CollectionIDs))
+		for i, id := range params.CollectionIDs {
+			collPlaceholders[i] = "?"
+			args = append(args, id)
+		}
+		itemPlaceholders := make([]string, len(params.ItemIDs))
+		for i, id := range params.ItemIDs {
+			itemPlaceholders[i] = "?"
+			args = append(args, id)
+		}
+		query += " AND (i.collection_id IN (" + strings.Join(collPlaceholders, ",") + ") OR i.id IN (" + strings.Join(itemPlaceholders, ",") + "))"
+	} else if len(params.CollectionIDs) > 0 {
 		placeholders := make([]string, len(params.CollectionIDs))
 		for i, id := range params.CollectionIDs {
 			placeholders[i] = "?"
 			args = append(args, id)
 		}
 		query += " AND i.collection_id IN (" + strings.Join(placeholders, ",") + ")"
+	} else if len(params.ItemIDs) > 0 {
+		placeholders := make([]string, len(params.ItemIDs))
+		for i, id := range params.ItemIDs {
+			placeholders[i] = "?"
+			args = append(args, id)
+		}
+		query += " AND i.id IN (" + strings.Join(placeholders, ",") + ")"
 	}
 
 	// SQLite bm25(): more negative = more relevant → ASC (default).

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -429,8 +429,10 @@ func (s *Store) GetItemBySlugIncludeDeleted(workspaceID, slug string) (*models.I
 
 func (s *Store) ListItems(workspaceID string, params models.ItemListParams) ([]models.Item, error) {
 	// Non-nil empty CollectionIDs means "no visible collections" — return
-	// empty results immediately rather than skipping the filter clause.
-	if params.CollectionIDs != nil && len(params.CollectionIDs) == 0 {
+	// empty results immediately, unless ItemIDs are also provided (item-level
+	// grants may still allow access to specific items even without full
+	// collection access).
+	if params.CollectionIDs != nil && len(params.CollectionIDs) == 0 && len(params.ItemIDs) == 0 {
 		return nil, nil
 	}
 

--- a/internal/store/migrations/033_grants.sql
+++ b/internal/store/migrations/033_grants.sql
@@ -1,0 +1,30 @@
+-- Collection and item grants for guest access and member overrides (TASK-417).
+-- Permission resolution order: owner bypass → item grant → collection grant → membership → deny.
+
+CREATE TABLE IF NOT EXISTS collection_grants (
+    id TEXT PRIMARY KEY,
+    collection_id TEXT NOT NULL REFERENCES collections(id) ON DELETE CASCADE,
+    workspace_id TEXT NOT NULL REFERENCES workspaces(id),
+    user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    permission TEXT NOT NULL DEFAULT 'view',   -- 'view' or 'edit'
+    granted_by TEXT NOT NULL REFERENCES users(id),
+    created_at TEXT NOT NULL,
+    UNIQUE(collection_id, user_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_collection_grants_user ON collection_grants(user_id, workspace_id);
+CREATE INDEX IF NOT EXISTS idx_collection_grants_collection ON collection_grants(collection_id);
+
+CREATE TABLE IF NOT EXISTS item_grants (
+    id TEXT PRIMARY KEY,
+    item_id TEXT NOT NULL REFERENCES items(id) ON DELETE CASCADE,
+    workspace_id TEXT NOT NULL REFERENCES workspaces(id),
+    user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    permission TEXT NOT NULL DEFAULT 'view',   -- 'view' or 'edit'
+    granted_by TEXT NOT NULL REFERENCES users(id),
+    created_at TEXT NOT NULL,
+    UNIQUE(item_id, user_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_item_grants_user ON item_grants(user_id, workspace_id);
+CREATE INDEX IF NOT EXISTS idx_item_grants_item ON item_grants(item_id);

--- a/internal/store/pgmigrations/013_grants.sql
+++ b/internal/store/pgmigrations/013_grants.sql
@@ -1,0 +1,29 @@
+-- Collection and item grants for guest access and member overrides (TASK-417).
+
+CREATE TABLE IF NOT EXISTS collection_grants (
+    id TEXT PRIMARY KEY,
+    collection_id TEXT NOT NULL REFERENCES collections(id) ON DELETE CASCADE,
+    workspace_id TEXT NOT NULL REFERENCES workspaces(id),
+    user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    permission TEXT NOT NULL DEFAULT 'view',
+    granted_by TEXT NOT NULL REFERENCES users(id),
+    created_at TEXT NOT NULL,
+    UNIQUE(collection_id, user_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_collection_grants_user ON collection_grants(user_id, workspace_id);
+CREATE INDEX IF NOT EXISTS idx_collection_grants_collection ON collection_grants(collection_id);
+
+CREATE TABLE IF NOT EXISTS item_grants (
+    id TEXT PRIMARY KEY,
+    item_id TEXT NOT NULL REFERENCES items(id) ON DELETE CASCADE,
+    workspace_id TEXT NOT NULL REFERENCES workspaces(id),
+    user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    permission TEXT NOT NULL DEFAULT 'view',
+    granted_by TEXT NOT NULL REFERENCES users(id),
+    created_at TEXT NOT NULL,
+    UNIQUE(item_id, user_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_item_grants_user ON item_grants(user_id, workspace_id);
+CREATE INDEX IF NOT EXISTS idx_item_grants_item ON item_grants(item_id);

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -32,8 +32,10 @@ type SearchParams struct {
 
 func (s *Store) Search(params SearchParams) ([]SearchResult, error) {
 	// Non-nil empty CollectionIDs means "no visible collections" — return
-	// empty results immediately rather than skipping the filter clause.
-	if params.CollectionIDs != nil && len(params.CollectionIDs) == 0 {
+	// empty results immediately, unless ItemIDs are also provided (item-level
+	// grants may still allow access to specific items even without full
+	// collection access).
+	if params.CollectionIDs != nil && len(params.CollectionIDs) == 0 && len(params.ItemIDs) == 0 {
 		return nil, nil
 	}
 

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -27,6 +27,7 @@ type SearchParams struct {
 	Workspace     string   // workspace slug, optional — scopes to single workspace
 	WorkspaceIDs  []string // workspace IDs to scope results to (used when no specific workspace is given)
 	CollectionIDs []string // permission filter: restrict to these collection IDs (nil = no filter)
+	ItemIDs       []string // permission filter: additionally allow these specific item IDs (for item-level grants)
 }
 
 func (s *Store) Search(params SearchParams) ([]SearchResult, error) {
@@ -67,9 +68,22 @@ func (s *Store) Search(params SearchParams) ([]SearchResult, error) {
 			}
 		}
 
-		if len(params.CollectionIDs) > 0 {
+		if len(params.CollectionIDs) > 0 && len(params.ItemIDs) > 0 {
+			refQuery += ` AND (i.collection_id IN (` + placeholders(len(params.CollectionIDs)) + `) OR i.id IN (` + placeholders(len(params.ItemIDs)) + `))`
+			for _, id := range params.CollectionIDs {
+				refArgs = append(refArgs, id)
+			}
+			for _, id := range params.ItemIDs {
+				refArgs = append(refArgs, id)
+			}
+		} else if len(params.CollectionIDs) > 0 {
 			refQuery += ` AND i.collection_id IN (` + placeholders(len(params.CollectionIDs)) + `)`
 			for _, id := range params.CollectionIDs {
+				refArgs = append(refArgs, id)
+			}
+		} else if len(params.ItemIDs) > 0 {
+			refQuery += ` AND i.id IN (` + placeholders(len(params.ItemIDs)) + `)`
+			for _, id := range params.ItemIDs {
 				refArgs = append(refArgs, id)
 			}
 		}
@@ -179,9 +193,22 @@ func (s *Store) Search(params SearchParams) ([]SearchResult, error) {
 		}
 	}
 
-	if len(params.CollectionIDs) > 0 {
+	if len(params.CollectionIDs) > 0 && len(params.ItemIDs) > 0 {
+		query += ` AND (i.collection_id IN (` + placeholders(len(params.CollectionIDs)) + `) OR i.id IN (` + placeholders(len(params.ItemIDs)) + `))`
+		for _, id := range params.CollectionIDs {
+			args = append(args, id)
+		}
+		for _, id := range params.ItemIDs {
+			args = append(args, id)
+		}
+	} else if len(params.CollectionIDs) > 0 {
 		query += ` AND i.collection_id IN (` + placeholders(len(params.CollectionIDs)) + `)`
 		for _, id := range params.CollectionIDs {
+			args = append(args, id)
+		}
+	} else if len(params.ItemIDs) > 0 {
+		query += ` AND i.id IN (` + placeholders(len(params.ItemIDs)) + `)`
+		for _, id := range params.ItemIDs {
 			args = append(args, id)
 		}
 	}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -157,6 +157,7 @@ func (s *Store) migrate() error {
 		"030_workspace_owner.sql",
 		"031_collection_access.sql",
 		"032_permission_indexes.sql",
+		"033_grants.sql",
 	}
 
 	for _, name := range migrations {
@@ -213,6 +214,7 @@ func (s *Store) migratePostgres() error {
 		"010_workspace_owner.sql",
 		"011_collection_access.sql",
 		"012_permission_indexes.sql",
+		"013_grants.sql",
 	}
 
 	for _, name := range migrations {

--- a/internal/store/workspace_members.go
+++ b/internal/store/workspace_members.go
@@ -104,7 +104,8 @@ func (s *Store) VisibleCollectionIDs(workspaceID, userID string) ([]string, erro
 		return nil, err
 	}
 	if member == nil {
-		return []string{}, nil // Not a member — no access
+		// Not a member — check for guest access via grants
+		return s.GuestVisibleCollectionIDs(workspaceID, userID)
 	}
 
 	// "all" access — return nil to indicate no filtering needed
@@ -274,7 +275,52 @@ func (s *Store) GetUserWorkspaces(userID string) ([]models.Workspace, error) {
 		ws.DeletedAt = parseTimePtr(deletedAt)
 		result = append(result, ws)
 	}
-	return result, rows.Err()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	// Also include workspaces where the user has grants but is NOT a member (guest access)
+	memberIDs := make(map[string]bool)
+	for _, ws := range result {
+		memberIDs[ws.ID] = true
+	}
+
+	guestRows, err := s.db.Query(s.q(`
+		SELECT DISTINCT w.id, w.name, w.slug, w.owner_id, COALESCE(ou.username, ''), w.description, w.settings, w.created_at, w.updated_at, w.deleted_at
+		FROM workspaces w
+		LEFT JOIN users ou ON ou.id = w.owner_id
+		WHERE w.deleted_at IS NULL AND (
+			EXISTS (SELECT 1 FROM collection_grants cg WHERE cg.workspace_id = w.id AND cg.user_id = ?)
+			OR EXISTS (SELECT 1 FROM item_grants ig WHERE ig.workspace_id = w.id AND ig.user_id = ?)
+		)
+	`), userID, userID)
+	if err != nil {
+		return result, nil // Non-fatal: return member workspaces even if guest query fails
+	}
+	defer guestRows.Close()
+
+	for guestRows.Next() {
+		var ws models.Workspace
+		var createdAt, updatedAt string
+		var deletedAt *string
+		if err := guestRows.Scan(
+			&ws.ID, &ws.Name, &ws.Slug, &ws.OwnerID, &ws.OwnerUsername, &ws.Description, &ws.Settings,
+			&createdAt, &updatedAt, &deletedAt,
+		); err != nil {
+			continue
+		}
+		// Skip workspaces the user is already a member of
+		if memberIDs[ws.ID] {
+			continue
+		}
+		ws.CreatedAt = parseTime(createdAt)
+		ws.UpdatedAt = parseTime(updatedAt)
+		ws.DeletedAt = parseTimePtr(deletedAt)
+		ws.IsGuest = true
+		result = append(result, ws)
+	}
+
+	return result, nil
 }
 
 // UpdateWorkspaceSortOrder sets the sort_order for a workspace in a user's membership.

--- a/internal/store/workspace_members.go
+++ b/internal/store/workspace_members.go
@@ -295,7 +295,7 @@ func (s *Store) GetUserWorkspaces(userID string) ([]models.Workspace, error) {
 		)
 	`), userID, userID)
 	if err != nil {
-		return result, nil // Non-fatal: return member workspaces even if guest query fails
+		return nil, fmt.Errorf("get guest workspaces: %w", err)
 	}
 	defer guestRows.Close()
 
@@ -307,7 +307,7 @@ func (s *Store) GetUserWorkspaces(userID string) ([]models.Workspace, error) {
 			&ws.ID, &ws.Name, &ws.Slug, &ws.OwnerID, &ws.OwnerUsername, &ws.Description, &ws.Settings,
 			&createdAt, &updatedAt, &deletedAt,
 		); err != nil {
-			continue
+			return nil, fmt.Errorf("scan guest workspace: %w", err)
 		}
 		// Skip workspaces the user is already a member of
 		if memberIDs[ws.ID] {
@@ -318,6 +318,9 @@ func (s *Store) GetUserWorkspaces(userID string) ([]models.Workspace, error) {
 		ws.DeletedAt = parseTimePtr(deletedAt)
 		ws.IsGuest = true
 		result = append(result, ws)
+	}
+	if err := guestRows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate guest workspaces: %w", err)
 	}
 
 	return result, nil

--- a/internal/store/workspace_members.go
+++ b/internal/store/workspace_members.go
@@ -40,6 +40,37 @@ func (s *Store) RemoveWorkspaceMember(workspaceID, userID string) error {
 	return nil
 }
 
+// RemoveWorkspaceMemberAndRevokeGrants atomically removes a user from a workspace
+// and revokes all their grants in a single transaction. This prevents the user
+// from retaining guest access if the member removal succeeds but grant revocation fails.
+func (s *Store) RemoveWorkspaceMemberAndRevokeGrants(workspaceID, userID string) error {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin transaction: %w", err)
+	}
+	defer tx.Rollback()
+
+	// Revoke grants first (before removing membership)
+	if _, err := tx.Exec(s.q("DELETE FROM collection_grants WHERE workspace_id = ? AND user_id = ?"), workspaceID, userID); err != nil {
+		return fmt.Errorf("revoke collection grants: %w", err)
+	}
+	if _, err := tx.Exec(s.q("DELETE FROM item_grants WHERE workspace_id = ? AND user_id = ?"), workspaceID, userID); err != nil {
+		return fmt.Errorf("revoke item grants: %w", err)
+	}
+
+	// Remove membership
+	result, err := tx.Exec(s.q("DELETE FROM workspace_members WHERE workspace_id = ? AND user_id = ?"), workspaceID, userID)
+	if err != nil {
+		return fmt.Errorf("remove workspace member: %w", err)
+	}
+	n, _ := result.RowsAffected()
+	if n == 0 {
+		return sql.ErrNoRows
+	}
+
+	return tx.Commit()
+}
+
 // GetWorkspaceMember retrieves a single membership record.
 func (s *Store) GetWorkspaceMember(workspaceID, userID string) (*models.WorkspaceMember, error) {
 	var m models.WorkspaceMember

--- a/internal/store/workspace_members.go
+++ b/internal/store/workspace_members.go
@@ -321,6 +321,29 @@ func (s *Store) GetMemberCollectionAccess(workspaceID, userID string) ([]string,
 	return ids, rows.Err()
 }
 
+// ListSystemCollectionIDs returns the IDs of system collections in a workspace.
+// System collections are always visible to members regardless of collection_access mode.
+func (s *Store) ListSystemCollectionIDs(workspaceID string) ([]string, error) {
+	rows, err := s.db.Query(s.q(`
+		SELECT id FROM collections
+		WHERE workspace_id = ? AND is_system = ? AND deleted_at IS NULL
+	`), workspaceID, s.dialect.BoolToInt(true))
+	if err != nil {
+		return nil, fmt.Errorf("list system collections: %w", err)
+	}
+	defer rows.Close()
+
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
+}
+
 // GetUserWorkspaces returns all workspaces a user has access to,
 // sorted by the user's custom sort order (then name as tiebreaker).
 func (s *Store) GetUserWorkspaces(userID string) ([]models.Workspace, error) {
@@ -370,8 +393,17 @@ func (s *Store) GetUserWorkspaces(userID string) ([]models.Workspace, error) {
 		FROM workspaces w
 		LEFT JOIN users ou ON ou.id = w.owner_id
 		WHERE w.deleted_at IS NULL AND (
-			EXISTS (SELECT 1 FROM collection_grants cg WHERE cg.workspace_id = w.id AND cg.user_id = ?)
-			OR EXISTS (SELECT 1 FROM item_grants ig WHERE ig.workspace_id = w.id AND ig.user_id = ?)
+			EXISTS (
+				SELECT 1 FROM collection_grants cg
+				JOIN collections c ON c.id = cg.collection_id
+				WHERE cg.workspace_id = w.id AND cg.user_id = ? AND c.deleted_at IS NULL
+			)
+			OR EXISTS (
+				SELECT 1 FROM item_grants ig
+				JOIN items i ON i.id = ig.item_id
+				JOIN collections c ON c.id = i.collection_id
+				WHERE ig.workspace_id = w.id AND ig.user_id = ? AND i.deleted_at IS NULL AND c.deleted_at IS NULL
+			)
 		)
 	`), userID, userID)
 	if err != nil {

--- a/internal/store/workspace_members.go
+++ b/internal/store/workspace_members.go
@@ -184,6 +184,18 @@ func (s *Store) VisibleCollectionIDs(workspaceID, userID string) ([]string, erro
 		ids[id] = true
 	}
 
+	// Also include collections from direct grants (collection grants +
+	// collections containing items with item grants). This ensures that
+	// members with "specific" access who are granted additional collections
+	// or items can see them even if they aren't in member_collection_access.
+	grantIDs, err := s.GuestVisibleCollectionIDs(workspaceID, userID)
+	if err != nil {
+		return nil, fmt.Errorf("get grant-based collections: %w", err)
+	}
+	for _, id := range grantIDs {
+		ids[id] = true
+	}
+
 	result := make([]string, 0, len(ids))
 	for id := range ids {
 		result = append(result, id)

--- a/internal/store/workspace_members.go
+++ b/internal/store/workspace_members.go
@@ -184,16 +184,53 @@ func (s *Store) VisibleCollectionIDs(workspaceID, userID string) ([]string, erro
 		ids[id] = true
 	}
 
-	// Also include collections from direct grants (collection grants +
-	// collections containing items with item grants). This ensures that
-	// members with "specific" access who are granted additional collections
-	// or items can see them even if they aren't in member_collection_access.
-	grantIDs, err := s.GuestVisibleCollectionIDs(workspaceID, userID)
+	// Also include collections from direct collection grants. This ensures
+	// that members with "specific" access who are granted additional
+	// collections can see them even if they aren't in member_collection_access.
+	// Note: we only merge full collection grants here, NOT collections derived
+	// from item grants. Item grants should not promote to collection-wide
+	// visibility for members — the item-level filtering in handlers handles that.
+	collGrantRows, err := s.db.Query(s.q(`
+		SELECT DISTINCT collection_id FROM collection_grants
+		WHERE workspace_id = ? AND user_id = ?
+	`), workspaceID, userID)
 	if err != nil {
-		return nil, fmt.Errorf("get grant-based collections: %w", err)
+		return nil, fmt.Errorf("get member collection grants: %w", err)
 	}
-	for _, id := range grantIDs {
+	defer collGrantRows.Close()
+	for collGrantRows.Next() {
+		var id string
+		if err := collGrantRows.Scan(&id); err != nil {
+			return nil, err
+		}
 		ids[id] = true
+	}
+	if err := collGrantRows.Err(); err != nil {
+		return nil, err
+	}
+
+	// Also include collections that contain items with item grants, so the
+	// collection appears in navigation. The actual item-level filtering is
+	// handled by the request handlers for members who also have item grants.
+	itemCollRows, err := s.db.Query(s.q(`
+		SELECT DISTINCT i.collection_id
+		FROM item_grants ig
+		JOIN items i ON i.id = ig.item_id
+		WHERE ig.workspace_id = ? AND ig.user_id = ? AND i.deleted_at IS NULL
+	`), workspaceID, userID)
+	if err != nil {
+		return nil, fmt.Errorf("get member item grant collections: %w", err)
+	}
+	defer itemCollRows.Close()
+	for itemCollRows.Next() {
+		var id string
+		if err := itemCollRows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids[id] = true
+	}
+	if err := itemCollRows.Err(); err != nil {
+		return nil, err
 	}
 
 	result := make([]string, 0, len(ids))

--- a/internal/store/workspaces.go
+++ b/internal/store/workspaces.go
@@ -169,16 +169,18 @@ func (s *Store) GetWorkspaceByID(id string) (*models.Workspace, error) {
 }
 
 // GetWorkspacesBySlugForUser finds workspaces matching a slug that are accessible
-// to the given user (owned by them or where they are a member).
+// to the given user (owned, member, or guest with grants).
 func (s *Store) GetWorkspacesBySlugForUser(slug, userID string) ([]models.Workspace, error) {
 	rows, err := s.db.Query(s.q(`
 		SELECT DISTINCT w.id, w.name, w.slug, w.owner_id, COALESCE(ou.username, ''), w.description, w.settings, w.created_at, w.updated_at
 		FROM workspaces w
 		LEFT JOIN workspace_members wm ON wm.workspace_id = w.id AND wm.user_id = ?
+		LEFT JOIN collection_grants cg ON cg.workspace_id = w.id AND cg.user_id = ?
+		LEFT JOIN item_grants ig ON ig.workspace_id = w.id AND ig.user_id = ?
 		LEFT JOIN users ou ON ou.id = w.owner_id
 		WHERE w.slug = ? AND w.deleted_at IS NULL
-		AND (w.owner_id = ? OR wm.user_id IS NOT NULL)
-	`), userID, slug, userID)
+		AND (w.owner_id = ? OR wm.user_id IS NOT NULL OR cg.user_id IS NOT NULL OR ig.user_id IS NOT NULL)
+	`), userID, userID, userID, slug, userID)
 	if err != nil {
 		return nil, fmt.Errorf("get workspaces by slug for user: %w", err)
 	}

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -507,8 +507,8 @@ export const api = {
 				`/workspaces/${ws}/members/invite`,
 				{ method: 'POST', body: JSON.stringify({ email, role }) }
 			),
-		remove: (ws: string, userId: string) =>
-			request<void>(`/workspaces/${ws}/members/${userId}`, { method: 'DELETE' }),
+		remove: (ws: string, userId: string, revokeGrants: boolean = true) =>
+			request<void>(`/workspaces/${ws}/members/${userId}?revoke_grants=${revokeGrants}`, { method: 'DELETE' }),
 		updateRole: (ws: string, userId: string, role: string) =>
 			request<{ user_id: string; role: string }>(`/workspaces/${ws}/members/${userId}`, {
 				method: 'PATCH',

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -33,7 +33,9 @@ import type {
 	AgentRoleCreate,
 	AgentRoleUpdate,
 	RoleBoardLane,
-	ChangesResponse
+	ChangesResponse,
+	CollectionGrant,
+	ItemGrant
 } from '$lib/types';
 
 const BASE = '/api/v1';
@@ -525,6 +527,31 @@ export const api = {
 				method: 'PUT',
 				body: JSON.stringify({ mode, collection_ids: collectionIDs })
 			})
+	},
+
+	// ── Grants ───────────────────────────────────────────────────────────────
+
+	grants: {
+		listCollectionGrants: (ws: string, collSlug: string) =>
+			request<CollectionGrant[]>(`/workspaces/${ws}/collections/${collSlug}/grants`),
+		createCollectionGrant: (ws: string, collSlug: string, email: string, permission: string) =>
+			request<CollectionGrant>(`/workspaces/${ws}/collections/${collSlug}/grants`, {
+				method: 'POST',
+				body: JSON.stringify({ email, permission })
+			}),
+		deleteCollectionGrant: (ws: string, collSlug: string, grantId: string) =>
+			request<void>(`/workspaces/${ws}/collections/${collSlug}/grants/${grantId}`, { method: 'DELETE' }),
+		listItemGrants: (ws: string, itemSlug: string) =>
+			request<ItemGrant[]>(`/workspaces/${ws}/items/${itemSlug}/grants`),
+		createItemGrant: (ws: string, itemSlug: string, email: string, permission: string) =>
+			request<ItemGrant>(`/workspaces/${ws}/items/${itemSlug}/grants`, {
+				method: 'POST',
+				body: JSON.stringify({ email, permission })
+			}),
+		deleteItemGrant: (ws: string, itemSlug: string, grantId: string) =>
+			request<void>(`/workspaces/${ws}/items/${itemSlug}/grants/${grantId}`, { method: 'DELETE' }),
+		listUserGrants: (ws: string, userId: string) =>
+			request<{ collection_grants: CollectionGrant[]; item_grants: ItemGrant[] }>(`/workspaces/${ws}/users/${userId}/grants`),
 	},
 
 	// ── Auth ──────────────────────────────────────────────────────────────────

--- a/web/src/lib/components/ShareDialog.svelte
+++ b/web/src/lib/components/ShareDialog.svelte
@@ -1,0 +1,474 @@
+<script lang="ts">
+	import { api } from '$lib/api/client';
+	import { toastStore } from '$lib/stores/toast.svelte';
+	import type { CollectionGrant, ItemGrant } from '$lib/types';
+
+	interface Props {
+		wsSlug: string;
+		type: 'collection' | 'item';
+		targetSlug: string;
+		targetName: string;
+		open: boolean;
+	}
+
+	let { wsSlug, type, targetSlug, targetName, open = $bindable() }: Props = $props();
+
+	let grants = $state<(CollectionGrant | ItemGrant)[]>([]);
+	let loadingGrants = $state(false);
+	let loadError = $state('');
+
+	let email = $state('');
+	let permission = $state('view');
+	let sharing = $state(false);
+	let shareError = $state('');
+
+	let revokingId = $state<string | null>(null);
+
+	// Track previous open state to detect open transitions
+	let prevOpen = $state(false);
+
+	$effect.pre(() => {
+		if (open && !prevOpen) {
+			// Reset form state on open
+			email = '';
+			permission = 'view';
+			shareError = '';
+			loadGrants();
+		}
+		prevOpen = open;
+	});
+
+	async function loadGrants() {
+		loadingGrants = true;
+		loadError = '';
+		try {
+			if (type === 'collection') {
+				grants = await api.grants.listCollectionGrants(wsSlug, targetSlug);
+			} else {
+				grants = await api.grants.listItemGrants(wsSlug, targetSlug);
+			}
+		} catch (e: any) {
+			loadError = e.message ?? 'Failed to load grants';
+			grants = [];
+		} finally {
+			loadingGrants = false;
+		}
+	}
+
+	async function handleShare() {
+		const trimmed = email.trim();
+		if (!trimmed || sharing) return;
+		sharing = true;
+		shareError = '';
+		try {
+			let newGrant: CollectionGrant | ItemGrant;
+			if (type === 'collection') {
+				newGrant = await api.grants.createCollectionGrant(wsSlug, targetSlug, trimmed, permission);
+			} else {
+				newGrant = await api.grants.createItemGrant(wsSlug, targetSlug, trimmed, permission);
+			}
+			grants = [...grants, newGrant];
+			email = '';
+			permission = 'view';
+			toastStore.show(`Shared with ${trimmed}`, 'success');
+		} catch (e: any) {
+			shareError = e.message ?? 'Failed to share';
+		} finally {
+			sharing = false;
+		}
+	}
+
+	async function handleRevoke(grantId: string) {
+		if (revokingId) return;
+		revokingId = grantId;
+		try {
+			if (type === 'collection') {
+				await api.grants.deleteCollectionGrant(wsSlug, targetSlug, grantId);
+			} else {
+				await api.grants.deleteItemGrant(wsSlug, targetSlug, grantId);
+			}
+			grants = grants.filter((g) => g.id !== grantId);
+			toastStore.show('Access revoked', 'success');
+		} catch (e: any) {
+			toastStore.show(e.message ?? 'Failed to revoke access', 'error');
+		} finally {
+			revokingId = null;
+		}
+	}
+
+	function handleKeydown(e: KeyboardEvent) {
+		if (e.key === 'Escape' && open) {
+			open = false;
+		}
+	}
+
+	function handleShareKeydown(e: KeyboardEvent) {
+		if (e.key === 'Enter' && email.trim()) {
+			e.preventDefault();
+			handleShare();
+		}
+	}
+
+	function formatPermission(perm: string): string {
+		return perm === 'edit' ? 'Can edit' : 'Can view';
+	}
+
+	function grantDisplayName(grant: CollectionGrant | ItemGrant): string {
+		if (grant.user_name) return grant.user_name;
+		if (grant.user_email) return grant.user_email;
+		return grant.user_id;
+	}
+
+	function grantDisplayEmail(grant: CollectionGrant | ItemGrant): string | null {
+		if (grant.user_name && grant.user_email) return grant.user_email;
+		return null;
+	}
+</script>
+
+<svelte:window onkeydown={handleKeydown} />
+
+{#if open}
+	<!-- svelte-ignore a11y_click_events_have_key_events -->
+	<!-- svelte-ignore a11y_no_static_element_interactions -->
+	<div class="overlay" onclick={() => (open = false)}>
+		<div class="modal" onclick={(e) => e.stopPropagation()}>
+			<div class="modal-header">
+				<h2>Share {targetName}</h2>
+				<button class="close-btn" type="button" onclick={() => (open = false)}>&#10005;</button>
+			</div>
+
+			<div class="modal-body">
+				<!-- Add people section -->
+				<div class="add-section">
+					<span class="section-label">Add people</span>
+					<div class="add-row">
+						<input
+							class="email-input"
+							type="email"
+							placeholder="Email address"
+							bind:value={email}
+							onkeydown={handleShareKeydown}
+							disabled={sharing}
+						/>
+						<select class="permission-select" bind:value={permission} disabled={sharing}>
+							<option value="view">Can view</option>
+							<option value="edit">Can edit</option>
+						</select>
+						<button
+							class="share-btn"
+							type="button"
+							onclick={handleShare}
+							disabled={!email.trim() || sharing}
+						>
+							{sharing ? 'Sharing...' : 'Share'}
+						</button>
+					</div>
+					{#if shareError}
+						<div class="error-msg">{shareError}</div>
+					{/if}
+				</div>
+
+				<!-- Current grants -->
+				<div class="grants-section">
+					<span class="section-label">People with access</span>
+
+					{#if loadingGrants}
+						<div class="grants-loading">Loading...</div>
+					{:else if loadError}
+						<div class="error-msg">{loadError}</div>
+					{:else if grants.length === 0}
+						<div class="grants-empty">No one has been granted access yet.</div>
+					{:else}
+						<div class="grants-list">
+							{#each grants as grant (grant.id)}
+								<div class="grant-row">
+									<div class="grant-user">
+										<span class="grant-name">{grantDisplayName(grant)}</span>
+										{#if grantDisplayEmail(grant)}
+											<span class="grant-email">{grantDisplayEmail(grant)}</span>
+										{/if}
+									</div>
+									<div class="grant-actions">
+										<span class="permission-badge">{formatPermission(grant.permission)}</span>
+										<button
+											class="revoke-btn"
+											type="button"
+											title="Revoke access"
+											onclick={() => handleRevoke(grant.id)}
+											disabled={revokingId === grant.id}
+										>
+											{revokingId === grant.id ? '...' : '\u00D7'}
+										</button>
+									</div>
+								</div>
+							{/each}
+						</div>
+					{/if}
+				</div>
+			</div>
+		</div>
+	</div>
+{/if}
+
+<style>
+	.overlay {
+		position: fixed;
+		inset: 0;
+		background: rgba(0, 0, 0, 0.5);
+		z-index: 50;
+		display: flex;
+		justify-content: center;
+		align-items: flex-start;
+		padding-top: 10vh;
+	}
+
+	.modal {
+		width: 100%;
+		max-width: 480px;
+		background: var(--bg-secondary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius-lg);
+		box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
+		overflow: hidden;
+		max-height: 80vh;
+		display: flex;
+		flex-direction: column;
+	}
+
+	.modal-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: var(--space-4) var(--space-5);
+		border-bottom: 1px solid var(--border);
+		flex-shrink: 0;
+	}
+
+	.modal-header h2 {
+		margin: 0;
+		font-size: 1.1em;
+		font-weight: 600;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.close-btn {
+		background: none;
+		border: none;
+		color: var(--text-muted);
+		font-size: 1em;
+		cursor: pointer;
+		padding: var(--space-1);
+		border-radius: var(--radius-sm);
+		line-height: 1;
+		flex-shrink: 0;
+	}
+
+	.close-btn:hover {
+		color: var(--text-primary);
+		background: var(--bg-hover);
+	}
+
+	.modal-body {
+		padding: var(--space-5);
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-5);
+		overflow-y: auto;
+	}
+
+	.section-label {
+		display: block;
+		font-size: 0.75em;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		color: var(--text-muted);
+		margin-bottom: var(--space-2);
+	}
+
+	/* Add people */
+	.add-row {
+		display: flex;
+		gap: var(--space-2);
+		align-items: center;
+	}
+
+	.email-input {
+		flex: 1;
+		padding: var(--space-2) var(--space-3);
+		background: var(--bg-tertiary);
+		border: 1px solid transparent;
+		border-radius: var(--radius);
+		font-size: 0.9em;
+		color: var(--text-primary);
+		min-width: 0;
+	}
+
+	.email-input:hover {
+		border-color: var(--border);
+	}
+
+	.email-input:focus {
+		border-color: var(--accent-blue);
+		outline: none;
+	}
+
+	.email-input::placeholder {
+		color: var(--text-muted);
+	}
+
+	.permission-select {
+		padding: var(--space-2) var(--space-3);
+		background: var(--bg-tertiary);
+		border: 1px solid transparent;
+		border-radius: var(--radius);
+		font-size: 0.85em;
+		color: var(--text-primary);
+		cursor: pointer;
+		flex-shrink: 0;
+	}
+
+	.permission-select:hover {
+		border-color: var(--border);
+	}
+
+	.permission-select:focus {
+		border-color: var(--accent-blue);
+		outline: none;
+	}
+
+	.share-btn {
+		padding: var(--space-2) var(--space-4);
+		background: var(--accent-blue);
+		border: none;
+		border-radius: var(--radius);
+		color: #fff;
+		font-size: 0.85em;
+		font-weight: 500;
+		cursor: pointer;
+		white-space: nowrap;
+		flex-shrink: 0;
+	}
+
+	.share-btn:hover:not(:disabled) {
+		filter: brightness(1.1);
+	}
+
+	.share-btn:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+
+	.error-msg {
+		margin-top: var(--space-2);
+		padding: var(--space-2) var(--space-3);
+		background: color-mix(in srgb, var(--accent-red, #ef4444) 12%, transparent);
+		color: var(--accent-red, #ef4444);
+		border-radius: var(--radius);
+		font-size: 0.82em;
+	}
+
+	/* Grants list */
+	.grants-loading,
+	.grants-empty {
+		font-size: 0.85em;
+		color: var(--text-muted);
+		padding: var(--space-3) 0;
+	}
+
+	.grants-list {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-1);
+	}
+
+	.grant-row {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: var(--space-3);
+		padding: var(--space-2) var(--space-3);
+		background: var(--bg-tertiary);
+		border-radius: var(--radius);
+	}
+
+	.grant-user {
+		display: flex;
+		flex-direction: column;
+		gap: 1px;
+		min-width: 0;
+	}
+
+	.grant-name {
+		font-size: 0.9em;
+		font-weight: 500;
+		color: var(--text-primary);
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.grant-email {
+		font-size: 0.78em;
+		color: var(--text-muted);
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.grant-actions {
+		display: flex;
+		align-items: center;
+		gap: var(--space-2);
+		flex-shrink: 0;
+	}
+
+	.permission-badge {
+		font-size: 0.75em;
+		font-weight: 500;
+		color: var(--text-secondary);
+		background: var(--bg-secondary);
+		padding: 2px 8px;
+		border-radius: 999px;
+		white-space: nowrap;
+	}
+
+	.revoke-btn {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 24px;
+		height: 24px;
+		background: none;
+		border: 1px solid transparent;
+		border-radius: var(--radius-sm);
+		color: var(--text-muted);
+		cursor: pointer;
+		font-size: 1.1em;
+		line-height: 1;
+		padding: 0;
+	}
+
+	.revoke-btn:hover:not(:disabled) {
+		color: var(--accent-red, #ef4444);
+		background: color-mix(in srgb, var(--accent-red, #ef4444) 10%, transparent);
+		border-color: color-mix(in srgb, var(--accent-red, #ef4444) 20%, transparent);
+	}
+
+	.revoke-btn:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+
+	@media (max-width: 480px) {
+		.add-row {
+			flex-wrap: wrap;
+		}
+
+		.email-input {
+			flex: 1 1 100%;
+		}
+	}
+</style>

--- a/web/src/lib/components/comments/CommentThread.svelte
+++ b/web/src/lib/components/comments/CommentThread.svelte
@@ -7,11 +7,12 @@
 
 	interface Props {
 		wsSlug: string;
+		username?: string;
 		itemSlug: string;
 		items?: Item[];
 	}
 
-	let { wsSlug, itemSlug, items = [] }: Props = $props();
+	let { wsSlug, username = '', itemSlug, items = [] }: Props = $props();
 
 	let comments = $state<Comment[]>([]);
 	let loading = $state(true);
@@ -147,7 +148,7 @@
 						</button>
 					</div>
 					<div class="comment-body prose">
-						{@html renderMarkdown(comment.body, items, wsSlug)}
+						{@html renderMarkdown(comment.body, items, wsSlug, username)}
 					</div>
 				</div>
 			{:else}

--- a/web/src/lib/components/layout/Sidebar.svelte
+++ b/web/src/lib/components/layout/Sidebar.svelte
@@ -24,6 +24,7 @@
 	let wsSlug = $derived(workspaceStore.current?.slug);
 	let wsUsername = $derived(workspaceStore.current?.owner_username ?? '');
 	let wsPrefix = $derived(wsUsername && wsSlug ? `/${wsUsername}/${wsSlug}` : '');
+	let isGuest = $derived(workspaceStore.current?.is_guest ?? false);
 	let isDashboardPage = $derived(wsPrefix ? page.url.pathname === wsPrefix : false);
 	let isRolesPage = $derived(wsPrefix ? page.url.pathname === `${wsPrefix}/roles` : false);
 	let isActivityPage = $derived(wsPrefix ? page.url.pathname === `${wsPrefix}/activity` : false);
@@ -303,6 +304,7 @@
 	<div class="sidebar-inner">
 		{#if wsSlug}
 			<nav class="collection-nav">
+				{#if !isGuest}
 				<a
 					href="{wsPrefix}"
 					class="nav-item dashboard"
@@ -330,8 +332,16 @@
 					<span class="nav-icon">📋</span>
 					<span class="nav-label">Activity</span>
 				</a>
+				{/if}
+
+				{#if isGuest}
+					<div class="section-header">
+						<span class="section-label">Shared with you</span>
+					</div>
+				{/if}
 
 				{#if sidebarCollections.length > 0}
+					{#if !isGuest}
 					<div class="section-header">
 						<span class="section-label">Collections</span>
 						<button
@@ -341,6 +351,7 @@
 							title="New collection"
 						>+</button>
 					</div>
+					{/if}
 					<!-- svelte-ignore a11y_no_static_element_interactions -->
 					<div
 						class="nav-section"
@@ -411,7 +422,7 @@
 				🔍 Search <kbd>⌘K</kbd>
 			</button>
 			<div class="footer-row">
-				{#if wsSlug}
+				{#if wsSlug && !isGuest}
 					<a href="{wsPrefix}/settings" class="settings-btn" onclick={() => uiStore.onNavigate()}>
 						⚙ Settings
 					</a>

--- a/web/src/lib/components/timeline/TimelineCommentCard.svelte
+++ b/web/src/lib/components/timeline/TimelineCommentCard.svelte
@@ -6,6 +6,7 @@
 	interface Props {
 		comment: Comment;
 		wsSlug: string;
+		username?: string;
 		items: Item[];
 		currentUserId?: string;
 		onDelete: (commentId: string) => void;
@@ -14,7 +15,7 @@
 		onRemoveReaction: (commentId: string, emoji: string) => void;
 	}
 
-	let { comment, wsSlug, items, currentUserId = '', onDelete, onReply, onReaction, onRemoveReaction }: Props = $props();
+	let { comment, wsSlug, username = '', items, currentUserId = '', onDelete, onReply, onReaction, onRemoveReaction }: Props = $props();
 
 	let showReplyForm = $state(false);
 	let replyBody = $state('');
@@ -148,7 +149,7 @@
 	{/if}
 
 	<div class="comment-body markdown-body">
-		{@html renderMarkdown(comment.body, items, wsSlug)}
+		{@html renderMarkdown(comment.body, items, wsSlug, username)}
 	</div>
 
 	<div class="comment-footer">
@@ -219,7 +220,7 @@
 					</div>
 
 					<div class="reply-body markdown-body">
-						{@html renderMarkdown(reply.body, items, wsSlug)}
+						{@html renderMarkdown(reply.body, items, wsSlug, username)}
 					</div>
 
 						<div class="reactions-row">

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -70,6 +70,7 @@ export interface Workspace {
 	slug: string;
 	owner_id?: string;
 	owner_username?: string;
+	is_guest?: boolean;
 	description: string;
 	settings: string;
 	sort_order: number;

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -34,6 +34,34 @@ export interface APITokenWithSecret extends APIToken {
 	token: string;
 }
 
+// ─── Grants ──────────────────────────────────────────────────────────────────
+
+export interface CollectionGrant {
+	id: string;
+	collection_id: string;
+	workspace_id: string;
+	user_id: string;
+	permission: string;
+	granted_by: string;
+	created_at: string;
+	user_name?: string;
+	user_email?: string;
+	user_username?: string;
+}
+
+export interface ItemGrant {
+	id: string;
+	item_id: string;
+	workspace_id: string;
+	user_id: string;
+	permission: string;
+	granted_by: string;
+	created_at: string;
+	user_name?: string;
+	user_email?: string;
+	user_username?: string;
+}
+
 // ─── Workspace ────────────────────────────────────────────────────────────────
 
 export interface Workspace {

--- a/web/src/lib/utils/markdown.ts
+++ b/web/src/lib/utils/markdown.ts
@@ -16,11 +16,27 @@ renderer.link = ({ href, title, tokens }: Tokens.Link) => {
 
 marked.use({ renderer });
 
-export function renderMarkdown(content: string, items: Item[], workspaceSlug: string): string {
+/**
+ * Render markdown with wiki-link resolution.
+ * @param visibleCollectionSlugs - Set of collection slugs the user can see.
+ *   undefined = all visible (no filtering). Empty set = nothing visible (anonymous).
+ */
+export function renderMarkdown(
+	content: string,
+	items: Item[],
+	workspaceSlug: string,
+	username?: string,
+	visibleCollectionSlugs?: Set<string>
+): string {
 	const withLinks = content.replace(/\[\[([^\]]+)\]\]/g, (_match, title: string) => {
 		const item = items.find(i => i.title === title);
 		if (item && item.collection_slug) {
-			return `<a href="/${workspaceSlug}/${item.collection_slug}/${itemUrlId(item)}" class="doc-link">${title}</a>`;
+			// Check visibility: if a visibility set is provided, check it
+			if (visibleCollectionSlugs !== undefined && !visibleCollectionSlugs.has(item.collection_slug)) {
+				return `<span class="doc-link locked" title="You don't have access to this item">🔒 ${title}</span>`;
+			}
+			const prefix = username ? `/${username}/${workspaceSlug}` : `/${workspaceSlug}`;
+			return `<a href="${prefix}/${item.collection_slug}/${itemUrlId(item)}" class="doc-link">${title}</a>`;
 		}
 		return `<span class="doc-link broken">${title}</span>`;
 	});

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -13,6 +13,8 @@
 	import { sseService } from '$lib/services/sse.svelte';
 	import { syncService } from '$lib/services/sync.svelte';
 	import { toastStore } from '$lib/stores/toast.svelte';
+	import ShareDialog from '$lib/components/ShareDialog.svelte';
+	import { authStore } from '$lib/stores/auth.svelte';
 
 	type ViewMode = 'list' | 'board' | 'table';
 
@@ -35,9 +37,13 @@
 	let saveViewName = $state('');
 	let saveViewInput = $state<HTMLInputElement>();
 
+	let shareDialogOpen = $state(false);
+	let workspaceMembers = $state<{ user_id: string; role: string }[]>([]);
+
 	let wsSlug = $derived(page.params.workspace ?? '');
 	let username = $derived(page.params.username ?? '');
 	let collSlug = $derived(page.params.collection ?? '');
+	let isOwner = $derived(workspaceMembers.some(m => m.user_id === authStore.userId && m.role === 'owner'));
 
 	// Persist view mode to localStorage per collection
 	function saveViewMode(mode: ViewMode) {
@@ -220,14 +226,16 @@
 		loading = true;
 		try {
 			const listParams = includeArchived ? { include_archived: true } : undefined;
-			const [collData, itemsData, viewsData] = await Promise.all([
+			const [collData, itemsData, viewsData, membersData] = await Promise.all([
 				api.collections.get(ws, coll),
 				api.items.listByCollection(ws, coll, listParams),
-				api.views.list(ws, coll).catch(() => [] as View[])
+				api.views.list(ws, coll).catch(() => [] as View[]),
+				api.members.list(ws).catch(() => ({ members: [], invitations: [] }))
 			]);
 			collection = collData;
 			items = itemsData;
 			savedViews = viewsData;
+			workspaceMembers = membersData.members ?? [];
 			activeViewId = null;
 
 			// Fetch plan progress if viewing plans collection
@@ -795,6 +803,17 @@
 						<QuickActionsMenu actions={quickActions} {collection} scope="collection" />
 					{/if}
 
+					{#if isOwner}
+						<button
+							class="share-btn-header"
+							onclick={() => { shareDialogOpen = true; }}
+							title="Share collection"
+						>
+							<svg class="share-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 12v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8"/><polyline points="16 6 12 2 8 6"/><line x1="12" y1="2" x2="12" y2="15"/></svg>
+							<span class="share-btn-label">Share</span>
+						</button>
+					{/if}
+
 					<button class="new-btn" onclick={handleNewButtonClick} disabled={creatingNew}>
 						+ <span class="new-btn-label">New {singularName()}</span>
 					</button>
@@ -936,6 +955,16 @@
 		{/if}
 	{/if}
 </div>
+
+{#if isOwner && collection}
+	<ShareDialog
+		{wsSlug}
+		type="collection"
+		targetSlug={collection.slug}
+		targetName={collection.name}
+		bind:open={shareDialogOpen}
+	/>
+{/if}
 
 <style>
 	.collection-page {
@@ -1341,5 +1370,34 @@
 		.save-view-label {
 			display: none;
 		}
+
+		.share-btn-label {
+			display: none;
+		}
+	}
+
+	/* Share button */
+	.share-btn-header {
+		display: flex;
+		align-items: center;
+		gap: var(--space-1);
+		background: var(--bg-secondary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+		padding: var(--space-1) var(--space-3);
+		cursor: pointer;
+		font-size: 0.82em;
+		color: var(--text-secondary);
+		white-space: nowrap;
+		transition: border-color 0.15s, color 0.15s;
+	}
+
+	.share-btn-header:hover {
+		color: var(--text-primary);
+		border-color: var(--text-muted);
+	}
+
+	.share-icon {
+		flex-shrink: 0;
 	}
 </style>

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -19,6 +19,8 @@
 	import type { Item, Collection, CollectionSettings, QuickAction, ItemLink, AgentRole } from '$lib/types';
 	import { parseFields, parseSchema, parseSettings, formatItemRef, getTerminalOptions } from '$lib/types';
 	import QuickActionsMenu from '$lib/components/common/QuickActionsMenu.svelte';
+	import ShareDialog from '$lib/components/ShareDialog.svelte';
+	import { authStore } from '$lib/stores/auth.svelte';
 
 	type RelationshipEntry = {
 		key: string;
@@ -77,12 +79,14 @@
 	let showMoveMenu = $state(false);
 	let moving = $state(false);
 	let itemLinks = $state<ItemLink[]>([]);
-	let workspaceMembers = $state<{ user_id: string; user_name: string; user_email: string }[]>([]);
+	let workspaceMembers = $state<{ user_id: string; user_name: string; user_email: string; role: string }[]>([]);
+	let shareDialogOpen = $state(false);
 	let agentRoles = $state<AgentRole[]>([]);
 	let childItemIds = $state<Set<string>>(new Set());
 	let hasChildren = $state(false);
 	let relationshipGroups = $derived(item ? buildRelationshipGroups(item, itemLinks, childItemIds) : []);
 	let codeContext = $derived(item?.code_context ?? null);
+	let isOwner = $derived(workspaceMembers.some(m => m.user_id === authStore.userId && m.role === 'owner'));
 	$effect(() => {
 		if (wsSlug && collSlug && itemSlug) {
 			loadData();
@@ -662,6 +666,11 @@
 					</div>
 				{/if}
 			</div>
+			{#if isOwner}
+				<button class="action-btn" onclick={() => { shareDialogOpen = true; }}>
+					Share
+				</button>
+			{/if}
 			{#if confirmDelete}
 				<span class="delete-confirm">
 					Delete this item?
@@ -936,6 +945,16 @@
 		</div>
 
 	</div>
+
+	{#if isOwner && item}
+		<ShareDialog
+			{wsSlug}
+			type="item"
+			targetSlug={item.slug}
+			targetName={formatItemRef(item) || item.title}
+			bind:open={shareDialogOpen}
+		/>
+	{/if}
 {/if}
 
 <style>


### PR DESCRIPTION
## Summary

Implements Phase 3 of PLAN-407 (Multi-User Permissions & Sharing): collection & item grants, guest access, share dialog, and wiki-link visibility.

- **Grant tables + permission resolution**: `collection_grants` and `item_grants` tables with CASCADE deletion, full CRUD API, and 5-step permission resolution (owner → item grant → collection grant → membership → deny) per DOC-406
- **Grant revocation + member removal**: `DELETE /members/{id}?revoke_grants=true` for full removal vs keeping grants (D4: owner chooses at removal time)
- **Share dialog UI**: reusable `ShareDialog.svelte` modal for listing/creating/revoking grants on items and collections, wired into item detail and collection pages (owner-only)
- **Guest access**: authenticated users with grants but no membership can access workspaces as guests — middleware allows through with `"guest"` role, workspace resolver JOINs on grant tables, `GetUserWorkspaces` includes guest workspaces with `is_guest` flag, sidebar hides Dashboard/Roles/Activity/Settings and shows "Shared with you"
- **Wiki-link locked icons**: `renderMarkdown` renders `🔒 Title` with tooltip for links to items in collections the user can't see

### Key design decisions
- Grants use `UNIQUE(collection_id, user_id)` / `UNIQUE(item_id, user_id)` — one grant per user per resource
- Permission resolution follows DOC-406's 5-step order with "best permission wins"
- Guest role level = 0 (below viewer), so role-gated actions naturally block guests
- `VisibleCollectionIDs` for non-members now falls through to `GuestVisibleCollectionIDs` (grant-based)
- Item grant inheritance to children is NOT applied (D6) — grants are explicit

### Tasks completed (5)
- TASK-417: Create collection_grants and item_grants tables + permission resolution middleware
- TASK-489: Grant revocation: API endpoints, UI, and cascade behavior on deletion
- TASK-419: Share dialog UI for items and collections (add people by email, set permissions)
- TASK-418: Guest access: Shared With Me home screen + minimal-chrome item/collection views
- TASK-420: Wiki-link rendering: locked icon for no-access authed users, plain text for anonymous

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./...` passes
- [ ] `npm run build` passes
- [ ] `make install` succeeds
- [ ] Grant API: `POST /collections/{coll}/grants` creates a grant; `GET` lists it; `DELETE` revokes it
- [ ] Grant API: `POST /items/{slug}/grants` creates an item grant; same CRUD pattern
- [ ] Grant API: `GET /users/{id}/grants` returns all grants for a user in a workspace
- [ ] Grant uniqueness: creating a duplicate grant returns 409 Conflict
- [ ] Member removal: `DELETE /members/{id}?revoke_grants=true` removes membership AND all grants
- [ ] Member removal: `DELETE /members/{id}` (no flag) removes membership but keeps grants
- [ ] Share dialog: "Share" button visible on item detail and collection pages for owners
- [ ] Share dialog: can add a grant by email, see existing grants, revoke grants
- [ ] Guest access: user with grants but no membership can access the workspace
- [ ] Guest sidebar: Dashboard, Roles, Activity, Settings hidden; "Shared with you" header shown
- [ ] Guest sees only granted collections in sidebar and collection list
- [ ] Wiki-links: items in hidden collections render as 🔒 with tooltip instead of clickable links
- [ ] ResolveUserPermission: owner → full access, item grant → uses it, collection grant → uses it, member → uses role, non-member non-guest → deny
- [ ] CASCADE: deleting a collection cascades to collection_grants; deleting an item cascades to item_grants
- [ ] CLI commands work unchanged (admin user = full access)