### PR TITLE
feat: share links, anonymous access, and analytics (PLAN-407 Phase 4)

### DIFF
--- a/internal/models/share_link.go
+++ b/internal/models/share_link.go
@@ -1,0 +1,39 @@
+package models
+
+import "time"
+
+// ShareLink represents a shareable link to an item or collection.
+// Tokens are hashed at rest; the raw token is returned only once on creation.
+type ShareLink struct {
+	ID              string     `json:"id"`
+	TokenHash       string     `json:"-"`                              // Never serialized
+	Token           string     `json:"token,omitempty"`                // Only set on creation response
+	TargetType      string     `json:"target_type"`                    // "item" or "collection"
+	TargetID        string     `json:"target_id"`
+	WorkspaceID     string     `json:"workspace_id"`
+	Permission      string     `json:"permission"`                     // "view" or "edit"
+	CreatedBy       string     `json:"created_by"`
+	PasswordHash    *string    `json:"-"`                              // Never serialized
+	HasPassword     bool       `json:"has_password"`                   // Derived: password_hash IS NOT NULL
+	ExpiresAt       *time.Time `json:"expires_at,omitempty"`
+	MaxViews        *int       `json:"max_views,omitempty"`
+	RequireAuth     bool       `json:"require_auth"`
+	RestrictToEmail string     `json:"restrict_to_email,omitempty"`
+	ViewCount       int        `json:"view_count"`
+	UniqueViewers   int        `json:"unique_viewers"`
+	LastViewedAt    *time.Time `json:"last_viewed_at,omitempty"`
+	CreatedAt       time.Time  `json:"created_at"`
+
+	// Derived (populated by handlers)
+	URL         string `json:"url,omitempty"`          // Full share URL (e.g. /s/{token})
+	TargetTitle string `json:"target_title,omitempty"` // Title of the shared item/collection
+}
+
+// ShareLinkView records a single view of a share link.
+type ShareLinkView struct {
+	ID                string    `json:"id"`
+	ShareLinkID       string    `json:"share_link_id"`
+	ViewerFingerprint string    `json:"viewer_fingerprint,omitempty"`
+	ViewerUserID      string    `json:"viewer_user_id,omitempty"`
+	ViewedAt          time.Time `json:"viewed_at"`
+}

--- a/internal/server/handlers_share_links.go
+++ b/internal/server/handlers_share_links.go
@@ -1,0 +1,262 @@
+package server
+
+import (
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/xarmian/pad/internal/models"
+)
+
+// handleCreateShareLink creates a new share link for an item or collection.
+// POST /workspaces/{ws}/items/{slug}/share-links or
+// POST /workspaces/{ws}/collections/{collSlug}/share-links
+func (s *Server) handleCreateItemShareLink(w http.ResponseWriter, r *http.Request) {
+	if !requireMinRole(w, r, "owner") {
+		return
+	}
+	workspaceID, ok := s.getWorkspaceID(w, r)
+	if !ok {
+		return
+	}
+
+	itemSlug := chi.URLParam(r, "itemSlug")
+	item, err := s.store.ResolveItem(workspaceID, itemSlug)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	if item == nil {
+		writeError(w, http.StatusNotFound, "not_found", "Item not found")
+		return
+	}
+
+	link, err := s.store.CreateShareLink(workspaceID, "item", item.ID, "view", currentUserID(r))
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+
+	if s.baseURL != "" {
+		link.URL = s.baseURL + "/s/" + link.Token
+	}
+	link.TargetTitle = item.Title
+
+	writeJSON(w, http.StatusCreated, link)
+}
+
+func (s *Server) handleCreateCollectionShareLink(w http.ResponseWriter, r *http.Request) {
+	if !requireMinRole(w, r, "owner") {
+		return
+	}
+	workspaceID, ok := s.getWorkspaceID(w, r)
+	if !ok {
+		return
+	}
+
+	collSlug := chi.URLParam(r, "collSlug")
+	coll, err := s.store.GetCollectionBySlug(workspaceID, collSlug)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	if coll == nil {
+		writeError(w, http.StatusNotFound, "not_found", "Collection not found")
+		return
+	}
+
+	link, err := s.store.CreateShareLink(workspaceID, "collection", coll.ID, "view", currentUserID(r))
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+
+	if s.baseURL != "" {
+		link.URL = s.baseURL + "/s/" + link.Token
+	}
+	link.TargetTitle = coll.Name
+
+	writeJSON(w, http.StatusCreated, link)
+}
+
+// handleListItemShareLinks lists share links for an item.
+func (s *Server) handleListItemShareLinks(w http.ResponseWriter, r *http.Request) {
+	if !requireMinRole(w, r, "owner") {
+		return
+	}
+	workspaceID, ok := s.getWorkspaceID(w, r)
+	if !ok {
+		return
+	}
+
+	itemSlug := chi.URLParam(r, "itemSlug")
+	item, err := s.store.ResolveItem(workspaceID, itemSlug)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	if item == nil {
+		writeError(w, http.StatusNotFound, "not_found", "Item not found")
+		return
+	}
+
+	links, err := s.store.ListShareLinks("item", item.ID)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	if links == nil {
+		links = []models.ShareLink{}
+	}
+	writeJSON(w, http.StatusOK, links)
+}
+
+func (s *Server) handleListCollectionShareLinks(w http.ResponseWriter, r *http.Request) {
+	if !requireMinRole(w, r, "owner") {
+		return
+	}
+	workspaceID, ok := s.getWorkspaceID(w, r)
+	if !ok {
+		return
+	}
+
+	collSlug := chi.URLParam(r, "collSlug")
+	coll, err := s.store.GetCollectionBySlug(workspaceID, collSlug)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	if coll == nil {
+		writeError(w, http.StatusNotFound, "not_found", "Collection not found")
+		return
+	}
+
+	links, err := s.store.ListShareLinks("collection", coll.ID)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	if links == nil {
+		links = []models.ShareLink{}
+	}
+	writeJSON(w, http.StatusOK, links)
+}
+
+// handleDeleteShareLink deletes a share link.
+func (s *Server) handleDeleteShareLink(w http.ResponseWriter, r *http.Request) {
+	if !requireMinRole(w, r, "owner") {
+		return
+	}
+	workspaceID, ok := s.getWorkspaceID(w, r)
+	if !ok {
+		return
+	}
+
+	linkID := chi.URLParam(r, "linkID")
+	if err := s.store.DeleteShareLink(linkID, workspaceID); err != nil {
+		writeError(w, http.StatusNotFound, "not_found", "Share link not found")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// handleResolveShareLink is the /s/{token} route. It resolves a share link
+// token and returns the shared content. Anonymous users are ALWAYS read-only (D8).
+func (s *Server) handleResolveShareLink(w http.ResponseWriter, r *http.Request) {
+	token := chi.URLParam(r, "token")
+	if token == "" {
+		writeError(w, http.StatusNotFound, "not_found", "Not found")
+		return
+	}
+
+	// Look up the share link by token hash
+	link, err := s.store.GetShareLinkByToken(token)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	if link == nil {
+		// Generic 404 — no info leakage about valid tokens
+		writeError(w, http.StatusNotFound, "not_found", "Not found")
+		return
+	}
+
+	// Validate constraints (expiry, max views)
+	if err := s.store.ValidateShareLink(link); err != nil {
+		writeError(w, http.StatusNotFound, "not_found", "Not found")
+		return
+	}
+
+	// Require auth check
+	if link.RequireAuth {
+		user := currentUser(r)
+		if user == nil {
+			writeJSON(w, http.StatusOK, map[string]interface{}{
+				"require_auth": true,
+				"message":      "Authentication required to view this content",
+			})
+			return
+		}
+		// Restrict to specific email
+		if link.RestrictToEmail != "" && user.Email != link.RestrictToEmail {
+			writeError(w, http.StatusForbidden, "forbidden", "This link is restricted")
+			return
+		}
+	}
+
+	// Record the view
+	fingerprint := r.Header.Get("X-Forwarded-For")
+	if fingerprint == "" {
+		fingerprint = r.RemoteAddr
+	}
+	userID := ""
+	if user := currentUser(r); user != nil {
+		userID = user.ID
+	}
+	_ = s.store.RecordShareLinkView(link.ID, fingerprint, userID)
+
+	// Resolve and return the shared content
+	switch link.TargetType {
+	case "item":
+		item, err := s.store.GetItem(link.TargetID)
+		if err != nil || item == nil {
+			writeError(w, http.StatusNotFound, "not_found", "Not found")
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]interface{}{
+			"type":       "item",
+			"item":       item,
+			"permission": "view", // D8: anonymous always read-only
+			"share_link": map[string]interface{}{
+				"id":          link.ID,
+				"target_type": link.TargetType,
+			},
+		})
+
+	case "collection":
+		coll, err := s.store.GetCollection(link.TargetID)
+		if err != nil || coll == nil {
+			writeError(w, http.StatusNotFound, "not_found", "Not found")
+			return
+		}
+		// Get items in the collection
+		items, err := s.store.ListItems(link.WorkspaceID, models.ItemListParams{
+			CollectionSlug: coll.Slug,
+		})
+		if err != nil {
+			items = []models.Item{}
+		}
+		writeJSON(w, http.StatusOK, map[string]interface{}{
+			"type":       "collection",
+			"collection": coll,
+			"items":      items,
+			"permission": "view", // D8: anonymous always read-only
+			"share_link": map[string]interface{}{
+				"id":          link.ID,
+				"target_type": link.TargetType,
+			},
+		})
+
+	default:
+		writeError(w, http.StatusNotFound, "not_found", "Not found")
+	}
+}

--- a/internal/server/handlers_share_links.go
+++ b/internal/server/handlers_share_links.go
@@ -39,7 +39,16 @@ func (s *Server) handleCreateItemShareLink(w http.ResponseWriter, r *http.Reques
 		RequireAuth     bool    `json:"require_auth,omitempty"`
 		RestrictToEmail string  `json:"restrict_to_email,omitempty"`
 	}
-	_ = decodeJSON(r, &input) // Optional body — defaults are fine
+	if err := decodeJSON(r, &input); err != nil && r.ContentLength > 0 {
+		writeError(w, http.StatusBadRequest, "bad_request", "Invalid JSON body")
+		return
+	}
+
+	// Force require_auth when restrict_to_email is set — otherwise the
+	// email restriction would be silently ignored.
+	if input.RestrictToEmail != "" {
+		input.RequireAuth = true
+	}
 
 	opts := &store.ShareLinkOptions{
 		Password:        input.Password,
@@ -90,7 +99,15 @@ func (s *Server) handleCreateCollectionShareLink(w http.ResponseWriter, r *http.
 		RequireAuth     bool    `json:"require_auth,omitempty"`
 		RestrictToEmail string  `json:"restrict_to_email,omitempty"`
 	}
-	_ = decodeJSON(r, &collInput)
+	if err := decodeJSON(r, &collInput); err != nil && r.ContentLength > 0 {
+		writeError(w, http.StatusBadRequest, "bad_request", "Invalid JSON body")
+		return
+	}
+
+	// Force require_auth when restrict_to_email is set
+	if collInput.RestrictToEmail != "" {
+		collInput.RequireAuth = true
+	}
 
 	collOpts := &store.ShareLinkOptions{
 		Password:        collInput.Password,
@@ -222,9 +239,12 @@ func (s *Server) handleResolveShareLink(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	// Password check
+	// Password check — prefer X-Share-Password header, fall back to query param
 	if link.HasPassword {
-		password := r.URL.Query().Get("password")
+		password := r.Header.Get("X-Share-Password")
+		if password == "" {
+			password = r.URL.Query().Get("password")
+		}
 		if password == "" {
 			writeJSON(w, http.StatusOK, map[string]interface{}{
 				"require_password": true,
@@ -255,7 +275,7 @@ func (s *Server) handleResolveShareLink(w http.ResponseWriter, r *http.Request) 
 		}
 	}
 
-	// Record the view
+	// Atomically record the view and enforce max_views
 	fingerprint := r.Header.Get("X-Forwarded-For")
 	if fingerprint == "" {
 		fingerprint = r.RemoteAddr
@@ -264,9 +284,19 @@ func (s *Server) handleResolveShareLink(w http.ResponseWriter, r *http.Request) 
 	if user := currentUser(r); user != nil {
 		userID = user.ID
 	}
-	_ = s.store.RecordShareLinkView(link.ID, fingerprint, userID)
+	allowed, err := s.store.RecordShareLinkView(link.ID, fingerprint, userID, link.MaxViews)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	if !allowed {
+		// max_views reached — treat as expired
+		writeError(w, http.StatusNotFound, "not_found", "Not found")
+		return
+	}
 
-	// Resolve and return the shared content
+	// Resolve and return the shared content using public DTOs
+	// to avoid leaking internal IDs, creator info, and other sensitive fields.
 	switch link.TargetType {
 	case "item":
 		item, err := s.store.GetItem(link.TargetID)
@@ -275,9 +305,16 @@ func (s *Server) handleResolveShareLink(w http.ResponseWriter, r *http.Request) 
 			return
 		}
 		writeJSON(w, http.StatusOK, map[string]interface{}{
-			"type":       "item",
-			"item":       item,
-			"permission": "view", // D8: anonymous always read-only
+			"type": "item",
+			"item": map[string]interface{}{
+				"title":           item.Title,
+				"content":         item.Content,
+				"fields":          item.Fields,
+				"ref":             item.Ref,
+				"collection_name": item.CollectionName,
+				"collection_icon": item.CollectionIcon,
+			},
+			"permission": "view",
 			"share_link": map[string]interface{}{
 				"id":          link.ID,
 				"target_type": link.TargetType,
@@ -290,18 +327,31 @@ func (s *Server) handleResolveShareLink(w http.ResponseWriter, r *http.Request) 
 			writeError(w, http.StatusNotFound, "not_found", "Not found")
 			return
 		}
-		// Get items in the collection
 		items, err := s.store.ListItems(link.WorkspaceID, models.ItemListParams{
 			CollectionSlug: coll.Slug,
 		})
 		if err != nil {
 			items = []models.Item{}
 		}
+		// Build public item list with only safe fields
+		publicItems := make([]map[string]interface{}, 0, len(items))
+		for _, it := range items {
+			publicItem := map[string]interface{}{
+				"title":  it.Title,
+				"ref":    it.Ref,
+				"fields": it.Fields,
+			}
+			publicItems = append(publicItems, publicItem)
+		}
 		writeJSON(w, http.StatusOK, map[string]interface{}{
-			"type":       "collection",
-			"collection": coll,
-			"items":      items,
-			"permission": "view", // D8: anonymous always read-only
+			"type": "collection",
+			"collection": map[string]interface{}{
+				"name":        coll.Name,
+				"icon":        coll.Icon,
+				"description": coll.Description,
+			},
+			"items":      publicItems,
+			"permission": "view",
 			"share_link": map[string]interface{}{
 				"id":          link.ID,
 				"target_type": link.TargetType,

--- a/internal/server/handlers_share_links.go
+++ b/internal/server/handlers_share_links.go
@@ -7,11 +7,26 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/xarmian/pad/internal/models"
 	"github.com/xarmian/pad/internal/store"
 )
+
+// validateShareLinkOpts checks that share link creation constraints are sane.
+// Returns an error message string (empty if valid).
+func validateShareLinkOpts(expiresAt *string, maxViews *int) string {
+	if expiresAt != nil {
+		if _, err := time.Parse(time.RFC3339, *expiresAt); err != nil {
+			return "expires_at must be a valid RFC3339 timestamp"
+		}
+	}
+	if maxViews != nil && *maxViews <= 0 {
+		return "max_views must be a positive integer"
+	}
+	return ""
+}
 
 // handleCreateShareLink creates a new share link for an item or collection.
 // POST /workspaces/{ws}/items/{slug}/share-links or
@@ -53,6 +68,11 @@ func (s *Server) handleCreateItemShareLink(w http.ResponseWriter, r *http.Reques
 	if input.RestrictToEmail != "" {
 		input.RestrictToEmail = strings.ToLower(strings.TrimSpace(input.RestrictToEmail))
 		input.RequireAuth = true
+	}
+
+	if msg := validateShareLinkOpts(input.ExpiresAt, input.MaxViews); msg != "" {
+		writeError(w, http.StatusBadRequest, "bad_request", msg)
+		return
 	}
 
 	opts := &store.ShareLinkOptions{
@@ -113,6 +133,11 @@ func (s *Server) handleCreateCollectionShareLink(w http.ResponseWriter, r *http.
 	if collInput.RestrictToEmail != "" {
 		collInput.RestrictToEmail = strings.ToLower(strings.TrimSpace(collInput.RestrictToEmail))
 		collInput.RequireAuth = true
+	}
+
+	if msg := validateShareLinkOpts(collInput.ExpiresAt, collInput.MaxViews); msg != "" {
+		writeError(w, http.StatusBadRequest, "bad_request", msg)
+		return
 	}
 
 	collOpts := &store.ShareLinkOptions{
@@ -249,6 +274,24 @@ func (s *Server) handleResolveShareLink(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	// Auth check first — prevent unauthenticated callers from probing
+	// passwords (which burns bcrypt CPU) before being rejected by the gate.
+	if link.RequireAuth {
+		user := currentUser(r)
+		if user == nil {
+			writeJSON(w, http.StatusOK, map[string]interface{}{
+				"require_auth": true,
+				"message":      "Authentication required to view this content",
+			})
+			return
+		}
+		// Restrict to specific email (stored normalized; normalize user email too)
+		if link.RestrictToEmail != "" && strings.ToLower(strings.TrimSpace(user.Email)) != link.RestrictToEmail {
+			writeError(w, http.StatusForbidden, "forbidden", "This link is restricted")
+			return
+		}
+	}
+
 	// Password check — via X-Share-Password header (never query string, to
 	// avoid leaking passwords in logs, browser history, and referrers).
 	if link.HasPassword {
@@ -262,23 +305,6 @@ func (s *Server) handleResolveShareLink(w http.ResponseWriter, r *http.Request) 
 		}
 		if !s.store.ValidateShareLinkPassword(link, password) {
 			writeError(w, http.StatusForbidden, "forbidden", "Incorrect password")
-			return
-		}
-	}
-
-	// Require auth check
-	if link.RequireAuth {
-		user := currentUser(r)
-		if user == nil {
-			writeJSON(w, http.StatusOK, map[string]interface{}{
-				"require_auth": true,
-				"message":      "Authentication required to view this content",
-			})
-			return
-		}
-		// Restrict to specific email (stored normalized; normalize user email too)
-		if link.RestrictToEmail != "" && strings.ToLower(strings.TrimSpace(user.Email)) != link.RestrictToEmail {
-			writeError(w, http.StatusForbidden, "forbidden", "This link is restricted")
 			return
 		}
 	}
@@ -389,11 +415,15 @@ func (s *Server) handleShareLinkViews(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	const maxViewLimit = 1000
 	limit := 100
 	if l := r.URL.Query().Get("limit"); l != "" {
 		if parsed, err := strconv.Atoi(l); err == nil && parsed > 0 {
 			limit = parsed
 		}
+	}
+	if limit > maxViewLimit {
+		limit = maxViewLimit
 	}
 
 	views, err := s.store.ListShareLinkViews(linkID, limit)

--- a/internal/server/handlers_share_links.go
+++ b/internal/server/handlers_share_links.go
@@ -2,9 +2,11 @@ package server
 
 import (
 	"net/http"
+	"strconv"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/xarmian/pad/internal/models"
+	"github.com/xarmian/pad/internal/store"
 )
 
 // handleCreateShareLink creates a new share link for an item or collection.
@@ -30,7 +32,24 @@ func (s *Server) handleCreateItemShareLink(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	link, err := s.store.CreateShareLink(workspaceID, "item", item.ID, "view", currentUserID(r))
+	var input struct {
+		Password        string  `json:"password,omitempty"`
+		ExpiresAt       *string `json:"expires_at,omitempty"`
+		MaxViews        *int    `json:"max_views,omitempty"`
+		RequireAuth     bool    `json:"require_auth,omitempty"`
+		RestrictToEmail string  `json:"restrict_to_email,omitempty"`
+	}
+	_ = decodeJSON(r, &input) // Optional body — defaults are fine
+
+	opts := &store.ShareLinkOptions{
+		Password:        input.Password,
+		ExpiresAt:       input.ExpiresAt,
+		MaxViews:        input.MaxViews,
+		RequireAuth:     input.RequireAuth,
+		RestrictToEmail: input.RestrictToEmail,
+	}
+
+	link, err := s.store.CreateShareLink(workspaceID, "item", item.ID, "view", currentUserID(r), opts)
 	if err != nil {
 		writeInternalError(w, err)
 		return
@@ -64,7 +83,24 @@ func (s *Server) handleCreateCollectionShareLink(w http.ResponseWriter, r *http.
 		return
 	}
 
-	link, err := s.store.CreateShareLink(workspaceID, "collection", coll.ID, "view", currentUserID(r))
+	var collInput struct {
+		Password        string  `json:"password,omitempty"`
+		ExpiresAt       *string `json:"expires_at,omitempty"`
+		MaxViews        *int    `json:"max_views,omitempty"`
+		RequireAuth     bool    `json:"require_auth,omitempty"`
+		RestrictToEmail string  `json:"restrict_to_email,omitempty"`
+	}
+	_ = decodeJSON(r, &collInput)
+
+	collOpts := &store.ShareLinkOptions{
+		Password:        collInput.Password,
+		ExpiresAt:       collInput.ExpiresAt,
+		MaxViews:        collInput.MaxViews,
+		RequireAuth:     collInput.RequireAuth,
+		RestrictToEmail: collInput.RestrictToEmail,
+	}
+
+	link, err := s.store.CreateShareLink(workspaceID, "collection", coll.ID, "view", currentUserID(r), collOpts)
 	if err != nil {
 		writeInternalError(w, err)
 		return
@@ -186,6 +222,22 @@ func (s *Server) handleResolveShareLink(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	// Password check
+	if link.HasPassword {
+		password := r.URL.Query().Get("password")
+		if password == "" {
+			writeJSON(w, http.StatusOK, map[string]interface{}{
+				"require_password": true,
+				"message":          "Password required to view this content",
+			})
+			return
+		}
+		if !s.store.ValidateShareLinkPassword(link, password) {
+			writeError(w, http.StatusForbidden, "forbidden", "Incorrect password")
+			return
+		}
+	}
+
 	// Require auth check
 	if link.RequireAuth {
 		user := currentUser(r)
@@ -259,4 +311,50 @@ func (s *Server) handleResolveShareLink(w http.ResponseWriter, r *http.Request) 
 	default:
 		writeError(w, http.StatusNotFound, "not_found", "Not found")
 	}
+}
+
+// handleShareLinkViews returns view history for a share link.
+// GET /workspaces/{ws}/share-links/{linkID}/views
+func (s *Server) handleShareLinkViews(w http.ResponseWriter, r *http.Request) {
+	if !requireMinRole(w, r, "owner") {
+		return
+	}
+	workspaceID, ok := s.getWorkspaceID(w, r)
+	if !ok {
+		return
+	}
+
+	linkID := chi.URLParam(r, "linkID")
+	link, err := s.store.GetShareLink(linkID)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	if link == nil || link.WorkspaceID != workspaceID {
+		writeError(w, http.StatusNotFound, "not_found", "Share link not found")
+		return
+	}
+
+	limit := 100
+	if l := r.URL.Query().Get("limit"); l != "" {
+		if parsed, err := strconv.Atoi(l); err == nil && parsed > 0 {
+			limit = parsed
+		}
+	}
+
+	views, err := s.store.ListShareLinkViews(linkID, limit)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	if views == nil {
+		views = []models.ShareLinkView{}
+	}
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"views":          views,
+		"total_views":    link.ViewCount,
+		"unique_viewers": link.UniqueViewers,
+		"last_viewed_at": link.LastViewedAt,
+	})
 }

--- a/internal/server/handlers_share_links.go
+++ b/internal/server/handlers_share_links.go
@@ -1,8 +1,12 @@
 package server
 
 import (
+	"database/sql"
+	"errors"
+	"io"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/xarmian/pad/internal/models"
@@ -39,14 +43,15 @@ func (s *Server) handleCreateItemShareLink(w http.ResponseWriter, r *http.Reques
 		RequireAuth     bool    `json:"require_auth,omitempty"`
 		RestrictToEmail string  `json:"restrict_to_email,omitempty"`
 	}
-	if err := decodeJSON(r, &input); err != nil && r.ContentLength > 0 {
+	if err := decodeJSON(r, &input); err != nil && !errors.Is(err, io.EOF) {
 		writeError(w, http.StatusBadRequest, "bad_request", "Invalid JSON body")
 		return
 	}
 
-	// Force require_auth when restrict_to_email is set — otherwise the
-	// email restriction would be silently ignored.
+	// Normalize and force require_auth when restrict_to_email is set —
+	// otherwise the email restriction would be silently ignored.
 	if input.RestrictToEmail != "" {
+		input.RestrictToEmail = strings.ToLower(strings.TrimSpace(input.RestrictToEmail))
 		input.RequireAuth = true
 	}
 
@@ -99,13 +104,14 @@ func (s *Server) handleCreateCollectionShareLink(w http.ResponseWriter, r *http.
 		RequireAuth     bool    `json:"require_auth,omitempty"`
 		RestrictToEmail string  `json:"restrict_to_email,omitempty"`
 	}
-	if err := decodeJSON(r, &collInput); err != nil && r.ContentLength > 0 {
+	if err := decodeJSON(r, &collInput); err != nil && !errors.Is(err, io.EOF) {
 		writeError(w, http.StatusBadRequest, "bad_request", "Invalid JSON body")
 		return
 	}
 
-	// Force require_auth when restrict_to_email is set
+	// Normalize and force require_auth when restrict_to_email is set
 	if collInput.RestrictToEmail != "" {
+		collInput.RestrictToEmail = strings.ToLower(strings.TrimSpace(collInput.RestrictToEmail))
 		collInput.RequireAuth = true
 	}
 
@@ -206,7 +212,11 @@ func (s *Server) handleDeleteShareLink(w http.ResponseWriter, r *http.Request) {
 
 	linkID := chi.URLParam(r, "linkID")
 	if err := s.store.DeleteShareLink(linkID, workspaceID); err != nil {
-		writeError(w, http.StatusNotFound, "not_found", "Share link not found")
+		if errors.Is(err, sql.ErrNoRows) {
+			writeError(w, http.StatusNotFound, "not_found", "Share link not found")
+		} else {
+			writeInternalError(w, err)
+		}
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
@@ -239,12 +249,10 @@ func (s *Server) handleResolveShareLink(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	// Password check — prefer X-Share-Password header, fall back to query param
+	// Password check — via X-Share-Password header (never query string, to
+	// avoid leaking passwords in logs, browser history, and referrers).
 	if link.HasPassword {
 		password := r.Header.Get("X-Share-Password")
-		if password == "" {
-			password = r.URL.Query().Get("password")
-		}
 		if password == "" {
 			writeJSON(w, http.StatusOK, map[string]interface{}{
 				"require_password": true,
@@ -268,18 +276,15 @@ func (s *Server) handleResolveShareLink(w http.ResponseWriter, r *http.Request) 
 			})
 			return
 		}
-		// Restrict to specific email
-		if link.RestrictToEmail != "" && user.Email != link.RestrictToEmail {
+		// Restrict to specific email (stored normalized; normalize user email too)
+		if link.RestrictToEmail != "" && strings.ToLower(strings.TrimSpace(user.Email)) != link.RestrictToEmail {
 			writeError(w, http.StatusForbidden, "forbidden", "This link is restricted")
 			return
 		}
 	}
 
 	// Atomically record the view and enforce max_views
-	fingerprint := r.Header.Get("X-Forwarded-For")
-	if fingerprint == "" {
-		fingerprint = r.RemoteAddr
-	}
+	fingerprint := clientIP(r)
 	userID := ""
 	if user := currentUser(r); user != nil {
 		userID = user.ID
@@ -316,7 +321,6 @@ func (s *Server) handleResolveShareLink(w http.ResponseWriter, r *http.Request) 
 			},
 			"permission": "view",
 			"share_link": map[string]interface{}{
-				"id":          link.ID,
 				"target_type": link.TargetType,
 			},
 		})
@@ -331,7 +335,8 @@ func (s *Server) handleResolveShareLink(w http.ResponseWriter, r *http.Request) 
 			CollectionSlug: coll.Slug,
 		})
 		if err != nil {
-			items = []models.Item{}
+			writeInternalError(w, err)
+			return
 		}
 		// Build public item list with only safe fields
 		publicItems := make([]map[string]interface{}, 0, len(items))
@@ -353,7 +358,6 @@ func (s *Server) handleResolveShareLink(w http.ResponseWriter, r *http.Request) 
 			"items":      publicItems,
 			"permission": "view",
 			"share_link": map[string]interface{}{
-				"id":          link.ID,
 				"target_type": link.TargetType,
 			},
 		})

--- a/internal/server/middleware_auth.go
+++ b/internal/server/middleware_auth.go
@@ -174,8 +174,8 @@ func (s *Server) RequireAuth(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		path := r.URL.Path
 
-		// Auth endpoints are always exempt
-		if strings.HasPrefix(path, "/api/v1/auth/") || path == "/api/v1/health" || strings.HasPrefix(path, "/api/v1/health/") {
+		// Auth endpoints and share link resolution are always exempt
+		if strings.HasPrefix(path, "/api/v1/auth/") || path == "/api/v1/health" || strings.HasPrefix(path, "/api/v1/health/") || strings.HasPrefix(path, "/api/v1/s/") {
 			next.ServeHTTP(w, r)
 			return
 		}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -279,6 +279,9 @@ func (s *Server) setupRouter() {
 		// Invitations (outside workspace scope)
 		r.Post("/invitations/{code}/accept", s.handleAcceptInvitation)
 
+		// Share link resolution (outside workspace scope, no auth required)
+		r.Get("/s/{token}", s.handleResolveShareLink)
+
 		// Workspaces
 		r.Route("/workspaces", func(r chi.Router) {
 			r.Get("/", s.handleListWorkspaces)
@@ -332,6 +335,8 @@ func (s *Server) setupRouter() {
 						r.Get("/grants", s.handleListCollectionGrants)
 						r.Post("/grants", s.handleCreateCollectionGrant)
 						r.Delete("/grants/{grantID}", s.handleDeleteCollectionGrant)
+						r.Get("/share-links", s.handleListCollectionShareLinks)
+						r.Post("/share-links", s.handleCreateCollectionShareLink)
 						// Saved views within collection
 						r.Get("/views", s.handleListViews)
 						r.Post("/views", s.handleCreateView)
@@ -370,10 +375,15 @@ func (s *Server) setupRouter() {
 					r.Get("/grants", s.handleListItemGrants)
 					r.Post("/grants", s.handleCreateItemGrant)
 					r.Delete("/grants/{grantID}", s.handleDeleteItemGrant)
+					r.Get("/share-links", s.handleListItemShareLinks)
+					r.Post("/share-links", s.handleCreateItemShareLink)
 				})
 
 				// Links (v2)
 				r.Delete("/links/{linkID}", s.handleDeleteItemLink)
+
+				// Share links (workspace-scoped delete)
+				r.Delete("/share-links/{linkID}", s.handleDeleteShareLink)
 
 				// Comments (v2)
 				r.Route("/comments/{commentID}", func(r chi.Router) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -209,7 +209,7 @@ func (s *Server) setupRouter() {
 		r.Use(cors.Handler(cors.Options{
 			AllowedOrigins:   parseCORSOrigins(s.corsOrigins),
 			AllowedMethods:   []string{"GET", "POST", "PATCH", "PUT", "DELETE", "OPTIONS"},
-			AllowedHeaders:   []string{"Accept", "Authorization", "Content-Type", "X-CSRF-Token"},
+			AllowedHeaders:   []string{"Accept", "Authorization", "Content-Type", "X-CSRF-Token", "X-Share-Password"},
 			AllowCredentials: true,
 			MaxAge:           300,
 		}))

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -382,8 +382,9 @@ func (s *Server) setupRouter() {
 				// Links (v2)
 				r.Delete("/links/{linkID}", s.handleDeleteItemLink)
 
-				// Share links (workspace-scoped delete)
+				// Share links (workspace-scoped management)
 				r.Delete("/share-links/{linkID}", s.handleDeleteShareLink)
+				r.Get("/share-links/{linkID}/views", s.handleShareLinkViews)
 
 				// Comments (v2)
 				r.Route("/comments/{commentID}", func(r chi.Router) {

--- a/internal/store/migrations/034_share_links.sql
+++ b/internal/store/migrations/034_share_links.sql
@@ -1,0 +1,35 @@
+-- Share links for anonymous/external access to items and collections (TASK-421).
+-- Tokens are hashed at rest (SHA-256). Raw token returned only once on creation.
+-- D8: Anonymous users are ALWAYS read-only regardless of permission field.
+
+CREATE TABLE IF NOT EXISTS share_links (
+    id TEXT PRIMARY KEY,
+    token_hash TEXT UNIQUE NOT NULL,
+    target_type TEXT NOT NULL,               -- 'item' or 'collection'
+    target_id TEXT NOT NULL,
+    workspace_id TEXT NOT NULL REFERENCES workspaces(id),
+    permission TEXT NOT NULL DEFAULT 'view', -- 'view' or 'edit' (edit only for require_auth links)
+    created_by TEXT NOT NULL REFERENCES users(id),
+    password_hash TEXT,
+    expires_at TEXT,
+    max_views INTEGER,
+    require_auth INTEGER DEFAULT 0,
+    restrict_to_email TEXT,
+    view_count INTEGER DEFAULT 0,
+    unique_viewers INTEGER DEFAULT 0,
+    last_viewed_at TEXT,
+    created_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_share_links_target ON share_links(target_type, target_id);
+CREATE INDEX IF NOT EXISTS idx_share_links_workspace ON share_links(workspace_id, created_by);
+
+CREATE TABLE IF NOT EXISTS share_link_views (
+    id TEXT PRIMARY KEY,
+    share_link_id TEXT NOT NULL REFERENCES share_links(id) ON DELETE CASCADE,
+    viewer_fingerprint TEXT,
+    viewer_user_id TEXT REFERENCES users(id),
+    viewed_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_share_link_views_link ON share_link_views(share_link_id);

--- a/internal/store/pgmigrations/014_share_links.sql
+++ b/internal/store/pgmigrations/014_share_links.sql
@@ -1,0 +1,33 @@
+-- Share links for anonymous/external access to items and collections (TASK-421).
+
+CREATE TABLE IF NOT EXISTS share_links (
+    id TEXT PRIMARY KEY,
+    token_hash TEXT UNIQUE NOT NULL,
+    target_type TEXT NOT NULL,
+    target_id TEXT NOT NULL,
+    workspace_id TEXT NOT NULL REFERENCES workspaces(id),
+    permission TEXT NOT NULL DEFAULT 'view',
+    created_by TEXT NOT NULL REFERENCES users(id),
+    password_hash TEXT,
+    expires_at TEXT,
+    max_views INTEGER,
+    require_auth BOOLEAN DEFAULT FALSE,
+    restrict_to_email TEXT,
+    view_count INTEGER DEFAULT 0,
+    unique_viewers INTEGER DEFAULT 0,
+    last_viewed_at TEXT,
+    created_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_share_links_target ON share_links(target_type, target_id);
+CREATE INDEX IF NOT EXISTS idx_share_links_workspace ON share_links(workspace_id, created_by);
+
+CREATE TABLE IF NOT EXISTS share_link_views (
+    id TEXT PRIMARY KEY,
+    share_link_id TEXT NOT NULL REFERENCES share_links(id) ON DELETE CASCADE,
+    viewer_fingerprint TEXT,
+    viewer_user_id TEXT REFERENCES users(id),
+    viewed_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_share_link_views_link ON share_link_views(share_link_id);

--- a/internal/store/share_links.go
+++ b/internal/store/share_links.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/xarmian/pad/internal/models"
+	"golang.org/x/crypto/bcrypt"
 )
 
 // generateShareToken creates a cryptographically random URL-safe token
@@ -32,9 +33,18 @@ func hashShareToken(token string) string {
 	return hex.EncodeToString(h[:])
 }
 
+// ShareLinkOptions holds optional constraint fields for creating a share link.
+type ShareLinkOptions struct {
+	Password        string  // Raw password (will be bcrypt-hashed if non-empty)
+	ExpiresAt       *string // ISO 8601 timestamp
+	MaxViews        *int
+	RequireAuth     bool
+	RestrictToEmail string
+}
+
 // CreateShareLink creates a new share link and returns it with the raw token.
 // The raw token is only available in this response — it is not stored.
-func (s *Store) CreateShareLink(workspaceID, targetType, targetID, permission, createdBy string) (*models.ShareLink, error) {
+func (s *Store) CreateShareLink(workspaceID, targetType, targetID, permission, createdBy string, opts *ShareLinkOptions) (*models.ShareLink, error) {
 	rawToken, tokenHash, err := generateShareToken()
 	if err != nil {
 		return nil, err
@@ -43,10 +53,35 @@ func (s *Store) CreateShareLink(workspaceID, targetType, targetID, permission, c
 	id := newID()
 	ts := now()
 
+	var passwordHash *string
+	var expiresAt *string
+	var maxViews *int
+	requireAuth := false
+	var restrictToEmail *string
+
+	if opts != nil {
+		if opts.Password != "" {
+			hash, err := bcrypt.GenerateFromPassword([]byte(opts.Password), 10)
+			if err != nil {
+				return nil, fmt.Errorf("hash share link password: %w", err)
+			}
+			h := string(hash)
+			passwordHash = &h
+		}
+		expiresAt = opts.ExpiresAt
+		maxViews = opts.MaxViews
+		requireAuth = opts.RequireAuth
+		if opts.RestrictToEmail != "" {
+			restrictToEmail = &opts.RestrictToEmail
+		}
+	}
+
 	_, err = s.db.Exec(s.q(`
-		INSERT INTO share_links (id, token_hash, target_type, target_id, workspace_id, permission, created_by, created_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-	`), id, tokenHash, targetType, targetID, workspaceID, permission, createdBy, ts)
+		INSERT INTO share_links (id, token_hash, target_type, target_id, workspace_id, permission, created_by,
+		                         password_hash, expires_at, max_views, require_auth, restrict_to_email, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`), id, tokenHash, targetType, targetID, workspaceID, permission, createdBy,
+		passwordHash, expiresAt, maxViews, s.dialect.BoolToInt(requireAuth), restrictToEmail, ts)
 	if err != nil {
 		return nil, fmt.Errorf("create share link: %w", err)
 	}
@@ -217,6 +252,44 @@ func (s *Store) RecordShareLinkView(linkID, fingerprint, userID string) error {
 	}
 
 	return nil
+}
+
+// ValidateShareLinkPassword checks a password against the share link's stored hash.
+func (s *Store) ValidateShareLinkPassword(link *models.ShareLink, password string) bool {
+	if link.PasswordHash == nil || *link.PasswordHash == "" {
+		return true // No password required
+	}
+	return bcrypt.CompareHashAndPassword([]byte(*link.PasswordHash), []byte(password)) == nil
+}
+
+// ListShareLinkViews returns view history for a share link.
+func (s *Store) ListShareLinkViews(linkID string, limit int) ([]models.ShareLinkView, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+	rows, err := s.db.Query(s.q(`
+		SELECT id, share_link_id, COALESCE(viewer_fingerprint, ''), COALESCE(viewer_user_id, ''), viewed_at
+		FROM share_link_views
+		WHERE share_link_id = ?
+		ORDER BY viewed_at DESC
+		LIMIT ?
+	`), linkID, limit)
+	if err != nil {
+		return nil, fmt.Errorf("list share link views: %w", err)
+	}
+	defer rows.Close()
+
+	var result []models.ShareLinkView
+	for rows.Next() {
+		var v models.ShareLinkView
+		var viewedAt string
+		if err := rows.Scan(&v.ID, &v.ShareLinkID, &v.ViewerFingerprint, &v.ViewerUserID, &viewedAt); err != nil {
+			return nil, err
+		}
+		v.ViewedAt = parseTime(viewedAt)
+		result = append(result, v)
+	}
+	return result, rows.Err()
 }
 
 // ValidateShareLink checks if a share link is valid (not expired, not over max views).

--- a/internal/store/share_links.go
+++ b/internal/store/share_links.go
@@ -210,16 +210,34 @@ func (s *Store) DeleteShareLink(id, workspaceID string) error {
 	return nil
 }
 
-// RecordShareLinkView increments the view counter and records a view entry.
-func (s *Store) RecordShareLinkView(linkID, fingerprint, userID string) error {
+// RecordShareLinkView atomically increments the view counter (respecting max_views)
+// and records a view entry. Returns true if the view was allowed, false if the
+// max_views limit has been reached.
+func (s *Store) RecordShareLinkView(linkID, fingerprint, userID string, maxViews *int) (bool, error) {
 	ts := now()
 
-	// Increment view_count and update last_viewed_at
-	_, err := s.db.Exec(s.q(`
-		UPDATE share_links SET view_count = view_count + 1, last_viewed_at = ? WHERE id = ?
-	`), ts, linkID)
+	// Atomically increment view_count, respecting max_views if set.
+	// The WHERE condition ensures we never exceed the limit.
+	var result sql.Result
+	var err error
+	if maxViews != nil {
+		result, err = s.db.Exec(s.q(`
+			UPDATE share_links SET view_count = view_count + 1, last_viewed_at = ?
+			WHERE id = ? AND view_count < ?
+		`), ts, linkID, *maxViews)
+	} else {
+		result, err = s.db.Exec(s.q(`
+			UPDATE share_links SET view_count = view_count + 1, last_viewed_at = ?
+			WHERE id = ?
+		`), ts, linkID)
+	}
 	if err != nil {
-		return fmt.Errorf("increment view count: %w", err)
+		return false, fmt.Errorf("increment view count: %w", err)
+	}
+	n, _ := result.RowsAffected()
+	if n == 0 {
+		// max_views limit reached — no row was updated
+		return false, nil
 	}
 
 	// Check unique viewers (by fingerprint or user ID)
@@ -248,10 +266,10 @@ func (s *Store) RecordShareLinkView(linkID, fingerprint, userID string) error {
 		VALUES (?, ?, ?, ?, ?)
 	`), viewID, linkID, fingerprint, viewerUserID, ts)
 	if err != nil {
-		return fmt.Errorf("record share link view: %w", err)
+		return true, fmt.Errorf("record share link view: %w", err)
 	}
 
-	return nil
+	return true, nil
 }
 
 // ValidateShareLinkPassword checks a password against the share link's stored hash.
@@ -292,7 +310,8 @@ func (s *Store) ListShareLinkViews(linkID string, limit int) ([]models.ShareLink
 	return result, rows.Err()
 }
 
-// ValidateShareLink checks if a share link is valid (not expired, not over max views).
+// ValidateShareLink checks if a share link is valid (not expired).
+// Max views enforcement is handled atomically by RecordShareLinkView.
 // Returns nil error if valid, or an error describing why it's invalid.
 func (s *Store) ValidateShareLink(link *models.ShareLink) error {
 	if link == nil {
@@ -302,11 +321,6 @@ func (s *Store) ValidateShareLink(link *models.ShareLink) error {
 	// Check expiry
 	if link.ExpiresAt != nil && time.Now().After(*link.ExpiresAt) {
 		return fmt.Errorf("share link has expired")
-	}
-
-	// Check max views
-	if link.MaxViews != nil && link.ViewCount >= *link.MaxViews {
-		return fmt.Errorf("share link has reached maximum views")
 	}
 
 	return nil

--- a/internal/store/share_links.go
+++ b/internal/store/share_links.go
@@ -1,0 +1,240 @@
+package store
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"time"
+
+	"github.com/xarmian/pad/internal/models"
+)
+
+// generateShareToken creates a cryptographically random URL-safe token
+// with at least 128 bits of entropy and returns both the raw token
+// and its SHA-256 hash for storage.
+func generateShareToken() (raw string, hash string, err error) {
+	b := make([]byte, 24) // 192 bits → 32 URL-safe base64 chars
+	if _, err := rand.Read(b); err != nil {
+		return "", "", fmt.Errorf("generate share token: %w", err)
+	}
+	raw = base64.URLEncoding.WithPadding(base64.NoPadding).EncodeToString(b)
+	h := sha256.Sum256([]byte(raw))
+	hash = hex.EncodeToString(h[:])
+	return raw, hash, nil
+}
+
+// hashShareToken computes the SHA-256 hash of a raw share token for lookup.
+func hashShareToken(token string) string {
+	h := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(h[:])
+}
+
+// CreateShareLink creates a new share link and returns it with the raw token.
+// The raw token is only available in this response — it is not stored.
+func (s *Store) CreateShareLink(workspaceID, targetType, targetID, permission, createdBy string) (*models.ShareLink, error) {
+	rawToken, tokenHash, err := generateShareToken()
+	if err != nil {
+		return nil, err
+	}
+
+	id := newID()
+	ts := now()
+
+	_, err = s.db.Exec(s.q(`
+		INSERT INTO share_links (id, token_hash, target_type, target_id, workspace_id, permission, created_by, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+	`), id, tokenHash, targetType, targetID, workspaceID, permission, createdBy, ts)
+	if err != nil {
+		return nil, fmt.Errorf("create share link: %w", err)
+	}
+
+	link, err := s.GetShareLink(id)
+	if err != nil {
+		return nil, err
+	}
+	link.Token = rawToken // Only set on creation
+	return link, nil
+}
+
+// GetShareLink retrieves a share link by ID.
+func (s *Store) GetShareLink(id string) (*models.ShareLink, error) {
+	var link models.ShareLink
+	var createdAt string
+	var expiresAt, lastViewedAt, passwordHash, restrictToEmail *string
+	var maxViews *int
+	var requireAuth bool
+
+	err := s.db.QueryRow(s.q(`
+		SELECT id, token_hash, target_type, target_id, workspace_id, permission, created_by,
+		       password_hash, expires_at, max_views, require_auth, restrict_to_email,
+		       view_count, unique_viewers, last_viewed_at, created_at
+		FROM share_links WHERE id = ?
+	`), id).Scan(
+		&link.ID, &link.TokenHash, &link.TargetType, &link.TargetID, &link.WorkspaceID,
+		&link.Permission, &link.CreatedBy,
+		&passwordHash, &expiresAt, &maxViews, &requireAuth, &restrictToEmail,
+		&link.ViewCount, &link.UniqueViewers, &lastViewedAt, &createdAt,
+	)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get share link: %w", err)
+	}
+
+	link.RequireAuth = requireAuth
+	link.PasswordHash = passwordHash
+	link.HasPassword = passwordHash != nil && *passwordHash != ""
+	link.CreatedAt = parseTime(createdAt)
+	link.ExpiresAt = parseTimePtr(expiresAt)
+	link.LastViewedAt = parseTimePtr(lastViewedAt)
+	if maxViews != nil {
+		link.MaxViews = maxViews
+	}
+	if restrictToEmail != nil {
+		link.RestrictToEmail = *restrictToEmail
+	}
+	return &link, nil
+}
+
+// GetShareLinkByToken looks up a share link by its raw token (hashes it first).
+func (s *Store) GetShareLinkByToken(token string) (*models.ShareLink, error) {
+	hash := hashShareToken(token)
+	var id string
+	err := s.db.QueryRow(s.q("SELECT id FROM share_links WHERE token_hash = ?"), hash).Scan(&id)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get share link by token: %w", err)
+	}
+	return s.GetShareLink(id)
+}
+
+// ListShareLinks returns all share links for a target (item or collection).
+func (s *Store) ListShareLinks(targetType, targetID string) ([]models.ShareLink, error) {
+	rows, err := s.db.Query(s.q(`
+		SELECT id, token_hash, target_type, target_id, workspace_id, permission, created_by,
+		       password_hash, expires_at, max_views, require_auth, restrict_to_email,
+		       view_count, unique_viewers, last_viewed_at, created_at
+		FROM share_links
+		WHERE target_type = ? AND target_id = ?
+		ORDER BY created_at DESC
+	`), targetType, targetID)
+	if err != nil {
+		return nil, fmt.Errorf("list share links: %w", err)
+	}
+	defer rows.Close()
+
+	var result []models.ShareLink
+	for rows.Next() {
+		var link models.ShareLink
+		var createdAt string
+		var expiresAt, lastViewedAt, passwordHash, restrictToEmail *string
+		var maxViews *int
+		var requireAuth bool
+
+		if err := rows.Scan(
+			&link.ID, &link.TokenHash, &link.TargetType, &link.TargetID, &link.WorkspaceID,
+			&link.Permission, &link.CreatedBy,
+			&passwordHash, &expiresAt, &maxViews, &requireAuth, &restrictToEmail,
+			&link.ViewCount, &link.UniqueViewers, &lastViewedAt, &createdAt,
+		); err != nil {
+			return nil, err
+		}
+
+		link.RequireAuth = requireAuth
+		link.HasPassword = passwordHash != nil && *passwordHash != ""
+		link.CreatedAt = parseTime(createdAt)
+		link.ExpiresAt = parseTimePtr(expiresAt)
+		link.LastViewedAt = parseTimePtr(lastViewedAt)
+		if maxViews != nil {
+			link.MaxViews = maxViews
+		}
+		if restrictToEmail != nil {
+			link.RestrictToEmail = *restrictToEmail
+		}
+		result = append(result, link)
+	}
+	return result, rows.Err()
+}
+
+// DeleteShareLink deletes a share link by ID, scoped to a workspace.
+func (s *Store) DeleteShareLink(id, workspaceID string) error {
+	result, err := s.db.Exec(s.q("DELETE FROM share_links WHERE id = ? AND workspace_id = ?"), id, workspaceID)
+	if err != nil {
+		return fmt.Errorf("delete share link: %w", err)
+	}
+	n, _ := result.RowsAffected()
+	if n == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
+}
+
+// RecordShareLinkView increments the view counter and records a view entry.
+func (s *Store) RecordShareLinkView(linkID, fingerprint, userID string) error {
+	ts := now()
+
+	// Increment view_count and update last_viewed_at
+	_, err := s.db.Exec(s.q(`
+		UPDATE share_links SET view_count = view_count + 1, last_viewed_at = ? WHERE id = ?
+	`), ts, linkID)
+	if err != nil {
+		return fmt.Errorf("increment view count: %w", err)
+	}
+
+	// Check unique viewers (by fingerprint or user ID)
+	var existingCount int
+	if userID != "" {
+		s.db.QueryRow(s.q(
+			"SELECT COUNT(*) FROM share_link_views WHERE share_link_id = ? AND viewer_user_id = ?"),
+			linkID, userID).Scan(&existingCount)
+	} else if fingerprint != "" {
+		s.db.QueryRow(s.q(
+			"SELECT COUNT(*) FROM share_link_views WHERE share_link_id = ? AND viewer_fingerprint = ?"),
+			linkID, fingerprint).Scan(&existingCount)
+	}
+
+	if existingCount == 0 {
+		_, _ = s.db.Exec(s.q(`
+			UPDATE share_links SET unique_viewers = unique_viewers + 1 WHERE id = ?
+		`), linkID)
+	}
+
+	// Record the view
+	viewID := newID()
+	viewerUserID := sql.NullString{String: userID, Valid: userID != ""}
+	_, err = s.db.Exec(s.q(`
+		INSERT INTO share_link_views (id, share_link_id, viewer_fingerprint, viewer_user_id, viewed_at)
+		VALUES (?, ?, ?, ?, ?)
+	`), viewID, linkID, fingerprint, viewerUserID, ts)
+	if err != nil {
+		return fmt.Errorf("record share link view: %w", err)
+	}
+
+	return nil
+}
+
+// ValidateShareLink checks if a share link is valid (not expired, not over max views).
+// Returns nil error if valid, or an error describing why it's invalid.
+func (s *Store) ValidateShareLink(link *models.ShareLink) error {
+	if link == nil {
+		return fmt.Errorf("share link not found")
+	}
+
+	// Check expiry
+	if link.ExpiresAt != nil && time.Now().After(*link.ExpiresAt) {
+		return fmt.Errorf("share link has expired")
+	}
+
+	// Check max views
+	if link.MaxViews != nil && link.ViewCount >= *link.MaxViews {
+		return fmt.Errorf("share link has reached maximum views")
+	}
+
+	return nil
+}

--- a/internal/store/share_links.go
+++ b/internal/store/share_links.go
@@ -211,22 +211,29 @@ func (s *Store) DeleteShareLink(id, workspaceID string) error {
 }
 
 // RecordShareLinkView atomically increments the view counter (respecting max_views)
-// and records a view entry. Returns true if the view was allowed, false if the
-// max_views limit has been reached.
+// and records a view entry inside a single transaction. Returns true if the view
+// was allowed, false if the max_views limit has been reached. If any step after
+// the increment fails, the entire transaction is rolled back so a view is never
+// consumed without being fully recorded.
 func (s *Store) RecordShareLinkView(linkID, fingerprint, userID string, maxViews *int) (bool, error) {
 	ts := now()
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return false, fmt.Errorf("begin share view tx: %w", err)
+	}
+	defer tx.Rollback() // no-op after Commit
 
 	// Atomically increment view_count, respecting max_views if set.
 	// The WHERE condition ensures we never exceed the limit.
 	var result sql.Result
-	var err error
 	if maxViews != nil {
-		result, err = s.db.Exec(s.q(`
+		result, err = tx.Exec(s.q(`
 			UPDATE share_links SET view_count = view_count + 1, last_viewed_at = ?
 			WHERE id = ? AND view_count < ?
 		`), ts, linkID, *maxViews)
 	} else {
-		result, err = s.db.Exec(s.q(`
+		result, err = tx.Exec(s.q(`
 			UPDATE share_links SET view_count = view_count + 1, last_viewed_at = ?
 			WHERE id = ?
 		`), ts, linkID)
@@ -243,32 +250,40 @@ func (s *Store) RecordShareLinkView(linkID, fingerprint, userID string, maxViews
 	// Check unique viewers (by fingerprint or user ID)
 	var existingCount int
 	if userID != "" {
-		s.db.QueryRow(s.q(
+		if err := tx.QueryRow(s.q(
 			"SELECT COUNT(*) FROM share_link_views WHERE share_link_id = ? AND viewer_user_id = ?"),
-			linkID, userID).Scan(&existingCount)
+			linkID, userID).Scan(&existingCount); err != nil {
+			return false, fmt.Errorf("check unique viewer: %w", err)
+		}
 	} else if fingerprint != "" {
-		s.db.QueryRow(s.q(
+		if err := tx.QueryRow(s.q(
 			"SELECT COUNT(*) FROM share_link_views WHERE share_link_id = ? AND viewer_fingerprint = ?"),
-			linkID, fingerprint).Scan(&existingCount)
+			linkID, fingerprint).Scan(&existingCount); err != nil {
+			return false, fmt.Errorf("check unique viewer: %w", err)
+		}
 	}
 
 	if existingCount == 0 {
-		_, _ = s.db.Exec(s.q(`
+		if _, err := tx.Exec(s.q(`
 			UPDATE share_links SET unique_viewers = unique_viewers + 1 WHERE id = ?
-		`), linkID)
+		`), linkID); err != nil {
+			return false, fmt.Errorf("increment unique viewers: %w", err)
+		}
 	}
 
 	// Record the view
 	viewID := newID()
 	viewerUserID := sql.NullString{String: userID, Valid: userID != ""}
-	_, err = s.db.Exec(s.q(`
+	if _, err := tx.Exec(s.q(`
 		INSERT INTO share_link_views (id, share_link_id, viewer_fingerprint, viewer_user_id, viewed_at)
 		VALUES (?, ?, ?, ?, ?)
-	`), viewID, linkID, fingerprint, viewerUserID, ts)
-	if err != nil {
-		return true, fmt.Errorf("record share link view: %w", err)
+	`), viewID, linkID, fingerprint, viewerUserID, ts); err != nil {
+		return false, fmt.Errorf("record share link view: %w", err)
 	}
 
+	if err := tx.Commit(); err != nil {
+		return false, fmt.Errorf("commit share view tx: %w", err)
+	}
 	return true, nil
 }
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -158,6 +158,7 @@ func (s *Store) migrate() error {
 		"031_collection_access.sql",
 		"032_permission_indexes.sql",
 		"033_grants.sql",
+		"034_share_links.sql",
 	}
 
 	for _, name := range migrations {
@@ -215,6 +216,7 @@ func (s *Store) migratePostgres() error {
 		"011_collection_access.sql",
 		"012_permission_indexes.sql",
 		"013_grants.sql",
+		"014_share_links.sql",
 	}
 
 	for _, name := range migrations {

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -7,6 +7,7 @@
 		"": {
 			"name": "web",
 			"version": "0.0.1",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@tiptap/core": "^3.20.4",
 				"@tiptap/extension-bubble-menu": "^3.20.4",
@@ -20,6 +21,7 @@
 				"@tiptap/starter-kit": "^3.20.4",
 				"@tiptap/suggestion": "^3.20.4",
 				"diff": "^8.0.3",
+				"dompurify": "^3.3.3",
 				"lowlight": "^3.3.0",
 				"mermaid": "^11.13.0",
 				"svelte-dnd-action": "^0.9.69",

--- a/web/package.json
+++ b/web/package.json
@@ -37,6 +37,7 @@
 		"@tiptap/starter-kit": "^3.20.4",
 		"@tiptap/suggestion": "^3.20.4",
 		"diff": "^8.0.3",
+		"dompurify": "^3.3.3",
 		"lowlight": "^3.3.0",
 		"mermaid": "^11.13.0",
 		"svelte-dnd-action": "^0.9.69",

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -573,15 +573,18 @@ export const api = {
 	// ── Public Share (no auth) ──────────────────────────────────────────────
 
 	share: {
-		get: (token: string) =>
-			fetch(`${BASE}/s/${token}`, { credentials: 'same-origin' }).then(async (resp) => {
+		get: (token: string, password?: string) => {
+			const headers: Record<string, string> = {};
+			if (password) headers['X-Share-Password'] = password;
+			return fetch(`${BASE}/s/${token}`, { credentials: 'same-origin', headers }).then(async (resp) => {
 				if (!resp.ok) {
 					const body = await resp.json().catch(() => null);
 					if (body?.error) throw new PadApiError(body.error);
 					throw new Error(`API error: ${resp.status}`);
 				}
 				return resp.json();
-			}),
+			});
+		},
 	},
 
 	// ── Auth ──────────────────────────────────────────────────────────────────

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -35,7 +35,8 @@ import type {
 	RoleBoardLane,
 	ChangesResponse,
 	CollectionGrant,
-	ItemGrant
+	ItemGrant,
+	ShareLink
 } from '$lib/types';
 
 const BASE = '/api/v1';
@@ -552,6 +553,35 @@ export const api = {
 			request<void>(`/workspaces/${ws}/items/${itemSlug}/grants/${grantId}`, { method: 'DELETE' }),
 		listUserGrants: (ws: string, userId: string) =>
 			request<{ collection_grants: CollectionGrant[]; item_grants: ItemGrant[] }>(`/workspaces/${ws}/users/${userId}/grants`),
+	},
+
+	// ── Share Links ─────────────────────────────────────────────────────────
+
+	shareLinks: {
+		listItemShareLinks: (ws: string, itemSlug: string) =>
+			request<ShareLink[]>(`/workspaces/${ws}/items/${itemSlug}/share-links`),
+		createItemShareLink: (ws: string, itemSlug: string) =>
+			request<ShareLink>(`/workspaces/${ws}/items/${itemSlug}/share-links`, { method: 'POST' }),
+		listCollectionShareLinks: (ws: string, collSlug: string) =>
+			request<ShareLink[]>(`/workspaces/${ws}/collections/${collSlug}/share-links`),
+		createCollectionShareLink: (ws: string, collSlug: string) =>
+			request<ShareLink>(`/workspaces/${ws}/collections/${collSlug}/share-links`, { method: 'POST' }),
+		deleteShareLink: (ws: string, linkId: string) =>
+			request<void>(`/workspaces/${ws}/share-links/${linkId}`, { method: 'DELETE' }),
+	},
+
+	// ── Public Share (no auth) ──────────────────────────────────────────────
+
+	share: {
+		get: (token: string) =>
+			fetch(`${BASE}/s/${token}`, { credentials: 'same-origin' }).then(async (resp) => {
+				if (!resp.ok) {
+					const body = await resp.json().catch(() => null);
+					if (body?.error) throw new PadApiError(body.error);
+					throw new Error(`API error: ${resp.status}`);
+				}
+				return resp.json();
+			}),
 	},
 
 	// ── Auth ──────────────────────────────────────────────────────────────────

--- a/web/src/lib/components/ShareDialog.svelte
+++ b/web/src/lib/components/ShareDialog.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { api } from '$lib/api/client';
 	import { toastStore } from '$lib/stores/toast.svelte';
-	import type { CollectionGrant, ItemGrant } from '$lib/types';
+	import type { CollectionGrant, ItemGrant, ShareLink } from '$lib/types';
 
 	interface Props {
 		wsSlug: string;
@@ -24,6 +24,14 @@
 
 	let revokingId = $state<string | null>(null);
 
+	// Share links state
+	let shareLinks = $state<ShareLink[]>([]);
+	let loadingLinks = $state(false);
+	let linksError = $state('');
+	let creatingLink = $state(false);
+	let newlyCreatedLinkId = $state<string | null>(null);
+	let deletingLinkId = $state<string | null>(null);
+
 	// Track previous open state to detect open transitions
 	let prevOpen = $state(false);
 
@@ -33,7 +41,9 @@
 			email = '';
 			permission = 'view';
 			shareError = '';
+			newlyCreatedLinkId = null;
 			loadGrants();
+			loadShareLinks();
 		}
 		prevOpen = open;
 	});
@@ -52,6 +62,78 @@
 			grants = [];
 		} finally {
 			loadingGrants = false;
+		}
+	}
+
+	async function loadShareLinks() {
+		loadingLinks = true;
+		linksError = '';
+		try {
+			if (type === 'collection') {
+				shareLinks = await api.shareLinks.listCollectionShareLinks(wsSlug, targetSlug);
+			} else {
+				shareLinks = await api.shareLinks.listItemShareLinks(wsSlug, targetSlug);
+			}
+		} catch (e: any) {
+			linksError = e.message ?? 'Failed to load share links';
+			shareLinks = [];
+		} finally {
+			loadingLinks = false;
+		}
+	}
+
+	async function handleCreateShareLink() {
+		if (creatingLink) return;
+		creatingLink = true;
+		try {
+			let newLink: ShareLink;
+			if (type === 'collection') {
+				newLink = await api.shareLinks.createCollectionShareLink(wsSlug, targetSlug);
+			} else {
+				newLink = await api.shareLinks.createItemShareLink(wsSlug, targetSlug);
+			}
+			shareLinks = [newLink, ...shareLinks];
+			newlyCreatedLinkId = newLink.id;
+			toastStore.show('Share link created', 'success');
+		} catch (e: any) {
+			toastStore.show(e.message ?? 'Failed to create share link', 'error');
+		} finally {
+			creatingLink = false;
+		}
+	}
+
+	async function handleDeleteShareLink(linkId: string) {
+		if (deletingLinkId) return;
+		deletingLinkId = linkId;
+		try {
+			await api.shareLinks.deleteShareLink(wsSlug, linkId);
+			shareLinks = shareLinks.filter((l) => l.id !== linkId);
+			if (newlyCreatedLinkId === linkId) {
+				newlyCreatedLinkId = null;
+			}
+			toastStore.show('Share link revoked', 'success');
+		} catch (e: any) {
+			toastStore.show(e.message ?? 'Failed to revoke share link', 'error');
+		} finally {
+			deletingLinkId = null;
+		}
+	}
+
+	function getShareLinkUrl(link: ShareLink): string {
+		if (link.url) return link.url;
+		if (link.token) {
+			const origin = typeof window !== 'undefined' ? window.location.origin : '';
+			return `${origin}/s/${link.token}`;
+		}
+		return '';
+	}
+
+	async function copyToClipboard(text: string) {
+		try {
+			await navigator.clipboard.writeText(text);
+			toastStore.show('Link copied to clipboard', 'success');
+		} catch {
+			toastStore.show('Failed to copy link', 'error');
 		}
 	}
 
@@ -122,6 +204,10 @@
 	function grantDisplayEmail(grant: CollectionGrant | ItemGrant): string | null {
 		if (grant.user_name && grant.user_email) return grant.user_email;
 		return null;
+	}
+
+	function formatDate(dateStr: string): string {
+		return new Date(dateStr).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
 	}
 </script>
 
@@ -200,6 +286,98 @@
 											{revokingId === grant.id ? '...' : '\u00D7'}
 										</button>
 									</div>
+								</div>
+							{/each}
+						</div>
+					{/if}
+				</div>
+
+				<!-- Share links section -->
+				<div class="share-links-section">
+					<div class="share-links-header">
+						<span class="section-label">Share links</span>
+						<button
+							class="create-link-btn"
+							type="button"
+							onclick={handleCreateShareLink}
+							disabled={creatingLink}
+						>
+							{creatingLink ? 'Creating...' : '+ Create link'}
+						</button>
+					</div>
+
+					{#if loadingLinks}
+						<div class="grants-loading">Loading...</div>
+					{:else if linksError}
+						<div class="error-msg">{linksError}</div>
+					{:else if shareLinks.length === 0}
+						<div class="grants-empty">No share links yet. Create one to share via URL.</div>
+					{:else}
+						<div class="share-links-list">
+							{#each shareLinks as link (link.id)}
+								{@const linkUrl = getShareLinkUrl(link)}
+								<div class="share-link-row" class:newly-created={link.id === newlyCreatedLinkId}>
+									{#if link.id === newlyCreatedLinkId && linkUrl}
+										<div class="new-link-highlight">
+											<span class="new-link-label">Link created -- copy it now, the token is only shown once:</span>
+											<div class="new-link-url-row">
+												<input
+													class="new-link-url"
+													type="text"
+													readonly
+													value={linkUrl}
+													onclick={(e) => (e.target as HTMLInputElement).select()}
+												/>
+												<button
+													class="copy-btn"
+													type="button"
+													onclick={() => copyToClipboard(linkUrl)}
+													title="Copy link"
+												>
+													Copy
+												</button>
+											</div>
+										</div>
+									{:else}
+										<div class="link-info">
+											<div class="link-url-display">
+												{#if linkUrl}
+													<span class="link-url-text">{linkUrl}</span>
+													<button
+														class="copy-btn-small"
+														type="button"
+														onclick={() => copyToClipboard(linkUrl)}
+														title="Copy link"
+													>
+														<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+															<rect x="9" y="9" width="13" height="13" rx="2" ry="2"/>
+															<path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>
+														</svg>
+													</button>
+												{:else}
+													<span class="link-url-text link-url-hidden">Link token hidden</span>
+												{/if}
+											</div>
+											<div class="link-meta">
+												<span>{link.view_count} view{link.view_count !== 1 ? 's' : ''}</span>
+												<span class="link-meta-sep">&middot;</span>
+												<span>Created {formatDate(link.created_at)}</span>
+												{#if link.require_auth}
+													<span class="link-meta-sep">&middot;</span>
+													<span class="link-auth-badge">Auth required</span>
+												{/if}
+											</div>
+										</div>
+									{/if}
+									<button
+										class="revoke-btn"
+										type="button"
+										title="Revoke share link"
+										onclick={() => handleDeleteShareLink(link.id)}
+										disabled={deletingLinkId === link.id}
+									>
+										{deletingLinkId === link.id ? '...' : '\u00D7'}
+									</button>
 								</div>
 							{/each}
 						</div>
@@ -462,12 +640,202 @@
 		cursor: not-allowed;
 	}
 
+	/* Share links section */
+	.share-links-section {
+		border-top: 1px solid var(--border);
+		padding-top: var(--space-4);
+	}
+
+	.share-links-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		margin-bottom: var(--space-2);
+	}
+
+	.share-links-header .section-label {
+		margin-bottom: 0;
+	}
+
+	.create-link-btn {
+		padding: var(--space-1) var(--space-3);
+		background: none;
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+		color: var(--text-secondary);
+		font-size: 0.8em;
+		font-weight: 500;
+		cursor: pointer;
+		white-space: nowrap;
+	}
+
+	.create-link-btn:hover:not(:disabled) {
+		border-color: var(--accent-blue);
+		color: var(--accent-blue);
+	}
+
+	.create-link-btn:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+
+	.share-links-list {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-2);
+	}
+
+	.share-link-row {
+		display: flex;
+		align-items: flex-start;
+		justify-content: space-between;
+		gap: var(--space-2);
+		padding: var(--space-3);
+		background: var(--bg-tertiary);
+		border-radius: var(--radius);
+		border: 1px solid transparent;
+	}
+
+	.share-link-row.newly-created {
+		border-color: var(--accent-blue);
+		background: color-mix(in srgb, var(--accent-blue) 6%, var(--bg-tertiary));
+	}
+
+	/* Newly created link highlight */
+	.new-link-highlight {
+		flex: 1;
+		min-width: 0;
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-2);
+	}
+
+	.new-link-label {
+		font-size: 0.78em;
+		font-weight: 600;
+		color: var(--accent-blue);
+	}
+
+	.new-link-url-row {
+		display: flex;
+		gap: var(--space-2);
+		align-items: center;
+	}
+
+	.new-link-url {
+		flex: 1;
+		padding: var(--space-2) var(--space-3);
+		background: var(--bg-primary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+		font-size: 0.82em;
+		font-family: var(--font-mono);
+		color: var(--text-primary);
+		min-width: 0;
+	}
+
+	.new-link-url:focus {
+		outline: none;
+		border-color: var(--accent-blue);
+	}
+
+	.copy-btn {
+		padding: var(--space-2) var(--space-3);
+		background: var(--accent-blue);
+		border: none;
+		border-radius: var(--radius);
+		color: #fff;
+		font-size: 0.82em;
+		font-weight: 500;
+		cursor: pointer;
+		white-space: nowrap;
+		flex-shrink: 0;
+	}
+
+	.copy-btn:hover {
+		filter: brightness(1.1);
+	}
+
+	/* Existing link info */
+	.link-info {
+		flex: 1;
+		min-width: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 3px;
+	}
+
+	.link-url-display {
+		display: flex;
+		align-items: center;
+		gap: var(--space-1);
+	}
+
+	.link-url-text {
+		font-size: 0.82em;
+		font-family: var(--font-mono);
+		color: var(--text-primary);
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		min-width: 0;
+	}
+
+	.link-url-hidden {
+		color: var(--text-muted);
+		font-family: var(--font-ui);
+		font-style: italic;
+	}
+
+	.copy-btn-small {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		background: none;
+		border: none;
+		color: var(--text-muted);
+		cursor: pointer;
+		padding: 2px;
+		border-radius: var(--radius-sm);
+		flex-shrink: 0;
+	}
+
+	.copy-btn-small:hover {
+		color: var(--accent-blue);
+		background: var(--bg-hover);
+	}
+
+	.link-meta {
+		display: flex;
+		align-items: center;
+		gap: var(--space-1);
+		font-size: 0.75em;
+		color: var(--text-muted);
+		flex-wrap: wrap;
+	}
+
+	.link-meta-sep {
+		color: var(--border);
+	}
+
+	.link-auth-badge {
+		color: var(--accent-amber);
+	}
+
 	@media (max-width: 480px) {
 		.add-row {
 			flex-wrap: wrap;
 		}
 
 		.email-input {
+			flex: 1 1 100%;
+		}
+
+		.new-link-url-row {
+			flex-wrap: wrap;
+		}
+
+		.new-link-url {
 			flex: 1 1 100%;
 		}
 	}

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -34,6 +34,28 @@ export interface APITokenWithSecret extends APIToken {
 	token: string;
 }
 
+// ─── Share Links ────────────────────────────────────────────────────────────
+
+export interface ShareLink {
+	id: string;
+	token?: string;
+	target_type: string;
+	target_id: string;
+	workspace_id: string;
+	permission: string;
+	created_by: string;
+	has_password: boolean;
+	expires_at?: string;
+	max_views?: number;
+	require_auth: boolean;
+	view_count: number;
+	unique_viewers: number;
+	last_viewed_at?: string;
+	created_at: string;
+	url?: string;
+	target_title?: string;
+}
+
 // ─── Grants ──────────────────────────────────────────────────────────────────
 
 export interface CollectionGrant {

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -19,6 +19,7 @@
 	let showShortcuts = $state(false);
 	let authReady = $state(false);
 	let isAuthPage = $derived(page.url.pathname === '/login' || page.url.pathname === '/register' || page.url.pathname.startsWith('/join/'));
+	let isSharePage = $derived(page.url.pathname.startsWith('/s/'));
 
 	onMount(async () => {
 		// Initialize theme
@@ -27,6 +28,12 @@
 			document.documentElement.setAttribute('data-theme', savedTheme);
 		} else if (window.matchMedia('(prefers-color-scheme: light)').matches) {
 			document.documentElement.setAttribute('data-theme', 'light');
+		}
+
+		// Share pages bypass auth entirely
+		if (isSharePage) {
+			authReady = true;
+			return;
 		}
 
 		// Check auth status before loading the app
@@ -113,7 +120,7 @@
 
 {#if !authReady}
 	<!-- Auth check in progress — blank screen to avoid flash -->
-{:else if isAuthPage}
+{:else if isAuthPage || isSharePage}
 	{@render children()}
 {:else}
 	{#if uiStore.isMobile && uiStore.sidebarOpen}

--- a/web/src/routes/s/[token]/+page.svelte
+++ b/web/src/routes/s/[token]/+page.svelte
@@ -3,12 +3,17 @@
 	import { onMount } from 'svelte';
 	import { api } from '$lib/api/client';
 	import { marked } from 'marked';
+	import DOMPurify from 'dompurify';
 
 	let token = $derived(page.params.token ?? '');
 
 	let loading = $state(true);
 	let error = $state('');
 	let requireAuth = $state(false);
+	let requirePassword = $state(false);
+	let passwordInput = $state('');
+	let passwordError = $state('');
+	let passwordLoading = $state(false);
 
 	let shareType = $state<'item' | 'collection' | ''>('');
 	let itemData = $state<{
@@ -29,7 +34,8 @@
 	let renderedContent = $derived.by(() => {
 		if (!itemData?.content) return '';
 		try {
-			return marked(itemData.content) as string;
+			const raw = marked(itemData.content) as string;
+			return typeof window !== 'undefined' ? DOMPurify.sanitize(raw) : raw;
 		} catch {
 			return itemData.content;
 		}
@@ -51,6 +57,12 @@
 				return;
 			}
 
+			if (data.require_password) {
+				requirePassword = true;
+				loading = false;
+				return;
+			}
+
 			if (data.type === 'item') {
 				shareType = 'item';
 				let fields: Record<string, any> = {};
@@ -67,15 +79,29 @@
 					content: data.item?.content ?? '',
 					collection_name: data.item?.collection_name,
 					collection_icon: data.item?.collection_icon,
-					item_ref: data.item?.item_ref
+					item_ref: data.item?.ref ?? data.item?.item_ref
 				};
 			} else if (data.type === 'collection') {
 				shareType = 'collection';
+				const rawItems = (data.items ?? []).map((item: any) => {
+					let status = '';
+					if (item.fields) {
+						try {
+							const fields = typeof item.fields === 'string' ? JSON.parse(item.fields) : item.fields;
+							status = fields.status ?? '';
+						} catch { /* ignore */ }
+					}
+					return {
+						title: item.title ?? 'Untitled',
+						item_ref: item.ref ?? item.item_ref ?? '',
+						status
+					};
+				});
 				collectionData = {
 					name: data.collection?.name ?? 'Collection',
 					icon: data.collection?.icon,
 					description: data.collection?.description,
-					items: data.collection?.items ?? []
+					items: rawItems
 				};
 			} else {
 				error = 'Unknown share type.';
@@ -99,6 +125,67 @@
 
 	function formatFieldLabel(key: string): string {
 		return key.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+	}
+
+	async function submitPassword() {
+		passwordError = '';
+		passwordLoading = true;
+		try {
+			const resp = await fetch(`/api/v1/s/${token}`, {
+				credentials: 'same-origin',
+				headers: { 'X-Share-Password': passwordInput }
+			});
+			const data = await resp.json();
+			if (!resp.ok) {
+				passwordError = data?.error?.message ?? 'Incorrect password';
+				return;
+			}
+			if (data.require_password) {
+				passwordError = 'Incorrect password';
+				return;
+			}
+			// Re-process the data exactly like onMount does
+			requirePassword = false;
+			if (data.type === 'item') {
+				shareType = 'item';
+				let fields: Record<string, any> = {};
+				if (data.item?.fields) {
+					try {
+						fields = typeof data.item.fields === 'string' ? JSON.parse(data.item.fields) : data.item.fields;
+					} catch { fields = {}; }
+				}
+				itemData = {
+					title: data.item?.title ?? 'Untitled',
+					fields,
+					content: data.item?.content ?? '',
+					collection_name: data.item?.collection_name,
+					collection_icon: data.item?.collection_icon,
+					item_ref: data.item?.ref ?? data.item?.item_ref
+				};
+			} else if (data.type === 'collection') {
+				shareType = 'collection';
+				const rawItems = (data.items ?? []).map((item: any) => {
+					let status = '';
+					if (item.fields) {
+						try {
+							const fields = typeof item.fields === 'string' ? JSON.parse(item.fields) : item.fields;
+							status = fields.status ?? '';
+						} catch { /* ignore */ }
+					}
+					return { title: item.title ?? 'Untitled', item_ref: item.ref ?? item.item_ref ?? '', status };
+				});
+				collectionData = {
+					name: data.collection?.name ?? 'Collection',
+					icon: data.collection?.icon,
+					description: data.collection?.description,
+					items: rawItems
+				};
+			}
+		} catch (e: any) {
+			passwordError = e.message ?? 'Failed to verify password';
+		} finally {
+			passwordLoading = false;
+		}
 	}
 </script>
 
@@ -130,6 +217,32 @@
 				<h1>Sign in to view</h1>
 				<p>This shared content requires authentication.</p>
 				<a href="/login" class="auth-link">Sign in</a>
+			</div>
+		{:else if requirePassword}
+			<div class="share-auth">
+				<div class="auth-icon">
+					<svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+						<rect x="3" y="11" width="18" height="11" rx="2" ry="2"/>
+						<path d="M7 11V7a5 5 0 0 1 10 0v4"/>
+					</svg>
+				</div>
+				<h1>Password required</h1>
+				<p>Enter the password to view this shared content.</p>
+				<form class="password-form" onsubmit={(e) => { e.preventDefault(); submitPassword(); }}>
+					<input
+						type="password"
+						bind:value={passwordInput}
+						placeholder="Enter password"
+						class="password-input"
+						disabled={passwordLoading}
+					/>
+					{#if passwordError}
+						<p class="password-error">{passwordError}</p>
+					{/if}
+					<button type="submit" class="auth-link" disabled={passwordLoading || !passwordInput}>
+						{passwordLoading ? 'Verifying...' : 'View content'}
+					</button>
+				</form>
 			</div>
 		{:else if error}
 			<div class="share-error">
@@ -568,6 +681,37 @@
 
 	.share-footer a:hover {
 		color: var(--accent-blue);
+	}
+
+	.password-form {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: var(--space-3);
+		width: 100%;
+		max-width: 320px;
+	}
+
+	.password-input {
+		width: 100%;
+		padding: var(--space-2) var(--space-3);
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+		background: var(--bg-secondary);
+		color: var(--text-primary);
+		font-size: 0.95em;
+		text-align: center;
+	}
+
+	.password-input:focus {
+		outline: none;
+		border-color: var(--accent-blue);
+	}
+
+	.password-error {
+		color: var(--accent-red, #e53e3e);
+		font-size: 0.85em;
+		margin: 0;
 	}
 
 	@media (max-width: 640px) {

--- a/web/src/routes/s/[token]/+page.svelte
+++ b/web/src/routes/s/[token]/+page.svelte
@@ -1,0 +1,582 @@
+<script lang="ts">
+	import { page } from '$app/state';
+	import { onMount } from 'svelte';
+	import { api } from '$lib/api/client';
+	import { marked } from 'marked';
+
+	let token = $derived(page.params.token ?? '');
+
+	let loading = $state(true);
+	let error = $state('');
+	let requireAuth = $state(false);
+
+	let shareType = $state<'item' | 'collection' | ''>('');
+	let itemData = $state<{
+		title: string;
+		fields: Record<string, any>;
+		content: string;
+		collection_name?: string;
+		collection_icon?: string;
+		item_ref?: string;
+	} | null>(null);
+	let collectionData = $state<{
+		name: string;
+		icon?: string;
+		description?: string;
+		items: { title: string; item_ref?: string; status?: string }[];
+	} | null>(null);
+
+	let renderedContent = $derived.by(() => {
+		if (!itemData?.content) return '';
+		try {
+			return marked(itemData.content) as string;
+		} catch {
+			return itemData.content;
+		}
+	});
+
+	onMount(async () => {
+		if (!token) {
+			error = 'Invalid share link.';
+			loading = false;
+			return;
+		}
+
+		try {
+			const data = await api.share.get(token);
+
+			if (data.require_auth) {
+				requireAuth = true;
+				loading = false;
+				return;
+			}
+
+			if (data.type === 'item') {
+				shareType = 'item';
+				let fields: Record<string, any> = {};
+				if (data.item?.fields) {
+					try {
+						fields = typeof data.item.fields === 'string' ? JSON.parse(data.item.fields) : data.item.fields;
+					} catch {
+						fields = {};
+					}
+				}
+				itemData = {
+					title: data.item?.title ?? 'Untitled',
+					fields,
+					content: data.item?.content ?? '',
+					collection_name: data.item?.collection_name,
+					collection_icon: data.item?.collection_icon,
+					item_ref: data.item?.item_ref
+				};
+			} else if (data.type === 'collection') {
+				shareType = 'collection';
+				collectionData = {
+					name: data.collection?.name ?? 'Collection',
+					icon: data.collection?.icon,
+					description: data.collection?.description,
+					items: data.collection?.items ?? []
+				};
+			} else {
+				error = 'Unknown share type.';
+			}
+		} catch (e: any) {
+			if (e.code === 'unauthorized' || e.code === 'auth_required') {
+				requireAuth = true;
+			} else {
+				error = e.message ?? 'Failed to load shared content.';
+			}
+		} finally {
+			loading = false;
+		}
+	});
+
+	function formatFieldValue(value: unknown): string {
+		if (value === null || value === undefined) return '';
+		if (Array.isArray(value)) return value.join(', ');
+		return String(value);
+	}
+
+	function formatFieldLabel(key: string): string {
+		return key.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+	}
+</script>
+
+<svelte:head>
+	{#if itemData}
+		<title>{itemData.title} - Shared via Pad</title>
+	{:else if collectionData}
+		<title>{collectionData.name} - Shared via Pad</title>
+	{:else}
+		<title>Shared - Pad</title>
+	{/if}
+</svelte:head>
+
+<div class="share-page">
+	<div class="share-container">
+		{#if loading}
+			<div class="share-loading">
+				<div class="loading-spinner"></div>
+				<p>Loading shared content...</p>
+			</div>
+		{:else if requireAuth}
+			<div class="share-auth">
+				<div class="auth-icon">
+					<svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+						<rect x="3" y="11" width="18" height="11" rx="2" ry="2"/>
+						<path d="M7 11V7a5 5 0 0 1 10 0v4"/>
+					</svg>
+				</div>
+				<h1>Sign in to view</h1>
+				<p>This shared content requires authentication.</p>
+				<a href="/login" class="auth-link">Sign in</a>
+			</div>
+		{:else if error}
+			<div class="share-error">
+				<h1>Unable to load</h1>
+				<p>{error}</p>
+			</div>
+		{:else if shareType === 'item' && itemData}
+			<article class="share-item">
+				{#if itemData.collection_name}
+					<div class="item-collection-badge">
+						{#if itemData.collection_icon}
+							<span class="collection-icon">{itemData.collection_icon}</span>
+						{/if}
+						<span>{itemData.collection_name}</span>
+						{#if itemData.item_ref}
+							<span class="item-ref">{itemData.item_ref}</span>
+						{/if}
+					</div>
+				{/if}
+
+				<h1 class="item-title">{itemData.title}</h1>
+
+				{#if Object.keys(itemData.fields).length > 0}
+					<div class="item-fields">
+						{#each Object.entries(itemData.fields) as [key, value] (key)}
+							{#if value !== null && value !== undefined && value !== ''}
+								<div class="field-chip">
+									<span class="field-chip-label">{formatFieldLabel(key)}</span>
+									<span class="field-chip-value">{formatFieldValue(value)}</span>
+								</div>
+							{/if}
+						{/each}
+					</div>
+				{/if}
+
+				{#if itemData.content}
+					<div class="item-content">
+						{@html renderedContent}
+					</div>
+				{/if}
+			</article>
+		{:else if shareType === 'collection' && collectionData}
+			<div class="share-collection">
+				<div class="collection-header">
+					{#if collectionData.icon}
+						<span class="collection-icon-large">{collectionData.icon}</span>
+					{/if}
+					<h1>{collectionData.name}</h1>
+				</div>
+
+				{#if collectionData.description}
+					<p class="collection-description">{collectionData.description}</p>
+				{/if}
+
+				{#if collectionData.items.length > 0}
+					<div class="collection-items">
+						{#each collectionData.items as item, i (i)}
+							<div class="collection-item-row">
+								<span class="collection-item-title">{item.title}</span>
+								{#if item.item_ref}
+									<span class="collection-item-ref">{item.item_ref}</span>
+								{/if}
+								{#if item.status}
+									<span class="collection-item-status">{item.status}</span>
+								{/if}
+							</div>
+						{/each}
+					</div>
+				{:else}
+					<p class="collection-empty">No items in this collection.</p>
+				{/if}
+			</div>
+		{/if}
+	</div>
+
+	<footer class="share-footer">
+		<span>Powered by <a href="https://getpad.dev" target="_blank" rel="noopener noreferrer">Pad</a></span>
+	</footer>
+</div>
+
+<style>
+	.share-page {
+		min-height: 100vh;
+		display: flex;
+		flex-direction: column;
+		background: var(--bg-primary);
+		color: var(--text-primary);
+	}
+
+	.share-container {
+		flex: 1;
+		width: 100%;
+		max-width: 780px;
+		margin: 0 auto;
+		padding: var(--space-8) var(--space-5);
+	}
+
+	/* Loading */
+	.share-loading {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: var(--space-4);
+		padding: var(--space-10) 0;
+		color: var(--text-muted);
+	}
+
+	.loading-spinner {
+		width: 32px;
+		height: 32px;
+		border: 2px solid var(--border);
+		border-top-color: var(--accent-blue);
+		border-radius: 50%;
+		animation: spin 0.8s linear infinite;
+	}
+
+	@keyframes spin {
+		to { transform: rotate(360deg); }
+	}
+
+	/* Auth required */
+	.share-auth {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: var(--space-4);
+		padding: var(--space-10) 0;
+		text-align: center;
+	}
+
+	.auth-icon {
+		color: var(--text-muted);
+	}
+
+	.share-auth h1 {
+		font-size: 1.5em;
+		font-weight: 600;
+	}
+
+	.share-auth p {
+		color: var(--text-secondary);
+		font-size: 0.95em;
+	}
+
+	.auth-link {
+		display: inline-block;
+		margin-top: var(--space-2);
+		padding: var(--space-2) var(--space-6);
+		background: var(--accent-blue);
+		color: #fff;
+		border-radius: var(--radius);
+		font-weight: 500;
+		text-decoration: none;
+		transition: filter 0.15s ease;
+	}
+
+	.auth-link:hover {
+		filter: brightness(1.1);
+		text-decoration: none;
+	}
+
+	/* Error */
+	.share-error {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: var(--space-3);
+		padding: var(--space-10) 0;
+		text-align: center;
+	}
+
+	.share-error h1 {
+		font-size: 1.3em;
+		font-weight: 600;
+	}
+
+	.share-error p {
+		color: var(--text-secondary);
+	}
+
+	/* Item view */
+	.share-item {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-5);
+	}
+
+	.item-collection-badge {
+		display: flex;
+		align-items: center;
+		gap: var(--space-2);
+		font-size: 0.82em;
+		color: var(--text-muted);
+		font-weight: 500;
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+	}
+
+	.collection-icon {
+		font-size: 1.1em;
+	}
+
+	.item-ref {
+		color: var(--text-muted);
+		font-weight: 400;
+	}
+
+	.item-title {
+		font-size: 2em;
+		font-weight: 700;
+		line-height: 1.25;
+		letter-spacing: -0.02em;
+	}
+
+	.item-fields {
+		display: flex;
+		flex-wrap: wrap;
+		gap: var(--space-2);
+	}
+
+	.field-chip {
+		display: inline-flex;
+		align-items: center;
+		gap: var(--space-1);
+		padding: var(--space-1) var(--space-3);
+		background: var(--bg-tertiary);
+		border-radius: 999px;
+		font-size: 0.82em;
+	}
+
+	.field-chip-label {
+		color: var(--text-muted);
+		font-weight: 500;
+	}
+
+	.field-chip-value {
+		color: var(--text-primary);
+	}
+
+	.item-content {
+		font-family: var(--font-content);
+		font-size: 1em;
+		line-height: 1.7;
+		color: var(--text-primary);
+	}
+
+	/* Markdown content styles */
+	.item-content :global(h1) {
+		font-size: 1.6em;
+		font-weight: 700;
+		margin: 1.5em 0 0.5em;
+		line-height: 1.3;
+	}
+
+	.item-content :global(h2) {
+		font-size: 1.3em;
+		font-weight: 600;
+		margin: 1.4em 0 0.4em;
+		line-height: 1.3;
+	}
+
+	.item-content :global(h3) {
+		font-size: 1.1em;
+		font-weight: 600;
+		margin: 1.2em 0 0.3em;
+	}
+
+	.item-content :global(p) {
+		margin: 0.8em 0;
+	}
+
+	.item-content :global(ul),
+	.item-content :global(ol) {
+		margin: 0.8em 0;
+		padding-left: 1.5em;
+	}
+
+	.item-content :global(li) {
+		margin: 0.3em 0;
+	}
+
+	.item-content :global(pre) {
+		background: var(--bg-tertiary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+		padding: var(--space-4);
+		overflow-x: auto;
+		font-family: var(--font-mono);
+		font-size: 0.88em;
+		margin: 1em 0;
+	}
+
+	.item-content :global(code) {
+		font-family: var(--font-mono);
+		font-size: 0.9em;
+		background: var(--bg-tertiary);
+		padding: 0.15em 0.4em;
+		border-radius: var(--radius-sm);
+	}
+
+	.item-content :global(pre code) {
+		background: none;
+		padding: 0;
+	}
+
+	.item-content :global(blockquote) {
+		border-left: 3px solid var(--accent-blue);
+		padding-left: var(--space-4);
+		margin: 1em 0;
+		color: var(--text-secondary);
+	}
+
+	.item-content :global(table) {
+		width: 100%;
+		border-collapse: collapse;
+		margin: 1em 0;
+	}
+
+	.item-content :global(th),
+	.item-content :global(td) {
+		border: 1px solid var(--border);
+		padding: var(--space-2) var(--space-3);
+		text-align: left;
+	}
+
+	.item-content :global(th) {
+		background: var(--bg-secondary);
+		font-weight: 600;
+	}
+
+	.item-content :global(hr) {
+		border: none;
+		border-top: 1px solid var(--border);
+		margin: 1.5em 0;
+	}
+
+	.item-content :global(img) {
+		max-width: 100%;
+		border-radius: var(--radius);
+	}
+
+	.item-content :global(a) {
+		color: var(--accent-blue);
+	}
+
+	/* Collection view */
+	.share-collection {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-5);
+	}
+
+	.collection-header {
+		display: flex;
+		align-items: center;
+		gap: var(--space-3);
+	}
+
+	.collection-icon-large {
+		font-size: 1.6em;
+	}
+
+	.collection-header h1 {
+		font-size: 1.8em;
+		font-weight: 700;
+		letter-spacing: -0.02em;
+	}
+
+	.collection-description {
+		color: var(--text-secondary);
+		font-size: 0.95em;
+	}
+
+	.collection-items {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-1);
+	}
+
+	.collection-item-row {
+		display: flex;
+		align-items: center;
+		gap: var(--space-3);
+		padding: var(--space-3) var(--space-4);
+		background: var(--bg-secondary);
+		border-radius: var(--radius);
+		border: 1px solid var(--border-subtle);
+	}
+
+	.collection-item-title {
+		flex: 1;
+		font-weight: 500;
+		min-width: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.collection-item-ref {
+		font-size: 0.8em;
+		color: var(--text-muted);
+		font-family: var(--font-mono);
+		flex-shrink: 0;
+	}
+
+	.collection-item-status {
+		font-size: 0.78em;
+		font-weight: 500;
+		color: var(--text-secondary);
+		background: var(--bg-tertiary);
+		padding: 2px 10px;
+		border-radius: 999px;
+		flex-shrink: 0;
+		text-transform: capitalize;
+	}
+
+	.collection-empty {
+		color: var(--text-muted);
+		font-size: 0.9em;
+		padding: var(--space-4) 0;
+	}
+
+	/* Footer */
+	.share-footer {
+		text-align: center;
+		padding: var(--space-6) var(--space-5);
+		border-top: 1px solid var(--border-subtle);
+		font-size: 0.8em;
+		color: var(--text-muted);
+	}
+
+	.share-footer a {
+		color: var(--text-secondary);
+		font-weight: 500;
+	}
+
+	.share-footer a:hover {
+		color: var(--accent-blue);
+	}
+
+	@media (max-width: 640px) {
+		.share-container {
+			padding: var(--space-5) var(--space-4);
+		}
+
+		.item-title {
+			font-size: 1.5em;
+		}
+	}
+</style>

--- a/web/src/routes/s/[token]/+page.svelte
+++ b/web/src/routes/s/[token]/+page.svelte
@@ -37,7 +37,9 @@
 			const raw = marked(itemData.content) as string;
 			return typeof window !== 'undefined' ? DOMPurify.sanitize(raw) : raw;
 		} catch {
-			return itemData.content;
+			// Sanitize the fallback too — never pass user content to {@html} raw
+			const fallback = itemData.content;
+			return typeof window !== 'undefined' ? DOMPurify.sanitize(fallback) : fallback;
 		}
 	});
 


### PR DESCRIPTION
## Summary

Implements Phase 4 of PLAN-407 (Multi-User Permissions & Sharing): share links with anonymous access, minimal-chrome rendering, constraints, and view analytics. **This completes PLAN-407 — all 26 tasks across 4 phases are done.**

- **Share link tables + /s/{token} route**: `share_links` and `share_link_views` tables with 192-bit tokens hashed at rest (SHA-256), anonymous resolution exempt from auth middleware, generic 404 for invalid tokens
- **Anonymous/minimal-chrome rendering**: SvelteKit route at `/s/[token]` renders items (title, fields, markdown) or collections (name, item list) with no app chrome — centered, readable layout with "Powered by Pad" footer
- **Share link constraints**: password protection (bcrypt), expiry timestamps, max view limits, require-auth, restrict-to-email — all enforced on the `/s/{token}` resolution path
- **View analytics**: per-view records with fingerprint/user tracking, `GET /share-links/{id}/views` endpoint with total views, unique viewers, and view history
- **Share link UI**: ShareDialog extended with "Share links" section — create/list/revoke links, copy-to-clipboard, newly created link highlighting with "only shown once" notice, view count badges

### Key design decisions
- **D8**: Anonymous users are ALWAYS read-only — `permission: "view"` regardless of link settings
- Tokens: 192-bit entropy via `crypto/rand`, base64url encoding, SHA-256 hash stored
- Password-protected links return `{require_password: true}` on first access; password verified via bcrypt
- Share link creation accepts optional constraints (password, expires_at, max_views, require_auth, restrict_to_email)
- Root layout bypasses auth for `/s/` routes so anonymous viewers are never redirected to login

### Tasks completed (5)
- TASK-421: Create share_links and share_link_views tables + /s/{token} route
- TASK-422: Anonymous/minimal-chrome rendering for share link viewers
- TASK-423: Share link constraints: password protection, expiry, max views, require-auth
- TASK-424: Share link analytics: view count, unique viewers, view history
- TASK-425: Share link UI: create/manage/revoke share links from item and collection views

### PLAN-407 Final Status
All 4 phases complete: 26/26 tasks done, 3 cancelled (by design).

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./...` passes
- [ ] `npm run build` passes
- [ ] `make install` succeeds
- [ ] Create share link: `POST /items/{slug}/share-links` returns token (shown once)
- [ ] Resolve anonymously: `GET /s/{token}` returns item content with `permission: "view"`
- [ ] Invalid token: `GET /s/invalid` returns generic 404
- [ ] Collection share link: `POST /collections/{coll}/share-links` + resolve shows item list
- [ ] Password protection: create with `{"password":"secret"}`, resolve without password gets `require_password` prompt, with correct password gets content
- [ ] Expiry: create with `{"expires_at":"2020-01-01T00:00:00Z"}`, resolve returns 404
- [ ] Max views: create with `{"max_views":1}`, first resolve succeeds, second returns 404
- [ ] View analytics: `GET /share-links/{id}/views` returns view history with counts
- [ ] Share dialog: "Share links" section appears, create/copy/revoke works
- [ ] Anonymous page (`/s/[token]`): renders item with title, fields, markdown — no sidebar/topbar
- [ ] Require-auth link: shows "Sign in to view" for unauthenticated users
- [ ] List/delete share links: `GET /items/{slug}/share-links` + `DELETE /share-links/{id}`
- [ ] CLI commands work unchanged