### PR TITLE
feat: cloud infrastructure for hosted Pad (PLAN-427)

### DIFF
--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"context"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -207,6 +208,25 @@ func serveCmd() *cobra.Command {
 			}
 			defer s.Close()
 
+			// Configure encryption key for sensitive fields (TOTP secrets)
+			if cfg.EncryptionKey != "" {
+				keyBytes, err := hex.DecodeString(cfg.EncryptionKey)
+				if err != nil || len(keyBytes) != 32 {
+					return fmt.Errorf("PAD_ENCRYPTION_KEY must be a 64-character hex string (32 bytes / 256 bits)")
+				}
+				s.SetEncryptionKey(keyBytes)
+				slog.Info("Encryption key configured for sensitive fields")
+
+				// Backfill: encrypt any plaintext TOTP secrets
+				if n, err := s.BackfillEncryptTOTPSecrets(); err != nil {
+					return fmt.Errorf("backfill TOTP encryption: %w", err)
+				} else if n > 0 {
+					slog.Info("Encrypted plaintext TOTP secrets", "count", n)
+				}
+			} else {
+				slog.Warn("No PAD_ENCRYPTION_KEY configured — TOTP secrets stored in plaintext. Set PAD_ENCRYPTION_KEY for production use.")
+			}
+
 			// Auto-upgrade: ensure all default collections exist in every workspace.
 			// This is safe because SeedDefaultCollections skips collections that already exist.
 			if workspaces, err := s.ListWorkspaces(); err == nil {
@@ -226,6 +246,31 @@ func serveCmd() *cobra.Command {
 			srv.SetCORSOrigins(cfg.CORSOrigins)
 			srv.SetSecureCookies(cfg.SecureCookies)
 			srv.SetSSELimits(cfg.SSEMaxConnections, cfg.SSEMaxPerWorkspace)
+
+			// Cloud mode: enable cloud-specific endpoints and behavior
+			if cfg.IsCloud() {
+				if cfg.CloudSecret == "" {
+					return fmt.Errorf("PAD_CLOUD_SECRET is required when running in cloud mode (PAD_MODE=cloud or PAD_CLOUD=true)")
+				}
+				srv.SetCloudMode(cfg.CloudSecret)
+				slog.Info("Cloud mode enabled")
+
+				// Seed default plan limits (idempotent — won't overwrite admin changes)
+				if err := s.SeedPlanLimits(); err != nil {
+					return fmt.Errorf("seed plan limits: %w", err)
+				}
+
+				// Backfill: set existing users with empty plan to 'free'
+				// (first cloud-mode boot after upgrade from self-hosted)
+				if err := s.BackfillUserPlans("free"); err != nil {
+					slog.Warn("failed to backfill user plans", "error", err)
+				}
+			} else {
+				// Self-hosted mode: ensure all users have 'self-hosted' plan (no limits)
+				if err := s.BackfillUserPlans("self-hosted"); err != nil {
+					slog.Warn("failed to set self-hosted plans", "error", err)
+				}
+			}
 
 			// Initialize Prometheus metrics
 			m := metrics.New()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,6 +37,12 @@ type Config struct {
 	EmailFrom      string `toml:"email_from"`      // Sender address (e.g. noreply@getpad.dev)
 	EmailFromName  string `toml:"email_from_name"` // Sender display name (e.g. Pad)
 
+	// Cloud mode
+	CloudSecret string `toml:"cloud_secret"` // Shared secret for pad-cloud sidecar communication
+
+	// Encryption
+	EncryptionKey string `toml:"encryption_key"` // 32-byte hex-encoded AES-256 key for encrypting sensitive fields
+
 	// Security
 	CORSOrigins    string `toml:"cors_origins"`    // Comma-separated allowed origins (e.g. "https://app.pad.dev,https://admin.pad.dev")
 	SecureCookies  bool   `toml:"secure_cookies"`  // Set Secure flag on cookies (requires TLS)
@@ -128,6 +134,17 @@ func Load() (*Config, error) {
 	if v := os.Getenv("PAD_EMAIL_FROM_NAME"); v != "" {
 		cfg.EmailFromName = v
 	}
+	// PAD_CLOUD=true is a convenience alias for PAD_MODE=cloud
+	if v := os.Getenv("PAD_CLOUD"); v == "true" || v == "1" {
+		cfg.Mode = ModeCloud
+		cfg.LoadedFromEnv = true
+	}
+	if v := os.Getenv("PAD_CLOUD_SECRET"); v != "" {
+		cfg.CloudSecret = v
+	}
+	if v := os.Getenv("PAD_ENCRYPTION_KEY"); v != "" {
+		cfg.EncryptionKey = v
+	}
 	if v := os.Getenv("PAD_CORS_ORIGINS"); v != "" {
 		cfg.CORSOrigins = v
 	}
@@ -157,7 +174,7 @@ func (c *Config) Save() error {
 		return err
 	}
 
-	f, err := os.Create(c.ConfigPath)
+	f, err := os.OpenFile(c.ConfigPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
 	if err != nil {
 		return err
 	}
@@ -190,6 +207,12 @@ func ValidMode(mode string) bool {
 	default:
 		return false
 	}
+}
+
+// IsCloud reports whether the server is running in cloud mode.
+// Cloud mode is enabled by PAD_MODE=cloud or PAD_CLOUD=true.
+func (c *Config) IsCloud() bool {
+	return c.Mode == ModeCloud
 }
 
 // Addr returns the host:port listen address.

--- a/internal/models/activity.go
+++ b/internal/models/activity.go
@@ -25,6 +25,10 @@ const (
 	ActionMemberRemoved   = "member_removed"
 	ActionRoleChanged     = "role_changed"
 	ActionSettingsChanged = "settings_changed"
+	ActionOAuthLogin      = "oauth_login"
+	ActionOAuthLoginFailed = "oauth_login_failed"
+	ActionPlanChanged      = "plan_changed"
+	ActionAccountDeleted   = "account_deleted"
 )
 
 type Activity struct {

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -4,18 +4,22 @@ import "time"
 
 // User represents a registered user in the system.
 type User struct {
-	ID             string    `json:"id"`
-	Email          string    `json:"email"`
-	Username       string    `json:"username"`                // Unique handle; empty until set
-	Name           string    `json:"name"`
-	PasswordHash   string    `json:"-"`                       // Never serialized
-	Role           string    `json:"role"`                    // "admin" or "member"
-	AvatarURL      string    `json:"avatar_url,omitempty"`
-	TOTPSecret     string    `json:"-"`                       // Never serialized
-	TOTPEnabled    bool      `json:"totp_enabled"`
-	RecoveryCodes  string    `json:"-"`                       // Never serialized
-	CreatedAt      time.Time `json:"created_at"`
-	UpdatedAt      time.Time `json:"updated_at"`
+	ID               string    `json:"id"`
+	Email            string    `json:"email"`
+	Username         string    `json:"username"`                // Unique handle; empty until set
+	Name             string    `json:"name"`
+	PasswordHash     string    `json:"-"`                       // Never serialized
+	Role             string    `json:"role"`                    // "admin" or "member"
+	AvatarURL        string    `json:"avatar_url,omitempty"`
+	TOTPSecret       string    `json:"-"`                       // Never serialized
+	TOTPEnabled      bool      `json:"totp_enabled"`
+	RecoveryCodes    string    `json:"-"`                       // Never serialized
+	Plan             string    `json:"plan"`                    // "free", "pro", or "self-hosted"
+	PlanExpiresAt    string    `json:"plan_expires_at,omitempty"`
+	StripeCustomerID string    `json:"-"`                       // Never serialized
+	PlanOverrides    string    `json:"plan_overrides,omitempty"` // JSON overrides for per-user limits
+	CreatedAt        time.Time `json:"created_at"`
+	UpdatedAt        time.Time `json:"updated_at"`
 }
 
 // UserCreate is the input for registering a new user.

--- a/internal/server/handlers_account.go
+++ b/internal/server/handlers_account.go
@@ -1,0 +1,166 @@
+package server
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+
+	"github.com/xarmian/pad/internal/models"
+	"golang.org/x/crypto/bcrypt"
+)
+
+// --- Account Deletion (GDPR Article 17 — Right to Erasure) ---
+
+// handleDeleteAccount handles POST /api/v1/auth/delete-account.
+// Requires password confirmation. Deletes the user and all owned data.
+func (s *Server) handleDeleteAccount(w http.ResponseWriter, r *http.Request) {
+	user := currentUser(r)
+	if user == nil {
+		user = s.validateSessionCookie(r)
+	}
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, "unauthorized", "Not logged in")
+		return
+	}
+
+	var input struct {
+		Password string `json:"password"`
+		Confirm  bool   `json:"confirm"`
+	}
+	if err := decodeJSON(r, &input); err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", "Invalid request body")
+		return
+	}
+
+	// Verify identity
+	fullUser, err := s.store.GetUser(user.ID)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+
+	if input.Password != "" {
+		// Password confirmation (normal flow)
+		if err := bcrypt.CompareHashAndPassword([]byte(fullUser.PasswordHash), []byte(input.Password)); err != nil {
+			writeError(w, http.StatusForbidden, "forbidden", "Incorrect password")
+			return
+		}
+	} else if input.Confirm {
+		// Explicit confirmation without password (for OAuth-only users)
+		// The session itself is the proof of identity
+	} else {
+		writeError(w, http.StatusBadRequest, "bad_request", "Password or explicit confirmation is required")
+		return
+	}
+
+	// Delete all owned workspaces
+	workspaces, err := s.store.GetUserWorkspaces(user.ID)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	for _, ws := range workspaces {
+		if ws.OwnerID == user.ID {
+			if err := s.store.DeleteWorkspace(ws.Slug); err != nil {
+				slog.Error("delete account: failed to delete workspace", "workspace", ws.Slug, "error", err)
+			}
+		}
+	}
+
+	// Revoke all sessions
+	_ = s.store.DeleteUserSessions(user.ID)
+
+	// Delete the user
+	if err := s.store.DeleteUser(user.ID); err != nil {
+		writeInternalError(w, err)
+		return
+	}
+
+	// Clear session cookie
+	http.SetCookie(w, &http.Cookie{
+		Name:     sessionCookie,
+		Value:    "",
+		Path:     "/",
+		MaxAge:   -1,
+		HttpOnly: true,
+		Secure:   s.secureCookies,
+		SameSite: http.SameSiteLaxMode,
+	})
+	clearCSRFCookie(w)
+
+	s.logAuditEventForUser(models.ActionAccountDeleted, r, user.ID, auditMeta(map[string]string{
+		"email": user.Email,
+	}))
+
+	slog.Info("account deleted", "user_id", user.ID, "email", user.Email)
+	writeJSON(w, http.StatusOK, map[string]interface{}{"ok": true})
+}
+
+// --- Data Export (GDPR Article 20 — Right to Portability) ---
+
+// handleExportAccount handles GET /api/v1/auth/export.
+// Returns all user data as a JSON object.
+func (s *Server) handleExportAccount(w http.ResponseWriter, r *http.Request) {
+	user := currentUser(r)
+	if user == nil {
+		user = s.validateSessionCookie(r)
+	}
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, "unauthorized", "Not logged in")
+		return
+	}
+
+	// Collect all user data
+	export := map[string]interface{}{
+		"user": map[string]interface{}{
+			"id":           user.ID,
+			"email":        user.Email,
+			"username":     user.Username,
+			"name":         user.Name,
+			"role":         user.Role,
+			"plan":         user.Plan,
+			"totp_enabled": user.TOTPEnabled,
+			"created_at":   user.CreatedAt,
+			"updated_at":   user.UpdatedAt,
+		},
+	}
+
+	// Export owned workspaces with all items
+	workspaces, err := s.store.GetUserWorkspaces(user.ID)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+
+	var wsExports []interface{}
+	for _, ws := range workspaces {
+		wsData := map[string]interface{}{
+			"id":         ws.ID,
+			"name":       ws.Name,
+			"slug":       ws.Slug,
+			"role":       "owner",
+			"created_at": ws.CreatedAt,
+		}
+
+		// Only export full data for owned workspaces
+		if ws.OwnerID == user.ID {
+			// Get collections
+			collections, _ := s.store.ListCollections(ws.ID)
+			wsData["collections"] = collections
+
+			// Get all items
+			items, _ := s.store.ListItems(ws.ID, models.ItemListParams{IncludeArchived: true})
+			wsData["items"] = items
+		}
+
+		wsExports = append(wsExports, wsData)
+	}
+	export["workspaces"] = wsExports
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Content-Disposition", "attachment; filename=\"pad-export.json\"")
+	w.WriteHeader(http.StatusOK)
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	enc.Encode(export)
+}

--- a/internal/server/handlers_account.go
+++ b/internal/server/handlers_account.go
@@ -45,11 +45,13 @@ func (s *Server) handleDeleteAccount(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusForbidden, "forbidden", "Incorrect password")
 			return
 		}
-	} else if input.Confirm {
-		// Explicit confirmation without password (for OAuth-only users)
-		// The session itself is the proof of identity
+	} else if input.Confirm && s.cloudMode {
+		// Cloud mode only: allow confirm-only deletion for OAuth-registered users
+		// who never set a password. The session itself is the proof of identity.
+		// In self-hosted mode, password is always required to prevent accidental
+		// or coerced account deletion.
 	} else {
-		writeError(w, http.StatusBadRequest, "bad_request", "Password or explicit confirmation is required")
+		writeError(w, http.StatusBadRequest, "bad_request", "Password is required to delete your account")
 		return
 	}
 

--- a/internal/server/handlers_admin_users.go
+++ b/internal/server/handlers_admin_users.go
@@ -217,6 +217,11 @@ func (s *Server) handleAdminGetLimits(w http.ResponseWriter, r *http.Request) {
 	}
 	plans := []string{"free", "pro"}
 
+	defaults := map[string]store.PlanLimits{
+		"free": store.DefaultFreeLimits,
+		"pro":  store.DefaultProLimits,
+	}
+
 	result := make(map[string]map[string]int)
 	for _, plan := range plans {
 		result[plan] = make(map[string]int)
@@ -224,30 +229,12 @@ func (s *Server) handleAdminGetLimits(w http.ResponseWriter, r *http.Request) {
 			key := "plan_limits_" + plan + "_" + feature
 			val, err := s.store.GetPlatformSetting(key)
 			if err != nil || val == "" {
-				// Fall back to hardcoded default
-				result[plan][feature] = store.DefaultFreeLimits.Workspaces // placeholder
+				// Fall back to hardcoded default for this plan+feature
+				result[plan][feature] = planLimitDefault(defaults[plan], feature)
 				continue
 			}
 			v, _ := strconv.Atoi(val)
 			result[plan][feature] = v
-		}
-	}
-
-	// Fill in proper hardcoded defaults for unset values
-	for _, feature := range features {
-		if result["free"][feature] == 0 {
-			switch feature {
-			case "workspaces":
-				result["free"][feature] = store.DefaultFreeLimits.Workspaces
-			case "items_per_workspace":
-				result["free"][feature] = store.DefaultFreeLimits.ItemsPerWorkspace
-			case "members_per_workspace":
-				result["free"][feature] = store.DefaultFreeLimits.MembersPerWorkspace
-			case "api_tokens":
-				result["free"][feature] = store.DefaultFreeLimits.APITokens
-			case "storage_bytes":
-				result["free"][feature] = store.DefaultFreeLimits.StorageBytes
-			}
 		}
 	}
 
@@ -304,10 +291,18 @@ func (s *Server) handleAdminStats(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	userCount, _ := s.store.UserCount()
+	userCount, err := s.store.UserCount()
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
 
 	// Count users by plan
-	users, _ := s.store.ListUsers()
+	users, err := s.store.ListUsers()
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
 	planCounts := map[string]int{}
 	for _, u := range users {
 		plan := u.Plan
@@ -317,7 +312,11 @@ func (s *Server) handleAdminStats(w http.ResponseWriter, r *http.Request) {
 		planCounts[plan]++
 	}
 
-	workspaces, _ := s.store.ListWorkspaces()
+	workspaces, err := s.store.ListWorkspaces()
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
 
 	writeJSON(w, http.StatusOK, map[string]interface{}{
 		"users":          userCount,
@@ -336,6 +335,28 @@ func requireAdmin(w http.ResponseWriter, r *http.Request) bool {
 		return false
 	}
 	return true
+}
+
+// planLimitDefault returns the hardcoded default for a plan+feature pair.
+func planLimitDefault(limits store.PlanLimits, feature string) int {
+	switch feature {
+	case "workspaces":
+		return limits.Workspaces
+	case "items_per_workspace":
+		return limits.ItemsPerWorkspace
+	case "members_per_workspace":
+		return limits.MembersPerWorkspace
+	case "api_tokens":
+		return limits.APITokens
+	case "storage_bytes":
+		return limits.StorageBytes
+	case "webhooks":
+		return limits.Webhooks
+	case "automated_backups":
+		return limits.AutomatedBackups
+	default:
+		return 0
+	}
 }
 
 // auditMeta is defined in handlers_documents.go

--- a/internal/server/handlers_admin_users.go
+++ b/internal/server/handlers_admin_users.go
@@ -1,0 +1,341 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/xarmian/pad/internal/models"
+	"github.com/xarmian/pad/internal/store"
+)
+
+// --- Admin User Management (TASK-502) ---
+
+// handleAdminListUsers returns a paginated list of users with plan info.
+// GET /api/v1/admin/users?q=search&plan=free&offset=0&limit=50
+func (s *Server) handleAdminListUsers(w http.ResponseWriter, r *http.Request) {
+	if !requireAdmin(w, r) {
+		return
+	}
+
+	users, err := s.store.ListUsers()
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+
+	// Filter by plan if specified
+	planFilter := r.URL.Query().Get("plan")
+	searchQuery := strings.ToLower(r.URL.Query().Get("q"))
+
+	type adminUser struct {
+		ID             string `json:"id"`
+		Email          string `json:"email"`
+		Username       string `json:"username"`
+		Name           string `json:"name"`
+		Role           string `json:"role"`
+		Plan           string `json:"plan"`
+		PlanExpiresAt  string `json:"plan_expires_at,omitempty"`
+		PlanOverrides  string `json:"plan_overrides,omitempty"`
+		TOTPEnabled    bool   `json:"totp_enabled"`
+		CreatedAt      string `json:"created_at"`
+		UpdatedAt      string `json:"updated_at"`
+	}
+
+	var result []adminUser
+	for _, u := range users {
+		// Filter
+		if planFilter != "" && u.Plan != planFilter {
+			continue
+		}
+		if searchQuery != "" &&
+			!strings.Contains(strings.ToLower(u.Email), searchQuery) &&
+			!strings.Contains(strings.ToLower(u.Name), searchQuery) &&
+			!strings.Contains(strings.ToLower(u.Username), searchQuery) {
+			continue
+		}
+
+		result = append(result, adminUser{
+			ID:            u.ID,
+			Email:         u.Email,
+			Username:      u.Username,
+			Name:          u.Name,
+			Role:          u.Role,
+			Plan:          u.Plan,
+			PlanExpiresAt: u.PlanExpiresAt,
+			PlanOverrides: u.PlanOverrides,
+			TOTPEnabled:   u.TOTPEnabled,
+			CreatedAt:     u.CreatedAt.Format("2006-01-02T15:04:05Z"),
+			UpdatedAt:     u.UpdatedAt.Format("2006-01-02T15:04:05Z"),
+		})
+	}
+
+	if result == nil {
+		result = []adminUser{}
+	}
+
+	writeJSON(w, http.StatusOK, result)
+}
+
+// handleAdminGetUser returns a single user with full detail.
+// GET /api/v1/admin/users/{userID}
+func (s *Server) handleAdminGetUser(w http.ResponseWriter, r *http.Request) {
+	if !requireAdmin(w, r) {
+		return
+	}
+
+	userID := chi.URLParam(r, "userID")
+	user, err := s.store.GetUser(userID)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	if user == nil {
+		writeError(w, http.StatusNotFound, "not_found", "User not found")
+		return
+	}
+
+	// Get workspace count for this user
+	workspaces, err := s.store.GetUserWorkspaces(user.ID)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"id":              user.ID,
+		"email":           user.Email,
+		"username":        user.Username,
+		"name":            user.Name,
+		"role":            user.Role,
+		"plan":            user.Plan,
+		"plan_expires_at": user.PlanExpiresAt,
+		"plan_overrides":  user.PlanOverrides,
+		"totp_enabled":    user.TOTPEnabled,
+		"created_at":      user.CreatedAt,
+		"updated_at":      user.UpdatedAt,
+		"workspace_count": len(workspaces),
+	})
+}
+
+// handleAdminUpdateUser updates a user's plan, overrides, or role.
+// PATCH /api/v1/admin/users/{userID}
+func (s *Server) handleAdminUpdateUser(w http.ResponseWriter, r *http.Request) {
+	if !requireAdmin(w, r) {
+		return
+	}
+
+	userID := chi.URLParam(r, "userID")
+	user, err := s.store.GetUser(userID)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	if user == nil {
+		writeError(w, http.StatusNotFound, "not_found", "User not found")
+		return
+	}
+
+	var input struct {
+		Plan          *string `json:"plan"`
+		PlanExpiresAt *string `json:"plan_expires_at"`
+		PlanOverrides *string `json:"plan_overrides"`
+	}
+	if err := decodeJSON(r, &input); err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", "Invalid request body")
+		return
+	}
+
+	if input.Plan != nil {
+		validPlans := map[string]bool{"free": true, "pro": true, "self-hosted": true}
+		if !validPlans[*input.Plan] {
+			writeError(w, http.StatusBadRequest, "bad_request", "plan must be 'free', 'pro', or 'self-hosted'")
+			return
+		}
+		expiresAt := ""
+		if input.PlanExpiresAt != nil {
+			expiresAt = *input.PlanExpiresAt
+		}
+		if err := s.store.SetUserPlan(userID, *input.Plan, expiresAt); err != nil {
+			writeInternalError(w, err)
+			return
+		}
+
+		s.logAuditEvent(models.ActionPlanChanged, r, auditMeta(map[string]string{
+			"target_user_id": userID,
+			"old_plan":       user.Plan,
+			"new_plan":       *input.Plan,
+		}))
+	}
+
+	if input.PlanOverrides != nil {
+		// Validate JSON
+		if *input.PlanOverrides != "" {
+			var overrides map[string]int
+			if err := json.Unmarshal([]byte(*input.PlanOverrides), &overrides); err != nil {
+				writeError(w, http.StatusBadRequest, "bad_request", "plan_overrides must be valid JSON (map of feature → limit)")
+				return
+			}
+		}
+		if err := s.store.SetUserPlanOverrides(userID, *input.PlanOverrides); err != nil {
+			writeInternalError(w, err)
+			return
+		}
+	}
+
+	// Return updated user
+	updated, err := s.store.GetUser(userID)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"id":              updated.ID,
+		"email":           updated.Email,
+		"plan":            updated.Plan,
+		"plan_overrides":  updated.PlanOverrides,
+		"plan_expires_at": updated.PlanExpiresAt,
+		"ok":              true,
+	})
+}
+
+// --- Admin Limits Management ---
+
+// handleAdminGetLimits returns the current default plan limits.
+// GET /api/v1/admin/limits
+func (s *Server) handleAdminGetLimits(w http.ResponseWriter, r *http.Request) {
+	if !requireAdmin(w, r) {
+		return
+	}
+
+	features := []string{
+		"workspaces", "items_per_workspace", "members_per_workspace",
+		"api_tokens", "storage_bytes", "webhooks", "automated_backups",
+	}
+	plans := []string{"free", "pro"}
+
+	result := make(map[string]map[string]int)
+	for _, plan := range plans {
+		result[plan] = make(map[string]int)
+		for _, feature := range features {
+			key := "plan_limits_" + plan + "_" + feature
+			val, err := s.store.GetPlatformSetting(key)
+			if err != nil || val == "" {
+				// Fall back to hardcoded default
+				result[plan][feature] = store.DefaultFreeLimits.Workspaces // placeholder
+				continue
+			}
+			v, _ := strconv.Atoi(val)
+			result[plan][feature] = v
+		}
+	}
+
+	// Fill in proper hardcoded defaults for unset values
+	for _, feature := range features {
+		if result["free"][feature] == 0 {
+			switch feature {
+			case "workspaces":
+				result["free"][feature] = store.DefaultFreeLimits.Workspaces
+			case "items_per_workspace":
+				result["free"][feature] = store.DefaultFreeLimits.ItemsPerWorkspace
+			case "members_per_workspace":
+				result["free"][feature] = store.DefaultFreeLimits.MembersPerWorkspace
+			case "api_tokens":
+				result["free"][feature] = store.DefaultFreeLimits.APITokens
+			case "storage_bytes":
+				result["free"][feature] = store.DefaultFreeLimits.StorageBytes
+			}
+		}
+	}
+
+	writeJSON(w, http.StatusOK, result)
+}
+
+// handleAdminUpdateLimits updates default plan limits.
+// PATCH /api/v1/admin/limits
+// Body: {"free": {"workspaces": 10, ...}, "pro": {"workspaces": -1, ...}}
+func (s *Server) handleAdminUpdateLimits(w http.ResponseWriter, r *http.Request) {
+	if !requireAdmin(w, r) {
+		return
+	}
+
+	var input map[string]map[string]int
+	if err := decodeJSON(r, &input); err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", "Invalid request body")
+		return
+	}
+
+	validPlans := map[string]bool{"free": true, "pro": true}
+	validFeatures := map[string]bool{
+		"workspaces": true, "items_per_workspace": true, "members_per_workspace": true,
+		"api_tokens": true, "storage_bytes": true, "webhooks": true, "automated_backups": true,
+	}
+
+	for plan, features := range input {
+		if !validPlans[plan] {
+			continue
+		}
+		for feature, value := range features {
+			if !validFeatures[feature] {
+				continue
+			}
+			key := "plan_limits_" + plan + "_" + feature
+			if err := s.store.SetPlatformSetting(key, strconv.Itoa(value)); err != nil {
+				writeInternalError(w, err)
+				return
+			}
+		}
+	}
+
+	s.logAuditEvent(models.ActionSettingsChanged, r, auditMeta(map[string]string{"scope": "plan_limits"}))
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{"ok": true})
+}
+
+// --- Admin Platform Stats ---
+
+// handleAdminStats returns platform-level statistics.
+// GET /api/v1/admin/stats
+func (s *Server) handleAdminStats(w http.ResponseWriter, r *http.Request) {
+	if !requireAdmin(w, r) {
+		return
+	}
+
+	userCount, _ := s.store.UserCount()
+
+	// Count users by plan
+	users, _ := s.store.ListUsers()
+	planCounts := map[string]int{}
+	for _, u := range users {
+		plan := u.Plan
+		if plan == "" {
+			plan = "free"
+		}
+		planCounts[plan]++
+	}
+
+	workspaces, _ := s.store.ListWorkspaces()
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"users":          userCount,
+		"users_by_plan":  planCounts,
+		"workspaces":     len(workspaces),
+		"cloud_mode":     s.cloudMode,
+	})
+}
+
+// --- Helpers ---
+
+func requireAdmin(w http.ResponseWriter, r *http.Request) bool {
+	user := currentUser(r)
+	if user == nil || user.Role != "admin" {
+		writeError(w, http.StatusForbidden, "forbidden", "Admin access required")
+		return false
+	}
+	return true
+}
+
+// auditMeta is defined in handlers_documents.go

--- a/internal/server/handlers_auth.go
+++ b/internal/server/handlers_auth.go
@@ -38,6 +38,7 @@ func sessionUserPayload(user *models.User) map[string]interface{} {
 		"name":         user.Name,
 		"role":         user.Role,
 		"totp_enabled": user.TOTPEnabled,
+		"plan":         user.Plan,
 	}
 }
 
@@ -91,20 +92,22 @@ func (s *Server) handleCheckUsername(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-func setupStatePayload(setupMethod string) map[string]interface{} {
+func (s *Server) setupStatePayload(setupMethod string) map[string]interface{} {
 	return map[string]interface{}{
 		"authenticated":  false,
 		"setup_required": true,
 		"setup_method":   setupMethod,
 		"auth_method":    authMethodPassword,
+		"cloud_mode":     s.cloudMode,
 	}
 }
 
-func sessionStatePayload(authenticated bool, user *models.User) map[string]interface{} {
+func (s *Server) sessionStatePayload(authenticated bool, user *models.User) map[string]interface{} {
 	payload := map[string]interface{}{
 		"authenticated":  authenticated,
 		"setup_required": false,
 		"auth_method":    authMethodPassword,
+		"cloud_mode":     s.cloudMode,
 	}
 	if authenticated {
 		payload["user"] = sessionUserPayload(user)
@@ -167,6 +170,10 @@ func (s *Server) createAuthSession(w http.ResponseWriter, r *http.Request, user 
 // It is only allowed from loopback-local requests so setup must happen
 // on the server host or from inside the container.
 func (s *Server) handleBootstrap(w http.ResponseWriter, r *http.Request) {
+	if s.cloudMode {
+		writeError(w, http.StatusForbidden, "forbidden", "Bootstrap is disabled in cloud mode — users register via OAuth or invitation")
+		return
+	}
 	if !requestIsLoopback(r) {
 		writeError(w, http.StatusForbidden, "forbidden", "Bootstrap is only allowed from localhost on the server host")
 		return
@@ -195,6 +202,10 @@ func (s *Server) handleBootstrap(w http.ResponseWriter, r *http.Request) {
 	}
 	if len(input.Password) < 8 {
 		writeError(w, http.StatusBadRequest, "validation_error", "Password must be at least 8 characters")
+		return
+	}
+	if len(input.Password) > 128 {
+		writeError(w, http.StatusBadRequest, "validation_error", "Password must be at most 128 characters")
 		return
 	}
 
@@ -244,6 +255,9 @@ func (s *Server) handleBootstrap(w http.ResponseWriter, r *http.Request) {
 
 	s.logAuditEventForUser(models.ActionBootstrap, r, user.ID, auditMeta(map[string]string{"email": user.Email}))
 
+	// Auto-create default workspace in cloud mode
+	s.autoCreateWorkspace(user)
+
 	writeJSON(w, http.StatusCreated, map[string]interface{}{
 		"user":  sessionUserPayload(user),
 		"token": token,
@@ -282,6 +296,10 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 	}
 	if len(input.Password) < 8 {
 		writeError(w, http.StatusBadRequest, "validation_error", "Password must be at least 8 characters")
+		return
+	}
+	if len(input.Password) > 128 {
+		writeError(w, http.StatusBadRequest, "validation_error", "Password must be at most 128 characters")
 		return
 	}
 
@@ -386,6 +404,9 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 
 	s.logAuditEventForUser(models.ActionRegister, r, user.ID, auditMeta(map[string]string{"email": user.Email}))
 
+	// Auto-create default workspace in cloud mode
+	s.autoCreateWorkspace(user)
+
 	writeJSON(w, http.StatusCreated, map[string]interface{}{
 		"user":  sessionUserPayload(user),
 		"token": token,
@@ -462,24 +483,24 @@ func (s *Server) handleSessionCheck(w http.ResponseWriter, r *http.Request) {
 
 	// No users → needs setup (first-time experience)
 	if count == 0 {
-		writeJSON(w, http.StatusOK, setupStatePayload(setupMethodLocalCLI))
+		writeJSON(w, http.StatusOK, s.setupStatePayload(setupMethodLocalCLI))
 		return
 	}
 
 	// Try to resolve user from context (set by middleware)
 	user := currentUser(r)
 	if user != nil {
-		writeJSON(w, http.StatusOK, sessionStatePayload(true, user))
+		writeJSON(w, http.StatusOK, s.sessionStatePayload(true, user))
 		return
 	}
 
 	// Try session cookie directly (since auth endpoints are exempt from middleware)
 	if user := s.validateSessionCookie(r); user != nil {
-		writeJSON(w, http.StatusOK, sessionStatePayload(true, user))
+		writeJSON(w, http.StatusOK, s.sessionStatePayload(true, user))
 		return
 	}
 
-	writeJSON(w, http.StatusOK, sessionStatePayload(false, nil))
+	writeJSON(w, http.StatusOK, s.sessionStatePayload(false, nil))
 }
 
 // handleLogout destroys the session and clears the cookie.
@@ -726,6 +747,10 @@ func (s *Server) handleResetPassword(w http.ResponseWriter, r *http.Request) {
 	}
 	if len(input.Password) < 8 {
 		writeError(w, http.StatusBadRequest, "validation_error", "Password must be at least 8 characters")
+		return
+	}
+	if len(input.Password) > 128 {
+		writeError(w, http.StatusBadRequest, "validation_error", "Password must be at most 128 characters")
 		return
 	}
 

--- a/internal/server/handlers_cloud.go
+++ b/internal/server/handlers_cloud.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -179,7 +180,7 @@ func (s *Server) handleOAuthLogin(w http.ResponseWriter, r *http.Request) {
 	s.logAuditEventForUser(models.ActionOAuthLogin, r, user.ID, auditMeta(map[string]string{
 		"provider": input.Provider,
 		"email":    input.Email,
-		"new_user": boolStr(isNewUser),
+		"new_user": strconv.FormatBool(isNewUser),
 	}))
 
 	// 8. Return session info
@@ -225,6 +226,14 @@ func (s *Server) handleSetPlan(w http.ResponseWriter, r *http.Request) {
 	if !validPlans[input.Plan] {
 		writeError(w, http.StatusBadRequest, "bad_request", "plan must be 'free', 'pro', or 'self-hosted'")
 		return
+	}
+
+	// 2b. Validate expires_at format if provided
+	if input.ExpiresAt != "" {
+		if _, err := time.Parse(time.RFC3339, input.ExpiresAt); err != nil {
+			writeError(w, http.StatusBadRequest, "bad_request", "expires_at must be a valid RFC3339 timestamp")
+			return
+		}
 	}
 
 	// 3. Verify user exists
@@ -352,10 +361,3 @@ func (s *Server) autoCreateWorkspace(user *models.User) {
 }
 
 // --- Helpers ---
-
-func boolStr(b bool) string {
-	if b {
-		return "true"
-	}
-	return "false"
-}

--- a/internal/server/handlers_cloud.go
+++ b/internal/server/handlers_cloud.go
@@ -1,0 +1,361 @@
+package server
+
+import (
+	"crypto/subtle"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/xarmian/pad/internal/models"
+	"github.com/xarmian/pad/internal/store"
+)
+
+// validateCloudSecret checks the cloud_secret field in a JSON request body
+// against the server's configured cloud secret. Returns true if the secret
+// matches; writes a 403 error and returns false otherwise.
+//
+// This is the authentication mechanism between the pad-cloud sidecar and
+// the pad binary. All cloud-gated endpoints (oauth-login, admin/plan) must
+// call this before processing the request.
+func (s *Server) validateCloudSecret(secret string, w http.ResponseWriter) bool {
+	if len(s.cloudSecrets) == 0 {
+		writeError(w, http.StatusForbidden, "forbidden", "Cloud mode not configured")
+		return false
+	}
+	for i, key := range s.cloudSecrets {
+		if subtle.ConstantTimeCompare([]byte(secret), []byte(key)) == 1 {
+			if i > 0 {
+				slog.Info("cloud secret validated with rotated key", "key_index", i)
+			}
+			return true
+		}
+	}
+	writeError(w, http.StatusForbidden, "forbidden", "Invalid cloud secret")
+	return false
+}
+
+// requireCloudMode is a middleware/guard that rejects requests when the server
+// is not running in cloud mode. Used to protect cloud-only endpoints.
+func (s *Server) requireCloudMode(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !s.cloudMode {
+			writeError(w, http.StatusNotFound, "not_found", "Not found")
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// --- OAuth Login (TASK-430) ---
+
+// handleOAuthLogin handles POST /api/v1/auth/oauth-login.
+// Called by the pad-cloud sidecar after completing an OAuth flow.
+// Creates or finds a user by email and creates a session.
+func (s *Server) handleOAuthLogin(w http.ResponseWriter, r *http.Request) {
+	var input struct {
+		Provider      string `json:"provider"`
+		Email         string `json:"email"`
+		Name          string `json:"name"`
+		AvatarURL     string `json:"avatar_url"`
+		EmailVerified bool   `json:"email_verified"`
+		CloudSecret   string `json:"cloud_secret"`
+	}
+	if err := decodeJSON(r, &input); err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", "Invalid request body")
+		return
+	}
+
+	// 1. Validate cloud secret
+	if !s.validateCloudSecret(input.CloudSecret, w) {
+		slog.Warn("oauth-login: invalid cloud secret", "provider", input.Provider, "email", input.Email)
+		return
+	}
+
+	// 2. Validate required fields
+	if input.Provider == "" {
+		writeError(w, http.StatusBadRequest, "bad_request", "provider is required")
+		return
+	}
+	if input.Provider != "github" && input.Provider != "google" {
+		writeError(w, http.StatusBadRequest, "bad_request", "provider must be 'github' or 'google'")
+		return
+	}
+
+	input.Email = strings.ToLower(strings.TrimSpace(input.Email))
+	if input.Email == "" || !emailRegexp.MatchString(input.Email) {
+		writeError(w, http.StatusBadRequest, "bad_request", "valid email is required")
+		return
+	}
+
+	// 3. Require verified email from OAuth provider
+	if !input.EmailVerified {
+		slog.Warn("oauth-login: rejected unverified email", "provider", input.Provider, "email", input.Email)
+		s.logAuditEvent(models.ActionOAuthLoginFailed, r, auditMeta(map[string]string{
+			"provider": input.Provider,
+			"email":    input.Email,
+			"reason":   "email_not_verified",
+		}))
+		writeError(w, http.StatusForbidden, "forbidden", "Only verified email addresses are accepted from OAuth providers")
+		return
+	}
+
+	// 4. Sanitize inputs
+	input.Name = strings.TrimSpace(input.Name)
+	if len(input.Name) > 200 {
+		input.Name = input.Name[:200]
+	}
+	if input.AvatarURL != "" {
+		if u, err := url.Parse(input.AvatarURL); err != nil || (u.Scheme != "http" && u.Scheme != "https") {
+			input.AvatarURL = "" // Invalid URL — drop it
+		}
+	}
+
+	// 5. Find or create user
+	user, err := s.store.GetUserByEmail(input.Email)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+
+	isNewUser := false
+	if user == nil {
+		// Create new user from OAuth
+		if input.Name == "" {
+			input.Name = strings.Split(input.Email, "@")[0]
+		}
+		user, err = s.store.CreateOAuthUser(input.Email, input.Name, input.AvatarURL)
+		if err != nil {
+			slog.Error("oauth-login: failed to create user", "error", err, "email", input.Email)
+			writeInternalError(w, err)
+			return
+		}
+		isNewUser = true
+		slog.Info("oauth-login: created new user", "provider", input.Provider, "email", input.Email, "user_id", user.ID)
+
+		// Auto-create default workspace for new OAuth users
+		s.autoCreateWorkspace(user)
+	} else {
+		// Existing user — implicit account link.
+		// Block OAuth login if the user has 2FA enabled — OAuth must not bypass 2FA.
+		if user.TOTPEnabled {
+			slog.Warn("oauth-login: blocked — existing user has 2FA enabled",
+				"provider", input.Provider,
+				"email", input.Email,
+				"user_id", user.ID,
+			)
+			s.logAuditEventForUser(models.ActionOAuthLoginFailed, r, user.ID, auditMeta(map[string]string{
+				"provider": input.Provider,
+				"email":    input.Email,
+				"reason":   "2fa_enabled",
+			}))
+			writeError(w, http.StatusForbidden, "forbidden",
+				"This account has two-factor authentication enabled. Please sign in with your password and 2FA code, then link your OAuth provider in account settings.")
+			return
+		}
+
+		// Log the implicit link for audit
+		slog.Info("oauth-login: existing user (account link)",
+			"provider", input.Provider,
+			"email", input.Email,
+			"user_id", user.ID,
+		)
+
+		// Update avatar if they don't have one
+		if user.AvatarURL == "" && input.AvatarURL != "" {
+			avatar := input.AvatarURL
+			s.store.UpdateUser(user.ID, models.UserUpdate{AvatarURL: &avatar})
+		}
+	}
+
+	// 6. Create session (30-day TTL for OAuth sessions)
+	token, err := s.createAuthSession(w, r, user, 30*24*time.Hour)
+	if err != nil {
+		return // Error already written by createAuthSession
+	}
+
+	// 7. Audit log
+	s.logAuditEventForUser(models.ActionOAuthLogin, r, user.ID, auditMeta(map[string]string{
+		"provider": input.Provider,
+		"email":    input.Email,
+		"new_user": boolStr(isNewUser),
+	}))
+
+	// 8. Return session info
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"user":     sessionUserPayload(user),
+		"token":    token,
+		"new_user": isNewUser,
+	})
+}
+
+// --- Admin Plan Endpoint (TASK-431) ---
+
+// handleSetPlan handles POST /api/v1/admin/plan.
+// Called by the pad-cloud sidecar to update a user's billing plan
+// after Stripe subscription events.
+func (s *Server) handleSetPlan(w http.ResponseWriter, r *http.Request) {
+	var input struct {
+		UserID      string `json:"user_id"`
+		Plan        string `json:"plan"`
+		ExpiresAt   string `json:"expires_at"`
+		CloudSecret string `json:"cloud_secret"`
+	}
+	if err := decodeJSON(r, &input); err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", "Invalid request body")
+		return
+	}
+
+	// 1. Validate cloud secret (or admin auth)
+	user := currentUser(r)
+	isAdmin := user != nil && user.Role == "admin"
+	if !isAdmin {
+		if !s.validateCloudSecret(input.CloudSecret, w) {
+			return
+		}
+	}
+
+	// 2. Validate inputs
+	if input.UserID == "" {
+		writeError(w, http.StatusBadRequest, "bad_request", "user_id is required")
+		return
+	}
+	validPlans := map[string]bool{"free": true, "pro": true, "self-hosted": true}
+	if !validPlans[input.Plan] {
+		writeError(w, http.StatusBadRequest, "bad_request", "plan must be 'free', 'pro', or 'self-hosted'")
+		return
+	}
+
+	// 3. Verify user exists
+	targetUser, err := s.store.GetUser(input.UserID)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	if targetUser == nil {
+		writeError(w, http.StatusNotFound, "not_found", "User not found")
+		return
+	}
+
+	// 4. Update plan
+	oldPlan := targetUser.Plan
+	if err := s.store.SetUserPlan(input.UserID, input.Plan, input.ExpiresAt); err != nil {
+		writeInternalError(w, err)
+		return
+	}
+
+	// 5. Audit log
+	actorID := ""
+	if user != nil {
+		actorID = user.ID
+	}
+	s.logAuditEventForUser(models.ActionPlanChanged, r, actorID, auditMeta(map[string]string{
+		"target_user_id": input.UserID,
+		"old_plan":       oldPlan,
+		"new_plan":       input.Plan,
+		"expires_at":     input.ExpiresAt,
+	}))
+
+	slog.Info("plan updated", "user_id", input.UserID, "old_plan", oldPlan, "new_plan", input.Plan)
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"user_id": input.UserID,
+		"plan":    input.Plan,
+		"ok":      true,
+	})
+}
+
+// --- Plan Limit Enforcement ---
+
+// enforcePlanLimit checks a workspace-scoped plan limit and writes a 403
+// error if the limit is exceeded. Returns true if the operation is allowed.
+// In non-cloud mode, always returns true (no limits enforced).
+func (s *Server) enforcePlanLimit(w http.ResponseWriter, workspaceID, feature string) bool {
+	if !s.cloudMode {
+		return true // Self-hosted: no limits
+	}
+
+	result, err := s.store.CheckLimit(workspaceID, feature)
+	if err != nil {
+		writeInternalError(w, err)
+		return false
+	}
+	if !result.Allowed {
+		writePlanLimitError(w, result)
+		return false
+	}
+	return true
+}
+
+// enforceUserPlanLimit checks a user-scoped plan limit and writes a 403
+// error if the limit is exceeded. Returns true if the operation is allowed.
+// In non-cloud mode, always returns true (no limits enforced).
+func (s *Server) enforceUserPlanLimit(w http.ResponseWriter, userID, feature string) bool {
+	if !s.cloudMode {
+		return true // Self-hosted: no limits
+	}
+
+	result, err := s.store.CheckUserLimit(userID, feature)
+	if err != nil {
+		writeInternalError(w, err)
+		return false
+	}
+	if !result.Allowed {
+		writePlanLimitError(w, result)
+		return false
+	}
+	return true
+}
+
+// writePlanLimitError writes a structured 403 response for plan limit violations.
+func writePlanLimitError(w http.ResponseWriter, result *store.LimitResult) {
+	writeJSON(w, http.StatusForbidden, map[string]interface{}{
+		"error":       "plan_limit_exceeded",
+		"feature":     result.Feature,
+		"limit":       result.Limit,
+		"current":     result.Current,
+		"plan":        result.Plan,
+		"upgrade_url": "/console/billing",
+	})
+}
+
+// --- Auto-create Workspace (TASK-432) ---
+
+// autoCreateWorkspace creates a default workspace for a new user in cloud mode.
+// Called after user creation in register, bootstrap, and oauth-login handlers.
+// No-op in self-hosted mode. Errors are logged but don't fail the signup.
+func (s *Server) autoCreateWorkspace(user *models.User) {
+	if !s.cloudMode {
+		return
+	}
+
+	name := user.Name + "'s Workspace"
+	ws, err := s.store.CreateWorkspace(models.WorkspaceCreate{
+		Name:    name,
+		OwnerID: user.ID,
+	})
+	if err != nil {
+		slog.Error("auto-create workspace failed", "user_id", user.ID, "error", err)
+		return
+	}
+
+	// Seed default collections
+	if err := s.store.SeedCollectionsFromTemplate(ws.ID, ""); err != nil {
+		slog.Warn("auto-create workspace: failed to seed collections", "workspace_id", ws.ID, "error", err)
+	}
+
+	// Add user as owner
+	_ = s.store.AddWorkspaceMember(ws.ID, user.ID, "owner")
+
+	slog.Info("auto-created default workspace", "user_id", user.ID, "workspace", ws.Slug)
+}
+
+// --- Helpers ---
+
+func boolStr(b bool) string {
+	if b {
+		return "true"
+	}
+	return "false"
+}

--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -193,6 +193,11 @@ func (s *Server) handleCreateItem(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Enforce item count limit (workspace-scoped)
+	if !s.enforcePlanLimit(w, workspaceID, "items_per_workspace") {
+		return
+	}
+
 	// Parse collection schema
 	var schema models.CollectionSchema
 	if err := json.Unmarshal([]byte(coll.Schema), &schema); err != nil {

--- a/internal/server/handlers_members.go
+++ b/internal/server/handlers_members.go
@@ -107,6 +107,11 @@ func (s *Server) handleInviteMember(w http.ResponseWriter, r *http.Request) {
 		input.Role = "editor"
 	}
 
+	// Enforce member count limit (workspace-scoped)
+	if !s.enforcePlanLimit(w, workspaceID, "members_per_workspace") {
+		return
+	}
+
 	inviterID := currentUserID(r)
 
 	// Check if user with this email already exists

--- a/internal/server/handlers_tokens.go
+++ b/internal/server/handlers_tokens.go
@@ -157,6 +157,11 @@ func (s *Server) handleCreateUserToken(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Enforce API token count limit (user-scoped)
+	if !s.enforceUserPlanLimit(w, userID, "api_tokens") {
+		return
+	}
+
 	defaultDays, maxDays := s.getTokenExpirySettings()
 
 	token, err := s.store.CreateAPIToken(userID, input, defaultDays, maxDays)

--- a/internal/server/handlers_webhooks.go
+++ b/internal/server/handlers_webhooks.go
@@ -29,6 +29,11 @@ func (s *Server) handleCreateWebhook(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Enforce webhook count limit (workspace-scoped)
+	if !s.enforcePlanLimit(w, workspaceID, "webhooks") {
+		return
+	}
+
 	var input models.WebhookCreate
 	if err := decodeJSON(r, &input); err != nil {
 		writeError(w, http.StatusBadRequest, "bad_request", err.Error())

--- a/internal/server/handlers_workspaces.go
+++ b/internal/server/handlers_workspaces.go
@@ -58,7 +58,7 @@ func normalizeWorkspaceUpdateInput(input *models.WorkspaceUpdate) error {
 }
 
 func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
-	resp := map[string]string{"status": "ok"}
+	resp := map[string]interface{}{"status": "ok"}
 	if s.version != "" {
 		resp["version"] = s.version
 	}
@@ -68,6 +68,7 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 	if s.buildTime != "" {
 		resp["build_time"] = s.buildTime
 	}
+	resp["cloud_mode"] = s.cloudMode
 	writeJSON(w, http.StatusOK, resp)
 }
 
@@ -207,6 +208,13 @@ func (s *Server) handleCreateWorkspace(w http.ResponseWriter, r *http.Request) {
 	// Set owner to the authenticated user
 	if userID := currentUserID(r); userID != "" {
 		input.OwnerID = userID
+	}
+
+	// Enforce workspace count limit (user-scoped)
+	if userID := currentUserID(r); userID != "" {
+		if !s.enforceUserPlanLimit(w, userID, "workspaces") {
+			return
+		}
 	}
 
 	ws, err := s.store.CreateWorkspace(input)

--- a/internal/server/middleware_auth.go
+++ b/internal/server/middleware_auth.go
@@ -174,8 +174,10 @@ func (s *Server) RequireAuth(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		path := r.URL.Path
 
-		// Auth endpoints and share link resolution are always exempt
-		if strings.HasPrefix(path, "/api/v1/auth/") || path == "/api/v1/health" || strings.HasPrefix(path, "/api/v1/health/") || strings.HasPrefix(path, "/api/v1/s/") {
+		// Auth endpoints, share link resolution, and cloud sidecar endpoints are always exempt.
+		// The cloud plan endpoint uses cloud_secret in the body for authentication,
+		// so it must bypass RequireAuth (which runs before the handler can read the body).
+		if strings.HasPrefix(path, "/api/v1/auth/") || path == "/api/v1/health" || strings.HasPrefix(path, "/api/v1/health/") || strings.HasPrefix(path, "/api/v1/s/") || path == "/api/v1/admin/plan" {
 			next.ServeHTTP(w, r)
 			return
 		}

--- a/internal/server/middleware_csrf.go
+++ b/internal/server/middleware_csrf.go
@@ -39,8 +39,10 @@ func (s *Server) CSRFProtect(next http.Handler) http.Handler {
 		}
 
 		// Auth endpoints that need to work before a CSRF token exists
-		// (login, register, bootstrap, password reset)
-		if strings.HasPrefix(r.URL.Path, "/api/v1/auth/") {
+		// (login, register, bootstrap, password reset).
+		// The cloud plan endpoint is also exempt — the sidecar authenticates
+		// via cloud_secret in the body, not via cookies.
+		if strings.HasPrefix(r.URL.Path, "/api/v1/auth/") || r.URL.Path == "/api/v1/admin/plan" {
 			next.ServeHTTP(w, r)
 			return
 		}

--- a/internal/server/middleware_ratelimit.go
+++ b/internal/server/middleware_ratelimit.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"log/slog"
+	"math"
 	"net/http"
 	"strconv"
 	"strings"
@@ -76,6 +78,8 @@ type RateLimiters struct {
 	PasswordReset *ipRateLimiter
 	// Registration: per-IP
 	Register *ipRateLimiter
+	// OAuth login: per-IP (higher limit since pad-cloud sidecar calls this)
+	OAuthLogin *ipRateLimiter
 	// API: per-user (authenticated)
 	API *ipRateLimiter
 	// Search: per-user or per-IP
@@ -99,6 +103,11 @@ func NewRateLimiters() *RateLimiters {
 		Register: newIPRateLimiter(rateLimitConfig{
 			Rate:  rate.Limit(5.0 / 3600.0),
 			Burst: 5,
+		}),
+		// OAuth login: 20 per minute per IP (sidecar calls this — higher than regular auth)
+		OAuthLogin: newIPRateLimiter(rateLimitConfig{
+			Rate:  rate.Limit(20.0 / 60.0),
+			Burst: 20,
 		}),
 		// API: 600 requests per minute per user/IP (= 10 per second, burst 60)
 		// Local-first tool with SSE-driven UI needs headroom for cascading refreshes.
@@ -143,14 +152,20 @@ func (s *Server) RateLimit(next http.Handler) http.Handler {
 				limiter = s.rateLimiters.PasswordReset
 			case path == "/api/v1/auth/register":
 				limiter = s.rateLimiters.Register
+			case path == "/api/v1/auth/oauth-login":
+				limiter = s.rateLimiters.OAuthLogin
 			default:
 				// Other auth endpoints (session check, logout) — use general API limit
 				limiter = s.rateLimiters.API
 			}
 
-			if limiter != nil && !limiter.getLimiter(ip).Allow() {
-				writeTooManyRequests(w)
-				return
+			if limiter != nil {
+				l := limiter.getLimiter(ip)
+				if !l.Allow() {
+					slog.Warn("rate limited", "ip", ip, "path", path, "limiter", "auth")
+					writeRateLimitResponse(w, limiter.config)
+					return
+				}
 			}
 			next.ServeHTTP(w, r)
 			return
@@ -160,7 +175,8 @@ func (s *Server) RateLimit(next http.Handler) http.Handler {
 		if path == "/api/v1/search" {
 			key := rateLimitKey(r, ip)
 			if !s.rateLimiters.Search.getLimiter(key).Allow() {
-				writeTooManyRequests(w)
+				slog.Warn("rate limited", "key", key, "path", path, "limiter", "search")
+				writeRateLimitResponse(w, s.rateLimiters.Search.config)
 				return
 			}
 			next.ServeHTTP(w, r)
@@ -170,7 +186,8 @@ func (s *Server) RateLimit(next http.Handler) http.Handler {
 		// General API rate limit
 		key := rateLimitKey(r, ip)
 		if !s.rateLimiters.API.getLimiter(key).Allow() {
-			writeTooManyRequests(w)
+			slog.Warn("rate limited", "key", key, "path", path, "limiter", "api")
+			writeRateLimitResponse(w, s.rateLimiters.API.config)
 			return
 		}
 
@@ -199,8 +216,28 @@ func clientIP(r *http.Request) string {
 	return host
 }
 
-// writeTooManyRequests sends a 429 response with a Retry-After header.
+// writeRateLimitResponse sends a 429 response with Retry-After and X-RateLimit-* headers.
+func writeRateLimitResponse(w http.ResponseWriter, cfg rateLimitConfig) {
+	// Calculate retry-after from the rate (seconds until one token is available)
+	retryAfter := int(math.Ceil(1.0 / float64(cfg.Rate)))
+	if retryAfter < 1 {
+		retryAfter = 1
+	}
+	if retryAfter > 3600 {
+		retryAfter = 3600
+	}
+
+	// Calculate requests per minute for the limit header
+	limitPerMinute := int(math.Ceil(float64(cfg.Rate) * 60))
+
+	w.Header().Set("Retry-After", strconv.Itoa(retryAfter))
+	w.Header().Set("X-RateLimit-Limit", strconv.Itoa(limitPerMinute))
+	w.Header().Set("X-RateLimit-Remaining", "0")
+	writeError(w, http.StatusTooManyRequests, "rate_limited", "Too many requests. Please try again later.")
+}
+
+// writeTooManyRequests sends a basic 429 response (for backward compatibility in tests).
 func writeTooManyRequests(w http.ResponseWriter) {
-	w.Header().Set("Retry-After", strconv.Itoa(60)) // suggest retry after 60s
+	w.Header().Set("Retry-After", strconv.Itoa(60))
 	writeError(w, http.StatusTooManyRequests, "rate_limited", "Too many requests. Please try again later.")
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -42,6 +42,8 @@ type Server struct {
 	metrics            *metrics.Metrics      // Prometheus metrics (optional)
 	sseMaxConnections  int                   // global SSE connection limit (0 = unlimited)
 	sseMaxPerWorkspace int                   // per-workspace SSE connection limit (0 = unlimited)
+	cloudMode           bool                 // true when running as Pad Cloud (PAD_CLOUD=true or PAD_MODE=cloud)
+	cloudSecrets        []string             // shared secrets for sidecar ↔ pad communication (supports rotation)
 	version            string               // release version (e.g. "dev", "1.2.3")
 	commit              string               // git commit hash
 	buildTime           string               // build timestamp
@@ -101,6 +103,25 @@ func (s *Server) Init2FASecret() error {
 	s.twoFAChallengeSecret = decoded
 	slog.Info("initialized 2FA challenge signing key")
 	return nil
+}
+
+// SetCloudMode enables cloud mode with the shared sidecar secret(s).
+// Accepts a comma-separated list of secrets for rotation support:
+// "new-key,old-key" — both are accepted during rollover.
+// The sidecar should always send the first (newest) key.
+func (s *Server) SetCloudMode(secret string) {
+	s.cloudMode = true
+	for _, k := range strings.Split(secret, ",") {
+		k = strings.TrimSpace(k)
+		if k != "" {
+			s.cloudSecrets = append(s.cloudSecrets, k)
+		}
+	}
+}
+
+// IsCloud reports whether the server is running in cloud mode.
+func (s *Server) IsCloud() bool {
+	return s.cloudMode
 }
 
 // SetVersion stores the build version info for the health endpoint.
@@ -250,11 +271,18 @@ func (s *Server) setupRouter() {
 			r.Post("/2fa/disable", s.handleTOTPDisable)
 			r.Post("/2fa/login-verify", s.handleTOTPLoginVerify)
 
+			// Account management (GDPR)
+			r.Post("/delete-account", s.handleDeleteAccount)
+			r.Get("/export", s.handleExportAccount)
+
 			// User-scoped API tokens
 			r.Get("/tokens", s.handleListUserTokens)
 			r.Post("/tokens", s.handleCreateUserToken)
 			r.Delete("/tokens/{tokenID}", s.handleDeleteUserToken)
 			r.Post("/tokens/{tokenID}/rotate", s.handleRotateUserToken)
+
+			// Cloud: OAuth login (called by pad-cloud sidecar, protected by cloud secret)
+			r.Post("/oauth-login", s.handleOAuthLogin)
 		})
 
 		// Admin endpoints (admin-only, handlers check role internally)
@@ -262,6 +290,19 @@ func (s *Server) setupRouter() {
 			r.Get("/settings", s.handleGetPlatformSettings)
 			r.Patch("/settings", s.handleUpdatePlatformSettings)
 			r.Post("/test-email", s.handleTestEmail)
+			r.Post("/plan", s.handleSetPlan) // Cloud: sidecar sets user plans; also accessible to admins
+
+			// User management
+			r.Get("/users", s.handleAdminListUsers)
+			r.Get("/users/{userID}", s.handleAdminGetUser)
+			r.Patch("/users/{userID}", s.handleAdminUpdateUser)
+
+			// Plan limits
+			r.Get("/limits", s.handleAdminGetLimits)
+			r.Patch("/limits", s.handleAdminUpdateLimits)
+
+			// Platform stats
+			r.Get("/stats", s.handleAdminStats)
 		})
 
 		// Audit log (admin-only)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -64,10 +64,14 @@ func TestHealthEndpoint(t *testing.T) {
 		t.Errorf("expected 200, got %d", rr.Code)
 	}
 
-	var resp map[string]string
+	var resp map[string]interface{}
 	parseJSON(t, rr, &resp)
 	if resp["status"] != "ok" {
-		t.Errorf("expected status 'ok', got %q", resp["status"])
+		t.Errorf("expected status 'ok', got %v", resp["status"])
+	}
+	// cloud_mode should default to false when not configured
+	if resp["cloud_mode"] != false {
+		t.Errorf("expected cloud_mode false, got %v", resp["cloud_mode"])
 	}
 }
 

--- a/internal/store/encryption.go
+++ b/internal/store/encryption.go
@@ -1,0 +1,144 @@
+package store
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"strings"
+)
+
+const encryptedPrefix = "enc:"
+
+// SetEncryptionKey configures the store's AES-256 encryption key for
+// encrypting sensitive fields (e.g., TOTP secrets) at rest.
+// The key must be exactly 32 bytes (256 bits). If empty, encryption is disabled
+// and secrets are stored in plaintext (with a warning logged at startup).
+func (s *Store) SetEncryptionKey(key []byte) {
+	s.encryptionKey = key
+}
+
+// HasEncryptionKey reports whether an encryption key is configured.
+func (s *Store) HasEncryptionKey() bool {
+	return len(s.encryptionKey) == 32
+}
+
+// encrypt encrypts plaintext using AES-256-GCM and returns a base64-encoded
+// ciphertext prefixed with "enc:" to distinguish from plaintext values.
+func (s *Store) encrypt(plaintext string) (string, error) {
+	if !s.HasEncryptionKey() {
+		return plaintext, nil // No key — store as plaintext
+	}
+	if plaintext == "" {
+		return "", nil
+	}
+
+	block, err := aes.NewCipher(s.encryptionKey)
+	if err != nil {
+		return "", fmt.Errorf("create cipher: %w", err)
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", fmt.Errorf("create GCM: %w", err)
+	}
+
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return "", fmt.Errorf("generate nonce: %w", err)
+	}
+
+	ciphertext := gcm.Seal(nonce, nonce, []byte(plaintext), nil)
+	return encryptedPrefix + base64.StdEncoding.EncodeToString(ciphertext), nil
+}
+
+// decrypt decrypts a value that was encrypted with encrypt().
+// If the value doesn't have the "enc:" prefix, it's treated as plaintext
+// (backward compatibility with pre-encryption data).
+func (s *Store) decrypt(value string) (string, error) {
+	if value == "" {
+		return "", nil
+	}
+
+	// Not encrypted — return as-is (plaintext from before encryption was enabled)
+	if !strings.HasPrefix(value, encryptedPrefix) {
+		return value, nil
+	}
+
+	if !s.HasEncryptionKey() {
+		return "", fmt.Errorf("encrypted value found but no encryption key configured")
+	}
+
+	encoded := strings.TrimPrefix(value, encryptedPrefix)
+	data, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return "", fmt.Errorf("decode base64: %w", err)
+	}
+
+	block, err := aes.NewCipher(s.encryptionKey)
+	if err != nil {
+		return "", fmt.Errorf("create cipher: %w", err)
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", fmt.Errorf("create GCM: %w", err)
+	}
+
+	nonceSize := gcm.NonceSize()
+	if len(data) < nonceSize {
+		return "", fmt.Errorf("ciphertext too short")
+	}
+
+	nonce, ciphertext := data[:nonceSize], data[nonceSize:]
+	plaintext, err := gcm.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return "", fmt.Errorf("decrypt: %w", err)
+	}
+
+	return string(plaintext), nil
+}
+
+// BackfillEncryptTOTPSecrets encrypts any plaintext TOTP secrets in the database.
+// Idempotent: skips secrets that already have the "enc:" prefix.
+// Called on startup when an encryption key is first configured.
+func (s *Store) BackfillEncryptTOTPSecrets() (int, error) {
+	if !s.HasEncryptionKey() {
+		return 0, nil
+	}
+
+	rows, err := s.db.Query(s.q(`SELECT id, totp_secret FROM users WHERE totp_secret != '' AND totp_secret NOT LIKE 'enc:%'`))
+	if err != nil {
+		return 0, fmt.Errorf("query plaintext secrets: %w", err)
+	}
+	defer rows.Close()
+
+	type row struct {
+		id, secret string
+	}
+	var toEncrypt []row
+	for rows.Next() {
+		var r row
+		if err := rows.Scan(&r.id, &r.secret); err != nil {
+			return 0, fmt.Errorf("scan row: %w", err)
+		}
+		toEncrypt = append(toEncrypt, r)
+	}
+	if err := rows.Err(); err != nil {
+		return 0, err
+	}
+
+	for _, r := range toEncrypt {
+		encrypted, err := s.encrypt(r.secret)
+		if err != nil {
+			return 0, fmt.Errorf("encrypt secret for user %s: %w", r.id, err)
+		}
+		if _, err := s.db.Exec(s.q(`UPDATE users SET totp_secret = ? WHERE id = ?`), encrypted, r.id); err != nil {
+			return 0, fmt.Errorf("update secret for user %s: %w", r.id, err)
+		}
+	}
+
+	return len(toEncrypt), nil
+}

--- a/internal/store/encryption_test.go
+++ b/internal/store/encryption_test.go
@@ -1,0 +1,140 @@
+package store
+
+import (
+	"crypto/rand"
+	"testing"
+
+	"github.com/xarmian/pad/internal/models"
+)
+
+func TestEncryptDecrypt(t *testing.T) {
+	s := testStore(t)
+
+	// Generate a random 32-byte key
+	key := make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		t.Fatal(err)
+	}
+	s.SetEncryptionKey(key)
+
+	// Test basic encrypt/decrypt
+	original := "JBSWY3DPEHPK3PXP"
+	encrypted, err := s.encrypt(original)
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+	if encrypted == original {
+		t.Error("encrypted value should differ from original")
+	}
+	if encrypted[:4] != "enc:" {
+		t.Errorf("encrypted value should start with 'enc:', got %q", encrypted[:4])
+	}
+
+	decrypted, err := s.decrypt(encrypted)
+	if err != nil {
+		t.Fatalf("decrypt: %v", err)
+	}
+	if decrypted != original {
+		t.Errorf("expected %q, got %q", original, decrypted)
+	}
+}
+
+func TestDecryptPlaintext(t *testing.T) {
+	s := testStore(t)
+
+	key := make([]byte, 32)
+	rand.Read(key)
+	s.SetEncryptionKey(key)
+
+	// Plaintext values (no "enc:" prefix) should pass through unchanged
+	plain := "JBSWY3DPEHPK3PXP"
+	result, err := s.decrypt(plain)
+	if err != nil {
+		t.Fatalf("decrypt plaintext: %v", err)
+	}
+	if result != plain {
+		t.Errorf("expected %q, got %q", plain, result)
+	}
+}
+
+func TestEncryptWithoutKey(t *testing.T) {
+	s := testStore(t)
+
+	// No encryption key — encrypt should return plaintext
+	original := "JBSWY3DPEHPK3PXP"
+	result, err := s.encrypt(original)
+	if err != nil {
+		t.Fatalf("encrypt without key: %v", err)
+	}
+	if result != original {
+		t.Errorf("without key, encrypt should return plaintext, got %q", result)
+	}
+}
+
+func TestEncryptDecryptEmpty(t *testing.T) {
+	s := testStore(t)
+
+	key := make([]byte, 32)
+	rand.Read(key)
+	s.SetEncryptionKey(key)
+
+	// Empty strings should pass through
+	encrypted, err := s.encrypt("")
+	if err != nil {
+		t.Fatalf("encrypt empty: %v", err)
+	}
+	if encrypted != "" {
+		t.Errorf("expected empty, got %q", encrypted)
+	}
+
+	decrypted, err := s.decrypt("")
+	if err != nil {
+		t.Fatalf("decrypt empty: %v", err)
+	}
+	if decrypted != "" {
+		t.Errorf("expected empty, got %q", decrypted)
+	}
+}
+
+func TestTOTPEncryptionRoundTrip(t *testing.T) {
+	s := testStore(t)
+
+	key := make([]byte, 32)
+	rand.Read(key)
+	s.SetEncryptionKey(key)
+
+	// Create a user
+	u, err := s.CreateUser(models.UserCreate{
+		Email:    "totp@test.com",
+		Name:     "TOTP Tester",
+		Password: "password123",
+	})
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+
+	// Set TOTP secret (should be encrypted in DB)
+	secret := "JBSWY3DPEHPK3PXP"
+	if err := s.SetTOTPSecret(u.ID, secret); err != nil {
+		t.Fatalf("set totp secret: %v", err)
+	}
+
+	// Read it back — should be decrypted automatically
+	fetched, err := s.GetUser(u.ID)
+	if err != nil {
+		t.Fatalf("get user: %v", err)
+	}
+	if fetched.TOTPSecret != secret {
+		t.Errorf("expected %q, got %q", secret, fetched.TOTPSecret)
+	}
+
+	// Verify the raw value in DB is encrypted
+	var rawSecret string
+	s.db.QueryRow("SELECT totp_secret FROM users WHERE id = ?", u.ID).Scan(&rawSecret)
+	if rawSecret == secret {
+		t.Error("raw DB value should be encrypted, not plaintext")
+	}
+	if rawSecret[:4] != "enc:" {
+		t.Errorf("raw DB value should start with 'enc:', got %q", rawSecret[:10])
+	}
+}

--- a/internal/store/limits.go
+++ b/internal/store/limits.go
@@ -1,0 +1,330 @@
+package store
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strconv"
+)
+
+// PlanLimits defines the limits for a billing plan tier.
+type PlanLimits struct {
+	Workspaces          int `json:"workspaces"`
+	ItemsPerWorkspace   int `json:"items_per_workspace"`
+	MembersPerWorkspace int `json:"members_per_workspace"`
+	APITokens           int `json:"api_tokens"`
+	StorageBytes        int `json:"storage_bytes"`
+	Webhooks            int `json:"webhooks"`
+	AutomatedBackups    int `json:"automated_backups"`
+}
+
+// DefaultFreeLimits are the hardcoded fallback limits for the free tier.
+// These are used only if the platform_settings table has no stored defaults.
+var DefaultFreeLimits = PlanLimits{
+	Workspaces:          5,
+	ItemsPerWorkspace:   1000,
+	MembersPerWorkspace: 3,
+	APITokens:           10,
+	StorageBytes:        524288000, // 500MB
+	Webhooks:            0,
+	AutomatedBackups:    0,
+}
+
+// DefaultProLimits are the hardcoded fallback limits for the pro tier.
+// -1 means unlimited.
+var DefaultProLimits = PlanLimits{
+	Workspaces:          -1,
+	ItemsPerWorkspace:   -1,
+	MembersPerWorkspace: -1,
+	APITokens:           -1,
+	StorageBytes:        10737418240, // 10GB
+	Webhooks:            -1,
+	AutomatedBackups:    -1,
+}
+
+// LimitResult is returned by CheckLimit with the enforcement decision
+// and current usage info for the feature.
+type LimitResult struct {
+	Allowed bool   `json:"allowed"`
+	Feature string `json:"feature"`
+	Limit   int    `json:"limit"`   // -1 means unlimited
+	Current int    `json:"current"`
+	Plan    string `json:"plan"`
+}
+
+// CheckLimit checks whether a workspace operation is allowed under the
+// owner's plan. Resolution order:
+//  1. User plan_overrides[feature] — per-user override (if set)
+//  2. Platform plan_limits[plan][feature] — DB-stored defaults for the tier
+//  3. Hardcoded fallback — safety net if DB config is missing
+func (s *Store) CheckLimit(workspaceID, feature string) (*LimitResult, error) {
+	// 1. Look up workspace → owner_id
+	var ownerID string
+	err := s.db.QueryRow(s.q(`SELECT owner_id FROM workspaces WHERE id = ?`), workspaceID).Scan(&ownerID)
+	if err != nil {
+		return nil, fmt.Errorf("check limit: get workspace owner: %w", err)
+	}
+
+	// 2. Look up user → plan, plan_overrides
+	user, err := s.GetUser(ownerID)
+	if err != nil {
+		return nil, fmt.Errorf("check limit: get user: %w", err)
+	}
+	if user == nil {
+		return nil, fmt.Errorf("check limit: owner not found")
+	}
+
+	// Self-hosted and pro always allowed
+	plan := user.Plan
+	if plan == "" {
+		plan = "free"
+	}
+	if plan == "self-hosted" || plan == "pro" {
+		return &LimitResult{Allowed: true, Feature: feature, Limit: -1, Current: 0, Plan: plan}, nil
+	}
+
+	// 3. Resolve the limit for this feature
+	limit := s.resolveLimit(plan, feature, user.PlanOverrides)
+
+	// -1 = unlimited
+	if limit < 0 {
+		return &LimitResult{Allowed: true, Feature: feature, Limit: -1, Current: 0, Plan: plan}, nil
+	}
+
+	// 4. Get current count for the feature
+	current, err := s.featureCount(workspaceID, ownerID, feature)
+	if err != nil {
+		return nil, fmt.Errorf("check limit: count %s: %w", feature, err)
+	}
+
+	return &LimitResult{
+		Allowed: current < limit,
+		Feature: feature,
+		Limit:   limit,
+		Current: current,
+		Plan:    plan,
+	}, nil
+}
+
+// CheckUserLimit checks a user-level limit (not workspace-scoped), such as
+// total workspace count or total API tokens.
+func (s *Store) CheckUserLimit(userID, feature string) (*LimitResult, error) {
+	user, err := s.GetUser(userID)
+	if err != nil {
+		return nil, fmt.Errorf("check user limit: get user: %w", err)
+	}
+	if user == nil {
+		return nil, fmt.Errorf("check user limit: user not found")
+	}
+
+	plan := user.Plan
+	if plan == "" {
+		plan = "free"
+	}
+	if plan == "self-hosted" || plan == "pro" {
+		return &LimitResult{Allowed: true, Feature: feature, Limit: -1, Current: 0, Plan: plan}, nil
+	}
+
+	limit := s.resolveLimit(plan, feature, user.PlanOverrides)
+	if limit < 0 {
+		return &LimitResult{Allowed: true, Feature: feature, Limit: -1, Current: 0, Plan: plan}, nil
+	}
+
+	current, err := s.userFeatureCount(userID, feature)
+	if err != nil {
+		return nil, fmt.Errorf("check user limit: count %s: %w", feature, err)
+	}
+
+	return &LimitResult{
+		Allowed: current < limit,
+		Feature: feature,
+		Limit:   limit,
+		Current: current,
+		Plan:    plan,
+	}, nil
+}
+
+// resolveLimit resolves the limit for a feature using the three-tier resolution:
+// user overrides → DB-stored plan defaults → hardcoded fallback.
+func (s *Store) resolveLimit(plan, feature, overridesJSON string) int {
+	// 1. Check per-user overrides
+	if overridesJSON != "" {
+		var overrides map[string]int
+		if err := json.Unmarshal([]byte(overridesJSON), &overrides); err == nil {
+			if v, ok := overrides[feature]; ok {
+				return v
+			}
+		}
+	}
+
+	// 2. Check DB-stored plan defaults
+	settingKey := "plan_limits_" + plan + "_" + feature
+	if val, err := s.GetPlatformSetting(settingKey); err == nil && val != "" {
+		if v, err := strconv.Atoi(val); err == nil {
+			return v
+		}
+	}
+
+	// 3. Hardcoded fallback
+	return hardcodedLimit(plan, feature)
+}
+
+// featureCount returns the current count for a workspace-scoped feature.
+func (s *Store) featureCount(workspaceID, ownerID, feature string) (int, error) {
+	var count int
+	var err error
+
+	switch feature {
+	case "items_per_workspace":
+		err = s.db.QueryRow(s.q(`SELECT COUNT(*) FROM items WHERE workspace_id = ? AND deleted_at IS NULL`), workspaceID).Scan(&count)
+	case "members_per_workspace":
+		err = s.db.QueryRow(s.q(`SELECT COUNT(*) FROM workspace_members WHERE workspace_id = ?`), workspaceID).Scan(&count)
+	case "webhooks":
+		err = s.db.QueryRow(s.q(`SELECT COUNT(*) FROM webhooks WHERE workspace_id = ?`), workspaceID).Scan(&count)
+	default:
+		return 0, fmt.Errorf("unknown workspace feature: %s", feature)
+	}
+
+	return count, err
+}
+
+// userFeatureCount returns the current count for a user-scoped feature.
+func (s *Store) userFeatureCount(userID, feature string) (int, error) {
+	var count int
+	var err error
+
+	switch feature {
+	case "workspaces":
+		err = s.db.QueryRow(s.q(`SELECT COUNT(*) FROM workspaces WHERE owner_id = ?`), userID).Scan(&count)
+	case "api_tokens":
+		err = s.db.QueryRow(s.q(`SELECT COUNT(*) FROM api_tokens WHERE user_id = ?`), userID).Scan(&count)
+	default:
+		return 0, fmt.Errorf("unknown user feature: %s", feature)
+	}
+
+	return count, err
+}
+
+// hardcodedLimit returns the hardcoded fallback limit for a feature on a given plan.
+func hardcodedLimit(plan, feature string) int {
+	var limits PlanLimits
+	switch plan {
+	case "pro":
+		limits = DefaultProLimits
+	default:
+		limits = DefaultFreeLimits
+	}
+
+	switch feature {
+	case "workspaces":
+		return limits.Workspaces
+	case "items_per_workspace":
+		return limits.ItemsPerWorkspace
+	case "members_per_workspace":
+		return limits.MembersPerWorkspace
+	case "api_tokens":
+		return limits.APITokens
+	case "storage_bytes":
+		return limits.StorageBytes
+	case "webhooks":
+		return limits.Webhooks
+	case "automated_backups":
+		return limits.AutomatedBackups
+	default:
+		slog.Warn("unknown plan limit feature — denying by default", "feature", feature, "plan", plan)
+		return 0 // Unknown features denied (fail closed)
+	}
+}
+
+// SeedPlanLimits writes the default plan limits to platform_settings if they
+// don't already exist. Called on server startup. Idempotent — existing values
+// are not overwritten, so admin changes via the UI are preserved.
+func (s *Store) SeedPlanLimits() error {
+	plans := map[string]PlanLimits{
+		"free": DefaultFreeLimits,
+		"pro":  DefaultProLimits,
+	}
+
+	features := []string{
+		"workspaces", "items_per_workspace", "members_per_workspace",
+		"api_tokens", "storage_bytes", "webhooks", "automated_backups",
+	}
+
+	for planName, limits := range plans {
+		limitsMap := map[string]int{
+			"workspaces":            limits.Workspaces,
+			"items_per_workspace":   limits.ItemsPerWorkspace,
+			"members_per_workspace": limits.MembersPerWorkspace,
+			"api_tokens":            limits.APITokens,
+			"storage_bytes":         limits.StorageBytes,
+			"webhooks":              limits.Webhooks,
+			"automated_backups":     limits.AutomatedBackups,
+		}
+
+		for _, feature := range features {
+			key := "plan_limits_" + planName + "_" + feature
+			existing, err := s.GetPlatformSetting(key)
+			if err != nil {
+				return fmt.Errorf("seed plan limits: check %s: %w", key, err)
+			}
+			if existing != "" {
+				continue // Already set — don't overwrite admin changes
+			}
+			if err := s.SetPlatformSetting(key, strconv.Itoa(limitsMap[feature])); err != nil {
+				return fmt.Errorf("seed plan limits: set %s: %w", key, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+// SetUserPlan updates a user's billing plan.
+func (s *Store) SetUserPlan(userID, plan, expiresAt string) error {
+	_, err := s.db.Exec(s.q(`UPDATE users SET plan = ?, plan_expires_at = ?, updated_at = ? WHERE id = ?`),
+		plan, expiresAt, now(), userID)
+	if err != nil {
+		return fmt.Errorf("set user plan: %w", err)
+	}
+	return nil
+}
+
+// SetUserPlanOverrides updates per-user limit overrides (JSON string).
+func (s *Store) SetUserPlanOverrides(userID, overridesJSON string) error {
+	_, err := s.db.Exec(s.q(`UPDATE users SET plan_overrides = ?, updated_at = ? WHERE id = ?`),
+		overridesJSON, now(), userID)
+	if err != nil {
+		return fmt.Errorf("set user plan overrides: %w", err)
+	}
+	return nil
+}
+
+// BackfillUserPlans sets the plan for all users that have an empty or default plan.
+// In cloud mode, call with "free" to ensure all users have a plan set.
+// In self-hosted mode, call with "self-hosted" to remove all limits.
+func (s *Store) BackfillUserPlans(targetPlan string) error {
+	var err error
+	if targetPlan == "self-hosted" {
+		// Self-hosted: override free and empty plans to self-hosted
+		_, err = s.db.Exec(s.q(`UPDATE users SET plan = ?, updated_at = ? WHERE plan IN ('', 'free')`),
+			targetPlan, now())
+	} else {
+		// Cloud: only fill in empty plans, don't override existing values
+		_, err = s.db.Exec(s.q(`UPDATE users SET plan = ?, updated_at = ? WHERE plan = ''`),
+			targetPlan, now())
+	}
+	if err != nil {
+		return fmt.Errorf("backfill user plans: %w", err)
+	}
+	return nil
+}
+
+// SetUserStripeCustomerID stores the Stripe customer ID for a user.
+func (s *Store) SetUserStripeCustomerID(userID, customerID string) error {
+	_, err := s.db.Exec(s.q(`UPDATE users SET stripe_customer_id = ?, updated_at = ? WHERE id = ?`),
+		customerID, now(), userID)
+	if err != nil {
+		return fmt.Errorf("set stripe customer id: %w", err)
+	}
+	return nil
+}

--- a/internal/store/migrations/035_plan_fields.sql
+++ b/internal/store/migrations/035_plan_fields.sql
@@ -1,0 +1,6 @@
+-- Add plan/billing columns to users table for cloud mode billing.
+-- Plan is account-level: workspaces inherit from their owner's plan.
+ALTER TABLE users ADD COLUMN plan TEXT NOT NULL DEFAULT 'free';
+ALTER TABLE users ADD COLUMN plan_expires_at TEXT DEFAULT '';
+ALTER TABLE users ADD COLUMN stripe_customer_id TEXT DEFAULT '';
+ALTER TABLE users ADD COLUMN plan_overrides TEXT DEFAULT '';

--- a/internal/store/pgmigrations/015_plan_fields.sql
+++ b/internal/store/pgmigrations/015_plan_fields.sql
@@ -1,0 +1,6 @@
+-- Add plan/billing columns to users table for cloud mode billing.
+-- Plan is account-level: workspaces inherit from their owner's plan.
+ALTER TABLE users ADD COLUMN IF NOT EXISTS plan TEXT NOT NULL DEFAULT 'free';
+ALTER TABLE users ADD COLUMN IF NOT EXISTS plan_expires_at TEXT DEFAULT '';
+ALTER TABLE users ADD COLUMN IF NOT EXISTS stripe_customer_id TEXT DEFAULT '';
+ALTER TABLE users ADD COLUMN IF NOT EXISTS plan_overrides TEXT DEFAULT '';

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -20,8 +20,9 @@ var migrationsFS embed.FS
 var pgMigrationsFS embed.FS
 
 type Store struct {
-	db      *sql.DB
-	dialect Dialect
+	db            *sql.DB
+	dialect       Dialect
+	encryptionKey []byte // 32-byte AES-256 key for encrypting sensitive fields (e.g., TOTP secrets)
 }
 
 // D returns the store's dialect for building backend-specific SQL.
@@ -159,6 +160,7 @@ func (s *Store) migrate() error {
 		"032_permission_indexes.sql",
 		"033_grants.sql",
 		"034_share_links.sql",
+		"035_plan_fields.sql",
 	}
 
 	for _, name := range migrations {
@@ -217,6 +219,7 @@ func (s *Store) migratePostgres() error {
 		"012_permission_indexes.sql",
 		"013_grants.sql",
 		"014_share_links.sql",
+		"015_plan_fields.sql",
 	}
 
 	for _, name := range migrations {

--- a/internal/store/users.go
+++ b/internal/store/users.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"crypto/rand"
 	"crypto/sha256"
 	"database/sql"
 	"encoding/hex"
@@ -17,9 +18,11 @@ var usernameCleanRe = regexp.MustCompile(`[^a-z0-9-]+`)
 const bcryptCost = 12
 
 // user SELECT columns — used by all user queries.
-const userColumns = `id, email, username, name, password_hash, role, avatar_url, totp_secret, totp_enabled, recovery_codes, created_at, updated_at`
+const userColumns = `id, email, username, name, password_hash, role, avatar_url, totp_secret, totp_enabled, recovery_codes, plan, plan_expires_at, stripe_customer_id, plan_overrides, created_at, updated_at`
 
 // scanUser scans a user row into a User struct.
+// Note: does NOT decrypt the TOTP secret — call store.decryptUserTOTP() after
+// scanning if you need the plaintext secret for validation.
 func scanUser(row interface{ Scan(...interface{}) error }) (*models.User, error) {
 	var u models.User
 	var createdAt, updatedAt string
@@ -27,6 +30,7 @@ func scanUser(row interface{ Scan(...interface{}) error }) (*models.User, error)
 	err := row.Scan(
 		&u.ID, &u.Email, &u.Username, &u.Name, &u.PasswordHash, &u.Role, &u.AvatarURL,
 		&u.TOTPSecret, &u.TOTPEnabled, &u.RecoveryCodes,
+		&u.Plan, &u.PlanExpiresAt, &u.StripeCustomerID, &u.PlanOverrides,
 		&createdAt, &updatedAt,
 	)
 	if err == sql.ErrNoRows {
@@ -39,6 +43,19 @@ func scanUser(row interface{ Scan(...interface{}) error }) (*models.User, error)
 	u.CreatedAt = parseTime(createdAt)
 	u.UpdatedAt = parseTime(updatedAt)
 	return &u, nil
+}
+
+// decryptUserTOTP decrypts the TOTP secret on a User struct in place.
+func (s *Store) decryptUserTOTP(u *models.User) error {
+	if u == nil || u.TOTPSecret == "" {
+		return nil
+	}
+	decrypted, err := s.decrypt(u.TOTPSecret)
+	if err != nil {
+		return fmt.Errorf("decrypt user TOTP: %w", err)
+	}
+	u.TOTPSecret = decrypted
+	return nil
 }
 
 // CreateUser creates a new user with a hashed password.
@@ -73,6 +90,9 @@ func (s *Store) GetUser(id string) (*models.User, error) {
 	if err != nil {
 		return nil, fmt.Errorf("get user: %w", err)
 	}
+	if err := s.decryptUserTOTP(u); err != nil {
+		return nil, err
+	}
 	return u, nil
 }
 
@@ -82,6 +102,9 @@ func (s *Store) GetUserByEmail(email string) (*models.User, error) {
 		strings.ToLower(strings.TrimSpace(email))))
 	if err != nil {
 		return nil, fmt.Errorf("get user by email: %w", err)
+	}
+	if err := s.decryptUserTOTP(u); err != nil {
+		return nil, err
 	}
 	return u, nil
 }
@@ -95,6 +118,9 @@ func (s *Store) GetUserByUsername(username string) (*models.User, error) {
 	u, err := scanUser(s.db.QueryRow(s.q(`SELECT `+userColumns+` FROM users WHERE LOWER(username) = ?`), username))
 	if err != nil {
 		return nil, fmt.Errorf("get user by username: %w", err)
+	}
+	if err := s.decryptUserTOTP(u); err != nil {
+		return nil, err
 	}
 	return u, nil
 }
@@ -178,6 +204,7 @@ func (s *Store) ListUsers() ([]models.User, error) {
 		if err != nil {
 			return nil, fmt.Errorf("scan user: %w", err)
 		}
+		_ = s.decryptUserTOTP(u) // Best-effort decrypt for list (TOTP secret is json:"-" anyway)
 		result = append(result, *u)
 	}
 	return result, rows.Err()
@@ -191,6 +218,49 @@ func (s *Store) UserCount() (int, error) {
 		return 0, fmt.Errorf("count users: %w", err)
 	}
 	return count, nil
+}
+
+// CreateOAuthUser creates a user from an OAuth provider with a random unusable password.
+// OAuth users can later set a password via the password reset flow if they want.
+func (s *Store) CreateOAuthUser(email, name, avatarURL string) (*models.User, error) {
+	// Generate a random 64-byte password the user will never use
+	randomPwd := make([]byte, 64)
+	if _, err := rand.Read(randomPwd); err != nil {
+		return nil, fmt.Errorf("generate random password: %w", err)
+	}
+
+	hash, err := bcrypt.GenerateFromPassword(randomPwd, bcryptCost)
+	if err != nil {
+		return nil, fmt.Errorf("hash password: %w", err)
+	}
+
+	id := newID()
+	ts := now()
+
+	username := GenerateUsername(name, email)
+	username, err = s.EnsureUniqueUsername(username)
+	if err != nil {
+		return nil, fmt.Errorf("generate username: %w", err)
+	}
+
+	_, err = s.db.Exec(s.q(`
+		INSERT INTO users (id, email, username, name, password_hash, role, avatar_url, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`), id, strings.ToLower(strings.TrimSpace(email)), username, strings.TrimSpace(name), string(hash), "member", avatarURL, ts, ts)
+	if err != nil {
+		return nil, fmt.Errorf("insert oauth user: %w", err)
+	}
+
+	return s.GetUser(id)
+}
+
+// DeleteUser permanently deletes a user by ID.
+func (s *Store) DeleteUser(id string) error {
+	_, err := s.db.Exec(s.q(`DELETE FROM users WHERE id = ?`), id)
+	if err != nil {
+		return fmt.Errorf("delete user: %w", err)
+	}
+	return nil
 }
 
 // --- Username backfill ---
@@ -319,14 +389,14 @@ func (s *Store) backfillUsernames() error {
 
 // --- TOTP 2FA ---
 
-// TODO: Encrypt TOTP secret at rest using an app-level encryption key
-// (e.g., AES-256-GCM with a key from PAD_ENCRYPTION_KEY env var).
-// The secret must remain decryptable for TOTP validation, so hashing
-// is not an option here. For now, it is stored as plaintext.
-
 // SetTOTPSecret stores the TOTP secret for a user (before 2FA is verified).
+// The secret is encrypted at rest if an encryption key is configured.
 func (s *Store) SetTOTPSecret(userID, secret string) error {
-	_, err := s.db.Exec(s.q(`UPDATE users SET totp_secret = ?, updated_at = ? WHERE id = ?`), secret, now(), userID)
+	encrypted, err := s.encrypt(secret)
+	if err != nil {
+		return fmt.Errorf("encrypt totp secret: %w", err)
+	}
+	_, err = s.db.Exec(s.q(`UPDATE users SET totp_secret = ?, updated_at = ? WHERE id = ?`), encrypted, now(), userID)
 	if err != nil {
 		return fmt.Errorf("set totp secret: %w", err)
 	}
@@ -334,19 +404,37 @@ func (s *Store) SetTOTPSecret(userID, secret string) error {
 }
 
 // EnableTOTP atomically enables 2FA for a user and stores hashed recovery codes.
-// The expectedSecret must match the currently stored totp_secret to prevent
-// TOCTOU races (e.g., a concurrent setup call overwriting the secret).
+// The expectedSecret is the plaintext secret — it's compared against the stored
+// (possibly encrypted) value to prevent TOCTOU races.
 func (s *Store) EnableTOTP(userID, expectedSecret, hashedRecoveryCodes string) error {
+	// Read the stored (possibly encrypted) secret to compare
+	var storedSecret string
+	err := s.db.QueryRow(s.q(`SELECT totp_secret FROM users WHERE id = ? AND totp_enabled = ?`),
+		userID, s.dialect.BoolToInt(false)).Scan(&storedSecret)
+	if err != nil {
+		return fmt.Errorf("enable totp: read secret: %w", err)
+	}
+
+	// Decrypt stored secret for comparison
+	decrypted, err := s.decrypt(storedSecret)
+	if err != nil {
+		return fmt.Errorf("enable totp: decrypt stored secret: %w", err)
+	}
+	if decrypted != expectedSecret {
+		return fmt.Errorf("enable totp: secret mismatch or user not found")
+	}
+
+	// Update — use the stored (encrypted) value in WHERE for atomicity
 	result, err := s.db.Exec(s.q(
 		`UPDATE users SET totp_enabled = ?, recovery_codes = ?, updated_at = ?
 		 WHERE id = ? AND totp_secret = ? AND totp_enabled = ?`),
-		s.dialect.BoolToInt(true), hashedRecoveryCodes, now(), userID, expectedSecret, s.dialect.BoolToInt(false))
+		s.dialect.BoolToInt(true), hashedRecoveryCodes, now(), userID, storedSecret, s.dialect.BoolToInt(false))
 	if err != nil {
 		return fmt.Errorf("enable totp: %w", err)
 	}
 	n, _ := result.RowsAffected()
 	if n == 0 {
-		return fmt.Errorf("enable totp: secret mismatch or user not found")
+		return fmt.Errorf("enable totp: concurrent modification or user not found")
 	}
 	return nil
 }

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -101,6 +101,7 @@ export interface HealthResponse {
 	version?: string;
 	commit?: string;
 	build_time?: string;
+	cloud_mode?: boolean;
 }
 
 export interface AuthSession {
@@ -108,11 +109,12 @@ export interface AuthSession {
 	setup_required: boolean;
 	setup_method?: 'local_cli' | 'docker_exec' | 'cloud';
 	auth_method: 'password' | 'cloud';
-	user?: { id: string; email: string; username: string; name: string; role: string };
+	cloud_mode?: boolean;
+	user?: { id: string; email: string; username: string; name: string; role: string; plan?: string };
 }
 
 export interface LoginResponse {
-	user?: { id: string; email: string; username: string; name: string; role: string };
+	user?: { id: string; email: string; username: string; name: string; role: string; plan?: string };
 	token?: string;
 	requires_2fa?: boolean;
 	challenge_token?: string;

--- a/web/src/lib/stores/auth.svelte.ts
+++ b/web/src/lib/stores/auth.svelte.ts
@@ -8,6 +8,7 @@ export const authStore = {
 	get user() { return session?.user ?? null; },
 	get userId() { return session?.user?.id ?? ''; },
 	get authenticated() { return session?.authenticated ?? false; },
+	get cloudMode() { return session?.cloud_mode ?? false; },
 	get loading() { return loading; },
 
 	async load() {

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -20,6 +20,7 @@
 	let authReady = $state(false);
 	let isAuthPage = $derived(page.url.pathname === '/login' || page.url.pathname === '/register' || page.url.pathname.startsWith('/join/'));
 	let isSharePage = $derived(page.url.pathname.startsWith('/s/'));
+	let isConsolePage = $derived(page.url.pathname.startsWith('/console'));
 
 	onMount(async () => {
 		// Initialize theme
@@ -120,7 +121,7 @@
 
 {#if !authReady}
 	<!-- Auth check in progress — blank screen to avoid flash -->
-{:else if isAuthPage || isSharePage}
+{:else if isAuthPage || isSharePage || isConsolePage}
 	{@render children()}
 {:else}
 	{#if uiStore.isMobile && uiStore.sidebarOpen}

--- a/web/src/routes/console/+layout.svelte
+++ b/web/src/routes/console/+layout.svelte
@@ -1,0 +1,212 @@
+<script lang="ts">
+	import { goto } from '$app/navigation';
+	import { page } from '$app/state';
+	import { authStore } from '$lib/stores/auth.svelte';
+	import { api } from '$lib/api/client';
+	import { onMount } from 'svelte';
+
+	let { children } = $props();
+	let ready = $state(false);
+
+	onMount(async () => {
+		try {
+			const session = await authStore.load();
+			if (!session?.authenticated) {
+				goto('/login', { replaceState: true });
+				return;
+			}
+		} catch {
+			goto('/login', { replaceState: true });
+			return;
+		}
+		ready = true;
+	});
+
+	let currentPath = $derived(page.url.pathname as string);
+
+	function isActive(path: string): boolean {
+		if (path === '/console') return currentPath === '/console';
+		return currentPath.startsWith(path);
+	}
+
+	async function logout() {
+		await api.auth.logout();
+		authStore.clear();
+		goto('/login');
+	}
+
+	let initial = $derived(
+		authStore.user?.name?.charAt(0)?.toUpperCase() ??
+		authStore.user?.email?.charAt(0)?.toUpperCase() ?? '?'
+	);
+</script>
+
+{#if ready}
+	<div class="console-layout">
+		<nav class="console-nav">
+			<div class="nav-left">
+				<a href="/console" class="nav-logo">Pad</a>
+				<div class="nav-links">
+					<a href="/console" class="nav-link" class:active={isActive('/console') && !isActive('/console/settings') && !isActive('/console/billing') && !isActive('/console/admin')}>
+						Workspaces
+					</a>
+					<a href="/console/settings" class="nav-link" class:active={isActive('/console/settings')}>
+						Settings
+					</a>
+					{#if authStore.cloudMode}
+						<a href="/console/billing" class="nav-link" class:active={isActive('/console/billing')}>
+							Billing
+						</a>
+					{/if}
+					{#if authStore.user?.role === 'admin'}
+						<a href="/console/admin" class="nav-link" class:active={isActive('/console/admin')}>
+							Admin
+						</a>
+					{/if}
+				</div>
+			</div>
+			<div class="nav-right">
+				<div class="user-info">
+					<span class="avatar">{initial}</span>
+					<span class="user-name">{authStore.user?.name || authStore.user?.email || ''}</span>
+				</div>
+				<button class="logout-btn" onclick={logout}>Sign out</button>
+			</div>
+		</nav>
+		<main class="console-main">
+			{@render children()}
+		</main>
+	</div>
+{/if}
+
+<style>
+	.console-layout {
+		min-height: 100vh;
+		background: var(--bg-primary);
+	}
+
+	.console-nav {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		height: 56px;
+		padding: 0 var(--space-6);
+		background: var(--bg-secondary);
+		border-bottom: 1px solid var(--border);
+	}
+
+	.nav-left {
+		display: flex;
+		align-items: center;
+		gap: var(--space-8);
+	}
+
+	.nav-logo {
+		font-size: 1.25rem;
+		font-weight: 700;
+		color: var(--text-primary);
+		text-decoration: none;
+		letter-spacing: -0.02em;
+	}
+
+	.nav-logo:hover {
+		text-decoration: none;
+	}
+
+	.nav-links {
+		display: flex;
+		align-items: center;
+		gap: var(--space-1);
+	}
+
+	.nav-link {
+		padding: var(--space-2) var(--space-3);
+		border-radius: var(--radius);
+		color: var(--text-secondary);
+		font-size: 0.9rem;
+		font-weight: 500;
+		text-decoration: none;
+		transition: color 0.15s, background 0.15s;
+	}
+
+	.nav-link:hover {
+		color: var(--text-primary);
+		background: var(--bg-hover);
+		text-decoration: none;
+	}
+
+	.nav-link.active {
+		color: var(--text-primary);
+		background: var(--bg-tertiary);
+	}
+
+	.nav-right {
+		display: flex;
+		align-items: center;
+		gap: var(--space-4);
+	}
+
+	.user-info {
+		display: flex;
+		align-items: center;
+		gap: var(--space-2);
+	}
+
+	.avatar {
+		width: 28px;
+		height: 28px;
+		border-radius: 50%;
+		background: var(--accent-blue);
+		color: #fff;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		font-size: 0.8rem;
+		font-weight: 600;
+	}
+
+	.user-name {
+		color: var(--text-secondary);
+		font-size: 0.85rem;
+	}
+
+	.logout-btn {
+		padding: var(--space-1) var(--space-3);
+		background: transparent;
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+		color: var(--text-muted);
+		font-size: 0.8rem;
+		cursor: pointer;
+		transition: color 0.15s, border-color 0.15s;
+	}
+
+	.logout-btn:hover {
+		color: var(--text-primary);
+		border-color: var(--text-muted);
+	}
+
+	.console-main {
+		max-width: 960px;
+		margin: 0 auto;
+		padding: var(--space-8) var(--space-6);
+	}
+
+	@media (max-width: 640px) {
+		.console-nav {
+			padding: 0 var(--space-4);
+		}
+
+		.nav-left {
+			gap: var(--space-4);
+		}
+
+		.user-name {
+			display: none;
+		}
+
+		.console-main {
+			padding: var(--space-6) var(--space-4);
+		}
+	}
+</style>

--- a/web/src/routes/console/+page.svelte
+++ b/web/src/routes/console/+page.svelte
@@ -1,0 +1,260 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { api } from '$lib/api/client';
+	import { authStore } from '$lib/stores/auth.svelte';
+	import type { Workspace } from '$lib/types';
+
+	let workspaces = $state<Workspace[]>([]);
+	let loading = $state(true);
+	let error = $state('');
+
+	let ownedWorkspaces = $derived(
+		workspaces.filter((w) => w.owner_id === authStore.userId)
+	);
+	let sharedWorkspaces = $derived(
+		workspaces.filter((w) => w.owner_id !== authStore.userId)
+	);
+
+	onMount(async () => {
+		try {
+			workspaces = await api.workspaces.list();
+		} catch (err) {
+			error = err instanceof Error ? err.message : 'Failed to load workspaces';
+		} finally {
+			loading = false;
+		}
+	});
+
+	function workspaceUrl(ws: Workspace): string {
+		const owner = ws.owner_username || authStore.user?.username || '';
+		return `/${owner}/${ws.slug}`;
+	}
+
+	function formatDate(dateStr: string): string {
+		const d = new Date(dateStr);
+		return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+	}
+</script>
+
+<svelte:head>
+	<title>Console - Pad</title>
+</svelte:head>
+
+<div class="console-page">
+	{#if loading}
+		<div class="loading">Loading workspaces...</div>
+	{:else if error}
+		<div class="error-msg">{error}</div>
+	{:else}
+		<section class="section">
+			<div class="section-header">
+				<h2 class="section-title">Your Workspaces</h2>
+				<a href="/console/new" class="create-btn">Create Workspace</a>
+			</div>
+
+			{#if ownedWorkspaces.length === 0}
+				<div class="empty-state">
+					<p class="empty-text">You don't have any workspaces yet.</p>
+					<a href="/console/new" class="empty-action">Create your first workspace</a>
+				</div>
+			{:else}
+				<div class="workspace-grid">
+					{#each ownedWorkspaces as ws (ws.id)}
+						<a href={workspaceUrl(ws)} class="workspace-card">
+							<div class="card-top">
+								<span class="card-name">{ws.name}</span>
+							</div>
+							{#if ws.description}
+								<p class="card-desc">{ws.description}</p>
+							{/if}
+							<div class="card-meta">
+								<span>Created {formatDate(ws.created_at)}</span>
+							</div>
+						</a>
+					{/each}
+				</div>
+			{/if}
+		</section>
+
+		<section class="section">
+			<div class="section-header">
+				<h2 class="section-title">Shared With Me</h2>
+			</div>
+
+			{#if sharedWorkspaces.length === 0}
+				<div class="empty-state">
+					<p class="empty-text">No workspaces have been shared with you yet.</p>
+				</div>
+			{:else}
+				<div class="workspace-grid">
+					{#each sharedWorkspaces as ws (ws.id)}
+						<a href={workspaceUrl(ws)} class="workspace-card shared">
+							<div class="card-top">
+								<span class="card-name">{ws.name}</span>
+								{#if ws.is_guest}
+									<span class="badge guest">Guest</span>
+								{:else}
+									<span class="badge member">Member</span>
+								{/if}
+							</div>
+							{#if ws.description}
+								<p class="card-desc">{ws.description}</p>
+							{/if}
+							<div class="card-meta">
+								<span>{ws.owner_username ?? 'Unknown owner'}</span>
+							</div>
+						</a>
+					{/each}
+				</div>
+			{/if}
+		</section>
+	{/if}
+</div>
+
+<style>
+	.console-page {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-10);
+	}
+
+	.loading {
+		color: var(--text-muted);
+		padding: var(--space-10) 0;
+		text-align: center;
+	}
+
+	.error-msg {
+		color: #ef4444;
+		padding: var(--space-6);
+		background: var(--bg-secondary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+	}
+
+	.section {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-4);
+	}
+
+	.section-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+	}
+
+	.section-title {
+		font-size: 1.1rem;
+		font-weight: 600;
+		color: var(--text-primary);
+	}
+
+	.create-btn {
+		padding: var(--space-2) var(--space-4);
+		background: var(--accent-blue);
+		color: #fff;
+		border-radius: var(--radius);
+		font-size: 0.85rem;
+		font-weight: 500;
+		text-decoration: none;
+		transition: opacity 0.15s;
+	}
+
+	.create-btn:hover {
+		opacity: 0.9;
+		text-decoration: none;
+	}
+
+	.workspace-grid {
+		display: grid;
+		grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+		gap: var(--space-4);
+	}
+
+	.workspace-card {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-2);
+		padding: var(--space-5);
+		background: var(--bg-secondary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius-lg);
+		text-decoration: none;
+		transition: border-color 0.15s, background 0.15s;
+	}
+
+	.workspace-card:hover {
+		border-color: var(--accent-blue);
+		background: var(--bg-tertiary);
+		text-decoration: none;
+	}
+
+	.card-top {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: var(--space-2);
+	}
+
+	.card-name {
+		font-weight: 600;
+		color: var(--text-primary);
+		font-size: 0.95rem;
+	}
+
+	.card-desc {
+		color: var(--text-secondary);
+		font-size: 0.85rem;
+		line-height: 1.4;
+		display: -webkit-box;
+		-webkit-line-clamp: 2;
+		line-clamp: 2;
+		-webkit-box-orient: vertical;
+		overflow: hidden;
+	}
+
+	.card-meta {
+		color: var(--text-muted);
+		font-size: 0.8rem;
+		margin-top: var(--space-1);
+	}
+
+	.badge {
+		padding: 2px var(--space-2);
+		border-radius: var(--radius-sm);
+		font-size: 0.75rem;
+		font-weight: 500;
+		flex-shrink: 0;
+	}
+
+	.badge.member {
+		background: color-mix(in srgb, var(--accent-blue) 15%, transparent);
+		color: var(--accent-blue);
+	}
+
+	.badge.guest {
+		background: color-mix(in srgb, var(--accent-amber) 15%, transparent);
+		color: var(--accent-amber);
+	}
+
+	.empty-state {
+		padding: var(--space-10) var(--space-6);
+		text-align: center;
+		background: var(--bg-secondary);
+		border: 1px dashed var(--border);
+		border-radius: var(--radius-lg);
+	}
+
+	.empty-text {
+		color: var(--text-muted);
+		font-size: 0.9rem;
+		margin-bottom: var(--space-3);
+	}
+
+	.empty-action {
+		color: var(--accent-blue);
+		font-size: 0.9rem;
+		font-weight: 500;
+	}
+</style>

--- a/web/src/routes/console/admin/+page.svelte
+++ b/web/src/routes/console/admin/+page.svelte
@@ -1,0 +1,374 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { authStore } from '$lib/stores/auth.svelte';
+
+	const BASE = '/api/v1';
+
+	async function adminFetch(path: string, opts?: RequestInit) {
+		const resp = await fetch(BASE + path, { credentials: 'same-origin', ...opts });
+		if (!resp.ok) throw new Error(`${resp.status}`);
+		return resp.json();
+	}
+
+	async function adminPatch(path: string, body: unknown) {
+		return adminFetch(path, {
+			method: 'PATCH',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify(body)
+		});
+	}
+
+	interface AdminUser {
+		id: string; email: string; username: string; name: string;
+		role: string; plan: string; plan_expires_at: string | null;
+		plan_overrides: Record<string, number> | null; totp_enabled: boolean; created_at: string;
+	}
+
+	interface Stats { users: number; users_by_plan: Record<string, number>; workspaces: number; cloud_mode: boolean; }
+	interface LimitTiers { free: Record<string, number>; pro: Record<string, number>; }
+
+	const LIMIT_FEATURES = [
+		'workspaces', 'items_per_workspace', 'members_per_workspace',
+		'api_tokens', 'storage_bytes', 'webhooks', 'automated_backups'
+	] as const;
+
+	let isAdmin = $derived(authStore.user?.role === 'admin');
+
+	let loading = $state(true);
+	let error = $state('');
+	let stats = $state<Stats | null>(null);
+	let users = $state<AdminUser[]>([]);
+	let limits = $state<LimitTiers | null>(null);
+	let search = $state('');
+	let selectedId = $state<string | null>(null);
+	let editPlan = $state('free');
+	let editOverrides = $state('');
+	let saving = $state(false);
+	let savingLimits = $state(false);
+	let saveMsg = $state('');
+	let limitMsg = $state('');
+
+	function formatDate(d: string): string {
+		return new Date(d).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+	}
+
+	async function loadData() {
+		loading = true;
+		error = '';
+		try {
+			const [s, u, l] = await Promise.all([
+				adminFetch('/admin/stats'),
+				adminFetch('/admin/users'),
+				adminFetch('/admin/limits')
+			]);
+			stats = s; users = u; limits = l;
+		} catch (e) {
+			error = e instanceof Error ? e.message : 'Failed to load';
+		} finally {
+			loading = false;
+		}
+	}
+
+	async function searchUsers() {
+		try {
+			users = await adminFetch(`/admin/users?q=${encodeURIComponent(search)}`);
+		} catch { /* keep existing */ }
+	}
+
+	function selectUser(u: AdminUser) {
+		if (selectedId === u.id) { selectedId = null; return; }
+		selectedId = u.id;
+		editPlan = u.plan || 'free';
+		editOverrides = u.plan_overrides ? JSON.stringify(u.plan_overrides, null, 2) : '';
+		saveMsg = '';
+	}
+
+	async function saveUser() {
+		if (!selectedId) return;
+		saving = true;
+		saveMsg = '';
+		try {
+			let overrides: Record<string, number> | null = null;
+			if (editOverrides.trim()) {
+				overrides = JSON.parse(editOverrides);
+			}
+			await adminPatch(`/admin/users/${selectedId}`, {
+				plan: editPlan,
+				plan_overrides: overrides
+			});
+			const updated = await adminFetch(`/admin/users/${selectedId}`);
+			users = users.map((u) => u.id === selectedId ? { ...u, ...updated } : u);
+			saveMsg = 'Saved';
+		} catch (e) {
+			saveMsg = e instanceof Error ? e.message : 'Save failed';
+		} finally {
+			saving = false;
+		}
+	}
+
+	async function saveLimits() {
+		if (!limits) return;
+		savingLimits = true;
+		limitMsg = '';
+		try {
+			await adminPatch('/admin/limits', limits);
+			limitMsg = 'Saved';
+		} catch (e) {
+			limitMsg = e instanceof Error ? e.message : 'Save failed';
+		} finally {
+			savingLimits = false;
+		}
+	}
+
+	function updateLimit(tier: 'free' | 'pro', key: string, val: string) {
+		if (!limits) return;
+		const num = val.trim() === '' ? 0 : Number(val);
+		limits[tier] = { ...limits[tier], [key]: isNaN(num) ? 0 : num };
+	}
+
+	onMount(() => {
+		if (isAdmin) loadData();
+	});
+</script>
+
+<svelte:head>
+	<title>Admin - Pad</title>
+</svelte:head>
+
+<div class="admin-page">
+	{#if !isAdmin}
+		<div class="denied">Admin access required</div>
+	{:else if loading}
+		<div class="loading-msg">Loading admin data...</div>
+	{:else if error}
+		<div class="error-msg">{error}</div>
+	{:else}
+		<!-- Stats bar -->
+		{#if stats}
+			<div class="stats-bar">
+				<div class="stat">
+					<span class="stat-value">{stats.users}</span>
+					<span class="stat-label">Users</span>
+				</div>
+				{#each Object.entries(stats.users_by_plan) as [plan, count] (plan)}
+					<div class="stat">
+						<span class="stat-value">{count}</span>
+						<span class="stat-label">{plan}</span>
+					</div>
+				{/each}
+				<div class="stat">
+					<span class="stat-value">{stats.workspaces}</span>
+					<span class="stat-label">Workspaces</span>
+				</div>
+			</div>
+		{/if}
+
+		<!-- Users section -->
+		<section class="section">
+			<h2 class="section-title">Users</h2>
+			<div class="search-row">
+				<input
+					type="text"
+					class="search-input"
+					placeholder="Search users..."
+					bind:value={search}
+					onkeydown={(e) => { if (e.key === 'Enter') searchUsers(); }}
+				/>
+				<button class="btn" onclick={searchUsers}>Search</button>
+			</div>
+
+			<div class="table-wrap">
+				<table class="table">
+					<thead>
+						<tr>
+							<th>Name</th><th>Email</th><th>Plan</th><th>Created</th>
+						</tr>
+					</thead>
+					<tbody>
+						{#each users as user (user.id)}
+							<tr
+								class="user-row"
+								class:selected={selectedId === user.id}
+								onclick={() => selectUser(user)}
+							>
+								<td>{user.name || user.username}</td>
+								<td>{user.email}</td>
+								<td><span class="badge" class:pro={user.plan === 'pro'}>{user.plan || 'free'}</span></td>
+								<td class="date-cell">{formatDate(user.created_at)}</td>
+							</tr>
+							{#if selectedId === user.id}
+								<tr class="edit-row">
+									<td colspan="4">
+										<div class="edit-panel">
+											<div class="edit-field">
+												<label for="edit-plan">Plan</label>
+												<select id="edit-plan" bind:value={editPlan}>
+													<option value="free">free</option>
+													<option value="pro">pro</option>
+												</select>
+											</div>
+											<div class="edit-field">
+												<label for="edit-overrides">Plan overrides (JSON)</label>
+												<textarea id="edit-overrides" bind:value={editOverrides} rows="3" placeholder={'{"workspaces": 10}'}></textarea>
+											</div>
+											<div class="edit-actions">
+												<button class="btn primary" onclick={saveUser} disabled={saving}>
+													{saving ? 'Saving...' : 'Save'}
+												</button>
+												{#if saveMsg}<span class="save-msg">{saveMsg}</span>{/if}
+											</div>
+										</div>
+									</td>
+								</tr>
+							{/if}
+						{/each}
+					</tbody>
+				</table>
+			</div>
+		</section>
+
+		<!-- Plan Limits section -->
+		{#if limits}
+			<section class="section">
+				<h2 class="section-title">Plan Limits</h2>
+				<p class="section-desc">Use -1 for unlimited.</p>
+				<div class="table-wrap">
+					<table class="table">
+						<thead>
+							<tr><th>Feature</th><th>Free</th><th>Pro</th></tr>
+						</thead>
+						<tbody>
+							{#each LIMIT_FEATURES as feat (feat)}
+								<tr>
+									<td class="feat-label">{feat.replace(/_/g, ' ')}</td>
+									<td>
+										<input
+											type="number"
+											class="limit-input"
+											value={limits.free[feat] ?? 0}
+											oninput={(e) => updateLimit('free', feat, e.currentTarget.value)}
+										/>
+									</td>
+									<td>
+										<input
+											type="number"
+											class="limit-input"
+											value={limits.pro[feat] ?? 0}
+											oninput={(e) => updateLimit('pro', feat, e.currentTarget.value)}
+										/>
+									</td>
+								</tr>
+							{/each}
+						</tbody>
+					</table>
+				</div>
+				<div class="edit-actions">
+					<button class="btn primary" onclick={saveLimits} disabled={savingLimits}>
+						{savingLimits ? 'Saving...' : 'Save Limits'}
+					</button>
+					{#if limitMsg}<span class="save-msg">{limitMsg}</span>{/if}
+				</div>
+			</section>
+		{/if}
+	{/if}
+</div>
+
+<style>
+	.admin-page { display: flex; flex-direction: column; gap: var(--space-8); }
+
+	.denied, .loading-msg {
+		color: var(--text-muted); padding: var(--space-10) 0; text-align: center; font-size: 0.95rem;
+	}
+	.error-msg {
+		color: #ef4444; padding: var(--space-6); background: var(--bg-secondary);
+		border: 1px solid var(--border); border-radius: var(--radius);
+	}
+
+	/* Stats */
+	.stats-bar {
+		display: flex; gap: var(--space-4); flex-wrap: wrap;
+	}
+	.stat {
+		flex: 1; min-width: 120px; padding: var(--space-4) var(--space-5);
+		background: var(--bg-secondary); border: 1px solid var(--border);
+		border-radius: var(--radius-lg); display: flex; flex-direction: column; gap: var(--space-1);
+	}
+	.stat-value { font-size: 1.5rem; font-weight: 700; color: var(--text-primary); }
+	.stat-label { font-size: 0.8rem; color: var(--text-muted); text-transform: capitalize; }
+
+	/* Section */
+	.section { display: flex; flex-direction: column; gap: var(--space-4); }
+	.section-title { font-size: 1.1rem; font-weight: 600; color: var(--text-primary); }
+	.section-desc { font-size: 0.8rem; color: var(--text-muted); margin-top: calc(-1 * var(--space-2)); }
+
+	/* Search */
+	.search-row { display: flex; gap: var(--space-2); }
+	.search-input {
+		flex: 1; padding: var(--space-2) var(--space-3); background: var(--bg-secondary);
+		border: 1px solid var(--border); border-radius: var(--radius); color: var(--text-primary);
+		font-size: 0.85rem; outline: none;
+	}
+	.search-input:focus { border-color: var(--accent-blue); }
+
+	/* Buttons */
+	.btn {
+		padding: var(--space-2) var(--space-4); border-radius: var(--radius);
+		border: 1px solid var(--border); background: var(--bg-secondary); color: var(--text-secondary);
+		font-size: 0.85rem; font-weight: 500; cursor: pointer; transition: border-color 0.15s, color 0.15s;
+	}
+	.btn:hover { color: var(--text-primary); border-color: var(--text-muted); }
+	.btn.primary { background: var(--accent-blue); color: #fff; border-color: transparent; }
+	.btn.primary:hover { opacity: 0.9; }
+	.btn:disabled { opacity: 0.5; cursor: default; }
+
+	/* Table */
+	.table-wrap { overflow-x: auto; }
+	.table {
+		width: 100%; border-collapse: collapse; font-size: 0.85rem;
+	}
+	.table th {
+		text-align: left; padding: var(--space-2) var(--space-3); color: var(--text-muted);
+		font-weight: 500; border-bottom: 1px solid var(--border); font-size: 0.8rem;
+	}
+	.table td {
+		padding: var(--space-2) var(--space-3); border-bottom: 1px solid var(--border);
+		color: var(--text-secondary);
+	}
+	.user-row { cursor: pointer; transition: background 0.1s; }
+	.user-row:hover { background: var(--bg-hover); }
+	.user-row.selected { background: var(--bg-tertiary); }
+	.date-cell { white-space: nowrap; }
+
+	.badge {
+		padding: 2px var(--space-2); border-radius: var(--radius-sm); font-size: 0.75rem; font-weight: 500;
+		background: color-mix(in srgb, var(--accent-gray, #888) 15%, transparent); color: var(--text-muted);
+	}
+	.badge.pro {
+		background: color-mix(in srgb, var(--accent-blue) 15%, transparent); color: var(--accent-blue);
+	}
+
+	/* Edit panel */
+	.edit-row td { padding: 0; border-bottom: 1px solid var(--border); }
+	.edit-panel {
+		padding: var(--space-4) var(--space-3); background: var(--bg-tertiary);
+		display: flex; flex-direction: column; gap: var(--space-3);
+	}
+	.edit-field { display: flex; flex-direction: column; gap: var(--space-1); }
+	.edit-field label { font-size: 0.8rem; color: var(--text-muted); font-weight: 500; }
+	.edit-field select, .edit-field textarea {
+		padding: var(--space-2) var(--space-3); background: var(--bg-secondary); border: 1px solid var(--border);
+		border-radius: var(--radius); color: var(--text-primary); font-size: 0.85rem; font-family: inherit;
+	}
+	.edit-field textarea { resize: vertical; font-family: monospace; font-size: 0.8rem; }
+	.edit-actions { display: flex; align-items: center; gap: var(--space-3); }
+	.save-msg { font-size: 0.8rem; color: var(--text-muted); }
+
+	/* Limits */
+	.feat-label { text-transform: capitalize; color: var(--text-primary); }
+	.limit-input {
+		width: 100px; padding: var(--space-1) var(--space-2); background: var(--bg-secondary);
+		border: 1px solid var(--border); border-radius: var(--radius); color: var(--text-primary);
+		font-size: 0.85rem; outline: none;
+	}
+	.limit-input:focus { border-color: var(--accent-blue); }
+</style>

--- a/web/src/routes/console/admin/+page.svelte
+++ b/web/src/routes/console/admin/+page.svelte
@@ -4,6 +4,11 @@
 
 	const BASE = '/api/v1';
 
+	function csrfToken(): string {
+		const match = document.cookie.match(/(?:^|;\s*)pad_csrf=([^;]+)/);
+		return match?.[1] ?? '';
+	}
+
 	async function adminFetch(path: string, opts?: RequestInit) {
 		const resp = await fetch(BASE + path, { credentials: 'same-origin', ...opts });
 		if (!resp.ok) throw new Error(`${resp.status}`);
@@ -13,7 +18,7 @@
 	async function adminPatch(path: string, body: unknown) {
 		return adminFetch(path, {
 			method: 'PATCH',
-			headers: { 'Content-Type': 'application/json' },
+			headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken() },
 			body: JSON.stringify(body)
 		});
 	}
@@ -88,13 +93,14 @@
 		saving = true;
 		saveMsg = '';
 		try {
-			let overrides: Record<string, number> | null = null;
+			// Validate JSON syntax before sending
 			if (editOverrides.trim()) {
-				overrides = JSON.parse(editOverrides);
+				JSON.parse(editOverrides); // throws if invalid
 			}
+			// Backend expects plan_overrides as a JSON string, not an object
 			await adminPatch(`/admin/users/${selectedId}`, {
 				plan: editPlan,
-				plan_overrides: overrides
+				plan_overrides: editOverrides.trim() || null
 			});
 			const updated = await adminFetch(`/admin/users/${selectedId}`);
 			users = users.map((u) => u.id === selectedId ? { ...u, ...updated } : u);

--- a/web/src/routes/console/billing/+page.svelte
+++ b/web/src/routes/console/billing/+page.svelte
@@ -58,11 +58,11 @@
 			</div>
 			<div class="usage-row">
 				<span class="usage-label">Workspaces</span>
-				<span class="usage-value">{isPro ? 'Unlimited' : 'Up to 3'}</span>
+				<span class="usage-value">{isPro ? 'Unlimited' : 'Up to 5'}</span>
 			</div>
 			<div class="usage-row">
 				<span class="usage-label">Members per workspace</span>
-				<span class="usage-value">{isPro ? 'Unlimited' : 'Up to 5'}</span>
+				<span class="usage-value">{isPro ? 'Unlimited' : 'Up to 3'}</span>
 			</div>
 		</div>
 	</section>

--- a/web/src/routes/console/billing/+page.svelte
+++ b/web/src/routes/console/billing/+page.svelte
@@ -1,0 +1,208 @@
+<script lang="ts">
+	import { authStore } from '$lib/stores/auth.svelte';
+	import { goto } from '$app/navigation';
+	import { onMount } from 'svelte';
+
+	let plan = $derived(authStore.user?.plan ?? 'free');
+	let isPro = $derived(plan === 'pro');
+
+	onMount(() => {
+		if (!authStore.cloudMode) {
+			goto('/console', { replaceState: true });
+		}
+	});
+</script>
+
+<svelte:head>
+	<title>Billing - Pad</title>
+</svelte:head>
+
+<div class="billing-page">
+	<h1 class="page-title">Billing</h1>
+
+	<section class="card">
+		<h2 class="card-title">Current Plan</h2>
+		<div class="card-body">
+			<div class="plan-row">
+				<div class="plan-info">
+					<span class="plan-name">
+						{isPro ? 'Pro' : 'Free'}
+					</span>
+					<span class="plan-badge" class:pro={isPro} class:free={!isPro}>
+						{isPro ? 'Active' : 'Current'}
+					</span>
+				</div>
+				<p class="plan-desc">
+					{#if isPro}
+						You have full access to all Pad features.
+					{:else}
+						The free plan includes basic workspace management with limited features.
+					{/if}
+				</p>
+			</div>
+
+			{#if isPro}
+				<a href="/billing/portal" class="secondary-btn">Manage Billing</a>
+			{:else}
+				<a href="/billing/checkout" class="primary-btn">Upgrade to Pro</a>
+			{/if}
+		</div>
+	</section>
+
+	<section class="card">
+		<h2 class="card-title">Usage</h2>
+		<div class="card-body">
+			<div class="usage-row">
+				<span class="usage-label">Plan</span>
+				<span class="usage-value">{isPro ? 'Pro' : 'Free'}</span>
+			</div>
+			<div class="usage-row">
+				<span class="usage-label">Workspaces</span>
+				<span class="usage-value">{isPro ? 'Unlimited' : 'Up to 3'}</span>
+			</div>
+			<div class="usage-row">
+				<span class="usage-label">Members per workspace</span>
+				<span class="usage-value">{isPro ? 'Unlimited' : 'Up to 5'}</span>
+			</div>
+		</div>
+	</section>
+</div>
+
+<style>
+	.billing-page {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-6);
+		max-width: 600px;
+	}
+
+	.page-title {
+		font-size: 1.4rem;
+		font-weight: 700;
+		color: var(--text-primary);
+	}
+
+	.card {
+		background: var(--bg-secondary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius-lg);
+		overflow: hidden;
+	}
+
+	.card-title {
+		font-size: 0.95rem;
+		font-weight: 600;
+		color: var(--text-primary);
+		padding: var(--space-4) var(--space-5);
+		border-bottom: 1px solid var(--border);
+	}
+
+	.card-body {
+		padding: var(--space-5);
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-4);
+	}
+
+	.plan-row {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-2);
+	}
+
+	.plan-info {
+		display: flex;
+		align-items: center;
+		gap: var(--space-3);
+	}
+
+	.plan-name {
+		font-size: 1.1rem;
+		font-weight: 700;
+		color: var(--text-primary);
+	}
+
+	.plan-badge {
+		padding: 2px var(--space-2);
+		border-radius: var(--radius-sm);
+		font-size: 0.75rem;
+		font-weight: 500;
+	}
+
+	.plan-badge.pro {
+		background: color-mix(in srgb, var(--accent-green) 15%, transparent);
+		color: var(--accent-green);
+	}
+
+	.plan-badge.free {
+		background: color-mix(in srgb, var(--accent-gray) 15%, transparent);
+		color: var(--accent-gray);
+	}
+
+	.plan-desc {
+		color: var(--text-secondary);
+		font-size: 0.85rem;
+		line-height: 1.4;
+	}
+
+	.primary-btn {
+		display: inline-block;
+		align-self: flex-start;
+		padding: var(--space-2) var(--space-5);
+		background: var(--accent-blue);
+		color: #fff;
+		border-radius: var(--radius);
+		font-size: 0.9rem;
+		font-weight: 500;
+		text-decoration: none;
+		transition: opacity 0.15s;
+	}
+
+	.primary-btn:hover {
+		opacity: 0.9;
+		text-decoration: none;
+	}
+
+	.secondary-btn {
+		display: inline-block;
+		align-self: flex-start;
+		padding: var(--space-2) var(--space-5);
+		background: transparent;
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+		color: var(--text-secondary);
+		font-size: 0.9rem;
+		font-weight: 500;
+		text-decoration: none;
+		transition: color 0.15s, border-color 0.15s;
+	}
+
+	.secondary-btn:hover {
+		color: var(--text-primary);
+		border-color: var(--text-muted);
+		text-decoration: none;
+	}
+
+	.usage-row {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: var(--space-2) 0;
+		border-bottom: 1px solid var(--border-subtle);
+	}
+
+	.usage-row:last-child {
+		border-bottom: none;
+	}
+
+	.usage-label {
+		color: var(--text-secondary);
+		font-size: 0.85rem;
+	}
+
+	.usage-value {
+		color: var(--text-primary);
+		font-size: 0.85rem;
+		font-weight: 500;
+	}
+</style>

--- a/web/src/routes/console/new/+page.svelte
+++ b/web/src/routes/console/new/+page.svelte
@@ -1,0 +1,266 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { goto } from '$app/navigation';
+	import { api } from '$lib/api/client';
+	import { authStore } from '$lib/stores/auth.svelte';
+	import type { WorkspaceTemplate } from '$lib/types';
+
+	let name = $state('');
+	let selectedTemplate = $state('startup');
+	let templates = $state<WorkspaceTemplate[]>([]);
+	let creating = $state(false);
+	let error = $state('');
+
+	let slug = $derived(
+		name
+			.toLowerCase()
+			.replace(/[^a-z0-9\s-]/g, '')
+			.replace(/\s+/g, '-')
+			.replace(/-+/g, '-')
+			.replace(/^-|-$/g, '')
+	);
+
+	let username = $derived(authStore.user?.username ?? '');
+
+	onMount(async () => {
+		try {
+			templates = await api.templates.list();
+		} catch {
+			// Templates are optional; fall back to defaults
+			templates = [
+				{ name: 'startup', description: 'Default template for general projects', collections: [] },
+				{ name: 'scrum', description: 'Scrum-style sprints and backlogs', collections: [] },
+				{ name: 'product', description: 'Product development workflow', collections: [] }
+			];
+		}
+	});
+
+	async function handleCreate() {
+		error = '';
+		if (!name.trim()) {
+			error = 'Please enter a workspace name.';
+			return;
+		}
+
+		creating = true;
+		try {
+			const ws = await api.workspaces.create({
+				name: name.trim(),
+				template: selectedTemplate
+			});
+			const owner = ws.owner_username || username;
+			await goto(`/${owner}/${ws.slug}`, { replaceState: true });
+		} catch (err) {
+			error = err instanceof Error ? err.message : 'Failed to create workspace';
+		} finally {
+			creating = false;
+		}
+	}
+
+	function handleKeydown(event: KeyboardEvent) {
+		if (event.key === 'Enter' && !creating) {
+			handleCreate();
+		}
+	}
+</script>
+
+<svelte:head>
+	<title>New Workspace - Pad</title>
+</svelte:head>
+
+<div class="new-page">
+	<a href="/console" class="back-link">Back to workspaces</a>
+
+	<h1 class="page-title">Create a new workspace</h1>
+
+	<div class="form">
+		<div class="field">
+			<label for="ws-name">Workspace name</label>
+			<input
+				id="ws-name"
+				type="text"
+				placeholder="My Project"
+				bind:value={name}
+				onkeydown={handleKeydown}
+				disabled={creating}
+			/>
+			{#if slug}
+				<p class="slug-preview">/{username}/{slug}</p>
+			{/if}
+		</div>
+
+		<div class="field">
+			<span class="field-label">Template</span>
+			<div class="template-grid">
+				{#each templates as tmpl (tmpl.name)}
+					<button
+						class="template-option"
+						class:selected={selectedTemplate === tmpl.name}
+						onclick={() => (selectedTemplate = tmpl.name)}
+						disabled={creating}
+						type="button"
+					>
+						<span class="template-name">{tmpl.name}</span>
+						<span class="template-desc">{tmpl.description}</span>
+					</button>
+				{/each}
+			</div>
+		</div>
+
+		{#if error}
+			<p class="error">{error}</p>
+		{/if}
+
+		<button class="submit-btn" onclick={handleCreate} disabled={creating || !name.trim()}>
+			{#if creating}
+				Creating...
+			{:else}
+				Create Workspace
+			{/if}
+		</button>
+	</div>
+</div>
+
+<style>
+	.new-page {
+		max-width: 520px;
+	}
+
+	.back-link {
+		display: inline-block;
+		color: var(--text-muted);
+		font-size: 0.85rem;
+		margin-bottom: var(--space-6);
+	}
+
+	.back-link:hover {
+		color: var(--text-primary);
+	}
+
+	.page-title {
+		font-size: 1.4rem;
+		font-weight: 700;
+		color: var(--text-primary);
+		margin-bottom: var(--space-8);
+	}
+
+	.form {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-6);
+	}
+
+	.field {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-2);
+	}
+
+	label, .field-label {
+		font-size: 0.85rem;
+		font-weight: 500;
+		color: var(--text-secondary);
+	}
+
+	input {
+		padding: var(--space-3) var(--space-4);
+		background: var(--bg-tertiary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+		color: var(--text-primary);
+		font-size: 0.95rem;
+		font-family: var(--font-ui);
+		outline: none;
+		transition: border-color 0.15s;
+	}
+
+	input::placeholder {
+		color: var(--text-muted);
+	}
+
+	input:focus {
+		border-color: var(--accent-blue);
+	}
+
+	input:disabled {
+		opacity: 0.6;
+	}
+
+	.slug-preview {
+		color: var(--text-muted);
+		font-size: 0.8rem;
+		font-family: var(--font-mono);
+	}
+
+	.template-grid {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-2);
+	}
+
+	.template-option {
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+		padding: var(--space-3) var(--space-4);
+		background: var(--bg-tertiary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+		text-align: left;
+		cursor: pointer;
+		transition: border-color 0.15s;
+	}
+
+	.template-option:hover {
+		border-color: var(--text-muted);
+	}
+
+	.template-option.selected {
+		border-color: var(--accent-blue);
+		background: color-mix(in srgb, var(--accent-blue) 8%, var(--bg-tertiary));
+	}
+
+	.template-option:disabled {
+		opacity: 0.6;
+		cursor: not-allowed;
+	}
+
+	.template-name {
+		font-weight: 600;
+		font-size: 0.9rem;
+		color: var(--text-primary);
+		text-transform: capitalize;
+	}
+
+	.template-desc {
+		font-size: 0.8rem;
+		color: var(--text-muted);
+	}
+
+	.error {
+		color: #ef4444;
+		font-size: 0.85rem;
+	}
+
+	.submit-btn {
+		padding: var(--space-3) var(--space-4);
+		background: var(--accent-blue);
+		color: #fff;
+		border: none;
+		border-radius: var(--radius);
+		font-size: 0.95rem;
+		font-weight: 500;
+		font-family: var(--font-ui);
+		cursor: pointer;
+		transition: opacity 0.15s;
+	}
+
+	.submit-btn:hover:not(:disabled) {
+		opacity: 0.9;
+	}
+
+	.submit-btn:disabled {
+		opacity: 0.6;
+		cursor: not-allowed;
+	}
+</style>

--- a/web/src/routes/console/settings/+page.svelte
+++ b/web/src/routes/console/settings/+page.svelte
@@ -1,0 +1,454 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { api } from '$lib/api/client';
+	import { authStore } from '$lib/stores/auth.svelte';
+	import type { User, APIToken, APITokenWithSecret } from '$lib/types';
+
+	// Profile
+	let profile = $state<User | null>(null);
+	let profileName = $state('');
+	let profileUsername = $state('');
+	let profileSaving = $state(false);
+	let profileMsg = $state('');
+	let profileError = $state('');
+
+	// Password
+	let currentPassword = $state('');
+	let newPassword = $state('');
+	let confirmPassword = $state('');
+	let passwordSaving = $state(false);
+	let passwordMsg = $state('');
+	let passwordError = $state('');
+
+	// Tokens
+	let tokens = $state<APIToken[]>([]);
+	let newTokenName = $state('');
+	let createdToken = $state<APITokenWithSecret | null>(null);
+	let tokenCreating = $state(false);
+	let tokenError = $state('');
+
+	let loading = $state(true);
+
+	onMount(async () => {
+		try {
+			const [me, tokenList] = await Promise.all([
+				api.auth.me(),
+				api.auth.tokens.list()
+			]);
+			profile = me;
+			profileName = me.name;
+			profileUsername = me.username;
+			tokens = tokenList;
+		} catch {
+			profileError = 'Failed to load profile';
+		} finally {
+			loading = false;
+		}
+	});
+
+	async function saveProfile() {
+		profileError = '';
+		profileMsg = '';
+		profileSaving = true;
+		try {
+			const updated = await api.auth.updateProfile({
+				name: profileName.trim(),
+				username: profileUsername.trim()
+			});
+			profile = updated;
+			profileMsg = 'Profile updated.';
+			await authStore.load();
+		} catch (err) {
+			profileError = err instanceof Error ? err.message : 'Failed to update profile';
+		} finally {
+			profileSaving = false;
+		}
+	}
+
+	async function changePassword() {
+		passwordError = '';
+		passwordMsg = '';
+		if (!currentPassword || !newPassword) {
+			passwordError = 'Please fill in all password fields.';
+			return;
+		}
+		if (newPassword !== confirmPassword) {
+			passwordError = 'New passwords do not match.';
+			return;
+		}
+		if (newPassword.length < 8) {
+			passwordError = 'Password must be at least 8 characters.';
+			return;
+		}
+
+		passwordSaving = true;
+		try {
+			await api.auth.updateProfile({
+				current_password: currentPassword,
+				new_password: newPassword
+			});
+			passwordMsg = 'Password changed successfully.';
+			currentPassword = '';
+			newPassword = '';
+			confirmPassword = '';
+		} catch (err) {
+			passwordError = err instanceof Error ? err.message : 'Failed to change password';
+		} finally {
+			passwordSaving = false;
+		}
+	}
+
+	async function createToken() {
+		tokenError = '';
+		createdToken = null;
+		if (!newTokenName.trim()) {
+			tokenError = 'Please enter a token name.';
+			return;
+		}
+
+		tokenCreating = true;
+		try {
+			const token = await api.auth.tokens.create(newTokenName.trim());
+			createdToken = token;
+			tokens = [...tokens, token];
+			newTokenName = '';
+		} catch (err) {
+			tokenError = err instanceof Error ? err.message : 'Failed to create token';
+		} finally {
+			tokenCreating = false;
+		}
+	}
+
+	async function deleteToken(tokenId: string) {
+		try {
+			await api.auth.tokens.delete(tokenId);
+			tokens = tokens.filter((t) => t.id !== tokenId);
+		} catch {
+			// Silent failure acceptable for delete
+		}
+	}
+
+	function formatDate(dateStr: string): string {
+		return new Date(dateStr).toLocaleDateString('en-US', {
+			month: 'short', day: 'numeric', year: 'numeric'
+		});
+	}
+</script>
+
+<svelte:head>
+	<title>Settings - Pad</title>
+</svelte:head>
+
+<div class="settings-page">
+	<h1 class="page-title">Account Settings</h1>
+
+	{#if loading}
+		<div class="loading">Loading...</div>
+	{:else}
+		<!-- Profile -->
+		<section class="card">
+			<h2 class="card-title">Profile</h2>
+			<div class="card-body">
+				<div class="field">
+					<label for="profile-name">Name</label>
+					<input id="profile-name" type="text" bind:value={profileName} disabled={profileSaving} />
+				</div>
+				<div class="field">
+					<label for="profile-username">Username</label>
+					<input id="profile-username" type="text" bind:value={profileUsername} disabled={profileSaving} />
+				</div>
+				<div class="field">
+					<label for="profile-email">Email</label>
+					<input id="profile-email" type="email" value={profile?.email ?? ''} disabled readonly />
+				</div>
+				{#if profileError}
+					<p class="error">{profileError}</p>
+				{/if}
+				{#if profileMsg}
+					<p class="success">{profileMsg}</p>
+				{/if}
+				<button class="primary-btn" onclick={saveProfile} disabled={profileSaving}>
+					{profileSaving ? 'Saving...' : 'Save Changes'}
+				</button>
+			</div>
+		</section>
+
+		<!-- Password -->
+		<section class="card">
+			<h2 class="card-title">Password</h2>
+			<div class="card-body">
+				<div class="field">
+					<label for="current-pw">Current password</label>
+					<input id="current-pw" type="password" bind:value={currentPassword} disabled={passwordSaving} autocomplete="current-password" />
+				</div>
+				<div class="field">
+					<label for="new-pw">New password</label>
+					<input id="new-pw" type="password" bind:value={newPassword} disabled={passwordSaving} autocomplete="new-password" />
+				</div>
+				<div class="field">
+					<label for="confirm-pw">Confirm new password</label>
+					<input id="confirm-pw" type="password" bind:value={confirmPassword} disabled={passwordSaving} autocomplete="new-password" />
+				</div>
+				{#if passwordError}
+					<p class="error">{passwordError}</p>
+				{/if}
+				{#if passwordMsg}
+					<p class="success">{passwordMsg}</p>
+				{/if}
+				<button class="primary-btn" onclick={changePassword} disabled={passwordSaving}>
+					{passwordSaving ? 'Changing...' : 'Change Password'}
+				</button>
+			</div>
+		</section>
+
+		<!-- API Tokens -->
+		<section class="card">
+			<h2 class="card-title">API Tokens</h2>
+			<div class="card-body">
+				{#if createdToken}
+					<div class="token-created">
+						<p class="token-warning">Copy this token now. It will not be shown again.</p>
+						<code class="token-value">{createdToken.token}</code>
+					</div>
+				{/if}
+
+				<div class="token-create-row">
+					<input
+						type="text"
+						placeholder="Token name"
+						bind:value={newTokenName}
+						disabled={tokenCreating}
+					/>
+					<button class="primary-btn" onclick={createToken} disabled={tokenCreating || !newTokenName.trim()}>
+						{tokenCreating ? 'Creating...' : 'Create'}
+					</button>
+				</div>
+
+				{#if tokenError}
+					<p class="error">{tokenError}</p>
+				{/if}
+
+				{#if tokens.length > 0}
+					<div class="token-list">
+						{#each tokens as token (token.id)}
+							<div class="token-row">
+								<div class="token-info">
+									<span class="token-name">{token.name}</span>
+									<span class="token-meta">
+										{token.prefix}... &middot; Created {formatDate(token.created_at)}
+										{#if token.expires_at}
+											&middot; Expires {formatDate(token.expires_at)}
+										{/if}
+									</span>
+								</div>
+								<button class="delete-btn" onclick={() => deleteToken(token.id)}>Delete</button>
+							</div>
+						{/each}
+					</div>
+				{:else}
+					<p class="empty-text">No API tokens yet.</p>
+				{/if}
+			</div>
+		</section>
+	{/if}
+</div>
+
+<style>
+	.settings-page {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-6);
+		max-width: 600px;
+	}
+
+	.page-title {
+		font-size: 1.4rem;
+		font-weight: 700;
+		color: var(--text-primary);
+	}
+
+	.loading {
+		color: var(--text-muted);
+		padding: var(--space-10) 0;
+		text-align: center;
+	}
+
+	.card {
+		background: var(--bg-secondary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius-lg);
+		overflow: hidden;
+	}
+
+	.card-title {
+		font-size: 0.95rem;
+		font-weight: 600;
+		color: var(--text-primary);
+		padding: var(--space-4) var(--space-5);
+		border-bottom: 1px solid var(--border);
+	}
+
+	.card-body {
+		padding: var(--space-5);
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-4);
+	}
+
+	.field {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-1);
+	}
+
+	label {
+		font-size: 0.8rem;
+		font-weight: 500;
+		color: var(--text-muted);
+	}
+
+	input {
+		padding: var(--space-2) var(--space-3);
+		background: var(--bg-tertiary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+		color: var(--text-primary);
+		font-size: 0.9rem;
+		font-family: var(--font-ui);
+		outline: none;
+		transition: border-color 0.15s;
+	}
+
+	input:focus {
+		border-color: var(--accent-blue);
+	}
+
+	input:disabled {
+		opacity: 0.6;
+	}
+
+	input[readonly] {
+		color: var(--text-muted);
+		cursor: not-allowed;
+	}
+
+	.error {
+		color: #ef4444;
+		font-size: 0.85rem;
+	}
+
+	.success {
+		color: var(--accent-green);
+		font-size: 0.85rem;
+	}
+
+	.primary-btn {
+		align-self: flex-start;
+		padding: var(--space-2) var(--space-4);
+		background: var(--accent-blue);
+		color: #fff;
+		border: none;
+		border-radius: var(--radius);
+		font-size: 0.85rem;
+		font-weight: 500;
+		font-family: var(--font-ui);
+		cursor: pointer;
+		transition: opacity 0.15s;
+	}
+
+	.primary-btn:hover:not(:disabled) {
+		opacity: 0.9;
+	}
+
+	.primary-btn:disabled {
+		opacity: 0.6;
+		cursor: not-allowed;
+	}
+
+	.token-created {
+		padding: var(--space-3) var(--space-4);
+		background: color-mix(in srgb, var(--accent-green) 10%, var(--bg-tertiary));
+		border: 1px solid color-mix(in srgb, var(--accent-green) 30%, transparent);
+		border-radius: var(--radius);
+	}
+
+	.token-warning {
+		font-size: 0.8rem;
+		font-weight: 500;
+		color: var(--accent-green);
+		margin-bottom: var(--space-2);
+	}
+
+	.token-value {
+		display: block;
+		font-family: var(--font-mono);
+		font-size: 0.8rem;
+		color: var(--text-primary);
+		word-break: break-all;
+	}
+
+	.token-create-row {
+		display: flex;
+		gap: var(--space-2);
+	}
+
+	.token-create-row input {
+		flex: 1;
+	}
+
+	.token-list {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-2);
+	}
+
+	.token-row {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: var(--space-3);
+		padding: var(--space-3) var(--space-4);
+		background: var(--bg-tertiary);
+		border-radius: var(--radius);
+	}
+
+	.token-info {
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+		min-width: 0;
+	}
+
+	.token-name {
+		font-weight: 500;
+		font-size: 0.85rem;
+		color: var(--text-primary);
+	}
+
+	.token-meta {
+		font-size: 0.75rem;
+		color: var(--text-muted);
+	}
+
+	.delete-btn {
+		padding: var(--space-1) var(--space-3);
+		background: transparent;
+		border: 1px solid var(--border);
+		border-radius: var(--radius-sm);
+		color: var(--text-muted);
+		font-size: 0.75rem;
+		cursor: pointer;
+		flex-shrink: 0;
+		transition: color 0.15s, border-color 0.15s;
+	}
+
+	.delete-btn:hover {
+		color: #ef4444;
+		border-color: #ef4444;
+	}
+
+	.empty-text {
+		color: var(--text-muted);
+		font-size: 0.85rem;
+	}
+</style>

--- a/web/src/routes/login/+page.svelte
+++ b/web/src/routes/login/+page.svelte
@@ -12,6 +12,7 @@
 	let setupMethod = $state<'local_cli' | 'docker_exec' | 'cloud' | undefined>(undefined);
 	let loading = $state(false);
 
+	let cloudMode = $state(false);
 	let step = $state<'credentials' | '2fa'>('credentials');
 	let challengeToken = $state('');
 	let totpCode = $state('');
@@ -19,6 +20,7 @@
 	onMount(async () => {
 		try {
 			const session = await api.auth.session();
+			cloudMode = session.cloud_mode ?? false;
 			if (session.setup_required) {
 				setupRequired = true;
 				setupMethod = session.setup_method;
@@ -191,12 +193,35 @@
 				</button>
 			</div>
 
+			{#if cloudMode}
+				<div class="oauth-divider">
+					<span>or</span>
+				</div>
+
+				<div class="oauth-buttons">
+					<a href="/auth/github" class="oauth-btn oauth-github">
+						<svg width="18" height="18" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
+						Continue with GitHub
+					</a>
+					<a href="/auth/google" class="oauth-btn oauth-google">
+						<svg width="18" height="18" viewBox="0 0 18 18" fill="none"><path d="M17.64 9.2c0-.637-.057-1.251-.164-1.84H9v3.481h4.844a4.14 4.14 0 01-1.796 2.716v2.259h2.908c1.702-1.567 2.684-3.875 2.684-6.615z" fill="#4285F4"/><path d="M9 18c2.43 0 4.467-.806 5.956-2.18l-2.908-2.259c-.806.54-1.837.86-3.048.86-2.344 0-4.328-1.584-5.036-3.711H.957v2.332A8.997 8.997 0 009 18z" fill="#34A853"/><path d="M3.964 10.71A5.41 5.41 0 013.682 9c0-.593.102-1.17.282-1.71V4.958H.957A8.996 8.996 0 000 9c0 1.452.348 2.827.957 4.042l3.007-2.332z" fill="#FBBC05"/><path d="M9 3.58c1.321 0 2.508.454 3.44 1.345l2.582-2.58C13.463.891 11.426 0 9 0A8.997 8.997 0 00.957 4.958L3.964 7.29C4.672 5.163 6.656 3.58 9 3.58z" fill="#EA4335"/></svg>
+						Continue with Google
+					</a>
+				</div>
+			{/if}
+
 			<p class="register-link">
 				<a href="/forgot-password">Forgot password?</a>
 			</p>
-			<p class="register-link">
-				Need an account? Ask your admin for an invitation link.
-			</p>
+			{#if cloudMode}
+				<p class="register-link">
+					Don't have an account? <a href="/register">Sign up</a>
+				</p>
+			{:else}
+				<p class="register-link">
+					Need an account? Ask your admin for an invitation link.
+				</p>
+			{/if}
 		{/if}
 	</div>
 </div>
@@ -328,5 +353,65 @@
 
 	.register-link a:hover {
 		text-decoration: underline;
+	}
+
+	.oauth-divider {
+		display: flex;
+		align-items: center;
+		gap: var(--space-4);
+		margin: var(--space-6) 0;
+		color: var(--text-muted);
+		font-size: 0.8rem;
+	}
+
+	.oauth-divider::before,
+	.oauth-divider::after {
+		content: '';
+		flex: 1;
+		height: 1px;
+		background: var(--border);
+	}
+
+	.oauth-buttons {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-3);
+	}
+
+	.oauth-btn {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		gap: var(--space-3);
+		width: 100%;
+		padding: var(--space-3) var(--space-4);
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+		font-size: 0.9rem;
+		font-weight: 500;
+		font-family: var(--font-ui);
+		text-decoration: none;
+		cursor: pointer;
+		transition: background 0.15s, border-color 0.15s;
+	}
+
+	.oauth-github {
+		background: var(--bg-tertiary);
+		color: var(--text-primary);
+	}
+
+	.oauth-github:hover {
+		background: var(--bg-hover);
+		border-color: var(--text-muted);
+	}
+
+	.oauth-google {
+		background: var(--bg-tertiary);
+		color: var(--text-primary);
+	}
+
+	.oauth-google:hover {
+		background: var(--bg-hover);
+		border-color: var(--text-muted);
 	}
 </style>


### PR DESCRIPTION
## Summary

Adds the foundation for running Pad as a hosted service at `app.getpad.dev`. Same binary in cloud mode (`PAD_CLOUD=true`) with a thin sidecar (`pad-cloud`) handling OAuth and Stripe.

- **Cloud mode flag** with cloud secret for sidecar ↔ Pad communication, rotation support
- **Account-level billing** — plan field on users, Free/Pro tiers, configurable limits with three-tier resolution (user overrides → DB defaults → hardcoded fallback)
- **Plan enforcement** on workspace, item, member, webhook, and API token creation endpoints
- **OAuth login endpoint** (`POST /api/v1/auth/oauth-login`) — cloud-secret gated, verified email required, 2FA bypass protection
- **TOTP encryption at rest** — AES-256-GCM via `PAD_ENCRYPTION_KEY`, auto-migration of plaintext secrets
- **Admin dashboard** — user management, plan overrides, configurable limits editor, platform stats
- **GDPR endpoints** — account deletion (`POST /api/v1/auth/delete-account`) and data export (`GET /api/v1/auth/export`)
- **Console UI** — `/console` (workspace list), `/console/new` (create wizard), `/console/settings` (profile/password/tokens), `/console/billing` (plan status), `/console/admin` (user management)
- **Login OAuth buttons** — GitHub/Google buttons shown in cloud mode
- **Security hardening** — rate limiting on OAuth, bootstrap disabled in cloud mode, password max length, config file 0600 permissions

### Companion repo
The `pad-cloud` sidecar (separate repo at `../pad-cloud`) handles OAuth provider flows (GitHub/Google), Stripe checkout/portal/webhooks, and deployment config (Docker Compose, Caddy, Litestream).

### Follow-up items (PLAN-503)
A security review identified items for the next phase:
- Stripe customer-to-user mapping for subscription lifecycle (critical, pre-payment)
- OAuth provider linking with explicit account authorization (high)
- Admin CSRF token attachment, sidecar rate limiting, `__Host-` cookie prefix

## Test plan
- [x] All Go tests pass (`go test ./...` — 12 packages, 0 failures)
- [x] Web UI builds (`npm run build`)
- [x] Server starts and serves health endpoint with `cloud_mode: false`
- [x] Migration 035 applies cleanly (plan fields on users table)
- [x] TOTP encryption round-trip test passes
- [x] Rate limiting test passes with OAuth endpoint coverage
- [ ] Manual: test OAuth flow end-to-end with pad-cloud sidecar
- [ ] Manual: test Console UI pages at /console/*
- [ ] Manual: test admin dashboard at /console/admin