### PR TITLE
feat: console navigation, PostgreSQL CI, and operational improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,44 @@ jobs:
       - name: Verify binary runs
         run: ./pad --help
 
+  go-postgres:
+    name: Go (PostgreSQL)
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:17-alpine
+        env:
+          POSTGRES_USER: pad
+          POSTGRES_PASSWORD: pad
+          POSTGRES_DB: pad
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U pad"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.25"
+
+      - name: Create web build placeholder for embed
+        run: mkdir -p web/build && echo "placeholder" > web/build/.gitkeep
+
+      - name: Run tests against PostgreSQL
+        env:
+          PAD_TEST_POSTGRES_URL: "postgres://pad:pad@localhost:5432/pad?sslmode=disable"
+        run: go test ./... -count=1
+
+      - name: Run tests with race detector against PostgreSQL
+        if: github.ref == 'refs/heads/main'
+        env:
+          PAD_TEST_POSTGRES_URL: "postgres://pad:pad@localhost:5432/pad?sslmode=disable"
+        run: go test -race ./... -count=1
+
   web:
     name: Web
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,42 @@
+<!-- headroom:rtk-instructions -->
+# RTK (Rust Token Killer) - Token-Optimized Commands
+
+When running shell commands, **always prefix with `rtk`**. This reduces context
+usage by 60-90% with zero behavior change. If rtk has no filter for a command,
+it passes through unchanged — so it is always safe to use.
+
+## Key Commands
+```bash
+# Git (59-80% savings)
+rtk git status          rtk git diff            rtk git log
+
+# Files & Search (60-75% savings)
+rtk ls <path>           rtk read <file>         rtk grep <pattern>
+rtk find <pattern>      rtk diff <file>
+
+# Test (90-99% savings) — shows failures only
+rtk pytest tests/       rtk cargo test          rtk test <cmd>
+
+# Build & Lint (80-90% savings) — shows errors only
+rtk tsc                 rtk lint                rtk cargo build
+rtk prettier --check    rtk mypy                rtk ruff check
+
+# Analysis (70-90% savings)
+rtk err <cmd>           rtk log <file>          rtk json <file>
+rtk summary <cmd>       rtk deps                rtk env
+
+# GitHub (26-87% savings)
+rtk gh pr view <n>      rtk gh run list         rtk gh issue list
+
+# Infrastructure (85% savings)
+rtk docker ps           rtk kubectl get         rtk docker logs <c>
+
+# Package managers (70-90% savings)
+rtk pip list            rtk pnpm install        rtk npm run <script>
+```
+
+## Rules
+- In command chains, prefix each segment: `rtk git add . && rtk git commit -m "msg"`
+- For debugging, use raw command without rtk prefix
+- `rtk proxy <cmd>` runs command without filtering but tracks usage
+<!-- /headroom:rtk-instructions -->

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test dev clean web dev-web serve restart lint install
+.PHONY: build test test-pg test-pg-down dev clean web dev-web serve restart lint install
 
 BINARY=pad
 BUILD_DIR=./cmd/pad
@@ -30,6 +30,16 @@ install: build
 
 test:
 	go test ./... -v
+
+# Run tests against PostgreSQL (starts a container automatically).
+# Uses port 5445 to avoid conflicts with any local PostgreSQL.
+test-pg:
+	docker compose -f docker-compose.test.yml up -d --wait
+	PAD_TEST_POSTGRES_URL="postgres://pad:pad@localhost:5445/pad?sslmode=disable" go test ./... -v -count=1
+	docker compose -f docker-compose.test.yml down -v
+
+test-pg-down:
+	docker compose -f docker-compose.test.yml down -v
 
 dev: build-go
 	./$(BINARY) server start --host $(HOST)

--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,10 @@ test:
 # Uses port 5445 to avoid conflicts with any local PostgreSQL.
 test-pg:
 	docker compose -f docker-compose.test.yml up -d --wait
-	PAD_TEST_POSTGRES_URL="postgres://pad:pad@localhost:5445/pad?sslmode=disable" go test ./... -v -count=1
-	docker compose -f docker-compose.test.yml down -v
+	PAD_TEST_POSTGRES_URL="postgres://pad:pad@localhost:5445/pad?sslmode=disable" go test ./... -v -count=1; \
+		EXIT_CODE=$$?; \
+		docker compose -f docker-compose.test.yml down -v; \
+		exit $$EXIT_CODE
 
 test-pg-down:
 	docker compose -f docker-compose.test.yml down -v

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,21 @@
+# PostgreSQL for integration tests.
+# Usage: docker compose -f docker-compose.test.yml up -d
+#        make test-pg
+#        docker compose -f docker-compose.test.yml down -v
+
+services:
+  postgres:
+    image: postgres:17-alpine
+    environment:
+      POSTGRES_USER: pad
+      POSTGRES_PASSWORD: pad
+      POSTGRES_DB: pad
+    ports:
+      - "5445:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U pad"]
+      interval: 2s
+      timeout: 2s
+      retries: 10
+    tmpfs:
+      - /var/lib/postgresql/data  # RAM-backed for speed

--- a/internal/server/handlers_workspaces.go
+++ b/internal/server/handlers_workspaces.go
@@ -89,7 +89,21 @@ func (s *Server) handleHealthReady(w http.ResponseWriter, r *http.Request) {
 		})
 		return
 	}
-	writeJSON(w, http.StatusOK, map[string]string{"status": "ready"})
+
+	resp := map[string]interface{}{
+		"status": "ready",
+	}
+
+	// Include connection pool stats (useful for debugging, not required for pass/fail).
+	dbStats := s.store.DB().Stats()
+	resp["db"] = map[string]interface{}{
+		"open_connections": dbStats.OpenConnections,
+		"in_use":           dbStats.InUse,
+		"idle":             dbStats.Idle,
+		"driver":           string(s.store.D().Driver()),
+	}
+
+	writeJSON(w, http.StatusOK, resp)
 }
 
 func (s *Server) handleListTemplates(w http.ResponseWriter, r *http.Request) {

--- a/internal/store/api_tokens_test.go
+++ b/internal/store/api_tokens_test.go
@@ -113,7 +113,7 @@ func TestValidateTokenExpired(t *testing.T) {
 	}
 
 	// Manually expire it
-	_, err = s.db.Exec("UPDATE api_tokens SET expires_at = '2020-01-01T00:00:00Z' WHERE id = ?", tok.ID)
+	_, err = s.db.Exec(s.q("UPDATE api_tokens SET expires_at = '2020-01-01T00:00:00Z' WHERE id = ?"), tok.ID)
 	if err != nil {
 		t.Fatalf("manual expire error: %v", err)
 	}

--- a/internal/store/bench_concurrent_test.go
+++ b/internal/store/bench_concurrent_test.go
@@ -1,0 +1,256 @@
+package store
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/xarmian/pad/internal/models"
+)
+
+// TestConcurrentWritePerformance measures how each backend handles concurrent
+// writers. SQLite serializes writes (SQLITE_BUSY under contention); PostgreSQL
+// supports true concurrent writes. This test quantifies the difference.
+//
+// Runs against both SQLite and PostgreSQL (when PAD_TEST_POSTGRES_URL is set).
+func TestConcurrentWritePerformance(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping load test in short mode")
+	}
+
+	pgURL := os.Getenv("PAD_TEST_POSTGRES_URL")
+
+	// Always test SQLite.
+	t.Run("SQLite", func(t *testing.T) {
+		dir := t.TempDir()
+		s, err := New(filepath.Join(dir, "test.db"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer s.Close()
+		runConcurrentWriteTest(t, s, "SQLite")
+	})
+
+	// Test PostgreSQL if available.
+	if pgURL != "" {
+		t.Run("PostgreSQL", func(t *testing.T) {
+			s := testStorePostgres(t, pgURL)
+			runConcurrentWriteTest(t, s, "PostgreSQL")
+		})
+	}
+}
+
+func runConcurrentWriteTest(t *testing.T, s *Store, label string) {
+	t.Helper()
+
+	// Seed a workspace + collection.
+	ws, err := s.CreateWorkspace(models.WorkspaceCreate{Name: "loadtest"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	coll, err := s.CreateCollection(ws.ID, models.CollectionCreate{
+		Name:   "Tasks",
+		Schema: `{"fields":[{"key":"status","label":"Status","type":"select","options":["open","done"],"default":"open","required":true}]}`,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	concurrencyLevels := []int{1, 5, 10, 25, 50}
+	opsPerWorker := 10
+
+	t.Logf("\n%s — Concurrent Write Performance", label)
+	t.Logf("%-12s | %-8s | %-10s | %-10s | %-10s | %s", "Workers", "Total", "Errors", "Throughput", "Avg", "p95")
+	t.Logf("%-12s-+%-10s+%-12s+%-12s+%-12s+%s", "------------", "----------", "------------", "------------", "------------", "----------")
+
+	for _, workers := range concurrencyLevels {
+		var (
+			wg        sync.WaitGroup
+			errors    atomic.Int64
+			latencies = make([]time.Duration, 0, workers*opsPerWorker)
+			mu        sync.Mutex
+		)
+
+		start := time.Now()
+
+		for w := 0; w < workers; w++ {
+			wg.Add(1)
+			go func(workerID int) {
+				defer wg.Done()
+				for i := 0; i < opsPerWorker; i++ {
+					opStart := time.Now()
+					title := fmt.Sprintf("Worker %d Item %d", workerID, i)
+					_, err := s.CreateItem(ws.ID, coll.ID, models.ItemCreate{
+						Title:   title,
+						Content: fmt.Sprintf("Content for %s — testing concurrent writes.", title),
+						Fields:  `{"status":"open"}`,
+					})
+					elapsed := time.Since(opStart)
+
+					mu.Lock()
+					latencies = append(latencies, elapsed)
+					mu.Unlock()
+
+					if err != nil {
+						errors.Add(1)
+						mu.Lock()
+						if errors.Load() <= 3 {
+							t.Logf("  [worker %d] error: %v", workerID, err)
+						}
+						mu.Unlock()
+					}
+				}
+			}(w)
+		}
+
+		wg.Wait()
+		totalTime := time.Since(start)
+		totalOps := workers * opsPerWorker
+		errCount := errors.Load()
+		throughput := float64(totalOps) / totalTime.Seconds()
+
+		// Calculate avg and p95.
+		avg := avgDuration(latencies)
+		p95 := percentileDuration(latencies, 0.95)
+
+		t.Logf("%-12d | %-8d | %-10d | %-10.1f/s | %-10s | %s",
+			workers, totalOps, errCount, throughput, avg.Truncate(time.Microsecond), p95.Truncate(time.Microsecond))
+
+		if errCount > 0 && label == "PostgreSQL" {
+			t.Errorf("PostgreSQL had %d errors with %d concurrent writers — should handle this cleanly", errCount, workers)
+		}
+	}
+}
+
+func avgDuration(durations []time.Duration) time.Duration {
+	if len(durations) == 0 {
+		return 0
+	}
+	var total time.Duration
+	for _, d := range durations {
+		total += d
+	}
+	return total / time.Duration(len(durations))
+}
+
+func percentileDuration(durations []time.Duration, p float64) time.Duration {
+	if len(durations) == 0 {
+		return 0
+	}
+	// Simple sort-based percentile (good enough for test sizes).
+	sorted := make([]time.Duration, len(durations))
+	copy(sorted, durations)
+	// Insertion sort — small slices.
+	for i := 1; i < len(sorted); i++ {
+		key := sorted[i]
+		j := i - 1
+		for j >= 0 && sorted[j] > key {
+			sorted[j+1] = sorted[j]
+			j--
+		}
+		sorted[j+1] = key
+	}
+	idx := int(float64(len(sorted)-1) * p)
+	return sorted[idx]
+}
+
+// TestConcurrentMixedReadWrite simulates a realistic workload: mostly reads with
+// some writes, to check for contention under typical usage patterns.
+func TestConcurrentMixedReadWrite(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping load test in short mode")
+	}
+
+	s := testStore(t)
+
+	// Seed initial data.
+	ws, err := s.CreateWorkspace(models.WorkspaceCreate{Name: "mixed-load"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	coll, err := s.CreateCollection(ws.ID, models.CollectionCreate{
+		Name:   "Tasks",
+		Schema: `{"fields":[{"key":"status","label":"Status","type":"select","options":["open","done"],"default":"open","required":true}]}`,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Pre-seed 50 items.
+	for i := 0; i < 50; i++ {
+		s.CreateItem(ws.ID, coll.ID, models.ItemCreate{
+			Title:   fmt.Sprintf("Seed Item %d", i),
+			Content: "Seeded content for mixed workload test.",
+			Fields:  `{"status":"open"}`,
+		})
+	}
+
+	const (
+		readers    = 20
+		writers    = 5
+		opsPerUser = 20
+		duration   = 3 * time.Second
+	)
+
+	var (
+		readOps, writeOps     atomic.Int64
+		readErrs, writeErrs   atomic.Int64
+		wg                    sync.WaitGroup
+	)
+
+	deadline := time.Now().Add(duration)
+
+	// Readers: list items.
+	for r := 0; r < readers; r++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for time.Now().Before(deadline) {
+				_, err := s.ListItems(ws.ID, models.ItemListParams{Limit: 20})
+				readOps.Add(1)
+				if err != nil {
+					readErrs.Add(1)
+				}
+			}
+		}()
+	}
+
+	// Writers: create items.
+	for w := 0; w < writers; w++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			i := 0
+			for time.Now().Before(deadline) {
+				_, err := s.CreateItem(ws.ID, coll.ID, models.ItemCreate{
+					Title:   fmt.Sprintf("Mixed Writer %d Item %d", id, i),
+					Content: "Content from mixed workload writer.",
+					Fields:  `{"status":"open"}`,
+				})
+				writeOps.Add(1)
+				if err != nil {
+					writeErrs.Add(1)
+				}
+				i++
+			}
+		}(w)
+	}
+
+	wg.Wait()
+
+	driver := string(s.D().Driver())
+	t.Logf("\n%s — Mixed Read/Write (%d readers, %d writers, %s)", driver, readers, writers, duration)
+	t.Logf("  Reads:  %d ops (%d errors)", readOps.Load(), readErrs.Load())
+	t.Logf("  Writes: %d ops (%d errors)", writeOps.Load(), writeErrs.Load())
+	t.Logf("  Read throughput:  %.0f ops/s", float64(readOps.Load())/duration.Seconds())
+	t.Logf("  Write throughput: %.0f ops/s", float64(writeOps.Load())/duration.Seconds())
+
+	// PostgreSQL should have zero errors.
+	if driver == "postgres" && (readErrs.Load() > 0 || writeErrs.Load() > 0) {
+		t.Errorf("PostgreSQL had errors under mixed workload: %d read, %d write", readErrs.Load(), writeErrs.Load())
+	}
+}

--- a/internal/store/encryption_test.go
+++ b/internal/store/encryption_test.go
@@ -130,7 +130,7 @@ func TestTOTPEncryptionRoundTrip(t *testing.T) {
 
 	// Verify the raw value in DB is encrypted
 	var rawSecret string
-	s.db.QueryRow("SELECT totp_secret FROM users WHERE id = ?", u.ID).Scan(&rawSecret)
+	s.db.QueryRow(s.q("SELECT totp_secret FROM users WHERE id = ?"), u.ID).Scan(&rawSecret)
 	if rawSecret == secret {
 		t.Error("raw DB value should be encrypted, not plaintext")
 	}

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -59,7 +59,7 @@ func (s *Store) validateAssignmentScope(workspaceID string, assignedUserID, agen
 
 // maxItemNumberRetries is the number of times CreateItem will retry when a
 // concurrent insert claims the same workspace-global item_number.
-const maxItemNumberRetries = 3
+const maxItemNumberRetries = 10
 
 func (s *Store) CreateItem(workspaceID, collectionID string, input models.ItemCreate) (*models.Item, error) {
 	// Validate assignment scope before writing
@@ -113,7 +113,9 @@ func (s *Store) CreateItem(workspaceID, collectionID string, input models.ItemCr
 }
 
 // tryCreateItem attempts a single transactional insert of an item with the
-// next available workspace-global item_number.
+// next available workspace-global item_number. The item_number is computed
+// atomically via a subquery in the INSERT to avoid races between concurrent
+// inserts reading the same MAX(item_number).
 func (s *Store) tryCreateItem(id, workspaceID, collectionID, slug, ts, fields, tags, createdBy, source string, input models.ItemCreate) error {
 	tx, err := s.db.Begin()
 	if err != nil {
@@ -121,21 +123,30 @@ func (s *Store) tryCreateItem(id, workspaceID, collectionID, slug, ts, fields, t
 	}
 	defer tx.Rollback()
 
-	// Assign the next item_number within this workspace (global counter)
-	var nextNum int
-	err = tx.QueryRow(s.q("SELECT COALESCE(MAX(item_number), 0) + 1 FROM items WHERE workspace_id = ?"), workspaceID).Scan(&nextNum)
-	if err != nil {
-		return fmt.Errorf("get next item number: %w", err)
+	// PostgreSQL: take an advisory lock keyed on the workspace to serialize
+	// item_number assignment. This eliminates the race between concurrent
+	// transactions reading the same MAX(item_number). The lock is released
+	// automatically when the transaction commits or rolls back.
+	// SQLite: single-writer by design, no advisory locks needed.
+	if s.dialect.Driver() == DriverPostgres {
+		// Use a hash of the workspace ID as the advisory lock key.
+		_, err = tx.Exec("SELECT pg_advisory_xact_lock(hashtext($1))", workspaceID)
+		if err != nil {
+			return fmt.Errorf("advisory lock: %w", err)
+		}
 	}
 
+	// Compute and insert the next item_number atomically within the lock.
 	_, err = tx.Exec(s.q(`
 		INSERT INTO items (id, workspace_id, collection_id, title, slug, content, fields, tags,
 		                   pinned, sort_order, parent_id, assigned_user_id, agent_role_id, role_sort_order,
 		                   created_by, last_modified_by, source, item_number, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?, ?, 0, ?, ?, ?, ?, ?, ?)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?, ?, 0, ?, ?, ?,
+		        (SELECT COALESCE(MAX(item_number), 0) + 1 FROM items WHERE workspace_id = ?),
+		        ?, ?)
 	`), id, workspaceID, collectionID, input.Title, slug, input.Content, fields, tags,
 		s.dialect.BoolToInt(input.Pinned), input.ParentID, input.AssignedUserID, input.AgentRoleID,
-		createdBy, createdBy, source, nextNum, ts, ts)
+		createdBy, createdBy, source, workspaceID, ts, ts)
 	if err != nil {
 		return err
 	}
@@ -653,8 +664,10 @@ func (s *Store) listItemsFTS(workspaceID string, params models.ItemListParams) (
 
 	// SQLite bm25(): more negative = more relevant → ASC (default).
 	// PostgreSQL ts_rank(): higher = more relevant → DESC.
+	// PostgreSQL FTSRank embeds a plainto_tsquery(?) that needs the search term.
 	if s.dialect.Driver() == DriverPostgres {
 		query += " ORDER BY " + ftsRank + " DESC"
+		args = append(args, params.Search)
 	} else {
 		query += " ORDER BY " + ftsRank
 	}

--- a/internal/store/search_quality_test.go
+++ b/internal/store/search_quality_test.go
@@ -1,0 +1,249 @@
+package store
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/xarmian/pad/internal/models"
+)
+
+// TestSearchQualityComparison seeds identical data into both SQLite and PostgreSQL,
+// runs the same queries against each, and reports ranking differences.
+// This test requires PAD_TEST_POSTGRES_URL to be set — otherwise it skips.
+func TestSearchQualityComparison(t *testing.T) {
+	pgURL := os.Getenv("PAD_TEST_POSTGRES_URL")
+	if pgURL == "" {
+		t.Skip("PAD_TEST_POSTGRES_URL not set — skipping search quality comparison")
+	}
+
+	// --- Set up both stores ---
+	dir := t.TempDir()
+	sqliteStore, err := New(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatalf("create sqlite store: %v", err)
+	}
+	t.Cleanup(func() { sqliteStore.Close() })
+
+	pgStore := testStorePostgres(t, pgURL)
+
+	// --- Seed identical data in both ---
+	type testItem struct {
+		title   string
+		content string
+	}
+
+	items := []testItem{
+		{"OAuth redirect bug", "The OAuth redirect URL is not being set correctly when using GitHub as the provider. Users get a 404 after login."},
+		{"Add Google OAuth support", "Implement Google OAuth as a second login provider alongside GitHub. Need to register app in Google Cloud Console."},
+		{"Fix database connection pooling", "Under high load the database connections are being exhausted. Need to tune pool settings and add connection limits."},
+		{"API rate limiting", "Add rate limiting to public API endpoints to prevent abuse. Consider using a token bucket algorithm."},
+		{"Redesign dashboard layout", "The current dashboard is cluttered. Proposal: move stats to sidebar, make the main area a kanban board."},
+		{"WebSocket support for real-time updates", "Replace SSE with WebSocket for bidirectional communication. This would enable collaborative editing features."},
+		{"Implement full-text search", "Add FTS to items and documents. SQLite has FTS5, PostgreSQL has tsvector. Need an abstraction layer."},
+		{"CI/CD pipeline improvements", "Add parallel test execution, Docker layer caching, and automatic deployment to staging on PR merge."},
+		{"User permissions and roles", "Implement RBAC with owner/editor/viewer roles per workspace. Need middleware for permission checks."},
+		{"Stripe billing integration", "Add Stripe for subscription billing. Need checkout flow, webhook handler, and plan enforcement."},
+		{"Mobile responsive design", "The web UI breaks on screens smaller than 768px. Need responsive CSS and touch-friendly interactions."},
+		{"PostgreSQL migration", "Migrate from SQLite to PostgreSQL for cloud deployment. Need dialect abstraction and separate migration files."},
+		{"Email notification system", "Send transactional emails for workspace invitations, password resets, and weekly digest summaries."},
+		{"Kubernetes deployment manifests", "Create K8s manifests: Deployment, Service, Ingress, ConfigMap, Secret, PVC for PostgreSQL."},
+		{"Dark mode theme", "Add a dark mode toggle. Use CSS custom properties for theming. Persist preference in localStorage."},
+		{"Export data to CSV and JSON", "Allow users to export collection items as CSV or JSON. Support filtering and field selection."},
+		{"Webhook delivery improvements", "Add retry logic with exponential backoff, delivery status tracking, and dead letter queue."},
+		{"Two-factor authentication", "Implement TOTP-based 2FA with QR code setup, recovery codes, and enforcement policies."},
+		{"API documentation with OpenAPI", "Generate OpenAPI spec from handler annotations. Serve Swagger UI at /docs."},
+		{"Performance profiling and optimization", "Profile the hot paths: item list queries, FTS search, and dashboard aggregation. Target p95 < 100ms."},
+	}
+
+	// Create workspace + collection in both stores.
+	stores := map[string]*Store{"sqlite": sqliteStore, "postgres": pgStore}
+	wsIDs := map[string]string{}
+	collIDs := map[string]string{}
+
+	for name, s := range stores {
+		ws, err := s.CreateWorkspace(models.WorkspaceCreate{Name: "test-ws"})
+		if err != nil {
+			t.Fatalf("[%s] create workspace: %v", name, err)
+		}
+		wsIDs[name] = ws.ID
+
+		coll, err := s.CreateCollection(ws.ID, models.CollectionCreate{
+			Name: "Tasks",
+			Schema: `{"fields":[{"key":"status","label":"Status","type":"select","options":["open","done"],"default":"open","required":true},{"key":"priority","label":"Priority","type":"select","options":["low","medium","high"]}]}`,
+		})
+		if err != nil {
+			t.Fatalf("[%s] create collection: %v", name, err)
+		}
+		collIDs[name] = coll.ID
+
+		for _, item := range items {
+			_, err := s.CreateItem(ws.ID, coll.ID, models.ItemCreate{
+				Title:   item.title,
+				Content: item.content,
+				Fields:  `{"status":"open","priority":"medium"}`,
+			})
+			if err != nil {
+				t.Fatalf("[%s] create item %q: %v", name, item.title, err)
+			}
+		}
+	}
+
+	// --- Run search queries and compare ---
+	queries := []struct {
+		query       string
+		expectTitle string // The title we most expect in the top results
+		hyphenated  bool   // SQLite FTS5 treats hyphens as NOT operator — these may error on SQLite
+	}{
+		{"OAuth", "OAuth redirect bug", false},
+		{"database connection", "Fix database connection pooling", false},
+		{"PostgreSQL migration", "PostgreSQL migration", false},
+		{"rate limiting", "API rate limiting", false},
+		{"billing stripe", "Stripe billing integration", false},
+		{"full text search", "Implement full-text search", false},
+		{"dark mode", "Dark mode theme", false},
+		{"two factor authentication", "Two-factor authentication", false},
+		{"real time updates", "WebSocket support for real-time updates", false},
+		{"Kubernetes deployment", "Kubernetes deployment manifests", false},
+		{"email notification", "Email notification system", false},
+		{"webhook retry", "Webhook delivery improvements", false},
+		{"dashboard", "Redesign dashboard layout", false},
+		{"permissions roles", "User permissions and roles", false},
+		{"performance optimization", "Performance profiling and optimization", false},
+	}
+
+	t.Logf("\n%-35s | %-8s | %-8s | %s", "Query", "SQLite#1", "PG #1", "Match?")
+	t.Logf("%-35s-+%-10s+%-10s+%s", "-----------------------------------", "----------", "----------", "------")
+
+	mismatches := 0
+	pgMissing := 0
+
+	for _, q := range queries {
+		sqliteResults, err := sqliteStore.SearchItems(wsIDs["sqlite"], q.query)
+		if err != nil {
+			t.Errorf("[sqlite] search %q: %v", q.query, err)
+			continue
+		}
+
+		pgResults, err := pgStore.SearchItems(wsIDs["postgres"], q.query)
+		if err != nil {
+			t.Errorf("[postgres] search %q: %v", q.query, err)
+			continue
+		}
+
+		sqliteTop := "(none)"
+		if len(sqliteResults) > 0 {
+			sqliteTop = truncate(sqliteResults[0].Item.Title, 30)
+		}
+
+		pgTop := "(none)"
+		if len(pgResults) > 0 {
+			pgTop = truncate(pgResults[0].Item.Title, 30)
+		}
+
+		// Check if expected result appears in top 3 for each backend.
+		sqliteHasExpected := containsTitle(sqliteResults, q.expectTitle, 3)
+		pgHasExpected := containsTitle(pgResults, q.expectTitle, 3)
+
+		match := "✓"
+		if !pgHasExpected && sqliteHasExpected {
+			match = "✗ PG missing"
+			pgMissing++
+		} else if sqliteTop != pgTop {
+			match = "~ different order"
+			mismatches++
+		}
+
+		t.Logf("%-35s | %-30s | %-30s | %s", q.query, sqliteTop, pgTop, match)
+		t.Logf("  SQLite: %d results, PG: %d results", len(sqliteResults), len(pgResults))
+	}
+
+	t.Logf("\nSummary: %d/%d queries match top result, %d PG missing from top 3",
+		len(queries)-mismatches-pgMissing, len(queries), pgMissing)
+
+	// Fail if PostgreSQL is missing expected results that SQLite finds.
+	if pgMissing > 3 {
+		t.Errorf("PostgreSQL missing too many expected results (%d/%d) — search quality needs tuning", pgMissing, len(queries))
+	}
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n-3] + "..."
+}
+
+func containsTitle(results []ItemSearchResult, title string, topN int) bool {
+	for i, r := range results {
+		if i >= topN {
+			break
+		}
+		if r.Item.Title == title {
+			return true
+		}
+	}
+	return false
+}
+
+// TestSearchEdgeCases tests tricky search scenarios on both backends.
+func TestSearchEdgeCases(t *testing.T) {
+	s := testStore(t)
+
+	ws := createTestWorkspace(t, s, "search-edge")
+	coll, err := s.CreateCollection(ws.ID, models.CollectionCreate{
+		Name: "Items",
+		Schema: `{"fields":[{"key":"status","label":"Status","type":"select","options":["open","done"],"default":"open","required":true}]}`,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testItems := []struct {
+		title, content string
+	}{
+		{"hyphen-separated-words", "This has kebab-case naming"},
+		{"CamelCaseTitle", "Testing camelCase search matching"},
+		{"Special chars: @#$%", "Content with special characters !@#$%^&*()"},
+		{"Short", "x"},
+		{"", "Untitled item with only content about authentication"},
+	}
+
+	for _, item := range testItems {
+		title := item.title
+		if title == "" {
+			title = "Untitled"
+		}
+		_, err := s.CreateItem(ws.ID, coll.ID, models.ItemCreate{
+			Title:   title,
+			Content: item.content,
+			Fields:  `{"status":"open"}`,
+		})
+		if err != nil {
+			t.Fatalf("create item %q: %v", title, err)
+		}
+	}
+
+	edgeCases := []struct {
+		query     string
+		expectMin int // Minimum results expected
+	}{
+		{"hyphen", 1},
+		{"camelCase", 0}, // CamelCase is a single token — neither FTS engine splits on case boundaries
+		{"authentication", 1},
+		{"xyznonexistentquerymatchesnothing", 0},
+	}
+
+	for _, tc := range edgeCases {
+		t.Run(fmt.Sprintf("search_%s", tc.query), func(t *testing.T) {
+			results, err := s.SearchItems(ws.ID, tc.query)
+			if err != nil {
+				t.Fatalf("search %q: %v", tc.query, err)
+			}
+			if len(results) < tc.expectMin {
+				t.Errorf("search %q: expected >= %d results, got %d", tc.query, tc.expectMin, len(results))
+			}
+		})
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -68,23 +68,31 @@ func New(dbPath string) (*Store, error) {
 	return s, nil
 }
 
-// NewPostgres creates a Store backed by PostgreSQL.
-// The connStr should be a PostgreSQL connection string (e.g. "postgres://user:pass@host/db").
-func NewPostgres(connStr string) (*Store, error) {
+// openPostgresDB opens and configures a PostgreSQL connection pool.
+func openPostgresDB(connStr string) (*sql.DB, error) {
 	db, err := sql.Open("pgx", connStr)
 	if err != nil {
 		return nil, fmt.Errorf("open postgres: %w", err)
 	}
 
-	// Verify connection
 	if err := db.Ping(); err != nil {
 		return nil, fmt.Errorf("ping postgres: %w", err)
 	}
 
-	// Connection pool tuning for cloud deployment
 	db.SetMaxOpenConns(25)
 	db.SetMaxIdleConns(5)
 	db.SetConnMaxLifetime(5 * time.Minute)
+
+	return db, nil
+}
+
+// NewPostgres creates a Store backed by PostgreSQL.
+// The connStr should be a PostgreSQL connection string (e.g. "postgres://user:pass@host/db").
+func NewPostgres(connStr string) (*Store, error) {
+	db, err := openPostgresDB(connStr)
+	if err != nil {
+		return nil, err
+	}
 
 	s := &Store{db: db, dialect: &postgresDialect{}}
 	if err := s.migratePostgres(); err != nil {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -2,15 +2,26 @@ package store
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/xarmian/pad/internal/models"
 )
 
+// testStore creates a Store for testing. When PAD_TEST_POSTGRES_URL is set,
+// it creates an isolated PostgreSQL database; otherwise it falls back to a
+// temporary SQLite file. Every test gets its own database so tests never
+// interfere with each other.
 func testStore(t *testing.T) *Store {
 	t.Helper()
+
+	if pgURL := os.Getenv("PAD_TEST_POSTGRES_URL"); pgURL != "" {
+		return testStorePostgres(t, pgURL)
+	}
+
 	dir := t.TempDir()
 	dbPath := filepath.Join(dir, "test.db")
 	s, err := New(dbPath)
@@ -19,6 +30,100 @@ func testStore(t *testing.T) *Store {
 	}
 	t.Cleanup(func() { s.Close() })
 	return s
+}
+
+// testStorePostgres creates an isolated test database on the PostgreSQL server.
+// It connects to the base URL, creates a randomly-named database, runs
+// migrations, and drops the database when the test finishes.
+func testStorePostgres(t *testing.T, baseURL string) *Store {
+	t.Helper()
+
+	// Generate a unique database name for this test.
+	dbName := "pad_test_" + uuid.New().String()[:8]
+
+	// Connect to the default "pad" database to issue CREATE/DROP DATABASE.
+	adminStore, err := newPostgresConn(baseURL)
+	if err != nil {
+		t.Fatalf("connect to postgres for admin: %v", err)
+	}
+
+	// CREATE DATABASE cannot run inside a transaction.
+	if _, err := adminStore.db.Exec(fmt.Sprintf("CREATE DATABASE %s", dbName)); err != nil {
+		adminStore.Close()
+		t.Fatalf("create test database %s: %v", dbName, err)
+	}
+	adminStore.Close()
+
+	// Build the connection string for the new database.
+	testURL := replaceDBName(baseURL, dbName)
+
+	s, err := NewPostgres(testURL)
+	if err != nil {
+		// Clean up the database we just created.
+		if admin2, err2 := newPostgresConn(baseURL); err2 == nil {
+			admin2.db.Exec(fmt.Sprintf("DROP DATABASE IF EXISTS %s", dbName))
+			admin2.Close()
+		}
+		t.Fatalf("open test postgres store: %v", err)
+	}
+
+	t.Cleanup(func() {
+		s.Close()
+		// Drop the test database.
+		if admin, err := newPostgresConn(baseURL); err == nil {
+			admin.db.Exec(fmt.Sprintf("DROP DATABASE IF EXISTS %s WITH (FORCE)", dbName))
+			admin.Close()
+		}
+	})
+
+	return s
+}
+
+// newPostgresConn opens a raw postgres connection (no migrations).
+func newPostgresConn(connStr string) (*Store, error) {
+	db, err := openPostgresDB(connStr)
+	if err != nil {
+		return nil, err
+	}
+	return &Store{db: db, dialect: &postgresDialect{}}, nil
+}
+
+// replaceDBName swaps the database name in a postgres:// URL.
+// e.g. "postgres://pad:pad@localhost:5432/pad?sslmode=disable"
+// becomes "postgres://pad:pad@localhost:5432/newdb?sslmode=disable"
+func replaceDBName(connStr, newDB string) string {
+	// Find the last '/' before any '?' query string.
+	query := ""
+	base := connStr
+	if idx := len(connStr) - len(connStr); idx >= 0 {
+		if qIdx := indexOf(connStr, '?'); qIdx >= 0 {
+			query = connStr[qIdx:]
+			base = connStr[:qIdx]
+		}
+	}
+	// Find the last '/' in the base to replace the db name.
+	if lastSlash := lastIndexOf(base, '/'); lastSlash >= 0 {
+		return base[:lastSlash+1] + newDB + query
+	}
+	return connStr
+}
+
+func indexOf(s string, c byte) int {
+	for i := 0; i < len(s); i++ {
+		if s[i] == c {
+			return i
+		}
+	}
+	return -1
+}
+
+func lastIndexOf(s string, c byte) int {
+	for i := len(s) - 1; i >= 0; i-- {
+		if s[i] == c {
+			return i
+		}
+	}
+	return -1
 }
 
 func createTestWorkspace(t *testing.T, s *Store, name string) *models.Workspace {
@@ -60,6 +165,9 @@ func schemaFieldKeys(t *testing.T, schemaJSON string) []string {
 }
 
 func TestNewStore(t *testing.T) {
+	if os.Getenv("PAD_TEST_POSTGRES_URL") != "" {
+		t.Skip("skipping SQLite-specific test when running against PostgreSQL")
+	}
 	dir := t.TempDir()
 	dbPath := filepath.Join(dir, "test.db")
 	s, err := New(dbPath)
@@ -71,6 +179,23 @@ func TestNewStore(t *testing.T) {
 	// DB file should exist
 	if _, err := os.Stat(dbPath); os.IsNotExist(err) {
 		t.Error("database file was not created")
+	}
+}
+
+func TestNewStorePostgres(t *testing.T) {
+	pgURL := os.Getenv("PAD_TEST_POSTGRES_URL")
+	if pgURL == "" {
+		t.Skip("PAD_TEST_POSTGRES_URL not set, skipping PostgreSQL test")
+	}
+
+	s := testStorePostgres(t, pgURL)
+
+	// Verify we can ping and the dialect is correct.
+	if err := s.Ping(); err != nil {
+		t.Fatalf("Ping() error: %v", err)
+	}
+	if s.dialect.Driver() != DriverPostgres {
+		t.Errorf("expected DriverPostgres, got %v", s.dialect.Driver())
 	}
 }
 

--- a/web/src/lib/components/layout/TopBar.svelte
+++ b/web/src/lib/components/layout/TopBar.svelte
@@ -198,9 +198,20 @@
 								<span class="user-dropdown-email">{authStore.user.email}</span>
 							</div>
 							<div class="dropdown-divider"></div>
-							{#if currentSlug}
-								<a href="/{currentUsername}/{currentSlug}/settings" class="dropdown-item" onclick={closeUserMenu}>
-									Settings
+							<a href="/console" class="dropdown-item" onclick={closeUserMenu}>
+								Workspaces
+							</a>
+							<a href="/console/settings" class="dropdown-item" onclick={closeUserMenu}>
+								Settings
+							</a>
+							{#if authStore.cloudMode}
+								<a href="/console/billing" class="dropdown-item" onclick={closeUserMenu}>
+									Billing
+								</a>
+							{/if}
+							{#if authStore.user?.role === 'admin'}
+								<a href="/console/admin" class="dropdown-item" onclick={closeUserMenu}>
+									Admin
 								</a>
 							{/if}
 							<button class="dropdown-item" onclick={toggleTheme}>

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -22,12 +22,4 @@
 		color: var(--text-secondary);
 		gap: var(--space-3);
 	}
-	h1 { font-size: 1.8em; color: var(--text-primary); }
-	code {
-		background: var(--bg-tertiary);
-		padding: 2px 8px;
-		border-radius: var(--radius-sm);
-		font-family: var(--font-mono);
-	}
-	.hint { font-size: 0.9em; color: var(--text-muted); }
 </style>

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -1,31 +1,14 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { goto } from '$app/navigation';
-	import { workspaceStore } from '$lib/stores/workspace.svelte';
 
 	onMount(async () => {
-		await workspaceStore.loadAll();
-		const ws = workspaceStore.workspaces;
-		if (ws.length > 0) {
-			// Pick the most recently updated workspace
-			const sorted = [...ws].sort((a, b) =>
-				new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime()
-			);
-			goto(`/${sorted[0].owner_username}/${sorted[0].slug}`, { replaceState: true });
-		}
+		goto('/console', { replaceState: true });
 	});
 </script>
 
 <div class="welcome">
-	{#if workspaceStore.loading}
-		<p>Loading...</p>
-	{:else if workspaceStore.workspaces.length === 0}
-		<h1>Welcome to Pad</h1>
-		<p>Create a workspace to get started.</p>
-		<p class="hint">Run <code>pad workspace init</code> in your project directory, or use the workspace switcher in the sidebar.</p>
-	{:else}
-		<p>Redirecting...</p>
-	{/if}
+	<p>Redirecting...</p>
 </div>
 
 <style>

--- a/web/src/routes/[username]/[workspace]/settings/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/settings/+page.svelte
@@ -4,7 +4,7 @@
 	import { onMount } from 'svelte';
 	import { api } from '$lib/api/client';
 	import { workspaceStore } from '$lib/stores/workspace.svelte';
-	import type { Collection, APIToken, WorkspaceContext } from '$lib/types';
+	import type { Collection, WorkspaceContext } from '$lib/types';
 	import { parseSchema } from '$lib/types';
 	import CreateCollectionModal from '$lib/components/collections/CreateCollectionModal.svelte';
 	import EditCollectionModal from '$lib/components/collections/EditCollectionModal.svelte';
@@ -43,56 +43,14 @@
 	let accessLoading = $state(false);
 	let accessSaving = $state(false);
 
-	// Account
-	let profileName = $state('');
-	let profileEmail = $state('');
-	let profileUsername = $state('');
-	let originalUsername = $state('');
-	let profileRole = $state('');
-	let savingProfile = $state(false);
-	let profileStatus = $state<'idle' | 'saved' | 'error'>('idle');
-	let profileError = $state('');
-
-	// Username availability checking
-	let usernameChecking = $state(false);
-	let usernameAvailable = $state<boolean | null>(null);
-	let usernameError = $state('');
-	let usernameCheckTimeout = $state<ReturnType<typeof setTimeout> | null>(null);
-	let usernameChanged = $derived(profileUsername !== originalUsername);
-
-	let currentPassword = $state('');
-	let newPassword = $state('');
-	let confirmPassword = $state('');
-	let changingPassword = $state(false);
-	let passwordStatus = $state<'idle' | 'saved' | 'error'>('idle');
-	let passwordError = $state('');
-
-	let tokens = $state<APIToken[]>([]);
-	let newTokenName = $state('');
-	let creatingToken = $state(false);
-	let newTokenSecret = $state('');
-
-	// Platform (admin-only)
-	let platformSettings = $state<Record<string, string>>({});
-	let savingPlatform = $state(false);
-	let platformStatus = $state<'idle' | 'saved' | 'error'>('idle');
-	let testingEmail = $state(false);
-	let testEmailResult = $state<{ message: string; type: 'success' | 'error' } | null>(null);
-
 	// Tabs
 	let activeTab = $state('general');
-	const baseTabs = [
+	const tabs = [
 		{ id: 'general', label: 'General', icon: '\u2699\uFE0F' },
-		{ id: 'account', label: 'Account', icon: '\uD83D\uDC64' },
 		{ id: 'members', label: 'Members', icon: '\uD83D\uDC65' },
 		{ id: 'collections', label: 'Collections', icon: '\uD83D\uDCC1' },
+		{ id: 'danger', label: 'Danger Zone', icon: '\u26A0\uFE0F' },
 	];
-	const dangerTab = { id: 'danger', label: 'Danger Zone', icon: '\u26A0\uFE0F' };
-	let tabs = $derived(
-		profileRole === 'admin'
-			? [...baseTabs, { id: 'platform', label: 'Platform', icon: '\uD83D\uDD27' }, dangerTab]
-			: [...baseTabs, dangerTab]
-	);
 	let validTabIds = $derived(tabs.map(t => t.id));
 
 	function switchTab(tabId: string) {
@@ -132,24 +90,6 @@
 					currentUserRole = me?.role ?? '';
 				}
 			} catch {}
-		// Load account data
-		try {
-			const me = await api.auth.me();
-			profileName = me.name;
-			profileEmail = me.email;
-			profileUsername = me.username;
-			originalUsername = me.username;
-			profileRole = me.role;
-		} catch {}
-		try {
-			tokens = await api.auth.tokens.list();
-		} catch {}
-		// Load platform settings (admin only)
-		if (profileRole === 'admin') {
-			try {
-				platformSettings = await api.admin.getSettings();
-			} catch {}
-		}
 		} catch { /* allow partial render */
 		} finally {
 			loading = false;
@@ -383,172 +323,10 @@
 		try {
 			await api.workspaces.delete(wsSlug);
 			toastStore.show(`Workspace "${wsName}" archived`, 'success');
-			goto('/');
+			goto('/console');
 		} catch {
 			toastStore.show('Failed to archive workspace', 'error');
 			deleting = false;
-		}
-	}
-
-	function checkUsernameAvailability() {
-		if (usernameCheckTimeout) clearTimeout(usernameCheckTimeout);
-		usernameAvailable = null;
-		usernameError = '';
-
-		if (!usernameChanged) {
-			usernameChecking = false;
-			return;
-		}
-
-		if (!profileUsername || profileUsername.length < 3) {
-			usernameChecking = false;
-			if (profileUsername.length > 0) {
-				usernameError = 'Username must be at least 3 characters';
-			}
-			return;
-		}
-
-		usernameChecking = true;
-		usernameCheckTimeout = setTimeout(async () => {
-			try {
-				const result = await api.auth.checkUsername(profileUsername);
-				usernameAvailable = result.available;
-				usernameError = result.message || '';
-			} catch {
-				usernameError = '';
-				usernameAvailable = null;
-			} finally {
-				usernameChecking = false;
-			}
-		}, 400);
-	}
-
-	async function saveProfile() {
-		if (!profileName.trim() || savingProfile) return;
-		if (usernameChanged && usernameAvailable === false) return;
-		if (usernameChanged && profileUsername.length > 0 && profileUsername.length < 3) return;
-		savingProfile = true;
-		profileStatus = 'idle';
-		profileError = '';
-		try {
-			const update: { name: string; username?: string } = { name: profileName.trim() };
-			if (usernameChanged) {
-				update.username = profileUsername.trim();
-			}
-			await api.auth.updateProfile(update);
-			if (usernameChanged) {
-				originalUsername = profileUsername.trim();
-				usernameAvailable = null;
-				usernameError = '';
-			}
-			profileStatus = 'saved';
-			setTimeout(() => (profileStatus = 'idle'), 2000);
-		} catch (err: unknown) {
-			profileStatus = 'error';
-			profileError = err instanceof Error ? err.message : 'Failed to save profile';
-		} finally {
-			savingProfile = false;
-		}
-	}
-
-	async function changePassword() {
-		passwordError = '';
-		if (!currentPassword || !newPassword || !confirmPassword) {
-			passwordError = 'All fields are required';
-			return;
-		}
-		if (newPassword.length < 8) {
-			passwordError = 'New password must be at least 8 characters';
-			return;
-		}
-		if (newPassword !== confirmPassword) {
-			passwordError = 'Passwords do not match';
-			return;
-		}
-		changingPassword = true;
-		passwordStatus = 'idle';
-		try {
-			await api.auth.updateProfile({
-				current_password: currentPassword,
-				new_password: newPassword
-			});
-			passwordStatus = 'saved';
-			currentPassword = '';
-			newPassword = '';
-			confirmPassword = '';
-			setTimeout(() => (passwordStatus = 'idle'), 3000);
-		} catch (err: unknown) {
-			passwordStatus = 'error';
-			if (err instanceof Error && err.message.includes('incorrect')) {
-				passwordError = 'Current password is incorrect';
-			} else {
-				passwordError = 'Failed to change password';
-			}
-		} finally {
-			changingPassword = false;
-		}
-	}
-
-	async function createToken() {
-		if (!newTokenName.trim() || creatingToken) return;
-		creatingToken = true;
-		newTokenSecret = '';
-		try {
-			const result = await api.auth.tokens.create(newTokenName.trim());
-			newTokenSecret = result.token;
-			newTokenName = '';
-			tokens = await api.auth.tokens.list();
-		} catch {
-			toastStore.show('Failed to create token', 'error');
-		} finally {
-			creatingToken = false;
-		}
-	}
-
-	async function deleteToken(tokenId: string, name: string) {
-		if (!confirm(`Revoke token "${name}"? This cannot be undone.`)) return;
-		try {
-			await api.auth.tokens.delete(tokenId);
-			tokens = tokens.filter(t => t.id !== tokenId);
-			toastStore.show('Token revoked', 'success');
-		} catch {
-			toastStore.show('Failed to revoke token', 'error');
-		}
-	}
-
-	async function copyToken() {
-		const ok = await copyToClipboard(newTokenSecret);
-		toastStore.show(ok ? 'Token copied to clipboard' : 'Failed to copy token', ok ? 'success' : 'error');
-	}
-
-	async function savePlatformSettings() {
-		if (savingPlatform) return;
-		savingPlatform = true;
-		platformStatus = 'idle';
-		try {
-			await api.admin.updateSettings(platformSettings);
-			platformStatus = 'saved';
-			setTimeout(() => (platformStatus = 'idle'), 2000);
-		} catch {
-			platformStatus = 'error';
-		} finally {
-			savingPlatform = false;
-		}
-	}
-
-	async function sendTestEmail() {
-		testingEmail = true;
-		testEmailResult = null;
-		try {
-			const result = await api.admin.testEmail();
-			testEmailResult = { message: `Test email sent to ${result.sent_to}`, type: 'success' };
-		} catch (err: unknown) {
-			testEmailResult = {
-				message: err instanceof Error ? err.message : 'Failed to send test email',
-				type: 'error'
-			};
-		} finally {
-			testingEmail = false;
 		}
 	}
 
@@ -692,151 +470,6 @@
 						{:else if contextStatus === 'error' && !contextError}
 							<span class="status-error">Error</span>
 						{/if}
-					</div>
-				</div>
-			</section>
-		{:else if activeTab === 'account'}
-			<section class="section">
-				<h2>Profile</h2>
-				<div class="card">
-					<div class="field-row">
-						<span class="field-label">Email</span>
-						<span class="field-value">{profileEmail}</span>
-					</div>
-					<div class="field-row">
-						<span class="field-label">Role</span>
-						<span class="field-value"><span class="role-badge">{profileRole}</span></span>
-					</div>
-					<div class="field-row">
-						<label for="profile-name">Name</label>
-						<div class="inline-edit">
-							<input id="profile-name" type="text" bind:value={profileName} onkeydown={(e) => e.key === 'Enter' && saveProfile()} />
-						</div>
-					</div>
-					<div class="field-row">
-						<label for="profile-username">Username</label>
-						<div class="inline-edit">
-							<div class="username-input-wrapper">
-								<span class="username-prefix">@</span>
-								<input
-									id="profile-username"
-									type="text"
-									bind:value={profileUsername}
-									oninput={checkUsernameAvailability}
-									onkeydown={(e) => e.key === 'Enter' && saveProfile()}
-									placeholder="username"
-									autocomplete="username"
-								/>
-							</div>
-							{#if usernameChanged}
-								{#if usernameChecking}
-									<span class="username-status checking">checking...</span>
-								{:else if usernameAvailable === true}
-									<span class="username-status available">available</span>
-								{:else if usernameAvailable === false}
-									<span class="username-status taken">{usernameError || 'not available'}</span>
-								{:else if usernameError}
-									<span class="username-status taken">{usernameError}</span>
-								{/if}
-							{/if}
-						</div>
-					</div>
-					<div class="field-row profile-actions-row">
-						<span class="field-label"></span>
-						<div class="inline-edit">
-							<button class="btn btn-small" onclick={saveProfile} disabled={savingProfile || (usernameChanged && usernameAvailable === false) || (usernameChanged && profileUsername.length > 0 && profileUsername.length < 3)}>
-								{savingProfile ? 'Saving...' : 'Save'}
-							</button>
-							{#if profileStatus === 'saved'}
-								<span class="status-saved">Saved</span>
-							{:else if profileStatus === 'error'}
-								<span class="status-error">{profileError || 'Error'}</span>
-							{/if}
-						</div>
-					</div>
-				</div>
-			</section>
-
-			<section class="section">
-				<h2>Change Password</h2>
-				<div class="card">
-					<div class="password-form">
-						<div class="password-field">
-							<label for="current-pw">Current password</label>
-							<input id="current-pw" type="password" bind:value={currentPassword} placeholder="Enter current password" />
-						</div>
-						<div class="password-field">
-							<label for="new-pw">New password</label>
-							<input id="new-pw" type="password" bind:value={newPassword} placeholder="At least 8 characters" />
-						</div>
-						<div class="password-field">
-							<label for="confirm-pw">Confirm new password</label>
-							<input id="confirm-pw" type="password" bind:value={confirmPassword} placeholder="Confirm new password"
-								onkeydown={(e) => e.key === 'Enter' && changePassword()} />
-						</div>
-						{#if passwordError}
-							<p class="password-error">{passwordError}</p>
-						{/if}
-						<div class="password-actions">
-							<button class="btn btn-primary" onclick={changePassword} disabled={changingPassword}>
-								{changingPassword ? 'Changing...' : 'Change Password'}
-							</button>
-							{#if passwordStatus === 'saved'}
-								<span class="status-saved">Password updated</span>
-							{/if}
-						</div>
-					</div>
-				</div>
-			</section>
-
-			<section class="section">
-				<h2>API Tokens</h2>
-				<p class="section-desc">Personal tokens for CLI and API access. Tokens are not tied to a specific workspace.</p>
-				{#if tokens.length > 0}
-					<div class="token-list">
-						{#each tokens as token (token.id)}
-							<div class="card token-row">
-								<div class="token-info">
-									<span class="token-name">{token.name}</span>
-									<code class="token-prefix">{token.prefix}...</code>
-									{#if token.last_used_at}
-										<span class="token-meta">Last used {new Date(token.last_used_at).toLocaleDateString()}</span>
-									{:else}
-										<span class="token-meta">Never used</span>
-									{/if}
-								</div>
-								<button class="btn btn-small btn-remove" onclick={() => deleteToken(token.id, token.name)}>
-									Revoke
-								</button>
-							</div>
-						{/each}
-					</div>
-				{:else}
-					<p class="empty-text">No API tokens yet.</p>
-				{/if}
-
-				{#if newTokenSecret}
-					<div class="card token-secret-card">
-						<p class="token-secret-warning">Copy this token now — it won't be shown again.</p>
-						<div class="token-secret-row">
-							<code class="token-secret">{newTokenSecret}</code>
-							<button class="btn btn-small" onclick={copyToken}>Copy</button>
-						</div>
-					</div>
-				{/if}
-
-				<div class="card token-create">
-					<div class="token-create-row">
-						<input
-							type="text"
-							placeholder="Token name (e.g. my-laptop)"
-							bind:value={newTokenName}
-							onkeydown={(e) => e.key === 'Enter' && createToken()}
-							disabled={creatingToken}
-						/>
-						<button class="btn btn-primary btn-small" onclick={createToken} disabled={creatingToken || !newTokenName.trim()}>
-							{creatingToken ? 'Creating...' : 'Create Token'}
-						</button>
 					</div>
 				</div>
 			</section>
@@ -1079,75 +712,6 @@
 					{/if}
 				</div>
 			</section>
-		{:else if activeTab === 'platform'}
-			<section class="section">
-				<h2>Email</h2>
-				<p class="section-desc">Configure transactional email for invitations, password resets, and notifications.</p>
-				<div class="card">
-					<div class="field-row">
-						<label for="email-provider">Provider</label>
-						<div class="inline-edit">
-							<select id="email-provider" class="role-select" bind:value={platformSettings['email_provider']}
-								onchange={() => { if (!platformSettings['email_provider']) platformSettings['email_provider'] = ''; }}>
-								<option value="">Disabled</option>
-								<option value="maileroo">Maileroo</option>
-							</select>
-						</div>
-					</div>
-					{#if platformSettings['email_provider'] === 'maileroo'}
-						<div class="field-row">
-							<label for="maileroo-key">API Key</label>
-							<div class="inline-edit">
-								<input id="maileroo-key" type="password" bind:value={platformSettings['maileroo_api_key']}
-									placeholder="Enter Maileroo sending key" />
-							</div>
-						</div>
-					{/if}
-					<div class="field-row">
-						<label for="email-from">From</label>
-						<div class="inline-edit">
-							<input id="email-from" type="email" bind:value={platformSettings['email_from']}
-								placeholder="noreply@yourdomain.com" />
-						</div>
-					</div>
-					<div class="field-row">
-						<label for="email-name">Name</label>
-						<div class="inline-edit">
-							<input id="email-name" type="text" bind:value={platformSettings['email_from_name']}
-								placeholder="Pad" />
-						</div>
-					</div>
-					<div class="platform-actions">
-						<button class="btn btn-primary" onclick={savePlatformSettings} disabled={savingPlatform}>
-							{savingPlatform ? 'Saving...' : 'Save Email Settings'}
-						</button>
-						{#if platformStatus === 'saved'}
-							<span class="status-saved">Saved</span>
-						{:else if platformStatus === 'error'}
-							<span class="status-error">Error</span>
-						{/if}
-					</div>
-				</div>
-			</section>
-
-			{#if platformSettings['email_provider']}
-				<section class="section">
-					<h2>Test Email</h2>
-					<p class="section-desc">Send a test email to verify your configuration is working.</p>
-					<div class="card">
-						<div class="platform-actions">
-							<button class="btn" onclick={sendTestEmail} disabled={testingEmail}>
-								{testingEmail ? 'Sending...' : 'Send Test Email'}
-							</button>
-							{#if testEmailResult}
-								<span class={testEmailResult.type === 'success' ? 'status-saved' : 'status-error'}>
-									{testEmailResult.message}
-								</span>
-							{/if}
-						</div>
-					</div>
-				</section>
-			{/if}
 		{/if}
 	{/if}
 </div>
@@ -1314,38 +878,5 @@
 	.danger-input { flex: 1; min-width: 180px; max-width: 300px; padding: var(--space-2); font-size: 0.88em; background: var(--bg-tertiary); border: 1px solid var(--border); border-radius: var(--radius); color: var(--text-primary); font-family: var(--font-mono); }
 	.danger-input:focus { outline: none; border-color: #ef4444; }
 	.danger-actions { display: flex; gap: var(--space-2); }
-	/* ── Account ──── */
-	.password-form { display: flex; flex-direction: column; gap: var(--space-3); }
-	.password-field { display: flex; flex-direction: column; gap: var(--space-1); }
-	.password-field label { font-size: 0.82em; color: var(--text-secondary); }
-	.password-field input { max-width: 300px; }
-	.password-error { font-size: 0.82em; color: #ef4444; margin: 0; }
-	.password-actions { display: flex; align-items: center; gap: var(--space-3); }
 	.section-desc { font-size: 0.85em; color: var(--text-muted); margin-bottom: var(--space-3); }
-	.token-list { display: flex; flex-direction: column; gap: var(--space-2); margin-bottom: var(--space-3); }
-	.token-row { display: flex; align-items: center; justify-content: space-between; padding: var(--space-3) var(--space-4); gap: var(--space-3); }
-	.token-info { display: flex; align-items: center; gap: var(--space-3); min-width: 0; flex-wrap: wrap; }
-	.token-name { font-weight: 500; font-size: 0.9em; }
-	.token-prefix { font-size: 0.8em; background: var(--bg-tertiary); padding: 1px 6px; border-radius: var(--radius-sm); color: var(--text-muted); }
-	.token-meta { font-size: 0.78em; color: var(--text-muted); }
-	.token-create { margin-top: var(--space-3); }
-	.token-create-row { display: flex; gap: var(--space-2); align-items: center; flex-wrap: wrap; }
-	.token-create-row input { flex: 1; min-width: 180px; max-width: 300px; }
-	.token-secret-card { margin-top: var(--space-3); border-color: var(--accent-green); background: color-mix(in srgb, var(--accent-green) 5%, var(--bg-secondary)); }
-	.token-secret-warning { font-size: 0.82em; color: var(--accent-orange); margin: 0 0 var(--space-2); font-weight: 500; }
-	.token-secret-row { display: flex; align-items: center; gap: var(--space-2); }
-	.token-secret { font-size: 0.82em; background: var(--bg-tertiary); padding: var(--space-2) var(--space-3); border-radius: var(--radius-sm); word-break: break-all; flex: 1; }
-	/* ── Username field ──── */
-	.username-input-wrapper { display: flex; align-items: center; flex: 1; min-width: 120px; max-width: 300px; background: var(--bg-tertiary); border: 1px solid var(--border); border-radius: var(--radius); overflow: hidden; }
-	.username-input-wrapper:focus-within { border-color: var(--accent-blue); }
-	.username-prefix { padding: var(--space-1) 0 var(--space-1) var(--space-2); font-size: 0.9em; color: var(--text-muted); flex-shrink: 0; user-select: none; }
-	.username-input-wrapper input { border: none; background: none; padding-left: var(--space-1); min-width: 0; flex: 1; }
-	.username-input-wrapper input:focus { outline: none; box-shadow: none; }
-	.username-status { font-size: 0.78em; white-space: nowrap; }
-	.username-status.checking { color: var(--text-muted); }
-	.username-status.available { color: var(--accent-green); }
-	.username-status.taken { color: #ef4444; }
-	.profile-actions-row { border-top: none !important; padding-top: 0; }
-	/* ── Platform ──── */
-	.platform-actions { display: flex; align-items: center; gap: var(--space-3); margin-top: var(--space-3); flex-wrap: wrap; }
 </style>

--- a/web/src/routes/console/admin/+page.svelte
+++ b/web/src/routes/console/admin/+page.svelte
@@ -59,6 +59,13 @@
 	let saveMsg = $state('');
 	let limitMsg = $state('');
 
+	// Email settings
+	let platformSettings = $state<Record<string, string>>({});
+	let savingPlatform = $state(false);
+	let platformStatus = $state<'idle' | 'saved' | 'error'>('idle');
+	let testingEmail = $state(false);
+	let testEmailResult = $state<{ message: string; type: 'success' | 'error' } | null>(null);
+
 	function formatDate(d: string): string {
 		return new Date(d).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
 	}
@@ -139,8 +146,66 @@
 		limits[tier] = { ...limits[tier], [key]: isNaN(num) ? 0 : num };
 	}
 
+	async function loadEmailSettings() {
+		try {
+			const resp = await fetch(BASE + '/admin/settings', { credentials: 'same-origin' });
+			if (resp.ok) platformSettings = await resp.json();
+		} catch {}
+	}
+
+	async function savePlatformSettings() {
+		if (savingPlatform) return;
+		savingPlatform = true;
+		platformStatus = 'idle';
+		try {
+			const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+			const csrf = getCSRFToken();
+			if (csrf) headers['X-CSRF-Token'] = csrf;
+			await fetch(BASE + '/admin/settings', {
+				method: 'PATCH',
+				credentials: 'same-origin',
+				headers,
+				body: JSON.stringify(platformSettings)
+			});
+			platformStatus = 'saved';
+			setTimeout(() => (platformStatus = 'idle'), 2000);
+		} catch {
+			platformStatus = 'error';
+		} finally {
+			savingPlatform = false;
+		}
+	}
+
+	async function sendTestEmail() {
+		testingEmail = true;
+		testEmailResult = null;
+		try {
+			const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+			const csrf = getCSRFToken();
+			if (csrf) headers['X-CSRF-Token'] = csrf;
+			const resp = await fetch(BASE + '/admin/test-email', {
+				method: 'POST',
+				credentials: 'same-origin',
+				headers
+			});
+			if (!resp.ok) throw new Error('Failed to send test email');
+			const result = await resp.json();
+			testEmailResult = { message: `Test email sent to ${result.sent_to}`, type: 'success' };
+		} catch (err: unknown) {
+			testEmailResult = {
+				message: err instanceof Error ? err.message : 'Failed to send test email',
+				type: 'error'
+			};
+		} finally {
+			testingEmail = false;
+		}
+	}
+
 	onMount(() => {
-		if (isAdmin) loadData();
+		if (isAdmin) {
+			loadData();
+			loadEmailSettings();
+		}
 	});
 </script>
 
@@ -240,8 +305,8 @@
 			</div>
 		</section>
 
-		<!-- Plan Limits section -->
-		{#if limits}
+		<!-- Plan Limits section (cloud mode only) -->
+		{#if limits && stats?.cloud_mode}
 			<section class="section">
 				<h2 class="section-title">Plan Limits</h2>
 				<p class="section-desc">Use -1 for unlimited.</p>
@@ -283,6 +348,66 @@
 				</div>
 			</section>
 		{/if}
+
+		<!-- Email Configuration -->
+		<section class="section">
+			<h2 class="section-title">Email Configuration</h2>
+			<p class="section-desc">Configure transactional email for invitations, password resets, and notifications.</p>
+			<div class="email-card">
+				<div class="email-field">
+					<label for="email-provider">Provider</label>
+					<select id="email-provider" bind:value={platformSettings['email_provider']}
+						onchange={() => { if (!platformSettings['email_provider']) platformSettings['email_provider'] = ''; }}>
+						<option value="">Disabled</option>
+						<option value="maileroo">Maileroo</option>
+					</select>
+				</div>
+				{#if platformSettings['email_provider'] === 'maileroo'}
+					<div class="email-field">
+						<label for="maileroo-key">API Key</label>
+						<input id="maileroo-key" type="password" bind:value={platformSettings['maileroo_api_key']}
+							placeholder="Enter Maileroo sending key" />
+					</div>
+				{/if}
+				<div class="email-field">
+					<label for="email-from">From Address</label>
+					<input id="email-from" type="email" bind:value={platformSettings['email_from']}
+						placeholder="noreply@yourdomain.com" />
+				</div>
+				<div class="email-field">
+					<label for="email-name">From Name</label>
+					<input id="email-name" type="text" bind:value={platformSettings['email_from_name']}
+						placeholder="Pad" />
+				</div>
+				<div class="edit-actions">
+					<button class="btn primary" onclick={savePlatformSettings} disabled={savingPlatform}>
+						{savingPlatform ? 'Saving...' : 'Save Email Settings'}
+					</button>
+					{#if platformStatus === 'saved'}
+						<span class="save-msg" style="color: var(--accent-green);">Saved</span>
+					{:else if platformStatus === 'error'}
+						<span class="save-msg" style="color: #ef4444;">Error</span>
+					{/if}
+				</div>
+			</div>
+
+			{#if platformSettings['email_provider']}
+				<div class="email-card">
+					<h3 class="email-subheading">Test Email</h3>
+					<p class="section-desc">Send a test email to verify your configuration is working.</p>
+					<div class="edit-actions">
+						<button class="btn" onclick={sendTestEmail} disabled={testingEmail}>
+							{testingEmail ? 'Sending...' : 'Send Test Email'}
+						</button>
+						{#if testEmailResult}
+							<span class="save-msg" style="color: {testEmailResult.type === 'success' ? 'var(--accent-green)' : '#ef4444'};">
+								{testEmailResult.message}
+							</span>
+						{/if}
+					</div>
+				</div>
+			{/if}
+		</section>
 	{/if}
 </div>
 
@@ -384,4 +509,20 @@
 		font-size: 0.85rem; outline: none;
 	}
 	.limit-input:focus { border-color: var(--accent-blue); }
+
+	/* Email config */
+	.email-card {
+		padding: var(--space-4) var(--space-5); background: var(--bg-secondary);
+		border: 1px solid var(--border); border-radius: var(--radius);
+		display: flex; flex-direction: column; gap: var(--space-3);
+	}
+	.email-card + .email-card { margin-top: var(--space-3); }
+	.email-field { display: flex; flex-direction: column; gap: var(--space-1); }
+	.email-field label { font-size: 0.8rem; color: var(--text-muted); font-weight: 500; }
+	.email-field select, .email-field input {
+		padding: var(--space-2) var(--space-3); background: var(--bg-tertiary); border: 1px solid var(--border);
+		border-radius: var(--radius); color: var(--text-primary); font-size: 0.85rem; max-width: 400px;
+	}
+	.email-field select:focus, .email-field input:focus { outline: none; border-color: var(--accent-blue); }
+	.email-subheading { font-size: 0.95rem; font-weight: 600; color: var(--text-primary); margin: 0; }
 </style>

--- a/web/src/routes/console/admin/+page.svelte
+++ b/web/src/routes/console/admin/+page.svelte
@@ -161,12 +161,13 @@
 			const headers: Record<string, string> = { 'Content-Type': 'application/json' };
 			const csrf = getCSRFToken();
 			if (csrf) headers['X-CSRF-Token'] = csrf;
-			await fetch(BASE + '/admin/settings', {
+			const resp = await fetch(BASE + '/admin/settings', {
 				method: 'PATCH',
 				credentials: 'same-origin',
 				headers,
 				body: JSON.stringify(platformSettings)
 			});
+			if (!resp.ok) throw new Error(`${resp.status}`);
 			platformStatus = 'saved';
 			setTimeout(() => (platformStatus = 'idle'), 2000);
 		} catch {

--- a/web/src/routes/join/[code]/+page.svelte
+++ b/web/src/routes/join/[code]/+page.svelte
@@ -54,7 +54,7 @@
 			const result = await api.members.acceptInvitation(code);
 			// Find the workspace slug to redirect to
 			// The API returns workspace_id, but we need the slug — redirect to root and let the app figure it out
-			await goto('/', { replaceState: true });
+			await goto('/console', { replaceState: true });
 		} catch (err: unknown) {
 			errorMsg = err instanceof Error ? err.message : 'Failed to accept invitation';
 			status = 'error';
@@ -124,7 +124,7 @@
 				await api.auth.register(email.trim(), name.trim(), password, username || undefined, code);
 				// Registration with invitation_code already accepted the invite,
 				// so redirect directly instead of calling acceptInvitation().
-				await goto('/', { replaceState: true });
+				await goto('/console', { replaceState: true });
 				return;
 			} else {
 				if (!email.trim()) { formError = 'Email is required'; submitting = false; return; }

--- a/web/src/routes/login/+page.svelte
+++ b/web/src/routes/login/+page.svelte
@@ -27,7 +27,7 @@
 				return;
 			}
 			if (session.authenticated) {
-				goto('/', { replaceState: true });
+				goto('/console', { replaceState: true });
 				return;
 			}
 		} catch {}
@@ -56,7 +56,7 @@
 			}
 
 			await authStore.load();
-			await goto('/', { replaceState: true });
+			await goto('/console', { replaceState: true });
 		} catch (err: unknown) {
 			if (err instanceof Error) {
 				error = err.message || 'Invalid email or password.';
@@ -88,7 +88,7 @@
 			}
 
 			await authStore.load();
-			await goto('/', { replaceState: true });
+			await goto('/console', { replaceState: true });
 		} catch (err: unknown) {
 			if (err instanceof Error) {
 				error = err.message || 'Invalid code. Please try again.';

--- a/web/src/routes/register/+page.svelte
+++ b/web/src/routes/register/+page.svelte
@@ -29,7 +29,7 @@
 				return;
 			}
 			if (session.authenticated) {
-				goto('/', { replaceState: true });
+				goto('/console', { replaceState: true });
 				return;
 			}
 		} catch {}
@@ -104,7 +104,7 @@
 		loading = true;
 		try {
 			await api.auth.register(email, name, password, username || undefined);
-			await goto('/', { replaceState: true });
+			await goto('/console', { replaceState: true });
 		} catch (err: unknown) {
 			if (err instanceof Error) {
 				error = err.message || 'Registration failed.';

--- a/web/src/routes/reset-password/[token]/+page.svelte
+++ b/web/src/routes/reset-password/[token]/+page.svelte
@@ -25,7 +25,7 @@
 		loading = true;
 		try {
 			await api.auth.resetPassword(token, password);
-			await goto('/', { replaceState: true });
+			await goto('/console', { replaceState: true });
 		} catch (err: unknown) {
 			if (err instanceof Error) {
 				error = err.message || 'Failed to reset password.';


### PR DESCRIPTION
## Summary

- Route root (`/`) to `/console` for centralized workspace management
- Update TopBar user dropdown with console navigation links (workspaces, settings, billing, admin)
- Move account settings (profile, password, API tokens) from per-workspace settings to `/console/settings`
- Enhance admin page with email configuration UI and CSRF-protected writes
- Add PostgreSQL CI job to GitHub Actions with race detector on main
- Add `make test-pg` for local PostgreSQL testing via docker-compose
- Expand health/ready endpoint with DB connection pool stats and driver info
- Increase item number retry limit (3→10) for high-concurrency environments
- Add concurrent store benchmarks and FTS search quality tests
- Add AGENTS.md for multi-agent development guidance

> **Note:** This PR includes commits from `feat/cloud-hardening-plan-503` (PR #90) in its history. Once PR #90 is merged, the diff will shrink to only the console-navigation changes.

## Test plan
- [ ] Verify `/` redirects to `/console`
- [ ] Verify TopBar dropdown links navigate to console pages
- [ ] Verify account settings (profile, password, tokens) work at `/console/settings`
- [ ] Verify admin email configuration UI saves and sends test emails
- [ ] Run `make test` — all Go tests pass
- [ ] Run `make test-pg` — PostgreSQL tests pass
- [ ] Verify health/ready endpoint returns DB stats