### PR TITLE
fix: quick-win bug fixes (BUG-517, BUG-538, BUG-401)

### DIFF
--- a/internal/server/item_lineage.go
+++ b/internal/server/item_lineage.go
@@ -176,9 +176,11 @@ func (s *Server) deriveItemClosure(item *models.Item, vis []string) (*models.Ite
 			RelatedItems: implementedBy,
 		}, nil
 	}
+	// NOTE: split_into does NOT auto-close the original item. Splitting work
+	// out doesn't mean the original is done — it still stands on its own.
 	if len(splitChildren) > 0 && allSplitChildrenDone {
 		return &models.ItemDerivedClosure{
-			IsClosed:     true,
+			IsClosed:     false,
 			Kind:         "split_into",
 			Summary:      "Split into completed items " + summarizeRelationRefs(splitChildren),
 			RelatedItems: splitChildren,

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -439,6 +439,9 @@ func slugify(s string) string {
 		if (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') {
 			result = append(result, byte(c))
 			prevHyphen = false
+		} else if c == '\'' {
+			// Strip apostrophes without inserting a hyphen
+			continue
 		} else if !prevHyphen && len(result) > 0 {
 			result = append(result, '-')
 			prevHyphen = true

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -766,6 +766,8 @@ func TestSlugify(t *testing.T) {
 		{"UPPERCASE", "uppercase"},
 		{"already-slugified", "already-slugified"},
 		{"dots.and.more", "dots-and-more"},
+		{"Dave's Workspace", "daves-workspace"},
+		{"it's a test", "its-a-test"},
 	}
 	for _, tt := range tests {
 		got := slugify(tt.input)

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -584,7 +584,7 @@
 		try {
 			const moved = await api.items.move(wsSlug, item.slug, targetSlug);
 			toastStore.show(`Moved to ${targetSlug}`, 'success');
-			goto(`/${username}/${wsSlug}/${targetSlug}/${moved.slug}`);
+			goto(`/${username}/${wsSlug}/${targetSlug}/${moved.slug}`, { replaceState: true });
 		} catch (e: any) {
 			toastStore.show(e.message ?? 'Failed to move item', 'error');
 		} finally {


### PR DESCRIPTION
## Summary

Three small, self-contained bug fixes:

- **BUG-517** — Apostrophes in workspace names caused extra hyphens in slugs (`dave-s-workspace` → `daves-workspace`). Fixed `slugify()` to strip apostrophes silently instead of converting them to hyphens. Added test cases.
- **BUG-538** — Moving an item to a different collection pushed a new entry to browser history. Now uses `replaceState: true` on the `goto()` call, matching the pattern used elsewhere in the codebase.
- **BUG-401** — `deriveItemClosure` incorrectly auto-closed items when all split children were done. Splitting work out doesn't mean the original is complete — changed `IsClosed` from `true` to `false` for the `split_into` closure kind.

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/store/ ./internal/server/` passes (including new slugify test cases)
- [x] `npm run build` compiles cleanly
- [ ] Manually verify: create a workspace with an apostrophe in the name → slug has no extra hyphen
- [ ] Manually verify: move an item between collections → browser back button doesn't return to the old collection URL
- [ ] Manually verify: split an item, complete the split children → original item stays open