### PR TITLE
fix: mobile UI — sidebar buttons, avatar, share copy

### DIFF
--- a/web/src/lib/components/ShareDialog.svelte
+++ b/web/src/lib/components/ShareDialog.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { api } from '$lib/api/client';
 	import { toastStore } from '$lib/stores/toast.svelte';
+	import { copyToClipboard } from '$lib/utils/clipboard';
 	import type { CollectionGrant, ItemGrant, ShareLink } from '$lib/types';
 
 	interface Props {
@@ -128,11 +129,11 @@
 		return '';
 	}
 
-	async function copyToClipboard(text: string) {
-		try {
-			await navigator.clipboard.writeText(text);
+	async function handleCopyLink(text: string) {
+		const success = await copyToClipboard(text);
+		if (success) {
 			toastStore.show('Link copied to clipboard', 'success');
-		} catch {
+		} else {
 			toastStore.show('Failed to copy link', 'error');
 		}
 	}
@@ -331,7 +332,7 @@
 												<button
 													class="copy-btn"
 													type="button"
-													onclick={() => copyToClipboard(linkUrl)}
+													onclick={() => handleCopyLink(linkUrl)}
 													title="Copy link"
 												>
 													Copy
@@ -346,7 +347,7 @@
 													<button
 														class="copy-btn-small"
 														type="button"
-														onclick={() => copyToClipboard(linkUrl)}
+														onclick={() => handleCopyLink(linkUrl)}
 														title="Copy link"
 													>
 														<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">

--- a/web/src/lib/components/layout/Sidebar.svelte
+++ b/web/src/lib/components/layout/Sidebar.svelte
@@ -618,6 +618,11 @@
 	.section-header:hover .section-add-btn {
 		opacity: 1;
 	}
+	@media (hover: none) {
+		.section-add-btn {
+			opacity: 1;
+		}
+	}
 	.section-add-btn:hover {
 		color: var(--text-primary);
 		background: var(--bg-hover);
@@ -642,6 +647,11 @@
 	}
 	.nav-item:hover .nav-quick-add {
 		visibility: visible;
+	}
+	@media (hover: none) {
+		.nav-quick-add {
+			visibility: visible;
+		}
 	}
 	.nav-quick-add:hover {
 		color: var(--text-primary);

--- a/web/src/lib/components/layout/TopBar.svelte
+++ b/web/src/lib/components/layout/TopBar.svelte
@@ -270,6 +270,51 @@
 				</svg>
 			</button>
 		{/if}
+		{#if authStore.user}
+			<div class="user-menu-container">
+				<button
+					class="user-trigger"
+					onclick={() => userMenuOpen = !userMenuOpen}
+				>
+					<span class="user-avatar" style="background: {wsColor(authStore.user.name || authStore.user.email)}">
+						{(authStore.user.name || authStore.user.email).charAt(0).toUpperCase()}
+					</span>
+				</button>
+
+				{#if userMenuOpen}
+					<div class="user-dropdown">
+						<div class="user-info">
+							<span class="user-dropdown-name">{authStore.user.name}</span>
+							<span class="user-dropdown-email">{authStore.user.email}</span>
+						</div>
+						<div class="dropdown-divider"></div>
+						<a href="/console" class="dropdown-item" onclick={closeUserMenu}>
+							Workspaces
+						</a>
+						<a href="/console/settings" class="dropdown-item" onclick={closeUserMenu}>
+							Settings
+						</a>
+						{#if authStore.cloudMode}
+							<a href="/console/billing" class="dropdown-item" onclick={closeUserMenu}>
+								Billing
+							</a>
+						{/if}
+						{#if authStore.user?.role === 'admin'}
+							<a href="/console/admin" class="dropdown-item" onclick={closeUserMenu}>
+								Admin
+							</a>
+						{/if}
+						<button class="dropdown-item" onclick={toggleTheme}>
+							{currentTheme === 'dark' ? 'Light mode' : 'Dark mode'}
+						</button>
+						<div class="dropdown-divider"></div>
+						<button class="dropdown-item logout" onclick={handleLogout}>
+							Sign out
+						</button>
+					</div>
+				{/if}
+			</div>
+		{/if}
 	</header>
 
 	<!-- Full-screen reorder overlay -->
@@ -454,7 +499,7 @@
 		z-index: 1;
 	}
 
-	/* Right side — user menu (desktop only) */
+	/* Right side — user menu */
 	.topbar-right {
 		position: absolute;
 		right: var(--space-3);

--- a/web/src/lib/components/layout/TopBar.svelte
+++ b/web/src/lib/components/layout/TopBar.svelte
@@ -370,6 +370,7 @@
 		left: 0;
 		right: 0;
 		z-index: 35;
+		padding-right: var(--space-3);
 	}
 
 	/* Workspace list — scrollable horizontally */


### PR DESCRIPTION
## Summary

Three mobile/UX bug fixes:

- **BUG-537** — Sidebar "+" buttons (add collection, add item) were hidden behind `:hover` which doesn't exist on touch devices. Added `@media (hover: none)` rules to make them always visible on mobile.
- **BUG-536** — User avatar was completely missing from the mobile TopBar. Added the full user menu (avatar + dropdown) to the mobile header, filling the blank space to the right of the workspace selector.
- **BUG-513** — Share link copy used `navigator.clipboard.writeText` directly, which fails on HTTP. Wired it into the existing `$lib/utils/clipboard` fallback utility that gracefully degrades to a textarea-based `execCommand('copy')`.

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/store/ ./internal/server/` passes
- [x] `npm run build` compiles cleanly
- [ ] Mobile: sidebar "+" buttons visible without hover
- [ ] Mobile: user avatar shows in the top bar, dropdown menu works
- [ ] HTTP: share link copy works (falls back to textarea method)