### PR TITLE
fix: parent-aware breadcrumbs for child items

### DIFF
--- a/internal/models/item.go
+++ b/internal/models/item.go
@@ -53,9 +53,11 @@ type Item struct {
 	CollectionPrefix    string                   `json:"collection_prefix,omitempty"`
 
 	// Parent link (populated by enrichItemForResponse / enrichItemsWithParent)
-	ParentLinkID string `json:"parent_link_id,omitempty"`
-	ParentRef    string `json:"parent_ref,omitempty"`
-	ParentTitle  string `json:"parent_title,omitempty"`
+	ParentLinkID          string `json:"parent_link_id,omitempty"`
+	ParentRef             string `json:"parent_ref,omitempty"`
+	ParentTitle           string `json:"parent_title,omitempty"`
+	ParentSlug            string `json:"parent_slug,omitempty"`
+	ParentCollectionSlug  string `json:"parent_collection_slug,omitempty"`
 
 	// HasChildren is true if this item has child items linked to it.
 	// Populated by enrichment, not stored in the DB.

--- a/internal/server/item_lineage.go
+++ b/internal/server/item_lineage.go
@@ -33,8 +33,10 @@ func (s *Server) enrichItemsWithParent(workspaceID string, items []models.Item, 
 	}
 	// Fetch parent item details (title, ref) in bulk
 	type parentInfo struct {
-		title string
-		ref   string
+		title          string
+		ref            string
+		slug           string
+		collectionSlug string
 	}
 	parents := make(map[string]parentInfo)
 	for pid := range parentIDs {
@@ -50,7 +52,7 @@ func (s *Server) enrichItemsWithParent(workspaceID string, items []models.Item, 
 		if item.CollectionPrefix != "" && item.ItemNumber != nil {
 			ref = fmt.Sprintf("%s-%d", item.CollectionPrefix, *item.ItemNumber)
 		}
-		parents[pid] = parentInfo{title: item.Title, ref: ref}
+		parents[pid] = parentInfo{title: item.Title, ref: ref, slug: item.Slug, collectionSlug: item.CollectionSlug}
 	}
 	// Populate items — only set parent fields when the parent passed
 	// the visibility filter (i.e. is in the parents map)
@@ -63,6 +65,8 @@ func (s *Server) enrichItemsWithParent(workspaceID string, items []models.Item, 
 			items[i].ParentLinkID = pid
 			items[i].ParentTitle = info.title
 			items[i].ParentRef = info.ref
+			items[i].ParentSlug = info.slug
+			items[i].ParentCollectionSlug = info.collectionSlug
 		}
 	}
 }
@@ -103,6 +107,8 @@ func (s *Server) enrichItemForResponse(item *models.Item, visibleIDs ...[]string
 			item.ParentLinkID = parentLink.TargetID
 			item.ParentRef = parentLink.TargetRef
 			item.ParentTitle = parentLink.TargetTitle
+			item.ParentSlug = parentLink.TargetSlug
+			item.ParentCollectionSlug = parentLink.TargetCollectionSlug
 		}
 	}
 

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -379,6 +379,8 @@ export interface Item {
 	parent_link_id?: string;
 	parent_ref?: string;
 	parent_title?: string;
+	parent_slug?: string;
+	parent_collection_slug?: string;
 	has_children?: boolean;
 	derived_closure?: ItemDerivedClosure;
 	code_context?: ItemCodeContext;

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -603,8 +603,16 @@
 		<nav class="breadcrumb">
 			<a href="/{username}/{wsSlug}">Home</a>
 			<span class="sep">/</span>
-			<a href="/{username}/{wsSlug}/{collSlug}">{collection.icon} {collection.name}</a>
-			<span class="sep">/</span>
+			{#if item.parent_collection_slug && item.parent_slug}
+				{@const parentColl = allCollections.find(c => c.slug === item.parent_collection_slug)}
+				<a href="/{username}/{wsSlug}/{item.parent_collection_slug}">{parentColl?.icon ?? ''} {parentColl?.name ?? item.parent_collection_slug}</a>
+				<span class="sep">/</span>
+				<a href="/{username}/{wsSlug}/{item.parent_collection_slug}/{item.parent_slug}">{item.parent_ref || item.parent_title}</a>
+				<span class="sep">/</span>
+			{:else}
+				<a href="/{username}/{wsSlug}/{collSlug}">{collection.icon} {collection.name}</a>
+				<span class="sep">/</span>
+			{/if}
 			<span class="current">{formatItemRef(item) || item.title}</span>
 		</nav>
 


### PR DESCRIPTION
## Summary

When viewing a child item (e.g. TASK-101 that's a child of PLAN-10), the breadcrumb now shows the parent path instead of the flat collection path:

- **Before:** `Home / Tasks / TASK-101`
- **After:** `Home / Plans / PLAN-10 / TASK-101`

Changes:
- Added `parent_slug` and `parent_collection_slug` fields to the Go `Item` model
- Populated them in both the single-item (`enrichItemForResponse`) and bulk (`enrichItemsWithParent`) enrichment paths from the already-available `ItemLink` data
- Added corresponding TypeScript types
- Updated the breadcrumb nav to render the parent collection → parent item → current item path when a parent exists, falling back to the item's own collection otherwise

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/store/ ./internal/server/` passes
- [x] `npm run build` compiles cleanly
- [ ] View a task that's a child of a plan — breadcrumb shows plan path
- [ ] View a standalone task (no parent) — breadcrumb shows collection as before
- [ ] View an item whose parent is in a hidden collection — breadcrumb falls back to own collection