### PR TITLE
fix: dashboard buttons target correct collections

### DIFF
--- a/web/src/lib/components/layout/Sidebar.svelte
+++ b/web/src/lib/components/layout/Sidebar.svelte
@@ -108,8 +108,10 @@
 	// Watch for Cmd-N quick-add requests from the layout
 	$effect(() => {
 		if (uiStore.quickAddRequested) {
+			const targetSlug = uiStore.quickAddTargetSlug;
 			uiStore.clearQuickAddRequest();
-			const target = activeColl
+			const target = (targetSlug ? regularCollections.find(c => c.slug === targetSlug) : null)
+				?? activeColl
 				?? regularCollections.find(c => c.slug === 'tasks')
 				?? regularCollections[0];
 			if (target) startQuickAdd(target);

--- a/web/src/lib/stores/ui.svelte.ts
+++ b/web/src/lib/stores/ui.svelte.ts
@@ -8,6 +8,7 @@ let isTouch = $state(browser ? 'ontouchstart' in window : false);
 let detailPanelOpen = $state(browser ? localStorage.getItem('pad-detail-panel') !== 'closed' && window.innerWidth > 768 : false);
 let createWorkspaceOpen = $state(false);
 let quickAddRequested = $state(false);
+let quickAddTargetSlug = $state<string | null>(null);
 
 if (browser) {
 	window.addEventListener('resize', () => {
@@ -71,8 +72,9 @@ export const uiStore = {
 
 	// Quick-add item trigger — sidebar watches this
 	get quickAddRequested() { return quickAddRequested; },
-	requestQuickAdd() { quickAddRequested = true; },
-	clearQuickAddRequest() { quickAddRequested = false; },
+	get quickAddTargetSlug() { return quickAddTargetSlug; },
+	requestQuickAdd(collectionSlug?: string) { quickAddTargetSlug = collectionSlug ?? null; quickAddRequested = true; },
+	clearQuickAddRequest() { quickAddRequested = false; quickAddTargetSlug = null; },
 
 	/** Close sidebar on mobile after navigation */
 	onNavigate() {

--- a/web/src/routes/[username]/[workspace]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/+page.svelte
@@ -78,6 +78,7 @@
 	}
 
 	let totalItems = $derived(dashboard?.summary.total_items ?? 0);
+	let firstCollection = $derived(collections.filter(c => !c.is_system && c.slug !== 'tasks').sort((a, b) => a.sort_order - b.sort_order)[0]);
 
 	function statusColor(status: string): string {
 		const s = status.toLowerCase().replace(/-/g, '_');
@@ -176,8 +177,10 @@
 				<span class="item-count">{totalItems} item{totalItems !== 1 ? 's' : ''}</span>
 			</div>
 			<div class="dash-header-actions">
-				<button class="btn btn-secondary" onclick={() => uiStore.requestQuickAdd()}>💡 New Idea</button>
-				<button class="btn btn-primary" onclick={() => uiStore.requestQuickAdd()}>+ New Task</button>
+				{#if firstCollection}
+					<button class="btn btn-secondary" onclick={() => uiStore.requestQuickAdd(firstCollection.slug)}>{firstCollection.icon} New {firstCollection.name.replace(/s$/, '')}</button>
+				{/if}
+				<button class="btn btn-primary" onclick={() => uiStore.requestQuickAdd('tasks')}>+ New Task</button>
 			</div>
 		</header>
 


### PR DESCRIPTION
## Summary

Both dashboard quick-add buttons called `requestQuickAdd()` with no argument, so they both created tasks regardless of label (BUG-498).

- **"New Task"** now explicitly passes `'tasks'` as the target collection
- **Second button** dynamically picks the first non-system, non-task collection by sort order — showing its actual icon and name (e.g. "💡 New Idea" if Ideas is first)
- Added optional `collectionSlug` parameter to `uiStore.requestQuickAdd()` and `quickAddTargetSlug` state so the sidebar respects the caller's target

## Test plan
- [x] `npm run build` compiles cleanly
- [ ] Dashboard: "New Task" opens quick-add for Tasks collection
- [ ] Dashboard: second button opens quick-add for first collection (e.g. Ideas)
- [ ] Cmd-N shortcut still works (defaults to active collection → tasks → first)