### PR TITLE
feat: email unsubscribe for non-transactional emails

### DIFF
--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -312,7 +312,7 @@ func serveCmd() *cobra.Command {
 				if fromName == "" {
 					fromName = "Pad"
 				}
-				srv.SetEmailSender(email.NewSender(cfg.MailerooAPIKey, fromAddr, fromName, cfg.BaseURL()))
+				srv.SetEmailSender(email.NewSender(cfg.MailerooAPIKey, fromAddr, fromName, cfg.BaseURL()), cfg.MailerooAPIKey)
 				slog.Info("Email sending enabled via Maileroo (env)")
 			}
 			// Platform settings can override or provide email config

--- a/internal/email/sender_test.go
+++ b/internal/email/sender_test.go
@@ -148,7 +148,7 @@ func TestSendInvitation_ContextualFromName(t *testing.T) {
 
 	s := newTestSender(ts)
 
-	err := s.SendInvitation(context.Background(), "invitee@example.com", "Alice", "My Project", "https://example.com/join/abc123")
+	err := s.SendInvitation(context.Background(), "invitee@example.com", "Alice", "My Project", "https://example.com/join/abc123", "")
 	if err != nil {
 		t.Fatalf("SendInvitation failed: %v", err)
 	}
@@ -173,7 +173,7 @@ func TestSendWelcome(t *testing.T) {
 
 	s := newTestSender(ts)
 
-	err := s.SendWelcome(context.Background(), "alice@example.com", "Alice")
+	err := s.SendWelcome(context.Background(), "alice@example.com", "Alice", "")
 	if err != nil {
 		t.Fatalf("SendWelcome failed: %v", err)
 	}

--- a/internal/email/templates.go
+++ b/internal/email/templates.go
@@ -7,8 +7,16 @@ import (
 )
 
 // SendInvitation sends a workspace invitation email.
-func (s *Sender) SendInvitation(ctx context.Context, to, inviterName, workspaceName, joinURL string) error {
+// If unsubscribeURL is non-empty, an unsubscribe link is included in the footer.
+func (s *Sender) SendInvitation(ctx context.Context, to, inviterName, workspaceName, joinURL, unsubscribeURL string) error {
 	subject := fmt.Sprintf("%s invited you to %s on Pad", inviterName, workspaceName)
+
+	unsubHTML := ""
+	unsubPlain := ""
+	if unsubscribeURL != "" {
+		unsubHTML = fmt.Sprintf(` <a href="%s" style="color: #999; text-decoration: underline;">Unsubscribe</a> from future emails.`, unsubscribeURL)
+		unsubPlain = fmt.Sprintf("\nUnsubscribe from future emails: %s", unsubscribeURL)
+	}
 
 	htmlBody := fmt.Sprintf(`<!DOCTYPE html>
 <html>
@@ -31,7 +39,7 @@ func (s *Sender) SendInvitation(ctx context.Context, to, inviterName, workspaceN
   <hr style="border: none; border-top: 1px solid #e5e5e5; margin: 32px 0;" />
   <p style="font-size: 12px; color: #999;">
     You received this email because someone invited you to a Pad workspace.
-    If you didn't expect this, you can safely ignore it.
+    If you didn't expect this, you can safely ignore it.%s
   </p>
 </body>
 </html>`,
@@ -40,6 +48,7 @@ func (s *Sender) SendInvitation(ctx context.Context, to, inviterName, workspaceN
 		joinURL,
 		joinURL,
 		joinURL,
+		unsubHTML,
 	)
 
 	plainBody := fmt.Sprintf(`%s has invited you to join %s on Pad.
@@ -48,8 +57,8 @@ Accept the invitation: %s
 
 ---
 You received this email because someone invited you to a Pad workspace.
-If you didn't expect this, you can safely ignore it.`,
-		inviterName, workspaceName, joinURL,
+If you didn't expect this, you can safely ignore it.%s`,
+		inviterName, workspaceName, joinURL, unsubPlain,
 	)
 
 	// Use inviter's name as the sender display name: "Dave via Pad"
@@ -58,8 +67,16 @@ If you didn't expect this, you can safely ignore it.`,
 }
 
 // SendWelcome sends a welcome email after registration.
-func (s *Sender) SendWelcome(ctx context.Context, to, name string) error {
+// If unsubscribeURL is non-empty, an unsubscribe link is included in the footer.
+func (s *Sender) SendWelcome(ctx context.Context, to, name, unsubscribeURL string) error {
 	subject := "Welcome to Pad"
+
+	unsubHTML := ""
+	unsubPlain := ""
+	if unsubscribeURL != "" {
+		unsubHTML = fmt.Sprintf(` <a href="%s" style="color: #999; text-decoration: underline;">Unsubscribe</a> from future emails.`, unsubscribeURL)
+		unsubPlain = fmt.Sprintf("\nUnsubscribe from future emails: %s", unsubscribeURL)
+	}
 
 	htmlBody := fmt.Sprintf(`<!DOCTYPE html>
 <html>
@@ -81,20 +98,21 @@ func (s *Sender) SendWelcome(ctx context.Context, to, name string) error {
   </p>
   <hr style="border: none; border-top: 1px solid #e5e5e5; margin: 32px 0;" />
   <p style="font-size: 12px; color: #999;">
-    You received this because an account was created with this email address.
+    You received this because an account was created with this email address.%s
   </p>
 </body>
 </html>`,
 		html.EscapeString(name),
 		s.baseURL,
+		unsubHTML,
 	)
 
 	plainBody := fmt.Sprintf(`Hi %s, welcome to Pad!
 
 Your account has been created. You can now create workspaces, manage projects, and collaborate with your team.
 
-Open Pad: %s`,
-		name, s.baseURL,
+Open Pad: %s%s`,
+		name, s.baseURL, unsubPlain,
 	)
 
 	return s.Send(ctx, to, name, subject, htmlBody, plainBody)

--- a/internal/email/unsubscribe.go
+++ b/internal/email/unsubscribe.go
@@ -1,0 +1,32 @@
+package email
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/url"
+)
+
+// UnsubscribeURL generates an HMAC-signed unsubscribe link for the given email.
+// The secret should be a stable server-side key (e.g. derived from the API key).
+func UnsubscribeURL(baseURL, emailAddr, secret string) string {
+	token := signEmail(emailAddr, secret)
+	return fmt.Sprintf("%s/api/v1/unsubscribe?email=%s&token=%s",
+		baseURL,
+		url.QueryEscape(emailAddr),
+		url.QueryEscape(token),
+	)
+}
+
+// ValidateUnsubscribeToken checks that the token is a valid HMAC for the email.
+func ValidateUnsubscribeToken(emailAddr, token, secret string) bool {
+	expected := signEmail(emailAddr, secret)
+	return hmac.Equal([]byte(expected), []byte(token))
+}
+
+func signEmail(emailAddr, secret string) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte("unsubscribe:" + emailAddr))
+	return hex.EncodeToString(mac.Sum(nil))
+}

--- a/internal/server/handlers_members.go
+++ b/internal/server/handlers_members.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
+	"github.com/xarmian/pad/internal/email"
 	"github.com/xarmian/pad/internal/models"
 )
 
@@ -169,6 +170,11 @@ func (s *Server) handleInviteMember(w http.ResponseWriter, r *http.Request) {
 	// Send invitation email asynchronously (fire-and-forget)
 	if s.email != nil && joinURL != "" {
 		go func() {
+			// Check if the recipient has opted out of emails
+			if optedOut, err := s.store.IsEmailOptedOut(inv.Email); err == nil && optedOut {
+				slog.Info("skipping invitation email: recipient opted out", "email", inv.Email)
+				return
+			}
 			inviterName := "A team member"
 			wsName := "a workspace"
 			if user, err := s.store.GetUser(inviterID); err == nil && user != nil {
@@ -177,7 +183,8 @@ func (s *Server) handleInviteMember(w http.ResponseWriter, r *http.Request) {
 			if ws, err := s.store.GetWorkspaceByID(workspaceID); err == nil && ws != nil {
 				wsName = ws.Name
 			}
-			if err := s.email.SendInvitation(context.Background(), inv.Email, inviterName, wsName, joinURL); err != nil {
+			unsubURL := email.UnsubscribeURL(s.baseURL, inv.Email, s.unsubscribeSecret())
+			if err := s.email.SendInvitation(context.Background(), inv.Email, inviterName, wsName, joinURL, unsubURL); err != nil {
 				slog.Error("failed to send invitation email", "error", err)
 			}
 		}()

--- a/internal/server/handlers_unsubscribe.go
+++ b/internal/server/handlers_unsubscribe.go
@@ -1,0 +1,73 @@
+package server
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/xarmian/pad/internal/email"
+)
+
+// unsubscribeSecret derives a stable HMAC key from the Maileroo API key.
+// This avoids needing a separate secret config — if the API key changes,
+// old unsubscribe links stop working, which is an acceptable trade-off.
+func (s *Server) unsubscribeSecret() string {
+	if s.email == nil {
+		return ""
+	}
+	h := sha256.Sum256([]byte("pad-unsubscribe:" + s.emailAPIKey))
+	return hex.EncodeToString(h[:])
+}
+
+// handleUnsubscribe processes GET /api/v1/unsubscribe?email=x&token=y
+// This endpoint is unauthenticated — anyone with a valid HMAC token can opt out.
+func (s *Server) handleUnsubscribe(w http.ResponseWriter, r *http.Request) {
+	emailAddr := strings.TrimSpace(r.URL.Query().Get("email"))
+	token := r.URL.Query().Get("token")
+
+	if emailAddr == "" || token == "" {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprint(w, unsubPage("Invalid Link", "This unsubscribe link is missing required parameters."))
+		return
+	}
+
+	secret := s.unsubscribeSecret()
+	if secret == "" || !email.ValidateUnsubscribeToken(emailAddr, token, secret) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprint(w, unsubPage("Invalid Link", "This unsubscribe link is invalid or has expired."))
+		return
+	}
+
+	if err := s.store.OptOutEmail(emailAddr); err != nil {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprint(w, unsubPage("Error", "Something went wrong. Please try again later."))
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	fmt.Fprint(w, unsubPage("Unsubscribed",
+		fmt.Sprintf("You've been unsubscribed. <strong>%s</strong> will no longer receive non-transactional emails from this Pad instance.", emailAddr)))
+}
+
+func unsubPage(title, message string) string {
+	return fmt.Sprintf(`<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>%s — Pad</title>
+</head>
+<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; color: #1a1a1a; max-width: 480px; margin: 80px auto; padding: 0 20px; text-align: center;">
+  <div style="margin-bottom: 24px;">
+    <strong style="font-size: 18px;">Pad</strong>
+  </div>
+  <h1 style="font-size: 22px; font-weight: 600; margin-bottom: 12px;">%s</h1>
+  <p style="font-size: 15px; line-height: 1.5; color: #444;">%s</p>
+</body>
+</html>`, title, title, message)
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -35,6 +35,7 @@ type Server struct {
 	events        events.EventBus       // real-time event bus (optional)
 	webhooks      *webhooks.Dispatcher // webhook dispatcher (optional)
 	email         *email.Sender        // transactional email sender (optional)
+	emailAPIKey   string               // Maileroo API key (used for unsubscribe HMAC)
 	rateLimiters  *RateLimiters        // per-endpoint rate limiters
 	baseURL       string               // public base URL for generating links (e.g. invite URLs)
 	corsOrigins   string               // comma-separated CORS origins (empty = localhost defaults)
@@ -147,8 +148,12 @@ func (s *Server) SetWebhookDispatcher(d *webhooks.Dispatcher) {
 }
 
 // SetEmailSender attaches a transactional email sender.
-func (s *Server) SetEmailSender(e *email.Sender) {
+// The apiKey is stored separately for deriving the unsubscribe HMAC secret.
+func (s *Server) SetEmailSender(e *email.Sender, apiKey ...string) {
 	s.email = e
+	if len(apiKey) > 0 {
+		s.emailAPIKey = apiKey[0]
+	}
 }
 
 // SetCORSOrigins configures allowed CORS origins (comma-separated).
@@ -185,6 +190,7 @@ func (s *Server) reconfigureEmail() {
 		return // No API key — leave email as-is (may still have env var config)
 	}
 
+	s.emailAPIKey = apiKey
 	if s.email == nil {
 		// Create a new sender from platform settings
 		s.email = email.NewSender(apiKey, fromAddr, fromName, s.baseURL)
@@ -250,6 +256,7 @@ func (s *Server) setupRouter() {
 		r.Get("/health/live", s.handleHealthLive)
 		r.Get("/health/ready", s.handleHealthReady)
 		r.Get("/plan-limits", s.handleGetPlanLimits) // Public: billing page reads plan limits
+		r.Get("/unsubscribe", s.handleUnsubscribe)   // Public: email opt-out (HMAC-signed)
 
 		// Auth endpoints (exempt from auth middleware)
 		r.Route("/auth", func(r chi.Router) {

--- a/internal/store/email_optouts.go
+++ b/internal/store/email_optouts.go
@@ -1,0 +1,22 @@
+package store
+
+import "strings"
+
+// IsEmailOptedOut returns true if the given email address has unsubscribed.
+func (s *Store) IsEmailOptedOut(email string) (bool, error) {
+	var count int
+	err := s.db.QueryRow(s.q(`SELECT COUNT(*) FROM email_optouts WHERE email = ?`), strings.ToLower(email)).Scan(&count)
+	if err != nil {
+		return false, err
+	}
+	return count > 0, nil
+}
+
+// OptOutEmail adds an email address to the opt-out list.
+func (s *Store) OptOutEmail(email string) error {
+	_, err := s.db.Exec(s.q(`
+		INSERT INTO email_optouts (email) VALUES (?)
+		ON CONFLICT (email) DO NOTHING
+	`), strings.ToLower(email))
+	return err
+}

--- a/internal/store/migrations/038_email_optouts.sql
+++ b/internal/store/migrations/038_email_optouts.sql
@@ -1,0 +1,5 @@
+-- Email opt-outs: tracks email addresses that have unsubscribed from non-transactional emails.
+CREATE TABLE IF NOT EXISTS email_optouts (
+    email      TEXT PRIMARY KEY,
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);

--- a/internal/store/pgmigrations/018_email_optouts.sql
+++ b/internal/store/pgmigrations/018_email_optouts.sql
@@ -1,0 +1,5 @@
+-- Email opt-outs: tracks email addresses that have unsubscribed from non-transactional emails.
+CREATE TABLE IF NOT EXISTS email_optouts (
+    email      TEXT PRIMARY KEY,
+    created_at TEXT NOT NULL DEFAULT (NOW() AT TIME ZONE 'UTC')::TEXT
+);

--- a/web/src/routes/[username]/[workspace]/settings/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/settings/+page.svelte
@@ -583,9 +583,13 @@
 							<div class="card invitation-row">
 								<span class="inv-email">{inv.email}</span>
 								<span class="role-badge">{inv.role}</span>
-								<button class="btn btn-small copy-link-btn" onclick={async () => { const url = inv.join_url || `${window.location.origin}/join/${inv.code}`; const ok = await copyToClipboard(url); toastStore.show(ok ? 'Link copied!' : 'Failed to copy link', ok ? 'success' : 'error'); }}>
-									Copy invite link
-								</button>
+								{#if inv.join_url || inv.code}
+									<button class="btn btn-small copy-link-btn" onclick={async () => { const url = inv.join_url || `${window.location.origin}/join/${inv.code}`; const ok = await copyToClipboard(url); toastStore.show(ok ? 'Link copied!' : 'Failed to copy link', ok ? 'success' : 'error'); }}>
+										Copy invite link
+									</button>
+								{:else}
+									<span class="inv-sent-label">Sent via email</span>
+								{/if}
 								{#if isOwner}
 									<button class="btn btn-small btn-remove" onclick={() => handleCancelInvitation(inv.id, inv.email)}>
 										Cancel
@@ -852,6 +856,7 @@
 	.inv-email { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; }
 	.copy-link-btn { color: var(--accent-blue); border-color: var(--accent-blue); background: none; }
 	.copy-link-btn:hover { background: color-mix(in srgb, var(--accent-blue) 15%, transparent); }
+	.inv-sent-label { font-size: 0.8em; color: var(--text-muted); font-style: italic; }
 	.invite-form { margin-top: var(--space-4); }
 	.invite-form h3 { font-size: 0.9em; color: var(--text-secondary); margin-bottom: var(--space-3); }
 	.invite-row { display: flex; gap: var(--space-2); align-items: center; flex-wrap: wrap; }


### PR DESCRIPTION
## Summary

Adds CAN-SPAM compliant email unsubscribe support, keyed by **email address** (not user ID) so uninvited recipients without accounts can opt out and stop invite spam.

- **`email_optouts` table** — simple `(email, created_at)` keyed by address. Migration for both SQLite and PostgreSQL.
- **HMAC-signed tokens** — derived from the Maileroo API key via SHA-256, so no separate secret config needed. Tokens are embedded in unsubscribe URLs.
- **`GET /api/v1/unsubscribe?email=x&token=y`** — unauthenticated endpoint that validates the HMAC, inserts into optouts, and renders a simple HTML confirmation page.
- **Invitation emails** — footer now includes an unsubscribe link. Before sending, the handler checks `email_optouts` and silently skips opted-out addresses.
- **Welcome emails** — template accepts optional unsubscribe URL (not currently triggered from any handler, but ready).
- **Password reset** — exempt (transactional, user-initiated).

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/email/ ./internal/store/ ./internal/server/` passes
- [x] `npm run build` compiles cleanly
- [ ] Send an invitation email — verify unsubscribe link appears in footer
- [ ] Click unsubscribe link — verify confirmation page renders
- [ ] Send another invitation to the same address — verify email is silently skipped
- [ ] Password reset emails should have no unsubscribe link