### PR TITLE
feat: browser-based CLI authentication flow

### DIFF
--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -497,7 +497,7 @@ func setupCmd() *cobra.Command {
 }
 
 func loginCmd() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "login",
 		Short: "Log in to Pad",
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -529,13 +529,89 @@ func loginCmd() *cobra.Command {
 				return fmt.Errorf("this Pad instance has not been initialized yet")
 			}
 
-			// Prompt for login
-			return doLogin(client, cfg)
+			interactive, _ := cmd.Flags().GetBool("interactive")
+			if interactive {
+				return doInteractiveLogin(client, cfg)
+			}
+			return doBrowserLogin(client, cfg)
 		},
+	}
+	cmd.Flags().BoolP("interactive", "i", false, "Use email/password prompt instead of browser-based login")
+	return cmd
+}
+
+// doBrowserLogin implements the browser-based CLI auth flow.
+// It creates a pending session, prints the auth URL, and polls until approved.
+func doBrowserLogin(client *cli.Client, cfg *config.Config) error {
+	// Create a CLI auth session on the server
+	sess, err := client.CreateCLIAuthSession()
+	if err != nil {
+		return fmt.Errorf("failed to start login session: %w", err)
+	}
+
+	fmt.Println()
+	fmt.Println("  Open this URL in your browser to authenticate:")
+	fmt.Println()
+	bold := color.New(color.Bold).SprintFunc()
+	fmt.Printf("  %s\n", bold(sess.AuthURL))
+	fmt.Println()
+	fmt.Println("  Waiting for authentication...")
+
+	// Set up signal handling for clean Ctrl+C
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		<-sigCh
+		cancel()
+	}()
+
+	// Poll until approved, expired, or cancelled
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			fmt.Println("\n  Login cancelled.")
+			return fmt.Errorf("login cancelled")
+		case <-ticker.C:
+			status, err := client.PollCLIAuthSession(sess.SessionCode)
+			if err != nil {
+				// Transient network errors — keep polling
+				continue
+			}
+
+			switch status.Status {
+			case "approved":
+				// Save credentials
+				if err := cli.SaveCredentials(&cli.Credentials{
+					ServerURL: cfg.BaseURL(),
+					Token:     status.Token,
+					UserID:    status.User.ID,
+					Email:     status.User.Email,
+					Name:      status.User.Name,
+				}); err != nil {
+					return fmt.Errorf("save credentials: %w", err)
+				}
+
+				green := color.New(color.FgGreen).SprintFunc()
+				fmt.Printf("  %s Logged in as %s (%s)\n", green("✓"), status.User.Name, status.User.Email)
+				return nil
+
+			case "expired":
+				return fmt.Errorf("login session expired — run 'pad auth login' to try again")
+
+			case "pending":
+				// Keep polling
+			}
+		}
 	}
 }
 
-func doLogin(client *cli.Client, cfg *config.Config) error {
+// doInteractiveLogin implements the classic email/password prompt login.
+func doInteractiveLogin(client *cli.Client, cfg *config.Config) error {
 	reader := bufio.NewReader(os.Stdin)
 
 	fmt.Print("  Email: ")
@@ -966,7 +1042,7 @@ Use --list-templates to see available templates.`,
 			} else if !session.Authenticated {
 				fmt.Println("Log in to continue.")
 				fmt.Println()
-				if err := doLogin(client, cfg); err != nil {
+				if err := doBrowserLogin(client, cfg); err != nil {
 					return err
 				}
 				fmt.Println()

--- a/internal/cli/client.go
+++ b/internal/cli/client.go
@@ -462,6 +462,34 @@ func (c *Client) Bootstrap(email, name, password string) (*LoginResponse, error)
 	return &result, err
 }
 
+// CLIAuthSessionResponse is the response from POST /auth/cli/sessions.
+type CLIAuthSessionResponse struct {
+	SessionCode string `json:"session_code"`
+	AuthURL     string `json:"auth_url"`
+	ExpiresAt   string `json:"expires_at"`
+}
+
+// CLIAuthSessionStatus is the response from GET /auth/cli/sessions/{code}.
+type CLIAuthSessionStatus struct {
+	Status string    `json:"status"` // "pending", "approved", "expired"
+	Token  string    `json:"token,omitempty"`
+	User   LoginUser `json:"user,omitempty"`
+}
+
+// CreateCLIAuthSession creates a new pending CLI auth session.
+func (c *Client) CreateCLIAuthSession() (*CLIAuthSessionResponse, error) {
+	var result CLIAuthSessionResponse
+	err := c.post("/auth/cli/sessions", nil, &result)
+	return &result, err
+}
+
+// PollCLIAuthSession checks the status of a CLI auth session.
+func (c *Client) PollCLIAuthSession(code string) (*CLIAuthSessionStatus, error) {
+	var result CLIAuthSessionStatus
+	err := c.get("/auth/cli/sessions/"+code, &result)
+	return &result, err
+}
+
 // Logout destroys the current session.
 func (c *Client) Logout() error {
 	return c.post("/auth/logout", nil, nil)

--- a/internal/server/handlers_cli_auth.go
+++ b/internal/server/handlers_cli_auth.go
@@ -1,0 +1,142 @@
+package server
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// handleCreateCLIAuthSession creates a new pending CLI auth session.
+// The CLI calls this, then presents the auth URL to the user.
+// POST /api/v1/auth/cli/sessions
+func (s *Server) handleCreateCLIAuthSession(w http.ResponseWriter, r *http.Request) {
+	sess, err := s.store.CreateCLIAuthSession()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to create CLI auth session")
+		return
+	}
+
+	// Build the auth URL that the user will open in their browser.
+	// Use the request's Host header to construct the URL so it works
+	// regardless of whether the server is at localhost, a VPS, or cloud.
+	scheme := "https"
+	if r.TLS == nil {
+		// Check X-Forwarded-Proto for reverse proxy setups
+		if proto := r.Header.Get("X-Forwarded-Proto"); proto != "" {
+			scheme = proto
+		} else {
+			scheme = "http"
+		}
+	}
+	authURL := fmt.Sprintf("%s://%s/auth/cli/%s", scheme, r.Host, sess.Code)
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"session_code": sess.Code,
+		"auth_url":     authURL,
+		"expires_at":   sess.ExpiresAt,
+	})
+}
+
+// handlePollCLIAuthSession checks the status of a CLI auth session.
+// The CLI polls this until the session is approved or expired.
+// GET /api/v1/auth/cli/sessions/{code}
+func (s *Server) handlePollCLIAuthSession(w http.ResponseWriter, r *http.Request) {
+	code := chi.URLParam(r, "code")
+	if code == "" {
+		writeError(w, http.StatusBadRequest, "bad_request", "Missing session code")
+		return
+	}
+
+	sess, err := s.store.GetCLIAuthSession(code)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to check CLI auth session")
+		return
+	}
+	if sess == nil {
+		writeError(w, http.StatusNotFound, "not_found", "CLI auth session not found")
+		return
+	}
+
+	response := map[string]interface{}{
+		"status": sess.Status,
+	}
+
+	// Only include the token and user info when approved
+	if sess.Status == "approved" && sess.Token != "" {
+		response["token"] = sess.Token
+
+		// Look up user info to return alongside the token
+		if sess.UserID != "" {
+			user, err := s.store.GetUser(sess.UserID)
+			if err == nil && user != nil {
+				response["user"] = sessionUserPayload(user)
+			}
+		}
+
+		// Clean up the session after it's been consumed
+		_ = s.store.DeleteCLIAuthSession(code)
+	}
+
+	writeJSON(w, http.StatusOK, response)
+}
+
+// handleApproveCLIAuthSession approves a pending CLI auth session.
+// Called from the browser by an authenticated user.
+// POST /api/v1/auth/cli/sessions/{code}/approve
+func (s *Server) handleApproveCLIAuthSession(w http.ResponseWriter, r *http.Request) {
+	code := chi.URLParam(r, "code")
+	if code == "" {
+		writeError(w, http.StatusBadRequest, "bad_request", "Missing session code")
+		return
+	}
+
+	// Resolve the authenticated user — try context first (set by middleware),
+	// then fall back to session cookie (since auth routes are exempt from middleware).
+	user := currentUser(r)
+	if user == nil {
+		user = s.validateSessionCookie(r)
+	}
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, "unauthorized", "You must be logged in to approve a CLI session")
+		return
+	}
+
+	// Verify the session exists and is pending
+	sess, err := s.store.GetCLIAuthSession(code)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to check CLI auth session")
+		return
+	}
+	if sess == nil {
+		writeError(w, http.StatusNotFound, "not_found", "CLI auth session not found")
+		return
+	}
+	if sess.Status == "expired" {
+		writeError(w, http.StatusGone, "expired", "This CLI auth session has expired. Run 'pad auth login' again.")
+		return
+	}
+	if sess.Status == "approved" {
+		writeError(w, http.StatusConflict, "already_approved", "This CLI session has already been approved")
+		return
+	}
+
+	// Create a new session token for the CLI (long-lived, 30 days)
+	token, err := s.store.CreateSession(user.ID, "cli-browser-auth", clientIP(r), "", 30*24*time.Hour)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to create session")
+		return
+	}
+
+	// Approve the CLI auth session with the new token
+	if err := s.store.ApproveCLIAuthSession(code, token, user.ID); err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to approve CLI auth session")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"approved": true,
+		"user":     sessionUserPayload(user),
+	})
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -293,6 +293,11 @@ func (s *Server) setupRouter() {
 			r.Post("/oauth-login", s.handleOAuthLogin)
 			r.Post("/oauth-link", s.handleOAuthLink)
 			r.Post("/oauth-unlink", s.handleOAuthUnlink)
+
+			// CLI browser-based auth flow
+			r.Post("/cli/sessions", s.handleCreateCLIAuthSession)
+			r.Get("/cli/sessions/{code}", s.handlePollCLIAuthSession)
+			r.Post("/cli/sessions/{code}/approve", s.handleApproveCLIAuthSession)
 		})
 
 		// Admin endpoints (admin-only, handlers check role internally)

--- a/internal/store/cli_auth_sessions.go
+++ b/internal/store/cli_auth_sessions.go
@@ -1,0 +1,145 @@
+package store
+
+import (
+	"crypto/rand"
+	"database/sql"
+	"encoding/hex"
+	"fmt"
+	"time"
+)
+
+const cliAuthSessionTTL = 5 * time.Minute
+
+// CLIAuthSession represents a pending or approved CLI login session.
+type CLIAuthSession struct {
+	Code      string `json:"code"`
+	Status    string `json:"status"` // "pending", "approved", "expired"
+	Token     string `json:"token,omitempty"`
+	UserID    string `json:"user_id,omitempty"`
+	ExpiresAt string `json:"expires_at"`
+	CreatedAt string `json:"created_at"`
+}
+
+// CreateCLIAuthSession generates a new pending CLI auth session with a
+// cryptographically random code. Returns the session including the code
+// the CLI should present to the user.
+func (s *Store) CreateCLIAuthSession() (*CLIAuthSession, error) {
+	// Clean up expired sessions opportunistically
+	_, _ = s.db.Exec(s.q(`
+		DELETE FROM cli_auth_sessions WHERE expires_at < ?
+	`), now())
+
+	// Generate a 16-byte random code (32 hex chars)
+	raw := make([]byte, 16)
+	if _, err := rand.Read(raw); err != nil {
+		return nil, fmt.Errorf("generate cli auth code: %w", err)
+	}
+	code := hex.EncodeToString(raw)
+
+	ts := now()
+	expiresAt := time.Now().UTC().Add(cliAuthSessionTTL).Format(time.RFC3339)
+
+	_, err := s.db.Exec(s.q(`
+		INSERT INTO cli_auth_sessions (code, status, created_at, expires_at)
+		VALUES (?, 'pending', ?, ?)
+	`), code, ts, expiresAt)
+	if err != nil {
+		return nil, fmt.Errorf("insert cli auth session: %w", err)
+	}
+
+	return &CLIAuthSession{
+		Code:      code,
+		Status:    "pending",
+		ExpiresAt: expiresAt,
+		CreatedAt: ts,
+	}, nil
+}
+
+// GetCLIAuthSession retrieves a CLI auth session by code. Returns nil if
+// not found. Expired sessions are returned with status updated to "expired".
+func (s *Store) GetCLIAuthSession(code string) (*CLIAuthSession, error) {
+	var sess CLIAuthSession
+	var token, userID sql.NullString
+
+	err := s.db.QueryRow(s.q(`
+		SELECT code, status, token, user_id, created_at, expires_at
+		FROM cli_auth_sessions WHERE code = ?
+	`), code).Scan(&sess.Code, &sess.Status, &token, &userID, &sess.CreatedAt, &sess.ExpiresAt)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get cli auth session: %w", err)
+	}
+
+	if token.Valid {
+		sess.Token = token.String
+	}
+	if userID.Valid {
+		sess.UserID = userID.String
+	}
+
+	// Check expiry
+	if sess.Status == "pending" && parseTime(sess.ExpiresAt).Before(time.Now().UTC()) {
+		sess.Status = "expired"
+		// Update in DB lazily
+		_, _ = s.db.Exec(s.q(`
+			UPDATE cli_auth_sessions SET status = 'expired' WHERE code = ?
+		`), code)
+	}
+
+	return &sess, nil
+}
+
+// ApproveCLIAuthSession marks a pending session as approved, storing the
+// session token and user ID. Returns an error if the session doesn't exist,
+// is expired, or was already approved.
+func (s *Store) ApproveCLIAuthSession(code, sessionToken, userID string) error {
+	sess, err := s.GetCLIAuthSession(code)
+	if err != nil {
+		return err
+	}
+	if sess == nil {
+		return fmt.Errorf("cli auth session not found")
+	}
+	if sess.Status == "expired" {
+		return fmt.Errorf("cli auth session has expired")
+	}
+	if sess.Status == "approved" {
+		return fmt.Errorf("cli auth session already approved")
+	}
+
+	result, err := s.db.Exec(s.q(`
+		UPDATE cli_auth_sessions
+		SET status = 'approved', token = ?, user_id = ?
+		WHERE code = ? AND status = 'pending'
+	`), sessionToken, userID, code)
+	if err != nil {
+		return fmt.Errorf("approve cli auth session: %w", err)
+	}
+
+	rows, _ := result.RowsAffected()
+	if rows == 0 {
+		return fmt.Errorf("cli auth session could not be approved (race condition or already consumed)")
+	}
+
+	return nil
+}
+
+// DeleteCLIAuthSession removes a CLI auth session by code.
+func (s *Store) DeleteCLIAuthSession(code string) error {
+	_, err := s.db.Exec(s.q(`DELETE FROM cli_auth_sessions WHERE code = ?`), code)
+	if err != nil {
+		return fmt.Errorf("delete cli auth session: %w", err)
+	}
+	return nil
+}
+
+// CleanExpiredCLIAuthSessions removes all expired CLI auth sessions.
+func (s *Store) CleanExpiredCLIAuthSessions() error {
+	_, err := s.db.Exec(s.q(`DELETE FROM cli_auth_sessions WHERE expires_at < ?`), now())
+	if err != nil {
+		return fmt.Errorf("clean expired cli auth sessions: %w", err)
+	}
+	return nil
+}

--- a/internal/store/migrations/039_cli_auth_sessions.sql
+++ b/internal/store/migrations/039_cli_auth_sessions.sql
@@ -1,0 +1,13 @@
+-- CLI auth sessions: browser-based CLI login flow.
+-- The CLI creates a pending session, the user approves it in the browser,
+-- and the CLI polls until a token is available.
+CREATE TABLE IF NOT EXISTS cli_auth_sessions (
+    code       TEXT PRIMARY KEY,
+    status     TEXT NOT NULL DEFAULT 'pending',  -- pending, approved, expired
+    token      TEXT,                              -- session token, set on approval
+    user_id    TEXT,                              -- set on approval
+    created_at TEXT NOT NULL,
+    expires_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_cli_auth_sessions_expires ON cli_auth_sessions(expires_at);

--- a/internal/store/pgmigrations/019_cli_auth_sessions.sql
+++ b/internal/store/pgmigrations/019_cli_auth_sessions.sql
@@ -1,0 +1,13 @@
+-- CLI auth sessions: browser-based CLI login flow.
+-- The CLI creates a pending session, the user approves it in the browser,
+-- and the CLI polls until a token is available.
+CREATE TABLE IF NOT EXISTS cli_auth_sessions (
+    code       TEXT PRIMARY KEY,
+    status     TEXT NOT NULL DEFAULT 'pending',
+    token      TEXT,
+    user_id    TEXT,
+    created_at TEXT NOT NULL,
+    expires_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_cli_auth_sessions_expires ON cli_auth_sessions(expires_at);

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -171,6 +171,8 @@ func (s *Store) migrate() error {
 		"035_plan_fields.sql",
 		"036_stripe_customer_index.sql",
 		"037_oauth_providers.sql",
+		"038_email_optouts.sql",
+		"039_cli_auth_sessions.sql",
 	}
 
 	for _, name := range migrations {
@@ -232,6 +234,8 @@ func (s *Store) migratePostgres() error {
 		"015_plan_fields.sql",
 		"016_stripe_customer_index.sql",
 		"017_oauth_providers.sql",
+		"018_email_optouts.sql",
+		"019_cli_auth_sessions.sql",
 	}
 
 	for _, name := range migrations {

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -644,6 +644,14 @@ export const api = {
 				}),
 			delete: (tokenId: string) =>
 				request<void>(`/auth/tokens/${tokenId}`, { method: 'DELETE' })
+		},
+		cli: {
+			getSession: (code: string) =>
+				request<{ status: string; token?: string; user?: { id: string; email: string; name: string; role: string } }>(`/auth/cli/sessions/${code}`),
+			approveSession: (code: string) =>
+				request<{ approved: boolean; user: { id: string; email: string; name: string; role: string } }>(`/auth/cli/sessions/${code}/approve`, {
+					method: 'POST'
+				})
 		}
 	},
 

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -18,7 +18,7 @@
 
 	let showShortcuts = $state(false);
 	let authReady = $state(false);
-	let isAuthPage = $derived(page.url.pathname === '/login' || page.url.pathname === '/register' || page.url.pathname.startsWith('/join/'));
+	let isAuthPage = $derived(page.url.pathname === '/login' || page.url.pathname === '/register' || page.url.pathname.startsWith('/join/') || page.url.pathname.startsWith('/auth/cli/'));
 	let isSharePage = $derived(page.url.pathname.startsWith('/s/'));
 	let isConsolePage = $derived(page.url.pathname.startsWith('/console'));
 

--- a/web/src/routes/auth/cli/[code]/+page.svelte
+++ b/web/src/routes/auth/cli/[code]/+page.svelte
@@ -1,0 +1,184 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { page } from '$app/stores';
+	import { goto } from '$app/navigation';
+	import { api } from '$lib/api/client';
+
+	let status = $state<'loading' | 'pending' | 'approved' | 'expired' | 'error' | 'success' | 'already_approved'>('loading');
+	let error = $state('');
+	let approving = $state(false);
+
+	onMount(async () => {
+		const code = $page.params.code;
+
+		try {
+			const session = await api.auth.cli.getSession(code);
+
+			if (session.status === 'expired') {
+				status = 'expired';
+				return;
+			}
+
+			if (session.status === 'approved') {
+				status = 'already_approved';
+				return;
+			}
+
+			// Session is pending — check if user is logged in
+			const authSession = await api.auth.session();
+			if (!authSession.authenticated) {
+				goto(`/login?redirect=/auth/cli/${code}`, { replaceState: true });
+				return;
+			}
+
+			status = 'pending';
+		} catch {
+			status = 'error';
+			error = 'This link is invalid or has expired. Run `pad auth login` again.';
+		}
+	});
+
+	async function handleApprove() {
+		const code = $page.params.code;
+		approving = true;
+		error = '';
+
+		try {
+			await api.auth.cli.approveSession(code);
+			status = 'success';
+		} catch (err: unknown) {
+			if (err instanceof Error) {
+				error = err.message || 'Failed to approve session.';
+			} else {
+				error = 'Failed to approve session.';
+			}
+		} finally {
+			approving = false;
+		}
+	}
+</script>
+
+<div class="login-page">
+	<div class="login-card">
+		<h1 class="logo">Pad</h1>
+
+		{#if status === 'loading'}
+			<p class="subtitle">Verifying session...</p>
+		{:else if status === 'error' || status === 'expired'}
+			<p class="subtitle">Session unavailable</p>
+			<p class="error-message">
+				{status === 'expired'
+					? 'This link is invalid or has expired. Run `pad auth login` again.'
+					: error}
+			</p>
+		{:else if status === 'already_approved'}
+			<p class="subtitle">Already approved</p>
+			<p class="success-message">This session has already been approved.</p>
+		{:else if status === 'pending'}
+			<p class="subtitle">Authorize CLI session</p>
+			<p class="description">
+				A CLI session is requesting access to your account. Approve this request to sign in from the terminal.
+			</p>
+
+			{#if error}
+				<p class="error">{error}</p>
+			{/if}
+
+			<button onclick={handleApprove} disabled={approving}>
+				{#if approving}
+					Approving...
+				{:else}
+					Approve
+				{/if}
+			</button>
+		{:else if status === 'success'}
+			<p class="subtitle">Authorized</p>
+			<p class="success-message">CLI session authorized. You can close this tab.</p>
+		{/if}
+	</div>
+</div>
+
+<style>
+	.login-page {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		min-height: 100vh;
+		background: var(--bg-primary);
+		padding: var(--space-4);
+	}
+
+	.login-card {
+		width: 100%;
+		max-width: 360px;
+		background: var(--bg-secondary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius-lg);
+		padding: var(--space-10) var(--space-8);
+		text-align: center;
+	}
+
+	.logo {
+		font-size: 2rem;
+		font-weight: 700;
+		color: var(--text-primary);
+		letter-spacing: -0.02em;
+		margin-bottom: var(--space-2);
+	}
+
+	.subtitle {
+		color: var(--text-muted);
+		font-size: 0.9rem;
+		margin-bottom: var(--space-6);
+	}
+
+	.description {
+		color: var(--text-secondary);
+		font-size: 0.85rem;
+		line-height: 1.5;
+		margin-bottom: var(--space-6);
+		text-align: left;
+	}
+
+	.error-message {
+		color: #ef4444;
+		font-size: 0.85rem;
+		line-height: 1.5;
+	}
+
+	.error {
+		color: #ef4444;
+		font-size: 0.85rem;
+		text-align: left;
+		margin-bottom: var(--space-4);
+	}
+
+	.success-message {
+		color: var(--text-secondary);
+		font-size: 0.9rem;
+		line-height: 1.5;
+	}
+
+	button {
+		width: 100%;
+		padding: var(--space-3) var(--space-4);
+		background: var(--accent-blue);
+		color: #fff;
+		border: none;
+		border-radius: var(--radius);
+		font-size: 0.95rem;
+		font-weight: 500;
+		font-family: var(--font-ui);
+		cursor: pointer;
+		transition: opacity 0.15s;
+	}
+
+	button:hover:not(:disabled) {
+		opacity: 0.9;
+	}
+
+	button:disabled {
+		opacity: 0.6;
+		cursor: not-allowed;
+	}
+</style>

--- a/web/src/routes/login/+page.svelte
+++ b/web/src/routes/login/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
+	import { page } from '$app/stores';
 	import { api } from '$lib/api/client';
 	import { authStore } from '$lib/stores/auth.svelte';
 	import { goto } from '$app/navigation';
@@ -17,6 +18,15 @@
 	let challengeToken = $state('');
 	let totpCode = $state('');
 
+	function getRedirectTarget(): string {
+		const redirect = $page.url.searchParams.get('redirect');
+		// Only allow relative redirects (prevent open redirect)
+		if (redirect && redirect.startsWith('/')) {
+			return redirect;
+		}
+		return '/console';
+	}
+
 	onMount(async () => {
 		try {
 			const session = await api.auth.session();
@@ -27,7 +37,7 @@
 				return;
 			}
 			if (session.authenticated) {
-				goto('/console', { replaceState: true });
+				goto(getRedirectTarget(), { replaceState: true });
 				return;
 			}
 		} catch {}
@@ -56,7 +66,7 @@
 			}
 
 			await authStore.load();
-			await goto('/console', { replaceState: true });
+			await goto(getRedirectTarget(), { replaceState: true });
 		} catch (err: unknown) {
 			if (err instanceof Error) {
 				error = err.message || 'Invalid email or password.';
@@ -88,7 +98,7 @@
 			}
 
 			await authStore.load();
-			await goto('/console', { replaceState: true });
+			await goto(getRedirectTarget(), { replaceState: true });
 		} catch (err: unknown) {
 			if (err instanceof Error) {
 				error = err.message || 'Invalid code. Please try again.';


### PR DESCRIPTION
## Summary

- Replace `pad auth login` email/password prompt with a browser-based auth flow
- CLI creates a pending session, prints a URL, and polls until the user approves in their browser
- Works identically for localhost, remote self-hosted, and Pad Cloud
- Old email/password flow preserved behind `pad auth login --interactive`

## Changes

- **Server:** 3 new endpoints — `POST /auth/cli/sessions` (create), `GET /auth/cli/sessions/{code}` (poll), `POST /auth/cli/sessions/{code}/approve` (approve)
- **Frontend:** New approval page at `/auth/cli/{code}` with login redirect support
- **CLI:** Rewrote `loginCmd()` to use browser flow by default, added `--interactive` flag
- **Migrations:** New `cli_auth_sessions` table (SQLite 039, PostgreSQL 019)
- **Login page:** Added `?redirect=` query param support for post-login bounce-back

## Test plan

- [x] `pad auth logout` then `pad auth login` — prints URL, waits for approval
- [x] Open URL in browser — shows approval page, click Approve
- [x] CLI picks up token and completes login
- [x] `pad auth login --interactive` — old email/password flow still works
- [x] Expired session shows clear error message
- [x] `go build ./...` and `go test ./...` pass
- [x] `npm run build` passes

Closes PLAN-539, IDEA-404