### PR TITLE
feat: refactor admin console into tabbed layout

### DIFF
--- a/web/src/lib/stores/admin.svelte.ts
+++ b/web/src/lib/stores/admin.svelte.ts
@@ -1,0 +1,104 @@
+// ---------------------------------------------------------------------------
+// Admin store – shared state & utilities for the admin section
+// ---------------------------------------------------------------------------
+
+// ---- Interfaces -----------------------------------------------------------
+
+export interface AdminUser {
+	id: string;
+	email: string;
+	username: string;
+	name: string;
+	role: string;
+	plan: string;
+	plan_expires_at: string | null;
+	plan_overrides: Record<string, number> | null;
+	totp_enabled: boolean;
+	created_at: string;
+}
+
+export interface Stats {
+	users: number;
+	users_by_plan: Record<string, number>;
+	workspaces: number;
+	cloud_mode: boolean;
+}
+
+export interface LimitTiers {
+	free: Record<string, number>;
+	pro: Record<string, number>;
+}
+
+// ---- Helper functions -----------------------------------------------------
+
+export function getCSRFToken(): string | null {
+	const hostMatch = document.cookie.match(/(?:^|;\s*)__Host-pad_csrf=([^;]+)/);
+	if (hostMatch) return hostMatch[1];
+	const match = document.cookie.match(/(?:^|;\s*)pad_csrf=([^;]+)/);
+	return match ? match[1] : null;
+}
+
+export async function adminFetch(path: string, opts?: RequestInit) {
+	const resp = await fetch('/api/v1' + path, { credentials: 'same-origin', ...opts });
+	if (!resp.ok) throw new Error(`${resp.status}`);
+	return resp.json();
+}
+
+export async function adminPatch(path: string, body: unknown) {
+	const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+	const csrf = getCSRFToken();
+	if (csrf) headers['X-CSRF-Token'] = csrf;
+	return adminFetch(path, {
+		method: 'PATCH',
+		headers,
+		body: JSON.stringify(body)
+	});
+}
+
+export async function adminPost(path: string, body?: unknown) {
+	const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+	const csrf = getCSRFToken();
+	if (csrf) headers['X-CSRF-Token'] = csrf;
+	const opts: RequestInit = { method: 'POST', headers };
+	if (body !== undefined) opts.body = JSON.stringify(body);
+	return adminFetch(path, opts);
+}
+
+export function formatDate(d: string): string {
+	return new Date(d).toLocaleDateString('en-US', {
+		month: 'short',
+		day: 'numeric',
+		year: 'numeric'
+	});
+}
+
+// ---- Reactive store -------------------------------------------------------
+
+let stats = $state<Stats | null>(null);
+let loading = $state(true);
+let error = $state('');
+
+async function loadStats() {
+	loading = true;
+	error = '';
+	try {
+		stats = await adminFetch('/admin/stats');
+	} catch (e) {
+		error = e instanceof Error ? e.message : 'Failed to load';
+	} finally {
+		loading = false;
+	}
+}
+
+export const adminStore = {
+	get stats() {
+		return stats;
+	},
+	get loading() {
+		return loading;
+	},
+	get error() {
+		return error;
+	},
+	loadStats
+};

--- a/web/src/routes/console/admin/+layout.svelte
+++ b/web/src/routes/console/admin/+layout.svelte
@@ -1,0 +1,126 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { page } from '$app/state';
+	import { authStore } from '$lib/stores/auth.svelte';
+	import { adminStore } from '$lib/stores/admin.svelte';
+
+	let { children } = $props();
+
+	let isAdmin = $derived(authStore.user?.role === 'admin');
+
+	onMount(() => {
+		if (isAdmin) {
+			adminStore.loadStats();
+		}
+	});
+
+	const tabs = [
+		{ label: 'Users', href: '/console/admin' },
+		{ label: 'Invitations', href: '/console/admin/invitations' },
+		{ label: 'Audit Log', href: '/console/admin/audit-log' },
+		{ label: 'Settings', href: '/console/admin/settings' }
+	];
+
+	function isActive(href: string): boolean {
+		const path = page.url.pathname;
+		if (href === '/console/admin') {
+			return path === '/console/admin';
+		}
+		return path.startsWith(href);
+	}
+</script>
+
+<svelte:head>
+	<title>Admin - Pad</title>
+</svelte:head>
+
+<div class="admin-layout">
+	{#if !isAdmin}
+		<div class="denied">Admin access required</div>
+	{:else if adminStore.loading}
+		<div class="loading-msg">Loading admin data...</div>
+	{:else if adminStore.error}
+		<div class="error-msg">{adminStore.error}</div>
+	{:else}
+		{#if adminStore.stats}
+			<div class="stats-bar">
+				<div class="stat">
+					<span class="stat-value">{adminStore.stats.users}</span>
+					<span class="stat-label">Users</span>
+				</div>
+				{#each Object.entries(adminStore.stats.users_by_plan) as [plan, count] (plan)}
+					<div class="stat">
+						<span class="stat-value">{count}</span>
+						<span class="stat-label">{plan}</span>
+					</div>
+				{/each}
+				<div class="stat">
+					<span class="stat-value">{adminStore.stats.workspaces}</span>
+					<span class="stat-label">Workspaces</span>
+				</div>
+			</div>
+		{/if}
+
+		<nav class="admin-tabs">
+			{#each tabs as tab (tab.href)}
+				<a
+					class="admin-tab"
+					class:active={isActive(tab.href)}
+					href={tab.href}
+				>
+					{tab.label}
+				</a>
+			{/each}
+		</nav>
+
+		{@render children()}
+	{/if}
+</div>
+
+<style>
+	.admin-layout { display: flex; flex-direction: column; gap: var(--space-6); }
+
+	.denied, .loading-msg {
+		color: var(--text-muted); padding: var(--space-10) 0; text-align: center; font-size: 0.95rem;
+	}
+	.error-msg {
+		color: #ef4444; padding: var(--space-6); background: var(--bg-secondary);
+		border: 1px solid var(--border); border-radius: var(--radius);
+	}
+
+	/* Stats */
+	.stats-bar { display: flex; gap: var(--space-4); flex-wrap: wrap; }
+	.stat {
+		flex: 1; min-width: 120px; padding: var(--space-4) var(--space-5);
+		background: var(--bg-secondary); border: 1px solid var(--border);
+		border-radius: var(--radius-lg); display: flex; flex-direction: column; gap: var(--space-1);
+	}
+	.stat-value { font-size: 1.5rem; font-weight: 700; color: var(--text-primary); }
+	.stat-label { font-size: 0.8rem; color: var(--text-muted); text-transform: capitalize; }
+
+	/* Tabs */
+	.admin-tabs {
+		display: flex;
+		gap: var(--space-1);
+		border-bottom: 1px solid var(--border);
+		margin-bottom: var(--space-6);
+	}
+	.admin-tab {
+		padding: var(--space-2) var(--space-4);
+		font-size: 0.85rem;
+		font-weight: 500;
+		color: var(--text-muted);
+		text-decoration: none;
+		border-bottom: 2px solid transparent;
+		margin-bottom: -1px;
+		transition: color 0.15s, border-color 0.15s;
+	}
+	.admin-tab:hover {
+		color: var(--text-primary);
+		text-decoration: none;
+	}
+	.admin-tab.active {
+		color: var(--text-primary);
+		border-bottom-color: var(--accent-blue);
+	}
+</style>

--- a/web/src/routes/console/admin/+page.svelte
+++ b/web/src/routes/console/admin/+page.svelte
@@ -10,14 +10,16 @@
 	let saving = $state(false);
 	let saveMsg = $state('');
 	let loading = $state(true);
+	let error = $state('');
 
 	async function loadUsers() {
 		loading = true;
+		error = '';
 		try {
 			const result = await adminFetch('/admin/users');
 			users = result.users ?? result;
-		} catch {
-			/* keep empty */
+		} catch (e) {
+			error = e instanceof Error ? e.message : 'Failed to load users';
 		} finally {
 			loading = false;
 		}
@@ -73,6 +75,11 @@
 <div class="users-page">
 	{#if loading}
 		<div class="loading-msg">Loading users...</div>
+	{:else if error}
+		<div class="error-msg">
+			<p>{error}</p>
+			<button class="btn" onclick={loadUsers}>Retry</button>
+		</div>
 	{:else}
 		<div class="search-row">
 			<input
@@ -306,5 +313,19 @@
 		padding: var(--space-6) 0;
 		text-align: center;
 		font-size: 0.9rem;
+	}
+	.error-msg {
+		color: #ef4444;
+		padding: var(--space-6);
+		background: var(--bg-secondary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+		display: flex;
+		align-items: center;
+		gap: var(--space-3);
+	}
+	.error-msg p {
+		margin: 0;
+		font-size: 0.85rem;
 	}
 </style>

--- a/web/src/routes/console/admin/+page.svelte
+++ b/web/src/routes/console/admin/+page.svelte
@@ -1,87 +1,23 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
-	import { authStore } from '$lib/stores/auth.svelte';
+	import { adminFetch, adminPatch, formatDate, type AdminUser } from '$lib/stores/admin.svelte';
 
-	const BASE = '/api/v1';
-
-	function getCSRFToken(): string | null {
-		// Check __Host- prefixed cookie first (secure/TLS mode), fall back to unprefixed
-		const hostMatch = document.cookie.match(/(?:^|;\s*)__Host-pad_csrf=([^;]+)/);
-		if (hostMatch) return hostMatch[1];
-		const match = document.cookie.match(/(?:^|;\s*)pad_csrf=([^;]+)/);
-		return match ? match[1] : null;
-	}
-
-	async function adminFetch(path: string, opts?: RequestInit) {
-		const resp = await fetch(BASE + path, { credentials: 'same-origin', ...opts });
-		if (!resp.ok) throw new Error(`${resp.status}`);
-		return resp.json();
-	}
-
-	async function adminPatch(path: string, body: unknown) {
-		const headers: Record<string, string> = { 'Content-Type': 'application/json' };
-		const csrf = getCSRFToken();
-		if (csrf) headers['X-CSRF-Token'] = csrf;
-		return adminFetch(path, {
-			method: 'PATCH',
-			headers,
-			body: JSON.stringify(body)
-		});
-	}
-
-	interface AdminUser {
-		id: string; email: string; username: string; name: string;
-		role: string; plan: string; plan_expires_at: string | null;
-		plan_overrides: Record<string, number> | null; totp_enabled: boolean; created_at: string;
-	}
-
-	interface Stats { users: number; users_by_plan: Record<string, number>; workspaces: number; cloud_mode: boolean; }
-	interface LimitTiers { free: Record<string, number>; pro: Record<string, number>; }
-
-	const LIMIT_FEATURES = [
-		'workspaces', 'items_per_workspace', 'members_per_workspace',
-		'api_tokens', 'storage_bytes', 'webhooks', 'automated_backups'
-	] as const;
-
-	let isAdmin = $derived(authStore.user?.role === 'admin');
-
-	let loading = $state(true);
-	let error = $state('');
-	let stats = $state<Stats | null>(null);
 	let users = $state<AdminUser[]>([]);
-	let limits = $state<LimitTiers | null>(null);
 	let search = $state('');
 	let selectedId = $state<string | null>(null);
 	let editPlan = $state('free');
 	let editOverrides = $state('');
 	let saving = $state(false);
-	let savingLimits = $state(false);
 	let saveMsg = $state('');
-	let limitMsg = $state('');
+	let loading = $state(true);
 
-	// Email settings
-	let platformSettings = $state<Record<string, string>>({});
-	let savingPlatform = $state(false);
-	let platformStatus = $state<'idle' | 'saved' | 'error'>('idle');
-	let testingEmail = $state(false);
-	let testEmailResult = $state<{ message: string; type: 'success' | 'error' } | null>(null);
-
-	function formatDate(d: string): string {
-		return new Date(d).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
-	}
-
-	async function loadData() {
+	async function loadUsers() {
 		loading = true;
-		error = '';
 		try {
-			const [s, u, l] = await Promise.all([
-				adminFetch('/admin/stats'),
-				adminFetch('/admin/users'),
-				adminFetch('/admin/limits')
-			]);
-			stats = s; users = u.users ?? u; limits = l;
-		} catch (e) {
-			error = e instanceof Error ? e.message : 'Failed to load';
+			const result = await adminFetch('/admin/users');
+			users = result.users ?? result;
+		} catch {
+			/* keep empty */
 		} finally {
 			loading = false;
 		}
@@ -91,11 +27,16 @@
 		try {
 			const result = await adminFetch(`/admin/users?q=${encodeURIComponent(search)}`);
 			users = result.users ?? result;
-		} catch { /* keep existing */ }
+		} catch {
+			/* keep existing */
+		}
 	}
 
 	function selectUser(u: AdminUser) {
-		if (selectedId === u.id) { selectedId = null; return; }
+		if (selectedId === u.id) {
+			selectedId = null;
+			return;
+		}
 		selectedId = u.id;
 		editPlan = u.plan || 'free';
 		editOverrides = u.plan_overrides ? JSON.stringify(u.plan_overrides, null, 2) : '';
@@ -107,17 +48,15 @@
 		saving = true;
 		saveMsg = '';
 		try {
-			// Validate JSON syntax before sending
 			if (editOverrides.trim()) {
-				JSON.parse(editOverrides); // throws if invalid
+				JSON.parse(editOverrides);
 			}
-			// Backend expects plan_overrides as a JSON string, not an object
 			await adminPatch(`/admin/users/${selectedId}`, {
 				plan: editPlan,
 				plan_overrides: editOverrides.trim() || null
 			});
 			const updated = await adminFetch(`/admin/users/${selectedId}`);
-			users = users.map((u) => u.id === selectedId ? { ...u, ...updated } : u);
+			users = users.map((u) => (u.id === selectedId ? { ...u, ...updated } : u));
 			saveMsg = 'Saved';
 		} catch (e) {
 			saveMsg = e instanceof Error ? e.message : 'Save failed';
@@ -126,404 +65,246 @@
 		}
 	}
 
-	async function saveLimits() {
-		if (!limits) return;
-		savingLimits = true;
-		limitMsg = '';
-		try {
-			await adminPatch('/admin/limits', limits);
-			limitMsg = 'Saved';
-		} catch (e) {
-			limitMsg = e instanceof Error ? e.message : 'Save failed';
-		} finally {
-			savingLimits = false;
-		}
-	}
-
-	function updateLimit(tier: 'free' | 'pro', key: string, val: string) {
-		if (!limits) return;
-		const num = val.trim() === '' ? 0 : Number(val);
-		limits[tier] = { ...limits[tier], [key]: isNaN(num) ? 0 : num };
-	}
-
-	async function loadEmailSettings() {
-		try {
-			const resp = await fetch(BASE + '/admin/settings', { credentials: 'same-origin' });
-			if (resp.ok) platformSettings = await resp.json();
-		} catch {}
-	}
-
-	async function savePlatformSettings() {
-		if (savingPlatform) return;
-		savingPlatform = true;
-		platformStatus = 'idle';
-		try {
-			const headers: Record<string, string> = { 'Content-Type': 'application/json' };
-			const csrf = getCSRFToken();
-			if (csrf) headers['X-CSRF-Token'] = csrf;
-			const resp = await fetch(BASE + '/admin/settings', {
-				method: 'PATCH',
-				credentials: 'same-origin',
-				headers,
-				body: JSON.stringify(platformSettings)
-			});
-			if (!resp.ok) throw new Error(`${resp.status}`);
-			platformStatus = 'saved';
-			setTimeout(() => (platformStatus = 'idle'), 2000);
-		} catch {
-			platformStatus = 'error';
-		} finally {
-			savingPlatform = false;
-		}
-	}
-
-	async function sendTestEmail() {
-		testingEmail = true;
-		testEmailResult = null;
-		try {
-			const headers: Record<string, string> = { 'Content-Type': 'application/json' };
-			const csrf = getCSRFToken();
-			if (csrf) headers['X-CSRF-Token'] = csrf;
-			const resp = await fetch(BASE + '/admin/test-email', {
-				method: 'POST',
-				credentials: 'same-origin',
-				headers
-			});
-			if (!resp.ok) throw new Error('Failed to send test email');
-			const result = await resp.json();
-			testEmailResult = { message: `Test email sent to ${result.sent_to}`, type: 'success' };
-		} catch (err: unknown) {
-			testEmailResult = {
-				message: err instanceof Error ? err.message : 'Failed to send test email',
-				type: 'error'
-			};
-		} finally {
-			testingEmail = false;
-		}
-	}
-
 	onMount(() => {
-		if (isAdmin) {
-			loadData();
-			loadEmailSettings();
-		}
+		loadUsers();
 	});
 </script>
 
-<svelte:head>
-	<title>Admin - Pad</title>
-</svelte:head>
-
-<div class="admin-page">
-	{#if !isAdmin}
-		<div class="denied">Admin access required</div>
-	{:else if loading}
-		<div class="loading-msg">Loading admin data...</div>
-	{:else if error}
-		<div class="error-msg">{error}</div>
+<div class="users-page">
+	{#if loading}
+		<div class="loading-msg">Loading users...</div>
 	{:else}
-		<!-- Stats bar -->
-		{#if stats}
-			<div class="stats-bar">
-				<div class="stat">
-					<span class="stat-value">{stats.users}</span>
-					<span class="stat-label">Users</span>
-				</div>
-				{#each Object.entries(stats.users_by_plan) as [plan, count] (plan)}
-					<div class="stat">
-						<span class="stat-value">{count}</span>
-						<span class="stat-label">{plan}</span>
-					</div>
-				{/each}
-				<div class="stat">
-					<span class="stat-value">{stats.workspaces}</span>
-					<span class="stat-label">Workspaces</span>
-				</div>
-			</div>
-		{/if}
+		<div class="search-row">
+			<input
+				type="text"
+				class="search-input"
+				placeholder="Search users..."
+				bind:value={search}
+				onkeydown={(e) => {
+					if (e.key === 'Enter') searchUsers();
+				}}
+			/>
+			<button class="btn" onclick={searchUsers}>Search</button>
+		</div>
 
-		<!-- Users section -->
-		<section class="section">
-			<h2 class="section-title">Users</h2>
-			<div class="search-row">
-				<input
-					type="text"
-					class="search-input"
-					placeholder="Search users..."
-					bind:value={search}
-					onkeydown={(e) => { if (e.key === 'Enter') searchUsers(); }}
-				/>
-				<button class="btn" onclick={searchUsers}>Search</button>
-			</div>
-
-			<div class="table-wrap">
-				<table class="table">
-					<thead>
-						<tr>
-							<th>Name</th><th>Email</th><th>Plan</th><th>Created</th>
-						</tr>
-					</thead>
-					<tbody>
-						{#each users as user (user.id)}
-							<tr
-								class="user-row"
-								class:selected={selectedId === user.id}
-								onclick={() => selectUser(user)}
+		<div class="table-wrap">
+			<table class="table">
+				<thead>
+					<tr>
+						<th>Name</th>
+						<th>Email</th>
+						<th>Plan</th>
+						<th>Created</th>
+					</tr>
+				</thead>
+				<tbody>
+					{#each users as user (user.id)}
+						<tr
+							class="user-row"
+							class:selected={selectedId === user.id}
+							onclick={() => selectUser(user)}
+						>
+							<td>{user.name || user.username}</td>
+							<td>{user.email}</td>
+							<td
+								><span class="badge" class:pro={user.plan === 'pro'}
+									>{user.plan || 'free'}</span
+								></td
 							>
-								<td>{user.name || user.username}</td>
-								<td>{user.email}</td>
-								<td><span class="badge" class:pro={user.plan === 'pro'}>{user.plan || 'free'}</span></td>
-								<td class="date-cell">{formatDate(user.created_at)}</td>
-							</tr>
-							{#if selectedId === user.id}
-								<tr class="edit-row">
-									<td colspan="4">
-										<div class="edit-panel">
-											<div class="edit-field">
-												<label for="edit-plan">Plan</label>
-												<select id="edit-plan" bind:value={editPlan}>
-													<option value="free">free</option>
-													<option value="pro">pro</option>
-												</select>
-											</div>
-											<div class="edit-field">
-												<label for="edit-overrides">Plan overrides (JSON)</label>
-												<textarea id="edit-overrides" bind:value={editOverrides} rows="3" placeholder={'{"workspaces": 10}'}></textarea>
-											</div>
-											<div class="edit-actions">
-												<button class="btn primary" onclick={saveUser} disabled={saving}>
-													{saving ? 'Saving...' : 'Save'}
-												</button>
-												{#if saveMsg}<span class="save-msg">{saveMsg}</span>{/if}
-											</div>
+							<td class="date-cell">{formatDate(user.created_at)}</td>
+						</tr>
+						{#if selectedId === user.id}
+							<tr class="edit-row">
+								<td colspan="4">
+									<div class="edit-panel">
+										<div class="edit-field">
+											<label for="edit-plan">Plan</label>
+											<select id="edit-plan" bind:value={editPlan}>
+												<option value="free">free</option>
+												<option value="pro">pro</option>
+											</select>
 										</div>
-									</td>
-								</tr>
-							{/if}
-						{/each}
-					</tbody>
-				</table>
-			</div>
-		</section>
-
-		<!-- Plan Limits section (cloud mode only) -->
-		{#if limits && stats?.cloud_mode}
-			<section class="section">
-				<h2 class="section-title">Plan Limits</h2>
-				<p class="section-desc">Use -1 for unlimited.</p>
-				<div class="table-wrap">
-					<table class="table">
-						<thead>
-							<tr><th>Feature</th><th>Free</th><th>Pro</th></tr>
-						</thead>
-						<tbody>
-							{#each LIMIT_FEATURES as feat (feat)}
-								<tr>
-									<td class="feat-label">{feat.replace(/_/g, ' ')}</td>
-									<td>
-										<input
-											type="number"
-											class="limit-input"
-											value={limits.free[feat] ?? 0}
-											oninput={(e) => updateLimit('free', feat, e.currentTarget.value)}
-										/>
-									</td>
-									<td>
-										<input
-											type="number"
-											class="limit-input"
-											value={limits.pro[feat] ?? 0}
-											oninput={(e) => updateLimit('pro', feat, e.currentTarget.value)}
-										/>
-									</td>
-								</tr>
-							{/each}
-						</tbody>
-					</table>
-				</div>
-				<div class="edit-actions">
-					<button class="btn primary" onclick={saveLimits} disabled={savingLimits}>
-						{savingLimits ? 'Saving...' : 'Save Limits'}
-					</button>
-					{#if limitMsg}<span class="save-msg">{limitMsg}</span>{/if}
-				</div>
-			</section>
-		{/if}
-
-		<!-- Email Configuration -->
-		<section class="section">
-			<h2 class="section-title">Email Configuration</h2>
-			<p class="section-desc">Configure transactional email for invitations, password resets, and notifications.</p>
-			<div class="email-card">
-				<div class="email-field">
-					<label for="email-provider">Provider</label>
-					<select id="email-provider" bind:value={platformSettings['email_provider']}
-						onchange={() => { if (!platformSettings['email_provider']) platformSettings['email_provider'] = ''; }}>
-						<option value="">Disabled</option>
-						<option value="maileroo">Maileroo</option>
-					</select>
-				</div>
-				{#if platformSettings['email_provider'] === 'maileroo'}
-					<div class="email-field">
-						<label for="maileroo-key">API Key</label>
-						<input id="maileroo-key" type="password" bind:value={platformSettings['maileroo_api_key']}
-							placeholder="Enter Maileroo sending key" />
-					</div>
-				{/if}
-				<div class="email-field">
-					<label for="email-from">From Address</label>
-					<input id="email-from" type="email" bind:value={platformSettings['email_from']}
-						placeholder="noreply@yourdomain.com" />
-				</div>
-				<div class="email-field">
-					<label for="email-name">From Name</label>
-					<input id="email-name" type="text" bind:value={platformSettings['email_from_name']}
-						placeholder="Pad" />
-				</div>
-				<div class="edit-actions">
-					<button class="btn primary" onclick={savePlatformSettings} disabled={savingPlatform}>
-						{savingPlatform ? 'Saving...' : 'Save Email Settings'}
-					</button>
-					{#if platformStatus === 'saved'}
-						<span class="save-msg" style="color: var(--accent-green);">Saved</span>
-					{:else if platformStatus === 'error'}
-						<span class="save-msg" style="color: #ef4444;">Error</span>
-					{/if}
-				</div>
-			</div>
-
-			{#if platformSettings['email_provider']}
-				<div class="email-card">
-					<h3 class="email-subheading">Test Email</h3>
-					<p class="section-desc">Send a test email to verify your configuration is working.</p>
-					<div class="edit-actions">
-						<button class="btn" onclick={sendTestEmail} disabled={testingEmail}>
-							{testingEmail ? 'Sending...' : 'Send Test Email'}
-						</button>
-						{#if testEmailResult}
-							<span class="save-msg" style="color: {testEmailResult.type === 'success' ? 'var(--accent-green)' : '#ef4444'};">
-								{testEmailResult.message}
-							</span>
+										<div class="edit-field">
+											<label for="edit-overrides">Plan overrides (JSON)</label>
+											<textarea
+												id="edit-overrides"
+												bind:value={editOverrides}
+												rows="3"
+												placeholder={'{"workspaces": 10}'}
+											></textarea>
+										</div>
+										<div class="edit-actions">
+											<button class="btn primary" onclick={saveUser} disabled={saving}>
+												{saving ? 'Saving...' : 'Save'}
+											</button>
+											{#if saveMsg}<span class="save-msg">{saveMsg}</span>{/if}
+										</div>
+									</div>
+								</td>
+							</tr>
 						{/if}
-					</div>
-				</div>
-			{/if}
-		</section>
+					{/each}
+				</tbody>
+			</table>
+		</div>
 	{/if}
 </div>
 
 <style>
-	.admin-page { display: flex; flex-direction: column; gap: var(--space-8); }
-
-	.denied, .loading-msg {
-		color: var(--text-muted); padding: var(--space-10) 0; text-align: center; font-size: 0.95rem;
-	}
-	.error-msg {
-		color: #ef4444; padding: var(--space-6); background: var(--bg-secondary);
-		border: 1px solid var(--border); border-radius: var(--radius);
-	}
-
-	/* Stats */
-	.stats-bar {
-		display: flex; gap: var(--space-4); flex-wrap: wrap;
-	}
-	.stat {
-		flex: 1; min-width: 120px; padding: var(--space-4) var(--space-5);
-		background: var(--bg-secondary); border: 1px solid var(--border);
-		border-radius: var(--radius-lg); display: flex; flex-direction: column; gap: var(--space-1);
-	}
-	.stat-value { font-size: 1.5rem; font-weight: 700; color: var(--text-primary); }
-	.stat-label { font-size: 0.8rem; color: var(--text-muted); text-transform: capitalize; }
-
-	/* Section */
-	.section { display: flex; flex-direction: column; gap: var(--space-4); }
-	.section-title { font-size: 1.1rem; font-weight: 600; color: var(--text-primary); }
-	.section-desc { font-size: 0.8rem; color: var(--text-muted); margin-top: calc(-1 * var(--space-2)); }
-
 	/* Search */
-	.search-row { display: flex; gap: var(--space-2); }
-	.search-input {
-		flex: 1; padding: var(--space-2) var(--space-3); background: var(--bg-secondary);
-		border: 1px solid var(--border); border-radius: var(--radius); color: var(--text-primary);
-		font-size: 0.85rem; outline: none;
+	.search-row {
+		display: flex;
+		gap: var(--space-2);
 	}
-	.search-input:focus { border-color: var(--accent-blue); }
+	.search-input {
+		flex: 1;
+		padding: var(--space-2) var(--space-3);
+		background: var(--bg-secondary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+		color: var(--text-primary);
+		font-size: 0.85rem;
+		outline: none;
+	}
+	.search-input:focus {
+		border-color: var(--accent-blue);
+	}
 
 	/* Buttons */
 	.btn {
-		padding: var(--space-2) var(--space-4); border-radius: var(--radius);
-		border: 1px solid var(--border); background: var(--bg-secondary); color: var(--text-secondary);
-		font-size: 0.85rem; font-weight: 500; cursor: pointer; transition: border-color 0.15s, color 0.15s;
+		padding: var(--space-2) var(--space-4);
+		border-radius: var(--radius);
+		border: 1px solid var(--border);
+		background: var(--bg-secondary);
+		color: var(--text-secondary);
+		font-size: 0.85rem;
+		font-weight: 500;
+		cursor: pointer;
+		transition:
+			border-color 0.15s,
+			color 0.15s;
 	}
-	.btn:hover { color: var(--text-primary); border-color: var(--text-muted); }
-	.btn.primary { background: var(--accent-blue); color: #fff; border-color: transparent; }
-	.btn.primary:hover { opacity: 0.9; }
-	.btn:disabled { opacity: 0.5; cursor: default; }
+	.btn:hover {
+		color: var(--text-primary);
+		border-color: var(--text-muted);
+	}
+	.btn.primary {
+		background: var(--accent-blue);
+		color: #fff;
+		border-color: transparent;
+	}
+	.btn.primary:hover {
+		opacity: 0.9;
+	}
+	.btn:disabled {
+		opacity: 0.5;
+		cursor: default;
+	}
 
 	/* Table */
-	.table-wrap { overflow-x: auto; }
+	.table-wrap {
+		overflow-x: auto;
+	}
 	.table {
-		width: 100%; border-collapse: collapse; font-size: 0.85rem;
+		width: 100%;
+		border-collapse: collapse;
+		font-size: 0.85rem;
 	}
 	.table th {
-		text-align: left; padding: var(--space-2) var(--space-3); color: var(--text-muted);
-		font-weight: 500; border-bottom: 1px solid var(--border); font-size: 0.8rem;
+		text-align: left;
+		padding: var(--space-2) var(--space-3);
+		color: var(--text-muted);
+		font-weight: 500;
+		border-bottom: 1px solid var(--border);
+		font-size: 0.8rem;
 	}
 	.table td {
-		padding: var(--space-2) var(--space-3); border-bottom: 1px solid var(--border);
+		padding: var(--space-2) var(--space-3);
+		border-bottom: 1px solid var(--border);
 		color: var(--text-secondary);
 	}
-	.user-row { cursor: pointer; transition: background 0.1s; }
-	.user-row:hover { background: var(--bg-hover); }
-	.user-row.selected { background: var(--bg-tertiary); }
-	.date-cell { white-space: nowrap; }
-
+	.user-row {
+		cursor: pointer;
+		transition: background 0.1s;
+	}
+	.user-row:hover {
+		background: var(--bg-hover);
+	}
+	.user-row.selected {
+		background: var(--bg-tertiary);
+	}
+	.date-cell {
+		white-space: nowrap;
+	}
 	.badge {
-		padding: 2px var(--space-2); border-radius: var(--radius-sm); font-size: 0.75rem; font-weight: 500;
-		background: color-mix(in srgb, var(--accent-gray, #888) 15%, transparent); color: var(--text-muted);
+		padding: 2px var(--space-2);
+		border-radius: var(--radius-sm);
+		font-size: 0.75rem;
+		font-weight: 500;
+		background: color-mix(in srgb, var(--accent-gray, #888) 15%, transparent);
+		color: var(--text-muted);
 	}
 	.badge.pro {
-		background: color-mix(in srgb, var(--accent-blue) 15%, transparent); color: var(--accent-blue);
+		background: color-mix(in srgb, var(--accent-blue) 15%, transparent);
+		color: var(--accent-blue);
 	}
 
 	/* Edit panel */
-	.edit-row td { padding: 0; border-bottom: 1px solid var(--border); }
+	.edit-row td {
+		padding: 0;
+		border-bottom: 1px solid var(--border);
+	}
 	.edit-panel {
-		padding: var(--space-4) var(--space-3); background: var(--bg-tertiary);
-		display: flex; flex-direction: column; gap: var(--space-3);
+		padding: var(--space-4) var(--space-3);
+		background: var(--bg-tertiary);
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-3);
 	}
-	.edit-field { display: flex; flex-direction: column; gap: var(--space-1); }
-	.edit-field label { font-size: 0.8rem; color: var(--text-muted); font-weight: 500; }
-	.edit-field select, .edit-field textarea {
-		padding: var(--space-2) var(--space-3); background: var(--bg-secondary); border: 1px solid var(--border);
-		border-radius: var(--radius); color: var(--text-primary); font-size: 0.85rem; font-family: inherit;
+	.edit-field {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-1);
 	}
-	.edit-field textarea { resize: vertical; font-family: monospace; font-size: 0.8rem; }
-	.edit-actions { display: flex; align-items: center; gap: var(--space-3); }
-	.save-msg { font-size: 0.8rem; color: var(--text-muted); }
+	.edit-field label {
+		font-size: 0.8rem;
+		color: var(--text-muted);
+		font-weight: 500;
+	}
+	.edit-field select,
+	.edit-field textarea {
+		padding: var(--space-2) var(--space-3);
+		background: var(--bg-secondary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+		color: var(--text-primary);
+		font-size: 0.85rem;
+		font-family: inherit;
+	}
+	.edit-field textarea {
+		resize: vertical;
+		font-family: monospace;
+		font-size: 0.8rem;
+	}
+	.edit-actions {
+		display: flex;
+		align-items: center;
+		gap: var(--space-3);
+	}
+	.save-msg {
+		font-size: 0.8rem;
+		color: var(--text-muted);
+	}
 
-	/* Limits */
-	.feat-label { text-transform: capitalize; color: var(--text-primary); }
-	.limit-input {
-		width: 100px; padding: var(--space-1) var(--space-2); background: var(--bg-secondary);
-		border: 1px solid var(--border); border-radius: var(--radius); color: var(--text-primary);
-		font-size: 0.85rem; outline: none;
+	.users-page {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-4);
 	}
-	.limit-input:focus { border-color: var(--accent-blue); }
-
-	/* Email config */
-	.email-card {
-		padding: var(--space-4) var(--space-5); background: var(--bg-secondary);
-		border: 1px solid var(--border); border-radius: var(--radius);
-		display: flex; flex-direction: column; gap: var(--space-3);
+	.loading-msg {
+		color: var(--text-muted);
+		padding: var(--space-6) 0;
+		text-align: center;
+		font-size: 0.9rem;
 	}
-	.email-card + .email-card { margin-top: var(--space-3); }
-	.email-field { display: flex; flex-direction: column; gap: var(--space-1); }
-	.email-field label { font-size: 0.8rem; color: var(--text-muted); font-weight: 500; }
-	.email-field select, .email-field input {
-		padding: var(--space-2) var(--space-3); background: var(--bg-tertiary); border: 1px solid var(--border);
-		border-radius: var(--radius); color: var(--text-primary); font-size: 0.85rem; max-width: 400px;
-	}
-	.email-field select:focus, .email-field input:focus { outline: none; border-color: var(--accent-blue); }
-	.email-subheading { font-size: 0.95rem; font-weight: 600; color: var(--text-primary); margin: 0; }
 </style>

--- a/web/src/routes/console/admin/audit-log/+page.svelte
+++ b/web/src/routes/console/admin/audit-log/+page.svelte
@@ -1,0 +1,21 @@
+<div class="placeholder">
+	<p class="placeholder-icon">📋</p>
+	<h2 class="placeholder-title">Audit Log</h2>
+	<p class="placeholder-desc">View authentication events, user actions, and administrative changes across the platform.</p>
+	<p class="placeholder-note">Coming soon</p>
+</div>
+
+<style>
+	.placeholder {
+		display: flex; flex-direction: column; align-items: center; justify-content: center;
+		padding: var(--space-10) 0; gap: var(--space-3); text-align: center;
+	}
+	.placeholder-icon { font-size: 2.5rem; margin: 0; }
+	.placeholder-title { font-size: 1.1rem; font-weight: 600; color: var(--text-primary); margin: 0; }
+	.placeholder-desc { font-size: 0.85rem; color: var(--text-muted); margin: 0; max-width: 400px; }
+	.placeholder-note {
+		font-size: 0.8rem; color: var(--text-muted); margin-top: var(--space-2);
+		padding: var(--space-1) var(--space-3); background: var(--bg-secondary);
+		border-radius: var(--radius); border: 1px solid var(--border);
+	}
+</style>

--- a/web/src/routes/console/admin/invitations/+page.svelte
+++ b/web/src/routes/console/admin/invitations/+page.svelte
@@ -1,0 +1,21 @@
+<div class="placeholder">
+	<p class="placeholder-icon">📨</p>
+	<h2 class="placeholder-title">Invitations</h2>
+	<p class="placeholder-desc">View and manage pending workspace invitations across the platform.</p>
+	<p class="placeholder-note">Coming soon</p>
+</div>
+
+<style>
+	.placeholder {
+		display: flex; flex-direction: column; align-items: center; justify-content: center;
+		padding: var(--space-10) 0; gap: var(--space-3); text-align: center;
+	}
+	.placeholder-icon { font-size: 2.5rem; margin: 0; }
+	.placeholder-title { font-size: 1.1rem; font-weight: 600; color: var(--text-primary); margin: 0; }
+	.placeholder-desc { font-size: 0.85rem; color: var(--text-muted); margin: 0; max-width: 400px; }
+	.placeholder-note {
+		font-size: 0.8rem; color: var(--text-muted); margin-top: var(--space-2);
+		padding: var(--space-1) var(--space-3); background: var(--bg-secondary);
+		border-radius: var(--radius); border: 1px solid var(--border);
+	}
+</style>

--- a/web/src/routes/console/admin/settings/+page.svelte
+++ b/web/src/routes/console/admin/settings/+page.svelte
@@ -1,0 +1,407 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import {
+		adminFetch,
+		adminPatch,
+		adminPost,
+		getCSRFToken,
+		adminStore,
+		type LimitTiers
+	} from '$lib/stores/admin.svelte';
+
+	// Plan limits
+	let limits = $state<LimitTiers | null>(null);
+	let savingLimits = $state(false);
+	let limitMsg = $state('');
+
+	const LIMIT_FEATURES = [
+		'workspaces',
+		'items_per_workspace',
+		'members_per_workspace',
+		'api_tokens',
+		'storage_bytes',
+		'webhooks',
+		'automated_backups'
+	] as const;
+
+	// Email settings
+	let platformSettings = $state<Record<string, string>>({});
+	let savingPlatform = $state(false);
+	let platformStatus = $state<'idle' | 'saved' | 'error'>('idle');
+	let testingEmail = $state(false);
+	let testEmailResult = $state<{ message: string; type: 'success' | 'error' } | null>(null);
+
+	let loading = $state(true);
+
+	async function loadSettings() {
+		try {
+			const [limitsData, settingsData] = await Promise.all([
+				adminFetch('/admin/limits').catch(() => null),
+				adminFetch('/admin/settings').catch(() => ({}))
+			]);
+			limits = limitsData;
+			platformSettings = settingsData ?? {};
+		} finally {
+			loading = false;
+		}
+	}
+
+	async function saveLimits() {
+		if (!limits) return;
+		savingLimits = true;
+		limitMsg = '';
+		try {
+			await adminPatch('/admin/limits', limits);
+			limitMsg = 'Saved';
+		} catch (e) {
+			limitMsg = e instanceof Error ? e.message : 'Failed to save';
+		} finally {
+			savingLimits = false;
+		}
+	}
+
+	function updateLimit(tier: 'free' | 'pro', key: string, val: string) {
+		if (!limits) return;
+		const num = parseInt(val, 10);
+		if (Number.isNaN(num)) return;
+		limits[tier] = { ...limits[tier], [key]: num };
+	}
+
+	async function savePlatformSettings() {
+		savingPlatform = true;
+		platformStatus = 'idle';
+		try {
+			await adminPatch('/admin/settings', platformSettings);
+			platformStatus = 'saved';
+		} catch {
+			platformStatus = 'error';
+		} finally {
+			savingPlatform = false;
+		}
+	}
+
+	async function sendTestEmail() {
+		testingEmail = true;
+		testEmailResult = null;
+		try {
+			const result = await adminPost('/admin/test-email');
+			testEmailResult = { message: result.message ?? 'Test email sent', type: 'success' };
+		} catch (e) {
+			testEmailResult = {
+				message: e instanceof Error ? e.message : 'Failed to send test email',
+				type: 'error'
+			};
+		} finally {
+			testingEmail = false;
+		}
+	}
+
+	onMount(() => {
+		loadSettings();
+	});
+</script>
+
+<div class="settings-page">
+	{#if loading}
+		<p class="loading-msg">Loading settings...</p>
+	{:else}
+		{#if adminStore.stats?.cloud_mode}
+			<section class="section">
+				<h2 class="section-title">Plan Limits</h2>
+				<p class="section-desc">Use -1 for unlimited.</p>
+
+				{#if limits}
+					<div class="table-wrap">
+						<table class="table">
+							<thead>
+								<tr>
+									<th>Feature</th>
+									<th>Free</th>
+									<th>Pro</th>
+								</tr>
+							</thead>
+							<tbody>
+								{#each LIMIT_FEATURES as feat (feat)}
+									<tr>
+										<td class="feat-label">{feat.replace(/_/g, ' ')}</td>
+										<td>
+											<input
+												class="limit-input"
+												type="number"
+												value={limits.free[feat] ?? 0}
+												onchange={(e) => updateLimit('free', feat, e.currentTarget.value)}
+											/>
+										</td>
+										<td>
+											<input
+												class="limit-input"
+												type="number"
+												value={limits.pro[feat] ?? 0}
+												onchange={(e) => updateLimit('pro', feat, e.currentTarget.value)}
+											/>
+										</td>
+									</tr>
+								{/each}
+							</tbody>
+						</table>
+					</div>
+
+					<div class="edit-actions">
+						<button class="btn primary" disabled={savingLimits} onclick={saveLimits}>
+							{savingLimits ? 'Saving...' : 'Save Limits'}
+						</button>
+						{#if limitMsg}
+							<span class="save-msg">{limitMsg}</span>
+						{/if}
+					</div>
+				{/if}
+			</section>
+		{/if}
+
+		<section class="section">
+			<h2 class="section-title">Email Configuration</h2>
+			<p class="section-desc">
+				Configure transactional email for invitations, password resets, and notifications.
+			</p>
+
+			<div class="email-card">
+				<div class="email-field">
+					<label for="email-provider">Provider</label>
+					<select
+						id="email-provider"
+						value={platformSettings.email_provider ?? ''}
+						onchange={(e) => {
+							platformSettings = { ...platformSettings, email_provider: e.currentTarget.value };
+						}}
+					>
+						<option value="">None (disabled)</option>
+						<option value="maileroo">Maileroo</option>
+					</select>
+				</div>
+
+				{#if platformSettings.email_provider === 'maileroo'}
+					<div class="email-field">
+						<label for="email-api-key">API Key</label>
+						<input
+							id="email-api-key"
+							type="password"
+							value={platformSettings.maileroo_api_key ?? ''}
+							oninput={(e) => {
+								platformSettings = {
+									...platformSettings,
+									maileroo_api_key: e.currentTarget.value
+								};
+							}}
+							placeholder="Maileroo sending key"
+						/>
+					</div>
+				{/if}
+
+				<div class="email-field">
+					<label for="email-from">From Address</label>
+					<input
+						id="email-from"
+						type="email"
+						value={platformSettings.email_from ?? ''}
+						oninput={(e) => {
+							platformSettings = { ...platformSettings, email_from: e.currentTarget.value };
+						}}
+						placeholder="noreply@yourdomain.com"
+					/>
+				</div>
+
+				<div class="email-field">
+					<label for="email-from-name">From Name</label>
+					<input
+						id="email-from-name"
+						type="text"
+						value={platformSettings.email_from_name ?? ''}
+						oninput={(e) => {
+							platformSettings = { ...platformSettings, email_from_name: e.currentTarget.value };
+						}}
+						placeholder="Pad"
+					/>
+				</div>
+
+				<div class="edit-actions">
+					<button class="btn primary" disabled={savingPlatform} onclick={savePlatformSettings}>
+						{savingPlatform ? 'Saving...' : 'Save Email Settings'}
+					</button>
+					{#if platformStatus === 'saved'}
+						<span class="save-msg">Saved</span>
+					{:else if platformStatus === 'error'}
+						<span class="save-msg">Failed to save</span>
+					{/if}
+				</div>
+			</div>
+
+			{#if platformSettings.email_provider}
+				<div class="email-card">
+					<p class="email-subheading">Test Email</p>
+					<div class="edit-actions">
+						<button class="btn" disabled={testingEmail} onclick={sendTestEmail}>
+							{testingEmail ? 'Sending...' : 'Send Test Email'}
+						</button>
+						{#if testEmailResult}
+							<span class="save-msg" class:error-msg={testEmailResult.type === 'error'}>
+								{testEmailResult.message}
+							</span>
+						{/if}
+					</div>
+				</div>
+			{/if}
+		</section>
+	{/if}
+</div>
+
+<style>
+	.settings-page {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-8);
+	}
+	.loading-msg {
+		color: var(--text-muted);
+		padding: var(--space-6) 0;
+		text-align: center;
+		font-size: 0.9rem;
+	}
+
+	.section {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-4);
+	}
+	.section-title {
+		font-size: 1.1rem;
+		font-weight: 600;
+		color: var(--text-primary);
+	}
+	.section-desc {
+		font-size: 0.8rem;
+		color: var(--text-muted);
+		margin-top: calc(-1 * var(--space-2));
+	}
+
+	.btn {
+		padding: var(--space-2) var(--space-4);
+		border-radius: var(--radius);
+		border: 1px solid var(--border);
+		background: var(--bg-secondary);
+		color: var(--text-secondary);
+		font-size: 0.85rem;
+		font-weight: 500;
+		cursor: pointer;
+		transition:
+			border-color 0.15s,
+			color 0.15s;
+	}
+	.btn:hover {
+		color: var(--text-primary);
+		border-color: var(--text-muted);
+	}
+	.btn.primary {
+		background: var(--accent-blue);
+		color: #fff;
+		border-color: transparent;
+	}
+	.btn.primary:hover {
+		opacity: 0.9;
+	}
+	.btn:disabled {
+		opacity: 0.5;
+		cursor: default;
+	}
+
+	.table-wrap {
+		overflow-x: auto;
+	}
+	.table {
+		width: 100%;
+		border-collapse: collapse;
+		font-size: 0.85rem;
+	}
+	.table th {
+		text-align: left;
+		padding: var(--space-2) var(--space-3);
+		color: var(--text-muted);
+		font-weight: 500;
+		border-bottom: 1px solid var(--border);
+		font-size: 0.8rem;
+	}
+	.table td {
+		padding: var(--space-2) var(--space-3);
+		border-bottom: 1px solid var(--border);
+		color: var(--text-secondary);
+	}
+	.feat-label {
+		text-transform: capitalize;
+		color: var(--text-primary);
+	}
+	.limit-input {
+		width: 100px;
+		padding: var(--space-1) var(--space-2);
+		background: var(--bg-secondary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+		color: var(--text-primary);
+		font-size: 0.85rem;
+		outline: none;
+	}
+	.limit-input:focus {
+		border-color: var(--accent-blue);
+	}
+	.edit-actions {
+		display: flex;
+		align-items: center;
+		gap: var(--space-3);
+	}
+	.save-msg {
+		font-size: 0.8rem;
+		color: var(--text-muted);
+	}
+
+	.email-card {
+		padding: var(--space-4) var(--space-5);
+		background: var(--bg-secondary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-3);
+	}
+	.email-card + .email-card {
+		margin-top: var(--space-3);
+	}
+	.email-field {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-1);
+	}
+	.email-field label {
+		font-size: 0.8rem;
+		color: var(--text-muted);
+		font-weight: 500;
+	}
+	.email-field select,
+	.email-field input {
+		padding: var(--space-2) var(--space-3);
+		background: var(--bg-tertiary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+		color: var(--text-primary);
+		font-size: 0.85rem;
+		max-width: 400px;
+	}
+	.email-field select:focus,
+	.email-field input:focus {
+		outline: none;
+		border-color: var(--accent-blue);
+	}
+	.email-subheading {
+		font-size: 0.95rem;
+		font-weight: 600;
+		color: var(--text-primary);
+		margin: 0;
+	}
+</style>


### PR DESCRIPTION
## Summary

- Split the monolithic 530-line `/console/admin` page into a tabbed layout with four sub-pages: **Users** (default), **Invitations**, **Audit Log**, and **Settings**
- Extracted shared admin utilities (`adminFetch`, `adminPatch`, `adminPost`, types, reactive stats store) into `lib/stores/admin.svelte.ts`
- Invitations and Audit Log tabs are placeholders — they'll be implemented in TASK-559 and TASK-560

Part of PLAN-552: Admin Console Enhancement (IDEA-242)

## Test plan

- [ ] Navigate to `/console/admin` — should show stats bar, tab navigation, and Users tab by default
- [ ] Click each tab — Users, Invitations, Audit Log, Settings — verify navigation and active tab highlighting
- [ ] Users tab: search users, click to expand edit panel, save plan changes
- [ ] Settings tab: verify email configuration and plan limits (cloud mode) render correctly and save
- [ ] Invitations and Audit Log tabs show "Coming soon" placeholders
- [ ] Non-admin users see "Admin access required" message