### PR TITLE
feat: add admin role management (promote/demote users)

### DIFF
--- a/internal/server/handlers_admin_users.go
+++ b/internal/server/handlers_admin_users.go
@@ -140,6 +140,7 @@ func (s *Server) handleAdminUpdateUser(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var input struct {
+		Role          *string `json:"role"`
 		Plan          *string `json:"plan"`
 		PlanExpiresAt *string `json:"plan_expires_at"`
 		PlanOverrides *string `json:"plan_overrides"`
@@ -147,6 +148,45 @@ func (s *Server) handleAdminUpdateUser(w http.ResponseWriter, r *http.Request) {
 	if err := decodeJSON(r, &input); err != nil {
 		writeError(w, http.StatusBadRequest, "bad_request", "Invalid request body")
 		return
+	}
+
+	if input.Role != nil {
+		validRoles := map[string]bool{"admin": true, "member": true}
+		if !validRoles[*input.Role] {
+			writeError(w, http.StatusBadRequest, "bad_request", "role must be 'admin' or 'member'")
+			return
+		}
+
+		// Guard: cannot demote yourself
+		caller := currentUser(r)
+		if caller != nil && caller.ID == userID {
+			writeError(w, http.StatusBadRequest, "bad_request", "Cannot change your own role")
+			return
+		}
+
+		// Guard: must always have at least one admin
+		if *input.Role == "member" && user.Role == "admin" {
+			adminCount, err := s.store.CountAdminUsers()
+			if err != nil {
+				writeInternalError(w, err)
+				return
+			}
+			if adminCount <= 1 {
+				writeError(w, http.StatusBadRequest, "bad_request", "Cannot demote the last admin")
+				return
+			}
+		}
+
+		if err := s.store.SetUserRole(userID, *input.Role); err != nil {
+			writeInternalError(w, err)
+			return
+		}
+
+		s.logAuditEvent(models.ActionRoleChanged, r, auditMeta(map[string]string{
+			"target_user_id": userID,
+			"old_role":       user.Role,
+			"new_role":       *input.Role,
+		}))
 	}
 
 	if input.Plan != nil {
@@ -196,9 +236,15 @@ func (s *Server) handleAdminUpdateUser(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]interface{}{
 		"id":              updated.ID,
 		"email":           updated.Email,
+		"username":        updated.Username,
+		"name":            updated.Name,
+		"role":            updated.Role,
 		"plan":            updated.Plan,
 		"plan_overrides":  updated.PlanOverrides,
 		"plan_expires_at": updated.PlanExpiresAt,
+		"totp_enabled":    updated.TOTPEnabled,
+		"created_at":      updated.CreatedAt,
+		"updated_at":      updated.UpdatedAt,
 		"ok":              true,
 	})
 }

--- a/internal/server/handlers_admin_users.go
+++ b/internal/server/handlers_admin_users.go
@@ -164,20 +164,12 @@ func (s *Server) handleAdminUpdateUser(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		// Guard: must always have at least one admin
-		if *input.Role == "member" && user.Role == "admin" {
-			adminCount, err := s.store.CountAdminUsers()
-			if err != nil {
-				writeInternalError(w, err)
-				return
-			}
-			if adminCount <= 1 {
+		// SetUserRole atomically guards against demoting the last admin.
+		if err := s.store.SetUserRole(userID, *input.Role); err != nil {
+			if err == store.ErrLastAdmin {
 				writeError(w, http.StatusBadRequest, "bad_request", "Cannot demote the last admin")
 				return
 			}
-		}
-
-		if err := s.store.SetUserRole(userID, *input.Role); err != nil {
 			writeInternalError(w, err)
 			return
 		}

--- a/internal/store/users.go
+++ b/internal/store/users.go
@@ -397,24 +397,39 @@ func (s *Store) RemoveOAuthProvider(userID, provider string) error {
 	return nil
 }
 
+// ErrLastAdmin is returned when a role change would leave zero admins.
+var ErrLastAdmin = fmt.Errorf("cannot demote the last admin")
+
 // SetUserRole updates a user's role (admin or member).
+// When demoting an admin to member, the update is conditional: it only
+// proceeds if at least one other admin exists, preventing a race where
+// two concurrent demotions could leave zero admins.
 func (s *Store) SetUserRole(userID, role string) error {
-	_, err := s.db.Exec(s.q(`UPDATE users SET role = ?, updated_at = ? WHERE id = ?`),
-		role, now(), userID)
+	var result sql.Result
+	var err error
+
+	if role == "member" {
+		// Atomic guard: only demote if another admin remains.
+		result, err = s.db.Exec(s.q(`
+			UPDATE users SET role = ?, updated_at = ?
+			WHERE id = ? AND (
+				role != 'admin'
+				OR (SELECT COUNT(*) FROM users WHERE role = 'admin' AND id != ?) > 0
+			)
+		`), role, now(), userID, userID)
+	} else {
+		result, err = s.db.Exec(s.q(`UPDATE users SET role = ?, updated_at = ? WHERE id = ?`),
+			role, now(), userID)
+	}
 	if err != nil {
 		return fmt.Errorf("set user role: %w", err)
 	}
-	return nil
-}
 
-// CountAdminUsers returns the number of users with the "admin" role.
-func (s *Store) CountAdminUsers() (int, error) {
-	var count int
-	err := s.db.QueryRow(s.q("SELECT COUNT(*) FROM users WHERE role = 'admin'")).Scan(&count)
-	if err != nil {
-		return 0, fmt.Errorf("count admin users: %w", err)
+	n, _ := result.RowsAffected()
+	if n == 0 {
+		return ErrLastAdmin
 	}
-	return count, nil
+	return nil
 }
 
 // DeleteUser permanently deletes a user by ID.

--- a/internal/store/users.go
+++ b/internal/store/users.go
@@ -397,6 +397,26 @@ func (s *Store) RemoveOAuthProvider(userID, provider string) error {
 	return nil
 }
 
+// SetUserRole updates a user's role (admin or member).
+func (s *Store) SetUserRole(userID, role string) error {
+	_, err := s.db.Exec(s.q(`UPDATE users SET role = ?, updated_at = ? WHERE id = ?`),
+		role, now(), userID)
+	if err != nil {
+		return fmt.Errorf("set user role: %w", err)
+	}
+	return nil
+}
+
+// CountAdminUsers returns the number of users with the "admin" role.
+func (s *Store) CountAdminUsers() (int, error) {
+	var count int
+	err := s.db.QueryRow(s.q("SELECT COUNT(*) FROM users WHERE role = 'admin'")).Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("count admin users: %w", err)
+	}
+	return count, nil
+}
+
 // DeleteUser permanently deletes a user by ID.
 func (s *Store) DeleteUser(id string) error {
 	_, err := s.db.Exec(s.q(`DELETE FROM users WHERE id = ?`), id)

--- a/web/src/routes/console/admin/+page.svelte
+++ b/web/src/routes/console/admin/+page.svelte
@@ -6,11 +6,15 @@
 	let search = $state('');
 	let selectedId = $state<string | null>(null);
 	let editPlan = $state('free');
+	let editRole = $state('member');
 	let editOverrides = $state('');
 	let saving = $state(false);
 	let saveMsg = $state('');
 	let loading = $state(true);
 	let error = $state('');
+	let roleConfirm = $state(false);
+	let roleSaving = $state(false);
+	let roleMsg = $state('');
 
 	async function loadUsers() {
 		loading = true;
@@ -41,8 +45,38 @@
 		}
 		selectedId = u.id;
 		editPlan = u.plan || 'free';
+		editRole = u.role || 'member';
 		editOverrides = u.plan_overrides ? JSON.stringify(u.plan_overrides, null, 2) : '';
 		saveMsg = '';
+		roleConfirm = false;
+		roleMsg = '';
+	}
+
+	function selectedUser(): AdminUser | undefined {
+		return users.find((u) => u.id === selectedId);
+	}
+
+	function roleAction(): string {
+		const user = selectedUser();
+		if (!user) return '';
+		return editRole === 'admin' ? 'Promote' : 'Demote';
+	}
+
+	async function changeRole() {
+		if (!selectedId) return;
+		roleSaving = true;
+		roleMsg = '';
+		try {
+			await adminPatch(`/admin/users/${selectedId}`, { role: editRole });
+			const updated = await adminFetch(`/admin/users/${selectedId}`);
+			users = users.map((u) => (u.id === selectedId ? { ...u, ...updated } : u));
+			roleMsg = 'Role updated';
+			roleConfirm = false;
+		} catch (e) {
+			roleMsg = e instanceof Error ? e.message : 'Role change failed';
+		} finally {
+			roleSaving = false;
+		}
 	}
 
 	async function saveUser() {
@@ -99,6 +133,7 @@
 				<thead>
 					<tr>
 						<th>Name</th>
+						<th>Role</th>
 						<th>Email</th>
 						<th>Plan</th>
 						<th>Created</th>
@@ -112,6 +147,11 @@
 							onclick={() => selectUser(user)}
 						>
 							<td>{user.name || user.username}</td>
+							<td
+								><span class="badge" class:admin={user.role === 'admin'}
+									>{user.role || 'member'}</span
+								></td
+							>
 							<td>{user.email}</td>
 							<td
 								><span class="badge" class:pro={user.plan === 'pro'}
@@ -122,8 +162,54 @@
 						</tr>
 						{#if selectedId === user.id}
 							<tr class="edit-row">
-								<td colspan="4">
+								<td colspan="5">
 									<div class="edit-panel">
+										<div class="edit-field">
+											<label for="edit-role">Role</label>
+											<div class="role-row">
+												<select id="edit-role" bind:value={editRole}>
+													<option value="member">member</option>
+													<option value="admin">admin</option>
+												</select>
+												{#if editRole !== (user.role || 'member')}
+													{#if !roleConfirm}
+														<button
+															class="btn role-btn"
+															onclick={() => {
+																roleConfirm = true;
+																roleMsg = '';
+															}}
+														>
+															Change Role
+														</button>
+													{:else}
+														<div class="role-confirm">
+															<span class="role-confirm-msg">
+																{roleAction()}
+																<strong>{user.name || user.username}</strong> to {editRole}?
+															</span>
+															<button
+																class="btn primary"
+																onclick={changeRole}
+																disabled={roleSaving}
+															>
+																{roleSaving ? 'Saving...' : 'Confirm'}
+															</button>
+															<button
+																class="btn"
+																onclick={() => {
+																	roleConfirm = false;
+																	roleMsg = '';
+																}}
+															>
+																Cancel
+															</button>
+														</div>
+													{/if}
+												{/if}
+												{#if roleMsg}<span class="save-msg">{roleMsg}</span>{/if}
+											</div>
+										</div>
 										<div class="edit-field">
 											<label for="edit-plan">Plan</label>
 											<select id="edit-plan" bind:value={editPlan}>
@@ -255,6 +341,10 @@
 		background: color-mix(in srgb, var(--accent-blue) 15%, transparent);
 		color: var(--accent-blue);
 	}
+	.badge.admin {
+		background: color-mix(in srgb, var(--accent-orange, #f59e0b) 15%, transparent);
+		color: var(--accent-orange, #f59e0b);
+	}
 
 	/* Edit panel */
 	.edit-row td {
@@ -301,6 +391,30 @@
 	.save-msg {
 		font-size: 0.8rem;
 		color: var(--text-muted);
+	}
+	.role-row {
+		display: flex;
+		align-items: center;
+		gap: var(--space-2);
+		flex-wrap: wrap;
+	}
+	.role-btn {
+		font-size: 0.8rem;
+		padding: var(--space-1) var(--space-3);
+	}
+	.role-confirm {
+		display: flex;
+		align-items: center;
+		gap: var(--space-2);
+		flex-wrap: wrap;
+	}
+	.role-confirm-msg {
+		font-size: 0.8rem;
+		color: var(--text-secondary);
+	}
+	.role-confirm .btn {
+		font-size: 0.8rem;
+		padding: var(--space-1) var(--space-3);
 	}
 
 	.users-page {


### PR DESCRIPTION
## Summary
- Extend `PATCH /api/v1/admin/users/{id}` to accept a `role` field (admin/member) with safety guards: cannot demote yourself, cannot demote the last admin
- Add `SetUserRole()` and `CountAdminUsers()` store methods
- Audit log role changes via the existing `ActionRoleChanged` event
- Add Role column with orange/amber badge to admin users table
- Add dedicated role change UI in the edit panel with confirmation dialog (separate from plan editing)

Closes TASK-554 — part of PLAN-552 (Admin Console Enhancement)

## Test plan
- [ ] Promote a member to admin — verify role badge updates, audit log entry created
- [ ] Demote an admin to member (with >1 admin) — verify it works
- [ ] Try to demote yourself — should get "Cannot change your own role" error
- [ ] Try to demote the last admin — should get "Cannot demote the last admin" error
- [ ] Verify `go test ./...` passes
- [ ] Verify `npm run build` compiles cleanly