### PR TITLE
feat: add admin password reset for other users

### DIFF
--- a/internal/models/activity.go
+++ b/internal/models/activity.go
@@ -28,7 +28,8 @@ const (
 	ActionOAuthLogin      = "oauth_login"
 	ActionOAuthLoginFailed = "oauth_login_failed"
 	ActionPlanChanged      = "plan_changed"
-	ActionAccountDeleted   = "account_deleted"
+	ActionPasswordResetByAdmin = "password_reset_by_admin"
+	ActionAccountDeleted       = "account_deleted"
 )
 
 type Activity struct {

--- a/internal/server/handlers_admin_users.go
+++ b/internal/server/handlers_admin_users.go
@@ -1,11 +1,9 @@
 package server
 
 import (
-	"context"
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
-	"log/slog"
 	"net/http"
 	"strconv"
 
@@ -273,11 +271,10 @@ func (s *Server) handleAdminResetPassword(w http.ResponseWriter, r *http.Request
 		}
 
 		resetURL := s.baseURL + "/reset-password/" + token
-		go func() {
-			if err := s.email.SendPasswordReset(context.Background(), user.Email, user.Name, resetURL); err != nil {
-				slog.Error("failed to send admin password reset email", "error", err, "user_id", userID)
-			}
-		}()
+		if err := s.email.SendPasswordReset(r.Context(), user.Email, user.Name, resetURL); err != nil {
+			writeError(w, http.StatusInternalServerError, "email_failed", "Failed to send password reset email")
+			return
+		}
 
 		s.logAuditEvent(models.ActionPasswordResetByAdmin, r, auditMeta(map[string]string{
 			"target_user_id": userID,
@@ -308,7 +305,8 @@ func (s *Server) handleAdminResetPassword(w http.ResponseWriter, r *http.Request
 
 	// Invalidate all existing sessions so the user must log in with the new password
 	if err := s.store.DeleteUserSessions(userID); err != nil {
-		slog.Error("failed to invalidate sessions after admin password reset", "error", err, "user_id", userID)
+		writeInternalError(w, err)
+		return
 	}
 
 	s.logAuditEvent(models.ActionPasswordResetByAdmin, r, auditMeta(map[string]string{

--- a/internal/server/handlers_admin_users.go
+++ b/internal/server/handlers_admin_users.go
@@ -1,7 +1,11 @@
 package server
 
 import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"strconv"
 
@@ -238,6 +242,85 @@ func (s *Server) handleAdminUpdateUser(w http.ResponseWriter, r *http.Request) {
 		"created_at":      updated.CreatedAt,
 		"updated_at":      updated.UpdatedAt,
 		"ok":              true,
+	})
+}
+
+// handleAdminResetPassword force-resets a user's password.
+// If email is configured, sends a reset link. Otherwise returns a temporary password.
+// POST /api/v1/admin/users/{userID}/reset-password
+func (s *Server) handleAdminResetPassword(w http.ResponseWriter, r *http.Request) {
+	if !requireAdmin(w, r) {
+		return
+	}
+
+	userID := chi.URLParam(r, "userID")
+	user, err := s.store.GetUser(userID)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	if user == nil {
+		writeError(w, http.StatusNotFound, "not_found", "User not found")
+		return
+	}
+
+	if s.email != nil && s.baseURL != "" {
+		// Email configured: generate reset token and send link
+		token, err := s.store.CreatePasswordReset(user.ID)
+		if err != nil {
+			writeInternalError(w, err)
+			return
+		}
+
+		resetURL := s.baseURL + "/reset-password/" + token
+		go func() {
+			if err := s.email.SendPasswordReset(context.Background(), user.Email, user.Name, resetURL); err != nil {
+				slog.Error("failed to send admin password reset email", "error", err, "user_id", userID)
+			}
+		}()
+
+		s.logAuditEvent(models.ActionPasswordResetByAdmin, r, auditMeta(map[string]string{
+			"target_user_id": userID,
+			"method":         "email",
+		}))
+
+		writeJSON(w, http.StatusOK, map[string]interface{}{
+			"ok":      true,
+			"method":  "email",
+			"message": "Password reset email sent to " + user.Email,
+		})
+		return
+	}
+
+	// No email: generate a temporary password
+	raw := make([]byte, 16)
+	if _, err := rand.Read(raw); err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	tempPassword := hex.EncodeToString(raw)
+
+	pwd := tempPassword
+	if _, err := s.store.UpdateUser(userID, models.UserUpdate{Password: &pwd}); err != nil {
+		writeInternalError(w, err)
+		return
+	}
+
+	// Invalidate all existing sessions so the user must log in with the new password
+	if err := s.store.DeleteUserSessions(userID); err != nil {
+		slog.Error("failed to invalidate sessions after admin password reset", "error", err, "user_id", userID)
+	}
+
+	s.logAuditEvent(models.ActionPasswordResetByAdmin, r, auditMeta(map[string]string{
+		"target_user_id": userID,
+		"method":         "temporary_password",
+	}))
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"ok":             true,
+		"method":         "temporary_password",
+		"temp_password":  tempPassword,
+		"message":        "Temporary password generated. The user's existing sessions have been invalidated.",
 	})
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -313,6 +313,7 @@ func (s *Server) setupRouter() {
 			r.Get("/users", s.handleAdminListUsers)
 			r.Get("/users/{userID}", s.handleAdminGetUser)
 			r.Patch("/users/{userID}", s.handleAdminUpdateUser)
+			r.Post("/users/{userID}/reset-password", s.handleAdminResetPassword)
 
 			// Plan limits
 			r.Get("/limits", s.handleAdminGetLimits)

--- a/web/src/routes/console/admin/+page.svelte
+++ b/web/src/routes/console/admin/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
-	import { adminFetch, adminPatch, formatDate, type AdminUser } from '$lib/stores/admin.svelte';
+	import { adminFetch, adminPatch, adminPost, formatDate, type AdminUser } from '$lib/stores/admin.svelte';
 
 	let users = $state<AdminUser[]>([]);
 	let search = $state('');
@@ -15,6 +15,10 @@
 	let roleConfirm = $state(false);
 	let roleSaving = $state(false);
 	let roleMsg = $state('');
+	let resetConfirm = $state(false);
+	let resetSaving = $state(false);
+	let resetResult = $state<{ method: string; temp_password?: string; message: string } | null>(null);
+	let resetError = $state('');
 
 	async function loadUsers() {
 		loading = true;
@@ -50,6 +54,9 @@
 		saveMsg = '';
 		roleConfirm = false;
 		roleMsg = '';
+		resetConfirm = false;
+		resetResult = null;
+		resetError = '';
 	}
 
 	function selectedUser(): AdminUser | undefined {
@@ -76,6 +83,22 @@
 			roleMsg = e instanceof Error ? e.message : 'Role change failed';
 		} finally {
 			roleSaving = false;
+		}
+	}
+
+	async function resetPassword() {
+		if (!selectedId) return;
+		resetSaving = true;
+		resetError = '';
+		resetResult = null;
+		try {
+			const result = await adminPost(`/admin/users/${selectedId}/reset-password`);
+			resetResult = result;
+		} catch (e) {
+			resetError = e instanceof Error ? e.message : 'Password reset failed';
+		} finally {
+			resetSaving = false;
+			resetConfirm = false;
 		}
 	}
 
@@ -208,6 +231,43 @@
 													{/if}
 												{/if}
 												{#if roleMsg}<span class="save-msg">{roleMsg}</span>{/if}
+											</div>
+										</div>
+										<div class="edit-field">
+											<span class="field-label">Password</span>
+											<div class="role-row">
+												{#if !resetConfirm && !resetResult}
+													<button class="btn role-btn" onclick={() => { resetConfirm = true; resetError = ''; }}>
+														Reset Password
+													</button>
+												{/if}
+												{#if resetConfirm && !resetResult}
+													<div class="role-confirm">
+														<span class="role-confirm-msg">
+															Send password reset for <strong>{user.name || user.username}</strong>?
+														</span>
+														<button class="btn primary" onclick={resetPassword} disabled={resetSaving}>
+															{resetSaving ? 'Resetting...' : 'Confirm'}
+														</button>
+														<button class="btn" onclick={() => { resetConfirm = false; }}>
+															Cancel
+														</button>
+													</div>
+												{/if}
+												{#if resetResult}
+													<div class="reset-result">
+														{#if resetResult.method === 'email'}
+															<span class="reset-success">{resetResult.message}</span>
+														{:else}
+															<div class="temp-password-result">
+																<span class="reset-success">Temporary password generated:</span>
+																<code class="temp-password">{resetResult.temp_password}</code>
+																<span class="reset-note">User's sessions have been invalidated. Share this password securely.</span>
+															</div>
+														{/if}
+													</div>
+												{/if}
+												{#if resetError}<span class="save-msg" style="color: #ef4444">{resetError}</span>{/if}
 											</div>
 										</div>
 										<div class="edit-field">
@@ -363,7 +423,8 @@
 		flex-direction: column;
 		gap: var(--space-1);
 	}
-	.edit-field label {
+	.edit-field label,
+	.edit-field .field-label {
 		font-size: 0.8rem;
 		color: var(--text-muted);
 		font-weight: 500;
@@ -415,6 +476,34 @@
 	.role-confirm .btn {
 		font-size: 0.8rem;
 		padding: var(--space-1) var(--space-3);
+	}
+	.reset-result {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-1);
+	}
+	.reset-success {
+		font-size: 0.8rem;
+		color: var(--accent-green, #22c55e);
+	}
+	.temp-password-result {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-1);
+	}
+	.temp-password {
+		font-family: monospace;
+		font-size: 0.85rem;
+		padding: var(--space-2) var(--space-3);
+		background: var(--bg-secondary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+		color: var(--text-primary);
+		user-select: all;
+	}
+	.reset-note {
+		font-size: 0.75rem;
+		color: var(--text-muted);
 	}
 
 	.users-page {


### PR DESCRIPTION
## Summary
- New `POST /api/v1/admin/users/{id}/reset-password` endpoint
- When email is configured: generates a reset token and sends a password reset email
- When email is not configured: generates a temporary password, sets it on the user, and invalidates all their sessions
- New `password_reset_by_admin` audit action with metadata (target user, method used)
- Frontend: "Reset Password" button in admin user edit panel with confirmation dialog and result display (shows email confirmation or temporary password in a copyable code block)

Closes TASK-555 — part of PLAN-552 (Admin Console Enhancement)

## Test plan
- [ ] Reset password for a user (without email configured) — verify temp password is returned and sessions invalidated
- [ ] Reset password for a user (with email configured) — verify reset email is sent
- [ ] Verify audit log entry is created with correct action and metadata
- [ ] Verify `go test ./...` passes
- [ ] Verify `npm run build` compiles cleanly