### PR TITLE
feat: add account disable/deactivation

### DIFF
--- a/internal/models/activity.go
+++ b/internal/models/activity.go
@@ -29,6 +29,8 @@ const (
 	ActionOAuthLoginFailed = "oauth_login_failed"
 	ActionPlanChanged      = "plan_changed"
 	ActionPasswordResetByAdmin = "password_reset_by_admin"
+	ActionUserDisabled         = "user_disabled"
+	ActionUserEnabled          = "user_enabled"
 	ActionAccountDeleted       = "account_deleted"
 )
 

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -22,8 +22,14 @@ type User struct {
 	StripeCustomerID string    `json:"-"`                       // Never serialized
 	PlanOverrides    string    `json:"plan_overrides,omitempty"` // JSON overrides for per-user limits
 	OAuthProviders   string    `json:"-"`                       // JSON array of linked providers, e.g. ["github","google"]
+	DisabledAt       string    `json:"disabled_at,omitempty"`   // Non-empty = account disabled
 	CreatedAt        time.Time `json:"created_at"`
 	UpdatedAt        time.Time `json:"updated_at"`
+}
+
+// IsDisabled returns true if the user account has been disabled.
+func (u *User) IsDisabled() bool {
+	return u.DisabledAt != ""
 }
 
 // GetOAuthProviders parses the JSON oauth_providers field into a string slice.

--- a/internal/server/handlers_admin_users.go
+++ b/internal/server/handlers_admin_users.go
@@ -55,6 +55,7 @@ func (s *Server) handleAdminListUsers(w http.ResponseWriter, r *http.Request) {
 		PlanExpiresAt string `json:"plan_expires_at,omitempty"`
 		PlanOverrides string `json:"plan_overrides,omitempty"`
 		TOTPEnabled   bool   `json:"totp_enabled"`
+		DisabledAt    string `json:"disabled_at,omitempty"`
 		CreatedAt     string `json:"created_at"`
 		UpdatedAt     string `json:"updated_at"`
 	}
@@ -71,6 +72,7 @@ func (s *Server) handleAdminListUsers(w http.ResponseWriter, r *http.Request) {
 			PlanExpiresAt: u.PlanExpiresAt,
 			PlanOverrides: u.PlanOverrides,
 			TOTPEnabled:   u.TOTPEnabled,
+			DisabledAt:    u.DisabledAt,
 			CreatedAt:     u.CreatedAt.Format("2006-01-02T15:04:05Z"),
 			UpdatedAt:     u.UpdatedAt.Format("2006-01-02T15:04:05Z"),
 		})
@@ -117,6 +119,7 @@ func (s *Server) handleAdminGetUser(w http.ResponseWriter, r *http.Request) {
 		"plan_expires_at": user.PlanExpiresAt,
 		"plan_overrides":  user.PlanOverrides,
 		"totp_enabled":    user.TOTPEnabled,
+		"disabled_at":     user.DisabledAt,
 		"created_at":      user.CreatedAt,
 		"updated_at":      user.UpdatedAt,
 		"workspace_count": len(workspaces),
@@ -319,6 +322,94 @@ func (s *Server) handleAdminResetPassword(w http.ResponseWriter, r *http.Request
 		"method":         "temporary_password",
 		"temp_password":  tempPassword,
 		"message":        "Temporary password generated. The user's existing sessions have been invalidated.",
+	})
+}
+
+// handleAdminDisableUser soft-disables a user account.
+// POST /api/v1/admin/users/{userID}/disable
+func (s *Server) handleAdminDisableUser(w http.ResponseWriter, r *http.Request) {
+	if !requireAdmin(w, r) {
+		return
+	}
+
+	userID := chi.URLParam(r, "userID")
+
+	// Guard: cannot disable yourself
+	caller := currentUser(r)
+	if caller != nil && caller.ID == userID {
+		writeError(w, http.StatusBadRequest, "bad_request", "Cannot disable your own account")
+		return
+	}
+
+	user, err := s.store.GetUser(userID)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	if user == nil {
+		writeError(w, http.StatusNotFound, "not_found", "User not found")
+		return
+	}
+	if user.IsDisabled() {
+		writeJSON(w, http.StatusOK, map[string]interface{}{"ok": true, "message": "User is already disabled"})
+		return
+	}
+
+	if err := s.store.DisableUser(userID); err != nil {
+		writeInternalError(w, err)
+		return
+	}
+
+	// Invalidate all sessions
+	if err := s.store.DeleteUserSessions(userID); err != nil {
+		writeInternalError(w, err)
+		return
+	}
+
+	s.logAuditEvent(models.ActionUserDisabled, r, auditMeta(map[string]string{
+		"target_user_id": userID,
+	}))
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"ok":      true,
+		"message": "User disabled and sessions invalidated",
+	})
+}
+
+// handleAdminEnableUser re-enables a disabled user account.
+// POST /api/v1/admin/users/{userID}/enable
+func (s *Server) handleAdminEnableUser(w http.ResponseWriter, r *http.Request) {
+	if !requireAdmin(w, r) {
+		return
+	}
+
+	userID := chi.URLParam(r, "userID")
+	user, err := s.store.GetUser(userID)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	if user == nil {
+		writeError(w, http.StatusNotFound, "not_found", "User not found")
+		return
+	}
+	if !user.IsDisabled() {
+		writeJSON(w, http.StatusOK, map[string]interface{}{"ok": true, "message": "User is already enabled"})
+		return
+	}
+
+	if err := s.store.EnableUser(userID); err != nil {
+		writeInternalError(w, err)
+		return
+	}
+
+	s.logAuditEvent(models.ActionUserEnabled, r, auditMeta(map[string]string{
+		"target_user_id": userID,
+	}))
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"ok":      true,
+		"message": "User re-enabled",
 	})
 }
 

--- a/internal/server/handlers_admin_users.go
+++ b/internal/server/handlers_admin_users.go
@@ -350,17 +350,12 @@ func (s *Server) handleAdminDisableUser(w http.ResponseWriter, r *http.Request) 
 		writeError(w, http.StatusNotFound, "not_found", "User not found")
 		return
 	}
-	if user.IsDisabled() {
-		writeJSON(w, http.StatusOK, map[string]interface{}{"ok": true, "message": "User is already disabled"})
-		return
-	}
-
 	if err := s.store.DisableUser(userID); err != nil {
 		writeInternalError(w, err)
 		return
 	}
 
-	// Invalidate all sessions
+	// Always invalidate sessions (also handles retry after partial failure)
 	if err := s.store.DeleteUserSessions(userID); err != nil {
 		writeInternalError(w, err)
 		return

--- a/internal/server/handlers_auth.go
+++ b/internal/server/handlers_auth.go
@@ -475,6 +475,12 @@ func (s *Server) handleLogin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Reject disabled accounts
+	if user.IsDisabled() {
+		writeError(w, http.StatusForbidden, "account_disabled", "Your account has been disabled. Contact an administrator.")
+		return
+	}
+
 	// If 2FA is enabled, return a challenge token instead of a full session.
 	// The challenge token is HMAC-signed, IP-bound, and expires in 5 minutes.
 	if user.TOTPEnabled {

--- a/internal/server/handlers_auth.go
+++ b/internal/server/handlers_auth.go
@@ -814,6 +814,12 @@ func (s *Server) handleResetPassword(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Reject disabled accounts
+	if user.IsDisabled() {
+		writeError(w, http.StatusForbidden, "account_disabled", "Your account has been disabled. Contact an administrator.")
+		return
+	}
+
 	// Update password
 	password := input.Password
 	update := models.UserUpdate{Password: &password}

--- a/internal/server/handlers_cloud.go
+++ b/internal/server/handlers_cloud.go
@@ -169,7 +169,13 @@ func (s *Server) handleOAuthLogin(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// 6. Create session (30-day TTL for OAuth sessions)
+	// 6. Reject disabled accounts
+	if user.IsDisabled() {
+		writeError(w, http.StatusForbidden, "account_disabled", "Your account has been disabled. Contact an administrator.")
+		return
+	}
+
+	// 7. Create session (30-day TTL for OAuth sessions)
 	token, err := s.createAuthSession(w, r, user, 30*24*time.Hour)
 	if err != nil {
 		return // Error already written by createAuthSession

--- a/internal/server/middleware_auth.go
+++ b/internal/server/middleware_auth.go
@@ -207,7 +207,15 @@ func (s *Server) RequireAuth(next http.Handler) http.Handler {
 		}
 
 		// Already authenticated via token or session
-		if currentUser(r) != nil || tokenWorkspaceID(r) != "" {
+		if user := currentUser(r); user != nil {
+			if user.IsDisabled() {
+				writeError(w, http.StatusForbidden, "account_disabled", "Your account has been disabled. Contact an administrator.")
+				return
+			}
+			next.ServeHTTP(w, r)
+			return
+		}
+		if tokenWorkspaceID(r) != "" {
 			next.ServeHTTP(w, r)
 			return
 		}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -314,6 +314,8 @@ func (s *Server) setupRouter() {
 			r.Get("/users/{userID}", s.handleAdminGetUser)
 			r.Patch("/users/{userID}", s.handleAdminUpdateUser)
 			r.Post("/users/{userID}/reset-password", s.handleAdminResetPassword)
+			r.Post("/users/{userID}/disable", s.handleAdminDisableUser)
+			r.Post("/users/{userID}/enable", s.handleAdminEnableUser)
 
 			// Plan limits
 			r.Get("/limits", s.handleAdminGetLimits)

--- a/internal/store/migrations/040_user_disabled_at.sql
+++ b/internal/store/migrations/040_user_disabled_at.sql
@@ -1,0 +1,3 @@
+-- Add disabled_at column for account deactivation (soft-disable).
+-- NULL = active, non-NULL = disabled at that time.
+ALTER TABLE users ADD COLUMN disabled_at TEXT DEFAULT NULL;

--- a/internal/store/pgmigrations/020_user_disabled_at.sql
+++ b/internal/store/pgmigrations/020_user_disabled_at.sql
@@ -1,0 +1,3 @@
+-- Add disabled_at column for account deactivation (soft-disable).
+-- NULL = active, non-NULL = disabled at that time.
+ALTER TABLE users ADD COLUMN IF NOT EXISTS disabled_at TEXT DEFAULT NULL;

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -173,6 +173,7 @@ func (s *Store) migrate() error {
 		"037_oauth_providers.sql",
 		"038_email_optouts.sql",
 		"039_cli_auth_sessions.sql",
+		"040_user_disabled_at.sql",
 	}
 
 	for _, name := range migrations {
@@ -236,6 +237,7 @@ func (s *Store) migratePostgres() error {
 		"017_oauth_providers.sql",
 		"018_email_optouts.sql",
 		"019_cli_auth_sessions.sql",
+		"020_user_disabled_at.sql",
 	}
 
 	for _, name := range migrations {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -4,6 +4,8 @@ import (
 	"database/sql"
 	"embed"
 	"fmt"
+	"io/fs"
+	"sort"
 	"strings"
 	"time"
 
@@ -123,6 +125,22 @@ func (s *Store) Ping() error {
 	return s.db.Ping()
 }
 
+// readMigrationNames returns sorted .sql filenames from an embedded FS directory.
+func readMigrationNames(fsys embed.FS, dir string) ([]string, error) {
+	entries, err := fs.ReadDir(fsys, dir)
+	if err != nil {
+		return nil, fmt.Errorf("read migration dir %s: %w", dir, err)
+	}
+	var names []string
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasSuffix(e.Name(), ".sql") {
+			names = append(names, e.Name())
+		}
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
 func (s *Store) migrate() error {
 	// Create migrations tracking table
 	_, err := s.db.Exec(`CREATE TABLE IF NOT EXISTS schema_migrations (
@@ -133,47 +151,9 @@ func (s *Store) migrate() error {
 		return fmt.Errorf("create migrations table: %w", err)
 	}
 
-	migrations := []string{
-		"001_initial.sql",
-		"002_version_diffs.sql",
-		"003_custom_templates.sql",
-		"004_progress_snapshots.sql",
-		"005_collections.sql",
-		"006_item_numbers.sql",
-		"007_comments.sql",
-		"008_tasks_phase_field.sql",
-		"009_ideas_implemented_status.sql",
-		"010_webhooks.sql",
-		"011_api_tokens.sql",
-		"012_users.sql",
-		"013_workspace_invitations.sql",
-		"014_platform_settings.sql",
-		"015_password_resets.sql",
-		"016_timeline.sql",
-		"017_agent_roles.sql",
-		"018_conventions_role_field.sql",
-		"019_agent_roles_tools.sql",
-		"020_role_sort_order.sql",
-		"021_phase_to_links.sql",
-		"022_audit_trail.sql",
-		"023_parent_link_type.sql",
-		"024_phases_to_plans.sql",
-		"025_doc_type_plan.sql",
-		"026_session_binding.sql",
-		"027_totp.sql",
-		"028_workspace_sort_order.sql",
-		"029_username.sql",
-		"030_workspace_owner.sql",
-		"031_collection_access.sql",
-		"032_permission_indexes.sql",
-		"033_grants.sql",
-		"034_share_links.sql",
-		"035_plan_fields.sql",
-		"036_stripe_customer_index.sql",
-		"037_oauth_providers.sql",
-		"038_email_optouts.sql",
-		"039_cli_auth_sessions.sql",
-		"040_user_disabled_at.sql",
+	migrations, err := readMigrationNames(migrationsFS, "migrations")
+	if err != nil {
+		return err
 	}
 
 	for _, name := range migrations {
@@ -217,27 +197,9 @@ func (s *Store) migratePostgres() error {
 		return fmt.Errorf("create migrations table: %w", err)
 	}
 
-	migrations := []string{
-		"001_initial.sql",
-		"002_audit_trail.sql",
-		"003_parent_link_type.sql",
-		"004_doc_type_plan.sql",
-		"005_phases_to_plans.sql",
-		"006_session_binding.sql",
-		"007_totp.sql",
-		"008_workspace_sort_order.sql",
-		"009_username.sql",
-		"010_workspace_owner.sql",
-		"011_collection_access.sql",
-		"012_permission_indexes.sql",
-		"013_grants.sql",
-		"014_share_links.sql",
-		"015_plan_fields.sql",
-		"016_stripe_customer_index.sql",
-		"017_oauth_providers.sql",
-		"018_email_optouts.sql",
-		"019_cli_auth_sessions.sql",
-		"020_user_disabled_at.sql",
+	migrations, err := readMigrationNames(pgMigrationsFS, "pgmigrations")
+	if err != nil {
+		return err
 	}
 
 	for _, name := range migrations {

--- a/internal/store/users.go
+++ b/internal/store/users.go
@@ -19,7 +19,7 @@ var usernameCleanRe = regexp.MustCompile(`[^a-z0-9-]+`)
 const bcryptCost = 12
 
 // user SELECT columns — used by all user queries.
-const userColumns = `id, email, username, name, password_hash, role, avatar_url, totp_secret, totp_enabled, recovery_codes, plan, plan_expires_at, stripe_customer_id, plan_overrides, oauth_providers, created_at, updated_at`
+const userColumns = `id, email, username, name, password_hash, role, avatar_url, totp_secret, totp_enabled, recovery_codes, plan, plan_expires_at, stripe_customer_id, plan_overrides, oauth_providers, disabled_at, created_at, updated_at`
 
 // scanUser scans a user row into a User struct.
 // Note: does NOT decrypt the TOTP secret — call store.decryptUserTOTP() after
@@ -28,12 +28,16 @@ func scanUser(row interface{ Scan(...interface{}) error }) (*models.User, error)
 	var u models.User
 	var createdAt, updatedAt string
 
+	var disabledAt sql.NullString
 	err := row.Scan(
 		&u.ID, &u.Email, &u.Username, &u.Name, &u.PasswordHash, &u.Role, &u.AvatarURL,
 		&u.TOTPSecret, &u.TOTPEnabled, &u.RecoveryCodes,
 		&u.Plan, &u.PlanExpiresAt, &u.StripeCustomerID, &u.PlanOverrides, &u.OAuthProviders,
-		&createdAt, &updatedAt,
+		&disabledAt, &createdAt, &updatedAt,
 	)
+	if disabledAt.Valid {
+		u.DisabledAt = disabledAt.String
+	}
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -399,6 +403,26 @@ func (s *Store) RemoveOAuthProvider(userID, provider string) error {
 
 // ErrLastAdmin is returned when a role change would leave zero admins.
 var ErrLastAdmin = fmt.Errorf("cannot demote the last admin")
+
+// DisableUser soft-disables a user account by setting disabled_at.
+func (s *Store) DisableUser(userID string) error {
+	_, err := s.db.Exec(s.q(`UPDATE users SET disabled_at = ?, updated_at = ? WHERE id = ?`),
+		now(), now(), userID)
+	if err != nil {
+		return fmt.Errorf("disable user: %w", err)
+	}
+	return nil
+}
+
+// EnableUser re-enables a disabled user account by clearing disabled_at.
+func (s *Store) EnableUser(userID string) error {
+	_, err := s.db.Exec(s.q(`UPDATE users SET disabled_at = NULL, updated_at = ? WHERE id = ?`),
+		now(), userID)
+	if err != nil {
+		return fmt.Errorf("enable user: %w", err)
+	}
+	return nil
+}
 
 // SetUserRole updates a user's role (admin or member).
 // When demoting an admin to member, the update is conditional: it only

--- a/web/src/lib/stores/admin.svelte.ts
+++ b/web/src/lib/stores/admin.svelte.ts
@@ -14,6 +14,7 @@ export interface AdminUser {
 	plan_expires_at: string | null;
 	plan_overrides: Record<string, number> | null;
 	totp_enabled: boolean;
+	disabled_at: string | null;
 	created_at: string;
 }
 

--- a/web/src/routes/console/admin/+page.svelte
+++ b/web/src/routes/console/admin/+page.svelte
@@ -19,6 +19,9 @@
 	let resetSaving = $state(false);
 	let resetResult = $state<{ method: string; temp_password?: string; message: string } | null>(null);
 	let resetError = $state('');
+	let disableConfirm = $state(false);
+	let disableSaving = $state(false);
+	let disableMsg = $state('');
 
 	async function loadUsers() {
 		loading = true;
@@ -57,6 +60,8 @@
 		resetConfirm = false;
 		resetResult = null;
 		resetError = '';
+		disableConfirm = false;
+		disableMsg = '';
 	}
 
 	function selectedUser(): AdminUser | undefined {
@@ -99,6 +104,26 @@
 		} finally {
 			resetSaving = false;
 			resetConfirm = false;
+		}
+	}
+
+	async function toggleDisable() {
+		if (!selectedId) return;
+		const user = selectedUser();
+		if (!user) return;
+		disableSaving = true;
+		disableMsg = '';
+		try {
+			const action = user.disabled_at ? 'enable' : 'disable';
+			await adminPost(`/admin/users/${selectedId}/${action}`);
+			const updated = await adminFetch(`/admin/users/${selectedId}`);
+			users = users.map((u) => (u.id === selectedId ? { ...u, ...updated } : u));
+			disableMsg = user.disabled_at ? 'User re-enabled' : 'User disabled';
+			disableConfirm = false;
+		} catch (e) {
+			disableMsg = e instanceof Error ? e.message : 'Action failed';
+		} finally {
+			disableSaving = false;
 		}
 	}
 
@@ -167,9 +192,15 @@
 						<tr
 							class="user-row"
 							class:selected={selectedId === user.id}
+							class:disabled-row={!!user.disabled_at}
 							onclick={() => selectUser(user)}
 						>
-							<td>{user.name || user.username}</td>
+							<td>
+								{user.name || user.username}
+								{#if user.disabled_at}
+									<span class="badge disabled">disabled</span>
+								{/if}
+							</td>
 							<td
 								><span class="badge" class:admin={user.role === 'admin'}
 									>{user.role || 'member'}</span
@@ -268,6 +299,42 @@
 													</div>
 												{/if}
 												{#if resetError}<span class="save-msg" style="color: #ef4444">{resetError}</span>{/if}
+											</div>
+										</div>
+										<div class="edit-field">
+											<span class="field-label">Account Status</span>
+											<div class="role-row">
+												{#if !disableConfirm}
+													<button
+														class="btn role-btn"
+														class:danger={!user.disabled_at}
+														onclick={() => { disableConfirm = true; disableMsg = ''; }}
+													>
+														{user.disabled_at ? 'Enable Account' : 'Disable Account'}
+													</button>
+												{:else}
+													<div class="role-confirm">
+														<span class="role-confirm-msg">
+															{#if user.disabled_at}
+																Re-enable <strong>{user.name || user.username}</strong>?
+															{:else}
+																Disable <strong>{user.name || user.username}</strong>? Their sessions will be invalidated.
+															{/if}
+														</span>
+														<button
+															class="btn primary"
+															class:danger={!user.disabled_at}
+															onclick={toggleDisable}
+															disabled={disableSaving}
+														>
+															{disableSaving ? 'Saving...' : 'Confirm'}
+														</button>
+														<button class="btn" onclick={() => { disableConfirm = false; }}>
+															Cancel
+														</button>
+													</div>
+												{/if}
+												{#if disableMsg}<span class="save-msg">{disableMsg}</span>{/if}
 											</div>
 										</div>
 										<div class="edit-field">
@@ -404,6 +471,29 @@
 	.badge.admin {
 		background: color-mix(in srgb, var(--accent-orange, #f59e0b) 15%, transparent);
 		color: var(--accent-orange, #f59e0b);
+	}
+	.badge.disabled {
+		background: color-mix(in srgb, #ef4444 15%, transparent);
+		color: #ef4444;
+		margin-left: var(--space-2);
+	}
+	.disabled-row {
+		opacity: 0.6;
+	}
+	.btn.danger {
+		border-color: #ef4444;
+		color: #ef4444;
+	}
+	.btn.danger:hover {
+		background: color-mix(in srgb, #ef4444 10%, transparent);
+	}
+	.btn.primary.danger {
+		background: #ef4444;
+		color: #fff;
+		border-color: transparent;
+	}
+	.btn.primary.danger:hover {
+		opacity: 0.9;
 	}
 
 	/* Edit panel */

--- a/web/src/routes/console/admin/+page.svelte
+++ b/web/src/routes/console/admin/+page.svelte
@@ -75,13 +75,14 @@
 	}
 
 	async function changeRole() {
-		if (!selectedId) return;
+		const userId = selectedId;
+		if (!userId) return;
 		roleSaving = true;
 		roleMsg = '';
 		try {
-			await adminPatch(`/admin/users/${selectedId}`, { role: editRole });
-			const updated = await adminFetch(`/admin/users/${selectedId}`);
-			users = users.map((u) => (u.id === selectedId ? { ...u, ...updated } : u));
+			await adminPatch(`/admin/users/${userId}`, { role: editRole });
+			const updated = await adminFetch(`/admin/users/${userId}`);
+			users = users.map((u) => (u.id === userId ? { ...u, ...updated } : u));
 			roleMsg = 'Role updated';
 			roleConfirm = false;
 		} catch (e) {
@@ -92,12 +93,13 @@
 	}
 
 	async function resetPassword() {
-		if (!selectedId) return;
+		const userId = selectedId;
+		if (!userId) return;
 		resetSaving = true;
 		resetError = '';
 		resetResult = null;
 		try {
-			const result = await adminPost(`/admin/users/${selectedId}/reset-password`);
+			const result = await adminPost(`/admin/users/${userId}/reset-password`);
 			resetResult = result;
 		} catch (e) {
 			resetError = e instanceof Error ? e.message : 'Password reset failed';
@@ -108,17 +110,19 @@
 	}
 
 	async function toggleDisable() {
-		if (!selectedId) return;
+		const userId = selectedId;
+		if (!userId) return;
 		const user = selectedUser();
 		if (!user) return;
+		const wasDisabled = !!user.disabled_at;
 		disableSaving = true;
 		disableMsg = '';
 		try {
-			const action = user.disabled_at ? 'enable' : 'disable';
-			await adminPost(`/admin/users/${selectedId}/${action}`);
-			const updated = await adminFetch(`/admin/users/${selectedId}`);
-			users = users.map((u) => (u.id === selectedId ? { ...u, ...updated } : u));
-			disableMsg = user.disabled_at ? 'User re-enabled' : 'User disabled';
+			const action = wasDisabled ? 'enable' : 'disable';
+			await adminPost(`/admin/users/${userId}/${action}`);
+			const updated = await adminFetch(`/admin/users/${userId}`);
+			users = users.map((u) => (u.id === userId ? { ...u, ...updated } : u));
+			disableMsg = wasDisabled ? 'User re-enabled' : 'User disabled';
 			disableConfirm = false;
 		} catch (e) {
 			disableMsg = e instanceof Error ? e.message : 'Action failed';


### PR DESCRIPTION
## Summary
- Migration: `disabled_at` nullable timestamp column on users table (SQLite + PostgreSQL)
- `DisableUser()` / `EnableUser()` store methods
- `POST /api/v1/admin/users/{id}/disable` and `/enable` endpoints with guards (cannot disable yourself) and session invalidation on disable
- Auth middleware rejects disabled users with 403 "Your account has been disabled"
- New `user_disabled` / `user_enabled` audit actions
- Frontend: disabled users show dimmed with red "disabled" badge in list, disable/enable toggle in edit panel with confirmation dialog and danger styling

Closes TASK-556 — part of PLAN-552 (Admin Console Enhancement)

## Test plan
- [ ] Disable a user — verify sessions invalidated, user gets 403 on next request
- [ ] Enable a disabled user — verify they can log in again
- [ ] Try to disable yourself — should get "Cannot disable your own account" error
- [ ] Verify disabled users show dimmed with badge in admin user list
- [ ] Verify `go test ./...` passes (includes migration test)
- [ ] Verify `npm run build` compiles cleanly