### PR TITLE
feat: add user detail panel with workspace memberships

### DIFF
--- a/internal/server/handlers_admin_users.go
+++ b/internal/server/handlers_admin_users.go
@@ -129,6 +129,28 @@ func (s *Server) handleAdminGetUser(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// handleAdminGetUserWorkspaces returns workspace memberships for a user.
+// GET /api/v1/admin/users/{userID}/workspaces
+func (s *Server) handleAdminGetUserWorkspaces(w http.ResponseWriter, r *http.Request) {
+	if !requireAdmin(w, r) {
+		return
+	}
+
+	userID := chi.URLParam(r, "userID")
+	memberships, err := s.store.GetUserWorkspaceMemberships(userID)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	if memberships == nil {
+		memberships = []store.AdminUserWorkspace{}
+	}
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"workspaces": memberships,
+	})
+}
+
 // handleAdminUpdateUser updates a user's plan, overrides, or role.
 // PATCH /api/v1/admin/users/{userID}
 func (s *Server) handleAdminUpdateUser(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -314,6 +314,7 @@ func (s *Server) setupRouter() {
 			r.Get("/users/{userID}", s.handleAdminGetUser)
 			r.Patch("/users/{userID}", s.handleAdminUpdateUser)
 			r.Post("/users/{userID}/reset-password", s.handleAdminResetPassword)
+			r.Get("/users/{userID}/workspaces", s.handleAdminGetUserWorkspaces)
 			r.Post("/users/{userID}/disable", s.handleAdminDisableUser)
 			r.Post("/users/{userID}/enable", s.handleAdminEnableUser)
 

--- a/internal/store/workspace_members.go
+++ b/internal/store/workspace_members.go
@@ -754,3 +754,39 @@ func (s *Store) backfillWorkspaceOwners() error {
 
 	return nil
 }
+
+// AdminUserWorkspace is a lightweight workspace membership for admin views.
+type AdminUserWorkspace struct {
+	WorkspaceID   string `json:"workspace_id"`
+	WorkspaceName string `json:"workspace_name"`
+	WorkspaceSlug string `json:"workspace_slug"`
+	OwnerUsername string `json:"owner_username"`
+	Role          string `json:"role"`
+	JoinedAt      string `json:"joined_at"`
+}
+
+// GetUserWorkspaceMemberships returns workspace memberships for admin user detail.
+func (s *Store) GetUserWorkspaceMemberships(userID string) ([]AdminUserWorkspace, error) {
+	rows, err := s.db.Query(s.q(`
+		SELECT w.id, w.name, w.slug, COALESCE(ou.username, ''), wm.role, wm.created_at
+		FROM workspace_members wm
+		JOIN workspaces w ON w.id = wm.workspace_id
+		LEFT JOIN users ou ON ou.id = w.owner_id
+		WHERE wm.user_id = ? AND w.deleted_at IS NULL
+		ORDER BY w.name ASC
+	`), userID)
+	if err != nil {
+		return nil, fmt.Errorf("get user workspace memberships: %w", err)
+	}
+	defer rows.Close()
+
+	var result []AdminUserWorkspace
+	for rows.Next() {
+		var m AdminUserWorkspace
+		if err := rows.Scan(&m.WorkspaceID, &m.WorkspaceName, &m.WorkspaceSlug, &m.OwnerUsername, &m.Role, &m.JoinedAt); err != nil {
+			return nil, fmt.Errorf("scan workspace membership: %w", err)
+		}
+		result = append(result, m)
+	}
+	return result, rows.Err()
+}

--- a/web/src/routes/console/admin/+page.svelte
+++ b/web/src/routes/console/admin/+page.svelte
@@ -22,6 +22,8 @@
 	let disableConfirm = $state(false);
 	let disableSaving = $state(false);
 	let disableMsg = $state('');
+	let userWorkspaces = $state<{ workspace_name: string; workspace_slug: string; owner_username: string; role: string; joined_at: string }[]>([]);
+	let workspacesLoading = $state(false);
 
 	async function loadUsers() {
 		loading = true;
@@ -62,6 +64,22 @@
 		resetError = '';
 		disableConfirm = false;
 		disableMsg = '';
+		userWorkspaces = [];
+		loadUserWorkspaces(u.id);
+	}
+
+	async function loadUserWorkspaces(userId: string) {
+		workspacesLoading = true;
+		try {
+			const result = await adminFetch(`/admin/users/${userId}/workspaces`);
+			if (selectedId === userId) {
+				userWorkspaces = result.workspaces ?? [];
+			}
+		} catch {
+			userWorkspaces = [];
+		} finally {
+			workspacesLoading = false;
+		}
 	}
 
 	function selectedUser(): AdminUser | undefined {
@@ -382,6 +400,24 @@
 											</button>
 											{#if saveMsg}<span class="save-msg">{saveMsg}</span>{/if}
 										</div>
+										<div class="edit-field">
+											<span class="field-label">Workspaces</span>
+											{#if workspacesLoading}
+												<span class="ws-loading">Loading...</span>
+											{:else if userWorkspaces.length === 0}
+												<span class="ws-empty">No workspace memberships</span>
+											{:else}
+												<div class="ws-list">
+													{#each userWorkspaces as ws}
+														<div class="ws-item">
+															<a class="ws-name" href="/{ws.owner_username}/{ws.workspace_slug}">{ws.workspace_name}</a>
+															<span class="badge" class:owner={ws.role === 'owner'}>{ws.role}</span>
+															<span class="ws-joined">joined {formatDate(ws.joined_at)}</span>
+														</div>
+													{/each}
+												</div>
+											{/if}
+										</div>
 									</div>
 								</td>
 							</tr>
@@ -621,6 +657,40 @@
 	.reset-note {
 		font-size: 0.75rem;
 		color: var(--text-muted);
+	}
+
+	.ws-loading,
+	.ws-empty {
+		font-size: 0.8rem;
+		color: var(--text-muted);
+	}
+	.ws-list {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-1);
+	}
+	.ws-item {
+		display: flex;
+		align-items: center;
+		gap: var(--space-2);
+		font-size: 0.8rem;
+		padding: var(--space-1) 0;
+	}
+	.ws-name {
+		color: var(--accent-blue);
+		text-decoration: none;
+		font-weight: 500;
+	}
+	.ws-name:hover {
+		text-decoration: underline;
+	}
+	.badge.owner {
+		background: color-mix(in srgb, var(--accent-green, #22c55e) 15%, transparent);
+		color: var(--accent-green, #22c55e);
+	}
+	.ws-joined {
+		color: var(--text-muted);
+		font-size: 0.75rem;
 	}
 
 	.users-page {

--- a/web/src/routes/console/admin/+page.svelte
+++ b/web/src/routes/console/admin/+page.svelte
@@ -76,9 +76,13 @@
 				userWorkspaces = result.workspaces ?? [];
 			}
 		} catch {
-			userWorkspaces = [];
+			if (selectedId === userId) {
+				userWorkspaces = [];
+			}
 		} finally {
-			workspacesLoading = false;
+			if (selectedId === userId) {
+				workspacesLoading = false;
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary
- New `GetUserWorkspaceMemberships()` store method joining workspaces + membership with role and join date
- New `GET /api/v1/admin/users/{id}/workspaces` admin endpoint
- Frontend: workspace memberships section in the user edit panel — loads on user selection, shows workspace name (linked to workspace UI), role badge (green for owner), and join date
- Race-safe: only updates UI if the selected user hasn't changed during the fetch

Closes TASK-558 — part of PLAN-552 (Admin Console Enhancement)

## Test plan
- [ ] Expand a user with workspace memberships — verify list shows with correct roles
- [ ] Click workspace name — verify it navigates to the workspace
- [ ] Expand a user with no memberships — verify "No workspace memberships" shown
- [ ] Rapidly click different users — verify no stale data from previous loads
- [ ] Verify `go test ./...` passes
- [ ] Verify `npm run build` compiles cleanly