### PR TITLE
feat: add invitation management panel for admin console

### DIFF
--- a/internal/server/handlers_admin_invitations.go
+++ b/internal/server/handlers_admin_invitations.go
@@ -52,8 +52,11 @@ func (s *Server) handleAdminResendInvitation(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	// Delete old and create fresh invitation with new code
-	_ = s.store.DeleteInvitationAdmin(invID)
+	// Delete old invitation — abort if it's already gone (accepted or revoked concurrently)
+	if err := s.store.DeleteInvitationAdmin(invID); err != nil {
+		writeError(w, http.StatusNotFound, "not_found", "Invitation is no longer pending")
+		return
+	}
 
 	caller := currentUser(r)
 	inviterID := old.InvitedBy
@@ -74,6 +77,16 @@ func (s *Server) handleAdminResendInvitation(w http.ResponseWriter, r *http.Requ
 	}
 
 	if s.email != nil && joinURL != "" {
+		// Respect email opt-out preferences
+		if optedOut, err := s.store.IsEmailOptedOut(inv.Email); err == nil && optedOut {
+			writeJSON(w, http.StatusOK, map[string]interface{}{
+				"ok":      true,
+				"method":  "code",
+				"message": "Invitation recreated but email not sent (recipient opted out)",
+			})
+			return
+		}
+
 		inviterName := "An administrator"
 		wsName := "a workspace"
 		if caller != nil {

--- a/internal/server/handlers_admin_invitations.go
+++ b/internal/server/handlers_admin_invitations.go
@@ -1,0 +1,133 @@
+package server
+
+import (
+	"database/sql"
+	"log/slog"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/xarmian/pad/internal/email"
+	"github.com/xarmian/pad/internal/models"
+	"github.com/xarmian/pad/internal/store"
+)
+
+// handleAdminListInvitations returns all pending invitations across all workspaces.
+// GET /api/v1/admin/invitations?q=search
+func (s *Server) handleAdminListInvitations(w http.ResponseWriter, r *http.Request) {
+	if !requireAdmin(w, r) {
+		return
+	}
+
+	query := r.URL.Query().Get("q")
+	invitations, err := s.store.ListPendingInvitationsAdmin(query)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	if invitations == nil {
+		invitations = []store.AdminInvitation{}
+	}
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"invitations": invitations,
+	})
+}
+
+// handleAdminResendInvitation revokes the old invitation and creates a fresh one
+// with a new code, then sends the invitation email.
+// POST /api/v1/admin/invitations/{invID}/resend
+func (s *Server) handleAdminResendInvitation(w http.ResponseWriter, r *http.Request) {
+	if !requireAdmin(w, r) {
+		return
+	}
+
+	invID := chi.URLParam(r, "invID")
+	old, err := s.store.GetInvitation(invID)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	if old == nil || old.AcceptedAt != nil {
+		writeError(w, http.StatusNotFound, "not_found", "Pending invitation not found")
+		return
+	}
+
+	// Delete old and create fresh invitation with new code
+	_ = s.store.DeleteInvitationAdmin(invID)
+
+	caller := currentUser(r)
+	inviterID := old.InvitedBy
+	if caller != nil {
+		inviterID = caller.ID
+	}
+
+	inv, err := s.store.CreateInvitation(old.WorkspaceID, old.Email, old.Role, inviterID)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+
+	// Send email
+	joinURL := ""
+	if s.baseURL != "" {
+		joinURL = s.baseURL + "/join/" + inv.Code
+	}
+
+	if s.email != nil && joinURL != "" {
+		inviterName := "An administrator"
+		wsName := "a workspace"
+		if caller != nil {
+			inviterName = caller.Name
+		}
+		if ws, err := s.store.GetWorkspaceByID(old.WorkspaceID); err == nil && ws != nil {
+			wsName = ws.Name
+		}
+		unsubURL := email.UnsubscribeURL(s.baseURL, inv.Email, s.unsubscribeSecret())
+		if err := s.email.SendInvitation(r.Context(), inv.Email, inviterName, wsName, joinURL, unsubURL); err != nil {
+			slog.Error("failed to resend invitation email", "error", err, "email", inv.Email)
+			writeError(w, http.StatusInternalServerError, "email_failed", "Invitation recreated but failed to send email")
+			return
+		}
+	}
+
+	s.logAuditEvent(models.ActionMemberInvited, r, auditMeta(map[string]string{
+		"email":     inv.Email,
+		"role":      inv.Role,
+		"workspace": old.WorkspaceID,
+		"resend":    "true",
+	}))
+
+	method := "code"
+	if s.email != nil && joinURL != "" {
+		method = "email"
+	}
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"ok":      true,
+		"method":  method,
+		"message": "Invitation resent to " + inv.Email,
+	})
+}
+
+// handleAdminDeleteInvitation revokes a pending invitation.
+// DELETE /api/v1/admin/invitations/{invID}
+func (s *Server) handleAdminDeleteInvitation(w http.ResponseWriter, r *http.Request) {
+	if !requireAdmin(w, r) {
+		return
+	}
+
+	invID := chi.URLParam(r, "invID")
+	if err := s.store.DeleteInvitationAdmin(invID); err != nil {
+		if err == sql.ErrNoRows {
+			writeError(w, http.StatusNotFound, "not_found", "Pending invitation not found")
+			return
+		}
+		writeInternalError(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"ok":      true,
+		"message": "Invitation revoked",
+	})
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -318,6 +318,11 @@ func (s *Server) setupRouter() {
 			r.Post("/users/{userID}/disable", s.handleAdminDisableUser)
 			r.Post("/users/{userID}/enable", s.handleAdminEnableUser)
 
+			// Invitations
+			r.Get("/invitations", s.handleAdminListInvitations)
+			r.Post("/invitations/{invID}/resend", s.handleAdminResendInvitation)
+			r.Delete("/invitations/{invID}", s.handleAdminDeleteInvitation)
+
 			// Plan limits
 			r.Get("/limits", s.handleAdminGetLimits)
 			r.Patch("/limits", s.handleAdminUpdateLimits)

--- a/internal/store/workspace_members.go
+++ b/internal/store/workspace_members.go
@@ -755,6 +755,77 @@ func (s *Store) backfillWorkspaceOwners() error {
 	return nil
 }
 
+// AdminInvitation holds enriched invitation data for the admin panel.
+type AdminInvitation struct {
+	ID            string `json:"id"`
+	Email         string `json:"email"`
+	Role          string `json:"role"`
+	WorkspaceID   string `json:"workspace_id"`
+	WorkspaceName string `json:"workspace_name"`
+	WorkspaceSlug string `json:"workspace_slug"`
+	InvitedByID   string `json:"invited_by_id"`
+	InvitedByName string `json:"invited_by_name"`
+	CreatedAt     string `json:"created_at"`
+}
+
+// ListPendingInvitationsAdmin returns all pending invitations across all workspaces
+// with workspace and inviter details for the admin panel.
+func (s *Store) ListPendingInvitationsAdmin(query string) ([]AdminInvitation, error) {
+	var where []string
+	var args []interface{}
+
+	where = append(where, "i.accepted_at IS NULL")
+	where = append(where, "w.deleted_at IS NULL")
+
+	if query != "" {
+		q := "%" + strings.ToLower(query) + "%"
+		where = append(where, "(LOWER(i.email) LIKE ? OR LOWER(w.name) LIKE ?)")
+		args = append(args, q, q)
+	}
+
+	whereClause := "WHERE " + strings.Join(where, " AND ")
+
+	rows, err := s.db.Query(s.q(`
+		SELECT i.id, i.email, i.role, w.id, w.name, w.slug, i.invited_by, COALESCE(u.name, ''), i.created_at
+		FROM workspace_invitations i
+		JOIN workspaces w ON w.id = i.workspace_id
+		LEFT JOIN users u ON u.id = i.invited_by
+		`+whereClause+`
+		ORDER BY i.created_at DESC
+	`), args...)
+	if err != nil {
+		return nil, fmt.Errorf("list pending invitations admin: %w", err)
+	}
+	defer rows.Close()
+
+	var result []AdminInvitation
+	for rows.Next() {
+		var inv AdminInvitation
+		if err := rows.Scan(&inv.ID, &inv.Email, &inv.Role, &inv.WorkspaceID, &inv.WorkspaceName,
+			&inv.WorkspaceSlug, &inv.InvitedByID, &inv.InvitedByName, &inv.CreatedAt); err != nil {
+			return nil, fmt.Errorf("scan admin invitation: %w", err)
+		}
+		result = append(result, inv)
+	}
+	return result, rows.Err()
+}
+
+// DeleteInvitationAdmin removes a pending invitation by ID (no workspace scoping).
+func (s *Store) DeleteInvitationAdmin(invitationID string) error {
+	result, err := s.db.Exec(
+		s.q("DELETE FROM workspace_invitations WHERE id = ? AND accepted_at IS NULL"),
+		invitationID,
+	)
+	if err != nil {
+		return fmt.Errorf("delete invitation admin: %w", err)
+	}
+	n, _ := result.RowsAffected()
+	if n == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
+}
+
 // AdminUserWorkspace is a lightweight workspace membership for admin views.
 type AdminUserWorkspace struct {
 	WorkspaceID   string `json:"workspace_id"`

--- a/web/src/routes/console/admin/invitations/+page.svelte
+++ b/web/src/routes/console/admin/invitations/+page.svelte
@@ -1,21 +1,381 @@
-<div class="placeholder">
-	<p class="placeholder-icon">📨</p>
-	<h2 class="placeholder-title">Invitations</h2>
-	<p class="placeholder-desc">View and manage pending workspace invitations across the platform.</p>
-	<p class="placeholder-note">Coming soon</p>
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { adminFetch, adminPost, getCSRFToken, formatDate } from '$lib/stores/admin.svelte';
+
+	interface AdminInvitation {
+		id: string;
+		email: string;
+		role: string;
+		workspace_id: string;
+		workspace_name: string;
+		workspace_slug: string;
+		invited_by_id: string;
+		invited_by_name: string;
+		created_at: string;
+	}
+
+	let invitations = $state<AdminInvitation[]>([]);
+	let search = $state('');
+	let loading = $state(true);
+	let error = $state('');
+	let actionId = $state<string | null>(null);
+	let actionType = $state<'resend' | 'revoke' | null>(null);
+	let actionSaving = $state(false);
+	let actionMsg = $state<Record<string, string>>({});
+
+	async function adminDelete(path: string) {
+		const headers: Record<string, string> = {};
+		const csrf = getCSRFToken();
+		if (csrf) headers['X-CSRF-Token'] = csrf;
+		const resp = await fetch('/api/v1' + path, {
+			method: 'DELETE',
+			credentials: 'same-origin',
+			headers
+		});
+		if (!resp.ok) throw new Error(`${resp.status}`);
+		return resp.json();
+	}
+
+	async function loadInvitations() {
+		loading = true;
+		error = '';
+		try {
+			const result = await adminFetch('/admin/invitations');
+			invitations = result.invitations ?? [];
+		} catch (e) {
+			error = e instanceof Error ? e.message : 'Failed to load invitations';
+		} finally {
+			loading = false;
+		}
+	}
+
+	async function searchInvitations() {
+		try {
+			const result = await adminFetch(`/admin/invitations?q=${encodeURIComponent(search)}`);
+			invitations = result.invitations ?? [];
+		} catch {
+			/* keep existing */
+		}
+	}
+
+	function startAction(id: string, type: 'resend' | 'revoke') {
+		actionId = id;
+		actionType = type;
+		actionSaving = false;
+		// Clear any previous message for this invitation
+		actionMsg = { ...actionMsg, [id]: '' };
+	}
+
+	function cancelAction() {
+		actionId = null;
+		actionType = null;
+		actionSaving = false;
+	}
+
+	async function confirmResend(id: string) {
+		actionSaving = true;
+		try {
+			const result = await adminPost(`/admin/invitations/${id}/resend`);
+			actionMsg = { ...actionMsg, [id]: result.message || 'Invitation resent' };
+			cancelAction();
+		} catch (e) {
+			actionMsg = { ...actionMsg, [id]: e instanceof Error ? e.message : 'Resend failed' };
+			cancelAction();
+		}
+	}
+
+	async function confirmRevoke(id: string) {
+		actionSaving = true;
+		try {
+			const result = await adminDelete(`/admin/invitations/${id}`);
+			actionMsg = { ...actionMsg, [id]: result.message || 'Invitation revoked' };
+			invitations = invitations.filter((inv) => inv.id !== id);
+			cancelAction();
+		} catch (e) {
+			actionMsg = { ...actionMsg, [id]: e instanceof Error ? e.message : 'Revoke failed' };
+			cancelAction();
+		}
+	}
+
+	onMount(() => {
+		loadInvitations();
+	});
+</script>
+
+<div class="invitations-page">
+	{#if loading}
+		<div class="loading-msg">Loading invitations...</div>
+	{:else if error}
+		<div class="error-msg">
+			<p>{error}</p>
+			<button class="btn" onclick={loadInvitations}>Retry</button>
+		</div>
+	{:else}
+		<div class="search-row">
+			<input
+				type="text"
+				class="search-input"
+				placeholder="Search by email or workspace..."
+				bind:value={search}
+				onkeydown={(e) => {
+					if (e.key === 'Enter') searchInvitations();
+				}}
+			/>
+			<button class="btn" onclick={searchInvitations}>Search</button>
+		</div>
+
+		{#if invitations.length === 0}
+			<div class="empty-state">
+				<p class="empty-title">No pending invitations</p>
+				<p class="empty-desc">Workspace invitations will appear here once users are invited.</p>
+			</div>
+		{:else}
+			<div class="table-wrap">
+				<table class="table">
+					<thead>
+						<tr>
+							<th>Email</th>
+							<th>Workspace</th>
+							<th>Role</th>
+							<th>Invited By</th>
+							<th>Created</th>
+							<th>Actions</th>
+						</tr>
+					</thead>
+					<tbody>
+						{#each invitations as inv (inv.id)}
+							<tr>
+								<td>{inv.email}</td>
+								<td>{inv.workspace_name}</td>
+								<td>
+									<span class="badge" class:owner={inv.role === 'owner'}>
+										{inv.role}
+									</span>
+								</td>
+								<td>{inv.invited_by_name}</td>
+								<td class="date-cell">{formatDate(inv.created_at)}</td>
+								<td class="actions-cell">
+									{#if actionId === inv.id && actionType === 'resend'}
+										<div class="action-confirm">
+											<span class="action-confirm-msg">Resend invitation?</span>
+											<button
+												class="btn primary btn-sm"
+												onclick={() => confirmResend(inv.id)}
+												disabled={actionSaving}
+											>
+												{actionSaving ? 'Sending...' : 'Confirm'}
+											</button>
+											<button class="btn btn-sm" onclick={cancelAction}>Cancel</button>
+										</div>
+									{:else if actionId === inv.id && actionType === 'revoke'}
+										<div class="action-confirm">
+											<span class="action-confirm-msg">Revoke invitation?</span>
+											<button
+												class="btn danger btn-sm"
+												onclick={() => confirmRevoke(inv.id)}
+												disabled={actionSaving}
+											>
+												{actionSaving ? 'Revoking...' : 'Confirm'}
+											</button>
+											<button class="btn btn-sm" onclick={cancelAction}>Cancel</button>
+										</div>
+									{:else}
+										<div class="action-buttons">
+											<button class="btn btn-sm" onclick={() => startAction(inv.id, 'resend')}>
+												Resend
+											</button>
+											<button class="btn danger btn-sm" onclick={() => startAction(inv.id, 'revoke')}>
+												Revoke
+											</button>
+										</div>
+									{/if}
+									{#if actionMsg[inv.id]}
+										<span class="action-msg">{actionMsg[inv.id]}</span>
+									{/if}
+								</td>
+							</tr>
+						{/each}
+					</tbody>
+				</table>
+			</div>
+		{/if}
+	{/if}
 </div>
 
 <style>
-	.placeholder {
-		display: flex; flex-direction: column; align-items: center; justify-content: center;
-		padding: var(--space-10) 0; gap: var(--space-3); text-align: center;
+	.invitations-page {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-4);
 	}
-	.placeholder-icon { font-size: 2.5rem; margin: 0; }
-	.placeholder-title { font-size: 1.1rem; font-weight: 600; color: var(--text-primary); margin: 0; }
-	.placeholder-desc { font-size: 0.85rem; color: var(--text-muted); margin: 0; max-width: 400px; }
-	.placeholder-note {
-		font-size: 0.8rem; color: var(--text-muted); margin-top: var(--space-2);
-		padding: var(--space-1) var(--space-3); background: var(--bg-secondary);
-		border-radius: var(--radius); border: 1px solid var(--border);
+
+	/* Search */
+	.search-row {
+		display: flex;
+		gap: var(--space-2);
+	}
+	.search-input {
+		flex: 1;
+		padding: var(--space-2) var(--space-3);
+		background: var(--bg-secondary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+		color: var(--text-primary);
+		font-size: 0.85rem;
+		outline: none;
+	}
+	.search-input:focus {
+		border-color: var(--accent-blue);
+	}
+
+	/* Buttons */
+	.btn {
+		padding: var(--space-2) var(--space-4);
+		border-radius: var(--radius);
+		border: 1px solid var(--border);
+		background: var(--bg-secondary);
+		color: var(--text-secondary);
+		font-size: 0.85rem;
+		font-weight: 500;
+		cursor: pointer;
+		transition:
+			border-color 0.15s,
+			color 0.15s;
+	}
+	.btn:hover {
+		color: var(--text-primary);
+		border-color: var(--text-muted);
+	}
+	.btn.primary {
+		background: var(--accent-blue);
+		color: #fff;
+		border-color: transparent;
+	}
+	.btn.primary:hover {
+		opacity: 0.9;
+	}
+	.btn.danger {
+		border-color: #ef4444;
+		color: #ef4444;
+	}
+	.btn.danger:hover {
+		background: color-mix(in srgb, #ef4444 10%, transparent);
+	}
+	.btn:disabled {
+		opacity: 0.5;
+		cursor: default;
+	}
+	.btn-sm {
+		font-size: 0.8rem;
+		padding: var(--space-1) var(--space-3);
+	}
+
+	/* Table */
+	.table-wrap {
+		overflow-x: auto;
+	}
+	.table {
+		width: 100%;
+		border-collapse: collapse;
+		font-size: 0.85rem;
+	}
+	.table th {
+		text-align: left;
+		padding: var(--space-2) var(--space-3);
+		color: var(--text-muted);
+		font-weight: 500;
+		border-bottom: 1px solid var(--border);
+		font-size: 0.8rem;
+	}
+	.table td {
+		padding: var(--space-2) var(--space-3);
+		border-bottom: 1px solid var(--border);
+		color: var(--text-secondary);
+	}
+	.date-cell {
+		white-space: nowrap;
+	}
+
+	/* Badge */
+	.badge {
+		padding: 2px var(--space-2);
+		border-radius: var(--radius-sm);
+		font-size: 0.75rem;
+		font-weight: 500;
+		background: color-mix(in srgb, var(--accent-gray, #888) 15%, transparent);
+		color: var(--text-muted);
+	}
+	.badge.owner {
+		background: color-mix(in srgb, var(--accent-green, #22c55e) 15%, transparent);
+		color: var(--accent-green, #22c55e);
+	}
+
+	/* Actions */
+	.actions-cell {
+		white-space: nowrap;
+	}
+	.action-buttons {
+		display: flex;
+		gap: var(--space-2);
+	}
+	.action-confirm {
+		display: flex;
+		align-items: center;
+		gap: var(--space-2);
+		flex-wrap: wrap;
+	}
+	.action-confirm-msg {
+		font-size: 0.8rem;
+		color: var(--text-secondary);
+	}
+	.action-msg {
+		display: block;
+		font-size: 0.75rem;
+		color: var(--text-muted);
+		margin-top: var(--space-1);
+	}
+
+	/* Empty state */
+	.empty-state {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		padding: var(--space-10) 0;
+		gap: var(--space-2);
+		text-align: center;
+	}
+	.empty-title {
+		font-size: 0.95rem;
+		font-weight: 600;
+		color: var(--text-primary);
+		margin: 0;
+	}
+	.empty-desc {
+		font-size: 0.85rem;
+		color: var(--text-muted);
+		margin: 0;
+	}
+
+	/* States */
+	.loading-msg {
+		color: var(--text-muted);
+		padding: var(--space-6) 0;
+		text-align: center;
+		font-size: 0.9rem;
+	}
+	.error-msg {
+		color: #ef4444;
+		padding: var(--space-6);
+		background: var(--bg-secondary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+		display: flex;
+		align-items: center;
+		gap: var(--space-3);
+	}
+	.error-msg p {
+		margin: 0;
+		font-size: 0.85rem;
 	}
 </style>

--- a/web/src/routes/console/admin/invitations/+page.svelte
+++ b/web/src/routes/console/admin/invitations/+page.svelte
@@ -75,9 +75,10 @@
 	async function confirmResend(id: string) {
 		actionSaving = true;
 		try {
-			const result = await adminPost(`/admin/invitations/${id}/resend`);
-			actionMsg = { ...actionMsg, [id]: result.message || 'Invitation resent' };
+			await adminPost(`/admin/invitations/${id}/resend`);
 			cancelAction();
+			// Reload because resend creates a new invitation with a different ID
+			await loadInvitations();
 		} catch (e) {
 			actionMsg = { ...actionMsg, [id]: e instanceof Error ? e.message : 'Resend failed' };
 			cancelAction();


### PR DESCRIPTION
## Summary
- New `ListPendingInvitationsAdmin()` store method — queries invitations across all workspaces with JOIN on workspace name/slug and inviter name
- New `DeleteInvitationAdmin()` store method — deletes by ID without workspace scoping
- New admin endpoints:
  - `GET /api/v1/admin/invitations?q=search` — list all pending invitations with search
  - `POST /api/v1/admin/invitations/{id}/resend` — revokes old invitation, creates fresh one with new code, sends email
  - `DELETE /api/v1/admin/invitations/{id}` — revoke pending invitation
- Frontend: full invitations page replacing "Coming soon" placeholder — search bar, table with email/workspace/role/inviter/date, inline resend and revoke with confirmation dialogs

Closes TASK-559 — part of PLAN-552 (Admin Console Enhancement)

## Test plan
- [ ] Navigate to admin console → Invitations tab — verify pending invitations load
- [ ] Search by email or workspace name — verify filtering works
- [ ] Resend an invitation — verify new email sent (or code generated if no email configured)
- [ ] Revoke an invitation — verify it disappears from the list
- [ ] Verify empty state when no pending invitations exist
- [ ] Verify `go test ./...` passes
- [ ] Verify `npm run build` compiles cleanly