### PR TITLE
feat: add web UI for TOTP 2FA setup in user settings

### DIFF
--- a/internal/server/handlers_auth.go
+++ b/internal/server/handlers_auth.go
@@ -585,14 +585,15 @@ func (s *Server) handleGetCurrentUser(w http.ResponseWriter, r *http.Request) {
 	}
 
 	resp := map[string]interface{}{
-		"id":         user.ID,
-		"email":      user.Email,
-		"username":   user.Username,
-		"name":       user.Name,
-		"role":       user.Role,
-		"avatar_url": user.AvatarURL,
-		"created_at": user.CreatedAt,
-		"updated_at": user.UpdatedAt,
+		"id":           user.ID,
+		"email":        user.Email,
+		"username":     user.Username,
+		"name":         user.Name,
+		"role":         user.Role,
+		"avatar_url":   user.AvatarURL,
+		"totp_enabled": user.TOTPEnabled,
+		"created_at":   user.CreatedAt,
+		"updated_at":   user.UpdatedAt,
 	}
 
 	// Include Stripe customer ID when present (used by pad-cloud sidecar

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -24,6 +24,7 @@
 				"dompurify": "^3.3.3",
 				"lowlight": "^3.3.0",
 				"mermaid": "^11.13.0",
+				"qrcode": "^1.5.4",
 				"svelte-dnd-action": "^0.9.69",
 				"tiptap-markdown": "^0.9.0"
 			},
@@ -1986,6 +1987,30 @@
 				"node": ">=0.4.0"
 			}
 		},
+		"node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"license": "MIT",
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
 		"node_modules/argparse": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -2008,6 +2033,15 @@
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">= 0.4"
+			}
+		},
+		"node_modules/camelcase": {
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/chevrotain": {
@@ -2052,6 +2086,17 @@
 				"url": "https://paulmillr.com/funding/"
 			}
 		},
+		"node_modules/cliui": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+			"integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+			"license": "ISC",
+			"dependencies": {
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.0",
+				"wrap-ansi": "^6.2.0"
+			}
+		},
 		"node_modules/clsx": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -2060,6 +2105,24 @@
 			"engines": {
 				"node": ">=6"
 			}
+		},
+		"node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"license": "MIT",
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"license": "MIT"
 		},
 		"node_modules/commander": {
 			"version": "7.2.0",
@@ -2606,6 +2669,15 @@
 			"integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
 			"license": "MIT"
 		},
+		"node_modules/decamelize": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+			"integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/deepmerge": {
 			"version": "4.3.1",
 			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
@@ -2662,6 +2734,12 @@
 				"node": ">=0.3.1"
 			}
 		},
+		"node_modules/dijkstrajs": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+			"integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+			"license": "MIT"
+		},
 		"node_modules/dompurify": {
 			"version": "3.3.3",
 			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
@@ -2670,6 +2748,12 @@
 			"optionalDependencies": {
 				"@types/trusted-types": "^2.0.7"
 			}
+		},
+		"node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"license": "MIT"
 		},
 		"node_modules/entities": {
 			"version": "4.5.0",
@@ -2771,6 +2855,19 @@
 				}
 			}
 		},
+		"node_modules/find-up": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+			"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+			"license": "MIT",
+			"dependencies": {
+				"locate-path": "^5.0.0",
+				"path-exists": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/fsevents": {
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2784,6 +2881,15 @@
 			],
 			"engines": {
 				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
+		},
+		"node_modules/get-caller-file": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+			"license": "ISC",
+			"engines": {
+				"node": "6.* || 8.* || >= 10.*"
 			}
 		},
 		"node_modules/hachure-fill": {
@@ -2820,6 +2926,15 @@
 			"license": "ISC",
 			"engines": {
 				"node": ">=12"
+			}
+		},
+		"node_modules/is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/is-reference": {
@@ -2914,6 +3029,18 @@
 			"resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
 			"integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
 			"license": "MIT"
+		},
+		"node_modules/locate-path": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+			"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+			"license": "MIT",
+			"dependencies": {
+				"p-locate": "^4.1.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
 		},
 		"node_modules/lodash-es": {
 			"version": "4.17.23",
@@ -3096,6 +3223,42 @@
 			"integrity": "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==",
 			"license": "MIT"
 		},
+		"node_modules/p-limit": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+			"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+			"license": "MIT",
+			"dependencies": {
+				"p-try": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/p-locate": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+			"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+			"license": "MIT",
+			"dependencies": {
+				"p-limit": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/p-try": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/package-manager-detector": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
@@ -3107,6 +3270,15 @@
 			"resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
 			"integrity": "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==",
 			"license": "MIT"
+		},
+		"node_modules/path-exists": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
 		},
 		"node_modules/pathe": {
 			"version": "2.0.3",
@@ -3143,6 +3315,15 @@
 				"confbox": "^0.1.8",
 				"mlly": "^1.7.4",
 				"pathe": "^2.0.1"
+			}
+		},
+		"node_modules/pngjs": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+			"integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.13.0"
 			}
 		},
 		"node_modules/points-on-curve": {
@@ -3394,6 +3575,23 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/qrcode": {
+			"version": "1.5.4",
+			"resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+			"integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+			"license": "MIT",
+			"dependencies": {
+				"dijkstrajs": "^1.0.1",
+				"pngjs": "^5.0.0",
+				"yargs": "^15.3.1"
+			},
+			"bin": {
+				"qrcode": "bin/qrcode"
+			},
+			"engines": {
+				"node": ">=10.13.0"
+			}
+		},
 		"node_modules/readdirp": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
@@ -3407,6 +3605,21 @@
 				"type": "individual",
 				"url": "https://paulmillr.com/funding/"
 			}
+		},
+		"node_modules/require-directory": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+			"integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/require-main-filename": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+			"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+			"license": "ISC"
 		},
 		"node_modules/robust-predicates": {
 			"version": "3.0.3",
@@ -3502,6 +3715,12 @@
 			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
 			"license": "MIT"
 		},
+		"node_modules/set-blocking": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+			"integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+			"license": "ISC"
+		},
 		"node_modules/set-cookie-parser": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.0.tgz",
@@ -3532,6 +3751,32 @@
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/stylis": {
@@ -3873,6 +4118,67 @@
 			"resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
 			"integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
 			"license": "MIT"
+		},
+		"node_modules/which-module": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+			"integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+			"license": "ISC"
+		},
+		"node_modules/wrap-ansi": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+			"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/y18n": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+			"integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+			"license": "ISC"
+		},
+		"node_modules/yargs": {
+			"version": "15.4.1",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+			"integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+			"license": "MIT",
+			"dependencies": {
+				"cliui": "^6.0.0",
+				"decamelize": "^1.2.0",
+				"find-up": "^4.1.0",
+				"get-caller-file": "^2.0.1",
+				"require-directory": "^2.1.1",
+				"require-main-filename": "^2.0.0",
+				"set-blocking": "^2.0.0",
+				"string-width": "^4.2.0",
+				"which-module": "^2.0.0",
+				"y18n": "^4.0.0",
+				"yargs-parser": "^18.1.2"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/yargs-parser": {
+			"version": "18.1.3",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+			"integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+			"license": "ISC",
+			"dependencies": {
+				"camelcase": "^5.0.0",
+				"decamelize": "^1.2.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
 		},
 		"node_modules/zimmerframe": {
 			"version": "1.1.4",

--- a/web/package.json
+++ b/web/package.json
@@ -40,6 +40,7 @@
 		"dompurify": "^3.3.3",
 		"lowlight": "^3.3.0",
 		"mermaid": "^11.13.0",
+		"qrcode": "^1.5.4",
 		"svelte-dnd-action": "^0.9.69",
 		"tiptap-markdown": "^0.9.0"
 	}

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -36,7 +36,10 @@ import type {
 	ChangesResponse,
 	CollectionGrant,
 	ItemGrant,
-	ShareLink
+	ShareLink,
+	TOTPSetupResponse,
+	TOTPVerifyResponse,
+	TOTPDisableResponse
 } from '$lib/types';
 
 const BASE = '/api/v1';
@@ -635,6 +638,19 @@ export const api = {
 				method: 'POST',
 				body: JSON.stringify({ provider })
 			}),
+		totp: {
+			setup: () => request<TOTPSetupResponse>('/auth/2fa/setup', { method: 'POST' }),
+			verify: (code: string, secret: string) =>
+				request<TOTPVerifyResponse>('/auth/2fa/verify', {
+					method: 'POST',
+					body: JSON.stringify({ code, secret })
+				}),
+			disable: (password: string) =>
+				request<TOTPDisableResponse>('/auth/2fa/disable', {
+					method: 'POST',
+					body: JSON.stringify({ password })
+				})
+		},
 		tokens: {
 			list: () => request<APIToken[]>('/auth/tokens'),
 			create: (name: string) =>

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -8,8 +8,23 @@ export interface User {
 	role: string;
 	avatar_url?: string;
 	oauth_providers?: string[];
+	totp_enabled?: boolean;
 	created_at: string;
 	updated_at: string;
+}
+
+export interface TOTPSetupResponse {
+	secret: string;
+	url: string;
+}
+
+export interface TOTPVerifyResponse {
+	enabled: boolean;
+	recovery_codes: string[];
+}
+
+export interface TOTPDisableResponse {
+	enabled: boolean;
 }
 
 export interface UserProfileUpdate {

--- a/web/src/routes/console/settings/+page.svelte
+++ b/web/src/routes/console/settings/+page.svelte
@@ -2,6 +2,7 @@
 	import { onMount } from 'svelte';
 	import { api } from '$lib/api/client';
 	import { authStore } from '$lib/stores/auth.svelte';
+	import { copyToClipboard } from '$lib/utils/clipboard';
 	import type { User, APIToken, APITokenWithSecret, TOTPSetupResponse } from '$lib/types';
 
 	// Profile
@@ -133,20 +134,25 @@
 		try {
 			totpSetup = await api.auth.totp.setup();
 			totpStep = 'setup';
-			// Generate QR code
+		} catch (err) {
+			totpError = err instanceof Error ? err.message : 'Failed to start 2FA setup';
+			totpStep = 'idle';
+			return;
+		} finally {
+			totpSaving = false;
+		}
+
+		// Render QR code separately — failure here should not abort setup
+		// since the user can still enter the secret manually
+		try {
 			const QRCode = (await import('qrcode')).default;
-			const canvas = document.getElementById('qr-canvas') as HTMLCanvasElement;
-			// Wait for canvas to be rendered
 			await new Promise(r => setTimeout(r, 50));
 			const el = document.getElementById('qr-canvas') as HTMLCanvasElement;
 			if (el) {
 				await QRCode.toCanvas(el, totpSetup.url, { width: 200, margin: 2 });
 			}
-		} catch (err) {
-			totpError = err instanceof Error ? err.message : 'Failed to start 2FA setup';
-			totpStep = 'idle';
-		} finally {
-			totpSaving = false;
+		} catch {
+			// QR rendering failed — manual entry still available
 		}
 	}
 
@@ -224,10 +230,14 @@
 		recoveryCodes = [];
 	}
 
-	function copyRecoveryCodes() {
+	async function copyRecoveryCodes() {
 		const text = recoveryCodes.join('\n');
-		navigator.clipboard.writeText(text);
-		totpMsg = 'Recovery codes copied to clipboard.';
+		const ok = await copyToClipboard(text);
+		if (ok) {
+			totpMsg = 'Recovery codes copied to clipboard.';
+		} else {
+			totpError = 'Failed to copy — please select and copy the codes manually.';
+		}
 	}
 
 	function downloadRecoveryCodes() {

--- a/web/src/routes/console/settings/+page.svelte
+++ b/web/src/routes/console/settings/+page.svelte
@@ -2,7 +2,7 @@
 	import { onMount } from 'svelte';
 	import { api } from '$lib/api/client';
 	import { authStore } from '$lib/stores/auth.svelte';
-	import type { User, APIToken, APITokenWithSecret } from '$lib/types';
+	import type { User, APIToken, APITokenWithSecret, TOTPSetupResponse } from '$lib/types';
 
 	// Profile
 	let profile = $state<User | null>(null);
@@ -23,6 +23,17 @@
 	// OAuth providers
 	let providerMsg = $state('');
 	let providerError = $state('');
+
+	// 2FA
+	let totpStep = $state<'idle' | 'setup' | 'verify' | 'recovery'>('idle');
+	let totpSetup = $state<TOTPSetupResponse | null>(null);
+	let totpCode = $state('');
+	let totpSaving = $state(false);
+	let totpMsg = $state('');
+	let totpError = $state('');
+	let recoveryCodes = $state<string[]>([]);
+	let disablePassword = $state('');
+	let showDisableConfirm = $state(false);
 
 	async function unlinkProvider(provider: string) {
 		providerMsg = '';
@@ -113,6 +124,121 @@
 		} finally {
 			passwordSaving = false;
 		}
+	}
+
+	async function startTOTPSetup() {
+		totpError = '';
+		totpMsg = '';
+		totpSaving = true;
+		try {
+			totpSetup = await api.auth.totp.setup();
+			totpStep = 'setup';
+			// Generate QR code
+			const QRCode = (await import('qrcode')).default;
+			const canvas = document.getElementById('qr-canvas') as HTMLCanvasElement;
+			// Wait for canvas to be rendered
+			await new Promise(r => setTimeout(r, 50));
+			const el = document.getElementById('qr-canvas') as HTMLCanvasElement;
+			if (el) {
+				await QRCode.toCanvas(el, totpSetup.url, { width: 200, margin: 2 });
+			}
+		} catch (err) {
+			totpError = err instanceof Error ? err.message : 'Failed to start 2FA setup';
+			totpStep = 'idle';
+		} finally {
+			totpSaving = false;
+		}
+	}
+
+	async function renderQRCode() {
+		if (!totpSetup) return;
+		try {
+			const QRCode = (await import('qrcode')).default;
+			const el = document.getElementById('qr-canvas') as HTMLCanvasElement;
+			if (el) {
+				await QRCode.toCanvas(el, totpSetup.url, { width: 200, margin: 2 });
+			}
+		} catch {}
+	}
+
+	async function verifyTOTP() {
+		totpError = '';
+		const code = totpCode.trim();
+		if (!code || !totpSetup) {
+			totpError = 'Please enter the 6-digit code from your authenticator app.';
+			return;
+		}
+
+		totpSaving = true;
+		try {
+			const result = await api.auth.totp.verify(code, totpSetup.secret);
+			recoveryCodes = result.recovery_codes;
+			totpStep = 'recovery';
+			totpCode = '';
+			// Refresh profile to get updated totp_enabled
+			profile = await api.auth.me();
+		} catch (err) {
+			totpError = err instanceof Error ? err.message : 'Invalid code. Please try again.';
+		} finally {
+			totpSaving = false;
+		}
+	}
+
+	async function disableTOTP() {
+		totpError = '';
+		if (!disablePassword) {
+			totpError = 'Please enter your password to disable 2FA.';
+			return;
+		}
+
+		totpSaving = true;
+		try {
+			await api.auth.totp.disable(disablePassword);
+			totpMsg = 'Two-factor authentication has been disabled.';
+			showDisableConfirm = false;
+			disablePassword = '';
+			totpStep = 'idle';
+			totpSetup = null;
+			recoveryCodes = [];
+			// Refresh profile
+			profile = await api.auth.me();
+		} catch (err) {
+			totpError = err instanceof Error ? err.message : 'Failed to disable 2FA';
+		} finally {
+			totpSaving = false;
+		}
+	}
+
+	function finishSetup() {
+		totpStep = 'idle';
+		totpSetup = null;
+		recoveryCodes = [];
+		totpMsg = 'Two-factor authentication is now enabled.';
+	}
+
+	function cancelSetup() {
+		totpStep = 'idle';
+		totpSetup = null;
+		totpCode = '';
+		totpError = '';
+		recoveryCodes = [];
+	}
+
+	function copyRecoveryCodes() {
+		const text = recoveryCodes.join('\n');
+		navigator.clipboard.writeText(text);
+		totpMsg = 'Recovery codes copied to clipboard.';
+	}
+
+	function downloadRecoveryCodes() {
+		const text = recoveryCodes.join('\n');
+		const blob = new Blob([text], { type: 'text/plain' });
+		const url = URL.createObjectURL(blob);
+		const a = document.createElement('a');
+		a.href = url;
+		a.download = 'pad-recovery-codes.txt';
+		a.click();
+		URL.revokeObjectURL(url);
 	}
 
 	async function createToken() {
@@ -215,6 +341,119 @@
 				<button class="primary-btn" onclick={changePassword} disabled={passwordSaving}>
 					{passwordSaving ? 'Changing...' : 'Change Password'}
 				</button>
+			</div>
+		</section>
+
+		<!-- Two-Factor Authentication -->
+		<section class="card">
+			<h2 class="card-title">Two-Factor Authentication</h2>
+			<div class="card-body">
+				{#if totpStep === 'idle'}
+					<div class="totp-status-row">
+						<div class="totp-status-info">
+							<span class="totp-label">Status</span>
+							{#if profile?.totp_enabled}
+								<span class="totp-badge enabled">Enabled</span>
+							{:else}
+								<span class="totp-badge">Disabled</span>
+							{/if}
+						</div>
+						{#if profile?.totp_enabled}
+							{#if showDisableConfirm}
+								<div class="disable-confirm">
+									<p class="section-desc">Enter your password to disable 2FA.</p>
+									<div class="field">
+										<input
+											type="password"
+											placeholder="Current password"
+											bind:value={disablePassword}
+											disabled={totpSaving}
+											autocomplete="current-password"
+										/>
+									</div>
+									{#if totpError}
+										<p class="error">{totpError}</p>
+									{/if}
+									<div class="btn-row">
+										<button class="danger-btn" onclick={disableTOTP} disabled={totpSaving}>
+											{totpSaving ? 'Disabling...' : 'Confirm Disable'}
+										</button>
+										<button class="secondary-btn" onclick={() => { showDisableConfirm = false; disablePassword = ''; totpError = ''; }} disabled={totpSaving}>
+											Cancel
+										</button>
+									</div>
+								</div>
+							{:else}
+								<button class="danger-btn" onclick={() => { showDisableConfirm = true; totpError = ''; totpMsg = ''; }}>
+									Disable 2FA
+								</button>
+							{/if}
+						{:else}
+							<button class="primary-btn" onclick={startTOTPSetup} disabled={totpSaving}>
+								{totpSaving ? 'Setting up...' : 'Enable 2FA'}
+							</button>
+						{/if}
+					</div>
+					{#if totpMsg}
+						<p class="success">{totpMsg}</p>
+					{/if}
+					{#if totpError && !showDisableConfirm}
+						<p class="error">{totpError}</p>
+					{/if}
+
+				{:else if totpStep === 'setup'}
+					<p class="section-desc">Scan this QR code with your authenticator app (Google Authenticator, Authy, 1Password, etc.)</p>
+					<div class="qr-container">
+						<canvas id="qr-canvas"></canvas>
+					</div>
+					{#if totpSetup}
+						<div class="manual-entry">
+							<p class="section-desc">Or enter this code manually:</p>
+							<code class="secret-code">{totpSetup.secret}</code>
+						</div>
+					{/if}
+					<div class="field">
+						<label for="totp-verify">Verification code</label>
+						<input
+							id="totp-verify"
+							type="text"
+							placeholder="Enter 6-digit code"
+							bind:value={totpCode}
+							disabled={totpSaving}
+							autocomplete="one-time-code"
+							inputmode="numeric"
+							maxlength="6"
+							onkeydown={(e) => { if (e.key === 'Enter') verifyTOTP(); }}
+						/>
+					</div>
+					{#if totpError}
+						<p class="error">{totpError}</p>
+					{/if}
+					<div class="btn-row">
+						<button class="primary-btn" onclick={verifyTOTP} disabled={totpSaving || !totpCode.trim()}>
+							{totpSaving ? 'Verifying...' : 'Verify & Enable'}
+						</button>
+						<button class="secondary-btn" onclick={cancelSetup} disabled={totpSaving}>Cancel</button>
+					</div>
+
+				{:else if totpStep === 'recovery'}
+					<div class="recovery-section">
+						<p class="section-desc"><strong>Save your recovery codes.</strong> Each code can only be used once. Store them in a safe place — you will not see them again.</p>
+						<div class="recovery-codes">
+							{#each recoveryCodes as code, i (i)}
+								<code class="recovery-code">{code}</code>
+							{/each}
+						</div>
+						<div class="btn-row">
+							<button class="secondary-btn" onclick={copyRecoveryCodes}>Copy</button>
+							<button class="secondary-btn" onclick={downloadRecoveryCodes}>Download</button>
+						</div>
+						{#if totpMsg}
+							<p class="success">{totpMsg}</p>
+						{/if}
+						<button class="primary-btn" onclick={finishSetup}>Done</button>
+					</div>
+				{/if}
 			</div>
 		</section>
 
@@ -544,5 +783,136 @@
 		padding: var(--space-1) var(--space-3);
 		font-size: 0.8rem;
 		text-decoration: none;
+	}
+
+	.totp-status-row {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-4);
+	}
+
+	.totp-status-info {
+		display: flex;
+		align-items: center;
+		gap: var(--space-3);
+	}
+
+	.totp-label {
+		font-size: 0.85rem;
+		color: var(--text-muted);
+	}
+
+	.totp-badge {
+		padding: 2px var(--space-2);
+		border-radius: var(--radius-sm);
+		font-size: 0.75rem;
+		font-weight: 500;
+		background: color-mix(in srgb, var(--accent-gray, #888) 15%, transparent);
+		color: var(--text-muted);
+	}
+
+	.totp-badge.enabled {
+		background: color-mix(in srgb, var(--accent-green) 15%, transparent);
+		color: var(--accent-green);
+	}
+
+	.qr-container {
+		display: flex;
+		justify-content: center;
+		padding: var(--space-4) 0;
+	}
+
+	.qr-container canvas {
+		border-radius: var(--radius);
+	}
+
+	.manual-entry {
+		text-align: center;
+	}
+
+	.secret-code {
+		display: inline-block;
+		font-family: var(--font-mono);
+		font-size: 0.85rem;
+		color: var(--text-primary);
+		background: var(--bg-tertiary);
+		padding: var(--space-2) var(--space-3);
+		border-radius: var(--radius);
+		letter-spacing: 0.05em;
+		word-break: break-all;
+		user-select: all;
+	}
+
+	.recovery-section {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-4);
+	}
+
+	.recovery-codes {
+		display: grid;
+		grid-template-columns: 1fr 1fr;
+		gap: var(--space-2);
+	}
+
+	.recovery-code {
+		font-family: var(--font-mono);
+		font-size: 0.85rem;
+		color: var(--text-primary);
+		background: var(--bg-tertiary);
+		padding: var(--space-2) var(--space-3);
+		border-radius: var(--radius-sm);
+		text-align: center;
+	}
+
+	.btn-row {
+		display: flex;
+		gap: var(--space-2);
+	}
+
+	.secondary-btn {
+		padding: var(--space-2) var(--space-4);
+		background: var(--bg-tertiary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+		color: var(--text-primary);
+		font-size: 0.85rem;
+		font-weight: 500;
+		font-family: var(--font-ui);
+		cursor: pointer;
+		transition: background 0.15s;
+	}
+
+	.secondary-btn:hover:not(:disabled) {
+		background: var(--bg-hover);
+	}
+
+	.danger-btn {
+		align-self: flex-start;
+		padding: var(--space-2) var(--space-4);
+		background: transparent;
+		border: 1px solid #ef4444;
+		border-radius: var(--radius);
+		color: #ef4444;
+		font-size: 0.85rem;
+		font-weight: 500;
+		font-family: var(--font-ui);
+		cursor: pointer;
+		transition: background 0.15s;
+	}
+
+	.danger-btn:hover:not(:disabled) {
+		background: color-mix(in srgb, #ef4444 10%, transparent);
+	}
+
+	.danger-btn:disabled {
+		opacity: 0.6;
+		cursor: not-allowed;
+	}
+
+	.disable-confirm {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-3);
 	}
 </style>


### PR DESCRIPTION
## Summary
- Adds a **Two-Factor Authentication** section to the console settings page (`/console/settings`) with full enable/disable flows
- Wires up the existing backend TOTP API (from PR #77) to the frontend — no backend logic changes beyond exposing `totp_enabled` on `/auth/me`
- Adds `qrcode` npm dependency for rendering the `otpauth://` URI as a scannable QR code

## What it does

**Enable flow:** Enable 2FA button → QR code + manual secret displayed → user enters 6-digit verification code → recovery codes shown with copy/download options

**Disable flow:** Disable 2FA button → password confirmation modal → 2FA disabled

**Files changed:**
- `internal/server/handlers_auth.go` — add `totp_enabled` to `/auth/me` response
- `web/src/lib/types/index.ts` — add `totp_enabled` to User, new TOTP response types
- `web/src/lib/api/client.ts` — add `auth.totp.setup/verify/disable` methods
- `web/src/routes/console/settings/+page.svelte` — 2FA settings card UI

## Test plan
- [ ] Open `/console/settings` — verify 2FA section shows "Disabled" badge and "Enable 2FA" button
- [ ] Click "Enable 2FA" — verify QR code renders and manual secret is displayed
- [ ] Scan QR code with authenticator app, enter 6-digit code, click "Verify & Enable"
- [ ] Verify recovery codes are displayed, test Copy and Download buttons
- [ ] Click "Done" — verify badge changes to "Enabled"
- [ ] Refresh page — verify 2FA status persists as enabled
- [ ] Click "Disable 2FA" — verify password confirmation modal appears
- [ ] Enter password, confirm — verify 2FA is disabled
- [ ] Log out, log back in with 2FA enabled — verify login page shows TOTP code input (existing flow)

Closes TASK-402