### PR TITLE
fix: sidebar collection drag-and-drop only moving by one slot

### DIFF
--- a/web/src/lib/components/layout/Sidebar.svelte
+++ b/web/src/lib/components/layout/Sidebar.svelte
@@ -64,6 +64,7 @@
 	// Drag-and-drop reordering state
 	let sidebarCollections: Collection[] = $state([]);
 	let isDraggingSidebar = $state(false);
+	let reorderGeneration = 0;
 	const flipDurationMs = 150;
 
 	const agentSlugs = ['conventions', 'playbooks'];
@@ -89,6 +90,7 @@
 	async function handleCollectionFinalize(e: CustomEvent<DndEvent<Collection>>) {
 		const reordered = e.detail.items;
 		sidebarCollections = reordered;
+		const generation = ++reorderGeneration;
 
 		if (!wsSlug) {
 			isDraggingSidebar = false;
@@ -106,7 +108,9 @@
 
 			await collectionStore.loadCollections(wsSlug);
 		} finally {
-			isDraggingSidebar = false;
+			if (reorderGeneration === generation) {
+				isDraggingSidebar = false;
+			}
 		}
 	}
 

--- a/web/src/lib/components/layout/Sidebar.svelte
+++ b/web/src/lib/components/layout/Sidebar.svelte
@@ -87,17 +87,24 @@
 	}
 
 	async function handleCollectionFinalize(e: CustomEvent<DndEvent<Collection>>) {
-		sidebarCollections = e.detail.items;
-		isDraggingSidebar = false;
+		const reordered = e.detail.items;
+		sidebarCollections = reordered;
 
-		if (!wsSlug) return;
-		for (let i = 0; i < sidebarCollections.length; i++) {
-			const coll = sidebarCollections[i];
-			if (coll.sort_order !== i) {
-				await api.collections.update(wsSlug, coll.slug, { sort_order: i });
-			}
+		if (!wsSlug) {
+			isDraggingSidebar = false;
+			return;
 		}
-		collectionStore.loadCollections(wsSlug);
+
+		await Promise.all(
+			reordered.map((coll, i) =>
+				coll.sort_order !== i
+					? api.collections.update(wsSlug, coll.slug, { sort_order: i })
+					: Promise.resolve()
+			)
+		);
+
+		await collectionStore.loadCollections(wsSlug);
+		isDraggingSidebar = false;
 	}
 
 	function startQuickAdd(coll: Collection) {

--- a/web/src/lib/components/layout/Sidebar.svelte
+++ b/web/src/lib/components/layout/Sidebar.svelte
@@ -95,16 +95,19 @@
 			return;
 		}
 
-		await Promise.all(
-			reordered.map((coll, i) =>
-				coll.sort_order !== i
-					? api.collections.update(wsSlug, coll.slug, { sort_order: i })
-					: Promise.resolve()
-			)
-		);
+		try {
+			await Promise.all(
+				reordered.map((coll, i) =>
+					coll.sort_order !== i
+						? api.collections.update(wsSlug, coll.slug, { sort_order: i })
+						: Promise.resolve()
+				)
+			);
 
-		await collectionStore.loadCollections(wsSlug);
-		isDraggingSidebar = false;
+			await collectionStore.loadCollections(wsSlug);
+		} finally {
+			isDraggingSidebar = false;
+		}
 	}
 
 	function startQuickAdd(coll: Collection) {


### PR DESCRIPTION
## Summary
- Fixed sidebar collection drag-and-drop reordering only moving items by one position instead of to the drop target
- Root cause: `isDraggingSidebar` was set to `false` before API update calls, causing a Svelte `$effect` to reset `sidebarCollections` back to the store's original order after the first `await` yielded execution
- Fix: keep `isDraggingSidebar = true` during updates, use a local copy of the reordered array, fire all `sort_order` updates in parallel with `Promise.all`, and only release the flag after `loadCollections` completes

Fixes BUG-562

## Test plan
- [ ] Drag a collection in the sidebar from position 1 to position 5 — it should land at position 5
- [ ] Drag a collection up by multiple positions — verify correct placement
- [ ] Drag a collection by one position — still works as before
- [ ] Verify no visual "snap back" during the update