### PR TITLE
fix: link comment to activity record to prevent duplicate timeline entries

### DIFF
--- a/internal/server/handlers_comments.go
+++ b/internal/server/handlers_comments.go
@@ -111,14 +111,16 @@ func (s *Server) handleCreateComment(w http.ResponseWriter, r *http.Request) {
 		input.Source = source
 	}
 
+	// Log activity first so we can link the comment to the activity record.
+	// This prevents duplicate timeline entries (one for the comment, one for the activity).
+	activityID, _ := s.logActivityWithMetaReturningID(workspaceID, item.ID, "commented", r, "")
+	input.ActivityID = activityID
+
 	comment, err := s.store.CreateComment(workspaceID, item.ID, input)
 	if err != nil {
 		writeInternalError(w, err)
 		return
 	}
-
-	// Log activity
-	s.logActivity(workspaceID, item.ID, "commented", r)
 
 	// Publish SSE event
 	s.publishCommentEvent(events.CommentCreated, workspaceID, item.ID, comment.ID, item.Title, item.CollectionSlug, actor, source)

--- a/internal/server/handlers_comments.go
+++ b/internal/server/handlers_comments.go
@@ -113,8 +113,11 @@ func (s *Server) handleCreateComment(w http.ResponseWriter, r *http.Request) {
 
 	// Log activity first so we can link the comment to the activity record.
 	// This prevents duplicate timeline entries (one for the comment, one for the activity).
-	activityID, _ := s.logActivityWithMetaReturningID(workspaceID, item.ID, "commented", r, "")
-	input.ActivityID = activityID
+	// Only set ActivityID on success — comments.activity_id has a FK constraint,
+	// and CreateActivity returns an ID even on insert failure.
+	if activityID, err := s.logActivityWithMetaReturningID(workspaceID, item.ID, "commented", r, ""); err == nil && activityID != "" {
+		input.ActivityID = activityID
+	}
 
 	comment, err := s.store.CreateComment(workspaceID, item.ID, input)
 	if err != nil {


### PR DESCRIPTION
## Summary

- **BUG-563**: Adding a comment created two timeline entries — a comment card and a separate "commented" activity card with no content
- Root cause: `handleCreateComment` created a comment (`activity_id=NULL`) and a "commented" activity independently, so `buildTimeline`'s dedup logic couldn't link them
- Fix: create the activity first via `logActivityWithMetaReturningID`, then pass its ID to `CreateComment` so the timeline correctly deduplicates

## Test plan

- [ ] Add a comment to an item via the web UI — verify only one timeline entry appears (the comment card)
- [ ] Add a comment via the CLI (`pad item comment`) — verify same behavior
- [ ] Verify existing comments without linked activities still display correctly
- [ ] Verify activity feed (`/activity`) still shows "commented" entries