### PR TITLE
feat: add item_stars table and store methods

### DIFF
--- a/internal/store/item_stars.go
+++ b/internal/store/item_stars.go
@@ -125,9 +125,16 @@ func (s *Store) ListStarredItems(userID, workspaceID string, includeTerminal boo
 	}
 
 	if !includeTerminal {
+		// Build a schema map from workspace collections for per-collection terminal status checks
+		schemaMap, err := s.buildCollectionSchemaMap(workspaceID)
+		if err != nil {
+			return nil, fmt.Errorf("list starred items: build schema map: %w", err)
+		}
+
 		filtered := make([]models.Item, 0, len(items))
 		for _, item := range items {
-			if !isItemFieldTerminal(item.Fields) {
+			status := extractStatusFromFields(item.Fields)
+			if !isTerminalWithSchema(status, item.CollectionID, schemaMap) {
 				filtered = append(filtered, item)
 			}
 		}
@@ -152,19 +159,44 @@ func (s *Store) CountStarredItems(userID, workspaceID string) (int, error) {
 	return count, nil
 }
 
-// isItemFieldTerminal extracts the status from an item's fields JSON and checks
-// whether it is a terminal status using the default terminal status list.
-func isItemFieldTerminal(fields string) bool {
+// buildCollectionSchemaMap loads all collections for a workspace and returns
+// a map from collection ID to parsed schema, for terminal status lookups.
+func (s *Store) buildCollectionSchemaMap(workspaceID string) (map[string]models.CollectionSchema, error) {
+	collections, err := s.ListCollections(workspaceID)
+	if err != nil {
+		return nil, err
+	}
+	m := make(map[string]models.CollectionSchema, len(collections))
+	for _, c := range collections {
+		var schema models.CollectionSchema
+		if err := json.Unmarshal([]byte(c.Schema), &schema); err == nil {
+			m[c.ID] = schema
+		}
+	}
+	return m, nil
+}
+
+// extractStatusFromFields extracts the "status" value from an item's fields JSON.
+func extractStatusFromFields(fields string) string {
 	if fields == "" || fields == "{}" {
-		return false
+		return ""
 	}
 	var m map[string]interface{}
 	if err := json.Unmarshal([]byte(fields), &m); err != nil {
+		return ""
+	}
+	status, _ := m["status"].(string)
+	return status
+}
+
+// isTerminalWithSchema checks if a status is terminal using the collection's schema.
+// Falls back to default terminal statuses if the collection is not in the schema map.
+func isTerminalWithSchema(status, collectionID string, schemaMap map[string]models.CollectionSchema) bool {
+	if status == "" {
 		return false
 	}
-	status, ok := m["status"].(string)
-	if !ok {
-		return false
+	if schema, ok := schemaMap[collectionID]; ok {
+		return models.IsTerminalStatus(status, schema)
 	}
 	return models.IsTerminalStatusDefault(status)
 }

--- a/internal/store/item_stars.go
+++ b/internal/store/item_stars.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -118,7 +119,22 @@ func (s *Store) ListStarredItems(userID, workspaceID string, includeTerminal boo
 	}
 	defer rows.Close()
 
-	return scanItems(rows)
+	items, err := scanItems(rows)
+	if err != nil {
+		return nil, err
+	}
+
+	if !includeTerminal {
+		filtered := make([]models.Item, 0, len(items))
+		for _, item := range items {
+			if !isItemFieldTerminal(item.Fields) {
+				filtered = append(filtered, item)
+			}
+		}
+		items = filtered
+	}
+
+	return items, nil
 }
 
 // CountStarredItems returns the number of starred items for a user in a workspace.
@@ -134,6 +150,23 @@ func (s *Store) CountStarredItems(userID, workspaceID string) (int, error) {
 		return 0, fmt.Errorf("count starred items: %w", err)
 	}
 	return count, nil
+}
+
+// isItemFieldTerminal extracts the status from an item's fields JSON and checks
+// whether it is a terminal status using the default terminal status list.
+func isItemFieldTerminal(fields string) bool {
+	if fields == "" || fields == "{}" {
+		return false
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal([]byte(fields), &m); err != nil {
+		return false
+	}
+	status, ok := m["status"].(string)
+	if !ok {
+		return false
+	}
+	return models.IsTerminalStatusDefault(status)
 }
 
 // DeleteStarsForItem removes all stars for a given item (used when deleting an item).

--- a/internal/store/item_stars.go
+++ b/internal/store/item_stars.go
@@ -159,21 +159,30 @@ func (s *Store) CountStarredItems(userID, workspaceID string) (int, error) {
 	return count, nil
 }
 
-// buildCollectionSchemaMap loads all collections for a workspace and returns
-// a map from collection ID to parsed schema, for terminal status lookups.
+// buildCollectionSchemaMap loads only collection IDs and schemas for a workspace,
+// avoiding the heavier ListCollections which runs per-collection COUNT queries.
 func (s *Store) buildCollectionSchemaMap(workspaceID string) (map[string]models.CollectionSchema, error) {
-	collections, err := s.ListCollections(workspaceID)
+	rows, err := s.db.Query(
+		s.q("SELECT id, schema FROM collections WHERE workspace_id = ?"),
+		workspaceID,
+	)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("load collection schemas: %w", err)
 	}
-	m := make(map[string]models.CollectionSchema, len(collections))
-	for _, c := range collections {
+	defer rows.Close()
+
+	m := make(map[string]models.CollectionSchema)
+	for rows.Next() {
+		var id, rawSchema string
+		if err := rows.Scan(&id, &rawSchema); err != nil {
+			return nil, err
+		}
 		var schema models.CollectionSchema
-		if err := json.Unmarshal([]byte(c.Schema), &schema); err == nil {
-			m[c.ID] = schema
+		if err := json.Unmarshal([]byte(rawSchema), &schema); err == nil {
+			m[id] = schema
 		}
 	}
-	return m, nil
+	return m, rows.Err()
 }
 
 // extractStatusFromFields extracts the "status" value from an item's fields JSON.

--- a/internal/store/item_stars.go
+++ b/internal/store/item_stars.go
@@ -1,0 +1,147 @@
+package store
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+
+	"github.com/xarmian/pad/internal/models"
+)
+
+// StarItem stars an item for a user. Idempotent — re-starring is a no-op.
+func (s *Store) StarItem(userID, itemID string) error {
+	ts := now()
+	_, err := s.db.Exec(s.q(`
+		INSERT INTO item_stars (user_id, item_id, created_at)
+		VALUES (?, ?, ?)
+		ON CONFLICT (user_id, item_id) DO NOTHING
+	`), userID, itemID, ts)
+	if err != nil {
+		return fmt.Errorf("star item: %w", err)
+	}
+	return nil
+}
+
+// UnstarItem removes a star from an item for a user. Returns sql.ErrNoRows if not starred.
+func (s *Store) UnstarItem(userID, itemID string) error {
+	result, err := s.db.Exec(
+		s.q("DELETE FROM item_stars WHERE user_id = ? AND item_id = ?"),
+		userID, itemID,
+	)
+	if err != nil {
+		return fmt.Errorf("unstar item: %w", err)
+	}
+	n, _ := result.RowsAffected()
+	if n == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
+}
+
+// IsItemStarred checks whether a specific item is starred by a user.
+func (s *Store) IsItemStarred(userID, itemID string) (bool, error) {
+	var count int
+	err := s.db.QueryRow(
+		s.q("SELECT COUNT(*) FROM item_stars WHERE user_id = ? AND item_id = ?"),
+		userID, itemID,
+	).Scan(&count)
+	if err != nil {
+		return false, fmt.Errorf("check item starred: %w", err)
+	}
+	return count > 0, nil
+}
+
+// AreItemsStarred returns a set of item IDs that are starred by the given user.
+// Pass the item IDs you want to check; the returned map contains only the starred ones.
+func (s *Store) AreItemsStarred(userID string, itemIDs []string) (map[string]bool, error) {
+	result := make(map[string]bool)
+	if len(itemIDs) == 0 {
+		return result, nil
+	}
+
+	// Build placeholders for IN clause
+	placeholders := make([]string, len(itemIDs))
+	args := make([]any, 0, len(itemIDs)+1)
+	args = append(args, userID)
+	for i, id := range itemIDs {
+		placeholders[i] = "?"
+		args = append(args, id)
+	}
+
+	query := fmt.Sprintf(
+		"SELECT item_id FROM item_stars WHERE user_id = ? AND item_id IN (%s)",
+		strings.Join(placeholders, ", "),
+	)
+
+	rows, err := s.db.Query(s.q(query), args...)
+	if err != nil {
+		return nil, fmt.Errorf("check items starred: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var itemID string
+		if err := rows.Scan(&itemID); err != nil {
+			return nil, err
+		}
+		result[itemID] = true
+	}
+	return result, rows.Err()
+}
+
+// ListStarredItems returns all items starred by a user in a workspace, enriched with
+// collection and assignment info. Only non-deleted items are returned.
+// If includeTerminal is false, items in terminal statuses are excluded.
+func (s *Store) ListStarredItems(userID, workspaceID string, includeTerminal bool) ([]models.Item, error) {
+	query := `
+		SELECT i.id, i.workspace_id, i.collection_id, i.title, i.slug, i.content, i.fields, i.tags,
+		       i.pinned, i.sort_order, i.parent_id, i.assigned_user_id, i.agent_role_id, i.role_sort_order,
+		       i.created_by, i.last_modified_by, i.source,
+		       i.item_number, i.created_at, i.updated_at,
+		       c.slug, c.name, c.icon, c.prefix,
+		       COALESCE(au.name, ''), COALESCE(au.email, ''),
+		       COALESCE(ar.name, ''), COALESCE(ar.slug, ''), COALESCE(ar.icon, '')
+		FROM item_stars s
+		JOIN items i ON i.id = s.item_id
+		JOIN collections c ON c.id = i.collection_id
+		LEFT JOIN users au ON au.id = i.assigned_user_id
+		LEFT JOIN agent_roles ar ON ar.id = i.agent_role_id
+		WHERE s.user_id = ?
+		  AND i.workspace_id = ?
+		  AND i.deleted_at IS NULL
+		ORDER BY s.created_at DESC
+	`
+
+	rows, err := s.db.Query(s.q(query), userID, workspaceID)
+	if err != nil {
+		return nil, fmt.Errorf("list starred items: %w", err)
+	}
+	defer rows.Close()
+
+	return scanItems(rows)
+}
+
+// CountStarredItems returns the number of starred items for a user in a workspace.
+func (s *Store) CountStarredItems(userID, workspaceID string) (int, error) {
+	var count int
+	err := s.db.QueryRow(s.q(`
+		SELECT COUNT(*)
+		FROM item_stars s
+		JOIN items i ON i.id = s.item_id
+		WHERE s.user_id = ? AND i.workspace_id = ? AND i.deleted_at IS NULL
+	`), userID, workspaceID).Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("count starred items: %w", err)
+	}
+	return count, nil
+}
+
+// DeleteStarsForItem removes all stars for a given item (used when deleting an item).
+func (s *Store) DeleteStarsForItem(itemID string) error {
+	_, err := s.db.Exec(s.q("DELETE FROM item_stars WHERE item_id = ?"), itemID)
+	if err != nil {
+		return fmt.Errorf("delete stars for item: %w", err)
+	}
+	return nil
+}
+

--- a/internal/store/item_stars_test.go
+++ b/internal/store/item_stars_test.go
@@ -1,0 +1,252 @@
+package store
+
+import (
+	"database/sql"
+	"testing"
+)
+
+func TestStarItem(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Test")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+	user := createTestUser(t, s, "alice@test.com", "Alice", "password123")
+	item := createTestItem(t, s, ws.ID, col.ID, "Fix bug", "")
+
+	// Star an item
+	if err := s.StarItem(user.ID, item.ID); err != nil {
+		t.Fatalf("StarItem: %v", err)
+	}
+
+	// Verify it's starred
+	starred, err := s.IsItemStarred(user.ID, item.ID)
+	if err != nil {
+		t.Fatalf("IsItemStarred: %v", err)
+	}
+	if !starred {
+		t.Error("expected item to be starred")
+	}
+
+	// Re-starring is idempotent (no error)
+	if err := s.StarItem(user.ID, item.ID); err != nil {
+		t.Fatalf("StarItem (idempotent): %v", err)
+	}
+}
+
+func TestUnstarItem(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Test")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+	user := createTestUser(t, s, "alice@test.com", "Alice", "password123")
+	item := createTestItem(t, s, ws.ID, col.ID, "Fix bug", "")
+
+	// Star then unstar
+	s.StarItem(user.ID, item.ID)
+
+	if err := s.UnstarItem(user.ID, item.ID); err != nil {
+		t.Fatalf("UnstarItem: %v", err)
+	}
+
+	starred, err := s.IsItemStarred(user.ID, item.ID)
+	if err != nil {
+		t.Fatalf("IsItemStarred: %v", err)
+	}
+	if starred {
+		t.Error("expected item to not be starred after unstar")
+	}
+
+	// Unstarring a non-starred item returns sql.ErrNoRows
+	err = s.UnstarItem(user.ID, item.ID)
+	if err != sql.ErrNoRows {
+		t.Errorf("expected sql.ErrNoRows, got %v", err)
+	}
+}
+
+func TestIsItemStarred(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Test")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+	user := createTestUser(t, s, "alice@test.com", "Alice", "password123")
+	item := createTestItem(t, s, ws.ID, col.ID, "Fix bug", "")
+
+	// Not starred initially
+	starred, err := s.IsItemStarred(user.ID, item.ID)
+	if err != nil {
+		t.Fatalf("IsItemStarred: %v", err)
+	}
+	if starred {
+		t.Error("expected item to not be starred initially")
+	}
+
+	// Star it
+	s.StarItem(user.ID, item.ID)
+
+	starred, err = s.IsItemStarred(user.ID, item.ID)
+	if err != nil {
+		t.Fatalf("IsItemStarred: %v", err)
+	}
+	if !starred {
+		t.Error("expected item to be starred")
+	}
+}
+
+func TestAreItemsStarred(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Test")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+	user := createTestUser(t, s, "alice@test.com", "Alice", "password123")
+	item1 := createTestItem(t, s, ws.ID, col.ID, "Task 1", "")
+	item2 := createTestItem(t, s, ws.ID, col.ID, "Task 2", "")
+	item3 := createTestItem(t, s, ws.ID, col.ID, "Task 3", "")
+
+	// Star only item1 and item3
+	s.StarItem(user.ID, item1.ID)
+	s.StarItem(user.ID, item3.ID)
+
+	result, err := s.AreItemsStarred(user.ID, []string{item1.ID, item2.ID, item3.ID})
+	if err != nil {
+		t.Fatalf("AreItemsStarred: %v", err)
+	}
+
+	if !result[item1.ID] {
+		t.Error("expected item1 to be starred")
+	}
+	if result[item2.ID] {
+		t.Error("expected item2 to not be starred")
+	}
+	if !result[item3.ID] {
+		t.Error("expected item3 to be starred")
+	}
+
+	// Empty input returns empty map
+	result, err = s.AreItemsStarred(user.ID, []string{})
+	if err != nil {
+		t.Fatalf("AreItemsStarred (empty): %v", err)
+	}
+	if len(result) != 0 {
+		t.Error("expected empty result for empty input")
+	}
+}
+
+func TestListStarredItems(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Test")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+	user := createTestUser(t, s, "alice@test.com", "Alice", "password123")
+	item1 := createTestItem(t, s, ws.ID, col.ID, "Task 1", "")
+	item2 := createTestItem(t, s, ws.ID, col.ID, "Task 2", "")
+
+	// Star both items
+	s.StarItem(user.ID, item1.ID)
+	s.StarItem(user.ID, item2.ID)
+
+	items, err := s.ListStarredItems(user.ID, ws.ID, true)
+	if err != nil {
+		t.Fatalf("ListStarredItems: %v", err)
+	}
+
+	if len(items) != 2 {
+		t.Fatalf("expected 2 starred items, got %d", len(items))
+	}
+
+	// Items should be enriched with collection info
+	for _, item := range items {
+		if item.CollectionSlug == "" {
+			t.Error("expected collection slug to be populated")
+		}
+		if item.CollectionName == "" {
+			t.Error("expected collection name to be populated")
+		}
+	}
+}
+
+func TestStarsArePerUser(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Test")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+	alice := createTestUser(t, s, "alice@test.com", "Alice", "password123")
+	bob := createTestUser(t, s, "bob@test.com", "Bob", "password123")
+	item := createTestItem(t, s, ws.ID, col.ID, "Shared task", "")
+
+	// Alice stars it
+	s.StarItem(alice.ID, item.ID)
+
+	// Bob hasn't starred it
+	starred, _ := s.IsItemStarred(bob.ID, item.ID)
+	if starred {
+		t.Error("expected item to not be starred for Bob")
+	}
+
+	// Alice sees it starred
+	starred, _ = s.IsItemStarred(alice.ID, item.ID)
+	if !starred {
+		t.Error("expected item to be starred for Alice")
+	}
+
+	// Each user's starred list is independent
+	aliceItems, _ := s.ListStarredItems(alice.ID, ws.ID, true)
+	bobItems, _ := s.ListStarredItems(bob.ID, ws.ID, true)
+	if len(aliceItems) != 1 {
+		t.Errorf("expected 1 starred item for Alice, got %d", len(aliceItems))
+	}
+	if len(bobItems) != 0 {
+		t.Errorf("expected 0 starred items for Bob, got %d", len(bobItems))
+	}
+}
+
+func TestCountStarredItems(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Test")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+	user := createTestUser(t, s, "alice@test.com", "Alice", "password123")
+
+	// Count starts at 0
+	count, err := s.CountStarredItems(user.ID, ws.ID)
+	if err != nil {
+		t.Fatalf("CountStarredItems: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("expected 0, got %d", count)
+	}
+
+	// Star 3 items
+	for i := 0; i < 3; i++ {
+		item := createTestItem(t, s, ws.ID, col.ID, "Task", "")
+		s.StarItem(user.ID, item.ID)
+	}
+
+	count, err = s.CountStarredItems(user.ID, ws.ID)
+	if err != nil {
+		t.Fatalf("CountStarredItems: %v", err)
+	}
+	if count != 3 {
+		t.Errorf("expected 3, got %d", count)
+	}
+}
+
+func TestDeleteStarsForItem(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Test")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+	alice := createTestUser(t, s, "alice@test.com", "Alice", "password123")
+	bob := createTestUser(t, s, "bob@test.com", "Bob", "password123")
+	item := createTestItem(t, s, ws.ID, col.ID, "Task", "")
+
+	// Both users star the item
+	s.StarItem(alice.ID, item.ID)
+	s.StarItem(bob.ID, item.ID)
+
+	// Delete all stars for the item
+	if err := s.DeleteStarsForItem(item.ID); err != nil {
+		t.Fatalf("DeleteStarsForItem: %v", err)
+	}
+
+	// Neither user should see it starred
+	starred, _ := s.IsItemStarred(alice.ID, item.ID)
+	if starred {
+		t.Error("expected item to not be starred for Alice after bulk delete")
+	}
+	starred, _ = s.IsItemStarred(bob.ID, item.ID)
+	if starred {
+		t.Error("expected item to not be starred for Bob after bulk delete")
+	}
+}

--- a/internal/store/item_stars_test.go
+++ b/internal/store/item_stars_test.go
@@ -3,6 +3,8 @@ package store
 import (
 	"database/sql"
 	"testing"
+
+	"github.com/xarmian/pad/internal/models"
 )
 
 func TestStarItem(t *testing.T) {
@@ -156,6 +158,44 @@ func TestListStarredItems(t *testing.T) {
 		if item.CollectionName == "" {
 			t.Error("expected collection name to be populated")
 		}
+	}
+}
+
+func TestListStarredItemsExcludesTerminal(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Test")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+	user := createTestUser(t, s, "alice@test.com", "Alice", "password123")
+	item1 := createTestItem(t, s, ws.ID, col.ID, "Open task", "")
+	item2 := createTestItem(t, s, ws.ID, col.ID, "Done task", "")
+
+	// Mark item2 as done (terminal status)
+	doneFields := `{"status":"done"}`
+	s.UpdateItem(item2.ID, models.ItemUpdate{Fields: &doneFields})
+
+	// Star both
+	s.StarItem(user.ID, item1.ID)
+	s.StarItem(user.ID, item2.ID)
+
+	// includeTerminal=true returns both
+	all, err := s.ListStarredItems(user.ID, ws.ID, true)
+	if err != nil {
+		t.Fatalf("ListStarredItems (all): %v", err)
+	}
+	if len(all) != 2 {
+		t.Errorf("expected 2 items with includeTerminal=true, got %d", len(all))
+	}
+
+	// includeTerminal=false excludes the done item
+	active, err := s.ListStarredItems(user.ID, ws.ID, false)
+	if err != nil {
+		t.Fatalf("ListStarredItems (active): %v", err)
+	}
+	if len(active) != 1 {
+		t.Errorf("expected 1 item with includeTerminal=false, got %d", len(active))
+	}
+	if len(active) > 0 && active[0].Title != "Open task" {
+		t.Errorf("expected 'Open task', got %q", active[0].Title)
 	}
 }
 

--- a/internal/store/migrations/042_item_stars.sql
+++ b/internal/store/migrations/042_item_stars.sql
@@ -2,7 +2,7 @@
 -- Users can star any item to mark it as personally important.
 -- Stars are user-scoped (my stars ≠ your stars).
 CREATE TABLE IF NOT EXISTS item_stars (
-    user_id    TEXT NOT NULL REFERENCES users(id),
+    user_id    TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
     item_id    TEXT NOT NULL REFERENCES items(id) ON DELETE CASCADE,
     created_at TEXT NOT NULL,
     PRIMARY KEY (user_id, item_id)

--- a/internal/store/migrations/042_item_stars.sql
+++ b/internal/store/migrations/042_item_stars.sql
@@ -1,0 +1,12 @@
+-- Item stars: per-user item bookmarking/favoriting.
+-- Users can star any item to mark it as personally important.
+-- Stars are user-scoped (my stars ≠ your stars).
+CREATE TABLE IF NOT EXISTS item_stars (
+    user_id    TEXT NOT NULL REFERENCES users(id),
+    item_id    TEXT NOT NULL REFERENCES items(id) ON DELETE CASCADE,
+    created_at TEXT NOT NULL,
+    PRIMARY KEY (user_id, item_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_item_stars_user ON item_stars(user_id);
+CREATE INDEX IF NOT EXISTS idx_item_stars_item ON item_stars(item_id);

--- a/internal/store/pgmigrations/022_item_stars.sql
+++ b/internal/store/pgmigrations/022_item_stars.sql
@@ -2,7 +2,7 @@
 -- Users can star any item to mark it as personally important.
 -- Stars are user-scoped (my stars ≠ your stars).
 CREATE TABLE IF NOT EXISTS item_stars (
-    user_id    TEXT NOT NULL REFERENCES users(id),
+    user_id    TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
     item_id    TEXT NOT NULL REFERENCES items(id) ON DELETE CASCADE,
     created_at TEXT NOT NULL,
     PRIMARY KEY (user_id, item_id)

--- a/internal/store/pgmigrations/022_item_stars.sql
+++ b/internal/store/pgmigrations/022_item_stars.sql
@@ -1,0 +1,12 @@
+-- Item stars: per-user item bookmarking/favoriting.
+-- Users can star any item to mark it as personally important.
+-- Stars are user-scoped (my stars ≠ your stars).
+CREATE TABLE IF NOT EXISTS item_stars (
+    user_id    TEXT NOT NULL REFERENCES users(id),
+    item_id    TEXT NOT NULL REFERENCES items(id) ON DELETE CASCADE,
+    created_at TEXT NOT NULL,
+    PRIMARY KEY (user_id, item_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_item_stars_user ON item_stars(user_id);
+CREATE INDEX IF NOT EXISTS idx_item_stars_item ON item_stars(item_id);


### PR DESCRIPTION
## Summary

- Adds `item_stars` join table via migration 042 (SQLite) and 022 (PostgreSQL) with `(user_id, item_id)` primary key, foreign keys with `ON DELETE CASCADE`, and indexes on both columns
- Implements store methods: `StarItem` (idempotent), `UnstarItem`, `IsItemStarred`, `AreItemsStarred` (batch check for list views), `ListStarredItems` (enriched with collection/assignment info), `CountStarredItems`, `DeleteStarsForItem`
- 8 tests covering star/unstar, idempotency, per-user isolation, batch lookups, enriched listing, counting, and bulk deletion

Part of PLAN-564: Item Starring / Favorites (TASK-565).

## Test plan

- [x] All 8 new star tests pass (`go test ./internal/store/ -run "TestStar|TestUnstar|TestIsItem|TestAreItems|TestListStarred|TestCount|TestDelete"`)
- [x] Full test suite passes (`go test ./...`)
- [x] `go build ./...` succeeds
- [x] `npm run build` (web) succeeds