### PR TITLE
feat: add star/unstar API endpoints

### DIFF
--- a/internal/server/handlers_stars.go
+++ b/internal/server/handlers_stars.go
@@ -1,0 +1,160 @@
+package server
+
+import (
+	"database/sql"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/xarmian/pad/internal/models"
+)
+
+// handleStarItem stars an item for the authenticated user (idempotent).
+// POST /api/v1/workspaces/{slug}/items/{itemSlug}/star
+func (s *Server) handleStarItem(w http.ResponseWriter, r *http.Request) {
+	workspaceID, ok := s.getWorkspaceID(w, r)
+	if !ok {
+		return
+	}
+
+	itemSlug := chi.URLParam(r, "itemSlug")
+	item, err := s.store.ResolveItem(workspaceID, itemSlug)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	if item == nil {
+		writeError(w, http.StatusNotFound, "not_found", "Item not found")
+		return
+	}
+
+	if !s.requireItemVisible(w, r, workspaceID, item) {
+		return
+	}
+
+	userID := currentUserID(r)
+	if userID == "" {
+		writeError(w, http.StatusUnauthorized, "unauthorized", "Authentication required")
+		return
+	}
+
+	if err := s.store.StarItem(userID, item.ID); err != nil {
+		writeInternalError(w, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// handleUnstarItem removes a star from an item for the authenticated user.
+// DELETE /api/v1/workspaces/{slug}/items/{itemSlug}/star
+func (s *Server) handleUnstarItem(w http.ResponseWriter, r *http.Request) {
+	workspaceID, ok := s.getWorkspaceID(w, r)
+	if !ok {
+		return
+	}
+
+	itemSlug := chi.URLParam(r, "itemSlug")
+	item, err := s.store.ResolveItem(workspaceID, itemSlug)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	if item == nil {
+		writeError(w, http.StatusNotFound, "not_found", "Item not found")
+		return
+	}
+
+	if !s.requireItemVisible(w, r, workspaceID, item) {
+		return
+	}
+
+	userID := currentUserID(r)
+	if userID == "" {
+		writeError(w, http.StatusUnauthorized, "unauthorized", "Authentication required")
+		return
+	}
+
+	if err := s.store.UnstarItem(userID, item.ID); err != nil {
+		if err == sql.ErrNoRows {
+			writeError(w, http.StatusNotFound, "not_found", "Item is not starred")
+			return
+		}
+		writeInternalError(w, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// handleListStarredItems returns all starred items for the authenticated user in a workspace.
+// GET /api/v1/workspaces/{slug}/starred
+// Query params:
+//   - include_terminal=true — include items in terminal statuses (default: false)
+func (s *Server) handleListStarredItems(w http.ResponseWriter, r *http.Request) {
+	workspaceID, ok := s.getWorkspaceID(w, r)
+	if !ok {
+		return
+	}
+
+	userID := currentUserID(r)
+	if userID == "" {
+		writeError(w, http.StatusUnauthorized, "unauthorized", "Authentication required")
+		return
+	}
+
+	includeTerminal := r.URL.Query().Get("include_terminal") == "true"
+
+	items, err := s.store.ListStarredItems(userID, workspaceID, includeTerminal)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+
+	// Hydrate items with parent links and computed refs
+	visibleIDs, _ := s.visibleCollectionIDs(r, workspaceID)
+	s.enrichItemsWithParent(workspaceID, items, visibleIDs)
+
+	if len(items) == 0 {
+		items = []models.Item{}
+	}
+
+	writeJSON(w, http.StatusOK, items)
+}
+
+// handleGetItemStarStatus returns whether the authenticated user has starred a specific item.
+// GET /api/v1/workspaces/{slug}/items/{itemSlug}/star
+func (s *Server) handleGetItemStarStatus(w http.ResponseWriter, r *http.Request) {
+	workspaceID, ok := s.getWorkspaceID(w, r)
+	if !ok {
+		return
+	}
+
+	itemSlug := chi.URLParam(r, "itemSlug")
+	item, err := s.store.ResolveItem(workspaceID, itemSlug)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	if item == nil {
+		writeError(w, http.StatusNotFound, "not_found", "Item not found")
+		return
+	}
+
+	if !s.requireItemVisible(w, r, workspaceID, item) {
+		return
+	}
+
+	userID := currentUserID(r)
+	if userID == "" {
+		writeError(w, http.StatusUnauthorized, "unauthorized", "Authentication required")
+		return
+	}
+
+	starred, err := s.store.IsItemStarred(userID, item.ID)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]bool{"starred": starred})
+}

--- a/internal/server/handlers_stars.go
+++ b/internal/server/handlers_stars.go
@@ -110,8 +110,53 @@ func (s *Server) handleListStarredItems(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	// Apply RBAC visibility filtering (same as handleListItems)
+	visibleIDs, err := s.visibleCollectionIDs(r, workspaceID)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+
+	// Build visibility sets for filtering
+	visibleSet := make(map[string]bool, len(visibleIDs))
+	if visibleIDs != nil {
+		for _, id := range visibleIDs {
+			visibleSet[id] = true
+		}
+	}
+
+	// Apply item-level grant filtering for guests/restricted members
+	fullCollIDs, grantedItemIDs, grantErr := s.guestResourceFilter(r, workspaceID)
+	if grantErr != nil {
+		writeInternalError(w, grantErr)
+		return
+	}
+
+	fullCollSet := make(map[string]bool, len(fullCollIDs))
+	for _, id := range fullCollIDs {
+		fullCollSet[id] = true
+	}
+	grantedItemSet := make(map[string]bool, len(grantedItemIDs))
+	for _, id := range grantedItemIDs {
+		grantedItemSet[id] = true
+	}
+
+	// Filter items by visibility
+	filtered := make([]models.Item, 0, len(items))
+	for _, item := range items {
+		if len(grantedItemIDs) > 0 {
+			// Guest with item-level grants: allow if collection has full access OR item is explicitly granted
+			if fullCollSet[item.CollectionID] || grantedItemSet[item.ID] {
+				filtered = append(filtered, item)
+			}
+		} else if visibleIDs == nil || visibleSet[item.CollectionID] {
+			// Regular member: allow if no visibility filter (full access) or collection is visible
+			filtered = append(filtered, item)
+		}
+	}
+	items = filtered
+
 	// Hydrate items with parent links and computed refs
-	visibleIDs, _ := s.visibleCollectionIDs(r, workspaceID)
 	s.enrichItemsWithParent(workspaceID, items, visibleIDs)
 
 	if len(items) == 0 {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -420,6 +420,9 @@ func (s *Server) setupRouter() {
 				// User grants (all grants for a specific user in this workspace)
 				r.Get("/users/{userID}/grants", s.handleListUserGrants)
 
+				// Starred items
+				r.Get("/starred", s.handleListStarredItems)
+
 				// Items (cross-collection, v2)
 				r.Get("/items", s.handleListItems)
 				r.Route("/items/{itemSlug}", func(r chi.Router) {
@@ -444,6 +447,10 @@ func (s *Server) setupRouter() {
 					r.Delete("/grants/{grantID}", s.handleDeleteItemGrant)
 					r.Get("/share-links", s.handleListItemShareLinks)
 					r.Post("/share-links", s.handleCreateItemShareLink)
+					// Stars
+					r.Get("/star", s.handleGetItemStarStatus)
+					r.Post("/star", s.handleStarItem)
+					r.Delete("/star", s.handleUnstarItem)
 				})
 
 				// Links (v2)


### PR DESCRIPTION
## Summary

- Adds `POST /items/{slug}/star` — star an item (idempotent, returns 204)
- Adds `DELETE /items/{slug}/star` — unstar an item (204 or 404 if not starred)
- Adds `GET /items/{slug}/star` — check if item is starred (`{"starred": true/false}`)
- Adds `GET /workspaces/{ws}/starred` — list user's starred items with `?include_terminal=true` filter
- All endpoints scoped to authenticated user, with RBAC/grant visibility checks
- List endpoint enriches items with parent links and computed refs

Part of PLAN-564: Item Starring / Favorites (TASK-566). Builds on #115 (store layer).

## Test plan

- [x] `go build ./...` succeeds
- [x] `go test ./...` all pass
- [x] `npm run build` (web) succeeds
- [x] Manual smoke test: star, check status, list starred, unstar — all return correct responses