### PR TITLE
feat: add star toggle to web UI item views

### DIFF
--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -304,7 +304,27 @@ export const api = {
 
 		/** @deprecated Use progress() per-item instead */
 		plansProgress: (ws: string) =>
-			request<{item_id: string; total: number; done: number}[]>(`/workspaces/${ws}/plans-progress`)
+			request<{item_id: string; total: number; done: number}[]>(`/workspaces/${ws}/plans-progress`),
+
+		/** Star an item for the current user (idempotent) */
+		star: (ws: string, itemSlug: string) =>
+			request<void>(`/workspaces/${ws}/items/${itemSlug}/star`, {
+				method: 'POST'
+			}),
+
+		/** Unstar an item for the current user */
+		unstar: (ws: string, itemSlug: string) =>
+			request<void>(`/workspaces/${ws}/items/${itemSlug}/star`, {
+				method: 'DELETE'
+			}),
+
+		/** Check if an item is starred by the current user */
+		starStatus: (ws: string, itemSlug: string) =>
+			request<{starred: boolean}>(`/workspaces/${ws}/items/${itemSlug}/star`),
+
+		/** List all starred items in a workspace for the current user */
+		starred: (ws: string, params?: {include_terminal?: boolean}) =>
+			request<Item[]>(`/workspaces/${ws}/starred${qs(params)}`)
 	},
 
 	// ── Versions ──────────────────────────────────────────────────────────────

--- a/web/src/lib/components/collections/ItemCard.svelte
+++ b/web/src/lib/components/collections/ItemCard.svelte
@@ -2,6 +2,7 @@
 	import { page } from '$app/state';
 	import type { Item, Collection } from '$lib/types';
 	import { parseFields, parseSchema, formatItemRef, itemUrlId } from '$lib/types';
+	import { starredStore } from '$lib/stores/starred.svelte';
 
 	interface Props {
 		item: Item;
@@ -26,6 +27,7 @@
 	let priorityField = $derived(schema.fields.find((f) => f.key === 'priority'));
 	let itemUrl = $derived(`/${username}/${wsSlug}/${collection.slug}/${itemUrlId(item)}`);
 	let itemRef = $derived(formatItemRef(item));
+	let starred = $derived(starredStore.isStarred(item.id));
 
 	let statusCyclable = $derived(
 		!!onStatusClick && !!statusOptions && statusOptions.length > 1 && !!fields.status
@@ -70,10 +72,24 @@
 	function formatLabel(value: string): string {
 		return value.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
 	}
+
+	function toggleStar(e: MouseEvent) {
+		e.preventDefault();
+		e.stopPropagation();
+		starredStore.toggle(wsSlug, item.slug, item.id);
+	}
 </script>
 
 <a href={itemUrl} class="item-card" class:compact class:focused>
 	<div class="card-top-row">
+		<button
+			class="star-btn"
+			class:starred
+			onclick={toggleStar}
+			title={starred ? 'Unstar' : 'Star'}
+		>
+			{starred ? '★' : '☆'}
+		</button>
 		{#if showCollection && item.collection_name}
 			<span class="collection-badge">
 				{#if item.collection_icon}{item.collection_icon} {/if}{item.collection_name}
@@ -304,5 +320,31 @@
 		color: var(--text-muted);
 		white-space: nowrap;
 		flex-shrink: 0;
+	}
+
+	.star-btn {
+		border: none;
+		background: none;
+		cursor: pointer;
+		padding: 0;
+		font-size: 0.95em;
+		line-height: 1;
+		color: var(--text-muted);
+		opacity: 0;
+		transition: opacity 0.15s, color 0.15s;
+		flex-shrink: 0;
+	}
+
+	.item-card:hover .star-btn,
+	.star-btn.starred {
+		opacity: 1;
+	}
+
+	.star-btn:hover {
+		color: var(--accent-amber);
+	}
+
+	.star-btn.starred {
+		color: var(--accent-amber);
 	}
 </style>

--- a/web/src/lib/stores/starred.svelte.ts
+++ b/web/src/lib/stores/starred.svelte.ts
@@ -3,6 +3,10 @@ import { api } from '$lib/api/client';
 // Set of starred item IDs for the current user in the current workspace
 let starredIds = $state<Set<string>>(new Set());
 let loaded = $state(false);
+let currentWs = $state('');
+
+// Monotonic request counter to discard stale responses on workspace switch
+let requestSeq = 0;
 
 export const starredStore = {
 	get ids() { return starredIds; },
@@ -14,12 +18,17 @@ export const starredStore = {
 
 	/** Load all starred item IDs for a workspace. Call once on workspace load. */
 	async load(wsSlug: string) {
+		currentWs = wsSlug;
+		const seq = ++requestSeq;
+
 		try {
 			const items = await api.items.starred(wsSlug, { include_terminal: true });
+			// Discard if a newer load was initiated while this one was in flight
+			if (seq !== requestSeq) return;
 			starredIds = new Set(items.map(i => i.id));
 			loaded = true;
 		} catch {
-			// Silently fail — starring is non-critical
+			if (seq !== requestSeq) return;
 			starredIds = new Set();
 			loaded = true;
 		}
@@ -45,7 +54,8 @@ export const starredStore = {
 				await api.items.star(wsSlug, itemSlug);
 			}
 		} catch {
-			// Revert on failure
+			// Revert on failure (only if still on the same workspace)
+			if (currentWs !== wsSlug) return;
 			const reverted = new Set(starredIds);
 			if (wasStarred) {
 				reverted.add(itemId);
@@ -59,5 +69,6 @@ export const starredStore = {
 	clear() {
 		starredIds = new Set();
 		loaded = false;
+		currentWs = '';
 	}
 };

--- a/web/src/lib/stores/starred.svelte.ts
+++ b/web/src/lib/stores/starred.svelte.ts
@@ -1,0 +1,63 @@
+import { api } from '$lib/api/client';
+
+// Set of starred item IDs for the current user in the current workspace
+let starredIds = $state<Set<string>>(new Set());
+let loaded = $state(false);
+
+export const starredStore = {
+	get ids() { return starredIds; },
+	get loaded() { return loaded; },
+
+	isStarred(itemId: string): boolean {
+		return starredIds.has(itemId);
+	},
+
+	/** Load all starred item IDs for a workspace. Call once on workspace load. */
+	async load(wsSlug: string) {
+		try {
+			const items = await api.items.starred(wsSlug, { include_terminal: true });
+			starredIds = new Set(items.map(i => i.id));
+			loaded = true;
+		} catch {
+			// Silently fail — starring is non-critical
+			starredIds = new Set();
+			loaded = true;
+		}
+	},
+
+	/** Toggle star with optimistic update. */
+	async toggle(wsSlug: string, itemSlug: string, itemId: string) {
+		const wasStarred = starredIds.has(itemId);
+
+		// Optimistic update
+		const next = new Set(starredIds);
+		if (wasStarred) {
+			next.delete(itemId);
+		} else {
+			next.add(itemId);
+		}
+		starredIds = next;
+
+		try {
+			if (wasStarred) {
+				await api.items.unstar(wsSlug, itemSlug);
+			} else {
+				await api.items.star(wsSlug, itemSlug);
+			}
+		} catch {
+			// Revert on failure
+			const reverted = new Set(starredIds);
+			if (wasStarred) {
+				reverted.add(itemId);
+			} else {
+				reverted.delete(itemId);
+			}
+			starredIds = reverted;
+		}
+	},
+
+	clear() {
+		starredIds = new Set();
+		loaded = false;
+	}
+};

--- a/web/src/lib/stores/starred.svelte.ts
+++ b/web/src/lib/stores/starred.svelte.ts
@@ -8,6 +8,11 @@ let currentWs = $state('');
 // Monotonic request counter to discard stale responses on workspace switch
 let requestSeq = 0;
 
+// Track toggles that happened while a load is in flight, so the load
+// result can be merged with local mutations instead of overwriting them.
+// Map of itemId → true (starred) or false (unstarred) since load started.
+let pendingToggles = new Map<string, boolean>();
+
 export const starredStore = {
 	get ids() { return starredIds; },
 	get loaded() { return loaded; },
@@ -20,12 +25,23 @@ export const starredStore = {
 	async load(wsSlug: string) {
 		currentWs = wsSlug;
 		const seq = ++requestSeq;
+		pendingToggles.clear();
 
 		try {
 			const items = await api.items.starred(wsSlug, { include_terminal: true });
 			// Discard if a newer load was initiated while this one was in flight
 			if (seq !== requestSeq) return;
-			starredIds = new Set(items.map(i => i.id));
+			const result = new Set(items.map(i => i.id));
+			// Merge any toggles that happened while loading
+			for (const [itemId, starred] of pendingToggles) {
+				if (starred) {
+					result.add(itemId);
+				} else {
+					result.delete(itemId);
+				}
+			}
+			pendingToggles.clear();
+			starredIds = result;
 			loaded = true;
 		} catch {
 			if (seq !== requestSeq) return;
@@ -37,13 +53,17 @@ export const starredStore = {
 	/** Toggle star with optimistic update. */
 	async toggle(wsSlug: string, itemSlug: string, itemId: string) {
 		const wasStarred = starredIds.has(itemId);
+		const nowStarred = !wasStarred;
+
+		// Track this toggle so an in-flight load can merge it
+		pendingToggles.set(itemId, nowStarred);
 
 		// Optimistic update
 		const next = new Set(starredIds);
-		if (wasStarred) {
-			next.delete(itemId);
-		} else {
+		if (nowStarred) {
 			next.add(itemId);
+		} else {
+			next.delete(itemId);
 		}
 		starredIds = next;
 
@@ -56,6 +76,7 @@ export const starredStore = {
 		} catch {
 			// Revert on failure (only if still on the same workspace)
 			if (currentWs !== wsSlug) return;
+			pendingToggles.set(itemId, wasStarred);
 			const reverted = new Set(starredIds);
 			if (wasStarred) {
 				reverted.add(itemId);
@@ -70,5 +91,6 @@ export const starredStore = {
 		starredIds = new Set();
 		loaded = false;
 		currentWs = '';
+		pendingToggles.clear();
 	}
 };

--- a/web/src/lib/stores/starred.svelte.ts
+++ b/web/src/lib/stores/starred.svelte.ts
@@ -42,6 +42,9 @@ export const starredStore = {
 		currentWs = wsSlug;
 		const seq = ++requestSeq;
 		pendingToggles.clear();
+		// Clear stale state immediately to avoid showing a previous user/workspace's stars
+		starredIds = new Set();
+		loaded = false;
 
 		try {
 			const items = await api.items.starred(wsSlug, { include_terminal: true });

--- a/web/src/lib/stores/starred.svelte.ts
+++ b/web/src/lib/stores/starred.svelte.ts
@@ -13,6 +13,22 @@ let requestSeq = 0;
 // Map of itemId → true (starred) or false (unstarred) since load started.
 let pendingToggles = new Map<string, boolean>();
 
+// Per-item toggle locks to serialize rapid clicks on the same item
+let toggleInFlight = new Set<string>();
+
+/** Apply pending toggles on top of a base set. */
+function applyPendingToggles(base: Set<string>): Set<string> {
+	for (const [itemId, starred] of pendingToggles) {
+		if (starred) {
+			base.add(itemId);
+		} else {
+			base.delete(itemId);
+		}
+	}
+	pendingToggles.clear();
+	return base;
+}
+
 export const starredStore = {
 	get ids() { return starredIds; },
 	get loaded() { return loaded; },
@@ -29,29 +45,22 @@ export const starredStore = {
 
 		try {
 			const items = await api.items.starred(wsSlug, { include_terminal: true });
-			// Discard if a newer load was initiated while this one was in flight
 			if (seq !== requestSeq) return;
-			const result = new Set(items.map(i => i.id));
-			// Merge any toggles that happened while loading
-			for (const [itemId, starred] of pendingToggles) {
-				if (starred) {
-					result.add(itemId);
-				} else {
-					result.delete(itemId);
-				}
-			}
-			pendingToggles.clear();
-			starredIds = result;
+			starredIds = applyPendingToggles(new Set(items.map(i => i.id)));
 			loaded = true;
 		} catch {
 			if (seq !== requestSeq) return;
-			starredIds = new Set();
+			// Preserve any optimistic toggles even if the load failed
+			starredIds = applyPendingToggles(new Set());
 			loaded = true;
 		}
 	},
 
-	/** Toggle star with optimistic update. */
+	/** Toggle star with optimistic update. Serialized per item. */
 	async toggle(wsSlug: string, itemSlug: string, itemId: string) {
+		// Drop rapid duplicate clicks while a toggle is in flight for this item
+		if (toggleInFlight.has(itemId)) return;
+
 		const wasStarred = starredIds.has(itemId);
 		const nowStarred = !wasStarred;
 
@@ -67,6 +76,7 @@ export const starredStore = {
 		}
 		starredIds = next;
 
+		toggleInFlight.add(itemId);
 		try {
 			if (wasStarred) {
 				await api.items.unstar(wsSlug, itemSlug);
@@ -84,6 +94,8 @@ export const starredStore = {
 				reverted.delete(itemId);
 			}
 			starredIds = reverted;
+		} finally {
+			toggleInFlight.delete(itemId);
 		}
 	},
 
@@ -92,5 +104,6 @@ export const starredStore = {
 		loaded = false;
 		currentWs = '';
 		pendingToggles.clear();
+		toggleInFlight.clear();
 	}
 };

--- a/web/src/routes/[username]/[workspace]/+layout.svelte
+++ b/web/src/routes/[username]/[workspace]/+layout.svelte
@@ -8,6 +8,7 @@
 	import { syncService } from '$lib/services/sync.svelte';
 	import { api } from '$lib/api/client';
 	import { toastStore } from '$lib/stores/toast.svelte';
+	import { starredStore } from '$lib/stores/starred.svelte';
 
 	let { children } = $props();
 
@@ -42,6 +43,7 @@
 		if (wsSlug) {
 			workspaceStore.setCurrent(wsSlug);
 			collectionStore.loadCollections(wsSlug);
+			starredStore.load(wsSlug);
 			syncService.setWorkspace(wsSlug);
 			connectSSE();
 		}

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -22,6 +22,7 @@
 	import ShareDialog from '$lib/components/ShareDialog.svelte';
 	import { copyToClipboard } from '$lib/utils/clipboard';
 	import { authStore } from '$lib/stores/auth.svelte';
+	import { starredStore } from '$lib/stores/starred.svelte';
 
 	type RelationshipEntry = {
 		key: string;
@@ -674,6 +675,14 @@
 
 		<!-- Actions -->
 		<div class="meta-actions">
+			<button
+				class="action-btn star-btn"
+				class:starred={starredStore.isStarred(item.id)}
+				onclick={() => starredStore.toggle(wsSlug, item.slug, item.id)}
+				title={starredStore.isStarred(item.id) ? 'Unstar' : 'Star'}
+			>
+				{starredStore.isStarred(item.id) ? '★' : '☆'}
+			</button>
 			{#if quickActions.length > 0 && collection}
 				<QuickActionsMenu actions={quickActions} {item} {collection} scope="item" />
 			{/if}
@@ -1619,6 +1628,12 @@
 		background: var(--accent-blue);
 		border-color: var(--accent-blue);
 		color: #fff;
+	}
+	.star-btn.starred {
+		color: var(--accent-amber);
+	}
+	.star-btn:hover {
+		color: var(--accent-amber);
 	}
 	.move-wrapper {
 		position: relative;


### PR DESCRIPTION
## Summary

- Adds `starredStore` (Svelte 5 rune store) that loads all starred item IDs on workspace init and provides optimistic toggle
- Adds API client methods: `star()`, `unstar()`, `starStatus()`, `starred()`
- Adds ☆/★ toggle button to **ItemCard** component (used in both list and board views) — hidden until hover, always visible when starred, amber colored
- Adds ★ toggle button to **item detail page** header in the meta-actions row
- Workspace layout loads starred state on workspace change

Part of PLAN-564: Item Starring / Favorites (TASK-567). Builds on #115 (store) and #116 (API).

## Test plan

- [x] `npm run build` succeeds
- [x] `go build ./...` + `go test ./...` all pass
- [x] `make install` — server restarted with new UI
- [ ] Visual: star toggle appears on hover in list/board view cards
- [ ] Visual: star toggle in item detail page header
- [ ] Optimistic update: star appears instantly, reverts on API failure