### PR TITLE
feat: add starred items to dashboard

### DIFF
--- a/internal/server/handlers_dashboard.go
+++ b/internal/server/handlers_dashboard.go
@@ -652,6 +652,9 @@ func (s *Server) handleGetDashboard(w http.ResponseWriter, r *http.Request) {
 					si.ItemRef = item.CollectionPrefix + "-" + strconv.Itoa(*item.ItemNumber)
 				}
 				starredItems = append(starredItems, si)
+				if len(starredItems) >= 10 {
+					break
+				}
 			}
 			if len(starredItems) > 0 {
 				resp.StarredItems = starredItems

--- a/internal/server/handlers_dashboard.go
+++ b/internal/server/handlers_dashboard.go
@@ -18,6 +18,7 @@ type DashboardResponse struct {
 	Summary        DashboardSummary       `json:"summary"`
 	ActiveItems    []DashboardActiveItem  `json:"active_items"`
 	ActivePlans    []DashboardPlan         `json:"active_plans"`
+	StarredItems   []DashboardActiveItem  `json:"starred_items,omitempty"`
 	ByRole         []store.RoleBreakdown  `json:"by_role,omitempty"`
 	Attention      []DashboardAttention   `json:"attention"`
 	RecentActivity []DashboardActivity    `json:"recent_activity"`
@@ -622,6 +623,39 @@ func (s *Server) handleGetDashboard(w http.ResponseWriter, r *http.Request) {
 		roleBreakdown, err := s.store.GetRoleBreakdown(workspaceID)
 		if err == nil && len(roleBreakdown) > 0 {
 			resp.ByRole = roleBreakdown
+		}
+	}
+
+	// Starred items: non-terminal items starred by the current user
+	if userID := currentUserID(r); userID != "" {
+		starred, err := s.store.ListStarredItems(userID, workspaceID, false)
+		if err == nil && len(starred) > 0 {
+			starredItems := []DashboardActiveItem{}
+			for _, item := range starred {
+				// Apply same visibility filter as the rest of the dashboard
+				if visibleIDs != nil && !isCollectionVisible(item.CollectionID, visibleIDs) {
+					continue
+				}
+				if len(dashGrantedItemIDs) > 0 && !dashFullCollSet[item.CollectionID] && !dashGrantedItemSet[item.ID] {
+					continue
+				}
+				si := DashboardActiveItem{
+					Slug:           item.Slug,
+					Title:          item.Title,
+					CollectionSlug: item.CollectionSlug,
+					CollectionIcon: item.CollectionIcon,
+					Status:         extractFieldValue(item.Fields, "status"),
+					UpdatedAt:      item.UpdatedAt.Format("2006-01-02T15:04:05Z"),
+				}
+				si.Priority = extractFieldValue(item.Fields, "priority")
+				if item.CollectionPrefix != "" && item.ItemNumber != nil {
+					si.ItemRef = item.CollectionPrefix + "-" + strconv.Itoa(*item.ItemNumber)
+				}
+				starredItems = append(starredItems, si)
+			}
+			if len(starredItems) > 0 {
+				resp.StarredItems = starredItems
+			}
 		}
 	}
 

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -589,6 +589,7 @@ export interface DashboardResponse {
 		by_collection: Record<string, Record<string, number>>;
 	};
 	active_items: DashboardActiveItem[];
+	starred_items?: DashboardActiveItem[];
 	active_plans: {
 		slug: string;
 		title: string;

--- a/web/src/routes/[username]/[workspace]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/+page.svelte
@@ -227,6 +227,38 @@
 			</section>
 		{/if}
 
+		<!-- Starred Items -->
+		{#if dashboard.starred_items && dashboard.starred_items.length > 0}
+			<section class="section">
+				<div class="section-header">
+					<span class="section-label">⭐ Starred</span>
+					<span class="section-badge">{dashboard.starred_items.length}</span>
+					<a href="/{username}/{wsSlug}/starred" class="section-link">View all</a>
+				</div>
+				<div class="active-grid">
+					{#each dashboard.starred_items as item (item.slug)}
+						<a href="/{username}/{wsSlug}/{item.collection_slug}/{item.slug}" class="active-card">
+							<div class="active-card-top">
+								{#if item.item_ref}
+									<span class="active-ref">{item.item_ref}</span>
+								{/if}
+								<span class="active-icon">{item.collection_icon}</span>
+							</div>
+							<div class="active-title">{item.title}</div>
+							<div class="active-card-bottom">
+								<span class="status-pill" style="background: color-mix(in srgb, {statusColor(item.status)} 15%, transparent); color: {statusColor(item.status)};">
+									{item.status.replace(/-/g, ' ')}
+								</span>
+								{#if item.priority}
+									<span class="active-priority" style="color: {priorityColor(item.priority)};">{item.priority}</span>
+								{/if}
+							</div>
+						</a>
+					{/each}
+				</div>
+			</section>
+		{/if}
+
 		<!-- 4. Active Plans -->
 		{#if dashboard.active_plans.length > 0}
 			<section class="section">
@@ -495,12 +527,11 @@
 	}
 	.section-link {
 		font-size: 0.8em;
-		color: var(--text-muted);
+		color: var(--accent-blue);
 		text-decoration: none;
 		margin-left: auto;
 	}
 	.section-link:hover {
-		color: var(--accent-blue);
 		text-decoration: underline;
 	}
 


### PR DESCRIPTION
## Summary

- Dashboard API (`GET /workspaces/{ws}/dashboard`) now includes `starred_items` — non-terminal items starred by the current user, with RBAC visibility filtering
- TypeScript types updated with `starred_items?: DashboardActiveItem[]`
- Dashboard UI renders a "⭐ Starred" section with item cards and a "View all" link to `/starred`

Part of PLAN-564: Item Starring / Favorites (TASK-569).

## Test plan

- [x] `go build ./...` + `go test ./...` all pass
- [x] `npm run build` succeeds
- [x] `make install` — server restarted
- [ ] Visual: starred section appears on dashboard when items are starred
- [ ] Visual: section hidden when no items are starred
- [ ] "View all" links to /starred page