### PR TITLE
feat: add CLI commands for item starring

### DIFF
--- a/cmd/pad/groups.go
+++ b/cmd/pad/groups.go
@@ -103,6 +103,9 @@ func itemCmd() *cobra.Command {
 		unimplementsCmd(),
 		relatedCmd(),
 		implementedByCmd(),
+		starCmd(),
+		unstarCmd(),
+		starredCmd(),
 	)
 	return cmd
 }

--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -5792,3 +5792,98 @@ func auditLogCmd() *cobra.Command {
 
 	return cmd
 }
+
+func starCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "star <ref>",
+		Short: "Star an item for quick access",
+		Long:  `Star an item to mark it as personally important. Starred items appear on your dashboard and in the Starred sidebar page.`,
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, _ := getClient()
+			ws := getWorkspace()
+
+			// Resolve item first so we can show its ref in output
+			item, err := client.GetItem(ws, args[0])
+			if err != nil {
+				return fmt.Errorf("resolve %q: %w", args[0], err)
+			}
+
+			if err := client.StarItem(ws, item.Slug); err != nil {
+				return err
+			}
+
+			ref := cli.ItemRef(*item)
+			if ref != "" {
+				fmt.Printf("⭐ Starred %s %q\n", ref, item.Title)
+			} else {
+				fmt.Printf("⭐ Starred %q\n", item.Title)
+			}
+			return nil
+		},
+	}
+}
+
+func unstarCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "unstar <ref>",
+		Short: "Remove a star from an item",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, _ := getClient()
+			ws := getWorkspace()
+
+			item, err := client.GetItem(ws, args[0])
+			if err != nil {
+				return fmt.Errorf("resolve %q: %w", args[0], err)
+			}
+
+			if err := client.UnstarItem(ws, item.Slug); err != nil {
+				return err
+			}
+
+			ref := cli.ItemRef(*item)
+			if ref != "" {
+				fmt.Printf("Unstarred %s %q\n", ref, item.Title)
+			} else {
+				fmt.Printf("Unstarred %q\n", item.Title)
+			}
+			return nil
+		},
+	}
+}
+
+func starredCmd() *cobra.Command {
+	var all bool
+
+	cmd := &cobra.Command{
+		Use:   "starred",
+		Short: "List your starred items",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, _ := getClient()
+			ws := getWorkspace()
+
+			items, err := client.ListStarredItems(ws, all)
+			if err != nil {
+				return err
+			}
+
+			if formatFlag == "json" {
+				return cli.PrintJSON(items)
+			}
+
+			if len(items) == 0 {
+				fmt.Println("No starred items.")
+				return nil
+			}
+
+			cli.PrintItemTable(items)
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&all, "all", false, "include completed/terminal items")
+
+	return cmd
+}

--- a/internal/cli/client.go
+++ b/internal/cli/client.go
@@ -156,6 +156,26 @@ func (c *Client) DeleteItem(wsSlug, itemSlug string) error {
 	return c.delete("/workspaces/" + wsSlug + "/items/" + itemSlug)
 }
 
+// StarItem stars an item for the current user.
+func (c *Client) StarItem(wsSlug, itemSlug string) error {
+	return c.post("/workspaces/"+wsSlug+"/items/"+itemSlug+"/star", nil, nil)
+}
+
+// UnstarItem removes a star from an item for the current user.
+func (c *Client) UnstarItem(wsSlug, itemSlug string) error {
+	return c.delete("/workspaces/" + wsSlug + "/items/" + itemSlug + "/star")
+}
+
+// ListStarredItems returns the current user's starred items in a workspace.
+func (c *Client) ListStarredItems(wsSlug string, includeTerminal bool) ([]models.Item, error) {
+	var result []models.Item
+	path := "/workspaces/" + wsSlug + "/starred"
+	if includeTerminal {
+		path += "?include_terminal=true"
+	}
+	return result, c.get(path, &result)
+}
+
 func (c *Client) MoveItem(wsSlug, itemSlug string, input map[string]any) (*models.Item, error) {
 	var result models.Item
 	return &result, c.post("/workspaces/"+wsSlug+"/items/"+itemSlug+"/move", input, &result)


### PR DESCRIPTION
## Summary

- `pad item star <ref>` — star an item for quick access
- `pad item unstar <ref>` — remove a star
- `pad item starred [--all] [--format json]` — list starred items (excludes terminal by default, `--all` includes them)
- Client methods: `StarItem`, `UnstarItem`, `ListStarredItems`

Part of PLAN-564: Item Starring / Favorites (TASK-570).

## Test plan

- [x] `go build ./...` + `go test ./...` all pass
- [x] `make install` — server restarted
- [x] Smoke test: `pad item star TASK-570` → starred, `pad item starred` → shows it, `pad item unstar TASK-570` → removed