### PR TITLE
feat: add SSE events for item star/unstar

### DIFF
--- a/internal/events/bus.go
+++ b/internal/events/bus.go
@@ -29,6 +29,10 @@ const (
 	ReactionAdded   = "reaction_added"
 	ReactionRemoved = "reaction_removed"
 
+	// Star events
+	ItemStarred   = "item_starred"
+	ItemUnstarred = "item_unstarred"
+
 	// Composite events
 	ItemUpdatedWithComment = "item_updated_with_comment"
 )

--- a/internal/events/bus.go
+++ b/internal/events/bus.go
@@ -56,6 +56,7 @@ type Event struct {
 	Actor       string `json:"actor,omitempty"`
 	ActorName   string `json:"actor_name,omitempty"`
 	Source      string `json:"source,omitempty"`
+	UserID      string `json:"user_id,omitempty"` // For user-scoped events (e.g. star/unstar)
 	Timestamp   int64  `json:"timestamp"`
 }
 

--- a/internal/server/handlers_events.go
+++ b/internal/server/handlers_events.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"strconv"
 	"time"
+
+	"github.com/xarmian/pad/internal/events"
 )
 
 // handleSSE streams Server-Sent Events for a workspace.
@@ -165,8 +167,16 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	sseUserID := currentUserID(r)
+
 	// sseEventVisible checks if an event should be sent to this client.
-	sseEventVisible := func(collection, itemID string) bool {
+	sseEventVisible := func(event events.Event) bool {
+		// User-scoped events (e.g. star/unstar) are only sent to the user who triggered them
+		if event.UserID != "" && event.UserID != sseUserID {
+			return false
+		}
+		collection := event.Collection
+		itemID := event.ItemID
 		if visibleSlugSet == nil {
 			return true // all access
 		}
@@ -214,7 +224,7 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 				slog.Info("SSE replaying missed events",
 					"workspace", ws.Slug, "last_event_id", lastID, "count", len(missed))
 				for _, event := range missed {
-					if sseEventVisible(event.Collection, event.ItemID) {
+					if sseEventVisible(event) {
 						writeSSEEvent(w, event.Type, event.ID, event)
 						flusher.Flush()
 					}
@@ -240,7 +250,7 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 				// Channel closed (unsubscribed)
 				return
 			}
-			if sseEventVisible(event.Collection, event.ItemID) {
+			if sseEventVisible(event) {
 				writeSSEEvent(w, event.Type, event.ID, event)
 				flusher.Flush()
 			}

--- a/internal/server/handlers_stars.go
+++ b/internal/server/handlers_stars.go
@@ -43,8 +43,20 @@ func (s *Server) handleStarItem(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	actor, source := actorFromRequest(r)
-	s.publishItemEventWithName(events.ItemStarred, workspaceID, item.ID, item.Title, item.CollectionSlug, actor, actorNameFromRequest(r), source)
+	if s.events != nil {
+		actor, source := actorFromRequest(r)
+		s.events.Publish(events.Event{
+			Type:        events.ItemStarred,
+			WorkspaceID: workspaceID,
+			ItemID:      item.ID,
+			Title:       item.Title,
+			Collection:  item.CollectionSlug,
+			Actor:       actor,
+			ActorName:   actorNameFromRequest(r),
+			Source:      source,
+			UserID:      userID,
+		})
+	}
 
 	w.WriteHeader(http.StatusNoContent)
 }
@@ -87,8 +99,20 @@ func (s *Server) handleUnstarItem(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	actor, source := actorFromRequest(r)
-	s.publishItemEventWithName(events.ItemUnstarred, workspaceID, item.ID, item.Title, item.CollectionSlug, actor, actorNameFromRequest(r), source)
+	if s.events != nil {
+		actor, source := actorFromRequest(r)
+		s.events.Publish(events.Event{
+			Type:        events.ItemUnstarred,
+			WorkspaceID: workspaceID,
+			ItemID:      item.ID,
+			Title:       item.Title,
+			Collection:  item.CollectionSlug,
+			Actor:       actor,
+			ActorName:   actorNameFromRequest(r),
+			Source:      source,
+			UserID:      userID,
+		})
+	}
 
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/internal/server/handlers_stars.go
+++ b/internal/server/handlers_stars.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/xarmian/pad/internal/events"
 	"github.com/xarmian/pad/internal/models"
 )
 
@@ -41,6 +42,9 @@ func (s *Server) handleStarItem(w http.ResponseWriter, r *http.Request) {
 		writeInternalError(w, err)
 		return
 	}
+
+	actor, source := actorFromRequest(r)
+	s.publishItemEventWithName(events.ItemStarred, workspaceID, item.ID, item.Title, item.CollectionSlug, actor, actorNameFromRequest(r), source)
 
 	w.WriteHeader(http.StatusNoContent)
 }
@@ -82,6 +86,9 @@ func (s *Server) handleUnstarItem(w http.ResponseWriter, r *http.Request) {
 		writeInternalError(w, err)
 		return
 	}
+
+	actor, source := actorFromRequest(r)
+	s.publishItemEventWithName(events.ItemUnstarred, workspaceID, item.ID, item.Title, item.CollectionSlug, actor, actorNameFromRequest(r), source)
 
 	w.WriteHeader(http.StatusNoContent)
 }


### PR DESCRIPTION
## Summary

- Adds `item_starred` and `item_unstarred` event type constants
- Emits events from star/unstar handlers after successful mutations
- Enables multi-tab sync for starred state via the existing SSE infrastructure

Part of PLAN-564: Item Starring / Favorites (TASK-571). Final task in the plan.

## Test plan

- [x] `go build ./...` + `go test ./...` all pass
- [x] `make install` — server restarted