### PR TITLE
feat: add collection and field filtering to search API

### DIFF
--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -2959,7 +2959,11 @@ Example:
 // --- search ---
 
 func searchCmd() *cobra.Command {
-	return &cobra.Command{
+	var collection string
+	var status string
+	var priority string
+
+	cmd := &cobra.Command{
 		Use:   "search <query>",
 		Short: "Full-text search across all items",
 		Args:  cobra.MinimumNArgs(1),
@@ -2970,6 +2974,15 @@ func searchCmd() *cobra.Command {
 			params := url.Values{}
 			params.Set("q", strings.Join(args, " "))
 			params.Set("workspace", ws)
+			if collection != "" {
+				params.Set("collection", normalizeCollectionSlug(collection))
+			}
+			if status != "" {
+				params.Set("status", status)
+			}
+			if priority != "" {
+				params.Set("priority", priority)
+			}
 
 			result, err := client.SearchItems(params)
 			if err != nil {
@@ -3015,6 +3028,12 @@ func searchCmd() *cobra.Command {
 			return nil
 		},
 	}
+
+	cmd.Flags().StringVarP(&collection, "collection", "c", "", "filter by collection (e.g. tasks, ideas)")
+	cmd.Flags().StringVar(&status, "status", "", "filter by status (e.g. open, done)")
+	cmd.Flags().StringVar(&priority, "priority", "", "filter by priority (e.g. high, medium)")
+
+	return cmd
 }
 
 // --- status ---

--- a/internal/server/handlers_search.go
+++ b/internal/server/handlers_search.go
@@ -2,10 +2,14 @@ package server
 
 import (
 	"net/http"
+	"regexp"
 	"strings"
 
 	"github.com/xarmian/pad/internal/store"
 )
+
+// safeFieldKey matches safe JSON field keys: starts with a letter, alphanumeric/underscore/hyphen.
+var safeFieldKey = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9_-]*$`)
 
 func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 	query := r.URL.Query().Get("q")
@@ -32,6 +36,9 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 	for key, values := range r.URL.Query() {
 		if strings.HasPrefix(key, "field.") && len(values) > 0 && values[0] != "" {
 			fieldKey := strings.TrimPrefix(key, "field.")
+			if !safeFieldKey.MatchString(fieldKey) {
+				continue // skip keys with unsafe characters
+			}
 			fieldFilters[fieldKey] = values[0]
 		}
 	}

--- a/internal/server/handlers_search.go
+++ b/internal/server/handlers_search.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/xarmian/pad/internal/store"
 )
@@ -14,8 +15,28 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 	}
 
 	params := store.SearchParams{
-		Query:     query,
-		Workspace: r.URL.Query().Get("workspace"),
+		Query:      query,
+		Workspace:  r.URL.Query().Get("workspace"),
+		Collection: r.URL.Query().Get("collection"),
+	}
+
+	// Parse field filters: status, priority as top-level params,
+	// plus generic field.* params (e.g. field.category=backend).
+	fieldFilters := make(map[string]string)
+	if v := r.URL.Query().Get("status"); v != "" {
+		fieldFilters["status"] = v
+	}
+	if v := r.URL.Query().Get("priority"); v != "" {
+		fieldFilters["priority"] = v
+	}
+	for key, values := range r.URL.Query() {
+		if strings.HasPrefix(key, "field.") && len(values) > 0 && values[0] != "" {
+			fieldKey := strings.TrimPrefix(key, "field.")
+			fieldFilters[fieldKey] = values[0]
+		}
+	}
+	if len(fieldFilters) > 0 {
+		params.FieldFilters = fieldFilters
 	}
 
 	// When no specific workspace is given, scope search to the user's

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -28,6 +28,10 @@ type SearchParams struct {
 	WorkspaceIDs  []string // workspace IDs to scope results to (used when no specific workspace is given)
 	CollectionIDs []string // permission filter: restrict to these collection IDs (nil = no filter)
 	ItemIDs       []string // permission filter: additionally allow these specific item IDs (for item-level grants)
+
+	// Content filters (applied on top of permission filters)
+	Collection   string            // collection slug — scope search to a single collection
+	FieldFilters map[string]string // field key → value filters (e.g. {"status": "open", "priority": "high"})
 }
 
 func (s *Store) Search(params SearchParams) ([]SearchResult, error) {
@@ -88,6 +92,16 @@ func (s *Store) Search(params SearchParams) ([]SearchResult, error) {
 			for _, id := range params.ItemIDs {
 				refArgs = append(refArgs, id)
 			}
+		}
+
+		// Apply content filters to ref lookup too
+		if params.Collection != "" {
+			refQuery += ` AND c.slug = ?`
+			refArgs = append(refArgs, params.Collection)
+		}
+		for key, value := range params.FieldFilters {
+			refQuery += ` AND ` + s.dialect.JSONExtractText("i.fields", key) + ` = ?`
+			refArgs = append(refArgs, value)
 		}
 
 		refRows, err := s.db.Query(s.q(refQuery), refArgs...)
@@ -213,6 +227,18 @@ func (s *Store) Search(params SearchParams) ([]SearchResult, error) {
 		for _, id := range params.ItemIDs {
 			args = append(args, id)
 		}
+	}
+
+	// Collection slug filter — scope to a single collection by slug.
+	if params.Collection != "" {
+		query += ` AND c.slug = ?`
+		args = append(args, params.Collection)
+	}
+
+	// Field filters — filter by structured field values in the JSON fields column.
+	for key, value := range params.FieldFilters {
+		query += ` AND ` + s.dialect.JSONExtractText("i.fields", key) + ` = ?`
+		args = append(args, value)
 	}
 
 	// SQLite bm25() returns negative values (more negative = more relevant) → ASC.

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -2,10 +2,14 @@ package store
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/xarmian/pad/internal/models"
 )
+
+// validFieldKey matches safe JSON field keys: alphanumeric, underscores, hyphens only.
+var validFieldKey = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9_-]*$`)
 
 type SearchResult struct {
 	Item    models.Item `json:"item"`
@@ -100,6 +104,9 @@ func (s *Store) Search(params SearchParams) ([]SearchResult, error) {
 			refArgs = append(refArgs, params.Collection)
 		}
 		for key, value := range params.FieldFilters {
+			if !validFieldKey.MatchString(key) {
+				continue // skip unsafe keys
+			}
 			refQuery += ` AND ` + s.dialect.JSONExtractText("i.fields", key) + ` = ?`
 			refArgs = append(refArgs, value)
 		}
@@ -237,6 +244,9 @@ func (s *Store) Search(params SearchParams) ([]SearchResult, error) {
 
 	// Field filters — filter by structured field values in the JSON fields column.
 	for key, value := range params.FieldFilters {
+		if !validFieldKey.MatchString(key) {
+			continue // skip unsafe keys
+		}
 		query += ` AND ` + s.dialect.JSONExtractText("i.fields", key) + ` = ?`
 		args = append(args, value)
 	}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -688,6 +688,158 @@ func TestFTSSearchScoped(t *testing.T) {
 	}
 }
 
+func TestSearchCollectionFilter(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Test")
+	s.SeedDefaultCollections(ws.ID)
+
+	colls, _ := s.ListCollections(ws.ID)
+	var tasksID, ideasID string
+	for _, c := range colls {
+		if c.Slug == "tasks" {
+			tasksID = c.ID
+		}
+		if c.Slug == "ideas" {
+			ideasID = c.ID
+		}
+	}
+
+	s.CreateItem(ws.ID, tasksID, models.ItemCreate{Title: "Fix authentication bug", Fields: `{"status":"open","priority":"high"}`})
+	s.CreateItem(ws.ID, tasksID, models.ItemCreate{Title: "Refactor authentication module", Fields: `{"status":"done","priority":"medium"}`})
+	s.CreateItem(ws.ID, ideasID, models.ItemCreate{Title: "New authentication provider", Fields: `{"status":"new"}`})
+
+	// Unfiltered — should find all 3
+	results, err := s.Search(SearchParams{Query: "authentication", Workspace: ws.Slug})
+	if err != nil {
+		t.Fatalf("unfiltered search: %v", err)
+	}
+	if len(results) != 3 {
+		t.Errorf("unfiltered: expected 3 results, got %d", len(results))
+	}
+
+	// Filter by collection slug — only tasks
+	results, err = s.Search(SearchParams{Query: "authentication", Workspace: ws.Slug, Collection: "tasks"})
+	if err != nil {
+		t.Fatalf("collection filter search: %v", err)
+	}
+	if len(results) != 2 {
+		t.Errorf("collection=tasks: expected 2 results, got %d", len(results))
+	}
+	for _, r := range results {
+		if r.Item.CollectionSlug != "tasks" {
+			t.Errorf("expected collection 'tasks', got %q", r.Item.CollectionSlug)
+		}
+	}
+
+	// Filter by collection slug — only ideas
+	results, err = s.Search(SearchParams{Query: "authentication", Workspace: ws.Slug, Collection: "ideas"})
+	if err != nil {
+		t.Fatalf("collection=ideas search: %v", err)
+	}
+	if len(results) != 1 {
+		t.Errorf("collection=ideas: expected 1 result, got %d", len(results))
+	}
+}
+
+func TestSearchFieldFilters(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Test")
+	s.SeedDefaultCollections(ws.ID)
+
+	colls, _ := s.ListCollections(ws.ID)
+	var tasksID string
+	for _, c := range colls {
+		if c.Slug == "tasks" {
+			tasksID = c.ID
+			break
+		}
+	}
+
+	s.CreateItem(ws.ID, tasksID, models.ItemCreate{Title: "Fix login bug", Fields: `{"status":"open","priority":"high"}`})
+	s.CreateItem(ws.ID, tasksID, models.ItemCreate{Title: "Fix logout bug", Fields: `{"status":"open","priority":"low"}`})
+	s.CreateItem(ws.ID, tasksID, models.ItemCreate{Title: "Fix signup bug", Fields: `{"status":"done","priority":"high"}`})
+
+	// Filter by status=open — should find 2
+	results, err := s.Search(SearchParams{
+		Query:        "bug",
+		Workspace:    ws.Slug,
+		FieldFilters: map[string]string{"status": "open"},
+	})
+	if err != nil {
+		t.Fatalf("field filter search: %v", err)
+	}
+	if len(results) != 2 {
+		t.Errorf("status=open: expected 2 results, got %d", len(results))
+	}
+
+	// Filter by priority=high — should find 2
+	results, err = s.Search(SearchParams{
+		Query:        "bug",
+		Workspace:    ws.Slug,
+		FieldFilters: map[string]string{"priority": "high"},
+	})
+	if err != nil {
+		t.Fatalf("priority filter search: %v", err)
+	}
+	if len(results) != 2 {
+		t.Errorf("priority=high: expected 2 results, got %d", len(results))
+	}
+
+	// Combine filters: status=open AND priority=high — should find 1
+	results, err = s.Search(SearchParams{
+		Query:        "bug",
+		Workspace:    ws.Slug,
+		FieldFilters: map[string]string{"status": "open", "priority": "high"},
+	})
+	if err != nil {
+		t.Fatalf("combined filter search: %v", err)
+	}
+	if len(results) != 1 {
+		t.Errorf("status=open+priority=high: expected 1 result, got %d", len(results))
+	}
+	if len(results) > 0 && results[0].Item.Title != "Fix login bug" {
+		t.Errorf("expected 'Fix login bug', got %q", results[0].Item.Title)
+	}
+}
+
+func TestSearchCollectionAndFieldFilters(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Test")
+	s.SeedDefaultCollections(ws.ID)
+
+	colls, _ := s.ListCollections(ws.ID)
+	var tasksID, ideasID string
+	for _, c := range colls {
+		if c.Slug == "tasks" {
+			tasksID = c.ID
+		}
+		if c.Slug == "ideas" {
+			ideasID = c.ID
+		}
+	}
+
+	s.CreateItem(ws.ID, tasksID, models.ItemCreate{Title: "Improve search speed", Fields: `{"status":"open","priority":"high"}`})
+	s.CreateItem(ws.ID, tasksID, models.ItemCreate{Title: "Search UI redesign", Fields: `{"status":"done","priority":"medium"}`})
+	s.CreateItem(ws.ID, ideasID, models.ItemCreate{Title: "Search autocomplete feature", Fields: `{"status":"new"}`})
+
+	// Collection + field filter: tasks with status=open
+	results, err := s.Search(SearchParams{
+		Query:        "search",
+		Workspace:    ws.Slug,
+		Collection:   "tasks",
+		FieldFilters: map[string]string{"status": "open"},
+	})
+	if err != nil {
+		t.Fatalf("combined collection+field filter: %v", err)
+	}
+	if len(results) != 1 {
+		t.Errorf("tasks+status=open: expected 1 result, got %d", len(results))
+	}
+	if len(results) > 0 && results[0].Item.Title != "Improve search speed" {
+		t.Errorf("expected 'Improve search speed', got %q", results[0].Item.Title)
+	}
+}
+
 func TestContext(t *testing.T) {
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -15,6 +15,7 @@ import type {
 	Version,
 	DashboardResponse,
 	SearchResponse,
+	SearchFilters,
 	Activity,
 	ApiError,
 	WorkspaceTemplate,
@@ -450,9 +451,17 @@ export const api = {
 
 	// ── Search ────────────────────────────────────────────────────────────────
 
-	search: (query: string, workspace?: string) => {
+	search: (query: string, filters?: SearchFilters) => {
 		const params: Record<string, string> = { q: query };
-		if (workspace) params.workspace = workspace;
+		if (filters?.workspace) params.workspace = filters.workspace;
+		if (filters?.collection) params.collection = filters.collection;
+		if (filters?.status) params.status = filters.status;
+		if (filters?.priority) params.priority = filters.priority;
+		if (filters?.fields) {
+			for (const [key, value] of Object.entries(filters.fields)) {
+				params[`field.${key}`] = value;
+			}
+		}
 		return request<SearchResponse>(`/search?${new URLSearchParams(params).toString()}`);
 	},
 

--- a/web/src/lib/components/search/CommandPalette.svelte
+++ b/web/src/lib/components/search/CommandPalette.svelte
@@ -31,7 +31,7 @@
 		searchTimeout = setTimeout(async () => {
 			const ws = workspaceStore.current?.slug;
 			try {
-				const resp = await api.search(query, ws);
+				const resp = await api.search(query, { workspace: ws });
 				results = resp.results;
 				selectedIdx = 0;
 			} catch {

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -645,6 +645,14 @@ export interface SearchResponse {
 	total: number;
 }
 
+export interface SearchFilters {
+	workspace?: string;
+	collection?: string;
+	status?: string;
+	priority?: string;
+	fields?: Record<string, string>;
+}
+
 // ─── Convention Library ──────────────────────────────────────────────────────
 
 export interface LibraryConvention {

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -556,7 +556,7 @@
 		}
 		addLinkLoading = true;
 		try {
-			const results = await api.search(addLinkSearch, wsSlug);
+			const results = await api.search(addLinkSearch, { workspace: wsSlug });
 			// Filter out self and items already linked
 			const linkedIds = new Set(itemLinks.flatMap(l => [l.source_id, l.target_id]));
 			addLinkResults = (results.results || [])


### PR DESCRIPTION
## Summary

- Extends the `/search` API endpoint to support **collection scoping** (`?collection=tasks`) and **field filtering** (`?status=open`, `?priority=high`, `?field.category=backend`)
- Filters apply to both FTS queries and item ref lookups, work on both SQLite and PostgreSQL
- Updates the frontend `api.search()` to accept a `SearchFilters` object, and adds `--collection`, `--status`, `--priority` flags to the CLI `pad item search` command

Part of PLAN-573 (First-Class Search) — implements TASK-574.

## Test plan

- [x] `TestSearchCollectionFilter` — verifies collection slug scoping returns only matching collection items
- [x] `TestSearchFieldFilters` — verifies single field, combined field, and status+priority filters
- [x] `TestSearchCollectionAndFieldFilters` — verifies combining collection + field filters
- [x] Full `go test ./...` passes
- [x] `npm run build` succeeds (frontend compiles with updated types)
- [x] Smoke tested live: `pad item search "auth" --collection tasks`, `pad item search "search" --status open`