### PR TITLE
feat: add pagination and sorting to search API

### DIFF
--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -2962,6 +2962,9 @@ func searchCmd() *cobra.Command {
 	var collection string
 	var status string
 	var priority string
+	var sort string
+	var limit int
+	var offset int
 
 	cmd := &cobra.Command{
 		Use:   "search <query>",
@@ -2983,6 +2986,15 @@ func searchCmd() *cobra.Command {
 			if priority != "" {
 				params.Set("priority", priority)
 			}
+			if sort != "" {
+				params.Set("sort", sort)
+			}
+			if limit > 0 {
+				params.Set("limit", fmt.Sprintf("%d", limit))
+			}
+			if offset > 0 {
+				params.Set("offset", fmt.Sprintf("%d", offset))
+			}
 
 			result, err := client.SearchItems(params)
 			if err != nil {
@@ -2999,7 +3011,9 @@ func searchCmd() *cobra.Command {
 					Item    models.Item `json:"item"`
 					Snippet string      `json:"snippet"`
 				} `json:"results"`
-				Total int `json:"total"`
+				Total  int `json:"total"`
+				Limit  int `json:"limit"`
+				Offset int `json:"offset"`
 			}
 
 			if err := json.Unmarshal(result, &searchResp); err != nil {
@@ -3024,7 +3038,13 @@ func searchCmd() *cobra.Command {
 				}
 				fmt.Println()
 			}
-			fmt.Printf("%d result(s)\n", searchResp.Total)
+
+			showing := len(searchResp.Results)
+			if searchResp.Offset > 0 || showing < searchResp.Total {
+				fmt.Printf("Showing %d-%d of %d result(s)\n", searchResp.Offset+1, searchResp.Offset+showing, searchResp.Total)
+			} else {
+				fmt.Printf("%d result(s)\n", searchResp.Total)
+			}
 			return nil
 		},
 	}
@@ -3032,6 +3052,9 @@ func searchCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&collection, "collection", "c", "", "filter by collection (e.g. tasks, ideas)")
 	cmd.Flags().StringVar(&status, "status", "", "filter by status (e.g. open, done)")
 	cmd.Flags().StringVar(&priority, "priority", "", "filter by priority (e.g. high, medium)")
+	cmd.Flags().StringVar(&sort, "sort", "", "sort by: relevance (default), created_at, updated_at, title")
+	cmd.Flags().IntVar(&limit, "limit", 0, "max results to return (default 50, max 200)")
+	cmd.Flags().IntVar(&offset, "offset", 0, "skip this many results (for pagination)")
 
 	return cmd
 }

--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -3040,7 +3040,9 @@ func searchCmd() *cobra.Command {
 			}
 
 			showing := len(searchResp.Results)
-			if searchResp.Offset > 0 || showing < searchResp.Total {
+			if showing == 0 && searchResp.Total > 0 {
+				fmt.Printf("No results on this page (%d total, offset %d)\n", searchResp.Total, searchResp.Offset)
+			} else if searchResp.Offset > 0 || showing < searchResp.Total {
 				fmt.Printf("Showing %d-%d of %d result(s)\n", searchResp.Offset+1, searchResp.Offset+showing, searchResp.Total)
 			} else {
 				fmt.Printf("%d result(s)\n", searchResp.Total)

--- a/internal/server/handlers_search.go
+++ b/internal/server/handlers_search.go
@@ -3,6 +3,7 @@ package server
 import (
 	"net/http"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/xarmian/pad/internal/store"
@@ -46,6 +47,25 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 		params.FieldFilters = fieldFilters
 	}
 
+	// Parse pagination params
+	if v := r.URL.Query().Get("limit"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			params.Limit = n
+		}
+	}
+	if v := r.URL.Query().Get("offset"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			params.Offset = n
+		}
+	}
+
+	// Parse sort params
+	params.Sort = r.URL.Query().Get("sort")
+	params.Order = r.URL.Query().Get("order")
+
+	// Normalize defaults early so early-return paths have correct values.
+	params.Normalize()
+
 	// When no specific workspace is given, scope search to the user's
 	// workspaces so results never leak across workspace boundaries.
 	if params.Workspace == "" {
@@ -61,9 +81,10 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 			}
 			// If user has no workspaces, return empty results
 			if len(params.WorkspaceIDs) == 0 {
-				writeJSON(w, http.StatusOK, map[string]interface{}{
-					"results": []store.SearchResult{},
-					"total":   0,
+				writeJSON(w, http.StatusOK, &store.SearchResponse{
+					Results: []store.SearchResult{},
+					Limit:   params.Limit,
+					Offset:  params.Offset,
 				})
 				return
 			}
@@ -198,19 +219,13 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	results, err := s.store.Search(params)
+	resp, err := s.store.Search(params)
 	if err != nil {
 		writeInternalError(w, err)
 		return
 	}
-	if results == nil {
-		results = []store.SearchResult{}
-	}
 
-	writeJSON(w, http.StatusOK, map[string]interface{}{
-		"results": results,
-		"total":   len(results),
-	})
+	writeJSON(w, http.StatusOK, resp)
 }
 
 func removeString(ss []string, s string) []string {

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -333,12 +333,37 @@ func (s *Store) Search(params SearchParams) (*SearchResponse, error) {
 		total = -1
 	}
 
-	// --- Sorting ---
+	// --- Sorting (with deterministic tie-breaker for stable pagination) ---
 	orderClause := s.searchOrderClause(params)
 	query += orderClause
 
 	// --- Pagination ---
-	query += fmt.Sprintf(" LIMIT %d OFFSET %d", params.Limit, params.Offset)
+	// Ref hits (if any) occupy slots on page 0. Adjust FTS limit/offset
+	// so the combined result set respects the requested pagination.
+	refCount := len(results)
+	ftsLimit := params.Limit
+	ftsOffset := params.Offset
+	if refCount > 0 {
+		if params.Offset == 0 {
+			// Page 0: ref hits fill first slots, FTS fills the rest
+			ftsLimit = params.Limit - refCount
+			if ftsLimit < 0 {
+				ftsLimit = 0
+			}
+		} else {
+			// Subsequent pages: ref hits were on page 0, adjust offset
+			ftsOffset = params.Offset - refCount
+			if ftsOffset < 0 {
+				ftsOffset = 0
+			}
+		}
+	}
+	query += fmt.Sprintf(" LIMIT %d OFFSET %d", ftsLimit, ftsOffset)
+
+	// On pages after 0, ref hits were already shown — don't include them again.
+	if params.Offset > 0 && refCount > 0 {
+		results = nil
+	}
 
 	rows, err := s.db.Query(s.q(query), args...)
 	if err != nil {
@@ -458,21 +483,22 @@ func (s *Store) appendSearchFilters(query string, args []interface{}, params Sea
 }
 
 // searchOrderClause returns the ORDER BY clause for search results.
+// Includes i.id as a tie-breaker for deterministic pagination.
 func (s *Store) searchOrderClause(params SearchParams) string {
 	switch params.Sort {
 	case "created_at":
-		return fmt.Sprintf(" ORDER BY i.created_at %s", params.Order)
+		return fmt.Sprintf(" ORDER BY i.created_at %s, i.id", params.Order)
 	case "updated_at":
-		return fmt.Sprintf(" ORDER BY i.updated_at %s", params.Order)
+		return fmt.Sprintf(" ORDER BY i.updated_at %s, i.id", params.Order)
 	case "title":
-		return fmt.Sprintf(" ORDER BY i.title %s", params.Order)
+		return fmt.Sprintf(" ORDER BY i.title %s, i.id", params.Order)
 	default: // "relevance"
 		// SQLite bm25() returns negative values (more negative = more relevant) → ASC.
 		// PostgreSQL ts_rank() returns positive values (higher = more relevant) → DESC.
 		if s.dialect.Driver() == DriverPostgres {
-			return " ORDER BY rank_score DESC"
+			return " ORDER BY rank_score DESC, i.id"
 		}
-		return " ORDER BY rank_score"
+		return " ORDER BY rank_score, i.id"
 	}
 }
 

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -17,6 +17,13 @@ type SearchResult struct {
 	Rank    float64     `json:"rank"`
 }
 
+type SearchResponse struct {
+	Results []SearchResult `json:"results"`
+	Total   int            `json:"total"`
+	Limit   int            `json:"limit"`
+	Offset  int            `json:"offset"`
+}
+
 // placeholders returns a comma-separated string of SQL placeholders: "?, ?, ?"
 func placeholders(n int) string {
 	if n <= 0 {
@@ -36,15 +43,52 @@ type SearchParams struct {
 	// Content filters (applied on top of permission filters)
 	Collection   string            // collection slug — scope search to a single collection
 	FieldFilters map[string]string // field key → value filters (e.g. {"status": "open", "priority": "high"})
+
+	// Pagination
+	Limit  int // max results per page (default 50, max 200)
+	Offset int // skip this many results
+
+	// Sorting: "relevance" (default), "created_at", "updated_at", "title"
+	Sort  string // sort field
+	Order string // "asc" or "desc" (default depends on sort field)
 }
 
-func (s *Store) Search(params SearchParams) ([]SearchResult, error) {
+// Normalize sets pagination and sorting defaults on SearchParams.
+func (p *SearchParams) Normalize() {
+	if p.Limit <= 0 {
+		p.Limit = 50
+	}
+	if p.Limit > 200 {
+		p.Limit = 200
+	}
+	if p.Offset < 0 {
+		p.Offset = 0
+	}
+	if p.Sort == "" {
+		p.Sort = "relevance"
+	}
+	if p.Order == "" {
+		switch p.Sort {
+		case "title":
+			p.Order = "asc"
+		default:
+			p.Order = "desc"
+		}
+	}
+	if p.Order != "asc" && p.Order != "desc" {
+		p.Order = "desc"
+	}
+}
+
+func (s *Store) Search(params SearchParams) (*SearchResponse, error) {
+	params.Normalize()
+
 	// Non-nil empty CollectionIDs means "no visible collections" — return
 	// empty results immediately, unless ItemIDs are also provided (item-level
 	// grants may still allow access to specific items even without full
 	// collection access).
 	if params.CollectionIDs != nil && len(params.CollectionIDs) == 0 && len(params.ItemIDs) == 0 {
-		return nil, nil
+		return &SearchResponse{Results: []SearchResult{}, Limit: params.Limit, Offset: params.Offset}, nil
 	}
 
 	var results []SearchResult
@@ -251,20 +295,60 @@ func (s *Store) Search(params SearchParams) ([]SearchResult, error) {
 		args = append(args, value)
 	}
 
-	// SQLite bm25() returns negative values (more negative = more relevant) → ASC.
-	// PostgreSQL ts_rank() returns positive values (higher = more relevant) → DESC.
+	// --- Count query (total matching results before pagination) ---
+	// Build the count query by replacing the SELECT columns with COUNT(*).
+	// We reuse the same WHERE/JOIN clauses.
+	var countQuery string
+	countArgs := make([]interface{}, len(args))
+	copy(countArgs, args)
+
 	if s.dialect.Driver() == DriverPostgres {
-		query += " ORDER BY rank_score DESC LIMIT 50"
+		ftsMatch := s.dialect.FTSMatch("i", "search_vector")
+		countQuery = fmt.Sprintf(`
+			SELECT COUNT(*)
+			FROM items i
+			JOIN collections c ON c.id = i.collection_id
+			WHERE %s AND i.deleted_at IS NULL
+		`, ftsMatch)
+		countArgs = []interface{}{params.Query}
 	} else {
-		query += " ORDER BY rank_score LIMIT 50"
+		ftsMatch := s.dialect.FTSMatch("items_fts", "search_vector")
+		countQuery = fmt.Sprintf(`
+			SELECT COUNT(*)
+			FROM items_fts fts
+			JOIN items i ON i.rowid = fts.rowid
+			JOIN collections c ON c.id = i.collection_id
+			WHERE %s AND i.deleted_at IS NULL
+		`, ftsMatch)
+		countArgs = []interface{}{sanitizeFTSQuery(params.Query)}
 	}
+
+	// Replay the same filters for the count query
+	countQuery, countArgs = s.appendSearchFilters(countQuery, countArgs, params)
+
+	var total int
+	countErr := s.db.QueryRow(s.q(countQuery), countArgs...).Scan(&total)
+	if countErr != nil {
+		// Count failure is non-fatal — fall back to reporting result count
+		total = -1
+	}
+
+	// --- Sorting ---
+	orderClause := s.searchOrderClause(params)
+	query += orderClause
+
+	// --- Pagination ---
+	query += fmt.Sprintf(" LIMIT %d OFFSET %d", params.Limit, params.Offset)
 
 	rows, err := s.db.Query(s.q(query), args...)
 	if err != nil {
 		// If we already have a ref match, return that instead of failing
 		// (FTS5 may reject queries like "TASK-5" due to special syntax)
 		if len(results) > 0 {
-			return results, nil
+			if total < 0 {
+				total = len(results)
+			}
+			return &SearchResponse{Results: results, Total: total, Limit: params.Limit, Offset: params.Offset}, nil
 		}
 		return nil, fmt.Errorf("search: %w", err)
 	}
@@ -306,7 +390,82 @@ func (s *Store) Search(params SearchParams) ([]SearchResult, error) {
 		r.Item.Content = ""
 		results = append(results, r)
 	}
-	return results, rows.Err()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	if total < 0 {
+		total = len(results)
+	}
+	return &SearchResponse{Results: results, Total: total, Limit: params.Limit, Offset: params.Offset}, nil
+}
+
+// appendSearchFilters adds workspace, collection, and field filter clauses to a query.
+// Used to keep count and results queries in sync.
+func (s *Store) appendSearchFilters(query string, args []interface{}, params SearchParams) (string, []interface{}) {
+	if params.Workspace != "" {
+		query += ` AND i.workspace_id = (SELECT id FROM workspaces WHERE slug = ? AND deleted_at IS NULL)`
+		args = append(args, params.Workspace)
+	} else if len(params.WorkspaceIDs) > 0 {
+		query += ` AND i.workspace_id IN (` + placeholders(len(params.WorkspaceIDs)) + `)`
+		for _, id := range params.WorkspaceIDs {
+			args = append(args, id)
+		}
+	}
+
+	if len(params.CollectionIDs) > 0 && len(params.ItemIDs) > 0 {
+		query += ` AND (i.collection_id IN (` + placeholders(len(params.CollectionIDs)) + `) OR i.id IN (` + placeholders(len(params.ItemIDs)) + `))`
+		for _, id := range params.CollectionIDs {
+			args = append(args, id)
+		}
+		for _, id := range params.ItemIDs {
+			args = append(args, id)
+		}
+	} else if len(params.CollectionIDs) > 0 {
+		query += ` AND i.collection_id IN (` + placeholders(len(params.CollectionIDs)) + `)`
+		for _, id := range params.CollectionIDs {
+			args = append(args, id)
+		}
+	} else if len(params.ItemIDs) > 0 {
+		query += ` AND i.id IN (` + placeholders(len(params.ItemIDs)) + `)`
+		for _, id := range params.ItemIDs {
+			args = append(args, id)
+		}
+	}
+
+	if params.Collection != "" {
+		query += ` AND c.slug = ?`
+		args = append(args, params.Collection)
+	}
+
+	for key, value := range params.FieldFilters {
+		if !validFieldKey.MatchString(key) {
+			continue
+		}
+		query += ` AND ` + s.dialect.JSONExtractText("i.fields", key) + ` = ?`
+		args = append(args, value)
+	}
+
+	return query, args
+}
+
+// searchOrderClause returns the ORDER BY clause for search results.
+func (s *Store) searchOrderClause(params SearchParams) string {
+	switch params.Sort {
+	case "created_at":
+		return fmt.Sprintf(" ORDER BY i.created_at %s", params.Order)
+	case "updated_at":
+		return fmt.Sprintf(" ORDER BY i.updated_at %s", params.Order)
+	case "title":
+		return fmt.Sprintf(" ORDER BY i.title %s", params.Order)
+	default: // "relevance"
+		// SQLite bm25() returns negative values (more negative = more relevant) → ASC.
+		// PostgreSQL ts_rank() returns positive values (higher = more relevant) → DESC.
+		if s.dialect.Driver() == DriverPostgres {
+			return " ORDER BY rank_score DESC"
+		}
+		return " ORDER BY rank_score"
+	}
 }
 
 // sanitizeFTSQuery wraps each token in double quotes so FTS5 treats

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -397,6 +397,14 @@ func (s *Store) Search(params SearchParams) (*SearchResponse, error) {
 	if total < 0 {
 		total = len(results)
 	}
+
+	// The count query only covers FTS hits, but direct ref lookups (e.g.
+	// searching "TASK-5") can return matches not in the FTS index. Ensure
+	// total is never less than actual results returned.
+	if len(seen) > 0 && total < len(results) {
+		total = len(results)
+	}
+
 	return &SearchResponse{Results: results, Total: total, Limit: params.Limit, Offset: params.Offset}, nil
 }
 

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -637,15 +637,15 @@ func TestFTSSearch(t *testing.T) {
 	s.CreateItem(ws.ID, docsCollID, models.ItemCreate{Title: "Auth Flow", Content: "OAuth2 authentication flow for API"})
 	s.CreateItem(ws.ID, docsCollID, models.ItemCreate{Title: "Data Model", Content: "Database schema and models"})
 
-	results, err := s.Search(SearchParams{Query: "authentication"})
+	resp, err := s.Search(SearchParams{Query: "authentication"})
 	if err != nil {
 		t.Fatalf("Search error: %v", err)
 	}
-	if len(results) != 1 {
-		t.Errorf("expected 1 result, got %d", len(results))
+	if len(resp.Results) != 1 {
+		t.Errorf("expected 1 result, got %d", len(resp.Results))
 	}
-	if len(results) > 0 && results[0].Item.Title != "Auth Flow" {
-		t.Errorf("expected 'Auth Flow', got %q", results[0].Item.Title)
+	if len(resp.Results) > 0 && resp.Results[0].Item.Title != "Auth Flow" {
+		t.Errorf("expected 'Auth Flow', got %q", resp.Results[0].Item.Title)
 	}
 }
 
@@ -676,15 +676,15 @@ func TestFTSSearchScoped(t *testing.T) {
 	s.CreateItem(ws2.ID, docs2ID, models.ItemCreate{Title: "Doc B", Content: "authentication in workspace 2"})
 
 	// Unscoped — should find both
-	results, _ := s.Search(SearchParams{Query: "authentication"})
-	if len(results) != 2 {
-		t.Errorf("unscoped: expected 2 results, got %d", len(results))
+	resp, _ := s.Search(SearchParams{Query: "authentication"})
+	if len(resp.Results) != 2 {
+		t.Errorf("unscoped: expected 2 results, got %d", len(resp.Results))
 	}
 
 	// Scoped — should find one
-	results, _ = s.Search(SearchParams{Query: "authentication", Workspace: ws1.Slug})
-	if len(results) != 1 {
-		t.Errorf("scoped: expected 1 result, got %d", len(results))
+	resp, _ = s.Search(SearchParams{Query: "authentication", Workspace: ws1.Slug})
+	if len(resp.Results) != 1 {
+		t.Errorf("scoped: expected 1 result, got %d", len(resp.Results))
 	}
 }
 
@@ -709,35 +709,35 @@ func TestSearchCollectionFilter(t *testing.T) {
 	s.CreateItem(ws.ID, ideasID, models.ItemCreate{Title: "New authentication provider", Fields: `{"status":"new"}`})
 
 	// Unfiltered — should find all 3
-	results, err := s.Search(SearchParams{Query: "authentication", Workspace: ws.Slug})
+	resp, err := s.Search(SearchParams{Query: "authentication", Workspace: ws.Slug})
 	if err != nil {
 		t.Fatalf("unfiltered search: %v", err)
 	}
-	if len(results) != 3 {
-		t.Errorf("unfiltered: expected 3 results, got %d", len(results))
+	if len(resp.Results) != 3 {
+		t.Errorf("unfiltered: expected 3 results, got %d", len(resp.Results))
 	}
 
 	// Filter by collection slug — only tasks
-	results, err = s.Search(SearchParams{Query: "authentication", Workspace: ws.Slug, Collection: "tasks"})
+	resp, err = s.Search(SearchParams{Query: "authentication", Workspace: ws.Slug, Collection: "tasks"})
 	if err != nil {
 		t.Fatalf("collection filter search: %v", err)
 	}
-	if len(results) != 2 {
-		t.Errorf("collection=tasks: expected 2 results, got %d", len(results))
+	if len(resp.Results) != 2 {
+		t.Errorf("collection=tasks: expected 2 results, got %d", len(resp.Results))
 	}
-	for _, r := range results {
+	for _, r := range resp.Results {
 		if r.Item.CollectionSlug != "tasks" {
 			t.Errorf("expected collection 'tasks', got %q", r.Item.CollectionSlug)
 		}
 	}
 
 	// Filter by collection slug — only ideas
-	results, err = s.Search(SearchParams{Query: "authentication", Workspace: ws.Slug, Collection: "ideas"})
+	resp, err = s.Search(SearchParams{Query: "authentication", Workspace: ws.Slug, Collection: "ideas"})
 	if err != nil {
 		t.Fatalf("collection=ideas search: %v", err)
 	}
-	if len(results) != 1 {
-		t.Errorf("collection=ideas: expected 1 result, got %d", len(results))
+	if len(resp.Results) != 1 {
+		t.Errorf("collection=ideas: expected 1 result, got %d", len(resp.Results))
 	}
 }
 
@@ -760,7 +760,7 @@ func TestSearchFieldFilters(t *testing.T) {
 	s.CreateItem(ws.ID, tasksID, models.ItemCreate{Title: "Fix signup bug", Fields: `{"status":"done","priority":"high"}`})
 
 	// Filter by status=open — should find 2
-	results, err := s.Search(SearchParams{
+	resp, err := s.Search(SearchParams{
 		Query:        "bug",
 		Workspace:    ws.Slug,
 		FieldFilters: map[string]string{"status": "open"},
@@ -768,12 +768,12 @@ func TestSearchFieldFilters(t *testing.T) {
 	if err != nil {
 		t.Fatalf("field filter search: %v", err)
 	}
-	if len(results) != 2 {
-		t.Errorf("status=open: expected 2 results, got %d", len(results))
+	if len(resp.Results) != 2 {
+		t.Errorf("status=open: expected 2 results, got %d", len(resp.Results))
 	}
 
 	// Filter by priority=high — should find 2
-	results, err = s.Search(SearchParams{
+	resp, err = s.Search(SearchParams{
 		Query:        "bug",
 		Workspace:    ws.Slug,
 		FieldFilters: map[string]string{"priority": "high"},
@@ -781,12 +781,12 @@ func TestSearchFieldFilters(t *testing.T) {
 	if err != nil {
 		t.Fatalf("priority filter search: %v", err)
 	}
-	if len(results) != 2 {
-		t.Errorf("priority=high: expected 2 results, got %d", len(results))
+	if len(resp.Results) != 2 {
+		t.Errorf("priority=high: expected 2 results, got %d", len(resp.Results))
 	}
 
 	// Combine filters: status=open AND priority=high — should find 1
-	results, err = s.Search(SearchParams{
+	resp, err = s.Search(SearchParams{
 		Query:        "bug",
 		Workspace:    ws.Slug,
 		FieldFilters: map[string]string{"status": "open", "priority": "high"},
@@ -794,11 +794,11 @@ func TestSearchFieldFilters(t *testing.T) {
 	if err != nil {
 		t.Fatalf("combined filter search: %v", err)
 	}
-	if len(results) != 1 {
-		t.Errorf("status=open+priority=high: expected 1 result, got %d", len(results))
+	if len(resp.Results) != 1 {
+		t.Errorf("status=open+priority=high: expected 1 result, got %d", len(resp.Results))
 	}
-	if len(results) > 0 && results[0].Item.Title != "Fix login bug" {
-		t.Errorf("expected 'Fix login bug', got %q", results[0].Item.Title)
+	if len(resp.Results) > 0 && resp.Results[0].Item.Title != "Fix login bug" {
+		t.Errorf("expected 'Fix login bug', got %q", resp.Results[0].Item.Title)
 	}
 }
 
@@ -823,7 +823,7 @@ func TestSearchCollectionAndFieldFilters(t *testing.T) {
 	s.CreateItem(ws.ID, ideasID, models.ItemCreate{Title: "Search autocomplete feature", Fields: `{"status":"new"}`})
 
 	// Collection + field filter: tasks with status=open
-	results, err := s.Search(SearchParams{
+	resp, err := s.Search(SearchParams{
 		Query:        "search",
 		Workspace:    ws.Slug,
 		Collection:   "tasks",
@@ -832,11 +832,137 @@ func TestSearchCollectionAndFieldFilters(t *testing.T) {
 	if err != nil {
 		t.Fatalf("combined collection+field filter: %v", err)
 	}
-	if len(results) != 1 {
-		t.Errorf("tasks+status=open: expected 1 result, got %d", len(results))
+	if len(resp.Results) != 1 {
+		t.Errorf("tasks+status=open: expected 1 result, got %d", len(resp.Results))
 	}
-	if len(results) > 0 && results[0].Item.Title != "Improve search speed" {
-		t.Errorf("expected 'Improve search speed', got %q", results[0].Item.Title)
+	if len(resp.Results) > 0 && resp.Results[0].Item.Title != "Improve search speed" {
+		t.Errorf("expected 'Improve search speed', got %q", resp.Results[0].Item.Title)
+	}
+}
+
+func TestSearchPagination(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Test")
+	s.SeedDefaultCollections(ws.ID)
+
+	colls, _ := s.ListCollections(ws.ID)
+	var tasksID string
+	for _, c := range colls {
+		if c.Slug == "tasks" {
+			tasksID = c.ID
+			break
+		}
+	}
+
+	// Create 5 items all matching "widget"
+	for i := 0; i < 5; i++ {
+		s.CreateItem(ws.ID, tasksID, models.ItemCreate{
+			Title:  fmt.Sprintf("Widget task %d", i+1),
+			Fields: `{"status":"open","priority":"medium"}`,
+		})
+	}
+
+	// Default pagination — should get all 5
+	resp, err := s.Search(SearchParams{Query: "widget", Workspace: ws.Slug})
+	if err != nil {
+		t.Fatalf("default pagination: %v", err)
+	}
+	if resp.Total != 5 {
+		t.Errorf("expected total=5, got %d", resp.Total)
+	}
+	if len(resp.Results) != 5 {
+		t.Errorf("expected 5 results, got %d", len(resp.Results))
+	}
+	if resp.Limit != 50 {
+		t.Errorf("expected default limit=50, got %d", resp.Limit)
+	}
+
+	// Limit=2 — should get 2 results but total still 5
+	resp, err = s.Search(SearchParams{Query: "widget", Workspace: ws.Slug, Limit: 2})
+	if err != nil {
+		t.Fatalf("limit=2: %v", err)
+	}
+	if resp.Total != 5 {
+		t.Errorf("expected total=5, got %d", resp.Total)
+	}
+	if len(resp.Results) != 2 {
+		t.Errorf("expected 2 results, got %d", len(resp.Results))
+	}
+	if resp.Limit != 2 {
+		t.Errorf("expected limit=2, got %d", resp.Limit)
+	}
+
+	// Offset=3, Limit=2 — should get 2 results (items 4 and 5)
+	resp, err = s.Search(SearchParams{Query: "widget", Workspace: ws.Slug, Limit: 2, Offset: 3})
+	if err != nil {
+		t.Fatalf("offset=3, limit=2: %v", err)
+	}
+	if resp.Total != 5 {
+		t.Errorf("expected total=5, got %d", resp.Total)
+	}
+	if len(resp.Results) != 2 {
+		t.Errorf("expected 2 results, got %d", len(resp.Results))
+	}
+	if resp.Offset != 3 {
+		t.Errorf("expected offset=3, got %d", resp.Offset)
+	}
+
+	// Offset beyond results — should get 0 results
+	resp, err = s.Search(SearchParams{Query: "widget", Workspace: ws.Slug, Offset: 10})
+	if err != nil {
+		t.Fatalf("offset=10: %v", err)
+	}
+	if resp.Total != 5 {
+		t.Errorf("expected total=5, got %d", resp.Total)
+	}
+	if len(resp.Results) != 0 {
+		t.Errorf("expected 0 results, got %d", len(resp.Results))
+	}
+}
+
+func TestSearchSorting(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Test")
+	s.SeedDefaultCollections(ws.ID)
+
+	colls, _ := s.ListCollections(ws.ID)
+	var tasksID string
+	for _, c := range colls {
+		if c.Slug == "tasks" {
+			tasksID = c.ID
+			break
+		}
+	}
+
+	s.CreateItem(ws.ID, tasksID, models.ItemCreate{Title: "Alpha gadget", Fields: `{"status":"open"}`})
+	s.CreateItem(ws.ID, tasksID, models.ItemCreate{Title: "Charlie gadget", Fields: `{"status":"open"}`})
+	s.CreateItem(ws.ID, tasksID, models.ItemCreate{Title: "Bravo gadget", Fields: `{"status":"open"}`})
+
+	// Sort by title ascending
+	resp, err := s.Search(SearchParams{Query: "gadget", Workspace: ws.Slug, Sort: "title", Order: "asc"})
+	if err != nil {
+		t.Fatalf("sort by title: %v", err)
+	}
+	if len(resp.Results) != 3 {
+		t.Fatalf("expected 3 results, got %d", len(resp.Results))
+	}
+	if resp.Results[0].Item.Title != "Alpha gadget" {
+		t.Errorf("expected first='Alpha gadget', got %q", resp.Results[0].Item.Title)
+	}
+	if resp.Results[2].Item.Title != "Charlie gadget" {
+		t.Errorf("expected last='Charlie gadget', got %q", resp.Results[2].Item.Title)
+	}
+
+	// Sort by title descending
+	resp, err = s.Search(SearchParams{Query: "gadget", Workspace: ws.Slug, Sort: "title", Order: "desc"})
+	if err != nil {
+		t.Fatalf("sort by title desc: %v", err)
+	}
+	if resp.Results[0].Item.Title != "Charlie gadget" {
+		t.Errorf("expected first='Charlie gadget', got %q", resp.Results[0].Item.Title)
+	}
+	if resp.Results[2].Item.Title != "Alpha gadget" {
+		t.Errorf("expected last='Alpha gadget', got %q", resp.Results[2].Item.Title)
 	}
 }
 

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -457,6 +457,10 @@ export const api = {
 		if (filters?.collection) params.collection = filters.collection;
 		if (filters?.status) params.status = filters.status;
 		if (filters?.priority) params.priority = filters.priority;
+		if (filters?.limit) params.limit = String(filters.limit);
+		if (filters?.offset) params.offset = String(filters.offset);
+		if (filters?.sort) params.sort = filters.sort;
+		if (filters?.order) params.order = filters.order;
 		if (filters?.fields) {
 			for (const [key, value] of Object.entries(filters.fields)) {
 				params[`field.${key}`] = value;

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -643,6 +643,8 @@ export interface SearchResult {
 export interface SearchResponse {
 	results: SearchResult[];
 	total: number;
+	limit: number;
+	offset: number;
 }
 
 export interface SearchFilters {
@@ -651,6 +653,10 @@ export interface SearchFilters {
 	status?: string;
 	priority?: string;
 	fields?: Record<string, string>;
+	limit?: number;
+	offset?: number;
+	sort?: 'relevance' | 'created_at' | 'updated_at' | 'title';
+	order?: 'asc' | 'desc';
 }
 
 // ─── Convention Library ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Adds `limit`/`offset` pagination and `sort`/`order` params to the `/search` API endpoint
- Response now returns `total` (full result count), `limit`, and `offset` metadata for frontend pagination
- Sort options: `relevance` (default), `created_at`, `updated_at`, `title` with `asc`/`desc` ordering
- CLI gets `--sort`, `--limit`, `--offset` flags; shows "Showing X-Y of Z" when paginated

Part of PLAN-573 (First-Class Search) — implements TASK-575.

## Test plan

- [x] `TestSearchPagination` — verifies limit, offset, total count across pages, offset beyond results
- [x] `TestSearchSorting` — verifies title sort asc/desc ordering
- [x] All existing search tests updated for new `SearchResponse` return type and pass
- [x] Full `go test ./...` passes
- [x] `npm run build` succeeds
- [x] Smoke tested: `pad item search "search" --limit 2`, `--limit 2 --offset 2`, `--sort title`