### PR TITLE
feat: add faceted counts to search results

### DIFF
--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -17,11 +17,17 @@ type SearchResult struct {
 	Rank    float64     `json:"rank"`
 }
 
+type SearchFacets struct {
+	Collections map[string]int `json:"collections"` // collection slug → count
+	Statuses    map[string]int `json:"statuses"`    // status value → count
+}
+
 type SearchResponse struct {
 	Results []SearchResult `json:"results"`
 	Total   int            `json:"total"`
 	Limit   int            `json:"limit"`
 	Offset  int            `json:"offset"`
+	Facets  *SearchFacets  `json:"facets,omitempty"`
 }
 
 // placeholders returns a comma-separated string of SQL placeholders: "?, ?, ?"
@@ -333,6 +339,9 @@ func (s *Store) Search(params SearchParams) (*SearchResponse, error) {
 		total = -1
 	}
 
+	// --- Faceted counts (full result set, not paginated) ---
+	facets := s.searchFacets(params)
+
 	// --- Sorting (with deterministic tie-breaker for stable pagination) ---
 	query += s.searchOrderClause(params)
 
@@ -381,7 +390,7 @@ func (s *Store) Search(params SearchParams) (*SearchResponse, error) {
 		// If we already have ref matches, return those instead of failing
 		// (FTS5 may reject queries like "TASK-5" due to special syntax)
 		if len(results) > 0 {
-			return &SearchResponse{Results: results, Total: total, Limit: params.Limit, Offset: params.Offset}, nil
+			return &SearchResponse{Results: results, Total: total, Limit: params.Limit, Offset: params.Offset, Facets: facets}, nil
 		}
 		return nil, fmt.Errorf("search: %w", err)
 	}
@@ -427,7 +436,7 @@ func (s *Store) Search(params SearchParams) (*SearchResponse, error) {
 		total = len(results)
 	}
 
-	return &SearchResponse{Results: results, Total: total, Limit: params.Limit, Offset: params.Offset}, nil
+	return &SearchResponse{Results: results, Total: total, Limit: params.Limit, Offset: params.Offset, Facets: facets}, nil
 }
 
 // appendSearchFilters adds workspace, collection, and field filter clauses to a query.
@@ -497,6 +506,76 @@ func (s *Store) searchOrderClause(params SearchParams) string {
 		}
 		return " ORDER BY rank_score, i.id"
 	}
+}
+
+// searchFacets runs two GROUP BY queries against the full (unpaginated) search
+// result set to produce collection and status breakdowns. Non-fatal — returns
+// nil if either query fails.
+func (s *Store) searchFacets(params SearchParams) *SearchFacets {
+	statusExtract := s.dialect.JSONExtractText("i.fields", "status")
+
+	var baseQuery string
+	var baseArgs []interface{}
+
+	if s.dialect.Driver() == DriverPostgres {
+		ftsMatch := s.dialect.FTSMatch("i", "search_vector")
+		baseQuery = fmt.Sprintf(`
+			FROM items i
+			JOIN collections c ON c.id = i.collection_id
+			WHERE %s AND i.deleted_at IS NULL
+		`, ftsMatch)
+		baseArgs = []interface{}{params.Query}
+	} else {
+		ftsMatch := s.dialect.FTSMatch("items_fts", "search_vector")
+		baseQuery = fmt.Sprintf(`
+			FROM items_fts fts
+			JOIN items i ON i.rowid = fts.rowid
+			JOIN collections c ON c.id = i.collection_id
+			WHERE %s AND i.deleted_at IS NULL
+		`, ftsMatch)
+		baseArgs = []interface{}{sanitizeFTSQuery(params.Query)}
+	}
+
+	baseQuery, baseArgs = s.appendSearchFilters(baseQuery, baseArgs, params)
+
+	facets := &SearchFacets{
+		Collections: make(map[string]int),
+		Statuses:    make(map[string]int),
+	}
+
+	// Collection facets
+	collQuery := "SELECT c.slug, COUNT(*) " + baseQuery + " GROUP BY c.slug"
+	collRows, err := s.db.Query(s.q(collQuery), baseArgs...)
+	if err == nil {
+		defer collRows.Close()
+		for collRows.Next() {
+			var slug string
+			var count int
+			if collRows.Scan(&slug, &count) == nil {
+				facets.Collections[slug] = count
+			}
+		}
+	}
+
+	// Status facets
+	statusQuery := fmt.Sprintf("SELECT %s, COUNT(*) %s AND %s IS NOT NULL GROUP BY %s",
+		statusExtract, baseQuery, statusExtract, statusExtract)
+	// Need fresh copy of args since baseArgs may be consumed
+	statusArgs := make([]interface{}, len(baseArgs))
+	copy(statusArgs, baseArgs)
+	statusRows, err := s.db.Query(s.q(statusQuery), statusArgs...)
+	if err == nil {
+		defer statusRows.Close()
+		for statusRows.Next() {
+			var status string
+			var count int
+			if statusRows.Scan(&status, &count) == nil && status != "" {
+				facets.Statuses[status] = count
+			}
+		}
+	}
+
+	return facets
 }
 
 // sanitizeFTSQuery wraps each token in double quotes so FTS5 treats

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -1,7 +1,6 @@
 package store
 
 import (
-	"encoding/json"
 	"fmt"
 	"regexp"
 	"strings"
@@ -343,25 +342,11 @@ func (s *Store) Search(params SearchParams) (*SearchResponse, error) {
 	// --- Faceted counts (full result set, not paginated) ---
 	facets := s.searchFacets(params)
 
-	// Merge ref hits into facets. Ref hits may not be in the FTS index,
-	// so the FTS-based facet queries can miss them. We conservatively add
-	// them here; for the common case where the ref hit IS in FTS, this
-	// slightly overcounts by 1 — acceptable for facet display purposes.
-	if facets != nil {
-		for _, r := range results {
-			collSlug := r.Item.CollectionSlug
-			if collSlug != "" {
-				facets.Collections[collSlug]++
-			}
-			// Extract status from fields JSON
-			var fields map[string]interface{}
-			if err := json.Unmarshal([]byte(r.Item.Fields), &fields); err == nil {
-				if status, ok := fields["status"].(string); ok && status != "" {
-					facets.Statuses[status]++
-				}
-			}
-		}
-	}
+	// Note: facets are computed from FTS results only. Direct ref hits
+	// (e.g. searching "TASK-42") may not appear in FTS and thus may not
+	// be reflected in facet counts. This is acceptable — ref searches
+	// typically return 1 exact match, and overcounting would be worse
+	// since we can't cheaply detect FTS overlap.
 
 	// --- Sorting (with deterministic tie-breaker for stable pagination) ---
 	query += s.searchOrderClause(params)

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"strings"
@@ -341,6 +342,26 @@ func (s *Store) Search(params SearchParams) (*SearchResponse, error) {
 
 	// --- Faceted counts (full result set, not paginated) ---
 	facets := s.searchFacets(params)
+
+	// Merge ref hits into facets. Ref hits may not be in the FTS index,
+	// so the FTS-based facet queries can miss them. We conservatively add
+	// them here; for the common case where the ref hit IS in FTS, this
+	// slightly overcounts by 1 — acceptable for facet display purposes.
+	if facets != nil {
+		for _, r := range results {
+			collSlug := r.Item.CollectionSlug
+			if collSlug != "" {
+				facets.Collections[collSlug]++
+			}
+			// Extract status from fields JSON
+			var fields map[string]interface{}
+			if err := json.Unmarshal([]byte(r.Item.Fields), &fields); err == nil {
+				if status, ok := fields["status"].(string); ok && status != "" {
+					facets.Statuses[status]++
+				}
+			}
+		}
+	}
 
 	// --- Sorting (with deterministic tie-breaker for stable pagination) ---
 	query += s.searchOrderClause(params)

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -966,6 +966,67 @@ func TestSearchSorting(t *testing.T) {
 	}
 }
 
+func TestSearchFacets(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Test")
+	s.SeedDefaultCollections(ws.ID)
+
+	colls, _ := s.ListCollections(ws.ID)
+	var tasksID, ideasID string
+	for _, c := range colls {
+		if c.Slug == "tasks" {
+			tasksID = c.ID
+		}
+		if c.Slug == "ideas" {
+			ideasID = c.ID
+		}
+	}
+
+	s.CreateItem(ws.ID, tasksID, models.ItemCreate{Title: "Fix auth widget", Fields: `{"status":"open","priority":"high"}`})
+	s.CreateItem(ws.ID, tasksID, models.ItemCreate{Title: "Refactor widget module", Fields: `{"status":"done","priority":"medium"}`})
+	s.CreateItem(ws.ID, tasksID, models.ItemCreate{Title: "Widget tests", Fields: `{"status":"open","priority":"low"}`})
+	s.CreateItem(ws.ID, ideasID, models.ItemCreate{Title: "Widget dashboard", Fields: `{"status":"new"}`})
+
+	resp, err := s.Search(SearchParams{Query: "widget", Workspace: ws.Slug})
+	if err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	if resp.Facets == nil {
+		t.Fatal("expected facets, got nil")
+	}
+
+	// Collection facets
+	if resp.Facets.Collections["tasks"] != 3 {
+		t.Errorf("expected tasks=3, got %d", resp.Facets.Collections["tasks"])
+	}
+	if resp.Facets.Collections["ideas"] != 1 {
+		t.Errorf("expected ideas=1, got %d", resp.Facets.Collections["ideas"])
+	}
+
+	// Status facets
+	if resp.Facets.Statuses["open"] != 2 {
+		t.Errorf("expected open=2, got %d", resp.Facets.Statuses["open"])
+	}
+	if resp.Facets.Statuses["done"] != 1 {
+		t.Errorf("expected done=1, got %d", resp.Facets.Statuses["done"])
+	}
+	if resp.Facets.Statuses["new"] != 1 {
+		t.Errorf("expected new=1, got %d", resp.Facets.Statuses["new"])
+	}
+
+	// Facets should reflect full result set even with pagination
+	resp, err = s.Search(SearchParams{Query: "widget", Workspace: ws.Slug, Limit: 1})
+	if err != nil {
+		t.Fatalf("paginated search: %v", err)
+	}
+	if len(resp.Results) != 1 {
+		t.Errorf("expected 1 result on page, got %d", len(resp.Results))
+	}
+	if resp.Facets.Collections["tasks"] != 3 {
+		t.Errorf("facets should be unpaginated: expected tasks=3, got %d", resp.Facets.Collections["tasks"])
+	}
+}
+
 func TestContext(t *testing.T) {
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -640,11 +640,17 @@ export interface SearchResult {
 	rank: number;
 }
 
+export interface SearchFacets {
+	collections: Record<string, number>;
+	statuses: Record<string, number>;
+}
+
 export interface SearchResponse {
 	results: SearchResult[];
 	total: number;
 	limit: number;
 	offset: number;
+	facets?: SearchFacets;
 }
 
 export interface SearchFilters {


### PR DESCRIPTION
## Summary

- Adds `facets` to the search API response with `collections` (slug → count) and `statuses` (status → count) breakdowns
- Facets reflect the full unpaginated result set via two GROUP BY queries that reuse the same filter logic as the main search
- Adds `SearchFacets` TypeScript type to frontend

Part of PLAN-573 (First-Class Search) — implements TASK-576.

## Test plan

- [x] `TestSearchFacets` — verifies collection counts, status counts, and that facets are independent of pagination
- [x] Full `go test ./...` passes
- [x] `npm run build` succeeds
- [x] Smoke tested: `pad item search "search" --format json` shows correct facet counts