### PR TITLE
feat: add collection-level search with Cmd+F

### DIFF
--- a/web/src/lib/components/collections/FilterBar.svelte
+++ b/web/src/lib/components/collections/FilterBar.svelte
@@ -9,9 +9,10 @@
 		onFilterChange: (filters: Record<string, string>) => void;
 		onSearchChange: (query: string) => void;
 		relationLabels?: Record<string, string>;
+		searchInputEl?: HTMLInputElement | undefined;
 	}
 
-	let { collection, activeFilters, searchQuery, onFilterChange, onSearchChange, relationLabels = {} }: Props = $props();
+	let { collection, activeFilters, searchQuery, onFilterChange, onSearchChange, relationLabels = {}, searchInputEl = $bindable() }: Props = $props();
 
 	let schema = $derived(parseSchema(collection));
 	let statusField = $derived(schema.fields.find((f) => f.key === 'status'));
@@ -83,11 +84,13 @@
 
 	<div class="search-wrapper">
 		<input
+			bind:this={searchInputEl}
 			type="text"
 			class="search-input"
 			placeholder="Search {collection.name.toLowerCase()}..."
 			value={searchQuery}
 			oninput={handleSearchInput}
+			onkeydown={(e) => { if (e.key === 'Escape') { onSearchChange(''); searchInputEl?.blur(); } }}
 		/>
 	</div>
 </div>

--- a/web/src/lib/stores/ui.svelte.ts
+++ b/web/src/lib/stores/ui.svelte.ts
@@ -9,6 +9,7 @@ let detailPanelOpen = $state(browser ? localStorage.getItem('pad-detail-panel') 
 let createWorkspaceOpen = $state(false);
 let quickAddRequested = $state(false);
 let quickAddTargetSlug = $state<string | null>(null);
+let collectionSearchRequested = $state(false);
 
 if (browser) {
 	window.addEventListener('resize', () => {
@@ -75,6 +76,11 @@ export const uiStore = {
 	get quickAddTargetSlug() { return quickAddTargetSlug; },
 	requestQuickAdd(collectionSlug?: string) { quickAddTargetSlug = collectionSlug ?? null; quickAddRequested = true; },
 	clearQuickAddRequest() { quickAddRequested = false; quickAddTargetSlug = null; },
+
+	// Collection search (Cmd+F) trigger — collection page watches this
+	get collectionSearchRequested() { return collectionSearchRequested; },
+	requestCollectionSearch() { collectionSearchRequested = true; },
+	clearCollectionSearchRequest() { collectionSearchRequested = false; },
 
 	/** Close sidebar on mobile after navigation */
 	onNavigate() {

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -93,6 +93,11 @@
 			uiStore.requestQuickAdd();
 			return;
 		}
+		if (isMod(e) && e.key === 'f') {
+			e.preventDefault();
+			uiStore.requestCollectionSearch();
+			return;
+		}
 		if (e.key === '?' && !isInputFocused()) {
 			e.preventDefault();
 			showShortcuts = !showShortcuts;

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -406,16 +406,19 @@
 			searchResultIds = null; // null = no search active, show all items
 			return;
 		}
+		const snapshotQuery = query;
 		searchTimeout = setTimeout(async () => {
 			try {
-				const resp = await api.search(query, {
+				const resp = await api.search(snapshotQuery, {
 					workspace: wsSlug,
 					collection: collSlug,
 					limit: 200,
 				});
+				// Discard if query changed while loading
+				if (searchQuery !== snapshotQuery) return;
 				searchResultIds = new Set(resp.results.map((r) => r.item.id));
 			} catch {
-				searchResultIds = null;
+				if (searchQuery === snapshotQuery) searchResultIds = null;
 			}
 		}, 200);
 	}
@@ -577,8 +580,12 @@
 	function handlePageKeydown(e: KeyboardEvent) {
 		// Cmd+F / Ctrl+F: focus collection search instead of browser search
 		if (e.key === 'f' && (e.metaKey || e.ctrlKey)) {
+			if (!filtersOpen) {
+				filtersOpen = true;
+			}
 			e.preventDefault();
-			searchInputEl?.focus();
+			// Wait for FilterBar to mount before focusing
+			requestAnimationFrame(() => searchInputEl?.focus());
 			return;
 		}
 

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -42,6 +42,9 @@
 	let shareDialogOpen = $state(false);
 	let editCollectionOpen = $state(false);
 	let workspaceMembers = $state<{ user_id: string; role: string }[]>([]);
+	let searchInputEl = $state<HTMLInputElement>();
+	let searchResultIds = $state<Set<string> | null>(null);
+	let searchTimeout: ReturnType<typeof setTimeout>;
 
 	let wsSlug = $derived(page.params.workspace ?? '');
 	let username = $derived(page.params.username ?? '');
@@ -327,8 +330,11 @@
 			});
 		}
 
-		// Apply search query
-		if (searchQuery.trim()) {
+		// Apply search query (API-backed FTS)
+		if (searchQuery.trim() && searchResultIds !== null) {
+			result = result.filter((item) => searchResultIds!.has(item.id));
+		} else if (searchQuery.trim()) {
+			// Fallback to client-side search while API response is pending
 			const q = searchQuery.trim().toLowerCase();
 			result = result.filter((item) => {
 				if (item.title.toLowerCase().includes(q)) return true;
@@ -393,6 +399,25 @@
 	function handleSearchChange(query: string) {
 		searchQuery = query;
 		updateUrlFilters();
+
+		// API-backed search with debounce for FTS (searches content, not just titles)
+		clearTimeout(searchTimeout);
+		if (!query.trim()) {
+			searchResultIds = null; // null = no search active, show all items
+			return;
+		}
+		searchTimeout = setTimeout(async () => {
+			try {
+				const resp = await api.search(query, {
+					workspace: wsSlug,
+					collection: collSlug,
+					limit: 200,
+				});
+				searchResultIds = new Set(resp.results.map((r) => r.item.id));
+			} catch {
+				searchResultIds = null;
+			}
+		}, 200);
 	}
 
 	async function handleStatusChange(item: Item, newValue: string) {
@@ -550,6 +575,13 @@
 	});
 
 	function handlePageKeydown(e: KeyboardEvent) {
+		// Cmd+F / Ctrl+F: focus collection search instead of browser search
+		if (e.key === 'f' && (e.metaKey || e.ctrlKey)) {
+			e.preventDefault();
+			searchInputEl?.focus();
+			return;
+		}
+
 		// Don't capture when typing in inputs/textareas or when quick-create is open
 		const tag = (e.target as HTMLElement)?.tagName;
 		if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
@@ -656,6 +688,7 @@
 		}
 		activeFilters = newFilters;
 		searchQuery = '';
+		searchResultIds = null;
 
 		// Open filters panel if the view has filters
 		if (Object.keys(newFilters).length > 0) {
@@ -670,6 +703,7 @@
 		activeViewId = null;
 		activeFilters = {};
 		searchQuery = '';
+		searchResultIds = null;
 		filtersOpen = false;
 		updateUrlFilters();
 	}
@@ -843,6 +877,7 @@
 						onFilterChange={handleFilterChange}
 						onSearchChange={handleSearchChange}
 						{relationLabels}
+						bind:searchInputEl
 					/>
 				</div>
 			{/if}
@@ -922,7 +957,7 @@
 				<div class="empty-icon">🔍</div>
 				<h2>No matches</h2>
 				<p>No items match your current filters.
-					<button class="clear-link" onclick={() => { activeFilters = {}; searchQuery = ''; }}>Clear filters</button>
+					<button class="clear-link" onclick={() => { activeFilters = {}; searchQuery = ''; searchResultIds = null; }}>Clear filters</button>
 				</p>
 			</div>
 		{:else if viewMode === 'board'}

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -407,6 +407,8 @@
 			searchResultIds = null; // null = no search active, show all items
 			return;
 		}
+		// Clear stale results immediately so client-side fallback kicks in
+		searchResultIds = null;
 		const snapshotQuery = query;
 		searchTimeout = setTimeout(async () => {
 			try {

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -17,6 +17,7 @@
 	import EditCollectionModal from '$lib/components/collections/EditCollectionModal.svelte';
 	import { authStore } from '$lib/stores/auth.svelte';
 	import { collectionStore } from '$lib/stores/collections.svelte';
+	import { uiStore } from '$lib/stores/ui.svelte';
 
 	type ViewMode = 'list' | 'board' | 'table';
 
@@ -577,18 +578,18 @@
 		focusedIndex = -1;
 	});
 
-	function handlePageKeydown(e: KeyboardEvent) {
-		// Cmd+F / Ctrl+F: focus collection search instead of browser search
-		if (e.key === 'f' && (e.metaKey || e.ctrlKey)) {
+	// Watch for Cmd+F signal from layout
+	$effect(() => {
+		if (uiStore.collectionSearchRequested) {
+			uiStore.clearCollectionSearchRequest();
 			if (!filtersOpen) {
 				filtersOpen = true;
 			}
-			e.preventDefault();
-			// Wait for FilterBar to mount before focusing
 			requestAnimationFrame(() => searchInputEl?.focus());
-			return;
 		}
+	});
 
+	function handlePageKeydown(e: KeyboardEvent) {
 		// Don't capture when typing in inputs/textareas or when quick-create is open
 		const tag = (e.target as HTMLElement)?.tagName;
 		if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;


### PR DESCRIPTION
## Summary

- Intercepts Cmd+F / Ctrl+F on collection pages to focus the search input instead of browser search
- Replaces client-side substring filtering with API-backed FTS search scoped to the collection (`/search?collection=<slug>`)
- Escape clears search and blurs input; client-side fallback while API debounce is pending
- FilterBar exposes `searchInputEl` via `$bindable` prop for parent focus control

Part of PLAN-573 (First-Class Search) — implements TASK-580.

## Test plan

- [x] `npm run build` succeeds
- [x] `go build ./... && go test ./...` passes
- [x] `make install` — binary rebuilt and server restarted
- [ ] Manual: open a collection, press Cmd+F, verify search input focuses, type to search, verify FTS results, press Escape to clear