### PR TITLE
fix: align Starred page layout with sibling pages (BUG-579)

### DIFF
--- a/web/src/routes/[username]/[workspace]/starred/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/starred/+page.svelte
@@ -93,7 +93,7 @@
 
 <div class="starred-page">
 	<div class="page-header">
-		<div class="header-top">
+		<div class="page-header-left">
 			<h1>⭐ Starred</h1>
 			<span class="item-count">{items.length} item{items.length !== 1 ? 's' : ''}</span>
 		</div>
@@ -141,24 +141,28 @@
 
 <style>
 	.starred-page {
-		max-width: 800px;
+		max-width: var(--content-max-width);
 		margin: 0 auto;
-		padding: var(--space-6) var(--space-6) var(--space-12);
+		padding: var(--space-8) var(--space-6);
 	}
 
 	.page-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: var(--space-4);
 		margin-bottom: var(--space-6);
+		flex-wrap: wrap;
 	}
 
-	.header-top {
+	.page-header-left {
 		display: flex;
 		align-items: baseline;
 		gap: var(--space-3);
-		margin-bottom: var(--space-3);
 	}
 
 	.page-header h1 {
-		font-size: 1.5em;
+		font-size: 1.6em;
 		font-weight: 700;
 		color: var(--text-primary);
 		margin: 0;


### PR DESCRIPTION
## Summary
- Starred page was using hardcoded layout values (`max-width: 800px`, asymmetric `padding: var(--space-6) ... var(--space-12)`, vertically-stacked header, smaller `h1`) while every other workspace page uses the shared design tokens — it felt visibly "off" against Activity, Conventions, Settings, etc.
- Swapped to the canonical pattern from `activity/+page.svelte`: `var(--content-max-width)`, `padding: var(--space-8) var(--space-6)`, `.page-header` as a flex row with `justify-content: space-between`, `h1` at `1.6em`.
- Pure layout/styling change. No behavior change. Fixes `BUG-579`.

## Changes
`web/src/routes/[username]/[workspace]/starred/+page.svelte`:
- `max-width: 800px` → `var(--content-max-width)` (960px)
- `padding: var(--space-6) var(--space-6) var(--space-12)` → `var(--space-8) var(--space-6)`
- `.page-header`: flex row with `justify-content: space-between`, `gap: var(--space-4)`, `flex-wrap: wrap`
- `.header-top` → `.page-header-left` (single rename, redundant `margin-bottom` removed — now lives on `.page-header`)
- `h1` font-size: `1.5em` → `1.6em`

## Test plan
- [x] `npm run build` — passes
- [x] `go test ./...` — passes
- [x] `make install` — clean build, server restarts
- [ ] Visual check: Starred page width/padding/header now matches Activity, Conventions, Settings pages
- [ ] Visual check: empty state still centers correctly
- [ ] Visual check: narrow viewport — header wraps gracefully via `flex-wrap`