### PR TITLE
fix: load workspaces reactively after post-auth navigation (BUG-584)

### DIFF
--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -70,13 +70,16 @@
 	});
 
 	$effect(() => {
-		// Load workspaces once the user is authenticated and on an app page.
+		// Load workspaces once auth is resolved and we're on an app page.
 		// This runs after onMount AND on subsequent navigation (e.g., post-login
 		// when the user moves from /login → /console → /{user}/{workspace}),
 		// which a one-shot onMount would miss. Fixes BUG-584.
+		//
+		// Note: we intentionally do NOT gate on authStore.authenticated, to
+		// preserve behavior on deployments where auth is unsupported and
+		// authStore.load() fails silently (see the try/catch in onMount).
 		if (
 			authReady &&
-			authStore.authenticated &&
 			!isAuthPage &&
 			!isSharePage &&
 			!workspacesLoaded &&

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -18,6 +18,7 @@
 
 	let showShortcuts = $state(false);
 	let authReady = $state(false);
+	let workspacesLoaded = $state(false);
 	let isAuthPage = $derived(page.url.pathname === '/login' || page.url.pathname === '/register' || page.url.pathname.startsWith('/join/') || page.url.pathname.startsWith('/auth/cli/'));
 	let isSharePage = $derived(page.url.pathname.startsWith('/s/'));
 	let isConsolePage = $derived(page.url.pathname.startsWith('/console'));
@@ -66,8 +67,23 @@
 		}
 
 		authReady = true;
-		if (!isAuthPage) {
-			await workspaceStore.loadAll();
+	});
+
+	$effect(() => {
+		// Load workspaces once the user is authenticated and on an app page.
+		// This runs after onMount AND on subsequent navigation (e.g., post-login
+		// when the user moves from /login → /console → /{user}/{workspace}),
+		// which a one-shot onMount would miss. Fixes BUG-584.
+		if (
+			authReady &&
+			authStore.authenticated &&
+			!isAuthPage &&
+			!isSharePage &&
+			!workspacesLoaded &&
+			!workspaceStore.loading
+		) {
+			workspacesLoaded = true;
+			workspaceStore.loadAll();
 		}
 	});
 
@@ -172,7 +188,7 @@
 								<rect y="15" width="20" height="2" rx="1" fill="currentColor"/>
 							</svg>
 						</button>
-						<a href="/{workspaceStore.current?.owner_username ?? ''}/${workspaceStore.current?.slug ?? ''}" class="mobile-title">{workspaceStore.current?.name ?? 'Pad'}</a>
+						<a href="/{workspaceStore.current?.owner_username ?? ''}/{workspaceStore.current?.slug ?? ''}" class="mobile-title">{workspaceStore.current?.name ?? 'Pad'}</a>
 					</div>
 				{/if}
 				{@render children()}

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -19,6 +19,7 @@
 	let showShortcuts = $state(false);
 	let authReady = $state(false);
 	let workspacesLoaded = $state(false);
+	let authLoadFailed = $state(false);
 	let isAuthPage = $derived(page.url.pathname === '/login' || page.url.pathname === '/register' || page.url.pathname.startsWith('/join/') || page.url.pathname.startsWith('/auth/cli/'));
 	let isSharePage = $derived(page.url.pathname.startsWith('/s/'));
 	let isConsolePage = $derived(page.url.pathname.startsWith('/console'));
@@ -63,7 +64,11 @@
 				return;
 			}
 		} catch {
-			// If auth check fails, proceed anyway (server may not support it)
+			// If auth check fails, proceed anyway (server may not support it).
+			// Track this so the workspace loader effect below can still fire — in
+			// this case authStore.authenticated stays false but we still want to
+			// load the workspace list.
+			authLoadFailed = true;
 		}
 
 		authReady = true;
@@ -75,11 +80,16 @@
 		// when the user moves from /login → /console → /{user}/{workspace}),
 		// which a one-shot onMount would miss. Fixes BUG-584.
 		//
-		// Note: we intentionally do NOT gate on authStore.authenticated, to
-		// preserve behavior on deployments where auth is unsupported and
-		// authStore.load() fails silently (see the try/catch in onMount).
+		// We gate on (authenticated || authLoadFailed) rather than !isAuthPage
+		// alone: authReady flips true inside the unauthenticated branches of
+		// onMount BEFORE the /login redirect completes, so during that window a
+		// logged-out user on a protected route would otherwise fire loadAll()
+		// and latch workspacesLoaded=true, blocking the retry after login.
+		// authLoadFailed covers the deployment case where the auth endpoint is
+		// unavailable and authStore.authenticated stays false by design.
 		if (
 			authReady &&
+			(authStore.authenticated || authLoadFailed) &&
 			!isAuthPage &&
 			!isSharePage &&
 			!workspacesLoaded &&


### PR DESCRIPTION
## Summary

After logging in, the workspace list in the nav header was blank until a full page refresh. The same failure affected register / join-invitation / reset-password flows.

**Root cause:** `+layout.svelte` only called `workspaceStore.loadAll()` inside `onMount`, guarded by `!isAuthPage`. When a user first lands on `/login`, `onMount` runs with `isAuthPage = true` and skips the load. After login, `goto('/console')` does a client-side navigation — SvelteKit preserves the root layout across navigation, so `onMount` does **not** re-run, and the workspace store stays empty. A hard refresh fixed it because that re-mounted the layout on an app page (`isAuthPage = false`).

**Fix:** replace the `onMount`-local load with a reactive `$effect` that fires whenever the user is authenticated, on an app page (not auth / not share), and the store hasn't been loaded yet. A `workspacesLoaded` latch prevents re-firing for users with zero workspaces and prevents duplicate in-flight fetches.

Also fixed a separate bug in the same file: the mobile header link used `\${workspaceStore.current?.slug}` — JS template-literal syntax inside a plain HTML attribute string, which Svelte renders as a literal `$`. Changed to Svelte's `{...}` attribute interpolation to match the sibling interpolation on the same attribute.

## Changes (`web/src/routes/+layout.svelte`)

- Added `let workspacesLoaded = $state(false);` latch.
- Removed the `if (!isAuthPage) { await workspaceStore.loadAll(); }` block from `onMount`; kept `authReady = true;`.
- Added a new `$effect` that loads workspaces when the user is authenticated and on an app page. Handles both initial mount AND subsequent navigation (the case that was broken).
- Mobile header `<a href>`: `\${…slug…}` → `{…slug…}` (dropped the stray `$`).

## Test plan

- [x] `npm run build` — passes
- [x] `go test ./...` — passes
- [x] `make install` — clean build, server restarts
- [ ] Log out, then log in fresh — workspace list populates in nav header immediately (no refresh)
- [ ] Register a new account — workspace list populates after hitting console
- [ ] Accept an invitation via `/join/{code}` — workspace list populates on the landed workspace
- [ ] Password reset → console — workspace list populates
- [ ] Mobile viewport: header title anchor links to correct `/<user>/<slug>` (no literal `$`)
- [ ] User with 0 workspaces — no infinite fetch loop; store stays empty gracefully