### PR TITLE
feat(web): surface required/default/suffix/relation field controls (TASK-596)

### DIFF
--- a/web/src/lib/components/collections/CreateCollectionModal.svelte
+++ b/web/src/lib/components/collections/CreateCollectionModal.svelte
@@ -3,7 +3,7 @@
 	import type { CollectionCreate, FieldDef, CollectionSettings } from '$lib/types';
 	import { COLLECTION_TEMPLATES, type CollectionTemplate } from './collection-templates';
 	import EmojiPicker from '$lib/components/common/EmojiPicker.svelte';
-	import FieldEditor from './FieldEditor.svelte';
+	import FieldEditor, { type CollectionOption } from './FieldEditor.svelte';
 	import {
 		blankField,
 		fieldFromDef,
@@ -34,6 +34,10 @@
 	let creating = $state(false);
 	let error = $state('');
 
+	// Workspace collections list, used to populate the relation target picker
+	// in FieldEditor. Fetched lazily on modal open.
+	let collectionOptions = $state<CollectionOption[]>([]);
+
 	// Track previous open state to detect open transitions
 	let prevOpen = $state(false);
 
@@ -48,9 +52,24 @@
 			selectedSettings = null;
 			showEmojiPicker = false;
 			error = '';
+			void loadCollectionOptions();
 		}
 		prevOpen = open;
 	});
+
+	async function loadCollectionOptions() {
+		try {
+			const list = await api.collections.list(wsSlug);
+			collectionOptions = list.map((c) => ({
+				slug: c.slug,
+				name: c.name,
+				icon: c.icon
+			}));
+		} catch {
+			// Relation picker falls back to its empty-state hint.
+			collectionOptions = [];
+		}
+	}
 
 	function resetForm() {
 		name = '';
@@ -172,6 +191,13 @@
 						const terms = f.terminalOptions.filter((t) => def.options!.includes(t));
 						if (terms.length > 0) def.terminal_options = terms;
 					}
+					// Advanced controls (T3 / TASK-596). Only emit when set so
+					// payloads stay compact and round-trip with existing schemas.
+					if (f.required) def.required = true;
+					if (f.computed) def.computed = true;
+					if (f.suffix) def.suffix = f.suffix;
+					if (f.collection) def.collection = f.collection;
+					if (f.default !== undefined) def.default = f.default;
 					return def;
 				});
 
@@ -303,6 +329,7 @@
 										total={fields.length}
 										isNew
 										keyError={keyErrors[i]}
+										collections={collectionOptions}
 										onmoveup={() => moveField(i, -1)}
 										onmovedown={() => moveField(i, 1)}
 										onremove={() => removeField(i)}

--- a/web/src/lib/components/collections/CreateCollectionModal.svelte
+++ b/web/src/lib/components/collections/CreateCollectionModal.svelte
@@ -6,6 +6,7 @@
 	import FieldEditor, { type CollectionOption } from './FieldEditor.svelte';
 	import {
 		blankField,
+		coerceDefault,
 		fieldFromDef,
 		typeSupportsDefault,
 		validateFieldKey,
@@ -203,8 +204,13 @@
 					if (f.computed) def.computed = true;
 					if (f.type === 'number' && f.suffix) def.suffix = f.suffix;
 					if (f.type === 'relation' && f.collection) def.collection = f.collection;
+					// Coerce default to match the active type. This catches
+					// both type-switch drift (boolean default left on a text
+					// field) and select whitespace drift (default raw text not
+					// matching the normalized options set).
 					if (f.default !== undefined && typeSupportsDefault(f.type)) {
-						def.default = f.default;
+						const coerced = coerceDefault(f.default, f.type, def.options);
+						if (coerced !== undefined) def.default = coerced;
 					}
 					return def;
 				});

--- a/web/src/lib/components/collections/CreateCollectionModal.svelte
+++ b/web/src/lib/components/collections/CreateCollectionModal.svelte
@@ -60,6 +60,12 @@
 	});
 
 	async function loadCollectionOptions() {
+		// Clear the stale list from a previous open before the new request
+		// resolves. Without this, reopening the modal (especially after a
+		// workspace switch) briefly shows the old relation targets — and a
+		// fast user can pick one and persist a slug that doesn't belong to
+		// the current workspace.
+		collectionOptions = [];
 		try {
 			const list = await api.collections.list(wsSlug);
 			collectionOptions = list.map((c) => ({

--- a/web/src/lib/components/collections/CreateCollectionModal.svelte
+++ b/web/src/lib/components/collections/CreateCollectionModal.svelte
@@ -7,6 +7,7 @@
 	import {
 		blankField,
 		fieldFromDef,
+		typeSupportsDefault,
 		validateFieldKey,
 		type EditableField
 	} from './field-editor-types';
@@ -193,11 +194,18 @@
 					}
 					// Advanced controls (T3 / TASK-596). Only emit when set so
 					// payloads stay compact and round-trip with existing schemas.
+					// Type-specific values are gated by `f.type` so stale state
+					// from a prior type doesn't leak into the saved schema —
+					// e.g. a user sets a number default/suffix, switches to
+					// `relation`, and the hidden number values would otherwise
+					// still be persisted.
 					if (f.required) def.required = true;
 					if (f.computed) def.computed = true;
-					if (f.suffix) def.suffix = f.suffix;
-					if (f.collection) def.collection = f.collection;
-					if (f.default !== undefined) def.default = f.default;
+					if (f.type === 'number' && f.suffix) def.suffix = f.suffix;
+					if (f.type === 'relation' && f.collection) def.collection = f.collection;
+					if (f.default !== undefined && typeSupportsDefault(f.type)) {
+						def.default = f.default;
+					}
 					return def;
 				});
 

--- a/web/src/lib/components/collections/CreateCollectionModal.svelte
+++ b/web/src/lib/components/collections/CreateCollectionModal.svelte
@@ -37,8 +37,11 @@
 	let error = $state('');
 
 	// Workspace collections list, used to populate the relation target picker
-	// in FieldEditor. Fetched lazily on modal open.
+	// in FieldEditor. Fetched lazily on modal open. `collectionsRequestToken`
+	// monotonically increases per fetch so a slow older response can't
+	// overwrite a newer one (e.g. on rapid reopens / workspace switches).
 	let collectionOptions = $state<CollectionOption[]>([]);
+	let collectionsRequestToken = 0;
 
 	// Track previous open state to detect open transitions
 	let prevOpen = $state(false);
@@ -61,13 +64,15 @@
 
 	async function loadCollectionOptions() {
 		// Clear the stale list from a previous open before the new request
-		// resolves. Without this, reopening the modal (especially after a
-		// workspace switch) briefly shows the old relation targets — and a
-		// fast user can pick one and persist a slug that doesn't belong to
-		// the current workspace.
+		// resolves, and bump the request token so only this call's response
+		// is allowed to write state. Without the token guard, an older slow
+		// response (e.g. from a previous open or workspace) could land after
+		// a newer one and overwrite it.
+		const token = ++collectionsRequestToken;
 		collectionOptions = [];
 		try {
 			const list = await api.collections.list(wsSlug);
+			if (token !== collectionsRequestToken) return;
 			collectionOptions = list.map((c) => ({
 				slug: c.slug,
 				name: c.name,
@@ -75,6 +80,7 @@
 			}));
 		} catch {
 			// Relation picker falls back to its empty-state hint.
+			if (token !== collectionsRequestToken) return;
 			collectionOptions = [];
 		}
 	}

--- a/web/src/lib/components/collections/CreateCollectionModal.svelte
+++ b/web/src/lib/components/collections/CreateCollectionModal.svelte
@@ -220,8 +220,15 @@
 					// both type-switch drift (boolean default left on a text
 					// field) and select whitespace drift (default raw text not
 					// matching the normalized options set).
+					//
+					// For select, always pass the full normalized options
+					// array (including []) so that a field with no options
+					// left can't retain a stale default. Using `def.options`
+					// here is wrong: it's omitted when the list is empty, and
+					// coerceDefault would then skip the membership check.
 					if (f.default !== undefined && typeSupportsDefault(f.type)) {
-						const coerced = coerceDefault(f.default, f.type, def.options);
+						const optsForCoerce = f.type === 'select' ? opts : undefined;
+						const coerced = coerceDefault(f.default, f.type, optsForCoerce);
 						if (coerced !== undefined) def.default = coerced;
 					}
 					return def;

--- a/web/src/lib/components/collections/EditCollectionModal.svelte
+++ b/web/src/lib/components/collections/EditCollectionModal.svelte
@@ -319,8 +319,18 @@
 					label: f.label.trim() || f.key,
 					type: f.type
 				};
-				if ((f.type === 'select' || f.type === 'multi_select') && f.options.length > 0) {
-					def.options = f.options.map((o) => o.trim()).filter(Boolean);
+				// Normalize options into a local so we can both emit them on
+				// def AND pass them to coerceDefault for select fields (even
+				// when empty — an empty list must drop stale defaults).
+				const normalizedOpts =
+					f.type === 'select' || f.type === 'multi_select'
+						? f.options.map((o) => o.trim()).filter(Boolean)
+						: [];
+				if (
+					(f.type === 'select' || f.type === 'multi_select') &&
+					normalizedOpts.length > 0
+				) {
+					def.options = normalizedOpts;
 				}
 				if (f.key === 'status' && f.terminalOptions.length > 0) {
 					// Only include terminal options that still exist in the options list
@@ -345,9 +355,13 @@
 				//   These defaults only arrive via API / imports, so silently
 				//   stripping them on save would mutate the schema in ways the
 				//   user didn't intend. Let them round-trip untouched.
+				//
+				// Pass the full normalized options array (including []) for
+				// select so that removing all options drops a stale default.
 				if (f.default !== undefined) {
 					if (typeSupportsDefault(f.type)) {
-						const coerced = coerceDefault(f.default, f.type, def.options);
+						const optsForCoerce = f.type === 'select' ? normalizedOpts : undefined;
+						const coerced = coerceDefault(f.default, f.type, optsForCoerce);
 						if (coerced !== undefined) def.default = coerced;
 					} else {
 						def.default = f.default;
@@ -389,9 +403,12 @@
 					if (f.type === 'number' && f.suffix) def.suffix = f.suffix;
 					if (f.type === 'relation' && f.collection) def.collection = f.collection;
 					// Coerce default to the active type (and normalize select
-					// defaults against the normalized option set).
+					// defaults against the normalized option set). Pass the
+					// full opts array (including []) so defaults are dropped
+					// when the options list is empty.
 					if (f.default !== undefined && typeSupportsDefault(f.type)) {
-						const coerced = coerceDefault(f.default, f.type, def.options);
+						const optsForCoerce = f.type === 'select' ? opts : undefined;
+						const coerced = coerceDefault(f.default, f.type, optsForCoerce);
 						if (coerced !== undefined) def.default = coerced;
 					}
 					return def;

--- a/web/src/lib/components/collections/EditCollectionModal.svelte
+++ b/web/src/lib/components/collections/EditCollectionModal.svelte
@@ -169,7 +169,11 @@
 				computed: f.computed,
 				collection: f.collection,
 				suffix: f.suffix,
-				default: f.default
+				default: f.default,
+				// Snapshot the load-time type so the save path can detect
+				// in-session type switches (used for the unsupported-type
+				// default preservation logic).
+				originalType: f.type
 			}));
 			newFields = [];
 			showEmojiPicker = false;
@@ -350,11 +354,18 @@
 				//   coerceDefault so stale values from a prior type don't leak
 				//   and select defaults are trimmed to match normalized
 				//   options.
-				// - If the active type is one the UI can't edit (multi_select,
-				//   relation), pass the existing default through verbatim.
+				// - If the active type is UI-unsupported for defaults
+				//   (multi_select, relation) AND the type hasn't changed
+				//   since load, pass the existing default through verbatim.
 				//   These defaults only arrive via API / imports, so silently
-				//   stripping them on save would mutate the schema in ways the
-				//   user didn't intend. Let them round-trip untouched.
+				//   stripping them on save would mutate the schema the user
+				//   didn't intend.
+				// - If the active type is UI-unsupported AND the type DID
+				//   change since load, drop the default. It was set against
+				//   the old type and is stale / meaningless now. Without
+				//   this, a user could set a text default, switch to
+				//   multi_select (hiding the default UI), save, and persist
+				//   a string default on a multi_select field.
 				//
 				// Pass the full normalized options array (including []) for
 				// select so that removing all options drops a stale default.
@@ -363,9 +374,10 @@
 						const optsForCoerce = f.type === 'select' ? normalizedOpts : undefined;
 						const coerced = coerceDefault(f.default, f.type, optsForCoerce);
 						if (coerced !== undefined) def.default = coerced;
-					} else {
+					} else if (f.originalType === f.type) {
 						def.default = f.default;
 					}
+					// else: type changed to an UI-unsupported type — drop.
 				}
 				return def;
 			});

--- a/web/src/lib/components/collections/EditCollectionModal.svelte
+++ b/web/src/lib/components/collections/EditCollectionModal.svelte
@@ -327,11 +327,24 @@
 				if (f.computed) def.computed = true;
 				if (f.type === 'relation' && f.collection) def.collection = f.collection;
 				if (f.type === 'number' && f.suffix) def.suffix = f.suffix;
-				// Coerce default to the active type (and normalize select
-				// defaults against the normalized option set).
-				if (f.default !== undefined && typeSupportsDefault(f.type)) {
-					const coerced = coerceDefault(f.default, f.type, def.options);
-					if (coerced !== undefined) def.default = coerced;
+				// Default-value handling for existing fields:
+				//
+				// - If the active type has UI-editable defaults, run through
+				//   coerceDefault so stale values from a prior type don't leak
+				//   and select defaults are trimmed to match normalized
+				//   options.
+				// - If the active type is one the UI can't edit (multi_select,
+				//   relation), pass the existing default through verbatim.
+				//   These defaults only arrive via API / imports, so silently
+				//   stripping them on save would mutate the schema in ways the
+				//   user didn't intend. Let them round-trip untouched.
+				if (f.default !== undefined) {
+					if (typeSupportsDefault(f.type)) {
+						const coerced = coerceDefault(f.default, f.type, def.options);
+						if (coerced !== undefined) def.default = coerced;
+					} else {
+						def.default = f.default;
+					}
 				}
 				return def;
 			});

--- a/web/src/lib/components/collections/EditCollectionModal.svelte
+++ b/web/src/lib/components/collections/EditCollectionModal.svelte
@@ -8,6 +8,7 @@
 	import {
 		blankField,
 		coerceDefault,
+		defaultsEqual,
 		typeSupportsDefault,
 		validateFieldKey,
 		type EditableField
@@ -170,10 +171,15 @@
 				collection: f.collection,
 				suffix: f.suffix,
 				default: f.default,
-				// Snapshot the load-time type so the save path can detect
-				// in-session type switches (used for the unsupported-type
-				// default preservation logic).
-				originalType: f.type
+				// Snapshot the load-time type AND default so the save path
+				// can detect in-session type switches and default mutations
+				// (used for the unsupported-type default preservation
+				// logic). Without originalDefault, a user could round-trip
+				// the type (relation -> text -> relation) with a new
+				// default injected in the middle and we'd preserve the
+				// stale value because originalType still matches.
+				originalType: f.type,
+				originalDefault: f.default
 			}));
 			newFields = [];
 			showEmojiPicker = false;
@@ -355,17 +361,13 @@
 				//   and select defaults are trimmed to match normalized
 				//   options.
 				// - If the active type is UI-unsupported for defaults
-				//   (multi_select, relation) AND the type hasn't changed
-				//   since load, pass the existing default through verbatim.
-				//   These defaults only arrive via API / imports, so silently
-				//   stripping them on save would mutate the schema the user
-				//   didn't intend.
-				// - If the active type is UI-unsupported AND the type DID
-				//   change since load, drop the default. It was set against
-				//   the old type and is stale / meaningless now. Without
-				//   this, a user could set a text default, switch to
-				//   multi_select (hiding the default UI), save, and persist
-				//   a string default on a multi_select field.
+				//   (multi_select, relation), only preserve the default when
+				//   BOTH type AND default are unchanged from load-time.
+				//   Matching only on type misses the round-trip case:
+				//   relation → text → relation with a new default injected
+				//   in the middle. The UI hides default controls for the
+				//   final type, so any mutation must be discarded.
+				// - Anything else: drop the default.
 				//
 				// Pass the full normalized options array (including []) for
 				// select so that removing all options drops a stale default.
@@ -374,10 +376,14 @@
 						const optsForCoerce = f.type === 'select' ? normalizedOpts : undefined;
 						const coerced = coerceDefault(f.default, f.type, optsForCoerce);
 						if (coerced !== undefined) def.default = coerced;
-					} else if (f.originalType === f.type) {
+					} else if (
+						f.originalType === f.type &&
+						defaultsEqual(f.default, f.originalDefault)
+					) {
 						def.default = f.default;
 					}
-					// else: type changed to an UI-unsupported type — drop.
+					// else: type or default was altered in-session on a type
+					// the UI can't represent — drop.
 				}
 				return def;
 			});

--- a/web/src/lib/components/collections/EditCollectionModal.svelte
+++ b/web/src/lib/components/collections/EditCollectionModal.svelte
@@ -70,6 +70,10 @@
 	let collectionOptions = $state<CollectionOption[]>([]);
 
 	async function loadCollectionOptions() {
+		// Clear the stale list from a previous open so a fast user can't
+		// pick a relation target from a workspace we've since left before
+		// the new fetch lands.
+		collectionOptions = [];
 		try {
 			const list = await api.collections.list(wsSlug);
 			collectionOptions = list.map((c) => ({

--- a/web/src/lib/components/collections/EditCollectionModal.svelte
+++ b/web/src/lib/components/collections/EditCollectionModal.svelte
@@ -7,6 +7,7 @@
 	import FieldEditor, { type CollectionOption } from './FieldEditor.svelte';
 	import {
 		blankField,
+		coerceDefault,
 		typeSupportsDefault,
 		validateFieldKey,
 		type EditableField
@@ -326,8 +327,11 @@
 				if (f.computed) def.computed = true;
 				if (f.type === 'relation' && f.collection) def.collection = f.collection;
 				if (f.type === 'number' && f.suffix) def.suffix = f.suffix;
+				// Coerce default to the active type (and normalize select
+				// defaults against the normalized option set).
 				if (f.default !== undefined && typeSupportsDefault(f.type)) {
-					def.default = f.default;
+					const coerced = coerceDefault(f.default, f.type, def.options);
+					if (coerced !== undefined) def.default = coerced;
 				}
 				return def;
 			});
@@ -364,8 +368,11 @@
 					if (f.computed) def.computed = true;
 					if (f.type === 'number' && f.suffix) def.suffix = f.suffix;
 					if (f.type === 'relation' && f.collection) def.collection = f.collection;
+					// Coerce default to the active type (and normalize select
+					// defaults against the normalized option set).
 					if (f.default !== undefined && typeSupportsDefault(f.type)) {
-						def.default = f.default;
+						const coerced = coerceDefault(f.default, f.type, def.options);
+						if (coerced !== undefined) def.default = coerced;
 					}
 					return def;
 				});

--- a/web/src/lib/components/collections/EditCollectionModal.svelte
+++ b/web/src/lib/components/collections/EditCollectionModal.svelte
@@ -67,21 +67,24 @@
 
 	// Workspace collections list, used to populate the relation target picker
 	// in FieldEditor for new relation-type fields. Fetched lazily on open.
+	// `collectionsRequestToken` guards against a slow older response
+	// overwriting a newer one on rapid reopens.
 	let collectionOptions = $state<CollectionOption[]>([]);
+	let collectionsRequestToken = 0;
 
 	async function loadCollectionOptions() {
-		// Clear the stale list from a previous open so a fast user can't
-		// pick a relation target from a workspace we've since left before
-		// the new fetch lands.
+		const token = ++collectionsRequestToken;
 		collectionOptions = [];
 		try {
 			const list = await api.collections.list(wsSlug);
+			if (token !== collectionsRequestToken) return;
 			collectionOptions = list.map((c) => ({
 				slug: c.slug,
 				name: c.name,
 				icon: c.icon
 			}));
 		} catch {
+			if (token !== collectionsRequestToken) return;
 			collectionOptions = [];
 		}
 	}

--- a/web/src/lib/components/collections/EditCollectionModal.svelte
+++ b/web/src/lib/components/collections/EditCollectionModal.svelte
@@ -4,7 +4,7 @@
 	import { parseSchema, parseSettings } from '$lib/types';
 	import EmojiPicker from '$lib/components/common/EmojiPicker.svelte';
 	import EmojiPickerButton from '$lib/components/common/EmojiPickerButton.svelte';
-	import FieldEditor from './FieldEditor.svelte';
+	import FieldEditor, { type CollectionOption } from './FieldEditor.svelte';
 	import {
 		blankField,
 		validateFieldKey,
@@ -62,6 +62,23 @@
 
 	let existingFields = $state<EditableField[]>([]);
 	let newFields = $state<EditableField[]>([]);
+
+	// Workspace collections list, used to populate the relation target picker
+	// in FieldEditor for new relation-type fields. Fetched lazily on open.
+	let collectionOptions = $state<CollectionOption[]>([]);
+
+	async function loadCollectionOptions() {
+		try {
+			const list = await api.collections.list(wsSlug);
+			collectionOptions = list.map((c) => ({
+				slug: c.slug,
+				name: c.name,
+				icon: c.icon
+			}));
+		} catch {
+			collectionOptions = [];
+		}
+	}
 
 	// ── Display settings state ──────────────────────────────────────────────
 
@@ -166,6 +183,8 @@
 				scope: a.scope,
 				icon: a.icon ?? ''
 			}));
+
+			void loadCollectionOptions();
 		}
 	});
 
@@ -330,6 +349,13 @@
 						const terms = f.terminalOptions.filter((t) => def.options!.includes(t));
 						if (terms.length > 0) def.terminal_options = terms;
 					}
+					// Advanced controls (T3 / TASK-596). Only emit when set so
+					// payloads stay compact and round-trip with existing schemas.
+					if (f.required) def.required = true;
+					if (f.computed) def.computed = true;
+					if (f.suffix) def.suffix = f.suffix;
+					if (f.collection) def.collection = f.collection;
+					if (f.default !== undefined) def.default = f.default;
 					return def;
 				});
 
@@ -491,6 +517,7 @@
 										bind:field={existingFields[i]}
 										index={i}
 										total={existingFields.length}
+										collections={collectionOptions}
 										onmoveup={() => moveField(i, -1)}
 										onmovedown={() => moveField(i, 1)}
 										onremove={() => removeExistingField(i)}
@@ -503,6 +530,7 @@
 										total={newFields.length}
 										isNew
 										keyError={newKeyErrors[i]}
+										collections={collectionOptions}
 										onmoveup={() => moveNewField(i, -1)}
 										onmovedown={() => moveNewField(i, 1)}
 										onremove={() => removeNewField(i)}

--- a/web/src/lib/components/collections/EditCollectionModal.svelte
+++ b/web/src/lib/components/collections/EditCollectionModal.svelte
@@ -7,6 +7,7 @@
 	import FieldEditor, { type CollectionOption } from './FieldEditor.svelte';
 	import {
 		blankField,
+		typeSupportsDefault,
 		validateFieldKey,
 		type EditableField
 	} from './field-editor-types';
@@ -317,11 +318,17 @@
 					// Only include terminal options that still exist in the options list
 					def.terminal_options = f.terminalOptions.filter(t => def.options?.includes(t));
 				}
+				// Gate type-specific advanced values by the current type so
+				// stale hidden values from a previous type (e.g. a number
+				// default/suffix after switching to relation) don't leak
+				// into the saved schema.
 				if (f.required) def.required = true;
 				if (f.computed) def.computed = true;
-				if (f.collection) def.collection = f.collection;
-				if (f.suffix) def.suffix = f.suffix;
-				if (f.default !== undefined) def.default = f.default;
+				if (f.type === 'relation' && f.collection) def.collection = f.collection;
+				if (f.type === 'number' && f.suffix) def.suffix = f.suffix;
+				if (f.default !== undefined && typeSupportsDefault(f.type)) {
+					def.default = f.default;
+				}
 				return def;
 			});
 
@@ -351,11 +358,15 @@
 					}
 					// Advanced controls (T3 / TASK-596). Only emit when set so
 					// payloads stay compact and round-trip with existing schemas.
+					// Type-specific values are gated by `f.type` so stale state
+					// from a prior type doesn't leak into the saved schema.
 					if (f.required) def.required = true;
 					if (f.computed) def.computed = true;
-					if (f.suffix) def.suffix = f.suffix;
-					if (f.collection) def.collection = f.collection;
-					if (f.default !== undefined) def.default = f.default;
+					if (f.type === 'number' && f.suffix) def.suffix = f.suffix;
+					if (f.type === 'relation' && f.collection) def.collection = f.collection;
+					if (f.default !== undefined && typeSupportsDefault(f.type)) {
+						def.default = f.default;
+					}
 					return def;
 				});
 

--- a/web/src/lib/components/collections/FieldEditor.svelte
+++ b/web/src/lib/components/collections/FieldEditor.svelte
@@ -8,7 +8,12 @@
 </script>
 
 <script lang="ts">
-	import { FIELD_TYPES, slugifyKey, type EditableField } from './field-editor-types';
+	import {
+		FIELD_TYPES,
+		slugifyKey,
+		typeSupportsDefault,
+		type EditableField
+	} from './field-editor-types';
 
 	interface Props {
 		/** The field being edited. Mutated in place via bindings. */
@@ -125,17 +130,10 @@
 		}
 	});
 
-	// Default-value support depends on type. multi_select and relation are
-	// deliberately excluded: array defaults are complex, relation defaults are
-	// nonsensical.
-	const supportsDefault = $derived(
-		field.type === 'text' ||
-			field.type === 'url' ||
-			field.type === 'number' ||
-			field.type === 'date' ||
-			field.type === 'checkbox' ||
-			field.type === 'select'
-	);
+	// Default-value support depends on type. See typeSupportsDefault() for
+	// the full rules. We read through the shared helper so the gating logic
+	// in both modals' save paths matches the UI.
+	const supportsDefault = $derived(typeSupportsDefault(field.type));
 
 	const isRelation = $derived(field.type === 'relation');
 	const isNumber = $derived(field.type === 'number');

--- a/web/src/lib/components/collections/FieldEditor.svelte
+++ b/web/src/lib/components/collections/FieldEditor.svelte
@@ -412,7 +412,7 @@
 								aria-labelledby="default-label-{field.key || index}"
 							>
 								<option value="">— none —</option>
-								{#each field.options.filter(Boolean) as opt (opt)}
+								{#each field.options.filter(Boolean) as opt, oi (oi)}
 									<option value={opt}>{opt}</option>
 								{/each}
 							</select>

--- a/web/src/lib/components/collections/FieldEditor.svelte
+++ b/web/src/lib/components/collections/FieldEditor.svelte
@@ -403,6 +403,22 @@
 								/>
 								<span>Checked by default</span>
 							</label>
+							<!--
+								Checkbox defaults are tri-state at the schema level:
+								no default / default false / default true. The
+								checkbox itself only toggles between true and false,
+								so we need an explicit "Clear" affordance to get
+								back to `undefined`. Shown only when a value is set.
+							-->
+							{#if field.default !== undefined}
+								<button
+									type="button"
+									class="advanced-clear"
+									onclick={() => (field.default = undefined)}
+									disabled={isComputed}
+									title="Remove the default — new items won't have this field pre-filled."
+								>Clear</button>
+							{/if}
 						{:else if isSelectSingle}
 							<select
 								class="advanced-input"
@@ -956,5 +972,24 @@
 
 	.advanced-inline-check input[type='checkbox']:disabled + span {
 		opacity: 0.5;
+	}
+
+	.advanced-clear {
+		background: none;
+		border: none;
+		color: var(--text-muted);
+		font-size: 0.78em;
+		text-decoration: underline;
+		cursor: pointer;
+		padding: 0 var(--space-1);
+	}
+
+	.advanced-clear:hover:not(:disabled) {
+		color: var(--accent-red, #ef4444);
+	}
+
+	.advanced-clear:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
 	}
 </style>

--- a/web/src/lib/components/collections/FieldEditor.svelte
+++ b/web/src/lib/components/collections/FieldEditor.svelte
@@ -151,13 +151,13 @@
 		field.default = v === '' ? undefined : v;
 	}
 	function onDefaultNumberInput(e: Event) {
+		// Keep the raw string in field.default while editing. Coercing to
+		// Number on every keystroke destroys partial states like "-" or
+		// "1." (Number("1.") === 1, so the dot gets erased and users can't
+		// type decimals). `coerceDefault` converts the string to a number
+		// at save time, dropping garbage values.
 		const v = (e.currentTarget as HTMLInputElement).value;
-		if (v === '') {
-			field.default = undefined;
-			return;
-		}
-		const n = Number(v);
-		field.default = Number.isFinite(n) ? n : undefined;
+		field.default = v === '' ? undefined : v;
 	}
 	function onDefaultDateInput(e: Event) {
 		const v = (e.currentTarget as HTMLInputElement).value;

--- a/web/src/lib/components/collections/FieldEditor.svelte
+++ b/web/src/lib/components/collections/FieldEditor.svelte
@@ -1,3 +1,12 @@
+<script lang="ts" module>
+	/** Minimal collection summary passed down from the modal for the relation picker. */
+	export interface CollectionOption {
+		slug: string;
+		name: string;
+		icon?: string;
+	}
+</script>
+
 <script lang="ts">
 	import { FIELD_TYPES, slugifyKey, type EditableField } from './field-editor-types';
 
@@ -21,6 +30,13 @@
 		 * surfaced when `isNew` is true.
 		 */
 		keyError?: string | null;
+		/**
+		 * List of workspace collections, used to populate the relation target
+		 * dropdown when the field type is `relation`. The parent modal fetches
+		 * these once on open and passes them down. Undefined or empty = the
+		 * picker renders an empty-state hint.
+		 */
+		collections?: CollectionOption[];
 		/** Optional: parent provides a move-up handler. If omitted, the button is hidden. */
 		onmoveup?: () => void;
 		/** Optional: parent provides a move-down handler. If omitted, the button is hidden. */
@@ -35,6 +51,7 @@
 		total,
 		isNew = false,
 		keyError = null,
+		collections = [],
 		onmoveup,
 		onmovedown,
 		onremove
@@ -83,6 +100,100 @@
 	function isTerminal(option: string): boolean {
 		return field.terminalOptions.includes(option);
 	}
+
+	// ── Advanced section ─────────────────────────────────────────────────────
+	// Contains: required, default value, suffix (number only), relation target.
+	// Auto-expanded when the field already has any advanced value configured so
+	// the user sees what's set without hunting for it. The user can still
+	// collapse manually; the state is local to this component instance.
+
+	const hasAdvancedValues = $derived(
+		!!field.required ||
+			field.default !== undefined ||
+			!!field.suffix ||
+			!!field.collection
+	);
+	let showAdvanced = $state(false);
+	// Sync once on mount (and after field identity changes): open if the field
+	// has any pre-set advanced value. Tracked by `field.key` so reopening the
+	// modal or switching field order doesn't clobber the user's manual toggle.
+	let lastSyncedKey = $state<string | undefined>(undefined);
+	$effect.pre(() => {
+		if (field.key !== lastSyncedKey) {
+			lastSyncedKey = field.key;
+			showAdvanced = hasAdvancedValues;
+		}
+	});
+
+	// Default-value support depends on type. multi_select and relation are
+	// deliberately excluded: array defaults are complex, relation defaults are
+	// nonsensical.
+	const supportsDefault = $derived(
+		field.type === 'text' ||
+			field.type === 'url' ||
+			field.type === 'number' ||
+			field.type === 'date' ||
+			field.type === 'checkbox' ||
+			field.type === 'select'
+	);
+
+	const isRelation = $derived(field.type === 'relation');
+	const isNumber = $derived(field.type === 'number');
+	const isCheckboxType = $derived(field.type === 'checkbox');
+	const isSelectSingle = $derived(field.type === 'select');
+
+	// Computed fields are read-only — they're populated by the server / agent,
+	// not the user. We still render them, but disable the advanced controls.
+	const isComputed = $derived(!!field.computed);
+
+	// `field.default` is polymorphic (string | number | boolean). We use typed
+	// handlers to keep the serialized value in the right shape.
+	function onDefaultTextInput(e: Event) {
+		const v = (e.currentTarget as HTMLInputElement).value;
+		field.default = v === '' ? undefined : v;
+	}
+	function onDefaultNumberInput(e: Event) {
+		const v = (e.currentTarget as HTMLInputElement).value;
+		if (v === '') {
+			field.default = undefined;
+			return;
+		}
+		const n = Number(v);
+		field.default = Number.isFinite(n) ? n : undefined;
+	}
+	function onDefaultDateInput(e: Event) {
+		const v = (e.currentTarget as HTMLInputElement).value;
+		field.default = v === '' ? undefined : v;
+	}
+	function onDefaultCheckboxInput(e: Event) {
+		field.default = (e.currentTarget as HTMLInputElement).checked;
+	}
+	function onDefaultSelectInput(e: Event) {
+		const v = (e.currentTarget as HTMLSelectElement).value;
+		field.default = v === '' ? undefined : v;
+	}
+	function onSuffixInput(e: Event) {
+		const v = (e.currentTarget as HTMLInputElement).value;
+		field.suffix = v === '' ? undefined : v;
+	}
+	function onCollectionInput(e: Event) {
+		const v = (e.currentTarget as HTMLSelectElement).value;
+		field.collection = v === '' ? undefined : v;
+	}
+	function onRequiredInput(e: Event) {
+		// Keep undefined rather than `false` so save payloads stay compact and
+		// round-trip-compatible with existing schemas.
+		field.required = (e.currentTarget as HTMLInputElement).checked || undefined;
+	}
+
+	// Coerce `field.default` to a string for text/number/date/select inputs.
+	const defaultAsString = $derived.by(() => {
+		if (field.default === undefined || field.default === null) return '';
+		if (typeof field.default === 'string') return field.default;
+		if (typeof field.default === 'number') return String(field.default);
+		return '';
+	});
+	const defaultAsBool = $derived(field.default === true);
 </script>
 
 <div class="field-card">
@@ -151,6 +262,13 @@
 			aria-label="Remove field"
 		>&#10005;</button>
 	</div>
+
+	{#if isComputed}
+		<div class="field-computed-badge" title="Computed fields are populated by the server and can't be configured here.">
+			<span class="computed-dot" aria-hidden="true"></span>
+			<span>computed</span>
+		</div>
+	{/if}
 
 	{#if isSelectType}
 		<div class="field-options">
@@ -240,6 +358,146 @@
 			<button class="option-add-btn" type="button" onclick={addOption}>+ Add option</button>
 		</div>
 	{/if}
+
+	<div class="field-advanced">
+		<button
+			type="button"
+			class="advanced-toggle"
+			onclick={() => (showAdvanced = !showAdvanced)}
+			aria-expanded={showAdvanced}
+		>
+			<span class="advanced-chevron" class:open={showAdvanced} aria-hidden="true">
+				<svg width="10" height="10" viewBox="0 0 10 10" fill="none">
+					<path d="M3 2L7 5L3 8" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+				</svg>
+			</span>
+			<span>Advanced</span>
+			{#if hasAdvancedValues && !showAdvanced}
+				<span class="advanced-badge" aria-label="Field has advanced settings configured">●</span>
+			{/if}
+		</button>
+
+		{#if showAdvanced}
+			<div class="advanced-content">
+				<!-- Required -->
+				<label class="advanced-row advanced-row--inline">
+					<input
+						type="checkbox"
+						checked={!!field.required}
+						onchange={onRequiredInput}
+						disabled={isComputed}
+					/>
+					<span class="advanced-label">Required</span>
+					<span class="advanced-hint">Item can't be saved without a value.</span>
+				</label>
+
+				<!-- Default value (type-appropriate) -->
+				{#if supportsDefault}
+					<div class="advanced-row">
+						<span class="advanced-label" id="default-label-{field.key || index}">Default value</span>
+						{#if isCheckboxType}
+							<label class="advanced-inline-check">
+								<input
+									type="checkbox"
+									checked={defaultAsBool}
+									onchange={onDefaultCheckboxInput}
+									disabled={isComputed}
+								/>
+								<span>Checked by default</span>
+							</label>
+						{:else if isSelectSingle}
+							<select
+								class="advanced-input"
+								value={defaultAsString}
+								onchange={onDefaultSelectInput}
+								disabled={isComputed}
+								aria-labelledby="default-label-{field.key || index}"
+							>
+								<option value="">— none —</option>
+								{#each field.options.filter(Boolean) as opt (opt)}
+									<option value={opt}>{opt}</option>
+								{/each}
+							</select>
+						{:else if isNumber}
+							<input
+								class="advanced-input"
+								type="number"
+								value={defaultAsString}
+								oninput={onDefaultNumberInput}
+								disabled={isComputed}
+								placeholder="e.g. 0"
+								aria-labelledby="default-label-{field.key || index}"
+							/>
+						{:else if field.type === 'date'}
+							<input
+								class="advanced-input"
+								type="date"
+								value={defaultAsString}
+								oninput={onDefaultDateInput}
+								disabled={isComputed}
+								aria-labelledby="default-label-{field.key || index}"
+							/>
+						{:else}
+							<input
+								class="advanced-input"
+								type={field.type === 'url' ? 'url' : 'text'}
+								value={defaultAsString}
+								oninput={onDefaultTextInput}
+								disabled={isComputed}
+								placeholder={field.type === 'url' ? 'https://...' : 'Empty = no default'}
+								aria-labelledby="default-label-{field.key || index}"
+							/>
+						{/if}
+					</div>
+				{/if}
+
+				<!-- Suffix (number only) -->
+				{#if isNumber}
+					<div class="advanced-row">
+						<span class="advanced-label" id="suffix-label-{field.key || index}">Suffix</span>
+						<input
+							class="advanced-input advanced-input--short"
+							type="text"
+							value={field.suffix ?? ''}
+							oninput={onSuffixInput}
+							disabled={isComputed}
+							placeholder="hrs, %, kg…"
+							maxlength="8"
+							aria-labelledby="suffix-label-{field.key || index}"
+						/>
+						<span class="advanced-hint">Shown next to the number when rendered.</span>
+					</div>
+				{/if}
+
+				<!-- Relation target (relation only) -->
+				{#if isRelation}
+					<div class="advanced-row">
+						<span class="advanced-label" id="relation-label-{field.key || index}">Relates to</span>
+						{#if collections.length === 0}
+							<span class="advanced-hint advanced-hint--alone">
+								No collections available to link. Create another collection first.
+							</span>
+						{:else}
+							<select
+								class="advanced-input"
+								value={field.collection ?? ''}
+								onchange={onCollectionInput}
+								disabled={isComputed}
+								aria-labelledby="relation-label-{field.key || index}"
+							>
+								<option value="">— pick a collection —</option>
+								{#each collections as c (c.slug)}
+									<option value={c.slug}>
+										{c.icon ? `${c.icon} ` : ''}{c.name}
+									</option>
+								{/each}
+							</select>
+						{/if}
+					</div>
+				{/if}
+			</div>
+		{/if}
+	</div>
 </div>
 
 <style>
@@ -549,5 +807,156 @@
 	.option-add-btn:hover {
 		color: var(--accent-blue);
 		background: color-mix(in srgb, var(--accent-blue) 6%, transparent);
+	}
+
+	/* ── Computed badge ───────────────────────────────────────────────────── */
+
+	.field-computed-badge {
+		display: flex;
+		align-items: center;
+		gap: var(--space-2);
+		padding: var(--space-1) var(--space-3);
+		margin: 0 var(--space-3) var(--space-2);
+		background: color-mix(in srgb, var(--text-muted) 8%, transparent);
+		border-radius: var(--radius-sm);
+		font-size: 0.7em;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		color: var(--text-muted);
+		width: fit-content;
+	}
+
+	.computed-dot {
+		width: 6px;
+		height: 6px;
+		border-radius: 50%;
+		background: currentColor;
+		opacity: 0.7;
+	}
+
+	/* ── Advanced section ─────────────────────────────────────────────────── */
+
+	.field-advanced {
+		border-top: 1px solid var(--border);
+	}
+
+	.advanced-toggle {
+		display: flex;
+		align-items: center;
+		gap: var(--space-2);
+		width: 100%;
+		padding: var(--space-2) var(--space-3);
+		background: none;
+		border: none;
+		color: var(--text-muted);
+		font-size: 0.78em;
+		font-weight: 500;
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+		cursor: pointer;
+		text-align: left;
+	}
+
+	.advanced-toggle:hover {
+		color: var(--text-secondary);
+		background: color-mix(in srgb, var(--text-muted) 4%, transparent);
+	}
+
+	.advanced-chevron {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		transition: transform 0.15s ease;
+	}
+
+	.advanced-chevron.open {
+		transform: rotate(90deg);
+	}
+
+	.advanced-badge {
+		margin-left: auto;
+		color: var(--accent-blue);
+		font-size: 0.9em;
+		line-height: 1;
+	}
+
+	.advanced-content {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-2);
+		padding: 0 var(--space-3) var(--space-3);
+	}
+
+	.advanced-row {
+		display: flex;
+		align-items: center;
+		gap: var(--space-2);
+		flex-wrap: wrap;
+	}
+
+	.advanced-row--inline {
+		cursor: pointer;
+	}
+
+	.advanced-label {
+		font-size: 0.78em;
+		font-weight: 500;
+		color: var(--text-secondary);
+		min-width: 90px;
+	}
+
+	.advanced-hint {
+		font-size: 0.72em;
+		color: var(--text-muted);
+	}
+
+	.advanced-hint--alone {
+		flex: 1;
+		font-style: italic;
+	}
+
+	.advanced-input {
+		flex: 1;
+		min-width: 140px;
+		padding: var(--space-1) var(--space-2);
+		background: var(--bg-secondary);
+		border: 1px solid transparent;
+		border-radius: var(--radius-sm);
+		font-size: 0.85em;
+		color: var(--text-primary);
+	}
+
+	.advanced-input--short {
+		flex: 0 0 auto;
+		width: 90px;
+		min-width: 90px;
+	}
+
+	.advanced-input:hover:not(:disabled) {
+		border-color: var(--border);
+	}
+
+	.advanced-input:focus {
+		border-color: var(--accent-blue);
+		outline: none;
+	}
+
+	.advanced-input:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+
+	.advanced-inline-check {
+		display: inline-flex;
+		align-items: center;
+		gap: var(--space-2);
+		font-size: 0.85em;
+		color: var(--text-primary);
+		cursor: pointer;
+	}
+
+	.advanced-inline-check input[type='checkbox']:disabled + span {
+		opacity: 0.5;
 	}
 </style>

--- a/web/src/lib/components/collections/FieldEditor.svelte
+++ b/web/src/lib/components/collections/FieldEditor.svelte
@@ -192,6 +192,16 @@
 		return '';
 	});
 	const defaultAsBool = $derived(field.default === true);
+	// <input type="date"> only accepts a YYYY-MM-DD value; an RFC3339
+	// datetime like "2026-01-01T10:00:00Z" would render blank and mislead
+	// the user into thinking there is no default. We truncate for display
+	// only — the underlying field.default stays untouched until the user
+	// actually picks a new date.
+	const dateDefaultDisplay = $derived.by(() => {
+		if (typeof field.default !== 'string') return '';
+		const m = /^(\d{4}-\d{2}-\d{2})/.exec(field.default);
+		return m ? m[1] : '';
+	});
 </script>
 
 <div class="field-card">
@@ -446,7 +456,7 @@
 							<input
 								class="advanced-input"
 								type="date"
-								value={defaultAsString}
+								value={dateDefaultDisplay}
 								oninput={onDefaultDateInput}
 								disabled={isComputed}
 								aria-labelledby="default-label-{field.key || index}"

--- a/web/src/lib/components/collections/field-editor-types.ts
+++ b/web/src/lib/components/collections/field-editor-types.ts
@@ -244,8 +244,18 @@ export function coerceDefault(
 				const hour = Number(dt[4]);
 				const min = Number(dt[5]);
 				const sec = Number(dt[6]);
+				const tz = dt[7];
 				if (month < 1 || month > 12 || day < 1 || day > 31) return undefined;
 				if (hour > 23 || min > 59 || sec > 59) return undefined;
+				// Validate the timezone offset numerically. The regex only
+				// enforces the `±hh:mm` shape; offsets like `+99:99` would
+				// otherwise slip through. Go's time.RFC3339 (backend
+				// parser) accepts any offset within ±23:59 minutes.
+				if (tz !== 'Z') {
+					const offH = Number(tz.slice(1, 3));
+					const offM = Number(tz.slice(4, 6));
+					if (offH > 23 || offM > 59) return undefined;
+				}
 				// Round-trip verify the date components: if the day is out
 				// of range for the month (e.g. Feb 31), Date.UTC rolls it
 				// forward and the components won't match.

--- a/web/src/lib/components/collections/field-editor-types.ts
+++ b/web/src/lib/components/collections/field-editor-types.ts
@@ -9,6 +9,11 @@ import type { FieldDef } from '$lib/types';
  *   build rename migrations on save.
  * - `terminalOptions` is always an array for easier binding (mirrors
  *   FieldDef.terminal_options).
+ * - `originalType` snapshots the field's type at load time. The
+ *   Edit-modal save path uses this to decide whether a default on an
+ *   otherwise-unsupported-for-UI type (multi_select, relation) is
+ *   opaque imported state to preserve or stale state from an in-session
+ *   type switch that should be dropped.
  * - `keyTouched` is a UI-only flag (not serialized) that tracks whether the
  *   user has manually edited the key. When false (and the field is new),
  *   FieldEditor auto-derives the key from the label on every change. Once
@@ -31,6 +36,8 @@ export interface EditableField {
 	collection?: string;
 	suffix?: string;
 	default?: unknown;
+	/** UI-only: the field's type at load time, used to detect in-session type switches. */
+	originalType?: FieldDef['type'];
 	/** UI-only: true once the user has manually edited the key. */
 	keyTouched?: boolean;
 }
@@ -218,14 +225,16 @@ export function coerceDefault(
 				return undefined;
 			}
 
-			// RFC3339 datetime: YYYY-MM-DDThh:mm[:ss[.frac]][Z|±hh:mm].
-			// Parse components explicitly and validate each against its
-			// valid range. `new Date(...)` alone is too permissive — it
-			// silently rolls invalid dates (e.g. "2026-02-31T10:00:00Z"
-			// becomes March 3), so a round-trip component check is
-			// required to reject impossible timestamps.
+			// Strict RFC3339 datetime: YYYY-MM-DDThh:mm:ss[.frac](Z|±hh:mm).
+			// Timezone is required. Offsets must include the colon
+			// separator (+01:00, not +0100). Seconds are required to match
+			// RFC3339 (the backend's time.RFC3339 parser also requires
+			// them). `new Date(...)` alone is too permissive — it silently
+			// rolls invalid dates (e.g. "2026-02-31T10:00:00Z" becomes
+			// March 3), so component-level round-trip verification is
+			// still needed.
 			const dt =
-				/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})(?::(\d{2})(?:\.\d+)?)?(Z|[+-]\d{2}:?\d{2})?$/.exec(
+				/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d+)?(Z|[+-]\d{2}:\d{2})$/.exec(
 					trimmed
 				);
 			if (dt) {
@@ -234,7 +243,7 @@ export function coerceDefault(
 				const day = Number(dt[3]);
 				const hour = Number(dt[4]);
 				const min = Number(dt[5]);
-				const sec = dt[6] !== undefined ? Number(dt[6]) : 0;
+				const sec = Number(dt[6]);
 				if (month < 1 || month > 12 || day < 1 || day > 31) return undefined;
 				if (hour > 23 || min > 59 || sec > 59) return undefined;
 				// Round-trip verify the date components: if the day is out
@@ -305,6 +314,7 @@ export function fieldFromDef(def: FieldDef, existing: boolean): EditableField {
 		collection: def.collection,
 		suffix: def.suffix,
 		default: def.default,
+		originalType: def.type,
 		// Both existing and template fields start with keyTouched=true so
 		// the key is preserved verbatim, not overwritten by slugify(label).
 		keyTouched: true

--- a/web/src/lib/components/collections/field-editor-types.ts
+++ b/web/src/lib/components/collections/field-editor-types.ts
@@ -188,8 +188,16 @@ export function coerceDefault(
 			}
 			return undefined;
 		}
-		case 'date':
-			return typeof raw === 'string' && raw.trim() !== '' ? raw : undefined;
+		case 'date': {
+			// Require ISO 8601 date or datetime format. HTML <input type="date">
+			// emits YYYY-MM-DD; we also accept a datetime suffix so imported
+			// schemas with RFC3339-style defaults round-trip. Server performs
+			// stricter validation; this gate just prevents obvious garbage like
+			// "soon" from surviving a type switch.
+			if (typeof raw !== 'string') return undefined;
+			const trimmed = raw.trim();
+			return /^\d{4}-\d{2}-\d{2}(T.+)?$/.test(trimmed) ? trimmed : undefined;
+		}
 		case 'checkbox':
 			return typeof raw === 'boolean' ? raw : undefined;
 		case 'select': {

--- a/web/src/lib/components/collections/field-editor-types.ts
+++ b/web/src/lib/components/collections/field-editor-types.ts
@@ -122,6 +122,29 @@ export function validateFieldKey(key: string): string | null {
 	return null;
 }
 
+/**
+ * Does a field of this type support a default value?
+ *
+ * Shared by FieldEditor (to decide whether to render the default input)
+ * and by both modals' save paths (to gate `default` emission so stale
+ * values from a prior type don't leak into the saved schema when the
+ * user switches types).
+ *
+ * multi_select: deliberately excluded — array defaults are complex and
+ * deferred.
+ * relation: excluded — a default target item isn't meaningful here.
+ */
+export function typeSupportsDefault(type: FieldDef['type']): boolean {
+	return (
+		type === 'text' ||
+		type === 'url' ||
+		type === 'number' ||
+		type === 'date' ||
+		type === 'checkbox' ||
+		type === 'select'
+	);
+}
+
 /** Create an empty EditableField for a new (unsaved) field. */
 export function blankField(): EditableField {
 	return {

--- a/web/src/lib/components/collections/field-editor-types.ts
+++ b/web/src/lib/components/collections/field-editor-types.ts
@@ -189,14 +189,47 @@ export function coerceDefault(
 			return undefined;
 		}
 		case 'date': {
-			// Require ISO 8601 date or datetime format. HTML <input type="date">
-			// emits YYYY-MM-DD; we also accept a datetime suffix so imported
-			// schemas with RFC3339-style defaults round-trip. Server performs
-			// stricter validation; this gate just prevents obvious garbage like
-			// "soon" from surviving a type switch.
+			// Require a real calendar date in ISO 8601 form. HTML <input
+			// type="date"> emits YYYY-MM-DD; imported schemas may carry
+			// RFC3339 datetime strings. A regex alone isn't enough — it would
+			// accept impossible dates like "2026-99-99" or "2026-01-32",
+			// which then survive into the saved schema and get injected into
+			// new items by ValidateFields without re-checking.
 			if (typeof raw !== 'string') return undefined;
 			const trimmed = raw.trim();
-			return /^\d{4}-\d{2}-\d{2}(T.+)?$/.test(trimmed) ? trimmed : undefined;
+
+			// Plain date: YYYY-MM-DD. Round-trip verify against Date to
+			// reject out-of-range months/days (e.g. 2026-01-32 would be
+			// silently rolled to 2026-02-01 otherwise).
+			const ymd = /^(\d{4})-(\d{2})-(\d{2})$/.exec(trimmed);
+			if (ymd) {
+				const year = Number(ymd[1]);
+				const month = Number(ymd[2]);
+				const day = Number(ymd[3]);
+				if (month < 1 || month > 12 || day < 1 || day > 31) return undefined;
+				const parsed = new Date(Date.UTC(year, month - 1, day));
+				if (
+					parsed.getUTCFullYear() === year &&
+					parsed.getUTCMonth() + 1 === month &&
+					parsed.getUTCDate() === day
+				) {
+					return trimmed;
+				}
+				return undefined;
+			}
+
+			// RFC3339 datetime: YYYY-MM-DDThh:mm[:ss[.frac]][Z|±hh:mm].
+			// Shape-check first so we don't accept loose strings the Date
+			// constructor happens to parse (e.g. "2026 Apr 17").
+			const dt =
+				/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2}(\.\d+)?)?(Z|[+-]\d{2}:?\d{2})?$/.exec(
+					trimmed
+				);
+			if (dt) {
+				const parsed = new Date(trimmed);
+				if (Number.isFinite(parsed.getTime())) return trimmed;
+			}
+			return undefined;
 		}
 		case 'checkbox':
 			return typeof raw === 'boolean' ? raw : undefined;

--- a/web/src/lib/components/collections/field-editor-types.ts
+++ b/web/src/lib/components/collections/field-editor-types.ts
@@ -38,6 +38,13 @@ export interface EditableField {
 	default?: unknown;
 	/** UI-only: the field's type at load time, used to detect in-session type switches. */
 	originalType?: FieldDef['type'];
+	/**
+	 * UI-only: the field's default at load time. Paired with `originalType`
+	 * by the Edit-modal save path to detect when a default on a UI-
+	 * unsupported type has been altered in-session (e.g. via a
+	 * supported-type detour) and should be dropped rather than preserved.
+	 */
+	originalDefault?: unknown;
 	/** UI-only: true once the user has manually edited the key. */
 	keyTouched?: boolean;
 }
@@ -288,6 +295,25 @@ export function coerceDefault(
 	}
 }
 
+/**
+ * Deep-equality check for default values, tolerant of the polymorphic
+ * shapes a default can take (string | number | boolean | string[] for
+ * multi_select). Uses JSON stringification — fine for schema defaults,
+ * which are always JSON-serializable primitives and arrays.
+ *
+ * Used by the Edit modal to decide whether a default on a UI-
+ * unsupported-for-editing type has been mutated in-session.
+ */
+export function defaultsEqual(a: unknown, b: unknown): boolean {
+	if (a === b) return true;
+	if (a === undefined || b === undefined) return false;
+	try {
+		return JSON.stringify(a) === JSON.stringify(b);
+	} catch {
+		return false;
+	}
+}
+
 /** Create an empty EditableField for a new (unsaved) field. */
 export function blankField(): EditableField {
 	return {
@@ -325,6 +351,7 @@ export function fieldFromDef(def: FieldDef, existing: boolean): EditableField {
 		suffix: def.suffix,
 		default: def.default,
 		originalType: def.type,
+		originalDefault: def.default,
 		// Both existing and template fields start with keyTouched=true so
 		// the key is preserved verbatim, not overwritten by slugify(label).
 		keyTouched: true

--- a/web/src/lib/components/collections/field-editor-types.ts
+++ b/web/src/lib/components/collections/field-editor-types.ts
@@ -219,15 +219,35 @@ export function coerceDefault(
 			}
 
 			// RFC3339 datetime: YYYY-MM-DDThh:mm[:ss[.frac]][Z|±hh:mm].
-			// Shape-check first so we don't accept loose strings the Date
-			// constructor happens to parse (e.g. "2026 Apr 17").
+			// Parse components explicitly and validate each against its
+			// valid range. `new Date(...)` alone is too permissive — it
+			// silently rolls invalid dates (e.g. "2026-02-31T10:00:00Z"
+			// becomes March 3), so a round-trip component check is
+			// required to reject impossible timestamps.
 			const dt =
-				/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2}(\.\d+)?)?(Z|[+-]\d{2}:?\d{2})?$/.exec(
+				/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})(?::(\d{2})(?:\.\d+)?)?(Z|[+-]\d{2}:?\d{2})?$/.exec(
 					trimmed
 				);
 			if (dt) {
-				const parsed = new Date(trimmed);
-				if (Number.isFinite(parsed.getTime())) return trimmed;
+				const year = Number(dt[1]);
+				const month = Number(dt[2]);
+				const day = Number(dt[3]);
+				const hour = Number(dt[4]);
+				const min = Number(dt[5]);
+				const sec = dt[6] !== undefined ? Number(dt[6]) : 0;
+				if (month < 1 || month > 12 || day < 1 || day > 31) return undefined;
+				if (hour > 23 || min > 59 || sec > 59) return undefined;
+				// Round-trip verify the date components: if the day is out
+				// of range for the month (e.g. Feb 31), Date.UTC rolls it
+				// forward and the components won't match.
+				const parsed = new Date(Date.UTC(year, month - 1, day));
+				if (
+					parsed.getUTCFullYear() === year &&
+					parsed.getUTCMonth() + 1 === month &&
+					parsed.getUTCDate() === day
+				) {
+					return trimmed;
+				}
 			}
 			return undefined;
 		}

--- a/web/src/lib/components/collections/field-editor-types.ts
+++ b/web/src/lib/components/collections/field-editor-types.ts
@@ -145,6 +145,69 @@ export function typeSupportsDefault(type: FieldDef['type']): boolean {
 	);
 }
 
+/**
+ * Coerce a raw `field.default` value to match the active field type,
+ * returning undefined when the value isn't representable (so the caller
+ * can drop it).
+ *
+ * This guards against two failure modes that the save paths would
+ * otherwise propagate into the saved schema:
+ *
+ * 1. Type-switch drift: a user sets a default on a `checkbox` field
+ *    (boolean `true`), switches the type to `text`, and the stale
+ *    boolean would be serialized as the text default. ValidateFields
+ *    would then auto-apply it to new items without re-validating.
+ *
+ * 2. Select whitespace drift: option text is normalized via `o.trim()`
+ *    at serialize time (e.g. "open " -> "open"), but the raw default
+ *    value captured at pick time still carries the whitespace. The
+ *    saved schema would have `options:["open"]` + `default:"open "` —
+ *    a default that isn't in the allowed set.
+ *
+ * @param raw the current `field.default` value (polymorphic)
+ * @param type the active field type at save time
+ * @param options for `select` fields, the already-normalized option set.
+ *   When supplied, the coerced default must be one of these values or
+ *   it is dropped.
+ */
+export function coerceDefault(
+	raw: unknown,
+	type: FieldDef['type'],
+	options?: string[]
+): unknown {
+	if (raw === undefined || raw === null) return undefined;
+	switch (type) {
+		case 'text':
+		case 'url':
+			return typeof raw === 'string' && raw !== '' ? raw : undefined;
+		case 'number': {
+			if (typeof raw === 'number' && Number.isFinite(raw)) return raw;
+			if (typeof raw === 'string' && raw.trim() !== '') {
+				const n = Number(raw);
+				return Number.isFinite(n) ? n : undefined;
+			}
+			return undefined;
+		}
+		case 'date':
+			return typeof raw === 'string' && raw.trim() !== '' ? raw : undefined;
+		case 'checkbox':
+			return typeof raw === 'boolean' ? raw : undefined;
+		case 'select': {
+			if (typeof raw !== 'string') return undefined;
+			const trimmed = raw.trim();
+			if (trimmed === '') return undefined;
+			// When the caller supplies the normalized options set, the
+			// default must be one of them. This catches (a) whitespace
+			// drift between option text and default text, and (b) stale
+			// defaults from when the options list was different.
+			if (options && !options.includes(trimmed)) return undefined;
+			return trimmed;
+		}
+		default:
+			return undefined;
+	}
+}
+
 /** Create an empty EditableField for a new (unsaved) field. */
 export function blankField(): EditableField {
 	return {


### PR DESCRIPTION
## Summary
Part of [PLAN-593 — Collection Modal Redesign](https://github.com/xarmian/pad). Surfaces field capabilities that already round-tripped through `EditableField` but had no UI. All controls live in a collapsible **Advanced** section on each field card.

**Closes TASK-596 in PLAN-593.**

## What's new

### `FieldEditor.svelte`
- Exports a new `CollectionOption` type for the relation picker input.
- **Advanced section** on each field card, collapsed by default. Auto-expanded when any of `required` / `default` / `suffix` / `collection` is already set — shows a small blue dot on the collapsed header when there are hidden values. Contains:
  - **Required** checkbox (all types)
  - **Default value** — type-appropriate input:
    - text / url → text input
    - number → number input (+ **Suffix** row below)
    - date → date picker
    - checkbox → \"Checked by default\" toggle
    - single select → dropdown restricted to the field's options
    - multi_select / relation → deliberately skipped (array default is complex; relation default is nonsensical)
  - **Relates to** dropdown (relation type only), populated from the workspace collections list. Shows a helpful empty-state when no other collections exist.
- **Computed** fields render a muted badge and the advanced inputs are disabled. Label / type / remove stay editable to match current behavior.
- Typed input handlers coerce `field.default` into the right shape (string / number / boolean) so the polymorphic value stays clean.

### `CreateCollectionModal.svelte` + `EditCollectionModal.svelte`
- Both fetch `api.collections.list(ws)` lazily on open and pass the result down to every `FieldEditor` as `collections`. Fetch failure falls back to empty state (picker shows the empty-state hint).
- Both **new-field save paths** now emit `required` / `computed` / `suffix` / `collection` / `default` onto the serialized `FieldDef`. (Existing-field path in `EditCollectionModal` already handled these; this brings the new-field paths to parity and adds equivalent handling in `CreateCollectionModal`.)
- Emit-when-set keeps payloads compact and compatible with existing schemas.

## Test plan
- [x] `go build ./...` / `go test ./...` — clean
- [x] `cd web && npm run build` — clean
- [x] Manual smoke test:
  - [x] Create a number field with required + default `1` + suffix `hrs` → save → reopen: all three round-trip
  - [x] Create a select field with default set to one of its options → persists
  - [x] Create a relation field → \"Relates to\" dropdown lists workspace collections, picking one persists as `collection: slug`
  - [x] Edit modal: existing status field's `required: true` + `default: 'open'` round-trip
  - [x] Advanced auto-expands when a field has values; collapses/expands manually afterward without clobbering state
  - [x] Computed-field simulation: badge renders and advanced inputs are disabled

## Known deferred
Advanced section increases card height, which may exacerbate the type-select alignment issue already tracked on TASK-598 (visual redesign). Not addressed here.

## Out of scope
- Generalizing terminal options to non-status select fields → TASK-597
- Visual redesign → TASK-598
- Create-time feature parity for Display / Quick Actions → TASK-599