### PR TITLE
feat(web): contextual browser-tab titles (IDEA-592)

### DIFF
--- a/web/src/lib/stores/title.svelte.ts
+++ b/web/src/lib/stores/title.svelte.ts
@@ -1,0 +1,88 @@
+/**
+ * Title store — central source of truth for the browser-tab title.
+ *
+ * The root layout's `<svelte:head><title>` reads `titleStore.title`
+ * reactively, and route-level pages call `titleStore.setPageTitle(...)`
+ * (wired up in TASK-603) to contribute their context.
+ *
+ * Format (most-specific-first, so tab truncation keeps the useful bits):
+ *   - item set:      `{item} · {workspace} · Pad`
+ *   - section set:   `{section} · {workspace} · Pad`
+ *   - workspace set: `{workspace} · Pad`
+ *   - otherwise:     `Pad`
+ * Workspace is skipped from the composed string if it is unset.
+ *
+ * Tracked by IDEA-592 / PLAN-601 / TASK-602.
+ */
+
+const SEP = ' \u00B7 '; // " · " — U+00B7 middle dot, with surrounding spaces
+const APP_NAME = 'Pad';
+
+let workspace = $state<string | undefined>(undefined);
+let section = $state<string | undefined>(undefined);
+let item = $state<string | undefined>(undefined);
+
+const title = $derived.by(() => {
+	if (item) {
+		return workspace
+			? `${item}${SEP}${workspace}${SEP}${APP_NAME}`
+			: `${item}${SEP}${APP_NAME}`;
+	}
+	if (section) {
+		return workspace
+			? `${section}${SEP}${workspace}${SEP}${APP_NAME}`
+			: `${section}${SEP}${APP_NAME}`;
+	}
+	if (workspace) {
+		return `${workspace}${SEP}${APP_NAME}`;
+	}
+	return APP_NAME;
+});
+
+export interface PageTitleParts {
+	workspace?: string | null;
+	section?: string | null;
+	item?: string | null;
+}
+
+export const titleStore = {
+	/** Composed browser-tab title, reactive. */
+	get title() { return title; },
+
+	/** Current workspace display name (for debugging/inspection). */
+	get workspace() { return workspace; },
+	/** Current section label (for debugging/inspection). */
+	get section() { return section; },
+	/** Current item ref (for debugging/inspection). */
+	get item() { return item; },
+
+	/**
+	 * Merge the provided keys into title state.
+	 *
+	 * Semantics per key:
+	 *  - omitted (key not present on `parts`): leave existing value unchanged
+	 *  - `null`: explicitly clear that key back to `undefined`
+	 *  - a string: set that key
+	 *
+	 * This lets a route set only what it knows (e.g. `{ section: 'Ideas' }`)
+	 * without clobbering the workspace that the layout set earlier.
+	 */
+	setPageTitle(parts: PageTitleParts) {
+		if ('workspace' in parts) {
+			workspace = parts.workspace ?? undefined;
+		}
+		if ('section' in parts) {
+			section = parts.section ?? undefined;
+		}
+		if ('item' in parts) {
+			item = parts.item ?? undefined;
+		}
+	},
+
+	/** Reset all parts; the resulting title is bare `Pad`. */
+	clearPageTitle() {
+		workspace = undefined;
+		section = undefined;
+		item = undefined;
+	},
+};

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -6,6 +6,7 @@
 	import { workspaceStore } from '$lib/stores/workspace.svelte';
 	import { authStore } from '$lib/stores/auth.svelte';
 	import { uiStore } from '$lib/stores/ui.svelte';
+	import { titleStore } from '$lib/stores/title.svelte';
 	import Sidebar from '$lib/components/layout/Sidebar.svelte';
 	import TopBar from '$lib/components/layout/TopBar.svelte';
 	import CommandPalette from '$lib/components/search/CommandPalette.svelte';
@@ -150,7 +151,7 @@
 </script>
 
 <svelte:head>
-	<title>Pad</title>
+	<title>{titleStore.title}</title>
 	<meta name="description" content="Project management for developers and AI agents" />
 	<meta property="og:title" content="Pad" />
 	<meta property="og:description" content="Project management for developers and AI agents" />

--- a/web/src/routes/[username]/[workspace]/+layout.svelte
+++ b/web/src/routes/[username]/[workspace]/+layout.svelte
@@ -40,9 +40,22 @@
 		titleStore.clearPageTitle();
 	});
 
-	// Keep browser tab title in sync with the current workspace name.
+	// Keep browser tab title in sync with the current workspace, and clear any
+	// stale section/item on every route change. Leaf pages under this layout
+	// that are wired to the title store (workspace home, collection list, item
+	// detail, activity) re-set their own parts in child `$effect`s that run
+	// after this one — Svelte 5 guarantees parent effects run before child
+	// effects. Unwired routes (settings, roles, etc.) inherit the cleared
+	// state and fall back to `{Workspace} · Pad`.
 	$effect(() => {
-		titleStore.setPageTitle({ workspace: workspaceStore.current?.name ?? null });
+		// Read pathname so this effect re-runs on every SPA navigation,
+		// not only when the workspace name changes.
+		page.url.pathname;
+		titleStore.setPageTitle({
+			workspace: workspaceStore.current?.name ?? null,
+			section: null,
+			item: null,
+		});
 	});
 
 	// Initialize workspace, load collections, and reconnect SSE when workspace changes

--- a/web/src/routes/[username]/[workspace]/+layout.svelte
+++ b/web/src/routes/[username]/[workspace]/+layout.svelte
@@ -40,22 +40,26 @@
 		titleStore.clearPageTitle();
 	});
 
-	// Keep browser tab title in sync with the current workspace, and clear any
-	// stale section/item on every route change. Leaf pages under this layout
-	// that are wired to the title store (workspace home, collection list, item
-	// detail, activity) re-set their own parts in child `$effect`s that run
-	// after this one — Svelte 5 guarantees parent effects run before child
-	// effects. Unwired routes (settings, roles, etc.) inherit the cleared
-	// state and fall back to `{Workspace} · Pad`.
+	// These two effects are split on purpose:
+	//
+	// 1. Workspace-name sync: runs whenever `workspaceStore.current` resolves
+	//    or changes. It only touches `workspace` — if it also cleared
+	//    section/item, an async workspace-name arrival AFTER a leaf page had
+	//    set its section/item would wipe that context.
+	//
+	// 2. Route-change clear: depends only on `page.url.pathname`, so it runs
+	//    exactly once per SPA navigation and clears section/item. Leaf pages
+	//    wired to the title store (workspace home, collection list, item
+	//    detail, activity) re-set their parts in child `$effect`s that run
+	//    after this one — Svelte 5 guarantees parent effects run before
+	//    child effects. Unwired routes (settings, roles, etc.) inherit the
+	//    cleared state and fall back to `{Workspace} · Pad`.
 	$effect(() => {
-		// Read pathname so this effect re-runs on every SPA navigation,
-		// not only when the workspace name changes.
+		titleStore.setPageTitle({ workspace: workspaceStore.current?.name ?? null });
+	});
+	$effect(() => {
 		page.url.pathname;
-		titleStore.setPageTitle({
-			workspace: workspaceStore.current?.name ?? null,
-			section: null,
-			item: null,
-		});
+		titleStore.setPageTitle({ section: null, item: null });
 	});
 
 	// Initialize workspace, load collections, and reconnect SSE when workspace changes

--- a/web/src/routes/[username]/[workspace]/+layout.svelte
+++ b/web/src/routes/[username]/[workspace]/+layout.svelte
@@ -9,6 +9,7 @@
 	import { api } from '$lib/api/client';
 	import { toastStore } from '$lib/stores/toast.svelte';
 	import { starredStore } from '$lib/stores/starred.svelte';
+	import { titleStore } from '$lib/stores/title.svelte';
 
 	let { children } = $props();
 
@@ -36,6 +37,12 @@
 		unsubscribeSSE?.();
 		unsubscribeSync?.();
 		sseService.disconnect();
+		titleStore.clearPageTitle();
+	});
+
+	// Keep browser tab title in sync with the current workspace name.
+	$effect(() => {
+		titleStore.setPageTitle({ workspace: workspaceStore.current?.name ?? null });
 	});
 
 	// Initialize workspace, load collections, and reconnect SSE when workspace changes

--- a/web/src/routes/[username]/[workspace]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/+page.svelte
@@ -8,6 +8,7 @@
 	import { syncService } from '$lib/services/sync.svelte';
 	import { relativeTime } from '$lib/utils/markdown';
 	import OnboardingChecklist from '$lib/components/OnboardingChecklist.svelte';
+	import { titleStore } from '$lib/stores/title.svelte';
 	import type { DashboardResponse, Collection } from '$lib/types';
 
 	let wsSlug = $derived(page.params.workspace ?? '');
@@ -38,6 +39,11 @@
 
 	$effect(() => {
 		if (wsSlug) load(wsSlug);
+	});
+
+	// Workspace home shows only the workspace-level title — clear section/item.
+	$effect(() => {
+		titleStore.setPageTitle({ section: null, item: null });
 	});
 
 	let unsubscribeSync: (() => void) | null = null;

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -18,6 +18,7 @@
 	import { authStore } from '$lib/stores/auth.svelte';
 	import { collectionStore } from '$lib/stores/collections.svelte';
 	import { uiStore } from '$lib/stores/ui.svelte';
+	import { titleStore } from '$lib/stores/title.svelte';
 
 	type ViewMode = 'list' | 'board' | 'table';
 
@@ -101,6 +102,14 @@
 
 	$effect(() => {
 		if (wsSlug && collSlug) loadCollection(wsSlug, collSlug, showArchived);
+	});
+
+	// Reflect the collection name in the browser tab; clear any stale item ref.
+	$effect(() => {
+		titleStore.setPageTitle({
+			section: collection?.name ?? null,
+			item: null,
+		});
 	});
 
 	// Subscribe to SSE events for live updates to this collection's items

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -23,6 +23,7 @@
 	import { copyToClipboard } from '$lib/utils/clipboard';
 	import { authStore } from '$lib/stores/auth.svelte';
 	import { starredStore } from '$lib/stores/starred.svelte';
+	import { titleStore } from '$lib/stores/title.svelte';
 
 	type RelationshipEntry = {
 		key: string;
@@ -104,6 +105,15 @@
 		if (wsSlug && collSlug && itemSlug) {
 			loadData();
 		}
+	});
+
+	// Surface the item's ref (e.g. IDEA-592) in the browser tab title.
+	// Clear the section so the format reads "{REF} · {Workspace} · Pad".
+	$effect(() => {
+		titleStore.setPageTitle({
+			section: null,
+			item: item ? (formatItemRef(item) || null) : null,
+		});
 	});
 
 	// Sync coordinator — refresh item data on tab resume

--- a/web/src/routes/[username]/[workspace]/activity/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/activity/+page.svelte
@@ -3,6 +3,7 @@
 	import { onMount } from 'svelte';
 	import { api } from '$lib/api/client';
 	import { workspaceStore } from '$lib/stores/workspace.svelte';
+	import { titleStore } from '$lib/stores/title.svelte';
 	import { relativeTime } from '$lib/utils/markdown';
 	import type { Activity, Collection } from '$lib/types';
 
@@ -42,6 +43,11 @@
 
 	onMount(() => {
 		workspaceStore.setCurrent(wsSlug);
+	});
+
+	// Reflect the activity feed in the browser tab title.
+	$effect(() => {
+		titleStore.setPageTitle({ section: 'Activity', item: null });
 	});
 
 	async function loadCollections(slug: string) {
@@ -202,10 +208,6 @@
 		}
 	}
 </script>
-
-<svelte:head>
-	<title>Activity - {workspaceStore.current?.name ?? wsSlug} | Pad</title>
-</svelte:head>
 
 <div class="activity-page">
 	<header class="page-header">

--- a/web/src/routes/[username]/[workspace]/activity/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/activity/+page.svelte
@@ -46,7 +46,13 @@
 	});
 
 	// Reflect the activity feed in the browser tab title.
+	// Track pathname so this re-runs on SPA navigation — the component is
+	// reused across workspaces (e.g. /alice/ws1/activity → /alice/ws2/activity)
+	// and the workspace layout clears `section` on every pathname change, so
+	// without this dep the title would drop to `{Workspace} · Pad` after a
+	// workspace switch.
 	$effect(() => {
+		page.url.pathname;
 		titleStore.setPageTitle({ section: 'Activity', item: null });
 	});
 


### PR DESCRIPTION
## Summary

- Adds a central rune store at `web/src/lib/stores/title.svelte.ts` that composes browser-tab titles as `{item | section} · {workspace} · Pad` (most-specific first, since browsers truncate tab titles from the right).
- Root layout renders `<title>{titleStore.title}</title>` reactively; leaf pages contribute their slice via `titleStore.setPageTitle({ workspace?, section?, item? })` with per-key merge semantics (`omitted` preserves, `null` clears, string sets).
- Wires the "big four" workspace-area routes: workspace home, collection list, item detail, activity. Niche routes (settings, roles, console, billing) are unchanged and continue to render the default `Pad` — they can migrate incrementally.

## What each route now shows

| Route | Title |
|---|---|
| `/` / `/login` | `Pad` |
| `/{user}/{ws}` | `{Workspace} · Pad` |
| `/{user}/{ws}/{collection}` | `{Collection Name} · {Workspace} · Pad` |
| `/{user}/{ws}/{collection}/{ref}` | `{ITEM-REF} · {Workspace} · Pad` |
| `/{user}/{ws}/activity` | `Activity · {Workspace} · Pad` |

Item detail intentionally omits the collection name — the ref prefix (e.g. `IDEA-`, `TASK-`) already encodes that, and the shorter format fits better in tab chrome.

Separator is the middle dot `·`. Workspace label is the human display name, not the slug.

## Design decisions

- **Centralized store over per-route `<svelte:head>`** — DRY, single source of truth for format/separator, easy to extend later (see follow-up below).
- **Merge semantics, not replace** — the workspace layout sets `workspace` once; leaf pages only set `section` / `item`. Keeps context stable across SPA nav without coordinating between layers.
- **Cleanup on workspace destroy** — `[username]/[workspace]/+layout.svelte` calls `titleStore.clearPageTitle()` in `onDestroy` so leaving the workspace area resets the tab to bare `Pad`.

## Items

- Implements IDEA-592 ("page title should have the name of the workspace we're in, maybe ID of the item we're in too")
- Delivers PLAN-601 (Contextual page titles)
- Closes TASK-602 (store + root layout) and TASK-603 (route wiring)

## Follow-up

IDEA-600 — **Unread/updated indicator in browser tab title** — hooks into the same store to prefix the title with a counter when backgrounded and SSE delivers external changes. Blocked by this PR landing. See that idea for detail on favicon badging, multi-tab dedup, and the user-preference toggle.

## Test plan

- [ ] `/` (pre-auth / logout) tab shows `Pad`
- [ ] `/{user}/{ws}` tab shows `{Workspace} · Pad`
- [ ] `/{user}/{ws}/ideas` tab shows `Ideas · {Workspace} · Pad`
- [ ] `/{user}/{ws}/ideas/IDEA-592` tab shows `IDEA-592 · {Workspace} · Pad`
- [ ] `/{user}/{ws}/activity` tab shows `Activity · {Workspace} · Pad`
- [ ] SPA navigation between the above flips the title reactively (no reload)
- [ ] Niche routes (settings, roles, console) render `Pad` or their prior override — no regression
- [ ] `npm run build` + `go build ./...` + `go test ./...` all pass on CI
- [ ] OG meta tags unchanged (og:title remains "Pad" — out of scope for this PR)