### PR TITLE
feat(web): allow terminal toggle on any select/multi_select field (TASK-597)

### DIFF
--- a/web/src/lib/components/collections/CreateCollectionModal.svelte
+++ b/web/src/lib/components/collections/CreateCollectionModal.svelte
@@ -195,13 +195,18 @@
 					if ((f.type === 'select' || f.type === 'multi_select') && opts.length > 0) {
 						def.options = opts;
 					}
-					// Persist terminal-option markings for status fields. Templates
-					// may ship with terminal_options, and FieldEditor lets users
-					// toggle them on a status field during create. Without this
-					// the choices are silently dropped on save. Gated on
-					// `key === 'status'` to mirror the current UI; T4 generalizes
-					// this to any select field.
-					if (key === 'status' && f.terminalOptions.length > 0 && def.options) {
+					// Persist terminal-option markings for any select/multi_select
+					// field. FieldEditor surfaces the terminal toggle on any
+					// select-type field (T4 / TASK-597); templates and custom
+					// schemas can ship their own terminal_options. Filter to
+					// options that still exist in the final saved set so a
+					// renamed/removed option doesn't leave a stale terminal
+					// pointer.
+					if (
+						(f.type === 'select' || f.type === 'multi_select') &&
+						f.terminalOptions.length > 0 &&
+						def.options
+					) {
 						const terms = f.terminalOptions.filter((t) => def.options!.includes(t));
 						if (terms.length > 0) def.terminal_options = terms;
 					}

--- a/web/src/lib/components/collections/EditCollectionModal.svelte
+++ b/web/src/lib/components/collections/EditCollectionModal.svelte
@@ -342,9 +342,17 @@
 				) {
 					def.options = normalizedOpts;
 				}
-				if (f.key === 'status' && f.terminalOptions.length > 0) {
-					// Only include terminal options that still exist in the options list
-					def.terminal_options = f.terminalOptions.filter(t => def.options?.includes(t));
+				// Persist terminal-option markings for any select/multi_select
+				// field (T4 / TASK-597). Filter to options that still exist
+				// in the saved set so renames/removals don't leave stale
+				// terminal pointers.
+				if (
+					(f.type === 'select' || f.type === 'multi_select') &&
+					f.terminalOptions.length > 0 &&
+					def.options
+				) {
+					const terms = f.terminalOptions.filter((t) => def.options!.includes(t));
+					if (terms.length > 0) def.terminal_options = terms;
 				}
 				// Gate type-specific advanced values by the current type so
 				// stale hidden values from a previous type (e.g. a number
@@ -405,10 +413,14 @@
 						def.options = opts;
 					}
 					// Mirror the existing-fields path: persist terminal-option
-					// markings for newly-added status fields. Without this,
-					// choices made via the terminal toggle are silently dropped
-					// on save.
-					if (key === 'status' && f.terminalOptions.length > 0 && def.options) {
+					// markings for any new select/multi_select field (T4 /
+					// TASK-597). Filter to options that still exist in the
+					// saved set.
+					if (
+						(f.type === 'select' || f.type === 'multi_select') &&
+						f.terminalOptions.length > 0 &&
+						def.options
+					) {
 						const terms = f.terminalOptions.filter((t) => def.options!.includes(t));
 						if (terms.length > 0) def.terminal_options = terms;
 					}

--- a/web/src/lib/components/collections/FieldEditor.svelte
+++ b/web/src/lib/components/collections/FieldEditor.svelte
@@ -65,10 +65,12 @@
 	const showReorder = $derived(onmoveup !== undefined && onmovedown !== undefined);
 	const isSelectType = $derived(field.type === 'select' || field.type === 'multi_select');
 
-	// Terminal-option toggle is currently scoped to the `status` field only.
-	// This matches the existing EditCollectionModal behavior exactly.
-	// Generalizing to any select field is the job of T4 (TASK-597).
-	const showsTerminalColumn = $derived(field.key === 'status' && field.options.length > 0);
+	// Terminal-option toggle: available on any select/multi_select field
+	// that has at least one option. Marking an option as terminal persists
+	// it on the FieldDef's terminal_options; the semantics of how the
+	// backend uses it for done-detection are currently status-centric and
+	// are being generalized in TASK-604 (cross-field done-detection).
+	const showsTerminalColumn = $derived(isSelectType && field.options.length > 0);
 
 	// Auto-derive the key from the label for new fields, unless the user has
 	// manually edited the key. Once `keyTouched` flips to true the user owns
@@ -285,7 +287,9 @@
 					<span class="options-col-label">Options</span>
 					<span
 						class="options-col-terminal"
-						title="Terminal statuses are treated as done/closed"
+						title={'Mark options as terminal — values that mean "done" or "closed" for items. ' +
+							'Used for dashboard filtering, progress bars, and changelog generation. ' +
+							'Most useful on status-like fields; optional on others.'}
 					>Done?</span>
 					<span class="options-col-spacer"></span>
 				</div>
@@ -294,8 +298,7 @@
 				{#each field.options as _opt, oi (oi)}
 					<div
 						class="option-row"
-						class:option-terminal={field.key === 'status' &&
-							isTerminal(field.options[oi])}
+						class:option-terminal={isTerminal(field.options[oi])}
 					>
 						<input
 							class="option-name-input"
@@ -303,56 +306,54 @@
 							bind:value={field.options[oi]}
 							placeholder="option name"
 						/>
-						{#if field.key === 'status'}
-							<button
-								class="option-done-toggle"
-								class:active={isTerminal(field.options[oi])}
-								type="button"
-								onclick={() => toggleTerminal(field.options[oi])}
-								title={isTerminal(field.options[oi])
-									? 'Marked as terminal (click to unmark)'
-									: 'Mark as terminal — items with this status are considered done'}
-								aria-label={isTerminal(field.options[oi])
-									? 'Unmark as terminal'
-									: 'Mark as terminal'}
-							>
-								{#if isTerminal(field.options[oi])}
-									<svg width="16" height="16" viewBox="0 0 16 16" fill="none">
-										<rect
-											x="1"
-											y="1"
-											width="14"
-											height="14"
-											rx="3"
-											fill="currentColor"
-											opacity="0.15"
-											stroke="currentColor"
-											stroke-width="1.5"
-										/>
-										<path
-											d="M4.5 8L7 10.5L11.5 5.5"
-											stroke="currentColor"
-											stroke-width="1.8"
-											stroke-linecap="round"
-											stroke-linejoin="round"
-										/>
-									</svg>
-								{:else}
-									<svg width="16" height="16" viewBox="0 0 16 16" fill="none">
-										<rect
-											x="1.5"
-											y="1.5"
-											width="13"
-											height="13"
-											rx="2.5"
-											stroke="currentColor"
-											stroke-width="1"
-											opacity="0.4"
-										/>
-									</svg>
-								{/if}
-							</button>
-						{/if}
+						<button
+							class="option-done-toggle"
+							class:active={isTerminal(field.options[oi])}
+							type="button"
+							onclick={() => toggleTerminal(field.options[oi])}
+							title={isTerminal(field.options[oi])
+								? 'Marked as terminal (click to unmark)'
+								: 'Mark as terminal — items with this value are considered done / closed'}
+							aria-label={isTerminal(field.options[oi])
+								? 'Unmark as terminal'
+								: 'Mark as terminal'}
+						>
+							{#if isTerminal(field.options[oi])}
+								<svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+									<rect
+										x="1"
+										y="1"
+										width="14"
+										height="14"
+										rx="3"
+										fill="currentColor"
+										opacity="0.15"
+										stroke="currentColor"
+										stroke-width="1.5"
+									/>
+									<path
+										d="M4.5 8L7 10.5L11.5 5.5"
+										stroke="currentColor"
+										stroke-width="1.8"
+										stroke-linecap="round"
+										stroke-linejoin="round"
+									/>
+								</svg>
+							{:else}
+								<svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+									<rect
+										x="1.5"
+										y="1.5"
+										width="13"
+										height="13"
+										rx="2.5"
+										stroke="currentColor"
+										stroke-width="1"
+										opacity="0.4"
+									/>
+								</svg>
+							{/if}
+						</button>
 						<button
 							class="option-remove-btn"
 							type="button"

--- a/web/src/lib/components/collections/FieldEditor.svelte
+++ b/web/src/lib/components/collections/FieldEditor.svelte
@@ -287,9 +287,10 @@
 					<span class="options-col-label">Options</span>
 					<span
 						class="options-col-terminal"
-						title={'Mark options as terminal — values that mean "done" or "closed" for items. ' +
-							'Used for dashboard filtering, progress bars, and changelog generation. ' +
-							'Most useful on status-like fields; optional on others.'}
+						title={'Mark options that mean "done" or "closed". ' +
+							'Today only the status field drives dashboard filtering, progress bars, and ' +
+							'changelog — markings on other fields are saved on the schema for API ' +
+							'consumers and future cross-field done-detection.'}
 					>Done?</span>
 					<span class="options-col-spacer"></span>
 				</div>


### PR DESCRIPTION
## Summary
Part of [PLAN-593 — Collection Modal Redesign](https://github.com/xarmian/pad). Lifts the `field.key === 'status'` gate from the terminal-option UI and save paths so any `select` / `multi_select` field with options can mark terminal values.

**Closes TASK-597 in PLAN-593** (scope A — UI + persistence only).

## Scope decision

The task originally asked for both UI surfacing **and** backend done-detection generalization across all terminal-marked fields (so e.g. `resolution: fixed` would count as done in dashboard / progress / changelog). On analysis, the backend is deeply status-centric — every aggregation SQL uses hardcoded `$.status` extraction with a single `IN (…)` clause, and ~15 files across `internal/store`, `internal/server`, `cmd/pad` would need updating to consider per-field terminal lookup with schema-driven dynamic `OR` clauses.

That's a meaningful architectural change separate from the modal UX surfacing. We chose to scope this PR to the UI + schema persistence only (the PLAN-593 \"surface, don't hide\" principle), and track the backend work separately in [**TASK-604** — Generalize done-detection to cross-field terminal options](https://github.com/xarmian/pad) (unparented task, medium priority).

## Changes

### `FieldEditor.svelte`
- `showsTerminalColumn` now derives from `isSelectType && field.options.length > 0` (was `field.key === 'status' && …`).
- Removed the inner `{#if field.key === 'status'}` around both the per-option toggle button and the `option-terminal` class directive.
- Column header title extended to explain the concept (\"Used for dashboard filtering, progress bars, and changelog generation. Most useful on status-like fields; optional on others.\") instead of the prior status-specific wording.

### Save paths (`CreateCollectionModal.svelte`, `EditCollectionModal.svelte` × 2)
- All three save paths replaced the `key === 'status'` gate with a select/multi_select type check.
- Stale-terminal filtering against the saved options set is preserved so renames/removals don't leave orphan terminal pointers.

### Backend
- **No changes.** Data model already accepts `terminal_options` on any field (`FieldDef.TerminalOptions []string`, no schema-level rejection). Aggregation remains status-centric per the scope decision above.

## Known limitation (intentional)

Marking a non-status field as terminal persists the schema correctly but **does not yet affect dashboard / progress / search aggregations** — those still look only at `$.status`. Users will see the terminal styling in the editor and the data round-trips, but aggregations won't treat a non-status terminal value as \"done\" until TASK-604 ships.

## Test plan
- [x] `go build ./...` / `go test ./...` — clean (no backend changes)
- [x] `cd web && npm run build` — clean
- [x] Manual smoke test:
  - [x] Create a select field with custom options; \"Done?\" toggle renders on each option (previously hidden for non-status).
  - [x] Mark multiple options as terminal; save → reopen → round-trips.
  - [x] Switching a field's type select/multi_select → text → select preserves terminal markings (existing behavior).
  - [x] Existing status field's terminal toggles unchanged.
  - [x] Tooltip on \"Done?\" column explains the concept.

## Follow-up
- **TASK-604** — Generalize done-detection to cross-field terminal options. Covers the SQL + Go refactor to make non-status terminal markings participate in done aggregation.

## Out of scope
- Backend done-detection generalization → TASK-604
- Visual redesign → TASK-598
- Create-time feature parity for Display / Quick Actions → TASK-599