### PR TITLE
feat: tie done-detection to the board group-by field (TASK-604)

### DIFF
--- a/internal/models/terminal.go
+++ b/internal/models/terminal.go
@@ -2,30 +2,136 @@ package models
 
 import "strings"
 
-// DefaultTerminalStatuses is the fallback list used when a collection schema
-// does not declare terminal_options on its status field. This is the union of
-// all historically hardcoded terminal status values across the codebase.
+// DefaultTerminalStatuses is the fallback list used when a collection's
+// done field has no `terminal_options` declared on its schema. This is the
+// union of all historically hardcoded terminal status values across the
+// codebase.
 var DefaultTerminalStatuses = []string{
 	"done", "completed", "resolved", "cancelled", "rejected",
 	"wontfix", "fixed", "implemented", "archived", "disabled", "deprecated",
 }
 
-// TerminalStatusesFromSchema extracts terminal status options from a
-// CollectionSchema. If the status field has TerminalOptions set, returns
-// those. Otherwise returns DefaultTerminalStatuses.
-func TerminalStatusesFromSchema(schema CollectionSchema) []string {
+// DoneFieldKey resolves which field on a collection's schema represents
+// "is this item done?". The resolution is:
+//
+//  1. If CollectionSettings.BoardGroupBy names a select / multi_select
+//     field on the schema, use that. This lets a collection whose board
+//     is organized by e.g. "resolution" naturally drive done-detection
+//     from the same field.
+//
+//  2. Otherwise, fall back to the literal key "status". Every collection
+//     shipped today groups by status by default, so this preserves
+//     existing behavior for all pre-TASK-604 collections.
+//
+// The function does not assume the resolved key actually exists on the
+// schema — callers should treat the return value as "the field key whose
+// value we read from items.fields JSON". A missing field on an item just
+// means we read an empty string, which is the safe, expected behavior for
+// unstyled items.
+func DoneFieldKey(schema CollectionSchema, settings CollectionSettings) string {
+	candidate := strings.TrimSpace(settings.BoardGroupBy)
+	if candidate == "" {
+		return "status"
+	}
 	for _, f := range schema.Fields {
-		if f.Key == "status" && (f.Type == "select" || f.Type == "multi_select") {
+		if f.Key == candidate && (f.Type == "select" || f.Type == "multi_select") {
+			return candidate
+		}
+	}
+	return "status"
+}
+
+// TerminalValuesForDoneField returns the resolved done-field key and the
+// list of terminal values for that field. If the resolved field has no
+// terminal_options set on the schema, falls back to DefaultTerminalStatuses
+// so existing collections without schema-declared terminals continue to
+// work.
+func TerminalValuesForDoneField(
+	schema CollectionSchema,
+	settings CollectionSettings,
+) (fieldKey string, values []string) {
+	fieldKey = DoneFieldKey(schema, settings)
+	for _, f := range schema.Fields {
+		if f.Key == fieldKey && (f.Type == "select" || f.Type == "multi_select") {
 			if len(f.TerminalOptions) > 0 {
-				return f.TerminalOptions
+				return fieldKey, f.TerminalOptions
 			}
 			break
 		}
 	}
-	return DefaultTerminalStatuses
+	return fieldKey, DefaultTerminalStatuses
 }
 
-// IsTerminalStatus checks whether a status string is terminal given a schema.
+// TerminalPlaceholdersForDoneField is a SQL-layer convenience that returns
+// the done-field key plus the placeholder + args pair needed for an IN
+// clause. All values are lowercased to match the WHERE clause pattern used
+// across the codebase (LOWER(json_extract(...)) IN (?, ?, ?)).
+func TerminalPlaceholdersForDoneField(
+	schema CollectionSchema,
+	settings CollectionSettings,
+) (fieldKey string, placeholders string, args []any) {
+	key, values := TerminalValuesForDoneField(schema, settings)
+	ph := make([]string, len(values))
+	ar := make([]any, len(values))
+	for i, v := range values {
+		ph[i] = "?"
+		ar[i] = strings.ToLower(v)
+	}
+	return key, strings.Join(ph, ","), ar
+}
+
+// IsTerminalItem reports whether an item's fields map indicates the item
+// is in a terminal state for its collection. This is the canonical Go-side
+// "is done" check when the caller has both the item's parsed fields and
+// the collection's schema + settings in scope.
+func IsTerminalItem(
+	itemFields map[string]any,
+	schema CollectionSchema,
+	settings CollectionSettings,
+) bool {
+	key, values := TerminalValuesForDoneField(schema, settings)
+	raw, ok := itemFields[key]
+	if !ok {
+		return false
+	}
+	s, ok := raw.(string)
+	if !ok {
+		return false
+	}
+	lower := strings.ToLower(s)
+	for _, v := range values {
+		if strings.ToLower(v) == lower {
+			return true
+		}
+	}
+	return false
+}
+
+// ── Back-compat wrappers ────────────────────────────────────────────────
+// The original API (status-only) stays in place so callers that don't yet
+// have CollectionSettings in scope keep working unchanged. Internally each
+// of these delegates to the new done-field-aware implementation with
+// empty settings — which resolves the done field to "status", matching
+// pre-TASK-604 behavior byte-for-byte.
+
+// TerminalStatusesFromSchema extracts terminal status options from a
+// CollectionSchema. If the `status` field has TerminalOptions set, returns
+// those. Otherwise returns DefaultTerminalStatuses.
+//
+// Deprecated: prefer TerminalValuesForDoneField when settings are in
+// scope. This wrapper forces done-field resolution to the literal
+// "status" key; callers that want to honor the collection's configured
+// board_group_by should migrate to the settings-aware API.
+func TerminalStatusesFromSchema(schema CollectionSchema) []string {
+	_, values := TerminalValuesForDoneField(schema, CollectionSettings{})
+	return values
+}
+
+// IsTerminalStatus checks whether a status string is terminal given a
+// schema. Like the status extract above, this is hardcoded to the `status`
+// field — it takes a pre-extracted status string and checks membership
+// against that field's terminal options. Use when you already know you're
+// working with the status field specifically (e.g. link-payload joins).
 func IsTerminalStatus(status string, schema CollectionSchema) bool {
 	lower := strings.ToLower(status)
 	for _, ts := range TerminalStatusesFromSchema(schema) {
@@ -36,8 +142,8 @@ func IsTerminalStatus(status string, schema CollectionSchema) bool {
 	return false
 }
 
-// IsTerminalStatusDefault checks using the default fallback list (for cases
-// where no collection schema is available).
+// IsTerminalStatusDefault checks using the default fallback list (for
+// cases where no collection schema is available).
 func IsTerminalStatusDefault(status string) bool {
 	lower := strings.ToLower(status)
 	for _, ts := range DefaultTerminalStatuses {
@@ -49,17 +155,12 @@ func IsTerminalStatusDefault(status string) bool {
 }
 
 // TerminalStatusPlaceholders returns a comma-separated placeholder string
-// and the corresponding args slice for use in SQL IN clauses.
-// Example: TerminalStatusPlaceholders(schema) might return ("?,?,?", ["done","cancelled","rejected"])
+// and the corresponding args slice for use in SQL IN clauses. Like the
+// *FromSchema variant it is hardcoded to the `status` field; prefer
+// TerminalPlaceholdersForDoneField when settings are in scope.
 func TerminalStatusPlaceholders(schema CollectionSchema) (string, []any) {
-	statuses := TerminalStatusesFromSchema(schema)
-	placeholders := make([]string, len(statuses))
-	args := make([]any, len(statuses))
-	for i, s := range statuses {
-		placeholders[i] = "?"
-		args[i] = strings.ToLower(s)
-	}
-	return strings.Join(placeholders, ","), args
+	_, placeholders, args := TerminalPlaceholdersForDoneField(schema, CollectionSettings{})
+	return placeholders, args
 }
 
 // DefaultTerminalStatusPlaceholders returns placeholders and args for the

--- a/internal/models/terminal.go
+++ b/internal/models/terminal.go
@@ -1,6 +1,18 @@
 package models
 
-import "strings"
+import (
+	"regexp"
+	"strings"
+)
+
+// safeDoneFieldKey bounds what we'll interpolate into the JSON path of a
+// SQL query (e.g. `json_extract(i.fields, '$.<key>')`). Collection schemas
+// are persisted without backend-side key validation, so a user could in
+// principle store a key containing quotes or path metacharacters; we
+// refuse to resolve done-detection to anything outside this shape and
+// fall back to "status". The pattern mirrors the convention already in
+// use for search filters in internal/server/handlers_search.go.
+var safeDoneFieldKey = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9_]*$`)
 
 // DefaultTerminalStatuses is the fallback list used when a collection's
 // done field has no `terminal_options` declared on its schema. This is the
@@ -37,6 +49,13 @@ var DefaultTerminalStatuses = []string{
 func DoneFieldKey(schema CollectionSchema, settings CollectionSettings) string {
 	candidate := strings.TrimSpace(settings.BoardGroupBy)
 	if candidate == "" {
+		return "status"
+	}
+	// Refuse to resolve to a key that would be unsafe to embed in a
+	// SQL JSON path. Callers pass the returned key to dialect-specific
+	// JSONExtractText builders that interpolate it as a string literal;
+	// schema keys are not validated on write, so we validate here.
+	if !safeDoneFieldKey.MatchString(candidate) {
 		return "status"
 	}
 	for _, f := range schema.Fields {

--- a/internal/models/terminal.go
+++ b/internal/models/terminal.go
@@ -14,27 +14,33 @@ var DefaultTerminalStatuses = []string{
 // DoneFieldKey resolves which field on a collection's schema represents
 // "is this item done?". The resolution is:
 //
-//  1. If CollectionSettings.BoardGroupBy names a select / multi_select
-//     field on the schema, use that. This lets a collection whose board
-//     is organized by e.g. "resolution" naturally drive done-detection
-//     from the same field.
+//  1. If CollectionSettings.BoardGroupBy names a `select` field on the
+//     schema, use that. This lets a collection whose board is organized
+//     by e.g. "resolution" naturally drive done-detection from the same
+//     field.
 //
 //  2. Otherwise, fall back to the literal key "status". Every collection
 //     shipped today groups by status by default, so this preserves
 //     existing behavior for all pre-TASK-604 collections.
 //
+// Only `select` (single-value) is accepted as a done field. `multi_select`
+// stores its values as a JSON array, and both the Go-side membership check
+// and the SQL `IN (…)` filter assume a scalar string — naively accepting
+// multi_select would cause done-detection to silently miss items whose
+// terminal value is one of several in the array. If array semantics are
+// ever needed, they belong in a follow-up task so the Go and SQL paths
+// can be updated together with a clear "any terminal value → done" rule.
+//
 // The function does not assume the resolved key actually exists on the
-// schema — callers should treat the return value as "the field key whose
-// value we read from items.fields JSON". A missing field on an item just
-// means we read an empty string, which is the safe, expected behavior for
-// unstyled items.
+// item — callers read `items.fields[key]` and a missing field just means
+// the item is treated as not terminal, which is the safe default.
 func DoneFieldKey(schema CollectionSchema, settings CollectionSettings) string {
 	candidate := strings.TrimSpace(settings.BoardGroupBy)
 	if candidate == "" {
 		return "status"
 	}
 	for _, f := range schema.Fields {
-		if f.Key == candidate && (f.Type == "select" || f.Type == "multi_select") {
+		if f.Key == candidate && f.Type == "select" {
 			return candidate
 		}
 	}
@@ -52,7 +58,9 @@ func TerminalValuesForDoneField(
 ) (fieldKey string, values []string) {
 	fieldKey = DoneFieldKey(schema, settings)
 	for _, f := range schema.Fields {
-		if f.Key == fieldKey && (f.Type == "select" || f.Type == "multi_select") {
+		// Restricted to `select` — see DoneFieldKey for why multi_select
+		// is deliberately rejected.
+		if f.Key == fieldKey && f.Type == "select" {
 			if len(f.TerminalOptions) > 0 {
 				return fieldKey, f.TerminalOptions
 			}
@@ -84,6 +92,12 @@ func TerminalPlaceholdersForDoneField(
 // is in a terminal state for its collection. This is the canonical Go-side
 // "is done" check when the caller has both the item's parsed fields and
 // the collection's schema + settings in scope.
+//
+// The value at the resolved done-field key is expected to be a scalar
+// string — DoneFieldKey only resolves to `select` fields, which round-
+// trip through the fields JSON as a single string. Non-string values
+// (e.g. an array from a misconfigured multi_select) return false rather
+// than trying to infer semantics.
 func IsTerminalItem(
 	itemFields map[string]any,
 	schema CollectionSchema,

--- a/internal/models/terminal_test.go
+++ b/internal/models/terminal_test.go
@@ -59,15 +59,21 @@ func TestDoneFieldKey_FallsBackForNonSelectField(t *testing.T) {
 	}
 }
 
-func TestDoneFieldKey_AcceptsMultiSelect(t *testing.T) {
+func TestDoneFieldKey_RejectsMultiSelect(t *testing.T) {
+	// multi_select stores values as JSON arrays, but both the Go-side
+	// membership check and the SQL IN(...) filter assume scalar string
+	// matching. Accepting multi_select as a done field would silently
+	// miss items whose terminal value is one of several in the array, so
+	// DoneFieldKey rejects it and falls back to 'status'.
 	schema := CollectionSchema{
 		Fields: []FieldDef{
+			{Key: "status", Type: "select", Options: []string{"open", "done"}},
 			{Key: "labels", Type: "multi_select", Options: []string{"p0", "done"}},
 		},
 	}
 	settings := CollectionSettings{BoardGroupBy: "labels"}
-	if got := DoneFieldKey(schema, settings); got != "labels" {
-		t.Fatalf("expected multi_select to qualify as done field, got %q", got)
+	if got := DoneFieldKey(schema, settings); got != "status" {
+		t.Fatalf("expected multi_select board_group_by to fall back to 'status', got %q", got)
 	}
 }
 

--- a/internal/models/terminal_test.go
+++ b/internal/models/terminal_test.go
@@ -1,0 +1,245 @@
+package models
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestDoneFieldKey_DefaultsToStatus(t *testing.T) {
+	schema := CollectionSchema{
+		Fields: []FieldDef{
+			{Key: "status", Type: "select", Options: []string{"open", "done"}},
+		},
+	}
+	settings := CollectionSettings{}
+	if got := DoneFieldKey(schema, settings); got != "status" {
+		t.Fatalf("expected default done field to be 'status', got %q", got)
+	}
+}
+
+func TestDoneFieldKey_HonorsBoardGroupBy(t *testing.T) {
+	schema := CollectionSchema{
+		Fields: []FieldDef{
+			{Key: "status", Type: "select", Options: []string{"open", "done"}},
+			{Key: "resolution", Type: "select", Options: []string{"fixed", "wontfix"}},
+		},
+	}
+	settings := CollectionSettings{BoardGroupBy: "resolution"}
+	if got := DoneFieldKey(schema, settings); got != "resolution" {
+		t.Fatalf("expected done field to follow board_group_by, got %q", got)
+	}
+}
+
+func TestDoneFieldKey_FallsBackWhenFieldMissing(t *testing.T) {
+	// BoardGroupBy names a field that doesn't exist on the schema —
+	// fall back to status rather than emitting a broken JSON path.
+	schema := CollectionSchema{
+		Fields: []FieldDef{
+			{Key: "status", Type: "select", Options: []string{"open"}},
+		},
+	}
+	settings := CollectionSettings{BoardGroupBy: "ghost"}
+	if got := DoneFieldKey(schema, settings); got != "status" {
+		t.Fatalf("expected fallback to 'status' for missing field, got %q", got)
+	}
+}
+
+func TestDoneFieldKey_FallsBackForNonSelectField(t *testing.T) {
+	// If board_group_by somehow points at a non-select field, done-
+	// detection can't meaningfully operate on it — fall back to status.
+	schema := CollectionSchema{
+		Fields: []FieldDef{
+			{Key: "status", Type: "select", Options: []string{"open"}},
+			{Key: "notes", Type: "text"},
+		},
+	}
+	settings := CollectionSettings{BoardGroupBy: "notes"}
+	if got := DoneFieldKey(schema, settings); got != "status" {
+		t.Fatalf("expected fallback to 'status' for non-select field, got %q", got)
+	}
+}
+
+func TestDoneFieldKey_AcceptsMultiSelect(t *testing.T) {
+	schema := CollectionSchema{
+		Fields: []FieldDef{
+			{Key: "labels", Type: "multi_select", Options: []string{"p0", "done"}},
+		},
+	}
+	settings := CollectionSettings{BoardGroupBy: "labels"}
+	if got := DoneFieldKey(schema, settings); got != "labels" {
+		t.Fatalf("expected multi_select to qualify as done field, got %q", got)
+	}
+}
+
+func TestTerminalValuesForDoneField_UsesFieldTerminals(t *testing.T) {
+	schema := CollectionSchema{
+		Fields: []FieldDef{
+			{
+				Key:             "resolution",
+				Type:            "select",
+				Options:         []string{"fixed", "wontfix", "open"},
+				TerminalOptions: []string{"fixed", "wontfix"},
+			},
+		},
+	}
+	settings := CollectionSettings{BoardGroupBy: "resolution"}
+	key, values := TerminalValuesForDoneField(schema, settings)
+	if key != "resolution" {
+		t.Fatalf("expected key 'resolution', got %q", key)
+	}
+	if !reflect.DeepEqual(values, []string{"fixed", "wontfix"}) {
+		t.Fatalf("expected resolution terminals, got %v", values)
+	}
+}
+
+func TestTerminalValuesForDoneField_FallsBackToDefaults(t *testing.T) {
+	// Resolved field exists but has no terminal_options set — fall back
+	// to the global default list so collections without schema-declared
+	// terminals continue to function.
+	schema := CollectionSchema{
+		Fields: []FieldDef{
+			{Key: "status", Type: "select", Options: []string{"open", "done"}},
+		},
+	}
+	settings := CollectionSettings{}
+	key, values := TerminalValuesForDoneField(schema, settings)
+	if key != "status" {
+		t.Fatalf("expected key 'status', got %q", key)
+	}
+	if !reflect.DeepEqual(values, DefaultTerminalStatuses) {
+		t.Fatalf("expected DefaultTerminalStatuses, got %v", values)
+	}
+}
+
+func TestTerminalValuesForDoneField_StatusTerminalsStillWork(t *testing.T) {
+	// Back-compat: a collection whose status field has TerminalOptions set
+	// should still produce those terminals when board_group_by is empty.
+	schema := CollectionSchema{
+		Fields: []FieldDef{
+			{
+				Key:             "status",
+				Type:            "select",
+				Options:         []string{"open", "done", "cancelled"},
+				TerminalOptions: []string{"done", "cancelled"},
+			},
+		},
+	}
+	settings := CollectionSettings{}
+	key, values := TerminalValuesForDoneField(schema, settings)
+	if key != "status" {
+		t.Fatalf("expected key 'status', got %q", key)
+	}
+	if !reflect.DeepEqual(values, []string{"done", "cancelled"}) {
+		t.Fatalf("expected status terminals, got %v", values)
+	}
+}
+
+func TestTerminalPlaceholdersForDoneField_LowercasesArgs(t *testing.T) {
+	schema := CollectionSchema{
+		Fields: []FieldDef{
+			{
+				Key:             "resolution",
+				Type:            "select",
+				Options:         []string{"Fixed", "WontFix", "Open"},
+				TerminalOptions: []string{"Fixed", "WontFix"},
+			},
+		},
+	}
+	settings := CollectionSettings{BoardGroupBy: "resolution"}
+	key, placeholders, args := TerminalPlaceholdersForDoneField(schema, settings)
+	if key != "resolution" {
+		t.Fatalf("expected key 'resolution', got %q", key)
+	}
+	if placeholders != "?,?" {
+		t.Fatalf("expected '?,?', got %q", placeholders)
+	}
+	if !reflect.DeepEqual(args, []any{"fixed", "wontfix"}) {
+		t.Fatalf("expected lowercased args, got %v", args)
+	}
+}
+
+func TestIsTerminalItem_TrueWhenFieldMatches(t *testing.T) {
+	schema := CollectionSchema{
+		Fields: []FieldDef{
+			{
+				Key:             "resolution",
+				Type:            "select",
+				Options:         []string{"fixed", "wontfix", "open"},
+				TerminalOptions: []string{"fixed", "wontfix"},
+			},
+		},
+	}
+	settings := CollectionSettings{BoardGroupBy: "resolution"}
+	if !IsTerminalItem(map[string]any{"resolution": "fixed"}, schema, settings) {
+		t.Fatal("expected item with resolution=fixed to be terminal")
+	}
+	if IsTerminalItem(map[string]any{"resolution": "open"}, schema, settings) {
+		t.Fatal("expected item with resolution=open NOT to be terminal")
+	}
+}
+
+func TestIsTerminalItem_FalseWhenFieldMissing(t *testing.T) {
+	schema := CollectionSchema{
+		Fields: []FieldDef{
+			{Key: "status", Type: "select", Options: []string{"open", "done"}},
+		},
+	}
+	settings := CollectionSettings{}
+	// No "status" key in the item's fields map — treat as not terminal.
+	if IsTerminalItem(map[string]any{}, schema, settings) {
+		t.Fatal("expected item with no status field to be non-terminal")
+	}
+}
+
+func TestIsTerminalItem_CaseInsensitive(t *testing.T) {
+	// Queries in the SQL layer lowercase both sides; the Go-side helper
+	// should match that semantics so behavior is consistent regardless of
+	// which path a caller takes.
+	schema := CollectionSchema{
+		Fields: []FieldDef{
+			{
+				Key:             "status",
+				Type:            "select",
+				Options:         []string{"Open", "Done"},
+				TerminalOptions: []string{"Done"},
+			},
+		},
+	}
+	settings := CollectionSettings{}
+	if !IsTerminalItem(map[string]any{"status": "done"}, schema, settings) {
+		t.Fatal("expected case-insensitive match to terminal option")
+	}
+	if !IsTerminalItem(map[string]any{"status": "DONE"}, schema, settings) {
+		t.Fatal("expected case-insensitive match to terminal option (uppercase)")
+	}
+}
+
+func TestTerminalStatusesFromSchema_CompatShim(t *testing.T) {
+	// The legacy API should still pick up status-field terminals.
+	schema := CollectionSchema{
+		Fields: []FieldDef{
+			{
+				Key:             "status",
+				Type:            "select",
+				Options:         []string{"open", "done"},
+				TerminalOptions: []string{"done"},
+			},
+		},
+	}
+	got := TerminalStatusesFromSchema(schema)
+	if !reflect.DeepEqual(got, []string{"done"}) {
+		t.Fatalf("expected ['done'], got %v", got)
+	}
+}
+
+func TestIsTerminalStatusDefault(t *testing.T) {
+	if !IsTerminalStatusDefault("done") {
+		t.Fatal("expected 'done' to be default-terminal")
+	}
+	if !IsTerminalStatusDefault("DONE") {
+		t.Fatal("expected case-insensitive default-terminal match")
+	}
+	if IsTerminalStatusDefault("in-progress") {
+		t.Fatal("expected 'in-progress' to NOT be default-terminal")
+	}
+}

--- a/internal/models/terminal_test.go
+++ b/internal/models/terminal_test.go
@@ -59,6 +59,33 @@ func TestDoneFieldKey_FallsBackForNonSelectField(t *testing.T) {
 	}
 }
 
+func TestDoneFieldKey_RejectsUnsafeKeys(t *testing.T) {
+	// Schema keys aren't validated on write; a malicious or buggy writer
+	// could in principle store a key like `status'); DROP TABLE --`. The
+	// resolver must refuse to resolve to such keys because callers
+	// interpolate the returned value into SQL JSON paths. Falls back to
+	// the literal 'status' — which is always safe.
+	cases := []string{
+		"status'); DROP",
+		"field with spaces",
+		"name.with.dots",
+		"key-with-dashes",
+		"1leading-digit",
+		"",
+	}
+	schema := CollectionSchema{
+		Fields: []FieldDef{
+			{Key: "status", Type: "select", Options: []string{"open"}},
+		},
+	}
+	for _, c := range cases {
+		settings := CollectionSettings{BoardGroupBy: c}
+		if got := DoneFieldKey(schema, settings); got != "status" {
+			t.Errorf("unsafe key %q: expected fallback to 'status', got %q", c, got)
+		}
+	}
+}
+
 func TestDoneFieldKey_RejectsMultiSelect(t *testing.T) {
 	// multi_select stores values as JSON arrays, but both the Go-side
 	// membership check and the SQL IN(...) filter assume scalar string

--- a/internal/server/handlers_dashboard.go
+++ b/internal/server/handlers_dashboard.go
@@ -194,7 +194,22 @@ func (s *Server) handleGetDashboard(w http.ResponseWriter, r *http.Request) {
 		writeInternalError(w, err)
 		return
 	}
-	// Filter collections by visibility
+	// Build the done-context map from ALL workspace collections before
+	// visibility filtering. The dashboard may surface item-level grants
+	// from collections that aren't in the user's full-visibility set
+	// (via dashItemIDs); those items still need their own collection's
+	// done rules for isItemDone, not the status-based default fallback.
+	// ListCollectionsMinimal skips the per-collection count queries —
+	// we only need schema + settings here.
+	allCollections, mcErr := s.store.ListCollectionsMinimal(workspaceID)
+	if mcErr != nil {
+		// Non-fatal: fall back to the visibility-filtered collections.
+		allCollections = collections
+	}
+	ctxMap := buildDoneContextMap(allCollections)
+
+	// Filter collections by visibility (drives the collection-summary
+	// section; done-detection above already sees every collection).
 	if visibleIDs != nil {
 		filtered := make([]models.Collection, 0, len(collections))
 		for _, c := range collections {
@@ -204,7 +219,6 @@ func (s *Server) handleGetDashboard(w http.ResponseWriter, r *http.Request) {
 		}
 		collections = filtered
 	}
-	ctxMap := buildDoneContextMap(collections)
 
 	resp := DashboardResponse{
 		Summary: DashboardSummary{

--- a/internal/server/handlers_dashboard.go
+++ b/internal/server/handlers_dashboard.go
@@ -108,24 +108,47 @@ func isActiveStatus(status string) bool {
 	}
 }
 
-// buildSchemaMap builds a map of collection ID → parsed CollectionSchema for quick lookups.
-func buildSchemaMap(collections []models.Collection) map[string]models.CollectionSchema {
-	m := make(map[string]models.CollectionSchema, len(collections))
+// doneContext pairs a collection's schema with its settings so
+// terminal-state checks can honor the configured done field
+// (board_group_by), not just the hardcoded `status` column.
+type doneContext struct {
+	schema   models.CollectionSchema
+	settings models.CollectionSettings
+}
+
+// buildDoneContextMap builds a map of collection ID → (schema, settings)
+// for quick lookups during dashboard / lineage traversals.
+func buildDoneContextMap(collections []models.Collection) map[string]doneContext {
+	m := make(map[string]doneContext, len(collections))
 	for _, c := range collections {
-		var schema models.CollectionSchema
-		if err := json.Unmarshal([]byte(c.Schema), &schema); err == nil {
-			m[c.ID] = schema
+		var ctx doneContext
+		if err := json.Unmarshal([]byte(c.Schema), &ctx.schema); err == nil {
+			// schema ok
 		}
+		if c.Settings != "" {
+			_ = json.Unmarshal([]byte(c.Settings), &ctx.settings)
+		}
+		m[c.ID] = ctx
 	}
 	return m
 }
 
-// isItemTerminal checks if an item's status is terminal using its collection's schema.
-// Falls back to default terminal statuses if the collection is not in the schema map.
-func isItemTerminal(status, collectionID string, schemaMap map[string]models.CollectionSchema) bool {
-	if schema, ok := schemaMap[collectionID]; ok {
-		return models.IsTerminalStatus(status, schema)
+// isItemDone reports whether an item is in a terminal state for its
+// collection's configured done field. Falls back to the default-terminal
+// list against `status` when the collection isn't in the map (e.g.
+// cross-workspace references).
+func isItemDone(fieldsJSON, collectionID string, ctxMap map[string]doneContext) bool {
+	if fieldsJSON == "" || fieldsJSON == "{}" {
+		return false
 	}
+	var fields map[string]any
+	if err := json.Unmarshal([]byte(fieldsJSON), &fields); err != nil {
+		return false
+	}
+	if ctx, ok := ctxMap[collectionID]; ok {
+		return models.IsTerminalItem(fields, ctx.schema, ctx.settings)
+	}
+	status, _ := fields["status"].(string)
 	return models.IsTerminalStatusDefault(status)
 }
 
@@ -181,7 +204,7 @@ func (s *Server) handleGetDashboard(w http.ResponseWriter, r *http.Request) {
 		}
 		collections = filtered
 	}
-	schemaMap := buildSchemaMap(collections)
+	ctxMap := buildDoneContextMap(collections)
 
 	resp := DashboardResponse{
 		Summary: DashboardSummary{
@@ -279,8 +302,7 @@ func (s *Server) handleGetDashboard(w http.ResponseWriter, r *http.Request) {
 						continue
 					}
 					total++
-					childStatus := extractFieldValue(child.Fields, "status")
-					if isItemTerminal(childStatus, child.CollectionID, schemaMap) {
+					if isItemDone(child.Fields, child.CollectionID, ctxMap) {
 						done++
 					}
 				}
@@ -334,11 +356,11 @@ func (s *Server) handleGetDashboard(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// (b) Overdue: items with a due_date or end_date in the past and status not done/completed/resolved
+	// (b) Overdue: items with a due_date or end_date in the past whose
+	// done field isn't in a terminal state.
 	todayStr := now.Format("2006-01-02")
 	for _, item := range allItems {
-		status := extractFieldValue(item.Fields, "status")
-		if isItemTerminal(status, item.CollectionID, schemaMap) {
+		if isItemDone(item.Fields, item.CollectionID, ctxMap) {
 			continue
 		}
 		for _, dateField := range []string{"due_date", "end_date"} {
@@ -396,8 +418,7 @@ func (s *Server) handleGetDashboard(w http.ResponseWriter, r *http.Request) {
 		})
 		if err == nil {
 			for _, task := range allTasks {
-				status := extractFieldValue(task.Fields, "status")
-				if isItemTerminal(status, task.CollectionID, schemaMap) {
+				if isItemDone(task.Fields, task.CollectionID, ctxMap) {
 					continue
 				}
 				if _, hasParent := parentMap[task.ID]; !hasParent {
@@ -416,8 +437,7 @@ func (s *Server) handleGetDashboard(w http.ResponseWriter, r *http.Request) {
 
 	// (e) Blocked: non-done items that are blocked by other non-done items
 	for _, item := range allItems {
-		status := extractFieldValue(item.Fields, "status")
-		if isItemTerminal(status, item.CollectionID, schemaMap) {
+		if isItemDone(item.Fields, item.CollectionID, ctxMap) {
 			continue
 		}
 		links, err := s.store.GetItemLinks(item.ID)
@@ -444,10 +464,12 @@ func (s *Server) handleGetDashboard(w http.ResponseWriter, r *http.Request) {
 			if !s.isItemVisibleToGuest(r, workspaceID, blocker, dashFullCollIDs, dashGrantedItemIDs) {
 				continue
 			}
-			blockerStatus := extractFieldValue(blocker.Fields, "status")
-			if isItemTerminal(blockerStatus, blocker.CollectionID, schemaMap) {
+			if isItemDone(blocker.Fields, blocker.CollectionID, ctxMap) {
 				continue
 			}
+			// Used only in the human-readable "Reason" string below — the
+			// terminal check above owns the actual done-detection.
+			blockerStatus := extractFieldValue(blocker.Fields, "status")
 			resp.Attention = append(resp.Attention, DashboardAttention{
 				Type:       "blocked",
 				ItemSlug:   item.Slug,
@@ -591,8 +613,7 @@ func (s *Server) handleGetDashboard(w http.ResponseWriter, r *http.Request) {
 				if item.AgentRoleID != nil {
 					roleID = *item.AgentRoleID
 				}
-				status := extractFieldValue(item.Fields, "status")
-				if isItemTerminal(status, item.CollectionID, schemaMap) {
+				if isItemDone(item.Fields, item.CollectionID, ctxMap) {
 					continue
 				}
 				roleCounts[roleID]++

--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -829,7 +829,9 @@ func (s *Server) handlePlansProgress(w http.ResponseWriter, r *http.Request) {
 
 		// Build a done-context map once so each child is evaluated against
 		// its own collection's configured done field, not a global default.
-		wsCollections, _ := s.store.ListCollections(workspaceID)
+		// ListCollectionsMinimal avoids the per-collection COUNT queries
+		// that ListCollections would run — we only need schema + settings.
+		wsCollections, _ := s.store.ListCollectionsMinimal(workspaceID)
 		ctxMap := buildDoneContextMap(wsCollections)
 
 		// Recompute each plan's progress using only visible children

--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -827,6 +827,11 @@ func (s *Server) handlePlansProgress(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
+		// Build a done-context map once so each child is evaluated against
+		// its own collection's configured done field, not a global default.
+		wsCollections, _ := s.store.ListCollections(workspaceID)
+		ctxMap := buildDoneContextMap(wsCollections)
+
 		// Recompute each plan's progress using only visible children
 		for i, p := range allProgress {
 			children, cerr := s.store.GetChildItems(p.ItemID)
@@ -842,8 +847,7 @@ func (s *Server) handlePlansProgress(w http.ResponseWriter, r *http.Request) {
 					continue
 				}
 				total++
-				status := extractStatus(child.Fields)
-				if models.IsTerminalStatusDefault(status) {
+				if isItemDone(child.Fields, child.CollectionID, ctxMap) {
 					done++
 				}
 			}
@@ -979,8 +983,9 @@ func (s *Server) handleGetItemProgress(w http.ResponseWriter, r *http.Request) {
 			writeInternalError(w, cerr)
 			return
 		}
-		// Cache collection schemas for terminal status lookup
-		schemaCache := make(map[string]models.CollectionSchema)
+		// Cache a schema+settings done-context per child collection so
+		// each child is evaluated against its own configured done field.
+		ctxCache := make(map[string]doneContext)
 		total, done := 0, 0
 		for _, child := range children {
 			if !isCollectionVisible(child.CollectionID, progVisIDs) {
@@ -990,15 +995,19 @@ func (s *Server) handleGetItemProgress(w http.ResponseWriter, r *http.Request) {
 				continue
 			}
 			total++
-			status := extractStatus(child.Fields)
-			schema, cached := schemaCache[child.CollectionID]
+			ctx, cached := ctxCache[child.CollectionID]
 			if !cached {
 				if coll, cerr := s.store.GetCollection(child.CollectionID); cerr == nil && coll != nil {
-					_ = json.Unmarshal([]byte(coll.Schema), &schema)
+					_ = json.Unmarshal([]byte(coll.Schema), &ctx.schema)
+					if coll.Settings != "" {
+						_ = json.Unmarshal([]byte(coll.Settings), &ctx.settings)
+					}
 				}
-				schemaCache[child.CollectionID] = schema
+				ctxCache[child.CollectionID] = ctx
 			}
-			if models.IsTerminalStatus(status, schema) {
+			// Build a one-entry ctx map for isItemDone so it hits the
+			// typed-context branch rather than the status-only fallback.
+			if isItemDone(child.Fields, child.CollectionID, map[string]doneContext{child.CollectionID: ctx}) {
 				done++
 			}
 		}

--- a/internal/store/agent_roles.go
+++ b/internal/store/agent_roles.go
@@ -2,7 +2,6 @@ package store
 
 import (
 	"database/sql"
-	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
@@ -179,20 +178,22 @@ func (s *Store) GetRoleBreakdown(workspaceID string) ([]RoleBreakdown, error) {
 		return nil, err
 	}
 
-	// Count non-terminal items per role (exclude done/completed/etc. to match board view)
-	termPlaceholders, termArgs := models.DefaultTerminalStatusPlaceholders()
-	roleCountArgs := append([]any{workspaceID}, termArgs...)
-	jsonExtractStatus := s.dialect.JSONExtractText("i.fields", "status")
+	// Count non-terminal items per role using each collection's own
+	// configured done field (board_group_by, defaulting to status). The
+	// expression becomes an OR of per-collection clauses; negating
+	// filters to items that are NOT in a terminal state.
+	filters := s.doneFiltersForWorkspace(workspaceID)
+	doneExpr, doneArgs := s.buildChildrenDoneExpr(filters, "i")
+	roleCountArgs := append([]any{workspaceID}, doneArgs...)
 	groupConcatUsers := s.dialect.GroupConcat("u.name", true)
 	rows, err := s.db.Query(s.q(fmt.Sprintf(`
 		SELECT i.agent_role_id, COUNT(*) as cnt, %s as users
 		FROM items i
 		LEFT JOIN users u ON u.id = i.assigned_user_id
 		WHERE i.workspace_id = ? AND i.deleted_at IS NULL
-		  AND LOWER(COALESCE(%s, '')) NOT IN
-		      (%s)
+		  AND NOT %s
 		GROUP BY i.agent_role_id
-	`, groupConcatUsers, jsonExtractStatus, termPlaceholders)), roleCountArgs...)
+	`, groupConcatUsers, doneExpr)), roleCountArgs...)
 	if err != nil {
 		return nil, fmt.Errorf("role breakdown: %w", err)
 	}
@@ -298,19 +299,17 @@ func (s *Store) GetRoleBoardItems(workspaceID string, params RoleBoardParams) ([
 		return nil, err
 	}
 
-	// Filter out terminal-status items
+	// Filter out terminal-state items using each collection's configured
+	// done field. buildCollectionDoneContextMap loads (schema, settings)
+	// for every collection in the workspace once so we don't re-parse
+	// per item.
+	ctxMap, err := s.buildCollectionDoneContextMap(workspaceID)
+	if err != nil {
+		ctxMap = nil // falls through to status-based default list
+	}
 	var activeItems []models.Item
 	for _, item := range allItems {
-		status := ""
-		if item.Fields != "" && item.Fields != "{}" {
-			var fields map[string]interface{}
-			if err := json.Unmarshal([]byte(item.Fields), &fields); err == nil {
-				if v, ok := fields["status"].(string); ok {
-					status = v
-				}
-			}
-		}
-		if !models.IsTerminalStatusDefault(status) {
+		if !isTerminalWithContext(item.Fields, item.CollectionID, ctxMap) {
 			activeItems = append(activeItems, item)
 		}
 	}

--- a/internal/store/collections.go
+++ b/internal/store/collections.go
@@ -141,23 +141,29 @@ func (s *Store) ListCollections(workspaceID string) ([]models.Collection, error)
 		return nil, err
 	}
 
-	// Compute active_item_count per collection using each collection's own
-	// terminal statuses from its schema (not the global default list).
-	jsonExtractStatus := s.dialect.JSONExtractText("i.fields", "status")
+	// Compute active_item_count per collection using that collection's own
+	// done-field + terminal options from its schema + settings (not the
+	// global default list, and not hardcoded to `status`). See TASK-604:
+	// collections whose board is grouped by e.g. `resolution` have
+	// done-detection follow that field naturally.
 	for idx := range result {
 		c := &result[idx]
 		var schema models.CollectionSchema
 		if err := json.Unmarshal([]byte(c.Schema), &schema); err != nil {
-			// If schema can't be parsed, fall back to default terminal statuses
 			schema = models.CollectionSchema{}
 		}
-		termPlaceholders, termArgs := models.TerminalStatusPlaceholders(schema)
+		var settings models.CollectionSettings
+		if c.Settings != "" {
+			_ = json.Unmarshal([]byte(c.Settings), &settings)
+		}
+		doneKey, termPlaceholders, termArgs := models.TerminalPlaceholdersForDoneField(schema, settings)
+		jsonExtractDone := s.dialect.JSONExtractText("i.fields", doneKey)
 		args := append([]any{c.ID}, termArgs...)
 		err := s.db.QueryRow(s.q(fmt.Sprintf(`
 			SELECT COUNT(*) FROM items i
 			WHERE i.collection_id = ? AND i.deleted_at IS NULL
 			AND LOWER(COALESCE(%s, '')) NOT IN (%s)
-		`, jsonExtractStatus, termPlaceholders)), args...).Scan(&c.ActiveItemCount)
+		`, jsonExtractDone, termPlaceholders)), args...).Scan(&c.ActiveItemCount)
 		if err != nil {
 			return nil, fmt.Errorf("count active items for collection %s: %w", c.Slug, err)
 		}

--- a/internal/store/collections.go
+++ b/internal/store/collections.go
@@ -104,6 +104,32 @@ func (s *Store) GetCollectionBySlug(workspaceID, slug string) (*models.Collectio
 	return s.GetCollection(id)
 }
 
+// ListCollectionsMinimal returns collection rows populated with just the
+// fields needed for done-detection context: ID, Schema, Settings.
+// Skips the per-collection COUNT queries that ListCollections runs, which
+// matters on hot paths that only need the schema + settings pair (e.g.
+// handlers that build a ctxMap for isItemDone). Includes soft-deleted
+// collections so items still attached to them can be evaluated.
+func (s *Store) ListCollectionsMinimal(workspaceID string) ([]models.Collection, error) {
+	rows, err := s.db.Query(
+		s.q(`SELECT id, schema, COALESCE(settings, '') FROM collections WHERE workspace_id = ?`),
+		workspaceID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list collections minimal: %w", err)
+	}
+	defer rows.Close()
+	var result []models.Collection
+	for rows.Next() {
+		var c models.Collection
+		if err := rows.Scan(&c.ID, &c.Schema, &c.Settings); err != nil {
+			return nil, fmt.Errorf("scan collection minimal: %w", err)
+		}
+		result = append(result, c)
+	}
+	return result, rows.Err()
+}
+
 func (s *Store) ListCollections(workspaceID string) ([]models.Collection, error) {
 	rows, err := s.db.Query(s.q(`
 		SELECT c.id, c.workspace_id, c.name, c.slug, c.prefix, c.icon, c.description,

--- a/internal/store/done_field_test.go
+++ b/internal/store/done_field_test.go
@@ -158,6 +158,67 @@ func TestGetItemProgress_DefaultsToStatusWithoutSettings(t *testing.T) {
 	}
 }
 
+// TestGetItemProgress_HonorsSoftDeletedChildCollections verifies a
+// regression Codex flagged: soft-deleted child collections must still
+// contribute done filters, otherwise their items can never satisfy the
+// per-collection `collection_id = ? AND ...` clause and would always be
+// counted as active.
+func TestGetItemProgress_HonorsSoftDeletedChildCollections(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "SoftDeleteTest")
+
+	plans, _ := s.CreateCollection(ws.ID, models.CollectionCreate{
+		Name:   "Plans",
+		Schema: `{"fields":[{"key":"status","label":"Status","type":"select","options":["active"],"default":"active"}]}`,
+	})
+	tasks, _ := s.CreateCollection(ws.ID, models.CollectionCreate{
+		Name:   "Tasks",
+		Schema: `{"fields":[{"key":"status","label":"Status","type":"select","options":["open","done"],"terminal_options":["done"],"default":"open"}]}`,
+	})
+
+	plan, _ := s.CreateItem(ws.ID, plans.ID, models.ItemCreate{Title: "P", Fields: `{"status":"active"}`})
+	done, _ := s.CreateItem(ws.ID, tasks.ID, models.ItemCreate{Title: "done task", Fields: `{"status":"done"}`})
+	open, _ := s.CreateItem(ws.ID, tasks.ID, models.ItemCreate{Title: "open task", Fields: `{"status":"open"}`})
+
+	for _, id := range []string{done.ID, open.ID} {
+		if _, err := s.CreateItemLink(ws.ID, models.ItemLinkCreate{
+			TargetID: plan.ID,
+			LinkType: "parent",
+		}, id); err != nil {
+			t.Fatalf("link: %v", err)
+		}
+	}
+
+	// Baseline: 1 done out of 2.
+	_, doneBefore, err := s.GetItemProgress(plan.ID)
+	if err != nil {
+		t.Fatalf("GetItemProgress before soft-delete: %v", err)
+	}
+	if doneBefore != 1 {
+		t.Fatalf("expected done=1 before soft-delete, got %d", doneBefore)
+	}
+
+	// Soft-delete the tasks collection. Its items remain in the DB and
+	// are still linked to the plan.
+	if err := s.DeleteCollection(tasks.ID); err != nil {
+		t.Fatalf("soft delete tasks: %v", err)
+	}
+
+	// Expect the same done count — soft-deleted collections still
+	// contribute their done rules.
+	_, doneAfter, err := s.GetItemProgress(plan.ID)
+	if err != nil {
+		t.Fatalf("GetItemProgress after soft-delete: %v", err)
+	}
+	if doneAfter != 1 {
+		t.Errorf(
+			"expected done count to remain 1 after collection soft-delete, got %d — "+
+				"soft-deleted collections must still contribute done filters",
+			doneAfter,
+		)
+	}
+}
+
 // TestGetItemProgress_MixedChildCollections verifies that when children
 // come from multiple collections with different done-field configurations,
 // each child is evaluated against its own collection's rules.

--- a/internal/store/done_field_test.go
+++ b/internal/store/done_field_test.go
@@ -1,0 +1,213 @@
+package store
+
+import (
+	"testing"
+
+	"github.com/xarmian/pad/internal/models"
+)
+
+// TestGetItemProgress_DoneFieldFollowsBoardGroupBy verifies the core
+// TASK-604 acceptance criterion: when a child collection's
+// settings.board_group_by points at a non-status select field that has
+// terminal_options declared, child-progress counts reflect THAT field's
+// terminals — not status, and not the global default list.
+func TestGetItemProgress_DoneFieldFollowsBoardGroupBy(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "DoneFieldTest")
+
+	// Parent collection — generic plans holder. Nothing special here.
+	plans, err := s.CreateCollection(ws.ID, models.CollectionCreate{
+		Name:   "Plans",
+		Schema: `{"fields":[{"key":"status","label":"Status","type":"select","options":["draft","active","completed"],"default":"draft"}]}`,
+	})
+	if err != nil {
+		t.Fatalf("create plans collection: %v", err)
+	}
+
+	// Child collection: a Bugs tracker whose board groups by `resolution`
+	// with terminal options `fixed` and `wontfix`. `status` is still on
+	// the schema with its own terminal options; we're specifically
+	// asserting that those don't win over `resolution`.
+	bugsSchema := `{"fields":[
+		{"key":"status","label":"Status","type":"select","options":["new","investigating","fixed"],"terminal_options":["fixed"],"default":"new"},
+		{"key":"resolution","label":"Resolution","type":"select","options":["open","fixed","wontfix"],"terminal_options":["fixed","wontfix"],"default":"open"}
+	]}`
+	bugsSettings := `{"board_group_by":"resolution"}`
+	bugs, err := s.CreateCollection(ws.ID, models.CollectionCreate{
+		Name:     "Bugs",
+		Schema:   bugsSchema,
+		Settings: bugsSettings,
+	})
+	if err != nil {
+		t.Fatalf("create bugs collection: %v", err)
+	}
+
+	// Create a parent plan.
+	plan, err := s.CreateItem(ws.ID, plans.ID, models.ItemCreate{
+		Title:  "Release Plan",
+		Fields: `{"status":"active"}`,
+	})
+	if err != nil {
+		t.Fatalf("create plan: %v", err)
+	}
+
+	// Create four bug items as children:
+	//   b1: resolution=open          → not done
+	//   b2: resolution=fixed         → done (terminal on resolution)
+	//   b3: resolution=wontfix       → done (terminal on resolution)
+	//   b4: resolution=open, status=fixed → NOT done
+	//        (status is terminal, but status isn't the done field anymore)
+	bugCases := []struct {
+		title  string
+		fields string
+	}{
+		{"Crash on login", `{"resolution":"open","status":"new"}`},
+		{"Memory leak", `{"resolution":"fixed","status":"fixed"}`},
+		{"Wrong copy", `{"resolution":"wontfix","status":"new"}`},
+		{"Layout glitch", `{"resolution":"open","status":"fixed"}`},
+	}
+	var bugItems []*models.Item
+	for _, bc := range bugCases {
+		it, cerr := s.CreateItem(ws.ID, bugs.ID, models.ItemCreate{
+			Title:  bc.title,
+			Fields: bc.fields,
+		})
+		if cerr != nil {
+			t.Fatalf("create bug %q: %v", bc.title, cerr)
+		}
+		bugItems = append(bugItems, it)
+	}
+
+	// Link each bug as a child of the plan.
+	for _, b := range bugItems {
+		if _, lerr := s.CreateItemLink(ws.ID, models.ItemLinkCreate{
+			TargetID: plan.ID,
+			LinkType: "parent",
+		}, b.ID); lerr != nil {
+			t.Fatalf("link %s → plan: %v", b.Title, lerr)
+		}
+	}
+
+	// Act: compute progress.
+	total, done, err := s.GetItemProgress(plan.ID)
+	if err != nil {
+		t.Fatalf("GetItemProgress: %v", err)
+	}
+
+	// Expected:
+	//   total = 4 (all children)
+	//   done  = 2 (b2 + b3 — the ones with terminal `resolution` values)
+	if total != 4 {
+		t.Errorf("expected total=4, got %d", total)
+	}
+	if done != 2 {
+		t.Errorf("expected done=2 (resolution-driven), got %d", done)
+	}
+}
+
+// TestGetItemProgress_DefaultsToStatusWithoutSettings verifies back-compat:
+// a collection without board_group_by (i.e. shipped today) should have its
+// `status` field drive done-detection, exactly as before.
+func TestGetItemProgress_DefaultsToStatusWithoutSettings(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "DefaultStatusTest")
+
+	plans, err := s.CreateCollection(ws.ID, models.CollectionCreate{
+		Name:   "Plans",
+		Schema: `{"fields":[{"key":"status","label":"Status","type":"select","options":["draft","active"],"default":"draft"}]}`,
+	})
+	if err != nil {
+		t.Fatalf("create plans: %v", err)
+	}
+
+	tasks, err := s.CreateCollection(ws.ID, models.CollectionCreate{
+		Name:   "Tasks",
+		Schema: `{"fields":[{"key":"status","label":"Status","type":"select","options":["open","in-progress","done","cancelled"],"terminal_options":["done","cancelled"],"default":"open"}]}`,
+	})
+	if err != nil {
+		t.Fatalf("create tasks: %v", err)
+	}
+
+	plan, _ := s.CreateItem(ws.ID, plans.ID, models.ItemCreate{Title: "P", Fields: `{"status":"active"}`})
+
+	taskCases := []string{
+		`{"status":"open"}`,
+		`{"status":"done"}`,
+		`{"status":"cancelled"}`,
+		`{"status":"in-progress"}`,
+	}
+	for _, f := range taskCases {
+		it, _ := s.CreateItem(ws.ID, tasks.ID, models.ItemCreate{Title: "t", Fields: f})
+		if _, err := s.CreateItemLink(ws.ID, models.ItemLinkCreate{
+			TargetID: plan.ID,
+			LinkType: "parent",
+		}, it.ID); err != nil {
+			t.Fatalf("link: %v", err)
+		}
+	}
+
+	total, done, err := s.GetItemProgress(plan.ID)
+	if err != nil {
+		t.Fatalf("GetItemProgress: %v", err)
+	}
+	if total != 4 {
+		t.Errorf("expected total=4, got %d", total)
+	}
+	if done != 2 {
+		t.Errorf("expected done=2 (status-driven), got %d", done)
+	}
+}
+
+// TestGetItemProgress_MixedChildCollections verifies that when children
+// come from multiple collections with different done-field configurations,
+// each child is evaluated against its own collection's rules.
+func TestGetItemProgress_MixedChildCollections(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "MixedChildTest")
+
+	plans, _ := s.CreateCollection(ws.ID, models.CollectionCreate{
+		Name:   "Plans",
+		Schema: `{"fields":[{"key":"status","label":"Status","type":"select","options":["active"],"default":"active"}]}`,
+	})
+
+	// Child A: status-driven, terminals ["done"].
+	tasks, _ := s.CreateCollection(ws.ID, models.CollectionCreate{
+		Name:   "Tasks",
+		Schema: `{"fields":[{"key":"status","label":"Status","type":"select","options":["open","done"],"terminal_options":["done"],"default":"open"}]}`,
+	})
+
+	// Child B: resolution-driven, terminals ["resolved"].
+	bugs, _ := s.CreateCollection(ws.ID, models.CollectionCreate{
+		Name:     "Bugs",
+		Schema:   `{"fields":[{"key":"resolution","label":"Resolution","type":"select","options":["open","resolved"],"terminal_options":["resolved"],"default":"open"}]}`,
+		Settings: `{"board_group_by":"resolution"}`,
+	})
+
+	plan, _ := s.CreateItem(ws.ID, plans.ID, models.ItemCreate{Title: "P", Fields: `{"status":"active"}`})
+
+	// 1 task done + 1 task open + 1 bug resolved + 1 bug open  → expect done=2, total=4.
+	link := func(id string) {
+		if _, err := s.CreateItemLink(ws.ID, models.ItemLinkCreate{TargetID: plan.ID, LinkType: "parent"}, id); err != nil {
+			t.Fatalf("link: %v", err)
+		}
+	}
+	t1, _ := s.CreateItem(ws.ID, tasks.ID, models.ItemCreate{Title: "t1", Fields: `{"status":"done"}`})
+	t2, _ := s.CreateItem(ws.ID, tasks.ID, models.ItemCreate{Title: "t2", Fields: `{"status":"open"}`})
+	b1, _ := s.CreateItem(ws.ID, bugs.ID, models.ItemCreate{Title: "b1", Fields: `{"resolution":"resolved"}`})
+	b2, _ := s.CreateItem(ws.ID, bugs.ID, models.ItemCreate{Title: "b2", Fields: `{"resolution":"open"}`})
+	link(t1.ID)
+	link(t2.ID)
+	link(b1.ID)
+	link(b2.ID)
+
+	total, done, err := s.GetItemProgress(plan.ID)
+	if err != nil {
+		t.Fatalf("GetItemProgress: %v", err)
+	}
+	if total != 4 {
+		t.Errorf("expected total=4, got %d", total)
+	}
+	if done != 2 {
+		t.Errorf("expected done=2 (one per collection's rules), got %d", done)
+	}
+}

--- a/internal/store/item_stars.go
+++ b/internal/store/item_stars.go
@@ -125,16 +125,16 @@ func (s *Store) ListStarredItems(userID, workspaceID string, includeTerminal boo
 	}
 
 	if !includeTerminal {
-		// Build a schema map from workspace collections for per-collection terminal status checks
-		schemaMap, err := s.buildCollectionSchemaMap(workspaceID)
+		// Build a (schema + settings) context per collection so terminal
+		// checks honor each collection's configured done field.
+		ctxMap, err := s.buildCollectionDoneContextMap(workspaceID)
 		if err != nil {
-			return nil, fmt.Errorf("list starred items: build schema map: %w", err)
+			return nil, fmt.Errorf("list starred items: build done-context map: %w", err)
 		}
 
 		filtered := make([]models.Item, 0, len(items))
 		for _, item := range items {
-			status := extractStatusFromFields(item.Fields)
-			if !isTerminalWithSchema(status, item.CollectionID, schemaMap) {
+			if !isTerminalWithContext(item.Fields, item.CollectionID, ctxMap) {
 				filtered = append(filtered, item)
 			}
 		}
@@ -159,54 +159,71 @@ func (s *Store) CountStarredItems(userID, workspaceID string) (int, error) {
 	return count, nil
 }
 
-// buildCollectionSchemaMap loads only collection IDs and schemas for a workspace,
-// avoiding the heavier ListCollections which runs per-collection COUNT queries.
-func (s *Store) buildCollectionSchemaMap(workspaceID string) (map[string]models.CollectionSchema, error) {
+// collectionDoneContext pairs a collection's parsed schema with its
+// parsed settings so terminal-state checks can honor the configured
+// done field (board_group_by) — not just the hardcoded `status` column.
+type collectionDoneContext struct {
+	schema   models.CollectionSchema
+	settings models.CollectionSettings
+}
+
+// buildCollectionDoneContextMap loads schema + settings for every
+// collection in a workspace. Used to evaluate "is terminal?" for a
+// batch of items from potentially different collections.
+func (s *Store) buildCollectionDoneContextMap(workspaceID string) (map[string]collectionDoneContext, error) {
 	rows, err := s.db.Query(
-		s.q("SELECT id, schema FROM collections WHERE workspace_id = ?"),
+		s.q("SELECT id, schema, settings FROM collections WHERE workspace_id = ?"),
 		workspaceID,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("load collection schemas: %w", err)
+		return nil, fmt.Errorf("load collection done-context: %w", err)
 	}
 	defer rows.Close()
 
-	m := make(map[string]models.CollectionSchema)
+	m := make(map[string]collectionDoneContext)
 	for rows.Next() {
 		var id, rawSchema string
-		if err := rows.Scan(&id, &rawSchema); err != nil {
+		var rawSettings sql.NullString
+		if err := rows.Scan(&id, &rawSchema, &rawSettings); err != nil {
 			return nil, err
 		}
-		var schema models.CollectionSchema
-		if err := json.Unmarshal([]byte(rawSchema), &schema); err == nil {
-			m[id] = schema
+		var ctx collectionDoneContext
+		if err := json.Unmarshal([]byte(rawSchema), &ctx.schema); err != nil {
+			// Don't drop the entry entirely — we still want an empty
+			// context so the membership test falls back to defaults
+			// rather than silently treating the item as non-terminal.
+			ctx.schema = models.CollectionSchema{}
 		}
+		if rawSettings.Valid && rawSettings.String != "" {
+			_ = json.Unmarshal([]byte(rawSettings.String), &ctx.settings)
+		}
+		m[id] = ctx
 	}
 	return m, rows.Err()
 }
 
-// extractStatusFromFields extracts the "status" value from an item's fields JSON.
-func extractStatusFromFields(fields string) string {
+// isTerminalWithContext reports whether an item is in a terminal state
+// given its collection's done-context. When the collection isn't in the
+// map (e.g. deleted collection), falls back to default-terminal checks
+// against the item's `status` field.
+func isTerminalWithContext(
+	fields string,
+	collectionID string,
+	ctxMap map[string]collectionDoneContext,
+) bool {
 	if fields == "" || fields == "{}" {
-		return ""
-	}
-	var m map[string]interface{}
-	if err := json.Unmarshal([]byte(fields), &m); err != nil {
-		return ""
-	}
-	status, _ := m["status"].(string)
-	return status
-}
-
-// isTerminalWithSchema checks if a status is terminal using the collection's schema.
-// Falls back to default terminal statuses if the collection is not in the schema map.
-func isTerminalWithSchema(status, collectionID string, schemaMap map[string]models.CollectionSchema) bool {
-	if status == "" {
 		return false
 	}
-	if schema, ok := schemaMap[collectionID]; ok {
-		return models.IsTerminalStatus(status, schema)
+	var m map[string]any
+	if err := json.Unmarshal([]byte(fields), &m); err != nil {
+		return false
 	}
+	if ctx, ok := ctxMap[collectionID]; ok {
+		return models.IsTerminalItem(m, ctx.schema, ctx.settings)
+	}
+	// No collection context available → check the status field against
+	// the global default list. Matches the legacy fallback behavior.
+	status, _ := m["status"].(string)
 	return models.IsTerminalStatusDefault(status)
 }
 

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -1402,6 +1402,14 @@ func (s *Store) childrenDoneFiltersForCollection(workspaceID, collectionSlug str
 
 // scanCollectionDoneFilters consumes rows yielding (id, schema, settings)
 // and resolves each into a collectionDoneFilter.
+//
+// When a collection's schema fails to parse we still emit a filter — one
+// that falls back to the `status` field and the global default terminal
+// list. Silently skipping the collection would leave its items without a
+// matching per-collection clause in buildChildrenDoneExpr, so they'd
+// always register as non-terminal in progress / role / starred queries
+// (a malformed schema on one collection would skew counts on every
+// parent-progress computation).
 func scanCollectionDoneFilters(rows *sql.Rows) []collectionDoneFilter {
 	var filters []collectionDoneFilter
 	for rows.Next() {
@@ -1412,9 +1420,15 @@ func scanCollectionDoneFilters(rows *sql.Rows) []collectionDoneFilter {
 		}
 		var schema models.CollectionSchema
 		if err := json.Unmarshal([]byte(schemaJSON), &schema); err != nil {
-			// Broken schema → skip this collection; buildChildrenDoneExpr
-			// will still include the default-fallback clause if no filters
-			// end up constructed overall.
+			// Malformed schema → emit a default-fallback filter so the
+			// collection's items still get evaluated against the status
+			// column + global default terminals. This matches pre-TASK-604
+			// behavior for those items.
+			filters = append(filters, collectionDoneFilter{
+				collectionID: id,
+				doneKey:      "status",
+				values:       models.DefaultTerminalStatuses,
+			})
 			continue
 		}
 		var settings models.CollectionSettings

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -1296,81 +1296,77 @@ func (s *Store) GetParentMap(workspaceID string) (map[string]string, error) {
 // --- Child Item Progress ---
 
 // GetItemProgress counts total and done child items linked to a parent via item_links.
-// "Done" means any terminal status as defined by the child items' collection schemas.
-// Children from any collection count toward progress.
+// "Done" means the child item's done field (resolved from its collection's
+// board_group_by, defaulting to status) matches one of that field's terminal
+// options. Children from any collection count toward progress, and each
+// child is evaluated against its own collection's done rules.
 func (s *Store) GetItemProgress(parentItemID string) (total int, done int, err error) {
-	termPlaceholders, termArgs := s.getChildTerminalPlaceholders(parentItemID)
-	args := append(termArgs, parentItemID)
-	statusExpr := s.dialect.JSONExtractText("i.fields", "status")
+	filters := s.childrenDoneFiltersForParent(parentItemID)
+	doneExpr, doneArgs := s.buildChildrenDoneExpr(filters, "i")
+	args := append(doneArgs, parentItemID)
 	err = s.db.QueryRow(s.q(fmt.Sprintf(`
 		SELECT COUNT(*),
-		       COUNT(CASE WHEN LOWER(%s) IN (%s) THEN 1 END)
+		       COUNT(CASE WHEN %s THEN 1 END)
 		FROM items i
 		JOIN item_links il ON il.source_id = i.id AND il.link_type IN (%s) AND il.target_id = ?
 		WHERE i.deleted_at IS NULL
-	`, statusExpr, termPlaceholders, childLinkTypeSQL())), args...).Scan(&total, &done)
+	`, doneExpr, childLinkTypeSQL())), args...).Scan(&total, &done)
 	if err != nil {
 		return 0, 0, fmt.Errorf("get item progress: %w", err)
 	}
 	return total, done, nil
 }
 
-// getChildTerminalPlaceholders returns SQL placeholders and args for the terminal
-// statuses of the collections that a parent item's children belong to.
-// It queries the actual child items' collection schemas rather than hardcoding 'tasks'.
-func (s *Store) getChildTerminalPlaceholders(parentItemID string) (string, []any) {
-	// Find distinct collection IDs of child items
+// collectionDoneFilter describes how to evaluate "done" for a single child
+// collection: which JSON key to read, and which values count as terminal.
+type collectionDoneFilter struct {
+	collectionID string
+	doneKey      string
+	values       []string
+}
+
+// childrenDoneFiltersForParent returns a filter per distinct child-item
+// collection under the given parent. Each filter carries the child
+// collection's resolved done field (honoring board_group_by) and terminal
+// values so the caller can build a per-collection OR clause that evaluates
+// each child against its own done rules.
+func (s *Store) childrenDoneFiltersForParent(parentItemID string) []collectionDoneFilter {
 	rows, err := s.db.Query(s.q(fmt.Sprintf(`
-		SELECT DISTINCT c.schema
+		SELECT DISTINCT c.id, c.schema, c.settings
 		FROM items i
 		JOIN collections c ON c.id = i.collection_id
 		JOIN item_links il ON il.source_id = i.id AND il.link_type IN (%s) AND il.target_id = ?
 		WHERE i.deleted_at IS NULL AND c.deleted_at IS NULL
 	`, childLinkTypeSQL())), parentItemID)
 	if err != nil {
-		return models.DefaultTerminalStatusPlaceholders()
+		return nil
 	}
 	defer rows.Close()
-
-	// Collect terminal statuses from all child collections
-	terminalSet := make(map[string]bool)
-	found := false
-	for rows.Next() {
-		var schemaJSON string
-		if err := rows.Scan(&schemaJSON); err != nil {
-			continue
-		}
-		found = true
-		var schema models.CollectionSchema
-		if err := json.Unmarshal([]byte(schemaJSON), &schema); err != nil {
-			continue
-		}
-		for _, ts := range models.TerminalStatusesFromSchema(schema) {
-			terminalSet[strings.ToLower(ts)] = true
-		}
-	}
-
-	if !found || len(terminalSet) == 0 {
-		return models.DefaultTerminalStatusPlaceholders()
-	}
-
-	placeholders := make([]string, 0, len(terminalSet))
-	args := make([]any, 0, len(terminalSet))
-	for ts := range terminalSet {
-		placeholders = append(placeholders, "?")
-		args = append(args, ts)
-	}
-	return strings.Join(placeholders, ","), args
+	return scanCollectionDoneFilters(rows)
 }
 
-// getCollectionChildTerminalPlaceholders returns SQL placeholders and args for the
-// terminal statuses of all child collections linked to parents in the given collection.
-// This is the batch version of getChildTerminalPlaceholders — instead of querying for
-// a single parent, it gathers terminal statuses across all parent→child links in a
-// workspace/collection pair.
-func (s *Store) getCollectionChildTerminalPlaceholders(workspaceID, collectionSlug string) (string, []any) {
+// doneFiltersForWorkspace returns a done-filter per non-deleted collection
+// in the workspace. Used by cross-collection queries (e.g. agent-role
+// breakdowns) that need to evaluate "is done?" for every item regardless
+// of which collection it belongs to.
+func (s *Store) doneFiltersForWorkspace(workspaceID string) []collectionDoneFilter {
+	rows, err := s.db.Query(
+		s.q(`SELECT id, schema, settings FROM collections WHERE workspace_id = ? AND deleted_at IS NULL`),
+		workspaceID,
+	)
+	if err != nil {
+		return nil
+	}
+	defer rows.Close()
+	return scanCollectionDoneFilters(rows)
+}
+
+// childrenDoneFiltersForCollection is the batch version: it gathers one
+// filter per distinct child-item collection across all parent→child links
+// for parents in a given (workspace, collectionSlug).
+func (s *Store) childrenDoneFiltersForCollection(workspaceID, collectionSlug string) []collectionDoneFilter {
 	rows, err := s.db.Query(s.q(fmt.Sprintf(`
-		SELECT DISTINCT c.schema
+		SELECT DISTINCT c.id, c.schema, c.settings
 		FROM items t
 		JOIN collections c ON c.id = t.collection_id
 		JOIN item_links il ON il.source_id = t.id AND il.link_type IN (%s)
@@ -1381,38 +1377,78 @@ func (s *Store) getCollectionChildTerminalPlaceholders(workspaceID, collectionSl
 		  AND c.deleted_at IS NULL
 	`, childLinkTypeSQL())), collectionSlug, workspaceID)
 	if err != nil {
-		return models.DefaultTerminalStatusPlaceholders()
+		return nil
 	}
 	defer rows.Close()
+	return scanCollectionDoneFilters(rows)
+}
 
-	terminalSet := make(map[string]bool)
-	found := false
+// scanCollectionDoneFilters consumes rows yielding (id, schema, settings)
+// and resolves each into a collectionDoneFilter.
+func scanCollectionDoneFilters(rows *sql.Rows) []collectionDoneFilter {
+	var filters []collectionDoneFilter
 	for rows.Next() {
-		var schemaJSON string
-		if err := rows.Scan(&schemaJSON); err != nil {
+		var id, schemaJSON string
+		var settingsJSON sql.NullString
+		if err := rows.Scan(&id, &schemaJSON, &settingsJSON); err != nil {
 			continue
 		}
-		found = true
 		var schema models.CollectionSchema
 		if err := json.Unmarshal([]byte(schemaJSON), &schema); err != nil {
+			// Broken schema → skip this collection; buildChildrenDoneExpr
+			// will still include the default-fallback clause if no filters
+			// end up constructed overall.
 			continue
 		}
-		for _, ts := range models.TerminalStatusesFromSchema(schema) {
-			terminalSet[strings.ToLower(ts)] = true
+		var settings models.CollectionSettings
+		if settingsJSON.Valid && settingsJSON.String != "" {
+			_ = json.Unmarshal([]byte(settingsJSON.String), &settings)
 		}
+		key, values := models.TerminalValuesForDoneField(schema, settings)
+		filters = append(filters, collectionDoneFilter{
+			collectionID: id,
+			doneKey:      key,
+			values:       values,
+		})
 	}
+	return filters
+}
 
-	if !found || len(terminalSet) == 0 {
-		return models.DefaultTerminalStatusPlaceholders()
+// buildChildrenDoneExpr compiles a set of per-collection done filters into
+// a single SQL boolean expression plus ordered args. `itemAlias` is the
+// item-table alias in the outer query (e.g. "i" for GetItemProgress, "t"
+// for GetAllItemProgress).
+//
+// Expression shape:
+//   ((<alias>.collection_id = ? AND LOWER(COALESCE(<field_A>, '')) IN (?,?)) OR
+//    (<alias>.collection_id = ? AND LOWER(COALESCE(<field_B>, '')) IN (?,?)))
+//
+// If no filters were constructed (no child collections discovered, or all
+// of their schemas failed to parse), falls back to checking <alias>.status
+// against the global default terminal list — mirroring the legacy behavior
+// so dashboards for untyped collections keep working.
+func (s *Store) buildChildrenDoneExpr(filters []collectionDoneFilter, itemAlias string) (string, []any) {
+	if len(filters) == 0 {
+		statusExpr := s.dialect.JSONExtractText(itemAlias+".fields", "status")
+		placeholders, args := models.DefaultTerminalStatusPlaceholders()
+		return fmt.Sprintf("LOWER(COALESCE(%s, '')) IN (%s)", statusExpr, placeholders), args
 	}
-
-	placeholders := make([]string, 0, len(terminalSet))
-	args := make([]any, 0, len(terminalSet))
-	for ts := range terminalSet {
-		placeholders = append(placeholders, "?")
-		args = append(args, ts)
+	clauses := make([]string, 0, len(filters))
+	args := make([]any, 0, len(filters)*4)
+	for _, f := range filters {
+		fieldExpr := s.dialect.JSONExtractText(itemAlias+".fields", f.doneKey)
+		placeholders := make([]string, len(f.values))
+		args = append(args, f.collectionID)
+		for i, v := range f.values {
+			placeholders[i] = "?"
+			args = append(args, strings.ToLower(v))
+		}
+		clauses = append(clauses, fmt.Sprintf(
+			"(%s.collection_id = ? AND LOWER(COALESCE(%s, '')) IN (%s))",
+			itemAlias, fieldExpr, strings.Join(placeholders, ","),
+		))
 	}
-	return strings.Join(placeholders, ","), args
+	return "(" + strings.Join(clauses, " OR ") + ")", args
 }
 
 // ItemProgress holds child item completion counts for a single parent item.
@@ -1425,13 +1461,13 @@ type ItemProgress struct {
 // GetAllItemProgress returns child item completion counts for every non-deleted
 // item in the given collection within a workspace.
 func (s *Store) GetAllItemProgress(workspaceID, collectionSlug string) ([]ItemProgress, error) {
-	termPlaceholders, termArgs := s.getCollectionChildTerminalPlaceholders(workspaceID, collectionSlug)
-	args := append(termArgs, workspaceID, collectionSlug)
-	tStatusExpr := s.dialect.JSONExtractText("t.fields", "status")
+	filters := s.childrenDoneFiltersForCollection(workspaceID, collectionSlug)
+	doneExpr, doneArgs := s.buildChildrenDoneExpr(filters, "t")
+	args := append(doneArgs, workspaceID, collectionSlug)
 	rows, err := s.db.Query(s.q(fmt.Sprintf(`
 		SELECT p.id,
 		       COUNT(t.id),
-		       COUNT(CASE WHEN LOWER(%s) IN (%s) THEN 1 END)
+		       COUNT(CASE WHEN t.id IS NOT NULL AND %s THEN 1 END)
 		FROM items p
 		JOIN collections pc ON pc.id = p.collection_id
 		LEFT JOIN item_links il ON il.link_type IN (%s) AND il.target_id = p.id
@@ -1441,7 +1477,7 @@ func (s *Store) GetAllItemProgress(workspaceID, collectionSlug string) ([]ItemPr
 		  AND pc.slug = ?
 		  AND p.deleted_at IS NULL
 		GROUP BY p.id
-	`, tStatusExpr, termPlaceholders, childLinkTypeSQL())), args...)
+	`, doneExpr, childLinkTypeSQL())), args...)
 	if err != nil {
 		return nil, fmt.Errorf("get all item progress: %w", err)
 	}

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -1330,13 +1330,20 @@ type collectionDoneFilter struct {
 // collection's resolved done field (honoring board_group_by) and terminal
 // values so the caller can build a per-collection OR clause that evaluates
 // each child against its own done rules.
+//
+// Soft-deleted collections are intentionally INCLUDED: progress-counting
+// callers count items regardless of their collection's deleted_at, so
+// excluding the collection here would leave those items without a
+// matching per-collection clause and cause them to always evaluate as
+// non-terminal. The collection row still carries valid schema + settings
+// until a hard delete cascades, so the done rules remain applicable.
 func (s *Store) childrenDoneFiltersForParent(parentItemID string) []collectionDoneFilter {
 	rows, err := s.db.Query(s.q(fmt.Sprintf(`
 		SELECT DISTINCT c.id, c.schema, c.settings
 		FROM items i
 		JOIN collections c ON c.id = i.collection_id
 		JOIN item_links il ON il.source_id = i.id AND il.link_type IN (%s) AND il.target_id = ?
-		WHERE i.deleted_at IS NULL AND c.deleted_at IS NULL
+		WHERE i.deleted_at IS NULL
 	`, childLinkTypeSQL())), parentItemID)
 	if err != nil {
 		return nil
@@ -1345,13 +1352,19 @@ func (s *Store) childrenDoneFiltersForParent(parentItemID string) []collectionDo
 	return scanCollectionDoneFilters(rows)
 }
 
-// doneFiltersForWorkspace returns a done-filter per non-deleted collection
-// in the workspace. Used by cross-collection queries (e.g. agent-role
+// doneFiltersForWorkspace returns a done-filter per collection in the
+// workspace. Used by cross-collection queries (e.g. agent-role
 // breakdowns) that need to evaluate "is done?" for every item regardless
 // of which collection it belongs to.
+//
+// Includes soft-deleted collections: callers (e.g. GetRoleBreakdown)
+// count items in the workspace without filtering by collection
+// deleted_at, so excluding soft-deleted collections here would leave
+// their items without a matching per-collection clause and cause them
+// to always register as non-terminal.
 func (s *Store) doneFiltersForWorkspace(workspaceID string) []collectionDoneFilter {
 	rows, err := s.db.Query(
-		s.q(`SELECT id, schema, settings FROM collections WHERE workspace_id = ? AND deleted_at IS NULL`),
+		s.q(`SELECT id, schema, settings FROM collections WHERE workspace_id = ?`),
 		workspaceID,
 	)
 	if err != nil {
@@ -1364,6 +1377,11 @@ func (s *Store) doneFiltersForWorkspace(workspaceID string) []collectionDoneFilt
 // childrenDoneFiltersForCollection is the batch version: it gathers one
 // filter per distinct child-item collection across all parent→child links
 // for parents in a given (workspace, collectionSlug).
+//
+// Includes soft-deleted child collections for the same reason as
+// childrenDoneFiltersForParent — callers count items regardless of their
+// collection's deleted_at, and we want items from soft-deleted
+// collections to still be evaluated against their own done rules.
 func (s *Store) childrenDoneFiltersForCollection(workspaceID, collectionSlug string) []collectionDoneFilter {
 	rows, err := s.db.Query(s.q(fmt.Sprintf(`
 		SELECT DISTINCT c.id, c.schema, c.settings
@@ -1374,7 +1392,6 @@ func (s *Store) childrenDoneFiltersForCollection(workspaceID, collectionSlug str
 		JOIN collections pc ON pc.id = p.collection_id AND pc.slug = ?
 		WHERE p.workspace_id = ?
 		  AND t.deleted_at IS NULL
-		  AND c.deleted_at IS NULL
 	`, childLinkTypeSQL())), collectionSlug, workspaceID)
 	if err != nil {
 		return nil

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -1423,6 +1423,12 @@ func scanCollectionDoneFilters(rows *sql.Rows) []collectionDoneFilter {
 //   ((<alias>.collection_id = ? AND LOWER(COALESCE(<field_A>, '')) IN (?,?)) OR
 //    (<alias>.collection_id = ? AND LOWER(COALESCE(<field_B>, '')) IN (?,?)))
 //
+// The `<field_X>` JSON extract uses scalar text extraction; this works
+// because DoneFieldKey in the models package only resolves done fields to
+// `select` typed columns (see that function's doc). multi_select-backed
+// done fields would store their values as a JSON array and scalar IN
+// matching would silently miss them — hence the upstream restriction.
+//
 // If no filters were constructed (no child collections discovered, or all
 // of their schemas failed to parse), falls back to checking <alias>.status
 // against the global default terminal list — mirroring the legacy behavior

--- a/web/src/lib/components/collections/CreateCollectionModal.svelte
+++ b/web/src/lib/components/collections/CreateCollectionModal.svelte
@@ -58,6 +58,20 @@
 	let listSortBy = $state('');
 	let quickActions = $state<EditableQuickAction[]>([]);
 
+	// Mirrors DoneFieldKey() in internal/models/terminal.go — honors the
+	// selected board_group_by when it points at an in-editor select/multi
+	// _select field, else falls back to 'status'. Used by FieldEditor to
+	// render Active/Saved pills on terminal-option columns.
+	const activeDoneField = $derived.by(() => {
+		const candidate = (boardGroupBy || '').trim();
+		if (!candidate) return 'status';
+		const matches = fields.some(
+			(f) =>
+				f.key.trim() === candidate && (f.type === 'select' || f.type === 'multi_select')
+		);
+		return matches ? candidate : 'status';
+	});
+
 	// The collection doesn't exist yet, so the preview context falls back to
 	// representative placeholder values. Updates live as the collection name
 	// changes so the {collection} token reflects what will be saved.
@@ -471,6 +485,7 @@
 										isNew
 										keyError={keyErrors[i]}
 										collections={collectionOptions}
+										{activeDoneField}
 										onmoveup={() => moveField(i, -1)}
 										onmovedown={() => moveField(i, 1)}
 										onremove={() => removeField(i)}

--- a/web/src/lib/components/collections/CreateCollectionModal.svelte
+++ b/web/src/lib/components/collections/CreateCollectionModal.svelte
@@ -58,17 +58,14 @@
 	let listSortBy = $state('');
 	let quickActions = $state<EditableQuickAction[]>([]);
 
-	// Mirrors DoneFieldKey() in internal/models/terminal.go — honors the
-	// selected board_group_by when it points at an in-editor select/multi
-	// _select field, else falls back to 'status'. Used by FieldEditor to
-	// render Active/Saved pills on terminal-option columns.
+	// Mirrors DoneFieldKey() in internal/models/terminal.go — only accepts
+	// `select` fields as a done field (multi_select is rejected because the
+	// Go + SQL paths only handle scalar string matching). Falls back to
+	// 'status' otherwise.
 	const activeDoneField = $derived.by(() => {
 		const candidate = (boardGroupBy || '').trim();
 		if (!candidate) return 'status';
-		const matches = fields.some(
-			(f) =>
-				f.key.trim() === candidate && (f.type === 'select' || f.type === 'multi_select')
-		);
+		const matches = fields.some((f) => f.key.trim() === candidate && f.type === 'select');
 		return matches ? candidate : 'status';
 	});
 

--- a/web/src/lib/components/collections/CreateCollectionModal.svelte
+++ b/web/src/lib/components/collections/CreateCollectionModal.svelte
@@ -8,6 +8,7 @@
 		blankField,
 		coerceDefault,
 		fieldFromDef,
+		isSafeDoneFieldKey,
 		typeSupportsDefault,
 		validateFieldKey,
 		type EditableField
@@ -58,13 +59,14 @@
 	let listSortBy = $state('');
 	let quickActions = $state<EditableQuickAction[]>([]);
 
-	// Mirrors DoneFieldKey() in internal/models/terminal.go — only accepts
-	// `select` fields as a done field (multi_select is rejected because the
-	// Go + SQL paths only handle scalar string matching). Falls back to
-	// 'status' otherwise.
+	// Mirrors DoneFieldKey() in internal/models/terminal.go:
+	// - only accepts `select` fields (multi_select is rejected — both
+	//   paths only handle scalar string matching)
+	// - requires the key to match the backend's safe-key pattern or the
+	//   server falls back to "status"
 	const activeDoneField = $derived.by(() => {
 		const candidate = (boardGroupBy || '').trim();
-		if (!candidate) return 'status';
+		if (!candidate || !isSafeDoneFieldKey(candidate)) return 'status';
 		const matches = fields.some((f) => f.key.trim() === candidate && f.type === 'select');
 		return matches ? candidate : 'status';
 	});

--- a/web/src/lib/components/collections/DisplaySettingsEditor.svelte
+++ b/web/src/lib/components/collections/DisplaySettingsEditor.svelte
@@ -68,6 +68,10 @@
 					<option value={f.key}>{f.label}</option>
 				{/each}
 			</select>
+			<p class="setting-hint">
+				Also determines which field's terminal options drive "done" in
+				dashboards, progress bars, and changelog.
+			</p>
 		</div>
 
 		<div class="setting-item">
@@ -110,6 +114,13 @@
 		font-weight: 600;
 		text-transform: uppercase;
 		letter-spacing: 0.05em;
+		color: var(--text-muted);
+	}
+
+	.setting-hint {
+		margin: var(--space-1) 0 0;
+		font-size: 0.72em;
+		line-height: 1.4;
 		color: var(--text-muted);
 	}
 

--- a/web/src/lib/components/collections/EditCollectionModal.svelte
+++ b/web/src/lib/components/collections/EditCollectionModal.svelte
@@ -103,6 +103,20 @@
 	let listGroupBy = $state('');
 	let listSortBy = $state('');
 
+	// Which field drives backend done-detection for this collection.
+	// Mirrors the DoneFieldKey() resolution in internal/models/terminal.go —
+	// honors boardGroupBy when it points at an existing select/multi_select
+	// field, otherwise falls back to 'status'. Used by FieldEditor to
+	// render the Active/Saved pill on each terminal-options column.
+	const activeDoneField = $derived.by(() => {
+		const candidate = (boardGroupBy || '').trim();
+		if (!candidate) return 'status';
+		const matches = existingFields.some(
+			(f) => f.key === candidate && (f.type === 'select' || f.type === 'multi_select')
+		);
+		return matches ? candidate : 'status';
+	});
+
 	// ── Quick actions state ─────────────────────────────────────────────────
 	// Shape comes from QuickActionsEditor; the editor component owns the
 	// per-card add/remove/reorder logic.
@@ -629,6 +643,7 @@
 										index={i}
 										total={existingFields.length}
 										collections={collectionOptions}
+										{activeDoneField}
 										onmoveup={() => moveField(i, -1)}
 										onmovedown={() => moveField(i, 1)}
 										onremove={() => removeExistingField(i)}
@@ -642,6 +657,7 @@
 										isNew
 										keyError={newKeyErrors[i]}
 										collections={collectionOptions}
+										{activeDoneField}
 										onmoveup={() => moveNewField(i, -1)}
 										onmovedown={() => moveNewField(i, 1)}
 										onremove={() => removeNewField(i)}

--- a/web/src/lib/components/collections/EditCollectionModal.svelte
+++ b/web/src/lib/components/collections/EditCollectionModal.svelte
@@ -104,16 +104,14 @@
 	let listSortBy = $state('');
 
 	// Which field drives backend done-detection for this collection.
-	// Mirrors the DoneFieldKey() resolution in internal/models/terminal.go —
-	// honors boardGroupBy when it points at an existing select/multi_select
-	// field, otherwise falls back to 'status'. Used by FieldEditor to
-	// render the Active/Saved pill on each terminal-options column.
+	// Mirrors the DoneFieldKey() resolution in internal/models/terminal.go:
+	// only `select` fields qualify (not multi_select — the Go + SQL paths
+	// only handle scalar string matching). Falls back to 'status' when the
+	// board_group_by doesn't name a qualifying select field.
 	const activeDoneField = $derived.by(() => {
 		const candidate = (boardGroupBy || '').trim();
 		if (!candidate) return 'status';
-		const matches = existingFields.some(
-			(f) => f.key === candidate && (f.type === 'select' || f.type === 'multi_select')
-		);
+		const matches = existingFields.some((f) => f.key === candidate && f.type === 'select');
 		return matches ? candidate : 'status';
 	});
 

--- a/web/src/lib/components/collections/EditCollectionModal.svelte
+++ b/web/src/lib/components/collections/EditCollectionModal.svelte
@@ -8,6 +8,7 @@
 		blankField,
 		coerceDefault,
 		defaultsEqual,
+		isSafeDoneFieldKey,
 		typeSupportsDefault,
 		validateFieldKey,
 		type EditableField
@@ -105,12 +106,14 @@
 
 	// Which field drives backend done-detection for this collection.
 	// Mirrors the DoneFieldKey() resolution in internal/models/terminal.go:
-	// only `select` fields qualify (not multi_select — the Go + SQL paths
-	// only handle scalar string matching). Falls back to 'status' when the
-	// board_group_by doesn't name a qualifying select field.
+	// - only `select` fields qualify (not multi_select — both paths only
+	//   handle scalar string matching)
+	// - the key must match the backend's safe-key pattern or the server
+	//   falls back to "status"; we apply the same check here so the UI
+	//   can't show an "Active" pill on a field the server will reject.
 	const activeDoneField = $derived.by(() => {
 		const candidate = (boardGroupBy || '').trim();
-		if (!candidate) return 'status';
+		if (!candidate || !isSafeDoneFieldKey(candidate)) return 'status';
 		const matches = existingFields.some((f) => f.key === candidate && f.type === 'select');
 		return matches ? candidate : 'status';
 	});

--- a/web/src/lib/components/collections/FieldEditor.svelte
+++ b/web/src/lib/components/collections/FieldEditor.svelte
@@ -42,6 +42,16 @@
 		 * picker renders an empty-state hint.
 		 */
 		collections?: CollectionOption[];
+		/**
+		 * Which field key is the "done" field for the collection (TASK-604).
+		 * This comes from settings.board_group_by via the parent modal. When
+		 * this field's key matches activeDoneField, its terminal markings
+		 * actually drive backend done-detection. For every other select
+		 * field the markings are still editable (so users can pre-configure
+		 * and then switch the board's group-by to activate them) but the
+		 * column header renders as "Saved" instead of "Active".
+		 */
+		activeDoneField?: string;
 		/** Optional: parent provides a move-up handler. If omitted, the button is hidden. */
 		onmoveup?: () => void;
 		/** Optional: parent provides a move-down handler. If omitted, the button is hidden. */
@@ -57,6 +67,7 @@
 		isNew = false,
 		keyError = null,
 		collections = [],
+		activeDoneField = 'status',
 		onmoveup,
 		onmovedown,
 		onremove
@@ -67,10 +78,14 @@
 
 	// Terminal-option toggle: available on any select/multi_select field
 	// that has at least one option. Marking an option as terminal persists
-	// it on the FieldDef's terminal_options; the semantics of how the
-	// backend uses it for done-detection are currently status-centric and
-	// are being generalized in TASK-604 (cross-field done-detection).
+	// it on the FieldDef's terminal_options.
 	const showsTerminalColumn = $derived(isSelectType && field.options.length > 0);
+
+	// Which field drives done-detection for this collection (TASK-604).
+	// When this field IS the active done field, its terminal markings are
+	// live. Otherwise they're saved on the schema but dormant — a hint to
+	// the user explains what needs to change to activate them.
+	const isActiveDoneField = $derived(isSelectType && field.key === activeDoneField);
 
 	// Auto-derive the key from the label for new fields, unless the user has
 	// manually edited the key. Once `keyTouched` flips to true the user owns
@@ -290,14 +305,30 @@
 				<div class="options-col-headers">
 					<span class="options-col-label">Options</span>
 					<span
-						class="options-col-terminal"
-						title={'Mark options that mean "done" or "closed". ' +
-							'Today only the status field drives dashboard filtering, progress bars, and ' +
-							'changelog — markings on other fields are saved on the schema for API ' +
-							'consumers and future cross-field done-detection.'}
-					>Done?</span>
+						class="options-col-terminal-group"
+						title={isActiveDoneField
+							? 'Mark options that mean "done" or "closed". These values drive ' +
+								'dashboard filtering, progress bars, and changelog because this field is ' +
+								'the collection\u2019s board group-by.'
+							: 'Saved terminal markings. They don\u2019t drive aggregation right now — ' +
+								'this field isn\u2019t the collection\u2019s board group-by. Set this ' +
+								'field in the Display tab\u2019s "Board group by" to activate them.'}
+					>
+						<span class="options-col-terminal">Done?</span>
+						{#if isActiveDoneField}
+							<span class="done-pill done-pill--active">Active</span>
+						{:else}
+							<span class="done-pill done-pill--saved">Saved</span>
+						{/if}
+					</span>
 					<span class="options-col-spacer"></span>
 				</div>
+				{#if !isActiveDoneField}
+					<p class="done-field-hint">
+						Markings are saved. Switch the board group-by to
+						<code>{field.key}</code> to make them drive done-detection.
+					</p>
+				{/if}
 			{/if}
 			<div class="options-rows">
 				{#each field.options as _opt, oi (oi)}
@@ -729,6 +760,12 @@
 		color: var(--text-muted);
 	}
 
+	.options-col-terminal-group {
+		display: inline-flex;
+		align-items: center;
+		gap: var(--space-1);
+	}
+
 	.options-col-terminal {
 		width: 40px;
 		text-align: center;
@@ -737,6 +774,44 @@
 		text-transform: uppercase;
 		letter-spacing: 0.05em;
 		color: var(--text-muted);
+	}
+
+	.done-pill {
+		font-size: 0.62em;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+		padding: 1px 6px;
+		border-radius: 999px;
+		border: 1px solid transparent;
+	}
+
+	.done-pill--active {
+		color: var(--accent-green, #22c55e);
+		background: color-mix(in srgb, var(--accent-green, #22c55e) 14%, transparent);
+		border-color: color-mix(in srgb, var(--accent-green, #22c55e) 30%, transparent);
+	}
+
+	.done-pill--saved {
+		color: var(--text-muted);
+		background: color-mix(in srgb, var(--text-muted) 10%, transparent);
+	}
+
+	.done-field-hint {
+		margin: 0 0 var(--space-1);
+		font-size: 0.72em;
+		line-height: 1.4;
+		color: var(--text-muted);
+		font-style: italic;
+	}
+
+	.done-field-hint code {
+		font-family: var(--font-mono);
+		font-style: normal;
+		padding: 0 4px;
+		background: var(--bg-secondary);
+		border-radius: var(--radius-sm);
+		color: var(--text-secondary);
 	}
 
 	.options-col-spacer {

--- a/web/src/lib/components/collections/FieldEditor.svelte
+++ b/web/src/lib/components/collections/FieldEditor.svelte
@@ -85,7 +85,9 @@
 	// When this field IS the active done field, its terminal markings are
 	// live. Otherwise they're saved on the schema but dormant — a hint to
 	// the user explains what needs to change to activate them.
-	const isActiveDoneField = $derived(isSelectType && field.key === activeDoneField);
+	// Restricted to `select` (not multi_select) to match the backend
+	// DoneFieldKey() resolution rule.
+	const isActiveDoneField = $derived(field.type === 'select' && field.key === activeDoneField);
 
 	// Auto-derive the key from the label for new fields, unless the user has
 	// manually edited the key. Once `keyTouched` flips to true the user owns

--- a/web/src/lib/components/collections/field-editor-types.ts
+++ b/web/src/lib/components/collections/field-editor-types.ts
@@ -314,6 +314,26 @@ export function defaultsEqual(a: unknown, b: unknown): boolean {
 	}
 }
 
+/**
+ * Matches the backend's `safeDoneFieldKey` regex in
+ * `internal/models/terminal.go`. A done-field candidate must be an
+ * identifier-shaped string the backend will accept, or it falls back to
+ * the literal "status" there — the UI needs to mirror that or it can
+ * falsely light up an "Active" pill on a field the server has actually
+ * rejected (e.g. legacy schemas with keys like `foo.bar` or
+ * `resolution-v2`).
+ */
+const SAFE_DONE_FIELD_KEY = /^[a-zA-Z][a-zA-Z0-9_]*$/;
+
+/**
+ * Returns true if the given key would be accepted by the backend's
+ * DoneFieldKey resolver. Used by the collection modals' `activeDoneField`
+ * derivations to keep UI state in sync with persisted behavior.
+ */
+export function isSafeDoneFieldKey(key: string): boolean {
+	return SAFE_DONE_FIELD_KEY.test(key);
+}
+
 /** Create an empty EditableField for a new (unsaved) field. */
 export function blankField(): EditableField {
 	return {


### PR DESCRIPTION
## Summary
Make "is this item done?" follow the collection's `settings.board_group_by` field rather than the hardcoded `status` key. If a collection's board is grouped by `resolution`, then `resolution`'s terminal options drive dashboard counts, progress bars, changelog, and starred-items filtering.

**Closes TASK-604.**

## Why this shape

This replaces the original "cross-field OR" proposal with a simpler, explicit-intent architecture:

- **No ambiguity.** One field per collection wins. No reconciling \"status says in-progress, resolution says fixed.\"
- **One JSON path to swap.** Every `$.status` query becomes `$.<done_field>`. No dynamic OR across schema-discovered fields.
- **Matches the mental model.** The field you organize the board by is the field that represents the item's current state. The old mismatch (board grouped by X, \"done\" count from status) is a latent bug this resolves.
- **Non-breaking.** `board_group_by` defaults to nil → `DoneFieldKey` returns `\"status\"` → behavior identical to pre-TASK-604 for every existing collection.

## What's in this PR

### Model layer (`internal/models/terminal.go`)
- `DoneFieldKey(schema, settings) string` — resolves with a fallback chain (valid select on schema → that field, else `\"status\"`).
- `TerminalValuesForDoneField(schema, settings) (fieldKey, values)`
- `TerminalPlaceholdersForDoneField(schema, settings) (fieldKey, placeholders, args)` — SQL helper.
- `IsTerminalItem(fields, schema, settings) bool` — canonical Go-side membership check.
- Legacy API (`TerminalStatusesFromSchema` etc.) kept as back-compat wrappers delegating with empty settings. Callers without settings in scope keep working unchanged.

### SQL callers migrated
- `internal/store/collections.go` — `ListCollections` active-count query
- `internal/store/items.go`:
  - New `collectionDoneFilter` type + `childrenDoneFiltersFor{Parent,Collection}` + `doneFiltersForWorkspace` helpers
  - `buildChildrenDoneExpr(filters, alias)` compiles filters into a per-collection OR clause: `((alias.collection_id=? AND LOWER(...) IN (...)) OR (alias.collection_id=? AND LOWER(...) IN (...)))`
  - `GetItemProgress` + `GetAllItemProgress` now evaluate each child against its own collection's done rules
- `internal/store/agent_roles.go` — role-count query + Go-side filter
- `internal/store/item_stars.go` — starred-items filtering via `collectionDoneContext` map

### Go-side callers migrated
- `internal/server/handlers_dashboard.go` — `buildSchemaMap` → `buildDoneContextMap`, `isItemTerminal` → `isItemDone`. All 7 call sites updated.
- `internal/server/handlers_items.go` — plan-progress recompute + per-item `/progress` endpoint

### Left status-specific (per task scope)
- Link-payload `$.status` extracts (`getItemLink`, `GetItemLinks`, `GetParentForItem`) — these populate `link.SourceStatus`/`TargetStatus`, which are status-specific by design.
- `cmd/pad` reconcile paths — no schema in scope, default-list fallback is the right call.
- Search facet `status` breakdown — a different UX concept (bucket search results by status values) than done-detection.

### Web UI reactivity
- `FieldEditor.svelte` gains an `activeDoneField` prop. Each modal derives it from `boardGroupBy` using the same fallback rule as the Go `DoneFieldKey`.
- Fields tab: each select field's \"Done?\" column header now renders:
  - **Active** (green pill) when this field is the board group-by
  - **Saved** (muted pill) + inline hint (*\"Switch the board group-by to `<key>` to make them drive done-detection.\"*) otherwise
- Reactive: switching `boardGroupBy` in the Display tab updates every FieldEditor's pill instantly.

### Display tab copy tweak
Under \"Board group by\" there's now a helper line: *\"Also determines which field's terminal options drive 'done' in dashboards, progress bars, and changelog.\"*

## Test plan

### Automated
- [x] `internal/models/terminal_test.go` — 13 new unit tests (done-field resolution, fallback, placeholders, membership, case-insensitivity, back-compat shim)
- [x] `internal/store/done_field_test.go` — 3 new integration tests:
  1. **Bugs collection grouped by `resolution`** with terminals `[fixed, wontfix]` → items with those resolution values count as done. Crucially, an item with `resolution=open` but `status=fixed` does NOT count as done (proves status isn't consulted when it isn't the done field).
  2. **Back-compat**: collection without `board_group_by` still uses `status` terminals.
  3. **Mixed-collection children**: each child evaluated against its own done rules.
- [x] `go build ./...` / `go test ./...` — clean
- [x] `cd web && npm run build` — clean

### Manual
- [x] Real bugs collection with resolution-driven done-detection; progress bar + dashboard counts reflect resolution terminals
- [x] Regression: Tasks collection (default status-driven) still works
- [x] Active/Saved pill reactivity when toggling board_group_by in Display tab
- [x] `pad project dashboard --format json` matches web UI counts

## Acceptance checkpoints (from the task)
- ✅ Bugs collection with `board_group_by: resolution` → items with resolution=fixed/wontfix count as done in dashboards, progress, starred
- ✅ Switching `board_group_by` between fields retains every field's terminal markings — no reconfiguration needed (TASK-597 already persists terminals on any select field; this PR only changes which one is *active*)
- ✅ Fields tab visually shows the active done field; others show Saved + hint
- ✅ Collections without explicit `board_group_by` behave identically to today (compat shims + default fallback)