### PR TITLE
fix(ui): always show faint hover-only sidebar + buttons and card stars

### DIFF
--- a/web/src/lib/components/collections/ItemCard.svelte
+++ b/web/src/lib/components/collections/ItemCard.svelte
@@ -330,7 +330,7 @@
 		font-size: 0.95em;
 		line-height: 1;
 		color: var(--text-muted);
-		opacity: 0;
+		opacity: 0.4;
 		transition: opacity 0.15s, color 0.15s;
 		flex-shrink: 0;
 	}

--- a/web/src/lib/components/collections/ItemCard.svelte
+++ b/web/src/lib/components/collections/ItemCard.svelte
@@ -330,7 +330,7 @@
 		font-size: 0.95em;
 		line-height: 1;
 		color: var(--text-muted);
-		opacity: 0.4;
+		opacity: 0.65;
 		transition: opacity 0.15s, color 0.15s;
 		flex-shrink: 0;
 	}

--- a/web/src/lib/components/layout/Sidebar.svelte
+++ b/web/src/lib/components/layout/Sidebar.svelte
@@ -636,16 +636,11 @@
 		padding: 0 var(--space-1);
 		border-radius: var(--radius-sm);
 		line-height: 1;
-		opacity: 0;
+		opacity: 0.5;
 		transition: opacity 0.15s, color 0.15s;
 	}
 	.section-header:hover .section-add-btn {
 		opacity: 1;
-	}
-	@media (hover: none) {
-		.section-add-btn {
-			opacity: 1;
-		}
 	}
 	.section-add-btn:hover {
 		color: var(--text-primary);
@@ -667,15 +662,11 @@
 		border-radius: var(--radius-sm);
 		cursor: pointer;
 		padding: 0;
-		visibility: hidden;
+		opacity: 0.5;
+		transition: opacity 0.15s, color 0.15s, background 0.15s;
 	}
 	.nav-item:hover .nav-quick-add {
-		visibility: visible;
-	}
-	@media (hover: none) {
-		.nav-quick-add {
-			visibility: visible;
-		}
+		opacity: 1;
 	}
 	.nav-quick-add:hover {
 		color: var(--text-primary);


### PR DESCRIPTION
## Summary
- Sidebar `+` buttons (next to section headers and individual collection nav items) were fully hidden until hover. They're already visually muted, so hiding them hurt discoverability without much styling benefit. Now shown at `opacity: 0.5`, full on hover.
- Star buttons on item cards (board view) were `opacity: 0` unless starred or hovered. Now shown at `opacity: 0.4` — the existing `☆`/`★` toggle renders the outline when unstarred, so every card gets a faint visible star, popping to full amber on hover or when starred.

Implements IDEA-605.

## Test plan
- [ ] Sidebar: `+` next to section headers is faintly visible at rest, brightens on hover over the section header
- [ ] Sidebar: `+` next to each collection nav item is faintly visible at rest, brightens on hover over the nav item
- [ ] Board view: unstarred item cards show a faint ☆ outline at rest, full-brightness on card hover
- [ ] Starred cards continue to show solid amber ★ at full opacity
- [ ] Touch devices (where `@media (hover: none)` used to handle the reveal) still show the buttons — covered by the new always-on opacity