### PR TITLE
feat(templates): ship interviewing template (TASK-615)

### DIFF
--- a/internal/collections/templates.go
+++ b/internal/collections/templates.go
@@ -570,6 +570,7 @@ var templates = []WorkspaceTemplate{
 		Playbooks:   SoftwareStarterPlaybooks(),
 	},
 	hiringTemplate(),
+	interviewingTemplate(),
 	{
 		Name:        "demo",
 		Category:    CategorySoftware,

--- a/internal/collections/templates_interviewing.go
+++ b/internal/collections/templates_interviewing.go
@@ -270,7 +270,7 @@ func interviewingStarterPlaybooks() []SeedPlaybook {
 2. Update prep_status to "completed".
 3. Add a comment on the Interview with: how you felt it went, questions they asked, questions you asked, red/green flags, follow-up items.
 4. Update the Application's stage if this interview advanced or ended the process.
-5. Create a follow-up Task for the thank-you note (due within 24h).
+5. Send a thank-you to each interviewer within 24h. Log it as a comment on the Interview item and update the matching Contact's last_contact field to today's date.
 6. If you took away useful lessons (a question pattern, a company-specific insight), note it on the Company item so future applications there benefit.
 
 💡 Ask your AI agent to customize this playbook for your job-search workflow.`,

--- a/internal/collections/templates_interviewing.go
+++ b/internal/collections/templates_interviewing.go
@@ -164,11 +164,12 @@ func interviewingCompaniesCollection(sortOrder int) DefaultCollection {
 		Schema: models.CollectionSchema{
 			Fields: []models.FieldDef{
 				{
-					Key:     "status",
-					Label:   "Status",
-					Type:    "select",
-					Options: []string{"interested", "researching", "active", "closed"},
-					Default: "interested",
+					Key:             "status",
+					Label:           "Status",
+					Type:            "select",
+					Options:         []string{"interested", "researching", "active", "closed"},
+					TerminalOptions: []string{"closed"},
+					Default:         "interested",
 				},
 				{
 					Key:   "industry",

--- a/internal/collections/templates_interviewing.go
+++ b/internal/collections/templates_interviewing.go
@@ -1,0 +1,323 @@
+package collections
+
+import "github.com/xarmian/pad/internal/models"
+
+// Trigger + scope vocabularies used by the interviewing (candidate-side)
+// workspace's Conventions and Playbooks collections. Different enough
+// from the hiring (company-side) template that both warrant their own
+// vocabulary, even though they share the People category.
+var (
+	InterviewingConventionTriggers = []string{"always", "on-application-submitted", "on-interview-scheduled", "on-interview-completed", "on-stage-change", "on-offer-received", "on-rejection", "weekly-review"}
+	InterviewingConventionScopes   = []string{"all", "research", "applications", "interviews", "followups"}
+	InterviewingPlaybookTriggers   = []string{"on-application-submitted", "on-interview-scheduled", "on-interview-completed", "on-stage-change", "weekly-review", "manual"}
+	InterviewingPlaybookScopes     = []string{"all", "research", "applications", "interviews", "followups"}
+)
+
+// interviewingTemplate builds the "interviewing" workspace template.
+// Candidate-side job search: track Applications, Interviews per
+// application, plus sibling collections for Companies you're researching
+// and Contacts (referrals, recruiters, interviewers) referenced via
+// wiki-links rather than parent/child.
+func interviewingTemplate() WorkspaceTemplate {
+	return WorkspaceTemplate{
+		Name:        "interviewing",
+		Category:    CategoryPeople,
+		Description: "Applications, Interviews, Companies, Contacts, Docs",
+		Icon:        "\U0001F4E8", // 📨
+		Collections: []DefaultCollection{
+			interviewingApplicationsCollection(0),
+			interviewingInterviewsCollection(1),
+			interviewingCompaniesCollection(2),
+			interviewingContactsCollection(3),
+			docsCollection(4),
+			conventionsCollection(5, InterviewingConventionTriggers, InterviewingConventionScopes),
+			playbooksCollection(6, InterviewingPlaybookTriggers, InterviewingPlaybookScopes),
+		},
+		Conventions: interviewingStarterConventions(),
+		Playbooks:   interviewingStarterPlaybooks(),
+		SeedItems:   interviewingSeedItems(),
+	}
+}
+
+func interviewingApplicationsCollection(sortOrder int) DefaultCollection {
+	return DefaultCollection{
+		Name:        "Applications",
+		Slug:        "applications",
+		Prefix:      "APP",
+		Icon:        "\U0001F4E8", // 📨
+		Description: "Roles you're applying to or actively interviewing for",
+		SortOrder:   sortOrder,
+		Schema: models.CollectionSchema{
+			Fields: []models.FieldDef{
+				{
+					Key:             "stage",
+					Label:           "Stage",
+					Type:            "select",
+					Options:         []string{"researching", "applied", "screen", "interviewing", "offer", "accepted", "rejected", "withdrawn"},
+					TerminalOptions: []string{"accepted", "rejected", "withdrawn"},
+					Default:         "researching",
+					Required:        true,
+				},
+				{
+					Key:   "company",
+					Label: "Company",
+					Type:  "text",
+				},
+				{
+					Key:   "role",
+					Label: "Role",
+					Type:  "text",
+				},
+				{
+					Key:     "source",
+					Label:   "Source",
+					Type:    "select",
+					Options: []string{"referral", "recruiter", "cold", "job-board", "network", "other"},
+				},
+				{
+					Key:   "salary_range",
+					Label: "Salary Range",
+					Type:  "text",
+				},
+				{
+					Key:     "remote",
+					Label:   "Remote",
+					Type:    "select",
+					Options: []string{"yes", "hybrid", "no"},
+				},
+				{
+					Key:   "applied_date",
+					Label: "Applied Date",
+					Type:  "date",
+				},
+			},
+		},
+		Settings: models.CollectionSettings{
+			Layout:       "balanced",
+			DefaultView:  "board",
+			BoardGroupBy: "stage",
+			ListSortBy:   "updated_at",
+		},
+	}
+}
+
+func interviewingInterviewsCollection(sortOrder int) DefaultCollection {
+	return DefaultCollection{
+		Name:        "Interviews",
+		Slug:        "interviews",
+		Prefix:      "INT",
+		Icon:        "\U0001F5E3\uFE0F", // 🗣️
+		Description: "Individual interview rounds, linked to an Application",
+		SortOrder:   sortOrder,
+		Schema: models.CollectionSchema{
+			Fields: []models.FieldDef{
+				{
+					Key:     "round",
+					Label:   "Round",
+					Type:    "select",
+					Options: []string{"screen", "technical", "behavioral", "onsite", "final"},
+				},
+				{
+					Key:   "date",
+					Label: "Date",
+					Type:  "date",
+				},
+				{
+					Key:   "interviewer",
+					Label: "Interviewer",
+					Type:  "text",
+				},
+				{
+					Key:     "format",
+					Label:   "Format",
+					Type:    "select",
+					Options: []string{"phone", "video", "onsite", "take-home"},
+				},
+				{
+					Key:             "prep_status",
+					Label:           "Prep Status",
+					Type:            "select",
+					Options:         []string{"not-started", "in-progress", "ready", "completed"},
+					TerminalOptions: []string{"completed"},
+					Default:         "not-started",
+					Required:        true,
+				},
+			},
+		},
+		Settings: models.CollectionSettings{
+			Layout:       "balanced",
+			DefaultView:  "list",
+			ListSortBy:   "date",
+			BoardGroupBy: "prep_status",
+		},
+	}
+}
+
+func interviewingCompaniesCollection(sortOrder int) DefaultCollection {
+	return DefaultCollection{
+		Name:        "Companies",
+		Slug:        "companies",
+		Prefix:      "CO",
+		Icon:        "\U0001F3E2", // 🏢
+		Description: "Companies you're researching or interviewing with",
+		SortOrder:   sortOrder,
+		Schema: models.CollectionSchema{
+			Fields: []models.FieldDef{
+				{
+					Key:     "status",
+					Label:   "Status",
+					Type:    "select",
+					Options: []string{"interested", "researching", "active", "closed"},
+					Default: "interested",
+				},
+				{
+					Key:   "industry",
+					Label: "Industry",
+					Type:  "text",
+				},
+				{
+					Key:     "size",
+					Label:   "Size",
+					Type:    "select",
+					Options: []string{"startup", "small", "medium", "large", "enterprise"},
+				},
+				{
+					Key:   "glassdoor_rating",
+					Label: "Glassdoor Rating",
+					Type:  "number",
+				},
+			},
+		},
+		Settings: models.CollectionSettings{
+			Layout:      "balanced",
+			DefaultView: "list",
+			ListSortBy:  "updated_at",
+		},
+	}
+}
+
+func interviewingContactsCollection(sortOrder int) DefaultCollection {
+	return DefaultCollection{
+		Name:        "Contacts",
+		Slug:        "contacts",
+		Prefix:      "CON",
+		Icon:        "\U0001F465", // 👥
+		Description: "People you've interacted with — referrals, recruiters, interviewers",
+		SortOrder:   sortOrder,
+		Schema: models.CollectionSchema{
+			Fields: []models.FieldDef{
+				{
+					Key:     "relationship",
+					Label:   "Relationship",
+					Type:    "select",
+					Options: []string{"referral", "recruiter", "interviewer", "network", "other"},
+				},
+				{
+					Key:   "company",
+					Label: "Company",
+					Type:  "text",
+				},
+				{
+					Key:   "role",
+					Label: "Role",
+					Type:  "text",
+				},
+				{
+					Key:   "last_contact",
+					Label: "Last Contact",
+					Type:  "date",
+				},
+			},
+		},
+		Settings: models.CollectionSettings{
+			Layout:      "balanced",
+			DefaultView: "list",
+			ListSortBy:  "last_contact",
+		},
+	}
+}
+
+// interviewingStarterConventions is the curated convention seed pack for
+// candidate-side job-search workspaces.
+func interviewingStarterConventions() []SeedConvention {
+	return []SeedConvention{
+		{
+			Title:   "Create prep notes 48 hours before each interview",
+			Content: "When an Interview is scheduled, create a Doc (or detailed content on the Interview item) with: the role and company context, expected questions for this round, STAR stories you'll use, and questions you'll ask them. Target 48 hours before the scheduled time so you have buffer to refine.",
+			Fields:  `{"status":"active","trigger":"on-interview-scheduled","scope":"interviews","priority":"should"}`,
+		},
+		{
+			Title:   "Log lessons when an Application ends (rejected or withdrawn)",
+			Content: "When an Application hits a terminal stage (rejected, withdrawn), add a final comment summarizing what you learned — fit signals, question types that surprised you, rapport observations. Over the search this builds a personal retro that sharpens the next pass.",
+			Fields:  `{"status":"active","trigger":"on-stage-change","scope":"applications","priority":"should"}`,
+		},
+		{
+			Title:   "Send a thank-you within 24 hours of every interview",
+			Content: "After each Interview Round completes, send a brief thank-you email to each interviewer within 24 hours. Reference something specific from the conversation. Log it on the Interview item (or a follow-up Task) so you can see at a glance who still needs one.",
+			Fields:  `{"status":"active","trigger":"on-interview-completed","scope":"followups","priority":"should"}`,
+		},
+	}
+}
+
+// interviewingStarterPlaybooks is the curated playbook seed pack for the
+// interviewing template.
+func interviewingStarterPlaybooks() []SeedPlaybook {
+	return []SeedPlaybook{
+		{
+			Title: "Log an Interview",
+			Content: `1. Find the Interview item (or create it as a child of the Application if you haven't already).
+2. Update prep_status to "completed".
+3. Add a comment on the Interview with: how you felt it went, questions they asked, questions you asked, red/green flags, follow-up items.
+4. Update the Application's stage if this interview advanced or ended the process.
+5. Create a follow-up Task for the thank-you note (due within 24h).
+6. If you took away useful lessons (a question pattern, a company-specific insight), note it on the Company item so future applications there benefit.
+
+💡 Ask your AI agent to customize this playbook for your job-search workflow.`,
+			Fields: `{"status":"active","trigger":"on-interview-completed","scope":"interviews"}`,
+		},
+		{
+			Title: "Weekly Job Search Review",
+			Content: `1. List active Applications grouped by stage — where's the funnel thin? where's it thick?
+2. Flag stalled Applications — anything without a stage-change or comment in the last 10 days. Decide: follow up, give up, or wait.
+3. Review upcoming Interviews for the next 7 days — does each one have prep notes? Is any underprepared?
+4. Review recent rejections and withdrawals — pull out lessons and capture them on the relevant Company or as Docs.
+5. Look at your Contacts — is there anyone you owe a reply or update to? Any referral opportunities to pursue?
+6. Update the pipeline: add new companies to research, close dead leads, prioritize top interests.
+7. Set a couple of concrete goals for the next week (applications submitted, interviews scheduled, thank-yous sent).
+
+💡 Ask your AI agent to customize this playbook for your job-search rhythm.`,
+			Fields: `{"status":"active","trigger":"weekly-review","scope":"all"}`,
+		},
+		{
+			Title: "Interviewing Workspace Onboarding",
+			Content: `1. Ask the user what roles they're targeting — capture those as starter Applications (with stage="researching" if they haven't applied yet).
+2. For each Application, capture the Company — create a Company item if it doesn't exist, or link by wiki-link from the Application content: [[Acme Corp]].
+3. For active Applications with scheduled interviews, add Interview items with dates and prep_status.
+4. Capture any Contacts the user wants to track — referrals, recruiters, networking connections.
+5. Review the workspace's seeded conventions (prep lead time, retros on rejections, 24h thank-yous) and confirm they fit the user's style.
+6. Suggest an initial Doc for their resume/cover-letter templates, or their STAR-story bank.
+7. Suggest agent roles — Researcher, Applier, Interviewer prep — if roles don't already exist.
+
+💡 Ask your AI agent to customize this onboarding for your own search workflow.`,
+			Fields: `{"status":"active","trigger":"manual","scope":"all"}`,
+		},
+	}
+}
+
+// interviewingSeedItems seeds one example in each core collection.
+func interviewingSeedItems() []SeedItem {
+	return []SeedItem{
+		{
+			CollectionSlug: "applications",
+			Title:          "Example Application: Senior Engineer at Acme Corp",
+			Content:        "This is a seeded example. Delete or overwrite once your first real application lands.\n\nLink Company via wiki-link: [[Example Company: Acme Corp]]. Add Interview items as children when rounds are scheduled.",
+			Fields:         `{"stage":"applied","company":"Acme Corp","role":"Senior Engineer","source":"referral","remote":"hybrid","applied_date":"2026-04-01"}`,
+		},
+		{
+			CollectionSlug: "companies",
+			Title:          "Example Company: Acme Corp",
+			Content:        "This is a seeded example. Delete or overwrite once your first real company lands.\n\nUse this item to capture research notes about a company — culture, stack, team structure, interview process — that you want available regardless of how many roles you apply to there.",
+			Fields:         `{"status":"interested","industry":"Software","size":"medium","glassdoor_rating":4.1}`,
+		},
+	}
+}

--- a/internal/collections/templates_test.go
+++ b/internal/collections/templates_test.go
@@ -279,6 +279,88 @@ func TestHiringTemplate(t *testing.T) {
 	}
 }
 
+// TestInterviewingTemplate verifies the interviewing (candidate-side)
+// template ships the expected collections, conventions, and playbooks with
+// the interviewing trigger vocabulary — distinct from hiring's.
+func TestInterviewingTemplate(t *testing.T) {
+	tmpl := GetTemplate("interviewing")
+	if tmpl == nil {
+		t.Fatal("interviewing template missing")
+	}
+	if tmpl.Category != CategoryPeople {
+		t.Errorf("interviewing category = %q, want %q", tmpl.Category, CategoryPeople)
+	}
+	if tmpl.Icon == "" {
+		t.Error("interviewing template has empty Icon")
+	}
+	if tmpl.Hidden {
+		t.Error("interviewing template should not be Hidden")
+	}
+
+	required := []string{"applications", "interviews", "companies", "contacts", "docs", "conventions", "playbooks"}
+	got := make(map[string]bool, len(tmpl.Collections))
+	for _, c := range tmpl.Collections {
+		got[c.Slug] = true
+	}
+	for _, slug := range required {
+		if !got[slug] {
+			t.Errorf("interviewing template missing collection %q", slug)
+		}
+	}
+
+	var conv, play *DefaultCollection
+	for i, c := range tmpl.Collections {
+		if c.Slug == "conventions" {
+			conv = &tmpl.Collections[i]
+		}
+		if c.Slug == "playbooks" {
+			play = &tmpl.Collections[i]
+		}
+	}
+	if conv == nil || play == nil {
+		t.Fatal("conventions and/or playbooks collection missing from interviewing template")
+	}
+
+	// Interviewing-specific triggers are present; software and hiring
+	// triggers are not present (they belong to different workspace types).
+	mustContain := func(name string, triggers []string, wanted string) {
+		for _, tr := range triggers {
+			if tr == wanted {
+				return
+			}
+		}
+		t.Errorf("interviewing %s triggers %v do not contain %q", name, triggers, wanted)
+	}
+	mustNotContain := func(name string, triggers []string, unwanted string) {
+		for _, tr := range triggers {
+			if tr == unwanted {
+				t.Errorf("interviewing %s triggers %v leaked foreign trigger %q", name, triggers, unwanted)
+				return
+			}
+		}
+	}
+	convTriggers := findFieldOptions(*conv, "trigger")
+	playTriggers := findFieldOptions(*play, "trigger")
+	mustContain("convention", convTriggers, "on-interview-scheduled")
+	mustContain("convention", convTriggers, "weekly-review")
+	mustNotContain("convention", convTriggers, "on-commit")
+	mustNotContain("convention", convTriggers, "on-candidate-advance") // hiring trigger
+	mustContain("playbook", playTriggers, "on-interview-completed")
+	mustContain("playbook", playTriggers, "weekly-review")
+	mustNotContain("playbook", playTriggers, "on-implement")
+
+	// Ships a non-empty starter pack
+	if len(tmpl.Conventions) == 0 {
+		t.Error("interviewing template ships no starter conventions")
+	}
+	if len(tmpl.Playbooks) == 0 {
+		t.Error("interviewing template ships no starter playbooks")
+	}
+	if len(tmpl.SeedItems) == 0 {
+		t.Error("interviewing template ships no seed items")
+	}
+}
+
 // TestSoftwareTemplatesUseSoftwareOptions verifies the startup/scrum/product
 // templates continue to ship the established software trigger vocabulary. If
 // these lists ever diverge, non-software templates are free to differ, but

--- a/internal/store/items_test.go
+++ b/internal/store/items_test.go
@@ -342,6 +342,58 @@ func TestSeedCollectionsFromTemplateHiring(t *testing.T) {
 	}
 }
 
+// TestSeedCollectionsFromTemplateInterviewing verifies end-to-end that the
+// interviewing template creates its collections and seeds the starter pack.
+func TestSeedCollectionsFromTemplateInterviewing(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Interviewing")
+
+	if err := s.SeedCollectionsFromTemplate(ws.ID, "interviewing"); err != nil {
+		t.Fatalf("seed interviewing template: %v", err)
+	}
+
+	for _, slug := range []string{"applications", "interviews", "companies", "contacts", "docs", "conventions", "playbooks"} {
+		coll, err := s.GetCollectionBySlug(ws.ID, slug)
+		if err != nil || coll == nil {
+			t.Errorf("interviewing workspace missing collection %q (err=%v)", slug, err)
+		}
+	}
+
+	convs, _ := s.ListItems(ws.ID, models.ItemListParams{CollectionSlug: "conventions"})
+	if len(convs) == 0 {
+		t.Error("expected interviewing starter conventions to be seeded, got 0")
+	}
+	plays, _ := s.ListItems(ws.ID, models.ItemListParams{CollectionSlug: "playbooks"})
+	if len(plays) == 0 {
+		t.Error("expected interviewing starter playbooks to be seeded, got 0")
+	}
+
+	apps, _ := s.ListItems(ws.ID, models.ItemListParams{CollectionSlug: "applications"})
+	if len(apps) == 0 {
+		t.Error("expected interviewing seed Application, got 0")
+	}
+	cos, _ := s.ListItems(ws.ID, models.ItemListParams{CollectionSlug: "companies"})
+	if len(cos) == 0 {
+		t.Error("expected interviewing seed Company, got 0")
+	}
+
+	// Explicit prefixes
+	for slug, want := range map[string]string{
+		"applications": "APP",
+		"interviews":   "INT",
+		"companies":    "CO",
+		"contacts":     "CON",
+	} {
+		coll, err := s.GetCollectionBySlug(ws.ID, slug)
+		if err != nil || coll == nil {
+			continue
+		}
+		if coll.Prefix != want {
+			t.Errorf("collection %q prefix = %q, want %q", slug, coll.Prefix, want)
+		}
+	}
+}
+
 // TestSeedCollectionsFromTemplateRecoversPartialInit verifies that a retry
 // after a partial seed (some items missing) fills in the missing items
 // rather than treating the workspace as already-seeded. This guards the


### PR DESCRIPTION
## Summary

Candidate-side companion to the hiring template shipped in TASK-614 / PR #146. Same People category, near-zero collection overlap — strong proof that one category can hold two templates with barely-related schemas.

### Collections

- **Applications** (APP) — roles being tracked; stages researching → applied → screen → interviewing → offer → accepted/rejected/withdrawn
- **Interviews** (INT) — individual rounds, child of an Application, with round/format/date/prep_status
- **Companies** (CO) — standalone research notes; referenced from Applications via wiki-link so notes persist even across multiple Applications at the same company
- **Contacts** (CON) — referrals, recruiters, interviewers; tracked independently for followup hygiene
- **Docs** + **Conventions** + **Playbooks**

### Trigger vocabularies

Distinct from software AND hiring:
- Convention triggers: \`always, on-application-submitted, on-interview-scheduled, on-interview-completed, on-stage-change, on-offer-received, on-rejection, weekly-review\`
- Playbook triggers: \`on-application-submitted, on-interview-scheduled, on-interview-completed, on-stage-change, weekly-review, manual\`
- Scopes: \`all, research, applications, interviews, followups\`

### Starter pack

- **Conventions (3):** 48h prep notes, end-of-application retros, 24h thank-yous
- **Playbooks (3):** \"Log an Interview\", \"Weekly Job Search Review\", \"Interviewing Workspace Onboarding\"
- **Seed items (2):** one example Application, one example Company

### Design notes from the TASK-614 review loop applied proactively

- **Explicit prefixes** (APP/INT/CO/CON) — avoids the DerivePrefix \"APPLI/INTER/COMPA/CONTA\" pitfall.
- **BoardGroupBy chosen for done-state accuracy** — Interviews group by prep_status (terminal=completed), not round. Applications group by stage (has terminal states).
- **Playbook instructions** use only valid field values (prep_status=completed, stage=... from the defined options).

## Context

Implements \`TASK-615\` under \`PLAN-609\`.

## Test plan

- [x] \`go build ./...\` — clean
- [x] \`go vet ./...\` — clean
- [x] \`go test ./internal/collections/... ./internal/store/...\` — all tests pass
- [x] New tests:
  - \`TestInterviewingTemplate\` — collections present, interviewing triggers present, software AND hiring triggers absent
  - \`TestSeedCollectionsFromTemplateInterviewing\` — end-to-end: seven collections, starter pack populated, prefixes correct
- [x] Smoke: \`pad workspace init --list-templates\` — now lists startup/scrum/product/hiring/interviewing