### PR TITLE
feat(cli): categorized template picker + interactive select (TASK-616)

### DIFF
--- a/cmd/pad/init.go
+++ b/cmd/pad/init.go
@@ -48,15 +48,9 @@ Examples:
 				tmpl := collections.GetTemplate(templateFlag)
 				if tmpl == nil {
 					fmt.Fprintf(os.Stderr, "Unknown template: %s\n\n", templateFlag)
-					tmpls := collections.ListTemplates()
 					fmt.Fprintln(os.Stderr, "Available templates:")
-					for _, t := range tmpls {
-						def := ""
-						if t.Name == "startup" {
-							def = " (default)"
-						}
-						fmt.Fprintf(os.Stderr, "  %-10s %s%s\n", t.Name, t.Description, def)
-					}
+					fmt.Fprintln(os.Stderr)
+					printGroupedTemplates(os.Stderr)
 					return fmt.Errorf("unknown template %q", templateFlag)
 				}
 			}
@@ -208,7 +202,7 @@ Examples:
 		},
 	}
 
-	cmd.Flags().StringVar(&templateFlag, "template", "", "workspace template (startup, scrum, product)")
+	cmd.Flags().StringVar(&templateFlag, "template", "", "workspace template (omit for interactive picker; run 'pad workspace init --list-templates' to see all)")
 	return cmd
 }
 
@@ -255,13 +249,24 @@ func ensureWorkspace(client *cli.Client, cfg *config.Config, cwd, name, template
 		return ws, false, nil
 	}
 
-	// Create new workspace. Default to the "startup" template when the caller
-	// didn't pass --template so the new workspace gets the curated starter
-	// pack (conventions + playbooks). Tests and other API callers that want
-	// an empty workspace can still POST with Template="" directly.
+	// Create new workspace. When the caller didn't pass --template:
+	//   - If stdin/stdout are TTYs, prompt interactively with the grouped
+	//     template picker.
+	//   - Otherwise fall back to the "startup" default so scripts and
+	//     non-interactive runs get the curated starter pack.
+	// Tests and other API callers that want an empty workspace can still
+	// POST with Template="" directly.
 	effectiveTemplate := templateFlag
 	if effectiveTemplate == "" {
-		effectiveTemplate = "startup"
+		if canPromptForTemplate() {
+			picked, perr := pickTemplateInteractive(os.Stdin, os.Stdout)
+			if perr != nil {
+				return nil, false, perr
+			}
+			effectiveTemplate = picked
+		} else {
+			effectiveTemplate = defaultTemplateName
+		}
 	}
 	ws, err = client.CreateWorkspace(models.WorkspaceCreate{
 		Name:     name,

--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -998,15 +998,9 @@ a workspace in one step.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Handle --list-templates
 			if listTemplates {
-				tmpls := collections.ListTemplates()
 				fmt.Println("Available templates:")
-				for _, t := range tmpls {
-					def := ""
-					if t.Name == "startup" {
-						def = " (default)"
-					}
-					fmt.Printf("  %-10s %s%s\n", t.Name, t.Description, def)
-				}
+				fmt.Println()
+				printGroupedTemplates(os.Stdout)
 				return nil
 			}
 
@@ -1015,15 +1009,9 @@ a workspace in one step.`,
 				tmpl := collections.GetTemplate(templateFlag)
 				if tmpl == nil {
 					fmt.Fprintf(os.Stderr, "Unknown template: %s\n\n", templateFlag)
-					tmpls := collections.ListTemplates()
 					fmt.Fprintln(os.Stderr, "Available templates:")
-					for _, t := range tmpls {
-						def := ""
-						if t.Name == "startup" {
-							def = " (default)"
-						}
-						fmt.Fprintf(os.Stderr, "  %-10s %s%s\n", t.Name, t.Description, def)
-					}
+					fmt.Fprintln(os.Stderr)
+					printGroupedTemplates(os.Stderr)
 					return fmt.Errorf("unknown template %q", templateFlag)
 				}
 			}
@@ -1080,7 +1068,7 @@ a workspace in one step.`,
 		},
 	}
 
-	cmd.Flags().StringVar(&templateFlag, "template", "", "workspace template (startup, scrum, product)")
+	cmd.Flags().StringVar(&templateFlag, "template", "", "workspace template (use --list-templates to see available templates by category)")
 	cmd.Flags().BoolVar(&listTemplates, "list-templates", false, "list available workspace templates")
 
 	return cmd

--- a/cmd/pad/templates_picker.go
+++ b/cmd/pad/templates_picker.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -131,8 +132,14 @@ func pickTemplateInteractive(in io.Reader, out io.Writer) (string, error) {
 		fmt.Fprintf(out, "Select a template [%d] (press enter for default): ", defaultIdx)
 		line, err := reader.ReadString('\n')
 		if err != nil {
-			// EOF on a pipe etc. — fall back to default rather than fail.
-			return defaultTemplateName, nil
+			// EOF is a benign signal (pipe closed, stdin exhausted in a
+			// test) and should fall back to the default template. Other
+			// read errors (e.g. EIO from a detached PTY) must abort so
+			// we don't silently apply a template the user never chose.
+			if errors.Is(err, io.EOF) {
+				return defaultTemplateName, nil
+			}
+			return "", fmt.Errorf("read template selection: %w", err)
 		}
 		line = strings.TrimSpace(line)
 		if line == "" {

--- a/cmd/pad/templates_picker.go
+++ b/cmd/pad/templates_picker.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/fatih/color"
+	"golang.org/x/term"
+
+	"github.com/xarmian/pad/internal/collections"
+)
+
+const defaultTemplateName = "startup"
+
+// printGroupedTemplates prints the visible templates to w, grouped by
+// category in canonical order. Used by `--list-templates` and the
+// "unknown template" error path.
+func printGroupedTemplates(w io.Writer) {
+	bold := color.New(color.Bold)
+	dim := color.New(color.Faint)
+	groups := collections.GroupTemplatesByCategory()
+
+	// Width of the template-name column, so descriptions line up.
+	nameWidth := 0
+	for _, g := range groups {
+		for _, t := range g.Templates {
+			if len(t.Name) > nameWidth {
+				nameWidth = len(t.Name)
+			}
+		}
+	}
+	if nameWidth < 10 {
+		nameWidth = 10
+	}
+
+	for i, g := range groups {
+		if i > 0 {
+			fmt.Fprintln(w)
+		}
+		fmt.Fprintln(w, bold.Sprint(collections.CategoryLabel(g.Category)))
+		for _, t := range g.Templates {
+			marker := ""
+			if t.Name == defaultTemplateName {
+				marker = " " + dim.Sprint("(default)")
+			}
+			icon := t.Icon
+			if icon == "" {
+				icon = " "
+			}
+			fmt.Fprintf(w, "  %s  %-*s  %s%s\n", icon, nameWidth, t.Name, t.Description, marker)
+		}
+	}
+}
+
+// canPromptForTemplate returns true when stdin and stdout are both TTYs —
+// i.e. we can interactively prompt the user for a template choice.
+func canPromptForTemplate() bool {
+	return term.IsTerminal(int(os.Stdin.Fd())) && term.IsTerminal(int(os.Stdout.Fd()))
+}
+
+// pickTemplateInteractive presents a numbered list of visible templates
+// grouped by category and returns the chosen template's Name. Returns the
+// default template name (startup) when the user presses enter without
+// picking. Returns an error only on unrecoverable input failure.
+//
+// Callers should only invoke this when canPromptForTemplate() returns true.
+func pickTemplateInteractive(in io.Reader, out io.Writer) (string, error) {
+	bold := color.New(color.Bold)
+	dim := color.New(color.Faint)
+
+	groups := collections.GroupTemplatesByCategory()
+
+	// Build a flat ordered list of templates while preserving group
+	// boundaries so we can show headers inline with numbered choices.
+	type numbered struct {
+		index int
+		tmpl  collections.WorkspaceTemplate
+	}
+	var flat []numbered
+
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, bold.Sprint("Choose a workspace template:"))
+
+	nameWidth := 0
+	for _, g := range groups {
+		for _, t := range g.Templates {
+			if len(t.Name) > nameWidth {
+				nameWidth = len(t.Name)
+			}
+		}
+	}
+	if nameWidth < 12 {
+		nameWidth = 12
+	}
+
+	counter := 0
+	for _, g := range groups {
+		fmt.Fprintln(out)
+		fmt.Fprintln(out, dim.Sprintf("  %s", collections.CategoryLabel(g.Category)))
+		for _, t := range g.Templates {
+			counter++
+			flat = append(flat, numbered{index: counter, tmpl: t})
+			marker := ""
+			if t.Name == defaultTemplateName {
+				marker = " " + dim.Sprint("(default)")
+			}
+			icon := t.Icon
+			if icon == "" {
+				icon = " "
+			}
+			fmt.Fprintf(out, "    %2d. %s  %-*s  %s%s\n", counter, icon, nameWidth, t.Name, t.Description, marker)
+		}
+	}
+
+	// Resolve the default's display index for the prompt.
+	defaultIdx := 1
+	for _, n := range flat {
+		if n.tmpl.Name == defaultTemplateName {
+			defaultIdx = n.index
+			break
+		}
+	}
+
+	reader := bufio.NewReader(in)
+	for {
+		fmt.Fprintln(out)
+		fmt.Fprintf(out, "Select a template [%d] (press enter for default): ", defaultIdx)
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			// EOF on a pipe etc. — fall back to default rather than fail.
+			return defaultTemplateName, nil
+		}
+		line = strings.TrimSpace(line)
+		if line == "" {
+			return defaultTemplateName, nil
+		}
+		// Allow typing a name directly as an escape hatch.
+		if tmpl := collections.GetTemplate(line); tmpl != nil && !tmpl.Hidden {
+			return tmpl.Name, nil
+		}
+		n, err := strconv.Atoi(line)
+		if err != nil || n < 1 || n > len(flat) {
+			fmt.Fprintf(out, "Invalid choice %q. Enter a number between 1 and %d, or a template name.\n", line, len(flat))
+			continue
+		}
+		return flat[n-1].tmpl.Name, nil
+	}
+}

--- a/cmd/pad/templates_picker_test.go
+++ b/cmd/pad/templates_picker_test.go
@@ -2,9 +2,16 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"strings"
 	"testing"
 )
+
+// errReader returns a fixed error on every Read — used to simulate
+// non-EOF read failures (e.g. EIO on a detached PTY).
+type errReader struct{ err error }
+
+func (r *errReader) Read(_ []byte) (int, error) { return 0, r.err }
 
 // TestPickTemplateInteractiveDefault verifies that pressing enter without
 // a number selects the default template (startup).
@@ -61,6 +68,24 @@ func TestPickTemplateInteractiveRetriesOnInvalid(t *testing.T) {
 	}
 	if !strings.Contains(out.String(), "Invalid choice") {
 		t.Errorf("expected 'Invalid choice' message in output, got:\n%s", out.String())
+	}
+}
+
+// TestPickTemplateInteractiveSurfacesNonEOFReadErrors verifies that a
+// non-EOF read failure aborts the picker rather than silently defaulting
+// to the startup template.
+func TestPickTemplateInteractiveSurfacesNonEOFReadErrors(t *testing.T) {
+	var out bytes.Buffer
+	sentinel := errors.New("simulated EIO")
+	picked, err := pickTemplateInteractive(&errReader{err: sentinel}, &out)
+	if err == nil {
+		t.Fatalf("expected read error to propagate, got picked=%q err=nil", picked)
+	}
+	if picked != "" {
+		t.Errorf("expected empty picked on error, got %q", picked)
+	}
+	if !errors.Is(err, sentinel) {
+		t.Errorf("expected wrapped sentinel error, got %v", err)
 	}
 }
 

--- a/cmd/pad/templates_picker_test.go
+++ b/cmd/pad/templates_picker_test.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// TestPickTemplateInteractiveDefault verifies that pressing enter without
+// a number selects the default template (startup).
+func TestPickTemplateInteractiveDefault(t *testing.T) {
+	var out bytes.Buffer
+	picked, err := pickTemplateInteractive(strings.NewReader("\n"), &out)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if picked != defaultTemplateName {
+		t.Errorf("pickTemplateInteractive empty input = %q, want %q", picked, defaultTemplateName)
+	}
+}
+
+// TestPickTemplateInteractiveByName verifies that typing a template name
+// directly (instead of a number) is accepted.
+func TestPickTemplateInteractiveByName(t *testing.T) {
+	var out bytes.Buffer
+	picked, err := pickTemplateInteractive(strings.NewReader("hiring\n"), &out)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if picked != "hiring" {
+		t.Errorf("pickTemplateInteractive by name = %q, want %q", picked, "hiring")
+	}
+}
+
+// TestPickTemplateInteractiveByNumber verifies that numeric selection maps
+// to the correct template. Number 1 should always be the first template in
+// the canonical ordering (currently "startup").
+func TestPickTemplateInteractiveByNumber(t *testing.T) {
+	var out bytes.Buffer
+	picked, err := pickTemplateInteractive(strings.NewReader("1\n"), &out)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if picked == "" {
+		t.Fatal("pickTemplateInteractive returned empty name on numeric input")
+	}
+}
+
+// TestPickTemplateInteractiveRetriesOnInvalid verifies that invalid input
+// re-prompts (rather than returning an error or defaulting silently).
+func TestPickTemplateInteractiveRetriesOnInvalid(t *testing.T) {
+	var out bytes.Buffer
+	// First "zzz" is invalid (not a number, not a known template name).
+	// Follow with enter to accept the default.
+	picked, err := pickTemplateInteractive(strings.NewReader("zzz\n\n"), &out)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if picked != defaultTemplateName {
+		t.Errorf("pickTemplateInteractive after invalid+default = %q, want %q", picked, defaultTemplateName)
+	}
+	if !strings.Contains(out.String(), "Invalid choice") {
+		t.Errorf("expected 'Invalid choice' message in output, got:\n%s", out.String())
+	}
+}
+
+// TestPrintGroupedTemplatesIncludesEveryVisibleTemplate is a smoke test
+// that the grouped printer covers each visible template's name.
+func TestPrintGroupedTemplatesIncludesEveryVisibleTemplate(t *testing.T) {
+	var out bytes.Buffer
+	printGroupedTemplates(&out)
+	rendered := out.String()
+	for _, name := range []string{"startup", "scrum", "product", "hiring", "interviewing"} {
+		if !strings.Contains(rendered, name) {
+			t.Errorf("grouped template output missing %q:\n%s", name, rendered)
+		}
+	}
+	// Hidden template (demo) should NOT appear.
+	if strings.Contains(rendered, "demo") {
+		t.Errorf("grouped template output leaked hidden template 'demo':\n%s", rendered)
+	}
+	// Category headers should render.
+	if !strings.Contains(rendered, "Software") {
+		t.Errorf("grouped template output missing 'Software' category header")
+	}
+	if !strings.Contains(rendered, "People") {
+		t.Errorf("grouped template output missing 'People' category header")
+	}
+}

--- a/internal/collections/templates.go
+++ b/internal/collections/templates.go
@@ -18,6 +18,75 @@ const (
 	CategoryPersonal   = "personal"
 )
 
+// CategoryOrder is the canonical display order of categories. Pickers and
+// grouped listings should iterate this slice so the order is stable and
+// consistent across the CLI and web UI.
+var CategoryOrder = []string{
+	CategorySoftware,
+	CategoryPeople,
+	CategoryResearch,
+	CategoryContent,
+	CategoryOperations,
+	CategoryPersonal,
+}
+
+// categoryLabels maps category slugs to their human-readable display labels.
+var categoryLabels = map[string]string{
+	CategorySoftware:   "Software",
+	CategoryPeople:     "People",
+	CategoryResearch:   "Research",
+	CategoryContent:    "Content",
+	CategoryOperations: "Operations",
+	CategoryPersonal:   "Personal",
+}
+
+// CategoryLabel returns the human-readable label for a category slug.
+// Unknown categories are returned unchanged so the picker can still render
+// a reasonable string if a template uses a custom category.
+func CategoryLabel(category string) string {
+	if label, ok := categoryLabels[category]; ok {
+		return label
+	}
+	return category
+}
+
+// CategoryGroup is an ordered pair of (category, templates-in-that-category).
+type CategoryGroup struct {
+	Category  string
+	Templates []WorkspaceTemplate
+}
+
+// GroupTemplatesByCategory returns the visible workspace templates grouped by
+// category in the canonical CategoryOrder. Categories with no visible
+// templates are omitted. Templates with a category not in CategoryOrder are
+// placed in a trailing "other" group sorted at the end.
+func GroupTemplatesByCategory() []CategoryGroup {
+	tmpls := ListTemplates()
+
+	byCat := make(map[string][]WorkspaceTemplate, len(CategoryOrder))
+	for _, t := range tmpls {
+		byCat[t.Category] = append(byCat[t.Category], t)
+	}
+
+	var groups []CategoryGroup
+	// Canonical order first
+	for _, cat := range CategoryOrder {
+		if items, ok := byCat[cat]; ok && len(items) > 0 {
+			groups = append(groups, CategoryGroup{Category: cat, Templates: items})
+			delete(byCat, cat)
+		}
+	}
+	// Any leftover categories (unknown/custom) appended in insertion order.
+	// Deterministic enough: templates are defined in a fixed order.
+	for _, t := range tmpls {
+		if items, ok := byCat[t.Category]; ok && len(items) > 0 {
+			groups = append(groups, CategoryGroup{Category: t.Category, Templates: items})
+			delete(byCat, t.Category)
+		}
+	}
+	return groups
+}
+
 // WorkspaceTemplate is a named set of collection definitions used to
 // initialize a new workspace.
 type WorkspaceTemplate struct {

--- a/internal/collections/templates_test.go
+++ b/internal/collections/templates_test.go
@@ -183,6 +183,64 @@ func TestSoftwareTemplatesShipStarterPacks(t *testing.T) {
 	}
 }
 
+// TestGroupTemplatesByCategory verifies the grouping helper used by CLI
+// and web pickers: canonical category order, only visible templates, and
+// every visible template lands in exactly one group.
+func TestGroupTemplatesByCategory(t *testing.T) {
+	groups := GroupTemplatesByCategory()
+	if len(groups) == 0 {
+		t.Fatal("GroupTemplatesByCategory returned no groups")
+	}
+
+	seen := make(map[string]bool)
+	prevCatIdx := -1
+	for _, g := range groups {
+		if len(g.Templates) == 0 {
+			t.Errorf("empty group returned for category %q", g.Category)
+		}
+		// If the group's category is in CategoryOrder, check it appears in order.
+		idx := -1
+		for i, cat := range CategoryOrder {
+			if cat == g.Category {
+				idx = i
+				break
+			}
+		}
+		if idx >= 0 {
+			if idx < prevCatIdx {
+				t.Errorf("group %q appeared out of canonical order (idx=%d, prev=%d)", g.Category, idx, prevCatIdx)
+			}
+			prevCatIdx = idx
+		}
+		for _, tmpl := range g.Templates {
+			if tmpl.Hidden {
+				t.Errorf("hidden template %q leaked into group %q", tmpl.Name, g.Category)
+			}
+			if seen[tmpl.Name] {
+				t.Errorf("template %q appeared in multiple groups", tmpl.Name)
+			}
+			seen[tmpl.Name] = true
+		}
+	}
+
+	// Every visible template should have been seen.
+	for _, tmpl := range ListTemplates() {
+		if !seen[tmpl.Name] {
+			t.Errorf("visible template %q missing from grouped output", tmpl.Name)
+		}
+	}
+}
+
+// TestCategoryLabel exercises known and unknown category label lookup.
+func TestCategoryLabel(t *testing.T) {
+	if got := CategoryLabel(CategorySoftware); got != "Software" {
+		t.Errorf("CategoryLabel(software) = %q, want %q", got, "Software")
+	}
+	if got := CategoryLabel("unknown-category"); got != "unknown-category" {
+		t.Errorf("CategoryLabel(unknown) = %q, want passthrough", got)
+	}
+}
+
 // TestHiringTemplate verifies the hiring template ships the expected
 // collections, conventions, and playbooks with the hiring trigger vocabulary.
 // This guards against accidental drift back into software-domain triggers.


### PR DESCRIPTION
## Summary

Turns the CLI template picker from a flat alphabetical dump into the category-aware flow established by PLAN-609. Shared helpers are exported from \`internal/collections\` so the upcoming web picker (TASK-617) reuses the same grouping logic.

### Library

- \`GroupTemplatesByCategory\` — returns visible templates bucketed by \`CategoryOrder\`
- \`CategoryLabel\` — slug → display label
- \`CategoryOrder\` — canonical display order, consumable by CLI + web

### CLI

- New \`templates_picker.go\` with \`printGroupedTemplates\` (listing + error paths) and \`pickTemplateInteractive\` (numbered picker with TTY detection)
- \`pad workspace init --list-templates\` now prints by category with icons + aligned columns:
  \`\`\`
  Software
    🚀  startup       Tasks, Ideas, Plans, Docs, Conventions, Playbooks (default)
    🏃  scrum         Backlog, Sprints, Bugs, Docs, Conventions, Playbooks
    📦  product       Features, Feedback, Roadmap Items, Docs, Conventions, Playbooks

  People
    👥  hiring        Requisitions, Candidates, Interview Loops, Feedback, Docs
    📨  interviewing  Applications, Interviews, Companies, Contacts, Docs
  \`\`\`
- \`pad init\` (no \`--template\` flag, TTY) now triggers the interactive picker. Number OR name accepted; enter selects default (startup); invalid input re-prompts.
- Non-TTY (scripts, CI) falls back to \`startup\` exactly like before.
- Unknown template errors show the grouped list.
- Flag help text no longer hardcodes \"startup, scrum, product.\"

## Context

Implements \`TASK-616\` under \`PLAN-609\`.

## Test plan

- [x] \`go build ./...\` — clean
- [x] \`go vet ./...\` — clean
- [x] \`go test ./...\` — all packages pass
- [x] New library tests: \`TestGroupTemplatesByCategory\`, \`TestCategoryLabel\`
- [x] New CLI tests: picker default / name / number / invalid retry, grouped printer smoke test
- [x] Manual smoke: \`pad workspace init --list-templates\` shows the new grouped output