### PR TITLE
feat(web): categorized template picker with icons (TASK-617)

### DIFF
--- a/web/src/lib/components/layout/CreateWorkspaceModal.svelte
+++ b/web/src/lib/components/layout/CreateWorkspaceModal.svelte
@@ -5,6 +5,7 @@
 	import { api } from '$lib/api/client';
 	import { toastStore } from '$lib/stores/toast.svelte';
 	import type { WorkspaceTemplate } from '$lib/types';
+	import { groupTemplatesByCategory } from '$lib/utils/templates';
 
 	let mode = $state<'create' | 'import'>('create');
 	let newName = $state('');
@@ -17,6 +18,8 @@
 	let nameInputEl = $state<HTMLInputElement>();
 	let dragging = $state(false);
 	let dragCounter = 0;
+
+	let grouped = $derived(groupTemplatesByCategory(templates));
 
 	$effect(() => {
 		if (uiStore.createWorkspaceOpen) {
@@ -146,23 +149,33 @@
 				{#if templates.length > 0}
 					<span class="field-label">Template</span>
 					<div class="template-list">
-						{#each templates as tpl (tpl.name)}
-							<button
-								class="template-card"
-								class:selected={selectedTemplate === tpl.name}
-								onclick={() => (selectedTemplate = tpl.name)}
-							>
-								<span class="tpl-name">{tpl.name}</span>
-								<span class="tpl-desc">{tpl.collections.join(', ')}</span>
-							</button>
+						{#each grouped as group (group.category)}
+							<span class="cat-label">{group.label}</span>
+							{#each group.templates as tpl (tpl.name)}
+								<button
+									class="template-card"
+									class:selected={selectedTemplate === tpl.name}
+									onclick={() => (selectedTemplate = tpl.name)}
+								>
+									{#if tpl.icon}
+										<span class="tpl-icon">{tpl.icon}</span>
+									{/if}
+									<span class="tpl-text">
+										<span class="tpl-name">{tpl.name}</span>
+										<span class="tpl-desc">{tpl.collections.join(', ')}</span>
+									</span>
+								</button>
+							{/each}
 						{/each}
 						<button
 							class="template-card"
 							class:selected={selectedTemplate === ''}
 							onclick={() => (selectedTemplate = '')}
 						>
-							<span class="tpl-name">blank</span>
-							<span class="tpl-desc">Empty workspace</span>
+							<span class="tpl-text">
+								<span class="tpl-name">blank</span>
+								<span class="tpl-desc">Empty workspace</span>
+							</span>
 						</button>
 					</div>
 				{/if}
@@ -309,8 +322,19 @@
 	.modal-body input:focus { outline: none; border-color: var(--accent-blue); }
 
 	.template-list { display: flex; flex-direction: column; gap: 4px; }
+	.cat-label {
+		font-size: 0.72em;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		color: var(--text-muted);
+		opacity: 0.8;
+		margin-top: var(--space-2);
+	}
+	.cat-label:first-child { margin-top: 0; }
 	.template-card {
-		display: flex; flex-direction: column; gap: 1px;
+		display: flex; flex-direction: row; align-items: center;
+		gap: var(--space-2);
 		padding: var(--space-2) var(--space-3);
 		border-radius: var(--radius-sm);
 		background: var(--bg-tertiary);
@@ -323,6 +347,12 @@
 		border-color: var(--accent-blue);
 		background: color-mix(in srgb, var(--accent-blue) 8%, var(--bg-tertiary));
 	}
+	.tpl-icon {
+		font-size: 1.1em;
+		margin-right: var(--space-2);
+		flex-shrink: 0;
+	}
+	.tpl-text { display: flex; flex-direction: column; gap: 1px; min-width: 0; }
 	.tpl-name { font-size: 0.88em; font-weight: 600; color: var(--text-primary); text-transform: capitalize; }
 	.tpl-desc { font-size: 0.78em; color: var(--text-muted); }
 

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -182,7 +182,9 @@ export interface WorkspaceUpdate {
 
 export interface WorkspaceTemplate {
 	name: string;
+	category?: string;
 	description: string;
+	icon?: string;
 	collections: string[];
 }
 

--- a/web/src/lib/utils/templates.ts
+++ b/web/src/lib/utils/templates.ts
@@ -1,0 +1,64 @@
+// Shared helpers for grouping workspace templates by category in pickers.
+// Mirrors internal/collections/templates.go (CategoryOrder + CategoryLabel)
+// so the CLI and web UI use the same canonical ordering and labels.
+
+import type { WorkspaceTemplate } from '$lib/types';
+
+export const CATEGORY_ORDER = [
+	'software',
+	'people',
+	'research',
+	'content',
+	'operations',
+	'personal',
+] as const;
+
+const CATEGORY_LABELS: Record<string, string> = {
+	software: 'Software',
+	people: 'People',
+	research: 'Research',
+	content: 'Content',
+	operations: 'Operations',
+	personal: 'Personal',
+};
+
+export function categoryLabel(slug: string | undefined): string {
+	if (!slug) return 'Other';
+	return CATEGORY_LABELS[slug] ?? slug;
+}
+
+export interface TemplateGroup {
+	category: string;
+	label: string;
+	templates: WorkspaceTemplate[];
+}
+
+// groupTemplatesByCategory returns templates bucketed by category in
+// CATEGORY_ORDER. Any template with a category not in CATEGORY_ORDER
+// (including undefined) is collected into a trailing "other" group so
+// nothing is hidden from the picker.
+export function groupTemplatesByCategory(templates: WorkspaceTemplate[]): TemplateGroup[] {
+	const byCat = new Map<string, WorkspaceTemplate[]>();
+	for (const t of templates) {
+		const cat = t.category ?? '';
+		const bucket = byCat.get(cat);
+		if (bucket) bucket.push(t);
+		else byCat.set(cat, [t]);
+	}
+
+	const groups: TemplateGroup[] = [];
+	for (const cat of CATEGORY_ORDER) {
+		const items = byCat.get(cat);
+		if (items && items.length > 0) {
+			groups.push({ category: cat, label: categoryLabel(cat), templates: items });
+			byCat.delete(cat);
+		}
+	}
+	// Append any leftover categories (custom or empty) in insertion order.
+	for (const [cat, items] of byCat) {
+		if (items.length > 0) {
+			groups.push({ category: cat, label: categoryLabel(cat), templates: items });
+		}
+	}
+	return groups;
+}

--- a/web/src/routes/console/new/+page.svelte
+++ b/web/src/routes/console/new/+page.svelte
@@ -4,12 +4,15 @@
 	import { api } from '$lib/api/client';
 	import { authStore } from '$lib/stores/auth.svelte';
 	import type { WorkspaceTemplate } from '$lib/types';
+	import { groupTemplatesByCategory } from '$lib/utils/templates';
 
 	let name = $state('');
 	let selectedTemplate = $state('startup');
 	let templates = $state<WorkspaceTemplate[]>([]);
 	let creating = $state(false);
 	let error = $state('');
+
+	let grouped = $derived(groupTemplatesByCategory(templates));
 
 	let slug = $derived(
 		name
@@ -28,9 +31,9 @@
 		} catch {
 			// Templates are optional; fall back to defaults
 			templates = [
-				{ name: 'startup', description: 'Default template for general projects', collections: [] },
-				{ name: 'scrum', description: 'Scrum-style sprints and backlogs', collections: [] },
-				{ name: 'product', description: 'Product development workflow', collections: [] }
+				{ name: 'startup', description: 'Default template for general projects', collections: [], category: 'software' },
+				{ name: 'scrum', description: 'Scrum-style sprints and backlogs', collections: [], category: 'software' },
+				{ name: 'product', description: 'Product development workflow', collections: [], category: 'software' }
 			];
 		}
 	});
@@ -92,17 +95,27 @@
 		<div class="field">
 			<span class="field-label">Template</span>
 			<div class="template-grid">
-				{#each templates as tmpl (tmpl.name)}
-					<button
-						class="template-option"
-						class:selected={selectedTemplate === tmpl.name}
-						onclick={() => (selectedTemplate = tmpl.name)}
-						disabled={creating}
-						type="button"
-					>
-						<span class="template-name">{tmpl.name}</span>
-						<span class="template-desc">{tmpl.description}</span>
-					</button>
+				{#each grouped as group (group.category)}
+					<div class="category-group">
+						<span class="category-label">{group.label}</span>
+						{#each group.templates as tmpl (tmpl.name)}
+							<button
+								class="template-option"
+								class:selected={selectedTemplate === tmpl.name}
+								onclick={() => (selectedTemplate = tmpl.name)}
+								disabled={creating}
+								type="button"
+							>
+								{#if tmpl.icon}
+									<span class="template-icon">{tmpl.icon}</span>
+								{/if}
+								<span class="template-text">
+									<span class="template-name">{tmpl.name}</span>
+									<span class="template-desc">{tmpl.description}</span>
+								</span>
+							</button>
+						{/each}
+					</div>
 				{/each}
 			</div>
 		</div>
@@ -198,10 +211,30 @@
 		gap: var(--space-2);
 	}
 
-	.template-option {
+	.category-group {
 		display: flex;
 		flex-direction: column;
-		gap: 2px;
+		gap: var(--space-2);
+	}
+
+	.category-group + .category-group {
+		margin-top: var(--space-3);
+	}
+
+	.category-label {
+		font-size: 0.72rem;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.06em;
+		color: var(--text-muted);
+		opacity: 0.85;
+	}
+
+	.template-option {
+		display: flex;
+		flex-direction: row;
+		align-items: center;
+		gap: var(--space-3);
 		padding: var(--space-3) var(--space-4);
 		background: var(--bg-tertiary);
 		border: 1px solid var(--border);
@@ -209,6 +242,18 @@
 		text-align: left;
 		cursor: pointer;
 		transition: border-color 0.15s;
+	}
+
+	.template-icon {
+		font-size: 1.2em;
+		flex-shrink: 0;
+	}
+
+	.template-text {
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+		min-width: 0;
 	}
 
 	.template-option:hover {


### PR DESCRIPTION
## Summary

Mirrors the CLI picker work from TASK-616 over to the web workspace-creation flows. Templates now render grouped by category with their icons in both places users create workspaces: the full-page \`/console/new\` route and the \`CreateWorkspaceModal\`.

## What changed

- \`WorkspaceTemplate\` TS type: added optional \`category\` and \`icon\` (the backend has been emitting these since TASK-610).
- New \`web/src/lib/utils/templates.ts\` with \`CATEGORY_ORDER\`, \`categoryLabel\`, \`groupTemplatesByCategory\` — mirrors Go's \`CategoryOrder\` / \`CategoryLabel\` so ordering and labels stay consistent across CLI and web.
- \`/console/new/+page.svelte\`: replaced flat template grid with a grouped list; each group gets a small subhead; each button renders icon + name + description. Offline fallback templates updated to include \`category: 'software'\`.
- \`CreateWorkspaceModal.svelte\`: same grouped treatment on the create tab. The existing \"blank\" option is preserved as a trailing category-less card. Icons prefix each template name.

## Context

Implements \`TASK-617\` under \`PLAN-609\`. Only the picker UX changes — workspace creation logic is unchanged.

## Test plan

- [x] \`npm run build\` (web) — clean
- [x] \`go test ./...\` — all existing Go tests still pass
- [x] Go \`TestGroupTemplatesByCategory\` covers the shared ordering contract the web helper mirrors
- [x] Manual: both pickers render grouped output with category headers and icons