### PR TITLE
docs: reflect domain-agnostic template library (TASK-618)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,8 +179,14 @@ Collection names accept singular forms: `task`→`tasks`, `idea`→`ideas`, `doc
 - **Items** have structured `fields` JSON + optional rich `content` (markdown)
 - **Parent/child links:** Any item can be a parent of child items (`--parent REF`). Children get progress tracking, burndown charts, and nested rendering. Plans are the most common parent, but Ideas, Docs, or Tasks can also have children.
 - **Wiki-links** `[[Title]]` resolve across all items, rendered as clickable links
-- **Default collections:** Tasks, Ideas, Plans, Docs
-- **Templates:** startup (default), scrum, product — set via `pad workspace init --template`
+- **Default collections:** Tasks, Ideas, Plans, Docs (software / `startup` template)
+- **Templates** are grouped by category so Pad supports more than just software workflows:
+  - **Software:** `startup` (default), `scrum`, `product`
+  - **People:** `hiring` (company-side: Requisitions → Candidates → Loops → Feedback), `interviewing` (candidate-side: Applications, Interviews, Companies, Contacts)
+  - *Research / Content / Operations / Personal are reserved categories awaiting their first templates.*
+- Each template ships a curated starter pack (conventions + playbooks + sample items) appropriate to its domain — trigger vocabularies vary (`on-commit` vs `on-candidate-advance` vs `on-interview-scheduled`).
+- Set the template via `pad workspace init --template <name>`. Running `pad init` with no flag in a TTY opens an interactive picker grouped by category. Run `pad workspace init --list-templates` to see the current catalog.
+- See `PLAN-609` and `IDEA-583` in this workspace for the design history.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -193,12 +193,17 @@ cd ~/projects/myapp
 pad workspace init "My App"
 ```
 
-This creates a `.pad.toml` file linking your project directory to a Pad workspace with default collections. Choose a template to start with pre-configured collections:
+This creates a `.pad.toml` file linking your project directory to a Pad workspace with default collections. Running `pad init` without `--template` in a terminal opens an interactive picker grouped by category (Software / People / …) so you can pick the one that fits.
 
 ```bash
-pad workspace init "My App" --template scrum     # Scrum-style with sprints
-pad workspace init "My App" --template product   # Product management focused
+pad workspace init --list-templates                   # See the full catalog grouped by category
+pad workspace init "My App" --template scrum          # Scrum-style with sprints
+pad workspace init "My App" --template product        # Product management focused
+pad workspace init "My Hiring" --template hiring      # Company-side: requisitions, candidates, interview loops, feedback
+pad workspace init "Job Search" --template interviewing  # Candidate-side: applications, interviews, companies, contacts
 ```
+
+Pad ships templates for software (startup / scrum / product), people workflows (hiring, interviewing), and has reserved categories for research, content, operations, and personal use so the same project-management primitives fit well beyond code projects.
 
 ### 3. Install the AI skill
 


### PR DESCRIPTION
## Summary

Final task of PLAN-609. Docs-only updates to reflect the new multi-category template library.

- **CLAUDE.md** Data Model → Templates section: lists the 6 categories (Software / People / Research / Content / Operations / Personal), names what ships under each, calls out that trigger vocabularies are per-template (\`on-commit\` vs \`on-candidate-advance\` vs \`on-interview-scheduled\`), mentions the interactive picker, points at PLAN-609 + IDEA-583 for design history.
- **README.md** Quick Start: template examples now include \`hiring\` and \`interviewing\` alongside the software templates, mentions \`--list-templates\` and the interactive picker, frames the system as covering workflows beyond just software.

Left the product-pitch line (\"Project management for developers and AI agents\") alone — that's a positioning decision, not a template-categorization one.

## Context

Implements \`TASK-618\` under \`PLAN-609\`. With this, all 9 tasks of the plan are complete.

## Test plan

- [x] \`go build ./...\` — clean (no code changes, verifies CLAUDE.md/README.md still read)
- [x] Markdown renders correctly (manual inspection)