### PR TITLE
fix(web): schema-driven trigger+scope options in create forms (IDEA-619)

### DIFF
--- a/web/src/routes/[username]/[workspace]/conventions/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/conventions/+page.svelte
@@ -76,11 +76,17 @@
 	}
 
 	async function loadConventionsCollection(ws: string) {
+		// Clear any previous workspace's schema before the fetch. Until the new
+		// response lands, createTriggers/createSurfaces fall back to the
+		// hardcoded software defaults — correct for a workspace whose schema
+		// we have not yet observed. This prevents the in-flight window from
+		// rendering the previous workspace's vocabulary on the new page.
+		conventionsCollection = null;
 		try {
 			const coll = await api.collections.get(ws, 'conventions');
-			// Guard against stale responses: if the workspace changed while this
-			// request was in flight, drop the result rather than overwriting
-			// state with schema from the previous workspace.
+			// Stale-response guard: if the user has since moved to another
+			// workspace, drop the result rather than overwriting state with
+			// schema from a workspace we are no longer on.
 			if (ws !== workspace) return;
 			conventionsCollection = coll;
 		} catch {

--- a/web/src/routes/[username]/[workspace]/conventions/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/conventions/+page.svelte
@@ -77,8 +77,14 @@
 
 	async function loadConventionsCollection(ws: string) {
 		try {
-			conventionsCollection = await api.collections.get(ws, 'conventions');
+			const coll = await api.collections.get(ws, 'conventions');
+			// Guard against stale responses: if the workspace changed while this
+			// request was in flight, drop the result rather than overwriting
+			// state with schema from the previous workspace.
+			if (ws !== workspace) return;
+			conventionsCollection = coll;
 		} catch {
+			if (ws !== workspace) return;
 			conventionsCollection = null;
 		}
 	}

--- a/web/src/routes/[username]/[workspace]/conventions/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/conventions/+page.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
 	import { page } from '$app/state';
 	import { api } from '$lib/api/client';
-	import type { Item, ItemConventionMetadata, ItemCreate } from '$lib/types';
-	import { parseFields } from '$lib/types';
+	import type { Collection, Item, ItemConventionMetadata, ItemCreate } from '$lib/types';
+	import { parseFields, parseSchema } from '$lib/types';
 	import { toastStore } from '$lib/stores/toast.svelte';
 	import { SvelteSet, SvelteMap } from 'svelte/reactivity';
 
@@ -32,6 +32,7 @@
 	let workspace = $derived(page.params.workspace ?? '');
 	let username = $derived(page.params.username ?? '');
 	let conventions = $state<Item[]>([]);
+	let conventionsCollection = $state<Collection | null>(null);
 	let loading = $state(true);
 	let expandedSlug = $state<string | null>(null);
 	let collapsedGroups = new SvelteSet<string>();
@@ -50,14 +51,17 @@
 	// Inline create form state
 	let newTitle = $state('');
 	let newCategory = $state<typeof CATEGORIES[number]>('custom');
-	let newTrigger = $state<Trigger>('always');
-	let newSurface = $state<typeof SURFACES[number]>('all');
+	let newTrigger = $state<string>('always');
+	let newSurface = $state<string>('all');
 	let newEnforcement = $state<typeof ENFORCEMENT_LEVELS[number]>('should');
 	let newCommands = $state('');
 	let newContent = $state('');
 
 	$effect(() => {
-		if (workspace) loadConventions(workspace);
+		if (workspace) {
+			loadConventions(workspace);
+			loadConventionsCollection(workspace);
+		}
 	});
 
 	async function loadConventions(ws: string) {
@@ -71,20 +75,64 @@
 		}
 	}
 
+	async function loadConventionsCollection(ws: string) {
+		try {
+			conventionsCollection = await api.collections.get(ws, 'conventions');
+		} catch {
+			conventionsCollection = null;
+		}
+	}
+
+	let schemaTriggers = $derived.by<readonly string[]>(() => {
+		if (!conventionsCollection) return [];
+		const schema = parseSchema(conventionsCollection);
+		const field = schema.fields.find((f) => f.key === 'trigger');
+		return field?.options ?? [];
+	});
+
+	let schemaSurfaces = $derived.by<readonly string[]>(() => {
+		if (!conventionsCollection) return [];
+		const schema = parseSchema(conventionsCollection);
+		const field = schema.fields.find((f) => f.key === 'scope');
+		return field?.options ?? [];
+	});
+
+	let createTriggers = $derived<readonly string[]>(
+		schemaTriggers.length > 0 ? schemaTriggers : (TRIGGERS as readonly string[])
+	);
+	let createSurfaces = $derived<readonly string[]>(
+		schemaSurfaces.length > 0 ? schemaSurfaces : (SURFACES as readonly string[])
+	);
+
+	// When schema-driven options load (or change), snap the create-form selections
+	// into the effective list. This prevents the <select> from showing a phantom
+	// value that isn't actually in its <option>s.
+	$effect(() => {
+		if (createTriggers.length > 0 && !createTriggers.includes(newTrigger)) {
+			newTrigger = createTriggers[0];
+		}
+	});
+	$effect(() => {
+		if (createSurfaces.length > 0 && !createSurfaces.includes(newSurface)) {
+			newSurface = createSurfaces[0];
+		}
+	});
+
 	let hasActiveFilters = $derived(searchQuery !== '' || filterScope !== '' || filterPriority !== '');
 
-	// Expose the union of SURFACES plus any scopes discovered on loaded items,
-	// so filter dropdowns show scopes from non-software templates (e.g. hiring's
-	// sourcing/screening/interviewing/offers). Create form still uses narrow SURFACES.
+	// Expose the union of the effective create-form surfaces plus any scopes
+	// discovered on loaded items, so filter dropdowns show scopes from
+	// non-software templates (e.g. hiring's sourcing/screening/interviewing/offers).
 	let allSurfaces = $derived.by(() => {
-		const known = new Set<string>(SURFACES as readonly string[]);
+		const base = createSurfaces;
+		const known = new Set<string>(base);
 		const extra = new Set<string>();
 		for (const c of conventions) {
 			const s = getPrimarySurface(c);
 			if (s && !known.has(s)) extra.add(s);
 		}
 		return [
-			...(SURFACES as readonly string[]),
+			...base,
 			...Array.from(extra).sort(),
 		];
 	});
@@ -113,7 +161,7 @@
 			if (!byTrigger.has(t)) byTrigger.set(t, []);
 			byTrigger.get(t)!.push(item);
 		}
-		const knownOrder = TRIGGERS as readonly string[];
+		const knownOrder = createTriggers;
 		const extraTriggers = Array.from(byTrigger.keys())
 			.filter((t) => !knownOrder.includes(t))
 			.sort((a, b) => a.localeCompare(b));
@@ -349,15 +397,16 @@
 					<label class="form-field">
 						<span>Trigger</span>
 						<select bind:value={newTrigger}>
-							{#each TRIGGERS as t (t)}
-								<option value={t}>{TRIGGER_META[t].icon} {TRIGGER_META[t].label}</option>
+							{#each createTriggers as t (t)}
+								{@const meta = triggerMeta(t)}
+								<option value={t}>{meta.icon} {meta.label}</option>
 							{/each}
 						</select>
 					</label>
 					<label class="form-field">
 						<span>Surface</span>
 						<select bind:value={newSurface}>
-							{#each SURFACES as s (s)}
+							{#each createSurfaces as s (s)}
 								<option value={s}>{s}</option>
 							{/each}
 						</select>

--- a/web/src/routes/[username]/[workspace]/playbooks/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/playbooks/+page.svelte
@@ -41,8 +41,17 @@
 	}
 
 	async function loadPlaybooksCollection(ws: string) {
-		try { playbooksCollection = await api.collections.get(ws, 'playbooks'); }
-		catch { playbooksCollection = null; }
+		try {
+			const coll = await api.collections.get(ws, 'playbooks');
+			// Guard against stale responses: if the workspace changed while this
+			// request was in flight, drop the result rather than overwriting
+			// state with schema from the previous workspace.
+			if (ws !== wsSlug) return;
+			playbooksCollection = coll;
+		} catch {
+			if (ws !== wsSlug) return;
+			playbooksCollection = null;
+		}
 	}
 
 	let schemaTriggers = $derived.by<readonly string[]>(() => {

--- a/web/src/routes/[username]/[workspace]/playbooks/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/playbooks/+page.svelte
@@ -41,11 +41,17 @@
 	}
 
 	async function loadPlaybooksCollection(ws: string) {
+		// Clear any previous workspace's schema before the fetch. Until the
+		// new response lands, createTriggers/createScopes fall back to the
+		// hardcoded software defaults — correct for a workspace whose schema
+		// we have not yet observed. Prevents the in-flight window from
+		// rendering the previous workspace's vocabulary on the new page.
+		playbooksCollection = null;
 		try {
 			const coll = await api.collections.get(ws, 'playbooks');
-			// Guard against stale responses: if the workspace changed while this
-			// request was in flight, drop the result rather than overwriting
-			// state with schema from the previous workspace.
+			// Stale-response guard: if the user has since moved to another
+			// workspace, drop the result rather than overwriting state with
+			// schema from a workspace we are no longer on.
 			if (ws !== wsSlug) return;
 			playbooksCollection = coll;
 		} catch {

--- a/web/src/routes/[username]/[workspace]/playbooks/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/playbooks/+page.svelte
@@ -2,7 +2,7 @@
 	import { page } from '$app/state';
 	import { goto } from '$app/navigation';
 	import { api } from '$lib/api/client';
-	import { parseFields, itemUrlId, type Item } from '$lib/types';
+	import { parseFields, parseSchema, itemUrlId, type Collection, type Item } from '$lib/types';
 	import { toastStore } from '$lib/stores/toast.svelte';
 
 	const TRIGGERS = ['on-implement', 'on-triage', 'on-release', 'on-plan', 'on-review', 'on-deploy', 'manual'] as const;
@@ -11,6 +11,7 @@
 	let wsSlug = $derived(page.params.workspace ?? '');
 	let username = $derived(page.params.username ?? '');
 	let playbooks = $state<Item[]>([]);
+	let playbooksCollection = $state<Collection | null>(null);
 	let loading = $state(true);
 	let expandedId = $state<string | null>(null);
 	let showNewForm = $state(false);
@@ -26,7 +27,12 @@
 	let newScope = $state<string>('all');
 	let newContent = $state('');
 
-	$effect(() => { if (wsSlug) loadPlaybooks(wsSlug); });
+	$effect(() => {
+		if (wsSlug) {
+			loadPlaybooks(wsSlug);
+			loadPlaybooksCollection(wsSlug);
+		}
+	});
 	async function loadPlaybooks(ws: string) {
 		loading = true;
 		try { playbooks = await api.items.listByCollection(ws, 'playbooks', {}); }
@@ -34,24 +40,65 @@
 		finally { loading = false; }
 	}
 
+	async function loadPlaybooksCollection(ws: string) {
+		try { playbooksCollection = await api.collections.get(ws, 'playbooks'); }
+		catch { playbooksCollection = null; }
+	}
+
+	let schemaTriggers = $derived.by<readonly string[]>(() => {
+		if (!playbooksCollection) return [];
+		const schema = parseSchema(playbooksCollection);
+		const field = schema.fields.find((f) => f.key === 'trigger');
+		return field?.options ?? [];
+	});
+
+	let schemaScopes = $derived.by<readonly string[]>(() => {
+		if (!playbooksCollection) return [];
+		const schema = parseSchema(playbooksCollection);
+		const field = schema.fields.find((f) => f.key === 'scope');
+		return field?.options ?? [];
+	});
+
+	let createTriggers = $derived<readonly string[]>(
+		schemaTriggers.length > 0 ? schemaTriggers : (TRIGGERS as readonly string[])
+	);
+	let createScopes = $derived<readonly string[]>(
+		schemaScopes.length > 0 ? schemaScopes : (SCOPES as readonly string[])
+	);
+
+	// Snap the create-form selections into the effective list when it changes,
+	// so the <select> never displays a phantom value that isn't in its <option>s.
+	$effect(() => {
+		if (createTriggers.length > 0 && !createTriggers.includes(newTrigger)) {
+			newTrigger = createTriggers[0];
+		}
+	});
+	$effect(() => {
+		if (createScopes.length > 0 && !createScopes.includes(newScope)) {
+			newScope = createScopes[0];
+		}
+	});
+
 	let hasActiveFilters = $derived(searchQuery !== '' || filterTrigger !== '' || filterScope !== '');
 
 	let allTriggers = $derived.by(() => {
-		const known = TRIGGERS as readonly string[];
+		const known = createTriggers;
+		const knownSet = new Set<string>(known);
 		const discovered = new Set<string>();
 		for (const p of playbooks) {
 			const t = parseFields(p).trigger;
-			if (typeof t === 'string' && t && !known.includes(t)) discovered.add(t);
+			if (typeof t === 'string' && t && !knownSet.has(t)) discovered.add(t);
 		}
 		return [...known, ...Array.from(discovered).sort((a, b) => a.localeCompare(b))];
 	});
 
 	let allScopes = $derived.by(() => {
-		const known = SCOPES as readonly string[];
+		const known = createScopes;
+		const knownSet = new Set<string>(known);
 		const discovered = new Set<string>();
 		for (const p of playbooks) {
 			const s = parseFields(p).scope;
-			if (typeof s === 'string' && s && !known.includes(s)) discovered.add(s);
+			if (typeof s === 'string' && s && !knownSet.has(s)) discovered.add(s);
 		}
 		return [...known, ...Array.from(discovered).sort((a, b) => a.localeCompare(b))];
 	});
@@ -184,13 +231,13 @@
 						<div class="form-row">
 							<label class="form-label" for="pb-trigger">Trigger</label>
 							<select id="pb-trigger" bind:value={newTrigger} class="form-select">
-								{#each TRIGGERS as t (t)}<option value={t}>{t}</option>{/each}
+								{#each createTriggers as t (t)}<option value={t}>{t}</option>{/each}
 							</select>
 						</div>
 						<div class="form-row">
 							<label class="form-label" for="pb-scope">Scope</label>
 							<select id="pb-scope" bind:value={newScope} class="form-select">
-								{#each SCOPES as s (s)}<option value={s}>{s}</option>{/each}
+								{#each createScopes as s (s)}<option value={s}>{s}</option>{/each}
 							</select>
 						</div>
 					</div>


### PR DESCRIPTION
## Summary

Follow-up to PLAN-609. After that plan, templates ship per-domain trigger vocabularies on their Conventions and Playbooks collections (hiring: \`on-candidate-advance\`; interviewing: \`on-interview-scheduled\`; etc.), but the web UI's CREATE forms on those pages still iterated hardcoded software-only constants. Users in non-software workspaces could SEE seeded items (display tolerance was added in PR #146) but not CREATE new ones with their workspace's own vocabulary.

This PR completes the story: both the conventions page and the playbooks page now drive their create-form trigger and scope dropdowns from the actual collection schema.

### Changes

Both pages:

- Load their collection schema alongside items on mount. A failed schema load leaves the page using the hardcoded software constants as a backstop, so older servers and offline edge cases keep working.
- New \`$derived\` \`createTriggers\` / \`createSurfaces\` (conventions) and \`createTriggers\` / \`createScopes\` (playbooks) source from the schema's \`trigger\` / \`scope\` field \`options\`, falling back to the hardcoded lists when empty.
- Create-form \`<select>\` dropdowns iterate the derived lists instead of the constants.
- A \`$effect\` snaps \`newTrigger\` / \`newSurface\` / \`newScope\` into the effective list when the schema arrives, so the select never shows a phantom value.
- Filter dropdowns (\`allSurfaces\`, \`allTriggers\`, \`allScopes\`) now use the schema-derived lists as the baseline, still unioned with any trigger/scope values actually seen on loaded items — the display tolerance from PR #146 is preserved.

### What users see

- **Hiring workspace →** New Convention form's trigger dropdown: \`always, on-candidate-advance, on-loop-scheduled, on-feedback-submitted, on-offer-extended, on-close-requisition\`. Scope dropdown: \`all, sourcing, screening, interviewing, offers\`.
- **Interviewing workspace →** its own trigger/scope vocabulary surfaces identically.
- **Software workspace →** unchanged.

## Test plan

- [x] \`cd web && npm run build\` — clean
- [x] \`go build ./...\` — clean (no Go changes, just verifies the embed still compiles)
- [x] Manual: hiring workspace's New Convention form shows hiring triggers/scopes; software workspace unchanged
- [x] Fallback: if the schema call fails, the form still renders with hardcoded software defaults