### PR TITLE
feat(web): print child items as a flat checklist (TASK-624)

### DIFF
--- a/web/src/lib/components/ChildItems.svelte
+++ b/web/src/lib/components/ChildItems.svelte
@@ -248,6 +248,33 @@
 
 	{/if}
 </div>
+
+<!-- Print-only flat checklist (PLAN-620 / TASK-624). Hidden on screen;
+     visible in print via @media print rule below. The interactive
+     `.child-items` view is hidden in print so this takes its place. -->
+{#if !loading && children.length > 0}
+	<div class="print-children" aria-hidden="true">
+		<div class="print-children-header">
+			Children ({doneCount}/{totalCount} done)
+		</div>
+		<ul class="print-child-list">
+			{#each children as child (child.id)}
+				{@const childFields = parseFields(child)}
+				{@const isDone = terminal.includes(childFields.status)}
+				<li class="print-child-row" class:done={isDone}>
+					<span class="print-check">{isDone ? '[x]' : '[ ]'}</span>
+					{#if formatItemRef(child)}
+						<span class="print-child-ref">{formatItemRef(child)}</span>
+					{/if}
+					<span class="print-child-title">{child.title}</span>
+					{#if childFields.status}
+						<span class="print-child-status">({formatLabel(childFields.status)})</span>
+					{/if}
+				</li>
+			{/each}
+		</ul>
+	</div>
+{/if}
 {/if}
 
 <style>
@@ -451,6 +478,82 @@
 		color: var(--accent-red, #ef4444);
 		border-radius: var(--radius);
 		font-size: 0.85em;
+	}
+
+	/* -----------------------------------------------------------------
+	   Print-only flat checklist (PLAN-620 / TASK-624).
+	   Hidden on screen. In print:
+	     - hide the interactive `.child-items` view (chart, drag-drop
+	       groups, expand toggles, progress bar) since those rely on
+	       state and controls that have no meaning on paper;
+	     - show a plain `<ul>` of children in a simple checkbox layout:
+	         [x] TASK-621 · Title (done)
+	         [ ] TASK-622 · Title (in progress)
+	     - the block is `break-inside: avoid` where it fits so the list
+	       doesn't split across pages.
+	   ----------------------------------------------------------------- */
+	.print-children {
+		display: none;
+	}
+
+	@media print {
+		.child-items {
+			display: none !important;
+		}
+
+		.print-children {
+			display: block;
+			margin: 14pt 0 0 0;
+			padding-top: 8pt;
+			border-top: 1px solid #ccc;
+			page-break-inside: avoid;
+			break-inside: avoid;
+		}
+		.print-children-header {
+			font-size: 10pt;
+			font-weight: 600;
+			text-transform: uppercase;
+			letter-spacing: 0.05em;
+			color: #333;
+			margin: 0 0 6pt 0;
+		}
+		.print-child-list {
+			list-style: none;
+			padding: 0;
+			margin: 0;
+		}
+		.print-child-row {
+			font-size: 10pt;
+			line-height: 1.45;
+			padding: 1pt 0;
+			color: #000;
+			break-inside: avoid;
+		}
+		.print-check {
+			display: inline-block;
+			width: 15pt;
+			font-family: var(--font-mono);
+			color: #000;
+			font-weight: 500;
+		}
+		.print-child-ref {
+			font-weight: 500;
+			margin-right: 4pt;
+			color: #333;
+			font-variant-numeric: tabular-nums;
+		}
+		.print-child-title {
+			color: #000;
+		}
+		.print-child-row.done .print-child-title {
+			color: #555;
+		}
+		.print-child-status {
+			color: #777;
+			margin-left: 4pt;
+			font-size: 9pt;
+			font-style: italic;
+		}
 	}
 
 </style>

--- a/web/src/lib/components/ChildItems.svelte
+++ b/web/src/lib/components/ChildItems.svelte
@@ -252,7 +252,7 @@
 <!-- Print-only flat checklist (PLAN-620 / TASK-624). Hidden on screen;
      visible in print via @media print rule below. The interactive
      `.child-items` view is hidden in print so this takes its place. -->
-{#if !loading && children.length > 0}
+{#if !loading && !error && children.length > 0}
 	<div class="print-children" aria-hidden="true">
 		<div class="print-children-header">
 			Children ({doneCount}/{totalCount} done)


### PR DESCRIPTION
## Summary

Last task under **PLAN-620**. Render a print-friendly checklist of a parent item's children at the bottom of the printed page, replacing the interactive view (chart, drag-drop, expand toggles, progress bar) — none of which are useful on paper.

**Format:**

\`\`\`
Children (3/5 done)
  [x] TASK-621 · Base @media print stylesheet (done)
  [x] TASK-622 · Print-format the item detail page (done)
  [x] TASK-623 · Print header and footer (done)
  [ ] TASK-624 · Print child items as a flat checklist (in progress)
\`\`\`

## Implementation

Took **Option A** from the task spec:

- Render a `.print-children` block alongside the existing `.child-items` container, driven by the same reactive `children` state — no duplicate fetches.
- `display: none` on screen, `display: block` inside `@media print`.
- Hide the interactive `.child-items` in print entirely.
- Checkboxes are textual `[x]` / `[ ]` so they render in any font; a status label in parens disambiguates beyond terminal-vs-open.
- `page-break-inside: avoid` on the list and each row so the checklist doesn't split awkwardly across pages when it fits.
- Nothing extra renders when the item has no children (outer `{#if loading || children.length > 0}` already short-circuits).

## Context

Implements **TASK-624** under **PLAN-620**. This closes out PLAN-620 — all four tasks shipped.

## Test plan

- [x] \`go build ./... && go vet ./... && go test ./...\` — all pass
- [x] \`cd web && npm run build\` — clean
- [ ] Manual: open PLAN-620's own item page, Ctrl/Cmd+P, verify the 4 child tasks appear as a checklist (with 3 done after merge) and the interactive children view is absent