### PR TITLE
fix(web): drop repeating print-header, clean page-1 layout, skip empty rows (BUG-626)

### DIFF
--- a/web/src/app.css
+++ b/web/src/app.css
@@ -378,7 +378,13 @@ input:focus, textarea:focus {
 	     per page in Chromium. Margin-box counters evaluate per page
 	     correctly. */
 	@page {
-		margin: 1.25in 0.6in 1in 0.6in;
+		/* Top margin is generous-but-plain (no reserved header strip):
+		   the page-1 document header lives in normal flow via
+		   `.title-row` + `.meta-info`, so subsequent pages start at
+		   this margin with no overlap risk. Bottom margin reserves
+		   space for the fixed footer + the `@bottom-right` page number.
+		   See BUG-626 for why the repeating header was dropped. */
+		margin: 0.6in 0.6in 1in 0.6in;
 		@bottom-right {
 			content: "Page " counter(page);
 			font-family: var(--font-ui);

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -24,7 +24,6 @@
 	import { authStore } from '$lib/stores/auth.svelte';
 	import { starredStore } from '$lib/stores/starred.svelte';
 	import { titleStore } from '$lib/stores/title.svelte';
-	import { workspaceStore } from '$lib/stores/workspace.svelte';
 
 	type RelationshipEntry = {
 		key: string;
@@ -645,22 +644,14 @@
 {:else if error}
 	<div class="center-message">{error}</div>
 {:else if item && collection}
-	<!-- Print-only header/footer (PLAN-620 / TASK-623). Hidden on screen,
-	     fixed-positioned in print so they repeat on every page. Page number
-	     injected via CSS `counter(page)` in ::after. -->
-	<div class="print-header" aria-hidden="true">
-		<span class="print-header-ws">{workspaceStore.current?.name ?? ''}</span>
-		<span class="print-sep">·</span>
-		<span class="print-header-coll">{collection.icon ?? ''} {collection.name}</span>
-		<span class="print-sep">·</span>
-		<span class="print-header-ref">{formatItemRef(item) || item.title}</span>
-	</div>
+	<!-- Print-only footer (hidden on screen, fixed-positioned in print).
+	     The repeating print-header was removed as part of BUG-626: a
+	     clean page-1-only document header is rendered inside the normal
+	     flow by `.title-row` + `.meta-info`. Page number comes from
+	     `@page { @bottom-right ... }` in app.css. -->
 	<div class="print-footer" aria-hidden="true">
 		<span class="print-footer-date">Printed {printDate}</span>
 		<span class="print-footer-url">{printUrl}</span>
-		<!-- Page number is rendered by `@page { @bottom-right ... }` in
-		     app.css (counter(page) must live in a margin-box to
-		     increment per page in Chromium). See BUG-625. -->
 	</div>
 
 	<div class="item-page">
@@ -841,12 +832,16 @@
 							</div>
 						</div>
 					{:else}
-						<div class="field-row">
+						{@const rawFieldValue = fieldValue(field.key)}
+						{@const isFieldEmpty = rawFieldValue == null
+							|| rawFieldValue === ''
+							|| (Array.isArray(rawFieldValue) && rawFieldValue.length === 0)}
+						<div class="field-row" class:print-empty={isFieldEmpty}>
 							<span class="field-label">{field.label}</span>
 							<div class="field-value">
 								<FieldEditor
 									{field}
-									value={fieldValue(field.key)}
+									value={rawFieldValue}
 									onchange={(v) => updateField(field.key, v)}
 								/>
 							</div>
@@ -1766,10 +1761,9 @@
 		}
 	}
 
-	/* Print header + footer (PLAN-620 / TASK-623) — hidden on screen,
-	   fixed-positioned and visible only in print. Shown in @media print
-	   block below. */
-	.print-header,
+	/* Print footer (fixed-positioned, visible only in print). The
+	   page-1 document header lives in normal flow via `.title-row` +
+	   `.meta-info` — no repeating print header. See BUG-626. */
 	.print-footer {
 		display: none;
 	}
@@ -1805,27 +1799,36 @@
 			display: none !important;
 		}
 
-		/* Title row — large, plain text, no button affordance. */
+		/* Title row — page-1 document header block (BUG-626).
+		   Title on the left, issue ref on the right, both aligned to
+		   the baseline of the title's first line. `.title` can wrap
+		   naturally; `.item-ref` stays compact on the right. */
 		.title-row {
-			display: block;
+			display: flex;
+			justify-content: space-between;
+			align-items: baseline;
+			gap: 12pt;
 			margin: 0 0 4pt 0;
 			padding: 0;
 			border: none;
 		}
 		.title-row .item-ref {
-			display: inline-block;
+			flex: 0 0 auto;
 			font-size: 10pt;
 			font-weight: 500;
 			color: #555;
-			margin: 0 8pt 0 0;
+			margin: 0;
 			padding: 0;
 			background: transparent;
 			border: none;
 			letter-spacing: 0.03em;
+			font-variant-numeric: tabular-nums;
+			white-space: nowrap;
 		}
 		.title-row .title,
 		.title-row .title-input {
-			display: inline;
+			flex: 1 1 auto;
+			display: block;
 			font-size: 20pt;
 			font-weight: 700;
 			color: #000;
@@ -1848,13 +1851,16 @@
 			white-space: pre-wrap;
 		}
 
-		/* Meta info (created / updated by). */
+		/* Meta info subtitle (created / updated by). Border-bottom
+		   separates the page-1 document header block from the
+		   properties card below. BUG-626. */
 		.meta-info {
 			font-size: 9pt;
 			color: #555;
 			margin: 0 0 12pt 0;
-			padding: 0;
+			padding: 0 0 10pt 0;
 			border: none;
+			border-bottom: 1px solid #ccc;
 			display: block;
 		}
 		.meta-info .meta-sep { color: #888; }
@@ -1924,6 +1930,13 @@
 			border: none !important;
 			font-size: 10pt;
 			align-items: baseline;
+		}
+		/* Non-computed fields whose raw value is blank (null / "" / []) —
+		   skip the whole row in print so we don't print a label with no
+		   value (e.g. an unset "Category"). Flag applied at the template
+		   level because :empty can't see the FieldEditor child. BUG-626. */
+		.field-row.print-empty {
+			display: none !important;
 		}
 		.field-label {
 			color: #555 !important;
@@ -2022,20 +2035,20 @@
 		}
 
 		/* -------------------------------------------------------------
-		   TASK-623 — rendered header / footer on every printed page.
-		   @page margins + page number counter live in app.css (single
-		   source of truth; see BUG-625 for why). This block owns only
-		   the fixed-positioned header / footer elements that sit in the
-		   carved-out margin strips.
+		   TASK-623 / BUG-626 — rendered footer on every printed page.
+		   The repeating print-header was removed as part of BUG-626;
+		   only the fixed footer (date + URL) remains. Page number
+		   lives in `@page @bottom-right` (see app.css). @page margins
+		   are owned globally in app.css.
 		   ------------------------------------------------------------- */
-		.print-header,
 		.print-footer {
 			display: flex;
 			position: fixed;
 			left: 0;
 			right: 0;
+			bottom: 0;
 			box-sizing: border-box;
-			padding: 10pt 0.6in;
+			padding: 10pt 1.2in 10pt 0.6in;
 			background: #fff;
 			color: #555;
 			font-size: 9pt;
@@ -2043,41 +2056,6 @@
 			gap: 6pt;
 			align-items: center;
 			z-index: 1000;
-		}
-
-		/* Reserve space on the right of the footer for the `@page
-		   @bottom-right` page-number margin box so its content and the
-		   date/URL don't overlap. */
-		.print-footer {
-			padding-right: 1.2in;
-		}
-
-		.print-header {
-			top: 0;
-			border-bottom: 1px solid #ccc;
-			justify-content: flex-start;
-			flex-wrap: wrap;
-		}
-		.print-header-ws {
-			font-weight: 600;
-			color: #333;
-		}
-		.print-header-coll {
-			color: #555;
-		}
-		.print-header-ref {
-			margin-left: auto;
-			font-weight: 500;
-			color: #333;
-			font-variant-numeric: tabular-nums;
-			letter-spacing: 0.02em;
-		}
-		.print-sep {
-			color: #999;
-		}
-
-		.print-footer {
-			bottom: 0;
 			border-top: 1px solid #ccc;
 			justify-content: space-between;
 		}

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -1800,12 +1800,14 @@
 		}
 
 		/* Title row — page-1 document header block (BUG-626).
-		   Title on the left, issue ref on the right, both aligned to
-		   the baseline of the title's first line. `.title` can wrap
-		   naturally; `.item-ref` stays compact on the right. */
+		   DOM order is [item-ref, title]; in print we want [title, ref]
+		   visually, so `order` flips the display sequence without
+		   touching the template. Title takes the remaining width and
+		   wraps naturally; `.item-ref` stays compact on the right,
+		   baseline-aligned to the title's first line. */
 		.title-row {
 			display: flex;
-			justify-content: space-between;
+			justify-content: flex-start;
 			align-items: baseline;
 			gap: 12pt;
 			margin: 0 0 4pt 0;
@@ -1813,11 +1815,12 @@
 			border: none;
 		}
 		.title-row .item-ref {
+			order: 2;
 			flex: 0 0 auto;
 			font-size: 10pt;
 			font-weight: 500;
 			color: #555;
-			margin: 0;
+			margin-left: auto;
 			padding: 0;
 			background: transparent;
 			border: none;
@@ -1827,6 +1830,7 @@
 		}
 		.title-row .title,
 		.title-row .title-input {
+			order: 1;
 			flex: 1 1 auto;
 			display: block;
 			font-size: 20pt;


### PR DESCRIPTION
## Summary

Follow-up to **BUG-625**. Real-print testing showed the repeating fixed-position `.print-header` is fragile even with a generous `@page` top margin — Chromium's pagination + fixed-element interaction overlapped the title on page 1, and there's no clean way to coordinate with page-break behavior cross-browser. Verified locally before shipping.

Replace the repeating header with a page-1 document header in **normal flow**, and simplify.

## Layout after this PR

\`\`\`
Title of the item                                 IDEA-591
Created 1d ago by user · Updated 1d ago
─────────────────────────────────────────────────────────
PROPERTIES
Status          New
Impact          —
ASSIGNMENT
Assigned to     Unassigned
Role            No role

<body markdown>

─────────────────────────────────────────────────────────
Printed Apr 18 · http://…/dave/docapp/ideas/IDEA-591         Page 1
\`\`\`

## Changes

**Template (`+page.svelte`)**
- Delete `.print-header` entirely + drop `workspaceStore` import.
- Tag non-computed field-rows with `class:print-empty={isFieldEmpty}` when raw value is `null` / `""` / `[]`. Flag at template level because `:empty` can't see FieldEditor children.

**Styles (`+page.svelte` `@media print`)**
- `.title-row` → flex row: title left (20pt, wraps), issue ref right (10pt, tabular-nums, nowrap), baseline-aligned.
- `.meta-info` gets a 1px bottom border as the header/properties divider.
- `.field-row.print-empty { display: none !important }`.
- Delete all `.print-header*` rules + the shared header+footer rule. `.print-footer` stands alone.

**Global (`app.css`)**
- `@page` top margin `1.25in → 0.6in` (no reserved header strip). Bottom stays `1in` for fixed footer + `@bottom-right` page counter.

## Context

Fixes **BUG-626**. Follow-up to **BUG-625**, **PLAN-620**, **IDEA-581**.

## Test plan

- [x] \`go build ./... && go vet ./... && go test ./...\` — all pass
- [x] \`cd web && npm run build\` — clean
- [x] Local Ctrl+P print preview in Chromium — verified clean layout, correct page number, no chevrons, empty "Category" row hidden