### PR TITLE
feat(web): inline + New and Manage affordances in QuickActionsMenu (TASK-629)

### DIFF
--- a/web/src/lib/components/collections/EditCollectionModal.svelte
+++ b/web/src/lib/components/collections/EditCollectionModal.svelte
@@ -26,11 +26,12 @@
 		open: boolean;
 		collection: Collection;
 		wsSlug: string;
+		initialSection?: 'general' | 'fields' | 'display' | 'actions';
 		onupdated: (updated?: Collection) => void;
 		onclose: () => void;
 	}
 
-	let { open, collection, wsSlug, onupdated, onclose }: Props = $props();
+	let { open, collection, wsSlug, initialSection, onupdated, onclose }: Props = $props();
 
 	let confirmArchive = $state(false);
 	let archiving = $state(false);
@@ -193,7 +194,7 @@
 			}));
 			newFields = [];
 			error = '';
-			activeTab = 'general';
+			activeTab = initialSection ?? 'general';
 			confirmArchive = false;
 
 			// Sync display settings

--- a/web/src/lib/components/common/QuickActionsMenu.svelte
+++ b/web/src/lib/components/common/QuickActionsMenu.svelte
@@ -192,6 +192,13 @@
 		// swipe-down) — skip the outside-click handler so it doesn't race.
 		if (isMobile) return;
 		const target = e.target as HTMLElement;
+		if (!target) return;
+		// The EmojiPickerButton portals its dropdown to document.body (or the
+		// nearest <dialog>); clicks inside the portal (.epb-dropdown) or on
+		// the emoji trigger itself (.emoji-picker-button) should NOT close
+		// the menu, or the in-progress emoji selection is lost before the
+		// bound value can update.
+		if (target.closest('.epb-dropdown') || target.closest('.emoji-picker-button')) return;
 		if (!target.closest('.quick-actions-menu')) {
 			open = false;
 			resetCreateForm();

--- a/web/src/lib/components/common/QuickActionsMenu.svelte
+++ b/web/src/lib/components/common/QuickActionsMenu.svelte
@@ -1,21 +1,45 @@
 <script lang="ts">
 	import type { QuickAction, Item, Collection } from '$lib/types';
-	import { parseFields, formatItemRef } from '$lib/types';
+	import { parseFields, formatItemRef, parseSettings } from '$lib/types';
+	import { api } from '$lib/api/client';
 	import { toastStore } from '$lib/stores/toast.svelte';
 	import BottomSheet from '$lib/components/common/BottomSheet.svelte';
+	import EmojiPickerButton from '$lib/components/common/EmojiPickerButton.svelte';
 
 	interface Props {
 		actions: QuickAction[];
 		item?: Item | null;
 		collection: Collection;
 		scope: 'item' | 'collection';
+		wsSlug: string;
+		canEdit?: boolean;
+		onmanage?: () => void;
+		oncollectionupdated?: (c: Collection) => void;
 	}
 
-	let { actions, item = null, collection, scope }: Props = $props();
+	let {
+		actions,
+		item = null,
+		collection,
+		scope,
+		wsSlug,
+		canEdit = false,
+		onmanage,
+		oncollectionupdated
+	}: Props = $props();
 
 	let open = $state(false);
 	let alignLeft = $state(false);
 	let triggerEl = $state<HTMLButtonElement | null>(null);
+
+	// ── Inline create-form state ─────────────────────────────────────────
+	// `showCreateForm` collapses the action list and swaps in the inline
+	// form when the user clicks "+ New quick action" in the footer.
+	let showCreateForm = $state(false);
+	let newLabel = $state('');
+	let newPrompt = $state('');
+	let newIcon = $state('');
+	let saving = $state(false);
 
 	let filtered = $derived(actions.filter((a) => a.scope === scope));
 
@@ -92,6 +116,58 @@
 		open = false;
 	}
 
+	function resetCreateForm() {
+		showCreateForm = false;
+		newLabel = '';
+		newPrompt = '';
+		newIcon = '';
+	}
+
+	function handleOpenCreateForm() {
+		showCreateForm = true;
+	}
+
+	function handleManage() {
+		open = false;
+		resetCreateForm();
+		onmanage?.();
+	}
+
+	async function handleSaveNewAction() {
+		const label = newLabel.trim();
+		const prompt = newPrompt.trim();
+		if (!label || !prompt || saving) return;
+		saving = true;
+		try {
+			const icon = newIcon.trim();
+			const newAction: QuickAction = {
+				label,
+				prompt,
+				scope,
+				...(icon ? { icon } : {})
+			};
+			const settings = parseSettings(collection);
+			const nextSettings = {
+				...settings,
+				quick_actions: [...(settings.quick_actions ?? []), newAction]
+			};
+			const updated = await api.collections.update(wsSlug, collection.slug, {
+				settings: JSON.stringify(nextSettings)
+			});
+			toastStore.show('Saved', 'success');
+			oncollectionupdated?.(updated);
+			resetCreateForm();
+			open = false;
+		} catch (err) {
+			toastStore.show(
+				err instanceof Error ? err.message : 'Failed to save quick action',
+				'error'
+			);
+		} finally {
+			saving = false;
+		}
+	}
+
 	function handleTriggerClick(e: MouseEvent) {
 		e.stopPropagation();
 		const nextOpen = !open;
@@ -103,6 +179,11 @@
 			// right-anchored 200px dropdown would clip — switch to left-anchored.
 			alignLeft = rect.left < 220;
 		}
+		if (!nextOpen) {
+			// Closing via trigger toggles the form off too so the next open
+			// returns to the action list.
+			resetCreateForm();
+		}
 		open = nextOpen;
 	}
 
@@ -113,25 +194,82 @@
 		const target = e.target as HTMLElement;
 		if (!target.closest('.quick-actions-menu')) {
 			open = false;
+			resetCreateForm();
 		}
+	}
+
+	function handleBottomSheetClose() {
+		open = false;
+		resetCreateForm();
 	}
 </script>
 
 <svelte:window onclick={handleWindowClick} />
 
-{#snippet actionList()}
-	{#each filtered as action (action.label)}
-		<button class="action-item" onclick={() => handleAction(action)}>
-			{#if action.icon}
-				<span class="action-icon">{action.icon}</span>
-			{/if}
-			<span class="action-label">{action.label}</span>
-		</button>
-	{/each}
-	<div class="dropdown-tagline">Copy a prompt to your agent</div>
+{#snippet createForm()}
+	<div class="create-form">
+		<div class="qa-row">
+			<EmojiPickerButton bind:value={newIcon} placeholder="+" size="sm" />
+			<input
+				class="qa-label-input"
+				type="text"
+				placeholder="Action label"
+				bind:value={newLabel}
+			/>
+		</div>
+		<textarea
+			class="qa-prompt-input"
+			placeholder="/pad ..."
+			rows="3"
+			bind:value={newPrompt}
+		></textarea>
+		<div class="qa-help">
+			Template variables: {'{ref}'} {'{title}'} {'{status}'} {'{priority}'} {'{collection}'} {'{content}'} {'{fields}'}
+		</div>
+		<div class="qa-actions">
+			<button class="qa-btn qa-btn-cancel" type="button" onclick={resetCreateForm}>
+				Cancel
+			</button>
+			<button
+				class="qa-btn qa-btn-save"
+				type="button"
+				onclick={handleSaveNewAction}
+				disabled={!newLabel.trim() || !newPrompt.trim() || saving}
+			>
+				{saving ? 'Saving...' : 'Save'}
+			</button>
+		</div>
+	</div>
 {/snippet}
 
-{#if filtered.length > 0}
+{#snippet actionList()}
+	{#if showCreateForm}
+		{@render createForm()}
+	{:else}
+		{#each filtered as action (action.label)}
+			<button class="action-item" onclick={() => handleAction(action)}>
+				{#if action.icon}
+					<span class="action-icon">{action.icon}</span>
+				{/if}
+				<span class="action-label">{action.label}</span>
+			</button>
+		{/each}
+		<div class="dropdown-tagline">Copy a prompt to your agent</div>
+		{#if canEdit}
+			<div class="footer-divider"></div>
+			<button class="action-item footer-row" type="button" onclick={handleOpenCreateForm}>
+				<span class="action-icon">+</span>
+				<span class="action-label">New quick action</span>
+			</button>
+			<button class="action-item footer-row" type="button" onclick={handleManage}>
+				<span class="action-icon">&#9881;</span>
+				<span class="action-label">Manage actions</span>
+			</button>
+		{/if}
+	{/if}
+{/snippet}
+
+{#if filtered.length > 0 || canEdit}
 	<div class="quick-actions-menu">
 		<button
 			bind:this={triggerEl}
@@ -143,7 +281,7 @@
 		</button>
 
 		{#if isMobile}
-			<BottomSheet open={open} onclose={() => (open = false)} title="Quick actions">
+			<BottomSheet {open} onclose={handleBottomSheetClose} title="Quick actions">
 				{@render actionList()}
 			</BottomSheet>
 		{:else if open}
@@ -181,7 +319,7 @@
 		top: 100%;
 		right: 0;
 		margin-top: var(--space-1);
-		min-width: 200px;
+		min-width: 240px;
 		/* Defensive cap so the popover can never overflow the viewport
 		   horizontally, even if trigger placement or zoom produces an
 		   edge case we didn't anticipate. */
@@ -235,5 +373,127 @@
 		color: var(--text-muted);
 		border-top: 1px solid var(--border);
 		text-align: center;
+	}
+
+	/* ── Footer rows (gated by canEdit) ─────────────────────────────── */
+
+	.footer-divider {
+		height: 1px;
+		background: var(--border);
+		margin: var(--space-1) 0;
+	}
+
+	.footer-row {
+		color: var(--text-secondary);
+	}
+
+	.footer-row:hover {
+		color: var(--text-primary);
+		background: var(--bg-tertiary);
+	}
+
+	/* ── Inline create form ─────────────────────────────────────────── */
+
+	.create-form {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-2);
+		padding: var(--space-3);
+	}
+
+	.qa-row {
+		display: flex;
+		align-items: center;
+		gap: var(--space-2);
+	}
+
+	.qa-label-input {
+		flex: 1;
+		min-width: 0;
+		padding: var(--space-2) var(--space-3);
+		background: var(--bg-tertiary);
+		border: 1px solid transparent;
+		border-radius: var(--radius);
+		font-size: 0.85em;
+		color: var(--text-primary);
+	}
+
+	.qa-label-input:hover {
+		border-color: var(--border);
+	}
+
+	.qa-label-input:focus {
+		border-color: var(--accent-blue);
+		outline: none;
+	}
+
+	.qa-prompt-input {
+		width: 100%;
+		padding: var(--space-2) var(--space-3);
+		background: var(--bg-tertiary);
+		border: 1px solid transparent;
+		border-radius: var(--radius);
+		font-family: var(--font-mono);
+		font-size: 0.8em;
+		color: var(--text-primary);
+		resize: vertical;
+		min-height: 60px;
+	}
+
+	.qa-prompt-input:hover {
+		border-color: var(--border);
+	}
+
+	.qa-prompt-input:focus {
+		border-color: var(--accent-blue);
+		outline: none;
+	}
+
+	.qa-help {
+		font-size: 0.7em;
+		color: var(--text-muted);
+		line-height: 1.4;
+		word-break: break-word;
+	}
+
+	.qa-actions {
+		display: flex;
+		justify-content: flex-end;
+		gap: var(--space-2);
+		margin-top: var(--space-1);
+	}
+
+	.qa-btn {
+		padding: var(--space-1) var(--space-3);
+		border-radius: var(--radius);
+		font-size: 0.8em;
+		cursor: pointer;
+		border: 1px solid var(--border);
+	}
+
+	.qa-btn-cancel {
+		background: var(--bg-tertiary);
+		color: var(--text-secondary);
+	}
+
+	.qa-btn-cancel:hover {
+		background: var(--bg-secondary);
+		color: var(--text-primary);
+	}
+
+	.qa-btn-save {
+		background: var(--accent-blue);
+		border-color: var(--accent-blue);
+		color: #fff;
+		font-weight: 500;
+	}
+
+	.qa-btn-save:hover:not(:disabled) {
+		filter: brightness(1.1);
+	}
+
+	.qa-btn-save:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
 	}
 </style>

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -867,7 +867,13 @@
 								editCollectionSection = 'actions';
 								editCollectionOpen = true;
 							}}
-							oncollectionupdated={() => {
+							oncollectionupdated={(updated) => {
+								// Apply the returned collection immediately so a fast
+								// follow-up save reads fresh settings.quick_actions
+								// instead of stale ones — without this, a second
+								// save can overwrite the first before loadCollection
+								// resolves.
+								collection = updated;
 								loadCollection(wsSlug, collSlug, showArchived);
 							}}
 						/>

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -43,6 +43,7 @@
 
 	let shareDialogOpen = $state(false);
 	let editCollectionOpen = $state(false);
+	let editCollectionSection = $state<'general' | 'fields' | 'display' | 'actions' | undefined>(undefined);
 	let workspaceMembers = $state<{ user_id: string; role: string }[]>([]);
 	let searchInputEl = $state<HTMLInputElement>();
 	let searchResultIds = $state<Set<string> | null>(null);
@@ -855,8 +856,21 @@
 						<span class="save-view-label">Save View</span>
 					</button>
 
-					{#if quickActions.length > 0 && collection}
-						<QuickActionsMenu actions={quickActions} {collection} scope="collection" />
+					{#if collection && (quickActions.length > 0 || isOwner)}
+						<QuickActionsMenu
+							actions={quickActions}
+							{collection}
+							scope="collection"
+							{wsSlug}
+							canEdit={isOwner}
+							onmanage={() => {
+								editCollectionSection = 'actions';
+								editCollectionOpen = true;
+							}}
+							oncollectionupdated={() => {
+								loadCollection(wsSlug, collSlug, showArchived);
+							}}
+						/>
 					{/if}
 
 					{#if isOwner}
@@ -1039,6 +1053,7 @@
 		bind:open={editCollectionOpen}
 		{collection}
 		{wsSlug}
+		initialSection={editCollectionSection}
 		onupdated={(updated) => {
 			collectionStore.loadCollections(wsSlug);
 			if (updated && updated.slug !== collSlug) {
@@ -1047,7 +1062,10 @@
 				loadCollection(wsSlug, collSlug, showArchived);
 			}
 		}}
-		onclose={() => { editCollectionOpen = false; }}
+		onclose={() => {
+			editCollectionOpen = false;
+			editCollectionSection = undefined;
+		}}
 	/>
 {/if}
 

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -1078,6 +1078,14 @@
 				}
 				collection = updated;
 				collectionStore.loadCollections(wsSlug);
+				// If the owner renamed the collection, its slug may have
+				// changed. The current `/[collection]/[slug]` URL still
+				// points at the old slug and subsequent loadData() calls
+				// (which fetch by collSlug) would 404. Navigate to the
+				// new slug while preserving the item slug.
+				if (updated.slug !== collSlug && itemSlug) {
+					void goto(`/${username}/${wsSlug}/${updated.slug}/${itemSlug}`);
+				}
 			}}
 			onclose={() => {
 				editCollectionOpen = false;

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -1068,7 +1068,15 @@
 			{wsSlug}
 			initialSection={editCollectionSection}
 			onupdated={(updated) => {
-				if (updated) collection = updated;
+				if (!updated) {
+					// Archive case — the collection is gone. Navigate away from
+					// this now-invalid item route rather than leaving the user
+					// with stale state that would hit deleted resources.
+					collectionStore.loadCollections(wsSlug);
+					void goto(`/${username}/${wsSlug}`);
+					return;
+				}
+				collection = updated;
 				collectionStore.loadCollections(wsSlug);
 			}}
 			onclose={() => {

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -1082,10 +1082,19 @@
 				// changed. The current `/[collection]/[slug]` URL still
 				// points at the old slug and subsequent loadData() calls
 				// (which fetch by collSlug) would 404. Navigate to the
-				// new slug while preserving the item slug.
+				// new slug while preserving the item slug. The new route
+				// will trigger its own loadData() via the $effect on
+				// wsSlug/collSlug/itemSlug, so no explicit refresh here.
 				if (updated.slug !== collSlug && itemSlug) {
 					void goto(`/${username}/${wsSlug}/${updated.slug}/${itemSlug}`);
+					return;
 				}
+				// Non-navigating update: schema or field mappings may have
+				// changed (rename / migration), so reload the item so fields
+				// reflect the new shape. Without this, a subsequent
+				// updateField() would write stale fields JSON back and
+				// clobber migrated values.
+				void loadData();
 			}}
 			onclose={() => {
 				editCollectionOpen = false;

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -19,6 +19,7 @@
 	import type { Item, Collection, CollectionSettings, QuickAction, ItemLink, AgentRole } from '$lib/types';
 	import { parseFields, parseSchema, parseSettings, formatItemRef, getTerminalOptions } from '$lib/types';
 	import QuickActionsMenu from '$lib/components/common/QuickActionsMenu.svelte';
+	import EditCollectionModal from '$lib/components/collections/EditCollectionModal.svelte';
 	import ShareDialog from '$lib/components/ShareDialog.svelte';
 	import { copyToClipboard } from '$lib/utils/clipboard';
 	import { authStore } from '$lib/stores/auth.svelte';
@@ -84,6 +85,8 @@
 	let itemLinks = $state<ItemLink[]>([]);
 	let workspaceMembers = $state<{ user_id: string; user_name: string; user_email: string; role: string }[]>([]);
 	let shareDialogOpen = $state(false);
+	let editCollectionOpen = $state(false);
+	let editCollectionSection = $state<'general' | 'fields' | 'display' | 'actions' | undefined>(undefined);
 	let agentRoles = $state<AgentRole[]>([]);
 	let childItemIds = $state<Set<string>>(new Set());
 	let hasChildren = $state(false);
@@ -726,8 +729,22 @@
 			>
 				{starredStore.isStarred(item.id) ? '★' : '☆'}
 			</button>
-			{#if quickActions.length > 0 && collection}
-				<QuickActionsMenu actions={quickActions} {item} {collection} scope="item" />
+			{#if collection && (quickActions.length > 0 || isOwner)}
+				<QuickActionsMenu
+					actions={quickActions}
+					{item}
+					{collection}
+					scope="item"
+					{wsSlug}
+					canEdit={isOwner}
+					onmanage={() => {
+						editCollectionSection = 'actions';
+						editCollectionOpen = true;
+					}}
+					oncollectionupdated={(updated) => {
+						collection = updated;
+					}}
+				/>
 			{/if}
 			<button
 				class="action-btn"
@@ -1041,6 +1058,23 @@
 			targetSlug={item.slug}
 			targetName={formatItemRef(item) || item.title}
 			bind:open={shareDialogOpen}
+		/>
+	{/if}
+
+	{#if isOwner && collection}
+		<EditCollectionModal
+			bind:open={editCollectionOpen}
+			{collection}
+			{wsSlug}
+			initialSection={editCollectionSection}
+			onupdated={(updated) => {
+				if (updated) collection = updated;
+				collectionStore.loadCollections(wsSlug);
+			}}
+			onclose={() => {
+				editCollectionOpen = false;
+				editCollectionSection = undefined;
+			}}
 		/>
 	{/if}
 {/if}


### PR DESCRIPTION
## Summary

Adds discovery paths for creating and editing quick actions directly from the menu, closing Problem 2 in IDEA-493. The editor already existed inside `EditCollectionModal` but was effectively invisible from the menu surface — users had to know to open collection settings, find the Quick Actions tab, and edit from there.

## Changes

### `QuickActionsMenu.svelte`
Gated behind a new `canEdit` prop:
- **+ New quick action** footer row → toggles an inline form (icon picker + label + monospace prompt input + template-variable help line). On save, PATCHes the collection via `api.collections.update`, appends the new action to `settings.quick_actions`, and fires `oncollectionupdated` so the parent reloads. Toast on success / error.
- **⚙️ Manage actions** footer row → fires `onmanage`, which the parent wires to open `EditCollectionModal` deep-linked to the Quick Actions tab.
- Trigger button now stays visible for editors even when no actions exist yet, so they can bootstrap the first action without round-tripping through collection settings.

New props: `wsSlug: string`, `canEdit?: boolean`, `onmanage?: () => void`, `oncollectionupdated?: (c: Collection) => void`.

### `EditCollectionModal.svelte`
New `initialSection?: 'general' | 'fields' | 'display' | 'actions'` prop. When set, opens the modal directly to that tab instead of the default `'general'`. Default behavior unchanged when prop is omitted.

### Route wiring
- `[collection]/+page.svelte` — passes new props, tracks `editCollectionSection` for deep-linking.
- `[collection]/[slug]/+page.svelte` — same wiring, plus imports + renders `EditCollectionModal` inline (it wasn't previously rendered on item detail pages) so the "Manage actions" link works from item pages too.

## Context

Implements `TASK-629` under `IDEA-493`. Completes the three-task arc started in PR #158 (TASK-627 — BottomSheet primitive) and PR #159 (TASK-628 — mobile sheet + viewport-aware positioning).

## Test plan

- [x] `go build ./...` / `go vet ./...` / `go test ./...` — clean
- [x] `cd web && npm run build` — clean (15.2s)
- [x] Svelte MCP `svelte-autofixer` — zero blocking issues
- [ ] Manual: create a new quick action from the inline form on both collection list and item detail pages
- [ ] Manual: "Manage actions" opens the modal to the Quick Actions tab directly
- [ ] Manual: non-owners don't see the footer affordances
- [ ] Manual: works inside mobile bottom sheet and desktop popover