### PR TITLE
feat(web): FilterBar parent filter renders as BottomSheet on mobile (TASK-635)

### DIFF
--- a/web/src/lib/components/collections/FilterBar.svelte
+++ b/web/src/lib/components/collections/FilterBar.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import type { Collection } from '$lib/types';
 	import { parseSchema } from '$lib/types';
+	import BottomSheet from '$lib/components/common/BottomSheet.svelte';
 
 	interface Props {
 		collection: Collection;
@@ -33,9 +34,9 @@
 
 	let hasParentFilter = $derived(Object.keys(relationLabels).length > 0);
 	let activeParent = $derived(activeFilters.parent ?? '');
+	let activeParentLabel = $derived(activeParent ? (relationLabels[activeParent] ?? activeParent) : 'All plans');
 
-	function setParentFilter(e: Event) {
-		const value = (e.target as HTMLSelectElement).value;
+	function setParentFilterValue(value: string) {
 		const next = { ...activeFilters };
 		if (value === '') {
 			delete next.parent;
@@ -45,6 +46,11 @@
 		onFilterChange(next);
 	}
 
+	function setParentFilter(e: Event) {
+		const value = (e.target as HTMLSelectElement).value;
+		setParentFilterValue(value);
+	}
+
 	function handleSearchInput(e: Event) {
 		const target = e.target as HTMLInputElement;
 		onSearchChange(target.value);
@@ -52,6 +58,33 @@
 
 	function formatLabel(value: string): string {
 		return value.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+	}
+
+	// ── Viewport detection ───────────────────────────────────────────────
+	// On mobile the parent filter is rendered as a chip that opens a
+	// BottomSheet of options; on desktop the native <select> is kept
+	// because it's compact inside the toolbar and familiar.
+	let isMobile = $state(false);
+	$effect(() => {
+		if (typeof window === 'undefined') return;
+		const mq = window.matchMedia('(max-width: 639.98px)');
+		isMobile = mq.matches;
+		const onChange = (e: MediaQueryListEvent) => {
+			isMobile = e.matches;
+		};
+		mq.addEventListener('change', onChange);
+		return () => mq.removeEventListener('change', onChange);
+	});
+
+	let parentSheetOpen = $state(false);
+
+	function openParentSheet() {
+		parentSheetOpen = true;
+	}
+
+	function handleParentSheetSelect(value: string) {
+		setParentFilterValue(value);
+		parentSheetOpen = false;
 	}
 </script>
 
@@ -74,12 +107,53 @@
 	{/if}
 
 	{#if hasParentFilter}
-		<select class="parent-filter" value={activeParent} onchange={setParentFilter}>
-			<option value="">All plans</option>
-			{#each Object.entries(relationLabels) as [id, label] (id)}
-				<option value={id}>{label}</option>
-			{/each}
-		</select>
+		{#if isMobile}
+			<!--
+				Mobile: render the parent filter as a chip + BottomSheet to keep
+				option labels readable full-width and avoid the native <select>'s
+				inconsistent mobile styling.
+			-->
+			<button class="parent-chip" type="button" onclick={openParentSheet}>
+				<span class="parent-chip-label">{activeParentLabel}</span>
+				<span class="parent-chip-caret" aria-hidden="true">▾</span>
+			</button>
+			{#if parentSheetOpen}
+				<!--
+					Gate the sheet on `parentSheetOpen` so BottomSheet's global
+					keydown listener isn't mounted when the filter is idle.
+					Same gate-on-open pattern as ReactionPicker/Move menu.
+				-->
+				<BottomSheet
+					open={parentSheetOpen}
+					onclose={() => (parentSheetOpen = false)}
+					title="Filter by plan"
+				>
+					<div class="parent-sheet-body">
+						<button
+							class="parent-sheet-option"
+							class:active={activeParent === ''}
+							type="button"
+							onclick={() => handleParentSheetSelect('')}
+						>All plans</button>
+						{#each Object.entries(relationLabels) as [id, label] (id)}
+							<button
+								class="parent-sheet-option"
+								class:active={activeParent === id}
+								type="button"
+								onclick={() => handleParentSheetSelect(id)}
+							>{label}</button>
+						{/each}
+					</div>
+				</BottomSheet>
+			{/if}
+		{:else}
+			<select class="parent-filter" value={activeParent} onchange={setParentFilter}>
+				<option value="">All plans</option>
+				{#each Object.entries(relationLabels) as [id, label] (id)}
+					<option value={id}>{label}</option>
+				{/each}
+			</select>
+		{/if}
 	{/if}
 
 	<div class="search-wrapper">
@@ -148,6 +222,66 @@
 	.parent-filter:focus {
 		border-color: var(--accent-blue);
 		outline: none;
+	}
+
+	/* Mobile: chip trigger for the parent filter. Styled to match the
+	   segmented filter buttons so it reads as part of the same toolbar. */
+	.parent-chip {
+		display: inline-flex;
+		align-items: center;
+		gap: var(--space-1);
+		background: var(--bg-secondary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+		padding: var(--space-1) var(--space-3);
+		font-size: 0.82em;
+		color: var(--text-primary);
+		cursor: pointer;
+		max-width: 220px;
+	}
+
+	.parent-chip-label {
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.parent-chip-caret {
+		color: var(--text-muted);
+		font-size: 0.9em;
+		line-height: 1;
+	}
+
+	.parent-chip:hover {
+		border-color: var(--accent-blue);
+	}
+
+	.parent-sheet-body {
+		display: flex;
+		flex-direction: column;
+		padding: 0 var(--space-2) var(--space-3);
+	}
+
+	.parent-sheet-option {
+		display: block;
+		width: 100%;
+		text-align: left;
+		background: none;
+		border: none;
+		padding: var(--space-3);
+		color: var(--text-primary);
+		font-size: 1em;
+		cursor: pointer;
+		border-radius: var(--radius-sm);
+	}
+
+	.parent-sheet-option:hover {
+		background: var(--bg-hover);
+	}
+
+	.parent-sheet-option.active {
+		background: var(--bg-tertiary);
+		font-weight: 600;
 	}
 
 	.search-wrapper {

--- a/web/src/lib/components/collections/FilterBar.svelte
+++ b/web/src/lib/components/collections/FilterBar.svelte
@@ -71,6 +71,12 @@
 		isMobile = mq.matches;
 		const onChange = (e: MediaQueryListEvent) => {
 			isMobile = e.matches;
+			// If the viewport crosses above the mobile breakpoint while the
+			// sheet is open (e.g. device rotation), close it so it doesn't
+			// spring back open as soon as the viewport returns to mobile.
+			if (!e.matches) {
+				parentSheetOpen = false;
+			}
 		};
 		mq.addEventListener('change', onChange);
 		return () => mq.removeEventListener('change', onChange);


### PR DESCRIPTION
## Summary

Wire `BottomSheet` into the parent filter on `FilterBar`. The status filter is already a segmented button group that wraps on mobile — no clipping, no change needed. The parent filter was a native `<select>`, which renders inconsistently across iOS/Android and doesn't match the rest of the app's mobile UX; on mobile it's now a chip trigger that opens a `BottomSheet` of plan options.

## Context

Implements `TASK-635` under `PLAN-631`.

**Scope note:** the task description referenced chip-per-field dropdowns with a clipping bug, but `FilterBar.svelte` doesn't have that shape today — it has an inline segmented status group + a native `<select>` for parent. Implementing the full "chips with dropdowns" redesign would be out of scope for this PR and isn't needed to fix real mobile pain. Scoped to the `<select>`-to-BottomSheet swap that delivers the acceptance-criteria outcome ("tapping any filter opens a full-width sheet with options; selecting applies filter and dismisses").

## Change

- Status segmented group: unchanged. Already mobile-safe.
- Parent filter on mobile: chip trigger + `<BottomSheet title="Filter by plan">`. Option list matches the native `<select>`.
- Parent filter on desktop: unchanged native `<select>`.
- Sheet gated on `parentSheetOpen` so it isn't mounted (and no dormant global keydown listener) when closed.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./...` — all tests pass
- [x] `cd web && npm run build` — clean
- [ ] Manual mobile: tap parent chip, sheet slides up with "All plans" + each plan, tap one → filter applies, sheet closes
- [ ] Manual mobile: active selection is visually highlighted in the sheet
- [ ] Manual desktop: native select unchanged; status segmented group unchanged
- [ ] Works across list, board, table views (same component)