### PR TITLE
fix(server): add script-src-attr 'none' to CSP (TASK-648)

### DIFF
--- a/internal/server/middleware_security.go
+++ b/internal/server/middleware_security.go
@@ -28,8 +28,14 @@ func SecurityHeaders(next http.Handler) http.Handler {
 
 		// CSP: strict policy for API responses. HTML pages served by spaHandler
 		// override this with a nonce-based script-src for SvelteKit inline scripts.
+		//
+		// script-src-attr 'none' blocks inline event handlers (onerror=, onclick=,
+		// onload=, …). Those bypass script-src per the CSP spec, so without this
+		// directive an attacker who slips markup past the sanitizer can still
+		// execute JS via event attributes. Defense-in-depth for the comment-XSS
+		// fix (TASK-647) and for any future sanitizer regression.
 		h.Set("Content-Security-Policy",
-			"default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'")
+			"default-src 'self'; script-src 'self'; script-src-attr 'none'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'")
 
 		next.ServeHTTP(w, r)
 	})

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -565,9 +565,11 @@ func (s *Server) spaHandler() http.Handler {
 		// Inject nonce into inline <script> tags (SvelteKit bootstrap)
 		html := bytes.Replace(indexHTML, []byte("<script>"), []byte(fmt.Sprintf(`<script nonce="%s">`, nonce)), -1)
 
-		// Set nonce-based CSP (overrides the strict default from SecurityHeaders)
+		// Set nonce-based CSP (overrides the strict default from SecurityHeaders).
+		// script-src-attr 'none' blocks inline event handlers regardless of the
+		// script-src nonce — per CSP spec, event attributes bypass script-src.
 		w.Header().Set("Content-Security-Policy", fmt.Sprintf(
-			"default-src 'self'; script-src 'self' 'nonce-%s'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'",
+			"default-src 'self'; script-src 'self' 'nonce-%s'; script-src-attr 'none'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'",
 			nonce))
 
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")


### PR DESCRIPTION
## Summary
Add the \`script-src-attr 'none'\` directive to both CSP headers. Blocks inline event handlers (onerror=, onclick=, onload=, …) which bypass script-src per the CSP spec.

## Context
Implements \`TASK-648\` (C1b) under \`PLAN-643\` (OSS Security Hardening). Defense-in-depth for \`TASK-647\` — even if the DOMPurify allowlist ever regresses, inline event attributes still won't execute.

## Changes
- \`internal/server/middleware_security.go\` — strict CSP for API responses gains \`script-src-attr 'none'\`.
- \`internal/server/server.go\` — nonce-based CSP for HTML pages gains the same.

## Test plan
- [x] \`go build ./...\` — clean
- [x] \`go vet ./...\` — clean
- [x] \`go test ./...\` — all pass (\`internal/server\` included)