### PR TITLE
fix(server): gate RealIP on PAD_TRUSTED_PROXIES (TASK-660)

### DIFF
--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -246,6 +246,7 @@ func serveCmd() *cobra.Command {
 			srv.SetBaseURL(cfg.BaseURL())
 			srv.SetCORSOrigins(cfg.CORSOrigins)
 			srv.SetSecureCookies(cfg.SecureCookies)
+			srv.SetTrustedProxies(cfg.TrustedProxies)
 			srv.SetSSELimits(cfg.SSEMaxConnections, cfg.SSEMaxPerWorkspace)
 
 			// Cloud mode: enable cloud-specific endpoints and behavior

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -46,6 +46,7 @@ type Config struct {
 	// Security
 	CORSOrigins    string `toml:"cors_origins"`    // Comma-separated allowed origins (e.g. "https://app.pad.dev,https://admin.pad.dev")
 	SecureCookies  bool   `toml:"secure_cookies"`  // Set Secure flag on cookies (requires TLS)
+	TrustedProxies string `toml:"trusted_proxies"` // Comma-separated CIDRs whose X-Forwarded-For is trusted. Empty = ignore proxy headers.
 
 	// SSE limits
 	SSEMaxConnections  int `toml:"sse_max_connections"`   // Global max SSE connections (0 = unlimited)
@@ -150,6 +151,9 @@ func Load() (*Config, error) {
 	}
 	if v := os.Getenv("PAD_SECURE_COOKIES"); v == "true" || v == "1" {
 		cfg.SecureCookies = true
+	}
+	if v := os.Getenv("PAD_TRUSTED_PROXIES"); v != "" {
+		cfg.TrustedProxies = v
 	}
 	if v := os.Getenv("PAD_SSE_MAX_CONNECTIONS"); v != "" {
 		if max, err := strconv.Atoi(v); err == nil {

--- a/internal/server/middleware_realip.go
+++ b/internal/server/middleware_realip.go
@@ -1,0 +1,112 @@
+package server
+
+import (
+	"log/slog"
+	"net"
+	"net/http"
+	"strings"
+)
+
+// TrustedProxyRealIP returns middleware that rewrites r.RemoteAddr from
+// X-Real-IP / X-Forwarded-For ONLY when the direct TCP peer is within one
+// of the supplied trusted-proxy CIDRs. This replaces chimiddleware.RealIP
+// which trusts proxy headers unconditionally — that is unsafe for any
+// deployment directly exposed to untrusted networks, because any client
+// can spoof X-Forwarded-For to bypass IP rate limits, the bootstrap
+// loopback check, and IP-based audit logs.
+//
+// Pass cidrs == nil (the default when PAD_TRUSTED_PROXIES is unset) to
+// disable proxy-header trust entirely; the TCP peer address is then used
+// everywhere, which is the safe behavior for direct-exposed servers.
+func TrustedProxyRealIP(cidrs []*net.IPNet) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		if len(cidrs) == 0 {
+			return next
+		}
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			peerIP := peerAddr(r.RemoteAddr)
+			if peerIP == nil || !ipInCIDRs(peerIP, cidrs) {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			// Peer is a trusted proxy — accept X-Real-IP or the first
+			// entry of X-Forwarded-For as the client IP.
+			var realIP string
+			if v := strings.TrimSpace(r.Header.Get("X-Real-IP")); v != "" {
+				realIP = v
+			} else if v := r.Header.Get("X-Forwarded-For"); v != "" {
+				for _, p := range strings.Split(v, ",") {
+					p = strings.TrimSpace(p)
+					if p != "" {
+						realIP = p
+						break
+					}
+				}
+			}
+
+			if realIP != "" && net.ParseIP(realIP) != nil {
+				r.RemoteAddr = realIP
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// ParseTrustedProxyCIDRs parses a comma-separated list of CIDRs or bare
+// IPs from the PAD_TRUSTED_PROXIES setting. Bare IPs get /32 (IPv4) or
+// /128 (IPv6). Invalid entries are logged and skipped so an operator typo
+// can't crash startup — but if the result is empty, proxy headers remain
+// untrusted.
+func ParseTrustedProxyCIDRs(spec string) []*net.IPNet {
+	if spec == "" {
+		return nil
+	}
+	var out []*net.IPNet
+	for _, raw := range strings.Split(spec, ",") {
+		raw = strings.TrimSpace(raw)
+		if raw == "" {
+			continue
+		}
+		// Accept bare IPs by appending /32 or /128.
+		if !strings.Contains(raw, "/") {
+			ip := net.ParseIP(raw)
+			if ip == nil {
+				slog.Warn("PAD_TRUSTED_PROXIES: skipping invalid entry", "entry", raw)
+				continue
+			}
+			if ip.To4() != nil {
+				raw += "/32"
+			} else {
+				raw += "/128"
+			}
+		}
+		_, cidr, err := net.ParseCIDR(raw)
+		if err != nil {
+			slog.Warn("PAD_TRUSTED_PROXIES: skipping invalid CIDR", "entry", raw, "error", err)
+			continue
+		}
+		out = append(out, cidr)
+	}
+	return out
+}
+
+// peerAddr extracts the IP from a RemoteAddr string, which may be either
+// "host:port" (the stdlib default) or a bare "host" (what some middleware
+// leaves behind after its own rewriting). Returns nil if parsing fails.
+func peerAddr(remoteAddr string) net.IP {
+	host := remoteAddr
+	if h, _, err := net.SplitHostPort(remoteAddr); err == nil {
+		host = h
+	}
+	return net.ParseIP(host)
+}
+
+func ipInCIDRs(ip net.IP, cidrs []*net.IPNet) bool {
+	for _, c := range cidrs {
+		if c.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/server/middleware_realip_test.go
+++ b/internal/server/middleware_realip_test.go
@@ -1,0 +1,168 @@
+package server
+
+import (
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestParseTrustedProxyCIDRs(t *testing.T) {
+	tests := []struct {
+		name     string
+		spec     string
+		wantLen  int
+		contains []string // IPs that should match
+		rejects  []string // IPs that should not match
+	}{
+		{
+			name:    "empty spec disables proxy trust",
+			spec:    "",
+			wantLen: 0,
+		},
+		{
+			name:     "single CIDR",
+			spec:     "10.0.0.0/8",
+			wantLen:  1,
+			contains: []string{"10.0.0.1", "10.255.255.255"},
+			rejects:  []string{"11.0.0.1", "192.168.1.1"},
+		},
+		{
+			name:     "bare IPv4 becomes /32",
+			spec:     "192.168.1.50",
+			wantLen:  1,
+			contains: []string{"192.168.1.50"},
+			rejects:  []string{"192.168.1.51"},
+		},
+		{
+			name:     "bare IPv6 becomes /128",
+			spec:     "::1",
+			wantLen:  1,
+			contains: []string{"::1"},
+			rejects:  []string{"::2"},
+		},
+		{
+			name:     "mixed CIDRs and IPs",
+			spec:     "10.0.0.0/8, 172.16.0.0/12, 192.168.1.1",
+			wantLen:  3,
+			contains: []string{"10.1.1.1", "172.16.0.5", "192.168.1.1"},
+			rejects:  []string{"8.8.8.8", "192.168.1.2"},
+		},
+		{
+			name:    "invalid entries are skipped",
+			spec:    "10.0.0.0/8, not-an-ip, 999.999.999.999",
+			wantLen: 1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ParseTrustedProxyCIDRs(tt.spec)
+			if len(got) != tt.wantLen {
+				t.Fatalf("len(cidrs) = %d, want %d", len(got), tt.wantLen)
+			}
+			for _, ip := range tt.contains {
+				if !ipInCIDRs(net.ParseIP(ip), got) {
+					t.Errorf("%s should match", ip)
+				}
+			}
+			for _, ip := range tt.rejects {
+				if ipInCIDRs(net.ParseIP(ip), got) {
+					t.Errorf("%s should NOT match", ip)
+				}
+			}
+		})
+	}
+}
+
+func TestTrustedProxyRealIP_NoProxies_HeadersIgnored(t *testing.T) {
+	// When no trusted proxies are configured, proxy headers are completely
+	// ignored and the real TCP peer address wins.
+	var seen string
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen = r.RemoteAddr
+	})
+	mw := TrustedProxyRealIP(nil)(next)
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.RemoteAddr = "203.0.113.5:12345"
+	req.Header.Set("X-Forwarded-For", "198.51.100.7") // attacker-spoofed
+	mw.ServeHTTP(httptest.NewRecorder(), req)
+
+	if seen != "203.0.113.5:12345" {
+		t.Fatalf("RemoteAddr was rewritten despite empty trust list: %s", seen)
+	}
+}
+
+func TestTrustedProxyRealIP_UntrustedPeer_HeadersIgnored(t *testing.T) {
+	// Proxy headers from an untrusted peer must be ignored even when the
+	// trust list is non-empty.
+	var seen string
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen = r.RemoteAddr
+	})
+	cidrs := ParseTrustedProxyCIDRs("10.0.0.0/8")
+	mw := TrustedProxyRealIP(cidrs)(next)
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.RemoteAddr = "203.0.113.5:12345" // NOT in 10/8
+	req.Header.Set("X-Forwarded-For", "198.51.100.7")
+	mw.ServeHTTP(httptest.NewRecorder(), req)
+
+	if seen != "203.0.113.5:12345" {
+		t.Fatalf("RemoteAddr was rewritten for untrusted peer: %s", seen)
+	}
+}
+
+func TestTrustedProxyRealIP_TrustedPeer_XRealIPUsed(t *testing.T) {
+	var seen string
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen = r.RemoteAddr
+	})
+	cidrs := ParseTrustedProxyCIDRs("10.0.0.0/8")
+	mw := TrustedProxyRealIP(cidrs)(next)
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.RemoteAddr = "10.0.0.5:12345"       // in trusted CIDR
+	req.Header.Set("X-Real-IP", "198.51.100.7")
+	mw.ServeHTTP(httptest.NewRecorder(), req)
+
+	if seen != "198.51.100.7" {
+		t.Fatalf("X-Real-IP from trusted peer was ignored: %s", seen)
+	}
+}
+
+func TestTrustedProxyRealIP_TrustedPeer_XFFFirstEntryUsed(t *testing.T) {
+	var seen string
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen = r.RemoteAddr
+	})
+	cidrs := ParseTrustedProxyCIDRs("10.0.0.0/8")
+	mw := TrustedProxyRealIP(cidrs)(next)
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.RemoteAddr = "10.0.0.5:12345"
+	req.Header.Set("X-Forwarded-For", "198.51.100.7, 10.0.0.5")
+	mw.ServeHTTP(httptest.NewRecorder(), req)
+
+	if seen != "198.51.100.7" {
+		t.Fatalf("XFF first entry not honored: %s", seen)
+	}
+}
+
+func TestTrustedProxyRealIP_TrustedPeer_InvalidHeaderIgnored(t *testing.T) {
+	var seen string
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen = r.RemoteAddr
+	})
+	cidrs := ParseTrustedProxyCIDRs("10.0.0.0/8")
+	mw := TrustedProxyRealIP(cidrs)(next)
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.RemoteAddr = "10.0.0.5:12345"
+	req.Header.Set("X-Real-IP", "not-an-ip")
+	mw.ServeHTTP(httptest.NewRecorder(), req)
+
+	if seen != "10.0.0.5:12345" {
+		t.Fatalf("invalid header was trusted: %s", seen)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io/fs"
 	"log/slog"
+	"net"
 	"net/http"
 	"strings"
 	"sync"
@@ -41,6 +42,7 @@ type Server struct {
 	corsOrigins   string               // comma-separated CORS origins (empty = localhost defaults)
 	secureCookies bool                 // set Secure flag on cookies (for TLS deployments)
 	metrics            *metrics.Metrics      // Prometheus metrics (optional)
+	trustedProxyCIDRs  []*net.IPNet          // CIDRs allowed to set X-Forwarded-For (nil = proxy headers untrusted)
 	sseMaxConnections  int                   // global SSE connection limit (0 = unlimited)
 	sseMaxPerWorkspace int                   // per-workspace SSE connection limit (0 = unlimited)
 	cloudMode           bool                 // true when running as Pad Cloud (PAD_CLOUD=true or PAD_MODE=cloud)
@@ -179,6 +181,16 @@ func (s *Server) SetSSELimits(global, perWorkspace int) {
 	s.sseMaxPerWorkspace = perWorkspace
 }
 
+// SetTrustedProxies configures which direct TCP peers are allowed to set
+// X-Real-IP / X-Forwarded-For on incoming requests. Accepts a comma-
+// separated list of CIDRs or bare IPs (e.g. "10.0.0.0/8, 172.16.0.0/12").
+// When empty (the default), proxy headers are ignored entirely — the
+// actual TCP peer address is used for rate limiting, the bootstrap
+// loopback check, and audit logging.
+func (s *Server) SetTrustedProxies(spec string) {
+	s.trustedProxyCIDRs = ParseTrustedProxyCIDRs(spec)
+}
+
 // reconfigureEmail reads email settings from the platform_settings table
 // and updates (or creates) the email sender. Called after admin settings change.
 func (s *Server) reconfigureEmail() {
@@ -210,7 +222,11 @@ func (s *Server) setupRouter() {
 	r := chi.NewRouter()
 
 	// Infrastructure middleware (applies to all routes including /metrics)
-	r.Use(chimiddleware.RealIP)
+	// RealIP is gated on PAD_TRUSTED_PROXIES. When unset (the default), proxy
+	// headers are ignored and the real TCP peer address is used everywhere.
+	// This prevents X-Forwarded-For spoofing from bypassing rate limits, the
+	// bootstrap loopback check, or audit logs on direct-exposed deployments.
+	r.Use(TrustedProxyRealIP(s.trustedProxyCIDRs))
 	r.Use(chimiddleware.RequestID)
 	r.Use(StructuredLogger)
 	if s.metrics != nil {


### PR DESCRIPTION
## Summary
Replace unconditional \`chimiddleware.RealIP\` with \`TrustedProxyRealIP\` — only trusts \`X-Real-IP\` / \`X-Forwarded-For\` when the direct TCP peer is in a configured CIDR list. Safe default: \`PAD_TRUSTED_PROXIES\` unset → proxy headers ignored, actual TCP peer used everywhere.

## Context
Implements \`TASK-660\` (M5) under \`PLAN-643\` (OSS Security Hardening). Previously any client could spoof \`X-Forwarded-For\` to bypass per-IP rate limits AND the bootstrap loopback check (\`handlers_auth.go\`) — on a direct-exposed Docker deploy (M6) this compounded into a full-takeover chain.

## Changes
- \`internal/server/middleware_realip.go\` — new \`TrustedProxyRealIP\` middleware + \`ParseTrustedProxyCIDRs\` helper (accepts CIDRs or bare IPs; invalid entries logged and skipped; empty spec = no-op).
- \`internal/server/server.go\` — swap \`chimiddleware.RealIP\` for the gated version; add \`trustedProxyCIDRs\` field + \`SetTrustedProxies\`.
- \`internal/config/config.go\` — new \`TrustedProxies\` field + \`PAD_TRUSTED_PROXIES\` env var.
- \`cmd/pad/main.go\` — plumb config to server.
- \`internal/server/middleware_realip_test.go\` — coverage for no-trust default, untrusted peer, trusted + X-Real-IP, trusted + XFF first entry, trusted + invalid header.

## Test plan
- [x] \`go build ./...\` — clean
- [x] \`go vet ./...\` — clean
- [x] \`go test ./...\` — all pass (6 new test subcases)
- [x] New middleware enforces: headers ignored when proxy list empty; headers ignored when peer untrusted; X-Real-IP / XFF accepted only for trusted peer; invalid header values ignored.