### PR TITLE
fix(server): read raw TCP peer for loopback check (TASK-662)

### DIFF
--- a/internal/server/handlers_auth.go
+++ b/internal/server/handlers_auth.go
@@ -133,13 +133,37 @@ func (s *Server) sessionStatePayload(authenticated bool, user *models.User) map[
 	return payload
 }
 
-// requestIsLoopback reports whether the request arrived from a loopback
-// interface. Uses the untampered TCP peer address captured by
-// CapturePeerAddr (never r.RemoteAddr directly) so a proxied request that
-// forged X-Forwarded-For: 127.0.0.1 cannot impersonate a local caller and
-// trigger the bootstrap bypass — a direct path to full-instance takeover
-// before TASK-660/TASK-662 closed it.
+// requestIsLoopback reports whether the request came from a local CLI
+// running on the same machine as the Pad server. The check is intentionally
+// strict: it must be satisfiable ONLY by a direct loopback-TCP connection,
+// never by a request relayed through a proxy (local or remote).
+//
+// Two conditions must hold:
+//
+//  1. The untampered TCP peer (captured by CapturePeerAddr before any
+//     RealIP rewrite) is a loopback address. This defeats X-Forwarded-For
+//     spoofing from a non-loopback attacker — TrustedProxyRealIP already
+//     ignores XFF from untrusted peers, but we re-check the raw peer so
+//     a proxy misconfigured to trust 127.0.0.0/8 still can't be fooled
+//     into rewriting the peer itself.
+//
+//  2. Neither X-Forwarded-For nor X-Real-IP is set. A legitimate local CLI
+//     talking directly to the Pad port never sets these headers. A reverse
+//     proxy forwarding public traffic always does — so this rejects the
+//     regression Codex flagged on PR #175: a local Caddy/nginx proxying
+//     public traffic to Pad on 127.0.0.1 would otherwise make every
+//     request look loopback and reopen the bootstrap gate.
+//
+// The rule denies some unusual legitimate setups (e.g. a local proxy that
+// deliberately strips forwarding headers) in exchange for a simple,
+// sound invariant. Operators in that narrow case can call
+// `pad auth setup` from the host CLI instead of through their proxy.
 func requestIsLoopback(r *http.Request) bool {
+	// (2) Reject any proxied request.
+	if r.Header.Get("X-Forwarded-For") != "" || r.Header.Get("X-Real-IP") != "" {
+		return false
+	}
+	// (1) The TCP peer must be a loopback address.
 	peer := rawPeerAddr(r)
 	host := peer
 	if parsedHost, _, err := net.SplitHostPort(peer); err == nil {

--- a/internal/server/handlers_auth.go
+++ b/internal/server/handlers_auth.go
@@ -133,9 +133,16 @@ func (s *Server) sessionStatePayload(authenticated bool, user *models.User) map[
 	return payload
 }
 
+// requestIsLoopback reports whether the request arrived from a loopback
+// interface. Uses the untampered TCP peer address captured by
+// CapturePeerAddr (never r.RemoteAddr directly) so a proxied request that
+// forged X-Forwarded-For: 127.0.0.1 cannot impersonate a local caller and
+// trigger the bootstrap bypass — a direct path to full-instance takeover
+// before TASK-660/TASK-662 closed it.
 func requestIsLoopback(r *http.Request) bool {
-	host := r.RemoteAddr
-	if parsedHost, _, err := net.SplitHostPort(r.RemoteAddr); err == nil {
+	peer := rawPeerAddr(r)
+	host := peer
+	if parsedHost, _, err := net.SplitHostPort(peer); err == nil {
 		host = parsedHost
 	}
 	ip := net.ParseIP(strings.Trim(host, "[]"))

--- a/internal/server/handlers_auth_loopback_test.go
+++ b/internal/server/handlers_auth_loopback_test.go
@@ -1,0 +1,69 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestRequestIsLoopback_IgnoresRealIPRewrite verifies that the bootstrap
+// loopback check reads the untampered TCP peer captured by
+// CapturePeerAddr, not r.RemoteAddr. A proxied attacker setting
+// X-Forwarded-For: 127.0.0.1 must not be able to trick the check.
+func TestRequestIsLoopback_IgnoresRealIPRewrite(t *testing.T) {
+	tests := []struct {
+		name         string
+		peer         string
+		spoofedXFF   string
+		trustedCIDRs string
+		wantLoopback bool
+	}{
+		{
+			name:         "direct loopback peer returns true",
+			peer:         "127.0.0.1:54321",
+			wantLoopback: true,
+		},
+		{
+			name:         "direct LAN peer returns false",
+			peer:         "192.168.1.5:54321",
+			wantLoopback: false,
+		},
+		{
+			name:         "trusted proxy forwarding spoofed 127.0.0.1 is NOT loopback",
+			peer:         "10.0.0.5:54321", // real peer in trusted CIDR
+			spoofedXFF:   "127.0.0.1",      // attacker-controlled header
+			trustedCIDRs: "10.0.0.0/8",
+			wantLoopback: false,
+		},
+		{
+			name:         "untrusted peer sending XFF=127.0.0.1 is NOT loopback",
+			peer:         "203.0.113.7:54321",
+			spoofedXFF:   "127.0.0.1",
+			trustedCIDRs: "10.0.0.0/8",
+			wantLoopback: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got bool
+			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				got = requestIsLoopback(r)
+			})
+			// Replicate the production middleware order: CapturePeerAddr, then TrustedProxyRealIP.
+			cidrs := ParseTrustedProxyCIDRs(tt.trustedCIDRs)
+			chain := CapturePeerAddr(TrustedProxyRealIP(cidrs)(handler))
+
+			req := httptest.NewRequest("GET", "/api/v1/auth/bootstrap", nil)
+			req.RemoteAddr = tt.peer
+			if tt.spoofedXFF != "" {
+				req.Header.Set("X-Forwarded-For", tt.spoofedXFF)
+			}
+			chain.ServeHTTP(httptest.NewRecorder(), req)
+
+			if got != tt.wantLoopback {
+				t.Fatalf("requestIsLoopback = %v, want %v", got, tt.wantLoopback)
+			}
+		})
+	}
+}

--- a/internal/server/handlers_auth_loopback_test.go
+++ b/internal/server/handlers_auth_loopback_test.go
@@ -15,32 +15,56 @@ func TestRequestIsLoopback_IgnoresRealIPRewrite(t *testing.T) {
 		name         string
 		peer         string
 		spoofedXFF   string
+		spoofedXRI   string // X-Real-IP
 		trustedCIDRs string
 		wantLoopback bool
 	}{
 		{
-			name:         "direct loopback peer returns true",
+			name:         "direct loopback peer, no proxy headers: allowed",
 			peer:         "127.0.0.1:54321",
 			wantLoopback: true,
 		},
 		{
-			name:         "direct LAN peer returns false",
+			name:         "direct LAN peer: rejected",
 			peer:         "192.168.1.5:54321",
 			wantLoopback: false,
 		},
 		{
-			name:         "trusted proxy forwarding spoofed 127.0.0.1 is NOT loopback",
-			peer:         "10.0.0.5:54321", // real peer in trusted CIDR
-			spoofedXFF:   "127.0.0.1",      // attacker-controlled header
+			name:         "loopback peer WITH X-Forwarded-For: rejected (proxy relay)",
+			peer:         "127.0.0.1:54321",
+			spoofedXFF:   "203.0.113.8",
+			wantLoopback: false,
+		},
+		{
+			name:         "loopback peer WITH X-Real-IP: rejected (proxy relay)",
+			peer:         "127.0.0.1:54321",
+			spoofedXRI:   "203.0.113.8",
+			wantLoopback: false,
+		},
+		{
+			name:         "loopback peer with spoofed XFF=127.0.0.1: rejected (any XFF rejects)",
+			peer:         "127.0.0.1:54321",
+			spoofedXFF:   "127.0.0.1",
+			wantLoopback: false,
+		},
+		{
+			name:         "trusted proxy forwarding spoofed XFF=127.0.0.1: rejected",
+			peer:         "10.0.0.5:54321",
+			spoofedXFF:   "127.0.0.1",
 			trustedCIDRs: "10.0.0.0/8",
 			wantLoopback: false,
 		},
 		{
-			name:         "untrusted peer sending XFF=127.0.0.1 is NOT loopback",
+			name:         "untrusted peer with spoofed XFF=127.0.0.1: rejected",
 			peer:         "203.0.113.7:54321",
 			spoofedXFF:   "127.0.0.1",
 			trustedCIDRs: "10.0.0.0/8",
 			wantLoopback: false,
+		},
+		{
+			name:         "IPv6 loopback peer, no proxy headers: allowed",
+			peer:         "[::1]:54321",
+			wantLoopback: true,
 		},
 	}
 
@@ -58,6 +82,9 @@ func TestRequestIsLoopback_IgnoresRealIPRewrite(t *testing.T) {
 			req.RemoteAddr = tt.peer
 			if tt.spoofedXFF != "" {
 				req.Header.Set("X-Forwarded-For", tt.spoofedXFF)
+			}
+			if tt.spoofedXRI != "" {
+				req.Header.Set("X-Real-IP", tt.spoofedXRI)
 			}
 			chain.ServeHTTP(httptest.NewRecorder(), req)
 

--- a/internal/server/middleware_realip.go
+++ b/internal/server/middleware_realip.go
@@ -1,11 +1,40 @@
 package server
 
 import (
+	"context"
 	"log/slog"
 	"net"
 	"net/http"
 	"strings"
 )
+
+// peerAddrCtxKey carries the untampered TCP peer address (the original
+// r.RemoteAddr) through the request context. Middleware downstream of
+// TrustedProxyRealIP can't read the raw address off r.RemoteAddr anymore
+// because the rewrite is already baked in.
+type peerAddrCtxKey struct{}
+
+// CapturePeerAddr must be installed BEFORE TrustedProxyRealIP in the chain.
+// It snapshots the real TCP peer RemoteAddr into the request context so
+// authenticity checks (e.g. bootstrap loopback) can verify the actual wire
+// peer even when a trusted proxy has rewritten r.RemoteAddr.
+func CapturePeerAddr(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := context.WithValue(r.Context(), peerAddrCtxKey{}, r.RemoteAddr)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+// rawPeerAddr returns the untampered TCP peer address captured by
+// CapturePeerAddr, falling back to the current r.RemoteAddr if the
+// middleware wasn't installed (e.g. in tests). Never use r.RemoteAddr
+// directly for authenticity decisions — use this.
+func rawPeerAddr(r *http.Request) string {
+	if v, ok := r.Context().Value(peerAddrCtxKey{}).(string); ok && v != "" {
+		return v
+	}
+	return r.RemoteAddr
+}
 
 // TrustedProxyRealIP returns middleware that rewrites r.RemoteAddr from
 // X-Real-IP / X-Forwarded-For ONLY when the direct TCP peer is within one

--- a/internal/server/middleware_realip_test.go
+++ b/internal/server/middleware_realip_test.go
@@ -149,6 +149,42 @@ func TestTrustedProxyRealIP_TrustedPeer_XFFFirstEntryUsed(t *testing.T) {
 	}
 }
 
+func TestCapturePeerAddr_PreservesOriginalRemoteAddr(t *testing.T) {
+	// CapturePeerAddr installs the raw peer into context BEFORE TrustedProxyRealIP
+	// has a chance to rewrite it — so downstream handlers can always fetch the
+	// real TCP peer, even on deployments with trusted proxies.
+	const realPeer = "10.0.0.5:12345"
+	var seenCtx, seenRemoteAddr string
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenCtx = rawPeerAddr(r)
+		seenRemoteAddr = r.RemoteAddr
+	})
+	cidrs := ParseTrustedProxyCIDRs("10.0.0.0/8")
+	chain := CapturePeerAddr(TrustedProxyRealIP(cidrs)(next))
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.RemoteAddr = realPeer
+	req.Header.Set("X-Forwarded-For", "198.51.100.7")
+	chain.ServeHTTP(httptest.NewRecorder(), req)
+
+	if seenRemoteAddr != "198.51.100.7" {
+		t.Fatalf("expected RemoteAddr rewritten to XFF value, got %q", seenRemoteAddr)
+	}
+	if seenCtx != realPeer {
+		t.Fatalf("expected context to preserve raw peer %q, got %q", realPeer, seenCtx)
+	}
+}
+
+func TestRawPeerAddr_FallsBackToRemoteAddrWithoutMiddleware(t *testing.T) {
+	// In tests (or any call path that skips CapturePeerAddr), rawPeerAddr
+	// falls back to r.RemoteAddr rather than returning empty.
+	req := httptest.NewRequest("GET", "/", nil)
+	req.RemoteAddr = "192.0.2.1:9999"
+	if got := rawPeerAddr(req); got != "192.0.2.1:9999" {
+		t.Fatalf("rawPeerAddr fallback = %q, want %q", got, "192.0.2.1:9999")
+	}
+}
+
 func TestTrustedProxyRealIP_TrustedPeer_InvalidHeaderIgnored(t *testing.T) {
 	var seen string
 	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -222,6 +222,11 @@ func (s *Server) setupRouter() {
 	r := chi.NewRouter()
 
 	// Infrastructure middleware (applies to all routes including /metrics)
+	// CapturePeerAddr MUST run before TrustedProxyRealIP so downstream code
+	// that needs to verify the real TCP peer (e.g. the bootstrap loopback
+	// check) can read the untampered value from request context even on
+	// deployments with a trusted reverse proxy in front.
+	r.Use(CapturePeerAddr)
 	// RealIP is gated on PAD_TRUSTED_PROXIES. When unset (the default), proxy
 	// headers are ignored and the real TCP peer address is used everywhere.
 	// This prevents X-Forwarded-For spoofing from bypassing rate limits, the


### PR DESCRIPTION
## Summary
Harden \`requestIsLoopback\` so a spoofed \`X-Forwarded-For: 127.0.0.1\` from behind a trusted proxy can't impersonate a local caller and trigger the bootstrap bypass.

## Context
Implements \`TASK-662\` (M6b) under \`PLAN-643\` (OSS Security Hardening). Pairs with \`TASK-660\` (M5) — M5 gates RealIP trust on a CIDR allowlist so unproxied deploys are safe; M6b closes the residual hole for deployments that legitimately have a trusted proxy in front.

## Changes
- \`internal/server/middleware_realip.go\` — new \`CapturePeerAddr\` middleware stashes untampered \`r.RemoteAddr\` into request context before any RealIP rewrite. \`rawPeerAddr(r)\` helper reads the captured value with a fallback to \`r.RemoteAddr\` (safe in tests that skip the middleware).
- \`internal/server/server.go\` — install \`CapturePeerAddr\` immediately before \`TrustedProxyRealIP\` in the middleware chain.
- \`internal/server/handlers_auth.go\` — \`requestIsLoopback\` now reads from context via \`rawPeerAddr\` (never \`r.RemoteAddr\` directly).
- \`internal/server/middleware_realip_test.go\` — coverage for the capture-then-rewrite interaction and the fallback branch.
- \`internal/server/handlers_auth_loopback_test.go\` — new table test: direct loopback, direct LAN, spoofed XFF behind trusted proxy, spoofed XFF from untrusted peer.

## Test plan
- [x] \`go build ./...\` — clean
- [x] \`go vet ./...\` — clean
- [x] \`go test ./...\` — all pass (4 loopback subcases + 2 middleware subcases)