### PR TITLE
feat(auth): expire workspace invitations after 14 days (TASK-649)

### DIFF
--- a/internal/models/invitation_test.go
+++ b/internal/models/invitation_test.go
@@ -1,0 +1,35 @@
+package models
+
+import (
+	"testing"
+	"time"
+)
+
+func TestWorkspaceInvitation_IsExpired(t *testing.T) {
+	past := time.Now().UTC().Add(-1 * time.Hour)
+	future := time.Now().UTC().Add(1 * time.Hour)
+
+	tests := []struct {
+		name      string
+		expiresAt *time.Time
+		want      bool
+	}{
+		{"nil expiry is not expired (legacy invitation)", nil, false},
+		{"future expiry is not expired", &future, false},
+		{"past expiry is expired", &past, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			inv := &WorkspaceInvitation{ExpiresAt: tt.expiresAt}
+			if got := inv.IsExpired(); got != tt.want {
+				t.Fatalf("IsExpired() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+
+	// Nil-safe: a nil receiver shouldn't panic.
+	var nilInv *WorkspaceInvitation
+	if nilInv.IsExpired() {
+		t.Fatalf("nil invitation reported expired")
+	}
+}

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -100,7 +100,18 @@ type WorkspaceInvitation struct {
 	InvitedBy   string     `json:"invited_by"`
 	Code        string     `json:"code"`
 	AcceptedAt  *time.Time `json:"accepted_at,omitempty"`
+	ExpiresAt   *time.Time `json:"expires_at,omitempty"`
 	CreatedAt   time.Time  `json:"created_at"`
+}
+
+// IsExpired reports whether an invitation is past its expiration window.
+// Invitations created before the expires_at migration (nil ExpiresAt) are
+// treated as non-expiring so existing codes don't break on upgrade.
+func (inv *WorkspaceInvitation) IsExpired() bool {
+	if inv == nil || inv.ExpiresAt == nil {
+		return false
+	}
+	return time.Now().UTC().After(*inv.ExpiresAt)
 }
 
 // WorkspaceMember represents a user's membership in a workspace.

--- a/internal/server/handlers_auth.go
+++ b/internal/server/handlers_auth.go
@@ -380,6 +380,13 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusBadRequest, "invalid_invitation", "Invalid or expired invitation code")
 			return
 		}
+		if inv.IsExpired() {
+			// Distinct status from the "not found" case so the UI can show
+			// a useful message ("ask the inviter to send a new one") rather
+			// than a generic retry-the-code prompt.
+			writeError(w, http.StatusGone, "expired", "This invitation has expired. Ask the inviter to send a new one.")
+			return
+		}
 		invitation = inv
 	}
 

--- a/internal/server/handlers_members.go
+++ b/internal/server/handlers_members.go
@@ -312,6 +312,10 @@ func (s *Server) handleAcceptInvitation(w http.ResponseWriter, r *http.Request) 
 		writeError(w, http.StatusNotFound, "not_found", "Invitation not found or already accepted")
 		return
 	}
+	if inv.IsExpired() {
+		writeError(w, http.StatusGone, "expired", "This invitation has expired. Ask the inviter to send a new one.")
+		return
+	}
 
 	user := currentUser(r)
 	if user == nil {

--- a/internal/store/invitation_test.go
+++ b/internal/store/invitation_test.go
@@ -1,0 +1,132 @@
+package store
+
+import (
+	"testing"
+	"time"
+
+	"github.com/xarmian/pad/internal/models"
+)
+
+// TestCreateInvitation_SetsExpiresAt verifies new invitations get an expires_at
+// ~InvitationTTL in the future, round-tripped through store hydration.
+func TestCreateInvitation_SetsExpiresAt(t *testing.T) {
+	s := testStore(t)
+
+	// Minimal workspace + user fixtures
+	u, err := s.CreateUser(models.UserCreate{
+		Email:    "inviter@example.com",
+		Username: "inviter",
+		Name:     "Inviter",
+		Password: "correcthorsebattery",
+		Role:     "admin",
+	})
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	ws, err := s.CreateWorkspace(models.WorkspaceCreate{Name: "WS", OwnerID: u.ID})
+	if err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+
+	before := time.Now().UTC()
+	inv, err := s.CreateInvitation(ws.ID, "invitee@example.com", "editor", u.ID)
+	if err != nil {
+		t.Fatalf("create invitation: %v", err)
+	}
+	after := time.Now().UTC()
+
+	if inv.ExpiresAt == nil {
+		t.Fatal("ExpiresAt is nil on a freshly-created invitation")
+	}
+	// Expect expires_at ≈ now + InvitationTTL (±1s margin).
+	wantLow := before.Add(InvitationTTL - time.Second)
+	wantHigh := after.Add(InvitationTTL + time.Second)
+	if inv.ExpiresAt.Before(wantLow) || inv.ExpiresAt.After(wantHigh) {
+		t.Fatalf("ExpiresAt = %v, expected within [%v, %v]", inv.ExpiresAt, wantLow, wantHigh)
+	}
+	if inv.IsExpired() {
+		t.Fatal("fresh invitation marked expired")
+	}
+}
+
+// TestMigration044_BackfillParsesCorrectly ensures the SQLite/Postgres backfill
+// writes expires_at in a shape that parseTime can round-trip. Codex flagged
+// the first cut of this migration because the default datetime()/::TEXT casts
+// produce space-separated output that parseTime silently rejects — that would
+// mark every pre-existing invitation as already expired right after upgrade.
+//
+// The test creates a fresh store (which auto-runs migrations, including 044's
+// backfill against any rows with NULL expires_at), inserts a legacy-style row
+// with NULL expires_at via raw SQL to simulate a pre-migration record, runs
+// the backfill UPDATE manually (since it only runs during migration time for
+// rows that exist AT migration time), and re-hydrates via the usual store API.
+func TestMigration044_BackfillProducesRFC3339(t *testing.T) {
+	s := testStore(t)
+
+	u, err := s.CreateUser(models.UserCreate{
+		Email: "a@b.com", Username: "a", Name: "A", Password: "correcthorsebattery", Role: "admin",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ws, err := s.CreateWorkspace(models.WorkspaceCreate{Name: "W2", OwnerID: u.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate a pre-migration row: insert invitation directly with expires_at NULL.
+	id := newID()
+	ts := now()
+	_, err = s.db.Exec(s.q(`
+		INSERT INTO workspace_invitations (id, workspace_id, email, role, invited_by, code, code_hash, created_at, expires_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL)
+	`), id, ws.ID, "legacy@example.com", "editor", u.ID, id, "deadbeef", ts)
+	if err != nil {
+		t.Fatalf("insert legacy invitation: %v", err)
+	}
+
+	// Apply the same backfill expression the migration uses. We can't re-run
+	// the full migration (already applied by New()), so we mirror it here.
+	switch s.dialect.(type) {
+	case *sqliteDialect:
+		_, err = s.db.Exec(`
+			UPDATE workspace_invitations
+			SET expires_at = strftime('%Y-%m-%dT%H:%M:%SZ', created_at, '+14 days')
+			WHERE expires_at IS NULL
+		`)
+	case *postgresDialect:
+		_, err = s.db.Exec(`
+			UPDATE workspace_invitations
+			SET expires_at = to_char(
+				(created_at::timestamp + INTERVAL '14 days') AT TIME ZONE 'UTC',
+				'YYYY-MM-DD"T"HH24:MI:SS"Z"'
+			)
+			WHERE expires_at IS NULL
+		`)
+	}
+	if err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+
+	inv, err := s.GetInvitation(id)
+	if err != nil {
+		t.Fatalf("get invitation: %v", err)
+	}
+	if inv == nil {
+		t.Fatal("legacy invitation disappeared")
+	}
+	if inv.ExpiresAt == nil {
+		t.Fatal("ExpiresAt still nil after backfill")
+	}
+	if inv.ExpiresAt.IsZero() {
+		t.Fatal("ExpiresAt is zero Time — parseTime failed to parse the backfilled value")
+	}
+	if inv.IsExpired() {
+		t.Fatalf("legacy invitation marked expired after backfill (ExpiresAt=%v)", inv.ExpiresAt)
+	}
+	// expires_at should be ~InvitationTTL after created_at (allow 2s drift for wall-clock jitter).
+	diff := inv.ExpiresAt.Sub(inv.CreatedAt)
+	if diff < InvitationTTL-2*time.Second || diff > InvitationTTL+2*time.Second {
+		t.Fatalf("backfill delta = %v, expected ~%v", diff, InvitationTTL)
+	}
+}

--- a/internal/store/invitation_test.go
+++ b/internal/store/invitation_test.go
@@ -98,7 +98,7 @@ func TestMigration044_BackfillProducesRFC3339(t *testing.T) {
 		_, err = s.db.Exec(`
 			UPDATE workspace_invitations
 			SET expires_at = to_char(
-				(created_at::timestamp + INTERVAL '14 days') AT TIME ZONE 'UTC',
+				created_at::timestamp + INTERVAL '14 days',
 				'YYYY-MM-DD"T"HH24:MI:SS"Z"'
 			)
 			WHERE expires_at IS NULL

--- a/internal/store/migrations/044_invitation_expires_at.sql
+++ b/internal/store/migrations/044_invitation_expires_at.sql
@@ -8,10 +8,16 @@
 -- backfilled relative to their created_at so they also age out.
 ALTER TABLE workspace_invitations ADD COLUMN expires_at TEXT;
 
--- Backfill: 14 days after the creation time. SQLite supports datetime arithmetic
--- via the modifiers passed to datetime().
+-- Backfill: 14 days after the creation time, emitted in RFC3339 with a 'Z'
+-- suffix. We must match the format used by Go's time.RFC3339 exactly —
+-- internal/store/store.go's parseTime silently returns the zero Time on
+-- parse failure, which would make IsExpired() treat every legacy invitation
+-- as already-expired right after the migration runs. The default
+-- datetime(..., '+14 days') output of 'YYYY-MM-DD HH:MM:SS' is space-separated
+-- and un-parseable by RFC3339, so we strftime the result into the expected
+-- shape.
 UPDATE workspace_invitations
-SET expires_at = datetime(created_at, '+14 days')
+SET expires_at = strftime('%Y-%m-%dT%H:%M:%SZ', created_at, '+14 days')
 WHERE expires_at IS NULL;
 
 CREATE INDEX IF NOT EXISTS idx_invitations_expires_at ON workspace_invitations(expires_at);

--- a/internal/store/migrations/044_invitation_expires_at.sql
+++ b/internal/store/migrations/044_invitation_expires_at.sql
@@ -1,0 +1,17 @@
+-- Add expires_at to workspace_invitations so stale join codes stop working.
+-- Without expiry, a one-time invite code lives forever until accepted — if it
+-- leaks (email forwarding, stale screenshot, git history) an attacker who
+-- registers the invitee's email can still claim the workspace seat months
+-- or years later.
+--
+-- Default window is 14 days, enforced in the Go handlers. Existing rows are
+-- backfilled relative to their created_at so they also age out.
+ALTER TABLE workspace_invitations ADD COLUMN expires_at TEXT;
+
+-- Backfill: 14 days after the creation time. SQLite supports datetime arithmetic
+-- via the modifiers passed to datetime().
+UPDATE workspace_invitations
+SET expires_at = datetime(created_at, '+14 days')
+WHERE expires_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_invitations_expires_at ON workspace_invitations(expires_at);

--- a/internal/store/pgmigrations/024_invitation_expires_at.sql
+++ b/internal/store/pgmigrations/024_invitation_expires_at.sql
@@ -8,10 +8,16 @@
 -- backfilled relative to their created_at so they also age out.
 ALTER TABLE workspace_invitations ADD COLUMN IF NOT EXISTS expires_at TEXT;
 
--- Backfill: 14 days after the creation time. created_at is stored as TEXT so
--- we cast it to TIMESTAMP for arithmetic, then back to TEXT for consistency.
+-- Backfill: 14 days after the creation time, emitted in RFC3339 with a 'Z'
+-- suffix so Go's time.Parse(time.RFC3339, …) can read the result. The default
+-- ::TEXT cast of a timestamp produces space-separated output that parseTime
+-- (internal/store/store.go) silently fails on, which would make IsExpired()
+-- treat every legacy invitation as already-expired right after migration.
 UPDATE workspace_invitations
-SET expires_at = ((created_at::timestamp + INTERVAL '14 days') AT TIME ZONE 'UTC')::TEXT
+SET expires_at = to_char(
+    (created_at::timestamp + INTERVAL '14 days') AT TIME ZONE 'UTC',
+    'YYYY-MM-DD"T"HH24:MI:SS"Z"'
+)
 WHERE expires_at IS NULL;
 
 CREATE INDEX IF NOT EXISTS idx_invitations_expires_at ON workspace_invitations(expires_at);

--- a/internal/store/pgmigrations/024_invitation_expires_at.sql
+++ b/internal/store/pgmigrations/024_invitation_expires_at.sql
@@ -1,0 +1,17 @@
+-- Add expires_at to workspace_invitations so stale join codes stop working.
+-- Without expiry, a one-time invite code lives forever until accepted — if it
+-- leaks (email forwarding, stale screenshot, git history) an attacker who
+-- registers the invitee's email can still claim the workspace seat months
+-- or years later.
+--
+-- Default window is 14 days, enforced in the Go handlers. Existing rows are
+-- backfilled relative to their created_at so they also age out.
+ALTER TABLE workspace_invitations ADD COLUMN IF NOT EXISTS expires_at TEXT;
+
+-- Backfill: 14 days after the creation time. created_at is stored as TEXT so
+-- we cast it to TIMESTAMP for arithmetic, then back to TEXT for consistency.
+UPDATE workspace_invitations
+SET expires_at = ((created_at::timestamp + INTERVAL '14 days') AT TIME ZONE 'UTC')::TEXT
+WHERE expires_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_invitations_expires_at ON workspace_invitations(expires_at);

--- a/internal/store/pgmigrations/024_invitation_expires_at.sql
+++ b/internal/store/pgmigrations/024_invitation_expires_at.sql
@@ -13,9 +13,16 @@ ALTER TABLE workspace_invitations ADD COLUMN IF NOT EXISTS expires_at TEXT;
 -- ::TEXT cast of a timestamp produces space-separated output that parseTime
 -- (internal/store/store.go) silently fails on, which would make IsExpired()
 -- treat every legacy invitation as already-expired right after migration.
+--
+-- We do the interval math on the NAIVE timestamp (no AT TIME ZONE conversion).
+-- created_at is stored as RFC3339 UTC text, so `created_at::timestamp` gives
+-- a timestamp-without-tz whose numeric value is already UTC. to_char on a
+-- plain timestamp uses the timestamp as-is — it does NOT apply the session's
+-- TimeZone setting (which would happen for timestamptz). The hardcoded 'Z'
+-- suffix then correctly labels the result as UTC regardless of server locale.
 UPDATE workspace_invitations
 SET expires_at = to_char(
-    (created_at::timestamp + INTERVAL '14 days') AT TIME ZONE 'UTC',
+    created_at::timestamp + INTERVAL '14 days',
     'YYYY-MM-DD"T"HH24:MI:SS"Z"'
 )
 WHERE expires_at IS NULL;

--- a/internal/store/workspace_members.go
+++ b/internal/store/workspace_members.go
@@ -7,9 +7,16 @@ import (
 	"encoding/hex"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/xarmian/pad/internal/models"
 )
+
+// InvitationTTL is how long a newly-created workspace invitation stays
+// accepted-by-code. 14 days mirrors the convention of every password-reset
+// or magic-link flow: long enough for a distracted invitee to notice the
+// email, short enough that a leaked code doesn't stay exploitable forever.
+const InvitationTTL = 14 * 24 * time.Hour
 
 // AddWorkspaceMember adds a user to a workspace with the given role.
 func (s *Store) AddWorkspaceMember(workspaceID, userID, role string) error {
@@ -502,11 +509,12 @@ func (s *Store) CreateInvitation(workspaceID, email, role, invitedBy string) (*m
 
 	id := newID()
 	ts := now()
+	expiresAt := time.Now().UTC().Add(InvitationTTL).Format(time.RFC3339)
 
 	_, err := s.db.Exec(s.q(`
-		INSERT INTO workspace_invitations (id, workspace_id, email, role, invited_by, code, code_hash, created_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-	`), id, workspaceID, strings.ToLower(strings.TrimSpace(email)), role, invitedBy, id, codeHash, ts)
+		INSERT INTO workspace_invitations (id, workspace_id, email, role, invited_by, code, code_hash, created_at, expires_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`), id, workspaceID, strings.ToLower(strings.TrimSpace(email)), role, invitedBy, id, codeHash, ts, expiresAt)
 	if err != nil {
 		return nil, fmt.Errorf("insert invitation: %w", err)
 	}
@@ -523,15 +531,15 @@ func (s *Store) CreateInvitation(workspaceID, email, role, invitedBy string) (*m
 // GetInvitation retrieves an invitation by ID.
 func (s *Store) GetInvitation(id string) (*models.WorkspaceInvitation, error) {
 	var inv models.WorkspaceInvitation
-	var acceptedAt *string
+	var acceptedAt, expiresAt *string
 	var createdAt string
 
 	err := s.db.QueryRow(s.q(`
-		SELECT id, workspace_id, email, role, invited_by, code, accepted_at, created_at
+		SELECT id, workspace_id, email, role, invited_by, code, accepted_at, expires_at, created_at
 		FROM workspace_invitations WHERE id = ?
 	`), id).Scan(
 		&inv.ID, &inv.WorkspaceID, &inv.Email, &inv.Role, &inv.InvitedBy,
-		&inv.Code, &acceptedAt, &createdAt,
+		&inv.Code, &acceptedAt, &expiresAt, &createdAt,
 	)
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -542,6 +550,7 @@ func (s *Store) GetInvitation(id string) (*models.WorkspaceInvitation, error) {
 
 	inv.CreatedAt = parseTime(createdAt)
 	inv.AcceptedAt = parseTimePtr(acceptedAt)
+	inv.ExpiresAt = parseTimePtr(expiresAt)
 	return &inv, nil
 }
 
@@ -554,20 +563,21 @@ func (s *Store) GetInvitationByCode(code string) (*models.WorkspaceInvitation, e
 	codeHash := hex.EncodeToString(hash[:])
 
 	var inv models.WorkspaceInvitation
-	var acceptedAt *string
+	var acceptedAt, expiresAt *string
 	var createdAt string
 
 	// Try hashed lookup first (new invitations)
 	err := s.db.QueryRow(s.q(`
-		SELECT id, workspace_id, email, role, invited_by, code, accepted_at, created_at
+		SELECT id, workspace_id, email, role, invited_by, code, accepted_at, expires_at, created_at
 		FROM workspace_invitations WHERE code_hash = ? AND accepted_at IS NULL
 	`), codeHash).Scan(
 		&inv.ID, &inv.WorkspaceID, &inv.Email, &inv.Role, &inv.InvitedBy,
-		&inv.Code, &acceptedAt, &createdAt,
+		&inv.Code, &acceptedAt, &expiresAt, &createdAt,
 	)
 	if err == nil {
 		inv.CreatedAt = parseTime(createdAt)
 		inv.AcceptedAt = parseTimePtr(acceptedAt)
+		inv.ExpiresAt = parseTimePtr(expiresAt)
 		return &inv, nil
 	}
 	if err != sql.ErrNoRows {
@@ -576,11 +586,11 @@ func (s *Store) GetInvitationByCode(code string) (*models.WorkspaceInvitation, e
 
 	// Fall back to plaintext lookup (legacy invitations)
 	err = s.db.QueryRow(s.q(`
-		SELECT id, workspace_id, email, role, invited_by, code, accepted_at, created_at
+		SELECT id, workspace_id, email, role, invited_by, code, accepted_at, expires_at, created_at
 		FROM workspace_invitations WHERE code = ? AND accepted_at IS NULL
 	`), code).Scan(
 		&inv.ID, &inv.WorkspaceID, &inv.Email, &inv.Role, &inv.InvitedBy,
-		&inv.Code, &acceptedAt, &createdAt,
+		&inv.Code, &acceptedAt, &expiresAt, &createdAt,
 	)
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -591,6 +601,7 @@ func (s *Store) GetInvitationByCode(code string) (*models.WorkspaceInvitation, e
 
 	inv.CreatedAt = parseTime(createdAt)
 	inv.AcceptedAt = parseTimePtr(acceptedAt)
+	inv.ExpiresAt = parseTimePtr(expiresAt)
 	return &inv, nil
 }
 
@@ -625,7 +636,7 @@ func (s *Store) DeleteInvitation(workspaceID, invitationID string) error {
 // ListWorkspaceInvitations returns all invitations for a workspace.
 func (s *Store) ListWorkspaceInvitations(workspaceID string) ([]models.WorkspaceInvitation, error) {
 	rows, err := s.db.Query(s.q(`
-		SELECT id, workspace_id, email, role, invited_by, code, accepted_at, created_at
+		SELECT id, workspace_id, email, role, invited_by, code, accepted_at, expires_at, created_at
 		FROM workspace_invitations
 		WHERE workspace_id = ? AND accepted_at IS NULL
 		ORDER BY created_at ASC
@@ -638,16 +649,17 @@ func (s *Store) ListWorkspaceInvitations(workspaceID string) ([]models.Workspace
 	var result []models.WorkspaceInvitation
 	for rows.Next() {
 		var inv models.WorkspaceInvitation
-		var acceptedAt *string
+		var acceptedAt, expiresAt *string
 		var createdAt string
 		if err := rows.Scan(
 			&inv.ID, &inv.WorkspaceID, &inv.Email, &inv.Role, &inv.InvitedBy,
-			&inv.Code, &acceptedAt, &createdAt,
+			&inv.Code, &acceptedAt, &expiresAt, &createdAt,
 		); err != nil {
 			return nil, fmt.Errorf("scan invitation: %w", err)
 		}
 		inv.CreatedAt = parseTime(createdAt)
 		inv.AcceptedAt = parseTimePtr(acceptedAt)
+		inv.ExpiresAt = parseTimePtr(expiresAt)
 		result = append(result, inv)
 	}
 	return result, rows.Err()


### PR DESCRIPTION
## Summary
Add \`expires_at\` to \`workspace_invitations\` (default TTL 14 days). Expired codes are rejected in the accept handler and in the registration-via-invite path.

## Context
Implements \`TASK-649\` (H1a) under \`PLAN-643\` (OSS Security Hardening). A leaked one-time invite code (email forwarding, stale screenshot, git history) was usable forever until accepted — this bounds the window.

## Changes
- **Migrations**: SQLite 044 + Postgres 024 add \`expires_at TEXT\` + index. Existing rows backfilled to \`created_at + 14d\` so old codes also age out; rows with \`NULL expires_at\` are treated as non-expiring for legacy compatibility.
- **Store**: \`CreateInvitation\` sets \`expires_at = now + InvitationTTL\` (\`14 * 24h\`). \`GetInvitation\`/\`GetInvitationByCode\`/\`ListWorkspaceInvitations\` include \`expires_at\` in SELECT and hydrate \`ExpiresAt\`.
- **Model**: \`WorkspaceInvitation.ExpiresAt *time.Time\` + \`IsExpired()\` helper (nil-safe).
- **Handlers**: \`handleAcceptInvitation\` and \`handleRegister\` return \`410 Gone\` \`expired\` on expired codes.
- **Tests**: \`TestWorkspaceInvitation_IsExpired\` covers nil / past / future, plus nil-receiver safety.

## Test plan
- [x] \`go build ./...\` — clean
- [x] \`go vet ./...\` — clean
- [x] \`go test ./...\` — all pass (new model test included)
- [x] \`cd web && npm run build\` — clean