### PR TITLE
fix(auth): bind invitation acceptance to invitee email (TASK-650)

### DIFF
--- a/internal/server/handlers_auth.go
+++ b/internal/server/handlers_auth.go
@@ -387,6 +387,17 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusGone, "expired", "This invitation has expired. Ask the inviter to send a new one.")
 			return
 		}
+		// An invitation is bound to the email it was sent to. If the signup
+		// form supplies a different address, the attacker probably intercepted
+		// the link — reject before creating the account. Case-insensitive per
+		// RFC 5321 §2.4 (local-parts are technically case-sensitive but mail
+		// providers universally normalize them; EqualFold matches the store's
+		// own ToLower() normalization).
+		if !strings.EqualFold(strings.TrimSpace(input.Email), inv.Email) {
+			writeError(w, http.StatusForbidden, "invitation_email_mismatch",
+				"This invitation was sent to a different email address. Sign in or register with the invited address.")
+			return
+		}
 		invitation = inv
 	}
 

--- a/internal/server/handlers_members.go
+++ b/internal/server/handlers_members.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"net/http"
+	"strings"
 
 	"github.com/go-chi/chi/v5"
 
@@ -320,6 +321,15 @@ func (s *Server) handleAcceptInvitation(w http.ResponseWriter, r *http.Request) 
 	user := currentUser(r)
 	if user == nil {
 		writeError(w, http.StatusUnauthorized, "unauthorized", "You must be logged in to accept an invitation")
+		return
+	}
+	// Bind the invitation to the invitee's email: the signed-in account must
+	// match the address on the invite. Otherwise anyone who learns the code
+	// (forwarded email, leaked screenshot, guessed URL) could claim the seat
+	// from a different account.
+	if !strings.EqualFold(strings.TrimSpace(user.Email), inv.Email) {
+		writeError(w, http.StatusForbidden, "invitation_email_mismatch",
+			"This invitation was sent to a different email address. Sign in with that account to accept.")
 		return
 	}
 


### PR DESCRIPTION
## Summary
Reject invitation acceptance when the user's email doesn't match the invitee's email. Closes the "forwarded invite URL" takeover vector.

## Context
Implements \`TASK-650\` (H1b) under \`PLAN-643\` (OSS Security Hardening). Pairs with \`TASK-649\` (H1a) — expiry bounds the leak window, this PR ensures only the right person can use the code within that window.

## Changes
- \`internal/server/handlers_auth.go\` (\`handleRegister\` invitation branch) — case-insensitive \`strings.EqualFold\` check between \`input.Email\` and \`inv.Email\` before creating the user. Mismatch → \`403 invitation_email_mismatch\`.
- \`internal/server/handlers_members.go\` (\`handleAcceptInvitation\`) — same check against the currently-authenticated user's email. Mismatch → \`403 invitation_email_mismatch\`.

Both paths give a message directing the user at the invited address, not the generic "invalid code" message, so legitimate typos are easy to recover from.

## Test plan
- [x] \`go build ./...\` — clean
- [x] \`go vet ./...\` — clean
- [x] \`go test ./...\` — all pass