### PR TITLE
feat(auth): per-email login rate limiter (TASK-651)

### DIFF
--- a/internal/server/handlers_auth.go
+++ b/internal/server/handlers_auth.go
@@ -158,6 +158,23 @@ func (s *Server) sessionStatePayload(authenticated bool, user *models.User) map[
 // deliberately strips forwarding headers) in exchange for a simple,
 // sound invariant. Operators in that narrow case can call
 // `pad auth setup` from the host CLI instead of through their proxy.
+// isPlausibleEmail is a cheap pre-filter used to decide whether an email
+// is worth creating a per-email rate-limiter bucket for. NOT a full RFC
+// 5322 validator — it only rejects the two easy ways an attacker could
+// flood the limiter's bucket map: (1) excessively long strings, (2)
+// strings with no '@' at all. Anything shape-like-an-email passes and
+// the real validation happens in the store's password check.
+func isPlausibleEmail(s string) bool {
+	// RFC 5321 §4.5.3.1.3 caps the full address at 254 octets.
+	if s == "" || len(s) > 254 {
+		return false
+	}
+	at := strings.IndexByte(s, '@')
+	// Require an '@' that isn't at position 0 or the last char, so
+	// neither side of the address is empty.
+	return at > 0 && at < len(s)-1
+}
+
 func requestIsLoopback(r *http.Request) bool {
 	// (2) Reject any proxied request.
 	if r.Header.Get("X-Forwarded-For") != "" || r.Header.Get("X-Real-IP") != "" {
@@ -517,9 +534,16 @@ func (s *Server) handleLogin(w http.ResponseWriter, r *http.Request) {
 	// (success or failure) so an attacker can't use successful guesses as a
 	// "reset" — but a legitimate user who remembers their password on try 1
 	// or 2 will never notice the limit.
+	//
+	// Only create a bucket for syntactically plausible emails. Inserting
+	// every attacker-supplied string would let a distributed attacker grow
+	// the bucket map without bound (retention = 2h), which is a memory-DoS
+	// vector — so we pre-filter by RFC 5321 max length (254) and require
+	// at least an '@'. Invalid input still gets the ordinary 401 from the
+	// password check below, just without producing a new limiter entry.
 	if s.rateLimiters != nil && s.rateLimiters.AuthEmail != nil {
 		emailKey := strings.ToLower(strings.TrimSpace(input.Email))
-		if emailKey != "" {
+		if isPlausibleEmail(emailKey) {
 			limiter := s.rateLimiters.AuthEmail.getLimiter(emailKey)
 			if !limiter.Allow() {
 				slog.Warn("rate limited", "email", emailKey, "limiter", "auth_email")

--- a/internal/server/handlers_auth.go
+++ b/internal/server/handlers_auth.go
@@ -511,6 +511,30 @@ func (s *Server) handleLogin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Per-email rate limit: catches credential spraying from a botnet that
+	// evades the per-IP limit by rotating source addresses. 10 attempts/hour
+	// per lowercased email address. The limiter is consumed on every attempt
+	// (success or failure) so an attacker can't use successful guesses as a
+	// "reset" — but a legitimate user who remembers their password on try 1
+	// or 2 will never notice the limit.
+	if s.rateLimiters != nil && s.rateLimiters.AuthEmail != nil {
+		emailKey := strings.ToLower(strings.TrimSpace(input.Email))
+		if emailKey != "" {
+			limiter := s.rateLimiters.AuthEmail.getLimiter(emailKey)
+			if !limiter.Allow() {
+				slog.Warn("rate limited", "email", emailKey, "limiter", "auth_email")
+				// Audit even the blocked attempt so an admin can see the
+				// sprayed account in the log.
+				s.logAuditEvent(models.ActionLoginFailed, r, auditMeta(map[string]string{
+					"email":  input.Email,
+					"reason": "email_rate_limited",
+				}))
+				writeRateLimitResponse(w, s.rateLimiters.AuthEmail.config)
+				return
+			}
+		}
+	}
+
 	user, err := s.store.ValidatePassword(input.Email, input.Password)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "internal_error", "Authentication failed")

--- a/internal/server/handlers_auth_ratelimit_test.go
+++ b/internal/server/handlers_auth_ratelimit_test.go
@@ -1,0 +1,88 @@
+package server
+
+import (
+	"net/http"
+	"testing"
+)
+
+// TestHandleLogin_PerEmailRateLimit asserts that the per-email limiter
+// (10/hour burst 10) triggers before the per-IP limiter (5/min burst 5)
+// when attempts come from many distinct IPs — exactly the credential-
+// spraying scenario the limiter is designed to defeat.
+func TestHandleLogin_PerEmailRateLimit(t *testing.T) {
+	srv := testServer(t)
+	bootstrapFirstUser(t, srv, "victim@example.com", "Victim")
+
+	// 10 wrong-password attempts from 10 distinct IPs should all get 401
+	// (password wrong) but consume the email limiter to exhaustion.
+	for i := 0; i < 10; i++ {
+		ip := []string{
+			"203.0.113.1:1", "203.0.113.2:1", "203.0.113.3:1", "203.0.113.4:1",
+			"203.0.113.5:1", "203.0.113.6:1", "203.0.113.7:1", "203.0.113.8:1",
+			"203.0.113.9:1", "203.0.113.10:1",
+		}[i]
+		rr := doRequestFromRemoteAddr(srv, "POST", "/api/v1/auth/login", map[string]string{
+			"email":    "victim@example.com",
+			"password": "wrong-password",
+		}, ip)
+		if rr.Code != http.StatusUnauthorized {
+			t.Fatalf("attempt %d from %s: expected 401, got %d: %s", i, ip, rr.Code, rr.Body.String())
+		}
+	}
+
+	// 11th attempt from a fresh IP — per-IP limiter is still fine, but the
+	// per-email limiter should now reject.
+	rr := doRequestFromRemoteAddr(srv, "POST", "/api/v1/auth/login", map[string]string{
+		"email":    "victim@example.com",
+		"password": "wrong-password",
+	}, "203.0.113.11:1")
+	if rr.Code != http.StatusTooManyRequests {
+		t.Fatalf("11th attempt: expected 429 (per-email lockout), got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	// Sanity check: a DIFFERENT email from a fresh IP should still work (401,
+	// not 429) — we only want the sprayed target to be locked out.
+	rr = doRequestFromRemoteAddr(srv, "POST", "/api/v1/auth/login", map[string]string{
+		"email":    "other@example.com",
+		"password": "wrong-password",
+	}, "198.51.100.1:1")
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("other email: expected 401, got %d (per-email lockout leaked across accounts?)", rr.Code)
+	}
+}
+
+// TestHandleLogin_EmailCaseInsensitive ensures the per-email limiter keys
+// by lowercased email, so an attacker can't bypass by alternating casing.
+// Each attempt uses a distinct IP so the per-IP limiter doesn't trip first.
+func TestHandleLogin_EmailCaseInsensitive(t *testing.T) {
+	srv := testServer(t)
+	bootstrapFirstUser(t, srv, "mixed@example.com", "Mixed")
+
+	ips := []string{
+		"203.0.113.101:1", "203.0.113.102:1", "203.0.113.103:1", "203.0.113.104:1",
+		"203.0.113.105:1", "203.0.113.106:1", "203.0.113.107:1", "203.0.113.108:1",
+		"203.0.113.109:1", "203.0.113.110:1",
+	}
+	for i := 0; i < 10; i++ {
+		// Alternate casing each attempt.
+		email := "MIXED@example.com"
+		if i%2 == 0 {
+			email = "mixed@Example.com"
+		}
+		rr := doRequestFromRemoteAddr(srv, "POST", "/api/v1/auth/login", map[string]string{
+			"email":    email,
+			"password": "wrong",
+		}, ips[i])
+		if rr.Code != http.StatusUnauthorized {
+			t.Fatalf("attempt %d (%s from %s): expected 401, got %d", i, email, ips[i], rr.Code)
+		}
+	}
+
+	rr := doRequestFromRemoteAddr(srv, "POST", "/api/v1/auth/login", map[string]string{
+		"email":    "Mixed@Example.Com",
+		"password": "wrong",
+	}, "198.51.100.100:1")
+	if rr.Code != http.StatusTooManyRequests {
+		t.Fatalf("casing-variant attempt: expected 429, got %d (limiter key not normalized?)", rr.Code)
+	}
+}

--- a/internal/server/handlers_auth_ratelimit_test.go
+++ b/internal/server/handlers_auth_ratelimit_test.go
@@ -2,8 +2,67 @@ package server
 
 import (
 	"net/http"
+	"strings"
 	"testing"
 )
+
+func TestIsPlausibleEmail(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{"valid email", "user@example.com", true},
+		{"empty string", "", false},
+		{"no at sign", "userexample.com", false},
+		{"at at start", "@example.com", false},
+		{"at at end", "user@", false},
+		{"over 254 chars", strings.Repeat("a", 250) + "@b.com", false},
+		{"exactly 254 chars", strings.Repeat("a", 246) + "@b.com", true}, // 246 + 1 + 5 = 252 → 254 cap OK
+		{"unicode local part", "üser@example.com", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isPlausibleEmail(tt.input); got != tt.want {
+				t.Fatalf("isPlausibleEmail(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestHandleLogin_ImplausibleEmail_NoBucketCreated asserts that a long
+// garbage string with no '@' does not create a bucket in the AuthEmail
+// limiter — the memory-DoS defense Codex asked for on PR #178.
+func TestHandleLogin_ImplausibleEmail_NoBucketCreated(t *testing.T) {
+	srv := testServer(t)
+	bootstrapFirstUser(t, srv, "victim@example.com", "Victim")
+
+	// Send 50 login attempts with distinct garbage "emails" from distinct IPs.
+	for i := 0; i < 50; i++ {
+		garbage := strings.Repeat("x", 500) // way over 254 cap
+		rr := doRequestFromRemoteAddr(srv, "POST", "/api/v1/auth/login", map[string]string{
+			"email":    garbage,
+			"password": "wrong",
+		}, "203.0.113.200:"+string(rune('0'+i%10)))
+		if rr.Code == http.StatusTooManyRequests {
+			// Acceptable — could be hit by per-IP limiter depending on IP reuse.
+			continue
+		}
+		if rr.Code != http.StatusUnauthorized {
+			t.Fatalf("garbage email attempt %d: expected 401 or 429, got %d", i, rr.Code)
+		}
+	}
+
+	// Confirm no bucket was created for the garbage: the map should be empty
+	// of any entry whose key starts with 'x...' (the long string).
+	srv.rateLimiters.AuthEmail.mu.Lock()
+	defer srv.rateLimiters.AuthEmail.mu.Unlock()
+	for key := range srv.rateLimiters.AuthEmail.limiters {
+		if strings.HasPrefix(key, "xxxxxxx") {
+			t.Fatalf("garbage email created bucket: %q (len=%d)", key[:20]+"…", len(key))
+		}
+	}
+}
 
 // TestHandleLogin_PerEmailRateLimit asserts that the per-email limiter
 // (10/hour burst 10) triggers before the per-IP limiter (5/min burst 5)

--- a/internal/server/middleware_ratelimit.go
+++ b/internal/server/middleware_ratelimit.go
@@ -16,13 +16,25 @@ import (
 type rateLimitConfig struct {
 	Rate  rate.Limit // events per second
 	Burst int        // max burst
+	// Retention is how long an inactive key stays in memory before the
+	// background cleanup evicts it. Must be at least as long as the rate
+	// window (≈ burst / rate) or premature eviction lets an attacker reset
+	// their bucket by waiting — defeating "N per hour" limits that pause
+	// naturally between bursts. Zero means "use the default".
+	Retention time.Duration
 }
+
+// defaultRetention is the minimum retention for a limiter whose config
+// doesn't specify one. Suitable for sub-minute windows like per-IP login
+// limiting; longer windows must set Retention explicitly.
+const defaultRetention = 30 * time.Minute
 
 // ipRateLimiter tracks per-key rate limiters with automatic cleanup.
 type ipRateLimiter struct {
-	mu       sync.Mutex
-	limiters map[string]*rateLimiterEntry
-	config   rateLimitConfig
+	mu        sync.Mutex
+	limiters  map[string]*rateLimiterEntry
+	config    rateLimitConfig
+	retention time.Duration
 }
 
 type rateLimiterEntry struct {
@@ -31,9 +43,14 @@ type rateLimiterEntry struct {
 }
 
 func newIPRateLimiter(cfg rateLimitConfig) *ipRateLimiter {
+	retention := cfg.Retention
+	if retention <= 0 {
+		retention = defaultRetention
+	}
 	rl := &ipRateLimiter{
-		limiters: make(map[string]*rateLimiterEntry),
-		config:   cfg,
+		limiters:  make(map[string]*rateLimiterEntry),
+		config:    cfg,
+		retention: retention,
 	}
 	// Background cleanup of stale entries every 5 minutes
 	go rl.cleanup()
@@ -62,7 +79,7 @@ func (rl *ipRateLimiter) cleanup() {
 		time.Sleep(5 * time.Minute)
 		rl.mu.Lock()
 		for key, entry := range rl.limiters {
-			if time.Since(entry.lastSeen) > 30*time.Minute {
+			if time.Since(entry.lastSeen) > rl.retention {
 				delete(rl.limiters, key)
 			}
 		}
@@ -105,9 +122,15 @@ func NewRateLimiters() *RateLimiters {
 		// spraying from a botnet (which evades the per-IP limit by rotating
 		// source addresses), high enough that a forgetful user mistyping
 		// their own password never hits it under normal use.
+		//
+		// Retention must be ≥ the refill window (10 attempts / (10/hour) =
+		// 60 min); otherwise the cleanup could evict the bucket between
+		// bursts, letting an attacker pace their guesses to avoid the cap.
+		// 2 hours gives plenty of margin.
 		AuthEmail: newIPRateLimiter(rateLimitConfig{
-			Rate:  rate.Limit(10.0 / 3600.0),
-			Burst: 10,
+			Rate:      rate.Limit(10.0 / 3600.0),
+			Burst:     10,
+			Retention: 2 * time.Hour,
 		}),
 		// Password reset: 3 per hour per IP (= 3/3600 per second, burst 3)
 		PasswordReset: newIPRateLimiter(rateLimitConfig{

--- a/internal/server/middleware_ratelimit.go
+++ b/internal/server/middleware_ratelimit.go
@@ -74,6 +74,11 @@ func (rl *ipRateLimiter) cleanup() {
 type RateLimiters struct {
 	// Auth endpoints: strict limits per IP
 	Auth *ipRateLimiter
+	// Login attempts per email: catches credential-spraying that bypasses
+	// the per-IP limit by rotating through a botnet. Consumed inside
+	// handleLogin on every login attempt (success or failure) — a
+	// legitimate user who only mistypes a couple of times never notices.
+	AuthEmail *ipRateLimiter
 	// Password reset: per-IP
 	PasswordReset *ipRateLimiter
 	// Registration: per-IP
@@ -95,6 +100,14 @@ func NewRateLimiters() *RateLimiters {
 		Auth: newIPRateLimiter(rateLimitConfig{
 			Rate:  rate.Limit(5.0 / 60.0),
 			Burst: 5,
+		}),
+		// Per-email: 10 attempts per hour. Low enough to defeat credential
+		// spraying from a botnet (which evades the per-IP limit by rotating
+		// source addresses), high enough that a forgetful user mistyping
+		// their own password never hits it under normal use.
+		AuthEmail: newIPRateLimiter(rateLimitConfig{
+			Rate:  rate.Limit(10.0 / 3600.0),
+			Burst: 10,
 		}),
 		// Password reset: 3 per hour per IP (= 3/3600 per second, burst 3)
 		PasswordReset: newIPRateLimiter(rateLimitConfig{


### PR DESCRIPTION
## Summary
Add a per-email login rate limiter (10 attempts/hour burst 10) on top of the existing per-IP limiter. Defeats credential-spraying from a botnet that rotates source IPs to bypass the per-IP bucket.

## Context
Implements \`TASK-651\` (H2) under \`PLAN-643\` (OSS Security Hardening). The existing per-IP limit (5/min) is effective against a single attacker but trivially bypassed by rotating through a botnet — 50 IPs × 5/min = 250 guesses/min against one victim with no throttle.

## Changes
- \`internal/server/middleware_ratelimit.go\` — new \`AuthEmail *ipRateLimiter\` in \`RateLimiters\` (10/hour burst 10).
- \`internal/server/handlers_auth.go\` (\`handleLogin\`) — check the per-email limiter after decoding the request body, before \`ValidatePassword\`. Exhausted bucket returns 429 and emits an \`ActionLoginFailed\` audit event with \`reason=email_rate_limited\`.
- \`internal/server/handlers_auth_ratelimit_test.go\` — two integration tests:
  - \`TestHandleLogin_PerEmailRateLimit\`: spray the same email from 10 distinct IPs → 10 × 401 then 11th attempt (fresh IP) → 429. Sanity check: different email from fresh IP still gets 401.
  - \`TestHandleLogin_EmailCaseInsensitive\`: alternating casing across 10 attempts hits the same bucket.

## Test plan
- [x] \`go build ./...\` — clean
- [x] \`go vet ./...\` — clean
- [x] \`go test ./...\` — all pass (including the two new tests)