### PR TITLE
fix(auth): rotate sessions on password change, TOTP off, OAuth unlink (TASK-652)

### DIFF
--- a/internal/server/handlers_2fa.go
+++ b/internal/server/handlers_2fa.go
@@ -184,6 +184,14 @@ func (s *Server) handleTOTPDisable(w http.ResponseWriter, r *http.Request) {
 
 	s.logAuditEvent(models.ActionTOTPDisabled, r, "")
 
+	// Disabling 2FA weakens the account's auth surface — rotate every
+	// other session the same way we do for password changes. Otherwise
+	// a cookie captured while 2FA was on keeps its privileges after 2FA
+	// comes off.
+	if _, ok := s.rotateSessionsAfterCredentialChange(w, r, user); !ok {
+		return
+	}
+
 	writeJSON(w, http.StatusOK, map[string]interface{}{
 		"enabled": false,
 	})

--- a/internal/server/handlers_2fa.go
+++ b/internal/server/handlers_2fa.go
@@ -188,12 +188,15 @@ func (s *Server) handleTOTPDisable(w http.ResponseWriter, r *http.Request) {
 	// other session the same way we do for password changes. Otherwise
 	// a cookie captured while 2FA was on keeps its privileges after 2FA
 	// comes off.
-	if _, ok := s.rotateSessionsAfterCredentialChange(w, r, user); !ok {
+	token, ok := s.rotateSessionsAfterCredentialChange(w, r, user)
+	if !ok {
 		return
 	}
 
+	// Include the fresh token for Bearer-only callers (CLI/API).
 	writeJSON(w, http.StatusOK, map[string]interface{}{
 		"enabled": false,
+		"token":   token,
 	})
 }
 

--- a/internal/server/handlers_auth.go
+++ b/internal/server/handlers_auth.go
@@ -213,6 +213,47 @@ func (s *Server) validateSessionCookie(r *http.Request) *models.User {
 	return session.User
 }
 
+// rotateSessionsAfterCredentialChange invalidates every existing session
+// for the user (forcing sign-out on all other devices) and then re-issues
+// a fresh session cookie for the current request so the caller stays
+// logged in. Call this after any action that changes the credentials or
+// auth surface tied to the account: password change, TOTP disable, OAuth
+// provider unlink, etc. Without it a stolen cookie stays valid forever —
+// defeating the point of letting a user "kick everyone else out" by
+// rotating their password.
+//
+// On DeleteUserSessions error we log and continue; on CreateSession
+// error we leave the cookie untouched and write an error response. The
+// caller should return immediately afterwards.
+func (s *Server) rotateSessionsAfterCredentialChange(w http.ResponseWriter, r *http.Request, user *models.User) (*models.User, bool) {
+	if err := s.store.DeleteUserSessions(user.ID); err != nil {
+		// Best-effort: even if deletion fails we must still mint a new
+		// session for the caller, but log loudly so the operator knows
+		// stale cookies may persist until expiry.
+		slog.Error("failed to invalidate sessions after credential change",
+			"user_id", user.ID, "error", err)
+	}
+
+	token, err := s.store.CreateSession(user.ID, "web", clientIP(r), r.UserAgent(), webSessionTTL)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error",
+			"Credentials updated but failed to refresh session. Please sign in again.")
+		return nil, false
+	}
+
+	http.SetCookie(w, &http.Cookie{
+		Name:     sessionCookieName(s.secureCookies),
+		Value:    token,
+		Path:     "/",
+		MaxAge:   int(webSessionTTL.Seconds()),
+		HttpOnly: true,
+		Secure:   s.secureCookies,
+		SameSite: http.SameSiteLaxMode,
+	})
+	setCSRFCookie(w, int(webSessionTTL.Seconds()), s.secureCookies)
+	return user, true
+}
+
 func (s *Server) createAuthSession(w http.ResponseWriter, r *http.Request, user *models.User, ttl time.Duration) (string, error) {
 	token, err := s.store.CreateSession(user.ID, "web", clientIP(r), r.UserAgent(), ttl)
 	if err != nil {
@@ -809,6 +850,13 @@ func (s *Server) handleUpdateCurrentUser(w http.ResponseWriter, r *http.Request)
 
 	if input.NewPassword != "" {
 		s.logAuditEvent(models.ActionPasswordChanged, r, "")
+		// Sign out every OTHER session — an attacker who sniffed a cookie
+		// before the password change shouldn't stay logged in afterwards.
+		// Re-issue a fresh session for the caller so they don't get
+		// kicked out of the tab they just changed the password in.
+		if _, ok := s.rotateSessionsAfterCredentialChange(w, r, updated); !ok {
+			return
+		}
 	}
 
 	writeJSON(w, http.StatusOK, map[string]interface{}{

--- a/internal/server/handlers_auth.go
+++ b/internal/server/handlers_auth.go
@@ -215,17 +215,23 @@ func (s *Server) validateSessionCookie(r *http.Request) *models.User {
 
 // rotateSessionsAfterCredentialChange invalidates every existing session
 // for the user (forcing sign-out on all other devices) and then re-issues
-// a fresh session cookie for the current request so the caller stays
-// logged in. Call this after any action that changes the credentials or
-// auth surface tied to the account: password change, TOTP disable, OAuth
-// provider unlink, etc. Without it a stolen cookie stays valid forever —
-// defeating the point of letting a user "kick everyone else out" by
-// rotating their password.
+// a fresh session for the current request so the caller stays logged in.
+// Call this after any action that changes the credentials or auth surface
+// tied to the account: password change, TOTP disable, OAuth provider
+// unlink, etc. Without it a stolen cookie stays valid forever — defeating
+// the point of letting a user "kick everyone else out" by rotating their
+// password.
+//
+// Sets a fresh session cookie on the response (for browser callers) AND
+// returns the new token string (for CLI / API callers using
+// Authorization: Bearer padsess_… who never read cookies). Handlers
+// should embed the returned token in their response body so both
+// transport styles stay authenticated.
 //
 // On DeleteUserSessions error we log and continue; on CreateSession
-// error we leave the cookie untouched and write an error response. The
-// caller should return immediately afterwards.
-func (s *Server) rotateSessionsAfterCredentialChange(w http.ResponseWriter, r *http.Request, user *models.User) (*models.User, bool) {
+// error we write a 500 response and return ok=false — the caller should
+// return immediately.
+func (s *Server) rotateSessionsAfterCredentialChange(w http.ResponseWriter, r *http.Request, user *models.User) (string, bool) {
 	if err := s.store.DeleteUserSessions(user.ID); err != nil {
 		// Best-effort: even if deletion fails we must still mint a new
 		// session for the caller, but log loudly so the operator knows
@@ -238,7 +244,7 @@ func (s *Server) rotateSessionsAfterCredentialChange(w http.ResponseWriter, r *h
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "internal_error",
 			"Credentials updated but failed to refresh session. Please sign in again.")
-		return nil, false
+		return "", false
 	}
 
 	http.SetCookie(w, &http.Cookie{
@@ -251,7 +257,7 @@ func (s *Server) rotateSessionsAfterCredentialChange(w http.ResponseWriter, r *h
 		SameSite: http.SameSiteLaxMode,
 	})
 	setCSRFCookie(w, int(webSessionTTL.Seconds()), s.secureCookies)
-	return user, true
+	return token, true
 }
 
 func (s *Server) createAuthSession(w http.ResponseWriter, r *http.Request, user *models.User, ttl time.Duration) (string, error) {
@@ -848,18 +854,7 @@ func (s *Server) handleUpdateCurrentUser(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	if input.NewPassword != "" {
-		s.logAuditEvent(models.ActionPasswordChanged, r, "")
-		// Sign out every OTHER session — an attacker who sniffed a cookie
-		// before the password change shouldn't stay logged in afterwards.
-		// Re-issue a fresh session for the caller so they don't get
-		// kicked out of the tab they just changed the password in.
-		if _, ok := s.rotateSessionsAfterCredentialChange(w, r, updated); !ok {
-			return
-		}
-	}
-
-	writeJSON(w, http.StatusOK, map[string]interface{}{
+	resp := map[string]interface{}{
 		"id":         updated.ID,
 		"email":      updated.Email,
 		"username":   updated.Username,
@@ -868,7 +863,23 @@ func (s *Server) handleUpdateCurrentUser(w http.ResponseWriter, r *http.Request)
 		"avatar_url": updated.AvatarURL,
 		"created_at": updated.CreatedAt,
 		"updated_at": updated.UpdatedAt,
-	})
+	}
+	if input.NewPassword != "" {
+		s.logAuditEvent(models.ActionPasswordChanged, r, "")
+		// Sign out every OTHER session — an attacker who sniffed a cookie
+		// before the password change shouldn't stay logged in afterwards.
+		// Re-issue a fresh session for the caller so they don't get
+		// kicked out of the tab they just changed the password in.
+		token, ok := s.rotateSessionsAfterCredentialChange(w, r, updated)
+		if !ok {
+			return
+		}
+		// Expose the fresh token for Bearer-only callers (CLI / API) who
+		// won't see the Set-Cookie header.
+		resp["token"] = token
+	}
+
+	writeJSON(w, http.StatusOK, resp)
 }
 
 // handleForgotPassword generates a password reset token and sends it via email.

--- a/internal/server/handlers_auth_session_rotation_test.go
+++ b/internal/server/handlers_auth_session_rotation_test.go
@@ -1,0 +1,88 @@
+package server
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// TestPasswordChange_InvalidatesOtherSessions verifies that rotating a
+// password (a) deletes every existing session for the user except the
+// caller's, and (b) re-issues a fresh session cookie for the caller.
+// Before TASK-652 a stolen cookie stayed valid forever after the owner
+// "rotated" their password.
+func TestPasswordChange_InvalidatesOtherSessions(t *testing.T) {
+	srv := testServer(t)
+	bootstrapFirstUser(t, srv, "admin@example.com", "Admin")
+
+	// Log in twice from different devices (same account). The bootstrap
+	// call above already established one session; grab its token by logging
+	// in again with the known password.
+	login := func() string {
+		rr := doRequest(srv, "POST", "/api/v1/auth/login", map[string]string{
+			"email":    "admin@example.com",
+			"password": "password123",
+		})
+		if rr.Code != http.StatusOK {
+			t.Fatalf("login: expected 200, got %d: %s", rr.Code, rr.Body.String())
+		}
+		var resp map[string]interface{}
+		parseJSON(t, rr, &resp)
+		tok, _ := resp["token"].(string)
+		if tok == "" {
+			t.Fatal("login returned no token")
+		}
+		return tok
+	}
+
+	// Session A: the "other device" session that should die when password changes.
+	otherSessionToken := login()
+
+	// Session B: the "current tab" session — the one we use to trigger the change.
+	currentSessionToken := login()
+
+	// Sanity: both cookies are valid before the change.
+	for _, tok := range []string{otherSessionToken, currentSessionToken} {
+		rr := doRequestWithCookie(srv, "GET", "/api/v1/auth/me", nil, tok)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("pre-change /me with token: expected 200, got %d: %s", rr.Code, rr.Body.String())
+		}
+	}
+
+	// Change password via the "current" session.
+	rr := doRequestWithCookie(srv, "PATCH", "/api/v1/auth/me", map[string]string{
+		"current_password": "password123",
+		"new_password":     "newpassword456",
+	}, currentSessionToken)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("password change: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	// The response must set a new session cookie — confirming the caller
+	// got re-issued. Scan Set-Cookie headers for the session cookie name.
+	foundNewSessionCookie := false
+	for _, c := range rr.Result().Cookies() {
+		if strings.HasPrefix(c.Name, "pad_session") && c.Value != "" && c.Value != currentSessionToken {
+			foundNewSessionCookie = true
+			break
+		}
+	}
+	if !foundNewSessionCookie {
+		t.Fatalf("password change did not set a fresh session cookie; headers=%v", rr.Header())
+	}
+
+	// The OTHER device's session token must now be invalid.
+	rr = doRequestWithCookie(srv, "GET", "/api/v1/auth/me", nil, otherSessionToken)
+	if rr.Code == http.StatusOK {
+		t.Fatal("other session stayed valid after password change — defeats the rotation")
+	}
+
+	// For defensive measure, the OLD current-session token should also be
+	// invalid (the caller got a NEW token in the response). The test above
+	// already proved that — if the old token still worked, both sessions
+	// would still be alive.
+	rr = doRequestWithCookie(srv, "GET", "/api/v1/auth/me", nil, currentSessionToken)
+	if rr.Code == http.StatusOK {
+		t.Fatal("old caller token stayed valid after password change")
+	}
+}

--- a/internal/server/handlers_cloud.go
+++ b/internal/server/handlers_cloud.go
@@ -416,6 +416,14 @@ func (s *Server) handleOAuthUnlink(w http.ResponseWriter, r *http.Request) {
 
 	slog.Info("oauth-unlink: provider unlinked", "provider", input.Provider, "user_id", user.ID)
 
+	// Removing a sign-in method changes the account's auth surface — rotate
+	// all sessions so any cookie issued while the provider was linked
+	// (possibly via a compromised OAuth account) becomes invalid. The
+	// caller keeps their session via a re-issued cookie.
+	if _, ok := s.rotateSessionsAfterCredentialChange(w, r, user); !ok {
+		return
+	}
+
 	writeJSON(w, http.StatusOK, map[string]interface{}{
 		"ok":       true,
 		"provider": input.Provider,

--- a/internal/server/handlers_cloud.go
+++ b/internal/server/handlers_cloud.go
@@ -420,13 +420,15 @@ func (s *Server) handleOAuthUnlink(w http.ResponseWriter, r *http.Request) {
 	// all sessions so any cookie issued while the provider was linked
 	// (possibly via a compromised OAuth account) becomes invalid. The
 	// caller keeps their session via a re-issued cookie.
-	if _, ok := s.rotateSessionsAfterCredentialChange(w, r, user); !ok {
+	token, ok := s.rotateSessionsAfterCredentialChange(w, r, user)
+	if !ok {
 		return
 	}
 
 	writeJSON(w, http.StatusOK, map[string]interface{}{
 		"ok":       true,
 		"provider": input.Provider,
+		"token":    token, // for Bearer-only callers
 	})
 }
 


### PR DESCRIPTION
## Summary
Invalidate every existing session for the account (and re-issue a fresh cookie for the caller) after any change to the account's credentials or auth surface: password change, TOTP disable, OAuth provider unlink.

## Context
Implements \`TASK-652\` (H3) under \`PLAN-643\` (OSS Security Hardening). Before this PR, \`handleUpdateCurrentUser\` updated the password but left every existing session cookie valid — a stolen cookie kept its access forever after the rightful user "rotated" their password. Same issue on \`handleTOTPDisable\` and \`handleOAuthUnlink\`.

## Changes
- \`internal/server/handlers_auth.go\` — new \`rotateSessionsAfterCredentialChange\` helper that wraps \`DeleteUserSessions\` + fresh \`CreateSession\` + session cookie + CSRF cookie. Error-path returns 500 after writing a clear message.
- \`handleUpdateCurrentUser\` calls it on successful password change.
- \`internal/server/handlers_2fa.go\` — \`handleTOTPDisable\` calls it after successful TOTP disable.
- \`internal/server/handlers_cloud.go\` — \`handleOAuthUnlink\` calls it after successful provider removal.
- \`internal/server/handlers_auth_session_rotation_test.go\` — new test establishes two sessions, changes the password from one, verifies fresh cookie is set and both old tokens (including caller's) are now 401.

## Test plan
- [x] \`go build ./...\` — clean
- [x] \`go vet ./...\` — clean
- [x] \`go test ./...\` — all pass