### PR TITLE
feat(server): gate /metrics behind loopback + bearer token (TASK-653)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,3 +34,10 @@ POSTGRES_PASSWORD=
 # OPTIONAL — Trusted reverse-proxy CIDRs. Only peers in these CIDRs may set
 # X-Forwarded-For / X-Real-IP. Leave unset for direct-exposed deploys.
 # PAD_TRUSTED_PROXIES=10.0.0.0/8,172.16.0.0/12
+
+# OPTIONAL — Bearer token required to scrape /metrics. When unset, /metrics
+# is reachable only from loopback (so a Prometheus on the same host keeps
+# working without config); when set, every scrape must send
+# "Authorization: Bearer $PAD_METRICS_TOKEN".
+#   openssl rand -hex 32
+# PAD_METRICS_TOKEN=

--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -247,6 +247,7 @@ func serveCmd() *cobra.Command {
 			srv.SetCORSOrigins(cfg.CORSOrigins)
 			srv.SetSecureCookies(cfg.SecureCookies)
 			srv.SetTrustedProxies(cfg.TrustedProxies)
+			srv.SetMetricsToken(cfg.MetricsToken)
 			srv.SetSSELimits(cfg.SSEMaxConnections, cfg.SSEMaxPerWorkspace)
 
 			// Cloud mode: enable cloud-specific endpoints and behavior

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -47,6 +47,7 @@ type Config struct {
 	CORSOrigins    string `toml:"cors_origins"`    // Comma-separated allowed origins (e.g. "https://app.pad.dev,https://admin.pad.dev")
 	SecureCookies  bool   `toml:"secure_cookies"`  // Set Secure flag on cookies (requires TLS)
 	TrustedProxies string `toml:"trusted_proxies"` // Comma-separated CIDRs whose X-Forwarded-For is trusted. Empty = ignore proxy headers.
+	MetricsToken   string `toml:"metrics_token"`   // Shared Bearer token required to scrape /metrics. Empty = loopback-only.
 
 	// SSE limits
 	SSEMaxConnections  int `toml:"sse_max_connections"`   // Global max SSE connections (0 = unlimited)
@@ -154,6 +155,9 @@ func Load() (*Config, error) {
 	}
 	if v := os.Getenv("PAD_TRUSTED_PROXIES"); v != "" {
 		cfg.TrustedProxies = v
+	}
+	if v := os.Getenv("PAD_METRICS_TOKEN"); v != "" {
+		cfg.MetricsToken = v
 	}
 	if v := os.Getenv("PAD_SSE_MAX_CONNECTIONS"); v != "" {
 		if max, err := strconv.Atoi(v); err == nil {

--- a/internal/server/metrics_auth_test.go
+++ b/internal/server/metrics_auth_test.go
@@ -1,0 +1,101 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/xarmian/pad/internal/metrics"
+	"github.com/xarmian/pad/internal/store"
+)
+
+// newMetricsTestServer builds a Server with metrics enabled and the given
+// static token. Uses a unique SQLite DB per test so tests never share state.
+func newMetricsTestServer(t *testing.T, token string) *Server {
+	t.Helper()
+	dir := t.TempDir()
+	s, err := store.New(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	t.Cleanup(func() { s.Close() })
+	srv := New(s)
+	srv.SetMetrics(metrics.New())
+	srv.SetMetricsToken(token)
+	return srv
+}
+
+func doMetricsRequest(srv *Server, remoteAddr, authHeader string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest("GET", "/metrics", nil)
+	req.RemoteAddr = remoteAddr
+	if authHeader != "" {
+		req.Header.Set("Authorization", authHeader)
+	}
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	return rr
+}
+
+// TestMetricsAuth_TokenUnset_LoopbackOnly: no PAD_METRICS_TOKEN → loopback
+// callers succeed, everyone else gets 403. Safe default for self-hosters
+// running Prometheus on the same box.
+func TestMetricsAuth_TokenUnset_LoopbackOnly(t *testing.T) {
+	srv := newMetricsTestServer(t, "")
+
+	rr := doMetricsRequest(srv, "127.0.0.1:12345", "")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("loopback /metrics: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	rr = doMetricsRequest(srv, "203.0.113.5:12345", "")
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("non-loopback /metrics: expected 403 (no token configured), got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+// TestMetricsAuth_TokenSet_RequiresBearer: with PAD_METRICS_TOKEN set,
+// every scrape — even loopback — must present the correct Bearer token.
+func TestMetricsAuth_TokenSet_RequiresBearer(t *testing.T) {
+	srv := newMetricsTestServer(t, "super-secret-token")
+
+	// Missing header → 401
+	rr := doMetricsRequest(srv, "127.0.0.1:1", "")
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("no auth header: expected 401, got %d", rr.Code)
+	}
+
+	// Wrong token → 401
+	rr = doMetricsRequest(srv, "127.0.0.1:1", "Bearer wrong-token")
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("wrong token: expected 401, got %d", rr.Code)
+	}
+
+	// Non-Bearer scheme → 401
+	rr = doMetricsRequest(srv, "127.0.0.1:1", "Basic dXNlcjpwYXNz")
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("basic auth: expected 401, got %d", rr.Code)
+	}
+
+	// Correct token — from anywhere — succeeds.
+	rr = doMetricsRequest(srv, "203.0.113.5:1", "Bearer super-secret-token")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("valid token: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	// WWW-Authenticate header is set for failed attempts.
+	rr = doMetricsRequest(srv, "127.0.0.1:1", "Bearer wrong")
+	if got := rr.Header().Get("WWW-Authenticate"); got == "" {
+		t.Error("expected WWW-Authenticate header on 401")
+	}
+}
+
+// TestMetricsAuth_NoMetricsMeans404 sanity-checks that /metrics is
+// simply not routed when metrics are disabled (SetMetrics never called).
+func TestMetricsAuth_NoMetricsMeans404(t *testing.T) {
+	srv := testServer(t) // no SetMetrics
+	rr := doMetricsRequest(srv, "127.0.0.1:1", "")
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("metrics disabled: expected 404, got %d", rr.Code)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"crypto/subtle"
 	"encoding/base64"
 	"encoding/json"
 	"bytes"
@@ -42,6 +43,7 @@ type Server struct {
 	corsOrigins   string               // comma-separated CORS origins (empty = localhost defaults)
 	secureCookies bool                 // set Secure flag on cookies (for TLS deployments)
 	metrics            *metrics.Metrics      // Prometheus metrics (optional)
+	metricsToken       string                // shared bearer token for /metrics scrapes ("" = loopback-only)
 	trustedProxyCIDRs  []*net.IPNet          // CIDRs allowed to set X-Forwarded-For (nil = proxy headers untrusted)
 	sseMaxConnections  int                   // global SSE connection limit (0 = unlimited)
 	sseMaxPerWorkspace int                   // per-workspace SSE connection limit (0 = unlimited)
@@ -174,6 +176,50 @@ func (s *Server) SetMetrics(m *metrics.Metrics) {
 	s.metrics = m
 }
 
+// SetMetricsToken configures the static bearer token required to scrape
+// /metrics. When empty (the default), /metrics is exposed only to loopback
+// callers so a self-hosted Prometheus on the same host keeps working
+// without config — but LAN/internet scrapes are refused. A non-empty
+// token requires "Authorization: Bearer <token>" regardless of source.
+func (s *Server) SetMetricsToken(token string) {
+	s.metricsToken = strings.TrimSpace(token)
+}
+
+// metricsAuth gates the /metrics endpoint. See SetMetricsToken for the
+// policy. Uses constant-time comparison to avoid leaking the configured
+// token via response timing.
+func (s *Server) metricsAuth(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if s.metricsToken == "" {
+			// No token configured → loopback-only access.
+			if !requestIsLoopback(r) {
+				writeError(w, http.StatusForbidden, "forbidden",
+					"/metrics is restricted to loopback when PAD_METRICS_TOKEN is unset")
+				return
+			}
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		const prefix = "Bearer "
+		authHeader := r.Header.Get("Authorization")
+		if !strings.HasPrefix(authHeader, prefix) {
+			w.Header().Set("WWW-Authenticate", `Bearer realm="metrics"`)
+			writeError(w, http.StatusUnauthorized, "unauthorized",
+				"Missing Bearer token for /metrics")
+			return
+		}
+		given := strings.TrimSpace(strings.TrimPrefix(authHeader, prefix))
+		if subtle.ConstantTimeCompare([]byte(given), []byte(s.metricsToken)) != 1 {
+			w.Header().Set("WWW-Authenticate", `Bearer realm="metrics"`)
+			writeError(w, http.StatusUnauthorized, "unauthorized",
+				"Invalid Bearer token for /metrics")
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
 // SetSSELimits configures global and per-workspace SSE connection limits.
 // A value of 0 means unlimited.
 func (s *Server) SetSSELimits(global, perWorkspace int) {
@@ -245,9 +291,22 @@ func (s *Server) setupRouter() {
 		r.Use(StrictTransportSecurity)
 	}
 
-	// Prometheus scrape endpoint — no auth/CSRF
+	// Prometheus scrape endpoint — exempt from the standard auth/CSRF stack
+	// (Prometheus can't present a session cookie or pass a CSRF header), but
+	// gated by a dedicated static bearer token. Without the gate, any
+	// unauthenticated caller on the network can read workspace counts, API
+	// usage patterns, and — via label enumeration — user/workspace IDs.
+	//
+	// The gate runs in three layers:
+	//   1. No PAD_METRICS_TOKEN → endpoint is open ONLY to loopback. Safe
+	//      default for self-hosters running Prometheus on the same box.
+	//   2. PAD_METRICS_TOKEN set → "Authorization: Bearer <token>" required.
+	//      Compared in constant time; empty/missing header → 401.
+	//   3. In either case the SecurityHeaders / rate-limit / logging chain
+	//      already wraps this group from the outer r.Use() calls above.
 	if s.metrics != nil {
 		r.Group(func(r chi.Router) {
+			r.Use(s.metricsAuth)
 			r.Handle("/metrics", promhttp.HandlerFor(s.metrics.Registry, promhttp.HandlerOpts{}))
 		})
 	}


### PR DESCRIPTION
## Summary
\`/metrics\` is no longer exposed to every caller on the network. Default: loopback-only. With \`PAD_METRICS_TOKEN\` set: \`Authorization: Bearer <token>\` required (constant-time compared).

## Context
Implements \`TASK-653\` (H4) under \`PLAN-643\` (OSS Security Hardening). Previously \`/metrics\` was served outside the auth middleware group — unauthenticated scrapes revealed workspace counts, API usage patterns, and (via labels) user/workspace IDs.

## Changes
- \`internal/server/server.go\` — new \`metricsAuth\` middleware wraps the \`/metrics\` group. \`subtle.ConstantTimeCompare\` on the token. \`WWW-Authenticate: Bearer realm="metrics"\` on 401s.
- \`SetMetricsToken(string)\` server API.
- \`internal/config/config.go\` — \`MetricsToken\` + \`PAD_METRICS_TOKEN\` env.
- \`cmd/pad/main.go\` — plumb config to server.
- \`.env.example\` — document \`PAD_METRICS_TOKEN\` with \`openssl rand -hex 32\` hint.
- \`internal/server/metrics_auth_test.go\` — coverage: loopback-allowed/LAN-denied when token unset; missing/wrong/correct Bearer when set; non-Bearer scheme rejected; \`WWW-Authenticate\` present on 401; \`/metrics\` returns 404 when \`SetMetrics\` wasn't called.

## Test plan
- [x] \`go build ./...\` — clean
- [x] \`go vet ./...\` — clean
- [x] \`go test ./...\` — all pass (3 new test cases)