### PR TITLE
chore(web): npm audit fix + CI audit gate (TASK-654)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,12 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Audit npm dependencies (production, high+)
+        # Fail the build on any HIGH or CRITICAL advisory in production deps.
+        # Dev-only advisories are treated as informational — they don't ship
+        # and fixing them can require waiting on upstream maintainers.
+        run: npm audit --audit-level=high --omit=dev
+
       - name: Build
         run: npm run build
 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -31,7 +31,7 @@
 			"devDependencies": {
 				"@sveltejs/adapter-auto": "^7.0.0",
 				"@sveltejs/adapter-static": "^3.0.10",
-				"@sveltejs/kit": "^2.50.2",
+				"@sveltejs/kit": "^2.57.1",
 				"@sveltejs/vite-plugin-svelte": "^6.2.4",
 				"@types/marked": "^5.0.2",
 				"marked": "^17.0.5",
@@ -61,42 +61,40 @@
 			"license": "MIT"
 		},
 		"node_modules/@chevrotain/cst-dts-gen": {
-			"version": "11.1.2",
-			"resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-11.1.2.tgz",
-			"integrity": "sha512-XTsjvDVB5nDZBQB8o0o/0ozNelQtn2KrUVteIHSlPd2VAV2utEb6JzyCJaJ8tGxACR4RiBNWy5uYUHX2eji88Q==",
+			"version": "12.0.0",
+			"resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-12.0.0.tgz",
+			"integrity": "sha512-fSL4KXjTl7cDgf0B5Rip9Q05BOrYvkJV/RrBTE/bKDN096E4hN/ySpcBK5B24T76dlQ2i32Zc3PAE27jFnFrKg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@chevrotain/gast": "11.1.2",
-				"@chevrotain/types": "11.1.2",
-				"lodash-es": "4.17.23"
+				"@chevrotain/gast": "12.0.0",
+				"@chevrotain/types": "12.0.0"
 			}
 		},
 		"node_modules/@chevrotain/gast": {
-			"version": "11.1.2",
-			"resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-11.1.2.tgz",
-			"integrity": "sha512-Z9zfXR5jNZb1Hlsd/p+4XWeUFugrHirq36bKzPWDSIacV+GPSVXdk+ahVWZTwjhNwofAWg/sZg58fyucKSQx5g==",
+			"version": "12.0.0",
+			"resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-12.0.0.tgz",
+			"integrity": "sha512-1ne/m3XsIT8aEdrvT33so0GUC+wkctpUPK6zU9IlOyJLUbR0rg4G7ZiApiJbggpgPir9ERy3FRjT6T7lpgetnQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@chevrotain/types": "11.1.2",
-				"lodash-es": "4.17.23"
+				"@chevrotain/types": "12.0.0"
 			}
 		},
 		"node_modules/@chevrotain/regexp-to-ast": {
-			"version": "11.1.2",
-			"resolved": "https://registry.npmjs.org/@chevrotain/regexp-to-ast/-/regexp-to-ast-11.1.2.tgz",
-			"integrity": "sha512-nMU3Uj8naWer7xpZTYJdxbAs6RIv/dxYzkYU8GSwgUtcAAlzjcPfX1w+RKRcYG8POlzMeayOQ/znfwxEGo5ulw==",
+			"version": "12.0.0",
+			"resolved": "https://registry.npmjs.org/@chevrotain/regexp-to-ast/-/regexp-to-ast-12.0.0.tgz",
+			"integrity": "sha512-p+EW9MaJwgaHguhoqwOtx/FwuGr+DnNn857sXWOi/mClXIkPGl3rn7hGNWvo31HA3vyeQxjqe+H36yZJwYU8cA==",
 			"license": "Apache-2.0"
 		},
 		"node_modules/@chevrotain/types": {
-			"version": "11.1.2",
-			"resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.1.2.tgz",
-			"integrity": "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==",
+			"version": "12.0.0",
+			"resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-12.0.0.tgz",
+			"integrity": "sha512-S+04vjFQKeuYw0/eW3U52LkAHQsB1ASxsPGsLPUyQgrZ2iNNibQrsidruDzjEX2JYfespXMG0eZmXlhA6z7nWA==",
 			"license": "Apache-2.0"
 		},
 		"node_modules/@chevrotain/utils": {
-			"version": "11.1.2",
-			"resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-11.1.2.tgz",
-			"integrity": "sha512-4mudFAQ6H+MqBTfqLmU7G1ZwRzCLfJEooL/fsF6rCX5eePMbGhoy5n4g+G4vlh2muDcsCTJtL+uKbOzWxs5LHA==",
+			"version": "12.0.0",
+			"resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-12.0.0.tgz",
+			"integrity": "sha512-lB59uJoaGIfOOL9knQqQRfhl9g7x8/wqFkp13zTdkRu1huG9kg6IJs1O8hqj9rs6h7orGxHJUKb+mX3rPbWGhA==",
 			"license": "Apache-2.0"
 		},
 		"node_modules/@esbuild/aix-ppc64": {
@@ -1076,9 +1074,9 @@
 			}
 		},
 		"node_modules/@sveltejs/kit": {
-			"version": "2.55.0",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.55.0.tgz",
-			"integrity": "sha512-MdFRjevVxmAknf2NbaUkDF16jSIzXMWd4Nfah0Qp8TtQVoSp3bV4jKt8mX7z7qTUTWvgSaxtR0EG5WJf53gcuA==",
+			"version": "2.57.1",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.57.1.tgz",
+			"integrity": "sha512-VRdSbB96cI1EnRh09CqmnQqP/YJvET5buj8S6k7CxaJqBJD4bw4fRKDjcarAj/eX9k2eHifQfDH8NtOh+ZxxPw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1105,7 +1103,7 @@
 				"@opentelemetry/api": "^1.0.0",
 				"@sveltejs/vite-plugin-svelte": "^3.0.0 || ^4.0.0-next.1 || ^5.0.0 || ^6.0.0-next.0 || ^7.0.0",
 				"svelte": "^4.0.0 || ^5.0.0-next.0",
-				"typescript": "^5.3.3",
+				"typescript": "^5.3.3 || ^6.0.0",
 				"vite": "^5.0.3 || ^6.0.0 || ^7.0.0-beta.0 || ^8.0.0"
 			},
 			"peerDependenciesMeta": {
@@ -2045,29 +2043,31 @@
 			}
 		},
 		"node_modules/chevrotain": {
-			"version": "11.1.2",
-			"resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.1.2.tgz",
-			"integrity": "sha512-opLQzEVriiH1uUQ4Kctsd49bRoFDXGGSC4GUqj7pGyxM3RehRhvTlZJc1FL/Flew2p5uwxa1tUDWKzI4wNM8pg==",
+			"version": "12.0.0",
+			"resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-12.0.0.tgz",
+			"integrity": "sha512-csJvb+6kEiQaqo1woTdSAuOWdN0WTLIydkKrBnS+V5gZz0oqBrp4kQ35519QgK6TpBThiG3V1vNSHlIkv4AglQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@chevrotain/cst-dts-gen": "11.1.2",
-				"@chevrotain/gast": "11.1.2",
-				"@chevrotain/regexp-to-ast": "11.1.2",
-				"@chevrotain/types": "11.1.2",
-				"@chevrotain/utils": "11.1.2",
-				"lodash-es": "4.17.23"
+				"@chevrotain/cst-dts-gen": "12.0.0",
+				"@chevrotain/gast": "12.0.0",
+				"@chevrotain/regexp-to-ast": "12.0.0",
+				"@chevrotain/types": "12.0.0",
+				"@chevrotain/utils": "12.0.0"
+			},
+			"engines": {
+				"node": ">=22.0.0"
 			}
 		},
 		"node_modules/chevrotain-allstar": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/chevrotain-allstar/-/chevrotain-allstar-0.3.1.tgz",
-			"integrity": "sha512-b7g+y9A0v4mxCW1qUhf3BSVPg+/NvGErk/dOkrDaHA0nQIQGAtrOjlX//9OQtRlSCy+x9rfB5N8yC71lH1nvMw==",
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/chevrotain-allstar/-/chevrotain-allstar-0.4.1.tgz",
+			"integrity": "sha512-PvVJm3oGqrveUVW2Vt/eZGeiAIsJszYweUcYwcskg9e+IubNYKKD+rHHem7A6XVO22eDAL+inxNIGAzZ/VIWlA==",
 			"license": "MIT",
 			"dependencies": {
 				"lodash-es": "^4.17.21"
 			},
 			"peerDependencies": {
-				"chevrotain": "^11.0.0"
+				"chevrotain": "^12.0.0"
 			}
 		},
 		"node_modules/chokidar": {
@@ -2140,9 +2140,9 @@
 			"license": "MIT"
 		},
 		"node_modules/cookie": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-			"integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+			"integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -2741,9 +2741,9 @@
 			"license": "MIT"
 		},
 		"node_modules/dompurify": {
-			"version": "3.3.3",
-			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
-			"integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+			"version": "3.4.1",
+			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.1.tgz",
+			"integrity": "sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==",
 			"license": "(MPL-2.0 OR Apache-2.0)",
 			"optionalDependencies": {
 				"@types/trusted-types": "^2.0.7"
@@ -2987,13 +2987,14 @@
 			}
 		},
 		"node_modules/langium": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/langium/-/langium-4.2.1.tgz",
-			"integrity": "sha512-zu9QWmjpzJcomzdJQAHgDVhLGq5bLosVak1KVa40NzQHXfqr4eAHupvnPOVXEoLkg6Ocefvf/93d//SB7du4YQ==",
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/langium/-/langium-4.2.2.tgz",
+			"integrity": "sha512-JUshTRAfHI4/MF9dH2WupvjSXyn8JBuUEWazB8ZVJUtXutT0doDlAv1XKbZ1Pb5sMexa8FF4CFBc0iiul7gbUQ==",
 			"license": "MIT",
 			"dependencies": {
-				"chevrotain": "~11.1.1",
-				"chevrotain-allstar": "~0.3.1",
+				"@chevrotain/regexp-to-ast": "~12.0.0",
+				"chevrotain": "~12.0.0",
+				"chevrotain-allstar": "~0.4.1",
 				"vscode-languageserver": "~9.0.1",
 				"vscode-languageserver-textdocument": "~1.0.11",
 				"vscode-uri": "~3.1.0"
@@ -3043,9 +3044,9 @@
 			}
 		},
 		"node_modules/lodash-es": {
-			"version": "4.17.23",
-			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-			"integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+			"version": "4.18.1",
+			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+			"integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
 			"license": "MIT"
 		},
 		"node_modules/lowlight": {
@@ -3294,9 +3295,9 @@
 			"license": "ISC"
 		},
 		"node_modules/picomatch": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -3970,9 +3971,9 @@
 			}
 		},
 		"node_modules/vite": {
-			"version": "7.3.1",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-			"integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+			"version": "7.3.2",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+			"integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/web/package.json
+++ b/web/package.json
@@ -15,7 +15,7 @@
 	"devDependencies": {
 		"@sveltejs/adapter-auto": "^7.0.0",
 		"@sveltejs/adapter-static": "^3.0.10",
-		"@sveltejs/kit": "^2.50.2",
+		"@sveltejs/kit": "^2.57.1",
 		"@sveltejs/vite-plugin-svelte": "^6.2.4",
 		"@types/marked": "^5.0.2",
 		"marked": "^17.0.5",
@@ -23,6 +23,9 @@
 		"svelte-check": "^4.4.2",
 		"typescript": "^5.9.3",
 		"vite": "^7.3.1"
+	},
+	"overrides": {
+		"cookie": "^0.7.2"
 	},
 	"dependencies": {
 		"@tiptap/core": "^3.20.4",


### PR DESCRIPTION
## Summary
Close the 11 npm advisories in \`web/\` and add \`npm audit --audit-level=high --omit=dev\` as a PR gate.

## Context
Implements \`TASK-654\` (H5) under \`PLAN-643\` (OSS Security Hardening). Pre-fix audit: 9 high + 1 moderate + 1 low across \`@sveltejs/kit\`, \`cookie\`, \`dompurify\`, \`vite\`, \`lodash-es\`, \`picomatch\`, \`chevrotain\`, \`langium\`, etc.

## Changes
- \`web/package.json\`: upgrade \`@sveltejs/kit\` to \`^2.57.1\`; add \`overrides\` pinning \`cookie\` to \`^0.7.2\` since upstream @sveltejs/kit@2.57.1 still ships \`cookie@0.6.0\` (LOW but trivial).
- \`web/package-lock.json\`: regenerated via \`npm install\` + \`npm audit fix\`.
- \`.github/workflows/ci.yml\`: new step after \`npm ci\` runs \`npm audit --audit-level=high --omit=dev\`. Fails the build on any HIGH+ advisory in production deps; dev-only advisories stay informational so CI isn't held hostage by unfixable upstream chevrotain/vite dev-server CVEs.

## Test plan
- [x] \`cd web && npm audit --audit-level=high --omit=dev\` → \`found 0 vulnerabilities\`
- [x] \`cd web && npm run build\` — clean
- [x] \`cd web && npm run check\` — same pre-existing errors as main (unrelated)
- [x] \`go test ./...\` — all pass