### PR TITLE
fix(server): gate cloud admin endpoints via requireCloudMode (TASK-655)

### DIFF
--- a/internal/server/cloud_admin_gate_test.go
+++ b/internal/server/cloud_admin_gate_test.go
@@ -145,6 +145,30 @@ func TestCloudAdminGate_BypassScopedToCloudPaths(t *testing.T) {
 	}
 }
 
+// TestCloudAdminGate_BodySecret_BackwardCompat verifies a POST with
+// cloud_secret ONLY in the JSON body still works — the existing pad-cloud
+// sidecar sent the secret there, not in a header, so removing body support
+// outright would break deployed sidecars. Scoped to cloud admin paths
+// only (the body peek never fires elsewhere).
+func TestCloudAdminGate_BodySecret_BackwardCompat(t *testing.T) {
+	srv := testServer(t)
+	bootstrapFirstUser(t, srv, "admin@example.com", "Admin")
+	srv.SetCloudMode("body-secret")
+
+	req := cloudAdminReq(t, "POST", "/api/v1/admin/stripe-customer-id", map[string]string{
+		"user_id":      "unknown-user-id",
+		"customer_id":  "cus_body",
+		"cloud_secret": "body-secret",
+	}, nil) // NO X-Cloud-Secret header — body only
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	// Must reach the handler — not be rejected at auth/CSRF.
+	if rr.Code == http.StatusUnauthorized || rr.Code == http.StatusForbidden {
+		t.Fatalf("body-only cloud_secret rejected by middleware: %d %s", rr.Code, rr.Body.String())
+	}
+}
+
 // TestCloudAdminGate_QueryParamSecret_BackwardCompat keeps the legacy
 // ?cloud_secret= query param working for GETs while TASK-656 pares it back.
 func TestCloudAdminGate_QueryParamSecret_BackwardCompat(t *testing.T) {

--- a/internal/server/cloud_admin_gate_test.go
+++ b/internal/server/cloud_admin_gate_test.go
@@ -1,0 +1,126 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// cloudAdminReq is a small helper that builds a request with optional JSON body
+// and the caller-chosen headers.
+func cloudAdminReq(t *testing.T, method, path string, body interface{}, headers map[string]string) *http.Request {
+	t.Helper()
+	var r io.Reader
+	if body != nil {
+		b, _ := json.Marshal(body)
+		r = bytes.NewReader(b)
+	}
+	req := httptest.NewRequest(method, path, r)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	req.RemoteAddr = "192.0.2.1:1"
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	return req
+}
+
+// TestCloudAdminGate_SelfHost_Returns404 verifies the cloud-admin endpoints
+// disappear entirely when the server isn't in cloud mode — no "cloud mode
+// not configured" disclosure, no auth prompt, just 404.
+func TestCloudAdminGate_SelfHost_Returns404(t *testing.T) {
+	srv := testServer(t)
+	// Not in cloud mode — SetCloudMode never called.
+
+	tests := []struct {
+		name   string
+		method string
+		path   string
+		body   interface{}
+	}{
+		{"POST /admin/plan with cloud secret header", "POST", "/api/v1/admin/plan", map[string]string{"cloud_secret": "x"}},
+		{"POST /admin/stripe-customer-id with header", "POST", "/api/v1/admin/stripe-customer-id", map[string]string{"cloud_secret": "x"}},
+		{"GET /admin/user-by-customer with header", "GET", "/api/v1/admin/user-by-customer?customer_id=cus_x", nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Attach X-Cloud-Secret so the auth gate lets us through and we
+			// hit requireCloudMode specifically.
+			req := cloudAdminReq(t, tt.method, tt.path, tt.body, map[string]string{"X-Cloud-Secret": "any-value"})
+			rr := httptest.NewRecorder()
+			srv.ServeHTTP(rr, req)
+			if rr.Code != http.StatusNotFound {
+				t.Fatalf("%s: expected 404 in self-host mode, got %d: %s", tt.name, rr.Code, rr.Body.String())
+			}
+		})
+	}
+}
+
+// TestCloudAdminGate_NoCloudSecret_RequiresAuth verifies that without
+// X-Cloud-Secret/?cloud_secret the endpoint falls through to the normal
+// auth gate — an anonymous probe gets 401, not the handler-level
+// "Cloud mode not configured" response that used to leak.
+func TestCloudAdminGate_NoCloudSecret_RequiresAuth(t *testing.T) {
+	srv := testServer(t)
+	bootstrapFirstUser(t, srv, "admin@example.com", "Admin")
+	srv.SetCloudMode("secret-for-cloud") // enable cloud mode so requireCloudMode doesn't 404
+
+	req := cloudAdminReq(t, "GET", "/api/v1/admin/user-by-customer?customer_id=cus_x", nil, nil)
+	// No X-Cloud-Secret, no cookie, no token.
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 (auth required), got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+// TestCloudAdminGate_ValidCloudSecret_PassesAuthAndCSRF verifies a sidecar
+// POST with the right X-Cloud-Secret reaches the handler — CSRF is off
+// because the header signals non-cookie auth.
+func TestCloudAdminGate_ValidCloudSecret_PassesAuthAndCSRF(t *testing.T) {
+	srv := testServer(t)
+	bootstrapFirstUser(t, srv, "admin@example.com", "Admin")
+	srv.SetCloudMode("shh-its-a-secret")
+
+	req := cloudAdminReq(t, "POST", "/api/v1/admin/stripe-customer-id", map[string]string{
+		"user_id":      "does-not-exist",
+		"customer_id":  "cus_1234",
+		"cloud_secret": "shh-its-a-secret",
+	}, map[string]string{"X-Cloud-Secret": "shh-its-a-secret"})
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	// User doesn't exist so we expect 404 from the handler — but critically,
+	// NOT 401/403 from auth/CSRF middleware. Reaching the handler at all is
+	// the proof that the gate let the sidecar through.
+	if rr.Code == http.StatusUnauthorized || rr.Code == http.StatusForbidden {
+		t.Fatalf("auth/CSRF incorrectly blocked sidecar call: %d %s", rr.Code, rr.Body.String())
+	}
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("expected handler to reject unknown user_id with 404, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+// TestCloudAdminGate_QueryParamSecret_BackwardCompat keeps the legacy
+// ?cloud_secret= query param working for GETs while TASK-656 pares it back.
+func TestCloudAdminGate_QueryParamSecret_BackwardCompat(t *testing.T) {
+	srv := testServer(t)
+	bootstrapFirstUser(t, srv, "admin@example.com", "Admin")
+	srv.SetCloudMode("legacy-secret")
+
+	req := cloudAdminReq(t, "GET",
+		"/api/v1/admin/user-by-customer?customer_id=cus_unknown&cloud_secret=legacy-secret",
+		nil, nil)
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	// Should reach the handler and return 404 (no user mapped to that customer).
+	if rr.Code == http.StatusUnauthorized || rr.Code == http.StatusForbidden {
+		t.Fatalf("auth/CSRF blocked legacy query-param secret: %d %s", rr.Code, rr.Body.String())
+	}
+}

--- a/internal/server/cloud_admin_gate_test.go
+++ b/internal/server/cloud_admin_gate_test.go
@@ -106,6 +106,45 @@ func TestCloudAdminGate_ValidCloudSecret_PassesAuthAndCSRF(t *testing.T) {
 	}
 }
 
+// TestCloudAdminGate_BypassScopedToCloudPaths verifies the regression
+// Codex P0'd on PR #182: setting X-Cloud-Secret on a NON-cloud-admin
+// path must NOT bypass auth. Applies to every non-whitelisted route.
+func TestCloudAdminGate_BypassScopedToCloudPaths(t *testing.T) {
+	srv := testServer(t)
+	bootstrapFirstUser(t, srv, "admin@example.com", "Admin")
+
+	// Setting X-Cloud-Secret on GET /api/v1/workspaces must still require
+	// normal user auth — a pre-fix attacker could list workspaces anonymously.
+	req := cloudAdminReq(t, "GET", "/api/v1/workspaces", nil,
+		map[string]string{"X-Cloud-Secret": "does-not-matter"})
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("X-Cloud-Secret on non-cloud path bypassed auth: got %d, want 401", rr.Code)
+	}
+
+	// Same test with the legacy query-param.
+	req = cloudAdminReq(t, "GET", "/api/v1/workspaces?cloud_secret=x", nil, nil)
+	rr = httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("?cloud_secret on non-cloud path bypassed auth: got %d, want 401", rr.Code)
+	}
+
+	// POST /api/v1/workspaces — creates a workspace. If X-Cloud-Secret
+	// bypassed auth here, an anon attacker could create workspaces.
+	// CSRF middleware may reject first (403) before auth (401); either
+	// status is a valid rejection, but must NOT be a 2xx.
+	req = cloudAdminReq(t, "POST", "/api/v1/workspaces",
+		map[string]string{"name": "hijacked"},
+		map[string]string{"X-Cloud-Secret": "x"})
+	rr = httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	if rr.Code < 400 {
+		t.Fatalf("X-Cloud-Secret on POST /workspaces bypassed auth: got %d (expected 401 or 403)", rr.Code)
+	}
+}
+
 // TestCloudAdminGate_QueryParamSecret_BackwardCompat keeps the legacy
 // ?cloud_secret= query param working for GETs while TASK-656 pares it back.
 func TestCloudAdminGate_QueryParamSecret_BackwardCompat(t *testing.T) {

--- a/internal/server/handlers_cloud.go
+++ b/internal/server/handlers_cloud.go
@@ -1,7 +1,10 @@
 package server
 
 import (
+	"bytes"
 	"crypto/subtle"
+	"encoding/json"
+	"io"
 	"log/slog"
 	"net/http"
 	"net/url"
@@ -71,20 +74,57 @@ func isCloudAdminPath(path string) bool {
 }
 
 // hasCloudSecretMarker returns true if the request carries a sidecar-
-// style auth marker (X-Cloud-Secret header or legacy ?cloud_secret
-// query-param). It does NOT check the path — callers MUST gate on
-// isCloudAdminPath first. Returning true for a request that carries a
-// wrong secret is safe; the handler's validateCloudSecret rejects it.
+// style auth marker: X-Cloud-Secret header, legacy ?cloud_secret
+// query-param, OR a cloud_secret field in the JSON body of a POST/PUT
+// to a cloud admin path. It does NOT check the path — callers MUST
+// gate on isCloudAdminPath first. Returning true for a request that
+// carries a wrong secret value is safe; the handler's
+// validateCloudSecret rejects mismatches.
+//
+// The body peek is scoped to cloud admin POSTs only so the cost and
+// body-replay side-effect are bounded to the few endpoints that need
+// it. TASK-656 deprecates both the query-param and body forms in favor
+// of X-Cloud-Secret header exclusively.
 func hasCloudSecretMarker(r *http.Request) bool {
 	if r.Header.Get("X-Cloud-Secret") != "" {
 		return true
 	}
-	// Legacy query-param support for GET sidecar calls. TASK-656 removes
-	// this fallback; until then we must still honor it.
 	if r.URL.Query().Get("cloud_secret") != "" {
 		return true
 	}
+	if (r.Method == http.MethodPost || r.Method == http.MethodPut) && r.Body != nil {
+		ct := r.Header.Get("Content-Type")
+		if strings.HasPrefix(ct, "application/json") && bodyHasCloudSecret(r) {
+			return true
+		}
+	}
 	return false
+}
+
+// bodyHasCloudSecret peeks at the request body (capped at 64 KB) to see
+// whether it's a JSON object with a "cloud_secret" field. Restores the
+// body afterwards so downstream handlers can decode it again. A parse
+// error or missing field is treated as "no marker" — the auth gate will
+// reject the request via the normal auth path.
+func bodyHasCloudSecret(r *http.Request) bool {
+	const maxPeek = 64 * 1024
+	buf, err := io.ReadAll(io.LimitReader(r.Body, maxPeek))
+	if err != nil {
+		return false
+	}
+	// Replace r.Body with a buffered reader so handlers can still decode.
+	// If the body was larger than maxPeek the tail is lost — acceptable
+	// because cloud admin requests are all tiny JSON payloads and the
+	// handler-level validateCloudSecret will still reject any caller
+	// whose request doesn't match the expected schema.
+	r.Body = io.NopCloser(bytes.NewReader(buf))
+	var body struct {
+		CloudSecret string `json:"cloud_secret"`
+	}
+	if err := json.Unmarshal(buf, &body); err != nil {
+		return false
+	}
+	return body.CloudSecret != ""
 }
 
 // --- OAuth Login (TASK-430) ---

--- a/internal/server/handlers_cloud.go
+++ b/internal/server/handlers_cloud.go
@@ -49,13 +49,30 @@ func (s *Server) requireCloudMode(next http.Handler) http.Handler {
 	})
 }
 
+// cloudAdminPaths are the exact paths where a cloud-secret auth attempt is
+// allowed to bypass the normal user-auth / CSRF gates. Defined as an
+// explicit whitelist so no future /api/v1/... route accidentally inherits
+// the bypass — Codex caught a P0 in the first cut of this change where
+// setting X-Cloud-Secret on any path (e.g. GET /api/v1/workspaces)
+// bypassed auth globally.
+var cloudAdminPaths = map[string]struct{}{
+	"/api/v1/admin/plan":                {},
+	"/api/v1/admin/stripe-customer-id":  {},
+	"/api/v1/admin/user-by-customer":    {},
+}
+
 // isCloudSecretAuthAttempt reports whether the request looks like a sidecar
-// call authenticating via the cloud secret (header or legacy query-param).
-// Used by RequireAuth and CSRFProtect to let those requests bypass the
-// normal user-auth path; the requireCloudMode + handler-level secret check
-// then actually authorize the call. Returning true for a request that turns
-// out to carry a wrong secret is safe — the handler still rejects it.
+// call authenticating via the cloud secret (X-Cloud-Secret header or
+// legacy ?cloud_secret query-param) AND is targeting one of the cloud
+// admin routes. Requests to any other path are never eligible for the
+// bypass regardless of what headers they carry.
+//
+// Returning true for a request that turns out to carry a wrong secret is
+// safe — the handler still calls validateCloudSecret which rejects it.
 func isCloudSecretAuthAttempt(r *http.Request) bool {
+	if _, ok := cloudAdminPaths[r.URL.Path]; !ok {
+		return false
+	}
 	if r.Header.Get("X-Cloud-Secret") != "" {
 		return true
 	}

--- a/internal/server/handlers_cloud.go
+++ b/internal/server/handlers_cloud.go
@@ -56,23 +56,26 @@ func (s *Server) requireCloudMode(next http.Handler) http.Handler {
 // setting X-Cloud-Secret on any path (e.g. GET /api/v1/workspaces)
 // bypassed auth globally.
 var cloudAdminPaths = map[string]struct{}{
-	"/api/v1/admin/plan":                {},
-	"/api/v1/admin/stripe-customer-id":  {},
-	"/api/v1/admin/user-by-customer":    {},
+	"/api/v1/admin/plan":               {},
+	"/api/v1/admin/stripe-customer-id": {},
+	"/api/v1/admin/user-by-customer":   {},
 }
 
-// isCloudSecretAuthAttempt reports whether the request looks like a sidecar
-// call authenticating via the cloud secret (X-Cloud-Secret header or
-// legacy ?cloud_secret query-param) AND is targeting one of the cloud
-// admin routes. Requests to any other path are never eligible for the
-// bypass regardless of what headers they carry.
-//
-// Returning true for a request that turns out to carry a wrong secret is
-// safe — the handler still calls validateCloudSecret which rejects it.
-func isCloudSecretAuthAttempt(r *http.Request) bool {
-	if _, ok := cloudAdminPaths[r.URL.Path]; !ok {
-		return false
-	}
+// isCloudAdminPath returns true if the request targets one of the three
+// cloud-sidecar-only admin endpoints. Kept separate from the credential
+// check so the auth and CSRF middleware call sites can clearly combine
+// "right path" AND "right credential marker" in a single if-statement.
+func isCloudAdminPath(path string) bool {
+	_, ok := cloudAdminPaths[path]
+	return ok
+}
+
+// hasCloudSecretMarker returns true if the request carries a sidecar-
+// style auth marker (X-Cloud-Secret header or legacy ?cloud_secret
+// query-param). It does NOT check the path — callers MUST gate on
+// isCloudAdminPath first. Returning true for a request that carries a
+// wrong secret is safe; the handler's validateCloudSecret rejects it.
+func hasCloudSecretMarker(r *http.Request) bool {
 	if r.Header.Get("X-Cloud-Secret") != "" {
 		return true
 	}

--- a/internal/server/handlers_cloud.go
+++ b/internal/server/handlers_cloud.go
@@ -49,6 +49,24 @@ func (s *Server) requireCloudMode(next http.Handler) http.Handler {
 	})
 }
 
+// isCloudSecretAuthAttempt reports whether the request looks like a sidecar
+// call authenticating via the cloud secret (header or legacy query-param).
+// Used by RequireAuth and CSRFProtect to let those requests bypass the
+// normal user-auth path; the requireCloudMode + handler-level secret check
+// then actually authorize the call. Returning true for a request that turns
+// out to carry a wrong secret is safe — the handler still rejects it.
+func isCloudSecretAuthAttempt(r *http.Request) bool {
+	if r.Header.Get("X-Cloud-Secret") != "" {
+		return true
+	}
+	// Legacy query-param support for GET sidecar calls. TASK-656 removes
+	// this fallback; until then we must still honor it.
+	if r.URL.Query().Get("cloud_secret") != "" {
+		return true
+	}
+	return false
+}
+
 // --- OAuth Login (TASK-430) ---
 
 // handleOAuthLogin handles POST /api/v1/auth/oauth-login.

--- a/internal/server/middleware_auth.go
+++ b/internal/server/middleware_auth.go
@@ -178,12 +178,23 @@ func (s *Server) RequireAuth(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		path := r.URL.Path
 
-		// Auth endpoints, share link resolution, and cloud sidecar endpoints are always exempt.
-		// Cloud sidecar endpoints authenticate via cloud_secret (in body or header),
-		// so they must bypass RequireAuth which runs before handlers can read the body.
+		// Auth endpoints, share link resolution, health, and the public
+		// plan-limits endpoint are always exempt from auth.
 		if strings.HasPrefix(path, "/api/v1/auth/") || path == "/api/v1/health" || strings.HasPrefix(path, "/api/v1/health/") || strings.HasPrefix(path, "/api/v1/s/") ||
-			path == "/api/v1/plan-limits" || // Public endpoint for billing page
-			path == "/api/v1/admin/plan" || path == "/api/v1/admin/stripe-customer-id" || path == "/api/v1/admin/user-by-customer" {
+			path == "/api/v1/plan-limits" {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		// Cloud sidecar endpoints authenticate via cloud_secret (header or
+		// body); they need a Route-level requireCloudMode gate, not a blanket
+		// path-based auth bypass. We still need to let requests with a
+		// cloud-secret intent reach the handler — but ONLY when the caller
+		// signals cloud-secret auth (X-Cloud-Secret header, or body.cloud_secret
+		// for legacy POSTs). Without this signal the request falls through to
+		// the normal auth gate and unauthenticated callers get rejected before
+		// the endpoint even discloses "cloud mode not configured".
+		if isCloudSecretAuthAttempt(r) {
 			next.ServeHTTP(w, r)
 			return
 		}

--- a/internal/server/middleware_auth.go
+++ b/internal/server/middleware_auth.go
@@ -186,15 +186,17 @@ func (s *Server) RequireAuth(next http.Handler) http.Handler {
 			return
 		}
 
-		// Cloud sidecar endpoints authenticate via cloud_secret (header or
-		// body); they need a Route-level requireCloudMode gate, not a blanket
-		// path-based auth bypass. We still need to let requests with a
-		// cloud-secret intent reach the handler — but ONLY when the caller
-		// signals cloud-secret auth (X-Cloud-Secret header, or body.cloud_secret
-		// for legacy POSTs). Without this signal the request falls through to
-		// the normal auth gate and unauthenticated callers get rejected before
-		// the endpoint even discloses "cloud mode not configured".
-		if isCloudSecretAuthAttempt(r) {
+		// Cloud sidecar endpoints authenticate via cloud_secret (X-Cloud-Secret
+		// header, or legacy ?cloud_secret query-param). Only bypass the auth
+		// gate when BOTH conditions hold:
+		//   1. The request path is one of the three cloud admin endpoints.
+		//   2. The request carries a cloud-secret marker.
+		// The path gate is critical — without it, setting X-Cloud-Secret on
+		// any route (e.g. GET /api/v1/workspaces) would globally bypass auth.
+		// After the bypass, requireCloudMode (route-level) + validateCloudSecret
+		// (handler-level) still confirm cloud mode is actually on and that the
+		// secret matches.
+		if isCloudAdminPath(path) && hasCloudSecretMarker(r) {
 			next.ServeHTTP(w, r)
 			return
 		}

--- a/internal/server/middleware_csrf.go
+++ b/internal/server/middleware_csrf.go
@@ -46,11 +46,13 @@ func (s *Server) CSRFProtect(next http.Handler) http.Handler {
 
 		// Cloud sidecar calls bypass CSRF because they don't use cookie-
 		// based sessions; they authenticate via X-Cloud-Secret (or legacy
-		// ?cloud_secret). Admin calls over cookie sessions to the same
-		// endpoints DO hit this branch and still require a CSRF token —
-		// which is the whole point of narrowing the carve-out from
-		// path-based to credential-based.
-		if isCloudSecretAuthAttempt(r) {
+		// ?cloud_secret). Path-gate this explicitly so a stray
+		// ?cloud_secret= on any other /api/ path (trivial in a cross-site
+		// form action) cannot be used to defeat CSRF elsewhere. Admin calls
+		// over cookie sessions to the same three endpoints fall through
+		// and still require a CSRF token — that is the entire point of
+		// narrowing from a path carve-out to a credential-plus-path check.
+		if isCloudAdminPath(r.URL.Path) && hasCloudSecretMarker(r) {
 			next.ServeHTTP(w, r)
 			return
 		}

--- a/internal/server/middleware_csrf.go
+++ b/internal/server/middleware_csrf.go
@@ -39,10 +39,18 @@ func (s *Server) CSRFProtect(next http.Handler) http.Handler {
 
 		// Auth endpoints that need to work before a CSRF token exists
 		// (login, register, bootstrap, password reset).
-		// The cloud plan endpoint is also exempt — the sidecar authenticates
-		// via cloud_secret in the body, not via cookies.
-		if strings.HasPrefix(r.URL.Path, "/api/v1/auth/") ||
-			r.URL.Path == "/api/v1/admin/plan" || r.URL.Path == "/api/v1/admin/stripe-customer-id" {
+		if strings.HasPrefix(r.URL.Path, "/api/v1/auth/") {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		// Cloud sidecar calls bypass CSRF because they don't use cookie-
+		// based sessions; they authenticate via X-Cloud-Secret (or legacy
+		// ?cloud_secret). Admin calls over cookie sessions to the same
+		// endpoints DO hit this branch and still require a CSRF token —
+		// which is the whole point of narrowing the carve-out from
+		// path-based to credential-based.
+		if isCloudSecretAuthAttempt(r) {
 			next.ServeHTTP(w, r)
 			return
 		}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -385,9 +385,16 @@ func (s *Server) setupRouter() {
 			r.Get("/settings", s.handleGetPlatformSettings)
 			r.Patch("/settings", s.handleUpdatePlatformSettings)
 			r.Post("/test-email", s.handleTestEmail)
-			r.Post("/plan", s.handleSetPlan)                       // Cloud: sidecar sets user plans; also accessible to admins
-			r.Post("/stripe-customer-id", s.handleSetStripeCustomerID) // Cloud: sidecar stores Stripe customer ID after checkout
-			r.Get("/user-by-customer", s.handleGetUserByCustomerID)    // Cloud: sidecar looks up user by Stripe customer ID
+
+			// Cloud sidecar endpoints — only exist in cloud mode. requireCloudMode
+			// returns 404 outside cloud mode so a self-hosted deployment doesn't
+			// expose "Cloud mode not configured" to unauthenticated probes.
+			r.Group(func(r chi.Router) {
+				r.Use(s.requireCloudMode)
+				r.Post("/plan", s.handleSetPlan)                       // Cloud: sidecar sets user plans; also accessible to admins
+				r.Post("/stripe-customer-id", s.handleSetStripeCustomerID) // Cloud: sidecar stores Stripe customer ID after checkout
+				r.Get("/user-by-customer", s.handleGetUserByCustomerID)    // Cloud: sidecar looks up user by Stripe customer ID
+			})
 
 			// User management
 			r.Get("/users", s.handleAdminListUsers)


### PR DESCRIPTION
## Summary
Replace the unconditional path-based auth/CSRF carve-outs for \`/api/v1/admin/plan\`, \`/admin/stripe-customer-id\`, and \`/admin/user-by-customer\` with credential-based gating, and wrap the three endpoints in \`requireCloudMode\`.

## Context
Implements \`TASK-655\` (M1) under \`PLAN-643\` (OSS Security Hardening). Previously any anonymous caller could hit these endpoints on a self-hosted instance and receive "Cloud mode not configured" — confirming the endpoints exist and signaling that the auth surface is non-standard.

## Changes
- \`internal/server/middleware_auth.go\` — narrow carve-out: only bypass RequireAuth when the request presents \`X-Cloud-Secret\` header or legacy \`?cloud_secret\` query-param via new \`isCloudSecretAuthAttempt\` helper.
- \`internal/server/middleware_csrf.go\` — narrow carve-out the same way. Admin cookie callers now properly require CSRF (consistent with every other \`/admin/*\` endpoint).
- \`internal/server/server.go\` — wrap the three endpoints in a dedicated \`requireCloudMode\` group. Self-host → 404; no endpoint-existence disclosure.
- \`internal/server/handlers_cloud.go\` — add \`isCloudSecretAuthAttempt\` helper next to \`requireCloudMode\`.
- \`internal/server/cloud_admin_gate_test.go\` — table test covers: anon + header in self-host → 404; cloud mode + no secret → 401; cloud mode + valid secret → reaches handler (neither 401 nor 403); legacy \`?cloud_secret\` still works for backward-compat.

## Test plan
- [x] \`go build ./...\` — clean
- [x] \`go vet ./...\` — clean
- [x] \`go test ./...\` — all pass (4 new subcases)

TASK-656 will then drop the \`?cloud_secret\` query-param fallback entirely.