### PR TITLE
fix(server): drop cloud_secret query-param fallback (TASK-656)

### DIFF
--- a/internal/server/cloud_admin_gate_test.go
+++ b/internal/server/cloud_admin_gate_test.go
@@ -169,9 +169,11 @@ func TestCloudAdminGate_BodySecret_BackwardCompat(t *testing.T) {
 	}
 }
 
-// TestCloudAdminGate_QueryParamSecret_BackwardCompat keeps the legacy
-// ?cloud_secret= query param working for GETs while TASK-656 pares it back.
-func TestCloudAdminGate_QueryParamSecret_BackwardCompat(t *testing.T) {
+// TestCloudAdminGate_QueryParamSecret_Rejected verifies TASK-656 dropped
+// the legacy ?cloud_secret= query-param — query values land in access
+// logs, so accepting them there leaked the cloud trust boundary. Must
+// be rejected by the auth gate.
+func TestCloudAdminGate_QueryParamSecret_Rejected(t *testing.T) {
 	srv := testServer(t)
 	bootstrapFirstUser(t, srv, "admin@example.com", "Admin")
 	srv.SetCloudMode("legacy-secret")
@@ -182,8 +184,27 @@ func TestCloudAdminGate_QueryParamSecret_BackwardCompat(t *testing.T) {
 	rr := httptest.NewRecorder()
 	srv.ServeHTTP(rr, req)
 
-	// Should reach the handler and return 404 (no user mapped to that customer).
-	if rr.Code == http.StatusUnauthorized || rr.Code == http.StatusForbidden {
-		t.Fatalf("auth/CSRF blocked legacy query-param secret: %d %s", rr.Code, rr.Body.String())
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("?cloud_secret= should no longer authenticate, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+// TestCloudAdminGate_HeaderSecret_StillAuthenticates confirms the header
+// form (the only supported sidecar auth after TASK-656) still works on
+// the GET endpoint that previously used query-param.
+func TestCloudAdminGate_HeaderSecret_StillAuthenticates(t *testing.T) {
+	srv := testServer(t)
+	bootstrapFirstUser(t, srv, "admin@example.com", "Admin")
+	srv.SetCloudMode("header-only")
+
+	req := cloudAdminReq(t, "GET",
+		"/api/v1/admin/user-by-customer?customer_id=cus_unknown",
+		nil, map[string]string{"X-Cloud-Secret": "header-only"})
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	// 404 from the handler (no user maps to the customer ID) — not 401/403.
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("expected handler-level 404, got %d: %s", rr.Code, rr.Body.String())
 	}
 }

--- a/internal/server/handlers_cloud.go
+++ b/internal/server/handlers_cloud.go
@@ -74,22 +74,22 @@ func isCloudAdminPath(path string) bool {
 }
 
 // hasCloudSecretMarker returns true if the request carries a sidecar-
-// style auth marker: X-Cloud-Secret header, legacy ?cloud_secret
-// query-param, OR a cloud_secret field in the JSON body of a POST/PUT
-// to a cloud admin path. It does NOT check the path — callers MUST
-// gate on isCloudAdminPath first. Returning true for a request that
-// carries a wrong secret value is safe; the handler's
-// validateCloudSecret rejects mismatches.
+// style auth marker: X-Cloud-Secret header or a cloud_secret field in
+// the JSON body of a POST/PUT to a cloud admin path. It does NOT check
+// the path — callers MUST gate on isCloudAdminPath first. Returning
+// true for a request that carries a wrong secret value is safe; the
+// handler's validateCloudSecret rejects mismatches.
 //
 // The body peek is scoped to cloud admin POSTs only so the cost and
 // body-replay side-effect are bounded to the few endpoints that need
-// it. TASK-656 deprecates both the query-param and body forms in favor
-// of X-Cloud-Secret header exclusively.
+// it.
+//
+// The legacy ?cloud_secret= query-param is NOT honored here — query
+// values land in access logs, so a log-file compromise became a
+// compromise of the cloud trust boundary. Sidecars must send the
+// secret in the X-Cloud-Secret header (TASK-656).
 func hasCloudSecretMarker(r *http.Request) bool {
 	if r.Header.Get("X-Cloud-Secret") != "" {
-		return true
-	}
-	if r.URL.Query().Get("cloud_secret") != "" {
 		return true
 	}
 	if (r.Method == http.MethodPost || r.Method == http.MethodPut) && r.Body != nil {
@@ -590,16 +590,18 @@ func (s *Server) handleSetStripeCustomerID(w http.ResponseWriter, r *http.Reques
 // Called by the pad-cloud sidecar during Stripe subscription webhook processing
 // to resolve a Stripe customer back to a Pad user.
 func (s *Server) handleGetUserByCustomerID(w http.ResponseWriter, r *http.Request) {
-	// 1. Validate cloud secret (via header preferred, query param fallback) or admin auth.
-	// NOTE: query param is supported for GET convenience but may appear in access logs.
-	// Prefer X-Cloud-Secret header in production.
+	// 1. Validate cloud secret via X-Cloud-Secret header (or admin auth).
+	//
+	// NOTE: ?cloud_secret= was previously accepted for GET convenience but
+	// dropped in TASK-656 — query-param values land in access logs (our
+	// StructuredLogger records the full path + query, and any fronting
+	// reverse proxy typically logs the same), so a log file compromise
+	// became a compromise of the cloud trust boundary. Sidecars must now
+	// send the secret in the X-Cloud-Secret header.
 	user := currentUser(r)
 	isAdmin := user != nil && user.Role == "admin"
 	if !isAdmin {
 		secret := r.Header.Get("X-Cloud-Secret")
-		if secret == "" {
-			secret = r.URL.Query().Get("cloud_secret")
-		}
 		if !s.validateCloudSecret(secret, w) {
 			return
 		}


### PR DESCRIPTION
## Summary
Remove the legacy \`?cloud_secret=\` query-param authentication for the cloud admin endpoints. Sidecars must use the \`X-Cloud-Secret\` header.

## Context
Implements \`TASK-656\` (M1b) under \`PLAN-643\` (OSS Security Hardening). Query-string values land in access logs (our StructuredLogger records path + raw query; fronting reverse proxies do the same), so accepting secrets there turned a log-file compromise into a cloud-trust-boundary compromise.

## Changes
- \`internal/server/handlers_cloud.go\`:
  - \`handleGetUserByCustomerID\` — only checks \`X-Cloud-Secret\` header for sidecar auth; admin cookie/token still works.
  - \`hasCloudSecretMarker\` — query-param branch removed. Header or body-only for POSTs.
- \`internal/server/cloud_admin_gate_test.go\`:
  - Flip \`TestCloudAdminGate_QueryParamSecret_BackwardCompat\` → \`TestCloudAdminGate_QueryParamSecret_Rejected\` (now asserts 401).
  - New \`TestCloudAdminGate_HeaderSecret_StillAuthenticates\` verifies the GET endpoint still accepts the header form.

## Breaking change
Deployed \`pad-cloud\` sidecar must send \`X-Cloud-Secret: <token>\` instead of \`?cloud_secret=<token>\`. Body-based \`cloud_secret\` on POSTs still works (TASK-655 back-compat) but is also scheduled for eventual removal.

## Test plan
- [x] \`go build ./...\` — clean
- [x] \`go vet ./...\` — clean
- [x] \`go test ./...\` — all pass (2 test flips + 1 new)