### PR TITLE
fix(server): escape unsubscribe page via html/template + strict CSP (TASK-657)

### DIFF
--- a/internal/server/handlers_unsubscribe.go
+++ b/internal/server/handlers_unsubscribe.go
@@ -3,7 +3,8 @@ package server
 import (
 	"crypto/sha256"
 	"encoding/hex"
-	"fmt"
+	"html/template"
+	"log/slog"
 	"net/http"
 	"strings"
 
@@ -28,46 +29,85 @@ func (s *Server) handleUnsubscribe(w http.ResponseWriter, r *http.Request) {
 	token := r.URL.Query().Get("token")
 
 	if emailAddr == "" || token == "" {
-		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		w.WriteHeader(http.StatusBadRequest)
-		fmt.Fprint(w, unsubPage("Invalid Link", "This unsubscribe link is missing required parameters."))
+		renderUnsubPage(w, http.StatusBadRequest, unsubData{
+			Title:   "Invalid Link",
+			Message: "This unsubscribe link is missing required parameters.",
+		})
 		return
 	}
 
 	secret := s.unsubscribeSecret()
 	if secret == "" || !email.ValidateUnsubscribeToken(emailAddr, token, secret) {
-		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		w.WriteHeader(http.StatusBadRequest)
-		fmt.Fprint(w, unsubPage("Invalid Link", "This unsubscribe link is invalid or has expired."))
+		renderUnsubPage(w, http.StatusBadRequest, unsubData{
+			Title:   "Invalid Link",
+			Message: "This unsubscribe link is invalid or has expired.",
+		})
 		return
 	}
 
 	if err := s.store.OptOutEmail(emailAddr); err != nil {
-		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		w.WriteHeader(http.StatusInternalServerError)
-		fmt.Fprint(w, unsubPage("Error", "Something went wrong. Please try again later."))
+		renderUnsubPage(w, http.StatusInternalServerError, unsubData{
+			Title:   "Error",
+			Message: "Something went wrong. Please try again later.",
+		})
 		return
 	}
 
-	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	fmt.Fprint(w, unsubPage("Unsubscribed",
-		fmt.Sprintf("You've been unsubscribed. <strong>%s</strong> will no longer receive non-transactional emails from this Pad instance.", emailAddr)))
+	renderUnsubPage(w, http.StatusOK, unsubData{
+		Title: "Unsubscribed",
+		// The template autoescapes Email before it reaches the rendered
+		// HTML, so even a malicious address like `"><script>alert(1)</script>`
+		// is neutered. The <strong> wrapping is applied in the template,
+		// not here — never again interpolate user input into a format
+		// string that composes HTML.
+		Message:          "You've been unsubscribed.",
+		ShowEmailMessage: true,
+		Email:            emailAddr,
+	})
 }
 
-func unsubPage(title, message string) string {
-	return fmt.Sprintf(`<!DOCTYPE html>
+type unsubData struct {
+	Title            string
+	Message          string
+	ShowEmailMessage bool
+	Email            string
+}
+
+// unsubPageTemplate is compiled once at init time. html/template auto-
+// escapes any value interpolated with {{.Field}}, so user-controlled
+// fields cannot inject markup or scripts into the rendered page.
+var unsubPageTemplate = template.Must(template.New("unsub").Parse(`<!DOCTYPE html>
 <html>
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>%s — Pad</title>
+<title>{{.Title}} — Pad</title>
 </head>
 <body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; color: #1a1a1a; max-width: 480px; margin: 80px auto; padding: 0 20px; text-align: center;">
   <div style="margin-bottom: 24px;">
     <strong style="font-size: 18px;">Pad</strong>
   </div>
-  <h1 style="font-size: 22px; font-weight: 600; margin-bottom: 12px;">%s</h1>
-  <p style="font-size: 15px; line-height: 1.5; color: #444;">%s</p>
+  <h1 style="font-size: 22px; font-weight: 600; margin-bottom: 12px;">{{.Title}}</h1>
+  <p style="font-size: 15px; line-height: 1.5; color: #444;">
+    {{.Message}}{{if .ShowEmailMessage}} <strong>{{.Email}}</strong> will no longer receive non-transactional emails from this Pad instance.{{end}}
+  </p>
 </body>
-</html>`, title, title, message)
+</html>`))
+
+// renderUnsubPage writes the unsubscribe status page with a strict CSP.
+// The CSP denies scripts, inline event handlers, iframes, and remote
+// resources outright — this page only needs its own inline styles, and
+// the HTML-escaped output already covers most XSS. CSP is defense in
+// depth for any future regression in the email validation / template.
+func renderUnsubPage(w http.ResponseWriter, status int, data unsubData) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Header().Set("Content-Security-Policy",
+		"default-src 'none'; style-src 'unsafe-inline'; script-src 'none'; script-src-attr 'none'; frame-ancestors 'none'; base-uri 'none'")
+	w.Header().Set("Referrer-Policy", "no-referrer")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.WriteHeader(status)
+	if err := unsubPageTemplate.Execute(w, data); err != nil {
+		// Response already committed — best we can do is log.
+		slog.Error("unsubscribe template render failed", "error", err)
+	}
 }

--- a/internal/server/handlers_unsubscribe_test.go
+++ b/internal/server/handlers_unsubscribe_test.go
@@ -1,0 +1,57 @@
+package server
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestUnsubscribePage_EscapesUserInput confirms the rendered HTML
+// doesn't contain raw attacker-controlled markup even when a malicious
+// "email" string is fed to the data struct. Before TASK-657 we used
+// fmt.Sprintf to inject the email directly into the page.
+func TestUnsubscribePage_EscapesUserInput(t *testing.T) {
+	malicious := `"><script>alert('xss')</script>`
+	rr := httptest.NewRecorder()
+	renderUnsubPage(rr, 200, unsubData{
+		Title:            "Unsubscribed",
+		Message:          "You've been unsubscribed.",
+		ShowEmailMessage: true,
+		Email:            malicious,
+	})
+
+	body := rr.Body.String()
+	if strings.Contains(body, "<script>") {
+		t.Fatalf("unescaped <script> in response:\n%s", body)
+	}
+	// Confirm the escaped form IS present — i.e. the content was rendered,
+	// just neutered.
+	if !strings.Contains(body, "&lt;script&gt;") {
+		t.Fatalf("expected escaped script marker in response:\n%s", body)
+	}
+}
+
+// TestUnsubscribePage_SetsStrictCSP verifies the defense-in-depth
+// headers are applied on every render path.
+func TestUnsubscribePage_SetsStrictCSP(t *testing.T) {
+	rr := httptest.NewRecorder()
+	renderUnsubPage(rr, 200, unsubData{Title: "x", Message: "x"})
+
+	csp := rr.Header().Get("Content-Security-Policy")
+	if csp == "" {
+		t.Fatal("CSP header missing on unsubscribe response")
+	}
+	for _, want := range []string{
+		"default-src 'none'",
+		"script-src 'none'",
+		"script-src-attr 'none'",
+		"frame-ancestors 'none'",
+	} {
+		if !strings.Contains(csp, want) {
+			t.Errorf("CSP missing directive %q; got: %s", want, csp)
+		}
+	}
+	if rr.Header().Get("X-Content-Type-Options") != "nosniff" {
+		t.Error("missing X-Content-Type-Options: nosniff")
+	}
+}


### PR DESCRIPTION
## Summary
Render the unsubscribe page with \`html/template\` (auto-escaped) instead of \`fmt.Sprintf\`, and add a strict CSP + \`nosniff\` to every response from the handler.

## Context
Implements \`TASK-657\` (M2) under \`PLAN-643\` (OSS Security Hardening). Previously \`handleUnsubscribe\` built its HTML via \`fmt.Sprintf(..., emailAddr)\` — any future regression in email validation would surface as reflected/stored XSS.

## Changes
- \`internal/server/handlers_unsubscribe.go\`:
  - Compile the status page once at init time (\`template.Must\`).
  - Every user-reachable field flows through \`{{.Field}}\` so html/template auto-escapes it.
  - New \`renderUnsubPage\` helper sets \`Content-Security-Policy: default-src 'none'; style-src 'unsafe-inline'; script-src 'none'; script-src-attr 'none'; frame-ancestors 'none'; base-uri 'none'\`, plus \`Referrer-Policy: no-referrer\` and \`X-Content-Type-Options: nosniff\` on every render path.
- \`internal/server/handlers_unsubscribe_test.go\` — new coverage:
  - Malicious \`"\><script>\` email is escaped in the body.
  - Strict CSP directives and \`nosniff\` header set on every render.

## Test plan
- [x] \`go build ./...\` — clean
- [x] \`go vet ./...\` — clean
- [x] \`go test ./...\` — all pass (2 new tests)