### PR TITLE
fix(server): reject CORS wildcard when credentials are on (TASK-664)

### DIFF
--- a/internal/server/middleware_security.go
+++ b/internal/server/middleware_security.go
@@ -3,6 +3,7 @@ package server
 import (
 	"crypto/rand"
 	"encoding/base64"
+	"log/slog"
 	"net/http"
 	"strings"
 )
@@ -60,6 +61,13 @@ func generateCSPNonce() string {
 
 // parseCORSOrigins parses a comma-separated list of origins into a slice.
 // Returns default localhost origins if the input is empty.
+//
+// The '*' wildcard is explicitly dropped (with a log warning): the CORS
+// middleware is configured with AllowCredentials=true, and per the Fetch
+// spec browsers refuse to honor `Access-Control-Allow-Origin: *` when
+// credentials are being sent. Rejecting wildcards here prevents an
+// operator misconfiguration (e.g. `PAD_CORS_ORIGINS=*`) from looking
+// like it works in curl but failing silently in every real browser.
 func parseCORSOrigins(origins string) []string {
 	if origins == "" {
 		return []string{"http://localhost:*", "http://127.0.0.1:*"}
@@ -68,12 +76,29 @@ func parseCORSOrigins(origins string) []string {
 	var result []string
 	for _, origin := range strings.Split(origins, ",") {
 		origin = strings.TrimSpace(origin)
-		if origin != "" {
-			result = append(result, origin)
+		if origin == "" {
+			continue
 		}
+		if origin == "*" {
+			slog.Warn("PAD_CORS_ORIGINS: dropping '*' — incompatible with AllowCredentials=true",
+				"hint", "list specific origins instead, e.g. https://pad.example.com")
+			continue
+		}
+		result = append(result, origin)
 	}
 	if len(result) == 0 {
 		return []string{"http://localhost:*", "http://127.0.0.1:*"}
 	}
 	return result
+}
+
+// corsAllowCredentials reports whether the CORS middleware should set
+// Access-Control-Allow-Credentials: true. The current CLI tooling uses
+// Bearer tokens rather than cookies for cross-origin calls, so when no
+// operator-configured origins are present we default to false — keeping
+// a browser on a different origin from piggy-backing user cookies on
+// its fetches. When operators provide explicit origins they opt into
+// credential sharing.
+func corsAllowCredentials(corsOrigins string) bool {
+	return strings.TrimSpace(corsOrigins) != ""
 }

--- a/internal/server/middleware_security_test.go
+++ b/internal/server/middleware_security_test.go
@@ -49,6 +49,12 @@ func TestParseCORSOrigins(t *testing.T) {
 		{"https://app.pad.dev", []string{"https://app.pad.dev"}},
 		{"https://app.pad.dev, https://admin.pad.dev", []string{"https://app.pad.dev", "https://admin.pad.dev"}},
 		{"  , ", []string{"http://localhost:*", "http://127.0.0.1:*"}}, // empty after trim
+		// TASK-664: '*' is incompatible with AllowCredentials=true and must
+		// be dropped. When it was the ONLY configured origin, parseCORSOrigins
+		// falls back to localhost defaults rather than producing an empty list.
+		{"*", []string{"http://localhost:*", "http://127.0.0.1:*"}},
+		{"https://app.pad.dev, *", []string{"https://app.pad.dev"}},
+		{"*, https://admin.pad.dev", []string{"https://admin.pad.dev"}},
 	}
 
 	for _, tt := range tests {
@@ -61,6 +67,28 @@ func TestParseCORSOrigins(t *testing.T) {
 			if got[i] != tt.want[i] {
 				t.Errorf("parseCORSOrigins(%q)[%d] = %q, want %q", tt.input, i, got[i], tt.want[i])
 			}
+		}
+	}
+}
+
+func TestCorsAllowCredentials(t *testing.T) {
+	// When PAD_CORS_ORIGINS is empty (or whitespace-only), AllowCredentials
+	// defaults to false. When an operator sets any non-empty value they
+	// opt into credential sharing across the listed origins. We don't
+	// second-guess a typo'd comma-only value — a stricter check should
+	// happen at parseCORSOrigins time.
+	tests := []struct {
+		in   string
+		want bool
+	}{
+		{"", false},
+		{"   ", false},
+		{"\t", false},
+		{"https://app.pad.dev", true},
+	}
+	for _, tt := range tests {
+		if got := corsAllowCredentials(tt.in); got != tt.want {
+			t.Errorf("corsAllowCredentials(%q) = %v, want %v", tt.in, got, tt.want)
 		}
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -314,10 +314,16 @@ func (s *Server) setupRouter() {
 	// All other routes — full middleware stack
 	r.Group(func(r chi.Router) {
 		r.Use(cors.Handler(cors.Options{
-			AllowedOrigins:   parseCORSOrigins(s.corsOrigins),
-			AllowedMethods:   []string{"GET", "POST", "PATCH", "PUT", "DELETE", "OPTIONS"},
-			AllowedHeaders:   []string{"Accept", "Authorization", "Content-Type", "X-CSRF-Token", "X-Share-Password"},
-			AllowCredentials: true,
+			AllowedOrigins: parseCORSOrigins(s.corsOrigins),
+			AllowedMethods: []string{"GET", "POST", "PATCH", "PUT", "DELETE", "OPTIONS"},
+			AllowedHeaders: []string{"Accept", "Authorization", "Content-Type", "X-CSRF-Token", "X-Share-Password"},
+			// Credentials flag is gated on an operator explicitly listing
+			// PAD_CORS_ORIGINS. The CLI uses Bearer tokens so the default
+			// "no CORS_ORIGINS set" path doesn't need credential sharing;
+			// leaving it off by default prevents cross-origin fetches from
+			// a browser on a different site from piggy-backing cookies
+			// on the victim's session.
+			AllowCredentials: corsAllowCredentials(s.corsOrigins),
 			MaxAge:           300,
 		}))
 		r.Use(s.TokenAuth)


### PR DESCRIPTION
## Summary
Drop \`*\` from \`PAD_CORS_ORIGINS\` (it's incompatible with \`AllowCredentials=true\`) and default \`AllowCredentials\` to false when no origins are explicitly configured.

## Context
Implements \`TASK-664\` (L1) under \`PLAN-643\` (OSS Security Hardening). Previously a typo like \`PAD_CORS_ORIGINS=*\` looked fine in curl but failed silently from every real browser, and empty \`PAD_CORS_ORIGINS\` ran with credential sharing on — letting a browser on a different origin piggy-back cookies on the victim's session.

## Changes
- \`internal/server/middleware_security.go\`:
  - \`parseCORSOrigins\` — explicit \`*\` dropped with a log warning; lone \`*\` falls back to localhost defaults.
  - New \`corsAllowCredentials(corsOrigins)\` — returns true only when an operator has set \`PAD_CORS_ORIGINS\`.
- \`internal/server/server.go\` — \`cors.Options.AllowCredentials = corsAllowCredentials(s.corsOrigins)\`.
- \`internal/server/middleware_security_test.go\` — coverage for \`*\` handling (lone / mixed / trailing) and \`corsAllowCredentials\` (empty / whitespace / explicit).

## Test plan
- [x] \`go build ./...\` — clean
- [x] \`go vet ./...\` — clean
- [x] \`go test ./...\` — all pass