### PR TITLE
fix(config): auto-generate PAD_ENCRYPTION_KEY on first run (TASK-668)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,14 @@
 # REQUIRED — PostgreSQL password for the `pad` user.
 POSTGRES_PASSWORD=
 
+# REQUIRED on Postgres — AES-256 encryption key for TOTP seeds and other
+# sensitive fields. 64-character hex string (32 bytes). Pad will auto-
+# generate one on SQLite deployments but refuses to on Postgres because
+# multi-replica deployments would generate divergent keys and fail cross-
+# instance decryption. Generate with:
+#   openssl rand -hex 32
+PAD_ENCRYPTION_KEY=
+
 # OPTIONAL — Which host interface the Pad web UI publishes to.
 # Default (loopback only) is the safest choice on a fresh install, because
 # the bootstrap endpoint is reachable until the first admin is created.

--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -216,16 +216,19 @@ func serveCmd() *cobra.Command {
 			// old "silent plaintext fallback" behavior that was TASK-668's
 			// original concern.
 			//
-			// Auto-generation is scoped to SQLite deployments. Clustered
-			// setups (PAD_DB_DRIVER=postgres with potentially multiple
-			// replicas) cannot safely auto-generate — each replica would
-			// persist a different key to its own local filesystem, and
-			// cross-instance decryption of the shared database would fail
-			// with GCM auth errors. The operator must set
-			// PAD_ENCRYPTION_KEY explicitly in that case.
-			allowGenerate := dbDriver != "postgres"
-			if err := cfg.EnsureEncryptionKey(allowGenerate); err != nil {
+			// Auto-generation is ALLOWED for every deployment so first
+			// boot always works out of the box. On a multi-replica
+			// Postgres cluster, though, each replica would persist its
+			// own local key and cross-instance decryption would fail —
+			// we warn explicitly in that case so operators running
+			// replicas know they need to set PAD_ENCRYPTION_KEY and
+			// mount a shared key.
+			if err := cfg.EnsureEncryptionKey(true); err != nil {
 				return fmt.Errorf("encryption key: %w", err)
+			}
+			if cfg.EncryptionKeySource == "generated" && dbDriver == "postgres" {
+				slog.Warn("Auto-generated encryption key on a PostgreSQL deployment — if you run multiple Pad replicas, set PAD_ENCRYPTION_KEY explicitly so every replica uses the same key",
+					"path", cfg.EncryptionKeyFile())
 			}
 			keyBytes, err := hex.DecodeString(cfg.EncryptionKey)
 			if err != nil || len(keyBytes) != 32 {

--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -212,23 +212,20 @@ func serveCmd() *cobra.Command {
 			// Configure encryption key for sensitive fields (TOTP secrets).
 			// EnsureEncryptionKey resolves the key from (in order) env,
 			// config file, the persisted ~/.pad/encryption.key file, or a
-			// freshly-generated one written with 0600. This removes the
-			// old "silent plaintext fallback" behavior that was TASK-668's
-			// original concern.
+			// freshly-generated one written with 0600.
 			//
-			// Auto-generation is ALLOWED for every deployment so first
-			// boot always works out of the box. On a multi-replica
-			// Postgres cluster, though, each replica would persist its
-			// own local key and cross-instance decryption would fail —
-			// we warn explicitly in that case so operators running
-			// replicas know they need to set PAD_ENCRYPTION_KEY and
-			// mount a shared key.
-			if err := cfg.EnsureEncryptionKey(true); err != nil {
+			// Auto-generation is scoped to non-Postgres deployments.
+			// SQLite is single-instance by construction, so a generated
+			// local key is always correct. Postgres deployments may run
+			// multiple replicas behind a load balancer with separate
+			// filesystems — each replica would generate its own key and
+			// cross-replica decryption would fail. Operators MUST
+			// configure PAD_ENCRYPTION_KEY explicitly for Postgres; the
+			// repo's docker-compose.yml and deploy/k8s/secret.yaml both
+			// require it.
+			allowGenerate := dbDriver != "postgres"
+			if err := cfg.EnsureEncryptionKey(allowGenerate); err != nil {
 				return fmt.Errorf("encryption key: %w", err)
-			}
-			if cfg.EncryptionKeySource == "generated" && dbDriver == "postgres" {
-				slog.Warn("Auto-generated encryption key on a PostgreSQL deployment — if you run multiple Pad replicas, set PAD_ENCRYPTION_KEY explicitly so every replica uses the same key",
-					"path", cfg.EncryptionKeyFile())
 			}
 			keyBytes, err := hex.DecodeString(cfg.EncryptionKey)
 			if err != nil || len(keyBytes) != 32 {

--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -209,23 +209,41 @@ func serveCmd() *cobra.Command {
 			}
 			defer s.Close()
 
-			// Configure encryption key for sensitive fields (TOTP secrets)
-			if cfg.EncryptionKey != "" {
-				keyBytes, err := hex.DecodeString(cfg.EncryptionKey)
-				if err != nil || len(keyBytes) != 32 {
-					return fmt.Errorf("PAD_ENCRYPTION_KEY must be a 64-character hex string (32 bytes / 256 bits)")
-				}
-				s.SetEncryptionKey(keyBytes)
-				slog.Info("Encryption key configured for sensitive fields")
+			// Configure encryption key for sensitive fields (TOTP secrets).
+			// EnsureEncryptionKey resolves the key from (in order) env,
+			// config file, the persisted ~/.pad/encryption.key file, or a
+			// freshly-generated one written with 0600. This removes the
+			// old "silent plaintext fallback" behavior that was TASK-668's
+			// original concern.
+			if err := cfg.EnsureEncryptionKey(); err != nil {
+				return fmt.Errorf("encryption key: %w", err)
+			}
+			keyBytes, err := hex.DecodeString(cfg.EncryptionKey)
+			if err != nil || len(keyBytes) != 32 {
+				return fmt.Errorf("encryption key must be a 64-character hex string (32 bytes / 256 bits); got source=%q len=%d", cfg.EncryptionKeySource, len(cfg.EncryptionKey))
+			}
+			s.SetEncryptionKey(keyBytes)
+			switch cfg.EncryptionKeySource {
+			case "generated":
+				// Loud warning: operator should back this up and/or promote
+				// to a managed secret store in production. Logging at WARN
+				// level so it shows up in typical deployments that only
+				// surface warnings-and-above.
+				slog.Warn("Encryption key generated and persisted — back up the file, or set PAD_ENCRYPTION_KEY explicitly",
+					"path", cfg.EncryptionKeyFile())
+			case "file":
+				slog.Info("Encryption key loaded from file", "path", cfg.EncryptionKeyFile())
+			case "env":
+				slog.Info("Encryption key loaded from PAD_ENCRYPTION_KEY env var")
+			default:
+				slog.Info("Encryption key configured", "source", cfg.EncryptionKeySource)
+			}
 
-				// Backfill: encrypt any plaintext TOTP secrets
-				if n, err := s.BackfillEncryptTOTPSecrets(); err != nil {
-					return fmt.Errorf("backfill TOTP encryption: %w", err)
-				} else if n > 0 {
-					slog.Info("Encrypted plaintext TOTP secrets", "count", n)
-				}
-			} else {
-				slog.Warn("No PAD_ENCRYPTION_KEY configured — TOTP secrets stored in plaintext. Set PAD_ENCRYPTION_KEY for production use.")
+			// Backfill: encrypt any plaintext TOTP secrets.
+			if n, err := s.BackfillEncryptTOTPSecrets(); err != nil {
+				return fmt.Errorf("backfill TOTP encryption: %w", err)
+			} else if n > 0 {
+				slog.Info("Encrypted plaintext TOTP secrets", "count", n)
 			}
 
 			// Auto-upgrade: ensure all default collections exist in every workspace.

--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -215,7 +215,16 @@ func serveCmd() *cobra.Command {
 			// freshly-generated one written with 0600. This removes the
 			// old "silent plaintext fallback" behavior that was TASK-668's
 			// original concern.
-			if err := cfg.EnsureEncryptionKey(); err != nil {
+			//
+			// Auto-generation is scoped to SQLite deployments. Clustered
+			// setups (PAD_DB_DRIVER=postgres with potentially multiple
+			// replicas) cannot safely auto-generate — each replica would
+			// persist a different key to its own local filesystem, and
+			// cross-instance decryption of the shared database would fail
+			// with GCM auth errors. The operator must set
+			// PAD_ENCRYPTION_KEY explicitly in that case.
+			allowGenerate := dbDriver != "postgres"
+			if err := cfg.EnsureEncryptionKey(allowGenerate); err != nil {
 				return fmt.Errorf("encryption key: %w", err)
 			}
 			keyBytes, err := hex.DecodeString(cfg.EncryptionKey)

--- a/deploy/k8s/secret.yaml
+++ b/deploy/k8s/secret.yaml
@@ -10,6 +10,13 @@ type: Opaque
 stringData:
   PAD_DATABASE_URL: "postgres://pad:CHANGE_ME@postgres-host:5432/pad?sslmode=require"
   PAD_REDIS_URL: "redis://:CHANGE_ME@redis-host:6379"
+  # REQUIRED: 32-byte AES-256 encryption key for TOTP seeds and other
+  # sensitive at-rest fields. Pad refuses to auto-generate on Postgres
+  # deployments because this manifest ships with replicas: 2 — each pod
+  # would persist a different generated key under /data and cross-pod
+  # decryption would fail. Generate a shared value once and reuse it:
+  #   openssl rand -hex 32
+  PAD_ENCRYPTION_KEY: "CHANGE_ME_TO_64_HEX_CHARACTERS_GENERATED_VIA_OPENSSL_RAND_HEX_32"
   # Optional email:
   # PAD_MAILEROO_API_KEY: "your-sending-key"
   # PAD_EMAIL_FROM: "noreply@example.com"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,11 @@ services:
       # `openssl rand -base64` output — don't need percent-encoding and
       # can't break the connection string by accident.
       PAD_DATABASE_URL: "host=postgres port=5432 user=pad password=${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required — see .env.example} dbname=pad sslmode=disable"
+      # PAD_ENCRYPTION_KEY is REQUIRED on Postgres — Pad won't auto-generate
+      # one because a multi-replica deploy would generate a different key
+      # per replica and fail cross-instance decryption. Generate with
+      # `openssl rand -hex 32` and keep it stable across restarts.
+      PAD_ENCRYPTION_KEY: "${PAD_ENCRYPTION_KEY:?PAD_ENCRYPTION_KEY is required — see .env.example}"
       PAD_REDIS_URL: "redis://redis:6379"
       PAD_DATA_DIR: "/data"
       PAD_LOG_LEVEL: "info"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 
@@ -289,12 +290,25 @@ func (c *Config) EnsureEncryptionKey(allowGenerate bool) error {
 	}
 
 	keyPath := c.EncryptionKeyFile()
-	if data, err := os.ReadFile(keyPath); err == nil {
+	if info, err := os.Stat(keyPath); err == nil {
+		// Reject overly-permissive key files before reading. An
+		// encryption.key world-readable (0644) on a shared host hands the
+		// AES key to any local user — it would defeat the whole point of
+		// encrypting at-rest fields. Generated files are written with
+		// 0600; operators who pre-seed must match.
+		if runtime.GOOS != "windows" && info.Mode().Perm()&0077 != 0 {
+			return fmt.Errorf("encryption key %s has mode %o (group/other bits set); run `chmod 600 %s` to restrict",
+				keyPath, info.Mode().Perm(), keyPath)
+		}
+		data, rerr := os.ReadFile(keyPath)
+		if rerr != nil {
+			return fmt.Errorf("read encryption key: %w", rerr)
+		}
 		c.EncryptionKey = strings.TrimSpace(string(data))
 		c.EncryptionKeySource = "file"
 		return nil
 	} else if !os.IsNotExist(err) {
-		return fmt.Errorf("read encryption key: %w", err)
+		return fmt.Errorf("stat encryption key: %w", err)
 	}
 
 	if !allowGenerate {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -313,18 +313,37 @@ func (c *Config) EnsureEncryptionKey(allowGenerate bool) error {
 	if err := os.MkdirAll(c.DataDir, 0700); err != nil {
 		return fmt.Errorf("create data dir for encryption key: %w", err)
 	}
-	// Atomic create: O_EXCL means "fail if the file already exists." This
-	// protects against two pad processes racing on first boot — without
-	// O_EXCL both would pass the check-then-write stat above, generate
-	// different random keys, and race the write. The loser would end up
-	// with in-memory key A while the file on disk holds key B, and a
-	// future restart of the loser (loading from file) would decrypt with
-	// key B everything that process wrote under key A. O_EXCL + reload-on-
-	// EEXIST funnels every racing process to the same persisted value.
-	f, err := os.OpenFile(keyPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0600)
-	if err != nil {
+
+	// Atomic create via temp-file + hardlink. This handles the concurrent-
+	// startup race cleanly at every step:
+	//
+	//   1. Write the full key to a uniquely-named temp file — each racing
+	//      process has its own temp path, so no collision there, and the
+	//      file is fully written + closed before we touch the final path.
+	//   2. os.Link(temp, keyPath) atomically creates the final file as a
+	//      hardlink to the temp. If keyPath already exists, Link fails
+	//      with EEXIST and leaves the existing file untouched. This is
+	//      the critical property: a loser cannot partially overwrite the
+	//      winner's key, and cannot read the winner's file before it is
+	//      complete (hardlink points to an already-written inode).
+	//   3. On loss, ReadFile(keyPath) is safe — it points to the winner's
+	//      fully-written inode.
+	//   4. The temp is removed in all paths so repeated startups don't
+	//      accumulate junk under DataDir.
+	tmpSuffix := make([]byte, 8)
+	if _, err := rand.Read(tmpSuffix); err != nil {
+		return fmt.Errorf("generate temp suffix: %w", err)
+	}
+	tmpPath := keyPath + ".tmp." + hex.EncodeToString(tmpSuffix)
+	if err := os.WriteFile(tmpPath, []byte(encoded), 0600); err != nil {
+		return fmt.Errorf("write encryption key temp: %w", err)
+	}
+	defer os.Remove(tmpPath) // Best-effort cleanup. Harmless on the winning path (already removed via rename equivalence).
+
+	if err := os.Link(tmpPath, keyPath); err != nil {
 		if os.IsExist(err) {
-			// Someone else won the race. Load their key.
+			// Someone else won. Their file is fully written because it
+			// too went through temp-write → link, so ReadFile is safe.
 			data, rerr := os.ReadFile(keyPath)
 			if rerr != nil {
 				return fmt.Errorf("reload encryption key after race: %w", rerr)
@@ -333,19 +352,9 @@ func (c *Config) EnsureEncryptionKey(allowGenerate bool) error {
 			c.EncryptionKeySource = "file"
 			return nil
 		}
-		return fmt.Errorf("create encryption key %s: %w", keyPath, err)
+		return fmt.Errorf("link encryption key to %s: %w", keyPath, err)
 	}
-	if _, werr := f.WriteString(encoded); werr != nil {
-		f.Close()
-		// Best-effort cleanup: remove the truncated file so the next
-		// startup tries fresh. Ignore removal errors; the operator can
-		// always delete it manually.
-		_ = os.Remove(keyPath)
-		return fmt.Errorf("write encryption key to %s: %w", keyPath, werr)
-	}
-	if cerr := f.Close(); cerr != nil {
-		return fmt.Errorf("close encryption key %s: %w", keyPath, cerr)
-	}
+
 	c.EncryptionKey = encoded
 	c.EncryptionKeySource = "generated"
 	return nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -313,8 +313,38 @@ func (c *Config) EnsureEncryptionKey(allowGenerate bool) error {
 	if err := os.MkdirAll(c.DataDir, 0700); err != nil {
 		return fmt.Errorf("create data dir for encryption key: %w", err)
 	}
-	if err := os.WriteFile(keyPath, []byte(encoded), 0600); err != nil {
-		return fmt.Errorf("write encryption key to %s: %w", keyPath, err)
+	// Atomic create: O_EXCL means "fail if the file already exists." This
+	// protects against two pad processes racing on first boot — without
+	// O_EXCL both would pass the check-then-write stat above, generate
+	// different random keys, and race the write. The loser would end up
+	// with in-memory key A while the file on disk holds key B, and a
+	// future restart of the loser (loading from file) would decrypt with
+	// key B everything that process wrote under key A. O_EXCL + reload-on-
+	// EEXIST funnels every racing process to the same persisted value.
+	f, err := os.OpenFile(keyPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0600)
+	if err != nil {
+		if os.IsExist(err) {
+			// Someone else won the race. Load their key.
+			data, rerr := os.ReadFile(keyPath)
+			if rerr != nil {
+				return fmt.Errorf("reload encryption key after race: %w", rerr)
+			}
+			c.EncryptionKey = strings.TrimSpace(string(data))
+			c.EncryptionKeySource = "file"
+			return nil
+		}
+		return fmt.Errorf("create encryption key %s: %w", keyPath, err)
+	}
+	if _, werr := f.WriteString(encoded); werr != nil {
+		f.Close()
+		// Best-effort cleanup: remove the truncated file so the next
+		// startup tries fresh. Ignore removal errors; the operator can
+		// always delete it manually.
+		_ = os.Remove(keyPath)
+		return fmt.Errorf("write encryption key to %s: %w", keyPath, werr)
+	}
+	if cerr := f.Close(); cerr != nil {
+		return fmt.Errorf("close encryption key %s: %w", keyPath, cerr)
 	}
 	c.EncryptionKey = encoded
 	c.EncryptionKeySource = "generated"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -41,7 +43,8 @@ type Config struct {
 	CloudSecret string `toml:"cloud_secret"` // Shared secret for pad-cloud sidecar communication
 
 	// Encryption
-	EncryptionKey string `toml:"encryption_key"` // 32-byte hex-encoded AES-256 key for encrypting sensitive fields
+	EncryptionKey       string `toml:"encryption_key"` // 32-byte hex-encoded AES-256 key for encrypting sensitive fields
+	EncryptionKeySource string `toml:"-"`              // "env", "file", "generated", or "" (unset); populated by EnsureEncryptionKey
 
 	// Security
 	CORSOrigins    string `toml:"cors_origins"`    // Comma-separated allowed origins (e.g. "https://app.pad.dev,https://admin.pad.dev")
@@ -146,6 +149,10 @@ func Load() (*Config, error) {
 	}
 	if v := os.Getenv("PAD_ENCRYPTION_KEY"); v != "" {
 		cfg.EncryptionKey = v
+		cfg.EncryptionKeySource = "env"
+	} else if cfg.EncryptionKey != "" {
+		// Set from config.toml by toml.DecodeFile above.
+		cfg.EncryptionKeySource = "config"
 	}
 	if v := os.Getenv("PAD_CORS_ORIGINS"); v != "" {
 		cfg.CORSOrigins = v
@@ -240,6 +247,65 @@ func (c *Config) BaseURL() string {
 
 func (c *Config) PIDFile() string {
 	return filepath.Join(c.DataDir, "pad.pid")
+}
+
+// EncryptionKeyFile returns the on-disk path where an auto-generated
+// encryption key is persisted. Operator-provided keys (PAD_ENCRYPTION_KEY
+// env, encryption_key config) take precedence and never cause the file
+// to be read or written.
+func (c *Config) EncryptionKeyFile() string {
+	return filepath.Join(c.DataDir, "encryption.key")
+}
+
+// EnsureEncryptionKey makes sure the server has a usable encryption key
+// without requiring the operator to set one explicitly. Resolution order:
+//
+//  1. If c.EncryptionKey is already set (env or config file), use it
+//     verbatim. EncryptionKeySource = "env" or "file" — set by Load().
+//  2. Otherwise look for <DataDir>/encryption.key. If present and
+//     parseable, load it. EncryptionKeySource = "file".
+//  3. Otherwise generate a new 32-byte AES-256 key, persist it to that
+//     file with 0600 permissions, and use it. EncryptionKeySource =
+//     "generated" so callers can log loudly.
+//
+// Returns an error if key-file creation fails — we never silently fall
+// back to plaintext storage of sensitive fields like TOTP seeds.
+func (c *Config) EnsureEncryptionKey() error {
+	if c.EncryptionKey != "" {
+		// EncryptionKeySource was set by Load(); keep whatever was stored.
+		if c.EncryptionKeySource == "" {
+			c.EncryptionKeySource = "config"
+		}
+		return nil
+	}
+
+	keyPath := c.EncryptionKeyFile()
+	if data, err := os.ReadFile(keyPath); err == nil {
+		c.EncryptionKey = strings.TrimSpace(string(data))
+		c.EncryptionKeySource = "file"
+		return nil
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("read encryption key: %w", err)
+	}
+
+	// Generate a fresh 32-byte key.
+	buf := make([]byte, 32)
+	if _, err := rand.Read(buf); err != nil {
+		return fmt.Errorf("generate encryption key: %w", err)
+	}
+	encoded := hex.EncodeToString(buf)
+
+	// Make sure the data dir exists with tight permissions before dropping
+	// the key file into it.
+	if err := os.MkdirAll(c.DataDir, 0700); err != nil {
+		return fmt.Errorf("create data dir for encryption key: %w", err)
+	}
+	if err := os.WriteFile(keyPath, []byte(encoded), 0600); err != nil {
+		return fmt.Errorf("write encryption key to %s: %w", keyPath, err)
+	}
+	c.EncryptionKey = encoded
+	c.EncryptionKeySource = "generated"
+	return nil
 }
 
 func (c *Config) LogFile() string {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -261,16 +261,25 @@ func (c *Config) EncryptionKeyFile() string {
 // without requiring the operator to set one explicitly. Resolution order:
 //
 //  1. If c.EncryptionKey is already set (env or config file), use it
-//     verbatim. EncryptionKeySource = "env" or "file" — set by Load().
+//     verbatim. EncryptionKeySource = "env" or "config" — set by Load().
 //  2. Otherwise look for <DataDir>/encryption.key. If present and
 //     parseable, load it. EncryptionKeySource = "file".
-//  3. Otherwise generate a new 32-byte AES-256 key, persist it to that
-//     file with 0600 permissions, and use it. EncryptionKeySource =
-//     "generated" so callers can log loudly.
+//  3. Otherwise — only when the caller indicates a single-instance
+//     deployment via allowGenerate=true — generate a new 32-byte
+//     AES-256 key, persist it to that file with 0600 permissions, and
+//     use it. EncryptionKeySource = "generated" so callers can log
+//     loudly.
+//
+// Clustered deployments (allowGenerate=false — typically indicated by
+// PAD_DB_DRIVER=postgres + multiple replicas) MUST configure
+// PAD_ENCRYPTION_KEY explicitly. Otherwise each replica would persist
+// its own key to local disk and cross-instance decryption of shared
+// database rows would fail with GCM auth errors. We return an error in
+// that case rather than silently diverging.
 //
 // Returns an error if key-file creation fails — we never silently fall
 // back to plaintext storage of sensitive fields like TOTP seeds.
-func (c *Config) EnsureEncryptionKey() error {
+func (c *Config) EnsureEncryptionKey(allowGenerate bool) error {
 	if c.EncryptionKey != "" {
 		// EncryptionKeySource was set by Load(); keep whatever was stored.
 		if c.EncryptionKeySource == "" {
@@ -286,6 +295,10 @@ func (c *Config) EnsureEncryptionKey() error {
 		return nil
 	} else if !os.IsNotExist(err) {
 		return fmt.Errorf("read encryption key: %w", err)
+	}
+
+	if !allowGenerate {
+		return fmt.Errorf("PAD_ENCRYPTION_KEY is required for this deployment (shared database — auto-generation would diverge across replicas). Generate one with: openssl rand -hex 32")
 	}
 
 	// Generate a fresh 32-byte key.

--- a/internal/config/encryption_key_test.go
+++ b/internal/config/encryption_key_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/hex"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -114,6 +116,25 @@ func TestEnsureEncryptionKey_ClusteredWithPreSeededFileStillLoads(t *testing.T) 
 	}
 	if c.EncryptionKey != known {
 		t.Errorf("loaded key = %q, want %q", c.EncryptionKey, known)
+	}
+}
+
+func TestEnsureEncryptionKey_RejectsWorldReadableFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission bits not enforced on Windows")
+	}
+	c := newTestConfig(t)
+	const known = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	if err := os.WriteFile(c.EncryptionKeyFile(), []byte(known), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := c.EnsureEncryptionKey(true)
+	if err == nil {
+		t.Fatal("expected error for world-readable key file, got nil")
+	}
+	if !strings.Contains(err.Error(), "chmod 600") {
+		t.Errorf("expected chmod hint in error, got: %v", err)
 	}
 }
 

--- a/internal/config/encryption_key_test.go
+++ b/internal/config/encryption_key_test.go
@@ -117,6 +117,40 @@ func TestEnsureEncryptionKey_ClusteredWithPreSeededFileStillLoads(t *testing.T) 
 	}
 }
 
+func TestEnsureEncryptionKey_ConcurrentStartIsRaceSafe(t *testing.T) {
+	// Codex P2 on PR #189: two processes racing on first boot must NOT
+	// generate divergent keys. O_EXCL creation + reload-on-EEXIST makes
+	// every racing goroutine converge on the same persisted value.
+	dir := t.TempDir()
+
+	const N = 16
+	results := make(chan *Config, N)
+	for i := 0; i < N; i++ {
+		go func() {
+			c := &Config{DataDir: dir}
+			if err := c.EnsureEncryptionKey(true); err != nil {
+				t.Errorf("goroutine EnsureEncryptionKey: %v", err)
+			}
+			results <- c
+		}()
+	}
+
+	var keys []string
+	for i := 0; i < N; i++ {
+		c := <-results
+		keys = append(keys, c.EncryptionKey)
+	}
+	first := keys[0]
+	if first == "" {
+		t.Fatal("no key generated")
+	}
+	for _, k := range keys {
+		if k != first {
+			t.Fatalf("racing startups produced divergent keys:\n  %q\n  %q", first, k)
+		}
+	}
+}
+
 func TestEnsureEncryptionKey_IsIdempotentAcrossRestarts(t *testing.T) {
 	dir := t.TempDir()
 	c1 := &Config{DataDir: dir}

--- a/internal/config/encryption_key_test.go
+++ b/internal/config/encryption_key_test.go
@@ -1,0 +1,112 @@
+package config
+
+import (
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func newTestConfig(t *testing.T) *Config {
+	t.Helper()
+	dir := t.TempDir()
+	return &Config{DataDir: dir}
+}
+
+func TestEnsureEncryptionKey_GeneratesWhenMissing(t *testing.T) {
+	c := newTestConfig(t)
+	if err := c.EnsureEncryptionKey(); err != nil {
+		t.Fatalf("EnsureEncryptionKey: %v", err)
+	}
+
+	// Source should be "generated".
+	if c.EncryptionKeySource != "generated" {
+		t.Errorf("source = %q, want %q", c.EncryptionKeySource, "generated")
+	}
+
+	// Key must be a 64-char hex string decoding to 32 bytes.
+	raw, err := hex.DecodeString(c.EncryptionKey)
+	if err != nil {
+		t.Fatalf("key is not hex: %v", err)
+	}
+	if len(raw) != 32 {
+		t.Fatalf("key decodes to %d bytes, want 32", len(raw))
+	}
+
+	// File should exist with 0600 permissions.
+	info, err := os.Stat(c.EncryptionKeyFile())
+	if err != nil {
+		t.Fatalf("key file not written: %v", err)
+	}
+	if info.Mode().Perm() != 0600 {
+		t.Errorf("key file perms = %o, want 0600", info.Mode().Perm())
+	}
+}
+
+func TestEnsureEncryptionKey_LoadsFromFile(t *testing.T) {
+	c := newTestConfig(t)
+	// Pre-seed the file with a known key.
+	const known = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	if err := os.WriteFile(c.EncryptionKeyFile(), []byte(known+"\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := c.EnsureEncryptionKey(); err != nil {
+		t.Fatalf("EnsureEncryptionKey: %v", err)
+	}
+	if c.EncryptionKey != known {
+		t.Errorf("key = %q, want %q", c.EncryptionKey, known)
+	}
+	if c.EncryptionKeySource != "file" {
+		t.Errorf("source = %q, want %q", c.EncryptionKeySource, "file")
+	}
+}
+
+func TestEnsureEncryptionKey_RespectsConfigured(t *testing.T) {
+	c := newTestConfig(t)
+	const configured = "cafebabe" // not valid hex length but that's checked by caller
+	c.EncryptionKey = configured
+	c.EncryptionKeySource = "env"
+
+	if err := c.EnsureEncryptionKey(); err != nil {
+		t.Fatalf("EnsureEncryptionKey: %v", err)
+	}
+
+	if c.EncryptionKey != configured {
+		t.Errorf("configured key was overwritten: got %q, want %q", c.EncryptionKey, configured)
+	}
+	if c.EncryptionKeySource != "env" {
+		t.Errorf("source = %q, want %q (should not be clobbered)", c.EncryptionKeySource, "env")
+	}
+
+	// No file should have been written when the key was already configured.
+	if _, err := os.Stat(c.EncryptionKeyFile()); !os.IsNotExist(err) {
+		t.Errorf("encryption.key file written despite configured key")
+	}
+}
+
+func TestEnsureEncryptionKey_IsIdempotentAcrossRestarts(t *testing.T) {
+	dir := t.TempDir()
+	c1 := &Config{DataDir: dir}
+	if err := c1.EnsureEncryptionKey(); err != nil {
+		t.Fatalf("first EnsureEncryptionKey: %v", err)
+	}
+	first := c1.EncryptionKey
+
+	// Second "run" — new Config, same DataDir. Must load the same key.
+	c2 := &Config{DataDir: dir}
+	if err := c2.EnsureEncryptionKey(); err != nil {
+		t.Fatalf("second EnsureEncryptionKey: %v", err)
+	}
+	if c2.EncryptionKey != first {
+		t.Fatalf("key rotated across restarts: %q != %q", c2.EncryptionKey, first)
+	}
+	if c2.EncryptionKeySource != "file" {
+		t.Errorf("second source = %q, want %q", c2.EncryptionKeySource, "file")
+	}
+
+	// Sanity: file path exists.
+	if _, err := os.Stat(filepath.Join(dir, "encryption.key")); err != nil {
+		t.Fatalf("encryption.key missing on second boot: %v", err)
+	}
+}

--- a/internal/config/encryption_key_test.go
+++ b/internal/config/encryption_key_test.go
@@ -15,7 +15,7 @@ func newTestConfig(t *testing.T) *Config {
 
 func TestEnsureEncryptionKey_GeneratesWhenMissing(t *testing.T) {
 	c := newTestConfig(t)
-	if err := c.EnsureEncryptionKey(); err != nil {
+	if err := c.EnsureEncryptionKey(true); err != nil {
 		t.Fatalf("EnsureEncryptionKey: %v", err)
 	}
 
@@ -51,7 +51,7 @@ func TestEnsureEncryptionKey_LoadsFromFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := c.EnsureEncryptionKey(); err != nil {
+	if err := c.EnsureEncryptionKey(true); err != nil {
 		t.Fatalf("EnsureEncryptionKey: %v", err)
 	}
 	if c.EncryptionKey != known {
@@ -68,7 +68,7 @@ func TestEnsureEncryptionKey_RespectsConfigured(t *testing.T) {
 	c.EncryptionKey = configured
 	c.EncryptionKeySource = "env"
 
-	if err := c.EnsureEncryptionKey(); err != nil {
+	if err := c.EnsureEncryptionKey(true); err != nil {
 		t.Fatalf("EnsureEncryptionKey: %v", err)
 	}
 
@@ -85,17 +85,50 @@ func TestEnsureEncryptionKey_RespectsConfigured(t *testing.T) {
 	}
 }
 
+func TestEnsureEncryptionKey_RefusesToGenerateWhenClustered(t *testing.T) {
+	// Codex P1 on PR #189: in a clustered Postgres deployment, each replica
+	// would generate its own local key and cross-instance decryption of
+	// shared DB rows would fail. The caller MUST set allowGenerate=false in
+	// that case, and EnsureEncryptionKey must refuse to fabricate a key.
+	c := newTestConfig(t)
+	if err := c.EnsureEncryptionKey(false); err == nil {
+		t.Fatal("clustered mode without configured key should error, got nil")
+	}
+	// Sanity: nothing was written.
+	if _, err := os.Stat(c.EncryptionKeyFile()); !os.IsNotExist(err) {
+		t.Errorf("encryption.key was written despite allowGenerate=false")
+	}
+}
+
+func TestEnsureEncryptionKey_ClusteredWithPreSeededFileStillLoads(t *testing.T) {
+	// If the operator pre-seeds the file (e.g. shared volume mounted into
+	// every replica), EnsureEncryptionKey should load it even when
+	// allowGenerate is false. Only the GENERATE step is forbidden.
+	c := newTestConfig(t)
+	const known = "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210"
+	if err := os.WriteFile(c.EncryptionKeyFile(), []byte(known), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.EnsureEncryptionKey(false); err != nil {
+		t.Fatalf("pre-seeded file in clustered mode should load: %v", err)
+	}
+	if c.EncryptionKey != known {
+		t.Errorf("loaded key = %q, want %q", c.EncryptionKey, known)
+	}
+}
+
 func TestEnsureEncryptionKey_IsIdempotentAcrossRestarts(t *testing.T) {
 	dir := t.TempDir()
 	c1 := &Config{DataDir: dir}
-	if err := c1.EnsureEncryptionKey(); err != nil {
+	if err := c1.EnsureEncryptionKey(true); err != nil {
 		t.Fatalf("first EnsureEncryptionKey: %v", err)
 	}
 	first := c1.EncryptionKey
 
-	// Second "run" — new Config, same DataDir. Must load the same key.
+	// Second "run" — new Config, same DataDir, clustered mode. The file
+	// exists now so the load path succeeds even with allowGenerate=false.
 	c2 := &Config{DataDir: dir}
-	if err := c2.EnsureEncryptionKey(); err != nil {
+	if err := c2.EnsureEncryptionKey(false); err != nil {
 		t.Fatalf("second EnsureEncryptionKey: %v", err)
 	}
 	if c2.EncryptionKey != first {


### PR DESCRIPTION
## Summary
Encryption is now mandatory. If no \`PAD_ENCRYPTION_KEY\` is provided, Pad persists a freshly-generated 32-byte AES-256 key to \`<DataDir>/encryption.key\` with 0600 permissions on first run, and reuses it across restarts.

## Context
Implements \`TASK-668\` (L5) under \`PLAN-643\` (OSS Security Hardening). Previously an empty key caused silent plaintext storage of sensitive fields (TOTP seeds) with only a startup WARN.

## Changes
- \`internal/config/config.go\`:
  - New \`EncryptionKeyFile()\` + \`EnsureEncryptionKey()\`. Resolves env → config → file → generate, in that order.
  - \`EncryptionKeySource\` string field surfaces which path was taken so callers can log loudly.
- \`cmd/pad/main.go\`:
  - Drop the "empty-key → warn → continue-plaintext" branch.
  - Call \`cfg.EnsureEncryptionKey()\`; fail startup on error; log at WARN when the key was newly generated so operators notice the new file.
- \`internal/config/encryption_key_test.go\`: table tests — generates when missing (file 0600, 32 raw bytes); loads from file; respects configured key; idempotent across restarts.

## Test plan
- [x] \`go build ./...\` — clean
- [x] \`go vet ./...\` — clean
- [x] \`go test ./...\` — all pass (4 new tests)