### PR TITLE
fix(server): derive CLI auth URL scheme from r.TLS, gate X-Forwarded-Proto on trusted proxies (TASK-665)

### DIFF
--- a/internal/server/handlers_cli_auth.go
+++ b/internal/server/handlers_cli_auth.go
@@ -2,7 +2,9 @@ package server
 
 import (
 	"fmt"
+	"net"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -21,15 +23,14 @@ func (s *Server) handleCreateCLIAuthSession(w http.ResponseWriter, r *http.Reque
 	// Build the auth URL that the user will open in their browser.
 	// Use the request's Host header to construct the URL so it works
 	// regardless of whether the server is at localhost, a VPS, or cloud.
-	scheme := "https"
-	if r.TLS == nil {
-		// Check X-Forwarded-Proto for reverse proxy setups
-		if proto := r.Header.Get("X-Forwarded-Proto"); proto != "" {
-			scheme = proto
-		} else {
-			scheme = "http"
-		}
-	}
+	//
+	// Security: derive the scheme from r.TLS first. Any HTTP client can
+	// inject X-Forwarded-Proto, so trust it ONLY when the request arrived
+	// from a peer in PAD_TRUSTED_PROXIES. A forged https:// in the CLI
+	// auth URL is low-impact phishing (user clicks a link in their own
+	// terminal), but the safe default is to ignore unauthenticated proxy
+	// headers on direct-exposed deployments.
+	scheme := cliAuthScheme(r, s.trustedProxyCIDRs)
 	authURL := fmt.Sprintf("%s://%s/auth/cli/%s", scheme, r.Host, sess.Code)
 
 	writeJSON(w, http.StatusOK, map[string]interface{}{
@@ -139,4 +140,35 @@ func (s *Server) handleApproveCLIAuthSession(w http.ResponseWriter, r *http.Requ
 		"approved": true,
 		"user":     sessionUserPayload(user),
 	})
+}
+
+// cliAuthScheme picks the URL scheme for the CLI auth link.
+//
+// Precedence:
+//  1. If the request hit this server over TLS (r.TLS != nil) → "https".
+//  2. If a trusted proxy is configured AND the direct TCP peer is in one
+//     of the trusted CIDRs, honor X-Forwarded-Proto. Only the first comma-
+//     separated value is used and it must be "http" or "https".
+//  3. Otherwise → "http". An untrusted client can still send X-Forwarded-
+//     Proto but we ignore it.
+//
+// This prevents an attacker from forging https://… in the terminal URL
+// printed by `pad auth login` on a plain-HTTP self-host deployment.
+func cliAuthScheme(r *http.Request, trustedCIDRs []*net.IPNet) string {
+	if r.TLS != nil {
+		return "https"
+	}
+	if len(trustedCIDRs) > 0 {
+		if peerIP := peerAddr(rawPeerAddr(r)); peerIP != nil && ipInCIDRs(peerIP, trustedCIDRs) {
+			if proto := r.Header.Get("X-Forwarded-Proto"); proto != "" {
+				// Some proxies emit "https, http" when multiple hops are
+				// involved; take the first value and normalize.
+				first := strings.ToLower(strings.TrimSpace(strings.SplitN(proto, ",", 2)[0]))
+				if first == "https" || first == "http" {
+					return first
+				}
+			}
+		}
+	}
+	return "http"
 }

--- a/internal/server/handlers_cli_auth_test.go
+++ b/internal/server/handlers_cli_auth_test.go
@@ -1,0 +1,114 @@
+package server
+
+import (
+	"context"
+	"crypto/tls"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCLIAuthScheme(t *testing.T) {
+	// Parse a trusted proxy CIDR once for reuse.
+	trustedCIDRs := ParseTrustedProxyCIDRs("10.0.0.0/8")
+	if len(trustedCIDRs) != 1 {
+		t.Fatalf("fixture: expected 1 CIDR, got %d", len(trustedCIDRs))
+	}
+
+	cases := []struct {
+		name         string
+		tls          bool
+		remoteAddr   string
+		proto        string
+		trustedCIDRs []*net.IPNet
+		want         string
+	}{
+		{
+			name:       "TLS terminated at server is always https",
+			tls:        true,
+			remoteAddr: "203.0.113.5:12345",
+			proto:      "http", // ignored
+			want:       "https",
+		},
+		{
+			name:         "Plain HTTP with no trusted proxies ignores X-Forwarded-Proto",
+			remoteAddr:   "203.0.113.5:12345",
+			proto:        "https",
+			trustedCIDRs: nil,
+			want:         "http",
+		},
+		{
+			name:         "Plain HTTP from untrusted peer ignores X-Forwarded-Proto",
+			remoteAddr:   "203.0.113.5:12345",
+			proto:        "https",
+			trustedCIDRs: trustedCIDRs,
+			want:         "http",
+		},
+		{
+			name:         "Plain HTTP from trusted peer with X-Forwarded-Proto=https returns https",
+			remoteAddr:   "10.0.0.1:12345",
+			proto:        "https",
+			trustedCIDRs: trustedCIDRs,
+			want:         "https",
+		},
+		{
+			name:         "Plain HTTP from trusted peer with X-Forwarded-Proto=http returns http",
+			remoteAddr:   "10.0.0.1:12345",
+			proto:        "http",
+			trustedCIDRs: trustedCIDRs,
+			want:         "http",
+		},
+		{
+			name:         "Plain HTTP from trusted peer with X-Forwarded-Proto=HTTPS (case-insensitive)",
+			remoteAddr:   "10.0.0.1:12345",
+			proto:        "HTTPS",
+			trustedCIDRs: trustedCIDRs,
+			want:         "https",
+		},
+		{
+			name:         "Plain HTTP from trusted peer with chained X-Forwarded-Proto takes first value",
+			remoteAddr:   "10.0.0.1:12345",
+			proto:        "https, http",
+			trustedCIDRs: trustedCIDRs,
+			want:         "https",
+		},
+		{
+			name:         "Plain HTTP from trusted peer with garbage X-Forwarded-Proto falls back to http",
+			remoteAddr:   "10.0.0.1:12345",
+			proto:        "javascript:",
+			trustedCIDRs: trustedCIDRs,
+			want:         "http",
+		},
+		{
+			name:         "Plain HTTP from trusted peer with empty X-Forwarded-Proto returns http",
+			remoteAddr:   "10.0.0.1:12345",
+			proto:        "",
+			trustedCIDRs: trustedCIDRs,
+			want:         "http",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/cli/sessions", nil)
+			req.Host = "pad.example.com"
+			req.RemoteAddr = tc.remoteAddr
+			if tc.proto != "" {
+				req.Header.Set("X-Forwarded-Proto", tc.proto)
+			}
+			if tc.tls {
+				req.TLS = &tls.ConnectionState{}
+			}
+			// Mirror what CapturePeerAddr would do in the real chain so that
+			// rawPeerAddr returns the untampered peer.
+			ctx := context.WithValue(req.Context(), peerAddrCtxKey{}, tc.remoteAddr)
+			req = req.WithContext(ctx)
+
+			got := cliAuthScheme(req, tc.trustedCIDRs)
+			if got != tc.want {
+				t.Errorf("cliAuthScheme() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
`handleCreateCLIAuthSession` accepted `X-Forwarded-Proto` from any client to choose the scheme for the browser auth URL printed by `pad auth login`. On a plain-HTTP self-host deployment an attacker could forge `https://` in that link — low-impact phishing (user clicks in their own terminal), but the safe default is to ignore unauthenticated proxy headers.

New precedence in `cliAuthScheme`:
1. `r.TLS != nil` → `https`
2. Peer in `PAD_TRUSTED_PROXIES` → honor `X-Forwarded-Proto` (first comma-separated value, case-insensitive, must be `http`/`https`)
3. Otherwise → `http`

Uses `rawPeerAddr` so the check still works after `TrustedProxyRealIP` rewrites `r.RemoteAddr`.

## Context
Implements `TASK-665` under `PLAN-643` (OSS Security Hardening).

## Test plan
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./...` — all tests pass
- [x] New table-driven test `TestCLIAuthScheme` covers TLS, untrusted-peer spoofing, trusted-peer forwarding, chained/case-insensitive/garbage `X-Forwarded-Proto` values