### PR TITLE
fix(server): deny-by-default whitelist for API token scopes (TASK-667)

### DIFF
--- a/internal/server/middleware_auth.go
+++ b/internal/server/middleware_auth.go
@@ -690,14 +690,9 @@ func clearSessionCookie(w http.ResponseWriter, secure bool) {
 func tokenScopeAllows(scopesJSON, method, path string) bool {
 	_ = path // reserved for future per-resource scopes
 
-	// Legacy tokens with no scopes column → full access. Same fast path
-	// for the explicit wildcard and for the explicit empty array (legacy
-	// "unrestricted" form). We compare the raw string so that other JSON
-	// values that ALSO decode to an empty slice (notably the literal
-	// `null`, which json.Unmarshal happily accepts) do NOT fall through
-	// the unrestricted path.
-	switch strings.TrimSpace(scopesJSON) {
-	case "", `["*"]`, `[ "*" ]`, `[]`:
+	// Empty string (legacy DB rows where the column was never populated)
+	// → full access. Same fast path for the explicit wildcard.
+	if scopesJSON == "" || strings.TrimSpace(scopesJSON) == `["*"]` {
 		return true
 	}
 
@@ -708,13 +703,20 @@ func tokenScopeAllows(scopesJSON, method, path string) bool {
 		return false
 	}
 
-	// Anything else that decoded to an empty slice (e.g. "null", or a
-	// non-array value accepted by some drivers) is NOT treated as
-	// legacy-unrestricted. Deny + warn so operators see the ambiguity.
-	if len(scopes) == 0 {
-		slog.Warn("token has non-array or null scopes; denying request",
+	// Distinguish JSON null (scopes == nil after unmarshal) from an
+	// explicit empty array (non-nil, len 0). null falls into the deny
+	// path because it signals a client-side serializer bug, not a
+	// documented legacy form. An explicit [] (including whitespace-
+	// padded "[ ]" or "[\n]") is the documented legacy-unrestricted
+	// form and keeps working.
+	if scopes == nil {
+		slog.Warn("token has null scopes; denying request",
 			"method", method, "path", path, "scopes_json", scopesJSON)
 		return false
+	}
+	if len(scopes) == 0 {
+		// Explicit empty array → unrestricted (legacy pre-enforcement).
+		return true
 	}
 
 	allowed := false

--- a/internal/server/middleware_auth.go
+++ b/internal/server/middleware_auth.go
@@ -669,47 +669,65 @@ func clearSessionCookie(w http.ResponseWriter, secure bool) {
 // and path. Scopes are stored as a JSON array of strings.
 //
 // Supported scopes:
-//   - "*"       — full access (default)
+//   - "*"       — full access
 //   - "read"    — GET/HEAD/OPTIONS only
 //   - "write"   — all methods
 //
-// An empty or unparseable scope string defaults to full access for
-// backward compatibility with tokens created before scope enforcement.
+// Policy (deny-by-default whitelist):
+//   - Empty scope string → allow (legacy DB rows where the column was never
+//     populated). These tokens pre-date scope enforcement.
+//   - Empty JSON array `[]` → allow (explicit "unrestricted" legacy form,
+//     equivalent to no scopes recorded).
+//   - Parseable array with at least one scope: allow iff a RECOGNIZED scope
+//     grants this method. Unrecognized scopes never contribute to allow
+//     and are logged once per request so operators can spot typos like
+//     "read-only" that would previously have fallen open.
+//   - Unparseable JSON → deny (data corruption or tampering). Previously
+//     fell open; that was the security concern behind TASK-667.
+//
+// Switching to deny-by-default closes the hole where a future scope name
+// like "read-only" would silently grant full access.
 func tokenScopeAllows(scopesJSON, method, path string) bool {
 	_ = path // reserved for future per-resource scopes
 
+	// Legacy tokens with no scopes column → full access. Same fast path
+	// for the explicit wildcard.
 	if scopesJSON == "" || scopesJSON == `["*"]` {
 		return true
 	}
 
 	var scopes []string
 	if err := json.Unmarshal([]byte(scopesJSON), &scopes); err != nil {
-		// Unparseable → allow (backward compat)
+		slog.Warn("token has unparseable scopes; denying request",
+			"method", method, "path", path, "error", err)
+		return false
+	}
+
+	// Empty array behaves like the legacy "no scope" case — unrestricted.
+	// Tokens explicitly created with [] by older code should not break on
+	// upgrade. New tokens should use ["*"] or a specific scope list.
+	if len(scopes) == 0 {
 		return true
 	}
 
-	hasKnownScope := false
+	allowed := false
+	var unknown []string
 	for _, scope := range scopes {
 		switch scope {
 		case "*", "write":
-			return true
+			allowed = true
 		case "read":
-			hasKnownScope = true
 			if method == http.MethodGet || method == http.MethodHead || method == http.MethodOptions {
-				return true
+				allowed = true
 			}
 		default:
-			// Unrecognized scope — ignore but don't block.
-			// Tokens created before scope enforcement may contain
-			// custom values that were previously stored but not checked.
+			unknown = append(unknown, scope)
 		}
 	}
 
-	// If no recognized scope was found, allow for backward compatibility
-	// (e.g. tokens with only custom/legacy scope strings).
-	if !hasKnownScope {
-		return true
+	if len(unknown) > 0 {
+		slog.Warn("token has unrecognized scopes; treated as no-grant",
+			"method", method, "path", path, "unknown_scopes", unknown)
 	}
-
-	return false
+	return allowed
 }

--- a/internal/server/middleware_auth.go
+++ b/internal/server/middleware_auth.go
@@ -691,8 +691,13 @@ func tokenScopeAllows(scopesJSON, method, path string) bool {
 	_ = path // reserved for future per-resource scopes
 
 	// Legacy tokens with no scopes column → full access. Same fast path
-	// for the explicit wildcard.
-	if scopesJSON == "" || scopesJSON == `["*"]` {
+	// for the explicit wildcard and for the explicit empty array (legacy
+	// "unrestricted" form). We compare the raw string so that other JSON
+	// values that ALSO decode to an empty slice (notably the literal
+	// `null`, which json.Unmarshal happily accepts) do NOT fall through
+	// the unrestricted path.
+	switch strings.TrimSpace(scopesJSON) {
+	case "", `["*"]`, `[ "*" ]`, `[]`:
 		return true
 	}
 
@@ -703,11 +708,13 @@ func tokenScopeAllows(scopesJSON, method, path string) bool {
 		return false
 	}
 
-	// Empty array behaves like the legacy "no scope" case — unrestricted.
-	// Tokens explicitly created with [] by older code should not break on
-	// upgrade. New tokens should use ["*"] or a specific scope list.
+	// Anything else that decoded to an empty slice (e.g. "null", or a
+	// non-array value accepted by some drivers) is NOT treated as
+	// legacy-unrestricted. Deny + warn so operators see the ambiguity.
 	if len(scopes) == 0 {
-		return true
+		slog.Warn("token has non-array or null scopes; denying request",
+			"method", method, "path", path, "scopes_json", scopesJSON)
+		return false
 	}
 
 	allowed := false

--- a/internal/server/token_scopes_test.go
+++ b/internal/server/token_scopes_test.go
@@ -40,6 +40,12 @@ func TestTokenScopeAllows(t *testing.T) {
 		{"invalid json denies all", "not-json", http.MethodPost, "/api/v1/test", false},
 		{"invalid json denies GET", "not-json", http.MethodGet, "/api/v1/test", false},
 
+		// JSON null MUST NOT fall through the legacy-unrestricted path.
+		// json.Unmarshal("null", &[]string) succeeds and leaves nil slice —
+		// without an explicit raw-string check we'd grant full access.
+		{"json null denies POST", "null", http.MethodPost, "/api/v1/test", false},
+		{"json null denies GET", "null", http.MethodGet, "/api/v1/test", false},
+
 		// Multiple scopes
 		{"read+write allows POST", `["read","write"]`, http.MethodPost, "/api/v1/test", true},
 		{"read only blocks PUT", `["read"]`, http.MethodPut, "/api/v1/test", false},

--- a/internal/server/token_scopes_test.go
+++ b/internal/server/token_scopes_test.go
@@ -51,9 +51,14 @@ func TestTokenScopeAllows(t *testing.T) {
 		{"read only blocks PUT", `["read"]`, http.MethodPut, "/api/v1/test", false},
 
 		// Empty array still allows all — legacy "unrestricted" form. New
-		// tokens should use ["*"].
+		// tokens should use ["*"]. Whitespace-padded variants that clients
+		// might serialize also count as empty arrays.
 		{"empty array allows all", `[]`, http.MethodGet, "/api/v1/test", true},
 		{"empty array allows POST", `[]`, http.MethodPost, "/api/v1/test", true},
+		{"empty array with spaces", `[ ]`, http.MethodPost, "/api/v1/test", true},
+		{"empty array with newline", "[\n]", http.MethodPost, "/api/v1/test", true},
+		{"empty array with tab", "[\t]", http.MethodGet, "/api/v1/test", true},
+		{"wildcard with spaces", `[ "*" ]`, http.MethodPost, "/api/v1/test", true},
 
 		// Unrecognized scopes — TASK-667 deny-by-default. A typo like
 		// "read-only" must NOT silently grant full access.

--- a/internal/server/token_scopes_test.go
+++ b/internal/server/token_scopes_test.go
@@ -35,21 +35,29 @@ func TestTokenScopeAllows(t *testing.T) {
 		{"write allows POST", `["write"]`, http.MethodPost, "/api/v1/test", true},
 		{"write allows DELETE", `["write"]`, http.MethodDelete, "/api/v1/test", true},
 
-		// Invalid/unparseable JSON (backward compat)
-		{"invalid json allows all", "not-json", http.MethodPost, "/api/v1/test", true},
+		// Invalid/unparseable JSON — now DENY (TASK-667 deny-by-default).
+		// Data corruption / tampering should not fall open.
+		{"invalid json denies all", "not-json", http.MethodPost, "/api/v1/test", false},
+		{"invalid json denies GET", "not-json", http.MethodGet, "/api/v1/test", false},
 
 		// Multiple scopes
 		{"read+write allows POST", `["read","write"]`, http.MethodPost, "/api/v1/test", true},
 		{"read only blocks PUT", `["read"]`, http.MethodPut, "/api/v1/test", false},
 
-		// Empty array (no known scopes → allow for backward compat)
+		// Empty array still allows all — legacy "unrestricted" form. New
+		// tokens should use ["*"].
 		{"empty array allows all", `[]`, http.MethodGet, "/api/v1/test", true},
+		{"empty array allows POST", `[]`, http.MethodPost, "/api/v1/test", true},
 
-		// Unrecognized/legacy scopes (backward compat — allow)
-		{"unknown scope allows GET", `["docs"]`, http.MethodGet, "/api/v1/test", true},
-		{"unknown scope allows POST", `["repo"]`, http.MethodPost, "/api/v1/test", true},
-		{"unknown+read blocks POST", `["docs","read"]`, http.MethodPost, "/api/v1/test", false},
+		// Unrecognized scopes — TASK-667 deny-by-default. A typo like
+		// "read-only" must NOT silently grant full access.
+		{"unknown scope only denies GET", `["docs"]`, http.MethodGet, "/api/v1/test", false},
+		{"unknown scope only denies POST", `["repo"]`, http.MethodPost, "/api/v1/test", false},
+		{"read-only typo denies GET", `["read-only"]`, http.MethodGet, "/api/v1/test", false},
 		{"unknown+read allows GET", `["docs","read"]`, http.MethodGet, "/api/v1/test", true},
+		{"unknown+read blocks POST", `["docs","read"]`, http.MethodPost, "/api/v1/test", false},
+		{"unknown+wildcard still allows POST", `["docs","*"]`, http.MethodPost, "/api/v1/test", true},
+		{"unknown+write still allows DELETE", `["docs","write"]`, http.MethodDelete, "/api/v1/test", true},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
\`tokenScopeAllows\` previously fell open on unrecognized scopes AND on unparseable scope JSON. A typo like \`\"read-only\"\` silently granted full access — exactly the kind of landmine that a fresh token minted by an admin who misremembers the vocabulary would step on.

**New policy (deny-by-default):**
- Unparseable JSON → **deny** + warn (was allow). Data corruption / tampering never falls open.
- Unrecognized scopes → never contribute to allow; all unknowns on a request log once so operators can spot typos.
- \`\"*\"\` and \`\"write\"\` still allow all methods; \`\"read\"\` still allows safe methods only.
- Empty string and empty array \`[]\` still allow — legacy pre-enforcement rows shouldn't break on upgrade.

## Context
Implements \`TASK-667\` under \`PLAN-643\` (OSS Security Hardening).

## Test plan
- [x] \`go build ./...\` — clean
- [x] \`go vet ./...\` — clean
- [x] \`go test ./...\` — all tests pass
- [x] Updated test table: \"unknown scope allows GET/POST\" → deny; \"read-only typo denies GET\" regression pin; \"unknown+wildcard still allows\" guard rails; \"invalid json denies all\" (was allow).