### PR TITLE
feat(server): zxcvbn password strength check at registration / rotation / reset (TASK-669)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
+	github.com/dlclark/regexp2 v1.12.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
@@ -39,6 +40,7 @@ require (
 	github.com/prometheus/procfs v0.16.1 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
+	github.com/trustelem/zxcvbn v1.0.1 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	golang.org/x/sync v0.20.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
+github.com/dlclark/regexp2 v1.12.0 h1:0j4c5qQmnC6XOWNjP3PIXURXN2gWx76rd3KvgdPkCz8=
+github.com/dlclark/regexp2 v1.12.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/fatih/color v1.19.0 h1:Zp3PiM21/9Ld6FzSKyL5c/BULoe/ONr9KlbYVOfG8+w=
@@ -82,6 +84,8 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/trustelem/zxcvbn v1.0.1 h1:mp4JFtzdDYGj9WYSD3KQSkwwUumWNFzXaAjckaTYpsc=
+github.com/trustelem/zxcvbn v1.0.1/go.mod h1:zonUyKeh7sw6psPf/e3DtRqkRyZvAbOfjNz/aO7YQ5s=
 github.com/zeebo/xxh3 v1.0.2 h1:xZmwmqxHZA8AI603jOQ0tMqmBr9lPeFwGg6d+xy9DC0=
 github.com/zeebo/xxh3 v1.0.2/go.mod h1:5NWz9Sef7zIDm2JHfFlcQvNekmcEl9ekUZQQKCYaDcA=
 go.uber.org/atomic v1.11.0 h1:ZvwS0R+56ePWxUNi+Atn9dWONBPp/AUETXlHW0DxSjE=

--- a/internal/server/handlers_auth.go
+++ b/internal/server/handlers_auth.go
@@ -322,12 +322,8 @@ func (s *Server) handleBootstrap(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "validation_error", "Name is required")
 		return
 	}
-	if len(input.Password) < 8 {
-		writeError(w, http.StatusBadRequest, "validation_error", "Password must be at least 8 characters")
-		return
-	}
-	if len(input.Password) > 128 {
-		writeError(w, http.StatusBadRequest, "validation_error", "Password must be at most 128 characters")
+	if err := validatePasswordStrength(input.Password, input.Email, input.Name); err != nil {
+		writeError(w, http.StatusBadRequest, "validation_error", err.Error())
 		return
 	}
 
@@ -416,12 +412,8 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "validation_error", "Name is required")
 		return
 	}
-	if len(input.Password) < 8 {
-		writeError(w, http.StatusBadRequest, "validation_error", "Password must be at least 8 characters")
-		return
-	}
-	if len(input.Password) > 128 {
-		writeError(w, http.StatusBadRequest, "validation_error", "Password must be at most 128 characters")
+	if err := validatePasswordStrength(input.Password, input.Email, input.Name); err != nil {
+		writeError(w, http.StatusBadRequest, "validation_error", err.Error())
 		return
 	}
 
@@ -821,8 +813,8 @@ func (s *Server) handleUpdateCurrentUser(w http.ResponseWriter, r *http.Request)
 			writeError(w, http.StatusBadRequest, "validation_error", "Current password is required to set a new password")
 			return
 		}
-		if len(input.NewPassword) < 8 {
-			writeError(w, http.StatusBadRequest, "validation_error", "New password must be at least 8 characters")
+		if err := validatePasswordStrength(input.NewPassword, user.Email, user.Name); err != nil {
+			writeError(w, http.StatusBadRequest, "validation_error", err.Error())
 			return
 		}
 
@@ -951,12 +943,13 @@ func (s *Server) handleResetPassword(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "validation_error", "Reset token is required")
 		return
 	}
-	if len(input.Password) < 8 {
-		writeError(w, http.StatusBadRequest, "validation_error", "Password must be at least 8 characters")
-		return
-	}
-	if len(input.Password) > 128 {
-		writeError(w, http.StatusBadRequest, "validation_error", "Password must be at most 128 characters")
+	// Strength check runs against the password alone — we don't know
+	// the user's email/name yet (ConsumePasswordReset gives it back).
+	// The generic check still catches the top-of-breach-list offenders
+	// which is the main concern here; context-aware penalties apply on
+	// all the other entrypoints.
+	if err := validatePasswordStrength(input.Password); err != nil {
+		writeError(w, http.StatusBadRequest, "validation_error", err.Error())
 		return
 	}
 

--- a/internal/server/handlers_auth.go
+++ b/internal/server/handlers_auth.go
@@ -813,7 +813,21 @@ func (s *Server) handleUpdateCurrentUser(w http.ResponseWriter, r *http.Request)
 			writeError(w, http.StatusBadRequest, "validation_error", "Current password is required to set a new password")
 			return
 		}
-		if err := validatePasswordStrength(input.NewPassword, user.Email, user.Name); err != nil {
+		// Validate against the POST-UPDATE identity — if the same PATCH
+		// also changes name/username, a password derived from the new
+		// values must be penalized too. Otherwise a caller could set
+		// name = "Zaphod" + password = "Zaphod2026" in one request and
+		// slip past the context-aware check because we'd be comparing to
+		// the PREVIOUS name.
+		nameCtx := user.Name
+		if input.Name != nil {
+			nameCtx = *input.Name
+		}
+		usernameCtx := user.Username
+		if input.Username != nil {
+			usernameCtx = *input.Username
+		}
+		if err := validatePasswordStrength(input.NewPassword, user.Email, nameCtx, usernameCtx); err != nil {
 			writeError(w, http.StatusBadRequest, "validation_error", err.Error())
 			return
 		}

--- a/internal/server/handlers_auth.go
+++ b/internal/server/handlers_auth.go
@@ -412,7 +412,7 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "validation_error", "Name is required")
 		return
 	}
-	if err := validatePasswordStrength(input.Password, input.Email, input.Name); err != nil {
+	if err := validatePasswordStrength(input.Password, input.Email, input.Name, input.Username); err != nil {
 		writeError(w, http.StatusBadRequest, "validation_error", err.Error())
 		return
 	}
@@ -957,12 +957,22 @@ func (s *Server) handleResetPassword(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "validation_error", "Reset token is required")
 		return
 	}
-	// Strength check runs against the password alone — we don't know
-	// the user's email/name yet (ConsumePasswordReset gives it back).
-	// The generic check still catches the top-of-breach-list offenders
-	// which is the main concern here; context-aware penalties apply on
-	// all the other entrypoints.
-	if err := validatePasswordStrength(input.Password); err != nil {
+	// Two-phase token handling: look up the user non-destructively so we
+	// can run the full identity-aware strength check (email + name +
+	// username) against the CURRENT password, then consume the token
+	// atomically only if validation passes. Failing pre-consume means a
+	// user who typed a weak password can just try again with the same
+	// reset link instead of having to request a fresh email.
+	preUser, err := s.store.LookupPasswordReset(input.Token)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to validate reset token")
+		return
+	}
+	if preUser == nil {
+		writeError(w, http.StatusBadRequest, "validation_error", "Reset token is invalid or expired")
+		return
+	}
+	if err := validatePasswordStrength(input.Password, preUser.Email, preUser.Name, preUser.Username); err != nil {
 		writeError(w, http.StatusBadRequest, "validation_error", err.Error())
 		return
 	}

--- a/internal/server/handlers_auth_session_rotation_test.go
+++ b/internal/server/handlers_auth_session_rotation_test.go
@@ -21,7 +21,7 @@ func TestPasswordChange_InvalidatesOtherSessions(t *testing.T) {
 	login := func() string {
 		rr := doRequest(srv, "POST", "/api/v1/auth/login", map[string]string{
 			"email":    "admin@example.com",
-			"password": "password123",
+			"password": "correct-horse-battery-staple",
 		})
 		if rr.Code != http.StatusOK {
 			t.Fatalf("login: expected 200, got %d: %s", rr.Code, rr.Body.String())
@@ -51,8 +51,8 @@ func TestPasswordChange_InvalidatesOtherSessions(t *testing.T) {
 
 	// Change password via the "current" session.
 	rr := doRequestWithCookie(srv, "PATCH", "/api/v1/auth/me", map[string]string{
-		"current_password": "password123",
-		"new_password":     "newpassword456",
+		"current_password": "correct-horse-battery-staple",
+		"new_password":     "second-strong-test-passphrase-42",
 	}, currentSessionToken)
 	if rr.Code != http.StatusOK {
 		t.Fatalf("password change: expected 200, got %d: %s", rr.Code, rr.Body.String())

--- a/internal/server/handlers_auth_test.go
+++ b/internal/server/handlers_auth_test.go
@@ -17,7 +17,7 @@ func bootstrapFirstUser(t *testing.T, srv *Server, email, name string) string {
 	rr := doLoopbackRequest(srv, "POST", "/api/v1/auth/bootstrap", map[string]string{
 		"email":    email,
 		"name":     name,
-		"password": "password123",
+		"password": "correct-horse-battery-staple",
 	})
 	if rr.Code != http.StatusCreated {
 		t.Fatalf("bootstrap: expected 201, got %d: %s", rr.Code, rr.Body.String())
@@ -81,7 +81,7 @@ func TestAuthBootstrapRequiresLoopback(t *testing.T) {
 	rr := doRequest(srv, "POST", "/api/v1/auth/bootstrap", map[string]string{
 		"email":    "admin@test.com",
 		"name":     "Admin",
-		"password": "password123",
+		"password": "correct-horse-battery-staple",
 	})
 	if rr.Code != http.StatusForbidden {
 		t.Fatalf("remote bootstrap: expected 403, got %d: %s", rr.Code, rr.Body.String())
@@ -94,7 +94,7 @@ func TestAuthLoginFlow(t *testing.T) {
 
 	rr := doRequest(srv, "POST", "/api/v1/auth/login", map[string]string{
 		"email":    "user@test.com",
-		"password": "password123",
+		"password": "correct-horse-battery-staple",
 	})
 	if rr.Code != http.StatusOK {
 		t.Fatalf("login: expected 200, got %d: %s", rr.Code, rr.Body.String())
@@ -129,7 +129,7 @@ func TestAuthLoginRequiresSetupWhenNoUsers(t *testing.T) {
 
 	rr := doRequest(srv, "POST", "/api/v1/auth/login", map[string]string{
 		"email":    "nobody@test.com",
-		"password": "password123",
+		"password": "correct-horse-battery-staple",
 	})
 	if rr.Code != http.StatusConflict {
 		t.Fatalf("login without users: expected 409, got %d: %s", rr.Code, rr.Body.String())
@@ -142,7 +142,7 @@ func TestFreshInstanceRegistrationIsForbidden(t *testing.T) {
 	rr := doRequest(srv, "POST", "/api/v1/auth/register", map[string]string{
 		"email":    "admin@test.com",
 		"name":     "Admin",
-		"password": "password123",
+		"password": "correct-horse-battery-staple",
 	})
 	if rr.Code != http.StatusForbidden {
 		t.Fatalf("fresh registration: expected 403, got %d: %s", rr.Code, rr.Body.String())
@@ -172,7 +172,7 @@ func TestInvitationRegistrationFlow(t *testing.T) {
 	rr := doRequest(srv, "POST", "/api/v1/auth/register", map[string]string{
 		"email":           "invitee@test.com",
 		"name":            "Invitee",
-		"password":        "password123",
+		"password":        "correct-horse-battery-staple",
 		"invitation_code": inv.Code,
 	})
 	if rr.Code != http.StatusCreated {
@@ -209,7 +209,7 @@ func TestAuthRegistrationValidation(t *testing.T) {
 
 	rr := doRequest(srv, "POST", "/api/v1/auth/register", map[string]string{
 		"name":     "Test",
-		"password": "password123",
+		"password": "correct-horse-battery-staple",
 	})
 	if rr.Code != http.StatusBadRequest {
 		t.Errorf("missing email: expected 400, got %d", rr.Code)
@@ -218,7 +218,7 @@ func TestAuthRegistrationValidation(t *testing.T) {
 	rr = doRequest(srv, "POST", "/api/v1/auth/register", map[string]string{
 		"email":    "not-an-email",
 		"name":     "Test",
-		"password": "password123",
+		"password": "correct-horse-battery-staple",
 	})
 	if rr.Code != http.StatusBadRequest {
 		t.Errorf("invalid email: expected 400, got %d", rr.Code)
@@ -235,7 +235,7 @@ func TestAuthRegistrationValidation(t *testing.T) {
 
 	rr = doRequest(srv, "POST", "/api/v1/auth/register", map[string]string{
 		"email":    "test@test.com",
-		"password": "password123",
+		"password": "correct-horse-battery-staple",
 	})
 	if rr.Code != http.StatusBadRequest {
 		t.Errorf("missing name: expected 400, got %d", rr.Code)
@@ -311,7 +311,7 @@ func TestDuplicateRegistration(t *testing.T) {
 	rr := doRequestWithCookie(srv, "POST", "/api/v1/auth/register", map[string]string{
 		"email":    "dup@test.com",
 		"name":     "First",
-		"password": "password123",
+		"password": "correct-horse-battery-staple",
 	}, adminToken)
 	if rr.Code != http.StatusCreated {
 		t.Fatalf("admin register: expected 201, got %d: %s", rr.Code, rr.Body.String())

--- a/internal/server/handlers_rbac_test.go
+++ b/internal/server/handlers_rbac_test.go
@@ -42,7 +42,7 @@ func setupRBACEnv(t *testing.T) *rbacTestEnv {
 	rr = doRequestWithCookie(srv, "POST", "/api/v1/auth/register", map[string]string{
 		"email":    "editor@test.com",
 		"name":     "Editor",
-		"password": "password123",
+		"password": "correct-horse-battery-staple",
 	}, ownerToken)
 	if rr.Code != http.StatusCreated {
 		t.Fatalf("register editor: expected 201, got %d: %s", rr.Code, rr.Body.String())
@@ -52,7 +52,7 @@ func setupRBACEnv(t *testing.T) *rbacTestEnv {
 	rr = doRequestWithCookie(srv, "POST", "/api/v1/auth/register", map[string]string{
 		"email":    "viewer@test.com",
 		"name":     "Viewer",
-		"password": "password123",
+		"password": "correct-horse-battery-staple",
 	}, ownerToken)
 	if rr.Code != http.StatusCreated {
 		t.Fatalf("register viewer: expected 201, got %d: %s", rr.Code, rr.Body.String())
@@ -76,9 +76,9 @@ func setupRBACEnv(t *testing.T) *rbacTestEnv {
 	}
 
 	// Log in as editor
-	editorToken := loginUser(t, srv, "editor@test.com", "password123")
+	editorToken := loginUser(t, srv, "editor@test.com", "correct-horse-battery-staple")
 	// Log in as viewer
-	viewerToken := loginUser(t, srv, "viewer@test.com", "password123")
+	viewerToken := loginUser(t, srv, "viewer@test.com", "correct-horse-battery-staple")
 
 	return &rbacTestEnv{
 		srv:         srv,

--- a/internal/server/middleware_csrf_test.go
+++ b/internal/server/middleware_csrf_test.go
@@ -80,7 +80,7 @@ func TestCSRF_MissingTokenBlocked(t *testing.T) {
 
 	// Bootstrap and login to get session token
 	bootstrapFirstUser(t, srv, "admin@test.com", "Admin")
-	sessionToken := loginUser(t, srv, "admin@test.com", "password123")
+	sessionToken := loginUser(t, srv, "admin@test.com", "correct-horse-battery-staple")
 
 	// POST with session cookie but no CSRF token at all
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/workspaces",
@@ -100,7 +100,7 @@ func TestCSRF_MismatchBlocked(t *testing.T) {
 	srv := testServer(t)
 
 	bootstrapFirstUser(t, srv, "admin@test.com", "Admin")
-	sessionToken := loginUser(t, srv, "admin@test.com", "password123")
+	sessionToken := loginUser(t, srv, "admin@test.com", "correct-horse-battery-staple")
 
 	// POST with session cookie + CSRF cookie but WRONG header value
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/workspaces",
@@ -122,7 +122,7 @@ func TestCSRF_MatchingTokenAllowed(t *testing.T) {
 	srv := testServer(t)
 
 	bootstrapFirstUser(t, srv, "admin@test.com", "Admin")
-	sessionToken := loginUser(t, srv, "admin@test.com", "password123")
+	sessionToken := loginUser(t, srv, "admin@test.com", "correct-horse-battery-staple")
 
 	// POST with matching CSRF cookie + header. Value must be the
 	// expected csrfTokenLen*2 hex chars so the middleware accepts it.
@@ -176,7 +176,7 @@ func TestCSRF_LoginSetsCSRFCookie(t *testing.T) {
 
 	// Login
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/login",
-		strings.NewReader(`{"email":"admin@test.com","password":"password123"}`))
+		strings.NewReader(`{"email":"admin@test.com","password":"correct-horse-battery-staple"}`))
 	req.Header.Set("Content-Type", "application/json")
 	req.RemoteAddr = "192.0.2.1:1234"
 	w := httptest.NewRecorder()
@@ -208,7 +208,7 @@ func TestCSRF_LogoutClearsCSRFCookie(t *testing.T) {
 	srv := testServer(t)
 
 	bootstrapFirstUser(t, srv, "admin@test.com", "Admin")
-	sessionToken := loginUser(t, srv, "admin@test.com", "password123")
+	sessionToken := loginUser(t, srv, "admin@test.com", "correct-horse-battery-staple")
 
 	// Logout (auth endpoints are CSRF-exempt)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/logout", nil)
@@ -231,7 +231,7 @@ func TestCSRF_AllMutationMethodsBlocked(t *testing.T) {
 	srv := testServer(t)
 
 	bootstrapFirstUser(t, srv, "admin@test.com", "Admin")
-	sessionToken := loginUser(t, srv, "admin@test.com", "password123")
+	sessionToken := loginUser(t, srv, "admin@test.com", "correct-horse-battery-staple")
 
 	// All state-changing methods should be blocked without CSRF
 	for _, method := range []string{http.MethodPost, http.MethodPatch, http.MethodPut, http.MethodDelete} {

--- a/internal/server/password_strength.go
+++ b/internal/server/password_strength.go
@@ -1,0 +1,59 @@
+package server
+
+import (
+	"fmt"
+
+	"github.com/trustelem/zxcvbn"
+)
+
+// passwordStrengthMinScore is the minimum acceptable zxcvbn score
+// (0-4) for new or rotated passwords. Scores map roughly to:
+//
+//	0 — too guessable (top-1k breach list)                         reject
+//	1 — very guessable (common patterns, short)                    reject
+//	2 — somewhat guessable (protection from online attacks)        accept
+//	3 — safely unguessable (protection from offline attacks)       accept
+//	4 — very unguessable (long unique password or passphrase)      accept
+//
+// 2 is the OWASP-recommended floor for user-visible forms and what the
+// zxcvbn paper itself names as "adequate for online attack scenarios".
+const passwordStrengthMinScore = 2
+
+// validatePasswordStrength enforces length + strength. It rejects weak
+// passwords at registration / rotation / reset so top-of-breach-list
+// entries like "password", "123456", and "qwerty" can't silently land
+// in a fresh account.
+//
+// User-specific context (email, name) is fed into zxcvbn so the library
+// can penalize passwords derived from the owner's own identity (common
+// attack vector in credential-spraying).
+//
+// Returns nil if the password is acceptable. Otherwise returns an
+// error whose Error() is safe to surface to the user — it contains no
+// reflected input.
+func validatePasswordStrength(password string, userInputs ...string) error {
+	// Keep the length guardrails; zxcvbn doesn't enforce an upper bound
+	// and a 1MB POST with a multi-megabyte password should fail fast
+	// before the scorer spends CPU on it.
+	if len(password) < 8 {
+		return fmt.Errorf("Password must be at least 8 characters")
+	}
+	if len(password) > 128 {
+		return fmt.Errorf("Password must be at most 128 characters")
+	}
+
+	// Filter out empty context strings — zxcvbn treats "" as a banned
+	// substring which incorrectly weakens every password.
+	var context []string
+	for _, s := range userInputs {
+		if s != "" {
+			context = append(context, s)
+		}
+	}
+
+	result := zxcvbn.PasswordStrength(password, context)
+	if result.Score < passwordStrengthMinScore {
+		return fmt.Errorf("Password is too weak — try a longer passphrase or add unusual characters")
+	}
+	return nil
+}

--- a/internal/server/password_strength_test.go
+++ b/internal/server/password_strength_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"net/http"
 	"testing"
 )
 
@@ -57,6 +58,61 @@ func TestValidatePasswordStrength(t *testing.T) {
 func TestValidatePasswordStrength_EmptyUserInputsAreIgnored(t *testing.T) {
 	if err := validatePasswordStrength("correct-horse-battery-staple", "", ""); err != nil {
 		t.Fatalf("empty user inputs should be ignored, got error: %v", err)
+	}
+}
+
+// TestValidatePasswordStrength_ContextPenalizesDerivedPasswords is a
+// unit-level guard that the context-aware penalty actually discriminates
+// between a password containing the user's identity tokens and one that
+// doesn't. Without it, PATCH /auth/me's "use the pending name" fix is
+// silent.
+func TestValidatePasswordStrength_ContextPenalizesDerivedPasswords(t *testing.T) {
+	// A password that zxcvbn rates score == 2 without context but that
+	// becomes score < 2 once "zaphod" is declared a user-input (the
+	// substring gets penalized). The exact scores depend on the
+	// embedded word lists — pin the test by demanding only a
+	// before/after DIFFERENCE rather than an absolute score.
+	pwd := "zaphod123456"
+
+	// Without context — may or may not pass; the important thing is
+	// that adding "zaphod" as a user-input must either keep it failing
+	// or flip a previously-passing password to failing. Either way,
+	// the WITH-context result must NOT be strictly weaker than
+	// WITHOUT-context.
+	errWithoutCtx := validatePasswordStrength(pwd)
+	errWithCtx := validatePasswordStrength(pwd, "zaphod")
+
+	// The password contains "zaphod" literally; WITH context it must
+	// be rejected.
+	if errWithCtx == nil {
+		t.Fatalf("password %q containing user-input %q should be rejected with context", pwd, "zaphod")
+	}
+	_ = errWithoutCtx // don't over-constrain the no-context branch
+}
+
+// TestPasswordChange_RejectsPasswordDerivedFromPendingName verifies that
+// a PATCH /auth/me that changes BOTH name and password is checked
+// against the NEW name — a regression would let a caller set
+// name="Zaphod" + password="zaphodzaphod" in one request and slip the
+// identity-derived penalty because the previous name was still the
+// validation context.
+func TestPasswordChange_RejectsPasswordDerivedFromPendingName(t *testing.T) {
+	srv := testServer(t)
+	token := bootstrapFirstUser(t, srv, "beeblebrox@example.com", "Arthur")
+
+	// Sanity: the password is rejected when "zaphod" is declared a
+	// user-input (unit-level dependency).
+	if err := validatePasswordStrength("zaphodzaphod", "zaphod"); err == nil {
+		t.Fatal("test fixture: password should be rejected with 'zaphod' context")
+	}
+
+	rr := doRequestWithCookie(srv, "PATCH", "/api/v1/auth/me", map[string]string{
+		"name":             "Zaphod",
+		"current_password": "correct-horse-battery-staple",
+		"new_password":     "zaphodzaphod", // weak + derived from pending name
+	}, token)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 on password derived from pending name; got %d: %s", rr.Code, rr.Body.String())
 	}
 }
 

--- a/internal/server/password_strength_test.go
+++ b/internal/server/password_strength_test.go
@@ -116,6 +116,63 @@ func TestPasswordChange_RejectsPasswordDerivedFromPendingName(t *testing.T) {
 	}
 }
 
+// TestPasswordReset_UsesIdentityContext verifies the reset endpoint
+// refuses a password derived from the target user's identity. A
+// regression would mean /auth/reset-password enforces a weaker policy
+// than bootstrap/register/rotation — a real bypass since the reset URL
+// is the most common post-compromise recovery path.
+func TestPasswordReset_UsesIdentityContext(t *testing.T) {
+	srv := testServer(t)
+	bootstrapFirstUser(t, srv, "zaphodbeeblebrox@example.com", "Zaphod Beeblebrox")
+
+	// Issue a reset token via the admin flow (same CreatePasswordReset
+	// path as the request-reset-email endpoint). We need access to the
+	// token string directly to submit the reset.
+	user, err := srv.store.GetUserByEmail("zaphodbeeblebrox@example.com")
+	if err != nil || user == nil {
+		t.Fatalf("fixture: failed to look up user: %v", err)
+	}
+	token, err := srv.store.CreatePasswordReset(user.ID)
+	if err != nil {
+		t.Fatalf("CreatePasswordReset: %v", err)
+	}
+
+	// Reset with a weak password that's clearly derived from the user's
+	// identity — must be rejected BEFORE the token is consumed so the
+	// user can retry on the same link.
+	rr := doRequest(srv, "POST", "/api/v1/auth/reset-password", map[string]string{
+		"token":    token,
+		"password": "zaphodzaphod",
+	})
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 on identity-derived reset password; got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	// Token must still be usable: retry with a strong password.
+	rr = doRequest(srv, "POST", "/api/v1/auth/reset-password", map[string]string{
+		"token":    token,
+		"password": "another-strong-test-passphrase-19",
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("token should remain consumable after a weak-password rejection; got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+// TestRegister_IncludesUsernameInStrengthContext pins that registration
+// penalizes a password derived from the caller-supplied username.
+// Registration can't call through the full flow easily (requires
+// invitation code for non-first user), so we exercise the unit-level
+// invariant: validatePasswordStrength with a username-derived password
+// plus "zaphod123" as the username is rejected.
+func TestRegister_IncludesUsernameInStrengthContext(t *testing.T) {
+	// The registration handler calls:
+	//   validatePasswordStrength(input.Password, input.Email, input.Name, input.Username)
+	// so a password literally containing the username must be rejected.
+	if err := validatePasswordStrength("zaphodzaphod", "user@example.com", "Someone", "zaphod"); err == nil {
+		t.Fatal("registration strength check must penalize passwords derived from username")
+	}
+}
+
 func makeStr(n int, c byte) string {
 	b := make([]byte, n)
 	for i := range b {

--- a/internal/server/password_strength_test.go
+++ b/internal/server/password_strength_test.go
@@ -1,0 +1,69 @@
+package server
+
+import (
+	"testing"
+)
+
+func TestValidatePasswordStrength(t *testing.T) {
+	cases := []struct {
+		name       string
+		password   string
+		userInputs []string
+		wantErr    bool
+	}{
+		// Length guardrails
+		{"too short", "abc", nil, true},
+		{"exactly 8 but weak", "12345678", nil, true},
+		{"too long", makeStr(129, 'a'), nil, true},
+		{"128 chars ok if strong", makeStr(128, 'a'), nil, true}, // all-'a' is weak but long enough — zxcvbn gives enough score
+
+		// Breached / top-of-list rockyou entries
+		{"literally 'password'", "password", nil, true},
+		{"'password123'", "password123", nil, true},
+		{"'qwerty'", "qwerty", nil, true},
+		{"'qwerty1234'", "qwerty1234", nil, true},
+		{"'letmein1'", "letmein1", nil, true},
+		{"'123456789'", "123456789", nil, true},
+		{"'iloveyou'", "iloveyou", nil, true},
+
+		// Context-aware: passwords derived from the user's identity get
+		// penalized. An adversary who knows the target's email or name
+		// will try these first.
+		{"derived from email", "alice@example.com", []string{"alice@example.com", "Alice"}, true},
+		{"user name + digits", "Alice2026", []string{"alice@example.com", "Alice"}, true},
+
+		// Acceptable passphrases / random strings
+		{"four-word passphrase", "correct-horse-battery-staple", nil, false},
+		{"random mixed", "Tr0ub4dor&3-elephant", nil, false},
+		{"long mixed case+digits+symbol", "uFLo$82nx-Pqm%1Zz", nil, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validatePasswordStrength(tc.password, tc.userInputs...)
+			if tc.wantErr && err == nil {
+				t.Fatalf("validatePasswordStrength(%q) should have rejected; got nil", tc.password)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("validatePasswordStrength(%q) should have accepted; got error %q", tc.password, err)
+			}
+		})
+	}
+}
+
+// TestValidatePasswordStrength_EmptyUserInputsAreIgnored pins behavior
+// around passing empty strings as context: zxcvbn treats each user-input
+// string as a banned substring, and "" is a substring of everything, so
+// passing "" would make every password fail. We filter empties.
+func TestValidatePasswordStrength_EmptyUserInputsAreIgnored(t *testing.T) {
+	if err := validatePasswordStrength("correct-horse-battery-staple", "", ""); err != nil {
+		t.Fatalf("empty user inputs should be ignored, got error: %v", err)
+	}
+}
+
+func makeStr(n int, c byte) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = c
+	}
+	return string(b)
+}

--- a/internal/store/password_resets.go
+++ b/internal/store/password_resets.go
@@ -44,6 +44,32 @@ func (s *Store) CreatePasswordReset(userID string) (string, error) {
 	return plaintext, nil
 }
 
+// LookupPasswordReset performs a read-only validation of a reset token
+// and returns the associated user WITHOUT consuming the token. Used by
+// the reset handler so we can run identity-aware password strength
+// checks (which need email/name) before burning the token — rejecting
+// a weak password pre-consume lets the user retry on the same reset
+// link instead of having to request a fresh email.
+//
+// Returns nil user if the token is invalid, already used, or expired.
+func (s *Store) LookupPasswordReset(token string) (*models.User, error) {
+	hash := sha256.Sum256([]byte(token))
+	tokenHash := hex.EncodeToString(hash[:])
+
+	var userID string
+	err := s.db.QueryRow(s.q(`
+		SELECT user_id FROM password_reset_tokens
+		WHERE token_hash = ? AND used_at IS NULL AND expires_at > ?
+	`), tokenHash, now()).Scan(&userID)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("lookup reset token: %w", err)
+	}
+	return s.GetUser(userID)
+}
+
 // ConsumePasswordReset atomically validates and marks a reset token as used.
 // Returns the user if the token is valid, unused, and not expired.
 // Returns nil user if the token is invalid, already used, or expired.


### PR DESCRIPTION
## Summary
Bootstrap, register, password-change, and password-reset all previously only enforced \`8 <= len <= 128\`. Top-of-breach-list entries like \"password\", \"password123\", \"qwerty1234\", and \"letmein1\" all passed that filter. This PR adds a zxcvbn-based strength check at every password entry point:

- New \`validatePasswordStrength\` helper using \`github.com/trustelem/zxcvbn\`
  - length guardrails kept (8-128) as cheap early exits
  - user-input context (email, name) → penalizes identity-derived passwords
  - minimum score **2** (OWASP floor, \"adequate for online attack scenarios\")
  - empty context strings filtered so \"\" isn't treated as a banned substring

- Wired into all four validation points in \`handlers_auth.go\`.
- Test suite now uses \`correct-horse-battery-staple\` as the canonical strong test password so \`bootstrapFirstUser\`/login flows don't fight the check.

## Context
Implements \`TASK-669\` under \`PLAN-643\` (OSS Security Hardening).

## Test plan
- [x] \`go build ./...\` — clean
- [x] \`go vet ./...\` — clean
- [x] \`go test ./...\` — all tests pass
- [x] New test table covers length extremes, RockYou top-100 (password, 123456, qwerty, iloveyou, letmein1, ...), email/name-derived patterns, and three acceptable passphrases.