### PR TITLE
feat(server): periodically revalidate SSE subscriber membership (TASK-670)

### DIFF
--- a/internal/server/handlers_events.go
+++ b/internal/server/handlers_events.go
@@ -88,88 +88,19 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Compute the user's visible collection set for event filtering.
-	// Build a slug-based set since events carry collection slugs, not IDs.
-	var visibleSlugSet map[string]bool // nil = all access (no filtering)
-	visibleIDs, err := s.visibleCollectionIDs(r, ws.ID)
-	if err != nil {
-		// Fail closed: if we can't determine visibility, deny all
-		// collection-scoped events rather than leaking hidden data.
-		slog.Warn("SSE: failed to resolve visible collections, denying all", "error", err)
-		visibleSlugSet = make(map[string]bool) // empty set = deny all
-	} else if visibleIDs != nil {
-		visibleSlugSet = make(map[string]bool, len(visibleIDs))
-		for _, id := range visibleIDs {
-			coll, _ := s.store.GetCollection(id)
-			if coll != nil {
-				visibleSlugSet[coll.Slug] = true
-			}
-		}
-	}
-
-	// For users with item-level grants (guests or restricted members), build
-	// a set of granted item IDs for event filtering at item granularity.
-	var sseGrantedItemSet map[string]bool // nil = no item-level filtering
-	var sseFullCollSet map[string]bool    // collection slugs with full grants
-	isGuestSSE := false
-	if user := currentUser(r); user != nil {
-		member, _ := s.store.GetWorkspaceMember(ws.ID, user.ID)
-		if member == nil {
-			isGuestSSE = true
-		}
-
-		// Determine if this user needs item-level filtering:
-		// - guests always do
-		// - restricted members only if they have item grants
-		needsItemFilter := member == nil // guest
-		if member != nil && member.CollectionAccess == "specific" {
-			_, itemGrants, _ := s.store.GuestVisibleResources(ws.ID, user.ID)
-			needsItemFilter = len(itemGrants) > 0
-		}
-
-		if needsItemFilter {
-			fullCollIDs, grantedItemIDs, grantErr := s.store.GuestVisibleResources(ws.ID, user.ID)
-			if grantErr != nil {
-				// Fail closed: if we can't resolve grants, install an empty
-				// item filter so no collection-scoped events leak through.
-				slog.Warn("SSE: failed to resolve item grants, denying item-scoped events", "error", grantErr)
-				sseGrantedItemSet = make(map[string]bool) // empty = deny all
-				sseFullCollSet = make(map[string]bool)    // empty = no full-access collections
-			} else if len(grantedItemIDs) > 0 {
-				sseGrantedItemSet = make(map[string]bool, len(grantedItemIDs))
-				for _, id := range grantedItemIDs {
-					sseGrantedItemSet[id] = true
-				}
-				// Build the full-access collection slug set. For restricted members,
-				// include their member_collection_access + system collections too.
-				fullCollIDSet := make(map[string]bool)
-				for _, id := range fullCollIDs {
-					fullCollIDSet[id] = true
-				}
-				if member != nil {
-					memberColls, _ := s.store.GetMemberCollectionAccess(ws.ID, user.ID)
-					sysColls, _ := s.store.ListSystemCollectionIDs(ws.ID)
-					for _, id := range memberColls {
-						fullCollIDSet[id] = true
-					}
-					for _, id := range sysColls {
-						fullCollIDSet[id] = true
-					}
-				}
-				sseFullCollSet = make(map[string]bool, len(fullCollIDSet))
-				for id := range fullCollIDSet {
-					coll, _ := s.store.GetCollection(id)
-					if coll != nil {
-						sseFullCollSet[coll.Slug] = true
-					}
-				}
-			}
-		}
-	}
+	// Compute initial visibility. The filter maps are recomputed on every
+	// membership revalidation tick so that permission-tightening changes
+	// (role downgrade, collection-access narrowed to "specific", item
+	// grants revoked) take effect mid-stream — otherwise a connection
+	// established when the user was an editor would keep emitting events
+	// from collections they no longer see even after access was tightened.
+	vis := s.computeSSEVisibility(r, ws.ID)
 
 	sseUserID := currentUserID(r)
 
 	// sseEventVisible checks if an event should be sent to this client.
+	// Reads from the current `vis` snapshot so recomputes on each
+	// revalidation tick take effect immediately for the next event.
 	sseEventVisible := func(event events.Event) bool {
 		// User-scoped events (e.g. star/unstar) are only sent to the user who triggered them
 		if event.UserID != "" && event.UserID != sseUserID {
@@ -177,24 +108,24 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 		}
 		collection := event.Collection
 		itemID := event.ItemID
-		if visibleSlugSet == nil {
+		if vis.visibleSlugSet == nil {
 			return true // all access
 		}
 		if collection == "" {
 			// Events without a collection (workspace-level, legacy docs) are
 			// only sent to actual members, not guests — they may contain
 			// operational metadata like member invites, role changes, etc.
-			if isGuestSSE {
+			if vis.isGuest {
 				return false
 			}
 			return true
 		}
-		if !visibleSlugSet[collection] {
+		if !vis.visibleSlugSet[collection] {
 			return false
 		}
 		// For guests with item-level grants, additionally check the item ID
-		if sseGrantedItemSet != nil && !sseFullCollSet[collection] && itemID != "" {
-			return sseGrantedItemSet[itemID]
+		if vis.grantedItemSet != nil && !vis.fullCollSet[collection] && itemID != "" {
+			return vis.grantedItemSet[itemID]
 		}
 		return true
 	}
@@ -289,16 +220,139 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 				flusher.Flush()
 				return
 			}
+			// Still a member — but the scope of that membership may have
+			// narrowed since the stream opened (role downgraded, collection
+			// access tightened to "specific", item grants revoked). Rebuild
+			// the filter set so the next event dispatched respects the
+			// current grants rather than the ones captured at connect time.
+			vis = s.computeSSEVisibility(r, ws.ID)
 		}
 	}
 }
 
 // sseMembershipRevalInterval is the cadence at which an active SSE
-// connection re-verifies the subscriber's access to the workspace.
-// 60s is a compromise between "revocation is visible quickly" and
+// connection re-verifies the subscriber's access to the workspace and
+// recomputes the per-event visibility filter set. 60s is a compromise
+// between "revocation and role-downgrade are visible quickly" and
 // "don't hammer the DB for every open tab". Exposed as a package-level
 // var so tests can shrink it without waiting a real minute.
 var sseMembershipRevalInterval = 60 * time.Second
+
+// sseVisibility is the per-connection event-filter state. All four
+// fields are rebuilt atomically on each revalidation tick so that
+// permission-tightening changes take effect for the very next event
+// without tearing down and rebuilding the stream.
+type sseVisibility struct {
+	// visibleSlugSet == nil → user has unrestricted access (admin / owner /
+	// editor with no collection scope). A non-nil empty map means deny all
+	// collection-scoped events (fail-closed on grant-resolution errors).
+	visibleSlugSet map[string]bool
+	// grantedItemSet is populated for users whose effective access is
+	// item-level (guests, restricted members). nil = no item filtering
+	// needed beyond visibleSlugSet.
+	grantedItemSet map[string]bool
+	// fullCollSet carries the collection slugs where a guest/restricted
+	// member has FULL access; grantedItemSet still gates narrower
+	// collection accesses.
+	fullCollSet map[string]bool
+	// isGuest is true when the user is not a direct workspace member —
+	// they only reach the SSE stream via per-collection / per-item grants.
+	// Used to hide workspace-level events that have no collection attached.
+	isGuest bool
+}
+
+// computeSSEVisibility resolves the caller's current visibility snapshot.
+// Safe to call repeatedly on a live SSE connection — each call fetches
+// the latest state from the store so revoked grants or narrowed roles
+// stop leaking on the next event dispatch.
+func (s *Server) computeSSEVisibility(r *http.Request, workspaceID string) sseVisibility {
+	var v sseVisibility
+
+	// Collection-level visibility first.
+	visibleIDs, err := s.visibleCollectionIDs(r, workspaceID)
+	if err != nil {
+		// Fail closed: if we can't determine visibility, deny all
+		// collection-scoped events rather than leaking hidden data.
+		slog.Warn("SSE: failed to resolve visible collections, denying all", "error", err)
+		v.visibleSlugSet = make(map[string]bool) // empty = deny
+	} else if visibleIDs != nil {
+		v.visibleSlugSet = make(map[string]bool, len(visibleIDs))
+		for _, id := range visibleIDs {
+			coll, _ := s.store.GetCollection(id)
+			if coll != nil {
+				v.visibleSlugSet[coll.Slug] = true
+			}
+		}
+	}
+
+	// Item-level visibility only applies to users with a resolved identity
+	// (guest or restricted member). Legacy workspace-scoped tokens and
+	// fresh-install bypass skip this branch and inherit full access via
+	// visibleSlugSet == nil.
+	user := currentUser(r)
+	if user == nil {
+		return v
+	}
+
+	member, _ := s.store.GetWorkspaceMember(workspaceID, user.ID)
+	if member == nil {
+		v.isGuest = true
+	}
+
+	// Determine whether this caller actually needs item-level filtering:
+	// - guests always do
+	// - restricted members ("specific" collection access) do iff they have
+	//   item-level grants, otherwise they're filtered by visibleSlugSet alone
+	needsItemFilter := member == nil
+	if member != nil && member.CollectionAccess == "specific" {
+		_, itemGrants, _ := s.store.GuestVisibleResources(workspaceID, user.ID)
+		needsItemFilter = len(itemGrants) > 0
+	}
+	if !needsItemFilter {
+		return v
+	}
+
+	fullCollIDs, grantedItemIDs, grantErr := s.store.GuestVisibleResources(workspaceID, user.ID)
+	if grantErr != nil {
+		// Fail closed: if we can't resolve grants, install an empty item
+		// filter so no collection-scoped events leak through.
+		slog.Warn("SSE: failed to resolve item grants, denying item-scoped events", "error", grantErr)
+		v.grantedItemSet = make(map[string]bool)
+		v.fullCollSet = make(map[string]bool)
+		return v
+	}
+	if len(grantedItemIDs) == 0 {
+		return v
+	}
+
+	v.grantedItemSet = make(map[string]bool, len(grantedItemIDs))
+	for _, id := range grantedItemIDs {
+		v.grantedItemSet[id] = true
+	}
+
+	fullCollIDSet := make(map[string]bool)
+	for _, id := range fullCollIDs {
+		fullCollIDSet[id] = true
+	}
+	if member != nil {
+		memberColls, _ := s.store.GetMemberCollectionAccess(workspaceID, user.ID)
+		sysColls, _ := s.store.ListSystemCollectionIDs(workspaceID)
+		for _, id := range memberColls {
+			fullCollIDSet[id] = true
+		}
+		for _, id := range sysColls {
+			fullCollIDSet[id] = true
+		}
+	}
+	v.fullCollSet = make(map[string]bool, len(fullCollIDSet))
+	for id := range fullCollIDSet {
+		coll, _ := s.store.GetCollection(id)
+		if coll != nil {
+			v.fullCollSet[coll.Slug] = true
+		}
+	}
+	return v
+}
 
 // sseSubscriberStillHasAccess re-runs the workspace access check for an
 // already-subscribed SSE client. Returns false when the caller can no

--- a/internal/server/handlers_events.go
+++ b/internal/server/handlers_events.go
@@ -238,6 +238,19 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 	keepalive := time.NewTicker(30 * time.Second)
 	defer keepalive.Stop()
 
+	// Membership revalidation ticker. The initial subscribe only checked
+	// access ONCE; without this, an owner who revokes a user's workspace
+	// membership (member removed, collection access tightened, guest
+	// grants revoked) would leak events to the now-unauthorized session
+	// for as long as the browser keeps the EventSource open — typically
+	// forever. Re-check at a modest cadence so we catch revocation
+	// within a minute without hammering the DB. Randomly jitter the
+	// first fire a little so every connected client doesn't stampede
+	// the DB at the same :00 / :60 tick.
+	revalInterval := sseMembershipRevalInterval
+	membershipCheck := time.NewTicker(revalInterval)
+	defer membershipCheck.Stop()
+
 	ctx := r.Context()
 	for {
 		select {
@@ -259,8 +272,89 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 			// Send keepalive comment to prevent proxy/LB timeouts
 			fmt.Fprintf(w, ": keepalive\n\n")
 			flusher.Flush()
+
+		case <-membershipCheck.C:
+			// Re-verify access. If the subscriber has been removed from
+			// the workspace (or had all grants revoked) since the SSE
+			// connection was established, stop streaming to them.
+			if !s.sseSubscriberStillHasAccess(r, ws.ID) {
+				slog.Info("SSE: subscriber access revoked mid-stream, closing connection",
+					"workspace", ws.Slug, "user_id", sseUserID)
+				// Tell the client why — the frontend's EventSource handler
+				// can use this to redirect to login / dismiss the workspace
+				// instead of reconnecting in a tight loop.
+				writeSSEEvent(w, "unauthorized", 0, map[string]string{
+					"reason": "Your access to this workspace was revoked.",
+				})
+				flusher.Flush()
+				return
+			}
 		}
 	}
+}
+
+// sseMembershipRevalInterval is the cadence at which an active SSE
+// connection re-verifies the subscriber's access to the workspace.
+// 60s is a compromise between "revocation is visible quickly" and
+// "don't hammer the DB for every open tab". Exposed as a package-level
+// var so tests can shrink it without waiting a real minute.
+var sseMembershipRevalInterval = 60 * time.Second
+
+// sseSubscriberStillHasAccess re-runs the workspace access check for an
+// already-subscribed SSE client. Returns false when the caller can no
+// longer see this workspace (member removed, grants revoked, token
+// re-scoped) and the connection should be closed.
+//
+// This mirrors the access logic in RequireWorkspaceAccess but avoids
+// writing error responses — we just need a boolean for the caller to
+// act on.
+func (s *Server) sseSubscriberStillHasAccess(r *http.Request, workspaceID string) bool {
+	// Fresh-install escape hatch: no users exist → everyone has access.
+	// Matches RequireWorkspaceAccess. Cheap to recheck.
+	if count, _ := s.store.UserCount(); count == 0 {
+		return true
+	}
+
+	// Legacy workspace-scoped API token (no user context). The token's
+	// scope was baked in at creation time and can only change by token
+	// revocation, which nukes the row and fails ValidateToken on the
+	// next request — but the SSE connection was already established.
+	// We verify the token context is still set + targets this workspace.
+	if currentUser(r) == nil {
+		tokenWsID := tokenWorkspaceID(r)
+		if tokenWsID == "" {
+			return false
+		}
+		return tokenWsID == workspaceID
+	}
+
+	user := currentUser(r)
+	// Admins can access any workspace.
+	if user.Role == "admin" {
+		return true
+	}
+	// Direct workspace member?
+	member, err := s.store.GetWorkspaceMember(workspaceID, user.ID)
+	if err != nil {
+		// DB error — err on the side of letting the client stay
+		// connected. A persistent failure will be caught on the next
+		// HTTP request anyway, and a transient blip shouldn't bounce
+		// every open tab.
+		slog.Warn("SSE revalidation: GetWorkspaceMember failed; keeping connection open",
+			"workspace_id", workspaceID, "user_id", user.ID, "error", err)
+		return true
+	}
+	if member != nil {
+		return true
+	}
+	// Not a member — check guest grants.
+	has, err := s.store.UserHasGrantsInWorkspace(workspaceID, user.ID)
+	if err != nil {
+		slog.Warn("SSE revalidation: UserHasGrantsInWorkspace failed; keeping connection open",
+			"workspace_id", workspaceID, "user_id", user.ID, "error", err)
+		return true
+	}
+	return has
 }
 
 // writeSSEEvent writes a single SSE event to the response writer.

--- a/internal/server/handlers_events.go
+++ b/internal/server/handlers_events.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"math/rand"
 	"net/http"
 	"strconv"
 	"time"
@@ -169,17 +170,27 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 	keepalive := time.NewTicker(30 * time.Second)
 	defer keepalive.Stop()
 
-	// Membership revalidation ticker. The initial subscribe only checked
+	// Membership revalidation timer. The initial subscribe only checked
 	// access ONCE; without this, an owner who revokes a user's workspace
 	// membership (member removed, collection access tightened, guest
 	// grants revoked) would leak events to the now-unauthorized session
 	// for as long as the browser keeps the EventSource open — typically
 	// forever. Re-check at a modest cadence so we catch revocation
-	// within a minute without hammering the DB. Randomly jitter the
-	// first fire a little so every connected client doesn't stampede
-	// the DB at the same :00 / :60 tick.
+	// within a minute without hammering the DB.
+	//
+	// We use a Timer (rather than a Ticker) so the FIRST fire can be
+	// jittered into a random [0, revalInterval) window. Without jitter,
+	// a wave of connections made in the same second — a post-deploy
+	// reconnect storm, a login wave, a cron-driven dashboard — would
+	// all land their revalidation DB reads on the same :00 / :60 tick
+	// and spike load once a minute forever after. After the first fire
+	// we reset to the regular interval for a steady cadence.
 	revalInterval := sseMembershipRevalInterval
-	membershipCheck := time.NewTicker(revalInterval)
+	firstDelay := revalInterval
+	if revalInterval > 0 {
+		firstDelay = time.Duration(rand.Int63n(int64(revalInterval)))
+	}
+	membershipCheck := time.NewTimer(firstDelay)
 	defer membershipCheck.Stop()
 
 	ctx := r.Context()
@@ -226,6 +237,11 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 			// the filter set so the next event dispatched respects the
 			// current grants rather than the ones captured at connect time.
 			vis = s.computeSSEVisibility(r, ws.ID)
+			// Re-arm the timer at the regular cadence. The first fire was
+			// jittered; subsequent fires can be evenly spaced without
+			// introducing a stampede because connect-time variance has
+			// already spread the clients.
+			membershipCheck.Reset(revalInterval)
 		}
 	}
 }

--- a/internal/server/handlers_events.go
+++ b/internal/server/handlers_events.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/xarmian/pad/internal/events"
+	"github.com/xarmian/pad/internal/models"
 )
 
 // handleSSE streams Server-Sent Events for a workspace.
@@ -281,11 +282,42 @@ type sseVisibility struct {
 // Safe to call repeatedly on a live SSE connection — each call fetches
 // the latest state from the store so revoked grants or narrowed roles
 // stop leaking on the next event dispatch.
+//
+// Unlike the request-scoped helpers (visibleCollectionIDs,
+// guestVisibleItemIDs) this function re-fetches the authenticated user
+// from the store so mid-stream role changes (admin demotion,
+// user.disabled flips) take effect on the next tick. The cached
+// currentUser(r) snapshot is only used to look up which user to
+// refresh.
 func (s *Server) computeSSEVisibility(r *http.Request, workspaceID string) sseVisibility {
 	var v sseVisibility
 
-	// Collection-level visibility first.
-	visibleIDs, err := s.visibleCollectionIDs(r, workspaceID)
+	// Resolve the current user fresh from the store. Fall back to the
+	// cached snapshot if the lookup fails so transient DB errors don't
+	// widen visibility unexpectedly.
+	var user *models.User
+	if cached := currentUser(r); cached != nil {
+		if fresh, err := s.store.GetUser(cached.ID); err == nil && fresh != nil {
+			user = fresh
+		} else {
+			if err != nil {
+				slog.Warn("SSE: GetUser failed during visibility recompute; using cached snapshot",
+					"user_id", cached.ID, "error", err)
+			}
+			user = cached
+		}
+	}
+
+	// Collection-level visibility first. Mirrors visibleCollectionIDs
+	// but with a freshly-fetched user so a mid-stream admin-to-member
+	// demotion immediately applies the collection filter.
+	var visibleIDs []string
+	var err error
+	if user != nil && user.Role != "admin" {
+		visibleIDs, err = s.store.VisibleCollectionIDs(workspaceID, user.ID)
+	}
+	// (user == nil || user.Role == "admin") falls through with nil
+	// visibleIDs — nil means "no filtering" in the snapshot below.
 	if err != nil {
 		// Fail closed: if we can't determine visibility, deny all
 		// collection-scoped events rather than leaking hidden data.
@@ -305,7 +337,6 @@ func (s *Server) computeSSEVisibility(r *http.Request, workspaceID string) sseVi
 	// (guest or restricted member). Legacy workspace-scoped tokens and
 	// fresh-install bypass skip this branch and inherit full access via
 	// visibleSlugSet == nil.
-	user := currentUser(r)
 	if user == nil {
 		return v
 	}

--- a/internal/server/handlers_events.go
+++ b/internal/server/handlers_events.go
@@ -373,11 +373,14 @@ func (s *Server) computeSSEVisibility(r *http.Request, workspaceID string) sseVi
 // sseSubscriberStillHasAccess re-runs the workspace access check for an
 // already-subscribed SSE client. Returns false when the caller can no
 // longer see this workspace (member removed, grants revoked, token
-// re-scoped) and the connection should be closed.
+// re-scoped, admin role demoted) and the connection should be closed.
 //
 // This mirrors the access logic in RequireWorkspaceAccess but avoids
-// writing error responses — we just need a boolean for the caller to
-// act on.
+// writing error responses. Unlike that middleware, we DO NOT trust the
+// user struct captured in the request context at connect time — it's a
+// snapshot that would not reflect a mid-stream role change (e.g. admin
+// demotion). We always GetUser fresh from the store so privilege
+// revocation closes streams within one tick.
 func (s *Server) sseSubscriberStillHasAccess(r *http.Request, workspaceID string) bool {
 	// Fresh-install escape hatch: no users exist → everyone has access.
 	// Matches RequireWorkspaceAccess. Cheap to recheck.
@@ -390,7 +393,8 @@ func (s *Server) sseSubscriberStillHasAccess(r *http.Request, workspaceID string
 	// revocation, which nukes the row and fails ValidateToken on the
 	// next request — but the SSE connection was already established.
 	// We verify the token context is still set + targets this workspace.
-	if currentUser(r) == nil {
+	cachedUser := currentUser(r)
+	if cachedUser == nil {
 		tokenWsID := tokenWorkspaceID(r)
 		if tokenWsID == "" {
 			return false
@@ -398,7 +402,23 @@ func (s *Server) sseSubscriberStillHasAccess(r *http.Request, workspaceID string
 		return tokenWsID == workspaceID
 	}
 
-	user := currentUser(r)
+	// Re-fetch the user FRESH — the cached snapshot in request context
+	// is only as current as session validation. An admin demoted mid-
+	// stream should lose workspace-wide access on the next tick.
+	user, err := s.store.GetUser(cachedUser.ID)
+	if err != nil {
+		slog.Warn("SSE revalidation: GetUser failed; keeping connection open",
+			"user_id", cachedUser.ID, "error", err)
+		return true
+	}
+	if user == nil {
+		// User deleted → revoke.
+		return false
+	}
+	// Disabled user → revoke.
+	if user.IsDisabled() {
+		return false
+	}
 	// Admins can access any workspace.
 	if user.Role == "admin" {
 		return true

--- a/internal/server/handlers_events_revalidation_test.go
+++ b/internal/server/handlers_events_revalidation_test.go
@@ -117,6 +117,65 @@ func TestSSESubscriberStillHasAccess(t *testing.T) {
 	}
 }
 
+// TestComputeSSEVisibility_ReflectsCurrentGrants verifies the
+// visibility-recompute path returns the current permission snapshot on
+// every call. A regression would mean a mid-stream permission change
+// (e.g. role downgrade from editor to guest, grants revoked) is
+// ignored until the next reconnect — the exact leak Codex P1 flagged.
+func TestComputeSSEVisibility_ReflectsCurrentGrants(t *testing.T) {
+	srv := testServer(t)
+
+	admin, err := srv.store.CreateUser(models.UserCreate{
+		Email: "admin@example.com", Name: "Admin", Password: "correct-horse-battery-staple", Role: "admin",
+	})
+	if err != nil {
+		t.Fatalf("create admin: %v", err)
+	}
+	user, err := srv.store.CreateUser(models.UserCreate{
+		Email: "user@example.com", Name: "User", Password: "correct-horse-battery-staple", Role: "member",
+	})
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	ws, err := srv.store.CreateWorkspace(models.WorkspaceCreate{Name: "VisTest"})
+	if err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	if err := srv.store.AddWorkspaceMember(ws.ID, user.ID, "editor"); err != nil {
+		t.Fatalf("add member: %v", err)
+	}
+
+	mkReq := func() *http.Request {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/events?workspace="+ws.Slug, nil)
+		return req.WithContext(context.WithValue(req.Context(), ctxCurrentUser, user))
+	}
+
+	// Initial: full editor access → visibleSlugSet == nil (all access).
+	v1 := srv.computeSSEVisibility(mkReq(), ws.ID)
+	if v1.visibleSlugSet != nil {
+		t.Fatalf("editor should have unrestricted access (nil visibleSlugSet); got %v", v1.visibleSlugSet)
+	}
+	if v1.isGuest {
+		t.Fatal("editor member must not be marked as guest")
+	}
+
+	// Revoke membership → recompute must flip the snapshot. Without the
+	// periodic recompute, the stream would keep using v1 forever.
+	if err := srv.store.RemoveWorkspaceMember(ws.ID, user.ID); err != nil {
+		t.Fatalf("remove member: %v", err)
+	}
+	v2 := srv.computeSSEVisibility(mkReq(), ws.ID)
+	// After membership loss, a user with no grants should land on the
+	// isGuest=true branch and whatever visibleSlugSet the store returns
+	// for a fully-unauthorized resolver — the important invariant is
+	// that the *second* call reflects the post-revocation state, not a
+	// stale copy of the first.
+	if !v2.isGuest {
+		t.Fatal("after removal the recomputed visibility should mark user as guest")
+	}
+	_ = admin // silence unused on branches that don't exercise admin path
+}
+
 // TestSSEMembershipRevalInterval_DefaultsToSensibleCadence pins the
 // default tick interval. Not functional on its own; it's a guard so a
 // future cleanup doesn't accidentally set the production default to a

--- a/internal/server/handlers_events_revalidation_test.go
+++ b/internal/server/handlers_events_revalidation_test.go
@@ -176,6 +176,56 @@ func TestComputeSSEVisibility_ReflectsCurrentGrants(t *testing.T) {
 	_ = admin // silence unused on branches that don't exercise admin path
 }
 
+// TestSSESubscriberStillHasAccess_AdminDemotion verifies that an admin
+// who is demoted to "member" AFTER the SSE connection was established
+// loses access on the next revalidation tick. A regression would mean
+// the cached user snapshot from request context is trusted
+// indefinitely (admin-forever bug).
+func TestSSESubscriberStillHasAccess_AdminDemotion(t *testing.T) {
+	srv := testServer(t)
+
+	admin, err := srv.store.CreateUser(models.UserCreate{
+		Email: "admin@example.com", Name: "Admin", Password: "correct-horse-battery-staple", Role: "admin",
+	})
+	if err != nil {
+		t.Fatalf("create admin: %v", err)
+	}
+	// Need another admin so demoting the first doesn't fail the
+	// last-admin guard in SetUserRole.
+	if _, err := srv.store.CreateUser(models.UserCreate{
+		Email: "admin2@example.com", Name: "Admin2", Password: "correct-horse-battery-staple", Role: "admin",
+	}); err != nil {
+		t.Fatalf("create second admin: %v", err)
+	}
+	ws, err := srv.store.CreateWorkspace(models.WorkspaceCreate{Name: "AdminDemotionTest"})
+	if err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+
+	// Request context still has the ORIGINAL admin snapshot (Role="admin").
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/events?workspace="+ws.Slug, nil)
+	req = req.WithContext(context.WithValue(req.Context(), ctxCurrentUser, admin))
+
+	// Before demotion: admin should have access.
+	if !srv.sseSubscriberStillHasAccess(req, ws.ID) {
+		t.Fatal("admin should have access before demotion")
+	}
+
+	// Demote the admin to member. They're NOT a member of the workspace,
+	// so they shouldn't have access via membership either.
+	if err := srv.store.SetUserRole(admin.ID, "member"); err != nil {
+		t.Fatalf("demote admin: %v", err)
+	}
+
+	// SAME request context (same cached snapshot showing Role="admin"),
+	// but the database has the demoted role. Without the fresh GetUser
+	// the function would return true from the admin-role branch. With
+	// it, the post-demotion role is checked and access is denied.
+	if srv.sseSubscriberStillHasAccess(req, ws.ID) {
+		t.Fatal("demoted admin without workspace membership should NOT have access; cached snapshot was trusted")
+	}
+}
+
 // TestSSEMembershipRevalInterval_DefaultsToSensibleCadence pins the
 // default tick interval. Not functional on its own; it's a guard so a
 // future cleanup doesn't accidentally set the production default to a

--- a/internal/server/handlers_events_revalidation_test.go
+++ b/internal/server/handlers_events_revalidation_test.go
@@ -1,0 +1,132 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/xarmian/pad/internal/models"
+)
+
+// TestSSESubscriberStillHasAccess verifies the per-tick membership
+// revalidation helper returns the right answer across all supported
+// access paths: admin, direct member, guest-with-grants, removed
+// member, and legacy workspace-scoped token. A regression here would
+// mean a silently-drifting SSE stream keeps feeding events to a user
+// who lost access.
+func TestSSESubscriberStillHasAccess(t *testing.T) {
+	srv := testServer(t)
+
+	// Setup: one admin, one workspace owned by admin, one regular user
+	// added as editor, one outsider.
+	admin, err := srv.store.CreateUser(models.UserCreate{
+		Email: "admin@example.com", Name: "Admin", Password: "correct-horse-battery-staple", Role: "admin",
+	})
+	if err != nil {
+		t.Fatalf("create admin: %v", err)
+	}
+	member, err := srv.store.CreateUser(models.UserCreate{
+		Email: "editor@example.com", Name: "Editor", Password: "correct-horse-battery-staple", Role: "member",
+	})
+	if err != nil {
+		t.Fatalf("create member: %v", err)
+	}
+	outsider, err := srv.store.CreateUser(models.UserCreate{
+		Email: "outsider@example.com", Name: "Outsider", Password: "correct-horse-battery-staple", Role: "member",
+	})
+	if err != nil {
+		t.Fatalf("create outsider: %v", err)
+	}
+
+	ws, err := srv.store.CreateWorkspace(models.WorkspaceCreate{Name: "TestWS"})
+	if err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	if err := srv.store.AddWorkspaceMember(ws.ID, member.ID, "editor"); err != nil {
+		t.Fatalf("add member: %v", err)
+	}
+
+	mkReq := func(u *models.User) *http.Request {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/events?workspace="+ws.Slug, nil)
+		if u != nil {
+			req = req.WithContext(context.WithValue(req.Context(), ctxCurrentUser, u))
+		}
+		return req
+	}
+
+	// Admin: always true regardless of membership.
+	if !srv.sseSubscriberStillHasAccess(mkReq(admin), ws.ID) {
+		t.Fatal("admin should have access")
+	}
+
+	// Direct member: true.
+	if !srv.sseSubscriberStillHasAccess(mkReq(member), ws.ID) {
+		t.Fatal("active member should have access")
+	}
+
+	// Outsider (no membership, no grants): false.
+	if srv.sseSubscriberStillHasAccess(mkReq(outsider), ws.ID) {
+		t.Fatal("outsider should NOT have access")
+	}
+
+	// Remove the member. sseSubscriberStillHasAccess should now return
+	// false on the same-shaped request — this is the core regression:
+	// a live SSE connection must stop streaming when membership is
+	// revoked.
+	if err := srv.store.RemoveWorkspaceMember(ws.ID, member.ID); err != nil {
+		t.Fatalf("remove member: %v", err)
+	}
+	if srv.sseSubscriberStillHasAccess(mkReq(member), ws.ID) {
+		t.Fatal("removed member should NOT have access after revocation")
+	}
+
+	// Re-add the outsider with a collection-level guest grant and
+	// confirm the has-grants branch flips to true.
+	// (Guest grants exercise a different code path than workspace_members.)
+	tasksColl, err := srv.store.GetCollectionBySlug(ws.ID, "tasks")
+	if err != nil || tasksColl == nil {
+		t.Log("skipping guest-grant subtest: tasks collection not seeded in this test fixture")
+	} else {
+		_, err = srv.store.CreateCollectionGrant(ws.ID, tasksColl.ID, outsider.ID, "view", admin.ID)
+		if err != nil {
+			t.Fatalf("create guest grant: %v", err)
+		}
+		if !srv.sseSubscriberStillHasAccess(mkReq(outsider), ws.ID) {
+			t.Fatal("user with active guest grant should have access")
+		}
+	}
+
+	// Unauthenticated request: false (no user, no legacy token).
+	if srv.sseSubscriberStillHasAccess(mkReq(nil), ws.ID) {
+		t.Fatal("unauthenticated subscriber should NOT have access")
+	}
+
+	// Legacy workspace-scoped token targeting THIS workspace: true.
+	reqWithToken := mkReq(nil)
+	reqWithToken = reqWithToken.WithContext(context.WithValue(reqWithToken.Context(), ctxTokenWorkspaceID, ws.ID))
+	if !srv.sseSubscriberStillHasAccess(reqWithToken, ws.ID) {
+		t.Fatal("legacy token scoped to this workspace should have access")
+	}
+
+	// Legacy workspace-scoped token targeting a DIFFERENT workspace: false.
+	reqWithOtherToken := mkReq(nil)
+	reqWithOtherToken = reqWithOtherToken.WithContext(context.WithValue(reqWithOtherToken.Context(), ctxTokenWorkspaceID, "some-other-workspace-id"))
+	if srv.sseSubscriberStillHasAccess(reqWithOtherToken, ws.ID) {
+		t.Fatal("legacy token scoped to a different workspace should NOT have access")
+	}
+}
+
+// TestSSEMembershipRevalInterval_DefaultsToSensibleCadence pins the
+// default tick interval. Not functional on its own; it's a guard so a
+// future cleanup doesn't accidentally set the production default to a
+// test-scale value like 100ms.
+func TestSSEMembershipRevalInterval_DefaultsToSensibleCadence(t *testing.T) {
+	const minReasonable = 30 // seconds
+	const maxReasonable = 300
+	sec := int(sseMembershipRevalInterval.Seconds())
+	if sec < minReasonable || sec > maxReasonable {
+		t.Fatalf("sseMembershipRevalInterval = %ds, want between %d and %d",
+			sec, minReasonable, maxReasonable)
+	}
+}

--- a/internal/server/handlers_events_revalidation_test.go
+++ b/internal/server/handlers_events_revalidation_test.go
@@ -226,6 +226,72 @@ func TestSSESubscriberStillHasAccess_AdminDemotion(t *testing.T) {
 	}
 }
 
+// TestComputeSSEVisibility_DemotedAdminGetsFilter verifies that when a
+// global admin is demoted to "member" mid-stream BUT remains a member
+// of the workspace, their visibility snapshot immediately picks up the
+// collection-level filter instead of continuing to use the admin
+// short-circuit (nil visibleSlugSet = "all access"). Without the fresh
+// GetUser inside computeSSEVisibility, visibleCollectionIDs would read
+// the cached Role="admin" from request context and keep returning nil.
+func TestComputeSSEVisibility_DemotedAdminGetsFilter(t *testing.T) {
+	srv := testServer(t)
+
+	admin, err := srv.store.CreateUser(models.UserCreate{
+		Email: "admin@example.com", Name: "Admin", Password: "correct-horse-battery-staple", Role: "admin",
+	})
+	if err != nil {
+		t.Fatalf("create admin: %v", err)
+	}
+	if _, err := srv.store.CreateUser(models.UserCreate{
+		Email: "admin2@example.com", Name: "Admin2", Password: "correct-horse-battery-staple", Role: "admin",
+	}); err != nil {
+		t.Fatalf("create second admin: %v", err)
+	}
+	ws, err := srv.store.CreateWorkspace(models.WorkspaceCreate{Name: "DemoteVis"})
+	if err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	// Add the admin as a member with "specific" collection access but
+	// zero granted collections — after demotion they should see nothing.
+	// Keep membership so sseSubscriberStillHasAccess still returns true;
+	// we specifically want to exercise the visibility recompute, not
+	// the revoke-and-close path.
+	if err := srv.store.AddWorkspaceMember(ws.ID, admin.ID, "editor"); err != nil {
+		t.Fatalf("add member: %v", err)
+	}
+	if err := srv.store.SetMemberCollectionAccess(ws.ID, admin.ID, "specific", nil); err != nil {
+		t.Fatalf("set specific collection access: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/events?workspace="+ws.Slug, nil)
+	req = req.WithContext(context.WithValue(req.Context(), ctxCurrentUser, admin))
+
+	// Before demotion: admin bypass → visibleSlugSet == nil (all access).
+	// visibleCollectionIDs / computeSSEVisibility treats the user as
+	// admin regardless of their member.CollectionAccess setting.
+	v1 := srv.computeSSEVisibility(req, ws.ID)
+	if v1.visibleSlugSet != nil {
+		t.Fatalf("admin should have unrestricted visibility; got %v", v1.visibleSlugSet)
+	}
+
+	// Demote to member. The cached snapshot in the request still says
+	// Role="admin". Without the fresh fetch inside computeSSEVisibility,
+	// the admin short-circuit would keep returning nil here, ignoring
+	// the "specific" + empty-granted-set member config entirely.
+	if err := srv.store.SetUserRole(admin.ID, "member"); err != nil {
+		t.Fatalf("demote admin: %v", err)
+	}
+
+	v2 := srv.computeSSEVisibility(req, ws.ID)
+	if v2.visibleSlugSet == nil {
+		t.Fatal("demoted admin should NOT have unrestricted visibility; cached Role=admin was trusted")
+	}
+	// With empty granted-collection set + system collections added
+	// automatically, the visibleSlugSet should be a finite set of only
+	// the system collection(s) they inherit — NOT nil. That's enough
+	// to prove the fresh-fetch path fired.
+}
+
 // TestSSEMembershipRevalInterval_DefaultsToSensibleCadence pins the
 // default tick interval. Not functional on its own; it's a guard so a
 // future cleanup doesn't accidentally set the production default to a

--- a/web/src/lib/services/sse.svelte.ts
+++ b/web/src/lib/services/sse.svelte.ts
@@ -1,6 +1,6 @@
 import { SvelteSet } from 'svelte/reactivity';
 
-export type SSEStatus = 'disconnected' | 'connected' | 'reconnecting';
+export type SSEStatus = 'disconnected' | 'connected' | 'reconnecting' | 'unauthorized';
 
 export interface ItemEvent {
 	type: string;
@@ -81,6 +81,22 @@ function createSSEService() {
 			import('./sync.svelte').then(({ syncService }) => {
 				syncService.triggerSync();
 			});
+		});
+
+		// Handle unauthorized: the server's periodic membership revalidation
+		// detected that this session has lost access to the workspace. We
+		// must close the EventSource ourselves — otherwise the browser
+		// auto-reconnect would tight-loop on a 401 or a stream that
+		// immediately closes again, hammering /api/v1/events. Surface the
+		// status so the surrounding UI can redirect to the workspace list
+		// or show a "revoked" message.
+		eventSource.addEventListener('unauthorized', () => {
+			status = 'unauthorized';
+			if (eventSource) {
+				eventSource.close();
+				eventSource = null;
+			}
+			currentWorkspace = '';
 		});
 
 		for (const eventType of ITEM_EVENTS) {


### PR DESCRIPTION
## Summary
\`handleSSE\` verified workspace access only at connection time. A removed member kept receiving events until they manually disconnected — or, more commonly, indefinitely because \`EventSource\` auto-reconnects. An owner who revoked access had no way to stop the leak.

- New 60s membership revalidation ticker inside the SSE select loop.
- \`sseSubscriberStillHasAccess\` mirrors \`RequireWorkspaceAccess\`'s matrix: fresh-install bypass, admin role, direct membership, guest grants, legacy workspace-scoped API token. DB errors fail OPEN (transient blip doesn't bounce every open tab); missing membership fails CLOSED.
- On revocation we emit \`{type:\"unauthorized\"}\` with a reason BEFORE closing the stream so the frontend can route to login instead of tight-loop reconnect.
- \`sseMembershipRevalInterval\` is a package-level var for test injection; pinned to a sensible 30-300s range.

## Context
Implements \`TASK-670\` under \`PLAN-643\` (OSS Security Hardening).

## Test plan
- [x] \`go build ./...\` — clean
- [x] \`go vet ./...\` — clean
- [x] \`go test ./...\` — all tests pass
- [x] Unit test covers admin, active member, outsider, removed member, guest-grant (skipped if default collections aren't seeded), unauthenticated, legacy token scoped to same workspace, and legacy token scoped to a different workspace.