### PR TITLE
fix(docker): correct goreleaser image CMD (TASK-671)

### DIFF
--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -7,4 +7,4 @@ ENV PAD_HOST=0.0.0.0
 EXPOSE 7777
 VOLUME /data
 ENTRYPOINT ["pad"]
-CMD ["serve"]
+CMD ["server", "start"]


### PR DESCRIPTION
## Summary
- Change `Dockerfile.goreleaser` CMD from `["serve"]` to `["server", "start"]`.
- Matches the main `Dockerfile` (which is already correct).

## Context
Implements `TASK-671` (B1 blocker) under `PLAN-644` — OSS Repo Hygiene & Launch Polish.

The pad binary does not have a `serve` subcommand; its HTTP server runs under `pad server start`. Today `docker run ghcr.io/xarmian/pad:latest` exits immediately with `unknown command "serve" for "pad"`. This fix unblocks the published goreleaser image.

## Test plan
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./...` — all tests pass
- [x] Diff inspected against `Dockerfile` (main) — CMDs now match