### PR TITLE
fix(docs): replace 'pad serve' with 'pad server start' (TASK-675)

### DIFF
--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -5711,7 +5711,7 @@ links, versions).
 
 Steps:
   1. Set up a fresh PostgreSQL database
-  2. Run 'pad serve' with PAD_DB_DRIVER=postgres once to create the schema
+  2. Run 'pad server start' with PAD_DB_DRIVER=postgres once to create the schema
   3. Stop the server
   4. Run this command to migrate workspace data`,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -5792,7 +5792,7 @@ Steps:
 
 			fmt.Fprintln(os.Stderr, "\nNext steps:")
 			fmt.Fprintln(os.Stderr, "  1. Set PAD_DB_DRIVER=postgres and PAD_DATABASE_URL in your environment")
-			fmt.Fprintln(os.Stderr, "  2. Start the server: pad serve")
+			fmt.Fprintln(os.Stderr, "  2. Start the server: pad server start")
 			fmt.Fprintln(os.Stderr, "  3. Run 'pad auth setup' to create an admin account on the new database")
 			fmt.Fprintln(os.Stderr, "  4. Verify your data in the web UI")
 

--- a/docs/backup.md
+++ b/docs/backup.md
@@ -78,7 +78,7 @@ When graduating from a local SQLite setup to production PostgreSQL:
 createdb pad
 
 # 2. Run Pad once against PostgreSQL to create the schema
-PAD_DB_DRIVER=postgres PAD_DATABASE_URL="postgres://pad:secret@localhost:5432/pad" pad serve &
+PAD_DB_DRIVER=postgres PAD_DATABASE_URL="postgres://pad:secret@localhost:5432/pad" pad server start &
 # Wait a few seconds for migrations to run, then stop it
 kill %1
 
@@ -91,7 +91,7 @@ pad db migrate-to-pg \
 PAD_DB_DRIVER=postgres PAD_DATABASE_URL="postgres://pad:secret@localhost:5432/pad" pad auth setup
 
 # 5. Start the server with PostgreSQL
-PAD_DB_DRIVER=postgres PAD_DATABASE_URL="postgres://pad:secret@localhost:5432/pad" pad serve
+PAD_DB_DRIVER=postgres PAD_DATABASE_URL="postgres://pad:secret@localhost:5432/pad" pad server start
 ```
 
 **What gets migrated:**

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -113,7 +113,7 @@ The simplest deployment — one binary, one file for the database.
 make build
 
 # Run directly
-PAD_HOST=0.0.0.0 ./pad serve
+PAD_HOST=0.0.0.0 ./pad server start
 
 # Or install as a systemd service (see below)
 ```
@@ -161,7 +161,7 @@ After=network.target postgresql.service redis.service
 Type=simple
 User=pad
 Group=pad
-ExecStart=/usr/local/bin/pad serve
+ExecStart=/usr/local/bin/pad server start
 Environment=PAD_HOST=0.0.0.0
 Environment=PAD_DATA_DIR=/var/lib/pad
 Environment=PAD_DB_DRIVER=postgres


### PR DESCRIPTION
## Summary
Rename 6 references to the nonexistent `pad serve` command to the canonical `pad server start`:

- `cmd/pad/main.go:5714` — `migrate-to-pg` long help text
- `cmd/pad/main.go:5795` — post-migration "Next steps" instruction
- `docs/backup.md:81,94` — Postgres migration walkthrough
- `docs/deployment.md:116` — binary launch example
- `docs/deployment.md:164` — `systemd ExecStart=…`

## Context
Implements `TASK-675` (H2) under `PLAN-644` — OSS Repo Hygiene & Launch Polish. Users copy-pasting the systemd example would get a non-starting service today. Repo-wide grep is clean outside gitignored `v1-archive/` and `.pad/`. README.md was already correct.

## Test plan
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./...` — all tests pass
- [x] `grep -r 'pad serve\b' --include='*.md' --include='*.go' --include='*.yaml' --include='*.yml' --include='*.sh'` returns only gitignored paths