### PR TITLE
fix(web): resolve 9 svelte-check errors blocking CI (TASK-674)

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -34,6 +34,7 @@
 				"@sveltejs/kit": "^2.57.1",
 				"@sveltejs/vite-plugin-svelte": "^6.2.4",
 				"@types/marked": "^5.0.2",
+				"@types/qrcode": "^1.5.6",
 				"marked": "^17.0.5",
 				"svelte": "^5.51.0",
 				"svelte-check": "^4.4.2",
@@ -1937,6 +1938,26 @@
 			"resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
 			"integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
 			"license": "MIT"
+		},
+		"node_modules/@types/node": {
+			"version": "25.6.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+			"integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~7.19.0"
+			}
+		},
+		"node_modules/@types/qrcode": {
+			"version": "1.5.6",
+			"resolved": "https://registry.npmjs.org/@types/qrcode/-/qrcode-1.5.6.tgz",
+			"integrity": "sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*"
+			}
 		},
 		"node_modules/@types/trusted-types": {
 			"version": "2.0.7",
@@ -3955,6 +3976,13 @@
 			"version": "1.6.3",
 			"resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
 			"integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
+			"license": "MIT"
+		},
+		"node_modules/undici-types": {
+			"version": "7.19.2",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+			"integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/uuid": {

--- a/web/package.json
+++ b/web/package.json
@@ -18,6 +18,7 @@
 		"@sveltejs/kit": "^2.57.1",
 		"@sveltejs/vite-plugin-svelte": "^6.2.4",
 		"@types/marked": "^5.0.2",
+		"@types/qrcode": "^1.5.6",
 		"marked": "^17.0.5",
 		"svelte": "^5.51.0",
 		"svelte-check": "^4.4.2",

--- a/web/src/lib/components/collections/EditCollectionModal.svelte
+++ b/web/src/lib/components/collections/EditCollectionModal.svelte
@@ -31,7 +31,14 @@
 		onclose: () => void;
 	}
 
-	let { open, collection, wsSlug, initialSection, onupdated, onclose }: Props = $props();
+	let {
+		open = $bindable(),
+		collection,
+		wsSlug,
+		initialSection,
+		onupdated,
+		onclose
+	}: Props = $props();
 
 	let confirmArchive = $state(false);
 	let archiving = $state(false);

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -681,8 +681,9 @@
 				<a href="/{username}/{wsSlug}">Home</a>
 				<span class="sep">/</span>
 				{#if item.parent_collection_slug && item.parent_slug}
-					{@const parentColl = allCollections.find(c => c.slug === item.parent_collection_slug)}
-					<a href="/{username}/{wsSlug}/{item.parent_collection_slug}">{parentColl?.icon ?? ''} {parentColl?.name ?? item.parent_collection_slug}</a>
+					{@const parentCollSlug = item.parent_collection_slug}
+					{@const parentColl = allCollections.find(c => c.slug === parentCollSlug)}
+					<a href="/{username}/{wsSlug}/{parentCollSlug}">{parentColl?.icon ?? ''} {parentColl?.name ?? parentCollSlug}</a>
 					<span class="sep">/</span>
 					<a href="/{username}/{wsSlug}/{item.parent_collection_slug}/{item.parent_slug}">{item.parent_ref || item.parent_title}</a>
 					<span class="sep">/</span>
@@ -741,7 +742,7 @@
 			<button
 				class="action-btn star-btn"
 				class:starred={starredStore.isStarred(item.id)}
-				onclick={() => starredStore.toggle(wsSlug, item.slug, item.id)}
+				onclick={() => item && starredStore.toggle(wsSlug, item.slug, item.id)}
 				title={starredStore.isStarred(item.id) ? 'Unstar' : 'Star'}
 			>
 				{starredStore.isStarred(item.id) ? '★' : '☆'}

--- a/web/src/routes/auth/cli/[code]/+page.svelte
+++ b/web/src/routes/auth/cli/[code]/+page.svelte
@@ -10,6 +10,11 @@
 
 	onMount(async () => {
 		const code = $page.params.code;
+		if (!code) {
+			status = 'error';
+			error = 'Missing CLI session code.';
+			return;
+		}
 
 		try {
 			const session = await api.auth.cli.getSession(code);
@@ -40,6 +45,10 @@
 
 	async function handleApprove() {
 		const code = $page.params.code;
+		if (!code) {
+			error = 'Missing CLI session code.';
+			return;
+		}
 		approving = true;
 		error = '';
 


### PR DESCRIPTION
## Summary
CI's svelte-check gate was reporting **9 errors on main**. All resolved:

1. **`EditCollectionModal`**: made `open` prop `$bindable()`. Unblocks `bind:open` at both call sites in `[collection]/+page.svelte:1153` and `[slug]/+page.svelte:1101`.
2. **`[slug]/+page.svelte`** item-null narrowing (TS doesn't narrow across closures):
   - Line 684 — extract `parent_collection_slug` to a template `@const` before passing to `.find()`.
   - Line 744 — star toggle handler short-circuits on `item &&` so both `.slug` and `.id` are safe.
3. **`auth/cli/[code]/+page.svelte`**: guard `$page.params.code` against `undefined` in both `onMount` and `handleApprove`.
4. **`console/settings/+page.svelte`**: add `@types/qrcode` dev dependency so dynamic `import('qrcode')` has proper typings.

After the fixes: `npx svelte-check` reports **0 errors** (10 warnings remain; those are out of scope and covered by TASK-685 / other cleanups).

## Context
Implements `TASK-674` (H3) under `PLAN-644` — OSS Repo Hygiene & Launch Polish. CI was red on main; this unblocks it.

## Test plan
- [x] `cd web && npx svelte-check` — 0 errors
- [x] `cd web && npm run build` — clean
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./...` — all tests pass