### PR TITLE
security(ci): pin all GitHub Actions to commit SHAs (TASK-677)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,14 +13,18 @@ concurrency:
 permissions:
   contents: read
 
+# All third-party Actions are pinned to a 40-char commit SHA with a trailing
+# '# vX.Y.Z' comment so a compromised maintainer or moved tag cannot silently
+# execute attacker code in CI. Bump the SHA + comment together when updating.
+
 jobs:
   go:
     name: Go
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: "1.25"
 
@@ -75,9 +79,9 @@ jobs:
           --health-timeout 3s
           --health-retries 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: "1.25"
 
@@ -102,9 +106,9 @@ jobs:
       run:
         working-directory: web
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "22"
           cache: "npm"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,20 +9,26 @@ permissions:
   contents: write
   packages: write
 
+# All third-party Actions are pinned to a 40-char commit SHA with a trailing
+# '# vX.Y.Z' comment so a compromised maintainer or moved tag cannot silently
+# execute attacker code in the release pipeline (this workflow has
+# contents:write + packages:write + the GHCR token, so a malicious action
+# here could publish tampered binaries). Bump the SHA + comment together.
+
 jobs:
   release:
     name: Build & Release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: "1.25"
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "22"
           cache: "npm"
@@ -35,17 +41,17 @@ jobs:
         run: go test ./...
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
           version: "~> v2"
           args: release --clean


### PR DESCRIPTION
## Summary
Pin every third-party Action in `.github/workflows/` to a 40-char commit SHA with a trailing `# vX.Y.Z` comment. **12 `uses:` lines updated** across `ci.yml` and `release.yml`.

- `actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1`
- `actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0`
- `actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0`
- `docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0`
- `docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0`
- `goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0`

Pinned to the latest release **within the same major** that was already in use, so behavior doesn't change. No major version jumps hidden in a security PR.

## Context
Implements `TASK-677` (H4) under `PLAN-644` — OSS Repo Hygiene & Launch Polish.

Floating tags (`@v4`) resolve dynamically: a compromised maintainer or a re-pointed tag can execute attacker code in CI with `contents:write` + `packages:write` + the GHCR token in scope. `release.yml` is especially exposed — a malicious step could publish tampered binaries. SHA pins block that attack surface.

Dependabot (coming in TASK-678) will track commit-pinned refs and open PRs that bump SHA + comment together.

## Test plan
- [x] `grep -nE '^\s*-?\s*uses:' .github/workflows/*.yml` — all 12 references pinned
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./...` — all tests pass
- [x] Version comments match the release tag that each SHA corresponds to (cross-referenced via `gh api repos/<owner>/<repo>/git/ref/tags/<tag>`)