### PR TITLE
chore: add HEALTHCHECK to both Dockerfiles (TASK-681)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,5 +29,8 @@ ENV PAD_HOST=0.0.0.0
 EXPOSE 7777
 VOLUME /data
 
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD wget -q --spider http://localhost:7777/api/v1/health || exit 1
+
 ENTRYPOINT ["pad"]
 CMD ["server", "start"]

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -6,5 +6,7 @@ ENV PAD_DATA_DIR=/data
 ENV PAD_HOST=0.0.0.0
 EXPOSE 7777
 VOLUME /data
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD wget -q --spider http://localhost:7777/api/v1/health || exit 1
 ENTRYPOINT ["pad"]
 CMD ["server", "start"]


### PR DESCRIPTION
## Summary
Add `HEALTHCHECK` instructions to `Dockerfile` and `Dockerfile.goreleaser` so containers self-report health when run outside of docker-compose.

## Context
Implements `TASK-681` under `PLAN-644` (OSS Repo Hygiene & Launch Polish).

Before: neither Dockerfile declared `HEALTHCHECK`. `docker-compose.yml` declares it at compose level only, so `docker run ghcr.io/xarmian/pad:latest` had no health signal for orchestrators like Kubernetes/Swarm/Docker.

Both Dockerfiles now add:
```dockerfile
HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
    CMD wget -q --spider http://localhost:7777/api/v1/health || exit 1
```

- Probes the existing `/api/v1/health` endpoint registered in `internal/server/server.go:353`.
- Uses `wget` from busybox (already present in `alpine:3.21`) — no extra `apk` install needed.
- Interval/timeout tuned for low-traffic single-user instances.

## Test plan
- [x] `docker build -t pad-test .` — image builds cleanly
- [x] `docker inspect pad-test --format '{{json .Config.Healthcheck}}'` reports the expected probe
- [x] `docker run -d pad-test` + `docker exec ... wget -q --spider http://localhost:7777/api/v1/health` — returns success against a live container
- [x] `go build ./... && go vet ./... && go test ./...` unchanged / green