### PR TITLE
fix(a11y): BottomSheet tabindex + roles page label associations (TASK-685)

### DIFF
--- a/web/src/lib/components/common/BottomSheet.svelte
+++ b/web/src/lib/components/common/BottomSheet.svelte
@@ -56,6 +56,7 @@
 			aria-modal="true"
 			aria-labelledby={title ? headingId : undefined}
 			aria-label={title ? undefined : 'Dialog'}
+			tabindex="-1"
 			onclick={(e) => e.stopPropagation()}
 		>
 			{#if title}

--- a/web/src/routes/[username]/[workspace]/roles/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/roles/+page.svelte
@@ -449,19 +449,19 @@
 		<div class="dialog-body">
 			<div class="role-edit-form">
 				<div class="role-field-group">
-					<label class="role-field-label">Icon & Name</label>
+					<label class="role-field-label" for="role-name">Icon & Name</label>
 					<div class="role-edit-row">
 						<EmojiPickerButton bind:value={editIcon} placeholder="🔨" size="md" />
-						<input class="role-input" type="text" bind:value={editName} placeholder="Role name" />
+						<input id="role-name" class="role-input" type="text" bind:value={editName} placeholder="Role name" />
 					</div>
 				</div>
 				<div class="role-field-group">
-					<label class="role-field-label">Description</label>
-					<input class="role-input" type="text" bind:value={editDescription} placeholder="What does this role do?" />
+					<label class="role-field-label" for="role-description">Description</label>
+					<input id="role-description" class="role-input" type="text" bind:value={editDescription} placeholder="What does this role do?" />
 				</div>
 				<div class="role-field-group">
-					<label class="role-field-label">Tools</label>
-					<input class="role-input" type="text" bind:value={editTools} placeholder="e.g. Claude Code + Sonnet 4.6" />
+					<label class="role-field-label" for="role-tools">Tools</label>
+					<input id="role-tools" class="role-input" type="text" bind:value={editTools} placeholder="e.g. Claude Code + Sonnet 4.6" />
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
## Summary
Close the four a11y warnings svelte-check currently surfaces.

## Context
Implements `TASK-685` under `PLAN-644` (OSS Repo Hygiene & Launch Polish).

### `BottomSheet.svelte`
The `<div role="dialog">` needs a \`tabindex\` so screen readers can programmatically focus the dialog on open. Add \`tabindex="-1"\` — focusable via script, not in the tab order. Matches the ARIA APG dialog pattern.

### `roles/+page.svelte`
Three `<label>` elements in the edit-role dialog (Icon & Name, Description, Tools) had no associated control. Each target `<input>` gets a stable \`id\` (`role-name`, `role-description`, `role-tools`) and the matching `<label for={id}>`. The dialog only renders one instance at a time, so hardcoded IDs are safe.

## Before / after
- Before: 10 svelte-check warnings (4 target + 6 pre-existing unrelated: `<svelte:self>` deprecation, empty CSS rulesets, unused selectors)
- After: 6 warnings — the 4 targets cleared, no new warnings introduced

## Test plan
- [x] `cd web && npm run check` — 4 target warnings gone, 6 pre-existing unrelated warnings still present, 0 errors
- [x] `cd web && npm run build` — clean
- [x] `go build ./... && go vet ./... && go test ./...` green
- [x] Visual spot-check on the diff: label→input linkage via `for`/`id`