### PR TITLE
docs: add Go Report Card, GHCR, Sponsors badges to README (TASK-688)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,10 @@
   <p align="center">
     <a href="https://github.com/xarmian/pad/actions/workflows/ci.yml"><img src="https://github.com/xarmian/pad/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
     <a href="https://github.com/xarmian/pad/releases"><img src="https://img.shields.io/github/v/release/xarmian/pad" alt="Release"></a>
+    <a href="https://goreportcard.com/report/github.com/xarmian/pad"><img src="https://goreportcard.com/badge/github.com/xarmian/pad" alt="Go Report Card"></a>
+    <a href="https://github.com/xarmian/pad/pkgs/container/pad"><img src="https://img.shields.io/badge/ghcr.io-xarmian%2Fpad-blue?logo=docker&logoColor=white" alt="Container image on GHCR"></a>
     <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue" alt="License"></a>
+    <a href="https://github.com/sponsors/xarmian"><img src="https://img.shields.io/github/sponsors/xarmian?label=sponsors&logo=github" alt="GitHub Sponsors"></a>
   </p>
 </p>
 


### PR DESCRIPTION
## Summary
Grouped README polish — gives the repo the public-OSS texture reviewers expect.

## Context
Implements `TASK-688` under `PLAN-644` (OSS Repo Hygiene & Launch Polish).

### New badges
- **Go Report Card** — reinforces code-quality signal once repo flips public.
- **Container image on GHCR** — static shields.io badge linking to the package page. GHCR doesn't expose a pulls endpoint like Docker Hub, so we skip the unreliable third-party pull-count services.
- **GitHub Sponsors** — shows live sponsor count; complements the FUNDING.yml Sponsor button added in TASK-679.

Existing CI, Release, License badges kept as-is.

## Test plan
- [x] `go build ./... && go test ./...` — green (no code changes but ran for sanity)
- [x] Visual review: badge URLs resolve; the GHCR link points to the right package page
- [ ] After merge + first public discovery: confirm Go Report Card populates and Sponsors badge renders