### PR TITLE
feat: durable Stripe webhook idempotency endpoint (PLAN-645 / TASK-696)

### DIFF
--- a/internal/server/cloud_admin_gate_test.go
+++ b/internal/server/cloud_admin_gate_test.go
@@ -45,6 +45,7 @@ func TestCloudAdminGate_SelfHost_Returns404(t *testing.T) {
 		{"POST /admin/plan with cloud secret header", "POST", "/api/v1/admin/plan", map[string]string{"cloud_secret": "x"}},
 		{"POST /admin/stripe-customer-id with header", "POST", "/api/v1/admin/stripe-customer-id", map[string]string{"cloud_secret": "x"}},
 		{"GET /admin/user-by-customer with header", "GET", "/api/v1/admin/user-by-customer?customer_id=cus_x", nil},
+		{"POST /admin/stripe-event-processed with header", "POST", "/api/v1/admin/stripe-event-processed", map[string]string{"cloud_secret": "x", "event_id": "evt_x"}},
 	}
 
 	for _, tt := range tests {
@@ -186,6 +187,93 @@ func TestCloudAdminGate_QueryParamSecret_Rejected(t *testing.T) {
 
 	if rr.Code != http.StatusUnauthorized {
 		t.Fatalf("?cloud_secret= should no longer authenticate, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+// TestStripeEventProcessed_RecordsAndDetectsDuplicates verifies TASK-696:
+// first call for a given event_id returns already_processed=false; a
+// second call for the same event_id returns already_processed=true. This
+// is what gives the sidecar durable idempotency across restarts.
+func TestStripeEventProcessed_RecordsAndDetectsDuplicates(t *testing.T) {
+	srv := testServer(t)
+	bootstrapFirstUser(t, srv, "admin@example.com", "Admin")
+	srv.SetCloudMode("shh-its-a-secret")
+
+	// First call — should be new.
+	req := cloudAdminReq(t, "POST", "/api/v1/admin/stripe-event-processed", map[string]string{
+		"event_id":     "evt_test_12345",
+		"cloud_secret": "shh-its-a-secret",
+	}, map[string]string{"X-Cloud-Secret": "shh-its-a-secret"})
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("first call expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var first struct {
+		EventID          string `json:"event_id"`
+		AlreadyProcessed bool   `json:"already_processed"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &first); err != nil {
+		t.Fatalf("decode first response: %v", err)
+	}
+	if first.AlreadyProcessed {
+		t.Fatalf("first call should return already_processed=false")
+	}
+	if first.EventID != "evt_test_12345" {
+		t.Fatalf("first call returned wrong event_id: %q", first.EventID)
+	}
+
+	// Second call with same event_id — must be flagged as duplicate.
+	req = cloudAdminReq(t, "POST", "/api/v1/admin/stripe-event-processed", map[string]string{
+		"event_id":     "evt_test_12345",
+		"cloud_secret": "shh-its-a-secret",
+	}, map[string]string{"X-Cloud-Secret": "shh-its-a-secret"})
+	rr = httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("second call expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var second struct {
+		EventID          string `json:"event_id"`
+		AlreadyProcessed bool   `json:"already_processed"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &second); err != nil {
+		t.Fatalf("decode second response: %v", err)
+	}
+	if !second.AlreadyProcessed {
+		t.Fatalf("second call should return already_processed=true")
+	}
+}
+
+// TestStripeEventProcessed_ValidatesEventIDPrefix verifies the handler
+// rejects event IDs that don't start with 'evt_', matching the existing
+// 'cus_' prefix validation on stripe-customer-id.
+func TestStripeEventProcessed_ValidatesEventIDPrefix(t *testing.T) {
+	srv := testServer(t)
+	bootstrapFirstUser(t, srv, "admin@example.com", "Admin")
+	srv.SetCloudMode("shh-its-a-secret")
+
+	tests := []struct {
+		name    string
+		eventID string
+	}{
+		{"empty event_id", ""},
+		{"missing evt_ prefix", "sub_12345"},
+		{"wrong prefix cus_", "cus_12345"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := cloudAdminReq(t, "POST", "/api/v1/admin/stripe-event-processed", map[string]string{
+				"event_id":     tt.eventID,
+				"cloud_secret": "shh-its-a-secret",
+			}, map[string]string{"X-Cloud-Secret": "shh-its-a-secret"})
+			rr := httptest.NewRecorder()
+			srv.ServeHTTP(rr, req)
+			if rr.Code != http.StatusBadRequest {
+				t.Fatalf("%s: expected 400, got %d: %s", tt.name, rr.Code, rr.Body.String())
+			}
+		})
 	}
 }
 

--- a/internal/server/handlers_cloud.go
+++ b/internal/server/handlers_cloud.go
@@ -59,9 +59,10 @@ func (s *Server) requireCloudMode(next http.Handler) http.Handler {
 // setting X-Cloud-Secret on any path (e.g. GET /api/v1/workspaces)
 // bypassed auth globally.
 var cloudAdminPaths = map[string]struct{}{
-	"/api/v1/admin/plan":               {},
-	"/api/v1/admin/stripe-customer-id": {},
-	"/api/v1/admin/user-by-customer":   {},
+	"/api/v1/admin/plan":                   {},
+	"/api/v1/admin/stripe-customer-id":     {},
+	"/api/v1/admin/user-by-customer":       {},
+	"/api/v1/admin/stripe-event-processed": {},
 }
 
 // isCloudAdminPath returns true if the request targets one of the three
@@ -634,6 +635,88 @@ func (s *Server) handleGetUserByCustomerID(w http.ResponseWriter, r *http.Reques
 		"user_id": targetUser.ID,
 		"email":   targetUser.Email,
 		"plan":    targetUser.Plan,
+	})
+}
+
+// --- Stripe Webhook Idempotency (TASK-696) ---
+
+// handleStripeEventProcessed handles POST /api/v1/admin/stripe-event-processed.
+// Called by the pad-cloud sidecar BEFORE processing a Stripe webhook event.
+// Pad is the source of truth for which event IDs have been handled, so the
+// check survives sidecar restarts (previously held in-memory, lost on crash).
+//
+// Request body:
+//
+//	{"event_id": "evt_xxx", "cloud_secret": "..."}
+//
+// Response:
+//
+//	{"already_processed": true|false, "event_id": "evt_xxx"}
+//
+// Semantics: the call is transactional — it atomically records the event and
+// tells the caller whether it was new or a duplicate. The caller should skip
+// handler logic if already_processed=true.
+//
+// Retention: records older than 7 days are opportunistically pruned inside
+// this handler (~1% of successful inserts trigger a DELETE). Stripe retries
+// events for up to 72h, so 7 days gives a safe margin.
+func (s *Server) handleStripeEventProcessed(w http.ResponseWriter, r *http.Request) {
+	var input struct {
+		EventID     string `json:"event_id"`
+		CloudSecret string `json:"cloud_secret"`
+	}
+	if err := decodeJSON(r, &input); err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", "Invalid request body")
+		return
+	}
+
+	// 1. Validate cloud secret (body field for POST; handler matches the
+	//    existing /admin/stripe-customer-id pattern).
+	user := currentUser(r)
+	isAdmin := user != nil && user.Role == "admin"
+	if !isAdmin {
+		if !s.validateCloudSecret(input.CloudSecret, w) {
+			return
+		}
+	}
+
+	// 2. Validate input
+	if input.EventID == "" {
+		writeError(w, http.StatusBadRequest, "bad_request", "event_id is required")
+		return
+	}
+	if !strings.HasPrefix(input.EventID, "evt_") {
+		writeError(w, http.StatusBadRequest, "bad_request", "event_id must start with 'evt_'")
+		return
+	}
+
+	// 3. Atomically record-or-detect-duplicate
+	alreadyProcessed, err := s.store.MarkStripeEventProcessed(input.EventID)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+
+	// 4. Opportunistic pruning (1% of calls; keeps the table bounded without
+	//    a dedicated goroutine). Failures here are non-fatal — log and continue.
+	if store.ShouldPruneStripeEvents() {
+		go func(eventID string) {
+			// Run in background so we don't block the response. 7-day retention
+			// covers Stripe's 72h retry window with a generous safety margin.
+			removed, perr := s.store.PruneStripeProcessedEvents(7 * 24 * time.Hour)
+			if perr != nil {
+				slog.Warn("prune stripe_processed_events failed", "error", perr, "trigger_event_id", eventID)
+				return
+			}
+			if removed > 0 {
+				slog.Info("pruned stripe_processed_events", "removed", removed)
+			}
+		}(input.EventID)
+	}
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"event_id":          input.EventID,
+		"already_processed": alreadyProcessed,
 	})
 }
 

--- a/internal/server/middleware_ratelimit.go
+++ b/internal/server/middleware_ratelimit.go
@@ -236,7 +236,7 @@ func (s *Server) RateLimit(next http.Handler) http.Handler {
 		// Cloud admin endpoints (sidecar → pad): plan changes, Stripe mapping, user lookup
 		if strings.HasPrefix(path, "/api/v1/admin/") {
 			switch path {
-			case "/api/v1/admin/plan", "/api/v1/admin/stripe-customer-id", "/api/v1/admin/user-by-customer":
+			case "/api/v1/admin/plan", "/api/v1/admin/stripe-customer-id", "/api/v1/admin/user-by-customer", "/api/v1/admin/stripe-event-processed":
 				l := s.rateLimiters.CloudAdmin.getLimiter(ip)
 				if !l.Allow() {
 					slog.Warn("rate limited", "ip", ip, "path", path, "limiter", "cloud_admin")

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,11 +1,11 @@
 package server
 
 import (
+	"bytes"
 	"context"
 	"crypto/subtle"
 	"encoding/base64"
 	"encoding/json"
-	"bytes"
 	"fmt"
 	"io/fs"
 	"log/slog"
@@ -29,31 +29,31 @@ import (
 )
 
 type Server struct {
-	store         *store.Store
-	router        *chi.Mux
-	routerOnce    sync.Once            // ensures setupRouter runs once, after all config
-	httpServer    *http.Server         // underlying HTTP server (set during ListenAndServe)
-	webFS         fs.FS                // embedded web UI static files (optional)
-	events        events.EventBus       // real-time event bus (optional)
-	webhooks      *webhooks.Dispatcher // webhook dispatcher (optional)
-	email         *email.Sender        // transactional email sender (optional)
-	emailAPIKey   string               // Maileroo API key (used for unsubscribe HMAC)
-	rateLimiters  *RateLimiters        // per-endpoint rate limiters
-	baseURL       string               // public base URL for generating links (e.g. invite URLs)
-	corsOrigins   string               // comma-separated CORS origins (empty = localhost defaults)
-	secureCookies bool                 // set Secure flag on cookies (for TLS deployments)
-	metrics             *metrics.Metrics      // Prometheus metrics (optional)
-	metricsToken        string                // shared bearer token for /metrics scrapes ("" = loopback-only)
-	trustedProxyCIDRs   []*net.IPNet          // CIDRs allowed to set X-Forwarded-For (nil = proxy headers untrusted)
-	ipChangeEnforceStrict bool                // when true, reject sessions whose client IP differs from the one recorded at session creation
-	sseMaxConnections   int                   // global SSE connection limit (0 = unlimited)
-	sseMaxPerWorkspace  int                   // per-workspace SSE connection limit (0 = unlimited)
-	cloudMode           bool                 // true when running as Pad Cloud (PAD_CLOUD=true or PAD_MODE=cloud)
-	cloudSecrets        []string             // shared secrets for sidecar ↔ pad communication (supports rotation)
-	version            string               // release version (e.g. "dev", "1.2.3")
-	commit              string               // git commit hash
-	buildTime           string               // build timestamp
-	twoFAChallengeSecret []byte              // HMAC key for 2FA challenge tokens
+	store                 *store.Store
+	router                *chi.Mux
+	routerOnce            sync.Once            // ensures setupRouter runs once, after all config
+	httpServer            *http.Server         // underlying HTTP server (set during ListenAndServe)
+	webFS                 fs.FS                // embedded web UI static files (optional)
+	events                events.EventBus      // real-time event bus (optional)
+	webhooks              *webhooks.Dispatcher // webhook dispatcher (optional)
+	email                 *email.Sender        // transactional email sender (optional)
+	emailAPIKey           string               // Maileroo API key (used for unsubscribe HMAC)
+	rateLimiters          *RateLimiters        // per-endpoint rate limiters
+	baseURL               string               // public base URL for generating links (e.g. invite URLs)
+	corsOrigins           string               // comma-separated CORS origins (empty = localhost defaults)
+	secureCookies         bool                 // set Secure flag on cookies (for TLS deployments)
+	metrics               *metrics.Metrics     // Prometheus metrics (optional)
+	metricsToken          string               // shared bearer token for /metrics scrapes ("" = loopback-only)
+	trustedProxyCIDRs     []*net.IPNet         // CIDRs allowed to set X-Forwarded-For (nil = proxy headers untrusted)
+	ipChangeEnforceStrict bool                 // when true, reject sessions whose client IP differs from the one recorded at session creation
+	sseMaxConnections     int                  // global SSE connection limit (0 = unlimited)
+	sseMaxPerWorkspace    int                  // per-workspace SSE connection limit (0 = unlimited)
+	cloudMode             bool                 // true when running as Pad Cloud (PAD_CLOUD=true or PAD_MODE=cloud)
+	cloudSecrets          []string             // shared secrets for sidecar ↔ pad communication (supports rotation)
+	version               string               // release version (e.g. "dev", "1.2.3")
+	commit                string               // git commit hash
+	buildTime             string               // build timestamp
+	twoFAChallengeSecret  []byte               // HMAC key for 2FA challenge tokens
 }
 
 func New(s *store.Store) *Server {
@@ -350,284 +350,285 @@ func (s *Server) setupRouter() {
 
 		// API routes
 		r.Route("/api/v1", func(r chi.Router) {
-		r.Get("/health", s.handleHealth)
-		r.Get("/health/live", s.handleHealthLive)
-		r.Get("/health/ready", s.handleHealthReady)
-		r.Get("/plan-limits", s.handleGetPlanLimits) // Public: billing page reads plan limits
-		r.Get("/unsubscribe", s.handleUnsubscribe)   // Public: email opt-out (HMAC-signed)
+			r.Get("/health", s.handleHealth)
+			r.Get("/health/live", s.handleHealthLive)
+			r.Get("/health/ready", s.handleHealthReady)
+			r.Get("/plan-limits", s.handleGetPlanLimits) // Public: billing page reads plan limits
+			r.Get("/unsubscribe", s.handleUnsubscribe)   // Public: email opt-out (HMAC-signed)
 
-		// Auth endpoints (exempt from auth middleware)
-		r.Route("/auth", func(r chi.Router) {
-			r.Get("/session", s.handleSessionCheck)
-			r.Post("/bootstrap", s.handleBootstrap)
-			r.Post("/register", s.handleRegister)
-			r.Get("/check-username", s.handleCheckUsername)
-			r.Post("/login", s.handleLogin)
-			r.Post("/logout", s.handleLogout)
-			r.Get("/me", s.handleGetCurrentUser)
-			r.Patch("/me", s.handleUpdateCurrentUser)
+			// Auth endpoints (exempt from auth middleware)
+			r.Route("/auth", func(r chi.Router) {
+				r.Get("/session", s.handleSessionCheck)
+				r.Post("/bootstrap", s.handleBootstrap)
+				r.Post("/register", s.handleRegister)
+				r.Get("/check-username", s.handleCheckUsername)
+				r.Post("/login", s.handleLogin)
+				r.Post("/logout", s.handleLogout)
+				r.Get("/me", s.handleGetCurrentUser)
+				r.Patch("/me", s.handleUpdateCurrentUser)
 
-			// Password reset
-			r.Post("/forgot-password", s.handleForgotPassword)
-			r.Post("/reset-password", s.handleResetPassword)
+				// Password reset
+				r.Post("/forgot-password", s.handleForgotPassword)
+				r.Post("/reset-password", s.handleResetPassword)
 
-			// Two-factor authentication
-			r.Post("/2fa/setup", s.handleTOTPSetup)
-			r.Post("/2fa/verify", s.handleTOTPVerify)
-			r.Post("/2fa/disable", s.handleTOTPDisable)
-			r.Post("/2fa/login-verify", s.handleTOTPLoginVerify)
+				// Two-factor authentication
+				r.Post("/2fa/setup", s.handleTOTPSetup)
+				r.Post("/2fa/verify", s.handleTOTPVerify)
+				r.Post("/2fa/disable", s.handleTOTPDisable)
+				r.Post("/2fa/login-verify", s.handleTOTPLoginVerify)
 
-			// Account management (GDPR)
-			r.Post("/delete-account", s.handleDeleteAccount)
-			r.Get("/export", s.handleExportAccount)
+				// Account management (GDPR)
+				r.Post("/delete-account", s.handleDeleteAccount)
+				r.Get("/export", s.handleExportAccount)
 
-			// User-scoped API tokens
-			r.Get("/tokens", s.handleListUserTokens)
-			r.Post("/tokens", s.handleCreateUserToken)
-			r.Delete("/tokens/{tokenID}", s.handleDeleteUserToken)
-			r.Post("/tokens/{tokenID}/rotate", s.handleRotateUserToken)
+				// User-scoped API tokens
+				r.Get("/tokens", s.handleListUserTokens)
+				r.Post("/tokens", s.handleCreateUserToken)
+				r.Delete("/tokens/{tokenID}", s.handleDeleteUserToken)
+				r.Post("/tokens/{tokenID}/rotate", s.handleRotateUserToken)
 
-			// Cloud: OAuth login/linking (called by pad-cloud sidecar, protected by cloud secret)
-			r.Post("/oauth-login", s.handleOAuthLogin)
-			r.Post("/oauth-link", s.handleOAuthLink)
-			r.Post("/oauth-unlink", s.handleOAuthUnlink)
+				// Cloud: OAuth login/linking (called by pad-cloud sidecar, protected by cloud secret)
+				r.Post("/oauth-login", s.handleOAuthLogin)
+				r.Post("/oauth-link", s.handleOAuthLink)
+				r.Post("/oauth-unlink", s.handleOAuthUnlink)
 
-			// CLI browser-based auth flow
-			r.Post("/cli/sessions", s.handleCreateCLIAuthSession)
-			r.Get("/cli/sessions/{code}", s.handlePollCLIAuthSession)
-			r.Post("/cli/sessions/{code}/approve", s.handleApproveCLIAuthSession)
-		})
-
-		// Admin endpoints (admin-only, handlers check role internally)
-		r.Route("/admin", func(r chi.Router) {
-			r.Get("/settings", s.handleGetPlatformSettings)
-			r.Patch("/settings", s.handleUpdatePlatformSettings)
-			r.Post("/test-email", s.handleTestEmail)
-
-			// Cloud sidecar endpoints — only exist in cloud mode. requireCloudMode
-			// returns 404 outside cloud mode so a self-hosted deployment doesn't
-			// expose "Cloud mode not configured" to unauthenticated probes.
-			r.Group(func(r chi.Router) {
-				r.Use(s.requireCloudMode)
-				r.Post("/plan", s.handleSetPlan)                       // Cloud: sidecar sets user plans; also accessible to admins
-				r.Post("/stripe-customer-id", s.handleSetStripeCustomerID) // Cloud: sidecar stores Stripe customer ID after checkout
-				r.Get("/user-by-customer", s.handleGetUserByCustomerID)    // Cloud: sidecar looks up user by Stripe customer ID
+				// CLI browser-based auth flow
+				r.Post("/cli/sessions", s.handleCreateCLIAuthSession)
+				r.Get("/cli/sessions/{code}", s.handlePollCLIAuthSession)
+				r.Post("/cli/sessions/{code}/approve", s.handleApproveCLIAuthSession)
 			})
 
-			// User management
-			r.Get("/users", s.handleAdminListUsers)
-			r.Get("/users/{userID}", s.handleAdminGetUser)
-			r.Patch("/users/{userID}", s.handleAdminUpdateUser)
-			r.Post("/users/{userID}/reset-password", s.handleAdminResetPassword)
-			r.Get("/users/{userID}/workspaces", s.handleAdminGetUserWorkspaces)
-			r.Post("/users/{userID}/disable", s.handleAdminDisableUser)
-			r.Post("/users/{userID}/enable", s.handleAdminEnableUser)
+			// Admin endpoints (admin-only, handlers check role internally)
+			r.Route("/admin", func(r chi.Router) {
+				r.Get("/settings", s.handleGetPlatformSettings)
+				r.Patch("/settings", s.handleUpdatePlatformSettings)
+				r.Post("/test-email", s.handleTestEmail)
 
-			// Invitations
-			r.Get("/invitations", s.handleAdminListInvitations)
-			r.Post("/invitations/{invID}/resend", s.handleAdminResendInvitation)
-			r.Delete("/invitations/{invID}", s.handleAdminDeleteInvitation)
-
-			// Plan limits
-			r.Get("/limits", s.handleAdminGetLimits)
-			r.Patch("/limits", s.handleAdminUpdateLimits)
-
-			// Platform stats
-			r.Get("/stats", s.handleAdminStats)
-		})
-
-		// Audit log (admin-only)
-		r.Get("/audit-log", s.handleAuditLog)
-
-		// Templates
-		r.Get("/templates", s.handleListTemplates)
-
-		// Convention Library
-		r.Get("/convention-library", s.handleConventionLibrary)
-
-		// Playbook Library
-		r.Get("/playbook-library", s.handlePlaybookLibrary)
-
-		// Invitations (outside workspace scope)
-		r.Post("/invitations/{code}/accept", s.handleAcceptInvitation)
-
-		// Share link resolution (outside workspace scope, no auth required)
-		r.Get("/s/{token}", s.handleResolveShareLink)
-
-		// Workspaces
-		r.Route("/workspaces", func(r chi.Router) {
-			r.Get("/", s.handleListWorkspaces)
-			r.Post("/", s.handleCreateWorkspace)
-			r.Post("/import", s.handleImportWorkspace)
-			r.Put("/reorder", s.handleReorderWorkspaces)
-
-			r.Route("/{slug}", func(r chi.Router) {
-				r.Use(s.RequireWorkspaceAccess)
-
-				r.Get("/", s.handleGetWorkspace)
-				r.Patch("/", s.handleUpdateWorkspace)
-				r.Delete("/", s.handleDeleteWorkspace)
-				r.Get("/export", s.handleExportWorkspace)
-
-				// Activity (workspace level)
-				r.Get("/activity", s.handleListWorkspaceActivity)
-
-				// Documents (v1 — will be replaced by items in Phase 2)
-				r.Route("/documents", func(r chi.Router) {
-					r.Get("/", s.handleListDocuments)
-					r.Post("/", s.handleCreateDocument)
-
-					r.Route("/{docID}", func(r chi.Router) {
-						r.Get("/", s.handleGetDocument)
-						r.Patch("/", s.handleUpdateDocument)
-						r.Delete("/", s.handleDeleteDocument)
-						r.Post("/restore", s.handleRestoreDocument)
-
-						// Versions
-						r.Get("/versions", s.handleListVersions)
-						r.Get("/versions/{versionID}", s.handleGetVersion)
-
-						// Activity (document level)
-						r.Get("/activity", s.handleListDocumentActivity)
-					})
+				// Cloud sidecar endpoints — only exist in cloud mode. requireCloudMode
+				// returns 404 outside cloud mode so a self-hosted deployment doesn't
+				// expose "Cloud mode not configured" to unauthenticated probes.
+				r.Group(func(r chi.Router) {
+					r.Use(s.requireCloudMode)
+					r.Post("/plan", s.handleSetPlan)                                // Cloud: sidecar sets user plans; also accessible to admins
+					r.Post("/stripe-customer-id", s.handleSetStripeCustomerID)      // Cloud: sidecar stores Stripe customer ID after checkout
+					r.Get("/user-by-customer", s.handleGetUserByCustomerID)         // Cloud: sidecar looks up user by Stripe customer ID
+					r.Post("/stripe-event-processed", s.handleStripeEventProcessed) // Cloud: sidecar webhook idempotency (TASK-696)
 				})
 
-				// Collections (v2)
-				r.Route("/collections", func(r chi.Router) {
-					r.Get("/", s.handleListCollections)
-					r.Post("/", s.handleCreateCollection)
-					r.Route("/{collSlug}", func(r chi.Router) {
-						r.Get("/", s.handleGetCollection)
-						r.Patch("/", s.handleUpdateCollection)
-						r.Delete("/", s.handleDeleteCollection)
-						// Items within collection
-						r.Get("/items", s.handleListCollectionItems)
-						r.Post("/items", s.handleCreateItem)
-						// Collection grants
-						r.Get("/grants", s.handleListCollectionGrants)
-						r.Post("/grants", s.handleCreateCollectionGrant)
-						r.Delete("/grants/{grantID}", s.handleDeleteCollectionGrant)
-						r.Get("/share-links", s.handleListCollectionShareLinks)
-						r.Post("/share-links", s.handleCreateCollectionShareLink)
-						// Saved views within collection
-						r.Get("/views", s.handleListViews)
-						r.Post("/views", s.handleCreateView)
-						r.Route("/views/{viewID}", func(r chi.Router) {
-							r.Patch("/", s.handleUpdateView)
-							r.Delete("/", s.handleDeleteView)
+				// User management
+				r.Get("/users", s.handleAdminListUsers)
+				r.Get("/users/{userID}", s.handleAdminGetUser)
+				r.Patch("/users/{userID}", s.handleAdminUpdateUser)
+				r.Post("/users/{userID}/reset-password", s.handleAdminResetPassword)
+				r.Get("/users/{userID}/workspaces", s.handleAdminGetUserWorkspaces)
+				r.Post("/users/{userID}/disable", s.handleAdminDisableUser)
+				r.Post("/users/{userID}/enable", s.handleAdminEnableUser)
+
+				// Invitations
+				r.Get("/invitations", s.handleAdminListInvitations)
+				r.Post("/invitations/{invID}/resend", s.handleAdminResendInvitation)
+				r.Delete("/invitations/{invID}", s.handleAdminDeleteInvitation)
+
+				// Plan limits
+				r.Get("/limits", s.handleAdminGetLimits)
+				r.Patch("/limits", s.handleAdminUpdateLimits)
+
+				// Platform stats
+				r.Get("/stats", s.handleAdminStats)
+			})
+
+			// Audit log (admin-only)
+			r.Get("/audit-log", s.handleAuditLog)
+
+			// Templates
+			r.Get("/templates", s.handleListTemplates)
+
+			// Convention Library
+			r.Get("/convention-library", s.handleConventionLibrary)
+
+			// Playbook Library
+			r.Get("/playbook-library", s.handlePlaybookLibrary)
+
+			// Invitations (outside workspace scope)
+			r.Post("/invitations/{code}/accept", s.handleAcceptInvitation)
+
+			// Share link resolution (outside workspace scope, no auth required)
+			r.Get("/s/{token}", s.handleResolveShareLink)
+
+			// Workspaces
+			r.Route("/workspaces", func(r chi.Router) {
+				r.Get("/", s.handleListWorkspaces)
+				r.Post("/", s.handleCreateWorkspace)
+				r.Post("/import", s.handleImportWorkspace)
+				r.Put("/reorder", s.handleReorderWorkspaces)
+
+				r.Route("/{slug}", func(r chi.Router) {
+					r.Use(s.RequireWorkspaceAccess)
+
+					r.Get("/", s.handleGetWorkspace)
+					r.Patch("/", s.handleUpdateWorkspace)
+					r.Delete("/", s.handleDeleteWorkspace)
+					r.Get("/export", s.handleExportWorkspace)
+
+					// Activity (workspace level)
+					r.Get("/activity", s.handleListWorkspaceActivity)
+
+					// Documents (v1 — will be replaced by items in Phase 2)
+					r.Route("/documents", func(r chi.Router) {
+						r.Get("/", s.handleListDocuments)
+						r.Post("/", s.handleCreateDocument)
+
+						r.Route("/{docID}", func(r chi.Router) {
+							r.Get("/", s.handleGetDocument)
+							r.Patch("/", s.handleUpdateDocument)
+							r.Delete("/", s.handleDeleteDocument)
+							r.Post("/restore", s.handleRestoreDocument)
+
+							// Versions
+							r.Get("/versions", s.handleListVersions)
+							r.Get("/versions/{versionID}", s.handleGetVersion)
+
+							// Activity (document level)
+							r.Get("/activity", s.handleListDocumentActivity)
 						})
 					})
-				})
 
-				// Plans progress
-				r.Get("/plans-progress", s.handlePlansProgress)
-
-				// User grants (all grants for a specific user in this workspace)
-				r.Get("/users/{userID}/grants", s.handleListUserGrants)
-
-				// Starred items
-				r.Get("/starred", s.handleListStarredItems)
-
-				// Items (cross-collection, v2)
-				r.Get("/items", s.handleListItems)
-				r.Route("/items/{itemSlug}", func(r chi.Router) {
-					r.Get("/", s.handleGetItem)
-					r.Patch("/", s.handleUpdateItem)
-					r.Delete("/", s.handleDeleteItem)
-					r.Post("/restore", s.handleRestoreItem)
-					r.Post("/move", s.handleMoveItem)
-					r.Get("/versions", s.handleListItemVersions)
-					r.Post("/versions/{versionID}/restore", s.handleRestoreItemVersion)
-					r.Get("/activity", s.handleListItemActivity)
-					r.Get("/links", s.handleGetItemLinks)
-					r.Post("/links", s.handleCreateItemLink)
-					r.Get("/comments", s.handleListComments)
-					r.Post("/comments", s.handleCreateComment)
-					r.Get("/timeline", s.handleListItemTimeline)
-					r.Get("/children", s.handleGetItemChildren)
-					r.Get("/progress", s.handleGetItemProgress)
-					r.Get("/tasks", s.handleGetItemChildren) // deprecated alias
-					r.Get("/grants", s.handleListItemGrants)
-					r.Post("/grants", s.handleCreateItemGrant)
-					r.Delete("/grants/{grantID}", s.handleDeleteItemGrant)
-					r.Get("/share-links", s.handleListItemShareLinks)
-					r.Post("/share-links", s.handleCreateItemShareLink)
-					// Stars
-					r.Get("/star", s.handleGetItemStarStatus)
-					r.Post("/star", s.handleStarItem)
-					r.Delete("/star", s.handleUnstarItem)
-				})
-
-				// Links (v2)
-				r.Delete("/links/{linkID}", s.handleDeleteItemLink)
-
-				// Share links (workspace-scoped management)
-				r.Delete("/share-links/{linkID}", s.handleDeleteShareLink)
-				r.Get("/share-links/{linkID}/views", s.handleShareLinkViews)
-
-				// Comments (v2)
-				r.Route("/comments/{commentID}", func(r chi.Router) {
-					r.Delete("/", s.handleDeleteComment)
-					r.Post("/replies", s.handleCreateReply)
-					r.Post("/reactions", s.handleAddReaction)
-					r.Delete("/reactions/{emoji}", s.handleRemoveReaction)
-				})
-
-				// Role Board (cross-collection role-based view)
-				r.Get("/roles/board", s.handleRoleBoard)
-				r.Put("/roles/board/reorder", s.handleRoleBoardReorder)
-				r.Put("/roles/board/lane-order", s.handleRoleBoardLaneReorder)
-
-				// Agent Roles
-				r.Route("/agent-roles", func(r chi.Router) {
-					r.Get("/", s.handleListAgentRoles)
-					r.Post("/", s.handleCreateAgentRole)
-					r.Route("/{roleID}", func(r chi.Router) {
-						r.Get("/", s.handleGetAgentRole)
-						r.Patch("/", s.handleUpdateAgentRole)
-						r.Delete("/", s.handleDeleteAgentRole)
+					// Collections (v2)
+					r.Route("/collections", func(r chi.Router) {
+						r.Get("/", s.handleListCollections)
+						r.Post("/", s.handleCreateCollection)
+						r.Route("/{collSlug}", func(r chi.Router) {
+							r.Get("/", s.handleGetCollection)
+							r.Patch("/", s.handleUpdateCollection)
+							r.Delete("/", s.handleDeleteCollection)
+							// Items within collection
+							r.Get("/items", s.handleListCollectionItems)
+							r.Post("/items", s.handleCreateItem)
+							// Collection grants
+							r.Get("/grants", s.handleListCollectionGrants)
+							r.Post("/grants", s.handleCreateCollectionGrant)
+							r.Delete("/grants/{grantID}", s.handleDeleteCollectionGrant)
+							r.Get("/share-links", s.handleListCollectionShareLinks)
+							r.Post("/share-links", s.handleCreateCollectionShareLink)
+							// Saved views within collection
+							r.Get("/views", s.handleListViews)
+							r.Post("/views", s.handleCreateView)
+							r.Route("/views/{viewID}", func(r chi.Router) {
+								r.Patch("/", s.handleUpdateView)
+								r.Delete("/", s.handleDeleteView)
+							})
+						})
 					})
-				})
 
-				// Webhooks
-				r.Route("/webhooks", func(r chi.Router) {
-					r.Get("/", s.handleListWebhooks)
-					r.Post("/", s.handleCreateWebhook)
-					r.Route("/{webhookID}", func(r chi.Router) {
-						r.Delete("/", s.handleDeleteWebhook)
-						r.Post("/test", s.handleTestWebhook)
+					// Plans progress
+					r.Get("/plans-progress", s.handlePlansProgress)
+
+					// User grants (all grants for a specific user in this workspace)
+					r.Get("/users/{userID}/grants", s.handleListUserGrants)
+
+					// Starred items
+					r.Get("/starred", s.handleListStarredItems)
+
+					// Items (cross-collection, v2)
+					r.Get("/items", s.handleListItems)
+					r.Route("/items/{itemSlug}", func(r chi.Router) {
+						r.Get("/", s.handleGetItem)
+						r.Patch("/", s.handleUpdateItem)
+						r.Delete("/", s.handleDeleteItem)
+						r.Post("/restore", s.handleRestoreItem)
+						r.Post("/move", s.handleMoveItem)
+						r.Get("/versions", s.handleListItemVersions)
+						r.Post("/versions/{versionID}/restore", s.handleRestoreItemVersion)
+						r.Get("/activity", s.handleListItemActivity)
+						r.Get("/links", s.handleGetItemLinks)
+						r.Post("/links", s.handleCreateItemLink)
+						r.Get("/comments", s.handleListComments)
+						r.Post("/comments", s.handleCreateComment)
+						r.Get("/timeline", s.handleListItemTimeline)
+						r.Get("/children", s.handleGetItemChildren)
+						r.Get("/progress", s.handleGetItemProgress)
+						r.Get("/tasks", s.handleGetItemChildren) // deprecated alias
+						r.Get("/grants", s.handleListItemGrants)
+						r.Post("/grants", s.handleCreateItemGrant)
+						r.Delete("/grants/{grantID}", s.handleDeleteItemGrant)
+						r.Get("/share-links", s.handleListItemShareLinks)
+						r.Post("/share-links", s.handleCreateItemShareLink)
+						// Stars
+						r.Get("/star", s.handleGetItemStarStatus)
+						r.Post("/star", s.handleStarItem)
+						r.Delete("/star", s.handleUnstarItem)
 					})
+
+					// Links (v2)
+					r.Delete("/links/{linkID}", s.handleDeleteItemLink)
+
+					// Share links (workspace-scoped management)
+					r.Delete("/share-links/{linkID}", s.handleDeleteShareLink)
+					r.Get("/share-links/{linkID}/views", s.handleShareLinkViews)
+
+					// Comments (v2)
+					r.Route("/comments/{commentID}", func(r chi.Router) {
+						r.Delete("/", s.handleDeleteComment)
+						r.Post("/replies", s.handleCreateReply)
+						r.Post("/reactions", s.handleAddReaction)
+						r.Delete("/reactions/{emoji}", s.handleRemoveReaction)
+					})
+
+					// Role Board (cross-collection role-based view)
+					r.Get("/roles/board", s.handleRoleBoard)
+					r.Put("/roles/board/reorder", s.handleRoleBoardReorder)
+					r.Put("/roles/board/lane-order", s.handleRoleBoardLaneReorder)
+
+					// Agent Roles
+					r.Route("/agent-roles", func(r chi.Router) {
+						r.Get("/", s.handleListAgentRoles)
+						r.Post("/", s.handleCreateAgentRole)
+						r.Route("/{roleID}", func(r chi.Router) {
+							r.Get("/", s.handleGetAgentRole)
+							r.Patch("/", s.handleUpdateAgentRole)
+							r.Delete("/", s.handleDeleteAgentRole)
+						})
+					})
+
+					// Webhooks
+					r.Route("/webhooks", func(r chi.Router) {
+						r.Get("/", s.handleListWebhooks)
+						r.Post("/", s.handleCreateWebhook)
+						r.Route("/{webhookID}", func(r chi.Router) {
+							r.Delete("/", s.handleDeleteWebhook)
+							r.Post("/test", s.handleTestWebhook)
+						})
+					})
+
+					// API Tokens
+					r.Route("/tokens", func(r chi.Router) {
+						r.Get("/", s.handleListTokens)
+						r.Post("/", s.handleCreateToken)
+						r.Delete("/{tokenID}", s.handleDeleteToken)
+					})
+
+					// Members
+					r.Route("/members", func(r chi.Router) {
+						r.Get("/", s.handleListMembers)
+						r.Post("/invite", s.handleInviteMember)
+						r.Delete("/invitations/{invID}", s.handleCancelInvitation)
+						r.Delete("/{userID}", s.handleRemoveMember)
+						r.Patch("/{userID}", s.handleUpdateMemberRole)
+						r.Get("/{userID}/collection-access", s.handleGetMemberCollectionAccess)
+						r.Put("/{userID}/collection-access", s.handleSetMemberCollectionAccess)
+					})
+
+					// Dashboard (v2)
+					r.Get("/dashboard", s.handleGetDashboard)
+
+					// Incremental sync — returns items changed since a timestamp
+					r.Get("/changes", s.handleGetChanges)
 				})
-
-				// API Tokens
-				r.Route("/tokens", func(r chi.Router) {
-					r.Get("/", s.handleListTokens)
-					r.Post("/", s.handleCreateToken)
-					r.Delete("/{tokenID}", s.handleDeleteToken)
-				})
-
-				// Members
-				r.Route("/members", func(r chi.Router) {
-					r.Get("/", s.handleListMembers)
-					r.Post("/invite", s.handleInviteMember)
-					r.Delete("/invitations/{invID}", s.handleCancelInvitation)
-					r.Delete("/{userID}", s.handleRemoveMember)
-					r.Patch("/{userID}", s.handleUpdateMemberRole)
-					r.Get("/{userID}/collection-access", s.handleGetMemberCollectionAccess)
-					r.Put("/{userID}/collection-access", s.handleSetMemberCollectionAccess)
-				})
-
-				// Dashboard (v2)
-				r.Get("/dashboard", s.handleGetDashboard)
-
-				// Incremental sync — returns items changed since a timestamp
-				r.Get("/changes", s.handleGetChanges)
 			})
-		})
 
-		// Search
-		r.Get("/search", s.handleSearch)
-	})
+			// Search
+			r.Get("/search", s.handleSearch)
+		})
 	}) // end r.Group (full middleware stack)
 
 	s.router = r

--- a/internal/store/migrations/045_stripe_processed_events.sql
+++ b/internal/store/migrations/045_stripe_processed_events.sql
@@ -1,0 +1,12 @@
+-- Persist Stripe webhook idempotency across restarts (TASK-696).
+-- pad-cloud previously held processed event IDs in RAM, so a restart would
+-- re-process every webhook Stripe retries within its 72h window. The sidecar
+-- now calls POST /api/v1/admin/stripe-event-processed on pad; pad is the
+-- source of truth for whether an event ID has already been handled.
+CREATE TABLE IF NOT EXISTS stripe_processed_events (
+    event_id     TEXT PRIMARY KEY,
+    processed_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_stripe_processed_events_processed_at
+    ON stripe_processed_events(processed_at);

--- a/internal/store/pgmigrations/025_stripe_processed_events.sql
+++ b/internal/store/pgmigrations/025_stripe_processed_events.sql
@@ -1,0 +1,12 @@
+-- Persist Stripe webhook idempotency across restarts (TASK-696).
+-- pad-cloud previously held processed event IDs in RAM, so a restart would
+-- re-process every webhook Stripe retries within its 72h window. The sidecar
+-- now calls POST /api/v1/admin/stripe-event-processed on pad; pad is the
+-- source of truth for whether an event ID has already been handled.
+CREATE TABLE IF NOT EXISTS stripe_processed_events (
+    event_id     TEXT PRIMARY KEY,
+    processed_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_stripe_processed_events_processed_at
+    ON stripe_processed_events(processed_at);

--- a/internal/store/stripe_events.go
+++ b/internal/store/stripe_events.go
@@ -1,0 +1,79 @@
+package store
+
+import (
+	"crypto/rand"
+	"encoding/binary"
+	"fmt"
+	"time"
+)
+
+// MarkStripeEventProcessed records a Stripe webhook event ID in
+// stripe_processed_events if it hasn't been seen before. Returns true when the
+// event was ALREADY recorded (i.e. the caller is seeing a duplicate Stripe
+// retry and should skip re-processing). Returns false for first-time events
+// (caller should run its handler logic).
+//
+// Implementation uses INSERT ... ON CONFLICT DO NOTHING and inspects the
+// RowsAffected count: 1 means we inserted (new), 0 means the row was already
+// present (duplicate). Both cases are success — only real DB errors propagate.
+func (s *Store) MarkStripeEventProcessed(eventID string) (alreadyProcessed bool, err error) {
+	if eventID == "" {
+		return false, fmt.Errorf("mark stripe event: event_id is required")
+	}
+
+	res, err := s.db.Exec(
+		s.q(`INSERT INTO stripe_processed_events (event_id, processed_at) VALUES (?, ?) ON CONFLICT (event_id) DO NOTHING`),
+		eventID, now(),
+	)
+	if err != nil {
+		return false, fmt.Errorf("mark stripe event %s: %w", eventID, err)
+	}
+
+	n, err := res.RowsAffected()
+	if err != nil {
+		// Some drivers don't report RowsAffected reliably after ON CONFLICT;
+		// in that case we can't tell whether this was the first insert. Treat
+		// as "not already processed" and let the caller run its handler (the
+		// event handler itself is idempotent at the application level — e.g.
+		// set_plan is an UPSERT).
+		return false, nil
+	}
+
+	// 1 row affected = we inserted a new row = first-time event.
+	// 0 rows affected = ON CONFLICT DO NOTHING fired = duplicate.
+	return n == 0, nil
+}
+
+// PruneStripeProcessedEvents deletes stripe_processed_events rows older than
+// maxAge. Returns the number of rows removed. Intended to be called on a
+// schedule (or opportunistically — see MarkStripeEventProcessed callers);
+// Stripe retries events for up to 72h, so a 7-day retention gives a safe
+// buffer while keeping the table bounded.
+func (s *Store) PruneStripeProcessedEvents(maxAge time.Duration) (int64, error) {
+	cutoff := time.Now().UTC().Add(-maxAge).Format(time.RFC3339)
+	res, err := s.db.Exec(
+		s.q(`DELETE FROM stripe_processed_events WHERE processed_at < ?`),
+		cutoff,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("prune stripe_processed_events: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return 0, nil
+	}
+	return n, nil
+}
+
+// ShouldPruneStripeEvents returns true with a ~1% chance, using crypto/rand.
+// Used to opportunistically prune stripe_processed_events without a dedicated
+// background goroutine — every ~100 handler invocations triggers a DELETE of
+// expired rows, which is plenty frequent for low-volume webhook traffic.
+// Exposed for the handler that decides whether to fire a cleanup.
+func ShouldPruneStripeEvents() bool {
+	var b [2]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return false
+	}
+	return binary.BigEndian.Uint16(b[:])%100 == 0
+}


### PR DESCRIPTION
## Summary

Adds a new cloud-gated admin endpoint `POST /api/v1/admin/stripe-event-processed` that the pad-cloud sidecar uses to durably record Stripe webhook event IDs. Previously the sidecar held `processedEvents` in RAM, so a restart would re-process every event Stripe retried within its 72h window — the audit flagged this as **H2** in [[DOC-642]] Stream 3.

**Half 1 of PLAN-645 chunk 3** — pad side (this PR). The pad-cloud side (TASK-695, 696 client call, 702, 703) ships as a follow-up PR in `../pad-cloud` immediately after this merges.

## Design

Architectural option selected: **pad is the source of truth** for webhook idempotency. pad-cloud calls `padClient.CheckAndMarkEventProcessed(eventID)` before running handlers; pad atomically INSERTs-or-detects-duplicate and returns a boolean. Keeps the "pad owns the DB" invariant, no new deps in pad-cloud.

### Endpoint

```
POST /api/v1/admin/stripe-event-processed
Body: { "event_id": "evt_xxx", "cloud_secret": "..." }
  or header: X-Cloud-Secret: ...

→ 200 OK
  { "event_id": "evt_xxx", "already_processed": true|false }
```

- `already_processed=false` → first time, caller should run its handler
- `already_processed=true` → duplicate retry, caller should skip

Rejects requests with missing / non-`evt_` prefixed IDs (400).

### Schema

```sql
CREATE TABLE stripe_processed_events (
    event_id     TEXT PRIMARY KEY,
    processed_at TEXT NOT NULL
);
CREATE INDEX idx_stripe_processed_events_processed_at
    ON stripe_processed_events(processed_at);
```

Same DDL in `migrations/045` (SQLite) and `pgmigrations/025` (Postgres). `ON CONFLICT (event_id) DO NOTHING` works in both dialects (SQLite 3.24+, Postgres 9.5+).

### Atomicity

`MarkStripeEventProcessed` uses `INSERT ... ON CONFLICT DO NOTHING`. `RowsAffected()==1` → new insert; `==0` → duplicate. Codex CLI verified this pattern works on both `modernc.org/sqlite` and `pgx stdlib` in this repo.

### Retention

Opportunistic prune: `ShouldPruneStripeEvents` samples ~1% of handler invocations (via `crypto/rand`); on hit, fires a background goroutine that runs `DELETE WHERE processed_at < now() - 7d`. Covers Stripe's 72h retry window with plenty of margin. No dedicated cleanup goroutine → no lifecycle bookkeeping.

### Security

- Gate: the new path is in `cloudAdminPaths` so `X-Cloud-Secret` / body `cloud_secret` authenticates it — same pattern as existing `admin/plan` / `stripe-customer-id` / `user-by-customer` endpoints.
- CSRF: exempt by the same mechanism (secret-based auth is a distinct trust channel from cookie auth).
- Rate limit: added to the `CloudAdmin` rate-limit bucket in `middleware_ratelimit.go`.
- Self-host mode: returns 404 (enforced by `requireCloudMode`).

## Files

```
internal/store/migrations/045_stripe_processed_events.sql       (new, SQLite)
internal/store/pgmigrations/025_stripe_processed_events.sql     (new, Postgres)
internal/store/stripe_events.go                                  (new — 3 funcs)
internal/server/handlers_cloud.go                                (+90 LOC handler + cloudAdminPaths entry)
internal/server/server.go                                        (+1 route; gofmt fixed struct alignment)
internal/server/middleware_ratelimit.go                          (+1 path in switch)
internal/server/cloud_admin_gate_test.go                         (+3 test cases)
```

## Test plan

- [x] `go build ./...` — clean
- [x] `gofmt -l` — clean (on changed files)
- [x] `go vet ./...` — clean
- [x] `go test ./...` — full suite passes
- [x] New tests:
  - `TestStripeEventProcessed_RecordsAndDetectsDuplicates` — end-to-end: first POST returns `already_processed:false`, second returns `true`
  - `TestStripeEventProcessed_ValidatesEventIDPrefix` — rejects empty / wrong-prefix event IDs
  - Existing `TestCloudAdminGate_SelfHost_Returns404` extended to cover the new path
- [x] Codex CLI review — **CLEAN** first pass (verified driver behavior, migration compat, rate-limit wiring, test coverage, security posture)

## Follow-up

Once this merges, the pad-cloud PR will:
- Replace `processedEvents map` + mutex + cleanup goroutine in `stripe.go` with a `padClient.CheckAndMarkEventProcessed` call
- Ship alongside the other 3 chunk-3 tasks (TASK-695 / 702 / 703) in a single pad-cloud PR