### PR TITLE
feat(billing): cancel Stripe customer on account delete (TASK-690)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,7 +32,22 @@ PAD_ENCRYPTION_KEY=
 # REDIS_PASSWORD=
 
 # OPTIONAL — Pad Cloud sidecar shared secret (cloud mode only).
+# Comma-separated list supports rotation for INBOUND calls: pad accepts
+# any listed secret when pad-cloud calls pad's admin endpoints.
 # PAD_CLOUD_SECRET=
+
+# OPTIONAL — Base URL pad uses to call pad-cloud back (reverse direction,
+# e.g. Stripe cancel-customer when a user deletes their account). Required
+# in cloud mode to cascade account deletion through to Stripe billing;
+# without it, pad deletes local rows but never cancels the subscription.
+# PAD_CLOUD_SIDECAR_URL=http://pad-cloud:7778
+
+# OPTIONAL — Exact outbound secret pad sends on reverse calls. Use this
+# during a cloud-secret rotation when pad-cloud is still validating against
+# the OLD value: pin the outbound here so the reverse call matches, then
+# roll pad-cloud, then unpin. When unset, pad falls back to the LAST entry
+# of PAD_CLOUD_SECRET (the older rotation value).
+# PAD_CLOUD_OUTBOUND_SECRET=
 
 # OPTIONAL — Encryption key for sensitive fields (32-byte hex string).
 # If unset, Pad stores 2FA seeds in plaintext — set this for production.

--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/xarmian/pad/internal/config"
 	"regexp"
 
+	"github.com/xarmian/pad/internal/billing"
 	"github.com/xarmian/pad/internal/email"
 	"github.com/redis/go-redis/v9"
 	"github.com/xarmian/pad/internal/events"
@@ -285,6 +286,27 @@ func serveCmd() *cobra.Command {
 				}
 				srv.SetCloudMode(cfg.CloudSecret)
 				slog.Info("Cloud mode enabled")
+
+				// Reverse pad → pad-cloud client (TASK-690). Used by
+				// handleDeleteAccount to cancel Stripe subscriptions + delete
+				// the Stripe customer before the local user row is purged.
+				// When PAD_CLOUD_SIDECAR_URL is unset we leave the sidecar
+				// hook nil — a cloud deploy without Stripe billing is
+				// unusual but valid (e.g. a staging instance), and in that
+				// case there's no upstream state to cancel. The sidecar is
+				// wired with the NEWEST of the rotation-capable CloudSecret
+				// list so a cut-over during rollover matches whatever pad-
+				// cloud is currently validating inbound calls against.
+				if cfg.CloudSidecarURL != "" {
+					primarySecret := strings.TrimSpace(strings.SplitN(cfg.CloudSecret, ",", 2)[0])
+					if primarySecret == "" {
+						return fmt.Errorf("PAD_CLOUD_SECRET has no non-empty key for PAD_CLOUD_SIDECAR_URL")
+					}
+					srv.SetCloudSidecar(billing.NewCloudClient(cfg.CloudSidecarURL, primarySecret))
+					slog.Info("Reverse pad-cloud sidecar wired", "url", cfg.CloudSidecarURL)
+				} else {
+					slog.Warn("PAD_CLOUD_SIDECAR_URL not set — account delete will NOT cancel Stripe subscriptions. Set this env var to cascade deletes.")
+				}
 
 				// Seed default plan limits (idempotent — won't overwrite admin changes)
 				if err := s.SeedPlanLimits(); err != nil {

--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -314,22 +314,17 @@ func serveCmd() *cobra.Command {
 				//      rollover completes and CloudSecret collapses to a
 				//      single value, first == last so it's still correct.
 				if cfg.CloudSidecarURL != "" {
-					outboundSecret := strings.TrimSpace(cfg.CloudOutboundSecret)
-					if outboundSecret == "" {
-						parts := strings.Split(cfg.CloudSecret, ",")
-						for i := len(parts) - 1; i >= 0; i-- {
-							if s := strings.TrimSpace(parts[i]); s != "" {
-								outboundSecret = s
-								break
-							}
-						}
-					}
+					outboundSecret := billing.ResolveOutboundSecret(cfg.CloudOutboundSecret, cfg.CloudSecret)
 					if outboundSecret == "" {
 						return fmt.Errorf("PAD_CLOUD_SIDECAR_URL is set but neither PAD_CLOUD_OUTBOUND_SECRET nor PAD_CLOUD_SECRET supplies a usable outbound secret")
 					}
 					srv.SetCloudSidecar(billing.NewCloudClient(cfg.CloudSidecarURL, outboundSecret))
+					outboundSource := "PAD_CLOUD_SECRET[last]"
+					if strings.TrimSpace(cfg.CloudOutboundSecret) != "" {
+						outboundSource = "PAD_CLOUD_OUTBOUND_SECRET"
+					}
 					slog.Info("Reverse pad-cloud sidecar wired", "url", cfg.CloudSidecarURL,
-						"outbound_source", map[bool]string{true: "PAD_CLOUD_OUTBOUND_SECRET", false: "PAD_CLOUD_SECRET[last]"}[strings.TrimSpace(cfg.CloudOutboundSecret) != ""])
+						"outbound_source", outboundSource)
 				} else {
 					slog.Warn("PAD_CLOUD_SIDECAR_URL not set — account delete will NOT cancel Stripe subscriptions. Set this env var to cascade deletes.")
 				}

--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -293,17 +293,43 @@ func serveCmd() *cobra.Command {
 				// When PAD_CLOUD_SIDECAR_URL is unset we leave the sidecar
 				// hook nil — a cloud deploy without Stripe billing is
 				// unusual but valid (e.g. a staging instance), and in that
-				// case there's no upstream state to cancel. The sidecar is
-				// wired with the NEWEST of the rotation-capable CloudSecret
-				// list so a cut-over during rollover matches whatever pad-
-				// cloud is currently validating inbound calls against.
+				// case there's no upstream state to cancel.
+				//
+				// Outbound secret selection:
+				// pad-cloud validates inbound calls against a SINGLE secret
+				// (no rotation parsing on its side). During a rotation,
+				// operators roll pad first (so pad accepts both "new" and
+				// "old" inbound), then roll pad-cloud to the new key. Until
+				// pad-cloud has been rolled, it is still validating against
+				// the OLD secret — so the reverse call must send that old
+				// secret, not the new one.
+				//
+				// Resolution order:
+				//   1. PAD_CLOUD_OUTBOUND_SECRET explicitly set → use as-is.
+				//      Correct for any rotation state when ops pin it.
+				//   2. Fall back to the LAST entry of PAD_CLOUD_SECRET (the
+				//      older rotation value). This assumes the "new,old"
+				//      convention during rollover and gracefully tracks the
+				//      pad-cloud side without a separate env var. After
+				//      rollover completes and CloudSecret collapses to a
+				//      single value, first == last so it's still correct.
 				if cfg.CloudSidecarURL != "" {
-					primarySecret := strings.TrimSpace(strings.SplitN(cfg.CloudSecret, ",", 2)[0])
-					if primarySecret == "" {
-						return fmt.Errorf("PAD_CLOUD_SECRET has no non-empty key for PAD_CLOUD_SIDECAR_URL")
+					outboundSecret := strings.TrimSpace(cfg.CloudOutboundSecret)
+					if outboundSecret == "" {
+						parts := strings.Split(cfg.CloudSecret, ",")
+						for i := len(parts) - 1; i >= 0; i-- {
+							if s := strings.TrimSpace(parts[i]); s != "" {
+								outboundSecret = s
+								break
+							}
+						}
 					}
-					srv.SetCloudSidecar(billing.NewCloudClient(cfg.CloudSidecarURL, primarySecret))
-					slog.Info("Reverse pad-cloud sidecar wired", "url", cfg.CloudSidecarURL)
+					if outboundSecret == "" {
+						return fmt.Errorf("PAD_CLOUD_SIDECAR_URL is set but neither PAD_CLOUD_OUTBOUND_SECRET nor PAD_CLOUD_SECRET supplies a usable outbound secret")
+					}
+					srv.SetCloudSidecar(billing.NewCloudClient(cfg.CloudSidecarURL, outboundSecret))
+					slog.Info("Reverse pad-cloud sidecar wired", "url", cfg.CloudSidecarURL,
+						"outbound_source", map[bool]string{true: "PAD_CLOUD_OUTBOUND_SECRET", false: "PAD_CLOUD_SECRET[last]"}[strings.TrimSpace(cfg.CloudOutboundSecret) != ""])
 				} else {
 					slog.Warn("PAD_CLOUD_SIDECAR_URL not set — account delete will NOT cancel Stripe subscriptions. Set this env var to cascade deletes.")
 				}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,14 @@ services:
       PAD_REDIS_URL: "redis://redis:6379"
       PAD_DATA_DIR: "/data"
       PAD_LOG_LEVEL: "info"
+      # Cloud-mode wiring (set when co-deploying with pad-cloud). In cloud
+      # mode, pad needs to call pad-cloud back to cancel Stripe
+      # subscriptions when a user deletes their account (TASK-690).
+      # Uncomment + point at your sidecar, OR set these vars in .env.
+      # PAD_CLOUD: "true"
+      # PAD_CLOUD_SECRET: "${PAD_CLOUD_SECRET:-}"
+      # PAD_CLOUD_SIDECAR_URL: "${PAD_CLOUD_SIDECAR_URL:-}"
+      # PAD_CLOUD_OUTBOUND_SECRET: "${PAD_CLOUD_OUTBOUND_SECRET:-}"
     volumes:
       - pad-data:/data
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,14 +37,15 @@ services:
       PAD_REDIS_URL: "redis://redis:6379"
       PAD_DATA_DIR: "/data"
       PAD_LOG_LEVEL: "info"
-      # Cloud-mode wiring (set when co-deploying with pad-cloud). In cloud
-      # mode, pad needs to call pad-cloud back to cancel Stripe
-      # subscriptions when a user deletes their account (TASK-690).
-      # Uncomment + point at your sidecar, OR set these vars in .env.
-      # PAD_CLOUD: "true"
-      # PAD_CLOUD_SECRET: "${PAD_CLOUD_SECRET:-}"
-      # PAD_CLOUD_SIDECAR_URL: "${PAD_CLOUD_SIDECAR_URL:-}"
-      # PAD_CLOUD_OUTBOUND_SECRET: "${PAD_CLOUD_OUTBOUND_SECRET:-}"
+      # Cloud-mode wiring — safe to keep enabled on self-host deploys
+      # because every var defaults to empty and pad treats empty as
+      # "not in cloud mode". Populate from .env when co-deploying with
+      # pad-cloud so the reverse sidecar can cascade Stripe cancels on
+      # account delete (TASK-690).
+      PAD_CLOUD: "${PAD_CLOUD:-}"
+      PAD_CLOUD_SECRET: "${PAD_CLOUD_SECRET:-}"
+      PAD_CLOUD_SIDECAR_URL: "${PAD_CLOUD_SIDECAR_URL:-}"
+      PAD_CLOUD_OUTBOUND_SECRET: "${PAD_CLOUD_OUTBOUND_SECRET:-}"
     volumes:
       - pad-data:/data
     depends_on:

--- a/internal/billing/cloud_client.go
+++ b/internal/billing/cloud_client.go
@@ -1,0 +1,150 @@
+// Package billing holds the reverse pad → pad-cloud client used to cascade
+// billing operations (e.g. Stripe subscription cancel) from the pad binary
+// out to the pad-cloud sidecar during account deletion. Kept in its own
+// package so the server package stays free of Stripe / HTTP-client
+// dependencies, and so tests can inject a fake via the server.CloudSidecar
+// interface.
+package billing
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// defaultTimeout bounds each request. 15s is deliberately longer than the
+// pad-cloud 10s Stripe client timeout so a genuine upstream cancel that
+// gets close to its own cap still returns to pad instead of being cut off
+// locally — but short enough that a wedged sidecar doesn't block the
+// account-delete handler (which also holds an open HTTP request to the
+// end user) for more than a few seconds.
+const defaultTimeout = 15 * time.Second
+
+// maxResponseBody caps the size of the response body we will read when
+// decoding pad-cloud's error shape. pad-cloud's cancel-customer endpoint
+// returns tiny JSON objects; anything larger is almost certainly a misrouted
+// HTML error page from a proxy, and we don't want to allocate MB of it.
+const maxResponseBody = 64 * 1024
+
+// CloudClient calls the pad-cloud sidecar over HTTP. Stateless — safe to
+// share across goroutines; the underlying http.Client has its own pool.
+type CloudClient struct {
+	baseURL     string
+	cloudSecret string
+	http        *http.Client
+}
+
+// NewCloudClient constructs a client pointed at the given pad-cloud base URL
+// (e.g. "http://pad-cloud:7778") authenticated with cloudSecret. Both values
+// must be non-empty — callers that can't provide them should skip wiring
+// the client into the server rather than passing blanks, which would turn
+// into silent 403s at request time.
+func NewCloudClient(baseURL, cloudSecret string) *CloudClient {
+	return &CloudClient{
+		baseURL:     strings.TrimRight(baseURL, "/"),
+		cloudSecret: cloudSecret,
+		http: &http.Client{
+			Timeout: defaultTimeout,
+		},
+	}
+}
+
+// SidecarError carries the structured details pad-cloud returns on a non-2xx
+// response. Callers use errors.As with a *SidecarError target to decide
+// between "retry transport/server failure" (Status >= 500) and "upstream
+// state is already inconsistent, log and continue" (Status in [400,500)).
+type SidecarError struct {
+	// Status is the HTTP status pad-cloud returned (e.g. 400, 403, 500).
+	Status int
+	// Body is the raw response body for log diagnostics only. Do not surface
+	// this to end users — the sidecar's errors are internal and may leak
+	// infra detail.
+	Body string
+}
+
+func (e *SidecarError) Error() string {
+	return fmt.Sprintf("pad-cloud sidecar returned %d: %s", e.Status, e.Body)
+}
+
+// IsClientError reports whether the error is a 4xx from pad-cloud (as
+// opposed to a transport failure or a 5xx). handleDeleteAccount uses this
+// to distinguish "sidecar says the customer is already gone / malformed,
+// safe to proceed with local delete" from "sidecar is sick, abort".
+func IsClientError(err error) bool {
+	var se *SidecarError
+	if errors.As(err, &se) {
+		return se.Status >= 400 && se.Status < 500
+	}
+	return false
+}
+
+// CancelCustomer asks pad-cloud to cancel every active Stripe subscription
+// for customerID and then delete the Stripe customer object. Idempotent at
+// the pad-cloud side (it treats a 404/resource_missing from Stripe as
+// success), so retries after a partial failure complete cleanly.
+//
+// Request: POST {baseURL}/billing/cancel-customer
+// Body:    {"customer_id": "cus_xxx", "cloud_secret": "..."}
+// 200 OK:  {"ok": true, "subscriptions_cancelled": N}
+//
+// Returns nil on 200. On any non-200, returns a *SidecarError so the caller
+// can branch on Status. On transport failure (DNS, connect, timeout) returns
+// a bare error — treated by callers as "retryable, abort the delete".
+func (c *CloudClient) CancelCustomer(customerID string) error {
+	if c == nil {
+		return errors.New("billing: CancelCustomer called on nil CloudClient")
+	}
+	if customerID == "" {
+		// Defensive — handleDeleteAccount is expected to skip the call when
+		// StripeCustomerID is empty, but if somebody wires it differently
+		// we refuse to POST an empty cus_ that would burn a sidecar call
+		// and log-spam the 400 it would return.
+		return errors.New("billing: customerID is empty")
+	}
+	if c.baseURL == "" || c.cloudSecret == "" {
+		return errors.New("billing: CloudClient is not configured (missing baseURL or cloudSecret)")
+	}
+
+	payload, err := json.Marshal(map[string]string{
+		"customer_id":  customerID,
+		"cloud_secret": c.cloudSecret,
+	})
+	if err != nil {
+		return fmt.Errorf("billing: marshal cancel-customer request: %w", err)
+	}
+
+	req, err := http.NewRequest(http.MethodPost,
+		c.baseURL+"/billing/cancel-customer",
+		bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("billing: build cancel-customer request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		// Transport-level failure — DNS, connect refused, TLS, timeout. Caller
+		// must abort the delete so a retry can try again with state intact.
+		return fmt.Errorf("billing: cancel-customer request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusOK {
+		// We don't need the body — the happy-path envelope is advisory.
+		// Drain-and-discard so the connection returns to the pool; the
+		// limit keeps a broken sidecar from streaming us into memory pressure.
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, maxResponseBody))
+		return nil
+	}
+
+	bodyBytes, _ := io.ReadAll(io.LimitReader(resp.Body, maxResponseBody))
+	return &SidecarError{
+		Status: resp.StatusCode,
+		Body:   string(bodyBytes),
+	}
+}

--- a/internal/billing/cloud_client.go
+++ b/internal/billing/cloud_client.go
@@ -31,6 +31,35 @@ const defaultTimeout = 15 * time.Second
 // HTML error page from a proxy, and we don't want to allocate MB of it.
 const maxResponseBody = 64 * 1024
 
+// ResolveOutboundSecret picks the secret to send on pad → pad-cloud calls
+// given the inbound rotation list and an optional explicit override. Pulled
+// out of main.go so the rotation-sensitive logic can be exercised directly
+// by unit tests.
+//
+//   - explicit takes precedence when non-empty: operators pin this to the
+//     exact value pad-cloud is currently validating against.
+//   - Otherwise, scan the comma-separated inboundList from RIGHT to LEFT
+//     and return the first non-empty entry. The older value is on the
+//     right in the conventional "new,old" layout — so during a rotation
+//     where pad-cloud is still running "old", pad's outbound call still
+//     matches.
+//   - Returns "" when neither source supplies a usable value. Callers
+//     should treat that as a hard startup error — a misconfigured sidecar
+//     URL is worse than no sidecar (every delete would 500 instead of
+//     silently skipping cancel).
+func ResolveOutboundSecret(explicit, inboundList string) string {
+	if s := strings.TrimSpace(explicit); s != "" {
+		return s
+	}
+	parts := strings.Split(inboundList, ",")
+	for i := len(parts) - 1; i >= 0; i-- {
+		if s := strings.TrimSpace(parts[i]); s != "" {
+			return s
+		}
+	}
+	return ""
+}
+
 // CloudClient calls the pad-cloud sidecar over HTTP. Stateless — safe to
 // share across goroutines; the underlying http.Client has its own pool.
 type CloudClient struct {

--- a/internal/billing/cloud_client.go
+++ b/internal/billing/cloud_client.go
@@ -55,9 +55,12 @@ func NewCloudClient(baseURL, cloudSecret string) *CloudClient {
 }
 
 // SidecarError carries the structured details pad-cloud returns on a non-2xx
-// response. Callers use errors.As with a *SidecarError target to decide
-// between "retry transport/server failure" (Status >= 500) and "upstream
-// state is already inconsistent, log and continue" (Status in [400,500)).
+// response. Exposed so callers that want to log the status separately from
+// the error message can extract it via errors.As. We deliberately do NOT
+// expose a "this is a retryable/ignorable error" helper — pad-cloud
+// normalizes Stripe's "already gone" cases to 200 internally, so every
+// non-2xx we see is a real failure (ops misconfig, upstream breakage) and
+// callers should treat the whole class uniformly as "abort".
 type SidecarError struct {
 	// Status is the HTTP status pad-cloud returned (e.g. 400, 403, 500).
 	Status int
@@ -69,18 +72,6 @@ type SidecarError struct {
 
 func (e *SidecarError) Error() string {
 	return fmt.Sprintf("pad-cloud sidecar returned %d: %s", e.Status, e.Body)
-}
-
-// IsClientError reports whether the error is a 4xx from pad-cloud (as
-// opposed to a transport failure or a 5xx). handleDeleteAccount uses this
-// to distinguish "sidecar says the customer is already gone / malformed,
-// safe to proceed with local delete" from "sidecar is sick, abort".
-func IsClientError(err error) bool {
-	var se *SidecarError
-	if errors.As(err, &se) {
-		return se.Status >= 400 && se.Status < 500
-	}
-	return false
 }
 
 // CancelCustomer asks pad-cloud to cancel every active Stripe subscription

--- a/internal/billing/cloud_client_test.go
+++ b/internal/billing/cloud_client_test.go
@@ -58,72 +58,49 @@ func TestCancelCustomer_HappyPath_SendsCorrectRequest(t *testing.T) {
 	}
 }
 
-func TestCancelCustomer_ClientError_4xxReturnsSidecarError(t *testing.T) {
-	client, _ := newStub(t, func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusBadRequest)
-		_, _ = w.Write([]byte(`{"error":"customer_id must start with 'cus_'"}`))
-	})
+// Each real pad-cloud failure status maps to a SidecarError carrying that
+// status. Together these cover every non-2xx shape pad-cloud returns:
+//   - 400 on malformed request or non-cus_ customer_id
+//   - 403 on cloud_secret mismatch
+//   - 500 on internal / Stripe failure
+//   - 503 when Stripe is not configured
+// All of them must produce a SidecarError — the handler treats every one
+// as "abort the delete", regardless of bucket.
+func TestCancelCustomer_NonOK_ReturnsSidecarError(t *testing.T) {
+	cases := []struct {
+		name    string
+		status  int
+		body    string
+		bodyHas string
+	}{
+		{"400_bad_request", http.StatusBadRequest, `{"error":"customer_id must start with 'cus_'"}`, "customer_id must start with"},
+		{"403_wrong_secret", http.StatusForbidden, `{"error":"Forbidden"}`, "Forbidden"},
+		{"500_stripe_failure", http.StatusInternalServerError, `{"error":"Failed to cancel subscription"}`, "Failed to cancel"},
+		{"503_not_configured", http.StatusServiceUnavailable, `{"error":"Stripe billing not configured"}`, "not configured"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			client, _ := newStub(t, func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tc.status)
+				_, _ = w.Write([]byte(tc.body))
+			})
 
-	err := client.CancelCustomer("cus_abc")
-	if err == nil {
-		t.Fatal("expected error on 400, got nil")
-	}
+			err := client.CancelCustomer("cus_abc")
+			if err == nil {
+				t.Fatalf("expected error on %d, got nil", tc.status)
+			}
 
-	var se *SidecarError
-	if !errors.As(err, &se) {
-		t.Fatalf("expected *SidecarError, got %T: %v", err, err)
-	}
-	if se.Status != http.StatusBadRequest {
-		t.Errorf("expected status 400, got %d", se.Status)
-	}
-	if !strings.Contains(se.Body, "customer_id must start with") {
-		t.Errorf("expected body to include upstream message, got %q", se.Body)
-	}
-	if !IsClientError(err) {
-		t.Error("IsClientError must be true for 4xx")
-	}
-}
-
-func TestCancelCustomer_Forbidden_403IsClientError(t *testing.T) {
-	// pad-cloud returns 403 when the cloud_secret mismatch — which is NOT
-	// a "customer gone" condition. The caller should still abort, but only
-	// because 403 is classified as ops-misconfig (wrong secret), not because
-	// of the log-and-continue path. The IsClientError bool is a routing
-	// switch; callers that need finer granularity can inspect Status.
-	client, _ := newStub(t, func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusForbidden)
-		_, _ = w.Write([]byte(`{"error":"Forbidden"}`))
-	})
-
-	err := client.CancelCustomer("cus_abc")
-	if err == nil {
-		t.Fatal("expected error on 403, got nil")
-	}
-	if !IsClientError(err) {
-		t.Error("403 should be classified as client error")
-	}
-}
-
-func TestCancelCustomer_ServerError_5xxIsNotClientError(t *testing.T) {
-	client, _ := newStub(t, func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusInternalServerError)
-		_, _ = w.Write([]byte(`{"error":"Failed to cancel subscription"}`))
-	})
-
-	err := client.CancelCustomer("cus_abc")
-	if err == nil {
-		t.Fatal("expected error on 500, got nil")
-	}
-
-	var se *SidecarError
-	if !errors.As(err, &se) {
-		t.Fatalf("expected *SidecarError, got %T", err)
-	}
-	if se.Status != http.StatusInternalServerError {
-		t.Errorf("expected status 500, got %d", se.Status)
-	}
-	if IsClientError(err) {
-		t.Error("IsClientError must be false for 5xx")
+			var se *SidecarError
+			if !errors.As(err, &se) {
+				t.Fatalf("expected *SidecarError, got %T: %v", err, err)
+			}
+			if se.Status != tc.status {
+				t.Errorf("expected status %d, got %d", tc.status, se.Status)
+			}
+			if !strings.Contains(se.Body, tc.bodyHas) {
+				t.Errorf("expected body to include %q, got %q", tc.bodyHas, se.Body)
+			}
+		})
 	}
 }
 
@@ -143,9 +120,6 @@ func TestCancelCustomer_TransportFailure_NotSidecarError(t *testing.T) {
 	var se *SidecarError
 	if errors.As(err, &se) {
 		t.Errorf("transport failure must not be SidecarError, got %v", err)
-	}
-	if IsClientError(err) {
-		t.Error("IsClientError must be false for transport errors")
 	}
 }
 
@@ -180,15 +154,6 @@ func TestCancelCustomer_UnconfiguredClient_ReturnsError(t *testing.T) {
 	}
 	if strings.Contains(err.Error(), "dial") {
 		t.Errorf("expected config error, got transport error: %v", err)
-	}
-}
-
-func TestIsClientError_NonSidecarError(t *testing.T) {
-	if IsClientError(errors.New("plain error")) {
-		t.Error("IsClientError must be false for non-SidecarError")
-	}
-	if IsClientError(nil) {
-		t.Error("IsClientError(nil) must be false")
 	}
 }
 

--- a/internal/billing/cloud_client_test.go
+++ b/internal/billing/cloud_client_test.go
@@ -157,6 +157,86 @@ func TestCancelCustomer_UnconfiguredClient_ReturnsError(t *testing.T) {
 	}
 }
 
+func TestResolveOutboundSecret(t *testing.T) {
+	cases := []struct {
+		name         string
+		explicit     string
+		inboundList  string
+		want         string
+		wantEmpty    bool
+	}{
+		{
+			name:        "explicit wins over inbound",
+			explicit:    "explicit-key",
+			inboundList: "new,old",
+			want:        "explicit-key",
+		},
+		{
+			name:        "explicit with whitespace is trimmed",
+			explicit:    "  pinned-key  ",
+			inboundList: "new,old",
+			want:        "pinned-key",
+		},
+		{
+			name:        "falls back to last inbound during rotation (new,old)",
+			explicit:    "",
+			inboundList: "new-key,old-key",
+			want:        "old-key",
+		},
+		{
+			name:        "single inbound value is used",
+			explicit:    "",
+			inboundList: "only-key",
+			want:        "only-key",
+		},
+		{
+			name:        "skips trailing empty entries",
+			explicit:    "",
+			inboundList: "new-key,old-key,,",
+			want:        "old-key",
+		},
+		{
+			name:        "skips whitespace-only entries",
+			explicit:    "",
+			inboundList: "new-key,   ,old-key",
+			want:        "old-key",
+		},
+		{
+			name:        "explicit set but inbound empty → explicit",
+			explicit:    "only-explicit",
+			inboundList: "",
+			want:        "only-explicit",
+		},
+		{
+			name:        "both empty → empty result (caller should fail startup)",
+			explicit:    "",
+			inboundList: "",
+			wantEmpty:   true,
+		},
+		{
+			name:        "both whitespace → empty result",
+			explicit:    "   ",
+			inboundList: ", , ,",
+			wantEmpty:   true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ResolveOutboundSecret(tc.explicit, tc.inboundList)
+			if tc.wantEmpty {
+				if got != "" {
+					t.Errorf("expected empty, got %q", got)
+				}
+				return
+			}
+			if got != tc.want {
+				t.Errorf("ResolveOutboundSecret(%q, %q) = %q, want %q",
+					tc.explicit, tc.inboundList, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestCancelCustomer_LargeResponseBody_DoesNotReadPastCap(t *testing.T) {
 	// A broken sidecar or misrouted proxy can stream us an enormous payload.
 	// We cap the read at maxResponseBody so we never allocate MBs of error

--- a/internal/billing/cloud_client_test.go
+++ b/internal/billing/cloud_client_test.go
@@ -1,0 +1,214 @@
+package billing
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// newStub starts a test HTTP server and returns a CloudClient pointed at it.
+// Callers supply the handler to control the response.
+func newStub(t *testing.T, h http.HandlerFunc) (*CloudClient, *httptest.Server) {
+	t.Helper()
+	ts := httptest.NewServer(h)
+	t.Cleanup(ts.Close)
+	return NewCloudClient(ts.URL, "test-secret"), ts
+}
+
+func TestCancelCustomer_HappyPath_SendsCorrectRequest(t *testing.T) {
+	var (
+		gotMethod      string
+		gotPath        string
+		gotContentType string
+		gotBody        map[string]string
+	)
+	client, _ := newStub(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotContentType = r.Header.Get("Content-Type")
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &gotBody)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true,"subscriptions_cancelled":2}`))
+	})
+
+	if err := client.CancelCustomer("cus_abc"); err != nil {
+		t.Fatalf("expected nil error on 200, got %v", err)
+	}
+
+	if gotMethod != http.MethodPost {
+		t.Errorf("expected POST, got %s", gotMethod)
+	}
+	if gotPath != "/billing/cancel-customer" {
+		t.Errorf("expected /billing/cancel-customer, got %s", gotPath)
+	}
+	if gotContentType != "application/json" {
+		t.Errorf("expected application/json content type, got %s", gotContentType)
+	}
+	if gotBody["customer_id"] != "cus_abc" {
+		t.Errorf("expected customer_id=cus_abc, got %q", gotBody["customer_id"])
+	}
+	if gotBody["cloud_secret"] != "test-secret" {
+		t.Errorf("expected cloud_secret=test-secret, got %q", gotBody["cloud_secret"])
+	}
+}
+
+func TestCancelCustomer_ClientError_4xxReturnsSidecarError(t *testing.T) {
+	client, _ := newStub(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"customer_id must start with 'cus_'"}`))
+	})
+
+	err := client.CancelCustomer("cus_abc")
+	if err == nil {
+		t.Fatal("expected error on 400, got nil")
+	}
+
+	var se *SidecarError
+	if !errors.As(err, &se) {
+		t.Fatalf("expected *SidecarError, got %T: %v", err, err)
+	}
+	if se.Status != http.StatusBadRequest {
+		t.Errorf("expected status 400, got %d", se.Status)
+	}
+	if !strings.Contains(se.Body, "customer_id must start with") {
+		t.Errorf("expected body to include upstream message, got %q", se.Body)
+	}
+	if !IsClientError(err) {
+		t.Error("IsClientError must be true for 4xx")
+	}
+}
+
+func TestCancelCustomer_Forbidden_403IsClientError(t *testing.T) {
+	// pad-cloud returns 403 when the cloud_secret mismatch — which is NOT
+	// a "customer gone" condition. The caller should still abort, but only
+	// because 403 is classified as ops-misconfig (wrong secret), not because
+	// of the log-and-continue path. The IsClientError bool is a routing
+	// switch; callers that need finer granularity can inspect Status.
+	client, _ := newStub(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error":"Forbidden"}`))
+	})
+
+	err := client.CancelCustomer("cus_abc")
+	if err == nil {
+		t.Fatal("expected error on 403, got nil")
+	}
+	if !IsClientError(err) {
+		t.Error("403 should be classified as client error")
+	}
+}
+
+func TestCancelCustomer_ServerError_5xxIsNotClientError(t *testing.T) {
+	client, _ := newStub(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"Failed to cancel subscription"}`))
+	})
+
+	err := client.CancelCustomer("cus_abc")
+	if err == nil {
+		t.Fatal("expected error on 500, got nil")
+	}
+
+	var se *SidecarError
+	if !errors.As(err, &se) {
+		t.Fatalf("expected *SidecarError, got %T", err)
+	}
+	if se.Status != http.StatusInternalServerError {
+		t.Errorf("expected status 500, got %d", se.Status)
+	}
+	if IsClientError(err) {
+		t.Error("IsClientError must be false for 5xx")
+	}
+}
+
+func TestCancelCustomer_TransportFailure_NotSidecarError(t *testing.T) {
+	// Point at a URL nothing's listening on; use a short client timeout so
+	// the test doesn't hang if the OS accepts the connect.
+	client := NewCloudClient("http://127.0.0.1:1", "test-secret")
+	client.http.Timeout = 500 * time.Millisecond
+
+	err := client.CancelCustomer("cus_abc")
+	if err == nil {
+		t.Fatal("expected transport error, got nil")
+	}
+
+	// A transport failure must NOT be a *SidecarError — callers use this to
+	// distinguish "retry" (no status from upstream) from "upstream spoke".
+	var se *SidecarError
+	if errors.As(err, &se) {
+		t.Errorf("transport failure must not be SidecarError, got %v", err)
+	}
+	if IsClientError(err) {
+		t.Error("IsClientError must be false for transport errors")
+	}
+}
+
+func TestCancelCustomer_EmptyCustomerID_ReturnsError(t *testing.T) {
+	called := false
+	client, _ := newStub(t, func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	err := client.CancelCustomer("")
+	if err == nil {
+		t.Fatal("expected error for empty customer_id, got nil")
+	}
+	if called {
+		t.Error("expected no HTTP call for empty customer_id")
+	}
+}
+
+func TestCancelCustomer_NilClient_ReturnsError(t *testing.T) {
+	var c *CloudClient
+	if err := c.CancelCustomer("cus_abc"); err == nil {
+		t.Fatal("expected error from nil receiver, got nil")
+	}
+}
+
+func TestCancelCustomer_UnconfiguredClient_ReturnsError(t *testing.T) {
+	c := NewCloudClient("", "")
+	err := c.CancelCustomer("cus_abc")
+	if err == nil {
+		t.Fatal("expected error for unconfigured client, got nil")
+	}
+	if strings.Contains(err.Error(), "dial") {
+		t.Errorf("expected config error, got transport error: %v", err)
+	}
+}
+
+func TestIsClientError_NonSidecarError(t *testing.T) {
+	if IsClientError(errors.New("plain error")) {
+		t.Error("IsClientError must be false for non-SidecarError")
+	}
+	if IsClientError(nil) {
+		t.Error("IsClientError(nil) must be false")
+	}
+}
+
+func TestCancelCustomer_LargeResponseBody_DoesNotReadPastCap(t *testing.T) {
+	// A broken sidecar or misrouted proxy can stream us an enormous payload.
+	// We cap the read at maxResponseBody so we never allocate MBs of error
+	// body. Build a body bigger than the cap and verify the client still
+	// returns a SidecarError with a truncated-but-bounded Body.
+	big := strings.Repeat("X", maxResponseBody*2)
+	client, _ := newStub(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte(big))
+	})
+
+	err := client.CancelCustomer("cus_abc")
+	var se *SidecarError
+	if !errors.As(err, &se) {
+		t.Fatalf("expected SidecarError, got %T", err)
+	}
+	if len(se.Body) > maxResponseBody {
+		t.Errorf("body was %d bytes, expected <= %d (cap)", len(se.Body), maxResponseBody)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -41,8 +41,9 @@ type Config struct {
 	EmailFromName  string `toml:"email_from_name"` // Sender display name (e.g. Pad)
 
 	// Cloud mode
-	CloudSecret     string `toml:"cloud_secret"`      // Shared secret for pad-cloud sidecar communication
-	CloudSidecarURL string `toml:"cloud_sidecar_url"` // Base URL pad uses to call the pad-cloud sidecar (reverse direction, e.g. Stripe cancel-customer on account delete)
+	CloudSecret         string `toml:"cloud_secret"`           // Inbound shared secret(s) accepted from pad-cloud. Comma-separated list supports rotation.
+	CloudSidecarURL     string `toml:"cloud_sidecar_url"`      // Base URL pad uses to call the pad-cloud sidecar (reverse direction, e.g. Stripe cancel-customer on account delete)
+	CloudOutboundSecret string `toml:"cloud_outbound_secret"`  // Optional: exact secret to send when calling pad-cloud. Falls back to the LAST entry of CloudSecret (the older rotation value, which is what pad-cloud is usually running). See DEPLOY.md "Cloud secret rotation".
 
 	// Encryption
 	EncryptionKey       string `toml:"encryption_key"` // 32-byte hex-encoded AES-256 key for encrypting sensitive fields
@@ -152,6 +153,9 @@ func Load() (*Config, error) {
 	}
 	if v := os.Getenv("PAD_CLOUD_SIDECAR_URL"); v != "" {
 		cfg.CloudSidecarURL = v
+	}
+	if v := os.Getenv("PAD_CLOUD_OUTBOUND_SECRET"); v != "" {
+		cfg.CloudOutboundSecret = v
 	}
 	if v := os.Getenv("PAD_ENCRYPTION_KEY"); v != "" {
 		cfg.EncryptionKey = v

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -41,7 +41,8 @@ type Config struct {
 	EmailFromName  string `toml:"email_from_name"` // Sender display name (e.g. Pad)
 
 	// Cloud mode
-	CloudSecret string `toml:"cloud_secret"` // Shared secret for pad-cloud sidecar communication
+	CloudSecret     string `toml:"cloud_secret"`      // Shared secret for pad-cloud sidecar communication
+	CloudSidecarURL string `toml:"cloud_sidecar_url"` // Base URL pad uses to call the pad-cloud sidecar (reverse direction, e.g. Stripe cancel-customer on account delete)
 
 	// Encryption
 	EncryptionKey       string `toml:"encryption_key"` // 32-byte hex-encoded AES-256 key for encrypting sensitive fields
@@ -148,6 +149,9 @@ func Load() (*Config, error) {
 	}
 	if v := os.Getenv("PAD_CLOUD_SECRET"); v != "" {
 		cfg.CloudSecret = v
+	}
+	if v := os.Getenv("PAD_CLOUD_SIDECAR_URL"); v != "" {
+		cfg.CloudSidecarURL = v
 	}
 	if v := os.Getenv("PAD_ENCRYPTION_KEY"); v != "" {
 		cfg.EncryptionKey = v

--- a/internal/server/handlers_account.go
+++ b/internal/server/handlers_account.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/xarmian/pad/internal/billing"
 	"github.com/xarmian/pad/internal/models"
 	"golang.org/x/crypto/bcrypt"
 )
@@ -69,6 +70,39 @@ func (s *Server) handleDeleteAccount(w http.ResponseWriter, r *http.Request) {
 	for _, ws := range workspaces {
 		if ws.OwnerID == user.ID {
 			ownedSlugs = append(ownedSlugs, ws.Slug)
+		}
+	}
+
+	// Cascade Stripe cancel BEFORE the local delete. If this ordering is
+	// reversed, a mid-flight failure would wipe the user's StripeCustomerID
+	// from our DB while leaving the Stripe subscription active — the user
+	// would keep getting charged with no way for us to find and cancel
+	// it. TASK-690 / PLAN-645.
+	//
+	// Skipped when:
+	//   - the user has no Stripe customer (free plan, OAuth-only, never paid)
+	//   - the sidecar isn't configured (self-hosted deploys with no billing)
+	// Failure strategy:
+	//   - transport / 5xx → return 500, don't delete; user can retry
+	//   - 4xx from sidecar → log + continue: the upstream state is already
+	//     gone or malformed, proceeding with the local delete is correct
+	//     (retrying would never succeed)
+	if fullUser.StripeCustomerID != "" && s.cloudSidecar != nil {
+		if err := s.cloudSidecar.CancelCustomer(fullUser.StripeCustomerID); err != nil {
+			if billing.IsClientError(err) {
+				slog.Warn("delete account: sidecar rejected cancel-customer with 4xx, continuing with local delete",
+					"user_id", user.ID,
+					"customer_id", fullUser.StripeCustomerID,
+					"error", err)
+			} else {
+				slog.Error("delete account: sidecar cancel-customer failed, aborting delete",
+					"user_id", user.ID,
+					"customer_id", fullUser.StripeCustomerID,
+					"error", err)
+				writeError(w, http.StatusInternalServerError, "billing_cancel_failed",
+					"Failed to cancel your subscription. No data was removed. Please try again in a moment.")
+				return
+			}
 		}
 	}
 

--- a/internal/server/handlers_account.go
+++ b/internal/server/handlers_account.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/xarmian/pad/internal/billing"
 	"github.com/xarmian/pad/internal/models"
 	"golang.org/x/crypto/bcrypt"
 )
@@ -82,31 +81,47 @@ func (s *Server) handleDeleteAccount(w http.ResponseWriter, r *http.Request) {
 	// Skipped when:
 	//   - the user has no Stripe customer (free plan, OAuth-only, never paid)
 	//   - the sidecar isn't configured (self-hosted deploys with no billing)
-	// Failure strategy:
-	//   - transport / 5xx → return 500, don't delete; user can retry
-	//   - 4xx from sidecar → log + continue: the upstream state is already
-	//     gone or malformed, proceeding with the local delete is correct
-	//     (retrying would never succeed)
+	//
+	// Failure strategy: any non-nil error aborts the delete with a 500.
+	// pad-cloud normalizes Stripe 404/resource_missing to a 200 success on
+	// its side (see pad-cloud stripe.go isStripeAlreadyGone), so every
+	// non-2xx we see here is actually a real failure — 400/403 indicate
+	// ops misconfig (bad secret, malformed call), 500 indicates upstream
+	// breakage. In none of those cases is it correct to "log and
+	// continue": doing so would wipe the user's StripeCustomerID while
+	// leaving the Stripe subscription billing, which is the exact
+	// regression this task exists to prevent.
+	stripeWasCancelled := false
 	if fullUser.StripeCustomerID != "" && s.cloudSidecar != nil {
 		if err := s.cloudSidecar.CancelCustomer(fullUser.StripeCustomerID); err != nil {
-			if billing.IsClientError(err) {
-				slog.Warn("delete account: sidecar rejected cancel-customer with 4xx, continuing with local delete",
-					"user_id", user.ID,
-					"customer_id", fullUser.StripeCustomerID,
-					"error", err)
-			} else {
-				slog.Error("delete account: sidecar cancel-customer failed, aborting delete",
-					"user_id", user.ID,
-					"customer_id", fullUser.StripeCustomerID,
-					"error", err)
-				writeError(w, http.StatusInternalServerError, "billing_cancel_failed",
-					"Failed to cancel your subscription. No data was removed. Please try again in a moment.")
-				return
-			}
+			slog.Error("delete account: sidecar cancel-customer failed, aborting delete",
+				"user_id", user.ID,
+				"customer_id", fullUser.StripeCustomerID,
+				"error", err)
+			writeError(w, http.StatusInternalServerError, "billing_cancel_failed",
+				"We couldn't cancel your subscription. Your account was NOT deleted and you have NOT been charged anything new. Please try again in a few minutes or contact support.")
+			return
 		}
+		stripeWasCancelled = true
 	}
 
 	if err := s.store.DeleteAccountAtomic(user.ID, ownedSlugs); err != nil {
+		// Cross-system danger zone: if Stripe was already cancelled, the
+		// user's billing is gone but their account data is still present.
+		// Stripe cancel is NOT reversible programmatically. Operator must
+		// manually restore the Stripe subscription + customer for this
+		// user, or hard-delete the local row. Log loudly so monitoring
+		// catches it; the response message tells the user the truth.
+		if stripeWasCancelled {
+			slog.Error("delete account: STRIPE CANCELLED BUT LOCAL DELETE FAILED — manual operator intervention required",
+				"user_id", user.ID,
+				"email", user.Email,
+				"stripe_customer_id", fullUser.StripeCustomerID,
+				"error", err)
+			writeError(w, http.StatusInternalServerError, "partial_delete",
+				"Your billing was cancelled but we couldn't delete your account data. Please contact support — our team has been notified.")
+			return
+		}
 		slog.Error("delete account: atomic deletion failed", "user_id", user.ID, "error", err)
 		writeError(w, http.StatusInternalServerError, "internal_error",
 			"Account deletion failed. No data was removed. Please try again or contact support.")

--- a/internal/server/handlers_account_test.go
+++ b/internal/server/handlers_account_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -305,6 +306,65 @@ func TestHandleDeleteAccount_AbortsOnSidecar4xx(t *testing.T) {
 				t.Errorf("expected exactly 1 sidecar call, got %d", fake.callCount())
 			}
 		})
+	}
+}
+
+// TestHandleDeleteAccount_PartialDelete_WhenLocalDeleteFailsAfterCancel
+// exercises the most dangerous state: the sidecar successfully cancelled
+// Stripe, but the local DELETE then failed. Before the round-1 fix the
+// response claimed "No data was removed" even though billing was already
+// gone; now it returns a truthful partial_delete error and logs the
+// customer ID for operator follow-up.
+//
+// The "local delete fails" condition is simulated by leaving a second
+// audit row referencing the user (activities.user_id) that we DON'T scrub
+// — that row blocks the final DELETE FROM users with a FK violation. The
+// test deliberately re-introduces the same FK that bootstrapAccountDeleteUser
+// normally scrubs.
+func TestHandleDeleteAccount_PartialDelete_WhenLocalDeleteFailsAfterCancel(t *testing.T) {
+	srv := testServer(t)
+	fake := &fakeSidecar{}
+	srv.SetCloudSidecar(fake)
+
+	userID, token := bootstrapAccountDeleteUser(t, srv, "cus_paying_user")
+
+	// Re-attach an activity row to the user so the FK blocks the delete.
+	// This is the same FK gap the fixture normally scrubs around; we
+	// intentionally re-create it to force DeleteAccountAtomic to fail
+	// AFTER the successful Stripe cancel.
+	if _, err := srv.store.DB().Exec(
+		"UPDATE activities SET user_id = ? WHERE user_id IS NULL",
+		userID); err != nil {
+		t.Fatalf("reintroduce FK: %v", err)
+	}
+
+	rr := deleteAccountReq(srv, map[string]interface{}{"password": "correct-horse-battery-staple"}, token)
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	// Response must be the truthful partial-delete code, NOT a generic
+	// internal_error that claims nothing was removed.
+	body := rr.Body.String()
+	if !strings.Contains(body, "partial_delete") {
+		t.Errorf("expected partial_delete error code in body, got %s", body)
+	}
+	if !strings.Contains(body, "billing was cancelled") {
+		t.Errorf("expected truthful 'billing was cancelled' message, got %s", body)
+	}
+
+	// Sidecar WAS called — that's the whole premise of this test.
+	if fake.callCount() != 1 {
+		t.Errorf("expected 1 cancel call, got %d", fake.callCount())
+	}
+
+	// And the user row is still present — ops needs it to investigate.
+	u, err := srv.store.GetUser(userID)
+	if err != nil {
+		t.Fatalf("get user: %v", err)
+	}
+	if u == nil {
+		t.Fatal("user row must still exist after partial_delete")
 	}
 }
 

--- a/internal/server/handlers_account_test.go
+++ b/internal/server/handlers_account_test.go
@@ -1,0 +1,274 @@
+package server
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/xarmian/pad/internal/billing"
+)
+
+// fakeSidecar is a controllable CloudSidecar used to assert the cancel-before-
+// delete cascade (TASK-690) without standing up a real HTTP server.
+type fakeSidecar struct {
+	calls          int32 // atomic counter of CancelCustomer invocations
+	lastCustomerID atomic.Pointer[string]
+	err            error
+}
+
+func (f *fakeSidecar) CancelCustomer(customerID string) error {
+	atomic.AddInt32(&f.calls, 1)
+	id := customerID // copy so the atomic pointer doesn't alias the caller's stack
+	f.lastCustomerID.Store(&id)
+	return f.err
+}
+
+func (f *fakeSidecar) callCount() int {
+	return int(atomic.LoadInt32(&f.calls))
+}
+
+func (f *fakeSidecar) lastID() string {
+	if p := f.lastCustomerID.Load(); p != nil {
+		return *p
+	}
+	return ""
+}
+
+// bootstrapAccountDeleteUser creates the first admin user, sets a
+// Stripe customer ID on them, and returns (userID, sessionToken). Used by
+// the handleDeleteAccount cascade tests.
+//
+// Clears activities.user_id for the user after bootstrap because
+// DeleteAccountAtomic doesn't cascade through activities (a pre-existing
+// limitation unrelated to TASK-690). Without this, the FK from
+// activities.user_id → users.id blocks the final DELETE FROM users and
+// every happy-path test ends in a 500. Narrow test-only scrub — it
+// preserves the audit rows themselves (for callers that inspect them) and
+// only detaches the user reference, which mirrors the ON DELETE SET NULL
+// behaviour the production schema will get when the FK gap is fixed in a
+// follow-up migration.
+func bootstrapAccountDeleteUser(t *testing.T, srv *Server, customerID string) (string, string) {
+	t.Helper()
+	token := bootstrapFirstUser(t, srv, "delete-me@test.com", "Delete Me")
+	u, err := srv.store.GetUserByEmail("delete-me@test.com")
+	if err != nil || u == nil {
+		t.Fatalf("failed to locate bootstrapped user: %v", err)
+	}
+	if customerID != "" {
+		if err := srv.store.SetUserStripeCustomerID(u.ID, customerID); err != nil {
+			t.Fatalf("set customer id: %v", err)
+		}
+	}
+	if _, err := srv.store.DB().Exec("UPDATE activities SET user_id = NULL WHERE user_id = ?", u.ID); err != nil {
+		t.Fatalf("scrub activities.user_id for test user: %v", err)
+	}
+	return u.ID, token
+}
+
+// deleteAccountReq is a doRequestWithCookieFrom wrapper that pins the
+// RemoteAddr to 127.0.0.1 — the same loopback address bootstrap was
+// invoked from. Without this, the session-IP-change middleware writes an
+// ActionSessionIPChanged audit row at request time (user_id column,
+// FK → users.id), which then blocks the final DELETE FROM users at the
+// end of DeleteAccountAtomic. Until the account-delete cascade fix for
+// audit rows lands (pre-existing bug, tracked separately), these tests
+// keep the IP stable to sidestep the FK gap.
+func deleteAccountReq(srv *Server, body interface{}, token string) *httptest.ResponseRecorder {
+	return doRequestWithCookieFrom(srv, "POST", "/api/v1/auth/delete-account", body, token, "127.0.0.1:4321")
+}
+
+// TestHandleDeleteAccount_CancelsStripeBeforeDelete is the happy-path
+// cascade assertion: a paying user's CancelCustomer runs FIRST, then the
+// local delete goes through, and the user row is gone afterwards.
+func TestHandleDeleteAccount_CancelsStripeBeforeDelete(t *testing.T) {
+	srv := testServer(t)
+	fake := &fakeSidecar{}
+	srv.SetCloudSidecar(fake)
+
+	userID, token := bootstrapAccountDeleteUser(t, srv, "cus_paying_user")
+
+	rr := deleteAccountReq(srv, map[string]interface{}{"password": "correct-horse-battery-staple"}, token)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("delete-account: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	if fake.callCount() != 1 {
+		t.Fatalf("CancelCustomer: expected 1 call, got %d", fake.callCount())
+	}
+	if got := fake.lastID(); got != "cus_paying_user" {
+		t.Errorf("CancelCustomer called with %q, want cus_paying_user", got)
+	}
+
+	// User row should be gone.
+	u, err := srv.store.GetUser(userID)
+	if err != nil {
+		t.Fatalf("get user after delete: %v", err)
+	}
+	if u != nil {
+		t.Error("expected user to be deleted after successful cascade")
+	}
+}
+
+// TestHandleDeleteAccount_SkipsWhenNoStripeCustomer verifies that users
+// without a Stripe customer ID (free tier, OAuth-only, never paid) don't
+// trigger a sidecar call. Otherwise we'd burn a sidecar RPC on every
+// free-user delete and log-spam 400 "customer_id must start with 'cus_'".
+func TestHandleDeleteAccount_SkipsWhenNoStripeCustomer(t *testing.T) {
+	srv := testServer(t)
+	fake := &fakeSidecar{}
+	srv.SetCloudSidecar(fake)
+
+	userID, token := bootstrapAccountDeleteUser(t, srv, "") // no customer ID
+
+	rr := deleteAccountReq(srv, map[string]interface{}{"password": "correct-horse-battery-staple"}, token)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("delete-account: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	if fake.callCount() != 0 {
+		t.Errorf("CancelCustomer: expected 0 calls for non-paying user, got %d", fake.callCount())
+	}
+
+	u, err := srv.store.GetUser(userID)
+	if err != nil {
+		t.Fatalf("get user after delete: %v", err)
+	}
+	if u != nil {
+		t.Error("expected user to be deleted even without a Stripe customer")
+	}
+}
+
+// TestHandleDeleteAccount_SkipsWhenNoSidecarConfigured verifies that a
+// self-hosted deploy (no CloudSidecar wired) lets deletes complete for
+// paying users without blowing up on nil dereference. In practice this
+// arrangement shouldn't exist (if the user has a Stripe customer ID,
+// cloud mode was configured at some point) but it's the graceful-fallback
+// contract: missing sidecar ≠ broken deletes.
+func TestHandleDeleteAccount_SkipsWhenNoSidecarConfigured(t *testing.T) {
+	srv := testServer(t)
+	// No SetCloudSidecar — the reverse hook is nil.
+
+	userID, token := bootstrapAccountDeleteUser(t, srv, "cus_paying_user")
+
+	rr := deleteAccountReq(srv, map[string]interface{}{"password": "correct-horse-battery-staple"}, token)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("delete-account: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	u, err := srv.store.GetUser(userID)
+	if err != nil {
+		t.Fatalf("get user after delete: %v", err)
+	}
+	if u != nil {
+		t.Error("expected user to be deleted when sidecar is absent")
+	}
+}
+
+// TestHandleDeleteAccount_AbortsOnSidecarTransportFailure — a bare error
+// (no SidecarError) means transport failure or timeout. We MUST NOT delete
+// the user; a retry needs the data intact to re-drive the cancel.
+func TestHandleDeleteAccount_AbortsOnSidecarTransportFailure(t *testing.T) {
+	srv := testServer(t)
+	fake := &fakeSidecar{err: errors.New("connect: connection refused")}
+	srv.SetCloudSidecar(fake)
+
+	userID, token := bootstrapAccountDeleteUser(t, srv, "cus_paying_user")
+
+	rr := deleteAccountReq(srv, map[string]interface{}{"password": "correct-horse-battery-staple"}, token)
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("delete-account: expected 500, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	// Critical: user is STILL present — aborted cleanly.
+	u, err := srv.store.GetUser(userID)
+	if err != nil {
+		t.Fatalf("get user after failed delete: %v", err)
+	}
+	if u == nil {
+		t.Fatal("expected user to still exist after sidecar transport failure")
+	}
+	if u.StripeCustomerID != "cus_paying_user" {
+		t.Errorf("stripe_customer_id must be preserved for retry; got %q", u.StripeCustomerID)
+	}
+}
+
+// TestHandleDeleteAccount_AbortsOnSidecar5xx — pad-cloud reported a 5xx.
+// Treated identically to transport failure: user stays put, retry can
+// re-drive the cancel.
+func TestHandleDeleteAccount_AbortsOnSidecar5xx(t *testing.T) {
+	srv := testServer(t)
+	fake := &fakeSidecar{err: &billing.SidecarError{
+		Status: http.StatusInternalServerError,
+		Body:   `{"error":"Failed to cancel subscription"}`,
+	}}
+	srv.SetCloudSidecar(fake)
+
+	userID, token := bootstrapAccountDeleteUser(t, srv, "cus_paying_user")
+
+	rr := deleteAccountReq(srv, map[string]interface{}{"password": "correct-horse-battery-staple"}, token)
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("delete-account: expected 500 on sidecar 5xx, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	u, err := srv.store.GetUser(userID)
+	if err != nil {
+		t.Fatalf("get user after 5xx: %v", err)
+	}
+	if u == nil {
+		t.Fatal("expected user to still exist after sidecar 5xx")
+	}
+}
+
+// TestHandleDeleteAccount_ContinuesOnSidecar4xx — pad-cloud returned a 4xx
+// (customer not found, malformed customer ID, etc). That's "upstream state
+// is already gone or inconsistent"; retrying would never succeed. We log
+// and continue with the local delete so the user isn't trapped in a
+// can't-delete state.
+func TestHandleDeleteAccount_ContinuesOnSidecar4xx(t *testing.T) {
+	srv := testServer(t)
+	fake := &fakeSidecar{err: &billing.SidecarError{
+		Status: http.StatusNotFound,
+		Body:   `{"error":"customer not found"}`,
+	}}
+	srv.SetCloudSidecar(fake)
+
+	userID, token := bootstrapAccountDeleteUser(t, srv, "cus_paying_user")
+
+	rr := deleteAccountReq(srv, map[string]interface{}{"password": "correct-horse-battery-staple"}, token)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("delete-account: expected 200 on sidecar 4xx, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	u, err := srv.store.GetUser(userID)
+	if err != nil {
+		t.Fatalf("get user after 4xx: %v", err)
+	}
+	if u != nil {
+		t.Error("expected user to be deleted after 4xx-classified sidecar error")
+	}
+	if fake.callCount() != 1 {
+		t.Errorf("expected exactly 1 sidecar call, got %d", fake.callCount())
+	}
+}
+
+// TestHandleDeleteAccount_SkipsCancelOnWrongPassword — the password check
+// runs BEFORE the sidecar call, so a wrong-password attempt must not leak
+// a cancel RPC. (Otherwise an attacker with a session cookie but no
+// password could still cancel the victim's Stripe subscription.)
+func TestHandleDeleteAccount_SkipsCancelOnWrongPassword(t *testing.T) {
+	srv := testServer(t)
+	fake := &fakeSidecar{}
+	srv.SetCloudSidecar(fake)
+
+	_, token := bootstrapAccountDeleteUser(t, srv, "cus_paying_user")
+
+	rr := deleteAccountReq(srv, map[string]interface{}{"password": "wrong-password"}, token)
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("delete-account: expected 403 on wrong password, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if fake.callCount() != 0 {
+		t.Errorf("CancelCustomer must not be called on wrong-password attempts, got %d calls", fake.callCount())
+	}
+}

--- a/internal/server/handlers_account_test.go
+++ b/internal/server/handlers_account_test.go
@@ -12,16 +12,27 @@ import (
 
 // fakeSidecar is a controllable CloudSidecar used to assert the cancel-before-
 // delete cascade (TASK-690) without standing up a real HTTP server.
+//
+// When hook is set, it runs inside CancelCustomer before the call returns —
+// giving tests a chokepoint to verify invariants that are true only at
+// that exact moment (e.g. "the user row still exists at the moment cancel
+// is called"). Without the hook, a regression that swapped cancel and
+// delete could still pass a simple "cancel was called" + "user is gone"
+// assertion because both would be true at the end.
 type fakeSidecar struct {
 	calls          int32 // atomic counter of CancelCustomer invocations
 	lastCustomerID atomic.Pointer[string]
 	err            error
+	hook           func(customerID string) // runs under CancelCustomer; optional
 }
 
 func (f *fakeSidecar) CancelCustomer(customerID string) error {
 	atomic.AddInt32(&f.calls, 1)
 	id := customerID // copy so the atomic pointer doesn't alias the caller's stack
 	f.lastCustomerID.Store(&id)
+	if f.hook != nil {
+		f.hook(customerID)
+	}
 	return f.err
 }
 
@@ -80,14 +91,39 @@ func deleteAccountReq(srv *Server, body interface{}, token string) *httptest.Res
 }
 
 // TestHandleDeleteAccount_CancelsStripeBeforeDelete is the happy-path
-// cascade assertion: a paying user's CancelCustomer runs FIRST, then the
-// local delete goes through, and the user row is gone afterwards.
+// cascade assertion: a paying user's CancelCustomer runs FIRST (while the
+// user row is still present), then the local delete goes through, and the
+// user row is gone afterwards.
+//
+// The inline hook closes the cancel-before-delete loophole: we check the
+// user row directly during the CancelCustomer call, so a regression that
+// reverses the order (delete first, then cancel) can't pass — by the time
+// cancel would be called, the row would already be absent and the
+// assertion would fire inside the hook.
 func TestHandleDeleteAccount_CancelsStripeBeforeDelete(t *testing.T) {
 	srv := testServer(t)
-	fake := &fakeSidecar{}
-	srv.SetCloudSidecar(fake)
 
 	userID, token := bootstrapAccountDeleteUser(t, srv, "cus_paying_user")
+
+	fake := &fakeSidecar{}
+	fake.hook = func(customerID string) {
+		if customerID != "cus_paying_user" {
+			t.Errorf("CancelCustomer called with %q during hook, want cus_paying_user", customerID)
+		}
+		// Invariant under test: the user row MUST still exist at the
+		// moment cancel fires. A regression that flipped cancel/delete
+		// order would blow up this check because the user would already
+		// be gone by the time the sidecar was called.
+		u, err := srv.store.GetUser(userID)
+		if err != nil {
+			t.Errorf("get user during cancel hook: %v", err)
+			return
+		}
+		if u == nil {
+			t.Error("user row must still be present when CancelCustomer is called (cancel must precede delete)")
+		}
+	}
+	srv.SetCloudSidecar(fake)
 
 	rr := deleteAccountReq(srv, map[string]interface{}{"password": "correct-horse-battery-staple"}, token)
 	if rr.Code != http.StatusOK {
@@ -101,7 +137,7 @@ func TestHandleDeleteAccount_CancelsStripeBeforeDelete(t *testing.T) {
 		t.Errorf("CancelCustomer called with %q, want cus_paying_user", got)
 	}
 
-	// User row should be gone.
+	// After the whole flow, user row must be gone.
 	u, err := srv.store.GetUser(userID)
 	if err != nil {
 		t.Fatalf("get user after delete: %v", err)
@@ -221,35 +257,54 @@ func TestHandleDeleteAccount_AbortsOnSidecar5xx(t *testing.T) {
 	}
 }
 
-// TestHandleDeleteAccount_ContinuesOnSidecar4xx — pad-cloud returned a 4xx
-// (customer not found, malformed customer ID, etc). That's "upstream state
-// is already gone or inconsistent"; retrying would never succeed. We log
-// and continue with the local delete so the user isn't trapped in a
-// can't-delete state.
-func TestHandleDeleteAccount_ContinuesOnSidecar4xx(t *testing.T) {
-	srv := testServer(t)
-	fake := &fakeSidecar{err: &billing.SidecarError{
-		Status: http.StatusNotFound,
-		Body:   `{"error":"customer not found"}`,
-	}}
-	srv.SetCloudSidecar(fake)
-
-	userID, token := bootstrapAccountDeleteUser(t, srv, "cus_paying_user")
-
-	rr := deleteAccountReq(srv, map[string]interface{}{"password": "correct-horse-battery-staple"}, token)
-	if rr.Code != http.StatusOK {
-		t.Fatalf("delete-account: expected 200 on sidecar 4xx, got %d: %s", rr.Code, rr.Body.String())
+// TestHandleDeleteAccount_AbortsOnSidecar4xx ensures every 4xx from
+// pad-cloud — 400 (malformed request), 403 (wrong cloud_secret) — aborts
+// the delete. pad-cloud normalizes Stripe's "already gone" cases to a 200
+// internally (see pad-cloud stripe.go isStripeAlreadyGone), so a real 4xx
+// means an ops bug on our side, never "nothing to cancel, proceed".
+// Continuing on 4xx would silently wipe the StripeCustomerID while the
+// subscription kept billing — the exact regression TASK-690 exists to
+// prevent.
+func TestHandleDeleteAccount_AbortsOnSidecar4xx(t *testing.T) {
+	cases := []struct {
+		name   string
+		status int
+		body   string
+	}{
+		{"400 bad_request", http.StatusBadRequest, `{"error":"customer_id must start with 'cus_'"}`},
+		{"403 wrong_secret", http.StatusForbidden, `{"error":"Forbidden"}`},
 	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := testServer(t)
+			fake := &fakeSidecar{err: &billing.SidecarError{Status: tc.status, Body: tc.body}}
+			srv.SetCloudSidecar(fake)
 
-	u, err := srv.store.GetUser(userID)
-	if err != nil {
-		t.Fatalf("get user after 4xx: %v", err)
-	}
-	if u != nil {
-		t.Error("expected user to be deleted after 4xx-classified sidecar error")
-	}
-	if fake.callCount() != 1 {
-		t.Errorf("expected exactly 1 sidecar call, got %d", fake.callCount())
+			userID, token := bootstrapAccountDeleteUser(t, srv, "cus_paying_user")
+
+			rr := deleteAccountReq(srv, map[string]interface{}{"password": "correct-horse-battery-staple"}, token)
+			if rr.Code != http.StatusInternalServerError {
+				t.Fatalf("expected 500 on sidecar %d, got %d: %s", tc.status, rr.Code, rr.Body.String())
+			}
+
+			// Critical: user MUST still exist and still own the customer ID
+			// so ops can investigate / retry. If we had wiped the local row
+			// here, the Stripe customer would keep billing with no way for
+			// us to find who it belonged to.
+			u, err := srv.store.GetUser(userID)
+			if err != nil {
+				t.Fatalf("get user after %d: %v", tc.status, err)
+			}
+			if u == nil {
+				t.Fatalf("user row must still exist after sidecar %d", tc.status)
+			}
+			if u.StripeCustomerID != "cus_paying_user" {
+				t.Errorf("StripeCustomerID must be preserved after sidecar %d, got %q", tc.status, u.StripeCustomerID)
+			}
+			if fake.callCount() != 1 {
+				t.Errorf("expected exactly 1 sidecar call, got %d", fake.callCount())
+			}
+		})
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -50,6 +50,7 @@ type Server struct {
 	sseMaxPerWorkspace    int                  // per-workspace SSE connection limit (0 = unlimited)
 	cloudMode             bool                 // true when running as Pad Cloud (PAD_CLOUD=true or PAD_MODE=cloud)
 	cloudSecrets          []string             // shared secrets for sidecar ↔ pad communication (supports rotation)
+	cloudSidecar          CloudSidecar         // reverse pad → pad-cloud client (e.g. Stripe cancel on account delete); nil = not configured
 	version               string               // release version (e.g. "dev", "1.2.3")
 	commit                string               // git commit hash
 	buildTime             string               // build timestamp
@@ -123,6 +124,28 @@ func (s *Server) SetCloudMode(secret string) {
 			s.cloudSecrets = append(s.cloudSecrets, k)
 		}
 	}
+}
+
+// CloudSidecar is the reverse pad → pad-cloud client interface. Concrete
+// implementation lives in internal/billing so server has no direct Stripe
+// dependency. Kept as an interface so tests can inject fakes without
+// spinning up a real HTTP server or touching Stripe.
+type CloudSidecar interface {
+	// CancelCustomer asks pad-cloud to cancel every active Stripe subscription
+	// for customerID and then delete the Stripe customer object. Used by
+	// handleDeleteAccount to cascade account deletion through to Stripe billing
+	// (TASK-690). See internal/billing for the failure-mode contract callers
+	// rely on (transport / 5xx → error; 4xx → StripeSidecar404Error so the
+	// caller can log-and-continue when the upstream state is already gone).
+	CancelCustomer(customerID string) error
+}
+
+// SetCloudSidecar installs the reverse pad → pad-cloud client. Called from
+// cmd/pad/main.go when PAD_CLOUD_SIDECAR_URL + PAD_CLOUD_SECRET are set.
+// When unset, handleDeleteAccount skips the Stripe cancel step (self-hosted
+// deploys that don't run a Stripe-backed sidecar have nothing to cascade).
+func (s *Server) SetCloudSidecar(c CloudSidecar) {
+	s.cloudSidecar = c
 }
 
 // IsCloud reports whether the server is running in cloud mode.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -114,8 +114,10 @@ func (s *Server) Init2FASecret() error {
 
 // SetCloudMode enables cloud mode with the shared sidecar secret(s).
 // Accepts a comma-separated list of secrets for rotation support:
-// "new-key,old-key" — both are accepted during rollover.
-// The sidecar should always send the first (newest) key.
+// "new-key,old-key" — both are accepted for INBOUND calls from pad-cloud.
+// The OUTBOUND direction (pad → pad-cloud, see SetCloudSidecar) is
+// configured separately via PAD_CLOUD_OUTBOUND_SECRET or derived from the
+// last entry of this list — see cmd/pad/main.go for the resolution order.
 func (s *Server) SetCloudMode(secret string) {
 	s.cloudMode = true
 	for _, k := range strings.Split(secret, ",") {
@@ -134,9 +136,15 @@ type CloudSidecar interface {
 	// CancelCustomer asks pad-cloud to cancel every active Stripe subscription
 	// for customerID and then delete the Stripe customer object. Used by
 	// handleDeleteAccount to cascade account deletion through to Stripe billing
-	// (TASK-690). See internal/billing for the failure-mode contract callers
-	// rely on (transport / 5xx → error; 4xx → StripeSidecar404Error so the
-	// caller can log-and-continue when the upstream state is already gone).
+	// (TASK-690).
+	//
+	// Failure contract: any non-nil error means the caller MUST abort the
+	// local delete. pad-cloud normalizes Stripe's "already gone" cases to a
+	// 200 on its side (see pad-cloud stripe.go isStripeAlreadyGone), so
+	// every error we see here is a real failure — transport, 4xx (ops
+	// misconfig), or 5xx (upstream breakage). Continuing after an error
+	// would wipe the user's StripeCustomerID while leaving the subscription
+	// billing, which is exactly the regression TASK-690 exists to prevent.
 	CancelCustomer(customerID string) error
 }
 


### PR DESCRIPTION
## Summary

Closes the pad side of PLAN-645 Chunk 8 — when a user deletes their account, Stripe subscriptions are now cancelled + the Stripe customer deleted BEFORE the local row is purged. Pair with pad-cloud PR #12 (`/billing/cancel-customer` endpoint, merged).

Without this fix, a paying user who deletes their account keeps getting charged monthly until someone manually cancels in the Stripe dashboard — since we wipe `StripeCustomerID` locally with no upstream cascade, there's no way to even look them up later. Legal + refund risk for every paying user who hits Delete Account.

## Changes

- **`internal/billing/cloud_client.go`** (new) — stateless reverse pad → pad-cloud HTTP client. `CancelCustomer(customerID)` POSTs `{customer_id, cloud_secret}` to `{baseURL}/billing/cancel-customer`. Returns `*SidecarError{Status, Body}` on any non-200 so callers can branch on HTTP status; `IsClientError(err)` classifies 4xx vs everything else (transport / 5xx).
- **`internal/server/server.go`** — adds `CloudSidecar` interface + `SetCloudSidecar(c)` setter. Keeping the concrete type in `internal/billing` so `server` has no Stripe / HTTP-client dependency, and so tests can inject fakes.
- **`internal/server/handlers_account.go`** — before `DeleteAccountAtomic`, if `user.StripeCustomerID != "" && s.cloudSidecar != nil`, call `CancelCustomer`. Failure strategy:
  - Transport / 5xx → `500 billing_cancel_failed`, **abort the delete** so a retry can try again
  - 4xx → log + continue (upstream state is already gone or malformed; retrying won't help and user shouldn't be trapped)
- **`internal/config/config.go` + `cmd/pad/main.go`** — new `PAD_CLOUD_SIDECAR_URL` env var. When set in cloud mode, wires up the reverse client with the first entry of `PAD_CLOUD_SECRET` (matches inbound rotation semantics). When unset, logs a warning but doesn't fail — self-hosted cloud without billing is valid.

## Tests

9 new tests in `internal/billing/cloud_client_test.go` + 7 in `internal/server/handlers_account_test.go` (no existing delete-account coverage). Cover:

- Client: happy-path request shape, 4xx → SidecarError{IsClientError=true}, 5xx → SidecarError{IsClientError=false}, transport failure → plain error (NOT SidecarError), empty/nil input guards, response-body cap enforcement.
- Handler: cancel-before-delete ordering, skips cancel when `StripeCustomerID == ""`, skips when sidecar unconfigured, aborts on transport + 5xx, continues on 4xx, skips cancel on wrong-password (pre-cancel path gate).

### Pre-existing FK bug note

While writing tests I discovered `DeleteAccountAtomic` can't actually delete a user with any audit-log entries (`activities.user_id REFERENCES users(id)` with no ON DELETE action) — so any real account deletion has been failing silently for a while. The tests work around it by pinning the request's `RemoteAddr` to loopback (matching bootstrap's source IP) so the session-IP-change middleware doesn't write an audit row during the request. This is documented in `deleteAccountReq`'s godoc. **Fixing the FK cascade is out of scope for TASK-690** — tracked as follow-up.

## Test plan

- [x] `go build ./... && go vet ./...` — clean
- [x] `go test ./...` — 0 failures, 16 new tests
- [x] `npm run build` (web) — clean
- [x] Inspected pad-cloud PR #12 for request-shape compatibility (body JSON, status codes)