### PR TITLE
feat(cloud): add /admin/stripe-event-unmark endpoint (TASK-736 / 1 of 2)

### DIFF
--- a/internal/models/activity.go
+++ b/internal/models/activity.go
@@ -39,6 +39,12 @@ const (
 	// deployments configured with PAD_IP_CHANGE_ENFORCE=strict the middleware
 	// additionally rejects the request.
 	ActionSessionIPChanged = "session_ip_changed"
+	// ActionStripeEventUnmarked is logged when /admin/stripe-event-unmark
+	// rolls back a row from stripe_processed_events (TASK-736). The
+	// endpoint intentionally reopens Stripe retry windows, so a persisted
+	// audit trail is required — a compromised cloud_secret could otherwise
+	// spam unmarks invisible to the admin /audit-log UI.
+	ActionStripeEventUnmarked = "stripe_event_unmarked"
 )
 
 type Activity struct {

--- a/internal/server/cloud_admin_gate_test.go
+++ b/internal/server/cloud_admin_gate_test.go
@@ -6,7 +6,11 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
+
+	"github.com/xarmian/pad/internal/models"
 )
 
 // cloudAdminReq is a small helper that builds a request with optional JSON body
@@ -46,7 +50,7 @@ func TestCloudAdminGate_SelfHost_Returns404(t *testing.T) {
 		{"POST /admin/stripe-customer-id with header", "POST", "/api/v1/admin/stripe-customer-id", map[string]string{"cloud_secret": "x"}},
 		{"GET /admin/user-by-customer with header", "GET", "/api/v1/admin/user-by-customer?customer_id=cus_x", nil},
 		{"POST /admin/stripe-event-processed with header", "POST", "/api/v1/admin/stripe-event-processed", map[string]string{"cloud_secret": "x", "event_id": "evt_x"}},
-		{"POST /admin/stripe-event-unmark with header", "POST", "/api/v1/admin/stripe-event-unmark", map[string]string{"cloud_secret": "x", "event_id": "evt_x"}},
+		{"POST /admin/stripe-event-unmark with header", "POST", "/api/v1/admin/stripe-event-unmark", map[string]string{"cloud_secret": "x", "event_id": "evt_x", "processed_at": "2025-01-01T00:00:00Z"}},
 	}
 
 	for _, tt := range tests {
@@ -195,6 +199,10 @@ func TestCloudAdminGate_QueryParamSecret_Rejected(t *testing.T) {
 // first call for a given event_id returns already_processed=false; a
 // second call for the same event_id returns already_processed=true. This
 // is what gives the sidecar durable idempotency across restarts.
+//
+// Also covers TASK-736: the response MUST include processed_at, and the
+// duplicate call MUST return the existing row's processed_at (not a fresh
+// one) so the sidecar can store a token that matches the row in the DB.
 func TestStripeEventProcessed_RecordsAndDetectsDuplicates(t *testing.T) {
 	srv := testServer(t)
 	bootstrapFirstUser(t, srv, "admin@example.com", "Admin")
@@ -213,6 +221,7 @@ func TestStripeEventProcessed_RecordsAndDetectsDuplicates(t *testing.T) {
 	var first struct {
 		EventID          string `json:"event_id"`
 		AlreadyProcessed bool   `json:"already_processed"`
+		ProcessedAt      string `json:"processed_at"`
 	}
 	if err := json.Unmarshal(rr.Body.Bytes(), &first); err != nil {
 		t.Fatalf("decode first response: %v", err)
@@ -223,8 +232,12 @@ func TestStripeEventProcessed_RecordsAndDetectsDuplicates(t *testing.T) {
 	if first.EventID != "evt_test_12345" {
 		t.Fatalf("first call returned wrong event_id: %q", first.EventID)
 	}
+	if first.ProcessedAt == "" {
+		t.Fatalf("first call must return a non-empty processed_at for the unmark round-trip")
+	}
 
-	// Second call with same event_id — must be flagged as duplicate.
+	// Second call with same event_id — must be flagged as duplicate AND
+	// return the existing row's processed_at (not a fresh timestamp).
 	req = cloudAdminReq(t, "POST", "/api/v1/admin/stripe-event-processed", map[string]string{
 		"event_id":     "evt_test_12345",
 		"cloud_secret": "shh-its-a-secret",
@@ -237,6 +250,7 @@ func TestStripeEventProcessed_RecordsAndDetectsDuplicates(t *testing.T) {
 	var second struct {
 		EventID          string `json:"event_id"`
 		AlreadyProcessed bool   `json:"already_processed"`
+		ProcessedAt      string `json:"processed_at"`
 	}
 	if err := json.Unmarshal(rr.Body.Bytes(), &second); err != nil {
 		t.Fatalf("decode second response: %v", err)
@@ -244,35 +258,58 @@ func TestStripeEventProcessed_RecordsAndDetectsDuplicates(t *testing.T) {
 	if !second.AlreadyProcessed {
 		t.Fatalf("second call should return already_processed=true")
 	}
+	if second.ProcessedAt != first.ProcessedAt {
+		t.Errorf("duplicate call must return the EXISTING row's processed_at (%q), got %q",
+			first.ProcessedAt, second.ProcessedAt)
+	}
+}
+
+// markEventForUnmarkTest is a helper that POSTs stripe-event-processed and
+// returns the processed_at token the response hands back. Keeps the setup
+// of the unmark tests focused on the unmark semantics.
+func markEventForUnmarkTest(t *testing.T, srv *Server, eventID, secret string) string {
+	t.Helper()
+	req := cloudAdminReq(t, "POST", "/api/v1/admin/stripe-event-processed", map[string]string{
+		"event_id":     eventID,
+		"cloud_secret": secret,
+	}, map[string]string{"X-Cloud-Secret": secret})
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("mark %s: %d %s", eventID, rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		ProcessedAt string `json:"processed_at"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode mark response: %v", err)
+	}
+	if resp.ProcessedAt == "" {
+		t.Fatalf("mark response missing processed_at")
+	}
+	return resp.ProcessedAt
 }
 
 // TestStripeEventUnmark_RoundTripWithMarkProcessed is the happy-path
-// regression for TASK-736: a row previously written by MarkStripeEventProcessed
-// can be deleted by the unmark endpoint, and a subsequent
-// MarkStripeEventProcessed call returns already_processed=false (proving
-// the row really went away and Stripe retries can re-run the handler).
+// regression for TASK-736: a row previously written by /stripe-event-processed
+// can be deleted by the unmark endpoint (given the matching processed_at
+// token), and a subsequent mark call returns already_processed=false
+// (proving the row really went away and Stripe retries can re-run).
 func TestStripeEventUnmark_RoundTripWithMarkProcessed(t *testing.T) {
 	srv := testServer(t)
 	bootstrapFirstUser(t, srv, "admin@example.com", "Admin")
 	srv.SetCloudMode("shh-its-a-secret")
 
-	// 1. Mark an event as processed.
-	req := cloudAdminReq(t, "POST", "/api/v1/admin/stripe-event-processed", map[string]string{
+	// 1. Mark an event as processed and grab the token.
+	token := markEventForUnmarkTest(t, srv, "evt_unmark_roundtrip", "shh-its-a-secret")
+
+	// 2. Unmark it — should report unmarked=true.
+	req := cloudAdminReq(t, "POST", "/api/v1/admin/stripe-event-unmark", map[string]string{
 		"event_id":     "evt_unmark_roundtrip",
+		"processed_at": token,
 		"cloud_secret": "shh-its-a-secret",
 	}, map[string]string{"X-Cloud-Secret": "shh-its-a-secret"})
 	rr := httptest.NewRecorder()
-	srv.ServeHTTP(rr, req)
-	if rr.Code != http.StatusOK {
-		t.Fatalf("mark: %d %s", rr.Code, rr.Body.String())
-	}
-
-	// 2. Unmark it — should report unmarked=true.
-	req = cloudAdminReq(t, "POST", "/api/v1/admin/stripe-event-unmark", map[string]string{
-		"event_id":     "evt_unmark_roundtrip",
-		"cloud_secret": "shh-its-a-secret",
-	}, map[string]string{"X-Cloud-Secret": "shh-its-a-secret"})
-	rr = httptest.NewRecorder()
 	srv.ServeHTTP(rr, req)
 	if rr.Code != http.StatusOK {
 		t.Fatalf("unmark: %d %s", rr.Code, rr.Body.String())
@@ -292,7 +329,6 @@ func TestStripeEventUnmark_RoundTripWithMarkProcessed(t *testing.T) {
 	}
 
 	// 3. Re-mark — now that the row is gone, must report already_processed=false.
-	//    This is the behavior Stripe retries rely on after an unmark.
 	req = cloudAdminReq(t, "POST", "/api/v1/admin/stripe-event-processed", map[string]string{
 		"event_id":     "evt_unmark_roundtrip",
 		"cloud_secret": "shh-its-a-secret",
@@ -313,11 +349,87 @@ func TestStripeEventUnmark_RoundTripWithMarkProcessed(t *testing.T) {
 	}
 }
 
+// TestStripeEventUnmark_StaleTokenIsNoOp addresses the TASK-736 race-
+// protection HIGH: a delayed unmark from an EARLIER failed attempt must
+// NOT delete the fresh marker left by a SUCCESSFUL retry. The composite
+// (event_id, processed_at) delete key enforces this — a stale token
+// simply doesn't match the fresh row.
+func TestStripeEventUnmark_StaleTokenIsNoOp(t *testing.T) {
+	srv := testServer(t)
+	bootstrapFirstUser(t, srv, "admin@example.com", "Admin")
+	srv.SetCloudMode("shh-its-a-secret")
+
+	// Capture the stale token from the first (doomed) attempt.
+	staleTok := markEventForUnmarkTest(t, srv, "evt_race", "shh-its-a-secret")
+
+	// Sidecar rolls back (successful unmark with the stale token).
+	req := cloudAdminReq(t, "POST", "/api/v1/admin/stripe-event-unmark", map[string]string{
+		"event_id":     "evt_race",
+		"processed_at": staleTok,
+		"cloud_secret": "shh-its-a-secret",
+	}, map[string]string{"X-Cloud-Secret": "shh-its-a-secret"})
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("rollback: %d %s", rr.Code, rr.Body.String())
+	}
+
+	// now() has second resolution; wait so the next mark writes a
+	// distinct timestamp. Without this the retry could re-use the same
+	// token and the test assumption collapses.
+	time.Sleep(1100 * time.Millisecond)
+
+	// A successful retry re-marks with a fresh token.
+	freshTok := markEventForUnmarkTest(t, srv, "evt_race", "shh-its-a-secret")
+	if freshTok == staleTok {
+		t.Fatalf("fresh mark reused the stale token (%q) — test setup assumption broken", freshTok)
+	}
+
+	// A delayed stale unmark fires. MUST be a no-op so the fresh row
+	// stays put.
+	req = cloudAdminReq(t, "POST", "/api/v1/admin/stripe-event-unmark", map[string]string{
+		"event_id":     "evt_race",
+		"processed_at": staleTok,
+		"cloud_secret": "shh-its-a-secret",
+	}, map[string]string{"X-Cloud-Secret": "shh-its-a-secret"})
+	rr = httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("stale unmark: %d %s", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		Unmarked bool `json:"unmarked"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode stale unmark: %v", err)
+	}
+	if resp.Unmarked {
+		t.Error("stale unmark must NOT delete the fresh marker (race would reopen retry window)")
+	}
+
+	// Sanity check: marking again still sees the fresh row.
+	req = cloudAdminReq(t, "POST", "/api/v1/admin/stripe-event-processed", map[string]string{
+		"event_id":     "evt_race",
+		"cloud_secret": "shh-its-a-secret",
+	}, map[string]string{"X-Cloud-Secret": "shh-its-a-secret"})
+	rr = httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	var sanity struct {
+		AlreadyProcessed bool   `json:"already_processed"`
+		ProcessedAt      string `json:"processed_at"`
+	}
+	_ = json.Unmarshal(rr.Body.Bytes(), &sanity)
+	if !sanity.AlreadyProcessed {
+		t.Error("fresh marker must still be present after stale unmark")
+	}
+	if sanity.ProcessedAt != freshTok {
+		t.Errorf("token changed unexpectedly; got %q, want %q", sanity.ProcessedAt, freshTok)
+	}
+}
+
 // TestStripeEventUnmark_IdempotentWhenRowMissing verifies the unmark call
-// succeeds with unmarked=false when the event ID was never marked. This is
-// the "unmark retry" case: the sidecar calls Unmark best-effort after a
-// handler failure, but the handler might have failed on a retried event
-// that was already rolled back. Either outcome is a 200.
+// succeeds with unmarked=false when the event ID was never marked. Either
+// outcome is a 200.
 func TestStripeEventUnmark_IdempotentWhenRowMissing(t *testing.T) {
 	srv := testServer(t)
 	bootstrapFirstUser(t, srv, "admin@example.com", "Admin")
@@ -325,6 +437,7 @@ func TestStripeEventUnmark_IdempotentWhenRowMissing(t *testing.T) {
 
 	req := cloudAdminReq(t, "POST", "/api/v1/admin/stripe-event-unmark", map[string]string{
 		"event_id":     "evt_never_marked",
+		"processed_at": "2025-01-01T00:00:00Z",
 		"cloud_secret": "shh-its-a-secret",
 	}, map[string]string{"X-Cloud-Secret": "shh-its-a-secret"})
 	rr := httptest.NewRecorder()
@@ -345,10 +458,7 @@ func TestStripeEventUnmark_IdempotentWhenRowMissing(t *testing.T) {
 }
 
 // TestStripeEventUnmark_RejectsWrongSecret verifies the cloud-secret gate
-// is applied symmetrically with /stripe-event-processed. A sidecar that
-// presents the wrong secret must get a 403, not a 200, so a compromised
-// or misconfigured caller cannot silently reopen Stripe retry windows for
-// arbitrary event IDs.
+// is applied symmetrically with /stripe-event-processed.
 func TestStripeEventUnmark_RejectsWrongSecret(t *testing.T) {
 	srv := testServer(t)
 	bootstrapFirstUser(t, srv, "admin@example.com", "Admin")
@@ -356,6 +466,7 @@ func TestStripeEventUnmark_RejectsWrongSecret(t *testing.T) {
 
 	req := cloudAdminReq(t, "POST", "/api/v1/admin/stripe-event-unmark", map[string]string{
 		"event_id":     "evt_x",
+		"processed_at": "2025-01-01T00:00:00Z",
 		"cloud_secret": "wrong-secret",
 	}, map[string]string{"X-Cloud-Secret": "wrong-secret"})
 	rr := httptest.NewRecorder()
@@ -366,9 +477,30 @@ func TestStripeEventUnmark_RejectsWrongSecret(t *testing.T) {
 	}
 }
 
+// TestStripeEventUnmark_RequiresProcessedAt verifies that a missing
+// processed_at field produces a 400 rather than falling back to any
+// fallback-by-event-id behaviour. The processed_at is the race-protection
+// contract; dropping it would be unsafe.
+func TestStripeEventUnmark_RequiresProcessedAt(t *testing.T) {
+	srv := testServer(t)
+	bootstrapFirstUser(t, srv, "admin@example.com", "Admin")
+	srv.SetCloudMode("shh-its-a-secret")
+
+	req := cloudAdminReq(t, "POST", "/api/v1/admin/stripe-event-unmark", map[string]string{
+		"event_id": "evt_x",
+		// processed_at intentionally omitted
+		"cloud_secret": "shh-its-a-secret",
+	}, map[string]string{"X-Cloud-Secret": "shh-its-a-secret"})
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 without processed_at, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
 // TestStripeEventUnmark_ValidatesEventIDPrefix verifies the handler
-// rejects event IDs that don't start with 'evt_', matching the
-// /stripe-event-processed contract.
+// rejects event IDs that don't start with 'evt_'.
 func TestStripeEventUnmark_ValidatesEventIDPrefix(t *testing.T) {
 	srv := testServer(t)
 	bootstrapFirstUser(t, srv, "admin@example.com", "Admin")
@@ -386,6 +518,7 @@ func TestStripeEventUnmark_ValidatesEventIDPrefix(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			req := cloudAdminReq(t, "POST", "/api/v1/admin/stripe-event-unmark", map[string]string{
 				"event_id":     tt.eventID,
+				"processed_at": "2025-01-01T00:00:00Z",
 				"cloud_secret": "shh-its-a-secret",
 			}, map[string]string{"X-Cloud-Secret": "shh-its-a-secret"})
 			rr := httptest.NewRecorder()
@@ -394,6 +527,53 @@ func TestStripeEventUnmark_ValidatesEventIDPrefix(t *testing.T) {
 				t.Fatalf("%s: expected 400, got %d: %s", tt.name, rr.Code, rr.Body.String())
 			}
 		})
+	}
+}
+
+// TestStripeEventUnmark_WritesAuditLog is the TASK-736 durable-audit
+// finding fix: a successful unmark MUST emit an ActionStripeEventUnmarked
+// audit entry so admins can see who reopened retry windows and when. slog
+// alone is not enough (no actor, not queryable via /audit-log).
+func TestStripeEventUnmark_WritesAuditLog(t *testing.T) {
+	srv := testServer(t)
+	bootstrapFirstUser(t, srv, "admin@example.com", "Admin")
+	srv.SetCloudMode("shh-its-a-secret")
+
+	token := markEventForUnmarkTest(t, srv, "evt_audit", "shh-its-a-secret")
+
+	req := cloudAdminReq(t, "POST", "/api/v1/admin/stripe-event-unmark", map[string]string{
+		"event_id":     "evt_audit",
+		"processed_at": token,
+		"cloud_secret": "shh-its-a-secret",
+	}, map[string]string{"X-Cloud-Secret": "shh-its-a-secret"})
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("unmark: %d %s", rr.Code, rr.Body.String())
+	}
+
+	// Verify an audit row exists via the audit-log query interface.
+	activities, err := srv.store.ListAuditLog(models.AuditLogParams{Action: models.ActionStripeEventUnmarked, Limit: 10})
+	if err != nil {
+		t.Fatalf("list audit log: %v", err)
+	}
+	if len(activities) == 0 {
+		t.Fatal("no ActionStripeEventUnmarked activity was logged")
+	}
+	// Find the one we just created.
+	var found bool
+	for _, a := range activities {
+		if strings.Contains(a.Metadata, "evt_audit") {
+			found = true
+			// Metadata should record unmarked=true.
+			if !strings.Contains(a.Metadata, `"unmarked":"true"`) {
+				t.Errorf("expected unmarked=true in metadata, got %q", a.Metadata)
+			}
+			break
+		}
+	}
+	if !found {
+		t.Errorf("no audit entry contained event_id=evt_audit; got %d entries", len(activities))
 	}
 }
 

--- a/internal/server/cloud_admin_gate_test.go
+++ b/internal/server/cloud_admin_gate_test.go
@@ -46,6 +46,7 @@ func TestCloudAdminGate_SelfHost_Returns404(t *testing.T) {
 		{"POST /admin/stripe-customer-id with header", "POST", "/api/v1/admin/stripe-customer-id", map[string]string{"cloud_secret": "x"}},
 		{"GET /admin/user-by-customer with header", "GET", "/api/v1/admin/user-by-customer?customer_id=cus_x", nil},
 		{"POST /admin/stripe-event-processed with header", "POST", "/api/v1/admin/stripe-event-processed", map[string]string{"cloud_secret": "x", "event_id": "evt_x"}},
+		{"POST /admin/stripe-event-unmark with header", "POST", "/api/v1/admin/stripe-event-unmark", map[string]string{"cloud_secret": "x", "event_id": "evt_x"}},
 	}
 
 	for _, tt := range tests {
@@ -242,6 +243,157 @@ func TestStripeEventProcessed_RecordsAndDetectsDuplicates(t *testing.T) {
 	}
 	if !second.AlreadyProcessed {
 		t.Fatalf("second call should return already_processed=true")
+	}
+}
+
+// TestStripeEventUnmark_RoundTripWithMarkProcessed is the happy-path
+// regression for TASK-736: a row previously written by MarkStripeEventProcessed
+// can be deleted by the unmark endpoint, and a subsequent
+// MarkStripeEventProcessed call returns already_processed=false (proving
+// the row really went away and Stripe retries can re-run the handler).
+func TestStripeEventUnmark_RoundTripWithMarkProcessed(t *testing.T) {
+	srv := testServer(t)
+	bootstrapFirstUser(t, srv, "admin@example.com", "Admin")
+	srv.SetCloudMode("shh-its-a-secret")
+
+	// 1. Mark an event as processed.
+	req := cloudAdminReq(t, "POST", "/api/v1/admin/stripe-event-processed", map[string]string{
+		"event_id":     "evt_unmark_roundtrip",
+		"cloud_secret": "shh-its-a-secret",
+	}, map[string]string{"X-Cloud-Secret": "shh-its-a-secret"})
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("mark: %d %s", rr.Code, rr.Body.String())
+	}
+
+	// 2. Unmark it — should report unmarked=true.
+	req = cloudAdminReq(t, "POST", "/api/v1/admin/stripe-event-unmark", map[string]string{
+		"event_id":     "evt_unmark_roundtrip",
+		"cloud_secret": "shh-its-a-secret",
+	}, map[string]string{"X-Cloud-Secret": "shh-its-a-secret"})
+	rr = httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("unmark: %d %s", rr.Code, rr.Body.String())
+	}
+	var unmarkResp struct {
+		EventID  string `json:"event_id"`
+		Unmarked bool   `json:"unmarked"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &unmarkResp); err != nil {
+		t.Fatalf("decode unmark: %v", err)
+	}
+	if !unmarkResp.Unmarked {
+		t.Errorf("unmark should return unmarked=true when row existed")
+	}
+	if unmarkResp.EventID != "evt_unmark_roundtrip" {
+		t.Errorf("unmark returned wrong event_id: %q", unmarkResp.EventID)
+	}
+
+	// 3. Re-mark — now that the row is gone, must report already_processed=false.
+	//    This is the behavior Stripe retries rely on after an unmark.
+	req = cloudAdminReq(t, "POST", "/api/v1/admin/stripe-event-processed", map[string]string{
+		"event_id":     "evt_unmark_roundtrip",
+		"cloud_secret": "shh-its-a-secret",
+	}, map[string]string{"X-Cloud-Secret": "shh-its-a-secret"})
+	rr = httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("re-mark: %d %s", rr.Code, rr.Body.String())
+	}
+	var remark struct {
+		AlreadyProcessed bool `json:"already_processed"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &remark); err != nil {
+		t.Fatalf("decode re-mark: %v", err)
+	}
+	if remark.AlreadyProcessed {
+		t.Errorf("after unmark, re-mark must return already_processed=false (retry path broken)")
+	}
+}
+
+// TestStripeEventUnmark_IdempotentWhenRowMissing verifies the unmark call
+// succeeds with unmarked=false when the event ID was never marked. This is
+// the "unmark retry" case: the sidecar calls Unmark best-effort after a
+// handler failure, but the handler might have failed on a retried event
+// that was already rolled back. Either outcome is a 200.
+func TestStripeEventUnmark_IdempotentWhenRowMissing(t *testing.T) {
+	srv := testServer(t)
+	bootstrapFirstUser(t, srv, "admin@example.com", "Admin")
+	srv.SetCloudMode("shh-its-a-secret")
+
+	req := cloudAdminReq(t, "POST", "/api/v1/admin/stripe-event-unmark", map[string]string{
+		"event_id":     "evt_never_marked",
+		"cloud_secret": "shh-its-a-secret",
+	}, map[string]string{"X-Cloud-Secret": "shh-its-a-secret"})
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 on missing-row unmark, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		Unmarked bool `json:"unmarked"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Unmarked {
+		t.Errorf("unmark of missing row must return unmarked=false")
+	}
+}
+
+// TestStripeEventUnmark_RejectsWrongSecret verifies the cloud-secret gate
+// is applied symmetrically with /stripe-event-processed. A sidecar that
+// presents the wrong secret must get a 403, not a 200, so a compromised
+// or misconfigured caller cannot silently reopen Stripe retry windows for
+// arbitrary event IDs.
+func TestStripeEventUnmark_RejectsWrongSecret(t *testing.T) {
+	srv := testServer(t)
+	bootstrapFirstUser(t, srv, "admin@example.com", "Admin")
+	srv.SetCloudMode("the-real-secret")
+
+	req := cloudAdminReq(t, "POST", "/api/v1/admin/stripe-event-unmark", map[string]string{
+		"event_id":     "evt_x",
+		"cloud_secret": "wrong-secret",
+	}, map[string]string{"X-Cloud-Secret": "wrong-secret"})
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 on wrong secret, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+// TestStripeEventUnmark_ValidatesEventIDPrefix verifies the handler
+// rejects event IDs that don't start with 'evt_', matching the
+// /stripe-event-processed contract.
+func TestStripeEventUnmark_ValidatesEventIDPrefix(t *testing.T) {
+	srv := testServer(t)
+	bootstrapFirstUser(t, srv, "admin@example.com", "Admin")
+	srv.SetCloudMode("shh-its-a-secret")
+
+	tests := []struct {
+		name    string
+		eventID string
+	}{
+		{"empty event_id", ""},
+		{"missing evt_ prefix", "sub_12345"},
+		{"wrong prefix cus_", "cus_12345"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := cloudAdminReq(t, "POST", "/api/v1/admin/stripe-event-unmark", map[string]string{
+				"event_id":     tt.eventID,
+				"cloud_secret": "shh-its-a-secret",
+			}, map[string]string{"X-Cloud-Secret": "shh-its-a-secret"})
+			rr := httptest.NewRecorder()
+			srv.ServeHTTP(rr, req)
+			if rr.Code != http.StatusBadRequest {
+				t.Fatalf("%s: expected 400, got %d: %s", tt.name, rr.Code, rr.Body.String())
+			}
+		})
 	}
 }
 

--- a/internal/server/handlers_cloud.go
+++ b/internal/server/handlers_cloud.go
@@ -63,6 +63,7 @@ var cloudAdminPaths = map[string]struct{}{
 	"/api/v1/admin/stripe-customer-id":     {},
 	"/api/v1/admin/user-by-customer":       {},
 	"/api/v1/admin/stripe-event-processed": {},
+	"/api/v1/admin/stripe-event-unmark":    {},
 }
 
 // isCloudAdminPath returns true if the request targets one of the three
@@ -717,6 +718,81 @@ func (s *Server) handleStripeEventProcessed(w http.ResponseWriter, r *http.Reque
 	writeJSON(w, http.StatusOK, map[string]interface{}{
 		"event_id":          input.EventID,
 		"already_processed": alreadyProcessed,
+	})
+}
+
+// handleStripeEventUnmark handles POST /api/v1/admin/stripe-event-unmark.
+// Called by the pad-cloud sidecar as a best-effort rollback when a webhook
+// handler fails AFTER /stripe-event-processed marked the event as seen
+// (TASK-736). Without this, Stripe's retries of the same event are
+// short-circuited as duplicates and the un-applied side effect has no
+// automated recovery — operators have to manually DELETE the row and
+// replay from the Stripe dashboard.
+//
+// Request body:
+//
+//	{"event_id": "evt_xxx", "cloud_secret": "..."}
+//
+// Response:
+//
+//	{"event_id": "evt_xxx", "unmarked": true|false}
+//
+// Semantics: idempotent. unmarked=true means we actually deleted a row;
+// unmarked=false means the event ID was not present (safe — a retry of
+// the unmark call after a successful re-process is a no-op). Either
+// outcome is 200.
+//
+// Auth: same cloud_secret gate as /stripe-event-processed. Admins hitting
+// the endpoint with a browser session can also unmark (useful for manual
+// reconciliation from the admin UI), mirroring the pattern of the
+// other cloud admin endpoints.
+func (s *Server) handleStripeEventUnmark(w http.ResponseWriter, r *http.Request) {
+	var input struct {
+		EventID     string `json:"event_id"`
+		CloudSecret string `json:"cloud_secret"`
+	}
+	if err := decodeJSON(r, &input); err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", "Invalid request body")
+		return
+	}
+
+	// 1. Validate cloud secret (body field for POST; admins also allowed).
+	user := currentUser(r)
+	isAdmin := user != nil && user.Role == "admin"
+	if !isAdmin {
+		if !s.validateCloudSecret(input.CloudSecret, w) {
+			return
+		}
+	}
+
+	// 2. Validate input — must match the shape /stripe-event-processed accepts
+	//    so that an operator copying an event ID from the Stripe dashboard
+	//    gets the same format validation across both endpoints.
+	if input.EventID == "" {
+		writeError(w, http.StatusBadRequest, "bad_request", "event_id is required")
+		return
+	}
+	if !strings.HasPrefix(input.EventID, "evt_") {
+		writeError(w, http.StatusBadRequest, "bad_request", "event_id must start with 'evt_'")
+		return
+	}
+
+	// 3. Delete the row (idempotent — missing row is fine).
+	unmarked, err := s.store.UnmarkStripeEventProcessed(input.EventID)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+
+	if unmarked {
+		slog.Info("unmarked stripe event for replay", "event_id", input.EventID, "actor_is_admin", isAdmin)
+	} else {
+		slog.Info("unmark stripe event: no row existed (idempotent)", "event_id", input.EventID, "actor_is_admin", isAdmin)
+	}
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"event_id": input.EventID,
+		"unmarked": unmarked,
 	})
 }
 

--- a/internal/server/handlers_cloud.go
+++ b/internal/server/handlers_cloud.go
@@ -652,7 +652,14 @@ func (s *Server) handleGetUserByCustomerID(w http.ResponseWriter, r *http.Reques
 //
 // Response:
 //
-//	{"already_processed": true|false, "event_id": "evt_xxx"}
+//	{"event_id": "evt_xxx", "already_processed": true|false, "processed_at": "RFC3339"}
+//
+// The processed_at field is the row's timestamp: the one we just inserted on
+// a fresh mark, or the existing row's timestamp on a duplicate. Sidecars
+// MUST persist this value and pass it back to /admin/stripe-event-unmark if
+// they later need to roll back a failed handler (TASK-736 race protection:
+// the unmark call uses (event_id, processed_at) as a composite key, so a
+// stale unmark can't delete a fresh marker left by a successful retry).
 //
 // Semantics: the call is transactional — it atomically records the event and
 // tells the caller whether it was new or a duplicate. The caller should skip
@@ -692,7 +699,7 @@ func (s *Server) handleStripeEventProcessed(w http.ResponseWriter, r *http.Reque
 	}
 
 	// 3. Atomically record-or-detect-duplicate
-	alreadyProcessed, err := s.store.MarkStripeEventProcessed(input.EventID)
+	alreadyProcessed, processedAt, err := s.store.MarkStripeEventProcessed(input.EventID)
 	if err != nil {
 		writeInternalError(w, err)
 		return
@@ -718,6 +725,7 @@ func (s *Server) handleStripeEventProcessed(w http.ResponseWriter, r *http.Reque
 	writeJSON(w, http.StatusOK, map[string]interface{}{
 		"event_id":          input.EventID,
 		"already_processed": alreadyProcessed,
+		"processed_at":      processedAt,
 	})
 }
 
@@ -731,16 +739,27 @@ func (s *Server) handleStripeEventProcessed(w http.ResponseWriter, r *http.Reque
 //
 // Request body:
 //
-//	{"event_id": "evt_xxx", "cloud_secret": "..."}
+//	{"event_id": "evt_xxx", "processed_at": "RFC3339", "cloud_secret": "..."}
 //
 // Response:
 //
 //	{"event_id": "evt_xxx", "unmarked": true|false}
 //
-// Semantics: idempotent. unmarked=true means we actually deleted a row;
-// unmarked=false means the event ID was not present (safe — a retry of
-// the unmark call after a successful re-process is a no-op). Either
-// outcome is 200.
+// Semantics: the delete is scoped to the specific (event_id, processed_at)
+// row originally inserted by /stripe-event-processed. processed_at is
+// mandatory — without it, a stale unmark from an earlier failed attempt
+// could silently delete the fresh marker left by a successful retry and
+// reopen the retry window after the event has been handled. With it, a
+// stale token simply doesn't match and the unmark becomes a no-op.
+//
+// Idempotent: unmarked=true means we actually deleted a row; unmarked=false
+// means nothing matched (missing row OR timestamp mismatch — both safe).
+// Either outcome is 200.
+//
+// Audit: every call is persisted to the audit log (ActionStripeEventUnmarked)
+// with the event_id and whether a row actually went away. The endpoint can
+// reopen Stripe retry windows, so a queryable audit trail is required —
+// slog alone would let a compromised cloud_secret spam unmarks invisibly.
 //
 // Auth: same cloud_secret gate as /stripe-event-processed. Admins hitting
 // the endpoint with a browser session can also unmark (useful for manual
@@ -749,6 +768,7 @@ func (s *Server) handleStripeEventProcessed(w http.ResponseWriter, r *http.Reque
 func (s *Server) handleStripeEventUnmark(w http.ResponseWriter, r *http.Request) {
 	var input struct {
 		EventID     string `json:"event_id"`
+		ProcessedAt string `json:"processed_at"`
 		CloudSecret string `json:"cloud_secret"`
 	}
 	if err := decodeJSON(r, &input); err != nil {
@@ -767,7 +787,8 @@ func (s *Server) handleStripeEventUnmark(w http.ResponseWriter, r *http.Request)
 
 	// 2. Validate input — must match the shape /stripe-event-processed accepts
 	//    so that an operator copying an event ID from the Stripe dashboard
-	//    gets the same format validation across both endpoints.
+	//    gets the same format validation across both endpoints. processed_at
+	//    is mandatory for race protection (see handler godoc).
 	if input.EventID == "" {
 		writeError(w, http.StatusBadRequest, "bad_request", "event_id is required")
 		return
@@ -776,24 +797,54 @@ func (s *Server) handleStripeEventUnmark(w http.ResponseWriter, r *http.Request)
 		writeError(w, http.StatusBadRequest, "bad_request", "event_id must start with 'evt_'")
 		return
 	}
+	if input.ProcessedAt == "" {
+		writeError(w, http.StatusBadRequest, "bad_request", "processed_at is required (pass the value returned by /stripe-event-processed)")
+		return
+	}
 
-	// 3. Delete the row (idempotent — missing row is fine).
-	unmarked, err := s.store.UnmarkStripeEventProcessed(input.EventID)
+	// 3. Delete the row only if (event_id, processed_at) matches.
+	unmarked, err := s.store.UnmarkStripeEventProcessed(input.EventID, input.ProcessedAt)
 	if err != nil {
 		writeInternalError(w, err)
 		return
 	}
 
+	// 4. Audit log — persisted so admins can see who/when reopened retry
+	//    windows. actor_is_admin distinguishes "manual operator action" from
+	//    "sidecar rollback" so dashboards can filter accordingly.
+	actorID := ""
+	if user != nil {
+		actorID = user.ID
+	}
+	s.logAuditEventForUser(models.ActionStripeEventUnmarked, r, actorID, auditMeta(map[string]string{
+		"event_id":       input.EventID,
+		"processed_at":   input.ProcessedAt,
+		"unmarked":       boolToString(unmarked),
+		"actor_is_admin": boolToString(isAdmin),
+	}))
+
 	if unmarked {
 		slog.Info("unmarked stripe event for replay", "event_id", input.EventID, "actor_is_admin", isAdmin)
 	} else {
-		slog.Info("unmark stripe event: no row existed (idempotent)", "event_id", input.EventID, "actor_is_admin", isAdmin)
+		slog.Info("unmark stripe event: no matching row (idempotent)", "event_id", input.EventID, "actor_is_admin", isAdmin)
 	}
 
 	writeJSON(w, http.StatusOK, map[string]interface{}{
 		"event_id": input.EventID,
 		"unmarked": unmarked,
 	})
+}
+
+// boolToString converts a Go bool to the string representation used in
+// audit metadata. Kept local to this file because audit metadata is
+// string-typed (JSON object of string→string), so we need the literal
+// "true"/"false" spelling rather than fmt.Sprintf's lower-case default
+// (which happens to match but is easy to misread).
+func boolToString(b bool) string {
+	if b {
+		return "true"
+	}
+	return "false"
 }
 
 // --- Public Plan Limits (TASK-511) ---

--- a/internal/server/middleware_ratelimit.go
+++ b/internal/server/middleware_ratelimit.go
@@ -236,7 +236,7 @@ func (s *Server) RateLimit(next http.Handler) http.Handler {
 		// Cloud admin endpoints (sidecar → pad): plan changes, Stripe mapping, user lookup
 		if strings.HasPrefix(path, "/api/v1/admin/") {
 			switch path {
-			case "/api/v1/admin/plan", "/api/v1/admin/stripe-customer-id", "/api/v1/admin/user-by-customer", "/api/v1/admin/stripe-event-processed":
+			case "/api/v1/admin/plan", "/api/v1/admin/stripe-customer-id", "/api/v1/admin/user-by-customer", "/api/v1/admin/stripe-event-processed", "/api/v1/admin/stripe-event-unmark":
 				l := s.rateLimiters.CloudAdmin.getLimiter(ip)
 				if !l.Allow() {
 					slog.Warn("rate limited", "ip", ip, "path", path, "limiter", "cloud_admin")

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -444,6 +444,7 @@ func (s *Server) setupRouter() {
 					r.Post("/stripe-customer-id", s.handleSetStripeCustomerID)      // Cloud: sidecar stores Stripe customer ID after checkout
 					r.Get("/user-by-customer", s.handleGetUserByCustomerID)         // Cloud: sidecar looks up user by Stripe customer ID
 					r.Post("/stripe-event-processed", s.handleStripeEventProcessed) // Cloud: sidecar webhook idempotency (TASK-696)
+					r.Post("/stripe-event-unmark", s.handleStripeEventUnmark)       // Cloud: sidecar handler-failure rollback (TASK-736)
 				})
 
 				// User management

--- a/internal/store/stripe_events.go
+++ b/internal/store/stripe_events.go
@@ -8,61 +8,95 @@ import (
 )
 
 // MarkStripeEventProcessed records a Stripe webhook event ID in
-// stripe_processed_events if it hasn't been seen before. Returns true when the
-// event was ALREADY recorded (i.e. the caller is seeing a duplicate Stripe
-// retry and should skip re-processing). Returns false for first-time events
-// (caller should run its handler logic).
+// stripe_processed_events if it hasn't been seen before. Returns
+// alreadyProcessed=true when the event was ALREADY recorded (i.e. the caller
+// is seeing a duplicate Stripe retry and should skip re-processing). Returns
+// false for first-time events (caller should run its handler logic).
 //
-// Implementation uses INSERT ... ON CONFLICT DO NOTHING and inspects the
-// RowsAffected count: 1 means we inserted (new), 0 means the row was already
-// present (duplicate). Both cases are success — only real DB errors propagate.
-func (s *Store) MarkStripeEventProcessed(eventID string) (alreadyProcessed bool, err error) {
+// Always returns processedAt — either the timestamp we just inserted (on a
+// fresh mark) or the existing row's timestamp (on a duplicate). Sidecars
+// MUST persist this string and pass it back to UnmarkStripeEventProcessed if
+// a best-effort rollback is later needed (TASK-736): the unmark uses
+// (event_id, processed_at) as a composite key, so a stale unmark from an
+// earlier attempt can't delete the fresh marker left by a successful retry.
+//
+// Implementation uses INSERT ... ON CONFLICT DO NOTHING. On fresh insert we
+// return the wall-clock we just wrote; on conflict we SELECT the existing
+// row to recover its timestamp. Both cases are success — only real DB
+// errors propagate.
+func (s *Store) MarkStripeEventProcessed(eventID string) (alreadyProcessed bool, processedAt string, err error) {
 	if eventID == "" {
-		return false, fmt.Errorf("mark stripe event: event_id is required")
+		return false, "", fmt.Errorf("mark stripe event: event_id is required")
 	}
 
+	ts := now()
 	res, err := s.db.Exec(
 		s.q(`INSERT INTO stripe_processed_events (event_id, processed_at) VALUES (?, ?) ON CONFLICT (event_id) DO NOTHING`),
-		eventID, now(),
+		eventID, ts,
 	)
 	if err != nil {
-		return false, fmt.Errorf("mark stripe event %s: %w", eventID, err)
+		return false, "", fmt.Errorf("mark stripe event %s: %w", eventID, err)
 	}
 
-	n, err := res.RowsAffected()
-	if err != nil {
-		// Some drivers don't report RowsAffected reliably after ON CONFLICT;
-		// in that case we can't tell whether this was the first insert. Treat
-		// as "not already processed" and let the caller run its handler (the
-		// event handler itself is idempotent at the application level — e.g.
-		// set_plan is an UPSERT).
-		return false, nil
+	n, rowsErr := res.RowsAffected()
+	if rowsErr == nil && n == 1 {
+		// Fresh insert — ts is authoritative and the unmark token.
+		return false, ts, nil
 	}
 
-	// 1 row affected = we inserted a new row = first-time event.
-	// 0 rows affected = ON CONFLICT DO NOTHING fired = duplicate.
-	return n == 0, nil
+	// Conflict (or driver couldn't report RowsAffected). Recover the
+	// existing row's processed_at so the caller has a token matching the
+	// row currently in the table — without this a retried-and-successful
+	// handler has no way for its future unmark call to target the right
+	// marker.
+	var existing string
+	selErr := s.db.QueryRow(
+		s.q(`SELECT processed_at FROM stripe_processed_events WHERE event_id = ?`),
+		eventID,
+	).Scan(&existing)
+	if selErr != nil {
+		// The row really isn't there (possible under a driver that didn't
+		// report RowsAffected AND a concurrent delete) — treat as fresh
+		// so the handler can still run. processedAt=ts may not match the
+		// actual DB row in this unusual case; that's acceptable because
+		// the sidecar handler is idempotent at the application level (set
+		// plan is an UPSERT, webhook handlers are defensively safe).
+		return false, ts, nil
+	}
+	return true, existing, nil
 }
 
 // UnmarkStripeEventProcessed deletes a row from stripe_processed_events,
 // allowing Stripe retries of the same event ID to be handled again (TASK-736).
 // Used by the sidecar as a best-effort rollback when the webhook handler
-// fails AFTER MarkStripeEventProcessed succeeded: without this, the event
-// stays marked "processed" and Stripe's retries are short-circuited before
-// they can rerun the handler, leaving the side effect un-applied with no
-// automated recovery path.
+// fails AFTER MarkStripeEventProcessed succeeded.
 //
-// Returns true when a row was actually deleted, false when the row was not
-// present (idempotent — a retry of the unmark call after a successful
-// re-process is not an error). Only real DB failures propagate.
-func (s *Store) UnmarkStripeEventProcessed(eventID string) (unmarked bool, err error) {
+// Race protection: the delete is scoped to the specific (event_id,
+// processed_at) pair the caller was handed by MarkStripeEventProcessed.
+// A delayed unmark from an earlier failed attempt can NOT delete a fresh
+// marker left by a successful retry, because the retry wrote a new
+// processed_at timestamp that no longer matches the stale token — so the
+// unmark becomes a safe no-op instead of reopening the retry window
+// after the event has already been handled. The sidecar must therefore
+// persist the processed_at it received from Mark and pass it here.
+//
+// Returns true when a row was actually deleted, false when nothing
+// matched (missing row OR a timestamp mismatch — both safe as no-ops).
+// Only real DB failures propagate.
+func (s *Store) UnmarkStripeEventProcessed(eventID, processedAt string) (unmarked bool, err error) {
 	if eventID == "" {
 		return false, fmt.Errorf("unmark stripe event: event_id is required")
 	}
+	if processedAt == "" {
+		// Refuse to delete without the processed_at token. Otherwise a
+		// caller that misplaces the token would fall back to deleting by
+		// event_id alone, defeating the race-protection contract.
+		return false, fmt.Errorf("unmark stripe event: processed_at is required (race protection)")
+	}
 
 	res, err := s.db.Exec(
-		s.q(`DELETE FROM stripe_processed_events WHERE event_id = ?`),
-		eventID,
+		s.q(`DELETE FROM stripe_processed_events WHERE event_id = ? AND processed_at = ?`),
+		eventID, processedAt,
 	)
 	if err != nil {
 		return false, fmt.Errorf("unmark stripe event %s: %w", eventID, err)
@@ -72,8 +106,6 @@ func (s *Store) UnmarkStripeEventProcessed(eventID string) (unmarked bool, err e
 	if err != nil {
 		// Drivers that don't report RowsAffected reliably — treat as
 		// success without asserting whether we actually deleted anything.
-		// Callers tolerate either outcome; the whole point is to make a
-		// retry possible, and if the row never existed a retry is a no-op.
 		return false, nil
 	}
 	return n > 0, nil

--- a/internal/store/stripe_events.go
+++ b/internal/store/stripe_events.go
@@ -44,6 +44,41 @@ func (s *Store) MarkStripeEventProcessed(eventID string) (alreadyProcessed bool,
 	return n == 0, nil
 }
 
+// UnmarkStripeEventProcessed deletes a row from stripe_processed_events,
+// allowing Stripe retries of the same event ID to be handled again (TASK-736).
+// Used by the sidecar as a best-effort rollback when the webhook handler
+// fails AFTER MarkStripeEventProcessed succeeded: without this, the event
+// stays marked "processed" and Stripe's retries are short-circuited before
+// they can rerun the handler, leaving the side effect un-applied with no
+// automated recovery path.
+//
+// Returns true when a row was actually deleted, false when the row was not
+// present (idempotent — a retry of the unmark call after a successful
+// re-process is not an error). Only real DB failures propagate.
+func (s *Store) UnmarkStripeEventProcessed(eventID string) (unmarked bool, err error) {
+	if eventID == "" {
+		return false, fmt.Errorf("unmark stripe event: event_id is required")
+	}
+
+	res, err := s.db.Exec(
+		s.q(`DELETE FROM stripe_processed_events WHERE event_id = ?`),
+		eventID,
+	)
+	if err != nil {
+		return false, fmt.Errorf("unmark stripe event %s: %w", eventID, err)
+	}
+
+	n, err := res.RowsAffected()
+	if err != nil {
+		// Drivers that don't report RowsAffected reliably — treat as
+		// success without asserting whether we actually deleted anything.
+		// Callers tolerate either outcome; the whole point is to make a
+		// retry possible, and if the row never existed a retry is a no-op.
+		return false, nil
+	}
+	return n > 0, nil
+}
+
 // PruneStripeProcessedEvents deletes stripe_processed_events rows older than
 // maxAge. Returns the number of rows removed. Intended to be called on a
 // schedule (or opportunistically — see MarkStripeEventProcessed callers);

--- a/internal/store/stripe_events_test.go
+++ b/internal/store/stripe_events_test.go
@@ -1,0 +1,80 @@
+package store
+
+import "testing"
+
+// TestUnmarkStripeEventProcessed_RoundTrip exercises the mark → unmark → re-mark
+// cycle that the sidecar relies on for TASK-736. After an unmark, the SAME
+// event ID must behave as brand-new on the next mark call so Stripe
+// retries can re-run the handler. A bug that made unmark a no-op (e.g.
+// wrong WHERE clause) would break this invariant.
+func TestUnmarkStripeEventProcessed_RoundTrip(t *testing.T) {
+	s := testStore(t)
+
+	// Mark a fresh event.
+	already, err := s.MarkStripeEventProcessed("evt_roundtrip")
+	if err != nil {
+		t.Fatalf("mark: %v", err)
+	}
+	if already {
+		t.Fatal("first mark must return already_processed=false")
+	}
+
+	// Duplicate mark — must be detected.
+	already, err = s.MarkStripeEventProcessed("evt_roundtrip")
+	if err != nil {
+		t.Fatalf("re-mark before unmark: %v", err)
+	}
+	if !already {
+		t.Fatal("second mark (no unmark yet) must detect duplicate")
+	}
+
+	// Unmark — row existed.
+	unmarked, err := s.UnmarkStripeEventProcessed("evt_roundtrip")
+	if err != nil {
+		t.Fatalf("unmark: %v", err)
+	}
+	if !unmarked {
+		t.Fatal("unmark of existing row must return unmarked=true")
+	}
+
+	// Re-mark — row is gone, must be treated as brand-new so the handler
+	// can run again. This is the whole point of the endpoint.
+	already, err = s.MarkStripeEventProcessed("evt_roundtrip")
+	if err != nil {
+		t.Fatalf("re-mark after unmark: %v", err)
+	}
+	if already {
+		t.Fatal("mark after unmark must return already_processed=false (retry path broken)")
+	}
+}
+
+// TestUnmarkStripeEventProcessed_MissingRow verifies idempotency: calling
+// unmark for an event ID that was never marked returns (false, nil). The
+// sidecar uses unmark as a best-effort rollback, so it may fire for an
+// event that Stripe retried (meaning the row already got unmarked and
+// remarked between attempts); a hard error in that case would mask real
+// problems in the sidecar logs.
+func TestUnmarkStripeEventProcessed_MissingRow(t *testing.T) {
+	s := testStore(t)
+
+	unmarked, err := s.UnmarkStripeEventProcessed("evt_never_marked")
+	if err != nil {
+		t.Fatalf("unexpected error for missing row: %v", err)
+	}
+	if unmarked {
+		t.Error("unmark of non-existent row must return unmarked=false")
+	}
+}
+
+// TestUnmarkStripeEventProcessed_RejectsEmptyID guards against accidental
+// "delete every row" calls through a nil/empty event_id. The handler
+// already rejects at the HTTP layer, but the store method is exported
+// and called in tests, so defensive empty-input rejection matters.
+func TestUnmarkStripeEventProcessed_RejectsEmptyID(t *testing.T) {
+	s := testStore(t)
+
+	_, err := s.UnmarkStripeEventProcessed("")
+	if err == nil {
+		t.Fatal("empty event_id must return an error")
+	}
+}

--- a/internal/store/stripe_events_test.go
+++ b/internal/store/stripe_events_test.go
@@ -1,6 +1,9 @@
 package store
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 // TestUnmarkStripeEventProcessed_RoundTrip exercises the mark → unmark → re-mark
 // cycle that the sidecar relies on for TASK-736. After an unmark, the SAME
@@ -11,35 +14,41 @@ func TestUnmarkStripeEventProcessed_RoundTrip(t *testing.T) {
 	s := testStore(t)
 
 	// Mark a fresh event.
-	already, err := s.MarkStripeEventProcessed("evt_roundtrip")
+	already, tok1, err := s.MarkStripeEventProcessed("evt_roundtrip")
 	if err != nil {
 		t.Fatalf("mark: %v", err)
 	}
 	if already {
 		t.Fatal("first mark must return already_processed=false")
 	}
+	if tok1 == "" {
+		t.Fatal("first mark must return a non-empty processed_at token")
+	}
 
-	// Duplicate mark — must be detected.
-	already, err = s.MarkStripeEventProcessed("evt_roundtrip")
+	// Duplicate mark — must be detected. Token must match the original.
+	already, tok2, err := s.MarkStripeEventProcessed("evt_roundtrip")
 	if err != nil {
 		t.Fatalf("re-mark before unmark: %v", err)
 	}
 	if !already {
 		t.Fatal("second mark (no unmark yet) must detect duplicate")
 	}
+	if tok2 != tok1 {
+		t.Errorf("duplicate mark must return the existing row's processed_at (%q), got %q", tok1, tok2)
+	}
 
-	// Unmark — row existed.
-	unmarked, err := s.UnmarkStripeEventProcessed("evt_roundtrip")
+	// Unmark with the correct token — row deleted.
+	unmarked, err := s.UnmarkStripeEventProcessed("evt_roundtrip", tok1)
 	if err != nil {
 		t.Fatalf("unmark: %v", err)
 	}
 	if !unmarked {
-		t.Fatal("unmark of existing row must return unmarked=true")
+		t.Fatal("unmark of existing row (matching token) must return unmarked=true")
 	}
 
 	// Re-mark — row is gone, must be treated as brand-new so the handler
 	// can run again. This is the whole point of the endpoint.
-	already, err = s.MarkStripeEventProcessed("evt_roundtrip")
+	already, _, err = s.MarkStripeEventProcessed("evt_roundtrip")
 	if err != nil {
 		t.Fatalf("re-mark after unmark: %v", err)
 	}
@@ -48,16 +57,76 @@ func TestUnmarkStripeEventProcessed_RoundTrip(t *testing.T) {
 	}
 }
 
+// TestUnmarkStripeEventProcessed_StaleTokenIsNoOp is the race-protection
+// test that addresses Codex's HIGH finding. Scenario: an earlier handler
+// failure queued an unmark, but before it fired, Stripe retried and a
+// SUCCESSFUL retry re-marked the same event (fresh processed_at). If the
+// stale unmark proceeded, it would wipe the fresh marker and reopen the
+// retry window, causing the handler to double-apply.
+//
+// The (event_id, processed_at) composite delete key prevents this: the
+// stale token doesn't match the fresh row, so the delete silently affects
+// zero rows and the fresh marker stays put.
+func TestUnmarkStripeEventProcessed_StaleTokenIsNoOp(t *testing.T) {
+	s := testStore(t)
+
+	// First attempt — record a token.
+	_, staleTok, err := s.MarkStripeEventProcessed("evt_race")
+	if err != nil {
+		t.Fatalf("first mark: %v", err)
+	}
+
+	// Simulate the sidecar successfully rolling back and then a fresh
+	// retry re-marking under a new timestamp. We delete by the stale
+	// token first (cleans up), then re-mark to get a new token that
+	// differs from the stale one.
+	if _, err := s.UnmarkStripeEventProcessed("evt_race", staleTok); err != nil {
+		t.Fatalf("rollback: %v", err)
+	}
+	// Make sure the clock advances so the re-mark writes a distinct ts.
+	// now() is RFC3339 second-resolution, so a bare `time.Sleep(1s)` is
+	// enough without introducing a flake.
+	time.Sleep(1100 * time.Millisecond)
+	_, freshTok, err := s.MarkStripeEventProcessed("evt_race")
+	if err != nil {
+		t.Fatalf("fresh mark: %v", err)
+	}
+	if freshTok == staleTok {
+		t.Fatalf("fresh mark wrote the same token as the stale one — test setup assumption broken (%q)", freshTok)
+	}
+
+	// Now a stale unmark fires. It MUST NOT delete the fresh row — that
+	// would reopen the retry window after a successful handler.
+	unmarked, err := s.UnmarkStripeEventProcessed("evt_race", staleTok)
+	if err != nil {
+		t.Fatalf("stale unmark: %v", err)
+	}
+	if unmarked {
+		t.Error("stale unmark must NOT delete the fresh marker (race: would reopen retry window)")
+	}
+
+	// Sanity check: the fresh row is still there.
+	already, tok, err := s.MarkStripeEventProcessed("evt_race")
+	if err != nil {
+		t.Fatalf("sanity mark: %v", err)
+	}
+	if !already {
+		t.Error("fresh marker must still be in place after stale unmark")
+	}
+	if tok != freshTok {
+		t.Errorf("fresh token changed unexpectedly; got %q, want %q", tok, freshTok)
+	}
+}
+
 // TestUnmarkStripeEventProcessed_MissingRow verifies idempotency: calling
 // unmark for an event ID that was never marked returns (false, nil). The
 // sidecar uses unmark as a best-effort rollback, so it may fire for an
-// event that Stripe retried (meaning the row already got unmarked and
-// remarked between attempts); a hard error in that case would mask real
-// problems in the sidecar logs.
+// event that was already cleaned up; a hard error in that case would mask
+// real problems in the sidecar logs.
 func TestUnmarkStripeEventProcessed_MissingRow(t *testing.T) {
 	s := testStore(t)
 
-	unmarked, err := s.UnmarkStripeEventProcessed("evt_never_marked")
+	unmarked, err := s.UnmarkStripeEventProcessed("evt_never_marked", "2025-01-01T00:00:00Z")
 	if err != nil {
 		t.Fatalf("unexpected error for missing row: %v", err)
 	}
@@ -73,8 +142,21 @@ func TestUnmarkStripeEventProcessed_MissingRow(t *testing.T) {
 func TestUnmarkStripeEventProcessed_RejectsEmptyID(t *testing.T) {
 	s := testStore(t)
 
-	_, err := s.UnmarkStripeEventProcessed("")
+	_, err := s.UnmarkStripeEventProcessed("", "2025-01-01T00:00:00Z")
 	if err == nil {
 		t.Fatal("empty event_id must return an error")
+	}
+}
+
+// TestUnmarkStripeEventProcessed_RejectsEmptyProcessedAt guards against
+// calls that forget to pass the processed_at token. Without the token the
+// race-protection contract falls back to "delete by event_id alone", which
+// is exactly the unsafe shape the composite key exists to prevent.
+func TestUnmarkStripeEventProcessed_RejectsEmptyProcessedAt(t *testing.T) {
+	s := testStore(t)
+
+	_, err := s.UnmarkStripeEventProcessed("evt_missing_token", "")
+	if err == nil {
+		t.Fatal("empty processed_at must return an error")
 	}
 }


### PR DESCRIPTION
## Summary

PR 1 of 2 for TASK-736 (PLAN-645). Adds a pad-side endpoint pad-cloud can call to DELETE a row from `stripe_processed_events`, so a webhook handler that fails AFTER the mark can roll back and let Stripe's retries re-run it.

Without this, the webhook-idempotency window opened in TASK-696 fails closed: the sidecar marks the event BEFORE running the handler (to prevent replay re-execution), but if the handler fails after that mark, Stripe's subsequent retries of the same event are short-circuited as duplicates — the un-applied side effect has no automated recovery and an operator has to manually delete the row and replay from the Stripe dashboard.

PR 2 (pad-cloud) will wire `HandleWebhook` to call this endpoint best-effort on handler failure.

## Changes

- **`internal/store/stripe_events.go`** — `UnmarkStripeEventProcessed(eventID) (unmarked bool, err error)`. `DELETE ... WHERE event_id = ?`. Idempotent: a missing row returns `(false, nil)` rather than an error. Empty `eventID` is rejected (defensive against accidental "delete every row" calls).
- **`internal/server/handlers_cloud.go`** — `handleStripeEventUnmark` handler mirrors `handleStripeEventProcessed`: same `cloud_secret` body-gate, same `evt_` prefix validation, admins can also call it (for manual reconciliation from the admin UI). Returns `{"event_id","unmarked"}`.
- **`internal/server/server.go`** — registers `POST /api/v1/admin/stripe-event-unmark` under the cloud-admin group (gated by `requireCloudMode` so self-host deploys 404 the path entirely).
- **`internal/server/handlers_cloud.go`** + **`middleware_ratelimit.go`** — adds the new path to `cloudAdminPaths` whitelist (so the sidecar auth bypass applies) and the cloud-admin rate-limit switch (same bucket as the other cloud admin calls).

## Tests

- **`internal/store/stripe_events_test.go`** — store-level round-trip: mark → (duplicate-detected) → unmark → mark-fresh. Plus missing-row idempotency and empty-ID rejection.
- **`internal/server/cloud_admin_gate_test.go`** — four HTTP tests:
  - Self-host returns 404 (added to the existing parametrized test)
  - Mark → Unmark → Re-mark round-trip: re-mark reports `already_processed=false` after unmark (proving Stripe retries can re-run)
  - Missing row returns 200 + `unmarked=false` (idempotent)
  - Wrong cloud_secret returns 403
  - Invalid event_id shapes return 400 (empty, wrong prefix, etc)

## Test plan

- [x] `go build ./... && go vet ./... && go test ./...` — clean