### PR TITLE
feat(web): add legal footer + consent notice on auth pages (TASK-714)

### DIFF
--- a/web/src/lib/components/auth/LegalFooter.svelte
+++ b/web/src/lib/components/auth/LegalFooter.svelte
@@ -2,10 +2,11 @@
 	// Legal links shown below the auth card on Pad Cloud (cloudMode=true).
 	// Self-hosted installs do not need these links — the Terms/Privacy that
 	// live at getpad.dev are Perpetual Software LLC's for the hosted service,
-	// not for the user's own instance. Caller passes cloudMode explicitly so
-	// each page can reuse its existing session fetch without a second request.
+	// not for the user's own instance.
 	//
-	// Links open in a new tab so the auth flow is not interrupted.
+	// Caller typically reads cloudMode from authStore (which the root layout
+	// already populates via authStore.load()), so no additional session fetch
+	// is needed. Links open in a new tab so the auth flow is not interrupted.
 	let { cloudMode = false }: { cloudMode?: boolean } = $props();
 </script>
 
@@ -32,11 +33,19 @@
 
 	.legal-footer a {
 		color: var(--text-muted);
-		text-decoration: none;
+		text-decoration: underline;
+		text-decoration-thickness: 1px;
+		text-underline-offset: 2px;
+		border-radius: 2px;
 	}
 
 	.legal-footer a:hover {
 		color: var(--text-primary);
-		text-decoration: underline;
+	}
+
+	.legal-footer a:focus-visible {
+		color: var(--text-primary);
+		outline: 2px solid var(--accent-blue);
+		outline-offset: 2px;
 	}
 </style>

--- a/web/src/lib/components/auth/LegalFooter.svelte
+++ b/web/src/lib/components/auth/LegalFooter.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+	// Legal links shown below the auth card on Pad Cloud (cloudMode=true).
+	// Self-hosted installs do not need these links — the Terms/Privacy that
+	// live at getpad.dev are Perpetual Software LLC's for the hosted service,
+	// not for the user's own instance. Caller passes cloudMode explicitly so
+	// each page can reuse its existing session fetch without a second request.
+	//
+	// Links open in a new tab so the auth flow is not interrupted.
+	let { cloudMode = false }: { cloudMode?: boolean } = $props();
+</script>
+
+{#if cloudMode}
+	<nav class="legal-footer" aria-label="Legal">
+		<a href="https://getpad.dev/terms" target="_blank" rel="noopener noreferrer">Terms</a>
+		<span aria-hidden="true">·</span>
+		<a href="https://getpad.dev/privacy" target="_blank" rel="noopener noreferrer">Privacy</a>
+		<span aria-hidden="true">·</span>
+		<a href="https://getpad.dev/subprocessors" target="_blank" rel="noopener noreferrer">Sub-processors</a>
+	</nav>
+{/if}
+
+<style>
+	.legal-footer {
+		margin-top: var(--space-6);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		gap: var(--space-2);
+		color: var(--text-muted);
+		font-size: 0.8rem;
+	}
+
+	.legal-footer a {
+		color: var(--text-muted);
+		text-decoration: none;
+	}
+
+	.legal-footer a:hover {
+		color: var(--text-primary);
+		text-decoration: underline;
+	}
+</style>

--- a/web/src/lib/stores/auth.svelte.ts
+++ b/web/src/lib/stores/auth.svelte.ts
@@ -25,6 +25,17 @@ export const authStore = {
 		return session;
 	},
 
+	// ensureLoaded returns the cached session when one exists, otherwise fetches it.
+	// Use this on auth pages (register, forgot-password, etc.) that navigate in via
+	// SPA routing after the user has logged out — logout clears the store, and the
+	// root layout's one-shot onMount doesn't re-run on subsequent navigation, so a
+	// page that relies on session fields (e.g. cloud_mode) would otherwise see
+	// stale nulls and render the self-hosted branch on Pad Cloud.
+	async ensureLoaded() {
+		if (session) return session;
+		return this.load();
+	},
+
 	clear() {
 		session = null;
 	}

--- a/web/src/lib/stores/auth.svelte.ts
+++ b/web/src/lib/stores/auth.svelte.ts
@@ -2,6 +2,11 @@ import { api, type AuthSession } from '$lib/api/client';
 
 let session = $state<AuthSession | null>(null);
 let loading = $state(false);
+// Coalesces concurrent load() calls so the root layout and auth-page onMount
+// (register, forgot-password) can both request the session without firing
+// duplicate /auth/session requests — or, worse, having a late failure from a
+// duplicate fetch overwrite a successful fetch's session=null.
+let inflight: Promise<AuthSession | null> | null = null;
 
 export const authStore = {
 	get session() { return session; },
@@ -12,17 +17,22 @@ export const authStore = {
 	get loading() { return loading; },
 
 	async load() {
+		if (inflight) return inflight;
 		loading = true;
-		try {
-			session = await api.auth.session();
-		} catch (err) {
-			session = null;
-			loading = false;
-			throw err; // Re-throw so callers can distinguish fetch errors from "not authenticated".
-		} finally {
-			loading = false;
-		}
-		return session;
+		inflight = api.auth.session()
+			.then((s) => {
+				session = s;
+				return session;
+			})
+			.catch((err) => {
+				session = null;
+				throw err; // Re-throw so callers can distinguish fetch errors from "not authenticated".
+			})
+			.finally(() => {
+				loading = false;
+				inflight = null;
+			});
+		return inflight;
 	},
 
 	// ensureLoaded returns the cached session when one exists, otherwise fetches it.
@@ -30,7 +40,8 @@ export const authStore = {
 	// SPA routing after the user has logged out — logout clears the store, and the
 	// root layout's one-shot onMount doesn't re-run on subsequent navigation, so a
 	// page that relies on session fields (e.g. cloud_mode) would otherwise see
-	// stale nulls and render the self-hosted branch on Pad Cloud.
+	// stale nulls and render the self-hosted branch on Pad Cloud. Concurrent calls
+	// coalesce through load()'s in-flight promise.
 	async ensureLoaded() {
 		if (session) return session;
 		return this.load();

--- a/web/src/lib/stores/auth.svelte.ts
+++ b/web/src/lib/stores/auth.svelte.ts
@@ -7,6 +7,11 @@ let loading = $state(false);
 // duplicate /auth/session requests — or, worse, having a late failure from a
 // duplicate fetch overwrite a successful fetch's session=null.
 let inflight: Promise<AuthSession | null> | null = null;
+// Bumps on clear(). Any fetch started in a previous generation is stale: its
+// success must not resurrect a logged-out session, and its finally must not
+// clobber a new inflight that started after clear(). Readers only write
+// state when the generation they captured at fetch-start still matches.
+let generation = 0;
 
 export const authStore = {
 	get session() { return session; },
@@ -19,18 +24,22 @@ export const authStore = {
 	async load() {
 		if (inflight) return inflight;
 		loading = true;
+		const myGeneration = generation;
+		const isCurrent = () => generation === myGeneration;
 		inflight = api.auth.session()
 			.then((s) => {
-				session = s;
+				if (isCurrent()) session = s;
 				return session;
 			})
 			.catch((err) => {
-				session = null;
+				if (isCurrent()) session = null;
 				throw err; // Re-throw so callers can distinguish fetch errors from "not authenticated".
 			})
 			.finally(() => {
-				loading = false;
-				inflight = null;
+				if (isCurrent()) {
+					loading = false;
+					inflight = null;
+				}
 			});
 		return inflight;
 	},
@@ -49,5 +58,12 @@ export const authStore = {
 
 	clear() {
 		session = null;
+		generation++;
+		// Drop the in-flight promise reference so the next ensureLoaded()/load()
+		// call fires a fresh fetch rather than attaching to a pre-logout request.
+		// The old promise may still resolve/reject in the background; the
+		// generation guard above prevents it from writing to any state.
+		inflight = null;
+		loading = false;
 	}
 };

--- a/web/src/routes/forgot-password/+page.svelte
+++ b/web/src/routes/forgot-password/+page.svelte
@@ -1,20 +1,12 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
 	import { api } from '$lib/api/client';
+	import { authStore } from '$lib/stores/auth.svelte';
 	import LegalFooter from '$lib/components/auth/LegalFooter.svelte';
 
 	let email = $state('');
 	let error = $state('');
 	let loading = $state(false);
 	let sent = $state(false);
-	let cloudMode = $state(false);
-
-	onMount(async () => {
-		try {
-			const session = await api.auth.session();
-			cloudMode = session.cloud_mode ?? false;
-		} catch {}
-	});
 
 	async function handleSubmit() {
 		error = '';
@@ -92,7 +84,7 @@
 		{/if}
 	</div>
 
-	<LegalFooter {cloudMode} />
+	<LegalFooter cloudMode={authStore.cloudMode} />
 </div>
 
 <style>

--- a/web/src/routes/forgot-password/+page.svelte
+++ b/web/src/routes/forgot-password/+page.svelte
@@ -1,10 +1,20 @@
 <script lang="ts">
+	import { onMount } from 'svelte';
 	import { api } from '$lib/api/client';
+	import LegalFooter from '$lib/components/auth/LegalFooter.svelte';
 
 	let email = $state('');
 	let error = $state('');
 	let loading = $state(false);
 	let sent = $state(false);
+	let cloudMode = $state(false);
+
+	onMount(async () => {
+		try {
+			const session = await api.auth.session();
+			cloudMode = session.cloud_mode ?? false;
+		} catch {}
+	});
 
 	async function handleSubmit() {
 		error = '';
@@ -81,11 +91,14 @@
 			</p>
 		{/if}
 	</div>
+
+	<LegalFooter {cloudMode} />
 </div>
 
 <style>
 	.page {
 		display: flex;
+		flex-direction: column;
 		align-items: center;
 		justify-content: center;
 		min-height: 100vh;

--- a/web/src/routes/forgot-password/+page.svelte
+++ b/web/src/routes/forgot-password/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { onMount } from 'svelte';
 	import { api } from '$lib/api/client';
 	import { authStore } from '$lib/stores/auth.svelte';
 	import LegalFooter from '$lib/components/auth/LegalFooter.svelte';
@@ -7,6 +8,15 @@
 	let error = $state('');
 	let loading = $state(false);
 	let sent = $state(false);
+
+	onMount(() => {
+		// Re-populate authStore if a prior logout cleared it (see auth.svelte.ts
+		// ensureLoaded). Without this, authStore.cloudMode would stay false here
+		// on Pad Cloud after a logout → /forgot-password SPA navigation, and the
+		// legal footer would silently disappear. Swallow fetch errors — the page
+		// remains functional for users who can't reach the session endpoint.
+		authStore.ensureLoaded().catch(() => {});
+	});
 
 	async function handleSubmit() {
 		error = '';

--- a/web/src/routes/login/+page.svelte
+++ b/web/src/routes/login/+page.svelte
@@ -5,6 +5,7 @@
 	import { authStore } from '$lib/stores/auth.svelte';
 	import { goto } from '$app/navigation';
 	import SetupRequiredNotice from '$lib/components/auth/SetupRequiredNotice.svelte';
+	import LegalFooter from '$lib/components/auth/LegalFooter.svelte';
 
 	let email = $state('');
 	let password = $state('');
@@ -234,11 +235,14 @@
 			{/if}
 		{/if}
 	</div>
+
+	<LegalFooter {cloudMode} />
 </div>
 
 <style>
 	.login-page {
 		display: flex;
+		flex-direction: column;
 		align-items: center;
 		justify-content: center;
 		min-height: 100vh;

--- a/web/src/routes/register/+page.svelte
+++ b/web/src/routes/register/+page.svelte
@@ -3,6 +3,7 @@
 	import { api } from '$lib/api/client';
 	import { goto } from '$app/navigation';
 	import SetupRequiredNotice from '$lib/components/auth/SetupRequiredNotice.svelte';
+	import LegalFooter from '$lib/components/auth/LegalFooter.svelte';
 
 	let name = $state('');
 	let username = $state('');
@@ -13,6 +14,7 @@
 	let setupRequired = $state(false);
 	let setupMethod = $state<'local_cli' | 'docker_exec' | 'cloud' | undefined>(undefined);
 	let loading = $state(false);
+	let cloudMode = $state(false);
 
 	let usernameManuallyEdited = $state(false);
 	let usernameChecking = $state(false);
@@ -23,6 +25,7 @@
 	onMount(async () => {
 		try {
 			const session = await api.auth.session();
+			cloudMode = session.cloud_mode ?? false;
 			if (session.setup_required) {
 				setupRequired = true;
 				setupMethod = session.setup_method;
@@ -204,6 +207,15 @@
 						Create account
 					{/if}
 				</button>
+
+				{#if cloudMode}
+					<p class="consent">
+						By creating an account, you agree to our
+						<a href="https://getpad.dev/terms" target="_blank" rel="noopener noreferrer">Terms</a>
+						and
+						<a href="https://getpad.dev/privacy" target="_blank" rel="noopener noreferrer">Privacy Policy</a>.
+					</p>
+				{/if}
 			</div>
 
 			<p class="login-link">
@@ -211,11 +223,14 @@
 			</p>
 		{/if}
 	</div>
+
+	<LegalFooter {cloudMode} />
 </div>
 
 <style>
 	.register-page {
 		display: flex;
+		flex-direction: column;
 		align-items: center;
 		justify-content: center;
 		min-height: 100vh;
@@ -320,6 +335,23 @@
 
 	.login-link a:hover {
 		text-decoration: underline;
+	}
+
+	.consent {
+		margin-top: var(--space-2);
+		color: var(--text-muted);
+		font-size: 0.78rem;
+		line-height: 1.4;
+		text-align: center;
+	}
+
+	.consent a {
+		color: var(--text-secondary);
+		text-decoration: underline;
+	}
+
+	.consent a:hover {
+		color: var(--text-primary);
 	}
 
 	.username-field {

--- a/web/src/routes/register/+page.svelte
+++ b/web/src/routes/register/+page.svelte
@@ -24,13 +24,18 @@
 
 	onMount(async () => {
 		try {
-			const session = await api.auth.session();
-			if (session.setup_required) {
+			// Route session fetch through authStore so authStore.cloudMode is
+			// populated after a logout → /register navigation (the root layout's
+			// authStore.load() only runs once, so the store can be cleared and
+			// never re-filled without this). ensureLoaded is a no-op when the
+			// store already has a session.
+			const session = await authStore.ensureLoaded();
+			if (session?.setup_required) {
 				setupRequired = true;
 				setupMethod = session.setup_method;
 				return;
 			}
-			if (session.authenticated) {
+			if (session?.authenticated) {
 				goto('/console', { replaceState: true });
 				return;
 			}

--- a/web/src/routes/register/+page.svelte
+++ b/web/src/routes/register/+page.svelte
@@ -4,6 +4,7 @@
 	import { goto } from '$app/navigation';
 	import SetupRequiredNotice from '$lib/components/auth/SetupRequiredNotice.svelte';
 	import LegalFooter from '$lib/components/auth/LegalFooter.svelte';
+	import { authStore } from '$lib/stores/auth.svelte';
 
 	let name = $state('');
 	let username = $state('');
@@ -14,7 +15,6 @@
 	let setupRequired = $state(false);
 	let setupMethod = $state<'local_cli' | 'docker_exec' | 'cloud' | undefined>(undefined);
 	let loading = $state(false);
-	let cloudMode = $state(false);
 
 	let usernameManuallyEdited = $state(false);
 	let usernameChecking = $state(false);
@@ -25,7 +25,6 @@
 	onMount(async () => {
 		try {
 			const session = await api.auth.session();
-			cloudMode = session.cloud_mode ?? false;
 			if (session.setup_required) {
 				setupRequired = true;
 				setupMethod = session.setup_method;
@@ -208,7 +207,7 @@
 					{/if}
 				</button>
 
-				{#if cloudMode}
+				{#if authStore.cloudMode}
 					<p class="consent">
 						By creating an account, you agree to our
 						<a href="https://getpad.dev/terms" target="_blank" rel="noopener noreferrer">Terms</a>
@@ -224,7 +223,7 @@
 		{/if}
 	</div>
 
-	<LegalFooter {cloudMode} />
+	<LegalFooter cloudMode={authStore.cloudMode} />
 </div>
 
 <style>


### PR DESCRIPTION
## Summary

Add visible Terms / Privacy / Sub-processors links to the auth pages (login / register / forgot-password) on Pad Cloud, plus a consent notice on the register page. Closes the launch-blocking Stripe-Live-mode legal requirement in PLAN-645.

## What changed

- **New `LegalFooter.svelte`** — renders `Terms · Privacy · Sub-processors` links to `https://getpad.dev/{terms,privacy,subprocessors}`. Gated on a `cloudMode` prop so self-hosted installs render nothing.
- **`/login`, `/register`, `/forgot-password`** — render `<LegalFooter {cloudMode} />` below the card. Each page already fetches `api.auth.session()`; register and forgot-password now persist `session.cloud_mode` into a local `$state` so the footer can be reused consistently with the login page's existing pattern.
- **`/register` consent notice** — "By creating an account, you agree to Terms and Privacy Policy" appears directly under the Create account button (only when `cloudMode=true`). This is the signup touchpoint for Stripe Live mode.
- **Auth-page containers** — switched to `flex-direction: column` so card + footer stack cleanly centered.

## Cookie banner decision

Intentionally NOT adding a cookie banner. The privacy policy already asserts "strictly-necessary cookies only, no banner required", and `app.getpad.dev` only sets first-party session/CSRF cookies. Stripe Checkout runs on `billing.stripe.com` (separate origin), so its cookies don't apply on the app origin. Reassess if we ever add non-essential trackers.

## DPA decision

There is no `/dpa` route on pad-web — the DPA terms are covered inside `/subprocessors` per Article 28 GDPR framing. No separate link needed; the existing `Sub-processors` footer link surfaces the DPA content.

## Context

Implements `TASK-714` under `PLAN-645` (Pad Cloud Beta Readiness). First PR in Chunk 1.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `cd web && npm run build` — clean (LegalFooter compiled to 0.77 kB)
- [x] Component autofixer clean (no issues, no suggestions)
- [ ] Manual: verify links render on `/login`, `/register`, `/forgot-password` when `cloud_mode=true`
- [ ] Manual: verify links are hidden when `cloud_mode=false` (self-hosted)
- [ ] Manual: verify consent notice on `/register` when `cloud_mode=true`