### PR TITLE
feat(web): add Support + Status links on auth pages and user menu (TASK-713)

### DIFF
--- a/web/src/lib/components/auth/SupportFooter.svelte
+++ b/web/src/lib/components/auth/SupportFooter.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+	// Support/help links shown below the auth card on Pad Cloud.
+	//
+	// Gated on cloudMode — the support@getpad.dev mailbox and status.getpad.dev
+	// page are for the hosted service, not for self-hosted deployments. Caller
+	// typically reads cloudMode from authStore. Links open in a new tab so
+	// clicking one mid-login does not lose the form state.
+	let { cloudMode = false }: { cloudMode?: boolean } = $props();
+</script>
+
+{#if cloudMode}
+	<nav class="support-footer" aria-label="Support">
+		<a href="mailto:support@getpad.dev">Support</a>
+		<span aria-hidden="true">·</span>
+		<a href="https://status.getpad.dev" target="_blank" rel="noopener noreferrer">Status</a>
+	</nav>
+{/if}
+
+<style>
+	.support-footer {
+		margin-top: var(--space-2);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		gap: var(--space-2);
+		color: var(--text-muted);
+		font-size: 0.8rem;
+	}
+
+	.support-footer a {
+		color: var(--text-muted);
+		text-decoration: underline;
+		text-decoration-thickness: 1px;
+		text-underline-offset: 2px;
+		border-radius: 2px;
+	}
+
+	.support-footer a:hover {
+		color: var(--text-primary);
+	}
+
+	.support-footer a:focus-visible {
+		color: var(--text-primary);
+		outline: 2px solid var(--accent-blue);
+		outline-offset: 2px;
+	}
+</style>

--- a/web/src/lib/components/layout/TopBar.svelte
+++ b/web/src/lib/components/layout/TopBar.svelte
@@ -196,6 +196,25 @@
 							<button class="dropdown-item" onclick={toggleTheme}>
 								{currentTheme === 'dark' ? 'Light mode' : 'Dark mode'}
 							</button>
+							{#if authStore.cloudMode}
+								<div class="dropdown-divider"></div>
+								<a
+									href="mailto:support@getpad.dev"
+									class="dropdown-item"
+									onclick={closeUserMenu}
+								>
+									Support
+								</a>
+								<a
+									href="https://status.getpad.dev"
+									target="_blank"
+									rel="noopener noreferrer"
+									class="dropdown-item"
+									onclick={closeUserMenu}
+								>
+									Status
+								</a>
+							{/if}
 							<div class="dropdown-divider"></div>
 							<button class="dropdown-item logout" onclick={handleLogout}>
 								Sign out
@@ -264,6 +283,25 @@
 						<button class="dropdown-item" onclick={toggleTheme}>
 							{currentTheme === 'dark' ? 'Light mode' : 'Dark mode'}
 						</button>
+						{#if authStore.cloudMode}
+							<div class="dropdown-divider"></div>
+							<a
+								href="mailto:support@getpad.dev"
+								class="dropdown-item"
+								onclick={closeUserMenu}
+							>
+								Support
+							</a>
+							<a
+								href="https://status.getpad.dev"
+								target="_blank"
+								rel="noopener noreferrer"
+								class="dropdown-item"
+								onclick={closeUserMenu}
+							>
+								Status
+							</a>
+						{/if}
 						<div class="dropdown-divider"></div>
 						<button class="dropdown-item logout" onclick={handleLogout}>
 							Sign out

--- a/web/src/routes/forgot-password/+page.svelte
+++ b/web/src/routes/forgot-password/+page.svelte
@@ -3,6 +3,7 @@
 	import { api } from '$lib/api/client';
 	import { authStore } from '$lib/stores/auth.svelte';
 	import LegalFooter from '$lib/components/auth/LegalFooter.svelte';
+	import SupportFooter from '$lib/components/auth/SupportFooter.svelte';
 
 	let email = $state('');
 	let error = $state('');
@@ -95,6 +96,7 @@
 	</div>
 
 	<LegalFooter cloudMode={authStore.cloudMode} />
+	<SupportFooter cloudMode={authStore.cloudMode} />
 </div>
 
 <style>

--- a/web/src/routes/login/+page.svelte
+++ b/web/src/routes/login/+page.svelte
@@ -6,6 +6,7 @@
 	import { goto } from '$app/navigation';
 	import SetupRequiredNotice from '$lib/components/auth/SetupRequiredNotice.svelte';
 	import LegalFooter from '$lib/components/auth/LegalFooter.svelte';
+	import SupportFooter from '$lib/components/auth/SupportFooter.svelte';
 
 	let email = $state('');
 	let password = $state('');
@@ -237,6 +238,7 @@
 	</div>
 
 	<LegalFooter {cloudMode} />
+	<SupportFooter {cloudMode} />
 </div>
 
 <style>

--- a/web/src/routes/register/+page.svelte
+++ b/web/src/routes/register/+page.svelte
@@ -4,6 +4,7 @@
 	import { goto } from '$app/navigation';
 	import SetupRequiredNotice from '$lib/components/auth/SetupRequiredNotice.svelte';
 	import LegalFooter from '$lib/components/auth/LegalFooter.svelte';
+	import SupportFooter from '$lib/components/auth/SupportFooter.svelte';
 	import { authStore } from '$lib/stores/auth.svelte';
 
 	let name = $state('');
@@ -229,6 +230,7 @@
 	</div>
 
 	<LegalFooter cloudMode={authStore.cloudMode} />
+	<SupportFooter cloudMode={authStore.cloudMode} />
 </div>
 
 <style>


### PR DESCRIPTION
## Summary

Add customer-facing support + status-page links so users on Pad Cloud can reach help without leaving the app. Covers TASK-713 bullets 1 and 2 from PLAN-645 Chunk 1. Bullets 3 (admin impersonation) and 4 (MRR/churn dashboard) intentionally deferred.

## What changed

- **New `SupportFooter.svelte`** — Support · Status row gated on \`cloudMode\`, same underline + focus-visible affordance as \`LegalFooter\`. Support is \`mailto:support@getpad.dev\`; Status points at \`https://status.getpad.dev\`.
- **Auth pages** (\`/login\`, \`/register\`, \`/forgot-password\`) — render \`<SupportFooter>\` below \`<LegalFooter>\` (same \`authStore.cloudMode\` wiring).
- **TopBar user dropdown** (desktop + mobile branches) — Support and Status entries between theme toggle and Sign out, grouped by a divider, gated on \`authStore.cloudMode\`.

## Deferred

- **Discord link:** Pad does not yet have a Discord server; will spawn a human-tasks follow-up to provision one and wire the URL in.
- **status.getpad.dev:** URL registered but the actual status page (Statuspage.io / Cachet / whatever) still needs to be set up. Will spawn a human-tasks follow-up with pickup runbook.
- **TASK-713 bullets 3+4:** admin impersonation + MRR dashboard. Not beta-blocking; carved out to a follow-up plan per the PLAN-645 audit decision.

## Context

Implements part of \`TASK-713\` under \`PLAN-645\`. The rest of the umbrella task will land in later PRs.

## Test plan

- [x] \`go build ./...\` — clean
- [x] \`go vet ./...\` — clean
- [x] \`cd web && npm run build\` — clean
- [x] \`cd web && npm run check\` — 0 errors (pre-existing warnings only)
- [x] Component autofixer clean on new SupportFooter
- [ ] Manual: verify Support + Status appear in user dropdown when \`cloud_mode=true\`, hidden when \`false\`
- [ ] Manual: verify Support mailto opens mail client, Status opens new tab to status.getpad.dev
- [ ] Manual: verify auth-page SupportFooter shows under LegalFooter on \`cloud_mode=true\`