### PR TITLE
fix(web): render markdown in timeline comments via .prose class (BUG-748)

### DIFF
--- a/web/src/lib/components/timeline/TimelineCommentCard.svelte
+++ b/web/src/lib/components/timeline/TimelineCommentCard.svelte
@@ -363,6 +363,15 @@
 		   bodies; comments live inside an already-constrained timeline column
 		   and should fill it instead of shrinking to 960px. */
 		max-width: none;
+		/* `.prose` also pins font-family to var(--font-content). Comments should
+		   keep using the surrounding UI font (currently identical, but make the
+		   relationship explicit so a future divergence doesn't silently change
+		   comment typography). */
+		font-family: inherit;
+		/* `.prose table { width: 100% }` plus padded cells can produce wider-
+		   than-column tables inside the indented replies; allow the rendered
+		   markdown subtree to scroll horizontally rather than spill out. */
+		overflow-x: auto;
 	}
 
 	.comment-body :global(p:last-child),

--- a/web/src/lib/components/timeline/TimelineCommentCard.svelte
+++ b/web/src/lib/components/timeline/TimelineCommentCard.svelte
@@ -148,7 +148,7 @@
 		<div class="activity-label">commented on update</div>
 	{/if}
 
-	<div class="comment-body markdown-body">
+	<div class="comment-body prose">
 		{@html renderMarkdown(comment.body, items, wsSlug, username)}
 	</div>
 
@@ -219,7 +219,7 @@
 						</button>
 					</div>
 
-					<div class="reply-body markdown-body">
+					<div class="reply-body prose">
 						{@html renderMarkdown(reply.body, items, wsSlug, username)}
 					</div>
 
@@ -359,6 +359,10 @@
 		line-height: 1.6;
 		color: var(--text-primary);
 		overflow-wrap: break-word;
+		/* `.prose` sets max-width: var(--content-max-width) for long-form item
+		   bodies; comments live inside an already-constrained timeline column
+		   and should fill it instead of shrinking to 960px. */
+		max-width: none;
 	}
 
 	.comment-body :global(p:last-child),


### PR DESCRIPTION
## Summary

Comments in the timeline rendered raw markdown (lists without bullets, headings without spacing, code blocks without backgrounds, etc.) because `TimelineCommentCard.svelte` tagged the comment + reply bodies with `markdown-body` — a class that has no rules anywhere in the codebase. Combined with the global `* { margin: 0; padding: 0 }` reset in `app.css`, every block-level markdown element lost its visual structure.

Switching both bodies to the existing `.prose` class (the same one used to render long-form item content) restores all the styling. A small scoped override sets `max-width: none` so comments still fill the timeline column instead of shrinking to the 960px `--content-max-width` that `.prose` pins for article-style content.

## Changes

- `web/src/lib/components/timeline/TimelineCommentCard.svelte`
  - Line 151: `class="comment-body markdown-body"` → `class="comment-body prose"`
  - Line 222: `class="reply-body markdown-body"` → `class="reply-body prose"`
  - Scoped CSS: added `max-width: none` to the existing `.comment-body, .reply-body` rule with a comment explaining why we're opting out of `.prose`'s 960px max-width.

## Why no XSS regression

Comments are already sanitized through DOMPurify in `renderMarkdown` (introduced in TASK-647 / commit 42cc220). This change is purely styling — the HTML pipeline is unchanged.

## Why scoped overrides aren't needed for font-size/line-height

Svelte's class hashing gives `.comment-body, .reply-body` (scoped) higher specificity than `.prose` (global), so the existing `font-size: 0.9em` and `line-height: 1.6` continue to win. `.prose`'s `font-size: 15px / line-height: 1.7` would otherwise apply.

## Test plan

- [x] `cd web && npm run build` — clean (15.30s)
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./...` — all 14 packages pass
- [x] Svelte autofixer: no NEW issues from this change (pre-existing `{@html}` and `Map` warnings are out of scope)
- [ ] **User-verified:** comments containing `**bold**`, `# headings`, fenced code, bullet lists, and tables now render with their full visual formatting in the item timeline.