### PR TITLE
fix(web): long-press delay on mobile status-header drag (BUG-641)

### DIFF
--- a/web/src/lib/components/collections/ListView.svelte
+++ b/web/src/lib/components/collections/ListView.svelte
@@ -206,7 +206,15 @@
 			flipDurationMs,
 			type: 'list-group',
 			dropTargetClasses: ['group-drop-target'],
-			morphDisabled: true
+			morphDisabled: true,
+			/* On mobile, touching a group header to scroll the page used to
+			   immediately seize the touch as the start of a group-reorder drag,
+			   so the page wouldn't scroll and the group would fly around with
+			   the finger. Mirror the inner item dndzone's `delayTouchStart`
+			   (BUG-641): a 500ms long-press is required before drag activates,
+			   which matches the existing intra-group item behaviour and lets
+			   ordinary taps/scrolls pass through unmolested. */
+			delayTouchStart: touchDragDelayMs
 		}}
 		onconsider={handleGroupConsider}
 		onfinalize={handleGroupFinalize}


### PR DESCRIPTION
## Summary

On mobile, touching a status group header in the list view (e.g. \`Open\`, \`In Progress\`) used to be interpreted as the start of a group-reorder drag. Trying to scroll the page by swiping at a header instead grabbed the header, so the page wouldn't scroll and the group flew around with the finger — making content below visible status bands hard or impossible to reach.

The inner dndzone (for items within a group) already gates touch-drag behind a 500ms long-press via \`delayTouchStart: touchDragDelayMs\`. The outer dndzone (for the group order itself) was missing this option, so it activated drag immediately. Add the same option to the outer zone so the same gesture (long-press, then drag) is required to reorder groups.

## What this preserves

- ✅ Quick tap on a header still toggles collapse/expand.
- ✅ Touch + immediate scroll still scrolls the page.
- ✅ Long-press on a header (≥500ms) + drag still reorders groups.

The bug explicitly said *"We do NOT want to remove the drag and drop behavior on mobile."* — the long-press fully preserves it.

## Why this is the right fix

\`svelte-dnd-action\`'s docs ([action.js](https://github.com/isaacHagoel/svelte-dnd-action)):

> \`delayTouchStart\`: On touch devices, wait this long before converting the gesture to a drag.

The \`touchDragDelayMs = 500\` constant (\`ListView.svelte:46\`) was already defined and applied to the inner items dndzone. This PR symmetrically applies it to the outer groups dndzone — same constant, same library option, same behaviour the user is already used to for intra-group item reordering.

## Test plan

- [x] \`cd web && npm run build\` — clean
- [x] \`go build ./... && go test ./...\` — clean (no Go change)
- [x] Manually verified on iOS via the running server:
  - Quick tap on status header → group collapses ✓
  - Brief touch + drag-to-scroll → page scrolls (header does NOT travel with finger) ✓
  - Long-press (≥500ms) on header + drag → group reorders ✓
- [ ] Reviewer to spot-check on Android.

## Related

Companion to the existing intra-group item touch behaviour. No backend change.