### PR TITLE
fix(web): truncate long parent titles on item cards (BUG-630)

### DIFF
--- a/web/src/lib/components/collections/ItemCard.svelte
+++ b/web/src/lib/components/collections/ItemCard.svelte
@@ -128,7 +128,8 @@
 		{/if}
 		{#if item.parent_title}
 			<span class="meta-sep">&middot;</span>
-			<span class="meta-parent">{item.parent_ref ? `${item.parent_ref}: ${item.parent_title}` : item.parent_title}</span>
+			{@const parentLabel = item.parent_ref ? `${item.parent_ref}: ${item.parent_title}` : item.parent_title}
+			<span class="meta-parent" title={parentLabel}>{parentLabel}</span>
 		{/if}
 		{#if item.agent_role_name}
 			<span class="meta-sep">&middot;</span>
@@ -219,6 +220,10 @@
 		align-items: center;
 		gap: 5px;
 		flex-wrap: wrap;
+		/* Allow flex children with intrinsic content wider than the card
+		   (e.g. a long parent title from an `implements` link to an idea)
+		   to shrink instead of pushing the card past its column. */
+		min-width: 0;
 	}
 
 	.meta-status {
@@ -279,7 +284,16 @@
 		font-size: 0.7em;
 		font-weight: 500;
 		color: var(--accent-purple, var(--text-secondary));
+		/* Long parent titles (e.g. a task that implements an idea whose
+		   title is a paragraph) used to push the card outside its
+		   container on Board view (BUG-630). Cap the chip to the card
+		   width and truncate with an ellipsis; the full label is still
+		   accessible via the tooltip on hover. */
 		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		max-width: 100%;
+		min-width: 0;
 	}
 
 	.meta-role {


### PR DESCRIPTION
## Summary

When a task implements an idea whose title is long (e.g. an idea recorded as a full sentence), the resulting `IDEA-XXX: <long sentence>` chip on the task's item card pushed the card past its column bounds on Board view, making the layout overflow horizontally.

## Why

`item.parent_title` is populated by `enrichItemForResponse()` for BOTH `parent` and `implements` link types — see `childLinkTypes = []string{"parent", "implements"}` in `internal/store/items.go:17`. So an "implements an idea" relationship puts the idea's title in the `.meta-parent` chip on `ItemCard.svelte`, which had `white-space: nowrap` and no width cap. A long parent title therefore extended beyond the card content area.

## Fix

`web/src/lib/components/collections/ItemCard.svelte`:

- `.meta-parent`: add `overflow: hidden; text-overflow: ellipsis; max-width: 100%; min-width: 0;` alongside the existing `nowrap`. Long titles now truncate with `…` at the card edge.
- `.card-meta`: add `min-width: 0` so flex children with intrinsic content wider than the card can actually shrink instead of forcing the parent flex container to grow.
- Template: extract the chip label into a `@const parentLabel` and pass it both as the visible text and as the `title` attribute, so the full label is still readable via the browser tooltip after truncation.

## Affected views

`ItemCard.svelte` is shared between Board and List views, so both benefit. The bug was reported against Board (where columns are narrowest), and that's where the visual overflow was worst.

## Test plan

- [x] `cd web && npm run build` — clean
- [x] `go build ./... && go test ./...` — clean (no Go change)
- [x] Manually verified at the running dev server (binary on this branch):
  - Loaded docapp/tasks Board view with the known long-parent item (`add-pad-server-info-for-local-and-remote-connection-status` → IDEA-322, parent title 89 chars).
  - Card stays within its column ✓
  - Chip shows `IDEA-322: we should add a 'pad info' cli command…` truncated with ellipsis ✓
  - Hover shows full label via tooltip ✓
  - List view also looks correct (no regression on items with short parent titles).

## Related

No backend change. Same constant `parent_title` API contract, just a frontend rendering fix.