### PR TITLE
fix(store): eliminate spurious SQLITE_BUSY on concurrent writes

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -34,20 +34,42 @@ func (s *Store) D() Dialect { return s.dialect }
 func (s *Store) DB() *sql.DB { return s.db }
 
 // New creates a Store backed by SQLite at the given path.
+//
+// The DSN is configured for safe concurrent use under Go's connection pool:
+//
+//   - `_pragma=busy_timeout(5000)`: when a connection finds the database
+//     locked, retry for up to 5 seconds before returning SQLITE_BUSY. The
+//     pragma is applied per-connection by the driver, so every pool member
+//     inherits it.
+//   - `_pragma=foreign_keys(on)`: foreign-key enforcement is per-connection
+//     in SQLite. Setting it via the DSN guarantees ALL pool members enforce
+//     them, not just the one that received a `db.Exec("PRAGMA ...")` call.
+//   - `_txlock=immediate`: makes every `db.Begin()` issue `BEGIN IMMEDIATE`
+//     instead of the default `BEGIN DEFERRED`. With deferred mode, a
+//     transaction starts holding only a SHARED lock and tries to upgrade
+//     to a write lock on the first INSERT/UPDATE — and lock upgrades are
+//     refused with SQLITE_BUSY *immediately* if another connection holds
+//     the write lock, regardless of busy_timeout (SQLite refuses to wait
+//     because that would risk deadlock between two connections both holding
+//     SHARED locks). With IMMEDIATE, the write lock is acquired at BEGIN
+//     time, and busy_timeout's wait-and-retry behaviour does apply, so
+//     concurrent writers serialize cleanly instead of failing with
+//     "database is locked". Reads are unaffected: single-statement SELECTs
+//     don't open a transaction at the SQL layer, so they continue to run
+//     concurrently against the WAL snapshot.
+//   - `journal_mode=WAL` is set via Exec below; WAL is a database-level
+//     setting (stored in the file header), so it persists across
+//     connections after the first one applies it.
 func New(dbPath string) (*Store, error) {
-	db, err := sql.Open("sqlite", dbPath+"?_pragma=busy_timeout(5000)")
+	dsn := dbPath + "?_pragma=busy_timeout(5000)&_pragma=foreign_keys(on)&_txlock=immediate"
+	db, err := sql.Open("sqlite", dsn)
 	if err != nil {
 		return nil, fmt.Errorf("open database: %w", err)
 	}
 
-	// Enable WAL mode
+	// Enable WAL mode (database-level: persists across connections).
 	if _, err := db.Exec("PRAGMA journal_mode=WAL"); err != nil {
 		return nil, fmt.Errorf("enable WAL: %w", err)
-	}
-
-	// Enable foreign keys
-	if _, err := db.Exec("PRAGMA foreign_keys=ON"); err != nil {
-		return nil, fmt.Errorf("enable foreign keys: %w", err)
 	}
 
 	s := &Store{db: db, dialect: &sqliteDialect{}}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -57,6 +57,28 @@ func (s *Store) DB() *sql.DB { return s.db }
 //     "database is locked". Reads are unaffected: single-statement SELECTs
 //     don't open a transaction at the SQL layer, so they continue to run
 //     concurrently against the WAL snapshot.
+//
+//     Tradeoff: IMMEDIATE widens the writer critical section. Some update
+//     flows (e.g. items.UpdateItem, documents.UpdateDocument) now hold the
+//     write lock during diff/version-throttle reads and slug-collision
+//     checks, not just during the final INSERT/UPDATE. In practice these
+//     reads are sub-millisecond and dominated by network/HTTP latency,
+//     so concurrent writers wait briefly for cleanly serialized work
+//     rather than failing fast. The pre-fix behaviour was "fail fast
+//     with BUSY"; this is strictly better. If a future hot path produces
+//     pathologically long write transactions (>100ms holding the lock),
+//     the right move is to narrow that specific transaction — not to
+//     revert this fix.
+//
+//     Rollout note for `_pragma=foreign_keys(on)`: FK enforcement was
+//     previously per-connection, applied to only one pool member. If a
+//     database was historically written through a different pool member
+//     with FKs disabled, latent integrity violations may exist; the
+//     `sql.Open` itself will not fail, but the next write touching a
+//     stale relationship can now return an FK error. For Pad's data
+//     model the realistic fallout is small (link tables already cascade),
+//     but the integrity check `PRAGMA foreign_key_check` can surface
+//     any pre-existing offenders.
 //   - `journal_mode=WAL` is set via Exec below; WAL is a database-level
 //     setting (stored in the file header), so it persists across
 //     connections after the first one applies it.

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/google/uuid"
@@ -199,28 +200,41 @@ func TestSQLiteConcurrentWritersNoBusy(t *testing.T) {
 		t.Fatalf("create collection: %v", err)
 	}
 
-	// 20 goroutines each create one item — these all open transactions
+	// 25 goroutines × 5 ops each — these all open transactions
 	// (tryCreateItem in items.go uses db.Begin), and previously raced
 	// for the write-lock on upgrade.
-	const workers = 20
-	errCh := make(chan error, workers)
-	doneCh := make(chan struct{}, workers)
+	//
+	// We use an explicit start gate so all goroutines try to write at
+	// roughly the same moment, maximising lock contention. Without the
+	// gate, slow CI runners could sequentialize the work and the test
+	// would silently pass even on a regressed build. We also do multiple
+	// ops per worker so each goroutine produces several BEGIN/COMMIT
+	// cycles instead of just one.
+	const workers = 25
+	const opsPerWorker = 5
+	errCh := make(chan error, workers*opsPerWorker)
+	var startGate sync.WaitGroup
+	startGate.Add(1)
+	var done sync.WaitGroup
 	for i := 0; i < workers; i++ {
 		idx := i
+		done.Add(1)
 		go func() {
-			_, err := s.CreateItem(ws.ID, coll.ID, models.ItemCreate{
-				Title:  fmt.Sprintf("concurrent-%d", idx),
-				Fields: `{"status":"open"}`,
-			})
-			if err != nil {
-				errCh <- err
+			defer done.Done()
+			startGate.Wait() // hold all goroutines until the gate opens
+			for op := 0; op < opsPerWorker; op++ {
+				_, err := s.CreateItem(ws.ID, coll.ID, models.ItemCreate{
+					Title:  fmt.Sprintf("concurrent-%d-%d", idx, op),
+					Fields: `{"status":"open"}`,
+				})
+				if err != nil {
+					errCh <- err
+				}
 			}
-			doneCh <- struct{}{}
 		}()
 	}
-	for i := 0; i < workers; i++ {
-		<-doneCh
-	}
+	startGate.Done() // release every worker simultaneously
+	done.Wait()
 	close(errCh)
 
 	var errs []error
@@ -228,7 +242,7 @@ func TestSQLiteConcurrentWritersNoBusy(t *testing.T) {
 		errs = append(errs, e)
 	}
 	if len(errs) > 0 {
-		t.Errorf("expected zero errors under concurrent writes, got %d:", len(errs))
+		t.Errorf("expected zero errors under %d concurrent writers × %d ops, got %d:", workers, opsPerWorker, len(errs))
 		for _, e := range errs {
 			t.Errorf("  - %v", e)
 		}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -204,24 +204,37 @@ func TestSQLiteConcurrentWritersNoBusy(t *testing.T) {
 	// (tryCreateItem in items.go uses db.Begin), and previously raced
 	// for the write-lock on upgrade.
 	//
-	// We use an explicit start gate so all goroutines try to write at
-	// roughly the same moment, maximising lock contention. Without the
-	// gate, slow CI runners could sequentialize the work and the test
-	// would silently pass even on a regressed build. We also do multiple
-	// ops per worker so each goroutine produces several BEGIN/COMMIT
-	// cycles instead of just one.
+	// We use a TRUE barrier (not just a start gate) so every worker has
+	// reached the wait point BEFORE we release them. The earlier draft
+	// of this test used a single Done()/Wait() pair, but that doesn't
+	// guarantee all goroutines have parked on Wait() before Done() runs
+	// — late-scheduled goroutines could arrive after Done() and never
+	// hit the gate at all, defeating the contention we're trying to
+	// reproduce on slow CI runners. The two-WaitGroup pattern below
+	// (every worker signals "ready", main thread waits for all, then
+	// releases everyone simultaneously) is the standard fix.
+	//
+	// Combined with multiple ops per worker (each producing its own
+	// BEGIN/COMMIT cycle through CreateItem → tryCreateItem), this
+	// produces a sustained lock-contention window that a regressed
+	// deferred-transaction build cannot pass.
 	const workers = 25
 	const opsPerWorker = 5
 	errCh := make(chan error, workers*opsPerWorker)
-	var startGate sync.WaitGroup
-	startGate.Add(1)
+
+	var ready sync.WaitGroup
+	ready.Add(workers)
+	var release sync.WaitGroup
+	release.Add(1)
 	var done sync.WaitGroup
+
 	for i := 0; i < workers; i++ {
 		idx := i
 		done.Add(1)
 		go func() {
 			defer done.Done()
-			startGate.Wait() // hold all goroutines until the gate opens
+			ready.Done()     // signal "I'm at the gate"
+			release.Wait()   // park here until main thread releases
 			for op := 0; op < opsPerWorker; op++ {
 				_, err := s.CreateItem(ws.ID, coll.ID, models.ItemCreate{
 					Title:  fmt.Sprintf("concurrent-%d-%d", idx, op),
@@ -233,7 +246,8 @@ func TestSQLiteConcurrentWritersNoBusy(t *testing.T) {
 			}
 		}()
 	}
-	startGate.Done() // release every worker simultaneously
+	ready.Wait()    // every worker is parked on release.Wait()
+	release.Done()  // release them all at once
 	done.Wait()
 	close(errCh)
 

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -204,20 +204,23 @@ func TestSQLiteConcurrentWritersNoBusy(t *testing.T) {
 	// (tryCreateItem in items.go uses db.Begin), and previously raced
 	// for the write-lock on upgrade.
 	//
-	// We use a TRUE barrier (not just a start gate) so every worker has
-	// reached the wait point BEFORE we release them. The earlier draft
-	// of this test used a single Done()/Wait() pair, but that doesn't
-	// guarantee all goroutines have parked on Wait() before Done() runs
-	// — late-scheduled goroutines could arrive after Done() and never
-	// hit the gate at all, defeating the contention we're trying to
-	// reproduce on slow CI runners. The two-WaitGroup pattern below
-	// (every worker signals "ready", main thread waits for all, then
-	// releases everyone simultaneously) is the standard fix.
+	// Synchronization: a two-WaitGroup pattern (`ready` to confirm each
+	// worker has reached the gate, then `release` to free them all at
+	// once). This is NOT a mathematically exact barrier — there's a
+	// small unobservable gap between `ready.Done()` and `release.Wait()`
+	// in each worker, and a worker descheduled in that gap could miss
+	// the simultaneous release. In practice the gap is sub-microsecond,
+	// vanishingly small compared to the millisecond-scale contention
+	// window the test is probing, and the multiple-ops-per-worker
+	// structure means even a slightly-late worker still produces enough
+	// concurrent BEGIN IMMEDIATE attempts to exercise the race.
 	//
-	// Combined with multiple ops per worker (each producing its own
-	// BEGIN/COMMIT cycle through CreateItem → tryCreateItem), this
-	// produces a sustained lock-contention window that a regressed
-	// deferred-transaction build cannot pass.
+	// Empirical check (2026-04-25): with `_txlock=immediate` removed
+	// from the DSN this test reliably FAILS — 22 errors out of 125 ops
+	// per run, all `database is locked (5) (SQLITE_BUSY)`. With the
+	// fix in place, 20 consecutive `go test -count=20` runs all pass.
+	// So the imprecision in the barrier doesn't impair the test's
+	// regression-catching ability.
 	const workers = 25
 	const opsPerWorker = 5
 	errCh := make(chan error, workers*opsPerWorker)

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -216,10 +216,12 @@ func TestSQLiteConcurrentWritersNoBusy(t *testing.T) {
 	// concurrent BEGIN IMMEDIATE attempts to exercise the race.
 	//
 	// Empirical check (2026-04-25): with `_txlock=immediate` removed
-	// from the DSN this test reliably FAILS — 22 errors out of 125 ops
-	// per run, all `database is locked (5) (SQLITE_BUSY)`. With the
-	// fix in place, 20 consecutive `go test -count=20` runs all pass.
-	// So the imprecision in the barrier doesn't impair the test's
+	// from the DSN this test reliably FAILS — a representative run on
+	// a developer laptop produced ~22 errors out of 125 ops, all
+	// `database is locked (5) (SQLITE_BUSY)`; the exact rate is
+	// host- and scheduler-dependent but consistently >0. With the fix
+	// in place, 20 consecutive `go test -count=20` runs all pass. So
+	// the imprecision in the barrier doesn't impair the test's
 	// regression-catching ability.
 	const workers = 25
 	const opsPerWorker = 5
@@ -249,7 +251,7 @@ func TestSQLiteConcurrentWritersNoBusy(t *testing.T) {
 			}
 		}()
 	}
-	ready.Wait()    // every worker is parked on release.Wait()
+	ready.Wait()    // every worker has called ready.Done() (best-effort gate)
 	release.Done()  // release them all at once
 	done.Wait()
 	close(errCh)

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -164,6 +164,77 @@ func schemaFieldKeys(t *testing.T, schemaJSON string) []string {
 	return keys
 }
 
+// TestSQLiteConcurrentWritersNoBusy guards against the BUG-748-followup
+// regression where Go's default deferred-mode transactions returned
+// SQLITE_BUSY immediately under contention because lock-upgrade does not
+// honor busy_timeout. With `_txlock=immediate` set in the DSN, every
+// `db.Begin()` issues `BEGIN IMMEDIATE`, so the write lock is acquired
+// up-front and concurrent writers wait via busy_timeout instead of
+// failing fast.
+//
+// The benchmark in `bench_concurrent_test.go` quantifies throughput;
+// this test specifically asserts ZERO errors under a concurrent-update
+// workload that previously produced multiple `SQLITE_BUSY` returns.
+func TestSQLiteConcurrentWritersNoBusy(t *testing.T) {
+	if os.Getenv("PAD_TEST_POSTGRES_URL") != "" {
+		t.Skip("SQLite-specific concurrency test; postgres has its own MVCC semantics")
+	}
+
+	dir := t.TempDir()
+	s, err := New(filepath.Join(dir, "test.db"))
+	if err != nil {
+		t.Fatalf("create store: %v", err)
+	}
+	defer s.Close()
+
+	ws, err := s.CreateWorkspace(models.WorkspaceCreate{Name: "concurrency"})
+	if err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	coll, err := s.CreateCollection(ws.ID, models.CollectionCreate{
+		Name:   "Tasks",
+		Schema: `{"fields":[{"key":"status","label":"Status","type":"select","options":["open","done"],"default":"open","required":true}]}`,
+	})
+	if err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+
+	// 20 goroutines each create one item — these all open transactions
+	// (tryCreateItem in items.go uses db.Begin), and previously raced
+	// for the write-lock on upgrade.
+	const workers = 20
+	errCh := make(chan error, workers)
+	doneCh := make(chan struct{}, workers)
+	for i := 0; i < workers; i++ {
+		idx := i
+		go func() {
+			_, err := s.CreateItem(ws.ID, coll.ID, models.ItemCreate{
+				Title:  fmt.Sprintf("concurrent-%d", idx),
+				Fields: `{"status":"open"}`,
+			})
+			if err != nil {
+				errCh <- err
+			}
+			doneCh <- struct{}{}
+		}()
+	}
+	for i := 0; i < workers; i++ {
+		<-doneCh
+	}
+	close(errCh)
+
+	var errs []error
+	for e := range errCh {
+		errs = append(errs, e)
+	}
+	if len(errs) > 0 {
+		t.Errorf("expected zero errors under concurrent writes, got %d:", len(errs))
+		for _, e := range errs {
+			t.Errorf("  - %v", e)
+		}
+	}
+}
+
 func TestNewStore(t *testing.T) {
 	if os.Getenv("PAD_TEST_POSTGRES_URL") != "" {
 		t.Skip("skipping SQLite-specific test when running against PostgreSQL")


### PR DESCRIPTION
## Summary

\`pad item update --comment ...\` and similar concurrent-write paths intermittently failed with \`internal error\` and a server log of \`update item: database is locked (5) (SQLITE_BUSY)\`. The skill's CLI reference even documented a workaround — *"use a separate \`pad item comment\` call rather than \`--comment\` on update"* — but that workaround only **lowered the contention probability**; the same root cause still bit both paths.

## Root cause

Go's default \`db.Begin()\` issues \`BEGIN DEFERRED\` on SQLite, which acquires only a SHARED lock at BEGIN time. The first INSERT/UPDATE in the transaction tries to upgrade to a write lock — and SQLite refuses that upgrade with \`SQLITE_BUSY\` **immediately** if any other connection already holds the write lock.

Crucially, \`busy_timeout\`'s wait-and-retry behaviour does **not** apply on lock-upgrade. Waiting could deadlock two connections that both hold SHARED locks, so SQLite chooses to fail fast. Result: under even modest write concurrency, the 5-second \`busy_timeout\` we configured is moot — transactions fail in milliseconds.

## Reproduction (before the fix)

20 concurrent PATCHes against the running server produced 4 \`SQLITE_BUSY\` errors. Logged failure durations were 4–14ms — far below the 5000ms \`busy_timeout\`. The pattern was very visible immediately after \`make install\` (web SSE clients reconnecting + workflow tooling firing PATCHes in tight loops).

## Fix

Add \`_txlock=immediate\` to the DSN. Every \`db.Begin()\` now issues \`BEGIN IMMEDIATE\`, acquiring the write lock up-front. **Lock acquisition DOES honor \`busy_timeout\`,** so concurrent writers serialize cleanly with up to 5s of patience instead of failing fast.

Reads are unaffected: single-statement SELECTs don't open a transaction at the SQL layer.

Also fold \`foreign_keys=on\` into the DSN's \`_pragma\` list. FK enforcement is per-connection in SQLite, so the previous \`db.Exec("PRAGMA foreign_keys=ON")\` only configured the one connection that received the call — every OTHER pool member ran without FK enforcement. The DSN form applies it to every connection the driver opens.

\`journal_mode=WAL\` stays as a \`db.Exec\` call because WAL is a database-level setting recorded in the file header; it persists across connections after the first one applies it.

## Validation

- ✅ Repro before the fix: 20 concurrent PATCHes → 4 errors.
- ✅ Same workload after the fix: 0 errors.
- ✅ New regression test \`TestSQLiteConcurrentWritersNoBusy\` (20 concurrent CreateItem) — passes; would have failed on \`main\`.
- ✅ Existing \`TestConcurrentWritePerformance\` benchmark — 0 errors at every level (1, 5, 10, 25, 50 concurrent workers); previously acknowledged non-zero errors as expected.
- ✅ \`go test -count=1 ./...\` — all 14 packages green.

## Investigation transcript (FYI)

Verified all 13 \`db.Begin()\` call sites in \`internal/store/\` are write paths — none are read-only — so making them all IMMEDIATE has no read-throughput downside. (\`grep -rn "s\.db\.Begin"\` listed: agent_roles, documents, export, items×3, share_links, store, users×2, workspace_members×2.) Also confirmed no \`BeginTx\` / \`TxOptions\` / \`LevelReadOnly\` callers anywhere.

## Test plan

- [x] \`go build ./...\` — clean
- [x] \`go vet ./...\` — clean
- [x] \`go test -count=1 ./...\` — clean (server pkg 67s, store pkg 30s, all green)
- [x] Concurrency benchmark: \`go test -run TestConcurrentWritePerformance ./internal/store -v\` — 0 errors at every level
- [x] Regression test: \`go test -run TestSQLiteConcurrentWritersNoBusy ./internal/store -v\` — passes
- [x] Live repro: \`make install\` and 20 concurrent \`pad item update --comment\` in a script — 0/20 errors after fix