### PR TITLE
feat(web): restore last-visited route on workspace switch (TASK-754)

### DIFF
--- a/web/src/lib/components/layout/WorkspaceSwitcher.svelte
+++ b/web/src/lib/components/layout/WorkspaceSwitcher.svelte
@@ -66,13 +66,17 @@
 		// Falls back to the dashboard on miss, parse error, storage error,
 		// or any saved path that doesn't belong to this workspace (guards
 		// against username changes / corrupt entries / cross-workspace
-		// bleed). Implements IDEA-753 / TASK-754.
+		// bleed). Saved value can include a `?...` query string — we
+		// validate the path-portion only. Implements IDEA-753 / TASK-754.
 		const fallback = `/${ws.owner_username}/${ws.slug}`;
 		let target = fallback;
 		try {
 			const saved = localStorage.getItem(`pad-last-route-${ws.slug}`);
-			if (saved && (saved === fallback || saved.startsWith(fallback + '/'))) {
-				target = saved;
+			if (saved) {
+				const savedPath = saved.split('?')[0];
+				if (savedPath === fallback || savedPath.startsWith(fallback + '/')) {
+					target = saved;
+				}
 			}
 		} catch {
 			// localStorage unavailable; fall through to dashboard.

--- a/web/src/lib/components/layout/WorkspaceSwitcher.svelte
+++ b/web/src/lib/components/layout/WorkspaceSwitcher.svelte
@@ -63,23 +63,40 @@
 
 		// Restore the last-visited route in this workspace if we have one
 		// in localStorage (written by the workspace +layout on every nav).
-		// Falls back to the dashboard on miss, parse error, storage error,
-		// or any saved path that doesn't belong to this workspace (guards
-		// against username changes / corrupt entries / cross-workspace
-		// bleed). Saved value can include a `?...` query string — we
-		// validate the path-portion only. Implements IDEA-753 / TASK-754.
+		// Implements IDEA-753 / TASK-754.
+		//
+		// The saved value is treated as untrusted input — it could be
+		// stale, corrupt, or crafted. We canonicalize through `URL` and
+		// require:
+		//
+		//  - same origin (rejects scheme/`//host` smuggling),
+		//  - workspace prefix on the *normalized* pathname,
+		//  - no traversal segments or percent-encoded chars in the path
+		//    (the app never generates either; rejecting them blocks
+		//    `%2e%2e/...` style escapes that could pass a naive prefix
+		//    check but resolve elsewhere via `goto()` normalization).
+		//
+		// Anything failing the gauntlet falls back to the dashboard.
 		const fallback = `/${ws.owner_username}/${ws.slug}`;
 		let target = fallback;
 		try {
 			const saved = localStorage.getItem(`pad-last-route-${ws.slug}`);
 			if (saved) {
-				const savedPath = saved.split('?')[0];
-				if (savedPath === fallback || savedPath.startsWith(fallback + '/')) {
-					target = saved;
+				const normalized = new URL(saved, window.location.origin);
+				const path = normalized.pathname;
+				const sameOrigin = normalized.origin === window.location.origin;
+				const inWorkspace = path === fallback || path.startsWith(fallback + '/');
+				const cleanPath =
+					!path.includes('/..') &&
+					!path.includes('/./') &&
+					!path.includes('//') &&
+					!/%[0-9a-fA-F]{2}/.test(path);
+				if (sameOrigin && inWorkspace && cleanPath) {
+					target = normalized.pathname + normalized.search + normalized.hash;
 				}
 			}
 		} catch {
-			// localStorage unavailable; fall through to dashboard.
+			// localStorage unavailable or URL parse failed; fall through to dashboard.
 		}
 		goto(target);
 	}

--- a/web/src/lib/components/layout/WorkspaceSwitcher.svelte
+++ b/web/src/lib/components/layout/WorkspaceSwitcher.svelte
@@ -60,7 +60,24 @@
 		// workspace links did this on click, so preserve the behavior now
 		// that the switcher is the mobile nav entry point.
 		uiStore.onNavigate();
-		goto(`/${ws.owner_username}/${ws.slug}`);
+
+		// Restore the last-visited route in this workspace if we have one
+		// in localStorage (written by the workspace +layout on every nav).
+		// Falls back to the dashboard on miss, parse error, storage error,
+		// or any saved path that doesn't belong to this workspace (guards
+		// against username changes / corrupt entries / cross-workspace
+		// bleed). Implements IDEA-753 / TASK-754.
+		const fallback = `/${ws.owner_username}/${ws.slug}`;
+		let target = fallback;
+		try {
+			const saved = localStorage.getItem(`pad-last-route-${ws.slug}`);
+			if (saved && (saved === fallback || saved.startsWith(fallback + '/'))) {
+				target = saved;
+			}
+		} catch {
+			// localStorage unavailable; fall through to dashboard.
+		}
+		goto(target);
 	}
 
 	function openCreateModal() {

--- a/web/src/routes/[username]/[workspace]/+layout.svelte
+++ b/web/src/routes/[username]/[workspace]/+layout.svelte
@@ -62,6 +62,24 @@
 		titleStore.setPageTitle({ section: null, item: null });
 	});
 
+	// Persist the user's last-visited route per workspace so the workspace
+	// switcher (WorkspaceSwitcher.svelte) can restore it on switch instead
+	// of always landing on the dashboard. Implements IDEA-753 / TASK-754.
+	//
+	// Per CONVE-606, this is its own effect with a clean dependency list
+	// (wsSlug + pathname). Combining with the title sync above would re-run
+	// it on async workspace-name resolution and could overwrite the saved
+	// route at unexpected times. Storage failures (private-mode quota,
+	// disabled storage) are swallowed — restoration just won't kick in.
+	$effect(() => {
+		if (!wsSlug) return;
+		try {
+			localStorage.setItem(`pad-last-route-${wsSlug}`, page.url.pathname);
+		} catch {
+			// localStorage unavailable; silent no-op.
+		}
+	});
+
 	// Initialize workspace, load collections, and reconnect SSE when workspace changes
 	$effect(() => {
 		if (wsSlug) {

--- a/web/src/routes/[username]/[workspace]/+layout.svelte
+++ b/web/src/routes/[username]/[workspace]/+layout.svelte
@@ -66,15 +66,24 @@
 	// switcher (WorkspaceSwitcher.svelte) can restore it on switch instead
 	// of always landing on the dashboard. Implements IDEA-753 / TASK-754.
 	//
+	// We persist `pathname + search` so URL-carried state (collection
+	// view mode, sort, group-by, filters, search query — see e.g.
+	// `/[collection]/+page.svelte` which mutates `?view=...`) is part of
+	// the restored location.
+	//
 	// Per CONVE-606, this is its own effect with a clean dependency list
-	// (wsSlug + pathname). Combining with the title sync above would re-run
-	// it on async workspace-name resolution and could overwrite the saved
-	// route at unexpected times. Storage failures (private-mode quota,
-	// disabled storage) are swallowed — restoration just won't kick in.
+	// (wsSlug + pathname + search). Combining with the title sync above
+	// would re-run it on async workspace-name resolution and could
+	// overwrite the saved route at unexpected times. Storage failures
+	// (private-mode quota, disabled storage) are swallowed — restoration
+	// just won't kick in.
 	$effect(() => {
 		if (!wsSlug) return;
 		try {
-			localStorage.setItem(`pad-last-route-${wsSlug}`, page.url.pathname);
+			localStorage.setItem(
+				`pad-last-route-${wsSlug}`,
+				page.url.pathname + page.url.search
+			);
 		} catch {
 			// localStorage unavailable; silent no-op.
 		}

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -213,6 +213,15 @@
 	async function loadData() {
 		loading = true;
 		error = '';
+		// Capture the URL parts this load was scoped to. Used in the catch
+		// path to detect whether the user has navigated away before this
+		// request rejected — without this the stale catch would clobber a
+		// fresh `pad-last-route-{wsSlug}` written by the workspace +layout
+		// effect after the user moved on (TASK-754 round-2 race guard).
+		const reqUsername = username;
+		const reqWsSlug = wsSlug;
+		const reqCollSlug = collSlug;
+		const reqItemSlug = itemSlug;
 		try {
 			const [itemData, collData] = await Promise.all([
 				api.items.get(wsSlug, itemSlug),
@@ -260,9 +269,20 @@
 			error = e.message ?? 'Failed to load item';
 			// Clear the workspace's last-route cache so the workspace
 			// switcher (TASK-754) doesn't keep restoring this dead item
-			// URL on subsequent re-entries. The workspace +layout will
-			// re-populate the cache as soon as the user navigates again.
-			try { localStorage.removeItem(`pad-last-route-${wsSlug}`); } catch {}
+			// URL on subsequent re-entries — but only if the stored value
+			// still points at THIS failed URL. If the user navigated away
+			// while the request was in flight, the +layout effect has
+			// already written a newer entry and we must not clobber it.
+			try {
+				const failedPath = `/${reqUsername}/${reqWsSlug}/${reqCollSlug}/${reqItemSlug}`;
+				const cached = localStorage.getItem(`pad-last-route-${reqWsSlug}`);
+				if (cached) {
+					const cachedPath = cached.split('?')[0].split('#')[0];
+					if (cachedPath === failedPath) {
+						localStorage.removeItem(`pad-last-route-${reqWsSlug}`);
+					}
+				}
+			} catch {}
 		} finally {
 			loading = false;
 

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -258,6 +258,11 @@
 			} catch { agentRoles = []; }
 		} catch (e: any) {
 			error = e.message ?? 'Failed to load item';
+			// Clear the workspace's last-route cache so the workspace
+			// switcher (TASK-754) doesn't keep restoring this dead item
+			// URL on subsequent re-entries. The workspace +layout will
+			// re-populate the cache as soon as the user navigates again.
+			try { localStorage.removeItem(`pad-last-route-${wsSlug}`); } catch {}
 		} finally {
 			loading = false;
 


### PR DESCRIPTION
## Summary

When a user clicks a workspace in the **WorkspaceSwitcher**, restore the route they last visited in that workspace instead of always landing on the dashboard.

- The workspace `+layout` writes the current `pathname + search` to `localStorage` on every nav, keyed by `pad-last-route-{wsSlug}`.
- The switcher's `select()` reads that key, validates it through a strict `URL` canonicalization (same origin, in-workspace, no traversal/encoded paths), and `goto()`s there — falling back to the dashboard on miss / corrupt entry / storage error.
- The item-detail page clears its workspace's cache on fetch failure so deleted items don't become sticky restore targets — guarded against in-flight stale-request clobber.
- Direct Dashboard navigation (sidebar + mobile header `<a href>`) is unchanged.

## Context

Implements `IDEA-753`. Closes `TASK-754`. Sibling task `TASK-755` (scroll-position restoration) follows.

Per `CONVE-735` the branch was reviewed via `codex exec` to **CLEAN** before push (3 rounds — round 1 surfaced query-string loss + sticky-stale items; round 2 surfaced an in-flight stale-request race + path-traversal smuggling; round 3 confirmed clean).

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./...` — all pass
- [x] `cd web && npm run build` — clean
- [x] Codex CLI review — CLEAN at round 3
- [ ] Manual: switch into workspace A from B, verify last route restored; deep into an item, switch out, switch back — same item URL with query string preserved
- [ ] Manual: workspace name (sidebar) and Dashboard nav still go to dashboard, unchanged
- [ ] Manual: navigate to a deleted item, switch out and back — switcher falls back to dashboard, not the dead URL