### PR TITLE
fix(web): wire desktop topbar workspace switching through last-route restore

### DIFF
--- a/web/src/lib/components/layout/TopBar.svelte
+++ b/web/src/lib/components/layout/TopBar.svelte
@@ -7,8 +7,10 @@
 	import { api } from '$lib/api/client';
 	import type { Workspace } from '$lib/types';
 	import { onMount } from 'svelte';
+	import { goto } from '$app/navigation';
 	import PadLogo from '$lib/components/layout/PadLogo.svelte';
 	import WorkspaceSwitcher from '$lib/components/layout/WorkspaceSwitcher.svelte';
+	import { workspaceRestoreTarget } from '$lib/utils/workspace-route';
 
 	let { mobile = false }: { mobile?: boolean } = $props();
 
@@ -124,11 +126,28 @@
 			onfinalize={handleFinalize}
 		>
 			{#each dndWorkspaces as ws (ws.id)}
+				<!--
+					href stays pointed at the workspace dashboard so a
+					middle-click / cmd-click / right-click → "Open in new
+					tab" lands on a clean dashboard. Plain left-click is
+					intercepted to restore the last-visited route in that
+					workspace (TASK-754) — the previous behavior was a
+					hard `<a>` nav to the dashboard, which silently
+					overwrote the saved deep route in localStorage on
+					every workspace switch.
+				-->
 				<a
 					href="/{ws.owner_username}/{ws.slug}"
 					class="workspace-item"
 					class:active={ws.slug === currentSlug}
 					title={ws.name}
+					onclick={(e) => {
+						// Respect modifier-clicks and middle-click (button !== 0)
+						// so users can still open the dashboard in a new tab.
+						if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) return;
+						e.preventDefault();
+						goto(workspaceRestoreTarget(ws));
+					}}
 				>
 					<span
 						class="workspace-icon"

--- a/web/src/lib/components/layout/TopBar.svelte
+++ b/web/src/lib/components/layout/TopBar.svelte
@@ -146,7 +146,14 @@
 						// so users can still open the dashboard in a new tab.
 						if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) return;
 						e.preventDefault();
-						goto(workspaceRestoreTarget(ws));
+						// Click on the workspace you're already in → go to
+						// dashboard (overrides restore — gives users a way back
+						// to the workspace home from any nested route).
+						// Click on a different workspace → restore last route.
+						const target = ws.slug === currentSlug
+							? `/${ws.owner_username}/${ws.slug}`
+							: workspaceRestoreTarget(ws);
+						goto(target);
 					}}
 				>
 					<span

--- a/web/src/lib/components/layout/WorkspaceSwitcher.svelte
+++ b/web/src/lib/components/layout/WorkspaceSwitcher.svelte
@@ -3,6 +3,7 @@
 	import { workspaceStore } from '$lib/stores/workspace.svelte';
 	import { uiStore } from '$lib/stores/ui.svelte';
 	import BottomSheet from '$lib/components/common/BottomSheet.svelte';
+	import { workspaceRestoreTarget } from '$lib/utils/workspace-route';
 
 	interface Props {
 		/**
@@ -60,45 +61,9 @@
 		// workspace links did this on click, so preserve the behavior now
 		// that the switcher is the mobile nav entry point.
 		uiStore.onNavigate();
-
-		// Restore the last-visited route in this workspace if we have one
-		// in localStorage (written by the workspace +layout on every nav).
-		// Implements IDEA-753 / TASK-754.
-		//
-		// The saved value is treated as untrusted input — it could be
-		// stale, corrupt, or crafted. We canonicalize through `URL` and
-		// require:
-		//
-		//  - same origin (rejects scheme/`//host` smuggling),
-		//  - workspace prefix on the *normalized* pathname,
-		//  - no traversal segments or percent-encoded chars in the path
-		//    (the app never generates either; rejecting them blocks
-		//    `%2e%2e/...` style escapes that could pass a naive prefix
-		//    check but resolve elsewhere via `goto()` normalization).
-		//
-		// Anything failing the gauntlet falls back to the dashboard.
-		const fallback = `/${ws.owner_username}/${ws.slug}`;
-		let target = fallback;
-		try {
-			const saved = localStorage.getItem(`pad-last-route-${ws.slug}`);
-			if (saved) {
-				const normalized = new URL(saved, window.location.origin);
-				const path = normalized.pathname;
-				const sameOrigin = normalized.origin === window.location.origin;
-				const inWorkspace = path === fallback || path.startsWith(fallback + '/');
-				const cleanPath =
-					!path.includes('/..') &&
-					!path.includes('/./') &&
-					!path.includes('//') &&
-					!/%[0-9a-fA-F]{2}/.test(path);
-				if (sameOrigin && inWorkspace && cleanPath) {
-					target = normalized.pathname + normalized.search + normalized.hash;
-				}
-			}
-		} catch {
-			// localStorage unavailable or URL parse failed; fall through to dashboard.
-		}
-		goto(target);
+		// Restore the last-visited route in this workspace if cached
+		// (TASK-754). Validation lives in workspaceRestoreTarget.
+		goto(workspaceRestoreTarget(ws));
 	}
 
 	function openCreateModal() {

--- a/web/src/lib/utils/workspace-route.ts
+++ b/web/src/lib/utils/workspace-route.ts
@@ -1,0 +1,47 @@
+/**
+ * Compute the URL to navigate to when "switching to" a workspace —
+ * the user's last-visited route in that workspace if we have one
+ * cached in localStorage, falling back to the dashboard otherwise.
+ *
+ * Implements TASK-754 (workspace switcher: restore last route). The
+ * cache entry is written by `[username]/[workspace]/+layout.svelte`'s
+ * scroll-to-route persistence effect.
+ *
+ * The saved value is treated as untrusted input — could be stale,
+ * corrupt, or crafted. We canonicalize through `URL` and require:
+ *   - same origin (rejects scheme/`//host` smuggling),
+ *   - workspace prefix on the *normalized* pathname,
+ *   - no traversal segments or percent-encoded chars in the path
+ *     (the app never generates either; rejecting them blocks
+ *     `%2e%2e/...` style escapes that could pass a naive prefix
+ *     check but resolve elsewhere via `goto()` normalization).
+ *
+ * Anything failing the gauntlet returns the dashboard fallback.
+ *
+ * Safe to call on the server (returns the fallback when `window` is
+ * unavailable) so the same helper can be used in `href={...}` slots
+ * without hydration warnings.
+ */
+export function workspaceRestoreTarget(ws: { slug: string; owner_username?: string }): string {
+	const fallback = `/${ws.owner_username}/${ws.slug}`;
+	if (typeof window === 'undefined') return fallback;
+	try {
+		const saved = localStorage.getItem(`pad-last-route-${ws.slug}`);
+		if (!saved) return fallback;
+		const normalized = new URL(saved, window.location.origin);
+		const path = normalized.pathname;
+		const sameOrigin = normalized.origin === window.location.origin;
+		const inWorkspace = path === fallback || path.startsWith(fallback + '/');
+		const cleanPath =
+			!path.includes('/..') &&
+			!path.includes('/./') &&
+			!path.includes('//') &&
+			!/%[0-9a-fA-F]{2}/.test(path);
+		if (sameOrigin && inWorkspace && cleanPath) {
+			return normalized.pathname + normalized.search + normalized.hash;
+		}
+	} catch {
+		// localStorage unavailable or URL parse failed — fall through.
+	}
+	return fallback;
+}


### PR DESCRIPTION
Follow-up to #240 / #241.

Two commits:
1. `b1a63c6` — extract the restore-target validation into `web/src/lib/utils/workspace-route.ts`; have the desktop TopBar's workspace icons call it on left-click instead of doing a hard `<a href>` nav to the dashboard. Modifier-clicks / middle-click still go to dashboard via the original href.
2. `92a80e6` — clicking the workspace you're already in goes to the dashboard (overrides restore), giving users a way back to workspace home from any nested route.

Tested manually after `make install`.