### PR TITLE
feat(web): replace desktop navbar scroll with overflow menu (TASK-759)

### DIFF
--- a/web/src/lib/components/layout/TopBar.svelte
+++ b/web/src/lib/components/layout/TopBar.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { dndzone } from 'svelte-dnd-action';
+	import { dndzone, SHADOW_ITEM_MARKER_PROPERTY_NAME } from 'svelte-dnd-action';
 	import type { DndEvent } from 'svelte-dnd-action';
 	import { workspaceStore } from '$lib/stores/workspace.svelte';
 	import { authStore } from '$lib/stores/auth.svelte';
@@ -19,46 +19,289 @@
 
 	let currentSlug = $derived(workspaceStore.current?.slug ?? '');
 
-	// DnD state — local copy of workspaces for reordering (desktop only;
-	// mobile uses WorkspaceSwitcher which doesn't expose reorder — users
-	// who want to reorder can do it on desktop).
+	// ── DnD + overflow state ─────────────────────────────────────────────
+	// Full ordered list, mirrors the store when idle and is mutated by
+	// dnd zones during reorder. Source of truth for persistence.
 	let dndWorkspaces: Workspace[] = $state([]);
 	let isDragging = $state(false);
+	// Drop cooldown blocks store→local sync for a moment after a drop so
+	// SSE refresh of the workspace list doesn't fight the just-written
+	// order. Mirrors BoardView's pattern.
+	let dropCooldown = $state(false);
 	const flipDurationMs = 150;
 
-	// Sync from store when not actively reordering
+	// Sync from store when not actively reordering and not in cooldown.
 	$effect(() => {
-		if (!isDragging) {
+		if (!isDragging && !dropCooldown) {
 			dndWorkspaces = [...workspaceStore.workspaces];
 		}
 	});
 
-	// Desktop: svelte-dnd-action handlers
-	function handleConsider(e: CustomEvent<DndEvent<Workspace>>) {
-		dndWorkspaces = e.detail.items;
+	// ── Width measurement ────────────────────────────────────────────────
+	// We replaced the previous `overflow-x: auto` scroll with a "priority+"
+	// pattern: pills that don't fit move into a `…` overflow menu. To
+	// decide which pills fit, we measure each pill's natural width once in
+	// a hidden ghost row, then walk the ordered list against the visible
+	// container's width. ResizeObserver re-derives on container width
+	// change (window resize, sidebar collapse, etc).
+	let containerEl: HTMLDivElement | null = $state(null);
+	let ghostEl: HTMLDivElement | null = $state(null);
+	let availableWidth = $state(0);
+	let pillWidths = $state(new Map<string, number>());
+
+	// Reserve width for the `…` trigger so the visible/overflow split is
+	// stable — see the rendering note on `.overflow-trigger-wrap.hidden`.
+	const TRIGGER_RESERVATION = 32;
+	const GAP = 2; // matches `.workspace-list` CSS gap
+
+	$effect(() => {
+		if (!containerEl) return;
+		const ro = new ResizeObserver((entries) => {
+			for (const entry of entries) {
+				availableWidth = entry.contentRect.width;
+			}
+		});
+		ro.observe(containerEl);
+		return () => ro.disconnect();
+	});
+
+	// Re-measure pill widths whenever the ghost row's children change
+	// (workspaces added/removed/renamed). Cached per slug.
+	$effect(() => {
+		// Re-run when dndWorkspaces changes — depend on the array reference
+		// and length so renames/reorders trigger remeasurement.
+		void dndWorkspaces.length;
+		void dndWorkspaces.map((w) => w.slug + '|' + w.name).join(',');
+		if (!ghostEl) return;
+		// Defer until after paint so the ghost row has laid out.
+		const raf = requestAnimationFrame(() => {
+			const next = new Map<string, number>();
+			for (const child of Array.from(ghostEl!.querySelectorAll<HTMLElement>('[data-ws-slug]'))) {
+				const slug = child.dataset.wsSlug;
+				if (slug) next.set(slug, child.offsetWidth);
+			}
+			pillWidths = next;
+		});
+		return () => cancelAnimationFrame(raf);
+	});
+
+	// ── Visible / overflow split ────────────────────────────────────────
+	// Always reserves trigger width when there's overflow, AND renders the
+	// trigger as `visibility: hidden` even when empty so layout is stable.
+	// This avoids oscillation between "trigger hidden → list grows → all
+	// fit → trigger hidden" and the next frame's "all fit → trigger shown
+	// (?) → ...". Stable layout > shaving 28px when not needed.
+	let propVisibleWorkspaces = $derived.by(() => {
+		if (!availableWidth || pillWidths.size === 0) return dndWorkspaces;
+
+		// Total width if we tried to fit everything (no trigger).
+		let total = 0;
+		for (let i = 0; i < dndWorkspaces.length; i++) {
+			total += pillWidths.get(dndWorkspaces[i].slug) ?? 0;
+			if (i > 0) total += GAP;
+		}
+		if (total <= availableWidth) return dndWorkspaces;
+
+		// Some pills overflow — reserve trigger room.
+		const budget = availableWidth - TRIGGER_RESERVATION - GAP;
+		const activeSlug = workspaceStore.current?.slug ?? '';
+
+		// Pin active: claim its width up front regardless of position.
+		let consumed = 0;
+		const activeWidth =
+			activeSlug && pillWidths.has(activeSlug) ? pillWidths.get(activeSlug)! : 0;
+		const haveActive = !!activeSlug && dndWorkspaces.some((w) => w.slug === activeSlug);
+		if (haveActive) {
+			consumed = activeWidth;
+		}
+
+		const visible: Workspace[] = [];
+		for (const ws of dndWorkspaces) {
+			if (ws.slug === activeSlug) {
+				visible.push(ws);
+				continue;
+			}
+			const w = pillWidths.get(ws.slug) ?? 0;
+			const addGap = visible.length > 0 || haveActive ? GAP : 0;
+			if (consumed + addGap + w <= budget) {
+				consumed += addGap + w;
+				visible.push(ws);
+			}
+			// Else: overflows — falls into the overflow set below.
+		}
+		return visible;
+	});
+
+	let propOverflowWorkspaces = $derived.by(() => {
+		const visibleSlugs = new Set(propVisibleWorkspaces.map((w) => w.slug));
+		return dndWorkspaces.filter((w) => !visibleSlugs.has(w.slug));
+	});
+
+	// DnD-mutable slices that mirror the derived split when idle. svelte-
+	// dnd-action wants its own array per zone; consider/finalize update
+	// these slices, and persistGlobalOrder folds them back into a single
+	// linear order to push to the API.
+	let visibleZone: Workspace[] = $state([]);
+	let overflowZone: Workspace[] = $state([]);
+	let triggerZone: Workspace[] = $state([]); // single-slot drop target for "drop on …"
+
+	$effect(() => {
+		const v = propVisibleWorkspaces;
+		const o = propOverflowWorkspaces;
+		if (!isDragging && !dropCooldown) {
+			visibleZone = [...v];
+			overflowZone = [...o];
+			triggerZone = [];
+		}
+	});
+
+	// ── Overflow menu state ──────────────────────────────────────────────
+	let overflowOpen = $state(false);
+	let overflowTriggerEl: HTMLButtonElement | null = $state(null);
+	let springLoadTimer: ReturnType<typeof setTimeout> | null = null;
+	const SPRING_LOAD_MS = 400;
+
+	function clearSpringLoad() {
+		if (springLoadTimer) {
+			clearTimeout(springLoadTimer);
+			springLoadTimer = null;
+		}
+	}
+
+	function closeOverflow() {
+		overflowOpen = false;
+		clearSpringLoad();
+	}
+
+	// ── DnD handlers ─────────────────────────────────────────────────────
+	function handleVisibleConsider(e: CustomEvent<DndEvent<Workspace>>) {
+		visibleZone = e.detail.items;
 		isDragging = true;
 	}
 
-	async function handleFinalize(e: CustomEvent<DndEvent<Workspace>>) {
-		dndWorkspaces = e.detail.items;
+	async function handleVisibleFinalize(e: CustomEvent<DndEvent<Workspace>>) {
+		visibleZone = e.detail.items;
 		isDragging = false;
-		await saveOrder();
+		clearSpringLoad();
+		schedulePersist();
 	}
 
-	async function saveOrder() {
-		const updates = dndWorkspaces.map((ws, i) => ({
-			slug: ws.slug,
-			sort_order: i
-		}));
+	function handleOverflowConsider(e: CustomEvent<DndEvent<Workspace>>) {
+		overflowZone = e.detail.items;
+		isDragging = true;
+	}
+
+	async function handleOverflowFinalize(e: CustomEvent<DndEvent<Workspace>>) {
+		let next = e.detail.items;
+		// Active-pin rule: if active was dragged into overflow, snap it
+		// back to visible and don't persist that move. The active pill is
+		// the only "you are here" cue in the bar — it must always render.
+		const activeSlug = workspaceStore.current?.slug;
+		if (activeSlug && next.some((w) => w.slug === activeSlug)) {
+			const active = next.find((w) => w.slug === activeSlug)!;
+			next = next.filter((w) => w.slug !== activeSlug);
+			if (!visibleZone.some((w) => w.slug === activeSlug)) {
+				visibleZone = [...visibleZone, active];
+			}
+		}
+		overflowZone = next;
+		isDragging = false;
+		clearSpringLoad();
+		schedulePersist();
+	}
+
+	// Trigger zone — single-slot drop target. While a drag is hovering,
+	// schedule the spring-load timer to auto-open the menu so the user
+	// can place the dropped item at a precise position. If the user drops
+	// on the trigger before the timer fires, the dropped item is appended
+	// to the end of overflow.
+	function handleTriggerConsider(e: CustomEvent<DndEvent<Workspace>>) {
+		triggerZone = e.detail.items;
+		isDragging = true;
+
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const hovering = triggerZone.some((item: any) => !!item[SHADOW_ITEM_MARKER_PROPERTY_NAME]);
+		if (hovering && !overflowOpen && !springLoadTimer) {
+			springLoadTimer = setTimeout(() => {
+				springLoadTimer = null;
+				overflowOpen = true;
+			}, SPRING_LOAD_MS);
+		} else if (!hovering) {
+			clearSpringLoad();
+		}
+	}
+
+	async function handleTriggerFinalize(e: CustomEvent<DndEvent<Workspace>>) {
+		const dropped = e.detail.items.filter(
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			(item: any) => !item[SHADOW_ITEM_MARKER_PROPERTY_NAME]
+		);
+		triggerZone = [];
+		clearSpringLoad();
+
+		if (dropped.length > 0) {
+			// Active-pin under "drop on trigger": same rule as overflow zone.
+			const activeSlug = workspaceStore.current?.slug;
+			const droppedSafe = activeSlug
+				? dropped.filter((w) => w.slug !== activeSlug)
+				: dropped;
+			if (droppedSafe.length > 0) {
+				overflowZone = [...overflowZone, ...droppedSafe];
+			}
+		}
+		isDragging = false;
+		schedulePersist();
+	}
+
+	// Both zones fire `finalize` for a cross-zone drag. Coalesce both into
+	// a single persist call to avoid racing API writes for one user action.
+	let persistScheduled = false;
+	function schedulePersist() {
+		if (persistScheduled) return;
+		persistScheduled = true;
+		queueMicrotask(async () => {
+			persistScheduled = false;
+			await persistGlobalOrder();
+		});
+	}
+
+	async function persistGlobalOrder() {
+		// svelte-dnd-action tags shadow items with SHADOW_ITEM_MARKER_PROPERTY_NAME
+		// during drag — strip them before we persist or update local state.
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const stripShadow = (arr: Workspace[]): Workspace[] =>
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			arr.filter((x) => !(x as any)[SHADOW_ITEM_MARKER_PROPERTY_NAME]);
+		const visible = stripShadow(visibleZone);
+		const overflow = stripShadow(overflowZone);
+		// Dedupe in case a cross-zone drag transiently appears in both
+		// (svelte-dnd-action shadow handling should prevent this, but
+		// belt-and-braces).
+		const seen = new Set<string>();
+		const fullOrder: Workspace[] = [];
+		for (const ws of [...visible, ...overflow]) {
+			if (!seen.has(ws.slug)) {
+				seen.add(ws.slug);
+				fullOrder.push(ws);
+			}
+		}
+		dndWorkspaces = fullOrder;
+		dropCooldown = true;
+
+		const updates = fullOrder.map((ws, i) => ({ slug: ws.slug, sort_order: i }));
 		try {
 			await api.workspaces.reorder(updates);
 			await workspaceStore.loadAll();
 		} catch {
+			// Restore from store on failure.
 			dndWorkspaces = [...workspaceStore.workspaces];
 		}
+		setTimeout(() => {
+			dropCooldown = false;
+		}, 1000);
 	}
 
-	// Color palette for workspace circles
+	// ── Color palette ────────────────────────────────────────────────────
 	const colors = [
 		'#4a9eff', '#4ade80', '#a78bfa', '#fbbf24',
 		'#22d3ee', '#fb923c', '#f472b6', '#34d399',
@@ -76,6 +319,7 @@
 		return name.charAt(0).toUpperCase();
 	}
 
+	// ── Theme ────────────────────────────────────────────────────────────
 	onMount(() => {
 		const saved = localStorage.getItem('pad-theme');
 		if (saved === 'light' || saved === 'dark') {
@@ -101,16 +345,60 @@
 	function closeUserMenu() {
 		userMenuOpen = false;
 	}
-</script>
 
-<svelte:window onclick={(e) => {
-	if (userMenuOpen) {
-		const target = e.target as HTMLElement;
-		if (!target.closest('.user-menu-container')) {
-			closeUserMenu();
+	// ── Workspace-link click ─────────────────────────────────────────────
+	// Plain left-click is intercepted to restore the last-visited route
+	// (TASK-754). Modifier-clicks fall through to the <a href> so users
+	// can still cmd-click / middle-click into a fresh dashboard tab.
+	function handleWsClick(e: MouseEvent, ws: Workspace) {
+		if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) return;
+		e.preventDefault();
+		closeOverflow();
+		goto(workspaceRestoreTarget(ws));
+	}
+
+	// ── Overflow menu keyboard ───────────────────────────────────────────
+	function handleOverflowKeydown(e: KeyboardEvent) {
+		if (!overflowOpen) return;
+		if (e.key === 'Escape') {
+			e.preventDefault();
+			closeOverflow();
+			overflowTriggerEl?.focus();
+			return;
+		}
+		if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+			e.preventDefault();
+			const items = Array.from(
+				document.querySelectorAll<HTMLElement>('#workspace-overflow-menu [role="menuitem"]')
+			);
+			if (items.length === 0) return;
+			const active = document.activeElement as HTMLElement | null;
+			const idx = active ? items.indexOf(active) : -1;
+			const next =
+				e.key === 'ArrowDown'
+					? items[(idx + 1 + items.length) % items.length]
+					: items[(idx - 1 + items.length) % items.length];
+			next.focus();
 		}
 	}
-}} />
+</script>
+
+<svelte:window
+	onclick={(e) => {
+		const target = e.target as HTMLElement;
+		if (userMenuOpen && !target.closest('.user-menu-container')) {
+			closeUserMenu();
+		}
+		if (
+			overflowOpen &&
+			!target.closest('#workspace-overflow-menu') &&
+			!target.closest('.overflow-trigger-wrap')
+		) {
+			closeOverflow();
+		}
+	}}
+	onkeydown={handleOverflowKeydown}
+/>
 
 {#if !mobile}
 	<!-- ── Desktop ────────────────────────────────────────────────────────── -->
@@ -121,11 +409,17 @@
 		<!-- svelte-ignore a11y_no_static_element_interactions -->
 		<div
 			class="workspace-list"
-			use:dndzone={{items: dndWorkspaces, flipDurationMs, type: 'topbar-workspace', dragDisabled: uiStore.isTouch}}
-			onconsider={handleConsider}
-			onfinalize={handleFinalize}
+			bind:this={containerEl}
+			use:dndzone={{
+				items: visibleZone,
+				flipDurationMs,
+				type: 'topbar-workspace',
+				dragDisabled: uiStore.isTouch
+			}}
+			onconsider={handleVisibleConsider}
+			onfinalize={handleVisibleFinalize}
 		>
-			{#each dndWorkspaces as ws (ws.id)}
+			{#each visibleZone as ws (ws.id)}
 				<!--
 					href stays pointed at the workspace dashboard so a
 					middle-click / cmd-click / right-click → "Open in new
@@ -141,24 +435,15 @@
 					class="workspace-item"
 					class:active={ws.slug === currentSlug}
 					title={ws.name}
-					onclick={(e) => {
-						// Respect modifier-clicks and middle-click (button !== 0)
-						// so users can still open the dashboard in a new tab.
-						if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) return;
-						e.preventDefault();
-						// Click on the workspace you're already in → go to
-						// dashboard (overrides restore — gives users a way back
-						// to the workspace home from any nested route).
-						// Click on a different workspace → restore last route.
-						const target = ws.slug === currentSlug
-							? `/${ws.owner_username}/${ws.slug}`
-							: workspaceRestoreTarget(ws);
-						goto(target);
-					}}
+					onclick={(e) => handleWsClick(e, ws)}
 				>
 					<span
 						class="workspace-icon"
-						style="background: {ws.slug === currentSlug ? wsColor(ws.name) : 'transparent'}; color: {ws.slug === currentSlug ? '#fff' : 'var(--text-secondary)'}; border-color: {wsColor(ws.name)}"
+						style="background: {ws.slug === currentSlug
+							? wsColor(ws.name)
+							: 'transparent'}; color: {ws.slug === currentSlug
+							? '#fff'
+							: 'var(--text-secondary)'}; border-color: {wsColor(ws.name)}"
 					>
 						{wsInitial(ws.name)}
 					</span>
@@ -166,6 +451,84 @@
 				</a>
 			{/each}
 		</div>
+
+		<!--
+			Overflow trigger. Always rendered (so layout stays stable as
+			workspaces are added/removed) but visually hidden when nothing
+			overflows. The wrapper is a 3rd dndzone with the same `type`
+			as the visible row and the menu, so dropping on the trigger
+			appends to overflow. Spring-loaded auto-open on hover-during-
+			drag is implemented in handleTriggerConsider.
+		-->
+		<!-- svelte-ignore a11y_no_static_element_interactions -->
+		<div
+			class="overflow-trigger-wrap"
+			class:hidden={overflowZone.length === 0}
+			use:dndzone={{
+				items: triggerZone,
+				flipDurationMs,
+				type: 'topbar-workspace',
+				dragDisabled: uiStore.isTouch || overflowZone.length === 0
+			}}
+			onconsider={handleTriggerConsider}
+			onfinalize={handleTriggerFinalize}
+		>
+			<button
+				class="overflow-trigger"
+				bind:this={overflowTriggerEl}
+				aria-haspopup="menu"
+				aria-expanded={overflowOpen}
+				aria-controls="workspace-overflow-menu"
+				aria-label="Show {overflowZone.length} more workspace{overflowZone.length === 1
+					? ''
+					: 's'}"
+				title="More workspaces"
+				onclick={() => (overflowOpen = !overflowOpen)}
+			>
+				<span class="overflow-dots" aria-hidden="true">⋯</span>
+			</button>
+		</div>
+
+		{#if overflowOpen && overflowZone.length > 0}
+			<!-- svelte-ignore a11y_no_static_element_interactions -->
+			<div
+				id="workspace-overflow-menu"
+				class="overflow-menu"
+				role="menu"
+				use:dndzone={{
+					items: overflowZone,
+					flipDurationMs,
+					type: 'topbar-workspace',
+					dragDisabled: uiStore.isTouch
+				}}
+				onconsider={handleOverflowConsider}
+				onfinalize={handleOverflowFinalize}
+			>
+				{#each overflowZone as ws (ws.id)}
+					<a
+						href="/{ws.owner_username}/{ws.slug}"
+						class="overflow-menu-item"
+						class:active={ws.slug === currentSlug}
+						role="menuitem"
+						title={ws.name}
+						onclick={(e) => handleWsClick(e, ws)}
+					>
+						<span
+							class="workspace-icon"
+							style="background: {ws.slug === currentSlug
+								? wsColor(ws.name)
+								: 'transparent'}; color: {ws.slug === currentSlug
+								? '#fff'
+								: 'var(--text-secondary)'}; border-color: {wsColor(ws.name)}"
+						>
+							{wsInitial(ws.name)}
+						</span>
+						<span class="workspace-name">{ws.name}</span>
+					</a>
+				{/each}
+			</div>
+		{/if}
+
 		<button
 			class="workspace-add"
 			onclick={() => uiStore.openCreateWorkspace()}
@@ -173,6 +536,26 @@
 		>
 			<span class="add-icon">+</span>
 		</button>
+
+		<!--
+			Hidden ghost row used to measure each pill's natural width.
+			Rendered with `position: absolute; visibility: hidden` so it
+			takes its own layout offscreen and doesn't influence the real
+			.workspace-list. Items are keyed by id for stable identity.
+		-->
+		<div class="workspace-ghost" bind:this={ghostEl} aria-hidden="true">
+			{#each dndWorkspaces as ws (ws.id)}
+				<span class="workspace-item ghost-item" data-ws-slug={ws.slug}>
+					<span
+						class="workspace-icon"
+						style="border-color: {wsColor(ws.name)}"
+					>
+						{wsInitial(ws.name)}
+					</span>
+					<span class="workspace-name">{ws.name}</span>
+				</span>
+			{/each}
+		</div>
 
 		<div class="topbar-right">
 			<button
@@ -364,20 +747,19 @@
 		padding-right: var(--space-3);
 	}
 
-	/* Workspace list — scrollable horizontally */
+	/*
+		Workspace list — pills that fit. No more `overflow-x: auto`; pills
+		that don't fit are routed into the .overflow-menu via
+		propVisibleWorkspaces / propOverflowWorkspaces. See script for the
+		measurement + split logic.
+	*/
 	.workspace-list {
 		display: flex;
 		align-items: center;
 		gap: 2px;
 		min-width: 0;
 		max-width: 100%;
-		overflow-x: auto;
-		scrollbar-width: none;
-		-ms-overflow-style: none;
 		padding-right: var(--space-2);
-	}
-	.workspace-list::-webkit-scrollbar {
-		display: none;
 	}
 
 	.workspace-item {
@@ -448,6 +830,128 @@
 		font-size: 0.85em;
 		font-weight: 600;
 		line-height: 1;
+	}
+
+	/*
+		Overflow trigger — visually a sibling of .workspace-list and
+		.workspace-add. Always rendered to keep layout stable; visually
+		hidden via `visibility: hidden` when overflowZone is empty (also
+		blocks pointer events so a hidden trigger isn't clickable).
+	*/
+	.overflow-trigger-wrap {
+		display: flex;
+		align-items: center;
+		flex-shrink: 0;
+	}
+	.overflow-trigger-wrap.hidden {
+		visibility: hidden;
+		pointer-events: none;
+	}
+	.overflow-trigger {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 24px;
+		height: 24px;
+		border-radius: 50%;
+		flex-shrink: 0;
+		color: var(--text-muted);
+		border: 2px solid var(--border);
+		background: transparent;
+		cursor: pointer;
+		transition: border-color 0.15s, color 0.15s, background 0.15s;
+		padding: 0;
+	}
+	.overflow-trigger:hover,
+	.overflow-trigger[aria-expanded='true'] {
+		border-color: var(--text-secondary);
+		color: var(--text-primary);
+		background: var(--bg-hover);
+	}
+	.overflow-dots {
+		font-size: 0.95em;
+		font-weight: 700;
+		line-height: 1;
+		letter-spacing: 0;
+	}
+
+	/*
+		Overflow menu — anchored under the trigger. Positioned absolutely
+		from .topbar so it floats over surrounding chrome. Reuses the
+		.user-dropdown look for visual consistency.
+	*/
+	.overflow-menu {
+		position: absolute;
+		top: calc(100% + 6px);
+		min-width: 220px;
+		max-height: 60vh;
+		overflow-y: auto;
+		background: var(--bg-secondary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius-lg);
+		box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
+		z-index: 50;
+		padding: var(--space-1);
+		display: flex;
+		flex-direction: column;
+		gap: 1px;
+		animation: dropdown-in 0.12s ease-out;
+		/*
+			Approximate horizontal anchor: place near the trigger which
+			sits between the list and the + button. Trigger is centered in
+			the topbar by flexbox; menu uses translateX to nudge under it.
+			Precise positioning isn't critical — the menu just needs to be
+			obviously associated with the trigger.
+		*/
+		left: 50%;
+		transform: translateX(-50%);
+	}
+	.overflow-menu-item {
+		display: flex;
+		align-items: center;
+		gap: var(--space-2);
+		padding: var(--space-2) var(--space-3);
+		border-radius: var(--radius);
+		text-decoration: none;
+		color: var(--text-secondary);
+		white-space: nowrap;
+		transition: background 0.1s, color 0.1s;
+	}
+	.overflow-menu-item:hover,
+	.overflow-menu-item:focus-visible {
+		background: var(--bg-hover);
+		color: var(--text-primary);
+		text-decoration: none;
+		outline: none;
+	}
+	.overflow-menu-item.active {
+		background: var(--bg-active, var(--bg-hover));
+		color: var(--text-primary);
+	}
+	.topbar:not(.topbar-mobile) .overflow-menu-item {
+		cursor: grab;
+	}
+	.topbar:not(.topbar-mobile) .overflow-menu-item:active {
+		cursor: grabbing;
+	}
+
+	/*
+		Ghost measurement row. Off-screen; layout-active only enough to
+		yield real offsetWidth values for each pill.
+	*/
+	.workspace-ghost {
+		position: absolute;
+		visibility: hidden;
+		pointer-events: none;
+		left: -9999px;
+		top: 0;
+		display: flex;
+		align-items: center;
+		gap: 2px;
+		white-space: nowrap;
+	}
+	.ghost-item {
+		flex-shrink: 0;
 	}
 
 	/* Mobile TopBar — slot that hosts the <WorkspaceSwitcher /> chip.

--- a/web/src/lib/components/layout/TopBar.svelte
+++ b/web/src/lib/components/layout/TopBar.svelte
@@ -294,6 +294,12 @@
 	let dragRejected = false;
 	function schedulePersist() {
 		if (persistScheduled) return;
+		// Clear any stale `persistCancelled` from a prior rejected drag.
+		// In target-first finalize order, cancelPersist() can fire when
+		// no microtask was queued (the source's schedulePersist hadn't
+		// run yet). Without this clear, the flag would leak and silently
+		// kill the next valid reorder. (Codex round 3 MEDIUM.)
+		persistCancelled = false;
 		persistScheduled = true;
 		queueMicrotask(async () => {
 			persistScheduled = false;

--- a/web/src/lib/components/layout/TopBar.svelte
+++ b/web/src/lib/components/layout/TopBar.svelte
@@ -181,9 +181,22 @@
 	function handleVisibleConsider(e: CustomEvent<DndEvent<Workspace>>) {
 		visibleZone = e.detail.items;
 		isDragging = true;
+		// Fresh drag — clear any stale rejection flag from a prior cycle.
+		dragRejected = false;
 	}
 
 	async function handleVisibleFinalize(e: CustomEvent<DndEvent<Workspace>>) {
+		// If the OTHER zone (overflow or trigger) already detected an
+		// active-pin rejection and reset state, don't clobber visibleZone
+		// with the post-drag items here — they exclude active. Just
+		// finish the drag cleanly. (svelte-dnd-action does not guarantee
+		// the order in which the source and target finalize events fire.)
+		if (dragRejected) {
+			dragRejected = false;
+			isDragging = false;
+			clearSpringLoad();
+			return;
+		}
 		visibleZone = e.detail.items;
 		isDragging = false;
 		clearSpringLoad();
@@ -193,6 +206,7 @@
 	function handleOverflowConsider(e: CustomEvent<DndEvent<Workspace>>) {
 		overflowZone = e.detail.items;
 		isDragging = true;
+		dragRejected = false;
 	}
 
 	async function handleOverflowFinalize(e: CustomEvent<DndEvent<Workspace>>) {
@@ -203,6 +217,7 @@
 		// drag) so active stays at its original position. Don't persist.
 		const activeSlug = workspaceStore.current?.slug;
 		if (activeSlug && next.some((w) => w.slug === activeSlug)) {
+			dragRejected = true;
 			resetZonesFromProps();
 			cancelPersist();
 			isDragging = false;
@@ -223,6 +238,7 @@
 	function handleTriggerConsider(e: CustomEvent<DndEvent<Workspace>>) {
 		triggerZone = e.detail.items;
 		isDragging = true;
+		dragRejected = false;
 
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		const hovering = triggerZone.some((item: any) => !!item[SHADOW_ITEM_MARKER_PROPERTY_NAME]);
@@ -250,6 +266,7 @@
 		// persisted order entirely (Codex round 1 HIGH).
 		const activeSlug = workspaceStore.current?.slug;
 		if (activeSlug && dropped.some((w) => w.slug === activeSlug)) {
+			dragRejected = true;
 			resetZonesFromProps();
 			cancelPersist();
 			isDragging = false;
@@ -270,6 +287,11 @@
 	// call entirely instead of racing with a corrupted order.
 	let persistScheduled = false;
 	let persistCancelled = false;
+	// `dragRejected` flags an active-pin rejection so the OTHER zone's
+	// finalize (which fires before or after the rejection — order isn't
+	// guaranteed by svelte-dnd-action) doesn't clobber visibleZone with
+	// its post-drag items, which exclude active.
+	let dragRejected = false;
 	function schedulePersist() {
 		if (persistScheduled) return;
 		persistScheduled = true;
@@ -317,14 +339,20 @@
 		}
 		dndWorkspaces = fullOrder;
 		dropCooldown = true;
+		// Cancel any pending cooldown clear from a previous persist BEFORE
+		// awaiting — otherwise the prior timeout can fire mid-request,
+		// flip dropCooldown false, and let SSE clobber the displayed order
+		// while the new write is still in flight.
+		if (cooldownTimer) {
+			clearTimeout(cooldownTimer);
+			cooldownTimer = null;
+		}
 
 		const updates = fullOrder.map((ws, i) => ({ slug: ws.slug, sort_order: i }));
 		try {
 			await api.workspaces.reorder(updates);
 			await workspaceStore.loadAll();
-			// Re-arm the cooldown clear; cancel any prior pending one so
-			// rapid reorders don't end the cooldown for the latest write.
-			if (cooldownTimer) clearTimeout(cooldownTimer);
+			// Re-arm the cooldown clear after success.
 			cooldownTimer = setTimeout(() => {
 				dropCooldown = false;
 				cooldownTimer = null;

--- a/web/src/lib/components/layout/TopBar.svelte
+++ b/web/src/lib/components/layout/TopBar.svelte
@@ -159,6 +159,10 @@
 	let overflowOpen = $state(false);
 	let overflowTriggerEl: HTMLButtonElement | null = $state(null);
 	let springLoadTimer: ReturnType<typeof setTimeout> | null = null;
+	// Single tracked timer for the post-drop cooldown — re-armed on each
+	// drop so two drops within 1s don't see the first timeout end the
+	// cooldown for the second (Codex round 1 MEDIUM).
+	let cooldownTimer: ReturnType<typeof setTimeout> | null = null;
 	const SPRING_LOAD_MS = 400;
 
 	function clearSpringLoad() {
@@ -192,17 +196,18 @@
 	}
 
 	async function handleOverflowFinalize(e: CustomEvent<DndEvent<Workspace>>) {
-		let next = e.detail.items;
-		// Active-pin rule: if active was dragged into overflow, snap it
-		// back to visible and don't persist that move. The active pill is
-		// the only "you are here" cue in the bar — it must always render.
+		const next = e.detail.items;
+		// Active-pin rule: if active landed in overflow, REJECT the entire
+		// drag (no-op). Reset all zones from the pre-drag derived split
+		// (which is computed from `dndWorkspaces` — un-mutated during
+		// drag) so active stays at its original position. Don't persist.
 		const activeSlug = workspaceStore.current?.slug;
 		if (activeSlug && next.some((w) => w.slug === activeSlug)) {
-			const active = next.find((w) => w.slug === activeSlug)!;
-			next = next.filter((w) => w.slug !== activeSlug);
-			if (!visibleZone.some((w) => w.slug === activeSlug)) {
-				visibleZone = [...visibleZone, active];
-			}
+			resetZonesFromProps();
+			cancelPersist();
+			isDragging = false;
+			clearSpringLoad();
+			return;
 		}
 		overflowZone = next;
 		isDragging = false;
@@ -239,15 +244,20 @@
 		triggerZone = [];
 		clearSpringLoad();
 
+		// Active-pin under "drop on trigger": REJECT the whole drag if
+		// active was the dropped item, same as the overflow zone. Don't
+		// silently strip it — that previously dropped active out of the
+		// persisted order entirely (Codex round 1 HIGH).
+		const activeSlug = workspaceStore.current?.slug;
+		if (activeSlug && dropped.some((w) => w.slug === activeSlug)) {
+			resetZonesFromProps();
+			cancelPersist();
+			isDragging = false;
+			return;
+		}
+
 		if (dropped.length > 0) {
-			// Active-pin under "drop on trigger": same rule as overflow zone.
-			const activeSlug = workspaceStore.current?.slug;
-			const droppedSafe = activeSlug
-				? dropped.filter((w) => w.slug !== activeSlug)
-				: dropped;
-			if (droppedSafe.length > 0) {
-				overflowZone = [...overflowZone, ...droppedSafe];
-			}
+			overflowZone = [...overflowZone, ...dropped];
 		}
 		isDragging = false;
 		schedulePersist();
@@ -255,14 +265,34 @@
 
 	// Both zones fire `finalize` for a cross-zone drag. Coalesce both into
 	// a single persist call to avoid racing API writes for one user action.
+	// `persistCancelled` is set when an active-pin rejection happens
+	// between scheduling and the microtask running, so we skip the API
+	// call entirely instead of racing with a corrupted order.
 	let persistScheduled = false;
+	let persistCancelled = false;
 	function schedulePersist() {
 		if (persistScheduled) return;
 		persistScheduled = true;
 		queueMicrotask(async () => {
 			persistScheduled = false;
+			if (persistCancelled) {
+				persistCancelled = false;
+				return;
+			}
 			await persistGlobalOrder();
 		});
+	}
+	function cancelPersist() {
+		persistCancelled = true;
+	}
+
+	// Reset both zones from the (un-mutated during drag) derived split.
+	// Used when an entire drag must be rejected — the spec calls for
+	// active-pin rejection to be a no-op, not a "snap back to end".
+	function resetZonesFromProps() {
+		visibleZone = [...propVisibleWorkspaces];
+		overflowZone = [...propOverflowWorkspaces];
+		triggerZone = [];
 	}
 
 	async function persistGlobalOrder() {
@@ -292,13 +322,26 @@
 		try {
 			await api.workspaces.reorder(updates);
 			await workspaceStore.loadAll();
+			// Re-arm the cooldown clear; cancel any prior pending one so
+			// rapid reorders don't end the cooldown for the latest write.
+			if (cooldownTimer) clearTimeout(cooldownTimer);
+			cooldownTimer = setTimeout(() => {
+				dropCooldown = false;
+				cooldownTimer = null;
+			}, 1000);
 		} catch {
-			// Restore from store on failure.
+			// Failure: restore from the un-reordered store and immediately
+			// resync the displayed zones — the cooldown gate would
+			// otherwise hide the rollback for up to a second.
 			dndWorkspaces = [...workspaceStore.workspaces];
-		}
-		setTimeout(() => {
+			visibleZone = [...propVisibleWorkspaces];
+			overflowZone = [...propOverflowWorkspaces];
+			if (cooldownTimer) {
+				clearTimeout(cooldownTimer);
+				cooldownTimer = null;
+			}
 			dropCooldown = false;
-		}, 1000);
+		}
 	}
 
 	// ── Color palette ────────────────────────────────────────────────────
@@ -318,6 +361,21 @@
 	function wsInitial(name: string): string {
 		return name.charAt(0).toUpperCase();
 	}
+
+	// ── Cleanup ──────────────────────────────────────────────────────────
+	// Clear any pending timers when the component unmounts (e.g. layout
+	// teardown, mobile-branch flip). Without this, a setTimeout that fires
+	// after the component is gone would write to dead state — Svelte's
+	// runtime no-ops the writes, but it's still tidier to cancel.
+	$effect(() => {
+		return () => {
+			clearSpringLoad();
+			if (cooldownTimer) {
+				clearTimeout(cooldownTimer);
+				cooldownTimer = null;
+			}
+		};
+	});
 
 	// ── Theme ────────────────────────────────────────────────────────────
 	onMount(() => {
@@ -350,11 +408,17 @@
 	// Plain left-click is intercepted to restore the last-visited route
 	// (TASK-754). Modifier-clicks fall through to the <a href> so users
 	// can still cmd-click / middle-click into a fresh dashboard tab.
+	// Click on the *current* workspace overrides the restore — gives the
+	// user a way back to the workspace dashboard from any deep route.
 	function handleWsClick(e: MouseEvent, ws: Workspace) {
 		if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) return;
 		e.preventDefault();
 		closeOverflow();
-		goto(workspaceRestoreTarget(ws));
+		const target =
+			ws.slug === currentSlug
+				? `/${ws.owner_username}/${ws.slug}`
+				: workspaceRestoreTarget(ws);
+		goto(target);
 	}
 
 	// ── Overflow menu keyboard ───────────────────────────────────────────
@@ -808,6 +872,19 @@
 	.workspace-name {
 		font-size: 0.82em;
 		font-weight: 500;
+	}
+	/*
+		Truncate long workspace names inside the desktop bar (and the
+		ghost row, so measurement and rendered widths match). Without this
+		cap, a single long active-workspace name could blow past the bar
+		because the active pill is pinned visible regardless of fit.
+		Overflow menu rows aren't capped — full names read better there.
+	*/
+	.workspace-list .workspace-name,
+	.workspace-ghost .workspace-name {
+		max-width: 200px;
+		overflow: hidden;
+		text-overflow: ellipsis;
 	}
 
 	.workspace-add {


### PR DESCRIPTION
## Summary

Replaces the desktop top-bar workspace list's `overflow-x: auto` with a "priority+" overflow menu. Pills that don't fit move into a `…` trigger menu at the right edge. Drag-and-drop works to and from overflow on day one.

Implements `TASK-759`. Spec: `IDEA-758`.

## What changed

- **Measurement**: hidden ghost row per `data-ws-slug`, widths cached in a `Map`. `ResizeObserver` on the `.workspace-list` container drives `availableWidth`.
- **Visible/overflow split**: `$derived` from `dndWorkspaces` + `availableWidth` + `pillWidths`. Active workspace is pinned to the visible row regardless of fit position.
- **Trigger**: always rendered to keep layout stable; `visibility: hidden` when nothing overflows.
- **DnD (cross-zone)**: three `dndzone`s share `type: 'topbar-workspace'` — visible row, overflow menu, and the trigger as a single-slot drop target. ~400ms spring-loaded auto-open lets the user drop into a precise position. Active dropped into overflow snaps back. Both finalize events coalesce into one persist via `queueMicrotask`.
- **Persistence**: existing `api.workspaces.reorder()` path. 1s `dropCooldown` guards against SSE-triggered re-sync, mirroring `BoardView`.
- **Mobile (≤640px)**: unchanged — still BottomSheet via `WorkspaceSwitcher`.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./...` — all pass
- [x] `cd web && npm run check` — 0 errors (6 baseline warnings unchanged)
- [x] `cd web && npm run build` — succeeds
- [ ] Manual: viewport with all workspaces fitting → no `…` trigger visible.
- [ ] Manual: viewport narrow enough to overflow → trigger appears, click reveals only hidden workspaces.
- [ ] Manual: active workspace remains visible regardless of width.
- [ ] Manual: drag visible→overflow with spring-load, drag overflow→visible, drag active→overflow (snap-back), reorder within visible.
- [ ] Manual: resize → split re-derives without flicker.
- [ ] Manual: keyboard a11y — Tab to trigger, Enter opens, ↑/↓ navigates, Esc closes + focus returns.
- [ ] Manual: mobile (≤640px) viewport unchanged — BottomSheet still works.