### PR TITLE
feat(web): mobile navbar workspace switcher always present, preserve sidebar state on switch (TASK-761)

### DIFF
--- a/web/src/lib/components/layout/WorkspaceSwitcher.svelte
+++ b/web/src/lib/components/layout/WorkspaceSwitcher.svelte
@@ -107,7 +107,7 @@
 	<button
 		class="current"
 		onclick={() => open = !open}
-		aria-haspopup={isMobile ? 'dialog' : 'menu'}
+		aria-haspopup={isMobile ? 'dialog' : undefined}
 		aria-expanded={open}
 	>
 		<span class="name">{workspaceStore.current?.name ?? 'Select workspace'}</span>

--- a/web/src/lib/components/layout/WorkspaceSwitcher.svelte
+++ b/web/src/lib/components/layout/WorkspaceSwitcher.svelte
@@ -107,7 +107,7 @@
 	<button
 		class="current"
 		onclick={() => open = !open}
-		aria-haspopup="menu"
+		aria-haspopup={isMobile ? 'dialog' : 'menu'}
 		aria-expanded={open}
 	>
 		<span class="name">{workspaceStore.current?.name ?? 'Select workspace'}</span>

--- a/web/src/lib/components/layout/WorkspaceSwitcher.svelte
+++ b/web/src/lib/components/layout/WorkspaceSwitcher.svelte
@@ -57,13 +57,21 @@
 
 	function select(ws: { slug: string; owner_username?: string }) {
 		open = false;
-		// Close the mobile sidebar if open — the TopBar's previous inline
-		// workspace links did this on click, so preserve the behavior now
-		// that the switcher is the mobile nav entry point.
-		uiStore.onNavigate();
-		// Restore the last-visited route in this workspace if cached
-		// (TASK-754). Validation lives in workspaceRestoreTarget.
-		goto(workspaceRestoreTarget(ws));
+		// IDEA-760: preserve mobile sidebar visibility across workspace
+		// switches. Previously this called uiStore.onNavigate() to mirror
+		// the TopBar's old inline-link behavior, but per the idea the
+		// switcher must work as a navbar control whether the sidebar is
+		// open or hidden, and the user's sidebar state should carry over
+		// to the new workspace.
+		//
+		// Click on the *current* workspace overrides the last-route
+		// restore — gives the user a one-tap path back to the workspace
+		// dashboard from any deep route. Mirrors TopBar.handleWsClick.
+		const isCurrent = ws.slug === workspaceStore.current?.slug;
+		const target = isCurrent
+			? `/${ws.owner_username ?? ''}/${ws.slug}`
+			: workspaceRestoreTarget(ws);
+		goto(target);
 	}
 
 	function openCreateModal() {

--- a/web/src/lib/components/layout/WorkspaceSwitcher.svelte
+++ b/web/src/lib/components/layout/WorkspaceSwitcher.svelte
@@ -65,11 +65,18 @@
 		// to the new workspace.
 		//
 		// Click on the *current* workspace overrides the last-route
-		// restore — gives the user a one-tap path back to the workspace
+		// restore — gives the user a path back to the workspace
 		// dashboard from any deep route. Mirrors TopBar.handleWsClick.
-		const isCurrent = ws.slug === workspaceStore.current?.slug;
+		// Use workspaceStore.current (rather than ws.owner_username,
+		// which is typed optional) for the dashboard URL — when isCurrent
+		// is true we know `current` is non-null and shares this slug, so
+		// its `owner_username` is guaranteed present. Avoids producing
+		// `//slug` (scheme-relative URL) if a caller passes a workspace
+		// shape without owner_username.
+		const current = workspaceStore.current;
+		const isCurrent = !!current && ws.slug === current.slug;
 		const target = isCurrent
-			? `/${ws.owner_username ?? ''}/${ws.slug}`
+			? `/${current.owner_username}/${current.slug}`
 			: workspaceRestoreTarget(ws);
 		goto(target);
 	}
@@ -97,9 +104,14 @@
 {/snippet}
 
 <div class="switcher">
-	<button class="current" onclick={() => open = !open}>
+	<button
+		class="current"
+		onclick={() => open = !open}
+		aria-haspopup="menu"
+		aria-expanded={open}
+	>
 		<span class="name">{workspaceStore.current?.name ?? 'Select workspace'}</span>
-		<span class="chevron">{open ? '▲' : '▼'}</span>
+		<span class="chevron" aria-hidden="true">{open ? '▲' : '▼'}</span>
 	</button>
 
 	{#if isMobile && open}

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -9,6 +9,7 @@
 	import { titleStore } from '$lib/stores/title.svelte';
 	import Sidebar from '$lib/components/layout/Sidebar.svelte';
 	import TopBar from '$lib/components/layout/TopBar.svelte';
+	import WorkspaceSwitcher from '$lib/components/layout/WorkspaceSwitcher.svelte';
 	import CommandPalette from '$lib/components/search/CommandPalette.svelte';
 	import ToastContainer from '$lib/components/common/ToastContainer.svelte';
 	import CreateWorkspaceModal from '$lib/components/layout/CreateWorkspaceModal.svelte';
@@ -209,7 +210,9 @@
 								<rect y="15" width="20" height="2" rx="1" fill="currentColor"/>
 							</svg>
 						</button>
-						<a href="/{workspaceStore.current?.owner_username ?? ''}/{workspaceStore.current?.slug ?? ''}" class="mobile-title">{workspaceStore.current?.name ?? 'Pad'}</a>
+						<div class="mobile-switcher-slot">
+							<WorkspaceSwitcher mobile />
+						</div>
 					</div>
 				{/if}
 				{@render children()}
@@ -266,15 +269,11 @@
 		background: var(--bg-hover);
 		color: var(--text-primary);
 	}
-	.mobile-title {
-		font-weight: 600;
-		font-size: 0.95em;
-		color: var(--text-primary);
-		text-decoration: none;
-	}
-	.mobile-title:hover {
-		color: var(--accent-blue);
-		text-decoration: none;
+	.mobile-switcher-slot {
+		flex: 1;
+		min-width: 0;
+		display: flex;
+		align-items: center;
 	}
 	.topbar-expand-btn {
 		position: absolute;


### PR DESCRIPTION
## Summary

Implements **IDEA-760**: on mobile, the workspace name on the navbar is now always a workspace switcher (not just a dashboard link when the sidebar is hidden), and switching workspaces no longer collapses the mobile sidebar — its open/closed state carries over to the new workspace.

- `web/src/routes/+layout.svelte`: in the `!sidebarOpen` mobile branch, replace the `<a class="mobile-title">` workspace-name link with `<WorkspaceSwitcher mobile />` so users can switch workspaces from either sidebar state. Adds `.mobile-switcher-slot` to flex-fill the gap next to the hamburger; drops the unused `.mobile-title` CSS.
- `web/src/lib/components/layout/WorkspaceSwitcher.svelte`: drop the `uiStore.onNavigate()` call inside `select()` so switching workspaces leaves the mobile sidebar's visibility untouched. Also adds same-workspace dashboard parity (mirrors `TopBar.handleWsClick`) — tapping the current workspace inside the switcher navigates to `/{owner_username}/{slug}` instead of restoring the same path, giving users a path back to the dashboard from any deep route now that the dedicated link is gone.
- A11y: switcher trigger gets `aria-expanded={open}`, `aria-haspopup="dialog"` on mobile (where the popup is the BottomSheet `role="dialog"`), and `aria-hidden="true"` on the chevron glyph. Desktop omits `aria-haspopup` because that popup is a plain dropdown without `role=menu/menuitem`.

`openCreateModal()` retains its `onNavigate()` call — closing the sidebar before showing the create-workspace modal is a separate UX call, intentionally unchanged.

## Trade-off

The previous mobile-header workspace name was a one-tap link to the workspace dashboard. After this change it's a switcher, so getting to the dashboard from the closed-sidebar header takes two taps (open switcher → tap current workspace). This is the explicit IDEA-760 requirement: the user asked to *turn the workspace name into a switcher*. The added "tap current workspace = dashboard" parity inside the switcher mirrors desktop TopBar behavior so the path still exists.

## Codex review

Reviewed 4 passes; final pass returned `CLEAN`. P2 + nit findings from earlier passes addressed in commits 2-4 (see commit history).

## Test plan

- [ ] On mobile (≤768px viewport), with sidebar **open**: workspace name in TopBar opens BottomSheet switcher; picking another workspace navigates and **sidebar stays open**.
- [ ] On mobile, with sidebar **closed** (hamburger visible): workspace name in mobile-header opens BottomSheet switcher; picking another workspace navigates and **sidebar stays closed**.
- [ ] On mobile, tap the **current** workspace in the switcher → lands on the workspace dashboard (`/{owner}/{slug}`).
- [ ] On desktop (>768px): workspace switcher (e.g. on `/console`) still works as a dropdown; selecting a workspace navigates correctly.
- [ ] Screen reader: the switcher trigger announces button + collapsed/expanded state. On mobile it announces "has popup, dialog".
- [ ] `make install`, `npm run build`, `go test ./...` all pass.

🤖 Implements [IDEA-760](https://getpad.dev) via [TASK-761](https://getpad.dev). Generated with [Claude Code](https://claude.com/claude-code).