### PR TITLE
fix(web): persistent low-opacity expand tabs for hidden sidebar/topbar (TASK-762)

### DIFF
--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -276,6 +276,16 @@
 		color: var(--accent-blue);
 		text-decoration: none;
 	}
+	/*
+		Expand tabs (both .topbar-expand-btn and .sidebar-expand-btn).
+		IDEA-757: persistent low-opacity affordance. ⌘\ toggles BOTH the
+		sidebar and the topbar at once — a user who hits it accidentally
+		needs to see *something* clickable to recover, even before they
+		move the mouse. Idle opacity (0.5) keeps the tabs faintly visible
+		so the affordance never disappears; hover amplifies to full. The
+		button tooltip ("Show workspace bar (⌘\)" / "Open sidebar (⌘\)")
+		teaches the shortcut once the user notices the tab.
+	*/
 	.topbar-expand-btn {
 		position: absolute;
 		top: 0;
@@ -294,7 +304,7 @@
 		color: var(--text-muted);
 		cursor: pointer;
 		padding: 0;
-		opacity: 0;
+		opacity: 0.5;
 		transition: opacity 0.2s ease, color 0.15s ease, background 0.15s ease;
 	}
 	.app-layout:hover .topbar-expand-btn {
@@ -322,7 +332,7 @@
 		color: var(--text-muted);
 		cursor: pointer;
 		padding: 0;
-		opacity: 0;
+		opacity: 0.5;
 		transition: opacity 0.2s ease, color 0.15s ease, background 0.15s ease;
 	}
 	.app-shell:hover .sidebar-expand-btn {


### PR DESCRIPTION
## Summary

Implements **IDEA-757**: when ⌘\ hides both the sidebar and the topbar on desktop, the recover affordances are no longer invisible at idle.

`Cmd/Ctrl+\` in `web/src/routes/+layout.svelte`'s keydown handler toggles both panels at once. When they go hidden, the only on-screen ways back are two small edge tabs (`.topbar-expand-btn` 48×20 at top center, `.sidebar-expand-btn` 20×48 at left center). Both were `opacity: 0` at idle and only became visible on `:hover` of the parent container. A user who hits the shortcut accidentally and stares at the now-empty screen sees no affordance.

CSS-only fix: bump idle opacity `0 → 0.5` on both expand tabs. Hover state stays `1`. Tooltips on the buttons already say "Show workspace bar (⌘\)" / "Open sidebar (⌘\)", so the moment the user notices the tab they discover the shortcut.

## Codex review

Pass 1 returned `CLEAN` on first try. No P1/P2/nit findings.

## Test plan

- [ ] On desktop, hit ⌘\ — both sidebar and topbar collapse. Confirm both edge tabs (top center + left center) are faintly visible without moving the mouse.
- [ ] Hover the page — tabs amplify to full opacity.
- [ ] Click either tab — corresponding panel reopens. Tooltip shows the shortcut.
- [ ] Light theme: tabs still discoverable.
- [ ] Dark theme: tabs still discoverable.
- [ ] On mobile: behavior unchanged (expand tabs only render on desktop branch via `!uiStore.isMobile`).

🤖 Implements [IDEA-757](https://getpad.dev) via [TASK-762](https://getpad.dev). Generated with [Claude Code](https://claude.com/claude-code).