### PR TITLE
chore: drop dead visibility-filter block in dashboard handler (TASK-765)

### DIFF
--- a/internal/server/handlers_dashboard.go
+++ b/internal/server/handlers_dashboard.go
@@ -208,12 +208,13 @@ func (s *Server) handleGetDashboard(w http.ResponseWriter, r *http.Request) {
 		allCollections = collections
 	}
 	ctxMap := buildDoneContextMap(allCollections)
-	// Note: visibility filtering for the dashboard outputs (summary,
-	// plans, attention, suggestions) is applied through dashCollIDs /
-	// dashItemIDs on the ListItems calls below — not by trimming the
-	// `collections` slice here. `collections` is now only retained as
-	// the fallback target for `allCollections` above when the minimal
-	// listing fails.
+	// Note: the `collections` slice is not part of response visibility
+	// filtering. Dashboard outputs are filtered by dashCollIDs /
+	// dashItemIDs on the ListItems calls below, plus per-item
+	// isCollectionVisible / isItemVisibleToGuest checks for outputs
+	// that walk graphs (plan progress, blocked attention, suggested
+	// next). `collections` is retained only as the fallback target for
+	// `allCollections` above when ListCollectionsMinimal fails.
 
 	resp := DashboardResponse{
 		Summary: DashboardSummary{

--- a/internal/server/handlers_dashboard.go
+++ b/internal/server/handlers_dashboard.go
@@ -208,18 +208,12 @@ func (s *Server) handleGetDashboard(w http.ResponseWriter, r *http.Request) {
 		allCollections = collections
 	}
 	ctxMap := buildDoneContextMap(allCollections)
-
-	// Filter collections by visibility (drives the collection-summary
-	// section; done-detection above already sees every collection).
-	if visibleIDs != nil {
-		filtered := make([]models.Collection, 0, len(collections))
-		for _, c := range collections {
-			if isCollectionVisible(c.ID, visibleIDs) {
-				filtered = append(filtered, c)
-			}
-		}
-		collections = filtered
-	}
+	// Note: visibility filtering for the dashboard outputs (summary,
+	// plans, attention, suggestions) is applied through dashCollIDs /
+	// dashItemIDs on the ListItems calls below — not by trimming the
+	// `collections` slice here. `collections` is now only retained as
+	// the fallback target for `allCollections` above when the minimal
+	// listing fails.
 
 	resp := DashboardResponse{
 		Summary: DashboardSummary{


### PR DESCRIPTION
## Summary
Delete the dead visibility-filter block in `internal/server/handlers_dashboard.go` (lines 212-222) that was triggering staticcheck SA4006 + SA4010.

## Investigation result
Spent the time to verify this is **leftover refactor scaffolding**, not a missing-filter bug:

The block built a `filtered` collections slice and reassigned `collections = filtered`, but **nothing reads `collections` after that point**. Tracing the rest of the handler:

- Summary uses `allItems` from `ListItems(workspaceID, {CollectionIDs: dashCollIDs, ItemIDs: dashItemIDs})`
- Active plans, attention items, suggestions all pass `dashCollIDs`/`dashItemIDs` and use inline `isCollectionVisible(...)` checks against `visibleIDs`

So visibility *is* applied to every dashboard output — through the `dashCollIDs`/`dashItemIDs` path built earlier at lines 185-190. The deleted block had no effect. The previous comment ("drives the collection-summary section") was misleading.

Replaced with an inline note documenting where visibility actually gets applied, so future readers don't re-introduce the same dead filter pattern.

## Context
Implements TASK-765 under PLAN-644 (OSS Repo Hygiene and Launch Polish), spawned from IDEA-732.

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./internal/server/...` all pass (Dashboard tests cover this code path)
- [x] `staticcheck -checks "SA4006,SA4010" ./...` clean
- [ ] Codex CLI review CLEAN (CONVE-735)