### PR TITLE
chore: modernize goreleaser config + wire homebrew-tap token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,11 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Cross-repo PAT for pushing the brew formula to xarmian/homebrew-tap.
+          # The default GITHUB_TOKEN above only has access to xarmian/pad.
+          # Add this secret in repo settings before tagging a release that ships
+          # a brew formula — without it goreleaser fails at the brew publish step.
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
 
       # SLSA build provenance for every archive GoReleaser produced.
       # Writes a Sigstore-backed attestation to the repo so downstream

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -106,6 +106,11 @@ brews:
   - repository:
       owner: xarmian
       name: homebrew-tap
+      # Cross-repo PAT — the default GITHUB_TOKEN is scoped to xarmian/pad
+      # only and cannot push to the separate tap repo. Set the secret
+      # `HOMEBREW_TAP_GITHUB_TOKEN` on this repo (fine-grained PAT,
+      # `Contents: write` + `Metadata: read` on xarmian/homebrew-tap only).
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
     directory: Formula
     homepage: "https://getpad.dev"
     description: "Project management for developers and AI agents"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -26,11 +26,11 @@ builds:
       - -X main.buildTime={{.Date}}
 
 archives:
-  - format: tar.gz
+  - formats: ["tar.gz"]
     name_template: "pad_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     format_overrides:
       - goos: windows
-        format: zip
+        formats: ["zip"]
 
 checksum:
   name_template: "checksums.txt"
@@ -102,7 +102,7 @@ changelog:
     - title: "Other changes"
       order: 999
 
-brews:
+homebrew_casks:
   - repository:
       owner: xarmian
       name: homebrew-tap
@@ -111,42 +111,27 @@ brews:
       # `HOMEBREW_TAP_GITHUB_TOKEN` on this repo (fine-grained PAT,
       # `Contents: write` + `Metadata: read` on xarmian/homebrew-tap only).
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
-    directory: Formula
+    directory: Casks
     homepage: "https://getpad.dev"
     description: "Project management for developers and AI agents"
     license: "Apache-2.0"
-    test: |
-      system "#{bin}/pad", "--version"
 
-dockers:
-  - image_templates:
-      - "ghcr.io/xarmian/pad:{{ .Version }}-amd64"
-    use: buildx
-    build_flag_templates:
-      - "--platform=linux/amd64"
-    goarch: amd64
+# dockers_v2 replaces the legacy `dockers:` + `docker_manifests:` blocks.
+# A single declaration handles multi-platform builds via buildx; goreleaser
+# pre-organizes binaries under `${TARGETPLATFORM}/pad` for the Dockerfile
+# to consume (see Dockerfile.goreleaser's COPY line).
+dockers_v2:
+  - images:
+      - "ghcr.io/xarmian/pad"
+    tags:
+      - "{{ .Version }}"
+      - "latest"
     dockerfile: Dockerfile.goreleaser
     extra_files:
       - web/build
-  - image_templates:
-      - "ghcr.io/xarmian/pad:{{ .Version }}-arm64"
-    use: buildx
-    build_flag_templates:
-      - "--platform=linux/arm64"
-    goarch: arm64
-    dockerfile: Dockerfile.goreleaser
-    extra_files:
-      - web/build
-
-docker_manifests:
-  - name_template: "ghcr.io/xarmian/pad:{{ .Version }}"
-    image_templates:
-      - "ghcr.io/xarmian/pad:{{ .Version }}-amd64"
-      - "ghcr.io/xarmian/pad:{{ .Version }}-arm64"
-  - name_template: "ghcr.io/xarmian/pad:latest"
-    image_templates:
-      - "ghcr.io/xarmian/pad:{{ .Version }}-amd64"
-      - "ghcr.io/xarmian/pad:{{ .Version }}-arm64"
+    platforms:
+      - linux/amd64
+      - linux/arm64
 
 release:
   github:

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,6 +1,10 @@
 FROM alpine:3.21
 RUN apk add --no-cache ca-certificates tzdata
-COPY pad /usr/local/bin/pad
+# dockers_v2 organizes goreleaser-built binaries under ${TARGETPLATFORM}/pad
+# (e.g. linux/amd64/pad, linux/arm64/pad). buildx sets TARGETPLATFORM
+# automatically per platform when the image is built.
+ARG TARGETPLATFORM
+COPY ${TARGETPLATFORM}/pad /usr/local/bin/pad
 RUN adduser -D -u 1000 -h /home/pad pad \
     && mkdir -p /data \
     && chown -R pad:pad /data


### PR DESCRIPTION
## What does this PR do?

Two coupled changes to the release pipeline. Both touch the same file (`.goreleaser.yaml`); landing them together avoids a follow-up PR that would just unnecessarily churn the same lines.

### 1. Wire the homebrew-tap PAT

Closes the gap surfaced by TASK-778's audit. The default `GITHUB_TOKEN` is scoped to `xarmian/pad` only and cannot push the brew formula to `xarmian/homebrew-tap`. Without a token override, the brew publish step would fail at first real tag.

- `.goreleaser.yaml` — add `repository.token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"` so goreleaser uses a cross-repo PAT.
- `.github/workflows/release.yml` — export `HOMEBREW_TAP_GITHUB_TOKEN` from `secrets` into the goreleaser step env.

The repo secret itself is created on the human side (HT-780). Independent of this PR — code change can land first.

### 2. Migrate goreleaser v2 deprecations

`goreleaser check` flagged three deprecations on main. Fixing them in this PR rather than filing tech debt because (a) we're already touching the file, and (b) we don't want to ship `v0.1.0` on a config that warns about deprecated keywords.

| Before | After | Notes |
|---|---|---|
| `archives.format` + `format_overrides[].format` | `archives.formats: [...]` + `format_overrides[].formats: [...]` | List form is the new spec |
| `dockers:` (per-arch) + `docker_manifests:` | `dockers_v2:` (single block, `platforms: [linux/amd64, linux/arm64]`) | Collapses ~40 lines into ~12. buildx implicit. |
| `brews:` → `directory: Formula` | `homebrew_casks:` → `directory: Casks` | `brews` is phased out in v2.10+; modern goreleaser Casks natively handle pre-compiled binaries. End-user `brew install xarmian/tap/pad` UX unchanged. |
| `Dockerfile.goreleaser`: `COPY pad /usr/local/bin/pad` | `ARG TARGETPLATFORM` + `COPY ${TARGETPLATFORM}/pad /usr/local/bin/pad` | dockers_v2 organizes pre-built binaries by platform |

Removed the no-op `test:` stanza on the brews block (doesn't apply to casks).

### `dockers_v2` is flagged "experimental"

Goreleaser warns that `dockers_v2` is "subject to change." We're committed to v2's roadmap (pinned `version: "~> v2"`), and `dockers` is the actively-deprecated path with no alternative. Accept the experimental flag.

## Validation

- `goreleaser check` — clean (zero warnings, was 5 before)
- `goreleaser release --snapshot --clean --skip=publish,sign,sbom`:
  - 6 binaries built (linux/darwin/windows × amd64/arm64)
  - 6 archives created (tar.gz + windows zip)
  - 1 Homebrew Cask manifest written (`dist/homebrew/Casks/pad.rb`) with all 4 platform sha256 stanzas
  - 2 cross-platform docker images built via buildx + QEMU
- `docker run --rm ghcr.io/xarmian/pad:latest-amd64 --version` — binary runs in the cross-built image, prints expected snapshot version
- Cask manifest reviewed: correct binary stanza, multi-platform, livecheck skip

## What's *not* in this PR

- Creating `xarmian/homebrew-tap` repo + generating the PAT + adding the secret (HT-780, operator step)
- Any change to the README's `brew install xarmian/tap/pad` command (still works — modern Homebrew auto-detects formula vs cask)

## Real end-to-end gate

Snapshot doesn't exercise: cosign signing (skipped above), SBOM generation, the actual GHCR push, the brew formula push to the tap repo. Those run only at real tag time. **HT-782 (v0.0.1-rc.1 dress rehearsal) is the gate.** If the secret is missing at that point, the brew step fails with a clear error pointing at the missing env var.

Refs: TASK-806, TASK-778 (audit), HT-780 (operator step)

## Checklist

- [x] `make build` passes (n/a — config-only, no Go/Svelte code)
- [x] `make test` passes (n/a)
- [x] New features have tests (n/a)
- [x] TypeScript types updated (n/a)
- [x] CLI help text updated (n/a)