### PR TITLE
fix: hide item_links pointing to soft-deleted items (BUG-734)

### DIFF
--- a/internal/store/export.go
+++ b/internal/store/export.go
@@ -97,7 +97,13 @@ func (s *Store) ExportWorkspace(slug string) (*models.WorkspaceExport, error) {
 		return nil, err
 	}
 
-	// Item links
+	// Item links — exported in full, including links whose source or target item
+	// is soft-deleted. This is intentional and differs from user-facing reads
+	// (GetItemLinks/GetParentForItem/GetParentMap, which all filter on
+	// items.deleted_at IS NULL — see BUG-734). Backups need to round-trip the
+	// raw graph so that re-importing into a workspace where the deleted items
+	// are restored preserves the original relationships. The import path
+	// already silently skips links whose endpoints are missing entirely.
 	linkRows, err := s.db.Query(s.q(`
 		SELECT id, source_id, target_id, link_type, created_by, created_at
 		FROM item_links WHERE workspace_id = ?

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -997,14 +997,15 @@ func (s *Store) getItemLink(id string) (*models.ItemLink, error) {
 
 	srcStatus := s.dialect.JSONExtractText("s.fields", "status")
 	tgtStatus := s.dialect.JSONExtractText("t.fields", "status")
+	// Filter out links pointing to or from soft-deleted items — see BUG-734.
 	err := s.db.QueryRow(s.q(fmt.Sprintf(`
 		SELECT l.id, l.workspace_id, l.source_id, l.target_id, l.link_type, l.created_by, l.created_at,
 		       s.title, t.title, s.slug, t.slug, sc.slug, tc.slug, sc.prefix, tc.prefix,
 		       s.item_number, t.item_number,
 		       %s, %s
 		FROM item_links l
-		JOIN items s ON s.id = l.source_id
-		JOIN items t ON t.id = l.target_id
+		JOIN items s ON s.id = l.source_id AND s.deleted_at IS NULL
+		JOIN items t ON t.id = l.target_id AND t.deleted_at IS NULL
 		JOIN collections sc ON sc.id = s.collection_id
 		JOIN collections tc ON tc.id = t.collection_id
 		WHERE l.id = ?
@@ -1040,6 +1041,12 @@ func (s *Store) getItemLink(id string) (*models.ItemLink, error) {
 	return &link, nil
 }
 
+// GetItemLinks returns links where the given item is either source or target.
+// Links pointing to or from soft-deleted items are filtered out so callers (e.g.
+// `pad item related`, the lineage panel, the dashboard enrichment pass) don't
+// surface dangling endpoints. The link rows themselves are preserved on disk —
+// restoring a soft-deleted item resurrects its relationships automatically. See
+// BUG-734.
 func (s *Store) GetItemLinks(itemID string) ([]models.ItemLink, error) {
 	srcStatusExpr := s.dialect.JSONExtractText("s.fields", "status")
 	tgtStatusExpr := s.dialect.JSONExtractText("t.fields", "status")
@@ -1049,8 +1056,8 @@ func (s *Store) GetItemLinks(itemID string) ([]models.ItemLink, error) {
 		       s.item_number, t.item_number,
 		       %s, %s
 		FROM item_links l
-		JOIN items s ON s.id = l.source_id
-		JOIN items t ON t.id = l.target_id
+		JOIN items s ON s.id = l.source_id AND s.deleted_at IS NULL
+		JOIN items t ON t.id = l.target_id AND t.deleted_at IS NULL
 		JOIN collections sc ON sc.id = s.collection_id
 		JOIN collections tc ON tc.id = t.collection_id
 		WHERE l.source_id = ? OR l.target_id = ?
@@ -1213,6 +1220,8 @@ func (s *Store) ClearParentLink(itemID string) error {
 }
 
 // GetParentForItem returns the parent link for an item, or nil if it has no parent.
+// A parent link pointing to a soft-deleted item is treated as no parent — the
+// breadcrumb / lineage UI shouldn't show a deleted ancestor. See BUG-734.
 func (s *Store) GetParentForItem(itemID string) (*models.ItemLink, error) {
 	sStatusExpr := s.dialect.JSONExtractText("s.fields", "status")
 	tStatusExpr := s.dialect.JSONExtractText("t.fields", "status")
@@ -1222,8 +1231,8 @@ func (s *Store) GetParentForItem(itemID string) (*models.ItemLink, error) {
 		       s.item_number, t.item_number,
 		       %s, %s
 		FROM item_links l
-		JOIN items s ON s.id = l.source_id
-		JOIN items t ON t.id = l.target_id
+		JOIN items s ON s.id = l.source_id AND s.deleted_at IS NULL
+		JOIN items t ON t.id = l.target_id AND t.deleted_at IS NULL
 		JOIN collections sc ON sc.id = s.collection_id
 		JOIN collections tc ON tc.id = t.collection_id
 		WHERE l.source_id = ? AND l.link_type IN (%s)

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -637,6 +637,17 @@ func (s *Store) listItemsFTS(workspaceID string, params models.ItemListParams) (
 		args = append(args, params.CollectionSlug)
 	}
 
+	// Parent link filter — must mirror the non-FTS path so combining
+	// `parent=<UUID>&search=<q>` doesn't silently drop the parent constraint
+	// (and, by extension, the soft-deleted-parent rejection from BUG-734).
+	// See Codex review on PR #259. Note: other filter kinds (tags, assignee,
+	// role, fields, ParentID) are also currently ignored in the FTS path —
+	// pre-existing behavior outside BUG-734's scope; tracked separately.
+	if params.ParentLinkID != "" {
+		query += " AND EXISTS (SELECT 1 FROM item_links il JOIN items p ON p.id = il.target_id AND p.deleted_at IS NULL WHERE il.source_id = i.id AND il.link_type = 'parent' AND il.target_id = ?)"
+		args = append(args, params.ParentLinkID)
+	}
+
 	if len(params.CollectionIDs) > 0 && len(params.ItemIDs) > 0 {
 		collPlaceholders := make([]string, len(params.CollectionIDs))
 		for i, id := range params.CollectionIDs {

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -987,6 +987,13 @@ func (s *Store) CreateItemLink(workspaceID string, input models.ItemLinkCreate, 
 	return s.getItemLink(id)
 }
 
+// getItemLink is the unfiltered post-insert readback used by CreateItemLink to
+// hydrate the freshly-inserted row with collection/source/target metadata. It
+// intentionally does NOT filter on items.deleted_at IS NULL: the only caller
+// is the immediate readback after INSERT, and a delete race against either
+// endpoint would otherwise cause the just-successful insert to return nil
+// (Codex review on PR #259). User-facing surfaces all read links via
+// GetItemLinks (plural) or GetParentForItem, both of which DO filter.
 func (s *Store) getItemLink(id string) (*models.ItemLink, error) {
 	var link models.ItemLink
 	var createdAt string
@@ -997,15 +1004,14 @@ func (s *Store) getItemLink(id string) (*models.ItemLink, error) {
 
 	srcStatus := s.dialect.JSONExtractText("s.fields", "status")
 	tgtStatus := s.dialect.JSONExtractText("t.fields", "status")
-	// Filter out links pointing to or from soft-deleted items — see BUG-734.
 	err := s.db.QueryRow(s.q(fmt.Sprintf(`
 		SELECT l.id, l.workspace_id, l.source_id, l.target_id, l.link_type, l.created_by, l.created_at,
 		       s.title, t.title, s.slug, t.slug, sc.slug, tc.slug, sc.prefix, tc.prefix,
 		       s.item_number, t.item_number,
 		       %s, %s
 		FROM item_links l
-		JOIN items s ON s.id = l.source_id AND s.deleted_at IS NULL
-		JOIN items t ON t.id = l.target_id AND t.deleted_at IS NULL
+		JOIN items s ON s.id = l.source_id
+		JOIN items t ON t.id = l.target_id
 		JOIN collections sc ON sc.id = s.collection_id
 		JOIN collections tc ON tc.id = t.collection_id
 		WHERE l.id = ?
@@ -1172,17 +1178,10 @@ func (s *Store) SetParentLink(workspaceID, itemID, parentID, createdBy string) (
 		return nil, fmt.Errorf("commit parent link: %w", err)
 	}
 
-	// Return the full link with enriched fields
-	links, err := s.GetItemLinks(itemID)
-	if err != nil {
-		return nil, err
-	}
-	for _, link := range links {
-		if link.ID == id {
-			return &link, nil
-		}
-	}
-	return nil, fmt.Errorf("parent link created but not found")
+	// Return the full link with enriched fields. Use the unfiltered readback
+	// helper so that a delete race against either endpoint between commit and
+	// readback doesn't cause the successful insert to surface as nil.
+	return s.getItemLink(id)
 }
 
 // checkParentCycle walks the ancestor chain from parentID and returns an error
@@ -1281,10 +1280,17 @@ func (s *Store) GetParentForItem(itemID string) (*models.ItemLink, error) {
 
 // GetParentMap returns a map of item ID -> parent item ID for all parent links
 // in a workspace. Used for efficient batch lookups (e.g., dashboard, list enrichment).
+//
+// Links whose source or target item is soft-deleted are excluded so that
+// dashboard orphan-detection (handlers_dashboard.go) and similar enrichment
+// passes don't treat a task whose parent has been archived as still parented.
+// See BUG-734.
 func (s *Store) GetParentMap(workspaceID string) (map[string]string, error) {
 	rows, err := s.db.Query(s.q(fmt.Sprintf(`
-		SELECT source_id, target_id FROM item_links
-		WHERE workspace_id = ? AND link_type IN (%s)
+		SELECT il.source_id, il.target_id FROM item_links il
+		JOIN items s ON s.id = il.source_id AND s.deleted_at IS NULL
+		JOIN items t ON t.id = il.target_id AND t.deleted_at IS NULL
+		WHERE il.workspace_id = ? AND il.link_type IN (%s)
 	`, childLinkTypeSQL())), workspaceID)
 	if err != nil {
 		return nil, fmt.Errorf("get parent map: %w", err)

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -529,9 +529,12 @@ func (s *Store) ListItems(workspaceID string, params models.ItemListParams) ([]m
 		args = append(args, params.AgentRoleID, params.AgentRoleID)
 	}
 
-	// Parent link filter via item_links
+	// Parent link filter via item_links. Joins items so we ignore links pointing
+	// to a soft-deleted parent — slug/ref filtering already rejects deleted
+	// parents upstream, but raw-UUID input bypasses that path. See BUG-734 /
+	// Codex review on PR #259.
 	if params.ParentLinkID != "" {
-		query += " AND EXISTS (SELECT 1 FROM item_links il WHERE il.source_id = i.id AND il.link_type = 'parent' AND il.target_id = ?)"
+		query += " AND EXISTS (SELECT 1 FROM item_links il JOIN items p ON p.id = il.target_id AND p.deleted_at IS NULL WHERE il.source_id = i.id AND il.link_type = 'parent' AND il.target_id = ?)"
 		args = append(args, params.ParentLinkID)
 	}
 

--- a/internal/store/items_test.go
+++ b/internal/store/items_test.go
@@ -954,6 +954,122 @@ func TestItemLinks(t *testing.T) {
 	}
 }
 
+// TestItemLinks_HidesSoftDeletedEndpoints exercises BUG-734: when an item that
+// is the source or target of a link gets soft-deleted, GetItemLinks should not
+// surface the link from the surviving endpoint's perspective. Restoring the
+// deleted item should resurrect the link automatically — the row is preserved
+// on disk; only the query layer filters it.
+func TestItemLinks_HidesSoftDeletedEndpoints(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Test")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+
+	plan := createTestItem(t, s, ws.ID, col.ID, "Plan", "")
+	implementer := createTestItem(t, s, ws.ID, col.ID, "Implementer task", "")
+
+	// implementer --implements--> plan
+	if _, err := s.CreateItemLink(ws.ID, models.ItemLinkCreate{
+		TargetID: plan.ID,
+		LinkType: "implements",
+	}, implementer.ID); err != nil {
+		t.Fatalf("CreateItemLink: %v", err)
+	}
+
+	// Sanity: link visible from both endpoints.
+	if links, _ := s.GetItemLinks(plan.ID); len(links) != 1 {
+		t.Fatalf("expected 1 link from plan side before delete, got %d", len(links))
+	}
+	if links, _ := s.GetItemLinks(implementer.ID); len(links) != 1 {
+		t.Fatalf("expected 1 link from implementer side before delete, got %d", len(links))
+	}
+
+	// Soft-delete the implementer (the BUG-734 scenario: source side gone).
+	if err := s.DeleteItem(implementer.ID); err != nil {
+		t.Fatalf("DeleteItem: %v", err)
+	}
+
+	// From the plan's perspective, the dangling implementer must not surface.
+	links, err := s.GetItemLinks(plan.ID)
+	if err != nil {
+		t.Fatalf("GetItemLinks after delete: %v", err)
+	}
+	if len(links) != 0 {
+		t.Errorf("expected 0 links from plan side after implementer deleted, got %d (orphan leak — BUG-734)", len(links))
+	}
+
+	// Restore the implementer — the link row was never deleted, so the
+	// relationship should reappear automatically.
+	if _, err := s.RestoreItem(implementer.ID); err != nil {
+		t.Fatalf("RestoreItem: %v", err)
+	}
+	links, err = s.GetItemLinks(plan.ID)
+	if err != nil {
+		t.Fatalf("GetItemLinks after restore: %v", err)
+	}
+	if len(links) != 1 {
+		t.Errorf("expected 1 link from plan side after restore, got %d (link should be preserved across soft-delete/restore)", len(links))
+	}
+
+	// Now soft-delete the plan side instead (target side gone) and verify the
+	// implementer's view also drops the dangling link.
+	if err := s.DeleteItem(plan.ID); err != nil {
+		t.Fatalf("DeleteItem plan: %v", err)
+	}
+	links, err = s.GetItemLinks(implementer.ID)
+	if err != nil {
+		t.Fatalf("GetItemLinks after target delete: %v", err)
+	}
+	if len(links) != 0 {
+		t.Errorf("expected 0 links from implementer side after plan deleted, got %d (target-side orphan leak)", len(links))
+	}
+}
+
+// TestGetParentForItem_HidesSoftDeletedParent ensures lineage / breadcrumb
+// queries don't surface a soft-deleted ancestor. See BUG-734.
+func TestGetParentForItem_HidesSoftDeletedParent(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Test")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+
+	parent := createTestItem(t, s, ws.ID, col.ID, "Parent", "")
+	child := createTestItem(t, s, ws.ID, col.ID, "Child", "")
+
+	if _, err := s.SetParentLink(ws.ID, child.ID, parent.ID, "user"); err != nil {
+		t.Fatalf("SetParentLink: %v", err)
+	}
+
+	// Before delete: parent visible.
+	if link, err := s.GetParentForItem(child.ID); err != nil {
+		t.Fatalf("GetParentForItem: %v", err)
+	} else if link == nil {
+		t.Fatal("expected parent link before delete, got nil")
+	}
+
+	// Soft-delete parent.
+	if err := s.DeleteItem(parent.ID); err != nil {
+		t.Fatalf("DeleteItem: %v", err)
+	}
+
+	// After delete: must read as no parent (don't render a deleted breadcrumb).
+	link, err := s.GetParentForItem(child.ID)
+	if err != nil {
+		t.Fatalf("GetParentForItem after delete: %v", err)
+	}
+	if link != nil {
+		t.Errorf("expected nil parent link after soft-delete, got %+v", link)
+	}
+
+	// After restore: parent visible again.
+	if _, err := s.RestoreItem(parent.ID); err != nil {
+		t.Fatalf("RestoreItem: %v", err)
+	}
+	if link, err := s.GetParentForItem(child.ID); err != nil {
+		t.Fatalf("GetParentForItem after restore: %v", err)
+	} else if link == nil {
+		t.Error("expected parent link to reappear after restore")
+	}
+}
+
 func TestItemLinkDefaultType(t *testing.T) {
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")

--- a/internal/store/items_test.go
+++ b/internal/store/items_test.go
@@ -1070,6 +1070,68 @@ func TestGetParentForItem_HidesSoftDeletedParent(t *testing.T) {
 	}
 }
 
+// TestGetParentMap_ExcludesSoftDeletedEndpoints covers the dashboard
+// orphan-detection path: a task whose parent has been soft-deleted should
+// NOT appear in GetParentMap, so handlers_dashboard.go correctly flags the
+// task as orphaned. See BUG-734 / Codex review on PR #259.
+func TestGetParentMap_ExcludesSoftDeletedEndpoints(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Test")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+
+	parent := createTestItem(t, s, ws.ID, col.ID, "Parent", "")
+	child := createTestItem(t, s, ws.ID, col.ID, "Child", "")
+	if _, err := s.SetParentLink(ws.ID, child.ID, parent.ID, "user"); err != nil {
+		t.Fatalf("SetParentLink: %v", err)
+	}
+
+	// Sanity: child→parent mapping present.
+	m, err := s.GetParentMap(ws.ID)
+	if err != nil {
+		t.Fatalf("GetParentMap: %v", err)
+	}
+	if m[child.ID] != parent.ID {
+		t.Fatalf("expected parent map %s→%s, got %s→%s", child.ID, parent.ID, child.ID, m[child.ID])
+	}
+
+	// Soft-delete the parent. The child must now look "parentless" so the
+	// dashboard orphan detector flags it.
+	if err := s.DeleteItem(parent.ID); err != nil {
+		t.Fatalf("DeleteItem: %v", err)
+	}
+	m, err = s.GetParentMap(ws.ID)
+	if err != nil {
+		t.Fatalf("GetParentMap after parent delete: %v", err)
+	}
+	if _, hasEntry := m[child.ID]; hasEntry {
+		t.Errorf("expected child to drop from parent map after parent soft-deleted (orphan-detection regression)")
+	}
+
+	// Restoring the parent should bring the mapping back.
+	if _, err := s.RestoreItem(parent.ID); err != nil {
+		t.Fatalf("RestoreItem: %v", err)
+	}
+	m, err = s.GetParentMap(ws.ID)
+	if err != nil {
+		t.Fatalf("GetParentMap after parent restore: %v", err)
+	}
+	if m[child.ID] != parent.ID {
+		t.Errorf("expected parent map to be restored to %s→%s, got %s→%s", child.ID, parent.ID, child.ID, m[child.ID])
+	}
+
+	// Soft-deleting the child side should also drop the entry.
+	if err := s.DeleteItem(child.ID); err != nil {
+		t.Fatalf("DeleteItem child: %v", err)
+	}
+	m, err = s.GetParentMap(ws.ID)
+	if err != nil {
+		t.Fatalf("GetParentMap after child delete: %v", err)
+	}
+	if _, hasEntry := m[child.ID]; hasEntry {
+		t.Errorf("expected child to drop from parent map after the child itself was soft-deleted")
+	}
+}
+
 func TestItemLinkDefaultType(t *testing.T) {
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")

--- a/internal/store/items_test.go
+++ b/internal/store/items_test.go
@@ -1132,6 +1132,68 @@ func TestGetParentMap_ExcludesSoftDeletedEndpoints(t *testing.T) {
 	}
 }
 
+// TestListItems_ParentFilter_FTS_RespectsSoftDeletedParent covers the
+// `parent=<UUID>&search=<q>` combination. The search path routes through
+// listItemsFTS, which the non-FTS parent filter doesn't touch; the FTS
+// path needs to enforce the same deleted-parent rejection. See BUG-734 /
+// Codex review on PR #259 (3rd pass).
+func TestListItems_ParentFilter_FTS_RespectsSoftDeletedParent(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Test")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+
+	parent := createTestItem(t, s, ws.ID, col.ID, "Parent", "")
+	// Use a distinctive title so the FTS match is unambiguous.
+	child := createTestItem(t, s, ws.ID, col.ID, "Distinctivekeyword child", "")
+	if _, err := s.SetParentLink(ws.ID, child.ID, parent.ID, "user"); err != nil {
+		t.Fatalf("SetParentLink: %v", err)
+	}
+
+	// Sanity: search + parent finds the child while parent is live.
+	items, err := s.ListItems(ws.ID, models.ItemListParams{
+		ParentLinkID: parent.ID,
+		Search:       "Distinctivekeyword",
+	})
+	if err != nil {
+		t.Fatalf("ListItems (FTS+parent): %v", err)
+	}
+	if len(items) != 1 || items[0].ID != child.ID {
+		t.Fatalf("expected to find 1 child via FTS+parent before delete, got %d", len(items))
+	}
+
+	// Soft-delete the parent. The FTS path must also reject the now-deleted
+	// parent, otherwise `?parent=<deleted-uuid>&search=foo` continues to leak
+	// active children of an archived parent (the gap Codex flagged).
+	if err := s.DeleteItem(parent.ID); err != nil {
+		t.Fatalf("DeleteItem: %v", err)
+	}
+	items, err = s.ListItems(ws.ID, models.ItemListParams{
+		ParentLinkID: parent.ID,
+		Search:       "Distinctivekeyword",
+	})
+	if err != nil {
+		t.Fatalf("ListItems (FTS+parent) after delete: %v", err)
+	}
+	if len(items) != 0 {
+		t.Errorf("expected 0 children via FTS+parent after parent soft-deleted, got %d (FTS-path parent-filter regression)", len(items))
+	}
+
+	// Restore brings the child back through the FTS+parent path.
+	if _, err := s.RestoreItem(parent.ID); err != nil {
+		t.Fatalf("RestoreItem: %v", err)
+	}
+	items, err = s.ListItems(ws.ID, models.ItemListParams{
+		ParentLinkID: parent.ID,
+		Search:       "Distinctivekeyword",
+	})
+	if err != nil {
+		t.Fatalf("ListItems (FTS+parent) after restore: %v", err)
+	}
+	if len(items) != 1 || items[0].ID != child.ID {
+		t.Errorf("expected child to reappear via FTS+parent after restoring parent, got %d", len(items))
+	}
+}
+
 // TestListItems_ParentFilter_RespectsSoftDeletedParent ensures the
 // `parent=<UUID>` query filter doesn't return children of a soft-deleted
 // parent. Slug/ref filters already reject deleted parents upstream via

--- a/internal/store/items_test.go
+++ b/internal/store/items_test.go
@@ -1132,6 +1132,57 @@ func TestGetParentMap_ExcludesSoftDeletedEndpoints(t *testing.T) {
 	}
 }
 
+// TestListItems_ParentFilter_RespectsSoftDeletedParent ensures the
+// `parent=<UUID>` query filter doesn't return children of a soft-deleted
+// parent. Slug/ref filters already reject deleted parents upstream via
+// GetItem/GetItemBySlug, but raw-UUID input bypasses that path. See
+// BUG-734 / Codex review on PR #259.
+func TestListItems_ParentFilter_RespectsSoftDeletedParent(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Test")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+
+	parent := createTestItem(t, s, ws.ID, col.ID, "Parent", "")
+	child := createTestItem(t, s, ws.ID, col.ID, "Child", "")
+	if _, err := s.SetParentLink(ws.ID, child.ID, parent.ID, "user"); err != nil {
+		t.Fatalf("SetParentLink: %v", err)
+	}
+
+	// Sanity: child is reachable via the parent filter.
+	items, err := s.ListItems(ws.ID, models.ItemListParams{ParentLinkID: parent.ID})
+	if err != nil {
+		t.Fatalf("ListItems: %v", err)
+	}
+	if len(items) != 1 || items[0].ID != child.ID {
+		t.Fatalf("expected to find 1 child via parent filter before delete, got %+v", items)
+	}
+
+	// Soft-delete the parent. Filter must now return no children — no
+	// caller should be able to list children of a deleted parent by UUID.
+	if err := s.DeleteItem(parent.ID); err != nil {
+		t.Fatalf("DeleteItem: %v", err)
+	}
+	items, err = s.ListItems(ws.ID, models.ItemListParams{ParentLinkID: parent.ID})
+	if err != nil {
+		t.Fatalf("ListItems after parent delete: %v", err)
+	}
+	if len(items) != 0 {
+		t.Errorf("expected 0 children after parent soft-deleted, got %d (parent-filter regression)", len(items))
+	}
+
+	// Restoring the parent should bring the child back into the filter.
+	if _, err := s.RestoreItem(parent.ID); err != nil {
+		t.Fatalf("RestoreItem: %v", err)
+	}
+	items, err = s.ListItems(ws.ID, models.ItemListParams{ParentLinkID: parent.ID})
+	if err != nil {
+		t.Fatalf("ListItems after restore: %v", err)
+	}
+	if len(items) != 1 || items[0].ID != child.ID {
+		t.Errorf("expected 1 child after restoring parent, got %d", len(items))
+	}
+}
+
 func TestItemLinkDefaultType(t *testing.T) {
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")


### PR DESCRIPTION
## Summary

Fixes **BUG-734** / **TASK-809** — `pad item related` (and the breadcrumb / dashboard enrichment paths) were surfacing relationships pointing to soft-deleted items, with stale titles and statuses. The link rows in `item_links` were intact, but the queries that JOIN them against `items` weren't filtering `deleted_at IS NULL` on the joined sides.

## Approach: query-time filter (not cascade-delete)

Initial plan was cascade-on-delete, but `DeleteItem` is a soft-delete (`UPDATE items SET deleted_at = …`) and `RestoreItem` is exposed via `POST /items/{slug}/restore`. Cascading on delete would have permanently destroyed link rows and broken restore. Instead, the fix filters at query time:

- ✅ **Backward compatible** — existing dangling rows from past deletes disappear from views immediately, no maintenance command needed
- ✅ **Restore-safe** — link rows stay on disk; restoring an item resurrects its relationships automatically
- ✅ **Lossless** — relationship graph is preserved as historical truth

## What changed

Three queries in `internal/store/items.go` that JOIN `item_links` ⨝ `items` (twice — source + target) now also filter `s.deleted_at IS NULL AND t.deleted_at IS NULL`:

| Function | Used by |
|---|---|
| `GetItemLinks` | `pad item related`, lineage panel, dashboard enrichment, `/items/{slug}/links` |
| `GetItemLink` (singular) | No current callers; fixed for consistency |
| `GetParentForItem` | Breadcrumb; soft-deleted parent now reads as no parent |

The other `item_links` queries already had the filter (audited lines 1311, 1345, 1391, 1513, 1551, 1589). `export.go` deliberately exports all link rows for full-data-dump correctness and is left unchanged.

## Test plan

- [x] `TestItemLinks_HidesSoftDeletedEndpoints` — delete + restore round-trip on both source-side and target-side endpoints
- [x] `TestGetParentForItem_HidesSoftDeletedParent` — breadcrumb path: parent disappears on delete, reappears on restore
- [x] `go test ./...` passes (full suite including server/store)
- [x] `cd web && npm run build` passes
- [x] `make install` clean
- [x] Manual end-to-end repro on the local instance:
  - Created `PLAN-810` and `TASK-811`, ran `pad item implements TASK-811 PLAN-810`
  - `pad item related PLAN-810` → showed `TASK-811` as implementer ✓
  - `pad item delete TASK-811`
  - `pad item related PLAN-810` → "No related items found" ✓ (was the bug surface)

## References

- Pad item: BUG-734 (was IDEA-734) — original report + repro
- Pad item: TASK-809 — implementation tracking, scope decisions, and the cascade→filter pivot rationale