### PR TITLE
fix: sanitize SQLite FTS5 queries + whitespace guards (BUG-818)

### DIFF
--- a/internal/store/documents.go
+++ b/internal/store/documents.go
@@ -40,7 +40,11 @@ func (s *Store) ListDocuments(workspaceID string, params models.DocumentListPara
 			query += " AND pinned = FALSE"
 		}
 	}
-	if params.Query != "" {
+	// Whitespace-only queries collapse to empty after FTS sanitization, and
+	// SQLite FTS5 errors on `MATCH ''`. Treat them as "no search filter" to
+	// match the !="" semantics callers expect. See BUG-818.
+	hasSearch := strings.TrimSpace(params.Query) != ""
+	if hasSearch {
 		// Use FTS for search
 		if s.dialect.Driver() == DriverSQLite {
 			ftsMatch := s.dialect.FTSMatch("documents_fts", "search_vector")
@@ -53,8 +57,12 @@ func (s *Store) ListDocuments(workspaceID string, params models.DocumentListPara
 				WHERE d.workspace_id = ? AND d.deleted_at IS NULL
 				AND %s
 			`, ftsMatch)
+			// Sanitize so FTS5 specials (hyphens, AND/OR/NOT, parens) are
+			// treated as literals rather than boolean operators — see BUG-818.
+			args = []interface{}{workspaceID, sanitizeFTSQuery(params.Query)}
 		} else {
 			// PostgreSQL: search_vector lives on the documents table (aliased as "d").
+			// plainto_tsquery handles arbitrary user input safely; no sanitize needed.
 			ftsMatch := s.dialect.FTSMatch("d", "search_vector")
 			query = fmt.Sprintf(`
 				SELECT d.id, d.workspace_id, d.title, d.slug, d.content, d.doc_type, d.status, d.tags,
@@ -64,8 +72,8 @@ func (s *Store) ListDocuments(workspaceID string, params models.DocumentListPara
 				WHERE d.workspace_id = ? AND d.deleted_at IS NULL
 				AND %s
 			`, ftsMatch)
+			args = []interface{}{workspaceID, params.Query}
 		}
-		args = []interface{}{workspaceID, params.Query}
 
 		if params.Type != "" {
 			query += " AND d.doc_type = ?"
@@ -96,7 +104,7 @@ func (s *Store) ListDocuments(workspaceID string, params models.DocumentListPara
 		order = "ASC"
 	}
 
-	if params.Query != "" {
+	if hasSearch {
 		if s.dialect.Driver() == DriverPostgres {
 			// PostgreSQL ts_rank(): higher = more relevant → DESC
 			ftsRank := s.dialect.FTSRank("d", "search_vector")

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -447,8 +447,10 @@ func (s *Store) ListItems(workspaceID string, params models.ItemListParams) ([]m
 		return nil, nil
 	}
 
-	// When search is specified, use FTS
-	if params.Search != "" {
+	// When search is specified, use FTS. Whitespace-only input is treated as
+	// "no search filter" (would otherwise sanitize to empty and crash SQLite
+	// FTS5 with "syntax error near \"\"" — see BUG-818).
+	if strings.TrimSpace(params.Search) != "" {
 		return s.listItemsFTS(workspaceID, params)
 	}
 
@@ -920,6 +922,13 @@ func (s *Store) RestoreItem(id string) (*models.Item, error) {
 }
 
 func (s *Store) SearchItems(workspaceID, query string) ([]ItemSearchResult, error) {
+	// Whitespace-only queries collapse to empty after FTS5 sanitization and
+	// would error on `MATCH ''`. Treat them as no-result rather than failing.
+	// See BUG-818.
+	if strings.TrimSpace(query) == "" {
+		return []ItemSearchResult{}, nil
+	}
+
 	var sqlQuery string
 	var args []interface{}
 

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -629,7 +629,12 @@ func (s *Store) listItemsFTS(workspaceID string, params models.ItemListParams) (
 			WHERE i.workspace_id = ? AND i.deleted_at IS NULL
 			AND %s
 		`, ftsMatch)
-		args = []interface{}{workspaceID, params.Search}
+		// Wrap each whitespace-delimited token in double quotes so FTS5 treats
+		// hyphens (and other special chars like AND/OR/NOT/(/)) as literals
+		// rather than boolean operators. Without this, `?search=TASK-5` raises
+		// "no such column: 5" — see BUG-818. Postgres path stays unsanitized
+		// because plainto_tsquery accepts arbitrary input.
+		args = []interface{}{workspaceID, sanitizeFTSQuery(params.Search)}
 	}
 
 	if params.CollectionSlug != "" {
@@ -967,7 +972,9 @@ func (s *Store) SearchItems(workspaceID, query string) ([]ItemSearchResult, erro
 			WHERE %s
 			AND i.deleted_at IS NULL
 		`, ftsSnippet, ftsRank, ftsMatch)
-		args = []interface{}{query}
+		// Sanitize the user query so FTS5 special characters (hyphens, boolean
+		// operators) are treated as literals — see BUG-818.
+		args = []interface{}{sanitizeFTSQuery(query)}
 	}
 
 	if workspaceID != "" {

--- a/internal/store/items_test.go
+++ b/internal/store/items_test.go
@@ -1316,6 +1316,72 @@ func TestSearchItems_HyphenatedQuery(t *testing.T) {
 	}
 }
 
+// TestListDocuments_HyphenatedQuery covers BUG-818 on the documents FTS path.
+// Same root cause as items: hyphenated queries hit FTS5's boolean parser and
+// 500 unless sanitized. Surfaces /documents?q=task-5 and the web UI doc list.
+func TestListDocuments_HyphenatedQuery(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Test")
+
+	want, err := s.CreateDocument(ws.ID, models.DocumentCreate{
+		Title:   "release-notes-q2",
+		Content: "Quarterly release notes for the Q2 2026 milestone.",
+	})
+	if err != nil {
+		t.Fatalf("CreateDocument: %v", err)
+	}
+	if _, err := s.CreateDocument(ws.ID, models.DocumentCreate{
+		Title:   "unrelated topic",
+		Content: "Nothing matching.",
+	}); err != nil {
+		t.Fatalf("CreateDocument unrelated: %v", err)
+	}
+
+	docs, err := s.ListDocuments(ws.ID, models.DocumentListParams{Query: "release-notes-q2"})
+	if err != nil {
+		t.Fatalf("ListDocuments(query=hyphenated) errored (FTS5 boolean parser regression?): %v", err)
+	}
+	if len(docs) == 0 {
+		t.Fatalf("ListDocuments returned 0 docs, expected to find %s", want.Title)
+	}
+	found := false
+	for _, d := range docs {
+		if d.ID == want.ID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("ListDocuments didn't include %s, got %d docs", want.Title, len(docs))
+	}
+}
+
+// TestFTS_WhitespaceOnlyQuery_DoesNotCrash exercises the whitespace-only
+// guard on each FTS entry point. sanitizeFTSQuery turns "   " into "" and
+// SQLite FTS5 errors on `MATCH ''`, so the routing/guard has to short-circuit
+// before binding. See BUG-818 / Codex follow-up.
+func TestFTS_WhitespaceOnlyQuery_DoesNotCrash(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Test")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+	createTestItem(t, s, ws.ID, col.ID, "anything", "")
+	if _, err := s.CreateDocument(ws.ID, models.DocumentCreate{Title: "anything"}); err != nil {
+		t.Fatalf("CreateDocument: %v", err)
+	}
+
+	for _, q := range []string{"   ", "\t", "\n  \t"} {
+		if _, err := s.ListItems(ws.ID, models.ItemListParams{Search: q}); err != nil {
+			t.Errorf("ListItems(search=%q) errored: %v", q, err)
+		}
+		if _, err := s.SearchItems(ws.ID, q); err != nil {
+			t.Errorf("SearchItems(%q) errored: %v", q, err)
+		}
+		if _, err := s.ListDocuments(ws.ID, models.DocumentListParams{Query: q}); err != nil {
+			t.Errorf("ListDocuments(query=%q) errored: %v", q, err)
+		}
+	}
+}
+
 // TestSanitizeFTSQuery is a unit test for the helper that wraps each token in
 // double quotes so SQLite FTS5 treats special characters as literals. See
 // internal/store/search.go and BUG-818.

--- a/internal/store/items_test.go
+++ b/internal/store/items_test.go
@@ -1245,6 +1245,108 @@ func TestListItems_ParentFilter_RespectsSoftDeletedParent(t *testing.T) {
 	}
 }
 
+// TestListItems_FTS_HyphenatedSearchTerm pins BUG-818: a hyphen in the search
+// query used to throw FTS5 boolean-parser errors ("no such column: foo")
+// because the input was bound verbatim into the MATCH clause. The fix wraps
+// each token in double quotes so FTS5 treats specials as literals.
+func TestListItems_FTS_HyphenatedSearchTerm(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Test")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+
+	// Single-word distinctive title for control.
+	want := createTestItem(t, s, ws.ID, col.ID, "task-five-distinctive", "")
+	// Plain non-matching item.
+	createTestItem(t, s, ws.ID, col.ID, "unrelated thing", "")
+
+	// Each of these queries used to raise an FTS5 syntax error before the fix.
+	// Now they should each return the matching item.
+	hyphenQueries := []string{
+		"task-five-distinctive", // full slug-ish
+		"task-five",             // partial hyphenated
+	}
+	for _, q := range hyphenQueries {
+		t.Run(q, func(t *testing.T) {
+			items, err := s.ListItems(ws.ID, models.ItemListParams{Search: q})
+			if err != nil {
+				t.Fatalf("ListItems(search=%q) errored (FTS5 boolean parser regression?): %v", q, err)
+			}
+			if len(items) == 0 {
+				t.Fatalf("ListItems(search=%q) returned 0 items, expected to find %s", q, want.Title)
+			}
+			found := false
+			for _, it := range items {
+				if it.ID == want.ID {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("ListItems(search=%q) didn't include %s, got %d items", q, want.Title, len(items))
+			}
+		})
+	}
+}
+
+// TestSearchItems_HyphenatedQuery is the BUG-818 regression test on the
+// /api/v1/search code path, which routes through Store.SearchItems instead
+// of Store.listItemsFTS.
+func TestSearchItems_HyphenatedQuery(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Test")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+	want := createTestItem(t, s, ws.ID, col.ID, "alpha-beta-gamma marker", "")
+
+	results, err := s.SearchItems(ws.ID, "alpha-beta-gamma")
+	if err != nil {
+		t.Fatalf("SearchItems errored on hyphenated query: %v", err)
+	}
+	if len(results) == 0 {
+		t.Fatalf("SearchItems returned 0 results, expected to find %s", want.Title)
+	}
+	found := false
+	for _, r := range results {
+		if r.Item.ID == want.ID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("SearchItems didn't include %s, got %d results", want.Title, len(results))
+	}
+}
+
+// TestSanitizeFTSQuery is a unit test for the helper that wraps each token in
+// double quotes so SQLite FTS5 treats special characters as literals. See
+// internal/store/search.go and BUG-818.
+func TestSanitizeFTSQuery(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"whitespace only", "   ", ""},
+		{"plain word", "hello", `"hello"`},
+		{"hyphenated phrase", "task-5", `"task-5"`},
+		{"multiple tokens", "foo bar", `"foo" "bar"`},
+		{"FTS5 boolean operator", "foo AND bar", `"foo" "AND" "bar"`},
+		{"NOT operator", "foo NOT bar", `"foo" "NOT" "bar"`},
+		{"parens", "(foo OR bar)", `"(foo" "OR" "bar)"`},
+		{"embedded quotes are stripped", `"foo"bar`, `"foobar"`},
+		{"surrounding whitespace trimmed", "  hello  ", `"hello"`},
+		{"unicode token preserved", "café-au-lait", `"café-au-lait"`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := sanitizeFTSQuery(tc.in)
+			if got != tc.want {
+				t.Errorf("sanitizeFTSQuery(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
 // --- BUG-812: listItemsFTS filter parity ---
 //
 // listItemsFTS used to silently drop most non-collection filters when the

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -97,6 +97,13 @@ func (s *Store) Search(params SearchParams) (*SearchResponse, error) {
 		return &SearchResponse{Results: []SearchResult{}, Limit: params.Limit, Offset: params.Offset}, nil
 	}
 
+	// Whitespace-only queries collapse to empty after FTS5 sanitization and
+	// would error on `MATCH ''`. Treat them as no-result rather than letting
+	// SQLite raise a syntax error. See BUG-818.
+	if strings.TrimSpace(params.Query) == "" {
+		return &SearchResponse{Results: []SearchResult{}, Limit: params.Limit, Offset: params.Offset}, nil
+	}
+
 	var results []SearchResult
 
 	// Check if the query looks like an item ref (e.g. "TASK-5", "BUG-8")


### PR DESCRIPTION
## Summary

Fixes **BUG-818** / **TASK-819**. SQLite FTS5 was treating user-input punctuation (hyphens, AND/OR/NOT, parens) as boolean operators, so any query like \`?search=TASK-5\` returned **HTTP 500** with \`"no such column: 5"\` from the FTS5 boolean parser. Whitespace-only queries collapsed to \`MATCH ''\` and threw a separate FTS5 syntax error.

The \`sanitizeFTSQuery\` helper that already existed in \`internal/store/search.go\` (used by \`Store.Search\`) wraps each whitespace-delimited token in double quotes, neutralizing FTS5 specials. This PR applies it everywhere user input was binding to a SQLite \`MATCH\` clause unsanitized.

## Changes

| Function | Before | After |
|---|---|---|
| \`Store.listItemsFTS\` | bound \`params.Search\` raw → 500 on hyphens | sanitized; whitespace short-circuited at \`listItems\` routing |
| \`Store.SearchItems\` | bound \`query\` raw → 500 on hyphens | sanitized; whitespace returns empty results |
| \`Store.ListDocuments\` | bound \`params.Query\` raw → 500 on hyphens | sanitized (SQLite branch); whitespace skips FTS branch |
| \`Store.Search\` | already sanitized; whitespace → \`MATCH ''\` 500 | early-return empty for whitespace-only |

PostgreSQL branches are intentionally left alone — \`plainto_tsquery\` accepts arbitrary user input safely.

## Test plan

- [x] \`TestListItems_FTS_HyphenatedSearchTerm\` — table-driven, multiple hyphen patterns
- [x] \`TestSearchItems_HyphenatedQuery\`
- [x] \`TestListDocuments_HyphenatedQuery\`
- [x] \`TestSanitizeFTSQuery\` — 11 sub-cases including empty, whitespace-only, FTS5 boolean operators (AND/OR/NOT), parens, embedded quotes (stripped), unicode
- [x] \`TestFTS_WhitespaceOnlyQuery_DoesNotCrash\` — covers all 3 store entry points (ListItems / SearchItems / ListDocuments) with spaces, tabs, mixed whitespace
- [x] \`go test ./...\` clean (full suite including \`internal/server\` and \`internal/store\`)
- [x] \`cd web && npm run build\` clean
- [x] \`make install\` clean

Manual verification — all 6 endpoints that previously 500'd now HTTP 200:

| Endpoint | Before | After |
|---|---|---|
| \`/items?search=task-five\` | 500 | **200** |
| \`/items?search=<3 spaces>\` | 500 | **200** |
| \`/documents?q=release-notes\` | 500 | **200** |
| \`/documents?q=<3 spaces>\` | 500 | **200** |
| \`/search?q=task-5\` | 200 (already worked) | 200 |
| \`/search?q=<3 spaces>\` | 500 | **200** |

## Codex review

Two passes. First found 1 MEDIUM (\`ListDocuments\` had the same bug class) + 1 LOW (whitespace edge case) — both addressed in commit \`5b77f48\`. Second pass verified BUG-818 itself is clean and surfaced an unrelated pre-existing issue (\`ListDocuments\` drops \`Tag\` and \`Pinned\` filters when \`search\` is set — the documents-side analog of BUG-812). Filed separately as **BUG-820**.

## Out of scope

- BUG-820 — \`ListDocuments\` filter-bypass on \`Tag\`/\`Pinned\` when search is set
- PostgreSQL semantics improvements (e.g. switching from \`plainto_tsquery\` to \`websearch_to_tsquery\`) — not the 500 surface

## References

- BUG-818 — original report (with the asymmetry investigation between \`/items?search=\` and \`/search?q=\`)
- TASK-819 — implementation tracking
- BUG-820 — filter-bypass on documents FTS path (Codex 2nd-pass discovery)
- BUG-812 / PR #260 — items-side analog of BUG-820