### PR TITLE
fix: apply Tag and Pinned filters in ListDocuments FTS branch (BUG-820)

### DIFF
--- a/internal/store/documents.go
+++ b/internal/store/documents.go
@@ -83,6 +83,20 @@ func (s *Store) ListDocuments(workspaceID string, params models.DocumentListPara
 			query += " AND d.status = ?"
 			args = append(args, params.Status)
 		}
+		// Tag and Pinned filters were silently dropped by the FTS branch
+		// before this fix — see BUG-820 (documents analog of BUG-812).
+		if params.Tag != "" {
+			tagExpr, tagArg := s.dialect.JSONArrayContains("d.tags", params.Tag)
+			query += " AND " + tagExpr
+			args = append(args, tagArg)
+		}
+		if params.Pinned != nil {
+			if *params.Pinned {
+				query += " AND d.pinned = TRUE"
+			} else {
+				query += " AND d.pinned = FALSE"
+			}
+		}
 	}
 
 	// Sort

--- a/internal/store/items_test.go
+++ b/internal/store/items_test.go
@@ -1356,6 +1356,88 @@ func TestListDocuments_HyphenatedQuery(t *testing.T) {
 	}
 }
 
+// TestListDocuments_FTS_TagFilter pins BUG-820: when a search query is set,
+// the FTS branch must still re-apply Tag filters (the documents analog of
+// BUG-812). Before the fix, /documents?q=foo&tag=bar returned all docs
+// matching "foo" regardless of tag.
+func TestListDocuments_FTS_TagFilter(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Test")
+
+	tagged, err := s.CreateDocument(ws.ID, models.DocumentCreate{
+		Title: "FTSdocfilter alpha",
+		Tags:  `["urgent"]`,
+	})
+	if err != nil {
+		t.Fatalf("CreateDocument tagged: %v", err)
+	}
+	if _, err := s.CreateDocument(ws.ID, models.DocumentCreate{
+		Title: "FTSdocfilter beta",
+		Tags:  `[]`,
+	}); err != nil {
+		t.Fatalf("CreateDocument untagged: %v", err)
+	}
+
+	// Sanity: search alone returns both.
+	docs, err := s.ListDocuments(ws.ID, models.DocumentListParams{Query: "FTSdocfilter"})
+	if err != nil {
+		t.Fatalf("ListDocuments sanity: %v", err)
+	}
+	if len(docs) != 2 {
+		t.Fatalf("sanity expected 2 docs via search, got %d", len(docs))
+	}
+
+	// Search + tag must narrow to the tagged doc only.
+	docs, err = s.ListDocuments(ws.ID, models.DocumentListParams{Query: "FTSdocfilter", Tag: "urgent"})
+	if err != nil {
+		t.Fatalf("ListDocuments search+tag: %v", err)
+	}
+	if len(docs) != 1 || docs[0].ID != tagged.ID {
+		t.Errorf("expected exactly the tagged doc, got %d docs", len(docs))
+	}
+}
+
+// TestListDocuments_FTS_PinnedFilter pins BUG-820 for the pinned filter:
+// /documents?q=foo&pinned=true used to ignore the pin bit when the FTS
+// branch took over. Documents analog of BUG-812.
+func TestListDocuments_FTS_PinnedFilter(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Test")
+
+	pinned, err := s.CreateDocument(ws.ID, models.DocumentCreate{
+		Title:  "FTSpindoc alpha",
+		Pinned: true,
+	})
+	if err != nil {
+		t.Fatalf("CreateDocument pinned: %v", err)
+	}
+	if _, err := s.CreateDocument(ws.ID, models.DocumentCreate{
+		Title:  "FTSpindoc beta",
+		Pinned: false,
+	}); err != nil {
+		t.Fatalf("CreateDocument unpinned: %v", err)
+	}
+
+	pinTrue := true
+	docs, err := s.ListDocuments(ws.ID, models.DocumentListParams{Query: "FTSpindoc", Pinned: &pinTrue})
+	if err != nil {
+		t.Fatalf("ListDocuments search+pinned=true: %v", err)
+	}
+	if len(docs) != 1 || docs[0].ID != pinned.ID {
+		t.Errorf("expected exactly the pinned doc via search+pinned=true, got %d docs", len(docs))
+	}
+
+	// And the inverse: pinned=false narrows to the other one.
+	pinFalse := false
+	docs, err = s.ListDocuments(ws.ID, models.DocumentListParams{Query: "FTSpindoc", Pinned: &pinFalse})
+	if err != nil {
+		t.Fatalf("ListDocuments search+pinned=false: %v", err)
+	}
+	if len(docs) != 1 || docs[0].Pinned {
+		t.Errorf("expected exactly the unpinned doc via search+pinned=false, got %d docs", len(docs))
+	}
+}
+
 // TestFTS_WhitespaceOnlyQuery_DoesNotCrash exercises the whitespace-only
 // guard on each FTS entry point. sanitizeFTSQuery turns "   " into "" and
 // SQLite FTS5 errors on `MATCH ''`, so the routing/guard has to short-circuit


### PR DESCRIPTION
## Summary

Fixes **BUG-820** / **TASK-821**. Documents-side analog of BUG-812.

\`Store.ListDocuments\` builds an initial query with \`Type\`/\`Status\`/\`Tag\`/\`Pinned\` filters. When \`params.Query\` is non-empty the FTS branch rebuilds \`query\` and \`args\` from scratch and only re-applies \`Type\` and \`Status\` — \`Tag\` and \`Pinned\` were silently dropped. So \`/documents?q=foo&tag=urgent\` returned all docs matching \`foo\` regardless of tag, and \`pinned\` had no effect on search results.

Discovered during Codex's 2nd review pass on PR #261 (BUG-818).

## Fix

Mirror the missing \`Tag\` and \`Pinned\` filter blocks into the FTS branch after the existing \`Type\`/\`Status\` blocks. Use the \`d.\` qualifier since the FTS branch aliases documents as \`d\` (vs the non-FTS branch which uses unqualified column names).

\`d.tags\` goes through \`s.dialect.JSONArrayContains\` (dialect-portable). \`d.pinned = TRUE/FALSE\` works in both SQLite (integer 1/0) and PostgreSQL (proper boolean).

## Codex review

One pass, **no findings** against BUG-820. Codex confirmed column qualifiers, dialect compatibility, filter ordering, ORDER BY non-interference, empty/nil semantics, and test coverage.

## Test plan

- [x] \`TestListDocuments_FTS_TagFilter\` — sanity (search alone returns 2) + tag narrows to 1
- [x] \`TestListDocuments_FTS_PinnedFilter\` — covers both \`pinned=true\` and \`pinned=false\` branches
- [x] \`go test ./...\` clean (full suite including \`internal/server\` and \`internal/store\`)
- [x] \`make install\` clean
- [x] Manual verification with two scratch docs (\`alpha\` tagged + pinned, \`beta\` untagged + unpinned):
  - \`?q=BUG820scratch\` → 2 docs
  - \`?q=BUG820scratch&tag=urgent\` → 1 doc (alpha)
  - \`?q=BUG820scratch&pinned=true\` → 1 doc (alpha)
  - \`?q=BUG820scratch&pinned=false\` → 1 doc (beta)

## Out of scope

- \`IncludeArchived\` parity in FTS (Codex's only LOW finding, pre-existing) — separate divergence. Documented as out-of-scope back on TASK-813.

## References

- BUG-820 — original report
- TASK-821 — implementation tracking
- BUG-812 / PR #260 — items-side analog
- BUG-818 / PR #261 — discovery context