### PR TITLE
fix: restore documents_fts triggers + rebuild index (BUG-822)

### DIFF
--- a/internal/store/items_test.go
+++ b/internal/store/items_test.go
@@ -1356,6 +1356,69 @@ func TestListDocuments_HyphenatedQuery(t *testing.T) {
 	}
 }
 
+// TestMigration046_DocumentsFTSTriggersExist verifies that after all
+// migrations run on a fresh DB, the three documents_* triggers are present.
+// This regression-protects BUG-822 — production DBs ended up missing these
+// triggers (likely from a transient quirk during migration 025), and
+// migration 046 restores them.
+func TestMigration046_DocumentsFTSTriggersExist(t *testing.T) {
+	s := testStore(t)
+
+	// SQLite-only — Postgres uses a different tsvector trigger setup and
+	// is unaffected.
+	if s.dialect.Driver() != DriverSQLite {
+		t.Skip("documents_ai/au/ad triggers are SQLite-FTS5 specific")
+	}
+
+	for _, want := range []string{"documents_ai", "documents_au", "documents_ad"} {
+		var name string
+		err := s.db.QueryRow(
+			"SELECT name FROM sqlite_master WHERE type='trigger' AND tbl_name='documents' AND name=?",
+			want,
+		).Scan(&name)
+		if err != nil {
+			t.Errorf("expected trigger %q to exist after migrations, got error: %v", want, err)
+		}
+	}
+}
+
+// TestCreateDocument_IsSearchableImmediately is the BUG-822 regression test:
+// a freshly-created document must be findable via FTS without any manual
+// rebuild. This was failing on production DBs whose documents_* triggers
+// were missing — Store.CreateDocument inserted into documents but the
+// after-insert trigger never fired to populate documents_fts, leaving the
+// new doc invisible to ListDocuments(Query=...).
+func TestCreateDocument_IsSearchableImmediately(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Test")
+
+	doc, err := s.CreateDocument(ws.ID, models.DocumentCreate{
+		Title:   "uniquesearchableword scratch",
+		Content: "body",
+	})
+	if err != nil {
+		t.Fatalf("CreateDocument: %v", err)
+	}
+
+	docs, err := s.ListDocuments(ws.ID, models.DocumentListParams{Query: "uniquesearchableword"})
+	if err != nil {
+		t.Fatalf("ListDocuments: %v", err)
+	}
+	if len(docs) == 0 {
+		t.Fatalf("expected to find newly-created doc by FTS, got 0 results (the BUG-822 regression)")
+	}
+	found := false
+	for _, d := range docs {
+		if d.ID == doc.ID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("FTS results don't include the new doc, got %d unrelated results", len(docs))
+	}
+}
+
 // TestListDocuments_FTS_TagFilter pins BUG-820: when a search query is set,
 // the FTS branch must still re-apply Tag filters (the documents analog of
 // BUG-812). Before the fix, /documents?q=foo&tag=bar returned all docs

--- a/internal/store/items_test.go
+++ b/internal/store/items_test.go
@@ -1382,6 +1382,64 @@ func TestMigration046_DocumentsFTSTriggersExist(t *testing.T) {
 	}
 }
 
+// TestMigration046_RebuildRecoversUnindexedDocs pins the *recovery* half of
+// migration 046 — the part that rescues already-broken DBs. We simulate the
+// production state Codex flagged: triggers were missing, so a document was
+// inserted into the documents table but never made it into documents_fts.
+// Migration 046's `INSERT INTO documents_fts(documents_fts) VALUES('rebuild')`
+// step is what makes such a document searchable again. Without this test,
+// removing the rebuild step would not break either of the other two BUG-822
+// tests — flagged in Codex review.
+func TestMigration046_RebuildRecoversUnindexedDocs(t *testing.T) {
+	s := testStore(t)
+
+	if s.dialect.Driver() != DriverSQLite {
+		t.Skip("FTS5 rebuild idiom is SQLite-specific")
+	}
+
+	ws := createTestWorkspace(t, s, "Test")
+
+	// Simulate the BUG-822 broken state: drop the FTS triggers so subsequent
+	// inserts don't propagate into documents_fts.
+	for _, name := range []string{"documents_ai", "documents_au", "documents_ad"} {
+		if _, err := s.db.Exec("DROP TRIGGER IF EXISTS " + name); err != nil {
+			t.Fatalf("DROP TRIGGER %s: %v", name, err)
+		}
+	}
+
+	// Insert via the normal store path; trigger is gone so it won't reach FTS.
+	doc, err := s.CreateDocument(ws.ID, models.DocumentCreate{
+		Title: "Bug822recoverable distinctive",
+	})
+	if err != nil {
+		t.Fatalf("CreateDocument: %v", err)
+	}
+
+	// Pin the broken state — the doc must NOT be searchable yet, otherwise
+	// the test isn't actually exercising the recovery path.
+	docs, err := s.ListDocuments(ws.ID, models.DocumentListParams{Query: "Bug822recoverable"})
+	if err != nil {
+		t.Fatalf("ListDocuments (pre-rebuild): %v", err)
+	}
+	if len(docs) != 0 {
+		t.Fatalf("test setup invalid: expected doc to be invisible to FTS pre-rebuild, got %d results", len(docs))
+	}
+
+	// Run just the rebuild step from migration 046 — the recovery action.
+	if _, err := s.db.Exec(`INSERT INTO documents_fts(documents_fts) VALUES ('rebuild')`); err != nil {
+		t.Fatalf("FTS rebuild: %v", err)
+	}
+
+	// Now the previously-unindexed doc must be findable.
+	docs, err = s.ListDocuments(ws.ID, models.DocumentListParams{Query: "Bug822recoverable"})
+	if err != nil {
+		t.Fatalf("ListDocuments (post-rebuild): %v", err)
+	}
+	if len(docs) != 1 || docs[0].ID != doc.ID {
+		t.Errorf("expected doc to become searchable post-rebuild, got %d results", len(docs))
+	}
+}
+
 // TestCreateDocument_IsSearchableImmediately is the BUG-822 regression test:
 // a freshly-created document must be findable via FTS without any manual
 // rebuild. This was failing on production DBs whose documents_* triggers

--- a/internal/store/migrations/046_restore_documents_fts_triggers.sql
+++ b/internal/store/migrations/046_restore_documents_fts_triggers.sql
@@ -1,0 +1,45 @@
+-- Migration 046: Restore documents_fts triggers + rebuild FTS index.
+--
+-- Background: BUG-822. Some production DBs ended up with the documents_*
+-- triggers missing — most likely a transient quirk during migration 025's
+-- table-rebuild for the doc_type CHECK constraint change, even though the
+-- migration was recorded as applied. Items_fts and comments_fts triggers
+-- are unaffected; the issue is isolated to the documents path.
+--
+-- This migration is intentionally idempotent and safe to apply on any DB:
+--   - Fresh installs that ran 025 cleanly already have these triggers; the
+--     DROP IF EXISTS + CREATE pair just round-trips.
+--   - Affected DBs (missing triggers) get them re-created.
+--   - The final 'rebuild' command repopulates the FTS5 internal index from
+--     the current documents table so previously-created docs become
+--     searchable, even if their inserts never fired the after-insert trigger.
+
+-- 1. Drop existing triggers if present so we can recreate them with
+--    consistent definitions. IF EXISTS makes this safe on DBs that don't
+--    have them.
+DROP TRIGGER IF EXISTS documents_ai;
+DROP TRIGGER IF EXISTS documents_au;
+DROP TRIGGER IF EXISTS documents_ad;
+
+-- 2. Recreate the three triggers. Bodies match migration 025 / 001 exactly.
+CREATE TRIGGER documents_ai AFTER INSERT ON documents BEGIN
+    INSERT INTO documents_fts(rowid, title, content, tags)
+    VALUES (new.rowid, new.title, new.content, new.tags);
+END;
+
+CREATE TRIGGER documents_ad AFTER DELETE ON documents BEGIN
+    INSERT INTO documents_fts(documents_fts, rowid, title, content, tags)
+    VALUES ('delete', old.rowid, old.title, old.content, old.tags);
+END;
+
+CREATE TRIGGER documents_au AFTER UPDATE ON documents BEGIN
+    INSERT INTO documents_fts(documents_fts, rowid, title, content, tags)
+    VALUES ('delete', old.rowid, old.title, old.content, old.tags);
+    INSERT INTO documents_fts(rowid, title, content, tags)
+    VALUES (new.rowid, new.title, new.content, new.tags);
+END;
+
+-- 3. Rebuild the FTS5 internal index from the current documents table.
+-- This recovers searchability for documents that were inserted while the
+-- triggers were missing. It's a no-op on DBs that were never broken.
+INSERT INTO documents_fts(documents_fts) VALUES ('rebuild');


### PR DESCRIPTION
## Summary

Fixes **BUG-822** / **TASK-823** — **HIGH severity**. Some production DBs are missing the \`documents_*\` triggers, so newly-created documents are silently invisible to FTS search. Plain list views still surface them, masking the regression.

Root-cause analysis: the issue is isolated to the table-rebuild path in migration 025 (the doc_type CHECK constraint change). \`items_fts\` and \`comments_fts\` triggers are intact across all DBs we checked. A fresh DB with all migrations applied produces all 9 triggers correctly. The migration runner is correct. The most likely explanation is a transient SQLite quirk during 025's \`DROP TABLE\` / \`RENAME\` / \`CREATE TRIGGER\` sequence on this specific DB. Not actionable beyond the fix.

## Fix

New migration \`046_restore_documents_fts_triggers.sql\` — intentionally idempotent:

1. \`DROP TRIGGER IF EXISTS\` for the three \`documents_*\` triggers — round-trips for fresh-install DBs that already have them, recovers DBs that don't.
2. \`CREATE TRIGGER\` (no \`IF NOT EXISTS\`, since we just dropped them) with bodies copied verbatim from migrations 001 / 025.
3. \`INSERT INTO documents_fts(documents_fts) VALUES ('rebuild')\` — repopulates the FTS5 internal index from the current \`documents\` table. This is what makes already-existing documents searchable on DBs that had the broken state.

PostgreSQL has its own tsvector trigger setup in \`pgmigrations/\` and is unaffected.

## Codex review

One pass, **0 HIGH/MEDIUM, 1 LOW**. Codex confirmed:
- \`DROP TRIGGER IF EXISTS\` syntax safe; \`CREATE TRIGGER\` post-drop correct
- Trigger bodies match 001/025 exactly
- FTS5 \`'rebuild'\` is the documented idiom
- Postgres path isolated (separate \`migratePostgres()\` reading from \`pgmigrations/\`)
- No similar table-rebuild risk on items_fts or comments_fts

The single LOW: tests didn't pin the recovery half (would still pass if the rebuild step were removed). Addressed in commit \`23a8151\` with \`TestMigration046_RebuildRecoversUnindexedDocs\` — drops triggers, inserts a doc, asserts it's invisible to FTS, runs the rebuild, asserts it becomes findable.

## Test plan

- [x] \`TestMigration046_DocumentsFTSTriggersExist\` — assert all 3 \`documents_*\` triggers exist after migrations
- [x] \`TestCreateDocument_IsSearchableImmediately\` — regression test: create doc, immediately search by unique title-keyword, assert findable
- [x] \`TestMigration046_RebuildRecoversUnindexedDocs\` — pins the recovery contract: rebuild makes previously-unindexed docs searchable
- [x] \`go test ./...\` clean
- [x] \`make install\` clean
- [x] **Manual verification on the actual broken production DB**:
  - Pre-migration: \`SELECT name FROM sqlite_master WHERE tbl_name='documents' AND type='trigger'\` → empty
  - Run \`make install\` → migration 046 applied
  - Post-migration: same query → \`documents_ai\`, \`documents_ad\`, \`documents_au\` all present
  - End-to-end: created a new doc with title \`BUG822verify distinctive\`, immediately searched \`?q=BUG822verify\` → returned 1 result (the new doc)

## References

- BUG-822 — original report with repro + root-cause investigation
- TASK-823 — implementation tracking
- BUG-820 / PR #263 — discovery context (manual repro on that PR is what stumbled into BUG-822)
- \`internal/store/migrations/025_doc_type_plan.sql\` — the migration where the regression most likely originated