### PR TITLE
feat(admin): add /api/v1/admin/billing-stats proxy + cloud client (TASK-827)

### DIFF
--- a/internal/billing/cloud_client.go
+++ b/internal/billing/cloud_client.go
@@ -103,6 +103,83 @@ func (e *SidecarError) Error() string {
 	return fmt.Sprintf("pad-cloud sidecar returned %d: %s", e.Status, e.Body)
 }
 
+// BillingMetricsResponse mirrors the JSON pad-cloud returns from
+// GET /admin/metrics/billing. All numeric fields are zero when
+// StripeConfigured is false (pad-cloud has no STRIPE_SECRET_KEY yet);
+// callers should render a "Stripe not configured" placeholder rather than
+// treating that as an error.
+//
+// Currency is lowercase ISO 4217 (Stripe's convention) and reports the
+// dominant currency across active subscriptions when the Stripe account
+// holds multiple currencies. ComputedAt is the wall-clock time of the
+// pad-cloud cache entry; CacheAgeSeconds is its age at response time.
+type BillingMetricsResponse struct {
+	StripeConfigured    bool      `json:"stripe_configured"`
+	ActiveSubscriptions int       `json:"active_subscriptions"`
+	MRRCents            int64     `json:"mrr_cents"`
+	ARRCents            int64     `json:"arr_cents"`
+	Currency            string    `json:"currency"`
+	ChurnRate30d        float64   `json:"churn_rate_30d"`
+	Cancelled30d        int       `json:"cancelled_30d"`
+	ComputedAt          time.Time `json:"computed_at"`
+	CacheAgeSeconds     int64     `json:"cache_age_seconds"`
+}
+
+// GetBillingMetrics asks pad-cloud for an aggregated Stripe-derived snapshot
+// (active subs, MRR, ARR, churn, cancellations). Auth is the same shared
+// CloudSecret pad-cloud uses for inbound calls — we send it via the
+// X-Cloud-Secret header rather than a body field because this endpoint is
+// a GET.
+//
+// Request: GET {baseURL}/admin/metrics/billing
+// Header:  X-Cloud-Secret: <CloudSecret>
+// 200 OK:  BillingMetricsResponse JSON
+//
+// Returns the decoded response on 200. On any non-200, returns a
+// *SidecarError so the caller can branch on Status (typically 403 for an
+// auth gate failure or 500 if the upstream Stripe call broke). On
+// transport failure (DNS, connect, timeout) returns a bare error — the
+// admin handler treats both as "degrade to local-only" and surfaces the
+// distinction via the cloud_unreachable flag in its own response.
+func (c *CloudClient) GetBillingMetrics() (*BillingMetricsResponse, error) {
+	if c == nil {
+		return nil, errors.New("billing: GetBillingMetrics called on nil CloudClient")
+	}
+	if c.baseURL == "" || c.cloudSecret == "" {
+		return nil, errors.New("billing: CloudClient is not configured (missing baseURL or cloudSecret)")
+	}
+
+	req, err := http.NewRequest(http.MethodGet, c.baseURL+"/admin/metrics/billing", nil)
+	if err != nil {
+		return nil, fmt.Errorf("billing: build billing-metrics request: %w", err)
+	}
+	req.Header.Set("X-Cloud-Secret", c.cloudSecret)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("billing: billing-metrics request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	bodyBytes, readErr := io.ReadAll(io.LimitReader(resp.Body, maxResponseBody))
+	if resp.StatusCode != http.StatusOK {
+		return nil, &SidecarError{
+			Status: resp.StatusCode,
+			Body:   string(bodyBytes),
+		}
+	}
+	if readErr != nil {
+		return nil, fmt.Errorf("billing: read billing-metrics response: %w", readErr)
+	}
+
+	var out BillingMetricsResponse
+	if err := json.Unmarshal(bodyBytes, &out); err != nil {
+		return nil, fmt.Errorf("billing: decode billing-metrics response: %w", err)
+	}
+	return &out, nil
+}
+
 // CancelCustomer asks pad-cloud to cancel every active Stripe subscription
 // for customerID and then delete the Stripe customer object. Idempotent at
 // the pad-cloud side (it treats a 404/resource_missing from Stripe as

--- a/internal/billing/cloud_client_test.go
+++ b/internal/billing/cloud_client_test.go
@@ -20,6 +20,155 @@ func newStub(t *testing.T, h http.HandlerFunc) (*CloudClient, *httptest.Server) 
 	return NewCloudClient(ts.URL, "test-secret"), ts
 }
 
+func TestGetBillingMetrics_HappyPath(t *testing.T) {
+	var (
+		gotMethod string
+		gotPath   string
+		gotSecret string
+		gotAccept string
+	)
+	want := BillingMetricsResponse{
+		StripeConfigured:    true,
+		ActiveSubscriptions: 7,
+		MRRCents:            49000,
+		ARRCents:            588000,
+		Currency:            "usd",
+		ChurnRate30d:        0.05,
+		Cancelled30d:        2,
+		ComputedAt:          time.Date(2026, 4, 27, 18, 0, 0, 0, time.UTC),
+		CacheAgeSeconds:     12,
+	}
+	client, _ := newStub(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotSecret = r.Header.Get("X-Cloud-Secret")
+		gotAccept = r.Header.Get("Accept")
+		w.WriteHeader(http.StatusOK)
+		body, _ := json.Marshal(want)
+		_, _ = w.Write(body)
+	})
+
+	got, err := client.GetBillingMetrics()
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+
+	if gotMethod != http.MethodGet {
+		t.Errorf("method: want GET, got %s", gotMethod)
+	}
+	if gotPath != "/admin/metrics/billing" {
+		t.Errorf("path: want /admin/metrics/billing, got %s", gotPath)
+	}
+	if gotSecret != "test-secret" {
+		t.Errorf("X-Cloud-Secret: want test-secret, got %s", gotSecret)
+	}
+	if gotAccept != "application/json" {
+		t.Errorf("Accept: want application/json, got %s", gotAccept)
+	}
+
+	if got.ActiveSubscriptions != want.ActiveSubscriptions ||
+		got.MRRCents != want.MRRCents ||
+		got.ARRCents != want.ARRCents ||
+		got.Currency != want.Currency ||
+		got.ChurnRate30d != want.ChurnRate30d ||
+		got.Cancelled30d != want.Cancelled30d ||
+		got.CacheAgeSeconds != want.CacheAgeSeconds ||
+		!got.ComputedAt.Equal(want.ComputedAt) {
+		t.Errorf("decoded response mismatch:\nwant %+v\ngot  %+v", want, *got)
+	}
+}
+
+func TestGetBillingMetrics_StripeNotConfigured(t *testing.T) {
+	// pad-cloud returns 200 + stripe_configured=false when STRIPE_SECRET_KEY
+	// is unset. The client must treat this as a successful call (no error).
+	client, _ := newStub(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"stripe_configured":false,"currency":"usd","computed_at":"2026-04-27T18:00:00Z"}`))
+	})
+
+	got, err := client.GetBillingMetrics()
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if got.StripeConfigured {
+		t.Errorf("stripe_configured: want false, got true")
+	}
+}
+
+func TestGetBillingMetrics_NonOK_ReturnsSidecarError(t *testing.T) {
+	client, _ := newStub(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error":"Forbidden"}`))
+	})
+
+	_, err := client.GetBillingMetrics()
+	var sidecarErr *SidecarError
+	if !errors.As(err, &sidecarErr) {
+		t.Fatalf("want *SidecarError, got %T: %v", err, err)
+	}
+	if sidecarErr.Status != http.StatusForbidden {
+		t.Errorf("status: want 403, got %d", sidecarErr.Status)
+	}
+	if !strings.Contains(sidecarErr.Body, "Forbidden") {
+		t.Errorf("body: want contains 'Forbidden', got %q", sidecarErr.Body)
+	}
+}
+
+func TestGetBillingMetrics_ServerError(t *testing.T) {
+	client, _ := newStub(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"boom"}`))
+	})
+
+	_, err := client.GetBillingMetrics()
+	var sidecarErr *SidecarError
+	if !errors.As(err, &sidecarErr) || sidecarErr.Status != 500 {
+		t.Errorf("want *SidecarError status=500, got %v", err)
+	}
+}
+
+func TestGetBillingMetrics_TransportError(t *testing.T) {
+	// Closed server triggers a transport-level error from c.http.Do.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	client := NewCloudClient(srv.URL, "test-secret")
+	srv.Close()
+
+	_, err := client.GetBillingMetrics()
+	if err == nil {
+		t.Fatal("want transport error, got nil")
+	}
+	// Transport errors should NOT be wrapped as *SidecarError — handler
+	// callers branch on type to log them differently.
+	var sidecarErr *SidecarError
+	if errors.As(err, &sidecarErr) {
+		t.Errorf("transport error should not be SidecarError, got %v", err)
+	}
+}
+
+func TestGetBillingMetrics_NilClient(t *testing.T) {
+	var c *CloudClient
+	if _, err := c.GetBillingMetrics(); err == nil {
+		t.Error("nil client: want error, got nil")
+	}
+}
+
+func TestGetBillingMetrics_UnconfiguredClient(t *testing.T) {
+	c := &CloudClient{} // empty baseURL + cloudSecret
+	if _, err := c.GetBillingMetrics(); err == nil {
+		t.Error("unconfigured client: want error, got nil")
+	}
+}
+
+func TestGetBillingMetrics_MalformedJSON(t *testing.T) {
+	client, _ := newStub(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`not json`))
+	})
+	if _, err := client.GetBillingMetrics(); err == nil {
+		t.Error("malformed JSON: want error, got nil")
+	}
+}
+
 func TestCancelCustomer_HappyPath_SendsCorrectRequest(t *testing.T) {
 	var (
 		gotMethod      string

--- a/internal/server/handlers_account_test.go
+++ b/internal/server/handlers_account_test.go
@@ -37,6 +37,14 @@ func (f *fakeSidecar) CancelCustomer(customerID string) error {
 	return f.err
 }
 
+// GetBillingMetrics is a stub so fakeSidecar satisfies the extended
+// CloudSidecar interface (TASK-827). The account-delete tests do not
+// exercise the billing dashboard path; the dedicated billing tests use
+// fakeBillingSidecar in handlers_admin_billing_test.go.
+func (f *fakeSidecar) GetBillingMetrics() (*billing.BillingMetricsResponse, error) {
+	return &billing.BillingMetricsResponse{}, nil
+}
+
 func (f *fakeSidecar) callCount() int {
 	return int(atomic.LoadInt32(&f.calls))
 }

--- a/internal/server/handlers_admin_billing.go
+++ b/internal/server/handlers_admin_billing.go
@@ -59,29 +59,18 @@ func (s *Server) handleAdminBillingStats(w http.ResponseWriter, r *http.Request)
 		Currency: "usd",
 	}
 
-	// Local fields: a single ListUsers walk computes both customers_by_plan
-	// and new_signups_30d. Same scaling profile as handleAdminStats; if
-	// users grows large the right next step is a SQL aggregate.
-	users, err := s.store.ListUsers()
+	// Local fields: two scalar SQL queries via store.CountBillingAggregates
+	// (per-plan COUNT(*) GROUP BY + a single COUNT(*) for new pro signups).
+	// Avoids the ListUsers + per-row TOTP decrypt that would otherwise burn
+	// CPU + bandwidth on every admin refresh as the user table grows.
+	cutoff := time.Now().UTC().Add(-30 * 24 * time.Hour)
+	agg, err := s.store.CountBillingAggregates(cutoff)
 	if err != nil {
 		writeInternalError(w, err)
 		return
 	}
-	planCounts := map[string]int{}
-	cutoff := time.Now().UTC().Add(-30 * 24 * time.Hour)
-	newSignups := 0
-	for _, u := range users {
-		plan := u.Plan
-		if plan == "" {
-			plan = "free"
-		}
-		planCounts[plan]++
-		if plan == "pro" && u.CreatedAt.After(cutoff) {
-			newSignups++
-		}
-	}
-	resp.CustomersByPlan = planCounts
-	resp.NewSignups30d = newSignups
+	resp.CustomersByPlan = agg.CustomersByPlan
+	resp.NewSignups30d = agg.NewProSignups
 
 	// Remote fields. cloudSidecar is nil when the operator is in cloud mode
 	// but hasn't wired PAD_CLOUD_SIDECAR_URL — treat that as unreachable.

--- a/internal/server/handlers_admin_billing.go
+++ b/internal/server/handlers_admin_billing.go
@@ -1,0 +1,127 @@
+package server
+
+import (
+	"errors"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/xarmian/pad/internal/billing"
+)
+
+// AdminBillingStatsResponse is the JSON shape returned by
+// GET /api/v1/admin/billing-stats. It merges Stripe-derived metrics from
+// pad-cloud (active_subscriptions, MRR, ARR, churn, cancellations) with
+// metrics computed from pad's local users table (customers_by_plan,
+// new_signups_30d).
+//
+// CloudUnreachable is true when the pad-cloud sidecar errored out (transport
+// failure, 5xx) — in that case the Stripe-derived fields are zero and the
+// UI renders a "sidecar unreachable" banner. CloudUnreachable=false +
+// StripeConfigured=false means the sidecar is reachable but no Stripe
+// account is wired up yet, which the UI surfaces as a placeholder.
+type AdminBillingStatsResponse struct {
+	StripeConfigured    bool           `json:"stripe_configured"`
+	CloudUnreachable    bool           `json:"cloud_unreachable"`
+	CustomersByPlan     map[string]int `json:"customers_by_plan"`
+	NewSignups30d       int            `json:"new_signups_30d"`
+	ActiveSubscriptions int            `json:"active_subscriptions"`
+	MRRCents            int64          `json:"mrr_cents"`
+	ARRCents            int64          `json:"arr_cents"`
+	Currency            string         `json:"currency"`
+	ChurnRate30d        float64        `json:"churn_rate_30d"`
+	Cancelled30d        int            `json:"cancelled_30d"`
+	ComputedAt          time.Time      `json:"computed_at"`
+	CacheAgeSeconds     int64          `json:"cache_age_seconds"`
+}
+
+// handleAdminBillingStats serves GET /api/v1/admin/billing-stats.
+//
+// Auth: requireCloudMode (the route group already gates on this) +
+// requireAdmin (this handler enforces). Returns 403 to non-admin users.
+//
+// Local fields (customers_by_plan, new_signups_30d) come straight from the
+// users table — same source as /api/v1/admin/stats. Remote fields come from
+// pad-cloud's /admin/metrics/billing endpoint via the CloudSidecar interface.
+//
+// Degradation: if the sidecar is not wired (cloudSidecar == nil) or returns
+// an error, the response carries cloud_unreachable=true with the
+// Stripe-derived fields zeroed. The endpoint always returns 200 — the UI
+// distinguishes "sidecar down" from "Stripe not configured" via the two
+// boolean flags rather than HTTP status, so a transient sidecar blip does
+// not blank the local-data half of the dashboard.
+func (s *Server) handleAdminBillingStats(w http.ResponseWriter, r *http.Request) {
+	if !requireAdmin(w, r) {
+		return
+	}
+
+	resp := AdminBillingStatsResponse{
+		Currency: "usd",
+	}
+
+	// Local fields: a single ListUsers walk computes both customers_by_plan
+	// and new_signups_30d. Same scaling profile as handleAdminStats; if
+	// users grows large the right next step is a SQL aggregate.
+	users, err := s.store.ListUsers()
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	planCounts := map[string]int{}
+	cutoff := time.Now().UTC().Add(-30 * 24 * time.Hour)
+	newSignups := 0
+	for _, u := range users {
+		plan := u.Plan
+		if plan == "" {
+			plan = "free"
+		}
+		planCounts[plan]++
+		if plan == "pro" && u.CreatedAt.After(cutoff) {
+			newSignups++
+		}
+	}
+	resp.CustomersByPlan = planCounts
+	resp.NewSignups30d = newSignups
+
+	// Remote fields. cloudSidecar is nil when the operator is in cloud mode
+	// but hasn't wired PAD_CLOUD_SIDECAR_URL — treat that as unreachable.
+	if s.cloudSidecar == nil {
+		resp.CloudUnreachable = true
+		resp.ComputedAt = time.Now().UTC()
+		writeJSON(w, http.StatusOK, resp)
+		return
+	}
+
+	metrics, err := s.cloudSidecar.GetBillingMetrics()
+	if err != nil {
+		// Either a transport failure or a non-200 (auth / upstream Stripe).
+		// Both degrade to local-only. Log enough to debug a misconfigured
+		// pair without leaking internal infra to the operator's browser.
+		var sidecarErr *billing.SidecarError
+		if errors.As(err, &sidecarErr) {
+			slog.Warn("admin/billing-stats: pad-cloud returned non-200, degrading to local-only",
+				"status", sidecarErr.Status, "body", sidecarErr.Body)
+		} else {
+			slog.Warn("admin/billing-stats: pad-cloud unreachable, degrading to local-only",
+				"error", err)
+		}
+		resp.CloudUnreachable = true
+		resp.ComputedAt = time.Now().UTC()
+		writeJSON(w, http.StatusOK, resp)
+		return
+	}
+
+	resp.StripeConfigured = metrics.StripeConfigured
+	resp.ActiveSubscriptions = metrics.ActiveSubscriptions
+	resp.MRRCents = metrics.MRRCents
+	resp.ARRCents = metrics.ARRCents
+	if metrics.Currency != "" {
+		resp.Currency = metrics.Currency
+	}
+	resp.ChurnRate30d = metrics.ChurnRate30d
+	resp.Cancelled30d = metrics.Cancelled30d
+	resp.ComputedAt = metrics.ComputedAt
+	resp.CacheAgeSeconds = metrics.CacheAgeSeconds
+
+	writeJSON(w, http.StatusOK, resp)
+}

--- a/internal/server/handlers_admin_billing_test.go
+++ b/internal/server/handlers_admin_billing_test.go
@@ -1,0 +1,362 @@
+package server
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/xarmian/pad/internal/billing"
+	"github.com/xarmian/pad/internal/models"
+)
+
+// fakeBillingSidecar is a controllable CloudSidecar used by the
+// handleAdminBillingStats tests. Lets each case decide whether
+// GetBillingMetrics returns a payload, a transport error, or a
+// *billing.SidecarError, without standing up a real HTTP server.
+type fakeBillingSidecar struct {
+	calls    atomic.Int32
+	response *billing.BillingMetricsResponse
+	err      error
+}
+
+func (f *fakeBillingSidecar) CancelCustomer(string) error {
+	return nil // unused by these tests
+}
+
+func (f *fakeBillingSidecar) GetBillingMetrics() (*billing.BillingMetricsResponse, error) {
+	f.calls.Add(1)
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.response, nil
+}
+
+// adminBillingReq fires GET /api/v1/admin/billing-stats with the cookie
+// from a logged-in user. Returns the recorder so callers can inspect status
+// + body. Pinned to 127.0.0.1 to match the bootstrap session's IP and
+// avoid the session-binding-changed audit-row write that would otherwise
+// fire on a different RemoteAddr.
+func adminBillingReq(srv *Server, token string) *httptest.ResponseRecorder {
+	return doRequestWithCookieFrom(srv, http.MethodGet, "/api/v1/admin/billing-stats",
+		nil, token, "127.0.0.1:5555")
+}
+
+// seedUser inserts a user directly with the given plan + created_at so
+// tests can deterministically populate the customers_by_plan and
+// new_signups_30d aggregates without round-tripping the registration flow.
+// Uses the test sqlite backend's raw `?` placeholders — these tests don't
+// run against postgres.
+//
+// Times are pre-formatted as RFC3339 strings to match the store's
+// formatting helper; passing a time.Time directly would let the driver
+// pick its own format (nano-precision RFC3339Nano), which the store's
+// parseTime() can't read back, leaving CreatedAt as a zero value and
+// silently breaking new_signups_30d filtering.
+func seedUser(t *testing.T, srv *Server, email, plan string, createdAt time.Time) {
+	t.Helper()
+	id := newSeedID(email)
+	username := "u_" + id // full ID for guaranteed uniqueness
+	ts := createdAt.UTC().Format(time.RFC3339)
+	_, err := srv.store.DB().Exec(
+		`INSERT INTO users
+			(id, email, username, name, password_hash, role, plan, created_at, updated_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		id, email, username, "Seed "+id, "x", "member", plan, ts, ts)
+	if err != nil {
+		t.Fatalf("seed user %s plan=%s: %v", email, plan, err)
+	}
+}
+
+// newSeedID is a stable test-only ID derived from the email. Used as both
+// the user.id AND the unique-per-row component of user.username, so
+// collisions are impossible across distinct emails.
+func newSeedID(email string) string {
+	h := uint64(0)
+	for _, c := range email {
+		h = h*31 + uint64(c)
+	}
+	return "seed_" + strconvUint(h)
+}
+
+// strconvUint is a tiny strconv.FormatUint replacement that avoids the
+// import dance for a one-line helper.
+func strconvUint(u uint64) string {
+	if u == 0 {
+		return "0"
+	}
+	var buf [20]byte
+	i := len(buf)
+	for u > 0 {
+		i--
+		buf[i] = byte('0' + u%10)
+		u /= 10
+	}
+	return string(buf[i:])
+}
+
+func decodeBillingStats(t *testing.T, rr *httptest.ResponseRecorder) AdminBillingStatsResponse {
+	t.Helper()
+	var resp AdminBillingStatsResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v body=%s", err, rr.Body.String())
+	}
+	return resp
+}
+
+// --- Tests ---
+
+func TestAdminBillingStats_SelfHostReturns404(t *testing.T) {
+	// Outside cloud mode the route group is gated by requireCloudMode and
+	// must disappear entirely from an authenticated admin's view — no
+	// "feature unavailable" disclosure, just 404 like any unrelated path.
+	srv := testServer(t)
+	adminToken := bootstrapFirstUser(t, srv, "admin@test.com", "Admin")
+	// Cloud mode deliberately NOT set.
+
+	rr := adminBillingReq(srv, adminToken)
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("self-host: want 404, got %d body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestAdminBillingStats_NonAdminReturns403(t *testing.T) {
+	srv := testServer(t)
+	// Bootstrap MUST happen before SetCloudMode — bootstrap is disabled
+	// in cloud mode (registration there flows through OAuth/invitations).
+	bootstrapFirstUser(t, srv, "admin@test.com", "Admin")
+	srv.SetCloudMode("cloud-secret")
+
+	memberToken := registerNonAdmin(t, srv, "member@test.com", "Member")
+
+	rr := adminBillingReq(srv, memberToken)
+	if rr.Code != http.StatusForbidden {
+		t.Errorf("non-admin: want 403, got %d body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestAdminBillingStats_AdminWithSidecarReachable_MergesLocalAndRemote(t *testing.T) {
+	srv := testServer(t)
+	now := time.Now().UTC()
+	recent := now.Add(-5 * 24 * time.Hour)
+	old := now.Add(-90 * 24 * time.Hour)
+
+	// Bootstrap before SetCloudMode (bootstrap is disabled in cloud mode).
+	adminToken := bootstrapFirstUser(t, srv, "admin@test.com", "Admin")
+	srv.SetCloudMode("cloud-secret")
+
+	// Seed local users for the customers_by_plan and new_signups_30d
+	// aggregates. The bootstrapped admin is plan="" → counted as "free" by
+	// the handler, so we account for it explicitly below.
+	seedUser(t, srv, "free1@test.com", "free", recent)
+	seedUser(t, srv, "free2@test.com", "free", old)
+	seedUser(t, srv, "pro1@test.com", "pro", recent) // counts as new_signup_30d
+	seedUser(t, srv, "pro2@test.com", "pro", recent) // counts as new_signup_30d
+	seedUser(t, srv, "pro_old@test.com", "pro", old) // pro but outside 30d window
+	seedUser(t, srv, "self@test.com", "self-hosted", old)
+
+	srv.SetCloudSidecar(&fakeBillingSidecar{
+		response: &billing.BillingMetricsResponse{
+			StripeConfigured:    true,
+			ActiveSubscriptions: 7,
+			MRRCents:            49000,
+			ARRCents:            588000,
+			Currency:            "usd",
+			ChurnRate30d:        0.05,
+			Cancelled30d:        2,
+			ComputedAt:          now,
+			CacheAgeSeconds:     12,
+		},
+	})
+
+	rr := adminBillingReq(srv, adminToken)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d body=%s", rr.Code, rr.Body.String())
+	}
+	resp := decodeBillingStats(t, rr)
+
+	if resp.CloudUnreachable {
+		t.Errorf("cloud_unreachable: want false on healthy sidecar")
+	}
+	if !resp.StripeConfigured {
+		t.Errorf("stripe_configured: want true")
+	}
+
+	// Local: 2 free seeded + admin (free) = 3; 3 pro; 1 self-hosted.
+	if got, want := resp.CustomersByPlan["free"], 3; got != want {
+		t.Errorf("customers_by_plan[free]: want %d, got %d", want, got)
+	}
+	if got, want := resp.CustomersByPlan["pro"], 3; got != want {
+		t.Errorf("customers_by_plan[pro]: want %d, got %d", want, got)
+	}
+	if got, want := resp.CustomersByPlan["self-hosted"], 1; got != want {
+		t.Errorf("customers_by_plan[self-hosted]: want %d, got %d", want, got)
+	}
+	// Only pro1 + pro2 are inside the 30-day window (pro_old is too old).
+	if got, want := resp.NewSignups30d, 2; got != want {
+		t.Errorf("new_signups_30d: want %d (pro1+pro2), got %d", want, got)
+	}
+
+	// Remote fields verbatim from the fake sidecar.
+	if resp.ActiveSubscriptions != 7 {
+		t.Errorf("active_subscriptions: want 7, got %d", resp.ActiveSubscriptions)
+	}
+	if resp.MRRCents != 49000 {
+		t.Errorf("mrr_cents: want 49000, got %d", resp.MRRCents)
+	}
+	if resp.ARRCents != 588000 {
+		t.Errorf("arr_cents: want 588000, got %d", resp.ARRCents)
+	}
+	if resp.Currency != "usd" {
+		t.Errorf("currency: want usd, got %s", resp.Currency)
+	}
+	if resp.Cancelled30d != 2 {
+		t.Errorf("cancelled_30d: want 2, got %d", resp.Cancelled30d)
+	}
+	if resp.CacheAgeSeconds != 12 {
+		t.Errorf("cache_age_seconds: want 12, got %d", resp.CacheAgeSeconds)
+	}
+}
+
+func TestAdminBillingStats_NoSidecarConfigured_DegradesToLocalOnly(t *testing.T) {
+	// Cloud mode is on but PAD_CLOUD_SIDECAR_URL was never set, so
+	// cloudSidecar is nil. The endpoint must still serve local data with
+	// cloud_unreachable=true.
+	srv := testServer(t)
+	adminToken := bootstrapFirstUser(t, srv, "admin@test.com", "Admin")
+	srv.SetCloudMode("cloud-secret")
+	seedUser(t, srv, "pro@test.com", "pro", time.Now().UTC())
+	// cloudSidecar deliberately not set.
+
+	rr := adminBillingReq(srv, adminToken)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("want 200 even without sidecar, got %d body=%s", rr.Code, rr.Body.String())
+	}
+	resp := decodeBillingStats(t, rr)
+	if !resp.CloudUnreachable {
+		t.Errorf("cloud_unreachable: want true when sidecar unwired")
+	}
+	if resp.StripeConfigured {
+		t.Errorf("stripe_configured: want false when no sidecar")
+	}
+	if resp.ActiveSubscriptions != 0 {
+		t.Errorf("active_subscriptions: want 0 when sidecar unwired, got %d", resp.ActiveSubscriptions)
+	}
+	// Local data still flows through.
+	if resp.CustomersByPlan["pro"] != 1 {
+		t.Errorf("local customers_by_plan[pro]: want 1, got %d", resp.CustomersByPlan["pro"])
+	}
+	if resp.NewSignups30d != 1 {
+		t.Errorf("new_signups_30d should reflect local data even without sidecar: want 1, got %d", resp.NewSignups30d)
+	}
+}
+
+func TestAdminBillingStats_SidecarTransportError_DegradesToLocalOnly(t *testing.T) {
+	srv := testServer(t)
+	adminToken := bootstrapFirstUser(t, srv, "admin@test.com", "Admin")
+	srv.SetCloudMode("cloud-secret")
+	srv.SetCloudSidecar(&fakeBillingSidecar{err: errors.New("dial tcp: connection refused")})
+
+	rr := adminBillingReq(srv, adminToken)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("transport error should still 200, got %d body=%s", rr.Code, rr.Body.String())
+	}
+	resp := decodeBillingStats(t, rr)
+	if !resp.CloudUnreachable {
+		t.Errorf("cloud_unreachable: want true on transport error")
+	}
+	if resp.ActiveSubscriptions != 0 {
+		t.Errorf("active_subscriptions: want 0 on transport error, got %d", resp.ActiveSubscriptions)
+	}
+}
+
+func TestAdminBillingStats_SidecarSidecarError_DegradesToLocalOnly(t *testing.T) {
+	// A non-200 from pad-cloud (e.g. wrong cloud secret, upstream Stripe
+	// 5xx) is reported as a *billing.SidecarError. The handler must treat
+	// it the same way as a transport error: cloud_unreachable=true, local
+	// data still flows.
+	srv := testServer(t)
+	adminToken := bootstrapFirstUser(t, srv, "admin@test.com", "Admin")
+	srv.SetCloudMode("cloud-secret")
+	srv.SetCloudSidecar(&fakeBillingSidecar{
+		err: &billing.SidecarError{Status: 500, Body: `{"error":"upstream stripe"}`},
+	})
+
+	rr := adminBillingReq(srv, adminToken)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("sidecar 5xx should still 200, got %d body=%s", rr.Code, rr.Body.String())
+	}
+	resp := decodeBillingStats(t, rr)
+	if !resp.CloudUnreachable {
+		t.Errorf("cloud_unreachable: want true on sidecar 5xx")
+	}
+}
+
+func TestAdminBillingStats_StripeNotConfigured_PropagatesFlag(t *testing.T) {
+	// pad-cloud returns stripe_configured=false when STRIPE_SECRET_KEY is
+	// unset; the proxy must surface that flag verbatim AND keep
+	// cloud_unreachable=false (the sidecar IS reachable, it just has no
+	// Stripe wired up).
+	srv := testServer(t)
+	adminToken := bootstrapFirstUser(t, srv, "admin@test.com", "Admin")
+	srv.SetCloudMode("cloud-secret")
+	srv.SetCloudSidecar(&fakeBillingSidecar{
+		response: &billing.BillingMetricsResponse{
+			StripeConfigured: false,
+			Currency:         "usd",
+			ComputedAt:       time.Now().UTC(),
+		},
+	})
+
+	rr := adminBillingReq(srv, adminToken)
+	resp := decodeBillingStats(t, rr)
+	if resp.CloudUnreachable {
+		t.Errorf("cloud_unreachable: want false (sidecar IS reachable)")
+	}
+	if resp.StripeConfigured {
+		t.Errorf("stripe_configured: want false")
+	}
+	if resp.ActiveSubscriptions != 0 || resp.MRRCents != 0 {
+		t.Errorf("zero metrics expected when Stripe not configured, got active=%d mrr=%d",
+			resp.ActiveSubscriptions, resp.MRRCents)
+	}
+}
+
+// --- helpers ---
+
+// registerNonAdmin inserts a member-role user directly into the store and
+// mints a session token for them. Bypasses the admin-registration flow
+// because that requires an admin session + CSRF, which would just be more
+// plumbing for what's a single-purpose test.
+func registerNonAdmin(t *testing.T, srv *Server, email, name string) string {
+	t.Helper()
+	id := newSeedID(email + "-nonadmin")
+	pwHash := "$2a$10$K9Rz.placeholderwhich.rejects.all.passwords.via.bcrypt"
+	ts := time.Now().UTC().Format(time.RFC3339)
+	if _, err := srv.store.DB().Exec(`INSERT INTO users
+			(id, email, username, name, password_hash, role, plan, created_at, updated_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		id, email, "u_"+id, name, pwHash, "member", "free", ts, ts); err != nil {
+		t.Fatalf("insert non-admin user: %v", err)
+	}
+
+	// Empty userAgent matches subsequent test requests (httptest.NewRequest
+	// does not set a User-Agent header), so the session-binding check sees
+	// "" → "" rather than firing a binding-mismatch 401.
+	token, err := srv.store.CreateSession(id, "test", "127.0.0.1", "", 24*time.Hour)
+	if err != nil {
+		t.Fatalf("create session for non-admin: %v", err)
+	}
+	return token
+}
+
+// Compile-time check that the response shape carries every field the UI
+// is going to read. Reaches into models so an unrelated User-shape rename
+// also signals a recompile here — cheap canary, drop if it gets noisy.
+var _ = func() *models.User {
+	_ = AdminBillingStatsResponse{ComputedAt: time.Time{}}
+	return nil
+}()

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -20,6 +20,7 @@ import (
 	"github.com/go-chi/cors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
+	"github.com/xarmian/pad/internal/billing"
 	"github.com/xarmian/pad/internal/email"
 	"github.com/xarmian/pad/internal/events"
 	"github.com/xarmian/pad/internal/metrics"
@@ -146,6 +147,17 @@ type CloudSidecar interface {
 	// would wipe the user's StripeCustomerID while leaving the subscription
 	// billing, which is exactly the regression TASK-690 exists to prevent.
 	CancelCustomer(customerID string) error
+
+	// GetBillingMetrics fetches an aggregated Stripe-derived snapshot from
+	// pad-cloud's /admin/metrics/billing endpoint (active subs, MRR, ARR,
+	// churn, cancellations). Used by handleAdminBillingStats to power the
+	// admin Billing dashboard (TASK-827 / PLAN-825).
+	//
+	// Failure contract: returns an error on transport failure or non-200
+	// status. The admin handler treats any error as "degrade to local-only"
+	// and surfaces the distinction in its response via cloud_unreachable —
+	// it never propagates the upstream failure to the operator's browser.
+	GetBillingMetrics() (*billing.BillingMetricsResponse, error)
 }
 
 // SetCloudSidecar installs the reverse pad → pad-cloud client. Called from
@@ -446,6 +458,14 @@ func (s *Server) setupRouter() {
 					r.Post("/stripe-event-processed", s.handleStripeEventProcessed) // Cloud: sidecar webhook idempotency (TASK-696)
 					r.Post("/stripe-event-unmark", s.handleStripeEventUnmark)       // Cloud: sidecar handler-failure rollback (TASK-736)
 					r.Post("/payment-failed", s.handlePaymentFailed)                // Cloud: sidecar forwards invoice.payment_failed to trigger email (TASK-712)
+
+					// Admin Billing dashboard data (TASK-827 / PLAN-825). Proxies
+					// pad-cloud's /admin/metrics/billing for Stripe-derived stats
+					// (active subs, MRR, ARR, churn) and merges with local
+					// users-table aggregates (customers_by_plan, new_signups_30d).
+					// Always returns 200; degraded states (sidecar unreachable,
+					// Stripe not configured) are surfaced as flags in the body.
+					r.Get("/billing-stats", s.handleAdminBillingStats)
 				})
 
 				// User management

--- a/internal/store/users.go
+++ b/internal/store/users.go
@@ -324,6 +324,62 @@ func (s *Store) UserCount() (int, error) {
 	return count, nil
 }
 
+// BillingAggregates is the set of users-table aggregates returned by
+// CountBillingAggregates: per-plan customer counts and the number of
+// new pro signups since a given cutoff. Intentionally narrow — the admin
+// billing dashboard is the only consumer today (PLAN-825).
+type BillingAggregates struct {
+	// CustomersByPlan maps plan slug ("free" / "pro" / "self-hosted") to
+	// user count. Users with an empty plan column are bucketed as "free"
+	// so the result matches handleAdminStats' presentation.
+	CustomersByPlan map[string]int
+	// NewProSignups is the count of users with plan='pro' whose
+	// created_at is strictly after the supplied cutoff.
+	NewProSignups int
+}
+
+// CountBillingAggregates returns the per-plan customer counts and the
+// count of new "pro" signups since `since`. Implemented as two scalar
+// SQL queries so the admin Billing dashboard does not have to materialise
+// every users row + decrypt every TOTP secret on each refresh
+// (Codex round 1, MEDIUM, PR for TASK-827).
+//
+// `since` is compared lexicographically against the stored RFC3339
+// created_at strings — that matches the rest of the store, where times
+// are stored as RFC3339 strings (see store.now / store.parseTime). For
+// any caller outside the test suite this is just time.Now().UTC()
+// minus the desired window.
+func (s *Store) CountBillingAggregates(since time.Time) (*BillingAggregates, error) {
+	out := &BillingAggregates{CustomersByPlan: map[string]int{}}
+
+	rows, err := s.db.Query(s.q(`SELECT COALESCE(NULLIF(plan, ''), 'free') AS plan, COUNT(*) FROM users GROUP BY plan`))
+	if err != nil {
+		return nil, fmt.Errorf("count users by plan: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var plan string
+		var count int
+		if err := rows.Scan(&plan, &count); err != nil {
+			return nil, fmt.Errorf("scan users-by-plan row: %w", err)
+		}
+		out.CustomersByPlan[plan] = count
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate users-by-plan: %w", err)
+	}
+
+	cutoff := since.UTC().Format(time.RFC3339)
+	if err := s.db.QueryRow(
+		s.q(`SELECT COUNT(*) FROM users WHERE plan = 'pro' AND created_at > ?`),
+		cutoff,
+	).Scan(&out.NewProSignups); err != nil {
+		return nil, fmt.Errorf("count new pro signups: %w", err)
+	}
+
+	return out, nil
+}
+
 // CreateOAuthUser creates a user from an OAuth provider with a random unusable password.
 // OAuth users can later set a password via the password reset flow if they want.
 func (s *Store) CreateOAuthUser(email, name, avatarURL string) (*models.User, error) {

--- a/internal/store/users.go
+++ b/internal/store/users.go
@@ -352,7 +352,13 @@ type BillingAggregates struct {
 func (s *Store) CountBillingAggregates(since time.Time) (*BillingAggregates, error) {
 	out := &BillingAggregates{CustomersByPlan: map[string]int{}}
 
-	rows, err := s.db.Query(s.q(`SELECT COALESCE(NULLIF(plan, ''), 'free') AS plan, COUNT(*) FROM users GROUP BY plan`))
+	// GROUP BY must match the projected expression — grouping on the raw
+	// `plan` column would split '' and 'free' into two result rows that
+	// both scan as "free" in Go and overwrite each other in the map,
+	// silently underreporting the free-tier count (Codex round 2).
+	rows, err := s.db.Query(s.q(`SELECT COALESCE(NULLIF(plan, ''), 'free') AS plan, COUNT(*)
+		FROM users
+		GROUP BY COALESCE(NULLIF(plan, ''), 'free')`))
 	if err != nil {
 		return nil, fmt.Errorf("count users by plan: %w", err)
 	}

--- a/internal/store/users_test.go
+++ b/internal/store/users_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"testing"
+	"time"
 
 	"github.com/xarmian/pad/internal/models"
 )
@@ -199,5 +200,65 @@ func TestUserCount(t *testing.T) {
 	count, _ = s.UserCount()
 	if count != 2 {
 		t.Errorf("expected 2 users, got %d", count)
+	}
+}
+
+func TestCountBillingAggregates(t *testing.T) {
+	s := testStore(t)
+	now := time.Now().UTC()
+	cutoff := now.Add(-30 * 24 * time.Hour)
+
+	// Empty store: zero counts, no plans, no signups.
+	agg, err := s.CountBillingAggregates(cutoff)
+	if err != nil {
+		t.Fatalf("CountBillingAggregates on empty store: %v", err)
+	}
+	if len(agg.CustomersByPlan) != 0 {
+		t.Errorf("empty store: want no plan entries, got %v", agg.CustomersByPlan)
+	}
+	if agg.NewProSignups != 0 {
+		t.Errorf("empty store: want NewProSignups=0, got %d", agg.NewProSignups)
+	}
+
+	// Two free users (one auto-bucketed from empty plan), one pro inside
+	// window, one pro outside window, one self-hosted outside window.
+	createTestUser(t, s, "free1@test.com", "Free One", "pass")    // empty plan → "free"
+	createTestUser(t, s, "free2@test.com", "Free Two", "pass")    // empty plan → "free"
+	insertWithPlanAndDate(t, s, "pro_recent@test.com", "pro", now.Add(-5*24*time.Hour))
+	insertWithPlanAndDate(t, s, "pro_old@test.com", "pro", now.Add(-90*24*time.Hour))
+	insertWithPlanAndDate(t, s, "self@test.com", "self-hosted", now.Add(-60*24*time.Hour))
+
+	agg, err = s.CountBillingAggregates(cutoff)
+	if err != nil {
+		t.Fatalf("CountBillingAggregates: %v", err)
+	}
+	if got, want := agg.CustomersByPlan["free"], 2; got != want {
+		t.Errorf("free: want %d, got %d (full map: %v)", want, got, agg.CustomersByPlan)
+	}
+	if got, want := agg.CustomersByPlan["pro"], 2; got != want {
+		t.Errorf("pro: want %d, got %d", want, got)
+	}
+	if got, want := agg.CustomersByPlan["self-hosted"], 1; got != want {
+		t.Errorf("self-hosted: want %d, got %d", want, got)
+	}
+	if got, want := agg.NewProSignups, 1; got != want {
+		t.Errorf("new pro signups in last 30d: want %d (recent only), got %d", want, got)
+	}
+}
+
+// insertWithPlanAndDate is a test-only helper that inserts a user with a
+// specific plan + created_at timestamp. CreateUser doesn't expose either
+// directly. Times are RFC3339-formatted strings (matching store.now) so
+// CountBillingAggregates can do a string lex-compare against the cutoff.
+func insertWithPlanAndDate(t *testing.T, s *Store, email, plan string, createdAt time.Time) {
+	t.Helper()
+	id := newID()
+	ts := createdAt.UTC().Format(time.RFC3339)
+	_, err := s.db.Exec(s.q(`
+		INSERT INTO users (id, email, username, name, password_hash, role, plan, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`),
+		id, email, "u_"+id, "Test "+id, "x", "member", plan, ts, ts)
+	if err != nil {
+		t.Fatalf("insert user with plan=%s: %v", plan, err)
 	}
 }

--- a/internal/store/users_test.go
+++ b/internal/store/users_test.go
@@ -220,10 +220,15 @@ func TestCountBillingAggregates(t *testing.T) {
 		t.Errorf("empty store: want NewProSignups=0, got %d", agg.NewProSignups)
 	}
 
-	// Two free users (one auto-bucketed from empty plan), one pro inside
-	// window, one pro outside window, one self-hosted outside window.
-	createTestUser(t, s, "free1@test.com", "Free One", "pass")    // empty plan → "free"
-	createTestUser(t, s, "free2@test.com", "Free Two", "pass")    // empty plan → "free"
+	// Mix: explicit-empty plan (older legacy rows) + explicit "free"
+	// (current default) + pro recent + pro old + self-hosted. Both the
+	// '' and 'free' rows must roll up into the same "free" bucket — Codex
+	// round 2 caught this regression where GROUP BY plan (raw column)
+	// produced two scanned rows both labelled "free" that overwrote each
+	// other in the result map.
+	insertWithPlanAndDate(t, s, "legacy_blank@test.com", "", now.Add(-100*24*time.Hour))
+	insertWithPlanAndDate(t, s, "free_explicit@test.com", "free", now.Add(-2*24*time.Hour))
+	insertWithPlanAndDate(t, s, "free_explicit2@test.com", "free", now.Add(-1*24*time.Hour))
 	insertWithPlanAndDate(t, s, "pro_recent@test.com", "pro", now.Add(-5*24*time.Hour))
 	insertWithPlanAndDate(t, s, "pro_old@test.com", "pro", now.Add(-90*24*time.Hour))
 	insertWithPlanAndDate(t, s, "self@test.com", "self-hosted", now.Add(-60*24*time.Hour))
@@ -232,8 +237,9 @@ func TestCountBillingAggregates(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CountBillingAggregates: %v", err)
 	}
-	if got, want := agg.CustomersByPlan["free"], 2; got != want {
-		t.Errorf("free: want %d, got %d (full map: %v)", want, got, agg.CustomersByPlan)
+	// 1 legacy blank + 2 explicit "free" must roll up to 3.
+	if got, want := agg.CustomersByPlan["free"], 3; got != want {
+		t.Errorf("free (rolls up '' + 'free'): want %d, got %d (full map: %v)", want, got, agg.CustomersByPlan)
 	}
 	if got, want := agg.CustomersByPlan["pro"], 2; got != want {
 		t.Errorf("pro: want %d, got %d", want, got)

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -40,7 +40,8 @@ import type {
 	ShareLink,
 	TOTPSetupResponse,
 	TOTPVerifyResponse,
-	TOTPDisableResponse
+	TOTPDisableResponse,
+	AdminBillingStats
 } from '$lib/types';
 
 const BASE = '/api/v1';
@@ -717,7 +718,15 @@ export const api = {
 			request<{ ok: boolean; sent_to: string }>('/admin/test-email', {
 				method: 'POST',
 				body: JSON.stringify(to ? { to } : {})
-			})
+			}),
+		// Billing stats for the admin Billing dashboard (TASK-828 / PLAN-825).
+		// Returns merged Stripe-derived metrics (active subs, MRR, ARR, churn,
+		// cancellations) plus local users-table aggregates (customers_by_plan,
+		// new_signups_30d). Always 200 — degraded states surface as the
+		// stripe_configured + cloud_unreachable booleans on the body.
+		// Cloud-mode only (returns 404 in self-host).
+		getBillingStats: () =>
+			request<AdminBillingStats>('/admin/billing-stats')
 	}
 };
 

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -716,6 +716,33 @@ export interface ApiError {
 	message: string;
 }
 
+// ─── Admin Billing Stats (PLAN-825) ──────────────────────────────────────────
+
+// Returned by GET /api/v1/admin/billing-stats. Merges Stripe-derived metrics
+// from the pad-cloud sidecar with local users-table aggregates. Two booleans
+// drive UI presentation:
+//
+// - `cloud_unreachable=true`  → sidecar errored; render banner, Stripe fields
+//   are zero, local fields are still valid.
+// - `stripe_configured=false` → sidecar reachable but no Stripe wired up yet;
+//   render "Stripe not configured" placeholder on Stripe-derived cards.
+//
+// Both false = healthy, render real numbers everywhere.
+export interface AdminBillingStats {
+	stripe_configured: boolean;
+	cloud_unreachable: boolean;
+	customers_by_plan: Record<string, number>;
+	new_signups_30d: number;
+	active_subscriptions: number;
+	mrr_cents: number;
+	arr_cents: number;
+	currency: string;
+	churn_rate_30d: number;
+	cancelled_30d: number;
+	computed_at: string;
+	cache_age_seconds: number;
+}
+
 // ─── Helper functions ────────────────────────────────────────────────────────
 
 export function parseFields(item: Item): Record<string, any> {

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -727,7 +727,9 @@ export interface ApiError {
 // - `stripe_configured=false` → sidecar reachable but no Stripe wired up yet;
 //   render "Stripe not configured" placeholder on Stripe-derived cards.
 //
-// Both false = healthy, render real numbers everywhere.
+// `cloud_unreachable=false` AND `stripe_configured=true` → fully healthy;
+// render real numbers on every card. Other combinations imply a degraded
+// state — see the two bullets above.
 export interface AdminBillingStats {
 	stripe_configured: boolean;
 	cloud_unreachable: boolean;


### PR DESCRIPTION
## Summary

New `GET /api/v1/admin/billing-stats` admin endpoint that powers the upcoming Pad Cloud Billing dashboard. Merges Stripe-derived metrics from the pad-cloud sidecar (active subscriptions, MRR, ARR, 30-day churn rate, 30-day cancellations) with locally-computed users-table aggregates (`customers_by_plan`, `new_signups_30d`).

## Context

Implements **TASK-827** under **PLAN-825** (Pad Cloud Admin Billing Dashboard). Second of three PRs.

- TASK-826 (pad-cloud `/admin/metrics/billing` endpoint) — already merged on pad-cloud `main`
- TASK-827 — **this PR**
- TASK-828 (web UI Billing tab) — next PR, will consume `api.admin.getBillingStats()` added here

## Architecture (PLAN-825 Option B)

- **pad-cloud** owns Stripe API access (single SDK + secret).
- **pad** proxies via this new endpoint. The reverse `pad → pad-cloud` HTTP client lives in `internal/billing/CloudClient`; this PR adds `GetBillingMetrics()` (GET, `X-Cloud-Secret` header) alongside the existing `CancelCustomer`.
- The `CloudSidecar` interface in `internal/server` gains `GetBillingMetrics()` so `internal/server` stays free of HTTP/Stripe deps and tests can inject fakes.

## Degradation contract

The endpoint **always returns 200**. Two booleans tell the UI which fallback to render:

| `cloud_unreachable` | `stripe_configured` | Meaning | UI |
|---|---|---|---|
| false | true | Healthy | Real numbers everywhere |
| false | false | Sidecar reachable, no Stripe yet | "Stripe not configured" placeholder on Stripe cards |
| true | (any) | Sidecar errored / unwired | Banner; local cards still show real numbers |

`requireCloudMode` (route group) + `requireAdmin` (handler) gate the route. Self-host gets 404, non-admin gets 403.

## Performance

`store.CountBillingAggregates(since)` does two scalar SQL queries (`SELECT plan, COUNT(*) GROUP BY COALESCE(NULLIF(plan,''), 'free')` and `SELECT COUNT(*) WHERE plan='pro' AND created_at > ?`) instead of materialising every users row + decrypting every TOTP secret. Caught by Codex round 1.

## Codex review

3 rounds:
- **Round 1**: 0 HIGH / 1 MEDIUM (`ListUsers` was loading the world for an aggregate) / 1 LOW (misleading TS comment) — both fixed
- **Round 2**: 0 HIGH / 1 MEDIUM / 0 LOW — caught a real bug: `GROUP BY plan` on the raw column made `''` and `'free'` produce two scanned rows that overwrote each other in the result map. Fixed: `GROUP BY` matches the projected `COALESCE`
- **Round 3**: **CLEAN**

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./...` — all pass
- [x] `cd web && npm run build` — clean
- [x] **Billing package tests** (8 new): `GetBillingMetrics` happy path (asserts method, path, `X-Cloud-Secret`, `Accept`), Stripe-not-configured pass-through, non-200 → `*SidecarError`, transport error stays bare, malformed JSON, nil/unconfigured client guards
- [x] **Server package tests** (7 new): self-host 404, non-admin 403, admin happy-path merge (local + remote), no-sidecar degrades, transport error degrades, sidecar 5xx degrades, `stripe_configured=false` propagates verbatim
- [x] **Store package tests** (1 new): `TestCountBillingAggregates` covers empty store, mixed plans, `''` + `'free'` roll-up, 30-day cutoff filter for new pro signups