### PR TITLE
fix(cli): use cfg.BaseURL()/BrowserURL() in pad init success message + pad open (TASK-834)

### DIFF
--- a/cmd/pad/init.go
+++ b/cmd/pad/init.go
@@ -195,7 +195,7 @@ Examples:
 			if !actioned {
 				printInitStatus(client, cfg, ws, skillResults)
 			} else if newlyCreated {
-				printOnboardingHints()
+				printOnboardingHints(cfg)
 			}
 
 			return nil

--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -483,7 +483,7 @@ func openCmd() *cobra.Command {
 				return fmt.Errorf("start server: %w", err)
 			}
 
-			url := cfg.BaseURL()
+			url := cfg.BrowserURL()
 
 			// If there's a workspace, go directly to it
 			ws, _ := cli.DetectWorkspace(workspaceFlag)

--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -1326,7 +1326,7 @@ func printOnboardingHints(cfg *config.Config) {
 	fmt.Printf("  %s  %s\n", cyan.Sprint("/pad"), "what conventions should this project follow?")
 	fmt.Printf("  %s  %s\n", cyan.Sprint("/pad"), "create a plan for what I'm working on")
 	fmt.Println()
-	fmt.Printf("Or open the web UI at %s\n", bold.Sprint(cfg.BaseURL()))
+	fmt.Printf("Or open the web UI at %s\n", bold.Sprint(cfg.BrowserURL()))
 	fmt.Println(dim.Sprint("Run 'pad project dashboard' to see your project dashboard"))
 }
 
@@ -1440,7 +1440,7 @@ recommend conventions from the built-in library.`,
 			choice := readChoice()
 			if choice != "y" && choice != "Y" {
 				fmt.Println("Skipped. You can activate conventions from the library:")
-				fmt.Printf("  %s/%s/library\n", cfg.BaseURL(), ws)
+				fmt.Printf("  %s/%s/library\n", cfg.BrowserURL(), ws)
 				return nil
 			}
 

--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -1137,7 +1137,7 @@ a workspace in one step.`,
 			offerSkillInstall()
 
 			if newlyCreated {
-				printOnboardingHints()
+				printOnboardingHints(cfg)
 			}
 			return nil
 		},
@@ -1315,7 +1315,7 @@ func readChoice() string {
 	return strings.TrimSpace(input)
 }
 
-func printOnboardingHints() {
+func printOnboardingHints(cfg *config.Config) {
 	bold := color.New(color.Bold)
 	dim := color.New(color.Faint)
 	cyan := color.New(color.FgCyan)
@@ -1326,7 +1326,7 @@ func printOnboardingHints() {
 	fmt.Printf("  %s  %s\n", cyan.Sprint("/pad"), "what conventions should this project follow?")
 	fmt.Printf("  %s  %s\n", cyan.Sprint("/pad"), "create a plan for what I'm working on")
 	fmt.Println()
-	fmt.Printf("Or open the web UI at %s\n", bold.Sprint("http://localhost:7777"))
+	fmt.Printf("Or open the web UI at %s\n", bold.Sprint(cfg.BaseURL()))
 	fmt.Println(dim.Sprint("Run 'pad project dashboard' to see your project dashboard"))
 }
 
@@ -1440,7 +1440,7 @@ recommend conventions from the built-in library.`,
 			choice := readChoice()
 			if choice != "y" && choice != "Y" {
 				fmt.Println("Skipped. You can activate conventions from the library:")
-				fmt.Printf("  http://localhost:7777/%s/library\n", ws)
+				fmt.Printf("  %s/%s/library\n", cfg.BaseURL(), ws)
 				return nil
 			}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -258,6 +258,25 @@ func (c *Config) BaseURL() string {
 	return fmt.Sprintf("http://%s:%d", c.Host, c.Port)
 }
 
+// BrowserURL returns a URL suitable for displaying to humans in CLI prompts
+// (e.g. "Or open the web UI at X"). It behaves like BaseURL except that
+// when the URL is constructed from host:port, an unspecified bind-all host
+// (empty, "0.0.0.0", "::", "[::]") is rewritten to "127.0.0.1" because
+// 0.0.0.0 is a bind address and not reliably usable as a browser
+// destination. When URL is explicitly set (Remote/Docker/Cloud) it is
+// returned as-is.
+func (c *Config) BrowserURL() string {
+	if c.URL != "" {
+		return strings.TrimRight(c.URL, "/")
+	}
+	host := c.Host
+	switch host {
+	case "", "0.0.0.0", "::", "[::]":
+		host = "127.0.0.1"
+	}
+	return fmt.Sprintf("http://%s:%d", host, c.Port)
+}
+
 func (c *Config) PIDFile() string {
 	return filepath.Join(c.DataDir, "pad.pid")
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -93,3 +93,38 @@ func TestManagesLocalServerRequiresConfiguredLocalMode(t *testing.T) {
 		t.Fatal("expected docker mode to avoid local server management")
 	}
 }
+
+func TestBrowserURLNormalizesUnspecifiedHost(t *testing.T) {
+	cases := []struct {
+		name string
+		host string
+		want string
+	}{
+		{"loopback unchanged", "127.0.0.1", "http://127.0.0.1:7777"},
+		{"named host unchanged", "pad.local", "http://pad.local:7777"},
+		{"empty host normalized", "", "http://127.0.0.1:7777"},
+		{"ipv4 unspecified normalized", "0.0.0.0", "http://127.0.0.1:7777"},
+		{"ipv6 unspecified normalized", "::", "http://127.0.0.1:7777"},
+		{"ipv6 bracketed unspecified normalized", "[::]", "http://127.0.0.1:7777"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &Config{Host: tc.host, Port: 7777}
+			if got := cfg.BrowserURL(); got != tc.want {
+				t.Fatalf("BrowserURL() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBrowserURLPrefersExplicitURL(t *testing.T) {
+	cfg := &Config{
+		Host: "0.0.0.0", // would normally be normalized
+		Port: 7777,
+		URL:  "https://app.getpad.dev/",
+	}
+	want := "https://app.getpad.dev"
+	if got := cfg.BrowserURL(); got != want {
+		t.Fatalf("BrowserURL() = %q, want %q (explicit URL must win and trailing slash trimmed)", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

Replaces hardcoded `http://localhost:7777` strings in user-facing CLI output with the configured base URL, so the success message, library hint, and `pad open` work correctly for every connection mode (Local / Remote / Docker / Cloud) — not just local.

- `printOnboardingHints` (`cmd/pad/main.go`) — the "Or open the web UI at X" line in the `pad init` / `pad workspace init` success path.
- `onboardCmd` skip-path (`cmd/pad/main.go`) — the "You can activate conventions from the library: X" hint.
- `pad open` (`cmd/pad/main.go`) — also flagged by Codex review; same class of bug.

`printOnboardingHints` now takes `*config.Config`; both call sites already had `cfg` in scope.

## New helper: `(*Config).BrowserURL()`

Codex review round 1 caught that `cfg.BaseURL()` returns `http://0.0.0.0:7777` when local mode is bound bind-all (`--host 0.0.0.0`), which is a bind address rather than a clickable browser URL. Added `BrowserURL()` next to `BaseURL()` — same behavior except that when constructing from `host:port`, an unspecified bind-all host (empty, `0.0.0.0`, `::`, `[::]`) is rewritten to `127.0.0.1`. When `URL` is explicitly set (Remote/Docker/Cloud) it is returned unchanged.

API clients, SSE, saved credentials, and server internals continue to use `BaseURL()` — only browser-display surfaces switched.

## Context

Implements **TASK-834** under **PLAN-833** (decomposition of **IDEA-831** — pad init UX gaps from the first end-to-end Pad Cloud auth test).

A related but separately-scoped issue surfaced during Codex review round 2: the **server**-issued CLI auth URL in `doBrowserLogin` (constructed from `r.Host` in `internal/server/handlers_cli_auth.go`) shows the same `0.0.0.0` problem. That fix has multiple possible strategies (server-side normalization vs CLI-side URL rewrite) and overlaps with the post-v0.1.0 OAuth-architecture work in TASK-838, so it was deferred to **TASK-839** with a written-up runbook.

## Codex review

3 rounds:
1. Found one MEDIUM (the `0.0.0.0` → bind-address issue). Fixed by adding `BrowserURL()`.
2. Confirmed round-1 fix; flagged two new MEDIUMs — `pad open` (fixed in this PR) and `doBrowserLogin` / `r.Host` (deferred to TASK-839).
3. **CLEAN.** No HIGH/MEDIUM/LOW findings.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` all pass
- [x] `cd web && npm run build` clean
- [x] New tests in `internal/config/config_test.go`:
  - `TestBrowserURLNormalizesUnspecifiedHost` (loopback / named host / empty / 0.0.0.0 / `::` / `[::]`)
  - `TestBrowserURLPrefersExplicitURL` (remote URL precedence + trailing-slash trim)
- [ ] Manual: `pad init` against a non-local config — success message prints the configured URL