### PR TITLE
feat(cli): explicit cancel + clean SIGINT for pad init prompts (TASK-835)

### DIFF
--- a/cmd/pad/cancel.go
+++ b/cmd/pad/cancel.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+// errCancelled is returned by interactive prompts (template picker, mode
+// picker) when the user explicitly aborts the flow. The init RunEs catch
+// it and exit cleanly via cancelInit().
+var errCancelled = errors.New("cancelled by user")
+
+// cancelInit is the canonical exit path for both Ctrl+C and explicit
+// "Cancel" actions during pad init / pad workspace init. It prints a
+// brief message to stderr and exits with code 130 (the conventional
+// shell exit code for SIGINT).
+//
+// We exit via os.Exit because the SIGINT case fires asynchronously in a
+// goroutine while the main flow is blocked reading stdin — there is no
+// way to gracefully unwind that read. Using the same path for the
+// explicit-cancel case keeps the user-visible behavior identical.
+func cancelInit() {
+	fmt.Fprintln(os.Stderr)
+	fmt.Fprintln(os.Stderr, "Cancelled.")
+	os.Exit(130)
+}
+
+// installInitCancelHandler installs a SIGINT/SIGTERM handler for the
+// duration of an interactive init run. On signal receipt it calls
+// cancelInit().
+//
+// The returned function MUST be deferred — it stops the signal listener
+// and lets the goroutine return when init completes successfully.
+//
+// Why explicit handling is needed: bufio.Reader.ReadString blocks on
+// stdin. Go's default SIGINT behavior terminates the process with no
+// printed message, which can surface oddly in some terminal stacks. A
+// custom handler guarantees a friendly "Cancelled." line before the
+// process exits.
+func installInitCancelHandler() func() {
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+
+	done := make(chan struct{})
+	go func() {
+		select {
+		case <-sigCh:
+			cancelInit()
+		case <-done:
+		}
+	}()
+
+	return func() {
+		close(done)
+		signal.Stop(sigCh)
+	}
+}
+
+// isCancellation reports whether err represents a user-initiated abort
+// from any interactive init prompt. Init RunEs use this to convert the
+// sentinel into the canonical cancelInit() exit instead of letting cobra
+// render an "Error:" line.
+func isCancellation(err error) bool {
+	return errors.Is(err, errCancelled)
+}

--- a/cmd/pad/cancel.go
+++ b/cmd/pad/cancel.go
@@ -30,7 +30,7 @@ func cancelInit() {
 
 // installInitCancelHandler installs a SIGINT/SIGTERM handler for the
 // duration of an interactive init run. On signal receipt it calls
-// cancelInit().
+// cancelInit() — but only if init has not already completed.
 //
 // The returned function MUST be deferred — it stops the signal listener
 // and lets the goroutine return when init completes successfully.
@@ -40,6 +40,11 @@ func cancelInit() {
 // printed message, which can surface oddly in some terminal stacks. A
 // custom handler guarantees a friendly "Cancelled." line before the
 // process exits.
+//
+// Cleanup race: a signal can arrive after init finished but before the
+// goroutine has been told to return. The inner select on done suppresses
+// that — once cleanup() runs, late signals are ignored rather than
+// turning a successful init into a spurious 130 exit.
 func installInitCancelHandler() func() {
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
@@ -48,14 +53,27 @@ func installInitCancelHandler() func() {
 	go func() {
 		select {
 		case <-sigCh:
-			cancelInit()
+			// Re-check whether init completed in the moment between the
+			// signal being delivered and this goroutine being scheduled.
+			// If done is closed, cleanup has already run and the user is
+			// no longer in init — suppress the cancellation.
+			select {
+			case <-done:
+				return
+			default:
+				cancelInit()
+			}
 		case <-done:
 		}
 	}()
 
 	return func() {
-		close(done)
+		// Stop signal delivery first so no new signals enter sigCh while
+		// we close done. Then close done so the goroutine returns
+		// cleanly. Any signal already buffered in sigCh is consumed by
+		// the inner select-on-done check above and discarded.
 		signal.Stop(sigCh)
+		close(done)
 	}
 }
 

--- a/cmd/pad/cancel_test.go
+++ b/cmd/pad/cancel_test.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+// TestIsCancellationRecognizesWrappedSentinel verifies that the helper
+// works on errors that have been wrapped with fmt.Errorf("...: %w", err)
+// — which is what every layer between the prompt and the init RunE does.
+func TestIsCancellationRecognizesWrappedSentinel(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil err is not cancellation", err: nil, want: false},
+		{name: "unrelated err is not cancellation", err: errors.New("network down"), want: false},
+		{name: "raw sentinel is cancellation", err: errCancelled, want: true},
+		{name: "wrapped once", err: fmt.Errorf("configure: %w", errCancelled), want: true},
+		{name: "wrapped twice", err: fmt.Errorf("init: %w", fmt.Errorf("configure: %w", errCancelled)), want: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isCancellation(tc.err); got != tc.want {
+				t.Errorf("isCancellation(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/pad/configure.go
+++ b/cmd/pad/configure.go
@@ -166,7 +166,7 @@ func promptForMode() (string, error) {
 	fmt.Println()
 
 	for {
-		fmt.Print("Select a mode [1-3]: ")
+		fmt.Print("Select a mode [1-3, 'c' to cancel]: ")
 		line, err := reader.ReadString('\n')
 		if err != nil {
 			return "", err
@@ -179,8 +179,10 @@ func promptForMode() (string, error) {
 			return config.ModeRemote, nil
 		case "3", "docker", "Docker":
 			return config.ModeDocker, nil
+		case "c", "C", "q", "Q", "cancel", "Cancel", "quit", "Quit":
+			return "", errCancelled
 		default:
-			fmt.Println("Enter 1, 2, or 3.")
+			fmt.Println("Enter 1, 2, 3, or 'c' to cancel.")
 		}
 	}
 }

--- a/cmd/pad/configure.go
+++ b/cmd/pad/configure.go
@@ -33,7 +33,16 @@ Modes:
   docker  This client connects to a Docker-managed Pad server, usually at localhost.
 
 Pad Cloud mode is reserved for a future release and is not yet available.`,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) (retErr error) {
+			// Mirror pad init: an explicit cancel keyword from a prompt
+			// surfaces as errCancelled. Convert to the canonical exit so
+			// it doesn't render as a generic cobra error.
+			defer func() {
+				if isCancellation(retErr) {
+					cancelInit()
+				}
+			}()
+
 			cfg := getConfig()
 			if err := runConfigureFlow(cfg, values); err != nil {
 				return err

--- a/cmd/pad/configure.go
+++ b/cmd/pad/configure.go
@@ -71,6 +71,12 @@ func getConfiguredConfig() *config.Config {
 	fmt.Println("Let's configure how this client connects to Pad.")
 	fmt.Println()
 	if err := runConfigureFlow(cfg, configureValues{}); err != nil {
+		// User-initiated cancellation routes through the canonical
+		// "Cancelled." + 130 exit even when triggered from this
+		// non-init entry point.
+		if isCancellation(err) {
+			cancelInit()
+		}
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
@@ -191,9 +197,9 @@ func promptForValue(label, defaultValue string) (string, error) {
 	reader := bufio.NewReader(os.Stdin)
 
 	if defaultValue != "" {
-		fmt.Printf("%s [%s]: ", label, defaultValue)
+		fmt.Printf("%s [%s, 'c' to cancel]: ", label, defaultValue)
 	} else {
-		fmt.Printf("%s: ", label)
+		fmt.Printf("%s ['c' to cancel]: ", label)
 	}
 
 	line, err := reader.ReadString('\n')
@@ -202,6 +208,15 @@ func promptForValue(label, defaultValue string) (string, error) {
 	}
 
 	value := strings.TrimSpace(line)
+	switch strings.ToLower(value) {
+	case "c", "q", "cancel", "quit":
+		// Recognized cancel keyword — let the caller convert to the
+		// canonical 'pad init' exit. Important: when a defaultValue
+		// is in scope (e.g. docker mode's localhost suggestion),
+		// pressing enter still selects the default; only an explicit
+		// keyword cancels.
+		return "", errCancelled
+	}
 	if value == "" {
 		value = defaultValue
 	}

--- a/cmd/pad/init.go
+++ b/cmd/pad/init.go
@@ -41,8 +41,24 @@ Examples:
   pad init                    # Auto-detect everything, use directory name
   pad init myproject          # Specify workspace name
   pad init --template scrum   # Use scrum template for new workspace`,
-		Args: cobra.MaximumNArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		Args:          cobra.MaximumNArgs(1),
+		SilenceErrors: true,
+		SilenceUsage:  true,
+		RunE: func(cmd *cobra.Command, args []string) (retErr error) {
+			// Install the SIGINT/SIGTERM handler first so the user can
+			// abort cleanly at any interactive prompt. Defers run in LIFO
+			// order: the cancellation check fires before the cleanup
+			// removes the signal listener, so a sentinel error propagated
+			// from a prompt is converted into the canonical exit before
+			// returning to cobra.
+			cleanup := installInitCancelHandler()
+			defer cleanup()
+			defer func() {
+				if isCancellation(retErr) {
+					cancelInit()
+				}
+			}()
+
 			// Validate template name up front before any state changes
 			if templateFlag != "" {
 				tmpl := collections.GetTemplate(templateFlag)

--- a/cmd/pad/init.go
+++ b/cmd/pad/init.go
@@ -41,9 +41,7 @@ Examples:
   pad init                    # Auto-detect everything, use directory name
   pad init myproject          # Specify workspace name
   pad init --template scrum   # Use scrum template for new workspace`,
-		Args:          cobra.MaximumNArgs(1),
-		SilenceErrors: true,
-		SilenceUsage:  true,
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) (retErr error) {
 			// Install the SIGINT/SIGTERM handler first so the user can
 			// abort cleanly at any interactive prompt. Defers run in LIFO

--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -1069,8 +1069,23 @@ Use --list-templates to see available templates.
 
 Tip: 'pad init' handles everything — configure, authenticate, and create
 a workspace in one step.`,
-		Args: cobra.MaximumNArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		Args:          cobra.MaximumNArgs(1),
+		SilenceErrors: true,
+		SilenceUsage:  true,
+		RunE: func(cmd *cobra.Command, args []string) (retErr error) {
+			// Same SIGINT/SIGTERM handling as 'pad init'. Installed BEFORE
+			// any interactive prompt so the user can abort cleanly. The
+			// LIFO defer order ensures the cancellation check converts
+			// errCancelled into the canonical exit before cleanup
+			// detaches the signal listener.
+			cleanup := installInitCancelHandler()
+			defer cleanup()
+			defer func() {
+				if isCancellation(retErr) {
+					cancelInit()
+				}
+			}()
+
 			// Handle --list-templates
 			if listTemplates {
 				fmt.Println("Available templates:")

--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -576,7 +576,18 @@ func loginCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "login",
 		Short: "Log in to Pad",
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) (retErr error) {
+			// doBrowserLogin returns errCancelled when its inner SIGINT
+			// listener fires. Outside of pad init this command is the
+			// final exit path, so route the sentinel through the
+			// canonical "Cancelled." + 130 exit instead of letting it
+			// surface as a generic cobra error.
+			defer func() {
+				if isCancellation(retErr) {
+					cancelInit()
+				}
+			}()
+
 			cfg := getConfiguredConfig()
 			if err := cli.EnsureServer(cfg); err != nil {
 				return err

--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -651,7 +651,15 @@ func doBrowserLogin(client *cli.Client, cfg *config.Config) error {
 		select {
 		case <-ctx.Done():
 			fmt.Println("\n  Login cancelled.")
-			return fmt.Errorf("login cancelled")
+			// Return the canonical cancellation sentinel so callers
+			// (e.g. pad init's RunE) treat this exactly like an abort
+			// at any other interactive prompt — same "Cancelled." +
+			// exit-130 path. This matters most when both this
+			// goroutine and the outer init signal handler race on
+			// the same SIGINT; whichever wins, the exit code stays
+			// 130 instead of falling back to cobra's generic error
+			// path.
+			return errCancelled
 		case <-ticker.C:
 			status, err := client.PollCLIAuthSession(sess.SessionCode)
 			if err != nil {
@@ -1069,9 +1077,7 @@ Use --list-templates to see available templates.
 
 Tip: 'pad init' handles everything — configure, authenticate, and create
 a workspace in one step.`,
-		Args:          cobra.MaximumNArgs(1),
-		SilenceErrors: true,
-		SilenceUsage:  true,
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) (retErr error) {
 			// Same SIGINT/SIGTERM handling as 'pad init'. Installed BEFORE
 			// any interactive prompt so the user can abort cleanly. The

--- a/cmd/pad/templates_picker.go
+++ b/cmd/pad/templates_picker.go
@@ -129,7 +129,7 @@ func pickTemplateInteractive(in io.Reader, out io.Writer) (string, error) {
 	reader := bufio.NewReader(in)
 	for {
 		fmt.Fprintln(out)
-		fmt.Fprintf(out, "Select a template [%d] (press enter for default): ", defaultIdx)
+		fmt.Fprintf(out, "Select a template [%d] (press enter for default, 'c' to cancel): ", defaultIdx)
 		line, err := reader.ReadString('\n')
 		if err != nil {
 			// EOF is a benign signal (pipe closed, stdin exhausted in a
@@ -145,13 +145,19 @@ func pickTemplateInteractive(in io.Reader, out io.Writer) (string, error) {
 		if line == "" {
 			return defaultTemplateName, nil
 		}
+		// Explicit cancel — equivalent to Ctrl+C. Returning errCancelled
+		// lets the caller treat this exactly like a SIGINT abort.
+		switch strings.ToLower(line) {
+		case "c", "q", "cancel", "quit":
+			return "", errCancelled
+		}
 		// Allow typing a name directly as an escape hatch.
 		if tmpl := collections.GetTemplate(line); tmpl != nil && !tmpl.Hidden {
 			return tmpl.Name, nil
 		}
 		n, err := strconv.Atoi(line)
 		if err != nil || n < 1 || n > len(flat) {
-			fmt.Fprintf(out, "Invalid choice %q. Enter a number between 1 and %d, or a template name.\n", line, len(flat))
+			fmt.Fprintf(out, "Invalid choice %q. Enter a number between 1 and %d, a template name, or 'c' to cancel.\n", line, len(flat))
 			continue
 		}
 		return flat[n-1].tmpl.Name, nil

--- a/cmd/pad/templates_picker_test.go
+++ b/cmd/pad/templates_picker_test.go
@@ -89,6 +89,40 @@ func TestPickTemplateInteractiveSurfacesNonEOFReadErrors(t *testing.T) {
 	}
 }
 
+// TestPickTemplateInteractiveCancelKeywords verifies that typing any of
+// the recognized cancel keywords (c, q, cancel, quit — case-insensitive)
+// returns the canonical errCancelled sentinel rather than silently
+// defaulting or treating the input as an invalid choice. The init RunE
+// translates this sentinel into the same exit path as a Ctrl+C abort.
+func TestPickTemplateInteractiveCancelKeywords(t *testing.T) {
+	cases := []string{"c\n", "C\n", "q\n", "Q\n", "cancel\n", "Cancel\n", "CANCEL\n", "quit\n", "Quit\n"}
+	for _, input := range cases {
+		t.Run(strings.TrimSpace(input), func(t *testing.T) {
+			var out bytes.Buffer
+			picked, err := pickTemplateInteractive(strings.NewReader(input), &out)
+			if !errors.Is(err, errCancelled) {
+				t.Fatalf("pickTemplateInteractive(%q) err = %v, want errCancelled", input, err)
+			}
+			if picked != "" {
+				t.Errorf("pickTemplateInteractive(%q) picked = %q, want empty on cancel", input, picked)
+			}
+			if strings.Contains(out.String(), "Invalid choice") {
+				t.Errorf("expected cancel keyword %q to skip the 'Invalid choice' branch:\n%s", input, out.String())
+			}
+		})
+	}
+}
+
+// TestPickTemplateInteractivePromptMentionsCancel verifies the prompt
+// surfaces the cancel option so users discover it without reading docs.
+func TestPickTemplateInteractivePromptMentionsCancel(t *testing.T) {
+	var out bytes.Buffer
+	_, _ = pickTemplateInteractive(strings.NewReader("\n"), &out)
+	if !strings.Contains(out.String(), "cancel") {
+		t.Errorf("expected picker prompt to mention 'cancel', got:\n%s", out.String())
+	}
+}
+
 // TestPrintGroupedTemplatesIncludesEveryVisibleTemplate is a smoke test
 // that the grouped printer covers each visible template's name.
 func TestPrintGroupedTemplatesIncludesEveryVisibleTemplate(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds an explicit cancel option to the interactive prompts in \`pad init\` / \`pad workspace init\` (template picker, mode picker, URL prompt) and a SIGINT/SIGTERM handler installed at init entry so Ctrl+C aborts cleanly with a "Cancelled." message and exit code 130.

Real-world hit this fixes: *"oh wait, I'm in the wrong directory / wrong account / I want to back out"* mid-init. Previously Ctrl+C terminated with no message and offered no in-prompt way to back out.

## What changes

- **New file \`cmd/pad/cancel.go\`** — \`errCancelled\` sentinel, \`cancelInit()\` (canonical "Cancelled." + os.Exit(130)), \`installInitCancelHandler()\`, \`isCancellation()\`. The handler uses an inner select-on-done check inside the sigCh case to suppress signals that arrive after init has finished cleaning up.
- **\`cmd/pad/templates_picker.go\`** — picker accepts \`c\` / \`q\` / \`cancel\` / \`quit\` (case-insensitive), prompt text now mentions the cancel option.
- **\`cmd/pad/configure.go\`** — same cancel keywords on the mode picker; \`promptForValue\` (URL prompt) recognizes them too. \`getConfiguredConfig\` routes \`errCancelled\` through \`cancelInit()\` before its generic Error path. \`configureCmd\` has the same deferred conversion so \`pad auth configure\` exits cleanly when cancelled.
- **\`cmd/pad/main.go\`** — \`workspaceInitCmd\` and \`loginCmd\` get the same deferred cancellation check. \`doBrowserLogin\` now returns \`errCancelled\` on signal cancellation so the SIGINT race between its inner listener and any outer init handler still converges on exit code 130.
- **\`cmd/pad/init.go\`** — installs the signal handler at the top of RunE; named-return + LIFO defer routes \`errCancelled\` through \`cancelInit()\`.

## Why state really is clean on cancel at the picker

The template picker is invoked **after** step 1 (configure) but **before** the workspace is created on the server and **before** \`.pad.toml\` is written (\`ensureWorkspace\` in \`init.go\`). An abort there leaves no half-created workspace, no orphan \`.pad.toml\`, and no stale credentials.

## Context

Implements **TASK-835** under **PLAN-833** (decomposition of **IDEA-831** — pad init UX gaps from the first end-to-end Pad Cloud auth test).

## Codex review

3 rounds, ending CLEAN:
1. Found 2 HIGH (\`getConfiguredConfig\` bypass, over-broad \`SilenceErrors\`), 3 MEDIUM (\`doBrowserLogin\` sentinel mismatch, cleanup race, missed URL prompt), 1 LOW (account prompts — intentionally not addressed).
2. Confirmed round-1 fixes; flagged 1 MEDIUM (\`configureCmd\` sentinel leak) + 1 LOW (\`loginCmd\` sentinel leak).
3. **CLEAN.**

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test ./...\` all pass
- [x] \`cd web && npm run build\` clean
- [x] New tests:
  - \`TestPickTemplateInteractiveCancelKeywords\` — every recognized variant
  - \`TestPickTemplateInteractivePromptMentionsCancel\` — discoverability
  - \`TestIsCancellationRecognizesWrappedSentinel\` — covers \`fmt.Errorf(...: %w, errCancelled)\` chains
- [ ] Manual: Ctrl+C at template picker → "Cancelled." + 130; type \`c\` at mode picker / URL prompt / template picker → same exit