### PR TITLE
feat(web): signed-in account chip on CLI auth approval + switch-accounts (TASK-836)

### DIFF
--- a/web/src/routes/auth/cli/[code]/+page.svelte
+++ b/web/src/routes/auth/cli/[code]/+page.svelte
@@ -3,10 +3,13 @@
 	import { page } from '$app/stores';
 	import { goto } from '$app/navigation';
 	import { api } from '$lib/api/client';
+	import type { User } from '$lib/types';
 
 	let status = $state<'loading' | 'pending' | 'approved' | 'expired' | 'error' | 'success' | 'already_approved'>('loading');
 	let error = $state('');
 	let approving = $state(false);
+	let switchingAccount = $state(false);
+	let currentUser = $state<User | null>(null);
 
 	onMount(async () => {
 		const code = $page.params.code;
@@ -34,6 +37,15 @@
 			if (!authSession.authenticated) {
 				goto(`/login?redirect=/auth/cli/${code}`, { replaceState: true });
 				return;
+			}
+
+			// Best-effort load of the current user so we can show which account
+			// the CLI session is about to be linked to. If this fails, the chip
+			// just won't render but the Approve flow still works.
+			try {
+				currentUser = await api.auth.me();
+			} catch {
+				currentUser = null;
 			}
 
 			status = 'pending';
@@ -65,6 +77,17 @@
 			approving = false;
 		}
 	}
+
+	async function handleSwitchAccount() {
+		const code = $page.params.code;
+		switchingAccount = true;
+		try {
+			await api.auth.logout();
+		} catch {
+			// Drop the session client-side regardless of server response.
+		}
+		goto(`/login?redirect=/auth/cli/${code}`, { replaceState: true });
+	}
 </script>
 
 <div class="login-page">
@@ -89,11 +112,41 @@
 				A CLI session is requesting access to your account. Approve this request to sign in from the terminal.
 			</p>
 
+			{#if currentUser}
+				<div class="account-chip">
+					{#if currentUser.avatar_url}
+						<img
+							class="avatar"
+							src={currentUser.avatar_url}
+							alt=""
+							width="32"
+							height="32"
+						/>
+					{/if}
+					<div class="account-info">
+						<div class="account-name">{currentUser.name || currentUser.username}</div>
+						<div class="account-email">{currentUser.email}</div>
+					</div>
+				</div>
+				<button
+					type="button"
+					class="link-button"
+					onclick={handleSwitchAccount}
+					disabled={switchingAccount || approving}
+				>
+					{#if switchingAccount}
+						Switching...
+					{:else}
+						I'm not {currentUser.name || currentUser.username} — switch accounts
+					{/if}
+				</button>
+			{/if}
+
 			{#if error}
 				<p class="error">{error}</p>
 			{/if}
 
-			<button onclick={handleApprove} disabled={approving}>
+			<button onclick={handleApprove} disabled={approving || switchingAccount}>
 				{#if approving}
 					Approving...
 				{:else}
@@ -187,6 +240,80 @@
 	}
 
 	button:disabled {
+		opacity: 0.6;
+		cursor: not-allowed;
+	}
+
+	.account-chip {
+		display: flex;
+		align-items: center;
+		gap: var(--space-3);
+		width: 100%;
+		padding: var(--space-3);
+		background: var(--bg-primary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+		margin-bottom: var(--space-3);
+		text-align: left;
+	}
+
+	.avatar {
+		width: 32px;
+		height: 32px;
+		border-radius: 50%;
+		object-fit: cover;
+		flex-shrink: 0;
+	}
+
+	.account-info {
+		display: flex;
+		flex-direction: column;
+		min-width: 0;
+		flex: 1;
+	}
+
+	.account-name {
+		color: var(--text-primary);
+		font-size: 0.9rem;
+		font-weight: 500;
+		line-height: 1.3;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.account-email {
+		color: var(--text-muted);
+		font-size: 0.8rem;
+		line-height: 1.3;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	button.link-button {
+		width: 100%;
+		padding: 0;
+		background: none;
+		color: var(--text-muted);
+		border: none;
+		border-radius: 0;
+		font-size: 0.8rem;
+		font-weight: 400;
+		font-family: var(--font-ui);
+		text-align: center;
+		cursor: pointer;
+		margin-bottom: var(--space-5);
+		transition: color 0.15s;
+	}
+
+	button.link-button:hover:not(:disabled) {
+		color: var(--text-primary);
+		opacity: 1;
+		text-decoration: underline;
+	}
+
+	button.link-button:disabled {
 		opacity: 0.6;
 		cursor: not-allowed;
 	}

--- a/web/src/routes/auth/cli/[code]/+page.svelte
+++ b/web/src/routes/auth/cli/[code]/+page.svelte
@@ -80,11 +80,26 @@
 
 	async function handleSwitchAccount() {
 		const code = $page.params.code;
+		if (!code) {
+			error = 'Missing CLI session code.';
+			return;
+		}
 		switchingAccount = true;
+		error = '';
 		try {
 			await api.auth.logout();
-		} catch {
-			// Drop the session client-side regardless of server response.
+		} catch (err: unknown) {
+			// Surface the failure rather than swallowing it: if the server
+			// did not invalidate the session cookie, navigating to /login
+			// would bounce straight back here authenticated and "switch
+			// accounts" would appear to be a no-op. Showing the error
+			// gives the user a clear next step (retry / close the tab).
+			switchingAccount = false;
+			error =
+				err instanceof Error && err.message
+					? `Couldn't sign you out: ${err.message}`
+					: "Couldn't sign you out. Please try again or close this tab.";
+			return;
 		}
 		goto(`/login?redirect=/auth/cli/${code}`, { replaceState: true });
 	}

--- a/web/src/routes/login/+page.svelte
+++ b/web/src/routes/login/+page.svelte
@@ -32,8 +32,17 @@
 
 	function getRedirectTarget(): string {
 		const redirect = $page.url.searchParams.get('redirect');
-		// Only allow relative redirects (prevent open redirect)
-		if (redirect && redirect.startsWith('/')) {
+		// Only allow relative redirects (prevent open redirect). A bare
+		// `startsWith('/')` is NOT enough: protocol-relative URLs like
+		// `//evil.example` and `/\evil.example` pass that check but are
+		// treated by browsers (and most server-side redirect handlers) as
+		// cross-origin destinations. Reject those explicitly.
+		if (
+			redirect &&
+			redirect.startsWith('/') &&
+			!redirect.startsWith('//') &&
+			!redirect.startsWith('/\\')
+		) {
 			return redirect;
 		}
 		return '/console';
@@ -43,6 +52,16 @@
 		const target = getRedirectTarget();
 		if (target === '/console') return '';
 		return `?redirect=${encodeURIComponent(target)}`;
+	});
+
+	// Same target appended with `&` so it composes with `?force=1` on
+	// the "Use a different <provider> account" banner buttons. Empty
+	// when redirect is the default destination so we don't append a
+	// redundant `&redirect=%2Fconsole`.
+	const oauthRedirectAmpQuery = $derived.by(() => {
+		const target = getRedirectTarget();
+		if (target === '/console') return '';
+		return `&redirect=${encodeURIComponent(target)}`;
 	});
 
 	// Map pad-cloud's /login?error=... redirect codes to a friendly banner
@@ -240,7 +259,7 @@
 					<div class="oauth-banner-actions">
 						{#if oauthBanner.provider === 'github' || oauthBanner.provider === null}
 							<a
-								href="/auth/github?force=1"
+								href="/auth/github?force=1{oauthRedirectAmpQuery}"
 								data-sveltekit-reload
 								class="oauth-banner-btn"
 							>
@@ -249,7 +268,7 @@
 						{/if}
 						{#if oauthBanner.provider === 'google' || oauthBanner.provider === null}
 							<a
-								href="/auth/google?force=1"
+								href="/auth/google?force=1{oauthRedirectAmpQuery}"
 								data-sveltekit-reload
 								class="oauth-banner-btn"
 							>

--- a/web/src/routes/login/+page.svelte
+++ b/web/src/routes/login/+page.svelte
@@ -39,6 +39,12 @@
 		return '/console';
 	}
 
+	const oauthRedirectQuery = $derived.by(() => {
+		const target = getRedirectTarget();
+		if (target === '/console') return '';
+		return `?redirect=${encodeURIComponent(target)}`;
+	});
+
 	// Map pad-cloud's /login?error=... redirect codes to a friendly banner
 	// plus optional CTAs. Kept near onMount so the full list of codes the
 	// frontend handles is easy to audit against pad-cloud/oauth.go.
@@ -335,11 +341,11 @@
 				</div>
 
 				<div class="oauth-buttons">
-					<a href="/auth/github" data-sveltekit-reload class="oauth-btn oauth-github">
+					<a href="/auth/github{oauthRedirectQuery}" data-sveltekit-reload class="oauth-btn oauth-github">
 						<svg width="18" height="18" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
 						Continue with GitHub
 					</a>
-					<a href="/auth/google" data-sveltekit-reload class="oauth-btn oauth-google">
+					<a href="/auth/google{oauthRedirectQuery}" data-sveltekit-reload class="oauth-btn oauth-google">
 						<svg width="18" height="18" viewBox="0 0 18 18" fill="none"><path d="M17.64 9.2c0-.637-.057-1.251-.164-1.84H9v3.481h4.844a4.14 4.14 0 01-1.796 2.716v2.259h2.908c1.702-1.567 2.684-3.875 2.684-6.615z" fill="#4285F4"/><path d="M9 18c2.43 0 4.467-.806 5.956-2.18l-2.908-2.259c-.806.54-1.837.86-3.048.86-2.344 0-4.328-1.584-5.036-3.711H.957v2.332A8.997 8.997 0 009 18z" fill="#34A853"/><path d="M3.964 10.71A5.41 5.41 0 013.682 9c0-.593.102-1.17.282-1.71V4.958H.957A8.996 8.996 0 000 9c0 1.452.348 2.827.957 4.042l3.007-2.332z" fill="#FBBC05"/><path d="M9 3.58c1.321 0 2.508.454 3.44 1.345l2.582-2.58C13.463.891 11.426 0 9 0A8.997 8.997 0 00.957 4.958L3.964 7.29C4.672 5.163 6.656 3.58 9 3.58z" fill="#EA4335"/></svg>
 						Continue with Google
 					</a>


### PR DESCRIPTION
## Summary

The CLI auth approval page (\`/auth/cli/{code}\`) previously showed only an "Approve" button with no indication of WHICH account was about to grant the CLI access. For OAuth users on Pad Cloud — most of whom have multiple GitHub/Google accounts — wrong-account approval was a silent footgun.

This PR adds:

1. **Account chip** above the Approve button when the session is pending — shows avatar, display name (with username fallback), and email. Best-effort \`api.auth.me()\` call; if it fails the chip just doesn't render and Approve still works.
2. **"I'm not <Name> — switch accounts" link button** below the chip that calls \`api.auth.logout()\` and routes to \`/login?redirect=/auth/cli/{code}\`. Logout failures are surfaced (no silent bouncing-back-while-still-authenticated).
3. **Redirect plumbing through OAuth** on the login page so post-login users land back on the CLI approval page even when signing in via GitHub/Google. Both the primary OAuth buttons and the "Use a different account" banner buttons preserve the redirect target via two derived query helpers.
4. **Tightened \`getRedirectTarget()\`** to reject protocol-relative URLs (\`//host\`, \`/\\\\host\`) — closes a pre-existing open-redirect path that the OAuth change would have widened.

## Context

Implements **TASK-836** under **PLAN-833** (decomposition of **IDEA-831** — pad init UX gaps from the first end-to-end Pad Cloud auth test).

## Codex review

3 rounds, ending CLEAN:
1. Found 1 MEDIUM (OAuth links lost the redirect) + 1 LOW (silent logout failure produced bouncing-loop UX). Both fixed.
2. Found 1 MEDIUM (\`getRedirectTarget\` accepted \`//\` protocol-relative as relative — open-redirect surface widened by the OAuth fix) + 1 LOW (banner "Use a different account" buttons missed the redirect). Both fixed.
3. **CLEAN.**

## Test plan

- [x] \`cd web && npm run build\` clean
- [x] \`npm run check\` 0 errors (pre-existing warnings unrelated)
- [x] \`go test ./...\` all pass (no Go changes — sanity check)
- [ ] Manual: sign in to a workspace, run \`pad auth login\`, click the CLI link, see account chip with name + email above Approve
- [ ] Manual: click "switch accounts" → bounces to /login → sign in as different account → land back on \`/auth/cli/{code}\` for the same code
- [ ] Manual: same path via OAuth (GitHub) on Cloud — redirect preserved through the OAuth roundtrip

## Files

- \`web/src/routes/auth/cli/[code]/+page.svelte\` — chip + switch-accounts UI + best-effort fetch + error surfacing
- \`web/src/routes/login/+page.svelte\` — \`oauthRedirectQuery\` / \`oauthRedirectAmpQuery\` derived helpers, tightened \`getRedirectTarget\`, OAuth and banner anchors updated