### PR TITLE
feat(cli): add Cloud mode to pad init, drop Docker option (TASK-837, TASK-838)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -92,9 +92,9 @@ PAD_ENCRYPTION_KEY=
 # Log level: debug | info | warn | error
 # PAD_LOG_LEVEL=info
 
-# Operating mode: local | remote | docker | cloud. Controls how the CLI
+# Operating mode: local | remote | cloud. Controls how the CLI
 # discovers the daemon and which credential keying rules apply.
-# PAD_MODE=docker
+# PAD_MODE=local
 
 # ─────────────────────────────────────────────────────────────────────
 # Database — SQLite default; set PAD_DB_DRIVER=postgres for Postgres.

--- a/cmd/pad/configure.go
+++ b/cmd/pad/configure.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 	"github.com/xarmian/pad/internal/config"
 	"golang.org/x/term"
@@ -28,11 +29,10 @@ func configureCmd() *cobra.Command {
 		Long: `Configure how this Pad client connects to a server.
 
 Modes:
-  local   This client manages a local Pad server.
-  remote  This client connects to another Pad server by base URL.
-  docker  This client connects to a Docker-managed Pad server, usually at localhost.
-
-Pad Cloud mode is reserved for a future release and is not yet available.`,
+  cloud   This client connects to your Pad Cloud account at ` + config.CloudBaseURL + `.
+          Managed, OAuth sign-in, no setup. Recommended.
+  local   This client manages a local Pad server on this machine.
+  remote  This client connects to your own self-hosted Pad server by base URL.`,
 		RunE: func(cmd *cobra.Command, args []string) (retErr error) {
 			// Mirror pad init: an explicit cancel keyword from a prompt
 			// surfaces as errCancelled. Convert to the canonical exit so
@@ -57,8 +57,8 @@ Pad Cloud mode is reserved for a future release and is not yet available.`,
 		},
 	}
 
-	cmd.Flags().StringVar(&values.Mode, "mode", "", "connection mode: local, remote, docker")
-	cmd.Flags().StringVar(&values.URL, "url", "", "server base URL for remote or docker mode")
+	cmd.Flags().StringVar(&values.Mode, "mode", "", "connection mode: cloud, local, remote")
+	cmd.Flags().StringVar(&values.URL, "url", "", "server base URL for remote mode")
 	cmd.Flags().StringVar(&values.Host, "host", "", "local server host override for local mode")
 	cmd.Flags().IntVar(&values.Port, "port", 0, "local server port override for local mode")
 
@@ -141,17 +141,12 @@ func applyConfigureValues(cfg *config.Config, values *configureValues) error {
 			cfg.Port = 7777
 		}
 		return nil
-	case config.ModeRemote, config.ModeDocker:
+	case config.ModeRemote:
 		if values.URL == "" {
 			if !canPromptForConfig() {
 				return fmt.Errorf("--url is required for %s mode", mode)
 			}
-			prompt := "Server URL"
-			defaultURL := "http://127.0.0.1:7777"
-			if mode == config.ModeRemote {
-				defaultURL = ""
-			}
-			url, err := promptForValue(prompt, defaultURL)
+			url, err := promptForValue("Server URL", "")
 			if err != nil {
 				return err
 			}
@@ -161,45 +156,144 @@ func applyConfigureValues(cfg *config.Config, values *configureValues) error {
 		if err != nil {
 			return err
 		}
-		cfg.Mode = mode
+		cfg.Mode = config.ModeRemote
 		cfg.URL = normalizedURL
 		return nil
 	case config.ModeCloud:
-		return fmt.Errorf("Pad Cloud is not available yet")
+		// Cloud is a labeled-Remote at runtime: same flow, hardcoded URL.
+		// The CLI doesn't need to know about OAuth-vs-password — that
+		// distinction lives entirely on the web side at /auth/cli/{code}.
+		// Ignore any --url passed in; Cloud is anchored to the canonical
+		// public endpoint.
+		cfg.Mode = config.ModeCloud
+		cfg.URL = config.CloudBaseURL
+		return nil
 	default:
 		return fmt.Errorf("invalid mode %q", values.Mode)
 	}
 }
 
-func promptForMode() (string, error) {
-	reader := bufio.NewReader(os.Stdin)
+// modeOption describes one row in the connection-mode picker. Order in
+// promptForMode dictates display order — Cloud is intentionally first as
+// the recommended path for new users.
+type modeOption struct {
+	key         string   // canonical config.Mode* value
+	icon        string   // emoji shown next to the label
+	label       string   // short human label ("Cloud", "Local", "Remote")
+	tagline     string   // primary one-line description
+	subline     string   // optional second descriptive line ("" to omit)
+	recommended bool     // adds a "(recommended)" marker after the label
+	aliases     []string // case-insensitive accepted typed inputs (besides the row number)
+}
 
-	fmt.Println("How should this client connect to Pad?")
-	fmt.Println("  1. Local")
-	fmt.Println("  2. Remote")
-	fmt.Println("  3. Docker")
+func promptForMode() (string, error) {
+	bold := color.New(color.Bold)
+	dim := color.New(color.Faint)
+	cyan := color.New(color.FgCyan)
+
+	options := []modeOption{
+		{
+			key:         config.ModeCloud,
+			icon:        "☁️ ",
+			label:       "Cloud",
+			tagline:     "Connect to your Pad Cloud account at " + config.CloudBaseURL,
+			subline:     "Managed, OAuth sign-in, no setup",
+			recommended: true,
+			aliases:     []string{"cloud"},
+		},
+		{
+			key:     config.ModeLocal,
+			icon:    "💻",
+			label:   "Local",
+			tagline: "Run a Pad server on this machine (data stays on your computer)",
+			aliases: []string{"local"},
+		},
+		{
+			key:     config.ModeRemote,
+			icon:    "🌐",
+			label:   "Remote",
+			tagline: "Connect to your own self-hosted Pad server by URL",
+			aliases: []string{"remote"},
+		},
+	}
+
+	fmt.Println()
+	fmt.Println(bold.Sprint("How should this client connect to Pad?"))
+	fmt.Println()
+	for i, opt := range options {
+		marker := ""
+		if opt.recommended {
+			marker = " " + cyan.Sprint("(recommended)")
+		}
+		fmt.Printf("  %d. %s  %s%s\n", i+1, opt.icon, bold.Sprint(opt.label), marker)
+		fmt.Printf("        %s\n", opt.tagline)
+		if opt.subline != "" {
+			fmt.Printf("        %s\n", dim.Sprint(opt.subline))
+		}
+	}
 	fmt.Println()
 
+	reader := bufio.NewReader(os.Stdin)
 	for {
-		fmt.Print("Select a mode [1-3, 'c' to cancel]: ")
+		fmt.Printf("Select a mode [1-%d, 'c' to cancel]: ", len(options))
 		line, err := reader.ReadString('\n')
 		if err != nil {
 			return "", err
 		}
+		input := strings.ToLower(strings.TrimSpace(line))
 
-		switch strings.TrimSpace(line) {
-		case "1", "local", "Local":
-			return config.ModeLocal, nil
-		case "2", "remote", "Remote":
-			return config.ModeRemote, nil
-		case "3", "docker", "Docker":
-			return config.ModeDocker, nil
-		case "c", "C", "q", "Q", "cancel", "Cancel", "quit", "Quit":
+		switch input {
+		case "c", "q", "cancel", "quit":
 			return "", errCancelled
-		default:
-			fmt.Println("Enter 1, 2, 3, or 'c' to cancel.")
+		}
+
+		// Numeric selection (1-based to match the displayed indexes).
+		if n := atoiSafe(input); n >= 1 && n <= len(options) {
+			return options[n-1].key, nil
+		}
+
+		// Alias selection — accept "cloud", "local", "remote" as typed input.
+		if matched := matchModeAlias(options, input); matched != "" {
+			return matched, nil
+		}
+
+		fmt.Printf("Invalid choice %q. Enter a number between 1 and %d, a mode name, or 'c' to cancel.\n", input, len(options))
+	}
+}
+
+// atoiSafe returns the decimal value of s, or 0 if s is not a positive
+// decimal integer. Used by promptForMode where 0 (no match) is always an
+// invalid mode selection so we don't need to distinguish "not a number"
+// from "zero".
+func atoiSafe(s string) int {
+	if s == "" {
+		return 0
+	}
+	n := 0
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return 0
+		}
+		n = n*10 + int(r-'0')
+		if n > 1_000_000 {
+			return 0
 		}
 	}
+	return n
+}
+
+func matchModeAlias(options []modeOption, input string) string {
+	if input == "" {
+		return ""
+	}
+	for _, opt := range options {
+		for _, a := range opt.aliases {
+			if a == input {
+				return opt.key
+			}
+		}
+	}
+	return ""
 }
 
 func promptForValue(label, defaultValue string) (string, error) {
@@ -221,9 +315,8 @@ func promptForValue(label, defaultValue string) (string, error) {
 	case "c", "q", "cancel", "quit":
 		// Recognized cancel keyword — let the caller convert to the
 		// canonical 'pad init' exit. Important: when a defaultValue
-		// is in scope (e.g. docker mode's localhost suggestion),
-		// pressing enter still selects the default; only an explicit
-		// keyword cancels.
+		// is in scope, pressing enter still selects the default;
+		// only an explicit keyword cancels.
 		return "", errCancelled
 	}
 	if value == "" {

--- a/cmd/pad/configure_test.go
+++ b/cmd/pad/configure_test.go
@@ -47,15 +47,83 @@ func TestApplyConfigureValuesRemote(t *testing.T) {
 	}
 }
 
-func TestApplyConfigureValuesCloudUnavailable(t *testing.T) {
+func TestApplyConfigureValuesCloud(t *testing.T) {
 	cfg := config.DefaultConfig()
 
+	// Cloud mode should ignore any incoming --url and pin to the canonical
+	// public endpoint. Picking Cloud is, by definition, opting into our
+	// managed deployment.
 	err := applyConfigureValues(cfg, &configureValues{
 		Mode: config.ModeCloud,
-		URL:  "https://cloud.getpad.dev",
+		URL:  "https://someone-tried-to-override.example.com",
+	})
+	if err != nil {
+		t.Fatalf("apply cloud configure values: %v", err)
+	}
+	if cfg.Mode != config.ModeCloud {
+		t.Fatalf("expected cloud mode, got %q", cfg.Mode)
+	}
+	if cfg.URL != config.CloudBaseURL {
+		t.Fatalf("expected cloud URL to be %q, got %q", config.CloudBaseURL, cfg.URL)
+	}
+}
+
+func TestApplyConfigureValuesRejectsDocker(t *testing.T) {
+	cfg := config.DefaultConfig()
+
+	// Docker mode was removed. Pre-launch — no back-compat. Any value
+	// other than "", local, remote, cloud must be rejected by ValidMode.
+	err := applyConfigureValues(cfg, &configureValues{
+		Mode: "docker",
+		URL:  "http://127.0.0.1:7777",
 	})
 	if err == nil {
-		t.Fatal("expected cloud mode to be unavailable")
+		t.Fatal("expected docker mode to be rejected after removal")
+	}
+}
+
+func TestPromptForModeAtoiSafe(t *testing.T) {
+	cases := []struct {
+		in   string
+		want int
+	}{
+		{"", 0},
+		{"1", 1},
+		{"3", 3},
+		{"42", 42},
+		{"-1", 0},          // leading minus is not a digit, rejected
+		{"1.5", 0},         // dot is not a digit, rejected
+		{"abc", 0},         // non-numeric input, rejected
+		{"100000000", 0},   // overflow guard rejects very large numbers
+	}
+	for _, tc := range cases {
+		if got := atoiSafe(tc.in); got != tc.want {
+			t.Fatalf("atoiSafe(%q) = %d, want %d", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestMatchModeAlias(t *testing.T) {
+	options := []modeOption{
+		{key: config.ModeCloud, aliases: []string{"cloud"}},
+		{key: config.ModeLocal, aliases: []string{"local"}},
+		{key: config.ModeRemote, aliases: []string{"remote"}},
+	}
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"cloud", config.ModeCloud},
+		{"local", config.ModeLocal},
+		{"remote", config.ModeRemote},
+		{"", ""},
+		{"docker", ""}, // intentionally unmapped — picker rejects "docker"
+		{"bogus", ""},
+	}
+	for _, tc := range cases {
+		if got := matchModeAlias(options, tc.in); got != tc.want {
+			t.Fatalf("matchModeAlias(%q) = %q, want %q", tc.in, got, tc.want)
+		}
 	}
 }
 

--- a/cmd/pad/configure_test.go
+++ b/cmd/pad/configure_test.go
@@ -91,10 +91,10 @@ func TestPromptForModeAtoiSafe(t *testing.T) {
 		{"1", 1},
 		{"3", 3},
 		{"42", 42},
-		{"-1", 0},          // leading minus is not a digit, rejected
-		{"1.5", 0},         // dot is not a digit, rejected
-		{"abc", 0},         // non-numeric input, rejected
-		{"100000000", 0},   // overflow guard rejects very large numbers
+		{"-1", 0},        // leading minus is not a digit, rejected
+		{"1.5", 0},       // dot is not a digit, rejected
+		{"abc", 0},       // non-numeric input, rejected
+		{"100000000", 0}, // overflow guard rejects very large numbers
 	}
 	for _, tc := range cases {
 		if got := atoiSafe(tc.in); got != tc.want {

--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -281,8 +281,12 @@ func serveCmd() *cobra.Command {
 			srv.SetIPChangeEnforce(cfg.IPChangeEnforce)
 			srv.SetSSELimits(cfg.SSEMaxConnections, cfg.SSEMaxPerWorkspace)
 
-			// Cloud mode: enable cloud-specific endpoints and behavior
-			if cfg.IsCloud() {
+			// Cloud-tenant mode: enable cloud-specific endpoints and
+			// behavior. Gated on IsCloudServer() (env-var opt-in) rather
+			// than IsCloud() (which is also true when a CLI user has
+			// picked "Cloud" as their `pad init` connection mode — that
+			// is a client signal, not a server-runtime signal).
+			if cfg.IsCloudServer() {
 				if cfg.CloudSecret == "" {
 					return fmt.Errorf("PAD_CLOUD_SECRET is required when running in cloud mode (PAD_MODE=cloud or PAD_CLOUD=true)")
 				}

--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -526,8 +526,6 @@ func setupCmd() *cobra.Command {
 
 			if cfg.IsConfigured() {
 				switch cfg.Mode {
-				case config.ModeDocker:
-					return fmt.Errorf("docker-managed Pad must be initialized from inside the container; run 'docker exec -it <container> pad auth setup'")
 				case config.ModeRemote, config.ModeCloud:
 					return fmt.Errorf("remote Pad instances must be initialized on the server host with 'pad auth setup'")
 				}
@@ -815,8 +813,6 @@ func saveCredentials(cfg *config.Config, resp *cli.LoginResponse) error {
 func printSetupRequiredHint(cfg *config.Config) {
 	fmt.Println("This Pad instance has not been initialized yet.")
 	switch cfg.Mode {
-	case config.ModeDocker:
-		fmt.Println("Run 'pad auth setup' inside the container, for example: docker exec -it <container> pad auth setup")
 	case config.ModeRemote, config.ModeCloud:
 		fmt.Println("Run 'pad auth setup' on the machine or container running the Pad server, then try again.")
 	default:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -132,8 +132,8 @@ There is only one binary, `pad`. Some commands run purely client-side
 - All other `pad <verb>` commands are CLI → HTTP → daemon → SQLite.
 
 The CLI discovers the daemon via `~/.pad/credentials.json` (see
-`internal/cli/client.go`). In Docker/Kubernetes mode, a different
-client targets the network-served Pad instance.
+`internal/cli/client.go`). In Remote or Cloud mode, the same client
+targets a network-served Pad instance instead of a local daemon.
 
 ## Agent integration
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -67,7 +67,7 @@ All configuration is via environment variables or a config file (`~/.pad/config.
 | `PAD_URL` | — | Public-facing base URL (e.g., `https://pad.example.com`). Used for invitation links. |
 | `PAD_DATA_DIR` | `~/.pad` | Data directory for SQLite DB, logs, and config |
 | `PAD_LOG_LEVEL` | `info` | Log level: `debug`, `info`, `warn`, `error` |
-| `PAD_MODE` | `local` | Mode: `local`, `remote`, `docker`, `cloud` |
+| `PAD_MODE` | `local` | Mode: `local`, `remote`, `cloud` |
 
 ### Database
 

--- a/internal/cli/workspace_context_detect.go
+++ b/internal/cli/workspace_context_detect.go
@@ -129,10 +129,10 @@ func detectWorkspaceAssumptions(dir string, cfg *config.Config) []string {
 	}
 	if cfg != nil {
 		switch cfg.Mode {
-		case config.ModeDocker:
-			assumptions = append(assumptions, "This client is configured for a docker-managed Pad instance")
+		case config.ModeCloud:
+			assumptions = append(assumptions, "This client connects to Pad Cloud at "+config.CloudBaseURL)
 		case config.ModeRemote:
-			assumptions = append(assumptions, "This client connects to a remote-managed Pad server")
+			assumptions = append(assumptions, "This client connects to a self-hosted remote Pad server")
 		case config.ModeLocal:
 			assumptions = append(assumptions, "This client manages a local Pad server by default")
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,8 +16,13 @@ import (
 const (
 	ModeLocal  = "local"
 	ModeRemote = "remote"
-	ModeDocker = "docker"
 	ModeCloud  = "cloud"
+
+	// CloudBaseURL is the canonical public endpoint that `pad configure`
+	// (and `pad init`) anchor "Cloud" mode to. Picking Cloud sets
+	// cfg.URL to this value verbatim — there is no per-user URL prompt
+	// because Cloud is, by definition, our managed deployment.
+	CloudBaseURL = "https://app.getpad.dev"
 )
 
 type Config struct {
@@ -230,7 +235,7 @@ func (c *Config) ManagesLocalServer() bool {
 
 func ValidMode(mode string) bool {
 	switch mode {
-	case "", ModeLocal, ModeRemote, ModeDocker, ModeCloud:
+	case "", ModeLocal, ModeRemote, ModeCloud:
 		return true
 	default:
 		return false
@@ -263,7 +268,7 @@ func (c *Config) BaseURL() string {
 // when the URL is constructed from host:port, an unspecified bind-all host
 // (empty, "0.0.0.0", "::", "[::]") is rewritten to "127.0.0.1" because
 // 0.0.0.0 is a bind address and not reliably usable as a browser
-// destination. When URL is explicitly set (Remote/Docker/Cloud) it is
+// destination. When URL is explicitly set (Remote/Cloud) it is
 // returned as-is.
 func (c *Config) BrowserURL() string {
 	if c.URL != "" {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -40,6 +40,16 @@ type Config struct {
 	LoadedFromEnv   bool   `toml:"-"`
 	LoadedFromFlags bool   `toml:"-"`
 
+	// cloudServerOptIn records whether THIS server process was explicitly
+	// asked to run in cloud-tenant mode by an env-var (PAD_CLOUD=true|1
+	// or PAD_MODE=cloud). It is intentionally NOT set by a config-file
+	// `mode = "cloud"` value, which `pad init` writes when the CLI user
+	// picks "Cloud" as their connection mode — that is a CLIENT signal,
+	// not a server-runtime signal. Without this distinction a CLI user
+	// configuring for Pad Cloud would accidentally trip cloud-server
+	// mode the next time `pad server start` ran from the same data dir.
+	cloudServerOptIn bool `toml:"-"`
+
 	// Email (Maileroo)
 	MailerooAPIKey string `toml:"maileroo_api_key"`
 	EmailFrom      string `toml:"email_from"`      // Sender address (e.g. noreply@getpad.dev)
@@ -119,6 +129,11 @@ func Load() (*Config, error) {
 	if v := os.Getenv("PAD_MODE"); v != "" {
 		cfg.Mode = v
 		cfg.LoadedFromEnv = true
+		if v == ModeCloud {
+			// PAD_MODE=cloud is an explicit operator opt-in to running
+			// THIS server in cloud-tenant mode. See cloudServerOptIn.
+			cfg.cloudServerOptIn = true
+		}
 	}
 	if v := os.Getenv("PAD_HOST"); v != "" {
 		cfg.Host = v
@@ -148,10 +163,12 @@ func Load() (*Config, error) {
 	if v := os.Getenv("PAD_EMAIL_FROM_NAME"); v != "" {
 		cfg.EmailFromName = v
 	}
-	// PAD_CLOUD=true is a convenience alias for PAD_MODE=cloud
+	// PAD_CLOUD=true is a convenience alias for PAD_MODE=cloud and
+	// likewise opts the server process into cloud-tenant mode.
 	if v := os.Getenv("PAD_CLOUD"); v == "true" || v == "1" {
 		cfg.Mode = ModeCloud
 		cfg.LoadedFromEnv = true
+		cfg.cloudServerOptIn = true
 	}
 	if v := os.Getenv("PAD_CLOUD_SECRET"); v != "" {
 		cfg.CloudSecret = v
@@ -242,10 +259,32 @@ func ValidMode(mode string) bool {
 	}
 }
 
-// IsCloud reports whether the server is running in cloud mode.
-// Cloud mode is enabled by PAD_MODE=cloud or PAD_CLOUD=true.
+// IsCloud reports whether the configured connection mode is Cloud
+// (i.e. cfg.Mode == ModeCloud). This is a CLIENT-side signal: the
+// CLI is configured to talk to Pad Cloud at https://app.getpad.dev.
+//
+// For the SERVER-side check ("this server process should run in
+// cloud-tenant mode") use IsCloudServer() instead. IsCloud() is
+// true whenever Mode is "cloud" regardless of source — including
+// a config.toml mode=cloud written by `pad init` — and so is NOT
+// safe to gate server-side cloud-tenant behavior on.
 func (c *Config) IsCloud() bool {
 	return c.Mode == ModeCloud
+}
+
+// IsCloudServer reports whether THIS server process should run in
+// cloud-tenant mode (enabling cloud-specific endpoints, requiring
+// PAD_CLOUD_SECRET, wiring the pad-cloud reverse sidecar).
+//
+// Cloud-tenant mode is opted into ONLY by an env-var: PAD_CLOUD=true|1
+// or PAD_MODE=cloud. A config.toml mode=cloud value (set by `pad init`
+// when a CLI user picks Pad Cloud) signals the CLIENT connection mode
+// and does NOT enable server cloud-tenant mode; without this
+// distinction a user who ran `pad init` against app.getpad.dev would
+// accidentally trip cloud-server-mode startup the next time they ran
+// `pad server start` from the same data dir.
+func (c *Config) IsCloudServer() bool {
+	return c.cloudServerOptIn
 }
 
 // Addr returns the host:port listen address.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -135,6 +135,131 @@ func TestCloudBaseURLIsCanonicalAppURL(t *testing.T) {
 	}
 }
 
+// TestIsCloudServerOnlyOptsInViaEnv guards the bug codex caught in PR
+// #272: a `pad init`-written `mode = "cloud"` in config.toml must NOT
+// turn the local pad server into a cloud-tenant deployment. Only an
+// explicit env-var opt-in (PAD_CLOUD=true|1 or PAD_MODE=cloud) should
+// flip IsCloudServer().
+func TestIsCloudServerOnlyOptsInViaEnv(t *testing.T) {
+	t.Run("config-file mode=cloud does NOT opt into server cloud mode", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		// Defensive: ensure no env vars leak into this case.
+		t.Setenv("PAD_MODE", "")
+		t.Setenv("PAD_CLOUD", "")
+
+		cfg := DefaultConfig()
+		cfg.Mode = ModeCloud
+		cfg.URL = CloudBaseURL
+		if err := cfg.Save(); err != nil {
+			t.Fatalf("save: %v", err)
+		}
+
+		reloaded, err := Load()
+		if err != nil {
+			t.Fatalf("reload: %v", err)
+		}
+		if !reloaded.IsCloud() {
+			t.Fatal("expected IsCloud() to be true (Mode == ModeCloud)")
+		}
+		if reloaded.IsCloudServer() {
+			t.Fatal("expected IsCloudServer() to be FALSE for a config-file-only mode=cloud — only env-vars must opt into server cloud-tenant mode")
+		}
+	})
+
+	t.Run("PAD_CLOUD=true opts into server cloud mode", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		t.Setenv("PAD_CLOUD", "true")
+
+		cfg, err := Load()
+		if err != nil {
+			t.Fatalf("load: %v", err)
+		}
+		if !cfg.IsCloud() {
+			t.Fatal("PAD_CLOUD=true should set IsCloud() = true")
+		}
+		if !cfg.IsCloudServer() {
+			t.Fatal("PAD_CLOUD=true must opt into server cloud-tenant mode")
+		}
+	})
+
+	t.Run("PAD_CLOUD=1 opts into server cloud mode", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		t.Setenv("PAD_CLOUD", "1")
+
+		cfg, err := Load()
+		if err != nil {
+			t.Fatalf("load: %v", err)
+		}
+		if !cfg.IsCloudServer() {
+			t.Fatal("PAD_CLOUD=1 must opt into server cloud-tenant mode")
+		}
+	})
+
+	t.Run("PAD_MODE=cloud opts into server cloud mode", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		t.Setenv("PAD_MODE", "cloud")
+
+		cfg, err := Load()
+		if err != nil {
+			t.Fatalf("load: %v", err)
+		}
+		if !cfg.IsCloud() {
+			t.Fatal("PAD_MODE=cloud should set IsCloud() = true")
+		}
+		if !cfg.IsCloudServer() {
+			t.Fatal("PAD_MODE=cloud must opt into server cloud-tenant mode")
+		}
+	})
+
+	t.Run("PAD_MODE=remote does NOT opt into server cloud mode", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		t.Setenv("PAD_MODE", "remote")
+
+		cfg, err := Load()
+		if err != nil {
+			t.Fatalf("load: %v", err)
+		}
+		if cfg.IsCloud() {
+			t.Fatal("PAD_MODE=remote should not set IsCloud() = true")
+		}
+		if cfg.IsCloudServer() {
+			t.Fatal("PAD_MODE=remote must not opt into server cloud-tenant mode")
+		}
+	})
+
+	t.Run("env-var opt-in overrides a non-cloud file config", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+
+		// Persist a non-cloud config first.
+		cfg := DefaultConfig()
+		cfg.Mode = ModeRemote
+		cfg.URL = "https://pad.example.com"
+		if err := cfg.Save(); err != nil {
+			t.Fatalf("save: %v", err)
+		}
+
+		// Then start with PAD_CLOUD=true: the env opt-in must win and
+		// flip both signals.
+		t.Setenv("PAD_CLOUD", "true")
+		reloaded, err := Load()
+		if err != nil {
+			t.Fatalf("reload: %v", err)
+		}
+		if !reloaded.IsCloud() {
+			t.Fatal("PAD_CLOUD=true must override file mode=remote in IsCloud()")
+		}
+		if !reloaded.IsCloudServer() {
+			t.Fatal("PAD_CLOUD=true must opt into server cloud-tenant mode regardless of file config")
+		}
+	})
+}
+
 func TestBrowserURLNormalizesUnspecifiedHost(t *testing.T) {
 	cases := []struct {
 		name string

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -20,8 +20,8 @@ func TestSaveAndLoadRoundTrip(t *testing.T) {
 		t.Fatal("expected config without file or overrides to be unconfigured")
 	}
 
-	cfg.Mode = ModeDocker
-	cfg.URL = "http://127.0.0.1:7777"
+	cfg.Mode = ModeRemote
+	cfg.URL = "https://pad.example.com"
 	cfg.Host = "127.0.0.1"
 	cfg.Port = 7777
 	if err := cfg.Save(); err != nil {
@@ -38,11 +38,11 @@ func TestSaveAndLoadRoundTrip(t *testing.T) {
 	if !reloaded.IsConfigured() {
 		t.Fatal("expected saved config to count as configured")
 	}
-	if reloaded.Mode != ModeDocker {
-		t.Fatalf("expected mode %q, got %q", ModeDocker, reloaded.Mode)
+	if reloaded.Mode != ModeRemote {
+		t.Fatalf("expected mode %q, got %q", ModeRemote, reloaded.Mode)
 	}
-	if reloaded.URL != "http://127.0.0.1:7777" {
-		t.Fatalf("expected docker URL to round-trip, got %q", reloaded.URL)
+	if reloaded.URL != "https://pad.example.com" {
+		t.Fatalf("expected remote URL to round-trip, got %q", reloaded.URL)
 	}
 	if reloaded.ConfigPath != filepath.Join(home, ".pad", "config.toml") {
 		t.Fatalf("unexpected config path %q", reloaded.ConfigPath)
@@ -88,9 +88,50 @@ func TestManagesLocalServerRequiresConfiguredLocalMode(t *testing.T) {
 		t.Fatal("expected configured local mode to manage a local server")
 	}
 
-	cfg.Mode = ModeDocker
+	cfg.Mode = ModeRemote
 	if cfg.ManagesLocalServer() {
-		t.Fatal("expected docker mode to avoid local server management")
+		t.Fatal("expected remote mode to avoid local server management")
+	}
+
+	cfg.Mode = ModeCloud
+	if cfg.ManagesLocalServer() {
+		t.Fatal("expected cloud mode to avoid local server management")
+	}
+}
+
+func TestValidModeAcceptsKnownModes(t *testing.T) {
+	cases := []struct {
+		mode string
+		want bool
+	}{
+		{"", true},
+		{ModeLocal, true},
+		{ModeRemote, true},
+		{ModeCloud, true},
+		{"docker", false}, // removed in favor of Remote — pre-launch, no back-compat
+		{"bogus", false},
+	}
+	for _, tc := range cases {
+		if got := ValidMode(tc.mode); got != tc.want {
+			t.Fatalf("ValidMode(%q) = %v, want %v", tc.mode, got, tc.want)
+		}
+	}
+}
+
+func TestIsCloudReportsCloudMode(t *testing.T) {
+	cfg := &Config{Mode: ModeCloud}
+	if !cfg.IsCloud() {
+		t.Fatal("expected IsCloud() to be true when Mode == ModeCloud")
+	}
+	cfg.Mode = ModeRemote
+	if cfg.IsCloud() {
+		t.Fatal("expected IsCloud() to be false when Mode == ModeRemote")
+	}
+}
+
+func TestCloudBaseURLIsCanonicalAppURL(t *testing.T) {
+	if CloudBaseURL != "https://app.getpad.dev" {
+		t.Fatalf("CloudBaseURL changed unexpectedly: %q — coordinate with pad-cloud and `pad configure` Cloud-mode handler before changing", CloudBaseURL)
 	}
 }
 

--- a/internal/models/workspace_settings_test.go
+++ b/internal/models/workspace_settings_test.go
@@ -16,7 +16,7 @@ func TestParseWorkspaceSettingsEmpty(t *testing.T) {
 }
 
 func TestParseWorkspaceSettingsExtractsStructuredContext(t *testing.T) {
-	settings, err := ParseWorkspaceSettings(`{"context":{"repositories":[{"name":"docapp","role":"primary","path":".","repo":"xarmian/pad"}],"paths":{"docs_repo":"../pad-web"},"commands":{"build":"make install","test":"go test ./..."},"stack":{"languages":["go","typescript"],"frameworks":["sveltekit"],"package_managers":["npm"]},"deployment":{"mode":"docker","base_url":"http://127.0.0.1:7777"},"assumptions":["pad-web lives at ../pad-web"]}}`)
+	settings, err := ParseWorkspaceSettings(`{"context":{"repositories":[{"name":"docapp","role":"primary","path":".","repo":"xarmian/pad"}],"paths":{"docs_repo":"../pad-web"},"commands":{"build":"make install","test":"go test ./..."},"stack":{"languages":["go","typescript"],"frameworks":["sveltekit"],"package_managers":["npm"]},"deployment":{"mode":"remote","base_url":"http://127.0.0.1:7777"},"assumptions":["pad-web lives at ../pad-web"]}}`)
 	if err != nil {
 		t.Fatalf("ParseWorkspaceSettings error: %v", err)
 	}
@@ -35,8 +35,8 @@ func TestParseWorkspaceSettingsExtractsStructuredContext(t *testing.T) {
 	if settings.Context.Stack == nil || len(settings.Context.Stack.Languages) != 2 {
 		t.Fatalf("expected stack languages, got %#v", settings.Context.Stack)
 	}
-	if settings.Context.Deployment == nil || settings.Context.Deployment.Mode != "docker" {
-		t.Fatalf("expected deployment mode docker, got %#v", settings.Context.Deployment)
+	if settings.Context.Deployment == nil || settings.Context.Deployment.Mode != "remote" {
+		t.Fatalf("expected deployment mode remote, got %#v", settings.Context.Deployment)
 	}
 }
 

--- a/internal/store/items_test.go
+++ b/internal/store/items_test.go
@@ -1721,8 +1721,9 @@ func TestListDocuments_FTS_PinnedFilter(t *testing.T) {
 
 // TestFTS_WhitespaceOnlyQuery_DoesNotCrash exercises the whitespace-only
 // guard on each FTS entry point. sanitizeFTSQuery turns "   " into "" and
-// SQLite FTS5 errors on `MATCH ''`, so the routing/guard has to short-circuit
-// before binding. See BUG-818 / Codex follow-up.
+// SQLite FTS5 errors on a MATCH against an empty string, so the
+// routing/guard has to short-circuit before binding.
+// See BUG-818 / Codex follow-up.
 func TestFTS_WhitespaceOnlyQuery_DoesNotCrash(t *testing.T) {
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -245,8 +245,7 @@ func (s *Store) migrate() error {
 //
 //   - items_fts_*    — internal/store/migrations/001_initial.sql
 //   - comments_fts_* — internal/store/migrations/007_comments.sql
-//   - documents_*    — internal/store/migrations/001_initial.sql,
-//                      restored by 046 after BUG-822 drift.
+//   - documents_*    — internal/store/migrations/001_initial.sql (restored by 046 after BUG-822 drift)
 //
 // If a future migration intentionally renames or removes any of these,
 // update this list in the same commit.


### PR DESCRIPTION
## Summary

Replaces the plain `Local / Remote / Docker` picker in `pad init` / `pad auth configure` with a colored numbered picker carrying per-row emoji and self-documenting descriptions. Three modes, Cloud-first:

```
How should this client connect to Pad?

  1. ☁️   Cloud (recommended)
        Connect to your Pad Cloud account at https://app.getpad.dev
        Managed, OAuth sign-in, no setup
  2. 💻  Local
        Run a Pad server on this machine (data stays on your computer)
  3. 🌐  Remote
        Connect to your own self-hosted Pad server by URL

Select a mode [1-3, 'c' to cancel]:
```

Three explicit goals from design discussion:

1. **Drop "Docker" entirely.** Functionally it's just Remote with a default URL of `127.0.0.1:7777`, and the label invites the wrong mental model — new users assume picking "Docker" will install Pad in Docker. Pre-launch app, no back-compat to preserve, so it's a clean break (constant, `ValidMode`, picker, `--mode` help, all switch cases gone).
2. **Self-documenting picker.** Each mode now has an inline description so the user doesn't have to guess what "Local" / "Remote" / "Cloud" means.
3. **Nudge toward Cloud.** Cloud is option 1 and carries a cyan `(recommended)` tag. That's our revenue path.

Cloud is a **labeled-Remote at runtime**: `cfg.Mode = "cloud"` + `cfg.URL = config.CloudBaseURL` ("https://app.getpad.dev"), then the existing `doBrowserLogin` flow runs unchanged. The OAuth-vs-password split lives entirely on the web side at `/auth/cli/{code}`; the CLI doesn't have to care. No new runtime branch in `cmd/pad/main.go` — keeps the surface tight.

## Context

Implements **TASK-837** + **TASK-838** under **PLAN-833** (decomposition of **IDEA-831** — pad init UX gaps from the first end-to-end Pad Cloud auth test).

Design captured in **DOC-840** ("pad init: Cloud mode + connection picker redesign").

Device flow for headless contexts (TASK-838 open Q3) is split out to **TASK-841** as a follow-up — not blocking the public Cloud launch.

## Files

- `cmd/pad/configure.go` — new `promptForMode` (colored numbered picker, emoji, descriptions, "(recommended)" tag); Cloud handling in `applyConfigureValues` pins to `config.CloudBaseURL`; Docker dropped from picker, Long help, and `--mode` flag help.
- `cmd/pad/configure_test.go` — replaced `TestApplyConfigureValuesCloudUnavailable` with `TestApplyConfigureValuesCloud` + `TestApplyConfigureValuesRejectsDocker`; added `TestPromptForModeAtoiSafe` and `TestMatchModeAlias`.
- `internal/config/config.go` — `ModeDocker` removed; new `CloudBaseURL` constant.
- `internal/config/config_test.go` — retargeted Docker placeholders to Remote/Cloud; added `TestValidModeAcceptsKnownModes`, `TestIsCloudReportsCloudMode`, `TestCloudBaseURLIsCanonicalAppURL`.
- `cmd/pad/main.go` — `ModeDocker` cases removed from `setupCmd` switch and `printSetupRequiredHint`.
- `internal/cli/workspace_context_detect.go` — Docker assumption replaced with a Cloud assumption.
- `internal/models/workspace_settings_test.go` — fixture JSON `mode: "docker"` → `"remote"`.
- `docs/deployment.md`, `docs/architecture.md`, `.env.example` — Docker mode references removed.

## Test plan

- [x] `go test ./...` all pass
- [x] `go vet ./...` clean
- [x] `make install` succeeds
- [x] `pad auth configure --mode cloud` writes `mode=cloud` + `url=https://app.getpad.dev` to config.toml
- [x] `pad auth configure --mode docker --url ...` rejected with `invalid mode "docker"`
- [x] `pad server info` against Cloud-mode config reports `base_url=https://app.getpad.dev` and `connection.reachable=true` (live check against app.getpad.dev)
- [x] Picker renders correctly in a real TTY (bold labels, cyan recommended tag, dim subline) — captured via `script(1)`
- [ ] **Manual:** signed-in path — log in to app.getpad.dev → `pad init` → pick Cloud → confirm `/auth/cli/{code}` shows account chip (TASK-836) and approves cleanly
- [ ] **Manual:** signed-out path — log out of app.getpad.dev → `pad init` → pick Cloud → confirm `/auth/cli/{code}` redirects to OAuth login, completes, returns to approval page with same code preserved