### PR TITLE
feat: rebrand to Perpetual Software + new tagline (IDEA-832)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,8 +74,8 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Cross-repo PAT for pushing the brew formula to xarmian/homebrew-tap.
-          # The default GITHUB_TOKEN above only has access to xarmian/pad.
+          # Cross-repo PAT for pushing the brew formula to PerpetualSoftware/homebrew-tap.
+          # The default GITHUB_TOKEN above only has access to PerpetualSoftware/pad.
           # Add this secret in repo settings before tagging a release that ships
           # a brew formula — without it goreleaser fails at the brew publish step.
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
@@ -85,7 +85,7 @@ jobs:
       # consumers can verify this binary was actually built by this
       # workflow from this commit, e.g.:
       #   gh attestation verify pad_v1.0.0_linux_amd64.tar.gz \
-      #     --repo xarmian/pad
+      #     --repo PerpetualSoftware/pad
       - name: Generate build provenance for archives
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -47,7 +47,7 @@ sboms:
 # CA + Rekor transparency log via GitHub Actions OIDC — no long-lived keys
 # to store. Verify with:
 #   cosign verify-blob --certificate-identity-regexp \
-#     "^https://github.com/xarmian/pad/.github/workflows/release.yml@.*" \
+#     "^https://github.com/PerpetualSoftware/pad/.github/workflows/release.yml@.*" \
 #     --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
 #     --bundle checksums.txt.cosign.bundle checksums.txt
 signs:
@@ -104,16 +104,16 @@ changelog:
 
 homebrew_casks:
   - repository:
-      owner: xarmian
+      owner: PerpetualSoftware
       name: homebrew-tap
-      # Cross-repo PAT — the default GITHUB_TOKEN is scoped to xarmian/pad
+      # Cross-repo PAT — the default GITHUB_TOKEN is scoped to PerpetualSoftware/pad
       # only and cannot push to the separate tap repo. Set the secret
       # `HOMEBREW_TAP_GITHUB_TOKEN` on this repo (fine-grained PAT,
-      # `Contents: write` + `Metadata: read` on xarmian/homebrew-tap only).
+      # `Contents: write` + `Metadata: read` on PerpetualSoftware/homebrew-tap only).
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
     directory: Casks
     homepage: "https://getpad.dev"
-    description: "Project management for developers and AI agents"
+    description: "Collaborate with your AI agents"
     license: "Apache-2.0"
 
 # dockers_v2 replaces the legacy `dockers:` + `docker_manifests:` blocks.
@@ -122,7 +122,7 @@ homebrew_casks:
 # to consume (see Dockerfile.goreleaser's COPY line).
 dockers_v2:
   - images:
-      - "ghcr.io/xarmian/pad"
+      - "ghcr.io/perpetualsoftware/pad"
     tags:
       - "{{ .Version }}"
       - "latest"
@@ -135,7 +135,7 @@ dockers_v2:
 
 release:
   github:
-    owner: xarmian
+    owner: PerpetualSoftware
     name: pad
   draft: false
   prerelease: auto

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ Thanks for your interest in contributing to Pad! This guide will help you get se
 ### Setup
 
 ```bash
-git clone https://github.com/xarmian/pad
+git clone https://github.com/PerpetualSoftware/pad
 cd pad
 make build    # Build web UI + Go binary
 ```

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 <p align="center">
   <h1 align="center">Pad</h1>
-  <p align="center"><strong>Project management for developers and AI agents.</strong></p>
+  <p align="center"><strong>Collaborate with your AI agents.</strong></p>
   <p align="center">
-    <a href="https://github.com/xarmian/pad/actions/workflows/ci.yml"><img src="https://github.com/xarmian/pad/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-    <a href="https://github.com/xarmian/pad/releases"><img src="https://img.shields.io/github/v/release/xarmian/pad" alt="Release"></a>
-    <a href="https://goreportcard.com/report/github.com/xarmian/pad"><img src="https://goreportcard.com/badge/github.com/xarmian/pad" alt="Go Report Card"></a>
-    <a href="https://github.com/xarmian/pad/pkgs/container/pad"><img src="https://img.shields.io/badge/ghcr.io-xarmian%2Fpad-blue?logo=docker&logoColor=white" alt="Container image on GHCR"></a>
+    <a href="https://github.com/PerpetualSoftware/pad/actions/workflows/ci.yml"><img src="https://github.com/PerpetualSoftware/pad/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+    <a href="https://github.com/PerpetualSoftware/pad/releases"><img src="https://img.shields.io/github/v/release/PerpetualSoftware/pad" alt="Release"></a>
+    <a href="https://goreportcard.com/report/github.com/PerpetualSoftware/pad"><img src="https://goreportcard.com/badge/github.com/PerpetualSoftware/pad" alt="Go Report Card"></a>
+    <a href="https://github.com/PerpetualSoftware/pad/pkgs/container/pad"><img src="https://img.shields.io/badge/ghcr.io-perpetualsoftware%2Fpad-blue?logo=docker&logoColor=white" alt="Container image on GHCR"></a>
     <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue" alt="License"></a>
     <a href="https://github.com/sponsors/xarmian"><img src="https://img.shields.io/github/sponsors/xarmian?label=sponsors&logo=github" alt="GitHub Sponsors"></a>
   </p>
@@ -22,7 +22,7 @@
 ## Quick Start
 
 ```bash
-brew install xarmian/tap/pad
+brew install PerpetualSoftware/tap/pad
 cd your-project
 pad init                    # configure, auth, workspace, AI skill — all in one
 pad server open             # opens the web UI at localhost:7777
@@ -140,13 +140,13 @@ Items get reference numbers automatically (`TASK-5`, `BUG-12`) and can be moved 
 ### Homebrew (macOS and Linux)
 
 ```bash
-brew install xarmian/tap/pad
+brew install PerpetualSoftware/tap/pad
 ```
 
 ### Build from Source
 
 ```bash
-git clone https://github.com/xarmian/pad
+git clone https://github.com/PerpetualSoftware/pad
 cd pad
 make build
 cp pad ~/.local/bin/   # or /usr/local/bin/
@@ -154,12 +154,12 @@ cp pad ~/.local/bin/   # or /usr/local/bin/
 
 Requires Go 1.26+ and Node.js 22+.
 
-The `go install github.com/xarmian/pad/cmd/pad@latest` path is not supported for the full Pad binary, because the web UI must be built and embedded during the source build.
+The `go install github.com/PerpetualSoftware/pad/cmd/pad@latest` path is not supported for the full Pad binary, because the web UI must be built and embedded during the source build.
 
 ### Docker
 
 ```bash
-docker run -p 127.0.0.1:7777:7777 -v pad-data:/data ghcr.io/xarmian/pad
+docker run -p 127.0.0.1:7777:7777 -v pad-data:/data ghcr.io/perpetualsoftware/pad
 ```
 
 This publishes Pad to `localhost:7777` on the host machine, which is the recommended default for local use.
@@ -167,14 +167,14 @@ This publishes Pad to `localhost:7777` on the host machine, which is the recomme
 **Single user, more than one device?** Publish to all interfaces so you can reach Pad from your phone, tablet, or another machine on the same LAN, Tailscale network, or home VPN:
 
 ```bash
-docker run -p 7777:7777 -v pad-data:/data ghcr.io/xarmian/pad
+docker run -p 7777:7777 -v pad-data:/data ghcr.io/perpetualsoftware/pad
 ```
 
 For multi-instance deployments, Pad supports Postgres + Redis via `docker-compose.yml` — see [docs/deployment.md](docs/deployment.md) for the full setup.
 
 ### Binary Download
 
-Pre-built binaries for macOS, Linux, and Windows are available on the [releases page](https://github.com/xarmian/pad/releases).
+Pre-built binaries for macOS, Linux, and Windows are available on the [releases page](https://github.com/PerpetualSoftware/pad/releases).
 
 ## Getting Started
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,7 +7,7 @@ If you discover a security vulnerability in Pad, **please do not open a public i
 Instead, report it privately:
 
 - **Email:** security@perpetualsoftware.org
-- **GitHub:** Use [GitHub's private vulnerability reporting](https://github.com/xarmian/pad/security/advisories/new)
+- **GitHub:** Use [GitHub's private vulnerability reporting](https://github.com/PerpetualSoftware/pad/security/advisories/new)
 
 Please include:
 

--- a/cmd/pad/configure.go
+++ b/cmd/pad/configure.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
-	"github.com/xarmian/pad/internal/config"
+	"github.com/PerpetualSoftware/pad/internal/config"
 	"golang.org/x/term"
 )
 

--- a/cmd/pad/configure_test.go
+++ b/cmd/pad/configure_test.go
@@ -3,7 +3,7 @@ package main
 import (
 	"testing"
 
-	"github.com/xarmian/pad/internal/config"
+	"github.com/PerpetualSoftware/pad/internal/config"
 )
 
 func TestApplyConfigureValuesLocal(t *testing.T) {

--- a/cmd/pad/init.go
+++ b/cmd/pad/init.go
@@ -11,11 +11,11 @@ import (
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 
-	pad "github.com/xarmian/pad"
-	"github.com/xarmian/pad/internal/cli"
-	"github.com/xarmian/pad/internal/collections"
-	"github.com/xarmian/pad/internal/config"
-	"github.com/xarmian/pad/internal/models"
+	pad "github.com/PerpetualSoftware/pad"
+	"github.com/PerpetualSoftware/pad/internal/cli"
+	"github.com/PerpetualSoftware/pad/internal/collections"
+	"github.com/PerpetualSoftware/pad/internal/config"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 func padInitCmd() *cobra.Command {

--- a/cmd/pad/lineage.go
+++ b/cmd/pad/lineage.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/xarmian/pad/internal/cli"
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/cli"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 type lineageLinkSpec struct {

--- a/cmd/pad/lineage_test.go
+++ b/cmd/pad/lineage_test.go
@@ -3,7 +3,7 @@ package main
 import (
 	"testing"
 
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 func TestFindMatchingLinkIDMatchesCanonicalType(t *testing.T) {

--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -24,22 +24,22 @@ import (
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 
-	pad "github.com/xarmian/pad"
-	"github.com/xarmian/pad/internal/cli"
-	"github.com/xarmian/pad/internal/collections"
-	"github.com/xarmian/pad/internal/config"
+	pad "github.com/PerpetualSoftware/pad"
+	"github.com/PerpetualSoftware/pad/internal/cli"
+	"github.com/PerpetualSoftware/pad/internal/collections"
+	"github.com/PerpetualSoftware/pad/internal/config"
 	"regexp"
 
 	"github.com/redis/go-redis/v9"
-	"github.com/xarmian/pad/internal/billing"
-	"github.com/xarmian/pad/internal/email"
-	"github.com/xarmian/pad/internal/events"
-	"github.com/xarmian/pad/internal/logging"
-	"github.com/xarmian/pad/internal/metrics"
-	"github.com/xarmian/pad/internal/models"
-	"github.com/xarmian/pad/internal/server"
-	"github.com/xarmian/pad/internal/store"
-	"github.com/xarmian/pad/internal/webhooks"
+	"github.com/PerpetualSoftware/pad/internal/billing"
+	"github.com/PerpetualSoftware/pad/internal/email"
+	"github.com/PerpetualSoftware/pad/internal/events"
+	"github.com/PerpetualSoftware/pad/internal/logging"
+	"github.com/PerpetualSoftware/pad/internal/metrics"
+	"github.com/PerpetualSoftware/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/server"
+	"github.com/PerpetualSoftware/pad/internal/store"
+	"github.com/PerpetualSoftware/pad/internal/webhooks"
 	"golang.org/x/term"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
@@ -5154,7 +5154,7 @@ func fetchGitHubPR() (*GitHubPR, error) {
 		return nil, fmt.Errorf("failed to parse gh output: %w", err)
 	}
 
-	// Extract owner/repo from the PR URL (e.g. https://github.com/xarmian/pad/pull/5)
+	// Extract owner/repo from the PR URL (e.g. https://github.com/PerpetualSoftware/pad/pull/5)
 	repo := ""
 	if parts := strings.Split(raw.URL, "/"); len(parts) >= 5 {
 		repo = parts[3] + "/" + parts[4]

--- a/cmd/pad/notes.go
+++ b/cmd/pad/notes.go
@@ -10,8 +10,8 @@ import (
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 
-	"github.com/xarmian/pad/internal/cli"
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/cli"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 func noteCmd() *cobra.Command {

--- a/cmd/pad/query.go
+++ b/cmd/pad/query.go
@@ -10,9 +10,9 @@ import (
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 
-	"github.com/xarmian/pad/internal/cli"
-	"github.com/xarmian/pad/internal/models"
-	"github.com/xarmian/pad/internal/server"
+	"github.com/PerpetualSoftware/pad/internal/cli"
+	"github.com/PerpetualSoftware/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/server"
 )
 
 type relatedEntry struct {

--- a/cmd/pad/query_test.go
+++ b/cmd/pad/query_test.go
@@ -3,8 +3,8 @@ package main
 import (
 	"testing"
 
-	"github.com/xarmian/pad/internal/models"
-	"github.com/xarmian/pad/internal/server"
+	"github.com/PerpetualSoftware/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/server"
 )
 
 func TestFilterAgentAttentionKeepsOnlyActionableBuckets(t *testing.T) {

--- a/cmd/pad/reconcile.go
+++ b/cmd/pad/reconcile.go
@@ -11,8 +11,8 @@ import (
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 
-	"github.com/xarmian/pad/internal/cli"
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/cli"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 type reconcileFinding struct {

--- a/cmd/pad/reconcile_test.go
+++ b/cmd/pad/reconcile_test.go
@@ -4,21 +4,21 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 func TestBuildReconcileFindingsMergedPROpenTask(t *testing.T) {
 	item := &models.Item{
-		Fields:      `{"status":"open","github_pr":{"number":41,"url":"https://github.com/xarmian/pad/pull/41","title":"PR","state":"OPEN","branch":"feat/test","repo":"xarmian/pad","updated_at":"2026-04-02T15:00:00Z"}}`,
-		CodeContext: models.ExtractItemCodeContext(`{"github_pr":{"number":41,"url":"https://github.com/xarmian/pad/pull/41","title":"PR","state":"OPEN","branch":"feat/test","repo":"xarmian/pad","updated_at":"2026-04-02T15:00:00Z"}}`),
+		Fields:      `{"status":"open","github_pr":{"number":41,"url":"https://github.com/PerpetualSoftware/pad/pull/41","title":"PR","state":"OPEN","branch":"feat/test","repo":"PerpetualSoftware/pad","updated_at":"2026-04-02T15:00:00Z"}}`,
+		CodeContext: models.ExtractItemCodeContext(`{"github_pr":{"number":41,"url":"https://github.com/PerpetualSoftware/pad/pull/41","title":"PR","state":"OPEN","branch":"feat/test","repo":"PerpetualSoftware/pad","updated_at":"2026-04-02T15:00:00Z"}}`),
 	}
 	livePR := &GitHubPR{
 		Number:    41,
-		URL:       "https://github.com/xarmian/pad/pull/41",
+		URL:       "https://github.com/PerpetualSoftware/pad/pull/41",
 		Title:     "PR",
 		State:     "MERGED",
 		Branch:    "feat/test",
-		Repo:      "xarmian/pad",
+		Repo:      "PerpetualSoftware/pad",
 		UpdatedAt: "2026-04-02T15:05:00Z",
 	}
 
@@ -41,16 +41,16 @@ func TestBuildReconcileFindingsMergedPROpenTask(t *testing.T) {
 
 func TestBuildReconcileFindingsOpenPRDoneTask(t *testing.T) {
 	item := &models.Item{
-		Fields:      `{"status":"done","github_pr":{"number":41,"url":"https://github.com/xarmian/pad/pull/41","title":"PR","state":"OPEN","branch":"feat/test","repo":"xarmian/pad","updated_at":"2026-04-02T15:00:00Z"}}`,
-		CodeContext: models.ExtractItemCodeContext(`{"github_pr":{"number":41,"url":"https://github.com/xarmian/pad/pull/41","title":"PR","state":"OPEN","branch":"feat/test","repo":"xarmian/pad","updated_at":"2026-04-02T15:00:00Z"}}`),
+		Fields:      `{"status":"done","github_pr":{"number":41,"url":"https://github.com/PerpetualSoftware/pad/pull/41","title":"PR","state":"OPEN","branch":"feat/test","repo":"PerpetualSoftware/pad","updated_at":"2026-04-02T15:00:00Z"}}`,
+		CodeContext: models.ExtractItemCodeContext(`{"github_pr":{"number":41,"url":"https://github.com/PerpetualSoftware/pad/pull/41","title":"PR","state":"OPEN","branch":"feat/test","repo":"PerpetualSoftware/pad","updated_at":"2026-04-02T15:00:00Z"}}`),
 	}
 	livePR := &GitHubPR{
 		Number:    41,
-		URL:       "https://github.com/xarmian/pad/pull/41",
+		URL:       "https://github.com/PerpetualSoftware/pad/pull/41",
 		Title:     "PR",
 		State:     "OPEN",
 		Branch:    "feat/test",
-		Repo:      "xarmian/pad",
+		Repo:      "PerpetualSoftware/pad",
 		UpdatedAt: "2026-04-02T15:00:00Z",
 	}
 
@@ -62,16 +62,16 @@ func TestBuildReconcileFindingsOpenPRDoneTask(t *testing.T) {
 
 func TestBuildReconcileFindingsMissingBranchOnOpenPR(t *testing.T) {
 	item := &models.Item{
-		Fields:      `{"status":"in-progress","github_pr":{"number":41,"url":"https://github.com/xarmian/pad/pull/41","title":"PR","state":"OPEN","branch":"feat/test","repo":"xarmian/pad","updated_at":"2026-04-02T15:00:00Z"}}`,
-		CodeContext: models.ExtractItemCodeContext(`{"github_pr":{"number":41,"url":"https://github.com/xarmian/pad/pull/41","title":"PR","state":"OPEN","branch":"feat/test","repo":"xarmian/pad","updated_at":"2026-04-02T15:00:00Z"}}`),
+		Fields:      `{"status":"in-progress","github_pr":{"number":41,"url":"https://github.com/PerpetualSoftware/pad/pull/41","title":"PR","state":"OPEN","branch":"feat/test","repo":"PerpetualSoftware/pad","updated_at":"2026-04-02T15:00:00Z"}}`,
+		CodeContext: models.ExtractItemCodeContext(`{"github_pr":{"number":41,"url":"https://github.com/PerpetualSoftware/pad/pull/41","title":"PR","state":"OPEN","branch":"feat/test","repo":"PerpetualSoftware/pad","updated_at":"2026-04-02T15:00:00Z"}}`),
 	}
 	livePR := &GitHubPR{
 		Number:    41,
-		URL:       "https://github.com/xarmian/pad/pull/41",
+		URL:       "https://github.com/PerpetualSoftware/pad/pull/41",
 		Title:     "PR",
 		State:     "OPEN",
 		Branch:    "feat/test",
-		Repo:      "xarmian/pad",
+		Repo:      "PerpetualSoftware/pad",
 		UpdatedAt: "2026-04-02T15:00:00Z",
 	}
 	branchExists := false
@@ -84,16 +84,16 @@ func TestBuildReconcileFindingsMissingBranchOnOpenPR(t *testing.T) {
 
 func TestNeedsPRMetadataRefresh(t *testing.T) {
 	item := &models.Item{
-		Fields:      `{"status":"open","github_pr":{"number":41,"url":"https://github.com/xarmian/pad/pull/41","title":"Old title","state":"OPEN","branch":"feat/test","repo":"xarmian/pad","updated_at":"2026-04-02T15:00:00Z"}}`,
-		CodeContext: models.ExtractItemCodeContext(`{"github_pr":{"number":41,"url":"https://github.com/xarmian/pad/pull/41","title":"Old title","state":"OPEN","branch":"feat/test","repo":"xarmian/pad","updated_at":"2026-04-02T15:00:00Z"}}`),
+		Fields:      `{"status":"open","github_pr":{"number":41,"url":"https://github.com/PerpetualSoftware/pad/pull/41","title":"Old title","state":"OPEN","branch":"feat/test","repo":"PerpetualSoftware/pad","updated_at":"2026-04-02T15:00:00Z"}}`,
+		CodeContext: models.ExtractItemCodeContext(`{"github_pr":{"number":41,"url":"https://github.com/PerpetualSoftware/pad/pull/41","title":"Old title","state":"OPEN","branch":"feat/test","repo":"PerpetualSoftware/pad","updated_at":"2026-04-02T15:00:00Z"}}`),
 	}
 	livePR := &GitHubPR{
 		Number:    41,
-		URL:       "https://github.com/xarmian/pad/pull/41",
+		URL:       "https://github.com/PerpetualSoftware/pad/pull/41",
 		Title:     "New title",
 		State:     "MERGED",
 		Branch:    "feat/test",
-		Repo:      "xarmian/pad",
+		Repo:      "PerpetualSoftware/pad",
 		UpdatedAt: "2026-04-02T15:05:00Z",
 	}
 
@@ -105,11 +105,11 @@ func TestNeedsPRMetadataRefresh(t *testing.T) {
 func TestMergeGitHubPRIntoFieldsPreservesOtherFields(t *testing.T) {
 	fields, err := mergeGitHubPRIntoFields(`{"status":"open","priority":"high"}`, &GitHubPR{
 		Number:    41,
-		URL:       "https://github.com/xarmian/pad/pull/41",
+		URL:       "https://github.com/PerpetualSoftware/pad/pull/41",
 		Title:     "PR",
 		State:     "MERGED",
 		Branch:    "feat/test",
-		Repo:      "xarmian/pad",
+		Repo:      "PerpetualSoftware/pad",
 		UpdatedAt: "2026-04-02T15:05:00Z",
 	})
 	if err != nil {

--- a/cmd/pad/server_info.go
+++ b/cmd/pad/server_info.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/xarmian/pad/internal/cli"
-	"github.com/xarmian/pad/internal/config"
+	"github.com/PerpetualSoftware/pad/internal/cli"
+	"github.com/PerpetualSoftware/pad/internal/config"
 )
 
 type serverInfoReport struct {

--- a/cmd/pad/server_info_test.go
+++ b/cmd/pad/server_info_test.go
@@ -8,8 +8,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/xarmian/pad/internal/cli"
-	"github.com/xarmian/pad/internal/config"
+	"github.com/PerpetualSoftware/pad/internal/cli"
+	"github.com/PerpetualSoftware/pad/internal/config"
 )
 
 func TestCollectServerInfoRemoteAuthenticated(t *testing.T) {

--- a/cmd/pad/templates_picker.go
+++ b/cmd/pad/templates_picker.go
@@ -12,7 +12,7 @@ import (
 	"github.com/fatih/color"
 	"golang.org/x/term"
 
-	"github.com/xarmian/pad/internal/collections"
+	"github.com/PerpetualSoftware/pad/internal/collections"
 )
 
 const defaultTemplateName = "startup"

--- a/cmd/pad/workspace_context.go
+++ b/cmd/pad/workspace_context.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/xarmian/pad/internal/cli"
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/cli"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 func workspaceContextCmd() *cobra.Command {

--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -24,7 +24,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: pad
-          image: ghcr.io/xarmian/pad:latest
+          image: ghcr.io/perpetualsoftware/pad:latest
           ports:
             - containerPort: 7777
               name: http

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -30,7 +30,7 @@ Pad is a single Go binary with an embedded web UI. It supports SQLite (default) 
 
 ```bash
 # Clone the repo
-git clone https://github.com/xarmian/pad.git
+git clone https://github.com/PerpetualSoftware/pad.git
 cd pad
 
 # Start everything (Pad + PostgreSQL + Redis)

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/xarmian/pad
+module github.com/PerpetualSoftware/pad
 
 go 1.26.0
 

--- a/internal/cli/client.go
+++ b/internal/cli/client.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 // Client is a thin HTTP client for the Pad API.

--- a/internal/cli/editor.go
+++ b/internal/cli/editor.go
@@ -6,7 +6,7 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/xarmian/pad/internal/config"
+	"github.com/PerpetualSoftware/pad/internal/config"
 )
 
 // OpenInEditor opens a temp file with content in the user's editor,

--- a/internal/cli/format.go
+++ b/internal/cli/format.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/fatih/color"
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 // Color definitions for reuse across the CLI.

--- a/internal/cli/server.go
+++ b/internal/cli/server.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/xarmian/pad/internal/config"
+	"github.com/PerpetualSoftware/pad/internal/config"
 )
 
 // EnsureServer checks if the pad server is running; if not, starts it in the background.

--- a/internal/cli/server_test.go
+++ b/internal/cli/server_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/xarmian/pad/internal/config"
+	"github.com/PerpetualSoftware/pad/internal/config"
 )
 
 func TestEnsureServerSkipsWhenClientDoesNotManageLocalServer(t *testing.T) {

--- a/internal/cli/workspace_context_detect.go
+++ b/internal/cli/workspace_context_detect.go
@@ -6,8 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/xarmian/pad/internal/config"
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/config"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 // BuildWorkspaceContext converts detected project metadata plus the current Pad

--- a/internal/cli/workspace_context_detect_test.go
+++ b/internal/cli/workspace_context_detect_test.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/xarmian/pad/internal/config"
+	"github.com/PerpetualSoftware/pad/internal/config"
 )
 
 func TestDetectProjectCapturesMakeAndNestedWebSignals(t *testing.T) {
@@ -95,11 +95,11 @@ func TestBuildWorkspaceContext(t *testing.T) {
 }
 
 func TestNormalizeGitRemoteSlug(t *testing.T) {
-	if got := normalizeGitRemoteSlug("git@github.com:xarmian/pad.git\n"); got != "xarmian/pad" {
-		t.Fatalf("expected SSH slug xarmian/pad, got %q", got)
+	if got := normalizeGitRemoteSlug("git@github.com:PerpetualSoftware/pad.git\n"); got != "PerpetualSoftware/pad" {
+		t.Fatalf("expected SSH slug PerpetualSoftware/pad, got %q", got)
 	}
-	if got := normalizeGitRemoteSlug("https://github.com/xarmian/pad.git"); got != "xarmian/pad" {
-		t.Fatalf("expected HTTPS slug xarmian/pad, got %q", got)
+	if got := normalizeGitRemoteSlug("https://github.com/PerpetualSoftware/pad.git"); got != "PerpetualSoftware/pad" {
+		t.Fatalf("expected HTTPS slug PerpetualSoftware/pad, got %q", got)
 	}
 	if got := normalizeGitRemoteSlug("ssh://git@example.com/foo"); got != "" {
 		t.Fatalf("expected unsupported remote to be blank, got %q", got)

--- a/internal/collections/defaults.go
+++ b/internal/collections/defaults.go
@@ -1,6 +1,6 @@
 package collections
 
-import "github.com/xarmian/pad/internal/models"
+import "github.com/PerpetualSoftware/pad/internal/models"
 
 // DefaultCollection holds the definition for a default collection that gets
 // created when a workspace is initialized.

--- a/internal/collections/templates.go
+++ b/internal/collections/templates.go
@@ -3,7 +3,7 @@ package collections
 import (
 	"encoding/json"
 
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 // Template categories. Templates are grouped in the picker by category so

--- a/internal/collections/templates_hiring.go
+++ b/internal/collections/templates_hiring.go
@@ -1,6 +1,6 @@
 package collections
 
-import "github.com/xarmian/pad/internal/models"
+import "github.com/PerpetualSoftware/pad/internal/models"
 
 // Trigger + scope vocabularies used by the hiring workspace's Conventions
 // and Playbooks collections. Separate from the software vocabularies so a

--- a/internal/collections/templates_interviewing.go
+++ b/internal/collections/templates_interviewing.go
@@ -1,6 +1,6 @@
 package collections
 
-import "github.com/xarmian/pad/internal/models"
+import "github.com/PerpetualSoftware/pad/internal/models"
 
 // Trigger + scope vocabularies used by the interviewing (candidate-side)
 // workspace's Conventions and Playbooks collections. Different enough

--- a/internal/items/migrate.go
+++ b/internal/items/migrate.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 // MigrateResult holds the outcome of field migration between collection schemas.

--- a/internal/items/migrate_test.go
+++ b/internal/items/migrate_test.go
@@ -3,7 +3,7 @@ package items
 import (
 	"testing"
 
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 func TestMigrateFields_MatchingTypes(t *testing.T) {

--- a/internal/items/validate.go
+++ b/internal/items/validate.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 // ValidateFields checks field values against the collection schema.

--- a/internal/items/validate_test.go
+++ b/internal/items/validate_test.go
@@ -3,7 +3,7 @@ package items
 import (
 	"testing"
 
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 func taskSchema() models.CollectionSchema {

--- a/internal/metrics/instrumented_bus.go
+++ b/internal/metrics/instrumented_bus.go
@@ -3,7 +3,7 @@ package metrics
 import (
 	"sync"
 
-	"github.com/xarmian/pad/internal/events"
+	"github.com/PerpetualSoftware/pad/internal/events"
 )
 
 // InstrumentedBus wraps an events.EventBus to record Prometheus metrics

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	io_prometheus_client "github.com/prometheus/client_model/go"
 
-	"github.com/xarmian/pad/internal/events"
+	"github.com/PerpetualSoftware/pad/internal/events"
 
 	_ "modernc.org/sqlite"
 )

--- a/internal/models/item_test.go
+++ b/internal/models/item_test.go
@@ -3,7 +3,7 @@ package models
 import "testing"
 
 func TestExtractItemCodeContextFromGitHubPRFields(t *testing.T) {
-	context := ExtractItemCodeContext(`{"github_pr":{"number":42,"url":"https://github.com/xarmian/pad/pull/42","title":"Add branch metadata","state":"OPEN","branch":"feat/task-123-branch-pr-metadata","repo":"xarmian/pad","updated_at":"2026-04-02T14:00:00Z"}}`)
+	context := ExtractItemCodeContext(`{"github_pr":{"number":42,"url":"https://github.com/PerpetualSoftware/pad/pull/42","title":"Add branch metadata","state":"OPEN","branch":"feat/task-123-branch-pr-metadata","repo":"PerpetualSoftware/pad","updated_at":"2026-04-02T14:00:00Z"}}`)
 	if context == nil {
 		t.Fatal("expected code context")
 	}
@@ -13,8 +13,8 @@ func TestExtractItemCodeContextFromGitHubPRFields(t *testing.T) {
 	if context.Branch != "feat/task-123-branch-pr-metadata" {
 		t.Fatalf("expected branch metadata, got %q", context.Branch)
 	}
-	if context.Repo != "xarmian/pad" {
-		t.Fatalf("expected repo xarmian/pad, got %q", context.Repo)
+	if context.Repo != "PerpetualSoftware/pad" {
+		t.Fatalf("expected repo PerpetualSoftware/pad, got %q", context.Repo)
 	}
 	if context.PullRequest == nil {
 		t.Fatal("expected pull request metadata")

--- a/internal/models/workspace_settings_test.go
+++ b/internal/models/workspace_settings_test.go
@@ -16,7 +16,7 @@ func TestParseWorkspaceSettingsEmpty(t *testing.T) {
 }
 
 func TestParseWorkspaceSettingsExtractsStructuredContext(t *testing.T) {
-	settings, err := ParseWorkspaceSettings(`{"context":{"repositories":[{"name":"docapp","role":"primary","path":".","repo":"xarmian/pad"}],"paths":{"docs_repo":"../pad-web"},"commands":{"build":"make install","test":"go test ./..."},"stack":{"languages":["go","typescript"],"frameworks":["sveltekit"],"package_managers":["npm"]},"deployment":{"mode":"remote","base_url":"http://127.0.0.1:7777"},"assumptions":["pad-web lives at ../pad-web"]}}`)
+	settings, err := ParseWorkspaceSettings(`{"context":{"repositories":[{"name":"docapp","role":"primary","path":".","repo":"PerpetualSoftware/pad"}],"paths":{"docs_repo":"../pad-web"},"commands":{"build":"make install","test":"go test ./..."},"stack":{"languages":["go","typescript"],"frameworks":["sveltekit"],"package_managers":["npm"]},"deployment":{"mode":"remote","base_url":"http://127.0.0.1:7777"},"assumptions":["pad-web lives at ../pad-web"]}}`)
 	if err != nil {
 		t.Fatalf("ParseWorkspaceSettings error: %v", err)
 	}

--- a/internal/server/cloud_admin_gate_test.go
+++ b/internal/server/cloud_admin_gate_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/xarmian/pad/internal/email"
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/email"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 // cloudAdminReq is a small helper that builds a request with optional JSON body

--- a/internal/server/handlers_2fa.go
+++ b/internal/server/handlers_2fa.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/pquerna/otp/totp"
 
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 const (

--- a/internal/server/handlers_account.go
+++ b/internal/server/handlers_account.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/models"
 	"golang.org/x/crypto/bcrypt"
 )
 

--- a/internal/server/handlers_account_test.go
+++ b/internal/server/handlers_account_test.go
@@ -8,7 +8,7 @@ import (
 	"sync/atomic"
 	"testing"
 
-	"github.com/xarmian/pad/internal/billing"
+	"github.com/PerpetualSoftware/pad/internal/billing"
 )
 
 // fakeSidecar is a controllable CloudSidecar used to assert the cancel-before-

--- a/internal/server/handlers_activity.go
+++ b/internal/server/handlers_activity.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 func (s *Server) handleListWorkspaceActivity(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/handlers_admin.go
+++ b/internal/server/handlers_admin.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 // Known platform setting keys. Values are stored in the platform_settings table.

--- a/internal/server/handlers_admin_billing.go
+++ b/internal/server/handlers_admin_billing.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/xarmian/pad/internal/billing"
+	"github.com/PerpetualSoftware/pad/internal/billing"
 )
 
 // AdminBillingStatsResponse is the JSON shape returned by

--- a/internal/server/handlers_admin_billing_test.go
+++ b/internal/server/handlers_admin_billing_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/xarmian/pad/internal/billing"
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/billing"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 // fakeBillingSidecar is a controllable CloudSidecar used by the

--- a/internal/server/handlers_admin_invitations.go
+++ b/internal/server/handlers_admin_invitations.go
@@ -6,9 +6,9 @@ import (
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/xarmian/pad/internal/email"
-	"github.com/xarmian/pad/internal/models"
-	"github.com/xarmian/pad/internal/store"
+	"github.com/PerpetualSoftware/pad/internal/email"
+	"github.com/PerpetualSoftware/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/store"
 )
 
 // handleAdminListInvitations returns all pending invitations across all workspaces.

--- a/internal/server/handlers_admin_users.go
+++ b/internal/server/handlers_admin_users.go
@@ -8,8 +8,8 @@ import (
 	"strconv"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/xarmian/pad/internal/models"
-	"github.com/xarmian/pad/internal/store"
+	"github.com/PerpetualSoftware/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/store"
 )
 
 // --- Admin User Management (TASK-502) ---

--- a/internal/server/handlers_agent_roles.go
+++ b/internal/server/handlers_agent_roles.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 // handleListAgentRoles returns all agent roles for a workspace.

--- a/internal/server/handlers_audit.go
+++ b/internal/server/handlers_audit.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 // handleAuditLog returns a filtered audit log. Admin-only.

--- a/internal/server/handlers_auth.go
+++ b/internal/server/handlers_auth.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/xarmian/pad/internal/models"
-	"github.com/xarmian/pad/internal/store"
+	"github.com/PerpetualSoftware/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/store"
 )
 
 const (

--- a/internal/server/handlers_auth_test.go
+++ b/internal/server/handlers_auth_test.go
@@ -8,7 +8,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 func bootstrapFirstUser(t *testing.T, srv *Server, email, name string) string {

--- a/internal/server/handlers_cloud.go
+++ b/internal/server/handlers_cloud.go
@@ -12,8 +12,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/xarmian/pad/internal/models"
-	"github.com/xarmian/pad/internal/store"
+	"github.com/PerpetualSoftware/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/store"
 )
 
 // validateCloudSecret checks the cloud_secret field in a JSON request body

--- a/internal/server/handlers_collections.go
+++ b/internal/server/handlers_collections.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 func (s *Server) handleListCollections(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/handlers_comments.go
+++ b/internal/server/handlers_comments.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
-	"github.com/xarmian/pad/internal/events"
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/events"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 // handleListComments returns all comments for an item.

--- a/internal/server/handlers_convention_library.go
+++ b/internal/server/handlers_convention_library.go
@@ -3,7 +3,7 @@ package server
 import (
 	"net/http"
 
-	"github.com/xarmian/pad/internal/collections"
+	"github.com/PerpetualSoftware/pad/internal/collections"
 )
 
 func (s *Server) handleConventionLibrary(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/handlers_dashboard.go
+++ b/internal/server/handlers_dashboard.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/xarmian/pad/internal/models"
-	"github.com/xarmian/pad/internal/store"
+	"github.com/PerpetualSoftware/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/store"
 )
 
 // Dashboard response types

--- a/internal/server/handlers_dashboard_test.go
+++ b/internal/server/handlers_dashboard_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 // helper: create an item in a collection and return the parsed Item

--- a/internal/server/handlers_documents.go
+++ b/internal/server/handlers_documents.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
-	"github.com/xarmian/pad/internal/events"
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/events"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 func (s *Server) handleListDocuments(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/handlers_events.go
+++ b/internal/server/handlers_events.go
@@ -9,8 +9,8 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/xarmian/pad/internal/events"
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/events"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 // handleSSE streams Server-Sent Events for a workspace.

--- a/internal/server/handlers_events_revalidation_test.go
+++ b/internal/server/handlers_events_revalidation_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 // TestSSESubscriberStillHasAccess verifies the per-tick membership

--- a/internal/server/handlers_events_test.go
+++ b/internal/server/handlers_events_test.go
@@ -13,8 +13,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/xarmian/pad/internal/events"
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/events"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 func testServerWithEvents(t *testing.T) *Server {

--- a/internal/server/handlers_grants.go
+++ b/internal/server/handlers_grants.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 // --- Collection Grant handlers ---

--- a/internal/server/handlers_item_links.go
+++ b/internal/server/handlers_item_links.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 // handleGetItemLinks returns all links (both directions) for an item.

--- a/internal/server/handlers_item_links_test.go
+++ b/internal/server/handlers_item_links_test.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 func TestCreateItemLinkAcceptsCanonicalLineageTypes(t *testing.T) {

--- a/internal/server/handlers_item_versions.go
+++ b/internal/server/handlers_item_versions.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
-	"github.com/xarmian/pad/internal/events"
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/events"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 // handleListItemVersions returns all versions for an item with diffs resolved.

--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -12,9 +12,9 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
-	"github.com/xarmian/pad/internal/events"
-	"github.com/xarmian/pad/internal/items"
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/events"
+	"github.com/PerpetualSoftware/pad/internal/items"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 // handleListItems lists all items across collections in a workspace.

--- a/internal/server/handlers_items_test.go
+++ b/internal/server/handlers_items_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 // createWSWithCollections creates a workspace and returns its slug.
@@ -730,7 +730,7 @@ func TestGetItemIncludesCodeContext(t *testing.T) {
 	var item models.Item
 	parseJSON(t, rr, &item)
 
-	fields := `{"status":"open","github_pr":{"number":40,"url":"https://github.com/xarmian/pad/pull/40","title":"Surface lineage relationships and derived closure for TASK-122","state":"MERGED","branch":"feat/task-122-lineage-display","repo":"xarmian/pad","updated_at":"2026-04-02T14:46:09Z"}}`
+	fields := `{"status":"open","github_pr":{"number":40,"url":"https://github.com/PerpetualSoftware/pad/pull/40","title":"Surface lineage relationships and derived closure for TASK-122","state":"MERGED","branch":"feat/task-122-lineage-display","repo":"PerpetualSoftware/pad","updated_at":"2026-04-02T14:46:09Z"}}`
 	updated, err := srv.store.UpdateItem(item.ID, models.ItemUpdate{Fields: &fields})
 	if err != nil {
 		t.Fatalf("update item fields: %v", err)

--- a/internal/server/handlers_members.go
+++ b/internal/server/handlers_members.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
-	"github.com/xarmian/pad/internal/email"
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/email"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 // handleListMembers returns all members of a workspace.

--- a/internal/server/handlers_playbook_library.go
+++ b/internal/server/handlers_playbook_library.go
@@ -3,7 +3,7 @@ package server
 import (
 	"net/http"
 
-	"github.com/xarmian/pad/internal/collections"
+	"github.com/PerpetualSoftware/pad/internal/collections"
 )
 
 func (s *Server) handlePlaybookLibrary(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/handlers_rbac_test.go
+++ b/internal/server/handlers_rbac_test.go
@@ -8,7 +8,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 // rbacTestEnv holds everything needed for RBAC tests:

--- a/internal/server/handlers_role_board.go
+++ b/internal/server/handlers_role_board.go
@@ -3,7 +3,7 @@ package server
 import (
 	"net/http"
 
-	"github.com/xarmian/pad/internal/store"
+	"github.com/PerpetualSoftware/pad/internal/store"
 )
 
 // handleRoleBoardReorder updates role_sort_order for items within a lane.

--- a/internal/server/handlers_search.go
+++ b/internal/server/handlers_search.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/xarmian/pad/internal/store"
+	"github.com/PerpetualSoftware/pad/internal/store"
 )
 
 // safeFieldKey matches safe JSON field keys: starts with a letter, alphanumeric/underscore/hyphen.

--- a/internal/server/handlers_share_links.go
+++ b/internal/server/handlers_share_links.go
@@ -10,8 +10,8 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/xarmian/pad/internal/models"
-	"github.com/xarmian/pad/internal/store"
+	"github.com/PerpetualSoftware/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/store"
 )
 
 // validateShareLinkOpts checks that share link creation constraints are sane.

--- a/internal/server/handlers_stars.go
+++ b/internal/server/handlers_stars.go
@@ -5,8 +5,8 @@ import (
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/xarmian/pad/internal/events"
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/events"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 // handleStarItem stars an item for the authenticated user (idempotent).

--- a/internal/server/handlers_timeline.go
+++ b/internal/server/handlers_timeline.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 // handleListItemTimeline returns a unified, chronological timeline for an item.

--- a/internal/server/handlers_tokens.go
+++ b/internal/server/handlers_tokens.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 // tokenExpiryWarningDays is the threshold for adding near-expiry warning

--- a/internal/server/handlers_unsubscribe.go
+++ b/internal/server/handlers_unsubscribe.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/xarmian/pad/internal/email"
+	"github.com/PerpetualSoftware/pad/internal/email"
 )
 
 // unsubscribeSecret derives a stable HMAC key from the Maileroo API key.

--- a/internal/server/handlers_versions.go
+++ b/internal/server/handlers_versions.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 func (s *Server) handleListVersions(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/handlers_views.go
+++ b/internal/server/handlers_views.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 // handleListViews returns all saved views for a collection.

--- a/internal/server/handlers_webhooks.go
+++ b/internal/server/handlers_webhooks.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
-	"github.com/xarmian/pad/internal/models"
-	"github.com/xarmian/pad/internal/webhooks"
+	"github.com/PerpetualSoftware/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/webhooks"
 )
 
 // dispatchWebhook fires a webhook event if a dispatcher is configured.

--- a/internal/server/handlers_workspaces.go
+++ b/internal/server/handlers_workspaces.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/xarmian/pad/internal/collections"
-	"github.com/xarmian/pad/internal/events"
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/collections"
+	"github.com/PerpetualSoftware/pad/internal/events"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 func normalizeWorkspaceInput(input *models.WorkspaceCreate) error {

--- a/internal/server/item_lineage.go
+++ b/internal/server/item_lineage.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 // enrichItemsWithParent batch-populates parent link info on a slice of items.

--- a/internal/server/metrics_auth_test.go
+++ b/internal/server/metrics_auth_test.go
@@ -6,8 +6,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/xarmian/pad/internal/metrics"
-	"github.com/xarmian/pad/internal/store"
+	"github.com/PerpetualSoftware/pad/internal/metrics"
+	"github.com/PerpetualSoftware/pad/internal/store"
 )
 
 // newMetricsTestServer builds a Server with metrics enabled and the given

--- a/internal/server/middleware_auth.go
+++ b/internal/server/middleware_auth.go
@@ -12,8 +12,8 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/xarmian/pad/internal/models"
-	"github.com/xarmian/pad/internal/store"
+	"github.com/PerpetualSoftware/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/store"
 )
 
 type contextKey string

--- a/internal/server/middleware_metrics.go
+++ b/internal/server/middleware_metrics.go
@@ -8,7 +8,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	chimiddleware "github.com/go-chi/chi/v5/middleware"
 
-	"github.com/xarmian/pad/internal/metrics"
+	"github.com/PerpetualSoftware/pad/internal/metrics"
 )
 
 // MetricsMiddleware returns a chi middleware that records Prometheus metrics

--- a/internal/server/middleware_metrics_test.go
+++ b/internal/server/middleware_metrics_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	io_prometheus_client "github.com/prometheus/client_model/go"
 
-	"github.com/xarmian/pad/internal/metrics"
+	"github.com/PerpetualSoftware/pad/internal/metrics"
 )
 
 func TestMetricsMiddleware_RecordsRequestMetrics(t *testing.T) {

--- a/internal/server/middleware_session_ip_test.go
+++ b/internal/server/middleware_session_ip_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 // doRequestWithCookieFrom is like doRequestWithCookie but lets the caller

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -20,13 +20,13 @@ import (
 	"github.com/go-chi/cors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
-	"github.com/xarmian/pad/internal/billing"
-	"github.com/xarmian/pad/internal/email"
-	"github.com/xarmian/pad/internal/events"
-	"github.com/xarmian/pad/internal/metrics"
-	"github.com/xarmian/pad/internal/models"
-	"github.com/xarmian/pad/internal/store"
-	"github.com/xarmian/pad/internal/webhooks"
+	"github.com/PerpetualSoftware/pad/internal/billing"
+	"github.com/PerpetualSoftware/pad/internal/email"
+	"github.com/PerpetualSoftware/pad/internal/events"
+	"github.com/PerpetualSoftware/pad/internal/metrics"
+	"github.com/PerpetualSoftware/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/store"
+	"github.com/PerpetualSoftware/pad/internal/webhooks"
 )
 
 type Server struct {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -9,8 +9,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/xarmian/pad/internal/models"
-	"github.com/xarmian/pad/internal/store"
+	"github.com/PerpetualSoftware/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/store"
 )
 
 func testServer(t *testing.T) *Server {
@@ -165,7 +165,7 @@ func TestWorkspaceContextAPI(t *testing.T) {
 		"name": "Contextual",
 		"context": map[string]interface{}{
 			"repositories": []map[string]string{
-				{"name": "docapp", "role": "primary", "path": ".", "repo": "xarmian/pad"},
+				{"name": "docapp", "role": "primary", "path": ".", "repo": "PerpetualSoftware/pad"},
 			},
 			"commands": map[string]string{
 				"build": "make install",

--- a/internal/store/activities.go
+++ b/internal/store/activities.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 // ActivityDebounceCooldown is the window during which repeated "updated" actions

--- a/internal/store/activities_test.go
+++ b/internal/store/activities_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 func TestCreateActivityDebounced_NonUpdateActions(t *testing.T) {

--- a/internal/store/agent_roles.go
+++ b/internal/store/agent_roles.go
@@ -6,7 +6,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 func (s *Store) CreateAgentRole(workspaceID string, input models.AgentRoleCreate) (*models.AgentRole, error) {

--- a/internal/store/api_tokens.go
+++ b/internal/store/api_tokens.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 // CreateAPIToken generates a new API token owned by a user, optionally

--- a/internal/store/api_tokens_test.go
+++ b/internal/store/api_tokens_test.go
@@ -3,7 +3,7 @@ package store
 import (
 	"testing"
 
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 func TestCreateAPITokenWithExpiry(t *testing.T) {

--- a/internal/store/bench_concurrent_test.go
+++ b/internal/store/bench_concurrent_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 // TestConcurrentWritePerformance measures how each backend handles concurrent

--- a/internal/store/collections.go
+++ b/internal/store/collections.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/xarmian/pad/internal/collections"
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/collections"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 func (s *Store) CreateCollection(workspaceID string, input models.CollectionCreate) (*models.Collection, error) {

--- a/internal/store/comments.go
+++ b/internal/store/comments.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 // CreateComment adds a new comment to an item.

--- a/internal/store/documents.go
+++ b/internal/store/documents.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/xarmian/pad/internal/diff"
-	"github.com/xarmian/pad/internal/links"
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/diff"
+	"github.com/PerpetualSoftware/pad/internal/links"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 func (s *Store) ListDocuments(workspaceID string, params models.DocumentListParams) ([]models.Document, error) {

--- a/internal/store/done_field_test.go
+++ b/internal/store/done_field_test.go
@@ -3,7 +3,7 @@ package store
 import (
 	"testing"
 
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 // TestGetItemProgress_DoneFieldFollowsBoardGroupBy verifies the core

--- a/internal/store/encryption_test.go
+++ b/internal/store/encryption_test.go
@@ -4,7 +4,7 @@ import (
 	"crypto/rand"
 	"testing"
 
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 func TestEncryptDecrypt(t *testing.T) {

--- a/internal/store/export.go
+++ b/internal/store/export.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 // ExportWorkspace exports all data for a workspace into a portable format.

--- a/internal/store/grants.go
+++ b/internal/store/grants.go
@@ -4,7 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 // --- Collection Grants ---

--- a/internal/store/invitation_test.go
+++ b/internal/store/invitation_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 // TestCreateInvitation_SetsExpiresAt verifies new invitations get an expires_at

--- a/internal/store/item_links_lineage_test.go
+++ b/internal/store/item_links_lineage_test.go
@@ -3,7 +3,7 @@ package store
 import (
 	"testing"
 
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 func TestCreateItemLinkNormalizesLineageTypes(t *testing.T) {

--- a/internal/store/item_stars.go
+++ b/internal/store/item_stars.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 // StarItem stars an item for a user. Idempotent — re-starring is a no-op.

--- a/internal/store/item_stars_test.go
+++ b/internal/store/item_stars_test.go
@@ -4,7 +4,7 @@ import (
 	"database/sql"
 	"testing"
 
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 func TestStarItem(t *testing.T) {

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/xarmian/pad/internal/diff"
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/diff"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 // childLinkTypes lists the link types that establish a parent→child relationship

--- a/internal/store/items_test.go
+++ b/internal/store/items_test.go
@@ -6,7 +6,7 @@ import (
 	"log/slog"
 	"testing"
 
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 // --- Collection helpers ---
@@ -572,7 +572,7 @@ func TestItemCodeContextIsHydratedOnRead(t *testing.T) {
 
 	item, err := s.CreateItem(ws.ID, col.ID, models.ItemCreate{
 		Title:  "Link PR",
-		Fields: `{"status":"open","github_pr":{"number":7,"url":"https://github.com/xarmian/pad/pull/7","title":"Link PR","state":"OPEN","branch":"feat/link-pr","repo":"xarmian/pad","updated_at":"2026-04-02T14:00:00Z"}}`,
+		Fields: `{"status":"open","github_pr":{"number":7,"url":"https://github.com/PerpetualSoftware/pad/pull/7","title":"Link PR","state":"OPEN","branch":"feat/link-pr","repo":"PerpetualSoftware/pad","updated_at":"2026-04-02T14:00:00Z"}}`,
 	})
 	if err != nil {
 		t.Fatalf("CreateItem error: %v", err)
@@ -600,7 +600,7 @@ func TestListItemsIncludesCodeContext(t *testing.T) {
 
 	_, err := s.CreateItem(ws.ID, col.ID, models.ItemCreate{
 		Title:  "Linked Item",
-		Fields: `{"status":"open","github_pr":{"number":9,"url":"https://github.com/xarmian/pad/pull/9","title":"Linked Item","state":"MERGED","branch":"feat/linked-item","repo":"xarmian/pad","updated_at":"2026-04-02T14:10:00Z"}}`,
+		Fields: `{"status":"open","github_pr":{"number":9,"url":"https://github.com/PerpetualSoftware/pad/pull/9","title":"Linked Item","state":"MERGED","branch":"feat/linked-item","repo":"PerpetualSoftware/pad","updated_at":"2026-04-02T14:10:00Z"}}`,
 	})
 	if err != nil {
 		t.Fatalf("CreateItem error: %v", err)

--- a/internal/store/limits.go
+++ b/internal/store/limits.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 // PlanLimits defines the limits for a billing plan tier.

--- a/internal/store/password_resets.go
+++ b/internal/store/password_resets.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 const resetTokenTTL = 1 * time.Hour

--- a/internal/store/permissions_test.go
+++ b/internal/store/permissions_test.go
@@ -3,7 +3,7 @@ package store
 import (
 	"testing"
 
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 // Phase 2 permission test suite (TASK-488).

--- a/internal/store/reactions.go
+++ b/internal/store/reactions.go
@@ -3,7 +3,7 @@ package store
 import (
 	"fmt"
 
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 // AddReaction adds an emoji reaction to a comment. Returns the created reaction,

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -5,7 +5,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 // validFieldKey matches safe JSON field keys: alphanumeric, underscores, hyphens only.

--- a/internal/store/search_quality_test.go
+++ b/internal/store/search_quality_test.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 // TestSearchQualityComparison seeds identical data into both SQLite and PostgreSQL,

--- a/internal/store/sessions.go
+++ b/internal/store/sessions.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 // SessionInfo holds the result of session validation, including the

--- a/internal/store/sessions_test.go
+++ b/internal/store/sessions_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 func TestSessionCreateAndValidate(t *testing.T) {

--- a/internal/store/share_links.go
+++ b/internal/store/share_links.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/models"
 	"golang.org/x/crypto/bcrypt"
 )
 

--- a/internal/store/snapshots.go
+++ b/internal/store/snapshots.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 // CreateSnapshot inserts a new progress snapshot.

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/google/uuid"
 	_ "github.com/jackc/pgx/v5/stdlib" // PostgreSQL driver
-	"github.com/xarmian/pad/internal/collections"
+	"github.com/PerpetualSoftware/pad/internal/collections"
 	_ "modernc.org/sqlite"
 )
 

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 // testStore creates a Store for testing. When PAD_TEST_POSTGRES_URL is set,
@@ -385,8 +385,8 @@ func TestWorkspaceSettingsHydrateStructuredContext(t *testing.T) {
 	settings, err := models.SerializeWorkspaceSettings(&models.WorkspaceSettings{
 		Context: &models.WorkspaceContext{
 			Repositories: []models.WorkspaceRepository{
-				{Name: "docapp", Role: "primary", Path: ".", Repo: "xarmian/pad"},
-				{Name: "pad-web", Role: "docs", Path: "../pad-web", Repo: "xarmian/pad-web"},
+				{Name: "docapp", Role: "primary", Path: ".", Repo: "PerpetualSoftware/pad"},
+				{Name: "pad-web", Role: "docs", Path: "../pad-web", Repo: "PerpetualSoftware/pad-web"},
 			},
 			Commands: &models.WorkspaceCommands{
 				Build: "make install",

--- a/internal/store/templates.go
+++ b/internal/store/templates.go
@@ -4,7 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 func (s *Store) ListCustomTemplates(workspaceID string) ([]models.CustomTemplate, error) {

--- a/internal/store/users.go
+++ b/internal/store/users.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/models"
 	"golang.org/x/crypto/bcrypt"
 )
 

--- a/internal/store/users_test.go
+++ b/internal/store/users_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 func createTestUser(t *testing.T, s *Store, email, name, password string) *models.User {

--- a/internal/store/versions.go
+++ b/internal/store/versions.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/xarmian/pad/internal/diff"
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/diff"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 // VersionThrottleInterval is the minimum time between version snapshots

--- a/internal/store/views.go
+++ b/internal/store/views.go
@@ -4,7 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 // CreateView adds a new saved view.

--- a/internal/store/webhooks.go
+++ b/internal/store/webhooks.go
@@ -4,7 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 // CreateWebhook registers a new webhook for a workspace.

--- a/internal/store/workspace_members.go
+++ b/internal/store/workspace_members.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 // InvitationTTL is how long a newly-created workspace invitation stays

--- a/internal/store/workspaces.go
+++ b/internal/store/workspaces.go
@@ -4,7 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 func (s *Store) ListWorkspaces() ([]models.Workspace, error) {

--- a/internal/webhooks/dispatcher.go
+++ b/internal/webhooks/dispatcher.go
@@ -10,7 +10,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 // WebhookStore is the interface the dispatcher needs to fetch webhooks

--- a/internal/webhooks/dispatcher_test.go
+++ b/internal/webhooks/dispatcher_test.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/xarmian/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
 // mockStore implements WebhookStore for testing.

--- a/skills/INSTALL.md
+++ b/skills/INSTALL.md
@@ -6,10 +6,10 @@
 
 ```bash
 # Via Homebrew
-brew install xarmian/tap/pad
+brew install PerpetualSoftware/tap/pad
 
 # Or build from source
-git clone https://github.com/xarmian/pad
+git clone https://github.com/PerpetualSoftware/pad
 cd pad && make build
 cp pad /usr/local/bin/
 ```

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -153,9 +153,9 @@
 
 <svelte:head>
 	<title>{titleStore.title}</title>
-	<meta name="description" content="Project management for developers and AI agents" />
+	<meta name="description" content="Collaborate with your AI agents" />
 	<meta property="og:title" content="Pad" />
-	<meta property="og:description" content="Project management for developers and AI agents" />
+	<meta property="og:description" content="Collaborate with your AI agents" />
 	<meta property="og:image" content="/padicon.png" />
 	<meta property="og:type" content="website" />
 </svelte:head>

--- a/web/static/manifest.json
+++ b/web/static/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Pad",
   "short_name": "Pad",
-  "description": "Project management for developers and AI agents",
+  "description": "Collaborate with your AI agents",
   "start_url": "/",
   "display": "standalone",
   "background_color": "#1a1a1a",

--- a/web/static/site.webmanifest
+++ b/web/static/site.webmanifest
@@ -1,7 +1,7 @@
 {
   "name": "Pad",
   "short_name": "Pad",
-  "description": "Project management for developers and AI agents",
+  "description": "Collaborate with your AI agents",
   "icons": [
     {
       "src": "/icon-192.png",


### PR DESCRIPTION
## Summary

- Migrates the entire repo from `xarmian/pad` → `PerpetualSoftware/pad` (Go module path, 219 import statements, test fixtures, README badges, CI/release configs, deploy manifests).
- Updates the product subtitle from *"Project management for developers and AI agents"* → *"Collaborate with your AI agents"* in the README, web manifests, and `og:description` meta.
- Brew tap → `PerpetualSoftware/tap/pad`. GHCR image → `ghcr.io/perpetualsoftware/pad` (lowercased per GHCR convention).
- Pairs with [pad-web PR](https://github.com/PerpetualSoftware/pad-web/pulls) regenerating the marketing-site OG card and updating all marketing-site URLs.

Refs: IDEA-832, TASK-844, TASK-845.

## What changed

**Go module**
- `go.mod`: `github.com/xarmian/pad` → `github.com/PerpetualSoftware/pad`
- All Go imports across `cmd/pad`, `internal/{cli,server,store,models,collections,items,events,metrics,webhooks}` (~130 files)
- Test fixtures with literal repo slugs (JSON shapes, SSH/HTTPS git URLs, workspace_context fixtures), including `xarmian/pad-web` → `PerpetualSoftware/pad-web` since pad-web also moved to the org.

**Docs / config**
- `README.md` — badges, install, brew tap, Docker run, source build, subtitle
- `CONTRIBUTING.md`, `SECURITY.md`, `skills/INSTALL.md`
- `.goreleaser.yaml` — homebrew_casks owner, GHCR image, release github owner, cosign cert-identity regex, cask description
- `.github/workflows/release.yml` — comment refs
- `deploy/k8s/deployment.yaml` — container image
- `docs/deployment.md` — clone URL
- `web/static/{site.webmanifest,manifest.json}` — description
- `web/src/routes/+layout.svelte` — meta description + og:description

**Intentionally retained as `xarmian`**
- `.github/CODEOWNERS @xarmian` — personal reviewer assignment
- `.github/FUNDING.yml github: xarmian` — personal sponsor account
- README "GitHub Sponsors" badge link

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./...` — all packages pass (incl. 70s server suite, 32s store suite)
- [x] `cd web && npm run build` — clean
- [x] `make install` — binary rebuilt, server restarted, no regressions
- [ ] CI passes on this branch
- [ ] Spot-check that the new module path resolves on `go mod tidy` from a clean cache after merge