### PR TITLE
fix(web): stop infinite recursion in marked link renderer (BUG-849)

### DIFF
--- a/web/src/lib/utils/markdown.ts
+++ b/web/src/lib/utils/markdown.ts
@@ -1,14 +1,22 @@
-import { marked, type Tokens } from 'marked';
+import { marked, Renderer, type Tokens } from 'marked';
 import DOMPurify from 'dompurify';
 import type { Item } from '$lib/types';
 import { itemUrlId } from '$lib/types';
 
-// Custom renderer to open external links in new tabs
+// Custom renderer to open external links in new tabs.
+//
+// Use a regular `function` (not an arrow) so `this` resolves to the Renderer
+// instance — marked invokes overrides via `override.apply(rendererInstance, args)`,
+// which gives us access to `this.parser.parseInline(tokens)`. We render the
+// already-parsed inline tokens; re-parsing the raw text via
+// `marked.parseInline(tokens.map(t => t.raw).join(''))` would re-tokenize bare
+// URLs in the link text as autolinks and recurse infinitely through this same
+// `link` renderer (e.g. for content like `https://example.com` inside a comment).
 const renderer = new marked.Renderer();
-renderer.link = ({ href, title, tokens }: Tokens.Link) => {
-	const text = marked.parseInline(tokens.map(t => t.raw).join(''));
+renderer.link = function (this: Renderer, { href, title, tokens }: Tokens.Link) {
+	const text = this.parser.parseInline(tokens);
 	const isExternal = href && /^https?:\/\//.test(href);
-	const titleAttr = title ? ` title="${title}"` : '';
+	const titleAttr = title ? ` title="${escapeHtml(title)}"` : '';
 	if (isExternal) {
 		return `<a href="${href}"${titleAttr} target="_blank" rel="noopener noreferrer" class="external-link">${text}<span class="external-icon" aria-hidden="true"> ↗</span></a>`;
 	}

--- a/web/src/lib/utils/markdown.ts
+++ b/web/src/lib/utils/markdown.ts
@@ -3,6 +3,22 @@ import DOMPurify from 'dompurify';
 import type { Item } from '$lib/types';
 import { itemUrlId } from '$lib/types';
 
+// Mirror of marked's internal cleanUrl() — percent-encodes the href so the
+// rendered HTML stays well-formed even when input contains spaces, quotes, or
+// other URL-unsafe characters. The %25 → % round-trip avoids double-encoding
+// hrefs that already contain percent-encoded bytes (e.g. `%20`). Returns null
+// when encodeURI throws on a malformed surrogate, matching marked's default
+// behavior of degrading to plain text rather than emitting a broken anchor.
+// DOMPurify still has the final say on URL safety; this is defense-in-depth
+// plus correctness for the intermediate HTML.
+function cleanUrl(href: string): string | null {
+	try {
+		return encodeURI(href).replace(/%25/g, '%');
+	} catch {
+		return null;
+	}
+}
+
 // Custom renderer to open external links in new tabs.
 //
 // Use a regular `function` (not an arrow) so `this` resolves to the Renderer
@@ -15,12 +31,18 @@ import { itemUrlId } from '$lib/types';
 const renderer = new marked.Renderer();
 renderer.link = function (this: Renderer, { href, title, tokens }: Tokens.Link) {
 	const text = this.parser.parseInline(tokens);
-	const isExternal = href && /^https?:\/\//.test(href);
+	const cleanHref = cleanUrl(href);
+	if (cleanHref === null) {
+		// encodeURI failed (malformed surrogate). Drop the link and emit just
+		// the parsed link text — same fallback marked's default renderer uses.
+		return text;
+	}
+	const isExternal = /^https?:\/\//.test(cleanHref);
 	const titleAttr = title ? ` title="${escapeHtml(title)}"` : '';
 	if (isExternal) {
-		return `<a href="${href}"${titleAttr} target="_blank" rel="noopener noreferrer" class="external-link">${text}<span class="external-icon" aria-hidden="true"> ↗</span></a>`;
+		return `<a href="${cleanHref}"${titleAttr} target="_blank" rel="noopener noreferrer" class="external-link">${text}<span class="external-icon" aria-hidden="true"> ↗</span></a>`;
 	}
-	return `<a href="${href}"${titleAttr}>${text}</a>`;
+	return `<a href="${cleanHref}"${titleAttr}>${text}</a>`;
 };
 
 marked.use({ renderer });


### PR DESCRIPTION
## Summary

- Fixes [BUG-849](http://localhost:7777/dave/docapp/bugs/markdown-renderer-infinite-recursion-on-autolinks-urls-inside-comments-crash-item-view): item pages with a bare URL in their content or comments crashed marked's renderer, flooding the browser console with `Please report this to https://github.com/markedjs/marked` and rendering the page as fallback/blank.
- Root cause: the custom `link` renderer called `marked.parseInline(tokens.map(t => t.raw).join(''))` to render link text. For autolinks the raw text is the URL itself, so `parseInline` re-tokenized it as another autolink → re-invoked the same custom renderer → infinite recursion.
- Fix: use marked's intended renderer API — `this.parser.parseInline(tokens)` against the **already-parsed** inline tokens. No re-tokenization, no recursion.

## Changes

- `web/src/lib/utils/markdown.ts`
  - Render link text via `this.parser.parseInline(tokens)` instead of `marked.parseInline(tokens.map(t => t.raw).join(''))`.
  - Switch the `link` override from arrow → regular `function` so `this` binds to the Renderer instance (marked invokes overrides via `override.apply(rendererInstance, args)`).
  - Add `Renderer` import for the `this: Renderer` type annotation.
  - Escape the `title` attribute via `escapeHtml()` at the source (DOMPurify catches it after the fact, but this matches marked's default renderer and avoids relying on the sanitizer for valid intermediate HTML).

## Repro

Triggering page during the bug report: `/dave/docapp/human-tasks/deploy-pad-web-stage-1-to-vercel-at-getpad-dev` (HT-786) — the failure was triggered by a comment containing `https://manage.maileroo.app`.

Minimal repro confirms the diagnosis: with the old renderer, `marked('Visit https://example.com')` throws `Maximum call stack size exceeded`. With the fix it renders correctly.

## Test plan

- [x] Repro script: bare URL in content with old renderer crashes; with fix renders cleanly
- [x] Verified `[**bold**](https://example.com)` still renders inline formatting (`**bold**`) inside link text
- [x] Verified internal links (`[click](/foo/bar)`) still render without the external-link decoration
- [x] Verified mixed content (autolink + explicit markdown link in same paragraph) renders both correctly
- [x] `npx tsc --noEmit` clean for `markdown.ts`
- [x] `npm run build` succeeds
- [x] `make install` succeeds, server restarts cleanly
- [ ] Manual: load `/dave/docapp/human-tasks/deploy-pad-web-stage-1-to-vercel-at-getpad-dev` in browser and confirm clean render + no console errors