### PR TITLE
fix: drain ipRateLimiter cleanup goroutines + bump -race timeout (BUG-851)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,11 @@ jobs:
 
       - name: Run tests with race detector
         if: github.ref == 'refs/heads/main'
-        run: go test -race ./...
+        # Default 10m is tight: the full server-package suite under -race
+        # measures ~13m locally on a developer laptop after BUG-851 (the
+        # ipRateLimiter goroutine drain) — 20m gives margin for the
+        # GitHub-hosted runner without papering over an actual hang.
+        run: go test -race -timeout=20m ./...
 
       - name: Build binary
         run: go build -o pad ./cmd/pad
@@ -113,7 +117,9 @@ jobs:
         if: github.ref == 'refs/heads/main'
         env:
           PAD_TEST_POSTGRES_URL: "postgres://pad:pad@localhost:5432/pad?sslmode=disable"
-        run: go test -race ./... -count=1
+        # See SQLite race-detector step: 20m headroom over the default 10m
+        # because the full suite under -race exceeds 10m post-BUG-851 fix.
+        run: go test -race -timeout=20m ./... -count=1
 
   web:
     name: Web

--- a/internal/server/middleware_ratelimit.go
+++ b/internal/server/middleware_ratelimit.go
@@ -36,6 +36,15 @@ type ipRateLimiter struct {
 	limiters  map[string]*rateLimiterEntry
 	config    rateLimitConfig
 	retention time.Duration
+
+	// stopCh / stopOnce / stopWg let Server.Stop() shut the cleanup
+	// goroutine down. Without this, every call to NewRateLimiters spawned
+	// 9 forever-sleeping goroutines that never exited — under -race the
+	// accumulation pushed the test runtime past the 10-minute timeout.
+	// See BUG-851.
+	stopCh   chan struct{}
+	stopOnce sync.Once
+	stopWg   sync.WaitGroup
 }
 
 type rateLimiterEntry struct {
@@ -52,10 +61,24 @@ func newIPRateLimiter(cfg rateLimitConfig) *ipRateLimiter {
 		limiters:  make(map[string]*rateLimiterEntry),
 		config:    cfg,
 		retention: retention,
+		stopCh:    make(chan struct{}),
 	}
-	// Background cleanup of stale entries every 5 minutes
+	// Background cleanup of stale entries every 5 minutes. Tracked via
+	// stopWg so Stop() can drain it before the surrounding Server is torn
+	// down (BUG-851).
+	rl.stopWg.Add(1)
 	go rl.cleanup()
 	return rl
+}
+
+// Stop signals the cleanup goroutine to exit and blocks until it does.
+// Safe to call multiple times — stopOnce guards the channel close.
+func (rl *ipRateLimiter) Stop() {
+	if rl == nil {
+		return
+	}
+	rl.stopOnce.Do(func() { close(rl.stopCh) })
+	rl.stopWg.Wait()
 }
 
 func (rl *ipRateLimiter) getLimiter(key string) *rate.Limiter {
@@ -76,15 +99,22 @@ func (rl *ipRateLimiter) getLimiter(key string) *rate.Limiter {
 }
 
 func (rl *ipRateLimiter) cleanup() {
+	defer rl.stopWg.Done()
+	ticker := time.NewTicker(5 * time.Minute)
+	defer ticker.Stop()
 	for {
-		time.Sleep(5 * time.Minute)
-		rl.mu.Lock()
-		for key, entry := range rl.limiters {
-			if time.Since(entry.lastSeen) > rl.retention {
-				delete(rl.limiters, key)
+		select {
+		case <-rl.stopCh:
+			return
+		case <-ticker.C:
+			rl.mu.Lock()
+			for key, entry := range rl.limiters {
+				if time.Since(entry.lastSeen) > rl.retention {
+					delete(rl.limiters, key)
+				}
 			}
+			rl.mu.Unlock()
 		}
-		rl.mu.Unlock()
 	}
 }
 
@@ -180,6 +210,29 @@ func NewRateLimiters() *RateLimiters {
 			Rate:  rate.Limit(6.0 / 3600.0),
 			Burst: 6,
 		}),
+	}
+}
+
+// Stop drains the cleanup goroutine of every limiter in the bundle. Called
+// from Server.Stop() so test cleanup (and graceful shutdown) doesn't leak
+// the 9 forever-sleeping goroutines NewRateLimiters spawns. Safe to call
+// on a nil receiver and idempotent per-limiter via stopOnce. See BUG-851.
+func (rls *RateLimiters) Stop() {
+	if rls == nil {
+		return
+	}
+	for _, rl := range []*ipRateLimiter{
+		rls.Auth,
+		rls.AuthEmail,
+		rls.PasswordReset,
+		rls.Register,
+		rls.OAuthLogin,
+		rls.CloudAdmin,
+		rls.API,
+		rls.Search,
+		rls.RecoveryCode,
+	} {
+		rl.Stop() // nil-safe via the receiver guard in (*ipRateLimiter).Stop
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -78,12 +78,14 @@ func (s *Server) goAsync(fn func()) {
 	}()
 }
 
-// Stop waits for all background goroutines started via goAsync to finish.
-// Safe to call multiple times. Should be called before Store.Close() so
-// in-flight DB writes don't race a closed connection (or worse, the
-// SQLite -wal/-shm file removal in t.TempDir cleanup).
+// Stop waits for all background goroutines started via goAsync to finish
+// AND drains the rate-limiter cleanup goroutines spawned at construction
+// time (BUG-851). Safe to call multiple times. Should be called before
+// Store.Close() so in-flight DB writes don't race a closed connection
+// (or worse, the SQLite -wal/-shm file removal in t.TempDir cleanup).
 func (s *Server) Stop() {
 	s.bg.Wait()
+	s.rateLimiters.Stop() // nil-safe via the RateLimiters receiver guard
 }
 
 func New(s *store.Store) *Server {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"runtime"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -398,6 +399,61 @@ func TestActivityEndpoints(t *testing.T) {
 	rr = doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/documents/"+doc.ID+"/activity", nil)
 	if rr.Code != http.StatusOK {
 		t.Fatalf("doc activity: expected 200, got %d", rr.Code)
+	}
+}
+
+// TestServer_Stop_DrainsRateLimiterCleanup pins BUG-851: NewRateLimiters
+// spawns 9 cleanup goroutines (one per ipRateLimiter), each in a
+// 5-minute Sleep loop. Without explicit drain on Stop(), these leak
+// across every testServer lifecycle and (under -race) push the
+// internal/server suite past the 10-minute test timeout — see the
+// goroutine dump in BUG-851.
+//
+// This test exercises N construct-then-Stop cycles and asserts that the
+// number of live goroutines settles back to baseline. We allow a small
+// tolerance for the test runtime's own bookkeeping goroutines.
+func TestServer_Stop_DrainsRateLimiterCleanup(t *testing.T) {
+	// Let any prior test scheduler activity quiesce so the baseline
+	// reading is meaningful. Two short waits + a GC pass — anything
+	// stronger and the test becomes its own flake.
+	settle := func() {
+		runtime.GC()
+		time.Sleep(20 * time.Millisecond)
+		runtime.GC()
+	}
+	settle()
+	baseline := runtime.NumGoroutine()
+
+	const cycles = 5
+	for i := 0; i < cycles; i++ {
+		// Use the bare New(s) constructor (not testServer) so we control
+		// when Stop runs and don't entangle with t.Cleanup ordering.
+		dir := t.TempDir()
+		s, err := store.New(filepath.Join(dir, "test.db"))
+		if err != nil {
+			t.Fatalf("store.New: %v", err)
+		}
+		srv := New(s)
+
+		// Each NewRateLimiters spawns 9 cleanup goroutines.
+		if got := runtime.NumGoroutine(); got < baseline+9 {
+			t.Fatalf("cycle %d: expected at least baseline+9 goroutines after New(), got %d (baseline %d)",
+				i, got, baseline)
+		}
+
+		srv.Stop()
+		s.Close()
+	}
+
+	settle()
+	final := runtime.NumGoroutine()
+
+	// Allow ±3 for Go runtime/test-framework noise (timer wheels,
+	// finalizers, etc.). A leak of 9 per cycle would put us at
+	// baseline + 9*5 = baseline + 45 — comfortably outside the tolerance.
+	if final > baseline+3 {
+		t.Errorf("goroutine leak: baseline=%d, after %d Stop cycles=%d (delta %d > 3)",
+			baseline, cycles, final, final-baseline)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes [BUG-851](https://github.com/PerpetualSoftware/pad/issues?q=BUG-851) / TASK-852: the `Run tests with race detector` step has been failing on every main run since 2026-04-13 because `NewRateLimiters` spawned 9 forever-sleeping goroutines per `Server`, leaked across every `testServer(t)` lifecycle. The accumulated goroutine count + race-detector sync overhead pushed the suite past the default 10-minute timeout.

This was the same flavor as BUG-842 part 2 (request-handler fire-and-forget goroutines drained via `Server.bg`), but for constructor-time goroutines — out of scope for that PR. Surfaced once #275 cleared the gofmt + FTS gates that had been masking it.

## Changes

- **`internal/server/middleware_ratelimit.go`** — `ipRateLimiter` gets `stopCh` + `stopOnce` + `stopWg`. `cleanup()` rewrites its `time.Sleep` loop as a `select` over `stopCh` + a 5-minute ticker, deferring `stopWg.Done()`. New `Stop()` closes `stopCh` once and waits for cleanup to return. New `(*RateLimiters).Stop()` walks all 9 limiters (nil-safe per receiver).
- **`internal/server/server.go`** — `Server.Stop()` now calls `s.rateLimiters.Stop()` after `s.bg.Wait()`. Test cleanups already call `Server.Stop()` (added in BUG-842), so no helper changes needed.
- **`internal/server/server_test.go`** — new `TestServer_Stop_DrainsRateLimiterCleanup` constructs N servers, calls `Stop()` on each, asserts `runtime.NumGoroutine()` returns to baseline ±3.
- **`.github/workflows/ci.yml`** — bump the `-race` timeout on both Go and Go (PostgreSQL) jobs from the default 10m to 20m. The full server suite under `-race` measures ~13m locally after the leak fix; 20m gives margin without papering over a real hang.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `gofmt -l ./cmd ./internal` clean
- [x] `go test ./...` (SQLite) green
- [x] `go test -race -timeout=1500s ./internal/server/` finishes ok in **776s (12m57s)** locally — without the fix it times out at 600s with hundreds of leaked `ipRateLimiter.cleanup` goroutines in the dump
- [x] `go test -run 'TestServer_Stop_DrainsRateLimiterCleanup' ./internal/server/` passes (regression test)
- [ ] CI: confirm `Go` race-detector step goes green on main post-merge (PR-stage CI doesn't run `-race`, so the acceptance signal is the post-merge main run)

## Acceptance (from BUG-851)

- `Run tests with race detector` and `Run tests with race detector against PostgreSQL` go green on a fresh main run.
- `go test -race ./internal/server/` finishes well under the (now 20m) timeout.
- No goroutine leak across server lifecycles (regression test).

## Related

- BUG-842 + TASK-850 + PR #275 — the parent class of bug; fixed request-handler fire-and-forget. This PR finishes the job for constructor-time goroutines.