### PR TITLE
fix: bump SQLite busy_timeout from 5s to 30s (BUG-853)

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -38,10 +38,22 @@ func (s *Store) DB() *sql.DB { return s.db }
 //
 // The DSN is configured for safe concurrent use under Go's connection pool:
 //
-//   - `_pragma=busy_timeout(5000)`: when a connection finds the database
-//     locked, retry for up to 5 seconds before returning SQLITE_BUSY. The
-//     pragma is applied per-connection by the driver, so every pool member
-//     inherits it.
+//   - `_pragma=busy_timeout(30000)`: when a connection finds the database
+//     locked, retry for up to 30 seconds before returning SQLITE_BUSY.
+//     The pragma is applied per-connection by the driver, so every pool
+//     member inherits it.
+//
+//     30s is much larger than the millisecond-scale p95 we observe under
+//     normal load — the slack is there to absorb shared-runner jitter
+//     under heavy CI contention. With the previous 5s value,
+//     TestSQLiteConcurrentWritersNoBusy (25 writers × 5 ops, all
+//     contending for BEGIN IMMEDIATE) intermittently failed on the
+//     GitHub-hosted SQLite job: the cumulative wall-time of 125
+//     serialized inserts on a slow runner can exceed 5s, leaving the
+//     unluckiest writer to time out. See BUG-853. Genuine deadlocks
+//     don't happen with WAL + BEGIN IMMEDIATE, so the only thing the
+//     larger value costs is "how long we wait before declaring lock
+//     contention pathological"; for Pad's workload, 30s is fine.
 //
 //   - `_pragma=foreign_keys(on)`: foreign-key enforcement is per-connection
 //     in SQLite. Setting it via the DSN guarantees ALL pool members enforce
@@ -87,7 +99,7 @@ func (s *Store) DB() *sql.DB { return s.db }
 //     setting (stored in the file header), so it persists across
 //     connections after the first one applies it.
 func New(dbPath string) (*Store, error) {
-	dsn := dbPath + "?_pragma=busy_timeout(5000)&_pragma=foreign_keys(on)&_txlock=immediate"
+	dsn := dbPath + "?_pragma=busy_timeout(30000)&_pragma=foreign_keys(on)&_txlock=immediate"
 	db, err := sql.Open("sqlite", dsn)
 	if err != nil {
 		return nil, fmt.Errorf("open database: %w", err)


### PR DESCRIPTION
## Summary

Fixes [BUG-853](https://github.com/PerpetualSoftware/pad/issues?q=BUG-853) / TASK-854: `TestSQLiteConcurrentWritersNoBusy` intermittently fails on the `Go` (SQLite) CI job with `database is locked (5) (SQLITE_BUSY)` under 25 concurrent writers × 5 ops. Cause: the DSN's `busy_timeout=5000` (5s) is tight enough that on a slow shared runner with sibling-test contention, 125 serialized inserts add up beyond the timeout for the unluckiest writer.

This was masked by BUG-851 (the rate-limiter goroutine leak) until #276 landed; surfaced on the post-merge main run https://github.com/PerpetualSoftware/pad/actions/runs/25078285191.

## Change

One-character DSN bump in `internal/store/store.go` plus an updated doc comment:

```diff
-    dsn := dbPath + "?_pragma=busy_timeout(5000)&_pragma=foreign_keys(on)&_txlock=immediate"
+    dsn := dbPath + "?_pragma=busy_timeout(30000)&_pragma=foreign_keys(on)&_txlock=immediate"
```

30s is ~6× the worst observed CI run, ~50× the normal local p95. Genuine deadlocks don't happen with WAL + BEGIN IMMEDIATE, so the only cost is "how long before declaring lock contention pathological" — for Pad's workload, fine.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `gofmt -l ./cmd ./internal` clean
- [x] `go test -count=20 -run TestSQLiteConcurrentWritersNoBusy ./internal/store/` → 20/20 green (6.1s)
- [x] `go test ./...` (full SQLite suite) green
- [ ] Post-merge: confirm `Run tests` (SQLite) goes green on main, and the previously-skipped `Run tests with race detector` step gets to run AND passes — completing the cleanup BUG-851 started.

## Acceptance (from BUG-853)

- `Go` (SQLite) job's `Run tests` step goes green on a fresh main run.
- The downstream race-detector step (gated to main) finally runs and passes.

## Out of scope (filed-or-fileable as follow-ups if needed)

- `db.SetMaxOpenConns(1)` for SQLite — would structurally eliminate BUSY but sacrifices WAL's concurrent-reader benefit. Not warranted while busy_timeout suffices.
- Application-level BUSY retry around `CreateItem`. Defense-in-depth; file a follow-up if BUSY ever recurs after this fix.

## Related

- BUG-851 / PR #276 — the rate-limiter goroutine drain that was masking this; fixing #276 made #853 visible.
- BUG-842 / PR #275 — the FTS + cleanup-race fix that came before #276.