### PR TITLE
feat(auth): link to /console from CLI auth success state (TASK-856)

### DIFF
--- a/web/src/routes/auth/cli/[code]/+page.svelte
+++ b/web/src/routes/auth/cli/[code]/+page.svelte
@@ -171,6 +171,7 @@
 		{:else if status === 'success'}
 			<p class="subtitle">Authorized</p>
 			<p class="success-message">CLI session authorized. You can close this tab.</p>
+			<a href="/console" class="primary-link">Go to your workspaces</a>
 		{/if}
 	</div>
 </div>
@@ -257,6 +258,27 @@
 	button:disabled {
 		opacity: 0.6;
 		cursor: not-allowed;
+	}
+
+	.primary-link {
+		display: block;
+		width: 100%;
+		padding: var(--space-3) var(--space-4);
+		margin-top: var(--space-4);
+		background: var(--accent-blue);
+		color: #fff;
+		border: none;
+		border-radius: var(--radius);
+		font-size: 0.95rem;
+		font-weight: 500;
+		font-family: var(--font-ui);
+		text-align: center;
+		text-decoration: none;
+		transition: opacity 0.15s;
+	}
+
+	.primary-link:hover {
+		opacity: 0.9;
 	}
 
 	.account-chip {


### PR DESCRIPTION
## Summary

After approving a CLI session at `/auth/cli/{code}`, the success state previously dead-ended with "you can close this tab" and no link out. This PR adds a primary "Go to your workspaces" CTA linking to `/console`.

`/console` is the natural destination — it's already where `/` redirects, where pad-cloud's OAuth flow lands users post-login (`oauth.go:273`, `:506`), and it lists owned + shared workspaces. Universal across self-hosted, Docker, Remote, and Pad Cloud (which proxies `/auth/cli/` to the upstream pad backend via nginx, so no pad-cloud change is needed).

The existing "you can close this tab" line stays — some users (CI runs, headless approvals, teammate's laptop) genuinely just want to close the tab.

## Context

Implements [`TASK-856`](https://app.getpad.dev) under `PLAN-833` (pad init UX gaps + Pad Cloud onboarding fixes). Sibling [`TASK-836`](https://app.getpad.dev) added the account chip + switch-accounts link to the `pending` state of the same file; this completes the pair on the `success` state.

Source idea: `IDEA-848`.

## Change

`web/src/routes/auth/cli/[code]/+page.svelte` — `status === 'success'` block:

```diff
 {:else if status === 'success'}
     <p class="subtitle">Authorized</p>
     <p class="success-message">CLI session authorized. You can close this tab.</p>
+    <a href="/console" class="primary-link">Go to your workspaces</a>
 {/if}
```

Plus a new `.primary-link` style block matching the existing primary `button` rule (same accent-blue, padding, radius, font, full width) but anchor-appropriate (`display: block`, `text-align: center`, `text-decoration: none`).

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./...` — all packages pass
- [x] `cd web && npm run build` — clean (15.24s)
- [x] `svelte-autofixer` — no issues
- [ ] Manual: approve a CLI session locally → verify the "Go to your workspaces" CTA appears below the success message and navigates to `/console`