### PR TITLE
fix(web/editor): copy from table puts plain text only on clipboard (TASK-858)

### DIFF
--- a/web/src/lib/components/editor/Editor.svelte
+++ b/web/src/lib/components/editor/Editor.svelte
@@ -7,6 +7,7 @@
 	import TaskList from '@tiptap/extension-task-list';
 	import TaskItem from '@tiptap/extension-task-item';
 	import { Table, TableRow, TableCell, TableHeader } from '@tiptap/extension-table';
+	import { CellSelection } from '@tiptap/pm/tables';
 	import Link from '@tiptap/extension-link';
 	import CodeBlock from '@tiptap/extension-code-block';
 	import Placeholder from '@tiptap/extension-placeholder';
@@ -110,6 +111,76 @@
 		event.preventDefault();
 		event.clipboardData.setData('text/plain', text);
 		// Clearing HTML prevents tiptap-markdown from re-decorating the paste target.
+		event.clipboardData.setData('text/html', '');
+
+		if (isCut) {
+			const tr = state.tr.delete(from, to);
+			view.dispatch(tr);
+		}
+		return true;
+	}
+
+	// ProseMirror plugin: when the user copies/cuts a selection that lives
+	// entirely inside a single table, write a plain-text representation of
+	// the cells (tab-separated, newline-separated rows) to the clipboard
+	// and clear text/html, so paste targets don't receive the wrapping
+	// <table> markup. Mirrors codeBlockCopyPlugin above.
+	const tableCopyPlugin = new Plugin({
+		props: {
+			handleDOMEvents: {
+				copy: (view, event) => writeTableClipboard(view, event as ClipboardEvent, false),
+				cut: (view, event) => writeTableClipboard(view, event as ClipboardEvent, true),
+			},
+		},
+	});
+
+	function writeTableClipboard(view: any, event: ClipboardEvent, isCut: boolean): boolean {
+		const { state } = view;
+		const selection = state.selection;
+		const { from, to, empty } = selection;
+		if (empty) return false;
+		if (!event.clipboardData) return false;
+
+		let text: string | null = null;
+
+		if (selection instanceof CellSelection) {
+			// Multi-cell selection — iterate cells, group by row, build TSV.
+			const rows: string[][] = [];
+			let currentRow: string[] = [];
+			let prevRow: any = null;
+			selection.forEachCell((cellNode: any, cellPos: number) => {
+				const resolvedCellPos = state.doc.resolve(cellPos);
+				const row = resolvedCellPos.parent;
+				if (row !== prevRow) {
+					if (currentRow.length) rows.push(currentRow);
+					currentRow = [];
+					prevRow = row;
+				}
+				currentRow.push((cellNode.textContent ?? '').replace(/\s+$/g, ''));
+			});
+			if (currentRow.length) rows.push(currentRow);
+			text = rows.map(r => r.join('\t')).join('\n');
+		} else {
+			// Plain text selection — must be entirely inside a single table.
+			const resolvedFrom = state.doc.resolve(from);
+			let tableDepth = -1;
+			for (let d = resolvedFrom.depth; d >= 0; d--) {
+				if (resolvedFrom.node(d).type.name === 'table') {
+					tableDepth = d;
+					break;
+				}
+			}
+			if (tableDepth < 0) return false;
+			const tableStart = resolvedFrom.start(tableDepth);
+			const tableEnd = resolvedFrom.end(tableDepth);
+			if (from < tableStart || to > tableEnd) return false;
+			text = state.doc.textBetween(from, to, '\n', ' ');
+		}
+
+		if (text === null) return false;
+
+		event.preventDefault();
+		event.clipboardData.setData('text/plain', text);
 		event.clipboardData.setData('text/html', '');
 
 		if (isCut) {
@@ -360,7 +431,7 @@
 			}),
 			TaskList,
 			TaskItem.configure({ nested: true }),
-			Table.configure({ resizable: true, HTMLAttributes: { class: 'table-wrapper' } }),
+			Table.extend({ addProseMirrorPlugins() { return [tableCopyPlugin]; } }).configure({ resizable: true, HTMLAttributes: { class: 'table-wrapper' } }),
 			TableRow,
 			TableCell,
 			TableHeader,

--- a/web/src/lib/components/editor/Editor.svelte
+++ b/web/src/lib/components/editor/Editor.svelte
@@ -184,7 +184,7 @@
 		event.clipboardData.setData('text/html', '');
 
 		if (isCut) {
-			const tr = state.tr.delete(from, to);
+			const tr = state.tr.deleteSelection();
 			view.dispatch(tr);
 		}
 		return true;
@@ -431,7 +431,11 @@
 			}),
 			TaskList,
 			TaskItem.configure({ nested: true }),
-			Table.extend({ addProseMirrorPlugins() { return [tableCopyPlugin]; } }).configure({ resizable: true, HTMLAttributes: { class: 'table-wrapper' } }),
+			Table.extend({
+				addProseMirrorPlugins() {
+					return [...(this.parent?.() ?? []), tableCopyPlugin];
+				},
+			}).configure({ resizable: true, HTMLAttributes: { class: 'table-wrapper' } }),
 			TableRow,
 			TableCell,
 			TableHeader,


### PR DESCRIPTION
## Summary

ProseMirror's default copy serialization for selections inside a table included the wrapping `<table>...</table>` in the clipboard's `text/html` payload. Pasting into rich-text apps (or anywhere that reads HTML first) reproduced the table styling when the user just wanted the cell text.

Adds a `tableCopyPlugin` mirroring the existing `codeBlockCopyPlugin` pattern: when the selection lives entirely inside a table, write a plain-text representation to `text/plain` and clear `text/html`. Cut also deletes the range, same as the code-block plugin.

Fixes [BUG-855](#) via [TASK-858](#).

## Behavior

- **Text selection inside a single cell** → cell text on `text/plain`.
- **`CellSelection` (multi-cell drag)** → tab between cells, newline between rows. Pastes correctly into Excel / Google Sheets / Numbers.
- **Selection that spans into or out of the table** → falls through to default behavior.
- **Cut** → writes the same plain text and deletes the range, mirroring `writeCodeBlockClipboard`.

## Trade-off (accepted)

Re-pasting a multi-cell copy back into our own editor yields tab-separated text, not a reconstructed table. This matches Linear / Notion / Slack and is the right call for the most common copy-out-of-table use case.

## Test plan

- [x] `go build ./... && go vet ./... && go test ./...` — green
- [x] `cd web && npm run build` — green
- [x] `svelte-autofixer` — clean (caught and fixed a `$cellPos` reserved-identifier issue during dev)
- [ ] Insert a table, type "hello" in a cell, select "hello", copy, paste into terminal/plain-text field → see only `hello`
- [ ] Same paste into a rich-text app → no `<table>` styling
- [ ] Drag-select a 2x2 region → copy → paste into a spreadsheet → cells land in correct rows/cols
- [ ] Cut single-cell text → cell empties, plain text on clipboard
- [ ] Selection from outside table that extends into the table → default behavior preserved
- [ ] Regression: code-block copy (pre-existing `codeBlockCopyPlugin`) still works
- [ ] Regression: ordinary paragraph copy outside any table still works