### PR TITLE
feat(cli): pad init --url X --workspace <slug> as web-first cold-start (TASK-860)

### DIFF
--- a/cmd/pad/init.go
+++ b/cmd/pad/init.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -100,6 +101,19 @@ Examples:
 				fmt.Println()
 				fmt.Println()
 				actioned = true
+			} else if urlFlag != "" && !cfg.LoadedFromFile {
+				// Cold-start shortcut: `pad init --url <server>` on a fresh
+				// machine. The flag override made IsConfigured() true, but
+				// nothing is persisted yet — so without saving, every
+				// subsequent command would also need --url. Persist now so
+				// this is a true one-shot configure.
+				if err := cfg.Save(); err != nil {
+					return fmt.Errorf("save config: %w", err)
+				}
+				green.Print("✓ ")
+				fmt.Printf("Configured: %s mode (%s)\n", cfg.Mode, cfg.BaseURL())
+				fmt.Println()
+				actioned = true
 			}
 
 			// ── Step 2: Ensure server is running ──────────────────────
@@ -191,7 +205,14 @@ Examples:
 				wsName = filepath.Base(cwd)
 			}
 
-			ws, newlyCreated, err := ensureWorkspace(client, cfg, cwd, wsName, templateFlag)
+			// When both a positional name and --workspace <slug> are passed,
+			// the slug wins (it unambiguously identifies an existing workspace
+			// on the server). Warn the user so the silent override is visible.
+			if workspaceFlag != "" && len(args) > 0 {
+				fmt.Fprintf(os.Stderr, "Note: --workspace %q overrides positional name %q.\n", workspaceFlag, args[0])
+			}
+
+			ws, newlyCreated, err := ensureWorkspace(client, cfg, cwd, wsName, workspaceFlag, templateFlag)
 			if err != nil {
 				return err
 			}
@@ -225,19 +246,67 @@ Examples:
 // ensureWorkspace checks if the current directory is linked to a workspace.
 // If not, it creates or links one. Returns the workspace, whether it was newly
 // created, and any error.
-func ensureWorkspace(client *cli.Client, cfg *config.Config, cwd, name, templateFlag string) (*models.Workspace, bool, error) {
+//
+// When wsSlug is non-empty, the caller has explicitly identified a workspace
+// by slug (typically `pad init --workspace <slug>`). In that mode we will
+// ONLY attach to a workspace with that exact slug — never silently fall
+// through to "create a new workspace named after the slug." This is the
+// keystone behavior for the web-first onboarding flow (IDEA-750/PLAN-859).
+func ensureWorkspace(client *cli.Client, cfg *config.Config, cwd, name, wsSlug, templateFlag string) (*models.Workspace, bool, error) {
 	green := color.New(color.FgGreen)
 	bold := color.New(color.Bold)
 	dim := color.New(color.Faint)
 
-	// Check if already linked
-	existingSlug, err := cli.DetectWorkspace("")
-	if err == nil {
+	// Always check for an existing CWD link first — never blindly clobber.
+	existingSlug, _ := cli.DetectWorkspace("")
+
+	// ── Slug-driven path ──────────────────────────────────────
+	// Caller said "use this exact workspace by slug." Look it up; never
+	// create. Refuse to relink a directory already pinned to a different
+	// workspace.
+	if wsSlug != "" {
+		if existingSlug != "" && existingSlug != wsSlug {
+			return nil, false, fmt.Errorf(
+				"this directory is already linked to workspace %q; refusing to relink to %q.\n"+
+					"Remove or edit the existing .pad.toml, or run from a different directory",
+				existingSlug, wsSlug)
+		}
+
+		ws, err := client.GetWorkspace(wsSlug)
+		if err != nil {
+			var apiErr *cli.APIError
+			if errors.As(err, &apiErr) && apiErr.Code == "not_found" {
+				return nil, false, fmt.Errorf(
+					"workspace %q not found on %s.\n"+
+						"Check the slug, or run 'pad workspace list' to see available workspaces",
+					wsSlug, cfg.BaseURL())
+			}
+			return nil, false, fmt.Errorf(
+				"look up workspace %q on %s: %w", wsSlug, cfg.BaseURL(), err)
+		}
+
+		// Already linked to this exact slug — idempotent, no-op.
+		if existingSlug == wsSlug {
+			return ws, false, nil
+		}
+
+		if err := cli.WriteWorkspaceLink(cwd, ws.Slug); err != nil {
+			return nil, false, fmt.Errorf("write .pad.toml: %w", err)
+		}
+		green.Print("✓ ")
+		fmt.Printf("Linked to existing workspace %s %s\n",
+			bold.Sprint(ws.Name),
+			dim.Sprintf("(slug: %s)", ws.Slug))
+		return ws, false, nil
+	}
+
+	// ── Name-driven path (legacy interactive behavior) ────────
+	if existingSlug != "" {
 		ws, err := client.GetWorkspace(existingSlug)
 		if err == nil && ws != nil {
 			return ws, false, nil
 		}
-		// Linked but workspace doesn't exist on server — fall through to create/link
+		// Linked but workspace doesn't exist on server — fall through to create/link.
 	}
 
 	// Check if a workspace with this name already exists

--- a/cmd/pad/init_test.go
+++ b/cmd/pad/init_test.go
@@ -1,0 +1,250 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/cli"
+	"github.com/PerpetualSoftware/pad/internal/config"
+)
+
+// setupEnsureWorkspaceTest produces a clean tempdir, points HOME at a tempdir
+// (so credential/config writes don't leak), chdirs into the project so
+// cli.DetectWorkspace can't walk up into the real repo's .pad.toml, and
+// returns the project path.
+func setupEnsureWorkspaceTest(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	project := t.TempDir()
+	prev, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(project); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(prev) })
+	return project
+}
+
+// remoteCfg builds a Config wired to point at the given test server URL.
+func remoteCfg(url string) *config.Config {
+	cfg := config.DefaultConfig()
+	cfg.Mode = config.ModeRemote
+	cfg.URL = url
+	cfg.LoadedFromFile = true
+	return cfg
+}
+
+// TestEnsureWorkspaceSlugAttachExisting: --workspace <slug> on a fresh dir
+// links to the existing workspace and writes .pad.toml.
+func TestEnsureWorkspaceSlugAttachExisting(t *testing.T) {
+	project := setupEnsureWorkspaceTest(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/workspaces/my-cool-project":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":   "ws-1",
+				"slug": "my-cool-project",
+				"name": "My Cool Project",
+			})
+		default:
+			t.Errorf("unexpected request: %s", r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client := cli.NewClientFromURL(server.URL)
+	cfg := remoteCfg(server.URL)
+
+	ws, created, err := ensureWorkspace(client, cfg, project, "ignored-name", "my-cool-project", "")
+	if err != nil {
+		t.Fatalf("ensureWorkspace: %v", err)
+	}
+	if created {
+		t.Fatal("expected attach (not create), got created=true")
+	}
+	if ws == nil || ws.Slug != "my-cool-project" {
+		t.Fatalf("expected workspace slug my-cool-project, got %#v", ws)
+	}
+
+	data, err := os.ReadFile(filepath.Join(project, ".pad.toml"))
+	if err != nil {
+		t.Fatalf("read .pad.toml: %v", err)
+	}
+	if !strings.Contains(string(data), `workspace = "my-cool-project"`) {
+		t.Fatalf("expected workspace link in .pad.toml, got: %s", data)
+	}
+}
+
+// TestEnsureWorkspaceSlugNotFound: a missing slug must produce a clear error
+// AND must NOT silently fall through to "create a workspace named after the
+// slug." That fallthrough was the keystone bug for the web-first onramp.
+func TestEnsureWorkspaceSlugNotFound(t *testing.T) {
+	project := setupEnsureWorkspaceTest(t)
+
+	createCalled := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && r.URL.Path == "/api/v1/workspaces" {
+			createCalled = true
+			http.Error(w, "must-not-create", http.StatusInternalServerError)
+			return
+		}
+		// 404 for any GET: the slug doesn't exist on this server.
+		w.WriteHeader(http.StatusNotFound)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]any{
+				"code":    "not_found",
+				"message": "Workspace not found",
+			},
+		})
+	}))
+	defer server.Close()
+
+	client := cli.NewClientFromURL(server.URL)
+	cfg := remoteCfg(server.URL)
+
+	_, _, err := ensureWorkspace(client, cfg, project, "ignored-name", "missing-slug", "")
+	if err == nil {
+		t.Fatal("expected error when workspace slug is missing")
+	}
+	if !strings.Contains(err.Error(), `"missing-slug" not found`) {
+		t.Fatalf("expected helpful 'not found' message, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), server.URL) {
+		t.Fatalf("expected error to mention server URL %s, got: %v", server.URL, err)
+	}
+	if createCalled {
+		t.Fatal("must NOT create a workspace when the slug is missing")
+	}
+	if _, err := os.Stat(filepath.Join(project, ".pad.toml")); err == nil {
+		t.Fatal(".pad.toml must not be written when slug attach fails")
+	}
+}
+
+// TestEnsureWorkspaceSlugRefusesClobber: when the CWD is already linked to a
+// different workspace, a slug attach must error rather than rewrite the link.
+func TestEnsureWorkspaceSlugRefusesClobber(t *testing.T) {
+	project := setupEnsureWorkspaceTest(t)
+	if err := cli.WriteWorkspaceLink(project, "already-linked"); err != nil {
+		t.Fatalf("write existing link: %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// We must never hit the network — clobber check is local-first.
+		t.Errorf("unexpected request when CWD is pre-linked: %s", r.URL.Path)
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	client := cli.NewClientFromURL(server.URL)
+	cfg := remoteCfg(server.URL)
+
+	_, _, err := ensureWorkspace(client, cfg, project, "ignored", "my-cool-project", "")
+	if err == nil {
+		t.Fatal("expected error when CWD is already linked to a different workspace")
+	}
+	if !strings.Contains(err.Error(), "already-linked") {
+		t.Fatalf("expected error to mention existing link, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "my-cool-project") {
+		t.Fatalf("expected error to mention requested slug, got: %v", err)
+	}
+
+	// The existing link must be untouched.
+	data, err := os.ReadFile(filepath.Join(project, ".pad.toml"))
+	if err != nil {
+		t.Fatalf("read .pad.toml: %v", err)
+	}
+	if !strings.Contains(string(data), `workspace = "already-linked"`) {
+		t.Fatalf("existing link clobbered, got: %s", data)
+	}
+}
+
+// TestEnsureWorkspaceSlugIdempotent: re-running with the same slug a directory
+// is already linked to is a no-op (returns the workspace, doesn't error).
+func TestEnsureWorkspaceSlugIdempotent(t *testing.T) {
+	project := setupEnsureWorkspaceTest(t)
+	if err := cli.WriteWorkspaceLink(project, "my-cool-project"); err != nil {
+		t.Fatalf("write existing link: %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/workspaces/my-cool-project":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":   "ws-1",
+				"slug": "my-cool-project",
+				"name": "My Cool Project",
+			})
+		default:
+			t.Errorf("unexpected request: %s", r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client := cli.NewClientFromURL(server.URL)
+	cfg := remoteCfg(server.URL)
+
+	ws, created, err := ensureWorkspace(client, cfg, project, "x", "my-cool-project", "")
+	if err != nil {
+		t.Fatalf("ensureWorkspace: %v", err)
+	}
+	if created {
+		t.Fatal("expected created=false on idempotent re-run")
+	}
+	if ws == nil || ws.Slug != "my-cool-project" {
+		t.Fatalf("expected workspace slug my-cool-project, got %#v", ws)
+	}
+}
+
+// TestEnsureWorkspaceNameDrivenStillWorks: the legacy name-driven path
+// (no --workspace flag) must keep behaving as before — match by name and
+// link without creating.
+func TestEnsureWorkspaceNameDrivenStillWorks(t *testing.T) {
+	project := setupEnsureWorkspaceTest(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/workspaces":
+			_ = json.NewEncoder(w).Encode([]map[string]any{
+				{"id": "ws-1", "slug": "legacy-name", "name": "Legacy Name"},
+			})
+		default:
+			t.Errorf("unexpected request: %s", r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client := cli.NewClientFromURL(server.URL)
+	cfg := remoteCfg(server.URL)
+
+	ws, created, err := ensureWorkspace(client, cfg, project, "Legacy Name", "", "")
+	if err != nil {
+		t.Fatalf("ensureWorkspace: %v", err)
+	}
+	if created {
+		t.Fatal("expected attach (not create) when name matches existing")
+	}
+	if ws == nil || ws.Slug != "legacy-name" {
+		t.Fatalf("expected workspace slug legacy-name, got %#v", ws)
+	}
+
+	data, err := os.ReadFile(filepath.Join(project, ".pad.toml"))
+	if err != nil {
+		t.Fatalf("read .pad.toml: %v", err)
+	}
+	if !strings.Contains(string(data), `workspace = "legacy-name"`) {
+		t.Fatalf("expected workspace link, got: %s", data)
+	}
+}

--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -1157,7 +1157,11 @@ a workspace in one step.`,
 				name = filepath.Base(cwd)
 			}
 
-			ws, newlyCreated, err := ensureWorkspace(client, cfg, cwd, name, templateFlag)
+			if workspaceFlag != "" && len(args) > 0 {
+				fmt.Fprintf(os.Stderr, "Note: --workspace %q overrides positional name %q.\n", workspaceFlag, args[0])
+			}
+
+			ws, newlyCreated, err := ensureWorkspace(client, cfg, cwd, name, workspaceFlag, templateFlag)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
## Summary

Keystone CLI work for the web-first onboarding on-ramp ([[PLAN-859]] / [[IDEA-750]]). Makes `pad init --url <server> --workspace <slug>` a reliable non-interactive cold-start so the web UI (next PRs) can hand users a single copy-paste command to connect a workspace they created on the web to their local project.

## What changed

- **`ensureWorkspace` gains a `wsSlug` parameter** — when set, it ONLY attaches by slug. Looks up via `GetWorkspace`, links the CWD if found, and emits a clear `workspace "X" not found on <server>` error otherwise. **Crucially, it never silently falls through to creating a new workspace named after the slug** — that was the keystone bug the web-first flow was hitting.
- **Refuses to clobber** a CWD already linked to a different workspace; idempotent re-run when the existing link matches.
- **`pad init --url X` on a fresh machine now persists the config** (writes `~/.pad/config.toml`) so subsequent commands don't need `--url` again.
- When both a positional `name` and `--workspace <slug>` are supplied, the slug wins and we print a `Note:` line so the override is visible.
- Same wiring applied to `pad workspace init` for consistency.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` clean
- [x] `cd web && npm run build` clean
- [x] `make install` clean
- [x] 5 new unit tests in `cmd/pad/init_test.go` covering:
  - slug-attach to existing workspace writes `.pad.toml`
  - missing slug returns clean error, **never creates** a workspace, leaves no `.pad.toml`
  - refusal to clobber an existing different link
  - idempotent re-run on matching existing link
  - legacy name-driven path still works
- [x] Smoke-tested against running local server end-to-end:
  - `pad init --workspace nonexistent-slug-xyz` → clean error, no `.pad.toml`
  - `pad init --workspace test-onboard` (in fresh dir) → linked, `.pad.toml` written
  - `pad init --workspace canvas` (already linked to test-onboard) → refused
  - `pad init --workspace test-onboard` (idempotent re-run) → silent, status output
  - `pad init somename --workspace test-onboard` → `Note:` warning printed, slug wins

## Follow-ups

- [[TASK-861]] — Web: `<ConnectWorkspaceModal>` + empty-workspace + avatar menu (now unblocked)
- [[TASK-862]] — Web: persistent dismissible "connect CLI" banner
- [[TASK-863]] — Docs (pad-web): web-to-local connect guide

Refs: TASK-860, PLAN-859, IDEA-750