### PR TITLE
feat(web): ConnectWorkspaceModal + empty-workspace and avatar surfaces (TASK-861)

### DIFF
--- a/web/src/lib/components/ConnectWorkspaceModal.svelte
+++ b/web/src/lib/components/ConnectWorkspaceModal.svelte
@@ -21,13 +21,15 @@
 	// from the detected platform on first mount.
 	let activeTab = $state<InstallTab>(defaultInstallTab());
 
+	// All commands mirror the README's Installation section. Homebrew works
+	// on both macOS and Linux. Windows has no first-party one-liner — direct
+	// users to the GitHub releases page. Docker matches the documented run
+	// invocation (data volume at /data, port published to localhost).
 	const installCommands: Record<InstallTab, string> = {
-		// Tap is PerpetualSoftware/tap/pad — see README.md and skills/INSTALL.md.
 		macos: 'brew install PerpetualSoftware/tap/pad',
-		linux: 'curl -fsSL https://getpad.dev/install.sh | sh',
-		// Same shell oneliner under WSL — note that explicitly in helper text.
-		windows: '# WSL2 recommended\ncurl -fsSL https://getpad.dev/install.sh | sh',
-		docker: 'docker run -v $HOME/.pad:/root/.pad ghcr.io/perpetualsoftware/pad:latest'
+		linux: 'brew install PerpetualSoftware/tap/pad',
+		windows: '# Download a Windows binary from\n# https://github.com/PerpetualSoftware/pad/releases',
+		docker: 'docker run -p 127.0.0.1:7777:7777 -v pad-data:/data ghcr.io/perpetualsoftware/pad'
 	};
 
 	const tabs: { id: InstallTab; label: string }[] = [

--- a/web/src/lib/components/ConnectWorkspaceModal.svelte
+++ b/web/src/lib/components/ConnectWorkspaceModal.svelte
@@ -22,7 +22,8 @@
 	let activeTab = $state<InstallTab>(defaultInstallTab());
 
 	const installCommands: Record<InstallTab, string> = {
-		macos: 'brew install xarmian/pad/pad',
+		// Tap is PerpetualSoftware/tap/pad — see README.md and skills/INSTALL.md.
+		macos: 'brew install PerpetualSoftware/tap/pad',
 		linux: 'curl -fsSL https://getpad.dev/install.sh | sh',
 		// Same shell oneliner under WSL — note that explicitly in helper text.
 		windows: '# WSL2 recommended\ncurl -fsSL https://getpad.dev/install.sh | sh',
@@ -55,10 +56,11 @@
 		}
 	}
 
-	// NOTE: docs URLs below (https://getpad.dev/docs/install,
-	// https://getpad.dev/docs/connect-local-project) are placeholders to be
-	// wired up by TASK-863 once TASK-4 (in PLAN-859) publishes the actual
-	// docs pages.
+	// NOTE: until TASK-863 (PLAN-859) publishes dedicated docs pages, the
+	// "Other install options", "Documentation", and "Troubleshooting" links
+	// fall back to anchors in the GitHub README, which has a complete
+	// install + getting-started section. Once the docs page exists, swap
+	// these for getpad.dev/docs/install and /docs/connect-local-project.
 </script>
 
 <svelte:window onkeydown={handleKeydown} />
@@ -127,7 +129,7 @@
 
 					<a
 						class="other-options"
-						href="https://getpad.dev/docs/install"
+						href="https://github.com/PerpetualSoftware/pad#installation"
 						target="_blank"
 						rel="noopener noreferrer"
 					>
@@ -167,7 +169,7 @@
 				<!-- Footer links -->
 				<div class="modal-footer-links">
 					<a
-						href="https://getpad.dev/docs/connect-local-project"
+						href="https://github.com/PerpetualSoftware/pad#getting-started"
 						target="_blank"
 						rel="noopener noreferrer"
 					>
@@ -175,7 +177,7 @@
 					</a>
 					<span class="footer-sep">&middot;</span>
 					<a
-						href="https://getpad.dev/docs/connect-local-project#troubleshooting"
+						href="https://github.com/PerpetualSoftware/pad#installation"
 						target="_blank"
 						rel="noopener noreferrer"
 					>

--- a/web/src/lib/components/ConnectWorkspaceModal.svelte
+++ b/web/src/lib/components/ConnectWorkspaceModal.svelte
@@ -1,0 +1,400 @@
+<script lang="ts">
+	import { toastStore } from '$lib/stores/toast.svelte';
+	import { copyToClipboard } from '$lib/utils/clipboard';
+	import { defaultInstallTab, type InstallTab } from '$lib/utils/platform';
+
+	interface Props {
+		open: boolean;
+		serverUrl: string;
+		workspaceSlug: string;
+		workspaceName?: string;
+	}
+
+	let {
+		open = $bindable(),
+		serverUrl,
+		workspaceSlug,
+		workspaceName = ''
+	}: Props = $props();
+
+	// Active install tab persists across open/close cycles — initialized
+	// from the detected platform on first mount.
+	let activeTab = $state<InstallTab>(defaultInstallTab());
+
+	const installCommands: Record<InstallTab, string> = {
+		macos: 'brew install xarmian/pad/pad',
+		linux: 'curl -fsSL https://getpad.dev/install.sh | sh',
+		// Same shell oneliner under WSL — note that explicitly in helper text.
+		windows: '# WSL2 recommended\ncurl -fsSL https://getpad.dev/install.sh | sh',
+		docker: 'docker run -v $HOME/.pad:/root/.pad ghcr.io/perpetualsoftware/pad:latest'
+	};
+
+	const tabs: { id: InstallTab; label: string }[] = [
+		{ id: 'macos', label: 'macOS' },
+		{ id: 'linux', label: 'Linux' },
+		{ id: 'windows', label: 'Windows' },
+		{ id: 'docker', label: 'Docker' }
+	];
+
+	let connectSnippet = $derived(
+		`cd /path/to/your/project\npad init --url ${serverUrl} --workspace ${workspaceSlug}`
+	);
+
+	async function handleCopy(text: string) {
+		const success = await copyToClipboard(text);
+		if (success) {
+			toastStore.show('Copied to clipboard', 'success');
+		} else {
+			toastStore.show('Failed to copy', 'error');
+		}
+	}
+
+	function handleKeydown(e: KeyboardEvent) {
+		if (e.key === 'Escape' && open) {
+			open = false;
+		}
+	}
+
+	// NOTE: docs URLs below (https://getpad.dev/docs/install,
+	// https://getpad.dev/docs/connect-local-project) are placeholders to be
+	// wired up by TASK-863 once TASK-4 (in PLAN-859) publishes the actual
+	// docs pages.
+</script>
+
+<svelte:window onkeydown={handleKeydown} />
+
+{#if open}
+	<!-- svelte-ignore a11y_click_events_have_key_events -->
+	<!-- svelte-ignore a11y_no_static_element_interactions -->
+	<div class="overlay" onclick={() => (open = false)}>
+		<div class="modal" onclick={(e) => e.stopPropagation()}>
+			<div class="modal-header">
+				<h2>Connect this workspace to your local project</h2>
+				<button class="close-btn" type="button" onclick={() => (open = false)}>&#10005;</button>
+			</div>
+
+			<div class="modal-body">
+				<p class="intro-copy">
+					{#if workspaceName}
+						Run <strong>{workspaceName}</strong> from your terminal with the pad CLI.
+					{:else}
+						Run this workspace from your terminal with the pad CLI.
+					{/if}
+				</p>
+
+				<!-- Step 1 — Install pad -->
+				<section class="step">
+					<span class="section-label">Step 1 — Install pad</span>
+
+					<div class="tab-strip" role="tablist">
+						{#each tabs as tab (tab.id)}
+							<button
+								class="tab-btn"
+								class:active={activeTab === tab.id}
+								role="tab"
+								aria-selected={activeTab === tab.id}
+								type="button"
+								onclick={() => (activeTab = tab.id)}
+							>
+								{tab.label}
+							</button>
+						{/each}
+					</div>
+
+					<div class="code-block">
+						<pre>{installCommands[activeTab]}</pre>
+						<button
+							class="copy-btn-small"
+							type="button"
+							title="Copy command"
+							onclick={() => handleCopy(installCommands[activeTab])}
+						>
+							<svg
+								width="14"
+								height="14"
+								viewBox="0 0 24 24"
+								fill="none"
+								stroke="currentColor"
+								stroke-width="2"
+								stroke-linecap="round"
+								stroke-linejoin="round"
+							>
+								<rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+								<path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+							</svg>
+						</button>
+					</div>
+
+					<a
+						class="other-options"
+						href="https://getpad.dev/docs/install"
+						target="_blank"
+						rel="noopener noreferrer"
+					>
+						Other install options &rarr;
+					</a>
+				</section>
+
+				<!-- Step 2 — Connect this workspace -->
+				<section class="step">
+					<span class="section-label">Step 2 — Connect this workspace</span>
+
+					<div class="code-block">
+						<pre>{connectSnippet}</pre>
+						<button
+							class="copy-btn-small"
+							type="button"
+							title="Copy snippet"
+							onclick={() => handleCopy(connectSnippet)}
+						>
+							<svg
+								width="14"
+								height="14"
+								viewBox="0 0 24 24"
+								fill="none"
+								stroke="currentColor"
+								stroke-width="2"
+								stroke-linecap="round"
+								stroke-linejoin="round"
+							>
+								<rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+								<path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+							</svg>
+						</button>
+					</div>
+				</section>
+
+				<!-- Footer links -->
+				<div class="modal-footer-links">
+					<a
+						href="https://getpad.dev/docs/connect-local-project"
+						target="_blank"
+						rel="noopener noreferrer"
+					>
+						Documentation
+					</a>
+					<span class="footer-sep">&middot;</span>
+					<a
+						href="https://getpad.dev/docs/connect-local-project#troubleshooting"
+						target="_blank"
+						rel="noopener noreferrer"
+					>
+						Troubleshooting
+					</a>
+				</div>
+			</div>
+		</div>
+	</div>
+{/if}
+
+<style>
+	.overlay {
+		position: fixed;
+		inset: 0;
+		background: rgba(0, 0, 0, 0.5);
+		z-index: 50;
+		display: flex;
+		justify-content: center;
+		align-items: flex-start;
+		padding-top: 10vh;
+	}
+
+	.modal {
+		width: 100%;
+		max-width: 560px;
+		background: var(--bg-secondary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius-lg);
+		box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
+		overflow: hidden;
+		max-height: 85vh;
+		display: flex;
+		flex-direction: column;
+	}
+
+	.modal-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: var(--space-4) var(--space-5);
+		border-bottom: 1px solid var(--border);
+		flex-shrink: 0;
+	}
+
+	.modal-header h2 {
+		margin: 0;
+		font-size: 1.1em;
+		font-weight: 600;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.close-btn {
+		background: none;
+		border: none;
+		color: var(--text-muted);
+		font-size: 1em;
+		cursor: pointer;
+		padding: var(--space-1);
+		border-radius: var(--radius-sm);
+		line-height: 1;
+		flex-shrink: 0;
+	}
+
+	.close-btn:hover {
+		color: var(--text-primary);
+		background: var(--bg-hover);
+	}
+
+	.modal-body {
+		padding: var(--space-5);
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-5);
+		overflow-y: auto;
+	}
+
+	.intro-copy {
+		margin: 0;
+		font-size: 0.9em;
+		color: var(--text-secondary);
+		line-height: 1.5;
+	}
+
+	.intro-copy strong {
+		color: var(--text-primary);
+		font-weight: 600;
+	}
+
+	.section-label {
+		display: block;
+		font-size: 0.75em;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		color: var(--text-muted);
+		margin-bottom: var(--space-3);
+	}
+
+	.step {
+		display: flex;
+		flex-direction: column;
+	}
+
+	/* Tab strip — flat, bordered buttons. Active tab gets accent border + filled bg. */
+	.tab-strip {
+		display: flex;
+		gap: var(--space-1);
+		margin-bottom: var(--space-3);
+		flex-wrap: wrap;
+	}
+
+	.tab-btn {
+		padding: var(--space-1) var(--space-3);
+		background: none;
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+		color: var(--text-secondary);
+		font-size: 0.82em;
+		font-weight: 500;
+		cursor: pointer;
+		white-space: nowrap;
+		transition: border-color 0.15s, color 0.15s, background 0.15s;
+	}
+
+	.tab-btn:hover {
+		border-color: var(--accent-blue);
+		color: var(--accent-blue);
+	}
+
+	.tab-btn.active {
+		border-color: var(--accent-blue);
+		background: color-mix(in srgb, var(--accent-blue) 12%, transparent);
+		color: var(--accent-blue);
+	}
+
+	/* Code block — monospace, padded, with copy button on the right. */
+	.code-block {
+		position: relative;
+		background: var(--bg-tertiary);
+		border-radius: var(--radius);
+		padding: var(--space-3) var(--space-9) var(--space-3) var(--space-3);
+		min-height: 0;
+	}
+
+	.code-block pre {
+		margin: 0;
+		font-family: var(--font-mono);
+		font-size: 0.82em;
+		color: var(--text-primary);
+		white-space: pre-wrap;
+		word-break: break-all;
+		line-height: 1.5;
+	}
+
+	.copy-btn-small {
+		position: absolute;
+		top: var(--space-2);
+		right: var(--space-2);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		background: none;
+		border: none;
+		color: var(--text-muted);
+		cursor: pointer;
+		padding: 4px;
+		border-radius: var(--radius-sm);
+		flex-shrink: 0;
+	}
+
+	.copy-btn-small:hover {
+		color: var(--accent-blue);
+		background: var(--bg-hover);
+	}
+
+	.other-options {
+		display: inline-block;
+		margin-top: var(--space-3);
+		font-size: 0.82em;
+		color: var(--text-muted);
+		text-decoration: none;
+		align-self: flex-start;
+	}
+
+	.other-options:hover {
+		color: var(--accent-blue);
+		text-decoration: underline;
+	}
+
+	.modal-footer-links {
+		display: flex;
+		align-items: center;
+		gap: var(--space-2);
+		padding-top: var(--space-3);
+		border-top: 1px solid var(--border);
+		font-size: 0.82em;
+	}
+
+	.modal-footer-links a {
+		color: var(--text-muted);
+		text-decoration: none;
+	}
+
+	.modal-footer-links a:hover {
+		color: var(--accent-blue);
+		text-decoration: underline;
+	}
+
+	.footer-sep {
+		color: var(--border);
+	}
+
+	@media (max-width: 480px) {
+		.modal-header h2 {
+			white-space: normal;
+			font-size: 1em;
+		}
+	}
+</style>

--- a/web/src/lib/components/layout/TopBar.svelte
+++ b/web/src/lib/components/layout/TopBar.svelte
@@ -10,12 +10,14 @@
 	import { goto } from '$app/navigation';
 	import PadLogo from '$lib/components/layout/PadLogo.svelte';
 	import WorkspaceSwitcher from '$lib/components/layout/WorkspaceSwitcher.svelte';
+	import ConnectWorkspaceModal from '$lib/components/ConnectWorkspaceModal.svelte';
 	import { workspaceRestoreTarget } from '$lib/utils/workspace-route';
 
 	let { mobile = false }: { mobile?: boolean } = $props();
 
 	let userMenuOpen = $state(false);
 	let currentTheme = $state<'dark' | 'light'>('dark');
+	let connectOpen = $state(false);
 
 	let currentSlug = $derived(workspaceStore.current?.slug ?? '');
 
@@ -872,6 +874,25 @@
 									Status
 								</a>
 							{/if}
+							<!--
+								"Connect a project…" sits after the cloud-mode Support/Status
+								block (when present) and just above the Sign-out divider —
+								it's a CLI-onboarding action, semantically closer to
+								Settings/Support than to account actions, but visually we
+								want it adjacent to the divider so it reads as a discrete
+								action rather than another link.
+							-->
+							{#if workspaceStore.current?.slug}
+								<button
+									class="dropdown-item"
+									onclick={() => {
+										closeUserMenu();
+										connectOpen = true;
+									}}
+								>
+									Connect a project…
+								</button>
+							{/if}
 							<div class="dropdown-divider"></div>
 							<button class="dropdown-item logout" onclick={handleLogout}>
 								Sign out
@@ -881,6 +902,21 @@
 				</div>
 			{/if}
 		</div>
+
+		<!--
+			Modal lives OUTSIDE the dropdown so it doesn't unmount when the
+			dropdown closes (closeUserMenu fires synchronously with opening
+			the modal). Gated on workspaceStore.current?.slug since the
+			modal needs a workspace to interpolate into the connect snippet.
+		-->
+		{#if workspaceStore.current?.slug}
+			<ConnectWorkspaceModal
+				bind:open={connectOpen}
+				serverUrl={typeof window !== 'undefined' ? window.location.origin : ''}
+				workspaceSlug={workspaceStore.current.slug}
+				workspaceName={workspaceStore.current.name}
+			/>
+		{/if}
 	</header>
 {:else}
 	<!-- ── Mobile ─────────────────────────────────────────────────────────── -->
@@ -959,6 +995,18 @@
 								Status
 							</a>
 						{/if}
+						<!-- Connect a project — see desktop branch for placement rationale. -->
+						{#if workspaceStore.current?.slug}
+							<button
+								class="dropdown-item"
+								onclick={() => {
+									closeUserMenu();
+									connectOpen = true;
+								}}
+							>
+								Connect a project…
+							</button>
+						{/if}
 						<div class="dropdown-divider"></div>
 						<button class="dropdown-item logout" onclick={handleLogout}>
 							Sign out
@@ -966,6 +1014,16 @@
 					</div>
 				{/if}
 			</div>
+		{/if}
+
+		<!-- Same Connect modal pattern as the desktop branch — see notes above. -->
+		{#if workspaceStore.current?.slug}
+			<ConnectWorkspaceModal
+				bind:open={connectOpen}
+				serverUrl={typeof window !== 'undefined' ? window.location.origin : ''}
+				workspaceSlug={workspaceStore.current.slug}
+				workspaceName={workspaceStore.current.name}
+			/>
 		{/if}
 	</header>
 {/if}

--- a/web/src/lib/utils/platform.ts
+++ b/web/src/lib/utils/platform.ts
@@ -1,0 +1,36 @@
+/**
+ * OS detection helpers. Used by ConnectWorkspaceModal to pick a sensible
+ * default install tab based on the user's machine. SSR returns "macos" by
+ * default since that's the most common dev environment for Pad's audience.
+ */
+
+export type Platform = 'macos' | 'linux' | 'windows' | 'other';
+export type InstallTab = 'macos' | 'linux' | 'windows' | 'docker';
+
+/**
+ * Best-effort platform detection from `navigator.userAgent` with
+ * `navigator.platform` as a fallback signal. Pure function — safe to call
+ * during render. Returns "macos" on the server (no `navigator`).
+ */
+export function detectPlatform(): Platform {
+	if (typeof navigator === 'undefined') return 'macos';
+
+	const ua = (navigator.userAgent || '').toLowerCase();
+	const plat = ((navigator as Navigator & { platform?: string }).platform || '').toLowerCase();
+	const haystack = ua + ' ' + plat;
+
+	if (haystack.includes('mac')) return 'macos';
+	if (haystack.includes('win')) return 'windows';
+	if (haystack.includes('linux') || haystack.includes('x11')) return 'linux';
+	return 'other';
+}
+
+/**
+ * Maps the detected platform to the install tab we want to show first.
+ * "other" maps to "macos" since that's the most common dev case.
+ */
+export function defaultInstallTab(): InstallTab {
+	const p = detectPlatform();
+	if (p === 'other') return 'macos';
+	return p;
+}

--- a/web/src/routes/[username]/[workspace]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/+page.svelte
@@ -8,6 +8,7 @@
 	import { syncService } from '$lib/services/sync.svelte';
 	import { relativeTime } from '$lib/utils/markdown';
 	import OnboardingChecklist from '$lib/components/OnboardingChecklist.svelte';
+	import ConnectWorkspaceModal from '$lib/components/ConnectWorkspaceModal.svelte';
 	import { titleStore } from '$lib/stores/title.svelte';
 	import type { DashboardResponse, Collection } from '$lib/types';
 
@@ -19,6 +20,7 @@
 	let collections = $state<Collection[]>([]);
 	let pollTimer: ReturnType<typeof setInterval> | undefined;
 	let onboardingDismissed = $state(false);
+	let connectOpen = $state(false);
 
 	// Sync dismissed state from localStorage when workspace changes
 	$effect(() => {
@@ -201,6 +203,19 @@
 		{#if totalItems === 0 && !onboardingDismissed}
 			<div class="onboarding-wrapper">
 				<OnboardingChecklist {wsSlug} {username} byCollection={dashboard.summary.by_collection} ondismiss={dismissOnboarding} />
+				<button class="connect-card" type="button" onclick={() => (connectOpen = true)}>
+					<span class="connect-card-icon" aria-hidden="true">
+						<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+							<polyline points="4 17 10 11 4 5" />
+							<line x1="12" y1="19" x2="20" y2="19" />
+						</svg>
+					</span>
+					<span class="connect-card-body">
+						<span class="connect-card-title">Connect your local project</span>
+						<span class="connect-card-subtitle">Manage this workspace from your terminal with the pad CLI.</span>
+					</span>
+					<span class="connect-card-cta" aria-hidden="true">&rarr;</span>
+				</button>
 			</div>
 		{:else if totalItems === 0 && onboardingDismissed}
 			<div class="onboarding-reshow">
@@ -421,6 +436,18 @@
 	{/if}
 </div>
 
+<!--
+	Mount the connect modal unconditionally at the page root so it
+	survives re-renders of the conditional onboarding block above —
+	closing the modal must not be entangled with that branch's state.
+-->
+<ConnectWorkspaceModal
+	bind:open={connectOpen}
+	serverUrl={typeof window !== 'undefined' ? window.location.origin : ''}
+	workspaceSlug={wsSlug}
+	workspaceName={workspaceStore.current?.name ?? ''}
+/>
+
 <style>
 	/* ── Layout ─────────────────────────────────────────────────────────── */
 	.dashboard {
@@ -495,6 +522,66 @@
 	/* ── Onboarding ─────────────────────────────────────────────────────── */
 	.onboarding-wrapper {
 		margin-bottom: var(--space-6);
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-3);
+	}
+	/* Connect-your-local-project card — sibling under OnboardingChecklist. */
+	.connect-card {
+		display: flex;
+		align-items: center;
+		gap: var(--space-3);
+		width: 100%;
+		padding: var(--space-3) var(--space-4);
+		background: var(--bg-secondary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius-lg);
+		text-align: left;
+		cursor: pointer;
+		color: inherit;
+		transition: border-color 0.15s, background 0.15s, transform 0.05s;
+	}
+	.connect-card:hover {
+		border-color: var(--accent-blue);
+		background: color-mix(in srgb, var(--accent-blue) 4%, var(--bg-secondary));
+	}
+	.connect-card:active {
+		transform: translateY(1px);
+	}
+	.connect-card-icon {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 36px;
+		height: 36px;
+		border-radius: var(--radius);
+		background: var(--bg-tertiary);
+		color: var(--accent-blue);
+		flex-shrink: 0;
+	}
+	.connect-card-body {
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+		flex: 1;
+		min-width: 0;
+	}
+	.connect-card-title {
+		font-size: 0.95em;
+		font-weight: 600;
+		color: var(--text-primary);
+	}
+	.connect-card-subtitle {
+		font-size: 0.82em;
+		color: var(--text-muted);
+	}
+	.connect-card-cta {
+		font-size: 1.1em;
+		color: var(--text-muted);
+		flex-shrink: 0;
+	}
+	.connect-card:hover .connect-card-cta {
+		color: var(--accent-blue);
 	}
 	.onboarding-reshow {
 		margin-bottom: var(--space-4);


### PR DESCRIPTION
## Summary

Web side of the web-first onboarding on-ramp ([[PLAN-859]] / [[IDEA-750]]). A user who creates a workspace via the web UI now has two clearly visible paths to connect that workspace to their local project, both rendering the same `<ConnectWorkspaceModal>` with a copy-paste-ready `pad init --url … --workspace …` command pre-filled with this server's URL and this workspace's slug.

The CLI command this modal hands to users now works correctly thanks to TASK-860 (#282), which just merged.

## What changed

- **New `<ConnectWorkspaceModal>` component** (`web/src/lib/components/ConnectWorkspaceModal.svelte`). Reusable, no host-page coupling. Matches `ShareDialog`'s modal pattern (native overlay + centered modal, `open = $bindable()`, Escape closes).
  - Props: `serverUrl`, `workspaceSlug`, `workspaceName?`.
  - **Step 1**: OS-tabbed install (macOS / Linux / Windows / Docker), default tab from detected platform, copy button per command.
  - **Step 2**: `cd /path/to/your/project` + `pad init --url <serverUrl> --workspace <workspaceSlug>` in a code block with a copy-the-whole-snippet button.
  - Footer: Documentation + Troubleshooting links (URLs are placeholders to be wired up by TASK-863).
- **New `web/src/lib/utils/platform.ts`** — tiny dependency-free OS detection. SSR-safe (defaults to `"macos"` with no `navigator`).
- **Mounted in the empty-workspace state**: a "Connect your local project" card directly under `<OnboardingChecklist>` in the empty-workspace `.onboarding-wrapper`. The modal itself is mounted unconditionally at the page root so it survives re-renders of the conditional empty-state block.
- **Mounted in `TopBar.svelte`'s user menu** (both desktop and mobile branches): a "Connect a project…" entry between the theme/cloud-support links and the Sign-out divider. Modal lives outside the dropdown (so it doesn't unmount when the dropdown closes) and is gated on `workspaceStore.current?.slug` since the modal needs a workspace to interpolate.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` all packages pass
- [x] `cd web && npm run build` clean (15.25s, no warnings)
- [x] `make install` clean, server restarted, reachable
- [x] Svelte MCP autofixer ran on all four touched files — no findings on the new code (the pre-existing `a11y_consider_explicit_label` warning on the user-trigger avatar button is unrelated)
- [ ] Manual smoke (please verify): open the modal from the user menu on a workspace page → copy the install command → copy the connect snippet → verify both copies match what's on screen

## Follow-ups (out of scope)

- **TASK-863** (now also unblocked): publish `getpad.dev/docs/install` and `getpad.dev/docs/connect-local-project` so the placeholder footer links resolve.
- **TASK-862** (still blocked on this PR): the persistent dismissible CLI banner — its CTA opens this same modal.
- The desktop and mobile branches of `TopBar.svelte` share user-menu markup almost verbatim; a future refactor could extract a shared `<UserMenu>` snippet to avoid drift.

Refs: TASK-861, PLAN-859, IDEA-750