### PR TITLE
feat(web): persistent dismissible CLI-connect banner on workspace pages (TASK-862)

### DIFF
--- a/internal/server/handlers_dashboard.go
+++ b/internal/server/handlers_dashboard.go
@@ -233,8 +233,11 @@ func (s *Server) handleGetDashboard(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Cheap EXISTS query — drives the connect-CLI banner's auto-hide on the
-	// web side. See WorkspaceHasCLISource for the rationale.
-	hasCLI, err := s.store.WorkspaceHasCLISource(workspaceID)
+	// web side. Filtered by the same visibility set used elsewhere in this
+	// handler (dashCollIDs / dashItemIDs) so a guest can't infer the
+	// existence of CLI-sourced items in collections they don't have access
+	// to. See WorkspaceHasCLISource for the rationale.
+	hasCLI, err := s.store.WorkspaceHasCLISource(workspaceID, dashCollIDs, dashItemIDs)
 	if err != nil {
 		writeInternalError(w, err)
 		return

--- a/internal/server/handlers_dashboard.go
+++ b/internal/server/handlers_dashboard.go
@@ -23,6 +23,11 @@ type DashboardResponse struct {
 	Attention      []DashboardAttention  `json:"attention"`
 	RecentActivity []DashboardActivity   `json:"recent_activity"`
 	SuggestedNext  []DashboardSuggestion `json:"suggested_next"`
+	// HasCLISource is true when any non-deleted item in the workspace was
+	// created via the CLI. Drives the "connect your local project" banner
+	// auto-hide — once true, the user is wired up and the banner stops
+	// nagging them on this workspace.
+	HasCLISource bool `json:"has_cli_source"`
 }
 
 type DashboardActiveItem struct {
@@ -226,6 +231,15 @@ func (s *Server) handleGetDashboard(w http.ResponseWriter, r *http.Request) {
 		RecentActivity: []DashboardActivity{},
 		SuggestedNext:  []DashboardSuggestion{},
 	}
+
+	// Cheap EXISTS query — drives the connect-CLI banner's auto-hide on the
+	// web side. See WorkspaceHasCLISource for the rationale.
+	hasCLI, err := s.store.WorkspaceHasCLISource(workspaceID)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	resp.HasCLISource = hasCLI
 
 	// Summary: items grouped by collection slug and status field
 	allItems, err := s.store.ListItems(workspaceID, models.ItemListParams{CollectionIDs: dashCollIDs, ItemIDs: dashItemIDs})

--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -266,6 +266,18 @@ func (s *Server) handleCreateItem(w http.ResponseWriter, r *http.Request) {
 	}
 	input.Fields = string(validatedFields)
 
+	// Persist the source from the request's auth context so the item row
+	// reflects which client created it. Without this, items created via
+	// the CLI would persist as 'web' (the column default) since the CLI's
+	// ItemCreate body has no Source field set, and downstream signals like
+	// the dashboard's has_cli_source flag (TASK-862) would never flip on.
+	// If a client explicitly sent a source in the body (e.g. an agent
+	// marking itself as 'skill'), respect it.
+	if input.Source == "" {
+		_, src := actorFromRequest(r)
+		input.Source = src
+	}
+
 	item, err := s.store.CreateItem(workspaceID, coll.ID, input)
 	if err != nil {
 		if strings.Contains(err.Error(), "UNIQUE constraint") {

--- a/internal/server/handlers_items_test.go
+++ b/internal/server/handlers_items_test.go
@@ -1,12 +1,37 @@
 package server
 
 import (
+	"bytes"
 	"encoding/json"
+	"io"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/PerpetualSoftware/pad/internal/models"
 )
+
+// doRequestWithHeaders is a thin variant of doRequest that lets a test set
+// arbitrary request headers (e.g. Authorization) without spinning up a real
+// auth flow. Mirrors doRequest's body marshalling + remote-addr behavior.
+func doRequestWithHeaders(srv *Server, method, path string, body interface{}, headers map[string]string) *httptest.ResponseRecorder {
+	var bodyReader io.Reader
+	if body != nil {
+		data, _ := json.Marshal(body)
+		bodyReader = bytes.NewReader(data)
+	}
+	req := httptest.NewRequest(method, path, bodyReader)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	req.RemoteAddr = "192.0.2.1:1234"
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	return rr
+}
 
 // createWSWithCollections creates a workspace and returns its slug.
 // The workspace will have default collections seeded automatically.
@@ -1002,4 +1027,99 @@ func TestItemCrossCollectionListing(t *testing.T) {
 			t.Errorf("item %q missing collection_name", item.Title)
 		}
 	}
+}
+
+// TestCreateItemSourcePersistedFromAuth covers the fix for the bug Codex
+// caught while reviewing TASK-862's PR: items created via the CLI were
+// persisting with source='web' (the column default) instead of 'cli',
+// because the handler decoded ItemCreate from the body — which has no
+// Source set by the CLI client — and only consulted actorFromRequest
+// AFTER persisting (for SSE / activity logs). With the fix, the handler
+// now backfills input.Source from actorFromRequest before calling
+// store.CreateItem, so items created with a Bearer auth header land as
+// source='cli'. Without it, the dashboard's has_cli_source signal
+// (TASK-862) would never flip on for normal CLI usage.
+//
+// The bearer-auth test uses a real bootstrapped session token because
+// the auth middleware validates token format (rejects "pad_anything"
+// shapes with 401 before the handler ever runs).
+func TestCreateItemSourcePersistedFromAuth(t *testing.T) {
+	srv := testServer(t)
+	sessionToken := bootstrapFirstUser(t, srv, "admin@example.com", "Admin")
+
+	// Create the workspace via the cookie path so subsequent tests have
+	// a real workspace to write into. CSRF is handled by doRequestWithCookie.
+	rr := doRequestWithCookie(srv, "POST", "/api/v1/workspaces",
+		map[string]string{"name": "Source Test"}, sessionToken)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create ws: expected 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var ws models.Workspace
+	parseJSON(t, rr, &ws)
+
+	t.Run("bearer auth header persists source as cli", func(t *testing.T) {
+		// Reusing the session token in the Authorization header simulates
+		// the CLI flow (CLI auth tokens are also surfaced this way through
+		// TokenAuth's padsess_ branch). actorFromRequest only checks
+		// Authorization-header presence to flip source, so this exercises
+		// the same branch.
+		rr := doRequestWithHeaders(srv, "POST",
+			"/api/v1/workspaces/"+ws.Slug+"/collections/tasks/items",
+			map[string]interface{}{
+				"title":  "From CLI",
+				"fields": `{"status":"open"}`,
+			},
+			map[string]string{"Authorization": "Bearer " + sessionToken},
+		)
+		if rr.Code != http.StatusCreated {
+			t.Fatalf("expected 201, got %d: %s", rr.Code, rr.Body.String())
+		}
+		var item models.Item
+		parseJSON(t, rr, &item)
+		if item.Source != "cli" {
+			t.Fatalf("expected source=cli when Authorization header is present, got %q", item.Source)
+		}
+	})
+
+	t.Run("cookie session persists source as web", func(t *testing.T) {
+		rr := doRequestWithCookie(srv, "POST",
+			"/api/v1/workspaces/"+ws.Slug+"/collections/tasks/items",
+			map[string]interface{}{
+				"title":  "From Web",
+				"fields": `{"status":"open"}`,
+			},
+			sessionToken,
+		)
+		if rr.Code != http.StatusCreated {
+			t.Fatalf("expected 201, got %d: %s", rr.Code, rr.Body.String())
+		}
+		var item models.Item
+		parseJSON(t, rr, &item)
+		if item.Source != "web" {
+			t.Fatalf("expected source=web with cookie session and no Authorization header, got %q", item.Source)
+		}
+	})
+
+	t.Run("explicit source in body wins over auth-derived", func(t *testing.T) {
+		// e.g. an agent acting through the CLI explicitly marks itself as
+		// 'skill'. We must respect that and not clobber it with the
+		// auth-derived 'cli' default.
+		rr := doRequestWithHeaders(srv, "POST",
+			"/api/v1/workspaces/"+ws.Slug+"/collections/tasks/items",
+			map[string]interface{}{
+				"title":  "From Skill",
+				"fields": `{"status":"open"}`,
+				"source": "skill",
+			},
+			map[string]string{"Authorization": "Bearer " + sessionToken},
+		)
+		if rr.Code != http.StatusCreated {
+			t.Fatalf("expected 201, got %d: %s", rr.Code, rr.Body.String())
+		}
+		var item models.Item
+		parseJSON(t, rr, &item)
+		if item.Source != "skill" {
+			t.Fatalf("expected source=skill when explicitly set in body, got %q", item.Source)
+		}
+	})
 }

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -2009,6 +2009,24 @@ func (s *Store) GetDeletedItemsWithCollection(workspaceID string, itemIDs []stri
 	return results, rows.Err()
 }
 
+// WorkspaceHasCLISource reports whether any non-deleted item in the workspace
+// was created via the CLI (source='cli'). Used by the dashboard to auto-hide
+// the "connect your local project" banner once a user has wired up the CLI.
+// Backed by EXISTS so it short-circuits on the first match.
+func (s *Store) WorkspaceHasCLISource(workspaceID string) (bool, error) {
+	var has bool
+	err := s.db.QueryRow(s.q(`
+		SELECT EXISTS(
+			SELECT 1 FROM items
+			WHERE workspace_id = ? AND source = 'cli' AND deleted_at IS NULL
+		)
+	`), workspaceID).Scan(&has)
+	if err != nil {
+		return false, fmt.Errorf("workspace has cli source: %w", err)
+	}
+	return has, nil
+}
+
 func hydrateItemComputedMetadata(item *models.Item) {
 	if item == nil {
 		return

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -2009,19 +2009,65 @@ func (s *Store) GetDeletedItemsWithCollection(workspaceID string, itemIDs []stri
 	return results, rows.Err()
 }
 
-// WorkspaceHasCLISource reports whether any non-deleted item in the workspace
-// was created via the CLI (source='cli'). Used by the dashboard to auto-hide
-// the "connect your local project" banner once a user has wired up the CLI.
+// WorkspaceHasCLISource reports whether any non-deleted item VISIBLE to the
+// caller was created via the CLI (source='cli'). Used by the dashboard to
+// auto-hide the "connect your local project" banner once a user has wired
+// up the CLI.
+//
+// Visibility filtering matches the dashboard's existing model (see
+// handleGetDashboard): an item counts when its collection is in
+// collectionIDs OR its id is in itemIDs (union — guest item-level grants
+// can expose items in otherwise-hidden collections). Pass nil for both to
+// run unfiltered (full-visibility caller). A non-nil empty
+// collectionIDs slice with no itemIDs means "no visible collections" and
+// returns false without hitting the DB — symmetric with ListItems.
+//
 // Backed by EXISTS so it short-circuits on the first match.
-func (s *Store) WorkspaceHasCLISource(workspaceID string) (bool, error) {
-	var has bool
-	err := s.db.QueryRow(s.q(`
+func (s *Store) WorkspaceHasCLISource(workspaceID string, collectionIDs, itemIDs []string) (bool, error) {
+	// Symmetric early-exit with ListItems: caller signaled no visibility.
+	if collectionIDs != nil && len(collectionIDs) == 0 && len(itemIDs) == 0 {
+		return false, nil
+	}
+
+	query := `
 		SELECT EXISTS(
 			SELECT 1 FROM items
 			WHERE workspace_id = ? AND source = 'cli' AND deleted_at IS NULL
-		)
-	`), workspaceID).Scan(&has)
-	if err != nil {
+	`
+	args := []interface{}{workspaceID}
+
+	if len(collectionIDs) > 0 && len(itemIDs) > 0 {
+		collPlaceholders := make([]string, len(collectionIDs))
+		for i, id := range collectionIDs {
+			collPlaceholders[i] = "?"
+			args = append(args, id)
+		}
+		itemPlaceholders := make([]string, len(itemIDs))
+		for i, id := range itemIDs {
+			itemPlaceholders[i] = "?"
+			args = append(args, id)
+		}
+		query += " AND (collection_id IN (" + strings.Join(collPlaceholders, ",") + ") OR id IN (" + strings.Join(itemPlaceholders, ",") + "))"
+	} else if len(collectionIDs) > 0 {
+		placeholders := make([]string, len(collectionIDs))
+		for i, id := range collectionIDs {
+			placeholders[i] = "?"
+			args = append(args, id)
+		}
+		query += " AND collection_id IN (" + strings.Join(placeholders, ",") + ")"
+	} else if len(itemIDs) > 0 {
+		placeholders := make([]string, len(itemIDs))
+		for i, id := range itemIDs {
+			placeholders[i] = "?"
+			args = append(args, id)
+		}
+		query += " AND id IN (" + strings.Join(placeholders, ",") + ")"
+	}
+
+	query += ")"
+
+	var has bool
+	if err := s.db.QueryRow(s.q(query), args...).Scan(&has); err != nil {
 		return false, fmt.Errorf("workspace has cli source: %w", err)
 	}
 	return has, nil

--- a/internal/store/items_test.go
+++ b/internal/store/items_test.go
@@ -2217,3 +2217,84 @@ func TestItemVersionCreation(t *testing.T) {
 		t.Errorf("expected at least 1 version, got %d", len(versions))
 	}
 }
+
+func TestWorkspaceHasCLISource(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Connect Banner")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+
+	// Empty workspace — false.
+	has, err := s.WorkspaceHasCLISource(ws.ID)
+	if err != nil {
+		t.Fatalf("WorkspaceHasCLISource: %v", err)
+	}
+	if has {
+		t.Fatal("expected false on empty workspace")
+	}
+
+	// Non-cli items shouldn't flip it on.
+	for _, src := range []string{"web", "skill"} {
+		_, err := s.CreateItem(ws.ID, col.ID, models.ItemCreate{
+			Title:  fmt.Sprintf("From %s", src),
+			Fields: `{"status":"open"}`,
+			Source: src,
+		})
+		if err != nil {
+			t.Fatalf("create %s item: %v", src, err)
+		}
+	}
+	has, err = s.WorkspaceHasCLISource(ws.ID)
+	if err != nil {
+		t.Fatalf("WorkspaceHasCLISource (non-cli): %v", err)
+	}
+	if has {
+		t.Fatal("expected false when only web/skill items exist")
+	}
+
+	// One CLI item — true.
+	cliItem, err := s.CreateItem(ws.ID, col.ID, models.ItemCreate{
+		Title:  "From CLI",
+		Fields: `{"status":"open"}`,
+		Source: "cli",
+	})
+	if err != nil {
+		t.Fatalf("create cli item: %v", err)
+	}
+	has, err = s.WorkspaceHasCLISource(ws.ID)
+	if err != nil {
+		t.Fatalf("WorkspaceHasCLISource (with cli): %v", err)
+	}
+	if !has {
+		t.Fatal("expected true after a cli-sourced item exists")
+	}
+
+	// Soft-deleting the only CLI item should flip it back off.
+	if err := s.DeleteItem(cliItem.ID); err != nil {
+		t.Fatalf("delete cli item: %v", err)
+	}
+	has, err = s.WorkspaceHasCLISource(ws.ID)
+	if err != nil {
+		t.Fatalf("WorkspaceHasCLISource (after delete): %v", err)
+	}
+	if has {
+		t.Fatal("expected false after the only cli item was deleted")
+	}
+
+	// Workspace isolation — a cli item in another workspace must not leak.
+	otherWS := createTestWorkspace(t, s, "Other")
+	otherCol := createTestCollection(t, s, otherWS.ID, "Tasks")
+	if _, err := s.CreateItem(otherWS.ID, otherCol.ID, models.ItemCreate{
+		Title:  "Other CLI",
+		Fields: `{"status":"open"}`,
+		Source: "cli",
+	}); err != nil {
+		t.Fatalf("create other-ws cli item: %v", err)
+	}
+	has, err = s.WorkspaceHasCLISource(ws.ID)
+	if err != nil {
+		t.Fatalf("WorkspaceHasCLISource (after other-ws cli): %v", err)
+	}
+	if has {
+		t.Fatal("a cli item in a different workspace must not flip ours on")
+	}
+}

--- a/internal/store/items_test.go
+++ b/internal/store/items_test.go
@@ -2224,7 +2224,7 @@ func TestWorkspaceHasCLISource(t *testing.T) {
 	col := createTestCollection(t, s, ws.ID, "Tasks")
 
 	// Empty workspace — false.
-	has, err := s.WorkspaceHasCLISource(ws.ID)
+	has, err := s.WorkspaceHasCLISource(ws.ID, nil, nil)
 	if err != nil {
 		t.Fatalf("WorkspaceHasCLISource: %v", err)
 	}
@@ -2243,7 +2243,7 @@ func TestWorkspaceHasCLISource(t *testing.T) {
 			t.Fatalf("create %s item: %v", src, err)
 		}
 	}
-	has, err = s.WorkspaceHasCLISource(ws.ID)
+	has, err = s.WorkspaceHasCLISource(ws.ID, nil, nil)
 	if err != nil {
 		t.Fatalf("WorkspaceHasCLISource (non-cli): %v", err)
 	}
@@ -2260,7 +2260,7 @@ func TestWorkspaceHasCLISource(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create cli item: %v", err)
 	}
-	has, err = s.WorkspaceHasCLISource(ws.ID)
+	has, err = s.WorkspaceHasCLISource(ws.ID, nil, nil)
 	if err != nil {
 		t.Fatalf("WorkspaceHasCLISource (with cli): %v", err)
 	}
@@ -2272,7 +2272,7 @@ func TestWorkspaceHasCLISource(t *testing.T) {
 	if err := s.DeleteItem(cliItem.ID); err != nil {
 		t.Fatalf("delete cli item: %v", err)
 	}
-	has, err = s.WorkspaceHasCLISource(ws.ID)
+	has, err = s.WorkspaceHasCLISource(ws.ID, nil, nil)
 	if err != nil {
 		t.Fatalf("WorkspaceHasCLISource (after delete): %v", err)
 	}
@@ -2290,11 +2290,81 @@ func TestWorkspaceHasCLISource(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("create other-ws cli item: %v", err)
 	}
-	has, err = s.WorkspaceHasCLISource(ws.ID)
+	has, err = s.WorkspaceHasCLISource(ws.ID, nil, nil)
 	if err != nil {
 		t.Fatalf("WorkspaceHasCLISource (after other-ws cli): %v", err)
 	}
 	if has {
 		t.Fatal("a cli item in a different workspace must not flip ours on")
+	}
+}
+
+// TestWorkspaceHasCLISourceVisibility covers the visibility filter so a
+// guest with restricted access can't infer the existence of CLI items in
+// collections they don't have visibility into. Codex flagged this as a
+// P2 leak during PR #284 review — without filtering, has_cli_source
+// reflected the whole workspace regardless of caller visibility.
+func TestWorkspaceHasCLISourceVisibility(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Visibility")
+	visibleColl := createTestCollection(t, s, ws.ID, "Visible")
+	hiddenColl := createTestCollection(t, s, ws.ID, "Hidden")
+
+	// CLI item in the HIDDEN collection only.
+	hiddenCLI, err := s.CreateItem(ws.ID, hiddenColl.ID, models.ItemCreate{
+		Title:  "Hidden CLI",
+		Fields: `{"status":"open"}`,
+		Source: "cli",
+	})
+	if err != nil {
+		t.Fatalf("create hidden cli item: %v", err)
+	}
+
+	// Web item in the VISIBLE collection (so the visible set isn't empty).
+	if _, err := s.CreateItem(ws.ID, visibleColl.ID, models.ItemCreate{
+		Title:  "Visible Web",
+		Fields: `{"status":"open"}`,
+		Source: "web",
+	}); err != nil {
+		t.Fatalf("create visible web item: %v", err)
+	}
+
+	// Unfiltered (full-visibility caller) sees the CLI item.
+	has, err := s.WorkspaceHasCLISource(ws.ID, nil, nil)
+	if err != nil {
+		t.Fatalf("unfiltered: %v", err)
+	}
+	if !has {
+		t.Fatal("unfiltered call must see the hidden CLI item")
+	}
+
+	// Caller with only the VISIBLE collection in scope must NOT see the
+	// CLI item that lives in a hidden collection.
+	has, err = s.WorkspaceHasCLISource(ws.ID, []string{visibleColl.ID}, nil)
+	if err != nil {
+		t.Fatalf("visible-coll only: %v", err)
+	}
+	if has {
+		t.Fatal("must not surface CLI items in collections outside the caller's visible set")
+	}
+
+	// Item-level grant on the hidden CLI item should expose it via the
+	// guest-item path even when the collection isn't in scope.
+	has, err = s.WorkspaceHasCLISource(ws.ID, []string{visibleColl.ID}, []string{hiddenCLI.ID})
+	if err != nil {
+		t.Fatalf("with item grant: %v", err)
+	}
+	if !has {
+		t.Fatal("an explicit item grant for the CLI item must surface it")
+	}
+
+	// Non-nil empty collectionIDs + no item grants = no visibility =
+	// short-circuit false (matches ListItems' early-exit semantics).
+	has, err = s.WorkspaceHasCLISource(ws.ID, []string{}, nil)
+	if err != nil {
+		t.Fatalf("empty visibility: %v", err)
+	}
+	if has {
+		t.Fatal("an empty visibility set must short-circuit to false")
 	}
 }

--- a/web/src/lib/components/ConnectBanner.svelte
+++ b/web/src/lib/components/ConnectBanner.svelte
@@ -33,22 +33,33 @@
 		}
 	});
 
-	// Fetch `has_cli_source` for a specific slug. The slug is captured at
-	// call time and re-checked before assigning, so a slow response from a
-	// previous workspace can't overwrite the current workspace's signal
-	// (e.g. the user clicks Workspace A → Workspace B before A's request
-	// resolves). Failures fall back to `false` (fail-open: better to show
-	// the banner than to hide it on a transient error).
+	// Fetch `has_cli_source` for a specific slug. Two safeguards against
+	// stale responses overwriting fresher ones:
+	//
+	// 1. A monotonic sequence id captured at call time — only the LATEST
+	//    request's result is applied. This handles same-workspace races,
+	//    e.g. an in-flight workspace-change fetch that resolves AFTER the
+	//    modal-close refetch (which would otherwise stomp the newer
+	//    `true` with the older `false`).
+	// 2. A captured slug recheck — if the user has already navigated to a
+	//    different workspace by the time the response lands, drop it.
+	//
+	// Failures fall back to `false` (fail-open: better to show the banner
+	// than to hide it on a transient error).
+	let fetchSeq = 0;
 	function refreshHasCliSource(slug: string) {
 		if (!slug) return;
+		const mySeq = ++fetchSeq;
 		hasCliSource = null;
 		api.dashboard
 			.get(slug)
 			.then((d) => {
-				if (slug !== wsSlug) return; // stale response — ignore
+				if (mySeq !== fetchSeq) return; // a newer request superseded us
+				if (slug !== wsSlug) return; // workspace changed under us
 				hasCliSource = d.has_cli_source;
 			})
 			.catch(() => {
+				if (mySeq !== fetchSeq) return;
 				if (slug !== wsSlug) return;
 				hasCliSource = false;
 			});

--- a/web/src/lib/components/ConnectBanner.svelte
+++ b/web/src/lib/components/ConnectBanner.svelte
@@ -113,6 +113,10 @@
 		tabindex="0"
 		onclick={openModal}
 		onkeydown={(e) => {
+			// Only react when the keydown originated on the banner itself —
+			// otherwise keyboard activation of nested focusable elements
+			// (e.g. the dismiss button) would also open the modal.
+			if (e.target !== e.currentTarget) return;
 			if (e.key === 'Enter' || e.key === ' ') {
 				e.preventDefault();
 				openModal();

--- a/web/src/lib/components/ConnectBanner.svelte
+++ b/web/src/lib/components/ConnectBanner.svelte
@@ -33,22 +33,49 @@
 		}
 	});
 
-	// Effect B — fetch `has_cli_source` from the dashboard whenever the
-	// workspace slug changes. Reset to `null` first so we don't briefly
-	// render the banner for the new workspace based on the previous
-	// workspace's signal. Failures fall back to `false` (fail-open: better
-	// to show the banner than to hide it on a transient error).
-	$effect(() => {
-		if (!wsSlug) return;
+	// Fetch `has_cli_source` for a specific slug. The slug is captured at
+	// call time and re-checked before assigning, so a slow response from a
+	// previous workspace can't overwrite the current workspace's signal
+	// (e.g. the user clicks Workspace A → Workspace B before A's request
+	// resolves). Failures fall back to `false` (fail-open: better to show
+	// the banner than to hide it on a transient error).
+	function refreshHasCliSource(slug: string) {
+		if (!slug) return;
 		hasCliSource = null;
 		api.dashboard
-			.get(wsSlug)
+			.get(slug)
 			.then((d) => {
+				if (slug !== wsSlug) return; // stale response — ignore
 				hasCliSource = d.has_cli_source;
 			})
 			.catch(() => {
+				if (slug !== wsSlug) return;
 				hasCliSource = false;
 			});
+	}
+
+	// Effect B — refetch on workspace change. Per CONVE-606, kept separate
+	// from the localStorage sync above.
+	$effect(() => {
+		refreshHasCliSource(wsSlug);
+	});
+
+	// Effect C — refetch when the modal CLOSES. The user's most common
+	// flow is: see banner → open modal → copy command → run it in their
+	// terminal → close the modal. By that point a CLI-sourced item has
+	// almost certainly landed; a fresh fetch makes the banner auto-hide
+	// in-session instead of waiting for a route change or page reload.
+	// `$effect.pre` + a tracked previous value matches the transition
+	// pattern used in ShareDialog. Out of scope for this PR but left as a
+	// follow-up: subscribe to SSE item-created events to also catch
+	// "user ran the CLI from another terminal without ever opening the
+	// modal" — see PLAN-859 for any spawned follow-up tasks.
+	let prevConnectOpen = $state(false);
+	$effect.pre(() => {
+		if (prevConnectOpen && !connectOpen) {
+			refreshHasCliSource(wsSlug);
+		}
+		prevConnectOpen = connectOpen;
 	});
 
 	let visible = $derived(

--- a/web/src/lib/components/ConnectBanner.svelte
+++ b/web/src/lib/components/ConnectBanner.svelte
@@ -1,0 +1,189 @@
+<script lang="ts">
+	import { browser } from '$app/environment';
+	import { api } from '$lib/api/client';
+	import ConnectWorkspaceModal from './ConnectWorkspaceModal.svelte';
+
+	interface Props {
+		wsSlug: string;
+		serverUrl: string;
+		workspaceName?: string;
+	}
+
+	let { wsSlug, serverUrl, workspaceName = '' }: Props = $props();
+
+	// `null` = unknown (still loading, banner stays hidden to avoid a flash);
+	// `true` = workspace already has at least one CLI-sourced item, auto-hide;
+	// `false` = no CLI source detected, show the banner.
+	let hasCliSource = $state<boolean | null>(null);
+	let dismissed = $state(false);
+	let connectOpen = $state(false);
+
+	// Effect A — sync dismissed state from localStorage when workspace
+	// changes. Mirrors the pattern in `[username]/[workspace]/+page.svelte`
+	// for the onboarding-dismissed flag. Per CONVE-606, kept separate from
+	// the data fetch below so a route change doesn't entangle two unrelated
+	// reactive lifecycles.
+	//
+	// TODO: persistence is per-browser today. If we need cross-device dismiss
+	// state we can back this with a `workspace_user_state` row.
+	$effect(() => {
+		if (browser && wsSlug) {
+			dismissed =
+				localStorage.getItem(`pad-cli-banner-dismissed-${wsSlug}`) === 'true';
+		}
+	});
+
+	// Effect B — fetch `has_cli_source` from the dashboard whenever the
+	// workspace slug changes. Reset to `null` first so we don't briefly
+	// render the banner for the new workspace based on the previous
+	// workspace's signal. Failures fall back to `false` (fail-open: better
+	// to show the banner than to hide it on a transient error).
+	$effect(() => {
+		if (!wsSlug) return;
+		hasCliSource = null;
+		api.dashboard
+			.get(wsSlug)
+			.then((d) => {
+				hasCliSource = d.has_cli_source;
+			})
+			.catch(() => {
+				hasCliSource = false;
+			});
+	});
+
+	let visible = $derived(
+		!!wsSlug && !dismissed && hasCliSource === false && !connectOpen
+	);
+
+	function dismiss(event: MouseEvent) {
+		event.stopPropagation();
+		dismissed = true;
+		if (browser) {
+			localStorage.setItem(`pad-cli-banner-dismissed-${wsSlug}`, 'true');
+		}
+	}
+
+	function openModal() {
+		connectOpen = true;
+	}
+</script>
+
+{#if visible}
+	<div
+		class="banner"
+		role="button"
+		tabindex="0"
+		onclick={openModal}
+		onkeydown={(e) => {
+			if (e.key === 'Enter' || e.key === ' ') {
+				e.preventDefault();
+				openModal();
+			}
+		}}
+	>
+		<span class="banner-icon" aria-hidden="true">
+			<svg
+				width="16"
+				height="16"
+				viewBox="0 0 24 24"
+				fill="none"
+				stroke="currentColor"
+				stroke-width="2"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+			>
+				<polyline points="4 17 10 11 4 5" />
+				<line x1="12" y1="19" x2="20" y2="19" />
+			</svg>
+		</span>
+		<span class="banner-text">
+			Manage this workspace from your terminal &mdash; get the CLI &rarr;
+		</span>
+		<span class="banner-actions">
+			<span class="banner-cta">Get the CLI</span>
+			<button
+				class="dismiss-btn"
+				type="button"
+				aria-label="Dismiss banner"
+				onclick={dismiss}
+			>
+				&#10005;
+			</button>
+		</span>
+	</div>
+{/if}
+
+<ConnectWorkspaceModal
+	bind:open={connectOpen}
+	{serverUrl}
+	workspaceSlug={wsSlug}
+	{workspaceName}
+/>
+
+<style>
+	.banner {
+		display: flex;
+		align-items: center;
+		gap: var(--space-3);
+		width: 100%;
+		padding: var(--space-2) var(--space-4);
+		background: var(--bg-secondary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+		color: var(--text-secondary);
+		cursor: pointer;
+		font-size: 0.85em;
+		transition: border-color 0.15s, background 0.15s;
+		box-sizing: border-box;
+	}
+	.banner:hover {
+		border-color: var(--accent-blue);
+		background: color-mix(in srgb, var(--accent-blue) 4%, var(--bg-secondary));
+	}
+	.banner:focus-visible {
+		outline: 2px solid var(--accent-blue);
+		outline-offset: 2px;
+	}
+	.banner-icon {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		color: var(--accent-blue);
+		flex-shrink: 0;
+	}
+	.banner-text {
+		flex: 1;
+		min-width: 0;
+		color: var(--text-secondary);
+	}
+	.banner-actions {
+		display: flex;
+		align-items: center;
+		gap: var(--space-3);
+		flex-shrink: 0;
+	}
+	.banner-cta {
+		color: var(--accent-blue);
+		font-weight: 600;
+	}
+	.dismiss-btn {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 22px;
+		height: 22px;
+		padding: 0;
+		background: transparent;
+		border: none;
+		border-radius: var(--radius);
+		color: var(--text-muted);
+		cursor: pointer;
+		font-size: 0.85em;
+		line-height: 1;
+		transition: background 0.15s, color 0.15s;
+	}
+	.dismiss-btn:hover {
+		background: var(--bg-tertiary);
+		color: var(--text-primary);
+	}
+</style>

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -623,6 +623,7 @@ export interface DashboardResponse {
 		collection: string;
 		reason: string;
 	}[];
+	has_cli_source: boolean;
 }
 
 // ─── Incremental Sync ────────────────────────────────────────────────────────

--- a/web/src/routes/[username]/[workspace]/+layout.svelte
+++ b/web/src/routes/[username]/[workspace]/+layout.svelte
@@ -10,6 +10,7 @@
 	import { toastStore } from '$lib/stores/toast.svelte';
 	import { starredStore } from '$lib/stores/starred.svelte';
 	import { titleStore } from '$lib/stores/title.svelte';
+	import ConnectBanner from '$lib/components/ConnectBanner.svelte';
 
 	let { children } = $props();
 
@@ -189,5 +190,11 @@
 		});
 	}
 </script>
+
+<ConnectBanner
+	{wsSlug}
+	serverUrl={typeof window !== 'undefined' ? window.location.origin : ''}
+	workspaceName={workspaceStore.current?.name ?? ''}
+/>
 
 {@render children()}


### PR DESCRIPTION
## Summary

Final web piece of the web-first onboarding on-ramp ([[PLAN-859]] / [[IDEA-750]]). A slim, dismissible top banner now nudges users to wire up the CLI on every workspace page, hidden the moment they actually do it.

## What changed

**Server:**
- `internal/store/items.go` — new `WorkspaceHasCLISource(workspaceID) (bool, error)`, backed by `EXISTS(... WHERE source='cli' AND deleted_at IS NULL)`. Cheap, indexed.
- `internal/server/handlers_dashboard.go` — `DashboardResponse` gains `HasCLISource bool` (`json:"has_cli_source"`).
- Unit test covers: empty workspace, web/skill items don't flip it on, a cli item does, soft-delete flips it back off, cross-workspace isolation.

**Web:**
- New `<ConnectBanner>` Svelte 5 component (`web/src/lib/components/ConnectBanner.svelte`). Self-contained: reads dismissed state from localStorage, fetches its own dashboard signal, mounts `<ConnectWorkspaceModal>` internally. Two split `$effect` blocks per **CONVE-606** so the localStorage sync and the dashboard fetch don't entangle on route change.
- Hidden while loading (`hasCliSource === null`) to avoid a flash-then-auto-hide on workspaces that already have CLI items.
- localStorage key `pad-cli-banner-dismissed-${wsSlug}` matches the existing onboarding-dismissed pattern. TODO note in source about backing with a `workspace_user_state` row if cross-device dismissal is wanted later.
- `DashboardResponse` TypeScript type in `web/src/lib/types/index.ts` gains `has_cli_source: boolean`.
- Mounted in `web/src/routes/[username]/[workspace]/+layout.svelte` above `{@render children()}` so it appears on every workspace page (dashboard, collection lists, item detail, search, activity, roles) and not on console/auth pages.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` all green (incl. new `TestWorkspaceHasCLISource` with 5 sub-cases)
- [x] `cd web && npm run build` clean (15.34s, no warnings)
- [x] `make install` clean, server restarted
- [x] Svelte MCP autofixer on `ConnectBanner.svelte` — no issues
- [x] Smoke test: live dashboard endpoint returns `has_cli_source: true` for this workspace (which has many CLI items), so banner is correctly auto-hidden here

## Follow-ups (out of scope)

- Cross-device dismissal — back the per-workspace localStorage key with a `workspace_user_state` row. Comment left in source.
- `+page.svelte` and `<ConnectBanner>` both call `api.dashboard.get(wsSlug)` on the workspace home — a small dashboard cache could deduplicate.
- TASK-863 (docs) is now unblocked — last task in PLAN-859.

Refs: TASK-862, PLAN-859, IDEA-750