### PR TITLE
chore(web/connect-modal): point footer + install links at getpad.dev/docs

### DIFF
--- a/web/src/lib/components/ConnectWorkspaceModal.svelte
+++ b/web/src/lib/components/ConnectWorkspaceModal.svelte
@@ -58,11 +58,10 @@
 		}
 	}
 
-	// NOTE: until TASK-863 (PLAN-859) publishes dedicated docs pages, the
-	// "Other install options", "Documentation", and "Troubleshooting" links
-	// fall back to anchors in the GitHub README, which has a complete
-	// install + getting-started section. Once the docs page exists, swap
-	// these for getpad.dev/docs/install and /docs/connect-local-project.
+	// Docs URLs point at getpad.dev/docs (TASK-863 / pad-web#30). The
+	// "Connect a Workspace" guide has its own #troubleshooting anchor;
+	// "Other install options" goes to the broader /docs#installation
+	// section which lists Homebrew, Docker, binary download, and source.
 </script>
 
 <svelte:window onkeydown={handleKeydown} />
@@ -131,7 +130,7 @@
 
 					<a
 						class="other-options"
-						href="https://github.com/PerpetualSoftware/pad#installation"
+						href="https://getpad.dev/docs#installation"
 						target="_blank"
 						rel="noopener noreferrer"
 					>
@@ -171,7 +170,7 @@
 				<!-- Footer links -->
 				<div class="modal-footer-links">
 					<a
-						href="https://github.com/PerpetualSoftware/pad#getting-started"
+						href="https://getpad.dev/docs/connect-workspace"
 						target="_blank"
 						rel="noopener noreferrer"
 					>
@@ -179,7 +178,7 @@
 					</a>
 					<span class="footer-sep">&middot;</span>
 					<a
-						href="https://github.com/PerpetualSoftware/pad#installation"
+						href="https://getpad.dev/docs/connect-workspace#troubleshooting"
 						target="_blank"
 						rel="noopener noreferrer"
 					>


### PR DESCRIPTION
## Summary

Last piece of [[PLAN-859]] (web-first onboarding on-ramp). The `<ConnectWorkspaceModal>`'s three footer/install links were placeholders pointing at GitHub README anchors while TASK-863's docs page didn't exist. That page is now live ([pad-web#30](https://github.com/PerpetualSoftware/pad-web/pull/30)), so swap the three URLs to the real docs.

| Link | Before | After |
|---|---|---|
| **Other install options →** | `github.com/PerpetualSoftware/pad#installation` | `getpad.dev/docs#installation` |
| **Documentation** | `github.com/PerpetualSoftware/pad#getting-started` | `getpad.dev/docs/connect-workspace` |
| **Troubleshooting** | `github.com/PerpetualSoftware/pad#installation` | `getpad.dev/docs/connect-workspace#troubleshooting` |

In-source comment updated to reflect that the URLs are now canonical, not placeholders.

This closes out PLAN-859: a user who creates a workspace in the web UI now has a complete in-app + docs path to connecting it to their local project.

## Test plan

- [x] `cd web && npm run build` clean
- [x] `go build ./... && go test ./...` clean
- [x] `make install` clean

Refs: PLAN-859, TASK-863 (docs page), TASK-861 (modal that hosts these links), IDEA-750