### PR TITLE
feat(store): attachments table + Attachment model (TASK-869)

### DIFF
--- a/internal/models/attachment.go
+++ b/internal/models/attachment.go
@@ -1,0 +1,40 @@
+package models
+
+import "time"
+
+// Attachment models a single uploaded blob in the attachments table.
+//
+// See [[Attachments — architecture & migration design]] (DOC-865). Storage is
+// content-addressed: StorageKey is "<backend>:<sha256>" so the driver registry
+// resolves the prefix to a concrete AttachmentStore. Item content references
+// attachments by UUID via "pad-attachment:<id>" — never by URL — so a backend
+// migration (FS → S3) leaves item content untouched.
+//
+// Derived blobs (thumbnails) are rows of their own with ParentID pointing at
+// the original and Variant set to one of "thumb-sm" / "thumb-md". They count
+// against the workspace storage quota — they are real bytes on disk.
+type Attachment struct {
+	ID          string  `json:"id"`
+	WorkspaceID string  `json:"workspace_id"`
+	ItemID      *string `json:"item_id,omitempty"` // nil = orphan, eligible for GC
+	UploadedBy  string  `json:"uploaded_by"`
+	StorageKey  string  `json:"storage_key"` // "<backend>:<hash>"
+	ContentHash string  `json:"content_hash"`
+	MimeType    string  `json:"mime_type"`
+	SizeBytes   int64   `json:"size_bytes"`
+	Filename    string  `json:"filename"`
+	Width       *int    `json:"width,omitempty"`  // images only
+	Height      *int    `json:"height,omitempty"` // images only
+	ParentID    *string `json:"parent_id,omitempty"`
+	Variant     *string `json:"variant,omitempty"` // "original" | "thumb-sm" | "thumb-md"
+
+	CreatedAt time.Time  `json:"created_at"`
+	DeletedAt *time.Time `json:"deleted_at,omitempty"`
+}
+
+// Attachment variants.
+const (
+	AttachmentVariantOriginal = "original"
+	AttachmentVariantThumbSm  = "thumb-sm"
+	AttachmentVariantThumbMd  = "thumb-md"
+)

--- a/internal/store/migrations/047_attachments.sql
+++ b/internal/store/migrations/047_attachments.sql
@@ -1,0 +1,47 @@
+-- Migration 047: Attachments table for inline images + file uploads (TASK-869).
+--
+-- See [[Attachments — architecture & migration design]] (DOC-865) for the full
+-- design. This migration is schema groundwork only — no Go consumers yet.
+--
+-- Key columns:
+--   storage_key   "<backend>:<hash>" so the driver registry can route by
+--                 prefix. Phase 1 ships fs:; Phase 2 introduces s3:.
+--   content_hash  Raw sha256 of the original bytes. Same hash across rows
+--                 means the same physical blob is referenced — content-
+--                 addressed dedupe is a free side effect.
+--   item_id       Nullable. NULL = orphan, eligible for GC after the grace
+--                 period expires.
+--   parent_id     Non-null on derived blobs (thumbnails) so the GC can
+--                 reclaim them when the original goes away.
+--   variant       'original' | 'thumb-sm' | 'thumb-md' | NULL.
+--   deleted_at    Soft delete; orphan GC reclaims later.
+
+CREATE TABLE IF NOT EXISTS attachments (
+    id            TEXT PRIMARY KEY,
+    workspace_id  TEXT NOT NULL,
+    item_id       TEXT,
+    uploaded_by   TEXT NOT NULL,
+    storage_key   TEXT NOT NULL,
+    content_hash  TEXT NOT NULL,
+    mime_type     TEXT NOT NULL,
+    size_bytes    INTEGER NOT NULL,
+    filename      TEXT NOT NULL,
+    width         INTEGER,
+    height        INTEGER,
+    parent_id     TEXT,
+    variant       TEXT,
+    created_at    TEXT NOT NULL,
+    deleted_at    TEXT
+);
+
+-- Hot paths:
+--   workspace lookup for storage usage SUM and listing
+--   item lookup for "what's attached to this item" + GC orphan scan
+--   hash lookup for dedupe (full index, not partial — dedupe must see
+--     soft-deleted rows so a re-upload of the same bytes can resurrect
+--     the existing blob without writing a duplicate)
+--   parent lookup so the GC can find a derived blob's siblings
+CREATE INDEX IF NOT EXISTS idx_attach_workspace ON attachments(workspace_id) WHERE deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_attach_item      ON attachments(item_id)      WHERE deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_attach_hash      ON attachments(content_hash);
+CREATE INDEX IF NOT EXISTS idx_attach_parent    ON attachments(parent_id)    WHERE parent_id IS NOT NULL;

--- a/internal/store/pgmigrations/026_attachments.sql
+++ b/internal/store/pgmigrations/026_attachments.sql
@@ -1,0 +1,25 @@
+-- Postgres mirror of migrations/047_attachments.sql (TASK-869).
+-- See [[Attachments — architecture & migration design]] (DOC-865) for context.
+
+CREATE TABLE IF NOT EXISTS attachments (
+    id            TEXT PRIMARY KEY,
+    workspace_id  TEXT NOT NULL,
+    item_id       TEXT,
+    uploaded_by   TEXT NOT NULL,
+    storage_key   TEXT NOT NULL,
+    content_hash  TEXT NOT NULL,
+    mime_type     TEXT NOT NULL,
+    size_bytes    BIGINT NOT NULL,
+    filename      TEXT NOT NULL,
+    width         INTEGER,
+    height        INTEGER,
+    parent_id     TEXT,
+    variant       TEXT,
+    created_at    TEXT NOT NULL,
+    deleted_at    TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_attach_workspace ON attachments(workspace_id) WHERE deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_attach_item      ON attachments(item_id)      WHERE deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_attach_hash      ON attachments(content_hash);
+CREATE INDEX IF NOT EXISTS idx_attach_parent    ON attachments(parent_id)    WHERE parent_id IS NOT NULL;


### PR DESCRIPTION
## Summary

Schema groundwork for inline images + file uploads — first task under PLAN-866. No code consumers yet; subsequent tasks build on this.

- `internal/store/migrations/047_attachments.sql` — SQLite table + 4 indexes
- `internal/store/pgmigrations/026_attachments.sql` — Postgres mirror (BIGINT for `size_bytes`)
- `internal/models/attachment.go` — Go model with pointer types for nullables

Partial indexes on `workspace_id` / `item_id` / `parent_id` mirror the existing `items` table convention. The `content_hash` index is intentionally **full** (not partial on `deleted_at IS NULL`) so dedupe can resurrect a soft-deleted blob without writing a duplicate when the same bytes are re-uploaded.

## Context

Implements `TASK-869` under `PLAN-866` (Attachments Phase 1). Architecture: `DOC-865`.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./...` — all packages pass (server + store run real migrations during tests)
- [x] `make install` — migration applied cleanly to live dev DB; verified table + 4 indexes via `sqlite3` and `schema_migrations` row recorded