### PR TITLE
feat(attachments): AttachmentStore interface + FSStore (TASK-870)

### DIFF
--- a/internal/attachments/fs_store.go
+++ b/internal/attachments/fs_store.go
@@ -1,0 +1,221 @@
+package attachments
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// FSPrefix is the storage-key prefix this backend registers under.
+const FSPrefix = "fs"
+
+// FSStore writes attachment blobs onto the local filesystem under a
+// sharded directory layout:
+//
+//	<baseDir>/<aa>/<bb>/<full-hash>
+//
+// where aa = hash[0:2] and bb = hash[2:4]. Sharding two levels deep keeps
+// each individual directory's file count bounded — at one million blobs
+// uniformly distributed across 256*256 buckets, each leaf holds ~16
+// entries — which keeps directory readdir + lookup fast on every common
+// filesystem.
+//
+// Writes are atomic: each Put streams to a randomly-named temp file in
+// the destination directory, fsyncs the data, then renames into place.
+// rename(2) within the same directory is atomic on POSIX, so a partial
+// blob never becomes visible under its final hash-named path. Concurrent
+// Puts of the same hash converge: both writers stream identical bytes,
+// both rename to the same target, and the second rename atomically
+// replaces the first with byte-identical content.
+type FSStore struct {
+	baseDir string
+}
+
+// NewFSStore returns a store rooted at baseDir, creating the directory
+// if it does not exist. baseDir is typically <DataDir>/attachments.
+func NewFSStore(baseDir string) (*FSStore, error) {
+	if baseDir == "" {
+		return nil, errors.New("attachments: FSStore baseDir must not be empty")
+	}
+	if err := os.MkdirAll(baseDir, 0o755); err != nil {
+		return nil, fmt.Errorf("attachments: create FSStore baseDir: %w", err)
+	}
+	return &FSStore{baseDir: baseDir}, nil
+}
+
+// Prefix returns the registry prefix this store is registered under
+// ("fs"). Useful for tests and for the orphan GC, which needs to know
+// which prefix to scan.
+func (s *FSStore) Prefix() string { return FSPrefix }
+
+// pathFor returns the full on-disk path for a given hash.
+func (s *FSStore) pathFor(hash string) string {
+	// hash has already been validated to be at least 4 chars by the
+	// callers — guard here defensively for direct use in tests.
+	if len(hash) < 4 {
+		return filepath.Join(s.baseDir, "_short", hash)
+	}
+	return filepath.Join(s.baseDir, hash[0:2], hash[2:4], hash)
+}
+
+// extractHash pulls the hash component out of an "fs:<hash>" key.
+func extractHash(key string) (string, error) {
+	prefix, hash, ok := strings.Cut(key, ":")
+	if !ok || prefix != FSPrefix {
+		return "", fmt.Errorf("attachments: FSStore cannot resolve key %q", key)
+	}
+	if hash == "" {
+		return "", fmt.Errorf("attachments: FSStore key %q has empty hash", key)
+	}
+	return hash, nil
+}
+
+// validHash returns true if h looks like a hex-encoded sha256 — 64 lowercase
+// hex characters. We only accept this canonical form so on-disk paths are
+// stable and predictable across architectures.
+func validHash(h string) bool {
+	if len(h) != 64 {
+		return false
+	}
+	for i := 0; i < len(h); i++ {
+		c := h[i]
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+			return false
+		}
+	}
+	return true
+}
+
+// Put writes the blob streamed from r at the canonical sharded path for
+// hash. _ mime is ignored by this backend (S3 will use it for object
+// metadata). The bytes are hashed during the write and verified against
+// the supplied hash before the rename — a mismatch leaves no visible
+// file and returns an error.
+func (s *FSStore) Put(ctx context.Context, hash, _ string, r io.Reader) (string, error) {
+	if !validHash(hash) {
+		return "", fmt.Errorf("attachments: FSStore.Put expected 64-char hex sha256, got %q", hash)
+	}
+	key := FSPrefix + ":" + hash
+	target := s.pathFor(hash)
+
+	// Idempotent fast path: if the canonical file already exists we
+	// trust prior writes (every prior write went through the same
+	// hash-verify rename dance). Skipping the write here is what makes
+	// concurrent Puts of the same hash cheap on the second caller.
+	if _, err := os.Stat(target); err == nil {
+		// Drain r so the caller doesn't hit a stuck stream — they
+		// passed a body in expecting it would be read.
+		_, _ = io.Copy(io.Discard, r)
+		return key, nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return "", fmt.Errorf("attachments: FSStore stat target %q: %w", target, err)
+	}
+
+	dir := filepath.Dir(target)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", fmt.Errorf("attachments: FSStore mkdir %q: %w", dir, err)
+	}
+
+	// Temp file lives in the same directory as the final path so the
+	// rename is intra-directory (atomic on POSIX). Randomized suffix
+	// avoids collision with other concurrent Puts of the same hash.
+	tmp, err := os.CreateTemp(dir, "."+hash+".*.tmp")
+	if err != nil {
+		return "", fmt.Errorf("attachments: FSStore create temp: %w", err)
+	}
+	tmpPath := tmp.Name()
+
+	// Always remove the temp file unless we successfully renamed it.
+	committed := false
+	defer func() {
+		if !committed {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+
+	// Stream + hash + write in one pass.
+	h := sha256.New()
+	if _, err := io.Copy(io.MultiWriter(tmp, h), r); err != nil {
+		_ = tmp.Close()
+		return "", fmt.Errorf("attachments: FSStore copy to temp: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return "", fmt.Errorf("attachments: FSStore fsync temp: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return "", fmt.Errorf("attachments: FSStore close temp: %w", err)
+	}
+
+	actual := hex.EncodeToString(h.Sum(nil))
+	if actual != hash {
+		return "", fmt.Errorf("attachments: FSStore hash mismatch: expected %s, got %s", hash, actual)
+	}
+
+	// Rename into place. Even if a parallel writer beat us here, they
+	// wrote byte-identical content, so atomically replacing it is safe.
+	if err := os.Rename(tmpPath, target); err != nil {
+		return "", fmt.Errorf("attachments: FSStore rename: %w", err)
+	}
+	committed = true
+
+	// Honor cancellation only after success — partial writes have
+	// already been cleaned up by the deferred cleanup above.
+	if err := ctx.Err(); err != nil {
+		return key, nil //nolint:nilerr // commit is durable; cancellation is informational here
+	}
+	return key, nil
+}
+
+// Get opens the blob for read. The returned reader MUST be closed by the
+// caller. ErrNotFound is returned (wrapped) if the key has no blob.
+func (s *FSStore) Get(_ context.Context, key string) (io.ReadCloser, error) {
+	hash, err := extractHash(key)
+	if err != nil {
+		return nil, err
+	}
+	f, err := os.Open(s.pathFor(hash))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf("%w: %s", ErrNotFound, key)
+		}
+		return nil, fmt.Errorf("attachments: FSStore open %q: %w", key, err)
+	}
+	return f, nil
+}
+
+// Stat returns the on-disk size of the blob, or an ErrNotFound-wrapped
+// error if the key has no blob.
+func (s *FSStore) Stat(_ context.Context, key string) (int64, error) {
+	hash, err := extractHash(key)
+	if err != nil {
+		return 0, err
+	}
+	fi, err := os.Stat(s.pathFor(hash))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return 0, fmt.Errorf("%w: %s", ErrNotFound, key)
+		}
+		return 0, fmt.Errorf("attachments: FSStore stat %q: %w", key, err)
+	}
+	return fi.Size(), nil
+}
+
+// Delete removes the blob. Deleting a missing key is NOT an error —
+// callers (orphan GC) treat it as the success case.
+func (s *FSStore) Delete(_ context.Context, key string) error {
+	hash, err := extractHash(key)
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(s.pathFor(hash)); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("attachments: FSStore delete %q: %w", key, err)
+	}
+	return nil
+}

--- a/internal/attachments/fs_store.go
+++ b/internal/attachments/fs_store.go
@@ -54,24 +54,27 @@ func NewFSStore(baseDir string) (*FSStore, error) {
 // which prefix to scan.
 func (s *FSStore) Prefix() string { return FSPrefix }
 
-// pathFor returns the full on-disk path for a given hash.
+// pathFor returns the full on-disk path for a given hash. Callers MUST
+// have already validated the hash via validHash — this function does not
+// re-check, since every public method routes through extractHash which
+// validates, and Put validates directly.
 func (s *FSStore) pathFor(hash string) string {
-	// hash has already been validated to be at least 4 chars by the
-	// callers — guard here defensively for direct use in tests.
-	if len(hash) < 4 {
-		return filepath.Join(s.baseDir, "_short", hash)
-	}
 	return filepath.Join(s.baseDir, hash[0:2], hash[2:4], hash)
 }
 
-// extractHash pulls the hash component out of an "fs:<hash>" key.
+// extractHash pulls the hash component out of an "fs:<hash>" key and
+// validates it. We require the canonical 64-char lowercase-hex sha256
+// form on every public method — not only Put — because a key segment
+// that ends up as a path component is a path-traversal vector if the
+// caller can sneak in "/" or ".." (e.g. "fs:../../etc/passwd"). The
+// validHash gate makes that impossible.
 func extractHash(key string) (string, error) {
 	prefix, hash, ok := strings.Cut(key, ":")
 	if !ok || prefix != FSPrefix {
 		return "", fmt.Errorf("attachments: FSStore cannot resolve key %q", key)
 	}
-	if hash == "" {
-		return "", fmt.Errorf("attachments: FSStore key %q has empty hash", key)
+	if !validHash(hash) {
+		return "", fmt.Errorf("attachments: FSStore key %q has invalid hash component", key)
 	}
 	return hash, nil
 }
@@ -105,13 +108,21 @@ func (s *FSStore) Put(ctx context.Context, hash, _ string, r io.Reader) (string,
 	target := s.pathFor(hash)
 
 	// Idempotent fast path: if the canonical file already exists we
-	// trust prior writes (every prior write went through the same
-	// hash-verify rename dance). Skipping the write here is what makes
-	// concurrent Puts of the same hash cheap on the second caller.
+	// can skip the temp-write + rename. We still MUST verify that the
+	// supplied reader's bytes hash to the supplied hash — the
+	// AttachmentStore.Put contract requires it, and silently trusting
+	// a caller-supplied hash here would let a buggy upload path
+	// associate the wrong content with a hash. Stream r through a
+	// hasher (no disk I/O) and compare.
 	if _, err := os.Stat(target); err == nil {
-		// Drain r so the caller doesn't hit a stuck stream — they
-		// passed a body in expecting it would be read.
-		_, _ = io.Copy(io.Discard, r)
+		h := sha256.New()
+		if _, err := io.Copy(h, r); err != nil {
+			return "", fmt.Errorf("attachments: FSStore drain reader (target exists): %w", err)
+		}
+		actual := hex.EncodeToString(h.Sum(nil))
+		if actual != hash {
+			return "", fmt.Errorf("attachments: FSStore hash mismatch (target exists): expected %s, got %s", hash, actual)
+		}
 		return key, nil
 	} else if !errors.Is(err, os.ErrNotExist) {
 		return "", fmt.Errorf("attachments: FSStore stat target %q: %w", target, err)

--- a/internal/attachments/fs_store_test.go
+++ b/internal/attachments/fs_store_test.go
@@ -216,20 +216,66 @@ func TestFSStore_ConcurrentPutSameHashConverges(t *testing.T) {
 	}
 }
 
-func TestFSStore_GetWithBadKeyFormat(t *testing.T) {
+func TestFSStore_GetStatDeleteRejectBadKeys(t *testing.T) {
 	s := newTestFSStore(t)
 	cases := []string{
 		"",
 		"no-prefix",
-		"s3:abcd",         // wrong backend
-		"fs:",             // empty hash
-		"fs:notreallyahex", // unrouted prefix? actually still "fs:" prefix — extractHash returns it but pathFor will not find the file → ErrNotFound
+		"s3:" + strings.Repeat("a", 64), // wrong backend
+		"fs:",                           // empty hash
+		"fs:notreallyahex",              // not 64 hex chars
+		"fs:" + strings.Repeat("g", 64), // non-hex
+		"fs:../../../etc/passwd",        // path traversal
+		"fs:aa/bb",                      // path separator
+		"fs:" + strings.ToUpper(sha256Hex([]byte("x"))), // wrong case
 	}
 	for _, k := range cases {
-		_, err := s.Get(context.Background(), k)
-		if err == nil {
-			t.Fatalf("Get(%q) returned nil error", k)
+		if _, err := s.Get(context.Background(), k); err == nil {
+			t.Fatalf("Get(%q) returned nil err", k)
 		}
+		if _, err := s.Stat(context.Background(), k); err == nil {
+			t.Fatalf("Stat(%q) returned nil err", k)
+		}
+		if err := s.Delete(context.Background(), k); err == nil {
+			t.Fatalf("Delete(%q) returned nil err", k)
+		}
+	}
+}
+
+func TestFSStore_PutFastPathStillVerifiesHash(t *testing.T) {
+	s := newTestFSStore(t)
+	ctx := context.Background()
+
+	body := []byte("legit bytes")
+	hash := sha256Hex(body)
+
+	// First call seeds the canonical file.
+	if _, err := s.Put(ctx, hash, "", bytes.NewReader(body)); err != nil {
+		t.Fatal(err)
+	}
+
+	// Second call lies about the hash: target file exists, but the
+	// supplied reader streams bytes that do NOT hash to the supplied
+	// hash. Put MUST refuse — the contract requires verification on
+	// every call, not only the first.
+	wrongBody := []byte("attacker bytes")
+	_, err := s.Put(ctx, hash, "", bytes.NewReader(wrongBody))
+	if err == nil {
+		t.Fatal("expected hash mismatch on fast path, got nil")
+	}
+	if !strings.Contains(err.Error(), "hash mismatch") {
+		t.Fatalf("err = %v, want hash mismatch", err)
+	}
+
+	// Original file untouched.
+	rc, err := s.Get(ctx, "fs:"+hash)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := io.ReadAll(rc)
+	rc.Close()
+	if !bytes.Equal(got, body) {
+		t.Fatalf("fast-path hash-mismatch corrupted on-disk content: got %q want %q", got, body)
 	}
 }
 

--- a/internal/attachments/fs_store_test.go
+++ b/internal/attachments/fs_store_test.go
@@ -1,0 +1,240 @@
+package attachments
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func sha256Hex(b []byte) string {
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
+
+func newTestFSStore(t *testing.T) *FSStore {
+	t.Helper()
+	s, err := NewFSStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewFSStore: %v", err)
+	}
+	return s
+}
+
+func TestFSStore_PutGetStatDelete(t *testing.T) {
+	s := newTestFSStore(t)
+	ctx := context.Background()
+
+	body := []byte("hello attachments")
+	hash := sha256Hex(body)
+
+	key, err := s.Put(ctx, hash, "text/plain", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+	if want := "fs:" + hash; key != want {
+		t.Fatalf("key = %q, want %q", key, want)
+	}
+
+	// Verify on-disk path matches the sharded layout.
+	expected := filepath.Join(s.baseDir, hash[0:2], hash[2:4], hash)
+	if _, err := os.Stat(expected); err != nil {
+		t.Fatalf("expected file at %s: %v", expected, err)
+	}
+
+	rc, err := s.Get(ctx, key)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	got, err := io.ReadAll(rc)
+	rc.Close()
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if !bytes.Equal(got, body) {
+		t.Fatalf("got %q, want %q", got, body)
+	}
+
+	size, err := s.Stat(ctx, key)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if size != int64(len(body)) {
+		t.Fatalf("size = %d, want %d", size, len(body))
+	}
+
+	if err := s.Delete(ctx, key); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, err := s.Stat(ctx, key); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("Stat after Delete = %v, want ErrNotFound", err)
+	}
+}
+
+func TestFSStore_GetMissingReturnsErrNotFound(t *testing.T) {
+	s := newTestFSStore(t)
+	hash := sha256Hex([]byte("missing"))
+	_, err := s.Get(context.Background(), "fs:"+hash)
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("Get missing = %v, want ErrNotFound", err)
+	}
+}
+
+func TestFSStore_DeleteMissingIsNoop(t *testing.T) {
+	s := newTestFSStore(t)
+	hash := sha256Hex([]byte("missing"))
+	if err := s.Delete(context.Background(), "fs:"+hash); err != nil {
+		t.Fatalf("Delete missing should be no-op, got %v", err)
+	}
+}
+
+func TestFSStore_HashMismatchRejected(t *testing.T) {
+	s := newTestFSStore(t)
+	body := []byte("real bytes")
+	wrongHash := sha256Hex([]byte("not these bytes"))
+
+	_, err := s.Put(context.Background(), wrongHash, "application/octet-stream", bytes.NewReader(body))
+	if err == nil {
+		t.Fatal("expected hash mismatch error, got nil")
+	}
+	if !strings.Contains(err.Error(), "hash mismatch") {
+		t.Fatalf("err = %v, want hash mismatch", err)
+	}
+	// File must NOT exist at the bogus path.
+	if _, statErr := os.Stat(s.pathFor(wrongHash)); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("hash-mismatch left a file: %v", statErr)
+	}
+	// And no orphan tmp files left behind.
+	dir := filepath.Join(s.baseDir, wrongHash[0:2], wrongHash[2:4])
+	entries, _ := os.ReadDir(dir)
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), ".") && strings.HasSuffix(e.Name(), ".tmp") {
+			t.Fatalf("orphan temp file left behind: %s", e.Name())
+		}
+	}
+}
+
+func TestFSStore_PutInvalidHashRejected(t *testing.T) {
+	s := newTestFSStore(t)
+	cases := []string{
+		"",
+		"abc",                                                                  // too short
+		strings.Repeat("g", 64),                                                // non-hex
+		strings.Repeat("a", 63),                                                // wrong length
+		strings.ToUpper(sha256Hex([]byte("uppercase rejected for stable path"))), // wrong case
+	}
+	for _, h := range cases {
+		_, err := s.Put(context.Background(), h, "", bytes.NewReader(nil))
+		if err == nil {
+			t.Fatalf("Put(%q) accepted invalid hash", h)
+		}
+	}
+}
+
+func TestFSStore_PutIdempotent(t *testing.T) {
+	s := newTestFSStore(t)
+	ctx := context.Background()
+	body := []byte("idempotent")
+	hash := sha256Hex(body)
+
+	key1, err := s.Put(ctx, hash, "", bytes.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	key2, err := s.Put(ctx, hash, "", bytes.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if key1 != key2 {
+		t.Fatalf("keys differ: %s vs %s", key1, key2)
+	}
+	// Second call must not have left a temp file in the leaf dir.
+	leaf := filepath.Join(s.baseDir, hash[0:2], hash[2:4])
+	entries, _ := os.ReadDir(leaf)
+	if len(entries) != 1 {
+		var names []string
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Fatalf("expected exactly one entry in leaf dir, got %d: %v", len(entries), names)
+	}
+}
+
+func TestFSStore_ConcurrentPutSameHashConverges(t *testing.T) {
+	s := newTestFSStore(t)
+	ctx := context.Background()
+	body := bytes.Repeat([]byte("concurrency"), 4096) // ~46KB
+	hash := sha256Hex(body)
+
+	const goroutines = 16
+	var wg sync.WaitGroup
+	keys := make([]string, goroutines)
+	errs := make([]error, goroutines)
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func(i int) {
+			defer wg.Done()
+			keys[i], errs[i] = s.Put(ctx, hash, "application/octet-stream", bytes.NewReader(body))
+		}(i)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("worker %d: %v", i, err)
+		}
+		if keys[i] != "fs:"+hash {
+			t.Fatalf("worker %d returned key %q", i, keys[i])
+		}
+	}
+
+	// Final on-disk content must equal the input bytes.
+	rc, err := s.Get(ctx, "fs:"+hash)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	defer rc.Close()
+	got, _ := io.ReadAll(rc)
+	if !bytes.Equal(got, body) {
+		t.Fatalf("on-disk content does not match input")
+	}
+
+	// No orphan temp files left behind.
+	leaf := filepath.Join(s.baseDir, hash[0:2], hash[2:4])
+	entries, _ := os.ReadDir(leaf)
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), ".") && strings.HasSuffix(e.Name(), ".tmp") {
+			t.Fatalf("orphan temp file: %s", e.Name())
+		}
+	}
+}
+
+func TestFSStore_GetWithBadKeyFormat(t *testing.T) {
+	s := newTestFSStore(t)
+	cases := []string{
+		"",
+		"no-prefix",
+		"s3:abcd",         // wrong backend
+		"fs:",             // empty hash
+		"fs:notreallyahex", // unrouted prefix? actually still "fs:" prefix — extractHash returns it but pathFor will not find the file → ErrNotFound
+	}
+	for _, k := range cases {
+		_, err := s.Get(context.Background(), k)
+		if err == nil {
+			t.Fatalf("Get(%q) returned nil error", k)
+		}
+	}
+}
+
+func TestNewFSStore_EmptyBaseDirRejected(t *testing.T) {
+	if _, err := NewFSStore(""); err == nil {
+		t.Fatal("expected error for empty baseDir")
+	}
+}

--- a/internal/attachments/registry.go
+++ b/internal/attachments/registry.go
@@ -1,0 +1,85 @@
+package attachments
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+)
+
+// Registry routes a storage key to the AttachmentStore that owns it,
+// keyed by the prefix portion of "<prefix>:<rest>". Phase 1 ships exactly
+// one prefix ("fs"); Phase 2 will register "s3" alongside it during the
+// migration window.
+//
+// Registry is safe for concurrent reads after registration completes.
+// Register should be called during process startup before any Resolve
+// happens (concurrent Register + Resolve is technically safe under the
+// mutex but no production caller mixes them).
+type Registry struct {
+	mu     sync.RWMutex
+	stores map[string]AttachmentStore
+}
+
+// NewRegistry returns an empty registry.
+func NewRegistry() *Registry {
+	return &Registry{stores: make(map[string]AttachmentStore)}
+}
+
+// Register installs store under prefix (e.g. "fs", "s3"). The prefix MUST
+// NOT contain a colon — Resolve splits keys on the first colon, so a
+// prefix with a colon would be unreachable.
+//
+// Registering the same prefix twice replaces the previous store. This is
+// the explicit contract for tests; production callers register each
+// prefix exactly once at startup.
+func (r *Registry) Register(prefix string, store AttachmentStore) {
+	if strings.Contains(prefix, ":") {
+		panic(fmt.Sprintf("attachments: Registry prefix must not contain ':' (got %q)", prefix))
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.stores[prefix] = store
+}
+
+// Resolve returns the store responsible for key, or an error if no
+// matching backend is registered. The key format is "<prefix>:<rest>".
+func (r *Registry) Resolve(key string) (AttachmentStore, error) {
+	prefix, _, ok := strings.Cut(key, ":")
+	if !ok || prefix == "" {
+		return nil, fmt.Errorf("attachments: invalid storage key %q (missing prefix)", key)
+	}
+	r.mu.RLock()
+	store, ok := r.stores[prefix]
+	r.mu.RUnlock()
+	if !ok {
+		return nil, fmt.Errorf("attachments: no store registered for prefix %q", prefix)
+	}
+	return store, nil
+}
+
+// Get / Stat / Delete are convenience helpers that resolve the key first.
+func (r *Registry) Get(ctx context.Context, key string) (io.ReadCloser, error) {
+	s, err := r.Resolve(key)
+	if err != nil {
+		return nil, err
+	}
+	return s.Get(ctx, key)
+}
+
+func (r *Registry) Stat(ctx context.Context, key string) (int64, error) {
+	s, err := r.Resolve(key)
+	if err != nil {
+		return 0, err
+	}
+	return s.Stat(ctx, key)
+}
+
+func (r *Registry) Delete(ctx context.Context, key string) error {
+	s, err := r.Resolve(key)
+	if err != nil {
+		return err
+	}
+	return s.Delete(ctx, key)
+}

--- a/internal/attachments/registry_test.go
+++ b/internal/attachments/registry_test.go
@@ -1,0 +1,124 @@
+package attachments
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestRegistry_ResolveAndRoute(t *testing.T) {
+	s := newTestFSStore(t)
+	r := NewRegistry()
+	r.Register(FSPrefix, s)
+
+	body := []byte("registry routes me to fs")
+	hash := sha256Hex(body)
+	key, err := s.Put(context.Background(), hash, "", bytes.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Resolve returns the right backend for an "fs:..." key.
+	got, err := r.Resolve(key)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got != s {
+		t.Fatalf("Resolve returned wrong store")
+	}
+
+	// Convenience helpers route correctly.
+	rc, err := r.Get(context.Background(), key)
+	if err != nil {
+		t.Fatalf("Registry.Get: %v", err)
+	}
+	bs, _ := io.ReadAll(rc)
+	rc.Close()
+	if !bytes.Equal(bs, body) {
+		t.Fatalf("Registry.Get returned %q", bs)
+	}
+
+	size, err := r.Stat(context.Background(), key)
+	if err != nil {
+		t.Fatalf("Registry.Stat: %v", err)
+	}
+	if size != int64(len(body)) {
+		t.Fatalf("size = %d", size)
+	}
+
+	if err := r.Delete(context.Background(), key); err != nil {
+		t.Fatalf("Registry.Delete: %v", err)
+	}
+}
+
+func TestRegistry_ResolveErrors(t *testing.T) {
+	r := NewRegistry()
+
+	cases := []string{
+		"",
+		"no-prefix",
+		":nopfx",
+	}
+	for _, k := range cases {
+		if _, err := r.Resolve(k); err == nil {
+			t.Fatalf("Resolve(%q) returned nil err", k)
+		}
+	}
+
+	// Unknown prefix.
+	_, err := r.Resolve("s3:abc")
+	if err == nil || !strings.Contains(err.Error(), "no store registered") {
+		t.Fatalf("expected unknown-prefix error, got %v", err)
+	}
+
+	// Get / Stat / Delete also surface the resolve error rather than panicking.
+	if _, err := r.Get(context.Background(), "s3:abc"); err == nil {
+		t.Fatal("Get on unknown prefix should error")
+	}
+	if _, err := r.Stat(context.Background(), "s3:abc"); err == nil {
+		t.Fatal("Stat on unknown prefix should error")
+	}
+	if err := r.Delete(context.Background(), "s3:abc"); err == nil {
+		t.Fatal("Delete on unknown prefix should error")
+	}
+}
+
+func TestRegistry_RegisterPrefixWithColonPanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic")
+		}
+	}()
+	r := NewRegistry()
+	r.Register("bad:prefix", nil)
+}
+
+// staticErrStore is a degenerate AttachmentStore used to verify the
+// Registry forwards errors verbatim from the underlying store.
+type staticErrStore struct{ err error }
+
+func (s staticErrStore) Put(context.Context, string, string, io.Reader) (string, error) {
+	return "", s.err
+}
+func (s staticErrStore) Get(context.Context, string) (io.ReadCloser, error) { return nil, s.err }
+func (s staticErrStore) Stat(context.Context, string) (int64, error)        { return 0, s.err }
+func (s staticErrStore) Delete(context.Context, string) error               { return s.err }
+
+func TestRegistry_ForwardsBackendErrors(t *testing.T) {
+	want := errors.New("backend boom")
+	r := NewRegistry()
+	r.Register("fs", staticErrStore{err: want})
+
+	if _, err := r.Get(context.Background(), "fs:abc"); !errors.Is(err, want) {
+		t.Fatalf("Get err = %v", err)
+	}
+	if _, err := r.Stat(context.Background(), "fs:abc"); !errors.Is(err, want) {
+		t.Fatalf("Stat err = %v", err)
+	}
+	if err := r.Delete(context.Background(), "fs:abc"); !errors.Is(err, want) {
+		t.Fatalf("Delete err = %v", err)
+	}
+}

--- a/internal/attachments/store.go
+++ b/internal/attachments/store.go
@@ -1,0 +1,59 @@
+// Package attachments provides the storage backend abstraction for
+// attachment blobs (images and files uploaded into items). See DOC-865
+// "Attachments — architecture & migration design" for the full design.
+//
+// Storage is content-addressed: every blob is keyed by sha256(content).
+// Identical bytes → identical key → one physical copy. Each AttachmentStore
+// implementation maps a hash to a concrete location (filesystem path, S3
+// object key, …) and namespaces its keys with a backend prefix
+// ("fs:<hash>", "s3:<bucket>/<hash>", …) so a Registry can route a key to
+// the right backend by prefix alone. This decouples item content (which
+// stores opaque "pad-attachment:<uuid>" references) from the backend the
+// blob actually lives in, and enables backend migrations (FS → S3) that
+// touch zero item content.
+package attachments
+
+import (
+	"context"
+	"errors"
+	"io"
+)
+
+// AttachmentStore is the backend abstraction every storage implementation
+// must satisfy. Methods are safe for concurrent use.
+type AttachmentStore interface {
+	// Put writes the blob from r into the backend, addressable by hash.
+	// The implementation MUST verify that the bytes streamed from r hash
+	// to the supplied hash and return an error if they do not — this is
+	// the integrity guarantee callers rely on.
+	//
+	// Put is idempotent: writing the same hash twice is a no-op on the
+	// second call. Concurrent Puts of the same hash converge — both
+	// callers receive the same key and the on-disk content is unchanged.
+	//
+	// The returned key is the "<backend>:<...>" form that Registry uses to
+	// route subsequent Get/Stat/Delete calls back to this store.
+	//
+	// mime is informational (some backends, e.g. S3, store it as object
+	// metadata). The FS backend ignores it; MIME for serving comes from
+	// the attachments DB row.
+	Put(ctx context.Context, hash, mime string, r io.Reader) (key string, err error)
+
+	// Get returns a ReadCloser positioned at the start of the blob.
+	// Callers MUST close the returned reader. If key is unknown to this
+	// store, the returned error wraps ErrNotFound.
+	Get(ctx context.Context, key string) (io.ReadCloser, error)
+
+	// Stat returns the size in bytes of the blob identified by key. If
+	// key is unknown, the returned error wraps ErrNotFound.
+	Stat(ctx context.Context, key string) (size int64, err error)
+
+	// Delete removes the blob identified by key. Deleting a missing key
+	// is NOT an error — callers (e.g. the orphan GC) treat it as the
+	// success case.
+	Delete(ctx context.Context, key string) error
+}
+
+// ErrNotFound is returned (or wrapped) by Get/Stat when the requested key
+// is not present in the backend. Callers can compare with errors.Is.
+var ErrNotFound = errors.New("attachment not found")


### PR DESCRIPTION
## Summary

Introduces the storage backend abstraction (DOC-865) and its first concrete implementation. No call sites yet — TASK-871 (upload API) wires it in.

- **`AttachmentStore`** interface — Put/Get/Stat/Delete. Put is idempotent and verifies the streamed bytes hash to the supplied value before committing.
- **`Registry`** — routes \`\"<prefix>:<rest>\"\` keys to the store for that prefix. Phase 1 ships \`fs\`; Phase 2 will register \`s3\` alongside it during the migration window.
- **`FSStore`** — writes to \`<baseDir>/<aa>/<bb>/<full-hash>\`, two-level shard. Atomic writes via temp-file + fsync + intra-directory rename. Idempotent fast path skips re-write when the canonical file already exists.

## Context

Implements \`TASK-870\` under \`PLAN-866\` (Attachments Phase 1). Architecture: \`DOC-865\`.

## Test plan

- [x] \`go build ./...\` — clean
- [x] \`go vet ./...\` — clean
- [x] \`go test ./...\` — all packages pass
- [x] \`go test ./internal/attachments/ -race\` — covers put/get/stat/delete, hash mismatch, invalid hash, idempotency, 16-goroutine concurrent Put-same-hash convergence, registry routing/error-forward/colon-prefix panic
- [x] \`make install\` — binary builds and server restarts