### PR TITLE
feat(attachments): download/serve API with auth + Range support (TASK-872)

### DIFF
--- a/internal/server/handlers_attachments.go
+++ b/internal/server/handlers_attachments.go
@@ -11,7 +11,11 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
 
 	"github.com/PerpetualSoftware/pad/internal/attachments"
 	"github.com/PerpetualSoftware/pad/internal/models"
@@ -242,13 +246,14 @@ func (s *Server) handleUploadAttachment(w http.ResponseWriter, r *http.Request) 
 	}
 
 	// Quota tracking — log only, no enforcement in Phase 1. The download
-	// URL is intentionally NOT returned by this handler: the serve
-	// endpoint lands in TASK-872. Until then, returning a URL here
-	// would point at a 404 and lull clients into baking it in.
+	// URL points at the GET handler shipped in TASK-872 (same PR series).
+	// Workspaces are addressed by slug everywhere else in the API; we
+	// surface the {slug} form here so the UI can link directly.
 	s.goAsync(func() { s.maybeWarnStorageQuota(workspaceID) })
 
 	writeJSON(w, http.StatusCreated, map[string]any{
 		"id":          att.ID,
+		"url":         attachmentURL(chi.URLParam(r, "slug"), att.ID),
 		"mime":        att.MimeType,
 		"size":        att.SizeBytes,
 		"width":       att.Width,
@@ -257,6 +262,13 @@ func (s *Server) handleUploadAttachment(w http.ResponseWriter, r *http.Request) 
 		"category":    string(entry.Category),
 		"render_mode": renderModeString(entry.RenderMode),
 	})
+}
+
+// attachmentURL returns the canonical download URL for an attachment.
+// Uses the workspace slug from the request — the same shape every other
+// API endpoint uses, so clients can build it without an extra lookup.
+func attachmentURL(workspaceSlug, attachmentID string) string {
+	return "/api/v1/workspaces/" + workspaceSlug + "/attachments/" + attachmentID
 }
 
 func renderModeString(m attachments.RenderMode) string {
@@ -270,6 +282,185 @@ func renderModeString(m attachments.RenderMode) string {
 	default:
 		return "chip"
 	}
+}
+
+// handleGetAttachment streams an attachment back to the caller. Auth is
+// enforced by the route's RequireWorkspaceAccess middleware; we
+// additionally require viewer+ here.
+//
+// The handler:
+//   - Looks up the row by ID (TASK-871's UUID), refusing with 404 if it
+//     belongs to a different workspace — leaking 403 vs 404 on a
+//     cross-workspace probe would let a member of workspace A enumerate
+//     attachment IDs in workspace B.
+//   - Optionally resolves a derived variant (?variant=thumb-sm|thumb-md).
+//     If the variant row is missing (TASK-878 hasn't generated thumbnails
+//     for this attachment yet), falls back to the original — clients can
+//     always ask for a thumb and get something renderable.
+//   - Resolves the storage backend via the Registry and opens the blob.
+//   - Sets Content-Type from the DB row (which is already the canonical
+//     post-allowlist MIME, not the client-supplied one).
+//   - Sets Content-Disposition from the MIME's RenderMode entry:
+//     RenderForceDownload → "attachment", everything else → "inline".
+//   - Hands off to http.ServeContent when the backend supports Seek
+//     (FSStore returns *os.File, so this is the common path) — that
+//     gives us If-Modified-Since, If-None-Match, Range/206, Accept-Ranges
+//     all for free. Backends that only support Read fall back to a
+//     plain stream copy with no Range support.
+//   - Sets a short Cache-Control: private, max-age=3600. Phase 3 will
+//     revisit for CDN caching.
+func (s *Server) handleGetAttachment(w http.ResponseWriter, r *http.Request) {
+	if !requireMinRole(w, r, "viewer") {
+		return
+	}
+	if s.attachments == nil {
+		writeError(w, http.StatusServiceUnavailable, "attachments_disabled",
+			"Attachment storage is not configured on this server")
+		return
+	}
+	workspaceID, ok := s.getWorkspaceID(w, r)
+	if !ok {
+		return
+	}
+
+	id := chi.URLParam(r, "attachmentID")
+	if id == "" {
+		writeError(w, http.StatusBadRequest, "bad_request", "Missing attachment id")
+		return
+	}
+
+	att, err := s.store.GetAttachment(id)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	// Cross-workspace defense: 404 (not 403) so an attacker can't
+	// distinguish "exists in another workspace" from "doesn't exist".
+	if att == nil || att.WorkspaceID != workspaceID || att.DeletedAt != nil {
+		writeError(w, http.StatusNotFound, "not_found", "Attachment not found")
+		return
+	}
+
+	// Optional variant lookup. If the requested variant doesn't exist
+	// yet (TASK-878 generates thumbnails — until that ships, every
+	// variant fetch falls back to the original) we silently serve the
+	// original. The editor uses thumbnails as an optimization, not a
+	// correctness requirement, so falling back keeps every render path
+	// working as soon as TASK-872 ships.
+	if variant := r.URL.Query().Get("variant"); variant != "" {
+		if !isKnownVariant(variant) {
+			writeError(w, http.StatusBadRequest, "bad_variant",
+				"Unknown variant — supported: thumb-sm, thumb-md")
+			return
+		}
+		if derived, dErr := s.store.GetAttachmentVariant(att.ID, variant); dErr != nil {
+			writeInternalError(w, dErr)
+			return
+		} else if derived != nil {
+			att = derived
+		}
+	}
+
+	store, err := s.attachments.Resolve(att.StorageKey)
+	if err != nil {
+		writeInternalError(w, fmt.Errorf("resolve attachment store for %s: %w", att.StorageKey, err))
+		return
+	}
+	body, err := store.Get(r.Context(), att.StorageKey)
+	if err != nil {
+		if errors.Is(err, attachments.ErrNotFound) {
+			// DB row exists but the on-disk blob is missing. This is a
+			// "shouldn't happen" state — log it and return 404 so the
+			// client can surface a useful error to the user.
+			slog.Warn("attachments: blob missing for live row",
+				"attachment_id", att.ID, "storage_key", att.StorageKey)
+			writeError(w, http.StatusNotFound, "blob_missing",
+				"Attachment metadata exists but the file is missing on disk")
+			return
+		}
+		writeInternalError(w, fmt.Errorf("get attachment blob: %w", err))
+		return
+	}
+	defer body.Close()
+
+	// Headers come BEFORE ServeContent / io.Copy so they make it onto
+	// the wire even when the response is a 304 / 206.
+	w.Header().Set("Content-Type", att.MimeType)
+	w.Header().Set("Cache-Control", "private, max-age=3600")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+
+	disposition := "inline"
+	if entry, ok := attachments.LookupMIME(att.MimeType); ok && entry.RenderMode == attachments.RenderForceDownload {
+		disposition = "attachment"
+	}
+	w.Header().Set("Content-Disposition",
+		fmt.Sprintf(`%s; filename=%q`, disposition, sanitizeHeaderFilename(att.Filename)))
+
+	// http.ServeContent gives Range, conditional GETs, and 206
+	// responses for free — but it requires an io.ReadSeeker. FSStore
+	// returns an *os.File, which satisfies that. Backends that don't
+	// support Seek (a future S3 streaming reader, say) fall back to a
+	// plain Copy with no Range / 304 support.
+	if seeker, ok := body.(io.ReadSeeker); ok {
+		modtime := att.CreatedAt
+		if modtime.IsZero() {
+			modtime = time.Now()
+		}
+		http.ServeContent(w, r, att.Filename, modtime, seeker)
+		return
+	}
+
+	// Streaming fallback. Set Content-Length when the backend exposes
+	// it (Stat is cheap on the FS but may be a network call on S3 —
+	// we only call it here, never on the ServeContent fast path).
+	if size, sErr := store.Stat(r.Context(), att.StorageKey); sErr == nil && size >= 0 {
+		w.Header().Set("Content-Length", strconv.FormatInt(size, 10))
+	}
+	if _, copyErr := io.Copy(w, body); copyErr != nil {
+		// Body has likely already been written to; can't change status.
+		// Just log so we have a trail.
+		slog.Warn("attachments: streaming copy failed",
+			"attachment_id", att.ID, "error", copyErr)
+	}
+}
+
+// isKnownVariant gates the ?variant= query against a closed set so an
+// attacker can't probe arbitrary variant strings. Mirrors the constants
+// in models.Attachment.
+func isKnownVariant(v string) bool {
+	switch v {
+	case models.AttachmentVariantThumbSm, models.AttachmentVariantThumbMd, models.AttachmentVariantOriginal:
+		return true
+	}
+	return false
+}
+
+// sanitizeHeaderFilename strips characters that can't safely appear in
+// a Content-Disposition filename header — quotes, CR, LF, and any
+// control byte. The Filename column was already basenamed at upload
+// time so path separators are not a concern; we only need to keep the
+// header value parseable.
+func sanitizeHeaderFilename(name string) string {
+	if name == "" {
+		return "attachment"
+	}
+	var b strings.Builder
+	b.Grow(len(name))
+	for _, r := range name {
+		switch {
+		case r == '"' || r == '\\':
+			// Drop quotes and backslashes — they break the quoted-string syntax.
+		case r < 0x20 || r == 0x7f:
+			// Drop control bytes — protect against header injection.
+		default:
+			b.WriteRune(r)
+		}
+	}
+	out := b.String()
+	if out == "" {
+		return "attachment"
+	}
+	return out
 }
 
 // maybeWarnStorageQuota emits a slog warning if the workspace's usage

--- a/internal/server/handlers_attachments_download_test.go
+++ b/internal/server/handlers_attachments_download_test.go
@@ -1,0 +1,288 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/attachments"
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// uploadHelper does a fresh upload and returns the parsed response.
+func uploadHelper(t *testing.T, srv *Server, slug string, filename string, body []byte) (id, mime, urlPath string) {
+	t.Helper()
+	rr := doMultipartUpload(srv, slug, filename, body)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("upload(%s): status=%d body=%s", filename, rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		ID   string `json:"id"`
+		URL  string `json:"url"`
+		MIME string `json:"mime"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode upload resp: %v", err)
+	}
+	return resp.ID, resp.MIME, resp.URL
+}
+
+func TestDownload_HappyPathPNG(t *testing.T) {
+	srv, slug := testServerWithAttachments(t)
+	body := realPNG()
+	id, mime, urlPath := uploadHelper(t, srv, slug, "screen.png", body)
+
+	req := httptest.NewRequest("GET", urlPath, nil)
+	req.RemoteAddr = "127.0.0.1:1234"
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rr.Code, rr.Body.String())
+	}
+	if got := rr.Header().Get("Content-Type"); got != mime {
+		t.Errorf("Content-Type = %q, want %q", got, mime)
+	}
+	if got := rr.Header().Get("Content-Disposition"); !strings.HasPrefix(got, "inline;") {
+		t.Errorf("Content-Disposition = %q, want inline; ...", got)
+	}
+	if got := rr.Header().Get("Cache-Control"); got != "private, max-age=3600" {
+		t.Errorf("Cache-Control = %q", got)
+	}
+	if got := rr.Header().Get("X-Content-Type-Options"); got != "nosniff" {
+		t.Errorf("X-Content-Type-Options = %q, want nosniff", got)
+	}
+	if got := rr.Body.Bytes(); len(got) != len(body) {
+		t.Errorf("body len = %d, want %d", len(got), len(body))
+	}
+	// Sanity: the served bytes match the uploaded bytes.
+	if !equalBytes(rr.Body.Bytes(), body) {
+		t.Errorf("served bytes do not match uploaded bytes (id=%s)", id)
+	}
+}
+
+func TestDownload_HTMLForcedAsAttachment(t *testing.T) {
+	srv, slug := testServerWithAttachments(t)
+	html := []byte("<!doctype html><html><body><script>alert(1)</script></body></html>")
+	_, _, urlPath := uploadHelper(t, srv, slug, "page.html", html)
+
+	req := httptest.NewRequest("GET", urlPath, nil)
+	req.RemoteAddr = "127.0.0.1:1234"
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d", rr.Code)
+	}
+	if got := rr.Header().Get("Content-Disposition"); !strings.HasPrefix(got, "attachment;") {
+		t.Errorf("Content-Disposition = %q, want attachment; ... (HTML must force download)", got)
+	}
+}
+
+func TestDownload_NotFound(t *testing.T) {
+	srv, slug := testServerWithAttachments(t)
+	req := httptest.NewRequest("GET", "/api/v1/workspaces/"+slug+"/attachments/00000000-0000-0000-0000-000000000000", nil)
+	req.RemoteAddr = "127.0.0.1:1234"
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rr.Code)
+	}
+}
+
+func TestDownload_CrossWorkspaceReturns404(t *testing.T) {
+	srv, slugA := testServerWithAttachments(t)
+	slugB := createWSForTest(t, srv)
+
+	// Upload into workspace A.
+	id, _, _ := uploadHelper(t, srv, slugA, "secret.png", realPNG())
+
+	// Try to fetch from workspace B with A's attachment ID.
+	req := httptest.NewRequest("GET", "/api/v1/workspaces/"+slugB+"/attachments/"+id, nil)
+	req.RemoteAddr = "127.0.0.1:1234"
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	// MUST be 404, not 403 — leaking 403 vs 404 lets a member of B
+	// enumerate attachment IDs in A.
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("cross-workspace status = %d, want 404 (NOT 403)", rr.Code)
+	}
+}
+
+func TestDownload_Range_206(t *testing.T) {
+	srv, slug := testServerWithAttachments(t)
+	// Build a payload long enough that a Range request makes sense.
+	// Use a real MP4 magic header so the upload passes MIME sniff, then
+	// pad with zero bytes.
+	mp4 := []byte{
+		0x00, 0x00, 0x00, 0x18, 'f', 't', 'y', 'p', 'm', 'p', '4', '2',
+		0x00, 0x00, 0x00, 0x00, 'm', 'p', '4', '2', 'i', 's', 'o', 'm',
+	}
+	payload := append(mp4, make([]byte, 4096)...)
+	_, _, urlPath := uploadHelper(t, srv, slug, "clip.mp4", payload)
+
+	req := httptest.NewRequest("GET", urlPath, nil)
+	req.Header.Set("Range", "bytes=10-29")
+	req.RemoteAddr = "127.0.0.1:1234"
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusPartialContent {
+		t.Fatalf("status = %d, want 206", rr.Code)
+	}
+	if got := rr.Header().Get("Accept-Ranges"); got != "bytes" {
+		t.Errorf("Accept-Ranges = %q, want bytes", got)
+	}
+	if got := rr.Header().Get("Content-Range"); !strings.HasPrefix(got, "bytes 10-29/") {
+		t.Errorf("Content-Range = %q, want bytes 10-29/...", got)
+	}
+	if got := rr.Body.Len(); got != 20 {
+		t.Errorf("body len = %d, want 20", got)
+	}
+	if got, want := rr.Body.Bytes(), payload[10:30]; !equalBytes(got, want) {
+		t.Errorf("range bytes mismatch")
+	}
+
+	// Content-Length = 20 on a successful Range response.
+	if cl, _ := strconv.Atoi(rr.Header().Get("Content-Length")); cl != 20 {
+		t.Errorf("Content-Length = %v, want 20", cl)
+	}
+}
+
+func TestDownload_VariantFallbackToOriginal(t *testing.T) {
+	srv, slug := testServerWithAttachments(t)
+	body := realPNG()
+	_, _, urlPath := uploadHelper(t, srv, slug, "tiny.png", body)
+
+	// Ask for thumb-sm — TASK-878 hasn't generated thumbs yet, so the
+	// handler must silently serve the original.
+	req := httptest.NewRequest("GET", urlPath+"?variant=thumb-sm", nil)
+	req.RemoteAddr = "127.0.0.1:1234"
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (variant should fall back to original)", rr.Code)
+	}
+	if !equalBytes(rr.Body.Bytes(), body) {
+		t.Errorf("variant fallback returned different bytes than original")
+	}
+}
+
+func TestDownload_VariantUnknown(t *testing.T) {
+	srv, slug := testServerWithAttachments(t)
+	_, _, urlPath := uploadHelper(t, srv, slug, "x.png", realPNG())
+	req := httptest.NewRequest("GET", urlPath+"?variant=quantum-foo", nil)
+	req.RemoteAddr = "127.0.0.1:1234"
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 for unknown variant", rr.Code)
+	}
+}
+
+func TestDownload_VariantHitsDerivedRow(t *testing.T) {
+	srv, slug := testServerWithAttachments(t)
+	body := realPNG()
+	id, _, urlPath := uploadHelper(t, srv, slug, "with-thumb.png", body)
+
+	// Hand-craft a derived row pointing at the same blob (so the FSStore
+	// already has the bytes — TASK-878 will do this for real with a
+	// real thumbnail). Variant lookup MUST find it and serve it.
+	wsID := mustWorkspaceID(t, srv, slug)
+	att, _ := srv.store.GetAttachment(id)
+	parentID := att.ID
+	variant := models.AttachmentVariantThumbSm
+	derived := &models.Attachment{
+		WorkspaceID: wsID,
+		UploadedBy:  "system",
+		StorageKey:  att.StorageKey, // same blob
+		ContentHash: att.ContentHash,
+		MimeType:    att.MimeType,
+		SizeBytes:   att.SizeBytes,
+		Filename:    "thumb-sm.png",
+		ParentID:    &parentID,
+		Variant:     &variant,
+	}
+	if err := srv.store.CreateAttachment(derived); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest("GET", urlPath+"?variant=thumb-sm", nil)
+	req.RemoteAddr = "127.0.0.1:1234"
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d", rr.Code)
+	}
+	if got := rr.Header().Get("Content-Disposition"); !strings.Contains(got, "thumb-sm.png") {
+		t.Errorf("Content-Disposition = %q, want filename to be the derived row's (thumb-sm.png)", got)
+	}
+}
+
+func TestDownload_BlobMissingOnDisk(t *testing.T) {
+	srv, slug := testServerWithAttachments(t)
+	id, _, urlPath := uploadHelper(t, srv, slug, "ephemeral.png", realPNG())
+
+	// Yank the blob out from under the row by deleting it via the store
+	// directly. This simulates the "DB row points at a hash whose file
+	// has been GC'd / corrupted" case.
+	att, _ := srv.store.GetAttachment(id)
+	store, err := srv.attachments.Resolve(att.StorageKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Delete(context.Background(), att.StorageKey); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest("GET", urlPath, nil)
+	req.RemoteAddr = "127.0.0.1:1234"
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404 when blob missing for live row", rr.Code)
+	}
+}
+
+func TestDownload_FilenameSanitized(t *testing.T) {
+	// We can't trigger this via upload (filepath.Base strips path
+	// separators) so test the helper directly.
+	cases := map[string]string{
+		"normal.png":   "normal.png",
+		`"quoted".png`: "quoted.png",
+		"control\x00\x01.png":   "control.png",
+		`with\backslash.png`:  "withbackslash.png",
+		"":                     "attachment",
+		"\x00\x01\x02":         "attachment",
+	}
+	for in, want := range cases {
+		if got := sanitizeHeaderFilename(in); got != want {
+			t.Errorf("sanitizeHeaderFilename(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func equalBytes(a, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// silence unused-import linter when this file is the only consumer
+var _ = io.EOF
+var _ = fmt.Sprintf
+var _ = attachments.FSPrefix

--- a/internal/server/handlers_attachments_test.go
+++ b/internal/server/handlers_attachments_test.go
@@ -75,6 +75,7 @@ func TestUpload_HappyPathPNG(t *testing.T) {
 	}
 	var resp struct {
 		ID         string `json:"id"`
+		URL        string `json:"url"`
 		MIME       string `json:"mime"`
 		Size       int64  `json:"size"`
 		Width      *int   `json:"width"`
@@ -104,29 +105,12 @@ func TestUpload_HappyPathPNG(t *testing.T) {
 	if resp.RenderMode != "inline" {
 		t.Errorf("render_mode = %q, want inline", resp.RenderMode)
 	}
-	// URL deliberately omitted from the upload response — TASK-872 adds
-	// the GET handler. Until then we don't want clients baking in a 404.
-	if rawURL := gjson(rr.Body.Bytes(), "url"); rawURL != "" {
-		t.Errorf("response should not include url yet (download API ships in TASK-872), got %q", rawURL)
+	// URL is the slug-based download path. Now that TASK-872 ships, the
+	// upload response includes it so the editor doesn't have to build
+	// the path itself.
+	if !strings.Contains(resp.URL, "/attachments/"+resp.ID) || !strings.Contains(resp.URL, "/workspaces/"+slug) {
+		t.Errorf("url = %q, want to contain workspace slug %q and attachment id %q", resp.URL, slug, resp.ID)
 	}
-}
-
-// gjson is a minimal JSON field reader for asserting on the absence of
-// a key. We don't pull in tidwall/gjson — callers only ever look at one
-// shallow string field per call.
-func gjson(b []byte, key string) string {
-	var m map[string]any
-	if err := json.Unmarshal(b, &m); err != nil {
-		return ""
-	}
-	v, ok := m[key]
-	if !ok {
-		return ""
-	}
-	if s, ok := v.(string); ok {
-		return s
-	}
-	return ""
 }
 
 func TestUpload_RejectsExeAsPNG(t *testing.T) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -688,8 +688,11 @@ func (s *Server) setupRouter() {
 						})
 					})
 
-					// Attachments (TASK-871 — upload only; download lands in TASK-872)
+					// Attachments
+					//   POST   /attachments              — upload (TASK-871)
+					//   GET    /attachments/{attachmentID} — serve blob (TASK-872, supports ?variant=)
 					r.Post("/attachments", s.handleUploadAttachment)
+					r.Get("/attachments/{attachmentID}", s.handleGetAttachment)
 
 					// Webhooks
 					r.Route("/webhooks", func(r chi.Router) {

--- a/internal/store/attachments.go
+++ b/internal/store/attachments.go
@@ -87,6 +87,27 @@ func (s *Store) GetAttachment(id string) (*models.Attachment, error) {
 	return a, nil
 }
 
+// GetAttachmentVariant returns the derived attachment row for parentID
+// with the given variant key (e.g. "thumb-sm"), or (nil, nil) if no such
+// row exists. Used by the download handler when a client passes
+// ?variant=thumb-sm — TASK-878 will populate these rows; TASK-872
+// implements the lookup so the handler degrades gracefully when no
+// thumbnail exists yet.
+func (s *Store) GetAttachmentVariant(parentID, variant string) (*models.Attachment, error) {
+	a, err := scanAttachment(s.db.QueryRow(s.q(`
+		SELECT `+attachmentColumns+` FROM attachments
+		WHERE parent_id = ? AND variant = ? AND deleted_at IS NULL
+		LIMIT 1
+	`), parentID, variant))
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get attachment variant: %w", err)
+	}
+	return a, nil
+}
+
 // WorkspaceStorageUsage returns the total bytes consumed by non-deleted
 // attachments in the workspace. Includes derived blobs (thumbnails) —
 // those are real bytes on disk and count against quota.


### PR DESCRIPTION
## Summary

Pairs with TASK-871's upload. Auth-gated GET that streams the blob from the resolved backend with proper headers, Range support via \`http.ServeContent\` (when the backend exposes Seek — FSStore does), cross-workspace 404 to avoid leaking existence, variant lookup with silent fallback to the original.

\`GET /api/v1/workspaces/{slug}/attachments/{attachmentID}\` — optional \`?variant=thumb-sm|thumb-md\`.

Headers: Content-Type from canonical MIME, Content-Disposition inline/attachment per the RenderMode entry (sanitized filename), Cache-Control private/max-age=3600, X-Content-Type-Options nosniff.

Upload response now includes \`url\` again (TASK-871 had dropped it pending this PR).

## Context

Implements \`TASK-872\` under \`PLAN-866\` (Attachments Phase 1). Architecture: \`DOC-865\`. Builds on TASK-869 (schema), TASK-870 (FSStore), TASK-871 (upload).

## Test plan

- [x] \`go build ./...\` — clean
- [x] \`go vet ./...\` — clean
- [x] \`go test ./...\` — all packages pass
- [x] download tests cover: happy path PNG inline, HTML force-download, 404 missing, **cross-workspace 404 (NOT 403)**, Range 206 with bytes 10-29 of an MP4, variant fallback to original (TASK-878 hasn't populated thumbnails yet — handler degrades silently), unknown variant 400, derived thumb-sm row honored when present, blob-missing 404, filename sanitizer table
- [x] upload happy-path test now asserts the response \`url\` round-trips
- [x] \`make install\` — server restarts on the new binary