### PR TITLE
feat(attachments): CLI + TypeScript clients + types (TASK-873)

### DIFF
--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -6210,30 +6210,51 @@ Examples:
 			id := args[0]
 			outPath := args[1]
 
-			var w io.Writer
+			// Stdout case: we can't roll back partial output, so any
+			// failure mid-stream is just visible as a short payload.
 			if outPath == "-" {
-				w = os.Stdout
-			} else {
-				f, err := os.Create(outPath)
+				mime, n, err := client.DownloadAttachment(ws, id, variantFlag, os.Stdout)
 				if err != nil {
-					return fmt.Errorf("create %s: %w", outPath, err)
+					return err
 				}
-				defer f.Close()
-				w = f
+				fmt.Fprintf(os.Stderr, "wrote %d bytes (%s)\n", n, mime)
+				return nil
 			}
 
-			mime, n, err := client.DownloadAttachment(ws, id, variantFlag, w)
+			// File case: write to a sibling temp file first and rename
+			// on success. A bad attachment ID, auth failure, or partial
+			// download otherwise truncates the existing destination
+			// file (Codex round 1, P2).
+			dir := filepath.Dir(outPath)
+			tmp, err := os.CreateTemp(dir, "."+filepath.Base(outPath)+".*.tmp")
+			if err != nil {
+				return fmt.Errorf("create download temp in %s: %w", dir, err)
+			}
+			tmpPath := tmp.Name()
+			committed := false
+			defer func() {
+				tmp.Close()
+				if !committed {
+					_ = os.Remove(tmpPath)
+				}
+			}()
+
+			mime, n, err := client.DownloadAttachment(ws, id, variantFlag, tmp)
 			if err != nil {
 				return err
 			}
-
-			// Only chatter to stderr when piping to stdout, so the
-			// payload stream stays clean.
-			if outPath == "-" {
-				fmt.Fprintf(os.Stderr, "wrote %d bytes (%s)\n", n, mime)
-			} else {
-				fmt.Printf("Saved %d bytes (%s) to %s\n", n, mime, outPath)
+			if err := tmp.Sync(); err != nil {
+				return fmt.Errorf("sync temp: %w", err)
 			}
+			if err := tmp.Close(); err != nil {
+				return fmt.Errorf("close temp: %w", err)
+			}
+			if err := os.Rename(tmpPath, outPath); err != nil {
+				return fmt.Errorf("rename %s -> %s: %w", tmpPath, outPath, err)
+			}
+			committed = true
+
+			fmt.Printf("Saved %d bytes (%s) to %s\n", n, mime, outPath)
 			return nil
 		},
 	}

--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -94,6 +94,7 @@ func main() {
 		githubCmd(),
 		roleCmd(),
 		webhooksCmd(),
+		attachmentCmd(),
 		dbCmd(),
 		completionCmd(),
 	)
@@ -6086,5 +6087,157 @@ func starredCmd() *cobra.Command {
 
 	cmd.Flags().BoolVar(&all, "all", false, "include completed/terminal items")
 
+	return cmd
+}
+
+// attachmentCmd is the root for `pad attachment ...` operations.
+//
+// Phase 1 ships upload + download — the endpoints TASK-871 and TASK-872
+// added. List + delete subcommands are intentionally absent because the
+// underlying endpoints don't exist yet (they ship with TASK-881 / a
+// future GC task). Adding clients that hit 404s is worse than not
+// shipping them — same logic that kept "url" out of the upload response
+// until the GET handler landed.
+func attachmentCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "attachment",
+		Short: "Upload and download item attachments",
+		Long: `Upload and download attachments (images, files) on items.
+
+Examples:
+  pad attachment upload TASK-5 ./screenshot.png
+  pad attachment upload TASK-5 ./design.pdf --filename "Design v2.pdf"
+  pad attachment download <attachment-id> ./screenshot.png
+  pad attachment download <attachment-id> --variant thumb-sm ./thumb.png
+
+Attachments belong to a workspace and may optionally reference an item.
+Pass "-" as the item argument to upload without associating with any item.`,
+	}
+
+	cmd.AddCommand(
+		attachmentUploadCmd(),
+		attachmentDownloadCmd(),
+	)
+	return cmd
+}
+
+func attachmentUploadCmd() *cobra.Command {
+	var filenameFlag string
+
+	cmd := &cobra.Command{
+		Use:   "upload <item-ref-or-dash> <path>",
+		Short: "Upload a file as an item attachment",
+		Long: `Upload a file. The first argument is the parent item (issue ref or slug).
+Use "-" to upload without associating with any item.
+
+Examples:
+  pad attachment upload TASK-5 ./screenshot.png
+  pad attachment upload - ./standalone.pdf
+  pad attachment upload TASK-5 ./design.pdf --filename "Design v2.pdf"`,
+		Args: cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, _ := getClient()
+			ws := getWorkspace()
+
+			itemArg := args[0]
+			path := args[1]
+
+			// "-" means "no parent item".
+			itemRef := ""
+			if itemArg != "" && itemArg != "-" {
+				// Resolve via GetItem so the user can pass either a ref
+				// like TASK-5 or a slug — and we fail fast with a useful
+				// error if the item doesn't exist.
+				it, err := client.GetItem(ws, itemArg)
+				if err != nil {
+					return fmt.Errorf("resolve item %q: %w", itemArg, err)
+				}
+				itemRef = it.ID
+			}
+
+			f, err := os.Open(path)
+			if err != nil {
+				return fmt.Errorf("open %s: %w", path, err)
+			}
+			defer f.Close()
+
+			filename := filenameFlag
+			if filename == "" {
+				filename = filepath.Base(path)
+			}
+
+			result, err := client.UploadAttachment(ws, itemRef, filename, f)
+			if err != nil {
+				return err
+			}
+
+			if formatFlag == "json" {
+				return cli.PrintJSON(result)
+			}
+
+			fmt.Printf("Uploaded %s (%s, %d bytes)\n", result.ID, result.MIME, result.Size)
+			fmt.Printf("URL: %s\n", result.URL)
+			if result.Width != nil && result.Height != nil {
+				fmt.Printf("Dimensions: %d × %d\n", *result.Width, *result.Height)
+			}
+			fmt.Printf("Render mode: %s (category: %s)\n", result.RenderMode, result.Category)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&filenameFlag, "filename", "", "override the stored filename (defaults to basename of path)")
+	return cmd
+}
+
+func attachmentDownloadCmd() *cobra.Command {
+	var variantFlag string
+
+	cmd := &cobra.Command{
+		Use:   "download <attachment-id> <out-path>",
+		Short: "Download an attachment by ID",
+		Long: `Download the bytes of an attachment by its UUID. Pass "-" as the out
+path to stream to stdout (useful for piping into image viewers etc.).
+
+Examples:
+  pad attachment download <id> ./screenshot.png
+  pad attachment download <id> --variant thumb-sm ./thumb.png
+  pad attachment download <id> -  | open -f -a Preview`,
+		Args: cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, _ := getClient()
+			ws := getWorkspace()
+
+			id := args[0]
+			outPath := args[1]
+
+			var w io.Writer
+			if outPath == "-" {
+				w = os.Stdout
+			} else {
+				f, err := os.Create(outPath)
+				if err != nil {
+					return fmt.Errorf("create %s: %w", outPath, err)
+				}
+				defer f.Close()
+				w = f
+			}
+
+			mime, n, err := client.DownloadAttachment(ws, id, variantFlag, w)
+			if err != nil {
+				return err
+			}
+
+			// Only chatter to stderr when piping to stdout, so the
+			// payload stream stays clean.
+			if outPath == "-" {
+				fmt.Fprintf(os.Stderr, "wrote %d bytes (%s)\n", n, mime)
+			} else {
+				fmt.Printf("Saved %d bytes (%s) to %s\n", n, mime, outPath)
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&variantFlag, "variant", "", "request a derived variant (thumb-sm | thumb-md)")
 	return cmd
 }

--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -6249,6 +6249,13 @@ Examples:
 			if err := tmp.Close(); err != nil {
 				return fmt.Errorf("close temp: %w", err)
 			}
+			// os.Rename atomically replaces an existing destination on
+			// every supported platform: POSIX rename(2) is atomic-replace
+			// by definition, and Windows uses MoveFileEx with
+			// MOVEFILE_REPLACE_EXISTING (see Go stdlib
+			// internal/syscall/windows/syscall_windows.go Rename — this
+			// has been the behavior since Go 1.5, released 2015). No
+			// platform-specific shim required.
 			if err := os.Rename(tmpPath, outPath); err != nil {
 				return fmt.Errorf("rename %s -> %s: %w", tmpPath, outPath, err)
 			}

--- a/internal/cli/client.go
+++ b/internal/cli/client.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"mime/multipart"
 	"net/http"
 	"net/url"
 	"strings"
@@ -567,6 +568,119 @@ type APIError struct {
 
 func (e *APIError) Error() string {
 	return e.Message
+}
+
+// --- Attachments ---
+//
+// AttachmentUploadResult mirrors the JSON returned by
+// POST /api/v1/workspaces/{slug}/attachments. It is the API contract
+// callers depend on; do NOT replace it with models.Attachment which has
+// different field names and embeds DB-only fields.
+type AttachmentUploadResult struct {
+	ID         string `json:"id"`
+	URL        string `json:"url"`
+	MIME       string `json:"mime"`
+	Size       int64  `json:"size"`
+	Width      *int   `json:"width,omitempty"`
+	Height     *int   `json:"height,omitempty"`
+	Filename   string `json:"filename"`
+	Category   string `json:"category"`
+	RenderMode string `json:"render_mode"`
+}
+
+// UploadAttachment streams the contents of body to
+// POST /api/v1/workspaces/{wsSlug}/attachments as a multipart file
+// part. filename is what the server stores (after basenaming); itemRef
+// is optional and associates the upload with a parent item via the
+// item_id form field — pass empty string for a free-floating upload.
+//
+// The caller is responsible for closing body if it's a *os.File or
+// other io.Closer; this method only reads from it.
+func (c *Client) UploadAttachment(wsSlug, itemRef, filename string, body io.Reader) (*AttachmentUploadResult, error) {
+	// Build the multipart envelope into a pipe so we don't have to
+	// buffer the entire upload in memory before sending.
+	pr, pw := io.Pipe()
+	mw := multipart.NewWriter(pw)
+
+	// Spawn a goroutine that writes the multipart body. We can't write
+	// inline because the http.Request.Body needs to be a Reader the
+	// transport pulls from in parallel with us writing.
+	go func() {
+		defer pw.Close()
+		defer mw.Close()
+
+		if itemRef != "" {
+			if err := mw.WriteField("item_id", itemRef); err != nil {
+				_ = pw.CloseWithError(fmt.Errorf("write item_id field: %w", err))
+				return
+			}
+		}
+		part, err := mw.CreateFormFile("file", filename)
+		if err != nil {
+			_ = pw.CloseWithError(fmt.Errorf("create file part: %w", err))
+			return
+		}
+		if _, err := io.Copy(part, body); err != nil {
+			_ = pw.CloseWithError(fmt.Errorf("stream upload body: %w", err))
+			return
+		}
+	}()
+
+	req, err := c.newRequest("POST", "/workspaces/"+wsSlug+"/attachments", pr)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+
+	// Uploads can be large and slow over a remote link. The default
+	// 10s ClientTimeout is too tight for a 25 MiB upload over a
+	// constrained connection, so use a fresh client with a generous
+	// timeout for this single request only.
+	uploadClient := &http.Client{Timeout: 5 * time.Minute}
+	resp, err := uploadClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("upload attachment: %w", err)
+	}
+	defer resp.Body.Close()
+	var result AttachmentUploadResult
+	if err := c.handleResponse(resp, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// DownloadAttachment streams the bytes of an attachment into w. Returns
+// the Content-Type the server set and the number of bytes copied so
+// callers can verify size or render with the right MIME hint.
+//
+// When variant is non-empty, requests ?variant=<variant>; the server
+// silently falls back to the original if the derived row doesn't exist
+// (TASK-872 / TASK-878 contract).
+func (c *Client) DownloadAttachment(wsSlug, attachmentID, variant string, w io.Writer) (mime string, size int64, err error) {
+	path := "/workspaces/" + wsSlug + "/attachments/" + attachmentID
+	if variant != "" {
+		path += "?variant=" + url.QueryEscape(variant)
+	}
+	req, err := c.newRequest("GET", path, nil)
+	if err != nil {
+		return "", 0, err
+	}
+	// Use a generous timeout — large blobs over a slow link otherwise
+	// trip the default 10s on the package-shared client.
+	dlClient := &http.Client{Timeout: 5 * time.Minute}
+	resp, err := dlClient.Do(req)
+	if err != nil {
+		return "", 0, fmt.Errorf("download attachment: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		return "", 0, c.parseError(resp)
+	}
+	n, copyErr := io.Copy(w, resp.Body)
+	if copyErr != nil {
+		return resp.Header.Get("Content-Type"), n, fmt.Errorf("stream download: %w", copyErr)
+	}
+	return resp.Header.Get("Content-Type"), n, nil
 }
 
 // newRequest creates an http.Request with auth and agent headers set.

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -41,7 +41,8 @@ import type {
 	TOTPSetupResponse,
 	TOTPVerifyResponse,
 	TOTPDisableResponse,
-	AdminBillingStats
+	AdminBillingStats,
+	AttachmentUploadResult
 } from '$lib/types';
 
 const BASE = '/api/v1';
@@ -702,6 +703,90 @@ export const api = {
 				request<{ approved: boolean; user: { id: string; email: string; name: string; role: string } }>(`/auth/cli/sessions/${code}/approve`, {
 					method: 'POST'
 				})
+		}
+	},
+
+	// ── Attachments ──────────────────────────────────────────────────────────
+	//
+	// The upload endpoint takes multipart/form-data, not JSON, so it
+	// bypasses the shared `request` helper (which sets Content-Type:
+	// application/json). It still uses fetch directly with cookies and
+	// CSRF — same behavior every other state-changing request gets.
+	//
+	// downloadUrl is a pure URL builder so callers can wire it directly
+	// into <img src=...>, anchor href, etc. — no fetch needed.
+
+	attachments: {
+		/**
+		 * Upload a file via multipart POST. Returns the persisted
+		 * attachment metadata + the canonical download URL.
+		 *
+		 * @param workspaceSlug  workspace slug (not ID)
+		 * @param file           the File / Blob to upload
+		 * @param itemId         optional parent item UUID — pass undefined
+		 *                       for a free-floating upload
+		 * @param onProgress     optional progress callback. Note: fetch()
+		 *                       has no upload-progress API; pass this only
+		 *                       when the caller wraps with XMLHttpRequest.
+		 *                       Currently unused by this method but kept
+		 *                       in the signature so the editor plugin can
+		 *                       opt in later (TASK-875).
+		 */
+		async upload(
+			workspaceSlug: string,
+			file: File | Blob,
+			itemId?: string,
+			_onProgress?: (loaded: number, total: number) => void
+		): Promise<AttachmentUploadResult> {
+			const fd = new FormData();
+			// FormData.append needs a filename string for Blob inputs;
+			// File already carries its own name.
+			if (file instanceof File) {
+				fd.append('file', file);
+			} else {
+				fd.append('file', file, 'upload.bin');
+			}
+			if (itemId) fd.append('item_id', itemId);
+
+			const headers: Record<string, string> = {};
+			const csrf = getCSRFToken();
+			if (csrf) headers['X-CSRF-Token'] = csrf;
+
+			const resp = await fetch(`${BASE}/workspaces/${workspaceSlug}/attachments`, {
+				method: 'POST',
+				headers,
+				credentials: 'same-origin',
+				body: fd
+			});
+			if (resp.status === 401) {
+				if (typeof window !== 'undefined' && !window.location.pathname.startsWith('/login')) {
+					window.location.href = '/login';
+				}
+				throw new PadApiError({ code: 'unauthorized', message: 'Authentication required' });
+			}
+			if (!resp.ok) {
+				const body = await resp.json().catch(() => null);
+				if (body?.error) throw new PadApiError(body.error);
+				throw new Error(`upload failed: ${resp.status}`);
+			}
+			return (await resp.json()) as AttachmentUploadResult;
+		},
+
+		/**
+		 * Build the GET URL for an attachment. Suitable for <img src> and
+		 * <a href> — the browser sends the auth cookie automatically.
+		 *
+		 * `variant` is optional and currently supports "thumb-sm" or
+		 * "thumb-md"; the server falls back to the original if no
+		 * derived row exists.
+		 */
+		downloadUrl(
+			workspaceSlug: string,
+			attachmentId: string,
+			variant?: 'thumb-sm' | 'thumb-md' | 'original'
+		): string {
+			const base = `${BASE}/workspaces/${workspaceSlug}/attachments/${attachmentId}`;
+			return variant ? `${base}?variant=${encodeURIComponent(variant)}` : base;
 		}
 	},
 

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -746,6 +746,45 @@ export interface AdminBillingStats {
 	cache_age_seconds: number;
 }
 
+// ─── Attachments ─────────────────────────────────────────────────────────────
+//
+// Mirrors the Go internal/models/attachment.go shape for the database row,
+// plus the upload-handler response shape (AttachmentUploadResult — not all
+// fields overlap with the row because the response also carries derived
+// metadata like category and render_mode).
+
+/** A row in the attachments table. */
+export interface Attachment {
+	id: string;
+	workspace_id: string;
+	item_id?: string | null; // null = orphan, eligible for GC
+	uploaded_by: string;
+	storage_key: string;     // "<backend>:<sha256>"
+	content_hash: string;
+	mime_type: string;
+	size_bytes: number;
+	filename: string;
+	width?: number | null;
+	height?: number | null;
+	parent_id?: string | null;
+	variant?: string | null; // "original" | "thumb-sm" | "thumb-md" | null
+	created_at: string;
+	deleted_at?: string | null;
+}
+
+/** Server response from POST /api/v1/workspaces/{slug}/attachments. */
+export interface AttachmentUploadResult {
+	id: string;
+	url: string;
+	mime: string;
+	size: number;
+	width?: number | null;
+	height?: number | null;
+	filename: string;
+	category: 'image' | 'video' | 'audio' | 'document' | 'text' | 'archive' | 'other';
+	render_mode: 'inline' | 'chip' | 'download';
+}
+
 // ─── Helper functions ────────────────────────────────────────────────────────
 
 export function parseFields(item: Item): Record<string, any> {


### PR DESCRIPTION
## Summary

Rounds out the API surface added in TASK-871 + TASK-872 with:

- **Go CLI client**: \`UploadAttachment\` (multipart via \`io.Pipe\` — never buffers in RAM) and \`DownloadAttachment\` (streams to caller's \`io.Writer\`).
- **\`pad attachment\` Cobra command**: \`upload <item-ref|-> <path>\` and \`download <id> <out|->\`. Item arg accepts issue refs (TASK-5) or slugs; "-" means no parent. Out path "-" streams to stdout (status messages go to stderr).
- **TypeScript types**: \`Attachment\` interface mirroring the DB row; \`AttachmentUploadResult\` interface for the upload response shape.
- **TypeScript API client**: \`api.attachments.upload(workspaceSlug, file, itemId?)\` (multipart fetch with CSRF + cookies); \`api.attachments.downloadUrl(...)\` URL builder for \`<img src>\` etc.

\`list\` + \`delete\` subcommands are intentionally omitted — those endpoints don't exist yet (they ship with TASK-881 + the future GC task). Adding clients that hit 404s would mislead callers, same logic that kept \`url\` out of TASK-871's response until TASK-872 wired GET.

## End-to-end smoke

\`\`\`
$ pad attachment upload TASK-869 /tmp/tiny.png
Uploaded aeff0d4e-298f-4311-bc97-8218ebeb863d (image/png, 67 bytes)
URL: /api/v1/workspaces/docapp/attachments/aeff0d4e-298f-4311-bc97-8218ebeb863d
Dimensions: 1 × 1
Render mode: inline (category: image)

$ pad attachment download aeff0d4e-298f-4311-bc97-8218ebeb863d /tmp/dl.png
Saved 67 bytes (image/png) to /tmp/dl.png

$ cmp /tmp/tiny.png /tmp/dl.png && echo OK
OK
\`\`\`

## Context

Implements \`TASK-873\` under \`PLAN-866\` (Attachments Phase 1). Architecture: \`DOC-865\`. Builds on TASK-869–872.

## Test plan

- [x] \`go build ./...\` — clean
- [x] \`go vet ./...\` — clean
- [x] \`go test ./...\` — all packages pass
- [x] \`cd web && npm run build\` — clean
- [x] End-to-end PNG upload → download → \`cmp\` byte-identical against the original
- [x] \`pad attachment --help\` shows the subcommand surface
- [x] \`make install\` — server restarts on the new binary