### PR TITLE
feat(attachments): markdown reference resolver for pad-attachment:UUID (TASK-874)

### DIFF
--- a/internal/server/render/attachments.go
+++ b/internal/server/render/attachments.go
@@ -1,0 +1,395 @@
+// Package render implements server-side rendering helpers shared between
+// API endpoints that emit pre-rendered HTML (a future shared-item view,
+// markdown export pipelines, etc.) and the editor's preview path.
+//
+// Today the only consumer is the attachment reference resolver — image
+// and file-chip rendering for `pad-attachment:UUID` markdown references.
+// The TS-side companion lives at `web/src/lib/markdown/attachments.ts`;
+// keep the two implementations in lock-step so server-rendered and
+// client-rendered output match for the same input. See DOC-865 for the
+// architecture.
+package render
+
+import (
+	"fmt"
+	"html"
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+// AttachmentMeta is the minimal metadata needed to render a `pad-attachment:UUID`
+// reference. Trimmed from the full models.Attachment row so callers can pass
+// a thin DTO without dragging the whole package graph in.
+type AttachmentMeta struct {
+	ID        string
+	MimeType  string
+	Filename  string
+	SizeBytes int64
+	Width     *int
+	Height    *int
+}
+
+// AttachmentResolver looks up an attachment by UUID. Returns nil for
+// missing/deleted attachments — the resolver renders a "missing"
+// placeholder in that case so the document doesn't show a broken-image
+// icon.
+type AttachmentResolver func(uuid string) *AttachmentMeta
+
+// attachmentRefPrefix is the URL scheme item content uses to reference
+// attachments (mirrored on the TS side as ATTACHMENT_URL_PREFIX). Stored
+// verbatim — never resolved to a backend URL — so a backend migration can
+// rewrite storage_keys without touching item content. See DOC-865.
+const attachmentRefPrefix = "pad-attachment:"
+
+// IsAttachmentHref reports whether href is a `pad-attachment:UUID` reference.
+func IsAttachmentHref(href string) bool {
+	return strings.HasPrefix(href, attachmentRefPrefix)
+}
+
+// ParseAttachmentHref returns the UUID portion of a `pad-attachment:UUID`
+// reference, or "" if href is not a pad-attachment reference / has an
+// empty UUID after trimming whitespace.
+func ParseAttachmentHref(href string) string {
+	if !IsAttachmentHref(href) {
+		return ""
+	}
+	return strings.TrimSpace(strings.TrimPrefix(href, attachmentRefPrefix))
+}
+
+// AttachmentDownloadURL builds the canonical attachment download URL.
+// Pass an empty variant for the original; otherwise "thumb-sm" / "thumb-md"
+// (the server falls back to the original if no derived row exists).
+func AttachmentDownloadURL(workspaceSlug, attachmentID, variant string) string {
+	base := "/api/v1/workspaces/" + url.PathEscape(workspaceSlug) + "/attachments/" + url.PathEscape(attachmentID)
+	if variant == "" {
+		return base
+	}
+	return base + "?variant=" + url.QueryEscape(variant)
+}
+
+// IsImageMime reports whether the MIME type renders inline as an image.
+// Mirrors `image/*` from the server-side allowlist (image/png, image/jpeg,
+// image/gif, image/webp, image/avif, image/heic, image/heif).
+func IsImageMime(mime string) bool {
+	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(mime)), "image/")
+}
+
+// FormatAttachmentSize returns a human-readable byte count ("832 B",
+// "1.2 MB", "5 GB"). Negative sizes return "" — that's a corrupt-row
+// signal, not something to print to the user.
+func FormatAttachmentSize(bytes int64) string {
+	if bytes < 0 {
+		return ""
+	}
+	if bytes < 1024 {
+		return fmt.Sprintf("%d B", bytes)
+	}
+	units := []string{"KB", "MB", "GB", "TB"}
+	n := float64(bytes) / 1024
+	i := 0
+	for n >= 1024 && i < len(units)-1 {
+		n /= 1024
+		i++
+	}
+	if n < 10 {
+		return fmt.Sprintf("%.1f %s", n, units[i])
+	}
+	return fmt.Sprintf("%.0f %s", n, units[i])
+}
+
+// RenderAttachmentImage builds an inline `<img>` element for an image
+// attachment. Width/height attributes are emitted when both are known and
+// positive so the browser can reserve layout space before the bytes
+// arrive — avoiding the reflow jank that would otherwise hit on every
+// render cycle.
+//
+// The `data-attachment-id` attribute is the editor's hook for click-to-
+// zoom, rotate, and crop interactions.
+//
+// All user-controlled strings are HTML-escaped before interpolation;
+// callers can safely pipe the result into a larger HTML document.
+func RenderAttachmentImage(meta *AttachmentMeta, alt, workspaceSlug string) string {
+	if meta == nil {
+		return ""
+	}
+	src := AttachmentDownloadURL(workspaceSlug, meta.ID, "thumb-md")
+	altText := alt
+	if strings.TrimSpace(altText) == "" {
+		altText = meta.Filename
+	}
+	sizeAttrs := ""
+	if meta.Width != nil && meta.Height != nil && *meta.Width > 0 && *meta.Height > 0 {
+		sizeAttrs = fmt.Sprintf(` width="%d" height="%d"`, *meta.Width, *meta.Height)
+	}
+	return fmt.Sprintf(`<img src="%s" data-attachment-id="%s" alt="%s"%s>`,
+		html.EscapeString(src),
+		html.EscapeString(meta.ID),
+		html.EscapeString(altText),
+		sizeAttrs,
+	)
+}
+
+// RenderAttachmentChip builds a Notion-style file-chip anchor for a
+// non-image attachment. `target=_blank` + `rel=noopener noreferrer`
+// matches the existing external-link defaults, and the `download`
+// attribute lets browsers save the file with its canonical filename.
+//
+// displayText overrides the chip label when non-empty; otherwise the
+// attachment's filename is used.
+func RenderAttachmentChip(meta *AttachmentMeta, displayText, workspaceSlug string) string {
+	if meta == nil {
+		return ""
+	}
+	href := AttachmentDownloadURL(workspaceSlug, meta.ID, "")
+	label := displayText
+	if strings.TrimSpace(label) == "" {
+		label = meta.Filename
+	}
+	size := FormatAttachmentSize(meta.SizeBytes)
+	sizeSpan := ""
+	if size != "" {
+		sizeSpan = ` <span class="file-chip-size">· ` + html.EscapeString(size) + `</span>`
+	}
+	return fmt.Sprintf(
+		`<a class="file-chip" href="%s" data-attachment-id="%s" download="%s" target="_blank" rel="noopener noreferrer"><span class="file-chip-icon" aria-hidden="true">📄</span><span class="file-chip-name">%s</span>%s</a>`,
+		html.EscapeString(href),
+		html.EscapeString(meta.ID),
+		html.EscapeString(meta.Filename),
+		html.EscapeString(label),
+		sizeSpan,
+	)
+}
+
+// RenderAttachmentMissing builds a placeholder span for a missing/deleted
+// attachment. Keeps the document layout intact and tells the user *why*
+// there's no image — a broken-image icon would suggest a transient network
+// failure, but this is a permanent metadata state (the row is soft-deleted
+// or the UUID was never valid).
+func RenderAttachmentMissing(uuid, alt string) string {
+	safeAlt := alt
+	if strings.TrimSpace(safeAlt) == "" {
+		safeAlt = "Missing attachment"
+	}
+	return fmt.Sprintf(
+		`<span class="attachment-missing" data-attachment-id="%s" title="This attachment is missing or has been deleted">📎 %s</span>`,
+		html.EscapeString(uuid),
+		html.EscapeString(safeAlt),
+	)
+}
+
+// ResolveAttachmentImage resolves a `![alt](pad-attachment:UUID)` image
+// reference into rendered HTML. Falls back to a file chip when the
+// attachment exists but isn't an image MIME — the markdown author asked
+// for an embed, but a PDF or zip can't sensibly inline.
+func ResolveAttachmentImage(href, alt, workspaceSlug string, resolve AttachmentResolver) string {
+	uuid := ParseAttachmentHref(href)
+	if uuid == "" {
+		return ""
+	}
+	meta := resolve(uuid)
+	if meta == nil {
+		return RenderAttachmentMissing(uuid, alt)
+	}
+	if IsImageMime(meta.MimeType) {
+		return RenderAttachmentImage(meta, alt, workspaceSlug)
+	}
+	chipText := alt
+	if strings.TrimSpace(chipText) == "" {
+		chipText = meta.Filename
+	}
+	return RenderAttachmentChip(meta, chipText, workspaceSlug)
+}
+
+// ResolveAttachmentLink resolves a `[text](pad-attachment:UUID)` link
+// reference into rendered HTML. Always renders as a file chip — link
+// syntax indicates the user wants a downloadable reference, not an
+// inline embed, even when the underlying MIME is an image.
+func ResolveAttachmentLink(href, text, workspaceSlug string, resolve AttachmentResolver) string {
+	uuid := ParseAttachmentHref(href)
+	if uuid == "" {
+		return ""
+	}
+	meta := resolve(uuid)
+	if meta == nil {
+		return RenderAttachmentMissing(uuid, text)
+	}
+	return RenderAttachmentChip(meta, text, workspaceSlug)
+}
+
+// markdownAttachmentRefRE matches both image and link forms of a
+// pad-attachment reference in source markdown:
+//
+//	![alt](pad-attachment:UUID)
+//	[text](pad-attachment:UUID)
+//
+// The leading `!?` captures whether the form is image or link. The
+// alt/text capture rejects literal `]` so it stops at the closing
+// bracket; the UUID capture rejects whitespace and `)` so it stops at
+// the closing paren. Markdown's optional " title" suffix on a link
+// destination is handled — anything between the UUID and `)` after a
+// space is captured into a title group we currently ignore (matches
+// our HTML output, which doesn't surface the title attribute today).
+//
+// References inside fenced code blocks must be skipped — that's done
+// by ResolveAttachmentReferences's caller via splitCodeFences.
+var markdownAttachmentRefRE = regexp.MustCompile(
+	`(!?)\[([^\]]*)\]\(pad-attachment:([^\s)]+)(?:\s+"[^"]*")?\)`,
+)
+
+// ResolveAttachmentReferences scans `markdown` for `pad-attachment:UUID`
+// references in standard markdown image/link syntax and replaces each
+// with rendered HTML using the supplied resolver:
+//
+//   - `![alt](pad-attachment:UUID)` → <img> for image MIMEs, file chip otherwise
+//   - `[text](pad-attachment:UUID)` → file chip
+//   - resolver returns nil → missing-attachment placeholder span
+//
+// References inside fenced code blocks (```…```) are left untouched so
+// documentation about the reference syntax renders verbatim. References
+// inside inline code (single backticks) are NOT skipped — that's a known
+// limitation; the editor doesn't generate references inside code spans,
+// and stripping them robustly would require a full markdown tokenizer.
+//
+// The output is mixed markdown + HTML. Downstream callers can pass it
+// through a CommonMark-compatible markdown→HTML stage, which renders
+// HTML blocks and inline HTML transparently.
+func ResolveAttachmentReferences(markdown, workspaceSlug string, resolve AttachmentResolver) string {
+	if resolve == nil {
+		return markdown
+	}
+	chunks := splitCodeFences(markdown)
+	var b strings.Builder
+	b.Grow(len(markdown))
+	for _, c := range chunks {
+		if c.fenced {
+			b.WriteString(c.text)
+			continue
+		}
+		b.WriteString(markdownAttachmentRefRE.ReplaceAllStringFunc(c.text, func(match string) string {
+			sub := markdownAttachmentRefRE.FindStringSubmatch(match)
+			if sub == nil {
+				return match
+			}
+			isImage := sub[1] == "!"
+			altOrText := sub[2]
+			uuid := strings.TrimSpace(sub[3])
+			href := attachmentRefPrefix + uuid
+			if isImage {
+				return ResolveAttachmentImage(href, altOrText, workspaceSlug, resolve)
+			}
+			return ResolveAttachmentLink(href, altOrText, workspaceSlug, resolve)
+		}))
+	}
+	return b.String()
+}
+
+// codeChunk is a single span of input — either inside a fenced code
+// block (fenced=true) or outside one. ResolveAttachmentReferences
+// skips substitution inside fenced spans so docs that demonstrate the
+// reference syntax render literally.
+type codeChunk struct {
+	text   string
+	fenced bool
+}
+
+// splitCodeFences partitions markdown source into alternating fenced /
+// non-fenced spans. The fence detector recognizes the CommonMark form:
+// at least three backticks or tildes at the start of a line, optional
+// info string, terminated by a fence of the same character at column 0
+// (or end of input). Indented code blocks are not skipped — they're
+// rare in our content and the spec for indented code is already fragile.
+func splitCodeFences(s string) []codeChunk {
+	var chunks []codeChunk
+	lines := strings.SplitAfter(s, "\n")
+	var cur strings.Builder
+	inFence := false
+	var fenceChar byte
+	var fenceLen int
+	flush := func(fenced bool) {
+		if cur.Len() == 0 {
+			return
+		}
+		chunks = append(chunks, codeChunk{text: cur.String(), fenced: fenced})
+		cur.Reset()
+	}
+	for _, line := range lines {
+		if !inFence {
+			if ch, n, ok := openingFence(line); ok {
+				// flush the non-fenced span we were accumulating
+				flush(false)
+				inFence = true
+				fenceChar = ch
+				fenceLen = n
+				cur.WriteString(line)
+				continue
+			}
+			cur.WriteString(line)
+			continue
+		}
+		// inside a fence
+		cur.WriteString(line)
+		if isClosingFence(line, fenceChar, fenceLen) {
+			flush(true)
+			inFence = false
+		}
+	}
+	if inFence {
+		flush(true)
+	} else {
+		flush(false)
+	}
+	return chunks
+}
+
+// openingFence checks if line starts a CommonMark fenced code block.
+// Returns the fence character (' ` ' or '~'), the length, and ok.
+func openingFence(line string) (byte, int, bool) {
+	trimmed := strings.TrimLeft(line, " ")
+	// CommonMark allows up to 3 spaces of indent before the fence.
+	if len(line)-len(trimmed) > 3 {
+		return 0, 0, false
+	}
+	if len(trimmed) < 3 {
+		return 0, 0, false
+	}
+	ch := trimmed[0]
+	if ch != '`' && ch != '~' {
+		return 0, 0, false
+	}
+	n := 0
+	for n < len(trimmed) && trimmed[n] == ch {
+		n++
+	}
+	if n < 3 {
+		return 0, 0, false
+	}
+	// For backtick fences, the info string MUST NOT contain a backtick
+	// (CommonMark §4.5). We don't bother validating beyond fence length
+	// here; isClosingFence enforces the matching rules on the close.
+	return ch, n, true
+}
+
+// isClosingFence checks if line closes a fenced code block opened with
+// `fenceLen` of `fenceChar`. The closing fence must be at least as long
+// as the opening fence, and must consist only of the fence character
+// (after optional indentation).
+func isClosingFence(line string, fenceChar byte, fenceLen int) bool {
+	trimmed := strings.TrimLeft(line, " ")
+	if len(line)-len(trimmed) > 3 {
+		return false
+	}
+	// Strip the trailing newline if present.
+	trimmed = strings.TrimRight(trimmed, "\n")
+	trimmed = strings.TrimRight(trimmed, "\r")
+	if len(trimmed) < fenceLen {
+		return false
+	}
+	for i := 0; i < len(trimmed); i++ {
+		if trimmed[i] != fenceChar {
+			// closing fence may be followed only by whitespace
+			return strings.TrimSpace(trimmed[i:]) == "" && i >= fenceLen
+		}
+	}
+	return len(trimmed) >= fenceLen
+}

--- a/internal/server/render/attachments.go
+++ b/internal/server/render/attachments.go
@@ -224,18 +224,52 @@ func ResolveAttachmentLink(href, text, workspaceSlug string, resolve AttachmentR
 //	[text](pad-attachment:UUID)
 //
 // The leading `!?` captures whether the form is image or link. The
-// alt/text capture rejects literal `]` so it stops at the closing
-// bracket; the UUID capture rejects whitespace and `)` so it stops at
-// the closing paren. Markdown's optional " title" suffix on a link
-// destination is handled — anything between the UUID and `)` after a
-// space is captured into a title group we currently ignore (matches
-// our HTML output, which doesn't surface the title attribute today).
+// alt/text capture accepts CommonMark escape sequences (`\]`, `\\`, etc.)
+// so labels containing literal brackets — e.g. `[Q1 \] report](pad-…)` —
+// match the same way marked does on the TS side; without this, the two
+// renderers disagree on edge-case labels and the lock-step contract
+// breaks. Captured escapes are unwound in unescapeMarkdownText before the
+// label reaches the render helpers. The UUID capture rejects whitespace
+// and `)` so it stops at the closing paren. Markdown's optional " title"
+// suffix on a link destination is handled — anything between the UUID
+// and `)` after a space matches the title group we currently ignore
+// (our HTML output doesn't surface the title attribute today).
 //
 // References inside fenced code blocks must be skipped — that's done
 // by ResolveAttachmentReferences's caller via splitCodeFences.
 var markdownAttachmentRefRE = regexp.MustCompile(
-	`(!?)\[([^\]]*)\]\(pad-attachment:([^\s)]+)(?:\s+"[^"]*")?\)`,
+	`(!?)\[((?:\\.|[^\]\\])*)\]\(pad-attachment:([^\s)]+)(?:\s+"[^"]*")?\)`,
 )
+
+// unescapeMarkdownText reverses CommonMark escape sequences in a captured
+// label. Marked's tokenizer drops the backslash and emits the literal
+// character, so the regex-based Go path needs to mirror that behavior
+// before passing the label to the render helpers — otherwise a label
+// like `Q1 \] report` would render with the backslash visible.
+//
+// We only unescape backslash + ASCII punctuation that can appear inside
+// a label match: `\\`, `\]`, `\[`, `\(`, `\)`, `\!`. Other escapes
+// pass through unchanged — matches CommonMark §6.1 closely enough for
+// the labels Pad's editor produces.
+func unescapeMarkdownText(s string) string {
+	if !strings.ContainsRune(s, '\\') {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\\' && i+1 < len(s) {
+			switch s[i+1] {
+			case '\\', ']', '[', '(', ')', '!':
+				b.WriteByte(s[i+1])
+				i++
+				continue
+			}
+		}
+		b.WriteByte(s[i])
+	}
+	return b.String()
+}
 
 // ResolveAttachmentReferences scans `markdown` for `pad-attachment:UUID`
 // references in standard markdown image/link syntax and replaces each
@@ -272,7 +306,7 @@ func ResolveAttachmentReferences(markdown, workspaceSlug string, resolve Attachm
 				return match
 			}
 			isImage := sub[1] == "!"
-			altOrText := sub[2]
+			altOrText := unescapeMarkdownText(sub[2])
 			uuid := strings.TrimSpace(sub[3])
 			href := attachmentRefPrefix + uuid
 			if isImage {

--- a/internal/server/render/attachments_test.go
+++ b/internal/server/render/attachments_test.go
@@ -392,6 +392,82 @@ func TestResolveAttachmentReferences_HandlesTitleSuffix(t *testing.T) {
 	}
 }
 
+func TestResolveAttachmentReferences_EscapedBrackets(t *testing.T) {
+	// Marked's tokenizer accepts `\]` inside link/image labels and emits the
+	// literal `]`. The Go regex must do the same to keep server/client
+	// rendering byte-aligned for edge-case labels.
+	resolver := func(uuid string) *AttachmentMeta {
+		switch uuid {
+		case "img-1":
+			return &AttachmentMeta{ID: "img-1", MimeType: "image/png", Filename: "a.png", SizeBytes: 1}
+		case "doc-1":
+			return &AttachmentMeta{ID: "doc-1", MimeType: "application/pdf", Filename: "doc.pdf", SizeBytes: 1}
+		}
+		return nil
+	}
+	cases := []struct {
+		name     string
+		in       string
+		wantSubs []string
+	}{
+		{
+			name: "escaped close bracket in image alt",
+			in:   `![Q1 \] report](pad-attachment:img-1)`,
+			wantSubs: []string{
+				`data-attachment-id="img-1"`,
+				`alt="Q1 ] report"`,
+			},
+		},
+		{
+			name: "escaped close bracket in link text",
+			in:   `[A \] B](pad-attachment:doc-1)`,
+			wantSubs: []string{
+				`data-attachment-id="doc-1"`,
+				`>A ] B</span>`,
+			},
+		},
+		{
+			name: "escaped backslash and bracket combo",
+			in:   `[a \\ b \[ c \] d](pad-attachment:doc-1)`,
+			wantSubs: []string{
+				`>a \ b [ c ] d</span>`,
+			},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := ResolveAttachmentReferences(c.in, "ws", resolver)
+			for _, s := range c.wantSubs {
+				if !strings.Contains(got, s) {
+					t.Errorf("missing %q in: %s", s, got)
+				}
+			}
+		})
+	}
+}
+
+func TestUnescapeMarkdownText(t *testing.T) {
+	cases := map[string]string{
+		"":                  "",
+		"plain":             "plain",
+		`\\`:                `\`,
+		`\]`:                `]`,
+		`\[`:                `[`,
+		`\(`:                `(`,
+		`\)`:                `)`,
+		`\!`:                `!`,
+		`a \] b`:            `a ] b`,
+		`a \\ b \[ c \] d`:  `a \ b [ c ] d`,
+		`unaffected: \n \t`: `unaffected: \n \t`, // non-punctuation escapes pass through
+		`trailing \`:        `trailing \`,        // dangling backslash preserved
+	}
+	for in, want := range cases {
+		if got := unescapeMarkdownText(in); got != want {
+			t.Errorf("unescapeMarkdownText(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
 func TestSplitCodeFences_NestedAndUnclosed(t *testing.T) {
 	// An unclosed fence at end-of-input should not crash. Everything after
 	// the opener is treated as inside the fence.

--- a/internal/server/render/attachments_test.go
+++ b/internal/server/render/attachments_test.go
@@ -1,0 +1,409 @@
+package render
+
+import (
+	"strings"
+	"testing"
+)
+
+func intp(i int) *int { return &i }
+
+func TestIsAttachmentHref(t *testing.T) {
+	cases := []struct {
+		href string
+		want bool
+	}{
+		{"pad-attachment:abc-123", true},
+		{"pad-attachment:", true}, // technically a prefix, ParseAttachmentHref returns ""
+		{"pad-attachments:abc", false},
+		{"http://example.com", false},
+		{"pad-attachment", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		if got := IsAttachmentHref(c.href); got != c.want {
+			t.Errorf("IsAttachmentHref(%q) = %v, want %v", c.href, got, c.want)
+		}
+	}
+}
+
+func TestParseAttachmentHref(t *testing.T) {
+	cases := []struct {
+		href string
+		want string
+	}{
+		{"pad-attachment:abc-123", "abc-123"},
+		{"pad-attachment: abc-123 ", "abc-123"}, // whitespace trimmed
+		{"pad-attachment:", ""},                 // empty UUID
+		{"pad-attachment:   ", ""},              // whitespace-only UUID
+		{"http://example.com", ""},              // not a pad-attachment href
+		{"", ""},
+	}
+	for _, c := range cases {
+		if got := ParseAttachmentHref(c.href); got != c.want {
+			t.Errorf("ParseAttachmentHref(%q) = %q, want %q", c.href, got, c.want)
+		}
+	}
+}
+
+func TestAttachmentDownloadURL(t *testing.T) {
+	cases := []struct {
+		ws, id, variant, want string
+	}{
+		{"acme", "abc-123", "", "/api/v1/workspaces/acme/attachments/abc-123"},
+		{"acme", "abc-123", "thumb-md", "/api/v1/workspaces/acme/attachments/abc-123?variant=thumb-md"},
+		{"weird ws", "id with space", "", "/api/v1/workspaces/weird%20ws/attachments/id%20with%20space"},
+	}
+	for _, c := range cases {
+		if got := AttachmentDownloadURL(c.ws, c.id, c.variant); got != c.want {
+			t.Errorf("AttachmentDownloadURL(%q,%q,%q) = %q, want %q", c.ws, c.id, c.variant, got, c.want)
+		}
+	}
+}
+
+func TestIsImageMime(t *testing.T) {
+	cases := map[string]bool{
+		"image/png":          true,
+		"image/jpeg":         true,
+		"image/webp":         true,
+		"IMAGE/PNG":          true, // case-insensitive
+		" image/png":         true, // whitespace tolerated
+		"application/pdf":    false,
+		"text/plain":         false,
+		"video/mp4":          false,
+		"":                   false,
+		"image":              false,
+		"images/png":         false,
+	}
+	for mime, want := range cases {
+		if got := IsImageMime(mime); got != want {
+			t.Errorf("IsImageMime(%q) = %v, want %v", mime, got, want)
+		}
+	}
+}
+
+func TestFormatAttachmentSize(t *testing.T) {
+	cases := []struct {
+		bytes int64
+		want  string
+	}{
+		{-1, ""},
+		{0, "0 B"},
+		{512, "512 B"},
+		{1023, "1023 B"},
+		{1024, "1.0 KB"},
+		{1536, "1.5 KB"},
+		{10 * 1024, "10 KB"},
+		{1024 * 1024, "1.0 MB"},
+		{int64(5.5 * 1024 * 1024), "5.5 MB"},
+		{1024 * 1024 * 1024, "1.0 GB"},
+		{1024 * 1024 * 1024 * 1024, "1.0 TB"},
+	}
+	for _, c := range cases {
+		if got := FormatAttachmentSize(c.bytes); got != c.want {
+			t.Errorf("FormatAttachmentSize(%d) = %q, want %q", c.bytes, got, c.want)
+		}
+	}
+}
+
+func TestRenderAttachmentImage(t *testing.T) {
+	meta := &AttachmentMeta{
+		ID:        "abc-123",
+		MimeType:  "image/png",
+		Filename:  "screenshot.png",
+		SizeBytes: 12345,
+		Width:     intp(800),
+		Height:    intp(600),
+	}
+	got := RenderAttachmentImage(meta, "Screenshot of dashboard", "acme")
+	wantSubstrs := []string{
+		`src="/api/v1/workspaces/acme/attachments/abc-123?variant=thumb-md"`,
+		`data-attachment-id="abc-123"`,
+		`alt="Screenshot of dashboard"`,
+		`width="800"`,
+		`height="600"`,
+	}
+	for _, s := range wantSubstrs {
+		if !strings.Contains(got, s) {
+			t.Errorf("RenderAttachmentImage missing %q in: %s", s, got)
+		}
+	}
+}
+
+func TestRenderAttachmentImage_NoDimensions(t *testing.T) {
+	meta := &AttachmentMeta{ID: "abc", MimeType: "image/webp", Filename: "x.webp", SizeBytes: 1}
+	got := RenderAttachmentImage(meta, "", "ws")
+	if strings.Contains(got, "width=") || strings.Contains(got, "height=") {
+		t.Errorf("expected no width/height when dims unknown, got: %s", got)
+	}
+	// Falls back to filename when alt is empty.
+	if !strings.Contains(got, `alt="x.webp"`) {
+		t.Errorf("expected alt fallback to filename, got: %s", got)
+	}
+}
+
+func TestRenderAttachmentImage_EscapesUserInput(t *testing.T) {
+	meta := &AttachmentMeta{ID: `<id>`, MimeType: "image/png", Filename: `f.png`, SizeBytes: 1}
+	got := RenderAttachmentImage(meta, `"><script>alert(1)</script>`, "ws")
+	if strings.Contains(got, "<script>") {
+		t.Errorf("alt text not escaped: %s", got)
+	}
+	if strings.Contains(got, "<id>") {
+		t.Errorf("id not escaped: %s", got)
+	}
+}
+
+func TestRenderAttachmentImage_NilMeta(t *testing.T) {
+	if got := RenderAttachmentImage(nil, "x", "ws"); got != "" {
+		t.Errorf("nil meta should return empty string, got %q", got)
+	}
+}
+
+func TestRenderAttachmentChip(t *testing.T) {
+	meta := &AttachmentMeta{
+		ID:        "abc-123",
+		MimeType:  "application/pdf",
+		Filename:  "report.pdf",
+		SizeBytes: 5 * 1024 * 1024,
+	}
+	got := RenderAttachmentChip(meta, "", "acme")
+	wants := []string{
+		`class="file-chip"`,
+		`href="/api/v1/workspaces/acme/attachments/abc-123"`,
+		`data-attachment-id="abc-123"`,
+		`download="report.pdf"`,
+		`target="_blank"`,
+		`rel="noopener noreferrer"`,
+		`report.pdf`,
+		`5.0 MB`,
+	}
+	for _, s := range wants {
+		if !strings.Contains(got, s) {
+			t.Errorf("chip missing %q in: %s", s, got)
+		}
+	}
+}
+
+func TestRenderAttachmentChip_DisplayTextOverridesFilename(t *testing.T) {
+	meta := &AttachmentMeta{ID: "x", MimeType: "application/zip", Filename: "release.zip", SizeBytes: 100}
+	got := RenderAttachmentChip(meta, "Latest release", "ws")
+	if !strings.Contains(got, ">Latest release</span>") {
+		t.Errorf("expected display text override, got: %s", got)
+	}
+	// download attribute always uses canonical filename, not the display text.
+	if !strings.Contains(got, `download="release.zip"`) {
+		t.Errorf("download attribute should use filename, got: %s", got)
+	}
+}
+
+func TestRenderAttachmentChip_EscapesUserInput(t *testing.T) {
+	meta := &AttachmentMeta{ID: "x", MimeType: "application/pdf", Filename: `<bad>".pdf`, SizeBytes: 1}
+	got := RenderAttachmentChip(meta, `<script>alert(1)</script>`, "ws")
+	if strings.Contains(got, "<script>") {
+		t.Errorf("display text not escaped: %s", got)
+	}
+	if strings.Contains(got, `download="<bad>`) {
+		t.Errorf("filename not escaped in download attr: %s", got)
+	}
+}
+
+func TestRenderAttachmentMissing(t *testing.T) {
+	got := RenderAttachmentMissing("abc-123", "Lost photo")
+	wants := []string{
+		`class="attachment-missing"`,
+		`data-attachment-id="abc-123"`,
+		`title="This attachment is missing or has been deleted"`,
+		`Lost photo`,
+	}
+	for _, s := range wants {
+		if !strings.Contains(got, s) {
+			t.Errorf("missing placeholder lacks %q in: %s", s, got)
+		}
+	}
+}
+
+func TestRenderAttachmentMissing_DefaultText(t *testing.T) {
+	got := RenderAttachmentMissing("abc-123", "")
+	if !strings.Contains(got, "Missing attachment") {
+		t.Errorf("expected default text, got: %s", got)
+	}
+}
+
+func TestRenderAttachmentMissing_EscapesUuid(t *testing.T) {
+	got := RenderAttachmentMissing(`<uuid>`, "")
+	if strings.Contains(got, "<uuid>") {
+		t.Errorf("uuid not escaped: %s", got)
+	}
+}
+
+func TestResolveAttachmentImage(t *testing.T) {
+	resolver := func(uuid string) *AttachmentMeta {
+		switch uuid {
+		case "img-1":
+			return &AttachmentMeta{ID: "img-1", MimeType: "image/png", Filename: "shot.png", SizeBytes: 100}
+		case "pdf-1":
+			return &AttachmentMeta{ID: "pdf-1", MimeType: "application/pdf", Filename: "doc.pdf", SizeBytes: 100}
+		}
+		return nil
+	}
+
+	// Image MIME → <img>
+	got := ResolveAttachmentImage("pad-attachment:img-1", "Screenshot", "ws", resolver)
+	if !strings.HasPrefix(got, "<img ") {
+		t.Errorf("expected <img>, got: %s", got)
+	}
+
+	// Non-image MIME → file chip (image syntax over a PDF)
+	got = ResolveAttachmentImage("pad-attachment:pdf-1", "doc", "ws", resolver)
+	if !strings.HasPrefix(got, `<a class="file-chip"`) {
+		t.Errorf("expected file chip for non-image MIME, got: %s", got)
+	}
+
+	// Missing → placeholder
+	got = ResolveAttachmentImage("pad-attachment:missing-1", "alt", "ws", resolver)
+	if !strings.Contains(got, "attachment-missing") {
+		t.Errorf("expected missing placeholder, got: %s", got)
+	}
+
+	// Non-attachment href → empty (caller should have filtered)
+	if got := ResolveAttachmentImage("http://example.com/foo.png", "alt", "ws", resolver); got != "" {
+		t.Errorf("non-attachment href should return empty, got: %s", got)
+	}
+}
+
+func TestResolveAttachmentLink_AlwaysChip(t *testing.T) {
+	resolver := func(uuid string) *AttachmentMeta {
+		return &AttachmentMeta{ID: uuid, MimeType: "image/png", Filename: "x.png", SizeBytes: 100}
+	}
+	// Link syntax over an image → still chip
+	got := ResolveAttachmentLink("pad-attachment:img-1", "Click me", "ws", resolver)
+	if !strings.HasPrefix(got, `<a class="file-chip"`) {
+		t.Errorf("link form should always render chip, got: %s", got)
+	}
+}
+
+func TestResolveAttachmentReferences_BasicReplacement(t *testing.T) {
+	resolver := func(uuid string) *AttachmentMeta {
+		switch uuid {
+		case "img-1":
+			return &AttachmentMeta{ID: "img-1", MimeType: "image/png", Filename: "shot.png", SizeBytes: 1024}
+		case "pdf-1":
+			return &AttachmentMeta{ID: "pdf-1", MimeType: "application/pdf", Filename: "doc.pdf", SizeBytes: 4096}
+		}
+		return nil
+	}
+	in := `Here is an image: ![alt text](pad-attachment:img-1)
+
+And a PDF: [Download report](pad-attachment:pdf-1)
+
+Missing: ![](pad-attachment:gone-1)`
+	out := ResolveAttachmentReferences(in, "acme", resolver)
+
+	// Image rendered
+	if !strings.Contains(out, `<img `) || !strings.Contains(out, `data-attachment-id="img-1"`) {
+		t.Errorf("image reference not resolved: %s", out)
+	}
+	// PDF chip rendered
+	if !strings.Contains(out, `class="file-chip"`) || !strings.Contains(out, `data-attachment-id="pdf-1"`) {
+		t.Errorf("pdf reference not resolved: %s", out)
+	}
+	// Missing placeholder rendered
+	if !strings.Contains(out, "attachment-missing") || !strings.Contains(out, `data-attachment-id="gone-1"`) {
+		t.Errorf("missing reference not resolved: %s", out)
+	}
+}
+
+func TestResolveAttachmentReferences_SkipsFencedCodeBlocks(t *testing.T) {
+	resolver := func(uuid string) *AttachmentMeta {
+		return &AttachmentMeta{ID: uuid, MimeType: "image/png", Filename: "x.png", SizeBytes: 1}
+	}
+	in := "Outside: ![real](pad-attachment:abc)\n\n```markdown\n![docs example](pad-attachment:should-stay)\n[link example](pad-attachment:also-stay)\n```\n\nAfter: ![real2](pad-attachment:def)\n"
+	out := ResolveAttachmentReferences(in, "ws", resolver)
+
+	// Outside the fence, references are resolved
+	if !strings.Contains(out, `data-attachment-id="abc"`) {
+		t.Errorf("expected outer reference resolved, got: %s", out)
+	}
+	if !strings.Contains(out, `data-attachment-id="def"`) {
+		t.Errorf("expected post-fence reference resolved, got: %s", out)
+	}
+
+	// Inside the fence, the literal markdown text must be preserved
+	if !strings.Contains(out, "![docs example](pad-attachment:should-stay)") {
+		t.Errorf("fenced image example was substituted, got: %s", out)
+	}
+	if !strings.Contains(out, "[link example](pad-attachment:also-stay)") {
+		t.Errorf("fenced link example was substituted, got: %s", out)
+	}
+}
+
+func TestResolveAttachmentReferences_TildeFence(t *testing.T) {
+	resolver := func(uuid string) *AttachmentMeta { return &AttachmentMeta{ID: uuid} }
+	in := "~~~\n![x](pad-attachment:x)\n~~~\n"
+	out := ResolveAttachmentReferences(in, "ws", resolver)
+	if !strings.Contains(out, "![x](pad-attachment:x)") {
+		t.Errorf("tilde fence not respected: %s", out)
+	}
+}
+
+func TestResolveAttachmentReferences_RoundTripStable(t *testing.T) {
+	// Same input + same metadata must produce identical output every call —
+	// the share/export pipeline relies on this for cache validation.
+	resolver := func(uuid string) *AttachmentMeta {
+		return &AttachmentMeta{ID: uuid, MimeType: "image/png", Filename: "x.png", SizeBytes: 100, Width: intp(10), Height: intp(20)}
+	}
+	in := `# Title
+
+![ok](pad-attachment:abc)`
+	a := ResolveAttachmentReferences(in, "ws", resolver)
+	b := ResolveAttachmentReferences(in, "ws", resolver)
+	if a != b {
+		t.Errorf("non-deterministic output:\n  a=%s\n  b=%s", a, b)
+	}
+}
+
+func TestResolveAttachmentReferences_NilResolver(t *testing.T) {
+	in := `![x](pad-attachment:abc)`
+	if got := ResolveAttachmentReferences(in, "ws", nil); got != in {
+		t.Errorf("nil resolver should pass-through, got: %s", got)
+	}
+}
+
+func TestResolveAttachmentReferences_NoFalsePositives(t *testing.T) {
+	resolver := func(uuid string) *AttachmentMeta {
+		return &AttachmentMeta{ID: uuid, MimeType: "image/png", Filename: "x.png", SizeBytes: 1}
+	}
+	// References to other URL schemes must not be substituted.
+	in := `![alt](http://example.com) and [link](https://example.com) and [ref](pad-attachment-not:abc)`
+	out := ResolveAttachmentReferences(in, "ws", resolver)
+	if out != in {
+		t.Errorf("non-attachment refs were modified:\n  in =%s\n  out=%s", in, out)
+	}
+}
+
+func TestResolveAttachmentReferences_HandlesTitleSuffix(t *testing.T) {
+	// Markdown links allow an optional " title" after the URL.
+	resolver := func(uuid string) *AttachmentMeta {
+		return &AttachmentMeta{ID: uuid, MimeType: "image/png", Filename: "x.png", SizeBytes: 1}
+	}
+	in := `![alt](pad-attachment:abc "Some title")`
+	out := ResolveAttachmentReferences(in, "ws", resolver)
+	if !strings.Contains(out, `data-attachment-id="abc"`) {
+		t.Errorf("title-suffixed reference not resolved: %s", out)
+	}
+}
+
+func TestSplitCodeFences_NestedAndUnclosed(t *testing.T) {
+	// An unclosed fence at end-of-input should not crash. Everything after
+	// the opener is treated as inside the fence.
+	in := "before\n```\nstill inside\n"
+	chunks := splitCodeFences(in)
+	if len(chunks) != 2 {
+		t.Fatalf("expected 2 chunks, got %d: %#v", len(chunks), chunks)
+	}
+	if chunks[0].fenced || !strings.Contains(chunks[0].text, "before") {
+		t.Errorf("first chunk wrong: %#v", chunks[0])
+	}
+	if !chunks[1].fenced || !strings.Contains(chunks[1].text, "still inside") {
+		t.Errorf("second chunk wrong: %#v", chunks[1])
+	}
+}

--- a/web/src/lib/markdown/attachments.ts
+++ b/web/src/lib/markdown/attachments.ts
@@ -1,0 +1,204 @@
+/**
+ * Markdown reference resolver for `pad-attachment:UUID`.
+ *
+ * Item content stores attachments as opaque references — `pad-attachment:UUID`
+ * embedded in standard markdown image/link syntax:
+ *
+ *   ![alt text](pad-attachment:abcdef-123)    — image embed
+ *   [filename.pdf](pad-attachment:abcdef-123) — file chip
+ *
+ * The actual download URL is computed at render time from the workspace slug
+ * and the current backend, so item content survives a backend migration
+ * (FS → S3) untouched. See DOC-865 (Attachments — architecture & migration).
+ *
+ * This module exports pure helpers that produce HTML strings for each
+ * rendering case (image, file chip, missing placeholder). They're integrated
+ * into the marked pipeline by `$lib/utils/markdown.ts` via the `image` and
+ * `link` renderer overrides — see that file for the wiring.
+ *
+ * The Go-side companion lives at `internal/server/render/attachments.go`;
+ * keep the two implementations in lock-step so server-rendered and
+ * client-rendered output match byte-for-byte for the same input.
+ */
+
+/** Minimal attachment metadata required to render a reference. */
+export interface AttachmentMeta {
+	id: string;
+	mime_type: string;
+	filename: string;
+	size_bytes: number;
+	width?: number | null;
+	height?: number | null;
+}
+
+/**
+ * Looks up an attachment by UUID. Should return `null` or `undefined` when
+ * the attachment is missing or deleted — the resolver renders a "missing"
+ * placeholder in that case so the document doesn't show a broken-image icon.
+ */
+export type AttachmentResolver = (uuid: string) => AttachmentMeta | null | undefined;
+
+/** URL scheme used in markdown content. Mirrored on the Go side. */
+const ATTACHMENT_URL_PREFIX = 'pad-attachment:';
+
+const API_BASE = '/api/v1';
+
+/** True if `href` is a `pad-attachment:UUID` reference. */
+export function isAttachmentHref(href: string | null | undefined): boolean {
+	return typeof href === 'string' && href.startsWith(ATTACHMENT_URL_PREFIX);
+}
+
+/**
+ * Extract the UUID from a `pad-attachment:UUID` reference. Returns `null`
+ * when `href` is not a pad-attachment reference, or when the UUID portion
+ * is empty / whitespace.
+ */
+export function parseAttachmentHref(href: string | null | undefined): string | null {
+	if (!isAttachmentHref(href)) return null;
+	const uuid = (href as string).slice(ATTACHMENT_URL_PREFIX.length).trim();
+	return uuid === '' ? null : uuid;
+}
+
+/**
+ * Build the canonical download URL for an attachment. Suitable for
+ * `<img src>` and anchor `href`. Optional variant (`thumb-sm` | `thumb-md`)
+ * falls back to the original on the server when no derived row exists,
+ * so callers can always request a thumbnail and get something renderable.
+ */
+export function attachmentDownloadUrl(
+	workspaceSlug: string,
+	attachmentId: string,
+	variant?: 'thumb-sm' | 'thumb-md' | 'original'
+): string {
+	const base = `${API_BASE}/workspaces/${encodeURIComponent(workspaceSlug)}/attachments/${encodeURIComponent(attachmentId)}`;
+	return variant ? `${base}?variant=${encodeURIComponent(variant)}` : base;
+}
+
+/** Format a byte count as a human-readable string ("832 B", "1.2 MB", "5 GB"). */
+export function formatAttachmentSize(bytes: number): string {
+	if (!Number.isFinite(bytes) || bytes < 0) return '';
+	if (bytes < 1024) return `${bytes} B`;
+	const units = ['KB', 'MB', 'GB', 'TB'];
+	let n = bytes / 1024;
+	let i = 0;
+	while (n >= 1024 && i < units.length - 1) {
+		n /= 1024;
+		i++;
+	}
+	return `${n < 10 ? n.toFixed(1) : Math.round(n).toString()} ${units[i]}`;
+}
+
+/**
+ * True if the MIME type renders inline as an image. Mirrors `image/*` from
+ * the server-side allowlist (image/png, image/jpeg, image/gif, image/webp,
+ * image/avif, image/heic, image/heif). Anything else falls back to a chip.
+ */
+export function isImageMime(mime: string | null | undefined): boolean {
+	return typeof mime === 'string' && mime.toLowerCase().trimStart().startsWith('image/');
+}
+
+/**
+ * Escape HTML-significant characters so user-controlled strings can be
+ * safely interpolated into attribute values and text nodes. Local copy so
+ * this module stays self-contained — DOMPurify still has the final say
+ * downstream when these helpers are piped through `sanitizeMarkdownHtml`.
+ */
+function escapeHtml(s: string): string {
+	return s
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;')
+		.replace(/"/g, '&quot;')
+		.replace(/'/g, '&#39;');
+}
+
+/**
+ * Render an image attachment as an inline `<img>` element. Width/height
+ * attributes are emitted when both are known and positive so the browser
+ * can reserve layout space before the bytes arrive — avoiding the reflow
+ * jank that would otherwise hit on every paste-and-render cycle in the
+ * editor preview.
+ *
+ * The `data-attachment-id` attribute is the editor's hook for click-to-
+ * zoom, rotate, and crop interactions (TASK-879/880).
+ */
+export function renderAttachmentImage(
+	meta: AttachmentMeta,
+	alt: string,
+	workspaceSlug: string
+): string {
+	const src = attachmentDownloadUrl(workspaceSlug, meta.id, 'thumb-md');
+	const altText = alt && alt.trim() !== '' ? alt : meta.filename;
+	const sizeAttrs =
+		meta.width && meta.height && meta.width > 0 && meta.height > 0
+			? ` width="${meta.width}" height="${meta.height}"`
+			: '';
+	return `<img src="${escapeHtml(src)}" data-attachment-id="${escapeHtml(meta.id)}" alt="${escapeHtml(altText)}"${sizeAttrs}>`;
+}
+
+/**
+ * Render a non-image attachment as a Notion-style file chip. The chip is
+ * an anchor element so users can click to download / open. `target=_blank`
+ * + `rel=noopener noreferrer` matches our other external-link defaults.
+ */
+export function renderAttachmentChip(
+	meta: AttachmentMeta,
+	displayText: string | undefined,
+	workspaceSlug: string
+): string {
+	const href = attachmentDownloadUrl(workspaceSlug, meta.id);
+	const label = displayText && displayText.trim() !== '' ? displayText : meta.filename;
+	const size = formatAttachmentSize(meta.size_bytes);
+	const sizeSpan = size ? ` <span class="file-chip-size">· ${escapeHtml(size)}</span>` : '';
+	return `<a class="file-chip" href="${escapeHtml(href)}" data-attachment-id="${escapeHtml(meta.id)}" download="${escapeHtml(meta.filename)}" target="_blank" rel="noopener noreferrer"><span class="file-chip-icon" aria-hidden="true">📄</span><span class="file-chip-name">${escapeHtml(label)}</span>${sizeSpan}</a>`;
+}
+
+/**
+ * Render a placeholder for a missing/deleted attachment. Keeps the document
+ * layout intact and tells the user *why* there's no image — a broken-image
+ * icon would suggest a network failure, but this is a permanent metadata
+ * state (the row is soft-deleted or the UUID was never valid).
+ */
+export function renderAttachmentMissing(uuid: string, alt: string): string {
+	const safeAlt = alt && alt.trim() !== '' ? escapeHtml(alt) : 'Missing attachment';
+	return `<span class="attachment-missing" data-attachment-id="${escapeHtml(uuid)}" title="This attachment is missing or has been deleted">📎 ${safeAlt}</span>`;
+}
+
+/**
+ * Resolve a `pad-attachment:UUID` image-syntax reference
+ * (`![alt](pad-attachment:UUID)`). Falls back to a file chip when the
+ * attachment exists but isn't an image MIME — the markdown author asked
+ * for an embed, but a PDF or zip can't sensibly inline.
+ */
+export function resolveAttachmentImage(
+	href: string,
+	alt: string,
+	workspaceSlug: string,
+	resolver: AttachmentResolver
+): string {
+	const uuid = parseAttachmentHref(href);
+	if (uuid === null) return '';
+	const meta = resolver(uuid);
+	if (!meta) return renderAttachmentMissing(uuid, alt);
+	if (isImageMime(meta.mime_type)) return renderAttachmentImage(meta, alt, workspaceSlug);
+	return renderAttachmentChip(meta, alt && alt.trim() !== '' ? alt : meta.filename, workspaceSlug);
+}
+
+/**
+ * Resolve a `pad-attachment:UUID` link-syntax reference
+ * (`[text](pad-attachment:UUID)`). Always renders as a file chip — link
+ * syntax indicates the user wants a downloadable reference, not an inline
+ * embed, even when the underlying MIME is an image.
+ */
+export function resolveAttachmentLink(
+	href: string,
+	text: string,
+	workspaceSlug: string,
+	resolver: AttachmentResolver
+): string {
+	const uuid = parseAttachmentHref(href);
+	if (uuid === null) return '';
+	const meta = resolver(uuid);
+	if (!meta) return renderAttachmentMissing(uuid, text);
+	return renderAttachmentChip(meta, text, workspaceSlug);
+}

--- a/web/src/lib/utils/markdown.ts
+++ b/web/src/lib/utils/markdown.ts
@@ -48,18 +48,26 @@ let currentAttachmentCtx: AttachmentRenderContext | null = null;
 // URLs in the link text as autolinks and recurse infinitely through this same
 // `link` renderer (e.g. for content like `https://example.com` inside a comment).
 const renderer = new marked.Renderer();
-renderer.link = function (this: Renderer, { href, title, tokens }: Tokens.Link) {
+renderer.link = function (this: Renderer, { href, title, text: rawText, tokens }: Tokens.Link) {
 	// pad-attachment:UUID links resolve to a file chip when a resolver is in
 	// scope. Without one (e.g. the bare `marked()` calls on the share page
 	// before that route opts in) the reference falls through to the default
 	// link rendering — the user sees the literal `pad-attachment:UUID` href,
 	// which is graceful degradation for SSR/preview environments that don't
 	// have the attachment registry hydrated yet.
+	//
+	// We pass the link token's raw `text` (not parseInline output) to the
+	// chip helper because renderAttachmentChip HTML-escapes its label
+	// argument. Feeding pre-rendered HTML (e.g. <strong>Report</strong>
+	// from `[**Report**](pad-attachment:…)`) would double-escape into
+	// `&lt;strong&gt;Report&lt;/strong&gt;`. Plain text matches the Go
+	// side's regex-based extraction and keeps both renderers byte-aligned;
+	// markdown emphasis inside chip labels degrades to literal markers,
+	// which is acceptable for the filename-style labels chips usually carry.
 	if (currentAttachmentCtx && isAttachmentHref(href)) {
-		const text = this.parser.parseInline(tokens);
 		return resolveAttachmentLink(
 			href,
-			text,
+			rawText,
 			currentAttachmentCtx.workspaceSlug,
 			currentAttachmentCtx.resolver
 		);

--- a/web/src/lib/utils/markdown.ts
+++ b/web/src/lib/utils/markdown.ts
@@ -2,6 +2,12 @@ import { marked, Renderer, type Tokens } from 'marked';
 import DOMPurify from 'dompurify';
 import type { Item } from '$lib/types';
 import { itemUrlId } from '$lib/types';
+import {
+	type AttachmentResolver,
+	isAttachmentHref,
+	resolveAttachmentImage,
+	resolveAttachmentLink
+} from '$lib/markdown/attachments';
 
 // Mirror of marked's internal cleanUrl() — percent-encodes the href so the
 // rendered HTML stays well-formed even when input contains spaces, quotes, or
@@ -19,6 +25,19 @@ function cleanUrl(href: string): string | null {
 	}
 }
 
+// Per-call attachment context. Set by renderMarkdown before invoking marked()
+// and cleared in the finally block. Marked's parsing is synchronous, so a
+// module-level slot is safe — every call drives the renderer through
+// completion before returning. We avoid a per-call `new Renderer()` because
+// the global renderer is also reached by `marked.parseInline` and the share
+// page's bare `marked()` calls; threading context through the global instance
+// keeps both paths consistent without forcing every call site to opt in.
+type AttachmentRenderContext = {
+	resolver: AttachmentResolver;
+	workspaceSlug: string;
+};
+let currentAttachmentCtx: AttachmentRenderContext | null = null;
+
 // Custom renderer to open external links in new tabs.
 //
 // Use a regular `function` (not an arrow) so `this` resolves to the Renderer
@@ -30,6 +49,21 @@ function cleanUrl(href: string): string | null {
 // `link` renderer (e.g. for content like `https://example.com` inside a comment).
 const renderer = new marked.Renderer();
 renderer.link = function (this: Renderer, { href, title, tokens }: Tokens.Link) {
+	// pad-attachment:UUID links resolve to a file chip when a resolver is in
+	// scope. Without one (e.g. the bare `marked()` calls on the share page
+	// before that route opts in) the reference falls through to the default
+	// link rendering — the user sees the literal `pad-attachment:UUID` href,
+	// which is graceful degradation for SSR/preview environments that don't
+	// have the attachment registry hydrated yet.
+	if (currentAttachmentCtx && isAttachmentHref(href)) {
+		const text = this.parser.parseInline(tokens);
+		return resolveAttachmentLink(
+			href,
+			text,
+			currentAttachmentCtx.workspaceSlug,
+			currentAttachmentCtx.resolver
+		);
+	}
 	const text = this.parser.parseInline(tokens);
 	const cleanHref = cleanUrl(href);
 	if (cleanHref === null) {
@@ -43,6 +77,28 @@ renderer.link = function (this: Renderer, { href, title, tokens }: Tokens.Link) 
 		return `<a href="${cleanHref}"${titleAttr} target="_blank" rel="noopener noreferrer" class="external-link">${text}<span class="external-icon" aria-hidden="true"> ↗</span></a>`;
 	}
 	return `<a href="${cleanHref}"${titleAttr}>${text}</a>`;
+};
+
+renderer.image = function (this: Renderer, { href, title, text }: Tokens.Image) {
+	// pad-attachment:UUID image references resolve to <img> for image MIMEs
+	// or a file chip for non-image MIMEs. Without a resolver in scope, fall
+	// through to the default image rendering so the literal href is at
+	// least visible (rendered as a broken image, which is the right UX
+	// signal: "we couldn't resolve this attachment").
+	if (currentAttachmentCtx && isAttachmentHref(href)) {
+		return resolveAttachmentImage(
+			href,
+			text,
+			currentAttachmentCtx.workspaceSlug,
+			currentAttachmentCtx.resolver
+		);
+	}
+	// Default image rendering. Mirrors marked's stdout behavior so
+	// overriding renderer.image here doesn't regress existing markdown.
+	const cleanHref = cleanUrl(href);
+	if (cleanHref === null) return escapeHtml(text);
+	const titleAttr = title ? ` title="${escapeHtml(title)}"` : '';
+	return `<img src="${cleanHref}" alt="${escapeHtml(text)}"${titleAttr}>`;
 };
 
 marked.use({ renderer });
@@ -62,7 +118,14 @@ const MARKDOWN_ALLOWED_ATTR = [
 	'href', 'title', 'target', 'rel', 'class', 'aria-hidden',
 	'alt', 'src', 'id', 'name', 'align', 'type', 'checked', 'disabled',
 	// <ol start="N"> — marked emits this for lists that don't begin at 1.
-	'start'
+	'start',
+	// Attachment renderer attributes. `data-attachment-id` is the editor's
+	// hook for click-to-zoom / rotate / crop interactions; `download` lets
+	// the browser save file chips with their canonical filename; `width`
+	// and `height` reserve layout space for inline images so the page
+	// doesn't reflow when the bytes arrive. ALLOW_DATA_ATTR stays false so
+	// only this single data-* attribute is permitted.
+	'data-attachment-id', 'download', 'width', 'height'
 ] as const;
 
 /**
@@ -109,13 +172,19 @@ function escapeHtml(s: string): string {
  *
  * @param visibleCollectionSlugs - Set of collection slugs the user can see.
  *   undefined = all visible (no filtering). Empty set = nothing visible (anonymous).
+ * @param attachmentResolver - Optional lookup that resolves
+ *   `pad-attachment:UUID` references to image / file-chip / missing HTML.
+ *   When omitted, those references render as plain markdown links pointing
+ *   at the literal `pad-attachment:UUID` href — clearly broken in the UI,
+ *   which is the right signal for unresolved environments.
  */
 export function renderMarkdown(
 	content: string,
 	items: Item[],
 	workspaceSlug: string,
 	username?: string,
-	visibleCollectionSlugs?: Set<string>
+	visibleCollectionSlugs?: Set<string>,
+	attachmentResolver?: AttachmentResolver
 ): string {
 	const withLinks = content.replace(/\[\[([^\]]+)\]\]/g, (_match, title: string) => {
 		// Escape user-controlled title so it can't break out of attribute
@@ -134,7 +203,17 @@ export function renderMarkdown(
 		}
 		return `<span class="doc-link broken">${safeTitle}</span>`;
 	});
-	return sanitizeMarkdownHtml(marked(withLinks) as string);
+	// Wire the attachment resolver into the global renderer for the duration
+	// of this synchronous parse. The try/finally ensures we never leak the
+	// context across calls, even when marked throws on malformed input.
+	if (attachmentResolver) {
+		currentAttachmentCtx = { resolver: attachmentResolver, workspaceSlug };
+	}
+	try {
+		return sanitizeMarkdownHtml(marked(withLinks) as string);
+	} finally {
+		currentAttachmentCtx = null;
+	}
 }
 
 export function wordCount(content: string): number {


### PR DESCRIPTION
## Summary

Shared step that translates `pad-attachment:UUID` markdown references into rendered HTML for image embeds, file chips, and missing placeholders. Wired into the editor preview path; Go-side helpers seed the future server-side rendering pipeline.

References are stored as opaque `pad-attachment:UUID` so a backend migration (FS → S3) can rewrite storage_keys without touching item content. See DOC-865 for the architecture.

### TS side (`web/src/lib/markdown/attachments.ts` + integration in `markdown.ts`)
- Pure helpers: `parseAttachmentHref`, `attachmentDownloadUrl`, `isImageMime`, `formatAttachmentSize`, `renderAttachmentImage` / `Chip` / `Missing`
- `resolveAttachmentImage` / `resolveAttachmentLink` for the marked hooks
- Image MIME → `<img src=…?variant=thumb-md data-attachment-id=…>`
- Non-image MIME (or link syntax) → file chip with `download` attribute
- Missing/deleted → "Missing attachment" placeholder span
- `renderer.image` override falls back to marked's default for non-attachment hrefs
- `renderer.link` checks `pad-attachment:` prefix before the existing external/internal-link logic
- `renderMarkdown` gains optional `attachmentResolver` parameter (purely additive — existing callers untouched)
- Resolver threaded via a per-call module slot (marked is synchronous; try/finally guarantees no leakage)
- DOMPurify allowlist extended: `data-attachment-id`, `download`, `width`, `height` (`ALLOW_DATA_ATTR` stays false)

### Go side (`internal/server/render/attachments.go`)
- Mirror of the TS API so server- and client-rendered HTML match for the same input
- `ResolveAttachmentReferences` scans markdown via regex, skipping fenced code blocks (backtick + tilde), substituting both image and link forms
- Pure functions, easy to unit test

## Context

Implements `TASK-874` under `PLAN-866` (Attachments Phase 1). Builds on the upload/download/CLI client work shipped in TASK-869–873. Unblocks TASK-875 (editor paste/drag-drop), TASK-876 (image node), TASK-877 (file chip node) which all assume this resolver is in place.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./...` — all packages pass; new package has 24 test cases covering href parsing, URL building, MIME detection, size formatting, image/chip/missing rendering, XSS escape safety on alt/filename/display, fenced-code skip, tilde fences, title-suffixed links, nil-resolver pass-through, no-false-positives, deterministic round-trip
- [x] `cd web && npm run build` — clean
- [x] `cd web && npm run check` — 0 errors (6 pre-existing warnings)
- [ ] Manual: paste image + reload (covered after TASK-875/876 land)
- [ ] Manual: render shared item view with attachment (covered after the share page opts into the resolver)