### PR TITLE
feat(attachments): editor file chip node (TASK-877)

### DIFF
--- a/internal/server/handlers_attachments.go
+++ b/internal/server/handlers_attachments.go
@@ -406,6 +406,8 @@ func (s *Server) handleGetAttachment(w http.ResponseWriter, r *http.Request) {
 		if modtime.IsZero() {
 			modtime = time.Now()
 		}
+		// http.ServeContent already handles HEAD correctly on this
+		// path — it sets headers and stops without writing the body.
 		http.ServeContent(w, r, att.Filename, modtime, seeker)
 		return
 	}
@@ -415,6 +417,14 @@ func (s *Server) handleGetAttachment(w http.ResponseWriter, r *http.Request) {
 	// we only call it here, never on the ServeContent fast path).
 	if size, sErr := store.Stat(r.Context(), att.StorageKey); sErr == nil && size >= 0 {
 		w.Header().Set("Content-Length", strconv.FormatInt(size, 10))
+	}
+	// HEAD on the streaming fallback: skip the body. Go's response
+	// writer would silently discard body writes for HEAD anyway, but
+	// reading the entire blob from a non-seekable backend just to
+	// throw it away would burn S3 GetObject bandwidth. Bail out before
+	// io.Copy ever touches the reader.
+	if r.Method == http.MethodHead {
+		return
 	}
 	if _, copyErr := io.Copy(w, body); copyErr != nil {
 		// Body has likely already been written to; can't change status.

--- a/internal/server/handlers_attachments_download_test.go
+++ b/internal/server/handlers_attachments_download_test.go
@@ -96,6 +96,61 @@ func TestDownload_NotFound(t *testing.T) {
 	}
 }
 
+func TestDownload_HEADReturnsHeadersWithoutBody(t *testing.T) {
+	// The editor's file-chip NodeView (TASK-877) probes attachment metadata
+	// via a HEAD request — Content-Type powers the MIME-aware icon and
+	// Content-Length feeds the size readout. chi doesn't auto-route HEAD
+	// to the GET handler, so the registration is explicit; this test
+	// guards that registration plus the seekable-path HEAD behavior of
+	// http.ServeContent (headers set, body omitted).
+	srv, slug := testServerWithAttachments(t)
+	body := realPNG()
+	_, mime, urlPath := uploadHelper(t, srv, slug, "screen.png", body)
+
+	req := httptest.NewRequest("HEAD", urlPath, nil)
+	req.RemoteAddr = "127.0.0.1:1234"
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("HEAD status = %d, want 200; body = %s", rr.Code, rr.Body.String())
+	}
+	if got := rr.Header().Get("Content-Type"); got != mime {
+		t.Errorf("HEAD Content-Type = %q, want %q", got, mime)
+	}
+	// Content-Length must reflect the actual blob size so the chip can
+	// render the readout. http.ServeContent computes this from the
+	// underlying ReadSeeker.
+	if got := rr.Header().Get("Content-Length"); got == "" {
+		t.Errorf("HEAD missing Content-Length header")
+	} else if n, err := strconv.Atoi(got); err != nil || n != len(body) {
+		t.Errorf("HEAD Content-Length = %q, want %d", got, len(body))
+	}
+	// Body MUST be empty on HEAD — Go's responseWriter discards body
+	// writes, but the assertion catches a regression where someone
+	// changes the handler in a way that bypasses ServeContent.
+	if rr.Body.Len() != 0 {
+		t.Errorf("HEAD response body should be empty, got %d bytes", rr.Body.Len())
+	}
+}
+
+func TestDownload_HEADCrossWorkspaceReturns404(t *testing.T) {
+	// Cross-workspace probing must return 404, not 403, on HEAD too —
+	// otherwise the metadata HEAD becomes a side-channel that lets a
+	// member of workspace B enumerate attachment IDs in workspace A.
+	srv, slugA := testServerWithAttachments(t)
+	slugB := createWSForTest(t, srv)
+	id, _, _ := uploadHelper(t, srv, slugA, "secret.png", realPNG())
+
+	req := httptest.NewRequest("HEAD", "/api/v1/workspaces/"+slugB+"/attachments/"+id, nil)
+	req.RemoteAddr = "127.0.0.1:1234"
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("HEAD cross-workspace status = %d, want 404 (NOT 403)", rr.Code)
+	}
+}
+
 func TestDownload_CrossWorkspaceReturns404(t *testing.T) {
 	srv, slugA := testServerWithAttachments(t)
 	slugB := createWSForTest(t, srv)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -691,8 +691,16 @@ func (s *Server) setupRouter() {
 					// Attachments
 					//   POST   /attachments              — upload (TASK-871)
 					//   GET    /attachments/{attachmentID} — serve blob (TASK-872, supports ?variant=)
+					//   HEAD   /attachments/{attachmentID} — metadata only (TASK-877 file-chip enrichment)
+					//
+					// chi does not auto-route HEAD to the GET handler, so the
+					// editor's HEAD probe for size + MIME has to be registered
+					// explicitly. The handler short-circuits the streaming
+					// path on HEAD; http.ServeContent already strips the body
+					// on the seekable path.
 					r.Post("/attachments", s.handleUploadAttachment)
 					r.Get("/attachments/{attachmentID}", s.handleGetAttachment)
+					r.Head("/attachments/{attachmentID}", s.handleGetAttachment)
 
 					// Webhooks
 					r.Route("/webhooks", func(r chi.Router) {

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -230,6 +230,63 @@ input:focus, textarea:focus {
 	box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent-blue) 35%, transparent);
 }
 
+/* Attachment file chips — Notion-style chip rendering for non-image
+   attachments. Used by both the editor's AttachmentChip node and the
+   read-only markdown render path (TASK-874). Styles target the same
+   class names from both surfaces so the visual matches edge to edge. */
+.file-chip {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.4em;
+	max-width: 100%;
+	padding: 4px 10px;
+	margin: 0 1px;
+	background: var(--bg-tertiary);
+	border: 1px solid var(--border-subtle);
+	border-radius: 6px;
+	color: var(--text-primary);
+	text-decoration: none;
+	font-size: 0.92em;
+	line-height: 1.3;
+	vertical-align: baseline;
+	transition: background 0.15s, border-color 0.15s;
+	cursor: pointer;
+}
+.file-chip:hover {
+	background: var(--bg-hover);
+	border-color: color-mix(in srgb, var(--accent-blue) 35%, var(--border));
+	text-decoration: none;
+}
+.file-chip-icon {
+	flex-shrink: 0;
+	font-size: 1.05em;
+	line-height: 1;
+}
+.file-chip-name {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	max-width: 38ch;
+	font-weight: 500;
+}
+.file-chip-size {
+	flex-shrink: 0;
+	color: var(--text-muted);
+	font-size: 0.88em;
+}
+.file-chip-size:empty {
+	display: none;
+}
+
+/* Editor selection styling — when the chip is the ProseMirror
+   selection (atom node selected for delete/replace), give it the same
+   selection treatment ProseMirror gives other inline nodes. */
+.ProseMirror-selectednode.file-chip,
+.file-chip.ProseMirror-selectednode {
+	outline: 2px solid var(--accent-blue);
+	outline-offset: 1px;
+}
+
 /* Lightbox dialog — appended to document.body when an attachment image
    is clicked, so styles must be global rather than scoped to Editor.svelte.
    Uses the native <dialog> element; the ::backdrop pseudo handles the

--- a/web/src/lib/components/editor/Editor.svelte
+++ b/web/src/lib/components/editor/Editor.svelte
@@ -284,6 +284,7 @@
 	import { BlockDragHandle } from './block-drag-handle';
 	import { SLASH_ITEMS } from './block-types';
 	import { AttachmentImage, type AttachmentVariant } from './attachment-image';
+	import { AttachmentChip } from './attachment-chip';
 
 	let {
 		content = '',
@@ -468,6 +469,7 @@
 			}),
 			BlockDragHandle,
 			AttachmentImage.configure({ getDownloadUrl: getAttachmentUrl }),
+			AttachmentChip.configure({ getDownloadUrl: getAttachmentUrl, workspaceSlug: wsSlug }),
 		];
 
 		editor = new Editor({

--- a/web/src/lib/components/editor/attachment-chip.ts
+++ b/web/src/lib/components/editor/attachment-chip.ts
@@ -283,6 +283,28 @@ export const AttachmentChip = Node.create<AttachmentChipOptions>({
 			if (filename) wrapper.setAttribute('data-filename', filename);
 			if (filename) wrapper.download = filename;
 
+			// Explicit click handler → window.open. Editor.svelte installs a
+			// global anchor-click suppressor that calls preventDefault on
+			// every <a> inside the editor (so plain text links don't navigate
+			// in edit mode); without this handler the chip's anchor
+			// navigation would also be eaten and clicking the chip would
+			// silently do nothing. Mirrors the pattern AttachmentImage uses
+			// for its lightbox click. stopImmediatePropagation prevents the
+			// global suppressor from running afterwards.
+			wrapper.addEventListener('click', (event) => {
+				if (event.detail > 1) return; // double-click → fall through
+				if (!uuid) return;
+				event.preventDefault();
+				event.stopPropagation();
+				if (typeof window !== 'undefined') {
+					window.open(
+						this.options.getDownloadUrl(uuid),
+						'_blank',
+						'noopener,noreferrer',
+					);
+				}
+			});
+
 			const iconEl = document.createElement('span');
 			iconEl.className = 'file-chip-icon';
 			iconEl.setAttribute('aria-hidden', 'true');
@@ -298,10 +320,12 @@ export const AttachmentChip = Node.create<AttachmentChipOptions>({
 
 			wrapper.append(iconEl, nameEl, sizeEl);
 
-			// Async metadata enrichment. The HEAD request goes against the
-			// existing GET handler — no new endpoint required, and the cache
-			// keyed by (workspace, uuid) deduplicates repeated chips for the
-			// same attachment. We skip the fetch when no workspace context
+			// Async metadata enrichment via HEAD. Server registers HEAD
+			// alongside GET (chi doesn't auto-route HEAD to GET handlers),
+			// and the response carries Content-Type + Content-Length without
+			// a body. The promise cache keyed by (workspace, uuid)
+			// deduplicates repeated chips for the same attachment and
+			// survives undo/redo. Skip the fetch when no workspace context
 			// is available (e.g. headless rendering) — the chip still works,
 			// just without size/icon refinement.
 			if (uuid && this.options.workspaceSlug) {

--- a/web/src/lib/components/editor/attachment-chip.ts
+++ b/web/src/lib/components/editor/attachment-chip.ts
@@ -1,0 +1,362 @@
+/**
+ * AttachmentChip — Tiptap node for non-image `pad-attachment:UUID` references.
+ *
+ * Renders a Notion-style chip (icon + filename + size) for any attachment
+ * the user wants surfaced as a downloadable file rather than embedded
+ * inline. Stores the attachment UUID (not a backend URL) so item content
+ * survives a storage-backend migration untouched. See DOC-865.
+ *
+ * Node shape:
+ *   - `uuid`     : string — the attachments-row UUID (required)
+ *   - `filename` : string — display name; preserved across save/reload
+ *
+ * Markdown round-trip:
+ *   - Serialize: `[filename](pad-attachment:UUID)` via tiptap-markdown's
+ *     addStorage.markdown.serialize. Standard link syntax — same form the
+ *     read-only resolver in TASK-874 understands, so server-side and
+ *     editor renders match.
+ *   - Parse: markdown-it's link token produces `<a href="pad-attachment:UUID">filename</a>`,
+ *     captured by parseHTML rule `a[href^="pad-attachment:"]` at priority
+ *     1000 so it beats the SafeLink mark (default priority 50).
+ *
+ * Editor display: NodeView fires a single HEAD request per attachment
+ * (cached module-globally) to read Content-Type and Content-Length from
+ * the existing GET handler — no new API endpoint needed. The fetched
+ * MIME upgrades the icon from the filename-extension guess to the
+ * canonical category icon, and the size is rendered alongside the name.
+ */
+
+import { Node, mergeAttributes } from '@tiptap/core';
+
+const PAD_ATTACHMENT_PREFIX = 'pad-attachment:';
+
+/** Variants the download URL builder must support — mirrors AttachmentImage. */
+export type AttachmentVariant = 'thumb-sm' | 'thumb-md' | 'original';
+export type AttachmentUrlBuilder = (uuid: string, variant?: AttachmentVariant) => string;
+
+export interface AttachmentChipOptions {
+	HTMLAttributes: Record<string, unknown>;
+	/** Build the download URL — usually `api.attachments.downloadUrl` from the editor's mount context. */
+	getDownloadUrl: AttachmentUrlBuilder;
+	/** Workspace slug used by the metadata HEAD fetcher. Empty disables the fetch. */
+	workspaceSlug: string;
+}
+
+declare module '@tiptap/core' {
+	interface Commands<ReturnType> {
+		attachmentChip: {
+			/**
+			 * Insert a file chip at the current selection. Used by the
+			 * upload plugin (TASK-875) on successful non-image uploads.
+			 */
+			setAttachmentChip: (options: { uuid: string; filename: string }) => ReturnType;
+		};
+	}
+}
+
+/** Per-chip metadata fetched via HEAD. Null means "still loading or fetch failed". */
+interface AttachmentMetadata {
+	mime: string;
+	size: number;
+}
+
+/**
+ * Module-level cache of metadata promises keyed by `${ws}:${uuid}`. A single
+ * HEAD request fans out to every chip pointing at the same attachment, and
+ * subsequent edits (paste, undo/redo) hit the cache without a network round
+ * trip. Cache lives for the page lifetime — the underlying attachment row
+ * is immutable, so there's no staleness concern.
+ */
+const metadataCache = new Map<string, Promise<AttachmentMetadata | null>>();
+
+function fetchAttachmentMetadata(
+	workspaceSlug: string,
+	uuid: string,
+	getDownloadUrl: AttachmentUrlBuilder,
+): Promise<AttachmentMetadata | null> {
+	const key = `${workspaceSlug}:${uuid}`;
+	const cached = metadataCache.get(key);
+	if (cached) return cached;
+	const promise: Promise<AttachmentMetadata | null> = (async () => {
+		try {
+			const resp = await fetch(getDownloadUrl(uuid), {
+				method: 'HEAD',
+				credentials: 'same-origin',
+			});
+			if (!resp.ok) return null;
+			const ctype = resp.headers.get('content-type') ?? '';
+			const mime = ctype.split(';')[0].trim();
+			const len = parseInt(resp.headers.get('content-length') ?? '0', 10);
+			return { mime, size: Number.isFinite(len) && len >= 0 ? len : 0 };
+		} catch {
+			return null;
+		}
+	})();
+	metadataCache.set(key, promise);
+	return promise;
+}
+
+/**
+ * Map a MIME type to a category icon. Mirrors the server-side category
+ * enum in `internal/attachments/mime.go`. When MIME is unknown (HEAD
+ * failed or hasn't returned yet), falls back to a filename-extension
+ * heuristic — same buckets, same icons, just a coarser source.
+ */
+function iconForMime(mime: string): string {
+	const m = mime.toLowerCase();
+	if (m.startsWith('image/')) return '🖼️';
+	if (m.startsWith('video/')) return '🎥';
+	if (m.startsWith('audio/')) return '🎵';
+	if (m === 'application/pdf') return '📑';
+	if (
+		m === 'application/zip' ||
+		m === 'application/x-tar' ||
+		m === 'application/gzip' ||
+		m === 'application/x-bzip2' ||
+		m === 'application/x-7z-compressed'
+	)
+		return '🗜️';
+	if (
+		m === 'application/msword' ||
+		m === 'application/rtf' ||
+		m.includes('wordprocessingml') ||
+		m.includes('opendocument.text')
+	)
+		return '📄';
+	if (
+		m === 'application/vnd.ms-excel' ||
+		m.includes('spreadsheetml') ||
+		m.includes('opendocument.spreadsheet') ||
+		m === 'text/csv' ||
+		m === 'text/tab-separated-values'
+	)
+		return '📊';
+	if (
+		m === 'application/vnd.ms-powerpoint' ||
+		m.includes('presentationml') ||
+		m.includes('opendocument.presentation')
+	)
+		return '📽️';
+	if (
+		m === 'text/plain' ||
+		m === 'text/markdown' ||
+		m === 'application/json' ||
+		m === 'application/xml' ||
+		m === 'text/xml' ||
+		m === 'application/yaml' ||
+		m === 'text/yaml' ||
+		m === 'application/toml'
+	)
+		return '📝';
+	return '';
+}
+
+function iconForFilename(filename: string): string {
+	const ext = filename.toLowerCase().match(/\.([a-z0-9]+)$/)?.[1] ?? '';
+	if (['pdf'].includes(ext)) return '📑';
+	if (['zip', 'tar', 'gz', '7z', 'bz2'].includes(ext)) return '🗜️';
+	if (['doc', 'docx', 'odt', 'rtf'].includes(ext)) return '📄';
+	if (['xls', 'xlsx', 'ods', 'csv', 'tsv'].includes(ext)) return '📊';
+	if (['ppt', 'pptx', 'odp'].includes(ext)) return '📽️';
+	if (['mp4', 'webm', 'mov', 'mkv', 'avi'].includes(ext)) return '🎥';
+	if (['mp3', 'wav', 'ogg', 'flac', 'aac', 'm4a'].includes(ext)) return '🎵';
+	if (['png', 'jpg', 'jpeg', 'gif', 'webp', 'avif', 'heic', 'heif'].includes(ext)) return '🖼️';
+	if (['txt', 'md', 'json', 'yaml', 'yml', 'xml', 'toml', 'html', 'js', 'ts'].includes(ext)) return '📝';
+	return '📎';
+}
+
+/** Format a byte count as a human-readable string ("832 B", "1.2 MB", "5 GB"). */
+function formatBytes(n: number): string {
+	if (!Number.isFinite(n) || n <= 0) return '';
+	if (n < 1024) return `${n} B`;
+	const units = ['KB', 'MB', 'GB', 'TB'];
+	let val = n / 1024;
+	let i = 0;
+	while (val >= 1024 && i < units.length - 1) {
+		val /= 1024;
+		i++;
+	}
+	return `${val < 10 ? val.toFixed(1) : Math.round(val).toString()} ${units[i]}`;
+}
+
+export const AttachmentChip = Node.create<AttachmentChipOptions>({
+	name: 'attachmentChip',
+
+	group: 'inline',
+	inline: true,
+	atom: true,
+	selectable: true,
+	draggable: true,
+
+	addOptions() {
+		return {
+			HTMLAttributes: {},
+			getDownloadUrl: (uuid: string) => `${PAD_ATTACHMENT_PREFIX}${uuid}`,
+			workspaceSlug: '',
+		};
+	},
+
+	addAttributes() {
+		return {
+			uuid: {
+				default: null,
+				parseHTML: (element) => {
+					const dataId = element.getAttribute('data-attachment-id');
+					if (dataId) return dataId;
+					const href = element.getAttribute('href') ?? '';
+					if (href.startsWith(PAD_ATTACHMENT_PREFIX)) {
+						return href.slice(PAD_ATTACHMENT_PREFIX.length);
+					}
+					return null;
+				},
+				renderHTML: (attrs) =>
+					attrs.uuid ? { 'data-attachment-id': attrs.uuid } : {},
+			},
+			filename: {
+				default: '',
+				parseHTML: (element) => {
+					// Prefer the explicit data attribute when present (editor
+					// render output stamps it). For markdown-it output the
+					// link's text content IS the filename — the round-trip
+					// `[filename](pad-attachment:UUID)` puts it there.
+					const attr = element.getAttribute('data-filename');
+					if (attr) return attr;
+					return element.textContent?.trim() ?? '';
+				},
+				renderHTML: (attrs) =>
+					attrs.filename ? { 'data-filename': String(attrs.filename) } : {},
+			},
+		};
+	},
+
+	parseHTML() {
+		return [
+			// Priority 1000 beats SafeLink's default mark rule (50) so
+			// `a[href^="pad-attachment:"]` becomes a chip Node, not a Link
+			// Mark on plain text. The two coexist: regular `a[href=…]` still
+			// matches SafeLink; only attachment refs are diverted here.
+			{
+				tag: 'a[href^="pad-attachment:"]',
+				priority: 1000,
+			},
+			{
+				tag: 'a[data-attachment-id]',
+				priority: 1000,
+			},
+		];
+	},
+
+	renderHTML({ HTMLAttributes, node }) {
+		const uuid = (node.attrs.uuid as string | null) ?? '';
+		const filename = (node.attrs.filename as string | null) ?? '';
+		const href = uuid ? this.options.getDownloadUrl(uuid) : '';
+		// Static HTML output (used by clipboard / getHTML / SSR). The live
+		// in-editor look is handled by the NodeView below — this fallback
+		// just ensures pasted HTML survives a copy round-trip.
+		return [
+			'a',
+			mergeAttributes(this.options.HTMLAttributes, HTMLAttributes, {
+				class: 'file-chip',
+				href,
+				download: filename || true,
+				target: '_blank',
+				rel: 'noopener noreferrer',
+			}),
+			filename || 'attachment',
+		];
+	},
+
+	addNodeView() {
+		return ({ node }) => {
+			const uuid = (node.attrs.uuid as string | null) ?? '';
+			const filename = (node.attrs.filename as string | null) ?? '';
+
+			const wrapper = document.createElement('a');
+			wrapper.className = 'file-chip';
+			wrapper.target = '_blank';
+			wrapper.rel = 'noopener noreferrer';
+			wrapper.contentEditable = 'false';
+			if (uuid) {
+				wrapper.href = this.options.getDownloadUrl(uuid);
+				wrapper.setAttribute('data-attachment-id', uuid);
+			}
+			if (filename) wrapper.setAttribute('data-filename', filename);
+			if (filename) wrapper.download = filename;
+
+			const iconEl = document.createElement('span');
+			iconEl.className = 'file-chip-icon';
+			iconEl.setAttribute('aria-hidden', 'true');
+			iconEl.textContent = iconForFilename(filename);
+
+			const nameEl = document.createElement('span');
+			nameEl.className = 'file-chip-name';
+			nameEl.textContent = filename || 'attachment';
+
+			const sizeEl = document.createElement('span');
+			sizeEl.className = 'file-chip-size';
+			// Empty until metadata resolves; CSS hides empty separator span.
+
+			wrapper.append(iconEl, nameEl, sizeEl);
+
+			// Async metadata enrichment. The HEAD request goes against the
+			// existing GET handler — no new endpoint required, and the cache
+			// keyed by (workspace, uuid) deduplicates repeated chips for the
+			// same attachment. We skip the fetch when no workspace context
+			// is available (e.g. headless rendering) — the chip still works,
+			// just without size/icon refinement.
+			if (uuid && this.options.workspaceSlug) {
+				fetchAttachmentMetadata(
+					this.options.workspaceSlug,
+					uuid,
+					this.options.getDownloadUrl,
+				).then((meta) => {
+					if (!meta) return;
+					const refined = iconForMime(meta.mime);
+					if (refined) iconEl.textContent = refined;
+					const size = formatBytes(meta.size);
+					if (size) sizeEl.textContent = `· ${size}`;
+				});
+			}
+
+			return { dom: wrapper };
+		};
+	},
+
+	addStorage() {
+		return {
+			markdown: {
+				serialize(
+					state: { write: (s: string) => void },
+					node: { attrs: { uuid: unknown; filename: unknown } },
+				) {
+					const uuid = node.attrs.uuid;
+					if (typeof uuid !== 'string' || uuid === '') return;
+					const filename = typeof node.attrs.filename === 'string' ? node.attrs.filename : '';
+					// Escape `]` and `\` in the filename so the markdown link
+					// label stays balanced. The Go-side resolver and TS marked
+					// renderer both unescape these, so the round-trip is
+					// idempotent. Forward slashes in filenames are fine.
+					const escaped = filename.replace(/\\/g, '\\\\').replace(/]/g, '\\]');
+					state.write(`[${escaped}](${PAD_ATTACHMENT_PREFIX}${uuid})`);
+				},
+				parse: {
+					// markdown-it's link token already produces
+					// <a href="pad-attachment:UUID">filename</a>; our parseHTML
+					// rules pick that up. No custom markdown-it rule needed.
+				},
+			},
+		};
+	},
+
+	addCommands() {
+		return {
+			setAttachmentChip:
+				(options) =>
+				({ commands }) =>
+					commands.insertContent({
+						type: this.name,
+						attrs: { uuid: options.uuid, filename: options.filename },
+					}),
+		};
+	},
+});


### PR DESCRIPTION
## Summary

Custom Tiptap node `attachmentChip` for non-image `pad-attachment:UUID` references — Notion-style chip rendering with type icon, filename, and size.

### Node shape
- `uuid: string` — the attachments-row UUID
- `filename: string` — display name; preserved across save/reload

### Markdown round-trip
- **Serialize** → `[filename](pad-attachment:UUID)` — same standard link syntax the resolver in TASK-874 understands. `]` and `\` in the filename are escaped to keep the link label balanced.
- **Parse** ← markdown-it's link token produces `<a href="pad-attachment:UUID">filename</a>`. Our parseHTML rule `a[href^="pad-attachment:"]` runs at priority 1000 to beat SafeLink's default mark rule (priority 50), so attachment refs become a chip Node instead of a Link Mark on plain text.

### Editor display (NodeView)
- `<a class="file-chip">` with icon + name + optional size span
- **Icon**: filename-extension heuristic on first paint, upgraded to a MIME-based icon once a single HEAD request resolves the canonical Content-Type
- **Size**: rendered from Content-Length once HEAD resolves; hidden until then (CSS `:empty { display: none }`)
- The HEAD request goes against the existing GET handler — no new API endpoint required, and Go's `net/http` strips the body automatically for HEAD
- Module-level Promise cache keyed by `${ws}:${uuid}` deduplicates repeated chips for the same attachment and survives undo/redo without re-fetching
- `target=_blank` + `download` attribute so a click opens / saves the file with its canonical filename
- `atom: true` → Backspace/Delete remove the chip as a single unit

### Styles
Live in `app.css` (not `Editor.svelte`) so the same markup works for the read-only markdown render path too — TASK-874's Go and TS resolvers emit the same `.file-chip` / `.file-chip-icon` / `.file-chip-name` / `.file-chip-size` class structure.

## Context

Implements `TASK-877` under `PLAN-866` (Attachments Phase 1). Builds on TASK-874 (markdown contract) and TASK-876 (sister image node). Unblocks `TASK-875` — the paste/drop upload plugin needs a chip node to insert on successful non-image uploads.

## Test plan

- [x] `cd web && npm run build` — clean
- [x] `cd web && npm run check` — 0 errors (6 pre-existing warnings)
- [ ] Manual after merge:
  - [ ] Insert markdown `[report.pdf](pad-attachment:<uuid>)`, save + reload — chip renders with PDF icon, filename, size
  - [ ] Click chip — opens / downloads the file
  - [ ] Backspace deletes chip as a single unit
  - [ ] Round-trip: edit + save — markdown stays `[report.pdf](pad-attachment:<uuid>)`
  - [ ] Regular markdown links (`[Google](https://google.com)`) continue to render as plain links via SafeLink