### PR TITLE
feat(attachments): editor paste + drag-drop upload plugin (TASK-875)

### DIFF
--- a/web/src/app.css
+++ b/web/src/app.css
@@ -287,6 +287,45 @@ input:focus, textarea:focus {
 	outline-offset: 1px;
 }
 
+/* Upload-in-progress placeholder — rendered as a ProseMirror widget
+   decoration by the AttachmentUpload extension. Dashed border + faded
+   color so it visually reads as "not yet committed content" while the
+   network round-trip resolves. */
+.attachment-upload-placeholder {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.4em;
+	padding: 4px 10px;
+	margin: 0 1px;
+	background: var(--bg-tertiary);
+	border: 1px dashed color-mix(in srgb, var(--accent-blue) 50%, var(--border));
+	border-radius: 6px;
+	color: var(--text-secondary);
+	font-size: 0.92em;
+	line-height: 1.3;
+	vertical-align: baseline;
+}
+.attachment-upload-spinner {
+	width: 12px;
+	height: 12px;
+	border: 2px solid color-mix(in srgb, var(--accent-blue) 35%, transparent);
+	border-top-color: var(--accent-blue);
+	border-radius: 50%;
+	animation: attachment-upload-spin 0.7s linear infinite;
+	flex-shrink: 0;
+}
+@keyframes attachment-upload-spin {
+	to {
+		transform: rotate(360deg);
+	}
+}
+.attachment-upload-label {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	max-width: 30ch;
+}
+
 /* Lightbox dialog — appended to document.body when an attachment image
    is clicked, so styles must be global rather than scoped to Editor.svelte.
    Uses the native <dialog> element; the ::backdrop pseudo handles the

--- a/web/src/lib/components/editor/Editor.svelte
+++ b/web/src/lib/components/editor/Editor.svelte
@@ -285,6 +285,7 @@
 	import { SLASH_ITEMS } from './block-types';
 	import { AttachmentImage, type AttachmentVariant } from './attachment-image';
 	import { AttachmentChip } from './attachment-chip';
+	import { AttachmentUpload } from './attachment-upload';
 
 	let {
 		content = '',
@@ -470,6 +471,29 @@
 			BlockDragHandle,
 			AttachmentImage.configure({ getDownloadUrl: getAttachmentUrl }),
 			AttachmentChip.configure({ getDownloadUrl: getAttachmentUrl, workspaceSlug: wsSlug }),
+			AttachmentUpload.configure({
+				upload: async (file) => {
+					if (!wsSlug) {
+						// Without a workspace context the upload endpoint
+						// has no path to hit. Fail the promise so the
+						// plugin's onError surfaces the limitation rather
+						// than leaving a silent stuck spinner.
+						throw new Error('No workspace context — drop a file from inside a workspace.');
+					}
+					return api.attachments.upload(wsSlug, file);
+				},
+				onError: (filename, message) => {
+					// Surface upload failures to the user. The editor's
+					// host route doesn't yet have a centralized toast
+					// system, so we log to console + window.alert as a
+					// minimal fallback. Replace with a real notification
+					// channel once the workspace ships one.
+					console.error(`[attachment upload] ${filename}: ${message}`);
+					if (typeof window !== 'undefined' && typeof window.alert === 'function') {
+						window.alert(`Couldn't upload ${filename}: ${message}`);
+					}
+				},
+			}),
 		];
 
 		editor = new Editor({

--- a/web/src/lib/components/editor/attachment-upload.ts
+++ b/web/src/lib/components/editor/attachment-upload.ts
@@ -1,0 +1,293 @@
+/**
+ * AttachmentUpload — Tiptap extension that intercepts paste and drop
+ * events with files and uploads them through the attachment API.
+ *
+ * Flow:
+ *   1. User pastes a screenshot or drops a file onto the editor.
+ *   2. The plugin detects file payloads in clipboardData / dataTransfer.
+ *   3. For each file: insert a position-tracked placeholder (decoration
+ *      widget — zero document width so it never enters serialized
+ *      markdown), kick off `api.attachments.upload`, race the network
+ *      with continued editing.
+ *   4. On success: replace the placeholder with an `attachmentImage`
+ *      node (image MIME) or `attachmentChip` node (everything else),
+ *      using the position the plugin's transaction mapping has carried
+ *      forward across intervening edits.
+ *   5. On error: remove the placeholder and surface the failure via the
+ *      injected `onError` callback. The placeholder is visual-only so
+ *      removing it leaves the document otherwise untouched.
+ *
+ * The uploaded blob is dropped silently if its placeholder has been
+ * deleted before completion (user changed their mind, navigated away,
+ * etc.). Orphan-GC reclaims the on-disk bytes after the grace period.
+ *
+ * Multiple files in a single drop fan out as concurrent uploads with
+ * individual placeholders — the user sees one spinner per file and
+ * each replaces its own placeholder when its upload finishes, in
+ * whatever order the network completes.
+ */
+
+import { Extension } from '@tiptap/core';
+import { Plugin, PluginKey } from '@tiptap/pm/state';
+import { Decoration, DecorationSet, type EditorView } from '@tiptap/pm/view';
+import type { AttachmentUploadResult } from '$lib/types';
+
+/** Per-upload metadata stored in plugin state and rendered as a decoration. */
+interface UploadEntry {
+	pos: number;
+	filename: string;
+}
+
+interface UploadState {
+	uploads: Map<string, UploadEntry>;
+}
+
+interface UploadAction {
+	/** Add a new upload placeholder. */
+	add?: { id: string; pos: number; filename: string };
+	/** Remove a placeholder by id (success or cancellation). */
+	remove?: string;
+}
+
+export interface AttachmentUploadOptions {
+	/** Upload a single file; returns the persisted attachment metadata. */
+	upload: (file: File) => Promise<AttachmentUploadResult>;
+	/**
+	 * Called when an upload fails or the file's MIME is rejected. The
+	 * plugin doesn't render its own error UI — the editor wires this to
+	 * the host app's notification system.
+	 */
+	onError?: (filename: string, message: string) => void;
+}
+
+const pluginKey = new PluginKey<UploadState>('attachmentUpload');
+
+/**
+ * Crypto-strong-ish placeholder id. crypto.randomUUID is the preferred
+ * source; the Math.random fallback is only hit in environments without
+ * the WebCrypto API (server-side rendering, ancient browsers) where
+ * the upload plugin can't run anyway. Collision-resistant within the
+ * scope of a single editing session, which is all we need.
+ */
+function newId(): string {
+	if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+		return crypto.randomUUID();
+	}
+	return `up-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+/** Build the placeholder DOM. Kept tiny — purely visual, ignored by ProseMirror's selection model. */
+function buildPlaceholder(filename: string): HTMLElement {
+	const wrapper = document.createElement('span');
+	wrapper.className = 'attachment-upload-placeholder';
+	wrapper.contentEditable = 'false';
+
+	const spinner = document.createElement('span');
+	spinner.className = 'attachment-upload-spinner';
+	spinner.setAttribute('aria-hidden', 'true');
+
+	const label = document.createElement('span');
+	label.className = 'attachment-upload-label';
+	label.textContent = `Uploading ${filename}…`;
+
+	wrapper.append(spinner, label);
+	return wrapper;
+}
+
+/**
+ * Extract file payloads from a paste event. Falls back to the empty
+ * array when the clipboard has no files (regular text paste, etc.) so
+ * the caller can cleanly defer to the default paste handler.
+ */
+function filesFromPaste(event: ClipboardEvent): File[] {
+	if (!event.clipboardData) return [];
+	const out: File[] = [];
+	for (const item of Array.from(event.clipboardData.items)) {
+		if (item.kind !== 'file') continue;
+		const file = item.getAsFile();
+		if (file) out.push(file);
+	}
+	return out;
+}
+
+/** Same idea for drop events — covers the dataTransfer.files surface. */
+function filesFromDrop(event: DragEvent): File[] {
+	const dt = event.dataTransfer;
+	if (!dt || dt.files.length === 0) return [];
+	return Array.from(dt.files);
+}
+
+/**
+ * Resolve the document position to insert at for a drop event. Uses
+ * the editor's coordinate-to-position mapping; returns null when the
+ * drop landed outside the editor body, so the handler can fall through.
+ */
+function dropPosition(view: EditorView, event: DragEvent): number | null {
+	const coords = view.posAtCoords({ left: event.clientX, top: event.clientY });
+	return coords?.pos ?? null;
+}
+
+/**
+ * Kick off an upload for a single file. Inserts the placeholder
+ * immediately, then races the network. The placeholder's position is
+ * mapped through every intervening transaction by the plugin's
+ * `apply`, so the final replace lands at the right spot even if the
+ * user keeps typing.
+ */
+function startUpload(
+	view: EditorView,
+	file: File,
+	insertPos: number,
+	opts: AttachmentUploadOptions,
+): void {
+	const id = newId();
+	const filename = file.name || 'attachment';
+
+	// 1. Add placeholder. The transaction is dispatched synchronously so
+	//    the user sees the spinner the moment the paste/drop lands.
+	view.dispatch(
+		view.state.tr.setMeta(pluginKey, {
+			add: { id, pos: insertPos, filename },
+		} satisfies UploadAction),
+	);
+
+	// 2. Race the network. We re-read state on resolve because the user
+	//    may have edited around the placeholder (the position has been
+	//    mapped) or removed it entirely (the placeholder is gone).
+	opts
+		.upload(file)
+		.then((result) => {
+			const state = pluginKey.getState(view.state);
+			const entry = state?.uploads.get(id);
+			if (!entry) return; // placeholder gone — drop the upload silently
+			const tr = view.state.tr;
+			const node = nodeForResult(view, result);
+			if (node) tr.insert(entry.pos, node);
+			tr.setMeta(pluginKey, { remove: id } satisfies UploadAction);
+			view.dispatch(tr);
+		})
+		.catch((err: unknown) => {
+			view.dispatch(view.state.tr.setMeta(pluginKey, { remove: id } satisfies UploadAction));
+			const message = err instanceof Error ? err.message : String(err ?? 'Upload failed');
+			opts.onError?.(filename, message);
+		});
+}
+
+/**
+ * Build the node that should replace a placeholder for a given upload
+ * result. Image MIMEs become `attachmentImage`; everything else becomes
+ * `attachmentChip`. Returns null when the schema has neither node
+ * registered (e.g. the editor was set up without those extensions) —
+ * the placeholder is removed and the upload silently lands as an
+ * orphan, which orphan-GC will reclaim later.
+ */
+function nodeForResult(view: EditorView, result: AttachmentUploadResult) {
+	const schema = view.state.schema;
+	const isImage = result.category === 'image';
+	if (isImage && schema.nodes.attachmentImage) {
+		return schema.nodes.attachmentImage.create({ uuid: result.id, alt: result.filename });
+	}
+	if (schema.nodes.attachmentChip) {
+		return schema.nodes.attachmentChip.create({ uuid: result.id, filename: result.filename });
+	}
+	return null;
+}
+
+/** Build the ProseMirror plugin. Exposed for tests / advanced wiring. */
+export function attachmentUploadPlugin(opts: AttachmentUploadOptions): Plugin<UploadState> {
+	return new Plugin<UploadState>({
+		key: pluginKey,
+		state: {
+			init: () => ({ uploads: new Map() }),
+			apply(tr, prev): UploadState {
+				// Map every placeholder's position through the new
+				// transaction so they track the user's edits. We always
+				// produce a fresh Map so the previous state object is
+				// never mutated — ProseMirror compares state objects by
+				// reference for change detection.
+				const next: UploadState = { uploads: new Map() };
+				for (const [id, entry] of prev.uploads) {
+					next.uploads.set(id, { ...entry, pos: tr.mapping.map(entry.pos) });
+				}
+				const action = tr.getMeta(pluginKey) as UploadAction | undefined;
+				if (action?.add) {
+					next.uploads.set(action.add.id, {
+						pos: action.add.pos,
+						filename: action.add.filename,
+					});
+				}
+				if (action?.remove) {
+					next.uploads.delete(action.remove);
+				}
+				return next;
+			},
+		},
+		props: {
+			decorations(state) {
+				const us = pluginKey.getState(state);
+				if (!us || us.uploads.size === 0) return null;
+				const decos: Decoration[] = [];
+				for (const [, entry] of us.uploads) {
+					decos.push(
+						Decoration.widget(entry.pos, () => buildPlaceholder(entry.filename), {
+							// side: -1 so the widget renders BEFORE the cursor
+							// position. This keeps the placeholder anchored
+							// to where the file was dropped/pasted, rather
+							// than drifting to the right as the user types.
+							side: -1,
+							// ignoreSelection prevents ProseMirror from
+							// putting the cursor inside the placeholder DOM
+							// when the user clicks on it.
+							ignoreSelection: true,
+						}),
+					);
+				}
+				return DecorationSet.create(state.doc, decos);
+			},
+			handleDOMEvents: {
+				paste(view, event) {
+					const files = filesFromPaste(event as ClipboardEvent);
+					if (files.length === 0) return false; // let other handlers process the paste
+					event.preventDefault();
+					const pos = view.state.selection.from;
+					for (const file of files) {
+						startUpload(view, file, pos, opts);
+					}
+					return true;
+				},
+				drop(view, event) {
+					const files = filesFromDrop(event as DragEvent);
+					if (files.length === 0) return false;
+					const pos = dropPosition(view, event as DragEvent);
+					if (pos === null) return false;
+					event.preventDefault();
+					for (const file of files) {
+						startUpload(view, file, pos, opts);
+					}
+					return true;
+				},
+			},
+		},
+	});
+}
+
+/**
+ * Tiptap-flavoured wrapper. Lets Editor.svelte add the upload behavior
+ * via the standard `extensions` array alongside StarterKit, etc.
+ */
+export const AttachmentUpload = Extension.create<AttachmentUploadOptions>({
+	name: 'attachmentUpload',
+
+	addOptions() {
+		return {
+			upload: async () => {
+				throw new Error('AttachmentUpload: configure({ upload }) is required');
+			},
+			onError: undefined,
+		};
+	},
+
+	addProseMirrorPlugins() {
+		return [attachmentUploadPlugin(this.options)];
+	},
+});


### PR DESCRIPTION
## Summary

Tiptap extension that intercepts paste/drop events with files, uploads each through the attachment API, and replaces the placeholder with the right node (`attachmentImage` for image MIMEs, `attachmentChip` for everything else) at the position the user dropped.

### Flow
1. Detect file payloads in `clipboardData.items` / `dataTransfer.files` — skip the event when there are none so plain text paste still goes through `tiptap-markdown`'s `transformPastedText`.
2. Insert a position-tracked placeholder at the paste/drop position via a `setMeta` transaction. Placeholders are **widget decorations** (zero document width) so they never enter serialized markdown.
3. Race the network. The plugin's `apply()` handler maps every placeholder position through every intervening transaction — continued editing doesn't strand the spinner.
4. **On success** → schema-aware replacement: `attachmentImage` for `category === 'image'`, `attachmentChip` otherwise. Placeholder removed in the same transaction.
5. **On error** → remove placeholder, surface via injected `onError` callback. Bytes that did land become orphans; orphan-GC reclaims them.
6. Placeholder gone before upload completes (user cancelled / navigated away) → drop silently, same orphan-GC outcome.

Multiple files in a single drop fan out as concurrent uploads; each gets its own placeholder and replaces independently.

### Editor.svelte wiring
- `upload` → `api.attachments.upload(wsSlug, file)`; rejects with a clear message when no workspace context
- `onError` → `console.error` + `window.alert` as a minimal fallback until a centralized toast system lands

### Styles (`app.css`)
Placeholder: dashed border, faded color, CSS spinner. `ignoreSelection: true` so ProseMirror's selection skips the widget DOM.

## Context

Implements `TASK-875` under `PLAN-866` (Attachments Phase 1). Closes the editor-input flow on top of:
- `TASK-874` — markdown resolver
- `TASK-876` — `attachmentImage` node
- `TASK-877` — `attachmentChip` node

## Test plan

- [x] `cd web && npm run build` — clean
- [x] `cd web && npm run check` — 0 errors (6 pre-existing warnings)
- [ ] Manual after merge:
  - [ ] Paste a screenshot — placeholder appears, image renders inline within ~1s
  - [ ] Drag a PDF onto editor — chip appears at drop position with PDF icon
  - [ ] Drop multiple files at once — each gets its own placeholder, all upload concurrently
  - [ ] Reject upload (e.g. .exe) — placeholder disappears, error alert fires
  - [ ] Type around a pending placeholder — placeholder tracks the position; final image lands correctly
  - [ ] Save + reload — round-trip works (markdown round-trip is from TASK-874 / 876 / 877, this PR only adds the upload path)