### PR TITLE
feat(attachments): server-side rotate transform + editor toolbar (TASK-879)

### DIFF
--- a/internal/server/handlers_attachments_transform.go
+++ b/internal/server/handlers_attachments_transform.go
@@ -189,10 +189,17 @@ func (s *Server) handleTransformAttachment(w http.ResponseWriter, r *http.Reques
 	// row is a peer (NOT a derived/variant row — that's only for
 	// thumbnails) so ParentID and Variant stay nil; the editor
 	// swaps its reference and the original ages into orphan GC.
+	//
+	// UploadedBy inherits from the parent — same policy as the
+	// thumbnail pipeline. A user who rotates someone else's upload
+	// shouldn't inadvertently take ownership of the resulting blob;
+	// audit attribution stays anchored to whoever first put the
+	// bytes into the workspace. (The transform itself is auditable
+	// at the request layer if/when we add a transform-events log.)
 	row := &models.Attachment{
 		WorkspaceID: parent.WorkspaceID,
 		ItemID:      parent.ItemID,
-		UploadedBy:  currentUserOrSystem(r),
+		UploadedBy:  parent.UploadedBy,
 		StorageKey:  storageKey,
 		ContentHash: hash,
 		MimeType:    attachments.ThumbnailMime(outFormat),
@@ -279,12 +286,3 @@ func transformedFilename(parent, op, format string) string {
 	return base + "." + op + ext
 }
 
-// currentUserOrSystem returns the authenticated user ID, falling
-// back to "system" for the no-users-yet case (mirrors the upload
-// handler's attribution policy).
-func currentUserOrSystem(r *http.Request) string {
-	if id := currentUserID(r); id != "" {
-		return id
-	}
-	return "system"
-}

--- a/internal/server/handlers_attachments_transform.go
+++ b/internal/server/handlers_attachments_transform.go
@@ -1,0 +1,290 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"image"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/PerpetualSoftware/pad/internal/attachments"
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// transformRequest is the body shape for POST /transform. Operation
+// is the discriminator; the per-operation params live in their own
+// fields so callers don't have to wrap them in a generic args map.
+//
+// Adding a new operation = adding a new case in the dispatch below
+// + a new param field here. Keeps the wire format tight and the
+// handler boring.
+type transformRequest struct {
+	Operation string `json:"operation"`
+
+	// rotate
+	Degrees int `json:"degrees,omitempty"`
+
+	// crop (TASK-880 will populate this; defined here so the wire
+	// format is stable across the two PRs).
+	Rect *transformRect `json:"rect,omitempty"`
+}
+
+// transformRect is the crop rectangle in original-image pixel space.
+// Origin top-left, x/y/w/h are integers — preview-pixel-to-original
+// conversion is the editor's responsibility, so server-side math
+// stays in canonical coordinates.
+type transformRect struct {
+	X int `json:"x"`
+	Y int `json:"y"`
+	W int `json:"w"`
+	H int `json:"h"`
+}
+
+// transformResponse is the success payload — same shape as the
+// upload response so the editor can swap the node's UUID and any
+// width/height attrs in one go without a follow-up GET.
+type transformResponse struct {
+	ID       string `json:"id"`
+	URL      string `json:"url"`
+	Mime     string `json:"mime"`
+	Size     int64  `json:"size"`
+	Width    *int   `json:"width,omitempty"`
+	Height   *int   `json:"height,omitempty"`
+	Filename string `json:"filename"`
+}
+
+// handleTransformAttachment implements POST
+// /api/v1/workspaces/{slug}/attachments/{attachmentID}/transform.
+//
+// Phase 1 supports two operations: "rotate" (TASK-879) and "crop"
+// (TASK-880). Both follow the same flow:
+//
+//  1. Auth: editor+ on the workspace.
+//  2. Load the parent attachment row (cross-workspace = 404).
+//  3. Reject if no image processor is wired (libvips build that
+//     hasn't shipped Phase 2 yet, or a self-host that opted out).
+//  4. Decode the original — defends against unsupported MIMEs and
+//     oversized inputs via the processor's Decode rules.
+//  5. Apply the operation. Each op validates its own params.
+//  6. Encode in the policy format (PNG → PNG to preserve alpha,
+//     everything else → JPEG q=85). Same policy as thumbnails so
+//     transformed and thumbnail blobs deduplicate cleanly.
+//  7. Hash + Put through the storage backend (content-addressed,
+//     so identical transforms collapse onto the same blob).
+//  8. Insert a NEW attachments row owned by the same workspace /
+//     uploaded_by / item as the parent. The original is left in
+//     place — orphan GC reclaims it past the grace period
+//     (TASK-886) once the editor swaps its reference.
+//  9. Return the new row's ID/URL/dimensions so the editor can
+//     update its node attrs without a follow-up GET.
+func (s *Server) handleTransformAttachment(w http.ResponseWriter, r *http.Request) {
+	if !requireMinRole(w, r, "editor") {
+		return
+	}
+	if s.attachments == nil {
+		writeError(w, http.StatusServiceUnavailable, "attachments_disabled",
+			"Attachment storage is not configured on this server")
+		return
+	}
+	if s.imageProcessor == nil {
+		writeError(w, http.StatusServiceUnavailable, "image_processor_disabled",
+			"Image transformation is not available on this build (the libvips backend has not shipped yet)")
+		return
+	}
+	workspaceID, ok := s.getWorkspaceID(w, r)
+	if !ok {
+		return
+	}
+
+	id := chi.URLParam(r, "attachmentID")
+	if id == "" {
+		writeError(w, http.StatusBadRequest, "bad_request", "Missing attachment id")
+		return
+	}
+
+	parent, err := s.store.GetAttachment(id)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	// 404 — same cross-workspace defense as the GET handler. Leaking
+	// 403 vs 404 here would let a member of workspace B enumerate
+	// attachment IDs in workspace A.
+	if parent == nil || parent.WorkspaceID != workspaceID || parent.DeletedAt != nil {
+		writeError(w, http.StatusNotFound, "not_found", "Attachment not found")
+		return
+	}
+
+	var req transformRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", "Invalid JSON body")
+		return
+	}
+
+	// Open the original blob through the registry. Defer Close so
+	// every error path below releases the file handle / network
+	// connection.
+	srcStore, err := s.attachments.Resolve(parent.StorageKey)
+	if err != nil {
+		writeInternalError(w, fmt.Errorf("resolve source backend: %w", err))
+		return
+	}
+	body, err := srcStore.Get(r.Context(), parent.StorageKey)
+	if err != nil {
+		writeInternalError(w, fmt.Errorf("read source blob: %w", err))
+		return
+	}
+	defer body.Close()
+
+	srcImg, srcFormat, err := s.imageProcessor.Decode(body)
+	if err != nil {
+		switch {
+		case errors.Is(err, attachments.ErrUnsupportedFormat):
+			// Per spec: editor surfaces this as an inline tooltip.
+			// 415 is the canonical "media type not supported" code.
+			writeError(w, http.StatusUnsupportedMediaType, "unsupported_format",
+				"Image transformation isn't available for "+parent.MimeType+" on this build")
+		case errors.Is(err, attachments.ErrImageTooLarge):
+			writeError(w, http.StatusRequestEntityTooLarge, "image_too_large",
+				"Image dimensions exceed the processor's safe-decode limit")
+		default:
+			writeInternalError(w, fmt.Errorf("decode source: %w", err))
+		}
+		return
+	}
+
+	transformed, opErr := applyImageTransform(s.imageProcessor, srcImg, &req)
+	if opErr != nil {
+		writeError(w, http.StatusBadRequest, "bad_transform", opErr.Error())
+		return
+	}
+
+	outFormat := attachments.ThumbnailFormat(srcFormat)
+	var buf bytes.Buffer
+	if err := s.imageProcessor.Encode(transformed, outFormat, &buf); err != nil {
+		writeInternalError(w, fmt.Errorf("encode transformed image: %w", err))
+		return
+	}
+	hash := sha256Hex(buf.Bytes())
+
+	dstStore, err := s.attachments.Resolve(attachments.FSPrefix + ":" + hash)
+	if err != nil {
+		writeInternalError(w, fmt.Errorf("resolve destination backend: %w", err))
+		return
+	}
+	storageKey, err := dstStore.Put(r.Context(), hash, attachments.ThumbnailMime(outFormat), bytes.NewReader(buf.Bytes()))
+	if err != nil {
+		writeInternalError(w, fmt.Errorf("put transformed blob: %w", err))
+		return
+	}
+
+	bounds := transformed.Bounds()
+	tw := bounds.Dx()
+	th := bounds.Dy()
+
+	// Inherit attribution + item linkage from the parent. The new
+	// row is a peer (NOT a derived/variant row — that's only for
+	// thumbnails) so ParentID and Variant stay nil; the editor
+	// swaps its reference and the original ages into orphan GC.
+	row := &models.Attachment{
+		WorkspaceID: parent.WorkspaceID,
+		ItemID:      parent.ItemID,
+		UploadedBy:  currentUserOrSystem(r),
+		StorageKey:  storageKey,
+		ContentHash: hash,
+		MimeType:    attachments.ThumbnailMime(outFormat),
+		SizeBytes:   int64(buf.Len()),
+		Filename:    transformedFilename(parent.Filename, req.Operation, outFormat),
+		Width:       &tw,
+		Height:      &th,
+	}
+	if err := s.store.CreateAttachment(row); err != nil {
+		writeInternalError(w, fmt.Errorf("create transformed row: %w", err))
+		return
+	}
+
+	// Quota tracking — observational only in Phase 1, same as upload.
+	s.goAsync(func() { s.maybeWarnStorageQuota(workspaceID) })
+
+	writeJSON(w, http.StatusCreated, transformResponse{
+		ID:       row.ID,
+		URL:      attachmentURL(chi.URLParam(r, "slug"), row.ID),
+		Mime:     row.MimeType,
+		Size:     row.SizeBytes,
+		Width:    row.Width,
+		Height:   row.Height,
+		Filename: row.Filename,
+	})
+}
+
+// applyImageTransform dispatches on the operation discriminator.
+// Each branch validates its own params and returns a clear error
+// — the handler turns those into 400 Bad Request without leaking
+// internal detail. New ops slot in here.
+func applyImageTransform(p attachments.Processor, src image.Image, req *transformRequest) (image.Image, error) {
+	switch req.Operation {
+	case "rotate":
+		// Validate degrees up-front so we can return a clean 400
+		// instead of leaking the processor's "only multiples of 90"
+		// internal-error message. The set is intentionally narrow:
+		// 90 / 180 / 270 are pixel-exact reorders (no resampling),
+		// and 0 is a no-op the editor shouldn't be sending.
+		switch req.Degrees {
+		case 90, 180, 270:
+			return p.Rotate(src, req.Degrees)
+		default:
+			return nil, fmt.Errorf("rotate: degrees must be 90, 180, or 270 (got %d)", req.Degrees)
+		}
+	case "crop":
+		if req.Rect == nil {
+			return nil, fmt.Errorf("crop: rect is required")
+		}
+		if req.Rect.W <= 0 || req.Rect.H <= 0 {
+			return nil, fmt.Errorf("crop: rect width/height must be positive")
+		}
+		if req.Rect.X < 0 || req.Rect.Y < 0 {
+			return nil, fmt.Errorf("crop: rect x/y must be non-negative")
+		}
+		// Processor.Crop intersects with the image bounds itself, so
+		// we don't need to clip here. The processor returns an error
+		// only for empty intersections (rect entirely outside the
+		// image) — bubble that up as a 400.
+		return p.Crop(src, image.Rect(req.Rect.X, req.Rect.Y, req.Rect.X+req.Rect.W, req.Rect.Y+req.Rect.H))
+	default:
+		return nil, fmt.Errorf("operation must be one of: rotate, crop (got %q)", req.Operation)
+	}
+}
+
+// transformedFilename builds the synthetic filename for the derived
+// row. We append the operation tag (e.g. ".rotated", ".cropped")
+// before the extension so a user downloading the file directly sees
+// what happened to it. Matches the shape thumbnailFilename emits.
+func transformedFilename(parent, op, format string) string {
+	ext := attachments.ThumbnailExt(format)
+	base := parent
+	// Strip any existing extension so we don't end up with
+	// "shot.png.rotated.png" round-trip cruft.
+	for i := len(base) - 1; i >= 0; i-- {
+		if base[i] == '.' {
+			base = base[:i]
+			break
+		}
+	}
+	if base == "" {
+		base = "attachment"
+	}
+	return base + "." + op + ext
+}
+
+// currentUserOrSystem returns the authenticated user ID, falling
+// back to "system" for the no-users-yet case (mirrors the upload
+// handler's attribution policy).
+func currentUserOrSystem(r *http.Request) string {
+	if id := currentUserID(r); id != "" {
+		return id
+	}
+	return "system"
+}

--- a/internal/server/handlers_attachments_transform_test.go
+++ b/internal/server/handlers_attachments_transform_test.go
@@ -1,0 +1,269 @@
+//go:build !libvips
+
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"image"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// transformRequestBody marshals a transform request for tests. Mirrors
+// the handler's internal struct so behavior under unknown / malformed
+// bodies is observable.
+type transformRequestBody struct {
+	Operation string `json:"operation"`
+	Degrees   int    `json:"degrees,omitempty"`
+	Rect      *struct {
+		X int `json:"x"`
+		Y int `json:"y"`
+		W int `json:"w"`
+		H int `json:"h"`
+	} `json:"rect,omitempty"`
+}
+
+func doTransform(srv *Server, slug, attachmentID string, body transformRequestBody) *httptest.ResponseRecorder {
+	buf, _ := json.Marshal(body)
+	req := httptest.NewRequest("POST",
+		"/api/v1/workspaces/"+slug+"/attachments/"+attachmentID+"/transform",
+		bytes.NewReader(buf))
+	req.Header.Set("Content-Type", "application/json")
+	req.RemoteAddr = "127.0.0.1:1234"
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	return rr
+}
+
+func uploadIntegrationPNG(t *testing.T, srv *Server, slug string, w, h int) (id, urlPath string) {
+	t.Helper()
+	body := makeIntegrationPNG(t, w, h)
+	rr := doMultipartUpload(srv, slug, "shot.png", body)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("seed upload status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		ID  string `json:"id"`
+		URL string `json:"url"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode upload resp: %v", err)
+	}
+	return resp.ID, resp.URL
+}
+
+func TestTransform_Rotate90SwapsWidthHeight(t *testing.T) {
+	srv, slug := testServerWithAttachments(t)
+	id, _ := uploadIntegrationPNG(t, srv, slug, 800, 400)
+	srv.Stop() // drain thumbnail goroutine
+
+	rr := doTransform(srv, slug, id, transformRequestBody{Operation: "rotate", Degrees: 90})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("rotate status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		ID     string `json:"id"`
+		Mime   string `json:"mime"`
+		Width  *int   `json:"width"`
+		Height *int   `json:"height"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.ID == "" || resp.ID == id {
+		t.Errorf("expected new attachment id, got %q (parent was %q)", resp.ID, id)
+	}
+	if resp.Width == nil || resp.Height == nil {
+		t.Fatal("response missing width/height")
+	}
+	if *resp.Width != 400 || *resp.Height != 800 {
+		t.Errorf("rotated dims = %dx%d, want 400x800 (90° swap)", *resp.Width, *resp.Height)
+	}
+	// PNG input → PNG output (preserves alpha policy).
+	if resp.Mime != "image/png" {
+		t.Errorf("rotated MIME = %q, want image/png", resp.Mime)
+	}
+}
+
+func TestTransform_Rotate180KeepsDimensions(t *testing.T) {
+	srv, slug := testServerWithAttachments(t)
+	id, _ := uploadIntegrationPNG(t, srv, slug, 800, 400)
+	srv.Stop()
+
+	rr := doTransform(srv, slug, id, transformRequestBody{Operation: "rotate", Degrees: 180})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+	var resp struct{ Width, Height *int }
+	_ = json.Unmarshal(rr.Body.Bytes(), &resp)
+	if resp.Width == nil || resp.Height == nil || *resp.Width != 800 || *resp.Height != 400 {
+		t.Errorf("180° dims = %v×%v, want 800×400", resp.Width, resp.Height)
+	}
+}
+
+func TestTransform_RotateRejectsBadDegrees(t *testing.T) {
+	srv, slug := testServerWithAttachments(t)
+	id, _ := uploadIntegrationPNG(t, srv, slug, 100, 100)
+	srv.Stop()
+
+	cases := []int{0, 45, 91, 360, -90}
+	for _, deg := range cases {
+		rr := doTransform(srv, slug, id, transformRequestBody{Operation: "rotate", Degrees: deg})
+		if rr.Code != http.StatusBadRequest {
+			t.Errorf("degrees=%d status = %d, want 400", deg, rr.Code)
+		}
+	}
+}
+
+func TestTransform_UnknownOperationIs400(t *testing.T) {
+	srv, slug := testServerWithAttachments(t)
+	id, _ := uploadIntegrationPNG(t, srv, slug, 100, 100)
+	srv.Stop()
+
+	rr := doTransform(srv, slug, id, transformRequestBody{Operation: "polarize"})
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("unknown op status = %d, want 400", rr.Code)
+	}
+}
+
+func TestTransform_NonExistentAttachmentIs404(t *testing.T) {
+	srv, slug := testServerWithAttachments(t)
+	defer srv.Stop()
+
+	rr := doTransform(srv, slug, "00000000-0000-0000-0000-000000000000",
+		transformRequestBody{Operation: "rotate", Degrees: 90})
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", rr.Code)
+	}
+}
+
+func TestTransform_CrossWorkspaceReturns404(t *testing.T) {
+	// Upload into A, attempt transform from B — must be 404, not 403.
+	srv, slugA := testServerWithAttachments(t)
+	slugB := createWSForTest(t, srv)
+	id, _ := uploadIntegrationPNG(t, srv, slugA, 100, 100)
+	srv.Stop()
+
+	rr := doTransform(srv, slugB, id, transformRequestBody{Operation: "rotate", Degrees: 90})
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("cross-workspace status = %d, want 404 (NOT 403)", rr.Code)
+	}
+}
+
+func TestTransform_DisabledWhenNoProcessor(t *testing.T) {
+	// Upload via a server WITH a processor (so we have a real attachment to point at),
+	// then unwire the processor and verify transform reports the disabled state.
+	srv, slug := testServerWithAttachments(t)
+	id, _ := uploadIntegrationPNG(t, srv, slug, 100, 100)
+	srv.Stop()
+
+	srv.SetImageProcessor(nil)
+
+	rr := doTransform(srv, slug, id, transformRequestBody{Operation: "rotate", Degrees: 90})
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Errorf("no-processor status = %d, want 503", rr.Code)
+	}
+	if !strings.Contains(rr.Body.String(), "image_processor_disabled") {
+		t.Errorf("error code missing from body: %s", rr.Body.String())
+	}
+}
+
+func TestTransform_ProducesNewBlob(t *testing.T) {
+	// Sanity: rotating an image creates a fresh content-addressed
+	// blob with a different hash + size. Without this, a regression
+	// that returned the parent's row would silently break the
+	// editor's UUID-swap flow.
+	srv, slug := testServerWithAttachments(t)
+	id, _ := uploadIntegrationPNG(t, srv, slug, 800, 400)
+	srv.Stop()
+
+	parent, err := srv.store.GetAttachment(id)
+	if err != nil || parent == nil {
+		t.Fatalf("get parent: %v", err)
+	}
+
+	rr := doTransform(srv, slug, id, transformRequestBody{Operation: "rotate", Degrees: 90})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("status = %d", rr.Code)
+	}
+	var resp struct{ ID string }
+	_ = json.Unmarshal(rr.Body.Bytes(), &resp)
+
+	derived, err := srv.store.GetAttachment(resp.ID)
+	if err != nil || derived == nil {
+		t.Fatalf("get derived: %v", err)
+	}
+	if derived.ContentHash == parent.ContentHash {
+		t.Errorf("derived hash matches parent (%s) — transform did not produce new bytes", parent.ContentHash)
+	}
+	// New row must inherit workspace + uploaded_by + item_id from parent.
+	if derived.WorkspaceID != parent.WorkspaceID {
+		t.Errorf("derived WorkspaceID = %q, want %q", derived.WorkspaceID, parent.WorkspaceID)
+	}
+	// Filename should carry the operation tag so a direct download
+	// surfaces what happened (UI nicety; the transform endpoint
+	// guarantees this filename shape).
+	if !strings.Contains(derived.Filename, "rotate") {
+		t.Errorf("derived filename %q missing rotate tag", derived.Filename)
+	}
+}
+
+func TestTransform_ServedDownloadDecodesAtNewDimensions(t *testing.T) {
+	srv, slug := testServerWithAttachments(t)
+	id, _ := uploadIntegrationPNG(t, srv, slug, 800, 400)
+	srv.Stop()
+
+	rr := doTransform(srv, slug, id, transformRequestBody{Operation: "rotate", Degrees: 90})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("status = %d", rr.Code)
+	}
+	var resp struct {
+		ID  string `json:"id"`
+		URL string `json:"url"`
+	}
+	_ = json.Unmarshal(rr.Body.Bytes(), &resp)
+
+	// Fetch the new blob via the standard GET handler.
+	req := httptest.NewRequest("GET", resp.URL, nil)
+	req.RemoteAddr = "127.0.0.1:1234"
+	getRR := httptest.NewRecorder()
+	srv.ServeHTTP(getRR, req)
+	if getRR.Code != http.StatusOK {
+		t.Fatalf("get rotated status = %d", getRR.Code)
+	}
+	out, _, err := image.Decode(bytes.NewReader(getRR.Body.Bytes()))
+	if err != nil {
+		t.Fatalf("decode rotated bytes: %v", err)
+	}
+	if out.Bounds().Dx() != 400 || out.Bounds().Dy() != 800 {
+		t.Errorf("served rotated dims = %v, want 400x800", out.Bounds())
+	}
+}
+
+func TestTransform_DeletedParentReturns404(t *testing.T) {
+	// Edge: the editor sends a transform after the user soft-deleted
+	// the original (race or stale UI). 404, not 500 / corrupt blob.
+	srv, slug := testServerWithAttachments(t)
+	id, _ := uploadIntegrationPNG(t, srv, slug, 100, 100)
+	srv.Stop()
+
+	// Manually soft-delete via the store's CreateAttachment-style row update.
+	// The handler checks DeletedAt — set it to a non-nil time.
+	parent, _ := srv.store.GetAttachment(id)
+	if parent == nil {
+		t.Fatal("seed attachment missing")
+	}
+	// We need a soft-delete path. The store doesn't expose one yet (TASK-886
+	// will add the GC path), so this test simulates the scenario by
+	// constructing a request against an ID that was never created.
+	// The shape is identical for the handler's purposes — both go through
+	// the same nil/DeletedAt check.
+	rr := doTransform(srv, slug, "00000000-0000-0000-0000-000000000000",
+		transformRequestBody{Operation: "rotate", Degrees: 90})
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", rr.Code)
+	}
+}

--- a/internal/server/handlers_attachments_transform_test.go
+++ b/internal/server/handlers_attachments_transform_test.go
@@ -243,6 +243,39 @@ func TestTransform_ServedDownloadDecodesAtNewDimensions(t *testing.T) {
 	}
 }
 
+func TestTransform_DerivedRowInheritsUploadedByFromParent(t *testing.T) {
+	// A user who rotates someone else's upload should NOT take
+	// ownership of the resulting blob. The transform pipeline
+	// inherits parent.UploadedBy (same policy as the thumbnail
+	// pipeline) so audit attribution stays anchored to the
+	// original uploader.
+	srv, slug := testServerWithAttachments(t)
+	id, _ := uploadIntegrationPNG(t, srv, slug, 800, 400)
+	srv.Stop()
+
+	parent, _ := srv.store.GetAttachment(id)
+	if parent == nil {
+		t.Fatal("parent missing")
+	}
+	parentUploader := parent.UploadedBy
+
+	rr := doTransform(srv, slug, id, transformRequestBody{Operation: "rotate", Degrees: 90})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("status = %d", rr.Code)
+	}
+	var resp struct{ ID string }
+	_ = json.Unmarshal(rr.Body.Bytes(), &resp)
+
+	derived, _ := srv.store.GetAttachment(resp.ID)
+	if derived == nil {
+		t.Fatal("derived missing")
+	}
+	if derived.UploadedBy != parentUploader {
+		t.Errorf("derived UploadedBy = %q, want %q (inherited from parent)",
+			derived.UploadedBy, parentUploader)
+	}
+}
+
 func TestTransform_DeletedParentReturns404(t *testing.T) {
 	// Edge: the editor sends a transform after the user soft-deleted
 	// the original (race or stale UI). 404, not 500 / corrupt blob.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -712,9 +712,10 @@ func (s *Server) setupRouter() {
 					})
 
 					// Attachments
-					//   POST   /attachments              — upload (TASK-871)
-					//   GET    /attachments/{attachmentID} — serve blob (TASK-872, supports ?variant=)
-					//   HEAD   /attachments/{attachmentID} — metadata only (TASK-877 file-chip enrichment)
+					//   POST   /attachments                          — upload (TASK-871)
+					//   GET    /attachments/{attachmentID}           — serve blob (TASK-872, supports ?variant=)
+					//   HEAD   /attachments/{attachmentID}           — metadata only (TASK-877 file-chip enrichment)
+					//   POST   /attachments/{attachmentID}/transform — server-side rotate/crop (TASK-879/880)
 					//
 					// chi does not auto-route HEAD to the GET handler, so the
 					// editor's HEAD probe for size + MIME has to be registered
@@ -724,6 +725,7 @@ func (s *Server) setupRouter() {
 					r.Post("/attachments", s.handleUploadAttachment)
 					r.Get("/attachments/{attachmentID}", s.handleGetAttachment)
 					r.Head("/attachments/{attachmentID}", s.handleGetAttachment)
+					r.Post("/attachments/{attachmentID}/transform", s.handleTransformAttachment)
 
 					// Webhooks
 					r.Route("/webhooks", func(r chi.Router) {

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -230,6 +230,63 @@ input:focus, textarea:focus {
 	box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent-blue) 35%, transparent);
 }
 
+/* Wrapper appended by the AttachmentImage NodeView to host the
+   selection-time rotate toolbar (TASK-879). Position relative so
+   the toolbar can pin to the top-right corner of the image. */
+.attachment-image-wrapper {
+	position: relative;
+	display: inline-block;
+	max-width: 100%;
+}
+.attachment-image-wrapper.attachment-image-selected .attachment-image {
+	box-shadow: 0 0 0 2px var(--accent-blue);
+}
+
+/* Rotate toolbar — appears when the AttachmentImage node is
+   selected. Pinned top-right with absolute positioning so it doesn't
+   shift the image's layout when toggling visibility. */
+.attachment-image-toolbar {
+	position: absolute;
+	top: 8px;
+	right: 8px;
+	display: inline-flex;
+	gap: 2px;
+	padding: 4px;
+	background: rgba(20, 20, 20, 0.85);
+	border-radius: var(--radius);
+	box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
+	z-index: 5;
+	-webkit-user-select: none;
+	user-select: none;
+}
+.attachment-image-toolbar-hidden {
+	display: none;
+}
+.attachment-image-toolbar-btn {
+	width: 28px;
+	height: 28px;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	padding: 0;
+	border: none;
+	background: transparent;
+	color: #fff;
+	font-size: 18px;
+	line-height: 1;
+	border-radius: 4px;
+	cursor: pointer;
+	transition: background 0.15s, opacity 0.15s;
+	font-family: inherit;
+}
+.attachment-image-toolbar-btn:hover:not(:disabled) {
+	background: rgba(255, 255, 255, 0.15);
+}
+.attachment-image-toolbar-btn:disabled {
+	opacity: 0.4;
+	cursor: not-allowed;
+}
+
 /* Attachment file chips — Notion-style chip rendering for non-image
    attachments. Used by both the editor's AttachmentChip node and the
    read-only markdown render path (TASK-874). Styles target the same

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -42,7 +42,10 @@ import type {
 	TOTPVerifyResponse,
 	TOTPDisableResponse,
 	AdminBillingStats,
-	AttachmentUploadResult
+	AttachmentUploadResult,
+	AttachmentTransformRequest,
+	AttachmentTransformResult,
+	ServerCapabilities
 } from '$lib/types';
 
 const BASE = '/api/v1';
@@ -787,7 +790,67 @@ export const api = {
 		): string {
 			const base = `${BASE}/workspaces/${workspaceSlug}/attachments/${attachmentId}`;
 			return variant ? `${base}?variant=${encodeURIComponent(variant)}` : base;
+		},
+
+		/**
+		 * Apply a server-side image transform (rotate / crop) to an
+		 * attachment, producing a NEW attachment row whose UUID the
+		 * editor swaps into the corresponding node. The original is
+		 * left in place and reclaimed by orphan GC after the grace
+		 * period (TASK-886) once nothing references it.
+		 *
+		 * Returns the same shape as the upload endpoint so callers
+		 * have everything they need (id, dimensions, etc.) to update
+		 * the editor node attrs without a follow-up GET.
+		 *
+		 * Only callable on attachments whose MIME the server's
+		 * configured Processor supports (the response is 415 when
+		 * not). Editors should gate the UI on
+		 * `server.capabilities()` upfront so users don't see a
+		 * disabled-then-enabled spinner cycle on each click.
+		 */
+		async transform(
+			workspaceSlug: string,
+			attachmentId: string,
+			payload: AttachmentTransformRequest
+		): Promise<AttachmentTransformResult> {
+			const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+			const csrf = getCSRFToken();
+			if (csrf) headers['X-CSRF-Token'] = csrf;
+			const resp = await fetch(
+				`${BASE}/workspaces/${workspaceSlug}/attachments/${attachmentId}/transform`,
+				{
+					method: 'POST',
+					headers,
+					credentials: 'same-origin',
+					body: JSON.stringify(payload)
+				}
+			);
+			if (resp.status === 401) {
+				if (typeof window !== 'undefined' && !window.location.pathname.startsWith('/login')) {
+					window.location.href = '/login';
+				}
+				throw new PadApiError({ code: 'unauthorized', message: 'Authentication required' });
+			}
+			if (!resp.ok) {
+				const body = await resp.json().catch(() => null);
+				if (body?.error) throw new PadApiError(body.error);
+				throw new Error(`transform failed: ${resp.status}`);
+			}
+			return (await resp.json()) as AttachmentTransformResult;
 		}
+	},
+
+	// ── Server capabilities ─────────────────────────────────────────────────
+	//
+	// Reports what the configured image processor can do (formats,
+	// transcode flag, max-pixels ceiling). Public endpoint — the
+	// editor reads it pre-login on shared-item preview surfaces. The
+	// response is static for the lifetime of the binary, so callers
+	// can cache freely.
+
+	server: {
+		capabilities: () => request<ServerCapabilities>('/server/capabilities')
 	},
 
 	// ── Admin ────────────────────────────────────────────────────────────────

--- a/web/src/lib/components/editor/Editor.svelte
+++ b/web/src/lib/components/editor/Editor.svelte
@@ -469,7 +469,29 @@
 				transformCopiedText: true,
 			}),
 			BlockDragHandle,
-			AttachmentImage.configure({ getDownloadUrl: getAttachmentUrl }),
+			AttachmentImage.configure({
+				getDownloadUrl: getAttachmentUrl,
+				workspaceSlug: wsSlug,
+				// Initial supportedFormats is empty — server capabilities
+				// are fetched async below. The toolbar starts disabled
+				// for all formats until capabilities resolve, then
+				// updates per-button via refreshToolbarState. The
+				// editor lifetime is long-lived so the one-call cost
+				// is amortized; no per-render fetch.
+				supportedFormats: [] as string[],
+				transform: async (uuid, payload) => {
+					if (!wsSlug) {
+						throw new Error('No workspace context — open the image inside a workspace to edit it.');
+					}
+					return api.attachments.transform(wsSlug, uuid, payload);
+				},
+				onError: (message) => {
+					console.error('[attachment image]', message);
+					if (typeof window !== 'undefined' && typeof window.alert === 'function') {
+						window.alert(`Couldn't transform image: ${message}`);
+					}
+				},
+			}),
 			AttachmentChip.configure({ getDownloadUrl: getAttachmentUrl, workspaceSlug: wsSlug }),
 			AttachmentUpload.configure({
 				upload: async (file) => {
@@ -601,6 +623,27 @@
 
 		lastMarkdown = unescapeDocLinks((editor.storage as any).markdown.getMarkdown());
 		onEditor?.(editor);
+
+		// Fetch the server's image-processor capabilities and push the
+		// supported-formats list into the AttachmentImage extension so
+		// its rotate toolbar can gate per-format. Async / fire-and-
+		// forget — the toolbar starts disabled (empty list) and
+		// snaps to the right state once this resolves. The endpoint
+		// is public, so the fetch works pre-login on shared-item
+		// preview surfaces too.
+		api.server.capabilities()
+			.then((caps) => {
+				const ext = editor?.extensionManager.extensions.find(
+					(e: { name: string }) => e.name === 'attachmentImage'
+				);
+				if (ext) ext.options.supportedFormats = caps.image.image_formats;
+			})
+			.catch(() => {
+				// Network blip / pre-login fetch failure → toolbar
+				// stays in its degraded "disabled with tooltip" state.
+				// We don't surface this to the user — the toolbar
+				// itself communicates the limitation.
+			});
 
 		editor.on('focus', () => { editorFocused = true; });
 		editor.on('blur', () => { editorFocused = false; });

--- a/web/src/lib/components/editor/Editor.svelte
+++ b/web/src/lib/components/editor/Editor.svelte
@@ -283,7 +283,11 @@
 	import { api } from '$lib/api/client';
 	import { BlockDragHandle } from './block-drag-handle';
 	import { SLASH_ITEMS } from './block-types';
-	import { AttachmentImage, type AttachmentVariant } from './attachment-image';
+	import {
+		AttachmentImage,
+		type AttachmentVariant,
+		notifyAttachmentImageCapabilitiesChanged,
+	} from './attachment-image';
 	import { AttachmentChip } from './attachment-chip';
 	import { AttachmentUpload } from './attachment-upload';
 
@@ -637,6 +641,12 @@
 					(e: { name: string }) => e.name === 'attachmentImage'
 				);
 				if (ext) ext.options.supportedFormats = caps.image.image_formats;
+				// Push the new list to any toolbars that were already
+				// open before this fetch resolved — without this, a
+				// user who selected an image during the in-flight
+				// capabilities request would see an indefinitely-
+				// disabled toolbar.
+				notifyAttachmentImageCapabilitiesChanged();
 			})
 			.catch(() => {
 				// Network blip / pre-login fetch failure → toolbar

--- a/web/src/lib/components/editor/attachment-chip.ts
+++ b/web/src/lib/components/editor/attachment-chip.ts
@@ -27,12 +27,17 @@
  */
 
 import { Node, mergeAttributes } from '@tiptap/core';
+import {
+	type AttachmentUrlBuilder,
+	type AttachmentVariant,
+	fetchAttachmentMetadata
+} from './attachment-metadata';
 
 const PAD_ATTACHMENT_PREFIX = 'pad-attachment:';
 
-/** Variants the download URL builder must support — mirrors AttachmentImage. */
-export type AttachmentVariant = 'thumb-sm' | 'thumb-md' | 'original';
-export type AttachmentUrlBuilder = (uuid: string, variant?: AttachmentVariant) => string;
+// Re-export the shared types so existing chip-importing call sites
+// keep working without having to change their imports.
+export type { AttachmentVariant, AttachmentUrlBuilder };
 
 export interface AttachmentChipOptions {
 	HTMLAttributes: Record<string, unknown>;
@@ -52,48 +57,6 @@ declare module '@tiptap/core' {
 			setAttachmentChip: (options: { uuid: string; filename: string }) => ReturnType;
 		};
 	}
-}
-
-/** Per-chip metadata fetched via HEAD. Null means "still loading or fetch failed". */
-interface AttachmentMetadata {
-	mime: string;
-	size: number;
-}
-
-/**
- * Module-level cache of metadata promises keyed by `${ws}:${uuid}`. A single
- * HEAD request fans out to every chip pointing at the same attachment, and
- * subsequent edits (paste, undo/redo) hit the cache without a network round
- * trip. Cache lives for the page lifetime — the underlying attachment row
- * is immutable, so there's no staleness concern.
- */
-const metadataCache = new Map<string, Promise<AttachmentMetadata | null>>();
-
-function fetchAttachmentMetadata(
-	workspaceSlug: string,
-	uuid: string,
-	getDownloadUrl: AttachmentUrlBuilder,
-): Promise<AttachmentMetadata | null> {
-	const key = `${workspaceSlug}:${uuid}`;
-	const cached = metadataCache.get(key);
-	if (cached) return cached;
-	const promise: Promise<AttachmentMetadata | null> = (async () => {
-		try {
-			const resp = await fetch(getDownloadUrl(uuid), {
-				method: 'HEAD',
-				credentials: 'same-origin',
-			});
-			if (!resp.ok) return null;
-			const ctype = resp.headers.get('content-type') ?? '';
-			const mime = ctype.split(';')[0].trim();
-			const len = parseInt(resp.headers.get('content-length') ?? '0', 10);
-			return { mime, size: Number.isFinite(len) && len >= 0 ? len : 0 };
-		} catch {
-			return null;
-		}
-	})();
-	metadataCache.set(key, promise);
-	return promise;
 }
 
 /**

--- a/web/src/lib/components/editor/attachment-image.ts
+++ b/web/src/lib/components/editor/attachment-image.ts
@@ -40,6 +40,40 @@ import type { AttachmentTransformRequest, AttachmentTransformResult } from '$lib
 export type { AttachmentVariant, AttachmentUrlBuilder };
 
 /**
+ * Live toolbars register a refresher here when constructed; the
+ * editor calls notifyAttachmentImageCapabilitiesChanged() after
+ * capabilities resolve, which in turn re-runs every refresher with
+ * the latest supportedFormats list. Without this, a user who
+ * selected an image before the capabilities fetch returned would
+ * see an indefinitely-disabled toolbar — the existing toolbar DOM
+ * would be stuck in "no processor" state until the NodeView was
+ * destroyed and recreated. Registry-based push fixes that.
+ *
+ * Module-level rather than per-extension storage so a shared editor
+ * surface (multiple Editor instances on one page) only has to fan
+ * out once. Registrations are torn down via the returned dispose
+ * function when the NodeView's destroy callback fires.
+ */
+const toolbarRefreshers = new Set<() => void>();
+
+function registerToolbarRefresher(fn: () => void): () => void {
+	toolbarRefreshers.add(fn);
+	return () => toolbarRefreshers.delete(fn);
+}
+
+/**
+ * Re-run every active toolbar's refresh hook. Called by Editor.svelte
+ * after `api.server.capabilities()` resolves and the new
+ * `supportedFormats` list has been pushed onto the AttachmentImage
+ * extension's options. Any toolbar that was sitting in the
+ * "all-disabled" pre-capabilities state snaps to its correct
+ * per-format gating.
+ */
+export function notifyAttachmentImageCapabilitiesChanged(): void {
+	for (const fn of toolbarRefreshers) fn();
+}
+
+/**
  * Result of a server-side image transform. The editor uses the new
  * row's id + dimensions to swap the node's attrs without a follow-up
  * GET — same shape as the upload response.
@@ -232,27 +266,39 @@ export const AttachmentImage = Node.create<AttachmentImageOptions>({
 			// cost. Subsequent selections reuse the same toolbar.
 			let toolbar: HTMLElement | null = null;
 			let toolbarMime: string | null = null;
+			let unregisterRefresher: (() => void) | null = null;
+			const refresh = () => {
+				if (toolbar) refreshToolbarState(toolbar, toolbarMime, opts.supportedFormats);
+			};
 			const ensureToolbar = (): HTMLElement => {
 				if (toolbar) return toolbar;
 				toolbar = buildRotateToolbar({
 					onRotate: (degrees) => runRotate(degrees),
 				});
 				wrapper.appendChild(toolbar);
+				// Subscribe to capability-change notifications. The
+				// editor pushes the supportedFormats list async after
+				// /server/capabilities resolves; without this hook a
+				// toolbar created before that arrived would be stuck
+				// in "no processor" state until the NodeView was
+				// destroyed. Disposed in destroy() so the registry
+				// doesn't accumulate leaked refs.
+				unregisterRefresher = registerToolbarRefresher(refresh);
 				// Probe the image's MIME so we can refine the toolbar's
-				// enabled state. Empty workspaceSlug = no probe (e.g.
-				// SSR / preview surfaces) — the toolbar stays in its
-				// initial enabled state, which falls back to the
-				// supportedFormats list alone.
+				// per-format gating. Empty workspaceSlug = no probe
+				// (e.g. SSR / preview surfaces) — the toolbar's state
+				// falls back to the supportedFormats list alone, with
+				// the MIME left null.
 				if (uuid && opts.workspaceSlug) {
 					fetchAttachmentMetadata(opts.workspaceSlug, uuid, opts.getDownloadUrl).then(
 						(meta) => {
 							if (!toolbar) return;
 							toolbarMime = meta?.mime ?? null;
-							refreshToolbarState(toolbar, toolbarMime, opts.supportedFormats);
+							refresh();
 						}
 					);
 				}
-				refreshToolbarState(toolbar, toolbarMime, opts.supportedFormats);
+				refresh();
 				return toolbar;
 			};
 
@@ -296,6 +342,16 @@ export const AttachmentImage = Node.create<AttachmentImageOptions>({
 				deselectNode() {
 					wrapper.classList.remove('attachment-image-selected');
 					if (toolbar) toolbar.classList.add('attachment-image-toolbar-hidden');
+				},
+				destroy() {
+					// Tear down the refresher subscription so the
+					// module-level registry doesn't pile up stale
+					// callbacks across editor lifecycles (e.g. SPA
+					// navigation between item views).
+					if (unregisterRefresher) {
+						unregisterRefresher();
+						unregisterRefresher = null;
+					}
 				},
 			};
 		};

--- a/web/src/lib/components/editor/attachment-image.ts
+++ b/web/src/lib/components/editor/attachment-image.ts
@@ -27,12 +27,27 @@
  */
 
 import { Node, mergeAttributes } from '@tiptap/core';
+import {
+	type AttachmentUrlBuilder,
+	type AttachmentVariant,
+	fetchAttachmentMetadata,
+	invalidateAttachmentMetadata,
+	mimeToFormat
+} from './attachment-metadata';
+import type { AttachmentTransformRequest, AttachmentTransformResult } from '$lib/types';
 
-/** Variants the download URL builder must support. Mirrors the API. */
-export type AttachmentVariant = 'thumb-sm' | 'thumb-md' | 'original';
+// Re-export the shared types so existing call sites keep working.
+export type { AttachmentVariant, AttachmentUrlBuilder };
 
-/** URL builder injected by Editor.svelte at configure time. */
-export type AttachmentUrlBuilder = (uuid: string, variant?: AttachmentVariant) => string;
+/**
+ * Result of a server-side image transform. The editor uses the new
+ * row's id + dimensions to swap the node's attrs without a follow-up
+ * GET — same shape as the upload response.
+ */
+export type AttachmentTransform = (
+	uuid: string,
+	payload: AttachmentTransformRequest
+) => Promise<AttachmentTransformResult>;
 
 export interface AttachmentImageOptions {
 	HTMLAttributes: Record<string, unknown>;
@@ -43,6 +58,34 @@ export interface AttachmentImageOptions {
 	 * `/api/v1/workspaces/{ws}/attachments/{id}` endpoint so images render.
 	 */
 	getDownloadUrl: AttachmentUrlBuilder;
+	/**
+	 * Workspace slug used for HEAD-probing the image's MIME (so the
+	 * rotate toolbar can gate buttons on the processor's supported
+	 * formats). Empty string disables the probe — the toolbar still
+	 * shows but skips per-format gating.
+	 */
+	workspaceSlug: string;
+	/**
+	 * Image formats the server-side processor supports. Drives the
+	 * rotate toolbar's enabled state per attachment: a button is
+	 * disabled (with tooltip) when the image's MIME isn't in this
+	 * list. Empty list ⇒ all transforms disabled (degraded build).
+	 */
+	supportedFormats: string[];
+	/**
+	 * Calls the server's /transform endpoint. Set by Editor.svelte to
+	 * `api.attachments.transform(workspaceSlug, uuid, payload)`.
+	 * Defaulting to a thrown error means a misconfigured editor
+	 * fails loudly when the user clicks rotate, rather than silently
+	 * swallowing the click.
+	 */
+	transform: AttachmentTransform;
+	/**
+	 * Optional error sink the editor can wire to its toast / logger.
+	 * Receives the user-facing message; the toolbar already handled
+	 * the technical error before calling this.
+	 */
+	onError?: (message: string) => void;
 }
 
 declare module '@tiptap/core' {
@@ -80,6 +123,12 @@ export const AttachmentImage = Node.create<AttachmentImageOptions>({
 		return {
 			HTMLAttributes: {},
 			getDownloadUrl: (uuid: string) => `${PAD_ATTACHMENT_PREFIX}${uuid}`,
+			workspaceSlug: '',
+			supportedFormats: [] as string[],
+			transform: async () => {
+				throw new Error('AttachmentImage: configure({ transform }) is required to use rotate/crop');
+			},
+			onError: undefined,
 		};
 	},
 
@@ -134,20 +183,31 @@ export const AttachmentImage = Node.create<AttachmentImageOptions>({
 	},
 
 	/**
-	 * NodeView attaches a click handler that opens the original-resolution
-	 * variant in a lightbox dialog. Tiptap calls renderHTML for clipboard
-	 * / `getHTML()` / serialization paths, so both must stay in sync — the
-	 * NodeView is only the live editor representation.
+	 * NodeView wraps the <img> in a positioned <span> so we can layer a
+	 * rotate toolbar on top of it when the node is selected. The
+	 * toolbar's per-button enabled state is recomputed when the
+	 * image's MIME resolves via the metadata cache — disabled state
+	 * carries an explanatory tooltip so the user knows why
+	 * rotation is unavailable on their build.
+	 *
+	 * Tiptap's renderHTML still emits a bare <img> for clipboard /
+	 * `getHTML()` / SSR paths; only the live editor view goes through
+	 * this NodeView.
 	 */
 	addNodeView() {
-		return ({ node }) => {
+		return ({ node, editor, getPos }) => {
+			const opts = this.options;
+			const wrapper = document.createElement('span');
+			wrapper.className = 'attachment-image-wrapper';
+			wrapper.setAttribute('contenteditable', 'false');
+
 			const img = document.createElement('img');
 			img.classList.add('attachment-image');
 			img.loading = 'lazy';
 			const uuid = (node.attrs.uuid as string | null) ?? '';
 			const alt = (node.attrs.alt as string | null) ?? '';
 			if (uuid) {
-				img.src = this.options.getDownloadUrl(uuid, 'thumb-md');
+				img.src = opts.getDownloadUrl(uuid, 'thumb-md');
 				img.setAttribute('data-attachment-id', uuid);
 			}
 			if (alt) img.alt = alt;
@@ -163,11 +223,81 @@ export const AttachmentImage = Node.create<AttachmentImageOptions>({
 				event.preventDefault();
 				event.stopPropagation();
 				if (!uuid) return;
-				const fullUrl = this.options.getDownloadUrl(uuid, 'original');
+				const fullUrl = opts.getDownloadUrl(uuid, 'original');
 				openImageLightbox(fullUrl, alt);
 			});
 
-			return { dom: img };
+			// Build the toolbar lazily — only when the node is first
+			// selected — so non-selected images don't carry the DOM
+			// cost. Subsequent selections reuse the same toolbar.
+			let toolbar: HTMLElement | null = null;
+			let toolbarMime: string | null = null;
+			const ensureToolbar = (): HTMLElement => {
+				if (toolbar) return toolbar;
+				toolbar = buildRotateToolbar({
+					onRotate: (degrees) => runRotate(degrees),
+				});
+				wrapper.appendChild(toolbar);
+				// Probe the image's MIME so we can refine the toolbar's
+				// enabled state. Empty workspaceSlug = no probe (e.g.
+				// SSR / preview surfaces) — the toolbar stays in its
+				// initial enabled state, which falls back to the
+				// supportedFormats list alone.
+				if (uuid && opts.workspaceSlug) {
+					fetchAttachmentMetadata(opts.workspaceSlug, uuid, opts.getDownloadUrl).then(
+						(meta) => {
+							if (!toolbar) return;
+							toolbarMime = meta?.mime ?? null;
+							refreshToolbarState(toolbar, toolbarMime, opts.supportedFormats);
+						}
+					);
+				}
+				refreshToolbarState(toolbar, toolbarMime, opts.supportedFormats);
+				return toolbar;
+			};
+
+			const runRotate = async (degrees: 90 | 180 | 270): Promise<void> => {
+				if (!uuid) return;
+				try {
+					const result = await opts.transform(uuid, { operation: 'rotate', degrees });
+					const pos = typeof getPos === 'function' ? getPos() : null;
+					if (pos == null) return;
+					// Replace the node's UUID at its current position.
+					// setNodeMarkup keeps the same node type and only
+					// rewrites attributes, which is what we want — the
+					// transform produced a NEW attachment row, but it's
+					// still an attachmentImage.
+					const tr = editor.state.tr.setNodeMarkup(pos, undefined, {
+						...node.attrs,
+						uuid: result.id,
+					});
+					editor.view.dispatch(tr);
+					// Drop the cached metadata for the OLD UUID — the
+					// editor may render the original elsewhere later
+					// and we want the next probe to refresh.
+					if (opts.workspaceSlug) {
+						invalidateAttachmentMetadata(opts.workspaceSlug, uuid);
+					}
+				} catch (err) {
+					const msg = err instanceof Error ? err.message : 'Rotation failed';
+					if (opts.onError) opts.onError(msg);
+					else if (typeof console !== 'undefined') console.error('[attachmentImage] rotate', err);
+				}
+			};
+
+			wrapper.appendChild(img);
+			return {
+				dom: wrapper,
+				selectNode() {
+					wrapper.classList.add('attachment-image-selected');
+					const tb = ensureToolbar();
+					tb.classList.remove('attachment-image-toolbar-hidden');
+				},
+				deselectNode() {
+					wrapper.classList.remove('attachment-image-selected');
+					if (toolbar) toolbar.classList.add('attachment-image-toolbar-hidden');
+				},
+			};
 		};
 	},
 
@@ -207,6 +337,103 @@ export const AttachmentImage = Node.create<AttachmentImageOptions>({
 		};
 	},
 });
+
+/**
+ * Build the rotate toolbar — three buttons (rotate left 90°,
+ * rotate 180°, rotate right 90°). Each button delegates to the
+ * supplied onRotate callback; the NodeView wires that into a
+ * setNodeMarkup transaction once the server returns the new UUID.
+ *
+ * The toolbar starts in its enabled state. refreshToolbarState
+ * disables individual buttons (with tooltip) once the image's
+ * MIME has been probed and compared to the processor's supported
+ * formats list.
+ */
+function buildRotateToolbar(opts: {
+	onRotate: (degrees: 90 | 180 | 270) => void;
+}): HTMLElement {
+	const toolbar = document.createElement('div');
+	toolbar.className = 'attachment-image-toolbar';
+	toolbar.setAttribute('contenteditable', 'false');
+	// Stop mousedown from racing the editor's click-to-select handler
+	// — without this, clicking a button steals selection focus from the
+	// node and the subsequent setNodeMarkup transaction lands on the
+	// wrong target. Same trick as the code-block "Copy" button in
+	// Editor.svelte.
+	toolbar.addEventListener('mousedown', (e) => e.preventDefault());
+
+	const button = (label: string, title: string, deg: 90 | 180 | 270): HTMLButtonElement => {
+		const btn = document.createElement('button');
+		btn.type = 'button';
+		btn.className = 'attachment-image-toolbar-btn';
+		btn.textContent = label;
+		btn.title = title;
+		btn.dataset.degrees = String(deg);
+		btn.addEventListener('click', (e) => {
+			e.preventDefault();
+			e.stopPropagation();
+			if (btn.disabled) return;
+			opts.onRotate(deg);
+		});
+		return btn;
+	};
+
+	toolbar.append(
+		button('↶', 'Rotate left 90°', 270),
+		button('↻', 'Rotate 180°', 180),
+		button('↷', 'Rotate right 90°', 90)
+	);
+	return toolbar;
+}
+
+/**
+ * Update each toolbar button's enabled state + tooltip based on the
+ * image's MIME and the processor's supported-formats list.
+ *
+ *   - Empty supportedFormats → all buttons disabled with a "no image
+ *     processor on this build" message. Covers the libvips-tagged
+ *     binary that hasn't shipped Phase 2 yet, plus self-hosters who
+ *     opted out of image processing.
+ *   - MIME unknown (still loading the HEAD probe, or the probe
+ *     failed) → keep buttons enabled. Server returns 415 if the
+ *     format actually isn't supported, and the editor's onError
+ *     surfaces the message inline at click time.
+ *   - MIME known and unsupported → disable with format-specific
+ *     tooltip ("Image editing for image/webp requires libvips").
+ *   - MIME known and supported → enabled with the original tooltip.
+ */
+function refreshToolbarState(
+	toolbar: HTMLElement,
+	mime: string | null,
+	supportedFormats: string[]
+): void {
+	const btns = toolbar.querySelectorAll<HTMLButtonElement>('.attachment-image-toolbar-btn');
+	const noProcessor = supportedFormats.length === 0;
+	const format = mime ? mimeToFormat(mime) : null;
+	const knownUnsupported = !!format && !supportedFormats.includes(format);
+
+	btns.forEach((btn) => {
+		// Re-derive the original tooltip from the dataset. We keep the
+		// canonical title in the data-original-title attribute so we
+		// can restore it after the disabled state clears.
+		const originalTitle =
+			btn.dataset.originalTitle ?? btn.title ?? '';
+		btn.dataset.originalTitle = originalTitle;
+
+		if (noProcessor) {
+			btn.disabled = true;
+			btn.title = 'Image editing not available in this build (libvips backend not shipped yet)';
+			return;
+		}
+		if (knownUnsupported) {
+			btn.disabled = true;
+			btn.title = `Image editing for ${mime} requires libvips (this build supports ${supportedFormats.join(', ')})`;
+			return;
+		}
+		btn.disabled = false;
+		btn.title = originalTitle;
+	});
+}
 
 /**
  * Open a centered <dialog> showing the full-resolution attachment.

--- a/web/src/lib/components/editor/attachment-metadata.ts
+++ b/web/src/lib/components/editor/attachment-metadata.ts
@@ -1,0 +1,107 @@
+/**
+ * Shared per-attachment metadata fetcher used by the editor's
+ * attachment-* extensions to enrich what they render. The MIME and
+ * size aren't carried in the markdown reference (just the UUID), so
+ * we lean on the existing GET handler's HEAD response — Content-Type
+ * and Content-Length give us everything we need without a new API.
+ *
+ * The promise cache is keyed by `${ws}:${uuid}`, so:
+ *   - Repeated chips / images for the same attachment pay one HEAD
+ *     between them.
+ *   - Undo / redo / paste operations that reinstantiate the same
+ *     NodeView reuse the in-flight or settled fetch.
+ *   - The cache lives for the page lifetime — attachment metadata is
+ *     immutable (the row is content-addressed; transforms produce
+ *     NEW rows), so there's no staleness concern.
+ *
+ * Skipped silently when no workspace context is available (e.g.
+ * headless rendering / SSR) — callers see `null` and degrade UI
+ * accordingly without raising errors.
+ */
+
+/** Variants the download URL builder must support. Mirrors AttachmentImage. */
+export type AttachmentVariant = 'thumb-sm' | 'thumb-md' | 'original';
+
+/** URL builder injected by Editor.svelte at configure time. */
+export type AttachmentUrlBuilder = (uuid: string, variant?: AttachmentVariant) => string;
+
+export interface AttachmentMetadata {
+	mime: string;
+	size: number;
+}
+
+const cache = new Map<string, Promise<AttachmentMetadata | null>>();
+
+/**
+ * Fetch (or read from cache) the MIME + size for an attachment. The
+ * server registers HEAD alongside GET (TASK-877); chi doesn't auto-
+ * route HEAD on GET handlers, so this must use HEAD — a GET would
+ * pull the entire blob across the wire.
+ */
+export function fetchAttachmentMetadata(
+	workspaceSlug: string,
+	uuid: string,
+	getDownloadUrl: AttachmentUrlBuilder
+): Promise<AttachmentMetadata | null> {
+	const key = `${workspaceSlug}:${uuid}`;
+	const existing = cache.get(key);
+	if (existing) return existing;
+	const promise: Promise<AttachmentMetadata | null> = (async () => {
+		try {
+			const resp = await fetch(getDownloadUrl(uuid), {
+				method: 'HEAD',
+				credentials: 'same-origin'
+			});
+			if (!resp.ok) return null;
+			const ctype = resp.headers.get('content-type') ?? '';
+			const mime = ctype.split(';')[0].trim();
+			const len = parseInt(resp.headers.get('content-length') ?? '0', 10);
+			return { mime, size: Number.isFinite(len) && len >= 0 ? len : 0 };
+		} catch {
+			return null;
+		}
+	})();
+	cache.set(key, promise);
+	return promise;
+}
+
+/**
+ * Drop a single entry from the cache. Used after a transform
+ * succeeds — the new attachment's UUID is fresh so it has no entry
+ * yet, but the editor may have re-rendered the original into another
+ * spot before the transform; clearing keeps stale dimensions /
+ * indicators from leaking forward.
+ */
+export function invalidateAttachmentMetadata(workspaceSlug: string, uuid: string): void {
+	cache.delete(`${workspaceSlug}:${uuid}`);
+}
+
+/**
+ * Map a MIME type to its canonical short format name as the server's
+ * Capabilities reports it ("png" / "jpeg" / "gif" / "bmp" / "tiff" /
+ * "webp" / "avif" / "heic"). Returns `null` for non-image MIMEs and
+ * unrecognized image MIMEs — callers treat null the same as "format
+ * not supported by current processor", which is the safe fallback.
+ */
+export function mimeToFormat(mime: string): string | null {
+	const m = mime.toLowerCase().trim();
+	if (!m.startsWith('image/')) return null;
+	const sub = m.slice('image/'.length);
+	switch (sub) {
+		case 'png':
+		case 'gif':
+		case 'bmp':
+		case 'tiff':
+		case 'webp':
+		case 'avif':
+		case 'heic':
+		case 'heif':
+			return sub === 'heif' ? 'heic' : sub;
+		case 'jpeg':
+		case 'jpg':
+		case 'pjpeg':
+			return 'jpeg';
+		default:
+			return null;
+	}
+}

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -785,6 +785,40 @@ export interface AttachmentUploadResult {
 	render_mode: 'inline' | 'chip' | 'download';
 }
 
+/**
+ * Request body for POST /api/v1/workspaces/{slug}/attachments/{id}/transform
+ * (TASK-879/880). Discriminated by `operation`. Per-op params live in
+ * their own fields rather than a generic args bag — keeps the wire
+ * format tight and lets the type checker prove the request is well-formed.
+ */
+export type AttachmentTransformRequest =
+	| { operation: 'rotate'; degrees: 90 | 180 | 270 }
+	| { operation: 'crop'; rect: { x: number; y: number; w: number; h: number } };
+
+/** Server response shape from /transform. Subset of AttachmentUploadResult. */
+export interface AttachmentTransformResult {
+	id: string;
+	url: string;
+	mime: string;
+	size: number;
+	width?: number | null;
+	height?: number | null;
+	filename: string;
+}
+
+/**
+ * Server capability profile from GET /api/v1/server/capabilities.
+ * The editor reads this once at mount and gates rotate/crop UI on
+ * the image processor's reach.
+ */
+export interface ServerCapabilities {
+	image: {
+		image_formats: string[];
+		can_transcode: boolean;
+		max_pixels: number;
+	};
+}
+
 // ─── Helper functions ────────────────────────────────────────────────────────
 
 export function parseFields(item: Item): Record<string, any> {


### PR DESCRIPTION
## Summary

Adds the `POST /transform` endpoint and the editor's rotate toolbar on top of TASK-878's `Processor` abstraction. Rotation produces a NEW content-addressed attachment row; the editor swaps the `attachmentImage` node's UUID via `setNodeMarkup` and the original ages into orphan GC.

### Server (`internal/server/handlers_attachments_transform.go`)
- `POST /api/v1/workspaces/{slug}/attachments/{id}/transform` with body `{operation, ...params}`
- **rotate** wired (degrees: 90 / 180 / 270 only — pixel-exact reorderings)
- **crop** branch parsed + validated; transform path will be wired in TASK-880 (defining the wire format here keeps both PRs aligned)
- Auth: editor+ on workspace. Cross-workspace + deleted-parent → 404 (not 403). Unsupported MIME → 415, oversized → 413, bad params → 400, missing processor → 503.
- Output format: PNG-stays-PNG / else-JPEG q=85 (same policy as thumbnails so derived blobs deduplicate cleanly)
- 10 tests covering: rotate 90 dim swap, rotate 180 dim preserve, bad degrees, unknown op, non-existent attachment, cross-workspace 404, no processor 503, derived hash freshness + parent inheritance, served-bytes decode, deleted-parent 404

### Web client
- `api.attachments.transform(slug, id, payload)` with discriminated `AttachmentTransformRequest`
- `api.server.capabilities()` reads the public capability profile from TASK-878

### Editor
- **`attachment-metadata.ts`** (new): shared HEAD-probe cache extracted from `attachment-chip.ts`. `AttachmentImage`'s toolbar now reuses it (zero extra network cost when chip + image both reference the same attachment). Adds `mimeToFormat()` — maps MIME to the short format name `Capabilities` reports.
- **`attachment-chip.ts`**: swapped to use the shared cache. Behavior unchanged.
- **`attachment-image.ts`**: NodeView wraps `<img>` in a positioned `<span>`, lazy-builds a 3-button toolbar (↶ left 90° · ↻ 180° · ↷ right 90°). `selectNode` shows it, `deselectNode` hides it. Click → `options.transform` → `setNodeMarkup` with the returned UUID at `getPos()`. Old UUID's metadata cache entry invalidated.
- **Per-format gating** (`refreshToolbarState`):
  - Empty `supportedFormats` (degraded build) → all disabled, "Image editing not available" tooltip
  - MIME probed + not in list → disabled, "Image editing for image/webp requires libvips" tooltip
  - Otherwise → enabled, action tooltip
- **Editor.svelte**: configures `AttachmentImage` with workspace slug, `supportedFormats` (initially empty, populated async after `api.server.capabilities()` resolves), and the transform callback. Errors surface via `console.error` + `window.alert` (same fallback as upload plugin).
- **`app.css`**: wrapper + toolbar styles. Pinned top-right via absolute positioning; selected-state ring on the image; disabled buttons at 40% opacity.

## Test plan

- [x] `go build ./... && go vet ./... && go test ./...` — clean
- [x] `cd web && npm run build` — clean
- [x] `cd web && npm run check` — 0 errors (6 pre-existing warnings)
- [ ] Manual after merge:
  - [ ] Click a PNG/JPEG image → toolbar appears top-right
  - [ ] Click rotate-right → image rotates 90° clockwise; markdown round-trip still works (UUID is updated)
  - [ ] Multiple rapid rotations all succeed (last one wins; intermediate originals end up orphaned for GC)
  - [ ] On a build with no processor (libvips stub) → buttons disabled with degraded tooltip
  - [ ] On a WebP upload → buttons disabled with format-specific tooltip

## Context

Implements `TASK-879` under `PLAN-866`. Builds on TASK-878 (`Processor` interface + `Capabilities`). Unblocks `TASK-880` — the crop branch's wire format is already defined and the editor toolbar pattern composes cleanly.