### PR TITLE
feat(attachments): editor image crop with aspect presets (TASK-880)

### DIFF
--- a/internal/server/handlers_attachments_transform_test.go
+++ b/internal/server/handlers_attachments_transform_test.go
@@ -243,6 +243,121 @@ func TestTransform_ServedDownloadDecodesAtNewDimensions(t *testing.T) {
 	}
 }
 
+func TestTransform_CropProducesNewBlobAtRectDimensions(t *testing.T) {
+	srv, slug := testServerWithAttachments(t)
+	id, _ := uploadIntegrationPNG(t, srv, slug, 800, 400)
+	srv.Stop()
+
+	rect := &struct {
+		X int `json:"x"`
+		Y int `json:"y"`
+		W int `json:"w"`
+		H int `json:"h"`
+	}{X: 100, Y: 50, W: 300, H: 200}
+
+	rr := doTransform(srv, slug, id, transformRequestBody{Operation: "crop", Rect: rect})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("crop status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		ID     string `json:"id"`
+		Width  *int   `json:"width"`
+		Height *int   `json:"height"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Width == nil || resp.Height == nil {
+		t.Fatal("response missing dimensions")
+	}
+	if *resp.Width != rect.W || *resp.Height != rect.H {
+		t.Errorf("crop dims = %dx%d, want %dx%d", *resp.Width, *resp.Height, rect.W, rect.H)
+	}
+	// Decode the served bytes to double-check the dimensions
+	// — guards against an off-by-one in the encode pipeline.
+	getReq := httptest.NewRequest("GET", "/api/v1/workspaces/"+slug+"/attachments/"+resp.ID, nil)
+	getReq.RemoteAddr = "127.0.0.1:1234"
+	getRR := httptest.NewRecorder()
+	srv.ServeHTTP(getRR, getReq)
+	if getRR.Code != http.StatusOK {
+		t.Fatalf("get cropped status = %d", getRR.Code)
+	}
+	out, _, err := image.Decode(bytes.NewReader(getRR.Body.Bytes()))
+	if err != nil {
+		t.Fatalf("decode cropped bytes: %v", err)
+	}
+	if out.Bounds().Dx() != rect.W || out.Bounds().Dy() != rect.H {
+		t.Errorf("served crop dims = %v, want %dx%d", out.Bounds(), rect.W, rect.H)
+	}
+}
+
+func TestTransform_CropClipsToImageBounds(t *testing.T) {
+	// Rect that extends past the image must clip rather than 400.
+	// The processor's Crop intersects with image bounds and the
+	// editor relies on this — its rounding can yield rect+1px past
+	// the natural width/height in rare fractional-scale cases.
+	srv, slug := testServerWithAttachments(t)
+	id, _ := uploadIntegrationPNG(t, srv, slug, 100, 100)
+	srv.Stop()
+
+	rect := &struct {
+		X int `json:"x"`
+		Y int `json:"y"`
+		W int `json:"w"`
+		H int `json:"h"`
+	}{X: 50, Y: 50, W: 200, H: 200}
+
+	rr := doTransform(srv, slug, id, transformRequestBody{Operation: "crop", Rect: rect})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+	var resp struct{ Width, Height *int }
+	_ = json.Unmarshal(rr.Body.Bytes(), &resp)
+	// Clipped to (50,50)..(100,100) → 50×50 result.
+	if resp.Width == nil || resp.Height == nil || *resp.Width != 50 || *resp.Height != 50 {
+		t.Errorf("clipped dims = %v×%v, want 50×50", resp.Width, resp.Height)
+	}
+}
+
+func TestTransform_CropRejectsBadRect(t *testing.T) {
+	srv, slug := testServerWithAttachments(t)
+	id, _ := uploadIntegrationPNG(t, srv, slug, 100, 100)
+	srv.Stop()
+
+	cases := []struct {
+		name string
+		body transformRequestBody
+	}{
+		{"missing rect", transformRequestBody{Operation: "crop"}},
+		{"zero width", transformRequestBody{Operation: "crop", Rect: &struct {
+			X int `json:"x"`
+			Y int `json:"y"`
+			W int `json:"w"`
+			H int `json:"h"`
+		}{0, 0, 0, 100}}},
+		{"negative xy", transformRequestBody{Operation: "crop", Rect: &struct {
+			X int `json:"x"`
+			Y int `json:"y"`
+			W int `json:"w"`
+			H int `json:"h"`
+		}{-10, -10, 50, 50}}},
+		{"rect entirely outside", transformRequestBody{Operation: "crop", Rect: &struct {
+			X int `json:"x"`
+			Y int `json:"y"`
+			W int `json:"w"`
+			H int `json:"h"`
+		}{500, 500, 100, 100}}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			rr := doTransform(srv, slug, id, c.body)
+			if rr.Code != http.StatusBadRequest {
+				t.Errorf("status = %d, want 400", rr.Code)
+			}
+		})
+	}
+}
+
 func TestTransform_DerivedRowInheritsUploadedByFromParent(t *testing.T) {
 	// A user who rotates someone else's upload should NOT take
 	// ownership of the resulting blob. The transform pipeline

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -383,6 +383,161 @@ input:focus, textarea:focus {
 	max-width: 30ch;
 }
 
+/* Crop modal (TASK-880). Appended to document.body so styles must
+   be global. Uses the native <dialog> element with a flex layout
+   so the image fills available space while header/footer stay fixed. */
+dialog.attachment-crop-modal {
+	border: none;
+	background: transparent;
+	padding: 0;
+	max-width: 100vw;
+	max-height: 100vh;
+	color: #fff;
+	overflow: visible;
+}
+dialog.attachment-crop-modal::backdrop {
+	background: rgba(0, 0, 0, 0.85);
+	backdrop-filter: blur(2px);
+}
+.attachment-crop-modal-shell {
+	display: flex;
+	flex-direction: column;
+	width: min(95vw, 1200px);
+	height: min(92vh, 900px);
+	background: var(--bg-secondary);
+	color: var(--text-primary);
+	border-radius: var(--radius);
+	overflow: hidden;
+	box-shadow: 0 12px 40px rgba(0, 0, 0, 0.55);
+}
+.attachment-crop-modal-header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: var(--space-3);
+	padding: var(--space-3) var(--space-4);
+	border-bottom: 1px solid var(--border);
+	background: var(--bg-secondary);
+}
+.attachment-crop-modal-title {
+	font-weight: 600;
+	font-size: 0.95em;
+}
+.attachment-crop-modal-aspects {
+	display: inline-flex;
+	gap: 4px;
+	background: var(--bg-tertiary);
+	padding: 2px;
+	border-radius: var(--radius);
+}
+.attachment-crop-modal-aspect-btn {
+	padding: 4px 12px;
+	border: none;
+	background: transparent;
+	color: var(--text-secondary);
+	border-radius: 4px;
+	font-size: 0.85em;
+	cursor: pointer;
+	font-family: inherit;
+	transition: background 0.15s, color 0.15s;
+}
+.attachment-crop-modal-aspect-btn:hover {
+	background: var(--bg-hover);
+	color: var(--text-primary);
+}
+.attachment-crop-modal-aspect-active,
+.attachment-crop-modal-aspect-active:hover {
+	background: var(--accent-blue);
+	color: #fff;
+}
+.attachment-crop-modal-stage {
+	flex: 1;
+	min-height: 0;
+	position: relative;
+	overflow: hidden;
+	background: rgba(0, 0, 0, 0.4);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	-webkit-user-select: none;
+	user-select: none;
+}
+.attachment-crop-modal-img {
+	max-width: 100%;
+	max-height: 100%;
+	display: block;
+	-webkit-user-drag: none;
+	pointer-events: none;
+}
+.attachment-crop-modal-rect {
+	position: absolute;
+	box-sizing: border-box;
+	border: 1px solid #fff;
+	box-shadow: 0 0 0 9999px rgba(0, 0, 0, 0.45);
+	cursor: move;
+	touch-action: none;
+}
+.attachment-crop-modal-handle {
+	position: absolute;
+	width: 12px;
+	height: 12px;
+	background: var(--accent-blue);
+	border: 2px solid #fff;
+	border-radius: 50%;
+	touch-action: none;
+}
+.attachment-crop-modal-handle-nw {
+	top: -7px;
+	left: -7px;
+	cursor: nwse-resize;
+}
+.attachment-crop-modal-handle-ne {
+	top: -7px;
+	right: -7px;
+	cursor: nesw-resize;
+}
+.attachment-crop-modal-handle-sw {
+	bottom: -7px;
+	left: -7px;
+	cursor: nesw-resize;
+}
+.attachment-crop-modal-handle-se {
+	bottom: -7px;
+	right: -7px;
+	cursor: nwse-resize;
+}
+.attachment-crop-modal-footer {
+	display: flex;
+	justify-content: flex-end;
+	gap: var(--space-2);
+	padding: var(--space-3) var(--space-4);
+	border-top: 1px solid var(--border);
+	background: var(--bg-secondary);
+}
+.attachment-crop-modal-cancel,
+.attachment-crop-modal-apply {
+	padding: 6px 16px;
+	border: 1px solid var(--border);
+	background: var(--bg-tertiary);
+	color: var(--text-primary);
+	border-radius: var(--radius);
+	font-family: inherit;
+	font-size: 0.92em;
+	cursor: pointer;
+	transition: background 0.15s, border-color 0.15s;
+}
+.attachment-crop-modal-cancel:hover {
+	background: var(--bg-hover);
+}
+.attachment-crop-modal-primary {
+	background: var(--accent-blue);
+	color: #fff;
+	border-color: var(--accent-blue);
+}
+.attachment-crop-modal-primary:hover {
+	filter: brightness(1.1);
+}
+
 /* Lightbox dialog — appended to document.body when an attachment image
    is clicked, so styles must be global rather than scoped to Editor.svelte.
    Uses the native <dialog> element; the ::backdrop pseudo handles the

--- a/web/src/lib/components/editor/attachment-crop-modal.ts
+++ b/web/src/lib/components/editor/attachment-crop-modal.ts
@@ -1,0 +1,401 @@
+/**
+ * Crop modal for AttachmentImage (TASK-880).
+ *
+ * Opens a centered <dialog> showing the full-resolution attachment
+ * with an overlaid crop rectangle the user can drag (to move) or
+ * resize via four corner handles. Aspect-preset toolbar (Free / 1:1 /
+ * 4:3 / 16:9) snaps the rectangle to the chosen ratio while
+ * preserving the rectangle's center.
+ *
+ * Returns a Promise that resolves to the crop rectangle in
+ * ORIGINAL-IMAGE pixel coordinates (origin top-left, integer pixels)
+ * when the user clicks Apply, or `null` when they Cancel / dismiss.
+ *
+ * The modal is pure DOM — no Svelte component, no extra deps. We
+ * deliberately avoid `svelte-easy-crop` and friends to keep the
+ * editor's bundle slim and the Svelte 5 migration story simple.
+ *
+ * Coordinate spaces:
+ *   - "preview-pixel" coords are relative to the displayed <img>
+ *     element's bounding box, which is fit-to-modal scaled.
+ *   - "natural-pixel" coords are the image's source dimensions
+ *     (image.naturalWidth × naturalHeight).
+ *   The translation factor is naturalDim / displayedDim, applied
+ *   per-axis so non-uniform scale (rare with object-fit: contain
+ *   but possible if the modal is portrait and the image landscape)
+ *   works correctly.
+ */
+
+export interface CropResult {
+	/** x in original-image pixels, origin top-left. */
+	x: number;
+	y: number;
+	w: number;
+	h: number;
+}
+
+export interface OpenCropModalOptions {
+	/** URL of the full-resolution image to crop. */
+	imageUrl: string;
+	/** Optional alt text for the modal's <img>. */
+	alt?: string;
+}
+
+/** Aspect ratio choices the toolbar exposes. `null` = free. */
+type AspectChoice = number | null;
+
+const ASPECT_PRESETS: { label: string; value: AspectChoice }[] = [
+	{ label: 'Free', value: null },
+	{ label: '1:1', value: 1 },
+	{ label: '4:3', value: 4 / 3 },
+	{ label: '16:9', value: 16 / 9 },
+];
+
+/**
+ * Display the crop modal and return a promise that resolves to the
+ * cropped rectangle (or null on cancel). The Promise never rejects —
+ * exceptional states (image fails to load, user closes browser tab,
+ * etc.) all resolve to null so callers can treat cancel + error
+ * the same way.
+ */
+export function openCropModal(opts: OpenCropModalOptions): Promise<CropResult | null> {
+	if (typeof document === 'undefined') return Promise.resolve(null);
+
+	return new Promise((resolve) => {
+		const dialog = document.createElement('dialog');
+		dialog.className = 'attachment-crop-modal';
+
+		// Layout: header with aspect presets, image stage with crop
+		// overlay, footer with Cancel / Apply buttons. All wrapped
+		// in a single .attachment-crop-modal-shell container so the
+		// dialog itself can stay minimal-styled.
+		const shell = document.createElement('div');
+		shell.className = 'attachment-crop-modal-shell';
+
+		const header = document.createElement('div');
+		header.className = 'attachment-crop-modal-header';
+		const title = document.createElement('span');
+		title.className = 'attachment-crop-modal-title';
+		title.textContent = 'Crop image';
+		header.appendChild(title);
+
+		const aspectBar = document.createElement('div');
+		aspectBar.className = 'attachment-crop-modal-aspects';
+		header.appendChild(aspectBar);
+
+		const stage = document.createElement('div');
+		stage.className = 'attachment-crop-modal-stage';
+
+		const img = document.createElement('img');
+		img.className = 'attachment-crop-modal-img';
+		img.alt = opts.alt ?? '';
+		img.src = opts.imageUrl;
+		// Prevent the contenteditable / drag interactions from racing
+		// the crop rectangle's pointer events.
+		img.draggable = false;
+
+		const crop = document.createElement('div');
+		crop.className = 'attachment-crop-modal-rect';
+		// Build four corner handles (nw, ne, sw, se). Mid-edge handles
+		// are deliberately omitted to keep the interaction surface
+		// minimal — corners cover both width and height changes, and
+		// the rectangle body itself is a "move" handle. Aspect locks
+		// constrain corner drags so width-only / height-only resizes
+		// fall out for free.
+		const handles: Record<string, HTMLElement> = {};
+		for (const corner of ['nw', 'ne', 'sw', 'se'] as const) {
+			const h = document.createElement('div');
+			h.className = `attachment-crop-modal-handle attachment-crop-modal-handle-${corner}`;
+			h.dataset.corner = corner;
+			crop.appendChild(h);
+			handles[corner] = h;
+		}
+
+		stage.append(img, crop);
+
+		const footer = document.createElement('div');
+		footer.className = 'attachment-crop-modal-footer';
+		const cancelBtn = button('Cancel', 'attachment-crop-modal-cancel');
+		const applyBtn = button('Apply', 'attachment-crop-modal-apply attachment-crop-modal-primary');
+		footer.append(cancelBtn, applyBtn);
+
+		shell.append(header, stage, footer);
+		dialog.appendChild(shell);
+		document.body.appendChild(dialog);
+
+		// State. `rect` is in preview-pixel coords relative to the
+		// <img> element. We don't render the crop visual until the
+		// image loads so dimensions are known.
+		let rect: CropResult = { x: 0, y: 0, w: 0, h: 0 };
+		let aspect: AspectChoice = null;
+
+		// Build aspect-preset buttons. Active state mirrors `aspect`.
+		const aspectButtons: HTMLButtonElement[] = [];
+		for (const preset of ASPECT_PRESETS) {
+			const btn = document.createElement('button');
+			btn.type = 'button';
+			btn.className = 'attachment-crop-modal-aspect-btn';
+			btn.textContent = preset.label;
+			btn.dataset.value = preset.value === null ? 'free' : String(preset.value);
+			btn.addEventListener('click', (e) => {
+				e.preventDefault();
+				aspect = preset.value;
+				rect = applyAspectToRect(rect, aspect, getNaturalBoundsPx());
+				renderRect();
+				updateAspectActive();
+			});
+			aspectBar.appendChild(btn);
+			aspectButtons.push(btn);
+		}
+		const updateAspectActive = () => {
+			for (const btn of aspectButtons) {
+				const v = btn.dataset.value === 'free' ? null : Number(btn.dataset.value);
+				btn.classList.toggle('attachment-crop-modal-aspect-active', v === aspect);
+			}
+		};
+
+		// Initialize the rect once the image has loaded — we need
+		// imgEl.offsetWidth / Height for sensible defaults.
+		const onImageReady = () => {
+			const bounds = getNaturalBoundsPx();
+			// Default: 80% of the image, centered. Generous starting
+			// point that the user can tighten without first having to
+			// click into the image to scale up.
+			const w = Math.round(bounds.w * 0.8);
+			const h = Math.round(bounds.h * 0.8);
+			rect = { x: Math.round((bounds.w - w) / 2), y: Math.round((bounds.h - h) / 2), w, h };
+			renderRect();
+			updateAspectActive();
+		};
+		if (img.complete && img.naturalWidth > 0) {
+			// Cached load — onload won't fire; init synchronously.
+			queueMicrotask(onImageReady);
+		} else {
+			img.addEventListener('load', onImageReady, { once: true });
+			img.addEventListener(
+				'error',
+				() => {
+					close(null);
+				},
+				{ once: true }
+			);
+		}
+
+		// Re-clamp the crop rect on viewport resize so it doesn't slip
+		// outside the (now smaller) preview bounds. Cheap to re-layout
+		// since rect is preview-pixel-based.
+		const onResize = () => {
+			const bounds = getNaturalBoundsPx();
+			rect = clampRect(rect, bounds);
+			renderRect();
+		};
+		window.addEventListener('resize', onResize);
+
+		// Drag interactions. We track three modes — move (rectangle
+		// body), resize-corner, none — via `dragMode`. Pointer events
+		// give us touch + mouse for free without wiring them
+		// separately.
+		type DragMode = { kind: 'none' } | { kind: 'move'; sx: number; sy: number; rx: number; ry: number } | { kind: 'resize'; corner: 'nw' | 'ne' | 'sw' | 'se'; sx: number; sy: number; sr: CropResult };
+		let drag: DragMode = { kind: 'none' };
+
+		const onPointerDown = (event: PointerEvent) => {
+			const target = event.target as HTMLElement;
+			if (handles[target.dataset.corner ?? '']) {
+				drag = {
+					kind: 'resize',
+					corner: target.dataset.corner as 'nw' | 'ne' | 'sw' | 'se',
+					sx: event.clientX,
+					sy: event.clientY,
+					sr: { ...rect },
+				};
+				event.preventDefault();
+				event.stopPropagation();
+				target.setPointerCapture?.(event.pointerId);
+				return;
+			}
+			if (target === crop || crop.contains(target)) {
+				drag = {
+					kind: 'move',
+					sx: event.clientX,
+					sy: event.clientY,
+					rx: rect.x,
+					ry: rect.y,
+				};
+				event.preventDefault();
+				event.stopPropagation();
+				crop.setPointerCapture?.(event.pointerId);
+			}
+		};
+		const onPointerMove = (event: PointerEvent) => {
+			if (drag.kind === 'none') return;
+			const bounds = getNaturalBoundsPx();
+			if (drag.kind === 'move') {
+				const dx = event.clientX - drag.sx;
+				const dy = event.clientY - drag.sy;
+				rect.x = drag.rx + dx;
+				rect.y = drag.ry + dy;
+				rect = clampRect(rect, bounds);
+			} else {
+				const dx = event.clientX - drag.sx;
+				const dy = event.clientY - drag.sy;
+				const c = drag.corner;
+				let nx = drag.sr.x;
+				let ny = drag.sr.y;
+				let nw = drag.sr.w;
+				let nh = drag.sr.h;
+				// Per-corner direction map: which edges move with
+				// the cursor. NW: left + top, NE: right + top,
+				// SW: left + bottom, SE: right + bottom.
+				if (c === 'nw' || c === 'sw') {
+					nx = drag.sr.x + dx;
+					nw = drag.sr.w - dx;
+				} else {
+					nw = drag.sr.w + dx;
+				}
+				if (c === 'nw' || c === 'ne') {
+					ny = drag.sr.y + dy;
+					nh = drag.sr.h - dy;
+				} else {
+					nh = drag.sr.h + dy;
+				}
+				// Aspect lock: clamp the secondary axis to match.
+				// Drive from whichever delta is bigger so cursor
+				// movement always wins on the dominant axis.
+				if (aspect != null && aspect > 0) {
+					const wDriven = Math.abs(dx) >= Math.abs(dy);
+					if (wDriven) {
+						const targetH = Math.round(nw / aspect);
+						if (c === 'nw' || c === 'ne') ny = drag.sr.y + (drag.sr.h - targetH);
+						nh = targetH;
+					} else {
+						const targetW = Math.round(nh * aspect);
+						if (c === 'nw' || c === 'sw') nx = drag.sr.x + (drag.sr.w - targetW);
+						nw = targetW;
+					}
+				}
+				rect = clampRect({ x: Math.round(nx), y: Math.round(ny), w: Math.round(nw), h: Math.round(nh) }, bounds);
+			}
+			renderRect();
+		};
+		const onPointerUp = (event: PointerEvent) => {
+			if (drag.kind !== 'none') {
+				event.preventDefault();
+				event.stopPropagation();
+			}
+			drag = { kind: 'none' };
+		};
+
+		stage.addEventListener('pointerdown', onPointerDown);
+		document.addEventListener('pointermove', onPointerMove);
+		document.addEventListener('pointerup', onPointerUp);
+
+		// Pixel coordinates expressed against the displayed <img>
+		// bounds. We use offset{Width,Height} (rounded ints) rather
+		// than getBoundingClientRect (subpixel) so the rect stays in
+		// integer space — simplifies clamping and avoids cumulative
+		// drift across many drags.
+		function getNaturalBoundsPx(): { w: number; h: number } {
+			return { w: img.offsetWidth, h: img.offsetHeight };
+		}
+
+		function renderRect(): void {
+			const offsetX = img.offsetLeft;
+			const offsetY = img.offsetTop;
+			crop.style.left = `${offsetX + rect.x}px`;
+			crop.style.top = `${offsetY + rect.y}px`;
+			crop.style.width = `${rect.w}px`;
+			crop.style.height = `${rect.h}px`;
+		}
+
+		const close = (result: CropResult | null) => {
+			window.removeEventListener('resize', onResize);
+			document.removeEventListener('pointermove', onPointerMove);
+			document.removeEventListener('pointerup', onPointerUp);
+			if (dialog.open) dialog.close();
+			dialog.remove();
+			resolve(result);
+		};
+
+		cancelBtn.addEventListener('click', (e) => {
+			e.preventDefault();
+			close(null);
+		});
+		applyBtn.addEventListener('click', (e) => {
+			e.preventDefault();
+			if (img.naturalWidth <= 0 || img.naturalHeight <= 0) {
+				close(null);
+				return;
+			}
+			// Translate preview-pixel rect → natural-pixel rect.
+			const sx = img.naturalWidth / img.offsetWidth;
+			const sy = img.naturalHeight / img.offsetHeight;
+			const result: CropResult = {
+				x: Math.max(0, Math.round(rect.x * sx)),
+				y: Math.max(0, Math.round(rect.y * sy)),
+				w: Math.max(1, Math.round(rect.w * sx)),
+				h: Math.max(1, Math.round(rect.h * sy)),
+			};
+			// Clamp to natural bounds so a fractional-rounding
+			// overrun doesn't push the rect off-image.
+			if (result.x + result.w > img.naturalWidth) result.w = img.naturalWidth - result.x;
+			if (result.y + result.h > img.naturalHeight) result.h = img.naturalHeight - result.y;
+			close(result);
+		});
+
+		// Esc / backdrop click → cancel.
+		dialog.addEventListener('cancel', (e) => {
+			e.preventDefault();
+			close(null);
+		});
+		dialog.addEventListener('click', (event) => {
+			if (event.target === dialog) close(null);
+		});
+
+		dialog.showModal();
+	});
+}
+
+/** Build a button with consistent typing on the modal. */
+function button(text: string, className: string): HTMLButtonElement {
+	const btn = document.createElement('button');
+	btn.type = 'button';
+	btn.className = className;
+	btn.textContent = text;
+	return btn;
+}
+
+/**
+ * Snap a rectangle to a target aspect ratio while preserving its
+ * center. `aspect == null` is a no-op (free crop). The result is
+ * clamped to `bounds` so the snapped rect never extends past the
+ * image's preview-pixel bounds. Integer pixel coords throughout.
+ */
+function applyAspectToRect(
+	r: CropResult,
+	aspect: AspectChoice,
+	bounds: { w: number; h: number }
+): CropResult {
+	if (aspect == null || aspect <= 0) return clampRect(r, bounds);
+	const cx = r.x + r.w / 2;
+	const cy = r.y + r.h / 2;
+	// Pick the dimension that fits the existing rect best so
+	// snapping doesn't grow past the image bounds.
+	let w = r.w;
+	let h = Math.round(w / aspect);
+	if (h > r.h) {
+		h = r.h;
+		w = Math.round(h * aspect);
+	}
+	const nx = Math.round(cx - w / 2);
+	const ny = Math.round(cy - h / 2);
+	return clampRect({ x: nx, y: ny, w, h }, bounds);
+}
+
+/** Clamp a rectangle to fit within `bounds`, integer coords throughout. */
+function clampRect(r: CropResult, bounds: { w: number; h: number }): CropResult {
+	const w = Math.max(1, Math.min(r.w, bounds.w));
+	const h = Math.max(1, Math.min(r.h, bounds.h));
+	const x = Math.max(0, Math.min(r.x, bounds.w - w));
+	const y = Math.max(0, Math.min(r.y, bounds.h - h));
+	return { x, y, w, h };
+}

--- a/web/src/lib/components/editor/attachment-image.ts
+++ b/web/src/lib/components/editor/attachment-image.ts
@@ -34,6 +34,7 @@ import {
 	invalidateAttachmentMetadata,
 	mimeToFormat
 } from './attachment-metadata';
+import { openCropModal, type CropResult } from './attachment-crop-modal';
 import type { AttachmentTransformRequest, AttachmentTransformResult } from '$lib/types';
 
 // Re-export the shared types so existing call sites keep working.
@@ -274,6 +275,7 @@ export const AttachmentImage = Node.create<AttachmentImageOptions>({
 				if (toolbar) return toolbar;
 				toolbar = buildRotateToolbar({
 					onRotate: (degrees) => runRotate(degrees),
+					onCrop: () => runCrop(),
 				});
 				wrapper.appendChild(toolbar);
 				// Subscribe to capability-change notifications. The
@@ -302,32 +304,65 @@ export const AttachmentImage = Node.create<AttachmentImageOptions>({
 				return toolbar;
 			};
 
+			const swapNodeUuid = (newId: string): void => {
+				const pos = typeof getPos === 'function' ? getPos() : null;
+				if (pos == null) return;
+				// Replace the node's UUID at its current position.
+				// setNodeMarkup keeps the same node type and only
+				// rewrites attributes, which is what we want — the
+				// transform produced a NEW attachment row, but it's
+				// still an attachmentImage.
+				const tr = editor.state.tr.setNodeMarkup(pos, undefined, {
+					...node.attrs,
+					uuid: newId,
+				});
+				editor.view.dispatch(tr);
+				// Drop the cached metadata for the OLD UUID — the
+				// editor may render the original elsewhere later and
+				// we want the next probe to refresh.
+				if (uuid && opts.workspaceSlug) {
+					invalidateAttachmentMetadata(opts.workspaceSlug, uuid);
+				}
+			};
+
 			const runRotate = async (degrees: 90 | 180 | 270): Promise<void> => {
 				if (!uuid) return;
 				try {
 					const result = await opts.transform(uuid, { operation: 'rotate', degrees });
-					const pos = typeof getPos === 'function' ? getPos() : null;
-					if (pos == null) return;
-					// Replace the node's UUID at its current position.
-					// setNodeMarkup keeps the same node type and only
-					// rewrites attributes, which is what we want — the
-					// transform produced a NEW attachment row, but it's
-					// still an attachmentImage.
-					const tr = editor.state.tr.setNodeMarkup(pos, undefined, {
-						...node.attrs,
-						uuid: result.id,
-					});
-					editor.view.dispatch(tr);
-					// Drop the cached metadata for the OLD UUID — the
-					// editor may render the original elsewhere later
-					// and we want the next probe to refresh.
-					if (opts.workspaceSlug) {
-						invalidateAttachmentMetadata(opts.workspaceSlug, uuid);
-					}
+					swapNodeUuid(result.id);
 				} catch (err) {
 					const msg = err instanceof Error ? err.message : 'Rotation failed';
 					if (opts.onError) opts.onError(msg);
 					else if (typeof console !== 'undefined') console.error('[attachmentImage] rotate', err);
+				}
+			};
+
+			const runCrop = async (): Promise<void> => {
+				if (!uuid) return;
+				// Open the crop modal pointing at the original-resolution
+				// variant — the user is composing pixel-precise rect
+				// coordinates, so we can't show the thumb-md downscale.
+				// The modal returns rect coordinates already translated
+				// to natural-image pixel space, ready to send to the
+				// server unchanged.
+				const fullUrl = opts.getDownloadUrl(uuid, 'original');
+				let rect: CropResult | null = null;
+				try {
+					rect = await openCropModal({ imageUrl: fullUrl, alt });
+				} catch {
+					// openCropModal never rejects today, but defensive
+					// catch keeps the editor responsive if that contract
+					// changes — treat as cancel.
+					rect = null;
+				}
+				if (rect == null) return;
+				try {
+					const result = await opts.transform(uuid, { operation: 'crop', rect });
+					swapNodeUuid(result.id);
+				} catch (err) {
+					const msg = err instanceof Error ? err.message : 'Crop failed';
+					if (opts.onError) opts.onError(msg);
+					else if (typeof console !== 'undefined') console.error('[attachmentImage] crop', err);
 				}
 			};
 
@@ -395,18 +430,20 @@ export const AttachmentImage = Node.create<AttachmentImageOptions>({
 });
 
 /**
- * Build the rotate toolbar — three buttons (rotate left 90°,
- * rotate 180°, rotate right 90°). Each button delegates to the
- * supplied onRotate callback; the NodeView wires that into a
- * setNodeMarkup transaction once the server returns the new UUID.
+ * Build the image-edit toolbar — rotate trio (left 90°, 180°, right
+ * 90°) plus a crop button. Each button delegates to the supplied
+ * callback; the NodeView wires those into setNodeMarkup transactions
+ * once the server returns the new UUID.
  *
  * The toolbar starts in its enabled state. refreshToolbarState
- * disables individual buttons (with tooltip) once the image's
- * MIME has been probed and compared to the processor's supported
- * formats list.
+ * disables individual buttons (with tooltip) once the image's MIME
+ * has been probed and compared to the processor's supported formats
+ * list — every button gates on the same per-format check, since
+ * both rotate and crop go through the same /transform path.
  */
 function buildRotateToolbar(opts: {
 	onRotate: (degrees: 90 | 180 | 270) => void;
+	onCrop: () => void;
 }): HTMLElement {
 	const toolbar = document.createElement('div');
 	toolbar.className = 'attachment-image-toolbar';
@@ -418,7 +455,7 @@ function buildRotateToolbar(opts: {
 	// Editor.svelte.
 	toolbar.addEventListener('mousedown', (e) => e.preventDefault());
 
-	const button = (label: string, title: string, deg: 90 | 180 | 270): HTMLButtonElement => {
+	const rotateButton = (label: string, title: string, deg: 90 | 180 | 270): HTMLButtonElement => {
 		const btn = document.createElement('button');
 		btn.type = 'button';
 		btn.className = 'attachment-image-toolbar-btn';
@@ -434,10 +471,27 @@ function buildRotateToolbar(opts: {
 		return btn;
 	};
 
+	const cropButton = (): HTMLButtonElement => {
+		const btn = document.createElement('button');
+		btn.type = 'button';
+		btn.className = 'attachment-image-toolbar-btn';
+		btn.textContent = '⌶';
+		btn.title = 'Crop…';
+		btn.dataset.action = 'crop';
+		btn.addEventListener('click', (e) => {
+			e.preventDefault();
+			e.stopPropagation();
+			if (btn.disabled) return;
+			opts.onCrop();
+		});
+		return btn;
+	};
+
 	toolbar.append(
-		button('↶', 'Rotate left 90°', 270),
-		button('↻', 'Rotate 180°', 180),
-		button('↷', 'Rotate right 90°', 90)
+		rotateButton('↶', 'Rotate left 90°', 270),
+		rotateButton('↻', 'Rotate 180°', 180),
+		rotateButton('↷', 'Rotate right 90°', 90),
+		cropButton()
 	);
 	return toolbar;
 }


### PR DESCRIPTION
## Summary

Drag-to-crop modal on top of the `AttachmentImage` toolbar introduced in TASK-879. The `/transform` endpoint already accepted the `crop` operation shape — this PR wires the editor UI plus supporting tests.

### Editor

**`attachment-crop-modal.ts`** (new) — pure-DOM crop modal, matches the existing image lightbox style. Returns a `Promise<CropResult | null>`: original-image pixel coordinates when the user clicks Apply, `null` on cancel / dismiss / image-load failure.
- Image fits a centered `<dialog>` via flex layout; backdrop click + Esc cancel.
- Crop rect starts at 80% of the image, centered. Body = "move" handle; four corner handles resize.
- Aspect presets: **Free, 1:1, 4:3, 16:9**. Preset click snaps current rect to the new ratio (preserving center); subsequent corner drags clamp to the locked ratio.
- Pointer events (touch + mouse for free) with `setPointerCapture` so drag continues even if the cursor leaves the handle.
- Coordinate translation: rect in preview-pixel space → `naturalWidth / offsetWidth` scale → original-image pixel space. Result clamped to natural bounds so a fractional-rounding overrun never pushes the rect off-image.

**`attachment-image.ts`** — extracts `swapNodeUuid()` from `runRotate` so `runCrop` shares the `setNodeMarkup` + invalidate-old-metadata flow. Toolbar gains a fourth button (⌶) that opens the modal pointed at the `original` variant. Per-format gating (`refreshToolbarState`) treats crop identically to rotate — both go through `/transform`, so a libvips-only format on the pure-Go build disables the whole toolbar with the same tooltip.

**`app.css`** — full styling for the crop modal: header with aspect toolbar, image stage with shadow-cutout overlay around the crop rect, four corner handles, footer with Cancel + Apply. Uses existing CSS-variable palette → light/dark mode track automatically.

### Server tests (3 new)

- `TestTransform_CropProducesNewBlobAtRectDimensions` — PNG crop end-to-end; verifies response dimensions AND that the served bytes decode at the same dimensions (guards against an encode-pipeline off-by-one)
- `TestTransform_CropClipsToImageBounds` — rect extending past the image clips rather than 400ing; the editor's rounding can produce `rect+1px` past natural dims in rare fractional-scale cases
- `TestTransform_CropRejectsBadRect` — missing rect, zero width, negative xy, rect entirely outside → 400

## Test plan

- [x] `go build ./... && go vet ./... && go test ./...` — clean
- [x] `cd web && npm run build` — clean
- [x] `cd web && npm run check` — 0 errors
- [ ] Manual after merge:
  - [ ] Click an image → toolbar appears → click ⌶ → modal opens with image + 80% rect
  - [ ] Drag rect body → moves; drag corner → resizes
  - [ ] Click 1:1 → rect snaps to square; corner drag stays 1:1
  - [ ] Click Apply → image replaced with cropped version; markdown round-trip works
  - [ ] On WebP (pure-Go build) → crop button disabled with tooltip

## Context

Implements `TASK-880` under `PLAN-866`. Closes the editor-side image-tools track on top of TASK-878 (`Processor`) and TASK-879 (rotate + `/transform` endpoint).