### PR TITLE
fix(ci): gofmt + bump race-detector timeout to 30m

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,9 +71,13 @@ jobs:
         if: github.ref == 'refs/heads/main'
         # Default 10m is tight: the full server-package suite under -race
         # measures ~13m locally on a developer laptop after BUG-851 (the
-        # ipRateLimiter goroutine drain) — 20m gives margin for the
-        # GitHub-hosted runner without papering over an actual hang.
-        run: go test -race -timeout=20m ./...
+        # ipRateLimiter goroutine drain). The PLAN-866 attachment work
+        # (image decode/encode/resize across thumbnail + transform tests)
+        # pushes total race-step runtime past 20m on the GitHub-hosted
+        # runner — bumped to 30m to give headroom without papering over
+        # an actual hang. Genuine deadlocks would still hit this and
+        # produce the goroutine-dump panic.
+        run: go test -race -timeout=30m ./...
 
       - name: Build binary
         run: go build -o pad ./cmd/pad
@@ -117,9 +121,12 @@ jobs:
         if: github.ref == 'refs/heads/main'
         env:
           PAD_TEST_POSTGRES_URL: "postgres://pad:pad@localhost:5432/pad?sslmode=disable"
-        # See SQLite race-detector step: 20m headroom over the default 10m
-        # because the full suite under -race exceeds 10m post-BUG-851 fix.
-        run: go test -race -timeout=20m ./... -count=1
+        # See SQLite race-detector step: 30m headroom over the default 10m.
+        # PostgreSQL adds latency on every CREATE/DROP and bcrypt under
+        # -race is ~3s per call — TestSessionIPChange-style tests that
+        # bootstrap a fresh user pay the full cost each time. The PLAN-866
+        # attachment work pushed the cumulative wall over 20m.
+        run: go test -race -timeout=30m ./... -count=1
 
   web:
     name: Web

--- a/internal/attachments/fs_store_test.go
+++ b/internal/attachments/fs_store_test.go
@@ -125,9 +125,9 @@ func TestFSStore_PutInvalidHashRejected(t *testing.T) {
 	s := newTestFSStore(t)
 	cases := []string{
 		"",
-		"abc",                                                                  // too short
-		strings.Repeat("g", 64),                                                // non-hex
-		strings.Repeat("a", 63),                                                // wrong length
+		"abc",                   // too short
+		strings.Repeat("g", 64), // non-hex
+		strings.Repeat("a", 63), // wrong length
 		strings.ToUpper(sha256Hex([]byte("uppercase rejected for stable path"))), // wrong case
 	}
 	for _, h := range cases {

--- a/internal/attachments/mime.go
+++ b/internal/attachments/mime.go
@@ -159,8 +159,8 @@ func NormalizeMIME(mime string) string {
 // Add new entries when a Codex round or a real-world upload turns up
 // another stdlib mismatch.
 var sniffAliases = map[string]string{
-	"audio/wave":         "audio/wav",         // .wav
-	"application/x-gzip": "application/gzip",  // .gz / .tar.gz
+	"audio/wave":         "audio/wav",        // .wav
+	"application/x-gzip": "application/gzip", // .gz / .tar.gz
 }
 
 // SniffMIME detects the MIME type from the leading bytes of a payload
@@ -303,15 +303,15 @@ var extMIMEMap = map[string]string{
 
 	// Known-blocked: included here ONLY so ValidateUpload can see them
 	// and reject by extension. None of these are on the `allowed` map.
-	".svg":  "image/svg+xml",
-	".exe":  "application/x-msdownload",
-	".dll":  "application/x-msdownload",
-	".msi":  "application/x-msi",
-	".bat":  "application/x-bat",
-	".sh":   "application/x-sh",
-	".com":  "application/x-msdownload",
-	".dmg":  "application/x-apple-diskimage",
-	".deb":  "application/vnd.debian.binary-package",
-	".rpm":  "application/x-rpm",
-	".app":  "application/octet-stream",
+	".svg": "image/svg+xml",
+	".exe": "application/x-msdownload",
+	".dll": "application/x-msdownload",
+	".msi": "application/x-msi",
+	".bat": "application/x-bat",
+	".sh":  "application/x-sh",
+	".com": "application/x-msdownload",
+	".dmg": "application/x-apple-diskimage",
+	".deb": "application/vnd.debian.binary-package",
+	".rpm": "application/x-rpm",
+	".app": "application/octet-stream",
 }

--- a/internal/attachments/mime_test.go
+++ b/internal/attachments/mime_test.go
@@ -33,12 +33,12 @@ func TestLookupMIME_AllowedAndRejected(t *testing.T) {
 	}
 
 	rejected := []string{
-		"image/svg+xml",                                // explicit XSS-vector block
-		"application/x-msdownload",                     // executable
-		"application/x-executable",                     // executable
+		"image/svg+xml",                                 // explicit XSS-vector block
+		"application/x-msdownload",                      // executable
+		"application/x-executable",                      // executable
 		"application/vnd.microsoft.portable-executable", // executable
-		"application/octet-stream",                     // unknown
-		"",                                             // empty
+		"application/octet-stream",                      // unknown
+		"",                                              // empty
 	}
 	for _, m := range rejected {
 		if _, ok := LookupMIME(m); ok {
@@ -78,10 +78,10 @@ var exeHeader = []byte("MZ\x90\x00\x03\x00\x00\x00\x04\x00\x00\x00\xff\xff\x00\x
 
 func TestSniffMIME(t *testing.T) {
 	cases := map[string][]byte{
-		"image/png":                 pngHeader,
-		"image/jpeg":                jpegHeader,
-		"text/plain":                []byte("hello world\nthis is plain text\n"),
-		"application/octet-stream":  exeHeader, // sniff doesn't classify EXE specifically
+		"image/png":                pngHeader,
+		"image/jpeg":               jpegHeader,
+		"text/plain":               []byte("hello world\nthis is plain text\n"),
+		"application/octet-stream": exeHeader, // sniff doesn't classify EXE specifically
 	}
 	for want, head := range cases {
 		got := SniffMIME(head)

--- a/internal/attachments/processor_test.go
+++ b/internal/attachments/processor_test.go
@@ -142,7 +142,7 @@ func TestProcessor_Decode_RejectsTooLarge(t *testing.T) {
 		t.Fatalf("PNG template too short: %d bytes", len(template))
 	}
 	patched := append([]byte(nil), template...)
-	const huge = uint32(100000) // 100k x 100k = 1e10 px > MaxPixelsDefault (64M)
+	const huge = uint32(100000)                      // 100k x 100k = 1e10 px > MaxPixelsDefault (64M)
 	binary.BigEndian.PutUint32(patched[16:20], huge) // width
 	binary.BigEndian.PutUint32(patched[20:24], huge) // height
 	crc := crc32.ChecksumIEEE(patched[12:29])        // type + 13-byte data

--- a/internal/server/handlers_attachments_download_test.go
+++ b/internal/server/handlers_attachments_download_test.go
@@ -311,12 +311,12 @@ func TestDownload_FilenameSanitized(t *testing.T) {
 	// We can't trigger this via upload (filepath.Base strips path
 	// separators) so test the helper directly.
 	cases := map[string]string{
-		"normal.png":   "normal.png",
-		`"quoted".png`: "quoted.png",
-		"control\x00\x01.png":   "control.png",
+		"normal.png":          "normal.png",
+		`"quoted".png`:        "quoted.png",
+		"control\x00\x01.png": "control.png",
 		`with\backslash.png`:  "withbackslash.png",
-		"":                     "attachment",
-		"\x00\x01\x02":         "attachment",
+		"":                    "attachment",
+		"\x00\x01\x02":        "attachment",
 	}
 	for in, want := range cases {
 		if got := sanitizeHeaderFilename(in); got != want {

--- a/internal/server/handlers_attachments_transform.go
+++ b/internal/server/handlers_attachments_transform.go
@@ -285,4 +285,3 @@ func transformedFilename(parent, op, format string) string {
 	}
 	return base + "." + op + ext
 }
-

--- a/internal/server/render/attachments_test.go
+++ b/internal/server/render/attachments_test.go
@@ -62,17 +62,17 @@ func TestAttachmentDownloadURL(t *testing.T) {
 
 func TestIsImageMime(t *testing.T) {
 	cases := map[string]bool{
-		"image/png":          true,
-		"image/jpeg":         true,
-		"image/webp":         true,
-		"IMAGE/PNG":          true, // case-insensitive
-		" image/png":         true, // whitespace tolerated
-		"application/pdf":    false,
-		"text/plain":         false,
-		"video/mp4":          false,
-		"":                   false,
-		"image":              false,
-		"images/png":         false,
+		"image/png":       true,
+		"image/jpeg":      true,
+		"image/webp":      true,
+		"IMAGE/PNG":       true, // case-insensitive
+		" image/png":      true, // whitespace tolerated
+		"application/pdf": false,
+		"text/plain":      false,
+		"video/mp4":       false,
+		"":                false,
+		"image":           false,
+		"images/png":      false,
 	}
 	for mime, want := range cases {
 		if got := IsImageMime(mime); got != want {


### PR DESCRIPTION
## Summary

Restore green CI on main. Two independent failures diagnosed and fixed:

### 1. `golangci-lint` gofmt failures
Seven files in the attachments path had trailing-comment alignment that `gofmt` wanted nudged a column. Pure whitespace, no logic changes. Ran `gofmt -w` across:
- `internal/attachments/{fs_store_test,mime,mime_test,processor_test}.go`
- `internal/server/{handlers_attachments_download_test,handlers_attachments_transform,render/attachments_test}.go`

The `golangci-lint` job had been failing on every push since TASK-870 — we just hadn't been treating those red checks as blockers because the PRs themselves were Codex-clean.

### 2. Race-detector tests timed out at 20m

`Run tests with race detector against PostgreSQL` was hitting the 20m wall on the GitHub-hosted runner. Two contributors:
- **bcrypt cost** under `-race` + Postgres: each `auth/bootstrap` call costs ~3s on the CI runner. Tests like `TestSessionIPChange_StrictDestroysSessionAtomically` bootstrap a fresh user and pay the full cost.
- **PLAN-866 image-processing tests** (thumbnail derivation, rotate/crop transform): add ~2-3 minutes of decode/encode work on top of the existing suite.

Reference points:
- TASK-875 main run #294 → `Go (PostgreSQL)` finished in **17m48s** ✓
- TASK-880 main run #298 → `Go (PostgreSQL)` hit **20m timeout** ✗

Bumped the race-detector timeout to **30m** on both the SQLite and PostgreSQL jobs. Genuine deadlocks would still trip this and produce the goroutine-dump panic — we just stop confusing "slow but progressing" with "permanently hung".

## Test plan

- [x] `gofmt -l ./...` (recursive) — clean
- [x] `go vet ./...` — clean
- [x] `go test ./...` — pass (75s for `internal/server` package locally)
- [x] Local `-race` benchmark on the new tests: `TestThumbnails | TestTransform | TestProcessor` adds ~63s on a developer laptop, ~2-3min of CI runtime is consistent with the observed 20m → 25m+ jump
- [ ] CI green on this PR (the merge into main is the real test — PR-only runs skip the race step)