### PR TITLE
feat(attachments): storage usage API + effective-limit computation (TASK-881)

### DIFF
--- a/cmd/pad/groups.go
+++ b/cmd/pad/groups.go
@@ -47,6 +47,7 @@ func workspaceCmd() *cobra.Command {
 		membersCmd(),
 		inviteCmd(),
 		joinCmd(),
+		storageCmd(),
 		exportCmd(),
 		importCmd(),
 		auditLogCmd(),

--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -949,6 +949,93 @@ func whoamiCmd() *cobra.Command {
 
 // --- members ---
 
+func storageCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "storage",
+		Short: "Show workspace storage usage and effective limit",
+		Long: `Print the workspace's current attachment storage usage versus the
+effective limit for the workspace owner's plan.
+
+The effective limit follows the resolution chain:
+  1. Per-user storage_bytes override (admin-set)
+  2. Platform plan_limits_<plan>_storage_bytes setting
+  3. Hardcoded plan default (free=500MB, pro=10GB)
+
+A limit of "unlimited" indicates no enforced cap (pro / self-hosted /
+workspaces with no owner).`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, _ := getClient()
+			ws := getWorkspace()
+
+			raw, err := client.RawGet("/workspaces/" + ws + "/storage/usage")
+			if err != nil {
+				return err
+			}
+
+			if formatFlag == "json" {
+				fmt.Println(string(raw))
+				return nil
+			}
+
+			var resp struct {
+				UsedBytes      int64  `json:"used_bytes"`
+				LimitBytes     int64  `json:"limit_bytes"`
+				Plan           string `json:"plan"`
+				OverrideActive bool   `json:"override_active"`
+			}
+			if err := json.Unmarshal(raw, &resp); err != nil {
+				return fmt.Errorf("decode storage usage: %w", err)
+			}
+
+			used := humanBytes(resp.UsedBytes)
+			if resp.LimitBytes < 0 {
+				fmt.Printf("%s used (unlimited)\n", used)
+			} else {
+				pct := 0.0
+				if resp.LimitBytes > 0 {
+					pct = float64(resp.UsedBytes) / float64(resp.LimitBytes) * 100
+				}
+				fmt.Printf("%s used of %s (%.1f%%)\n", used, humanBytes(resp.LimitBytes), pct)
+			}
+			plan := resp.Plan
+			if plan == "" {
+				plan = "(none)"
+			}
+			suffix := ""
+			if resp.OverrideActive {
+				suffix = " — admin override active"
+			}
+			fmt.Printf("Plan: %s%s\n", plan, suffix)
+
+			return nil
+		},
+	}
+	return cmd
+}
+
+// humanBytes formats a byte count with the smallest IEC unit that
+// keeps the value under 1024 — matches the convention used across
+// the web UI's storage bar so CLI and browser reads agree.
+func humanBytes(n int64) string {
+	if n < 0 {
+		return "?"
+	}
+	const unit = 1024
+	if n < unit {
+		return fmt.Sprintf("%d B", n)
+	}
+	div, exp := int64(unit), 0
+	for x := n / unit; x >= unit; x /= unit {
+		div *= unit
+		exp++
+	}
+	suffixes := []string{"KiB", "MiB", "GiB", "TiB", "PiB"}
+	if exp >= len(suffixes) {
+		exp = len(suffixes) - 1
+	}
+	return fmt.Sprintf("%.1f %s", float64(n)/float64(div), suffixes[exp])
+}
+
 func membersCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "members",

--- a/internal/server/handlers_attachments.go
+++ b/internal/server/handlers_attachments.go
@@ -245,6 +245,12 @@ func (s *Server) handleUploadAttachment(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	// Bump the storage-usage cache so the next GET sees fresh used_bytes
+	// without waiting for TTL expiry. Done eagerly here (and after each
+	// thumbnail derivation / transform) so the Settings → Storage UI
+	// stays consistent with the actual on-disk total.
+	s.storageInfoCache.invalidate(workspaceID)
+
 	// Quota tracking — log only, no enforcement in Phase 1. The download
 	// URL points at the GET handler shipped in TASK-872 (same PR series).
 	// Workspaces are addressed by slug everywhere else in the API; we

--- a/internal/server/handlers_attachments_thumbnails.go
+++ b/internal/server/handlers_attachments_thumbnails.go
@@ -116,6 +116,12 @@ func (s *Server) deriveThumbnails(parentID string) {
 			continue
 		}
 	}
+
+	// Derived rows count toward workspace storage usage. Drop the
+	// cached summary so the next storage/usage GET reflects the new
+	// thumbnail bytes; the upload handler already invalidated when
+	// inserting the original, but thumbnail rows land later.
+	s.storageInfoCache.invalidate(parent.WorkspaceID)
 }
 
 // openOriginalForThumbnail resolves the parent row's storage key

--- a/internal/server/handlers_attachments_transform.go
+++ b/internal/server/handlers_attachments_transform.go
@@ -213,6 +213,11 @@ func (s *Server) handleTransformAttachment(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
+	// Drop the storage-usage cache so the Settings → Storage UI sees
+	// the new attachment bytes on the next read. Same rationale as
+	// the upload path.
+	s.storageInfoCache.invalidate(workspaceID)
+
 	// Quota tracking — observational only in Phase 1, same as upload.
 	s.goAsync(func() { s.maybeWarnStorageQuota(workspaceID) })
 

--- a/internal/server/handlers_storage.go
+++ b/internal/server/handlers_storage.go
@@ -96,7 +96,11 @@ func (c *storageInfoCache) invalidate(workspaceID string) {
 //
 // GET /api/v1/workspaces/{ws}/storage/usage
 //
-// Auth: viewer+ (route is already gated by RequireWorkspaceAccess).
+// Auth: viewer+. RequireWorkspaceAccess admits item-grant guests
+// with workspaceRole=="guest", who shouldn't see workspace-wide
+// quota numbers — requireMinRole("viewer") is the explicit gate that
+// matches the activity / members / versions read endpoints.
+//
 // Response: {used_bytes, limit_bytes, plan, override_active}.
 //
 // limit_bytes == -1 means unlimited (pro / self-hosted plans, or
@@ -104,6 +108,9 @@ func (c *storageInfoCache) invalidate(workspaceID string) {
 // decide whether to render a usage bar (capped) or a counter
 // ("3.2 GB used") with no maximum.
 func (s *Server) handleGetWorkspaceStorageUsage(w http.ResponseWriter, r *http.Request) {
+	if !requireMinRole(w, r, "viewer") {
+		return
+	}
 	workspaceID, ok := s.getWorkspaceID(w, r)
 	if !ok {
 		return

--- a/internal/server/handlers_storage.go
+++ b/internal/server/handlers_storage.go
@@ -1,0 +1,124 @@
+package server
+
+import (
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/store"
+)
+
+// storageInfoTTL is the cache lifetime for workspace storage usage
+// summaries. Settings → Storage hits the endpoint on every page load,
+// and other surfaces (admin user-detail, soon dashboard widgets) can
+// poll it too — caching for a short window collapses repeated SUMs +
+// owner lookups to a single DB round-trip per workspace.
+//
+// 30s is short enough that a freshly uploaded file appears in the bar
+// within one refresh cycle even without explicit invalidation, and
+// long enough to absorb a burst of reloads from the same client.
+const storageInfoTTL = 30 * time.Second
+
+// storageInfoCache memoizes WorkspaceStorageInfo results keyed by
+// workspace ID. Invalidation is implicit via TTL expiry rather than
+// coupling the upload/delete paths to a cache invalidation callback —
+// the eventual-consistency window is bounded by storageInfoTTL.
+type storageInfoCache struct {
+	mu      sync.RWMutex
+	entries map[string]storageInfoCacheEntry
+	ttl     time.Duration
+	now     func() time.Time // injected for tests; nil falls back to time.Now
+}
+
+type storageInfoCacheEntry struct {
+	info      *store.WorkspaceStorageInfo
+	expiresAt time.Time
+}
+
+func newStorageInfoCache(ttl time.Duration) *storageInfoCache {
+	return &storageInfoCache{
+		entries: make(map[string]storageInfoCacheEntry),
+		ttl:     ttl,
+	}
+}
+
+func (c *storageInfoCache) clock() time.Time {
+	if c.now != nil {
+		return c.now()
+	}
+	return time.Now()
+}
+
+// get returns a cached entry if present and unexpired. A nil result
+// means the caller must recompute and call set.
+func (c *storageInfoCache) get(workspaceID string) *store.WorkspaceStorageInfo {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	e, ok := c.entries[workspaceID]
+	if !ok {
+		return nil
+	}
+	if c.clock().After(e.expiresAt) {
+		return nil
+	}
+	// Defensive copy: callers may mutate the returned pointer (e.g.
+	// admin-only fields stripped before write). Without this, a single
+	// admin-stripped read could poison the cache for non-admin readers.
+	cp := *e.info
+	return &cp
+}
+
+func (c *storageInfoCache) set(workspaceID string, info *store.WorkspaceStorageInfo) {
+	if info == nil {
+		return
+	}
+	cp := *info
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.entries[workspaceID] = storageInfoCacheEntry{
+		info:      &cp,
+		expiresAt: c.clock().Add(c.ttl),
+	}
+}
+
+// invalidate clears the cached entry for a workspace. Call after any
+// mutation that changes used_bytes (uploads, deletes, transforms) so
+// the next GET sees the fresh value without waiting for TTL expiry.
+func (c *storageInfoCache) invalidate(workspaceID string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.entries, workspaceID)
+}
+
+// handleGetWorkspaceStorageUsage returns the consolidated quota summary
+// for the workspace: used bytes, effective limit, the owner's plan,
+// and whether a per-user override is configured.
+//
+// GET /api/v1/workspaces/{ws}/storage/usage
+//
+// Auth: viewer+ (route is already gated by RequireWorkspaceAccess).
+// Response: {used_bytes, limit_bytes, plan, override_active}.
+//
+// limit_bytes == -1 means unlimited (pro / self-hosted plans, or
+// workspaces with no owner). The Settings → Storage UI uses this to
+// decide whether to render a usage bar (capped) or a counter
+// ("3.2 GB used") with no maximum.
+func (s *Server) handleGetWorkspaceStorageUsage(w http.ResponseWriter, r *http.Request) {
+	workspaceID, ok := s.getWorkspaceID(w, r)
+	if !ok {
+		return
+	}
+
+	if cached := s.storageInfoCache.get(workspaceID); cached != nil {
+		writeJSON(w, http.StatusOK, cached)
+		return
+	}
+
+	info, err := s.store.WorkspaceStorageInfo(workspaceID)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	s.storageInfoCache.set(workspaceID, info)
+	writeJSON(w, http.StatusOK, info)
+}

--- a/internal/server/handlers_storage_test.go
+++ b/internal/server/handlers_storage_test.go
@@ -1,8 +1,10 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -85,6 +87,30 @@ func TestStorageUsage_TracksUploads(t *testing.T) {
 	if afterSecond.UsedBytes != 2*int64(len(first)) {
 		t.Errorf("after second upload used_bytes = %d, want %d (cache should have been invalidated)",
 			afterSecond.UsedBytes, 2*int64(len(first)))
+	}
+}
+
+// TestStorageUsage_RejectsGuests pins the requireMinRole("viewer") guard.
+// RequireWorkspaceAccess admits item-grant guests (workspaceRole=="guest")
+// who shouldn't see workspace-wide quota numbers — the explicit gate is
+// what the activity / members / versions read endpoints all use.
+//
+// We exercise the gate by calling the handler directly with a context
+// pre-populated with the "guest" role, rather than building an
+// item-grant fixture (which would require a member-role user, an item,
+// a grant row, and a session — all just to flip a single role string).
+func TestStorageUsage_RejectsGuests(t *testing.T) {
+	srv, slug := testServerWithAttachments(t)
+
+	req := httptest.NewRequest("GET", "/api/v1/workspaces/"+slug+"/storage/usage", nil)
+	ctx := context.WithValue(req.Context(), ctxWorkspaceRole, "guest")
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+
+	srv.handleGetWorkspaceStorageUsage(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("guest got status %d, want 403; body=%s", rr.Code, rr.Body.String())
 	}
 }
 

--- a/internal/server/handlers_storage_test.go
+++ b/internal/server/handlers_storage_test.go
@@ -1,0 +1,134 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/store"
+)
+
+// storageUsageResponse mirrors store.WorkspaceStorageInfo + the JSON
+// shape the handler returns. Kept local so test asserts don't drift if
+// the public type adds fields later (e.g. a "computed_at" timestamp).
+type storageUsageResponse struct {
+	UsedBytes      int64  `json:"used_bytes"`
+	LimitBytes     int64  `json:"limit_bytes"`
+	Plan           string `json:"plan"`
+	OverrideActive bool   `json:"override_active"`
+}
+
+// TestStorageUsage_EmptyWorkspace covers the "fresh install" path:
+// workspace has no owner_id, no attachments. Expected: used_bytes = 0,
+// limit_bytes = -1 (unlimited fallback), plan empty, no override.
+func TestStorageUsage_EmptyWorkspace(t *testing.T) {
+	srv, slug := testServerWithAttachments(t)
+
+	rr := doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/storage/usage", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+
+	var resp storageUsageResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v body=%s", err, rr.Body.String())
+	}
+	if resp.UsedBytes != 0 {
+		t.Errorf("used_bytes = %d, want 0", resp.UsedBytes)
+	}
+	if resp.LimitBytes != -1 {
+		t.Errorf("limit_bytes = %d, want -1 (unlimited)", resp.LimitBytes)
+	}
+	if resp.OverrideActive {
+		t.Errorf("override_active = true, want false")
+	}
+}
+
+// TestStorageUsage_TracksUploads pins the core acceptance criterion:
+// after an upload the endpoint reports the new used_bytes total. We
+// also exercise the cache invalidation hook by uploading twice and
+// asserting the second value reflects both blobs.
+func TestStorageUsage_TracksUploads(t *testing.T) {
+	srv, slug := testServerWithAttachments(t)
+	first := realPNG()
+
+	if rr := doMultipartUpload(srv, slug, "a.png", first); rr.Code != http.StatusCreated {
+		t.Fatalf("first upload: %d %s", rr.Code, rr.Body.String())
+	}
+
+	rr := doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/storage/usage", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+	var afterFirst storageUsageResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &afterFirst); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if afterFirst.UsedBytes != int64(len(first)) {
+		t.Fatalf("after first upload used_bytes = %d, want %d", afterFirst.UsedBytes, len(first))
+	}
+
+	// Upload a different blob (different filename, same bytes still
+	// dedupes via content-hash but inserts a second row pointing at
+	// the same storage_key; SUM(size_bytes) double-counts that row by
+	// design — quota tracks logical usage, not unique bytes on disk).
+	if rr := doMultipartUpload(srv, slug, "b.png", first); rr.Code != http.StatusCreated {
+		t.Fatalf("second upload: %d %s", rr.Code, rr.Body.String())
+	}
+
+	rr = doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/storage/usage", nil)
+	var afterSecond storageUsageResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &afterSecond); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if afterSecond.UsedBytes != 2*int64(len(first)) {
+		t.Errorf("after second upload used_bytes = %d, want %d (cache should have been invalidated)",
+			afterSecond.UsedBytes, 2*int64(len(first)))
+	}
+}
+
+// TestStorageInfoCache covers the in-memory cache directly so the TTL +
+// invalidate paths have a focused test. The handler-level integration
+// is exercised by TestStorageUsage_TracksUploads (which depends on
+// invalidate-on-upload working).
+func TestStorageInfoCache(t *testing.T) {
+	now := time.Now()
+	c := newStorageInfoCache(30 * time.Second)
+	c.now = func() time.Time { return now }
+
+	if got := c.get("ws1"); got != nil {
+		t.Fatalf("get on empty cache = %v, want nil", got)
+	}
+
+	c.set("ws1", &store.WorkspaceStorageInfo{UsedBytes: 100, LimitBytes: 500, Plan: "free"})
+	got := c.get("ws1")
+	if got == nil {
+		t.Fatal("get after set returned nil")
+	}
+	if got.UsedBytes != 100 {
+		t.Errorf("used_bytes = %d, want 100", got.UsedBytes)
+	}
+
+	// Mutating the returned value must not poison the cache.
+	got.UsedBytes = 999
+	again := c.get("ws1")
+	if again.UsedBytes != 100 {
+		t.Errorf("cache mutated by caller: used_bytes = %d, want 100", again.UsedBytes)
+	}
+
+	// TTL expiry: advance the clock past 30s and assert the entry is gone.
+	now = now.Add(31 * time.Second)
+	if got := c.get("ws1"); got != nil {
+		t.Errorf("get after TTL expiry = %v, want nil", got)
+	}
+
+	// Invalidate clears the entry immediately.
+	now = time.Now()
+	c.now = func() time.Time { return now }
+	c.set("ws2", &store.WorkspaceStorageInfo{UsedBytes: 7})
+	c.invalidate("ws2")
+	if got := c.get("ws2"); got != nil {
+		t.Errorf("get after invalidate = %v, want nil", got)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -72,6 +72,13 @@ type Server struct {
 	// other endpoint and stores originals untouched.
 	imageProcessor attachments.Processor
 
+	// storageInfoCache memoizes per-workspace storage usage summaries
+	// behind a short TTL (storageInfoTTL). Reduces DB load on the
+	// Settings → Storage page and quota-aware UI surfaces. Initialized
+	// in newServer; never nil so handlers can call get/set without
+	// guarding.
+	storageInfoCache *storageInfoCache
+
 	// bg tracks fire-and-forget goroutines spawned by request handlers
 	// (TouchUserActivity in middleware_auth, async email sends, etc.) so
 	// the server can drain them before shutdown / test cleanup. Without
@@ -105,8 +112,9 @@ func (s *Server) Stop() {
 
 func New(s *store.Store) *Server {
 	return &Server{
-		store:        s,
-		rateLimiters: NewRateLimiters(),
+		store:            s,
+		rateLimiters:     NewRateLimiters(),
+		storageInfoCache: newStorageInfoCache(storageInfoTTL),
 	}
 }
 
@@ -726,6 +734,11 @@ func (s *Server) setupRouter() {
 					r.Get("/attachments/{attachmentID}", s.handleGetAttachment)
 					r.Head("/attachments/{attachmentID}", s.handleGetAttachment)
 					r.Post("/attachments/{attachmentID}/transform", s.handleTransformAttachment)
+
+					// Storage usage summary for Settings → Storage and other
+					// quota-aware UI surfaces (TASK-881). Cached behind a
+					// short TTL — see handleGetWorkspaceStorageUsage.
+					r.Get("/storage/usage", s.handleGetWorkspaceStorageUsage)
 
 					// Webhooks
 					r.Route("/webhooks", func(r chi.Router) {

--- a/internal/store/attachments.go
+++ b/internal/store/attachments.go
@@ -2,10 +2,29 @@ package store
 
 import (
 	"database/sql"
+	"encoding/json"
 	"fmt"
 
 	"github.com/PerpetualSoftware/pad/internal/models"
 )
+
+// WorkspaceStorageInfo is the consolidated quota summary for a workspace:
+// used bytes (from the attachments table), the effective limit for the
+// owner's plan (after override + platform-setting + hardcoded fallback),
+// the plan name, and whether the owner has a per-user storage_bytes
+// override configured. -1 in LimitBytes means unlimited.
+//
+// The override_active flag tracks whether the workspace owner's
+// PlanOverrides JSON contains a storage_bytes key — independent of
+// whether that override actually changes the effective limit. (On
+// pro/self-hosted plans the limit is unlimited regardless; the flag
+// still surfaces the admin's intent in the Settings → Storage UI.)
+type WorkspaceStorageInfo struct {
+	UsedBytes      int64  `json:"used_bytes"`
+	LimitBytes     int64  `json:"limit_bytes"` // -1 = unlimited
+	Plan           string `json:"plan"`
+	OverrideActive bool   `json:"override_active"`
+}
 
 // attachmentColumns is the canonical column list. Keep the column names in
 // alignment with migrations/047_attachments.sql + pgmigrations/026_attachments.sql.
@@ -125,50 +144,93 @@ func (s *Store) WorkspaceStorageUsage(workspaceID string) (int64, error) {
 }
 
 // WorkspaceStorageLimit returns the effective storage limit (bytes) for
-// the workspace owner's plan, or -1 if the plan is unlimited. Resolution
-// matches the existing CheckLimit three-tier order:
+// the workspace owner's plan, or -1 if the plan is unlimited. Thin
+// wrapper around WorkspaceStorageInfo for the upload-time quota check
+// path that doesn't care about used bytes / plan / override metadata.
 //
+// Resolution matches the CheckLimit three-tier order:
 //  1. Per-user override (user.PlanOverrides JSON, key "storage_bytes")
 //  2. Platform setting (plan_limits_<plan>_storage_bytes)
 //  3. Hardcoded fallback (DefaultFreeLimits / DefaultProLimits)
 //
 // CheckLimit itself can't be reused here because its featureCount path
 // only knows about row-counted features (items, members, webhooks, …) —
-// storage_bytes is byte-counted via WorkspaceStorageUsage. TASK-881 will
-// expose a richer endpoint built on top of this helper; TASK-871 uses it
-// only for the observational quota warning.
+// storage_bytes is byte-counted via WorkspaceStorageUsage.
 func (s *Store) WorkspaceStorageLimit(workspaceID string) (int64, error) {
+	info, err := s.WorkspaceStorageInfo(workspaceID)
+	if err != nil {
+		return 0, err
+	}
+	return info.LimitBytes, nil
+}
+
+// WorkspaceStorageInfo returns the consolidated quota summary for a
+// workspace (used + limit + plan + override flag) in a single call.
+// Used by the storage usage API (TASK-881) and the Settings → Storage
+// page (TASK-882) so the UI can render the usage bar and the
+// "(override)" badge from one fetch.
+//
+// Limit resolution mirrors WorkspaceStorageLimit; pro and self-hosted
+// plans return -1 (unlimited) in Phase 1. Workspaces with no owner
+// (fresh install, deleted owner) also resolve to unlimited rather than
+// blocking uploads.
+func (s *Store) WorkspaceStorageInfo(workspaceID string) (*WorkspaceStorageInfo, error) {
+	used, err := s.WorkspaceStorageUsage(workspaceID)
+	if err != nil {
+		return nil, err
+	}
+
+	info := &WorkspaceStorageInfo{
+		UsedBytes:  used,
+		LimitBytes: -1, // default: no enforceable limit (no owner / pro / self-hosted)
+	}
+
 	var ownerID sql.NullString
-	if err := s.db.QueryRow(s.q(`SELECT owner_id FROM workspaces WHERE id = ?`), workspaceID).Scan(&ownerID); err != nil {
-		if err == sql.ErrNoRows {
-			return -1, nil
-		}
-		return 0, fmt.Errorf("workspace storage limit: get owner: %w", err)
+	err = s.db.QueryRow(s.q(`SELECT owner_id FROM workspaces WHERE id = ?`), workspaceID).Scan(&ownerID)
+	if err == sql.ErrNoRows {
+		return info, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("workspace storage info: get owner: %w", err)
 	}
 	// Workspaces created on a fresh install (no users yet) and legacy
 	// workspaces from before owner_id was added have no owner. In both
 	// cases there is no plan to consult — treat as unlimited rather
 	// than rejecting uploads.
 	if !ownerID.Valid || ownerID.String == "" {
-		return -1, nil
+		return info, nil
 	}
 	user, err := s.GetUser(ownerID.String)
 	if err != nil {
-		return 0, fmt.Errorf("workspace storage limit: get user: %w", err)
+		return nil, fmt.Errorf("workspace storage info: get user: %w", err)
 	}
 	if user == nil {
 		// Owner row was deleted but the workspace still references it.
-		// Treat as unlimited; the orphan is a separate cleanup concern.
-		return -1, nil
+		return info, nil
 	}
 
 	plan := user.Plan
 	if plan == "" {
 		plan = "free"
 	}
+	info.Plan = plan
+
+	// Detect whether a per-user storage_bytes override is configured.
+	// We surface this as a flag for the UI even when the plan is
+	// pro/self-hosted (where the override has no effect on the
+	// effective limit) so admins can see the configured value.
+	if user.PlanOverrides != "" {
+		var overrides map[string]int
+		if err := json.Unmarshal([]byte(user.PlanOverrides), &overrides); err == nil {
+			if _, ok := overrides["storage_bytes"]; ok {
+				info.OverrideActive = true
+			}
+		}
+	}
+
 	// Pro and self-hosted have no enforced limit in Phase 1.
 	if plan == "pro" || plan == "self-hosted" {
-		return -1, nil
+		return info, nil
 	}
 
 	// resolveLimit returns int (32-bit on 32-bit platforms) so we can't
@@ -177,5 +239,6 @@ func (s *Store) WorkspaceStorageLimit(workspaceID string) (int64, error) {
 	// and 32-bit production hosts are not a supported deployment target
 	// for Pad Cloud. If a future plan-tier ever exceeds INT_MAX bytes
 	// we'll widen resolveLimit.
-	return int64(s.resolveLimit(plan, "storage_bytes", user.PlanOverrides)), nil
+	info.LimitBytes = int64(s.resolveLimit(plan, "storage_bytes", user.PlanOverrides))
+	return info, nil
 }

--- a/internal/store/attachments_test.go
+++ b/internal/store/attachments_test.go
@@ -1,0 +1,171 @@
+package store
+
+import (
+	"testing"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// TestWorkspaceStorageInfo_NoOwner covers the "fresh install" /
+// legacy-workspace path: workspace exists but has no owner_id.
+// Expected: limit unlimited, plan empty, no override (matches the
+// upload-time behavior in WorkspaceStorageLimit, which returns -1
+// rather than rejecting the upload outright).
+func TestWorkspaceStorageInfo_NoOwner(t *testing.T) {
+	s := testStore(t)
+
+	wsID := newID()
+	ts := time.Now().UTC().Format(time.RFC3339)
+	if _, err := s.db.Exec(s.q(`INSERT INTO workspaces (id, slug, name, settings, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?)`),
+		wsID, "no-owner", "No Owner", "{}", ts, ts); err != nil {
+		t.Fatalf("insert workspace: %v", err)
+	}
+
+	info, err := s.WorkspaceStorageInfo(wsID)
+	if err != nil {
+		t.Fatalf("WorkspaceStorageInfo: %v", err)
+	}
+	if info.UsedBytes != 0 {
+		t.Errorf("used_bytes = %d, want 0", info.UsedBytes)
+	}
+	if info.LimitBytes != -1 {
+		t.Errorf("limit_bytes = %d, want -1", info.LimitBytes)
+	}
+	if info.Plan != "" {
+		t.Errorf("plan = %q, want empty", info.Plan)
+	}
+	if info.OverrideActive {
+		t.Errorf("override_active = true, want false")
+	}
+}
+
+// TestWorkspaceStorageInfo_FreePlanResolution exercises the full
+// owner → plan → override resolution chain:
+//
+//  1. Free plan with no override → limit_bytes = DefaultFreeLimits, override_active=false
+//  2. Free plan + storage_bytes override → limit_bytes = override value, override_active=true
+//  3. Pro plan → limit_bytes = -1 unconditionally (Phase 1 quirk:
+//     pro/self-hosted bypass override resolution; the flag still
+//     surfaces the configured override for admin visibility)
+func TestWorkspaceStorageInfo_FreePlanResolution(t *testing.T) {
+	s := testStore(t)
+
+	owner, err := s.CreateUser(models.UserCreate{
+		Email:    "owner@example.com",
+		Name:     "Owner",
+		Password: "correct-horse-battery-staple",
+		Role:     "member",
+	})
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	if err := s.SetUserPlan(owner.ID, "free", ""); err != nil {
+		t.Fatalf("SetUserPlan(free): %v", err)
+	}
+
+	wsID := newID()
+	ts := time.Now().UTC().Format(time.RFC3339)
+	if _, err := s.db.Exec(s.q(`INSERT INTO workspaces (id, slug, name, settings, owner_id, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?)`),
+		wsID, "owned", "Owned", "{}", owner.ID, ts, ts); err != nil {
+		t.Fatalf("insert workspace: %v", err)
+	}
+
+	// 1. Free plan, no override.
+	info, err := s.WorkspaceStorageInfo(wsID)
+	if err != nil {
+		t.Fatalf("WorkspaceStorageInfo: %v", err)
+	}
+	if info.Plan != "free" {
+		t.Errorf("plan = %q, want free", info.Plan)
+	}
+	if info.LimitBytes != int64(DefaultFreeLimits.StorageBytes) {
+		t.Errorf("limit_bytes = %d, want %d", info.LimitBytes, DefaultFreeLimits.StorageBytes)
+	}
+	if info.OverrideActive {
+		t.Errorf("override_active = true, want false")
+	}
+
+	// 2. Free plan + override.
+	if err := s.SetUserPlanOverrides(owner.ID, `{"storage_bytes":1073741824}`); err != nil {
+		t.Fatalf("SetUserPlanOverrides: %v", err)
+	}
+	info, err = s.WorkspaceStorageInfo(wsID)
+	if err != nil {
+		t.Fatalf("WorkspaceStorageInfo (override): %v", err)
+	}
+	if info.LimitBytes != 1073741824 {
+		t.Errorf("limit_bytes with override = %d, want 1073741824", info.LimitBytes)
+	}
+	if !info.OverrideActive {
+		t.Errorf("override_active = false, want true after setting override")
+	}
+
+	// 3. Pro plan: the limit is unlimited regardless of override (Phase 1).
+	// The override_active flag still surfaces the configured override
+	// so the admin UI can show it; it just doesn't affect the limit.
+	if err := s.SetUserPlan(owner.ID, "pro", ""); err != nil {
+		t.Fatalf("SetUserPlan(pro): %v", err)
+	}
+	info, err = s.WorkspaceStorageInfo(wsID)
+	if err != nil {
+		t.Fatalf("WorkspaceStorageInfo (pro): %v", err)
+	}
+	if info.LimitBytes != -1 {
+		t.Errorf("pro plan limit_bytes = %d, want -1 (unlimited)", info.LimitBytes)
+	}
+	if !info.OverrideActive {
+		t.Errorf("override_active should still be true for pro plan with configured override")
+	}
+}
+
+// TestWorkspaceStorageInfo_TracksLiveAttachments inserts a few
+// attachment rows directly and asserts SUM(size_bytes) shows up in
+// used_bytes — and that soft-deleted rows are excluded so the user
+// sees the post-delete value (Settings → Storage UX expectation).
+func TestWorkspaceStorageInfo_TracksLiveAttachments(t *testing.T) {
+	s := testStore(t)
+
+	wsID := newID()
+	ts := time.Now().UTC().Format(time.RFC3339)
+	if _, err := s.db.Exec(s.q(`INSERT INTO workspaces (id, slug, name, settings, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?)`),
+		wsID, "ws", "WS", "{}", ts, ts); err != nil {
+		t.Fatalf("insert workspace: %v", err)
+	}
+
+	mkAttach := func(size int64, deleted bool) {
+		t.Helper()
+		a := &models.Attachment{
+			WorkspaceID: wsID,
+			UploadedBy:  "system",
+			StorageKey:  "fs:" + newID(),
+			ContentHash: newID(),
+			MimeType:    "image/png",
+			SizeBytes:   size,
+			Filename:    "x.png",
+		}
+		if err := s.CreateAttachment(a); err != nil {
+			t.Fatalf("CreateAttachment: %v", err)
+		}
+		if deleted {
+			if _, err := s.db.Exec(s.q(`UPDATE attachments SET deleted_at = ? WHERE id = ?`), ts, a.ID); err != nil {
+				t.Fatalf("soft-delete: %v", err)
+			}
+		}
+	}
+
+	mkAttach(1024, false)
+	mkAttach(2048, false)
+	mkAttach(99999, true) // deleted — must not count
+
+	info, err := s.WorkspaceStorageInfo(wsID)
+	if err != nil {
+		t.Fatalf("WorkspaceStorageInfo: %v", err)
+	}
+	if info.UsedBytes != 3072 {
+		t.Errorf("used_bytes = %d, want 3072 (1024 + 2048; soft-deleted excluded)", info.UsedBytes)
+	}
+}

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -45,7 +45,8 @@ import type {
 	AttachmentUploadResult,
 	AttachmentTransformRequest,
 	AttachmentTransformResult,
-	ServerCapabilities
+	ServerCapabilities,
+	WorkspaceStorageInfo
 } from '$lib/types';
 
 const BASE = '/api/v1';
@@ -838,6 +839,27 @@ export const api = {
 				throw new Error(`transform failed: ${resp.status}`);
 			}
 			return (await resp.json()) as AttachmentTransformResult;
+		},
+
+		/**
+		 * Workspace storage usage summary: bytes consumed by live
+		 * attachments + the effective limit for the workspace owner's
+		 * plan + a flag for whether an admin-set per-user override is
+		 * configured.
+		 *
+		 * Server caches per-workspace for ~30s — uploads invalidate
+		 * the cache eagerly so the bar doesn't lag behind a new
+		 * upload, but multiple page loads in the cache window collapse
+		 * to a single DB read.
+		 *
+		 * `limit_bytes === -1` means unlimited (pro / self-hosted /
+		 * unowned workspaces). Callers should branch on that to render
+		 * a counter rather than a capped usage bar.
+		 */
+		storageUsage(workspaceSlug: string): Promise<WorkspaceStorageInfo> {
+			return request<WorkspaceStorageInfo>(
+				`/workspaces/${workspaceSlug}/storage/usage`
+			);
 		}
 	},
 

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -819,6 +819,27 @@ export interface ServerCapabilities {
 	};
 }
 
+/**
+ * Consolidated quota summary returned by
+ * GET /api/v1/workspaces/{ws}/storage/usage.
+ *
+ * `limit_bytes === -1` indicates no enforced cap — the workspace
+ * is on a pro / self-hosted plan (or has no owner). Render a usage
+ * counter rather than a capped bar in that case.
+ *
+ * `override_active === true` means the workspace owner has a
+ * per-user storage_bytes override configured. The flag stays true
+ * for pro/self-hosted plans even though the override doesn't change
+ * the effective limit there — the admin UI uses the flag to surface
+ * "(custom override)" in the user-detail view.
+ */
+export interface WorkspaceStorageInfo {
+	used_bytes: number;
+	limit_bytes: number;
+	plan: string;
+	override_active: boolean;
+}
+
 // ─── Helper functions ────────────────────────────────────────────────────────
 
 export function parseFields(item: Item): Record<string, any> {


### PR DESCRIPTION
## Summary

Adds `GET /api/v1/workspaces/{ws}/storage/usage` returning `{used_bytes, limit_bytes, plan, override_active}` so the upcoming Settings → Storage page (TASK-882) and the admin user-detail page (TASK-883) can render usage bars and surface per-user overrides.

- **Store helper**: `store.WorkspaceStorageInfo` consolidates SUM(size_bytes) + owner→plan→override resolution in one call. `WorkspaceStorageLimit` is now a thin wrapper so upload-time quota and the API path stay consistent.
- **Cache**: 30s TTL `storageInfoCache` to absorb repeated page loads, with eager invalidation on upload / thumbnail derivation / transform. Defensive copy on read so callers can't poison the cache.
- **CLI**: `pad workspace storage` prints "X used of Y (Z%)" with IEC units; surfaces override flag.
- **TS**: `api.attachments.storageUsage()` + `WorkspaceStorageInfo` type, ready for TASK-882.
- **No enforcement**: phase 1 is observational; TASK-871's existing warn-on-100% remains the only side effect.

## Context

Implements `TASK-881` under `PLAN-866` (Attachments Phase 1).

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./internal/server/ ./internal/store/` — green (76s + 33s)
- [x] `cd web && npm run check` — 0 errors, 6 pre-existing warnings
- [x] Store-level: no-owner fallback, free-plan resolution, override flip, pro-plan visibility, soft-delete exclusion
- [x] Server-level: empty workspace, upload-then-read cache invalidation, dedicated cache TTL/invalidate/copy-safety test
- [x] `pad workspace storage --help` smoke test