### PR TITLE
feat(attachments): Settings → Storage tab with attachment list (TASK-882)

### DIFF
--- a/internal/server/handlers_storage.go
+++ b/internal/server/handlers_storage.go
@@ -187,6 +187,30 @@ func (s *Server) handleListWorkspaceAttachments(w http.ResponseWriter, r *http.R
 		}
 	}
 
+	// Enforce per-user collection-level access control. Mirrors the
+	// pattern used by handlers_search / handlers_dashboard / etc:
+	// nil = admin/no restriction; explicit (possibly empty) slice =
+	// member with limited visibility.
+	visibleIDs, err := s.visibleCollectionIDs(r, workspaceID)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	filters.VisibleCollectionIDs = visibleIDs
+	// Mutually exclusive item filter — if a restricted member asks
+	// for unattached, return nothing rather than leak orphan rows.
+	// The store-level filter already excludes orphans for restricted
+	// users; this just makes the handler's intent explicit.
+	if visibleIDs != nil && filters.Unattached {
+		writeJSON(w, http.StatusOK, map[string]any{
+			"attachments": []store.AttachmentListItem{},
+			"total":       0,
+			"limit":       effectiveLimit(filters.Limit),
+			"offset":      effectiveOffset(filters.Offset),
+		})
+		return
+	}
+
 	rows, total, err := s.store.WorkspaceAttachments(workspaceID, filters)
 	if err != nil {
 		writeInternalError(w, err)

--- a/internal/server/handlers_storage.go
+++ b/internal/server/handlers_storage.go
@@ -1,9 +1,15 @@
 package server
 
 import (
+	"database/sql"
+	"errors"
 	"net/http"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
+
+	"github.com/go-chi/chi/v5"
 
 	"github.com/PerpetualSoftware/pad/internal/store"
 )
@@ -128,4 +134,157 @@ func (s *Server) handleGetWorkspaceStorageUsage(w http.ResponseWriter, r *http.R
 	}
 	s.storageInfoCache.set(workspaceID, info)
 	writeJSON(w, http.StatusOK, info)
+}
+
+// handleListWorkspaceAttachments returns a paginated list of original
+// (non-derived) attachments in the workspace. Supports filter +
+// sort + pagination via query string:
+//
+//	GET /api/v1/workspaces/{ws}/attachments
+//	    ?category=image|video|audio|document|text|archive|other
+//	    &item=attached|unattached
+//	    &collection=<collection_id>
+//	    &sort=size|size_desc|filename|filename_desc|created_at|created_at_desc
+//	    &limit=<1..200>
+//	    &offset=<n>
+//
+// Unknown values are silently ignored — the server defaults
+// (`created_at_desc`, limit 50, offset 0, no filters) take over.
+//
+// Auth: viewer+. Same gate as storage/usage — workspace-wide
+// attachment metadata leaks the same surface area.
+//
+// Response: {attachments: [...], total: N, limit, offset}.
+func (s *Server) handleListWorkspaceAttachments(w http.ResponseWriter, r *http.Request) {
+	if !requireMinRole(w, r, "viewer") {
+		return
+	}
+	workspaceID, ok := s.getWorkspaceID(w, r)
+	if !ok {
+		return
+	}
+
+	q := r.URL.Query()
+	filters := store.AttachmentListFilters{
+		MimeCategory: strings.ToLower(strings.TrimSpace(q.Get("category"))),
+		CollectionID: strings.TrimSpace(q.Get("collection")),
+		Sort:         strings.ToLower(strings.TrimSpace(q.Get("sort"))),
+	}
+	switch strings.ToLower(strings.TrimSpace(q.Get("item"))) {
+	case "attached":
+		filters.Attached = true
+	case "unattached":
+		filters.Unattached = true
+	}
+	if v := q.Get("limit"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			filters.Limit = n
+		}
+	}
+	if v := q.Get("offset"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			filters.Offset = n
+		}
+	}
+
+	rows, total, err := s.store.WorkspaceAttachments(workspaceID, filters)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	if rows == nil {
+		// Marshal `[]` rather than `null` so the UI can iterate
+		// without a falsy-check guard on every render.
+		rows = []store.AttachmentListItem{}
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"attachments": rows,
+		"total":       total,
+		"limit":       effectiveLimit(filters.Limit),
+		"offset":      effectiveOffset(filters.Offset),
+	})
+}
+
+// effectiveLimit / effectiveOffset mirror the store-side defaults so
+// the response carries the canonical values the handler used. Useful
+// to the UI when the request omitted them.
+func effectiveLimit(n int) int {
+	if n <= 0 {
+		return 50
+	}
+	if n > 200 {
+		return 200
+	}
+	return n
+}
+
+func effectiveOffset(n int) int {
+	if n < 0 {
+		return 0
+	}
+	return n
+}
+
+// handleDeleteWorkspaceAttachment soft-deletes an attachment by ID.
+// Tombstones the row + every thumbnail variant; the orphan GC reclaims
+// the on-disk blob after the grace period (TASK-886).
+//
+//	DELETE /api/v1/workspaces/{ws}/attachments/{attachmentID}
+//
+// Auth: editor+. Delete is destructive (the bytes go away after GC) —
+// view-only members shouldn't be able to remove attachments other
+// users uploaded.
+//
+// Cross-workspace requests get 404 (not 403) to avoid leaking which
+// IDs exist in other workspaces. Same pattern as the download
+// handler.
+//
+// Returns 204 on success. The storage-usage cache is invalidated
+// eagerly so the bar drops within a refresh cycle.
+func (s *Server) handleDeleteWorkspaceAttachment(w http.ResponseWriter, r *http.Request) {
+	if !requireMinRole(w, r, "editor") {
+		return
+	}
+	workspaceID, ok := s.getWorkspaceID(w, r)
+	if !ok {
+		return
+	}
+	id := chi.URLParam(r, "attachmentID")
+	if id == "" {
+		writeError(w, http.StatusBadRequest, "missing_id", "Attachment ID required")
+		return
+	}
+
+	att, err := s.store.GetAttachment(id)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	if att == nil || att.WorkspaceID != workspaceID || att.DeletedAt != nil {
+		writeError(w, http.StatusNotFound, "not_found", "Attachment not found")
+		return
+	}
+	// Refuse to delete derived (thumbnail) rows directly — they're
+	// auto-managed and deleting the original cascades. A direct
+	// delete here would leave the original without thumbnails until
+	// a future "regenerate" job runs.
+	if att.ParentID != nil {
+		writeError(w, http.StatusBadRequest, "derived_attachment",
+			"Cannot delete a thumbnail directly — delete the original.")
+		return
+	}
+
+	if err := s.store.SoftDeleteAttachment(id); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			writeError(w, http.StatusNotFound, "not_found", "Attachment not found")
+			return
+		}
+		writeInternalError(w, err)
+		return
+	}
+
+	s.storageInfoCache.invalidate(workspaceID)
+
+	w.WriteHeader(http.StatusNoContent)
 }

--- a/internal/server/handlers_storage.go
+++ b/internal/server/handlers_storage.go
@@ -311,8 +311,14 @@ func (s *Server) handleDeleteWorkspaceAttachment(w http.ResponseWriter, r *http.
 	// they can't see — even if they obtain the attachment ID some
 	// other way. Mirrors requireItemVisible's logic but operates on
 	// the attachment's parent item id rather than a fully-loaded item.
+	//
+	// GetItemIncludeDeleted is used (not GetItem) because the storage
+	// list intentionally surfaces attachments whose parent item is
+	// soft-deleted — they're still consuming quota and the user
+	// needs a path to delete the blob. The collection_id stays set
+	// after a soft delete, so the visibility predicate still works.
 	if att.ItemID != nil {
-		item, err := s.store.GetItem(*att.ItemID)
+		item, err := s.store.GetItemIncludeDeleted(*att.ItemID)
 		if err != nil {
 			writeInternalError(w, err)
 			return

--- a/internal/server/handlers_storage.go
+++ b/internal/server/handlers_storage.go
@@ -187,28 +187,35 @@ func (s *Server) handleListWorkspaceAttachments(w http.ResponseWriter, r *http.R
 		}
 	}
 
-	// Enforce per-user collection-level access control. Mirrors the
-	// pattern used by handlers_search / handlers_dashboard / etc:
-	// nil = admin/no restriction; explicit (possibly empty) slice =
-	// member with limited visibility.
-	visibleIDs, err := s.visibleCollectionIDs(r, workspaceID)
+	// Enforce per-user collection + item-level access control. Mirrors
+	// the (fullCollIDs, grantedItemIDs) tuple used by handlers_search /
+	// handlers_activity for cross-collection lists. nil/nil from
+	// guestResourceFilter means admin or full-access member — no
+	// restriction. Otherwise a restricted user's view is the union of
+	// their member-access collections + any item-level grants.
+	fullCollIDs, grantedItemIDs, err := s.guestResourceFilter(r, workspaceID)
 	if err != nil {
 		writeInternalError(w, err)
 		return
 	}
-	filters.VisibleCollectionIDs = visibleIDs
-	// Mutually exclusive item filter — if a restricted member asks
-	// for unattached, return nothing rather than leak orphan rows.
-	// The store-level filter already excludes orphans for restricted
-	// users; this just makes the handler's intent explicit.
-	if visibleIDs != nil && filters.Unattached {
-		writeJSON(w, http.StatusOK, map[string]any{
-			"attachments": []store.AttachmentListItem{},
-			"total":       0,
-			"limit":       effectiveLimit(filters.Limit),
-			"offset":      effectiveOffset(filters.Offset),
-		})
-		return
+	restricted := fullCollIDs != nil || grantedItemIDs != nil
+	if restricted {
+		filters.Restricted = true
+		filters.FullCollectionIDs = fullCollIDs
+		filters.GrantedItemIDs = grantedItemIDs
+		// Restricted users never see orphans (item_id IS NULL) — the
+		// store filter already excludes them, so the Unattached
+		// filter would always yield zero rows. Short-circuit so the
+		// UI sees an immediate empty page rather than firing the SQL.
+		if filters.Unattached {
+			writeJSON(w, http.StatusOK, map[string]any{
+				"attachments": []store.AttachmentListItem{},
+				"total":       0,
+				"limit":       effectiveLimit(filters.Limit),
+				"offset":      effectiveOffset(filters.Offset),
+			})
+			return
+		}
 	}
 
 	rows, total, err := s.store.WorkspaceAttachments(workspaceID, filters)
@@ -297,6 +304,41 @@ func (s *Server) handleDeleteWorkspaceAttachment(w http.ResponseWriter, r *http.
 		writeError(w, http.StatusBadRequest, "derived_attachment",
 			"Cannot delete a thumbnail directly — delete the original.")
 		return
+	}
+
+	// Item-level visibility check. An editor with restricted collection
+	// access shouldn't be able to delete attachments in collections
+	// they can't see — even if they obtain the attachment ID some
+	// other way. Mirrors requireItemVisible's logic but operates on
+	// the attachment's parent item id rather than a fully-loaded item.
+	if att.ItemID != nil {
+		item, err := s.store.GetItem(*att.ItemID)
+		if err != nil {
+			writeInternalError(w, err)
+			return
+		}
+		if item == nil || !s.requireItemVisible(w, r, workspaceID, item) {
+			// requireItemVisible already wrote a 404 on its denial path.
+			// Two cases land us here: the item was hard-deleted out from
+			// under us (item == nil) or the user can't see it.
+			if item == nil {
+				writeError(w, http.StatusNotFound, "not_found", "Attachment not found")
+			}
+			return
+		}
+	} else {
+		// Orphan attachments (item_id IS NULL) are not associated with
+		// any collection, so collection-level visibility doesn't apply.
+		// Restricted members shouldn't reach here because the LIST
+		// endpoint hides orphans from them, but a direct DELETE with a
+		// guessed UUID could — gate orphans on full-access editors.
+		if fullCollIDs, grantedItemIDs, gErr := s.guestResourceFilter(r, workspaceID); gErr != nil {
+			writeInternalError(w, gErr)
+			return
+		} else if fullCollIDs != nil || grantedItemIDs != nil {
+			writeError(w, http.StatusNotFound, "not_found", "Attachment not found")
+			return
+		}
 	}
 
 	if err := s.store.SoftDeleteAttachment(id); err != nil {

--- a/internal/server/handlers_storage_test.go
+++ b/internal/server/handlers_storage_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/PerpetualSoftware/pad/internal/models"
 	"github.com/PerpetualSoftware/pad/internal/store"
 )
 
@@ -112,6 +113,258 @@ func TestStorageUsage_RejectsGuests(t *testing.T) {
 	if rr.Code != http.StatusForbidden {
 		t.Fatalf("guest got status %d, want 403; body=%s", rr.Code, rr.Body.String())
 	}
+}
+
+// TestListAttachments_Pagination covers list + paginate + sort ordering.
+// Uploads three blobs of distinct sizes and verifies:
+//   - default sort is created_at DESC (newest first)
+//   - sort=size ascends from smallest
+//   - limit + offset paginate correctly with the right total count
+func TestListAttachments_Pagination(t *testing.T) {
+	srv, slug := testServerWithAttachments(t)
+
+	// Three uploads. realPNG is the only stdlib-decodable shape we
+	// have; pad each one with a different number of trailing bytes
+	// after the IEND chunk so the size_bytes column varies. The
+	// upload handler doesn't re-validate after the IEND — extra
+	// trailing bytes are stored verbatim, which suits the test fine.
+	base := realPNG()
+	mkBody := func(extra int) []byte {
+		out := make([]byte, len(base)+extra)
+		copy(out, base)
+		return out
+	}
+	doMultipartUpload(srv, slug, "small.png", mkBody(0))
+	doMultipartUpload(srv, slug, "medium.png", mkBody(100))
+	doMultipartUpload(srv, slug, "large.png", mkBody(1000))
+
+	rr := doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/attachments", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		Attachments []struct {
+			Filename  string `json:"filename"`
+			SizeBytes int64  `json:"size_bytes"`
+		} `json:"attachments"`
+		Total  int `json:"total"`
+		Limit  int `json:"limit"`
+		Offset int `json:"offset"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v body=%s", err, rr.Body.String())
+	}
+	if resp.Total != 3 {
+		t.Errorf("total = %d, want 3", resp.Total)
+	}
+	if len(resp.Attachments) != 3 {
+		t.Fatalf("got %d rows, want 3", len(resp.Attachments))
+	}
+	// Default created_at DESC. Three uploads in the same millisecond
+	// can land with the same timestamp, so we don't pin the order —
+	// just assert all three filenames are present in the page. The
+	// sort=size assertion below covers the ordered case.
+	gotFilenames := map[string]bool{}
+	for _, a := range resp.Attachments {
+		gotFilenames[a.Filename] = true
+	}
+	for _, want := range []string{"small.png", "medium.png", "large.png"} {
+		if !gotFilenames[want] {
+			t.Errorf("default sort: missing filename %q in result", want)
+		}
+	}
+
+	// Ascending size sort.
+	rr = doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/attachments?sort=size", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("sort=size status = %d", rr.Code)
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Attachments[0].Filename != "small.png" || resp.Attachments[2].Filename != "large.png" {
+		t.Errorf("sort=size order: %q,%q,%q want small,medium,large",
+			resp.Attachments[0].Filename, resp.Attachments[1].Filename, resp.Attachments[2].Filename)
+	}
+
+	// Pagination: limit=2, offset=2 → only 1 row.
+	rr = doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/attachments?limit=2&offset=2", nil)
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Total != 3 {
+		t.Errorf("total stays 3 across pages, got %d", resp.Total)
+	}
+	if len(resp.Attachments) != 1 {
+		t.Errorf("limit=2 offset=2: got %d rows, want 1", len(resp.Attachments))
+	}
+	if resp.Limit != 2 || resp.Offset != 2 {
+		t.Errorf("echoed limit/offset = %d/%d, want 2/2", resp.Limit, resp.Offset)
+	}
+}
+
+// TestListAttachments_HidesDerived asserts that thumbnail rows
+// (parent_id != NULL) don't show up in the list. They count toward
+// quota but are managed automatically — surfacing them clutters the
+// settings page with rows the user didn't upload.
+//
+// We synthesize a thumbnail row directly via the store rather than
+// running the real thumbnail pipeline, which would require a decodable
+// image the pure-Go processor accepts.
+func TestListAttachments_HidesDerived(t *testing.T) {
+	srv, slug := testServerWithAttachments(t)
+	wsID := workspaceIDForSlug(t, srv, slug)
+
+	if rr := doMultipartUpload(srv, slug, "original.png", realPNG()); rr.Code != http.StatusCreated {
+		t.Fatalf("upload: %d", rr.Code)
+	}
+
+	// Insert a synthetic thumbnail row pointing at the original.
+	// The handler should skip it because parent_id IS NOT NULL.
+	originalID := getOnlyAttachmentID(t, srv, wsID)
+	thumbVariant := "thumb-sm"
+	if err := srv.store.CreateAttachment(&models.Attachment{
+		WorkspaceID: wsID,
+		UploadedBy:  "system",
+		StorageKey:  "fs:fakehash",
+		ContentHash: "fakehash",
+		MimeType:    "image/png",
+		SizeBytes:   123,
+		Filename:    "original-thumb-sm.png",
+		ParentID:    &originalID,
+		Variant:     &thumbVariant,
+	}); err != nil {
+		t.Fatalf("CreateAttachment(thumb): %v", err)
+	}
+
+	rr := doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/attachments", nil)
+	var resp struct {
+		Attachments []struct{ ID string } `json:"attachments"`
+		Total       int                   `json:"total"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Total != 1 {
+		t.Errorf("total = %d, want 1 (derived thumbnail must be hidden)", resp.Total)
+	}
+}
+
+// TestDeleteAttachment_HappyPath covers the soft-delete flow: a
+// successful upload, a 204 from the delete handler, and a follow-up
+// list call that no longer sees the row. Storage usage drops to 0
+// confirming the cache invalidation hook fires.
+func TestDeleteAttachment_HappyPath(t *testing.T) {
+	srv, slug := testServerWithAttachments(t)
+	body := realPNG()
+
+	rr := doMultipartUpload(srv, slug, "victim.png", body)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("upload: %d %s", rr.Code, rr.Body.String())
+	}
+	var upload struct{ ID string }
+	if err := json.Unmarshal(rr.Body.Bytes(), &upload); err != nil {
+		t.Fatalf("decode upload: %v", err)
+	}
+
+	rr = doRequest(srv, "DELETE", "/api/v1/workspaces/"+slug+"/attachments/"+upload.ID, nil)
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("delete: status=%d body=%s", rr.Code, rr.Body.String())
+	}
+
+	// List should be empty now.
+	rr = doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/attachments", nil)
+	var listResp struct {
+		Total int `json:"total"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &listResp); err != nil {
+		t.Fatalf("decode list: %v", err)
+	}
+	if listResp.Total != 0 {
+		t.Errorf("after delete: total = %d, want 0", listResp.Total)
+	}
+
+	// Storage usage drops to 0 (cache was invalidated).
+	rr = doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/storage/usage", nil)
+	var usage storageUsageResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &usage); err != nil {
+		t.Fatalf("decode usage: %v", err)
+	}
+	if usage.UsedBytes != 0 {
+		t.Errorf("after delete: used_bytes = %d, want 0", usage.UsedBytes)
+	}
+
+	// Second delete → 404 (already tombstoned).
+	rr = doRequest(srv, "DELETE", "/api/v1/workspaces/"+slug+"/attachments/"+upload.ID, nil)
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("second delete: status=%d, want 404", rr.Code)
+	}
+}
+
+// TestDeleteAttachment_DerivedRefused pins the carve-out for thumbnail
+// rows: a direct delete of a derived attachment should return 400
+// rather than silently succeed (which would leave the original
+// without thumbnails until a regenerate job runs).
+func TestDeleteAttachment_DerivedRefused(t *testing.T) {
+	srv, slug := testServerWithAttachments(t)
+	wsID := workspaceIDForSlug(t, srv, slug)
+
+	if rr := doMultipartUpload(srv, slug, "x.png", realPNG()); rr.Code != http.StatusCreated {
+		t.Fatalf("upload: %d", rr.Code)
+	}
+	originalID := getOnlyAttachmentID(t, srv, wsID)
+
+	thumbVariant := "thumb-sm"
+	thumb := &models.Attachment{
+		WorkspaceID: wsID,
+		UploadedBy:  "system",
+		StorageKey:  "fs:fakehash2",
+		ContentHash: "fakehash2",
+		MimeType:    "image/png",
+		SizeBytes:   1,
+		Filename:    "x-thumb-sm.png",
+		ParentID:    &originalID,
+		Variant:     &thumbVariant,
+	}
+	if err := srv.store.CreateAttachment(thumb); err != nil {
+		t.Fatalf("CreateAttachment(thumb): %v", err)
+	}
+
+	rr := doRequest(srv, "DELETE", "/api/v1/workspaces/"+slug+"/attachments/"+thumb.ID, nil)
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("delete derived: status=%d, want 400", rr.Code)
+	}
+}
+
+// getOnlyAttachmentID returns the ID of the single live attachment
+// row in a workspace — the test infrastructure uploads at most one
+// blob per call, so this lookup is deterministic. Fails the test if
+// zero or multiple rows are live.
+func getOnlyAttachmentID(t *testing.T, srv *Server, workspaceID string) string {
+	t.Helper()
+	rows, _, err := srv.store.WorkspaceAttachments(workspaceID, store.AttachmentListFilters{})
+	if err != nil {
+		t.Fatalf("WorkspaceAttachments: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected exactly 1 attachment, got %d", len(rows))
+	}
+	return rows[0].ID
+}
+
+// workspaceIDForSlug looks up the internal UUID for a slug — used
+// by tests that synthesize attachment rows directly via the store
+// (bypassing the upload handler).
+func workspaceIDForSlug(t *testing.T, srv *Server, slug string) string {
+	t.Helper()
+	ws, err := srv.store.GetWorkspaceBySlug(slug)
+	if err != nil {
+		t.Fatalf("GetWorkspaceBySlug(%q): %v", slug, err)
+	}
+	if ws == nil {
+		t.Fatalf("workspace %q not found", slug)
+	}
+	return ws.ID
 }
 
 // TestStorageInfoCache covers the in-memory cache directly so the TTL +

--- a/internal/server/handlers_storage_test.go
+++ b/internal/server/handlers_storage_test.go
@@ -301,6 +301,73 @@ func TestDeleteAttachment_HappyPath(t *testing.T) {
 	}
 }
 
+// TestDeleteAttachment_AfterParentSoftDeleted pins Codex P2 from
+// PR #303 round 3: when the parent item is soft-deleted, the
+// attachment row remains in the storage list (so the user can see
+// it's still consuming quota), and the Delete button must work.
+//
+// The earlier draft used GetItem which filters out soft-deleted
+// items, so the handler returned 404 before ever calling
+// SoftDeleteAttachment. This test creates an item, attaches a row,
+// soft-deletes the item, and then exercises the delete endpoint.
+func TestDeleteAttachment_AfterParentSoftDeleted(t *testing.T) {
+	srv, slug := testServerWithAttachments(t)
+	wsID := workspaceIDForSlug(t, srv, slug)
+
+	// Create a real item so the attachment has a parent. Use the
+	// docs collection (preseeded by the workspace template).
+	rr := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections/docs/items",
+		map[string]any{"title": "Doomed", "content": "x"})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create item: %d %s", rr.Code, rr.Body.String())
+	}
+	var item struct{ ID string }
+	if err := json.Unmarshal(rr.Body.Bytes(), &item); err != nil {
+		t.Fatalf("decode item: %v", err)
+	}
+
+	// Attach a row to the item directly via the store — easier than
+	// orchestrating an upload + association sequence.
+	att := &models.Attachment{
+		WorkspaceID: wsID,
+		ItemID:      &item.ID,
+		UploadedBy:  "system",
+		StorageKey:  "fs:" + "x",
+		ContentHash: "fakehash3",
+		MimeType:    "image/png",
+		SizeBytes:   123,
+		Filename:    "doomed.png",
+	}
+	if err := srv.store.CreateAttachment(att); err != nil {
+		t.Fatalf("CreateAttachment: %v", err)
+	}
+
+	// Soft-delete the parent item.
+	rr = doRequest(srv, "DELETE", "/api/v1/workspaces/"+slug+"/items/"+item.ID, nil)
+	if rr.Code != http.StatusNoContent && rr.Code != http.StatusOK {
+		t.Fatalf("soft-delete item: %d %s", rr.Code, rr.Body.String())
+	}
+
+	// Attachment should still be visible in the storage list.
+	rr = doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/attachments", nil)
+	var resp struct {
+		Total       int                        `json:"total"`
+		Attachments []store.AttachmentListItem `json:"attachments"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode list: %v", err)
+	}
+	if resp.Total != 1 {
+		t.Errorf("after soft-delete: total=%d, want 1 (attachment must remain visible)", resp.Total)
+	}
+
+	// Delete must succeed despite the parent item being soft-deleted.
+	rr = doRequest(srv, "DELETE", "/api/v1/workspaces/"+slug+"/attachments/"+att.ID, nil)
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("delete after parent soft-delete: status=%d body=%s", rr.Code, rr.Body.String())
+	}
+}
+
 // TestDeleteAttachment_DerivedRefused pins the carve-out for thumbnail
 // rows: a direct delete of a derived attachment should return 400
 // rather than silently succeed (which would leave the original

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -731,9 +731,11 @@ func (s *Server) setupRouter() {
 					// path on HEAD; http.ServeContent already strips the body
 					// on the seekable path.
 					r.Post("/attachments", s.handleUploadAttachment)
+					r.Get("/attachments", s.handleListWorkspaceAttachments)
 					r.Get("/attachments/{attachmentID}", s.handleGetAttachment)
 					r.Head("/attachments/{attachmentID}", s.handleGetAttachment)
 					r.Post("/attachments/{attachmentID}/transform", s.handleTransformAttachment)
+					r.Delete("/attachments/{attachmentID}", s.handleDeleteWorkspaceAttachment)
 
 					// Storage usage summary for Settings → Storage and other
 					// quota-aware UI surfaces (TASK-881). Cached behind a

--- a/internal/store/attachments.go
+++ b/internal/store/attachments.go
@@ -135,9 +135,9 @@ func (s *Store) GetAttachmentVariant(parentID, variant string) (*models.Attachme
 type AttachmentListFilters struct {
 	// MimeCategory restricts to a single MIME category bucket
 	// (matches attachments.Category — "image", "document", etc.).
-	// Empty = all categories. Translated to a MIME-prefix LIKE clause
-	// because the attachments table only stores the raw MIME, not a
-	// pre-classified category column.
+	// Empty = all categories. Translated to MIME predicates per
+	// mimePredicateForCategory; categories without a clean prefix
+	// (document, text, archive, other) use an explicit IN list.
 	MimeCategory string
 
 	// Attached restricts to attachments associated with an item.
@@ -161,16 +161,32 @@ type AttachmentListFilters struct {
 	// Offset pages forward. Combined with Limit + Total for the UI's
 	// classic page navigator. Negative values clamped to 0.
 	Offset int
+
+	// VisibleCollectionIDs enforces collection-level access control:
+	// when non-nil, only attachments whose parent item belongs to one
+	// of these collections are returned, plus any orphans (item_id IS
+	// NULL) ARE EXCLUDED so a restricted member can't enumerate
+	// filenames from collections they shouldn't see.
+	//
+	// nil  → no filter (admin / unrestricted member)
+	// []   → empty filter (member with zero visible collections;
+	//         result set is always empty)
+	// [...] → restrict to listed collection IDs only.
+	VisibleCollectionIDs []string
 }
 
 // AttachmentListItem is a row from WorkspaceAttachments enriched with
-// the parent item's title + ref + collection slug so the UI can render
+// the parent item's title + slug + collection slug so the UI can render
 // a clickable link without a follow-up GET. Item fields are nullable
 // for orphan rows.
+//
+// URL construction: the item route is /{user}/{ws}/{collection_slug}/{item_slug},
+// so the UI uses ItemSlug — never a synthetic "TASK-5"-style ref. The
+// ref shape isn't 1:1 with the route, and exposing it here led to a
+// double-collection-slug bug in an earlier draft.
 type AttachmentListItem struct {
 	models.Attachment
 	ItemTitle      *string `json:"item_title,omitempty"`
-	ItemRef        *string `json:"item_ref,omitempty"` // "TASK-5" form
 	ItemSlug       *string `json:"item_slug,omitempty"`
 	CollectionSlug *string `json:"collection_slug,omitempty"`
 }
@@ -187,20 +203,101 @@ var allowedAttachmentSorts = map[string]string{
 	"created_at_desc": "a.created_at DESC",
 }
 
-// mimePrefixForCategory maps an attachments.Category value to the
-// SQL LIKE prefix that selects all MIMEs in that bucket. Used by the
-// list filter — kept here next to the SQL it generates so the mapping
-// stays close to the storage layer that consumes it.
-func mimePrefixForCategory(category string) (prefix string, ok bool) {
+// mimePredicateForCategory maps an attachments.Category value to a
+// SQL fragment + matching argument list that selects all MIMEs in
+// that bucket. Categories with a clean type prefix (image/, video/,
+// audio/) use a LIKE; the rest use an explicit IN list mirroring
+// the entries in internal/attachments/mime.go.
+//
+// Returns (frag, args, true) when the category is known. The frag
+// uses ? placeholders that the caller splices into the WHERE. ok=false
+// for unknown categories — caller must skip the filter so the UI
+// shows everything rather than zero rows for typos.
+//
+// Keep the literal MIME lists in lockstep with internal/attachments/
+// mime.go: any time a new MIME is added to the allowlist there, mirror
+// it here so the Settings → Storage filter stays useful.
+func mimePredicateForCategory(category string) (frag string, args []any, ok bool) {
 	switch category {
 	case "image":
-		return "image/%", true
+		return "a.mime_type LIKE ?", []any{"image/%"}, true
 	case "video":
-		return "video/%", true
+		return "a.mime_type LIKE ?", []any{"video/%"}, true
 	case "audio":
-		return "audio/%", true
+		return "a.mime_type LIKE ?", []any{"audio/%"}, true
+	case "document":
+		return mimeInPredicate([]string{
+			"application/pdf",
+			"application/msword",
+			"application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+			"application/vnd.ms-excel",
+			"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+			"application/vnd.ms-powerpoint",
+			"application/vnd.openxmlformats-officedocument.presentationml.presentation",
+			"application/vnd.oasis.opendocument.text",
+			"application/vnd.oasis.opendocument.spreadsheet",
+			"application/vnd.oasis.opendocument.presentation",
+			"application/rtf",
+		})
+	case "text":
+		return mimeInPredicate([]string{
+			"text/plain", "text/markdown", "text/csv", "text/tab-separated-values",
+			"application/json", "application/xml", "text/xml",
+			"application/yaml", "text/yaml", "application/toml",
+			"text/html", "text/javascript", "application/javascript",
+		})
+	case "archive":
+		return mimeInPredicate([]string{
+			"application/zip", "application/x-tar", "application/gzip",
+			"application/x-bzip2", "application/x-7z-compressed",
+		})
+	case "other":
+		// "Other" is the negation of every named bucket. Easier to
+		// build by exclusion: NOT in the union of all known MIMEs.
+		// Listing the categories explicitly keeps this in lockstep
+		// with the named buckets above without a second source of
+		// truth.
+		all := []string{
+			"application/pdf", "application/msword",
+			"application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+			"application/vnd.ms-excel",
+			"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+			"application/vnd.ms-powerpoint",
+			"application/vnd.openxmlformats-officedocument.presentationml.presentation",
+			"application/vnd.oasis.opendocument.text",
+			"application/vnd.oasis.opendocument.spreadsheet",
+			"application/vnd.oasis.opendocument.presentation",
+			"application/rtf",
+			"text/plain", "text/markdown", "text/csv", "text/tab-separated-values",
+			"application/json", "application/xml", "text/xml",
+			"application/yaml", "text/yaml", "application/toml",
+			"text/html", "text/javascript", "application/javascript",
+			"application/zip", "application/x-tar", "application/gzip",
+			"application/x-bzip2", "application/x-7z-compressed",
+		}
+		placeholders := make([]string, len(all))
+		args := make([]any, len(all))
+		for i, m := range all {
+			placeholders[i] = "?"
+			args[i] = m
+		}
+		frag := "a.mime_type NOT LIKE 'image/%' AND a.mime_type NOT LIKE 'video/%' AND a.mime_type NOT LIKE 'audio/%' AND a.mime_type NOT IN (" + strings.Join(placeholders, ",") + ")"
+		return frag, args, true
 	}
-	return "", false
+	return "", nil, false
+}
+
+// mimeInPredicate builds a `a.mime_type IN (?,?,...)` fragment with
+// matching args. Helper used by mimePredicateForCategory for the
+// non-prefix categories.
+func mimeInPredicate(mimes []string) (string, []any, bool) {
+	placeholders := make([]string, len(mimes))
+	args := make([]any, len(mimes))
+	for i, m := range mimes {
+		placeholders[i] = "?"
+		args[i] = m
+	}
+	return "a.mime_type IN (" + strings.Join(placeholders, ",") + ")", args, true
 }
 
 // WorkspaceAttachments lists original (non-derived) attachments in a
@@ -239,13 +336,32 @@ func (s *Store) WorkspaceAttachments(workspaceID string, filters AttachmentListF
 	if filters.Unattached {
 		conds = append(conds, "a.item_id IS NULL")
 	}
-	if prefix, ok := mimePrefixForCategory(filters.MimeCategory); ok {
-		conds = append(conds, "a.mime_type LIKE ?")
-		args = append(args, prefix)
+	if frag, mimeArgs, ok := mimePredicateForCategory(filters.MimeCategory); ok {
+		conds = append(conds, frag)
+		args = append(args, mimeArgs...)
 	}
 	if filters.CollectionID != "" {
 		conds = append(conds, "i.collection_id = ?")
 		args = append(args, filters.CollectionID)
+	}
+
+	// Collection-level visibility enforcement. Restricts the result to
+	// attachments whose parent item lives in a visible collection;
+	// orphans (item_id IS NULL) are excluded so a restricted member
+	// can't enumerate filenames from collections they shouldn't see.
+	// nil  → admin / no restriction; empty slice → user has zero
+	// visible collections, query yields zero rows by design.
+	if filters.VisibleCollectionIDs != nil {
+		if len(filters.VisibleCollectionIDs) == 0 {
+			conds = append(conds, "1 = 0")
+		} else {
+			placeholders := make([]string, len(filters.VisibleCollectionIDs))
+			for i := range filters.VisibleCollectionIDs {
+				placeholders[i] = "?"
+				args = append(args, filters.VisibleCollectionIDs[i])
+			}
+			conds = append(conds, "i.collection_id IN ("+strings.Join(placeholders, ",")+")")
+		}
 	}
 
 	where := strings.Join(conds, " AND ")
@@ -285,7 +401,7 @@ func (s *Store) WorkspaceAttachments(workspaceID string, filters AttachmentListF
 
 	q := `
 		SELECT ` + aliasedAttachmentColumns + `,
-		       i.title, i.slug, i.item_number,
+		       i.title, i.slug,
 		       c.slug, c.name
 		FROM attachments a
 		LEFT JOIN items i       ON i.id = a.item_id AND i.deleted_at IS NULL
@@ -310,14 +426,13 @@ func (s *Store) WorkspaceAttachments(workspaceID string, filters AttachmentListF
 
 		// Item + collection columns from the LEFT JOIN. All nullable.
 		var itemTitle, itemSlug *string
-		var itemNumber *int
 		var collSlug, collName *string
 
 		if err := rows.Scan(
 			&a.ID, &a.WorkspaceID, &itemID, &a.UploadedBy, &a.StorageKey, &a.ContentHash,
 			&a.MimeType, &a.SizeBytes, &a.Filename, &width, &height,
 			&parentID, &variant, &createdAt, &deletedAt,
-			&itemTitle, &itemSlug, &itemNumber,
+			&itemTitle, &itemSlug,
 			&collSlug, &collName,
 		); err != nil {
 			return nil, 0, fmt.Errorf("scan workspace attachment: %w", err)
@@ -339,15 +454,6 @@ func (s *Store) WorkspaceAttachments(workspaceID string, filters AttachmentListF
 		}
 		if collSlug != nil {
 			row.CollectionSlug = collSlug
-		}
-		// Compose ref like "TASK-5" when we have both pieces.
-		// collection.name uppercased + first 5 letters → ref prefix
-		// is non-trivial (it's stored elsewhere), so the UI builds
-		// the display label from item_title + collection_slug. We
-		// surface item_number as the ref so URL building is direct.
-		if itemNumber != nil && collSlug != nil {
-			ref := fmt.Sprintf("%s/%d", *collSlug, *itemNumber)
-			row.ItemRef = &ref
 		}
 		out = append(out, row)
 	}

--- a/internal/store/attachments.go
+++ b/internal/store/attachments.go
@@ -192,10 +192,16 @@ type AttachmentListFilters struct {
 // so the UI uses ItemSlug — never a synthetic "TASK-5"-style ref. The
 // ref shape isn't 1:1 with the route, and exposing it here led to a
 // double-collection-slug bug in an earlier draft.
+//
+// ItemDeleted is true when the parent item exists but has been soft-
+// deleted. The row is still surfaced because the bytes still consume
+// quota; the UI uses the flag to render "(deleted)" instead of a
+// clickable link to a 404'd item.
 type AttachmentListItem struct {
 	models.Attachment
 	ItemTitle      *string `json:"item_title,omitempty"`
 	ItemSlug       *string `json:"item_slug,omitempty"`
+	ItemDeleted    bool    `json:"item_deleted,omitempty"`
 	CollectionSlug *string `json:"collection_slug,omitempty"`
 }
 
@@ -391,10 +397,17 @@ func (s *Store) WorkspaceAttachments(workspaceID string, filters AttachmentListF
 
 	// Count total before applying limit/offset so the UI can render
 	// "showing 1–25 of 312".
+	//
+	// The items LEFT JOIN intentionally does NOT filter on
+	// items.deleted_at — attachments survive a soft-deleted parent
+	// (they still consume quota), so the storage list must surface
+	// them and the collection-level visibility predicate
+	// (i.collection_id IN ...) must keep working. The handler's
+	// delete path uses GetItemIncludeDeleted for the same reason.
 	var total int
 	if err := s.db.QueryRow(s.q(`
 		SELECT COUNT(*) FROM attachments a
-		LEFT JOIN items i ON i.id = a.item_id AND i.deleted_at IS NULL
+		LEFT JOIN items i ON i.id = a.item_id
 		WHERE `+where), args...).Scan(&total); err != nil {
 		return nil, 0, fmt.Errorf("count workspace attachments: %w", err)
 	}
@@ -422,12 +435,18 @@ func (s *Store) WorkspaceAttachments(workspaceID string, filters AttachmentListF
 	const aliasedAttachmentColumns = `a.id, a.workspace_id, a.item_id, a.uploaded_by, a.storage_key, a.content_hash,
 		a.mime_type, a.size_bytes, a.filename, a.width, a.height, a.parent_id, a.variant, a.created_at, a.deleted_at`
 
+	// Same rationale as the count query above: include soft-deleted
+	// parent items so the row is still visible for users who would
+	// be allowed to see the live item, and so the collection-level
+	// ACL predicate sees a non-NULL i.collection_id. The response
+	// surfaces deleted_at on the joined item via item_deleted so the
+	// UI can render a "(deleted)" tag instead of a clickable link.
 	q := `
 		SELECT ` + aliasedAttachmentColumns + `,
-		       i.title, i.slug,
+		       i.title, i.slug, i.deleted_at,
 		       c.slug, c.name
 		FROM attachments a
-		LEFT JOIN items i       ON i.id = a.item_id AND i.deleted_at IS NULL
+		LEFT JOIN items i       ON i.id = a.item_id
 		LEFT JOIN collections c ON c.id = i.collection_id
 		WHERE ` + where + `
 		ORDER BY ` + orderBy + `
@@ -448,14 +467,14 @@ func (s *Store) WorkspaceAttachments(workspaceID string, filters AttachmentListF
 		var createdAt string
 
 		// Item + collection columns from the LEFT JOIN. All nullable.
-		var itemTitle, itemSlug *string
+		var itemTitle, itemSlug, itemDeletedAt *string
 		var collSlug, collName *string
 
 		if err := rows.Scan(
 			&a.ID, &a.WorkspaceID, &itemID, &a.UploadedBy, &a.StorageKey, &a.ContentHash,
 			&a.MimeType, &a.SizeBytes, &a.Filename, &width, &height,
 			&parentID, &variant, &createdAt, &deletedAt,
-			&itemTitle, &itemSlug,
+			&itemTitle, &itemSlug, &itemDeletedAt,
 			&collSlug, &collName,
 		); err != nil {
 			return nil, 0, fmt.Errorf("scan workspace attachment: %w", err)
@@ -474,6 +493,9 @@ func (s *Store) WorkspaceAttachments(workspaceID string, filters AttachmentListF
 		}
 		if itemSlug != nil {
 			row.ItemSlug = itemSlug
+		}
+		if itemDeletedAt != nil && *itemDeletedAt != "" {
+			row.ItemDeleted = true
 		}
 		if collSlug != nil {
 			row.CollectionSlug = collSlug

--- a/internal/store/attachments.go
+++ b/internal/store/attachments.go
@@ -162,17 +162,25 @@ type AttachmentListFilters struct {
 	// classic page navigator. Negative values clamped to 0.
 	Offset int
 
-	// VisibleCollectionIDs enforces collection-level access control:
-	// when non-nil, only attachments whose parent item belongs to one
-	// of these collections are returned, plus any orphans (item_id IS
-	// NULL) ARE EXCLUDED so a restricted member can't enumerate
-	// filenames from collections they shouldn't see.
+	// Restricted, FullCollectionIDs, GrantedItemIDs together encode
+	// per-user collection + item visibility. When Restricted is true
+	// the list filters to attachments whose parent item is either
+	// in one of FullCollectionIDs or has its id in GrantedItemIDs.
+	// Orphans (item_id IS NULL) are excluded from restricted views
+	// so a member who only sees one collection can't enumerate
+	// filenames of unattached uploads from collections they don't
+	// have access to.
 	//
-	// nil  → no filter (admin / unrestricted member)
-	// []   → empty filter (member with zero visible collections;
-	//         result set is always empty)
-	// [...] → restrict to listed collection IDs only.
-	VisibleCollectionIDs []string
+	// Restricted=false → no filter (admin / full-access member).
+	// Restricted=true with empty Full+Granted → zero rows.
+	// Restricted=true with one or both populated → SQL OR of the
+	//   two predicates.
+	//
+	// Mirrors the (fullCollIDs, grantedItemIDs) tuple returned by
+	// Server.guestResourceFilter — keep the semantics in sync.
+	Restricted        bool
+	FullCollectionIDs []string
+	GrantedItemIDs    []string
 }
 
 // AttachmentListItem is a row from WorkspaceAttachments enriched with
@@ -345,22 +353,37 @@ func (s *Store) WorkspaceAttachments(workspaceID string, filters AttachmentListF
 		args = append(args, filters.CollectionID)
 	}
 
-	// Collection-level visibility enforcement. Restricts the result to
-	// attachments whose parent item lives in a visible collection;
-	// orphans (item_id IS NULL) are excluded so a restricted member
-	// can't enumerate filenames from collections they shouldn't see.
-	// nil  → admin / no restriction; empty slice → user has zero
-	// visible collections, query yields zero rows by design.
-	if filters.VisibleCollectionIDs != nil {
-		if len(filters.VisibleCollectionIDs) == 0 {
+	// Collection + item-level visibility enforcement. Two sources of
+	// access: collections the user can see in full (FullCollectionIDs)
+	// and individual items granted to them (GrantedItemIDs). The
+	// predicate ORs them so an item-grant in a hidden collection still
+	// resolves; orphans (item_id IS NULL) are excluded entirely so a
+	// restricted user can't enumerate orphan filenames.
+	//
+	// Restricted=false → no filter (admin / full-access member).
+	// Restricted=true with both lists empty → zero rows.
+	if filters.Restricted {
+		var ors []string
+		if len(filters.FullCollectionIDs) > 0 {
+			ph := make([]string, len(filters.FullCollectionIDs))
+			for i, id := range filters.FullCollectionIDs {
+				ph[i] = "?"
+				args = append(args, id)
+			}
+			ors = append(ors, "i.collection_id IN ("+strings.Join(ph, ",")+")")
+		}
+		if len(filters.GrantedItemIDs) > 0 {
+			ph := make([]string, len(filters.GrantedItemIDs))
+			for i, id := range filters.GrantedItemIDs {
+				ph[i] = "?"
+				args = append(args, id)
+			}
+			ors = append(ors, "a.item_id IN ("+strings.Join(ph, ",")+")")
+		}
+		if len(ors) == 0 {
 			conds = append(conds, "1 = 0")
 		} else {
-			placeholders := make([]string, len(filters.VisibleCollectionIDs))
-			for i := range filters.VisibleCollectionIDs {
-				placeholders[i] = "?"
-				args = append(args, filters.VisibleCollectionIDs[i])
-			}
-			conds = append(conds, "i.collection_id IN ("+strings.Join(placeholders, ",")+")")
+			conds = append(conds, "("+strings.Join(ors, " OR ")+")")
 		}
 	}
 

--- a/internal/store/attachments.go
+++ b/internal/store/attachments.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/PerpetualSoftware/pad/internal/models"
 )
@@ -125,6 +126,281 @@ func (s *Store) GetAttachmentVariant(parentID, variant string) (*models.Attachme
 		return nil, fmt.Errorf("get attachment variant: %w", err)
 	}
 	return a, nil
+}
+
+// AttachmentListFilters narrow the WorkspaceAttachments result set.
+// Zero values mean "no filter on this dimension". The handler turns
+// query-string parameters into this struct so the SQL builder stays
+// pure and unit-testable.
+type AttachmentListFilters struct {
+	// MimeCategory restricts to a single MIME category bucket
+	// (matches attachments.Category — "image", "document", etc.).
+	// Empty = all categories. Translated to a MIME-prefix LIKE clause
+	// because the attachments table only stores the raw MIME, not a
+	// pre-classified category column.
+	MimeCategory string
+
+	// Attached restricts to attachments associated with an item.
+	Attached bool
+
+	// Unattached restricts to orphan attachments (item_id IS NULL).
+	// Mutually exclusive with Attached — handler validates upstream.
+	Unattached bool
+
+	// CollectionID restricts to attachments belonging to items in
+	// this collection. Empty = no collection filter.
+	CollectionID string
+
+	// Sort field. Accepts "size", "filename", "created_at" with an
+	// optional " desc" suffix. Empty = "created_at desc" (newest first).
+	Sort string
+
+	// Limit caps the page size. Clamped to [1, 200] by the handler.
+	Limit int
+
+	// Offset pages forward. Combined with Limit + Total for the UI's
+	// classic page navigator. Negative values clamped to 0.
+	Offset int
+}
+
+// AttachmentListItem is a row from WorkspaceAttachments enriched with
+// the parent item's title + ref + collection slug so the UI can render
+// a clickable link without a follow-up GET. Item fields are nullable
+// for orphan rows.
+type AttachmentListItem struct {
+	models.Attachment
+	ItemTitle      *string `json:"item_title,omitempty"`
+	ItemRef        *string `json:"item_ref,omitempty"` // "TASK-5" form
+	ItemSlug       *string `json:"item_slug,omitempty"`
+	CollectionSlug *string `json:"collection_slug,omitempty"`
+}
+
+// allowedAttachmentSorts pins the columns + directions the list
+// endpoint accepts, so a hand-crafted sort= query can't smuggle in
+// arbitrary SQL. Map values are the literal SQL fragment we splice in.
+var allowedAttachmentSorts = map[string]string{
+	"size":            "a.size_bytes ASC",
+	"size_desc":       "a.size_bytes DESC",
+	"filename":        "a.filename ASC",
+	"filename_desc":   "a.filename DESC",
+	"created_at":      "a.created_at ASC",
+	"created_at_desc": "a.created_at DESC",
+}
+
+// mimePrefixForCategory maps an attachments.Category value to the
+// SQL LIKE prefix that selects all MIMEs in that bucket. Used by the
+// list filter — kept here next to the SQL it generates so the mapping
+// stays close to the storage layer that consumes it.
+func mimePrefixForCategory(category string) (prefix string, ok bool) {
+	switch category {
+	case "image":
+		return "image/%", true
+	case "video":
+		return "video/%", true
+	case "audio":
+		return "audio/%", true
+	}
+	return "", false
+}
+
+// WorkspaceAttachments lists original (non-derived) attachments in a
+// workspace, with optional filtering + sorting + pagination. Returns
+// the page rows and the total count of matching rows so the UI can
+// render a paginator without a second round-trip.
+//
+// Intentionally hides derived blobs (thumbnails — rows where
+// parent_id IS NOT NULL): they're managed automatically and showing
+// them in the list would clutter the page with rows the user didn't
+// upload. They still count against storage quota via
+// WorkspaceStorageUsage; the totals match the bar even when the list
+// shows only originals.
+//
+// LEFT JOIN to items + collections gives the UI everything it needs
+// to render an "in [[Task X]]" link. Soft-deleted items are returned
+// with item fields nulled out — the attachment is still visible
+// (a deleted item could still be restored), but the link target
+// isn't reachable.
+func (s *Store) WorkspaceAttachments(workspaceID string, filters AttachmentListFilters) ([]AttachmentListItem, int, error) {
+	// Build the WHERE clause incrementally. Every branch parameter
+	// goes through the placeholder slice — no string concatenation of
+	// user input. Sort is the only user-controllable splice and it
+	// goes through the allowedAttachmentSorts allowlist.
+	var conds []string
+	var args []any
+
+	conds = append(conds, "a.workspace_id = ?")
+	args = append(args, workspaceID)
+	conds = append(conds, "a.deleted_at IS NULL")
+	conds = append(conds, "a.parent_id IS NULL") // hide derived blobs
+
+	if filters.Attached {
+		conds = append(conds, "a.item_id IS NOT NULL")
+	}
+	if filters.Unattached {
+		conds = append(conds, "a.item_id IS NULL")
+	}
+	if prefix, ok := mimePrefixForCategory(filters.MimeCategory); ok {
+		conds = append(conds, "a.mime_type LIKE ?")
+		args = append(args, prefix)
+	}
+	if filters.CollectionID != "" {
+		conds = append(conds, "i.collection_id = ?")
+		args = append(args, filters.CollectionID)
+	}
+
+	where := strings.Join(conds, " AND ")
+
+	// Count total before applying limit/offset so the UI can render
+	// "showing 1–25 of 312".
+	var total int
+	if err := s.db.QueryRow(s.q(`
+		SELECT COUNT(*) FROM attachments a
+		LEFT JOIN items i ON i.id = a.item_id AND i.deleted_at IS NULL
+		WHERE `+where), args...).Scan(&total); err != nil {
+		return nil, 0, fmt.Errorf("count workspace attachments: %w", err)
+	}
+
+	orderBy, ok := allowedAttachmentSorts[filters.Sort]
+	if !ok {
+		orderBy = "a.created_at DESC" // sensible default — newest first
+	}
+
+	limit := filters.Limit
+	if limit <= 0 {
+		limit = 50
+	}
+	if limit > 200 {
+		limit = 200
+	}
+	offset := filters.Offset
+	if offset < 0 {
+		offset = 0
+	}
+
+	// Column list is the same as attachmentColumns but prefixed with
+	// `a.` so SQLite doesn't choke on the ambiguous `id` shared with
+	// the joined items table.
+	const aliasedAttachmentColumns = `a.id, a.workspace_id, a.item_id, a.uploaded_by, a.storage_key, a.content_hash,
+		a.mime_type, a.size_bytes, a.filename, a.width, a.height, a.parent_id, a.variant, a.created_at, a.deleted_at`
+
+	q := `
+		SELECT ` + aliasedAttachmentColumns + `,
+		       i.title, i.slug, i.item_number,
+		       c.slug, c.name
+		FROM attachments a
+		LEFT JOIN items i       ON i.id = a.item_id AND i.deleted_at IS NULL
+		LEFT JOIN collections c ON c.id = i.collection_id
+		WHERE ` + where + `
+		ORDER BY ` + orderBy + `
+		LIMIT ? OFFSET ?`
+
+	args = append(args, limit, offset)
+	rows, err := s.db.Query(s.q(q), args...)
+	if err != nil {
+		return nil, 0, fmt.Errorf("list workspace attachments: %w", err)
+	}
+	defer rows.Close()
+
+	var out []AttachmentListItem
+	for rows.Next() {
+		var a models.Attachment
+		var itemID, parentID, variant, deletedAt *string
+		var width, height *int
+		var createdAt string
+
+		// Item + collection columns from the LEFT JOIN. All nullable.
+		var itemTitle, itemSlug *string
+		var itemNumber *int
+		var collSlug, collName *string
+
+		if err := rows.Scan(
+			&a.ID, &a.WorkspaceID, &itemID, &a.UploadedBy, &a.StorageKey, &a.ContentHash,
+			&a.MimeType, &a.SizeBytes, &a.Filename, &width, &height,
+			&parentID, &variant, &createdAt, &deletedAt,
+			&itemTitle, &itemSlug, &itemNumber,
+			&collSlug, &collName,
+		); err != nil {
+			return nil, 0, fmt.Errorf("scan workspace attachment: %w", err)
+		}
+		a.ItemID = itemID
+		a.ParentID = parentID
+		a.Variant = variant
+		a.Width = width
+		a.Height = height
+		a.CreatedAt = parseTime(createdAt)
+		a.DeletedAt = parseTimePtr(deletedAt)
+
+		row := AttachmentListItem{Attachment: a}
+		if itemTitle != nil {
+			row.ItemTitle = itemTitle
+		}
+		if itemSlug != nil {
+			row.ItemSlug = itemSlug
+		}
+		if collSlug != nil {
+			row.CollectionSlug = collSlug
+		}
+		// Compose ref like "TASK-5" when we have both pieces.
+		// collection.name uppercased + first 5 letters → ref prefix
+		// is non-trivial (it's stored elsewhere), so the UI builds
+		// the display label from item_title + collection_slug. We
+		// surface item_number as the ref so URL building is direct.
+		if itemNumber != nil && collSlug != nil {
+			ref := fmt.Sprintf("%s/%d", *collSlug, *itemNumber)
+			row.ItemRef = &ref
+		}
+		out = append(out, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, 0, fmt.Errorf("iterate workspace attachments: %w", err)
+	}
+	return out, total, nil
+}
+
+// SoftDeleteAttachment marks the given attachment row deleted (and
+// every variant whose parent_id points at it) so the orphan GC will
+// reclaim the bytes after the grace period. Returns sql.ErrNoRows if
+// no live row matches.
+//
+// We mark variants via a separate UPDATE keyed on parent_id rather
+// than letting a foreign-key cascade do it — the attachments table
+// has no FK on parent_id, by design (DOC-865: thumbnails are
+// independent rows so a missing original doesn't break a list query).
+//
+// The blob on disk is NOT removed here; the same content_hash may be
+// referenced by other rows (content-addressed dedupe), so reclamation
+// is the GC's job once it can prove no live row references the hash.
+func (s *Store) SoftDeleteAttachment(id string) error {
+	ts := now()
+	res, err := s.db.Exec(s.q(`
+		UPDATE attachments
+		SET deleted_at = ?
+		WHERE id = ? AND deleted_at IS NULL
+	`), ts, id)
+	if err != nil {
+		return fmt.Errorf("soft delete attachment: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("soft delete attachment rows affected: %w", err)
+	}
+	if n == 0 {
+		return sql.ErrNoRows
+	}
+	// Also tombstone any thumbnail variants. They're synthetic rows
+	// derived from the original; without the original they have no
+	// reason to exist. Errors here are non-fatal — orphan GC will
+	// still reach them eventually via the deleted-parent path.
+	if _, err := s.db.Exec(s.q(`
+		UPDATE attachments
+		SET deleted_at = ?
+		WHERE parent_id = ? AND deleted_at IS NULL
+	`), ts, id); err != nil {
+		// Log via the caller; we don't have a logger here. The row
+		// went through, so don't fail the request.
+		return nil
+	}
+	return nil
 }
 
 // WorkspaceStorageUsage returns the total bytes consumed by non-deleted

--- a/internal/store/attachments_test.go
+++ b/internal/store/attachments_test.go
@@ -189,7 +189,8 @@ func TestWorkspaceAttachments_VisibilityFilter(t *testing.T) {
 
 	// Restricted to tasks only: see task-screenshot, hide secret + orphan.
 	rows, total, err = s.WorkspaceAttachments(wsID, AttachmentListFilters{
-		VisibleCollectionIDs: []string{collA},
+		Restricted:        true,
+		FullCollectionIDs: []string{collA},
 	})
 	if err != nil {
 		t.Fatalf("restricted list: %v", err)
@@ -201,9 +202,28 @@ func TestWorkspaceAttachments_VisibilityFilter(t *testing.T) {
 		t.Errorf("restricted: filename=%q, want task-screenshot.png", rows[0].Filename)
 	}
 
-	// Empty visibility (member with zero access) — zero rows.
+	// Item-level grant only: a restricted user with a single granted
+	// item in collB should see only that item's attachment, not the
+	// rest of collB's contents. Mirrors handlers_search's
+	// (fullCollIDs, grantedItemIDs) tuple.
 	rows, total, err = s.WorkspaceAttachments(wsID, AttachmentListFilters{
-		VisibleCollectionIDs: []string{},
+		Restricted:     true,
+		GrantedItemIDs: []string{itemB},
+	})
+	if err != nil {
+		t.Fatalf("item-grant list: %v", err)
+	}
+	if total != 1 || len(rows) != 1 {
+		t.Fatalf("item-grant: total=%d rows=%d, want 1/1", total, len(rows))
+	}
+	if rows[0].Filename != "secret-screenshot.png" {
+		t.Errorf("item-grant: filename=%q, want secret-screenshot.png", rows[0].Filename)
+	}
+
+	// Empty visibility (restricted with no collections + no item
+	// grants) — zero rows.
+	rows, total, err = s.WorkspaceAttachments(wsID, AttachmentListFilters{
+		Restricted: true,
 	})
 	if err != nil {
 		t.Fatalf("zero-visibility list: %v", err)

--- a/internal/store/attachments_test.go
+++ b/internal/store/attachments_test.go
@@ -233,6 +233,98 @@ func TestWorkspaceAttachments_VisibilityFilter(t *testing.T) {
 	}
 }
 
+// TestWorkspaceAttachments_SurfacesSoftDeletedParents pins Codex P2
+// from PR #303 round 4: an attachment whose parent item is soft-
+// deleted must remain in the list so the user can reclaim the
+// bytes, AND the collection-level visibility filter must still see
+// the (still-set) collection_id so restricted users with access to
+// that collection can find the attachment.
+//
+// Two assertions:
+//   - Full-access caller (Restricted=false) sees the row.
+//   - Restricted caller scoped to the right collection sees the row;
+//     restricted to a different collection does not.
+//   - The row carries item_deleted=true so the UI can render the
+//     "(deleted)" badge.
+func TestWorkspaceAttachments_SurfacesSoftDeletedParents(t *testing.T) {
+	s := testStore(t)
+
+	wsID := newID()
+	collA := newID()
+	collB := newID()
+	itemA := newID()
+	ts := time.Now().UTC().Format(time.RFC3339)
+	if _, err := s.db.Exec(s.q(`INSERT INTO workspaces (id, slug, name, settings, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?)`),
+		wsID, "ws", "WS", "{}", ts, ts); err != nil {
+		t.Fatalf("insert workspace: %v", err)
+	}
+	for _, c := range []struct{ id, slug, name string }{{collA, "tasks", "Tasks"}, {collB, "ideas", "Ideas"}} {
+		if _, err := s.db.Exec(s.q(`INSERT INTO collections (id, workspace_id, name, slug, schema, created_at, updated_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?)`),
+			c.id, wsID, c.name, c.slug, `{"fields":[]}`, ts, ts); err != nil {
+			t.Fatalf("insert collection: %v", err)
+		}
+	}
+	// Soft-deleted item — deleted_at is set.
+	if _, err := s.db.Exec(s.q(`INSERT INTO items (id, workspace_id, collection_id, title, slug, created_at, updated_at, deleted_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)`),
+		itemA, wsID, collA, "Doomed", "doomed", ts, ts, ts); err != nil {
+		t.Fatalf("insert deleted item: %v", err)
+	}
+	if err := s.CreateAttachment(&models.Attachment{
+		WorkspaceID: wsID,
+		ItemID:      &itemA,
+		UploadedBy:  "system",
+		StorageKey:  "fs:" + newID(),
+		ContentHash: newID(),
+		MimeType:    "image/png",
+		SizeBytes:   100,
+		Filename:    "doomed.png",
+	}); err != nil {
+		t.Fatalf("CreateAttachment: %v", err)
+	}
+
+	// 1. Admin / full-access sees the row + item_deleted flag.
+	rows, total, err := s.WorkspaceAttachments(wsID, AttachmentListFilters{})
+	if err != nil {
+		t.Fatalf("admin list: %v", err)
+	}
+	if total != 1 || len(rows) != 1 {
+		t.Fatalf("admin: total=%d rows=%d, want 1/1", total, len(rows))
+	}
+	if !rows[0].ItemDeleted {
+		t.Errorf("admin: ItemDeleted=false, want true (parent is soft-deleted)")
+	}
+	if rows[0].ItemTitle == nil || *rows[0].ItemTitle != "Doomed" {
+		t.Errorf("admin: item_title=%v, want Doomed (soft-deleted parent's title still surfaces)", rows[0].ItemTitle)
+	}
+
+	// 2. Restricted to collA sees the row.
+	rows, total, err = s.WorkspaceAttachments(wsID, AttachmentListFilters{
+		Restricted:        true,
+		FullCollectionIDs: []string{collA},
+	})
+	if err != nil {
+		t.Fatalf("restricted-collA list: %v", err)
+	}
+	if total != 1 || len(rows) != 1 {
+		t.Fatalf("restricted-collA: total=%d rows=%d, want 1/1", total, len(rows))
+	}
+
+	// 3. Restricted to collB does NOT see the row.
+	rows, total, err = s.WorkspaceAttachments(wsID, AttachmentListFilters{
+		Restricted:        true,
+		FullCollectionIDs: []string{collB},
+	})
+	if err != nil {
+		t.Fatalf("restricted-collB list: %v", err)
+	}
+	if total != 0 || len(rows) != 0 {
+		t.Errorf("restricted-collB: total=%d rows=%d, want 0/0", total, len(rows))
+	}
+}
+
 // TestWorkspaceAttachments_CategoryFilters covers the document/text/
 // archive/other filter buckets per Codex P2 from PR #303 round 1:
 // the earlier prefix-only mapping silently passed those filters

--- a/internal/store/attachments_test.go
+++ b/internal/store/attachments_test.go
@@ -121,6 +121,174 @@ func TestWorkspaceStorageInfo_FreePlanResolution(t *testing.T) {
 	}
 }
 
+// TestWorkspaceAttachments_VisibilityFilter verifies that
+// VisibleCollectionIDs gates the result set per Codex P1 from
+// PR #303 round 1: a restricted member must not see attachments
+// in collections they can't access, and orphans (item_id IS NULL)
+// must be hidden as well so filenames don't leak.
+func TestWorkspaceAttachments_VisibilityFilter(t *testing.T) {
+	s := testStore(t)
+
+	wsID := newID()
+	collA := newID()
+	collB := newID()
+	itemA := newID()
+	itemB := newID()
+	ts := time.Now().UTC().Format(time.RFC3339)
+	if _, err := s.db.Exec(s.q(`INSERT INTO workspaces (id, slug, name, settings, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?)`),
+		wsID, "ws", "WS", "{}", ts, ts); err != nil {
+		t.Fatalf("insert workspace: %v", err)
+	}
+	for _, c := range []struct{ id, slug, name string }{{collA, "tasks", "Tasks"}, {collB, "secrets", "Secrets"}} {
+		if _, err := s.db.Exec(s.q(`INSERT INTO collections (id, workspace_id, name, slug, schema, created_at, updated_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?)`),
+			c.id, wsID, c.name, c.slug, `{"fields":[]}`, ts, ts); err != nil {
+			t.Fatalf("insert collection %s: %v", c.slug, err)
+		}
+	}
+	mkItem := func(id, collID, slug, title string) {
+		t.Helper()
+		if _, err := s.db.Exec(s.q(`INSERT INTO items (id, workspace_id, collection_id, title, slug, created_at, updated_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?)`),
+			id, wsID, collID, title, slug, ts, ts); err != nil {
+			t.Fatalf("insert item: %v", err)
+		}
+	}
+	mkItem(itemA, collA, "task-1", "Task 1")
+	mkItem(itemB, collB, "secret-1", "Secret")
+
+	mkAttach := func(itemID *string, filename string) {
+		t.Helper()
+		a := &models.Attachment{
+			WorkspaceID: wsID,
+			ItemID:      itemID,
+			UploadedBy:  "system",
+			StorageKey:  "fs:" + newID(),
+			ContentHash: newID(),
+			MimeType:    "image/png",
+			SizeBytes:   100,
+			Filename:    filename,
+		}
+		if err := s.CreateAttachment(a); err != nil {
+			t.Fatalf("CreateAttachment: %v", err)
+		}
+	}
+	mkAttach(&itemA, "task-screenshot.png")
+	mkAttach(&itemB, "secret-screenshot.png")
+	mkAttach(nil, "orphan.png")
+
+	// Admin / unrestricted (nil) sees everything.
+	rows, total, err := s.WorkspaceAttachments(wsID, AttachmentListFilters{})
+	if err != nil {
+		t.Fatalf("admin list: %v", err)
+	}
+	if total != 3 || len(rows) != 3 {
+		t.Errorf("admin: total=%d rows=%d, want 3/3", total, len(rows))
+	}
+
+	// Restricted to tasks only: see task-screenshot, hide secret + orphan.
+	rows, total, err = s.WorkspaceAttachments(wsID, AttachmentListFilters{
+		VisibleCollectionIDs: []string{collA},
+	})
+	if err != nil {
+		t.Fatalf("restricted list: %v", err)
+	}
+	if total != 1 || len(rows) != 1 {
+		t.Fatalf("restricted: total=%d rows=%d, want 1/1", total, len(rows))
+	}
+	if rows[0].Filename != "task-screenshot.png" {
+		t.Errorf("restricted: filename=%q, want task-screenshot.png", rows[0].Filename)
+	}
+
+	// Empty visibility (member with zero access) — zero rows.
+	rows, total, err = s.WorkspaceAttachments(wsID, AttachmentListFilters{
+		VisibleCollectionIDs: []string{},
+	})
+	if err != nil {
+		t.Fatalf("zero-visibility list: %v", err)
+	}
+	if total != 0 || len(rows) != 0 {
+		t.Errorf("zero-visibility: total=%d rows=%d, want 0/0", total, len(rows))
+	}
+}
+
+// TestWorkspaceAttachments_CategoryFilters covers the document/text/
+// archive/other filter buckets per Codex P2 from PR #303 round 1:
+// the earlier prefix-only mapping silently passed those filters
+// through with no MIME predicate, returning the full list.
+func TestWorkspaceAttachments_CategoryFilters(t *testing.T) {
+	s := testStore(t)
+
+	wsID := newID()
+	ts := time.Now().UTC().Format(time.RFC3339)
+	if _, err := s.db.Exec(s.q(`INSERT INTO workspaces (id, slug, name, settings, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?)`),
+		wsID, "ws", "WS", "{}", ts, ts); err != nil {
+		t.Fatalf("insert workspace: %v", err)
+	}
+
+	mk := func(mime, filename string) {
+		t.Helper()
+		a := &models.Attachment{
+			WorkspaceID: wsID,
+			UploadedBy:  "system",
+			StorageKey:  "fs:" + newID(),
+			ContentHash: newID(),
+			MimeType:    mime,
+			SizeBytes:   1,
+			Filename:    filename,
+		}
+		if err := s.CreateAttachment(a); err != nil {
+			t.Fatalf("CreateAttachment: %v", err)
+		}
+	}
+	mk("image/png", "a.png")
+	mk("application/pdf", "b.pdf")
+	mk("text/markdown", "c.md")
+	mk("application/zip", "d.zip")
+	mk("application/octet-stream", "e.bin") // not in any named bucket → "other"
+
+	cases := []struct {
+		category string
+		want     []string
+	}{
+		{"image", []string{"a.png"}},
+		{"document", []string{"b.pdf"}},
+		{"text", []string{"c.md"}},
+		{"archive", []string{"d.zip"}},
+		{"other", []string{"e.bin"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.category, func(t *testing.T) {
+			rows, total, err := s.WorkspaceAttachments(wsID, AttachmentListFilters{
+				MimeCategory: tc.category,
+			})
+			if err != nil {
+				t.Fatalf("list: %v", err)
+			}
+			if total != len(tc.want) {
+				t.Fatalf("total=%d, want %d", total, len(tc.want))
+			}
+			got := make([]string, len(rows))
+			for i, r := range rows {
+				got[i] = r.Filename
+			}
+			for _, want := range tc.want {
+				found := false
+				for _, g := range got {
+					if g == want {
+						found = true
+					}
+				}
+				if !found {
+					t.Errorf("missing %q in result %v", want, got)
+				}
+			}
+		})
+	}
+}
+
 // TestWorkspaceStorageInfo_TracksLiveAttachments inserts a few
 // attachment rows directly and asserts SUM(size_bytes) shows up in
 // used_bytes — and that soft-deleted rows are excluded so the user

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -392,6 +392,58 @@ func parseItemRef(s string) (string, int, bool) {
 	return prefix, num, true
 }
 
+// GetItemIncludeDeleted finds an item by id including soft-deleted
+// items. Used by code paths that need to act on records the user
+// already owns even though the parent item has been moved to trash —
+// the most common case is the Settings → Storage attachment list,
+// where attachments survive a soft-deleted parent (so the user can
+// see what's still consuming quota and decide whether to delete the
+// blob). The visibility check still keys off the (still-set)
+// collection_id, so soft-deleting an item doesn't escalate access.
+func (s *Store) GetItemIncludeDeleted(id string) (*models.Item, error) {
+	var item models.Item
+	var createdAt, updatedAt string
+	var deletedAt *string
+	var pinned bool
+
+	err := s.db.QueryRow(s.q(`
+		SELECT i.id, i.workspace_id, i.collection_id, i.title, i.slug, i.content, i.fields, i.tags,
+		       i.pinned, i.sort_order, i.parent_id, i.assigned_user_id, i.agent_role_id, i.role_sort_order,
+		       i.created_by, i.last_modified_by, i.source,
+		       i.item_number, i.created_at, i.updated_at, i.deleted_at,
+		       c.slug, c.name, c.icon, c.prefix,
+		       COALESCE(au.name, ''), COALESCE(au.email, ''),
+		       COALESCE(ar.name, ''), COALESCE(ar.slug, ''), COALESCE(ar.icon, '')
+		FROM items i
+		JOIN collections c ON c.id = i.collection_id
+		LEFT JOIN users au ON au.id = i.assigned_user_id
+		LEFT JOIN agent_roles ar ON ar.id = i.agent_role_id
+		WHERE i.id = ?
+	`), id).Scan(
+		&item.ID, &item.WorkspaceID, &item.CollectionID, &item.Title, &item.Slug,
+		&item.Content, &item.Fields, &item.Tags,
+		&pinned, &item.SortOrder, &item.ParentID, &item.AssignedUserID, &item.AgentRoleID, &item.RoleSortOrder,
+		&item.CreatedBy, &item.LastModifiedBy, &item.Source,
+		&item.ItemNumber, &createdAt, &updatedAt, &deletedAt,
+		&item.CollectionSlug, &item.CollectionName, &item.CollectionIcon, &item.CollectionPrefix,
+		&item.AssignedUserName, &item.AssignedUserEmail,
+		&item.AgentRoleName, &item.AgentRoleSlug, &item.AgentRoleIcon,
+	)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get item (include deleted): %w", err)
+	}
+
+	item.Pinned = pinned
+	item.CreatedAt = parseTime(createdAt)
+	item.UpdatedAt = parseTime(updatedAt)
+	item.DeletedAt = parseTimePtr(deletedAt)
+	hydrateItemComputedMetadata(&item)
+	return &item, nil
+}
+
 // GetItemBySlugIncludeDeleted finds an item by slug including soft-deleted items.
 // Used for restore operations where the item is archived.
 func (s *Store) GetItemBySlugIncludeDeleted(workspaceID, slug string) (*models.Item, error) {

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -46,7 +46,9 @@ import type {
 	AttachmentTransformRequest,
 	AttachmentTransformResult,
 	ServerCapabilities,
-	WorkspaceStorageInfo
+	WorkspaceStorageInfo,
+	AttachmentListFilters,
+	AttachmentListResponse
 } from '$lib/types';
 
 const BASE = '/api/v1';
@@ -859,6 +861,49 @@ export const api = {
 		storageUsage(workspaceSlug: string): Promise<WorkspaceStorageInfo> {
 			return request<WorkspaceStorageInfo>(
 				`/workspaces/${workspaceSlug}/storage/usage`
+			);
+		},
+
+		/**
+		 * Paginated list of attachments in a workspace, used by the
+		 * Settings → Storage page. Hides derived blobs (thumbnails) by
+		 * default — those are managed automatically and shouldn't show
+		 * as user-visible rows.
+		 *
+		 * `total` in the response is the count of all matching rows
+		 * (across all pages); pair it with `limit` + `offset` to render
+		 * a classic paginator. Server clamps limit to [1, 200].
+		 */
+		list(
+			workspaceSlug: string,
+			filters: AttachmentListFilters = {}
+		): Promise<AttachmentListResponse> {
+			const params = new URLSearchParams();
+			if (filters.category) params.set('category', filters.category);
+			if (filters.item) params.set('item', filters.item);
+			if (filters.collection) params.set('collection', filters.collection);
+			if (filters.sort) params.set('sort', filters.sort);
+			if (filters.limit !== undefined) params.set('limit', String(filters.limit));
+			if (filters.offset !== undefined) params.set('offset', String(filters.offset));
+			const qs = params.toString();
+			const suffix = qs ? `?${qs}` : '';
+			return request<AttachmentListResponse>(
+				`/workspaces/${workspaceSlug}/attachments${suffix}`
+			);
+		},
+
+		/**
+		 * Soft-delete an attachment by ID. The blob on disk stays put
+		 * (content-addressed dedupe means the same hash may still be
+		 * referenced) — orphan GC reclaims past the grace period.
+		 *
+		 * Returns 204 No Content. Refuses to delete derived
+		 * (thumbnail) rows — caller must delete the original.
+		 */
+		async delete(workspaceSlug: string, attachmentId: string): Promise<void> {
+			await request<void>(
+				`/workspaces/${workspaceSlug}/attachments/${attachmentId}`,
+				{ method: 'DELETE' }
 			);
 		}
 	},

--- a/web/src/lib/components/settings/StorageTab.svelte
+++ b/web/src/lib/components/settings/StorageTab.svelte
@@ -391,7 +391,14 @@
 							<div class="att-line3">
 								{#if att.item_title && att.collection_slug}
 									in
-									<a href={itemHref(att)}>[[{att.item_title}]]</a>
+									{#if att.item_deleted}
+										<!-- Parent item is soft-deleted: render the title without
+										     a link so the user knows the link target would 404. -->
+										<span class="deleted-item">[[{att.item_title}]]</span>
+										<span class="deleted-tag">deleted</span>
+									{:else}
+										<a href={itemHref(att)}>[[{att.item_title}]]</a>
+									{/if}
 								{:else}
 									<span class="unattached-tag">Unattached</span>
 								{/if}
@@ -657,6 +664,21 @@
 
 	.unattached-tag {
 		font-style: italic;
+	}
+
+	.deleted-item {
+		opacity: 0.7;
+		text-decoration: line-through;
+	}
+
+	.deleted-tag {
+		margin-left: var(--space-1);
+		font-size: 0.7em;
+		text-transform: uppercase;
+		color: #ef4444;
+		background: color-mix(in srgb, #ef4444 12%, transparent);
+		padding: 0 var(--space-1);
+		border-radius: var(--radius-sm);
 	}
 
 	.att-actions {

--- a/web/src/lib/components/settings/StorageTab.svelte
+++ b/web/src/lib/components/settings/StorageTab.svelte
@@ -215,16 +215,19 @@
 	}
 
 	function itemHref(att: AttachmentListItem): string {
-		// Settings page sits at /{username}/{wsSlug}/settings, so the item
-		// page is two levels up: ../../{collection_slug}/{item_slug-or-ref}.
-		// Prefer absolute when we have username; fall back to relative.
+		// Item route is /{username}/{wsSlug}/{collection_slug}/{item_slug}.
+		// item_ref (collection-prefix + number, e.g. "TASK-5") doesn't
+		// match the route shape — only item_slug does — so we ignore
+		// item_ref here even if a future API surfaces one.
 		const collSlug = att.collection_slug ?? '';
-		const itemId = att.item_ref ?? att.item_slug ?? '';
-		if (!collSlug || !itemId) return '#';
+		const itemSlug = att.item_slug ?? '';
+		if (!collSlug || !itemSlug) return '#';
 		if (username) {
-			return `/${username}/${wsSlug}/${collSlug}/${itemId}`;
+			return `/${username}/${wsSlug}/${collSlug}/${itemSlug}`;
 		}
-		return `../../${collSlug}/${itemId}`;
+		// Settings page sits at /{username}/{wsSlug}/settings, so two
+		// levels up is the item route's parent.
+		return `../../${collSlug}/${itemSlug}`;
 	}
 </script>
 

--- a/web/src/lib/components/settings/StorageTab.svelte
+++ b/web/src/lib/components/settings/StorageTab.svelte
@@ -1,0 +1,676 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { page } from '$app/state';
+	import { api } from '$lib/api/client';
+	import type {
+		AttachmentListItem,
+		AttachmentListFilters,
+		AttachmentListResponse,
+		Collection,
+		WorkspaceStorageInfo
+	} from '$lib/types';
+	import { toastStore } from '$lib/stores/toast.svelte';
+
+	// ── Props ────────────────────────────────────────────────────────────────
+	interface Props {
+		wsSlug: string;
+		collections: Collection[];
+	}
+	let { wsSlug, collections }: Props = $props();
+
+	// ── State ────────────────────────────────────────────────────────────────
+	let loading = $state(true);
+	let usage = $state<WorkspaceStorageInfo | null>(null);
+	let attachments = $state<AttachmentListItem[]>([]);
+	let total = $state(0);
+	let limit = $state(50);
+	let offset = $state(0);
+
+	// Filters (UI selections — empty string means "All" / not applied)
+	type CategoryValue = '' | 'image' | 'video' | 'audio' | 'document' | 'text' | 'archive' | 'other';
+	type ItemValue = '' | 'attached' | 'unattached';
+	type SortValue =
+		| 'created_at_desc'
+		| 'created_at'
+		| 'size_desc'
+		| 'size'
+		| 'filename'
+		| 'filename_desc';
+
+	let filterCategory = $state<CategoryValue>('');
+	let filterItem = $state<ItemValue>('');
+	let filterCollection = $state<string>('');
+	let sortValue = $state<SortValue>('created_at_desc');
+
+	// ── Helpers ──────────────────────────────────────────────────────────────
+
+	// Same algorithm as web/src/routes/console/billing/+page.svelte. Picks a
+	// unit so the displayed value is < 1024; bump thresholds nudged down half
+	// the previous unit so 1,048,575 bytes reads as "1.0 MB" rather than the
+	// misleading "1024 KB" you'd get from a straight Math.round at the KB tier.
+	function formatBytes(bytes: number): string {
+		if (bytes < 0) return `${bytes} B`;
+		const KB = 1024;
+		const MB = KB * 1024;
+		const GB = MB * 1024;
+		const bumpGB = GB - MB / 2;
+		const bumpMB = MB - KB / 2;
+		if (bytes >= bumpGB) return formatUnit(bytes / GB, 'GB');
+		if (bytes >= bumpMB) return formatUnit(bytes / MB, 'MB');
+		if (bytes >= KB) return formatUnit(bytes / KB, 'KB');
+		return `${bytes} B`;
+	}
+
+	function formatUnit(value: number, unit: string): string {
+		if (value >= 10) return `${Math.round(value)} ${unit}`;
+		return `${value.toFixed(1)} ${unit}`;
+	}
+
+	function formatDate(iso: string): string {
+		try {
+			return new Date(iso).toLocaleDateString(undefined, {
+				year: 'numeric',
+				month: 'short',
+				day: 'numeric'
+			});
+		} catch {
+			return iso;
+		}
+	}
+
+	function categoryIcon(mime: string): string {
+		if (mime.startsWith('image/')) return '🖼️';
+		if (mime.startsWith('video/')) return '🎬';
+		if (mime.startsWith('audio/')) return '🔊';
+		if (mime.startsWith('text/')) return '📄';
+		if (mime === 'application/pdf') return '📄';
+		if (
+			mime === 'application/zip' ||
+			mime === 'application/x-tar' ||
+			mime === 'application/gzip' ||
+			mime === 'application/x-7z-compressed' ||
+			mime === 'application/x-rar-compressed'
+		)
+			return '📦';
+		if (
+			mime.startsWith('application/vnd.openxmlformats') ||
+			mime.startsWith('application/vnd.ms-') ||
+			mime.startsWith('application/vnd.oasis') ||
+			mime === 'application/msword'
+		)
+			return '📄';
+		return '❓';
+	}
+
+	function isImage(mime: string): boolean {
+		return mime.startsWith('image/');
+	}
+
+	// ── Derived values ───────────────────────────────────────────────────────
+
+	let usagePercent = $derived.by(() => {
+		if (!usage || usage.limit_bytes < 0) return 0;
+		if (usage.limit_bytes === 0) return 0;
+		return (usage.used_bytes / usage.limit_bytes) * 100;
+	});
+
+	let usageBarClass = $derived.by(() => {
+		if (!usage || usage.limit_bytes < 0) return '';
+		if (usagePercent >= 100) return 'crit';
+		if (usagePercent >= 80) return 'warn';
+		return '';
+	});
+
+	let pageStart = $derived(total === 0 ? 0 : offset + 1);
+	let pageEnd = $derived(Math.min(offset + attachments.length, total));
+	let canPrev = $derived(offset > 0);
+	let canNext = $derived(offset + limit < total);
+
+	let username = $derived(page.params.username ?? '');
+
+	// ── Data loading ─────────────────────────────────────────────────────────
+
+	function buildFilters(): AttachmentListFilters {
+		const f: AttachmentListFilters = {
+			limit,
+			offset,
+			sort: sortValue
+		};
+		if (filterCategory) f.category = filterCategory;
+		if (filterItem) f.item = filterItem;
+		if (filterCollection) f.collection = filterCollection;
+		return f;
+	}
+
+	async function loadUsage() {
+		try {
+			usage = await api.attachments.storageUsage(wsSlug);
+		} catch (err) {
+			const msg = err instanceof Error ? err.message : 'Failed to load storage usage';
+			toastStore.show(msg, 'error');
+		}
+	}
+
+	async function loadList() {
+		try {
+			const resp: AttachmentListResponse = await api.attachments.list(wsSlug, buildFilters());
+			attachments = resp.attachments ?? [];
+			total = resp.total ?? 0;
+			limit = resp.limit ?? limit;
+			offset = resp.offset ?? offset;
+		} catch (err) {
+			const msg = err instanceof Error ? err.message : 'Failed to load attachments';
+			toastStore.show(msg, 'error');
+		}
+	}
+
+	async function reload() {
+		await Promise.all([loadList(), loadUsage()]);
+	}
+
+	onMount(async () => {
+		try {
+			await Promise.all([loadList(), loadUsage()]);
+		} finally {
+			loading = false;
+		}
+	});
+
+	// Filter / sort changes reset to the first page and refetch. Using an
+	// explicit handler instead of an $effect keeps the side-effect tied to
+	// the user action and avoids an effect that mutates state + calls a
+	// fetch on every dependency tick.
+	function onFiltersChanged() {
+		offset = 0;
+		loadList();
+	}
+
+	// ── Actions ──────────────────────────────────────────────────────────────
+
+	async function handleDelete(att: AttachmentListItem) {
+		const ok = confirm(
+			`Delete ${att.filename}? The blob is reclaimed by garbage collection after a grace period.`
+		);
+		if (!ok) return;
+		try {
+			await api.attachments.delete(wsSlug, att.id);
+			toastStore.show(`Deleted ${att.filename}`, 'success');
+			await reload();
+		} catch (err) {
+			const msg = err instanceof Error ? err.message : 'Failed to delete attachment';
+			toastStore.show(msg, 'error');
+		}
+	}
+
+	function gotoPrev() {
+		if (!canPrev) return;
+		offset = Math.max(0, offset - limit);
+		loadList();
+	}
+
+	function gotoNext() {
+		if (!canNext) return;
+		offset = offset + limit;
+		loadList();
+	}
+
+	function itemHref(att: AttachmentListItem): string {
+		// Settings page sits at /{username}/{wsSlug}/settings, so the item
+		// page is two levels up: ../../{collection_slug}/{item_slug-or-ref}.
+		// Prefer absolute when we have username; fall back to relative.
+		const collSlug = att.collection_slug ?? '';
+		const itemId = att.item_ref ?? att.item_slug ?? '';
+		if (!collSlug || !itemId) return '#';
+		if (username) {
+			return `/${username}/${wsSlug}/${collSlug}/${itemId}`;
+		}
+		return `../../${collSlug}/${itemId}`;
+	}
+</script>
+
+<div class="storage-tab">
+	{#if loading}
+		<p class="empty-text">Loading storage…</p>
+	{:else}
+		<!-- Usage bar -->
+		<div class="card usage-bar-card">
+			{#if usage}
+				<div class="usage-line">
+					{#if usage.limit_bytes >= 0}
+						<span>
+							<strong>{formatBytes(usage.used_bytes)}</strong>
+							used of
+							<strong>{formatBytes(usage.limit_bytes)}</strong>
+							({usagePercent.toFixed(1)}%)
+						</span>
+					{:else}
+						<span>
+							<strong>{formatBytes(usage.used_bytes)}</strong>
+							used
+							<span class="usage-unlimited">(unlimited)</span>
+						</span>
+					{/if}
+					{#if usage.override_active}
+						<span class="override-badge">custom override</span>
+					{/if}
+				</div>
+
+				{#if usage.limit_bytes >= 0}
+					<div class="usage-bar">
+						<div
+							class="usage-fill {usageBarClass}"
+							style:width="{Math.min(100, usagePercent)}%"
+						></div>
+					</div>
+				{/if}
+
+				{#if usage.override_active && usage.plan}
+					<div class="usage-subline">
+						Plan: {usage.plan} — admin override active
+					</div>
+				{/if}
+			{:else}
+				<p class="empty-text">Unable to load usage info.</p>
+			{/if}
+		</div>
+
+		<!-- Filters -->
+		<div class="filter-row">
+			<label>
+				Category
+				<select
+					class="role-select"
+					bind:value={filterCategory}
+					onchange={onFiltersChanged}
+				>
+					<option value="">All</option>
+					<option value="image">Images</option>
+					<option value="video">Videos</option>
+					<option value="audio">Audio</option>
+					<option value="document">Documents</option>
+					<option value="text">Text</option>
+					<option value="archive">Archive</option>
+					<option value="other">Other</option>
+				</select>
+			</label>
+			<label>
+				Item
+				<select
+					class="role-select"
+					bind:value={filterItem}
+					onchange={onFiltersChanged}
+				>
+					<option value="">All</option>
+					<option value="attached">Attached</option>
+					<option value="unattached">Unattached</option>
+				</select>
+			</label>
+			<label>
+				Collection
+				<select
+					class="role-select"
+					bind:value={filterCollection}
+					onchange={onFiltersChanged}
+				>
+					<option value="">All</option>
+					{#each collections as coll (coll.id)}
+						<option value={coll.id}>{coll.name}</option>
+					{/each}
+				</select>
+			</label>
+			<label>
+				Sort
+				<select
+					class="role-select"
+					bind:value={sortValue}
+					onchange={onFiltersChanged}
+				>
+					<option value="created_at_desc">Newest first</option>
+					<option value="created_at">Oldest first</option>
+					<option value="size_desc">Largest first</option>
+					<option value="size">Smallest first</option>
+					<option value="filename">Filename A→Z</option>
+					<option value="filename_desc">Filename Z→A</option>
+				</select>
+			</label>
+			<label>
+				Per page
+				<select
+					class="role-select"
+					bind:value={limit}
+					onchange={onFiltersChanged}
+				>
+					<option value={25}>25</option>
+					<option value={50}>50</option>
+					<option value={100}>100</option>
+				</select>
+			</label>
+		</div>
+
+		<!-- Attachment list -->
+		{#if total === 0}
+			<p class="empty-text">
+				No attachments yet — paste or drag a file into any item to upload one.
+			</p>
+		{:else}
+			<div class="att-list">
+				{#each attachments as att (att.id)}
+					<div class="att-row card">
+						<a
+							class="att-thumb"
+							href={api.attachments.downloadUrl(wsSlug, att.id)}
+							target="_blank"
+							rel="noopener"
+							aria-label="Open {att.filename}"
+						>
+							{#if isImage(att.mime_type)}
+								<img
+									src={api.attachments.downloadUrl(wsSlug, att.id, 'thumb-sm')}
+									alt={att.filename}
+									loading="lazy"
+								/>
+							{:else}
+								<span aria-hidden="true">{categoryIcon(att.mime_type)}</span>
+							{/if}
+						</a>
+
+						<div class="att-meta">
+							<div class="att-line1">
+								<span class="att-filename" title={att.filename}>{att.filename}</span>
+							</div>
+							<div class="att-line2">
+								<span class="att-size">{formatBytes(att.size_bytes)}</span>
+								·
+								<span class="att-mime mono">{att.mime_type}</span>
+								·
+								<span class="att-date">{formatDate(att.created_at)}</span>
+							</div>
+							<div class="att-line3">
+								{#if att.item_title && att.collection_slug}
+									in
+									<a href={itemHref(att)}>[[{att.item_title}]]</a>
+								{:else}
+									<span class="unattached-tag">Unattached</span>
+								{/if}
+							</div>
+						</div>
+
+						<div class="att-actions">
+							<button
+								type="button"
+								class="btn btn-small btn-remove"
+								onclick={() => handleDelete(att)}
+							>
+								Delete
+							</button>
+						</div>
+					</div>
+				{/each}
+			</div>
+
+			<!-- Pager -->
+			<div class="pager">
+				<span>Showing {pageStart}–{pageEnd} of {total}</span>
+				<div class="pager-btns">
+					<button
+						type="button"
+						class="btn btn-small"
+						disabled={!canPrev}
+						onclick={gotoPrev}
+					>
+						Prev
+					</button>
+					<button
+						type="button"
+						class="btn btn-small"
+						disabled={!canNext}
+						onclick={gotoNext}
+					>
+						Next
+					</button>
+				</div>
+			</div>
+		{/if}
+	{/if}
+</div>
+
+<style>
+	/* ── Local copies of the parent settings page primitives ────────────────
+	 * Svelte 5 scopes styles to the component, so a child cannot reach the
+	 * parent's `.card`/`.btn`/etc. These match the parent's visual conventions
+	 * so the Storage tab feels native inside the settings page.
+	 */
+	.card {
+		background: var(--bg-secondary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+		padding: var(--space-4);
+	}
+
+	.btn {
+		padding: var(--space-2) var(--space-4);
+		background: var(--bg-tertiary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+		font-size: 0.85em;
+		cursor: pointer;
+		color: var(--text-primary);
+	}
+
+	.btn:hover {
+		background: var(--bg-hover);
+	}
+
+	.btn:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+
+	.btn-small {
+		padding: var(--space-1) var(--space-3);
+		font-size: 0.8em;
+	}
+
+	.btn-remove {
+		color: #ef4444;
+		border-color: transparent;
+		background: none;
+	}
+
+	.btn-remove:hover {
+		background: color-mix(in srgb, #ef4444 15%, transparent);
+	}
+
+	.role-select {
+		background: var(--bg-tertiary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius-sm);
+		padding: var(--space-1) var(--space-2);
+		font-size: 0.8em;
+		color: var(--text-primary);
+	}
+
+	.empty-text {
+		color: var(--text-muted);
+		font-size: 0.9em;
+		text-align: center;
+		padding: var(--space-6);
+	}
+
+	.mono {
+		font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+	}
+
+	/* ── Storage-specific styles ──────────────────────────────────────────── */
+
+	.storage-tab {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-4);
+	}
+
+	.usage-bar-card {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-2);
+	}
+
+	.usage-line {
+		display: flex;
+		align-items: center;
+		gap: var(--space-3);
+		font-size: 1em;
+		flex-wrap: wrap;
+	}
+
+	.usage-unlimited {
+		color: var(--text-muted);
+		font-weight: 400;
+	}
+
+	.override-badge {
+		display: inline-block;
+		padding: 2px var(--space-2);
+		border-radius: var(--radius-sm);
+		background: color-mix(in srgb, var(--accent-blue) 15%, transparent);
+		color: var(--accent-blue);
+		font-size: 0.72em;
+		font-weight: 500;
+		letter-spacing: 0.02em;
+	}
+
+	.usage-bar {
+		height: 8px;
+		width: 100%;
+		background: var(--bg-tertiary);
+		border-radius: 4px;
+		overflow: hidden;
+	}
+
+	.usage-fill {
+		height: 100%;
+		background: var(--accent-blue);
+		transition: width 0.3s ease;
+	}
+
+	.usage-fill.warn {
+		background: color-mix(in srgb, #f59e0b 80%, transparent);
+	}
+
+	.usage-fill.crit {
+		background: color-mix(in srgb, #ef4444 85%, transparent);
+	}
+
+	.usage-subline {
+		font-size: 0.78em;
+		color: var(--text-muted);
+	}
+
+	.filter-row {
+		display: flex;
+		flex-wrap: wrap;
+		gap: var(--space-2);
+		align-items: center;
+		margin: var(--space-3) 0;
+	}
+
+	.filter-row label {
+		display: inline-flex;
+		align-items: center;
+		gap: var(--space-2);
+		font-size: 0.8em;
+		color: var(--text-secondary);
+	}
+
+	.att-list {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-2);
+	}
+
+	.att-row {
+		display: flex;
+		flex-direction: row;
+		gap: var(--space-3);
+		align-items: center;
+		padding: var(--space-2) var(--space-3);
+	}
+
+	.att-thumb {
+		flex-shrink: 0;
+		width: 48px;
+		height: 48px;
+		border-radius: var(--radius-sm);
+		background: var(--bg-tertiary);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		font-size: 1.4em;
+		overflow: hidden;
+		text-decoration: none;
+	}
+
+	.att-thumb img {
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+	}
+
+	.att-meta {
+		flex: 1;
+		min-width: 0;
+	}
+
+	.att-filename {
+		display: block;
+		font-weight: 500;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.att-line2,
+	.att-line3 {
+		font-size: 0.78em;
+		color: var(--text-muted);
+	}
+
+	.att-line2 {
+		margin-top: 2px;
+	}
+
+	.att-line3 {
+		margin-top: 2px;
+	}
+
+	.att-line3 a {
+		color: var(--accent-blue);
+		text-decoration: none;
+	}
+
+	.att-line3 a:hover {
+		text-decoration: underline;
+	}
+
+	.unattached-tag {
+		font-style: italic;
+	}
+
+	.att-actions {
+		flex-shrink: 0;
+	}
+
+	.pager {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		margin-top: var(--space-4);
+		font-size: 0.85em;
+		color: var(--text-muted);
+	}
+
+	.pager-btns {
+		display: flex;
+		gap: var(--space-2);
+	}
+</style>

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -865,6 +865,12 @@ export interface AttachmentListItem {
 	deleted_at?: string | null;
 	item_title?: string | null;
 	item_slug?: string | null;
+	/**
+	 * True when the parent item is soft-deleted. The attachment is
+	 * still surfaced (the bytes still count toward quota) but the
+	 * UI should render "(deleted)" instead of a clickable link.
+	 */
+	item_deleted?: boolean;
 	collection_slug?: string | null;
 }
 

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -865,7 +865,6 @@ export interface AttachmentListItem {
 	deleted_at?: string | null;
 	item_title?: string | null;
 	item_slug?: string | null;
-	item_ref?: string | null;
 	collection_slug?: string | null;
 }
 

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -840,6 +840,63 @@ export interface WorkspaceStorageInfo {
 	override_active: boolean;
 }
 
+/**
+ * Row shape from GET /api/v1/workspaces/{ws}/attachments. Mirrors
+ * the store's AttachmentListItem — base attachment columns plus
+ * LEFT JOIN'd item title / slug / collection slug for the "in
+ * [[Item X]]" link in the settings page. Item fields are absent
+ * for orphan attachments.
+ */
+export interface AttachmentListItem {
+	id: string;
+	workspace_id: string;
+	item_id?: string | null;
+	uploaded_by: string;
+	storage_key: string;
+	content_hash: string;
+	mime_type: string;
+	size_bytes: number;
+	filename: string;
+	width?: number | null;
+	height?: number | null;
+	parent_id?: string | null;
+	variant?: string | null;
+	created_at: string;
+	deleted_at?: string | null;
+	item_title?: string | null;
+	item_slug?: string | null;
+	item_ref?: string | null;
+	collection_slug?: string | null;
+}
+
+/**
+ * Paginated response from GET /api/v1/workspaces/{ws}/attachments.
+ * `total` is the count of all matching rows (across all pages); the
+ * UI uses it with `limit` + `offset` to render a classic paginator.
+ */
+export interface AttachmentListResponse {
+	attachments: AttachmentListItem[];
+	total: number;
+	limit: number;
+	offset: number;
+}
+
+/** Filters accepted by attachments.list — translated to query params. */
+export interface AttachmentListFilters {
+	category?: 'image' | 'video' | 'audio' | 'document' | 'text' | 'archive' | 'other';
+	item?: 'attached' | 'unattached';
+	collection?: string;
+	sort?:
+		| 'size'
+		| 'size_desc'
+		| 'filename'
+		| 'filename_desc'
+		| 'created_at'
+		| 'created_at_desc';
+	limit?: number;
+	offset?: number;
+}
+
 // ─── Helper functions ────────────────────────────────────────────────────────
 
 export function parseFields(item: Item): Record<string, any> {

--- a/web/src/routes/[username]/[workspace]/settings/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/settings/+page.svelte
@@ -8,6 +8,7 @@
 	import { parseSchema } from '$lib/types';
 	import CreateCollectionModal from '$lib/components/collections/CreateCollectionModal.svelte';
 	import EditCollectionModal from '$lib/components/collections/EditCollectionModal.svelte';
+	import StorageTab from '$lib/components/settings/StorageTab.svelte';
 	import { collectionStore } from '$lib/stores/collections.svelte';
 	import { toastStore } from '$lib/stores/toast.svelte';
 	import { copyToClipboard } from '$lib/utils/clipboard';
@@ -49,6 +50,7 @@
 		{ id: 'general', label: 'General', icon: '\u2699\uFE0F' },
 		{ id: 'members', label: 'Members', icon: '\uD83D\uDC65' },
 		{ id: 'collections', label: 'Collections', icon: '\uD83D\uDCC1' },
+		{ id: 'storage', label: 'Storage', icon: '\uD83D\uDCBE' },
 		{ id: 'danger', label: 'Danger Zone', icon: '\u26A0\uFE0F' },
 	];
 	let validTabIds = $derived(tabs.map(t => t.id));
@@ -676,6 +678,10 @@
 						onclose={() => (editingCollection = null)}
 					/>
 				{/if}
+			</section>
+		{:else if activeTab === 'storage'}
+			<section class="section">
+				<StorageTab {wsSlug} {collections} />
 			</section>
 		{:else if activeTab === 'danger'}
 			<section class="section">


### PR DESCRIPTION
## Summary

Adds the Settings → Storage tab and the underlying list/delete API endpoints so workspace owners can audit and reclaim attachment bytes.

**Backend** (TASK-882 needs this — there was no list/delete API yet):
- `store.WorkspaceAttachments`: paginated list with filter (category, attached/unattached, collection_id) + sort allowlist. LEFT JOIN enriches rows with item title/slug + collection slug. Hides derived (thumbnail) rows.
- `store.SoftDeleteAttachment`: tombstones row + variants; blob reclaimed by orphan GC.
- `GET /workspaces/{ws}/attachments` (viewer+) — `{attachments, total, limit, offset}`.
- `DELETE /workspaces/{ws}/attachments/{id}` (editor+) — refuses derived rows, invalidates usage cache.

**Frontend**:
- `StorageTab.svelte` with usage bar (80%/100% color thresholds, override badge), 5-select filter row, attachment list with thumbnails, "in [[Item]]" links, per-row delete with confirm. Pagination footer.
- TS `api.attachments.list()` / `delete()` + types.
- Wired as a new "Storage" tab.

## Context

Implements `TASK-882` under `PLAN-866` (Attachments Phase 1).

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./internal/server/ ./internal/store/` — green (76s + 33s)
- [x] `gofmt -l internal/ cmd/` — clean
- [x] `cd web && npm run check` — 0 errors, 6 pre-existing warnings
- [x] `cd web && npm run build` — production build succeeds
- [x] Backend tests: pagination + sort + filter, hides derived, delete happy path (cache invalidation), delete derived returns 400