### PR TITLE
chore(import-bundle): audit + harden bundle import validation (TASK-891)

### DIFF
--- a/internal/server/handlers_import_bundle.go
+++ b/internal/server/handlers_import_bundle.go
@@ -230,8 +230,14 @@ func (s *Server) importBundle(ctx context.Context, r io.Reader, newName, ownerID
 		// up front so the audit story is unambiguous and so a bundle
 		// that's been hand-edited to look malicious fails loudly
 		// rather than silently being skipped via the `default` arm.
+		//
+		// Return ws here (not nil) so the handler can roll back any
+		// workspace that was already created by a preceding valid
+		// pad-export.json. Before pad-export.json is seen, ws is nil
+		// so this falls through to the no-workspace cleanup path
+		// anyway. Codex P1 round 3 on PR #308.
 		if !isSafeBundleEntryName(hdr.Name) {
-			return nil, &importStatusError{
+			return ws, &importStatusError{
 				status: http.StatusBadRequest, code: "bad_bundle",
 				message: "Bundle contains unsafe entry name: " + hdr.Name,
 			}

--- a/internal/server/handlers_import_bundle.go
+++ b/internal/server/handlers_import_bundle.go
@@ -135,6 +135,15 @@ func (s *Server) handleImportWorkspaceBundle(w http.ResponseWriter, r *http.Requ
 		// or malformed bundle can't pile up half-imported workspaces
 		// in the destination instance. Codex P1 on PR #308.
 		//
+		// Cascade: a duplicate manifest.json or duplicate pad-export.json
+		// can fire AFTER blobs have already been rehydrated — those
+		// attachment rows would otherwise stay live (deleted_at IS NULL),
+		// pin their blobs from orphan-GC, and count toward the
+		// importing user's storage usage. Tombstone every attachment
+		// in the partial workspace BEFORE soft-deleting the workspace
+		// itself so orphan-GC reclaims the blobs after the grace
+		// window. Codex P1 round 2 on PR #308.
+		//
 		// Mid-stream errors that are NOT importStatusError (e.g.
 		// manifest decode failure after items inserted) intentionally
 		// keep the partial workspace — the existing comment on the
@@ -142,6 +151,13 @@ func (s *Server) handleImportWorkspaceBundle(w http.ResponseWriter, r *http.Requ
 		// attachments not restored" and that decision is tracked
 		// separately under TASK-896 (partial-import design).
 		if isValidationReject && ws != nil {
+			if n, attErr := s.store.SoftDeleteWorkspaceAttachments(ws.ID); attErr != nil {
+				slog.Warn("import: failed to tombstone partial-workspace attachments",
+					"workspace_id", ws.ID, "error", attErr)
+			} else if n > 0 {
+				slog.Info("import: rolled back partial-workspace attachments",
+					"workspace_id", ws.ID, "rows", n)
+			}
 			if delErr := s.store.DeleteWorkspace(ws.Slug); delErr != nil {
 				slog.Warn("import: failed to roll back partial workspace after validation reject",
 					"workspace_slug", ws.Slug, "error", delErr)

--- a/internal/server/handlers_import_bundle.go
+++ b/internal/server/handlers_import_bundle.go
@@ -126,7 +126,29 @@ func (s *Server) handleImportWorkspaceBundle(w http.ResponseWriter, r *http.Requ
 		// Errors from importBundle are already shaped with status hints —
 		// surface as 400 unless the underlying error wraps an http hint.
 		var statusErr *importStatusError
-		if errors.As(err, &statusErr) {
+		isValidationReject := errors.As(err, &statusErr)
+
+		// If a clean validation-phase reject happens AFTER the
+		// workspace has been created (e.g. a duplicate pad-export.json
+		// or path-traversal entry that follows the first export
+		// header), roll back the partial workspace so a malicious
+		// or malformed bundle can't pile up half-imported workspaces
+		// in the destination instance. Codex P1 on PR #308.
+		//
+		// Mid-stream errors that are NOT importStatusError (e.g.
+		// manifest decode failure after items inserted) intentionally
+		// keep the partial workspace — the existing comment on the
+		// manifest decode path notes "workspace created but
+		// attachments not restored" and that decision is tracked
+		// separately under TASK-896 (partial-import design).
+		if isValidationReject && ws != nil {
+			if delErr := s.store.DeleteWorkspace(ws.Slug); delErr != nil {
+				slog.Warn("import: failed to roll back partial workspace after validation reject",
+					"workspace_slug", ws.Slug, "error", delErr)
+			}
+		}
+
+		if isValidationReject {
 			writeError(w, statusErr.status, statusErr.code, statusErr.message)
 			return
 		}

--- a/internal/server/handlers_import_bundle.go
+++ b/internal/server/handlers_import_bundle.go
@@ -63,6 +63,18 @@ func (s *Server) effectiveBlobMaxBytes() int64 {
 // The handler does the JSON / bundle dispatch; the actual work is
 // done by importBundle which is unit-testable without the http stack.
 //
+// Auth: any authenticated user. The global RequireAuth middleware
+// (server.go:539) gates this endpoint when users exist on the host.
+// There is no per-workspace role check because import CREATES a new
+// workspace — there's nothing pre-existing to authorize against.
+// The importing user becomes the workspace owner via AddWorkspaceMember
+// after a successful import (mirrors handleCreateWorkspace).
+//
+// Quota: per-user storage quotas are NOT enforced on import. The
+// upload handler is also warn-only in Phase 1 (see handlers_attachments.go
+// maybeWarnStorageQuota). When quota enforcement lands the import
+// path needs the same gate. Tracked as a follow-up under PLAN-890.
+//
 // Bundle layout (matches handlers_export_bundle.go):
 //
 //	pad-export.json
@@ -172,8 +184,33 @@ func (s *Server) importBundle(ctx context.Context, r io.Reader, newName, ownerID
 			continue
 		}
 
+		// Defense-in-depth path-traversal rejection. The bundle path
+		// is hash-keyed at the storage layer (see rehydrateAttachment
+		// → store.Put with the locally-computed sha256), so a tar
+		// entry name with `..` or an absolute path can't actually
+		// write outside the attachment store. We still reject these
+		// up front so the audit story is unambiguous and so a bundle
+		// that's been hand-edited to look malicious fails loudly
+		// rather than silently being skipped via the `default` arm.
+		if !isSafeBundleEntryName(hdr.Name) {
+			return nil, &importStatusError{
+				status: http.StatusBadRequest, code: "bad_bundle",
+				message: "Bundle contains unsafe entry name: " + hdr.Name,
+			}
+		}
+
 		switch {
 		case hdr.Name == "pad-export.json":
+			// Bundles must contain exactly one pad-export.json.
+			// A second occurrence would call ImportWorkspace again,
+			// stranding the first workspace as an orphan with no
+			// attachments. Reject duplicates loudly.
+			if exportSeen {
+				return ws, &importStatusError{
+					status: http.StatusBadRequest, code: "bad_bundle",
+					message: "Bundle contains duplicate pad-export.json",
+				}
+			}
 			// pad-export.json can grow large for content-heavy
 			// workspaces (items + version history). Use the
 			// metadata-specific cap so deployments that lower
@@ -212,6 +249,17 @@ func (s *Server) importBundle(ctx context.Context, r io.Reader, newName, ownerID
 				return nil, &importStatusError{
 					status: http.StatusBadRequest, code: "bad_bundle",
 					message: "Bundle ordering violation: manifest.json before pad-export.json",
+				}
+			}
+			// Reject duplicate manifest.json — a second occurrence
+			// would silently overwrite manifestByPath, dropping prior
+			// entries and leaving any blobs that referenced them
+			// looking orphaned (manifest lookup miss → consumed and
+			// skipped). Same shape as the duplicate-export guard.
+			if manifestSeen {
+				return ws, &importStatusError{
+					status: http.StatusBadRequest, code: "bad_bundle",
+					message: "Bundle contains duplicate attachments/manifest.json",
 				}
 			}
 			// Manifest size scales with attachment count, not blob
@@ -441,3 +489,42 @@ type importStatusError struct {
 }
 
 func (e *importStatusError) Error() string { return e.message }
+
+// isSafeBundleEntryName rejects tar entry names that look like a
+// path-traversal attempt. The bundle path is already hash-keyed at
+// the storage layer (see rehydrateAttachment), so a malicious entry
+// name can't actually escape the attachment store — but rejecting
+// up front makes the audit story unambiguous and means hand-edited
+// bundles fail loudly rather than silently slipping through the
+// `default` arm of importBundle's switch.
+//
+// Rules:
+//   - Reject absolute paths ("/etc/passwd", "\\windows\\system32").
+//   - Reject any segment equal to "..". A literal "." segment is
+//     rare but harmless; we only block ".." since that's the
+//     traversal vector.
+//   - Reject embedded NUL bytes (defense against C-style truncation
+//     bugs in any downstream consumer).
+//
+// Returns true when the entry name is safe to consume.
+func isSafeBundleEntryName(name string) bool {
+	if name == "" {
+		return false
+	}
+	if strings.ContainsRune(name, 0) {
+		return false
+	}
+	if strings.HasPrefix(name, "/") || strings.HasPrefix(name, "\\") {
+		return false
+	}
+	// Treat both forward- and back-slashes as separators for the
+	// traversal check; tar names are canonically forward-slashed but
+	// a malicious bundle could mix them to bypass a naive split.
+	normalized := strings.ReplaceAll(name, "\\", "/")
+	for _, segment := range strings.Split(normalized, "/") {
+		if segment == ".." {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/server/handlers_import_bundle_test.go
+++ b/internal/server/handlers_import_bundle_test.go
@@ -421,6 +421,121 @@ func TestImportBundle_RejectsPathTraversal(t *testing.T) {
 	}
 }
 
+// TestImportBundle_RollbackTombstonesAttachments pins Codex P1
+// round 2 on PR #308: when the duplicate-manifest guard fires AFTER
+// blobs have already been rehydrated, the rollback must tombstone
+// every attachment row in the partial workspace (deleted_at set) so
+// orphan-GC reclaims the blobs and per-user storage usage is
+// correct. Without the cascade, the workspace was soft-deleted but
+// the attachment rows stayed live, pinning blobs from GC.
+//
+// The test builds a real export bundle (so manifest entries match
+// real blob bytes), then surgically appends a duplicate manifest.json
+// at the end. Posting that to a fresh server triggers blob
+// rehydration of the original bundle's entries before the duplicate
+// guard fires.
+func TestImportBundle_RollbackTombstonesAttachments(t *testing.T) {
+	// Source workspace: upload a real PNG so the bundle has a real
+	// blob entry the destination must rehydrate before hitting the
+	// duplicate at the end.
+	src, srcSlug := testServerWithAttachments(t)
+	rr := doMultipartUpload(src, srcSlug, "logo.png", realPNG())
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("upload: %d %s", rr.Code, rr.Body.String())
+	}
+
+	// Real bundle from the source.
+	rr = doRequest(src, "GET", "/api/v1/workspaces/"+srcSlug+"/export?format=tar", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("export: %d %s", rr.Code, rr.Body.String())
+	}
+	realBundle := rr.Body.Bytes()
+
+	// Extract every tar entry from the real bundle, then re-emit them
+	// in order + inject a duplicate attachments/manifest.json AFTER
+	// every original entry. The duplicate fires after blob
+	// rehydration, exercising the cascade path.
+	gz, err := gzip.NewReader(bytes.NewReader(realBundle))
+	if err != nil {
+		t.Fatalf("gzip read: %v", err)
+	}
+	tr := tar.NewReader(gz)
+
+	var out bytes.Buffer
+	outGz := gzip.NewWriter(&out)
+	outTw := tar.NewWriter(outGz)
+
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("tar next: %v", err)
+		}
+		body, err := io.ReadAll(tr)
+		if err != nil {
+			t.Fatalf("read entry: %v", err)
+		}
+		if err := outTw.WriteHeader(&tar.Header{Name: hdr.Name, Mode: 0o644, Size: int64(len(body))}); err != nil {
+			t.Fatalf("write header: %v", err)
+		}
+		if _, err := outTw.Write(body); err != nil {
+			t.Fatalf("write body: %v", err)
+		}
+	}
+	gz.Close()
+
+	// Inject the duplicate manifest.json after every real entry.
+	dupe := []byte(`{"version":1,"entries":[]}`)
+	if err := outTw.WriteHeader(&tar.Header{Name: "attachments/manifest.json", Mode: 0o644, Size: int64(len(dupe))}); err != nil {
+		t.Fatalf("write dupe header: %v", err)
+	}
+	if _, err := outTw.Write(dupe); err != nil {
+		t.Fatalf("write dupe: %v", err)
+	}
+	outTw.Close()
+	outGz.Close()
+
+	// Post to a fresh server and confirm 400.
+	dest, _ := testServerWithAttachments(t)
+	req := httptest.NewRequest("POST", "/api/v1/workspaces/import?name=Tombstoned",
+		bytes.NewReader(out.Bytes()))
+	req.Header.Set("Content-Type", "application/gzip")
+	req.RemoteAddr = "127.0.0.1:1234"
+	rr = httptest.NewRecorder()
+	dest.ServeHTTP(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("rollback test: status=%d, want 400; body=%s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "duplicate") {
+		t.Fatalf("expected duplicate-manifest error, got body=%s", rr.Body.String())
+	}
+
+	// Workspace must be gone from listings.
+	rr = doRequest(dest, "GET", "/api/v1/workspaces", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("list workspaces: %d", rr.Code)
+	}
+	if strings.Contains(rr.Body.String(), `"slug":"Tombstoned"`) || strings.Contains(rr.Body.String(), `"name":"Tombstoned"`) {
+		t.Errorf("workspace was NOT rolled back; listing body=%s", rr.Body.String())
+	}
+
+	// Critically: every attachment row that the partial-import
+	// rehydrated must now have deleted_at set so orphan-GC can
+	// reclaim the blobs. Querying the store directly because the
+	// workspace is gone from the API surface.
+	var live int
+	if err := dest.store.DB().QueryRow(
+		`SELECT COUNT(*) FROM attachments WHERE deleted_at IS NULL`,
+	).Scan(&live); err != nil {
+		t.Fatalf("count live attachments: %v", err)
+	}
+	if live != 0 {
+		t.Errorf("rollback left %d live attachment rows; expected 0 (all should be tombstoned)", live)
+	}
+}
+
 // TestIsSafeBundleEntryName covers isSafeBundleEntryName as a pure
 // helper. Some inputs (NUL bytes, empty strings) can't be exercised
 // through archive/tar — Go's tar.WriteHeader refuses to encode them

--- a/internal/server/handlers_import_bundle_test.go
+++ b/internal/server/handlers_import_bundle_test.go
@@ -247,6 +247,192 @@ func TestImportBundle_RejectsBadGzip(t *testing.T) {
 	}
 }
 
+// TestImportBundle_RejectsDuplicateExport pins the duplicate-entry
+// guard added during the PLAN-890 audit (TASK-891). A bundle that
+// contains two pad-export.json entries used to call ImportWorkspace
+// twice — leaving the first workspace as an orphan with no
+// attachments. The handler now rejects the second occurrence with a
+// 400 so the failure is loud.
+func TestImportBundle_RejectsDuplicateExport(t *testing.T) {
+	// Build a real, valid pad-export.json by exporting an empty
+	// workspace from a live server, then assemble a tar.gz that
+	// includes it twice.
+	src, srcSlug := testServerWithAttachments(t)
+	rr := doRequest(src, "GET", "/api/v1/workspaces/"+srcSlug+"/export", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("export src: %d %s", rr.Code, rr.Body.String())
+	}
+	exportJSON := rr.Body.Bytes()
+
+	var buf bytes.Buffer
+	gzw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gzw)
+	for i := 0; i < 2; i++ {
+		if err := tw.WriteHeader(&tar.Header{Name: "pad-export.json", Mode: 0o644, Size: int64(len(exportJSON))}); err != nil {
+			t.Fatalf("write header: %v", err)
+		}
+		if _, err := tw.Write(exportJSON); err != nil {
+			t.Fatalf("write export: %v", err)
+		}
+	}
+	tw.Close()
+	gzw.Close()
+
+	dest, _ := testServerWithAttachments(t)
+	req := httptest.NewRequest("POST", "/api/v1/workspaces/import?name=DupExport",
+		bytes.NewReader(buf.Bytes()))
+	req.Header.Set("Content-Type", "application/gzip")
+	req.RemoteAddr = "127.0.0.1:1234"
+	rr = httptest.NewRecorder()
+	dest.ServeHTTP(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("duplicate export: status=%d, want 400; body=%s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "duplicate") {
+		t.Errorf("expected duplicate-export error, got body=%s", rr.Body.String())
+	}
+}
+
+// TestImportBundle_RejectsDuplicateManifest pins the matching guard
+// for attachments/manifest.json. A second occurrence would silently
+// overwrite manifestByPath and any blobs that matched the first
+// manifest's keys would look orphaned — mark as a consumed-skip and
+// be lost.
+func TestImportBundle_RejectsDuplicateManifest(t *testing.T) {
+	src, srcSlug := testServerWithAttachments(t)
+	rr := doRequest(src, "GET", "/api/v1/workspaces/"+srcSlug+"/export", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("export src: %d %s", rr.Code, rr.Body.String())
+	}
+	exportJSON := rr.Body.Bytes()
+
+	// Hand-build the manifest bytes — tiny empty manifest is fine for
+	// this test; we only care that it parses, and a second copy
+	// triggers the guard.
+	manifest := []byte(`{"version":1,"entries":[]}`)
+
+	var buf bytes.Buffer
+	gzw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gzw)
+	if err := tw.WriteHeader(&tar.Header{Name: "pad-export.json", Mode: 0o644, Size: int64(len(exportJSON))}); err != nil {
+		t.Fatalf("write export header: %v", err)
+	}
+	if _, err := tw.Write(exportJSON); err != nil {
+		t.Fatalf("write export: %v", err)
+	}
+	for i := 0; i < 2; i++ {
+		if err := tw.WriteHeader(&tar.Header{Name: "attachments/manifest.json", Mode: 0o644, Size: int64(len(manifest))}); err != nil {
+			t.Fatalf("write manifest header: %v", err)
+		}
+		if _, err := tw.Write(manifest); err != nil {
+			t.Fatalf("write manifest: %v", err)
+		}
+	}
+	tw.Close()
+	gzw.Close()
+
+	dest, _ := testServerWithAttachments(t)
+	req := httptest.NewRequest("POST", "/api/v1/workspaces/import?name=DupManifest",
+		bytes.NewReader(buf.Bytes()))
+	req.Header.Set("Content-Type", "application/gzip")
+	req.RemoteAddr = "127.0.0.1:1234"
+	rr = httptest.NewRecorder()
+	dest.ServeHTTP(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("duplicate manifest: status=%d, want 400; body=%s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "duplicate") {
+		t.Errorf("expected duplicate-manifest error, got body=%s", rr.Body.String())
+	}
+}
+
+// TestImportBundle_RejectsPathTraversal pins the defense-in-depth
+// reject of tar entries with `..` segments or absolute paths. The
+// storage backend is hash-keyed so a malicious entry name can't
+// actually escape the attachment store, but rejecting up front
+// keeps the audit story unambiguous and means hand-edited bundles
+// fail loudly rather than slipping through the default arm.
+//
+// Cases involving NUL bytes are covered by the unit test on
+// isSafeBundleEntryName below — Go's archive/tar refuses to encode a
+// NUL-bearing header name, so we can't exercise that path through
+// the integration handler.
+func TestImportBundle_RejectsPathTraversal(t *testing.T) {
+	cases := []struct {
+		name    string
+		entry   string
+		wantErr string
+	}{
+		{"dot-dot in path", "attachments/../../etc/passwd", "unsafe entry name"},
+		{"absolute unix path", "/etc/passwd", "unsafe entry name"},
+		{"absolute windows path", "\\windows\\system32\\config", "unsafe entry name"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			gzw := gzip.NewWriter(&buf)
+			tw := tar.NewWriter(gzw)
+			if err := tw.WriteHeader(&tar.Header{Name: tc.entry, Mode: 0o644, Size: 4}); err != nil {
+				t.Fatalf("write header: %v", err)
+			}
+			if _, err := tw.Write([]byte{0xde, 0xad, 0xbe, 0xef}); err != nil {
+				t.Fatalf("write blob: %v", err)
+			}
+			tw.Close()
+			gzw.Close()
+
+			srv, _ := testServerWithAttachments(t)
+			req := httptest.NewRequest("POST", "/api/v1/workspaces/import",
+				bytes.NewReader(buf.Bytes()))
+			req.Header.Set("Content-Type", "application/gzip")
+			req.RemoteAddr = "127.0.0.1:1234"
+			rr := httptest.NewRecorder()
+			srv.ServeHTTP(rr, req)
+			if rr.Code != http.StatusBadRequest {
+				t.Errorf("%s: status=%d, want 400; body=%s", tc.name, rr.Code, rr.Body.String())
+			}
+			if !strings.Contains(rr.Body.String(), tc.wantErr) {
+				t.Errorf("%s: expected %q in body, got %s", tc.name, tc.wantErr, rr.Body.String())
+			}
+		})
+	}
+}
+
+// TestIsSafeBundleEntryName covers isSafeBundleEntryName as a pure
+// helper. Some inputs (NUL bytes, empty strings) can't be exercised
+// through archive/tar — Go's tar.WriteHeader refuses to encode them
+// — so we test the helper directly to keep the defense-in-depth
+// guarantees verifiable.
+func TestIsSafeBundleEntryName(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"normal export", "pad-export.json", true},
+		{"normal manifest", "attachments/manifest.json", true},
+		{"normal blob", "attachments/abc123.png", true},
+		{"single dot segment is fine", "./pad-export.json", true},
+		{"empty string", "", false},
+		{"absolute unix", "/etc/passwd", false},
+		{"absolute windows", "\\windows\\system32", false},
+		{"dot-dot prefix", "../etc/passwd", false},
+		{"dot-dot mid", "attachments/../../etc/passwd", false},
+		{"dot-dot only", "..", false},
+		{"NUL byte mid", "attachments/foo\x00.png", false},
+		{"backslash dot-dot", "attachments\\..\\..\\etc", false},
+		{"trailing dot-dot", "attachments/..", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isSafeBundleEntryName(tc.in)
+			if got != tc.want {
+				t.Errorf("isSafeBundleEntryName(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
 // readBundleAsBytes is a tiny helper for callers that want the raw
 // bundle to feed straight into another POST. Kept separate from
 // readBundle (which extracts a map) so import-side tests don't have

--- a/internal/server/handlers_import_bundle_test.go
+++ b/internal/server/handlers_import_bundle_test.go
@@ -252,7 +252,9 @@ func TestImportBundle_RejectsBadGzip(t *testing.T) {
 // contains two pad-export.json entries used to call ImportWorkspace
 // twice — leaving the first workspace as an orphan with no
 // attachments. The handler now rejects the second occurrence with a
-// 400 so the failure is loud.
+// 400 AND rolls back the partial workspace from the first occurrence
+// so a malformed bundle can't pile up half-imported workspaces in
+// the destination. Codex P1 on PR #308.
 func TestImportBundle_RejectsDuplicateExport(t *testing.T) {
 	// Build a real, valid pad-export.json by exporting an empty
 	// workspace from a live server, then assemble a tar.gz that
@@ -290,6 +292,16 @@ func TestImportBundle_RejectsDuplicateExport(t *testing.T) {
 	}
 	if !strings.Contains(rr.Body.String(), "duplicate") {
 		t.Errorf("expected duplicate-export error, got body=%s", rr.Body.String())
+	}
+
+	// Verify the partial workspace from the first pad-export.json
+	// occurrence got rolled back. Listing must NOT include "DupExport".
+	rr = doRequest(dest, "GET", "/api/v1/workspaces", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("list workspaces: %d %s", rr.Code, rr.Body.String())
+	}
+	if strings.Contains(rr.Body.String(), `"name":"DupExport"`) || strings.Contains(rr.Body.String(), `"slug":"DupExport"`) {
+		t.Errorf("partial workspace was NOT rolled back; listing body=%s", rr.Body.String())
 	}
 }
 
@@ -343,6 +355,17 @@ func TestImportBundle_RejectsDuplicateManifest(t *testing.T) {
 	}
 	if !strings.Contains(rr.Body.String(), "duplicate") {
 		t.Errorf("expected duplicate-manifest error, got body=%s", rr.Body.String())
+	}
+
+	// Verify the partial workspace from the first pad-export.json
+	// occurrence got rolled back when the duplicate manifest was
+	// detected. Same rollback contract as TestImportBundle_RejectsDuplicateExport.
+	rr = doRequest(dest, "GET", "/api/v1/workspaces", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("list workspaces: %d %s", rr.Code, rr.Body.String())
+	}
+	if strings.Contains(rr.Body.String(), `"name":"DupManifest"`) || strings.Contains(rr.Body.String(), `"slug":"DupManifest"`) {
+		t.Errorf("partial workspace was NOT rolled back; listing body=%s", rr.Body.String())
 	}
 }
 

--- a/internal/server/handlers_import_bundle_test.go
+++ b/internal/server/handlers_import_bundle_test.go
@@ -421,6 +421,68 @@ func TestImportBundle_RejectsPathTraversal(t *testing.T) {
 	}
 }
 
+// TestImportBundle_PathTraversalAfterExportRollsBack pins Codex P1
+// round 3 on PR #308: a path-traversal entry that follows a valid
+// pad-export.json must trigger the workspace rollback, not just
+// return a 400 with the workspace left behind. Earlier the
+// path-traversal early-return passed nil instead of ws, so the
+// handler skipped the cleanup cascade.
+func TestImportBundle_PathTraversalAfterExportRollsBack(t *testing.T) {
+	// Real pad-export.json so the first entry creates a workspace.
+	src, srcSlug := testServerWithAttachments(t)
+	rr := doRequest(src, "GET", "/api/v1/workspaces/"+srcSlug+"/export", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("export src: %d %s", rr.Code, rr.Body.String())
+	}
+	exportJSON := rr.Body.Bytes()
+
+	var buf bytes.Buffer
+	gzw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gzw)
+	if err := tw.WriteHeader(&tar.Header{Name: "pad-export.json", Mode: 0o644, Size: int64(len(exportJSON))}); err != nil {
+		t.Fatalf("write export header: %v", err)
+	}
+	if _, err := tw.Write(exportJSON); err != nil {
+		t.Fatalf("write export: %v", err)
+	}
+	// Inject a path-traversal entry AFTER the valid pad-export.json
+	// so workspace creation has already happened by the time the
+	// guard fires.
+	if err := tw.WriteHeader(&tar.Header{Name: "attachments/../../etc/passwd", Mode: 0o644, Size: 4}); err != nil {
+		t.Fatalf("write evil header: %v", err)
+	}
+	if _, err := tw.Write([]byte{0xde, 0xad, 0xbe, 0xef}); err != nil {
+		t.Fatalf("write evil body: %v", err)
+	}
+	tw.Close()
+	gzw.Close()
+
+	dest, _ := testServerWithAttachments(t)
+	req := httptest.NewRequest("POST", "/api/v1/workspaces/import?name=PostExportTraversal",
+		bytes.NewReader(buf.Bytes()))
+	req.Header.Set("Content-Type", "application/gzip")
+	req.RemoteAddr = "127.0.0.1:1234"
+	rr = httptest.NewRecorder()
+	dest.ServeHTTP(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("traversal-after-export: status=%d, want 400; body=%s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "unsafe entry name") {
+		t.Errorf("expected unsafe-entry error, got body=%s", rr.Body.String())
+	}
+
+	// Workspace must be gone — the partial create from the valid
+	// pad-export.json should have been rolled back.
+	rr = doRequest(dest, "GET", "/api/v1/workspaces", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("list workspaces: %d", rr.Code)
+	}
+	if strings.Contains(rr.Body.String(), `"slug":"PostExportTraversal"`) ||
+		strings.Contains(rr.Body.String(), `"name":"PostExportTraversal"`) {
+		t.Errorf("workspace was NOT rolled back after path-traversal reject; body=%s", rr.Body.String())
+	}
+}
+
 // TestImportBundle_RollbackTombstonesAttachments pins Codex P1
 // round 2 on PR #308: when the duplicate-manifest guard fires AFTER
 // blobs have already been rehydrated, the rollback must tombstone

--- a/internal/store/attachments.go
+++ b/internal/store/attachments.go
@@ -643,6 +643,39 @@ func (s *Store) AttachmentReferencedInItems(workspaceID, attachmentID string) (b
 	return n > 0, nil
 }
 
+// SoftDeleteWorkspaceAttachments tombstones every live attachment
+// row (originals AND thumbnail variants) under a workspace in a
+// single bulk UPDATE. Used by the bundle import handler to roll back
+// a partial workspace when a validation reject fires AFTER blobs
+// have already been rehydrated — without this cascade the
+// attachment rows stay live (deleted_at IS NULL), pin their blobs
+// from orphan-GC reclamation, and continue counting toward the
+// importing user's storage usage. Codex P1 on PR #308.
+//
+// Both originals and thumbnails carry the same workspace_id, so a
+// single WHERE workspace_id = ? clause covers both. Returns the
+// number of rows tombstoned.
+//
+// The blob bytes on disk are NOT touched — content-addressed dedupe
+// means another live row may still reference the same hash, so
+// reclamation is the orphan-GC's job after the grace period.
+func (s *Store) SoftDeleteWorkspaceAttachments(workspaceID string) (int64, error) {
+	ts := now()
+	res, err := s.db.Exec(s.q(`
+		UPDATE attachments
+		SET deleted_at = ?
+		WHERE workspace_id = ? AND deleted_at IS NULL
+	`), ts, workspaceID)
+	if err != nil {
+		return 0, fmt.Errorf("soft delete workspace attachments: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("soft delete workspace attachments rows affected: %w", err)
+	}
+	return n, nil
+}
+
 // SoftDeleteAttachment marks the given attachment row deleted (and
 // every variant whose parent_id points at it) so the orphan GC will
 // reclaim the bytes after the grace period. Returns sql.ErrNoRows if


### PR DESCRIPTION
## Summary

Re-reviewed `handlers_import_bundle.go` before exposing the bundle import flow through the web UI under PLAN-890. The audit doc lives at DOC-895 (in the workspace); this PR lands the small inline fixes that surfaced.

## Inline fixes

- **Duplicate `pad-export.json` now rejected.** Previously, a second occurrence silently invoked `ImportWorkspace` again, stranding the first workspace as an orphan with no attachments.
- **Duplicate `attachments/manifest.json` now rejected.** Previously, a second occurrence silently overwrote `manifestByPath`, dropping prior entries.
- **Defense-in-depth path-traversal guard.** New `isSafeBundleEntryName` rejects tar entries with `..` segments, absolute paths, or NUL bytes BEFORE the switch. Storage was already hash-keyed and safe, but the silent-skip behavior on malicious names made the audit story unnecessarily ambiguous.
- **Auth/permissions documented inline.** Added a `// Auth:` block to `handleImportWorkspaceBundle` so future readers don't have to chase `RequireAuth` middleware through `server.go` to understand the policy.

## Tests

- `TestImportBundle_RejectsDuplicateExport`
- `TestImportBundle_RejectsDuplicateManifest`
- `TestImportBundle_RejectsPathTraversal` (3 sub-cases)
- `TestIsSafeBundleEntryName` (12 sub-cases — covers cases like NUL bytes that `archive/tar`'s writer refuses to emit, so they can't be reached via the integration test)

## Deferred (filed as follow-up tasks under PLAN-890)

- **TASK-896** — Partial-import orphan workspace on mid-stream failure. Two reasonable designs (rollback vs. `import_status=partial` flag), needs discussion. Doesn't block widening the surface to the web UI.
- **TASK-897** — Per-user storage quota enforcement on import. Gated on Phase 2 quota work — matches the upload handler's warn-only Phase 1 policy today. Both surfaces must flip together when Phase 2 lands.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` — full suite green
- [x] `cd web && npm run build` — clean (no web changes in this PR but ran for the conventional smoke)

## Context

Implements TASK-891 under PLAN-890 (Web UI workspace import/export: switch to tgz bundle).