### PR TITLE
fix(cli): construct auth login URL on CLI side to avoid 0.0.0.0 leak (TASK-839)

### DIFF
--- a/cmd/pad/cli_auth_url_test.go
+++ b/cmd/pad/cli_auth_url_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/config"
+)
+
+// TestCLIAuthBrowserURLRewritesBindAllHost covers the regression from
+// TASK-839: when the local server is bound to a bind-all address such as
+// 0.0.0.0 or ::, the CLI must NOT print a login URL containing that
+// address. Browsers do not reliably resolve 0.0.0.0/:: as connect
+// destinations. cliAuthBrowserURL delegates to cfg.BrowserURL(), which
+// is responsible for the rewrite — these cases verify the wiring stays
+// correct end-to-end.
+func TestCLIAuthBrowserURLRewritesBindAllHost(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  *config.Config
+		code string
+		want string
+	}{
+		{
+			name: "bind-all IPv4 rewritten to 127.0.0.1",
+			cfg:  &config.Config{Host: "0.0.0.0", Port: 7777},
+			code: "abc123",
+			want: "http://127.0.0.1:7777/auth/cli/abc123",
+		},
+		{
+			name: "bind-all IPv6 rewritten to 127.0.0.1",
+			cfg:  &config.Config{Host: "::", Port: 7777},
+			code: "abc123",
+			want: "http://127.0.0.1:7777/auth/cli/abc123",
+		},
+		{
+			name: "empty host rewritten to 127.0.0.1",
+			cfg:  &config.Config{Host: "", Port: 7777},
+			code: "abc123",
+			want: "http://127.0.0.1:7777/auth/cli/abc123",
+		},
+		{
+			name: "explicit loopback host preserved",
+			cfg:  &config.Config{Host: "127.0.0.1", Port: 7777},
+			code: "abc123",
+			want: "http://127.0.0.1:7777/auth/cli/abc123",
+		},
+		{
+			name: "explicit URL (Remote/Cloud) preserved verbatim",
+			cfg:  &config.Config{URL: "https://app.getpad.dev"},
+			code: "WDJBMJHT",
+			want: "https://app.getpad.dev/auth/cli/WDJBMJHT",
+		},
+		{
+			name: "explicit URL trims trailing slash before joining",
+			cfg:  &config.Config{URL: "https://app.getpad.dev/"},
+			code: "WDJBMJHT",
+			want: "https://app.getpad.dev/auth/cli/WDJBMJHT",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := cliAuthBrowserURL(tc.cfg, tc.code)
+			if got != tc.want {
+				t.Fatalf("cliAuthBrowserURL() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -698,6 +698,20 @@ func loginCmd() *cobra.Command {
 	return cmd
 }
 
+// cliAuthBrowserURL builds the auth-approval URL we print to the user during
+// `pad auth login`. We construct it on the CLI side rather than trusting the
+// server-issued auth_url field: the server builds its URL from r.Host, which
+// echoes back whatever Host header the CLI sent. If the CLI's own config
+// points at a bind-all address (e.g. the user started the server with
+// --host 0.0.0.0), that address would end up in the printed URL and is not
+// a usable browser destination. cfg.BrowserURL() already handles the
+// "rewrite unspecified host to 127.0.0.1" rule for the local-server case
+// and returns the explicit URL verbatim for Remote/Cloud, so it's the
+// right source of truth.
+func cliAuthBrowserURL(cfg *config.Config, sessionCode string) string {
+	return fmt.Sprintf("%s/auth/cli/%s", cfg.BrowserURL(), sessionCode)
+}
+
 // doBrowserLogin implements the browser-based CLI auth flow.
 // It creates a pending session, prints the auth URL, and polls until approved.
 func doBrowserLogin(client *cli.Client, cfg *config.Config) error {
@@ -707,11 +721,13 @@ func doBrowserLogin(client *cli.Client, cfg *config.Config) error {
 		return fmt.Errorf("failed to start login session: %w", err)
 	}
 
+	authURL := cliAuthBrowserURL(cfg, sess.SessionCode)
+
 	fmt.Println()
 	fmt.Println("  Open this URL in your browser to authenticate:")
 	fmt.Println()
 	bold := color.New(color.Bold).SprintFunc()
-	fmt.Printf("  %s\n", bold(sess.AuthURL))
+	fmt.Printf("  %s\n", bold(authURL))
 	fmt.Println()
 	fmt.Println("  Waiting for authentication...")
 

--- a/internal/server/handlers_import_bundle_test.go
+++ b/internal/server/handlers_import_bundle_test.go
@@ -632,16 +632,3 @@ func TestIsSafeBundleEntryName(t *testing.T) {
 		})
 	}
 }
-
-// readBundleAsBytes is a tiny helper for callers that want the raw
-// bundle to feed straight into another POST. Kept separate from
-// readBundle (which extracts a map) so import-side tests don't have
-// to re-encode the bundle.
-func readBundleAsBytes(t *testing.T, body io.Reader) []byte {
-	t.Helper()
-	out, err := io.ReadAll(body)
-	if err != nil {
-		t.Fatalf("read bundle: %v", err)
-	}
-	return out
-}


### PR DESCRIPTION
## Summary
- The server constructs the CLI auth-approval URL from `r.Host`, which echoes back whatever Host header the CLI sent. When the local server is bound to `--host 0.0.0.0`, `pad auth login` printed `http://0.0.0.0:7777/auth/cli/{code}` — a bind address, not a usable browser destination.
- Build the URL on the CLI side instead, from `cfg.BrowserURL()` + `session_code`. `BrowserURL()` already rewrites `0.0.0.0` / `::` / empty to `127.0.0.1` and returns the explicit URL verbatim for Remote/Cloud, so it's the right source of truth.
- Extracts a small `cliAuthBrowserURL` helper and adds regression coverage for IPv4/IPv6 bind-all, empty host, explicit loopback, explicit Remote URL, and trailing-slash trim.

Closes TASK-839 (carved out of the TASK-834 PR review pass).

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (full Go suite)
- [x] `go test ./cmd/pad/ -run TestCLIAuthBrowserURL -v` — all 6 cases pass
- [x] `go vet ./cmd/pad/` clean
- [x] `make install` — web build + binary build clean, server restarted
- [ ] Manual: start server with `pad server start --host 0.0.0.0`, run `pad auth login`, confirm printed URL has `127.0.0.1` host