### PR TITLE
feat(auth): shared marketing header on auth-page family in Cloud mode (TASK-902)

### DIFF
--- a/web/src/lib/components/auth/AuthHeader.svelte
+++ b/web/src/lib/components/auth/AuthHeader.svelte
@@ -1,0 +1,216 @@
+<script lang="ts">
+	// Top header for the auth-page family on Pad Cloud installs (login, register,
+	// forgot-password, reset-password, join, OAuth-error landings).
+	//
+	// Renders the same visual contract as getpad.dev's marketing header so the
+	// marketing → product handoff (clicking "Login" / "Sign Up" on getpad.dev)
+	// does not reset the user's sense of being on the same property.
+	//
+	// Visual contract: docs/brand.md, sections 5–6. The structural source of
+	// truth is pad-web/src/routes/+layout.svelte. When changing tokens, header
+	// structure, or link list here, update that file (and the brand doc) too.
+	//
+	// Self-hosted (cloudMode === false) renders nothing — operators ship Pad
+	// under their own brand and must not get getpad.dev chrome imposed on them.
+	// This matches the existing pattern in LegalFooter.svelte / SupportFooter.svelte.
+
+	let { cloudMode = false }: { cloudMode?: boolean } = $props();
+
+	let mobileMenuOpen = $state(false);
+
+	// Link list mirrors pad-web's marketing nav (Docs / Blog / GitHub) but
+	// points at absolute marketing URLs explicitly — auth pages are pre-login,
+	// the user has no workspace context, and these are "go back to the
+	// marketing site" links rather than in-app nav.
+	const navLinks: Array<{ label: string; href: string }> = [
+		{ label: 'Docs', href: 'https://getpad.dev/docs' },
+		{ label: 'Blog', href: 'https://getpad.dev/blog' },
+		{ label: 'GitHub', href: 'https://github.com/PerpetualSoftware/pad' }
+	];
+
+	function handleKeydown(event: KeyboardEvent) {
+		if (event.key === 'Escape' && mobileMenuOpen) {
+			mobileMenuOpen = false;
+		}
+	}
+</script>
+
+<!-- svelte:window must be top-level (Svelte requires meta tags outside blocks).
+     Safe to register unconditionally: handleKeydown only acts on mobileMenuOpen,
+     which can only be true when cloudMode is true (the toggle only renders in
+     the cloud branch below). On self-hosted the listener is a cheap no-op. -->
+<svelte:window onkeydown={handleKeydown} />
+
+{#if cloudMode}
+	<header class="auth-header">
+		<nav class="auth-header-nav" aria-label="Marketing navigation">
+			<a href="https://getpad.dev/" class="auth-header-wordmark">pad</a>
+
+			<div class="auth-header-links">
+				{#each navLinks as link (link.label)}
+					<a
+						href={link.href}
+						target="_blank"
+						rel="noopener noreferrer"
+						class="auth-header-link"
+					>
+						{link.label}
+					</a>
+				{/each}
+			</div>
+
+			<button
+				type="button"
+				class="auth-header-toggle"
+				onclick={() => (mobileMenuOpen = !mobileMenuOpen)}
+				aria-label="Toggle menu"
+				aria-expanded={mobileMenuOpen}
+				aria-controls="auth-header-mobile-menu"
+			>
+				{#if mobileMenuOpen}
+					<svg
+						xmlns="http://www.w3.org/2000/svg"
+						width="20"
+						height="20"
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="currentColor"
+						stroke-width="2"
+						stroke-linecap="round"
+						stroke-linejoin="round"
+						aria-hidden="true"
+					>
+						<line x1="18" y1="6" x2="6" y2="18" />
+						<line x1="6" y1="6" x2="18" y2="18" />
+					</svg>
+				{:else}
+					<svg
+						xmlns="http://www.w3.org/2000/svg"
+						width="20"
+						height="20"
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="currentColor"
+						stroke-width="2"
+						stroke-linecap="round"
+						stroke-linejoin="round"
+						aria-hidden="true"
+					>
+						<line x1="4" y1="8" x2="20" y2="8" />
+						<line x1="4" y1="16" x2="20" y2="16" />
+					</svg>
+				{/if}
+			</button>
+		</nav>
+
+		{#if mobileMenuOpen}
+			<div id="auth-header-mobile-menu" class="auth-header-mobile-menu">
+				{#each navLinks as link (link.label)}
+					<a
+						href={link.href}
+						target="_blank"
+						rel="noopener noreferrer"
+						class="auth-header-link"
+						onclick={() => (mobileMenuOpen = false)}
+					>
+						{link.label}
+					</a>
+				{/each}
+			</div>
+		{/if}
+	</header>
+{/if}
+
+<style>
+	.auth-header {
+		position: fixed;
+		top: 0;
+		left: 0;
+		right: 0;
+		z-index: 50;
+		width: 100%;
+		border-bottom: 1px solid var(--border-subtle);
+		/* 80% opacity over --bg-primary (#1a1a1a) gives the soft-glass effect.
+		   Hex equivalent of rgba(26,26,26,0.8) — kept inline because we want
+		   to match pad-web's bg-bg/80 backdrop-blur pattern byte-for-byte and
+		   the app's CSS variable system doesn't expose alpha-modified tokens. */
+		background-color: rgba(26, 26, 26, 0.8);
+		backdrop-filter: blur(20px);
+		-webkit-backdrop-filter: blur(20px);
+	}
+
+	.auth-header-nav {
+		margin: 0 auto;
+		max-width: 72rem; /* matches pad-web's max-w-6xl (1152px) */
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: var(--space-4) var(--space-6);
+	}
+
+	.auth-header-wordmark {
+		font-size: 1.125rem; /* text-lg */
+		font-weight: 700;
+		letter-spacing: -0.025em;
+		color: var(--text-primary);
+		text-decoration: none;
+	}
+
+	.auth-header-wordmark:hover,
+	.auth-header-wordmark:focus-visible {
+		text-decoration: none;
+	}
+
+	.auth-header-links {
+		display: none;
+		align-items: center;
+		gap: var(--space-8);
+	}
+
+	.auth-header-link {
+		font-size: 0.875rem; /* text-sm */
+		color: var(--text-secondary);
+		text-decoration: none;
+		transition: color 150ms ease;
+	}
+
+	.auth-header-link:hover,
+	.auth-header-link:focus-visible {
+		color: var(--text-primary);
+		text-decoration: none;
+	}
+
+	.auth-header-toggle {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		color: var(--text-secondary);
+		background: transparent;
+		border: none;
+		padding: 0;
+		cursor: pointer;
+	}
+
+	.auth-header-toggle:hover {
+		color: var(--text-primary);
+	}
+
+	.auth-header-mobile-menu {
+		border-top: 1px solid var(--border-subtle);
+		padding: var(--space-4) var(--space-6);
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-4);
+	}
+
+	/* md breakpoint = 768px (Tailwind default; matches pad-web's md:flex). */
+	@media (min-width: 768px) {
+		.auth-header-links {
+			display: flex;
+		}
+		.auth-header-toggle,
+		.auth-header-mobile-menu {
+			display: none;
+		}
+	}
+</style>

--- a/web/src/routes/forgot-password/+page.svelte
+++ b/web/src/routes/forgot-password/+page.svelte
@@ -2,6 +2,7 @@
 	import { onMount } from 'svelte';
 	import { api } from '$lib/api/client';
 	import { authStore } from '$lib/stores/auth.svelte';
+	import AuthHeader from '$lib/components/auth/AuthHeader.svelte';
 	import LegalFooter from '$lib/components/auth/LegalFooter.svelte';
 	import SupportFooter from '$lib/components/auth/SupportFooter.svelte';
 
@@ -48,9 +49,13 @@
 	}
 </script>
 
-<div class="page">
+<AuthHeader cloudMode={authStore.cloudMode} />
+
+<div class="page" class:cloud-mode={authStore.cloudMode}>
 	<div class="card">
-		<h1 class="logo">Pad</h1>
+		{#if !authStore.cloudMode}
+			<h1 class="logo">Pad</h1>
+		{/if}
 
 		{#if sent}
 			<p class="subtitle">Check your email</p>
@@ -108,6 +113,10 @@
 		min-height: 100vh;
 		background: var(--bg-primary);
 		padding: var(--space-4);
+	}
+
+	.page.cloud-mode {
+		padding-top: 4rem;
 	}
 
 	.card {

--- a/web/src/routes/join/[code]/+page.svelte
+++ b/web/src/routes/join/[code]/+page.svelte
@@ -3,7 +3,9 @@
 	import { goto } from '$app/navigation';
 	import { page } from '$app/state';
 	import { api } from '$lib/api/client';
+	import { authStore } from '$lib/stores/auth.svelte';
 	import SetupRequiredNotice from '$lib/components/auth/SetupRequiredNotice.svelte';
+	import AuthHeader from '$lib/components/auth/AuthHeader.svelte';
 
 	let code = $derived(page.params.code ?? '');
 	let status = $state<'loading' | 'login' | 'register' | 'accepting' | 'error' | 'setup' | '2fa'>('loading');
@@ -29,6 +31,13 @@
 	let checkTimeout: ReturnType<typeof setTimeout> | null = null;
 
 	onMount(async () => {
+		// Hydrate authStore so AuthHeader can branch on cloudMode (matching the
+		// pattern in /forgot-password and /reset-password). Fire-and-forget so
+		// it does not delay the join-flow logic below — the header just won't
+		// render its Cloud branch on the very first paint if the session
+		// fetch is mid-flight, and it lights up once authStore resolves.
+		authStore.ensureLoaded().catch(() => {});
+
 		try {
 			const session = await api.auth.session();
 			if (session.authenticated) {
@@ -192,9 +201,13 @@
 	}
 </script>
 
-<div class="join-page">
+<AuthHeader cloudMode={authStore.cloudMode} />
+
+<div class="join-page" class:cloud-mode={authStore.cloudMode}>
 	<div class="join-card">
-		<h1 class="logo">Pad</h1>
+		{#if !authStore.cloudMode}
+			<h1 class="logo">Pad</h1>
+		{/if}
 
 		{#if status === 'loading'}
 			<p class="subtitle">Checking invitation...</p>
@@ -336,6 +349,10 @@
 		min-height: 100vh;
 		background: var(--bg-primary);
 		padding: var(--space-4);
+	}
+
+	.join-page.cloud-mode {
+		padding-top: 4rem;
 	}
 
 	.join-card {

--- a/web/src/routes/login/+page.svelte
+++ b/web/src/routes/login/+page.svelte
@@ -5,6 +5,7 @@
 	import { authStore } from '$lib/stores/auth.svelte';
 	import { goto } from '$app/navigation';
 	import SetupRequiredNotice from '$lib/components/auth/SetupRequiredNotice.svelte';
+	import AuthHeader from '$lib/components/auth/AuthHeader.svelte';
 	import LegalFooter from '$lib/components/auth/LegalFooter.svelte';
 	import SupportFooter from '$lib/components/auth/SupportFooter.svelte';
 
@@ -233,9 +234,13 @@
 	}
 </script>
 
-<div class="login-page">
+<AuthHeader {cloudMode} />
+
+<div class="login-page" class:cloud-mode={cloudMode}>
 	<div class="login-card">
-		<h1 class="logo">Pad</h1>
+		{#if !cloudMode}
+			<h1 class="logo">Pad</h1>
+		{/if}
 
 		{#if oauthBanner}
 			<div
@@ -399,6 +404,14 @@
 		min-height: 100vh;
 		background: var(--bg-primary);
 		padding: var(--space-4);
+	}
+
+	/* On Cloud the AuthHeader is fixed at the top; reserve room so the auth
+	   card does not slide under it. 4rem matches the header's effective
+	   height (text-lg wordmark + py-4 padding ≈ 56–64px depending on line
+	   metrics; we round up to the brand-spec value of pt-16 = 4rem). */
+	.login-page.cloud-mode {
+		padding-top: 4rem;
 	}
 
 	.login-card {

--- a/web/src/routes/register/+page.svelte
+++ b/web/src/routes/register/+page.svelte
@@ -3,6 +3,7 @@
 	import { api } from '$lib/api/client';
 	import { goto } from '$app/navigation';
 	import SetupRequiredNotice from '$lib/components/auth/SetupRequiredNotice.svelte';
+	import AuthHeader from '$lib/components/auth/AuthHeader.svelte';
 	import LegalFooter from '$lib/components/auth/LegalFooter.svelte';
 	import SupportFooter from '$lib/components/auth/SupportFooter.svelte';
 	import { authStore } from '$lib/stores/auth.svelte';
@@ -131,9 +132,13 @@
 	}
 </script>
 
-<div class="register-page">
+<AuthHeader cloudMode={authStore.cloudMode} />
+
+<div class="register-page" class:cloud-mode={authStore.cloudMode}>
 	<div class="register-card">
-		<h1 class="logo">Pad</h1>
+		{#if !authStore.cloudMode}
+			<h1 class="logo">Pad</h1>
+		{/if}
 		{#if setupRequired}
 			<SetupRequiredNotice
 				{setupMethod}
@@ -242,6 +247,10 @@
 		min-height: 100vh;
 		background: var(--bg-primary);
 		padding: var(--space-4);
+	}
+
+	.register-page.cloud-mode {
+		padding-top: 4rem;
 	}
 
 	.register-card {

--- a/web/src/routes/reset-password/[token]/+page.svelte
+++ b/web/src/routes/reset-password/[token]/+page.svelte
@@ -1,9 +1,21 @@
 <script lang="ts">
+	import { onMount } from 'svelte';
 	import { page } from '$app/state';
 	import { goto } from '$app/navigation';
 	import { api } from '$lib/api/client';
+	import { authStore } from '$lib/stores/auth.svelte';
+	import AuthHeader from '$lib/components/auth/AuthHeader.svelte';
 
 	let token = $derived(page.params.token ?? '');
+
+	onMount(() => {
+		// Hydrate authStore so AuthHeader can branch on cloudMode. See the
+		// matching pattern in /forgot-password — without this, a user landing
+		// on a reset-password link after a logout sees the self-hosted layout
+		// even on Pad Cloud. Swallow fetch errors so the reset flow stays
+		// usable even if the session endpoint is unreachable.
+		authStore.ensureLoaded().catch(() => {});
+	});
 
 	let password = $state('');
 	let confirmPassword = $state('');
@@ -44,9 +56,13 @@
 	}
 </script>
 
-<div class="page">
+<AuthHeader cloudMode={authStore.cloudMode} />
+
+<div class="page" class:cloud-mode={authStore.cloudMode}>
 	<div class="card">
-		<h1 class="logo">Pad</h1>
+		{#if !authStore.cloudMode}
+			<h1 class="logo">Pad</h1>
+		{/if}
 		<p class="subtitle">Set a new password</p>
 
 		<div class="form">
@@ -95,6 +111,10 @@
 		min-height: 100vh;
 		background: var(--bg-primary);
 		padding: var(--space-4);
+	}
+
+	.page.cloud-mode {
+		padding-top: 4rem;
 	}
 
 	.card {


### PR DESCRIPTION
## Summary
- New \`<AuthHeader cloudMode={...} />\` Svelte component in \`web/src/lib/components/auth/\` rendering the same visual contract as \`pad-web/src/routes/+layout.svelte\` (fixed top, blur backdrop, \`pad\` wordmark, Docs/Blog/GitHub links, mobile hamburger).
- Wired into all five auth-family pages: \`/login\`, \`/register\`, \`/forgot-password\`, \`/reset-password/[token]\`, \`/join/[code]\`.
- Self-hosted (\`cloudMode === false\`) renders nothing — operators stay neutral. Same pattern as existing \`LegalFooter\` / \`SupportFooter\`.
- Inline \`<h1>Pad</h1>\` wordmark on each card hidden in Cloud (header carries it); kept on self-hosted (header is absent).
- \`.cloud-mode\` class on each page wrapper adds \`padding-top: 4rem\` so the auth card doesn't collide with the fixed header.

## Context
Implements [TASK-902](https://github.com/PerpetualSoftware/pad) under [PLAN-900](https://github.com/PerpetualSoftware/pad). Visual contract anchored on \`docs/brand.md\` sections 5–6 (the brand spec from TASK-904).

## Notable details
- \`/reset-password/[token]\` and \`/join/[code]\` did not previously hydrate \`authStore\`; both now call \`authStore.ensureLoaded()\` in \`onMount\` matching the existing pattern in \`/forgot-password\`.
- Svelte autofixer caught a misplaced \`<svelte:window>\` (originally inside the \`{#if cloudMode}\` block); corrected to top-level with a comment explaining why it's safe to register unconditionally (the keydown handler only acts on \`mobileMenuOpen\`, which can only be true in the cloud branch).
- No new env var: every Cloud check uses the existing \`cloud_mode\` flag plumbed through \`/api/v1/auth/session\` → \`authStore.cloudMode\`.

## Out of scope
- Footer parity (TASK-903)
- Inter / JetBrains Mono font loading — auth pages still inherit the app's \`--font-ui\` (system-ui). The brand spec allows this; if pixel-parity at the font level is desired, that's a separate task.
- Operator-customizable header for self-hosted (deferred per PLAN-900).

## Test plan
- [x] \`web/npm run check\` — 0 errors (6 pre-existing warnings in unrelated files)
- [x] \`web/npm run build\` — clean (15.7s)
- [x] \`go build ./... && go vet ./... && go test ./...\` — all pass
- [x] Svelte autofixer — clean
- [ ] Manual: \`pad server start --host 0.0.0.0\` → \`/login\` shows no header (self-hosted); production \`app.getpad.dev/login\` should show header (Cloud)
- [ ] Manual: mobile hamburger toggle on each auth-family page