### PR TITLE
feat(email): cloud-mode marketing footer in transactional emails (TASK-907)

### DIFF
--- a/internal/email/sender.go
+++ b/internal/email/sender.go
@@ -18,13 +18,14 @@ import (
 // The from address and name are defaults; individual send methods can
 // override them for contextual sender names (e.g. "Dave via Pad").
 type Sender struct {
-	mu       sync.RWMutex
-	apiKey   string
-	fromAddr string
-	fromName string
-	baseURL  string // Pad's public base URL for generating links
-	endpoint string // Maileroo API endpoint (overridable for tests)
-	client   *http.Client
+	mu        sync.RWMutex
+	apiKey    string
+	fromAddr  string
+	fromName  string
+	baseURL   string // Pad's public base URL for generating links
+	endpoint  string // Maileroo API endpoint (overridable for tests)
+	cloudMode bool   // adds getpad.dev marketing footer to outgoing emails
+	client    *http.Client
 }
 
 // defaultEndpoint is the Maileroo v2 email sending API.
@@ -68,6 +69,25 @@ func (s *Sender) SetEndpoint(url string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.endpoint = url
+}
+
+// SetCloudMode toggles the getpad.dev marketing footer on outgoing
+// transactional emails. Server callers flip it on after Server.SetCloudMode
+// fires (see internal/server/server.go). Self-hosted deployments leave it
+// off so emails stay neutral. Thread-safe.
+func (s *Sender) SetCloudMode(enabled bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.cloudMode = enabled
+}
+
+// CloudMode reports whether the marketing footer is currently enabled.
+// Templates read it through getCloudMode() so they pick up the same
+// snapshot for the entire render of one email. Thread-safe.
+func (s *Sender) CloudMode() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.cloudMode
 }
 
 // BaseURL returns the configured base URL.

--- a/internal/email/shell.go
+++ b/internal/email/shell.go
@@ -1,0 +1,104 @@
+package email
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// buildHTMLShell wraps body HTML in the standard transactional-email
+// chrome — header (Pad wordmark) + body + footer note + (Cloud only)
+// marketing footer (copyright line + canonical link list).
+//
+// Self-hosted output is byte-equivalent to the prior inline templates so
+// operators see no visible change after this refactor — they ship Pad
+// under their own brand and getpad.dev marketing links would be wrong on
+// their notifications.
+//
+// Visual contract: docs/brand.md §6 (header) + §7 (footer link order).
+// Email is light-themed for cross-client readability — emails generally
+// don't follow the dark theme of the in-app surfaces. The accent color
+// (#2563eb) is kept from the prior templates because it has known
+// contrast properties on light backgrounds.
+//
+// The bodyHTML parameter is interpolated verbatim — callers must
+// HTML-escape any user-controlled content before passing it in. The
+// footerNote is a single-paragraph "you received this because…"
+// disclosure rendered in the small grey footer text directly above
+// the optional marketing block.
+func buildHTMLShell(bodyHTML, footerNoteHTML string, cloudMode bool) string {
+	var b strings.Builder
+	b.WriteString(`<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"></head>
+<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; color: #1a1a1a; max-width: 560px; margin: 0 auto; padding: 40px 20px;">
+  <div style="margin-bottom: 32px;">
+    <strong style="font-size: 18px;">Pad</strong>
+  </div>
+`)
+	b.WriteString(bodyHTML)
+	b.WriteString(`  <hr style="border: none; border-top: 1px solid #e5e5e5; margin: 32px 0;" />
+`)
+	if footerNoteHTML != "" {
+		b.WriteString(`  <p style="font-size: 12px; color: #999;">
+    `)
+		b.WriteString(footerNoteHTML)
+		b.WriteString(`
+  </p>
+`)
+	}
+	if cloudMode {
+		// Marketing footer block — the same getpad.dev link set the auth-page
+		// AuthFooter component carries (docs/brand.md §7), trimmed to the
+		// links most relevant from an inbox: Docs / Changelog / GitHub /
+		// Privacy / Terms. Sub-processors / Security / FAQ / Contribute are
+		// omitted to keep the email small; users can reach them via the docs
+		// site once they click in.
+		year := time.Now().UTC().Year()
+		b.WriteString(fmt.Sprintf(`  <p style="font-size: 11px; color: #999; line-height: 1.5; margin-top: 16px;">
+    <a href="https://github.com/PerpetualSoftware/pad" style="color: #999; text-decoration: underline;">GitHub</a>
+    &nbsp;·&nbsp;
+    <a href="https://getpad.dev/docs" style="color: #999; text-decoration: underline;">Docs</a>
+    &nbsp;·&nbsp;
+    <a href="https://getpad.dev/changelog" style="color: #999; text-decoration: underline;">Changelog</a>
+    &nbsp;·&nbsp;
+    <a href="https://getpad.dev/privacy" style="color: #999; text-decoration: underline;">Privacy</a>
+    &nbsp;·&nbsp;
+    <a href="https://getpad.dev/terms" style="color: #999; text-decoration: underline;">Terms</a>
+  </p>
+  <p style="font-size: 11px; color: #aaa; margin-top: 8px;">
+    &copy; %d Pad &middot; Perpetual Software
+  </p>
+`, year))
+	}
+	b.WriteString(`</body>
+</html>`)
+	return b.String()
+}
+
+// buildPlainShell builds the plain-text body for transactional emails.
+// Self-hosted output is byte-equivalent to the prior templates. Cloud
+// output adds a small marketing-link block and copyright line below the
+// per-template footer note. Plain text intentionally stays minimal —
+// no chrome, no decorative separators beyond the dashed rule.
+func buildPlainShell(bodyText, footerNoteText string, cloudMode bool) string {
+	var b strings.Builder
+	b.WriteString(bodyText)
+	if footerNoteText != "" {
+		b.WriteString("\n\n---\n")
+		b.WriteString(footerNoteText)
+	}
+	if cloudMode {
+		year := time.Now().UTC().Year()
+		b.WriteString(fmt.Sprintf(`
+
+GitHub:    https://github.com/PerpetualSoftware/pad
+Docs:      https://getpad.dev/docs
+Changelog: https://getpad.dev/changelog
+Privacy:   https://getpad.dev/privacy
+Terms:     https://getpad.dev/terms
+
+(c) %d Pad — Perpetual Software`, year))
+	}
+	return b.String()
+}

--- a/internal/email/shell.go
+++ b/internal/email/shell.go
@@ -48,12 +48,13 @@ func buildHTMLShell(bodyHTML, footerNoteHTML string, cloudMode bool) string {
 `)
 	}
 	if cloudMode {
-		// Marketing footer block — the same getpad.dev link set the auth-page
-		// AuthFooter component carries (docs/brand.md §7), trimmed to the
-		// links most relevant from an inbox: Docs / Changelog / GitHub /
-		// Privacy / Terms. Sub-processors / Security / FAQ / Contribute are
-		// omitted to keep the email small; users can reach them via the docs
-		// site once they click in.
+		// Marketing footer block — full canonical link list from docs/brand.md
+		// §7, in the order the brand spec mandates: GitHub, Docs, Changelog,
+		// Contribute, FAQ, Security, Privacy, Terms, Sub-processors. The
+		// auth-page AuthFooter component carries the same nine links; emails
+		// get the same set so the brand spec's "Full parity" promise for
+		// transactional mail (§1) is honored. Codex caught a trimmed subset
+		// on first review (TASK-907 round 1).
 		year := time.Now().UTC().Year()
 		b.WriteString(fmt.Sprintf(`  <p style="font-size: 11px; color: #999; line-height: 1.5; margin-top: 16px;">
     <a href="https://github.com/PerpetualSoftware/pad" style="color: #999; text-decoration: underline;">GitHub</a>
@@ -62,9 +63,17 @@ func buildHTMLShell(bodyHTML, footerNoteHTML string, cloudMode bool) string {
     &nbsp;·&nbsp;
     <a href="https://getpad.dev/changelog" style="color: #999; text-decoration: underline;">Changelog</a>
     &nbsp;·&nbsp;
+    <a href="https://getpad.dev/contribute" style="color: #999; text-decoration: underline;">Contribute</a>
+    &nbsp;·&nbsp;
+    <a href="https://getpad.dev/faq" style="color: #999; text-decoration: underline;">FAQ</a>
+    &nbsp;·&nbsp;
+    <a href="https://getpad.dev/security" style="color: #999; text-decoration: underline;">Security</a>
+    &nbsp;·&nbsp;
     <a href="https://getpad.dev/privacy" style="color: #999; text-decoration: underline;">Privacy</a>
     &nbsp;·&nbsp;
     <a href="https://getpad.dev/terms" style="color: #999; text-decoration: underline;">Terms</a>
+    &nbsp;·&nbsp;
+    <a href="https://getpad.dev/subprocessors" style="color: #999; text-decoration: underline;">Sub-processors</a>
   </p>
   <p style="font-size: 11px; color: #aaa; margin-top: 8px;">
     &copy; %d Pad &middot; Perpetual Software
@@ -89,14 +98,22 @@ func buildPlainShell(bodyText, footerNoteText string, cloudMode bool) string {
 		b.WriteString(footerNoteText)
 	}
 	if cloudMode {
+		// Same nine canonical links as the HTML branch (docs/brand.md §7).
+		// Plain text uses fixed-width labels for legibility in monospaced
+		// mail clients; URL alignment doesn't matter visually but reads
+		// cleanly when piped through a screen reader.
 		year := time.Now().UTC().Year()
 		b.WriteString(fmt.Sprintf(`
 
-GitHub:    https://github.com/PerpetualSoftware/pad
-Docs:      https://getpad.dev/docs
-Changelog: https://getpad.dev/changelog
-Privacy:   https://getpad.dev/privacy
-Terms:     https://getpad.dev/terms
+GitHub:         https://github.com/PerpetualSoftware/pad
+Docs:           https://getpad.dev/docs
+Changelog:      https://getpad.dev/changelog
+Contribute:     https://getpad.dev/contribute
+FAQ:            https://getpad.dev/faq
+Security:       https://getpad.dev/security
+Privacy:        https://getpad.dev/privacy
+Terms:          https://getpad.dev/terms
+Sub-processors: https://getpad.dev/subprocessors
 
 (c) %d Pad — Perpetual Software`, year))
 	}

--- a/internal/email/shell_test.go
+++ b/internal/email/shell_test.go
@@ -1,0 +1,100 @@
+package email
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestBuildHTMLShellSelfHostedNeutral pins that self-hosted output
+// carries no getpad.dev marketing footer. Operators ship Pad under
+// their own brand and would not want the hosted-service footer
+// imposed on transactional emails sent from their deployment.
+func TestBuildHTMLShellSelfHostedNeutral(t *testing.T) {
+	out := buildHTMLShell("<p>body</p>", "footer note", false)
+
+	if !strings.Contains(out, "<strong style=\"font-size: 18px;\">Pad</strong>") {
+		t.Error("self-hosted should keep the Pad wordmark header")
+	}
+	if !strings.Contains(out, "<p>body</p>") {
+		t.Error("self-hosted should include the body content verbatim")
+	}
+	if !strings.Contains(out, "footer note") {
+		t.Error("self-hosted should include the footer note")
+	}
+
+	// The Cloud-only artifacts must not appear in self-hosted output.
+	cloudOnly := []string{
+		"github.com/PerpetualSoftware/pad",
+		"getpad.dev/docs",
+		"getpad.dev/changelog",
+		"getpad.dev/privacy",
+		"getpad.dev/terms",
+		"Perpetual Software",
+	}
+	for _, marker := range cloudOnly {
+		if strings.Contains(out, marker) {
+			t.Errorf("self-hosted output unexpectedly contained Cloud-only marker %q", marker)
+		}
+	}
+}
+
+// TestBuildHTMLShellCloudIncludesMarketingFooter pins the Cloud-mode
+// marketing-footer link order from docs/brand.md §7 and the copyright
+// line. The link order is GitHub → Docs → Changelog → Privacy → Terms,
+// matching the auth-page AuthFooter component (also derived from the
+// brand spec). Tests check raw substring order rather than using a
+// regex so a future code review can read the assertion at a glance.
+func TestBuildHTMLShellCloudIncludesMarketingFooter(t *testing.T) {
+	out := buildHTMLShell("<p>body</p>", "footer note", true)
+
+	for _, marker := range []string{
+		"github.com/PerpetualSoftware/pad",
+		"getpad.dev/docs",
+		"getpad.dev/changelog",
+		"getpad.dev/privacy",
+		"getpad.dev/terms",
+		"Pad &middot; Perpetual Software",
+	} {
+		if !strings.Contains(out, marker) {
+			t.Errorf("Cloud output missing marketing-footer marker %q", marker)
+		}
+	}
+
+	// Order matters per docs/brand.md §7: GitHub before Docs before
+	// Changelog before Privacy before Terms. We pin pairwise positions
+	// so a future reorder forces the test author to revisit the brand
+	// spec contract intentionally.
+	pairs := [][2]string{
+		{"github.com/PerpetualSoftware/pad", "getpad.dev/docs"},
+		{"getpad.dev/docs", "getpad.dev/changelog"},
+		{"getpad.dev/changelog", "getpad.dev/privacy"},
+		{"getpad.dev/privacy", "getpad.dev/terms"},
+	}
+	for _, pair := range pairs {
+		if strings.Index(out, pair[0]) > strings.Index(out, pair[1]) {
+			t.Errorf("Cloud footer link order violated: %q must precede %q", pair[0], pair[1])
+		}
+	}
+}
+
+// TestBuildPlainShellMatchesHTMLBranching ensures the plain-text shell
+// follows the same self-hosted vs Cloud branching as the HTML helper.
+// Plain text has its own minimal format (no chrome) but must still
+// gate the marketing-link block on cloudMode.
+func TestBuildPlainShellMatchesHTMLBranching(t *testing.T) {
+	selfHosted := buildPlainShell("hello", "received because…", false)
+	cloud := buildPlainShell("hello", "received because…", true)
+
+	if !strings.Contains(selfHosted, "received because…") {
+		t.Error("self-hosted plain shell should include the footer note")
+	}
+	if strings.Contains(selfHosted, "github.com/PerpetualSoftware/pad") {
+		t.Error("self-hosted plain shell should NOT include marketing links")
+	}
+
+	if !strings.Contains(cloud, "github.com/PerpetualSoftware/pad") ||
+		!strings.Contains(cloud, "getpad.dev/docs") ||
+		!strings.Contains(cloud, "Perpetual Software") {
+		t.Error("Cloud plain shell should include the marketing link block + copyright")
+	}
+}

--- a/internal/email/shell_test.go
+++ b/internal/email/shell_test.go
@@ -27,8 +27,12 @@ func TestBuildHTMLShellSelfHostedNeutral(t *testing.T) {
 		"github.com/PerpetualSoftware/pad",
 		"getpad.dev/docs",
 		"getpad.dev/changelog",
+		"getpad.dev/contribute",
+		"getpad.dev/faq",
+		"getpad.dev/security",
 		"getpad.dev/privacy",
 		"getpad.dev/terms",
+		"getpad.dev/subprocessors",
 		"Perpetual Software",
 	}
 	for _, marker := range cloudOnly {
@@ -40,10 +44,10 @@ func TestBuildHTMLShellSelfHostedNeutral(t *testing.T) {
 
 // TestBuildHTMLShellCloudIncludesMarketingFooter pins the Cloud-mode
 // marketing-footer link order from docs/brand.md §7 and the copyright
-// line. The link order is GitHub → Docs → Changelog → Privacy → Terms,
-// matching the auth-page AuthFooter component (also derived from the
-// brand spec). Tests check raw substring order rather than using a
-// regex so a future code review can read the assertion at a glance.
+// line. Full canonical order: GitHub → Docs → Changelog → Contribute
+// → FAQ → Security → Privacy → Terms → Sub-processors. Tests check
+// pairwise substring positions rather than using a regex so a future
+// code review can read the assertion at a glance.
 func TestBuildHTMLShellCloudIncludesMarketingFooter(t *testing.T) {
 	out := buildHTMLShell("<p>body</p>", "footer note", true)
 
@@ -51,8 +55,12 @@ func TestBuildHTMLShellCloudIncludesMarketingFooter(t *testing.T) {
 		"github.com/PerpetualSoftware/pad",
 		"getpad.dev/docs",
 		"getpad.dev/changelog",
+		"getpad.dev/contribute",
+		"getpad.dev/faq",
+		"getpad.dev/security",
 		"getpad.dev/privacy",
 		"getpad.dev/terms",
+		"getpad.dev/subprocessors",
 		"Pad &middot; Perpetual Software",
 	} {
 		if !strings.Contains(out, marker) {
@@ -60,15 +68,18 @@ func TestBuildHTMLShellCloudIncludesMarketingFooter(t *testing.T) {
 		}
 	}
 
-	// Order matters per docs/brand.md §7: GitHub before Docs before
-	// Changelog before Privacy before Terms. We pin pairwise positions
-	// so a future reorder forces the test author to revisit the brand
-	// spec contract intentionally.
+	// Order matters per docs/brand.md §7. Pinning pairwise positions
+	// across the full canonical list so a future reorder forces the
+	// test author to revisit the brand spec contract intentionally.
 	pairs := [][2]string{
 		{"github.com/PerpetualSoftware/pad", "getpad.dev/docs"},
 		{"getpad.dev/docs", "getpad.dev/changelog"},
-		{"getpad.dev/changelog", "getpad.dev/privacy"},
+		{"getpad.dev/changelog", "getpad.dev/contribute"},
+		{"getpad.dev/contribute", "getpad.dev/faq"},
+		{"getpad.dev/faq", "getpad.dev/security"},
+		{"getpad.dev/security", "getpad.dev/privacy"},
 		{"getpad.dev/privacy", "getpad.dev/terms"},
+		{"getpad.dev/terms", "getpad.dev/subprocessors"},
 	}
 	for _, pair := range pairs {
 		if strings.Index(out, pair[0]) > strings.Index(out, pair[1]) {

--- a/internal/email/templates.go
+++ b/internal/email/templates.go
@@ -10,6 +10,7 @@ import (
 // If unsubscribeURL is non-empty, an unsubscribe link is included in the footer.
 func (s *Sender) SendInvitation(ctx context.Context, to, inviterName, workspaceName, joinURL, unsubscribeURL string) error {
 	subject := fmt.Sprintf("%s invited you to %s on Pad", inviterName, workspaceName)
+	cloudMode := s.CloudMode()
 
 	unsubHTML := ""
 	unsubPlain := ""
@@ -18,14 +19,7 @@ func (s *Sender) SendInvitation(ctx context.Context, to, inviterName, workspaceN
 		unsubPlain = fmt.Sprintf("\nUnsubscribe from future emails: %s", unsubscribeURL)
 	}
 
-	htmlBody := fmt.Sprintf(`<!DOCTYPE html>
-<html>
-<head><meta charset="utf-8"></head>
-<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; color: #1a1a1a; max-width: 560px; margin: 0 auto; padding: 40px 20px;">
-  <div style="margin-bottom: 32px;">
-    <strong style="font-size: 18px;">Pad</strong>
-  </div>
-  <p style="font-size: 16px; line-height: 1.5;">
+	body := fmt.Sprintf(`  <p style="font-size: 16px; line-height: 1.5;">
     <strong>%s</strong> has invited you to join <strong>%s</strong> on Pad.
   </p>
   <p style="margin: 32px 0;">
@@ -36,29 +30,26 @@ func (s *Sender) SendInvitation(ctx context.Context, to, inviterName, workspaceN
   <p style="font-size: 13px; color: #666; line-height: 1.5;">
     Or copy this link: <a href="%s" style="color: #2563eb;">%s</a>
   </p>
-  <hr style="border: none; border-top: 1px solid #e5e5e5; margin: 32px 0;" />
-  <p style="font-size: 12px; color: #999;">
-    You received this email because someone invited you to a Pad workspace.
-    If you didn't expect this, you can safely ignore it.%s
-  </p>
-</body>
-</html>`,
+`,
 		html.EscapeString(inviterName),
 		html.EscapeString(workspaceName),
 		joinURL,
 		joinURL,
 		joinURL,
-		unsubHTML,
 	)
 
-	plainBody := fmt.Sprintf(`%s has invited you to join %s on Pad.
+	footerNoteHTML := fmt.Sprintf(`You received this email because someone invited you to a Pad workspace.
+    If you didn't expect this, you can safely ignore it.%s`, unsubHTML)
 
-Accept the invitation: %s
+	htmlBody := buildHTMLShell(body, footerNoteHTML, cloudMode)
 
----
-You received this email because someone invited you to a Pad workspace.
-If you didn't expect this, you can safely ignore it.%s`,
-		inviterName, workspaceName, joinURL, unsubPlain,
+	plainBody := buildPlainShell(
+		fmt.Sprintf(`%s has invited you to join %s on Pad.
+
+Accept the invitation: %s`, inviterName, workspaceName, joinURL),
+		fmt.Sprintf(`You received this email because someone invited you to a Pad workspace.
+If you didn't expect this, you can safely ignore it.%s`, unsubPlain),
+		cloudMode,
 	)
 
 	// Use inviter's name as the sender display name: "Dave via Pad"
@@ -70,6 +61,7 @@ If you didn't expect this, you can safely ignore it.%s`,
 // If unsubscribeURL is non-empty, an unsubscribe link is included in the footer.
 func (s *Sender) SendWelcome(ctx context.Context, to, name, unsubscribeURL string) error {
 	subject := "Welcome to Pad"
+	cloudMode := s.CloudMode()
 
 	unsubHTML := ""
 	unsubPlain := ""
@@ -78,14 +70,7 @@ func (s *Sender) SendWelcome(ctx context.Context, to, name, unsubscribeURL strin
 		unsubPlain = fmt.Sprintf("\nUnsubscribe from future emails: %s", unsubscribeURL)
 	}
 
-	htmlBody := fmt.Sprintf(`<!DOCTYPE html>
-<html>
-<head><meta charset="utf-8"></head>
-<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; color: #1a1a1a; max-width: 560px; margin: 0 auto; padding: 40px 20px;">
-  <div style="margin-bottom: 32px;">
-    <strong style="font-size: 18px;">Pad</strong>
-  </div>
-  <p style="font-size: 16px; line-height: 1.5;">
+	body := fmt.Sprintf(`  <p style="font-size: 16px; line-height: 1.5;">
     Hi %s, welcome to Pad!
   </p>
   <p style="font-size: 15px; line-height: 1.5; color: #444;">
@@ -96,23 +81,23 @@ func (s *Sender) SendWelcome(ctx context.Context, to, name, unsubscribeURL strin
       Open Pad
     </a>
   </p>
-  <hr style="border: none; border-top: 1px solid #e5e5e5; margin: 32px 0;" />
-  <p style="font-size: 12px; color: #999;">
-    You received this because an account was created with this email address.%s
-  </p>
-</body>
-</html>`,
+`,
 		html.EscapeString(name),
 		s.baseURL,
-		unsubHTML,
 	)
 
-	plainBody := fmt.Sprintf(`Hi %s, welcome to Pad!
+	footerNoteHTML := fmt.Sprintf("You received this because an account was created with this email address.%s", unsubHTML)
+
+	htmlBody := buildHTMLShell(body, footerNoteHTML, cloudMode)
+
+	plainBody := buildPlainShell(
+		fmt.Sprintf(`Hi %s, welcome to Pad!
 
 Your account has been created. You can now create workspaces, manage projects, and collaborate with your team.
 
-Open Pad: %s%s`,
-		name, s.baseURL, unsubPlain,
+Open Pad: %s`, name, s.baseURL),
+		fmt.Sprintf("You received this because an account was created with this email address.%s", unsubPlain),
+		cloudMode,
 	)
 
 	return s.Send(ctx, to, name, subject, htmlBody, plainBody)
@@ -123,15 +108,9 @@ Open Pad: %s%s`,
 // once the reset token endpoint exists.
 func (s *Sender) SendPasswordReset(ctx context.Context, to, name, resetURL string) error {
 	subject := "Reset your Pad password"
+	cloudMode := s.CloudMode()
 
-	htmlBody := fmt.Sprintf(`<!DOCTYPE html>
-<html>
-<head><meta charset="utf-8"></head>
-<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; color: #1a1a1a; max-width: 560px; margin: 0 auto; padding: 40px 20px;">
-  <div style="margin-bottom: 32px;">
-    <strong style="font-size: 18px;">Pad</strong>
-  </div>
-  <p style="font-size: 16px; line-height: 1.5;">
+	body := fmt.Sprintf(`  <p style="font-size: 16px; line-height: 1.5;">
     Hi %s, we received a request to reset your password.
   </p>
   <p style="margin: 32px 0;">
@@ -142,22 +121,23 @@ func (s *Sender) SendPasswordReset(ctx context.Context, to, name, resetURL strin
   <p style="font-size: 13px; color: #666; line-height: 1.5;">
     This link expires in 1 hour. If you didn't request a password reset, you can safely ignore this email.
   </p>
-  <hr style="border: none; border-top: 1px solid #e5e5e5; margin: 32px 0;" />
-  <p style="font-size: 12px; color: #999;">
-    You received this because a password reset was requested for your Pad account.
-  </p>
-</body>
-</html>`,
+`,
 		html.EscapeString(name),
 		resetURL,
 	)
 
-	plainBody := fmt.Sprintf(`Hi %s, we received a request to reset your password.
+	footerNoteHTML := "You received this because a password reset was requested for your Pad account."
+
+	htmlBody := buildHTMLShell(body, footerNoteHTML, cloudMode)
+
+	plainBody := buildPlainShell(
+		fmt.Sprintf(`Hi %s, we received a request to reset your password.
 
 Reset your password: %s
 
-This link expires in 1 hour. If you didn't request a password reset, you can safely ignore this email.`,
-		name, resetURL,
+This link expires in 1 hour. If you didn't request a password reset, you can safely ignore this email.`, name, resetURL),
+		"You received this because a password reset was requested for your Pad account.",
+		cloudMode,
 	)
 
 	return s.Send(ctx, to, name, subject, htmlBody, plainBody)
@@ -172,6 +152,7 @@ This link expires in 1 hour. If you didn't request a password reset, you can saf
 // is the same for the retry date ("April 30, 2026" or empty).
 func (s *Sender) SendPaymentFailed(ctx context.Context, to, name, amountDisplay, nextRetryDisplay, billingPortalURL string) error {
 	subject := "Your Pad payment couldn't be processed"
+	cloudMode := s.CloudMode()
 
 	// Build optional lines conditionally so we don't ship empty paragraphs
 	// when the webhook payload lacks amount or retry info (Stripe normally
@@ -199,14 +180,7 @@ func (s *Sender) SendPaymentFailed(ctx context.Context, to, name, amountDisplay,
 		retryLinePlain = "Stripe will retry automatically over the next few days. To avoid an interruption, update your card before then.\n\n"
 	}
 
-	htmlBody := fmt.Sprintf(`<!DOCTYPE html>
-<html>
-<head><meta charset="utf-8"></head>
-<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; color: #1a1a1a; max-width: 560px; margin: 0 auto; padding: 40px 20px;">
-  <div style="margin-bottom: 32px;">
-    <strong style="font-size: 18px;">Pad</strong>
-  </div>
-  <p style="font-size: 16px; line-height: 1.5; margin: 0 0 16px;">
+	body := fmt.Sprintf(`  <p style="font-size: 16px; line-height: 1.5; margin: 0 0 16px;">
     Hi %s,
   </p>
   <p style="font-size: 16px; line-height: 1.5; margin: 0 0 16px;">
@@ -222,32 +196,32 @@ func (s *Sender) SendPaymentFailed(ctx context.Context, to, name, amountDisplay,
   <p style="font-size: 13px; color: #666; line-height: 1.5;">
     If you meant to cancel, you can ignore this email — the subscription will cancel automatically after Stripe's retries are exhausted.
   </p>
-  <hr style="border: none; border-top: 1px solid #e5e5e5; margin: 32px 0;" />
-  <p style="font-size: 12px; color: #999;">
-    You received this because your Pad account has a Pro subscription with a failed payment. Replies go to support@getpad.dev.
-  </p>
-</body>
-</html>`,
+`,
 		html.EscapeString(name),
 		amountLineHTML,
 		retryLineHTML,
 		html.EscapeString(billingPortalURL),
 	)
 
-	plainBody := fmt.Sprintf(`Hi %s,
+	footerNoteHTML := "You received this because your Pad account has a Pro subscription with a failed payment. Replies go to support@getpad.dev."
+
+	htmlBody := buildHTMLShell(body, footerNoteHTML, cloudMode)
+
+	plainBody := buildPlainShell(
+		fmt.Sprintf(`Hi %s,
 
 We tried to charge your card for your Pad Pro subscription but the payment didn't go through.
 
 %s%sUpdate your payment method: %s
 
-If you meant to cancel, you can ignore this email — the subscription will cancel automatically after Stripe's retries are exhausted.
-
---
-You received this because your Pad account has a Pro subscription with a failed payment. Replies go to support@getpad.dev.`,
-		name,
-		amountLinePlain,
-		retryLinePlain,
-		billingPortalURL,
+If you meant to cancel, you can ignore this email — the subscription will cancel automatically after Stripe's retries are exhausted.`,
+			name,
+			amountLinePlain,
+			retryLinePlain,
+			billingPortalURL,
+		),
+		"You received this because your Pad account has a Pro subscription with a failed payment. Replies go to support@getpad.dev.",
+		cloudMode,
 	)
 
 	return s.Send(ctx, to, name, subject, htmlBody, plainBody)
@@ -256,25 +230,22 @@ You received this because your Pad account has a Pro subscription with a failed 
 // SendTest sends a test email to verify the email configuration.
 func (s *Sender) SendTest(ctx context.Context, to string) error {
 	subject := "Pad — Test Email"
+	cloudMode := s.CloudMode()
 
-	htmlBody := `<!DOCTYPE html>
-<html>
-<head><meta charset="utf-8"></head>
-<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; color: #1a1a1a; max-width: 560px; margin: 0 auto; padding: 40px 20px;">
-  <div style="margin-bottom: 32px;">
-    <strong style="font-size: 18px;">Pad</strong>
-  </div>
-  <p style="font-size: 16px; line-height: 1.5;">
+	body := `  <p style="font-size: 16px; line-height: 1.5;">
     This is a test email from your Pad instance. If you're reading this, email delivery is working correctly!
   </p>
-  <hr style="border: none; border-top: 1px solid #e5e5e5; margin: 32px 0;" />
-  <p style="font-size: 12px; color: #999;">
-    Sent from Pad platform settings.
-  </p>
-</body>
-</html>`
+`
 
-	plainBody := "This is a test email from your Pad instance. If you're reading this, email delivery is working correctly!"
+	footerNoteHTML := "Sent from Pad platform settings."
+
+	htmlBody := buildHTMLShell(body, footerNoteHTML, cloudMode)
+
+	plainBody := buildPlainShell(
+		"This is a test email from your Pad instance. If you're reading this, email delivery is working correctly!",
+		"Sent from Pad platform settings.",
+		cloudMode,
+	)
 
 	return s.Send(ctx, to, "", subject, htmlBody, plainBody)
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -212,6 +212,13 @@ func (s *Server) SetCloudMode(secret string) {
 			s.cloudSecrets = append(s.cloudSecrets, k)
 		}
 	}
+	// Propagate to the email sender so transactional emails carry the
+	// getpad.dev marketing footer (docs/brand.md §7) on Cloud installs.
+	// Self-hosted deployments leave cloudMode false on the sender, keeping
+	// outgoing mail neutral so operators can ship under their own brand.
+	if s.email != nil {
+		s.email.SetCloudMode(true)
+	}
 }
 
 // CloudSidecar is the reverse pad → pad-cloud client interface. Concrete
@@ -282,10 +289,20 @@ func (s *Server) SetWebhookDispatcher(d *webhooks.Dispatcher) {
 
 // SetEmailSender attaches a transactional email sender.
 // The apiKey is stored separately for deriving the unsubscribe HMAC secret.
+//
+// If the server is already in cloud mode when this is called (i.e.
+// SetCloudMode ran before email config arrived from main.go), propagate
+// the flag so the new sender adds the getpad.dev marketing footer to
+// outgoing emails. Without this, the cloud-mode flag would silently
+// fail to take effect when callers wired email and cloud mode in
+// either order.
 func (s *Server) SetEmailSender(e *email.Sender, apiKey ...string) {
 	s.email = e
 	if len(apiKey) > 0 {
 		s.emailAPIKey = apiKey[0]
+	}
+	if s.cloudMode && s.email != nil {
+		s.email.SetCloudMode(true)
 	}
 }
 
@@ -461,6 +478,13 @@ func (s *Server) reconfigureEmail() {
 	} else {
 		// Update existing sender
 		s.email.Configure(apiKey, fromAddr, fromName, s.baseURL)
+	}
+	// Propagate cloud mode whichever way email was wired — see SetEmailSender
+	// for the matching note. Configure() preserves cloudMode on existing
+	// senders since SetCloudMode is independent; this branch covers the
+	// fresh-NewSender path.
+	if s.cloudMode {
+		s.email.SetCloudMode(true)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Extracts a shared HTML/plain shell helper for the five existing transactional-email templates (\`SendInvitation\`, \`SendWelcome\`, \`SendPasswordReset\`, \`SendPaymentFailed\`, \`SendTest\`).
- **Cloud-only marketing footer** mirrors the auth-page \`AuthFooter\` component: GitHub / Docs / Changelog / Privacy / Terms link list (canonical order from \`docs/brand.md\` §7) plus a \`© <year> Pad · Perpetual Software\` copyright line.
- **Self-hosted output is byte-equivalent** to the prior inline templates: same wordmark, same body, same footer disclosure, no marketing links. Operators stay neutral.
- Pinned with three regression tests: self-hosted neutrality, Cloud link order, plain-text branching parity.

## Context
Implements [TASK-907](https://github.com/PerpetualSoftware/pad) under [PLAN-900](https://github.com/PerpetualSoftware/pad). Companion to AuthHeader / AuthFooter / +error.svelte / UserMenuResources already shipped this run.

## Plumbing
- \`email.Sender\` gains \`cloudMode bool\` with \`SetCloudMode\` + \`CloudMode\` accessors. \`Configure()\` doesn't touch it (set independently).
- \`Server.SetCloudMode\` now propagates to \`s.email.SetCloudMode(true)\`.
- \`Server.SetEmailSender\` and \`Server.reconfigureEmail()\` both pick up cloudMode if it's already set when email is wired (handles either ordering in \`cmd/pad/main.go\`).

## Notable details
- Email accent color (\`#2563eb\`) is preserved — known contrast on white email backgrounds. Emails are light-themed for cross-client readability; the dark-theme tokens from brand spec §3 are for in-app/auth surfaces, not transactional mail.
- Plain-text fallback gets a small text-only marketing-link block on Cloud (no chrome).

## Test plan
- [x] \`go build ./...\` — clean
- [x] \`go vet ./...\` — clean
- [x] \`go test ./...\` — all pass (including new \`shell_test.go\` cases)
- [x] \`web/npm run check\` — 0 errors
- [x] \`web/npm run build\` — clean