### PR TITLE
fix(config): read PUBLIC_URL for emailed link generation (BUG-899)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -89,9 +89,11 @@ PAD_ENCRYPTION_KEY=
 # PAD_URL=https://pad.example.com
 
 # Alternative to PAD_URL using the generic env-var convention. Read by the
-# server only (does not flip the CLI to remote mode), so it's safe to set
-# alongside other tools that already use PUBLIC_URL. Pad-cloud sets this
-# on its sidecar and we forward it to the pad service in the same compose.
+# server only (does not flip the CLI to remote mode, does not contaminate
+# the CLI's BaseURL, and is intentionally NOT persisted to config.toml on
+# `pad init` / `pad configure` saves), so it's safe to set on hosts that
+# already use PUBLIC_URL for other tooling. Pad-cloud sets it on its
+# sidecar and forwards it to the pad service in the same compose.
 # Precedence: PAD_URL > PUBLIC_URL > constructed http://host:port.
 # PUBLIC_URL=https://pad.example.com
 

--- a/.env.example
+++ b/.env.example
@@ -84,7 +84,16 @@ PAD_ENCRYPTION_KEY=
 # PAD_PORT=7777
 
 # Public-facing base URL. Used to build invitation + password-reset links.
+# Required on deployments that bind to 0.0.0.0 — without it, emailed links
+# point at "http://0.0.0.0:7777" which recipients cannot reach (BUG-899).
 # PAD_URL=https://pad.example.com
+
+# Alternative to PAD_URL using the generic env-var convention. Read by the
+# server only (does not flip the CLI to remote mode), so it's safe to set
+# alongside other tools that already use PUBLIC_URL. Pad-cloud sets this
+# on its sidecar and we forward it to the pad service in the same compose.
+# Precedence: PAD_URL > PUBLIC_URL > constructed http://host:port.
+# PUBLIC_URL=https://pad.example.com
 
 # Writable data directory — SQLite DB, config, logs. Default: ~/.pad
 # PAD_DATA_DIR=/data

--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -276,7 +276,11 @@ func serveCmd() *cobra.Command {
 
 			srv := server.New(s)
 			srv.SetVersion(version, commit, buildTime)
-			srv.SetBaseURL(cfg.BaseURL())
+			// PublicLinkBaseURL — not BaseURL() — so the server picks up
+			// PUBLIC_URL from the deployment env (BUG-899). BaseURL() is
+			// CLI-client-only and would leak the same env var into local
+			// CLI API routing on developer hosts.
+			srv.SetBaseURL(cfg.PublicLinkBaseURL())
 			srv.SetCORSOrigins(cfg.CORSOrigins)
 			srv.SetSecureCookies(cfg.SecureCookies)
 			srv.SetTrustedProxies(cfg.TrustedProxies)
@@ -461,7 +465,9 @@ func serveCmd() *cobra.Command {
 				if fromName == "" {
 					fromName = "Pad"
 				}
-				srv.SetEmailSender(email.NewSender(cfg.MailerooAPIKey, fromAddr, fromName, cfg.BaseURL()), cfg.MailerooAPIKey)
+				// PublicLinkBaseURL — emailed links must use the deployment's
+				// public URL (PUBLIC_URL), not the CLI BaseURL().
+				srv.SetEmailSender(email.NewSender(cfg.MailerooAPIKey, fromAddr, fromName, cfg.PublicLinkBaseURL()), cfg.MailerooAPIKey)
 				slog.Info("Email sending enabled via Maileroo (env)")
 			}
 			// Platform settings can override or provide email config

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -65,7 +65,7 @@ All configuration is via environment variables or a config file (`~/.pad/config.
 | `PAD_HOST` | `127.0.0.1` | Listen address (`0.0.0.0` for Docker/production) |
 | `PAD_PORT` | `7777` | Listen port |
 | `PAD_URL` | — | Public-facing base URL (e.g., `https://pad.example.com`). Used for invitation, password-reset, and share-link emails. **Required when `PAD_HOST=0.0.0.0`** — otherwise emailed links point at `http://0.0.0.0:port` and are unreachable to recipients. |
-| `PUBLIC_URL` | — | Alternative to `PAD_URL` using the generic env-var convention. Read server-side only (does not affect CLI mode). Precedence: `PAD_URL` > `PUBLIC_URL` > constructed `http://host:port`. |
+| `PUBLIC_URL` | — | Alternative to `PAD_URL` using the generic env-var convention. Server-side only — does not affect CLI mode, does not influence the CLI's API endpoint, and is not persisted to `config.toml`. Precedence: `PAD_URL` > `PUBLIC_URL` > constructed `http://host:port`. |
 | `PAD_DATA_DIR` | `~/.pad` | Data directory for SQLite DB, logs, and config |
 | `PAD_LOG_LEVEL` | `info` | Log level: `debug`, `info`, `warn`, `error` |
 | `PAD_MODE` | `local` | Mode: `local`, `remote`, `cloud` |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -64,7 +64,8 @@ All configuration is via environment variables or a config file (`~/.pad/config.
 |----------|---------|-------------|
 | `PAD_HOST` | `127.0.0.1` | Listen address (`0.0.0.0` for Docker/production) |
 | `PAD_PORT` | `7777` | Listen port |
-| `PAD_URL` | — | Public-facing base URL (e.g., `https://pad.example.com`). Used for invitation links. |
+| `PAD_URL` | — | Public-facing base URL (e.g., `https://pad.example.com`). Used for invitation, password-reset, and share-link emails. **Required when `PAD_HOST=0.0.0.0`** — otherwise emailed links point at `http://0.0.0.0:port` and are unreachable to recipients. |
+| `PUBLIC_URL` | — | Alternative to `PAD_URL` using the generic env-var convention. Read server-side only (does not affect CLI mode). Precedence: `PAD_URL` > `PUBLIC_URL` > constructed `http://host:port`. |
 | `PAD_DATA_DIR` | `~/.pad` | Data directory for SQLite DB, logs, and config |
 | `PAD_LOG_LEVEL` | `info` | Log level: `debug`, `info`, `warn`, `error` |
 | `PAD_MODE` | `local` | Mode: `local`, `remote`, `cloud` |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,7 +30,7 @@ type Config struct {
 	Host     string `toml:"host"`
 	Port     int    `toml:"port"`
 	URL      string `toml:"url"`        // Optional: full base URL (e.g., https://api.getpad.dev). Overrides host/port for CLI.
-	PublicURL string `toml:"public_url"` // Optional: deployment's public URL used by the server in emailed links (e.g., https://app.getpad.dev). Consulted by PublicLinkBaseURL() only; does NOT influence the CLI's BaseURL() and does NOT flip Mode to remote.
+	PublicURL string `toml:"-"` // Deployment's public URL used by the server in emailed links (e.g., https://app.getpad.dev). Sourced from the PUBLIC_URL env var only — intentionally NOT persisted to ~/.pad/config.toml so a CLI Save() (via `pad init` / `pad configure`) on a host where PUBLIC_URL is set for unrelated reasons cannot contaminate the user's config file with a stale URL that outlives the env var. Operators who want a config-file equivalent should set `url` (the toml `URL` field). Consulted by PublicLinkBaseURL() only; does NOT influence the CLI's BaseURL() and does NOT flip Mode to remote.
 	Editor   string `toml:"editor"`
 	LogLevel string `toml:"log_level"`
 	DBPath   string `toml:"-"` // computed, not from config file
@@ -331,12 +331,13 @@ func (c *Config) BaseURL() string {
 // links (password reset, invites, share links, admin invitations).
 // Resolution order:
 //  1. URL (set via config "url", --url flag, or PAD_URL env)
-//  2. PublicURL (set via config "public_url" or PUBLIC_URL env) — the
-//     deployment's public URL. PUBLIC_URL is a generic env var commonly
-//     set in deployment environments (e.g. pad-cloud's docker-compose
-//     forwards it to the pad service); consulting it here lets the
-//     server pick up the correct public hostname without an extra
-//     pad-namespaced env var.
+//  2. PublicURL (sourced from the PUBLIC_URL env var only — see the
+//     PublicURL field comment for why it isn't persisted to config) —
+//     the deployment's public URL. PUBLIC_URL is a generic env var
+//     commonly set in deployment environments (e.g. pad-cloud's
+//     docker-compose forwards it to the pad service); consulting it
+//     here lets the server pick up the correct public hostname without
+//     an extra pad-namespaced env var.
 //  3. Construct from Host and Port — the historical fallback.
 //
 // IMPORTANT: when this server runs with Host=0.0.0.0 (Docker, k8s, any

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,7 +30,7 @@ type Config struct {
 	Host     string `toml:"host"`
 	Port     int    `toml:"port"`
 	URL      string `toml:"url"`        // Optional: full base URL (e.g., https://api.getpad.dev). Overrides host/port for CLI.
-	PublicURL string `toml:"public_url"` // Optional: deployment's public URL used in emailed links (e.g., https://app.getpad.dev). Server-only; does NOT flip CLI to remote mode. Falls back here when URL is empty.
+	PublicURL string `toml:"public_url"` // Optional: deployment's public URL used by the server in emailed links (e.g., https://app.getpad.dev). Consulted by PublicLinkBaseURL() only; does NOT influence the CLI's BaseURL() and does NOT flip Mode to remote.
 	Editor   string `toml:"editor"`
 	LogLevel string `toml:"log_level"`
 	DBPath   string `toml:"-"` // computed, not from config file
@@ -312,22 +312,45 @@ func (c *Config) Addr() string {
 }
 
 // BaseURL returns the base URL for the API.
+// If URL is set (via config, --url flag, or PAD_URL), it takes precedence.
+// Otherwise, constructs from host and port.
+//
+// This is the CLI-client-facing accessor: it controls where the local
+// `pad` CLI sends API requests, so it must NOT be influenced by the
+// generic PUBLIC_URL env var (which a developer's host might have set
+// for unrelated reasons — e.g. some other CI tool or framework). For
+// the server's emailed-link target, see PublicLinkBaseURL().
+func (c *Config) BaseURL() string {
+	if c.URL != "" {
+		return strings.TrimRight(c.URL, "/")
+	}
+	return fmt.Sprintf("http://%s:%d", c.Host, c.Port)
+}
+
+// PublicLinkBaseURL returns the URL the server should embed in emailed
+// links (password reset, invites, share links, admin invitations).
 // Resolution order:
 //  1. URL (set via config "url", --url flag, or PAD_URL env)
 //  2. PublicURL (set via config "public_url" or PUBLIC_URL env) — the
-//     deployment's public URL, used for server-side link generation in
-//     emails (password reset, invites, share links). Distinct from URL
-//     because PUBLIC_URL is a generic env var commonly set in deployment
-//     environments and we don't want it to flip CLI Mode to Remote.
-//  3. Construct from Host and Port.
+//     deployment's public URL. PUBLIC_URL is a generic env var commonly
+//     set in deployment environments (e.g. pad-cloud's docker-compose
+//     forwards it to the pad service); consulting it here lets the
+//     server pick up the correct public hostname without an extra
+//     pad-namespaced env var.
+//  3. Construct from Host and Port — the historical fallback.
 //
 // IMPORTANT: when this server runs with Host=0.0.0.0 (Docker, k8s, any
-// bind-all setup) and neither URL nor PublicURL is set, the constructed
-// fallback will be "http://0.0.0.0:port" — a string the recipient of an
-// email cannot resolve. Callers that emit user-facing links should set
-// PublicURL on those deployments. The server logs a startup warning in
-// that scenario; see internal/server/server.go.
-func (c *Config) BaseURL() string {
+// bind-all setup) and neither URL nor PublicURL is set, the fallback
+// yields "http://0.0.0.0:port" — a string email recipients cannot
+// resolve. Callers should set PUBLIC_URL (or PAD_URL) on those
+// deployments. The server logs a startup warning in that scenario; see
+// (*server.Server).SetBaseURL.
+//
+// This is intentionally distinct from BaseURL() (the CLI client URL):
+// the CLI must never be hijacked by an unrelated PUBLIC_URL set in the
+// developer's shell, but the server SHOULD pick it up to avoid shipping
+// http://0.0.0.0:7777 in user-facing emails (BUG-899).
+func (c *Config) PublicLinkBaseURL() string {
 	if c.URL != "" {
 		return strings.TrimRight(c.URL, "/")
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,7 +29,8 @@ type Config struct {
 	Mode     string `toml:"mode"`
 	Host     string `toml:"host"`
 	Port     int    `toml:"port"`
-	URL      string `toml:"url"` // Optional: full base URL (e.g., https://api.getpad.dev). Overrides host/port for CLI.
+	URL      string `toml:"url"`        // Optional: full base URL (e.g., https://api.getpad.dev). Overrides host/port for CLI.
+	PublicURL string `toml:"public_url"` // Optional: deployment's public URL used in emailed links (e.g., https://app.getpad.dev). Server-only; does NOT flip CLI to remote mode. Falls back here when URL is empty.
 	Editor   string `toml:"editor"`
 	LogLevel string `toml:"log_level"`
 	DBPath   string `toml:"-"` // computed, not from config file
@@ -151,6 +152,18 @@ func Load() (*Config, error) {
 		if cfg.Mode == "" {
 			cfg.Mode = ModeRemote
 		}
+	}
+	// PUBLIC_URL is the deployment's public URL, used by the server to build
+	// emailed link targets (password reset, invites, share links). It is
+	// intentionally separate from PAD_URL: PUBLIC_URL is a generic env var
+	// name commonly set in deployment environments (e.g. pad-cloud's
+	// docker-compose passes it to the sidecar), so reading it into cfg.URL
+	// would risk flipping a CLI user's Mode to Remote on any host that
+	// happens to have PUBLIC_URL set for unrelated reasons. Keep it
+	// server-only and consult it from BaseURL() as a fallback.
+	if v := os.Getenv("PUBLIC_URL"); v != "" {
+		cfg.PublicURL = v
+		cfg.LoadedFromEnv = true
 	}
 
 	// Email (Maileroo)
@@ -293,11 +306,27 @@ func (c *Config) Addr() string {
 }
 
 // BaseURL returns the base URL for the API.
-// If URL is set (via config, --url flag, or PAD_URL), it takes precedence.
-// Otherwise, constructs from host and port.
+// Resolution order:
+//  1. URL (set via config "url", --url flag, or PAD_URL env)
+//  2. PublicURL (set via config "public_url" or PUBLIC_URL env) — the
+//     deployment's public URL, used for server-side link generation in
+//     emails (password reset, invites, share links). Distinct from URL
+//     because PUBLIC_URL is a generic env var commonly set in deployment
+//     environments and we don't want it to flip CLI Mode to Remote.
+//  3. Construct from Host and Port.
+//
+// IMPORTANT: when this server runs with Host=0.0.0.0 (Docker, k8s, any
+// bind-all setup) and neither URL nor PublicURL is set, the constructed
+// fallback will be "http://0.0.0.0:port" — a string the recipient of an
+// email cannot resolve. Callers that emit user-facing links should set
+// PublicURL on those deployments. The server logs a startup warning in
+// that scenario; see internal/server/server.go.
 func (c *Config) BaseURL() string {
 	if c.URL != "" {
 		return strings.TrimRight(c.URL, "/")
+	}
+	if c.PublicURL != "" {
+		return strings.TrimRight(c.PublicURL, "/")
 	}
 	return fmt.Sprintf("http://%s:%d", c.Host, c.Port)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -161,9 +161,15 @@ func Load() (*Config, error) {
 	// would risk flipping a CLI user's Mode to Remote on any host that
 	// happens to have PUBLIC_URL set for unrelated reasons. Keep it
 	// server-only and consult it from BaseURL() as a fallback.
+	//
+	// Crucially, do NOT mark LoadedFromEnv when only PUBLIC_URL is set —
+	// IsConfigured() (which gates CLI setup-flow short-circuits) would
+	// otherwise treat a host that happens to have PUBLIC_URL set as
+	// "configured" and skip the CLI "not configured" branch even though
+	// the user never made any CLI choice. PUBLIC_URL is purely a
+	// server-side fact; LoadedFromEnv is purely a CLI-affordance signal.
 	if v := os.Getenv("PUBLIC_URL"); v != "" {
 		cfg.PublicURL = v
-		cfg.LoadedFromEnv = true
 	}
 
 	// Email (Maileroo)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,7 +1,9 @@
 package config
 
 import (
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -393,6 +395,43 @@ func TestPublicURLAloneDoesNotMarkConfigured(t *testing.T) {
 	cfg := &Config{PublicURL: "https://app.example.com"}
 	if cfg.IsConfigured() {
 		t.Fatal("PUBLIC_URL on its own must not make IsConfigured() true — would short-circuit the CLI's not-configured branch on hosts that set the var for unrelated reasons")
+	}
+}
+
+// TestPublicURLNotPersistedToTOML pins the contract that PUBLIC_URL is a
+// runtime/deployment fact only and never gets written to config.toml.
+// Without this, `pad init` or `pad configure` running on a host with a
+// generic PUBLIC_URL set for unrelated reasons would persist that URL
+// into ~/.pad/config.toml — the value would then outlive the env var
+// (the next pad invocation, even with PUBLIC_URL unset, would still
+// pick it up from the file) and contaminate emailed links indefinitely.
+func TestPublicURLNotPersistedToTOML(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("PAD_DATA_DIR", home)
+
+	cfg := DefaultConfig()
+	cfg.ConfigPath = filepath.Join(home, "config.toml")
+	cfg.URL = "https://api.example.com"
+	cfg.PublicURL = "https://app.example.com" // simulating value loaded from PUBLIC_URL env
+
+	if err := cfg.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	raw, err := os.ReadFile(cfg.ConfigPath)
+	if err != nil {
+		t.Fatalf("read saved config: %v", err)
+	}
+	if strings.Contains(string(raw), "https://app.example.com") {
+		t.Fatalf("config.toml must not persist PUBLIC_URL value:\n%s", raw)
+	}
+	if strings.Contains(string(raw), "public_url") {
+		t.Fatalf("config.toml must not contain a public_url key:\n%s", raw)
+	}
+	// The persisted url= key (PAD_URL/--url path) should still be present.
+	if !strings.Contains(string(raw), "https://api.example.com") {
+		t.Fatalf("expected url= to round-trip:\n%s", raw)
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -352,11 +352,22 @@ func TestLoadWithPublicURLDoesNotFlipMode(t *testing.T) {
 	if cfg.Mode == ModeRemote {
 		t.Fatal("PUBLIC_URL must not flip Mode to Remote — that's PAD_URL's job")
 	}
-	if !cfg.LoadedFromEnv {
-		t.Fatal("expected PUBLIC_URL to mark config as env-loaded")
-	}
 	if cfg.BaseURL() != "https://app.example.com" {
 		t.Fatalf("expected BaseURL to use PUBLIC_URL when PAD_URL is unset, got %q", cfg.BaseURL())
+	}
+}
+
+// TestPublicURLAloneDoesNotMarkConfigured guards against PUBLIC_URL
+// affecting CLI control flow. IsConfigured() gates whether the CLI shows
+// its "not configured / run setup" branch (cmd/pad/configure.go); if a
+// generic PUBLIC_URL on the host marked the config as env-loaded, a
+// developer who's never run `pad init` would get past that gate and the
+// CLI would happily talk to a default-mode endpoint built from PUBLIC_URL.
+// PUBLIC_URL is server-only — it must never participate in IsConfigured().
+func TestPublicURLAloneDoesNotMarkConfigured(t *testing.T) {
+	cfg := &Config{PublicURL: "https://app.example.com"}
+	if cfg.IsConfigured() {
+		t.Fatal("PUBLIC_URL on its own must not make IsConfigured() true — would short-circuit the CLI's not-configured branch on hosts that set the var for unrelated reasons")
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -294,3 +294,93 @@ func TestBrowserURLPrefersExplicitURL(t *testing.T) {
 		t.Fatalf("BrowserURL() = %q, want %q (explicit URL must win and trailing slash trimmed)", got, want)
 	}
 }
+
+// TestBaseURLPrecedence pins the resolution order documented on
+// (*Config).BaseURL: URL > PublicURL > constructed http://host:port. This is
+// what fixes BUG-899 — Pad Cloud sets PUBLIC_URL on the pad-cloud sidecar
+// and forwards it to the pad service, so emailed links use the public
+// domain instead of the bind address.
+func TestBaseURLPrecedence(t *testing.T) {
+	cases := []struct {
+		name      string
+		url       string
+		publicURL string
+		host      string
+		port      int
+		want      string
+	}{
+		{"URL wins over PublicURL", "https://api.example.com", "https://app.example.com", "0.0.0.0", 7777, "https://api.example.com"},
+		{"URL wins with trailing slash trimmed", "https://api.example.com/", "", "0.0.0.0", 7777, "https://api.example.com"},
+		{"PublicURL used when URL empty", "", "https://app.example.com", "0.0.0.0", 7777, "https://app.example.com"},
+		{"PublicURL trims trailing slash", "", "https://app.example.com/", "0.0.0.0", 7777, "https://app.example.com"},
+		{"falls through to host:port when both empty", "", "", "127.0.0.1", 7777, "http://127.0.0.1:7777"},
+		{"host:port fallback exposes 0.0.0.0 (BUG-899 repro shape)", "", "", "0.0.0.0", 7777, "http://0.0.0.0:7777"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &Config{URL: tc.url, PublicURL: tc.publicURL, Host: tc.host, Port: tc.port}
+			if got := cfg.BaseURL(); got != tc.want {
+				t.Fatalf("BaseURL() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestLoadWithPublicURLDoesNotFlipMode is the safety belt against the
+// footgun of treating PUBLIC_URL the same as PAD_URL: PUBLIC_URL is a
+// generic env var name commonly set in unrelated deployment contexts, so
+// reading it must NOT change the CLI's Mode (which would route the local
+// CLI at a remote URL the operator never asked it to use).
+func TestLoadWithPublicURLDoesNotFlipMode(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("PAD_DATA_DIR", home)
+	t.Setenv("PUBLIC_URL", "https://app.example.com")
+	// Explicitly clear PAD_URL in case the runner's environment has it.
+	t.Setenv("PAD_URL", "")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("load config with PUBLIC_URL: %v", err)
+	}
+	if cfg.PublicURL != "https://app.example.com" {
+		t.Fatalf("expected PUBLIC_URL to populate cfg.PublicURL, got %q", cfg.PublicURL)
+	}
+	if cfg.URL != "" {
+		t.Fatalf("PUBLIC_URL must not populate cfg.URL (would flip CLI to remote mode), got %q", cfg.URL)
+	}
+	if cfg.Mode == ModeRemote {
+		t.Fatal("PUBLIC_URL must not flip Mode to Remote — that's PAD_URL's job")
+	}
+	if !cfg.LoadedFromEnv {
+		t.Fatal("expected PUBLIC_URL to mark config as env-loaded")
+	}
+	if cfg.BaseURL() != "https://app.example.com" {
+		t.Fatalf("expected BaseURL to use PUBLIC_URL when PAD_URL is unset, got %q", cfg.BaseURL())
+	}
+}
+
+// TestLoadPADURLBeatsPUBLICURL pins the precedence at the env-load layer
+// so an operator running on a host that has PUBLIC_URL set for unrelated
+// reasons can still override it explicitly with PAD_URL.
+func TestLoadPADURLBeatsPUBLICURL(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("PAD_DATA_DIR", home)
+	t.Setenv("PAD_URL", "https://api.example.com")
+	t.Setenv("PUBLIC_URL", "https://app.example.com")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if cfg.URL != "https://api.example.com" {
+		t.Fatalf("expected PAD_URL to populate cfg.URL, got %q", cfg.URL)
+	}
+	if cfg.PublicURL != "https://app.example.com" {
+		t.Fatalf("expected PUBLIC_URL to still populate cfg.PublicURL even when PAD_URL set, got %q", cfg.PublicURL)
+	}
+	if cfg.BaseURL() != "https://api.example.com" {
+		t.Fatalf("PAD_URL must win in BaseURL(), got %q", cfg.BaseURL())
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -295,12 +295,31 @@ func TestBrowserURLPrefersExplicitURL(t *testing.T) {
 	}
 }
 
-// TestBaseURLPrecedence pins the resolution order documented on
-// (*Config).BaseURL: URL > PublicURL > constructed http://host:port. This is
-// what fixes BUG-899 — Pad Cloud sets PUBLIC_URL on the pad-cloud sidecar
-// and forwards it to the pad service, so emailed links use the public
-// domain instead of the bind address.
-func TestBaseURLPrecedence(t *testing.T) {
+// TestBaseURLIgnoresPublicURL pins the CLI-only contract for BaseURL():
+// the function backs the local `pad` CLI's choice of API endpoint and
+// must NOT be influenced by PublicURL, even when PublicURL is set.
+// Otherwise a developer with a host-level PUBLIC_URL set for unrelated
+// reasons would have their CLI silently route requests to that URL
+// instead of their actual local server (Codex review of BUG-899).
+func TestBaseURLIgnoresPublicURL(t *testing.T) {
+	cfg := &Config{
+		Host:      "127.0.0.1",
+		Port:      7777,
+		PublicURL: "https://app.example.com",
+	}
+	const want = "http://127.0.0.1:7777"
+	if got := cfg.BaseURL(); got != want {
+		t.Fatalf("BaseURL() = %q, want %q (PublicURL must not leak into CLI routing)", got, want)
+	}
+}
+
+// TestPublicLinkBaseURLPrecedence pins the resolution order on the
+// server-side accessor used to build emailed link targets: URL >
+// PublicURL > constructed http://host:port. This is what fixes BUG-899
+// — Pad Cloud sets PUBLIC_URL on the pad-cloud sidecar and forwards it
+// to the pad service, so emailed links use the public domain instead
+// of the bind address.
+func TestPublicLinkBaseURLPrecedence(t *testing.T) {
 	cases := []struct {
 		name      string
 		url       string
@@ -319,8 +338,8 @@ func TestBaseURLPrecedence(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			cfg := &Config{URL: tc.url, PublicURL: tc.publicURL, Host: tc.host, Port: tc.port}
-			if got := cfg.BaseURL(); got != tc.want {
-				t.Fatalf("BaseURL() = %q, want %q", got, tc.want)
+			if got := cfg.PublicLinkBaseURL(); got != tc.want {
+				t.Fatalf("PublicLinkBaseURL() = %q, want %q", got, tc.want)
 			}
 		})
 	}
@@ -352,8 +371,14 @@ func TestLoadWithPublicURLDoesNotFlipMode(t *testing.T) {
 	if cfg.Mode == ModeRemote {
 		t.Fatal("PUBLIC_URL must not flip Mode to Remote — that's PAD_URL's job")
 	}
-	if cfg.BaseURL() != "https://app.example.com" {
-		t.Fatalf("expected BaseURL to use PUBLIC_URL when PAD_URL is unset, got %q", cfg.BaseURL())
+	// Server-side public-link accessor sees PUBLIC_URL...
+	if cfg.PublicLinkBaseURL() != "https://app.example.com" {
+		t.Fatalf("expected PublicLinkBaseURL to use PUBLIC_URL when PAD_URL is unset, got %q", cfg.PublicLinkBaseURL())
+	}
+	// ...but the CLI client accessor does not (would otherwise hijack
+	// CLI routing on hosts with PUBLIC_URL set for unrelated reasons).
+	if cfg.BaseURL() == "https://app.example.com" {
+		t.Fatal("BaseURL() must not be influenced by PUBLIC_URL — CLI routing isolation")
 	}
 }
 
@@ -393,5 +418,8 @@ func TestLoadPADURLBeatsPUBLICURL(t *testing.T) {
 	}
 	if cfg.BaseURL() != "https://api.example.com" {
 		t.Fatalf("PAD_URL must win in BaseURL(), got %q", cfg.BaseURL())
+	}
+	if cfg.PublicLinkBaseURL() != "https://api.example.com" {
+		t.Fatalf("PAD_URL must also win in PublicLinkBaseURL(), got %q", cfg.PublicLinkBaseURL())
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -11,6 +11,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"net/url"
 	"strings"
 	"sync"
 	"time"
@@ -273,8 +274,24 @@ func (s *Server) SetVersion(version, commit, buildTime string) {
 }
 
 // SetBaseURL sets the public base URL used for generating shareable links.
-func (s *Server) SetBaseURL(url string) {
-	s.baseURL = strings.TrimRight(url, "/")
+//
+// If the supplied URL has an unspecified bind-all host ("0.0.0.0", "::",
+// "[::]"), this logs a WARN: such a URL is the right thing to *bind* to
+// but the wrong thing to *send* to a recipient (their browser cannot
+// resolve 0.0.0.0 / :: as a connect target). Callers shipping email
+// links from such a deployment should set PAD_URL or PUBLIC_URL to the
+// real public hostname (e.g. https://app.getpad.dev). See BUG-899.
+func (s *Server) SetBaseURL(rawURL string) {
+	s.baseURL = strings.TrimRight(rawURL, "/")
+	if s.baseURL == "" {
+		return
+	}
+	if u, err := url.Parse(s.baseURL); err == nil {
+		switch u.Hostname() {
+		case "", "0.0.0.0", "::":
+			slog.Warn("server base URL has an unspecified host; emailed links (password reset, invites, share links) will not be reachable. Set PAD_URL or PUBLIC_URL to the deployment's public URL (e.g. https://app.getpad.dev).", "base_url", s.baseURL)
+		}
+	}
 }
 
 // SetEventBus attaches an event bus for real-time SSE streaming.


### PR DESCRIPTION
## Summary

Fixes BUG-899: password-reset (and invite, share-link, admin-invitation) emails sent to users on the Pad Cloud deployment contained `http://0.0.0.0:7777/...` link targets that recipients couldn't reach. Root cause: `pad`'s `cfg.BaseURL()` fell through to `http://Host:Port` when no `PAD_URL` was set, and pad-cloud's docker-compose passed `PAD_HOST=0.0.0.0` to the pad service without setting `PAD_URL` on it (the `PUBLIC_URL` env var was set on the pad-cloud sidecar only).

This PR teaches pad to read `PUBLIC_URL` natively, but very narrowly:
- Stored in a separate `Config.PublicURL` field (not `Config.URL`), so it cannot flip the CLI's Mode to Remote.
- Consulted ONLY by a new `Config.PublicLinkBaseURL()`, used at the two server-side wire-points that build emailed link targets — `cmd/pad/main.go:279` (`srv.SetBaseURL`) and `cmd/pad/main.go:464` (`email.NewSender`). The CLI's `BaseURL()` is unchanged and untouchable from `PUBLIC_URL`, so a developer's host-level `PUBLIC_URL` cannot hijack their CLI's API endpoint.
- Does NOT mark `LoadedFromEnv`, so it cannot make `IsConfigured()` true on a host where it's set for unrelated reasons (would short-circuit the CLI's not-configured / setup branch).
- `toml:"-"` so `pad init` / `pad configure` Save() cannot persist it into `~/.pad/config.toml` and contaminate the file beyond the env var's lifetime.

Resolution order in `PublicLinkBaseURL()`: `PAD_URL` > `PUBLIC_URL` > constructed `http://Host:Port`. `PAD_URL` keeps full back-compat as the explicit pad-namespaced override.

Adds a startup `WARN` (in `server.SetBaseURL`) when the resolved base URL has an unspecified bind-all host (`0.0.0.0`, `::`) — would have caught BUG-899 the first time email went out.

## Companion change

`xarmian/pad-cloud` will receive a one-line `docker-compose.yml` change: `- PUBLIC_URL=https://${DOMAIN}` added to the `pad` service env block (separate PR — opened immediately after this merges).

## Codex review history

4 rounds. Each round caught a real footgun:
1. `LoadedFromEnv = true` would have made `IsConfigured()` true for unrelated `PUBLIC_URL` env on developer hosts — fixed by dropping the assignment.
2. `BaseURL()` falling through to `PublicURL` leaked into ~20 CLI-client call sites — fixed by splitting `PublicLinkBaseURL()` from `BaseURL()`.
3. `Save()` would persist `PublicURL` into `config.toml` — fixed by `toml:"-"`.
4. CLEAN.

Sequence is in commit history: `6f920d5` initial → `aabb7d6` round 2 → `9d95df1` round 3 → `aa0e6fc` round 4.

## Context

Implements `TASK-908` under `BUG-899`.

## Test plan
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./...` — all packages pass (sqlite + non-PG path)
- [x] `cd web && npm run build` — clean
- [x] Codex CLI review: CLEAN on round 4
- [ ] Post-merge in pad-cloud: deploy + verify a real password-reset email contains `https://app.getpad.dev/reset-password/<token>` (not 0.0.0.0)
- [ ] Post-merge in pad-cloud: verify the same fix lands for workspace invite + admin invitation + share link surfaces (all six email sites enumerated in BUG-899)