### PR TITLE
fix(search): explicit selection on Enter + numeric go-to (BUG-864, BUG-910)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,15 +26,15 @@ const (
 )
 
 type Config struct {
-	Mode     string `toml:"mode"`
-	Host     string `toml:"host"`
-	Port     int    `toml:"port"`
-	URL      string `toml:"url"`        // Optional: full base URL (e.g., https://api.getpad.dev). Overrides host/port for CLI.
-	PublicURL string `toml:"-"` // Deployment's public URL used by the server in emailed links (e.g., https://app.getpad.dev). Sourced from the PUBLIC_URL env var only — intentionally NOT persisted to ~/.pad/config.toml so a CLI Save() (via `pad init` / `pad configure`) on a host where PUBLIC_URL is set for unrelated reasons cannot contaminate the user's config file with a stale URL that outlives the env var. Operators who want a config-file equivalent should set `url` (the toml `URL` field). Consulted by PublicLinkBaseURL() only; does NOT influence the CLI's BaseURL() and does NOT flip Mode to remote.
-	Editor   string `toml:"editor"`
-	LogLevel string `toml:"log_level"`
-	DBPath   string `toml:"-"` // computed, not from config file
-	DataDir  string `toml:"-"` // computed
+	Mode      string `toml:"mode"`
+	Host      string `toml:"host"`
+	Port      int    `toml:"port"`
+	URL       string `toml:"url"` // Optional: full base URL (e.g., https://api.getpad.dev). Overrides host/port for CLI.
+	PublicURL string `toml:"-"`   // Deployment's public URL used by the server in emailed links (e.g., https://app.getpad.dev). Sourced from the PUBLIC_URL env var only — intentionally NOT persisted to ~/.pad/config.toml so a CLI Save() (via `pad init` / `pad configure`) on a host where PUBLIC_URL is set for unrelated reasons cannot contaminate the user's config file with a stale URL that outlives the env var. Operators who want a config-file equivalent should set `url` (the toml `URL` field). Consulted by PublicLinkBaseURL() only; does NOT influence the CLI's BaseURL() and does NOT flip Mode to remote.
+	Editor    string `toml:"editor"`
+	LogLevel  string `toml:"log_level"`
+	DBPath    string `toml:"-"` // computed, not from config file
+	DataDir   string `toml:"-"` // computed
 
 	ConfigPath      string `toml:"-"`
 	LoadedFromFile  bool   `toml:"-"`

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -392,6 +392,36 @@ func parseItemRef(s string) (string, int, bool) {
 	return prefix, num, true
 }
 
+// parseItemNumber parses a bare numeric string (e.g. "843") into a positive
+// item number. Returns false for empty strings, non-digit input, zero, or
+// values exceeding a sane upper bound (999999 — items_workspace_number is
+// workspace-global so this comfortably fits any real workspace).
+//
+// Used by Search() to support "type a number, get the item" — a workspace
+// has at most one item with any given item_number (unique index on
+// (workspace_id, item_number)) so this resolves to a single direct hit.
+// See BUG-910.
+func parseItemNumber(s string) (int, bool) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, false
+	}
+	num := 0
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			return 0, false
+		}
+		num = num*10 + int(c-'0')
+		if num > 999999 {
+			return 0, false
+		}
+	}
+	if num == 0 {
+		return 0, false
+	}
+	return num, true
+}
+
 // GetItemIncludeDeleted finds an item by id including soft-deleted
 // items. Used by code paths that need to act on records the user
 // already owns even though the parent item has been moved to trash —

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -307,6 +307,23 @@ func (s *Store) Search(params SearchParams) (*SearchResponse, error) {
 		// FTS still runs below — bare numeric tokens may also match titles/content
 	}
 
+	// Snapshot direct hits (ref + numeric) before FTS so we can:
+	//   1) exclude their IDs in the FTS WHERE clause to prevent them from
+	//      consuming pagination slots that would otherwise be deduped after
+	//      LIMIT/OFFSET (which would shrink page 0 below `limit` and skew
+	//      later pages); and
+	//   2) add their count back to the FTS total so SearchResponse.Total
+	//      reflects the true result set size.
+	// See Codex review for BUG-864/910 round 1.
+	refHits := results
+	refCount := len(refHits)
+	refIDs := make(map[string]bool, refCount)
+	directHitIDs := make([]string, 0, refCount)
+	for _, r := range refHits {
+		refIDs[r.Item.ID] = true
+		directHitIDs = append(directHitIDs, r.Item.ID)
+	}
+
 	// Build the FTS query — the approach differs between SQLite (FTS5 virtual table)
 	// and PostgreSQL (tsvector column on the items table).
 	var query string
@@ -421,6 +438,15 @@ func (s *Store) Search(params SearchParams) (*SearchResponse, error) {
 		args = append(args, value)
 	}
 
+	// Exclude direct hits (ref + numeric) from FTS so duplicates don't consume
+	// pagination slots. See snapshot above and Codex review for BUG-864/910 r1.
+	if len(directHitIDs) > 0 {
+		query += ` AND i.id NOT IN (` + placeholders(len(directHitIDs)) + `)`
+		for _, id := range directHitIDs {
+			args = append(args, id)
+		}
+	}
+
 	// --- Count query (total matching results before pagination) ---
 	// Build the count query by replacing the SELECT columns with COUNT(*).
 	// We reuse the same WHERE/JOIN clauses.
@@ -453,11 +479,23 @@ func (s *Store) Search(params SearchParams) (*SearchResponse, error) {
 	// Replay the same filters for the count query
 	countQuery, countArgs = s.appendSearchFilters(countQuery, countArgs, params)
 
+	// Mirror the FTS direct-hit exclusion so the count matches the SELECT.
+	if len(directHitIDs) > 0 {
+		countQuery += ` AND i.id NOT IN (` + placeholders(len(directHitIDs)) + `)`
+		for _, id := range directHitIDs {
+			countArgs = append(countArgs, id)
+		}
+	}
+
 	var total int
 	countErr := s.db.QueryRow(s.q(countQuery), countArgs...).Scan(&total)
 	if countErr != nil {
 		// Count failure is non-fatal — fall back to reporting result count
 		total = -1
+	} else {
+		// FTS count excluded direct hits via NOT IN — add them back so
+		// SearchResponse.Total reflects the full result set the caller sees.
+		total += refCount
 	}
 
 	// --- Faceted counts (full result set, not paginated) ---
@@ -473,15 +511,11 @@ func (s *Store) Search(params SearchParams) (*SearchResponse, error) {
 	query += s.searchOrderClause(params)
 
 	// --- Pagination ---
-	// Direct ref hits (e.g. searching "TASK-5") are prepended to results
-	// and always appear first. They occupy slots on page 0; on subsequent
-	// pages we exclude them and adjust the FTS offset accordingly.
-	refHits := results // save ref results before FTS
-	refCount := len(refHits)
-	refIDs := make(map[string]bool, refCount)
-	for _, r := range refHits {
-		refIDs[r.Item.ID] = true
-	}
+	// Direct hits (ref + numeric) are prepended to results and always appear
+	// first. They occupy slots on page 0; on subsequent pages we exclude them
+	// and adjust the FTS offset accordingly. refCount/refIDs were snapshotted
+	// above (before the FTS query was built) so the FTS WHERE clause could
+	// already exclude their IDs.
 
 	if total < 0 {
 		total = 0

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -168,6 +168,11 @@ func (s *Store) Search(params SearchParams) (*SearchResponse, error) {
 			refArgs = append(refArgs, value)
 		}
 
+		// Stable order for cross-workspace global searches (where the same
+		// PREFIX-N can match in multiple workspaces) so pagination is
+		// deterministic across pages.
+		refQuery += ` ORDER BY i.workspace_id, i.id`
+
 		refRows, err := s.db.Query(s.q(refQuery), refArgs...)
 		if err == nil {
 			defer refRows.Close()
@@ -271,6 +276,10 @@ func (s *Store) Search(params SearchParams) (*SearchResponse, error) {
 		for _, r := range results {
 			alreadySeen[r.Item.ID] = true
 		}
+
+		// Stable cross-workspace order for global searches (item_number is
+		// only unique per workspace, so q="1" can match one row per workspace).
+		numQuery += ` ORDER BY i.workspace_id, i.id`
 
 		numRows, err := s.db.Query(s.q(numQuery), numArgs...)
 		if err == nil {
@@ -511,40 +520,42 @@ func (s *Store) Search(params SearchParams) (*SearchResponse, error) {
 	query += s.searchOrderClause(params)
 
 	// --- Pagination ---
-	// Direct hits (ref + numeric) are prepended to results and always appear
-	// first. They occupy slots on page 0; on subsequent pages we exclude them
-	// and adjust the FTS offset accordingly. refCount/refIDs were snapshotted
-	// above (before the FTS query was built) so the FTS WHERE clause could
-	// already exclude their IDs.
+	// Direct hits (ref + numeric) sort first conceptually (rank=-1000); FTS
+	// fills in afterwards. Both halves must be paginated together to honour
+	// (offset, limit). In global searches (no `workspace`), the same
+	// PREFIX-N or bare number can match in multiple workspaces, so refCount
+	// can exceed Limit — we must slice direct hits, not just append them.
+	// See Codex review for BUG-864/910 round 2.
 
 	if total < 0 {
 		total = 0
 	}
 
-	// Adjust FTS pagination to account for ref hit slots on page 0.
-	ftsLimit := params.Limit
-	ftsOffset := params.Offset
-	if refCount > 0 {
-		if params.Offset == 0 {
-			// Page 0: ref hits take first slots, FTS fills the rest.
-			ftsLimit = params.Limit - refCount
-			if ftsLimit < 0 {
-				ftsLimit = 0
-			}
-		} else {
-			// Pages after 0: ref hits were shown on page 0, shift offset.
-			ftsOffset = params.Offset - refCount
-			if ftsOffset < 0 {
-				ftsOffset = 0
-			}
-		}
+	// Slice direct hits according to (offset, limit). After this block,
+	// `results` holds the direct-hit page slice, `directConsumed` is how
+	// many direct-hit slots that consumed, and ftsLimit/ftsOffset are the
+	// FTS-side adjustments to fill the remaining slots / skip past direct
+	// hits we already showed.
+	directStart := params.Offset
+	if directStart > refCount {
+		directStart = refCount
+	}
+	directEnd := params.Offset + params.Limit
+	if directEnd > refCount {
+		directEnd = refCount
+	}
+	results = results[directStart:directEnd]
+	directConsumed := directEnd - directStart
+
+	ftsLimit := params.Limit - directConsumed
+	if ftsLimit < 0 {
+		ftsLimit = 0
+	}
+	ftsOffset := params.Offset - refCount
+	if ftsOffset < 0 {
+		ftsOffset = 0
 	}
 	query += fmt.Sprintf(" LIMIT %d OFFSET %d", ftsLimit, ftsOffset)
-
-	// Start building final results: page 0 includes ref hits, later pages don't.
-	if params.Offset > 0 {
-		results = nil
-	}
 
 	rows, err := s.db.Query(s.q(query), args...)
 	if err != nil {

--- a/internal/store/search.go
+++ b/internal/store/search.go
@@ -200,6 +200,113 @@ func (s *Store) Search(params SearchParams) (*SearchResponse, error) {
 		// If no ref matches, fall through to FTS below
 	}
 
+	// Bare numeric query (e.g. "843") — resolve to the workspace-global
+	// item with that item_number. Mirrors the parseItemRef block above
+	// but without a collection prefix filter, since item_number is unique
+	// per workspace (idx_items_workspace_number). At most one item matches.
+	// Lets the search palette double as a quick "go to item N" jump. See BUG-910.
+	if number, ok := parseItemNumber(strings.TrimSpace(params.Query)); ok {
+		numQuery := `
+			SELECT i.id, i.workspace_id, i.collection_id, i.title, i.slug, i.content, i.fields, i.tags,
+			       i.pinned, i.sort_order, i.parent_id, i.assigned_user_id, i.agent_role_id, i.role_sort_order,
+			       i.created_by, i.last_modified_by, i.source,
+			       i.item_number, i.created_at, i.updated_at,
+			       c.slug, c.name, c.icon, c.prefix,
+			       COALESCE(au.name, ''), COALESCE(au.email, ''),
+			       COALESCE(ar.name, ''), COALESCE(ar.slug, ''), COALESCE(ar.icon, '')
+			FROM items i
+			JOIN collections c ON c.id = i.collection_id
+			LEFT JOIN users au ON au.id = i.assigned_user_id
+			LEFT JOIN agent_roles ar ON ar.id = i.agent_role_id
+			WHERE i.item_number = ? AND i.deleted_at IS NULL
+		`
+		numArgs := []interface{}{number}
+
+		if params.Workspace != "" {
+			numQuery += ` AND i.workspace_id = (SELECT id FROM workspaces WHERE slug = ? AND deleted_at IS NULL)`
+			numArgs = append(numArgs, params.Workspace)
+		} else if len(params.WorkspaceIDs) > 0 {
+			numQuery += ` AND i.workspace_id IN (` + placeholders(len(params.WorkspaceIDs)) + `)`
+			for _, id := range params.WorkspaceIDs {
+				numArgs = append(numArgs, id)
+			}
+		}
+
+		if len(params.CollectionIDs) > 0 && len(params.ItemIDs) > 0 {
+			numQuery += ` AND (i.collection_id IN (` + placeholders(len(params.CollectionIDs)) + `) OR i.id IN (` + placeholders(len(params.ItemIDs)) + `))`
+			for _, id := range params.CollectionIDs {
+				numArgs = append(numArgs, id)
+			}
+			for _, id := range params.ItemIDs {
+				numArgs = append(numArgs, id)
+			}
+		} else if len(params.CollectionIDs) > 0 {
+			numQuery += ` AND i.collection_id IN (` + placeholders(len(params.CollectionIDs)) + `)`
+			for _, id := range params.CollectionIDs {
+				numArgs = append(numArgs, id)
+			}
+		} else if len(params.ItemIDs) > 0 {
+			numQuery += ` AND i.id IN (` + placeholders(len(params.ItemIDs)) + `)`
+			for _, id := range params.ItemIDs {
+				numArgs = append(numArgs, id)
+			}
+		}
+
+		// Apply content filters to numeric lookup too
+		if params.Collection != "" {
+			numQuery += ` AND c.slug = ?`
+			numArgs = append(numArgs, params.Collection)
+		}
+		for key, value := range params.FieldFilters {
+			if !validFieldKey.MatchString(key) {
+				continue
+			}
+			numQuery += ` AND ` + s.dialect.JSONExtractText("i.fields", key) + ` = ?`
+			numArgs = append(numArgs, value)
+		}
+
+		// Avoid duplicating an item already added by the parseItemRef path
+		// (can't happen for purely numeric queries, but cheap to be safe).
+		alreadySeen := make(map[string]bool, len(results))
+		for _, r := range results {
+			alreadySeen[r.Item.ID] = true
+		}
+
+		numRows, err := s.db.Query(s.q(numQuery), numArgs...)
+		if err == nil {
+			defer numRows.Close()
+			for numRows.Next() {
+				var r SearchResult
+				var createdAt, updatedAt string
+				var pinned bool
+				if err := numRows.Scan(
+					&r.Item.ID, &r.Item.WorkspaceID, &r.Item.CollectionID, &r.Item.Title, &r.Item.Slug,
+					&r.Item.Content, &r.Item.Fields, &r.Item.Tags,
+					&pinned, &r.Item.SortOrder, &r.Item.ParentID, &r.Item.AssignedUserID, &r.Item.AgentRoleID, &r.Item.RoleSortOrder,
+					&r.Item.CreatedBy, &r.Item.LastModifiedBy,
+					&r.Item.Source, &r.Item.ItemNumber, &createdAt, &updatedAt,
+					&r.Item.CollectionSlug, &r.Item.CollectionName, &r.Item.CollectionIcon, &r.Item.CollectionPrefix,
+					&r.Item.AssignedUserName, &r.Item.AssignedUserEmail,
+					&r.Item.AgentRoleName, &r.Item.AgentRoleSlug, &r.Item.AgentRoleIcon,
+				); err != nil {
+					continue
+				}
+				if alreadySeen[r.Item.ID] {
+					continue
+				}
+				r.Item.Pinned = pinned
+				r.Item.CreatedAt = parseTime(createdAt)
+				r.Item.UpdatedAt = parseTime(updatedAt)
+				hydrateItemComputedMetadata(&r.Item)
+				r.Item.Content = ""
+				r.Snippet = r.Item.Title
+				r.Rank = -1000 // Best possible rank so it sorts first
+				results = append(results, r)
+			}
+		}
+		// FTS still runs below — bare numeric tokens may also match titles/content
+	}
+
 	// Build the FTS query — the approach differs between SQLite (FTS5 virtual table)
 	// and PostgreSQL (tsvector column on the items table).
 	var query string

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1309,22 +1309,22 @@ func TestSearch_BareNumericQueryPaginatesAcrossWorkspaces(t *testing.T) {
 // TestParseItemNumber covers the helper that gates the bare-numeric search path.
 func TestParseItemNumber(t *testing.T) {
 	cases := []struct {
-		in     string
-		num    int
-		ok     bool
+		in  string
+		num int
+		ok  bool
 	}{
 		{"843", 843, true},
 		{"1", 1, true},
 		{"  42  ", 42, true},
 		{"", 0, false},
-		{"0", 0, false},        // zero is not a valid item number
+		{"0", 0, false}, // zero is not a valid item number
 		{"abc", 0, false},
 		{"843a", 0, false},
 		{"a843", 0, false},
 		{"TASK-843", 0, false}, // hyphens go through parseItemRef instead
 		{"-5", 0, false},
 		{"12.5", 0, false},
-		{"9999999", 0, false},  // exceeds upper bound
+		{"9999999", 0, false}, // exceeds upper bound
 	}
 	for _, c := range cases {
 		num, ok := parseItemNumber(c.in)

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1154,6 +1154,61 @@ func TestSearch_BareNumericQueryFindsItemByNumber(t *testing.T) {
 	}
 }
 
+// TestSearch_BareNumericQueryDedupsAgainstFTS guards the fix for the Codex
+// review finding on the BUG-864/910 PR: when a bare-numeric query also
+// matches FTS via the item's title/content (because the title literally
+// contains the digit string), the direct hit must not also appear as an
+// FTS row — otherwise pagination shrinks page 0 below `limit` and shifts
+// later pages. With the FTS WHERE-clause exclusion, the item appears
+// exactly once and Total counts it exactly once.
+func TestSearch_BareNumericQueryDedupsAgainstFTS(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Test")
+	s.SeedDefaultCollections(ws.ID)
+	colls, _ := s.ListCollections(ws.ID)
+	var tasksID string
+	for _, c := range colls {
+		if c.Slug == "tasks" {
+			tasksID = c.ID
+			break
+		}
+	}
+
+	// First item gets item_number=1 (workspace-global).
+	target, err := s.CreateItem(ws.ID, tasksID, models.ItemCreate{
+		Title:   "Reference number 1 in title",
+		Content: "This task talks about the digit 1 a lot. 1 is everywhere.",
+	})
+	if err != nil {
+		t.Fatalf("CreateItem target: %v", err)
+	}
+	if target.ItemNumber == nil || *target.ItemNumber != 1 {
+		t.Fatalf("expected target.ItemNumber=1, got %v", target.ItemNumber)
+	}
+
+	resp, err := s.Search(SearchParams{Query: "1", Workspace: ws.Slug})
+	if err != nil {
+		t.Fatalf("Search error: %v", err)
+	}
+
+	// The target must appear exactly once across results.
+	count := 0
+	for _, r := range resp.Results {
+		if r.Item.ID == target.ID {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected target item to appear exactly once, got %d occurrences", count)
+	}
+
+	// Total must count the target exactly once too — not double-counted as
+	// (1 direct hit) + (1 FTS hit) = 2.
+	if resp.Total != len(resp.Results) {
+		t.Errorf("expected Total=%d (= len(Results)), got Total=%d", len(resp.Results), resp.Total)
+	}
+}
+
 // TestParseItemNumber covers the helper that gates the bare-numeric search path.
 func TestParseItemNumber(t *testing.T) {
 	cases := []struct {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1209,6 +1209,103 @@ func TestSearch_BareNumericQueryDedupsAgainstFTS(t *testing.T) {
 	}
 }
 
+// TestSearch_BareNumericQueryPaginatesAcrossWorkspaces guards the round-2
+// Codex finding: in global search (WorkspaceIDs scoping, no single
+// `Workspace`), a bare numeric query like "1" can match one item per
+// workspace. Direct hits must be paginated together with FTS results so
+// that (limit, offset) honours the full ordered list — not return all
+// direct hits on page 0 ignoring `limit`, and not skip them entirely on
+// page 1.
+func TestSearch_BareNumericQueryPaginatesAcrossWorkspaces(t *testing.T) {
+	s := testStore(t)
+	ws1 := createTestWorkspace(t, s, "WS One")
+	ws2 := createTestWorkspace(t, s, "WS Two")
+	ws3 := createTestWorkspace(t, s, "WS Three")
+	for _, ws := range []*models.Workspace{ws1, ws2, ws3} {
+		s.SeedDefaultCollections(ws.ID)
+		colls, _ := s.ListCollections(ws.ID)
+		var tasksID string
+		for _, c := range colls {
+			if c.Slug == "tasks" {
+				tasksID = c.ID
+				break
+			}
+		}
+		// Item #1 in each workspace.
+		if _, err := s.CreateItem(ws.ID, tasksID, models.ItemCreate{Title: "Task one in " + ws.Name}); err != nil {
+			t.Fatalf("CreateItem in %s: %v", ws.Name, err)
+		}
+	}
+
+	allWs := []string{ws1.ID, ws2.ID, ws3.ID}
+
+	// Page 0: limit=1 — must return exactly one direct hit, not all three.
+	resp, err := s.Search(SearchParams{Query: "1", WorkspaceIDs: allWs, Limit: 1})
+	if err != nil {
+		t.Fatalf("page 0: %v", err)
+	}
+	if len(resp.Results) != 1 {
+		t.Errorf("page 0: expected 1 result, got %d", len(resp.Results))
+	}
+	if resp.Total != 3 {
+		t.Errorf("page 0: expected Total=3 (all three direct hits), got %d", resp.Total)
+	}
+	page0ID := ""
+	if len(resp.Results) > 0 {
+		page0ID = resp.Results[0].Item.ID
+	}
+
+	// Page 1: limit=1, offset=1 — must return the second direct hit, NOT
+	// fall through to FTS rows after dropping all direct hits.
+	resp, err = s.Search(SearchParams{Query: "1", WorkspaceIDs: allWs, Limit: 1, Offset: 1})
+	if err != nil {
+		t.Fatalf("page 1: %v", err)
+	}
+	if len(resp.Results) != 1 {
+		t.Errorf("page 1: expected 1 result, got %d", len(resp.Results))
+	}
+	if resp.Total != 3 {
+		t.Errorf("page 1: expected Total=3, got %d", resp.Total)
+	}
+	if len(resp.Results) > 0 && resp.Results[0].Item.ID == page0ID {
+		t.Errorf("page 1: expected a different direct hit than page 0, got the same item %q", page0ID)
+	}
+
+	// Page 2: limit=1, offset=2 — third direct hit.
+	resp, err = s.Search(SearchParams{Query: "1", WorkspaceIDs: allWs, Limit: 1, Offset: 2})
+	if err != nil {
+		t.Fatalf("page 2: %v", err)
+	}
+	if len(resp.Results) != 1 {
+		t.Errorf("page 2: expected 1 result, got %d", len(resp.Results))
+	}
+
+	// Single-page (limit=10) — must return all three direct hits, in
+	// deterministic order (by workspace_id then id).
+	resp, err = s.Search(SearchParams{Query: "1", WorkspaceIDs: allWs, Limit: 10})
+	if err != nil {
+		t.Fatalf("single page: %v", err)
+	}
+	if len(resp.Results) != 3 {
+		t.Errorf("single page: expected 3 results, got %d", len(resp.Results))
+	}
+	if resp.Total != 3 {
+		t.Errorf("single page: expected Total=3, got %d", resp.Total)
+	}
+
+	// Stable ordering — same query twice gives the same order.
+	resp2, _ := s.Search(SearchParams{Query: "1", WorkspaceIDs: allWs, Limit: 10})
+	for i := range resp.Results {
+		if i >= len(resp2.Results) {
+			break
+		}
+		if resp.Results[i].Item.ID != resp2.Results[i].Item.ID {
+			t.Errorf("ordering not deterministic at index %d: %q vs %q",
+				i, resp.Results[i].Item.ID, resp2.Results[i].Item.ID)
+		}
+	}
+}
+
 // TestParseItemNumber covers the helper that gates the bare-numeric search path.
 func TestParseItemNumber(t *testing.T) {
 	cases := []struct {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1080,6 +1080,108 @@ func TestActivity(t *testing.T) {
 	}
 }
 
+// TestSearch_BareNumericQueryFindsItemByNumber verifies that typing a plain
+// number into the search field (e.g. "843") resolves to the workspace-global
+// item with that item_number. This lets the search palette double as a quick
+// "go to item N" jump. See BUG-910.
+func TestSearch_BareNumericQueryFindsItemByNumber(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Test")
+	s.SeedDefaultCollections(ws.ID)
+	colls, _ := s.ListCollections(ws.ID)
+	var tasksID, ideasID string
+	for _, c := range colls {
+		if c.Slug == "tasks" {
+			tasksID = c.ID
+		}
+		if c.Slug == "ideas" {
+			ideasID = c.ID
+		}
+	}
+
+	// Create a few items so item_numbers are 1, 2, 3 (workspace-global).
+	if _, err := s.CreateItem(ws.ID, tasksID, models.ItemCreate{Title: "First task"}); err != nil {
+		t.Fatalf("CreateItem 1: %v", err)
+	}
+	target, err := s.CreateItem(ws.ID, tasksID, models.ItemCreate{Title: "Target task"})
+	if err != nil {
+		t.Fatalf("CreateItem 2: %v", err)
+	}
+	if _, err := s.CreateItem(ws.ID, ideasID, models.ItemCreate{Title: "Some idea"}); err != nil {
+		t.Fatalf("CreateItem 3: %v", err)
+	}
+
+	// Sanity: the second item should have item_number = 2.
+	if target.ItemNumber == nil || *target.ItemNumber != 2 {
+		t.Fatalf("expected target.ItemNumber=2, got %v", target.ItemNumber)
+	}
+
+	// Bare numeric query "2" should find the item with item_number=2.
+	resp, err := s.Search(SearchParams{Query: "2", Workspace: ws.Slug})
+	if err != nil {
+		t.Fatalf("Search error: %v", err)
+	}
+	if len(resp.Results) == 0 {
+		t.Fatalf("expected at least 1 result for bare numeric query, got 0")
+	}
+	if resp.Results[0].Item.ID != target.ID {
+		gotNum := -1
+		if resp.Results[0].Item.ItemNumber != nil {
+			gotNum = *resp.Results[0].Item.ItemNumber
+		}
+		t.Errorf("expected target item first, got %q (item_number=%d)",
+			resp.Results[0].Item.Title, gotNum)
+	}
+
+	// A non-existent number should not surface as a direct hit.
+	resp, err = s.Search(SearchParams{Query: "9999", Workspace: ws.Slug})
+	if err != nil {
+		t.Fatalf("Search error: %v", err)
+	}
+	for _, r := range resp.Results {
+		if r.Item.ItemNumber != nil && *r.Item.ItemNumber == 9999 {
+			t.Errorf("did not expect any item with item_number=9999")
+		}
+	}
+
+	// Whitespace around a bare number should still resolve.
+	resp, err = s.Search(SearchParams{Query: "  2  ", Workspace: ws.Slug})
+	if err != nil {
+		t.Fatalf("Search error: %v", err)
+	}
+	if len(resp.Results) == 0 || resp.Results[0].Item.ID != target.ID {
+		t.Errorf("expected whitespace-padded numeric query to resolve to target item")
+	}
+}
+
+// TestParseItemNumber covers the helper that gates the bare-numeric search path.
+func TestParseItemNumber(t *testing.T) {
+	cases := []struct {
+		in     string
+		num    int
+		ok     bool
+	}{
+		{"843", 843, true},
+		{"1", 1, true},
+		{"  42  ", 42, true},
+		{"", 0, false},
+		{"0", 0, false},        // zero is not a valid item number
+		{"abc", 0, false},
+		{"843a", 0, false},
+		{"a843", 0, false},
+		{"TASK-843", 0, false}, // hyphens go through parseItemRef instead
+		{"-5", 0, false},
+		{"12.5", 0, false},
+		{"9999999", 0, false},  // exceeds upper bound
+	}
+	for _, c := range cases {
+		num, ok := parseItemNumber(c.in)
+		if num != c.num || ok != c.ok {
+			t.Errorf("parseItemNumber(%q) = (%d, %v), want (%d, %v)", c.in, num, ok, c.num, c.ok)
+		}
+	}
+}
+
 func TestSlugify(t *testing.T) {
 	tests := []struct {
 		input    string

--- a/web/src/lib/components/search/CommandPalette.svelte
+++ b/web/src/lib/components/search/CommandPalette.svelte
@@ -16,7 +16,9 @@
 	let results = $state<SearchResult[]>([]);
 	let total = $state(0);
 	let facets = $state<SearchFacets | undefined>(undefined);
-	let selectedIdx = $state(0);
+	// -1 means "no result armed". The user must press an arrow key (or type a
+	// bare number) before Enter will navigate. See BUG-864.
+	let selectedIdx = $state(-1);
 	let loading = $state(false);
 	let loadingMore = $state(false);
 	let searchTimeout: ReturnType<typeof setTimeout>;
@@ -62,7 +64,7 @@
 			results = [];
 			total = 0;
 			facets = undefined;
-			selectedIdx = 0;
+			selectedIdx = -1;
 			filterCollection = null;
 			filterStatus = null;
 			loading = false;
@@ -86,7 +88,7 @@
 			results = [];
 			total = 0;
 			facets = undefined;
-			selectedIdx = 0;
+			selectedIdx = -1;
 			loading = false;
 			return;
 		}
@@ -99,7 +101,10 @@
 				results = resp.results ?? [];
 				total = resp.total ?? 0;
 				facets = resp.facets;
-				selectedIdx = 0;
+				// BUG-864: do NOT auto-arm the first result. The user must
+				// press an arrow key (or type a bare number + Enter) to
+				// trigger navigation.
+				selectedIdx = -1;
 			} catch {
 				results = [];
 				total = 0;
@@ -150,20 +155,56 @@
 		});
 	}
 
-	function handleKeydown(e: KeyboardEvent) {
+	async function handleKeydown(e: KeyboardEvent) {
 		if (e.key === 'Escape') {
 			uiStore.closeSearch();
 		} else if (e.key === 'ArrowDown') {
 			e.preventDefault();
+			// From -1 ("nothing armed") this lands on 0, the first result.
 			selectedIdx = Math.min(selectedIdx + 1, flatResults.length - 1);
 			scrollSelectedIntoView();
 		} else if (e.key === 'ArrowUp') {
 			e.preventDefault();
+			// Clamp at 0 — once the user has armed a selection, ArrowUp
+			// shouldn't deselect back to -1.
 			selectedIdx = Math.max(selectedIdx - 1, 0);
 			scrollSelectedIntoView();
-		} else if (e.key === 'Enter' && flatResults.length > 0) {
+		} else if (e.key === 'Enter') {
 			e.preventDefault();
-			selectResult(flatResults[selectedIdx]);
+			// Numeric go-to mode: typing a bare number + Enter jumps directly
+			// to the item with that item_number — the search palette doubles
+			// as a quick "go to item N" jump. See BUG-910 + BUG-864.
+			const trimmed = query.trim();
+			if (/^\d+$/.test(trimmed)) {
+				const targetNum = parseInt(trimmed, 10);
+				// Flush any pending debounced search so Enter feels instant
+				// even if the user beats the 200ms debounce.
+				clearTimeout(searchTimeout);
+				let item = results.find((r) => r.item.item_number === targetNum);
+				if (!item) {
+					loading = true;
+					try {
+						const resp = await api.search(trimmed, buildFilters(0));
+						results = resp.results ?? [];
+						total = resp.total ?? 0;
+						facets = resp.facets;
+						item = results.find((r) => r.item.item_number === targetNum);
+					} catch {
+						// ignore — falls through to no-op below
+					} finally {
+						loading = false;
+					}
+				}
+				if (item) {
+					selectResult(item);
+				}
+				return;
+			}
+			// BUG-864: for non-numeric queries, only navigate when the user
+			// has explicitly arrow-selected a result.
+			if (selectedIdx >= 0 && flatResults.length > 0 && flatResults[selectedIdx]) {
+				selectResult(flatResults[selectedIdx]);
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

Fixes two related issues in the command palette / search modal.

- **BUG-864** — Pressing Enter armed the first result automatically. `selectedIdx` now starts at `-1`; the user must press an arrow key (or type a bare number) before Enter will navigate. The misleading "first recent search highlighted but Enter is a no-op" state on initial open also goes away.
- **BUG-910** — Typing a bare number like `843` returned no results because `parseItemRef` requires `PREFIX-NUMBER` and FTS doesn't index `item_number`. Adds a backend bare-numeric direct-lookup path; `item_number` is workspace-globally unique, so this resolves to at most one item.
- **Bonus (per follow-up):** numeric query + Enter is a deliberate exception to the BUG-864 rule — it navigates directly to the matching item, letting the palette double as a quick "go to item N" jump. The frontend flushes the search debounce on Enter for instant feel.

## Files

**Backend** (`internal/store/`)
- `items.go` — new `parseItemNumber()` helper.
- `search.go` — bare-numeric lookup mirrors existing `parseItemRef` block; respects workspace, collection, field, and permission filters.
- `store_test.go` — `TestSearch_BareNumericQueryFindsItemByNumber`, `TestParseItemNumber`.

**Frontend** (`web/src/lib/components/search/CommandPalette.svelte`)
- `selectedIdx` defaults to `-1`; reset to `-1` on modal open, on empty query, and after each search.
- `handleKeydown` is now `async` so Enter can flush the debounce.
- Enter on numeric query → navigate directly. Enter on non-numeric → no-op unless arrow-selected.

## Test plan

- [x] `go test ./internal/store/` — new tests pass; full suite green.
- [x] `go test ./...` — all pass.
- [x] `cd web && npm run build` — clean.
- [x] `make install` — installs and restarts server.
- [x] Live API smoke: `GET /api/v1/search?q=843&workspace=docapp` returns TASK-843 with rank=-1000 as the first result.
- [x] Live API smoke: `GET /api/v1/search?q=99999&workspace=docapp` returns 0 results (no false direct hits).
- [ ] Manual UI: open palette, type `843` → Enter jumps to TASK-843.
- [ ] Manual UI: open palette, type `oauth` → Enter is no-op until ArrowDown.
- [ ] Manual UI: open palette with no query → no recent search auto-highlighted.