### PR TITLE
feat(attachment): add `pad attachment view|show|list` CLI surfaces (IDEA-898)

### DIFF
--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"io/fs"
 	"log/slog"
+	goMime "mime"
 	"net/http"
 	"net/url"
 	"os"
@@ -6359,22 +6360,34 @@ func starredCmd() *cobra.Command {
 func attachmentCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "attachment",
-		Short: "Upload and download item attachments",
-		Long: `Upload and download attachments (images, files) on items.
+		Short: "Upload, download, view, and list item attachments",
+		Long: `Upload, download, view, and list attachments (images, files) on items.
 
 Examples:
-  pad attachment upload TASK-5 ./screenshot.png
-  pad attachment upload TASK-5 ./design.pdf --filename "Design v2.pdf"
-  pad attachment download <attachment-id> ./screenshot.png
-  pad attachment download <attachment-id> --variant thumb-sm ./thumb.png
+  pad attachment list                                # all workspace attachments
+  pad attachment list --item TASK-5                  # attachments on a specific item
+  pad attachment list --category image --limit 20    # filter + paginate
+  pad attachment show <attachment-id>                # metadata only (HEAD)
+  pad attachment view <attachment-id>                # save to temp file, print path
+  pad attachment view <attachment-id> -o ./pic.png   # save to a chosen path
+  pad attachment upload TASK-5 ./screenshot.png      # upload + attach to item
+  pad attachment download <attachment-id> ./pic.png  # download to explicit path
 
 Attachments belong to a workspace and may optionally reference an item.
-Pass "-" as the item argument to upload without associating with any item.`,
+Pass "-" as the item argument to upload without associating with any item.
+
+For agents: ALWAYS use these CLI commands to read attachments — never read
+directly from ~/.pad/attachments/. The CLI goes through the authenticated
+REST API, which works on local SQLite, Pad Cloud, and remote/Postgres
+deployments and respects workspace ACLs.`,
 	}
 
 	cmd.AddCommand(
 		attachmentUploadCmd(),
 		attachmentDownloadCmd(),
+		attachmentViewCmd(),
+		attachmentShowCmd(),
+		attachmentListCmd(),
 	)
 	return cmd
 }
@@ -6480,45 +6493,12 @@ Examples:
 			}
 
 			// File case: write to a sibling temp file first and rename
-			// on success. A bad attachment ID, auth failure, or partial
-			// download otherwise truncates the existing destination
-			// file (Codex round 1, P2).
-			dir := filepath.Dir(outPath)
-			tmp, err := os.CreateTemp(dir, "."+filepath.Base(outPath)+".*.tmp")
-			if err != nil {
-				return fmt.Errorf("create download temp in %s: %w", dir, err)
-			}
-			tmpPath := tmp.Name()
-			committed := false
-			defer func() {
-				tmp.Close()
-				if !committed {
-					_ = os.Remove(tmpPath)
-				}
-			}()
-
-			mime, n, err := client.DownloadAttachment(ws, id, variantFlag, tmp)
+			// on success. Shared helper keeps `download` and
+			// `view -o <path>` on the same crash-safe code path.
+			mime, n, err := downloadAttachmentToPath(client, ws, id, variantFlag, outPath)
 			if err != nil {
 				return err
 			}
-			if err := tmp.Sync(); err != nil {
-				return fmt.Errorf("sync temp: %w", err)
-			}
-			if err := tmp.Close(); err != nil {
-				return fmt.Errorf("close temp: %w", err)
-			}
-			// os.Rename atomically replaces an existing destination on
-			// every supported platform: POSIX rename(2) is atomic-replace
-			// by definition, and Windows uses MoveFileEx with
-			// MOVEFILE_REPLACE_EXISTING (see Go stdlib
-			// internal/syscall/windows/syscall_windows.go Rename — this
-			// has been the behavior since Go 1.5, released 2015). No
-			// platform-specific shim required.
-			if err := os.Rename(tmpPath, outPath); err != nil {
-				return fmt.Errorf("rename %s -> %s: %w", tmpPath, outPath, err)
-			}
-			committed = true
-
 			fmt.Printf("Saved %d bytes (%s) to %s\n", n, mime, outPath)
 			return nil
 		},
@@ -6526,4 +6506,429 @@ Examples:
 
 	cmd.Flags().StringVar(&variantFlag, "variant", "", "request a derived variant (thumb-sm | thumb-md)")
 	return cmd
+}
+
+// downloadAttachmentToPath streams the attachment into a sibling temp
+// file and atomically renames it onto outPath on success. Shared by
+// `attachment download` and `attachment view -o <path>` so both get
+// the same crash-safe behavior (a bad ID, auth failure, or partial
+// download never truncates an existing destination — Codex round 1
+// P2 on the original download command).
+func downloadAttachmentToPath(client *cli.Client, ws, id, variant, outPath string) (mime string, n int64, err error) {
+	dir := filepath.Dir(outPath)
+	tmp, err := os.CreateTemp(dir, "."+filepath.Base(outPath)+".*.tmp")
+	if err != nil {
+		return "", 0, fmt.Errorf("create download temp in %s: %w", dir, err)
+	}
+	tmpPath := tmp.Name()
+	committed := false
+	defer func() {
+		tmp.Close()
+		if !committed {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+
+	mime, n, err = client.DownloadAttachment(ws, id, variant, tmp)
+	if err != nil {
+		return "", 0, err
+	}
+	if err := tmp.Sync(); err != nil {
+		return "", 0, fmt.Errorf("sync temp: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return "", 0, fmt.Errorf("close temp: %w", err)
+	}
+	// os.Rename atomically replaces an existing destination on every
+	// supported platform (POSIX rename(2); Windows MoveFileEx with
+	// MOVEFILE_REPLACE_EXISTING since Go 1.5).
+	if err := os.Rename(tmpPath, outPath); err != nil {
+		return "", 0, fmt.Errorf("rename %s -> %s: %w", tmpPath, outPath, err)
+	}
+	committed = true
+	return mime, n, nil
+}
+
+// parseAttachmentFilename pulls the filename parameter out of a
+// Content-Disposition header. Returns "" when the header is absent
+// or unparseable so the caller can fall back to a synthetic name.
+// Always passes the result through filepath.Base to defuse a
+// hostile "../etc/passwd"-style filename — defense in depth even
+// though the server already sanitizes on upload.
+func parseAttachmentFilename(disposition string) string {
+	if disposition == "" {
+		return ""
+	}
+	_, params, err := goMime.ParseMediaType(disposition)
+	if err != nil {
+		return ""
+	}
+	name := params["filename"]
+	if name == "" {
+		return ""
+	}
+	return filepath.Base(name)
+}
+
+// extensionForMIME returns a leading-dot extension for a MIME type,
+// or "" if the MIME isn't on our known list. Used as a last-resort
+// fallback when the Content-Disposition header is missing a filename
+// — we'd rather give the agent `<id>.png` than `<id>` with no hint
+// for downstream tooling.
+//
+// We can't use mime.ExtensionsByType here because its results depend
+// on the host's /etc/mime.types and aren't deterministic across
+// platforms (Linux/macOS/Windows all differ). The hardcoded map
+// mirrors the canonical entries in internal/attachments/mime.go.
+func extensionForMIME(mimeType string) string {
+	if i := strings.IndexByte(mimeType, ';'); i >= 0 {
+		mimeType = mimeType[:i]
+	}
+	mimeType = strings.ToLower(strings.TrimSpace(mimeType))
+	switch mimeType {
+	case "image/png":
+		return ".png"
+	case "image/jpeg":
+		return ".jpg"
+	case "image/gif":
+		return ".gif"
+	case "image/webp":
+		return ".webp"
+	case "image/avif":
+		return ".avif"
+	case "image/heic":
+		return ".heic"
+	case "image/heif":
+		return ".heif"
+	case "video/mp4":
+		return ".mp4"
+	case "video/webm":
+		return ".webm"
+	case "video/quicktime":
+		return ".mov"
+	case "audio/mpeg":
+		return ".mp3"
+	case "audio/wav":
+		return ".wav"
+	case "audio/ogg":
+		return ".ogg"
+	case "audio/flac":
+		return ".flac"
+	case "audio/aac":
+		return ".aac"
+	case "audio/mp4":
+		return ".m4a"
+	case "application/pdf":
+		return ".pdf"
+	case "application/zip":
+		return ".zip"
+	case "application/json":
+		return ".json"
+	case "text/plain":
+		return ".txt"
+	case "text/markdown":
+		return ".md"
+	case "text/csv":
+		return ".csv"
+	}
+	return ""
+}
+
+func attachmentViewCmd() *cobra.Command {
+	var outFlag string
+	var variantFlag string
+
+	cmd := &cobra.Command{
+		Use:   "view <attachment-id>",
+		Short: "Fetch an attachment to a file and print its path",
+		Long: `Fetch an attachment by UUID through the authenticated REST API
+and save it to disk. Prints the absolute path of the saved file on
+stdout — designed for agents to use as $(pad attachment view <id>).
+
+With no -o flag, the file lands in a fresh OS temp directory. The
+filename comes from the attachment's Content-Disposition header so
+agents can hand the path to image-viewing tools without rewriting
+the extension.
+
+With -o <path>, the file is written to that path using the same
+atomic temp-then-rename strategy as 'pad attachment download'.
+
+This is the recommended way for AI agents (Claude Code, Cursor, etc.)
+to view attachments referenced in item content as
+![alt](pad-attachment:<uuid>). It works for every Pad install
+(local SQLite, Pad Cloud, remote/Postgres) and respects workspace
+ACLs. Reading directly from ~/.pad/attachments/ does NOT — never
+do that.
+
+Examples:
+  pad attachment view <id>                         # tmp file, print path
+  pad attachment view <id> -o ./screenshot.png     # save to chosen path
+  pad attachment view <id> --variant thumb-md      # serve a derived variant
+  pad attachment view <id> --format json           # {path,mime,size}`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, _ := getClient()
+			ws := getWorkspace()
+			id := args[0]
+
+			outPath := outFlag
+			if outPath == "" {
+				// HEAD first so we can name the temp file using the
+				// real filename + extension. Cheap (no body) and
+				// gives us the size for the JSON output too.
+				meta, err := client.HeadAttachment(ws, id, variantFlag)
+				if err != nil {
+					return err
+				}
+				name := parseAttachmentFilename(meta.ContentDisposition)
+				if name == "" {
+					name = id + extensionForMIME(meta.MIME)
+				}
+				dir, err := os.MkdirTemp("", "pad-attachment-")
+				if err != nil {
+					return fmt.Errorf("create temp dir: %w", err)
+				}
+				outPath = filepath.Join(dir, name)
+			}
+
+			mime, n, err := downloadAttachmentToPath(client, ws, id, variantFlag, outPath)
+			if err != nil {
+				return err
+			}
+
+			abs, err := filepath.Abs(outPath)
+			if err != nil {
+				abs = outPath
+			}
+
+			if formatFlag == "json" {
+				return cli.PrintJSON(map[string]any{
+					"path": abs,
+					"mime": mime,
+					"size": n,
+				})
+			}
+			// Default: just the path on stdout. Anything chatty goes
+			// to stderr so $(pad attachment view <id>) substitutes
+			// cleanly into a shell pipeline.
+			fmt.Println(abs)
+			fmt.Fprintf(os.Stderr, "wrote %d bytes (%s)\n", n, mime)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&outFlag, "output", "o", "", "save to this path instead of an OS temp file")
+	cmd.Flags().StringVar(&variantFlag, "variant", "", "request a derived variant (thumb-sm | thumb-md)")
+	return cmd
+}
+
+func attachmentShowCmd() *cobra.Command {
+	var variantFlag string
+
+	cmd := &cobra.Command{
+		Use:   "show <attachment-id>",
+		Short: "Show attachment metadata (size, MIME, filename) without downloading",
+		Long: `Issue a HEAD request and print the attachment's MIME type,
+size, filename, ETag, and Last-Modified — without transferring the
+bytes. Useful to confirm an attachment exists, or to size a
+download before committing to it.
+
+Examples:
+  pad attachment show <id>
+  pad attachment show <id> --format json
+  pad attachment show <id> --variant thumb-sm`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, _ := getClient()
+			ws := getWorkspace()
+			id := args[0]
+
+			meta, err := client.HeadAttachment(ws, id, variantFlag)
+			if err != nil {
+				return err
+			}
+
+			if formatFlag == "json" {
+				out := map[string]any{
+					"id":   meta.ID,
+					"mime": meta.MIME,
+					"size": meta.Size,
+				}
+				if name := parseAttachmentFilename(meta.ContentDisposition); name != "" {
+					out["filename"] = name
+				}
+				if meta.ETag != "" {
+					out["etag"] = meta.ETag
+				}
+				if meta.LastModified != "" {
+					out["last_modified"] = meta.LastModified
+				}
+				return cli.PrintJSON(out)
+			}
+
+			fmt.Printf("%-15s %s\n", "ID:", meta.ID)
+			fmt.Printf("%-15s %s\n", "MIME:", meta.MIME)
+			fmt.Printf("%-15s %s\n", "Size:", humanSize(meta.Size))
+			if name := parseAttachmentFilename(meta.ContentDisposition); name != "" {
+				fmt.Printf("%-15s %s\n", "Filename:", name)
+			}
+			if meta.ETag != "" {
+				fmt.Printf("%-15s %s\n", "ETag:", meta.ETag)
+			}
+			if meta.LastModified != "" {
+				fmt.Printf("%-15s %s\n", "Last-Modified:", meta.LastModified)
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&variantFlag, "variant", "", "request a derived variant (thumb-sm | thumb-md)")
+	return cmd
+}
+
+func attachmentListCmd() *cobra.Command {
+	var (
+		itemFlag       string
+		categoryFlag   string
+		collectionFlag string
+		attachedFlag   bool
+		unattachedFlag bool
+		sortFlag       string
+		limitFlag      int
+		offsetFlag     int
+	)
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List attachments in the workspace",
+		Long: `List attachments in the current workspace, with optional
+filters. Returns the same fields the web UI uses (id, mime, size,
+filename, parent item, collection, created_at).
+
+Examples:
+  pad attachment list                              # all originals
+  pad attachment list --item TASK-5                # one item's attachments
+  pad attachment list --category image --limit 20  # images only
+  pad attachment list --unattached                 # orphan uploads
+  pad attachment list --format json                # parseable output
+
+The --item flag accepts an item ref (TASK-5) or slug; the CLI
+resolves it to a UUID before calling the API.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if attachedFlag && unattachedFlag {
+				return fmt.Errorf("--attached and --unattached are mutually exclusive")
+			}
+			if itemFlag != "" && unattachedFlag {
+				return fmt.Errorf("--item and --unattached are mutually exclusive")
+			}
+
+			client, _ := getClient()
+			ws := getWorkspace()
+
+			params := cli.AttachmentListParams{
+				Category:     categoryFlag,
+				CollectionID: collectionFlag,
+				Sort:         sortFlag,
+				Limit:        limitFlag,
+				Offset:       offsetFlag,
+			}
+			if itemFlag != "" {
+				it, err := client.GetItem(ws, itemFlag)
+				if err != nil {
+					return fmt.Errorf("resolve item %q: %w", itemFlag, err)
+				}
+				params.ItemID = it.ID
+			}
+			if attachedFlag {
+				params.Item = "attached"
+			}
+			if unattachedFlag {
+				params.Item = "unattached"
+			}
+
+			resp, err := client.ListAttachments(ws, params)
+			if err != nil {
+				return err
+			}
+
+			if formatFlag == "json" {
+				return cli.PrintJSON(resp)
+			}
+
+			if len(resp.Attachments) == 0 {
+				fmt.Println("No attachments.")
+				return nil
+			}
+
+			tw := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+			fmt.Fprintln(tw, "ID\tMIME\tSIZE\tFILENAME\tITEM\tCREATED")
+			for _, raw := range resp.Attachments {
+				var row struct {
+					ID             string  `json:"id"`
+					MimeType       string  `json:"mime_type"`
+					SizeBytes      int64   `json:"size_bytes"`
+					Filename       string  `json:"filename"`
+					ItemTitle      *string `json:"item_title"`
+					CollectionSlug *string `json:"collection_slug"`
+					ItemDeleted    bool    `json:"item_deleted"`
+					CreatedAt      string  `json:"created_at"`
+				}
+				if err := json.Unmarshal(raw, &row); err != nil {
+					continue
+				}
+				item := "—"
+				if row.ItemTitle != nil && *row.ItemTitle != "" {
+					item = *row.ItemTitle
+					if row.ItemDeleted {
+						item += " (deleted)"
+					}
+				}
+				short := row.ID
+				if len(short) > 8 {
+					short = short[:8]
+				}
+				created := row.CreatedAt
+				if t, err := time.Parse(time.RFC3339, row.CreatedAt); err == nil {
+					created = t.Format("2006-01-02 15:04")
+				}
+				fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\n",
+					short, row.MimeType, humanSize(row.SizeBytes), row.Filename, item, created)
+			}
+			tw.Flush()
+			fmt.Printf("\n%d of %d (limit %d, offset %d)\n", len(resp.Attachments), resp.Total, resp.Limit, resp.Offset)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&itemFlag, "item", "", "filter to attachments on a specific item (ref or slug)")
+	cmd.Flags().StringVar(&categoryFlag, "category", "", "filter by MIME category: image|video|audio|document|text|archive|other")
+	cmd.Flags().StringVar(&collectionFlag, "collection", "", "filter by collection UUID")
+	cmd.Flags().BoolVar(&attachedFlag, "attached", false, "only attachments associated with an item")
+	cmd.Flags().BoolVar(&unattachedFlag, "unattached", false, "only orphan attachments (no parent item)")
+	cmd.Flags().StringVar(&sortFlag, "sort", "", "sort: size|size_desc|filename|filename_desc|created_at|created_at_desc (default created_at_desc)")
+	cmd.Flags().IntVar(&limitFlag, "limit", 0, "page size (1-200, default 50)")
+	cmd.Flags().IntVar(&offsetFlag, "offset", 0, "page offset")
+	return cmd
+}
+
+// humanSize formats a byte count in a compact human-readable form
+// (1.2 MB, 340 KB). Used by attachment list / show; not exported because
+// the formatting is opinionated for those tables specifically.
+func humanSize(n int64) string {
+	const (
+		KB = 1024
+		MB = KB * 1024
+		GB = MB * 1024
+	)
+	switch {
+	case n >= GB:
+		return fmt.Sprintf("%.1f GB", float64(n)/float64(GB))
+	case n >= MB:
+		return fmt.Sprintf("%.1f MB", float64(n)/float64(MB))
+	case n >= KB:
+		return fmt.Sprintf("%.1f KB", float64(n)/float64(KB))
+	default:
+		return fmt.Sprintf("%d B", n)
+	}
 }

--- a/internal/cli/client.go
+++ b/internal/cli/client.go
@@ -8,6 +8,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -761,6 +762,127 @@ func (c *Client) DownloadAttachment(wsSlug, attachmentID, variant string, w io.W
 		return resp.Header.Get("Content-Type"), n, fmt.Errorf("stream download: %w", copyErr)
 	}
 	return resp.Header.Get("Content-Type"), n, nil
+}
+
+// AttachmentMetadata mirrors the response headers of
+// HEAD /api/v1/workspaces/{slug}/attachments/{id}. The server doesn't
+// expose a separate JSON metadata endpoint — HEAD returns the same
+// Content-Type / Content-Length / etc. headers a GET would set, with
+// no body. That's enough for the CLI's `pad attachment show` to
+// surface size + MIME without paying for the bytes.
+type AttachmentMetadata struct {
+	ID                 string `json:"id"`
+	MIME               string `json:"mime"`
+	Size               int64  `json:"size"`
+	ContentDisposition string `json:"content_disposition,omitempty"`
+	ETag               string `json:"etag,omitempty"`
+	LastModified       string `json:"last_modified,omitempty"`
+}
+
+// HeadAttachment issues a HEAD request and returns the headers as
+// structured metadata. Variant is forwarded the same way as
+// DownloadAttachment — empty string for the original blob.
+func (c *Client) HeadAttachment(wsSlug, attachmentID, variant string) (*AttachmentMetadata, error) {
+	path := "/workspaces/" + wsSlug + "/attachments/" + attachmentID
+	if variant != "" {
+		path += "?variant=" + url.QueryEscape(variant)
+	}
+	req, err := c.newRequest("HEAD", path, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("head attachment: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		return nil, c.parseError(resp)
+	}
+	meta := &AttachmentMetadata{
+		ID:                 attachmentID,
+		MIME:               resp.Header.Get("Content-Type"),
+		ContentDisposition: resp.Header.Get("Content-Disposition"),
+		ETag:               resp.Header.Get("ETag"),
+		LastModified:       resp.Header.Get("Last-Modified"),
+	}
+	if cl := resp.Header.Get("Content-Length"); cl != "" {
+		if n, err := strconv.ParseInt(cl, 10, 64); err == nil {
+			meta.Size = n
+		}
+	}
+	return meta, nil
+}
+
+// AttachmentListParams encodes the query-string filters the
+// `GET /api/v1/workspaces/{slug}/attachments` endpoint accepts. Zero
+// values are skipped — the server falls back to its built-in defaults.
+type AttachmentListParams struct {
+	// ItemID restricts to attachments parented by this item UUID.
+	// The CLI resolves a TASK-5-style ref to a UUID via GetItem
+	// before calling this method.
+	ItemID string
+	// Item is the legacy attached/unattached enum exposed by the
+	// list endpoint. Ignored when empty.
+	Item string
+	// Category filters by MIME bucket: image|video|audio|document|text|archive|other.
+	Category string
+	// CollectionID restricts to attachments parented by items in
+	// the given collection UUID.
+	CollectionID string
+	// Sort accepts: size|size_desc|filename|filename_desc|created_at|created_at_desc.
+	Sort string
+	Limit  int
+	Offset int
+}
+
+// AttachmentListResponse mirrors the JSON returned by
+// GET /api/v1/workspaces/{slug}/attachments. Rows are typed as
+// json.RawMessage so the CLI can surface the full shape (including
+// joined item title / slug / collection slug) without re-declaring the
+// store.AttachmentListItem struct here.
+type AttachmentListResponse struct {
+	Attachments []json.RawMessage `json:"attachments"`
+	Total       int               `json:"total"`
+	Limit       int               `json:"limit"`
+	Offset      int               `json:"offset"`
+}
+
+// ListAttachments returns a page of attachments in the workspace,
+// applying any filters set on params. Empty fields are omitted from
+// the query string so the server's defaults take over.
+func (c *Client) ListAttachments(wsSlug string, params AttachmentListParams) (*AttachmentListResponse, error) {
+	q := url.Values{}
+	if params.ItemID != "" {
+		q.Set("item_id", params.ItemID)
+	}
+	if params.Item != "" {
+		q.Set("item", params.Item)
+	}
+	if params.Category != "" {
+		q.Set("category", params.Category)
+	}
+	if params.CollectionID != "" {
+		q.Set("collection", params.CollectionID)
+	}
+	if params.Sort != "" {
+		q.Set("sort", params.Sort)
+	}
+	if params.Limit > 0 {
+		q.Set("limit", strconv.Itoa(params.Limit))
+	}
+	if params.Offset > 0 {
+		q.Set("offset", strconv.Itoa(params.Offset))
+	}
+	path := "/workspaces/" + wsSlug + "/attachments"
+	if encoded := q.Encode(); encoded != "" {
+		path += "?" + encoded
+	}
+	var result AttachmentListResponse
+	if err := c.get(path, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
 }
 
 // newRequest creates an http.Request with auth and agent headers set.

--- a/internal/cli/client.go
+++ b/internal/cli/client.go
@@ -831,7 +831,7 @@ type AttachmentListParams struct {
 	// the given collection UUID.
 	CollectionID string
 	// Sort accepts: size|size_desc|filename|filename_desc|created_at|created_at_desc.
-	Sort string
+	Sort   string
 	Limit  int
 	Offset int
 }

--- a/internal/server/handlers_storage.go
+++ b/internal/server/handlers_storage.go
@@ -143,6 +143,7 @@ func (s *Server) handleGetWorkspaceStorageUsage(w http.ResponseWriter, r *http.R
 //	GET /api/v1/workspaces/{ws}/attachments
 //	    ?category=image|video|audio|document|text|archive|other
 //	    &item=attached|unattached
+//	    &item_id=<uuid>
 //	    &collection=<collection_id>
 //	    &sort=size|size_desc|filename|filename_desc|created_at|created_at_desc
 //	    &limit=<1..200>
@@ -150,6 +151,11 @@ func (s *Server) handleGetWorkspaceStorageUsage(w http.ResponseWriter, r *http.R
 //
 // Unknown values are silently ignored — the server defaults
 // (`created_at_desc`, limit 50, offset 0, no filters) take over.
+//
+// `item_id` (UUID of a specific parent item) is mutually exclusive
+// with `item=unattached`; combining the two yields an empty result
+// set. The CLI's `pad attachment list --item REF` resolves the ref
+// to a UUID client-side and passes it here.
 //
 // Auth: viewer+. Same gate as storage/usage — workspace-wide
 // attachment metadata leaks the same surface area.
@@ -168,6 +174,7 @@ func (s *Server) handleListWorkspaceAttachments(w http.ResponseWriter, r *http.R
 	filters := store.AttachmentListFilters{
 		MimeCategory: strings.ToLower(strings.TrimSpace(q.Get("category"))),
 		CollectionID: strings.TrimSpace(q.Get("collection")),
+		ItemID:       strings.TrimSpace(q.Get("item_id")),
 		Sort:         strings.ToLower(strings.TrimSpace(q.Get("sort"))),
 	}
 	switch strings.ToLower(strings.TrimSpace(q.Get("item"))) {

--- a/internal/store/attachments.go
+++ b/internal/store/attachments.go
@@ -148,6 +148,13 @@ type AttachmentListFilters struct {
 	// Mutually exclusive with Attached — handler validates upstream.
 	Unattached bool
 
+	// ItemID restricts to attachments whose parent item has this
+	// UUID. Empty = no per-item filter. Mutually exclusive with
+	// Unattached (an orphan can't match a specific item) — handler
+	// validates upstream. Used by `pad attachment list --item REF`
+	// after the CLI resolves a TASK-5-style ref to its UUID.
+	ItemID string
+
 	// CollectionID restricts to attachments belonging to items in
 	// this collection. Empty = no collection filter.
 	CollectionID string
@@ -350,6 +357,10 @@ func (s *Store) WorkspaceAttachments(workspaceID string, filters AttachmentListF
 	}
 	if filters.Unattached {
 		conds = append(conds, "a.item_id IS NULL")
+	}
+	if filters.ItemID != "" {
+		conds = append(conds, "a.item_id = ?")
+		args = append(args, filters.ItemID)
 	}
 	if frag, mimeArgs, ok := mimePredicateForCategory(filters.MimeCategory); ok {
 		conds = append(conds, frag)

--- a/skills/pad/SKILL.md
+++ b/skills/pad/SKILL.md
@@ -132,6 +132,21 @@ Interpret the user's intent and route to the appropriate action. Here are common
 
 **Best practice:** Always use `--comment` when changing status to explain *why*. This creates an audit trail linking each status change to a reason.
 
+**Working with attachments:**
+
+Items can carry image and file attachments. They appear in item content as `![alt](pad-attachment:<uuid>)` for images or `[label](pad-attachment:<uuid>)` for files. To inspect or read those bytes, **always use the CLI** — never read files directly from `~/.pad/attachments/`.
+
+- "show me the attachments on TASK-5" → `pad attachment list --item TASK-5 --format json`
+- "list all images in this workspace" → `pad attachment list --category image --format json`
+- "what is attachment <uuid>?" → `pad attachment show <uuid> --format json` (HEAD; metadata only)
+- "let me see the screenshot on TASK-5" / encountering `pad-attachment:<uuid>` in content → `pad attachment view <uuid>` then read the printed file path with your image tool
+- "save the design PDF locally" → `pad attachment view <uuid> -o ./design.pdf`
+- "upload this screenshot to TASK-5" → `pad attachment upload TASK-5 ./screenshot.png`
+
+`pad attachment view <uuid>` writes the bytes to a fresh OS temp file and prints just the absolute path on stdout, so it composes cleanly: `IMG=$(pad attachment view <uuid>) && open "$IMG"`. The filename comes from the attachment's stored name so the extension is correct.
+
+**Hard rule for agents:** NEVER read files directly from `~/.pad/attachments/<storage_key>`. That bypasses workspace ACLs, doesn't work on Pad Cloud / remote / Postgres deployments, skips the variant pipeline (thumbnails, EXIF strip, server-side rotate/crop), and breaks when storage moves to S3. Always go through `pad attachment view|show|list|download` so the request is authenticated and works on every Pad install.
+
 **Planning:**
 - "let's create a plan" → Multi-step planning workflow (see below)
 - "break plan 2 into tasks" → Decompose a plan into task items
@@ -269,6 +284,27 @@ pad item unblock TASK-5 TASK-8        # Remove a dependency
 pad collection list [--format json]   # List collections with counts
 pad collection create "Name" --fields "key:type[:options]; ..." [--icon "X"]
 ```
+
+### Attachments
+```bash
+# List + inspect (HEAD) — no bytes transferred
+pad attachment list [--item REF] [--category image|video|audio|document|text|archive|other]
+pad attachment list [--attached|--unattached] [--limit N] [--offset N] [--format json]
+pad attachment show <id> [--format json]                    # MIME, size, filename, ETag
+
+# View — fetch to a temp file (or -o path) and print the path. Use this
+# when you encounter ![alt](pad-attachment:<uuid>) in item content.
+pad attachment view <id>                                    # → /tmp/.../filename.png
+pad attachment view <id> -o ./screenshot.png                # explicit destination
+pad attachment view <id> --variant thumb-md                 # derived variant
+pad attachment view <id> --format json                      # {path,mime,size}
+
+# Upload + explicit-path download
+pad attachment upload <item-ref-or-dash> <path> [--filename "Name.ext"]
+pad attachment download <id> <out-path> [--variant thumb-sm|thumb-md]
+```
+
+**NEVER** read directly from `~/.pad/attachments/`. Always go through these commands.
 
 ### Webhooks
 ```bash


### PR DESCRIPTION
## Summary

Closes IDEA-898. Three new CLI surfaces let agents and users fetch attachment bytes through the authenticated REST API instead of reading directly from `~/.pad/attachments/<storage_key>`.

- `pad attachment view <id> [-o path]` — agent-friendly default. With no `-o`, fetches to a fresh OS temp dir using the stored filename and prints just the absolute path on stdout, so `IMG=$(pad attachment view <id>) && open "$IMG"` works in shell pipelines. With `-o`, reuses `download`'s atomic temp-then-rename pattern via a shared helper.
- `pad attachment show <id>` — HEAD-based metadata only: MIME, size, filename, ETag, Last-Modified.
- `pad attachment list [--item REF] [--category X] [--attached|--unattached] [--collection ID] [--sort ...] [--limit N] [--offset N]` — workspace list. `--item REF` resolves a TASK-5-style ref to a UUID client-side and passes a new `item_id=<uuid>` query param to the list endpoint (server gained `AttachmentListFilters.ItemID` + a one-line handler read).

`skills/pad/SKILL.md` gains a "Working with attachments" subsection plus a CLI Reference entry, both ending in the hard rule that agents must NEVER read directly from `~/.pad/attachments/`. That bypasses workspace ACLs, doesn't work on Pad Cloud / remote / Postgres deployments, skips the variant pipeline (TASK-872 / TASK-879 / TASK-880), and breaks when storage moves to S3.

Companion docs PR: PerpetualSoftware/pad-web#docs/cli-attachment-IDEA-898

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (full suite, including `internal/store` + `internal/server`)
- [x] `cd web && npm run build`
- [x] `make install` and verify server restarts cleanly
- [x] `pad attachment list` — table + JSON + `--item TASK-N` (ref → UUID resolution) + `--category image` + `--unattached`
- [x] `pad attachment list --item TASK-N --unattached` rejected as mutually exclusive
- [x] `pad attachment list --item TASK-99999` produces a useful "Item not found" error
- [x] `pad attachment show <id>` table + JSON; bogus UUID → 404
- [x] `pad attachment view <id>` writes to `/tmp/pad-attachment-*/filename.ext`, prints path on stdout, "wrote N bytes" on stderr; resulting file is byte-identical PNG
- [x] `pad attachment view <id> -o ./pic.png` atomic-renames into place
- [x] `pad attachment view <id> --variant thumb-sm` falls back to original (server contract) when no thumbnail row exists
- [x] `IMG=$(pad attachment view <id>)` substitution returns just the path