### PR TITLE
chore(make): add `make check` mirroring CI lint + test + web build (IDEA-921)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test test-pg test-pg-down dev clean web dev-web serve restart lint install check
+.PHONY: build test test-pg test-pg-down dev clean web dev-web serve restart lint install check vuln web-check
 
 BINARY=pad
 BUILD_DIR=./cmd/pad
@@ -10,10 +10,12 @@ COMMIT    := $(shell git rev-parse --short HEAD 2>/dev/null)
 BUILD_TIME := $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 LDFLAGS   := -X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.buildTime=$(BUILD_TIME)
 
-# Pin to the same golangci-lint version CI runs (see
-# .github/workflows/ci.yml). Bump both places together when upgrading.
+# Pin to the same golangci-lint and govulncheck versions CI runs (see
+# .github/workflows/ci.yml). Bump these and CI together when upgrading.
 GOLANGCI_LINT_VERSION ?= v2.11.4
 GOLANGCI_LINT := $(shell go env GOPATH)/bin/golangci-lint
+GOVULNCHECK_VERSION  ?= v1.2.0
+GOVULNCHECK := $(shell go env GOPATH)/bin/govulncheck
 
 build: web
 	go build -ldflags "$(LDFLAGS)" -o $(BINARY) $(BUILD_DIR)
@@ -76,24 +78,52 @@ clean:
 	rm -rf web/build
 	go clean ./...
 
-# Run the same golangci-lint suite CI runs (see .golangci.yml). Auto-
-# installs the pinned binary on first run so contributors don't have to
-# remember a separate setup step. The lint suite already includes
-# go vet via the govet linter, so we don't double-run it here.
-lint: $(GOLANGCI_LINT)
+# Run the same golangci-lint suite CI runs (.golangci.yml: govet,
+# ineffassign, staticcheck SA*, unused, plus the gofmt formatter with
+# simplify: true). The lint suite already includes go vet via the govet
+# linter, so we don't double-run it here.
+#
+# Version enforcement: the recipe checks the installed binary against
+# GOLANGCI_LINT_VERSION and reinstalls on mismatch. A file-target
+# dependency wouldn't enforce the pin — make only runs the install rule
+# when the binary is missing, so an outdated local binary would be
+# silently reused and disagree with CI (Codex review on PR #322).
+lint:
+	@bin="$(GOLANGCI_LINT)"; pin="$(GOLANGCI_LINT_VERSION)"; want="$${pin#v}"; \
+	have=$$( $$bin version 2>/dev/null | sed -n 's/.*version \([0-9.]*\) built.*/\1/p' ); \
+	if [ "$$have" != "$$want" ]; then \
+		echo "Installing golangci-lint $$pin (had: $${have:-none})..."; \
+		go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$$pin; \
+	fi
 	$(GOLANGCI_LINT) run --timeout=5m ./...
 
-# Bootstrap rule: install golangci-lint into $(go env GOPATH)/bin if it's
-# missing or doesn't match the pinned version. `go install` is idempotent
-# and respects GOBIN; piping through `command -v` keeps the no-op fast.
-$(GOLANGCI_LINT):
-	@echo "Installing golangci-lint $(GOLANGCI_LINT_VERSION)..."
-	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
+# Run govulncheck against the call graph. Mirrors the "Run govulncheck"
+# step in CI's Go job verbatim. `go install foo@vX.Y.Z` is idempotent
+# and rebuilds quickly when the pinned version is already in the module
+# cache, so we don't need a version-check shim like lint has.
+vuln:
+	go install golang.org/x/vuln/cmd/govulncheck@$(GOVULNCHECK_VERSION)
+	$(GOVULNCHECK) ./...
 
-# Pre-flight target that mirrors the Go and Web jobs in CI. Run this
-# before pushing — if it passes, the corresponding CI checks should pass
-# too. Keeps `make install` lightweight (build + restart only) so the
-# inner dev loop stays fast; opt into `check` when you're done.
+# Web pre-flight that mirrors CI's Web job beyond the build step:
+# `npm audit` (production dependencies, high severity+) and svelte-check
+# type checking. Depends on `web` so npm ci + build are already done.
+# Separate target so a contributor iterating on the UI can run just the
+# extra checks via `make web-check`.
+web-check: web
+	cd web && npm audit --audit-level=high --omit=dev && npm run check
+
+# Pre-flight target that mirrors CI's Go and Web jobs. Run this before
+# pushing — if it passes, the corresponding CI checks should pass too.
+#
+# Covers: golangci-lint suite (lint), Go test suite, govulncheck, npm ci,
+# npm audit, web build, svelte-check. The race-detector + Postgres jobs
+# only run on push to main (per .github/workflows/ci.yml) and are not
+# included here; run `make test-pg` separately if you want them locally.
+#
+# `make install` stays lightweight (build + restart only) so the inner
+# dev loop is fast; opt into `check` when you're ready to push.
 check: lint
 	go test ./...
-	cd web && npm run build
+	$(MAKE) vuln
+	$(MAKE) web-check

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test test-pg test-pg-down dev clean web dev-web serve restart lint install
+.PHONY: build test test-pg test-pg-down dev clean web dev-web serve restart lint install check
 
 BINARY=pad
 BUILD_DIR=./cmd/pad
@@ -9,6 +9,11 @@ VERSION   ?= dev
 COMMIT    := $(shell git rev-parse --short HEAD 2>/dev/null)
 BUILD_TIME := $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 LDFLAGS   := -X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.buildTime=$(BUILD_TIME)
+
+# Pin to the same golangci-lint version CI runs (see
+# .github/workflows/ci.yml). Bump both places together when upgrading.
+GOLANGCI_LINT_VERSION ?= v2.11.4
+GOLANGCI_LINT := $(shell go env GOPATH)/bin/golangci-lint
 
 build: web
 	go build -ldflags "$(LDFLAGS)" -o $(BINARY) $(BUILD_DIR)
@@ -71,5 +76,24 @@ clean:
 	rm -rf web/build
 	go clean ./...
 
-lint:
-	go vet ./...
+# Run the same golangci-lint suite CI runs (see .golangci.yml). Auto-
+# installs the pinned binary on first run so contributors don't have to
+# remember a separate setup step. The lint suite already includes
+# go vet via the govet linter, so we don't double-run it here.
+lint: $(GOLANGCI_LINT)
+	$(GOLANGCI_LINT) run --timeout=5m ./...
+
+# Bootstrap rule: install golangci-lint into $(go env GOPATH)/bin if it's
+# missing or doesn't match the pinned version. `go install` is idempotent
+# and respects GOBIN; piping through `command -v` keeps the no-op fast.
+$(GOLANGCI_LINT):
+	@echo "Installing golangci-lint $(GOLANGCI_LINT_VERSION)..."
+	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
+
+# Pre-flight target that mirrors the Go and Web jobs in CI. Run this
+# before pushing — if it passes, the corresponding CI checks should pass
+# too. Keeps `make install` lightweight (build + restart only) so the
+# inner dev loop stays fast; opt into `check` when you're done.
+check: lint
+	go test ./...
+	cd web && npm run build


### PR DESCRIPTION
## Summary

Closes IDEA-921. Eliminates the local-vs-CI gap that let PR #321 (IDEA-898) ship a trivial gofmt violation past every step of CONVE-190's pre-flight.

**`make lint` now runs the same lint suite CI runs.** Previously it just ran `go vet ./...` — none of the linters CI gates on (`gofmt`, `staticcheck SA*`, `ineffassign`, `unused`). It now runs `golangci-lint v2.11.4` against `.golangci.yml`, exactly mirroring the `Run golangci-lint` step in `.github/workflows/ci.yml`. The version is pinned via `GOLANGCI_LINT_VERSION ?= v2.11.4` and a bootstrap rule auto-installs the binary into `$(go env GOPATH)/bin` on first run, so contributors don't need a separate setup step.

**New `make check` umbrella target** runs lint + Go tests + web build — the exact set of jobs CI's "Go" and "Web" jobs run. Designed to be the pre-push gate.

**`make install` is unchanged** (build + restart) so the inner dev loop stays fast. `check` is the opt-in checkpoint.

CONVE-190 was updated separately via the Pad CLI to point contributors at `make check` instead of the old `go build && go test && cd web && npm run build` triple.

## Why this matters

PR #321 followed CONVE-190 to the letter — `go build` ✓, `go test` ✓, `npm run build` ✓ — and still tripped CI on a one-character gofmt issue. The convention prescribed an incomplete pre-flight; this PR closes that gap structurally instead of asking everyone to remember to run an extra command.

The CI lint job catches: `govet`, `ineffassign`, `staticcheck SA*` (real-bug checks), `unused`, and the `gofmt` formatter with `simplify: true`. All of those now run locally via `make lint` / `make check`.

## Test plan

- [x] `make lint` from a fresh clone (no golangci-lint pre-installed) installs it and exits 0 on a clean tree
- [x] `make check` runs lint + tests + web build and passes
- [x] Pinned version (`v2.11.4`) matches `.github/workflows/ci.yml`
- [x] CONVE-190 updated to require `make check`
- [ ] Verify CI passes on this branch
- [ ] After merge: re-run `make check` on a deliberately broken gofmt commit and confirm it surfaces the same error CI would

## Notes

If a contributor sees stale staticcheck noise from a prior run, `golangci-lint cache clean` clears it — known upstream quirk, not specific to this Makefile. Worth documenting if it bites someone, but I didn't want to bake the cache-clean into `make lint` because it'd slow every clean run.