### PR TITLE
feat(web): last-used auth method banner on /login (TASK-923)

### DIFF
--- a/web/src/lib/auth/lastMethod.ts
+++ b/web/src/lib/auth/lastMethod.ts
@@ -1,0 +1,84 @@
+// Last-used auth method hint (TASK-923).
+//
+// Stores the auth method (`password`, `github`, `google`) the user most
+// recently used to sign in, in the browser's own localStorage. Read on the
+// /login page to render a soft "you used X last time" banner so returning
+// users don't have to re-decide which button to click.
+//
+// Privacy
+// -------
+// - Only the method *name* is stored — never an email, user ID, or token.
+// - localStorage is per-origin and is never sent over the wire.
+// - No cookie, no URL param, no server log entry.
+//
+// OAuth note
+// ----------
+// The OAuth handshake completes externally (provider → pad-cloud sidecar →
+// pad backend creates the session and redirects), so the web client never
+// receives a "OAuth succeeded" callback in JS. Instead, the /login page
+// records the chosen method *speculatively* when the user clicks
+// "Continue with GitHub/Google" — see `recordAuthMethod` callsites. If the
+// user bails out at the provider's consent screen, the value still
+// reflects "what the user tried last", which is the right answer for the
+// banner ("you used GitHub last time" stays accurate).
+//
+// All reads/writes are wrapped in try/catch so SSR (no `window`),
+// Safari private mode (localStorage throws on write), or a paranoid CSP
+// can't break the auth pages.
+
+export type AuthMethod = 'password' | 'github' | 'google';
+
+const METHOD_KEY = 'pad_last_auth_method';
+const AT_KEY = 'pad_last_auth_at';
+
+function isAuthMethod(value: unknown): value is AuthMethod {
+	return value === 'password' || value === 'github' || value === 'google';
+}
+
+/**
+ * Record the auth method the user just used. Safe to call from any page
+ * that completes an auth flow — failures are swallowed so a broken
+ * localStorage cannot block the sign-in path.
+ */
+export function recordAuthMethod(method: AuthMethod): void {
+	if (typeof window === 'undefined') return;
+	try {
+		window.localStorage.setItem(METHOD_KEY, method);
+		window.localStorage.setItem(AT_KEY, String(Date.now()));
+	} catch {
+		// Disabled storage / private mode / quota — the banner is a nice-to-
+		// have, never block auth on it.
+	}
+}
+
+/**
+ * Read the most recently recorded auth method from localStorage. Returns
+ * `null` for first-time visitors, SSR, or any storage error. The
+ * timestamp is exposed so callers can implement freshness gates later
+ * without changing this signature; v1 callers can ignore it.
+ */
+export function getLastAuthMethod(): { method: AuthMethod; at: number } | null {
+	if (typeof window === 'undefined') return null;
+	try {
+		const raw = window.localStorage.getItem(METHOD_KEY);
+		if (!isAuthMethod(raw)) return null;
+		const at = Number(window.localStorage.getItem(AT_KEY) ?? '');
+		return { method: raw, at: Number.isFinite(at) ? at : 0 };
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Clear the recorded auth method. Reserved for a future "this isn't me"
+ * affordance and for tests; not currently called from the auth pages.
+ */
+export function clearLastAuthMethod(): void {
+	if (typeof window === 'undefined') return;
+	try {
+		window.localStorage.removeItem(METHOD_KEY);
+		window.localStorage.removeItem(AT_KEY);
+	} catch {
+		// See recordAuthMethod — never throw from a hint helper.
+	}
+}

--- a/web/src/routes/login/+page.svelte
+++ b/web/src/routes/login/+page.svelte
@@ -7,6 +7,11 @@
 	import SetupRequiredNotice from '$lib/components/auth/SetupRequiredNotice.svelte';
 	import AuthHeader from '$lib/components/auth/AuthHeader.svelte';
 	import AuthFooter from '$lib/components/auth/AuthFooter.svelte';
+	import {
+		recordAuthMethod,
+		getLastAuthMethod,
+		type AuthMethod
+	} from '$lib/auth/lastMethod';
 
 	let email = $state('');
 	let password = $state('');
@@ -29,6 +34,11 @@
 		| { kind: 'generic'; message: string; tone: 'error' | 'info' }
 		| null
 	>(null);
+
+	// Last-used auth method (TASK-923) — reads from localStorage on mount,
+	// drives a soft "you used X last time" banner and a visual lift on the
+	// matching CTA. Never blocks any flow; first-time visitors see no banner.
+	let lastMethod = $state<AuthMethod | null>(null);
 
 	function getRedirectTarget(): string {
 		const redirect = $page.url.searchParams.get('redirect');
@@ -133,6 +143,19 @@
 
 	onMount(async () => {
 		readOAuthErrorFromQuery();
+		// Read the last-used method before the session check so the banner
+		// can render on the same paint as the form (no flash on slow
+		// networks). Suppress the banner if pad-cloud just bounced us back
+		// with an error tied to that exact provider — surfacing both at
+		// once muddles the message.
+		const last = getLastAuthMethod();
+		if (last) {
+			const errorTiedToLastProvider =
+				oauthBanner?.kind === 'not_linked' && oauthBanner.provider === last.method;
+			if (!errorTiedToLastProvider) {
+				lastMethod = last.method;
+			}
+		}
 		try {
 			const session = await api.auth.session();
 			cloudMode = session.cloud_mode ?? false;
@@ -170,6 +193,7 @@
 				return;
 			}
 
+			recordAuthMethod('password');
 			await authStore.load();
 			await goto(getRedirectTarget(), { replaceState: true });
 		} catch (err: unknown) {
@@ -202,6 +226,7 @@
 				await api.auth.verify2FA(challengeToken, undefined, code);
 			}
 
+			recordAuthMethod('password');
 			await authStore.load();
 			await goto(getRedirectTarget(), { replaceState: true });
 		} catch (err: unknown) {
@@ -230,6 +255,17 @@
 				handleVerify2FA();
 			}
 		}
+	}
+
+	// OAuth completion happens entirely outside the SPA — the user leaves
+	// pad, signs in with the provider, pad-cloud creates the session, and
+	// the browser is redirected back to the redirect target. There is no
+	// JS callback we can hang the localStorage write on, so we record the
+	// chosen method *speculatively* on click. If the user bails at the
+	// provider's consent screen the value still reflects "what the user
+	// tried last", which is the right answer for the next-visit banner.
+	function handleOAuthClick(provider: AuthMethod) {
+		recordAuthMethod(provider);
 	}
 </script>
 
@@ -283,6 +319,21 @@
 				{:else}
 					<p class="oauth-banner-msg">{oauthBanner.message}</p>
 				{/if}
+			</div>
+		{/if}
+
+		{#if !setupRequired && step !== '2fa' && lastMethod && !oauthBanner}
+			<div class="last-used-banner" role="status" aria-live="polite">
+				<span class="last-used-emoji" aria-hidden="true">👋</span>
+				<span class="last-used-text">
+					{#if lastMethod === 'github'}
+						Last time, you used <strong>GitHub</strong> to sign in.
+					{:else if lastMethod === 'google'}
+						Last time, you used <strong>Google</strong> to sign in.
+					{:else}
+						Last time, you signed in with your <strong>password</strong>.
+					{/if}
+				</span>
 			</div>
 		{/if}
 
@@ -364,13 +415,31 @@
 				</div>
 
 				<div class="oauth-buttons">
-					<a href="/auth/github{oauthRedirectQuery}" data-sveltekit-reload class="oauth-btn oauth-github">
+					<a
+						href="/auth/github{oauthRedirectQuery}"
+						data-sveltekit-reload
+						class="oauth-btn oauth-github"
+						class:last-used={lastMethod === 'github'}
+						onclick={() => handleOAuthClick('github')}
+					>
 						<svg width="18" height="18" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
 						Continue with GitHub
+						{#if lastMethod === 'github'}
+							<span class="last-used-pill">Last used</span>
+						{/if}
 					</a>
-					<a href="/auth/google{oauthRedirectQuery}" data-sveltekit-reload class="oauth-btn oauth-google">
+					<a
+						href="/auth/google{oauthRedirectQuery}"
+						data-sveltekit-reload
+						class="oauth-btn oauth-google"
+						class:last-used={lastMethod === 'google'}
+						onclick={() => handleOAuthClick('google')}
+					>
 						<svg width="18" height="18" viewBox="0 0 18 18" fill="none"><path d="M17.64 9.2c0-.637-.057-1.251-.164-1.84H9v3.481h4.844a4.14 4.14 0 01-1.796 2.716v2.259h2.908c1.702-1.567 2.684-3.875 2.684-6.615z" fill="#4285F4"/><path d="M9 18c2.43 0 4.467-.806 5.956-2.18l-2.908-2.259c-.806.54-1.837.86-3.048.86-2.344 0-4.328-1.584-5.036-3.711H.957v2.332A8.997 8.997 0 009 18z" fill="#34A853"/><path d="M3.964 10.71A5.41 5.41 0 013.682 9c0-.593.102-1.17.282-1.71V4.958H.957A8.996 8.996 0 000 9c0 1.452.348 2.827.957 4.042l3.007-2.332z" fill="#FBBC05"/><path d="M9 3.58c1.321 0 2.508.454 3.44 1.345l2.582-2.58C13.463.891 11.426 0 9 0A8.997 8.997 0 00.957 4.958L3.964 7.29C4.672 5.163 6.656 3.58 9 3.58z" fill="#EA4335"/></svg>
 						Continue with Google
+						{#if lastMethod === 'google'}
+							<span class="last-used-pill">Last used</span>
+						{/if}
 					</a>
 				</div>
 			{/if}
@@ -658,5 +727,53 @@
 		background: var(--bg-hover);
 		border-color: var(--text-muted);
 		text-decoration: none;
+	}
+
+	/*
+	 * Last-used auth method banner + CTA emphasis (TASK-923).
+	 * Soft hint above the form for returning users; matching OAuth button
+	 * gets a subtle border lift + "Last used" pill so the recommended
+	 * action reads at a glance without overwhelming first-time visitors
+	 * who still see all methods equally.
+	 */
+	.last-used-banner {
+		display: flex;
+		align-items: center;
+		gap: var(--space-2);
+		margin-bottom: var(--space-5);
+		padding: var(--space-3) var(--space-4);
+		border-radius: var(--radius);
+		background: color-mix(in srgb, var(--accent-blue) 8%, transparent);
+		border: 1px solid color-mix(in srgb, var(--accent-blue) 25%, transparent);
+		color: var(--text-primary);
+		font-size: 0.85rem;
+		line-height: 1.4;
+		text-align: left;
+	}
+
+	.last-used-emoji {
+		font-size: 1rem;
+		flex-shrink: 0;
+	}
+
+	.last-used-text {
+		flex: 1;
+		min-width: 0;
+	}
+
+	.oauth-btn.last-used {
+		border-color: color-mix(in srgb, var(--accent-blue) 50%, var(--border));
+		box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent-blue) 20%, transparent);
+	}
+
+	.last-used-pill {
+		margin-left: auto;
+		padding: 2px var(--space-2);
+		background: color-mix(in srgb, var(--accent-blue) 15%, transparent);
+		color: var(--accent-blue);
+		border-radius: var(--radius-sm);
+		font-size: 0.7rem;
+		font-weight: 500;
+		letter-spacing: 0.02em;
 	}
 </style>

--- a/web/src/routes/register/+page.svelte
+++ b/web/src/routes/register/+page.svelte
@@ -6,6 +6,7 @@
 	import AuthHeader from '$lib/components/auth/AuthHeader.svelte';
 	import AuthFooter from '$lib/components/auth/AuthFooter.svelte';
 	import { authStore } from '$lib/stores/auth.svelte';
+	import { recordAuthMethod } from '$lib/auth/lastMethod';
 
 	let name = $state('');
 	let username = $state('');
@@ -112,6 +113,7 @@
 		loading = true;
 		try {
 			await api.auth.register(email, name, password, username || undefined);
+			recordAuthMethod('password');
 			await goto('/console', { replaceState: true });
 		} catch (err: unknown) {
 			if (err instanceof Error) {


### PR DESCRIPTION
## Summary

Returning users who are logged out land on `/login` with no context about how they signed in before. This adds a soft "last time, you used X to sign in" hint and visually elevates the matching CTA so the right next step reads at a glance — without overwhelming first-time visitors who still see all methods equally.

## Context

Implements `TASK-923` under `PLAN-776` (Post-launch Backlog). Promotes `IDEA-922`. Companion to the still-open `IDEA-743` (masked-email-on-error) which fixes the *error path*; this PR fixes the *cold-start path*.

## Implementation

- **New helper** `web/src/lib/auth/lastMethod.ts` reads/writes `pad_last_auth_method` (`'password' | 'github' | 'google'`) + `pad_last_auth_at` in localStorage. All access wrapped in try/catch so SSR / private mode / disabled storage / quota errors never break auth pages.
- **Login page** records `password` on successful credential and 2FA login. Records the OAuth provider *speculatively on click* — the OAuth handshake completes outside the SPA (provider → pad-cloud sidecar → pad backend session → redirect), so there's no JS callback to hang the write on. If the user bails at the consent screen the value still reflects "what the user tried last", which is the right answer for the next-visit banner.
- **Register page** records `password` on successful registration so newly registered users see the same hint when they return logged out.
- **Banner** above the form names the method; matching OAuth button gets a subtle border lift + "Last used" pill. Suppressed when an OAuth error banner for the same provider is already visible — surfacing both at once muddles the message.

## Privacy

- Only the method *name* is stored — never an email, user ID, or token.
- localStorage is per-origin and never sent over the wire.
- No cookie, no URL param, no server log entry, no new endpoints, no schema changes.

## Test plan

- [x] `make check` — golangci-lint + go test + web build all clean
- [x] `svelte-check` — 0 errors (only pre-existing warnings in untouched files)
- [x] svelte-autofixer — 0 issues on the modified login page
- [ ] Manual: log in via password → log out → revisit /login → banner names password, email field is the primary CTA
- [ ] Manual: click "Continue with GitHub" → bail at provider consent → revisit /login → banner names GitHub, GitHub button has the "Last used" pill
- [ ] Manual: complete a Google OAuth login → log out → revisit /login → banner names Google, Google button has the pill
- [ ] Manual: clear localStorage → revisit /login → no banner, all CTAs equal
- [ ] Manual: arrive on /login with `?error=oauth_provider_not_linked&provider=github` after a stored `lastMethod=github` → only the error banner shows (the last-used banner is suppressed)