### PR TITLE
fix(billing): gate Pro upgrade CTAs while Stripe is unwired

### DIFF
--- a/web/src/routes/console/billing/+page.svelte
+++ b/web/src/routes/console/billing/+page.svelte
@@ -34,6 +34,16 @@
 	let isPro = $derived(plan === 'pro');
 	let limits = $state<{ free: PlanLimits; pro: PlanLimits } | null>(null);
 
+	// Gate for Stripe-backed upgrade affordances. Stripe isn't wired up on
+	// this deployment yet, so the Free → Pro CTAs would dead-end at a 404
+	// from /billing/checkout. Flip this to `true` (or thread it through a
+	// server flag like `authStore.session?.billing_enabled`) once the
+	// pad-cloud sidecar's Stripe integration is live so the "Upgrade to Pro"
+	// buttons return. The "Confirming your upgrade…" / "Upgrade confirmed"
+	// banners below stay wired — they only fire when ?checkout=success is
+	// present in the URL, which can only happen after a real Stripe redirect.
+	const STRIPE_AVAILABLE = false;
+
 	// Upgrade-confirmation state. After Stripe Checkout redirects back with
 	// ?checkout=success, pad-cloud's webhook handler needs a moment to land
 	// at pad's /admin/plan endpoint before the user's plan flips to "pro".
@@ -240,7 +250,7 @@
 
 			{#if isPro}
 				<a href="/billing/portal" class="secondary-btn">Manage Billing</a>
-			{:else}
+			{:else if STRIPE_AVAILABLE}
 				<a href="/billing/checkout" class="primary-btn">Upgrade to Pro</a>
 			{/if}
 		</div>
@@ -278,9 +288,18 @@
 				</tbody>
 			</table>
 			{#if !isPro}
-				<div class="compare-cta">
-					<a href="/billing/checkout" class="primary-btn">Upgrade to Pro</a>
-				</div>
+				{#if STRIPE_AVAILABLE}
+					<div class="compare-cta">
+						<a href="/billing/checkout" class="primary-btn">Upgrade to Pro</a>
+					</div>
+				{:else}
+					<div class="compare-cta coming-soon">
+						<span class="coming-soon-label">Pro — coming soon</span>
+						<span class="coming-soon-note">
+							Interested? Email <a href="mailto:info@getpad.dev?subject=Pad%20Pro%20interest">info@getpad.dev</a> and we'll let you know when it's ready.
+						</span>
+					</div>
+				{/if}
 			{/if}
 		</div>
 	</section>
@@ -489,6 +508,30 @@
 		border-top: 1px solid var(--border);
 		display: flex;
 		justify-content: flex-end;
+	}
+
+	.compare-cta.coming-soon {
+		flex-direction: column;
+		align-items: flex-start;
+		justify-content: flex-start;
+		gap: var(--space-1);
+	}
+
+	.coming-soon-label {
+		font-size: 0.85rem;
+		font-weight: 600;
+		color: var(--text-primary);
+	}
+
+	.coming-soon-note {
+		font-size: 0.8rem;
+		color: var(--text-secondary);
+		line-height: 1.4;
+	}
+
+	.coming-soon-note a {
+		color: var(--accent-blue);
+		text-decoration: underline;
 	}
 
 	@media (max-width: 480px) {


### PR DESCRIPTION
## Summary

- Hide the "Upgrade to Pro" button under **Current Plan** on `/console/billing` while Stripe isn't configured — the link dead-ended at a 404 from `/billing/checkout`.
- Replace the **Compare plans** CTA with a "Pro — coming soon" block + `mailto:info@getpad.dev?subject=Pad%20Pro%20interest` so we can still capture interest while the integration is pending.
- Gate is a single client-side `STRIPE_AVAILABLE` constant with a comment explaining how to flip it on (or thread it through a server flag like `authStore.session?.billing_enabled`) once the pad-cloud sidecar's Stripe path is live. The post-checkout polling/banners (`?checkout=success` → "Confirming your upgrade…" → "Upgrade confirmed") stay wired since they can't fire until the gate flips back on.

## Test plan

- [ ] On `/console/billing` (Free user, cloud mode), the **Current Plan** card shows no "Upgrade to Pro" button.
- [ ] The **Compare plans** card shows "Pro — coming soon" with a working `mailto:info@getpad.dev` link in place of the upgrade button.
- [ ] Pro users still see "Manage Billing" under Current Plan (regression check).
- [ ] No console errors; layout still looks right at narrow widths (≤480px).
- [ ] Flipping `STRIPE_AVAILABLE` to `true` locally restores both upgrade buttons.