### PR TITLE
feat(schema): publish cmdhelp.schema.json v0.1 (TASK-932)

### DIFF
--- a/schema/README.md
+++ b/schema/README.md
@@ -42,9 +42,9 @@ print('OK')
 " < <(pad help --format json)
 ```
 
-### Validating in Go (used by Pad's own test suite)
+### Validating in Go (planned for Pad's own test suite)
 
-The test suite in `internal/cmdhelp/` validates the live `pad help --format json` output against this schema as part of `go test ./...`. A drift between emitter and schema fails CI. (See `TASK-938` for the test-side contract.)
+Once the JSON emitter ships (`TASK-934`), the test suite in `internal/cmdhelp/` will validate the live `pad help --format json` output against this schema as part of `go test ./...`, so a drift between emitter and schema fails CI. The test-side contract is owned by `TASK-938`. The schema is committed first because `TASK-934` and `TASK-938` are both downstream of (and validated against) it.
 
 ## v0.1 highlights
 

--- a/schema/README.md
+++ b/schema/README.md
@@ -1,0 +1,66 @@
+# `cmdhelp.schema.json`
+
+Formal JSON Schema (draft 2020-12) for the [`cmdhelp` v0.1](https://getpad.dev/cmdhelp) wire format — the structured output produced by `<cmd> help --format json` on any conforming CLI.
+
+## What this is
+
+`cmdhelp` is a tiny vendor-neutral convention for CLI tools to expose their documentation and invocation schema to LLMs and LLM harnesses (Claude Code, Cursor, MCP servers, IDE plugins). Each conforming CLI emits two formats from one source of truth:
+
+- **Markdown** (`--format md`) — drop-in context for an LLM to *read*.
+- **JSON** (`--format json`) — structured schema for an LLM (or its harness) to *call*. ← **this schema describes that JSON.**
+
+See the full v0.1 spec on [getpad.dev/cmdhelp](https://getpad.dev/cmdhelp) (or `IDEA-927` in this workspace).
+
+## Who consumes this
+
+- **CLI authors** validate their `--format json` output as a CI step so the wire format never silently drifts.
+- **Wrappers** (MCP servers, IDE plugins, agent harnesses) validate received `cmdhelp` documents before parsing, so a buggy producer surfaces as a clear schema error rather than a mysterious downstream failure.
+- **Spec implementers** use it as the authoritative reference for which fields are required, which are optional, and what shapes are allowed.
+
+## Usage
+
+The schema is published at the canonical URL inside Pad's reference implementation, and committed into this repository at `schema/cmdhelp.schema.json`.
+
+### Validating a `cmdhelp` document with `ajv`
+
+```bash
+npm install -g ajv-cli
+pad help --format json > /tmp/cmdhelp.json
+ajv validate -s schema/cmdhelp.schema.json -d /tmp/cmdhelp.json --spec=draft2020
+```
+
+### Validating with Python `jsonschema`
+
+```bash
+pip install 'jsonschema[format]'
+python -c "
+import json, jsonschema, sys
+schema = json.load(open('schema/cmdhelp.schema.json'))
+doc    = json.load(sys.stdin)
+jsonschema.validate(doc, schema)
+print('OK')
+" < <(pad help --format json)
+```
+
+### Validating in Go (used by Pad's own test suite)
+
+The test suite in `internal/cmdhelp/` validates the live `pad help --format json` output against this schema as part of `go test ./...`. A drift between emitter and schema fails CI. (See `TASK-938` for the test-side contract.)
+
+## v0.1 highlights
+
+- **Required top-level keys:** `cmdhelp_version`, `binary`, `commands`.
+- **Argument-type vocabulary** (closed set + `x-*` extension namespace): `string`, `int`, `float`, `bool`, `enum` (required); `path`, `url`, `duration`, `date`, `datetime`, `json`, `ref` (recommended); `x-<tool-specific>` (extension).
+- **Boolean flag arity** (spec §5.3): bool flags are presence switches by default; valued booleans use `enum: ["true", "false"]`; negation via the optional `negate_flag` field.
+- **`exit_codes` union** (spec §5.2): each entry MAY be a terse string OR a rich object `{ when, recovery?, message_template? }`. Consumers MUST handle both shapes.
+- **Dynamic enums** (spec §7): args/flags that depend on session state (workspace, profile, account) declare an `enum_source: "dynamic:<command>"` and MAY include the resolved values in `enum`.
+- **Wire format version** (spec §9): `MAJOR.MINOR` only — never includes a PATCH component. Validated by pattern `^[0-9]+\.[0-9]+$`.
+
+## Versioning
+
+This file's schema describes **cmdhelp v0.1**. When the spec moves to a new MAJOR or MINOR, this file is updated in lockstep and the `$id` URL bumps.
+
+Forward-compat: tools advertising `cmdhelp/0.1` MUST tolerate unknown fields (the schema sets `additionalProperties: true` at every level where extensibility is desirable). Add fields freely in MINOR bumps.
+
+## Provenance
+
+Drafted in the design conversation captured under `IDEA-927`, frozen 2026-05-01 after four rounds of Codex review, reference implementation tracked under `PLAN-930`.

--- a/schema/cmdhelp.schema.json
+++ b/schema/cmdhelp.schema.json
@@ -158,8 +158,11 @@
     },
 
     "flagMap": {
-      "description": "Map of flag names (without leading --) to flag definitions.",
+      "description": "Map of flag names (without leading --) to flag definitions. Keys MUST match the flag-name pattern: start with a letter, followed by letters, digits, hyphens, or underscores. Long-form (e.g. `format`) and short-form (e.g. `h`) names are both valid; consumers add the leading `-` or `--` themselves at invocation time.",
       "type": "object",
+      "propertyNames": {
+        "pattern": "^[a-zA-Z][a-zA-Z0-9_-]*$"
+      },
       "additionalProperties": { "$ref": "#/$defs/flag" }
     },
 

--- a/schema/cmdhelp.schema.json
+++ b/schema/cmdhelp.schema.json
@@ -1,0 +1,268 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://getpad.dev/cmdhelp.schema.json",
+  "title": "cmdhelp v0.1",
+  "description": "JSON Schema for output of `<cmd> help --format json` per the cmdhelp v0.1 spec. Tools advertising cmdhelp/0.1 via their capability bit emit documents matching this schema. Consumers (LLM harnesses, MCP servers, IDE plugins, wrappers) validate against this schema before parsing. See IDEA-927 for the full spec.",
+  "type": "object",
+  "required": ["cmdhelp_version", "binary", "commands"],
+  "additionalProperties": true,
+  "properties": {
+    "cmdhelp_version": {
+      "description": "Wire format version. MAJOR.MINOR only — never includes a PATCH component. See spec §9.",
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+$"
+    },
+    "binary": {
+      "description": "The CLI's binary name as invoked on the command line (e.g. \"pad\", \"git\", \"kubectl\").",
+      "type": "string",
+      "minLength": 1
+    },
+    "version": {
+      "description": "The implementation's own software version (independent from cmdhelp_version). Free-form; semver recommended.",
+      "type": "string"
+    },
+    "summary": {
+      "description": "One-line description of the binary, suitable for an LLM context blurb.",
+      "type": "string"
+    },
+    "homepage": {
+      "description": "Optional canonical URL for the project.",
+      "type": "string",
+      "format": "uri"
+    },
+    "global_flags": {
+      "description": "Flags that apply to every command in the tree (e.g. --workspace, --format). Same shape as a per-command `flags` object.",
+      "$ref": "#/$defs/flagMap"
+    },
+    "commands": {
+      "description": "Map of command paths (space-joined, e.g. \"item create\") to their definitions.",
+      "type": "object",
+      "additionalProperties": { "$ref": "#/$defs/command" },
+      "minProperties": 0
+    },
+    "schemas": {
+      "description": "Reusable JSON Schema fragments referenced by per-command stdout definitions via `json_schema_ref` (e.g. \"#/schemas/Item\").",
+      "type": "object",
+      "additionalProperties": true
+    },
+    "context": {
+      "description": "Optional dynamic context spliced into help output by CLIs with session state. See spec §7.",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "workspace": { "type": "string" },
+        "profile":   { "type": "string" },
+        "auth":      { "type": "string" }
+      }
+    }
+  },
+
+  "$defs": {
+
+    "command": {
+      "description": "Definition of a single command in the CLI.",
+      "type": "object",
+      "required": ["summary"],
+      "additionalProperties": true,
+      "properties": {
+        "summary": {
+          "description": "One-line description of the command.",
+          "type": "string",
+          "minLength": 1
+        },
+        "description": {
+          "description": "Optional longer prose explanation, may include markdown.",
+          "type": "string"
+        },
+        "args": {
+          "description": "Positional arguments in order.",
+          "type": "array",
+          "items": { "$ref": "#/$defs/arg" }
+        },
+        "flags": {
+          "description": "Map of flag names (without leading dashes) to flag definitions.",
+          "$ref": "#/$defs/flagMap"
+        },
+        "stdin": {
+          "description": "Whether the command accepts stdin and the expected format.",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "accepted": { "type": "boolean" },
+            "format":   { "type": "string", "description": "MIME-style hint such as text/markdown or application/json." }
+          },
+          "required": ["accepted"]
+        },
+        "stdout": {
+          "description": "What the command writes to stdout on success.",
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "text_template":    { "type": "string", "description": "Template string for the human-readable line; may use {placeholder} substitutions." },
+            "json_schema_ref":  { "type": "string", "description": "JSON Pointer (typically into the top-level `schemas` map, e.g. \"#/schemas/Item\") describing the JSON shape printed under --format json." }
+          }
+        },
+        "exit_codes": {
+          "description": "Map of exit codes (as decimal strings) to their meaning. Each entry MAY be a terse string OR a rich object — consumers MUST handle both forms (spec §5.2).",
+          "type": "object",
+          "patternProperties": {
+            "^[0-9]+$": {
+              "oneOf": [
+                { "type": "string", "minLength": 1 },
+                { "$ref": "#/$defs/exitCodeRich" }
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        "examples": {
+          "description": "Canonical examples — single source of truth, rendered to both --format json and --format md (spec §6).",
+          "type": "array",
+          "items": { "$ref": "#/$defs/example" }
+        },
+        "see_also": {
+          "description": "Other command paths a reader might find relevant (e.g. [\"item update\", \"item delete\"]).",
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "since": {
+          "description": "Implementation version in which the command first appeared (independent of cmdhelp_version).",
+          "type": "string"
+        },
+        "stability": {
+          "description": "Stability promise. Free-form; common values: experimental, beta, stable, deprecated.",
+          "type": "string"
+        }
+      }
+    },
+
+    "arg": {
+      "description": "A positional argument.",
+      "type": "object",
+      "required": ["name", "type"],
+      "additionalProperties": true,
+      "properties": {
+        "name":         { "type": "string", "minLength": 1 },
+        "type":         { "$ref": "#/$defs/typeName" },
+        "required":     { "type": "boolean" },
+        "description":  { "type": "string" },
+        "default":      { "description": "Default value if argument is omitted (when not required)." },
+        "format":       { "type": "string", "description": "Free-form sub-type hint (e.g. \"key=value\")." },
+        "repeatable":   { "type": "boolean" },
+        "enum":         { "$ref": "#/$defs/enumValues" },
+        "enum_source":  { "$ref": "#/$defs/enumSource" }
+      },
+      "allOf": [
+        { "$ref": "#/$defs/enumConsistency" }
+      ]
+    },
+
+    "flagMap": {
+      "description": "Map of flag names (without leading --) to flag definitions.",
+      "type": "object",
+      "additionalProperties": { "$ref": "#/$defs/flag" }
+    },
+
+    "flag": {
+      "description": "A flag (option) on a command.",
+      "type": "object",
+      "required": ["type"],
+      "additionalProperties": true,
+      "properties": {
+        "type":         { "$ref": "#/$defs/typeName" },
+        "required":     { "type": "boolean" },
+        "description":  { "type": "string" },
+        "default":      { "description": "Default value if flag is omitted." },
+        "format":       { "type": "string", "description": "Free-form sub-type hint (e.g. \"key=value\")." },
+        "repeatable":   { "type": "boolean", "description": "True if the flag may appear more than once on a single invocation." },
+        "enum":         { "$ref": "#/$defs/enumValues" },
+        "enum_source":  { "$ref": "#/$defs/enumSource" },
+        "negate_flag":  {
+          "description": "Optional negation form for a bool flag (e.g. \"--no-cache\"). Only meaningful when type=bool. See spec §5.3.",
+          "type": "string",
+          "pattern": "^--[a-zA-Z0-9][a-zA-Z0-9-]*$"
+        }
+      },
+      "allOf": [
+        { "$ref": "#/$defs/enumConsistency" },
+        {
+          "description": "negate_flag only applies to bool-typed flags.",
+          "if":   { "required": ["negate_flag"] },
+          "then": { "properties": { "type": { "const": "bool" } } }
+        }
+      ]
+    },
+
+    "typeName": {
+      "description": "Argument/flag type. Closed set per spec §5.1, plus x-* extension namespace for tool-specific types.",
+      "anyOf": [
+        {
+          "type": "string",
+          "enum": [
+            "string", "int", "float", "bool", "enum",
+            "path", "url", "duration", "date", "datetime", "json", "ref"
+          ]
+        },
+        {
+          "type": "string",
+          "pattern": "^x-[a-zA-Z0-9][a-zA-Z0-9_-]*$",
+          "description": "Tool-specific extension type. Wrappers MAY treat unknown x-* types as `string`."
+        }
+      ]
+    },
+
+    "enumValues": {
+      "description": "Concrete list of allowed values when type=enum (or as a snapshot for dynamic enums).",
+      "type": "array",
+      "items": {
+        "type": ["string", "number", "boolean"]
+      },
+      "minItems": 0
+    },
+
+    "enumSource": {
+      "description": "Reference to a command that resolves the enum dynamically at help-emission time (e.g. \"dynamic:pad collection list\"). The literal `enum` array, when present alongside, is a snapshot.",
+      "type": "string",
+      "pattern": "^dynamic:.+$"
+    },
+
+    "enumConsistency": {
+      "description": "If `enum` or `enum_source` is set, the type SHOULD be `enum`. Encoded as a soft constraint via if/then so this remains permissive for tools that prefer to type the slot more specifically.",
+      "if": {
+        "anyOf": [
+          { "required": ["enum"] },
+          { "required": ["enum_source"] }
+        ]
+      },
+      "then": {
+        "properties": {
+          "type": { "type": "string" }
+        }
+      }
+    },
+
+    "exitCodeRich": {
+      "description": "Rich object form of an exit-code entry. The string form is also valid (see exit_codes patternProperties).",
+      "type": "object",
+      "required": ["when"],
+      "additionalProperties": true,
+      "properties": {
+        "when":             { "type": "string", "minLength": 1, "description": "Concise description of the condition that produces this exit code." },
+        "recovery":         { "type": "string", "description": "Suggested user/agent action to recover from this exit code." },
+        "message_template": { "type": "string", "description": "Template for the stderr message printed alongside the exit; may use {placeholder} substitutions." }
+      }
+    },
+
+    "example": {
+      "description": "A canonical example invocation. Same source for --format json and --format md (spec §6).",
+      "type": "object",
+      "required": ["cmd"],
+      "additionalProperties": true,
+      "properties": {
+        "cmd":  { "type": "string", "minLength": 1, "description": "The runnable invocation. MUST resolve against the live command tree (validated in test suite per spec §6)." },
+        "note": { "type": "string", "description": "Short prose accompanying the invocation." }
+      }
+    }
+
+  }
+}


### PR DESCRIPTION
## Summary

Adds the formal JSON Schema (draft 2020-12) describing `cmdhelp` v0.1's `--format json` wire format, plus a `schema/README.md` documenting intended use.

## Context

Implements `TASK-932` under `PLAN-930` (Implement cmdhelp v0.1 in pad). Spec lives in `IDEA-927` (frozen 2026-05-01 after four rounds of Codex review).

### What this enforces

- **Required top-level:** `cmdhelp_version`, `binary`, `commands`.
- **`cmdhelp_version` pattern** is `MAJOR.MINOR` only (`^[0-9]+\.[0-9]+$`). `0.1.0` is rejected per spec §9.
- **Argument types** (spec §5.1): closed set `{string,int,float,bool,enum,path,url,duration,date,datetime,json,ref}` plus `x-*` extension namespace.
- **Boolean flag arity** (spec §5.3): `negate_flag` only valid when `type=bool` (enforced via `if/then`).
- **`exit_codes` union** (spec §5.2): each entry is string OR `{when, recovery?, message_template?}`. Object form requires `when`. Keys must be numeric.
- **Dynamic enums** (spec §7): `enum_source` pattern is `^dynamic:.+$`.
- **Forward-compat** (spec §9): `additionalProperties: true` at extension points so MINOR bumps can add fields without breaking old consumers.

### Unblocks

- `TASK-934` (JSON emitter — emits documents that must validate against this).
- `TASK-938` (test suite — validates the live `pad help --format json` output against this schema in CI).
- `TASK-940` (docs page on getpad.dev — links to this schema as the canonical reference).

## Test plan

- [x] Schema syntax validates as Draft 2020-12 (`jsonschema.Draft202012Validator.check_schema`).
- [x] Sample document from IDEA-927 §5 validates (positive case).
- [x] 5 negative cases reject correctly:
  - missing required top-level keys
  - `0.1.0` as wire version (semver-style with PATCH)
  - `type=integer` (not in closed set)
  - `negate_flag` on `type=enum` (non-bool)
  - object-form `exit_code` missing `when`
  - non-numeric `exit_code` key
- [x] 2 positive extension cases accepted:
  - `x-pad-priority` extension type
  - `dynamic:pad role list` enum_source
- [x] `make check` clean (lint + go test + web build).
- [x] No Go code changes; no new test failures vs `main`.

## Follow-up

The Pad-side test suite (TASK-938) will exercise this schema against the live `pad help --format json` output once that emitter (TASK-934) is implemented.