### PR TITLE
feat(cli): wire pad help subcommand + scope levels (TASK-933)

### DIFF
--- a/cmd/pad/help_cmdhelp.go
+++ b/cmd/pad/help_cmdhelp.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// CmdhelpVersion is the cmdhelp wire-format version this binary advertises.
+// MAJOR.MINOR only — never includes a PATCH component (cmdhelp v0.1 §9).
+const CmdhelpVersion = "0.1"
+
+// helpCmd returns a custom `pad help` subcommand that replaces cobra's
+// built-in help. It implements the cmdhelp v0.1 mandatory surface
+// (https://getpad.dev/cmdhelp; IDEA-927):
+//
+//	pad help [subcommand…] [--format <fmt>] [--depth <n>] [--all]
+//
+// Default --format=text delegates to the existing cobra help renderer so
+// behavior matches the previous built-in. The structured emitters
+// (--format json|md|llm) land in TASK-934/935; they are stubbed here as
+// "not yet implemented" errors so the routing layer is testable
+// independently of the emitter work.
+func helpCmd() *cobra.Command {
+	var format string
+	var depth int
+	var all bool
+
+	cmd := &cobra.Command{
+		Use:   "help [command path…]",
+		Short: "Help about any command",
+		Long: `Show help for the pad CLI tree.
+
+Default output is the human-readable text format (matching cobra's built-in
+help). Pass --format json|md|llm to emit machine-readable output per the
+cmdhelp v0.1 spec (https://getpad.dev/cmdhelp).
+
+Scope:
+  pad help                       full tree summary
+  pad help <group>               one subtree (e.g. ` + "`pad help item`" + `)
+  pad help <group> <command>     single command, deep`,
+		DisableFlagsInUseLine: true,
+		// Errors from this command (unknown topic, unknown --format, stub
+		// emitter not-yet-implemented) are self-describing — suppress the
+		// auto-printed usage block so terminal output stays focused on the
+		// error message.
+		SilenceUsage: true,
+		ValidArgsFunction: func(c *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			parent, _, _ := c.Root().Find(args)
+			if parent == nil {
+				parent = c.Root()
+			}
+			var names []string
+			for _, sub := range parent.Commands() {
+				if sub.Hidden || sub.Name() == "help" {
+					continue
+				}
+				if strings.HasPrefix(sub.Name(), toComplete) {
+					names = append(names, sub.Name())
+				}
+			}
+			return names, cobra.ShellCompDirectiveNoFileComp
+		},
+		RunE: func(c *cobra.Command, args []string) error {
+			target, _, err := c.Root().Find(args)
+			if err != nil || target == nil {
+				return fmt.Errorf("unknown help topic %q", strings.Join(args, " "))
+			}
+
+			switch strings.ToLower(format) {
+			case "", "text":
+				target.InitDefaultHelpFlag()
+				target.InitDefaultVersionFlag()
+				return target.Help()
+			case "json":
+				return emitCmdhelpJSON(target, depth, all, c.OutOrStdout())
+			case "md", "llm":
+				return emitCmdhelpMarkdown(target, depth, all, c.OutOrStdout())
+			default:
+				return fmt.Errorf("unknown --format %q (want one of: text, md, json, llm)", format)
+			}
+		},
+	}
+
+	cmd.Flags().StringVar(&format, "format", "text", "output format: text, md, json, llm (alias for md) — per cmdhelp v0.1")
+	cmd.Flags().IntVar(&depth, "depth", -1, "truncate the command tree to N levels (-1 = unlimited; --depth=0 is summary)")
+	cmd.Flags().BoolVar(&all, "all", false, "include every leaf with full detail (convenience alias for unlimited depth)")
+
+	return cmd
+}
+
+// emitCmdhelpJSON is a stub for the cmdhelp v0.1 JSON emitter. The real
+// implementation walks the cobra command tree and writes a document
+// matching schema/cmdhelp.schema.json. Lands in TASK-934.
+func emitCmdhelpJSON(target *cobra.Command, depth int, all bool, w io.Writer) error {
+	_ = target
+	_ = depth
+	_ = all
+	_ = w
+	return fmt.Errorf("--format json not yet implemented (cmdhelp v%s JSON emitter — TASK-934)", CmdhelpVersion)
+}
+
+// emitCmdhelpMarkdown is a stub for the cmdhelp v0.1 markdown emitter
+// (also serves --format llm as an alias). The real implementation walks
+// the cobra command tree and writes a document matching the predictable
+// section order in cmdhelp v0.1 §6. Lands in TASK-935.
+func emitCmdhelpMarkdown(target *cobra.Command, depth int, all bool, w io.Writer) error {
+	_ = target
+	_ = depth
+	_ = all
+	_ = w
+	return fmt.Errorf("--format md/llm not yet implemented (cmdhelp v%s markdown emitter — TASK-935)", CmdhelpVersion)
+}

--- a/cmd/pad/help_cmdhelp_test.go
+++ b/cmd/pad/help_cmdhelp_test.go
@@ -1,0 +1,192 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// buildTestRoot returns a minimal cobra tree that mirrors `pad`'s structure
+// closely enough to exercise the help routing layer:
+//
+//	root
+//	├── item (group)
+//	│   ├── create
+//	│   └── update
+//	└── project (group)
+//	    └── dashboard
+//
+// Using a synthetic root keeps the routing test independent of the real
+// command tree (which can change frequently) and avoids spinning up the
+// HTTP server that real subcommands need.
+func buildTestRoot() *cobra.Command {
+	root := &cobra.Command{Use: "padtest", Short: "test root"}
+
+	itemGroup := &cobra.Command{Use: "item", Short: "item group"}
+	itemGroup.AddCommand(
+		&cobra.Command{Use: "create", Short: "create an item"},
+		&cobra.Command{Use: "update", Short: "update an item"},
+	)
+	projectGroup := &cobra.Command{Use: "project", Short: "project group"}
+	projectGroup.AddCommand(
+		&cobra.Command{Use: "dashboard", Short: "show dashboard"},
+	)
+
+	root.AddCommand(itemGroup, projectGroup)
+	root.SetHelpCommand(helpCmd())
+	return root
+}
+
+// runHelp invokes the help command with the given args and returns
+// (stdout, stderr, error).
+func runHelp(t *testing.T, args ...string) (string, string, error) {
+	t.Helper()
+	root := buildTestRoot()
+	var stdout, stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	root.SetArgs(append([]string{"help"}, args...))
+	err := root.Execute()
+	return stdout.String(), stderr.String(), err
+}
+
+func TestHelpCmd_DefaultTextRoutesToCobra(t *testing.T) {
+	out, _, err := runHelp(t)
+	if err != nil {
+		t.Fatalf("pad help: unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "Available Commands:") {
+		t.Errorf("expected cobra-style text output with 'Available Commands:', got:\n%s", out)
+	}
+	for _, name := range []string{"item", "project"} {
+		if !strings.Contains(out, name) {
+			t.Errorf("expected root help to list subcommand %q, got:\n%s", name, out)
+		}
+	}
+}
+
+func TestHelpCmd_GroupScope(t *testing.T) {
+	out, _, err := runHelp(t, "item")
+	if err != nil {
+		t.Fatalf("pad help item: unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "create") || !strings.Contains(out, "update") {
+		t.Errorf("expected `pad help item` to list child commands, got:\n%s", out)
+	}
+}
+
+func TestHelpCmd_LeafScope(t *testing.T) {
+	out, _, err := runHelp(t, "item", "create")
+	if err != nil {
+		t.Fatalf("pad help item create: unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "create an item") {
+		t.Errorf("expected leaf help to include leaf description, got:\n%s", out)
+	}
+}
+
+func TestHelpCmd_FormatTextEquivalent(t *testing.T) {
+	defaultOut, _, _ := runHelp(t)
+	explicitOut, _, err := runHelp(t, "--format", "text")
+	if err != nil {
+		t.Fatalf("pad help --format text: unexpected error: %v", err)
+	}
+	if defaultOut == "" || explicitOut == "" {
+		t.Fatalf("expected non-empty output from both default and --format=text")
+	}
+	if defaultOut != explicitOut {
+		t.Errorf("expected --format=text to match default output exactly\n--- default ---\n%s\n--- explicit ---\n%s", defaultOut, explicitOut)
+	}
+}
+
+func TestHelpCmd_FormatJSONStubError(t *testing.T) {
+	_, _, err := runHelp(t, "--format", "json")
+	if err == nil {
+		t.Fatalf("expected --format json to return a stub error (TASK-934 unimplemented)")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "TASK-934") {
+		t.Errorf("expected JSON stub error to reference TASK-934, got: %s", msg)
+	}
+	if !strings.Contains(msg, "not yet implemented") {
+		t.Errorf("expected JSON stub error to say 'not yet implemented', got: %s", msg)
+	}
+}
+
+func TestHelpCmd_FormatMarkdownStubError(t *testing.T) {
+	for _, format := range []string{"md", "llm"} {
+		t.Run(format, func(t *testing.T) {
+			_, _, err := runHelp(t, "--format", format)
+			if err == nil {
+				t.Fatalf("expected --format %s to return a stub error (TASK-935 unimplemented)", format)
+			}
+			msg := err.Error()
+			if !strings.Contains(msg, "TASK-935") {
+				t.Errorf("expected --format %s stub error to reference TASK-935, got: %s", format, msg)
+			}
+		})
+	}
+}
+
+func TestHelpCmd_FormatLLMAliasRoutesToMarkdown(t *testing.T) {
+	// Both md and llm should produce the same error message body (modulo
+	// "TASK-935") since llm is a renderer-level alias for md.
+	_, _, mdErr := runHelp(t, "--format", "md")
+	_, _, llmErr := runHelp(t, "--format", "llm")
+	if mdErr == nil || llmErr == nil {
+		t.Fatalf("expected both --format md and --format llm to return stub errors")
+	}
+	if mdErr.Error() != llmErr.Error() {
+		t.Errorf("expected --format llm to alias --format md (same stub error)\nmd:  %s\nllm: %s", mdErr.Error(), llmErr.Error())
+	}
+}
+
+func TestHelpCmd_FormatUnknownRejected(t *testing.T) {
+	_, _, err := runHelp(t, "--format", "yaml")
+	if err == nil {
+		t.Fatalf("expected --format yaml to be rejected as unknown")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "unknown") || !strings.Contains(msg, "yaml") {
+		t.Errorf("expected unknown-format error to mention the bad value, got: %s", msg)
+	}
+}
+
+func TestHelpCmd_UnknownTopicRejected(t *testing.T) {
+	_, _, err := runHelp(t, "no-such-command")
+	if err == nil {
+		t.Fatalf("expected unknown topic to return an error")
+	}
+	if !strings.Contains(err.Error(), "unknown help topic") {
+		t.Errorf("expected error to mention 'unknown help topic', got: %s", err.Error())
+	}
+}
+
+func TestHelpCmd_DepthAndAllAccepted(t *testing.T) {
+	// --depth and --all are part of the cmdhelp v0.1 surface but their
+	// effect lives in the JSON/MD emitters (TASK-934/935). At this layer
+	// we just need to confirm they're plumbed through and don't error.
+	if _, _, err := runHelp(t, "--depth", "2"); err != nil {
+		t.Errorf("--depth 2 should be accepted at default text format, got: %v", err)
+	}
+	if _, _, err := runHelp(t, "--all"); err != nil {
+		t.Errorf("--all should be accepted at default text format, got: %v", err)
+	}
+}
+
+func TestCmdhelpVersion_WireFormat(t *testing.T) {
+	// Per cmdhelp v0.1 §9, the wire-format version is MAJOR.MINOR — never
+	// includes a PATCH component. Lock that here so a stray "0.1.0" can't
+	// land without breaking this test.
+	parts := strings.Split(CmdhelpVersion, ".")
+	if len(parts) != 2 {
+		t.Errorf("CmdhelpVersion %q must be MAJOR.MINOR (no PATCH); got %d parts", CmdhelpVersion, len(parts))
+	}
+	for i, p := range parts {
+		if p == "" {
+			t.Errorf("CmdhelpVersion %q has empty component at index %d", CmdhelpVersion, i)
+		}
+	}
+}

--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -100,6 +100,12 @@ func main() {
 		completionCmd(),
 	)
 
+	// Replace cobra's built-in `help` with our cmdhelp v0.1 routing layer.
+	// Default --format=text delegates back to cobra's text renderer so the
+	// existing UX is unchanged; --format json|md|llm calls into the
+	// structured emitters (currently stubbed — see TASK-934/935).
+	rootCmd.SetHelpCommand(helpCmd())
+
 	rootCmd.RegisterFlagCompletionFunc("workspace", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		cfg, err := config.Load()
 		if err != nil || !cfg.IsConfigured() {


### PR DESCRIPTION
## Summary

Replaces cobra's built-in `help` with a custom subcommand implementing the cmdhelp v0.1 mandatory surface (https://getpad.dev/cmdhelp; IDEA-927):

```
pad help [subcommand…] [--format <fmt>] [--depth <n>] [--all]
```

This is the **routing layer**. The structured emitters (`--format json|md|llm`) are stubbed — they return clear `not yet implemented` errors pointing to TASK-934 / TASK-935 so the skeleton ships and is testable independently of the emitter work.

## Context

Implements `TASK-933` under `PLAN-930`. Schema sibling (`TASK-932`) merged in #325. The remaining children — emitters (`TASK-934/935`), capability flag (`TASK-937`), tests (`TASK-938`) — unblock once this skeleton is in place.

### Behaviour

| invocation | result |
|---|---|
| `pad help` | root tree summary — delegates to cobra's text renderer (UX unchanged) |
| `pad help item` | subtree — delegates to cobra |
| `pad help item create` | leaf — delegates to cobra |
| `pad help --format text` | byte-for-byte equivalent to default |
| `pad help --format json` | exit 1, error mentions TASK-934 |
| `pad help --format md` | exit 1, error mentions TASK-935 |
| `pad help --format llm` | aliases md (same error) |
| `pad help --format yaml` | exit 1, "unknown --format" |
| `pad help no-such-cmd` | exit 1, "unknown help topic" |
| `pad help --depth 2` | accepted; effect lives in emitters |
| `pad help --all` | accepted; effect lives in emitters |
| `pad item --help` | unchanged |
| `pad --help` | unchanged |

### Design choices

- **Replace via `rootCmd.SetHelpCommand()`** — cobra's canonical extension point; doesn't break `pad <cmd> --help` (which uses cobra's `--help` flag, not the `help` subcommand).
- **Local `--format` shadows the persistent root flag** for the help command only — keeps the cmdhelp vocabulary (`text/md/json/llm`) separate from the existing output-format vocabulary (`table/json/markdown`).
- **`SilenceUsage: true`** so error paths don't print a redundant usage block — error messages are self-describing.
- **Stubs return errors, not placeholder output** — prevents downstream tools from accidentally consuming "not yet implemented" text as if it were valid cmdhelp.

## Test plan

- [x] `cmd/pad/help_cmdhelp_test.go` — 11 routing cases, all pass:
  - Default text routes to cobra (group + leaf summaries appear)
  - `--format text` byte-equivalent to default
  - `--format json` errors with TASK-934 reference
  - `--format md` and `--format llm` error with TASK-935 reference
  - `llm` alias produces identical message body to `md`
  - Unknown `--format` rejected with the bad value in the error
  - Unknown help topic rejected
  - `--depth` and `--all` accepted without error in default mode
  - `CmdhelpVersion` is `MAJOR.MINOR` (no PATCH per spec §9)
- [x] `make check` clean (lint + go test + web build).
- [x] Manual smoke-test on built binary across 13 paths.
- [x] No regressions to existing `pad <cmd> --help` behavior.

## Out of scope (deferred to subsequent tasks)

- JSON emitter — `TASK-934`
- Markdown / `--llm` emitter — `TASK-935`
- Dynamic enum resolution — `TASK-936`
- `--capabilities` discovery flag — `TASK-937`
- Golden-file tests + flag-tree validation of examples — `TASK-938`