### PR TITLE
feat(cmdhelp): implement --format json emitter (TASK-934)

### DIFF
--- a/cmd/pad/help_cmdhelp.go
+++ b/cmd/pad/help_cmdhelp.go
@@ -6,11 +6,21 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+
+	"github.com/PerpetualSoftware/pad/internal/cmdhelp"
 )
 
 // CmdhelpVersion is the cmdhelp wire-format version this binary advertises.
 // MAJOR.MINOR only — never includes a PATCH component (cmdhelp v0.1 §9).
-const CmdhelpVersion = "0.1"
+//
+// Re-exported from internal/cmdhelp so the CLI layer can reference the
+// constant without importing the emitter package in places that only
+// need the version string.
+const CmdhelpVersion = cmdhelp.Version
+
+// padHomepage is the canonical project URL emitted in the cmdhelp
+// document's `homepage` field.
+const padHomepage = "https://getpad.dev"
 
 // helpCmd returns a custom `pad help` subcommand that replaces cobra's
 // built-in help. It implements the cmdhelp v0.1 mandatory surface
@@ -91,15 +101,22 @@ Scope:
 	return cmd
 }
 
-// emitCmdhelpJSON is a stub for the cmdhelp v0.1 JSON emitter. The real
-// implementation walks the cobra command tree and writes a document
-// matching schema/cmdhelp.schema.json. Lands in TASK-934.
+// emitCmdhelpJSON walks the cobra command tree below `target` and emits
+// a cmdhelp v0.1 JSON document matching schema/cmdhelp.schema.json.
+//
+// `--all` is a convenience alias for unlimited depth (spec §4); when
+// passed it overrides any explicit `--depth=N`.
 func emitCmdhelpJSON(target *cobra.Command, depth int, all bool, w io.Writer) error {
-	_ = target
-	_ = depth
-	_ = all
-	_ = w
-	return fmt.Errorf("--format json not yet implemented (cmdhelp v%s JSON emitter — TASK-934)", CmdhelpVersion)
+	maxDepth := depth
+	if all {
+		maxDepth = -1
+	}
+	return cmdhelp.EmitJSON(target, target.Root(), cmdhelp.Options{
+		Binary:   target.Root().Name(),
+		Version:  fullVersion(),
+		Homepage: padHomepage,
+		MaxDepth: maxDepth,
+	}, w)
 }
 
 // emitCmdhelpMarkdown is a stub for the cmdhelp v0.1 markdown emitter

--- a/cmd/pad/help_cmdhelp_test.go
+++ b/cmd/pad/help_cmdhelp_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -101,17 +102,31 @@ func TestHelpCmd_FormatTextEquivalent(t *testing.T) {
 	}
 }
 
-func TestHelpCmd_FormatJSONStubError(t *testing.T) {
-	_, _, err := runHelp(t, "--format", "json")
-	if err == nil {
-		t.Fatalf("expected --format json to return a stub error (TASK-934 unimplemented)")
+func TestHelpCmd_FormatJSONEmits(t *testing.T) {
+	// TASK-934 replaced the stub with a real emitter. Verify --format json
+	// produces a parseable cmdhelp document with the expected envelope.
+	out, _, err := runHelp(t, "--format", "json")
+	if err != nil {
+		t.Fatalf("--format json: unexpected error: %v\nstdout:\n%s", err, out)
 	}
-	msg := err.Error()
-	if !strings.Contains(msg, "TASK-934") {
-		t.Errorf("expected JSON stub error to reference TASK-934, got: %s", msg)
+	var doc map[string]interface{}
+	if uerr := json.Unmarshal([]byte(out), &doc); uerr != nil {
+		t.Fatalf("--format json output is not valid JSON: %v\n%s", uerr, out)
 	}
-	if !strings.Contains(msg, "not yet implemented") {
-		t.Errorf("expected JSON stub error to say 'not yet implemented', got: %s", msg)
+	if doc["cmdhelp_version"] != "0.1" {
+		t.Errorf("cmdhelp_version = %v, want 0.1", doc["cmdhelp_version"])
+	}
+	if _, ok := doc["binary"]; !ok {
+		t.Errorf("emitted JSON missing required key 'binary'")
+	}
+	cmds, ok := doc["commands"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("emitted JSON missing required key 'commands' or wrong type: %T", doc["commands"])
+	}
+	for _, want := range []string{"item", "item create", "project", "project dashboard"} {
+		if _, ok := cmds[want]; !ok {
+			t.Errorf("expected command %q in emitted commands map", want)
+		}
 	}
 }
 

--- a/internal/cmdhelp/json.go
+++ b/internal/cmdhelp/json.go
@@ -1,0 +1,303 @@
+package cmdhelp
+
+import (
+	"encoding/json"
+	"io"
+	"regexp"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// Options configure a Build/EmitJSON call. All fields are optional except
+// Binary, which is used as the document's `binary` key.
+type Options struct {
+	// Binary is the CLI binary name as invoked on the command line
+	// (e.g. "pad"). Defaults to root.Name() when empty.
+	Binary string
+
+	// Version is the implementation's own software version, independent
+	// of cmdhelp's wire-format version. Free-form.
+	Version string
+
+	// Homepage is the project's canonical URL. Optional.
+	Homepage string
+
+	// MaxDepth caps the walk at N levels below `target`. Pass a negative
+	// value (-1 is conventional) for unlimited depth. 0 emits only the
+	// target itself; 1 emits the target plus its direct subcommands; N
+	// emits N levels of subcommands.
+	//
+	// Note that Go's zero value (0) means "target only". Callers that
+	// want the unlimited default MUST pass -1 (or any negative value)
+	// explicitly — see cmd/pad/help_cmdhelp.go for the canonical wiring.
+	MaxDepth int
+}
+
+// EmitJSON walks the command tree below `target`, builds a cmdhelp v0.1
+// Document, and writes it to w as indented JSON terminated by a newline.
+//
+// `root` MUST be the root cobra command (used to derive global flags and
+// command-path keys relative to the binary). `target` is where the user
+// requested help; pass root for both when the user runs `<cmd> help`.
+func EmitJSON(target, root *cobra.Command, opts Options, w io.Writer) error {
+	doc := Build(target, root, opts)
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(doc)
+}
+
+// Build returns a cmdhelp Document without serializing it. Callers that
+// need to inspect or further mutate the document (tests, dynamic enum
+// resolvers in TASK-936) should use this and serialize themselves.
+func Build(target, root *cobra.Command, opts Options) *Document {
+	binary := opts.Binary
+	if binary == "" {
+		binary = root.Name()
+	}
+
+	doc := &Document{
+		CmdhelpVersion: Version,
+		Binary:         binary,
+		Version:        opts.Version,
+		Summary:        firstLine(root.Short),
+		Homepage:       opts.Homepage,
+		Commands:       map[string]Command{},
+	}
+
+	if globals := collectFlags(root.PersistentFlags()); len(globals) > 0 {
+		doc.GlobalFlags = globals
+	}
+
+	walk(target, root, doc, 0, opts.MaxDepth)
+
+	return doc
+}
+
+func walk(cur, root *cobra.Command, doc *Document, depth, maxDepth int) {
+	if cur == nil || cur.Hidden {
+		return
+	}
+
+	// Skip the help command itself — it documents the cmdhelp surface,
+	// not a regular command, and cobra installs it on every root.
+	if cur.Name() == "help" && cur.Parent() != nil && cur.Parent() == root {
+		return
+	}
+
+	// The root binary itself is described by top-level fields (binary,
+	// summary, version, etc.) — don't also emit it as a command entry.
+	if cur != root {
+		path := commandPath(cur, root)
+		if path != "" {
+			doc.Commands[path] = buildCommand(cur)
+		}
+	}
+
+	// `depth` is how many levels below the initial target we currently are.
+	// `maxDepth` is the number of additional levels of descendants to emit;
+	// children of target sit at depth=1, grandchildren at depth=2, etc.
+	// Per spec §4, --depth=0 means "subcommand list" (immediate children of
+	// target), so we recurse while depth+1 <= maxDepth+1 — i.e. while
+	// depth <= maxDepth. maxDepth < 0 disables the cap.
+	if maxDepth >= 0 && depth > maxDepth {
+		return
+	}
+	for _, sub := range cur.Commands() {
+		walk(sub, root, doc, depth+1, maxDepth)
+	}
+}
+
+func commandPath(cmd, root *cobra.Command) string {
+	full := cmd.CommandPath()
+	rootPath := root.CommandPath()
+	trimmed := strings.TrimPrefix(full, rootPath)
+	return strings.TrimSpace(trimmed)
+}
+
+func buildCommand(cmd *cobra.Command) Command {
+	out := Command{
+		Summary: firstLine(cmd.Short),
+	}
+
+	// Long-form description: only emit if it adds something beyond Short.
+	if longTrimmed := strings.TrimSpace(cmd.Long); longTrimmed != "" && longTrimmed != cmd.Short && firstLine(longTrimmed) != cmd.Short {
+		out.Description = longTrimmed
+	}
+
+	out.Args = parseArgs(cmd.Use)
+	if flags := collectFlags(cmd.LocalFlags()); len(flags) > 0 {
+		out.Flags = flags
+	}
+	out.Examples = parseExamples(cmd.Example)
+
+	return out
+}
+
+// argRE matches positional arg placeholders in a cobra Use string:
+//
+//	<name>  → required
+//	[name]  → optional
+//
+// The conventional `[flags]` placeholder cobra appends is filtered in
+// parseArgs.
+var argRE = regexp.MustCompile(`<([a-zA-Z0-9_-]+)>|\[([a-zA-Z0-9_./-]+)\]`)
+
+func parseArgs(use string) []Arg {
+	matches := argRE.FindAllStringSubmatch(use, -1)
+	if len(matches) == 0 {
+		return nil
+	}
+	args := make([]Arg, 0, len(matches))
+	for _, m := range matches {
+		var name string
+		var required bool
+		switch {
+		case m[1] != "":
+			name = m[1]
+			required = true
+		case m[2] != "":
+			name = m[2]
+			required = false
+			// Filter cobra-conventional placeholders that are not real args.
+			lower := strings.ToLower(name)
+			if lower == "flags" || lower == "options" || lower == "command" {
+				continue
+			}
+		default:
+			continue
+		}
+		args = append(args, Arg{Name: name, Type: "string", Required: required})
+	}
+	if len(args) == 0 {
+		return nil
+	}
+	return args
+}
+
+func collectFlags(fs *pflag.FlagSet) map[string]Flag {
+	if fs == nil {
+		return nil
+	}
+	out := map[string]Flag{}
+	fs.VisitAll(func(f *pflag.Flag) {
+		// Skip cobra's auto-installed --help flag and any explicitly
+		// hidden flag. These are noise in machine-readable output.
+		if f.Hidden || f.Name == "help" {
+			return
+		}
+		out[f.Name] = buildFlag(f)
+	})
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func buildFlag(f *pflag.Flag) Flag {
+	typ, repeatable := mapPflagType(f.Value.Type())
+	flag := Flag{
+		Type:        typ,
+		Description: f.Usage,
+		Repeatable:  repeatable,
+	}
+	if f.DefValue != "" && !isZeroDefault(f.DefValue, typ, repeatable) {
+		flag.Default = f.DefValue
+	}
+	return flag
+}
+
+// isZeroDefault returns true when DefValue is the conventional zero for
+// the flag's type. Suppressing zero defaults keeps the emitted document
+// small and avoids encoding "" / "0" / "false" / "[]" everywhere.
+func isZeroDefault(def, typ string, repeatable bool) bool {
+	if repeatable && (def == "[]" || def == "" || def == "[" || def == "]") {
+		return true
+	}
+	switch typ {
+	case "string":
+		return def == ""
+	case "int", "float":
+		return def == "0" || def == "0.0"
+	case "bool":
+		return def == "false"
+	case "duration":
+		return def == "0s" || def == "0"
+	}
+	return false
+}
+
+// mapPflagType translates pflag Value.Type() strings to the cmdhelp v0.1
+// type vocabulary (spec §5.1) and reports whether the flag is repeatable.
+//
+// pflag exposes a wider type space than cmdhelp; we map related types
+// down to the closed cmdhelp set. Slice/array variants become the scalar
+// type with repeatable=true. Unknown/unmapped types fall back to "string"
+// so emission never fails on an exotic flag.
+func mapPflagType(t string) (cmdhelpType string, repeatable bool) {
+	switch t {
+	case "string":
+		return "string", false
+	case "int", "int8", "int16", "int32", "int64",
+		"uint", "uint8", "uint16", "uint32", "uint64",
+		"count":
+		return "int", false
+	case "float32", "float64":
+		return "float", false
+	case "bool":
+		return "bool", false
+	case "duration":
+		return "duration", false
+	case "stringSlice", "stringArray", "stringToString":
+		return "string", true
+	case "intSlice":
+		return "int", true
+	case "boolSlice":
+		return "bool", true
+	case "ip", "ipMask", "ipNet", "ipSlice":
+		return "string", t == "ipSlice"
+	case "bytesHex", "bytesBase64":
+		return "string", false
+	default:
+		return "string", false
+	}
+}
+
+// parseExamples turns cobra's Example field (a single multiline string)
+// into individual Example entries. Each non-empty, non-comment line is
+// taken as one runnable invocation; comment lines (`# ...`) are dropped.
+//
+// The convention in pad's existing commands is two-space-indented lines
+// like:
+//
+//	pad item create task "Fix" --priority high
+//
+// We trim leading/trailing whitespace per line.
+func parseExamples(example string) []Example {
+	example = strings.TrimSpace(example)
+	if example == "" {
+		return nil
+	}
+	var examples []Example
+	for _, line := range strings.Split(example, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		examples = append(examples, Example{Cmd: line})
+	}
+	if len(examples) == 0 {
+		return nil
+	}
+	return examples
+}
+
+// firstLine returns the first line of s with surrounding whitespace
+// trimmed. Useful for collapsing a multi-line Long string into a Summary.
+func firstLine(s string) string {
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		return strings.TrimSpace(s[:i])
+	}
+	return strings.TrimSpace(s)
+}

--- a/internal/cmdhelp/json.go
+++ b/internal/cmdhelp/json.go
@@ -126,7 +126,7 @@ func buildCommand(cmd *cobra.Command) Command {
 		out.Description = longTrimmed
 	}
 
-	out.Args = parseArgs(cmd.Use)
+	out.Args = parseArgs(cmd)
 	if flags := collectFlags(cmd.LocalFlags()); len(flags) > 0 {
 		out.Flags = flags
 	}
@@ -137,43 +137,129 @@ func buildCommand(cmd *cobra.Command) Command {
 
 // argRE matches positional arg placeholders in a cobra Use string:
 //
-//	<name>  → required
-//	[name]  → optional
+//	<name>      → required
+//	[name]      → optional
+//	<name>...   → required + repeatable (variadic)
+//	[name]...   → optional + repeatable (variadic)
+//	[a|b|c]     → optional alternation (cobra ValidArgs convention) — enum-typed
+//	<a|b|c>     → required alternation — enum-typed
 //
-// The conventional `[flags]` placeholder cobra appends is filtered in
-// parseArgs.
-var argRE = regexp.MustCompile(`<([a-zA-Z0-9_-]+)>|\[([a-zA-Z0-9_./-]+)\]`)
+// Cobra-conventional placeholders ([flags], [options], [command]) and
+// embedded flag-like fragments ([--status X]) are filtered downstream
+// in parseArgs.
+var argRE = regexp.MustCompile(`<([^<>]+)>(\.\.\.)?|\[([^\[\]]+)\](\.\.\.)?`)
 
-func parseArgs(use string) []Arg {
-	matches := argRE.FindAllStringSubmatch(use, -1)
-	if len(matches) == 0 {
-		return nil
-	}
+func parseArgs(cmd *cobra.Command) []Arg {
+	matches := argRE.FindAllStringSubmatch(cmd.Use, -1)
 	args := make([]Arg, 0, len(matches))
 	for _, m := range matches {
-		var name string
+		var inner, ellipsis string
 		var required bool
 		switch {
 		case m[1] != "":
-			name = m[1]
+			inner = m[1]
+			ellipsis = m[2]
 			required = true
-		case m[2] != "":
-			name = m[2]
+		case m[3] != "":
+			inner = m[3]
+			ellipsis = m[4]
 			required = false
-			// Filter cobra-conventional placeholders that are not real args.
-			lower := strings.ToLower(name)
-			if lower == "flags" || lower == "options" || lower == "command" {
-				continue
-			}
 		default:
 			continue
 		}
-		args = append(args, Arg{Name: name, Type: "string", Required: required})
+		inner = strings.TrimSpace(inner)
+		if inner == "" {
+			continue
+		}
+
+		// Filter cobra-conventional placeholders that are not real args.
+		lower := strings.ToLower(inner)
+		if !required && (lower == "flags" || lower == "options" || lower == "command") {
+			continue
+		}
+		// Filter embedded flag-like fragments such as `[--status X]`.
+		if strings.HasPrefix(inner, "-") {
+			continue
+		}
+
+		// Alternation: <a|b|c> or [a|b|c] → enum-typed positional.
+		if strings.Contains(inner, "|") {
+			parts := strings.Split(inner, "|")
+			values := make([]interface{}, 0, len(parts))
+			for _, p := range parts {
+				p = strings.TrimSpace(p)
+				if p != "" {
+					values = append(values, p)
+				}
+			}
+			if len(values) > 0 {
+				args = append(args, Arg{
+					Name:       "value", // synthesized; cobra Use doesn't carry a name here
+					Type:       "enum",
+					Required:   required,
+					Enum:       values,
+					Repeatable: ellipsis != "",
+				})
+				continue
+			}
+		}
+
+		// Plain <name> / [name]. Reject anything that looks like prose
+		// (spaces, punctuation that wouldn't be in an arg identifier).
+		if !validArgName(inner) {
+			continue
+		}
+		args = append(args, Arg{
+			Name:       inner,
+			Type:       "string",
+			Required:   required,
+			Repeatable: ellipsis != "",
+		})
 	}
+
+	// If cobra's ValidArgs is set and we have at least one positional,
+	// attach those values as the first arg's enum. ValidArgs is the
+	// authoritative machine-readable form (Use is for humans), so this
+	// covers the case where Use says `[shell]` but the allowed values
+	// only live on the cobra struct.
+	if len(cmd.ValidArgs) > 0 && len(args) > 0 && args[0].Type == "string" {
+		values := make([]interface{}, len(cmd.ValidArgs))
+		for i, v := range cmd.ValidArgs {
+			// cobra ValidArgs entries can carry shell-completion descriptions
+			// after a tab; strip them so the enum carries just the values.
+			if tab := strings.IndexByte(v, '\t'); tab >= 0 {
+				v = v[:tab]
+			}
+			values[i] = v
+		}
+		args[0].Type = "enum"
+		args[0].Enum = values
+	}
+
 	if len(args) == 0 {
 		return nil
 	}
 	return args
+}
+
+// validArgName returns true if s looks like an ordinary identifier-style
+// arg name. Used to reject embedded flag fragments and prose that the
+// regex would otherwise capture from idiosyncratic Use strings.
+func validArgName(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		switch {
+		case r == '-' || r == '_' || r == '.' || r == '/':
+		case r >= 'a' && r <= 'z':
+		case r >= 'A' && r <= 'Z':
+		case r >= '0' && r <= '9':
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 func collectFlags(fs *pflag.FlagSet) map[string]Flag {

--- a/internal/cmdhelp/json_test.go
+++ b/internal/cmdhelp/json_test.go
@@ -55,7 +55,29 @@ func buildSyntheticTree() *cobra.Command {
 		Short: "Update an item",
 	}
 
-	item.AddCommand(create, update)
+	// Variadic + embedded flag-like fragments — exercised by bulk:
+	//   `bulk-update [--status X] <ref>...`
+	bulk := &cobra.Command{
+		Use:   "bulk-update [--status X] <ref>...",
+		Short: "Update multiple items",
+	}
+
+	// Alternation in Use string + ValidArgs on the cobra struct —
+	// exercised by `completion [bash|zsh|fish|powershell]`.
+	completion := &cobra.Command{
+		Use:       "completion [bash|zsh|fish|powershell]",
+		Short:     "Generate shell completion",
+		ValidArgs: []string{"bash", "zsh", "fish", "powershell"},
+	}
+
+	// ValidArgs without alternation — exercised by `Use: completion2 [shell]`.
+	completion2 := &cobra.Command{
+		Use:       "completion2 [shell]",
+		Short:     "Generate shell completion (named arg)",
+		ValidArgs: []string{"bash", "zsh"},
+	}
+
+	item.AddCommand(create, update, bulk, completion, completion2)
 
 	deep := &cobra.Command{Use: "deep", Short: "deep group"}
 	nest := &cobra.Command{Use: "nest", Short: "nest group"}
@@ -130,6 +152,81 @@ func TestBuild_HiddenCommandsAndFlagsExcluded(t *testing.T) {
 	}
 	if _, present := create.Flags["help"]; present {
 		t.Errorf("cobra-installed --help flag must not appear in emitted flags")
+	}
+}
+
+func TestBuild_VariadicArgsRepeatable(t *testing.T) {
+	root := buildSyntheticTree()
+	doc := Build(root, root, Options{Binary: "padtest", MaxDepth: -1})
+
+	bulk := doc.Commands["item bulk-update"]
+	if len(bulk.Args) != 1 {
+		t.Fatalf("item bulk-update: expected 1 positional arg (embedded --status filtered), got %d: %+v", len(bulk.Args), bulk.Args)
+	}
+	if bulk.Args[0].Name != "ref" {
+		t.Errorf("expected arg name 'ref', got %q", bulk.Args[0].Name)
+	}
+	if !bulk.Args[0].Required {
+		t.Errorf("expected <ref>... to be required")
+	}
+	if !bulk.Args[0].Repeatable {
+		t.Errorf("expected <ref>... to be marked repeatable (variadic)")
+	}
+}
+
+func TestBuild_AlternationProducesEnum(t *testing.T) {
+	root := buildSyntheticTree()
+	doc := Build(root, root, Options{Binary: "padtest", MaxDepth: -1})
+
+	completion := doc.Commands["item completion"]
+	if len(completion.Args) != 1 {
+		t.Fatalf("item completion: expected 1 positional arg, got %d: %+v", len(completion.Args), completion.Args)
+	}
+	a := completion.Args[0]
+	if a.Type != "enum" {
+		t.Errorf("expected alternation to produce type=enum, got %q", a.Type)
+	}
+	if len(a.Enum) != 4 {
+		t.Errorf("expected 4 enum values, got %d: %v", len(a.Enum), a.Enum)
+	}
+	// Values should be in source order.
+	wantValues := []string{"bash", "zsh", "fish", "powershell"}
+	for i, w := range wantValues {
+		if i >= len(a.Enum) || a.Enum[i] != w {
+			t.Errorf("enum[%d] = %v, want %s", i, a.Enum[i], w)
+		}
+	}
+}
+
+func TestBuild_ValidArgsFillsEnumOnNamedArg(t *testing.T) {
+	root := buildSyntheticTree()
+	doc := Build(root, root, Options{Binary: "padtest", MaxDepth: -1})
+
+	c2 := doc.Commands["item completion2"]
+	if len(c2.Args) != 1 {
+		t.Fatalf("item completion2: expected 1 positional, got %d: %+v", len(c2.Args), c2.Args)
+	}
+	a := c2.Args[0]
+	if a.Name != "shell" {
+		t.Errorf("expected arg name from Use string ('shell'), got %q", a.Name)
+	}
+	if a.Type != "enum" {
+		t.Errorf("expected ValidArgs to upgrade type from string to enum, got %q", a.Type)
+	}
+	if len(a.Enum) != 2 || a.Enum[0] != "bash" || a.Enum[1] != "zsh" {
+		t.Errorf("expected enum from ValidArgs [bash zsh], got %v", a.Enum)
+	}
+}
+
+func TestBuild_EmbeddedFlagFragmentsFiltered(t *testing.T) {
+	root := buildSyntheticTree()
+	doc := Build(root, root, Options{Binary: "padtest", MaxDepth: -1})
+
+	bulk := doc.Commands["item bulk-update"]
+	for _, a := range bulk.Args {
+		if strings.HasPrefix(a.Name, "-") {
+			t.Errorf("flag-like fragment leaked as positional arg: %+v", a)
+		}
 	}
 }
 

--- a/internal/cmdhelp/json_test.go
+++ b/internal/cmdhelp/json_test.go
@@ -1,0 +1,422 @@
+package cmdhelp
+
+import (
+	"bytes"
+	"encoding/json"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// buildSyntheticTree returns a small cobra tree exercising the shapes the
+// emitter has to handle: subgroups, leaf commands with positional args,
+// flags of every cmdhelp type, repeatable flags, hidden commands, and
+// embedded Examples.
+//
+//	root
+//	├── item                    (group)
+//	│   ├── create <coll> <title>   (string args + flags of every type)
+//	│   └── update <ref>            (single positional)
+//	├── deep                    (group, depth>1 to test MaxDepth)
+//	│   └── nest                (group)
+//	│       └── leaf
+//	└── secret                  (hidden)
+func buildSyntheticTree() *cobra.Command {
+	root := &cobra.Command{
+		Use:     "padtest",
+		Short:   "Test root",
+		Version: "9.9.9",
+	}
+	root.PersistentFlags().String("workspace", "", "workspace slug override")
+	root.PersistentFlags().Int("port", 0, "server port")
+
+	item := &cobra.Command{Use: "item", Short: "item group"}
+
+	create := &cobra.Command{
+		Use:     "create <collection> <title> [flags]",
+		Short:   "Create a new item",
+		Long:    "Create a new item in the specified collection.\n\nLonger description here.",
+		Example: "  padtest item create task \"Fix OAuth\" --priority high\n  padtest item create idea \"Realtime\" --tags x,y,z\n  # comment line should be skipped",
+	}
+	create.Flags().String("priority", "medium", "priority level")
+	create.Flags().Bool("stdin", false, "read from stdin")
+	create.Flags().Int("retries", 0, "retry count")
+	create.Flags().Float64("budget", 0, "budget cap")
+	create.Flags().StringSlice("tags", nil, "comma-separated tags")
+	create.Flags().StringArray("field", nil, "repeatable --field key=value")
+	hiddenFlag := "internal-debug"
+	create.Flags().Bool(hiddenFlag, false, "internal use")
+	_ = create.Flags().MarkHidden(hiddenFlag)
+
+	update := &cobra.Command{
+		Use:   "update <ref>",
+		Short: "Update an item",
+	}
+
+	item.AddCommand(create, update)
+
+	deep := &cobra.Command{Use: "deep", Short: "deep group"}
+	nest := &cobra.Command{Use: "nest", Short: "nest group"}
+	leaf := &cobra.Command{Use: "leaf", Short: "leaf"}
+	nest.AddCommand(leaf)
+	deep.AddCommand(nest)
+
+	secret := &cobra.Command{Use: "secret", Short: "hidden", Hidden: true}
+
+	root.AddCommand(item, deep, secret)
+	return root
+}
+
+func TestBuild_TopLevelEnvelope(t *testing.T) {
+	root := buildSyntheticTree()
+	doc := Build(root, root, Options{
+		Binary:   "padtest",
+		Version:  "9.9.9",
+		Homepage: "https://example.test",
+		MaxDepth: -1,
+	})
+
+	if doc.CmdhelpVersion != "0.1" {
+		t.Errorf("cmdhelp_version = %q, want 0.1", doc.CmdhelpVersion)
+	}
+	if doc.Binary != "padtest" {
+		t.Errorf("binary = %q, want padtest", doc.Binary)
+	}
+	if doc.Version != "9.9.9" {
+		t.Errorf("version = %q, want 9.9.9", doc.Version)
+	}
+	if doc.Homepage != "https://example.test" {
+		t.Errorf("homepage = %q, want https://example.test", doc.Homepage)
+	}
+	if doc.Summary != "Test root" {
+		t.Errorf("summary = %q, want Test root", doc.Summary)
+	}
+}
+
+func TestBuild_GlobalFlagsEmittedTopLevelOnly(t *testing.T) {
+	root := buildSyntheticTree()
+	doc := Build(root, root, Options{Binary: "padtest", MaxDepth: -1})
+
+	// Top-level global_flags should contain workspace + port.
+	if _, ok := doc.GlobalFlags["workspace"]; !ok {
+		t.Errorf("expected --workspace in global_flags, got: %v", keys(doc.GlobalFlags))
+	}
+	if _, ok := doc.GlobalFlags["port"]; !ok {
+		t.Errorf("expected --port in global_flags, got: %v", keys(doc.GlobalFlags))
+	}
+	// And NOT duplicated in any per-command flags map.
+	for path, cmd := range doc.Commands {
+		if _, dup := cmd.Flags["workspace"]; dup {
+			t.Errorf("global flag --workspace must not be duplicated on command %q", path)
+		}
+		if _, dup := cmd.Flags["port"]; dup {
+			t.Errorf("global flag --port must not be duplicated on command %q", path)
+		}
+	}
+}
+
+func TestBuild_HiddenCommandsAndFlagsExcluded(t *testing.T) {
+	root := buildSyntheticTree()
+	doc := Build(root, root, Options{Binary: "padtest", MaxDepth: -1})
+
+	if _, present := doc.Commands["secret"]; present {
+		t.Errorf("hidden command 'secret' must not appear in commands map")
+	}
+	create := doc.Commands["item create"]
+	if _, present := create.Flags["internal-debug"]; present {
+		t.Errorf("hidden flag --internal-debug must not appear on item create")
+	}
+	if _, present := create.Flags["help"]; present {
+		t.Errorf("cobra-installed --help flag must not appear in emitted flags")
+	}
+}
+
+func TestBuild_PositionalArgsParsed(t *testing.T) {
+	root := buildSyntheticTree()
+	doc := Build(root, root, Options{Binary: "padtest", MaxDepth: -1})
+
+	create := doc.Commands["item create"]
+	if len(create.Args) != 2 {
+		t.Fatalf("item create: expected 2 positional args (collection, title), got %d: %+v", len(create.Args), create.Args)
+	}
+	if create.Args[0].Name != "collection" || !create.Args[0].Required {
+		t.Errorf("arg[0] = %+v, want {collection required:true}", create.Args[0])
+	}
+	if create.Args[1].Name != "title" || !create.Args[1].Required {
+		t.Errorf("arg[1] = %+v, want {title required:true}", create.Args[1])
+	}
+
+	// "[flags]" placeholder must not become a positional arg.
+	for _, a := range create.Args {
+		if a.Name == "flags" || a.Name == "options" {
+			t.Errorf("positional arg %q leaked from cobra placeholder; should be filtered", a.Name)
+		}
+	}
+}
+
+func TestBuild_FlagTypeMapping(t *testing.T) {
+	root := buildSyntheticTree()
+	doc := Build(root, root, Options{Binary: "padtest", MaxDepth: -1})
+	create := doc.Commands["item create"]
+
+	tests := []struct {
+		name       string
+		wantType   string
+		repeatable bool
+	}{
+		{"priority", "string", false},
+		{"stdin", "bool", false},
+		{"retries", "int", false},
+		{"budget", "float", false},
+		{"tags", "string", true},  // StringSlice → repeatable string
+		{"field", "string", true}, // StringArray → repeatable string
+	}
+	for _, tt := range tests {
+		f, ok := create.Flags[tt.name]
+		if !ok {
+			t.Errorf("expected flag --%s, missing; have: %v", tt.name, keys(create.Flags))
+			continue
+		}
+		if f.Type != tt.wantType {
+			t.Errorf("--%s type = %q, want %q", tt.name, f.Type, tt.wantType)
+		}
+		if f.Repeatable != tt.repeatable {
+			t.Errorf("--%s repeatable = %v, want %v", tt.name, f.Repeatable, tt.repeatable)
+		}
+	}
+}
+
+func TestBuild_ZeroDefaultsSuppressed(t *testing.T) {
+	root := buildSyntheticTree()
+	doc := Build(root, root, Options{Binary: "padtest", MaxDepth: -1})
+	create := doc.Commands["item create"]
+
+	// stdin defaults to false → suppressed.
+	if d := create.Flags["stdin"].Default; d != nil {
+		t.Errorf("--stdin default should be suppressed (zero), got %v", d)
+	}
+	// retries defaults to 0 → suppressed.
+	if d := create.Flags["retries"].Default; d != nil {
+		t.Errorf("--retries default should be suppressed (zero), got %v", d)
+	}
+	// priority defaults to "medium" → emitted.
+	if d := create.Flags["priority"].Default; d != "medium" {
+		t.Errorf("--priority default = %v, want \"medium\"", d)
+	}
+}
+
+func TestBuild_ExamplesParsed(t *testing.T) {
+	root := buildSyntheticTree()
+	doc := Build(root, root, Options{Binary: "padtest", MaxDepth: -1})
+	create := doc.Commands["item create"]
+
+	if len(create.Examples) != 2 {
+		t.Fatalf("expected 2 examples (comment line filtered), got %d: %+v", len(create.Examples), create.Examples)
+	}
+	if !strings.Contains(create.Examples[0].Cmd, "Fix OAuth") {
+		t.Errorf("first example: %q does not mention OAuth", create.Examples[0].Cmd)
+	}
+	for _, ex := range create.Examples {
+		if strings.HasPrefix(ex.Cmd, "#") {
+			t.Errorf("comment line leaked through as example: %q", ex.Cmd)
+		}
+		if ex.Cmd != strings.TrimSpace(ex.Cmd) {
+			t.Errorf("example not whitespace-trimmed: %q", ex.Cmd)
+		}
+	}
+}
+
+func TestBuild_DescriptionVsSummary(t *testing.T) {
+	root := buildSyntheticTree()
+	doc := Build(root, root, Options{Binary: "padtest", MaxDepth: -1})
+	create := doc.Commands["item create"]
+
+	if create.Summary != "Create a new item" {
+		t.Errorf("summary = %q, want Short value", create.Summary)
+	}
+	if !strings.Contains(create.Description, "Longer description here") {
+		t.Errorf("description missing or wrong: %q", create.Description)
+	}
+}
+
+func TestBuild_CommandPathKeysAreSpaceJoined(t *testing.T) {
+	root := buildSyntheticTree()
+	doc := Build(root, root, Options{Binary: "padtest", MaxDepth: -1})
+
+	wantPaths := []string{"item", "item create", "item update", "deep", "deep nest", "deep nest leaf"}
+	for _, p := range wantPaths {
+		if _, ok := doc.Commands[p]; !ok {
+			t.Errorf("expected command path %q in commands map; have: %v", p, keys(doc.Commands))
+		}
+	}
+	// Binary itself should not appear as a command entry.
+	if _, present := doc.Commands["padtest"]; present {
+		t.Errorf("root binary 'padtest' must not be a command entry")
+	}
+	if _, present := doc.Commands[""]; present {
+		t.Errorf("empty-string key must not be a command entry")
+	}
+}
+
+func TestBuild_MaxDepthLimitsWalk(t *testing.T) {
+	root := buildSyntheticTree()
+
+	// MaxDepth=0 from root: emit only depth-1 children (immediate children of root).
+	doc0 := Build(root, root, Options{Binary: "padtest", MaxDepth: 0})
+	if _, ok := doc0.Commands["item"]; !ok {
+		t.Errorf("MaxDepth=0 should still emit immediate children of root")
+	}
+	if _, ok := doc0.Commands["item create"]; ok {
+		t.Errorf("MaxDepth=0 should not recurse to grandchildren")
+	}
+
+	// MaxDepth=1: include grandchildren.
+	doc1 := Build(root, root, Options{Binary: "padtest", MaxDepth: 1})
+	if _, ok := doc1.Commands["item create"]; !ok {
+		t.Errorf("MaxDepth=1 should include grandchildren like 'item create'")
+	}
+	if _, ok := doc1.Commands["deep nest leaf"]; ok {
+		t.Errorf("MaxDepth=1 should not include depth-3 leaves")
+	}
+
+	// MaxDepth=-1: unlimited.
+	docAll := Build(root, root, Options{Binary: "padtest", MaxDepth: -1})
+	if _, ok := docAll.Commands["deep nest leaf"]; !ok {
+		t.Errorf("MaxDepth=-1 should walk the full tree")
+	}
+}
+
+func TestBuild_TargetSubtree(t *testing.T) {
+	root := buildSyntheticTree()
+	itemGroup, _, err := root.Find([]string{"item"})
+	if err != nil || itemGroup == nil {
+		t.Fatalf("unable to locate item subtree: %v", err)
+	}
+	doc := Build(itemGroup, root, Options{Binary: "padtest", MaxDepth: -1})
+
+	// Should contain item subtree.
+	if _, ok := doc.Commands["item create"]; !ok {
+		t.Errorf("targeted subtree should include 'item create'")
+	}
+	if _, ok := doc.Commands["item update"]; !ok {
+		t.Errorf("targeted subtree should include 'item update'")
+	}
+	// Should NOT contain unrelated subtrees.
+	if _, ok := doc.Commands["deep"]; ok {
+		t.Errorf("targeted subtree should not include 'deep' from sibling subtree")
+	}
+	if _, ok := doc.Commands["deep nest leaf"]; ok {
+		t.Errorf("targeted subtree should not include 'deep nest leaf'")
+	}
+}
+
+func TestEmitJSON_ProducesValidJSON(t *testing.T) {
+	root := buildSyntheticTree()
+	var buf bytes.Buffer
+	if err := EmitJSON(root, root, Options{Binary: "padtest", MaxDepth: -1}, &buf); err != nil {
+		t.Fatalf("EmitJSON: %v", err)
+	}
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(buf.Bytes(), &parsed); err != nil {
+		t.Fatalf("emitted output is not valid JSON: %v\n%s", err, buf.String())
+	}
+	// Required top-level keys per cmdhelp v0.1 §3.
+	for _, k := range []string{"cmdhelp_version", "binary", "commands"} {
+		if _, ok := parsed[k]; !ok {
+			t.Errorf("emitted JSON missing required top-level key %q", k)
+		}
+	}
+}
+
+func TestEmitJSON_VersionPatternMatchesSpec(t *testing.T) {
+	// Spec §9: cmdhelp_version is MAJOR.MINOR — never includes a PATCH.
+	versionRE := regexp.MustCompile(`^[0-9]+\.[0-9]+$`)
+	if !versionRE.MatchString(Version) {
+		t.Errorf("Version constant %q must match %s (no PATCH per spec §9)", Version, versionRE)
+	}
+}
+
+func TestExitCode_TerseMarshalsAsString(t *testing.T) {
+	code := ExitCode{Description: "ok"}
+	out, err := json.Marshal(code)
+	if err != nil {
+		t.Fatalf("marshal terse exit code: %v", err)
+	}
+	if string(out) != `"ok"` {
+		t.Errorf("terse form should marshal as bare string, got: %s", out)
+	}
+}
+
+func TestExitCode_RichMarshalsAsObject(t *testing.T) {
+	code := ExitCode{When: "validation error", Recovery: "Check args"}
+	out, err := json.Marshal(code)
+	if err != nil {
+		t.Fatalf("marshal rich exit code: %v", err)
+	}
+	// Must be an object, must contain "when".
+	var asObj map[string]interface{}
+	if err := json.Unmarshal(out, &asObj); err != nil {
+		t.Fatalf("rich form not an object: %v", err)
+	}
+	if asObj["when"] != "validation error" {
+		t.Errorf("rich form missing/wrong 'when': %s", out)
+	}
+	if asObj["recovery"] != "Check args" {
+		t.Errorf("rich form missing/wrong 'recovery': %s", out)
+	}
+}
+
+func TestParseExamples_FiltersBlankAndComments(t *testing.T) {
+	in := "  \n  cmd one\n# a comment\n\n  cmd two\n  # also a comment\n"
+	got := parseExamples(in)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 examples, got %d: %+v", len(got), got)
+	}
+	if got[0].Cmd != "cmd one" || got[1].Cmd != "cmd two" {
+		t.Errorf("got %+v, want [cmd one, cmd two]", got)
+	}
+}
+
+func TestMapPflagType_CoversCommonTypes(t *testing.T) {
+	cases := map[string]struct {
+		want       string
+		repeatable bool
+	}{
+		"string":      {"string", false},
+		"int":         {"int", false},
+		"int64":       {"int", false},
+		"float64":     {"float", false},
+		"bool":        {"bool", false},
+		"duration":    {"duration", false},
+		"stringSlice": {"string", true},
+		"stringArray": {"string", true},
+		"boolSlice":   {"bool", true},
+		"weirdType":   {"string", false}, // fallback
+	}
+	for in, want := range cases {
+		got, rep := mapPflagType(in)
+		if got != want.want || rep != want.repeatable {
+			t.Errorf("mapPflagType(%q) = (%q, %v), want (%q, %v)", in, got, rep, want.want, want.repeatable)
+		}
+	}
+}
+
+func keys(m interface{}) []string {
+	switch v := m.(type) {
+	case map[string]Flag:
+		out := make([]string, 0, len(v))
+		for k := range v {
+			out = append(out, k)
+		}
+		return out
+	case map[string]Command:
+		out := make([]string, 0, len(v))
+		for k := range v {
+			out = append(out, k)
+		}
+		return out
+	}
+	return nil
+}

--- a/internal/cmdhelp/types.go
+++ b/internal/cmdhelp/types.go
@@ -1,0 +1,130 @@
+// Package cmdhelp implements the cmdhelp v0.1 wire format
+// (https://getpad.dev/cmdhelp; IDEA-927) for the `pad` CLI.
+//
+// The package walks a cobra command tree and emits a Document conforming
+// to schema/cmdhelp.schema.json. JSON serialization lives in json.go;
+// markdown serialization arrives in TASK-935.
+package cmdhelp
+
+import "encoding/json"
+
+// Version is the cmdhelp wire-format version this package emits.
+// MAJOR.MINOR only — never includes a PATCH component (spec §9).
+const Version = "0.1"
+
+// Document is the top-level cmdhelp envelope. JSON-serializable; field
+// tags match schema/cmdhelp.schema.json exactly. Optional fields use
+// `omitempty` so the emitter does not produce noisy null/empty keys.
+type Document struct {
+	CmdhelpVersion string                     `json:"cmdhelp_version"`
+	Binary         string                     `json:"binary"`
+	Version        string                     `json:"version,omitempty"`
+	Summary        string                     `json:"summary,omitempty"`
+	Homepage       string                     `json:"homepage,omitempty"`
+	GlobalFlags    map[string]Flag            `json:"global_flags,omitempty"`
+	Commands       map[string]Command         `json:"commands"`
+	Schemas        map[string]json.RawMessage `json:"schemas,omitempty"`
+	Context        *Context                   `json:"context,omitempty"`
+}
+
+// Context holds dynamic facts spliced in by CLIs with session state
+// (spec §7). Populated by TASK-936; left nil for static emission.
+type Context struct {
+	Workspace string `json:"workspace,omitempty"`
+	Profile   string `json:"profile,omitempty"`
+	Auth      string `json:"auth,omitempty"`
+}
+
+// Command describes a single command in the tree.
+type Command struct {
+	Summary     string              `json:"summary"`
+	Description string              `json:"description,omitempty"`
+	Args        []Arg               `json:"args,omitempty"`
+	Flags       map[string]Flag     `json:"flags,omitempty"`
+	Stdin       *Stdin              `json:"stdin,omitempty"`
+	Stdout      *Stdout             `json:"stdout,omitempty"`
+	ExitCodes   map[string]ExitCode `json:"exit_codes,omitempty"`
+	Examples    []Example           `json:"examples,omitempty"`
+	SeeAlso     []string            `json:"see_also,omitempty"`
+	Since       string              `json:"since,omitempty"`
+	Stability   string              `json:"stability,omitempty"`
+}
+
+// Arg is a positional argument.
+type Arg struct {
+	Name        string        `json:"name"`
+	Type        string        `json:"type"`
+	Required    bool          `json:"required,omitempty"`
+	Description string        `json:"description,omitempty"`
+	Default     interface{}   `json:"default,omitempty"`
+	Format      string        `json:"format,omitempty"`
+	Repeatable  bool          `json:"repeatable,omitempty"`
+	Enum        []interface{} `json:"enum,omitempty"`
+	EnumSource  string        `json:"enum_source,omitempty"`
+}
+
+// Flag is a flag (option) on a command.
+type Flag struct {
+	Type        string        `json:"type"`
+	Required    bool          `json:"required,omitempty"`
+	Description string        `json:"description,omitempty"`
+	Default     interface{}   `json:"default,omitempty"`
+	Format      string        `json:"format,omitempty"`
+	Repeatable  bool          `json:"repeatable,omitempty"`
+	Enum        []interface{} `json:"enum,omitempty"`
+	EnumSource  string        `json:"enum_source,omitempty"`
+	NegateFlag  string        `json:"negate_flag,omitempty"`
+}
+
+// Stdin describes whether the command accepts stdin.
+type Stdin struct {
+	Accepted bool   `json:"accepted"`
+	Format   string `json:"format,omitempty"`
+}
+
+// Stdout describes the command's success output.
+type Stdout struct {
+	TextTemplate  string `json:"text_template,omitempty"`
+	JSONSchemaRef string `json:"json_schema_ref,omitempty"`
+}
+
+// ExitCode is a string-or-object union (spec §5.2). When only Description
+// is set, it marshals as a bare string ("terse" form). When any of When,
+// Recovery, or MessageTemplate is set, it marshals as an object ("rich"
+// form). The schema's `oneOf: [string, object]` accepts both shapes.
+type ExitCode struct {
+	// Description is the terse-form text. Mutually exclusive with the
+	// rich-form fields below — set Description OR (When [+ Recovery +
+	// MessageTemplate]), not both.
+	Description string `json:"-"`
+
+	When            string `json:"-"`
+	Recovery        string `json:"-"`
+	MessageTemplate string `json:"-"`
+}
+
+// MarshalJSON serializes the union per spec §5.2.
+func (e ExitCode) MarshalJSON() ([]byte, error) {
+	hasRich := e.When != "" || e.Recovery != "" || e.MessageTemplate != ""
+	if e.Description != "" && !hasRich {
+		return json.Marshal(e.Description)
+	}
+	type rich struct {
+		When            string `json:"when,omitempty"`
+		Recovery        string `json:"recovery,omitempty"`
+		MessageTemplate string `json:"message_template,omitempty"`
+	}
+	return json.Marshal(rich{
+		When:            e.When,
+		Recovery:        e.Recovery,
+		MessageTemplate: e.MessageTemplate,
+	})
+}
+
+// Example is a canonical invocation. Same source feeds both --format json
+// and --format md (spec §6); MD rendering wraps cmd in a fenced bash block
+// and renders note as accompanying prose.
+type Example struct {
+	Cmd  string `json:"cmd"`
+	Note string `json:"note,omitempty"`
+}


### PR DESCRIPTION
## Summary

Adds the `internal/cmdhelp` package that walks the cobra command tree and emits a cmdhelp v0.1 Document conforming to `schema/cmdhelp.schema.json` (shipped in #325). Wires it into `cmd/pad/help_cmdhelp.go` so `pad help --format json` is no longer a stub.

## Context

Implements `TASK-934` under `PLAN-930`. Builds on the schema (`TASK-932` / #325) and the routing skeleton (`TASK-933` / #326).

### What this does

- **`internal/cmdhelp/types.go`** — Go structs mirroring the schema. `ExitCode` has custom `MarshalJSON` for the string-or-object union (spec §5.2).
- **`internal/cmdhelp/json.go`** — `Build()` walks target's subtree, returning a `*Document`; `EmitJSON()` serializes to indented JSON. Highlights:
  - Pflag → cmdhelp type mapping covers `string`, `int*`, `uint*`, `float*`, `bool`, `duration`, slice/array variants (→ repeatable), `count`, `ip*`, `bytes*`, with `string` fallback for unknown.
  - Hidden commands and flags filtered. Cobra's `--help` flag suppressed.
  - Zero-default values suppressed (no noisy `""` / `"0"` / `"false"` / `"[]"`).
  - Positional arg parser handles `<required>` and `[optional]` placeholders, filters cobra-conventional `[flags]`/`[options]`/`[command]`.
  - `parseExamples` splits `cmd.Example` by newline, drops blanks and `#` comments.
  - `MaxDepth` semantics match spec §4 (`0` = subcommand list, `1` = + grandchildren, `-1` = unlimited).
- **`cmd/pad/help_cmdhelp.go`** — replaces the JSON stub with a call into the package; threads `--depth` / `--all` through (`--all` overrides `--depth`).

### Schema validation against the real binary

```
pad help --format json | jsonschema validate against schema/cmdhelp.schema.json → VALID
```

- Root scope: 100 commands emitted across the full tree.
- `pad help item --format json`: scoped to the 29 commands under `item`.
- `pad help --format json --depth 0`: 15 immediate children of root only.
- Global flags (`--workspace`, `--format`, `--url`) emitted at top level only — not duplicated per command (verified by test).

## Test plan

- [x] **17 emitter tests** in `internal/cmdhelp/json_test.go` covering: envelope, global-flag emission, hidden-thing exclusion, positional arg parsing, pflag type mapping (every type), zero-default suppression, example parsing, description-vs-summary, command-path key shape, MaxDepth semantics (3 cases), target-subtree scoping, JSON validity, version pattern, ExitCode union marshaling (terse + rich), parseExamples filtering.
- [x] **11 routing tests** in `cmd/pad/help_cmdhelp_test.go` still pass; `TestHelpCmd_FormatJSONStubError` replaced by `TestHelpCmd_FormatJSONEmits` which validates structure (not stub error).
- [x] End-to-end: `pad help --format json` on the real binary validates against the published schema (`schema/cmdhelp.schema.json`).
- [x] Scope routing verified: subtree (`pad help item`) and depth limiting (`--depth 0`) both produce expected subsets.
- [x] `make check` clean (lint + go test + web build).

## Out of scope (deferred)

- **Examples populated for all commands** — pad's existing commands embed examples in `Long` rather than using cobra's `Example` field. The emitter correctly reads `Example`; `TASK-939` will normalize the pad-side commands.
- **Dynamic enum injection** (workspace-aware enums for `collection`, `role`, `assign`): `TASK-936`.
- **`--capabilities` discovery flag**: `TASK-937`.
- **CI schema-validation of live output**: `TASK-938`.