### PR TITLE
feat(cmdhelp): implement --format md emitter (TASK-935)

### DIFF
--- a/cmd/pad/help_cmdhelp.go
+++ b/cmd/pad/help_cmdhelp.go
@@ -119,14 +119,22 @@ func emitCmdhelpJSON(target *cobra.Command, depth int, all bool, w io.Writer) er
 	}, w)
 }
 
-// emitCmdhelpMarkdown is a stub for the cmdhelp v0.1 markdown emitter
-// (also serves --format llm as an alias). The real implementation walks
-// the cobra command tree and writes a document matching the predictable
-// section order in cmdhelp v0.1 §6. Lands in TASK-935.
+// emitCmdhelpMarkdown walks the cobra command tree below `target` and
+// emits a cmdhelp v0.1 markdown document with the predictable section
+// order from spec §6. Also serves `--format llm` as an alias today
+// (reserved for future "best for LLMs" default).
+//
+// `--all` is a convenience alias for unlimited depth (spec §4); when
+// passed it overrides any explicit `--depth=N`.
 func emitCmdhelpMarkdown(target *cobra.Command, depth int, all bool, w io.Writer) error {
-	_ = target
-	_ = depth
-	_ = all
-	_ = w
-	return fmt.Errorf("--format md/llm not yet implemented (cmdhelp v%s markdown emitter — TASK-935)", CmdhelpVersion)
+	maxDepth := depth
+	if all {
+		maxDepth = -1
+	}
+	return cmdhelp.EmitMarkdown(target, target.Root(), cmdhelp.Options{
+		Binary:   target.Root().Name(),
+		Version:  fullVersion(),
+		Homepage: padHomepage,
+		MaxDepth: maxDepth,
+	}, w)
 }

--- a/cmd/pad/help_cmdhelp_test.go
+++ b/cmd/pad/help_cmdhelp_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -130,32 +131,54 @@ func TestHelpCmd_FormatJSONEmits(t *testing.T) {
 	}
 }
 
-func TestHelpCmd_FormatMarkdownStubError(t *testing.T) {
+func TestHelpCmd_FormatMarkdownEmits(t *testing.T) {
+	// TASK-935 replaced the stub with a real emitter. Assert structural
+	// markers — YAML frontmatter, H1, command block — are present.
 	for _, format := range []string{"md", "llm"} {
 		t.Run(format, func(t *testing.T) {
-			_, _, err := runHelp(t, "--format", format)
-			if err == nil {
-				t.Fatalf("expected --format %s to return a stub error (TASK-935 unimplemented)", format)
+			out, _, err := runHelp(t, "--format", format)
+			if err != nil {
+				t.Fatalf("--format %s: unexpected error: %v\n%s", format, err, out)
 			}
-			msg := err.Error()
-			if !strings.Contains(msg, "TASK-935") {
-				t.Errorf("expected --format %s stub error to reference TASK-935, got: %s", format, msg)
+			if !strings.HasPrefix(out, "---\n") {
+				t.Errorf("--format %s: must start with YAML frontmatter, got first line: %q", format, firstLine(out))
+			}
+			for _, want := range []string{
+				`cmdhelp_version: "0.1"`,
+				"binary: padtest",
+				"# padtest",
+				"## `padtest item create`",
+				"### Synopsis",
+			} {
+				if !strings.Contains(out, want) {
+					t.Errorf("--format %s missing %q in output", format, want)
+				}
 			}
 		})
 	}
 }
 
-func TestHelpCmd_FormatLLMAliasRoutesToMarkdown(t *testing.T) {
-	// Both md and llm should produce the same error message body (modulo
-	// "TASK-935") since llm is a renderer-level alias for md.
-	_, _, mdErr := runHelp(t, "--format", "md")
-	_, _, llmErr := runHelp(t, "--format", "llm")
-	if mdErr == nil || llmErr == nil {
-		t.Fatalf("expected both --format md and --format llm to return stub errors")
+func TestHelpCmd_FormatLLMIsAliasForMD(t *testing.T) {
+	// llm and md routes share an emitter; the only legitimate difference
+	// between two consecutive runs is the wall-clock timestamp in the
+	// frontmatter `generated:` field. Normalize that, then expect
+	// byte-identical output.
+	mdOut, _, mdErr := runHelp(t, "--format", "md")
+	llmOut, _, llmErr := runHelp(t, "--format", "llm")
+	if mdErr != nil || llmErr != nil {
+		t.Fatalf("expected both formats to succeed; mdErr=%v llmErr=%v", mdErr, llmErr)
 	}
-	if mdErr.Error() != llmErr.Error() {
-		t.Errorf("expected --format llm to alias --format md (same stub error)\nmd:  %s\nllm: %s", mdErr.Error(), llmErr.Error())
+	tsRE := regexp.MustCompile(`generated: .*`)
+	if tsRE.ReplaceAllString(mdOut, "TS") != tsRE.ReplaceAllString(llmOut, "TS") {
+		t.Errorf("--format md and --format llm should produce identical output (modulo timestamp)")
 	}
+}
+
+func firstLine(s string) string {
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		return s[:i]
+	}
+	return s
 }
 
 func TestHelpCmd_FormatUnknownRejected(t *testing.T) {

--- a/internal/cmdhelp/json.go
+++ b/internal/cmdhelp/json.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -33,6 +34,11 @@ type Options struct {
 	// want the unlimited default MUST pass -1 (or any negative value)
 	// explicitly — see cmd/pad/help_cmdhelp.go for the canonical wiring.
 	MaxDepth int
+
+	// Now overrides time.Now for the markdown emitter's YAML frontmatter
+	// `generated:` field. Useful for snapshot tests that need a stable
+	// timestamp. Leave nil to use the real wall clock (UTC).
+	Now func() time.Time
 }
 
 // EmitJSON walks the command tree below `target`, builds a cmdhelp v0.1

--- a/internal/cmdhelp/md.go
+++ b/internal/cmdhelp/md.go
@@ -1,0 +1,302 @@
+package cmdhelp
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// EmitMarkdown walks the command tree below `target`, builds a cmdhelp
+// v0.1 Document, and writes it to w as a markdown document with the
+// predictable section order from spec §6.
+//
+// `--format llm` is an alias for `--format md` at the routing layer; both
+// reach this function. Callers that need to vary llm-specific behavior
+// in the future can branch upstream — the markdown shape itself is the
+// same regardless of which alias was invoked.
+func EmitMarkdown(target, root *cobra.Command, opts Options, w io.Writer) error {
+	doc := Build(target, root, opts)
+	return RenderMarkdown(doc, opts, w)
+}
+
+// RenderMarkdown writes a Document as markdown matching cmdhelp v0.1 §6.
+// Useful for tests that build a Document manually and want to render it
+// without re-walking a cobra tree.
+func RenderMarkdown(doc *Document, opts Options, w io.Writer) error {
+	now := opts.Now
+	if now == nil {
+		now = time.Now
+	}
+
+	// YAML frontmatter (spec §6).
+	if _, err := fmt.Fprintln(w, "---"); err != nil {
+		return err
+	}
+	fmt.Fprintf(w, "cmdhelp_version: %q\n", doc.CmdhelpVersion)
+	fmt.Fprintf(w, "binary: %s\n", doc.Binary)
+	if doc.Version != "" {
+		fmt.Fprintf(w, "version: %s\n", doc.Version)
+	}
+	fmt.Fprintf(w, "generated: %s\n", now().UTC().Format(time.RFC3339))
+	fmt.Fprintln(w, "---")
+	fmt.Fprintln(w)
+
+	// Top-level binary heading + summary.
+	fmt.Fprintf(w, "# %s\n\n", doc.Binary)
+	if doc.Summary != "" {
+		fmt.Fprintf(w, "%s\n\n", doc.Summary)
+	}
+	if doc.Homepage != "" {
+		fmt.Fprintf(w, "Homepage: <%s>\n\n", doc.Homepage)
+	}
+
+	// Workspace context (dynamic, optional — populated in TASK-936).
+	if ctx := doc.Context; ctx != nil && (ctx.Workspace != "" || ctx.Profile != "" || ctx.Auth != "") {
+		fmt.Fprintln(w, "## Workspace context")
+		fmt.Fprintln(w)
+		if ctx.Workspace != "" {
+			fmt.Fprintf(w, "- workspace: `%s`\n", ctx.Workspace)
+		}
+		if ctx.Profile != "" {
+			fmt.Fprintf(w, "- profile: `%s`\n", ctx.Profile)
+		}
+		if ctx.Auth != "" {
+			fmt.Fprintf(w, "- auth: `%s`\n", ctx.Auth)
+		}
+		fmt.Fprintln(w)
+	}
+
+	// Global flags (emitted once at top level — never duplicated per command).
+	if len(doc.GlobalFlags) > 0 {
+		fmt.Fprintln(w, "## Global flags")
+		fmt.Fprintln(w)
+		writeFlagsTable(w, doc.GlobalFlags)
+		fmt.Fprintln(w)
+	}
+
+	// Commands. Sorted by path for deterministic output (golden snapshots).
+	if len(doc.Commands) > 0 {
+		paths := make([]string, 0, len(doc.Commands))
+		for p := range doc.Commands {
+			paths = append(paths, p)
+		}
+		sort.Strings(paths)
+		for _, p := range paths {
+			renderCommand(w, doc.Binary, p, doc.Commands[p])
+		}
+	}
+	return nil
+}
+
+// renderCommand writes one command's markdown section. Section order
+// matches cmdhelp v0.1 §6 exactly.
+func renderCommand(w io.Writer, binary, path string, cmd Command) {
+	fmt.Fprintf(w, "## `%s %s`\n\n", binary, path)
+
+	if cmd.Summary != "" {
+		fmt.Fprintf(w, "%s\n\n", cmd.Summary)
+	}
+	// Long-form description: only emit when it adds something beyond Summary.
+	if cmd.Description != "" && cmd.Description != cmd.Summary {
+		fmt.Fprintf(w, "%s\n\n", cmd.Description)
+	}
+
+	// 1. Synopsis
+	fmt.Fprintln(w, "### Synopsis")
+	fmt.Fprintln(w)
+	fmt.Fprintf(w, "```\n%s\n```\n\n", renderSynopsis(binary, path, cmd))
+
+	// 2. Arguments
+	if len(cmd.Args) > 0 {
+		fmt.Fprintln(w, "### Arguments")
+		fmt.Fprintln(w)
+		writeArgsTable(w, cmd.Args)
+		fmt.Fprintln(w)
+	}
+
+	// 3. Flags
+	if len(cmd.Flags) > 0 {
+		fmt.Fprintln(w, "### Flags")
+		fmt.Fprintln(w)
+		writeFlagsTable(w, cmd.Flags)
+		fmt.Fprintln(w)
+	}
+
+	// 4. Stdin
+	if cmd.Stdin != nil && cmd.Stdin.Accepted {
+		fmt.Fprintln(w, "### Stdin")
+		fmt.Fprintln(w)
+		if cmd.Stdin.Format != "" {
+			fmt.Fprintf(w, "Accepts stdin (`%s`).\n\n", cmd.Stdin.Format)
+		} else {
+			fmt.Fprintln(w, "Accepts stdin.")
+			fmt.Fprintln(w)
+		}
+	}
+
+	// 5. Examples — same canonical example set as JSON, rendered as
+	//    fenced bash blocks with note as accompanying prose (spec §6).
+	if len(cmd.Examples) > 0 {
+		fmt.Fprintln(w, "### Examples")
+		fmt.Fprintln(w)
+		for _, ex := range cmd.Examples {
+			fmt.Fprintf(w, "```bash\n%s\n```\n\n", ex.Cmd)
+			if ex.Note != "" {
+				fmt.Fprintf(w, "%s\n\n", ex.Note)
+			}
+		}
+	}
+
+	// 6. Output
+	if cmd.Stdout != nil && (cmd.Stdout.TextTemplate != "" || cmd.Stdout.JSONSchemaRef != "") {
+		fmt.Fprintln(w, "### Output")
+		fmt.Fprintln(w)
+		if cmd.Stdout.TextTemplate != "" {
+			fmt.Fprintf(w, "Stdout (text): `%s`\n\n", cmd.Stdout.TextTemplate)
+		}
+		if cmd.Stdout.JSONSchemaRef != "" {
+			fmt.Fprintf(w, "Stdout (`--format json`): schema `%s`\n\n", cmd.Stdout.JSONSchemaRef)
+		}
+	}
+
+	// 7. Exit codes (when present — pad commands don't typically populate
+	//    this yet, but the schema and spec §5.2 support it).
+	if len(cmd.ExitCodes) > 0 {
+		fmt.Fprintln(w, "### Exit codes")
+		fmt.Fprintln(w)
+		writeExitCodesTable(w, cmd.ExitCodes)
+		fmt.Fprintln(w)
+	}
+
+	// 8. See also
+	if len(cmd.SeeAlso) > 0 {
+		fmt.Fprintln(w, "### See also")
+		fmt.Fprintln(w)
+		for _, related := range cmd.SeeAlso {
+			fmt.Fprintf(w, "- `%s`\n", related)
+		}
+		fmt.Fprintln(w)
+	}
+}
+
+// renderSynopsis reconstructs a cobra-style usage line from the
+// Document's structured args + flags. Output looks like:
+//
+//	pad item create <collection> <title> [--priority <value>] [flags]
+//
+// We use the structured Args (not cmd.UseLine()) so the synopsis is
+// driven by the same parsed data the JSON emitter uses — keeping the
+// two formats in lockstep.
+func renderSynopsis(binary, path string, cmd Command) string {
+	parts := []string{binary}
+	if path != "" {
+		parts = append(parts, path)
+	}
+	for _, a := range cmd.Args {
+		var token string
+		if a.Required {
+			token = "<" + a.Name + ">"
+		} else {
+			token = "[" + a.Name + "]"
+		}
+		if a.Repeatable {
+			token += "..."
+		}
+		parts = append(parts, token)
+	}
+	if len(cmd.Flags) > 0 {
+		parts = append(parts, "[flags]")
+	}
+	return strings.Join(parts, " ")
+}
+
+// writeFlagsTable renders a flag map as a markdown table with sorted
+// keys. Repeatable flags are marked in the type column for visibility.
+func writeFlagsTable(w io.Writer, flags map[string]Flag) {
+	fmt.Fprintln(w, "| flag | type | default | description |")
+	fmt.Fprintln(w, "| --- | --- | --- | --- |")
+	names := make([]string, 0, len(flags))
+	for n := range flags {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	for _, n := range names {
+		f := flags[n]
+		typ := f.Type
+		if f.Repeatable {
+			typ += " (repeatable)"
+		}
+		if len(f.Enum) > 0 {
+			vals := make([]string, len(f.Enum))
+			for i, v := range f.Enum {
+				vals[i] = fmt.Sprint(v)
+			}
+			typ = fmt.Sprintf("enum: %s", strings.Join(vals, "\\|"))
+		}
+		def := ""
+		if f.Default != nil {
+			def = fmt.Sprintf("`%v`", f.Default)
+		}
+		fmt.Fprintf(w, "| `--%s` | %s | %s | %s |\n",
+			n, typ, def, escapeTable(f.Description))
+	}
+}
+
+// writeArgsTable renders positional args. Args are emitted in source
+// order (no sorting) so the table reflects invocation order.
+func writeArgsTable(w io.Writer, args []Arg) {
+	fmt.Fprintln(w, "| name | type | required | description |")
+	fmt.Fprintln(w, "| --- | --- | --- | --- |")
+	for _, a := range args {
+		typ := a.Type
+		if a.Repeatable {
+			typ += " (repeatable)"
+		}
+		if len(a.Enum) > 0 {
+			vals := make([]string, len(a.Enum))
+			for i, v := range a.Enum {
+				vals[i] = fmt.Sprint(v)
+			}
+			typ = fmt.Sprintf("enum: %s", strings.Join(vals, "\\|"))
+		}
+		req := "no"
+		if a.Required {
+			req = "yes"
+		}
+		fmt.Fprintf(w, "| `%s` | %s | %s | %s |\n",
+			a.Name, typ, req, escapeTable(a.Description))
+	}
+}
+
+// writeExitCodesTable renders an exit_codes map. Keys are numeric strings
+// from the schema; sort them numerically (best-effort string sort works
+// for sensible exit codes 0-255).
+func writeExitCodesTable(w io.Writer, codes map[string]ExitCode) {
+	fmt.Fprintln(w, "| code | when | recovery |")
+	fmt.Fprintln(w, "| --- | --- | --- |")
+	keys := make([]string, 0, len(codes))
+	for k := range codes {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		c := codes[k]
+		when := c.When
+		if when == "" {
+			when = c.Description
+		}
+		fmt.Fprintf(w, "| `%s` | %s | %s |\n", k, escapeTable(when), escapeTable(c.Recovery))
+	}
+}
+
+// escapeTable replaces newlines and pipes so a value can sit in a
+// markdown table cell without breaking the table grid.
+func escapeTable(s string) string {
+	s = strings.ReplaceAll(s, "\n", " ")
+	s = strings.ReplaceAll(s, "|", `\|`)
+	return strings.TrimSpace(s)
+}

--- a/internal/cmdhelp/md_test.go
+++ b/internal/cmdhelp/md_test.go
@@ -1,0 +1,377 @@
+package cmdhelp
+
+import (
+	"bytes"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fixedClock returns a deterministic time for snapshot stability.
+func fixedClock() time.Time {
+	return time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+}
+
+// renderMD is a small test helper that builds + renders the synthetic
+// tree with a fixed clock and returns the markdown output as a string.
+func renderMD(t *testing.T, opts Options) string {
+	t.Helper()
+	root := buildSyntheticTree()
+	if opts.Binary == "" {
+		opts.Binary = "padtest"
+	}
+	if opts.Now == nil {
+		opts.Now = fixedClock
+	}
+	if opts.MaxDepth == 0 {
+		opts.MaxDepth = -1
+	}
+	var buf bytes.Buffer
+	if err := EmitMarkdown(root, root, opts, &buf); err != nil {
+		t.Fatalf("EmitMarkdown: %v", err)
+	}
+	return buf.String()
+}
+
+func TestRenderMarkdown_Frontmatter(t *testing.T) {
+	out := renderMD(t, Options{
+		Binary:  "padtest",
+		Version: "9.9.9",
+	})
+	// Frontmatter must be the first thing in the document.
+	if !strings.HasPrefix(out, "---\n") {
+		t.Fatalf("output must start with YAML frontmatter, got first line: %q", firstLine(out))
+	}
+	want := []string{
+		`cmdhelp_version: "0.1"`,
+		"binary: padtest",
+		"version: 9.9.9",
+		"generated: 2026-05-01T12:00:00Z",
+	}
+	for _, w := range want {
+		if !strings.Contains(out, w) {
+			t.Errorf("frontmatter missing %q\noutput head:\n%s", w, head(out, 10))
+		}
+	}
+	// Closing frontmatter delimiter present.
+	if !strings.Contains(out, "\n---\n\n# padtest") {
+		t.Errorf("closing frontmatter delimiter missing or H1 not immediately after")
+	}
+}
+
+func TestRenderMarkdown_FrontmatterTimestampOverridable(t *testing.T) {
+	// Inject a different clock and verify the timestamp follows.
+	custom := func() time.Time {
+		return time.Date(2030, 1, 1, 0, 0, 0, 0, time.UTC)
+	}
+	out := renderMD(t, Options{Now: custom})
+	if !strings.Contains(out, "generated: 2030-01-01T00:00:00Z") {
+		t.Errorf("expected injected timestamp in frontmatter; first 10 lines:\n%s", head(out, 10))
+	}
+}
+
+func TestRenderMarkdown_SectionOrder(t *testing.T) {
+	// Per spec §6, per-command section order is:
+	//   ## `cmd`
+	//   summary
+	//   ### Synopsis
+	//   ### Arguments
+	//   ### Flags
+	//   ### Stdin (when applicable)
+	//   ### Examples
+	//   ### Output
+	//   ### See also
+	//
+	// Use the synthetic `item create` block — it has args, flags, and
+	// examples, so we can assert the ordering of those sections.
+	out := renderMD(t, Options{})
+	itemBlock := extractCommandBlock(out, "item create")
+	if itemBlock == "" {
+		t.Fatalf("could not locate `item create` block in output:\n%s", head(out, 30))
+	}
+
+	wantOrder := []string{
+		"## `padtest item create`",
+		"### Synopsis",
+		"### Arguments",
+		"### Flags",
+		"### Examples",
+	}
+	last := -1
+	for _, marker := range wantOrder {
+		idx := strings.Index(itemBlock, marker)
+		if idx < 0 {
+			t.Errorf("section %q missing from item-create block", marker)
+			continue
+		}
+		if idx <= last {
+			t.Errorf("section %q at index %d does not follow previous section (idx %d) — wrong order:\n%s",
+				marker, idx, last, itemBlock)
+		}
+		last = idx
+	}
+}
+
+func TestRenderMarkdown_SynopsisIncludesArgsAndFlagsHint(t *testing.T) {
+	out := renderMD(t, Options{})
+	itemBlock := extractCommandBlock(out, "item create")
+
+	// Synopsis fence must contain the binary, command path, and arg tokens.
+	wantIn := []string{
+		"```\npadtest item create",
+		"<collection>",
+		"<title>",
+		"[flags]", // because the command has flags
+	}
+	for _, w := range wantIn {
+		if !strings.Contains(itemBlock, w) {
+			t.Errorf("synopsis missing %q in:\n%s", w, itemBlock)
+		}
+	}
+}
+
+func TestRenderMarkdown_VariadicSynopsis(t *testing.T) {
+	out := renderMD(t, Options{})
+	bulkBlock := extractCommandBlock(out, "item bulk-update")
+	if !strings.Contains(bulkBlock, "<ref>...") {
+		t.Errorf("variadic <ref>... should appear in synopsis; block was:\n%s", bulkBlock)
+	}
+}
+
+func TestRenderMarkdown_AlternationAsEnum(t *testing.T) {
+	out := renderMD(t, Options{})
+	completionBlock := extractCommandBlock(out, "item completion")
+	// Alternation arg is rendered as enum: bash\|zsh\|fish\|powershell
+	if !strings.Contains(completionBlock, "bash") || !strings.Contains(completionBlock, "powershell") {
+		t.Errorf("expected enum values from alternation in arguments table; block:\n%s", completionBlock)
+	}
+}
+
+func TestRenderMarkdown_GlobalFlagsTopLevelOnly(t *testing.T) {
+	out := renderMD(t, Options{})
+	// A "## Global flags" heading should appear.
+	if !strings.Contains(out, "## Global flags") {
+		t.Errorf("expected '## Global flags' heading at top level")
+	}
+	// The global flag --workspace should appear under the top-level
+	// section, not in any per-command Flags block.
+	for _, name := range []string{"item", "item create", "item update", "deep nest leaf"} {
+		block := extractCommandBlock(out, name)
+		if block == "" {
+			continue
+		}
+		// It's fine for the per-command block to NOT have a Flags table
+		// at all; we just want to make sure --workspace is not in it.
+		if strings.Contains(block, "`--workspace`") {
+			t.Errorf("global flag --workspace must not be duplicated in `%s` block", name)
+		}
+	}
+}
+
+func TestRenderMarkdown_ExamplesAsFencedBash(t *testing.T) {
+	out := renderMD(t, Options{})
+	itemBlock := extractCommandBlock(out, "item create")
+
+	if !strings.Contains(itemBlock, "### Examples") {
+		t.Fatalf("Examples section missing from item-create block")
+	}
+	// The synthetic tree's Example field has two non-comment lines.
+	// Each should be rendered as a separate ```bash ... ``` block.
+	count := strings.Count(itemBlock, "```bash\n")
+	if count < 2 {
+		t.Errorf("expected at least 2 fenced bash example blocks, got %d", count)
+	}
+	if !strings.Contains(itemBlock, "Fix OAuth") {
+		t.Errorf("expected first example to mention Fix OAuth")
+	}
+	// Comment line from the synthetic Example field must NOT leak.
+	if strings.Contains(itemBlock, "comment line should be skipped") {
+		t.Errorf("comment line leaked into rendered example block")
+	}
+}
+
+func TestRenderMarkdown_HiddenItemsExcluded(t *testing.T) {
+	out := renderMD(t, Options{})
+	if strings.Contains(out, "## `padtest secret`") {
+		t.Errorf("hidden 'secret' command leaked into markdown output")
+	}
+	if strings.Contains(out, "internal-debug") {
+		t.Errorf("hidden flag --internal-debug leaked into markdown output")
+	}
+}
+
+func TestRenderMarkdown_DeterministicCommandOrder(t *testing.T) {
+	// Two consecutive renders with the same fixed clock must produce
+	// byte-identical output (commands sorted by path).
+	a := renderMD(t, Options{})
+	b := renderMD(t, Options{})
+	if a != b {
+		t.Errorf("two renders with the same fixed clock must be byte-identical (commands not sorted?)\n--- A ---\n%s\n--- B ---\n%s", head(a, 20), head(b, 20))
+	}
+}
+
+func TestRenderMarkdown_StdinSection(t *testing.T) {
+	// Build a small Document directly and verify the Stdin section
+	// renders. We don't use the synthetic tree because cobra has no
+	// machine-readable hint that a command accepts stdin; the Stdin
+	// field on Command is populated explicitly by callers (TASK-936/938).
+	doc := &Document{
+		CmdhelpVersion: Version,
+		Binary:         "demo",
+		Commands: map[string]Command{
+			"create": {
+				Summary: "create",
+				Stdin:   &Stdin{Accepted: true, Format: "text/markdown"},
+			},
+		},
+	}
+	var buf bytes.Buffer
+	if err := RenderMarkdown(doc, Options{Now: fixedClock}, &buf); err != nil {
+		t.Fatalf("RenderMarkdown: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "### Stdin") {
+		t.Errorf("Stdin section missing")
+	}
+	if !strings.Contains(out, "text/markdown") {
+		t.Errorf("Stdin format hint missing")
+	}
+}
+
+func TestRenderMarkdown_OutputAndExitCodesSections(t *testing.T) {
+	doc := &Document{
+		CmdhelpVersion: Version,
+		Binary:         "demo",
+		Commands: map[string]Command{
+			"create": {
+				Summary: "create",
+				Stdout:  &Stdout{TextTemplate: "Created {ref}", JSONSchemaRef: "#/schemas/Item"},
+				ExitCodes: map[string]ExitCode{
+					"0": {Description: "ok"},
+					"2": {When: "validation error", Recovery: "Check args"},
+				},
+			},
+		},
+	}
+	var buf bytes.Buffer
+	if err := RenderMarkdown(doc, Options{Now: fixedClock}, &buf); err != nil {
+		t.Fatalf("RenderMarkdown: %v", err)
+	}
+	out := buf.String()
+
+	if !strings.Contains(out, "### Output") {
+		t.Errorf("Output section missing")
+	}
+	if !strings.Contains(out, "Created {ref}") {
+		t.Errorf("text_template missing from Output section")
+	}
+	if !strings.Contains(out, "#/schemas/Item") {
+		t.Errorf("json_schema_ref missing from Output section")
+	}
+	if !strings.Contains(out, "### Exit codes") {
+		t.Errorf("Exit codes section missing")
+	}
+	if !strings.Contains(out, "validation error") {
+		t.Errorf("Exit codes table missing 'when' for code 2")
+	}
+}
+
+func TestRenderMarkdown_WorkspaceContextSection(t *testing.T) {
+	doc := &Document{
+		CmdhelpVersion: Version,
+		Binary:         "demo",
+		Commands:       map[string]Command{},
+		Context:        &Context{Workspace: "docapp", Profile: "default"},
+	}
+	var buf bytes.Buffer
+	if err := RenderMarkdown(doc, Options{Now: fixedClock}, &buf); err != nil {
+		t.Fatalf("RenderMarkdown: %v", err)
+	}
+	out := buf.String()
+
+	if !strings.Contains(out, "## Workspace context") {
+		t.Errorf("Workspace context section missing when Context is populated")
+	}
+	if !strings.Contains(out, "workspace: `docapp`") {
+		t.Errorf("workspace value missing")
+	}
+}
+
+func TestRenderMarkdown_SeeAlso(t *testing.T) {
+	doc := &Document{
+		CmdhelpVersion: Version,
+		Binary:         "demo",
+		Commands: map[string]Command{
+			"create": {
+				Summary: "create",
+				SeeAlso: []string{"item update", "item delete"},
+			},
+		},
+	}
+	var buf bytes.Buffer
+	if err := RenderMarkdown(doc, Options{Now: fixedClock}, &buf); err != nil {
+		t.Fatalf("RenderMarkdown: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "### See also") {
+		t.Errorf("See also section missing")
+	}
+	if !strings.Contains(out, "`item update`") || !strings.Contains(out, "`item delete`") {
+		t.Errorf("see_also entries missing from output")
+	}
+}
+
+func TestRenderMarkdown_EscapesPipeInTableCell(t *testing.T) {
+	// Flag descriptions containing `|` would otherwise break a markdown
+	// table; verify they're escaped.
+	doc := &Document{
+		CmdhelpVersion: Version,
+		Binary:         "demo",
+		Commands: map[string]Command{
+			"f": {
+				Summary: "flag stress",
+				Flags: map[string]Flag{
+					"weird": {Type: "string", Description: "value | with | pipes"},
+				},
+			},
+		},
+	}
+	var buf bytes.Buffer
+	if err := RenderMarkdown(doc, Options{Now: fixedClock}, &buf); err != nil {
+		t.Fatalf("RenderMarkdown: %v", err)
+	}
+	if strings.Contains(buf.String(), "value | with | pipes") {
+		t.Errorf("pipes in description not escaped — table grid will break")
+	}
+	if !strings.Contains(buf.String(), `value \| with \| pipes`) {
+		t.Errorf("expected escaped pipes in description")
+	}
+}
+
+// extractCommandBlock returns the substring of `md` covering one
+// command's section, identified by its full path (e.g. "item create").
+// Used to scope assertions to a single command rather than the whole
+// document.
+func extractCommandBlock(md, path string) string {
+	heading := "## `padtest " + path + "`"
+	idx := strings.Index(md, heading)
+	if idx < 0 {
+		return ""
+	}
+	rest := md[idx+len(heading):]
+	// Block ends at the next `## ` heading at the same level.
+	next := regexp.MustCompile(`(?m)^## `)
+	if loc := next.FindStringIndex(rest); loc != nil {
+		return md[idx : idx+len(heading)+loc[0]]
+	}
+	return md[idx:]
+}
+
+func head(s string, lines int) string {
+	parts := strings.SplitN(s, "\n", lines+1)
+	if len(parts) > lines {
+		parts = parts[:lines]
+	}
+	return strings.Join(parts, "\n")
+}


### PR DESCRIPTION
## Summary

Adds `internal/cmdhelp/md.go` that renders the `Document` built in TASK-934 as markdown with the predictable section order from cmdhelp v0.1 §6. Replaces the markdown stub in `cmd/pad/help_cmdhelp.go` so `pad help --format md` and `pad help --format llm` (alias) produce real output.

## Context

Implements `TASK-935` under `PLAN-930`. Builds on the JSON emitter (`TASK-934` / #327) — both formats share `Build()`, so spec changes to the underlying Document propagate to both outputs by construction.

### Per-command section order (spec §6)

```
## `binary path`
summary  /  description
### Synopsis           ← fenced usage line, reconstructed from structured args+flags
### Arguments          ← table: name | type | required | description
### Flags              ← table: flag | type | default | description
### Stdin              ← when Stdin.Accepted
### Examples           ← fenced bash blocks (same canonical set as JSON)
### Output             ← text_template + json_schema_ref
### Exit codes         ← table when populated
### See also           ← bullet list of related command paths
```

### Top-level structure

- YAML frontmatter (`cmdhelp_version`, `binary`, `version`, `generated`)
- `# binary` heading + summary + homepage
- `## Workspace context` (when `Context` is populated — TASK-936)
- `## Global flags` table (top-level only — never duplicated per command)
- Per-command sections, sorted by path for deterministic output

### Design choices

- **Synopsis reconstructed from structured args** rather than `cmd.UseLine()` so JSON and MD stay driven by the same parsed data. Variadic `<ref>...` and alternation enums from TASK-934 carry through naturally.
- **`Options.Now` injectable** for snapshot-test stability — defaults to wall-clock UTC.
- **Pipes in descriptions escaped** (`\|`) so they don't break markdown table grids.
- **Sorted output** — commands by path, flag tables by name — for byte-deterministic snapshots.

## Test plan

- [x] **15 markdown emitter tests** in `internal/cmdhelp/md_test.go`:
  - YAML frontmatter (presence + timestamp injectability)
  - Per-command section order
  - Synopsis reconstruction (incl. variadic `<ref>...` + alternation enums)
  - Global-flag dedup
  - Fenced bash examples (multi-example, comment lines filtered)
  - Hidden command/flag exclusion
  - Deterministic ordering across consecutive renders
  - Stdin / Output / Exit codes / See also / Workspace context sections
  - Table-pipe escaping
- [x] **`TestHelpCmd_FormatMarkdownStubError` → `TestHelpCmd_FormatMarkdownEmits`** — structural assertions for both md and llm.
- [x] **`TestHelpCmd_FormatLLMIsAliasForMD`** — byte-equality after timestamp normalization.
- [x] **End-to-end on real binary**: `pad help --format md`, `pad help --format llm`, scoped `pad help item create --format md`, all valid; md/llm byte-identical modulo timestamp.
- [x] `make check` clean (lint + go test + web build).

## Out of scope (deferred)

- **Dynamic Workspace context population** — `TASK-936`.
- **`--capabilities` discovery flag** — `TASK-937`.
- **Schema-validation + golden-file tests in CI** — `TASK-938`.
- **Examples populated for every pad command** — `TASK-939`.