### PR TITLE
feat(cmdhelp): dynamic enum resolution + workspace context (TASK-936)

### DIFF
--- a/cmd/pad/help_cmdhelp.go
+++ b/cmd/pad/help_cmdhelp.go
@@ -174,14 +174,35 @@ func newDynamicResolver() *cmdhelp.Resolver {
 
 	client := cli.NewClientFromURL(cfg.BaseURL())
 
+	// Per-command bindings: --role and --assign only resolve to agent
+	// roles / workspace members on commands where that's their actual
+	// semantic. They MUST NOT bind globally because:
+	//
+	//   pad workspace invite --role         # workspace role: owner|editor|viewer
+	//   pad item create     --role <slug>   # agent role slug
+	//   pad item update     --role <slug>   # agent role slug
+	//   pad item create     --assign <user> # workspace member
+	//   pad item update     --assign <user> # workspace member
+	//   pad item list       --assign <user> # workspace member (filter)
+	//
+	// `--role` on `workspace invite` is intentionally left without a
+	// dynamic binding so help correctly reflects the static workspace-
+	// role enum (owner/editor/viewer) rather than agent role slugs.
+	itemRoleAssign := map[string]string{
+		"role":   cmdhelp.EnumSourceRoles,
+		"assign": cmdhelp.EnumSourceMembers,
+	}
 	return &cmdhelp.Resolver{
 		Workspace: ws,
+		// `<collection>` is unambiguous across the entire CLI — every
+		// instance refers to a pad collection. Safe to bind globally.
 		ArgEnumSources: map[string]string{
 			"collection": cmdhelp.EnumSourceCollections,
 		},
-		FlagEnumSources: map[string]string{
-			"role":   cmdhelp.EnumSourceRoles,
-			"assign": cmdhelp.EnumSourceMembers,
+		CommandFlagBindings: map[string]map[string]string{
+			"item create": itemRoleAssign,
+			"item update": itemRoleAssign,
+			"item list":   {"assign": cmdhelp.EnumSourceMembers},
 		},
 		Sources: map[string]cmdhelp.DynamicEnum{
 			cmdhelp.EnumSourceCollections: func() ([]interface{}, error) {

--- a/cmd/pad/help_cmdhelp.go
+++ b/cmd/pad/help_cmdhelp.go
@@ -179,15 +179,19 @@ func newDynamicResolver() *cmdhelp.Resolver {
 	// semantic. They MUST NOT bind globally because:
 	//
 	//   pad workspace invite --role         # workspace role: owner|editor|viewer
-	//   pad item create     --role <slug>   # agent role slug
-	//   pad item update     --role <slug>   # agent role slug
-	//   pad item create     --assign <user> # workspace member
-	//   pad item update     --assign <user> # workspace member
-	//   pad item list       --assign <user> # workspace member (filter)
+	//   pad item create      --role <slug>  # agent role slug
+	//   pad item update      --role <slug>  # agent role slug
+	//   pad item list        --role <slug>  # agent role filter
+	//   pad item create      --assign <u>   # workspace member
+	//   pad item update      --assign <u>   # workspace member
+	//   pad item list        --assign <u>   # workspace member (filter)
 	//
 	// `--role` on `workspace invite` is intentionally left without a
 	// dynamic binding so help correctly reflects the static workspace-
 	// role enum (owner/editor/viewer) rather than agent role slugs.
+	//
+	// To find new sites if this comment goes stale:
+	//   grep -nE 'Flags\(\)\.StringVar\([^,]+,\s*"(role|assign)"' cmd/pad/main.go
 	itemRoleAssign := map[string]string{
 		"role":   cmdhelp.EnumSourceRoles,
 		"assign": cmdhelp.EnumSourceMembers,
@@ -202,7 +206,7 @@ func newDynamicResolver() *cmdhelp.Resolver {
 		CommandFlagBindings: map[string]map[string]string{
 			"item create": itemRoleAssign,
 			"item update": itemRoleAssign,
-			"item list":   {"assign": cmdhelp.EnumSourceMembers},
+			"item list":   itemRoleAssign,
 		},
 		Sources: map[string]cmdhelp.DynamicEnum{
 			cmdhelp.EnumSourceCollections: func() ([]interface{}, error) {

--- a/cmd/pad/help_cmdhelp.go
+++ b/cmd/pad/help_cmdhelp.go
@@ -7,7 +7,9 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/PerpetualSoftware/pad/internal/cli"
 	"github.com/PerpetualSoftware/pad/internal/cmdhelp"
+	"github.com/PerpetualSoftware/pad/internal/config"
 )
 
 // CmdhelpVersion is the cmdhelp wire-format version this binary advertises.
@@ -101,22 +103,34 @@ Scope:
 	return cmd
 }
 
+// cmdhelpOptions builds the Options struct shared by JSON and markdown
+// emitters. Centralized so both formats see the same dynamic resolver,
+// version metadata, and homepage.
+//
+// Binary is derived from the root command's name rather than hardcoded
+// so tests constructing a synthetic root (e.g. "padtest") get a
+// document keyed to that name.
+func cmdhelpOptions(target *cobra.Command, depth int, all bool) cmdhelp.Options {
+	maxDepth := depth
+	if all {
+		maxDepth = -1
+	}
+	return cmdhelp.Options{
+		Binary:   target.Root().Name(),
+		Version:  fullVersion(),
+		Homepage: padHomepage,
+		MaxDepth: maxDepth,
+		Resolver: newDynamicResolver(),
+	}
+}
+
 // emitCmdhelpJSON walks the cobra command tree below `target` and emits
 // a cmdhelp v0.1 JSON document matching schema/cmdhelp.schema.json.
 //
 // `--all` is a convenience alias for unlimited depth (spec §4); when
 // passed it overrides any explicit `--depth=N`.
 func emitCmdhelpJSON(target *cobra.Command, depth int, all bool, w io.Writer) error {
-	maxDepth := depth
-	if all {
-		maxDepth = -1
-	}
-	return cmdhelp.EmitJSON(target, target.Root(), cmdhelp.Options{
-		Binary:   target.Root().Name(),
-		Version:  fullVersion(),
-		Homepage: padHomepage,
-		MaxDepth: maxDepth,
-	}, w)
+	return cmdhelp.EmitJSON(target, target.Root(), cmdhelpOptions(target, depth, all), w)
 }
 
 // emitCmdhelpMarkdown walks the cobra command tree below `target` and
@@ -127,14 +141,88 @@ func emitCmdhelpJSON(target *cobra.Command, depth int, all bool, w io.Writer) er
 // `--all` is a convenience alias for unlimited depth (spec §4); when
 // passed it overrides any explicit `--depth=N`.
 func emitCmdhelpMarkdown(target *cobra.Command, depth int, all bool, w io.Writer) error {
-	maxDepth := depth
-	if all {
-		maxDepth = -1
+	return cmdhelp.EmitMarkdown(target, target.Root(), cmdhelpOptions(target, depth, all), w)
+}
+
+// newDynamicResolver constructs a cmdhelp.Resolver bound to the current
+// pad runtime: workspace, configured server URL, and credentials.
+//
+// Returns nil whenever the runtime is unavailable — no config, no
+// workspace detected, or any error during detection. nil disables
+// dynamic resolution entirely; the help command emits a purely static
+// document. This is the right behavior because `pad help` MUST work
+// even when pad isn't authenticated, the server isn't running, or the
+// invocation happens outside any workspace.
+//
+// Per-source failures (server unreachable, auth missing) are handled
+// inside the resolver itself: enum_source is announced on the binding
+// arg/flag but Enum is left empty.
+func newDynamicResolver() *cmdhelp.Resolver {
+	cfg, err := config.Load()
+	if err != nil || !cfg.IsConfigured() {
+		return nil
 	}
-	return cmdhelp.EmitMarkdown(target, target.Root(), cmdhelp.Options{
-		Binary:   target.Root().Name(),
-		Version:  fullVersion(),
-		Homepage: padHomepage,
-		MaxDepth: maxDepth,
-	}, w)
+	if urlFlag != "" {
+		cfg.URL = urlFlag
+		cfg.LoadedFromFlags = true
+	}
+
+	ws, err := cli.DetectWorkspace(workspaceFlag)
+	if err != nil || ws == "" {
+		return nil
+	}
+
+	client := cli.NewClientFromURL(cfg.BaseURL())
+
+	return &cmdhelp.Resolver{
+		Workspace: ws,
+		ArgEnumSources: map[string]string{
+			"collection": cmdhelp.EnumSourceCollections,
+		},
+		FlagEnumSources: map[string]string{
+			"role":   cmdhelp.EnumSourceRoles,
+			"assign": cmdhelp.EnumSourceMembers,
+		},
+		Sources: map[string]cmdhelp.DynamicEnum{
+			cmdhelp.EnumSourceCollections: func() ([]interface{}, error) {
+				cols, err := client.ListCollections(ws)
+				if err != nil {
+					return nil, err
+				}
+				out := make([]interface{}, 0, len(cols))
+				for _, c := range cols {
+					out = append(out, c.Slug)
+				}
+				return out, nil
+			},
+			cmdhelp.EnumSourceRoles: func() ([]interface{}, error) {
+				roles, err := client.ListAgentRoles(ws)
+				if err != nil {
+					return nil, err
+				}
+				out := make([]interface{}, 0, len(roles))
+				for _, r := range roles {
+					out = append(out, r.Slug)
+				}
+				return out, nil
+			},
+			cmdhelp.EnumSourceMembers: func() ([]interface{}, error) {
+				members, err := client.ListWorkspaceMembers(ws)
+				if err != nil {
+					return nil, err
+				}
+				out := make([]interface{}, 0, len(members))
+				for _, m := range members {
+					if m.UserUsername != "" {
+						out = append(out, m.UserUsername)
+					} else if m.UserName != "" {
+						out = append(out, m.UserName)
+					} else if m.UserEmail != "" {
+						out = append(out, m.UserEmail)
+					}
+				}
+				return out, nil
+			},
+		},
+	}
 }

--- a/internal/cmdhelp/dynamic.go
+++ b/internal/cmdhelp/dynamic.go
@@ -1,0 +1,151 @@
+package cmdhelp
+
+import "strings"
+
+// Canonical enum_source identifiers for the dynamic facts pad's CLI
+// can splice into help output. Format: "dynamic:<command>" per spec §7.
+//
+// New tools adding cmdhelp may declare their own dynamic sources;
+// these constants are pad-flavored and live here so the cli layer and
+// tests reference them via stable names.
+const (
+	EnumSourceCollections = "dynamic:pad collection list"
+	EnumSourceRoles       = "dynamic:pad role list"
+	EnumSourceMembers     = "dynamic:pad workspace members"
+)
+
+// DynamicEnum resolves a single enum_source to its current values.
+// Implementations close over a CLI client; see cmd/pad/help_cmdhelp.go
+// for pad's wiring.
+//
+// Returning (nil, error) is treated as "no values available" — the
+// document still announces enum_source so consumers know the binding,
+// but Enum is left empty. This is the right behavior when the server
+// is unreachable or auth is missing: the help command MUST NOT fail
+// just because dynamic facts can't be fetched.
+type DynamicEnum func() ([]interface{}, error)
+
+// Resolver maps known arg/flag names to dynamic enum sources, plus the
+// resolver functions that fetch live values for each source. It's
+// passed via Options.Resolver and applied by Build after the static
+// document is constructed.
+//
+// All maps use lowercase keys; lookups are case-insensitive.
+type Resolver struct {
+	// Workspace, when non-empty, populates doc.Context.Workspace so
+	// markdown's `## Workspace context` section has something to render.
+	Workspace string
+
+	// ArgEnumSources binds positional arg names to enum_source.
+	// Example: {"collection": EnumSourceCollections}.
+	ArgEnumSources map[string]string
+
+	// FlagEnumSources binds flag names to enum_source.
+	// Example: {"role": EnumSourceRoles, "assign": EnumSourceMembers}.
+	FlagEnumSources map[string]string
+
+	// Sources maps enum_source string → resolver function. Functions
+	// are called at most once per Apply call (results cached internally).
+	Sources map[string]DynamicEnum
+}
+
+// Apply walks doc and stamps EnumSource + resolved Enum values on
+// matching args and flags. Resolution failures are silent: the document
+// continues to advertise enum_source even when no values are available,
+// so consumers can fall back to invoking the dynamic command themselves.
+//
+// Apply is a no-op when r is nil — callers may pass nil from
+// Options.Resolver to disable dynamic resolution entirely.
+func (r *Resolver) Apply(doc *Document) {
+	if r == nil || doc == nil {
+		return
+	}
+
+	// Per-Apply cache: each enum_source resolved at most once even when
+	// many commands reference it (e.g. every `item` subcommand has a
+	// `collection` arg).
+	cache := make(map[string][]interface{}, len(r.Sources))
+	resolve := func(src string) []interface{} {
+		if cached, ok := cache[src]; ok {
+			return cached
+		}
+		fn, ok := r.Sources[src]
+		if !ok {
+			cache[src] = nil
+			return nil
+		}
+		values, err := fn()
+		if err != nil {
+			values = nil
+		}
+		cache[src] = values
+		return values
+	}
+
+	// Global flags first — same lookup rules as per-command flags.
+	for name, f := range doc.GlobalFlags {
+		src, ok := r.FlagEnumSources[strings.ToLower(name)]
+		if !ok {
+			continue
+		}
+		f.EnumSource = src
+		values := resolve(src)
+		if len(values) > 0 && len(f.Enum) == 0 {
+			f.Enum = values
+			if f.Type == "string" {
+				f.Type = "enum"
+			}
+		}
+		doc.GlobalFlags[name] = f
+	}
+
+	for path, cmd := range doc.Commands {
+		// Args: in-place via index since cmd.Args is a slice value
+		// inside the map's struct value.
+		for i := range cmd.Args {
+			src, ok := r.ArgEnumSources[strings.ToLower(cmd.Args[i].Name)]
+			if !ok {
+				continue
+			}
+			cmd.Args[i].EnumSource = src
+			values := resolve(src)
+			// Don't replace existing Enum values from alternation /
+			// ValidArgs — those are the authoritative spec for that arg
+			// and dynamic resolution is only meant to fill the gap.
+			if len(values) > 0 && len(cmd.Args[i].Enum) == 0 {
+				cmd.Args[i].Enum = values
+				// Upgrade type from generic string → enum, but preserve
+				// any non-string type that was set deliberately upstream.
+				if cmd.Args[i].Type == "string" {
+					cmd.Args[i].Type = "enum"
+				}
+			}
+		}
+		// Flags: map values must be re-stored after mutation (Go map
+		// values are not addressable).
+		for name, f := range cmd.Flags {
+			src, ok := r.FlagEnumSources[strings.ToLower(name)]
+			if !ok {
+				continue
+			}
+			f.EnumSource = src
+			values := resolve(src)
+			if len(values) > 0 && len(f.Enum) == 0 {
+				f.Enum = values
+				if f.Type == "string" {
+					f.Type = "enum"
+				}
+			}
+			cmd.Flags[name] = f
+		}
+		doc.Commands[path] = cmd
+	}
+
+	// Workspace context for markdown's ## Workspace context section.
+	if r.Workspace != "" {
+		if doc.Context == nil {
+			doc.Context = &Context{}
+		}
+		doc.Context.Workspace = r.Workspace
+	}
+}

--- a/internal/cmdhelp/dynamic.go
+++ b/internal/cmdhelp/dynamic.go
@@ -31,22 +31,76 @@ type DynamicEnum func() ([]interface{}, error)
 // document is constructed.
 //
 // All maps use lowercase keys; lookups are case-insensitive.
+//
+// Two binding scopes are supported:
+//
+//  1. **Wildcard** (ArgEnumSources / FlagEnumSources) — applied to
+//     every command. Use only when the arg/flag name has a unique
+//     semantic across the entire CLI (e.g. an `<collection>` arg
+//     always refers to a pad collection regardless of which command
+//     declares it).
+//
+//  2. **Per-command** (CommandArgBindings / CommandFlagBindings) —
+//     scoped to a specific command path. Use whenever the same name
+//     can mean different things in different places — for example
+//     `--role` accepts agent-role slugs on item commands but accepts
+//     workspace roles (owner / editor / viewer) on `workspace invite`.
+//
+// Per-command bindings win over wildcards when both match.
 type Resolver struct {
 	// Workspace, when non-empty, populates doc.Context.Workspace so
 	// markdown's `## Workspace context` section has something to render.
 	Workspace string
 
-	// ArgEnumSources binds positional arg names to enum_source.
+	// ArgEnumSources binds positional arg names to enum_source globally.
 	// Example: {"collection": EnumSourceCollections}.
 	ArgEnumSources map[string]string
 
-	// FlagEnumSources binds flag names to enum_source.
-	// Example: {"role": EnumSourceRoles, "assign": EnumSourceMembers}.
+	// FlagEnumSources binds flag names to enum_source globally.
+	// Use cautiously: a single name often means different things on
+	// different commands. Prefer CommandFlagBindings unless you've
+	// verified the name is unambiguous across the entire CLI.
 	FlagEnumSources map[string]string
+
+	// CommandArgBindings: per-command-path overrides for positional args.
+	// Outer key is the command path (e.g. "item create"); inner key is
+	// arg name. Wins over ArgEnumSources when both match.
+	CommandArgBindings map[string]map[string]string
+
+	// CommandFlagBindings: per-command-path overrides for flags.
+	// Outer key is the command path (e.g. "item create"); inner key is
+	// flag name. Wins over FlagEnumSources when both match.
+	CommandFlagBindings map[string]map[string]string
 
 	// Sources maps enum_source string → resolver function. Functions
 	// are called at most once per Apply call (results cached internally).
 	Sources map[string]DynamicEnum
+}
+
+// argSource looks up the enum_source for a positional arg on the
+// given command path. Returns ("", false) when no binding applies.
+func (r *Resolver) argSource(path, name string) (string, bool) {
+	name = strings.ToLower(name)
+	if specific, ok := r.CommandArgBindings[path][name]; ok {
+		return specific, true
+	}
+	if global, ok := r.ArgEnumSources[name]; ok {
+		return global, true
+	}
+	return "", false
+}
+
+// flagSource looks up the enum_source for a flag on the given command
+// path. Returns ("", false) when no binding applies.
+func (r *Resolver) flagSource(path, name string) (string, bool) {
+	name = strings.ToLower(name)
+	if specific, ok := r.CommandFlagBindings[path][name]; ok {
+		return specific, true
+	}
+	if global, ok := r.FlagEnumSources[name]; ok {
+		return global, true
+	}
+	return "", false
 }
 
 // Apply walks doc and stamps EnumSource + resolved Enum values on
@@ -82,7 +136,8 @@ func (r *Resolver) Apply(doc *Document) {
 		return values
 	}
 
-	// Global flags first — same lookup rules as per-command flags.
+	// Global flags: only the wildcard FlagEnumSources applies — there's
+	// no command path to scope a per-command binding against.
 	for name, f := range doc.GlobalFlags {
 		src, ok := r.FlagEnumSources[strings.ToLower(name)]
 		if !ok {
@@ -103,7 +158,7 @@ func (r *Resolver) Apply(doc *Document) {
 		// Args: in-place via index since cmd.Args is a slice value
 		// inside the map's struct value.
 		for i := range cmd.Args {
-			src, ok := r.ArgEnumSources[strings.ToLower(cmd.Args[i].Name)]
+			src, ok := r.argSource(path, cmd.Args[i].Name)
 			if !ok {
 				continue
 			}
@@ -124,7 +179,7 @@ func (r *Resolver) Apply(doc *Document) {
 		// Flags: map values must be re-stored after mutation (Go map
 		// values are not addressable).
 		for name, f := range cmd.Flags {
-			src, ok := r.FlagEnumSources[strings.ToLower(name)]
+			src, ok := r.flagSource(path, name)
 			if !ok {
 				continue
 			}

--- a/internal/cmdhelp/dynamic_test.go
+++ b/internal/cmdhelp/dynamic_test.go
@@ -219,6 +219,104 @@ func TestResolver_Apply_PreservesExistingEnum(t *testing.T) {
 	}
 }
 
+func TestResolver_Apply_PerCommandBindingScoped(t *testing.T) {
+	// Codex round 1 caught: a global `--role` binding is wrong because
+	// `pad workspace invite --role` accepts workspace roles while
+	// `pad item create --role` accepts agent role slugs. CommandFlagBindings
+	// fixes this by scoping bindings to a specific command path.
+	doc := &Document{
+		CmdhelpVersion: Version,
+		Binary:         "pad",
+		Commands: map[string]Command{
+			"item create":      {Summary: "create item", Flags: map[string]Flag{"role": {Type: "string"}}},
+			"workspace invite": {Summary: "invite user", Flags: map[string]Flag{"role": {Type: "string"}}},
+		},
+	}
+	r := &Resolver{
+		// No global FlagEnumSources for "role" — must be per-command.
+		CommandFlagBindings: map[string]map[string]string{
+			"item create": {"role": EnumSourceRoles},
+		},
+		Sources: map[string]DynamicEnum{
+			EnumSourceRoles: func() ([]interface{}, error) {
+				return []interface{}{"planner", "implementer"}, nil
+			},
+		},
+	}
+	r.Apply(doc)
+
+	// Bound: `item create --role` resolved to agent roles.
+	if got := doc.Commands["item create"].Flags["role"]; got.EnumSource != EnumSourceRoles {
+		t.Errorf("item create --role: enum_source = %q, want %q", got.EnumSource, EnumSourceRoles)
+	}
+	// Unbound: `workspace invite --role` left as plain string. This is
+	// the regression-protection assertion.
+	if got := doc.Commands["workspace invite"].Flags["role"]; got.EnumSource != "" || got.Type != "string" {
+		t.Errorf("workspace invite --role MUST be untouched without a binding; got %+v", got)
+	}
+}
+
+func TestResolver_Apply_PerCommandWinsOverWildcard(t *testing.T) {
+	// When both wildcard and per-command bindings match, per-command wins.
+	// Useful when a name has a common meaning AND a special-case override.
+	doc := &Document{
+		CmdhelpVersion: Version,
+		Binary:         "pad",
+		Commands: map[string]Command{
+			"foo": {Flags: map[string]Flag{"x": {Type: "string"}}, Summary: "foo"},
+			"bar": {Flags: map[string]Flag{"x": {Type: "string"}}, Summary: "bar"},
+		},
+	}
+	r := &Resolver{
+		FlagEnumSources: map[string]string{
+			"x": "dynamic:wildcard",
+		},
+		CommandFlagBindings: map[string]map[string]string{
+			"bar": {"x": "dynamic:specific"},
+		},
+		Sources: map[string]DynamicEnum{
+			"dynamic:wildcard": func() ([]interface{}, error) { return []interface{}{"w"}, nil },
+			"dynamic:specific": func() ([]interface{}, error) { return []interface{}{"s"}, nil },
+		},
+	}
+	r.Apply(doc)
+
+	if got := doc.Commands["foo"].Flags["x"]; got.EnumSource != "dynamic:wildcard" {
+		t.Errorf("foo.x should have wildcard binding, got %q", got.EnumSource)
+	}
+	if got := doc.Commands["bar"].Flags["x"]; got.EnumSource != "dynamic:specific" {
+		t.Errorf("bar.x should have per-command binding, got %q (wildcard leaked through)", got.EnumSource)
+	}
+}
+
+func TestResolver_Apply_PerCommandArgBindings(t *testing.T) {
+	// Same precedence rule applies to positional args.
+	doc := &Document{
+		CmdhelpVersion: Version,
+		Binary:         "pad",
+		Commands: map[string]Command{
+			"a": {Args: []Arg{{Name: "id", Type: "string", Required: true}}, Summary: "a"},
+			"b": {Args: []Arg{{Name: "id", Type: "string", Required: true}}, Summary: "b"},
+		},
+	}
+	r := &Resolver{
+		CommandArgBindings: map[string]map[string]string{
+			"a": {"id": "dynamic:a-ids"},
+		},
+		Sources: map[string]DynamicEnum{
+			"dynamic:a-ids": func() ([]interface{}, error) { return []interface{}{"a1", "a2"}, nil },
+		},
+	}
+	r.Apply(doc)
+
+	if got := doc.Commands["a"].Args[0]; got.EnumSource != "dynamic:a-ids" {
+		t.Errorf("a.id should have per-command binding, got %q", got.EnumSource)
+	}
+	if got := doc.Commands["b"].Args[0]; got.EnumSource != "" {
+		t.Errorf("b.id MUST be untouched without a binding, got %q", got.EnumSource)
+	}
+}
+
 func TestResolver_Apply_GlobalFlags(t *testing.T) {
 	// Global flags participate in resolution the same way per-command flags do.
 	fake := &fakeResolver{roles: []interface{}{"planner"}}

--- a/internal/cmdhelp/dynamic_test.go
+++ b/internal/cmdhelp/dynamic_test.go
@@ -1,0 +1,287 @@
+package cmdhelp
+
+import (
+	"errors"
+	"testing"
+)
+
+// fakeResolver builds a Resolver that pulls from in-memory fixtures.
+// It tracks how many times each Source func is called so we can assert
+// caching: even when many commands reference the same enum_source, the
+// Source MUST execute at most once per Apply.
+type fakeResolver struct {
+	collectionsCalls int
+	rolesCalls       int
+
+	collections []interface{}
+	roles       []interface{}
+
+	rolesError error
+}
+
+func (f *fakeResolver) build(workspace string) *Resolver {
+	return &Resolver{
+		Workspace: workspace,
+		ArgEnumSources: map[string]string{
+			"collection": EnumSourceCollections,
+		},
+		FlagEnumSources: map[string]string{
+			"role": EnumSourceRoles,
+		},
+		Sources: map[string]DynamicEnum{
+			EnumSourceCollections: func() ([]interface{}, error) {
+				f.collectionsCalls++
+				return f.collections, nil
+			},
+			EnumSourceRoles: func() ([]interface{}, error) {
+				f.rolesCalls++
+				if f.rolesError != nil {
+					return nil, f.rolesError
+				}
+				return f.roles, nil
+			},
+		},
+	}
+}
+
+// docWith constructs a minimal Document with two commands sharing a
+// `collection` arg (caching test) and one `role` flag.
+func docWith() *Document {
+	return &Document{
+		CmdhelpVersion: Version,
+		Binary:         "padtest",
+		Commands: map[string]Command{
+			"item create": {
+				Summary: "create",
+				Args:    []Arg{{Name: "collection", Type: "string", Required: true}},
+				Flags:   map[string]Flag{"role": {Type: "string"}},
+			},
+			"item update": {
+				Summary: "update",
+				Args:    []Arg{{Name: "collection", Type: "string", Required: true}},
+			},
+			"unrelated": {
+				Summary: "no dynamic args here",
+				Args:    []Arg{{Name: "title", Type: "string"}},
+			},
+		},
+	}
+}
+
+func TestResolver_Apply_PopulatesEnumOnArgs(t *testing.T) {
+	fake := &fakeResolver{
+		collections: []interface{}{"tasks", "ideas", "plans"},
+	}
+	r := fake.build("docapp")
+
+	doc := docWith()
+	r.Apply(doc)
+
+	for _, path := range []string{"item create", "item update"} {
+		got := doc.Commands[path].Args[0]
+		if got.EnumSource != EnumSourceCollections {
+			t.Errorf("%s: enum_source = %q, want %q", path, got.EnumSource, EnumSourceCollections)
+		}
+		if got.Type != "enum" {
+			t.Errorf("%s: type = %q, want enum", path, got.Type)
+		}
+		if len(got.Enum) != 3 {
+			t.Errorf("%s: expected 3 enum values, got %d", path, len(got.Enum))
+		}
+	}
+}
+
+func TestResolver_Apply_PopulatesEnumOnFlags(t *testing.T) {
+	fake := &fakeResolver{
+		roles: []interface{}{"planner", "implementer"},
+	}
+	r := fake.build("docapp")
+
+	doc := docWith()
+	r.Apply(doc)
+
+	got := doc.Commands["item create"].Flags["role"]
+	if got.EnumSource != EnumSourceRoles {
+		t.Errorf("enum_source = %q, want %q", got.EnumSource, EnumSourceRoles)
+	}
+	if got.Type != "enum" {
+		t.Errorf("type = %q, want enum", got.Type)
+	}
+	if len(got.Enum) != 2 {
+		t.Errorf("expected 2 enum values, got %d", len(got.Enum))
+	}
+}
+
+func TestResolver_Apply_PopulatesContext(t *testing.T) {
+	fake := &fakeResolver{}
+	r := fake.build("docapp")
+
+	doc := docWith()
+	r.Apply(doc)
+
+	if doc.Context == nil {
+		t.Fatalf("expected Context to be populated")
+	}
+	if doc.Context.Workspace != "docapp" {
+		t.Errorf("workspace = %q, want docapp", doc.Context.Workspace)
+	}
+}
+
+func TestResolver_Apply_CachesPerSource(t *testing.T) {
+	// Two commands share the `collection` arg. The Source func MUST run
+	// at most once per Apply call regardless of how many commands need it.
+	fake := &fakeResolver{collections: []interface{}{"tasks"}}
+	r := fake.build("docapp")
+
+	doc := docWith()
+	r.Apply(doc)
+
+	if fake.collectionsCalls != 1 {
+		t.Errorf("collections source called %d times, want 1 (caching broken)", fake.collectionsCalls)
+	}
+	// Second apply restarts cache; another invocation = +1 call.
+	r.Apply(doc)
+	if fake.collectionsCalls != 2 {
+		t.Errorf("after 2nd Apply, collections source called %d times, want 2", fake.collectionsCalls)
+	}
+}
+
+func TestResolver_Apply_GracefulOnError(t *testing.T) {
+	// Source returning error → enum_source is still announced, Enum is
+	// left empty, and no other arg/flag is affected. The help command
+	// MUST NOT fail because dynamic resolution failed.
+	fake := &fakeResolver{
+		collections: []interface{}{"tasks"},
+		rolesError:  errors.New("server unreachable"),
+	}
+	r := fake.build("docapp")
+
+	doc := docWith()
+	r.Apply(doc) // must not panic / return error (Apply has no error)
+
+	// Successful source still resolves.
+	if got := doc.Commands["item create"].Args[0]; len(got.Enum) == 0 {
+		t.Errorf("collections enum should still resolve when an unrelated source fails")
+	}
+	// Failed source: announces enum_source but leaves Enum empty AND
+	// keeps the type as the original "string" (no upgrade without values).
+	role := doc.Commands["item create"].Flags["role"]
+	if role.EnumSource != EnumSourceRoles {
+		t.Errorf("expected enum_source set even when resolution fails, got %q", role.EnumSource)
+	}
+	if len(role.Enum) != 0 {
+		t.Errorf("expected empty Enum when resolution failed, got %v", role.Enum)
+	}
+	if role.Type != "string" {
+		t.Errorf("type should remain string when no values resolved, got %q", role.Type)
+	}
+}
+
+func TestResolver_Apply_NilIsNoOp(t *testing.T) {
+	// Callers MUST be able to pass a nil Resolver via Options to disable
+	// dynamic resolution entirely. The function call is what matters,
+	// not the value.
+	doc := docWith()
+	var r *Resolver
+	r.Apply(doc) // must not panic
+
+	if doc.Commands["item create"].Args[0].EnumSource != "" {
+		t.Errorf("nil Resolver must not stamp enum_source")
+	}
+	if doc.Context != nil {
+		t.Errorf("nil Resolver must not populate Context")
+	}
+}
+
+func TestResolver_Apply_PreservesExistingEnum(t *testing.T) {
+	// When an arg already has Enum from alternation/ValidArgs, dynamic
+	// resolution must NOT replace it. EnumSource is still stamped (so
+	// the binding is announced) but the original values win — they are
+	// the spec for that arg, not a snapshot.
+	fake := &fakeResolver{collections: []interface{}{"would-replace"}}
+	r := fake.build("docapp")
+
+	doc := docWith()
+	cmd := doc.Commands["item create"]
+	cmd.Args[0].Enum = []interface{}{"locked"}
+	cmd.Args[0].Type = "enum"
+	doc.Commands["item create"] = cmd
+
+	r.Apply(doc)
+
+	got := doc.Commands["item create"].Args[0]
+	if len(got.Enum) != 1 || got.Enum[0] != "locked" {
+		t.Errorf("dynamic resolution should not replace existing Enum, got %v", got.Enum)
+	}
+	// EnumSource is still announced for transparency.
+	if got.EnumSource != EnumSourceCollections {
+		t.Errorf("expected enum_source to be set even when Enum is preserved, got %q", got.EnumSource)
+	}
+}
+
+func TestResolver_Apply_GlobalFlags(t *testing.T) {
+	// Global flags participate in resolution the same way per-command flags do.
+	fake := &fakeResolver{roles: []interface{}{"planner"}}
+	r := fake.build("docapp")
+
+	doc := docWith()
+	doc.GlobalFlags = map[string]Flag{"role": {Type: "string"}}
+	r.Apply(doc)
+
+	got := doc.GlobalFlags["role"]
+	if got.EnumSource != EnumSourceRoles {
+		t.Errorf("global flag --role: enum_source = %q, want %q", got.EnumSource, EnumSourceRoles)
+	}
+	if got.Type != "enum" || len(got.Enum) != 1 {
+		t.Errorf("global flag --role: expected enum-typed with 1 value, got type=%q enum=%v", got.Type, got.Enum)
+	}
+}
+
+func TestResolver_Apply_UnaffectedCommandsUnchanged(t *testing.T) {
+	// A command with no matching arg/flag names must be untouched.
+	fake := &fakeResolver{collections: []interface{}{"tasks"}}
+	r := fake.build("docapp")
+
+	doc := docWith()
+	r.Apply(doc)
+
+	un := doc.Commands["unrelated"]
+	if un.Args[0].EnumSource != "" {
+		t.Errorf("unrelated arg should not be touched, got enum_source = %q", un.Args[0].EnumSource)
+	}
+	if un.Args[0].Type != "string" {
+		t.Errorf("unrelated arg type should remain string, got %q", un.Args[0].Type)
+	}
+}
+
+func TestBuild_AppliesResolver(t *testing.T) {
+	// End-to-end via Build(): when Options.Resolver is set, the emitted
+	// Document must reflect both the static walk AND dynamic resolution.
+	fake := &fakeResolver{collections: []interface{}{"tasks", "ideas"}}
+
+	root := buildSyntheticTree()
+	doc := Build(root, root, Options{
+		Binary: "padtest",
+		Resolver: &Resolver{
+			Workspace: "fixture",
+			ArgEnumSources: map[string]string{
+				"collection": EnumSourceCollections,
+			},
+			Sources: map[string]DynamicEnum{
+				EnumSourceCollections: func() ([]interface{}, error) {
+					fake.collectionsCalls++
+					return fake.collections, nil
+				},
+			},
+		},
+		MaxDepth: -1,
+	})
+
+	create := doc.Commands["item create"]
+	if create.Args[0].EnumSource != EnumSourceCollections {
+		t.Errorf("Build did not apply Resolver to args; enum_source = %q", create.Args[0].EnumSource)
+	}
+	if doc.Context == nil || doc.Context.Workspace != "fixture" {
+		t.Errorf("Build did not apply Resolver to context; got %+v", doc.Context)
+	}
+}

--- a/internal/cmdhelp/json.go
+++ b/internal/cmdhelp/json.go
@@ -39,6 +39,12 @@ type Options struct {
 	// `generated:` field. Useful for snapshot tests that need a stable
 	// timestamp. Leave nil to use the real wall clock (UTC).
 	Now func() time.Time
+
+	// Resolver, when non-nil, splices live workspace facts into the
+	// emitted Document after the static walk completes (spec §7). Pass
+	// nil to emit a purely static document — useful when no workspace
+	// is detected, when running outside a pad install, or in tests.
+	Resolver *Resolver
 }
 
 // EmitJSON walks the command tree below `target`, builds a cmdhelp v0.1
@@ -77,6 +83,10 @@ func Build(target, root *cobra.Command, opts Options) *Document {
 	}
 
 	walk(target, root, doc, 0, opts.MaxDepth)
+
+	// Splice dynamic workspace facts after the static walk so callers
+	// can inspect Build's output as either pre- or post-resolution.
+	opts.Resolver.Apply(doc)
 
 	return doc
 }


### PR DESCRIPTION
## Summary

The killer differentiator from cmdhelp v0.1 — splice **live workspace facts** into the emitted help so an LLM asking "what collections exist?" gets the actual answer instead of a generic `string`.

## Context

Implements `TASK-936` under `PLAN-930`. Builds on the static JSON + MD emitters (TASK-934/935). Pad already does workspace-aware help in `pad item create --help`; this just standardises the envelope per spec §7.

### Pad-side bindings

| target | becomes | source |
|---|---|---|
| arg `collection` | `enum`, `enum=[…]`, `enum_source` set | `dynamic:pad collection list` |
| flag `--role` | same | `dynamic:pad role list` |
| flag `--assign` | same | `dynamic:pad workspace members` |
| document | `context.workspace` populated | from `cli.DetectWorkspace` |

### Inside a workspace

```jsonc
"args": [
  {
    "name": "collection",
    "type": "enum",
    "required": true,
    "enum": ["ideas","conventions","plans","docs","tasks","..."],
    "enum_source": "dynamic:pad collection list"
  }
]
```

Markdown gets a `## Workspace context` section: `- workspace: \`docapp\``.

### Outside any workspace

`newDynamicResolver` returns nil. Document emits as purely static (no `enum_source`, no `context`, plain `type: string`). Schema-validates either way.

### Fail-safe layering

1. **No workspace detected** → resolver is nil → static doc.
2. **Per-source error** (server down, auth missing) → `enum_source` still announced (so consumers know the binding) but `Enum` left empty. Help command never fails because dynamic facts can't be fetched.
3. **Existing `Enum` from alternation / ValidArgs** is preserved — resolver only fills gaps, never overwrites authoritative spec.

### Files

- **`internal/cmdhelp/dynamic.go` (new)** — `Resolver` type with `Apply(doc)`. Per-`Apply` cache: each `Sources` func runs at most once even when many commands reference the same `enum_source`.
- **`internal/cmdhelp/json.go`** — added `Options.Resolver`; `Build()` calls `Resolver.Apply` after the static walk.
- **`cmd/pad/help_cmdhelp.go`** — `newDynamicResolver()` constructs the runtime resolver (workspace + 3 sources). `cmdhelpOptions(target,…)` derives `Binary` from `target.Root().Name()` so synthetic test trees keep working.

## Test plan

- [x] **10 new dynamic-resolver tests** in `internal/cmdhelp/dynamic_test.go`:
  - arg + flag enum population
  - context population (workspace)
  - per-source caching across multiple commands (≤1 fetch per source per Apply)
  - graceful error handling (one source errors, others still resolve, no panic)
  - nil resolver as no-op
  - existing-Enum preservation (alternation/ValidArgs not overwritten)
  - global flag resolution
  - unaffected commands left unchanged
  - end-to-end via `Build()` with a Resolver in Options
- [x] All 24 prior cmdhelp tests + 12 routing tests still pass.
- [x] **End-to-end on real binary**:
  - inside docapp workspace: `pad help item create --format json` produces enum-typed `collection` with all 10 collections, `--role` enum with `[planner,implementer,reviewer]`, `--assign` with `[dave]`, `context.workspace="docapp"`. Schema-valid.
  - outside any workspace (`cd /tmp && pad help …`): args/flags emit as plain `string`, no `enum_source`, no `context`. Still schema-valid.
  - `pad help --format md` shows `## Workspace context` section.
- [x] `make check` clean.

## Out of scope (deferred)

- `--capabilities` discovery flag — `TASK-937`.
- Schema-validate live output in CI — `TASK-938`.
- Audit pad's existing commands' Example fields — `TASK-939`.