### PR TITLE
feat(cmdhelp): --capabilities discovery + --cmdhelp-capabilities fallback (TASK-937)

### DIFF
--- a/cmd/pad/help_cmdhelp.go
+++ b/cmd/pad/help_cmdhelp.go
@@ -24,6 +24,13 @@ const CmdhelpVersion = cmdhelp.Version
 // document's `homepage` field.
 const padHomepage = "https://getpad.dev"
 
+// padCmdhelpFormats is the list this binary advertises in response to
+// `pad help --capabilities`. Order is not significant (spec §8) but
+// pad lists `text` first to keep the line readable for humans grepping
+// shell output. `llm` is included because pad supports it as an alias
+// for `md`.
+var padCmdhelpFormats = []string{"text", "md", "json", "llm"}
+
 // helpCmd returns a custom `pad help` subcommand that replaces cobra's
 // built-in help. It implements the cmdhelp v0.1 mandatory surface
 // (https://getpad.dev/cmdhelp; IDEA-927):
@@ -39,6 +46,7 @@ func helpCmd() *cobra.Command {
 	var format string
 	var depth int
 	var all bool
+	var capabilities bool
 
 	cmd := &cobra.Command{
 		Use:   "help [command path…]",
@@ -76,6 +84,13 @@ Scope:
 			return names, cobra.ShellCompDirectiveNoFileComp
 		},
 		RunE: func(c *cobra.Command, args []string) error {
+			// --capabilities short-circuits everything else (spec §8).
+			// MUST be side-effect-free, single-line, exit 0.
+			if capabilities {
+				fmt.Fprintln(c.OutOrStdout(), cmdhelp.CapabilityLine(padCmdhelpFormats))
+				return nil
+			}
+
 			target, _, err := c.Root().Find(args)
 			if err != nil || target == nil {
 				return fmt.Errorf("unknown help topic %q", strings.Join(args, " "))
@@ -99,6 +114,7 @@ Scope:
 	cmd.Flags().StringVar(&format, "format", "text", "output format: text, md, json, llm (alias for md) — per cmdhelp v0.1")
 	cmd.Flags().IntVar(&depth, "depth", -1, "truncate the command tree to N levels (-1 = unlimited; --depth=0 is summary)")
 	cmd.Flags().BoolVar(&all, "all", false, "include every leaf with full detail (convenience alias for unlimited depth)")
+	cmd.Flags().BoolVar(&capabilities, "capabilities", false, "print cmdhelp capability bit (e.g. cmdhelp/0.1: text, md, json, llm) and exit")
 
 	return cmd
 }

--- a/cmd/pad/help_cmdhelp_test.go
+++ b/cmd/pad/help_cmdhelp_test.go
@@ -202,6 +202,33 @@ func TestHelpCmd_UnknownTopicRejected(t *testing.T) {
 	}
 }
 
+func TestHelpCmd_CapabilitiesExactString(t *testing.T) {
+	out, _, err := runHelp(t, "--capabilities")
+	if err != nil {
+		t.Fatalf("--capabilities: unexpected error: %v", err)
+	}
+	// Per spec §8: single line, exact format. The trailing newline
+	// comes from fmt.Fprintln. Anything else (extra whitespace,
+	// stray prose, multiple lines) breaks the contract.
+	want := "cmdhelp/0.1: text, md, json, llm\n"
+	if out != want {
+		t.Errorf("--capabilities output mismatch:\n got: %q\nwant: %q", out, want)
+	}
+}
+
+func TestHelpCmd_CapabilitiesShortCircuits(t *testing.T) {
+	// --capabilities MUST take precedence over --format / --depth /
+	// scope args (spec §8 makes the bit side-effect-free).
+	out, _, err := runHelp(t, "item", "--capabilities", "--format", "json", "--depth", "0")
+	if err != nil {
+		t.Fatalf("--capabilities + extra flags: unexpected error: %v", err)
+	}
+	want := "cmdhelp/0.1: text, md, json, llm\n"
+	if out != want {
+		t.Errorf("expected --capabilities to short-circuit other flags; got: %q", out)
+	}
+}
+
 func TestHelpCmd_DepthAndAllAccepted(t *testing.T) {
 	// --depth and --all are part of the cmdhelp v0.1 surface but their
 	// effect lives in the JSON/MD emitters (TASK-934/935). At this layer

--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -29,6 +29,7 @@ import (
 	pad "github.com/PerpetualSoftware/pad"
 	"github.com/PerpetualSoftware/pad/internal/attachments"
 	"github.com/PerpetualSoftware/pad/internal/cli"
+	"github.com/PerpetualSoftware/pad/internal/cmdhelp"
 	"github.com/PerpetualSoftware/pad/internal/collections"
 	"github.com/PerpetualSoftware/pad/internal/config"
 	"regexp"
@@ -72,6 +73,23 @@ func fullVersion() string {
 }
 
 func main() {
+	// `--cmdhelp-capabilities` is the spec §8 fallback form for the
+	// capability bit, designed for CLIs whose `help` subcommand is
+	// already overloaded. Pad's `help --capabilities` is the preferred
+	// form (and is wired in helpCmd()), but we honor the fallback here
+	// so wrappers and harnesses that prefer it work uniformly across
+	// every conforming CLI.
+	//
+	// Handled before cobra parsing so it's truly side-effect-free
+	// (no flag-parse errors on unrelated args, no config load, no
+	// server reach-out, no auth challenge) per spec §8 requirements.
+	for _, a := range os.Args[1:] {
+		if a == "--cmdhelp-capabilities" {
+			fmt.Println(cmdhelp.CapabilityLine(padCmdhelpFormats))
+			return
+		}
+	}
+
 	rootCmd := &cobra.Command{
 		Use:     "pad",
 		Short:   "Pad — project management for developers and AI agents",

--- a/internal/cmdhelp/json.go
+++ b/internal/cmdhelp/json.go
@@ -2,6 +2,7 @@ package cmdhelp
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"regexp"
 	"strings"
@@ -10,6 +11,22 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
+
+// CapabilityLine returns the single-line capability bit a conforming
+// CLI emits in response to `<cmd> help --capabilities` (or the
+// `--cmdhelp-capabilities` fallback form). Per spec §8:
+//
+//   - Format: `cmdhelp/<MAJOR>.<MINOR>: <comma-separated formats>`
+//   - Single-line, parseable, stable across releases.
+//   - The format list MUST include every supported format, including
+//     the mandatory `text`. Order is not significant.
+//
+// Pass the formats this binary actually supports. The helper does not
+// imply any default set so different binaries can advertise different
+// surfaces (e.g. a future cmdhelp v0.2 might add formats).
+func CapabilityLine(formats []string) string {
+	return fmt.Sprintf("cmdhelp/%s: %s", Version, strings.Join(formats, ", "))
+}
 
 // Options configure a Build/EmitJSON call. All fields are optional except
 // Binary, which is used as the document's `binary` key.

--- a/internal/cmdhelp/json_test.go
+++ b/internal/cmdhelp/json_test.go
@@ -427,6 +427,24 @@ func TestEmitJSON_ProducesValidJSON(t *testing.T) {
 	}
 }
 
+func TestCapabilityLine_FormatExact(t *testing.T) {
+	got := CapabilityLine([]string{"text", "md", "json", "llm"})
+	want := "cmdhelp/0.1: text, md, json, llm"
+	if got != want {
+		t.Errorf("CapabilityLine = %q, want %q", got, want)
+	}
+}
+
+func TestCapabilityLine_HonorsCallerOrderAndSet(t *testing.T) {
+	// Order is not significant per spec — the helper preserves caller
+	// order so different binaries can list formats however reads best.
+	got := CapabilityLine([]string{"json", "text", "md"})
+	want := "cmdhelp/0.1: json, text, md"
+	if got != want {
+		t.Errorf("CapabilityLine should preserve caller order: got %q want %q", got, want)
+	}
+}
+
 func TestEmitJSON_VersionPatternMatchesSpec(t *testing.T) {
 	// Spec §9: cmdhelp_version is MAJOR.MINOR — never includes a PATCH.
 	versionRE := regexp.MustCompile(`^[0-9]+\.[0-9]+$`)


### PR DESCRIPTION
## Summary

Implements the cmdhelp v0.1 §8 capability bit so wrappers can detect support without trial and error.

```
$ pad help --capabilities
cmdhelp/0.1: text, md, json, llm

$ pad --cmdhelp-capabilities         # spec §8 fallback form
cmdhelp/0.1: text, md, json, llm
```

## Context

Implements `TASK-937` under `PLAN-930`. Independent of the emitter work — slot fits cleanly between TASK-933 (skeleton) and TASK-938 (golden tests, which will assert equivalence between both forms).

### Spec §8 contract enforced

- **Single-line** on stdout, terminated by newline only.
- **Side-effect-free** — no logging, no network, no config writes, no auth challenge. Verified by running outside any workspace (`cd /tmp && pad help --capabilities`).
- **Exit 0** on success.
- **Format**: `cmdhelp/<MAJOR>.<MINOR>: <comma-separated formats>`.
- The format list MUST include every supported format including `text`.

### Both forms

Spec §8 lists `<cmd> help --capabilities` as preferred and `<cmd> --cmdhelp-capabilities` as a fallback for CLIs whose `help` subcommand is overloaded. Pad's `help` is not overloaded, but supporting both costs nothing and lets wrappers pick whichever convention they want.

The fallback is handled in `main()` **before** cobra parsing so it's truly side-effect-free — doesn't reach `config.Load()`, no `cobra` flag-parse errors on unrelated args, no auth challenge, no server reach-out. A simple `os.Args` scan + early return.

### Files

- **`internal/cmdhelp/json.go`** — new `CapabilityLine(formats []string) string` helper that produces the spec-format string. Caller passes the format set; helper preserves caller order (spec §8 says order isn't significant).
- **`cmd/pad/help_cmdhelp.go`** — adds `--capabilities` to `helpCmd`; new `padCmdhelpFormats = ["text","md","json","llm"]`; short-circuit in `RunE` before any other logic.
- **`cmd/pad/main.go`** — pre-args scan handles `--cmdhelp-capabilities` before `rootCmd.Execute()`.

## Test plan

- [x] `TestCapabilityLine_FormatExact` — exact string match.
- [x] `TestCapabilityLine_HonorsCallerOrderAndSet` — preserves caller order.
- [x] `TestHelpCmd_CapabilitiesExactString` — exact-byte assertion on `help --capabilities` output including trailing newline.
- [x] `TestHelpCmd_CapabilitiesShortCircuits` — verifies `--capabilities` wins over `--format`/`--depth`/extra args.
- [x] All 35 existing cmdhelp tests + 14 routing tests still pass.
- [x] **End-to-end on real binary**:
  - `pad help --capabilities` → exact line, exit 0.
  - `pad --cmdhelp-capabilities` → same line, exit 0.
  - `cd /tmp && pad help --capabilities` → still works (no auth, no workspace).
  - Both forms byte-identical.
- [x] `make check` clean.

## Out of scope (deferred)

- CI-level golden snapshot of the capability line — `TASK-938`.
- Spec doc page on getpad.dev — `TASK-940`.