### PR TITLE
feat(cmdhelp): tests + golden contract + drift validator (TASK-938)

### DIFF
--- a/cmd/pad/cmdhelp_real_test.go
+++ b/cmd/pad/cmdhelp_real_test.go
@@ -1,0 +1,185 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/cmdhelp"
+)
+
+// emitRealPadJSON builds the real pad cobra tree and emits its JSON
+// representation with a static (no-resolver, no live-workspace)
+// configuration. Tests that exercise schema validation and example
+// drift detection against the actual command surface use this.
+//
+// `Resolver: nil` is deliberate: deterministic emission, no flakiness
+// from a live or absent workspace, no need to mock the cli client.
+func emitRealPadJSON(t *testing.T) []byte {
+	t.Helper()
+	root := newRootCmd()
+	var buf bytes.Buffer
+	if err := cmdhelp.EmitJSON(root, root, cmdhelp.Options{
+		Binary:   "pad",
+		Version:  "test",
+		Homepage: "https://getpad.dev",
+		MaxDepth: -1,
+	}, &buf); err != nil {
+		t.Fatalf("EmitJSON on real pad tree: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func TestRealPadTree_ValidatesAgainstSchema(t *testing.T) {
+	// THE BIG ASSERTION: the real, full pad CLI emits cmdhelp v0.1
+	// JSON that satisfies every contract in schema/cmdhelp.schema.json.
+	//
+	// Future regressions caught by this test:
+	//   - new flag with a type outside the closed vocabulary
+	//   - exit_code key that isn't numeric
+	//   - flag name with leading dashes (violates propertyNames)
+	//   - cmdhelp_version pattern broken
+	//   - any required field accidentally omitted
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	schema, err := cmdhelp.FindAndCompileSchema(cwd)
+	if err != nil {
+		t.Fatalf("load schema: %v", err)
+	}
+	jsonBytes := emitRealPadJSON(t)
+
+	var doc interface{}
+	if err := json.Unmarshal(jsonBytes, &doc); err != nil {
+		t.Fatalf("unmarshal pad's cmdhelp JSON: %v", err)
+	}
+	if err := schema.Validate(doc); err != nil {
+		// Don't dump the full output (it's huge) — the validator's
+		// error already names the offending JSON pointer.
+		t.Errorf("pad's cmdhelp JSON does not validate against schema/cmdhelp.schema.json:\n%v", err)
+	}
+}
+
+func TestRealPadTree_ExampleDriftValidator(t *testing.T) {
+	// THE DRIFT-PREVENTION CONTRACT (spec §6 / §11 Q5): every example
+	// emitted in cmdhelp output MUST resolve against the live cobra
+	// command tree. A typo'd flag, a renamed/deleted command, or a
+	// stale example block in cobra Long that references a defunct
+	// surface — all caught here.
+	//
+	// If this test fails after a code change:
+	//   1. The implementation changed (renamed flag, removed cmd) but
+	//      the example block in Long still references the old name —
+	//      fix the example.
+	//   2. Or the implementation is correct and the example was always
+	//      wrong — fix the example.
+	//
+	// Adding a new typo'd example to any cobra Long block in cmd/pad
+	// MUST break this test. That's the spec contract in action.
+	root := newRootCmd()
+	jsonBytes := emitRealPadJSON(t)
+	var doc cmdhelp.Document
+	if err := json.Unmarshal(jsonBytes, &doc); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	findings := cmdhelp.ValidateExamples(&doc, root)
+	if len(findings) > 0 {
+		t.Errorf("example drift detected — %d finding(s):", len(findings))
+		for _, f := range findings {
+			t.Errorf("  %s", f)
+		}
+	}
+}
+
+func TestRealPadTree_BoolArityRule(t *testing.T) {
+	// Spec §5.3: bool flags must be presence-only. None of pad's
+	// existing examples should reference a bool flag in valued form.
+	jsonBytes := emitRealPadJSON(t)
+	var doc cmdhelp.Document
+	if err := json.Unmarshal(jsonBytes, &doc); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	findings := cmdhelp.ValidateBoolArity(&doc)
+	if len(findings) > 0 {
+		t.Errorf("bool arity violations — %d finding(s):", len(findings))
+		for _, f := range findings {
+			t.Errorf("  %s", f)
+		}
+	}
+}
+
+func TestCapabilities_FallbackEquivalent(t *testing.T) {
+	// Spec §8 says either form must produce the same line. The fallback
+	// form (--cmdhelp-capabilities) is implemented in main() before
+	// cobra parsing; the primary form (help --capabilities) goes
+	// through helpCmd. They MUST advertise the same capability bit.
+	var fb bytes.Buffer
+	handled := handleCmdhelpCapabilitiesFallback([]string{"--cmdhelp-capabilities"}, &fb)
+	if !handled {
+		t.Fatalf("handleCmdhelpCapabilitiesFallback should have handled --cmdhelp-capabilities")
+	}
+
+	// helpCmd's --capabilities path: build a synthetic root just to
+	// route the flag through helpCmd's RunE. This intentionally mirrors
+	// the structure of help_cmdhelp_test.go's runHelp helper to share
+	// the same wiring across tests.
+	primary := captureHelpCmdCapabilities(t)
+
+	if string(fb.Bytes()) != primary {
+		t.Errorf("capability bit forms differ:\nfallback: %q\nprimary:  %q", fb.String(), primary)
+	}
+}
+
+func TestCapabilities_FallbackIsSideEffectFree(t *testing.T) {
+	// Side-effect-free contract (spec §8): no logging, no network,
+	// no auth challenge, no flag-parse errors on unrelated args.
+	// Verify by passing args alongside --cmdhelp-capabilities that
+	// would normally trigger errors (unknown subcommand, bad flags).
+	var fb bytes.Buffer
+	handled := handleCmdhelpCapabilitiesFallback(
+		[]string{"completely", "bogus", "--garbage", "--cmdhelp-capabilities", "--more=junk"},
+		&fb,
+	)
+	if !handled {
+		t.Fatalf("expected fallback to handle --cmdhelp-capabilities even alongside garbage args")
+	}
+	want := cmdhelp.CapabilityLine(padCmdhelpFormats) + "\n"
+	if fb.String() != want {
+		t.Errorf("output mismatch.\n got: %q\nwant: %q", fb.String(), want)
+	}
+}
+
+func TestCapabilities_FallbackNotTriggeredWithoutFlag(t *testing.T) {
+	var fb bytes.Buffer
+	handled := handleCmdhelpCapabilitiesFallback([]string{"item", "list"}, &fb)
+	if handled {
+		t.Errorf("fallback should NOT trigger on plain args; got handled=true")
+	}
+	if fb.Len() != 0 {
+		t.Errorf("fallback should not write output without the flag; got: %q", fb.String())
+	}
+}
+
+// captureHelpCmdCapabilities runs helpCmd via a synthetic root and
+// returns its --capabilities output as a string. Mirrors the
+// runHelp pattern in help_cmdhelp_test.go.
+func captureHelpCmdCapabilities(t *testing.T) string {
+	t.Helper()
+	root := buildTestRoot()
+	root.SetArgs([]string{"help", "--capabilities"})
+	var stdout, stderr bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(&stderr)
+	if err := root.Execute(); err != nil {
+		t.Fatalf("help --capabilities: unexpected error: %v\nstderr: %s", err, stderr.String())
+	}
+	out := stdout.String()
+	// Strip any unexpected leading/trailing whitespace artifacts before
+	// the comparison so the capability bit (which uses Fprintln) is the
+	// only meaningful differentiator.
+	return strings.TrimRight(out, "\n") + "\n"
+}

--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -73,23 +73,47 @@ func fullVersion() string {
 }
 
 func main() {
-	// `--cmdhelp-capabilities` is the spec §8 fallback form for the
-	// capability bit, designed for CLIs whose `help` subcommand is
-	// already overloaded. Pad's `help --capabilities` is the preferred
-	// form (and is wired in helpCmd()), but we honor the fallback here
-	// so wrappers and harnesses that prefer it work uniformly across
-	// every conforming CLI.
-	//
-	// Handled before cobra parsing so it's truly side-effect-free
-	// (no flag-parse errors on unrelated args, no config load, no
-	// server reach-out, no auth challenge) per spec §8 requirements.
-	for _, a := range os.Args[1:] {
-		if a == "--cmdhelp-capabilities" {
-			fmt.Println(cmdhelp.CapabilityLine(padCmdhelpFormats))
-			return
-		}
+	// Spec §8 fallback form: --cmdhelp-capabilities. Handled before
+	// cobra parsing so the discovery bit is truly side-effect-free
+	// (no flag-parse errors, no config load, no server reach-out, no
+	// auth challenge) per spec requirements.
+	if handleCmdhelpCapabilitiesFallback(os.Args[1:], os.Stdout) {
+		return
 	}
 
+	if err := newRootCmd().Execute(); err != nil {
+		os.Exit(1)
+	}
+}
+
+// handleCmdhelpCapabilitiesFallback scans args for the --cmdhelp-capabilities
+// flag (cmdhelp v0.1 §8 fallback form). If found, it writes the
+// capability bit to w and returns true so callers can short-circuit.
+// Returns false (no output) when the flag isn't present.
+//
+// Extracted from main() so the side-effect-free guarantee can be
+// asserted in tests without spawning a subprocess.
+func handleCmdhelpCapabilitiesFallback(args []string, w io.Writer) bool {
+	for _, a := range args {
+		if a == "--cmdhelp-capabilities" {
+			fmt.Fprintln(w, cmdhelp.CapabilityLine(padCmdhelpFormats))
+			return true
+		}
+	}
+	return false
+}
+
+// newRootCmd constructs the pad CLI's root cobra command tree.
+//
+// Extracted from main() so tests can use the real tree (golden
+// snapshots, schema validation, example-vs-flag-tree drift detection)
+// without running it. Build it, inspect it, never call Execute() in
+// tests.
+//
+// Each call returns a fresh tree. The persistent flags bind to the
+// package-level vars (workspaceFlag, formatFlag, urlFlag) — fine for
+// tests as long as they don't run concurrently with the real CLI flow.
+func newRootCmd() *cobra.Command {
 	rootCmd := &cobra.Command{
 		Use:     "pad",
 		Short:   "Pad — project management for developers and AI agents",
@@ -118,10 +142,6 @@ func main() {
 		completionCmd(),
 	)
 
-	// Replace cobra's built-in `help` with our cmdhelp v0.1 routing layer.
-	// Default --format=text delegates back to cobra's text renderer so the
-	// existing UX is unchanged; --format json|md|llm calls into the
-	// structured emitters (currently stubbed — see TASK-934/935).
 	rootCmd.SetHelpCommand(helpCmd())
 
 	rootCmd.RegisterFlagCompletionFunc("workspace", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
@@ -141,9 +161,7 @@ func main() {
 		return slugs, cobra.ShellCompDirectiveNoFileComp
 	})
 
-	if err := rootCmd.Execute(); err != nil {
-		os.Exit(1)
-	}
+	return rootCmd
 }
 
 // --- helpers ---
@@ -5412,11 +5430,11 @@ func githubCmd() *cobra.Command {
 Requires the GitHub CLI (gh) to be installed: https://cli.github.com/
 
 Examples:
-  pad github link TASK-5          Link current branch's PR to TASK-5
-  pad github link                 Auto-detect item ref from branch name
-  pad github status               Show PR status for all linked items
-  pad github status TASK-5        Show PR status for a specific item
-  pad github unlink TASK-5        Remove PR link from an item`,
+  pad github link TASK-5          # Link current branch's PR to TASK-5
+  pad github link                 # Auto-detect item ref from branch name
+  pad github status               # Show PR status for all linked items
+  pad github status TASK-5        # Show PR status for a specific item
+  pad github unlink TASK-5        # Remove PR link from an item`,
 	}
 
 	cmd.AddCommand(

--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/test-go/testify v1.1.4 // indirect
 	go.uber.org/atomic v1.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -85,6 +85,8 @@ github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qq
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/sergi/go-diff v1.4.0 h1:n/SP9D5ad1fORl+llWyN+D6qoUETXNZARKjyY2/KVCw=
 github.com/sergi/go-diff v1.4.0/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=

--- a/internal/cmdhelp/example_validation.go
+++ b/internal/cmdhelp/example_validation.go
@@ -1,0 +1,222 @@
+package cmdhelp
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// ValidateExamples is the contractual mechanism by which cmdhelp v0.1
+// prevents documentation drift (spec §6, §11 Q5). For every example in
+// every command of `doc`:
+//
+//  1. Tokenize the `cmd` string with a shell-aware splitter.
+//  2. Resolve the non-flag tokens against `root`'s live cobra command
+//     tree. Failure means the example references a command path that
+//     doesn't exist (typo, deleted command, drift).
+//  3. Verify every `--flag` token resolves to a flag on the resolved
+//     command — local, persistent, or inherited from any parent.
+//
+// Returns a slice of error strings, one per finding, with the offending
+// command path + example index for fast triage. Empty slice means clean.
+//
+// This is intentionally a function not a test so cmd/pad's own test
+// suite (which has access to the real cobra tree) can call it.
+// Callers must pass `root` so flag-tree walks can include persistent
+// flags from the binary root.
+func ValidateExamples(doc *Document, root *cobra.Command) []string {
+	if doc == nil || root == nil {
+		return nil
+	}
+	var findings []string
+
+	for path, cmd := range doc.Commands {
+		for i, ex := range cmd.Examples {
+			if ferrs := validateExample(path, i, ex, doc, root); len(ferrs) > 0 {
+				findings = append(findings, ferrs...)
+			}
+		}
+	}
+	return findings
+}
+
+func validateExample(path string, idx int, ex Example, doc *Document, root *cobra.Command) []string {
+	tokens, err := shellSplit(ex.Cmd)
+	if err != nil {
+		return []string{fmt.Sprintf("%s example[%d]: cannot tokenize %q: %v", path, idx, ex.Cmd, err)}
+	}
+	if len(tokens) == 0 {
+		return []string{fmt.Sprintf("%s example[%d]: empty cmd string", path, idx)}
+	}
+
+	// Token 0 should be the binary's name. Examples that begin with
+	// something else (e.g. `cat ~/foo.json | jq`) are documentation
+	// snippets showing related output, not pad invocations the
+	// validator can check. Skip them rather than fail — the drift
+	// contract is for pad-invocation drift specifically.
+	binary := root.Name()
+	if tokens[0] != binary {
+		return nil
+	}
+
+	// Walk non-flag tokens through the cobra tree to find the target.
+	// flag-form tokens: "--name", "--name=value", "-n", "-n=value".
+	var nonFlags []string
+	for _, t := range tokens[1:] {
+		if strings.HasPrefix(t, "-") {
+			break
+		}
+		nonFlags = append(nonFlags, t)
+	}
+	target, _, ferr := root.Find(nonFlags)
+	if ferr != nil || target == nil {
+		return []string{fmt.Sprintf("%s example[%d]: command path doesn't resolve: %s", path, idx, ex.Cmd)}
+	}
+
+	// Validate every --flag/-f against target's flag tree.
+	// Note: flags can appear before the subcommand path on cobra
+	// (e.g. `pad --workspace foo item create ...`), so scan all tokens.
+	var findings []string
+	skipNext := false
+	for _, t := range tokens[1:] {
+		if skipNext {
+			skipNext = false
+			continue
+		}
+		if !strings.HasPrefix(t, "-") {
+			continue
+		}
+		// Strip leading dashes and any =value suffix.
+		name := strings.TrimLeft(t, "-")
+		if eq := strings.IndexByte(name, '='); eq >= 0 {
+			name = name[:eq]
+		}
+		if name == "" {
+			continue // bare "--" terminator
+		}
+		// Walk target up to root, accept the flag if any level has it.
+		// Boolean flags don't consume the next token; non-bool flags
+		// do — but we only need the name check for drift detection,
+		// so don't bother with the value-consumption walk except to
+		// note that the "next token" might be a value rather than
+		// another flag (no special handling needed here).
+		if !flagExists(target, name) {
+			// Try negate-flag form: --no-<rest>.
+			if strings.HasPrefix(name, "no-") {
+				stripped := strings.TrimPrefix(name, "no-")
+				if flagExists(target, stripped) {
+					continue
+				}
+			}
+			findings = append(findings, fmt.Sprintf("%s example[%d]: unknown flag --%s in %q", path, idx, name, ex.Cmd))
+		}
+	}
+	return findings
+}
+
+// flagExists reports whether `name` is a known flag on cmd or any of
+// its ancestors (covers persistent / inherited flags). Both long and
+// short forms are checked — pflag's Lookup treats single-character
+// names as shorthand and ShorthandLookup as the lookup for them.
+func flagExists(cmd *cobra.Command, name string) bool {
+	for c := cmd; c != nil; c = c.Parent() {
+		if c.Flags().Lookup(name) != nil {
+			return true
+		}
+		if c.PersistentFlags().Lookup(name) != nil {
+			return true
+		}
+		if len(name) == 1 {
+			if c.Flags().ShorthandLookup(name) != nil {
+				return true
+			}
+			if c.PersistentFlags().ShorthandLookup(name) != nil {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// shellSplit tokenizes a command line in a POSIX-ish way: whitespace
+// separates tokens, double-quotes group, single-quotes group (no
+// expansion inside), backslash escapes the next rune outside single
+// quotes. Stops at the first unquoted pipeline boundary (`|`, `;`,
+// `&`, `>`, `<`) so the validator only checks the first command in a
+// pipeline. Not a full shell — no $vars, no globbing.
+//
+// Sufficient for cmdhelp `examples[].cmd` strings, which are expected
+// to be runnable invocations of one CLI command (possibly piped to
+// another tool — that other tool is the user's shell, not pad's).
+func shellSplit(s string) ([]string, error) {
+	var tokens []string
+	var cur strings.Builder
+	var inDQuote, inSQuote, escape bool
+	flush := func() {
+		if cur.Len() > 0 {
+			tokens = append(tokens, cur.String())
+			cur.Reset()
+		}
+	}
+	for _, r := range s {
+		switch {
+		case escape:
+			cur.WriteRune(r)
+			escape = false
+		case r == '\\' && !inSQuote:
+			escape = true
+		case r == '"' && !inSQuote:
+			inDQuote = !inDQuote
+		case r == '\'' && !inDQuote:
+			inSQuote = !inSQuote
+		case (r == ' ' || r == '\t') && !inDQuote && !inSQuote:
+			flush()
+		case (r == '|' || r == ';' || r == '&' || r == '>' || r == '<') && !inDQuote && !inSQuote:
+			// Pipeline boundary — return what we have so far. The rest
+			// of the string belongs to a different command (or the
+			// shell), which is out of scope for cmdhelp validation.
+			flush()
+			return tokens, nil
+		default:
+			cur.WriteRune(r)
+		}
+	}
+	if inDQuote || inSQuote {
+		return nil, fmt.Errorf("unterminated quote")
+	}
+	if escape {
+		return nil, fmt.Errorf("trailing backslash")
+	}
+	flush()
+	return tokens, nil
+}
+
+// ValidateBoolArity asserts that every bool-typed flag in doc obeys
+// spec §5.3: bool flags MUST be presence switches. They MUST NOT
+// appear in `--flag=value` form anywhere in their command's examples
+// (those should be declared as enum-typed instead).
+//
+// Returns one finding per violation. Empty slice means clean.
+func ValidateBoolArity(doc *Document) []string {
+	if doc == nil {
+		return nil
+	}
+	var findings []string
+	for path, cmd := range doc.Commands {
+		for fname, f := range cmd.Flags {
+			if f.Type != "bool" {
+				continue
+			}
+			needle := "--" + fname + "="
+			for i, ex := range cmd.Examples {
+				if strings.Contains(ex.Cmd, needle) {
+					findings = append(findings,
+						fmt.Sprintf("%s example[%d]: bool flag --%s appears in valued form (--%s=...) — spec §5.3 requires bool flags to be presence-only; declare as enum: [\"true\",\"false\"] for valued booleans",
+							path, i, fname, fname))
+				}
+			}
+		}
+	}
+	return findings
+}

--- a/internal/cmdhelp/example_validation.go
+++ b/internal/cmdhelp/example_validation.go
@@ -60,16 +60,12 @@ func validateExample(path string, idx int, ex Example, doc *Document, root *cobr
 		return nil
 	}
 
-	// Walk non-flag tokens through the cobra tree to find the target.
-	// flag-form tokens: "--name", "--name=value", "-n", "-n=value".
-	var nonFlags []string
-	for _, t := range tokens[1:] {
-		if strings.HasPrefix(t, "-") {
-			break
-		}
-		nonFlags = append(nonFlags, t)
-	}
-	target, _, ferr := root.Find(nonFlags)
+	// Pass the full post-binary token stream to cobra's Find. Cobra
+	// knows each command's flag set and skips flag/value pairs while
+	// matching subcommand names — so examples that interleave flags
+	// with subcommands (e.g. `pad --workspace foo item create task`)
+	// resolve to `item create`, not the root.
+	target, _, ferr := root.Find(tokens[1:])
 	if ferr != nil || target == nil {
 		return []string{fmt.Sprintf("%s example[%d]: command path doesn't resolve: %s", path, idx, ex.Cmd)}
 	}

--- a/internal/cmdhelp/example_validation_test.go
+++ b/internal/cmdhelp/example_validation_test.go
@@ -131,6 +131,32 @@ func TestValidateExamples_AcceptsNegateFlag(t *testing.T) {
 	}
 }
 
+func TestValidateExamples_FlagBeforeSubcommandResolvesToCorrectTarget(t *testing.T) {
+	// Cobra accepts flags interleaved with the command path — e.g.
+	// `pad --workspace foo item create task --priority high`.
+	// The validator MUST resolve to `item create` (not root) so leaf
+	// flags like --priority are checked against the leaf, not just
+	// against root's flag set. (Caught by Codex round 1.)
+	root := &cobra.Command{Use: "padtest"}
+	root.PersistentFlags().String("workspace", "", "workspace override")
+
+	create := &cobra.Command{
+		Use:     "create <coll>",
+		Short:   "create",
+		Example: `  padtest --workspace foo item create task --priority high`,
+	}
+	create.Flags().String("priority", "", "priority")
+
+	item := &cobra.Command{Use: "item", Short: "item group"}
+	item.AddCommand(create)
+	root.AddCommand(item)
+
+	doc := Build(root, root, Options{Binary: "padtest", MaxDepth: -1})
+	if findings := ValidateExamples(doc, root); len(findings) != 0 {
+		t.Errorf("flag-before-subcommand example should resolve cleanly; got: %v", findings)
+	}
+}
+
 func TestValidateExamples_AcceptsPersistentFlagFromAncestor(t *testing.T) {
 	// `--workspace` is a persistent root flag; it must be accepted on
 	// any subcommand example.

--- a/internal/cmdhelp/example_validation_test.go
+++ b/internal/cmdhelp/example_validation_test.go
@@ -1,0 +1,249 @@
+package cmdhelp
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestShellSplit_BasicCases(t *testing.T) {
+	cases := map[string][]string{
+		`pad item create task "Fix OAuth"`: {"pad", "item", "create", "task", "Fix OAuth"},
+		`pad item create idea 'one two'`:   {"pad", "item", "create", "idea", "one two"},
+		`pad foo --bar=baz qux`:            {"pad", "foo", "--bar=baz", "qux"},
+		`pad x \"escaped\"`:                {"pad", "x", `"escaped"`},
+		`pad   item    create`:             {"pad", "item", "create"},
+	}
+	for in, want := range cases {
+		got, err := shellSplit(in)
+		if err != nil {
+			t.Errorf("shellSplit(%q) error: %v", in, err)
+			continue
+		}
+		if len(got) != len(want) {
+			t.Errorf("shellSplit(%q) = %v (len %d), want %v (len %d)", in, got, len(got), want, len(want))
+			continue
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Errorf("shellSplit(%q)[%d] = %q, want %q", in, i, got[i], want[i])
+			}
+		}
+	}
+}
+
+func TestShellSplit_UnterminatedQuotesError(t *testing.T) {
+	if _, err := shellSplit(`pad "unterminated`); err == nil {
+		t.Errorf("expected error for unterminated double quote")
+	}
+	if _, err := shellSplit(`pad 'unterminated`); err == nil {
+		t.Errorf("expected error for unterminated single quote")
+	}
+}
+
+func TestValidateExamples_Clean(t *testing.T) {
+	// Build a tree where the example references real commands and flags.
+	root := &cobra.Command{Use: "padtest"}
+	root.PersistentFlags().String("workspace", "", "workspace override")
+
+	create := &cobra.Command{
+		Use:     "create <coll>",
+		Short:   "create item",
+		Example: `  padtest item create task --priority high`,
+	}
+	create.Flags().String("priority", "", "priority")
+
+	item := &cobra.Command{Use: "item", Short: "item group"}
+	item.AddCommand(create)
+	root.AddCommand(item)
+
+	doc := Build(root, root, Options{Binary: "padtest", MaxDepth: -1})
+	findings := ValidateExamples(doc, root)
+	if len(findings) != 0 {
+		t.Errorf("expected no findings, got: %v", findings)
+	}
+}
+
+func TestValidateExamples_DetectsTypoFlag(t *testing.T) {
+	// THIS IS THE DRIFT-PREVENTION CONTRACT TEST (spec §6 / §11 Q5).
+	// A typo in an example flag — `--priorty` instead of `--priority`
+	// — MUST be detected by ValidateExamples and reported with the
+	// offending command + example index.
+	root := &cobra.Command{Use: "padtest"}
+	leaf := &cobra.Command{
+		Use:     "leaf",
+		Short:   "leaf",
+		Example: `  padtest leaf --priorty high`, // typo
+	}
+	leaf.Flags().String("priority", "", "priority")
+	root.AddCommand(leaf)
+
+	doc := Build(root, root, Options{Binary: "padtest", MaxDepth: -1})
+	findings := ValidateExamples(doc, root)
+
+	if len(findings) == 0 {
+		t.Fatalf("expected at least one finding for --priorty typo, got none")
+	}
+	want := []string{"leaf", "example[0]", "priorty"}
+	for _, w := range want {
+		if !strings.Contains(findings[0], w) {
+			t.Errorf("finding should mention %q for triage; got: %q", w, findings[0])
+		}
+	}
+}
+
+func TestValidateExamples_DetectsUnknownCommand(t *testing.T) {
+	// Example references a command path that doesn't exist on the tree.
+	// Common when a command gets renamed/deleted but the example block
+	// in Long stays stale.
+	root := &cobra.Command{Use: "padtest"}
+	leaf := &cobra.Command{
+		Use:     "leaf",
+		Short:   "leaf",
+		Example: `  padtest does-not-exist --foo bar`,
+	}
+	root.AddCommand(leaf)
+
+	doc := Build(root, root, Options{Binary: "padtest", MaxDepth: -1})
+	findings := ValidateExamples(doc, root)
+	if len(findings) == 0 {
+		t.Errorf("expected finding for unknown command 'does-not-exist'")
+	}
+}
+
+func TestValidateExamples_AcceptsNegateFlag(t *testing.T) {
+	// `--no-cache` form must be accepted when the underlying flag is
+	// `cache` (negation per spec §5.3).
+	root := &cobra.Command{Use: "padtest"}
+	leaf := &cobra.Command{
+		Use:     "leaf",
+		Short:   "leaf",
+		Example: `  padtest leaf --no-cache`,
+	}
+	leaf.Flags().Bool("cache", true, "use cache")
+	root.AddCommand(leaf)
+
+	doc := Build(root, root, Options{Binary: "padtest", MaxDepth: -1})
+	findings := ValidateExamples(doc, root)
+	if len(findings) != 0 {
+		t.Errorf("--no-cache should resolve via negate-flag rule, got findings: %v", findings)
+	}
+}
+
+func TestValidateExamples_AcceptsPersistentFlagFromAncestor(t *testing.T) {
+	// `--workspace` is a persistent root flag; it must be accepted on
+	// any subcommand example.
+	root := &cobra.Command{Use: "padtest"}
+	root.PersistentFlags().String("workspace", "", "workspace override")
+	leaf := &cobra.Command{
+		Use:     "leaf",
+		Short:   "leaf",
+		Example: `  padtest leaf --workspace foo`,
+	}
+	root.AddCommand(leaf)
+
+	doc := Build(root, root, Options{Binary: "padtest", MaxDepth: -1})
+	if findings := ValidateExamples(doc, root); len(findings) != 0 {
+		t.Errorf("persistent root flag should resolve on subcommand, got: %v", findings)
+	}
+}
+
+func TestValidateExamples_SkipsNonBinaryExamples(t *testing.T) {
+	// Documentation snippets that aren't pad invocations (e.g.
+	// `cat ~/foo.json | jq` to show output) are skipped, not flagged.
+	// The drift contract is for pad-invocation drift specifically;
+	// non-pad lines are docs prose.
+	root := &cobra.Command{Use: "padtest"}
+	leaf := &cobra.Command{
+		Use:   "leaf",
+		Short: "leaf",
+		Example: `  cat ~/.padtest/foo.json | jq
+  padtest leaf --real-flag`,
+	}
+	leaf.Flags().Bool("real-flag", false, "real flag")
+	root.AddCommand(leaf)
+
+	doc := Build(root, root, Options{Binary: "padtest", MaxDepth: -1})
+	findings := ValidateExamples(doc, root)
+	if len(findings) != 0 {
+		t.Errorf("non-pad example should be skipped silently; got: %v", findings)
+	}
+}
+
+func TestValidateExamples_PipelineStopsAtFirstCommand(t *testing.T) {
+	// `padtest leaf --foo | jq -r .x` — the validator only checks the
+	// first command in the pipeline. The `-r .x` after the pipe
+	// belongs to jq, not padtest, and would erroneously flag if we
+	// kept tokenizing past `|`.
+	root := &cobra.Command{Use: "padtest"}
+	leaf := &cobra.Command{
+		Use:     "leaf",
+		Short:   "leaf",
+		Example: `  padtest leaf --foo | jq -r .x`,
+	}
+	leaf.Flags().Bool("foo", false, "foo flag")
+	root.AddCommand(leaf)
+
+	doc := Build(root, root, Options{Binary: "padtest", MaxDepth: -1})
+	if findings := ValidateExamples(doc, root); len(findings) != 0 {
+		t.Errorf("pipeline should be honored; got: %v", findings)
+	}
+}
+
+func TestParseExamplesFromLong_StripsSameLineComments(t *testing.T) {
+	// Pad's existing convention: trailing `# annotation` on an example
+	// line. Should be stripped before recording the example.
+	long := `Examples:
+  pad attachment list --item TASK-5    # one item's attachments
+  pad attachment list --category image # filter by category`
+
+	got := parseExamplesFromLong(long)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 examples, got %d: %+v", len(got), got)
+	}
+	if strings.Contains(got[0].Cmd, "#") {
+		t.Errorf("trailing comment leaked into example[0]: %q", got[0].Cmd)
+	}
+	if got[0].Cmd != "pad attachment list --item TASK-5" {
+		t.Errorf("example[0] = %q, want stripped form", got[0].Cmd)
+	}
+}
+
+func TestValidateBoolArity_DetectsValuedBool(t *testing.T) {
+	// Spec §5.3: bool flags MUST be presence-only. An example using
+	// `--cache=true` violates the contract.
+	root := &cobra.Command{Use: "padtest"}
+	leaf := &cobra.Command{
+		Use:     "leaf",
+		Short:   "leaf",
+		Example: `  padtest leaf --cache=true`,
+	}
+	leaf.Flags().Bool("cache", false, "cache")
+	root.AddCommand(leaf)
+
+	doc := Build(root, root, Options{Binary: "padtest", MaxDepth: -1})
+	findings := ValidateBoolArity(doc)
+	if len(findings) == 0 {
+		t.Errorf("expected violation for --cache=true on bool flag")
+	}
+	if len(findings) > 0 && !strings.Contains(findings[0], "cache") {
+		t.Errorf("finding should mention the offending flag: %q", findings[0])
+	}
+}
+
+func TestValidateBoolArity_AcceptsPresenceForm(t *testing.T) {
+	root := &cobra.Command{Use: "padtest"}
+	leaf := &cobra.Command{
+		Use:     "leaf",
+		Short:   "leaf",
+		Example: `  padtest leaf --cache`,
+	}
+	leaf.Flags().Bool("cache", false, "cache")
+	root.AddCommand(leaf)
+
+	doc := Build(root, root, Options{Binary: "padtest", MaxDepth: -1})
+	if findings := ValidateBoolArity(doc); len(findings) != 0 {
+		t.Errorf("--cache (presence form) should be accepted, got: %v", findings)
+	}
+}

--- a/internal/cmdhelp/json.go
+++ b/internal/cmdhelp/json.go
@@ -237,6 +237,16 @@ func parseExamplesFromLong(long string) []Example {
 		if line == trimmed && len(examples) > 0 {
 			break
 		}
+		// Strip a trailing same-line comment ("  # blah") so it doesn't
+		// pollute the recorded example. Pad's existing Long blocks use
+		// this idiom occasionally, e.g.
+		//   pad attachment list --item TASK-5    # one item's attachments
+		if hashIdx := stripCommentIndex(trimmed); hashIdx >= 0 {
+			trimmed = strings.TrimRight(trimmed[:hashIdx], " \t")
+		}
+		if trimmed == "" {
+			continue
+		}
 		examples = append(examples, Example{Cmd: trimmed})
 	}
 	if len(examples) == 0 {
@@ -496,4 +506,37 @@ func firstLine(s string) string {
 		return strings.TrimSpace(s[:i])
 	}
 	return strings.TrimSpace(s)
+}
+
+// stripCommentIndex returns the position of an unquoted `#` that begins
+// a same-line comment in s, or -1 if no such comment exists. Comments
+// preceded by an unquoted `#` and at least one whitespace separator are
+// considered comments; `#abc` glued to a token is left alone (could be
+// a literal). Quote handling matches shell semantics: `#` inside double
+// or single quotes is a literal character, not a comment.
+func stripCommentIndex(s string) int {
+	var inDQuote, inSQuote, escape bool
+	for i, r := range s {
+		switch {
+		case escape:
+			escape = false
+		case r == '\\' && !inSQuote:
+			escape = true
+		case r == '"' && !inSQuote:
+			inDQuote = !inDQuote
+		case r == '\'' && !inDQuote:
+			inSQuote = !inSQuote
+		case r == '#' && !inDQuote && !inSQuote:
+			// Require whitespace before # (or # at start) to avoid eating
+			// literal #s glued to a token.
+			if i == 0 {
+				return i
+			}
+			prev := s[i-1]
+			if prev == ' ' || prev == '\t' {
+				return i
+			}
+		}
+	}
+	return -1
 }

--- a/internal/cmdhelp/schema.go
+++ b/internal/cmdhelp/schema.go
@@ -1,0 +1,42 @@
+package cmdhelp
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+)
+
+// SchemaFileName is the conventional filename for the cmdhelp v0.1
+// JSON Schema, located at `schema/cmdhelp.schema.json` relative to
+// the pad repository root.
+const SchemaFileName = "cmdhelp.schema.json"
+
+// FindAndCompileSchema locates and compiles the cmdhelp v0.1 JSON
+// Schema by walking up from `startDir` until it finds a directory
+// containing `schema/cmdhelp.schema.json`. Returns the compiled
+// schema ready for Validate(), or an error if the file isn't found
+// or fails to compile.
+//
+// Used by tests in this package and in cmd/pad to validate emitted
+// JSON against the published schema as a CI gate.
+func FindAndCompileSchema(startDir string) (*jsonschema.Schema, error) {
+	dir := startDir
+	for {
+		path := filepath.Join(dir, "schema", SchemaFileName)
+		if _, err := os.Stat(path); err == nil {
+			c := jsonschema.NewCompiler()
+			s, err := c.Compile(path)
+			if err != nil {
+				return nil, fmt.Errorf("compile %s: %w", path, err)
+			}
+			return s, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return nil, fmt.Errorf("schema/%s not found by walking up from %s", SchemaFileName, startDir)
+		}
+		dir = parent
+	}
+}

--- a/internal/cmdhelp/schema_test.go
+++ b/internal/cmdhelp/schema_test.go
@@ -1,0 +1,115 @@
+package cmdhelp
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+)
+
+// loadSchemaForTest is a test-only wrapper around FindAndCompileSchema
+// that fails the test on error and starts the walk from the test's CWD.
+func loadSchemaForTest(t *testing.T) *jsonschema.Schema {
+	t.Helper()
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	schema, err := FindAndCompileSchema(cwd)
+	if err != nil {
+		t.Fatalf("load schema: %v", err)
+	}
+	return schema
+}
+
+// validateAgainstSchema runs the compiled schema against the given JSON
+// document and returns the validation error (nil on success).
+func validateAgainstSchema(t *testing.T, schema *jsonschema.Schema, jsonBytes []byte) error {
+	t.Helper()
+	var doc interface{}
+	if err := json.Unmarshal(jsonBytes, &doc); err != nil {
+		t.Fatalf("unmarshal emitted JSON: %v", err)
+	}
+	return schema.Validate(doc)
+}
+
+func TestEmittedJSON_ValidatesAgainstSchema_StaticTree(t *testing.T) {
+	// Lock the static-tree path: emit the synthetic tree (no resolver,
+	// no dynamic enums) and assert the result satisfies every contract
+	// in cmdhelp.schema.json. This protects every TASK-934/935 emitter
+	// change going forward — break the schema contract and CI fails.
+	root := buildSyntheticTree()
+	var buf bytes.Buffer
+	if err := EmitJSON(root, root, Options{
+		Binary:   "padtest",
+		Version:  "test",
+		Homepage: "https://example.test",
+		MaxDepth: -1,
+	}, &buf); err != nil {
+		t.Fatalf("EmitJSON: %v", err)
+	}
+
+	schema := loadSchemaForTest(t)
+	if err := validateAgainstSchema(t, schema, buf.Bytes()); err != nil {
+		t.Errorf("synthetic tree's emitted JSON fails schema validation:\n%v\n--- output ---\n%s", err, buf.String())
+	}
+}
+
+func TestEmittedJSON_ValidatesAgainstSchema_AfterDynamicResolution(t *testing.T) {
+	// Same lock, post-resolver: dynamic enum injection must not break
+	// schema validity. Common regressions this guards against:
+	//   - dynamic enum_source not matching `^dynamic:.+$`
+	//   - non-numeric exit_code keys after some future templating
+	//   - flag-name keys violating the propertyNames pattern
+	root := buildSyntheticTree()
+	r := &Resolver{
+		Workspace: "fixture",
+		ArgEnumSources: map[string]string{
+			"collection": EnumSourceCollections,
+		},
+		Sources: map[string]DynamicEnum{
+			EnumSourceCollections: func() ([]interface{}, error) {
+				return []interface{}{"tasks", "ideas"}, nil
+			},
+		},
+	}
+	var buf bytes.Buffer
+	if err := EmitJSON(root, root, Options{
+		Binary:   "padtest",
+		MaxDepth: -1,
+		Resolver: r,
+	}, &buf); err != nil {
+		t.Fatalf("EmitJSON: %v", err)
+	}
+
+	schema := loadSchemaForTest(t)
+	if err := validateAgainstSchema(t, schema, buf.Bytes()); err != nil {
+		t.Errorf("post-resolver JSON fails schema validation:\n%v\n--- output ---\n%s", err, buf.String())
+	}
+}
+
+func TestEmittedJSON_ValidatesAgainstSchema_NoWorkspaceFallback(t *testing.T) {
+	// When dynamic resolution would fail (no workspace, no live values),
+	// the document must STILL validate against the schema. This is the
+	// graceful-fallback guarantee from TASK-936.
+	root := buildSyntheticTree()
+	r := &Resolver{
+		// No workspace, no sources — resolver is essentially a no-op
+		// shape but with the path set up for testing the fallback.
+	}
+	var buf bytes.Buffer
+	if err := EmitJSON(root, root, Options{
+		Binary:   "padtest",
+		MaxDepth: -1,
+		Resolver: r,
+	}, &buf); err != nil {
+		t.Fatalf("EmitJSON: %v", err)
+	}
+
+	schema := loadSchemaForTest(t)
+	if err := validateAgainstSchema(t, schema, buf.Bytes()); err != nil {
+		t.Errorf("no-workspace fallback JSON fails schema validation:\n%v", err)
+	}
+}


### PR DESCRIPTION
## Summary

The verification layer that turns cmdhelp v0.1 from implementation into a stable contract. Three categories, all running in `go test ./...`:

### 1. Schema validation as a CI gate

- `internal/cmdhelp/schema_test.go` — synthetic tree's emitted JSON validates against `schema/cmdhelp.schema.json` after the static walk, after dynamic resolution, and in the no-workspace fallback.
- `cmd/pad/cmdhelp_real_test.go::TestRealPadTree_ValidatesAgainstSchema` — the **real** pad cobra tree's emitted JSON satisfies every contract in the published schema. Future regressions this catches: types outside the closed vocabulary, non-numeric `exit_code` keys, flag names violating the `propertyNames` pattern, malformed `cmdhelp_version`, accidentally omitted required fields.

### 2. Drift-prevention contract (spec §6 / §11 Q5)

- `internal/cmdhelp/example_validation.go::ValidateExamples` walks every example's `cmd`, tokenizes with `shellSplit`, resolves non-flag tokens against the live cobra tree, and asserts every `--flag` exists on the resolved command (or any ancestor for persistent flags). Negation form `--no-cache` honored per spec §5.3.
- `shellSplit` handles quotes + backslash escape and **stops at unquoted pipeline boundaries** (`|`, `;`, `&`, `>`, `<`) — only the first command in a pipeline is validated.
- `ValidateBoolArity` asserts no bool flag appears in valued form (`--flag=value`) anywhere in its examples.
- `cmd/pad/cmdhelp_real_test.go` runs both against the real pad tree as CI gates.
- Negative tests prove the validator catches: typo'd flag (`--priorty`), unknown command path, valued-form bool flag, malformed quotes.

### 3. Capabilities form equivalence (spec §8)

- Both forms (`help --capabilities` and `--cmdhelp-capabilities` fallback) produce byte-identical output.
- Side-effect-free guarantee verified by passing garbage args alongside the fallback flag.

## Context

Implements `TASK-938` under `PLAN-930`. Builds on the schema (`#325`), emitters (`#327` / `#328`), dynamic resolution (`#329`), capabilities (`#330`), and the Long-Examples fallback (`#331`).

## Refactors enabling the tests

- **`cmd/pad/main.go`** — extracted `newRootCmd()` so tests can build the real cobra tree without running it. `main()` body shrinks to two lines.
- **`cmd/pad/main.go`** — extracted `handleCmdhelpCapabilitiesFallback()` so the fallback's side-effect-free contract is directly assertable in-process (no subprocess needed).

## Parser improvements driven by real-tree findings

The drift validator caught **5 real issues** in pad's existing example blocks on first run. Two are now parser improvements (legitimate ambiguities):

- `parseExamplesFromLong` strips same-line `# comment` annotations (`pad foo --bar # one item's attachments`).
- `stripCommentIndex` is quote-aware: `#` inside `"..."` or `'...'` stays literal.

The remaining 3 fell into two cases:
- **Non-pad invocations** (`cat ~/foo.json | jq`) — these are docs prose, not pad invocations. The validator now skips them silently rather than failing. The drift contract is for pad-invocation drift specifically.
- **Pipelines** (`pad attachment download <id> - | open -f -a Preview`) — `shellSplit` now stops at the pipe so the `-f -a` flags belonging to `open` aren't checked against pad's flag tree.

One genuinely **malformed example** caught: `pad github link TASK-5    Link current branch's PR to TASK-5` — annotations on example lines separated only by spaces (no `#`), which created an unterminated quote at the apostrophe in "branch's". Fixed in `cmd/pad/main.go` to use `#` separators. **The validator caught this on first run** — exactly as the §6 drift contract intends.

## New dependency

`github.com/santhosh-tekuri/jsonschema/v6 v6.0.2` — Go JSON Schema validator supporting draft 2020-12 (matches `$schema` in `cmdhelp.schema.json`). Tiny dep, no transitive runtime deps.

## New helpers in `internal/cmdhelp/`

- `FindAndCompileSchema(startDir)` — walks up to locate `schema/cmdhelp.schema.json` and returns a compiled schema. Reusable by any consumer that wants to validate cmdhelp documents (other CLIs, agent harnesses, MCP servers).

## Test plan

- [x] **3 schema-validation tests** in `internal/cmdhelp/schema_test.go` covering static / post-resolver / no-workspace paths.
- [x] **10 validator tests** in `internal/cmdhelp/example_validation_test.go`: clean baseline, typo flag detection, unknown command detection, negate-flag acceptance, persistent-flag acceptance from ancestor, non-binary skip, pipeline stop, same-line comment stripping, valued-bool detection, presence-form acceptance.
- [x] **6 real-tree tests** in `cmd/pad/cmdhelp_real_test.go`: schema validation, drift validator, bool arity, capabilities equivalence, side-effect-free fallback, fallback-not-triggered-without-flag.
- [x] All 35 prior cmdhelp + 17 routing tests still pass.
- [x] `make check` clean (lint + go test + web build).

## What's now locked

After this PR merges, the following can no longer regress without breaking CI:

| Contract | Asserted by |
|---|---|
| Spec §3-§9 envelope shape | `TestRealPadTree_ValidatesAgainstSchema` |
| Spec §6 drift prevention | `TestRealPadTree_ExampleDriftValidator` |
| Spec §5.3 boolean arity | `TestRealPadTree_BoolArityRule` |
| Spec §8 capability bit format | `TestHelpCmd_CapabilitiesExactString` |
| Spec §8 fallback equivalence | `TestCapabilities_FallbackEquivalent` |
| Spec §8 side-effect-free | `TestCapabilities_FallbackIsSideEffectFree` |

Adding a typo'd flag in any cobra `Long` block in `cmd/pad` will now break the build. The user-visible drift contract from IDEA-927 §6 is enforced.