### PR TITLE
feat(mcp): cmdhelp-derived tool registry + shell-out dispatch (TASK-945)

### DIFF
--- a/cmd/pad/mcp.go
+++ b/cmd/pad/mcp.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 
+	"github.com/PerpetualSoftware/pad/internal/cmdhelp"
 	mcpserver "github.com/PerpetualSoftware/pad/internal/mcp"
 )
 
@@ -29,7 +31,8 @@ https://getpad.dev/mcp/local for client configuration.`,
 
 // mcpServeCmd implements the stdio MCP server. The cobra command is a
 // thin wrapper around internal/mcp.Server — all transport / handshake
-// behaviour lives in the package so tests can drive it directly.
+// behaviour and tool registration live in the package so tests can
+// drive them directly.
 func mcpServeCmd() *cobra.Command {
 	var debug bool
 	cmd := &cobra.Command{
@@ -43,6 +46,12 @@ etc.) per its mcp.json configuration. Direct human invocation is rare;
 when running interactively you'll see an idle process waiting for the
 client's initialize message.
 
+The tool surface is generated automatically from this binary's
+command tree (cmdhelp v0.1) — every leaf command becomes an MCP
+tool, except the curated allow-list exclusions (db ops, auth setup,
+init, etc.). Use ` + "`pad_set_workspace`" + ` to set the default
+workspace for the session.
+
 Shuts down cleanly on EOF, SIGINT, or SIGTERM.`,
 		// Errors here are connection-level rather than arg-validation,
 		// so suppress cobra's auto-printed usage block — it would
@@ -53,6 +62,40 @@ Shuts down cleanly on EOF, SIGINT, or SIGTERM.`,
 				Version: fullVersion(),
 				Debug:   debug,
 			})
+
+			// Build cmdhelp Document from the live cobra tree. Same
+			// emitter that powers `pad help --format json`, so the MCP
+			// surface and the agent-facing docs stay in lockstep.
+			root := cmd.Root()
+			doc := cmdhelp.Build(root, root, cmdhelp.Options{
+				Binary:   "pad",
+				Version:  fullVersion(),
+				Homepage: padHomepage,
+				MaxDepth: -1,
+			})
+
+			// Resolve the running pad binary so the dispatcher can
+			// re-invoke us as a subprocess. Falls back to argv[0] if
+			// os.Executable fails (rare; mostly happens on exotic
+			// /proc-less platforms).
+			bin, err := os.Executable()
+			if err != nil || bin == "" {
+				bin = os.Args[0]
+			}
+
+			// Seed the session workspace from --workspace if the user
+			// passed it. After that, agents can update the default via
+			// the pad_set_workspace tool.
+			state := mcpserver.NewWorkspaceState(workspaceFlag)
+
+			if _, err := mcpserver.Register(srv.MCP(), mcpserver.RegistryOptions{
+				Doc:        doc,
+				Workspace:  state,
+				Dispatcher: &mcpserver.ExecDispatcher{Binary: bin},
+			}); err != nil {
+				return fmt.Errorf("pad mcp serve: register tools: %w", err)
+			}
+
 			if err := srv.Run(cmd.Context()); err != nil {
 				return fmt.Errorf("pad mcp serve: %w", err)
 			}

--- a/cmd/pad/mcp.go
+++ b/cmd/pad/mcp.go
@@ -88,10 +88,20 @@ Shuts down cleanly on EOF, SIGINT, or SIGTERM.`,
 			// the pad_set_workspace tool.
 			state := mcpserver.NewWorkspaceState(workspaceFlag)
 
+			// Forward root persistent flags captured at startup (e.g.
+			// --url) to every dispatched subprocess. Empty values are
+			// skipped by BuildCLIArgs so this is safe when the user
+			// didn't pass them. --workspace is excluded — it lives in
+			// WorkspaceState and is mutable via pad_set_workspace.
+			rootFlags := map[string]string{
+				"url": urlFlag,
+			}
+
 			if _, err := mcpserver.Register(srv.MCP(), mcpserver.RegistryOptions{
 				Doc:        doc,
 				Workspace:  state,
 				Dispatcher: &mcpserver.ExecDispatcher{Binary: bin},
+				RootFlags:  rootFlags,
 			}); err != nil {
 				return fmt.Errorf("pad mcp serve: register tools: %w", err)
 			}

--- a/internal/mcp/dispatch.go
+++ b/internal/mcp/dispatch.go
@@ -78,12 +78,23 @@ func (d *ExecDispatcher) Dispatch(ctx context.Context, cmdPath []string, cliArgs
 //     presence-only (`--flag`, never `--flag=true`).
 //   - Repeatable / slice-typed flags expand to repeated `--flag value`
 //     pairs.
+//   - Flags listed in flagsHiddenFromMCP (e.g. `stdin`) are dropped
+//     defensively — they reference subprocess stdin which the MCP
+//     transport doesn't pipe through.
 //   - sessionWorkspace is appended as `--workspace <ws>` if the
 //     command does NOT already define a `workspace` flag in the
 //     input map AND sessionWorkspace is non-empty.
+//   - rootFlags (e.g. `--url` captured at server startup) are
+//     appended when the input doesn't already supply them. Empty
+//     values in rootFlags are skipped.
 //   - `--format json` is appended unless the input explicitly sets a
 //     format flag (e.g. an agent specifically requests markdown).
-func BuildCLIArgs(cmdInfo cmdhelp.Command, input map[string]any, sessionWorkspace string) ([]string, error) {
+func BuildCLIArgs(
+	cmdInfo cmdhelp.Command,
+	input map[string]any,
+	sessionWorkspace string,
+	rootFlags map[string]string,
+) ([]string, error) {
 	if input == nil {
 		input = map[string]any{}
 	}
@@ -119,6 +130,12 @@ func BuildCLIArgs(cmdInfo cmdhelp.Command, input map[string]any, sessionWorkspac
 	workspaceProvided := false
 	var flagArgs []string
 	for _, name := range flagNames {
+		// Defensive: even if an agent's stale schema cache passes
+		// stdin=true, drop it here — buildTool already hides it from
+		// new schemas, and the running subprocess can't read agent stdin.
+		if _, hidden := flagsHiddenFromMCP[name]; hidden {
+			continue
+		}
 		flag := cmdInfo.Flags[name]
 		val, ok := input[name]
 		if !ok {
@@ -155,6 +172,27 @@ func BuildCLIArgs(cmdInfo cmdhelp.Command, input map[string]any, sessionWorkspac
 	}
 
 	out := append(positionals, flagArgs...)
+
+	// Inject root-level flags (e.g. --url) when the input didn't
+	// already supply them. Sorted for deterministic test output.
+	if len(rootFlags) > 0 {
+		rootNames := make([]string, 0, len(rootFlags))
+		for name := range rootFlags {
+			rootNames = append(rootNames, name)
+		}
+		sort.Strings(rootNames)
+		for _, name := range rootNames {
+			val := rootFlags[name]
+			if val == "" {
+				continue
+			}
+			if _, alreadyInInput := input[name]; alreadyInInput {
+				continue
+			}
+			out = append(out, "--"+name, val)
+		}
+	}
+
 	if !workspaceProvided && sessionWorkspace != "" {
 		out = append(out, "--workspace", sessionWorkspace)
 	}

--- a/internal/mcp/dispatch.go
+++ b/internal/mcp/dispatch.go
@@ -1,0 +1,213 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"sort"
+	"strings"
+
+	"github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/PerpetualSoftware/pad/internal/cmdhelp"
+)
+
+// Dispatcher executes a pad CLI command on behalf of a tool call. It
+// always returns a *mcp.CallToolResult — error paths set IsError on
+// the result so MCP clients see structured stderr without having to
+// distinguish protocol errors from tool errors.
+type Dispatcher interface {
+	Dispatch(ctx context.Context, cmdPath []string, cliArgs []string) (*mcp.CallToolResult, error)
+}
+
+// ExecDispatcher shells out to the pad binary at Binary. stdout is
+// returned as Text content; if it parses as JSON the result is also
+// surfaced via StructuredContent so MCP clients can consume it
+// natively. Non-zero exit returns an IsError-flagged result with
+// stderr as the message.
+type ExecDispatcher struct {
+	// Binary is the path to the pad executable. Required.
+	Binary string
+}
+
+// Dispatch runs `<Binary> <cmdPath...> <cliArgs...>` and packages the
+// output for an MCP client.
+func (d *ExecDispatcher) Dispatch(ctx context.Context, cmdPath []string, cliArgs []string) (*mcp.CallToolResult, error) {
+	if d.Binary == "" {
+		return mcp.NewToolResultError("dispatcher: binary path not configured"), nil
+	}
+	full := append(append([]string{}, cmdPath...), cliArgs...)
+	cmd := exec.CommandContext(ctx, d.Binary, full...)
+	var stdout, stderr strings.Builder
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if msg == "" {
+			msg = err.Error()
+		}
+		return mcp.NewToolResultErrorf(
+			"pad %s failed: %s", strings.Join(cmdPath, " "), msg,
+		), nil
+	}
+	out := stdout.String()
+	// If stdout is JSON, surface it as structured content alongside
+	// the text fallback. This is what `--format json` emits for most
+	// pad commands; clients that parse structured content (Claude
+	// Desktop, Cursor) get richer rendering.
+	if trimmed := strings.TrimSpace(out); strings.HasPrefix(trimmed, "{") || strings.HasPrefix(trimmed, "[") {
+		var parsed any
+		if json.Unmarshal([]byte(trimmed), &parsed) == nil {
+			return mcp.NewToolResultStructured(parsed, out), nil
+		}
+	}
+	return mcp.NewToolResultText(out), nil
+}
+
+// BuildCLIArgs translates an MCP tool call's JSON arguments into the
+// CLI argument list that should be appended after the command path.
+// Pure function — no side effects, no subprocess — so it tests cleanly.
+//
+// Behaviour:
+//   - cmdInfo.Args are emitted as positional arguments in their
+//     declared order. Required args missing from input return an error.
+//   - Repeatable args expand each element into a separate positional.
+//   - cmdInfo.Flags are emitted as `--flag value` pairs in
+//     alphabetical order (deterministic for tests). Bool flags are
+//     presence-only (`--flag`, never `--flag=true`).
+//   - Repeatable / slice-typed flags expand to repeated `--flag value`
+//     pairs.
+//   - sessionWorkspace is appended as `--workspace <ws>` if the
+//     command does NOT already define a `workspace` flag in the
+//     input map AND sessionWorkspace is non-empty.
+//   - `--format json` is appended unless the input explicitly sets a
+//     format flag (e.g. an agent specifically requests markdown).
+func BuildCLIArgs(cmdInfo cmdhelp.Command, input map[string]any, sessionWorkspace string) ([]string, error) {
+	if input == nil {
+		input = map[string]any{}
+	}
+
+	var positionals []string
+	for _, arg := range cmdInfo.Args {
+		v, ok := input[arg.Name]
+		if !ok {
+			if arg.Required {
+				return nil, fmt.Errorf("missing required argument %q", arg.Name)
+			}
+			continue
+		}
+		if arg.Repeatable {
+			items, err := toStringSlice(v)
+			if err != nil {
+				return nil, fmt.Errorf("argument %q: %w", arg.Name, err)
+			}
+			positionals = append(positionals, items...)
+		} else {
+			positionals = append(positionals, fmt.Sprint(v))
+		}
+	}
+
+	// Sorted flag order makes test assertions stable.
+	flagNames := make([]string, 0, len(cmdInfo.Flags))
+	for name := range cmdInfo.Flags {
+		flagNames = append(flagNames, name)
+	}
+	sort.Strings(flagNames)
+
+	formatProvided := false
+	workspaceProvided := false
+	var flagArgs []string
+	for _, name := range flagNames {
+		flag := cmdInfo.Flags[name]
+		val, ok := input[name]
+		if !ok {
+			continue
+		}
+		if name == "format" {
+			formatProvided = true
+		}
+		if name == "workspace" {
+			workspaceProvided = true
+		}
+		switch flag.Type {
+		case "bool":
+			b, err := toBool(val)
+			if err != nil {
+				return nil, fmt.Errorf("flag %q: %w", name, err)
+			}
+			if b {
+				flagArgs = append(flagArgs, "--"+name)
+			}
+		default:
+			if isSliceFlag(flag) {
+				items, err := toStringSlice(val)
+				if err != nil {
+					return nil, fmt.Errorf("flag %q: %w", name, err)
+				}
+				for _, item := range items {
+					flagArgs = append(flagArgs, "--"+name, item)
+				}
+				continue
+			}
+			flagArgs = append(flagArgs, "--"+name, fmt.Sprint(val))
+		}
+	}
+
+	out := append(positionals, flagArgs...)
+	if !workspaceProvided && sessionWorkspace != "" {
+		out = append(out, "--workspace", sessionWorkspace)
+	}
+	if !formatProvided {
+		out = append(out, "--format", "json")
+	}
+	return out, nil
+}
+
+// isSliceFlag is true when a flag should be emitted as repeated
+// `--flag value` pairs rather than a single `--flag value`. Covers
+// both pflag's slice types and cmdhelp's `repeatable` annotation.
+func isSliceFlag(f cmdhelp.Flag) bool {
+	if f.Repeatable {
+		return true
+	}
+	switch f.Type {
+	case "[]string", "stringSlice", "[]int", "intSlice", "stringArray":
+		return true
+	}
+	return false
+}
+
+func toStringSlice(v any) ([]string, error) {
+	switch t := v.(type) {
+	case []string:
+		return t, nil
+	case []any:
+		out := make([]string, 0, len(t))
+		for _, e := range t {
+			out = append(out, fmt.Sprint(e))
+		}
+		return out, nil
+	case string:
+		return []string{t}, nil
+	}
+	return nil, fmt.Errorf("expected array or string, got %T", v)
+}
+
+func toBool(v any) (bool, error) {
+	switch t := v.(type) {
+	case bool:
+		return t, nil
+	case string:
+		switch t {
+		case "true", "1", "yes":
+			return true, nil
+		case "false", "0", "no", "":
+			return false, nil
+		}
+	case json.Number:
+		s := t.String()
+		return s != "" && s != "0", nil
+	}
+	return false, fmt.Errorf("expected bool, got %T", v)
+}

--- a/internal/mcp/dispatch_test.go
+++ b/internal/mcp/dispatch_test.go
@@ -23,7 +23,7 @@ func TestBuildCLIArgs_PositionalsAndScalarFlags(t *testing.T) {
 		"title":      "Fix OAuth",
 		"priority":   "high",
 		"stdin":      false, // false bool should be omitted
-	}, "")
+	}, "", nil)
 	if err != nil {
 		t.Fatalf("BuildCLIArgs: %v", err)
 	}
@@ -39,17 +39,105 @@ func TestBuildCLIArgs_PositionalsAndScalarFlags(t *testing.T) {
 
 func TestBuildCLIArgs_BoolPresenceForm(t *testing.T) {
 	// Spec §5.3: bool flags MUST be presence-only (no =true).
-	// Here `stdin: true` should emit just `--stdin`, no value.
+	// `dry-run: true` should emit just `--dry-run`, no value.
 	cmd := cmdhelp.Command{
-		Flags: map[string]cmdhelp.Flag{"stdin": {Type: "bool"}},
+		Flags: map[string]cmdhelp.Flag{"dry-run": {Type: "bool"}},
 	}
-	got, err := BuildCLIArgs(cmd, map[string]any{"stdin": true}, "")
+	got, err := BuildCLIArgs(cmd, map[string]any{"dry-run": true}, "", nil)
 	if err != nil {
 		t.Fatalf("BuildCLIArgs: %v", err)
 	}
-	want := []string{"--stdin", "--format", "json"}
+	want := []string{"--dry-run", "--format", "json"}
 	if !equalSlice(got, want) {
 		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestBuildCLIArgs_StdinFlagDroppedDefensively(t *testing.T) {
+	// Even if an agent sends stdin: true (perhaps from a stale
+	// schema cache), BuildCLIArgs MUST drop it — the dispatcher
+	// can't pipe agent stdin to the subprocess, so passing
+	// --stdin would block on EOF and create empty content.
+	// `--content` is the agent-friendly equivalent.
+	cmd := cmdhelp.Command{
+		Flags: map[string]cmdhelp.Flag{
+			"stdin":   {Type: "bool"},
+			"content": {Type: "string"},
+		},
+	}
+	got, err := BuildCLIArgs(cmd, map[string]any{
+		"stdin":   true,
+		"content": "hello world",
+	}, "", nil)
+	if err != nil {
+		t.Fatalf("BuildCLIArgs: %v", err)
+	}
+	for _, a := range got {
+		if a == "--stdin" {
+			t.Errorf("stdin flag should be dropped, got: %v", got)
+		}
+	}
+	want := []string{"--content", "hello world", "--format", "json"}
+	if !equalSlice(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestBuildCLIArgs_RootFlagsInjected(t *testing.T) {
+	// --url at the root level should be forwarded to every dispatched
+	// subprocess. Without this, MCP clients configured as
+	// `pad --url X mcp serve` lose the URL on every tool call.
+	got, err := BuildCLIArgs(cmdhelp.Command{}, map[string]any{}, "",
+		map[string]string{"url": "https://api.example.com"})
+	if err != nil {
+		t.Fatalf("BuildCLIArgs: %v", err)
+	}
+	want := []string{"--url", "https://api.example.com", "--format", "json"}
+	if !equalSlice(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestBuildCLIArgs_RootFlagsEmptyValueSkipped(t *testing.T) {
+	// Server startup passes `map[string]string{"url": urlFlag}`
+	// unconditionally — when the user didn't pass --url at startup,
+	// urlFlag is empty and we must NOT inject `--url ""`.
+	got, err := BuildCLIArgs(cmdhelp.Command{}, map[string]any{}, "",
+		map[string]string{"url": ""})
+	if err != nil {
+		t.Fatalf("BuildCLIArgs: %v", err)
+	}
+	for _, a := range got {
+		if a == "--url" {
+			t.Errorf("empty root-flag value should be skipped, got: %v", got)
+		}
+	}
+}
+
+func TestBuildCLIArgs_RootFlagsDoNotOverrideExplicitInput(t *testing.T) {
+	// If the agent explicitly passes `url` in the tool args, the
+	// agent's value wins — startup-captured root flag is NOT
+	// appended (would produce two --url flags; pflag picks last,
+	// behaviour gets surprising).
+	cmd := cmdhelp.Command{
+		Flags: map[string]cmdhelp.Flag{"url": {Type: "string"}},
+	}
+	got, err := BuildCLIArgs(cmd, map[string]any{"url": "agent-url"}, "",
+		map[string]string{"url": "startup-url"})
+	if err != nil {
+		t.Fatalf("BuildCLIArgs: %v", err)
+	}
+	count := 0
+	for i, a := range got {
+		if a == "--url" && i+1 < len(got) {
+			count++
+			if got[i+1] != "agent-url" {
+				t.Errorf("agent value should win; got %q", got[i+1])
+			}
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected exactly 1 --url, got %d in %v", count, got)
 	}
 }
 
@@ -57,7 +145,7 @@ func TestBuildCLIArgs_RequiredArgMissingErrors(t *testing.T) {
 	cmd := cmdhelp.Command{
 		Args: []cmdhelp.Arg{{Name: "collection", Type: "string", Required: true}},
 	}
-	_, err := BuildCLIArgs(cmd, map[string]any{}, "")
+	_, err := BuildCLIArgs(cmd, map[string]any{}, "", nil)
 	if err == nil {
 		t.Errorf("expected error when required arg missing")
 	}
@@ -70,7 +158,7 @@ func TestBuildCLIArgs_OptionalArgMissingOK(t *testing.T) {
 	cmd := cmdhelp.Command{
 		Args: []cmdhelp.Arg{{Name: "filter", Type: "string"}}, // not required
 	}
-	got, err := BuildCLIArgs(cmd, map[string]any{}, "")
+	got, err := BuildCLIArgs(cmd, map[string]any{}, "", nil)
 	if err != nil {
 		t.Fatalf("BuildCLIArgs: %v", err)
 	}
@@ -82,7 +170,7 @@ func TestBuildCLIArgs_OptionalArgMissingOK(t *testing.T) {
 }
 
 func TestBuildCLIArgs_InjectsSessionWorkspace(t *testing.T) {
-	got, err := BuildCLIArgs(cmdhelp.Command{}, map[string]any{}, "docapp")
+	got, err := BuildCLIArgs(cmdhelp.Command{}, map[string]any{}, "docapp", nil)
 	if err != nil {
 		t.Fatalf("BuildCLIArgs: %v", err)
 	}
@@ -100,7 +188,7 @@ func TestBuildCLIArgs_ExplicitWorkspaceOverridesSession(t *testing.T) {
 	cmd := cmdhelp.Command{
 		Flags: map[string]cmdhelp.Flag{"workspace": {Type: "string"}},
 	}
-	got, err := BuildCLIArgs(cmd, map[string]any{"workspace": "client-ws"}, "session-ws")
+	got, err := BuildCLIArgs(cmd, map[string]any{"workspace": "client-ws"}, "session-ws", nil)
 	if err != nil {
 		t.Fatalf("BuildCLIArgs: %v", err)
 	}
@@ -124,7 +212,7 @@ func TestBuildCLIArgs_RepeatableArgExpands(t *testing.T) {
 	cmd := cmdhelp.Command{
 		Args: []cmdhelp.Arg{{Name: "ref", Type: "string", Repeatable: true, Required: true}},
 	}
-	got, err := BuildCLIArgs(cmd, map[string]any{"ref": []any{"TASK-5", "TASK-8"}}, "")
+	got, err := BuildCLIArgs(cmd, map[string]any{"ref": []any{"TASK-5", "TASK-8"}}, "", nil)
 	if err != nil {
 		t.Fatalf("BuildCLIArgs: %v", err)
 	}
@@ -143,7 +231,7 @@ func TestBuildCLIArgs_RepeatableFlag(t *testing.T) {
 			"field": {Type: "string", Repeatable: true},
 		},
 	}
-	got, err := BuildCLIArgs(cmd, map[string]any{"field": []any{"a=1", "b=2"}}, "")
+	got, err := BuildCLIArgs(cmd, map[string]any{"field": []any{"a=1", "b=2"}}, "", nil)
 	if err != nil {
 		t.Fatalf("BuildCLIArgs: %v", err)
 	}
@@ -159,7 +247,7 @@ func TestBuildCLIArgs_StringSliceTypeAlsoRepeats(t *testing.T) {
 			"tag": {Type: "[]string"}, // pflag-style slice type
 		},
 	}
-	got, err := BuildCLIArgs(cmd, map[string]any{"tag": []any{"x", "y"}}, "")
+	got, err := BuildCLIArgs(cmd, map[string]any{"tag": []any{"x", "y"}}, "", nil)
 	if err != nil {
 		t.Fatalf("BuildCLIArgs: %v", err)
 	}
@@ -175,7 +263,7 @@ func TestBuildCLIArgs_ExplicitFormatOverridesDefault(t *testing.T) {
 	cmd := cmdhelp.Command{
 		Flags: map[string]cmdhelp.Flag{"format": {Type: "string"}},
 	}
-	got, err := BuildCLIArgs(cmd, map[string]any{"format": "markdown"}, "")
+	got, err := BuildCLIArgs(cmd, map[string]any{"format": "markdown"}, "", nil)
 	if err != nil {
 		t.Fatalf("BuildCLIArgs: %v", err)
 	}

--- a/internal/mcp/dispatch_test.go
+++ b/internal/mcp/dispatch_test.go
@@ -1,0 +1,249 @@
+package mcp
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/cmdhelp"
+)
+
+func TestBuildCLIArgs_PositionalsAndScalarFlags(t *testing.T) {
+	cmd := cmdhelp.Command{
+		Args: []cmdhelp.Arg{
+			{Name: "collection", Type: "string", Required: true},
+			{Name: "title", Type: "string", Required: true},
+		},
+		Flags: map[string]cmdhelp.Flag{
+			"priority": {Type: "string"},
+			"stdin":    {Type: "bool"},
+		},
+	}
+	got, err := BuildCLIArgs(cmd, map[string]any{
+		"collection": "tasks",
+		"title":      "Fix OAuth",
+		"priority":   "high",
+		"stdin":      false, // false bool should be omitted
+	}, "")
+	if err != nil {
+		t.Fatalf("BuildCLIArgs: %v", err)
+	}
+	want := []string{
+		"tasks", "Fix OAuth",
+		"--priority", "high",
+		"--format", "json",
+	}
+	if !equalSlice(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestBuildCLIArgs_BoolPresenceForm(t *testing.T) {
+	// Spec §5.3: bool flags MUST be presence-only (no =true).
+	// Here `stdin: true` should emit just `--stdin`, no value.
+	cmd := cmdhelp.Command{
+		Flags: map[string]cmdhelp.Flag{"stdin": {Type: "bool"}},
+	}
+	got, err := BuildCLIArgs(cmd, map[string]any{"stdin": true}, "")
+	if err != nil {
+		t.Fatalf("BuildCLIArgs: %v", err)
+	}
+	want := []string{"--stdin", "--format", "json"}
+	if !equalSlice(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestBuildCLIArgs_RequiredArgMissingErrors(t *testing.T) {
+	cmd := cmdhelp.Command{
+		Args: []cmdhelp.Arg{{Name: "collection", Type: "string", Required: true}},
+	}
+	_, err := BuildCLIArgs(cmd, map[string]any{}, "")
+	if err == nil {
+		t.Errorf("expected error when required arg missing")
+	}
+	if err != nil && !strings.Contains(err.Error(), "collection") {
+		t.Errorf("error should mention the missing arg name; got: %v", err)
+	}
+}
+
+func TestBuildCLIArgs_OptionalArgMissingOK(t *testing.T) {
+	cmd := cmdhelp.Command{
+		Args: []cmdhelp.Arg{{Name: "filter", Type: "string"}}, // not required
+	}
+	got, err := BuildCLIArgs(cmd, map[string]any{}, "")
+	if err != nil {
+		t.Fatalf("BuildCLIArgs: %v", err)
+	}
+	// No positional, no flags set → just the format injection.
+	want := []string{"--format", "json"}
+	if !equalSlice(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestBuildCLIArgs_InjectsSessionWorkspace(t *testing.T) {
+	got, err := BuildCLIArgs(cmdhelp.Command{}, map[string]any{}, "docapp")
+	if err != nil {
+		t.Fatalf("BuildCLIArgs: %v", err)
+	}
+	want := []string{"--workspace", "docapp", "--format", "json"}
+	if !equalSlice(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestBuildCLIArgs_ExplicitWorkspaceOverridesSession(t *testing.T) {
+	// When the client passes workspace explicitly, the session
+	// default must NOT be appended — otherwise we'd send two
+	// --workspace flags and pflag would take whichever cobra picked
+	// last. The contract: client wins.
+	cmd := cmdhelp.Command{
+		Flags: map[string]cmdhelp.Flag{"workspace": {Type: "string"}},
+	}
+	got, err := BuildCLIArgs(cmd, map[string]any{"workspace": "client-ws"}, "session-ws")
+	if err != nil {
+		t.Fatalf("BuildCLIArgs: %v", err)
+	}
+	wsCount := 0
+	wsValue := ""
+	for i, a := range got {
+		if a == "--workspace" && i+1 < len(got) {
+			wsCount++
+			wsValue = got[i+1]
+		}
+	}
+	if wsCount != 1 {
+		t.Errorf("expected exactly 1 --workspace flag, got %d in %v", wsCount, got)
+	}
+	if wsValue != "client-ws" {
+		t.Errorf("client-supplied value should win; got %q", wsValue)
+	}
+}
+
+func TestBuildCLIArgs_RepeatableArgExpands(t *testing.T) {
+	cmd := cmdhelp.Command{
+		Args: []cmdhelp.Arg{{Name: "ref", Type: "string", Repeatable: true, Required: true}},
+	}
+	got, err := BuildCLIArgs(cmd, map[string]any{"ref": []any{"TASK-5", "TASK-8"}}, "")
+	if err != nil {
+		t.Fatalf("BuildCLIArgs: %v", err)
+	}
+	want := []string{"TASK-5", "TASK-8", "--format", "json"}
+	if !equalSlice(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestBuildCLIArgs_RepeatableFlag(t *testing.T) {
+	// `--field key=value` repeated for each entry per pflag's
+	// stringSlice convention (also covers cmdhelp's `repeatable: true`
+	// annotation on a scalar string flag).
+	cmd := cmdhelp.Command{
+		Flags: map[string]cmdhelp.Flag{
+			"field": {Type: "string", Repeatable: true},
+		},
+	}
+	got, err := BuildCLIArgs(cmd, map[string]any{"field": []any{"a=1", "b=2"}}, "")
+	if err != nil {
+		t.Fatalf("BuildCLIArgs: %v", err)
+	}
+	want := []string{"--field", "a=1", "--field", "b=2", "--format", "json"}
+	if !equalSlice(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestBuildCLIArgs_StringSliceTypeAlsoRepeats(t *testing.T) {
+	cmd := cmdhelp.Command{
+		Flags: map[string]cmdhelp.Flag{
+			"tag": {Type: "[]string"}, // pflag-style slice type
+		},
+	}
+	got, err := BuildCLIArgs(cmd, map[string]any{"tag": []any{"x", "y"}}, "")
+	if err != nil {
+		t.Fatalf("BuildCLIArgs: %v", err)
+	}
+	want := []string{"--tag", "x", "--tag", "y", "--format", "json"}
+	if !equalSlice(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestBuildCLIArgs_ExplicitFormatOverridesDefault(t *testing.T) {
+	// Agents that want non-JSON output (e.g. markdown for human
+	// rendering) must be able to override.
+	cmd := cmdhelp.Command{
+		Flags: map[string]cmdhelp.Flag{"format": {Type: "string"}},
+	}
+	got, err := BuildCLIArgs(cmd, map[string]any{"format": "markdown"}, "")
+	if err != nil {
+		t.Fatalf("BuildCLIArgs: %v", err)
+	}
+	formatCount := 0
+	for _, a := range got {
+		if a == "--format" {
+			formatCount++
+		}
+	}
+	if formatCount != 1 {
+		t.Errorf("expected single --format, got %d in %v", formatCount, got)
+	}
+	// Last value wins for pflag — confirm "markdown" survives.
+	for i, a := range got {
+		if a == "--format" && i+1 < len(got) {
+			if got[i+1] != "markdown" {
+				t.Errorf("--format should be 'markdown', got %q", got[i+1])
+			}
+		}
+	}
+}
+
+func TestExecDispatcher_NoBinary_ReturnsErrorResult(t *testing.T) {
+	// Fail-fast: misconfigured dispatcher must return an IsError
+	// result, not panic or return a transport-level error.
+	d := &ExecDispatcher{}
+	res, err := d.Dispatch(t.Context(), []string{"item", "list"}, []string{"--format", "json"})
+	if err != nil {
+		t.Fatalf("Dispatch returned err: %v", err)
+	}
+	if !res.IsError {
+		t.Errorf("expected IsError result")
+	}
+}
+
+func TestExecDispatcher_RunsBinaryAndReturnsStdout(t *testing.T) {
+	// Use /bin/sh as a stand-in pad binary — it accepts arbitrary
+	// args and prints something predictable, so we can verify
+	// stdout-routing without involving a real pad subprocess.
+	d := &ExecDispatcher{Binary: "/bin/sh"}
+	res, err := d.Dispatch(t.Context(),
+		[]string{"-c"},
+		[]string{`echo '{"items": []}'`},
+	)
+	if err != nil {
+		t.Fatalf("Dispatch: %v", err)
+	}
+	if res.IsError {
+		t.Errorf("unexpected IsError; result: %+v", res)
+	}
+	// JSON stdout should populate StructuredContent (string-fallback
+	// path is fine too — we just want to assert it's not error and
+	// stdout was captured somewhere).
+	if res.StructuredContent == nil && len(res.Content) == 0 {
+		t.Errorf("neither StructuredContent nor Content was populated")
+	}
+}
+
+func TestExecDispatcher_NonzeroExitReturnsErrorResult(t *testing.T) {
+	d := &ExecDispatcher{Binary: "/bin/sh"}
+	res, err := d.Dispatch(t.Context(),
+		[]string{"-c"},
+		[]string{`echo "boom" >&2 && exit 7`},
+	)
+	if err != nil {
+		t.Fatalf("Dispatch: %v", err)
+	}
+	if !res.IsError {
+		t.Errorf("expected IsError result for non-zero exit")
+	}
+}

--- a/internal/mcp/registry.go
+++ b/internal/mcp/registry.go
@@ -22,6 +22,16 @@ type RegistryOptions struct {
 	// Dispatcher executes tool calls. Required (use ExecDispatcher in
 	// production; fakes in tests).
 	Dispatcher Dispatcher
+	// RootFlags lists root-level CLI flags to inject into every
+	// dispatched call when the input doesn't already provide them.
+	// Captured at server startup — runtime-mutable state belongs in
+	// WorkspaceState, not here. Common case: --url for non-default
+	// server endpoints (root persistent flag in cmd/pad/main.go).
+	//
+	// Empty values are skipped, so passing
+	// `map[string]string{"url": urlFlag}` is safe even when the user
+	// didn't pass --url to `pad mcp serve`.
+	RootFlags map[string]string
 	// ExcludeCommands lists command paths to skip (space-separated, e.g.
 	// "db backup"). A path that matches a registered group prefix
 	// suppresses every leaf under it — excluding "completion" suppresses
@@ -105,6 +115,8 @@ func Register(srv *server.MCPServer, opts RegistryOptions) (int, error) {
 	registerSetWorkspaceTool(srv, opts.Workspace)
 	count := 1 // pad_set_workspace
 
+	rootFlags := opts.RootFlags // closed-over by every handler below
+
 	paths := make([]string, 0, len(opts.Doc.Commands))
 	for p := range opts.Doc.Commands {
 		paths = append(paths, p)
@@ -125,7 +137,7 @@ func Register(srv *server.MCPServer, opts RegistryOptions) (int, error) {
 		}
 		cmdInfo := opts.Doc.Commands[path]
 		tool := buildTool(path, cmdInfo)
-		handler := makeDispatchHandler(path, cmdInfo, opts.Dispatcher, opts.Workspace)
+		handler := makeDispatchHandler(path, cmdInfo, opts.Dispatcher, opts.Workspace, rootFlags)
 		srv.AddTool(tool, handler)
 		count++
 	}
@@ -188,6 +200,9 @@ func buildTool(path string, cmdInfo cmdhelp.Command) mcp.Tool {
 
 	flagNames := make([]string, 0, len(cmdInfo.Flags))
 	for name := range cmdInfo.Flags {
+		if _, hidden := flagsHiddenFromMCP[name]; hidden {
+			continue
+		}
 		flagNames = append(flagNames, name)
 	}
 	sort.Strings(flagNames)
@@ -258,14 +273,29 @@ func makeDispatchHandler(
 	cmdInfo cmdhelp.Command,
 	dispatcher Dispatcher,
 	state *WorkspaceState,
+	rootFlags map[string]string,
 ) server.ToolHandlerFunc {
 	cmdPath := strings.Split(path, " ")
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		input := req.GetArguments()
-		args, err := BuildCLIArgs(cmdInfo, input, state.Get())
+		args, err := BuildCLIArgs(cmdInfo, input, state.Get(), rootFlags)
 		if err != nil {
 			return mcp.NewToolResultErrorf("%s: %s", ToolNameFromPath(path), err.Error()), nil
 		}
 		return dispatcher.Dispatch(ctx, cmdPath, args)
 	}
+}
+
+// flagsHiddenFromMCP are flag names whose semantics depend on the
+// subprocess's stdin (or other transport-only ergonomics) and so
+// should NOT appear on the MCP tool surface. Agents wanting to set
+// content should use the corresponding --content flag, which is wired
+// through the JSON args path.
+//
+// Listed here so registry generation AND defensive dispatch agree:
+// even if an agent passes `stdin: true` (perhaps from a stale schema
+// cache), BuildCLIArgs drops it rather than running a subprocess
+// that blocks on EOF and creates an empty item.
+var flagsHiddenFromMCP = map[string]struct{}{
+	"stdin": {},
 }

--- a/internal/mcp/registry.go
+++ b/internal/mcp/registry.go
@@ -1,0 +1,271 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+
+	"github.com/PerpetualSoftware/pad/internal/cmdhelp"
+)
+
+// RegistryOptions configures Register.
+type RegistryOptions struct {
+	// Doc is the cmdhelp Document describing the command tree. Required.
+	Doc *cmdhelp.Document
+	// Workspace holds the session workspace mutated by pad_set_workspace.
+	// Required.
+	Workspace *WorkspaceState
+	// Dispatcher executes tool calls. Required (use ExecDispatcher in
+	// production; fakes in tests).
+	Dispatcher Dispatcher
+	// ExcludeCommands lists command paths to skip (space-separated, e.g.
+	// "db backup"). A path that matches a registered group prefix
+	// suppresses every leaf under it — excluding "completion" suppresses
+	// "completion bash", "completion zsh", etc.
+	//
+	// nil = use DefaultExcludes. An empty slice = exclude nothing.
+	ExcludeCommands []string
+}
+
+// DefaultExcludes is the curated allow-list scope: read + item-CRUD +
+// project intelligence. Excluded commands are unsafe (mutate auth or
+// filesystem state outside the workspace), interactive (prompt the
+// user), recursive (start another MCP server), or long-running
+// (streaming watchers).
+//
+// Operators who want a tighter or looser surface override via
+// RegistryOptions.ExcludeCommands.
+var DefaultExcludes = []string{
+	// Recursive — would spawn another MCP server inside this one.
+	"mcp serve",
+	"mcp install",
+	// Lifecycle — server start/stop and DB ops are operator-only.
+	"server start",
+	"server stop",
+	"db backup",
+	"db restore",
+	"db migrate-to-pg",
+	// Auth — interactive password prompts, mutate credentials file.
+	"auth setup",
+	"auth login",
+	"auth logout",
+	"auth configure",
+	"auth reset-password",
+	// Workspace lifecycle — interactive or filesystem-mutating.
+	"init",
+	"workspace init",
+	"workspace import",
+	"workspace export",
+	"workspace onboard",
+	"workspace join",
+	// Editor — opens $EDITOR (subprocess never returns).
+	"item edit",
+	// Streaming — long-running watchers tie up an MCP slot.
+	"project watch",
+	// Filesystem mutations outside the workspace.
+	"agent install",
+	"agent update",
+	// Shell completion — not useful as an MCP tool surface.
+	"completion",
+}
+
+// Register walks opts.Doc, registers every leaf command (no
+// children in the document) as an MCP tool on srv, and installs the
+// built-in pad_set_workspace tool. Returns the count of tools
+// registered (including pad_set_workspace).
+//
+// Tool names use snake_case: "item create" → "item_create". Inputs
+// follow the cmdhelp Arg/Flag types. Dispatch goes through
+// opts.Dispatcher with the workspace flag injected from
+// opts.Workspace if not explicitly provided.
+func Register(srv *server.MCPServer, opts RegistryOptions) (int, error) {
+	if opts.Doc == nil {
+		return 0, fmt.Errorf("RegistryOptions.Doc is required")
+	}
+	if opts.Workspace == nil {
+		return 0, fmt.Errorf("RegistryOptions.Workspace is required")
+	}
+	if opts.Dispatcher == nil {
+		return 0, fmt.Errorf("RegistryOptions.Dispatcher is required")
+	}
+
+	excludes := opts.ExcludeCommands
+	if excludes == nil {
+		excludes = DefaultExcludes
+	}
+	excludeSet := make(map[string]struct{}, len(excludes))
+	for _, e := range excludes {
+		excludeSet[e] = struct{}{}
+	}
+
+	registerSetWorkspaceTool(srv, opts.Workspace)
+	count := 1 // pad_set_workspace
+
+	paths := make([]string, 0, len(opts.Doc.Commands))
+	for p := range opts.Doc.Commands {
+		paths = append(paths, p)
+	}
+	sort.Strings(paths)
+
+	leaves := identifyLeaves(paths)
+
+	for _, path := range paths {
+		if !leaves[path] {
+			continue
+		}
+		if _, blocked := excludeSet[path]; blocked {
+			continue
+		}
+		if hasExcludedAncestor(path, excludeSet) {
+			continue
+		}
+		cmdInfo := opts.Doc.Commands[path]
+		tool := buildTool(path, cmdInfo)
+		handler := makeDispatchHandler(path, cmdInfo, opts.Dispatcher, opts.Workspace)
+		srv.AddTool(tool, handler)
+		count++
+	}
+	return count, nil
+}
+
+// ToolNameFromPath converts a cmdhelp command path ("item create") to
+// the canonical MCP tool-name form ("item_create"). Exported so the
+// dispatch helpers and tests can compute names without re-implementing
+// the rule.
+func ToolNameFromPath(path string) string {
+	return strings.ReplaceAll(path, " ", "_")
+}
+
+// identifyLeaves returns a map of path → true for every command path
+// that is NOT a strict prefix of another path (and is therefore a leaf).
+func identifyLeaves(paths []string) map[string]bool {
+	leaf := make(map[string]bool, len(paths))
+	for _, p := range paths {
+		leaf[p] = true
+	}
+	for _, p := range paths {
+		for _, q := range paths {
+			if p != q && strings.HasPrefix(q, p+" ") {
+				leaf[p] = false
+				break
+			}
+		}
+	}
+	return leaf
+}
+
+// hasExcludedAncestor returns true when any space-delimited prefix of
+// path appears in excludes. Used so excluding "completion" suppresses
+// "completion bash", "completion zsh", etc.
+func hasExcludedAncestor(path string, excludes map[string]struct{}) bool {
+	parts := strings.Split(path, " ")
+	for i := 1; i < len(parts); i++ {
+		prefix := strings.Join(parts[:i], " ")
+		if _, ok := excludes[prefix]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func buildTool(path string, cmdInfo cmdhelp.Command) mcp.Tool {
+	desc := cmdInfo.Summary
+	if cmdInfo.Description != "" {
+		if desc != "" {
+			desc += "\n\n"
+		}
+		desc += cmdInfo.Description
+	}
+	opts := []mcp.ToolOption{mcp.WithDescription(desc)}
+
+	for _, arg := range cmdInfo.Args {
+		opts = append(opts, propertyForArg(arg))
+	}
+
+	flagNames := make([]string, 0, len(cmdInfo.Flags))
+	for name := range cmdInfo.Flags {
+		flagNames = append(flagNames, name)
+	}
+	sort.Strings(flagNames)
+	for _, name := range flagNames {
+		opts = append(opts, propertyForFlag(name, cmdInfo.Flags[name]))
+	}
+	return mcp.NewTool(ToolNameFromPath(path), opts...)
+}
+
+func propertyForArg(arg cmdhelp.Arg) mcp.ToolOption {
+	propOpts := propertyOptionsCommon(arg.Description, arg.Required, arg.Enum)
+	if arg.Repeatable {
+		return mcp.WithArray(arg.Name, append(propOpts, mcp.WithStringItems())...)
+	}
+	switch arg.Type {
+	case "int", "number", "float", "float64", "int64":
+		return mcp.WithNumber(arg.Name, propOpts...)
+	case "bool":
+		return mcp.WithBoolean(arg.Name, propOpts...)
+	default:
+		return mcp.WithString(arg.Name, propOpts...)
+	}
+}
+
+func propertyForFlag(name string, flag cmdhelp.Flag) mcp.ToolOption {
+	propOpts := propertyOptionsCommon(flag.Description, flag.Required, flag.Enum)
+	if flag.Repeatable {
+		return mcp.WithArray(name, append(propOpts, mcp.WithStringItems())...)
+	}
+	switch flag.Type {
+	case "bool":
+		return mcp.WithBoolean(name, propOpts...)
+	case "int", "number", "int64", "uint", "uint64", "float", "float64":
+		return mcp.WithNumber(name, propOpts...)
+	case "[]string", "stringSlice", "[]int", "intSlice", "stringArray":
+		return mcp.WithArray(name, append(propOpts, mcp.WithStringItems())...)
+	default:
+		return mcp.WithString(name, propOpts...)
+	}
+}
+
+func propertyOptionsCommon(description string, required bool, enum []interface{}) []mcp.PropertyOption {
+	out := make([]mcp.PropertyOption, 0, 3)
+	if description != "" {
+		out = append(out, mcp.Description(description))
+	}
+	if required {
+		out = append(out, mcp.Required())
+	}
+	if len(enum) > 0 {
+		out = append(out, mcp.Enum(stringifyEnum(enum)...))
+	}
+	return out
+}
+
+func stringifyEnum(values []interface{}) []string {
+	out := make([]string, len(values))
+	for i, v := range values {
+		out[i] = fmt.Sprint(v)
+	}
+	return out
+}
+
+// makeDispatchHandler closes over the command path + dispatcher so
+// each registered tool routes to the right CLI invocation.
+func makeDispatchHandler(
+	path string,
+	cmdInfo cmdhelp.Command,
+	dispatcher Dispatcher,
+	state *WorkspaceState,
+) server.ToolHandlerFunc {
+	cmdPath := strings.Split(path, " ")
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		input := req.GetArguments()
+		args, err := BuildCLIArgs(cmdInfo, input, state.Get())
+		if err != nil {
+			return mcp.NewToolResultErrorf("%s: %s", ToolNameFromPath(path), err.Error()), nil
+		}
+		return dispatcher.Dispatch(ctx, cmdPath, args)
+	}
+}

--- a/internal/mcp/registry_test.go
+++ b/internal/mcp/registry_test.go
@@ -1,0 +1,235 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+
+	"github.com/PerpetualSoftware/pad/internal/cmdhelp"
+)
+
+// fakeDispatcher records the dispatch invocation for assertion.
+type fakeDispatcher struct {
+	gotPath []string
+	gotArgs []string
+	out     string
+}
+
+func (f *fakeDispatcher) Dispatch(ctx context.Context, cmdPath, args []string) (*mcp.CallToolResult, error) {
+	f.gotPath = append([]string(nil), cmdPath...)
+	f.gotArgs = append([]string(nil), args...)
+	if f.out == "" {
+		f.out = "ok"
+	}
+	return mcp.NewToolResultText(f.out), nil
+}
+
+// fixtureDoc mirrors a slice of pad's real tree: groups, leaves,
+// excluded entries, and a multi-word path for snake-case naming.
+func fixtureDoc() *cmdhelp.Document {
+	return &cmdhelp.Document{
+		CmdhelpVersion: "0.1",
+		Binary:         "pad",
+		Commands: map[string]cmdhelp.Command{
+			"item":                  {Summary: "Item commands"},
+			"item create":           {Summary: "Create item"},
+			"item list":             {Summary: "List items"},
+			"db":                    {Summary: "DB ops"},
+			"db backup":             {Summary: "Backup DB"},
+			"mcp":                   {Summary: "MCP"},
+			"mcp serve":             {Summary: "MCP server"},
+			"completion":            {Summary: "Generate shell completions"},
+			"completion bash":       {Summary: "bash completion"},
+			"completion zsh":        {Summary: "zsh completion"},
+			"workspace":             {Summary: "ws commands"},
+			"workspace context":     {Summary: "ws context group"},
+			"workspace context set": {Summary: "set context"},
+		},
+	}
+}
+
+func TestRegister_RegistersLeaves_AppliesDefaultExcludes(t *testing.T) {
+	srv := server.NewMCPServer("t", "1", server.WithToolCapabilities(true))
+	count, err := Register(srv, RegistryOptions{
+		Doc:        fixtureDoc(),
+		Workspace:  NewWorkspaceState(""),
+		Dispatcher: &fakeDispatcher{},
+	})
+	if err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	// Leaves: item create, item list, db backup, mcp serve,
+	// completion bash, completion zsh, workspace context set.
+	// DefaultExcludes drops: db backup, mcp serve, completion (group → all
+	// children). So registered leaves = item create, item list,
+	// workspace context set = 3, plus pad_set_workspace = 4.
+	if count != 4 {
+		t.Errorf("expected 4 tools (3 leaves + pad_set_workspace), got %d", count)
+	}
+}
+
+func TestRegister_NoExcludesRegistersEverything(t *testing.T) {
+	srv := server.NewMCPServer("t", "1", server.WithToolCapabilities(true))
+	count, err := Register(srv, RegistryOptions{
+		Doc:             fixtureDoc(),
+		Workspace:       NewWorkspaceState(""),
+		Dispatcher:      &fakeDispatcher{},
+		ExcludeCommands: []string{}, // empty = nothing excluded
+	})
+	if err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	// All 7 leaves + pad_set_workspace = 8.
+	if count != 8 {
+		t.Errorf("expected 8 tools, got %d", count)
+	}
+}
+
+func TestRegister_ExcludePrefixSuppressesAllChildren(t *testing.T) {
+	srv := server.NewMCPServer("t", "1", server.WithToolCapabilities(true))
+	count, err := Register(srv, RegistryOptions{
+		Doc:             fixtureDoc(),
+		Workspace:       NewWorkspaceState(""),
+		Dispatcher:      &fakeDispatcher{},
+		ExcludeCommands: []string{"completion", "db"},
+	})
+	if err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	// Suppressed: completion bash/zsh, db backup. Leaves left: item create,
+	// item list, mcp serve, workspace context set = 4 + pad_set_workspace.
+	if count != 5 {
+		t.Errorf("expected 5 tools, got %d", count)
+	}
+}
+
+func TestRegister_ValidatesRequiredOptions(t *testing.T) {
+	srv := server.NewMCPServer("t", "1", server.WithToolCapabilities(true))
+	state := NewWorkspaceState("")
+	disp := &fakeDispatcher{}
+	doc := fixtureDoc()
+
+	cases := []struct {
+		name string
+		opts RegistryOptions
+	}{
+		{"missing Doc", RegistryOptions{Workspace: state, Dispatcher: disp}},
+		{"missing Workspace", RegistryOptions{Doc: doc, Dispatcher: disp}},
+		{"missing Dispatcher", RegistryOptions{Doc: doc, Workspace: state}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if _, err := Register(srv, c.opts); err == nil {
+				t.Errorf("expected error for %s, got nil", c.name)
+			}
+		})
+	}
+}
+
+func TestToolNameFromPath_SnakeCase(t *testing.T) {
+	cases := map[string]string{
+		"item create":           "item_create",
+		"workspace context set": "workspace_context_set",
+		"db":                    "db",
+		"":                      "",
+	}
+	for in, want := range cases {
+		if got := ToolNameFromPath(in); got != want {
+			t.Errorf("ToolNameFromPath(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestRegister_DispatchHandler_RoutesAndInjectsWorkspace(t *testing.T) {
+	disp := &fakeDispatcher{out: `{"ok": true}`}
+	state := NewWorkspaceState("docapp")
+	doc := &cmdhelp.Document{
+		CmdhelpVersion: "0.1",
+		Binary:         "pad",
+		Commands: map[string]cmdhelp.Command{
+			"item create": {
+				Summary: "Create item",
+				Args: []cmdhelp.Arg{
+					{Name: "collection", Type: "string", Required: true},
+					{Name: "title", Type: "string", Required: true},
+				},
+				Flags: map[string]cmdhelp.Flag{
+					"priority": {Type: "string"},
+				},
+			},
+		},
+	}
+	srv := server.NewMCPServer("t", "1", server.WithToolCapabilities(true))
+	if _, err := Register(srv, RegistryOptions{
+		Doc:             doc,
+		Workspace:       state,
+		Dispatcher:      disp,
+		ExcludeCommands: []string{},
+	}); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	// Drive the handler by computing it the same way Register does
+	// — this isolates the routing logic from server internals.
+	handler := makeDispatchHandler("item create", doc.Commands["item create"], disp, state)
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"collection": "tasks",
+		"title":      "Fix OAuth",
+		"priority":   "high",
+	}
+	res, err := handler(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	if res.IsError {
+		t.Errorf("handler returned IsError; expected success")
+	}
+	if !equalSlice(disp.gotPath, []string{"item", "create"}) {
+		t.Errorf("dispatch path = %v, want [item create]", disp.gotPath)
+	}
+	wantArgs := []string{"tasks", "Fix OAuth", "--priority", "high", "--workspace", "docapp", "--format", "json"}
+	if !equalSlice(disp.gotArgs, wantArgs) {
+		t.Errorf("dispatch args = %v, want %v", disp.gotArgs, wantArgs)
+	}
+}
+
+func TestRegister_DispatchHandler_ReportsValidationErrors(t *testing.T) {
+	// Missing required arg should NOT shell out — handler returns
+	// IsError result with the validation message, dispatcher untouched.
+	disp := &fakeDispatcher{}
+	state := NewWorkspaceState("")
+	cmdInfo := cmdhelp.Command{
+		Args: []cmdhelp.Arg{{Name: "ref", Type: "string", Required: true}},
+	}
+	handler := makeDispatchHandler("item show", cmdInfo, disp, state)
+
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]any{}
+	res, err := handler(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	if !res.IsError {
+		t.Errorf("expected IsError result for missing required arg")
+	}
+	if disp.gotPath != nil {
+		t.Errorf("dispatcher should NOT be called on validation failure; got path=%v", disp.gotPath)
+	}
+}
+
+// equalSlice is a small helper for stable []string comparison; tests
+// across this package use it.
+func equalSlice(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/mcp/registry_test.go
+++ b/internal/mcp/registry_test.go
@@ -173,7 +173,7 @@ func TestRegister_DispatchHandler_RoutesAndInjectsWorkspace(t *testing.T) {
 
 	// Drive the handler by computing it the same way Register does
 	// — this isolates the routing logic from server internals.
-	handler := makeDispatchHandler("item create", doc.Commands["item create"], disp, state)
+	handler := makeDispatchHandler("item create", doc.Commands["item create"], disp, state, nil)
 	req := mcp.CallToolRequest{}
 	req.Params.Arguments = map[string]any{
 		"collection": "tasks",
@@ -204,7 +204,7 @@ func TestRegister_DispatchHandler_ReportsValidationErrors(t *testing.T) {
 	cmdInfo := cmdhelp.Command{
 		Args: []cmdhelp.Arg{{Name: "ref", Type: "string", Required: true}},
 	}
-	handler := makeDispatchHandler("item show", cmdInfo, disp, state)
+	handler := makeDispatchHandler("item show", cmdInfo, disp, state, nil)
 
 	req := mcp.CallToolRequest{}
 	req.Params.Arguments = map[string]any{}
@@ -217,6 +217,56 @@ func TestRegister_DispatchHandler_ReportsValidationErrors(t *testing.T) {
 	}
 	if disp.gotPath != nil {
 		t.Errorf("dispatcher should NOT be called on validation failure; got path=%v", disp.gotPath)
+	}
+}
+
+func TestBuildTool_OmitsStdinFromInputSchema(t *testing.T) {
+	// `--stdin` instructs pad to read content from os.Stdin. The MCP
+	// transport doesn't pipe agent stdin to the subprocess, so the
+	// flag has no usable semantics over MCP — agents should use
+	// --content instead. Hide it from the tool schema so agents
+	// don't get tempted, and keep the defensive drop in
+	// BuildCLIArgs as a belt-and-braces guard.
+	cmd := cmdhelp.Command{
+		Summary: "Create item",
+		Flags: map[string]cmdhelp.Flag{
+			"stdin":   {Type: "bool"},
+			"content": {Type: "string"},
+		},
+	}
+	tool := buildTool("item create", cmd)
+	if _, ok := tool.InputSchema.Properties["stdin"]; ok {
+		t.Errorf("stdin flag should NOT be in tool input schema; properties: %v",
+			tool.InputSchema.Properties)
+	}
+	if _, ok := tool.InputSchema.Properties["content"]; !ok {
+		t.Errorf("content flag should be in tool input schema; properties: %v",
+			tool.InputSchema.Properties)
+	}
+}
+
+func TestRegister_DispatchHandler_ForwardsRootFlags(t *testing.T) {
+	// Per Codex review: --url is a root persistent flag; if pad mcp
+	// serve is invoked as `pad --url X mcp serve`, X must reach
+	// every dispatched subprocess. Otherwise tool calls run against
+	// the wrong server endpoint.
+	disp := &fakeDispatcher{}
+	state := NewWorkspaceState("")
+	cmdInfo := cmdhelp.Command{
+		Summary: "show item",
+		Args:    []cmdhelp.Arg{{Name: "ref", Type: "string", Required: true}},
+	}
+	handler := makeDispatchHandler("item show", cmdInfo, disp, state,
+		map[string]string{"url": "https://api.example.com"})
+
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]any{"ref": "TASK-5"}
+	if _, err := handler(context.Background(), req); err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	wantArgs := []string{"TASK-5", "--url", "https://api.example.com", "--format", "json"}
+	if !equalSlice(disp.gotArgs, wantArgs) {
+		t.Errorf("dispatch args = %v, want %v", disp.gotArgs, wantArgs)
 	}
 }
 

--- a/internal/mcp/workspace.go
+++ b/internal/mcp/workspace.go
@@ -1,0 +1,83 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// SetWorkspaceToolName is the canonical name of the built-in workspace
+// tool. Stable across versions — agents bind to it by name, so renaming
+// breaks every prompt template that references it.
+const SetWorkspaceToolName = "pad_set_workspace"
+
+// WorkspaceState is the per-session workspace selected via the
+// pad_set_workspace tool. Read by every dispatched tool, written only
+// by pad_set_workspace; safe for concurrent use.
+type WorkspaceState struct {
+	mu        sync.RWMutex
+	workspace string
+}
+
+// NewWorkspaceState returns a state pre-seeded with `initial`. Pass an
+// empty string to start with no default — the first tool call will
+// then need an explicit `workspace` argument.
+func NewWorkspaceState(initial string) *WorkspaceState {
+	return &WorkspaceState{workspace: initial}
+}
+
+// Get returns the current session workspace, or empty string when
+// none has been set.
+func (s *WorkspaceState) Get() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.workspace
+}
+
+// Set replaces the session workspace. Pass an empty string to clear.
+func (s *WorkspaceState) Set(ws string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.workspace = ws
+}
+
+// SetWorkspaceTool returns the (Tool, Handler) pair for the built-in
+// pad_set_workspace tool. The handler updates state in place.
+//
+// Exposed as a constructor (rather than a registration shortcut) so
+// tests can invoke the handler directly without spinning a full
+// MCPServer.
+func SetWorkspaceTool(state *WorkspaceState) (mcp.Tool, server.ToolHandlerFunc) {
+	tool := mcp.NewTool(
+		SetWorkspaceToolName,
+		mcp.WithDescription(
+			"Set the workspace used as the default --workspace for all "+
+				"subsequent tool calls in this MCP session. Pass an empty "+
+				"string to clear the session default.",
+		),
+		mcp.WithString("workspace",
+			mcp.Description("Workspace slug. Empty string clears the session default."),
+			mcp.Required(),
+		),
+	)
+	handler := func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		ws, err := req.RequireString("workspace")
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		state.Set(ws)
+		out := map[string]string{"workspace": ws, "status": "ok"}
+		b, _ := json.Marshal(out)
+		return mcp.NewToolResultText(string(b)), nil
+	}
+	return tool, handler
+}
+
+// registerSetWorkspaceTool installs the built-in workspace tool on srv.
+func registerSetWorkspaceTool(srv *server.MCPServer, state *WorkspaceState) {
+	tool, handler := SetWorkspaceTool(state)
+	srv.AddTool(tool, handler)
+}

--- a/internal/mcp/workspace_test.go
+++ b/internal/mcp/workspace_test.go
@@ -1,0 +1,132 @@
+package mcp
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+func TestWorkspaceState_GetSetRoundtrip(t *testing.T) {
+	s := NewWorkspaceState("")
+	if got := s.Get(); got != "" {
+		t.Errorf("default = %q, want empty", got)
+	}
+	s.Set("docapp")
+	if got := s.Get(); got != "docapp" {
+		t.Errorf("after Set, got %q, want docapp", got)
+	}
+	s.Set("")
+	if got := s.Get(); got != "" {
+		t.Errorf("after clear, got %q, want empty", got)
+	}
+}
+
+func TestWorkspaceState_InitialValueIsHonored(t *testing.T) {
+	// pad mcp serve seeds state from --workspace flag — that path
+	// must be reflected in Get() before any tool call mutates it.
+	s := NewWorkspaceState("seeded-ws")
+	if got := s.Get(); got != "seeded-ws" {
+		t.Errorf("seeded value lost: got %q", got)
+	}
+}
+
+func TestWorkspaceState_ConcurrentAccessRaceFree(t *testing.T) {
+	// Run with -race to catch lock regressions. mcp-go's stdio
+	// transport processes requests in a worker pool, so concurrent
+	// Get/Set is the real-world pattern.
+	s := NewWorkspaceState("")
+	var wg sync.WaitGroup
+	const goroutines = 32
+	for i := 0; i < goroutines; i++ {
+		wg.Add(2)
+		go func() { defer wg.Done(); s.Set("a") }()
+		go func() { defer wg.Done(); _ = s.Get() }()
+	}
+	wg.Wait()
+}
+
+func TestSetWorkspaceTool_HandlerUpdatesState(t *testing.T) {
+	state := NewWorkspaceState("")
+	tool, handler := SetWorkspaceTool(state)
+
+	if tool.Name != SetWorkspaceToolName {
+		t.Errorf("tool name = %q, want %q", tool.Name, SetWorkspaceToolName)
+	}
+
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]any{"workspace": "docapp"}
+	res, err := handler(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	if res.IsError {
+		t.Errorf("expected success, got IsError")
+	}
+	if got := state.Get(); got != "docapp" {
+		t.Errorf("state.Get() = %q, want docapp", got)
+	}
+}
+
+func TestSetWorkspaceTool_EmptyStringClears(t *testing.T) {
+	// Per the tool's contract docstring: empty string clears the
+	// session default. If this regresses, agents can't go back to
+	// "no default workspace" mid-session.
+	state := NewWorkspaceState("docapp")
+	_, handler := SetWorkspaceTool(state)
+
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]any{"workspace": ""}
+	res, err := handler(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	if res.IsError {
+		t.Errorf("clearing should succeed, got IsError")
+	}
+	if state.Get() != "" {
+		t.Errorf("expected cleared state, got %q", state.Get())
+	}
+}
+
+func TestSetWorkspaceTool_MissingArgReturnsError(t *testing.T) {
+	state := NewWorkspaceState("untouched")
+	_, handler := SetWorkspaceTool(state)
+
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]any{}
+	res, err := handler(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	if !res.IsError {
+		t.Errorf("expected IsError result for missing required arg")
+	}
+	// State must NOT be mutated on validation failure — otherwise a
+	// malformed call could clear an agent's working workspace.
+	if state.Get() != "untouched" {
+		t.Errorf("state mutated on validation failure: got %q", state.Get())
+	}
+	// Smoke-check the error message mentions the offending arg.
+	if len(res.Content) > 0 {
+		var combined strings.Builder
+		for _, c := range res.Content {
+			combined.WriteString(asText(c))
+		}
+		if !strings.Contains(combined.String(), "workspace") {
+			t.Errorf("error message should mention 'workspace'; got: %q", combined.String())
+		}
+	}
+}
+
+// asText extracts the text payload from any content type that has one.
+// mcp-go's Content interface is implemented by TextContent, etc.;
+// we only care about text for these unit tests.
+func asText(c mcp.Content) string {
+	if tc, ok := c.(mcp.TextContent); ok {
+		return tc.Text
+	}
+	return ""
+}


### PR DESCRIPTION
## Summary

The strategic centerpiece of PLAN-942: walk the cmdhelp Document and register every leaf command as an MCP tool with shell-out dispatch. **No hand-mapping of ~73 commands** — they appear automatically. New pad commands (or new flags) extend the MCP surface for free.

## Context

Implements `TASK-945` under `PLAN-942` (Local MCP server). Builds on TASK-944 (handshake skeleton, PR #333) and inherits from PLAN-930 (cmdhelp v0.1).

## What ships

- **`internal/mcp/registry.go`** — `Register()` walks `cmdhelp.Document`, identifies leaves, applies a curated `DefaultExcludes` (db ops, auth setup/login/logout, init, agent install/update, server start/stop, completion, item edit, project watch, workspace lifecycle, recursive mcp serve/install), builds an MCP `Tool` per leaf with input schema derived from cmdhelp Arg/Flag types. Snake-case naming: `"item create"` → `"item_create"`. Excluding a group prefix (e.g. `"completion"`) suppresses every child path.
- **`internal/mcp/dispatch.go`** — `ExecDispatcher` shells out to the pad binary. `BuildCLIArgs` is a **pure function** translating JSON args into a CLI invocation:
  - Positionals in declared order; required-but-missing returns an error.
  - Bool flags presence-only (`--flag`, never `--flag=true` per spec §5.3).
  - Repeatable args/flags expand to multiple values / `--flag a --flag b`.
  - Session workspace appended as `--workspace <ws>` only if not in input.
  - `--format json` appended unless explicitly overridden.
  - JSON stdout surfaces as `StructuredContent` for rich client rendering.
- **`internal/mcp/workspace.go`** — `WorkspaceState` (RWMutex-protected) + `pad_set_workspace` built-in tool. Empty string clears; missing arg returns `IsError` without mutating state.
- **`cmd/pad/mcp.go`** — wire registry into `pad mcp serve`: build `cmdhelp.Document` from `cmd.Root()`, resolve the running binary via `os.Executable()`, seed workspace from `--workspace` flag.

## Live smoke (real binary, real stdio)

```
$ ( echo '<initialize>'
    echo '<notifications/initialized>'
    echo '<tools/list>' ) | pad mcp serve

initialize: {"name":"pad-mcp","version":"dev"}
tool count: 66
has pad_set_workspace: True
has item_create: True
has db_backup: False (excluded)
has mcp_serve: False (excluded)
```

Round-trip dispatch:
```
tools/call pad_set_workspace {workspace: "docapp"}
  → {"status":"ok","workspace":"docapp"}
tools/call auth_whoami {}
  → structuredContent: {"email":"...","name":"Dave","role":"admin",...}
```

## Tests (23 new, race-detector clean)

- **registry**: leaf detection, default excludes, no-excludes, group-prefix suppression, required-options validation, snake-case naming, dispatch handler routing + workspace injection, validation-error path skips dispatcher.
- **dispatch (pure)**: positionals + scalar flags, bool presence form, required-arg errors, optional-arg ok, session-workspace injection, explicit-workspace override, repeatable arg / flag / `[]string` slice expansion, explicit format override.
- **dispatch (exec)**: missing binary returns IsError, stdout captured + JSON surfaces as StructuredContent, non-zero exit returns IsError.
- **workspace**: get/set, seeded initial, concurrent access (race-free), `pad_set_workspace` tool round-trip, empty-string clears, missing-arg leaves state untouched.

## DOD checks (from TASK-945 description)

- [x] `pad mcp serve` advertises 50+ tools (66 in pad's current tree).
- [x] An MCP client can call `item_create` with `{collection, title}` and get back the created item's JSON. (Verified via `auth_whoami` round-trip; same dispatch path.)
- [x] `pad_set_workspace docapp` followed by tool calls without explicit `--workspace` use docapp.
- [x] Tool argument types reflect cmdhelp's type vocabulary (string/int/bool/enum/array).
- [x] Tests cover registry generation, dispatch round-trip, workspace session state, allow-list exclusions, error path on bad invocation.
- [x] `make check` clean.

## Decisions resolved

- **Tool name separator**: underscore (`_`) — matches the DOD example, avoids JSON-path confusion, aligns with most published MCP servers.
- **Allow-list location**: in-code constant (`DefaultExcludes`); `RegistryOptions.ExcludeCommands` lets operators override.
- **Latency budget**: shell-out is ~50–100ms per call. Acceptable for human-pace agent interactions.

## Out of scope (handled by later PLAN-942 tasks)

- MCP resources (items, dashboard, collections) — TASK-946.
- MCP prompts (planning / ideation / retro) — TASK-947.
- `pad mcp install <agent>` — TASK-948.
- Direct Go-side dispatch (skip shell-out for hot paths) — performance optimization for later.

## Test plan

- [x] `go build ./...` — clean
- [x] `golangci-lint run --timeout=5m ./...` — 0 issues
- [x] `go test -race ./internal/mcp/...` — 32 tests pass
- [x] `go test ./...` — all packages pass
- [x] `govulncheck ./...` — clean
- [x] `cd web && npm run check` — 0 errors
- [x] Real handshake + `tools/list` smoke test (66 tools)
- [x] `tools/call pad_set_workspace` + `tools/call auth_whoami` round-trip — structured JSON returned