### PR TITLE
feat(mcp): read-only resource templates (TASK-946)

### DIFF
--- a/cmd/pad/mcp.go
+++ b/cmd/pad/mcp.go
@@ -106,6 +106,16 @@ Shuts down cleanly on EOF, SIGINT, or SIGTERM.`,
 				return fmt.Errorf("pad mcp serve: register tools: %w", err)
 			}
 
+			// Resource templates (TASK-946): four read-only views over
+			// pad://workspace/{ws}/* URIs. Independent of the tool
+			// dispatcher because resource handlers return raw bytes
+			// rather than CallToolResult.
+			mcpserver.RegisterResources(
+				srv.MCP(),
+				&mcpserver.ExecResourceFetcher{Binary: bin},
+				rootFlags,
+			)
+
 			if err := srv.Run(cmd.Context()); err != nil {
 				return fmt.Errorf("pad mcp serve: %w", err)
 			}

--- a/internal/mcp/resources.go
+++ b/internal/mcp/resources.go
@@ -2,8 +2,10 @@ package mcp
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os/exec"
+	"sort"
 	"strings"
 
 	"github.com/mark3labs/mcp-go/mcp"
@@ -131,6 +133,13 @@ func RegisterResources(srv *server.MCPServer, fetcher ResourceFetcher, rootFlags
 }
 
 // readItem handles pad://workspace/{ws}/items/{ref}.
+//
+// Why JSON-then-format instead of `--format markdown`: pad's CLI
+// `--format markdown` for `item show` prints only the body content
+// (item.Content), losing ref/title/fields/parent-link. The resource
+// is advertised as "Full markdown content … includes title, fields,
+// body, and links," so the resource layer composes the full markdown
+// from the JSON response. (Codex review on TASK-946 caught this gap.)
 func (r *resources) readItem(ctx context.Context, req mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
 	ws, kind, ref, err := parsePadURI(req.Params.URI)
 	if err != nil {
@@ -139,8 +148,87 @@ func (r *resources) readItem(ctx context.Context, req mcp.ReadResourceRequest) (
 	if kind != resourceKindItem || ref == "" {
 		return nil, fmt.Errorf("resource %q is not an item URI", req.Params.URI)
 	}
-	return r.fetchAsResource(ctx, req.Params.URI, itemMIMEType,
-		[]string{"item", "show", ref, "--workspace", ws, "--format", "markdown"})
+	padArgs := []string{"item", "show", ref, "--workspace", ws, "--format", "json"}
+	full := append(append([]string{}, padArgs...), r.rootArgs...)
+	out, err := r.fetcher.Fetch(ctx, full)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", req.Params.URI, err)
+	}
+	md, err := formatItemAsMarkdown(out)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", req.Params.URI, err)
+	}
+	return []mcp.ResourceContents{
+		mcp.TextResourceContents{
+			URI:      req.Params.URI,
+			MIMEType: itemMIMEType,
+			Text:     md,
+		},
+	}, nil
+}
+
+// formatItemAsMarkdown turns the JSON body returned by
+// `pad item show --format json` into a self-contained markdown
+// document: heading with ref + title, sorted metadata fields,
+// optional parent link, then the item's body content.
+//
+// Map-key iteration is sorted so the output is stable for tests.
+func formatItemAsMarkdown(jsonBlob string) (string, error) {
+	var item map[string]any
+	if err := json.Unmarshal([]byte(jsonBlob), &item); err != nil {
+		return "", fmt.Errorf("parse item JSON: %w", err)
+	}
+	var b strings.Builder
+
+	// Heading: `# REF: Title`
+	ref, _ := item["ref"].(string)
+	title, _ := item["title"].(string)
+	switch {
+	case ref != "" && title != "":
+		fmt.Fprintf(&b, "# %s: %s\n\n", ref, title)
+	case title != "":
+		fmt.Fprintf(&b, "# %s\n\n", title)
+	case ref != "":
+		fmt.Fprintf(&b, "# %s\n\n", ref)
+	}
+
+	// Parent link (optional). Useful for agents to traverse the tree.
+	if parentRef, _ := item["parent_ref"].(string); parentRef != "" {
+		parentTitle, _ := item["parent_title"].(string)
+		if parentTitle != "" {
+			fmt.Fprintf(&b, "**Parent:** %s — %s\n\n", parentRef, parentTitle)
+		} else {
+			fmt.Fprintf(&b, "**Parent:** %s\n\n", parentRef)
+		}
+	}
+
+	// Structured metadata fields. The `fields` payload is a JSON
+	// string-encoded object on the wire — unmarshal a second time.
+	if fieldsStr, ok := item["fields"].(string); ok && fieldsStr != "" && fieldsStr != "{}" {
+		var fields map[string]any
+		if json.Unmarshal([]byte(fieldsStr), &fields) == nil && len(fields) > 0 {
+			keys := make([]string, 0, len(fields))
+			for k := range fields {
+				keys = append(keys, k)
+			}
+			sort.Strings(keys)
+			for _, k := range keys {
+				fmt.Fprintf(&b, "- **%s:** %v\n", k, fields[k])
+			}
+			b.WriteString("\n")
+		}
+	}
+
+	// Body. Pad items often have rich markdown here already; pass
+	// through verbatim.
+	if content, _ := item["content"].(string); content != "" {
+		b.WriteString(content)
+		if !strings.HasSuffix(content, "\n") {
+			b.WriteString("\n")
+		}
+	}
+
+	return b.String(), nil
 }
 
 // readItems handles pad://workspace/{ws}/items.

--- a/internal/mcp/resources.go
+++ b/internal/mcp/resources.go
@@ -1,0 +1,267 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// MIME types reported in the read response. Stable across versions —
+// MCP clients (Claude Desktop, Cursor) display them and may switch
+// rendering paths based on the value.
+const (
+	itemMIMEType        = "text/markdown"
+	jsonMIMEType        = "application/json"
+	uriPrefixWorkspace  = "pad://workspace/"
+	resourceKindItem    = "items" // /{ws}/items[/{ref}]
+	resourceKindDash    = "dashboard"
+	resourceKindCollect = "collections"
+)
+
+// ResourceFetcher executes a pad CLI invocation and returns its
+// stdout. Used by the resource layer where the contract is "fetch raw
+// output"; shape conversion to MCP ResourceContents happens in the
+// handler. Errors propagate as Go errors (the resource read protocol
+// surfaces them as JSON-RPC errors, not IsError-flagged results).
+type ResourceFetcher interface {
+	Fetch(ctx context.Context, args []string) (string, error)
+}
+
+// ExecResourceFetcher shells out to the pad binary at Binary. Stderr
+// is folded into the returned error on non-zero exit so MCP clients
+// see the underlying CLI message.
+type ExecResourceFetcher struct {
+	// Binary is the path to the pad executable. Required.
+	Binary string
+}
+
+// Fetch runs `<Binary> <args...>` and returns stdout on success.
+func (f *ExecResourceFetcher) Fetch(ctx context.Context, args []string) (string, error) {
+	if f.Binary == "" {
+		return "", fmt.Errorf("resource fetcher: binary path not configured")
+	}
+	cmd := exec.CommandContext(ctx, f.Binary, args...)
+	var stdout, stderr strings.Builder
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if msg == "" {
+			msg = err.Error()
+		}
+		return "", fmt.Errorf("pad %s: %s", strings.Join(args, " "), msg)
+	}
+	return stdout.String(), nil
+}
+
+// resources owns the four resource handlers and their shared state.
+type resources struct {
+	fetcher  ResourceFetcher
+	rootArgs []string // pre-formatted root-flag tokens (e.g. ["--url", "X"])
+}
+
+// RegisterResources installs the four read-only MCP resource
+// templates on srv:
+//
+//   - pad://workspace/{ws}/items/{ref} — single item markdown
+//   - pad://workspace/{ws}/items       — list of items in workspace
+//   - pad://workspace/{ws}/dashboard   — project dashboard JSON
+//   - pad://workspace/{ws}/collections — collections list JSON
+//
+// rootFlags carries any startup-captured persistent flags (e.g. --url)
+// to forward to every shell-out — same shape as RegistryOptions.RootFlags.
+// Empty values are skipped.
+func RegisterResources(srv *server.MCPServer, fetcher ResourceFetcher, rootFlags map[string]string) {
+	r := &resources{
+		fetcher:  fetcher,
+		rootArgs: rootFlagsToArgs(rootFlags),
+	}
+
+	srv.AddResourceTemplate(
+		mcp.NewResourceTemplate(
+			"pad://workspace/{workspace}/items/{ref}",
+			"pad item",
+			mcp.WithTemplateDescription(
+				"Full markdown content of a single pad item identified by its ref "+
+					"(e.g. TASK-5, IDEA-12). Includes title, fields, body, and links.",
+			),
+			mcp.WithTemplateMIMEType(itemMIMEType),
+		),
+		r.readItem,
+	)
+	srv.AddResourceTemplate(
+		mcp.NewResourceTemplate(
+			"pad://workspace/{workspace}/items",
+			"pad items",
+			mcp.WithTemplateDescription(
+				"List of every item in the workspace as JSON. Useful for "+
+					"resource discovery before reading a specific item.",
+			),
+			mcp.WithTemplateMIMEType(jsonMIMEType),
+		),
+		r.readItems,
+	)
+	srv.AddResourceTemplate(
+		mcp.NewResourceTemplate(
+			"pad://workspace/{workspace}/dashboard",
+			"pad dashboard",
+			mcp.WithTemplateDescription(
+				"Computed project overview for the workspace: active items, "+
+					"plans, attention, blockers.",
+			),
+			mcp.WithTemplateMIMEType(jsonMIMEType),
+		),
+		r.readDashboard,
+	)
+	srv.AddResourceTemplate(
+		mcp.NewResourceTemplate(
+			"pad://workspace/{workspace}/collections",
+			"pad collections",
+			mcp.WithTemplateDescription(
+				"List of collections in the workspace plus their JSON Schemas.",
+			),
+			mcp.WithTemplateMIMEType(jsonMIMEType),
+		),
+		r.readCollections,
+	)
+}
+
+// readItem handles pad://workspace/{ws}/items/{ref}.
+func (r *resources) readItem(ctx context.Context, req mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+	ws, kind, ref, err := parsePadURI(req.Params.URI)
+	if err != nil {
+		return nil, err
+	}
+	if kind != resourceKindItem || ref == "" {
+		return nil, fmt.Errorf("resource %q is not an item URI", req.Params.URI)
+	}
+	return r.fetchAsResource(ctx, req.Params.URI, itemMIMEType,
+		[]string{"item", "show", ref, "--workspace", ws, "--format", "markdown"})
+}
+
+// readItems handles pad://workspace/{ws}/items.
+func (r *resources) readItems(ctx context.Context, req mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+	ws, kind, arg, err := parsePadURI(req.Params.URI)
+	if err != nil {
+		return nil, err
+	}
+	if kind != resourceKindItem || arg != "" {
+		return nil, fmt.Errorf("resource %q is not the items list URI", req.Params.URI)
+	}
+	return r.fetchAsResource(ctx, req.Params.URI, jsonMIMEType,
+		[]string{"item", "list", "--all", "--workspace", ws, "--format", "json"})
+}
+
+// readDashboard handles pad://workspace/{ws}/dashboard.
+func (r *resources) readDashboard(ctx context.Context, req mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+	ws, kind, arg, err := parsePadURI(req.Params.URI)
+	if err != nil {
+		return nil, err
+	}
+	if kind != resourceKindDash || arg != "" {
+		return nil, fmt.Errorf("resource %q is not the dashboard URI", req.Params.URI)
+	}
+	return r.fetchAsResource(ctx, req.Params.URI, jsonMIMEType,
+		[]string{"project", "dashboard", "--workspace", ws, "--format", "json"})
+}
+
+// readCollections handles pad://workspace/{ws}/collections.
+func (r *resources) readCollections(ctx context.Context, req mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+	ws, kind, arg, err := parsePadURI(req.Params.URI)
+	if err != nil {
+		return nil, err
+	}
+	if kind != resourceKindCollect || arg != "" {
+		return nil, fmt.Errorf("resource %q is not the collections URI", req.Params.URI)
+	}
+	return r.fetchAsResource(ctx, req.Params.URI, jsonMIMEType,
+		[]string{"collection", "list", "--workspace", ws, "--format", "json"})
+}
+
+// fetchAsResource is the shared shell-out + wrap path. padArgs is
+// the leading argument list (without root flags); rootArgs are
+// appended so --url etc. survive into every dispatched call.
+func (r *resources) fetchAsResource(
+	ctx context.Context,
+	uri, mimeType string,
+	padArgs []string,
+) ([]mcp.ResourceContents, error) {
+	full := append(append([]string{}, padArgs...), r.rootArgs...)
+	out, err := r.fetcher.Fetch(ctx, full)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", uri, err)
+	}
+	return []mcp.ResourceContents{
+		mcp.TextResourceContents{
+			URI:      uri,
+			MIMEType: mimeType,
+			Text:     out,
+		},
+	}, nil
+}
+
+// parsePadURI extracts (workspace, kind, arg) from a pad:// URI.
+// arg is empty for list-style resources (no trailing segment).
+//
+// Forms accepted:
+//
+//	pad://workspace/{ws}/items
+//	pad://workspace/{ws}/items/{ref}
+//	pad://workspace/{ws}/dashboard
+//	pad://workspace/{ws}/collections
+//
+// Returns an error for malformed URIs (missing prefix, missing
+// workspace, missing kind). Callers downstream still validate that
+// kind matches the handler's expected resource type.
+func parsePadURI(uri string) (workspace, kind, arg string, err error) {
+	if !strings.HasPrefix(uri, uriPrefixWorkspace) {
+		return "", "", "", fmt.Errorf("not a pad workspace URI: %q", uri)
+	}
+	rest := strings.TrimPrefix(uri, uriPrefixWorkspace)
+	if rest == "" {
+		return "", "", "", fmt.Errorf("missing workspace segment: %q", uri)
+	}
+	parts := strings.SplitN(rest, "/", 3)
+	if len(parts) < 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", "", fmt.Errorf("malformed pad URI: %q", uri)
+	}
+	workspace = parts[0]
+	kind = parts[1]
+	if len(parts) == 3 {
+		arg = parts[2]
+	}
+	return workspace, kind, arg, nil
+}
+
+// rootFlagsToArgs converts a startup root-flags map into the
+// pre-formatted CLI token list every fetch should append. Empty
+// values are skipped (matching BuildCLIArgs in dispatch.go).
+func rootFlagsToArgs(rootFlags map[string]string) []string {
+	if len(rootFlags) == 0 {
+		return nil
+	}
+	// Sorted for deterministic test output.
+	names := make([]string, 0, len(rootFlags))
+	for n := range rootFlags {
+		names = append(names, n)
+	}
+	// Keep a stable order without pulling in sort just for this.
+	for i := 1; i < len(names); i++ {
+		for j := i; j > 0 && names[j] < names[j-1]; j-- {
+			names[j], names[j-1] = names[j-1], names[j]
+		}
+	}
+	var out []string
+	for _, n := range names {
+		v := rootFlags[n]
+		if v == "" {
+			continue
+		}
+		out = append(out, "--"+n, v)
+	}
+	return out
+}

--- a/internal/mcp/resources_test.go
+++ b/internal/mcp/resources_test.go
@@ -1,0 +1,263 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// fakeFetcher records the args passed to Fetch and returns a
+// configured stdout string + optional error.
+type fakeFetcher struct {
+	gotArgs []string
+	stdout  string
+	err     error
+}
+
+func (f *fakeFetcher) Fetch(ctx context.Context, args []string) (string, error) {
+	f.gotArgs = append([]string(nil), args...)
+	return f.stdout, f.err
+}
+
+func TestParsePadURI_Forms(t *testing.T) {
+	cases := []struct {
+		uri     string
+		ws      string
+		kind    string
+		arg     string
+		wantErr bool
+	}{
+		{"pad://workspace/docapp/items/TASK-5", "docapp", "items", "TASK-5", false},
+		{"pad://workspace/docapp/items", "docapp", "items", "", false},
+		{"pad://workspace/docapp/dashboard", "docapp", "dashboard", "", false},
+		{"pad://workspace/docapp/collections", "docapp", "collections", "", false},
+		{"pad://workspace/x/items/y/extra", "x", "items", "y/extra", false}, // trailing path packed into arg
+		// Malformed:
+		{"http://example.com/foo", "", "", "", true},
+		{"pad://workspace/", "", "", "", true},
+		{"pad://workspace/onlyws", "", "", "", true},
+		{"pad://workspace//items", "", "", "", true}, // empty ws
+	}
+	for _, c := range cases {
+		gotWS, gotKind, gotArg, err := parsePadURI(c.uri)
+		if c.wantErr {
+			if err == nil {
+				t.Errorf("parsePadURI(%q) expected error, got ws=%q kind=%q arg=%q", c.uri, gotWS, gotKind, gotArg)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("parsePadURI(%q) unexpected error: %v", c.uri, err)
+			continue
+		}
+		if gotWS != c.ws || gotKind != c.kind || gotArg != c.arg {
+			t.Errorf("parsePadURI(%q) = (%q, %q, %q), want (%q, %q, %q)",
+				c.uri, gotWS, gotKind, gotArg, c.ws, c.kind, c.arg)
+		}
+	}
+}
+
+func TestRegisterResources_AdvertisesAllFourTemplates(t *testing.T) {
+	srv := server.NewMCPServer("t", "1", server.WithToolCapabilities(true))
+	RegisterResources(srv, &fakeFetcher{}, nil)
+
+	// We can't easily list registered templates from outside the
+	// package, but we can drive the public read path by URI and
+	// confirm each kind hits its handler successfully.
+	ctx := context.Background()
+	_ = ctx
+
+	// Indirect smoke: the dispatch tests below cover each handler.
+	// Here just assert RegisterResources returns without panic on a
+	// vanilla MCPServer — guards against future option changes that
+	// might require WithResourceCapabilities up-front.
+}
+
+func TestReadItem_DispatchesAndReturnsMarkdown(t *testing.T) {
+	f := &fakeFetcher{stdout: "# TASK-5\n\nbody"}
+	r := &resources{fetcher: f}
+	req := mcp.ReadResourceRequest{}
+	req.Params.URI = "pad://workspace/docapp/items/TASK-5"
+
+	contents, err := r.readItem(context.Background(), req)
+	if err != nil {
+		t.Fatalf("readItem: %v", err)
+	}
+	if len(contents) != 1 {
+		t.Fatalf("expected 1 ResourceContents, got %d", len(contents))
+	}
+	tc, ok := contents[0].(mcp.TextResourceContents)
+	if !ok {
+		t.Fatalf("expected TextResourceContents, got %T", contents[0])
+	}
+	if tc.MIMEType != itemMIMEType {
+		t.Errorf("MIMEType = %q, want %q", tc.MIMEType, itemMIMEType)
+	}
+	if tc.URI != req.Params.URI {
+		t.Errorf("URI = %q, want %q", tc.URI, req.Params.URI)
+	}
+	if tc.Text != "# TASK-5\n\nbody" {
+		t.Errorf("body wasn't passed through verbatim, got: %q", tc.Text)
+	}
+	wantArgs := []string{"item", "show", "TASK-5", "--workspace", "docapp", "--format", "markdown"}
+	if !equalSlice(f.gotArgs, wantArgs) {
+		t.Errorf("dispatched args = %v, want %v", f.gotArgs, wantArgs)
+	}
+}
+
+func TestReadItems_DispatchesItemListJSON(t *testing.T) {
+	f := &fakeFetcher{stdout: `[{"ref":"TASK-1"}]`}
+	r := &resources{fetcher: f}
+	req := mcp.ReadResourceRequest{}
+	req.Params.URI = "pad://workspace/docapp/items"
+
+	contents, err := r.readItems(context.Background(), req)
+	if err != nil {
+		t.Fatalf("readItems: %v", err)
+	}
+	tc := contents[0].(mcp.TextResourceContents)
+	if tc.MIMEType != jsonMIMEType {
+		t.Errorf("MIMEType = %q, want %q", tc.MIMEType, jsonMIMEType)
+	}
+	wantArgs := []string{"item", "list", "--all", "--workspace", "docapp", "--format", "json"}
+	if !equalSlice(f.gotArgs, wantArgs) {
+		t.Errorf("dispatched args = %v, want %v", f.gotArgs, wantArgs)
+	}
+}
+
+func TestReadDashboard_DispatchesProjectDashboard(t *testing.T) {
+	f := &fakeFetcher{stdout: `{"plans":[]}`}
+	r := &resources{fetcher: f}
+	req := mcp.ReadResourceRequest{}
+	req.Params.URI = "pad://workspace/docapp/dashboard"
+
+	contents, err := r.readDashboard(context.Background(), req)
+	if err != nil {
+		t.Fatalf("readDashboard: %v", err)
+	}
+	if contents[0].(mcp.TextResourceContents).MIMEType != jsonMIMEType {
+		t.Errorf("dashboard should be JSON")
+	}
+	wantArgs := []string{"project", "dashboard", "--workspace", "docapp", "--format", "json"}
+	if !equalSlice(f.gotArgs, wantArgs) {
+		t.Errorf("dispatched args = %v, want %v", f.gotArgs, wantArgs)
+	}
+}
+
+func TestReadCollections_DispatchesCollectionList(t *testing.T) {
+	f := &fakeFetcher{stdout: `[]`}
+	r := &resources{fetcher: f}
+	req := mcp.ReadResourceRequest{}
+	req.Params.URI = "pad://workspace/docapp/collections"
+
+	contents, err := r.readCollections(context.Background(), req)
+	if err != nil {
+		t.Fatalf("readCollections: %v", err)
+	}
+	if contents[0].(mcp.TextResourceContents).MIMEType != jsonMIMEType {
+		t.Errorf("collections should be JSON")
+	}
+	wantArgs := []string{"collection", "list", "--workspace", "docapp", "--format", "json"}
+	if !equalSlice(f.gotArgs, wantArgs) {
+		t.Errorf("dispatched args = %v, want %v", f.gotArgs, wantArgs)
+	}
+}
+
+func TestReadItem_RejectsMismatchedURI(t *testing.T) {
+	// readItem is registered against the items/{ref} template, but
+	// guards against being invoked with a mismatched URI (defensive —
+	// covers future template-routing regressions).
+	r := &resources{fetcher: &fakeFetcher{}}
+	req := mcp.ReadResourceRequest{}
+	req.Params.URI = "pad://workspace/docapp/dashboard"
+	if _, err := r.readItem(context.Background(), req); err == nil {
+		t.Errorf("readItem should reject non-item URI")
+	}
+}
+
+func TestRead_PropagatesFetchErrors(t *testing.T) {
+	// When the underlying pad invocation fails (e.g. unknown
+	// workspace), the error must surface as a Go error so MCP
+	// returns a JSON-RPC error to the client (not a successful read
+	// with empty contents).
+	f := &fakeFetcher{err: errors.New("workspace not found")}
+	r := &resources{fetcher: f}
+	req := mcp.ReadResourceRequest{}
+	req.Params.URI = "pad://workspace/ghost/items/TASK-5"
+	_, err := r.readItem(context.Background(), req)
+	if err == nil {
+		t.Fatalf("expected error when fetcher fails")
+	}
+	if !strings.Contains(err.Error(), "workspace not found") {
+		t.Errorf("error should propagate fetcher message; got: %v", err)
+	}
+}
+
+func TestRead_AppendsRootFlags(t *testing.T) {
+	// Per Codex review on TASK-945: --url root flag must reach every
+	// dispatched subprocess. Resource fetches go through a separate
+	// fetcher path, so this contract has to be retested here.
+	f := &fakeFetcher{stdout: "{}"}
+	r := &resources{
+		fetcher:  f,
+		rootArgs: rootFlagsToArgs(map[string]string{"url": "https://api.example.com"}),
+	}
+	req := mcp.ReadResourceRequest{}
+	req.Params.URI = "pad://workspace/docapp/dashboard"
+	if _, err := r.readDashboard(context.Background(), req); err != nil {
+		t.Fatalf("readDashboard: %v", err)
+	}
+	joined := strings.Join(f.gotArgs, " ")
+	if !strings.Contains(joined, "--url https://api.example.com") {
+		t.Errorf("root flag --url not forwarded; got args: %v", f.gotArgs)
+	}
+}
+
+func TestRootFlagsToArgs_SkipsEmptyValues(t *testing.T) {
+	got := rootFlagsToArgs(map[string]string{"url": "", "other": "x"})
+	want := []string{"--other", "x"}
+	if !equalSlice(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestRootFlagsToArgs_NilMap(t *testing.T) {
+	if got := rootFlagsToArgs(nil); got != nil {
+		t.Errorf("expected nil for nil input, got: %v", got)
+	}
+}
+
+func TestExecResourceFetcher_NoBinaryReturnsError(t *testing.T) {
+	f := &ExecResourceFetcher{}
+	_, err := f.Fetch(t.Context(), []string{"item", "list"})
+	if err == nil {
+		t.Errorf("expected error when binary unset")
+	}
+}
+
+func TestExecResourceFetcher_RunsBinaryAndReturnsStdout(t *testing.T) {
+	// /bin/sh stand-in: same pattern as ExecDispatcher tests.
+	f := &ExecResourceFetcher{Binary: "/bin/sh"}
+	out, err := f.Fetch(t.Context(), []string{"-c", `echo hello`})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if !strings.Contains(out, "hello") {
+		t.Errorf("expected 'hello' in stdout, got: %q", out)
+	}
+}
+
+func TestExecResourceFetcher_NonzeroExitReturnsErrorWithStderr(t *testing.T) {
+	f := &ExecResourceFetcher{Binary: "/bin/sh"}
+	_, err := f.Fetch(t.Context(), []string{"-c", `echo "boom" >&2 && exit 9`})
+	if err == nil {
+		t.Fatalf("expected error on non-zero exit")
+	}
+	if !strings.Contains(err.Error(), "boom") {
+		t.Errorf("error should contain stderr; got: %v", err)
+	}
+}

--- a/internal/mcp/resources_test.go
+++ b/internal/mcp/resources_test.go
@@ -77,8 +77,18 @@ func TestRegisterResources_AdvertisesAllFourTemplates(t *testing.T) {
 	// might require WithResourceCapabilities up-front.
 }
 
-func TestReadItem_DispatchesAndReturnsMarkdown(t *testing.T) {
-	f := &fakeFetcher{stdout: "# TASK-5\n\nbody"}
+func TestReadItem_DispatchesJSONAndComposesMarkdown(t *testing.T) {
+	// Codex review (round 1) caught: `pad item show --format markdown`
+	// emits only item.Content (no ref/title/fields). The MCP resource
+	// promises full markdown, so we fetch JSON and compose the
+	// document here. Test guards both contracts: dispatch uses
+	// --format json, output contains heading + fields + body.
+	f := &fakeFetcher{stdout: `{
+		"ref": "TASK-5",
+		"title": "Fix OAuth",
+		"fields": "{\"priority\":\"high\",\"status\":\"in-progress\"}",
+		"content": "Detailed plan goes here."
+	}`}
 	r := &resources{fetcher: f}
 	req := mcp.ReadResourceRequest{}
 	req.Params.URI = "pad://workspace/docapp/items/TASK-5"
@@ -97,15 +107,71 @@ func TestReadItem_DispatchesAndReturnsMarkdown(t *testing.T) {
 	if tc.MIMEType != itemMIMEType {
 		t.Errorf("MIMEType = %q, want %q", tc.MIMEType, itemMIMEType)
 	}
-	if tc.URI != req.Params.URI {
-		t.Errorf("URI = %q, want %q", tc.URI, req.Params.URI)
+	wantParts := []string{
+		"# TASK-5: Fix OAuth",
+		"- **priority:** high",
+		"- **status:** in-progress",
+		"Detailed plan goes here.",
 	}
-	if tc.Text != "# TASK-5\n\nbody" {
-		t.Errorf("body wasn't passed through verbatim, got: %q", tc.Text)
+	for _, p := range wantParts {
+		if !strings.Contains(tc.Text, p) {
+			t.Errorf("composed markdown missing %q; got:\n%s", p, tc.Text)
+		}
 	}
-	wantArgs := []string{"item", "show", "TASK-5", "--workspace", "docapp", "--format", "markdown"}
+	wantArgs := []string{"item", "show", "TASK-5", "--workspace", "docapp", "--format", "json"}
 	if !equalSlice(f.gotArgs, wantArgs) {
 		t.Errorf("dispatched args = %v, want %v", f.gotArgs, wantArgs)
+	}
+}
+
+func TestFormatItemAsMarkdown_FullShape(t *testing.T) {
+	got, err := formatItemAsMarkdown(`{
+		"ref": "TASK-9",
+		"title": "Add MCP",
+		"parent_ref": "PLAN-942",
+		"parent_title": "Local MCP server",
+		"fields": "{\"priority\":\"high\"}",
+		"content": "body"
+	}`)
+	if err != nil {
+		t.Fatalf("formatItemAsMarkdown: %v", err)
+	}
+	want := "# TASK-9: Add MCP\n\n**Parent:** PLAN-942 — Local MCP server\n\n- **priority:** high\n\nbody\n"
+	if got != want {
+		t.Errorf("formatItemAsMarkdown output drift\ngot:  %q\nwant: %q", got, want)
+	}
+}
+
+func TestFormatItemAsMarkdown_HandlesMissingFields(t *testing.T) {
+	// Resilience: items with no parent_ref / no fields / no content
+	// should still produce a valid heading-only document, not a panic.
+	got, err := formatItemAsMarkdown(`{"ref":"DOC-1","title":"Onboarding"}`)
+	if err != nil {
+		t.Fatalf("formatItemAsMarkdown: %v", err)
+	}
+	if got != "# DOC-1: Onboarding\n\n" {
+		t.Errorf("got %q, want heading-only doc", got)
+	}
+}
+
+func TestFormatItemAsMarkdown_HandlesEmptyFields(t *testing.T) {
+	// fields is `{}` (no keys) — should NOT emit a stray blank
+	// "fields:" section.
+	got, err := formatItemAsMarkdown(`{"ref":"X","title":"y","fields":"{}","content":"z"}`)
+	if err != nil {
+		t.Fatalf("formatItemAsMarkdown: %v", err)
+	}
+	if strings.Contains(got, "**") {
+		t.Errorf("empty fields object should not produce list items; got: %q", got)
+	}
+	if !strings.Contains(got, "z") {
+		t.Errorf("body missing: %q", got)
+	}
+}
+
+func TestFormatItemAsMarkdown_RejectsInvalidJSON(t *testing.T) {
+	if _, err := formatItemAsMarkdown(`not json`); err == nil {
+		t.Errorf("expected error on invalid JSON")
 	}
 }
 


### PR DESCRIPTION
## Summary

Four MCP resource templates expose pad workspace state to agents without requiring a tool invocation:

- `pad://workspace/{ws}/items/{ref}` → single item markdown
- `pad://workspace/{ws}/items` → list of items (JSON)
- `pad://workspace/{ws}/dashboard` → project dashboard (JSON)
- `pad://workspace/{ws}/collections` → collections + schemas (JSON)

Agents can `resources/read` these URIs and ingest the body directly into context — useful for "load TASK-5 then plan" flows where they shouldn't have to pick a tool.

## Context

Implements `TASK-946` under `PLAN-942` (Local MCP server). Builds on TASK-944 (skeleton) and TASK-945 (tool registry). Same `RootFlags` injection contract — `--url` reaches resource fetches too.

## Live smoke

```
resources/templates/list → 4 templates with correct mime types + URI patterns
resources/read pad://workspace/docapp/items/TASK-944 → 1764 bytes text/markdown
```

## Test plan

- [x] go build ./... — clean
- [x] golangci-lint run — 0 issues
- [x] go test -race ./internal/mcp/... — all green (51 tests now)
- [x] Real `resources/templates/list` + `resources/read` against built binary
- [x] make check — clean