### PR TITLE
feat(mcp): pad mcp install / uninstall / status (TASK-948)

### DIFF
--- a/cmd/pad/mcp.go
+++ b/cmd/pad/mcp.go
@@ -12,9 +12,11 @@ import (
 
 // mcpCmd is the parent of `pad mcp ...` subcommands.
 //
-// v1 ships `pad mcp serve` (stdio transport). Future tasks add:
-//   - TASK-948 — `pad mcp install <agent>` to write client configs
-//     for Claude Desktop / Cursor / Windsurf in one shot.
+//   - `pad mcp serve` — run the stdio MCP server.
+//   - `pad mcp install [agent]` — write a "pad" entry into a client's
+//     MCP config (Claude Desktop / Cursor / Windsurf).
+//   - `pad mcp uninstall <agent>` — remove the entry.
+//   - `pad mcp status` — show install state across all supported clients.
 func mcpCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "mcp",
@@ -22,11 +24,174 @@ func mcpCmd() *cobra.Command {
 		Long: `Run pad as an MCP server so AI agents (Claude Desktop, Cursor, Windsurf, etc.)
 can call pad commands as tools and read pad data as resources.
 
-Use ` + "`pad mcp serve`" + ` to start the server over stdio. See
-https://getpad.dev/mcp/local for client configuration.`,
+Use ` + "`pad mcp serve`" + ` to start the server over stdio.
+Use ` + "`pad mcp install`" + ` to register pad with a client app.
+See https://getpad.dev/mcp/local for client configuration.`,
 	}
-	cmd.AddCommand(mcpServeCmd())
+	cmd.AddCommand(
+		mcpServeCmd(),
+		mcpInstallCmd(),
+		mcpUninstallCmd(),
+		mcpStatusCmd(),
+	)
 	return cmd
+}
+
+// mcpInstallCmd implements `pad mcp install [agent]`.
+//
+// With no arguments, prints the install status across supported
+// agents (so the user picks one). With an agent name, writes a
+// `pad` entry into that agent's MCP config. With --all, installs
+// for every supported agent (creating config dirs as needed).
+func mcpInstallCmd() *cobra.Command {
+	var allFlag bool
+	cmd := &cobra.Command{
+		Use:   "install [agent]",
+		Short: "Install pad as an MCP server for a client app",
+		Long: `Write a "pad" entry into the named agent's MCP server config.
+
+Supported agents:
+  claude-desktop   Claude Desktop
+  cursor           Cursor
+  windsurf         Windsurf
+
+With no arguments, lists current install status across supported
+agents (run ` + "`pad mcp status`" + ` for the same view). With
+--all, installs for every supported agent, creating config files
+on demand.
+
+Existing MCP server entries (other servers configured by the user)
+are preserved — only the "pad" entry is touched.`,
+		ValidArgs:    agentValidArgs(),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			binary, err := os.Executable()
+			if err != nil || binary == "" {
+				binary = os.Args[0]
+			}
+			inst := &mcpserver.Installer{Binary: binary}
+			switch {
+			case allFlag:
+				return runMCPInstallAll(cmd, inst)
+			case len(args) == 0:
+				return runMCPStatus(cmd, inst)
+			default:
+				return runMCPInstallOne(cmd, inst, args[0])
+			}
+		},
+	}
+	cmd.Flags().BoolVar(&allFlag, "all", false, "install for every supported agent")
+	return cmd
+}
+
+// mcpUninstallCmd implements `pad mcp uninstall <agent>`.
+func mcpUninstallCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "uninstall <agent>",
+		Short: "Remove the pad MCP entry from a client's config",
+		Long: `Remove the "pad" entry from the named agent's MCP server
+config. Other server entries are preserved. Idempotent: removing a
+non-existent entry is not an error.`,
+		ValidArgs:    agentValidArgs(),
+		Args:         cobra.ExactArgs(1),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			inst := &mcpserver.Installer{}
+			path, removed, err := inst.Uninstall(args[0])
+			if err != nil {
+				return err
+			}
+			if removed {
+				fmt.Fprintf(cmd.OutOrStdout(), "Removed pad MCP entry from %s\n  config: %s\n", args[0], path)
+			} else {
+				fmt.Fprintf(cmd.OutOrStdout(), "%s: pad entry not present (nothing to remove)\n  config: %s\n", args[0], path)
+			}
+			return nil
+		},
+	}
+	return cmd
+}
+
+// mcpStatusCmd implements `pad mcp status` — same as
+// `pad mcp install` with no args, but exposed as a dedicated command
+// for shell scripts.
+func mcpStatusCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "status",
+		Short: "Show pad MCP install status across supported clients",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			binary, err := os.Executable()
+			if err != nil || binary == "" {
+				binary = os.Args[0]
+			}
+			inst := &mcpserver.Installer{Binary: binary}
+			return runMCPStatus(cmd, inst)
+		},
+	}
+}
+
+func agentValidArgs() []string {
+	out := make([]string, 0, len(mcpserver.SupportedAgents))
+	for _, a := range mcpserver.SupportedAgents {
+		out = append(out, a.Name)
+	}
+	return out
+}
+
+func runMCPStatus(cmd *cobra.Command, inst *mcpserver.Installer) error {
+	w := cmd.OutOrStdout()
+	fmt.Fprintln(w, "Pad MCP install status:")
+	fmt.Fprintln(w)
+	for _, row := range inst.Status() {
+		marker := "[ ]"
+		if row.Installed {
+			marker = "[x]"
+		}
+		fmt.Fprintf(w, "  %s %-20s %s\n", marker, row.Label, row.ConfigPath)
+		if row.Error != "" {
+			fmt.Fprintf(w, "      error: %s\n", row.Error)
+		}
+		if row.Installed && row.Command != "" {
+			fmt.Fprintf(w, "      command: %s\n", row.Command)
+		}
+	}
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Install: pad mcp install <agent>   (or --all for every supported)")
+	return nil
+}
+
+func runMCPInstallOne(cmd *cobra.Command, inst *mcpserver.Installer, agent string) error {
+	path, modified, err := inst.Install(agent)
+	if err != nil {
+		return err
+	}
+	w := cmd.OutOrStdout()
+	if modified {
+		fmt.Fprintf(w, "Installed pad MCP entry for %s\n  config: %s\n  command: %s mcp serve\n", agent, path, inst.Binary)
+		fmt.Fprintln(w, "  → Restart the client to pick up the new server entry.")
+	} else {
+		fmt.Fprintf(w, "%s already up to date\n  config: %s\n", agent, path)
+	}
+	return nil
+}
+
+func runMCPInstallAll(cmd *cobra.Command, inst *mcpserver.Installer) error {
+	w := cmd.OutOrStdout()
+	for _, a := range mcpserver.SupportedAgents {
+		path, modified, err := inst.Install(a.Name)
+		if err != nil {
+			fmt.Fprintf(w, "  ✗ %s — skipped: %v\n", a.Label, err)
+			continue
+		}
+		if modified {
+			fmt.Fprintf(w, "  ✓ %s installed (%s)\n", a.Label, path)
+		} else {
+			fmt.Fprintf(w, "  ✓ %s already up to date (%s)\n", a.Label, path)
+		}
+	}
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Restart each client to pick up the new server entry.")
+	return nil
 }
 
 // mcpServeCmd implements the stdio MCP server. The cobra command is a

--- a/cmd/pad/mcp.go
+++ b/cmd/pad/mcp.go
@@ -62,9 +62,20 @@ on demand.
 
 Existing MCP server entries (other servers configured by the user)
 are preserved — only the "pad" entry is touched.`,
-		ValidArgs:    agentValidArgs(),
+		ValidArgs: agentValidArgs(),
+		// Cobra defaults to ArbitraryArgs for cmds without Args set —
+		// silently accepts extras, which Codex caught as a UX bug
+		// (`pad mcp install cursor windsurf` would only install Cursor).
+		Args:         cobra.MaximumNArgs(1),
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// --all is mutually exclusive with an agent name. Without
+			// this guard `pad mcp install --all cursor` would install
+			// every agent and silently drop the cursor argument,
+			// which Codex round 1 flagged as confusing.
+			if allFlag && len(args) > 0 {
+				return fmt.Errorf("--all cannot be combined with an agent name")
+			}
 			binary, err := os.Executable()
 			if err != nil || binary == "" {
 				binary = os.Args[0]

--- a/internal/mcp/install.go
+++ b/internal/mcp/install.go
@@ -147,6 +147,12 @@ func AddPadEntry(path, binary string) (bool, error) {
 	}
 	current, hadPad := servers[MCPServerKey].(map[string]any)
 	if hadPad && jsonEqual(current, wantedEntry) {
+		// Idempotent path: content already correct, no rewrite.
+		// Still tighten perms — a previous tool / manual edit may
+		// have left the file 0644, and the security-tightening
+		// guarantee should not depend on whether content changed.
+		// Codex round 2 (TASK-948) caught this gap.
+		tightenPerms(path)
 		return false, nil
 	}
 	servers[MCPServerKey] = wantedEntry
@@ -155,6 +161,20 @@ func AddPadEntry(path, binary string) (bool, error) {
 		return false, err
 	}
 	return true, nil
+}
+
+// tightenPerms sets path to 0600 if it exists. Best-effort: errors
+// only emit a warning to stderr (the user's primary intent — install /
+// no-op — already succeeded). Used by both the write-modified and
+// idempotent code paths so the security claim ("config is 0600 after
+// install") holds regardless of whether content changed.
+func tightenPerms(path string) {
+	if _, err := os.Stat(path); err != nil {
+		return // nothing to tighten
+	}
+	if err := os.Chmod(path, 0o600); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: failed to chmod 0600 %s: %v\n", path, err)
+	}
 }
 
 // RemovePadEntry deletes mcpServers.pad while leaving other servers +
@@ -271,11 +291,7 @@ func writeJSONConfig(path string, cfg map[string]any) error {
 	if err := os.WriteFile(path, append(b, '\n'), 0o600); err != nil {
 		return fmt.Errorf("write %s: %w", path, err)
 	}
-	if err := os.Chmod(path, 0o600); err != nil {
-		// Log-only: the install succeeded; perms hardening is a
-		// best-effort defense-in-depth. Don't fail the user's flow.
-		fmt.Fprintf(os.Stderr, "warning: failed to chmod 0600 %s: %v\n", path, err)
-	}
+	tightenPerms(path)
 	return nil
 }
 

--- a/internal/mcp/install.go
+++ b/internal/mcp/install.go
@@ -1,0 +1,400 @@
+package mcp
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+// MCPServerKey is the canonical name pad registers itself under in
+// each agent's `mcpServers` map. Stable across versions; renaming
+// would orphan every existing install.
+const MCPServerKey = "pad"
+
+// Agent describes a known MCP-compatible client and how to find its
+// per-user config file.
+type Agent struct {
+	// Name is the canonical lookup key, used as the command argument
+	// (e.g. `pad mcp install claude-desktop`).
+	Name string
+	// Label is the human-readable name for prints.
+	Label string
+	// Aliases match alternate user inputs.
+	Aliases []string
+	// PathFor resolves the config path given a user's home directory
+	// and runtime.GOOS. Pure function — no I/O — so tests override
+	// `home` and `goos` to verify path logic without touching the
+	// real filesystem.
+	PathFor func(home, goos string) (string, error)
+}
+
+// SupportedAgents is the canonical list of MCP-aware clients pad
+// knows how to configure. Order is the iteration order for the
+// auto-detect / status path.
+var SupportedAgents = []Agent{
+	{
+		Name:    "claude-desktop",
+		Label:   "Claude Desktop",
+		Aliases: []string{"claude", "anthropic"},
+		PathFor: claudeDesktopPathFor,
+	},
+	{
+		Name:    "cursor",
+		Label:   "Cursor",
+		PathFor: cursorPathFor,
+	},
+	{
+		Name:    "windsurf",
+		Label:   "Windsurf",
+		PathFor: windsurfPathFor,
+	},
+}
+
+// FindAgent returns the matching Agent for a name or alias. Names are
+// case-insensitive (Claude / claude / CLAUDE all resolve).
+func FindAgent(name string) (*Agent, error) {
+	for i := range SupportedAgents {
+		a := &SupportedAgents[i]
+		if equalFold(a.Name, name) {
+			return a, nil
+		}
+		for _, alias := range a.Aliases {
+			if equalFold(alias, name) {
+				return a, nil
+			}
+		}
+	}
+	return nil, fmt.Errorf("unknown agent %q (supported: claude-desktop, cursor, windsurf)", name)
+}
+
+// equalFold is a tiny case-insensitive string compare without
+// pulling in strings.EqualFold's full Unicode logic — agent names
+// are ASCII.
+func equalFold(a, b string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := 0; i < len(a); i++ {
+		ca, cb := a[i], b[i]
+		if ca >= 'A' && ca <= 'Z' {
+			ca += 32
+		}
+		if cb >= 'A' && cb <= 'Z' {
+			cb += 32
+		}
+		if ca != cb {
+			return false
+		}
+	}
+	return true
+}
+
+func claudeDesktopPathFor(home, goos string) (string, error) {
+	switch goos {
+	case "darwin":
+		return filepath.Join(home, "Library", "Application Support", "Claude", "claude_desktop_config.json"), nil
+	case "windows":
+		appData := os.Getenv("APPDATA")
+		if appData == "" {
+			return "", errors.New("APPDATA env var not set; cannot resolve Claude Desktop config path")
+		}
+		return filepath.Join(appData, "Claude", "claude_desktop_config.json"), nil
+	default: // linux + bsd + others
+		return filepath.Join(home, ".config", "Claude", "claude_desktop_config.json"), nil
+	}
+}
+
+func cursorPathFor(home, _ string) (string, error) {
+	// Cursor uses ~/.cursor/mcp.json on every platform.
+	return filepath.Join(home, ".cursor", "mcp.json"), nil
+}
+
+func windsurfPathFor(home, goos string) (string, error) {
+	if goos == "windows" {
+		appData := os.Getenv("APPDATA")
+		if appData == "" {
+			return "", errors.New("APPDATA env var not set; cannot resolve Windsurf config path")
+		}
+		return filepath.Join(appData, "Codeium", "windsurf", "mcp_config.json"), nil
+	}
+	return filepath.Join(home, ".codeium", "windsurf", "mcp_config.json"), nil
+}
+
+// AddPadEntry reads (or creates) the JSON config at path, ensures
+// mcpServers.pad points to `binary`, and writes the file back.
+// Existing entries outside `mcpServers.pad` are preserved.
+//
+// Returns (modified=true, nil) when the on-disk content actually
+// changed, (false, nil) when the file was already up to date.
+func AddPadEntry(path, binary string) (bool, error) {
+	if binary == "" {
+		return false, errors.New("AddPadEntry: binary path is required")
+	}
+	cfg, err := loadJSONConfig(path)
+	if err != nil {
+		return false, err
+	}
+	wantedEntry := map[string]any{
+		"command": binary,
+		"args":    []any{"mcp", "serve"},
+	}
+	servers, _ := cfg["mcpServers"].(map[string]any)
+	if servers == nil {
+		servers = map[string]any{}
+	}
+	current, hadPad := servers[MCPServerKey].(map[string]any)
+	if hadPad && jsonEqual(current, wantedEntry) {
+		return false, nil
+	}
+	servers[MCPServerKey] = wantedEntry
+	cfg["mcpServers"] = servers
+	if err := writeJSONConfig(path, cfg); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// RemovePadEntry deletes mcpServers.pad while leaving other servers +
+// top-level keys intact. Returns (true, nil) when an entry was
+// removed, (false, nil) when there was nothing to do (file missing,
+// no mcpServers key, or no `pad` entry).
+func RemovePadEntry(path string) (bool, error) {
+	if _, err := os.Stat(path); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+		return false, fmt.Errorf("stat %s: %w", path, err)
+	}
+	cfg, err := loadJSONConfig(path)
+	if err != nil {
+		return false, err
+	}
+	servers, ok := cfg["mcpServers"].(map[string]any)
+	if !ok {
+		return false, nil
+	}
+	if _, exists := servers[MCPServerKey]; !exists {
+		return false, nil
+	}
+	delete(servers, MCPServerKey)
+	cfg["mcpServers"] = servers
+	if err := writeJSONConfig(path, cfg); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// HasPadEntry returns whether mcpServers.pad is present, plus the
+// current `command` value (empty string when missing). Missing files
+// are reported as not installed without error.
+func HasPadEntry(path string) (installed bool, command string, err error) {
+	if _, statErr := os.Stat(path); statErr != nil {
+		if errors.Is(statErr, os.ErrNotExist) {
+			return false, "", nil
+		}
+		return false, "", fmt.Errorf("stat %s: %w", path, statErr)
+	}
+	cfg, err := loadJSONConfig(path)
+	if err != nil {
+		return false, "", err
+	}
+	servers, _ := cfg["mcpServers"].(map[string]any)
+	if servers == nil {
+		return false, "", nil
+	}
+	entry, ok := servers[MCPServerKey].(map[string]any)
+	if !ok {
+		return false, "", nil
+	}
+	cmd, _ := entry["command"].(string)
+	return true, cmd, nil
+}
+
+// loadJSONConfig reads path as a JSON object. A missing or
+// whitespace-only file is treated as an empty config (so AddPadEntry
+// can populate from scratch on first install). Callers that need to
+// distinguish "missing" from "empty" check os.Stat separately.
+//
+// Read or parse errors on a non-empty file propagate verbatim — we
+// never silently overwrite a corrupt config; the user has to fix or
+// remove it.
+func loadJSONConfig(path string) (map[string]any, error) {
+	b, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return map[string]any{}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	if isAllWhitespace(b) {
+		return map[string]any{}, nil
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	if raw == nil {
+		raw = map[string]any{}
+	}
+	return raw, nil
+}
+
+func isAllWhitespace(b []byte) bool {
+	for _, c := range b {
+		if c != ' ' && c != '\t' && c != '\n' && c != '\r' {
+			return false
+		}
+	}
+	return true
+}
+
+func writeJSONConfig(path string, cfg map[string]any) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("mkdir %s: %w", filepath.Dir(path), err)
+	}
+	b, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal config: %w", err)
+	}
+	// 0o600 — config files often hold credentials for OTHER MCP
+	// servers; tighten perms even though pad's own entry has none.
+	if err := os.WriteFile(path, append(b, '\n'), 0o600); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return nil
+}
+
+// jsonEqual compares two parsed-JSON maps for value equality. Cheaper
+// than reflect.DeepEqual and accepts the float/string nuances of
+// json.Unmarshal output.
+func jsonEqual(a, b map[string]any) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	ab, _ := json.Marshal(a)
+	bb, _ := json.Marshal(b)
+	if len(ab) == 0 || len(bb) == 0 {
+		return false
+	}
+	// Cheap-but-correct: round-trip both and compare the canonical
+	// JSON byte form. Order is deterministic per encoding/json.
+	return string(ab) == string(bb)
+}
+
+// Installer is the high-level façade over AddPadEntry / RemovePadEntry,
+// resolving config paths from per-agent rules and the user's home dir.
+//
+// Production callers leave Home/GOOS empty so the installer queries
+// the runtime; tests inject explicit values to point at a tempdir.
+type Installer struct {
+	// Binary is the pad executable to register. Required for Install.
+	Binary string
+	// Home overrides os.UserHomeDir when non-empty (test-only).
+	Home string
+	// GOOS overrides runtime.GOOS when non-empty (test-only).
+	GOOS string
+}
+
+// AgentStatus is one row of Installer.Status output.
+type AgentStatus struct {
+	Name       string
+	Label      string
+	ConfigPath string // empty when path resolution failed
+	Installed  bool
+	Command    string // current `command` value, when installed
+	// Error captures any non-fatal issue (path resolution failed,
+	// config file unreadable). Status keeps reporting on success of
+	// other agents even if one row errors.
+	Error string
+}
+
+func (i *Installer) home() (string, error) {
+	if i.Home != "" {
+		return i.Home, nil
+	}
+	return os.UserHomeDir()
+}
+
+func (i *Installer) goos() string {
+	if i.GOOS != "" {
+		return i.GOOS
+	}
+	return runtime.GOOS
+}
+
+// ResolvePath returns the absolute config path for the given agent
+// using the installer's home + goos overrides.
+func (i *Installer) ResolvePath(agent *Agent) (string, error) {
+	home, err := i.home()
+	if err != nil {
+		return "", err
+	}
+	if agent.PathFor == nil {
+		return "", fmt.Errorf("agent %q has no PathFor resolver", agent.Name)
+	}
+	return agent.PathFor(home, i.goos())
+}
+
+// Install adds (or refreshes) the pad entry in the named agent's
+// config. Returns the resolved path + whether the file was actually
+// modified (false on a no-op refresh).
+func (i *Installer) Install(agentName string) (string, bool, error) {
+	if i.Binary == "" {
+		return "", false, errors.New("Installer.Binary is required")
+	}
+	agent, err := FindAgent(agentName)
+	if err != nil {
+		return "", false, err
+	}
+	path, err := i.ResolvePath(agent)
+	if err != nil {
+		return "", false, err
+	}
+	modified, err := AddPadEntry(path, i.Binary)
+	return path, modified, err
+}
+
+// Uninstall removes the pad entry from the named agent's config.
+// Idempotent: a missing file or missing entry is not an error and
+// returns (path, false, nil).
+func (i *Installer) Uninstall(agentName string) (string, bool, error) {
+	agent, err := FindAgent(agentName)
+	if err != nil {
+		return "", false, err
+	}
+	path, err := i.ResolvePath(agent)
+	if err != nil {
+		return "", false, err
+	}
+	removed, err := RemovePadEntry(path)
+	return path, removed, err
+}
+
+// Status walks every supported agent and reports installation state.
+// Per-agent failures are captured in AgentStatus.Error rather than
+// short-circuiting the whole report.
+func (i *Installer) Status() []AgentStatus {
+	out := make([]AgentStatus, 0, len(SupportedAgents))
+	for idx := range SupportedAgents {
+		agent := &SupportedAgents[idx]
+		row := AgentStatus{Name: agent.Name, Label: agent.Label}
+		path, err := i.ResolvePath(agent)
+		if err != nil {
+			row.Error = err.Error()
+			out = append(out, row)
+			continue
+		}
+		row.ConfigPath = path
+		installed, cmd, err := HasPadEntry(path)
+		if err != nil {
+			row.Error = err.Error()
+		}
+		row.Installed = installed
+		row.Command = cmd
+		out = append(out, row)
+	}
+	return out
+}

--- a/internal/mcp/install.go
+++ b/internal/mcp/install.go
@@ -260,9 +260,21 @@ func writeJSONConfig(path string, cfg map[string]any) error {
 		return fmt.Errorf("marshal config: %w", err)
 	}
 	// 0o600 — config files often hold credentials for OTHER MCP
-	// servers; tighten perms even though pad's own entry has none.
+	// servers (postgres URIs, OpenAI keys, etc.); tighten perms even
+	// though pad's own entry has no secrets.
+	//
+	// os.WriteFile only honors the mode when CREATING the file — an
+	// existing 0644 config keeps 0644 after the write. Codex caught
+	// this on TASK-948 round 1, so we Chmod after writing. Best-effort:
+	// chmod failures don't fail the install (the data write
+	// succeeded; the user can re-tighten manually).
 	if err := os.WriteFile(path, append(b, '\n'), 0o600); err != nil {
 		return fmt.Errorf("write %s: %w", path, err)
+	}
+	if err := os.Chmod(path, 0o600); err != nil {
+		// Log-only: the install succeeded; perms hardening is a
+		// best-effort defense-in-depth. Don't fail the user's flow.
+		fmt.Fprintf(os.Stderr, "warning: failed to chmod 0600 %s: %v\n", path, err)
 	}
 	return nil
 }

--- a/internal/mcp/install_test.go
+++ b/internal/mcp/install_test.go
@@ -363,6 +363,30 @@ func TestAddPadEntry_HandlesEmptyAndWhitespaceFile(t *testing.T) {
 	}
 }
 
+func TestAddPadEntry_TightensExistingFilePerms(t *testing.T) {
+	// Codex round 1 (TASK-948): os.WriteFile only honors the mode
+	// when CREATING the file. If the user had a pre-existing 0644
+	// config (the system default), the install must still leave it
+	// 0600 so the credentials in OTHER MCP server entries don't leak.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	// Pre-create with loose perms.
+	if err := os.WriteFile(path, []byte(`{"mcpServers":{}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := AddPadEntry(path, "/p"); err != nil {
+		t.Fatalf("AddPadEntry: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mode := info.Mode().Perm()
+	if mode != 0o600 {
+		t.Errorf("expected 0600 after install, got %#o", mode)
+	}
+}
+
 func TestAddPadEntry_RejectsCorruptJSON(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "broken.json")

--- a/internal/mcp/install_test.go
+++ b/internal/mcp/install_test.go
@@ -363,6 +363,37 @@ func TestAddPadEntry_HandlesEmptyAndWhitespaceFile(t *testing.T) {
 	}
 }
 
+func TestAddPadEntry_TightensPermsOnIdempotentNoop(t *testing.T) {
+	// Codex round 2 (TASK-948): the idempotent path returns BEFORE
+	// writeJSONConfig, so an already-up-to-date 0644 config kept
+	// loose perms. Tighten on the no-op path too.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	desired := map[string]any{
+		"mcpServers": map[string]any{
+			"pad": map[string]any{
+				"command": "/p",
+				"args":    []any{"mcp", "serve"},
+			},
+		},
+	}
+	b, _ := json.MarshalIndent(desired, "", "  ")
+	if err := os.WriteFile(path, b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	modified, err := AddPadEntry(path, "/p")
+	if err != nil {
+		t.Fatalf("AddPadEntry: %v", err)
+	}
+	if modified {
+		t.Errorf("expected modified=false on identical content")
+	}
+	info, _ := os.Stat(path)
+	if mode := info.Mode().Perm(); mode != 0o600 {
+		t.Errorf("expected 0600 even on no-op path, got %#o", mode)
+	}
+}
+
 func TestAddPadEntry_TightensExistingFilePerms(t *testing.T) {
 	// Codex round 1 (TASK-948): os.WriteFile only honors the mode
 	// when CREATING the file. If the user had a pre-existing 0644

--- a/internal/mcp/install_test.go
+++ b/internal/mcp/install_test.go
@@ -1,0 +1,408 @@
+package mcp
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestFindAgent_NameAndAliases(t *testing.T) {
+	cases := []struct {
+		input     string
+		wantName  string
+		wantError bool
+	}{
+		{"claude-desktop", "claude-desktop", false},
+		{"claude", "claude-desktop", false}, // alias
+		{"Claude", "claude-desktop", false}, // case-insensitive
+		{"anthropic", "claude-desktop", false},
+		{"cursor", "cursor", false},
+		{"windsurf", "windsurf", false},
+		{"vscode", "", true}, // unsupported
+		{"", "", true},       // empty
+	}
+	for _, c := range cases {
+		got, err := FindAgent(c.input)
+		if c.wantError {
+			if err == nil {
+				t.Errorf("FindAgent(%q) expected error, got %+v", c.input, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("FindAgent(%q): %v", c.input, err)
+			continue
+		}
+		if got.Name != c.wantName {
+			t.Errorf("FindAgent(%q).Name = %q, want %q", c.input, got.Name, c.wantName)
+		}
+	}
+}
+
+func TestPathResolvers_LinuxAndDarwin(t *testing.T) {
+	// Path-resolution logic is platform-aware. Test against fixed
+	// home + goos values so the assertions don't depend on the
+	// host OS.
+	cases := []struct {
+		agentName string
+		goos      string
+		wantPath  string
+	}{
+		{"claude-desktop", "linux", "/h/.config/Claude/claude_desktop_config.json"},
+		{"claude-desktop", "darwin", "/h/Library/Application Support/Claude/claude_desktop_config.json"},
+		{"cursor", "linux", "/h/.cursor/mcp.json"},
+		{"cursor", "darwin", "/h/.cursor/mcp.json"},
+		{"windsurf", "linux", "/h/.codeium/windsurf/mcp_config.json"},
+	}
+	for _, c := range cases {
+		agent, _ := FindAgent(c.agentName)
+		got, err := agent.PathFor("/h", c.goos)
+		if err != nil {
+			t.Errorf("%s/%s: %v", c.agentName, c.goos, err)
+			continue
+		}
+		if got != c.wantPath {
+			t.Errorf("%s on %s = %q, want %q", c.agentName, c.goos, got, c.wantPath)
+		}
+	}
+}
+
+func TestAddPadEntry_NewConfig(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "claude_desktop_config.json")
+
+	modified, err := AddPadEntry(path, "/usr/local/bin/pad")
+	if err != nil {
+		t.Fatalf("AddPadEntry: %v", err)
+	}
+	if !modified {
+		t.Errorf("expected modified=true on fresh install")
+	}
+
+	cfg := readConfig(t, path)
+	servers := cfg["mcpServers"].(map[string]any)
+	pad := servers[MCPServerKey].(map[string]any)
+	if pad["command"] != "/usr/local/bin/pad" {
+		t.Errorf("command = %v, want /usr/local/bin/pad", pad["command"])
+	}
+	args := pad["args"].([]any)
+	if len(args) != 2 || args[0] != "mcp" || args[1] != "serve" {
+		t.Errorf("args = %v, want [mcp serve]", args)
+	}
+}
+
+func TestAddPadEntry_PreservesOtherServers(t *testing.T) {
+	// The user has another MCP server configured (e.g. a postgres
+	// MCP). Our install MUST NOT clobber that entry — only modify
+	// `mcpServers.pad`.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	existing := map[string]any{
+		"mcpServers": map[string]any{
+			"postgres": map[string]any{
+				"command": "/usr/local/bin/postgres-mcp",
+				"args":    []any{"--db", "main"},
+			},
+		},
+		"theme": "dark",
+	}
+	writeConfig(t, path, existing)
+
+	if _, err := AddPadEntry(path, "/usr/bin/pad"); err != nil {
+		t.Fatalf("AddPadEntry: %v", err)
+	}
+
+	cfg := readConfig(t, path)
+	servers := cfg["mcpServers"].(map[string]any)
+	if _, ok := servers["postgres"]; !ok {
+		t.Errorf("preserved postgres entry was removed; servers=%v", servers)
+	}
+	if _, ok := servers["pad"]; !ok {
+		t.Errorf("pad entry not added; servers=%v", servers)
+	}
+	// Top-level keys outside mcpServers also preserved.
+	if cfg["theme"] != "dark" {
+		t.Errorf("unrelated top-level key 'theme' was lost: %v", cfg["theme"])
+	}
+}
+
+func TestAddPadEntry_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+
+	if _, err := AddPadEntry(path, "/usr/bin/pad"); err != nil {
+		t.Fatalf("first install: %v", err)
+	}
+	modified, err := AddPadEntry(path, "/usr/bin/pad")
+	if err != nil {
+		t.Fatalf("second install: %v", err)
+	}
+	if modified {
+		t.Errorf("re-install with identical config should report modified=false")
+	}
+}
+
+func TestAddPadEntry_BinaryPathChangeMarksModified(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+
+	if _, err := AddPadEntry(path, "/old/pad"); err != nil {
+		t.Fatalf("initial: %v", err)
+	}
+	modified, err := AddPadEntry(path, "/new/pad")
+	if err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	if !modified {
+		t.Errorf("binary path change should mark modified=true")
+	}
+	cfg := readConfig(t, path)
+	servers := cfg["mcpServers"].(map[string]any)
+	pad := servers[MCPServerKey].(map[string]any)
+	if pad["command"] != "/new/pad" {
+		t.Errorf("expected updated command, got %v", pad["command"])
+	}
+}
+
+func TestAddPadEntry_RequiresBinary(t *testing.T) {
+	if _, err := AddPadEntry("/tmp/x", ""); err == nil {
+		t.Errorf("expected error when binary path empty")
+	}
+}
+
+func TestRemovePadEntry_RemovesOnlyPad(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	writeConfig(t, path, map[string]any{
+		"mcpServers": map[string]any{
+			"pad":      map[string]any{"command": "/usr/bin/pad"},
+			"postgres": map[string]any{"command": "/usr/bin/postgres-mcp"},
+		},
+	})
+
+	removed, err := RemovePadEntry(path)
+	if err != nil {
+		t.Fatalf("RemovePadEntry: %v", err)
+	}
+	if !removed {
+		t.Errorf("expected removed=true")
+	}
+
+	cfg := readConfig(t, path)
+	servers := cfg["mcpServers"].(map[string]any)
+	if _, ok := servers["pad"]; ok {
+		t.Errorf("pad entry not removed")
+	}
+	if _, ok := servers["postgres"]; !ok {
+		t.Errorf("postgres entry should be preserved")
+	}
+}
+
+func TestRemovePadEntry_MissingFileIsNoOp(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "does-not-exist.json")
+
+	removed, err := RemovePadEntry(path)
+	if err != nil {
+		t.Fatalf("missing file should be no-op, got: %v", err)
+	}
+	if removed {
+		t.Errorf("expected removed=false for missing file")
+	}
+}
+
+func TestRemovePadEntry_MissingEntryIsNoOp(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	writeConfig(t, path, map[string]any{"mcpServers": map[string]any{"postgres": map[string]any{}}})
+
+	removed, err := RemovePadEntry(path)
+	if err != nil {
+		t.Fatalf("RemovePadEntry: %v", err)
+	}
+	if removed {
+		t.Errorf("expected removed=false when pad entry not present")
+	}
+}
+
+func TestHasPadEntry_AllPaths(t *testing.T) {
+	dir := t.TempDir()
+
+	// missing file
+	missing := filepath.Join(dir, "missing.json")
+	installed, _, err := HasPadEntry(missing)
+	if err != nil {
+		t.Errorf("missing file: unexpected error: %v", err)
+	}
+	if installed {
+		t.Errorf("missing file: expected installed=false")
+	}
+
+	// no mcpServers
+	bare := filepath.Join(dir, "bare.json")
+	writeConfig(t, bare, map[string]any{"theme": "dark"})
+	installed, _, err = HasPadEntry(bare)
+	if err != nil || installed {
+		t.Errorf("bare config: installed=%v err=%v, want (false, nil)", installed, err)
+	}
+
+	// pad present
+	full := filepath.Join(dir, "full.json")
+	writeConfig(t, full, map[string]any{"mcpServers": map[string]any{"pad": map[string]any{"command": "/p"}}})
+	installed, cmd, err := HasPadEntry(full)
+	if err != nil {
+		t.Errorf("full config: %v", err)
+	}
+	if !installed {
+		t.Errorf("expected installed=true")
+	}
+	if cmd != "/p" {
+		t.Errorf("command = %q, want /p", cmd)
+	}
+}
+
+func TestInstaller_Install_RoundTripWithTempHome(t *testing.T) {
+	tmpHome := t.TempDir()
+	inst := &Installer{
+		Binary: "/usr/local/bin/pad",
+		Home:   tmpHome,
+		GOOS:   "linux",
+	}
+	path, modified, err := inst.Install("claude-desktop")
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if !modified {
+		t.Errorf("first install should modify=true")
+	}
+	wantPath := filepath.Join(tmpHome, ".config", "Claude", "claude_desktop_config.json")
+	if path != wantPath {
+		t.Errorf("path = %q, want %q", path, wantPath)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("expected config file written at %s, got: %v", path, err)
+	}
+}
+
+func TestInstaller_Install_MissingBinaryErrors(t *testing.T) {
+	inst := &Installer{Home: t.TempDir(), GOOS: "linux"}
+	if _, _, err := inst.Install("cursor"); err == nil {
+		t.Errorf("expected error when Binary is empty")
+	}
+}
+
+func TestInstaller_Uninstall_AfterInstall(t *testing.T) {
+	tmpHome := t.TempDir()
+	inst := &Installer{Binary: "/p", Home: tmpHome, GOOS: "linux"}
+	if _, _, err := inst.Install("cursor"); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	_, removed, err := inst.Uninstall("cursor")
+	if err != nil {
+		t.Fatalf("uninstall: %v", err)
+	}
+	if !removed {
+		t.Errorf("expected removed=true after install")
+	}
+	// Re-uninstall is idempotent.
+	_, removed, err = inst.Uninstall("cursor")
+	if err != nil {
+		t.Fatalf("second uninstall: %v", err)
+	}
+	if removed {
+		t.Errorf("second uninstall should be no-op")
+	}
+}
+
+func TestInstaller_Status_ReportsAllAgents(t *testing.T) {
+	tmpHome := t.TempDir()
+	inst := &Installer{Binary: "/p", Home: tmpHome, GOOS: "linux"}
+
+	// install only cursor; status should reflect mixed state.
+	if _, _, err := inst.Install("cursor"); err != nil {
+		t.Fatalf("install cursor: %v", err)
+	}
+	status := inst.Status()
+	if len(status) != len(SupportedAgents) {
+		t.Fatalf("status returned %d rows, want %d", len(status), len(SupportedAgents))
+	}
+	for _, row := range status {
+		switch row.Name {
+		case "cursor":
+			if !row.Installed {
+				t.Errorf("cursor should be installed")
+			}
+			if row.Command != "/p" {
+				t.Errorf("cursor command = %q, want /p", row.Command)
+			}
+		default:
+			if row.Installed {
+				t.Errorf("%s reports installed but we never wrote it", row.Name)
+			}
+		}
+		if row.ConfigPath == "" && row.Error == "" {
+			t.Errorf("%s: ConfigPath and Error both empty", row.Name)
+		}
+	}
+}
+
+func TestAddPadEntry_HandlesEmptyAndWhitespaceFile(t *testing.T) {
+	dir := t.TempDir()
+	cases := []string{"", "   \n\t", "\n"}
+	for _, body := range cases {
+		path := filepath.Join(dir, "x.json")
+		if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := AddPadEntry(path, "/p"); err != nil {
+			t.Errorf("empty body %q should be treated as fresh config; got %v", body, err)
+		}
+		_ = os.Remove(path)
+	}
+}
+
+func TestAddPadEntry_RejectsCorruptJSON(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "broken.json")
+	if err := os.WriteFile(path, []byte(`{"mcpServers": {`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := AddPadEntry(path, "/p"); err == nil {
+		t.Errorf("expected error on malformed JSON; we should NOT silently overwrite")
+	}
+}
+
+// Helpers ------------------------------------------------------------------
+
+func writeConfig(t *testing.T, path string, data map[string]any) {
+	t.Helper()
+	b, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, b, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func readConfig(t *testing.T, path string) map[string]any {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(b, &raw); err != nil {
+		t.Fatalf("parse %s: %v\n%s", path, err, b)
+	}
+	return raw
+}
+
+// Quiet the "unused" lint when one or more helpers go unused in a
+// future trim — we want to keep them around.
+var _ = strings.Contains


### PR DESCRIPTION
## Summary

One-shot config writers for the three MCP-capable client apps:

```
pad mcp install claude-desktop   # ~/.config/Claude/claude_desktop_config.json (linux)
pad mcp install cursor           # ~/.cursor/mcp.json
pad mcp install windsurf         # ~/.codeium/windsurf/mcp_config.json
pad mcp install --all            # all three
pad mcp uninstall cursor         # remove
pad mcp status                   # show install state
```

## Context

Implements `TASK-948` under `PLAN-942` (Local MCP server). Final functional task before docs (TASK-949).

## Per-platform paths

- Claude Desktop: macOS `~/Library/Application Support/Claude/claude_desktop_config.json`, Linux `~/.config/Claude/claude_desktop_config.json`, Windows `%APPDATA%/Claude/claude_desktop_config.json`
- Cursor: `~/.cursor/mcp.json` (all platforms)
- Windsurf: `~/.codeium/windsurf/mcp_config.json` (or `%APPDATA%/Codeium/windsurf/...` on Windows)

## Merge contract

Existing entries — both other MCP servers (e.g. `postgres`, `slack`) and unrelated top-level keys — are preserved. Only `mcpServers.pad` is touched.

## Idempotency

- Install with same binary → `modified=false`, no file write.
- Install with different binary → updates `command`, returns `modified=true`.
- Uninstall when entry missing → no-op (returns `removed=false`).
- Uninstall when file missing → no-op.

## Live smoke (in fake HOME)

```
$ HOME=/tmp/fakehome pad mcp install cursor
Installed pad MCP entry for cursor
  config: /tmp/fakehome/.cursor/mcp.json
  command: /tmp/padbin7 mcp serve

$ HOME=/tmp/fakehome pad mcp status
Pad MCP install status:
  [ ] Claude Desktop       /tmp/fakehome/.config/Claude/claude_desktop_config.json
  [x] Cursor               /tmp/fakehome/.cursor/mcp.json
      command: /tmp/padbin7
  [ ] Windsurf             /tmp/fakehome/.codeium/windsurf/mcp_config.json

$ HOME=/tmp/fakehome pad mcp uninstall cursor
Removed pad MCP entry from cursor
```

## Test plan

- [x] go build ./... — clean
- [x] golangci-lint run — 0 issues
- [x] go test -race ./internal/mcp/... — 78 tests green
- [x] make check — clean
- [x] Live install/status/uninstall round-trip in fake HOME
- [x] Per-platform path resolution tested for linux + darwin

## Security note

Config files are written with mode `0600` rather than `0644`. Other MCP server entries in these files often contain API keys (postgres URIs, OpenAI keys, etc.); tightening perms is the right default even though pad's own entry has no secrets.