### PR TITLE
docs(mcp): MCP section in README + CLAUDE.md (TASK-949)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,6 +173,24 @@ pad workspace join <code>     # Accept workspace invitation
 
 Collection names accept singular forms: `task`→`tasks`, `idea`→`ideas`, `doc`→`docs`.
 
+## MCP server
+
+Pad runs as a local Model Context Protocol server so Claude Desktop / Cursor / Windsurf can call every `pad` command as a tool. The surface is auto-generated from the cmdhelp Document (`pad help --format json`), so any new pad command lands as an MCP tool for free — no hand-mapping.
+
+```bash
+pad mcp serve                 # JSON-RPC over stdio (called by clients)
+pad mcp install <client>      # Write the client's mcp.json entry
+pad mcp uninstall <client>    # Remove the entry
+pad mcp status                # Install state across supported clients
+```
+
+Surface:
+- **Tools:** every leaf `pad` command (minus a curated allow-list of unsafe / interactive ones — `auth setup/login`, `db backup/restore`, `init`, `item edit`, `project watch`, `workspace export/import`, etc.). Plus `pad_set_workspace` to set the session default.
+- **Resources:** `pad://workspace/{ws}/items/{ref}`, `pad://workspace/{ws}/items`, `pad://workspace/{ws}/dashboard`, `pad://workspace/{ws}/collections`.
+- **Prompts:** `pad_plan`, `pad_ideate`, `pad_retro`, `pad_onboard` — multi-step workflows lifted from `skills/pad/SKILL.md`.
+
+Code lives in `internal/mcp/` (built on `github.com/mark3labs/mcp-go`). Public docs at `getpad.dev/mcp/local`.
+
 ## Data Model
 
 - **Collections** have JSON schemas defining typed fields (select, text, date, number, etc.)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,7 +175,7 @@ Collection names accept singular forms: `task`→`tasks`, `idea`→`ideas`, `doc
 
 ## MCP server
 
-Pad runs as a local Model Context Protocol server so Claude Desktop / Cursor / Windsurf can call every `pad` command as a tool. The surface is auto-generated from the cmdhelp Document (`pad help --format json`), so any new pad command lands as an MCP tool for free — no hand-mapping.
+Pad runs as a local Model Context Protocol server so Claude Desktop / Cursor / Windsurf can call non-interactive `pad` commands as tools. The surface is auto-generated from the cmdhelp Document (`pad help --format json`), so any new pad command that isn't on `internal/mcp.DefaultExcludes` lands as an MCP tool for free — no hand-mapping.
 
 ```bash
 pad mcp serve                 # JSON-RPC over stdio (called by clients)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,7 +175,9 @@ Collection names accept singular forms: `task`→`tasks`, `idea`→`ideas`, `doc
 
 ## MCP server
 
-Pad runs as a local Model Context Protocol server so Claude Desktop / Cursor / Windsurf can call non-interactive `pad` commands as tools. The surface is auto-generated from the cmdhelp Document (`pad help --format json`), so any new pad command that isn't on `internal/mcp.DefaultExcludes` lands as an MCP tool for free — no hand-mapping.
+Pad runs as a local Model Context Protocol server so Claude Desktop / Cursor / Windsurf can call non-interactive `pad` commands as tools. The surface is derived from the cmdhelp Document (`pad help --format json`) and filtered against `internal/mcp.DefaultExcludes` (which strips interactive / destructive commands — `auth setup/login`, `db backup/restore`, `init`, `item edit`, `project watch`, `workspace export/import`, `mcp serve/install`, `completion`, etc.).
+
+**When adding a new `pad` command, decide whether it belongs on the MCP surface.** If it's interactive (prompts the user), destructive (mutates auth / filesystem state), long-running (streaming watcher), or recursive (would spawn another MCP server), add it to `DefaultExcludes` in `internal/mcp/registry.go`. Otherwise it's safe to expose, and the registry picks it up automatically.
 
 ```bash
 pad mcp serve                 # JSON-RPC over stdio (called by clients)
@@ -185,7 +187,7 @@ pad mcp status                # Install state across supported clients
 ```
 
 Surface:
-- **Tools:** every leaf `pad` command (minus a curated allow-list of unsafe / interactive ones — `auth setup/login`, `db backup/restore`, `init`, `item edit`, `project watch`, `workspace export/import`, etc.). Plus `pad_set_workspace` to set the session default.
+- **Tools:** leaf `pad` commands not in `DefaultExcludes` (the per-PR review gate above). Plus `pad_set_workspace` for the session default.
 - **Resources:** `pad://workspace/{ws}/items/{ref}`, `pad://workspace/{ws}/items`, `pad://workspace/{ws}/dashboard`, `pad://workspace/{ws}/collections`.
 - **Prompts:** `pad_plan`, `pad_ideate`, `pad_retro`, `pad_onboard` — multi-step workflows lifted from `skills/pad/SKILL.md`.
 

--- a/README.md
+++ b/README.md
@@ -232,6 +232,20 @@ pad library list --type conventions  # Pre-built conventions you can adopt
 pad library list --type playbooks    # Pre-built multi-step workflows
 ```
 
+### 4. Optional — connect a desktop AI app via MCP
+
+Pad ships an MCP (Model Context Protocol) server so Claude Desktop, Cursor, or
+Windsurf can call every `pad` command as a tool, read items by URL, and load
+multi-step workflows as prompts.
+
+```bash
+pad mcp install claude-desktop   # or: cursor, windsurf, --all
+# Restart the client; pad shows up as the "pad" MCP server.
+```
+
+Full guide at [getpad.dev/mcp/local](https://getpad.dev/mcp/local) — install
+paths, available tools/resources/prompts, troubleshooting.
+
 ## CLI Reference
 
 ```

--- a/README.md
+++ b/README.md
@@ -235,8 +235,10 @@ pad library list --type playbooks    # Pre-built multi-step workflows
 ### 4. Optional — connect a desktop AI app via MCP
 
 Pad ships an MCP (Model Context Protocol) server so Claude Desktop, Cursor, or
-Windsurf can call every `pad` command as a tool, read items by URL, and load
-multi-step workflows as prompts.
+Windsurf can call non-interactive `pad` commands as tools (item CRUD, project
+intelligence, search, etc. — not destructive / lifecycle ones like `auth setup`,
+`db restore`, `init`, `item edit`), read items and the dashboard by URL, and
+load multi-step workflows as prompts.
 
 ```bash
 pad mcp install claude-desktop   # or: cursor, windsurf, --all


### PR DESCRIPTION
## Summary

Closes PLAN-942's docs task. README gets a one-line "connect a desktop AI app via MCP" subsection under Getting Started; CLAUDE.md gets a full "MCP server" section so agents working in pad's repo know the surface exists.

## Context

Implements `TASK-949` under `PLAN-942` (Local MCP server). Companion to [pad-web PR #41](https://github.com/PerpetualSoftware/pad-web/pull/41) which adds the canonical `/mcp/local` guide.

## What's documented in each file

**README.md** — short user-facing pointer:
> ### 4. Optional — connect a desktop AI app via MCP
> ```bash
> pad mcp install claude-desktop   # or: cursor, windsurf, --all
> ```
> Full guide at [getpad.dev/mcp/local](...)

**CLAUDE.md** — agent-facing summary:
- Lists `pad mcp serve / install / uninstall / status` commands
- Documents the surface: tools (auto-generated from cmdhelp), resources (`pad://workspace/{ws}/...`), prompts (`pad_plan` / `pad_ideate` / `pad_retro` / `pad_onboard`)
- Points to `internal/mcp/` for the code

## Test plan

- [x] `make check` — 0 lint issues, all tests pass
- [x] No code changes; markdown only