### PR TITLE
feat(mcp): advertise cmdhelp_version stability tier in handshake (TASK-963)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,8 +188,10 @@ pad mcp status                # Install state across supported clients
 
 Surface:
 - **Tools:** leaf `pad` commands not in `DefaultExcludes` (the per-PR review gate above). Plus `pad_set_workspace` for the session default.
-- **Resources:** `pad://workspace/{ws}/items/{ref}`, `pad://workspace/{ws}/items`, `pad://workspace/{ws}/dashboard`, `pad://workspace/{ws}/collections`.
+- **Resources:** `pad://workspace/{ws}/items/{ref}`, `pad://workspace/{ws}/items`, `pad://workspace/{ws}/dashboard`, `pad://workspace/{ws}/collections`, plus the server-wide `pad://_meta/version`.
 - **Prompts:** `pad_plan`, `pad_ideate`, `pad_retro`, `pad_onboard` — multi-step workflows lifted from `skills/pad/SKILL.md`.
+
+**Stability contract.** The cmdhelp tool surface is versioned via `internal/mcp.CmdhelpVersion` (currently `"0.1"`). Bump the major when tool names, argument shapes, or resource URIs change incompatibly — external agents (Cursor, Claude Desktop, the future Pad Cloud remote MCP) pin against it. The version is advertised on the wire two ways: under `serverCapabilities.experimental.padCmdhelp` in the initialize handshake, and as a JSON document at `pad://_meta/version`.
 
 Code lives in `internal/mcp/` (built on `github.com/mark3labs/mcp-go`). Public docs at `getpad.dev/mcp/local`.
 

--- a/README.md
+++ b/README.md
@@ -245,6 +245,11 @@ pad mcp install claude-desktop   # or: cursor, windsurf, --all
 # Restart the client; pad shows up as the "pad" MCP server.
 ```
 
+The server advertises a tool-surface stability tier (`cmdhelp_version`)
+in the initialize handshake under `serverCapabilities.experimental.padCmdhelp`,
+and as a queryable JSON document at `pad://_meta/version`. External agents
+can pin against this so a future tool rename doesn't break them silently.
+
 Full guide at [getpad.dev/mcp/local](https://getpad.dev/mcp/local) — install
 paths, available tools/resources/prompts, troubleshooting.
 

--- a/cmd/pad/mcp.go
+++ b/cmd/pad/mcp.go
@@ -298,6 +298,12 @@ Shuts down cleanly on EOF, SIGINT, or SIGTERM.`,
 			// embedded text returned as user-role messages.
 			mcpserver.RegisterPrompts(srv.MCP())
 
+			// Tool-surface stability metadata (TASK-963). Static
+			// resource at pad://_meta/version. Complements the
+			// handshake's serverCapabilities.experimental.padCmdhelp
+			// for clients that prefer reading a JSON document.
+			mcpserver.RegisterMeta(srv.MCP(), fullVersion())
+
 			if err := srv.Run(cmd.Context()); err != nil {
 				return fmt.Errorf("pad mcp serve: %w", err)
 			}

--- a/internal/mcp/meta.go
+++ b/internal/mcp/meta.go
@@ -27,9 +27,12 @@ type MetaPayload struct {
 	// stability contract. False during pre-release iteration.
 	ToolSurfaceStable bool `json:"tool_surface_stable"`
 
-	// MCPProtocolVersion is the MCP wire protocol revision this server
-	// targets. Surfaced so consumers can detect feature support
-	// (e.g. RFC 8707 Resource Indicators land in the 2025-11-25 revision).
+	// MCPProtocolVersion is the latest MCP wire protocol revision this
+	// server can negotiate. Sourced from the underlying mcp-go library's
+	// LATEST_PROTOCOL_VERSION constant so the value never drifts from
+	// what NewMCPServer actually advertises in the handshake. Surfaced
+	// so consumers can detect feature support (e.g. RFC 8707 Resource
+	// Indicators land in the 2025-11-25 revision).
 	MCPProtocolVersion string `json:"mcp_protocol_version"`
 }
 
@@ -37,6 +40,12 @@ type MetaPayload struct {
 // version. An empty padVersion falls back to FallbackVersion for the
 // same reason serverInfo.version does — empty values confuse some
 // clients that display them in their UI.
+//
+// MCPProtocolVersion is sourced from mcp.LATEST_PROTOCOL_VERSION, which
+// is the maximum protocol revision the server can negotiate. If a
+// client downgrades during initialize, the per-session negotiated
+// version may be lower; the meta document reports the server's
+// upper bound, not any specific session.
 func BuildMetaPayload(padVersion string) MetaPayload {
 	if padVersion == "" {
 		padVersion = FallbackVersion
@@ -45,7 +54,7 @@ func BuildMetaPayload(padVersion string) MetaPayload {
 		PadVersion:         padVersion,
 		CmdhelpVersion:     CmdhelpVersion,
 		ToolSurfaceStable:  true,
-		MCPProtocolVersion: MCPProtocolVersion,
+		MCPProtocolVersion: mcp.LATEST_PROTOCOL_VERSION,
 	}
 }
 

--- a/internal/mcp/meta.go
+++ b/internal/mcp/meta.go
@@ -1,0 +1,112 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// MetaPayload is the JSON shape returned by pad://_meta/version.
+//
+// The fields are explicit (no embedded structs, no omitempty) so
+// downstream consumers can pin against a known schema across pad
+// releases. Adding fields is safe; renaming or removing them is a
+// CmdhelpVersion bump.
+type MetaPayload struct {
+	// PadVersion is the runtime version of the pad binary (e.g. "0.1.5").
+	PadVersion string `json:"pad_version"`
+
+	// CmdhelpVersion is the tool-surface stability tier. See the
+	// CmdhelpVersion constant for the bump policy.
+	CmdhelpVersion string `json:"cmdhelp_version"`
+
+	// ToolSurfaceStable signals that the cmdhelp surface has shipped its
+	// stability contract. False during pre-release iteration.
+	ToolSurfaceStable bool `json:"tool_surface_stable"`
+
+	// MCPProtocolVersion is the MCP wire protocol revision this server
+	// targets. Surfaced so consumers can detect feature support
+	// (e.g. RFC 8707 Resource Indicators land in the 2025-11-25 revision).
+	MCPProtocolVersion string `json:"mcp_protocol_version"`
+}
+
+// BuildMetaPayload returns the meta payload for the given pad runtime
+// version. An empty padVersion falls back to FallbackVersion for the
+// same reason serverInfo.version does — empty values confuse some
+// clients that display them in their UI.
+func BuildMetaPayload(padVersion string) MetaPayload {
+	if padVersion == "" {
+		padVersion = FallbackVersion
+	}
+	return MetaPayload{
+		PadVersion:         padVersion,
+		CmdhelpVersion:     CmdhelpVersion,
+		ToolSurfaceStable:  true,
+		MCPProtocolVersion: MCPProtocolVersion,
+	}
+}
+
+// RegisterMeta installs the pad://_meta/version static resource on srv
+// so MCP clients can discover pad's tool-surface stability tier
+// without parsing the (free-form) handshake instructions field.
+//
+// padVersion is typically the same string passed to NewServer's
+// Options.Version (the runtime fullVersion()).
+func RegisterMeta(srv *server.MCPServer, padVersion string) {
+	payload := BuildMetaPayload(padVersion)
+	resource := mcp.NewResource(
+		MetaVersionURI,
+		"pad meta version",
+		mcp.WithResourceDescription(
+			"Tool-surface stability metadata for this pad MCP server. "+
+				"Returns pad runtime version, cmdhelp surface version "+
+				"(the contract external agents depend on), and the MCP "+
+				"protocol revision the server pins against.",
+		),
+		mcp.WithMIMEType(jsonMIMEType),
+	)
+	srv.AddResource(resource, func(_ context.Context, req mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+		body, err := json.Marshal(payload)
+		if err != nil {
+			// json.Marshal failing on a struct with only string + bool
+			// fields is so unlikely it would indicate a runtime bug;
+			// surface as an error rather than panicking the handler.
+			return nil, fmt.Errorf("marshal meta payload: %w", err)
+		}
+		return []mcp.ResourceContents{
+			mcp.TextResourceContents{
+				URI:      req.Params.URI,
+				MIMEType: jsonMIMEType,
+				Text:     string(body),
+			},
+		}, nil
+	})
+}
+
+// experimentalCapabilities returns the map advertised in the
+// initialize handshake's serverCapabilities.experimental field. Lets
+// clients discover the cmdhelp tier in one round-trip without reading
+// the meta resource.
+//
+// Wire shape:
+//
+//	"capabilities": {
+//	  "experimental": {
+//	    "padCmdhelp": {
+//	      "version":             "0.1",
+//	      "tool_surface_stable": true
+//	    }
+//	  },
+//	  ...
+//	}
+func experimentalCapabilities() map[string]any {
+	return map[string]any{
+		experimentalCapabilityKey: map[string]any{
+			"version":             CmdhelpVersion,
+			"tool_surface_stable": true,
+		},
+	}
+}

--- a/internal/mcp/meta_test.go
+++ b/internal/mcp/meta_test.go
@@ -24,8 +24,13 @@ func TestBuildMetaPayload_FallbackVersion(t *testing.T) {
 	if !got.ToolSurfaceStable {
 		t.Errorf("ToolSurfaceStable = false, want true")
 	}
-	if got.MCPProtocolVersion != MCPProtocolVersion {
-		t.Errorf("MCPProtocolVersion = %q, want %q", got.MCPProtocolVersion, MCPProtocolVersion)
+	if got.MCPProtocolVersion != mcp.LATEST_PROTOCOL_VERSION {
+		t.Errorf("MCPProtocolVersion = %q, want library LATEST %q",
+			got.MCPProtocolVersion, mcp.LATEST_PROTOCOL_VERSION)
+	}
+	// Belt-and-braces: never empty, regardless of library state.
+	if got.MCPProtocolVersion == "" {
+		t.Errorf("MCPProtocolVersion is empty — library constant unset?")
 	}
 }
 

--- a/internal/mcp/meta_test.go
+++ b/internal/mcp/meta_test.go
@@ -1,0 +1,148 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// TestBuildMetaPayload_FallbackVersion guarantees an empty padVersion
+// resolves to FallbackVersion — same invariant the handshake's
+// serverInfo.version honours, so the meta document never reports a
+// blank pad_version.
+func TestBuildMetaPayload_FallbackVersion(t *testing.T) {
+	got := BuildMetaPayload("")
+	if got.PadVersion != FallbackVersion {
+		t.Errorf("PadVersion = %q, want fallback %q", got.PadVersion, FallbackVersion)
+	}
+	if got.CmdhelpVersion != CmdhelpVersion {
+		t.Errorf("CmdhelpVersion = %q, want %q", got.CmdhelpVersion, CmdhelpVersion)
+	}
+	if !got.ToolSurfaceStable {
+		t.Errorf("ToolSurfaceStable = false, want true")
+	}
+	if got.MCPProtocolVersion != MCPProtocolVersion {
+		t.Errorf("MCPProtocolVersion = %q, want %q", got.MCPProtocolVersion, MCPProtocolVersion)
+	}
+}
+
+// TestBuildMetaPayload_PassesThroughExplicit verifies the runtime
+// version is faithfully forwarded into the meta payload.
+func TestBuildMetaPayload_PassesThroughExplicit(t *testing.T) {
+	const want = "1.2.3-test"
+	got := BuildMetaPayload(want)
+	if got.PadVersion != want {
+		t.Errorf("PadVersion = %q, want %q", got.PadVersion, want)
+	}
+}
+
+// TestBuildMetaPayload_JSONFieldNames locks the wire-level field names.
+// External consumers (the future Pad Cloud remote MCP, third-party
+// agents) pin against these — renames are a CmdhelpVersion bump.
+func TestBuildMetaPayload_JSONFieldNames(t *testing.T) {
+	body, err := json.Marshal(BuildMetaPayload("0.0.1"))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(body, &raw); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	want := []string{"pad_version", "cmdhelp_version", "tool_surface_stable", "mcp_protocol_version"}
+	for _, k := range want {
+		if _, ok := raw[k]; !ok {
+			t.Errorf("field %q missing from JSON; got keys %v", k, mapKeys(raw))
+		}
+	}
+}
+
+// TestRegisterMeta_ResourceRoundTrip drives the resource through the
+// real MCP HandleMessage path — the same code path Claude Desktop /
+// Cursor exercises — and asserts the response body matches
+// BuildMetaPayload. Guards against breakage in mcp-go's resource
+// dispatch and in our handler wiring at the same time.
+func TestRegisterMeta_ResourceRoundTrip(t *testing.T) {
+	const padVersion = "0.42.0-meta-test"
+	srv := server.NewMCPServer("t", "1", server.WithResourceCapabilities(false, false))
+	RegisterMeta(srv, padVersion)
+
+	body := readResourceJSON(t, srv, MetaVersionURI)
+
+	var got MetaPayload
+	if err := json.Unmarshal([]byte(body), &got); err != nil {
+		t.Fatalf("unmarshal meta payload: %v\nbody=%s", err, body)
+	}
+	want := BuildMetaPayload(padVersion)
+	if got != want {
+		t.Errorf("meta payload mismatch\n got: %+v\nwant: %+v", got, want)
+	}
+}
+
+// readResourceJSON drives a resources/read request through the server
+// for uri and returns the text body. Fails the test on protocol
+// errors, missing contents, or wrong MIME.
+func readResourceJSON(t *testing.T, srv *server.MCPServer, uri string) string {
+	t.Helper()
+
+	reqJSON := []byte(`{
+		"jsonrpc": "2.0",
+		"id": 1,
+		"method": "resources/read",
+		"params": { "uri": "` + uri + `" }
+	}`)
+	resp := srv.HandleMessage(context.Background(), reqJSON)
+	if resp == nil {
+		t.Fatalf("HandleMessage returned nil response for %q", uri)
+	}
+	envelope, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal response: %v", err)
+	}
+	var parsed struct {
+		Error *struct {
+			Code    int    `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+		Result struct {
+			Contents []struct {
+				URI      string `json:"uri"`
+				MIMEType string `json:"mimeType"`
+				Text     string `json:"text"`
+			} `json:"contents"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(envelope, &parsed); err != nil {
+		t.Fatalf("parse response envelope: %v\nraw=%s", err, envelope)
+	}
+	if parsed.Error != nil {
+		t.Fatalf("read %q returned JSON-RPC error %d: %s", uri, parsed.Error.Code, parsed.Error.Message)
+	}
+	if len(parsed.Result.Contents) != 1 {
+		t.Fatalf("expected exactly 1 content block for %q, got %d", uri, len(parsed.Result.Contents))
+	}
+	c := parsed.Result.Contents[0]
+	if c.URI != uri {
+		t.Errorf("content URI = %q, want %q", c.URI, uri)
+	}
+	if c.MIMEType != jsonMIMEType {
+		t.Errorf("content MIMEType = %q, want %q", c.MIMEType, jsonMIMEType)
+	}
+	return c.Text
+}
+
+// mapKeys returns the keys of m, in arbitrary order. Used only by test
+// failure messages where order doesn't matter.
+func mapKeys(m map[string]any) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+// _ silences a potential unused-import warning if this file ever
+// drops its mcp.* references during refactoring. Keep it cheap.
+var _ = mcp.ReadResourceRequest{}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -58,6 +58,12 @@ func NewServer(opts Options) *Server {
 		// shell-out dispatcher (TASK-945) starts running pad
 		// subprocesses with arbitrary client-supplied args.
 		server.WithRecovery(),
+		// Tool-surface stability tier (TASK-963). Surfaces the cmdhelp
+		// contract directly in the handshake under
+		// serverCapabilities.experimental.padCmdhelp, so external
+		// agents can detect compatibility without reading
+		// pad://_meta/version first.
+		server.WithExperimental(experimentalCapabilities()),
 	)
 	return &Server{mcp: mcp, debug: opts.Debug}
 }

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -38,7 +38,9 @@ func TestNewServer_Construction(t *testing.T) {
 
 // TestServer_InitializeHandshake is the contract test: a real
 // initialize round-trip through the stdio pipeline must return
-// serverInfo with our canonical name + the version we passed in.
+// serverInfo with our canonical name + the version we passed in,
+// AND must advertise the cmdhelp tool-surface tier under
+// serverCapabilities.experimental.padCmdhelp.
 //
 // This is what every MCP client (Claude Desktop, Cursor, Windsurf,
 // mcp-inspector) sees on connect — if it regresses, downstream
@@ -55,6 +57,28 @@ func TestServer_InitializeHandshake(t *testing.T) {
 	}
 	if res.ServerInfo.Version != wantVersion {
 		t.Errorf("serverInfo.version = %q, want %q", res.ServerInfo.Version, wantVersion)
+	}
+
+	// TASK-963: verify the experimental cmdhelp capability is on the
+	// wire so external agents can pin against the stability tier
+	// directly from the handshake.
+	exp := res.Capabilities.Experimental
+	if exp == nil {
+		t.Fatalf("serverCapabilities.experimental missing — cmdhelp tier not advertised")
+	}
+	rawNS, ok := exp[experimentalCapabilityKey]
+	if !ok {
+		t.Fatalf("experimental[%q] missing; got %#v", experimentalCapabilityKey, exp)
+	}
+	ns, ok := rawNS.(map[string]any)
+	if !ok {
+		t.Fatalf("experimental[%q] is %T, want map[string]any", experimentalCapabilityKey, rawNS)
+	}
+	if got := ns["version"]; got != CmdhelpVersion {
+		t.Errorf("experimental[%q].version = %v, want %q", experimentalCapabilityKey, got, CmdhelpVersion)
+	}
+	if got := ns["tool_surface_stable"]; got != true {
+		t.Errorf("experimental[%q].tool_surface_stable = %v, want true", experimentalCapabilityKey, got)
 	}
 }
 

--- a/internal/mcp/version.go
+++ b/internal/mcp/version.go
@@ -41,11 +41,12 @@ const CmdhelpVersion = "0.1"
 // server-wide attribute, not a workspace-scoped resource.
 const MetaVersionURI = "pad://_meta/version"
 
-// MCPProtocolVersion is the MCP wire protocol revision this server is
-// pinned against. Surfaced in the meta resource so consumers can tell
-// at a glance whether a feature they need (e.g. RFC 8707 Resource
-// Indicators) is part of the spec we implement.
-const MCPProtocolVersion = "2024-11-05"
+// The MCP wire protocol revision this server speaks isn't a constant
+// owned by pad — it's whatever mcp-go's `LATEST_PROTOCOL_VERSION`
+// resolves to at build time, since that's what NewMCPServer will
+// negotiate with clients that request the latest. The meta resource
+// reads it dynamically (see meta.go) so the value never drifts from
+// what the library actually advertises.
 
 // experimentalCapabilityKey is the namespace under
 // serverCapabilities.experimental that carries the cmdhelp tier.

--- a/internal/mcp/version.go
+++ b/internal/mcp/version.go
@@ -6,6 +6,7 @@
 //   - TASK-946 — MCP resources (items, dashboard, collections).
 //   - TASK-947 — MCP prompts (planning / ideation / retro).
 //   - TASK-948 — `pad mcp install <agent>` client config writer.
+//   - TASK-963 — cmdhelp_version handshake metadata + pad://_meta/version.
 package mcp
 
 // ServerName is the canonical name pad's MCP server advertises in the
@@ -20,3 +21,33 @@ const ServerName = "pad-mcp"
 // fullVersion(); this fallback covers tests, embedders, and `dev`
 // builds where the version string is empty.
 const FallbackVersion = "0.0.0-dev"
+
+// CmdhelpVersion is the tool-surface stability contract this MCP server
+// advertises. External agents (Claude Desktop, Cursor, ChatGPT
+// connectors, future Pad Cloud remote MCP) depend on tool names,
+// argument shapes, and resource URIs being stable across pad releases.
+// Bump the major when those change incompatibly:
+//
+//   - "0.1" — initial cmdhelp-derived surface from PLAN-942.
+//
+// Discovery surfaces:
+//
+//   - serverCapabilities.experimental.padCmdhelp.version (handshake).
+//   - pad://_meta/version resource (queryable JSON document).
+const CmdhelpVersion = "0.1"
+
+// MetaVersionURI is the canonical URI of the queryable version document.
+// Lives outside the pad://workspace/{ws}/... namespace because it's a
+// server-wide attribute, not a workspace-scoped resource.
+const MetaVersionURI = "pad://_meta/version"
+
+// MCPProtocolVersion is the MCP wire protocol revision this server is
+// pinned against. Surfaced in the meta resource so consumers can tell
+// at a glance whether a feature they need (e.g. RFC 8707 Resource
+// Indicators) is part of the spec we implement.
+const MCPProtocolVersion = "2024-11-05"
+
+// experimentalCapabilityKey is the namespace under
+// serverCapabilities.experimental that carries the cmdhelp tier.
+// Namespaced so other servers' experimental capabilities don't collide.
+const experimentalCapabilityKey = "padCmdhelp"


### PR DESCRIPTION
## Summary

External agents (Cursor, Claude Desktop, the future Pad Cloud remote MCP in PLAN-943) depend on tool names, argument shapes, and resource URIs being stable across pad releases. Without an explicit contract, any future surface change breaks consumers silently.

This PR adds the contract on two complementary surfaces:

- **`serverCapabilities.experimental.padCmdhelp`** in the initialize handshake — namespaced map carrying `{version, tool_surface_stable}`, discoverable in one round-trip via `WithExperimental`.
- **`pad://_meta/version`** static resource — full JSON document with `{pad_version, cmdhelp_version, tool_surface_stable, mcp_protocol_version}` for clients that prefer reading a typed payload.

`CmdhelpVersion` is pinned at `"0.1"` — the initial cmdhelp-derived surface shipped in PLAN-942. Bump the major when tool names / arg shapes / resource URIs change incompatibly.

## Context

Implements `TASK-963` under `PLAN-942` (re-activated post-merge after the PLAN-943 audit identified two pre-deployment follow-ups).

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./...` — all tests pass
- [x] `make check` — lint + Go test + web build all green
- [x] New `TestServer_InitializeHandshake` assertions verify the experimental capability shape on the wire
- [x] New `TestRegisterMeta_ResourceRoundTrip` drives the resource through the real `HandleMessage` path
- [x] New `TestBuildMetaPayload_*` lock payload field names + fallback behaviour

## Follow-up

- Public docs at `getpad.dev/mcp/local` need a parallel PR in the `pad-web` repo (per CONVE-159) to mention the stability contract on the user-facing page. Will open separately after this merges.