### PR TITLE
feat(mcp): stars + roles + webhooks + auth.whoami + workspace surface (TASK-968 partial)

### DIFF
--- a/internal/mcp/dispatch_http.go
+++ b/internal/mcp/dispatch_http.go
@@ -134,8 +134,9 @@ var commandsAcceptingRoleBySlug = map[string]struct{}{
 // noRemoteEquivalent enumerates leaf commands that have no useful
 // HTTP-transport mapping because they mutate or inspect local state
 // only — config files, MCP-client mcp.json entries, the local server
-// process. Distinct from "not yet implemented over HTTP transport"
-// because those will eventually land; these never will.
+// process, the local git checkout. Distinct from "not yet implemented
+// over HTTP transport" because those will eventually land; these never
+// will.
 //
 // Surfacing the distinction lets agents recognize-and-skip rather
 // than retrying or escalating. The error message is stable so
@@ -149,6 +150,16 @@ var noRemoteEquivalent = map[string]struct{}{
 	"workspace link":    {}, // local .pad.toml mutation
 	"workspace switch":  {}, // local .pad.toml mutation
 	"workspace context": {}, // local .pad.toml inspection
+	// `github` commands chain `git rev-parse` + `gh` CLI for the
+	// branch/PR data they write to the linked item — that data
+	// inherently lives in the agent's local checkout, not on
+	// pad-cloud. A remote MCP would have no way to query it. Agents
+	// that want this functionality should use their own GitHub /
+	// shell tools to fetch PR data and then pass it through `item
+	// update --field github_pr=...`.
+	"github link":   {},
+	"github status": {},
+	"github unlink": {},
 }
 
 // Dispatch satisfies the Dispatcher interface. cliArgs are accepted

--- a/internal/mcp/dispatch_http_routes.go
+++ b/internal/mcp/dispatch_http_routes.go
@@ -233,7 +233,224 @@ func init() {
 			method:       http.MethodGet,
 			pathTemplate: "/api/v1/workspaces/{workspace}/members",
 		}.toRouteMapper(),
+
+		// --- Stars (TASK-968 follow-up) ---
+		// `item star`/`unstar` use the item's slug-or-ref directly in
+		// the URL — handleStarItem calls store.ResolveItem which
+		// accepts UUIDs, slugs, AND issue refs (TASK-5), so no prefetch
+		// is needed. Same shape as `item show`/`item delete`.
+		"item star": routeSpec{
+			method:       http.MethodPost,
+			pathTemplate: "/api/v1/workspaces/{workspace}/items/{ref}/star",
+		}.toRouteMapper(),
+		"item unstar": routeSpec{
+			method:       http.MethodDelete,
+			pathTemplate: "/api/v1/workspaces/{workspace}/items/{ref}/star",
+		}.toRouteMapper(),
+		// `--all` becomes `?include_terminal=true` on the listing
+		// endpoint to surface starred items even when they're in a
+		// terminal status. Without --all, the handler hides them.
+		"item starred": mapItemStarred,
+
+		// --- Roles (admin) ---
+		"role create": mapRoleCreate,
+		"role delete": routeSpec{
+			method:       http.MethodDelete,
+			pathTemplate: "/api/v1/workspaces/{workspace}/agent-roles/{slug}",
+		}.toRouteMapper(),
+
+		// --- Webhooks (admin) ---
+		"webhook list": routeSpec{
+			method:       http.MethodGet,
+			pathTemplate: "/api/v1/workspaces/{workspace}/webhooks",
+		}.toRouteMapper(),
+		"webhook create": mapWebhookCreate,
+		"webhook delete": routeSpec{
+			method:       http.MethodDelete,
+			pathTemplate: "/api/v1/workspaces/{workspace}/webhooks/{id}",
+		}.toRouteMapper(),
+		"webhook test": routeSpec{
+			method:       http.MethodPost,
+			pathTemplate: "/api/v1/workspaces/{workspace}/webhooks/{id}/test",
+		}.toRouteMapper(),
+
+		// --- Auth ---
+		// `auth whoami` is global (not workspace-scoped) — the
+		// /api/v1/auth/me endpoint returns the requesting user's
+		// profile. Useful as an early sanity check for an MCP client
+		// that's just authenticated.
+		"auth whoami": routeSpec{
+			method:       http.MethodGet,
+			pathTemplate: "/api/v1/auth/me",
+		}.toRouteMapper(),
+
+		// --- Workspace surfaces ---
+		// `workspace list` lists workspaces visible to the requesting
+		// user (admins see all; everyone else sees their memberships).
+		"workspace list": routeSpec{
+			method:       http.MethodGet,
+			pathTemplate: "/api/v1/workspaces",
+		}.toRouteMapper(),
+		"workspace storage": routeSpec{
+			method:       http.MethodGet,
+			pathTemplate: "/api/v1/workspaces/{workspace}/storage/usage",
+		}.toRouteMapper(),
+		// `workspace audit-log` hits the GLOBAL /api/v1/audit-log
+		// endpoint (admin-only) — the CLI command's "workspace" prefix
+		// is naming convention, not URL scoping. The handler accepts a
+		// `?workspace=<id>` query param to scope when desired; the CLI
+		// doesn't pass it by default, so we don't either (the
+		// dispatcher's `workspace` input remains injected for
+		// session-default purposes but isn't auto-forwarded — agents
+		// can pass an explicit `workspace` param to scope if they want).
+		"workspace audit-log": mapWorkspaceAuditLog,
+		"workspace invite":    mapWorkspaceInvite,
 	}
+}
+
+// mapItemStarred dispatches `pad item starred [--all]`.
+//
+// GET /api/v1/workspaces/{ws}/starred?include_terminal=true when
+// --all is set. Without --all the default behaviour hides terminal-
+// status items (done/completed/etc.) — matches handleListStarredItems'
+// query-param treatment.
+func mapItemStarred(input map[string]any) (string, string, []byte, error) {
+	workspace, _ := input["workspace"].(string)
+	if workspace == "" {
+		return "", "", nil, fmt.Errorf("workspace is required")
+	}
+	urlPath := "/api/v1/workspaces/" + url.PathEscape(workspace) + "/starred"
+	if all, _ := input["all"].(bool); all {
+		urlPath += "?include_terminal=true"
+	}
+	return http.MethodGet, urlPath, nil, nil
+}
+
+// mapRoleCreate dispatches `pad role create <name> [--description ...]
+// [--icon ...] [--tools ...]`.
+//
+// POST /api/v1/workspaces/{ws}/agent-roles with body matching
+// models.AgentRoleCreate. The handler requires `name` and validates
+// against the workspace template; everything else is optional.
+//
+// `--tools` is a comma-separated string in the CLI (cmdhelp string
+// flag, not a repeatable). Pass through verbatim — the handler
+// stores it as the `tools` JSON field on the role.
+func mapRoleCreate(input map[string]any) (string, string, []byte, error) {
+	workspace, _ := input["workspace"].(string)
+	if workspace == "" {
+		return "", "", nil, fmt.Errorf("workspace is required")
+	}
+	name, _ := input["name"].(string)
+	if name == "" {
+		return "", "", nil, fmt.Errorf("name is required")
+	}
+	payload := map[string]any{"name": name}
+	for _, key := range []string{"description", "icon", "tools"} {
+		if v, _ := input[key].(string); v != "" {
+			payload[key] = v
+		}
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return "", "", nil, fmt.Errorf("encode body: %w", err)
+	}
+	urlPath := "/api/v1/workspaces/" + url.PathEscape(workspace) + "/agent-roles"
+	return http.MethodPost, urlPath, body, nil
+}
+
+// mapWebhookCreate dispatches `pad webhook create <url> [--events ...]
+// [--secret ...]`.
+//
+// POST /api/v1/workspaces/{ws}/webhooks with body matching
+// models.WebhookCreate. `--events` is comma-separated in the CLI
+// (cmdhelp string flag); the handler accepts a slice or comma-separated
+// string per the underlying schema. We pass verbatim and let the
+// handler split.
+func mapWebhookCreate(input map[string]any) (string, string, []byte, error) {
+	workspace, _ := input["workspace"].(string)
+	if workspace == "" {
+		return "", "", nil, fmt.Errorf("workspace is required")
+	}
+	urlVal, _ := input["url"].(string)
+	if urlVal == "" {
+		return "", "", nil, fmt.Errorf("url is required")
+	}
+	payload := map[string]any{"url": urlVal}
+	for _, key := range []string{"events", "secret"} {
+		if v, _ := input[key].(string); v != "" {
+			payload[key] = v
+		}
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return "", "", nil, fmt.Errorf("encode body: %w", err)
+	}
+	urlPath := "/api/v1/workspaces/" + url.PathEscape(workspace) + "/webhooks"
+	return http.MethodPost, urlPath, body, nil
+}
+
+// mapWorkspaceAuditLog dispatches `pad workspace audit-log [--days N]
+// [--actor X] [--action X] [--limit N]`.
+//
+// GET /api/v1/audit-log (NOT workspace-scoped — the URL is global,
+// admin-only). All filters become query params. Mirrors
+// internal/cli/client.go's GetAuditLog wire shape so behaviour matches
+// the CLI exactly: omit empty filters, pass numerics as decimal strings.
+//
+// Forwards an explicit `workspace` input as `?workspace=<id>` so an
+// admin agent can scope without needing to know the CLI's
+// session-default convention. The handler accepts a workspace UUID;
+// pass-through preserves whatever shape the agent sent.
+func mapWorkspaceAuditLog(input map[string]any) (string, string, []byte, error) {
+	q := url.Values{}
+	if s, _ := input["action"].(string); s != "" {
+		q.Set("action", s)
+	}
+	if s, _ := input["actor"].(string); s != "" {
+		q.Set("actor", s)
+	}
+	if s, _ := input["workspace"].(string); s != "" {
+		q.Set("workspace", s)
+	}
+	if n, ok := numericInput(input["days"]); ok && n > 0 {
+		q.Set("days", strconv.FormatInt(n, 10))
+	}
+	if n, ok := numericInput(input["limit"]); ok && n > 0 {
+		q.Set("limit", strconv.FormatInt(n, 10))
+	}
+	urlPath := "/api/v1/audit-log"
+	if encoded := q.Encode(); encoded != "" {
+		urlPath += "?" + encoded
+	}
+	return http.MethodGet, urlPath, nil, nil
+}
+
+// mapWorkspaceInvite dispatches `pad workspace invite <email>
+// [--role X]`.
+//
+// POST /api/v1/workspaces/{ws}/members/invite with body
+// {email, role?}. Default role on the handler side is "editor" so
+// we don't forward an empty value.
+func mapWorkspaceInvite(input map[string]any) (string, string, []byte, error) {
+	workspace, _ := input["workspace"].(string)
+	if workspace == "" {
+		return "", "", nil, fmt.Errorf("workspace is required")
+	}
+	email, _ := input["email"].(string)
+	if email == "" {
+		return "", "", nil, fmt.Errorf("email is required")
+	}
+	payload := map[string]any{"email": email}
+	if role, _ := input["role"].(string); role != "" {
+		payload["role"] = role
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return "", "", nil, fmt.Errorf("encode body: %w", err)
+	}
+	urlPath := "/api/v1/workspaces/" + url.PathEscape(workspace) + "/members/invite"
+	return http.MethodPost, urlPath, body, nil
 }
 
 // defaultActiveStatusFilter mirrors the broad inclusion list the

--- a/internal/mcp/dispatch_http_routes.go
+++ b/internal/mcp/dispatch_http_routes.go
@@ -398,10 +398,18 @@ func mapWebhookCreate(input map[string]any) (string, string, []byte, error) {
 // internal/cli/client.go's GetAuditLog wire shape so behaviour matches
 // the CLI exactly: omit empty filters, pass numerics as decimal strings.
 //
-// Forwards an explicit `workspace` input as `?workspace=<id>` so an
-// admin agent can scope without needing to know the CLI's
-// session-default convention. The handler accepts a workspace UUID;
-// pass-through preserves whatever shape the agent sent.
+// Crucially, the `workspace` input is NOT forwarded as
+// `?workspace=<id>`. The CLI's auditLogCmd never passes WorkspaceID
+// to GetAuditLog, so `pad workspace audit-log` returns the GLOBAL
+// audit log filtered by other params. The MCP dispatcher's
+// session-default mechanism (mergeDispatchInput) auto-injects
+// `workspace` into every input — if we forwarded it here, an admin
+// listing audit entries through MCP would silently miss every entry
+// outside the session workspace. Codex review on PR #347 caught this
+// divergence; matching the CLI's "no workspace filter" behaviour
+// keeps parity. Workspace-scoping admin audit logs needs its own
+// CLI flag (and would surface as a separate input via cmdhelp) —
+// not folding-in the implicit session value.
 func mapWorkspaceAuditLog(input map[string]any) (string, string, []byte, error) {
 	q := url.Values{}
 	if s, _ := input["action"].(string); s != "" {
@@ -409,9 +417,6 @@ func mapWorkspaceAuditLog(input map[string]any) (string, string, []byte, error) 
 	}
 	if s, _ := input["actor"].(string); s != "" {
 		q.Set("actor", s)
-	}
-	if s, _ := input["workspace"].(string); s != "" {
-		q.Set("workspace", s)
 	}
 	if n, ok := numericInput(input["days"]); ok && n > 0 {
 		q.Set("days", strconv.FormatInt(n, 10))

--- a/internal/mcp/dispatch_http_routes.go
+++ b/internal/mcp/dispatch_http_routes.go
@@ -363,10 +363,26 @@ func mapRoleCreate(input map[string]any) (string, string, []byte, error) {
 // [--secret ...]`.
 //
 // POST /api/v1/workspaces/{ws}/webhooks with body matching
-// models.WebhookCreate. `--events` is comma-separated in the CLI
-// (cmdhelp string flag); the handler accepts a slice or comma-separated
-// string per the underlying schema. We pass verbatim and let the
-// handler split.
+// models.WebhookCreate. The store persists `events` verbatim into a
+// column read back by webhooks.matchesEvent, which requires the value
+// be a JSON-array string (e.g. `["item.created","item.updated"]`) —
+// any other shape unmarshals to nil and matches no events at all.
+//
+// Codex review on PR #347 caught that the CLI's `--events
+// "item.created,item.updated"` example produces a literal comma-
+// separated string in the column, which matchesEvent then can't
+// parse. The CLI is independently bugged — fixing it is its own
+// task — but the MCP path should produce a working webhook the
+// first time. So we normalize:
+//
+//   - Empty / missing → omit, let the store default to `["*"]`.
+//   - Already a JSON array (starts with `[`, ends with `]`) →
+//     pass through.
+//   - Anything else → split on commas, trim, JSON-encode as
+//     []string. A bare wildcard `*` becomes `["*"]`.
+//
+// Same shape semantics for the schema-permissive case where the
+// agent passes an []any/[]string directly via the MCP property.
 func mapWebhookCreate(input map[string]any) (string, string, []byte, error) {
 	workspace, _ := input["workspace"].(string)
 	if workspace == "" {
@@ -377,10 +393,11 @@ func mapWebhookCreate(input map[string]any) (string, string, []byte, error) {
 		return "", "", nil, fmt.Errorf("url is required")
 	}
 	payload := map[string]any{"url": urlVal}
-	for _, key := range []string{"events", "secret"} {
-		if v, _ := input[key].(string); v != "" {
-			payload[key] = v
-		}
+	if events, ok := normalizeWebhookEvents(input["events"]); ok {
+		payload["events"] = events
+	}
+	if v, _ := input["secret"].(string); v != "" {
+		payload["secret"] = v
 	}
 	body, err := json.Marshal(payload)
 	if err != nil {
@@ -388,6 +405,70 @@ func mapWebhookCreate(input map[string]any) (string, string, []byte, error) {
 	}
 	urlPath := "/api/v1/workspaces/" + url.PathEscape(workspace) + "/webhooks"
 	return http.MethodPost, urlPath, body, nil
+}
+
+// normalizeWebhookEvents canonicalizes a webhook's event filter to
+// the JSON-array string the store + dispatcher expect.
+//
+// Returns (value, true) when a non-empty filter should be sent;
+// (_, false) when the input is missing/empty so the caller should
+// omit the field and let the store apply its `["*"]` default.
+func normalizeWebhookEvents(raw any) (string, bool) {
+	// Already-typed list — encode directly.
+	encodeList := func(items []string) (string, bool) {
+		clean := make([]string, 0, len(items))
+		for _, e := range items {
+			e = strings.TrimSpace(e)
+			if e != "" {
+				clean = append(clean, e)
+			}
+		}
+		if len(clean) == 0 {
+			return "", false
+		}
+		out, err := json.Marshal(clean)
+		if err != nil {
+			return "", false
+		}
+		return string(out), true
+	}
+
+	switch v := raw.(type) {
+	case nil:
+		return "", false
+	case []string:
+		return encodeList(v)
+	case []any:
+		items := make([]string, 0, len(v))
+		for _, e := range v {
+			s, ok := e.(string)
+			if !ok {
+				return "", false
+			}
+			items = append(items, s)
+		}
+		return encodeList(items)
+	case string:
+		s := strings.TrimSpace(v)
+		if s == "" {
+			return "", false
+		}
+		// Already JSON? Pass through.
+		if strings.HasPrefix(s, "[") && strings.HasSuffix(s, "]") {
+			var probe []string
+			if err := json.Unmarshal([]byte(s), &probe); err == nil {
+				return s, true
+			}
+			// Looked like JSON but wasn't a string array — fall
+			// through to comma-split treatment so a malformed
+			// `[oops]` becomes `["oops"]` rather than going on
+			// the wire and silently breaking matchesEvent.
+		}
+		parts := strings.Split(s, ",")
+		return encodeList(parts)
+	default:
+		return "", false
+	}
 }
 
 // mapWorkspaceAuditLog dispatches `pad workspace audit-log [--days N]

--- a/internal/mcp/dispatch_http_routes_extras_test.go
+++ b/internal/mcp/dispatch_http_routes_extras_test.go
@@ -193,11 +193,17 @@ func TestRouteTable_WebhookListAndDelete(t *testing.T) {
 	}
 }
 
-func TestMapWebhookCreate_BuildsCanonicalBody(t *testing.T) {
+func TestMapWebhookCreate_NormalizesCommaSeparatedEventsToJSONArray(t *testing.T) {
+	// The store persists `events` verbatim into a column that the
+	// dispatcher's matchesEvent later parses as a JSON array. A
+	// comma-separated string never matches anything once stored.
+	// Codex review on PR #347 caught this divergence; the dispatcher
+	// must normalize CLI-style commas into the JSON-array shape so
+	// MCP-created webhooks actually fire.
 	_, p, body, err := mapWebhookCreate(map[string]any{
 		"workspace": "docapp",
 		"url":       "https://example.com/hook",
-		"events":    "item.created,item.updated",
+		"events":    "item.created, item.updated",
 		"secret":    "shhh",
 	})
 	if err != nil {
@@ -213,11 +219,84 @@ func TestMapWebhookCreate_BuildsCanonicalBody(t *testing.T) {
 	if got["url"] != "https://example.com/hook" {
 		t.Errorf("url not preserved: %v", got)
 	}
-	if got["events"] != "item.created,item.updated" {
-		t.Errorf("events not preserved: %v", got)
-	}
 	if got["secret"] != "shhh" {
 		t.Errorf("secret not preserved: %v", got)
+	}
+	eventsStr, _ := got["events"].(string)
+	// Must be valid JSON array so matchesEvent can parse it.
+	var events []string
+	if err := json.Unmarshal([]byte(eventsStr), &events); err != nil {
+		t.Fatalf("events should be valid JSON array; got %q: %v", eventsStr, err)
+	}
+	want := []string{"item.created", "item.updated"}
+	if len(events) != len(want) {
+		t.Fatalf("events length = %d, want %d (got %v)", len(events), len(want), events)
+	}
+	for i, e := range want {
+		if events[i] != e {
+			t.Errorf("events[%d] = %q, want %q", i, events[i], e)
+		}
+	}
+}
+
+func TestNormalizeWebhookEvents_PassesThroughValidJSONArray(t *testing.T) {
+	// An agent that passes the canonical JSON-array form should get
+	// it back unchanged — round-trip identity, no double-encoding.
+	got, ok := normalizeWebhookEvents(`["item.created","item.updated"]`)
+	if !ok {
+		t.Fatalf("expected valid JSON array to be accepted")
+	}
+	if got != `["item.created","item.updated"]` {
+		t.Errorf("expected pass-through; got %q", got)
+	}
+}
+
+func TestNormalizeWebhookEvents_HandlesArrayInput(t *testing.T) {
+	// Schema-permissive case where the agent passes an []any (e.g.
+	// from a YAML-loaded spec). Trim and encode without dropping
+	// signal.
+	got, ok := normalizeWebhookEvents([]any{"item.created", " item.updated "})
+	if !ok {
+		t.Fatalf("expected []any input to be accepted")
+	}
+	var events []string
+	if err := json.Unmarshal([]byte(got), &events); err != nil {
+		t.Fatalf("not valid JSON array: %q", got)
+	}
+	if events[0] != "item.created" || events[1] != "item.updated" {
+		t.Errorf("entries not trimmed/preserved: %v", events)
+	}
+}
+
+func TestNormalizeWebhookEvents_OmitsEmpty(t *testing.T) {
+	// Empty / missing → return false so caller omits the field
+	// and lets the store apply its `["*"]` default.
+	cases := []any{nil, "", "   ", []any{}, []string{}}
+	for _, c := range cases {
+		if _, ok := normalizeWebhookEvents(c); ok {
+			t.Errorf("expected empty input %#v to be omitted", c)
+		}
+	}
+}
+
+func TestMapWebhookCreate_OmitsEventsWhenMissing(t *testing.T) {
+	// No events flag → field absent in body → store applies
+	// its default `["*"]`. The CLI's `--events` flag can be omitted
+	// for this exact behaviour, so MCP must not silently send a
+	// different default.
+	_, _, body, err := mapWebhookCreate(map[string]any{
+		"workspace": "docapp",
+		"url":       "https://example.com/hook",
+	})
+	if err != nil {
+		t.Fatalf("mapWebhookCreate: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if _, present := got["events"]; present {
+		t.Errorf("events should be omitted when not set; got %v", got)
 	}
 }
 

--- a/internal/mcp/dispatch_http_routes_extras_test.go
+++ b/internal/mcp/dispatch_http_routes_extras_test.go
@@ -1,0 +1,571 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// --- Stars ---
+
+func TestRouteTable_ItemStarPostsToStarEndpoint(t *testing.T) {
+	m, p, body, err := routeTable["item star"](map[string]any{
+		"workspace": "docapp", "ref": "TASK-5",
+	})
+	if err != nil {
+		t.Fatalf("routeTable[item star]: %v", err)
+	}
+	if m != http.MethodPost {
+		t.Errorf("method = %q, want POST", m)
+	}
+	if p != "/api/v1/workspaces/docapp/items/TASK-5/star" {
+		t.Errorf("path = %q", p)
+	}
+	if len(body) != 0 {
+		t.Errorf("expected empty body for star POST; got %q", string(body))
+	}
+}
+
+func TestRouteTable_ItemUnstarDeletesStarEndpoint(t *testing.T) {
+	m, p, _, err := routeTable["item unstar"](map[string]any{
+		"workspace": "docapp", "ref": "TASK-5",
+	})
+	if err != nil {
+		t.Fatalf("routeTable[item unstar]: %v", err)
+	}
+	if m != http.MethodDelete {
+		t.Errorf("method = %q, want DELETE", m)
+	}
+	if p != "/api/v1/workspaces/docapp/items/TASK-5/star" {
+		t.Errorf("path = %q", p)
+	}
+}
+
+func TestMapItemStarred_DefaultsHidesTerminalItems(t *testing.T) {
+	// Without --all the dispatcher omits include_terminal so the
+	// handler defaults to hiding done/completed items. Mirrors
+	// `pad item starred` (default) on the CLI side.
+	m, p, _, err := mapItemStarred(map[string]any{"workspace": "docapp"})
+	if err != nil {
+		t.Fatalf("mapItemStarred: %v", err)
+	}
+	if m != http.MethodGet {
+		t.Errorf("method = %q", m)
+	}
+	if p != "/api/v1/workspaces/docapp/starred" {
+		t.Errorf("path = %q (expected no include_terminal query)", p)
+	}
+}
+
+func TestMapItemStarred_AllSetsIncludeTerminal(t *testing.T) {
+	_, p, _, err := mapItemStarred(map[string]any{
+		"workspace": "docapp",
+		"all":       true,
+	})
+	if err != nil {
+		t.Fatalf("mapItemStarred: %v", err)
+	}
+	if !strings.Contains(p, "include_terminal=true") {
+		t.Errorf("path missing include_terminal=true: %q", p)
+	}
+}
+
+func TestMapItemStarred_RequiresWorkspace(t *testing.T) {
+	_, _, _, err := mapItemStarred(map[string]any{})
+	if err == nil {
+		t.Errorf("expected error when workspace missing")
+	}
+}
+
+// --- Roles ---
+
+func TestMapRoleCreate_BuildsCanonicalBody(t *testing.T) {
+	m, p, body, err := mapRoleCreate(map[string]any{
+		"workspace":   "docapp",
+		"name":        "Designer",
+		"description": "UX work",
+		"icon":        "🎨",
+		"tools":       "figma,sketch",
+	})
+	if err != nil {
+		t.Fatalf("mapRoleCreate: %v", err)
+	}
+	if m != http.MethodPost {
+		t.Errorf("method = %q", m)
+	}
+	if p != "/api/v1/workspaces/docapp/agent-roles" {
+		t.Errorf("path = %q", p)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	want := map[string]string{
+		"name":        "Designer",
+		"description": "UX work",
+		"icon":        "🎨",
+		"tools":       "figma,sketch",
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("body[%q] = %v, want %v", k, got[k], v)
+		}
+	}
+}
+
+func TestMapRoleCreate_OmitsEmptyOptionalFields(t *testing.T) {
+	_, _, body, err := mapRoleCreate(map[string]any{
+		"workspace": "docapp",
+		"name":      "Reviewer",
+	})
+	if err != nil {
+		t.Fatalf("mapRoleCreate: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if got["name"] != "Reviewer" {
+		t.Errorf("name not preserved: %v", got)
+	}
+	for _, key := range []string{"description", "icon", "tools"} {
+		if _, present := got[key]; present {
+			t.Errorf("empty %q should be omitted from body; got %v", key, got)
+		}
+	}
+}
+
+func TestMapRoleCreate_RequiresName(t *testing.T) {
+	_, _, _, err := mapRoleCreate(map[string]any{"workspace": "ws"})
+	if err == nil {
+		t.Errorf("expected error when name missing")
+	}
+}
+
+func TestRouteTable_RoleDelete(t *testing.T) {
+	m, p, _, err := routeTable["role delete"](map[string]any{
+		"workspace": "docapp",
+		"slug":      "designer",
+	})
+	if err != nil {
+		t.Fatalf("routeTable[role delete]: %v", err)
+	}
+	if m != http.MethodDelete {
+		t.Errorf("method = %q", m)
+	}
+	if p != "/api/v1/workspaces/docapp/agent-roles/designer" {
+		t.Errorf("path = %q", p)
+	}
+}
+
+// --- Webhooks ---
+
+func TestRouteTable_WebhookListAndDelete(t *testing.T) {
+	if m, p, _, err := routeTable["webhook list"](map[string]any{"workspace": "docapp"}); err != nil {
+		t.Errorf("webhook list: %v", err)
+	} else {
+		if m != http.MethodGet || p != "/api/v1/workspaces/docapp/webhooks" {
+			t.Errorf("webhook list mapping = %q %q", m, p)
+		}
+	}
+	if m, p, _, err := routeTable["webhook delete"](map[string]any{
+		"workspace": "docapp", "id": "abc-123",
+	}); err != nil {
+		t.Errorf("webhook delete: %v", err)
+	} else {
+		if m != http.MethodDelete || p != "/api/v1/workspaces/docapp/webhooks/abc-123" {
+			t.Errorf("webhook delete mapping = %q %q", m, p)
+		}
+	}
+	if m, p, _, err := routeTable["webhook test"](map[string]any{
+		"workspace": "docapp", "id": "abc-123",
+	}); err != nil {
+		t.Errorf("webhook test: %v", err)
+	} else {
+		if m != http.MethodPost || p != "/api/v1/workspaces/docapp/webhooks/abc-123/test" {
+			t.Errorf("webhook test mapping = %q %q", m, p)
+		}
+	}
+}
+
+func TestMapWebhookCreate_BuildsCanonicalBody(t *testing.T) {
+	_, p, body, err := mapWebhookCreate(map[string]any{
+		"workspace": "docapp",
+		"url":       "https://example.com/hook",
+		"events":    "item.created,item.updated",
+		"secret":    "shhh",
+	})
+	if err != nil {
+		t.Fatalf("mapWebhookCreate: %v", err)
+	}
+	if p != "/api/v1/workspaces/docapp/webhooks" {
+		t.Errorf("path = %q", p)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if got["url"] != "https://example.com/hook" {
+		t.Errorf("url not preserved: %v", got)
+	}
+	if got["events"] != "item.created,item.updated" {
+		t.Errorf("events not preserved: %v", got)
+	}
+	if got["secret"] != "shhh" {
+		t.Errorf("secret not preserved: %v", got)
+	}
+}
+
+func TestMapWebhookCreate_RequiresURL(t *testing.T) {
+	_, _, _, err := mapWebhookCreate(map[string]any{"workspace": "ws"})
+	if err == nil {
+		t.Errorf("expected error when url missing")
+	}
+}
+
+// --- Auth + workspace surfaces ---
+
+func TestRouteTable_AuthWhoamiNoWorkspaceRequired(t *testing.T) {
+	// `auth whoami` is global — input map need not carry workspace,
+	// and the URL must NOT include /workspaces/ prefix.
+	m, p, _, err := routeTable["auth whoami"](map[string]any{})
+	if err != nil {
+		t.Fatalf("auth whoami: %v", err)
+	}
+	if m != http.MethodGet {
+		t.Errorf("method = %q", m)
+	}
+	if p != "/api/v1/auth/me" {
+		t.Errorf("path = %q (expected /api/v1/auth/me with no workspace scoping)", p)
+	}
+}
+
+func TestRouteTable_WorkspaceListNoWorkspaceRequired(t *testing.T) {
+	m, p, _, err := routeTable["workspace list"](map[string]any{})
+	if err != nil {
+		t.Fatalf("workspace list: %v", err)
+	}
+	if m != http.MethodGet {
+		t.Errorf("method = %q", m)
+	}
+	if p != "/api/v1/workspaces" {
+		t.Errorf("path = %q", p)
+	}
+}
+
+func TestRouteTable_WorkspaceStorage(t *testing.T) {
+	m, p, _, err := routeTable["workspace storage"](map[string]any{"workspace": "docapp"})
+	if err != nil {
+		t.Fatalf("workspace storage: %v", err)
+	}
+	if m != http.MethodGet {
+		t.Errorf("method = %q", m)
+	}
+	if p != "/api/v1/workspaces/docapp/storage/usage" {
+		t.Errorf("path = %q", p)
+	}
+}
+
+func TestMapWorkspaceAuditLog_OmitsEmptyFilters(t *testing.T) {
+	// No filters → bare /api/v1/audit-log path. Mirrors the CLI's
+	// "only set ?<key>=<val> if the flag has a value" behaviour.
+	m, p, _, err := mapWorkspaceAuditLog(map[string]any{})
+	if err != nil {
+		t.Fatalf("mapWorkspaceAuditLog: %v", err)
+	}
+	if m != http.MethodGet {
+		t.Errorf("method = %q", m)
+	}
+	if p != "/api/v1/audit-log" {
+		t.Errorf("path = %q (expected no query string)", p)
+	}
+}
+
+func TestMapWorkspaceAuditLog_PassesFiltersThrough(t *testing.T) {
+	_, p, _, err := mapWorkspaceAuditLog(map[string]any{
+		"action":    "item.created",
+		"actor":     "user-uuid-1",
+		"workspace": "docapp",
+		"days":      float64(7),
+		"limit":     float64(25),
+	})
+	if err != nil {
+		t.Fatalf("mapWorkspaceAuditLog: %v", err)
+	}
+	idx := strings.Index(p, "?")
+	if idx < 0 {
+		t.Fatalf("path missing query string: %q", p)
+	}
+	values, parseErr := url.ParseQuery(p[idx+1:])
+	if parseErr != nil {
+		t.Fatalf("parse query: %v", parseErr)
+	}
+	want := map[string]string{
+		"action":    "item.created",
+		"actor":     "user-uuid-1",
+		"workspace": "docapp",
+		"days":      "7",
+		"limit":     "25",
+	}
+	for k, v := range want {
+		if got := values.Get(k); got != v {
+			t.Errorf("query[%q] = %q, want %q", k, got, v)
+		}
+	}
+}
+
+func TestMapWorkspaceInvite_BuildsCanonicalBody(t *testing.T) {
+	_, p, body, err := mapWorkspaceInvite(map[string]any{
+		"workspace": "docapp",
+		"email":     "alice@example.com",
+		"role":      "viewer",
+	})
+	if err != nil {
+		t.Fatalf("mapWorkspaceInvite: %v", err)
+	}
+	if p != "/api/v1/workspaces/docapp/members/invite" {
+		t.Errorf("path = %q", p)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if got["email"] != "alice@example.com" {
+		t.Errorf("email not preserved: %v", got)
+	}
+	if got["role"] != "viewer" {
+		t.Errorf("role not preserved: %v", got)
+	}
+}
+
+func TestMapWorkspaceInvite_RoleOmittedWhenMissing(t *testing.T) {
+	// Handler defaults to "editor" when role is unset, so the
+	// dispatcher should NOT forward an empty role string — that
+	// would override the default with "" and surprise the agent.
+	_, _, body, err := mapWorkspaceInvite(map[string]any{
+		"workspace": "docapp", "email": "alice@example.com",
+	})
+	if err != nil {
+		t.Fatalf("mapWorkspaceInvite: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if _, present := got["role"]; present {
+		t.Errorf("role should be omitted when not set; got %v", got)
+	}
+}
+
+func TestMapWorkspaceInvite_RequiresEmail(t *testing.T) {
+	_, _, _, err := mapWorkspaceInvite(map[string]any{"workspace": "ws"})
+	if err == nil {
+		t.Errorf("expected error when email missing")
+	}
+}
+
+// --- noRemoteEquivalent extension ---
+
+func TestDispatch_GithubCommandsRejectedAsCLIOnly(t *testing.T) {
+	// `github link/status/unlink` chain `git rev-parse` + `gh` CLI for
+	// the local branch + PR data they write — the agent's local
+	// checkout has no representation on pad-cloud, so these commands
+	// can never have a remote equivalent. The dispatcher should give
+	// the same stable "no remote equivalent" message it gives for
+	// other CLI-only commands.
+	d := &HTTPHandlerDispatcher{
+		Handler:      errorHandler(t, "github commands must not reach handler"),
+		UserResolver: fixedUserResolver(&models.User{ID: "u"}),
+	}
+	for _, cmd := range []string{"github link", "github status", "github unlink"} {
+		t.Run(cmd, func(t *testing.T) {
+			ctx := WithDispatchInput(context.Background(), map[string]any{
+				"workspace": "docapp",
+			})
+			res, err := d.Dispatch(ctx, strings.Split(cmd, " "), nil)
+			if err != nil {
+				t.Fatalf("Dispatch err: %v", err)
+			}
+			if !res.IsError {
+				t.Errorf("expected IsError; got %#v", res)
+			}
+			if !containsToolText(res, "no remote equivalent") {
+				t.Errorf("error should call out CLI-only nature; got %#v", res)
+			}
+		})
+	}
+}
+
+// --- Integration smoke ---
+
+// TestHTTPHandlerDispatcher_Integration_StarsRolesWebhooksWhoami exercises
+// the new route-table additions end-to-end against a real
+// *server.Server. Catches regressions in handler shape, route
+// registration, and authentication for this slice's commands.
+func TestHTTPHandlerDispatcher_Integration_StarsRolesWebhooksWhoami(t *testing.T) {
+	srv, st := newPadServer(t)
+
+	// Bootstrap workspace + owner.
+	wsRec := doJSONReq(t, srv, http.MethodPost, "/api/v1/workspaces",
+		map[string]any{"name": "DocApp"})
+	if wsRec.Code != http.StatusCreated {
+		t.Fatalf("create workspace: %d %s", wsRec.Code, wsRec.Body.String())
+	}
+	var ws models.Workspace
+	if err := json.Unmarshal(wsRec.Body.Bytes(), &ws); err != nil {
+		t.Fatalf("decode workspace: %v", err)
+	}
+	owner, err := st.CreateUser(models.UserCreate{Email: "dave@example.com", Name: "Dave", Password: "x"})
+	if err != nil {
+		t.Fatalf("create owner: %v", err)
+	}
+	if err := st.AddWorkspaceMember(ws.ID, owner.ID, "owner"); err != nil {
+		t.Fatalf("add owner: %v", err)
+	}
+
+	d := &HTTPHandlerDispatcher{Handler: srv, UserResolver: fixedUserResolver(owner)}
+
+	// auth whoami — global, no workspace.
+	whoamiRes, err := d.Dispatch(
+		WithDispatchInput(context.Background(), map[string]any{}),
+		[]string{"auth", "whoami"},
+		nil,
+	)
+	if err != nil || whoamiRes.IsError {
+		t.Fatalf("auth whoami: err=%v IsError=%v: %#v", err, whoamiRes != nil && whoamiRes.IsError, whoamiRes)
+	}
+	me, ok := whoamiRes.StructuredContent.(map[string]any)
+	if !ok {
+		t.Fatalf("whoami result not structured: %#v", whoamiRes.StructuredContent)
+	}
+	if me["email"] != "dave@example.com" {
+		t.Errorf("whoami did not return current user: %v", me)
+	}
+
+	// workspace list — should include the bootstrapped workspace.
+	wsListRes, err := d.Dispatch(
+		WithDispatchInput(context.Background(), map[string]any{}),
+		[]string{"workspace", "list"},
+		nil,
+	)
+	if err != nil || wsListRes.IsError {
+		t.Fatalf("workspace list: err=%v IsError=%v: %#v", err, wsListRes != nil && wsListRes.IsError, wsListRes)
+	}
+	wsList, ok := wsListRes.StructuredContent.([]any)
+	if !ok || len(wsList) == 0 {
+		t.Fatalf("workspace list result not array or empty: %#v", wsListRes.StructuredContent)
+	}
+
+	// Create an item, then star it.
+	createCtx := WithDispatchInput(context.Background(), map[string]any{
+		"workspace": ws.Slug, "collection": "tasks", "title": "To star",
+	})
+	createRes, err := d.Dispatch(createCtx, []string{"item", "create"}, nil)
+	if err != nil || createRes.IsError {
+		t.Fatalf("item create: err=%v IsError=%v: %#v", err, createRes != nil && createRes.IsError, createRes)
+	}
+	created := createRes.StructuredContent.(map[string]any)
+	ref, _ := created["ref"].(string)
+	if ref == "" {
+		t.Fatalf("item create missing ref: %#v", created)
+	}
+
+	starRes, err := d.Dispatch(
+		WithDispatchInput(context.Background(), map[string]any{
+			"workspace": ws.Slug, "ref": ref,
+		}),
+		[]string{"item", "star"},
+		nil,
+	)
+	if err != nil || starRes.IsError {
+		t.Fatalf("item star: err=%v IsError=%v: %#v", err, starRes != nil && starRes.IsError, starRes)
+	}
+
+	starredRes, err := d.Dispatch(
+		WithDispatchInput(context.Background(), map[string]any{"workspace": ws.Slug}),
+		[]string{"item", "starred"},
+		nil,
+	)
+	if err != nil || starredRes.IsError {
+		t.Fatalf("item starred: err=%v IsError=%v: %#v", err, starredRes != nil && starredRes.IsError, starredRes)
+	}
+	starred, ok := starredRes.StructuredContent.([]any)
+	if !ok || len(starred) != 1 {
+		t.Fatalf("expected 1 starred item; got %#v", starredRes.StructuredContent)
+	}
+
+	// role create (owner-only) → role delete.
+	roleRes, err := d.Dispatch(
+		WithDispatchInput(context.Background(), map[string]any{
+			"workspace": ws.Slug, "name": "Designer", "icon": "🎨",
+		}),
+		[]string{"role", "create"},
+		nil,
+	)
+	if err != nil || roleRes.IsError {
+		t.Fatalf("role create: err=%v IsError=%v: %#v", err, roleRes != nil && roleRes.IsError, roleRes)
+	}
+	role, _ := roleRes.StructuredContent.(map[string]any)
+	roleSlug, _ := role["slug"].(string)
+	if roleSlug == "" {
+		t.Fatalf("role create did not return slug: %#v", role)
+	}
+
+	delRes, err := d.Dispatch(
+		WithDispatchInput(context.Background(), map[string]any{
+			"workspace": ws.Slug, "slug": roleSlug,
+		}),
+		[]string{"role", "delete"},
+		nil,
+	)
+	if err != nil || delRes.IsError {
+		t.Fatalf("role delete: err=%v IsError=%v: %#v", err, delRes != nil && delRes.IsError, delRes)
+	}
+
+	// Webhook list (empty) → create → list (one) → delete → list (empty).
+	listRes, err := d.Dispatch(
+		WithDispatchInput(context.Background(), map[string]any{"workspace": ws.Slug}),
+		[]string{"webhook", "list"},
+		nil,
+	)
+	if err != nil || listRes.IsError {
+		t.Fatalf("webhook list (empty): err=%v IsError=%v: %#v", err, listRes != nil && listRes.IsError, listRes)
+	}
+	if hooks, _ := listRes.StructuredContent.([]any); len(hooks) != 0 {
+		t.Errorf("expected no webhooks initially; got %v", hooks)
+	}
+
+	createHookRes, err := d.Dispatch(
+		WithDispatchInput(context.Background(), map[string]any{
+			"workspace": ws.Slug,
+			"url":       "https://example.com/hook",
+			"events":    "item.created",
+		}),
+		[]string{"webhook", "create"},
+		nil,
+	)
+	if err != nil || createHookRes.IsError {
+		t.Fatalf("webhook create: err=%v IsError=%v: %#v", err, createHookRes != nil && createHookRes.IsError, createHookRes)
+	}
+	hook, _ := createHookRes.StructuredContent.(map[string]any)
+	hookID, _ := hook["id"].(string)
+	if hookID == "" {
+		t.Fatalf("webhook create did not return id: %#v", hook)
+	}
+
+	delHookRes, err := d.Dispatch(
+		WithDispatchInput(context.Background(), map[string]any{
+			"workspace": ws.Slug, "id": hookID,
+		}),
+		[]string{"webhook", "delete"},
+		nil,
+	)
+	if err != nil || delHookRes.IsError {
+		t.Fatalf("webhook delete: err=%v IsError=%v: %#v", err, delHookRes != nil && delHookRes.IsError, delHookRes)
+	}
+}

--- a/internal/mcp/dispatch_http_routes_extras_test.go
+++ b/internal/mcp/dispatch_http_routes_extras_test.go
@@ -288,11 +288,10 @@ func TestMapWorkspaceAuditLog_OmitsEmptyFilters(t *testing.T) {
 
 func TestMapWorkspaceAuditLog_PassesFiltersThrough(t *testing.T) {
 	_, p, _, err := mapWorkspaceAuditLog(map[string]any{
-		"action":    "item.created",
-		"actor":     "user-uuid-1",
-		"workspace": "docapp",
-		"days":      float64(7),
-		"limit":     float64(25),
+		"action": "item.created",
+		"actor":  "user-uuid-1",
+		"days":   float64(7),
+		"limit":  float64(25),
 	})
 	if err != nil {
 		t.Fatalf("mapWorkspaceAuditLog: %v", err)
@@ -306,16 +305,39 @@ func TestMapWorkspaceAuditLog_PassesFiltersThrough(t *testing.T) {
 		t.Fatalf("parse query: %v", parseErr)
 	}
 	want := map[string]string{
-		"action":    "item.created",
-		"actor":     "user-uuid-1",
-		"workspace": "docapp",
-		"days":      "7",
-		"limit":     "25",
+		"action": "item.created",
+		"actor":  "user-uuid-1",
+		"days":   "7",
+		"limit":  "25",
 	}
 	for k, v := range want {
 		if got := values.Get(k); got != v {
 			t.Errorf("query[%q] = %q, want %q", k, got, v)
 		}
+	}
+}
+
+func TestMapWorkspaceAuditLog_DoesNotForwardSessionWorkspace(t *testing.T) {
+	// The MCP session-default mechanism (mergeDispatchInput) auto-
+	// injects `workspace` into every input map. The CLI's
+	// `pad workspace audit-log` deliberately doesn't pass workspace
+	// as a filter — it returns the GLOBAL audit log. The dispatcher
+	// must match: forwarding the implicit session workspace as
+	// `?workspace=<id>` would silently hide audit entries from other
+	// workspaces for an admin who queried "give me everything"
+	// (Codex review on PR #347, finding 1).
+	_, p, _, err := mapWorkspaceAuditLog(map[string]any{
+		"workspace": "docapp", // session-default; should NOT scope
+		"action":    "item.created",
+	})
+	if err != nil {
+		t.Fatalf("mapWorkspaceAuditLog: %v", err)
+	}
+	if strings.Contains(p, "workspace=") {
+		t.Errorf("workspace input must NOT be forwarded as ?workspace=; got %q", p)
+	}
+	if !strings.Contains(p, "action=item.created") {
+		t.Errorf("explicit filters must still be forwarded; got %q", p)
 	}
 }
 


### PR DESCRIPTION
## Summary

Continues PLAN-943 / TASK-968 past PR #346's link/lifecycle slice. Twelve more commands land in the route table, plus `github link/status/unlink` move into the `noRemoteEquivalent` rejection set.

### New commands

- **Stars (3):** `item star`, `unstar`, `starred`
- **Roles (2):** `role create`, `role delete`
- **Webhooks (4):** `webhook list`, `create`, `delete`, `test`
- **Auth (1):** `auth whoami` (global — `/api/v1/auth/me`)
- **Workspace (3):** `workspace list`, `storage`, `audit-log`
- **Plus:** `workspace invite` (bonus — POST `/members/invite`)

The simple-shape commands flow through `routeSpec`. Custom mappers handle `role create`/`webhook create` body shapes, `item starred`'s `--all` → `?include_terminal=true` toggle, `workspace audit-log`'s filter forwarding, and `workspace invite`'s default-respecting role omission (handler defaults to `editor`, so we don't pass an empty role string).

`auth whoami` and `workspace list` are genuinely global — no `{workspace}` placeholder. The route-spec framework already supports that. `workspace audit-log` hits `/api/v1/audit-log` (admin-only, NOT scoped to workspace by URL — can be filtered by `?workspace=<id>` via input pass-through).

`item star`/`unstar` lean on `handleStarItem`'s `store.ResolveItem` accepting refs/slugs/UUIDs interchangeably — no prefetch needed.

### Extending `noRemoteEquivalent`

`github link`/`status`/`unlink` chain `git rev-parse` + `gh` CLI to build the PR data they write to the linked item — that data inherently lives in the agent's local checkout, with no representation on pad-cloud. They join the existing CLI-only set with the same stable error message; the comment points agents at the alternative (use their own GitHub tools, then `item update --field github_pr=...`).

## Context

Implements `TASK-968` under `PLAN-943`. PR #346 shipped item link/lifecycle commands + `--role` slug resolution; this PR extends with the stars/roles/webhooks/auth surface. Sections C (project intelligence aliases), F (collection create + library), and J (attachments) follow as separate PRs.

## Test plan

- [x] `go build ./... && go vet ./...` — clean
- [x] `make check` — golangci-lint + Go tests + web build all clean
- [x] Per-command happy + missing-input tests
- [x] Default-vs-`--all` behaviour for `item starred`'s `?include_terminal`
- [x] `role create` / `workspace invite` omit empty optional fields
- [x] `workspace audit-log` query-string shape pinned (filters + numerics)
- [x] `github link/status/unlink` rejected with stable `noRemoteEquivalent` message
- [x] Integration smoke against `*server.Server`: whoami → workspace list → item create+star+starred → role create+delete → webhook list+create+delete