### PR TITLE
feat(mcp): project standup + changelog + library activate (TASK-968 partial)

### DIFF
--- a/internal/mcp/dispatch_http.go
+++ b/internal/mcp/dispatch_http.go
@@ -272,8 +272,14 @@ func (d *HTTPHandlerDispatcher) Dispatch(ctx context.Context, cmdPath, _ []strin
 		return d.dispatchProjectReady(ctx, input, user)
 	case "project stale":
 		return d.dispatchProjectStale(ctx, input, user)
+	case "project standup":
+		return d.dispatchProjectStandup(ctx, input, user)
+	case "project changelog":
+		return d.dispatchProjectChangelog(ctx, input, user)
 	case "library list":
 		return d.dispatchLibraryList(ctx, input, user)
+	case "library activate":
+		return d.dispatchLibraryActivate(ctx, input, user)
 	}
 
 	// Item link create/delete commands. The asymmetry between which

--- a/internal/mcp/dispatch_http_slice4.go
+++ b/internal/mcp/dispatch_http_slice4.go
@@ -1,0 +1,545 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/PerpetualSoftware/pad/internal/collections"
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// --- project standup ---
+
+// dispatchProjectStandup reproduces `pad project standup --format
+// json`: fetches the dashboard for blockers + suggested-next, lists
+// items in each terminal status to find recently completed work,
+// lists in-progress items separately. Mirrors cmd/pad/main.go's
+// standupCmd JSON branch exactly:
+//
+//	{
+//	  "date":          "YYYY-MM-DD",
+//	  "days":          N,
+//	  "completed":     [{ref, title, status},  ...],
+//	  "in_progress":   [{ref, title, priority}, ...],
+//	  "blockers":      [{title, reason},        ...],
+//	  "suggested_next":[{title, reason},        ...]
+//	}
+//
+// The CLI defaults --days to 1; we apply that default in-dispatcher
+// since cmdhelp doesn't carry a default forward to MCP property
+// schemas (registry.go strips them). Without the default, a missing
+// `days` input would zero-out the cutoff and report nothing as
+// "completed", surprising agents that omit the flag.
+func (d *HTTPHandlerDispatcher) dispatchProjectStandup(
+	ctx context.Context,
+	input map[string]any,
+	user *models.User,
+) (*mcp.CallToolResult, error) {
+	const cmdKey = "project standup"
+	workspace, _ := input["workspace"].(string)
+	if workspace == "" {
+		return mcp.NewToolResultErrorf("%s: workspace is required", cmdKey), nil
+	}
+
+	days := 1
+	if n, ok := numericInput(input["days"]); ok && n > 0 {
+		days = int(n)
+	}
+	cutoff := time.Now().AddDate(0, 0, -days)
+
+	dash, errRes := d.fetchDashboardJSON(ctx, input, user, cmdKey)
+	if errRes != nil {
+		return errRes, nil
+	}
+
+	// One list call per terminal status (matches the CLI's loop —
+	// avoids OR-ing all statuses into a single query, which would
+	// hit the comma-separated-status path that the broader
+	// defaultActiveStatusFilter also relies on but would here treat
+	// as "any of these statuses"). Filter by cutoff client-side.
+	var completed []map[string]any
+	for _, status := range models.DefaultTerminalStatuses {
+		items, err := d.listWorkspaceItems(ctx, user, workspace, url.Values{
+			"status": {status},
+			"sort":   {"updated_at:desc"},
+			"limit":  {"20"},
+		})
+		if err != nil {
+			// Match the CLI: per-status errors don't abort the whole
+			// command — best-effort accumulation across statuses.
+			continue
+		}
+		for _, item := range items {
+			if itemUpdatedAfter(item, cutoff) {
+				completed = append(completed, item)
+			}
+		}
+	}
+
+	inProgress, err := d.listWorkspaceItems(ctx, user, workspace, url.Values{
+		"status": {"in-progress"},
+		"sort":   {"updated_at:desc"},
+	})
+	if err != nil {
+		// Match the CLI: in-progress fetch failures are tolerated;
+		// the rest of the standup still ships.
+		inProgress = nil
+	}
+
+	type standupItem struct {
+		Ref      string `json:"ref"`
+		Title    string `json:"title"`
+		Status   string `json:"status,omitempty"`
+		Priority string `json:"priority,omitempty"`
+		Reason   string `json:"reason,omitempty"`
+	}
+	completedOut := make([]standupItem, 0, len(completed))
+	for _, item := range completed {
+		completedOut = append(completedOut, standupItem{
+			Ref:    itemRefFromMap(item),
+			Title:  itemTitleFromMap(item),
+			Status: extractItemFieldString(item, "status"),
+		})
+	}
+	inProgressOut := make([]standupItem, 0, len(inProgress))
+	for _, item := range inProgress {
+		inProgressOut = append(inProgressOut, standupItem{
+			Ref:      itemRefFromMap(item),
+			Title:    itemTitleFromMap(item),
+			Priority: extractItemFieldString(item, "priority"),
+		})
+	}
+
+	blockers := make([]standupItem, 0)
+	for _, a := range dashboardArrayField(dash, "attention") {
+		blockers = append(blockers, standupItem{
+			Title:  stringFromMap(a, "item_title"),
+			Reason: stringFromMap(a, "reason"),
+		})
+	}
+	suggested := make([]standupItem, 0)
+	for _, s := range dashboardArrayField(dash, "suggested_next") {
+		suggested = append(suggested, standupItem{
+			Title:  stringFromMap(s, "item_title"),
+			Reason: stringFromMap(s, "reason"),
+		})
+	}
+
+	payload := map[string]any{
+		"date":           time.Now().Format("2006-01-02"),
+		"days":           days,
+		"completed":      completedOut,
+		"in_progress":    inProgressOut,
+		"blockers":       blockers,
+		"suggested_next": suggested,
+	}
+	return packageStructuredResponse(cmdKey, payload)
+}
+
+// --- project changelog ---
+
+// dispatchProjectChangelog reproduces `pad project changelog
+// --format json`: lists items in each terminal status, filters by
+// date (--since YYYY-MM-DD takes precedence over --days), filters by
+// parent ref/slug/title, then groups by collection.
+//
+//	{
+//	  "period": "<human label>",
+//	  "since":  "YYYY-MM-DD",
+//	  "total":  N,
+//	  "groups": [{collection, icon?, count, items:[{ref,title,status}]}]
+//	}
+//
+// CLI defaults: --days 7, --since "" (overrides days), --parent "".
+// The dispatcher applies the same defaults in-process so MCP agents
+// don't need to know the cmdhelp-stripped defaults.
+func (d *HTTPHandlerDispatcher) dispatchProjectChangelog(
+	ctx context.Context,
+	input map[string]any,
+	user *models.User,
+) (*mcp.CallToolResult, error) {
+	const cmdKey = "project changelog"
+	workspace, _ := input["workspace"].(string)
+	if workspace == "" {
+		return mcp.NewToolResultErrorf("%s: workspace is required", cmdKey), nil
+	}
+
+	since, _ := input["since"].(string)
+	since = strings.TrimSpace(since)
+	days := 7
+	if n, ok := numericInput(input["days"]); ok && n > 0 {
+		days = int(n)
+	}
+
+	var cutoff time.Time
+	if since != "" {
+		parsed, err := time.Parse("2006-01-02", since)
+		if err != nil {
+			return mcp.NewToolResultErrorf(
+				"%s: invalid --since date %q (expected YYYY-MM-DD): %s",
+				cmdKey, since, err.Error(),
+			), nil
+		}
+		cutoff = parsed
+	} else {
+		cutoff = time.Now().AddDate(0, 0, -days)
+	}
+
+	parentFilter, _ := input["parent"].(string)
+	parentFilter = strings.TrimSpace(parentFilter)
+
+	var allItems []map[string]any
+	for _, status := range models.DefaultTerminalStatuses {
+		items, err := d.listWorkspaceItems(ctx, user, workspace, url.Values{
+			"status": {status},
+			"sort":   {"updated_at:desc"},
+			"limit":  {"100"},
+		})
+		if err != nil {
+			continue
+		}
+		for _, item := range items {
+			if !itemUpdatedAfter(item, cutoff) {
+				continue
+			}
+			if parentFilter != "" && !itemMatchesParent(item, parentFilter) {
+				continue
+			}
+			allItems = append(allItems, item)
+		}
+	}
+
+	// Group by collection slug, preserving first-seen ordering so
+	// the output is stable across runs (matches the CLI's
+	// groupOrder slice).
+	type collectionGroup struct {
+		Name  string
+		Icon  string
+		Items []map[string]any
+	}
+	groupOrder := []string{}
+	groups := map[string]*collectionGroup{}
+	for _, item := range allItems {
+		key := stringFromMap(item, "collection_slug")
+		if key == "" {
+			key = "other"
+		}
+		if _, exists := groups[key]; !exists {
+			name := stringFromMap(item, "collection_name")
+			if name == "" {
+				name = key
+			}
+			groups[key] = &collectionGroup{
+				Name: name,
+				Icon: stringFromMap(item, "collection_icon"),
+			}
+			groupOrder = append(groupOrder, key)
+		}
+		groups[key].Items = append(groups[key].Items, item)
+	}
+
+	periodLabel := fmt.Sprintf("last %d days", days)
+	if since != "" {
+		periodLabel = "since " + since
+	}
+	if parentFilter != "" {
+		periodLabel += " (parent: " + parentFilter + ")"
+	}
+
+	type changelogItem struct {
+		Ref    string `json:"ref"`
+		Title  string `json:"title"`
+		Status string `json:"status"`
+	}
+	type changelogGroup struct {
+		Collection string          `json:"collection"`
+		Icon       string          `json:"icon,omitempty"`
+		Count      int             `json:"count"`
+		Items      []changelogItem `json:"items"`
+	}
+
+	outGroups := make([]changelogGroup, 0, len(groupOrder))
+	for _, key := range groupOrder {
+		g := groups[key]
+		cg := changelogGroup{
+			Collection: g.Name,
+			Icon:       g.Icon,
+			Count:      len(g.Items),
+			Items:      make([]changelogItem, 0, len(g.Items)),
+		}
+		for _, item := range g.Items {
+			cg.Items = append(cg.Items, changelogItem{
+				Ref:    itemRefFromMap(item),
+				Title:  itemTitleFromMap(item),
+				Status: extractItemFieldString(item, "status"),
+			})
+		}
+		outGroups = append(outGroups, cg)
+	}
+
+	payload := map[string]any{
+		"period": periodLabel,
+		"since":  cutoff.Format("2006-01-02"),
+		"total":  len(allItems),
+		"groups": outGroups,
+	}
+	return packageStructuredResponse(cmdKey, payload)
+}
+
+// listWorkspaceItems issues an in-process GET against
+// /api/v1/workspaces/{ws}/items with the supplied query params and
+// returns the response decoded into []map[string]any. Used by
+// standup/changelog where iterating per-status keeps the dispatcher
+// from having to re-decode into a typed slice for every call.
+//
+// Returns a non-nil error on 4xx/5xx — the caller decides whether
+// to swallow (per-status best-effort, matching the CLI) or surface.
+func (d *HTTPHandlerDispatcher) listWorkspaceItems(
+	ctx context.Context,
+	user *models.User,
+	workspace string,
+	values url.Values,
+) ([]map[string]any, error) {
+	path := "/api/v1/workspaces/" + url.PathEscape(workspace) + "/items"
+	if encoded := values.Encode(); encoded != "" {
+		path += "?" + encoded
+	}
+	req, err := d.buildAuthedRequest(ctx, http.MethodGet, path, nil, user)
+	if err != nil {
+		return nil, fmt.Errorf("build items request: %w", err)
+	}
+	rec := httptest.NewRecorder()
+	d.Handler.ServeHTTP(rec, req)
+	if rec.Code >= 400 {
+		body := strings.TrimSpace(rec.Body.String())
+		if body == "" {
+			body = http.StatusText(rec.Code)
+		}
+		return nil, fmt.Errorf("list items: %d %s", rec.Code, body)
+	}
+	var items []map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &items); err != nil {
+		return nil, fmt.Errorf("parse items response: %w", err)
+	}
+	return items, nil
+}
+
+// itemUpdatedAfter compares an item's updated_at against cutoff,
+// returning true if the item is newer. The CLI parses updated_at as
+// RFC3339; we accept the same format. Items with malformed or
+// missing timestamps are excluded so a stale or partial response
+// can't fall through and pollute "completed" with everything.
+func itemUpdatedAfter(item map[string]any, cutoff time.Time) bool {
+	ts := stringFromMap(item, "updated_at")
+	if ts == "" {
+		return false
+	}
+	parsed, err := time.Parse(time.RFC3339, ts)
+	if err != nil {
+		// Accept the alternate "no fractional seconds" RFC3339Nano
+		// shape that some Go encoders emit. If this also fails,
+		// the item is excluded.
+		parsed, err = time.Parse(time.RFC3339Nano, ts)
+		if err != nil {
+			return false
+		}
+	}
+	return parsed.After(cutoff)
+}
+
+// itemMatchesParent mirrors the CLI's parent-filter matching:
+// case-insensitive comparison against the item's parent_link_id,
+// parent_ref, OR parent_title. Useful so an agent can pass either a
+// UUID, an issue ref like "PLAN-3", or the human-readable title and
+// have the filter match.
+func itemMatchesParent(item map[string]any, parent string) bool {
+	for _, key := range []string{"parent_link_id", "parent_ref", "parent_title"} {
+		if v := stringFromMap(item, key); v != "" && strings.EqualFold(v, parent) {
+			return true
+		}
+	}
+	return false
+}
+
+// extractItemFieldString pulls a value out of an item's `fields`
+// JSON-string. Mirrors cmd/pad/main.go's extractFieldFromJSON helper.
+// Used by standup/changelog to surface status / priority into the
+// flattened output without forcing the agent to parse the fields
+// blob themselves.
+func extractItemFieldString(item map[string]any, key string) string {
+	raw := stringFromMap(item, "fields")
+	if raw == "" || raw == "{}" {
+		return ""
+	}
+	var fields map[string]any
+	if err := json.Unmarshal([]byte(raw), &fields); err != nil {
+		return ""
+	}
+	if v, ok := fields[key].(string); ok {
+		return v
+	}
+	return ""
+}
+
+// itemRefFromMap returns "TASK-5"-style refs for items that carry
+// collection_prefix + item_number, matching cli.ItemRef. Used in
+// changelog/standup output where the user-visible identifier is
+// preferred over the slug.
+func itemRefFromMap(item map[string]any) string {
+	prefix := stringFromMap(item, "collection_prefix")
+	if prefix == "" {
+		return ""
+	}
+	switch v := item["item_number"].(type) {
+	case nil:
+		return ""
+	case float64:
+		return fmt.Sprintf("%s-%d", prefix, int64(v))
+	case int:
+		return fmt.Sprintf("%s-%d", prefix, v)
+	case int64:
+		return fmt.Sprintf("%s-%d", prefix, v)
+	case json.Number:
+		n, err := v.Int64()
+		if err != nil {
+			return ""
+		}
+		return fmt.Sprintf("%s-%d", prefix, n)
+	case string:
+		// Some encoders stringify integers; treat empty as missing.
+		if v == "" {
+			return ""
+		}
+		if n, err := strconv.ParseInt(v, 10, 64); err == nil {
+			return fmt.Sprintf("%s-%d", prefix, n)
+		}
+		return ""
+	default:
+		return ""
+	}
+}
+
+// itemTitleFromMap returns the item's human-readable title, falling
+// back to slug if title is unset (matches CLI behaviour for items
+// that may have only a slug populated in legacy paths).
+func itemTitleFromMap(item map[string]any) string {
+	if t := stringFromMap(item, "title"); t != "" {
+		return t
+	}
+	return stringFromMap(item, "slug")
+}
+
+// stringFromMap is a tiny helper that does the type-assert dance.
+// Returns the empty string for missing keys or non-string values so
+// callers can compose conditionals cleanly without nested asserts.
+func stringFromMap(m map[string]any, key string) string {
+	if v, ok := m[key].(string); ok {
+		return v
+	}
+	return ""
+}
+
+// --- library activate ---
+
+// dispatchLibraryActivate reproduces `pad library activate <title>`:
+// looks up a library entry by title (conventions first, then
+// playbooks — same precedence the CLI uses), builds the right
+// fields blob, and POSTs an item into the workspace's
+// conventions/playbooks collection.
+//
+// Library data is sourced from internal/collections directly rather
+// than via the /convention-library / /playbook-library endpoints.
+// Both paths return the same data (the handlers wrap the same
+// constants), and the in-process accessor avoids two extra HTTP
+// round-trips per activate. The OAuth-scope hook (d.Apply) still
+// runs on the eventual POST, so this isn't a scope bypass.
+//
+// Two minor divergences from the CLI:
+//
+//   - The CLI uses `models.BuildConventionItemFields` for
+//     conventions (deals with surfaces/enforcement/commands metadata)
+//     but builds the playbook fields by hand. We match exactly.
+//   - The CLI's "conventions" / "playbooks" target collection slugs
+//     are hardcoded; we do the same. Workspaces from non-software
+//     templates may not have these collections, in which case the
+//     POST will 404 — same UX the CLI delivers.
+func (d *HTTPHandlerDispatcher) dispatchLibraryActivate(
+	ctx context.Context,
+	input map[string]any,
+	user *models.User,
+) (*mcp.CallToolResult, error) {
+	const cmdKey = "library activate"
+	workspace, _ := input["workspace"].(string)
+	if workspace == "" {
+		return mcp.NewToolResultErrorf("%s: workspace is required", cmdKey), nil
+	}
+	title, _ := input["title"].(string)
+	if title == "" {
+		return mcp.NewToolResultErrorf("%s: title is required", cmdKey), nil
+	}
+
+	if conv := collections.GetLibraryConvention(title); conv != nil {
+		fieldsJSON, err := models.BuildConventionItemFields("active", &models.ItemConventionMetadata{
+			Category:    conv.Category,
+			Trigger:     conv.Trigger,
+			Surfaces:    conv.Surfaces,
+			Enforcement: conv.Enforcement,
+			Commands:    conv.Commands,
+		})
+		if err != nil {
+			return mcp.NewToolResultErrorf("%s: build convention fields: %s", cmdKey, err.Error()), nil
+		}
+		return d.postLibraryItem(ctx, user, workspace, "conventions", cmdKey, conv.Title, conv.Content, fieldsJSON)
+	}
+
+	if pb := collections.GetLibraryPlaybook(title); pb != nil {
+		fields := map[string]any{
+			"status":  "active",
+			"trigger": pb.Trigger,
+			"scope":   pb.Scope,
+		}
+		fieldsJSON, err := json.Marshal(fields)
+		if err != nil {
+			return mcp.NewToolResultErrorf("%s: encode playbook fields: %s", cmdKey, err.Error()), nil
+		}
+		return d.postLibraryItem(ctx, user, workspace, "playbooks", cmdKey, pb.Title, pb.Content, string(fieldsJSON))
+	}
+
+	return mcp.NewToolResultErrorf(
+		"%s: not found in convention or playbook library: %q", cmdKey, title,
+	), nil
+}
+
+// postLibraryItem POSTs an ItemCreate body into the named
+// collection's items endpoint. Shared between conventions /
+// playbooks branches of dispatchLibraryActivate so the URL +
+// envelope shape stays in lockstep.
+func (d *HTTPHandlerDispatcher) postLibraryItem(
+	ctx context.Context,
+	user *models.User,
+	workspace, collection, cmdKey, title, content, fieldsJSON string,
+) (*mcp.CallToolResult, error) {
+	payload := map[string]any{
+		"title":  title,
+		"fields": fieldsJSON,
+	}
+	if content != "" {
+		payload["content"] = content
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return mcp.NewToolResultErrorf("%s: encode body: %s", cmdKey, err.Error()), nil
+	}
+	urlPath := "/api/v1/workspaces/" + url.PathEscape(workspace) +
+		"/collections/" + url.PathEscape(collection) + "/items"
+	return d.executeRequest(ctx, cmdKey, user, http.MethodPost, urlPath, body)
+}

--- a/internal/mcp/dispatch_http_slice4_test.go
+++ b/internal/mcp/dispatch_http_slice4_test.go
@@ -1,0 +1,588 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// --- project standup ---
+
+func TestDispatch_ProjectStandup_BuildsExpectedShape(t *testing.T) {
+	// One completed item, one in-progress, one blocker (dashboard
+	// attention), one suggested-next. Verify the response shape
+	// matches the CLI's standupCmd JSON branch.
+	now := time.Now().UTC()
+	yesterday := now.Add(-12 * time.Hour).Format(time.RFC3339)
+	weekAgo := now.Add(-7 * 24 * time.Hour).Format(time.RFC3339)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/workspaces/docapp/dashboard", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"attention":[{"item_title":"Blocked task","reason":"waiting on review"}],
+			"suggested_next":[{"item_title":"Next thing","reason":"top priority"}]
+		}`))
+	})
+	mux.HandleFunc("/api/v1/workspaces/docapp/items", func(w http.ResponseWriter, r *http.Request) {
+		status := r.URL.Query().Get("status")
+		w.Header().Set("Content-Type", "application/json")
+		switch status {
+		case "done":
+			_, _ = w.Write([]byte(`[
+				{"collection_prefix":"TASK","item_number":1,"title":"Recently done","collection_slug":"tasks","fields":"{\"status\":\"done\"}","updated_at":"` + yesterday + `"},
+				{"collection_prefix":"TASK","item_number":99,"title":"Old done","collection_slug":"tasks","fields":"{\"status\":\"done\"}","updated_at":"` + weekAgo + `"}
+			]`))
+		case "in-progress":
+			_, _ = w.Write([]byte(`[
+				{"collection_prefix":"TASK","item_number":2,"title":"Working","collection_slug":"tasks","fields":"{\"priority\":\"high\"}","updated_at":"` + yesterday + `"}
+			]`))
+		default:
+			_, _ = w.Write([]byte(`[]`))
+		}
+	})
+
+	d := &HTTPHandlerDispatcher{Handler: mux, UserResolver: fixedUserResolver(&models.User{ID: "u"})}
+	res, err := d.Dispatch(
+		WithDispatchInput(context.Background(), map[string]any{
+			"workspace": "docapp",
+			"days":      float64(1),
+		}),
+		[]string{"project", "standup"}, nil,
+	)
+	if err != nil || res.IsError {
+		t.Fatalf("Dispatch err=%v IsError=%v: %#v", err, res != nil && res.IsError, res)
+	}
+	payload, ok := res.StructuredContent.(map[string]any)
+	if !ok {
+		t.Fatalf("not structured: %#v", res.StructuredContent)
+	}
+	if payload["days"].(float64) != 1 {
+		t.Errorf("days = %v, want 1", payload["days"])
+	}
+	if _, ok := payload["date"].(string); !ok {
+		t.Errorf("date should be a string: %v", payload["date"])
+	}
+	completed, _ := payload["completed"].([]any)
+	if len(completed) != 1 {
+		t.Errorf("completed should have 1 entry (old item filtered by cutoff); got %d", len(completed))
+	} else {
+		entry := completed[0].(map[string]any)
+		if entry["ref"] != "TASK-1" {
+			t.Errorf("completed[0].ref = %v", entry["ref"])
+		}
+		if entry["status"] != "done" {
+			t.Errorf("completed[0].status = %v", entry["status"])
+		}
+	}
+	inProgress, _ := payload["in_progress"].([]any)
+	if len(inProgress) != 1 {
+		t.Fatalf("in_progress length = %d, want 1", len(inProgress))
+	}
+	ipEntry := inProgress[0].(map[string]any)
+	if ipEntry["priority"] != "high" {
+		t.Errorf("in_progress priority = %v", ipEntry["priority"])
+	}
+	blockers, _ := payload["blockers"].([]any)
+	if len(blockers) != 1 || blockers[0].(map[string]any)["title"] != "Blocked task" {
+		t.Errorf("blockers unexpected: %v", blockers)
+	}
+	suggested, _ := payload["suggested_next"].([]any)
+	if len(suggested) != 1 || suggested[0].(map[string]any)["title"] != "Next thing" {
+		t.Errorf("suggested_next unexpected: %v", suggested)
+	}
+}
+
+func TestDispatch_ProjectStandup_DefaultsDaysToOne(t *testing.T) {
+	// CLI default for --days is 1. Without input, dispatcher must
+	// apply that default rather than zeroing the cutoff (which
+	// would surface every terminal-status item ever).
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/workspaces/docapp/dashboard", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{}`))
+	})
+	mux.HandleFunc("/api/v1/workspaces/docapp/items", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`[]`))
+	})
+	d := &HTTPHandlerDispatcher{Handler: mux, UserResolver: fixedUserResolver(&models.User{ID: "u"})}
+	res, err := d.Dispatch(
+		WithDispatchInput(context.Background(), map[string]any{"workspace": "docapp"}),
+		[]string{"project", "standup"}, nil,
+	)
+	if err != nil || res.IsError {
+		t.Fatalf("Dispatch err=%v IsError=%v: %#v", err, res != nil && res.IsError, res)
+	}
+	payload, _ := res.StructuredContent.(map[string]any)
+	if payload["days"].(float64) != 1 {
+		t.Errorf("default days = %v, want 1", payload["days"])
+	}
+}
+
+func TestDispatch_ProjectStandup_RequiresWorkspace(t *testing.T) {
+	d := &HTTPHandlerDispatcher{
+		Handler:      errorHandler(t, "must not be called when workspace missing"),
+		UserResolver: fixedUserResolver(&models.User{ID: "u"}),
+	}
+	res, err := d.Dispatch(
+		WithDispatchInput(context.Background(), map[string]any{}),
+		[]string{"project", "standup"}, nil,
+	)
+	if err != nil {
+		t.Fatalf("Dispatch err: %v", err)
+	}
+	if !res.IsError {
+		t.Errorf("expected IsError when workspace missing")
+	}
+}
+
+// --- project changelog ---
+
+func TestDispatch_ProjectChangelog_GroupsByCollection(t *testing.T) {
+	now := time.Now().UTC()
+	recent := now.Add(-2 * 24 * time.Hour).Format(time.RFC3339)
+	stale := now.Add(-30 * 24 * time.Hour).Format(time.RFC3339)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/workspaces/docapp/items", func(w http.ResponseWriter, r *http.Request) {
+		status := r.URL.Query().Get("status")
+		w.Header().Set("Content-Type", "application/json")
+		switch status {
+		case "done":
+			_, _ = w.Write([]byte(`[
+				{"collection_prefix":"TASK","item_number":1,"title":"Recent task","collection_slug":"tasks","collection_name":"Tasks","collection_icon":"📋","fields":"{\"status\":\"done\"}","updated_at":"` + recent + `"},
+				{"collection_prefix":"TASK","item_number":99,"title":"Old task","collection_slug":"tasks","fields":"{\"status\":\"done\"}","updated_at":"` + stale + `"}
+			]`))
+		case "completed":
+			_, _ = w.Write([]byte(`[
+				{"collection_prefix":"DOC","item_number":3,"title":"Recent doc","collection_slug":"docs","collection_name":"Docs","collection_icon":"📄","fields":"{\"status\":\"completed\"}","updated_at":"` + recent + `"}
+			]`))
+		default:
+			_, _ = w.Write([]byte(`[]`))
+		}
+	})
+
+	d := &HTTPHandlerDispatcher{Handler: mux, UserResolver: fixedUserResolver(&models.User{ID: "u"})}
+	res, err := d.Dispatch(
+		WithDispatchInput(context.Background(), map[string]any{
+			"workspace": "docapp",
+			"days":      float64(7),
+		}),
+		[]string{"project", "changelog"}, nil,
+	)
+	if err != nil || res.IsError {
+		t.Fatalf("Dispatch err=%v IsError=%v: %#v", err, res != nil && res.IsError, res)
+	}
+	payload, _ := res.StructuredContent.(map[string]any)
+	if payload["total"].(float64) != 2 {
+		t.Errorf("total = %v, want 2 (old item filtered)", payload["total"])
+	}
+	if !strings.Contains(payload["period"].(string), "last 7 days") {
+		t.Errorf("period = %v", payload["period"])
+	}
+	groups, _ := payload["groups"].([]any)
+	if len(groups) != 2 {
+		t.Fatalf("groups length = %d, want 2 (tasks + docs)", len(groups))
+	}
+	// Both groups should appear; map first-seen ordering is
+	// deterministic per the dispatcher's groupOrder slice.
+	gotCollections := map[string]bool{}
+	for _, g := range groups {
+		gm := g.(map[string]any)
+		gotCollections[gm["collection"].(string)] = true
+		if gm["count"].(float64) != 1 {
+			t.Errorf("group %v count = %v, want 1", gm["collection"], gm["count"])
+		}
+	}
+	if !gotCollections["Tasks"] || !gotCollections["Docs"] {
+		t.Errorf("expected Tasks + Docs groups; got %v", gotCollections)
+	}
+}
+
+func TestDispatch_ProjectChangelog_SinceOverridesDays(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/workspaces/docapp/items", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`[]`))
+	})
+	d := &HTTPHandlerDispatcher{Handler: mux, UserResolver: fixedUserResolver(&models.User{ID: "u"})}
+	res, err := d.Dispatch(
+		WithDispatchInput(context.Background(), map[string]any{
+			"workspace": "docapp",
+			"days":      float64(7), // ignored when --since set
+			"since":     "2025-01-01",
+		}),
+		[]string{"project", "changelog"}, nil,
+	)
+	if err != nil || res.IsError {
+		t.Fatalf("Dispatch err=%v IsError=%v: %#v", err, res != nil && res.IsError, res)
+	}
+	payload, _ := res.StructuredContent.(map[string]any)
+	if payload["since"] != "2025-01-01" {
+		t.Errorf("since = %v, want 2025-01-01 (must use --since over --days)", payload["since"])
+	}
+	if !strings.Contains(payload["period"].(string), "since 2025-01-01") {
+		t.Errorf("period label should reflect --since: %v", payload["period"])
+	}
+}
+
+func TestDispatch_ProjectChangelog_FiltersByParent(t *testing.T) {
+	now := time.Now().UTC()
+	recent := now.Add(-1 * 24 * time.Hour).Format(time.RFC3339)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/workspaces/docapp/items", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Query().Get("status") == "done" {
+			_, _ = w.Write([]byte(`[
+				{"collection_prefix":"TASK","item_number":1,"title":"In plan","collection_slug":"tasks","fields":"{}","updated_at":"` + recent + `","parent_ref":"PLAN-3"},
+				{"collection_prefix":"TASK","item_number":2,"title":"Outside plan","collection_slug":"tasks","fields":"{}","updated_at":"` + recent + `","parent_ref":"PLAN-99"}
+			]`))
+			return
+		}
+		_, _ = w.Write([]byte(`[]`))
+	})
+	d := &HTTPHandlerDispatcher{Handler: mux, UserResolver: fixedUserResolver(&models.User{ID: "u"})}
+	res, err := d.Dispatch(
+		WithDispatchInput(context.Background(), map[string]any{
+			"workspace": "docapp",
+			"parent":    "PLAN-3",
+		}),
+		[]string{"project", "changelog"}, nil,
+	)
+	if err != nil || res.IsError {
+		t.Fatalf("Dispatch err=%v IsError=%v: %#v", err, res != nil && res.IsError, res)
+	}
+	payload, _ := res.StructuredContent.(map[string]any)
+	if payload["total"].(float64) != 1 {
+		t.Errorf("total = %v, want 1 (only PLAN-3 child)", payload["total"])
+	}
+	if !strings.Contains(payload["period"].(string), "parent: PLAN-3") {
+		t.Errorf("period label should mention parent: %v", payload["period"])
+	}
+}
+
+func TestDispatch_ProjectChangelog_RejectsBadSinceDate(t *testing.T) {
+	d := &HTTPHandlerDispatcher{
+		Handler:      errorHandler(t, "must not be called for invalid since"),
+		UserResolver: fixedUserResolver(&models.User{ID: "u"}),
+	}
+	res, err := d.Dispatch(
+		WithDispatchInput(context.Background(), map[string]any{
+			"workspace": "docapp",
+			"since":     "not-a-date",
+		}),
+		[]string{"project", "changelog"}, nil,
+	)
+	if err != nil {
+		t.Fatalf("Dispatch err: %v", err)
+	}
+	if !res.IsError {
+		t.Errorf("expected IsError for malformed --since")
+	}
+	if !containsToolText(res, "invalid --since") {
+		t.Errorf("error should mention invalid --since: %#v", res)
+	}
+}
+
+// --- library activate ---
+
+func TestDispatch_LibraryActivate_ConventionByTitle(t *testing.T) {
+	// Pick a known convention from the seed library — tied to the
+	// convention_library.go constants.
+	const wantTitle = "Conventional commit format"
+
+	mux := http.NewServeMux()
+	posted := ""
+	mux.HandleFunc("/api/v1/workspaces/docapp/collections/conventions/items", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST; got %s", r.Method)
+		}
+		buf := make([]byte, r.ContentLength)
+		_, _ = r.Body.Read(buf)
+		posted = string(buf)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"id":"item-1","title":"Conventional commit format"}`))
+	})
+	// Playbook endpoint MUST NOT be hit (we found a convention).
+	mux.HandleFunc("/api/v1/workspaces/docapp/collections/playbooks/items", func(_ http.ResponseWriter, _ *http.Request) {
+		t.Errorf("playbook endpoint should not be hit when convention matches")
+	})
+
+	d := &HTTPHandlerDispatcher{Handler: mux, UserResolver: fixedUserResolver(&models.User{ID: "u"})}
+	res, err := d.Dispatch(
+		WithDispatchInput(context.Background(), map[string]any{
+			"workspace": "docapp",
+			"title":     wantTitle,
+		}),
+		[]string{"library", "activate"}, nil,
+	)
+	if err != nil || res.IsError {
+		t.Fatalf("Dispatch err=%v IsError=%v: %#v", err, res != nil && res.IsError, res)
+	}
+	var got map[string]any
+	if err := json.Unmarshal([]byte(posted), &got); err != nil {
+		t.Fatalf("decode posted body: %v\n%s", err, posted)
+	}
+	if got["title"] != wantTitle {
+		t.Errorf("posted title = %v, want %v", got["title"], wantTitle)
+	}
+	// Convention fields must include the canonical metadata.
+	fieldsStr, _ := got["fields"].(string)
+	var fields map[string]any
+	if err := json.Unmarshal([]byte(fieldsStr), &fields); err != nil {
+		t.Fatalf("decode fields: %v", err)
+	}
+	if fields["status"] != "active" {
+		t.Errorf("status = %v, want active", fields["status"])
+	}
+	if fields["category"] != "git" {
+		t.Errorf("category = %v, want git (from seed library)", fields["category"])
+	}
+	if fields["trigger"] != "on-commit" {
+		t.Errorf("trigger = %v, want on-commit", fields["trigger"])
+	}
+}
+
+func TestDispatch_LibraryActivate_PlaybookByTitle_FallsThroughConventionLookup(t *testing.T) {
+	// A playbook title — the dispatcher should NOT find it in
+	// conventions, then fall through to the playbook library.
+	const wantTitle = "Implementation Workflow"
+
+	mux := http.NewServeMux()
+	posted := ""
+	mux.HandleFunc("/api/v1/workspaces/docapp/collections/playbooks/items", func(w http.ResponseWriter, r *http.Request) {
+		buf := make([]byte, r.ContentLength)
+		_, _ = r.Body.Read(buf)
+		posted = string(buf)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"id":"pb-1","title":"Implementation Workflow"}`))
+	})
+
+	d := &HTTPHandlerDispatcher{Handler: mux, UserResolver: fixedUserResolver(&models.User{ID: "u"})}
+	res, err := d.Dispatch(
+		WithDispatchInput(context.Background(), map[string]any{
+			"workspace": "docapp",
+			"title":     wantTitle,
+		}),
+		[]string{"library", "activate"}, nil,
+	)
+	if err != nil || res.IsError {
+		t.Fatalf("Dispatch err=%v IsError=%v: %#v", err, res != nil && res.IsError, res)
+	}
+	var got map[string]any
+	if err := json.Unmarshal([]byte(posted), &got); err != nil {
+		t.Fatalf("decode posted body: %v\n%s", err, posted)
+	}
+	if got["title"] != wantTitle {
+		t.Errorf("posted title = %v", got["title"])
+	}
+	fieldsStr, _ := got["fields"].(string)
+	var fields map[string]any
+	if err := json.Unmarshal([]byte(fieldsStr), &fields); err != nil {
+		t.Fatalf("decode fields: %v", err)
+	}
+	if fields["status"] != "active" {
+		t.Errorf("status = %v, want active", fields["status"])
+	}
+	if _, ok := fields["trigger"]; !ok {
+		t.Errorf("playbook fields should include trigger: %v", fields)
+	}
+	if _, ok := fields["scope"]; !ok {
+		t.Errorf("playbook fields should include scope: %v", fields)
+	}
+}
+
+func TestDispatch_LibraryActivate_NotFoundReturnsError(t *testing.T) {
+	d := &HTTPHandlerDispatcher{
+		Handler:      errorHandler(t, "must not POST when title is unmatched"),
+		UserResolver: fixedUserResolver(&models.User{ID: "u"}),
+	}
+	res, err := d.Dispatch(
+		WithDispatchInput(context.Background(), map[string]any{
+			"workspace": "docapp",
+			"title":     "NoSuchLibraryEntryEverShouldExist",
+		}),
+		[]string{"library", "activate"}, nil,
+	)
+	if err != nil {
+		t.Fatalf("Dispatch err: %v", err)
+	}
+	if !res.IsError {
+		t.Errorf("expected IsError when title not in either library")
+	}
+	if !containsToolText(res, "not found in convention or playbook library") {
+		t.Errorf("error should mention library lookup; got %#v", res)
+	}
+}
+
+func TestDispatch_LibraryActivate_RequiresWorkspaceAndTitle(t *testing.T) {
+	d := &HTTPHandlerDispatcher{
+		Handler:      errorHandler(t, "must not POST when args missing"),
+		UserResolver: fixedUserResolver(&models.User{ID: "u"}),
+	}
+	for _, missing := range []string{"workspace", "title"} {
+		t.Run("missing-"+missing, func(t *testing.T) {
+			input := map[string]any{
+				"workspace": "docapp", "title": "Anything",
+			}
+			delete(input, missing)
+			res, err := d.Dispatch(
+				WithDispatchInput(context.Background(), input),
+				[]string{"library", "activate"}, nil,
+			)
+			if err != nil {
+				t.Fatalf("Dispatch err: %v", err)
+			}
+			if !res.IsError {
+				t.Errorf("expected IsError when %s missing", missing)
+			}
+		})
+	}
+}
+
+// --- Helpers around stringFromMap / itemRefFromMap / extractItemFieldString ---
+
+func TestItemRefFromMap_NumericFormVariants(t *testing.T) {
+	cases := []struct {
+		name   string
+		number any
+		want   string
+	}{
+		{"float64 (typical)", float64(5), "TASK-5"},
+		{"int", 42, "TASK-42"},
+		{"int64", int64(99), "TASK-99"},
+		{"json.Number", json.Number("7"), "TASK-7"},
+		{"missing", nil, ""},
+		{"non-numeric string", "abc", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := itemRefFromMap(map[string]any{
+				"collection_prefix": "TASK",
+				"item_number":       tc.number,
+			})
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestItemRefFromMap_NoPrefixReturnsEmpty(t *testing.T) {
+	if got := itemRefFromMap(map[string]any{"item_number": float64(5)}); got != "" {
+		t.Errorf("expected empty string when collection_prefix missing; got %q", got)
+	}
+}
+
+func TestExtractItemFieldString_HandlesEmptyAndMalformedJSON(t *testing.T) {
+	cases := []struct {
+		fields string
+		want   string
+	}{
+		{"", ""},
+		{"{}", ""},
+		{"not json", ""},
+		{`{"status":"done"}`, "done"},
+		{`{"status":42}`, ""}, // wrong type → empty
+	}
+	for _, tc := range cases {
+		t.Run(tc.fields, func(t *testing.T) {
+			got := extractItemFieldString(map[string]any{"fields": tc.fields}, "status")
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestItemMatchesParent_CaseInsensitiveAcrossThreeFields(t *testing.T) {
+	item := map[string]any{
+		"parent_link_id": "abc-uuid",
+		"parent_ref":     "PLAN-3",
+		"parent_title":   "API Redesign",
+	}
+	if !itemMatchesParent(item, "ABC-UUID") {
+		t.Errorf("uppercase UUID should match parent_link_id")
+	}
+	if !itemMatchesParent(item, "plan-3") {
+		t.Errorf("lowercase ref should match parent_ref")
+	}
+	if !itemMatchesParent(item, "api redesign") {
+		t.Errorf("lowercase title should match parent_title")
+	}
+	if itemMatchesParent(item, "OTHER") {
+		t.Errorf("unrelated value should not match")
+	}
+	// Empty parent never matches even when an item has an empty value
+	// (defensive — caller is expected to gate on parentFilter != "").
+	emptyItem := map[string]any{"parent_ref": ""}
+	if itemMatchesParent(emptyItem, "") {
+		t.Errorf("empty value should not falsely match")
+	}
+}
+
+// --- Integration smoke ---
+
+func TestHTTPHandlerDispatcher_Integration_Slice4(t *testing.T) {
+	srv, st := newPadServer(t)
+
+	wsRec := doJSONReq(t, srv, http.MethodPost, "/api/v1/workspaces",
+		map[string]any{"name": "DocApp"})
+	if wsRec.Code != http.StatusCreated {
+		t.Fatalf("create workspace: %d %s", wsRec.Code, wsRec.Body.String())
+	}
+	var ws models.Workspace
+	if err := json.Unmarshal(wsRec.Body.Bytes(), &ws); err != nil {
+		t.Fatalf("decode workspace: %v", err)
+	}
+	owner, err := st.CreateUser(models.UserCreate{Email: "dave@example.com", Name: "Dave", Password: "x"})
+	if err != nil {
+		t.Fatalf("create owner: %v", err)
+	}
+	if err := st.AddWorkspaceMember(ws.ID, owner.ID, "owner"); err != nil {
+		t.Fatalf("add owner: %v", err)
+	}
+
+	d := &HTTPHandlerDispatcher{Handler: srv, UserResolver: fixedUserResolver(owner)}
+
+	// project standup against a fresh workspace — should not 500
+	// even though there's no completed work.
+	standupRes, err := d.Dispatch(
+		WithDispatchInput(context.Background(), map[string]any{"workspace": ws.Slug}),
+		[]string{"project", "standup"}, nil,
+	)
+	if err != nil || standupRes.IsError {
+		t.Fatalf("standup: err=%v IsError=%v: %#v", err, standupRes != nil && standupRes.IsError, standupRes)
+	}
+
+	// project changelog same — empty workspace, no error.
+	clRes, err := d.Dispatch(
+		WithDispatchInput(context.Background(), map[string]any{"workspace": ws.Slug}),
+		[]string{"project", "changelog"}, nil,
+	)
+	if err != nil || clRes.IsError {
+		t.Fatalf("changelog: err=%v IsError=%v: %#v", err, clRes != nil && clRes.IsError, clRes)
+	}
+
+	// library activate with a known seed convention. The default
+	// "startup" template seeds Conventions; this should succeed.
+	actRes, err := d.Dispatch(
+		WithDispatchInput(context.Background(), map[string]any{
+			"workspace": ws.Slug,
+			"title":     "Conventional commit format",
+		}),
+		[]string{"library", "activate"}, nil,
+	)
+	if err != nil || actRes.IsError {
+		t.Fatalf("library activate: err=%v IsError=%v: %#v", err, actRes != nil && actRes.IsError, actRes)
+	}
+	created, _ := actRes.StructuredContent.(map[string]any)
+	if title, _ := created["title"].(string); title != "Conventional commit format" {
+		t.Errorf("activated item title = %v", title)
+	}
+}


### PR DESCRIPTION
## Summary

Continues PLAN-943 / TASK-968 past PR #348. Three more commands wired — the last of the project-intelligence + library composition surfaces.

### New commands

- **`project standup`** — multi-call composition: GET `/dashboard` + per-terminal-status `/items` lists + `/items?status=in-progress`. Filters completed by `--days` cutoff (default 1) client-side. Returns `{date, days, completed, in_progress, blockers, suggested_next}` matching CLI `--format json` exactly.
- **`project changelog`** — multi-call: iterates terminal statuses, filters by date (`--since` YYYY-MM-DD overrides `--days`, default 7) and parent (`--parent` matches case-insensitively across `parent_link_id` / `parent_ref` / `parent_title`). Groups by `collection_slug` with stable first-seen ordering.
- **`library activate`** — looks up by title via `internal/collections.GetLibraryConvention` / `GetLibraryPlaybook` (avoids two HTTP round-trips for static data; OAuth-scope hook still applies on the eventual POST). Builds canonical fields via `models.BuildConventionItemFields` for conventions, `{status, trigger, scope}` for playbooks. POSTs into the workspace's conventions/playbooks collection.

### Helper consolidation

The standup + changelog code shares small map-based helpers (`listWorkspaceItems`, `itemUpdatedAfter`, `itemMatchesParent`, `itemRefFromMap`, `itemTitleFromMap`, `extractItemFieldString`, `stringFromMap`) so future composition commands have a clean substrate. Operates on `map[string]any` not typed structs — same forward-compat approach the slice 3 fix introduced after Codex caught a typed-struct dropping `dashboard.attention.collection`.

## Context

Implements `TASK-968` under `PLAN-943`. **Cumulative: 36 of ~50 commands wired** across PRs #346, #347, #348, this PR. Remaining: **attachments (5 commands, multipart bodies — separate PR).**

## Test plan

- [x] `make check` — golangci-lint + Go tests + web build all clean
- [x] Standup: shape pinned + cutoff filter + `--days` default to 1
- [x] Changelog: collection grouping/count + `--since` overrides `--days` + parent filter + bad-since rejection
- [x] Library activate: convention path + playbook fallthrough + not-found error + missing-input rejection
- [x] Helper coverage: `itemRefFromMap` numeric form variants, `extractItemFieldString` malformed JSON, `itemMatchesParent` case-insensitive across three fields
- [x] Integration smoke: standup + changelog (empty workspace) + library activate ("Conventional commit format" from seed library) against real `*server.Server`