### PR TITLE
feat(mcp): attachment list + show; reject upload/download/view as CLI-only (TASK-968 final slice)

### DIFF
--- a/internal/mcp/dispatch_http.go
+++ b/internal/mcp/dispatch_http.go
@@ -134,38 +134,48 @@ var commandsAcceptingRoleBySlug = map[string]struct{}{
 // noRemoteEquivalent enumerates leaf commands that have no useful
 // HTTP-transport mapping because they mutate or inspect local state
 // only — config files, MCP-client mcp.json entries, the local server
-// process, the local git checkout. Distinct from "not yet implemented
-// over HTTP transport" because those will eventually land; these never
+// process, the local git checkout, the local filesystem path
+// arguments (attachments). Distinct from "not yet implemented over
+// HTTP transport" because those will eventually land; these never
 // will.
 //
+// The map value is a rationale clause appended to the error message,
+// giving agents a hint about why the command is local-only AND what
+// the alternative path is (when there is one — e.g. attachments
+// suggest fetching bytes via the URL directly + using `attachment
+// show` for metadata).
+//
 // Surfacing the distinction lets agents recognize-and-skip rather
-// than retrying or escalating. The error message is stable so
-// downstream tooling can match on it if needed.
-var noRemoteEquivalent = map[string]struct{}{
-	"agent status":      {}, // local skill-detection (~/.claude/, etc.)
-	"mcp status":        {}, // local mcp.json across MCP clients
-	"mcp uninstall":     {}, // local mcp.json mutation
-	"server info":       {}, // local pad-server process state
-	"server open":       {}, // local browser launch
-	"workspace link":    {}, // local .pad.toml mutation
-	"workspace switch":  {}, // local .pad.toml mutation
-	"workspace context": {}, // local .pad.toml inspection
+// than retrying or escalating. The "no remote equivalent" prefix is
+// stable so downstream tooling can match on it if needed.
+var noRemoteEquivalent = map[string]string{
+	"agent status":      "operates on local skill-detection state (~/.claude/, etc.), not the workspace",
+	"mcp status":        "inspects local mcp.json across MCP clients, not the workspace",
+	"mcp uninstall":     "mutates local mcp.json, not the workspace",
+	"server info":       "reports local pad-server process state, not workspace data",
+	"server open":       "launches a local browser, not a workspace operation",
+	"workspace link":    "mutates local .pad.toml, not workspace state",
+	"workspace switch":  "mutates local .pad.toml, not workspace state",
+	"workspace context": "inspects local .pad.toml, not workspace state",
 	// `github` commands chain `git rev-parse` + `gh` CLI for the
 	// branch/PR data they write to the linked item — that data
 	// inherently lives in the agent's local checkout, not on
-	// pad-cloud. A remote MCP would have no way to query it. Agents
-	// that want this functionality should use their own GitHub /
-	// shell tools to fetch PR data and then pass it through `item
-	// update --field github_pr=...`.
-	"github link":   {},
-	"github status": {},
-	"github unlink": {},
+	// pad-cloud. Agents with their own GitHub tools can update items
+	// via `item update --field github_pr=...` once they have the data.
+	"github link":   "needs the agent's local git branch + `gh` CLI; agents pass PR data via `item update --field github_pr=...`",
+	"github status": "needs the agent's local git branch + `gh` CLI; query GitHub directly via the agent's tools",
+	"github unlink": "needs the agent's local git branch + `gh` CLI; clear PR data via `item update --field github_pr=null`",
 	// `project reconcile` shells out to `gh` CLI to compare stored
-	// PR metadata against live GitHub state — same locality argument
-	// as the github commands. Agents that want this functionality
-	// have their own GitHub tools and can update items via
-	// `item update --field github_pr=...`.
-	"project reconcile": {},
+	// PR metadata against live GitHub state — same locality argument.
+	"project reconcile": "shells out to `gh` CLI to compare stored PR metadata against live GitHub state; agents reconcile via their own GitHub tools + `item update`",
+	// Attachment commands that take a local filesystem `<path>` /
+	// `<out-path>` argument — agents on a remote MCP server have no
+	// shared filesystem. Metadata commands (list, show) are wired;
+	// upload/download/view are not because the path argument is
+	// fundamentally local.
+	"attachment upload":   "needs a local filesystem `<path>` arg; agents fetch raw bytes via the attachment URL directly (see `attachment show` for metadata)",
+	"attachment download": "writes to a local filesystem `<out-path>`; agents read raw bytes via the attachment URL directly (see `attachment show` for metadata)",
+	"attachment view":     "writes to a local filesystem path and prints it; agents read raw bytes via the attachment URL directly (see `attachment show` for metadata)",
 }
 
 // Dispatch satisfies the Dispatcher interface. cliArgs are accepted
@@ -202,12 +212,13 @@ func (d *HTTPHandlerDispatcher) Dispatch(ctx context.Context, cmdPath, _ []strin
 	// message. These never get an HTTP mapping — the action is
 	// inherently local-state-only — so failing fast saves agents the
 	// retry-or-escalate cycle they'd run on a "not yet implemented"
-	// reply.
-	if _, local := noRemoteEquivalent[cmdKey]; local {
+	// reply. The rationale clause from noRemoteEquivalent gives the
+	// agent a hint about WHY (and, for the github / attachment
+	// commands, the alternative path).
+	if rationale, local := noRemoteEquivalent[cmdKey]; local {
 		return mcp.NewToolResultErrorf(
-			"%s: no remote equivalent — CLI-only command "+
-				"(operates on local pad client / config state, not the workspace)",
-			cmdKey,
+			"%s: no remote equivalent — CLI-only command (%s)",
+			cmdKey, rationale,
 		), nil
 	}
 
@@ -280,6 +291,10 @@ func (d *HTTPHandlerDispatcher) Dispatch(ctx context.Context, cmdPath, _ []strin
 		return d.dispatchLibraryList(ctx, input, user)
 	case "library activate":
 		return d.dispatchLibraryActivate(ctx, input, user)
+	case "attachment list":
+		return d.dispatchAttachmentList(ctx, input, user)
+	case "attachment show":
+		return d.dispatchAttachmentShow(ctx, input, user)
 	}
 
 	// Item link create/delete commands. The asymmetry between which

--- a/internal/mcp/dispatch_http_attachments.go
+++ b/internal/mcp/dispatch_http_attachments.go
@@ -2,9 +2,11 @@ package mcp
 
 import (
 	"context"
+	goMime "mime"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -169,37 +171,32 @@ func (d *HTTPHandlerDispatcher) dispatchAttachmentShow(
 
 // parseAttachmentFilename extracts the filename from a
 // Content-Disposition header. Mirrors the CLI's helper of the same
-// name (cmd/pad/main.go) — handles both the bare `filename=value` and
-// the URL-encoded `filename*=UTF-8”value` forms.
+// name (cmd/pad/main.go parseAttachmentFilename): defers to
+// mime.ParseMediaType so quoted filenames containing semicolons —
+// like `attachment; filename="a;b.png"` — round-trip correctly.
+// A naive `strings.Split(";")` here would chop the filename at the
+// first internal `;` and silently corrupt the result (Codex review
+// on PR #350 caught this).
 //
-// Reproduced here rather than imported because the CLI's helper is
-// in package main and not callable from internal/mcp.
+// Returns filepath.Base(name) so a server-emitted path-like value
+// can't escape into a directory traversal — same defensive base
+// the CLI applies even though the server is supposed to sanitize
+// before emitting the header.
+//
+// mime.ParseMediaType handles BOTH the bare `filename="value"` and
+// the RFC 5987 `filename*=UTF-8”<urlencoded>` forms automatically;
+// we don't need to special-case either.
 func parseAttachmentFilename(header string) string {
 	if header == "" {
 		return ""
 	}
-	// Prefer the RFC 5987 `filename*=UTF-8''<urlencoded>` form when
-	// present — it's the spec-compliant carrier for non-ASCII names.
-	const filenameStarPrefix = "filename*=UTF-8''"
-	for _, part := range strings.Split(header, ";") {
-		part = strings.TrimSpace(part)
-		if strings.HasPrefix(part, filenameStarPrefix) {
-			raw := part[len(filenameStarPrefix):]
-			decoded, err := url.QueryUnescape(raw)
-			if err == nil {
-				return decoded
-			}
-		}
+	_, params, err := goMime.ParseMediaType(header)
+	if err != nil {
+		return ""
 	}
-	for _, part := range strings.Split(header, ";") {
-		part = strings.TrimSpace(part)
-		if strings.HasPrefix(part, "filename=") {
-			value := part[len("filename="):]
-			value = strings.TrimSpace(value)
-			value = strings.TrimPrefix(value, `"`)
-			value = strings.TrimSuffix(value, `"`)
-			return value
-		}
+	name := params["filename"]
+	if name == "" {
+		return ""
 	}
-	return ""
+	return filepath.Base(name)
 }

--- a/internal/mcp/dispatch_http_attachments.go
+++ b/internal/mcp/dispatch_http_attachments.go
@@ -1,0 +1,205 @@
+package mcp
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// dispatchAttachmentList handles `pad attachment list` — pure metadata
+// query against /api/v1/workspaces/{ws}/attachments.
+//
+// Custom dispatcher (rather than a routeSpec) for two reasons:
+//
+//  1. `--item <ref>` needs ref→UUID resolution. The handler reads
+//     `item_id` (UUID); the CLI resolves the ref via GetItem before
+//     calling the API. Without resolution, an agent passing
+//     `item=TASK-5` would get an empty result silently.
+//  2. `--attached` / `--unattached` are mutex booleans on the CLI
+//     side that fold into a single `item=attached|unattached` query
+//     param. The dispatcher does the same fold (and rejects the
+//     mutex violation) so MCP behaviour matches the CLI's
+//     pre-flight validation.
+//
+// Also returns the same `{attachments, total, limit, offset}` shape
+// the handler emits — that's the parity contract.
+func (d *HTTPHandlerDispatcher) dispatchAttachmentList(
+	ctx context.Context,
+	input map[string]any,
+	user *models.User,
+) (*mcp.CallToolResult, error) {
+	const cmdKey = "attachment list"
+	workspace, _ := input["workspace"].(string)
+	if workspace == "" {
+		return mcp.NewToolResultErrorf("%s: workspace is required", cmdKey), nil
+	}
+
+	attached, _ := input["attached"].(bool)
+	unattached, _ := input["unattached"].(bool)
+	if attached && unattached {
+		return mcp.NewToolResultErrorf(
+			"%s: --attached and --unattached are mutually exclusive", cmdKey,
+		), nil
+	}
+	itemRef, _ := input["item"].(string)
+	if itemRef != "" && unattached {
+		return mcp.NewToolResultErrorf(
+			"%s: --item and --unattached are mutually exclusive", cmdKey,
+		), nil
+	}
+
+	q := url.Values{}
+	if s, _ := input["category"].(string); s != "" {
+		q.Set("category", s)
+	}
+	if s, _ := input["collection"].(string); s != "" {
+		q.Set("collection", s)
+	}
+	if s, _ := input["sort"].(string); s != "" {
+		q.Set("sort", s)
+	}
+	if n, ok := numericInput(input["limit"]); ok && n > 0 {
+		q.Set("limit", strconv.FormatInt(n, 10))
+	}
+	if n, ok := numericInput(input["offset"]); ok && n > 0 {
+		q.Set("offset", strconv.FormatInt(n, 10))
+	}
+	switch {
+	case attached:
+		q.Set("item", "attached")
+	case unattached:
+		q.Set("item", "unattached")
+	}
+
+	// Resolve --item ref → item_id UUID. Goes through the existing
+	// resolveItemRef helper that the link dispatchers use, so the
+	// Apply (OAuth-scope) hook applies uniformly.
+	if itemRef != "" {
+		resolved, err := d.resolveItemRef(ctx, user, workspace, itemRef)
+		if err != nil {
+			return mcp.NewToolResultErrorf("%s: resolve --item: %s", cmdKey, err.Error()), nil
+		}
+		q.Set("item_id", resolved.ID)
+	}
+
+	urlPath := "/api/v1/workspaces/" + url.PathEscape(workspace) + "/attachments"
+	if encoded := q.Encode(); encoded != "" {
+		urlPath += "?" + encoded
+	}
+	return d.executeRequest(ctx, cmdKey, user, http.MethodGet, urlPath, nil)
+}
+
+// dispatchAttachmentShow handles `pad attachment show <attachment-id>
+// [--variant ...]` — metadata-only HEAD request.
+//
+// The HEAD response has no body; the metadata lives in headers
+// (Content-Type, Content-Length, Content-Disposition, ETag,
+// Last-Modified). We extract those into a JSON object that mirrors
+// the CLI's `--format json` output (cmd/pad/main.go attachmentShowCmd):
+//
+//	{id, mime, size, filename?, etag?, last_modified?}
+//
+// Custom dispatcher because packageHTTPResponse expects a JSON body —
+// HEAD responses always have an empty body, so we'd otherwise return
+// empty TextContent which is uninformative.
+func (d *HTTPHandlerDispatcher) dispatchAttachmentShow(
+	ctx context.Context,
+	input map[string]any,
+	user *models.User,
+) (*mcp.CallToolResult, error) {
+	const cmdKey = "attachment show"
+	workspace, _ := input["workspace"].(string)
+	if workspace == "" {
+		return mcp.NewToolResultErrorf("%s: workspace is required", cmdKey), nil
+	}
+	attachmentID, _ := input["attachment_id"].(string)
+	if attachmentID == "" {
+		return mcp.NewToolResultErrorf("%s: attachment_id is required", cmdKey), nil
+	}
+
+	urlPath := "/api/v1/workspaces/" + url.PathEscape(workspace) +
+		"/attachments/" + url.PathEscape(attachmentID)
+	if v, _ := input["variant"].(string); v != "" {
+		urlPath += "?variant=" + url.QueryEscape(v)
+	}
+
+	req, err := d.buildAuthedRequest(ctx, http.MethodHead, urlPath, nil, user)
+	if err != nil {
+		return mcp.NewToolResultErrorf("%s: build request: %s", cmdKey, err.Error()), nil
+	}
+	rec := httptest.NewRecorder()
+	d.Handler.ServeHTTP(rec, req)
+
+	if rec.Code >= 400 {
+		body := strings.TrimSpace(rec.Body.String())
+		if body == "" {
+			body = http.StatusText(rec.Code)
+		}
+		return mcp.NewToolResultErrorf("pad %s failed: %s", cmdKey, body), nil
+	}
+
+	headers := rec.Result().Header
+	out := map[string]any{
+		"id":   attachmentID,
+		"mime": headers.Get("Content-Type"),
+	}
+	if cl := headers.Get("Content-Length"); cl != "" {
+		if n, err := strconv.ParseInt(cl, 10, 64); err == nil {
+			out["size"] = n
+		}
+	}
+	if filename := parseAttachmentFilename(headers.Get("Content-Disposition")); filename != "" {
+		out["filename"] = filename
+	}
+	if etag := headers.Get("ETag"); etag != "" {
+		out["etag"] = etag
+	}
+	if lm := headers.Get("Last-Modified"); lm != "" {
+		out["last_modified"] = lm
+	}
+	return packageStructuredResponse(cmdKey, out)
+}
+
+// parseAttachmentFilename extracts the filename from a
+// Content-Disposition header. Mirrors the CLI's helper of the same
+// name (cmd/pad/main.go) — handles both the bare `filename=value` and
+// the URL-encoded `filename*=UTF-8”value` forms.
+//
+// Reproduced here rather than imported because the CLI's helper is
+// in package main and not callable from internal/mcp.
+func parseAttachmentFilename(header string) string {
+	if header == "" {
+		return ""
+	}
+	// Prefer the RFC 5987 `filename*=UTF-8''<urlencoded>` form when
+	// present — it's the spec-compliant carrier for non-ASCII names.
+	const filenameStarPrefix = "filename*=UTF-8''"
+	for _, part := range strings.Split(header, ";") {
+		part = strings.TrimSpace(part)
+		if strings.HasPrefix(part, filenameStarPrefix) {
+			raw := part[len(filenameStarPrefix):]
+			decoded, err := url.QueryUnescape(raw)
+			if err == nil {
+				return decoded
+			}
+		}
+	}
+	for _, part := range strings.Split(header, ";") {
+		part = strings.TrimSpace(part)
+		if strings.HasPrefix(part, "filename=") {
+			value := part[len("filename="):]
+			value = strings.TrimSpace(value)
+			value = strings.TrimPrefix(value, `"`)
+			value = strings.TrimSuffix(value, `"`)
+			return value
+		}
+	}
+	return ""
+}

--- a/internal/mcp/dispatch_http_attachments_test.go
+++ b/internal/mcp/dispatch_http_attachments_test.go
@@ -1,0 +1,497 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// --- attachment list ---
+
+func TestDispatch_AttachmentList_BuildsExpectedQueryString(t *testing.T) {
+	gotPath := ""
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/workspaces/docapp/attachments", func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.RequestURI()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"attachments":[],"total":0,"limit":50,"offset":0}`))
+	})
+	d := &HTTPHandlerDispatcher{Handler: mux, UserResolver: fixedUserResolver(&models.User{ID: "u"})}
+	res, err := d.Dispatch(
+		WithDispatchInput(context.Background(), map[string]any{
+			"workspace":  "docapp",
+			"category":   "image",
+			"collection": "tasks-uuid",
+			"sort":       "created_at_desc",
+			"limit":      float64(20),
+			"offset":     float64(40),
+		}),
+		[]string{"attachment", "list"}, nil,
+	)
+	if err != nil || res.IsError {
+		t.Fatalf("Dispatch err=%v IsError=%v: %#v", err, res != nil && res.IsError, res)
+	}
+	idx := strings.Index(gotPath, "?")
+	if idx < 0 {
+		t.Fatalf("expected query string in path; got %q", gotPath)
+	}
+	values, err := url.ParseQuery(gotPath[idx+1:])
+	if err != nil {
+		t.Fatalf("parse query: %v", err)
+	}
+	want := map[string]string{
+		"category":   "image",
+		"collection": "tasks-uuid",
+		"sort":       "created_at_desc",
+		"limit":      "20",
+		"offset":     "40",
+	}
+	for k, v := range want {
+		if got := values.Get(k); got != v {
+			t.Errorf("query[%q] = %q, want %q", k, got, v)
+		}
+	}
+}
+
+func TestDispatch_AttachmentList_AttachedAndUnattachedFolds(t *testing.T) {
+	cases := []struct {
+		name string
+		in   map[string]any
+		want string
+	}{
+		{
+			name: "attached=true folds to item=attached",
+			in: map[string]any{
+				"workspace": "docapp",
+				"attached":  true,
+			},
+			want: "attached",
+		},
+		{
+			name: "unattached=true folds to item=unattached",
+			in: map[string]any{
+				"workspace":  "docapp",
+				"unattached": true,
+			},
+			want: "unattached",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotPath := ""
+			mux := http.NewServeMux()
+			mux.HandleFunc("/api/v1/workspaces/docapp/attachments", func(w http.ResponseWriter, r *http.Request) {
+				gotPath = r.URL.RequestURI()
+				_, _ = w.Write([]byte(`{"attachments":[],"total":0,"limit":50,"offset":0}`))
+			})
+			d := &HTTPHandlerDispatcher{Handler: mux, UserResolver: fixedUserResolver(&models.User{ID: "u"})}
+			res, err := d.Dispatch(
+				WithDispatchInput(context.Background(), tc.in),
+				[]string{"attachment", "list"}, nil,
+			)
+			if err != nil || res.IsError {
+				t.Fatalf("Dispatch err=%v IsError=%v: %#v", err, res != nil && res.IsError, res)
+			}
+			values, _ := url.ParseQuery(strings.SplitN(gotPath, "?", 2)[1])
+			if got := values.Get("item"); got != tc.want {
+				t.Errorf("item filter = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDispatch_AttachmentList_RejectsAttachedAndUnattachedTogether(t *testing.T) {
+	d := &HTTPHandlerDispatcher{
+		Handler:      errorHandler(t, "must not call handler when both flags set"),
+		UserResolver: fixedUserResolver(&models.User{ID: "u"}),
+	}
+	res, err := d.Dispatch(
+		WithDispatchInput(context.Background(), map[string]any{
+			"workspace":  "docapp",
+			"attached":   true,
+			"unattached": true,
+		}),
+		[]string{"attachment", "list"}, nil,
+	)
+	if err != nil {
+		t.Fatalf("Dispatch err: %v", err)
+	}
+	if !res.IsError {
+		t.Errorf("expected IsError when both --attached and --unattached set")
+	}
+	if !containsToolText(res, "mutually exclusive") {
+		t.Errorf("error should mention mutex; got %#v", res)
+	}
+}
+
+func TestDispatch_AttachmentList_RejectsItemAndUnattached(t *testing.T) {
+	d := &HTTPHandlerDispatcher{
+		Handler:      errorHandler(t, "must not call handler when both --item and --unattached set"),
+		UserResolver: fixedUserResolver(&models.User{ID: "u"}),
+	}
+	res, err := d.Dispatch(
+		WithDispatchInput(context.Background(), map[string]any{
+			"workspace":  "docapp",
+			"item":       "TASK-5",
+			"unattached": true,
+		}),
+		[]string{"attachment", "list"}, nil,
+	)
+	if err != nil {
+		t.Fatalf("Dispatch err: %v", err)
+	}
+	if !res.IsError {
+		t.Errorf("expected IsError when --item and --unattached set together")
+	}
+}
+
+func TestDispatch_AttachmentList_ResolvesItemRefToUUID(t *testing.T) {
+	// CLI passes --item TASK-5; handler reads item_id (UUID). The
+	// dispatcher must prefetch the item to convert ref → UUID
+	// before forwarding, otherwise the filter silently matches
+	// nothing.
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/workspaces/docapp/items/TASK-5", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"item-uuid-5","slug":"task-5"}`))
+	})
+	gotItemID := ""
+	mux.HandleFunc("/api/v1/workspaces/docapp/attachments", func(w http.ResponseWriter, r *http.Request) {
+		gotItemID = r.URL.Query().Get("item_id")
+		_, _ = w.Write([]byte(`{"attachments":[],"total":0,"limit":50,"offset":0}`))
+	})
+	d := &HTTPHandlerDispatcher{Handler: mux, UserResolver: fixedUserResolver(&models.User{ID: "u"})}
+	res, err := d.Dispatch(
+		WithDispatchInput(context.Background(), map[string]any{
+			"workspace": "docapp",
+			"item":      "TASK-5",
+		}),
+		[]string{"attachment", "list"}, nil,
+	)
+	if err != nil || res.IsError {
+		t.Fatalf("Dispatch err=%v IsError=%v: %#v", err, res != nil && res.IsError, res)
+	}
+	if gotItemID != "item-uuid-5" {
+		t.Errorf("item_id = %q, want item-uuid-5 (resolved from TASK-5)", gotItemID)
+	}
+}
+
+func TestDispatch_AttachmentList_ItemRefResolutionFailureSurfacesError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/workspaces/docapp/items/TASK-99", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":"not found"}`))
+	})
+	listCount := 0
+	mux.HandleFunc("/api/v1/workspaces/docapp/attachments", func(_ http.ResponseWriter, _ *http.Request) {
+		listCount++
+	})
+	d := &HTTPHandlerDispatcher{Handler: mux, UserResolver: fixedUserResolver(&models.User{ID: "u"})}
+	res, err := d.Dispatch(
+		WithDispatchInput(context.Background(), map[string]any{
+			"workspace": "docapp",
+			"item":      "TASK-99",
+		}),
+		[]string{"attachment", "list"}, nil,
+	)
+	if err != nil {
+		t.Fatalf("Dispatch err: %v", err)
+	}
+	if !res.IsError {
+		t.Errorf("expected IsError when item ref doesn't resolve")
+	}
+	if listCount != 0 {
+		t.Errorf("attachments endpoint must not be called after ref-resolution failure; got %d", listCount)
+	}
+}
+
+func TestDispatch_AttachmentList_RequiresWorkspace(t *testing.T) {
+	d := &HTTPHandlerDispatcher{
+		Handler:      errorHandler(t, "must not call handler when workspace missing"),
+		UserResolver: fixedUserResolver(&models.User{ID: "u"}),
+	}
+	res, err := d.Dispatch(
+		WithDispatchInput(context.Background(), map[string]any{}),
+		[]string{"attachment", "list"}, nil,
+	)
+	if err != nil {
+		t.Fatalf("Dispatch err: %v", err)
+	}
+	if !res.IsError {
+		t.Errorf("expected IsError when workspace missing")
+	}
+}
+
+// --- attachment show ---
+
+func TestDispatch_AttachmentShow_ExtractsHeadersAsJSON(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/workspaces/docapp/attachments/abc-123", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodHead {
+			t.Errorf("expected HEAD, got %s", r.Method)
+		}
+		w.Header().Set("Content-Type", "image/png")
+		w.Header().Set("Content-Length", "12345")
+		w.Header().Set("Content-Disposition", `attachment; filename="screenshot.png"`)
+		w.Header().Set("ETag", `"sha256-abc"`)
+		w.Header().Set("Last-Modified", "Wed, 21 Oct 2026 07:28:00 GMT")
+		w.WriteHeader(http.StatusOK)
+	})
+	d := &HTTPHandlerDispatcher{Handler: mux, UserResolver: fixedUserResolver(&models.User{ID: "u"})}
+	res, err := d.Dispatch(
+		WithDispatchInput(context.Background(), map[string]any{
+			"workspace":     "docapp",
+			"attachment_id": "abc-123",
+		}),
+		[]string{"attachment", "show"}, nil,
+	)
+	if err != nil || res.IsError {
+		t.Fatalf("Dispatch err=%v IsError=%v: %#v", err, res != nil && res.IsError, res)
+	}
+	payload, ok := res.StructuredContent.(map[string]any)
+	if !ok {
+		t.Fatalf("not structured: %#v", res.StructuredContent)
+	}
+	if payload["id"] != "abc-123" {
+		t.Errorf("id = %v", payload["id"])
+	}
+	if payload["mime"] != "image/png" {
+		t.Errorf("mime = %v", payload["mime"])
+	}
+	if payload["size"].(float64) != 12345 {
+		t.Errorf("size = %v, want 12345", payload["size"])
+	}
+	if payload["filename"] != "screenshot.png" {
+		t.Errorf("filename = %v", payload["filename"])
+	}
+	if payload["etag"] != `"sha256-abc"` {
+		t.Errorf("etag = %v", payload["etag"])
+	}
+	if payload["last_modified"] != "Wed, 21 Oct 2026 07:28:00 GMT" {
+		t.Errorf("last_modified = %v", payload["last_modified"])
+	}
+}
+
+func TestDispatch_AttachmentShow_ForwardsVariantQuery(t *testing.T) {
+	gotURL := ""
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/workspaces/docapp/attachments/abc-123", func(w http.ResponseWriter, r *http.Request) {
+		gotURL = r.URL.RequestURI()
+		w.Header().Set("Content-Type", "image/png")
+		w.WriteHeader(http.StatusOK)
+	})
+	d := &HTTPHandlerDispatcher{Handler: mux, UserResolver: fixedUserResolver(&models.User{ID: "u"})}
+	_, _ = d.Dispatch(
+		WithDispatchInput(context.Background(), map[string]any{
+			"workspace":     "docapp",
+			"attachment_id": "abc-123",
+			"variant":       "thumb-md",
+		}),
+		[]string{"attachment", "show"}, nil,
+	)
+	if !strings.Contains(gotURL, "variant=thumb-md") {
+		t.Errorf("variant should be forwarded as query param; got %q", gotURL)
+	}
+}
+
+func TestDispatch_AttachmentShow_404SurfacesAsToolError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/workspaces/docapp/attachments/missing", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+	d := &HTTPHandlerDispatcher{Handler: mux, UserResolver: fixedUserResolver(&models.User{ID: "u"})}
+	res, err := d.Dispatch(
+		WithDispatchInput(context.Background(), map[string]any{
+			"workspace":     "docapp",
+			"attachment_id": "missing",
+		}),
+		[]string{"attachment", "show"}, nil,
+	)
+	if err != nil {
+		t.Fatalf("Dispatch err: %v", err)
+	}
+	if !res.IsError {
+		t.Errorf("expected IsError on 404; got %#v", res)
+	}
+}
+
+func TestDispatch_AttachmentShow_RequiresArgs(t *testing.T) {
+	d := &HTTPHandlerDispatcher{
+		Handler:      errorHandler(t, "must not call handler when args missing"),
+		UserResolver: fixedUserResolver(&models.User{ID: "u"}),
+	}
+	for _, missing := range []string{"workspace", "attachment_id"} {
+		t.Run("missing-"+missing, func(t *testing.T) {
+			input := map[string]any{
+				"workspace": "docapp", "attachment_id": "abc-123",
+			}
+			delete(input, missing)
+			res, err := d.Dispatch(
+				WithDispatchInput(context.Background(), input),
+				[]string{"attachment", "show"}, nil,
+			)
+			if err != nil {
+				t.Fatalf("Dispatch err: %v", err)
+			}
+			if !res.IsError {
+				t.Errorf("expected IsError when %s missing", missing)
+			}
+		})
+	}
+}
+
+// --- parseAttachmentFilename ---
+
+func TestParseAttachmentFilename_StandardForm(t *testing.T) {
+	got := parseAttachmentFilename(`attachment; filename="screenshot.png"`)
+	if got != "screenshot.png" {
+		t.Errorf("got %q, want screenshot.png", got)
+	}
+}
+
+func TestParseAttachmentFilename_PrefersFilenameStarOverFilename(t *testing.T) {
+	// RFC 5987 says filename* takes precedence — it's the
+	// spec-compliant carrier for non-ASCII names.
+	got := parseAttachmentFilename(`attachment; filename="ascii.txt"; filename*=UTF-8''r%C3%A9sum%C3%A9.pdf`)
+	if got != "résumé.pdf" {
+		t.Errorf("got %q, want résumé.pdf", got)
+	}
+}
+
+func TestParseAttachmentFilename_HandlesQuotedAndUnquoted(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{`attachment; filename="quoted.txt"`, "quoted.txt"},
+		{`attachment; filename=unquoted.txt`, "unquoted.txt"},
+		{``, ""},
+		{`inline`, ""}, // no filename
+	}
+	for _, tc := range cases {
+		got := parseAttachmentFilename(tc.in)
+		if got != tc.want {
+			t.Errorf("parse(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// --- noRemoteEquivalent: attachment upload/download/view ---
+
+func TestDispatch_AttachmentUploadDownloadView_RejectedAsCLIOnly(t *testing.T) {
+	d := &HTTPHandlerDispatcher{
+		Handler:      errorHandler(t, "attachment upload/download/view must not reach handler"),
+		UserResolver: fixedUserResolver(&models.User{ID: "u"}),
+	}
+	for _, cmd := range []string{"attachment upload", "attachment download", "attachment view"} {
+		t.Run(cmd, func(t *testing.T) {
+			ctx := WithDispatchInput(context.Background(), map[string]any{
+				"workspace": "docapp",
+			})
+			res, err := d.Dispatch(ctx, strings.Split(cmd, " "), nil)
+			if err != nil {
+				t.Fatalf("Dispatch err: %v", err)
+			}
+			if !res.IsError {
+				t.Errorf("expected IsError; got %#v", res)
+			}
+			if !containsToolText(res, "no remote equivalent") {
+				t.Errorf("error should call out CLI-only nature; got %#v", res)
+			}
+			// The rationale clause should mention the alternative
+			// path so agents can pivot to fetching bytes via the URL.
+			if !containsToolText(res, "attachment URL") {
+				t.Errorf("rationale should point at attachment URL; got %#v", res)
+			}
+		})
+	}
+}
+
+// --- noRemoteEquivalent rationale clause is per-entry ---
+
+func TestNoRemoteEquivalent_RationaleIsPerEntry(t *testing.T) {
+	// PR #350 refactor: noRemoteEquivalent went from
+	// map[string]struct{} to map[string]string with a per-entry
+	// rationale clause. Verify that github vs attachment commands
+	// surface DIFFERENT rationale content (not the old generic
+	// "operates on local pad client / config state" string).
+	d := &HTTPHandlerDispatcher{
+		Handler:      errorHandler(t, "must not reach handler"),
+		UserResolver: fixedUserResolver(&models.User{ID: "u"}),
+	}
+	githubRes, _ := d.Dispatch(
+		WithDispatchInput(context.Background(), map[string]any{}),
+		[]string{"github", "link"}, nil,
+	)
+	attachRes, _ := d.Dispatch(
+		WithDispatchInput(context.Background(), map[string]any{}),
+		[]string{"attachment", "upload"}, nil,
+	)
+	if !containsToolText(githubRes, "git branch") {
+		t.Errorf("github link rationale should mention git branch; got %#v", githubRes)
+	}
+	if !containsToolText(attachRes, "filesystem") {
+		t.Errorf("attachment upload rationale should mention filesystem; got %#v", attachRes)
+	}
+}
+
+// --- Integration smoke ---
+
+func TestHTTPHandlerDispatcher_Integration_Attachments(t *testing.T) {
+	srv, st := newPadServer(t)
+
+	wsRec := doJSONReq(t, srv, http.MethodPost, "/api/v1/workspaces",
+		map[string]any{"name": "DocApp"})
+	if wsRec.Code != http.StatusCreated {
+		t.Fatalf("create workspace: %d %s", wsRec.Code, wsRec.Body.String())
+	}
+	var ws models.Workspace
+	if err := json.Unmarshal(wsRec.Body.Bytes(), &ws); err != nil {
+		t.Fatalf("decode workspace: %v", err)
+	}
+	owner, err := st.CreateUser(models.UserCreate{Email: "dave@example.com", Name: "Dave", Password: "x"})
+	if err != nil {
+		t.Fatalf("create owner: %v", err)
+	}
+	if err := st.AddWorkspaceMember(ws.ID, owner.ID, "owner"); err != nil {
+		t.Fatalf("add owner: %v", err)
+	}
+
+	d := &HTTPHandlerDispatcher{Handler: srv, UserResolver: fixedUserResolver(owner)}
+
+	// Empty workspace: list should return zero attachments without
+	// 500ing.
+	listRes, err := d.Dispatch(
+		WithDispatchInput(context.Background(), map[string]any{
+			"workspace": ws.Slug,
+		}),
+		[]string{"attachment", "list"}, nil,
+	)
+	if err != nil || listRes.IsError {
+		t.Fatalf("attachment list: err=%v IsError=%v: %#v", err, listRes != nil && listRes.IsError, listRes)
+	}
+	payload, _ := listRes.StructuredContent.(map[string]any)
+	if total, _ := payload["total"].(float64); total != 0 {
+		t.Errorf("expected total=0 on empty workspace; got %v", total)
+	}
+
+	// Upload/download/view are CLI-only; verify they reject with a
+	// stable message even when the workspace + auth are wired up.
+	for _, cmd := range []string{"attachment upload", "attachment download", "attachment view"} {
+		res, err := d.Dispatch(
+			WithDispatchInput(context.Background(), map[string]any{"workspace": ws.Slug}),
+			strings.Split(cmd, " "), nil,
+		)
+		if err != nil {
+			t.Fatalf("%s: err=%v", cmd, err)
+		}
+		if !res.IsError || !containsToolText(res, "no remote equivalent") {
+			t.Errorf("%s: expected noRemoteEquivalent rejection; got %#v", cmd, res)
+		}
+	}
+}

--- a/internal/mcp/dispatch_http_attachments_test.go
+++ b/internal/mcp/dispatch_http_attachments_test.go
@@ -357,6 +357,7 @@ func TestParseAttachmentFilename_StandardForm(t *testing.T) {
 func TestParseAttachmentFilename_PrefersFilenameStarOverFilename(t *testing.T) {
 	// RFC 5987 says filename* takes precedence — it's the
 	// spec-compliant carrier for non-ASCII names.
+	// mime.ParseMediaType prefers the encoded form automatically.
 	got := parseAttachmentFilename(`attachment; filename="ascii.txt"; filename*=UTF-8''r%C3%A9sum%C3%A9.pdf`)
 	if got != "résumé.pdf" {
 		t.Errorf("got %q, want résumé.pdf", got)
@@ -378,6 +379,28 @@ func TestParseAttachmentFilename_HandlesQuotedAndUnquoted(t *testing.T) {
 		if got != tc.want {
 			t.Errorf("parse(%q) = %q, want %q", tc.in, got, tc.want)
 		}
+	}
+}
+
+func TestParseAttachmentFilename_PreservesSemicolonsInQuotedFilename(t *testing.T) {
+	// Codex review on PR #350 caught the previous Split(";") approach
+	// chopping `attachment; filename="a;b.png"` at the internal
+	// semicolon. mime.ParseMediaType respects the quote boundaries
+	// so the inner ; survives.
+	got := parseAttachmentFilename(`attachment; filename="a;b.png"`)
+	if got != "a;b.png" {
+		t.Errorf("got %q, want a;b.png (semicolons inside quotes must round-trip)", got)
+	}
+}
+
+func TestParseAttachmentFilename_AppliesBasenameDefense(t *testing.T) {
+	// Match the CLI's filepath.Base fallback — even if a server
+	// emitted a path-like filename we strip the directory portion
+	// so callers can't accidentally hand a traversal-y path to a
+	// downstream tool.
+	got := parseAttachmentFilename(`attachment; filename="../../etc/passwd"`)
+	if got != "passwd" {
+		t.Errorf("got %q, want passwd (directory portion must be stripped)", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

Final slice of TASK-968's surface expansion. Two attachment commands wired (the metadata-only ones), three rejected as `noRemoteEquivalent` (those that take a local filesystem `<path>` argument), and a small refactor giving `noRemoteEquivalent` per-entry rationale clauses.

### New commands

- **`attachment list`** — custom dispatcher: resolves `--item TASK-5` → `item_id=<UUID>` via the existing `resolveItemRef` helper (introduced in PR #346 for the link commands), folds `--attached` / `--unattached` to the handler's `item=attached|unattached` query param, rejects the mutex violations the CLI also rejects, forwards `category` / `collection` / `sort` / `limit` / `offset`.
- **`attachment show`** — issues HEAD against `/api/v1/workspaces/{ws}/attachments/{id}` and packages response headers (Content-Type, -Length, -Disposition, ETag, Last-Modified) into the CLI's `--format json` shape: `{id, mime, size, filename?, etag?, last_modified?}`.

### Rejected as `noRemoteEquivalent`

- `attachment upload` — needs a local filesystem `<path>`; agents fetch raw bytes via the attachment URL directly
- `attachment download` — writes to a local filesystem `<out-path>`; agents read bytes via the URL
- `attachment view` — writes to a local filesystem path and prints it; same alternative

### `noRemoteEquivalent` refactor

Switched from `map[string]struct{}` to `map[string]string` where the value is a rationale clause appended to the error message. The previous generic message ("operates on local pad client / config state") was misleading for attachments (which DO operate on workspace state, just via a local filesystem arg). Per-entry rationale also lets `github link/status/unlink` point at `item update --field github_pr=...` and lets `attachment` rejections point at the URL + `attachment show`.

### `parseAttachmentFilename` helper

Reproduces the CLI helper of the same name. Handles `filename="value"` and the RFC 5987 `filename*=UTF-8''<urlencoded>` form, preferring the latter when both appear (spec-compliant carrier for non-ASCII names).

## Context

Closes the route-table expansion work for `TASK-968` under `PLAN-943`. **Cumulative: 38 commands wired across PR #346 + #347 + #348 + #349 + this PR, plus 13 commands explicitly rejected as `noRemoteEquivalent`.** The dispatcher now exposes the full mid-tier MCP surface that `TASK-950` (mounting `/mcp`) needs.

## Test plan

- [x] `make check` — golangci-lint + Go tests + web build all clean
- [x] Attachment list happy path: query string fully forwarded
- [x] `--attached` / `--unattached` fold + mutex rejection + `--item`/`--unattached` mutex
- [x] `--item` ref → UUID resolution, abort-on-resolution-failure pin
- [x] Attachment show: all five header fields → JSON; `--variant` forwarded; 404 → IsError
- [x] `parseAttachmentFilename` covers standard / quoted / unquoted / RFC5987 forms
- [x] Per-entry rationale refactor verified: github vs attachment messages differ
- [x] Integration smoke: attachment list against fresh workspace (total=0); upload/download/view rejected with stable "no remote equivalent" prefix