### PR TITLE
feat(brand): new tagline — Project Management for the agent era

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -138,7 +138,7 @@ homebrew_casks:
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
     directory: Casks
     homepage: "https://getpad.dev"
-    description: "Collaborate with your AI agents"
+    description: "Project Management for the agent era"
     license: "Apache-2.0"
 
 # dockers_v2 replaces the legacy `dockers:` + `docker_manifests:` blocks.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <h1 align="center">Pad</h1>
-  <p align="center"><strong>Collaborate with your AI agents.</strong></p>
+  <p align="center"><strong>Project Management for the agent era.</strong></p>
   <p align="center">
     <a href="https://github.com/PerpetualSoftware/pad/actions/workflows/ci.yml"><img src="https://github.com/PerpetualSoftware/pad/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
     <a href="https://github.com/PerpetualSoftware/pad/releases"><img src="https://img.shields.io/github/v/release/PerpetualSoftware/pad" alt="Release"></a>

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -153,9 +153,9 @@
 
 <svelte:head>
 	<title>{titleStore.title}</title>
-	<meta name="description" content="Collaborate with your AI agents" />
+	<meta name="description" content="Project Management for the agent era" />
 	<meta property="og:title" content="Pad" />
-	<meta property="og:description" content="Collaborate with your AI agents" />
+	<meta property="og:description" content="Project Management for the agent era" />
 	<meta property="og:image" content="/padicon.png" />
 	<meta property="og:type" content="website" />
 </svelte:head>

--- a/web/static/manifest.json
+++ b/web/static/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Pad",
   "short_name": "Pad",
-  "description": "Collaborate with your AI agents",
+  "description": "Project Management for the agent era",
   "start_url": "/",
   "display": "standalone",
   "background_color": "#1a1a1a",

--- a/web/static/site.webmanifest
+++ b/web/static/site.webmanifest
@@ -1,7 +1,7 @@
 {
   "name": "Pad",
   "short_name": "Pad",
-  "description": "Collaborate with your AI agents",
+  "description": "Project Management for the agent era",
   "icons": [
     {
       "src": "/icon-192.png",


### PR DESCRIPTION
## Summary

- Retire **Collaborate with your AI agents** in favor of **Project Management for the agent era**.
- Companion to [pad-web#45](https://github.com/PerpetualSoftware/pad-web/pull/45) — they ship together so the brand reads consistently across the marketing site (`getpad.dev`) and the product (`app.getpad.dev` + the self-host UI).

## Why this phrasing

- **"the agent era"** is more confident than "an AI era" or "the AI era" — "agent" points at *how* AI shows up in your workflow (an autonomous teammate), not just *that* it exists.
- It's also the unit of change Pad is uniquely structured around — issue IDs, conventions, playbooks — things agents read and act on.

## What this PR does (plain-text surfaces only)

| File | Change |
|---|---|
| `README.md` | Top-of-readme tagline (centered `<strong>` line). |
| `.goreleaser.yaml` | Homebrew formula description. |
| `web/static/site.webmanifest` | Embedded PWA description. |
| `web/static/manifest.json` | Duplicate PWA manifest in the same dir. |
| `web/src/routes/+layout.svelte` | `<meta name="description">` and `<meta property="og:description">` on every app page. |

Visual accenting of the word **agent** in brand blue lives in `pad-web` (homepage hero `<h1>` + OG card image), the only places that render the tagline to humans rather than to package managers / OG crawlers.

## Test plan

- [x] `make check` — exit 0.
  - `golangci-lint run --timeout=5m ./...` — 0 issues.
  - `go test ./...` — all packages pass.
  - `govulncheck ./...` — no vulnerabilities.
  - `cd web && npm run build` — clean build.
  - `svelte-check` — 0 errors. The 6 warnings are all **pre-existing** in files this PR doesn't touch (NestedChildren, ChildItems, roles/+page, console/admin/+page).
- [ ] After merge, confirm new release artifact's Homebrew formula description matches.
- [ ] Force re-scrape on social platforms once `app.getpad.dev` redeploys (LinkedIn / Facebook / X test post) to flush cached OG tags.

## Companion PR

- pad-web#45 — homepage hero (with `<span class="text-accent">agent</span>`), OG card regen with "agent" rendered in accent blue, llms.txt, getpad.dev manifest, internal storyboard doc.