### PR TITLE
feat(mcp): v0.2 catalog scaffold + ToolSurfaceVersion + pad_meta tool (TASK-979)

### DIFF
--- a/cmd/pad/mcp.go
+++ b/cmd/pad/mcp.go
@@ -273,13 +273,30 @@ Shuts down cleanly on EOF, SIGINT, or SIGTERM.`,
 				"url": urlFlag,
 			}
 
+			dispatcher := &mcpserver.ExecDispatcher{Binary: bin}
 			if _, err := mcpserver.Register(srv.MCP(), mcpserver.RegistryOptions{
 				Doc:        doc,
 				Workspace:  state,
-				Dispatcher: &mcpserver.ExecDispatcher{Binary: bin},
+				Dispatcher: dispatcher,
 				RootFlags:  rootFlags,
 			}); err != nil {
 				return fmt.Errorf("pad mcp serve: register tools: %w", err)
+			}
+
+			// v0.2 catalog (PLAN-969 TASK-970) — runs alongside the
+			// cmdhelp-walk path while the catalog is being filled in.
+			// First commit (TASK-979) ships pad_meta only; subsequent
+			// commits add the read-only tools and pad_item, then flip
+			// the v0.1 surface off. Same Doc + Dispatcher so dispatch
+			// behaviour is identical between the two surfaces.
+			if _, err := mcpserver.RegisterCatalog(srv.MCP(), mcpserver.CatalogOptions{
+				Doc:        doc,
+				Workspace:  state,
+				Dispatcher: dispatcher,
+				RootFlags:  rootFlags,
+				PadVersion: fullVersion(),
+			}); err != nil {
+				return fmt.Errorf("pad mcp serve: register catalog: %w", err)
 			}
 
 			// Resource templates (TASK-946): four read-only views over

--- a/internal/mcp/catalog.go
+++ b/internal/mcp/catalog.go
@@ -1,0 +1,363 @@
+package mcp
+
+import (
+	"context"
+	"sort"
+	"strings"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+
+	"github.com/PerpetualSoftware/pad/internal/cmdhelp"
+)
+
+// ─────────────────────────────────────────────────────────────────────
+// MCP tool catalog (v0.2) — the hand-curated resource × action surface
+// that replaces PLAN-942's cmdhelp-derived 1:1 verb tools.
+//
+// Architecture (DOC-978 / TASK-970):
+//
+//   - Catalog declares ~7 ToolDefs (pad_item, pad_workspace, ...).
+//   - Each ToolDef has a map of action names → ActionFn.
+//   - The registered handler for a ToolDef is a thin fan-out shim: it
+//     reads `action` from the input, looks up the handler, and invokes
+//     it. Most ActionFns delegate to env.Dispatch(cmdPath, input) which
+//     forwards through the existing Dispatcher (ExecDispatcher /
+//     HTTPHandlerDispatcher) — so the dispatch contract below the
+//     registry boundary is unchanged.
+//
+//   - cmdhelp remains the source of truth for individual CLI command
+//     schemas (args, flags, types). env.Dispatch uses opts.Doc to look
+//     up the cmdInfo for a cmdPath and then calls BuildCLIArgs. The
+//     catalog merely chooses which cmdPath to invoke for each action.
+//
+//   - A few ToolDefs (notably pad_meta) handle their actions inline
+//     without dispatching to a CLI cmdPath. Those just return a
+//     CallToolResult directly from the ActionFn.
+//
+// Why a fan-out layer instead of replacing the dispatcher: TASK-965
+// + TASK-967 + TASK-968 stabilized the dispatcher and route table for
+// HTTP transport. Reshaping the surface in the registry without
+// touching dispatch keeps that investment intact and gives ExecDispatcher
+// + HTTPHandlerDispatcher the v0.2 surface for free.
+// ─────────────────────────────────────────────────────────────────────
+
+// ToolDef is one v0.2 tool: name, description, schema, and the actions
+// it supports. Hand-curated; one ToolDef per catalog_<resource>.go file.
+type ToolDef struct {
+	// Name is the MCP tool name as advertised in tools/list. Stable
+	// across versions — a rename is a ToolSurfaceVersion bump.
+	Name string
+
+	// Description shows up in tools/list and in Claude Desktop's tool
+	// picker. Should enumerate each action's purpose + required params
+	// inline, since the schema below uses a flat union of all
+	// parameters across actions and relies on the description for
+	// per-action discoverability.
+	Description string
+
+	// Schema is the union of parameters across all actions. Only
+	// `action` is required at the schema level; per-action constraints
+	// (e.g. "create requires title") are enforced inside the action
+	// handler and surface as structured validation errors.
+	Schema ToolSchema
+
+	// Actions maps the `action` enum value to its handler. Snake_case
+	// for verb-only ("list", "create"); kebab-case where the verb is
+	// compound ("list-comments", "tool-surface", "blocked-by"). The
+	// distinction matches CLI subcommand naming so agents can mentally
+	// map `pad_item.action: create` ↔ `pad item create`.
+	Actions map[string]ActionFn
+}
+
+// ToolSchema is a structured description of the tool's input shape.
+// Compiled to mcp.ToolOption slices when registering with mcp-go.
+//
+// Workspace, when true, adds an optional `workspace` string to the
+// schema. Most tools need it; pad_meta does not.
+type ToolSchema struct {
+	Workspace bool
+	Params    []ParamDef
+}
+
+// ParamDef declares one parameter on a tool's input schema. Type maps
+// to mcp-go's helper functions (WithString, WithNumber, WithBoolean,
+// WithArray). Enum, when non-empty, constrains string parameters.
+type ParamDef struct {
+	Name        string
+	Type        string // "string" | "number" | "bool" | "array<string>"
+	Description string
+	Enum        []string
+}
+
+// ActionFn handles one tool action. Receives the call context, the raw
+// MCP input map, and a per-tool execution environment. Returns the
+// CallToolResult that gets surfaced to the agent.
+//
+// Two patterns:
+//
+//  1. Fan-out (most actions): call env.Dispatch(ctx, cmdPath, input).
+//     For the common case of "this action is just a CLI subcommand,
+//     forward the input verbatim", use the passThrough helper.
+//
+//  2. Inline (pad_meta + similar): build the CallToolResult directly
+//     from in-memory state (ToolSurfaceVersion, the catalog itself,
+//     etc.) without dispatching anywhere.
+type ActionFn func(ctx context.Context, input map[string]any, env ActionEnv) (*mcp.CallToolResult, error)
+
+// ActionEnv carries everything an action handler needs to either
+// dispatch to a CLI cmdPath or build a result inline. Wired up once
+// per RegisterCatalog call; passed by value into every action handler
+// (small struct; copy is cheap; immutable in practice).
+type ActionEnv struct {
+	// Doc is the cmdhelp document — source of truth for CLI command
+	// schemas consumed by BuildCLIArgs.
+	Doc *cmdhelp.Document
+
+	// Workspace is the session workspace state. Read by env.Dispatch
+	// (and by inline handlers that care about default workspace).
+	Workspace *WorkspaceState
+
+	// Dispatcher executes CLI cmdPaths. Same instance used by the
+	// v0.1 cmdhelp-walk path; both surfaces share dispatch.
+	Dispatcher Dispatcher
+
+	// RootFlags are startup-captured persistent flags (e.g. --url)
+	// forwarded to every dispatched call.
+	RootFlags map[string]string
+
+	// PadVersion is the runtime pad binary version. Threaded through
+	// for pad_meta.action: server-info / version.
+	PadVersion string
+
+	// Catalog is the live catalog slice — supplied so pad_meta.action:
+	// tool-surface can introspect the catalog without an import cycle.
+	Catalog []ToolDef
+}
+
+// Dispatch is the helper most fan-out actions use. Looks up cmdInfo
+// in env.Doc, builds CLI args, attaches the dispatch input to ctx,
+// forwards to env.Dispatcher.
+//
+// Unknown cmdPath produces a "registry bug" error rather than panicking
+// — catches catalog/cmdhelp drift early in tests. A clean run on
+// startup ensures every action's cmdPath maps to a real CLI command.
+func (env ActionEnv) Dispatch(ctx context.Context, cmdPath []string, input map[string]any) (*mcp.CallToolResult, error) {
+	if input == nil {
+		input = map[string]any{}
+	}
+	pathStr := strings.Join(cmdPath, " ")
+	cmdInfo, ok := env.Doc.Commands[pathStr]
+	if !ok {
+		return mcp.NewToolResultErrorf(
+			"action mapped to unknown cmdPath %q (catalog/cmdhelp drift)",
+			pathStr), nil
+	}
+	cliArgs, err := BuildCLIArgs(cmdInfo, input, env.Workspace.Get(), env.RootFlags)
+	if err != nil {
+		return mcp.NewToolResultErrorf("%s", err.Error()), nil
+	}
+	ctx = WithDispatchInput(ctx, mergeDispatchInput(input, env.Workspace.Get(), env.RootFlags))
+	return env.Dispatcher.Dispatch(ctx, cmdPath, cliArgs)
+}
+
+// passThrough returns an ActionFn that forwards the input verbatim to
+// the given cmdPath via env.Dispatch. The vast majority of catalog
+// actions use this — a custom handler is only needed when the action
+// reshapes the input or dispatches on a parameter (see actionItemLink
+// for the link_type → cmdPath dispatch pattern).
+func passThrough(cmdPath []string) ActionFn {
+	return func(ctx context.Context, input map[string]any, env ActionEnv) (*mcp.CallToolResult, error) {
+		return env.Dispatch(ctx, cmdPath, input)
+	}
+}
+
+// Catalog is the live v0.2 tool catalog. Populated by per-tool init()
+// functions in catalog_<resource>.go via appendToCatalog so each tool
+// definition lives in its own file without a central registration list
+// drifting out of sync.
+var Catalog []ToolDef
+
+// appendToCatalog inserts def into Catalog. Called from
+// catalog_<resource>.go init() functions. Keep this small + simple;
+// validation happens at RegisterCatalog time (where errors surface
+// once at startup rather than per-init).
+func appendToCatalog(def ToolDef) {
+	Catalog = append(Catalog, def)
+}
+
+// CatalogOptions configures RegisterCatalog. Mirrors RegistryOptions
+// for the cmdhelp-walk path but adds PadVersion (needed by pad_meta).
+type CatalogOptions struct {
+	Doc        *cmdhelp.Document
+	Workspace  *WorkspaceState
+	Dispatcher Dispatcher
+	RootFlags  map[string]string
+	PadVersion string
+}
+
+// RegisterCatalog installs the v0.2 catalog tools on srv. Returns the
+// count of tools registered (excluding pad_set_workspace, which the
+// cmdhelp-walk path in Register() owns).
+//
+// Called alongside Register() from cmd/pad/mcp.go during the parallel-
+// rollout phase of TASK-970. Once TASK-981 lands, Register() collapses
+// into RegisterCatalog and the cmdhelp leaf walker goes away.
+func RegisterCatalog(srv *server.MCPServer, opts CatalogOptions) (int, error) {
+	if err := validateCatalogOptions(opts); err != nil {
+		return 0, err
+	}
+	env := ActionEnv{
+		Doc:        opts.Doc,
+		Workspace:  opts.Workspace,
+		Dispatcher: opts.Dispatcher,
+		RootFlags:  opts.RootFlags,
+		PadVersion: opts.PadVersion,
+		Catalog:    Catalog,
+	}
+	count := 0
+	for _, def := range Catalog {
+		tool := buildToolFromDef(def)
+		handler := makeFanOutHandler(def, env)
+		srv.AddTool(tool, handler)
+		count++
+	}
+	return count, nil
+}
+
+func validateCatalogOptions(opts CatalogOptions) error {
+	if opts.Doc == nil {
+		return errCatalogMissing("Doc")
+	}
+	if opts.Workspace == nil {
+		return errCatalogMissing("Workspace")
+	}
+	if opts.Dispatcher == nil {
+		return errCatalogMissing("Dispatcher")
+	}
+	return nil
+}
+
+// errCatalogMissing keeps the validation error messages in one place
+// so the surface is consistent across the three required fields.
+func errCatalogMissing(field string) error {
+	return &catalogError{msg: "CatalogOptions." + field + " is required"}
+}
+
+type catalogError struct{ msg string }
+
+func (e *catalogError) Error() string { return e.msg }
+
+// buildToolFromDef compiles a ToolDef into the mcp.Tool shape mcp-go
+// expects. The schema is flat: `action` is required, every other
+// parameter is optional at the schema level (per-action validation
+// runs in the action handler). This matches DOC-978's design — JSON
+// Schema discriminated unions are awkward in mcp-go's helpers, and
+// the description carries the action × params matrix anyway.
+func buildToolFromDef(def ToolDef) mcp.Tool {
+	opts := []mcp.ToolOption{mcp.WithDescription(def.Description)}
+
+	// `action` is always required and always enumerated. Sorted for
+	// deterministic schema output across builds.
+	actions := sortedActionNames(def)
+	opts = append(opts,
+		mcp.WithString("action",
+			mcp.Description("The action to perform. See tool description for required parameters per action."),
+			mcp.Required(),
+			mcp.Enum(actions...),
+		),
+	)
+
+	if def.Schema.Workspace {
+		opts = append(opts,
+			mcp.WithString("workspace",
+				mcp.Description(
+					"Workspace slug. Defaults to the session workspace set via "+
+						"pad_set_workspace, then to the CWD-linked workspace from .pad.toml.",
+				),
+			),
+		)
+	}
+
+	for _, p := range def.Schema.Params {
+		opts = append(opts, paramDefToToolOption(p))
+	}
+
+	return mcp.NewTool(def.Name, opts...)
+}
+
+// paramDefToToolOption maps a ParamDef to the matching mcp-go helper.
+// Unknown Type strings fall through to WithString — same defensive
+// default the cmdhelp-walk path uses.
+func paramDefToToolOption(p ParamDef) mcp.ToolOption {
+	propOpts := make([]mcp.PropertyOption, 0, 2)
+	if p.Description != "" {
+		propOpts = append(propOpts, mcp.Description(p.Description))
+	}
+	if len(p.Enum) > 0 {
+		propOpts = append(propOpts, mcp.Enum(p.Enum...))
+	}
+	switch p.Type {
+	case "number":
+		return mcp.WithNumber(p.Name, propOpts...)
+	case "bool":
+		return mcp.WithBoolean(p.Name, propOpts...)
+	case "array<string>":
+		return mcp.WithArray(p.Name, append(propOpts, mcp.WithStringItems())...)
+	default:
+		return mcp.WithString(p.Name, propOpts...)
+	}
+}
+
+// makeFanOutHandler returns the ToolHandlerFunc that mcp-go invokes
+// when the tool is called. Reads `action` from the input, looks up the
+// handler, and forwards. Unknown / missing action returns a structured
+// error result so the agent sees the valid options and can recover.
+func makeFanOutHandler(def ToolDef, env ActionEnv) server.ToolHandlerFunc {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		input := req.GetArguments()
+		if input == nil {
+			input = map[string]any{}
+		}
+		action, _ := input["action"].(string)
+		if action == "" {
+			return errMissingAction(def), nil
+		}
+		handler, ok := def.Actions[action]
+		if !ok {
+			return errUnknownAction(def, action), nil
+		}
+		return handler(ctx, input, env)
+	}
+}
+
+// sortedActionNames returns def.Actions' keys in lexical order. Used
+// for both the schema's action enum (so the ordering is stable across
+// builds and reproducible in tests) and the error helpers below (so
+// users see actions alphabetized rather than in map-iteration order).
+func sortedActionNames(def ToolDef) []string {
+	out := make([]string, 0, len(def.Actions))
+	for name := range def.Actions {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// errMissingAction is the structured result returned when the input
+// has no `action` field. Lists the valid actions inline so agents can
+// retry with a correct value.
+func errMissingAction(def ToolDef) *mcp.CallToolResult {
+	return mcp.NewToolResultErrorf(
+		"%s: missing required field 'action'. Valid actions: %s",
+		def.Name, strings.Join(sortedActionNames(def), ", "))
+}
+
+// errUnknownAction is the structured result returned when `action` is
+// set but not in the tool's action table. Same listing as
+// errMissingAction so agents can self-correct.
+func errUnknownAction(def ToolDef, action string) *mcp.CallToolResult {
+	return mcp.NewToolResultErrorf(
+		"%s: unknown action %q. Valid actions: %s",
+		def.Name, action, strings.Join(sortedActionNames(def), ", "))
+}

--- a/internal/mcp/catalog_meta.go
+++ b/internal/mcp/catalog_meta.go
@@ -1,0 +1,134 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// padMetaTool is the v0.2 server-introspection tool. Three actions,
+// all handled inline (no CLI dispatch) — they read in-memory state
+// and return JSON.
+//
+// Why a tool and not just resources: pad://_meta/version is the
+// canonical resource for read-only version metadata, but tools/list
+// is what most agents introspect first when establishing context.
+// Exposing the same data plus a full catalog dump as a tool means
+// agents that haven't enumerated resources yet can still discover the
+// surface in one tool call. pad_meta complements RegisterMeta — it
+// doesn't replace it.
+//
+// The three actions:
+//
+//   - server-info   → {name, version} — minimal handshake-equivalent.
+//   - version       → MetaPayload — same JSON the meta resource serves.
+//   - tool-surface  → {tools: [...]} — full catalog for getpad.dev/docs/mcp.
+//
+// All inline → padMetaTool's actions never call env.Dispatch.
+
+func init() {
+	appendToCatalog(padMetaTool)
+}
+
+var padMetaTool = ToolDef{
+	Name:        "pad_meta",
+	Description: padMetaToolDescription,
+	Schema: ToolSchema{
+		Workspace: false, // server-wide; no workspace context needed
+		Params:    nil,   // only `action` (added by buildToolFromDef)
+	},
+	Actions: map[string]ActionFn{
+		"server-info":  actionMetaServerInfo,
+		"version":      actionMetaVersion,
+		"tool-surface": actionMetaToolSurface,
+	},
+}
+
+const padMetaToolDescription = `Server introspection — version, capabilities, and the full tool catalog.
+
+Actions:
+  server-info   — Server name + runtime version. Lightweight; no params.
+  version       — Full version metadata (pad version, cmdhelp version, tool surface
+                  version, MCP protocol version). Same JSON as pad://_meta/version.
+  tool-surface  — Full catalog dump: every tool, its actions, and its input schema.
+                  Useful for agents that want to enumerate the surface programmatically
+                  rather than parsing tools/list.
+
+Use pad_meta when an agent needs to discover server capabilities or generate
+documentation. For runtime task work, use pad_item / pad_workspace / etc.`
+
+// actionMetaServerInfo returns the minimal {name, version} pair.
+// Roughly equivalent to what the MCP handshake exposes, but available
+// post-handshake without a full reconnect.
+func actionMetaServerInfo(_ context.Context, _ map[string]any, env ActionEnv) (*mcp.CallToolResult, error) {
+	version := env.PadVersion
+	if version == "" {
+		version = FallbackVersion
+	}
+	payload := map[string]any{
+		"name":    ServerName,
+		"version": version,
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		// Marshalling a string-valued map can't realistically fail;
+		// surface as an error result rather than panicking.
+		return mcp.NewToolResultErrorf("pad_meta.server-info: marshal: %s", err.Error()), nil
+	}
+	return mcp.NewToolResultStructured(payload, string(body)), nil
+}
+
+// actionMetaVersion returns the same MetaPayload that pad://_meta/version
+// serves as a resource. Two surfaces, one source of truth (BuildMetaPayload).
+func actionMetaVersion(_ context.Context, _ map[string]any, env ActionEnv) (*mcp.CallToolResult, error) {
+	payload := BuildMetaPayload(env.PadVersion)
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return mcp.NewToolResultErrorf("pad_meta.version: marshal: %s", err.Error()), nil
+	}
+	return mcp.NewToolResultStructured(payload, string(body)), nil
+}
+
+// actionMetaToolSurface returns the full catalog as JSON. Pairs with
+// PLAN-943 TASK-957 (getpad.dev/docs/mcp) — that page can generate
+// docs from this single canonical source instead of re-introspecting
+// tools/list and reverse-engineering action enums.
+//
+// Schema is intentionally simple — name + description per tool, plus
+// per-action name + presence. Full per-action parameter schemas live
+// in tools/list (the JSON Schema mcp-go emits for each tool); the
+// catalog summary is a higher-level "what can this server do" view.
+func actionMetaToolSurface(_ context.Context, _ map[string]any, env ActionEnv) (*mcp.CallToolResult, error) {
+	type actionSummary struct {
+		Name string `json:"name"`
+	}
+	type toolSummary struct {
+		Name        string          `json:"name"`
+		Description string          `json:"description"`
+		Workspace   bool            `json:"workspace"`
+		Actions     []actionSummary `json:"actions"`
+	}
+	tools := make([]toolSummary, 0, len(env.Catalog))
+	for _, def := range env.Catalog {
+		actions := make([]actionSummary, 0, len(def.Actions))
+		for _, name := range sortedActionNames(def) {
+			actions = append(actions, actionSummary{Name: name})
+		}
+		tools = append(tools, toolSummary{
+			Name:        def.Name,
+			Description: def.Description,
+			Workspace:   def.Schema.Workspace,
+			Actions:     actions,
+		})
+	}
+	payload := map[string]any{
+		"tool_surface_version": ToolSurfaceVersion,
+		"tools":                tools,
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return mcp.NewToolResultErrorf("pad_meta.tool-surface: marshal: %s", err.Error()), nil
+	}
+	return mcp.NewToolResultStructured(payload, string(body)), nil
+}

--- a/internal/mcp/catalog_meta.go
+++ b/internal/mcp/catalog_meta.go
@@ -110,19 +110,29 @@ func actionMetaVersion(_ context.Context, _ map[string]any, env ActionEnv) (*mcp
 // consumers can detect "catalog is partial" and fall back to
 // tools/list when they need the complete advertised surface.
 //
-// Schema is intentionally simple — name + description per tool, plus
-// per-action name + presence. Full per-action parameter schemas live
-// in tools/list (the JSON Schema mcp-go emits for each tool); the
-// catalog summary is a higher-level "what can this server do" view.
+// Schema: per-tool entries carry name + description + workspace flag +
+// actions[] + params[]. The params list is synthesized to mirror what
+// consumers see in tools/list — `action` (always required, enum of
+// declared actions), `workspace` (when ToolDef.Schema.Workspace=true),
+// and the per-tool ParamDefs. This makes the dump self-contained for
+// docs generators: they don't have to reproduce buildToolFromDef's
+// implicit-param logic separately.
 func actionMetaToolSurface(_ context.Context, _ map[string]any, env ActionEnv) (*mcp.CallToolResult, error) {
 	type actionSummary struct {
 		Name string `json:"name"`
+	}
+	type paramSummary struct {
+		Name        string   `json:"name"`
+		Type        string   `json:"type"`
+		Description string   `json:"description,omitempty"`
+		Enum        []string `json:"enum,omitempty"`
 	}
 	type toolSummary struct {
 		Name        string          `json:"name"`
 		Description string          `json:"description"`
 		Workspace   bool            `json:"workspace"`
 		Actions     []actionSummary `json:"actions"`
+		Params      []paramSummary  `json:"params"`
 	}
 	tools := make([]toolSummary, 0, len(env.Catalog))
 	for _, def := range env.Catalog {
@@ -130,11 +140,39 @@ func actionMetaToolSurface(_ context.Context, _ map[string]any, env ActionEnv) (
 		for _, name := range sortedActionNames(def) {
 			actions = append(actions, actionSummary{Name: name})
 		}
+		// `action` is always present and always required — buildToolFromDef
+		// injects it into the schema. Synthesize it here so consumers
+		// reading tool-surface get the full param picture without having
+		// to know about that injection. Enum mirrors sortedActionNames.
+		params := []paramSummary{{
+			Name:        "action",
+			Type:        "string",
+			Description: "The action to perform. Required.",
+			Enum:        sortedActionNames(def),
+		}}
+		if def.Schema.Workspace {
+			params = append(params, paramSummary{
+				Name: "workspace",
+				Type: "string",
+				Description: "Workspace slug. Defaults to the session workspace " +
+					"set via pad_set_workspace, then to the CWD-linked workspace " +
+					"from .pad.toml.",
+			})
+		}
+		for _, p := range def.Schema.Params {
+			params = append(params, paramSummary{
+				Name:        p.Name,
+				Type:        p.Type,
+				Description: p.Description,
+				Enum:        p.Enum,
+			})
+		}
 		tools = append(tools, toolSummary{
 			Name:        def.Name,
 			Description: def.Description,
 			Workspace:   def.Schema.Workspace,
 			Actions:     actions,
+			Params:      params,
 		})
 	}
 	// rollout_status is "complete" only after TASK-981 retires the

--- a/internal/mcp/catalog_meta.go
+++ b/internal/mcp/catalog_meta.go
@@ -45,15 +45,18 @@ var padMetaTool = ToolDef{
 	},
 }
 
-const padMetaToolDescription = `Server introspection — version, capabilities, and the full tool catalog.
+const padMetaToolDescription = `Server introspection — version, capabilities, and the v0.2 tool catalog.
 
 Actions:
   server-info   — Server name + runtime version. Lightweight; no params.
   version       — Full version metadata (pad version, cmdhelp version, tool surface
                   version, MCP protocol version). Same JSON as pad://_meta/version.
-  tool-surface  — Full catalog dump: every tool, its actions, and its input schema.
-                  Useful for agents that want to enumerate the surface programmatically
-                  rather than parsing tools/list.
+  tool-surface  — v0.2 catalog dump: every tool managed by the hand-curated catalog,
+                  its actions, and its input schema. During PLAN-969's rollout the
+                  cmdhelp walker also contributes to tools/list; tool-surface
+                  intentionally only enumerates the catalog (the source it can
+                  introspect cleanly). For the complete advertised surface, read
+                  tools/list directly.
 
 Use pad_meta when an agent needs to discover server capabilities or generate
 documentation. For runtime task work, use pad_item / pad_workspace / etc.`
@@ -90,10 +93,22 @@ func actionMetaVersion(_ context.Context, _ map[string]any, env ActionEnv) (*mcp
 	return mcp.NewToolResultStructured(payload, string(body)), nil
 }
 
-// actionMetaToolSurface returns the full catalog as JSON. Pairs with
+// actionMetaToolSurface returns the v0.2 catalog as JSON. Pairs with
 // PLAN-943 TASK-957 (getpad.dev/docs/mcp) — that page can generate
 // docs from this single canonical source instead of re-introspecting
 // tools/list and reverse-engineering action enums.
+//
+// Scope: the v0.2 catalog only. Until TASK-981 retires the cmdhelp
+// walker, tools/list contains both the catalog (currently pad_meta)
+// AND the walker-derived ~85 verb tools — but tool-surface
+// deliberately does not enumerate the walker output. The walker
+// surface is opaque to the catalog (no shared ToolDef shape), and
+// hand-mapping it would cost duplication for value that's about to
+// disappear in TASK-981.
+//
+// During rollout the response includes a `rollout_status` field so
+// consumers can detect "catalog is partial" and fall back to
+// tools/list when they need the complete advertised surface.
 //
 // Schema is intentionally simple — name + description per tool, plus
 // per-action name + presence. Full per-action parameter schemas live
@@ -122,8 +137,18 @@ func actionMetaToolSurface(_ context.Context, _ map[string]any, env ActionEnv) (
 			Actions:     actions,
 		})
 	}
+	// rollout_status is "complete" only after TASK-981 retires the
+	// cmdhelp walker and the catalog is the sole tools/list source.
+	// Before then, "in-progress" signals to consumers that the catalog
+	// is a strict subset of the advertised surface and they should
+	// read tools/list directly if they need everything.
+	rolloutStatus := "in-progress"
+	if ToolSurfaceVersion != "0.1" {
+		rolloutStatus = "complete"
+	}
 	payload := map[string]any{
 		"tool_surface_version": ToolSurfaceVersion,
+		"rollout_status":       rolloutStatus,
 		"tools":                tools,
 	}
 	body, err := json.Marshal(payload)

--- a/internal/mcp/catalog_meta_test.go
+++ b/internal/mcp/catalog_meta_test.go
@@ -115,6 +115,18 @@ func TestActionMetaToolSurface_DumpsCatalog(t *testing.T) {
 	if got["tool_surface_version"] != ToolSurfaceVersion {
 		t.Errorf("tool_surface_version = %v, want %q", got["tool_surface_version"], ToolSurfaceVersion)
 	}
+	// rollout_status signals to consumers that the catalog is a strict
+	// subset of tools/list during PLAN-969's parallel-rollout phase.
+	// "in-progress" while ToolSurfaceVersion stays at 0.1; flips to
+	// "complete" when TASK-981 bumps the constant.
+	wantStatus := "in-progress"
+	if ToolSurfaceVersion != "0.1" {
+		wantStatus = "complete"
+	}
+	if got["rollout_status"] != wantStatus {
+		t.Errorf("rollout_status = %v, want %q (ToolSurfaceVersion=%q)",
+			got["rollout_status"], wantStatus, ToolSurfaceVersion)
+	}
 	tools, ok := got["tools"].([]any)
 	if !ok {
 		t.Fatalf("tools is %T, want []any", got["tools"])

--- a/internal/mcp/catalog_meta_test.go
+++ b/internal/mcp/catalog_meta_test.go
@@ -1,0 +1,223 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// TestPadMetaTool_RegisteredInCatalog locks the invariant that init()
+// in catalog_meta.go appends padMetaTool to Catalog. If the registration
+// pattern changes (e.g. someone moves to explicit registration), this
+// test forces a deliberate update rather than silently dropping the tool.
+func TestPadMetaTool_RegisteredInCatalog(t *testing.T) {
+	found := false
+	for _, def := range Catalog {
+		if def.Name == "pad_meta" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("pad_meta missing from Catalog; init() in catalog_meta.go should appendToCatalog")
+	}
+}
+
+// TestActionMetaServerInfo_ReturnsServerNameAndVersion verifies the
+// minimal {name, version} pair. Empty PadVersion falls back to
+// FallbackVersion — same invariant the handshake's serverInfo honours,
+// so the agent never sees a blank version string.
+func TestActionMetaServerInfo_ReturnsServerNameAndVersion(t *testing.T) {
+	t.Run("explicit version", func(t *testing.T) {
+		env := ActionEnv{PadVersion: "1.2.3-test"}
+		res, err := actionMetaServerInfo(context.Background(), nil, env)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if res.IsError {
+			t.Fatalf("unexpected error: %s", textOf(res))
+		}
+		got := parseStructured(t, res)
+		if got["name"] != ServerName {
+			t.Errorf("name = %v, want %q", got["name"], ServerName)
+		}
+		if got["version"] != "1.2.3-test" {
+			t.Errorf("version = %v, want 1.2.3-test", got["version"])
+		}
+	})
+	t.Run("empty version falls back", func(t *testing.T) {
+		env := ActionEnv{PadVersion: ""}
+		res, err := actionMetaServerInfo(context.Background(), nil, env)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		got := parseStructured(t, res)
+		if got["version"] != FallbackVersion {
+			t.Errorf("version = %v, want fallback %q", got["version"], FallbackVersion)
+		}
+	})
+}
+
+// TestActionMetaVersion_MatchesMetaPayload verifies pad_meta.action:
+// version returns the exact same shape as pad://_meta/version. One
+// source of truth (BuildMetaPayload) keeps the two surfaces in sync;
+// this test is the regression net.
+func TestActionMetaVersion_MatchesMetaPayload(t *testing.T) {
+	const padVersion = "0.42.0-meta-test"
+	env := ActionEnv{PadVersion: padVersion}
+	res, err := actionMetaVersion(context.Background(), nil, env)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected error: %s", textOf(res))
+	}
+	var got MetaPayload
+	if err := json.Unmarshal([]byte(textOf(res)), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	want := BuildMetaPayload(padVersion)
+	if got != want {
+		t.Errorf("version payload mismatch\n got: %+v\nwant: %+v", got, want)
+	}
+	// Direct check on the new field — guards against a future build
+	// where MetaPayload accidentally drops ToolSurfaceVersion.
+	if got.ToolSurfaceVersion != ToolSurfaceVersion {
+		t.Errorf("ToolSurfaceVersion = %q, want %q", got.ToolSurfaceVersion, ToolSurfaceVersion)
+	}
+}
+
+// TestActionMetaToolSurface_DumpsCatalog verifies the action returns a
+// summary of every tool currently in Catalog. The shape is the
+// canonical source for getpad.dev/docs/mcp generation (PLAN-943
+// TASK-957) — locking it now so the docs page can pin against this
+// schema.
+func TestActionMetaToolSurface_DumpsCatalog(t *testing.T) {
+	env := ActionEnv{
+		PadVersion: "test",
+		Catalog:    Catalog, // production catalog
+	}
+	res, err := actionMetaToolSurface(context.Background(), nil, env)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected error: %s", textOf(res))
+	}
+	var got map[string]any
+	if err := json.Unmarshal([]byte(textOf(res)), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got["tool_surface_version"] != ToolSurfaceVersion {
+		t.Errorf("tool_surface_version = %v, want %q", got["tool_surface_version"], ToolSurfaceVersion)
+	}
+	tools, ok := got["tools"].([]any)
+	if !ok {
+		t.Fatalf("tools is %T, want []any", got["tools"])
+	}
+	if len(tools) != len(Catalog) {
+		t.Errorf("tools length = %d, want %d (one per Catalog entry)", len(tools), len(Catalog))
+	}
+	// Cross-check every tool entry mirrors a real Catalog entry.
+	byName := map[string]map[string]any{}
+	for _, t := range tools {
+		if m, ok := t.(map[string]any); ok {
+			byName[m["name"].(string)] = m
+		}
+	}
+	for _, def := range Catalog {
+		entry, ok := byName[def.Name]
+		if !ok {
+			t.Errorf("tool %q absent from tool-surface dump", def.Name)
+			continue
+		}
+		if entry["description"] != def.Description {
+			t.Errorf("%s.description mismatch", def.Name)
+		}
+		if entry["workspace"] != def.Schema.Workspace {
+			t.Errorf("%s.workspace = %v, want %v", def.Name, entry["workspace"], def.Schema.Workspace)
+		}
+		actions, ok := entry["actions"].([]any)
+		if !ok {
+			t.Errorf("%s.actions is %T, want []any", def.Name, entry["actions"])
+			continue
+		}
+		if len(actions) != len(def.Actions) {
+			t.Errorf("%s.actions length = %d, want %d", def.Name, len(actions), len(def.Actions))
+		}
+	}
+}
+
+// TestPadMetaTool_RoundTripThroughFanOut exercises the full path:
+// register → call via the fan-out handler → assert the result. Same
+// code path Claude Desktop hits on tools/call.
+func TestPadMetaTool_RoundTripThroughFanOut(t *testing.T) {
+	env := ActionEnv{PadVersion: "round-trip", Catalog: Catalog}
+	handler := makeFanOutHandler(padMetaTool, env)
+
+	cases := []struct {
+		action       string
+		wantContains string
+	}{
+		{"server-info", `"name":"pad-mcp"`},
+		{"version", `"tool_surface_version":"` + ToolSurfaceVersion + `"`},
+		{"tool-surface", `"tool_surface_version":"` + ToolSurfaceVersion + `"`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.action, func(t *testing.T) {
+			res, err := handler(context.Background(), callToolRequest(map[string]any{
+				"action": tc.action,
+			}))
+			if err != nil {
+				t.Fatalf("handler error: %v", err)
+			}
+			if res.IsError {
+				t.Fatalf("expected success, got error: %s", textOf(res))
+			}
+			if got := textOf(res); !strings.Contains(got, tc.wantContains) {
+				t.Errorf("result %q does not contain %q", got, tc.wantContains)
+			}
+		})
+	}
+}
+
+// TestPadMetaTool_NoWorkspaceInSchema confirms the schema for a server-
+// wide tool (Schema.Workspace=false) does NOT include a workspace
+// property. Server-introspection actions don't need a workspace —
+// adding one would mislead agents into thinking they should pass it.
+func TestPadMetaTool_NoWorkspaceInSchema(t *testing.T) {
+	tool := buildToolFromDef(padMetaTool)
+	raw, err := json.Marshal(tool.InputSchema)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(raw), `"workspace"`) {
+		t.Errorf("pad_meta schema unexpectedly includes 'workspace' property: %s", raw)
+	}
+}
+
+// parseStructured pulls the JSON body out of a structured tool result
+// and unmarshals it. mcp-go's NewToolResultStructured serializes the
+// Go value as text alongside the structured envelope; we read the
+// text form because that's what wire-level clients see.
+func parseStructured(t *testing.T, res *mcp.CallToolResult) map[string]any {
+	t.Helper()
+	body := textOf(res)
+	if body == "" {
+		t.Fatalf("expected non-empty structured result body")
+	}
+	var out map[string]any
+	if err := json.Unmarshal([]byte(body), &out); err != nil {
+		t.Fatalf("unmarshal structured body: %v\nbody=%s", err, body)
+	}
+	return out
+}
+
+// _ keeps the server import alive in this file even when only
+// catalog-level helpers are used — prevents a stray unused-import
+// warning if mcp-go's API changes mid-refactor.
+var _ = server.NewMCPServer

--- a/internal/mcp/catalog_meta_test.go
+++ b/internal/mcp/catalog_meta_test.go
@@ -161,7 +161,46 @@ func TestActionMetaToolSurface_DumpsCatalog(t *testing.T) {
 		if len(actions) != len(def.Actions) {
 			t.Errorf("%s.actions length = %d, want %d", def.Name, len(actions), len(def.Actions))
 		}
+
+		// params must always include an `action` entry (synthesized) so
+		// the dump is self-contained for docs generation. workspace is
+		// added when def.Schema.Workspace=true.
+		params, ok := entry["params"].([]any)
+		if !ok {
+			t.Errorf("%s.params is %T, want []any", def.Name, entry["params"])
+			continue
+		}
+		wantLen := 1 + len(def.Schema.Params)
+		if def.Schema.Workspace {
+			wantLen++
+		}
+		if len(params) != wantLen {
+			t.Errorf("%s.params length = %d, want %d (1 action + %d schema + %d workspace)",
+				def.Name, len(params), wantLen, len(def.Schema.Params), boolToInt(def.Schema.Workspace))
+		}
+		// First param is always `action` with full enum.
+		if len(params) > 0 {
+			first, _ := params[0].(map[string]any)
+			if first["name"] != "action" {
+				t.Errorf("%s.params[0].name = %v, want \"action\"", def.Name, first["name"])
+			}
+			enum, _ := first["enum"].([]any)
+			if len(enum) != len(def.Actions) {
+				t.Errorf("%s.params[0].enum length = %d, want %d (one per action)",
+					def.Name, len(enum), len(def.Actions))
+			}
+		}
 	}
+}
+
+// boolToInt is the trivial converter used in test failure messages
+// where formatting "n params + 0 workspace" reads cleaner than a
+// branching message.
+func boolToInt(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
 }
 
 // TestPadMetaTool_RoundTripThroughFanOut exercises the full path:

--- a/internal/mcp/catalog_test.go
+++ b/internal/mcp/catalog_test.go
@@ -1,0 +1,313 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+
+	"github.com/PerpetualSoftware/pad/internal/cmdhelp"
+)
+
+// TestRegisterCatalog_RegistersAllCatalogTools is the smoke test —
+// every ToolDef in Catalog gets registered exactly once.
+func TestRegisterCatalog_RegistersAllCatalogTools(t *testing.T) {
+	srv := server.NewMCPServer("t", "1", server.WithToolCapabilities(true))
+	count, err := RegisterCatalog(srv, CatalogOptions{
+		Doc:        fixtureDoc(),
+		Workspace:  NewWorkspaceState(""),
+		Dispatcher: &fakeDispatcher{},
+		PadVersion: "test",
+	})
+	if err != nil {
+		t.Fatalf("RegisterCatalog: %v", err)
+	}
+	if count != len(Catalog) {
+		t.Errorf("registered %d tools, want %d (one per Catalog entry)", count, len(Catalog))
+	}
+	if count == 0 {
+		t.Errorf("Catalog is empty — at least pad_meta should be present after init()")
+	}
+}
+
+// TestRegisterCatalog_RequiresOptions verifies the validation surface.
+// Each missing required field produces a clear error rather than a
+// nil-deref later in the action handler.
+func TestRegisterCatalog_RequiresOptions(t *testing.T) {
+	cases := []struct {
+		name string
+		opts CatalogOptions
+		want string
+	}{
+		{"missing Doc", CatalogOptions{Workspace: NewWorkspaceState(""), Dispatcher: &fakeDispatcher{}}, "Doc"},
+		{"missing Workspace", CatalogOptions{Doc: fixtureDoc(), Dispatcher: &fakeDispatcher{}}, "Workspace"},
+		{"missing Dispatcher", CatalogOptions{Doc: fixtureDoc(), Workspace: NewWorkspaceState("")}, "Dispatcher"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := server.NewMCPServer("t", "1", server.WithToolCapabilities(true))
+			_, err := RegisterCatalog(srv, tc.opts)
+			if err == nil {
+				t.Fatalf("expected error mentioning %q, got nil", tc.want)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error %q does not mention %q", err.Error(), tc.want)
+			}
+		})
+	}
+}
+
+// TestBuildToolFromDef_ActionRequiredAndEnumerated verifies that every
+// tool's input schema enforces `action` as required and enumerates the
+// declared action names. This is the schema invariant the fan-out
+// handler relies on.
+func TestBuildToolFromDef_ActionRequiredAndEnumerated(t *testing.T) {
+	def := ToolDef{
+		Name:        "pad_test",
+		Description: "test tool",
+		Schema:      ToolSchema{Workspace: true},
+		Actions: map[string]ActionFn{
+			"alpha":   passThrough([]string{"item", "list"}),
+			"bravo":   passThrough([]string{"item", "show"}),
+			"charlie": passThrough([]string{"item", "create"}),
+		},
+	}
+	tool := buildToolFromDef(def)
+	if tool.Name != "pad_test" {
+		t.Errorf("tool.Name = %q, want pad_test", tool.Name)
+	}
+
+	// The schema is exposed via JSON marshalling; round-trip through
+	// the wire shape so the test asserts what mcp-go actually emits.
+	raw, err := json.Marshal(tool.InputSchema)
+	if err != nil {
+		t.Fatalf("marshal input schema: %v", err)
+	}
+	var schema struct {
+		Properties map[string]struct {
+			Type string   `json:"type"`
+			Enum []string `json:"enum"`
+		} `json:"properties"`
+		Required []string `json:"required"`
+	}
+	if err := json.Unmarshal(raw, &schema); err != nil {
+		t.Fatalf("unmarshal input schema: %v", err)
+	}
+	action, ok := schema.Properties["action"]
+	if !ok {
+		t.Fatalf("input schema missing 'action' property; got %s", raw)
+	}
+	if action.Type != "string" {
+		t.Errorf("action.type = %q, want string", action.Type)
+	}
+	wantEnum := []string{"alpha", "bravo", "charlie"}
+	if !equalStrings(action.Enum, wantEnum) {
+		t.Errorf("action.enum = %v, want %v (lexically sorted)", action.Enum, wantEnum)
+	}
+	if !contains(schema.Required, "action") {
+		t.Errorf("'action' missing from required[]; got %v", schema.Required)
+	}
+	if _, ok := schema.Properties["workspace"]; !ok {
+		t.Errorf("Schema.Workspace=true but workspace property absent; got %s", raw)
+	}
+}
+
+// TestMakeFanOutHandler_DispatchesPerAction verifies the handler reads
+// `action` from the input, looks up the right ActionFn, and forwards.
+func TestMakeFanOutHandler_DispatchesPerAction(t *testing.T) {
+	called := ""
+	def := ToolDef{
+		Name:   "pad_test",
+		Schema: ToolSchema{},
+		Actions: map[string]ActionFn{
+			"foo": func(_ context.Context, _ map[string]any, _ ActionEnv) (*mcp.CallToolResult, error) {
+				called = "foo"
+				return mcp.NewToolResultText("foo-result"), nil
+			},
+			"bar": func(_ context.Context, _ map[string]any, _ ActionEnv) (*mcp.CallToolResult, error) {
+				called = "bar"
+				return mcp.NewToolResultText("bar-result"), nil
+			},
+		},
+	}
+	env := ActionEnv{Workspace: NewWorkspaceState("")}
+	handler := makeFanOutHandler(def, env)
+
+	res, err := handler(context.Background(), callToolRequest(map[string]any{"action": "bar"}))
+	if err != nil {
+		t.Fatalf("handler returned error: %v", err)
+	}
+	if res.IsError {
+		t.Errorf("expected success, got error result: %s", textOf(res))
+	}
+	if called != "bar" {
+		t.Errorf("expected 'bar' handler called, got %q", called)
+	}
+	if got := textOf(res); got != "bar-result" {
+		t.Errorf("result text = %q, want bar-result", got)
+	}
+}
+
+// TestMakeFanOutHandler_MissingAction returns a structured error
+// listing valid actions so the agent can self-correct without a
+// human round-trip. Wire-level guarantee: IsError = true, message
+// contains every valid action name.
+func TestMakeFanOutHandler_MissingAction(t *testing.T) {
+	def := ToolDef{
+		Name: "pad_test",
+		Actions: map[string]ActionFn{
+			"alpha": passThrough([]string{"item", "list"}),
+			"beta":  passThrough([]string{"item", "show"}),
+		},
+	}
+	handler := makeFanOutHandler(def, ActionEnv{Workspace: NewWorkspaceState("")})
+	res, err := handler(context.Background(), callToolRequest(map[string]any{}))
+	if err != nil {
+		t.Fatalf("handler returned protocol error (wanted IsError result): %v", err)
+	}
+	if !res.IsError {
+		t.Errorf("expected IsError=true; got success result %q", textOf(res))
+	}
+	msg := textOf(res)
+	if !strings.Contains(msg, "missing required field 'action'") {
+		t.Errorf("error message %q does not explain the missing field", msg)
+	}
+	if !strings.Contains(msg, "alpha") || !strings.Contains(msg, "beta") {
+		t.Errorf("error message %q should list valid actions (alpha, beta)", msg)
+	}
+}
+
+// TestMakeFanOutHandler_UnknownAction is the symmetric case: action is
+// set but not in the handler table. Same recovery pattern — list the
+// valid actions so the agent can retry.
+func TestMakeFanOutHandler_UnknownAction(t *testing.T) {
+	def := ToolDef{
+		Name: "pad_test",
+		Actions: map[string]ActionFn{
+			"foo": passThrough([]string{"item", "list"}),
+		},
+	}
+	handler := makeFanOutHandler(def, ActionEnv{Workspace: NewWorkspaceState("")})
+	res, err := handler(context.Background(), callToolRequest(map[string]any{"action": "nope"}))
+	if err != nil {
+		t.Fatalf("handler returned protocol error: %v", err)
+	}
+	if !res.IsError {
+		t.Errorf("expected IsError=true for unknown action")
+	}
+	msg := textOf(res)
+	if !strings.Contains(msg, `unknown action "nope"`) {
+		t.Errorf("error message %q does not name the bad action", msg)
+	}
+	if !strings.Contains(msg, "foo") {
+		t.Errorf("error message %q should list the one valid action", msg)
+	}
+}
+
+// TestPassThrough_ForwardsToDispatcher exercises the helper end-to-end
+// against a fake dispatcher. The dispatched cmdPath + cliArgs prove
+// that the input flowed through BuildCLIArgs unchanged.
+func TestPassThrough_ForwardsToDispatcher(t *testing.T) {
+	disp := &fakeDispatcher{}
+	env := ActionEnv{
+		Doc: &cmdhelp.Document{
+			CmdhelpVersion: "0.1",
+			Binary:         "pad",
+			Commands: map[string]cmdhelp.Command{
+				"item list": {
+					Summary: "List items",
+					Flags: map[string]cmdhelp.Flag{
+						"workspace": {Type: "string"},
+					},
+				},
+			},
+		},
+		Workspace:  NewWorkspaceState("docapp"),
+		Dispatcher: disp,
+	}
+	handler := passThrough([]string{"item", "list"})
+	res, err := handler(context.Background(), nil, env)
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected error result: %s", textOf(res))
+	}
+	if !equalStrings(disp.gotPath, []string{"item", "list"}) {
+		t.Errorf("dispatcher saw cmdPath %v, want [item list]", disp.gotPath)
+	}
+	// session workspace should be injected by BuildCLIArgs
+	wantArgs := []string{"--workspace", "docapp", "--format", "json"}
+	if !equalStrings(disp.gotArgs, wantArgs) {
+		t.Errorf("dispatcher saw cliArgs %v, want %v", disp.gotArgs, wantArgs)
+	}
+}
+
+// TestActionEnv_Dispatch_UnknownCmdPath catches catalog/cmdhelp drift.
+// If a future commit adds an action whose cmdPath isn't in cmdhelp,
+// this surfaces as a "registry bug" error result rather than a panic.
+func TestActionEnv_Dispatch_UnknownCmdPath(t *testing.T) {
+	env := ActionEnv{
+		Doc:        &cmdhelp.Document{Binary: "pad", Commands: map[string]cmdhelp.Command{}},
+		Workspace:  NewWorkspaceState(""),
+		Dispatcher: &fakeDispatcher{},
+	}
+	res, err := env.Dispatch(context.Background(), []string{"item", "ghost"}, nil)
+	if err != nil {
+		t.Fatalf("Dispatch returned protocol error (wanted IsError result): %v", err)
+	}
+	if !res.IsError {
+		t.Fatalf("expected IsError=true for unknown cmdPath")
+	}
+	if !strings.Contains(textOf(res), `unknown cmdPath "item ghost"`) {
+		t.Errorf("error message %q should name the missing cmdPath", textOf(res))
+	}
+}
+
+// ── test helpers ──
+
+// callToolRequest builds an mcp.CallToolRequest with the given input
+// arguments — the public constructor isn't exposed by mcp-go so we
+// reach for the same field-level construction the library's own
+// tests use.
+func callToolRequest(args map[string]any) mcp.CallToolRequest {
+	var req mcp.CallToolRequest
+	req.Params.Arguments = args
+	return req
+}
+
+// textOf returns the text of the first content block, or empty string.
+// Robust to mcp-go's content-type variations (TextContent, ErrorContent).
+func textOf(res *mcp.CallToolResult) string {
+	if res == nil || len(res.Content) == 0 {
+		return ""
+	}
+	if tc, ok := res.Content[0].(mcp.TextContent); ok {
+		return tc.Text
+	}
+	return ""
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func contains(haystack []string, needle string) bool {
+	for _, h := range haystack {
+		if h == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/mcp/meta.go
+++ b/internal/mcp/meta.go
@@ -19,11 +19,16 @@ type MetaPayload struct {
 	// PadVersion is the runtime version of the pad binary (e.g. "0.1.5").
 	PadVersion string `json:"pad_version"`
 
-	// CmdhelpVersion is the tool-surface stability tier. See the
+	// CmdhelpVersion is the CLI help-tree stability tier. See the
 	// CmdhelpVersion constant for the bump policy.
 	CmdhelpVersion string `json:"cmdhelp_version"`
 
-	// ToolSurfaceStable signals that the cmdhelp surface has shipped its
+	// ToolSurfaceVersion is the MCP tool catalog stability tier. See
+	// the ToolSurfaceVersion constant for the bump policy. Independent
+	// of CmdhelpVersion: the catalog can rev without changing the CLI.
+	ToolSurfaceVersion string `json:"tool_surface_version"`
+
+	// ToolSurfaceStable signals that the tool surface has shipped its
 	// stability contract. False during pre-release iteration.
 	ToolSurfaceStable bool `json:"tool_surface_stable"`
 
@@ -53,6 +58,7 @@ func BuildMetaPayload(padVersion string) MetaPayload {
 	return MetaPayload{
 		PadVersion:         padVersion,
 		CmdhelpVersion:     CmdhelpVersion,
+		ToolSurfaceVersion: ToolSurfaceVersion,
 		ToolSurfaceStable:  true,
 		MCPProtocolVersion: mcp.LATEST_PROTOCOL_VERSION,
 	}
@@ -97,8 +103,8 @@ func RegisterMeta(srv *server.MCPServer, padVersion string) {
 
 // experimentalCapabilities returns the map advertised at
 // capabilities.experimental in the initialize handshake's result
-// envelope. Lets clients discover the cmdhelp tier in one round-trip
-// without reading the meta resource.
+// envelope. Lets clients discover the cmdhelp + tool-surface tiers in
+// one round-trip without reading the meta resource.
 //
 // Wire shape:
 //
@@ -108,16 +114,28 @@ func RegisterMeta(srv *server.MCPServer, padVersion string) {
 //	      "padCmdhelp": {
 //	        "version":             "0.1",
 //	        "tool_surface_stable": true
+//	      },
+//	      "padToolSurface": {
+//	        "version":             "0.2",
+//	        "tool_surface_stable": true
 //	      }
 //	    },
 //	    ...
 //	  },
 //	  ...
 //	}
+//
+// Two independent contracts: padCmdhelp tracks CLI help-tree shape,
+// padToolSurface tracks the MCP tool catalog. They version separately
+// so a catalog reshape doesn't force a cmdhelp bump and vice versa.
 func experimentalCapabilities() map[string]any {
 	return map[string]any{
 		experimentalCapabilityKey: map[string]any{
 			"version":             CmdhelpVersion,
+			"tool_surface_stable": true,
+		},
+		experimentalToolSurfaceKey: map[string]any{
+			"version":             ToolSurfaceVersion,
 			"tool_surface_stable": true,
 		},
 	}

--- a/internal/mcp/meta_test.go
+++ b/internal/mcp/meta_test.go
@@ -21,6 +21,9 @@ func TestBuildMetaPayload_FallbackVersion(t *testing.T) {
 	if got.CmdhelpVersion != CmdhelpVersion {
 		t.Errorf("CmdhelpVersion = %q, want %q", got.CmdhelpVersion, CmdhelpVersion)
 	}
+	if got.ToolSurfaceVersion != ToolSurfaceVersion {
+		t.Errorf("ToolSurfaceVersion = %q, want %q", got.ToolSurfaceVersion, ToolSurfaceVersion)
+	}
 	if !got.ToolSurfaceStable {
 		t.Errorf("ToolSurfaceStable = false, want true")
 	}
@@ -56,7 +59,7 @@ func TestBuildMetaPayload_JSONFieldNames(t *testing.T) {
 	if err := json.Unmarshal(body, &raw); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	want := []string{"pad_version", "cmdhelp_version", "tool_surface_stable", "mcp_protocol_version"}
+	want := []string{"pad_version", "cmdhelp_version", "tool_surface_version", "tool_surface_stable", "mcp_protocol_version"}
 	for _, k := range want {
 		if _, ok := raw[k]; !ok {
 			t.Errorf("field %q missing from JSON; got keys %v", k, mapKeys(raw))

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -66,19 +66,34 @@ func TestServer_InitializeHandshake(t *testing.T) {
 	if exp == nil {
 		t.Fatalf("capabilities.experimental missing — cmdhelp tier not advertised")
 	}
-	rawNS, ok := exp[experimentalCapabilityKey]
+	assertExperimentalNamespace(t, exp, experimentalCapabilityKey, CmdhelpVersion)
+
+	// TASK-979 (PLAN-969): verify the v0.2 tool-surface tier is also on
+	// the wire. cmdhelp + tool-surface are independent contracts — both
+	// must be discoverable in the handshake so consumers don't have to
+	// fetch the meta resource to learn the catalog version.
+	assertExperimentalNamespace(t, exp, experimentalToolSurfaceKey, ToolSurfaceVersion)
+}
+
+// assertExperimentalNamespace fails the test if exp[key] doesn't carry
+// the expected version + a tool_surface_stable=true flag. Shared by the
+// padCmdhelp and padToolSurface assertions to keep the wire-level
+// contract uniform across both namespaces.
+func assertExperimentalNamespace(t *testing.T, exp map[string]any, key, wantVersion string) {
+	t.Helper()
+	rawNS, ok := exp[key]
 	if !ok {
-		t.Fatalf("experimental[%q] missing; got %#v", experimentalCapabilityKey, exp)
+		t.Fatalf("experimental[%q] missing; got keys %v", key, mapKeys(exp))
 	}
 	ns, ok := rawNS.(map[string]any)
 	if !ok {
-		t.Fatalf("experimental[%q] is %T, want map[string]any", experimentalCapabilityKey, rawNS)
+		t.Fatalf("experimental[%q] is %T, want map[string]any", key, rawNS)
 	}
-	if got := ns["version"]; got != CmdhelpVersion {
-		t.Errorf("experimental[%q].version = %v, want %q", experimentalCapabilityKey, got, CmdhelpVersion)
+	if got := ns["version"]; got != wantVersion {
+		t.Errorf("experimental[%q].version = %v, want %q", key, got, wantVersion)
 	}
 	if got := ns["tool_surface_stable"]; got != true {
-		t.Errorf("experimental[%q].tool_surface_stable = %v, want true", experimentalCapabilityKey, got)
+		t.Errorf("experimental[%q].tool_surface_stable = %v, want true", key, got)
 	}
 }
 

--- a/internal/mcp/version.go
+++ b/internal/mcp/version.go
@@ -22,19 +22,40 @@ const ServerName = "pad-mcp"
 // builds where the version string is empty.
 const FallbackVersion = "0.0.0-dev"
 
-// CmdhelpVersion is the tool-surface stability contract this MCP server
-// advertises. External agents (Claude Desktop, Cursor, ChatGPT
-// connectors, future Pad Cloud remote MCP) depend on tool names,
-// argument shapes, and resource URIs being stable across pad releases.
-// Bump the major when those change incompatibly:
+// CmdhelpVersion is the cmdhelp CLI-help-tree stability contract this
+// MCP server advertises. cmdhelp is the source of truth for individual
+// CLI command schemas (args, flags, types) consumed at MCP dispatch
+// time by BuildCLIArgs. Bump the major when those CLI-side schemas
+// change incompatibly:
 //
-//   - "0.1" — initial cmdhelp-derived surface from PLAN-942.
+//   - "0.1" — initial cmdhelp surface from PLAN-942.
+//
+// This is independent of ToolSurfaceVersion below — cmdhelp owns the
+// CLI's help-tree contract; ToolSurfaceVersion owns the MCP tool
+// catalog's contract. Two contracts, two version constants.
 //
 // Discovery surfaces (paths into the JSON-RPC envelope):
 //
 //   - result.capabilities.experimental.padCmdhelp.version (handshake).
 //   - pad://_meta/version resource (queryable JSON document).
 const CmdhelpVersion = "0.1"
+
+// ToolSurfaceVersion is the MCP tool catalog stability contract this
+// server advertises. External agents (Claude Desktop, Cursor, ChatGPT
+// connectors, future Pad Cloud remote MCP) pin against it so a future
+// tool rename, action enum change, or parameter reshape doesn't
+// silently break consumers. Bump the major when the catalog shape
+// changes incompatibly:
+//
+//   - "0.1" — cmdhelp-derived ~85 flat verb tools (PLAN-942).
+//   - "0.2" — hand-curated resource × action catalog (PLAN-969).
+//
+// Discovery surfaces:
+//
+//   - result.capabilities.experimental.padToolSurface.version (handshake).
+//   - pad://_meta/version resource (queryable JSON document).
+//   - pad_meta.action: tool-surface (full catalog introspection).
+const ToolSurfaceVersion = "0.2"
 
 // MetaVersionURI is the canonical URI of the queryable version document.
 // Lives outside the pad://workspace/{ws}/... namespace because it's a
@@ -53,3 +74,9 @@ const MetaVersionURI = "pad://_meta/version"
 // initialize handshake. Namespaced so other servers' experimental
 // capabilities don't collide.
 const experimentalCapabilityKey = "padCmdhelp"
+
+// experimentalToolSurfaceKey is the JSON object key under
+// capabilities.experimental that carries the MCP tool-catalog tier in
+// the initialize handshake. Distinct from experimentalCapabilityKey so
+// the cmdhelp and tool-surface contracts can version independently.
+const experimentalToolSurfaceKey = "padToolSurface"

--- a/internal/mcp/version.go
+++ b/internal/mcp/version.go
@@ -47,15 +47,26 @@ const CmdhelpVersion = "0.1"
 // silently break consumers. Bump the major when the catalog shape
 // changes incompatibly:
 //
-//   - "0.1" — cmdhelp-derived ~85 flat verb tools (PLAN-942).
-//   - "0.2" — hand-curated resource × action catalog (PLAN-969).
+//   - "0.1" — current. cmdhelp-derived ~85 flat verb tools (PLAN-942).
+//     During PLAN-969's 3-stage rollout, the v0.2 catalog
+//     scaffold + pad_meta tool also ride this version because
+//     the user-visible surface is still predominantly v0.1
+//     (the cmdhelp walker is still active alongside). Bumping
+//     before the catalog is complete would mislead consumers
+//     into believing the resource/action shape is available
+//     for every tool, when only pad_meta + the walker output
+//     show up in tools/list.
+//   - "0.2" — planned. Hand-curated resource × action catalog
+//     (PLAN-969). Version bumped in TASK-981, the commit that
+//     retires the cmdhelp walker and delivers the complete
+//     v0.2 catalog.
 //
 // Discovery surfaces:
 //
 //   - result.capabilities.experimental.padToolSurface.version (handshake).
 //   - pad://_meta/version resource (queryable JSON document).
 //   - pad_meta.action: tool-surface (full catalog introspection).
-const ToolSurfaceVersion = "0.2"
+const ToolSurfaceVersion = "0.1"
 
 // MetaVersionURI is the canonical URI of the queryable version document.
 // Lives outside the pad://workspace/{ws}/... namespace because it's a


### PR DESCRIPTION
## Summary
- Introduces the hand-curated v0.2 MCP catalog types (`ToolDef`, `ActionFn`, `ActionEnv`) and the fan-out registration path (`RegisterCatalog`).
- Ships **one** tool end-to-end: `pad_meta` with three inline actions — `server-info`, `version`, `tool-surface`.
- Adds `ToolSurfaceVersion = "0.2"` as an independent contract from `CmdhelpVersion`. Both advertised in handshake `_meta` and `pad://_meta/version`.
- v0.1 cmdhelp-walk surface is **untouched** — TASK-980 / TASK-981 migrate the rest and flip v0.1 off.

## Context

First commit of `TASK-970`'s 3-stage rollout under `PLAN-969` (Local MCP v2: idiomatic tool surface).

Architecture record at **DOC-978**. Driving feedback was a Claude Desktop dogfooding session against the v0.1 surface — ~85 deferred verb tools, no server instructions, raw error strings. The reshape is purely additive in this PR; `tools/list` will return the existing v0.1 surface plus `pad_meta`.

The fan-out registry sits **above** the dispatcher boundary — `Dispatcher` interface and `routeTable` (TASK-965/967/968) are unchanged. ExecDispatcher (stdio) and HTTPHandlerDispatcher (HTTP) both inherit the new shape automatically.

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./internal/mcp/...` passes
- [x] `make check` clean (lint + full test suite + web build)
- [x] New tests cover: catalog registration smoke, options validation (Doc/Workspace/Dispatcher required), schema invariants (`action` required + enumerated), fan-out missing/unknown action error envelopes, `passThrough` round-trip, `ActionEnv.Dispatch` unknown-cmdPath drift detection, all three `pad_meta` actions, MetaPayload's new `tool_surface_version` field, handshake's `experimental.padToolSurface` capability.
- [ ] Manual: connect Claude Desktop, verify `pad_meta` is in `tools/list` alongside the existing v0.1 surface (deferred to TASK-981 dogfood).