### PR TITLE
feat(mcp): v0.2 catalog read-only tools (workspace, collection, project, role, search) (TASK-980)

### DIFF
--- a/internal/mcp/catalog.go
+++ b/internal/mcp/catalog.go
@@ -313,6 +313,18 @@ func paramDefToToolOption(p ParamDef) mcp.ToolOption {
 // when the tool is called. Reads `action` from the input, looks up the
 // handler, and forwards. Unknown / missing action returns a structured
 // error result so the agent sees the valid options and can recover.
+//
+// The catalog's `action` key is stripped from the input before the
+// action handler runs. It's the fan-out routing field — its value
+// names the handler we just dispatched to, so the handler doesn't
+// need it. More importantly, leaving it in would shadow any CLI flag
+// named `--action` when the handler eventually dispatches: e.g.
+// `pad workspace audit-log --action item.created` reuses the same
+// flag name as our routing key, and BuildCLIArgs would emit
+// `--action audit-log` (the catalog action name) instead of the
+// user's filter. Stripping at the boundary keeps action handlers
+// free to talk to the dispatcher in CLI-flag terms without watching
+// for that collision.
 func makeFanOutHandler(def ToolDef, env ActionEnv) server.ToolHandlerFunc {
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		input := req.GetArguments()
@@ -327,7 +339,17 @@ func makeFanOutHandler(def ToolDef, env ActionEnv) server.ToolHandlerFunc {
 		if !ok {
 			return errUnknownAction(def, action), nil
 		}
-		return handler(ctx, input, env)
+		// Clone before stripping so we don't mutate req.Params.Arguments
+		// — defensive against any future mcp-go change that re-reads the
+		// request map after dispatch.
+		stripped := make(map[string]any, len(input))
+		for k, v := range input {
+			if k == "action" {
+				continue
+			}
+			stripped[k] = v
+		}
+		return handler(ctx, stripped, env)
 	}
 }
 

--- a/internal/mcp/catalog_collection.go
+++ b/internal/mcp/catalog_collection.go
@@ -1,0 +1,82 @@
+package mcp
+
+// padCollectionTool exposes collection management. Two actions in
+// v0.2: list (read-only) and create (admin-mutating).
+//
+// `schema` was discussed in DOC-978 but dropped from v0.2 — the CLI
+// has no `collection schema` command, and consumers can read each
+// collection's schema field from the `list` response. If dogfooding
+// (TASK-975) shows demand for a dedicated read-by-slug action, add
+// it as a follow-up rather than synthesizing one inside the catalog.
+
+func init() {
+	appendToCatalog(padCollectionTool)
+}
+
+var padCollectionTool = ToolDef{
+	Name:        "pad_collection",
+	Description: padCollectionToolDescription,
+	Schema: ToolSchema{
+		Workspace: true,
+		Params: []ParamDef{
+			{
+				Name:        "name",
+				Type:        "string",
+				Description: "Display name of the collection. Required for action=create.",
+			},
+			{
+				Name:        "fields",
+				Type:        "string",
+				Description: "Field DSL: \"key:type[:options]; ...\". Optional for action=create. Example: \"status:select:open,done; priority:select:high,medium,low\".",
+			},
+			{
+				Name:        "icon",
+				Type:        "string",
+				Description: "Emoji icon for the collection (e.g. \"🐛\"). Optional for action=create.",
+			},
+			{
+				Name:        "description",
+				Type:        "string",
+				Description: "Plain-text description of the collection's purpose. Optional for action=create.",
+			},
+			{
+				Name:        "layout",
+				Type:        "string",
+				Description: "UI layout hint. Optional for action=create.",
+				Enum:        []string{"fields-primary", "content-primary", "balanced"},
+			},
+			{
+				Name:        "default_view",
+				Type:        "string",
+				Description: "Default view mode. Optional for action=create.",
+				Enum:        []string{"list", "board", "table"},
+			},
+			{
+				Name:        "board_group_by",
+				Type:        "string",
+				Description: "Field key to group by when in board view. Optional for action=create. Defaults to \"status\".",
+			},
+		},
+	},
+	Actions: map[string]ActionFn{
+		"list":   passThrough([]string{"collection", "list"}),
+		"create": passThrough([]string{"collection", "create"}),
+	},
+}
+
+const padCollectionToolDescription = `Collection management — list and create collection types.
+
+Actions:
+  list    — List collections in the workspace with their schemas + counts.
+            Required: workspace.
+  create  — Create a new collection.
+            Required: workspace, name.
+            Optional: fields, icon, description, layout, default_view, board_group_by.
+            Field DSL example: "status:select:open,done; priority:select:high,medium,low".
+
+Schema for an individual collection is included in the list response — read it
+from there rather than calling list again. v0.2 does not expose a dedicated
+read-by-slug action; if you need that, file a feature request.
+
+Use pad_collection when an agent needs to discover collection types or set up
+a new one. For item-level CRUD inside a collection, use pad_item.`

--- a/internal/mcp/catalog_project.go
+++ b/internal/mcp/catalog_project.go
@@ -1,0 +1,58 @@
+package mcp
+
+// padProjectTool exposes project intelligence — computed views over
+// the workspace state. All actions are read-only.
+
+func init() {
+	appendToCatalog(padProjectTool)
+}
+
+var padProjectTool = ToolDef{
+	Name:        "pad_project",
+	Description: padProjectToolDescription,
+	Schema: ToolSchema{
+		Workspace: true,
+		Params: []ParamDef{
+			{
+				Name:        "days",
+				Type:        "number",
+				Description: "Lookback window in days. Optional for action=standup (default 1) and action=changelog (default 7).",
+			},
+			{
+				Name:        "since",
+				Type:        "string",
+				Description: "ISO date (YYYY-MM-DD) — include changes on or after this date. Optional for action=changelog. Mutually exclusive with `days`.",
+			},
+			{
+				Name:        "parent",
+				Type:        "string",
+				Description: "Parent item ref (e.g. PLAN-2). Optional for action=changelog — scope the changelog to items under this parent.",
+			},
+		},
+	},
+	Actions: map[string]ActionFn{
+		"dashboard": passThrough([]string{"project", "dashboard"}),
+		"next":      passThrough([]string{"project", "next"}),
+		"standup":   passThrough([]string{"project", "standup"}),
+		"changelog": passThrough([]string{"project", "changelog"}),
+	},
+}
+
+const padProjectToolDescription = `Project intelligence — computed views over workspace state.
+
+Actions:
+  dashboard  — Project overview: collections, active items, plans, attention,
+               blockers, suggested next.
+               Required: workspace.
+  next       — Recommended next item to work on (uses dashboard's suggestion logic).
+               Required: workspace.
+  standup    — Daily standup report (recent done, in-progress, blockers).
+               Required: workspace.
+               Optional: days (default 1).
+  changelog  — Changelog of completed items.
+               Required: workspace.
+               Optional: days (default 7), since (ISO date), parent (item ref to scope).
+               Use parent=PLAN-N to generate a release-notes view for one plan.
+
+Use pad_project when an agent needs to summarize progress, plan next work, or
+generate retro / standup / changelog reports.`

--- a/internal/mcp/catalog_readonly_test.go
+++ b/internal/mcp/catalog_readonly_test.go
@@ -129,6 +129,98 @@ func TestReadOnlyCatalog_ActionsMatchCmdhelp(t *testing.T) {
 	}
 }
 
+// TestReadOnlyCatalog_ActionsDispatchExpectedCmdPath actually invokes
+// every catalog action through a fake dispatcher and asserts the
+// captured cmdPath matches the expected table from
+// TestReadOnlyCatalog_ActionsMatchCmdhelp. Closes the catalog → dispatch
+// drift hole — without this, a typo like
+// passThrough([]string{"some", "other"}) on pad_search.query would
+// pass the bijection check (the action name still matches) but
+// silently dispatch to the wrong command.
+//
+// The fixtureInput map covers every required positional arg across
+// the read-only surface so the action handlers all reach Dispatch
+// rather than erroring on missing input. Extra keys are harmless —
+// BuildCLIArgs ignores anything that isn't in cmdInfo.Flags or
+// cmdInfo.Args.
+func TestReadOnlyCatalog_ActionsDispatchExpectedCmdPath(t *testing.T) {
+	doc := liveCmdhelpDoc(t)
+	// Mirror of expected{} in the bijection test, kept literal so a
+	// renamed cmdPath fails THIS test loudly with the actual
+	// dispatched path printed in the error message.
+	expected := map[[2]string][]string{
+		{"pad_workspace", "list"}:      {"workspace", "list"},
+		{"pad_workspace", "members"}:   {"workspace", "members"},
+		{"pad_workspace", "invite"}:    {"workspace", "invite"},
+		{"pad_workspace", "storage"}:   {"workspace", "storage"},
+		{"pad_workspace", "audit-log"}: {"workspace", "audit-log"},
+
+		{"pad_collection", "list"}:   {"collection", "list"},
+		{"pad_collection", "create"}: {"collection", "create"},
+
+		{"pad_project", "dashboard"}: {"project", "dashboard"},
+		{"pad_project", "next"}:      {"project", "next"},
+		{"pad_project", "standup"}:   {"project", "standup"},
+		{"pad_project", "changelog"}: {"project", "changelog"},
+
+		{"pad_role", "list"}:   {"role", "list"},
+		{"pad_role", "create"}: {"role", "create"},
+		{"pad_role", "delete"}: {"role", "delete"},
+
+		{"pad_search", "query"}: {"item", "search"},
+	}
+
+	// Required-positional fixture: every CLI command in the read-only
+	// surface gets its required args satisfied so BuildCLIArgs reaches
+	// dispatcher.Dispatch instead of returning a missing-arg error.
+	fixtureInput := map[string]any{
+		"email": "test@example.com",
+		"name":  "test-name",
+		"slug":  "test-slug",
+		"query": "test-query",
+	}
+
+	for _, def := range Catalog {
+		if def.Name == "pad_meta" {
+			continue // inline-handled, doesn't dispatch
+		}
+		for actionName, handler := range def.Actions {
+			key := [2]string{def.Name, actionName}
+			wantCmdPath, ok := expected[key]
+			if !ok {
+				// Already covered by TestReadOnlyCatalog_ActionsMatchCmdhelp's
+				// bijection check; skip silently here to keep this test
+				// focused on dispatch correctness.
+				continue
+			}
+			t.Run(def.Name+"."+actionName, func(t *testing.T) {
+				disp := &fakeDispatcher{}
+				env := ActionEnv{
+					Doc:        doc,
+					Workspace:  NewWorkspaceState("docapp"),
+					Dispatcher: disp,
+				}
+				// Per-test copy so cross-test ordering doesn't matter.
+				input := make(map[string]any, len(fixtureInput))
+				for k, v := range fixtureInput {
+					input[k] = v
+				}
+				res, err := handler(context.Background(), input, env)
+				if err != nil {
+					t.Fatalf("handler returned protocol error: %v", err)
+				}
+				if res != nil && res.IsError {
+					t.Fatalf("handler returned error result (BuildCLIArgs likely missing input): %s",
+						textOf(res))
+				}
+				if !equalStrings(disp.gotPath, wantCmdPath) {
+					t.Errorf("dispatched cmdPath = %v, want %v", disp.gotPath, wantCmdPath)
+				}
+			})
+		}
+	}
+}
+
 // TestPadWorkspaceAuditLog_RenamesActionFilter is the regression test
 // for the action-flag-shadow bug: the catalog's `action_filter` input
 // must arrive at the dispatcher as `--action <value>`. If the rename

--- a/internal/mcp/catalog_readonly_test.go
+++ b/internal/mcp/catalog_readonly_test.go
@@ -9,9 +9,9 @@ import (
 )
 
 // TestReadOnlyCatalog_AllToolsRegistered locks the v0.2 read-only
-// surface. If a future commit accidentally drops a tool from
-// appendToCatalog (or adds one without intent), this test forces a
-// deliberate update to the expected list.
+// surface. Catches drift in BOTH directions — drops (expected tool
+// missing) and unexpected adds (a new tool registered without
+// updating this test).
 func TestReadOnlyCatalog_AllToolsRegistered(t *testing.T) {
 	want := map[string]bool{
 		// pad_meta is from TASK-979; the rest are TASK-980.
@@ -25,30 +25,47 @@ func TestReadOnlyCatalog_AllToolsRegistered(t *testing.T) {
 	for _, def := range Catalog {
 		if _, ok := want[def.Name]; ok {
 			want[def.Name] = true
+			continue
 		}
+		// Unexpected tool — surface it loudly. If the addition is
+		// intentional (TASK-981 will add pad_item), bump this test's
+		// `want` map in the same commit.
+		t.Errorf("unexpected catalog entry %q — update want{} in this test if intentional",
+			def.Name)
 	}
 	for name, found := range want {
 		if !found {
 			t.Errorf("expected catalog entry %q not registered", name)
 		}
 	}
+	if len(Catalog) != len(want) {
+		t.Errorf("Catalog has %d tools, expected exactly %d", len(Catalog), len(want))
+	}
 }
 
 // TestReadOnlyCatalog_ActionsMatchCmdhelp guards against cmdhelp drift.
-// Every passThrough action's cmdPath must resolve in cmdhelp; if it
-// doesn't, env.Dispatch returns a "registry bug" error at runtime —
-// this test catches it at compile-time-of-test rather than waiting for
-// a user to hit the action.
+// Three-way validation:
 //
-// Custom (non-passThrough) actions are skipped because they may
-// reshape the input or compose multiple cmdPaths internally.
+//  1. Every entry in `expected` must point at a cmdPath that exists in
+//     cmdhelp (catches typos in our own table).
+//  2. Every action in every catalog tool (except pad_meta, which
+//     handles inline) must have an entry in `expected` (catches new
+//     actions added without test coverage).
+//  3. Every entry in `expected` must correspond to an actual catalog
+//     action (catches table entries that outlive the action they
+//     describe).
+//
+// pad_meta is excluded because its actions are inline server-info /
+// version / tool-surface — they don't dispatch to a CLI cmdPath.
+//
+// pad_item is excluded for now — TASK-981 adds it; the same test
+// gets extended there with the expected entries.
 func TestReadOnlyCatalog_ActionsMatchCmdhelp(t *testing.T) {
 	doc := liveCmdhelpDoc(t)
 
-	// Hand-curated map of (toolName, action) → expected cmdPath, used
-	// to catch silent renames in catalog_*.go. Custom handlers
-	// (workspace audit-log) appear here too — they dispatch to the
-	// listed cmdPath even though the input shape differs.
+	// Hand-curated map of (toolName, action) → expected cmdPath. Custom
+	// handlers (workspace audit-log) appear here too — they dispatch
+	// to the listed cmdPath even though the input shape differs.
 	expected := map[[2]string][]string{
 		{"pad_workspace", "list"}:      {"workspace", "list"},
 		{"pad_workspace", "members"}:   {"workspace", "members"},
@@ -70,11 +87,44 @@ func TestReadOnlyCatalog_ActionsMatchCmdhelp(t *testing.T) {
 
 		{"pad_search", "query"}: {"item", "search"},
 	}
+
+	// Direction 1: every expected cmdPath resolves in cmdhelp.
 	for key, cmdPath := range expected {
 		joined := strings.Join(cmdPath, " ")
 		if _, ok := doc.Commands[joined]; !ok {
-			t.Errorf("%s.action=%s maps to cmdPath %q which is not in cmdhelp",
+			t.Errorf("expected[%s.%s] = %q is not in cmdhelp",
 				key[0], key[1], joined)
+		}
+	}
+
+	// Tools that handle their actions inline (no CLI dispatch) are
+	// skipped — they're correct as-is and don't need expected entries.
+	skipTools := map[string]bool{
+		"pad_meta": true,
+	}
+
+	// Direction 2 + 3: catalog ⇄ expected bijection (modulo skipTools).
+	// Every catalog action (in non-skipped tools) needs a cmdPath
+	// entry; every entry needs a corresponding catalog action.
+	catalogActions := map[[2]string]bool{}
+	for _, def := range Catalog {
+		if skipTools[def.Name] {
+			continue
+		}
+		for actionName := range def.Actions {
+			catalogActions[[2]string{def.Name, actionName}] = true
+		}
+	}
+	for key := range catalogActions {
+		if _, ok := expected[key]; !ok {
+			t.Errorf("catalog has %s.%s but no expected cmdPath entry — add one to expected{}",
+				key[0], key[1])
+		}
+	}
+	for key := range expected {
+		if !catalogActions[key] {
+			t.Errorf("expected entry for %s.%s but no such action in catalog",
+				key[0], key[1])
 		}
 	}
 }

--- a/internal/mcp/catalog_readonly_test.go
+++ b/internal/mcp/catalog_readonly_test.go
@@ -1,0 +1,237 @@
+package mcp
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/cmdhelp"
+)
+
+// TestReadOnlyCatalog_AllToolsRegistered locks the v0.2 read-only
+// surface. If a future commit accidentally drops a tool from
+// appendToCatalog (or adds one without intent), this test forces a
+// deliberate update to the expected list.
+func TestReadOnlyCatalog_AllToolsRegistered(t *testing.T) {
+	want := map[string]bool{
+		// pad_meta is from TASK-979; the rest are TASK-980.
+		"pad_meta":       false,
+		"pad_workspace":  false,
+		"pad_collection": false,
+		"pad_project":    false,
+		"pad_role":       false,
+		"pad_search":     false,
+	}
+	for _, def := range Catalog {
+		if _, ok := want[def.Name]; ok {
+			want[def.Name] = true
+		}
+	}
+	for name, found := range want {
+		if !found {
+			t.Errorf("expected catalog entry %q not registered", name)
+		}
+	}
+}
+
+// TestReadOnlyCatalog_ActionsMatchCmdhelp guards against cmdhelp drift.
+// Every passThrough action's cmdPath must resolve in cmdhelp; if it
+// doesn't, env.Dispatch returns a "registry bug" error at runtime —
+// this test catches it at compile-time-of-test rather than waiting for
+// a user to hit the action.
+//
+// Custom (non-passThrough) actions are skipped because they may
+// reshape the input or compose multiple cmdPaths internally.
+func TestReadOnlyCatalog_ActionsMatchCmdhelp(t *testing.T) {
+	doc := liveCmdhelpDoc(t)
+
+	// Hand-curated map of (toolName, action) → expected cmdPath, used
+	// to catch silent renames in catalog_*.go. Custom handlers
+	// (workspace audit-log) appear here too — they dispatch to the
+	// listed cmdPath even though the input shape differs.
+	expected := map[[2]string][]string{
+		{"pad_workspace", "list"}:      {"workspace", "list"},
+		{"pad_workspace", "members"}:   {"workspace", "members"},
+		{"pad_workspace", "invite"}:    {"workspace", "invite"},
+		{"pad_workspace", "storage"}:   {"workspace", "storage"},
+		{"pad_workspace", "audit-log"}: {"workspace", "audit-log"},
+
+		{"pad_collection", "list"}:   {"collection", "list"},
+		{"pad_collection", "create"}: {"collection", "create"},
+
+		{"pad_project", "dashboard"}: {"project", "dashboard"},
+		{"pad_project", "next"}:      {"project", "next"},
+		{"pad_project", "standup"}:   {"project", "standup"},
+		{"pad_project", "changelog"}: {"project", "changelog"},
+
+		{"pad_role", "list"}:   {"role", "list"},
+		{"pad_role", "create"}: {"role", "create"},
+		{"pad_role", "delete"}: {"role", "delete"},
+
+		{"pad_search", "query"}: {"item", "search"},
+	}
+	for key, cmdPath := range expected {
+		joined := strings.Join(cmdPath, " ")
+		if _, ok := doc.Commands[joined]; !ok {
+			t.Errorf("%s.action=%s maps to cmdPath %q which is not in cmdhelp",
+				key[0], key[1], joined)
+		}
+	}
+}
+
+// TestPadWorkspaceAuditLog_RenamesActionFilter is the regression test
+// for the action-flag-shadow bug: the catalog's `action_filter` input
+// must arrive at the dispatcher as `--action <value>`. If the rename
+// regresses, audit-log filtering silently breaks.
+func TestPadWorkspaceAuditLog_RenamesActionFilter(t *testing.T) {
+	disp := &fakeDispatcher{}
+	env := ActionEnv{
+		Doc:        liveCmdhelpDoc(t),
+		Workspace:  NewWorkspaceState("docapp"),
+		Dispatcher: disp,
+	}
+
+	_, err := actionWorkspaceAuditLog(context.Background(), map[string]any{
+		"action_filter": "item.created",
+		"days":          float64(7),
+	}, env)
+	if err != nil {
+		t.Fatalf("dispatch error: %v", err)
+	}
+	if !equalStrings(disp.gotPath, []string{"workspace", "audit-log"}) {
+		t.Errorf("cmdPath = %v, want [workspace audit-log]", disp.gotPath)
+	}
+	// The dispatched cliArgs should include "--action item.created"
+	// and "--days 7" — not "--action_filter ..." and not bare action.
+	joined := strings.Join(disp.gotArgs, " ")
+	if !strings.Contains(joined, "--action item.created") {
+		t.Errorf("cliArgs should contain '--action item.created'; got %q", joined)
+	}
+	if strings.Contains(joined, "action_filter") {
+		t.Errorf("cliArgs should not contain 'action_filter' (rename leaked); got %q", joined)
+	}
+	if !strings.Contains(joined, "--days 7") {
+		t.Errorf("cliArgs should contain '--days 7'; got %q", joined)
+	}
+}
+
+// TestPadWorkspaceAuditLog_ForwardsWithoutFilter exercises the
+// no-rename path: a call with no action_filter dispatches identically
+// to passThrough.
+func TestPadWorkspaceAuditLog_ForwardsWithoutFilter(t *testing.T) {
+	disp := &fakeDispatcher{}
+	env := ActionEnv{
+		Doc:        liveCmdhelpDoc(t),
+		Workspace:  NewWorkspaceState("docapp"),
+		Dispatcher: disp,
+	}
+	_, err := actionWorkspaceAuditLog(context.Background(), map[string]any{
+		"actor": "dave",
+	}, env)
+	if err != nil {
+		t.Fatalf("dispatch error: %v", err)
+	}
+	joined := strings.Join(disp.gotArgs, " ")
+	if !strings.Contains(joined, "--actor dave") {
+		t.Errorf("cliArgs should contain '--actor dave'; got %q", joined)
+	}
+	if strings.Contains(joined, "--action ") {
+		t.Errorf("cliArgs should not contain '--action ...' when no filter set; got %q", joined)
+	}
+}
+
+// liveCmdhelpDoc returns a minimal cmdhelp.Document with every
+// command path the read-only catalog references. Lighter than
+// re-running pad's full cobra emitter inside tests; lets the
+// table-driven assertions above run without external deps.
+func liveCmdhelpDoc(t *testing.T) *cmdhelp.Document {
+	t.Helper()
+	mkFlags := func(names ...string) map[string]cmdhelp.Flag {
+		out := make(map[string]cmdhelp.Flag, len(names))
+		for _, n := range names {
+			out[n] = cmdhelp.Flag{Type: "string"}
+		}
+		return out
+	}
+	mkArgs := func(names ...string) []cmdhelp.Arg {
+		out := make([]cmdhelp.Arg, len(names))
+		for i, n := range names {
+			out[i] = cmdhelp.Arg{Name: n, Required: true}
+		}
+		return out
+	}
+	return &cmdhelp.Document{
+		CmdhelpVersion: "0.1",
+		Binary:         "pad",
+		Commands: map[string]cmdhelp.Command{
+			// Workspace
+			"workspace list":    {Summary: "list ws"},
+			"workspace members": {Summary: "list members", Flags: mkFlags("workspace")},
+			"workspace invite": {
+				Summary: "invite",
+				Args:    mkArgs("email"),
+				Flags:   mkFlags("workspace", "role"),
+			},
+			"workspace storage": {Summary: "storage", Flags: mkFlags("workspace")},
+			"workspace audit-log": {
+				Summary: "audit log",
+				Flags: map[string]cmdhelp.Flag{
+					"action": {Type: "string"},
+					"actor":  {Type: "string"},
+					"days":   {Type: "int"},
+					"limit":  {Type: "int"},
+				},
+			},
+			// Collection
+			"collection list": {Summary: "list cols", Flags: mkFlags("workspace")},
+			"collection create": {
+				Summary: "create col",
+				Args:    mkArgs("name"),
+				Flags: mkFlags(
+					"workspace", "fields", "icon", "description",
+					"layout", "default-view", "board-group-by",
+				),
+			},
+			// Project
+			"project dashboard": {Summary: "dash", Flags: mkFlags("workspace")},
+			"project next":      {Summary: "next", Flags: mkFlags("workspace")},
+			"project standup": {
+				Summary: "standup",
+				Flags: map[string]cmdhelp.Flag{
+					"workspace": {Type: "string"},
+					"days":      {Type: "int"},
+				},
+			},
+			"project changelog": {
+				Summary: "changelog",
+				Flags: map[string]cmdhelp.Flag{
+					"workspace": {Type: "string"},
+					"days":      {Type: "int"},
+					"since":     {Type: "string"},
+					"parent":    {Type: "string"},
+				},
+			},
+			// Role
+			"role list": {Summary: "list roles", Flags: mkFlags("workspace")},
+			"role create": {
+				Summary: "create role",
+				Args:    mkArgs("name"),
+				Flags:   mkFlags("workspace", "description", "icon", "tools"),
+			},
+			"role delete": {
+				Summary: "delete role",
+				Args:    mkArgs("slug"),
+				Flags:   mkFlags("workspace"),
+			},
+			// Search (item search)
+			"item search": {
+				Summary: "search items",
+				Args:    mkArgs("query"),
+				Flags: mkFlags(
+					"workspace", "collection", "status", "priority",
+					"sort", "limit", "offset",
+				),
+			},
+		},
+	}
+}

--- a/internal/mcp/catalog_role.go
+++ b/internal/mcp/catalog_role.go
@@ -1,0 +1,64 @@
+package mcp
+
+// padRoleTool exposes agent-role management. Roles let users organize
+// items by what kind of thinking is required (Planner / Implementer /
+// Reviewer). One per (user, role) assignment on items.
+
+func init() {
+	appendToCatalog(padRoleTool)
+}
+
+var padRoleTool = ToolDef{
+	Name:        "pad_role",
+	Description: padRoleToolDescription,
+	Schema: ToolSchema{
+		Workspace: true,
+		Params: []ParamDef{
+			{
+				Name:        "name",
+				Type:        "string",
+				Description: "Display name of the role (e.g. \"Implementer\"). Required for action=create.",
+			},
+			{
+				Name:        "slug",
+				Type:        "string",
+				Description: "Role slug (e.g. \"implementer\"). Required for action=delete.",
+			},
+			{
+				Name:        "description",
+				Type:        "string",
+				Description: "What kind of work this role does. Optional for action=create.",
+			},
+			{
+				Name:        "icon",
+				Type:        "string",
+				Description: "Emoji icon for the role (e.g. \"🔨\"). Optional for action=create.",
+			},
+			{
+				Name:        "tools",
+				Type:        "string",
+				Description: "Comma-separated list of tools/integrations the role uses. Optional for action=create.",
+			},
+		},
+	},
+	Actions: map[string]ActionFn{
+		"list":   passThrough([]string{"role", "list"}),
+		"create": passThrough([]string{"role", "create"}),
+		"delete": passThrough([]string{"role", "delete"}),
+	},
+}
+
+const padRoleToolDescription = `Agent role management — what kind of thinking each item requires.
+
+Actions:
+  list    — List roles in the workspace.
+            Required: workspace.
+  create  — Create a new role.
+            Required: workspace, name.
+            Optional: description, icon, tools.
+  delete  — Delete a role by slug.
+            Required: workspace, slug.
+
+Roles let users organize items by what kind of work they require (Planner,
+Implementer, Reviewer, Researcher, etc.). To assign an item to a role, use
+pad_item.action=update with the role parameter.`

--- a/internal/mcp/catalog_search.go
+++ b/internal/mcp/catalog_search.go
@@ -1,0 +1,77 @@
+package mcp
+
+// padSearchTool exposes full-text search across all items. Cross-
+// workspace by design — the underlying CLI command (`pad item search`)
+// queries an FTS index over every workspace the user can read.
+//
+// Why a separate tool instead of folding into pad_item: search is the
+// one operation that doesn't fit pad_item's "operate on a single item
+// or a single collection" mental model. Carving it out keeps pad_item's
+// action enum focused.
+
+func init() {
+	appendToCatalog(padSearchTool)
+}
+
+var padSearchTool = ToolDef{
+	Name:        "pad_search",
+	Description: padSearchToolDescription,
+	Schema: ToolSchema{
+		Workspace: true,
+		Params: []ParamDef{
+			{
+				Name:        "query",
+				Type:        "string",
+				Description: "Search query string. FTS syntax supported. Required.",
+			},
+			{
+				Name:        "collection",
+				Type:        "string",
+				Description: "Restrict results to items in this collection slug (e.g. \"tasks\"). Optional.",
+			},
+			{
+				Name:        "status",
+				Type:        "string",
+				Description: "Restrict results to items with this status. Optional.",
+			},
+			{
+				Name:        "priority",
+				Type:        "string",
+				Description: "Restrict results to items with this priority. Optional.",
+			},
+			{
+				Name:        "sort",
+				Type:        "string",
+				Description: "Sort order for results. Optional.",
+			},
+			{
+				Name:        "limit",
+				Type:        "number",
+				Description: "Maximum results to return. Optional.",
+			},
+			{
+				Name:        "offset",
+				Type:        "number",
+				Description: "Pagination offset. Optional.",
+			},
+		},
+	},
+	Actions: map[string]ActionFn{
+		// `pad item search` is the underlying CLI command — search is
+		// item-level FTS. The catalog exposes it under pad_search rather
+		// than pad_item.action: search because the operation is logically
+		// distinct (cross-workspace, scoring) and folding it would force
+		// an unwieldy union schema on pad_item.
+		"query": passThrough([]string{"item", "search"}),
+	},
+}
+
+const padSearchToolDescription = `Full-text search across items.
+
+Actions:
+  query  — FTS search across items. Required: workspace, query.
+           Optional filters: collection, status, priority, sort, limit, offset.
+
+Use pad_search when looking for items by content keywords or fuzzy title match.
+For ref-based lookup (TASK-5, IDEA-12), use pad_item.action=get directly — it's
+faster and doesn't require a query string.`

--- a/internal/mcp/catalog_test.go
+++ b/internal/mcp/catalog_test.go
@@ -180,6 +180,43 @@ func TestMakeFanOutHandler_MissingAction(t *testing.T) {
 	}
 }
 
+// TestMakeFanOutHandler_StripsActionFromInput proves the routing
+// `action` key never reaches the action handler — important because
+// some downstream CLI commands (workspace audit-log) declare their
+// own `--action` flag, which would collide with the catalog's
+// routing key and silently emit the catalog action name as the flag
+// value. Strip-at-the-boundary keeps action handlers ergonomic.
+func TestMakeFanOutHandler_StripsActionFromInput(t *testing.T) {
+	var seen map[string]any
+	def := ToolDef{
+		Name: "pad_test",
+		Actions: map[string]ActionFn{
+			"audit-log": func(_ context.Context, input map[string]any, _ ActionEnv) (*mcp.CallToolResult, error) {
+				seen = input
+				return mcp.NewToolResultText("ok"), nil
+			},
+		},
+	}
+	handler := makeFanOutHandler(def, ActionEnv{Workspace: NewWorkspaceState("")})
+	_, err := handler(context.Background(), callToolRequest(map[string]any{
+		"action":     "audit-log",
+		"days":       float64(7),
+		"actor_name": "dave",
+	}))
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if _, has := seen["action"]; has {
+		t.Errorf("action key leaked into action handler input: %v", seen)
+	}
+	if seen["days"] != float64(7) {
+		t.Errorf("days lost: got %v", seen["days"])
+	}
+	if seen["actor_name"] != "dave" {
+		t.Errorf("actor_name lost: got %v", seen["actor_name"])
+	}
+}
+
 // TestMakeFanOutHandler_UnknownAction is the symmetric case: action is
 // set but not in the handler table. Same recovery pattern — list the
 // valid actions so the agent can retry.

--- a/internal/mcp/catalog_workspace.go
+++ b/internal/mcp/catalog_workspace.go
@@ -1,0 +1,120 @@
+package mcp
+
+import (
+	"context"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// padWorkspaceTool exposes workspace-level operations: discovery
+// (list), membership (members, invite), storage usage, and audit log.
+//
+// All actions dispatch through the existing CLI/HTTP route table.
+// Workspace context: this tool operates ON workspaces, so the
+// `workspace` parameter targets a specific workspace for the action
+// (e.g. members of which workspace) rather than picking the session
+// default. Where the action is server-wide (`list`), the param is
+// ignored.
+
+func init() {
+	appendToCatalog(padWorkspaceTool)
+}
+
+var padWorkspaceTool = ToolDef{
+	Name:        "pad_workspace",
+	Description: padWorkspaceToolDescription,
+	Schema: ToolSchema{
+		Workspace: true,
+		Params: []ParamDef{
+			{
+				Name:        "email",
+				Type:        "string",
+				Description: "Email address to invite. Required for action=invite.",
+			},
+			{
+				Name:        "role",
+				Type:        "string",
+				Description: "Role to grant on invite (owner | editor | viewer). Optional for action=invite; defaults to editor.",
+				Enum:        []string{"owner", "editor", "viewer"},
+			},
+			{
+				Name:        "action_filter",
+				Type:        "string",
+				Description: "Filter audit-log entries by action name (e.g. \"item.created\"). Optional for action=audit-log.",
+			},
+			{
+				Name:        "actor",
+				Type:        "string",
+				Description: "Filter audit-log entries by actor (user name or \"agent\"). Optional for action=audit-log.",
+			},
+			{
+				Name:        "days",
+				Type:        "number",
+				Description: "Limit audit-log entries to the last N days. Optional for action=audit-log.",
+			},
+			{
+				Name:        "limit",
+				Type:        "number",
+				Description: "Maximum entries to return. Optional for action=audit-log.",
+			},
+		},
+	},
+	Actions: map[string]ActionFn{
+		"list":      passThrough([]string{"workspace", "list"}),
+		"members":   passThrough([]string{"workspace", "members"}),
+		"invite":    passThrough([]string{"workspace", "invite"}),
+		"storage":   passThrough([]string{"workspace", "storage"}),
+		"audit-log": actionWorkspaceAuditLog,
+	},
+}
+
+// actionWorkspaceAuditLog reshapes the input for `pad workspace
+// audit-log`'s `--action` filter flag. The CLI flag name `action`
+// would normally be reachable via passThrough — but the catalog's
+// fan-out routing field is also named `action` (and is stripped by
+// makeFanOutHandler before reaching the handler). To preserve user-
+// supplied `--action` filtering without forcing every action handler
+// to know about the routing-key stripping, we expose the filter as
+// `action_filter` in the schema and rename here before dispatch.
+//
+// All other audit-log flags (actor, days, limit) flow through unchanged.
+func actionWorkspaceAuditLog(ctx context.Context, input map[string]any, env ActionEnv) (*mcp.CallToolResult, error) {
+	if v, ok := input["action_filter"]; ok {
+		// Clone so the caller's map (and req.Params.Arguments) stays
+		// untouched. Same defensive copy makeFanOutHandler does.
+		out := make(map[string]any, len(input))
+		for k, val := range input {
+			if k == "action_filter" {
+				continue
+			}
+			out[k] = val
+		}
+		// Re-inject under the CLI flag name. By this point the catalog's
+		// `action` routing key has already been stripped by makeFanOutHandler,
+		// so writing `action` here goes directly to the CLI's --action flag
+		// via BuildCLIArgs.
+		out["action"] = v
+		input = out
+	}
+	return env.Dispatch(ctx, []string{"workspace", "audit-log"}, input)
+}
+
+const padWorkspaceToolDescription = `Workspace operations — discovery, membership, storage, and audit log.
+
+Actions:
+  list       — List workspaces visible to the current user. No params; admins see all,
+               regular users see their memberships.
+  members    — List members + pending invitations for a workspace.
+               Required: workspace.
+  invite     — Invite a user to a workspace.
+               Required: workspace, email.
+               Optional: role (owner | editor | viewer; default editor).
+  storage    — Workspace storage usage breakdown (attachments, items, total bytes).
+               Required: workspace.
+  audit-log  — Workspace audit log. ADMIN ONLY — non-admin users get an auth error.
+               Optional: action_filter, actor, days, limit.
+               Note: the underlying endpoint is global, so this returns entries
+               across all workspaces filtered by the supplied params.
+
+Use pad_workspace when an agent needs to discover, manage membership, or audit
+workspace activity. For item-level operations use pad_item.`


### PR DESCRIPTION
## Summary
- Adds 5 read-only tools to the v0.2 catalog: `pad_workspace`, `pad_collection`, `pad_project`, `pad_role`, `pad_search`.
- Fixes a latent bug in the fan-out handler — strips the catalog's `action` routing key from the input before action handlers run, so it doesn't shadow CLI flags named `--action` (e.g. `workspace audit-log --action <filter>`).
- v0.1 cmdhelp walker stays live alongside — TASK-981 retires it.

## Context
Second commit of `TASK-970`'s 3-stage rollout under `PLAN-969`. Architecture: **DOC-978**.

## Catalog adjustments from DOC-978
- Dropped `pad_workspace.action: get` — no equivalent CLI command exists.
- Dropped `pad_collection.action: schema` — schema is in `collection list` output; can be added later if dogfooding (TASK-975) shows demand.

## Bug fix: fan-out routing key shadow
The catalog uses `action` as its routing key (`pad_workspace.action: list`). The CLI command `workspace audit-log` *also* has an `--action <filter>` flag. Without stripping the routing key from the input before dispatch, `BuildCLIArgs` would emit `--action audit-log` (the catalog action name) instead of the user's filter value.

`makeFanOutHandler` now strips `action` from the input map before invoking the action handler. The schema exposes the audit-log filter as `action_filter`; a custom handler renames it to `action` at dispatch time so it lands on `--action <filter>` correctly.

This bug was latent in TASK-979 (pad_meta actions don't dispatch to a CLI command) and surfaces here.

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./internal/mcp/...` passes
- [x] `make check` clean (lint + tests + web build)
- [x] New tests cover: catalog completeness (all 6 v0.2 tools registered: pad_meta + 5 here), cmdhelp drift (every passThrough cmdPath exists in cmdhelp), audit-log rename in both directions (with and without filter), action-key strip behavior in `makeFanOutHandler`.
- [ ] Manual: connect Claude Desktop, exercise read-only tools (deferred to TASK-981 dogfood).