### PR TITLE
feat(mcp): v0.2 catalog migrate pad_item + retire cmdhelp walker (TASK-981)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,9 +175,11 @@ Collection names accept singular forms: `task`→`tasks`, `idea`→`ideas`, `doc
 
 ## MCP server
 
-Pad runs as a local Model Context Protocol server so Claude Desktop / Cursor / Windsurf can call non-interactive `pad` commands as tools. The surface is derived from the cmdhelp Document (`pad help --format json`) and filtered against `internal/mcp.DefaultExcludes` (which strips interactive / destructive commands — `auth setup/login`, `db backup/restore`, `init`, `item edit`, `project watch`, `workspace export/import`, `mcp serve/install`, `completion`, etc.).
+Pad runs as a local Model Context Protocol server so Claude Desktop / Cursor / Windsurf can call non-interactive `pad` commands as tools. As of PLAN-969 (TASK-981) the tool surface is a **hand-curated v0.2 catalog** in `internal/mcp/catalog_*.go` — one ToolDef per resource (`pad_item`, `pad_workspace`, `pad_collection`, `pad_project`, `pad_role`, `pad_search`, `pad_meta`) with an `action` enum dispatching to underlying CLI commands. The previous v0.1 cmdhelp leaf walker is retired.
 
-**When adding a new `pad` command, decide whether it belongs on the MCP surface.** If it's interactive (prompts the user), destructive (mutates auth / filesystem state), long-running (streaming watcher), or recursive (would spawn another MCP server), add it to `DefaultExcludes` in `internal/mcp/registry.go`. Otherwise it's safe to expose, and the registry picks it up automatically.
+cmdhelp is still consumed at dispatch time — `BuildCLIArgs` reads individual command schemas to translate the catalog's snake_case input map into CLI args. cmdhelp no longer drives tool naming or count.
+
+**When adding a new `pad` command, decide whether it belongs on the MCP surface.** If yes, add an action to the appropriate `pad_<resource>` ToolDef in `internal/mcp/catalog_<resource>.go`. The action's handler — usually `passThrough([]string{"resource", "subcommand"})` — wires it through to dispatch. Don't expose interactive (prompts the user), destructive (mutates auth / filesystem state), long-running (streaming watcher), or recursive (would spawn another MCP server) commands.
 
 ```bash
 pad mcp serve                 # JSON-RPC over stdio (called by clients)
@@ -187,11 +189,15 @@ pad mcp status                # Install state across supported clients
 ```
 
 Surface:
-- **Tools:** leaf `pad` commands not in `DefaultExcludes` (the per-PR review gate above). Plus `pad_set_workspace` for the session default.
+- **Tools:** the v0.2 catalog (`pad_item`, `pad_workspace`, `pad_collection`, `pad_project`, `pad_role`, `pad_search`, `pad_meta`) plus `pad_set_workspace` for the session default. Each tool takes `action: <verb>` to choose what it does.
 - **Resources:** `pad://workspace/{ws}/items/{ref}`, `pad://workspace/{ws}/items`, `pad://workspace/{ws}/dashboard`, `pad://workspace/{ws}/collections`, plus the server-wide `pad://_meta/version`.
 - **Prompts:** `pad_plan`, `pad_ideate`, `pad_retro`, `pad_onboard` — multi-step workflows lifted from `skills/pad/SKILL.md`.
 
-**Stability contract.** The cmdhelp tool surface is versioned via `internal/mcp.CmdhelpVersion` (currently `"0.1"`). Bump the major when tool names, argument shapes, or resource URIs change incompatibly — external agents (Cursor, Claude Desktop, the future Pad Cloud remote MCP) pin against it. The version is advertised on the wire two ways: at `capabilities.experimental.padCmdhelp` in the initialize handshake, and as a JSON document at `pad://_meta/version`.
+**Stability contract.** Two version constants live in `internal/mcp/version.go`, advertised in the handshake under `capabilities.experimental.padCmdhelp` and `capabilities.experimental.padToolSurface`:
+- `CmdhelpVersion` (currently `"0.1"`) — the cmdhelp CLI help-tree contract. Bump when CLI flag/arg schemas change incompatibly.
+- `ToolSurfaceVersion` (currently `"0.2"`) — the MCP tool catalog contract. Bump when tool names, action enums, or parameter shapes change incompatibly.
+
+Both are also returned by `pad://_meta/version` and `pad_meta.action: version`.
 
 **Dispatchers.** Two ship in `internal/mcp/`:
 

--- a/cmd/pad/mcp.go
+++ b/cmd/pad/mcp.go
@@ -273,30 +273,21 @@ Shuts down cleanly on EOF, SIGINT, or SIGTERM.`,
 				"url": urlFlag,
 			}
 
+			// As of TASK-981 (PLAN-969) Register registers pad_set_workspace
+			// + every v0.2 catalog tool in one call. The cmdhelp leaf
+			// walker that powered v0.1 has been retired; cmdhelp is
+			// still consumed at dispatch time (BuildCLIArgs reads
+			// individual command schemas) but no longer drives the tool
+			// surface shape.
 			dispatcher := &mcpserver.ExecDispatcher{Binary: bin}
 			if _, err := mcpserver.Register(srv.MCP(), mcpserver.RegistryOptions{
 				Doc:        doc,
 				Workspace:  state,
 				Dispatcher: dispatcher,
 				RootFlags:  rootFlags,
-			}); err != nil {
-				return fmt.Errorf("pad mcp serve: register tools: %w", err)
-			}
-
-			// v0.2 catalog (PLAN-969 TASK-970) — runs alongside the
-			// cmdhelp-walk path while the catalog is being filled in.
-			// First commit (TASK-979) ships pad_meta only; subsequent
-			// commits add the read-only tools and pad_item, then flip
-			// the v0.1 surface off. Same Doc + Dispatcher so dispatch
-			// behaviour is identical between the two surfaces.
-			if _, err := mcpserver.RegisterCatalog(srv.MCP(), mcpserver.CatalogOptions{
-				Doc:        doc,
-				Workspace:  state,
-				Dispatcher: dispatcher,
-				RootFlags:  rootFlags,
 				PadVersion: fullVersion(),
 			}); err != nil {
-				return fmt.Errorf("pad mcp serve: register catalog: %w", err)
+				return fmt.Errorf("pad mcp serve: register tools: %w", err)
 			}
 
 			// Resource templates (TASK-946): four read-only views over

--- a/internal/mcp/catalog_item.go
+++ b/internal/mcp/catalog_item.go
@@ -1,0 +1,380 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// padItemTool is the v0.2 tool that consolidates the ~20 v0.1 verb
+// tools (item_create, item_update, item_block, item_star, ...) into
+// one resource × action shape. Largest single ToolDef in the catalog.
+//
+// Most actions are passThrough — they forward the input verbatim to
+// the underlying CLI cmdPath. Two actions are custom:
+//
+//   - link / unlink — dispatch on link_type to one of several CLI
+//     commands (item block / supersedes / implements / split-from /
+//     blocked-by, plus their inverses). The custom handler reshapes
+//     the uniform schema (`ref`, `target`) into the per-link-type
+//     arg names the CLI expects (source_ref/target_ref, new_ref/old_ref,
+//     etc.).
+//
+// Read-modify-write semantics for action=update are handled by the
+// HTTPHandlerDispatcher's existing item-update route mapper (TASK-967);
+// the catalog just forwards the input.
+
+func init() {
+	appendToCatalog(padItemTool)
+}
+
+var padItemTool = ToolDef{
+	Name:        "pad_item",
+	Description: padItemToolDescription,
+	Schema: ToolSchema{
+		Workspace: true,
+		Params:    padItemSchemaParams,
+	},
+	Actions: map[string]ActionFn{
+		// Lifecycle
+		"create": passThrough([]string{"item", "create"}),
+		"update": passThrough([]string{"item", "update"}),
+		"delete": passThrough([]string{"item", "delete"}),
+		"get":    passThrough([]string{"item", "show"}),
+		"list":   passThrough([]string{"item", "list"}),
+		"move":   passThrough([]string{"item", "move"}),
+
+		// Relationships — link/unlink fan out to per-type cmdPaths.
+		"link":   actionItemLink,
+		"unlink": actionItemUnlink,
+		"deps":   passThrough([]string{"item", "deps"}),
+
+		// Stars
+		"star":    passThrough([]string{"item", "star"}),
+		"unstar":  passThrough([]string{"item", "unstar"}),
+		"starred": passThrough([]string{"item", "starred"}),
+
+		// Comments. reply-comment isn't a separate CLI verb — the
+		// `comment` command takes a --reply-to flag, exposed here as
+		// the `reply_to` parameter.
+		"comment":       passThrough([]string{"item", "comment"}),
+		"list-comments": passThrough([]string{"item", "comments"}),
+
+		// Bulk + notes + decisions
+		"bulk-update": passThrough([]string{"item", "bulk-update"}),
+		"note":        passThrough([]string{"item", "note"}),
+		"decide":      passThrough([]string{"item", "decide"}),
+	},
+}
+
+// padItemSchemaParams is the union of every parameter any pad_item
+// action accepts. Per-action requirements are documented in the
+// description and enforced at dispatch time by BuildCLIArgs (which
+// errors when a CLI arg's `required` flag isn't satisfied).
+//
+// We deliberately do NOT use JSON Schema oneOf here. mcp-go's helpers
+// don't expose discriminated unions cleanly, and the description-led
+// approach gives Claude / Cursor enough signal to call correctly while
+// keeping the schema simple to maintain.
+var padItemSchemaParams = []ParamDef{
+	// ── Targeting ──
+	{Name: "ref", Type: "string", Description: "Item reference (e.g. TASK-5, IDEA-12). Required for: update, delete, get, move, link, unlink, deps, star, unstar, comment, list-comments, bulk-update, note, decide."},
+	{Name: "target", Type: "string", Description: "The OTHER end of a relationship. Required for: link, unlink (paired with `ref` and `link_type`). For link_type=blocks, target is the item being blocked; for blocked-by it's the blocker; for supersedes it's the superseded item; etc."},
+	{Name: "link_type", Type: "string", Description: "Type of relationship for action=link/unlink.", Enum: []string{"blocks", "blocked-by", "supersedes", "implements", "split-from"}},
+
+	// ── Item content ──
+	{Name: "collection", Type: "string", Description: "Collection slug (e.g. \"tasks\", \"ideas\"). Required for: create. Optional filter for: list."},
+	{Name: "title", Type: "string", Description: "Item title. Required for: create. Optional rename for: update."},
+	{Name: "content", Type: "string", Description: "Markdown body. Optional for: create, update."},
+
+	// ── Status / priority / scheduling ──
+	{Name: "status", Type: "string", Description: "Item status (collection-specific enum). Optional for: create, update, list filter, bulk-update."},
+	{Name: "priority", Type: "string", Description: "Item priority. Optional for: create, update, list filter, bulk-update."},
+	{Name: "category", Type: "string", Description: "Item category. Optional for: create, update."},
+
+	// ── Hierarchy / assignment ──
+	{Name: "parent", Type: "string", Description: "Parent item ref (e.g. PLAN-3). Optional for: create, update, list filter."},
+	{Name: "role", Type: "string", Description: "Agent role slug to assign (e.g. implementer). Optional for: create, update, list filter."},
+	{Name: "assign", Type: "string", Description: "User name or email to assign. Optional for: create, update, list filter."},
+
+	// ── Tagging ──
+	{Name: "tags", Type: "string", Description: "Comma-separated tags. Optional for: create, update."},
+	{Name: "field", Type: "array<string>", Description: "Custom field key=value pairs (repeatable). Optional for: create, update, list filter, move."},
+
+	// ── List / starred ──
+	{Name: "all", Type: "bool", Description: "Include archived/done items in list responses. Optional for: list, starred."},
+	{Name: "limit", Type: "number", Description: "Maximum results. Optional for: list."},
+	{Name: "sort", Type: "string", Description: "Sort field. Optional for: list."},
+	{Name: "group_by", Type: "string", Description: "Group-by field. Optional for: list."},
+
+	// ── Move ──
+	{Name: "target_collection", Type: "string", Description: "Destination collection slug for action=move. Required for: move."},
+
+	// ── Comments ──
+	{Name: "message", Type: "string", Description: "Comment body. Required for: comment."},
+	{Name: "reply_to", Type: "string", Description: "Parent comment ID for threading replies. Optional for: comment."},
+	{Name: "comment", Type: "string", Description: "Audit comment explaining the change. Optional for: update."},
+
+	// ── Notes / decisions ──
+	{Name: "summary", Type: "string", Description: "Short note headline. Required for: note."},
+	{Name: "details", Type: "string", Description: "Long-form note body. Optional for: note."},
+	{Name: "decision", Type: "string", Description: "Decision summary text. Required for: decide."},
+	{Name: "rationale", Type: "string", Description: "Reasoning behind the decision. Optional for: decide."},
+}
+
+const padItemToolDescription = `Item operations — the consolidated CRUD + relationships + comments + notes surface.
+
+Actions:
+  create        — Create a new item.
+                  Required: collection, title.
+                  Optional: priority, status, content, parent, role, assign, fields, tags.
+  update        — Update an item by ref.
+                  Required: ref. At least one mutable field.
+                  Optional: title, status, priority, content, role, assign, parent, comment.
+  delete        — Archive an item.
+                  Required: ref.
+  get           — Read an item.
+                  Required: ref.
+  list          — List items, optionally filtered.
+                  Optional: collection, status, priority, parent, role, assign, all, limit.
+  move          — Move an item to a different collection.
+                  Required: ref, target_collection.
+  link          — Create a relationship between two items.
+                  Required: ref, target, link_type.
+                  link_type: blocks | blocked-by | supersedes | implements | split-from.
+  unlink        — Remove a relationship.
+                  Required: ref, target, link_type.
+  deps          — Show all dependencies (incoming + outgoing) for an item.
+                  Required: ref.
+  star          — Star an item for quick access.
+                  Required: ref.
+  unstar        — Remove star.
+                  Required: ref.
+  starred       — List starred items.
+                  Optional: all.
+  comment       — Add a comment.
+                  Required: ref, message.
+                  Optional: reply_to (comment ID for threaded reply).
+  list-comments — List comments on an item.
+                  Required: ref.
+  bulk-update   — Update status/priority across multiple items.
+                  Required: ref (repeatable), status or priority.
+  note          — Append an implementation note to an item.
+                  Required: ref, summary.
+                  Optional: details.
+  decide        — Record a decision on an item.
+                  Required: ref, decision.
+                  Optional: rationale.
+
+ALWAYS prefer issue refs (TASK-5, IDEA-12) over slugs.
+
+When updating status, include comment="why" so the audit trail tells the team
+WHY the status changed, not just THAT it did.
+
+For cross-item search use pad_search.action=query — pad_item.list filters within
+a single query but doesn't do FTS scoring.`
+
+// itemLinkOp describes one direction (link or unlink) of a link_type
+// — the cmdPath to invoke, the snake_case input keys the CLI's
+// positional args expect, and whether to swap the user's
+// (ref, target) tuple before mapping.
+//
+// Per-direction (rather than per-link_type) because some link_types
+// have asymmetric directions: `blocked-by` uses different cmdPaths
+// AND different positional arg names for create vs delete (its delete
+// shares with `blocks`).
+type itemLinkOp struct {
+	// cmdPath is the cmdhelp command path for this direction. Nil
+	// means the direction isn't supported for the link_type.
+	cmdPath []string
+
+	// firstArg is the snake_case input key the CLI's first positional
+	// expects (e.g. "source_ref" for `item block`).
+	firstArg string
+
+	// secondArg is the snake_case input key for the CLI's second
+	// positional (e.g. "target_ref" for `item block`).
+	secondArg string
+
+	// inverted, when true, swaps the user's (ref, target) tuple
+	// before mapping to (firstArg, secondArg). Required when the
+	// catalog's user-facing direction (e.g. "A blocked-by B") differs
+	// from the underlying graph direction the cmdPath models (e.g.
+	// `pad item unblock` removes "B blocks A" → operands swapped).
+	inverted bool
+}
+
+// itemLinkRoute pairs a link_type's create direction with its delete
+// direction. Either op can have a nil cmdPath if the operation isn't
+// supported for that type.
+type itemLinkRoute struct {
+	link   itemLinkOp
+	unlink itemLinkOp
+}
+
+// itemLinkRoutes is the dispatch table for actionItemLink /
+// actionItemUnlink. Keys are link_type values from the catalog schema.
+//
+// Behavioral notes:
+//
+//   - blocks / blocked-by: the underlying graph edge is directional
+//     ("X blocks Y"). blocked-by is the same edge expressed from the
+//     other side ("Y blocked-by X"); link_type encodes the user's
+//     mental model. blocked-by's UNLINK reuses the `item unblock`
+//     command (the create wasn't a separate edge type) but with
+//     operands swapped because unblock takes (source, target) where
+//     source is the blocker.
+//   - supersedes / implements / split-from: each have their own
+//     create + delete commands with type-specific arg names; the
+//     positional names are the same in both directions.
+//
+// Edges that exist in the CLI but aren't exposed here:
+//   - decides: standalone action (pad_item.action: decide), not a link
+//     because it carries decision text + rationale that don't fit the
+//     ref/target shape.
+//   - related: read-only listing, no create/delete; consumers use
+//     pad_search or pad_item.action: deps for graph traversal.
+var itemLinkRoutes = map[string]itemLinkRoute{
+	"blocks": {
+		link:   itemLinkOp{cmdPath: []string{"item", "block"}, firstArg: "source_ref", secondArg: "target_ref"},
+		unlink: itemLinkOp{cmdPath: []string{"item", "unblock"}, firstArg: "source_ref", secondArg: "target_ref"},
+	},
+	"blocked-by": {
+		link: itemLinkOp{cmdPath: []string{"item", "blocked-by"}, firstArg: "source_ref", secondArg: "blocker_ref"},
+		// User intent: "ref blocked-by target" = "target blocks ref".
+		// Unlink reuses `pad item unblock SOURCE TARGET`. Operands
+		// must swap so SOURCE is the blocker (target) and TARGET is
+		// the blocked item (ref).
+		unlink: itemLinkOp{cmdPath: []string{"item", "unblock"}, firstArg: "source_ref", secondArg: "target_ref", inverted: true},
+	},
+	"supersedes": {
+		link:   itemLinkOp{cmdPath: []string{"item", "supersedes"}, firstArg: "new_ref", secondArg: "old_ref"},
+		unlink: itemLinkOp{cmdPath: []string{"item", "unsupersede"}, firstArg: "new_ref", secondArg: "old_ref"},
+	},
+	"implements": {
+		link:   itemLinkOp{cmdPath: []string{"item", "implements"}, firstArg: "implementer_ref", secondArg: "target_ref"},
+		unlink: itemLinkOp{cmdPath: []string{"item", "unimplements"}, firstArg: "implementer_ref", secondArg: "target_ref"},
+	},
+	"split-from": {
+		link:   itemLinkOp{cmdPath: []string{"item", "split-from"}, firstArg: "child_ref", secondArg: "parent_ref"},
+		unlink: itemLinkOp{cmdPath: []string{"item", "unsplit"}, firstArg: "child_ref", secondArg: "parent_ref"},
+	},
+}
+
+// actionItemLink dispatches pad_item.action=link to the appropriate
+// CLI cmdPath based on link_type. Renames the schema's uniform `ref`
+// and `target` to the type-specific positional arg names (source_ref/
+// target_ref, new_ref/old_ref, etc.) before calling env.Dispatch.
+//
+// Errors:
+//   - missing or unknown link_type → structured error envelope with
+//     the valid options, same shape as makeFanOutHandler's errMissingAction.
+//   - missing ref or target → BuildCLIArgs catches it as a missing-
+//     positional error.
+func actionItemLink(ctx context.Context, input map[string]any, env ActionEnv) (*mcp.CallToolResult, error) {
+	cmdPath, dispatchInput, err := resolveItemLink(input, true)
+	if err != nil {
+		return errStructured("pad_item.link", err), nil
+	}
+	return env.Dispatch(ctx, cmdPath, dispatchInput)
+}
+
+// actionItemUnlink is the symmetric un-create operation. Same routing
+// rules; uses route.unlinkCmdPath instead of route.linkCmdPath.
+func actionItemUnlink(ctx context.Context, input map[string]any, env ActionEnv) (*mcp.CallToolResult, error) {
+	cmdPath, dispatchInput, err := resolveItemLink(input, false)
+	if err != nil {
+		return errStructured("pad_item.unlink", err), nil
+	}
+	return env.Dispatch(ctx, cmdPath, dispatchInput)
+}
+
+// resolveItemLink reads link_type/ref/target from input and returns
+// the dispatch tuple for action=link (creating=true) or action=unlink
+// (creating=false). Pure function — no side effects.
+//
+// Returns reshaped dispatchInput rather than mutating the caller's
+// map. The catalog's `link_type`, `ref`, and `target` keys are
+// dropped from the dispatch input and replaced with op.firstArg /
+// op.secondArg per the route table. When op.inverted is true, the
+// user's (ref, target) tuple is swapped before mapping.
+func resolveItemLink(input map[string]any, creating bool) ([]string, map[string]any, error) {
+	linkType, _ := input["link_type"].(string)
+	if linkType == "" {
+		return nil, nil, fmt.Errorf("link_type is required (one of: %s)",
+			joinSorted(itemLinkRoutesKeys()))
+	}
+	route, ok := itemLinkRoutes[linkType]
+	if !ok {
+		return nil, nil, fmt.Errorf("unknown link_type %q (valid: %s)",
+			linkType, joinSorted(itemLinkRoutesKeys()))
+	}
+	op := route.link
+	if !creating {
+		op = route.unlink
+	}
+	if op.cmdPath == nil {
+		direction := "link"
+		if !creating {
+			direction = "unlink"
+		}
+		return nil, nil, fmt.Errorf("link_type %q does not support %s", linkType, direction)
+	}
+	ref, _ := input["ref"].(string)
+	target, _ := input["target"].(string)
+	if ref == "" {
+		return nil, nil, fmt.Errorf("ref is required for link/unlink")
+	}
+	if target == "" {
+		return nil, nil, fmt.Errorf("target is required for link/unlink")
+	}
+	first, second := ref, target
+	if op.inverted {
+		first, second = target, ref
+	}
+
+	// Build the dispatch input from scratch — we want to drop the
+	// catalog-only keys (ref, target, link_type) and inject the
+	// CLI-positional keys (op.firstArg, op.secondArg). Pass through
+	// everything else (workspace, format, etc.).
+	out := make(map[string]any, len(input))
+	for k, v := range input {
+		if k == "ref" || k == "target" || k == "link_type" {
+			continue
+		}
+		out[k] = v
+	}
+	out[op.firstArg] = first
+	out[op.secondArg] = second
+	return op.cmdPath, out, nil
+}
+
+// itemLinkRoutesKeys returns the registered link_type values in
+// stable sort order, used in error messages so users see the same
+// listing every time.
+func itemLinkRoutesKeys() []string {
+	out := make([]string, 0, len(itemLinkRoutes))
+	for k := range itemLinkRoutes {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// joinSorted concatenates ss with ", " between values. Caller is
+// expected to pass a pre-sorted slice (the only call site uses
+// itemLinkRoutesKeys which sorts on the way out).
+func joinSorted(ss []string) string {
+	return strings.Join(ss, ", ")
+}
+
+// errStructured wraps a Go error into the standard MCP tool-error
+// shape with a stable identifier prefix (e.g. "pad_item.link").
+// Local helper — avoids leaking actionFn-specific formatting up to
+// every caller.
+func errStructured(prefix string, err error) *mcp.CallToolResult {
+	return mcp.NewToolResultErrorf("%s: %s", prefix, err.Error())
+}

--- a/internal/mcp/catalog_item.go
+++ b/internal/mcp/catalog_item.go
@@ -64,7 +64,12 @@ var padItemTool = ToolDef{
 		"list-comments": passThrough([]string{"item", "comments"}),
 
 		// Bulk + notes + decisions
-		"bulk-update": passThrough([]string{"item", "bulk-update"}),
+		// bulk-update is custom because the CLI takes repeatable
+		// positional refs (one or more); our uniform schema exposes
+		// scalar `ref` everywhere else, so the action accepts a
+		// dedicated `refs: array<string>` and translates to the
+		// repeatable form BuildCLIArgs expects.
+		"bulk-update": actionItemBulkUpdate,
 		"note":        passThrough([]string{"item", "note"}),
 		"decide":      passThrough([]string{"item", "decide"}),
 	},
@@ -81,7 +86,8 @@ var padItemTool = ToolDef{
 // keeping the schema simple to maintain.
 var padItemSchemaParams = []ParamDef{
 	// ── Targeting ──
-	{Name: "ref", Type: "string", Description: "Item reference (e.g. TASK-5, IDEA-12). Required for: update, delete, get, move, link, unlink, deps, star, unstar, comment, list-comments, bulk-update, note, decide."},
+	{Name: "ref", Type: "string", Description: "Item reference (e.g. TASK-5, IDEA-12). Required for: update, delete, get, move, link, unlink, deps, star, unstar, comment, list-comments, note, decide. NOT used for bulk-update — pass `refs` (array) instead."},
+	{Name: "refs", Type: "array<string>", Description: "Item references for batch operations. Required for: bulk-update (one or more refs)."},
 	{Name: "target", Type: "string", Description: "The OTHER end of a relationship. Required for: link, unlink (paired with `ref` and `link_type`). For link_type=blocks, target is the item being blocked; for blocked-by it's the blocker; for supersedes it's the superseded item; etc."},
 	{Name: "link_type", Type: "string", Description: "Type of relationship for action=link/unlink.", Enum: []string{"blocks", "blocked-by", "supersedes", "implements", "split-from"}},
 
@@ -161,7 +167,8 @@ Actions:
   list-comments — List comments on an item.
                   Required: ref.
   bulk-update   — Update status/priority across multiple items.
-                  Required: ref (repeatable), status or priority.
+                  Required: refs (array of refs, e.g. ["TASK-5", "TASK-8"]),
+                  AND at least one of status / priority.
   note          — Append an implementation note to an item.
                   Required: ref, summary.
                   Optional: details.
@@ -377,4 +384,88 @@ func joinSorted(ss []string) string {
 // every caller.
 func errStructured(prefix string, err error) *mcp.CallToolResult {
 	return mcp.NewToolResultErrorf("%s: %s", prefix, err.Error())
+}
+
+// actionItemBulkUpdate translates the catalog's `refs: array<string>`
+// param into the repeatable positional `ref` that BuildCLIArgs feeds
+// to `pad item bulk-update REF [REF ...]`. The CLI's cmdhelp entry
+// declares ref as Repeatable=true, so passing a []string under the
+// `ref` key produces multiple positionals.
+//
+// We expose `refs` (plural) on the catalog rather than overloading
+// `ref` (which is scalar across every other action) so the schema
+// stays consistent — agents see a single shape per param name. The
+// rename happens here at dispatch time.
+func actionItemBulkUpdate(ctx context.Context, input map[string]any, env ActionEnv) (*mcp.CallToolResult, error) {
+	rawRefs, ok := input["refs"]
+	if !ok || rawRefs == nil {
+		return errStructured("pad_item.bulk-update",
+			fmt.Errorf("refs is required (array of item references)")), nil
+	}
+	refs, err := normalizeBulkUpdateRefs(rawRefs)
+	if err != nil {
+		return errStructured("pad_item.bulk-update", err), nil
+	}
+	if len(refs) == 0 {
+		return errStructured("pad_item.bulk-update",
+			fmt.Errorf("refs cannot be empty")), nil
+	}
+	out := make(map[string]any, len(input))
+	for k, v := range input {
+		if k == "refs" {
+			continue
+		}
+		out[k] = v
+	}
+	// BuildCLIArgs expects []string under the cmd's positional name
+	// (`ref`) when arg.Repeatable=true.
+	out["ref"] = refs
+	return env.Dispatch(ctx, []string{"item", "bulk-update"}, out)
+}
+
+// normalizeBulkUpdateRefs accepts the JSON shapes the MCP transport
+// can deliver for an array<string> param: []string (canonical),
+// []any (mcp-go's typical decoded form), or a single string (lenient
+// fallback so an agent that passes one ref unwrapped still works).
+func normalizeBulkUpdateRefs(raw any) ([]string, error) {
+	switch v := raw.(type) {
+	case []string:
+		out := make([]string, 0, len(v))
+		for _, s := range v {
+			if s = trimSpace(s); s != "" {
+				out = append(out, s)
+			}
+		}
+		return out, nil
+	case []any:
+		out := make([]string, 0, len(v))
+		for i, e := range v {
+			s, ok := e.(string)
+			if !ok {
+				return nil, fmt.Errorf("refs[%d] is %T, want string", i, e)
+			}
+			if s = trimSpace(s); s != "" {
+				out = append(out, s)
+			}
+		}
+		return out, nil
+	case string:
+		// Lenient fallback: a single ref passed unwrapped. Logically
+		// equivalent to a 1-element array.
+		if s := trimSpace(v); s != "" {
+			return []string{s}, nil
+		}
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("refs is %T, want array of strings", raw)
+	}
+}
+
+// trimSpace is strings.TrimSpace inlined to avoid pulling strings
+// through this file just for one call. catalog_item.go already
+// imports strings for joinSorted, so the inline isn't strictly
+// necessary — kept anyway because the call site is in a hot path
+// (every bulk-update entry).
+func trimSpace(s string) string {
+	return strings.TrimSpace(s)
 }

--- a/internal/mcp/catalog_item_test.go
+++ b/internal/mcp/catalog_item_test.go
@@ -1,0 +1,218 @@
+package mcp
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// TestPadItemLink_DispatchTable exercises every link_type ↔ cmdPath
+// mapping in itemLinkRoutes for both action=link (create) and
+// action=unlink (remove). Acts as the regression test for the
+// "uniform (ref, target) → CLI's per-type positional names" rename.
+//
+// Cases are derived from itemLinkRoutes itself rather than hand-
+// written so adding a new link_type only requires updating the route
+// table, not this test.
+func TestPadItemLink_DispatchTable(t *testing.T) {
+	doc := liveCmdhelpDoc(t)
+	ws := NewWorkspaceState("docapp")
+
+	for linkType, route := range itemLinkRoutes {
+		t.Run("link/"+linkType, func(t *testing.T) {
+			disp := &fakeDispatcher{}
+			env := ActionEnv{Doc: doc, Workspace: ws, Dispatcher: disp}
+			input := map[string]any{
+				"link_type": linkType,
+				"ref":       "TASK-A",
+				"target":    "TASK-B",
+			}
+			res, err := actionItemLink(context.Background(), input, env)
+			if err != nil {
+				t.Fatalf("actionItemLink error: %v", err)
+			}
+			if res != nil && res.IsError {
+				t.Fatalf("error result: %s", textOf(res))
+			}
+			if !equalStrings(disp.gotPath, route.link.cmdPath) {
+				t.Errorf("cmdPath = %v, want %v", disp.gotPath, route.link.cmdPath)
+			}
+			if len(disp.gotArgs) < 2 {
+				t.Fatalf("cliArgs too short: %v", disp.gotArgs)
+			}
+			wantFirst, wantSecond := "TASK-A", "TASK-B"
+			if route.link.inverted {
+				wantFirst, wantSecond = "TASK-B", "TASK-A"
+			}
+			if disp.gotArgs[0] != wantFirst || disp.gotArgs[1] != wantSecond {
+				t.Errorf("positionals = (%q, %q), want (%q, %q) — link op = %+v",
+					disp.gotArgs[0], disp.gotArgs[1], wantFirst, wantSecond, route.link)
+			}
+		})
+
+		if route.unlink.cmdPath == nil {
+			continue
+		}
+		t.Run("unlink/"+linkType, func(t *testing.T) {
+			disp := &fakeDispatcher{}
+			env := ActionEnv{Doc: doc, Workspace: ws, Dispatcher: disp}
+			input := map[string]any{
+				"link_type": linkType,
+				"ref":       "TASK-A",
+				"target":    "TASK-B",
+			}
+			res, err := actionItemUnlink(context.Background(), input, env)
+			if err != nil {
+				t.Fatalf("actionItemUnlink error: %v", err)
+			}
+			if res != nil && res.IsError {
+				t.Fatalf("error result: %s", textOf(res))
+			}
+			if !equalStrings(disp.gotPath, route.unlink.cmdPath) {
+				t.Errorf("cmdPath = %v, want %v", disp.gotPath, route.unlink.cmdPath)
+			}
+			if len(disp.gotArgs) < 2 {
+				t.Fatalf("cliArgs too short: %v", disp.gotArgs)
+			}
+			wantFirst, wantSecond := "TASK-A", "TASK-B"
+			if route.unlink.inverted {
+				wantFirst, wantSecond = "TASK-B", "TASK-A"
+			}
+			if disp.gotArgs[0] != wantFirst || disp.gotArgs[1] != wantSecond {
+				t.Errorf("positionals = (%q, %q), want (%q, %q) — unlink op = %+v",
+					disp.gotArgs[0], disp.gotArgs[1], wantFirst, wantSecond, route.unlink)
+			}
+		})
+	}
+}
+
+// TestPadItemLink_MissingLinkType returns a structured error listing
+// the valid options. Ensures the agent gets enough signal to retry
+// with a correct value.
+func TestPadItemLink_MissingLinkType(t *testing.T) {
+	disp := &fakeDispatcher{}
+	env := ActionEnv{
+		Doc:        liveCmdhelpDoc(t),
+		Workspace:  NewWorkspaceState("docapp"),
+		Dispatcher: disp,
+	}
+	res, err := actionItemLink(context.Background(), map[string]any{
+		"ref":    "TASK-A",
+		"target": "TASK-B",
+	}, env)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !res.IsError {
+		t.Fatalf("expected IsError, got %s", textOf(res))
+	}
+	msg := textOf(res)
+	if !strings.Contains(msg, "link_type is required") {
+		t.Errorf("message %q should mention required link_type", msg)
+	}
+	for k := range itemLinkRoutes {
+		if !strings.Contains(msg, k) {
+			t.Errorf("message %q should list link_type %q", msg, k)
+		}
+	}
+	if len(disp.gotPath) > 0 {
+		t.Errorf("dispatcher should not have been called; got %v", disp.gotPath)
+	}
+}
+
+// TestPadItemLink_UnknownLinkType rejects values outside the route
+// table. Must surface what's valid so consumers can correct.
+func TestPadItemLink_UnknownLinkType(t *testing.T) {
+	env := ActionEnv{
+		Doc:        liveCmdhelpDoc(t),
+		Workspace:  NewWorkspaceState("docapp"),
+		Dispatcher: &fakeDispatcher{},
+	}
+	res, err := actionItemLink(context.Background(), map[string]any{
+		"link_type": "totally-invalid",
+		"ref":       "TASK-A",
+		"target":    "TASK-B",
+	}, env)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !res.IsError {
+		t.Fatalf("expected IsError, got %s", textOf(res))
+	}
+	msg := textOf(res)
+	if !strings.Contains(msg, `unknown link_type "totally-invalid"`) {
+		t.Errorf("message %q should name the bad value", msg)
+	}
+}
+
+// TestPadItemLink_MissingRefOrTarget covers the other two required
+// inputs. Failing fast at the action handler keeps BuildCLIArgs from
+// emitting a confusingly-named CLI error.
+func TestPadItemLink_MissingRefOrTarget(t *testing.T) {
+	cases := []struct {
+		name  string
+		input map[string]any
+		want  string
+	}{
+		{
+			name: "missing ref",
+			input: map[string]any{
+				"link_type": "blocks",
+				"target":    "TASK-B",
+			},
+			want: "ref is required",
+		},
+		{
+			name: "missing target",
+			input: map[string]any{
+				"link_type": "blocks",
+				"ref":       "TASK-A",
+			},
+			want: "target is required",
+		},
+	}
+	env := ActionEnv{
+		Doc:        liveCmdhelpDoc(t),
+		Workspace:  NewWorkspaceState("docapp"),
+		Dispatcher: &fakeDispatcher{},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res, err := actionItemLink(context.Background(), tc.input, env)
+			if err != nil {
+				t.Fatalf("err: %v", err)
+			}
+			if !res.IsError {
+				t.Fatalf("expected IsError, got %s", textOf(res))
+			}
+			if !strings.Contains(textOf(res), tc.want) {
+				t.Errorf("message %q should contain %q", textOf(res), tc.want)
+			}
+		})
+	}
+}
+
+// TestPadItemLink_ForwardsAuxFields confirms that non-link fields
+// (workspace, format) flow through to the dispatcher unchanged. The
+// rename should ONLY touch ref/target/link_type.
+func TestPadItemLink_ForwardsAuxFields(t *testing.T) {
+	disp := &fakeDispatcher{}
+	env := ActionEnv{
+		Doc:        liveCmdhelpDoc(t),
+		Workspace:  NewWorkspaceState("docapp"),
+		Dispatcher: disp,
+	}
+	_, err := actionItemLink(context.Background(), map[string]any{
+		"link_type": "blocks",
+		"ref":       "TASK-A",
+		"target":    "TASK-B",
+		"workspace": "docapp", // explicit workspace
+	}, env)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	joined := strings.Join(disp.gotArgs, " ")
+	if !strings.Contains(joined, "--workspace docapp") {
+		t.Errorf("explicit workspace should reach dispatcher; got %q", joined)
+	}
+}

--- a/internal/mcp/catalog_item_test.go
+++ b/internal/mcp/catalog_item_test.go
@@ -192,6 +192,97 @@ func TestPadItemLink_MissingRefOrTarget(t *testing.T) {
 	}
 }
 
+// TestPadItemBulkUpdate_TranslatesRefsArray verifies the catalog's
+// `refs: array<string>` param becomes the CLI's repeatable positional
+// `ref` (one positional per refs entry). Regression test for the
+// scalar/array mismatch Codex flagged on PR #354.
+func TestPadItemBulkUpdate_TranslatesRefsArray(t *testing.T) {
+	t.Run("array of strings", func(t *testing.T) {
+		disp := &fakeDispatcher{}
+		env := ActionEnv{
+			Doc:        liveCmdhelpDoc(t),
+			Workspace:  NewWorkspaceState("docapp"),
+			Dispatcher: disp,
+		}
+		_, err := actionItemBulkUpdate(context.Background(), map[string]any{
+			"refs":   []any{"TASK-5", "TASK-8"},
+			"status": "done",
+		}, env)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if !equalStrings(disp.gotPath, []string{"item", "bulk-update"}) {
+			t.Errorf("cmdPath = %v, want [item bulk-update]", disp.gotPath)
+		}
+		// Both refs become positionals (BuildCLIArgs expands repeatable
+		// args). The `--status done` flag follows.
+		joined := strings.Join(disp.gotArgs, " ")
+		if !strings.HasPrefix(joined, "TASK-5 TASK-8") {
+			t.Errorf("cliArgs %q should begin with both refs as positionals", joined)
+		}
+		if !strings.Contains(joined, "--status done") {
+			t.Errorf("cliArgs %q should contain --status done", joined)
+		}
+	})
+
+	t.Run("single string lenient fallback", func(t *testing.T) {
+		disp := &fakeDispatcher{}
+		env := ActionEnv{
+			Doc:        liveCmdhelpDoc(t),
+			Workspace:  NewWorkspaceState("docapp"),
+			Dispatcher: disp,
+		}
+		_, err := actionItemBulkUpdate(context.Background(), map[string]any{
+			"refs":   "TASK-5", // unwrapped — still acceptable
+			"status": "done",
+		}, env)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if disp.gotArgs[0] != "TASK-5" {
+			t.Errorf("first positional = %q, want TASK-5", disp.gotArgs[0])
+		}
+	})
+
+	t.Run("missing refs", func(t *testing.T) {
+		env := ActionEnv{
+			Doc:        liveCmdhelpDoc(t),
+			Workspace:  NewWorkspaceState("docapp"),
+			Dispatcher: &fakeDispatcher{},
+		}
+		res, err := actionItemBulkUpdate(context.Background(), map[string]any{
+			"status": "done",
+		}, env)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if !res.IsError {
+			t.Fatalf("expected IsError, got %s", textOf(res))
+		}
+		if !strings.Contains(textOf(res), "refs is required") {
+			t.Errorf("error %q should mention refs requirement", textOf(res))
+		}
+	})
+
+	t.Run("empty refs array", func(t *testing.T) {
+		env := ActionEnv{
+			Doc:        liveCmdhelpDoc(t),
+			Workspace:  NewWorkspaceState("docapp"),
+			Dispatcher: &fakeDispatcher{},
+		}
+		res, err := actionItemBulkUpdate(context.Background(), map[string]any{
+			"refs":   []any{},
+			"status": "done",
+		}, env)
+		if err != nil {
+			t.Fatalf("err: %v", err)
+		}
+		if !res.IsError {
+			t.Fatalf("expected IsError, got %s", textOf(res))
+		}
+	})
+}
+
 // TestPadItemLink_ForwardsAuxFields confirms that non-link fields
 // (workspace, format) flow through to the dispatcher unchanged. The
 // rename should ONLY touch ref/target/link_type.

--- a/internal/mcp/catalog_readonly_test.go
+++ b/internal/mcp/catalog_readonly_test.go
@@ -236,6 +236,7 @@ func TestReadOnlyCatalog_ActionsDispatchExpectedCmdPath(t *testing.T) {
 		"slug":              "test-slug",
 		"query":             "test-query",
 		"ref":               "TASK-1",
+		"refs":              []any{"TASK-1", "TASK-2"}, // bulk-update only
 		"collection":        "tasks",
 		"title":             "test title",
 		"target_collection": "ideas",

--- a/internal/mcp/catalog_readonly_test.go
+++ b/internal/mcp/catalog_readonly_test.go
@@ -8,19 +8,26 @@ import (
 	"github.com/PerpetualSoftware/pad/internal/cmdhelp"
 )
 
-// TestReadOnlyCatalog_AllToolsRegistered locks the v0.2 read-only
+// TestReadOnlyCatalog_AllToolsRegistered locks the v0.2 catalog
 // surface. Catches drift in BOTH directions — drops (expected tool
 // missing) and unexpected adds (a new tool registered without
 // updating this test).
+//
+// Naming retains "ReadOnly" for git-blame continuity even though the
+// catalog now includes pad_item (write surface). Renaming would
+// scatter blame across the test file's history; cosmetic refactor
+// can come later.
 func TestReadOnlyCatalog_AllToolsRegistered(t *testing.T) {
 	want := map[string]bool{
-		// pad_meta is from TASK-979; the rest are TASK-980.
+		// pad_meta is from TASK-979; the read-only tools are TASK-980;
+		// pad_item is TASK-981.
 		"pad_meta":       false,
 		"pad_workspace":  false,
 		"pad_collection": false,
 		"pad_project":    false,
 		"pad_role":       false,
 		"pad_search":     false,
+		"pad_item":       false,
 	}
 	for _, def := range Catalog {
 		if _, ok := want[def.Name]; ok {
@@ -86,6 +93,33 @@ func TestReadOnlyCatalog_ActionsMatchCmdhelp(t *testing.T) {
 		{"pad_role", "delete"}: {"role", "delete"},
 
 		{"pad_search", "query"}: {"item", "search"},
+
+		// pad_item passThrough actions. link/unlink are excluded —
+		// they fan out to per-link_type cmdPaths and are tested in
+		// catalog_item_test.go instead.
+		{"pad_item", "create"}:        {"item", "create"},
+		{"pad_item", "update"}:        {"item", "update"},
+		{"pad_item", "delete"}:        {"item", "delete"},
+		{"pad_item", "get"}:           {"item", "show"},
+		{"pad_item", "list"}:          {"item", "list"},
+		{"pad_item", "move"}:          {"item", "move"},
+		{"pad_item", "deps"}:          {"item", "deps"},
+		{"pad_item", "star"}:          {"item", "star"},
+		{"pad_item", "unstar"}:        {"item", "unstar"},
+		{"pad_item", "starred"}:       {"item", "starred"},
+		{"pad_item", "comment"}:       {"item", "comment"},
+		{"pad_item", "list-comments"}: {"item", "comments"},
+		{"pad_item", "bulk-update"}:   {"item", "bulk-update"},
+		{"pad_item", "note"}:          {"item", "note"},
+		{"pad_item", "decide"}:        {"item", "decide"},
+	}
+
+	// Actions whose dispatch is too custom for the cmdPath bijection —
+	// they fan out to multiple cmdPaths based on a parameter. Tested
+	// separately in their own files.
+	skipActions := map[[2]string]bool{
+		{"pad_item", "link"}:   true,
+		{"pad_item", "unlink"}: true,
 	}
 
 	// Direction 1: every expected cmdPath resolves in cmdhelp.
@@ -103,16 +137,21 @@ func TestReadOnlyCatalog_ActionsMatchCmdhelp(t *testing.T) {
 		"pad_meta": true,
 	}
 
-	// Direction 2 + 3: catalog ⇄ expected bijection (modulo skipTools).
-	// Every catalog action (in non-skipped tools) needs a cmdPath
-	// entry; every entry needs a corresponding catalog action.
+	// Direction 2 + 3: catalog ⇄ expected bijection (modulo skipTools
+	// and skipActions). Every catalog action (in non-skipped tools)
+	// needs a cmdPath entry; every entry needs a corresponding catalog
+	// action.
 	catalogActions := map[[2]string]bool{}
 	for _, def := range Catalog {
 		if skipTools[def.Name] {
 			continue
 		}
 		for actionName := range def.Actions {
-			catalogActions[[2]string{def.Name, actionName}] = true
+			key := [2]string{def.Name, actionName}
+			if skipActions[key] {
+				continue
+			}
+			catalogActions[key] = true
 		}
 	}
 	for key := range catalogActions {
@@ -168,16 +207,41 @@ func TestReadOnlyCatalog_ActionsDispatchExpectedCmdPath(t *testing.T) {
 		{"pad_role", "delete"}: {"role", "delete"},
 
 		{"pad_search", "query"}: {"item", "search"},
+
+		// pad_item passThrough actions. link/unlink excluded — see
+		// catalog_item_test.go for their dispatch test.
+		{"pad_item", "create"}:        {"item", "create"},
+		{"pad_item", "update"}:        {"item", "update"},
+		{"pad_item", "delete"}:        {"item", "delete"},
+		{"pad_item", "get"}:           {"item", "show"},
+		{"pad_item", "list"}:          {"item", "list"},
+		{"pad_item", "move"}:          {"item", "move"},
+		{"pad_item", "deps"}:          {"item", "deps"},
+		{"pad_item", "star"}:          {"item", "star"},
+		{"pad_item", "unstar"}:        {"item", "unstar"},
+		{"pad_item", "starred"}:       {"item", "starred"},
+		{"pad_item", "comment"}:       {"item", "comment"},
+		{"pad_item", "list-comments"}: {"item", "comments"},
+		{"pad_item", "bulk-update"}:   {"item", "bulk-update"},
+		{"pad_item", "note"}:          {"item", "note"},
+		{"pad_item", "decide"}:        {"item", "decide"},
 	}
 
-	// Required-positional fixture: every CLI command in the read-only
+	// Required-positional fixture: every CLI command in the v0.2
 	// surface gets its required args satisfied so BuildCLIArgs reaches
 	// dispatcher.Dispatch instead of returning a missing-arg error.
 	fixtureInput := map[string]any{
-		"email": "test@example.com",
-		"name":  "test-name",
-		"slug":  "test-slug",
-		"query": "test-query",
+		"email":             "test@example.com",
+		"name":              "test-name",
+		"slug":              "test-slug",
+		"query":             "test-query",
+		"ref":               "TASK-1",
+		"collection":        "tasks",
+		"title":             "test title",
+		"target_collection": "ideas",
+		"message":           "test message",
+		"summary":           "test summary",
+		"decision":          "test decision",
 	}
 
 	for _, def := range Catalog {
@@ -188,9 +252,9 @@ func TestReadOnlyCatalog_ActionsDispatchExpectedCmdPath(t *testing.T) {
 			key := [2]string{def.Name, actionName}
 			wantCmdPath, ok := expected[key]
 			if !ok {
-				// Already covered by TestReadOnlyCatalog_ActionsMatchCmdhelp's
-				// bijection check; skip silently here to keep this test
-				// focused on dispatch correctness.
+				// link/unlink and other custom-dispatch actions skipped —
+				// they have dedicated tests; the bijection check covers
+				// the catalog/expected pair.
 				continue
 			}
 			t.Run(def.Name+"."+actionName, func(t *testing.T) {
@@ -373,6 +437,154 @@ func liveCmdhelpDoc(t *testing.T) *cmdhelp.Document {
 					"workspace", "collection", "status", "priority",
 					"sort", "limit", "offset",
 				),
+			},
+			// pad_item surface (TASK-981)
+			"item create": {
+				Summary: "create item",
+				Args:    mkArgs("collection", "title"),
+				Flags: mkFlags(
+					"workspace", "assign", "category", "content", "field",
+					"parent", "priority", "role", "status", "tags",
+				),
+			},
+			"item update": {
+				Summary: "update item",
+				Args:    mkArgs("ref"),
+				Flags: mkFlags(
+					"workspace", "assign", "category", "comment", "content",
+					"field", "parent", "priority", "role", "status",
+					"tags", "title",
+				),
+			},
+			"item delete": {
+				Summary: "delete item",
+				Args:    mkArgs("ref"),
+				Flags:   mkFlags("workspace"),
+			},
+			"item show": {
+				Summary: "show item",
+				Args:    mkArgs("ref"),
+				Flags:   mkFlags("workspace"),
+			},
+			"item list": {
+				Summary: "list items",
+				Args:    []cmdhelp.Arg{{Name: "collection"}}, // optional
+				Flags: map[string]cmdhelp.Flag{
+					"workspace": {Type: "string"},
+					"all":       {Type: "bool"},
+					"assign":    {Type: "string"},
+					"field":     {Type: "[]string", Repeatable: true},
+					"group-by":  {Type: "string"},
+					"limit":     {Type: "int"},
+					"parent":    {Type: "string"},
+					"priority":  {Type: "string"},
+					"role":      {Type: "string"},
+					"sort":      {Type: "string"},
+					"status":    {Type: "string"},
+				},
+			},
+			"item move": {
+				Summary: "move item",
+				Args:    mkArgs("ref", "target-collection"),
+				Flags: map[string]cmdhelp.Flag{
+					"workspace": {Type: "string"},
+					"field":     {Type: "[]string", Repeatable: true},
+				},
+			},
+			"item deps": {
+				Summary: "show deps",
+				Args:    mkArgs("ref"),
+				Flags:   mkFlags("workspace"),
+			},
+			"item star": {
+				Summary: "star item",
+				Args:    mkArgs("ref"),
+				Flags:   mkFlags("workspace"),
+			},
+			"item unstar": {
+				Summary: "unstar item",
+				Args:    mkArgs("ref"),
+				Flags:   mkFlags("workspace"),
+			},
+			"item starred": {
+				Summary: "list starred",
+				Flags: map[string]cmdhelp.Flag{
+					"workspace": {Type: "string"},
+					"all":       {Type: "bool"},
+				},
+			},
+			"item comment": {
+				Summary: "add comment",
+				Args:    mkArgs("ref", "message"),
+				Flags:   mkFlags("workspace", "reply-to"),
+			},
+			"item comments": {
+				Summary: "list comments",
+				Args:    mkArgs("ref"),
+				Flags:   mkFlags("workspace"),
+			},
+			"item bulk-update": {
+				Summary: "bulk update",
+				Args:    []cmdhelp.Arg{{Name: "ref", Required: true, Repeatable: true}},
+				Flags:   mkFlags("workspace", "priority", "status"),
+			},
+			"item note": {
+				Summary: "add note",
+				Args:    mkArgs("ref", "summary"),
+				Flags:   mkFlags("workspace", "details"),
+			},
+			"item decide": {
+				Summary: "record decision",
+				Args:    mkArgs("ref", "decision"),
+				Flags:   mkFlags("workspace", "rationale"),
+			},
+			// Link family — used by catalog_item_test.go for the
+			// link/unlink dispatch tests. Args mirror the real CLI's
+			// inconsistent positional names.
+			"item block": {
+				Summary: "block item",
+				Args:    mkArgs("source-ref", "target-ref"),
+				Flags:   mkFlags("workspace"),
+			},
+			"item unblock": {
+				Summary: "unblock item",
+				Args:    mkArgs("source-ref", "target-ref"),
+				Flags:   mkFlags("workspace"),
+			},
+			"item blocked-by": {
+				Summary: "blocked-by item",
+				Args:    mkArgs("source-ref", "blocker-ref"),
+				Flags:   mkFlags("workspace"),
+			},
+			"item supersedes": {
+				Summary: "supersedes",
+				Args:    mkArgs("new-ref", "old-ref"),
+				Flags:   mkFlags("workspace"),
+			},
+			"item unsupersede": {
+				Summary: "unsupersede",
+				Args:    mkArgs("new-ref", "old-ref"),
+				Flags:   mkFlags("workspace"),
+			},
+			"item implements": {
+				Summary: "implements",
+				Args:    mkArgs("implementer-ref", "target-ref"),
+				Flags:   mkFlags("workspace"),
+			},
+			"item unimplements": {
+				Summary: "unimplements",
+				Args:    mkArgs("implementer-ref", "target-ref"),
+				Flags:   mkFlags("workspace"),
+			},
+			"item split-from": {
+				Summary: "split-from",
+				Args:    mkArgs("child-ref", "parent-ref"),
+				Flags:   mkFlags("workspace"),
+			},
+			"item unsplit": {
+				Summary: "unsplit",
+				Args:    mkArgs("child-ref", "parent-ref"),
+				Flags:   mkFlags("workspace"),
 			},
 		},
 	}

--- a/internal/mcp/dispatch.go
+++ b/internal/mcp/dispatch.go
@@ -66,6 +66,39 @@ func DispatchInputFromContext(ctx context.Context) map[string]any {
 	return v
 }
 
+// mergeDispatchInput returns a copy of the user-supplied MCP input
+// augmented with the same default injections BuildCLIArgs applies —
+// session workspace, root flags — so the dispatcher receives the
+// effective input rather than a partial map. Pure function (no
+// mutation of `input`); safe to call with a nil input map.
+//
+// HTTPHandlerDispatcher reads the merged map via
+// DispatchInputFromContext to build a structured request body without
+// reverse-parsing CLI flags. ExecDispatcher ignores it (it dispatches
+// via cliArgs).
+func mergeDispatchInput(input map[string]any, sessionWorkspace string, rootFlags map[string]string) map[string]any {
+	out := make(map[string]any, len(input)+len(rootFlags)+1)
+	for k, v := range input {
+		out[k] = v
+	}
+	if _, ok := out["workspace"]; !ok && sessionWorkspace != "" {
+		out["workspace"] = sessionWorkspace
+	}
+	for k, v := range rootFlags {
+		if v == "" {
+			continue
+		}
+		// MCP property names are snake_case (TASK-964) — translate
+		// rootFlags' kebab-case keys before checking collision.
+		propName := MCPPropertyName(k)
+		if _, ok := out[propName]; ok {
+			continue
+		}
+		out[propName] = v
+	}
+	return out
+}
+
 // ExecDispatcher shells out to the pad binary at Binary. stdout is
 // returned as Text content; if it parses as JSON the result is also
 // surfaced via StructuredContent so MCP clients can consume it

--- a/internal/mcp/registry.go
+++ b/internal/mcp/registry.go
@@ -1,27 +1,36 @@
 package mcp
 
 import (
-	"context"
 	"fmt"
-	"sort"
 	"strings"
 
-	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 
 	"github.com/PerpetualSoftware/pad/internal/cmdhelp"
 )
 
 // RegistryOptions configures Register.
+//
+// As of TASK-981 the v0.1 cmdhelp leaf walker is retired — Register
+// registers pad_set_workspace plus the v0.2 catalog (catalog.go).
+// cmdhelp is still required (the source of truth for individual CLI
+// command schemas consumed by BuildCLIArgs at dispatch time), but no
+// longer drives tool naming or count.
 type RegistryOptions struct {
-	// Doc is the cmdhelp Document describing the command tree. Required.
+	// Doc is the cmdhelp Document describing the command tree.
+	// Required — used by env.Dispatch to look up cmdInfo for
+	// BuildCLIArgs. The tool surface itself is hand-curated in
+	// catalog.go and per-resource catalog_<name>.go files.
 	Doc *cmdhelp.Document
+
 	// Workspace holds the session workspace mutated by pad_set_workspace.
 	// Required.
 	Workspace *WorkspaceState
+
 	// Dispatcher executes tool calls. Required (use ExecDispatcher in
 	// production; fakes in tests).
 	Dispatcher Dispatcher
+
 	// RootFlags lists root-level CLI flags to inject into every
 	// dispatched call when the input doesn't already provide them.
 	// Captured at server startup — runtime-mutable state belongs in
@@ -32,66 +41,22 @@ type RegistryOptions struct {
 	// `map[string]string{"url": urlFlag}` is safe even when the user
 	// didn't pass --url to `pad mcp serve`.
 	RootFlags map[string]string
-	// ExcludeCommands lists command paths to skip (space-separated, e.g.
-	// "db backup"). A path that matches a registered group prefix
-	// suppresses every leaf under it — excluding "completion" suppresses
-	// "completion bash", "completion zsh", etc.
-	//
-	// nil = use DefaultExcludes. An empty slice = exclude nothing.
-	ExcludeCommands []string
+
+	// PadVersion is the runtime pad binary version. Forwarded to the
+	// catalog's ActionEnv so pad_meta.action: server-info / version
+	// can report it. Empty falls back to FallbackVersion.
+	PadVersion string
 }
 
-// DefaultExcludes is the curated allow-list scope: read + item-CRUD +
-// project intelligence. Excluded commands are unsafe (mutate auth or
-// filesystem state outside the workspace), interactive (prompt the
-// user), recursive (start another MCP server), or long-running
-// (streaming watchers).
+// Register installs pad's MCP tools on srv: the built-in
+// pad_set_workspace plus every v0.2 catalog tool. Returns the count of
+// registered tools (including pad_set_workspace).
 //
-// Operators who want a tighter or looser surface override via
-// RegistryOptions.ExcludeCommands.
-var DefaultExcludes = []string{
-	// Recursive — would spawn another MCP server inside this one.
-	"mcp serve",
-	"mcp install",
-	// Lifecycle — server start/stop and DB ops are operator-only.
-	"server start",
-	"server stop",
-	"db backup",
-	"db restore",
-	"db migrate-to-pg",
-	// Auth — interactive password prompts, mutate credentials file.
-	"auth setup",
-	"auth login",
-	"auth logout",
-	"auth configure",
-	"auth reset-password",
-	// Workspace lifecycle — interactive or filesystem-mutating.
-	"init",
-	"workspace init",
-	"workspace import",
-	"workspace export",
-	"workspace onboard",
-	"workspace join",
-	// Editor — opens $EDITOR (subprocess never returns).
-	"item edit",
-	// Streaming — long-running watchers tie up an MCP slot.
-	"project watch",
-	// Filesystem mutations outside the workspace.
-	"agent install",
-	"agent update",
-	// Shell completion — not useful as an MCP tool surface.
-	"completion",
-}
-
-// Register walks opts.Doc, registers every leaf command (no
-// children in the document) as an MCP tool on srv, and installs the
-// built-in pad_set_workspace tool. Returns the count of tools
-// registered (including pad_set_workspace).
-//
-// Tool names use snake_case: "item create" → "item_create". Inputs
-// follow the cmdhelp Arg/Flag types. Dispatch goes through
-// opts.Dispatcher with the workspace flag injected from
-// opts.Workspace if not explicitly provided.
+// As of TASK-981 (PLAN-969), this is the single tool-registration
+// entry point. The legacy cmdhelp leaf walker has been retired —
+// Register no longer iterates opts.Doc.Commands. Doc is still required
+// because the catalog's action handlers use it via ActionEnv.Dispatch
+// to look up CLI flag/arg schemas at dispatch time.
 func Register(srv *server.MCPServer, opts RegistryOptions) (int, error) {
 	if opts.Doc == nil {
 		return 0, fmt.Errorf("RegistryOptions.Doc is required")
@@ -103,57 +68,24 @@ func Register(srv *server.MCPServer, opts RegistryOptions) (int, error) {
 		return 0, fmt.Errorf("RegistryOptions.Dispatcher is required")
 	}
 
-	excludes := opts.ExcludeCommands
-	if excludes == nil {
-		excludes = DefaultExcludes
-	}
-	excludeSet := make(map[string]struct{}, len(excludes))
-	for _, e := range excludes {
-		excludeSet[e] = struct{}{}
-	}
-
 	registerSetWorkspaceTool(srv, opts.Workspace)
 	count := 1 // pad_set_workspace
 
-	rootFlags := opts.RootFlags // closed-over by every handler below
-
-	paths := make([]string, 0, len(opts.Doc.Commands))
-	for p := range opts.Doc.Commands {
-		paths = append(paths, p)
+	catalogCount, err := RegisterCatalog(srv, CatalogOptions{
+		Doc:        opts.Doc,
+		Workspace:  opts.Workspace,
+		Dispatcher: opts.Dispatcher,
+		RootFlags:  opts.RootFlags,
+		PadVersion: opts.PadVersion,
+	})
+	if err != nil {
+		return 0, fmt.Errorf("register catalog: %w", err)
 	}
-	sort.Strings(paths)
-
-	leaves := identifyLeaves(paths)
-
-	for _, path := range paths {
-		if !leaves[path] {
-			continue
-		}
-		if _, blocked := excludeSet[path]; blocked {
-			continue
-		}
-		if hasExcludedAncestor(path, excludeSet) {
-			continue
-		}
-		cmdInfo := opts.Doc.Commands[path]
-		tool := buildTool(path, cmdInfo)
-		handler := makeDispatchHandler(path, cmdInfo, opts.Dispatcher, opts.Workspace, rootFlags)
-		srv.AddTool(tool, handler)
-		count++
-	}
-	return count, nil
-}
-
-// ToolNameFromPath converts a cmdhelp command path ("item create") to
-// the canonical MCP tool-name form ("item_create"). Exported so the
-// dispatch helpers and tests can compute names without re-implementing
-// the rule.
-func ToolNameFromPath(path string) string {
-	return strings.ReplaceAll(path, " ", "_")
+	return count + catalogCount, nil
 }
 
 // MCPPropertyName converts a CLI flag or argument name to the
-// snake_case form advertised on the MCP tool surface. Hyphens become
+// snake_case form used inside the dispatch input map. Hyphens become
 // underscores; everything else passes through.
 //
 // Why translate (TASK-964): Cobra's flag names are kebab-case
@@ -161,185 +93,14 @@ func ToolNameFromPath(path string) string {
 // but Anthropic's tool-use convention — and most LLMs' training data
 // — is snake_case (`due_date`). Hyphenated property names trip up
 // agents that auto-normalize to snake_case before emitting JSON, and
-// silently lose every flag with a hyphen. We expose snake_case on the
-// MCP surface and translate back to kebab-case at dispatch.
+// silently lose every flag with a hyphen. The catalog's parameter
+// names are snake_case; BuildCLIArgs translates them back to kebab-
+// case at dispatch.
 //
 // Single-word names (workspace, format, content, stdin) round-trip
 // unchanged.
 func MCPPropertyName(cliName string) string {
 	return strings.ReplaceAll(cliName, "-", "_")
-}
-
-// identifyLeaves returns a map of path → true for every command path
-// that is NOT a strict prefix of another path (and is therefore a leaf).
-func identifyLeaves(paths []string) map[string]bool {
-	leaf := make(map[string]bool, len(paths))
-	for _, p := range paths {
-		leaf[p] = true
-	}
-	for _, p := range paths {
-		for _, q := range paths {
-			if p != q && strings.HasPrefix(q, p+" ") {
-				leaf[p] = false
-				break
-			}
-		}
-	}
-	return leaf
-}
-
-// hasExcludedAncestor returns true when any space-delimited prefix of
-// path appears in excludes. Used so excluding "completion" suppresses
-// "completion bash", "completion zsh", etc.
-func hasExcludedAncestor(path string, excludes map[string]struct{}) bool {
-	parts := strings.Split(path, " ")
-	for i := 1; i < len(parts); i++ {
-		prefix := strings.Join(parts[:i], " ")
-		if _, ok := excludes[prefix]; ok {
-			return true
-		}
-	}
-	return false
-}
-
-func buildTool(path string, cmdInfo cmdhelp.Command) mcp.Tool {
-	desc := cmdInfo.Summary
-	if cmdInfo.Description != "" {
-		if desc != "" {
-			desc += "\n\n"
-		}
-		desc += cmdInfo.Description
-	}
-	opts := []mcp.ToolOption{mcp.WithDescription(desc)}
-
-	for _, arg := range cmdInfo.Args {
-		opts = append(opts, propertyForArg(arg))
-	}
-
-	flagNames := make([]string, 0, len(cmdInfo.Flags))
-	for name := range cmdInfo.Flags {
-		if _, hidden := flagsHiddenFromMCP[name]; hidden {
-			continue
-		}
-		flagNames = append(flagNames, name)
-	}
-	sort.Strings(flagNames)
-	for _, name := range flagNames {
-		opts = append(opts, propertyForFlag(name, cmdInfo.Flags[name]))
-	}
-	return mcp.NewTool(ToolNameFromPath(path), opts...)
-}
-
-func propertyForArg(arg cmdhelp.Arg) mcp.ToolOption {
-	propOpts := propertyOptionsCommon(arg.Description, arg.Required, arg.Enum)
-	propName := MCPPropertyName(arg.Name)
-	if arg.Repeatable {
-		return mcp.WithArray(propName, append(propOpts, mcp.WithStringItems())...)
-	}
-	switch arg.Type {
-	case "int", "number", "float", "float64", "int64":
-		return mcp.WithNumber(propName, propOpts...)
-	case "bool":
-		return mcp.WithBoolean(propName, propOpts...)
-	default:
-		return mcp.WithString(propName, propOpts...)
-	}
-}
-
-func propertyForFlag(name string, flag cmdhelp.Flag) mcp.ToolOption {
-	propOpts := propertyOptionsCommon(flag.Description, flag.Required, flag.Enum)
-	propName := MCPPropertyName(name)
-	if flag.Repeatable {
-		return mcp.WithArray(propName, append(propOpts, mcp.WithStringItems())...)
-	}
-	switch flag.Type {
-	case "bool":
-		return mcp.WithBoolean(propName, propOpts...)
-	case "int", "number", "int64", "uint", "uint64", "float", "float64":
-		return mcp.WithNumber(propName, propOpts...)
-	case "[]string", "stringSlice", "[]int", "intSlice", "stringArray":
-		return mcp.WithArray(propName, append(propOpts, mcp.WithStringItems())...)
-	default:
-		return mcp.WithString(propName, propOpts...)
-	}
-}
-
-func propertyOptionsCommon(description string, required bool, enum []interface{}) []mcp.PropertyOption {
-	out := make([]mcp.PropertyOption, 0, 3)
-	if description != "" {
-		out = append(out, mcp.Description(description))
-	}
-	if required {
-		out = append(out, mcp.Required())
-	}
-	if len(enum) > 0 {
-		out = append(out, mcp.Enum(stringifyEnum(enum)...))
-	}
-	return out
-}
-
-func stringifyEnum(values []interface{}) []string {
-	out := make([]string, len(values))
-	for i, v := range values {
-		out[i] = fmt.Sprint(v)
-	}
-	return out
-}
-
-// makeDispatchHandler closes over the command path + dispatcher so
-// each registered tool routes to the right CLI invocation.
-func makeDispatchHandler(
-	path string,
-	cmdInfo cmdhelp.Command,
-	dispatcher Dispatcher,
-	state *WorkspaceState,
-	rootFlags map[string]string,
-) server.ToolHandlerFunc {
-	cmdPath := strings.Split(path, " ")
-	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		input := req.GetArguments()
-		args, err := BuildCLIArgs(cmdInfo, input, state.Get(), rootFlags)
-		if err != nil {
-			return mcp.NewToolResultErrorf("%s: %s", ToolNameFromPath(path), err.Error()), nil
-		}
-		// Forward the original JSON input so HTTPHandlerDispatcher can
-		// build a structured request body without reverse-parsing
-		// cliArgs. ExecDispatcher ignores this; see Dispatcher godoc.
-		// Note: input may be missing values that BuildCLIArgs injected
-		// (session workspace, root flags, default --format) — pass the
-		// computed-superset map by merging them in here so HTTP
-		// dispatch and exec dispatch see the same effective values.
-		ctx = WithDispatchInput(ctx, mergeDispatchInput(input, state.Get(), rootFlags))
-		return dispatcher.Dispatch(ctx, cmdPath, args)
-	}
-}
-
-// mergeDispatchInput returns a copy of the user-supplied MCP input
-// augmented with the same default injections BuildCLIArgs applies —
-// session workspace, root flags — so the dispatcher receives the
-// effective input rather than a partial map. Pure function (no
-// mutation of `input`); safe to call with a nil input map.
-func mergeDispatchInput(input map[string]any, sessionWorkspace string, rootFlags map[string]string) map[string]any {
-	out := make(map[string]any, len(input)+len(rootFlags)+1)
-	for k, v := range input {
-		out[k] = v
-	}
-	if _, ok := out["workspace"]; !ok && sessionWorkspace != "" {
-		out["workspace"] = sessionWorkspace
-	}
-	for k, v := range rootFlags {
-		if v == "" {
-			continue
-		}
-		// MCP property names are snake_case (TASK-964) — translate
-		// rootFlags' kebab-case keys before checking collision.
-		propName := MCPPropertyName(k)
-		if _, ok := out[propName]; ok {
-			continue
-		}
-		out[propName] = v
-	}
-	return out
 }
 
 // flagsHiddenFromMCP are flag names whose semantics depend on the
@@ -348,10 +109,10 @@ func mergeDispatchInput(input map[string]any, sessionWorkspace string, rootFlags
 // content should use the corresponding --content flag, which is wired
 // through the JSON args path.
 //
-// Listed here so registry generation AND defensive dispatch agree:
-// even if an agent passes `stdin: true` (perhaps from a stale schema
-// cache), BuildCLIArgs drops it rather than running a subprocess
-// that blocks on EOF and creates an empty item.
+// Even though catalog.go declares parameters explicitly (so stdin is
+// never advertised), BuildCLIArgs still defends against an agent
+// passing `stdin: true` from a stale schema cache — the subprocess
+// would then block on EOF and create an empty item.
 var flagsHiddenFromMCP = map[string]struct{}{
 	"stdin": {},
 }

--- a/internal/mcp/registry_test.go
+++ b/internal/mcp/registry_test.go
@@ -11,14 +11,29 @@ import (
 	"github.com/PerpetualSoftware/pad/internal/cmdhelp"
 )
 
-// fakeDispatcher records the dispatch invocation for assertion.
+// As of TASK-981 (PLAN-969) the v0.1 cmdhelp leaf walker is retired.
+// This file used to test buildTool / makeDispatchHandler / identifyLeaves /
+// the DefaultExcludes filter — none of which exist anymore. The
+// remaining contents are:
+//
+//   - Tests of Register's validation surface (still public; just
+//     does less work now — registers pad_set_workspace and delegates
+//     to RegisterCatalog).
+//   - Tests of MCPPropertyName, the snake_case translation rule still
+//     used by BuildCLIArgs and mergeDispatchInput.
+//   - Shared helpers (fakeDispatcher, fixtureDoc, equalSlice) used by
+//     other test files in this package.
+
+// fakeDispatcher records the dispatch invocation for assertion. Used
+// across catalog_*_test.go and the few tests below that drive Register
+// directly.
 type fakeDispatcher struct {
 	gotPath []string
 	gotArgs []string
 	out     string
 }
 
-func (f *fakeDispatcher) Dispatch(ctx context.Context, cmdPath, args []string) (*mcp.CallToolResult, error) {
+func (f *fakeDispatcher) Dispatch(_ context.Context, cmdPath, args []string) (*mcp.CallToolResult, error) {
 	f.gotPath = append([]string(nil), cmdPath...)
 	f.gotArgs = append([]string(nil), args...)
 	if f.out == "" {
@@ -27,31 +42,51 @@ func (f *fakeDispatcher) Dispatch(ctx context.Context, cmdPath, args []string) (
 	return mcp.NewToolResultText(f.out), nil
 }
 
-// fixtureDoc mirrors a slice of pad's real tree: groups, leaves,
-// excluded entries, and a multi-word path for snake-case naming.
+// fixtureDoc returns a small cmdhelp.Document with the items the
+// catalog tests need most often. Catalog actions only require their
+// own cmdPath to be present — most catalog tests use liveCmdhelpDoc
+// from catalog_readonly_test.go which mirrors the real CLI; this
+// minimal variant suits the few tests below that don't need the full
+// surface.
 func fixtureDoc() *cmdhelp.Document {
 	return &cmdhelp.Document{
 		CmdhelpVersion: "0.1",
 		Binary:         "pad",
 		Commands: map[string]cmdhelp.Command{
-			"item":                  {Summary: "Item commands"},
-			"item create":           {Summary: "Create item"},
-			"item list":             {Summary: "List items"},
-			"db":                    {Summary: "DB ops"},
-			"db backup":             {Summary: "Backup DB"},
-			"mcp":                   {Summary: "MCP"},
-			"mcp serve":             {Summary: "MCP server"},
-			"completion":            {Summary: "Generate shell completions"},
-			"completion bash":       {Summary: "bash completion"},
-			"completion zsh":        {Summary: "zsh completion"},
-			"workspace":             {Summary: "ws commands"},
-			"workspace context":     {Summary: "ws context group"},
-			"workspace context set": {Summary: "set context"},
+			"item": {Summary: "Item commands"},
+			"item create": {
+				Summary: "Create item",
+				Args: []cmdhelp.Arg{
+					{Name: "collection", Required: true},
+					{Name: "title", Required: true},
+				},
+				Flags: map[string]cmdhelp.Flag{
+					"workspace": {Type: "string"},
+					"priority":  {Type: "string"},
+				},
+			},
+			"item list": {
+				Summary: "List items",
+				Args:    []cmdhelp.Arg{{Name: "collection"}},
+				Flags: map[string]cmdhelp.Flag{
+					"workspace": {Type: "string"},
+				},
+			},
+			"item show": {
+				Summary: "Show item",
+				Args:    []cmdhelp.Arg{{Name: "ref", Required: true}},
+				Flags: map[string]cmdhelp.Flag{
+					"workspace": {Type: "string"},
+				},
+			},
 		},
 	}
 }
 
-func TestRegister_RegistersLeaves_AppliesDefaultExcludes(t *testing.T) {
+// TestRegister_RegistersSetWorkspaceAndCatalog confirms Register
+// installs pad_set_workspace plus every catalog tool. Count =
+// 1 (set_workspace) + len(Catalog).
+func TestRegister_RegistersSetWorkspaceAndCatalog(t *testing.T) {
 	srv := server.NewMCPServer("t", "1", server.WithToolCapabilities(true))
 	count, err := Register(srv, RegistryOptions{
 		Doc:        fixtureDoc(),
@@ -61,51 +96,16 @@ func TestRegister_RegistersLeaves_AppliesDefaultExcludes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Register: %v", err)
 	}
-	// Leaves: item create, item list, db backup, mcp serve,
-	// completion bash, completion zsh, workspace context set.
-	// DefaultExcludes drops: db backup, mcp serve, completion (group → all
-	// children). So registered leaves = item create, item list,
-	// workspace context set = 3, plus pad_set_workspace = 4.
-	if count != 4 {
-		t.Errorf("expected 4 tools (3 leaves + pad_set_workspace), got %d", count)
+	want := 1 + len(Catalog)
+	if count != want {
+		t.Errorf("registered %d tools, want %d (1 + len(Catalog))", count, want)
 	}
 }
 
-func TestRegister_NoExcludesRegistersEverything(t *testing.T) {
-	srv := server.NewMCPServer("t", "1", server.WithToolCapabilities(true))
-	count, err := Register(srv, RegistryOptions{
-		Doc:             fixtureDoc(),
-		Workspace:       NewWorkspaceState(""),
-		Dispatcher:      &fakeDispatcher{},
-		ExcludeCommands: []string{}, // empty = nothing excluded
-	})
-	if err != nil {
-		t.Fatalf("Register: %v", err)
-	}
-	// All 7 leaves + pad_set_workspace = 8.
-	if count != 8 {
-		t.Errorf("expected 8 tools, got %d", count)
-	}
-}
-
-func TestRegister_ExcludePrefixSuppressesAllChildren(t *testing.T) {
-	srv := server.NewMCPServer("t", "1", server.WithToolCapabilities(true))
-	count, err := Register(srv, RegistryOptions{
-		Doc:             fixtureDoc(),
-		Workspace:       NewWorkspaceState(""),
-		Dispatcher:      &fakeDispatcher{},
-		ExcludeCommands: []string{"completion", "db"},
-	})
-	if err != nil {
-		t.Fatalf("Register: %v", err)
-	}
-	// Suppressed: completion bash/zsh, db backup. Leaves left: item create,
-	// item list, mcp serve, workspace context set = 4 + pad_set_workspace.
-	if count != 5 {
-		t.Errorf("expected 5 tools, got %d", count)
-	}
-}
-
+// TestRegister_ValidatesRequiredOptions confirms the validation
+// surface still rejects nil Doc/Workspace/Dispatcher. PadVersion is
+// optional; Register doesn't validate it (FallbackVersion in pad_meta
+// covers the empty case).
 func TestRegister_ValidatesRequiredOptions(t *testing.T) {
 	srv := server.NewMCPServer("t", "1", server.WithToolCapabilities(true))
 	state := NewWorkspaceState("")
@@ -115,153 +115,56 @@ func TestRegister_ValidatesRequiredOptions(t *testing.T) {
 	cases := []struct {
 		name string
 		opts RegistryOptions
+		want string
 	}{
-		{"missing Doc", RegistryOptions{Workspace: state, Dispatcher: disp}},
-		{"missing Workspace", RegistryOptions{Doc: doc, Dispatcher: disp}},
-		{"missing Dispatcher", RegistryOptions{Doc: doc, Workspace: state}},
+		{"missing Doc", RegistryOptions{Workspace: state, Dispatcher: disp}, "Doc"},
+		{"missing Workspace", RegistryOptions{Doc: doc, Dispatcher: disp}, "Workspace"},
+		{"missing Dispatcher", RegistryOptions{Doc: doc, Workspace: state}, "Dispatcher"},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			if _, err := Register(srv, c.opts); err == nil {
-				t.Errorf("expected error for %s, got nil", c.name)
+			_, err := Register(srv, c.opts)
+			if err == nil {
+				t.Fatalf("expected error mentioning %q, got nil", c.want)
+			}
+			if !strings.Contains(err.Error(), c.want) {
+				t.Errorf("error %q should mention %q", err.Error(), c.want)
 			}
 		})
 	}
 }
 
-func TestToolNameFromPath_SnakeCase(t *testing.T) {
-	cases := map[string]string{
-		"item create":           "item_create",
-		"workspace context set": "workspace_context_set",
-		"db":                    "db",
-		"":                      "",
-	}
-	for in, want := range cases {
-		if got := ToolNameFromPath(in); got != want {
-			t.Errorf("ToolNameFromPath(%q) = %q, want %q", in, got, want)
-		}
-	}
-}
-
-func TestRegister_DispatchHandler_RoutesAndInjectsWorkspace(t *testing.T) {
-	disp := &fakeDispatcher{out: `{"ok": true}`}
-	state := NewWorkspaceState("docapp")
-	doc := &cmdhelp.Document{
-		CmdhelpVersion: "0.1",
-		Binary:         "pad",
-		Commands: map[string]cmdhelp.Command{
-			"item create": {
-				Summary: "Create item",
-				Args: []cmdhelp.Arg{
-					{Name: "collection", Type: "string", Required: true},
-					{Name: "title", Type: "string", Required: true},
-				},
-				Flags: map[string]cmdhelp.Flag{
-					"priority": {Type: "string"},
-				},
-			},
-		},
-	}
+// TestRegister_PassesPadVersionToCatalog round-trips PadVersion
+// through pad_meta.action: server-info. Confirms the option is wired
+// from RegistryOptions through CatalogOptions to the action env.
+func TestRegister_PassesPadVersionToCatalog(t *testing.T) {
 	srv := server.NewMCPServer("t", "1", server.WithToolCapabilities(true))
+	const wantVersion = "1.2.3-register-passthrough"
 	if _, err := Register(srv, RegistryOptions{
-		Doc:             doc,
-		Workspace:       state,
-		Dispatcher:      disp,
-		ExcludeCommands: []string{},
+		Doc:        fixtureDoc(),
+		Workspace:  NewWorkspaceState(""),
+		Dispatcher: &fakeDispatcher{},
+		PadVersion: wantVersion,
 	}); err != nil {
 		t.Fatalf("Register: %v", err)
 	}
-
-	// Drive the handler by computing it the same way Register does
-	// — this isolates the routing logic from server internals.
-	handler := makeDispatchHandler("item create", doc.Commands["item create"], disp, state, nil)
-	req := mcp.CallToolRequest{}
-	req.Params.Arguments = map[string]any{
-		"collection": "tasks",
-		"title":      "Fix OAuth",
-		"priority":   "high",
-	}
-	res, err := handler(context.Background(), req)
+	// Drive pad_meta.server-info directly (avoids spinning up a full
+	// stdio handshake just to read serverInfo).
+	env := ActionEnv{PadVersion: wantVersion, Catalog: Catalog}
+	res, err := actionMetaServerInfo(context.Background(), nil, env)
 	if err != nil {
-		t.Fatalf("handler: %v", err)
+		t.Fatalf("server-info: %v", err)
 	}
-	if res.IsError {
-		t.Errorf("handler returned IsError; expected success")
-	}
-	if !equalSlice(disp.gotPath, []string{"item", "create"}) {
-		t.Errorf("dispatch path = %v, want [item create]", disp.gotPath)
-	}
-	wantArgs := []string{"tasks", "Fix OAuth", "--priority", "high", "--workspace", "docapp", "--format", "json"}
-	if !equalSlice(disp.gotArgs, wantArgs) {
-		t.Errorf("dispatch args = %v, want %v", disp.gotArgs, wantArgs)
+	body := textOf(res)
+	if !strings.Contains(body, wantVersion) {
+		t.Errorf("server-info body %q should contain version %q", body, wantVersion)
 	}
 }
 
-func TestRegister_DispatchHandler_ReportsValidationErrors(t *testing.T) {
-	// Missing required arg should NOT shell out — handler returns
-	// IsError result with the validation message, dispatcher untouched.
-	disp := &fakeDispatcher{}
-	state := NewWorkspaceState("")
-	cmdInfo := cmdhelp.Command{
-		Args: []cmdhelp.Arg{{Name: "ref", Type: "string", Required: true}},
-	}
-	handler := makeDispatchHandler("item show", cmdInfo, disp, state, nil)
-
-	req := mcp.CallToolRequest{}
-	req.Params.Arguments = map[string]any{}
-	res, err := handler(context.Background(), req)
-	if err != nil {
-		t.Fatalf("handler: %v", err)
-	}
-	if !res.IsError {
-		t.Errorf("expected IsError result for missing required arg")
-	}
-	if disp.gotPath != nil {
-		t.Errorf("dispatcher should NOT be called on validation failure; got path=%v", disp.gotPath)
-	}
-}
-
-func TestBuildTool_HyphenatedFlagsSurfaceAsSnakeCase(t *testing.T) {
-	// TASK-964: kebab-case flag names (`--due-date`) become snake_case
-	// schema properties (`due_date`) so agents can emit standard
-	// JSON without having to special-case hyphenated keys.
-	cmd := cmdhelp.Command{
-		Summary: "Update item",
-		Args: []cmdhelp.Arg{
-			{Name: "ref", Type: "string", Required: true}, // already underscore-free
-		},
-		Flags: map[string]cmdhelp.Flag{
-			"due-date":   {Type: "string"},
-			"blocked-by": {Type: "string"},
-			"workspace":  {Type: "string"}, // single-word: round-trip unchanged
-		},
-	}
-	tool := buildTool("item update", cmd)
-
-	// Hyphens must NOT appear as schema property names.
-	for prop := range tool.InputSchema.Properties {
-		if strings.Contains(prop, "-") {
-			t.Errorf("schema property %q contains hyphen — agents see kebab-case where they expect snake_case", prop)
-		}
-	}
-	// The translated forms must be present.
-	wantPresent := []string{"ref", "due_date", "blocked_by", "workspace"}
-	for _, want := range wantPresent {
-		if _, ok := tool.InputSchema.Properties[want]; !ok {
-			t.Errorf("schema missing %q; got %v", want, tool.InputSchema.Properties)
-		}
-	}
-	// And the kebab forms must NOT be present (no double-publishing).
-	wantAbsent := []string{"due-date", "blocked-by"}
-	for _, gone := range wantAbsent {
-		if _, ok := tool.InputSchema.Properties[gone]; ok {
-			t.Errorf("schema still contains kebab-case %q alongside snake_case form", gone)
-		}
-	}
-}
-
+// TestMCPPropertyName_RoundTrip locks the kebab→snake translation rule.
+// Used by BuildCLIArgs and mergeDispatchInput to keep input keys
+// snake_case across the dispatch boundary.
 func TestMCPPropertyName_RoundTrip(t *testing.T) {
-	// Lock the translation rule so changes to it stay obvious.
 	cases := map[string]string{
 		"workspace":     "workspace",     // single-word
 		"due-date":      "due_date",      // single hyphen
@@ -277,58 +180,11 @@ func TestMCPPropertyName_RoundTrip(t *testing.T) {
 	}
 }
 
-func TestBuildTool_OmitsStdinFromInputSchema(t *testing.T) {
-	// `--stdin` instructs pad to read content from os.Stdin. The MCP
-	// transport doesn't pipe agent stdin to the subprocess, so the
-	// flag has no usable semantics over MCP — agents should use
-	// --content instead. Hide it from the tool schema so agents
-	// don't get tempted, and keep the defensive drop in
-	// BuildCLIArgs as a belt-and-braces guard.
-	cmd := cmdhelp.Command{
-		Summary: "Create item",
-		Flags: map[string]cmdhelp.Flag{
-			"stdin":   {Type: "bool"},
-			"content": {Type: "string"},
-		},
-	}
-	tool := buildTool("item create", cmd)
-	if _, ok := tool.InputSchema.Properties["stdin"]; ok {
-		t.Errorf("stdin flag should NOT be in tool input schema; properties: %v",
-			tool.InputSchema.Properties)
-	}
-	if _, ok := tool.InputSchema.Properties["content"]; !ok {
-		t.Errorf("content flag should be in tool input schema; properties: %v",
-			tool.InputSchema.Properties)
-	}
-}
-
-func TestRegister_DispatchHandler_ForwardsRootFlags(t *testing.T) {
-	// Per Codex review: --url is a root persistent flag; if pad mcp
-	// serve is invoked as `pad --url X mcp serve`, X must reach
-	// every dispatched subprocess. Otherwise tool calls run against
-	// the wrong server endpoint.
-	disp := &fakeDispatcher{}
-	state := NewWorkspaceState("")
-	cmdInfo := cmdhelp.Command{
-		Summary: "show item",
-		Args:    []cmdhelp.Arg{{Name: "ref", Type: "string", Required: true}},
-	}
-	handler := makeDispatchHandler("item show", cmdInfo, disp, state,
-		map[string]string{"url": "https://api.example.com"})
-
-	req := mcp.CallToolRequest{}
-	req.Params.Arguments = map[string]any{"ref": "TASK-5"}
-	if _, err := handler(context.Background(), req); err != nil {
-		t.Fatalf("handler: %v", err)
-	}
-	wantArgs := []string{"TASK-5", "--url", "https://api.example.com", "--format", "json"}
-	if !equalSlice(disp.gotArgs, wantArgs) {
-		t.Errorf("dispatch args = %v, want %v", disp.gotArgs, wantArgs)
-	}
-}
-
-// equalSlice is a small helper for stable []string comparison; tests
-// across this package use it.
+// equalSlice is a small helper for stable []string comparison; kept
+// here so test files across the package can share it.
+//
+// catalog_test.go has equalStrings with the same semantics — duplicate
+// kept for git-blame continuity. Either name works in new tests.
 func equalSlice(a, b []string) bool {
 	if len(a) != len(b) {
 		return false

--- a/internal/mcp/version.go
+++ b/internal/mcp/version.go
@@ -47,26 +47,21 @@ const CmdhelpVersion = "0.1"
 // silently break consumers. Bump the major when the catalog shape
 // changes incompatibly:
 //
-//   - "0.1" — current. cmdhelp-derived ~85 flat verb tools (PLAN-942).
-//     During PLAN-969's 3-stage rollout, the v0.2 catalog
-//     scaffold + pad_meta tool also ride this version because
-//     the user-visible surface is still predominantly v0.1
-//     (the cmdhelp walker is still active alongside). Bumping
-//     before the catalog is complete would mislead consumers
-//     into believing the resource/action shape is available
-//     for every tool, when only pad_meta + the walker output
-//     show up in tools/list.
-//   - "0.2" — planned. Hand-curated resource × action catalog
-//     (PLAN-969). Version bumped in TASK-981, the commit that
-//     retires the cmdhelp walker and delivers the complete
-//     v0.2 catalog.
+//   - "0.1" — historical. cmdhelp-derived ~85 flat verb tools
+//     (PLAN-942). Lived from PLAN-942 through TASK-980 of PLAN-969's
+//     3-stage rollout; never bumped during rollout because the
+//     user-visible surface was a transitional mix of v0.1 walker
+//     output + the partial v0.2 catalog.
+//   - "0.2" — current. Hand-curated resource × action catalog (PLAN-969,
+//     TASK-981). The cmdhelp leaf walker is retired; tools/list
+//     advertises only the catalog (~7 tools + pad_set_workspace).
 //
 // Discovery surfaces:
 //
 //   - result.capabilities.experimental.padToolSurface.version (handshake).
 //   - pad://_meta/version resource (queryable JSON document).
 //   - pad_meta.action: tool-surface (full catalog introspection).
-const ToolSurfaceVersion = "0.1"
+const ToolSurfaceVersion = "0.2"
 
 // MetaVersionURI is the canonical URI of the queryable version document.
 // Lives outside the pad://workspace/{ws}/... namespace because it's a


### PR DESCRIPTION
## Summary
- Adds `pad_item` to the v0.2 catalog: 17 actions consolidating the v0.1 verb-tool surface (`item_create / item_block / item_star / item_supersedes / ...`).
- Retires the cmdhelp leaf walker. `tools/list` now advertises **only** the v0.2 catalog (~7 catalog tools + `pad_set_workspace`).
- Bumps `ToolSurfaceVersion` from `0.1` → `0.2`. `pad_meta.tool-surface` flips `rollout_status` to `"complete"` automatically.
- Final commit of `TASK-970`'s 3-stage rollout under `PLAN-969`.

## pad_item actions
| Category | Actions |
|---|---|
| Lifecycle | `create`, `update`, `delete`, `get`, `list`, `move` |
| Relationships | `link`, `unlink`, `deps` |
| Stars | `star`, `unstar`, `starred` |
| Comments | `comment`, `list-comments` |
| Bulk + notes + decisions | `bulk-update`, `note`, `decide` |

`link` / `unlink` dispatch on `link_type` via `itemLinkRoutes`. Each route has separate per-direction ops with `(cmdPath, firstArg, secondArg, inverted)` so asymmetric cases like `blocked-by` (unlink shares `pad item unblock` but with operands swapped) work correctly.

## Walker retirement
`internal/mcp/registry.go` shrinks dramatically:
- `Register()` registers `pad_set_workspace` + delegates to `RegisterCatalog`.
- Dropped: `identifyLeaves`, `hasExcludedAncestor`, `buildTool`, `makeDispatchHandler`, `propertyForArg`, `propertyForFlag`, `propertyOptionsCommon`, `stringifyEnum`, `ToolNameFromPath`, `DefaultExcludes`, `RegistryOptions.ExcludeCommands`.
- `mergeDispatchInput` moved to `dispatch.go` (still used by `env.Dispatch`).
- `registry_test.go` pruned to validation + `MCPPropertyName` tests + shared helpers. Per `DOC-978`: delete & rebuild rather than patch.
- `cmd/pad/mcp.go` collapses to a single `Register()` call.

## CLAUDE.md
Updated to reflect the catalog-over-walker architecture and the two independent version constants (`CmdhelpVersion` for CLI help-tree contract; `ToolSurfaceVersion` for MCP tool catalog contract).

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./internal/mcp/...` passes (all walker tests removed; v0.2 catalog tests pass)
- [x] `make check` clean (lint + tests + web build)
- [x] New tests cover: `pad_item.link/unlink` dispatch table for every `link_type` including the blocked-by-with-swapped-operands case, missing/unknown `link_type` structured errors, missing `ref`/`target` validation, aux fields (workspace) flow through, `Register()` passes `PadVersion` end-to-end, catalog action bijection extended to include `pad_item` passThrough actions.
- [ ] Manual: connect Claude Desktop, run real workflows (create / list / update / star / link / standup / changelog) — deferred to TASK-975 dogfood.