### PR TITLE
fix(mcp): explicit workspace param + wrap list responses (BUG-985)

### DIFF
--- a/internal/mcp/bug985_test.go
+++ b/internal/mcp/bug985_test.go
@@ -1,0 +1,229 @@
+package mcp
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/cmdhelp"
+)
+
+// Tests covering BUG-985 (Pad MCP v0.2 Issue Report). Three regressions
+// reported by Claude Desktop after v0.1.0-rc.2:
+//
+//   - Bug 1: explicit `workspace` parameter silently dropped because
+//     the flag is registered as a persistent root flag in cobra and
+//     therefore never appears in cmdhelp's per-command flag list,
+//     so BuildCLIArgs's flag-iteration loop can't see it.
+//   - Bug 2: session default appeared to fail for some tools — same
+//     root cause; the post-loop session-fallback works but the
+//     explicit-input branch was missing entirely.
+//   - Bug 3: list responses returned top-level JSON arrays as
+//     structuredContent, which MCP host validators reject ("expected
+//     record"). Required wrapping in `{items: [...]}`.
+
+// TestBuildCLIArgs_ExplicitWorkspaceWhenNotInCmdInfoFlags is the
+// regression test for BUG-985 bug 1. The cmdhelp document for `item
+// list` does NOT include `workspace` in its Flags map (because cobra
+// registers --workspace persistently on the root command, not per
+// leaf), so the per-flag iteration in BuildCLIArgs has no entry to
+// look up. Without the explicit-input check added in this PR, the
+// `workspace` value passed in the MCP input is silently dropped and
+// the resulting subprocess hits the CWD-fallback path — which is why
+// agents got `no_workspace` errors despite passing `workspace=docapp`.
+func TestBuildCLIArgs_ExplicitWorkspaceWhenNotInCmdInfoFlags(t *testing.T) {
+	// Mirror the real cmdhelp shape: `item list` has 10 flags, none of
+	// which is `workspace`.
+	cmd := cmdhelp.Command{
+		Args: []cmdhelp.Arg{{Name: "collection"}},
+		Flags: map[string]cmdhelp.Flag{
+			"all":      {Type: "bool"},
+			"assign":   {Type: "string"},
+			"field":    {Type: "[]string", Repeatable: true},
+			"group-by": {Type: "string"},
+			"limit":    {Type: "int"},
+			"parent":   {Type: "string"},
+			"priority": {Type: "string"},
+			"role":     {Type: "string"},
+			"sort":     {Type: "string"},
+			"status":   {Type: "string"},
+		},
+	}
+
+	t.Run("explicit workspace emitted even when not in cmdInfo.Flags", func(t *testing.T) {
+		got, err := BuildCLIArgs(cmd,
+			map[string]any{"workspace": "docapp"},
+			"", // no session — explicit must still emit
+			nil,
+		)
+		if err != nil {
+			t.Fatalf("BuildCLIArgs: %v", err)
+		}
+		if !containsPair(got, "--workspace", "docapp") {
+			t.Errorf("expected --workspace docapp in cliArgs; got %v", got)
+		}
+	})
+
+	t.Run("explicit workspace overrides session", func(t *testing.T) {
+		got, err := BuildCLIArgs(cmd,
+			map[string]any{"workspace": "explicit-ws"},
+			"session-ws",
+			nil,
+		)
+		if err != nil {
+			t.Fatalf("BuildCLIArgs: %v", err)
+		}
+		// Exactly one --workspace, with the explicit value.
+		count, value := countAndValue(got, "--workspace")
+		if count != 1 {
+			t.Errorf("expected exactly 1 --workspace, got %d in %v", count, got)
+		}
+		if value != "explicit-ws" {
+			t.Errorf("--workspace value = %q, want explicit-ws (explicit must beat session)", value)
+		}
+	})
+
+	t.Run("session falls through when no explicit", func(t *testing.T) {
+		got, err := BuildCLIArgs(cmd, nil, "session-ws", nil)
+		if err != nil {
+			t.Fatalf("BuildCLIArgs: %v", err)
+		}
+		if !containsPair(got, "--workspace", "session-ws") {
+			t.Errorf("expected session fallback --workspace session-ws; got %v", got)
+		}
+	})
+
+	t.Run("no explicit, no session — no --workspace emitted", func(t *testing.T) {
+		got, err := BuildCLIArgs(cmd, nil, "", nil)
+		if err != nil {
+			t.Fatalf("BuildCLIArgs: %v", err)
+		}
+		if count, _ := countAndValue(got, "--workspace"); count != 0 {
+			t.Errorf("expected no --workspace flag; got %v", got)
+		}
+	})
+}
+
+// TestPackageJSONResult_WrapsTopLevelArray is the regression test for
+// BUG-985 bug 3. Top-level arrays must be wrapped in `{items: [...]}`
+// so MCP host validators (Claude Desktop) accept the structuredContent
+// shape. Without the wrap they reject with "expected record".
+func TestPackageJSONResult_WrapsTopLevelArray(t *testing.T) {
+	t.Run("array wrapped under items key", func(t *testing.T) {
+		body := `[{"slug":"docapp"},{"slug":"pad-web"}]`
+		res := packageJSONResult(body)
+		if res.IsError {
+			t.Fatalf("unexpected IsError")
+		}
+		// structuredContent must be a record (map), not an array.
+		m, ok := res.StructuredContent.(map[string]any)
+		if !ok {
+			t.Fatalf("structuredContent = %T, want map[string]any", res.StructuredContent)
+		}
+		items, ok := m["items"].([]any)
+		if !ok {
+			t.Fatalf("items missing or wrong type: %#v", m)
+		}
+		if len(items) != 2 {
+			t.Errorf("items length = %d, want 2", len(items))
+		}
+		// Text fallback preserves the ORIGINAL JSON (not the wrapped
+		// shape) so clients that don't parse structuredContent keep
+		// seeing the raw array. Important: anything pinning against
+		// the text body shouldn't break from this fix.
+		if textOf(res) != body {
+			t.Errorf("text fallback = %q, want original body %q", textOf(res), body)
+		}
+	})
+
+	t.Run("object passes through unchanged", func(t *testing.T) {
+		body := `{"summary":{"total_items":42}}`
+		res := packageJSONResult(body)
+		m, ok := res.StructuredContent.(map[string]any)
+		if !ok {
+			t.Fatalf("structuredContent = %T, want map[string]any", res.StructuredContent)
+		}
+		// Top-level keys preserved as-is.
+		if _, ok := m["summary"]; !ok {
+			t.Errorf("summary key lost; structuredContent=%#v", m)
+		}
+		if _, hasItemsWrap := m["items"]; hasItemsWrap {
+			t.Errorf("object body should NOT be wrapped under items; got %#v", m)
+		}
+	})
+
+	t.Run("non-JSON falls back to text", func(t *testing.T) {
+		body := "hello world"
+		res := packageJSONResult(body)
+		if res.StructuredContent != nil {
+			t.Errorf("non-JSON should not produce structuredContent; got %#v", res.StructuredContent)
+		}
+		if textOf(res) != body {
+			t.Errorf("text fallback = %q, want %q", textOf(res), body)
+		}
+	})
+
+	t.Run("empty array still wrapped", func(t *testing.T) {
+		body := `[]`
+		res := packageJSONResult(body)
+		m, ok := res.StructuredContent.(map[string]any)
+		if !ok {
+			t.Fatalf("empty array should still produce a wrapped record; got %T", res.StructuredContent)
+		}
+		items, _ := m["items"].([]any)
+		if len(items) != 0 {
+			t.Errorf("expected empty items; got %v", items)
+		}
+	})
+
+	t.Run("malformed JSON falls back to text", func(t *testing.T) {
+		body := `[invalid`
+		res := packageJSONResult(body)
+		if res.StructuredContent != nil {
+			t.Errorf("malformed JSON should fall back to text; got %#v", res.StructuredContent)
+		}
+		if textOf(res) != body {
+			t.Errorf("text fallback = %q, want %q", textOf(res), body)
+		}
+	})
+
+	t.Run("envelope round-trips through JSON", func(t *testing.T) {
+		// Belt-and-braces: marshal the wrapped envelope and confirm it
+		// produces a valid JSON object so Claude Desktop's JSON-Schema
+		// "expected: record" validator passes.
+		body := `[{"slug":"docapp"}]`
+		res := packageJSONResult(body)
+		out, err := json.Marshal(res.StructuredContent)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if !strings.HasPrefix(strings.TrimSpace(string(out)), "{") {
+			t.Errorf("structuredContent JSON must start with '{' to satisfy MCP record validator; got %s", out)
+		}
+	})
+}
+
+// containsPair returns true when args contains an adjacent (flag, value)
+// pair. Used to assert "--workspace docapp" appears in BuildCLIArgs's
+// output without depending on overall argument order.
+func containsPair(args []string, flag, value string) bool {
+	for i := 0; i < len(args)-1; i++ {
+		if args[i] == flag && args[i+1] == value {
+			return true
+		}
+	}
+	return false
+}
+
+// countAndValue returns the number of times flag appears followed by a
+// value, plus the LAST such value. Used to assert "exactly one
+// --workspace and it has the right value" without ordering assumptions.
+func countAndValue(args []string, flag string) (count int, lastValue string) {
+	for i := 0; i < len(args)-1; i++ {
+		if args[i] == flag {
+			count++
+			lastValue = args[i+1]
+		}
+	}
+	return count, lastValue
+}

--- a/internal/mcp/dispatch.go
+++ b/internal/mcp/dispatch.go
@@ -145,13 +145,37 @@ func (d *ExecDispatcher) Dispatch(ctx context.Context, cmdPath []string, cliArgs
 	// the text fallback. This is what `--format json` emits for most
 	// pad commands; clients that parse structured content (Claude
 	// Desktop, Cursor) get richer rendering.
-	if trimmed := strings.TrimSpace(out); strings.HasPrefix(trimmed, "{") || strings.HasPrefix(trimmed, "[") {
-		var parsed any
-		if json.Unmarshal([]byte(trimmed), &parsed) == nil {
-			return mcp.NewToolResultStructured(parsed, out), nil
-		}
+	return packageJSONResult(out), nil
+}
+
+// packageJSONResult converts a CLI stdout string into an MCP tool
+// result. JSON bodies surface as structuredContent; non-JSON falls
+// back to text. Top-level arrays are wrapped in `{items: [...]}` so
+// MCP host validators (Claude Desktop) accept the structured shape —
+// without the wrap they reject the tool call with "expected: record"
+// (BUG-985 bug 3).
+//
+// Shared between ExecDispatcher and HTTPHandlerDispatcher's
+// packageHTTPResponse so both transports produce the same wire
+// shape.
+func packageJSONResult(out string) *mcp.CallToolResult {
+	trimmed := strings.TrimSpace(out)
+	if !strings.HasPrefix(trimmed, "{") && !strings.HasPrefix(trimmed, "[") {
+		return mcp.NewToolResultText(out)
 	}
-	return mcp.NewToolResultText(out), nil
+	var parsed any
+	if err := json.Unmarshal([]byte(trimmed), &parsed); err != nil {
+		return mcp.NewToolResultText(out)
+	}
+	if arr, ok := parsed.([]any); ok {
+		// Wrap top-level arrays. MCP host validators (Claude Desktop)
+		// require `structuredContent` to be an object/record, not an
+		// array. The original JSON text is still returned as the text
+		// fallback so clients that don't parse structured content keep
+		// seeing the raw shape they used to.
+		return mcp.NewToolResultStructured(map[string]any{"items": arr}, out)
+	}
+	return mcp.NewToolResultStructured(parsed, out)
 }
 
 // ListWorkspaces satisfies WorkspaceLister so error helpers can
@@ -347,8 +371,23 @@ func BuildCLIArgs(
 		}
 	}
 
-	if !workspaceProvided && sessionWorkspace != "" {
-		out = append(out, "--workspace", sessionWorkspace)
+	// `--workspace` is a persistent root flag on cobra (registered
+	// globally via rootCmd, not on individual leaf commands), so it
+	// never appears in cmdInfo.Flags and the per-flag iteration above
+	// can't see it. Honor it here directly: prefer explicit
+	// input["workspace"], fall back to sessionWorkspace.
+	//
+	// Without this branch, BUG-985 reproduced: agents passing
+	// `workspace=docapp` explicitly got no_workspace errors because
+	// the flag was silently dropped — only the session-default
+	// fallback below ever ran, which itself only fires when no
+	// explicit value is set.
+	if !workspaceProvided {
+		if explicit, _ := input["workspace"].(string); explicit != "" {
+			out = append(out, "--workspace", explicit)
+		} else if sessionWorkspace != "" {
+			out = append(out, "--workspace", sessionWorkspace)
+		}
 	}
 	if !formatProvided {
 		out = append(out, "--format", "json")

--- a/internal/mcp/dispatch_http.go
+++ b/internal/mcp/dispatch_http.go
@@ -439,13 +439,10 @@ func packageHTTPResponse(ctx context.Context, cmdKey string, resp *http.Response
 		return classifyHTTPStatus(ctx, cmdKey, resp.StatusCode, bodyBytes, nil), nil
 	}
 
-	if trimmed := strings.TrimSpace(body); strings.HasPrefix(trimmed, "{") || strings.HasPrefix(trimmed, "[") {
-		var parsed any
-		if json.Unmarshal([]byte(trimmed), &parsed) == nil {
-			return mcp.NewToolResultStructured(parsed, body), nil
-		}
-	}
-	return mcp.NewToolResultText(body), nil
+	// Use the shared packager so both transports produce the same
+	// structured-vs-text shape. In particular, top-level arrays get
+	// wrapped in `{items: [...]}` for MCP host validators (BUG-985).
+	return packageJSONResult(body), nil
 }
 
 // mapItemCreate translates an `item create` MCP call into a POST to

--- a/internal/mcp/dispatch_http_links_test.go
+++ b/internal/mcp/dispatch_http_links_test.go
@@ -444,13 +444,30 @@ func TestDispatch_ItemDeps_ReturnsRawLinksArray(t *testing.T) {
 	if gotPath != "/api/v1/workspaces/docapp/items/TASK-5/links" {
 		t.Errorf("path = %q", gotPath)
 	}
-	links, ok := res.StructuredContent.([]any)
-	if !ok {
-		t.Fatalf("deps result not a JSON array: %#v", res.StructuredContent)
-	}
+	// Top-level arrays are wrapped as {items: [...]} for MCP host
+	// validators (BUG-985 fix). Unwrap to assert the underlying links.
+	links := unwrapItems(t, res.StructuredContent)
 	if len(links) != 1 {
 		t.Errorf("expected 1 link in deps result; got %d", len(links))
 	}
+}
+
+// unwrapItems extracts the array from a `{items: [...]}` envelope —
+// the post-BUG-985 shape ExecDispatcher and packageHTTPResponse use
+// for top-level array responses. Tests that previously asserted the
+// raw-array shape go through this helper to read the underlying
+// items without duplicating the cast logic.
+func unwrapItems(t *testing.T, sc any) []any {
+	t.Helper()
+	m, ok := sc.(map[string]any)
+	if !ok {
+		t.Fatalf("structuredContent is %T, want map[string]any (post-BUG-985 wrap shape)", sc)
+	}
+	items, ok := m["items"].([]any)
+	if !ok {
+		t.Fatalf("structuredContent has no 'items' array; got keys %v", mapKeys(m))
+	}
+	return items
 }
 
 func TestDispatch_ItemRelated_ReturnsGroupedShape(t *testing.T) {
@@ -853,10 +870,7 @@ func TestHTTPHandlerDispatcher_Integration_ItemLinkLifecycle(t *testing.T) {
 	if err != nil || depsRes.IsError {
 		t.Fatalf("deps: err=%v IsError=%v: %#v", err, depsRes != nil && depsRes.IsError, depsRes)
 	}
-	links, ok := depsRes.StructuredContent.([]any)
-	if !ok {
-		t.Fatalf("deps result not a JSON array: %#v", depsRes.StructuredContent)
-	}
+	links := unwrapItems(t, depsRes.StructuredContent)
 	if len(links) != 1 {
 		t.Fatalf("expected 1 link, got %d: %#v", len(links), links)
 	}
@@ -882,8 +896,8 @@ func TestHTTPHandlerDispatcher_Integration_ItemLinkLifecycle(t *testing.T) {
 	if err != nil || depsAfterRes.IsError {
 		t.Fatalf("deps after unblock: err=%v IsError=%v: %#v", err, depsAfterRes != nil && depsAfterRes.IsError, depsAfterRes)
 	}
-	if linksAfter, ok := depsAfterRes.StructuredContent.([]any); !ok || len(linksAfter) != 0 {
-		t.Errorf("expected empty links after unblock, got %#v", depsAfterRes.StructuredContent)
+	if linksAfter := unwrapItems(t, depsAfterRes.StructuredContent); len(linksAfter) != 0 {
+		t.Errorf("expected empty links after unblock, got %#v", linksAfter)
 	}
 
 	// `item supersedes new old` exercises the lineage path against

--- a/internal/mcp/dispatch_http_routes_extras_test.go
+++ b/internal/mcp/dispatch_http_routes_extras_test.go
@@ -557,9 +557,9 @@ func TestHTTPHandlerDispatcher_Integration_StarsRolesWebhooksWhoami(t *testing.T
 	if err != nil || wsListRes.IsError {
 		t.Fatalf("workspace list: err=%v IsError=%v: %#v", err, wsListRes != nil && wsListRes.IsError, wsListRes)
 	}
-	wsList, ok := wsListRes.StructuredContent.([]any)
-	if !ok || len(wsList) == 0 {
-		t.Fatalf("workspace list result not array or empty: %#v", wsListRes.StructuredContent)
+	wsList := unwrapItems(t, wsListRes.StructuredContent)
+	if len(wsList) == 0 {
+		t.Fatalf("workspace list result empty: %#v", wsListRes.StructuredContent)
 	}
 
 	// Create an item, then star it.
@@ -595,8 +595,8 @@ func TestHTTPHandlerDispatcher_Integration_StarsRolesWebhooksWhoami(t *testing.T
 	if err != nil || starredRes.IsError {
 		t.Fatalf("item starred: err=%v IsError=%v: %#v", err, starredRes != nil && starredRes.IsError, starredRes)
 	}
-	starred, ok := starredRes.StructuredContent.([]any)
-	if !ok || len(starred) != 1 {
+	starred := unwrapItems(t, starredRes.StructuredContent)
+	if len(starred) != 1 {
 		t.Fatalf("expected 1 starred item; got %#v", starredRes.StructuredContent)
 	}
 
@@ -637,7 +637,7 @@ func TestHTTPHandlerDispatcher_Integration_StarsRolesWebhooksWhoami(t *testing.T
 	if err != nil || listRes.IsError {
 		t.Fatalf("webhook list (empty): err=%v IsError=%v: %#v", err, listRes != nil && listRes.IsError, listRes)
 	}
-	if hooks, _ := listRes.StructuredContent.([]any); len(hooks) != 0 {
+	if hooks := unwrapItems(t, listRes.StructuredContent); len(hooks) != 0 {
 		t.Errorf("expected no webhooks initially; got %v", hooks)
 	}
 

--- a/internal/mcp/dispatch_http_routes_test.go
+++ b/internal/mcp/dispatch_http_routes_test.go
@@ -704,9 +704,9 @@ func TestHTTPHandlerDispatcher_Integration_ReadPaths(t *testing.T) {
 	if err != nil || listRes.IsError {
 		t.Fatalf("item list: err=%v IsError=%v %#v", err, listRes != nil && listRes.IsError, listRes)
 	}
-	listed, ok := listRes.StructuredContent.([]any)
-	if !ok || len(listed) == 0 {
-		t.Fatalf("item list returned unexpected shape: %#v", listRes.StructuredContent)
+	listed := unwrapItems(t, listRes.StructuredContent)
+	if len(listed) == 0 {
+		t.Fatalf("item list returned empty items array: %#v", listRes.StructuredContent)
 	}
 	first, _ := listed[0].(map[string]any)
 	ref, _ := first["ref"].(string)


### PR DESCRIPTION
## Summary
Hotfix for [BUG-985](pad item link). Claude Desktop's exploratory test of `v0.1.0-rc.2` surfaced three regressions in the v0.2 MCP surface:

1. **Bug 1** — explicit `workspace` parameter silently dropped on most tools (everything except `pad_meta`).
2. **Bug 3** — list responses produced top-level array `structuredContent`, which MCP host validators reject with `expected: record`.
3. **Bug 2** (only pad_project honors session) — turned out to be bug 1 manifesting inconsistently; resolved by the bug 1 fix.
4. **Bug 4** (`tool_surface_stable: true` inaccurate) — self-resolves once 1-3 land.

## Root causes
- `--workspace` is a persistent ROOT flag on cobra, so cmdhelp doesn't list it per-command. `BuildCLIArgs`'s per-flag iteration only saw flags from `cmdInfo.Flags`, so `input["workspace"]` was never read. Post-loop session fallback fired for some cases (`pad_project` because its flag list is empty), but explicit input always failed.
- `ExecDispatcher.Dispatch` + `packageHTTPResponse` passed parsed arrays directly to `NewToolResultStructured`. MCP host validators want a record (object).

## Fixes
- `BuildCLIArgs`: after the flag loop, honor `input["workspace"]` directly. Prefer explicit, fall back to `sessionWorkspace`, otherwise omit (CLI's CWD fallback applies).
- New shared helper `packageJSONResult(out)` wraps top-level JSON arrays in `{items: [...]}` for `structuredContent`. Text fallback keeps the original raw-array body for clients that don't parse structured content.
- ExecDispatcher + HTTPHandlerDispatcher both go through the helper so stdio + HTTP produce identical wire shapes.

## Live verification
From `/tmp` (no `.pad.toml`), all four reported failure modes now succeed:
\`\`\`
id=3 (pad_role list workspace=docapp)         isError=False sc_type=dict
id=4 (pad_workspace members workspace=docapp) isError=False sc_type=dict
id=2 (pad_item list workspace=docapp)         isError=False sc_type=dict
id=5 (pad_project dashboard workspace=docapp) isError=False sc_type=dict
\`\`\`

## Test plan
- [x] `make check` clean
- [x] New `bug985_test.go` covers BuildCLIArgs explicit/session/no-flag scenarios + packageJSONResult wrap behavior (10 subtests).
- [x] Existing integration tests updated to expect the new wrapped shape via shared `unwrapItems` helper.
- [x] Live repro from `/tmp` confirms all four originally-failing tools now succeed with both explicit and session workspace.

## Out of scope
- Bug report's "Smaller observations" (god-tool split for `pad_item`, missing `pad_workspace.create`, audit-log scope leak) — design discussions, separate items.