### PR TITLE
fix(mcp): BUG-987 round 2 — standup CLI ref + classifier polish

### DIFF
--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -3720,14 +3720,21 @@ func standupCmd() *cobra.Command {
 					Status   string `json:"status"`
 					ItemRef  string `json:"item_ref"`
 				} `json:"active_items"`
+				// BUG-987 bug 8: previously omitted ItemRef from
+				// Attention + SuggestedNext, leaving the JSON output's
+				// blockers / suggested_next entries with empty refs.
+				// The dashboard handler populates item_ref on both
+				// arrays already; we just weren't reading the field.
 				Attention []struct {
 					Type      string `json:"type"`
 					ItemSlug  string `json:"item_slug"`
+					ItemRef   string `json:"item_ref"`
 					ItemTitle string `json:"item_title"`
 					Reason    string `json:"reason"`
 				} `json:"attention"`
 				SuggestedNext []struct {
 					ItemSlug  string `json:"item_slug"`
+					ItemRef   string `json:"item_ref"`
 					ItemTitle string `json:"item_title"`
 					Reason    string `json:"reason"`
 				} `json:"suggested_next"`
@@ -3810,12 +3817,14 @@ func standupCmd() *cobra.Command {
 				}
 				for _, a := range dash.Attention {
 					output.Blockers = append(output.Blockers, standupItem{
+						Ref:    a.ItemRef,
 						Title:  a.ItemTitle,
 						Reason: a.Reason,
 					})
 				}
 				for _, s := range dash.SuggestedNext {
 					output.SuggestedNext = append(output.SuggestedNext, standupItem{
+						Ref:    s.ItemRef,
 						Title:  s.ItemTitle,
 						Reason: s.Reason,
 					})

--- a/internal/mcp/bug987_test.go
+++ b/internal/mcp/bug987_test.go
@@ -150,6 +150,89 @@ func TestValidationFailedFromBuildErr(t *testing.T) {
 	})
 }
 
+// TestClassifyExecError_CannotPhrasingClassifiesAsValidation pins
+// the round-2 fix: server-side rejections phrased "cannot link an
+// item to itself" / "cannot modify archived item" / etc. were
+// falling through to ErrServerError. They're validation-shaped and
+// should classify as ErrValidationFailed so agents can branch on
+// the right code (BUG-987 bug 11 round 2).
+func TestClassifyExecError_CannotPhrasingClassifiesAsValidation(t *testing.T) {
+	cases := []string{
+		"Error: cannot link an item to itself",
+		"Error: cannot modify archived item",
+		"cannot supersede an item that is already superseded",
+	}
+	for _, stderr := range cases {
+		t.Run(stderr, func(t *testing.T) {
+			res := classifyExecError(context.Background(),
+				[]string{"item", "block"},
+				errors.New("exit 1"),
+				stderr,
+				nil,
+			)
+			env := decodeEnvelope(t, res)
+			if env.Error.Code != ErrValidationFailed {
+				t.Errorf("Code = %q, want %q (stderr=%q)",
+					env.Error.Code, ErrValidationFailed, stderr)
+			}
+		})
+	}
+}
+
+// TestClassifyExecError_NoLegacyVerbPrefixInMessage pins the round-2
+// fix that drops the "pad <cmd> failed: " prefix from server_error
+// fallback messages. The prefix referenced OLD CLI verb names which
+// don't match the v0.2 MCP catalog action names agents see, and was
+// noise on top of the cmdPath that's already implicit from the
+// invoked tool (BUG-987 bug 11 round 2).
+func TestClassifyExecError_NoLegacyVerbPrefixInMessage(t *testing.T) {
+	// Use a stderr that won't hit any classifier matcher so we
+	// definitely fall through to the server_error fallback path.
+	stderr := "Error: completely novel runtime issue"
+	res := classifyExecError(context.Background(),
+		[]string{"item", "block"},
+		errors.New("exit 1"),
+		stderr,
+		nil,
+	)
+	env := decodeEnvelope(t, res)
+	if env.Error.Code != ErrServerError {
+		t.Fatalf("Code = %q, want %q", env.Error.Code, ErrServerError)
+	}
+	if strings.Contains(env.Error.Message, "pad item block failed") {
+		t.Errorf("server_error message should not carry legacy verb prefix; got %q",
+			env.Error.Message)
+	}
+	if strings.Contains(env.Error.Message, "Error:") {
+		t.Errorf("server_error message should strip leading Error: prefix; got %q",
+			env.Error.Message)
+	}
+	if !strings.Contains(env.Error.Message, "completely novel runtime issue") {
+		t.Errorf("server_error message dropped the underlying detail; got %q",
+			env.Error.Message)
+	}
+}
+
+// TestStripErrorPrefix locks the prefix-strip rules so they don't
+// accidentally over- or under-trim.
+func TestStripErrorPrefix(t *testing.T) {
+	cases := map[string]string{
+		"Error: bad input":          "bad input",
+		"  Error:  spaced  input  ": "spaced  input",
+		"error: lowercase":          "lowercase",
+		"ERROR: shouty":             "shouty",
+		"no prefix":                 "no prefix",
+		"":                          "",
+	}
+	for in, want := range cases {
+		t.Run(in, func(t *testing.T) {
+			if got := stripErrorPrefix(in); got != want {
+				t.Errorf("got %q, want %q", got, want)
+			}
+		})
+	}
+}
+
 // TestEnvDispatch_ValidationErrorIsStructured drives env.Dispatch
 // with a missing-arg input and confirms the resulting error result is
 // a structured validation_failed envelope, not a bare-text result.

--- a/internal/mcp/errors.go
+++ b/internal/mcp/errors.go
@@ -274,31 +274,34 @@ func classifyExecError(ctx context.Context, cmdPath []string, runErr error, stde
 		return NewErrorResult(ErrorPayload{
 			Code:    ErrAuthRequired,
 			Message: "Authentication required. Run `pad auth login` to sign in.",
-			Hint:    stderr,
+			Hint:    stripErrorPrefix(stderr),
 		})
 	case execStderrMatchesPermissionDenied(lower):
 		return NewErrorResult(ErrorPayload{
 			Code:    ErrPermissionDenied,
 			Message: "Permission denied for this operation.",
-			Hint:    stderr,
+			Hint:    stripErrorPrefix(stderr),
 		})
 	case execStderrMatchesItemNotFound(lower):
 		return NewErrorResult(ErrorPayload{
 			Code:    ErrItemNotFound,
 			Message: "Item not found.",
-			Hint:    stderr,
+			Hint:    stripErrorPrefix(stderr),
 		})
 	case execStderrMatchesValidation(lower):
 		return NewErrorResult(ErrorPayload{
 			Code:    ErrValidationFailed,
 			Message: "Validation failed.",
-			Hint:    stderr,
+			Hint:    stripErrorPrefix(stderr),
 		})
 	}
 
-	// Fallback: unstructured server error. Preserve the original
-	// "pad <cmd> failed: <stderr>" shape so any agent that special-
-	// cased the old text still has something to read.
+	// Fallback: unstructured server error. Surface the cleaned stderr
+	// directly without the legacy "pad <cmd> failed:" prefix — that
+	// prefix referenced OLD CLI verb names (e.g. `pad item block`)
+	// that don't match the v0.2 catalog action names agents see, and
+	// the cmdPath is already implicit from which tool was called
+	// (BUG-987 bug 11 round 2).
 	msg := stderr
 	if msg == "" && runErr != nil {
 		msg = runErr.Error()
@@ -306,11 +309,24 @@ func classifyExecError(ctx context.Context, cmdPath []string, runErr error, stde
 	if msg == "" {
 		msg = "unknown error"
 	}
-	cmd := strings.Join(cmdPath, " ")
 	return NewErrorResult(ErrorPayload{
 		Code:    ErrServerError,
-		Message: fmt.Sprintf("pad %s failed: %s", cmd, msg),
+		Message: stripErrorPrefix(msg),
 	})
+}
+
+// stripErrorPrefix removes the leading "Error:" prefix that the CLI
+// (and many of its dependencies) emit on stderr lines. Cosmetic — the
+// envelope's error.code already carries the "this is an error" signal
+// so the prefix is redundant noise.
+func stripErrorPrefix(msg string) string {
+	msg = strings.TrimSpace(msg)
+	for _, prefix := range []string{"Error: ", "error: ", "ERROR: "} {
+		if strings.HasPrefix(msg, prefix) {
+			return strings.TrimSpace(msg[len(prefix):])
+		}
+	}
+	return msg
 }
 
 // Stderr-pattern matchers. Compiled at init for cost-free
@@ -323,7 +339,12 @@ var (
 	reAuthRequired      = regexp.MustCompile(`(not authenticated|authentication required|please log in|run pad auth login|invalid token|expired token)`)
 	rePermissionDenied  = regexp.MustCompile(`(permission denied|forbidden|insufficient (permissions|role))`)
 	reItemNotFound      = regexp.MustCompile(`(item.*not found|no such item|unknown ref)`)
-	reValidationFailed  = regexp.MustCompile(`(invalid|missing required|must be one of|validation)`)
+	// reValidationFailed catches generic validation phrasings. Includes
+	// "cannot ..." (e.g. "cannot link an item to itself", "cannot
+	// modify archived item") which are validation-shaped server
+	// rejections previously falling through to server_error
+	// (BUG-987 bug 11 round 2).
+	reValidationFailed = regexp.MustCompile(`(invalid|missing required|must be one of|validation|cannot )`)
 	// Only match QUOTED slugs to avoid capturing stop-words like "not"
 	// in generic "Workspace not found" / "workspace not visible"
 	// messages. Quoted forms come from CLI stderr ("workspace 'foo'


### PR DESCRIPTION
## Summary
Round 2 follow-up to PR #361 ([rc.4](https://github.com/PerpetualSoftware/pad/releases/tag/v0.1.0-rc.4)). Claude Desktop's re-review surfaced two fixes that didn't fully land.

## Fixes

### Bug 8 — round 1 went to the wrong layer
My `HTTPHandlerDispatcher` fix populated `ref` on standup blockers, but Claude Desktop's path is `ExecDispatcher` → CLI subprocess → `standupCmd`, which has its OWN JSON composition struct that didn't even define `ItemRef` as a parseable field.

Fix: extend `cmd/pad/main.go`'s `standupCmd` Attention + SuggestedNext structs to read `item_ref` from the dashboard, propagate to the emitted standup items.

### Bug 11 round 2 — two leaks remained
1. **`pad <verb> failed:` prefix** on `server_error` fallback messages. The verb name is the OLD CLI verb (e.g. `pad item block`) that doesn't match the v0.2 catalog action names agents see. Drop it.
2. **`cannot ...` rejections classified as `server_error`** instead of `validation_failed`. Self-link, archived-modify, etc. are validation-shaped rejections. Extended the validation regex.

Plus a new `stripErrorPrefix` helper that trims leading `Error:` / `error:` / `ERROR:` from envelope text so it isn't redundant with `error.code`.

## Live verification
\`\`\`
=== Bug 8 standup blockers (post-fix) ===
  ref='TASK-993' title='Probe item: ...'
  ref='TASK-951' title='OAuth 2.1 server with DCR + PKCE...'
  ref='TASK-953' title='Token scopes (user + workspace allow-list...'

=== Bug 11 round 2: self-link ===
{"error":{"code":"validation_failed","message":"Validation failed.","hint":"cannot link an item to itself"}}
\`\`\`

## Bugs 13, 14 status
My round-1 fixes verified working locally on rc.4 (fresh Task → `convention=None`; dashboard `by_role` shows `"Unassigned"`/`"unassigned"`). The reviewer's stale results almost certainly reflect a pad server process that wasn't restarted with the rc.4 binary swap. **Recommend `pad server stop && pad server start` (or equivalent) to pick up the new binary** when re-testing.

## Test plan
- [x] `make check` clean
- [x] New tests cover `cannot ...` classification, prefix-strip, and round-trip behavior.
- [x] Live verification against fresh `pad mcp serve`.