### PR TITLE
fix(mcp): parse fields/tags at MCP boundary so agents see native shapes (BUG-991 path A)

### DIFF
--- a/internal/mcp/bug991_test.go
+++ b/internal/mcp/bug991_test.go
@@ -1,0 +1,238 @@
+package mcp
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+// TestNormalizeStringEncodedJSONFields_SingleItem covers the most
+// common shape — a single-item response with stringified `fields`
+// and `tags`. After the BUG-991 path-A normalization at the MCP
+// boundary, both come back as native types.
+func TestNormalizeStringEncodedJSONFields_SingleItem(t *testing.T) {
+	in := map[string]any{
+		"ref":    "TASK-5",
+		"title":  "Test",
+		"fields": `{"status":"open","priority":"high"}`,
+		"tags":   `["frontend","auth"]`,
+	}
+	got := normalizeStringEncodedJSONFields(in)
+	gotMap, ok := got.(map[string]any)
+	if !ok {
+		t.Fatalf("got %T, want map", got)
+	}
+
+	fields, ok := gotMap["fields"].(map[string]any)
+	if !ok {
+		t.Fatalf("fields = %T, want map[string]any", gotMap["fields"])
+	}
+	if fields["status"] != "open" || fields["priority"] != "high" {
+		t.Errorf("fields content lost: %v", fields)
+	}
+
+	tags, ok := gotMap["tags"].([]any)
+	if !ok {
+		t.Fatalf("tags = %T, want []any", gotMap["tags"])
+	}
+	if len(tags) != 2 || tags[0] != "frontend" || tags[1] != "auth" {
+		t.Errorf("tags content lost: %v", tags)
+	}
+}
+
+// TestNormalizeStringEncodedJSONFields_ItemArray covers list-style
+// responses where every entry has stringified fields/tags. Each
+// item gets normalized independently.
+func TestNormalizeStringEncodedJSONFields_ItemArray(t *testing.T) {
+	in := []any{
+		map[string]any{
+			"ref":    "TASK-1",
+			"fields": `{"status":"open"}`,
+			"tags":   `[]`,
+		},
+		map[string]any{
+			"ref":    "TASK-2",
+			"fields": `{"status":"done","priority":"low"}`,
+			"tags":   `["bug"]`,
+		},
+	}
+	got := normalizeStringEncodedJSONFields(in).([]any)
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2", len(got))
+	}
+	first := got[0].(map[string]any)
+	second := got[1].(map[string]any)
+
+	if _, ok := first["fields"].(map[string]any); !ok {
+		t.Errorf("first.fields = %T, want map", first["fields"])
+	}
+	if _, ok := first["tags"].([]any); !ok {
+		t.Errorf("first.tags = %T, want []any", first["tags"])
+	}
+	if _, ok := second["fields"].(map[string]any); !ok {
+		t.Errorf("second.fields = %T, want map", second["fields"])
+	}
+}
+
+// TestNormalizeStringEncodedJSONFields_NestedItem covers shapes with
+// items embedded inside a wrapping envelope (e.g. dashboard's
+// active_items, recent_activity, etc.). Each nested item still gets
+// its fields/tags normalized.
+func TestNormalizeStringEncodedJSONFields_NestedItem(t *testing.T) {
+	in := map[string]any{
+		"summary": map[string]any{"total": 5},
+		"active_items": []any{
+			map[string]any{
+				"ref":    "TASK-1",
+				"fields": `{"status":"in-progress"}`,
+			},
+		},
+		"recent_activity": []any{
+			map[string]any{
+				"action": "updated",
+				"item": map[string]any{
+					"ref":    "TASK-2",
+					"fields": `{"status":"done"}`,
+					"tags":   `["release"]`,
+				},
+			},
+		},
+	}
+	got := normalizeStringEncodedJSONFields(in).(map[string]any)
+	active := got["active_items"].([]any)
+	first := active[0].(map[string]any)
+	if _, ok := first["fields"].(map[string]any); !ok {
+		t.Errorf("active_items[0].fields = %T, want map", first["fields"])
+	}
+	activity := got["recent_activity"].([]any)
+	embeddedItem := activity[0].(map[string]any)["item"].(map[string]any)
+	if _, ok := embeddedItem["fields"].(map[string]any); !ok {
+		t.Errorf("recent_activity[0].item.fields = %T, want map", embeddedItem["fields"])
+	}
+	if _, ok := embeddedItem["tags"].([]any); !ok {
+		t.Errorf("recent_activity[0].item.tags = %T, want []any", embeddedItem["tags"])
+	}
+}
+
+// TestNormalizeStringEncodedJSONFields_LeavesUnrelatedStringsAlone is
+// the safety net: free-form `tags` / `fields` keys outside item
+// contexts (e.g. `metadata` blobs) shouldn't be touched if their
+// strings don't look like JSON. Conservative: only objects with
+// leading `{` or `[` are candidates for substitution.
+func TestNormalizeStringEncodedJSONFields_LeavesUnrelatedStringsAlone(t *testing.T) {
+	in := map[string]any{
+		"ref":    "TASK-1",
+		"fields": `not actually json`,
+		"tags":   ``,
+		"deeply": map[string]any{
+			"nested": map[string]any{
+				"unrelated": "value",
+			},
+		},
+	}
+	got := normalizeStringEncodedJSONFields(in).(map[string]any)
+	if got["fields"] != "not actually json" {
+		t.Errorf("non-JSON fields modified: %v", got["fields"])
+	}
+	if got["tags"] != "" {
+		t.Errorf("empty tags modified: %v", got["tags"])
+	}
+	// Sanity: nested unrelated values stay where they are.
+	deeply, _ := got["deeply"].(map[string]any)
+	nested, _ := deeply["nested"].(map[string]any)
+	if nested["unrelated"] != "value" {
+		t.Errorf("nested traversal mutated unrelated leaves: %v", nested)
+	}
+}
+
+// TestNormalizeStringEncodedJSONFields_PrimitivesPassThrough confirms
+// the walk doesn't bomb on primitive values at any depth. Any non-
+// (map|slice) input is returned unchanged.
+func TestNormalizeStringEncodedJSONFields_PrimitivesPassThrough(t *testing.T) {
+	cases := []any{
+		nil,
+		"hello",
+		float64(42),
+		true,
+		[]any{},
+		map[string]any{},
+	}
+	for _, in := range cases {
+		got := normalizeStringEncodedJSONFields(in)
+		if !reflect.DeepEqual(got, in) {
+			t.Errorf("got %v, want %v (input %v)", got, in, in)
+		}
+	}
+}
+
+// TestPackageJSONResult_NormalizesItemFields end-to-end test: a CLI
+// stdout body containing a single item with stringified fields/tags
+// produces structuredContent where both are native shapes. The text
+// fallback is unchanged (raw CLI body) so older clients that read
+// content[0].text keep seeing the same shape.
+func TestPackageJSONResult_NormalizesItemFields(t *testing.T) {
+	body := `{"ref":"TASK-5","title":"x","fields":"{\"status\":\"open\",\"priority\":\"high\"}","tags":"[\"frontend\"]"}`
+	res := packageJSONResult(body)
+	if res.IsError {
+		t.Fatalf("unexpected IsError")
+	}
+	sc := res.StructuredContent.(map[string]any)
+	fields, ok := sc["fields"].(map[string]any)
+	if !ok {
+		t.Fatalf("structuredContent.fields = %T, want map[string]any", sc["fields"])
+	}
+	if fields["status"] != "open" || fields["priority"] != "high" {
+		t.Errorf("fields content wrong: %v", fields)
+	}
+	tags, ok := sc["tags"].([]any)
+	if !ok || len(tags) != 1 || tags[0] != "frontend" {
+		t.Errorf("structuredContent.tags wrong: %v", sc["tags"])
+	}
+	// Text fallback preserves the original CLI body verbatim. Older
+	// clients that don't parse structuredContent should NOT see a
+	// breaking shape change.
+	if got := textOf(res); got != body {
+		t.Errorf("text fallback diverged:\n got %q\nwant %q", got, body)
+	}
+}
+
+// TestPackageJSONResult_ArrayItemsNormalized confirms list-style
+// responses are normalized too, in combination with the BUG-985
+// {items: [...]} array wrap.
+func TestPackageJSONResult_ArrayItemsNormalized(t *testing.T) {
+	body := `[{"ref":"TASK-1","fields":"{\"status\":\"open\"}"},{"ref":"TASK-2","fields":"{\"status\":\"done\"}"}]`
+	res := packageJSONResult(body)
+	wrapped := res.StructuredContent.(map[string]any)
+	items := wrapped["items"].([]any)
+	if len(items) != 2 {
+		t.Fatalf("expected 2 items; got %d", len(items))
+	}
+	for i, it := range items {
+		m := it.(map[string]any)
+		if _, ok := m["fields"].(map[string]any); !ok {
+			t.Errorf("items[%d].fields = %T, want map", i, m["fields"])
+		}
+	}
+}
+
+// TestPackageJSONResult_MalformedFieldsStaysString covers the safety
+// net at the end-to-end level: if `fields` carries an invalid JSON
+// string, leave it as a string rather than dropping it. Agents that
+// see a string here can still surface the underlying value.
+func TestPackageJSONResult_MalformedFieldsStaysString(t *testing.T) {
+	body := `{"ref":"TASK-X","fields":"{not actually json"}`
+	res := packageJSONResult(body)
+	sc := res.StructuredContent.(map[string]any)
+	fields, ok := sc["fields"].(string)
+	if !ok {
+		t.Fatalf("malformed fields should stay string; got %T", sc["fields"])
+	}
+	if fields != "{not actually json" {
+		t.Errorf("malformed fields content lost: %q", fields)
+	}
+}
+
+// _ silences a potential unused-import warning on encoding/json if a
+// later refactor stops using it directly. Keeps the file resilient
+// without affecting the test inventory.
+var _ = json.Marshal

--- a/internal/mcp/dispatch.go
+++ b/internal/mcp/dispatch.go
@@ -155,6 +155,11 @@ func (d *ExecDispatcher) Dispatch(ctx context.Context, cmdPath []string, cliArgs
 // without the wrap they reject the tool call with "expected: record"
 // (BUG-985 bug 3).
 //
+// Item-shaped objects also get their `fields` and `tags` properties
+// parsed from JSON-encoded strings into native objects/arrays
+// (BUG-991, path A). Server / web / CLI keep their existing
+// stringified contract; the MCP boundary normalizes for agents.
+//
 // Shared between ExecDispatcher and HTTPHandlerDispatcher's
 // packageHTTPResponse so both transports produce the same wire
 // shape.
@@ -167,6 +172,7 @@ func packageJSONResult(out string) *mcp.CallToolResult {
 	if err := json.Unmarshal([]byte(trimmed), &parsed); err != nil {
 		return mcp.NewToolResultText(out)
 	}
+	parsed = normalizeStringEncodedJSONFields(parsed)
 	if arr, ok := parsed.([]any); ok {
 		// Wrap top-level arrays. MCP host validators (Claude Desktop)
 		// require `structuredContent` to be an object/record, not an
@@ -176,6 +182,72 @@ func packageJSONResult(out string) *mcp.CallToolResult {
 		return mcp.NewToolResultStructured(map[string]any{"items": arr}, out)
 	}
 	return mcp.NewToolResultStructured(parsed, out)
+}
+
+// normalizeStringEncodedJSONFields recursively walks a parsed JSON
+// value, finds string-typed `fields` and `tags` properties, parses
+// them as embedded JSON, and substitutes the native object/array.
+//
+// Why: the server-side `models.Item` carries `Fields` and `Tags` as
+// JSON-string columns (a SQLite-era choice that propagated through
+// the API contract). For agents going through MCP this means a
+// double-encode every read — the agent has to JSON.parse the field
+// before doing anything useful. Normalizing at the MCP boundary
+// gives agents clean JSON without coordinating a server / web / CLI
+// migration (which is the bigger BUG-991 path B).
+//
+// The walk handles every common item shape:
+//   - Single-item responses (top-level item object).
+//   - Item arrays (item list, dashboard.active_items, comment lists).
+//   - Nested items (dashboard.recent_activity[].item, parent_*).
+//
+// Strings that don't parse as JSON pass through unchanged — covers
+// hand-written field values that happen to share a key name.
+func normalizeStringEncodedJSONFields(v any) any {
+	switch x := v.(type) {
+	case map[string]any:
+		for k, val := range x {
+			if s, ok := val.(string); ok && (k == "fields" || k == "tags") {
+				if parsed, ok := tryParseEmbeddedJSON(s); ok {
+					x[k] = parsed
+					continue
+				}
+			}
+			x[k] = normalizeStringEncodedJSONFields(val)
+		}
+		return x
+	case []any:
+		for i, val := range x {
+			x[i] = normalizeStringEncodedJSONFields(val)
+		}
+		return x
+	default:
+		return v
+	}
+}
+
+// tryParseEmbeddedJSON attempts to parse s as JSON, returning the
+// native value when it succeeds. Returns (nil, false) when the
+// string is empty, doesn't start with `{` or `[`, or fails to
+// unmarshal — leaves the caller free to keep the original string.
+//
+// We require the leading-brace check before attempting Unmarshal so
+// hand-written values that happen to be quoted-but-numeric or
+// quoted-but-bare strings don't get spuriously coerced into Go
+// values agents weren't expecting.
+func tryParseEmbeddedJSON(s string) (any, bool) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil, false
+	}
+	if !strings.HasPrefix(s, "{") && !strings.HasPrefix(s, "[") {
+		return nil, false
+	}
+	var out any
+	if err := json.Unmarshal([]byte(s), &out); err != nil {
+		return nil, false
+	}
+	return out, true
 }
 
 // ListWorkspaces satisfies WorkspaceLister so error helpers can

--- a/internal/mcp/dispatch_http_advanced_test.go
+++ b/internal/mcp/dispatch_http_advanced_test.go
@@ -465,11 +465,10 @@ func TestHTTPHandlerDispatcher_Integration_ItemUpdateAndAssignResolution(t *test
 	if !ok {
 		t.Fatalf("update result not structured: %#v", updateRes.StructuredContent)
 	}
-	fields, _ := updated["fields"].(string)
-	var fieldMap map[string]any
-	if err := json.Unmarshal([]byte(fields), &fieldMap); err != nil {
-		t.Fatalf("decode fields: %v\n%s", err, fields)
-	}
+	// BUG-991 path A: `fields` is now parsed at the MCP boundary so
+	// it arrives as a native map. Pre-fix we had to JSON.Unmarshal
+	// the string ourselves here.
+	fieldMap := itemFieldsAsMap(t, updated)
 	want := map[string]string{
 		"status":   "in-progress",
 		"priority": "high",  // pre-existing, must survive RMW
@@ -480,6 +479,24 @@ func TestHTTPHandlerDispatcher_Integration_ItemUpdateAndAssignResolution(t *test
 			t.Errorf("fields[%q] = %q, want %q (full fields: %v)", k, got, v, fieldMap)
 		}
 	}
+}
+
+// itemFieldsAsMap reads the parsed `fields` value off an item-shape
+// structuredContent map. After BUG-991 path A's normalization the
+// MCP boundary returns `fields` as a native map[string]any; tests
+// that previously decoded a string fall through this helper for
+// readability + a clear error when the shape regresses.
+func itemFieldsAsMap(t *testing.T, item map[string]any) map[string]any {
+	t.Helper()
+	v, ok := item["fields"]
+	if !ok {
+		t.Fatalf("item missing `fields`: %#v", item)
+	}
+	m, ok := v.(map[string]any)
+	if !ok {
+		t.Fatalf("item.fields is %T, want map[string]any (BUG-991 normalization regressed?)", v)
+	}
+	return m
 }
 
 func TestDispatchItemUpdate_LiftsAgentRoleIDFromFieldKVPToColumn(t *testing.T) {

--- a/internal/mcp/dispatch_http_project_test.go
+++ b/internal/mcp/dispatch_http_project_test.go
@@ -832,9 +832,9 @@ func TestHTTPHandlerDispatcher_Integration_Slice3(t *testing.T) {
 		t.Fatalf("item show: %#v", showRes)
 	}
 	shown, _ := showRes.StructuredContent.(map[string]any)
-	fieldsStr, _ := shown["fields"].(string)
-	var fields map[string]any
-	_ = json.Unmarshal([]byte(fieldsStr), &fields)
+	// BUG-991 path A: fields is now parsed at the MCP boundary; no
+	// JSON.Unmarshal step needed.
+	fields := itemFieldsAsMap(t, shown)
 	if fields["priority"] != "high" {
 		t.Errorf("priority should survive bulk-update; got %v", fields["priority"])
 	}


### PR DESCRIPTION
## Summary
Path A of BUG-991: normalize `fields` and `tags` at the MCP boundary so agents see native objects/arrays instead of JSON-encoded strings. Server / web / CLI keep their existing stringified contract; only the MCP wire changes.

## Before / after
\`\`\`jsonc
// Before
{ "ref": "TASK-5", "fields": "{\"status\":\"open\",\"priority\":\"high\"}", "tags": "[]" }

// After (structuredContent)
{ "ref": "TASK-5", "fields": {"status":"open","priority":"high"}, "tags": [] }
\`\`\`

## How
- New \`normalizeStringEncodedJSONFields\` walks parsed JSON in \`packageJSONResult\`. Conservative: only strings starting with \`{\` or \`[\` that successfully parse get substituted.
- Handles single items, item arrays (item list, dashboard.active_items), and nested items (dashboard.recent_activity[].item).
- Text fallback (\`content[0].text\`) preserves the original CLI body verbatim — older clients that read text aren't affected. Same back-compat pattern as BUG-985's \`{items: [...]}\` wrap.

## Why path A
Path B (full migration of \`models.Item.Fields\` from string to \`map[string]any\` across server / store / web TypeScript / CLI helpers) is the architecturally correct fix but Plan-sized. Per the user direction in the BUG-991 fork discussion, A is the cheap win that addresses the agent-facing complaint without coordinating a full-stack migration. B remains tracked in BUG-991's notes if it ever makes sense to do later.

## Test plan
- [x] \`make check\` clean
- [x] 8 new test cases in \`bug991_test.go\` covering walker behavior + end-to-end
- [x] Existing tests that decoded \`fields\` strings updated to use a small \`itemFieldsAsMap\` helper that reads the parsed map directly

## Context
Implements BUG-991 (deferred from BUG-987 bug 9).