### PR TITLE
fix(mcp): dedup implementation_notes / decision_log from fields blob (BUG-992)

### DIFF
--- a/internal/mcp/bug992_test.go
+++ b/internal/mcp/bug992_test.go
@@ -1,0 +1,131 @@
+package mcp
+
+import (
+	"testing"
+)
+
+// TestStripDuplicatedFieldsKeys covers the dedup helper behavior in
+// isolation. Both implementation_notes and decision_log get dropped;
+// other keys pass through untouched.
+func TestStripDuplicatedFieldsKeys(t *testing.T) {
+	t.Run("strips both", func(t *testing.T) {
+		in := map[string]any{
+			"status":               "open",
+			"priority":             "high",
+			"implementation_notes": []any{map[string]any{"id": "n1"}},
+			"decision_log":         []any{map[string]any{"id": "d1"}},
+		}
+		out := stripDuplicatedFieldsKeys(in).(map[string]any)
+		if _, has := out["implementation_notes"]; has {
+			t.Errorf("implementation_notes not stripped: %v", out)
+		}
+		if _, has := out["decision_log"]; has {
+			t.Errorf("decision_log not stripped: %v", out)
+		}
+		if out["status"] != "open" || out["priority"] != "high" {
+			t.Errorf("non-duplicate keys lost: %v", out)
+		}
+	})
+
+	t.Run("no-op when keys absent", func(t *testing.T) {
+		in := map[string]any{"status": "open"}
+		out := stripDuplicatedFieldsKeys(in).(map[string]any)
+		if out["status"] != "open" {
+			t.Errorf("status lost: %v", out)
+		}
+		if len(out) != 1 {
+			t.Errorf("unexpected keys present: %v", out)
+		}
+	})
+
+	t.Run("non-object input passes through", func(t *testing.T) {
+		// Defensive: if a hand-written fields value is somehow a
+		// primitive or array, stripDuplicatedFieldsKeys must not
+		// panic.
+		cases := []any{
+			nil,
+			"a string",
+			float64(42),
+			[]any{1, 2, 3},
+		}
+		for _, in := range cases {
+			out := stripDuplicatedFieldsKeys(in)
+			// Just confirm no crash and the value is returned (we
+			// don't compare DeepEqual because nil passes through as nil
+			// and we want to avoid the type-assertion noise).
+			_ = out
+		}
+	})
+}
+
+// TestPackageJSONResult_StripsDuplicatedNotesAndLog is the end-to-end
+// regression: a CLI body that carries top-level
+// implementation_notes / decision_log arrays AND embeds them inside
+// the fields blob — exactly the duplication BUG-987 bug 10 reported —
+// produces a normalized structuredContent where the embeds are gone
+// and the top-level arrays remain.
+func TestPackageJSONResult_StripsDuplicatedNotesAndLog(t *testing.T) {
+	body := `{
+		"ref": "TASK-7",
+		"implementation_notes": [{"id":"n1","summary":"Outer note"}],
+		"decision_log": [{"id":"d1","decision":"Outer decision"}],
+		"fields": "{\"status\":\"open\",\"implementation_notes\":[{\"id\":\"n1\"}],\"decision_log\":[{\"id\":\"d1\"}]}"
+	}`
+	res := packageJSONResult(body)
+	sc := res.StructuredContent.(map[string]any)
+
+	// Top-level arrays preserved verbatim.
+	notes, ok := sc["implementation_notes"].([]any)
+	if !ok || len(notes) != 1 {
+		t.Errorf("top-level implementation_notes lost or wrong shape: %v", sc["implementation_notes"])
+	}
+	log, ok := sc["decision_log"].([]any)
+	if !ok || len(log) != 1 {
+		t.Errorf("top-level decision_log lost or wrong shape: %v", sc["decision_log"])
+	}
+
+	// fields parsed (BUG-991) AND the duplicated entries removed.
+	fields, ok := sc["fields"].(map[string]any)
+	if !ok {
+		t.Fatalf("fields = %T, want map[string]any", sc["fields"])
+	}
+	if fields["status"] != "open" {
+		t.Errorf("fields.status lost: %v", fields)
+	}
+	if _, has := fields["implementation_notes"]; has {
+		t.Errorf("fields.implementation_notes not stripped: %v", fields)
+	}
+	if _, has := fields["decision_log"]; has {
+		t.Errorf("fields.decision_log not stripped: %v", fields)
+	}
+}
+
+// TestPackageJSONResult_StripsAcrossArrayItems confirms the dedup
+// happens for every entry in a list-style response, not just the
+// top-level item.
+func TestPackageJSONResult_StripsAcrossArrayItems(t *testing.T) {
+	body := `[
+		{"ref":"TASK-1","fields":"{\"status\":\"open\",\"implementation_notes\":[{\"id\":\"n1\"}]}"},
+		{"ref":"TASK-2","fields":"{\"status\":\"done\",\"decision_log\":[{\"id\":\"d1\"}]}"}
+	]`
+	res := packageJSONResult(body)
+	wrapped := res.StructuredContent.(map[string]any)
+	items := wrapped["items"].([]any)
+	if len(items) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(items))
+	}
+	for i, it := range items {
+		m := it.(map[string]any)
+		fields, ok := m["fields"].(map[string]any)
+		if !ok {
+			t.Errorf("items[%d].fields = %T, want map", i, m["fields"])
+			continue
+		}
+		if _, has := fields["implementation_notes"]; has {
+			t.Errorf("items[%d].fields.implementation_notes not stripped", i)
+		}
+		if _, has := fields["decision_log"]; has {
+			t.Errorf("items[%d].fields.decision_log not stripped", i)
+		}
+	}
+}

--- a/internal/mcp/dispatch.go
+++ b/internal/mcp/dispatch.go
@@ -187,6 +187,9 @@ func packageJSONResult(out string) *mcp.CallToolResult {
 // normalizeStringEncodedJSONFields recursively walks a parsed JSON
 // value, finds string-typed `fields` and `tags` properties, parses
 // them as embedded JSON, and substitutes the native object/array.
+// Additionally drops `implementation_notes` and `decision_log` from
+// the parsed fields object — those entries are duplicates of the
+// top-level arrays the server hydrates onto each item (BUG-992).
 //
 // Why: the server-side `models.Item` carries `Fields` and `Tags` as
 // JSON-string columns (a SQLite-era choice that propagated through
@@ -209,6 +212,9 @@ func normalizeStringEncodedJSONFields(v any) any {
 		for k, val := range x {
 			if s, ok := val.(string); ok && (k == "fields" || k == "tags") {
 				if parsed, ok := tryParseEmbeddedJSON(s); ok {
+					if k == "fields" {
+						parsed = stripDuplicatedFieldsKeys(parsed)
+					}
 					x[k] = parsed
 					continue
 				}
@@ -224,6 +230,33 @@ func normalizeStringEncodedJSONFields(v any) any {
 	default:
 		return v
 	}
+}
+
+// stripDuplicatedFieldsKeys removes implementation_notes and
+// decision_log from a parsed fields object. The server hydrates both
+// onto items as top-level arrays (item.ImplementationNotes,
+// item.DecisionLog) by extracting them from the fields blob — so
+// every response that carries the fields blob ALSO carries the
+// arrays as top-level. Surfacing them inside fields too is a
+// duplicate that bloats payloads and forces agents to dedupe.
+//
+// Per BUG-992 the top-level arrays are the canonical shape; the
+// fields embed is a write-side artifact of how AppendImplementation*
+// stores data. Stripping at the MCP boundary keeps the wire shape
+// clean without coordinating a write-side migration.
+//
+// Returns the input unchanged when it isn't an object — defensive
+// against hand-written fields values that aren't shaped as objects
+// (rare but plausible if someone stuffs a primitive into the column).
+func stripDuplicatedFieldsKeys(parsed any) any {
+	m, ok := parsed.(map[string]any)
+	if !ok {
+		return parsed
+	}
+	for _, dup := range []string{"implementation_notes", "decision_log"} {
+		delete(m, dup)
+	}
+	return m
 }
 
 // tryParseEmbeddedJSON attempts to parse s as JSON, returning the


### PR DESCRIPTION
## Summary
Item responses carried implementation_notes / decision_log in TWO places: as top-level arrays (\`item.ImplementationNotes\`, \`item.DecisionLog\`) AND embedded inside the stringified \`fields\` blob. Per BUG-987 bug 10, the top-level arrays are the cleaner shape; drop the embed.

Path-consistent with BUG-991 path A (MCP-only normalization): extend the boundary normalizer so after \`fields\` is parsed, the duplicated keys get stripped. Server / web / CLI keep their existing storage behavior.

## Before / after
\`\`\`jsonc
// Before
{
  "ref": "TASK-7",
  "implementation_notes": [{"id":"n1","summary":"..."}],
  "fields": {"status":"open","implementation_notes":[{"id":"n1"}]}  // duplicate
}

// After
{
  "ref": "TASK-7",
  "implementation_notes": [{"id":"n1","summary":"..."}],
  "fields": {"status":"open"}  // duplicate stripped
}
\`\`\`

## Test plan
- [x] \`make check\` clean
- [x] \`stripDuplicatedFieldsKeys\` helper: strips both keys, no-op when absent, defensive on non-object inputs
- [x] End-to-end \`packageJSONResult\` cases for single-item AND array-style responses

## Out of scope
Write-side migration (stop persisting embeds, one-shot data clean-up of existing items) is the architecturally proper fix and remains tracked in BUG-992's notes.

## Context
Implements BUG-992 (deferred from BUG-987 bug 10).