### PR TITLE
fix(dashboard): suggested_next surfaces in-progress + filters blocked items (BUG-990)

### DIFF
--- a/internal/server/handlers_dashboard.go
+++ b/internal/server/handlers_dashboard.go
@@ -84,6 +84,61 @@ type DashboardSuggestion struct {
 	Reason     string `json:"reason"`
 }
 
+// itemBlockedByActive returns true when the item identified by id
+// has at least one active "blocks" link with a non-done blocker.
+// Mirrors the attention-blocked logic above so the suggested_next
+// algorithm filters out the same items the dashboard's attention
+// section flags as blocked.
+//
+// Visibility filters (collection visibility + per-item guest grants)
+// apply to BLOCKERS too — a blocker the requesting user can't see
+// shouldn't influence whether the target is suggested. This matches
+// the attention block's behavior.
+//
+// Returns false on lookup errors (best-effort: better to surface a
+// suggestion than swallow the algorithm on a transient store hiccup).
+//
+// BUG-990 introduced this helper alongside the in-progress
+// surfacing change in handleDashboard's suggested_next section.
+func (s *Server) itemBlockedByActive(
+	workspaceID, itemID string,
+	ctxMap map[string]doneContext,
+	visibleIDs []string,
+	r *http.Request,
+	dashFullCollIDs, dashGrantedItemIDs []string,
+) bool {
+	links, err := s.store.GetItemLinks(itemID)
+	if err != nil {
+		return false
+	}
+	for _, link := range links {
+		if link.LinkType != "blocks" {
+			continue
+		}
+		// We care only about links where this item is the BLOCKED
+		// (target) side — `source blocks target`.
+		if link.TargetID != itemID {
+			continue
+		}
+		blocker, err := s.store.GetItem(link.SourceID)
+		if err != nil || blocker == nil {
+			continue
+		}
+		if !isCollectionVisible(blocker.CollectionID, visibleIDs) {
+			continue
+		}
+		if !s.isItemVisibleToGuest(r, workspaceID, blocker, dashFullCollIDs, dashGrantedItemIDs) {
+			continue
+		}
+		if isItemDone(blocker.Fields, blocker.CollectionID, ctxMap) {
+			continue
+		}
+		// At least one active blocker visible to this user — bail.
+		return true
+	}
+	return false
+}
+
 // priorityRank returns a sort rank for task priority (lower = higher priority).
 func priorityRank(priority string) int {
 	switch strings.ToLower(priority) {
@@ -565,11 +620,22 @@ func (s *Server) handleGetDashboard(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// --- Suggested Next ---
-	// Find open child items in active plans, sorted by priority, top 3
+	// BUG-990: includes both open AND in-progress child items in
+	// active plans. In-progress items rank ABOVE open ones — the user
+	// is already working them, so "what should I work on next" should
+	// almost always surface continuing work first. Items with active
+	// blockers are excluded entirely (the agent shouldn't suggest
+	// work the user can't actually do).
+	//
+	// Bucket order (within each, by priority rank):
+	//   1. in-progress, unblocked
+	//   2. open, unblocked
 	type suggestion struct {
-		item     models.Item
-		plan     string
-		priority int
+		item       models.Item
+		plan       string
+		status     string
+		priority   int
+		inProgress bool
 	}
 	var candidates []suggestion
 
@@ -591,19 +657,35 @@ func (s *Server) handleGetDashboard(w http.ResponseWriter, r *http.Request) {
 				continue
 			}
 			taskStatus := extractFieldValue(task.Fields, "status")
-			if taskStatus == "open" {
-				pri := extractFieldValue(task.Fields, "priority")
-				candidates = append(candidates, suggestion{
-					item:     task,
-					plan:     dp.Title,
-					priority: priorityRank(pri),
-				})
+			isInProgress := isActiveStatus(taskStatus)
+			isOpen := taskStatus == "open"
+			if !isInProgress && !isOpen {
+				continue
 			}
+			// Filter blocked items: don't suggest work an agent can't
+			// actually start. Mirrors the attention-blocked logic
+			// above — `blocks` link with this item as the target,
+			// where the blocker is still non-done.
+			if s.itemBlockedByActive(workspaceID, task.ID, ctxMap, visibleIDs, r, dashFullCollIDs, dashGrantedItemIDs) {
+				continue
+			}
+			pri := extractFieldValue(task.Fields, "priority")
+			candidates = append(candidates, suggestion{
+				item:       task,
+				plan:       dp.Title,
+				status:     taskStatus,
+				priority:   priorityRank(pri),
+				inProgress: isInProgress,
+			})
 		}
 	}
 
-	// Sort by priority rank (ascending = highest priority first)
+	// Sort: in-progress first, then by priority rank within each
+	// bucket. Lower rank = higher priority.
 	sort.Slice(candidates, func(i, j int) bool {
+		if candidates[i].inProgress != candidates[j].inProgress {
+			return candidates[i].inProgress
+		}
 		return candidates[i].priority < candidates[j].priority
 	})
 
@@ -614,7 +696,12 @@ func (s *Server) handleGetDashboard(w http.ResponseWriter, r *http.Request) {
 	}
 	for _, c := range candidates[:limit] {
 		pri := extractFieldValue(c.item.Fields, "priority")
-		reason := "Open task in active plan \"" + c.plan + "\""
+		var reason string
+		if c.inProgress {
+			reason = "In-progress task in active plan \"" + c.plan + "\""
+		} else {
+			reason = "Open task in active plan \"" + c.plan + "\""
+		}
 		if pri != "" {
 			reason += " (" + pri + " priority)"
 		}

--- a/internal/server/handlers_dashboard_test.go
+++ b/internal/server/handlers_dashboard_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"encoding/json"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/PerpetualSoftware/pad/internal/models"
@@ -532,24 +533,38 @@ func TestDashboardSuggestedNext(t *testing.T) {
 		"fields": `{"status":"open","priority":"medium","parent":"` + plan.ID + `"}`,
 	})
 
-	// This one is in-progress — not "open", so NOT suggested
+	// In-progress task: BUG-990 changed the algorithm to surface
+	// in-progress items FIRST (the user is actively working them, so
+	// "what should I work on next" should suggest continuing).
+	// Pre-fix this task was ignored (status != open); now it ranks
+	// above any open task regardless of priority.
 	createItem(t, srv, slug, "tasks", map[string]interface{}{
 		"title":  "Already In Progress",
-		"fields": `{"status":"in-progress","priority":"critical","parent":"` + plan.ID + `"}`,
+		"fields": `{"status":"in-progress","priority":"medium","parent":"` + plan.ID + `"}`,
 	})
 
 	resp := getDashboard(t, srv, slug)
 
-	// Should get top 3 sorted by priority
+	// Should get top 3: in-progress first, then open by priority.
 	if len(resp.SuggestedNext) != 3 {
 		t.Fatalf("expected 3 suggested_next, got %d: %+v", len(resp.SuggestedNext), resp.SuggestedNext)
 	}
 
-	expectedOrder := []string{"Critical Priority Task", "High Priority Task", "Medium Priority Task"}
+	expectedOrder := []string{
+		"Already In Progress",    // in-progress always wins
+		"Critical Priority Task", // highest open priority
+		"High Priority Task",     // next-highest open
+	}
 	for i, expected := range expectedOrder {
 		if resp.SuggestedNext[i].ItemTitle != expected {
 			t.Errorf("suggested_next[%d]: expected %q, got %q", i, expected, resp.SuggestedNext[i].ItemTitle)
 		}
+	}
+
+	// First suggestion's reason should mention in-progress framing.
+	if !strings.Contains(resp.SuggestedNext[0].Reason, "In-progress") {
+		t.Errorf("first suggestion reason should mark in-progress; got %q",
+			resp.SuggestedNext[0].Reason)
 	}
 
 	// Verify collection and reason are populated
@@ -563,6 +578,67 @@ func TestDashboardSuggestedNext(t *testing.T) {
 		if sn.ItemSlug == "" {
 			t.Errorf("expected item_slug to be set for suggestion %q", sn.ItemTitle)
 		}
+	}
+}
+
+// TestDashboardSuggestedNext_FiltersBlockedItems is the regression
+// test for BUG-990's blocked-item filter. Items with at least one
+// active "blocks" link from a non-done blocker shouldn't appear in
+// suggested_next — the agent shouldn't recommend work the user
+// can't actually start. Verifies that an explicit blocker results
+// in the otherwise-eligible task being skipped.
+func TestDashboardSuggestedNext_FiltersBlockedItems(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	plan := createItem(t, srv, slug, "plans", map[string]interface{}{
+		"title":  "Active Plan",
+		"fields": `{"status":"active"}`,
+	})
+	blocker := createItem(t, srv, slug, "tasks", map[string]interface{}{
+		"title":  "Blocker",
+		"fields": `{"status":"open","priority":"high","parent":"` + plan.ID + `"}`,
+	})
+	blocked := createItem(t, srv, slug, "tasks", map[string]interface{}{
+		"title":  "Blocked Task",
+		"fields": `{"status":"open","priority":"critical","parent":"` + plan.ID + `"}`,
+	})
+	free := createItem(t, srv, slug, "tasks", map[string]interface{}{
+		"title":  "Free Task",
+		"fields": `{"status":"open","priority":"medium","parent":"` + plan.ID + `"}`,
+	})
+	_ = free // avoid unused-var if Go reorders
+
+	// Create a `blocks` link: blocker → blocked. The route creates
+	// the link FROM the URL ref TO the body's target_id, so we POST
+	// to the BLOCKER's slug with the BLOCKED item's ID as target.
+	// Result: "Blocker blocks Blocked Task". `Blocked Task` should
+	// NOT appear in suggested_next even though it has the highest
+	// priority of any open task in the plan.
+	doRequest(srv, "POST",
+		"/api/v1/workspaces/"+slug+"/items/"+blocker.Slug+"/links",
+		map[string]interface{}{
+			"link_type": "blocks",
+			"target_id": blocked.ID,
+			"actor":     "user",
+			"source":    "test",
+		})
+
+	resp := getDashboard(t, srv, slug)
+	for _, s := range resp.SuggestedNext {
+		if s.ItemTitle == "Blocked Task" {
+			t.Errorf("blocked task surfaced in suggested_next: %+v", s)
+		}
+	}
+	// Sanity: Free Task and Blocker should both appear (both
+	// unblocked, both open). At least one of them should be there.
+	titles := map[string]bool{}
+	for _, s := range resp.SuggestedNext {
+		titles[s.ItemTitle] = true
+	}
+	if !titles["Blocker"] && !titles["Free Task"] {
+		t.Errorf("expected at least one of Blocker / Free Task in suggested_next; got %v",
+			titles)
 	}
 }
 


### PR DESCRIPTION
## Summary
Pre-fix \`suggested_next\` only considered \`status == "open"\` child items in active plans. Two issues:
1. **In-progress items never appeared.** The most likely "what should I work on next" answer is the work the user is already on; pre-fix the engine returned \`[]\` if nothing was open even when a task was actively in-progress.
2. **Blocked items appeared.** Suggesting work with unresolved blockers wastes the user's time.

## Algorithm changes (\`handlers_dashboard.go\`)
- Include open AND active-status items (in-progress, fixing, exploring — via existing \`isActiveStatus\`).
- New \`itemBlockedByActive\` helper filters items with at least one non-done \`blocks\` link. Mirrors the attention-section logic.
- Sort: **in-progress first** (always wins over open regardless of priority), then by priority rank within each bucket.
- Reason text distinguishes \`"In-progress task in active plan ..."\` vs \`"Open task in active plan ..."\` so agents see WHY an item was suggested.

## Test plan
- [x] \`make check\` clean
- [x] \`TestDashboardSuggestedNext\` updated for new in-progress-first ordering
- [x] New \`TestDashboardSuggestedNext_FiltersBlockedItems\` confirms a blocked task is suppressed even at critical priority

## Out of scope
High-priority orphan suggestions (items not under an active plan) — flagged as stretch in BUG-990; needs a relevance model since "everything high priority" can be a long list. Stays in the bug item.

## Context
Implements BUG-990 (deferred from BUG-987 bug 7).