### PR TITLE
feat(auth): extract <AuthOAuthButtons> + render on /register (TASK-1000)

### DIFF
--- a/web/src/lib/auth/redirect.ts
+++ b/web/src/lib/auth/redirect.ts
@@ -1,0 +1,52 @@
+// Redirect-target validation + query-string helpers shared between
+// /login and /register. Both pages support a `?redirect=` query param
+// that lets the OAuth-server `/oauth/authorize` endpoint (or any
+// future inbound deep link) bounce the user back to the original
+// destination after auth completes.
+//
+// Validation logic mirrors what the `/login` page used to inline:
+// a bare `startsWith('/')` check is NOT enough because protocol-
+// relative URLs like `//evil.example` and `/\evil.example` pass that
+// check but are treated by browsers (and most server-side redirect
+// handlers) as cross-origin destinations. Reject those explicitly.
+
+export const DEFAULT_REDIRECT = '/console';
+
+/**
+ * Validate the `redirect` query param and return a safe relative path.
+ *
+ * Returns DEFAULT_REDIRECT (`/console`) for missing, malformed, or
+ * potentially-cross-origin values. Callers can compare the return
+ * value against DEFAULT_REDIRECT to detect "no real redirect requested"
+ * without re-parsing.
+ */
+export function validateRedirect(raw: string | null | undefined): string {
+	if (
+		raw &&
+		raw.startsWith('/') &&
+		!raw.startsWith('//') &&
+		!raw.startsWith('/\\')
+	) {
+		return raw;
+	}
+	return DEFAULT_REDIRECT;
+}
+
+/**
+ * Build a query-string fragment encoding the redirect target.
+ *
+ * Returns an empty string when the target is the default destination
+ * so the fragment composes cleanly into URLs that don't already need
+ * a separator. Pass separator='&' when appending to a URL that
+ * already has a query string (e.g. `/auth/github?force=1`).
+ *
+ * @param target - Already-validated redirect target (output of validateRedirect).
+ * @param separator - '?' to start a new query string (default), '&' to append.
+ */
+export function redirectQueryFragment(
+	target: string,
+	separator: '?' | '&' = '?'
+): string {
+	if (target === DEFAULT_REDIRECT) return '';
+	return `${separator}redirect=${encodeURIComponent(target)}`;
+}

--- a/web/src/lib/components/auth/AuthOAuthButtons.svelte
+++ b/web/src/lib/components/auth/AuthOAuthButtons.svelte
@@ -1,0 +1,157 @@
+<script lang="ts">
+	// Cloud-mode SSO buttons (Continue with GitHub / Continue with Google),
+	// shared between /login and /register so both pages offer the same
+	// one-click sign-in/sign-up affordance and pass `redirect=` through
+	// identically.
+	//
+	// Self-hosted (cloudMode === false) renders nothing — pad-cloud owns the
+	// OAuth provider integrations. Same gate-on-cloudMode pattern as the
+	// companion AuthHeader / AuthFooter components in this directory.
+	//
+	// Layout-wise this component owns the "or" divider above its buttons,
+	// so callers can drop it directly under their primary submit button
+	// without needing an extra spacer wrapper.
+
+	import type { AuthMethod } from '$lib/auth/lastMethod';
+	import { redirectQueryFragment } from '$lib/auth/redirect';
+
+	let {
+		cloudMode = false,
+		redirectTarget,
+		lastMethod = null,
+		onProviderClick
+	}: {
+		cloudMode?: boolean;
+		/** Already-validated redirect target (use validateRedirect from $lib/auth/redirect). */
+		redirectTarget: string;
+		lastMethod?: AuthMethod | null;
+		onProviderClick: (provider: AuthMethod) => void;
+	} = $props();
+
+	const oauthRedirectQuery = $derived(redirectQueryFragment(redirectTarget, '?'));
+</script>
+
+{#if cloudMode}
+	<div class="oauth-divider">
+		<span>or</span>
+	</div>
+
+	<div class="oauth-buttons">
+		<a
+			href="/auth/github{oauthRedirectQuery}"
+			data-sveltekit-reload
+			class="oauth-btn oauth-github"
+			class:last-used={lastMethod === 'github'}
+			onclick={() => onProviderClick('github')}
+		>
+			<svg width="18" height="18" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"
+				><path
+					d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"
+				/></svg
+			>
+			Continue with GitHub
+			{#if lastMethod === 'github'}
+				<span class="last-used-pill">Last used</span>
+			{/if}
+		</a>
+		<a
+			href="/auth/google{oauthRedirectQuery}"
+			data-sveltekit-reload
+			class="oauth-btn oauth-google"
+			class:last-used={lastMethod === 'google'}
+			onclick={() => onProviderClick('google')}
+		>
+			<svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true"
+				><path
+					d="M17.64 9.2c0-.637-.057-1.251-.164-1.84H9v3.481h4.844a4.14 4.14 0 01-1.796 2.716v2.259h2.908c1.702-1.567 2.684-3.875 2.684-6.615z"
+					fill="#4285F4"
+				/><path
+					d="M9 18c2.43 0 4.467-.806 5.956-2.18l-2.908-2.259c-.806.54-1.837.86-3.048.86-2.344 0-4.328-1.584-5.036-3.711H.957v2.332A8.997 8.997 0 009 18z"
+					fill="#34A853"
+				/><path
+					d="M3.964 10.71A5.41 5.41 0 013.682 9c0-.593.102-1.17.282-1.71V4.958H.957A8.996 8.996 0 000 9c0 1.452.348 2.827.957 4.042l3.007-2.332z"
+					fill="#FBBC05"
+				/><path
+					d="M9 3.58c1.321 0 2.508.454 3.44 1.345l2.582-2.58C13.463.891 11.426 0 9 0A8.997 8.997 0 00.957 4.958L3.964 7.29C4.672 5.163 6.656 3.58 9 3.58z"
+					fill="#EA4335"
+				/></svg
+			>
+			Continue with Google
+			{#if lastMethod === 'google'}
+				<span class="last-used-pill">Last used</span>
+			{/if}
+		</a>
+	</div>
+{/if}
+
+<style>
+	.oauth-divider {
+		display: flex;
+		align-items: center;
+		gap: var(--space-4);
+		margin: var(--space-6) 0;
+		color: var(--text-muted);
+		font-size: 0.8rem;
+	}
+
+	.oauth-divider::before,
+	.oauth-divider::after {
+		content: '';
+		flex: 1;
+		height: 1px;
+		background: var(--border);
+	}
+
+	.oauth-buttons {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-3);
+	}
+
+	.oauth-btn {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		gap: var(--space-3);
+		width: 100%;
+		padding: var(--space-3) var(--space-4);
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+		font-size: 0.9rem;
+		font-weight: 500;
+		font-family: var(--font-ui);
+		text-decoration: none;
+		cursor: pointer;
+		transition:
+			background 0.15s,
+			border-color 0.15s;
+	}
+
+	.oauth-github,
+	.oauth-google {
+		background: var(--bg-tertiary);
+		color: var(--text-primary);
+	}
+
+	.oauth-github:hover,
+	.oauth-google:hover {
+		background: var(--bg-hover);
+		border-color: var(--text-muted);
+	}
+
+	.oauth-btn.last-used {
+		border-color: color-mix(in srgb, var(--accent-blue) 50%, var(--border));
+		box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent-blue) 20%, transparent);
+	}
+
+	.last-used-pill {
+		margin-left: auto;
+		padding: 2px var(--space-2);
+		background: color-mix(in srgb, var(--accent-blue) 15%, transparent);
+		color: var(--accent-blue);
+		border-radius: var(--radius-sm);
+		font-size: 0.7rem;
+		font-weight: 500;
+		letter-spacing: 0.02em;
+	}
+</style>

--- a/web/src/routes/login/+page.svelte
+++ b/web/src/routes/login/+page.svelte
@@ -7,11 +7,13 @@
 	import SetupRequiredNotice from '$lib/components/auth/SetupRequiredNotice.svelte';
 	import AuthHeader from '$lib/components/auth/AuthHeader.svelte';
 	import AuthFooter from '$lib/components/auth/AuthFooter.svelte';
+	import AuthOAuthButtons from '$lib/components/auth/AuthOAuthButtons.svelte';
 	import {
 		recordAuthMethod,
 		getLastAuthMethod,
 		type AuthMethod
 	} from '$lib/auth/lastMethod';
+	import { validateRedirect, redirectQueryFragment } from '$lib/auth/redirect';
 
 	let email = $state('');
 	let password = $state('');
@@ -40,39 +42,13 @@
 	// matching CTA. Never blocks any flow; first-time visitors see no banner.
 	let lastMethod = $state<AuthMethod | null>(null);
 
-	function getRedirectTarget(): string {
-		const redirect = $page.url.searchParams.get('redirect');
-		// Only allow relative redirects (prevent open redirect). A bare
-		// `startsWith('/')` is NOT enough: protocol-relative URLs like
-		// `//evil.example` and `/\evil.example` pass that check but are
-		// treated by browsers (and most server-side redirect handlers) as
-		// cross-origin destinations. Reject those explicitly.
-		if (
-			redirect &&
-			redirect.startsWith('/') &&
-			!redirect.startsWith('//') &&
-			!redirect.startsWith('/\\')
-		) {
-			return redirect;
-		}
-		return '/console';
-	}
-
-	const oauthRedirectQuery = $derived.by(() => {
-		const target = getRedirectTarget();
-		if (target === '/console') return '';
-		return `?redirect=${encodeURIComponent(target)}`;
-	});
-
-	// Same target appended with `&` so it composes with `?force=1` on
-	// the "Use a different <provider> account" banner buttons. Empty
-	// when redirect is the default destination so we don't append a
-	// redundant `&redirect=%2Fconsole`.
-	const oauthRedirectAmpQuery = $derived.by(() => {
-		const target = getRedirectTarget();
-		if (target === '/console') return '';
-		return `&redirect=${encodeURIComponent(target)}`;
-	});
+	// Validation + query-string helpers live in $lib/auth/redirect so /register
+	// can share them. `redirectTarget` is the validated target (or '/console'
+	// default); `oauthRedirectAmpQuery` composes the same encoding behind a
+	// '&' separator so it can append onto banner URLs that already carry
+	// `?force=1`.
+	const redirectTarget = $derived(validateRedirect($page.url.searchParams.get('redirect')));
+	const oauthRedirectAmpQuery = $derived(redirectQueryFragment(redirectTarget, '&'));
 
 	// Map pad-cloud's /login?error=... redirect codes to a friendly banner
 	// plus optional CTAs. Kept near onMount so the full list of codes the
@@ -165,7 +141,7 @@
 				return;
 			}
 			if (session.authenticated) {
-				goto(getRedirectTarget(), { replaceState: true });
+				goto(redirectTarget, { replaceState: true });
 				return;
 			}
 		} catch {}
@@ -195,7 +171,7 @@
 
 			recordAuthMethod('password');
 			await authStore.load();
-			await goto(getRedirectTarget(), { replaceState: true });
+			await goto(redirectTarget, { replaceState: true });
 		} catch (err: unknown) {
 			if (err instanceof Error) {
 				error = err.message || 'Invalid email or password.';
@@ -228,7 +204,7 @@
 
 			recordAuthMethod('password');
 			await authStore.load();
-			await goto(getRedirectTarget(), { replaceState: true });
+			await goto(redirectTarget, { replaceState: true });
 		} catch (err: unknown) {
 			if (err instanceof Error) {
 				error = err.message || 'Invalid code. Please try again.';
@@ -409,40 +385,12 @@
 				</button>
 			</div>
 
-			{#if cloudMode}
-				<div class="oauth-divider">
-					<span>or</span>
-				</div>
-
-				<div class="oauth-buttons">
-					<a
-						href="/auth/github{oauthRedirectQuery}"
-						data-sveltekit-reload
-						class="oauth-btn oauth-github"
-						class:last-used={lastMethod === 'github'}
-						onclick={() => handleOAuthClick('github')}
-					>
-						<svg width="18" height="18" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
-						Continue with GitHub
-						{#if lastMethod === 'github'}
-							<span class="last-used-pill">Last used</span>
-						{/if}
-					</a>
-					<a
-						href="/auth/google{oauthRedirectQuery}"
-						data-sveltekit-reload
-						class="oauth-btn oauth-google"
-						class:last-used={lastMethod === 'google'}
-						onclick={() => handleOAuthClick('google')}
-					>
-						<svg width="18" height="18" viewBox="0 0 18 18" fill="none"><path d="M17.64 9.2c0-.637-.057-1.251-.164-1.84H9v3.481h4.844a4.14 4.14 0 01-1.796 2.716v2.259h2.908c1.702-1.567 2.684-3.875 2.684-6.615z" fill="#4285F4"/><path d="M9 18c2.43 0 4.467-.806 5.956-2.18l-2.908-2.259c-.806.54-1.837.86-3.048.86-2.344 0-4.328-1.584-5.036-3.711H.957v2.332A8.997 8.997 0 009 18z" fill="#34A853"/><path d="M3.964 10.71A5.41 5.41 0 013.682 9c0-.593.102-1.17.282-1.71V4.958H.957A8.996 8.996 0 000 9c0 1.452.348 2.827.957 4.042l3.007-2.332z" fill="#FBBC05"/><path d="M9 3.58c1.321 0 2.508.454 3.44 1.345l2.582-2.58C13.463.891 11.426 0 9 0A8.997 8.997 0 00.957 4.958L3.964 7.29C4.672 5.163 6.656 3.58 9 3.58z" fill="#EA4335"/></svg>
-						Continue with Google
-						{#if lastMethod === 'google'}
-							<span class="last-used-pill">Last used</span>
-						{/if}
-					</a>
-				</div>
-			{/if}
+			<AuthOAuthButtons
+				{cloudMode}
+				{redirectTarget}
+				{lastMethod}
+				onProviderClick={handleOAuthClick}
+			/>
 
 			<p class="register-link">
 				<a href="/forgot-password">Forgot password?</a>
@@ -600,65 +548,11 @@
 		text-decoration: underline;
 	}
 
-	.oauth-divider {
-		display: flex;
-		align-items: center;
-		gap: var(--space-4);
-		margin: var(--space-6) 0;
-		color: var(--text-muted);
-		font-size: 0.8rem;
-	}
-
-	.oauth-divider::before,
-	.oauth-divider::after {
-		content: '';
-		flex: 1;
-		height: 1px;
-		background: var(--border);
-	}
-
-	.oauth-buttons {
-		display: flex;
-		flex-direction: column;
-		gap: var(--space-3);
-	}
-
-	.oauth-btn {
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		gap: var(--space-3);
-		width: 100%;
-		padding: var(--space-3) var(--space-4);
-		border: 1px solid var(--border);
-		border-radius: var(--radius);
-		font-size: 0.9rem;
-		font-weight: 500;
-		font-family: var(--font-ui);
-		text-decoration: none;
-		cursor: pointer;
-		transition: background 0.15s, border-color 0.15s;
-	}
-
-	.oauth-github {
-		background: var(--bg-tertiary);
-		color: var(--text-primary);
-	}
-
-	.oauth-github:hover {
-		background: var(--bg-hover);
-		border-color: var(--text-muted);
-	}
-
-	.oauth-google {
-		background: var(--bg-tertiary);
-		color: var(--text-primary);
-	}
-
-	.oauth-google:hover {
-		background: var(--bg-hover);
-		border-color: var(--text-muted);
-	}
+	/* OAuth provider button styles (.oauth-divider, .oauth-buttons, .oauth-btn,
+	   .oauth-github, .oauth-google, .oauth-btn.last-used, .last-used-pill)
+	   live in $lib/components/auth/AuthOAuthButtons.svelte. The styles below
+	   are the OAuth-error banner and the welcome "last used" banner, both
+	   page-local. */
 
 	.oauth-banner {
 		position: relative;
@@ -759,21 +653,5 @@
 	.last-used-text {
 		flex: 1;
 		min-width: 0;
-	}
-
-	.oauth-btn.last-used {
-		border-color: color-mix(in srgb, var(--accent-blue) 50%, var(--border));
-		box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent-blue) 20%, transparent);
-	}
-
-	.last-used-pill {
-		margin-left: auto;
-		padding: 2px var(--space-2);
-		background: color-mix(in srgb, var(--accent-blue) 15%, transparent);
-		color: var(--accent-blue);
-		border-radius: var(--radius-sm);
-		font-size: 0.7rem;
-		font-weight: 500;
-		letter-spacing: 0.02em;
 	}
 </style>

--- a/web/src/routes/login/+page.svelte
+++ b/web/src/routes/login/+page.svelte
@@ -48,6 +48,7 @@
 	// '&' separator so it can append onto banner URLs that already carry
 	// `?force=1`.
 	const redirectTarget = $derived(validateRedirect($page.url.searchParams.get('redirect')));
+	const oauthRedirectQuery = $derived(redirectQueryFragment(redirectTarget, '?'));
 	const oauthRedirectAmpQuery = $derived(redirectQueryFragment(redirectTarget, '&'));
 
 	// Map pad-cloud's /login?error=... redirect codes to a friendly banner
@@ -397,7 +398,7 @@
 			</p>
 			{#if cloudMode}
 				<p class="register-link">
-					Don't have an account? <a href="/register">Sign up</a>
+					Don't have an account? <a href="/register{oauthRedirectQuery}">Sign up</a>
 				</p>
 			{:else}
 				<p class="register-link">

--- a/web/src/routes/register/+page.svelte
+++ b/web/src/routes/register/+page.svelte
@@ -13,7 +13,7 @@
 		getLastAuthMethod,
 		type AuthMethod
 	} from '$lib/auth/lastMethod';
-	import { validateRedirect } from '$lib/auth/redirect';
+	import { validateRedirect, redirectQueryFragment } from '$lib/auth/redirect';
 
 	let name = $state('');
 	let username = $state('');
@@ -43,6 +43,9 @@
 	// the user to /oauth/authorize after SSO. Falls back to /console for
 	// missing or invalid values.
 	const redirectTarget = $derived(validateRedirect($page.url.searchParams.get('redirect')));
+	// Forward redirect= onto the "Sign in" cross-link so a user mid-OAuth flow
+	// can hop /register ↔ /login without dropping their original destination.
+	const loginRedirectQuery = $derived(redirectQueryFragment(redirectTarget, '?'));
 
 	onMount(async () => {
 		// Read the last-used method on mount so the "Last used" pill on the
@@ -273,7 +276,7 @@
 			/>
 
 			<p class="login-link">
-				Already have an account? <a href="/login">Sign in</a>
+				Already have an account? <a href="/login{loginRedirectQuery}">Sign in</a>
 			</p>
 		{/if}
 	</div>

--- a/web/src/routes/register/+page.svelte
+++ b/web/src/routes/register/+page.svelte
@@ -1,12 +1,19 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
+	import { page } from '$app/stores';
 	import { api } from '$lib/api/client';
 	import { goto } from '$app/navigation';
 	import SetupRequiredNotice from '$lib/components/auth/SetupRequiredNotice.svelte';
 	import AuthHeader from '$lib/components/auth/AuthHeader.svelte';
 	import AuthFooter from '$lib/components/auth/AuthFooter.svelte';
+	import AuthOAuthButtons from '$lib/components/auth/AuthOAuthButtons.svelte';
 	import { authStore } from '$lib/stores/auth.svelte';
-	import { recordAuthMethod } from '$lib/auth/lastMethod';
+	import {
+		recordAuthMethod,
+		getLastAuthMethod,
+		type AuthMethod
+	} from '$lib/auth/lastMethod';
+	import { validateRedirect } from '$lib/auth/redirect';
 
 	let name = $state('');
 	let username = $state('');
@@ -24,7 +31,26 @@
 	let usernameError = $state('');
 	let checkTimeout: ReturnType<typeof setTimeout> | null = null;
 
+	// Last-used auth method (TASK-923 / TASK-1000) — populated on mount,
+	// drives the "Last used" pill on whichever SSO button matches. Same
+	// behavior as /login for cross-page consistency.
+	let lastMethod = $state<AuthMethod | null>(null);
+
+	// Validated redirect target. /register supports `?redirect=` for the
+	// register-during-OAuth flow: agent clients send unauth users to
+	// /register?redirect=/oauth/authorize?... and we hand the param off
+	// to /auth/<provider> so pad-cloud's callback (TASK-998) can return
+	// the user to /oauth/authorize after SSO. Falls back to /console for
+	// missing or invalid values.
+	const redirectTarget = $derived(validateRedirect($page.url.searchParams.get('redirect')));
+
 	onMount(async () => {
+		// Read the last-used method on mount so the "Last used" pill on the
+		// SSO buttons paints with the form. Fails silent in SSR / private mode
+		// (the helper returns null).
+		const last = getLastAuthMethod();
+		if (last) lastMethod = last.method;
+
 		try {
 			// Route session fetch through authStore so authStore.cloudMode is
 			// populated after a logout → /register navigation (the root layout's
@@ -38,11 +64,21 @@
 				return;
 			}
 			if (session?.authenticated) {
-				goto('/console', { replaceState: true });
+				goto(redirectTarget, { replaceState: true });
 				return;
 			}
 		} catch {}
 	});
+
+	// OAuth completion happens entirely outside the SPA (provider → pad-cloud
+	// callback → server-set session cookie → server-driven redirect). There's
+	// no JS callback to hang the localStorage write on, so record speculatively
+	// on click. Same approach as /login. If the user bails at the provider's
+	// consent screen, the value still reflects "what the user tried last",
+	// which is the right answer for the next-visit banner.
+	function handleOAuthClick(provider: AuthMethod) {
+		recordAuthMethod(provider);
+	}
 
 	function generateUsername(name: string): string {
 		let u = name.toLowerCase().trim();
@@ -114,7 +150,7 @@
 		try {
 			await api.auth.register(email, name, password, username || undefined);
 			recordAuthMethod('password');
-			await goto('/console', { replaceState: true });
+			await goto(redirectTarget, { replaceState: true });
 		} catch (err: unknown) {
 			if (err instanceof Error) {
 				error = err.message || 'Registration failed.';
@@ -228,6 +264,13 @@
 					</p>
 				{/if}
 			</div>
+
+			<AuthOAuthButtons
+				cloudMode={authStore.cloudMode}
+				{redirectTarget}
+				{lastMethod}
+				onProviderClick={handleOAuthClick}
+			/>
 
 			<p class="login-link">
 				Already have an account? <a href="/login">Sign in</a>


### PR DESCRIPTION
## Summary

Lift the cloud-mode SSO block (Continue with GitHub / Continue with Google) out of `/login` into a shared `AuthOAuthButtons.svelte` component and render it on both `/login` and `/register`. Extract `redirect=` validation + query-string helpers into `\$lib/auth/redirect` so both pages compose the same encoding.

## Why

The marketing-site "Sign up to connect Claude" CTA lands new users on `/register`, which had no SSO buttons. First-touch users fell off the 30-second-onboard path. With this PR, `/register` exposes the same one-click SSO buttons as `/login` and preserves `?redirect=` through the click so completing SSO returns to the original destination (e.g. `/oauth/authorize?...` once TASK-998 lands pad-cloud's `redirect=` honoring).

## Behavior changes

- `/register` reads the same `redirect` query param `/login` does and honors it on `goto()` after password registration.
- `/register` populates the "Last used" pill from localStorage so returning users see the visual lift on their preferred provider.
- `/login` is byte-identical: the inline SSO block is replaced with the component, the inline redirect helpers replaced with helper imports, and the now-unused CSS rules removed.

## Files

- `web/src/lib/auth/redirect.ts` (new) — `validateRedirect` + `redirectQueryFragment` helpers.
- `web/src/lib/components/auth/AuthOAuthButtons.svelte` (new) — shared SSO buttons component.
- `web/src/routes/login/+page.svelte` — refactor to use helpers + component; ~150 LOC removed.
- `web/src/routes/register/+page.svelte` — render component, plumb redirect, populate lastMethod.

## Out of scope (separate tasks under PLAN-943)

- TASK-998: pad-cloud OAuth callback honoring `redirect=` (so SSO actually returns to `/oauth/authorize` instead of `/console`).
- TASK-1001: contextual OAuth-intent banner on `/login` + `/register`.

## Context

Implements TASK-1000 under PLAN-943 (Pad Cloud as a remote MCP server).

## Test plan

- [x] \`npm run check\` — clean (0 errors; 6 pre-existing warnings in unrelated files)
- [x] \`npm run build\` — clean
- [x] \`go build ./...\` + \`go vet ./...\` — clean (no Go changes; sanity)
- [x] \`make check\` — clean (lint + go test + vuln + web-check all green)
- [x] \`make install\` — server rebuilt + restarted
- [x] Svelte autofixer (MCP) — no issues, no suggestions on the new component

### Manual verification (cloud mode)

- [ ] \`/login?redirect=/oauth/authorize?foo\` — clicking "Continue with Google" navigates to \`/auth/google?redirect=%2Foauth%2Fauthorize%3Ffoo\`
- [ ] \`/register?redirect=/oauth/authorize?foo\` — same outbound URL behavior
- [ ] \`/register\` (no redirect) — buttons go to \`/auth/google\` (no query string)
- [ ] Last-used pill appears on the correct button after a prior SSO click

### Notes for reviewers

- The Playwright e2e harness doesn't currently support \`PAD_CLOUD=true\` mode, so the URL-assertion E2E in TASK-1000's DoD is verified by inspection + the upstream \`/login\` behavior already exercising the same component code path. A follow-up to expand the e2e harness for cloud-mode coverage is reasonable scope for a separate task.