### PR TITLE
feat(auth): contextual OAuth-intent banner on /login + /register (TASK-1001)

### DIFF
--- a/web/src/lib/components/auth/AuthIntentBanner.svelte
+++ b/web/src/lib/components/auth/AuthIntentBanner.svelte
@@ -1,0 +1,77 @@
+<script lang="ts">
+	// Contextual banner shown on /login and /register when the user landed
+	// there mid-OAuth-flow, e.g. by clicking "Connect to Claude" on the
+	// marketing site → an OAuth client redirected them to
+	// /login?redirect=/oauth/authorize?... → and the user is now staring at
+	// a sign-in form for a tool they may have never used.
+	//
+	// Without this banner, first-touch users get a fairly steep "wait, why am
+	// I being asked to sign up to a new tool?" moment. The banner tells them
+	// what they're in the middle of so the form doesn't feel like a non
+	// sequitur.
+	//
+	// Detection is purely a heuristic on the validated `redirect` target —
+	// if it begins with `/oauth/authorize`, we assume the user is mid-flow.
+	// We don't need to be exact: false positives only mean a slightly more
+	// specific banner; false negatives leave the user with the same UX they
+	// had before this banner existed.
+	//
+	// FUTURE (TASK-951 / follow-up): once `/api/v1/oauth/clients/{id}/
+	// public-info` ships from TASK-951, parse `client_id` out of the inner
+	// query string and fetch the client's display name so the banner can
+	// say "connect Claude Desktop" instead of the generic "connect an AI
+	// agent." The component contract is shaped to allow that extension
+	// without consumer changes.
+
+	let {
+		redirectTarget,
+		mode
+	}: {
+		/** Already-validated redirect target (output of validateRedirect from $lib/auth/redirect). */
+		redirectTarget: string;
+		/** Drives the verb: signin = "signing in", signup = "creating an account". */
+		mode: 'signin' | 'signup';
+	} = $props();
+
+	const isOAuthFlow = $derived(redirectTarget.startsWith('/oauth/authorize'));
+	const verb = $derived(mode === 'signin' ? 'signing in' : 'creating an account');
+</script>
+
+{#if isOAuthFlow}
+	<div class="intent-banner" role="status" aria-live="polite">
+		<span class="intent-emoji" aria-hidden="true">🔌</span>
+		<span class="intent-text">
+			You're <strong>{verb}</strong> to connect an AI agent to your Pad workspaces.
+		</span>
+	</div>
+{/if}
+
+<style>
+	/* Same visual family as the OAuth-error banner on /login (blue info tone)
+	   but always informational, never dismissible. Sits above the form so
+	   the user reads context first, form second. */
+	.intent-banner {
+		display: flex;
+		align-items: center;
+		gap: var(--space-2);
+		margin-bottom: var(--space-5);
+		padding: var(--space-3) var(--space-4);
+		border-radius: var(--radius);
+		background: color-mix(in srgb, var(--accent-blue) 10%, transparent);
+		border: 1px solid color-mix(in srgb, var(--accent-blue) 35%, transparent);
+		color: var(--text-primary);
+		font-size: 0.85rem;
+		line-height: 1.4;
+		text-align: left;
+	}
+
+	.intent-emoji {
+		font-size: 1rem;
+		flex-shrink: 0;
+	}
+
+	.intent-text {
+		flex: 1;
+		min-width: 0;
+	}
+</style>

--- a/web/src/routes/login/+page.svelte
+++ b/web/src/routes/login/+page.svelte
@@ -8,6 +8,7 @@
 	import AuthHeader from '$lib/components/auth/AuthHeader.svelte';
 	import AuthFooter from '$lib/components/auth/AuthFooter.svelte';
 	import AuthOAuthButtons from '$lib/components/auth/AuthOAuthButtons.svelte';
+	import AuthIntentBanner from '$lib/components/auth/AuthIntentBanner.svelte';
 	import {
 		recordAuthMethod,
 		getLastAuthMethod,
@@ -353,6 +354,8 @@
 			</div>
 		{:else}
 			<p class="subtitle">Sign in to continue</p>
+
+			<AuthIntentBanner {redirectTarget} mode="signin" />
 
 			<div class="form">
 				<input

--- a/web/src/routes/register/+page.svelte
+++ b/web/src/routes/register/+page.svelte
@@ -7,6 +7,7 @@
 	import AuthHeader from '$lib/components/auth/AuthHeader.svelte';
 	import AuthFooter from '$lib/components/auth/AuthFooter.svelte';
 	import AuthOAuthButtons from '$lib/components/auth/AuthOAuthButtons.svelte';
+	import AuthIntentBanner from '$lib/components/auth/AuthIntentBanner.svelte';
 	import { authStore } from '$lib/stores/auth.svelte';
 	import {
 		recordAuthMethod,
@@ -188,6 +189,8 @@
 			/>
 		{:else}
 			<p class="subtitle">Create your account</p>
+
+			<AuthIntentBanner {redirectTarget} mode="signup" />
 
 			<div class="form">
 				<input


### PR DESCRIPTION
## Summary

Add a small informational banner on \`/login\` + \`/register\` that fires when the page is loaded with \`?redirect=/oauth/authorize?...\`. Reduces "wait, why am I being asked to sign up to a new tool?" anxiety on first-touch users coming from the marketing site's "Connect to Claude" CTA.

## Why

Without this banner, a user lands on /login or /register from the marketing CTA → sees a generic sign-in form → has no signal that they're mid-connection-flow. With it: *"You're [signing in / creating an account] to connect an AI agent to your Pad workspaces."*

## Generic-only for now

The banner uses generic copy (*"connect an AI agent"*) until TASK-951 ships \`GET /api/v1/oauth/clients/{id}/public-info\`. Once that lands, a follow-up will parse \`client_id\` from the inner query string and substitute the friendly name (e.g. *"connect Claude Desktop"*). Component contract is shaped to allow that extension without consumer changes.

## Detection

Heuristic on the validated \`redirectTarget\`: if it begins with \`/oauth/authorize\`, render the banner. False positives = slightly more specific banner. False negatives = the same UX users had before this PR. Either way safe.

## Files

- \`web/src/lib/components/auth/AuthIntentBanner.svelte\` (new)
- \`web/src/routes/login/+page.svelte\` — render between subtitle and form, mode="signin"
- \`web/src/routes/register/+page.svelte\` — same placement, mode="signup"

## Context

Implements TASK-1001 under PLAN-943 (Pad Cloud as a remote MCP server). Builds directly on TASK-1000 (the \`redirectTarget\` derived state introduced there is what this banner reads).

## Test plan

- [x] \`npm run check\` — clean (0 errors; 6 pre-existing warnings unrelated)
- [x] \`make install\` — server rebuilt + restarted
- [x] Svelte autofixer (MCP) — no issues, no suggestions

### Manual verification

- [ ] /login (no redirect) — no banner
- [ ] /login?redirect=/console — no banner
- [ ] /login?redirect=/oauth/authorize?client_id=foo — banner renders, "signing in" verb
- [ ] /register?redirect=/oauth/authorize?client_id=foo — banner renders, "creating an account" verb
- [ ] Banner placement: above the form, below the page subtitle/last-used pill, looks visually consistent with existing oauth-banner