### PR TITLE
feat(mcp): mount /mcp Streamable HTTP transport + OAuth discovery (TASK-950)

### DIFF
--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -38,11 +38,13 @@ import (
 	"github.com/PerpetualSoftware/pad/internal/email"
 	"github.com/PerpetualSoftware/pad/internal/events"
 	"github.com/PerpetualSoftware/pad/internal/logging"
+	mcpserver "github.com/PerpetualSoftware/pad/internal/mcp"
 	"github.com/PerpetualSoftware/pad/internal/metrics"
 	"github.com/PerpetualSoftware/pad/internal/models"
 	"github.com/PerpetualSoftware/pad/internal/server"
 	"github.com/PerpetualSoftware/pad/internal/store"
 	"github.com/PerpetualSoftware/pad/internal/webhooks"
+	mcptransport "github.com/mark3labs/mcp-go/server"
 	"github.com/redis/go-redis/v9"
 	"golang.org/x/term"
 	"golang.org/x/text/cases"
@@ -343,6 +345,74 @@ func serveCmd() *cobra.Command {
 				}
 				srv.SetCloudMode(cfg.CloudSecret)
 				slog.Info("Cloud mode enabled")
+
+				// MCP Streamable HTTP transport (PLAN-943 TASK-950).
+				// Mount the public /mcp endpoint + RFC 9728 / RFC 8414
+				// discovery docs. Wired only in cloud mode because:
+				//
+				//   - It requires user-owned PATs (the existing
+				//     workspace-scoped PAT path is rejected — see
+				//     MCPBearerAuth in middleware_mcp_auth.go), so a
+				//     self-host running without users would have no
+				//     usable auth path.
+				//   - The discovery docs reference a public OAuth
+				//     authorization server URL (TASK-951) that only
+				//     exists on the Pad-Cloud deployment.
+				//
+				// Construction shape mirrors `pad mcp serve` (cmd/pad/mcp.go)
+				// minus the stdio runtime: cmdhelp.Doc → MCPServer →
+				// catalog/prompts/meta registration → wrap in Streamable
+				// HTTP transport → hand to *server.Server. Resources
+				// are intentionally skipped for v1 of TASK-950 — the
+				// existing ExecResourceFetcher shells out to the pad
+				// binary, which doesn't carry a per-OAuth-user
+				// credential context. An HTTPResourceFetcher equivalent
+				// is its own follow-up task.
+				root := cmd.Root()
+				mcpDoc := cmdhelp.Build(root, root, cmdhelp.Options{
+					Binary:   "pad",
+					Version:  fullVersion(),
+					Homepage: padHomepage,
+					MaxDepth: -1,
+				})
+				mcpSrv := mcpserver.NewServer(mcpserver.Options{Version: fullVersion()})
+				// CurrentUserFromContext returns (*User, bool); the
+				// dispatcher's UserResolver signature is just
+				// (ctx) *User. The bool is "found", which equals
+				// "non-nil pointer" for the path the MCP middleware
+				// guarantees (it 401s on no-user before reaching
+				// dispatch), so flatten with a closure.
+				dispatcher := &mcpserver.HTTPHandlerDispatcher{
+					Handler: srv,
+					UserResolver: func(ctx context.Context) *models.User {
+						u, _ := server.CurrentUserFromContext(ctx)
+						return u
+					},
+				}
+				if _, regErr := mcpserver.Register(mcpSrv.MCP(), mcpserver.RegistryOptions{
+					Doc:        mcpDoc,
+					Workspace:  mcpserver.NewWorkspaceState(""),
+					Dispatcher: dispatcher,
+					PadVersion: fullVersion(),
+				}); regErr != nil {
+					return fmt.Errorf("register MCP catalog: %w", regErr)
+				}
+				mcpserver.RegisterPrompts(mcpSrv.MCP())
+				mcpserver.RegisterMeta(mcpSrv.MCP(), fullVersion())
+				// Stateless mode: every Streamable HTTP request stands
+				// alone, Bearer is the auth, no session resumption to
+				// manage. Matches the spike's verified shape.
+				streamable := mcptransport.NewStreamableHTTPServer(
+					mcpSrv.MCP(),
+					mcptransport.WithEndpointPath("/mcp"),
+					mcptransport.WithStateLess(true),
+				)
+				srv.SetMCPTransport(streamable, cfg.MCPPublicURL, cfg.AuthServerURL)
+				slog.Info("MCP /mcp transport mounted",
+					"public_url", cfg.MCPPublicURL,
+					"auth_server", cfg.AuthServerURL,
+					"resources_wired", false,
+				)
 
 				// Reverse pad → pad-cloud client (TASK-690). Used by
 				// handleDeleteAccount to cancel Stripe subscriptions + delete

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -61,6 +61,15 @@ type Config struct {
 	CloudSidecarURL     string `toml:"cloud_sidecar_url"`     // Base URL pad uses to call the pad-cloud sidecar (reverse direction, e.g. Stripe cancel-customer on account delete)
 	CloudOutboundSecret string `toml:"cloud_outbound_secret"` // Optional: exact secret to send when calling pad-cloud. Falls back to the LAST entry of CloudSecret (the older rotation value, which is what pad-cloud is usually running). See DEPLOY.md "Cloud secret rotation".
 
+	// MCP remote-transport surface (PLAN-943 TASK-950). Optional even
+	// in cloud mode — leaving them empty in dev lets the discovery doc
+	// + WWW-Authenticate header fall back to the request Host. In
+	// production, set them to the canonical public URLs so the
+	// metadata document matches the cert and the URL agents paste into
+	// Claude Desktop.
+	MCPPublicURL  string `toml:"mcp_public_url"`  // Canonical URL of the MCP vhost, e.g. https://mcp.getpad.dev. Concatenated with /mcp + /.well-known/oauth-protected-resource.
+	AuthServerURL string `toml:"auth_server_url"` // Canonical URL of the OAuth authorization server (TASK-951), e.g. https://app.getpad.dev. Embedded in protected-resource metadata's authorization_servers field.
+
 	// Encryption
 	EncryptionKey       string `toml:"encryption_key"` // 32-byte hex-encoded AES-256 key for encrypting sensitive fields
 	EncryptionKeySource string `toml:"-"`              // "env", "file", "generated", or "" (unset); populated by EnsureEncryptionKey
@@ -197,6 +206,12 @@ func Load() (*Config, error) {
 	}
 	if v := os.Getenv("PAD_CLOUD_OUTBOUND_SECRET"); v != "" {
 		cfg.CloudOutboundSecret = v
+	}
+	if v := os.Getenv("PAD_MCP_PUBLIC_URL"); v != "" {
+		cfg.MCPPublicURL = v
+	}
+	if v := os.Getenv("PAD_AUTH_SERVER_URL"); v != "" {
+		cfg.AuthServerURL = v
 	}
 	if v := os.Getenv("PAD_ENCRYPTION_KEY"); v != "" {
 		cfg.EncryptionKey = v

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -426,8 +426,16 @@ func TestPublicURLNotPersistedToTOML(t *testing.T) {
 	if strings.Contains(string(raw), "https://app.example.com") {
 		t.Fatalf("config.toml must not persist PUBLIC_URL value:\n%s", raw)
 	}
-	if strings.Contains(string(raw), "public_url") {
-		t.Fatalf("config.toml must not contain a public_url key:\n%s", raw)
+	// Anchor on the TOML key form (key + " =") so adjacent keys with
+	// "public_url" as a substring (e.g. mcp_public_url) don't trip the
+	// assertion. This test is specifically guarding the PUBLIC_URL env
+	// → cfg.PublicURL → file regression — the substring check would
+	// otherwise produce false positives as the schema grows.
+	for _, line := range strings.Split(string(raw), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "public_url ") || strings.HasPrefix(trimmed, "public_url=") {
+			t.Fatalf("config.toml must not contain a public_url key:\n%s", raw)
+		}
 	}
 	// The persisted url= key (PAD_URL/--url path) should still be present.
 	if !strings.Contains(string(raw), "https://api.example.com") {

--- a/internal/mcp/dispatch_http.go
+++ b/internal/mcp/dispatch_http.go
@@ -342,21 +342,11 @@ func (d *HTTPHandlerDispatcher) Dispatch(ctx context.Context, cmdPath, _ []strin
 // special-case methods (dispatchItemUpdate, future RMW commands) can
 // reuse the same auth-context + recorder + response-shaping path.
 //
-// Scope enforcement:
-//
-// MCPBearerAuth stashes the API token's scopes string in context via
-// server.WithTokenScopes. Synthesizing the in-process request via
-// server.WithCurrentUser bypasses TokenAuth's chain-level
-// tokenScopeAllows check (TokenAuth short-circuits when currentUser
-// is already set), so we re-check scope here per synthesized request.
-// Without this, a PAT with scope `["read"]` could drive write tools
-// (POST/PATCH/DELETE) because the in-process request looks
-// pre-authenticated to the handler tree. Codex review #369 round 1.
-//
-// The scope check uses the request's actual HTTP method, not the
-// MCP cmdKey, so a `read`-scoped token can still drive read-only
-// tools (project dashboard, item show, search) while writes are
-// rejected with a structured permission_denied error envelope.
+// Scope enforcement lives in buildAuthedRequest (called below) so it
+// applies uniformly to every synthesized request — including
+// bulk-update's per-item PATCH and the RMW prefetches that don't go
+// through this method. Codex review #369 round 2 caught the leak that
+// motivated centralizing the check.
 func (d *HTTPHandlerDispatcher) executeRequest(
 	ctx context.Context,
 	cmdKey string,
@@ -364,13 +354,6 @@ func (d *HTTPHandlerDispatcher) executeRequest(
 	method, urlPath string,
 	body []byte,
 ) (*mcp.CallToolResult, error) {
-	if scopes := server.TokenScopesFromContext(ctx); !server.TokenScopeAllows(scopes, method, urlPath) {
-		return mcp.NewToolResultErrorf(
-			"%s: permission_denied — token scope does not permit %s on this resource",
-			cmdKey, method,
-		), nil
-	}
-
 	req, err := d.buildAuthedRequest(ctx, method, urlPath, body, user)
 	if err != nil {
 		return mcp.NewToolResultErrorf("%s: build request: %s", cmdKey, err.Error()), nil
@@ -393,12 +376,32 @@ func (d *HTTPHandlerDispatcher) executeRequest(
 // middleware attached workspace-allow-list context via Apply, the
 // prefetches were bypassing that and could read members / items
 // outside the allowed set during resolution.
+//
+// Scope enforcement (Codex review #369 rounds 1+2):
+//
+// Every synthesized request — main writes, RMW prefetches,
+// bulk-update per-item PATCHes, link-create POSTs — passes through
+// here, so this is the single place to enforce the API token's
+// scope. The MCP middleware (MCPBearerAuth) stashes
+// apiToken.Scopes in context via server.WithTokenScopes; we read
+// them here and call server.TokenScopeAllows. Reads
+// (GET/HEAD/OPTIONS) under a `["read"]` scope still pass; writes
+// fail with a "permission_denied" error that flows up through
+// each caller's existing build-error handling.
+//
+// Centralizing here closes the gap Codex round 2 found in
+// dispatch_http_project.go's bulk-update path (PATCH issued
+// directly via buildAuthedRequest + ServeHTTP, bypassing
+// executeRequest's previous scope check).
 func (d *HTTPHandlerDispatcher) buildAuthedRequest(
 	ctx context.Context,
 	method, urlPath string,
 	body []byte,
 	user *models.User,
 ) (*http.Request, error) {
+	if scopes := server.TokenScopesFromContext(ctx); !server.TokenScopeAllows(scopes, method, urlPath) {
+		return nil, fmt.Errorf("permission_denied: token scope does not permit %s on this resource", method)
+	}
 	req, err := buildHTTPRequest(ctx, method, urlPath, body, user)
 	if err != nil {
 		return nil, err

--- a/internal/mcp/dispatch_http.go
+++ b/internal/mcp/dispatch_http.go
@@ -341,6 +341,22 @@ func (d *HTTPHandlerDispatcher) Dispatch(ctx context.Context, cmdPath, _ []strin
 // against the wrapped handler. Pulled out of Dispatch so the
 // special-case methods (dispatchItemUpdate, future RMW commands) can
 // reuse the same auth-context + recorder + response-shaping path.
+//
+// Scope enforcement:
+//
+// MCPBearerAuth stashes the API token's scopes string in context via
+// server.WithTokenScopes. Synthesizing the in-process request via
+// server.WithCurrentUser bypasses TokenAuth's chain-level
+// tokenScopeAllows check (TokenAuth short-circuits when currentUser
+// is already set), so we re-check scope here per synthesized request.
+// Without this, a PAT with scope `["read"]` could drive write tools
+// (POST/PATCH/DELETE) because the in-process request looks
+// pre-authenticated to the handler tree. Codex review #369 round 1.
+//
+// The scope check uses the request's actual HTTP method, not the
+// MCP cmdKey, so a `read`-scoped token can still drive read-only
+// tools (project dashboard, item show, search) while writes are
+// rejected with a structured permission_denied error envelope.
 func (d *HTTPHandlerDispatcher) executeRequest(
 	ctx context.Context,
 	cmdKey string,
@@ -348,6 +364,13 @@ func (d *HTTPHandlerDispatcher) executeRequest(
 	method, urlPath string,
 	body []byte,
 ) (*mcp.CallToolResult, error) {
+	if scopes := server.TokenScopesFromContext(ctx); !server.TokenScopeAllows(scopes, method, urlPath) {
+		return mcp.NewToolResultErrorf(
+			"%s: permission_denied — token scope does not permit %s on this resource",
+			cmdKey, method,
+		), nil
+	}
+
 	req, err := d.buildAuthedRequest(ctx, method, urlPath, body, user)
 	if err != nil {
 		return mcp.NewToolResultErrorf("%s: build request: %s", cmdKey, err.Error()), nil

--- a/internal/mcp/dispatch_http_test.go
+++ b/internal/mcp/dispatch_http_test.go
@@ -48,9 +48,15 @@ func (h *recordingHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	h.gotPath = r.URL.Path
 	h.contentType = r.Header.Get("Content-Type")
 
-	body, _ := io.ReadAll(r.Body)
-	h.gotBody = string(body)
-	defer r.Body.Close()
+	// GET / DELETE requests synthesized by buildHTTPRequest have nil
+	// r.Body (no payload to send). Guard so the test handler is
+	// usable for both the create-with-body and the list-without-body
+	// dispatcher paths.
+	if r.Body != nil {
+		body, _ := io.ReadAll(r.Body)
+		h.gotBody = string(body)
+		_ = r.Body.Close()
+	}
 
 	// Pull whatever the dispatcher attached via server.WithCurrentUser
 	// + server.WithAPITokenAuth. Going through exported helpers keeps
@@ -166,6 +172,116 @@ func TestHTTPHandlerDispatcher_RoutesItemCreate(t *testing.T) {
 	}
 	if !rec.gotIsAPITok {
 		t.Errorf("isAPIToken not set; auth context missing")
+	}
+}
+
+// TestHTTPHandlerDispatcher_ScopeEnforcement_RejectsReadScopeOnWrites
+// pins the security fix from Codex review #369 round 1: a PAT with
+// scopes `["read"]` must not drive write tools through the in-process
+// dispatcher.
+//
+// Background: MCPBearerAuth used to skip tokenScopeAllows entirely.
+// The dispatcher's synthesized request bypasses TokenAuth's chain-
+// level check (because WithCurrentUser is already set), so without
+// the executeRequest scope re-check, a read-scoped token could POST
+// item create / PATCH item update / DELETE item — silently. The
+// fix stashes scopes in MCPBearerAuth via server.WithTokenScopes
+// and re-checks per synthesized request here.
+func TestHTTPHandlerDispatcher_ScopeEnforcement_RejectsReadScopeOnWrites(t *testing.T) {
+	user := &models.User{ID: "user-1", Name: "Dave", Email: "dave@example.com"}
+	rec := &recordingHandler{t: t}
+
+	d := &HTTPHandlerDispatcher{
+		Handler:      rec,
+		UserResolver: fixedUserResolver(user),
+	}
+
+	// Read-only scope in context — simulates what MCPBearerAuth
+	// stashes for a `["read"]` PAT.
+	ctx := server.WithTokenScopes(context.Background(), `["read"]`)
+	ctx = WithDispatchInput(ctx, map[string]any{
+		"workspace":  "docapp",
+		"collection": "tasks",
+		"title":      "Should Be Rejected",
+	})
+
+	res, err := d.Dispatch(ctx, []string{"item", "create"}, nil)
+	if err != nil {
+		t.Fatalf("Dispatch: %v", err)
+	}
+	if !res.IsError {
+		t.Fatalf("expected IsError result for read-scoped POST; got success: %#v", res)
+	}
+	if rec.requestCount != 0 {
+		t.Errorf("handler must not be invoked when scope check fails (defense in depth); got %d calls", rec.requestCount)
+	}
+	// The error envelope must mention permission_denied so agents can
+	// branch on the code rather than parse free-text.
+	var msg string
+	if len(res.Content) > 0 {
+		if tc, ok := res.Content[0].(mcp.TextContent); ok {
+			msg = tc.Text
+		}
+	}
+	if !strings.Contains(msg, "permission_denied") {
+		t.Errorf("error envelope missing permission_denied marker: %q", msg)
+	}
+}
+
+// TestHTTPHandlerDispatcher_ScopeEnforcement_AllowsReadScopeOnReads
+// is the positive complement: a `["read"]` PAT can still call
+// read-only tools (project dashboard, item show, etc.) because their
+// synthesized HTTP method is GET.
+func TestHTTPHandlerDispatcher_ScopeEnforcement_AllowsReadScopeOnReads(t *testing.T) {
+	user := &models.User{ID: "user-1", Name: "Dave", Email: "dave@example.com"}
+	rec := &recordingHandler{t: t, wantStatus: http.StatusOK, respBody: `{"items":[]}`}
+
+	d := &HTTPHandlerDispatcher{
+		Handler:      rec,
+		UserResolver: fixedUserResolver(user),
+	}
+
+	ctx := server.WithTokenScopes(context.Background(), `["read"]`)
+	ctx = WithDispatchInput(ctx, map[string]any{"workspace": "docapp"})
+
+	// item list resolves to GET — read scope must allow it.
+	res, err := d.Dispatch(ctx, []string{"item", "list"}, nil)
+	if err != nil {
+		t.Fatalf("Dispatch: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("read-scoped GET should succeed; got error: %#v", res)
+	}
+	if rec.gotMethod != http.MethodGet {
+		t.Errorf("expected GET (precondition for the scope-allow path), got %q", rec.gotMethod)
+	}
+}
+
+// TestHTTPHandlerDispatcher_ScopeEnforcement_NoScopeContextAllows
+// pins the legacy/empty-context behaviour: when no scope is stashed
+// (e.g. the dispatcher is used outside the MCP middleware path, or
+// for tests that don't simulate a token), the scope check defers to
+// tokenScopeAllows's "" → allow-all branch. Without this, every
+// existing dispatcher test would break.
+func TestHTTPHandlerDispatcher_ScopeEnforcement_NoScopeContextAllows(t *testing.T) {
+	user := &models.User{ID: "user-1", Name: "Dave", Email: "dave@example.com"}
+	rec := &recordingHandler{t: t}
+
+	d := &HTTPHandlerDispatcher{
+		Handler:      rec,
+		UserResolver: fixedUserResolver(user),
+	}
+
+	// No WithTokenScopes call — empty scope falls through.
+	ctx := WithDispatchInput(context.Background(), map[string]any{
+		"workspace": "docapp", "collection": "tasks", "title": "OK",
+	})
+	res, err := d.Dispatch(ctx, []string{"item", "create"}, nil)
+	if err != nil {
+		t.Fatalf("Dispatch: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("empty scope must allow (legacy); got error: %#v", res)
 	}
 }
 

--- a/internal/mcp/dispatch_http_test.go
+++ b/internal/mcp/dispatch_http_test.go
@@ -257,6 +257,77 @@ func TestHTTPHandlerDispatcher_ScopeEnforcement_AllowsReadScopeOnReads(t *testin
 	}
 }
 
+// TestHTTPHandlerDispatcher_ScopeEnforcement_BulkUpdateBlockedOnReadScope
+// pins the round-2 fix Codex caught: bulk-update used to call
+// buildAuthedRequest + d.Handler.ServeHTTP directly for the per-item
+// PATCH, bypassing the executeRequest scope check that round 1
+// added. Centralizing the check inside buildAuthedRequest closes the
+// gap — every synthesized request, no matter the caller, is gated.
+//
+// The expected behavior with `["read"]` scope: each ref's GET
+// prefetch succeeds (read scope allows GET), but the subsequent
+// PATCH fails at request-build time with permission_denied. The
+// per-item error envelope carries the message; the bulk operation
+// returns successfully with all-errors recorded (the "no abort on
+// per-item failure" contract is unchanged).
+func TestHTTPHandlerDispatcher_ScopeEnforcement_BulkUpdateBlockedOnReadScope(t *testing.T) {
+	user := &models.User{ID: "user-1"}
+
+	// Test handler: respond 200 with a minimal item JSON to GET (so
+	// the prefetch parses), 200 to anything else. We only care that
+	// PATCH never reaches the handler — the scope gate must reject
+	// before ServeHTTP runs.
+	patchSeen := false
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPatch {
+			patchSeen = true
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"fields":"{\"status\":\"open\"}"}`))
+	})
+
+	d := &HTTPHandlerDispatcher{
+		Handler:      h,
+		UserResolver: fixedUserResolver(user),
+	}
+
+	ctx := server.WithTokenScopes(context.Background(), `["read"]`)
+
+	res, err := d.dispatchItemBulkUpdate(ctx, map[string]any{
+		"workspace": "docapp",
+		"ref":       []any{"TASK-1", "TASK-2"},
+		"status":    "done",
+	}, user)
+	if err != nil {
+		t.Fatalf("dispatchItemBulkUpdate: %v", err)
+	}
+	if patchSeen {
+		t.Fatal("PATCH must not reach the handler when scope check fails (regression: round-2 fix removed the gap)")
+	}
+	if res.IsError {
+		t.Fatalf("bulk-update returns success with per-item errors recorded; got top-level IsError: %#v", res)
+	}
+
+	// Pull the structured result out and confirm both refs carry a
+	// permission_denied error in their per-item entry. We accept any
+	// reasonable wrapping of "permission_denied" in the message string.
+	var content string
+	if len(res.Content) > 0 {
+		if tc, ok := res.Content[0].(mcp.TextContent); ok {
+			content = tc.Text
+		}
+	}
+	for _, ref := range []string{"TASK-1", "TASK-2"} {
+		if !strings.Contains(content, ref) {
+			t.Errorf("expected per-item entry for %s in result; got %q", ref, content)
+		}
+	}
+	if !strings.Contains(content, "permission_denied") {
+		t.Errorf("expected permission_denied in per-item errors; got %q", content)
+	}
+}
+
 // TestHTTPHandlerDispatcher_ScopeEnforcement_NoScopeContextAllows
 // pins the legacy/empty-context behaviour: when no scope is stashed
 // (e.g. the dispatcher is used outside the MCP middleware path, or

--- a/internal/server/context.go
+++ b/internal/server/context.go
@@ -72,3 +72,52 @@ func IsAPITokenFromContext(ctx context.Context) bool {
 	v, _ := ctx.Value(ctxIsAPIToken).(bool)
 	return v
 }
+
+// WithTokenScopes returns ctx decorated with the API token's
+// JSON-encoded scopes string (e.g. `["read"]`, `["*"]`). Stashed by
+// the MCP Bearer middleware so the in-process dispatcher
+// (internal/mcp/dispatch_http.go) can enforce per-tool scope checks
+// — the dispatcher bypasses the standard TokenAuth chain by setting
+// WithCurrentUser directly, so the chain-level scope check at
+// middleware_auth.go:TokenAuth doesn't run for synthesized requests.
+//
+// Without this, a PAT with scope `["read"]` could drive write MCP
+// tools because the in-process request looks pre-authenticated to
+// the handler tree. Codex review #369 round 1 flagged the gap.
+//
+// Empty string clears any previously set scope.
+func WithTokenScopes(ctx context.Context, scopes string) context.Context {
+	return context.WithValue(ctx, ctxTokenScopes, scopes)
+}
+
+// TokenScopesFromContext returns the JSON-encoded scopes attached by
+// WithTokenScopes, or "" if none. Empty maps to "unrestricted" in
+// TokenScopeAllows (the legacy behaviour) — callers wanting
+// strict-deny on the unset path must check the empty-string branch
+// before passing it on.
+func TokenScopesFromContext(ctx context.Context) string {
+	v, _ := ctx.Value(ctxTokenScopes).(string)
+	return v
+}
+
+// TokenScopeAllows is the exported wrapper around the package-private
+// tokenScopeAllows: returns true iff the scopes JSON permits the given
+// HTTP method against path. Public so internal/mcp/dispatch_http.go
+// can re-check scopes on each synthesized tool call without
+// reimplementing the policy.
+//
+// Policy summary (see tokenScopeAllows for the full doc):
+//
+//   - "" or `["*"]`        → allow all methods (legacy / explicit wildcard).
+//   - `["read"]`           → allow GET / HEAD / OPTIONS only.
+//   - `["write"]`          → allow all methods.
+//   - explicit `[]`        → allow all methods (legacy unrestricted form).
+//   - unparseable / null   → deny.
+//   - unknown scope only   → deny (policy-relevant unknowns are logged).
+//
+// Caller is expected to be the in-process MCP dispatcher; the
+// chain-level enforcement on /api/v1/* still runs through tokenScopeAllows
+// directly.
+func TokenScopeAllows(scopesJSON, method, path string) bool {
+	return tokenScopeAllows(scopesJSON, method, path)
+}

--- a/internal/server/handlers_mcp.go
+++ b/internal/server/handlers_mcp.go
@@ -1,0 +1,112 @@
+package server
+
+import (
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// MCP transport state. Set at startup by cmd/pad/main.go via
+// SetMCPTransport when the deployment is in cloud mode (PAD_MODE=cloud).
+// Self-hosted deployments leave mcpTransport nil and the routes below
+// don't mount, so the binary stays free of MCP-server overhead unless
+// it's actually serving the public /mcp surface.
+//
+// Why these fields live on Server (not in a separate sub-struct):
+//
+// They're cheap (one pointer + two strings), plumbed through
+// setupRouter which already lives on Server, and read by both the
+// /mcp middleware (mcpPublicURL for WWW-Authenticate) and the
+// /.well-known handlers (both URLs for the discovery doc). A nested
+// struct would add an indirection without saving any clarity.
+//
+// Why they aren't on the routes themselves (closure-captured):
+//
+// setupRouter runs once via routerOnce; SetMCPTransport must be called
+// BEFORE setupRouter to take effect. We document that contract in
+// SetMCPTransport's comment and rely on the cmd/pad/main.go startup
+// order. Capturing in closure would make that ordering invisible —
+// the Server-field path is easier to reason about.
+
+// SetMCPTransport wires the Streamable HTTP MCP server onto pad's
+// router. Called once at startup by cmd/pad/main.go after the MCP
+// server, dispatcher, and tool catalog have been constructed.
+//
+// transport is the http.Handler returned by mcp-go's
+// NewStreamableHTTPServer — it owns request decoding, JSON-RPC
+// dispatch, and tool-call execution. This file's job is just to mount
+// it under the right auth middleware on the right route.
+//
+// mcpPublicURL is the canonical public URL of the MCP vhost, e.g.
+// "https://mcp.getpad.dev". Used by:
+//
+//   - handleOAuthProtectedResource to populate the "resource" field
+//     of the discovery doc (concatenates "/mcp").
+//   - writeMCPUnauthorized to populate the WWW-Authenticate header's
+//     "resource_metadata" parameter (concatenates
+//     "/.well-known/oauth-protected-resource").
+//
+// authServerURL is the canonical URL of the OAuth authorization
+// server, e.g. "https://app.getpad.dev". Used by
+// handleOAuthProtectedResource to populate "authorization_servers".
+//
+// Both URLs may be left empty in development; the handlers fall back
+// to the request's Host header with a best-effort mcp.→app. rewrite
+// (see rewriteMcpSubdomain). Production deployments should always set
+// PAD_MCP_PUBLIC_URL and PAD_AUTH_SERVER_URL so the discovery
+// document's URLs match the cert + the URL agents paste into Claude.
+//
+// MUST be called before the first request hits the server, i.e.
+// before ListenAndServe. Setting this after setupRouter has already
+// run is a no-op (chi routes are immutable post-mount); the Server
+// silently accepts the call to avoid breaking tests that wire
+// transport state into a Server they then never start, but the
+// `routerOnce.Do` ordering in ensureRouter means production traffic
+// would just see 404s on /mcp.
+func (s *Server) SetMCPTransport(transport http.Handler, mcpPublicURL, authServerURL string) {
+	s.mcpTransport = transport
+	s.mcpPublicURL = mcpPublicURL
+	s.mcpAuthServerURL = authServerURL
+}
+
+// registerMCPRoutes installs the /mcp + /.well-known endpoints on r,
+// gated by cloud mode. Called from setupRouter at infrastructure-
+// middleware level (NOT inside the API group), because:
+//
+//   - /mcp uses Bearer auth (its own middleware), bypassing TokenAuth /
+//     SessionAuth / CSRFProtect / RequireAuth — those are designed for
+//     the SPA + CLI surface and produce a different 401 envelope.
+//   - /.well-known/* are public discovery documents (RFC 9728 §3
+//     "MUST be available without authentication"). Putting them inside
+//     the auth-required API group would force a special-case exemption.
+//
+// Routes mount only when SetMCPTransport has been called AND cloud mode
+// is enabled. Self-hosted deployments with no cloud secret skip this
+// entirely; deployments running cloud mode without the MCP transport
+// wired (e.g. someone testing a build with PAD_MCP_PUBLIC_URL unset)
+// also skip. No 404 leaks in either case — the routes simply don't
+// exist on the chi tree.
+//
+// Why a Get on /mcp (not just Post): MCP Streamable HTTP supports
+// GET for server-initiated SSE streams (mcp-go's StreamableHTTPServer
+// handles both methods). Mounting via chi's Method-agnostic Mount
+// would also catch DELETE (session-end notifications). Use the same
+// Mount the streamable_http server expects.
+func (s *Server) registerMCPRoutes(r chi.Router) {
+	if s.mcpTransport == nil || !s.IsCloud() {
+		return
+	}
+
+	// /mcp — gated by Bearer auth, no CSRF (Bearer auth is immune),
+	// no rate limit yet (TASK-959 wires that). The streamable HTTP
+	// server handles all methods (POST handshake/calls, GET for SSE
+	// streams, DELETE for session termination), so we Mount() rather
+	// than registering per-method.
+	r.With(s.requireCloudMode, s.MCPBearerAuth).Mount("/mcp", s.mcpTransport)
+
+	// Discovery endpoints — unauthenticated, cloud-mode-gated. RFC 9728
+	// (protected-resource) gets the real metadata; RFC 8414 (auth-server)
+	// is the 501 stub TASK-951 fills in.
+	r.With(s.requireCloudMode).Get("/.well-known/oauth-protected-resource", s.handleOAuthProtectedResource)
+	r.With(s.requireCloudMode).Get("/.well-known/oauth-authorization-server", s.handleOAuthAuthorizationServerStub)
+}

--- a/internal/server/handlers_mcp_test.go
+++ b/internal/server/handlers_mcp_test.go
@@ -233,6 +233,128 @@ func TestMCP_ValidPAT_ReachesTransport(t *testing.T) {
 // A unit test against extractBearer + a fake store interface is the
 // right shape if someone adds tests for this branch later.
 
+// TestMCP_NoToken_FallsBackToHostWhenPublicURLUnset pins the
+// regression Codex review #369 round 1 caught: when PAD_MCP_PUBLIC_URL
+// is unset, writeMCPUnauthorized used to drop the WWW-Authenticate
+// header entirely, which breaks fresh-client discovery on cloud-mode
+// deploys that hadn't configured the public URL yet. The fallback
+// derives "https://" + r.Host so the discovery handshake completes.
+func TestMCP_NoToken_FallsBackToHostWhenPublicURLUnset(t *testing.T) {
+	srv := testServer(t)
+	srv.SetCloudMode("test-secret")
+	stub := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	// Both URLs intentionally empty — simulates a cloud deploy that
+	// hasn't set PAD_MCP_PUBLIC_URL / PAD_AUTH_SERVER_URL yet.
+	srv.SetMCPTransport(stub, "", "")
+
+	req := httptest.NewRequest("POST", "/mcp", strings.NewReader(`{}`))
+	req.Host = "mcp.test.local"
+	req.RemoteAddr = "192.0.2.1:1234"
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", rr.Code)
+	}
+	wwwAuth := rr.Header().Get("WWW-Authenticate")
+	if wwwAuth == "" {
+		t.Fatal("WWW-Authenticate must be set even when PAD_MCP_PUBLIC_URL is unset; got empty header")
+	}
+	wantSubstring := `resource_metadata="https://mcp.test.local/.well-known/oauth-protected-resource"`
+	if !strings.Contains(wwwAuth, wantSubstring) {
+		t.Errorf("expected fallback resource_metadata derived from r.Host, got %q", wwwAuth)
+	}
+}
+
+// TestMCP_ReadScopedPAT_RejectedOnWriteTool pins the security fix
+// for Codex review #369 round 1 finding 1: a PAT with scopes
+// `["read"]` must NOT be able to drive write tools through /mcp.
+// MCPBearerAuth used to skip tokenScopeAllows entirely; the
+// dispatcher's synthesized in-process request bypassed TokenAuth's
+// chain-level check too, so a read-scoped token could perform writes
+// silently. The fix stashes scopes via server.WithTokenScopes in
+// MCPBearerAuth and re-checks them per synthesized request in
+// HTTPHandlerDispatcher.executeRequest. This test exercises the
+// MCPBearerAuth-side stash; the dispatcher enforcement is unit-
+// tested in internal/mcp/dispatch_http_test.go.
+func TestMCP_ReadScopedPAT_StashesScopesInContext(t *testing.T) {
+	srv := testServer(t)
+
+	user, err := srv.store.CreateUser(models.UserCreate{
+		Email: "scope-test@example.com", Name: "Scope Tester", Password: "pw-test-12345",
+	})
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	ws, err := srv.store.CreateWorkspace(models.WorkspaceCreate{Name: "Scope Test WS"})
+	if err != nil {
+		t.Fatalf("CreateWorkspace: %v", err)
+	}
+	tok, err := srv.store.CreateAPIToken(user.ID, models.APITokenCreate{
+		Name:        "read-only-pat",
+		WorkspaceID: ws.ID,
+		Scopes:      `["read"]`,
+	}, 30, 0)
+	if err != nil {
+		t.Fatalf("CreateAPIToken: %v", err)
+	}
+
+	// Stub transport reads scopes from context to confirm they
+	// arrived. Without the WithTokenScopes call in MCPBearerAuth,
+	// the assertion fails — pinning the fix.
+	var seenScopes string
+	stub := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenScopes = TokenScopesFromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+	srv.SetCloudMode("test-secret")
+	srv.SetMCPTransport(stub, "https://mcp.test.example", "https://app.test.example")
+
+	req := httptest.NewRequest("POST", "/mcp", strings.NewReader(`{}`))
+	req.Header.Set("Authorization", "Bearer "+tok.Token)
+	req.RemoteAddr = "192.0.2.1:1234"
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 (auth passes — scope check is dispatcher-side), got %d", rr.Code)
+	}
+	if seenScopes != `["read"]` {
+		t.Errorf("expected scopes to round-trip via WithTokenScopes; got %q want `[\"read\"]`", seenScopes)
+	}
+}
+
+// TestTokenScopeAllows_PublicWrapper sanity-checks that the exported
+// helper preserves the policy (so the dispatcher can rely on it).
+// Specifically pins the read-vs-write decision the security finding
+// cared about.
+func TestTokenScopeAllows_PublicWrapper(t *testing.T) {
+	cases := []struct {
+		name           string
+		scopes, method string
+		want           bool
+	}{
+		{"read scope on GET", `["read"]`, "GET", true},
+		{"read scope on POST", `["read"]`, "POST", false},
+		{"read scope on PATCH", `["read"]`, "PATCH", false},
+		{"read scope on DELETE", `["read"]`, "DELETE", false},
+		{"write scope on POST", `["write"]`, "POST", true},
+		{"wildcard on POST", `["*"]`, "POST", true},
+		{"empty scopes (legacy) on POST", "", "POST", true},
+		{"unparseable denies", `not-json`, "GET", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := TokenScopeAllows(tc.scopes, tc.method, "/api/v1/anything")
+			if got != tc.want {
+				t.Errorf("TokenScopeAllows(%q, %s) = %v, want %v", tc.scopes, tc.method, got, tc.want)
+			}
+		})
+	}
+}
+
 // mcpEnabledTestServer builds a Server with cloud mode + a stub
 // streamable-HTTP transport so tests targeting auth / discovery /
 // routing don't need to drive a full MCP handshake. The stub returns

--- a/internal/server/handlers_mcp_test.go
+++ b/internal/server/handlers_mcp_test.go
@@ -1,0 +1,268 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// TestMCP_CloudModeOff_RoutesAbsent verifies the negative case:
+// when cloud mode is NOT enabled, every MCP-related route returns
+// 404. This is the self-hosted contract — the binary stays free of
+// MCP-server overhead unless an operator explicitly opts in.
+func TestMCP_CloudModeOff_RoutesAbsent(t *testing.T) {
+	srv := testServer(t)
+	// Cloud mode deliberately not set; SetMCPTransport never called.
+
+	cases := []struct {
+		method, path string
+	}{
+		{"POST", "/mcp"},
+		{"GET", "/.well-known/oauth-protected-resource"},
+		{"GET", "/.well-known/oauth-authorization-server"},
+	}
+	for _, tc := range cases {
+		rr := doRequest(srv, tc.method, tc.path, nil)
+		if rr.Code != http.StatusNotFound {
+			t.Errorf("%s %s: expected 404 with cloud mode off, got %d (body: %s)",
+				tc.method, tc.path, rr.Code, rr.Body.String())
+		}
+	}
+}
+
+// TestMCP_CloudModeOnButTransportNotWired_RoutesAbsent guards against
+// the regression where someone enables cloud mode but forgets to call
+// SetMCPTransport. The route group is gated on BOTH conditions; this
+// pins the AND.
+func TestMCP_CloudModeOnButTransportNotWired_RoutesAbsent(t *testing.T) {
+	srv := testServer(t)
+	srv.SetCloudMode("test-secret")
+	// Note: SetMCPTransport NOT called.
+
+	rr := doRequest(srv, "POST", "/mcp", nil)
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("expected 404 when transport not wired, got %d", rr.Code)
+	}
+}
+
+// TestMCP_DiscoveryDoc_PopulatedFromConfig verifies the protected-
+// resource metadata document echoes the URLs we hand SetMCPTransport
+// (no host-derived fallback). Pinning this prevents a regression
+// where a config change makes the doc emit fallback values that don't
+// match the cert in production.
+func TestMCP_DiscoveryDoc_PopulatedFromConfig(t *testing.T) {
+	srv := mcpEnabledTestServer(t)
+
+	rr := doRequest(srv, "GET", "/.well-known/oauth-protected-resource", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+	if ct := rr.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("expected Content-Type application/json, got %q", ct)
+	}
+	if cc := rr.Header().Get("Cache-Control"); cc == "" {
+		t.Errorf("expected Cache-Control header on discovery doc, got empty")
+	}
+
+	var doc protectedResourceMetadata
+	parseJSON(t, rr, &doc)
+
+	if doc.Resource != "https://mcp.test.example/mcp" {
+		t.Errorf("Resource: got %q, want %q", doc.Resource, "https://mcp.test.example/mcp")
+	}
+	if len(doc.AuthorizationServers) != 1 || doc.AuthorizationServers[0] != "https://app.test.example" {
+		t.Errorf("AuthorizationServers: got %v, want [https://app.test.example]", doc.AuthorizationServers)
+	}
+	wantScopes := []string{"pad:read", "pad:write", "pad:admin"}
+	if !sliceEqual(doc.ScopesSupported, wantScopes) {
+		t.Errorf("ScopesSupported: got %v, want %v", doc.ScopesSupported, wantScopes)
+	}
+	if !sliceEqual(doc.BearerMethodsSupported, []string{"header"}) {
+		t.Errorf("BearerMethodsSupported: got %v, want [header]", doc.BearerMethodsSupported)
+	}
+}
+
+// TestMCP_AuthServerStub_Returns501 confirms the RFC 8414 stub mounts
+// alongside the protected-resource doc. Once TASK-951 lands and fills
+// in real metadata, this test will be replaced with a positive doc-
+// shape assertion.
+func TestMCP_AuthServerStub_Returns501(t *testing.T) {
+	srv := mcpEnabledTestServer(t)
+
+	rr := doRequest(srv, "GET", "/.well-known/oauth-authorization-server", nil)
+	if rr.Code != http.StatusNotImplemented {
+		t.Errorf("expected 501 stub, got %d", rr.Code)
+	}
+	if ra := rr.Header().Get("Retry-After"); ra == "" {
+		t.Errorf("expected Retry-After header on 501 stub, got empty")
+	}
+}
+
+// TestMCP_NoToken_Returns401WithWWWAuthenticate covers the most
+// important MCP discovery-flow case: a fresh client with no token hits
+// /mcp and gets the spec-shaped 401 + WWW-Authenticate that points
+// them at the discovery doc. Without this, Claude Desktop refuses to
+// proceed past the first request.
+func TestMCP_NoToken_Returns401WithWWWAuthenticate(t *testing.T) {
+	srv := mcpEnabledTestServer(t)
+
+	rr := doRequest(srv, "POST", "/mcp", map[string]any{
+		"jsonrpc": "2.0", "id": 1, "method": "initialize",
+	})
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 with no token, got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+	wwwAuth := rr.Header().Get("WWW-Authenticate")
+	if wwwAuth == "" {
+		t.Fatal("expected WWW-Authenticate header on 401, got empty")
+	}
+	if !strings.Contains(wwwAuth, `Bearer realm="pad"`) {
+		t.Errorf("WWW-Authenticate missing Bearer realm: %q", wwwAuth)
+	}
+	if !strings.Contains(wwwAuth, `resource_metadata="https://mcp.test.example/.well-known/oauth-protected-resource"`) {
+		t.Errorf("WWW-Authenticate missing resource_metadata pointing at discovery doc: %q", wwwAuth)
+	}
+}
+
+// TestMCP_BadTokenFormat_Returns401WithWWWAuthenticate covers the
+// same envelope shape for a bearer that isn't even shaped like a pad
+// PAT. Format-rejection happens before the DB lookup.
+func TestMCP_BadTokenFormat_Returns401WithWWWAuthenticate(t *testing.T) {
+	srv := mcpEnabledTestServer(t)
+
+	req := httptest.NewRequest("POST", "/mcp", strings.NewReader(`{}`))
+	req.Header.Set("Authorization", "Bearer not-a-real-pad-token")
+	req.RemoteAddr = "192.0.2.1:1234"
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", rr.Code)
+	}
+	if rr.Header().Get("WWW-Authenticate") == "" {
+		t.Error("expected WWW-Authenticate header on 401 for bad-format token")
+	}
+}
+
+// TestMCP_ValidPAT_ReachesTransport confirms the happy path: a real
+// PAT for a real user authenticates, and the request reaches the
+// downstream MCP transport handler with the user attached to context.
+//
+// We replace the streamable-HTTP server with a tiny stub so the test
+// doesn't need to drive a full MCP handshake — the contract this
+// test pins is "auth + routing put the request in front of the
+// transport with the right user," not "the streamable transport
+// works" (mcp-go's own tests cover that).
+func TestMCP_ValidPAT_ReachesTransport(t *testing.T) {
+	srv := testServer(t)
+
+	user, err := srv.store.CreateUser(models.UserCreate{
+		Email:    "mcp-test@example.com",
+		Name:     "MCP Tester",
+		Password: "pw-test-12345",
+	})
+	if err != nil {
+		t.Fatalf("CreateUser: err=%v", err)
+	}
+	// PATs are stored with workspace_id NOT NULL (migration 011),
+	// so even user-owned tokens need a workspace handle. The auth
+	// middleware doesn't enforce token-workspace match for user-
+	// owned tokens — workspace membership is the gate (see
+	// middleware_auth.go:393) — but we still need a row that
+	// satisfies the FK.
+	ws, err := srv.store.CreateWorkspace(models.WorkspaceCreate{Name: "MCP Test WS"})
+	if err != nil {
+		t.Fatalf("CreateWorkspace: %v", err)
+	}
+	tok, err := srv.store.CreateAPIToken(user.ID, models.APITokenCreate{
+		Name:        "mcp-test-token",
+		WorkspaceID: ws.ID,
+	}, 30, 0)
+	if err != nil {
+		t.Fatalf("CreateAPIToken: err=%v", err)
+	}
+
+	// Stub transport: records that it was called + which user was
+	// attached. Assertions live in the stub so a misrouted request
+	// (e.g. anonymous reach) shows up as "stub never called" rather
+	// than a misleading 200.
+	var called bool
+	var seenUserID string
+	stub := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		if u, ok := CurrentUserFromContext(r.Context()); ok && u != nil {
+			seenUserID = u.ID
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{}}`))
+	})
+
+	srv.SetCloudMode("test-secret")
+	srv.SetMCPTransport(stub, "https://mcp.test.example", "https://app.test.example")
+
+	req := httptest.NewRequest("POST", "/mcp", strings.NewReader(`{"jsonrpc":"2.0","id":1}`))
+	req.Header.Set("Authorization", "Bearer "+tok.Token)
+	req.Header.Set("Content-Type", "application/json")
+	req.RemoteAddr = "192.0.2.1:1234"
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+	if !called {
+		t.Fatal("transport stub never called — auth or routing failed silently")
+	}
+	if seenUserID != user.ID {
+		t.Errorf("user not attached to transport context: got %q, want %q", seenUserID, user.ID)
+	}
+}
+
+// Note on legacy workspace-scoped tokens: MCPBearerAuth rejects PATs
+// that have no user_id (the pre-migration-012 path). We don't have a
+// full-stack test for that branch because the current api_tokens
+// schema (workspace_id NOT NULL + user_id FK to users) makes it
+// impossible to construct such a token via the public store API —
+// CreateAPIToken with userID="" fails the FK constraint, and there's
+// no SQL backdoor in the test helpers. The branch exists as defense
+// in depth for old rows that survived migration 012, and is
+// documented in MCPBearerAuth's comment (middleware_mcp_auth.go).
+// A unit test against extractBearer + a fake store interface is the
+// right shape if someone adds tests for this branch later.
+
+// mcpEnabledTestServer builds a Server with cloud mode + a stub
+// streamable-HTTP transport so tests targeting auth / discovery /
+// routing don't need to drive a full MCP handshake. The stub returns
+// 200 with an empty JSON-RPC success — sufficient to confirm "the
+// auth chain let the request through."
+func mcpEnabledTestServer(t *testing.T) *Server {
+	t.Helper()
+	srv := testServer(t)
+	srv.SetCloudMode("test-secret")
+	stub := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{}}`))
+	})
+	srv.SetMCPTransport(stub, "https://mcp.test.example", "https://app.test.example")
+	return srv
+}
+
+// sliceEqual reports whether a and b have the same elements in the
+// same order. Local tiny helper avoids pulling reflect.DeepEqual into
+// each assertion at call sites; the order assertion is intentional —
+// the MCP spec doesn't mandate scope order, but pinning it gives us
+// stable tests + matches the order our handler produces.
+func sliceEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/server/handlers_well_known.go
+++ b/internal/server/handlers_well_known.go
@@ -1,0 +1,138 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+)
+
+// handleOAuthProtectedResource serves RFC 9728 "OAuth 2.0 Protected
+// Resource Metadata" at /.well-known/oauth-protected-resource on the
+// MCP vhost (mcp.getpad.dev in production). Claude Desktop and other
+// MCP clients fetch this in response to a 401 + WWW-Authenticate from
+// /mcp; the document tells them which authorization server issues
+// tokens for this resource and which scopes / methods we accept.
+//
+// Spec: https://datatracker.ietf.org/doc/html/rfc9728
+//
+// The companion document (authorization-server metadata, RFC 8414)
+// lives on the auth-server vhost (app.getpad.dev) and is wired in
+// TASK-951; for TASK-950 the corresponding handler is a 501 stub
+// (see handleOAuthAuthorizationServerStub below) so MCP clients
+// hitting the discovery chain get a clear "not yet" rather than a
+// 404 that would look like a misconfigured deployment.
+//
+// This handler is mounted under the cloud-mode gate — self-hosted
+// deployments don't expose it (they don't host a public OAuth surface).
+// It's intentionally unauthenticated: discovery documents are public
+// by design (RFC 9728 §3 "MUST be available without authentication").
+//
+// Output:
+//
+//	{
+//	  "resource": "https://mcp.getpad.dev/mcp",
+//	  "authorization_servers": ["https://app.getpad.dev"],
+//	  "bearer_methods_supported": ["header"],
+//	  "scopes_supported": ["pad:read", "pad:write", "pad:admin"]
+//	}
+//
+// resource and authorization_servers come from runtime config wired at
+// startup via SetMCPTransport (cmd/pad/main.go reads PAD_MCP_PUBLIC_URL
+// and PAD_AUTH_SERVER_URL). When unset, we fall back to deriving from
+// the request scheme + host so local testing without those env vars
+// still produces a valid document; ops should always set them in
+// production so the doc matches the public URL the cert covers.
+func (s *Server) handleOAuthProtectedResource(w http.ResponseWriter, r *http.Request) {
+	resource := strings.TrimRight(s.mcpPublicURL, "/")
+	if resource == "" {
+		resource = "https://" + r.Host
+	}
+	resource = resource + "/mcp"
+
+	authServer := strings.TrimRight(s.mcpAuthServerURL, "/")
+	if authServer == "" {
+		// Fallback: assume the auth server lives at the same scheme +
+		// host as the request, with the mcp.* subdomain rewritten to
+		// app.* per PLAN-943 architecture. Imperfect — local dev
+		// against a single host won't have the rewrite — but better
+		// than emitting an empty list. Operators should set
+		// PAD_AUTH_SERVER_URL explicitly in production.
+		authServer = "https://" + rewriteMcpSubdomain(r.Host)
+	}
+
+	doc := protectedResourceMetadata{
+		Resource:               resource,
+		AuthorizationServers:   []string{authServer},
+		BearerMethodsSupported: []string{"header"},
+		// Scopes_supported is the full set we anticipate offering once
+		// TASK-953 lands the per-token allow-list. Listed here even
+		// though the PAT-first cut of TASK-950 doesn't enforce them —
+		// MCP clients use this set during DCR (TASK-951) to decide
+		// which scopes to request, so under-promising would force a
+		// doc update + cache invalidation when scope-aware tokens land.
+		ScopesSupported: []string{"pad:read", "pad:write", "pad:admin"},
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	// Cache-Control on a small, deploy-static document keeps repeat
+	// discovery requests off the backend. 1 hour is short enough that
+	// a deploy fixing the doc propagates quickly, long enough to
+	// absorb the chatter from a directory of MCP clients (Claude,
+	// Cursor, ChatGPT, …) all probing in parallel.
+	w.Header().Set("Cache-Control", "public, max-age=3600")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(doc)
+}
+
+// handleOAuthAuthorizationServerStub is the placeholder for RFC 8414
+// "OAuth 2.0 Authorization Server Metadata" on the auth-server vhost.
+// TASK-951 will fill this in with the real /oauth/{authorize, token,
+// register, revoke, introspect} endpoint URLs + supported response
+// types, grant types, PKCE methods, etc.
+//
+// We mount the stub now so the discovery chain is complete from the
+// MCP client's perspective: they hit /.well-known/oauth-protected-
+// resource (this PR), follow authorization_servers[0] to /.well-known/
+// oauth-authorization-server, and get a 501 with a clear message
+// rather than a 404 that would suggest misconfiguration.
+//
+// Once TASK-951 ships, replace the body with the real metadata
+// document.
+func (s *Server) handleOAuthAuthorizationServerStub(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	// Retry-After helps well-behaved clients back off rather than
+	// hammering us until TASK-951 lands. 3600 seconds is generous
+	// enough to absorb a deploy window without being annoyingly long.
+	w.Header().Set("Retry-After", "3600")
+	w.WriteHeader(http.StatusNotImplemented)
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"error":             "not_implemented",
+		"error_description": "OAuth authorization server is not yet enabled on this deployment. Tracked under PLAN-943 TASK-951.",
+	})
+}
+
+// protectedResourceMetadata is the RFC 9728 wire format. Field names
+// match the spec; only the four fields we actually populate are
+// declared — the rest of RFC 9728 (jwks_uri,
+// resource_signing_alg_values_supported, etc.) is optional and not
+// relevant to our opaque-token deployment.
+type protectedResourceMetadata struct {
+	Resource               string   `json:"resource"`
+	AuthorizationServers   []string `json:"authorization_servers"`
+	BearerMethodsSupported []string `json:"bearer_methods_supported"`
+	ScopesSupported        []string `json:"scopes_supported"`
+}
+
+// rewriteMcpSubdomain best-effort rewrites "mcp.<rest>" to "app.<rest>"
+// so the discovery doc's authorization_servers entry points at the
+// auth vhost when the operator hasn't set PAD_AUTH_SERVER_URL. If the
+// host doesn't start with "mcp.", returns it unchanged — useful for
+// local development against a single host (localhost:7777) where the
+// auth server and protected resource share an origin.
+func rewriteMcpSubdomain(host string) string {
+	const prefix = "mcp."
+	if strings.HasPrefix(host, prefix) {
+		return "app." + host[len(prefix):]
+	}
+	return host
+}

--- a/internal/server/middleware_auth.go
+++ b/internal/server/middleware_auth.go
@@ -28,6 +28,14 @@ const (
 	// ctxIsAPIToken is set to true when the request is authenticated via an API token
 	// (as opposed to a session cookie or CLI session token).
 	ctxIsAPIToken contextKey = "is_api_token"
+	// ctxTokenScopes carries the JSON-encoded scopes string from the
+	// validated API token (e.g. `["read"]`, `["*"]`). Stashed by
+	// MCPBearerAuth so the in-process MCP dispatcher can re-check
+	// scopes per synthesized tool call (the dispatcher bypasses
+	// TokenAuth's chain-level scope check by setting WithCurrentUser
+	// directly). See WithTokenScopes / TokenScopesFromContext in
+	// context.go and the per-tool gate in internal/mcp/dispatch_http.go.
+	ctxTokenScopes contextKey = "token_scopes"
 	// ctxResolvedWorkspaceID is set by RequireWorkspaceAccess after resolving
 	// the workspace slug/ID. Avoids redundant lookups in handlers.
 	ctxResolvedWorkspaceID contextKey = "resolved_workspace_id"

--- a/internal/server/middleware_mcp_auth.go
+++ b/internal/server/middleware_mcp_auth.go
@@ -1,0 +1,181 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+)
+
+// MCPBearerAuth is the auth gate for the /mcp Streamable HTTP endpoint.
+//
+// Behaviour, in order:
+//
+//  1. No Authorization header, or one that doesn't start with "Bearer " →
+//     401 with WWW-Authenticate per RFC 9728. The header points the
+//     client at our protected-resource discovery doc so it can begin
+//     the OAuth flow.
+//  2. Bearer token present but not a recognized format / not in the
+//     api_tokens table / expired → 401 with the same WWW-Authenticate
+//     header (so a stale token doesn't drop the client into a "token
+//     unrecognized" dead end — they re-discover and recover).
+//  3. Valid token → user attached to context via WithCurrentUser; next
+//     handler runs.
+//
+// Note for TASK-951:
+//
+// This middleware is the single integration point for OAuth-issued
+// tokens. The PAT-first cut shipping with TASK-950 calls
+// store.ValidateToken (the existing pad_*-prefixed PAT path); when
+// TASK-951 lands, this function gains a branch that tries OAuth
+// introspection first (RFC 7662 lookup against the auth-server's
+// /oauth/introspect endpoint) and falls back to PAT validation. The
+// 401 + WWW-Authenticate envelope below stays identical — only the
+// token-validation step changes. Keeping the auth path centralized
+// here means TASK-951 doesn't need to touch handlers_mcp.go.
+//
+// Why a dedicated middleware (not the existing TokenAuth):
+//
+// TokenAuth on /api/v1/* writes a JSON error envelope on 401 (so the
+// SPA / CLI clients can render a friendly message) and never sets
+// WWW-Authenticate. MCP clients expect the spec-shape: 401 with the
+// WWW-Authenticate "resource_metadata" parameter pointing them at
+// our discovery doc (RFC 9728 §5.3, MCP authorization spec
+// 2025-11-25). Wrapping TokenAuth would mean rewriting its 401
+// responses post-hoc — a layered hack. A standalone middleware is
+// shorter and clearer.
+//
+// CSRF / rate limiting:
+//
+// /mcp uses Bearer auth (Authorization header), not session cookies,
+// so CSRF doesn't apply (CSRF defends cookie-bearing requests). Rate
+// limiting is wired separately via TASK-959; this middleware is auth
+// only, intentionally.
+func (s *Server) MCPBearerAuth(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		token, ok := extractBearer(r.Header.Get("Authorization"))
+		if !ok {
+			s.writeMCPUnauthorized(w, "missing_token", "Bearer token required.")
+			return
+		}
+
+		// Format gate matching TokenAuth's check (middleware_auth.go:103).
+		// Rejecting at the prefix avoids a DB lookup for obviously-
+		// malformed tokens — a small but meaningful win under any
+		// volume of unauth probes.
+		if !strings.HasPrefix(token, "pad_") || len(token) != 68 {
+			s.writeMCPUnauthorized(w, "invalid_token", "Token format not recognized.")
+			return
+		}
+
+		apiToken, err := s.store.ValidateToken(token)
+		if err != nil {
+			// A DB error during token validation is a server-side
+			// problem, not the client's fault. 500 (not 401) so MCP
+			// clients don't churn through reconnect loops on a backend
+			// outage. No WWW-Authenticate header — re-running
+			// discovery wouldn't help.
+			writeError(w, http.StatusInternalServerError, "internal_error", "Token validation failed.")
+			return
+		}
+		if apiToken == nil {
+			s.writeMCPUnauthorized(w, "invalid_token", "Token is invalid or expired.")
+			return
+		}
+
+		// Resolve the user. Workspace-scope binding (apiToken.WorkspaceID)
+		// is intentionally NOT pinned here for user-owned PATs — the
+		// downstream RequireWorkspaceAccess middleware (when handlers
+		// run in-process via HTTPHandlerDispatcher) checks
+		// GetWorkspaceMember instead, matching the v0.2 design where
+		// a PAT grants access to whichever workspace its owning user
+		// belongs to. TASK-953 introduces a per-token allowed_workspaces[]
+		// allow-list which IS enforced here once it lands; for now,
+		// membership is the gate.
+		if apiToken.UserID == "" {
+			// Legacy workspace-scoped tokens (no user_id) predate the
+			// user-token refactor. They still authenticate the existing
+			// API surface — see handlers_events.go:52 — but the MCP
+			// transport requires a user identity (every audit log entry,
+			// every "who created this item", etc.). Reject cleanly.
+			s.writeMCPUnauthorized(w, "invalid_token", "MCP requires a user-owned token. Legacy workspace-scoped tokens are not supported here.")
+			return
+		}
+		user, err := s.store.GetUser(apiToken.UserID)
+		if err != nil || user == nil {
+			s.writeMCPUnauthorized(w, "invalid_token", "Token references an unknown user.")
+			return
+		}
+
+		ctx := WithCurrentUser(r.Context(), user)
+		// Mirror TokenAuth's ctxIsAPIToken signal so downstream
+		// handlers that distinguish session vs token auth see the same
+		// shape they would on /api/v1/*. Cheap, future-proof.
+		ctx = context.WithValue(ctx, ctxIsAPIToken, true)
+
+		// Surface near-expiry warning headers the same way TokenAuth
+		// does (middleware_auth.go:125). MCP clients can read them,
+		// but more importantly: the existing handlers_auth.go logic
+		// expects the warning to fire consistently regardless of
+		// transport.
+		setTokenExpiryWarning(w, apiToken)
+
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+// extractBearer parses an Authorization header value. Returns the
+// token and true on success. Anything that isn't "Bearer <token>"
+// (case-insensitive scheme, single space, non-empty token) returns
+// "", false. Permissive on the scheme casing because RFC 6750 §2.1
+// says it's case-insensitive; strict on the single-space separator
+// to match the actual wire format mainstream clients send.
+func extractBearer(h string) (string, bool) {
+	if h == "" {
+		return "", false
+	}
+	const prefix = "Bearer "
+	if len(h) <= len(prefix) {
+		return "", false
+	}
+	if !strings.EqualFold(h[:len(prefix)], prefix) {
+		return "", false
+	}
+	tok := strings.TrimSpace(h[len(prefix):])
+	if tok == "" {
+		return "", false
+	}
+	return tok, true
+}
+
+// writeMCPUnauthorized emits the spec-shaped 401 every MCP client
+// expects: WWW-Authenticate with realm + resource_metadata, plus a
+// small JSON body so curl / log scrapers see the reason without
+// needing to parse the header.
+//
+// resource_metadata points at the same URL handleOAuthProtectedResource
+// serves — Claude Desktop, Cursor, etc. follow it to begin the OAuth
+// discovery flow described in the MCP authorization spec.
+func (s *Server) writeMCPUnauthorized(w http.ResponseWriter, code, msg string) {
+	resourceMeta := strings.TrimRight(s.mcpPublicURL, "/")
+	if resourceMeta == "" {
+		// Fallback for local dev without PAD_MCP_PUBLIC_URL set. The
+		// blank-resource-metadata case is intentionally unsupported
+		// because RFC 9728 §5.3 requires the URL — emitting an empty
+		// value would let agents skip discovery and fail in confusing
+		// ways. Skip the header entirely; the JSON body still carries
+		// the error code.
+		writeError(w, http.StatusUnauthorized, code, msg)
+		return
+	}
+	resourceMeta = resourceMeta + "/.well-known/oauth-protected-resource"
+	w.Header().Set("WWW-Authenticate", `Bearer realm="pad", resource_metadata="`+resourceMeta+`"`)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusUnauthorized)
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"error": map[string]string{
+			"code":    code,
+			"message": msg,
+		},
+	})
+}

--- a/internal/server/middleware_mcp_auth.go
+++ b/internal/server/middleware_mcp_auth.go
@@ -55,7 +55,7 @@ func (s *Server) MCPBearerAuth(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		token, ok := extractBearer(r.Header.Get("Authorization"))
 		if !ok {
-			s.writeMCPUnauthorized(w, "missing_token", "Bearer token required.")
+			s.writeMCPUnauthorized(w, r, "missing_token", "Bearer token required.")
 			return
 		}
 
@@ -64,7 +64,7 @@ func (s *Server) MCPBearerAuth(next http.Handler) http.Handler {
 		// malformed tokens — a small but meaningful win under any
 		// volume of unauth probes.
 		if !strings.HasPrefix(token, "pad_") || len(token) != 68 {
-			s.writeMCPUnauthorized(w, "invalid_token", "Token format not recognized.")
+			s.writeMCPUnauthorized(w, r, "invalid_token", "Token format not recognized.")
 			return
 		}
 
@@ -79,7 +79,7 @@ func (s *Server) MCPBearerAuth(next http.Handler) http.Handler {
 			return
 		}
 		if apiToken == nil {
-			s.writeMCPUnauthorized(w, "invalid_token", "Token is invalid or expired.")
+			s.writeMCPUnauthorized(w, r, "invalid_token", "Token is invalid or expired.")
 			return
 		}
 
@@ -98,12 +98,12 @@ func (s *Server) MCPBearerAuth(next http.Handler) http.Handler {
 			// API surface — see handlers_events.go:52 — but the MCP
 			// transport requires a user identity (every audit log entry,
 			// every "who created this item", etc.). Reject cleanly.
-			s.writeMCPUnauthorized(w, "invalid_token", "MCP requires a user-owned token. Legacy workspace-scoped tokens are not supported here.")
+			s.writeMCPUnauthorized(w, r, "invalid_token", "MCP requires a user-owned token. Legacy workspace-scoped tokens are not supported here.")
 			return
 		}
 		user, err := s.store.GetUser(apiToken.UserID)
 		if err != nil || user == nil {
-			s.writeMCPUnauthorized(w, "invalid_token", "Token references an unknown user.")
+			s.writeMCPUnauthorized(w, r, "invalid_token", "Token references an unknown user.")
 			return
 		}
 
@@ -112,6 +112,14 @@ func (s *Server) MCPBearerAuth(next http.Handler) http.Handler {
 		// handlers that distinguish session vs token auth see the same
 		// shape they would on /api/v1/*. Cheap, future-proof.
 		ctx = context.WithValue(ctx, ctxIsAPIToken, true)
+		// Stash the token's scopes so the in-process MCP dispatcher
+		// (internal/mcp/dispatch_http.go) can enforce per-tool scope
+		// checks. Without this, a PAT with `["read"]` scope can drive
+		// write MCP tools because the synthesized in-process request
+		// looks pre-authenticated to the handler tree, bypassing
+		// TokenAuth's chain-level scopeAllows check. Codex review
+		// #369 round 1.
+		ctx = WithTokenScopes(ctx, apiToken.Scopes)
 
 		// Surface near-expiry warning headers the same way TokenAuth
 		// does (middleware_auth.go:125). MCP clients can read them,
@@ -156,19 +164,41 @@ func extractBearer(h string) (string, bool) {
 // resource_metadata points at the same URL handleOAuthProtectedResource
 // serves — Claude Desktop, Cursor, etc. follow it to begin the OAuth
 // discovery flow described in the MCP authorization spec.
-func (s *Server) writeMCPUnauthorized(w http.ResponseWriter, code, msg string) {
-	resourceMeta := strings.TrimRight(s.mcpPublicURL, "/")
-	if resourceMeta == "" {
-		// Fallback for local dev without PAD_MCP_PUBLIC_URL set. The
-		// blank-resource-metadata case is intentionally unsupported
-		// because RFC 9728 §5.3 requires the URL — emitting an empty
-		// value would let agents skip discovery and fail in confusing
-		// ways. Skip the header entirely; the JSON body still carries
-		// the error code.
+//
+// URL resolution for the resource_metadata parameter:
+//
+//  1. s.mcpPublicURL (set by SetMCPTransport from PAD_MCP_PUBLIC_URL).
+//     The canonical case — production deployments always set this.
+//  2. Fallback: derive from the request's Host header with "https://"
+//     prefix. Matches handleOAuthProtectedResource's fallback so the
+//     two URLs stay in sync for local dev without env vars set.
+//
+// Codex review #369 round 1 caught a regression where the fallback
+// path dropped the WWW-Authenticate header entirely — that broke MCP
+// client discovery on cloud-mode-without-PAD_MCP_PUBLIC_URL deploys
+// because fresh clients rely on the header to find the metadata doc.
+func (s *Server) writeMCPUnauthorized(w http.ResponseWriter, r *http.Request, code, msg string) {
+	resourceBase := strings.TrimRight(s.mcpPublicURL, "/")
+	if resourceBase == "" && r != nil && r.Host != "" {
+		// Same fallback as handleOAuthProtectedResource — assume HTTPS
+		// because RFC 9728 §3 + MCP authorization spec both require
+		// HTTPS in production, and the test harness doesn't probe the
+		// scheme. Operators on dev hosts running plain HTTP will see
+		// "https://localhost:7777/..." in the header; the test rig
+		// already pins the canonical case via SetMCPTransport.
+		resourceBase = "https://" + r.Host
+	}
+	if resourceBase == "" {
+		// No request and no configured URL — extremely rare (would
+		// only fire if writeMCPUnauthorized is called from a path
+		// that synthesizes a 401 without a request, which today none
+		// do). Fall back to the plain JSON 401 so the response is
+		// still well-formed; agents will get a generic "unauthorized"
+		// rather than a discovery-pointing one.
 		writeError(w, http.StatusUnauthorized, code, msg)
 		return
 	}
-	resourceMeta = resourceMeta + "/.well-known/oauth-protected-resource"
+	resourceMeta := resourceBase + "/.well-known/oauth-protected-resource"
 	w.Header().Set("WWW-Authenticate", `Bearer realm="pad", resource_metadata="`+resourceMeta+`"`)
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusUnauthorized)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -73,6 +73,15 @@ type Server struct {
 	// other endpoint and stores originals untouched.
 	imageProcessor attachments.Processor
 
+	// MCP Streamable HTTP transport (PLAN-943 TASK-950). Wired via
+	// SetMCPTransport at startup when the deployment is in cloud mode.
+	// nil on self-hosted deployments and on any cloud build that hasn't
+	// constructed the MCP server yet — registerMCPRoutes nil-checks so
+	// the routes don't mount in either case. See handlers_mcp.go.
+	mcpTransport     http.Handler
+	mcpPublicURL     string // canonical public URL of the MCP vhost (e.g. https://mcp.getpad.dev)
+	mcpAuthServerURL string // canonical URL of the OAuth auth server (e.g. https://app.getpad.dev), TASK-951
+
 	// storageInfoCache memoizes per-workspace storage usage summaries
 	// behind a short TTL (storageInfoTTL). Reduces DB load on the
 	// Settings → Storage page and quota-aware UI surfaces. Initialized
@@ -537,6 +546,23 @@ func (s *Server) setupRouter() {
 	if s.secureCookies {
 		r.Use(StrictTransportSecurity)
 	}
+
+	// MCP Streamable HTTP transport + OAuth discovery endpoints
+	// (PLAN-943 TASK-950). Mounted outside the standard /api/v1
+	// auth-required group because:
+	//
+	//   - /mcp uses Bearer auth via its own MCPBearerAuth middleware,
+	//     producing the spec-shape 401 + WWW-Authenticate that MCP
+	//     clients expect (the API-stack 401 envelope is JSON-only and
+	//     would fail Claude Desktop's discovery handshake).
+	//   - /.well-known/oauth-protected-resource and
+	//     /.well-known/oauth-authorization-server are public discovery
+	//     documents (RFC 9728 / RFC 8414); routing them through
+	//     TokenAuth+SessionAuth+RequireAuth would 401 unauth probes.
+	//
+	// No-op when SetMCPTransport hasn't been called or cloud mode is
+	// off — see registerMCPRoutes for the gating.
+	s.registerMCPRoutes(r)
 
 	// Prometheus scrape endpoint — exempt from the standard auth/CSRF stack
 	// (Prometheus can't present a session cookie or pass a CSRF header), but


### PR DESCRIPTION
## Summary

First public cut of pad-cloud as a remote MCP server (PLAN-943). Mounts the Streamable HTTP transport on `/mcp`, the RFC 9728 protected-resource discovery doc on `/.well-known/oauth-protected-resource`, and a 501 stub for RFC 8414 auth-server metadata that TASK-951 will fill in.

- **`internal/server/handlers_mcp.go`** — `Server.SetMCPTransport` + chi route registration under cloud-mode gate. Self-host deployments stay free of MCP overhead unless they explicitly opt in.
- **`internal/server/middleware_mcp_auth.go`** — Bearer auth that produces the spec-shape `401 + WWW-Authenticate` (with `resource_metadata` pointer) MCP clients expect, distinct from `/api/v1`'s JSON-only 401 envelope. Reuses the existing PAT (`api_tokens`) validation path; OAuth-issued tokens (TASK-951) layer in via this same middleware.
- **`internal/server/handlers_well_known.go`** — RFC 9728 discovery doc + RFC 8414 stub. URLs come from `PAD_MCP_PUBLIC_URL` + `PAD_AUTH_SERVER_URL` with a best-effort request-host fallback for local dev.
- **`cmd/pad/main.go`** — wires `mcpserver.NewServer` + `HTTPHandlerDispatcher` + `StreamableHTTPServer` in cloud mode, immediately after `SetCloudMode`.
- **`internal/config`** — adds `PAD_MCP_PUBLIC_URL` and `PAD_AUTH_SERVER_URL` env vars.
- **`internal/server/handlers_mcp_test.go`** — 7 tests covering the DoD cases.

Resources are intentionally skipped in this v1 — they require an `HTTPResourceFetcher` equivalent of `ExecResourceFetcher` and that's a follow-up task. Tools, prompts, instructions, and `_meta` all flow through identically to the stdio surface (verified via spike against `mcp-go v0.50.0`'s `StreamableHTTPServer` before writing the real PR).

## DoD coverage

| DoD bullet | Covered by |
|---|---|
| Valid Bearer roundtrip | `TestMCP_ValidPAT_ReachesTransport` |
| Missing token → 401 + WWW-Authenticate | `TestMCP_NoToken_Returns401WithWWWAuthenticate` |
| Bad-format token → 401 + WWW-Authenticate | `TestMCP_BadTokenFormat_Returns401WithWWWAuthenticate` |
| Discovery doc shape (RFC 9728) | `TestMCP_DiscoveryDoc_PopulatedFromConfig` |
| Cloud-off → routes absent | `TestMCP_CloudModeOff_RoutesAbsent`, `TestMCP_CloudModeOnButTransportNotWired_RoutesAbsent` |
| Auth-server discovery 501 stub | `TestMCP_AuthServerStub_Returns501` |
| Tool catalog matches v0.2 | Inherited from spike + handshake `padToolSurface = "0.2"` propagation |

## Carry-over

- **TASK-951** — fills in `/.well-known/oauth-authorization-server` and adds the `/oauth/{authorize,token,register,revoke,introspect}` endpoints. The MCPBearerAuth middleware gains an OAuth-introspection branch alongside the PAT path; envelope shape unchanged.
- **TASK-953** — adds per-token `allowed_workspaces[]` allow-list. Carry-over note recorded on the task: enforcement happens after user membership but before role decision; `available_workspaces` in error envelopes must come from the token's allow-list, not all workspaces (privacy).
- **TASK-977** — HTTPHandlerDispatcher structured error envelopes (per PLAN-969 T4) — orthogonal to TASK-950 plumbing; can land in either order.
- **Resources over HTTP transport** — needs an `HTTPResourceFetcher` that resolves the per-OAuth-user context. Follow-up; not blocking.

## Test plan

- [x] `go test ./...` — all green
- [x] `make install` — clean build, server restarts, `/api/v1/health` regression-free
- [x] Cloud-off smoke: `/mcp` and `/.well-known/*` fall through to the SPA catch-all (pre-existing behavior, not a regression)
- [ ] `/codex` review loop (next)
- [ ] Cloud-mode end-to-end against Claude Desktop (after TASK-997 nginx vhost or with `Host: mcp.getpad.dev` override)