### PR TITLE
feat(oauth): schema + storage layer (TASK-1023, sub-PR A of TASK-951)

### DIFF
--- a/internal/models/oauth.go
+++ b/internal/models/oauth.go
@@ -1,0 +1,91 @@
+package models
+
+import "time"
+
+// Models for the OAuth 2.1 authorization server (PLAN-943 TASK-951).
+// These are pad-internal types used by internal/store/oauth.go to
+// persist OAuth state. Sub-PR B (TASK-1024) introduces fosite, and
+// sub-PR C wires fosite.Requester ⇄ OAuthRequest adapters in the
+// HTTP handlers. The store layer never imports fosite so the schema
+// boundary stays clean.
+
+// OAuthClient is a registered OAuth client (RFC 7591 Dynamic Client
+// Registration). Only public clients (no secret) are supported in
+// v1 — see migrations/048_oauth.sql for why. The Public flag is a
+// forward-compat toggle; future confidential-client support adds a
+// secret column without changing this struct's shape.
+//
+// Field names use the RFC 7591 vocabulary so the JSON form can be
+// served back to clients verbatim from the registration endpoint
+// (sub-PR C).
+type OAuthClient struct {
+	ID                      string    `json:"client_id"`
+	Name                    string    `json:"client_name"`
+	RedirectURIs            []string  `json:"redirect_uris"`
+	GrantTypes              []string  `json:"grant_types"`
+	ResponseTypes           []string  `json:"response_types"`
+	TokenEndpointAuthMethod string    `json:"token_endpoint_auth_method"`
+	Scopes                  []string  `json:"scope"`
+	Public                  bool      `json:"-"` // internal — never serialized
+	LogoURL                 string    `json:"logo_uri,omitempty"`
+	CreatedAt               time.Time `json:"client_id_issued_at"`
+}
+
+// OAuthRequest is the persisted form of a fosite.Requester (without
+// the fosite import). Carries everything the auth-code, access-token,
+// refresh-token, and PKCE storage rows need:
+//
+//   - Signature: the HMAC-derived lookup key (the row's primary key).
+//   - RequestID: fosite's stable Requester.GetID() — preserved across
+//     refresh-token rotations, so it doubles as the chain identifier
+//     for theft-detection family revocation.
+//   - RequestedAt: original grant timestamp; used by the cleaner.
+//   - ClientID: FK to oauth_clients.
+//   - Scopes / GrantedScopes: space-separated.
+//   - RequestForm: URL-encoded form data from the original request
+//     (PKCE handler reads code_challenge from here).
+//   - SessionData: JSON-encoded session struct (subject + custom
+//     claims). Sub-PR B defines pad's session type; the store layer
+//     just round-trips it as bytes.
+//   - Audience / GrantedAudience: space-separated RFC 8707 resource
+//     indicators.
+//   - Active: token-revocation toggle. RevokeRefreshToken /
+//     RevokeAccessToken set this false; GetXxxSession returns
+//     ErrInactiveToken (a sentinel defined in oauth.go) when active=false.
+//   - Subject: denormalized from SessionData for fast subject-bound
+//     queries (admin "list active tokens for user X" surfaces). Empty
+//     for auth-code and PKCE rows where there is no subject yet.
+//   - AccessTokenSignature: refresh-only; links the refresh row to
+//     the access row issued in the same grant (or rotation step).
+//     Empty for non-refresh rows.
+type OAuthRequest struct {
+	Signature            string
+	RequestID            string
+	RequestedAt          time.Time
+	ClientID             string
+	Scopes               string
+	GrantedScopes        string
+	RequestForm          string
+	SessionData          string
+	Audience             string
+	GrantedAudience      string
+	Active               bool
+	Subject              string
+	AccessTokenSignature string
+}
+
+// OAuthClientCreate is the input shape for the storage-level
+// CreateClient method. The Postgres / SQLite migration already
+// constrains required fields; this type lets callers set only the
+// fields they have without populating the timestamp (the store sets
+// CreatedAt from now()).
+type OAuthClientCreate struct {
+	Name                    string
+	RedirectURIs            []string
+	GrantTypes              []string
+	ResponseTypes           []string
+	TokenEndpointAuthMethod string
+	Scopes                  []string
+	Public                  bool
+	LogoURL                 string
+}

--- a/internal/store/migrations/048_oauth.sql
+++ b/internal/store/migrations/048_oauth.sql
@@ -1,0 +1,168 @@
+-- Migration 048: OAuth 2.1 server tables (PLAN-943 TASK-951 sub-PR A).
+--
+-- Five tables backing the OAuth authorization server defined in
+-- PLAN-943 TASK-951: registered DCR clients, authorization codes,
+-- access tokens, refresh tokens, PKCE request sessions. Schema
+-- mirrors the storage interfaces fosite expects (handler/oauth2/storage.go,
+-- handler/pkce/storage.go, client_manager.go in github.com/ory/fosite v0.49.0)
+-- without importing fosite — this migration is pure SQL and the
+-- storage layer in internal/store/oauth.go uses pad-internal types.
+-- Sub-PR B wires fosite types over the top via adapter methods.
+--
+-- No table for token revocation: fosite's TokenRevocationStorage
+-- semantics are satisfied by toggling each token row's `active` flag.
+-- RevokeRefreshToken(request_id) walks the chain via the request_id
+-- index (rotations preserve the originating Requester's ID, see
+-- fosite handler/oauth2/flow_refresh.go:86).
+
+-- ============================================================
+-- 1. Registered OAuth clients (RFC 7591 Dynamic Client Registration)
+-- ============================================================
+--
+-- Public clients only for v1 (Claude Desktop / Cursor / etc. — they
+-- can't keep a secret). Confidential clients can be added later by
+-- introducing a `client_secret` column; we keep `public` as a flag
+-- now so the schema doesn't need to change.
+CREATE TABLE IF NOT EXISTS oauth_clients (
+    id                          TEXT PRIMARY KEY,             -- client_id (random ID, opaque)
+    name                        TEXT NOT NULL,                -- human-readable, surfaced on consent screen
+    redirect_uris               TEXT NOT NULL,                -- JSON array; OAuth 2.1 requires exact match
+    grant_types                 TEXT NOT NULL,                -- JSON array, e.g. ["authorization_code","refresh_token"]
+    response_types              TEXT NOT NULL,                -- JSON array, e.g. ["code"]
+    token_endpoint_auth_method  TEXT NOT NULL DEFAULT 'none', -- "none" for public clients (PKCE-only)
+    scopes                      TEXT NOT NULL DEFAULT '[]',   -- JSON array, the scopes this client is allowed to request
+    public                      INTEGER NOT NULL DEFAULT 1,   -- 1=public (no secret), 0=confidential (future)
+    logo_url                    TEXT,                         -- optional, surfaced on consent screen
+    created_at                  TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS oauth_clients_created_at_idx
+    ON oauth_clients(created_at);
+
+-- ============================================================
+-- 2. Authorization codes (one per /authorize → /token exchange)
+-- ============================================================
+--
+-- The `signature` is the HMAC-derived lookup key for the code;
+-- the actual code value is never stored (so a DB read can't replay).
+-- `request_form` is the URL-encoded /authorize query string; fosite
+-- uses it to verify PKCE on /token exchange (the code_challenge is
+-- in here). `session_data` is the marshalled session struct, which
+-- pad will define in sub-PR B (subject = pad user ID, etc.).
+CREATE TABLE IF NOT EXISTS oauth_authorization_codes (
+    signature         TEXT PRIMARY KEY,            -- code's HMAC signature
+    request_id        TEXT NOT NULL,               -- fosite Requester.GetID() — chain root for this grant
+    requested_at      TEXT NOT NULL,               -- ISO8601
+    client_id         TEXT NOT NULL,
+    scopes            TEXT NOT NULL DEFAULT '',    -- space-separated, requested
+    granted_scopes    TEXT NOT NULL DEFAULT '',    -- space-separated, after consent
+    request_form      TEXT NOT NULL DEFAULT '',    -- URL-encoded form data
+    session_data      TEXT NOT NULL DEFAULT '',    -- JSON-encoded session struct
+    audience          TEXT NOT NULL DEFAULT '',    -- space-separated, requested (RFC 8707 resource= values)
+    granted_audience  TEXT NOT NULL DEFAULT '',    -- space-separated, after binding
+    active            INTEGER NOT NULL DEFAULT 1,  -- 0 once exchanged or invalidated
+    FOREIGN KEY (client_id) REFERENCES oauth_clients(id)
+);
+
+CREATE INDEX IF NOT EXISTS oauth_codes_request_id_idx
+    ON oauth_authorization_codes(request_id);
+CREATE INDEX IF NOT EXISTS oauth_codes_requested_at_idx
+    ON oauth_authorization_codes(requested_at);
+
+-- ============================================================
+-- 3. Access tokens (opaque HMAC, audience-bound per RFC 8707)
+-- ============================================================
+--
+-- `subject` is denormalized from session_data so user-bound lookups
+-- (audit, "list active tokens for user X") don't have to JSON-parse
+-- every row. fosite doesn't query by subject itself; the column is
+-- here for our admin / connected-apps surfaces (TASK-954).
+CREATE TABLE IF NOT EXISTS oauth_access_tokens (
+    signature         TEXT PRIMARY KEY,
+    request_id        TEXT NOT NULL,               -- preserved across refresh rotations (chain identifier)
+    requested_at      TEXT NOT NULL,
+    client_id         TEXT NOT NULL,
+    scopes            TEXT NOT NULL DEFAULT '',
+    granted_scopes    TEXT NOT NULL DEFAULT '',
+    request_form      TEXT NOT NULL DEFAULT '',
+    session_data      TEXT NOT NULL DEFAULT '',
+    audience          TEXT NOT NULL DEFAULT '',
+    granted_audience  TEXT NOT NULL DEFAULT '',
+    active            INTEGER NOT NULL DEFAULT 1,
+    subject           TEXT NOT NULL DEFAULT '',    -- denormalized from session_data for fast subject-bound queries
+    FOREIGN KEY (client_id) REFERENCES oauth_clients(id)
+);
+
+CREATE INDEX IF NOT EXISTS oauth_access_request_id_idx
+    ON oauth_access_tokens(request_id);
+CREATE INDEX IF NOT EXISTS oauth_access_subject_idx
+    ON oauth_access_tokens(subject);
+CREATE INDEX IF NOT EXISTS oauth_access_requested_at_idx
+    ON oauth_access_tokens(requested_at);
+
+-- ============================================================
+-- 4. Refresh tokens (rotated single-use; theft-detection by family)
+-- ============================================================
+--
+-- `access_token_signature` links the refresh to the access token it
+-- was issued alongside. fosite passes both signatures into
+-- CreateRefreshTokenSession so the storage can chain them, useful
+-- when revoking a refresh token to also invalidate its sibling
+-- access token.
+--
+-- `request_id` is the chain identifier for theft detection: every
+-- token in a rotation chain (initial → rotated → rotated-again …)
+-- shares the same request_id. RevokeRefreshToken(request_id) walks
+-- this column and marks every chain member inactive — the "revoke
+-- the whole family on replay" rule from the OAuth 2.1 BCP.
+CREATE TABLE IF NOT EXISTS oauth_refresh_tokens (
+    signature               TEXT PRIMARY KEY,
+    request_id              TEXT NOT NULL,           -- chain root; family revocation walks this index
+    access_token_signature  TEXT,                    -- nullable; links to oauth_access_tokens.signature
+    requested_at            TEXT NOT NULL,
+    client_id               TEXT NOT NULL,
+    scopes                  TEXT NOT NULL DEFAULT '',
+    granted_scopes          TEXT NOT NULL DEFAULT '',
+    request_form            TEXT NOT NULL DEFAULT '',
+    session_data            TEXT NOT NULL DEFAULT '',
+    audience                TEXT NOT NULL DEFAULT '',
+    granted_audience        TEXT NOT NULL DEFAULT '',
+    active                  INTEGER NOT NULL DEFAULT 1,
+    subject                 TEXT NOT NULL DEFAULT '',
+    FOREIGN KEY (client_id) REFERENCES oauth_clients(id)
+);
+
+CREATE INDEX IF NOT EXISTS oauth_refresh_request_id_idx
+    ON oauth_refresh_tokens(request_id);
+CREATE INDEX IF NOT EXISTS oauth_refresh_subject_idx
+    ON oauth_refresh_tokens(subject);
+CREATE INDEX IF NOT EXISTS oauth_refresh_requested_at_idx
+    ON oauth_refresh_tokens(requested_at);
+
+-- ============================================================
+-- 5. PKCE request sessions
+-- ============================================================
+--
+-- fosite's PKCE handler stores the request alongside the auth code
+-- (signature == auth code's signature) so the code_challenge from
+-- /authorize can be verified against the code_verifier from /token.
+-- Same shape as oauth_authorization_codes; separate table because
+-- fosite uses a distinct interface (PKCERequestStorage) and the
+-- lifecycle differs slightly — PKCE rows are deleted on /token
+-- exchange success rather than flagged inactive.
+CREATE TABLE IF NOT EXISTS oauth_pkce_requests (
+    signature         TEXT PRIMARY KEY,
+    request_id        TEXT NOT NULL,
+    requested_at      TEXT NOT NULL,
+    client_id         TEXT NOT NULL,
+    scopes            TEXT NOT NULL DEFAULT '',
+    granted_scopes    TEXT NOT NULL DEFAULT '',
+    request_form      TEXT NOT NULL DEFAULT '',    -- contains code_challenge + code_challenge_method
+    session_data      TEXT NOT NULL DEFAULT '',
+    audience          TEXT NOT NULL DEFAULT '',
+    granted_audience  TEXT NOT NULL DEFAULT '',
+    FOREIGN KEY (client_id) REFERENCES oauth_clients(id)
+);
+
+CREATE INDEX IF NOT EXISTS oauth_pkce_request_id_idx
+    ON oauth_pkce_requests(request_id);

--- a/internal/store/oauth.go
+++ b/internal/store/oauth.go
@@ -316,23 +316,37 @@ func (s *Store) DeleteRefreshToken(signature string) error {
 	return nil
 }
 
-// RotateRefreshToken marks a single refresh token inactive in place.
-// fosite calls this after issuing the rotated pair (new access + new
-// refresh) so the previous refresh becomes single-use. Distinct from
-// RevokeRefreshTokenFamily, which walks the entire chain — this
-// only touches one row.
+// RotateRefreshToken revokes the entire grant — both the refresh
+// family AND the paired access family for the given requestID —
+// then fosite immediately issues a new refresh + access pair via
+// CreateRefreshTokenSession + CreateAccessTokenSession.
 //
-// signatureToRotate identifies the refresh row to flip; requestID is
-// passed by fosite for log correlation but the pure storage layer
-// doesn't need it (fosite preserves request_id across rotation, so
-// the chain is naturally walkable on revocation regardless of
-// which row we flip).
-func (s *Store) RotateRefreshToken(_ /*requestID*/, signatureToRotate string) error {
-	_, err := s.db.Exec(s.q(`
-		UPDATE oauth_refresh_tokens SET active = ? WHERE signature = ?
-	`), false, signatureToRotate)
-	if err != nil {
-		return fmt.Errorf("rotate refresh token: %w", err)
+// This matches fosite's reference MemoryStore.RotateRefreshToken
+// (storage/memory.go:497-504), which delegates to
+// RevokeRefreshToken + RevokeAccessToken: the simple "revoke the
+// whole grant on rotation" model rather than the more complex
+// graceful-rotation pattern fosite mentions but doesn't implement.
+//
+// Why both families: every token in a refresh-rotation chain shares
+// the same request_id (fosite preserves it via flow_refresh.go:86),
+// so the new access + new refresh fosite issues immediately after
+// this call inherit the same request_id. They get inserted with
+// active=TRUE per insertOAuthRequestRow's hardcode, so the net
+// state is "all old rows in this chain inactive; the new pair
+// active." Without revoking the access family here, the previously-
+// issued access token would remain active until its TTL expired —
+// the bug Codex review #370 round 2 caught.
+//
+// signatureToRotate is fosite's hint about which specific refresh
+// row triggered the rotation; we ignore it because revoking by
+// request_id catches the entire chain whether we flip one row at
+// a time or all at once.
+func (s *Store) RotateRefreshToken(requestID, _ /*signatureToRotate*/ string) error {
+	if err := s.RevokeRefreshTokenFamily(requestID); err != nil {
+		return fmt.Errorf("rotate refresh: revoke refresh family: %w", err)
+	}
+	if err := s.RevokeAccessTokenFamily(requestID); err != nil {
+		return fmt.Errorf("rotate refresh: revoke access family: %w", err)
 	}
 	return nil
 }

--- a/internal/store/oauth.go
+++ b/internal/store/oauth.go
@@ -1,0 +1,646 @@
+package store
+
+import (
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// OAuth 2.1 server storage layer (PLAN-943 TASK-951 sub-PR A).
+//
+// This file implements pure CRUD against the five oauth_* tables
+// added by migrations/048_oauth.sql + pgmigrations/027_oauth.sql.
+// The methods are intentionally fosite-agnostic: callers pass and
+// receive pad-internal types (models.OAuthClient, models.OAuthRequest)
+// rather than fosite.Client / fosite.Requester. Sub-PR B (TASK-1024)
+// adds the fosite import + adapter wrappers in internal/oauth/.
+//
+// Why the boundary lives here:
+//
+// fosite's storage interfaces accept fosite.Requester (an interface
+// with ~20 methods) and fosite.Session (another interface with custom
+// claims). Implementing them directly in this package would pull
+// fosite into every Pad build, including builds that don't host the
+// MCP/OAuth surface (self-hosted CLI users). Keeping the storage
+// layer in pure Go means:
+//
+//   - Self-host builds skip the fosite dep entirely (smaller binary).
+//   - The schema can be tested in isolation with simple structs.
+//   - Sub-PR B's adapter is the single place a Requester ⇄ DB row
+//     translation happens — easier to audit + mock in tests.
+//
+// Concurrency:
+//
+// Each method runs as a single SQL statement. SQLite serializes
+// writes globally (BEGIN IMMEDIATE per store.go), so the visible
+// behaviour is one-at-a-time even under concurrent callers; Postgres
+// allows row-level concurrent writes. Both backends are safe for the
+// "rotate refresh = invalidate one row + insert two rows" pattern
+// fosite uses, because fosite always issues those calls inside the
+// same handler request and pad's existing /api/v1/* code paths
+// don't share rows with the OAuth grant flow.
+
+// Sentinel errors. fosite-side adapters in sub-PR B map these to
+// fosite.ErrNotFound / fosite.ErrInvalidatedAuthorizeCode etc.
+// Defined here so the storage layer can return them without
+// importing fosite.
+var (
+	// ErrOAuthNotFound is returned when a row lookup misses (no
+	// matching client / signature). Callers should map to fosite.ErrNotFound.
+	ErrOAuthNotFound = errors.New("oauth: not found")
+
+	// ErrOAuthInvalidatedCode is returned when GetAuthorizationCode
+	// hits a row whose active flag is false. fosite expects
+	// ErrInvalidatedAuthorizeCode in that case (it uses the error
+	// to trigger family-revocation on the original request).
+	ErrOAuthInvalidatedCode = errors.New("oauth: authorization code invalidated")
+
+	// ErrOAuthInactiveToken signals an access/refresh row exists but
+	// has been revoked or rotated out. Adapters map to
+	// fosite.ErrInactiveToken.
+	ErrOAuthInactiveToken = errors.New("oauth: token inactive")
+)
+
+// ============================================================
+// Clients (RFC 7591 — Dynamic Client Registration)
+// ============================================================
+
+// CreateOAuthClient inserts a new client and returns its issued
+// client_id (random ID + creation timestamp).
+//
+// Validation lives at the HTTP boundary in sub-PR C; this method
+// trusts the caller. Empty slices serialize to "[]" so reads always
+// produce a stable JSON shape.
+func (s *Store) CreateOAuthClient(input models.OAuthClientCreate) (*models.OAuthClient, error) {
+	id := newID()
+	created := time.Now().UTC()
+	createdStr := created.Format(time.RFC3339)
+
+	redirects, err := jsonStringList(input.RedirectURIs)
+	if err != nil {
+		return nil, fmt.Errorf("encode redirect_uris: %w", err)
+	}
+	grants, err := jsonStringList(input.GrantTypes)
+	if err != nil {
+		return nil, fmt.Errorf("encode grant_types: %w", err)
+	}
+	respTypes, err := jsonStringList(input.ResponseTypes)
+	if err != nil {
+		return nil, fmt.Errorf("encode response_types: %w", err)
+	}
+	scopes, err := jsonStringList(input.Scopes)
+	if err != nil {
+		return nil, fmt.Errorf("encode scopes: %w", err)
+	}
+
+	authMethod := input.TokenEndpointAuthMethod
+	if authMethod == "" {
+		authMethod = "none"
+	}
+
+	// Postgres uses a BOOLEAN column for `public`; SQLite uses INTEGER.
+	// Both accept Go's bool via the standard driver — no dialect-
+	// specific handling needed at the call site.
+	_, err = s.db.Exec(s.q(`
+		INSERT INTO oauth_clients (
+			id, name, redirect_uris, grant_types, response_types,
+			token_endpoint_auth_method, scopes, public, logo_url, created_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`), id, input.Name, redirects, grants, respTypes, authMethod,
+		scopes, input.Public, input.LogoURL, createdStr)
+	if err != nil {
+		return nil, fmt.Errorf("insert oauth client: %w", err)
+	}
+
+	return &models.OAuthClient{
+		ID:                      id,
+		Name:                    input.Name,
+		RedirectURIs:            cloneStringSlice(input.RedirectURIs),
+		GrantTypes:              cloneStringSlice(input.GrantTypes),
+		ResponseTypes:           cloneStringSlice(input.ResponseTypes),
+		TokenEndpointAuthMethod: authMethod,
+		Scopes:                  cloneStringSlice(input.Scopes),
+		Public:                  input.Public,
+		LogoURL:                 input.LogoURL,
+		CreatedAt:               created,
+	}, nil
+}
+
+// GetOAuthClient looks up a registered client by ID. Returns
+// ErrOAuthNotFound if no row matches.
+func (s *Store) GetOAuthClient(id string) (*models.OAuthClient, error) {
+	var (
+		c                                                models.OAuthClient
+		redirectsRaw, grantsRaw, respTypesRaw, scopesRaw string
+		logoURL                                          sql.NullString
+		createdStr                                       string
+		public                                           bool
+	)
+	err := s.db.QueryRow(s.q(`
+		SELECT id, name, redirect_uris, grant_types, response_types,
+		       token_endpoint_auth_method, scopes, public, logo_url, created_at
+		FROM oauth_clients WHERE id = ?
+	`), id).Scan(&c.ID, &c.Name, &redirectsRaw, &grantsRaw, &respTypesRaw,
+		&c.TokenEndpointAuthMethod, &scopesRaw, &public, &logoURL, &createdStr)
+	if err == sql.ErrNoRows {
+		return nil, ErrOAuthNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("query oauth client: %w", err)
+	}
+
+	if c.RedirectURIs, err = parseJSONStringList(redirectsRaw); err != nil {
+		return nil, fmt.Errorf("decode redirect_uris: %w", err)
+	}
+	if c.GrantTypes, err = parseJSONStringList(grantsRaw); err != nil {
+		return nil, fmt.Errorf("decode grant_types: %w", err)
+	}
+	if c.ResponseTypes, err = parseJSONStringList(respTypesRaw); err != nil {
+		return nil, fmt.Errorf("decode response_types: %w", err)
+	}
+	if c.Scopes, err = parseJSONStringList(scopesRaw); err != nil {
+		return nil, fmt.Errorf("decode scopes: %w", err)
+	}
+	c.Public = public
+	c.LogoURL = logoURL.String
+	c.CreatedAt = parseTime(createdStr)
+	return &c, nil
+}
+
+// DeleteOAuthClient removes a client and all dependent token /
+// auth-code / pkce rows by FK cascade is NOT used because Postgres
+// FKs default to NO ACTION and we never wrote ON DELETE CASCADE in
+// the migration. Callers needing to delete a client must revoke its
+// outstanding grants first (sub-PR D's revocation flow), then delete.
+// Returns nil even if the client doesn't exist (idempotent delete).
+func (s *Store) DeleteOAuthClient(id string) error {
+	_, err := s.db.Exec(s.q(`DELETE FROM oauth_clients WHERE id = ?`), id)
+	if err != nil {
+		return fmt.Errorf("delete oauth client: %w", err)
+	}
+	return nil
+}
+
+// ============================================================
+// Authorization codes (handler/oauth2/storage.go AuthorizeCodeStorage)
+// ============================================================
+
+// CreateAuthorizationCode persists a code's session under its
+// signature. The signature is fosite's HMAC of the code value;
+// the code itself is never stored, so a DB read can't replay it.
+func (s *Store) CreateAuthorizationCode(req models.OAuthRequest) error {
+	return s.insertOAuthRequestRow("oauth_authorization_codes", req, false)
+}
+
+// GetAuthorizationCode hydrates the code's session. Returns
+// ErrOAuthInvalidatedCode if the row exists but active=false (fosite
+// triggers grant-family revocation on this); ErrOAuthNotFound if the
+// row is missing entirely.
+func (s *Store) GetAuthorizationCode(signature string) (*models.OAuthRequest, error) {
+	req, active, err := s.queryOAuthRequestRow("oauth_authorization_codes", signature)
+	if err != nil {
+		return nil, err
+	}
+	if !active {
+		// Per fosite contract: still return the request payload
+		// alongside the invalidation error so the caller can run
+		// family revocation against the now-known request_id.
+		return req, ErrOAuthInvalidatedCode
+	}
+	return req, nil
+}
+
+// InvalidateAuthorizationCode marks a code inactive (single-use).
+// Idempotent: invalidating an already-invalid or missing row is a
+// no-op (fosite's contract here is "make it invalid", not "fail if
+// it's already invalid").
+func (s *Store) InvalidateAuthorizationCode(signature string) error {
+	_, err := s.db.Exec(s.q(`
+		UPDATE oauth_authorization_codes SET active = ? WHERE signature = ?
+	`), false, signature)
+	if err != nil {
+		return fmt.Errorf("invalidate auth code: %w", err)
+	}
+	return nil
+}
+
+// ============================================================
+// Access tokens (handler/oauth2/storage.go AccessTokenStorage)
+// ============================================================
+
+// CreateAccessToken persists an access token row. fosite always
+// stamps `active=true` on insert; the column is materialized here
+// so RevokeAccessToken can flip it without re-issuing.
+func (s *Store) CreateAccessToken(req models.OAuthRequest) error {
+	return s.insertOAuthRequestRow("oauth_access_tokens", req, true)
+}
+
+// GetAccessToken hydrates an access token by its HMAC signature.
+// Returns ErrOAuthInactiveToken if the row exists but has been
+// revoked / rotated out, ErrOAuthNotFound if missing.
+func (s *Store) GetAccessToken(signature string) (*models.OAuthRequest, error) {
+	req, active, err := s.queryOAuthRequestRow("oauth_access_tokens", signature)
+	if err != nil {
+		return nil, err
+	}
+	if !active {
+		return req, ErrOAuthInactiveToken
+	}
+	return req, nil
+}
+
+// DeleteAccessToken removes a row entirely (fosite uses Delete after
+// successful exchange to prevent reuse). Distinct from RevokeAccessToken
+// which preserves the row for introspection auditing.
+func (s *Store) DeleteAccessToken(signature string) error {
+	_, err := s.db.Exec(s.q(`DELETE FROM oauth_access_tokens WHERE signature = ?`), signature)
+	if err != nil {
+		return fmt.Errorf("delete access token: %w", err)
+	}
+	return nil
+}
+
+// ============================================================
+// Refresh tokens (handler/oauth2/storage.go RefreshTokenStorage)
+// ============================================================
+
+// CreateRefreshToken persists a refresh token. accessSignature links
+// the refresh to the access token issued in the same grant; pass
+// empty string when there is no paired access token (rare — only
+// during error recovery flows).
+func (s *Store) CreateRefreshToken(req models.OAuthRequest) error {
+	return s.insertOAuthRequestRow("oauth_refresh_tokens", req, true)
+}
+
+// GetRefreshToken hydrates a refresh token. Returns
+// ErrOAuthInactiveToken when active=false, which fosite uses to
+// trigger family revocation on the matching request_id (the OAuth
+// 2.1 BCP "revoke the whole family on replay" rule). Sub-PR D wires
+// the family-revocation walk via RevokeRefreshTokenFamily.
+func (s *Store) GetRefreshToken(signature string) (*models.OAuthRequest, error) {
+	req, active, err := s.queryOAuthRequestRow("oauth_refresh_tokens", signature)
+	if err != nil {
+		return nil, err
+	}
+	if !active {
+		return req, ErrOAuthInactiveToken
+	}
+	return req, nil
+}
+
+// DeleteRefreshToken removes a refresh row entirely. Used by the
+// rotation flow to drop the previous-step's refresh after the new
+// one is in place.
+func (s *Store) DeleteRefreshToken(signature string) error {
+	_, err := s.db.Exec(s.q(`DELETE FROM oauth_refresh_tokens WHERE signature = ?`), signature)
+	if err != nil {
+		return fmt.Errorf("delete refresh token: %w", err)
+	}
+	return nil
+}
+
+// RotateRefreshToken marks a single refresh token inactive in place.
+// fosite calls this after issuing the rotated pair (new access + new
+// refresh) so the previous refresh becomes single-use. Distinct from
+// RevokeRefreshTokenFamily, which walks the entire chain — this
+// only touches one row.
+//
+// signatureToRotate identifies the refresh row to flip; requestID is
+// passed by fosite for log correlation but the pure storage layer
+// doesn't need it (fosite preserves request_id across rotation, so
+// the chain is naturally walkable on revocation regardless of
+// which row we flip).
+func (s *Store) RotateRefreshToken(_ /*requestID*/, signatureToRotate string) error {
+	_, err := s.db.Exec(s.q(`
+		UPDATE oauth_refresh_tokens SET active = ? WHERE signature = ?
+	`), false, signatureToRotate)
+	if err != nil {
+		return fmt.Errorf("rotate refresh token: %w", err)
+	}
+	return nil
+}
+
+// ============================================================
+// Token revocation (handler/oauth2/revocation_storage.go)
+// ============================================================
+
+// RevokeRefreshTokenFamily marks every refresh token sharing the
+// given requestID inactive — the OAuth 2.1 BCP §4.14
+// (refresh_token_replay rule) "revoke the whole family on a replayed
+// refresh" behaviour. fosite's RevokeRefreshToken adapter in sub-PR
+// B calls this when GetRefreshToken returns ErrOAuthInactiveToken.
+//
+// The walk uses the request_id index (oauth_refresh_request_id_idx)
+// added by the migration, so it stays O(family-size) even when the
+// table grows. Idempotent — re-revoking an already-inactive family
+// is a no-op.
+func (s *Store) RevokeRefreshTokenFamily(requestID string) error {
+	_, err := s.db.Exec(s.q(`
+		UPDATE oauth_refresh_tokens SET active = ? WHERE request_id = ?
+	`), false, requestID)
+	if err != nil {
+		return fmt.Errorf("revoke refresh family: %w", err)
+	}
+	return nil
+}
+
+// RevokeAccessTokenFamily mirrors RevokeRefreshTokenFamily for
+// access tokens. fosite calls these in pairs when revoking by
+// request_id (the unified RevokeRefreshToken / RevokeAccessToken
+// pair in TokenRevocationStorage).
+func (s *Store) RevokeAccessTokenFamily(requestID string) error {
+	_, err := s.db.Exec(s.q(`
+		UPDATE oauth_access_tokens SET active = ? WHERE request_id = ?
+	`), false, requestID)
+	if err != nil {
+		return fmt.Errorf("revoke access family: %w", err)
+	}
+	return nil
+}
+
+// ============================================================
+// PKCE request sessions (handler/pkce/storage.go PKCERequestStorage)
+// ============================================================
+
+// CreatePKCERequest persists a PKCE session keyed by the auth code's
+// signature. fosite stores the original /authorize request here so
+// the code_challenge can be re-validated against the code_verifier
+// on /token exchange.
+func (s *Store) CreatePKCERequest(req models.OAuthRequest) error {
+	// PKCE rows have no `active` column (lifecycle is "exists or
+	// deleted" rather than "active or revoked"). insertOAuthRequestRow
+	// with table=oauth_pkce_requests skips the active column write.
+	return s.insertOAuthRequestRow("oauth_pkce_requests", req, false /*ignored for pkce*/)
+}
+
+// GetPKCERequest hydrates the PKCE session. Returns ErrOAuthNotFound
+// if the row is missing.
+func (s *Store) GetPKCERequest(signature string) (*models.OAuthRequest, error) {
+	req, _, err := s.queryOAuthRequestRow("oauth_pkce_requests", signature)
+	return req, err
+}
+
+// DeletePKCERequest removes the row after a successful /token
+// exchange (fosite's lifecycle for PKCE is delete-on-use, unlike
+// auth codes which are flagged inactive).
+func (s *Store) DeletePKCERequest(signature string) error {
+	_, err := s.db.Exec(s.q(`DELETE FROM oauth_pkce_requests WHERE signature = ?`), signature)
+	if err != nil {
+		return fmt.Errorf("delete pkce request: %w", err)
+	}
+	return nil
+}
+
+// ============================================================
+// Helpers — shared by the three "request-row" tables
+// ============================================================
+
+// insertOAuthRequestRow writes a request payload into the named
+// table. The four request-row tables (auth codes, access tokens,
+// refresh tokens, pkce) share the same column set with two
+// exceptions:
+//
+//   - pkce has no `active` column (no revocation lifecycle).
+//   - access + refresh have a `subject` column for fast subject-
+//     bound lookups; auth codes have a subject column too (set when
+//     consent fires); pkce sets it to the empty string for now.
+//   - refresh has an `access_token_signature` column linking to the
+//     access row issued in the same grant.
+//
+// Switch on the table name to pick the right INSERT — uglier than
+// per-table methods but keeps the call sites uniform and lets the
+// helpers below share the same row-decoding code on read. The
+// per-table methods above (CreateAccessToken etc.) are the public
+// surface; this is the private worker.
+func (s *Store) insertOAuthRequestRow(table string, req models.OAuthRequest, defaultActive bool) error {
+	if req.Signature == "" {
+		return fmt.Errorf("oauth: signature required")
+	}
+	if req.RequestID == "" {
+		return fmt.Errorf("oauth: request_id required")
+	}
+	if req.ClientID == "" {
+		return fmt.Errorf("oauth: client_id required")
+	}
+
+	requestedAt := req.RequestedAt
+	if requestedAt.IsZero() {
+		requestedAt = time.Now().UTC()
+	}
+	requestedStr := requestedAt.UTC().Format(time.RFC3339)
+
+	// Active defaults to true for token tables on insert; auth-code
+	// rows are also active on insert. The defaultActive flag is the
+	// hint the caller passes, but the OAuthRequest itself wins when
+	// explicitly set (false on insert is rare — only used by tests
+	// to seed a pre-revoked row).
+	active := defaultActive
+	if req.Active != defaultActive {
+		// The caller explicitly overrode it.
+		active = req.Active
+	}
+
+	switch table {
+	case "oauth_authorization_codes":
+		_, err := s.db.Exec(s.q(`
+			INSERT INTO oauth_authorization_codes (
+				signature, request_id, requested_at, client_id,
+				scopes, granted_scopes, request_form, session_data,
+				audience, granted_audience, active
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		`), req.Signature, req.RequestID, requestedStr, req.ClientID,
+			req.Scopes, req.GrantedScopes, req.RequestForm, req.SessionData,
+			req.Audience, req.GrantedAudience, active)
+		if err != nil {
+			return fmt.Errorf("insert auth code: %w", err)
+		}
+	case "oauth_access_tokens":
+		_, err := s.db.Exec(s.q(`
+			INSERT INTO oauth_access_tokens (
+				signature, request_id, requested_at, client_id,
+				scopes, granted_scopes, request_form, session_data,
+				audience, granted_audience, active, subject
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		`), req.Signature, req.RequestID, requestedStr, req.ClientID,
+			req.Scopes, req.GrantedScopes, req.RequestForm, req.SessionData,
+			req.Audience, req.GrantedAudience, active, req.Subject)
+		if err != nil {
+			return fmt.Errorf("insert access token: %w", err)
+		}
+	case "oauth_refresh_tokens":
+		var accessSig interface{}
+		if req.AccessTokenSignature != "" {
+			accessSig = req.AccessTokenSignature
+		}
+		_, err := s.db.Exec(s.q(`
+			INSERT INTO oauth_refresh_tokens (
+				signature, request_id, access_token_signature, requested_at,
+				client_id, scopes, granted_scopes, request_form, session_data,
+				audience, granted_audience, active, subject
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		`), req.Signature, req.RequestID, accessSig, requestedStr,
+			req.ClientID, req.Scopes, req.GrantedScopes, req.RequestForm, req.SessionData,
+			req.Audience, req.GrantedAudience, active, req.Subject)
+		if err != nil {
+			return fmt.Errorf("insert refresh token: %w", err)
+		}
+	case "oauth_pkce_requests":
+		// PKCE rows have no active column — fosite's lifecycle is
+		// "exists or deleted", not "active or revoked".
+		_, err := s.db.Exec(s.q(`
+			INSERT INTO oauth_pkce_requests (
+				signature, request_id, requested_at, client_id,
+				scopes, granted_scopes, request_form, session_data,
+				audience, granted_audience
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		`), req.Signature, req.RequestID, requestedStr, req.ClientID,
+			req.Scopes, req.GrantedScopes, req.RequestForm, req.SessionData,
+			req.Audience, req.GrantedAudience)
+		if err != nil {
+			return fmt.Errorf("insert pkce request: %w", err)
+		}
+	default:
+		return fmt.Errorf("oauth: unknown table %q", table)
+	}
+	return nil
+}
+
+// queryOAuthRequestRow reads a row by signature from the named
+// table and returns (request, active, err).
+//
+//   - For oauth_pkce_requests, active is always true (no column).
+//   - Returns ErrOAuthNotFound when the row is missing; callers map
+//     that to fosite.ErrNotFound.
+//   - Active=false rows are returned alongside no error; the caller
+//     decides whether to treat that as ErrInvalidatedCode (auth
+//     codes) or ErrInactiveToken (access/refresh).
+func (s *Store) queryOAuthRequestRow(table, signature string) (*models.OAuthRequest, bool, error) {
+	if signature == "" {
+		return nil, false, fmt.Errorf("oauth: signature required")
+	}
+
+	var req models.OAuthRequest
+	req.Signature = signature
+	var requestedStr string
+
+	switch table {
+	case "oauth_authorization_codes":
+		err := s.db.QueryRow(s.q(`
+			SELECT request_id, requested_at, client_id, scopes, granted_scopes,
+			       request_form, session_data, audience, granted_audience, active
+			FROM oauth_authorization_codes WHERE signature = ?
+		`), signature).Scan(&req.RequestID, &requestedStr, &req.ClientID,
+			&req.Scopes, &req.GrantedScopes, &req.RequestForm, &req.SessionData,
+			&req.Audience, &req.GrantedAudience, &req.Active)
+		if err == sql.ErrNoRows {
+			return nil, false, ErrOAuthNotFound
+		}
+		if err != nil {
+			return nil, false, fmt.Errorf("query auth code: %w", err)
+		}
+	case "oauth_access_tokens":
+		err := s.db.QueryRow(s.q(`
+			SELECT request_id, requested_at, client_id, scopes, granted_scopes,
+			       request_form, session_data, audience, granted_audience, active, subject
+			FROM oauth_access_tokens WHERE signature = ?
+		`), signature).Scan(&req.RequestID, &requestedStr, &req.ClientID,
+			&req.Scopes, &req.GrantedScopes, &req.RequestForm, &req.SessionData,
+			&req.Audience, &req.GrantedAudience, &req.Active, &req.Subject)
+		if err == sql.ErrNoRows {
+			return nil, false, ErrOAuthNotFound
+		}
+		if err != nil {
+			return nil, false, fmt.Errorf("query access token: %w", err)
+		}
+	case "oauth_refresh_tokens":
+		var accessSig sql.NullString
+		err := s.db.QueryRow(s.q(`
+			SELECT request_id, access_token_signature, requested_at, client_id,
+			       scopes, granted_scopes, request_form, session_data,
+			       audience, granted_audience, active, subject
+			FROM oauth_refresh_tokens WHERE signature = ?
+		`), signature).Scan(&req.RequestID, &accessSig, &requestedStr, &req.ClientID,
+			&req.Scopes, &req.GrantedScopes, &req.RequestForm, &req.SessionData,
+			&req.Audience, &req.GrantedAudience, &req.Active, &req.Subject)
+		if err == sql.ErrNoRows {
+			return nil, false, ErrOAuthNotFound
+		}
+		if err != nil {
+			return nil, false, fmt.Errorf("query refresh token: %w", err)
+		}
+		req.AccessTokenSignature = accessSig.String
+	case "oauth_pkce_requests":
+		err := s.db.QueryRow(s.q(`
+			SELECT request_id, requested_at, client_id, scopes, granted_scopes,
+			       request_form, session_data, audience, granted_audience
+			FROM oauth_pkce_requests WHERE signature = ?
+		`), signature).Scan(&req.RequestID, &requestedStr, &req.ClientID,
+			&req.Scopes, &req.GrantedScopes, &req.RequestForm, &req.SessionData,
+			&req.Audience, &req.GrantedAudience)
+		if err == sql.ErrNoRows {
+			return nil, false, ErrOAuthNotFound
+		}
+		if err != nil {
+			return nil, false, fmt.Errorf("query pkce: %w", err)
+		}
+		// PKCE rows are always "active" for the purposes of this method —
+		// lifecycle is exists/deleted, not flagged.
+		req.Active = true
+	default:
+		return nil, false, fmt.Errorf("oauth: unknown table %q", table)
+	}
+
+	req.RequestedAt = parseTime(requestedStr)
+	return &req, req.Active, nil
+}
+
+// jsonStringList encodes a []string as a JSON array string suitable
+// for both SQLite (TEXT column) and Postgres (JSONB column — pgx
+// accepts a JSON-shaped string and validates it server-side). nil
+// input encodes to "[]" so reads always parse cleanly.
+func jsonStringList(in []string) (string, error) {
+	if in == nil {
+		in = []string{}
+	}
+	b, err := json.Marshal(in)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+// parseJSONStringList decodes a JSON array string back to []string.
+// Empty / null inputs produce an empty (non-nil) slice so callers
+// can range without nil-checking.
+func parseJSONStringList(raw string) ([]string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" || raw == "null" {
+		return []string{}, nil
+	}
+	var out []string
+	if err := json.Unmarshal([]byte(raw), &out); err != nil {
+		return nil, err
+	}
+	if out == nil {
+		out = []string{}
+	}
+	return out, nil
+}
+
+// cloneStringSlice returns a copy of in so callers holding the
+// returned model can't mutate the input the caller still owns.
+// nil → nil so the model's slice fields stay falsy when the caller
+// passed nil; sub-PR B's adapter relies on that.
+func cloneStringSlice(in []string) []string {
+	if in == nil {
+		return nil
+	}
+	out := make([]string, len(in))
+	copy(out, in)
+	return out
+}

--- a/internal/store/oauth.go
+++ b/internal/store/oauth.go
@@ -184,16 +184,44 @@ func (s *Store) GetOAuthClient(id string) (*models.OAuthClient, error) {
 // previous behaviour where DeleteOAuthClient errored on FK violation
 // for any client that had ever issued a grant.
 //
+// Postgres concurrency note (Codex review #370 round 4): without the
+// row-level lock below, a concurrent grant/token insert on the same
+// client_id could land between our child-row deletes and the parent
+// delete, producing a fresh FK reference that fails the parent
+// delete. We take SELECT … FOR UPDATE on the client row as the very
+// first statement in the tx, which blocks any concurrent insert
+// trying to read the client (which fosite does as part of FK
+// resolution on grant insert) until our tx commits. SQLite serializes
+// writes via BEGIN IMMEDIATE (set globally in store.go's DSN), so
+// the race doesn't exist there — we skip the FOR UPDATE on SQLite
+// because the syntax isn't universally supported by the driver.
+//
 // Idempotent: calling on a non-existent client is a no-op (every
-// dependent table's WHERE matches nothing). Atomic: if any of the
-// five DELETEs fails, the whole transaction rolls back so we never
-// leave a half-deleted client.
+// dependent table's WHERE matches nothing; the FOR UPDATE locks no
+// row but doesn't error). Atomic: if any DELETE fails, the whole
+// transaction rolls back so we never leave a half-deleted client.
 func (s *Store) DeleteOAuthClient(id string) error {
 	tx, err := s.db.Begin()
 	if err != nil {
 		return fmt.Errorf("begin delete oauth client tx: %w", err)
 	}
 	defer tx.Rollback() // no-op after Commit
+
+	// Postgres: lock the parent row first to serialize against
+	// concurrent grant/token inserts. Skipped on SQLite because
+	// (a) BEGIN IMMEDIATE already serializes writes, and (b) the
+	// FOR UPDATE syntax isn't recognized by every SQLite driver.
+	if s.dialect.Driver() == DriverPostgres {
+		var locked sql.NullString
+		err := tx.QueryRow(s.q(`SELECT id FROM oauth_clients WHERE id = ? FOR UPDATE`), id).Scan(&locked)
+		if err != nil && err != sql.ErrNoRows {
+			return fmt.Errorf("lock oauth client row: %w", err)
+		}
+		// sql.ErrNoRows is fine: the client doesn't exist, so the
+		// subsequent DELETEs match nothing and the call stays
+		// idempotent. We still proceed through the deletes for
+		// uniform code paths.
+	}
 
 	// Order: child rows first, parent (oauth_clients) last. Required
 	// for the FK constraint to be satisfied at commit time when ON

--- a/internal/store/oauth.go
+++ b/internal/store/oauth.go
@@ -193,8 +193,13 @@ func (s *Store) DeleteOAuthClient(id string) error {
 // CreateAuthorizationCode persists a code's session under its
 // signature. The signature is fosite's HMAC of the code value;
 // the code itself is never stored, so a DB read can't replay it.
+//
+// The row's `active` column is always set TRUE on insert; callers
+// flip it via InvalidateAuthorizationCode after the code is
+// exchanged. Pre-seeding an inactive row isn't a supported flow —
+// fosite never does it.
 func (s *Store) CreateAuthorizationCode(req models.OAuthRequest) error {
-	return s.insertOAuthRequestRow("oauth_authorization_codes", req, false)
+	return s.insertOAuthRequestRow("oauth_authorization_codes", req)
 }
 
 // GetAuthorizationCode hydrates the code's session. Returns
@@ -233,11 +238,17 @@ func (s *Store) InvalidateAuthorizationCode(signature string) error {
 // Access tokens (handler/oauth2/storage.go AccessTokenStorage)
 // ============================================================
 
-// CreateAccessToken persists an access token row. fosite always
-// stamps `active=true` on insert; the column is materialized here
-// so RevokeAccessToken can flip it without re-issuing.
+// CreateAccessToken persists an access token row. The row's
+// `active` column is always set TRUE on insert; callers flip it
+// via DeleteAccessToken (drop) or RevokeAccessTokenFamily (mark
+// inactive but keep the row for introspection auditing). The
+// caller's `req.Active` field is ignored on insert — fosite never
+// issues pre-revoked tokens, so honoring it would only enable
+// silently-broken adapters. Codex review #370 round 1 caught the
+// previous bug where zero-value `req.Active=false` collided with
+// the default and silently issued inactive tokens.
 func (s *Store) CreateAccessToken(req models.OAuthRequest) error {
-	return s.insertOAuthRequestRow("oauth_access_tokens", req, true)
+	return s.insertOAuthRequestRow("oauth_access_tokens", req)
 }
 
 // GetAccessToken hydrates an access token by its HMAC signature.
@@ -272,9 +283,10 @@ func (s *Store) DeleteAccessToken(signature string) error {
 // CreateRefreshToken persists a refresh token. accessSignature links
 // the refresh to the access token issued in the same grant; pass
 // empty string when there is no paired access token (rare — only
-// during error recovery flows).
+// during error recovery flows). Same active-on-insert contract as
+// CreateAccessToken — the caller's req.Active field is ignored.
 func (s *Store) CreateRefreshToken(req models.OAuthRequest) error {
-	return s.insertOAuthRequestRow("oauth_refresh_tokens", req, true)
+	return s.insertOAuthRequestRow("oauth_refresh_tokens", req)
 }
 
 // GetRefreshToken hydrates a refresh token. Returns
@@ -375,7 +387,7 @@ func (s *Store) CreatePKCERequest(req models.OAuthRequest) error {
 	// PKCE rows have no `active` column (lifecycle is "exists or
 	// deleted" rather than "active or revoked"). insertOAuthRequestRow
 	// with table=oauth_pkce_requests skips the active column write.
-	return s.insertOAuthRequestRow("oauth_pkce_requests", req, false /*ignored for pkce*/)
+	return s.insertOAuthRequestRow("oauth_pkce_requests", req)
 }
 
 // GetPKCERequest hydrates the PKCE session. Returns ErrOAuthNotFound
@@ -402,7 +414,7 @@ func (s *Store) DeletePKCERequest(signature string) error {
 
 // insertOAuthRequestRow writes a request payload into the named
 // table. The four request-row tables (auth codes, access tokens,
-// refresh tokens, pkce) share the same column set with two
+// refresh tokens, pkce) share the same column set with three
 // exceptions:
 //
 //   - pkce has no `active` column (no revocation lifecycle).
@@ -412,12 +424,19 @@ func (s *Store) DeletePKCERequest(signature string) error {
 //   - refresh has an `access_token_signature` column linking to the
 //     access row issued in the same grant.
 //
+// Active-on-insert contract: the three flagged tables (codes /
+// access / refresh) ALWAYS get `active=TRUE`. The caller's
+// req.Active field is ignored — fosite never issues pre-revoked
+// tokens, and honoring zero-value Active=false would silently
+// produce immediately-revoked tokens for any adapter that didn't
+// remember to set it. Codex review #370 round 1.
+//
 // Switch on the table name to pick the right INSERT — uglier than
 // per-table methods but keeps the call sites uniform and lets the
 // helpers below share the same row-decoding code on read. The
 // per-table methods above (CreateAccessToken etc.) are the public
 // surface; this is the private worker.
-func (s *Store) insertOAuthRequestRow(table string, req models.OAuthRequest, defaultActive bool) error {
+func (s *Store) insertOAuthRequestRow(table string, req models.OAuthRequest) error {
 	if req.Signature == "" {
 		return fmt.Errorf("oauth: signature required")
 	}
@@ -434,16 +453,10 @@ func (s *Store) insertOAuthRequestRow(table string, req models.OAuthRequest, def
 	}
 	requestedStr := requestedAt.UTC().Format(time.RFC3339)
 
-	// Active defaults to true for token tables on insert; auth-code
-	// rows are also active on insert. The defaultActive flag is the
-	// hint the caller passes, but the OAuthRequest itself wins when
-	// explicitly set (false on insert is rare — only used by tests
-	// to seed a pre-revoked row).
-	active := defaultActive
-	if req.Active != defaultActive {
-		// The caller explicitly overrode it.
-		active = req.Active
-	}
+	// Always TRUE on insert for the three flagged tables. Callers
+	// drop a row to inactive via Invalidate / Rotate /
+	// RevokeXxxFamily; pre-seeding inactive isn't a supported flow.
+	const active = true
 
 	switch table {
 	case "oauth_authorization_codes":

--- a/internal/store/oauth.go
+++ b/internal/store/oauth.go
@@ -172,16 +172,48 @@ func (s *Store) GetOAuthClient(id string) (*models.OAuthClient, error) {
 	return &c, nil
 }
 
-// DeleteOAuthClient removes a client and all dependent token /
-// auth-code / pkce rows by FK cascade is NOT used because Postgres
-// FKs default to NO ACTION and we never wrote ON DELETE CASCADE in
-// the migration. Callers needing to delete a client must revoke its
-// outstanding grants first (sub-PR D's revocation flow), then delete.
-// Returns nil even if the client doesn't exist (idempotent delete).
+// DeleteOAuthClient removes a client AND every dependent row (auth
+// codes, access tokens, refresh tokens, PKCE sessions) atomically.
+//
+// Why explicit cascade in code rather than ON DELETE CASCADE on the
+// FKs: keeping the FK as a plain reference means a stray
+// `DELETE FROM oauth_clients` from a future migration / admin tool
+// errors loudly instead of silently nuking grants. The intentional
+// cascade lives here, in one named method, so its blast radius is
+// obvious and auditable. Codex review #370 round 3 caught the
+// previous behaviour where DeleteOAuthClient errored on FK violation
+// for any client that had ever issued a grant.
+//
+// Idempotent: calling on a non-existent client is a no-op (every
+// dependent table's WHERE matches nothing). Atomic: if any of the
+// five DELETEs fails, the whole transaction rolls back so we never
+// leave a half-deleted client.
 func (s *Store) DeleteOAuthClient(id string) error {
-	_, err := s.db.Exec(s.q(`DELETE FROM oauth_clients WHERE id = ?`), id)
+	tx, err := s.db.Begin()
 	if err != nil {
-		return fmt.Errorf("delete oauth client: %w", err)
+		return fmt.Errorf("begin delete oauth client tx: %w", err)
+	}
+	defer tx.Rollback() // no-op after Commit
+
+	// Order: child rows first, parent (oauth_clients) last. Required
+	// for the FK constraint to be satisfied at commit time when ON
+	// DELETE CASCADE isn't set. The order between the four child
+	// tables doesn't matter — none reference each other.
+	deletes := []string{
+		`DELETE FROM oauth_pkce_requests WHERE client_id = ?`,
+		`DELETE FROM oauth_refresh_tokens WHERE client_id = ?`,
+		`DELETE FROM oauth_access_tokens WHERE client_id = ?`,
+		`DELETE FROM oauth_authorization_codes WHERE client_id = ?`,
+		`DELETE FROM oauth_clients WHERE id = ?`,
+	}
+	for _, q := range deletes {
+		if _, err := tx.Exec(s.q(q), id); err != nil {
+			return fmt.Errorf("delete oauth client cascade (%q): %w", q, err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit delete oauth client: %w", err)
 	}
 	return nil
 }

--- a/internal/store/oauth_test.go
+++ b/internal/store/oauth_test.go
@@ -423,6 +423,81 @@ func TestOAuth_PKCE_CRUD(t *testing.T) {
 // Validation
 // ------------------------------------------------------------
 
+// TestOAuth_Insert_AlwaysActive pins the active-on-insert contract
+// the round-1 Codex finding flushed out. Before the fix,
+// insertOAuthRequestRow used `if req.Active != defaultActive` to
+// detect "explicit override" — but a zero-value bool is
+// indistinguishable from "the caller forgot to set it," so any
+// adapter that built an OAuthRequest without explicitly setting
+// Active=true would silently store an immediately-revoked token.
+//
+// The fix hardcodes active=TRUE on insert; this test enforces that
+// invariant by passing zero-value Active and asserting the row is
+// readable as active. Without the fix, GetAccessToken would return
+// ErrOAuthInactiveToken here.
+func TestOAuth_Insert_AlwaysActive(t *testing.T) {
+	s := testStore(t)
+	c := newTestClient(t, s)
+
+	// Deliberately omit Active — caller used the zero value.
+	req := models.OAuthRequest{
+		Signature:   "active-default-1",
+		RequestID:   "req-1",
+		ClientID:    c.ID,
+		Subject:     "user-x",
+		RequestedAt: time.Now().UTC(),
+		// Active: not set; zero value is false.
+	}
+	if err := s.CreateAccessToken(req); err != nil {
+		t.Fatalf("CreateAccessToken: %v", err)
+	}
+
+	got, err := s.GetAccessToken("active-default-1")
+	if err != nil {
+		t.Fatalf("GetAccessToken (must succeed because insert hardcodes active=true): %v", err)
+	}
+	if !got.Active {
+		t.Error("row stored with active=false despite hardcoded active=true on insert; the round-1 fix regressed")
+	}
+
+	// Same for refresh tokens.
+	rreq := models.OAuthRequest{
+		Signature:   "active-default-2",
+		RequestID:   "req-2",
+		ClientID:    c.ID,
+		Subject:     "user-x",
+		RequestedAt: time.Now().UTC(),
+	}
+	if err := s.CreateRefreshToken(rreq); err != nil {
+		t.Fatalf("CreateRefreshToken: %v", err)
+	}
+	rgot, err := s.GetRefreshToken("active-default-2")
+	if err != nil {
+		t.Fatalf("GetRefreshToken: %v", err)
+	}
+	if !rgot.Active {
+		t.Error("refresh row stored inactive despite zero-value Active in input")
+	}
+
+	// Same for auth codes.
+	creq := models.OAuthRequest{
+		Signature:   "active-default-3",
+		RequestID:   "req-3",
+		ClientID:    c.ID,
+		RequestedAt: time.Now().UTC(),
+	}
+	if err := s.CreateAuthorizationCode(creq); err != nil {
+		t.Fatalf("CreateAuthorizationCode: %v", err)
+	}
+	cgot, err := s.GetAuthorizationCode("active-default-3")
+	if err != nil {
+		t.Fatalf("GetAuthorizationCode (must succeed; insert is active=true): %v", err)
+	}
+	if !cgot.Active {
+		t.Error("auth code stored inactive despite zero-value Active in input")
+	}
+}
+
 func TestOAuth_Insert_RejectsEmptyRequiredFields(t *testing.T) {
 	// The store-level guards exist as defense in depth — fosite's
 	// adapter in sub-PR B will populate these fields, but the SQL

--- a/internal/store/oauth_test.go
+++ b/internal/store/oauth_test.go
@@ -109,6 +109,57 @@ func TestOAuth_GetOAuthClient_NotFound(t *testing.T) {
 	}
 }
 
+// TestOAuth_DeleteOAuthClient_CascadesDependentRows pins the round-3
+// fix Codex caught: DeleteOAuthClient must cascade through the four
+// dependent tables (auth codes, access tokens, refresh tokens, PKCE)
+// rather than failing with an FK violation on any client that has
+// ever issued a grant. The cascade is intentional + named (no ON
+// DELETE CASCADE on the migration) so its blast radius stays
+// obvious to future readers.
+func TestOAuth_DeleteOAuthClient_CascadesDependentRows(t *testing.T) {
+	s := testStore(t)
+	c := newTestClient(t, s)
+
+	// Seed every dependent table with a row referencing this client.
+	if err := s.CreateAuthorizationCode(newTestRequest(c.ID, "code-cascade", "req-cascade")); err != nil {
+		t.Fatalf("create code: %v", err)
+	}
+	if err := s.CreateAccessToken(newTestRequest(c.ID, "access-cascade", "req-cascade")); err != nil {
+		t.Fatalf("create access: %v", err)
+	}
+	if err := s.CreateRefreshToken(newTestRequest(c.ID, "refresh-cascade", "req-cascade")); err != nil {
+		t.Fatalf("create refresh: %v", err)
+	}
+	if err := s.CreatePKCERequest(newTestRequest(c.ID, "pkce-cascade", "req-cascade")); err != nil {
+		t.Fatalf("create pkce: %v", err)
+	}
+
+	// Without the round-3 fix this errors with an FK constraint
+	// violation. With the cascade in place, the delete succeeds and
+	// every dependent row is gone.
+	if err := s.DeleteOAuthClient(c.ID); err != nil {
+		t.Fatalf("DeleteOAuthClient with dependent rows must cascade: %v", err)
+	}
+
+	// Verify nothing's left behind. NotFound on each row's
+	// signature confirms the cascade reached it.
+	if _, err := s.GetAuthorizationCode("code-cascade"); !errors.Is(err, ErrOAuthNotFound) {
+		t.Errorf("auth code not cascaded; got %v", err)
+	}
+	if _, err := s.GetAccessToken("access-cascade"); !errors.Is(err, ErrOAuthNotFound) {
+		t.Errorf("access token not cascaded; got %v", err)
+	}
+	if _, err := s.GetRefreshToken("refresh-cascade"); !errors.Is(err, ErrOAuthNotFound) {
+		t.Errorf("refresh token not cascaded; got %v", err)
+	}
+	if _, err := s.GetPKCERequest("pkce-cascade"); !errors.Is(err, ErrOAuthNotFound) {
+		t.Errorf("pkce row not cascaded; got %v", err)
+	}
+	if _, err := s.GetOAuthClient(c.ID); !errors.Is(err, ErrOAuthNotFound) {
+		t.Errorf("client itself not deleted; got %v", err)
+	}
+}
+
 func TestOAuth_DeleteOAuthClient_Idempotent(t *testing.T) {
 	s := testStore(t)
 	c := newTestClient(t, s)

--- a/internal/store/oauth_test.go
+++ b/internal/store/oauth_test.go
@@ -1,0 +1,451 @@
+package store
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// Tests for the OAuth 2.1 storage layer (PLAN-943 TASK-951 sub-PR A).
+// The store layer is fosite-agnostic by design — sub-PR B introduces
+// the fosite import + adapter wrappers. These tests exercise the
+// storage primitives directly so the schema + CRUD shape is verified
+// in isolation, before fosite types add semantic checks on top.
+//
+// Both backends share the same test bodies via testStore(t), which
+// switches to Postgres when PAD_TEST_POSTGRES_URL is set in CI.
+// The test client used everywhere (newTestClient) seeds an
+// oauth_clients row first because every other table FKs into it.
+
+func newTestClient(t *testing.T, s *Store) *models.OAuthClient {
+	t.Helper()
+	c, err := s.CreateOAuthClient(models.OAuthClientCreate{
+		Name:                    "Test Client",
+		RedirectURIs:            []string{"https://example.test/callback"},
+		GrantTypes:              []string{"authorization_code", "refresh_token"},
+		ResponseTypes:           []string{"code"},
+		TokenEndpointAuthMethod: "none",
+		Scopes:                  []string{"pad:read", "pad:write"},
+		Public:                  true,
+	})
+	if err != nil {
+		t.Fatalf("CreateOAuthClient: %v", err)
+	}
+	return c
+}
+
+// newTestRequest builds an OAuthRequest with sensible defaults; tests
+// override fields they care about. signature uniqueness is the
+// caller's responsibility — pass distinct strings per row.
+func newTestRequest(clientID, signature, requestID string) models.OAuthRequest {
+	return models.OAuthRequest{
+		Signature:       signature,
+		RequestID:       requestID,
+		RequestedAt:     time.Now().UTC(),
+		ClientID:        clientID,
+		Scopes:          "pad:read pad:write",
+		GrantedScopes:   "pad:read pad:write",
+		RequestForm:     "client_id=" + clientID + "&code_challenge=abc&code_challenge_method=S256",
+		SessionData:     `{"subject":"user-123"}`,
+		Audience:        "https://mcp.test.example/mcp",
+		GrantedAudience: "https://mcp.test.example/mcp",
+		Active:          true,
+		Subject:         "user-123",
+	}
+}
+
+// ------------------------------------------------------------
+// Clients
+// ------------------------------------------------------------
+
+func TestOAuth_ClientCRUD(t *testing.T) {
+	s := testStore(t)
+
+	created, err := s.CreateOAuthClient(models.OAuthClientCreate{
+		Name:                    "MyApp",
+		RedirectURIs:            []string{"https://app.test/cb", "http://localhost:3000/cb"},
+		GrantTypes:              []string{"authorization_code", "refresh_token"},
+		ResponseTypes:           []string{"code"},
+		TokenEndpointAuthMethod: "none",
+		Scopes:                  []string{"pad:read", "pad:write", "pad:admin"},
+		Public:                  true,
+		LogoURL:                 "https://app.test/logo.png",
+	})
+	if err != nil {
+		t.Fatalf("CreateOAuthClient: %v", err)
+	}
+	if created.ID == "" {
+		t.Error("expected non-empty client_id")
+	}
+	if created.CreatedAt.IsZero() {
+		t.Error("expected non-zero CreatedAt")
+	}
+
+	got, err := s.GetOAuthClient(created.ID)
+	if err != nil {
+		t.Fatalf("GetOAuthClient: %v", err)
+	}
+	if got.Name != "MyApp" {
+		t.Errorf("Name: got %q, want %q", got.Name, "MyApp")
+	}
+	if len(got.RedirectURIs) != 2 || got.RedirectURIs[1] != "http://localhost:3000/cb" {
+		t.Errorf("RedirectURIs round-trip lost order or values: %v", got.RedirectURIs)
+	}
+	if !got.Public {
+		t.Error("Public flag did not round-trip true")
+	}
+	if got.LogoURL != "https://app.test/logo.png" {
+		t.Errorf("LogoURL: got %q", got.LogoURL)
+	}
+}
+
+func TestOAuth_GetOAuthClient_NotFound(t *testing.T) {
+	s := testStore(t)
+	_, err := s.GetOAuthClient("does-not-exist")
+	if !errors.Is(err, ErrOAuthNotFound) {
+		t.Errorf("expected ErrOAuthNotFound, got %v", err)
+	}
+}
+
+func TestOAuth_DeleteOAuthClient_Idempotent(t *testing.T) {
+	s := testStore(t)
+	c := newTestClient(t, s)
+	if err := s.DeleteOAuthClient(c.ID); err != nil {
+		t.Fatalf("first delete: %v", err)
+	}
+	// Second delete must not error — idempotency is part of the
+	// contract so /oauth/register failure-recovery flows can retry.
+	if err := s.DeleteOAuthClient(c.ID); err != nil {
+		t.Errorf("second delete: %v", err)
+	}
+	// Get must report not-found after delete.
+	if _, err := s.GetOAuthClient(c.ID); !errors.Is(err, ErrOAuthNotFound) {
+		t.Errorf("expected ErrOAuthNotFound after delete, got %v", err)
+	}
+}
+
+func TestOAuth_CreateClient_EmptySlicesNormalize(t *testing.T) {
+	// nil / empty slices must round-trip as empty (non-nil) so
+	// callers can range without nil-checking. Pinning this prevents
+	// a regression where Postgres's JSONB column returns null for
+	// missing fields — the store would have to map null→[].
+	s := testStore(t)
+	c, err := s.CreateOAuthClient(models.OAuthClientCreate{
+		Name: "Minimal",
+	})
+	if err != nil {
+		t.Fatalf("CreateOAuthClient minimal: %v", err)
+	}
+	got, err := s.GetOAuthClient(c.ID)
+	if err != nil {
+		t.Fatalf("GetOAuthClient: %v", err)
+	}
+	for name, slice := range map[string][]string{
+		"RedirectURIs":  got.RedirectURIs,
+		"GrantTypes":    got.GrantTypes,
+		"ResponseTypes": got.ResponseTypes,
+		"Scopes":        got.Scopes,
+	} {
+		if slice == nil {
+			t.Errorf("%s: expected empty slice, got nil", name)
+		}
+		if len(slice) != 0 {
+			t.Errorf("%s: expected empty, got %v", name, slice)
+		}
+	}
+	// Default token endpoint auth method.
+	if got.TokenEndpointAuthMethod != "none" {
+		t.Errorf("TokenEndpointAuthMethod default: got %q, want %q", got.TokenEndpointAuthMethod, "none")
+	}
+}
+
+// ------------------------------------------------------------
+// Authorization codes
+// ------------------------------------------------------------
+
+func TestOAuth_AuthorizationCode_CRUDAndInvalidate(t *testing.T) {
+	s := testStore(t)
+	c := newTestClient(t, s)
+
+	req := newTestRequest(c.ID, "code-sig-1", "request-1")
+	if err := s.CreateAuthorizationCode(req); err != nil {
+		t.Fatalf("CreateAuthorizationCode: %v", err)
+	}
+
+	got, err := s.GetAuthorizationCode("code-sig-1")
+	if err != nil {
+		t.Fatalf("GetAuthorizationCode active: %v", err)
+	}
+	if got.ClientID != c.ID || got.RequestID != "request-1" {
+		t.Errorf("round-trip mismatch: got=%+v", got)
+	}
+	if got.SessionData != `{"subject":"user-123"}` {
+		t.Errorf("session_data round-trip lost: %q", got.SessionData)
+	}
+
+	if err := s.InvalidateAuthorizationCode("code-sig-1"); err != nil {
+		t.Fatalf("InvalidateAuthorizationCode: %v", err)
+	}
+
+	got2, err := s.GetAuthorizationCode("code-sig-1")
+	if !errors.Is(err, ErrOAuthInvalidatedCode) {
+		t.Fatalf("expected ErrOAuthInvalidatedCode after invalidate, got %v", err)
+	}
+	// Per fosite contract, the request payload is still returned
+	// alongside the error so the caller can run family revocation.
+	if got2 == nil {
+		t.Fatal("expected request payload returned alongside ErrOAuthInvalidatedCode, got nil")
+	}
+	if got2.RequestID != "request-1" {
+		t.Errorf("invalidate-then-get must still surface request_id (caller revokes family by it); got %q", got2.RequestID)
+	}
+}
+
+func TestOAuth_GetAuthorizationCode_NotFound(t *testing.T) {
+	s := testStore(t)
+	_, err := s.GetAuthorizationCode("nope")
+	if !errors.Is(err, ErrOAuthNotFound) {
+		t.Errorf("expected ErrOAuthNotFound, got %v", err)
+	}
+}
+
+func TestOAuth_InvalidateAuthorizationCode_Idempotent(t *testing.T) {
+	// Invalidating an absent / already-invalid row must not error.
+	// fosite's contract is "make it invalid"; our store doesn't
+	// distinguish "wasn't there" from "was already invalid".
+	s := testStore(t)
+	if err := s.InvalidateAuthorizationCode("never-existed"); err != nil {
+		t.Errorf("expected nil on absent code, got %v", err)
+	}
+}
+
+// ------------------------------------------------------------
+// Access tokens
+// ------------------------------------------------------------
+
+func TestOAuth_AccessToken_CRUDAndDelete(t *testing.T) {
+	s := testStore(t)
+	c := newTestClient(t, s)
+
+	req := newTestRequest(c.ID, "access-sig-1", "request-1")
+	if err := s.CreateAccessToken(req); err != nil {
+		t.Fatalf("CreateAccessToken: %v", err)
+	}
+
+	got, err := s.GetAccessToken("access-sig-1")
+	if err != nil {
+		t.Fatalf("GetAccessToken: %v", err)
+	}
+	if got.Subject != "user-123" {
+		t.Errorf("Subject not denormalized correctly: %q", got.Subject)
+	}
+
+	if err := s.DeleteAccessToken("access-sig-1"); err != nil {
+		t.Fatalf("DeleteAccessToken: %v", err)
+	}
+
+	if _, err := s.GetAccessToken("access-sig-1"); !errors.Is(err, ErrOAuthNotFound) {
+		t.Errorf("expected ErrOAuthNotFound after delete, got %v", err)
+	}
+}
+
+// ------------------------------------------------------------
+// Refresh tokens — rotation + family revocation (the security-critical part)
+// ------------------------------------------------------------
+
+func TestOAuth_RefreshToken_CRUD(t *testing.T) {
+	s := testStore(t)
+	c := newTestClient(t, s)
+
+	req := newTestRequest(c.ID, "refresh-sig-1", "request-1")
+	req.AccessTokenSignature = "access-sig-1"
+	if err := s.CreateRefreshToken(req); err != nil {
+		t.Fatalf("CreateRefreshToken: %v", err)
+	}
+
+	got, err := s.GetRefreshToken("refresh-sig-1")
+	if err != nil {
+		t.Fatalf("GetRefreshToken: %v", err)
+	}
+	if got.AccessTokenSignature != "access-sig-1" {
+		t.Errorf("AccessTokenSignature did not round-trip: got %q", got.AccessTokenSignature)
+	}
+	if got.RequestID != "request-1" {
+		t.Errorf("RequestID round-trip: got %q", got.RequestID)
+	}
+}
+
+func TestOAuth_RotateRefreshToken_FlipsActiveOnSingleRow(t *testing.T) {
+	// fosite's RotateRefreshToken marks the named row inactive after
+	// issuing the next-step rotation. It must NOT touch other rows
+	// in the chain — that's RevokeRefreshTokenFamily's job.
+	s := testStore(t)
+	c := newTestClient(t, s)
+
+	chain := "request-rotate-1"
+
+	r1 := newTestRequest(c.ID, "refresh-1", chain)
+	r2 := newTestRequest(c.ID, "refresh-2", chain) // simulates the rotated successor
+	if err := s.CreateRefreshToken(r1); err != nil {
+		t.Fatalf("create r1: %v", err)
+	}
+	if err := s.CreateRefreshToken(r2); err != nil {
+		t.Fatalf("create r2: %v", err)
+	}
+
+	// Rotate r1 (mark inactive); r2 stays active.
+	if err := s.RotateRefreshToken(chain, "refresh-1"); err != nil {
+		t.Fatalf("RotateRefreshToken: %v", err)
+	}
+
+	// r1 → inactive: GetRefreshToken returns ErrOAuthInactiveToken
+	// alongside the request payload (so the caller can run family
+	// revocation if this was a replay).
+	got1, err := s.GetRefreshToken("refresh-1")
+	if !errors.Is(err, ErrOAuthInactiveToken) {
+		t.Errorf("expected ErrOAuthInactiveToken on rotated refresh, got %v", err)
+	}
+	if got1 == nil {
+		t.Fatal("expected request payload alongside ErrOAuthInactiveToken")
+	}
+
+	// r2 must still be active — rotation is per-row, not per-chain.
+	got2, err := s.GetRefreshToken("refresh-2")
+	if err != nil {
+		t.Fatalf("expected r2 still active, got error: %v", err)
+	}
+	if !got2.Active {
+		t.Error("rotation must NOT touch other rows in the same chain")
+	}
+}
+
+func TestOAuth_RevokeRefreshTokenFamily_RevokesEntireChain(t *testing.T) {
+	// The OAuth 2.1 BCP §4.14 "revoke the whole family on a replayed
+	// refresh" rule. fosite triggers this when GetRefreshToken on a
+	// previously-rotated (inactive) row signals replay.
+	s := testStore(t)
+	c := newTestClient(t, s)
+
+	chain := "request-family-1"
+	other := "request-other-1"
+
+	for _, sig := range []string{"r1", "r2", "r3"} {
+		if err := s.CreateRefreshToken(newTestRequest(c.ID, sig, chain)); err != nil {
+			t.Fatalf("create %s: %v", sig, err)
+		}
+	}
+	// Other-chain row must NOT be touched by the revocation.
+	if err := s.CreateRefreshToken(newTestRequest(c.ID, "other-r1", other)); err != nil {
+		t.Fatalf("create other-r1: %v", err)
+	}
+
+	if err := s.RevokeRefreshTokenFamily(chain); err != nil {
+		t.Fatalf("RevokeRefreshTokenFamily: %v", err)
+	}
+
+	for _, sig := range []string{"r1", "r2", "r3"} {
+		_, err := s.GetRefreshToken(sig)
+		if !errors.Is(err, ErrOAuthInactiveToken) {
+			t.Errorf("%s: expected ErrOAuthInactiveToken after family revoke, got %v", sig, err)
+		}
+	}
+
+	otherGot, err := s.GetRefreshToken("other-r1")
+	if err != nil {
+		t.Fatalf("other-chain r1 should still be readable, got %v", err)
+	}
+	if !otherGot.Active {
+		t.Error("RevokeRefreshTokenFamily(chain) must NOT touch rows in a different request_id chain")
+	}
+}
+
+func TestOAuth_RevokeAccessTokenFamily_RevokesEntireChain(t *testing.T) {
+	// Symmetric to RevokeRefreshTokenFamily — fosite revokes both
+	// access and refresh families when the user clicks "log out
+	// everywhere" or POSTs /oauth/revoke (sub-PR D).
+	s := testStore(t)
+	c := newTestClient(t, s)
+
+	chain := "request-access-family-1"
+	for _, sig := range []string{"a1", "a2"} {
+		if err := s.CreateAccessToken(newTestRequest(c.ID, sig, chain)); err != nil {
+			t.Fatalf("create %s: %v", sig, err)
+		}
+	}
+
+	if err := s.RevokeAccessTokenFamily(chain); err != nil {
+		t.Fatalf("RevokeAccessTokenFamily: %v", err)
+	}
+
+	for _, sig := range []string{"a1", "a2"} {
+		_, err := s.GetAccessToken(sig)
+		if !errors.Is(err, ErrOAuthInactiveToken) {
+			t.Errorf("%s: expected ErrOAuthInactiveToken after family revoke, got %v", sig, err)
+		}
+	}
+}
+
+// ------------------------------------------------------------
+// PKCE
+// ------------------------------------------------------------
+
+func TestOAuth_PKCE_CRUD(t *testing.T) {
+	s := testStore(t)
+	c := newTestClient(t, s)
+
+	req := newTestRequest(c.ID, "pkce-sig-1", "request-1")
+	if err := s.CreatePKCERequest(req); err != nil {
+		t.Fatalf("CreatePKCERequest: %v", err)
+	}
+
+	got, err := s.GetPKCERequest("pkce-sig-1")
+	if err != nil {
+		t.Fatalf("GetPKCERequest: %v", err)
+	}
+	// PKCE row carries the same request_form fosite stored at /authorize
+	// time; sub-PR B's adapter parses code_challenge out of it.
+	if got.RequestForm == "" {
+		t.Error("RequestForm must round-trip (carries code_challenge for verification)")
+	}
+
+	if err := s.DeletePKCERequest("pkce-sig-1"); err != nil {
+		t.Fatalf("DeletePKCERequest: %v", err)
+	}
+
+	if _, err := s.GetPKCERequest("pkce-sig-1"); !errors.Is(err, ErrOAuthNotFound) {
+		t.Errorf("expected ErrOAuthNotFound after delete, got %v", err)
+	}
+}
+
+// ------------------------------------------------------------
+// Validation
+// ------------------------------------------------------------
+
+func TestOAuth_Insert_RejectsEmptyRequiredFields(t *testing.T) {
+	// The store-level guards exist as defense in depth — fosite's
+	// adapter in sub-PR B will populate these fields, but the SQL
+	// schema's NOT NULL constraints would otherwise produce
+	// confusing "constraint failed" errors. The store rejects
+	// upstream with a clear message.
+	s := testStore(t)
+	c := newTestClient(t, s)
+
+	cases := map[string]models.OAuthRequest{
+		"missing signature": {
+			RequestID: "r1", ClientID: c.ID,
+		},
+		"missing request_id": {
+			Signature: "sig", ClientID: c.ID,
+		},
+		"missing client_id": {
+			Signature: "sig", RequestID: "r1",
+		},
+	}
+	for name, req := range cases {
+		if err := s.CreateAccessToken(req); err == nil {
+			t.Errorf("%s: expected error, got nil", name)
+		}
+	}
+}

--- a/internal/store/oauth_test.go
+++ b/internal/store/oauth_test.go
@@ -277,47 +277,65 @@ func TestOAuth_RefreshToken_CRUD(t *testing.T) {
 	}
 }
 
-func TestOAuth_RotateRefreshToken_FlipsActiveOnSingleRow(t *testing.T) {
-	// fosite's RotateRefreshToken marks the named row inactive after
-	// issuing the next-step rotation. It must NOT touch other rows
-	// in the chain — that's RevokeRefreshTokenFamily's job.
+func TestOAuth_RotateRefreshToken_RevokesEntireGrant(t *testing.T) {
+	// Per fosite's reference MemoryStore.RotateRefreshToken
+	// (storage/memory.go:497-504), rotation revokes BOTH the refresh
+	// family AND the access family for the grant's request_id, then
+	// fosite immediately issues a fresh pair via CreateAccessTokenSession
+	// + CreateRefreshTokenSession (which inherit the same request_id
+	// per flow_refresh.go:86 and get inserted active=TRUE per our
+	// insertOAuthRequestRow contract).
+	//
+	// Codex review #370 round 2 caught the previous implementation
+	// that flipped only the named refresh row, leaving the previously-
+	// issued access token active until TTL expired. The test below
+	// pins the corrected behavior: after rotation, the OLD refresh +
+	// OLD access in the grant are inactive, and unrelated grants are
+	// untouched.
 	s := testStore(t)
 	c := newTestClient(t, s)
-
 	chain := "request-rotate-1"
+	other := "request-other-1"
 
-	r1 := newTestRequest(c.ID, "refresh-1", chain)
-	r2 := newTestRequest(c.ID, "refresh-2", chain) // simulates the rotated successor
-	if err := s.CreateRefreshToken(r1); err != nil {
-		t.Fatalf("create r1: %v", err)
+	// Seed the grant: one refresh + one access token sharing
+	// request_id = chain. (fosite never has multiple active
+	// refreshes in the same chain at once — the chain is sequential —
+	// so a single pair is the realistic input shape.)
+	rreq := newTestRequest(c.ID, "refresh-1", chain)
+	rreq.AccessTokenSignature = "access-1"
+	if err := s.CreateRefreshToken(rreq); err != nil {
+		t.Fatalf("create refresh: %v", err)
 	}
-	if err := s.CreateRefreshToken(r2); err != nil {
-		t.Fatalf("create r2: %v", err)
+	if err := s.CreateAccessToken(newTestRequest(c.ID, "access-1", chain)); err != nil {
+		t.Fatalf("create access: %v", err)
 	}
 
-	// Rotate r1 (mark inactive); r2 stays active.
+	// Seed an unrelated grant to verify rotation is scoped by request_id.
+	if err := s.CreateRefreshToken(newTestRequest(c.ID, "other-refresh", other)); err != nil {
+		t.Fatalf("create other refresh: %v", err)
+	}
+	if err := s.CreateAccessToken(newTestRequest(c.ID, "other-access", other)); err != nil {
+		t.Fatalf("create other access: %v", err)
+	}
+
 	if err := s.RotateRefreshToken(chain, "refresh-1"); err != nil {
 		t.Fatalf("RotateRefreshToken: %v", err)
 	}
 
-	// r1 → inactive: GetRefreshToken returns ErrOAuthInactiveToken
-	// alongside the request payload (so the caller can run family
-	// revocation if this was a replay).
-	got1, err := s.GetRefreshToken("refresh-1")
-	if !errors.Is(err, ErrOAuthInactiveToken) {
-		t.Errorf("expected ErrOAuthInactiveToken on rotated refresh, got %v", err)
+	// Both old refresh AND old access in the rotated grant must be inactive.
+	if got, err := s.GetRefreshToken("refresh-1"); !errors.Is(err, ErrOAuthInactiveToken) {
+		t.Errorf("refresh-1 must be inactive after rotation, got err=%v got=%+v", err, got)
 	}
-	if got1 == nil {
-		t.Fatal("expected request payload alongside ErrOAuthInactiveToken")
+	if got, err := s.GetAccessToken("access-1"); !errors.Is(err, ErrOAuthInactiveToken) {
+		t.Errorf("access-1 must be inactive after rotation (matches fosite's reference); got err=%v got=%+v", err, got)
 	}
 
-	// r2 must still be active — rotation is per-row, not per-chain.
-	got2, err := s.GetRefreshToken("refresh-2")
-	if err != nil {
-		t.Fatalf("expected r2 still active, got error: %v", err)
+	// Unrelated grant must be untouched — rotation is request_id-scoped.
+	if got, err := s.GetRefreshToken("other-refresh"); err != nil || !got.Active {
+		t.Errorf("other-chain refresh touched by rotation: err=%v got=%+v", err, got)
 	}
-	if !got2.Active {
-		t.Error("rotation must NOT touch other rows in the same chain")
+	if got, err := s.GetAccessToken("other-access"); err != nil || !got.Active {
+		t.Errorf("other-chain access touched by rotation: err=%v got=%+v", err, got)
 	}
 }
 

--- a/internal/store/pgmigrations/027_oauth.sql
+++ b/internal/store/pgmigrations/027_oauth.sql
@@ -1,0 +1,134 @@
+-- Migration 027 (Postgres): OAuth 2.1 server tables.
+--
+-- Postgres counterpart to migrations/048_oauth.sql. The two files
+-- carry the SAME schema with dialect-specific type tweaks:
+--
+--   - JSONB instead of TEXT for JSON-typed columns (faster + native
+--     containment queries, in case future audit queries want to
+--     introspect grant_types / redirect_uris arrays).
+--   - BOOLEAN instead of INTEGER for true/false flags (matches the
+--     pattern in pgmigrations/001_initial.sql for webhooks.active).
+--   - (NOW() AT TIME ZONE 'UTC')::TEXT for default timestamps,
+--     keeping the column TEXT so the cross-dialect ISO8601 contract
+--     stays uniform on the Go side.
+--   - REFERENCES <tab>(<col>) inline FK syntax.
+--
+-- Numbering note: Postgres migrations are at index 026 prior to
+-- this; SQLite is at 047. The two histories are independent (the
+-- runners scan their own dir + their own schema_migrations table)
+-- so the asymmetric numbering is fine. See store.go:migrate vs
+-- store.go:migratePostgres.
+--
+-- See migrations/048_oauth.sql for the full schema-level
+-- documentation. Comments here are dialect-only.
+
+-- ============================================================
+-- 1. Registered OAuth clients (RFC 7591 DCR)
+-- ============================================================
+CREATE TABLE IF NOT EXISTS oauth_clients (
+    id                          TEXT PRIMARY KEY,
+    name                        TEXT NOT NULL,
+    redirect_uris               JSONB NOT NULL DEFAULT '[]'::jsonb,
+    grant_types                 JSONB NOT NULL DEFAULT '[]'::jsonb,
+    response_types              JSONB NOT NULL DEFAULT '[]'::jsonb,
+    token_endpoint_auth_method  TEXT NOT NULL DEFAULT 'none',
+    scopes                      JSONB NOT NULL DEFAULT '[]'::jsonb,
+    public                      BOOLEAN NOT NULL DEFAULT TRUE,
+    logo_url                    TEXT,
+    created_at                  TEXT NOT NULL DEFAULT (NOW() AT TIME ZONE 'UTC')::TEXT
+);
+
+CREATE INDEX IF NOT EXISTS oauth_clients_created_at_idx
+    ON oauth_clients(created_at);
+
+-- ============================================================
+-- 2. Authorization codes
+-- ============================================================
+CREATE TABLE IF NOT EXISTS oauth_authorization_codes (
+    signature         TEXT PRIMARY KEY,
+    request_id        TEXT NOT NULL,
+    requested_at      TEXT NOT NULL,
+    client_id         TEXT NOT NULL REFERENCES oauth_clients(id),
+    scopes            TEXT NOT NULL DEFAULT '',
+    granted_scopes    TEXT NOT NULL DEFAULT '',
+    request_form      TEXT NOT NULL DEFAULT '',
+    session_data      TEXT NOT NULL DEFAULT '',
+    audience          TEXT NOT NULL DEFAULT '',
+    granted_audience  TEXT NOT NULL DEFAULT '',
+    active            BOOLEAN NOT NULL DEFAULT TRUE
+);
+
+CREATE INDEX IF NOT EXISTS oauth_codes_request_id_idx
+    ON oauth_authorization_codes(request_id);
+CREATE INDEX IF NOT EXISTS oauth_codes_requested_at_idx
+    ON oauth_authorization_codes(requested_at);
+
+-- ============================================================
+-- 3. Access tokens
+-- ============================================================
+CREATE TABLE IF NOT EXISTS oauth_access_tokens (
+    signature         TEXT PRIMARY KEY,
+    request_id        TEXT NOT NULL,
+    requested_at      TEXT NOT NULL,
+    client_id         TEXT NOT NULL REFERENCES oauth_clients(id),
+    scopes            TEXT NOT NULL DEFAULT '',
+    granted_scopes    TEXT NOT NULL DEFAULT '',
+    request_form      TEXT NOT NULL DEFAULT '',
+    session_data      TEXT NOT NULL DEFAULT '',
+    audience          TEXT NOT NULL DEFAULT '',
+    granted_audience  TEXT NOT NULL DEFAULT '',
+    active            BOOLEAN NOT NULL DEFAULT TRUE,
+    subject           TEXT NOT NULL DEFAULT ''
+);
+
+CREATE INDEX IF NOT EXISTS oauth_access_request_id_idx
+    ON oauth_access_tokens(request_id);
+CREATE INDEX IF NOT EXISTS oauth_access_subject_idx
+    ON oauth_access_tokens(subject);
+CREATE INDEX IF NOT EXISTS oauth_access_requested_at_idx
+    ON oauth_access_tokens(requested_at);
+
+-- ============================================================
+-- 4. Refresh tokens
+-- ============================================================
+CREATE TABLE IF NOT EXISTS oauth_refresh_tokens (
+    signature               TEXT PRIMARY KEY,
+    request_id              TEXT NOT NULL,
+    access_token_signature  TEXT,
+    requested_at            TEXT NOT NULL,
+    client_id               TEXT NOT NULL REFERENCES oauth_clients(id),
+    scopes                  TEXT NOT NULL DEFAULT '',
+    granted_scopes          TEXT NOT NULL DEFAULT '',
+    request_form            TEXT NOT NULL DEFAULT '',
+    session_data            TEXT NOT NULL DEFAULT '',
+    audience                TEXT NOT NULL DEFAULT '',
+    granted_audience        TEXT NOT NULL DEFAULT '',
+    active                  BOOLEAN NOT NULL DEFAULT TRUE,
+    subject                 TEXT NOT NULL DEFAULT ''
+);
+
+CREATE INDEX IF NOT EXISTS oauth_refresh_request_id_idx
+    ON oauth_refresh_tokens(request_id);
+CREATE INDEX IF NOT EXISTS oauth_refresh_subject_idx
+    ON oauth_refresh_tokens(subject);
+CREATE INDEX IF NOT EXISTS oauth_refresh_requested_at_idx
+    ON oauth_refresh_tokens(requested_at);
+
+-- ============================================================
+-- 5. PKCE request sessions
+-- ============================================================
+CREATE TABLE IF NOT EXISTS oauth_pkce_requests (
+    signature         TEXT PRIMARY KEY,
+    request_id        TEXT NOT NULL,
+    requested_at      TEXT NOT NULL,
+    client_id         TEXT NOT NULL REFERENCES oauth_clients(id),
+    scopes            TEXT NOT NULL DEFAULT '',
+    granted_scopes    TEXT NOT NULL DEFAULT '',
+    request_form      TEXT NOT NULL DEFAULT '',
+    session_data      TEXT NOT NULL DEFAULT '',
+    audience          TEXT NOT NULL DEFAULT '',
+    granted_audience  TEXT NOT NULL DEFAULT ''
+);
+
+CREATE INDEX IF NOT EXISTS oauth_pkce_request_id_idx
+    ON oauth_pkce_requests(request_id);


### PR DESCRIPTION
## Summary

First of 5 sub-PRs landing the OAuth 2.1 authorization server in PLAN-943. **Foundation only** — no HTTP exposure, no fosite import, no public surface change.

- **5 tables** (parallel SQLite + Postgres migrations) backing fosite's storage interfaces:
  - \`oauth_clients\` — RFC 7591 DCR; public clients only for v1
  - \`oauth_authorization_codes\` — short-lived auth codes
  - \`oauth_access_tokens\` — opaque HMAC; \`subject\` denormalized for fast user-bound queries
  - \`oauth_refresh_tokens\` — \`access_token_signature\` link + \`request_id\` chain identifier
  - \`oauth_pkce_requests\` — PKCE session keyed by auth-code signature
- **\`internal/store/oauth.go\`** — 12 public methods covering fosite's \`ClientManager\` + \`CoreStorage\` + \`PKCERequestStorage\` + \`TokenRevocationStorage\` interface shapes, using pad-internal types (\`models.OAuthClient\`, \`models.OAuthRequest\`) so the package stays fosite-free. Sub-PR B (TASK-1024) adds the fosite import + adapter wrappers.
- **3 sentinel errors** (\`ErrOAuthNotFound\`, \`ErrOAuthInvalidatedCode\`, \`ErrOAuthInactiveToken\`) that sub-PR B's adapter maps to fosite errors.

## Key design choice

\`request_id\` IS the chain identifier for theft-detection family revocation — fosite preserves it across rotations (handler/oauth2/flow_refresh.go:86), so \`RevokeRefreshTokenFamily(request_id)\` is a single indexed \`UPDATE … WHERE request_id = ?\` rather than walking a separate \`chain_id\` column.

## Tests (14, all passing)

- Client CRUD + idempotent delete + empty-slice normalization (\`[]\` not \`nil\` round-trip)
- Auth-code create/get/invalidate, including the "return payload alongside ErrInvalidatedCode" contract fosite relies on for family revocation
- Access-token CRUD + delete
- Refresh-token CRUD + \`RotateRefreshToken\` (single-row flip, leaves other chains untouched)
- **Refresh-token family revocation** (entire chain via \`request_id\`, leaves other chains untouched)
- Access-token family revocation
- PKCE CRUD
- Required-field validation

Both backends share test bodies via \`testStore(t)\`; set \`PAD_TEST_POSTGRES_URL\` in CI to run the same suite against Postgres.

## Out of scope (subsequent sub-PRs of TASK-951)

| Sub-PR | Task | Brings |
|---|---|---|
| B | TASK-1024 | fosite import + \`internal/oauth/server.go\` adapter |
| C | TASK-1025 | DCR + \`/authorize\` + \`/token\` endpoints + populated discovery doc |
| D | TASK-1026 | \`/revoke\` + \`/introspect\` endpoints |
| E | TASK-1027 | \`MCPBearerAuth\` OAuth introspection branch + \`/api/v1/oauth/clients/{id}/public-info\` |

## Test plan

- [x] \`go test ./...\` — all green (SQLite locally; Postgres via CI)
- [x] \`make install\` clean, server restarts without regression
- [x] Migration runner picks up \`048_oauth.sql\` on next boot, confirmed via existing tests
- [ ] \`/codex review --loop\`