### PR TITLE
feat(oauth): DCR + authorize + token endpoints + populated discovery (TASK-1025, sub-PR C of TASK-951)

### DIFF
--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -41,6 +41,7 @@ import (
 	mcpserver "github.com/PerpetualSoftware/pad/internal/mcp"
 	"github.com/PerpetualSoftware/pad/internal/metrics"
 	"github.com/PerpetualSoftware/pad/internal/models"
+	oauthpkg "github.com/PerpetualSoftware/pad/internal/oauth"
 	"github.com/PerpetualSoftware/pad/internal/server"
 	"github.com/PerpetualSoftware/pad/internal/store"
 	"github.com/PerpetualSoftware/pad/internal/webhooks"
@@ -413,6 +414,36 @@ func serveCmd() *cobra.Command {
 					"auth_server", cfg.AuthServerURL,
 					"resources_wired", false,
 				)
+
+				// OAuth 2.1 authorization server (PLAN-943 TASK-1024
+				// constructor + TASK-1025 HTTP handlers). Wired only
+				// when the cloud deployment has a configured MCP
+				// public URL — the OAuth server's audience strategy
+				// rejects every request unless tokens are bound to
+				// cfg.MCPPublicURL + "/mcp" (the canonical resource).
+				//
+				// HMAC secret reuses cfg.EncryptionKey, the same
+				// 32-byte hex key cloud deployments already require
+				// (validated above). fosite uses it to sign the
+				// opaque token signature half; rotation arrives
+				// alongside the operator runbook for TASK-953/954.
+				if cfg.MCPPublicURL != "" {
+					oauthSrv, oauthErr := oauthpkg.NewServer(oauthpkg.Config{
+						Store:           s,
+						HMACSecret:      keyBytes,
+						AllowedAudience: strings.TrimRight(cfg.MCPPublicURL, "/") + "/mcp",
+					})
+					if oauthErr != nil {
+						return fmt.Errorf("init OAuth server: %w", oauthErr)
+					}
+					srv.SetOAuthServer(oauthSrv)
+					slog.Info("OAuth server mounted",
+						"endpoints", "/oauth/{register,authorize,token}",
+						"audience", oauthSrv.AllowedAudience(),
+					)
+				} else {
+					slog.Warn("PAD_MCP_PUBLIC_URL not set — OAuth server NOT mounted (no canonical audience to bind tokens to)")
+				}
 
 				// Reverse pad → pad-cloud client (TASK-690). Used by
 				// handleDeleteAccount to cancel Stripe subscriptions + delete

--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
-	github.com/go-jose/go-jose/v3 v3.0.3 // indirect
+	github.com/go-jose/go-jose/v3 v3.0.4 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/gobuffalo/pop/v6 v6.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -110,8 +110,8 @@ github.com/go-chi/cors v1.2.2/go.mod h1:sSbTewc+6wYHBBCW7ytsFSn836hqM7JxpglAy2Vz
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
-github.com/go-jose/go-jose/v3 v3.0.3 h1:fFKWeig/irsp7XD2zBxvnmA/XaRWp5V3CBsZXJF7G7k=
-github.com/go-jose/go-jose/v3 v3.0.3/go.mod h1:5b+7YgP7ZICgJDBdfjZaIt+H/9L9T/YQrVfLAMboGkQ=
+github.com/go-jose/go-jose/v3 v3.0.4 h1:Wp5HA7bLQcKnf6YYao/4kpRpVMp/yf6+pJKV8WFSaNY=
+github.com/go-jose/go-jose/v3 v3.0.4/go.mod h1:5b+7YgP7ZICgJDBdfjZaIt+H/9L9T/YQrVfLAMboGkQ=
 github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vbaY=
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=

--- a/internal/server/handlers_mcp.go
+++ b/internal/server/handlers_mcp.go
@@ -108,5 +108,5 @@ func (s *Server) registerMCPRoutes(r chi.Router) {
 	// (protected-resource) gets the real metadata; RFC 8414 (auth-server)
 	// is the 501 stub TASK-951 fills in.
 	r.With(s.requireCloudMode).Get("/.well-known/oauth-protected-resource", s.handleOAuthProtectedResource)
-	r.With(s.requireCloudMode).Get("/.well-known/oauth-authorization-server", s.handleOAuthAuthorizationServerStub)
+	r.With(s.requireCloudMode).Get("/.well-known/oauth-authorization-server", s.handleOAuthAuthorizationServer)
 }

--- a/internal/server/handlers_mcp_test.go
+++ b/internal/server/handlers_mcp_test.go
@@ -85,19 +85,25 @@ func TestMCP_DiscoveryDoc_PopulatedFromConfig(t *testing.T) {
 	}
 }
 
-// TestMCP_AuthServerStub_Returns501 confirms the RFC 8414 stub mounts
-// alongside the protected-resource doc. Once TASK-951 lands and fills
-// in real metadata, this test will be replaced with a positive doc-
-// shape assertion.
-func TestMCP_AuthServerStub_Returns501(t *testing.T) {
+// TestMCP_AuthServerMetadata_Mounted confirms the RFC 8414
+// authorization-server discovery doc is mounted by the cloud-mode
+// route group.
+//
+// The stub-501 contract from TASK-950 was replaced by sub-PR C
+// (TASK-1025) when /oauth/{authorize,token,register} actually
+// exist. The full document-shape assertions live in
+// TestOAuth_AuthorizationServerMetadata_PopulatedShape; here we
+// just confirm the endpoint mounts + serves a 200 (or a 503 when
+// the auth-server URL is not configured, the fail-loud branch).
+func TestMCP_AuthServerMetadata_Mounted(t *testing.T) {
 	srv := mcpEnabledTestServer(t)
 
 	rr := doRequest(srv, "GET", "/.well-known/oauth-authorization-server", nil)
-	if rr.Code != http.StatusNotImplemented {
-		t.Errorf("expected 501 stub, got %d", rr.Code)
-	}
-	if ra := rr.Header().Get("Retry-After"); ra == "" {
-		t.Errorf("expected Retry-After header on 501 stub, got empty")
+	// mcpEnabledTestServer passes a non-empty mcpAuthServerURL
+	// ("https://app.test.example"), so the doc serves 200 with
+	// the populated metadata. 501 is now extinct.
+	if rr.Code != http.StatusOK {
+		t.Errorf("expected 200 with populated RFC 8414 metadata, got %d (body: %s)", rr.Code, rr.Body.String())
 	}
 }
 

--- a/internal/server/handlers_mcp_test.go
+++ b/internal/server/handlers_mcp_test.go
@@ -85,25 +85,24 @@ func TestMCP_DiscoveryDoc_PopulatedFromConfig(t *testing.T) {
 	}
 }
 
-// TestMCP_AuthServerMetadata_Mounted confirms the RFC 8414
+// TestMCP_AuthServerMetadata_MountedAndGated confirms the RFC 8414
 // authorization-server discovery doc is mounted by the cloud-mode
-// route group.
+// route group AND fail-loud-503s when the OAuth server isn't
+// wired (Codex review #372 round 3 — the MCP routes mount the
+// discovery doc, but the /oauth/* handlers only mount when
+// SetOAuthServer is called; without OAuth the doc must NOT
+// advertise live URLs that 404).
 //
-// The stub-501 contract from TASK-950 was replaced by sub-PR C
-// (TASK-1025) when /oauth/{authorize,token,register} actually
-// exist. The full document-shape assertions live in
-// TestOAuth_AuthorizationServerMetadata_PopulatedShape; here we
-// just confirm the endpoint mounts + serves a 200 (or a 503 when
-// the auth-server URL is not configured, the fail-loud branch).
-func TestMCP_AuthServerMetadata_Mounted(t *testing.T) {
+// mcpEnabledTestServer mounts MCP transport but NOT OAuth, so 503
+// is the correct fail-loud response. The full happy-path 200
+// shape assertions live in TestOAuth_AuthorizationServerMetadata_PopulatedShape
+// (which uses oauthEnabledTestServer).
+func TestMCP_AuthServerMetadata_MountedAndGated(t *testing.T) {
 	srv := mcpEnabledTestServer(t)
 
 	rr := doRequest(srv, "GET", "/.well-known/oauth-authorization-server", nil)
-	// mcpEnabledTestServer passes a non-empty mcpAuthServerURL
-	// ("https://app.test.example"), so the doc serves 200 with
-	// the populated metadata. 501 is now extinct.
-	if rr.Code != http.StatusOK {
-		t.Errorf("expected 200 with populated RFC 8414 metadata, got %d (body: %s)", rr.Code, rr.Body.String())
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Errorf("expected 503 (MCP mounted but OAuth disabled), got %d (body: %s)", rr.Code, rr.Body.String())
 	}
 }
 

--- a/internal/server/handlers_oauth.go
+++ b/internal/server/handlers_oauth.go
@@ -332,6 +332,46 @@ func writeDCRError(w http.ResponseWriter, status int, code, msg string) {
 // /oauth/authorize — start auth-code flow
 // =====================================================================
 
+// translateResourceToAudience copies any RFC 8707 `resource` form
+// parameters into fosite's non-standard `audience` parameter slot,
+// so the request fosite parses sees the audience it expects.
+//
+// The two are semantically equivalent: RFC 8707 §2 calls them
+// "resource indicators" and labels them "audience hints"; fosite
+// (v0.49.0) reads `audience` only. Without translation, real RFC
+// 8707 clients (Claude Desktop, Cursor, ChatGPT) sending only
+// `resource=https://mcp.getpad.dev/mcp` would hit our custom
+// audienceMatchingStrategy with an empty needle and fail every
+// authorize / token request. Codex review #372 round 1.
+//
+// Mutates r.Form in place. Idempotent — if `audience` is already
+// set we leave it (the test suite uses both keys as belt-and-
+// suspenders; production clients would send only one). r MUST
+// have ParseForm called before this; the OAuth handlers below
+// parse before invoking fosite.
+//
+// Both keys land in the form because fosite preserves r.Form into
+// the AuthorizeRequester, and the storage layer round-trips the
+// form on token exchange — so the translated audience is what
+// gets persisted + compared on the /token side too.
+func translateResourceToAudience(r *http.Request) {
+	if r == nil || r.Form == nil {
+		return
+	}
+	resources := r.Form["resource"]
+	if len(resources) == 0 {
+		return
+	}
+	if existing := r.Form["audience"]; len(existing) > 0 {
+		// Caller passed both — defer to audience as canonical and
+		// leave it untouched. Audit-log noise about ambiguity isn't
+		// worth the complexity for the v1 stub; if this becomes a
+		// real source of confusion we can warn here later.
+		return
+	}
+	r.Form["audience"] = append([]string(nil), resources...)
+}
+
 // handleOAuthAuthorize is the entry point for the authorization-code
 // flow. fosite validates the request shape; if the user is logged
 // in we render the inline consent stub (TODO TASK-952), otherwise we
@@ -355,6 +395,15 @@ func (s *Server) handleOAuthAuthorize(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	ctx := r.Context()
+
+	// fosite reads only `audience` from the form; RFC 8707 mandates
+	// `resource`. Translate before fosite parses (Codex review #372
+	// round 1). ParseForm has to run first so r.Form exists.
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, "invalid query string", http.StatusBadRequest)
+		return
+	}
+	translateResourceToAudience(r)
 
 	ar, err := s.oauthServer.Provider().NewAuthorizeRequest(ctx, r)
 	if err != nil {
@@ -439,6 +488,9 @@ func (s *Server) handleOAuthAuthorizeDecide(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
+	// RFC 8707 resource= → fosite audience= (Codex #372 round 1).
+	translateResourceToAudience(r)
+
 	ctx := r.Context()
 	ar, err := s.oauthServer.Provider().NewAuthorizeRequest(ctx, r)
 	if err != nil {
@@ -511,6 +563,15 @@ func (s *Server) handleOAuthToken(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	ctx := r.Context()
+
+	// RFC 8707 resource= → fosite audience= before fosite parses.
+	// Codex review #372 round 1 caught this — without translation
+	// real RFC 8707 token-exchange requests fail audience matching.
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, "Invalid form body", http.StatusBadRequest)
+		return
+	}
+	translateResourceToAudience(r)
 
 	// Empty session for fosite to populate from storage. The auth
 	// code's stored session_data carries the user's Subject; fosite

--- a/internal/server/handlers_oauth.go
+++ b/internal/server/handlers_oauth.go
@@ -1,0 +1,744 @@
+package server
+
+import (
+	"context"
+	"crypto/subtle"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"html/template"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/ory/fosite"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/oauth"
+)
+
+// OAuth 2.1 authorization-server HTTP handlers (PLAN-943 TASK-951
+// sub-PR C). The four endpoints below + the populated
+// /.well-known/oauth-authorization-server discovery doc complete
+// the flow-driving half of the OAuth surface — sub-PR D adds
+// /revoke and /introspect, sub-PR E wires MCPBearerAuth to OAuth
+// introspection.
+//
+// Mounting:
+//
+// All routes are mounted top-level (alongside /mcp, /.well-known/*),
+// outside the /api/v1 auth-required group, gated by cloud-mode + a
+// non-nil oauthServer. CSRF middleware runs only on /api/* paths
+// (middleware_csrf.go:36-39) so /oauth/* is naturally exempt; the
+// consent-decision endpoint adds its own form-token check using the
+// existing __Host-pad_csrf cookie because consent is the one POST
+// here that rides a session cookie.
+//
+// Endpoints:
+//
+//   - POST /oauth/register — Dynamic Client Registration (RFC 7591).
+//     Hand-written, no fosite. Public clients only.
+//   - GET /oauth/authorize — start auth-code flow. Renders the
+//     inline-HTML consent stub if the user is logged in;
+//     otherwise 302 → /login?redirect=…
+//   - POST /oauth/authorize/decide — process the consent decision.
+//     Validates the form-bound CSRF token, runs fosite, redirects
+//     to the client.
+//   - POST /oauth/token — code exchange (PKCE + RFC 8707 verified
+//     by fosite). Also handles refresh_token grant.
+//
+// All four go via Server.oauthServer (set by SetOAuthServer at
+// startup). When that's nil the routes don't mount — see
+// registerOAuthRoutes.
+
+// SetOAuthServer wires the OAuth 2.1 authorization server (built
+// in cmd/pad/main.go via internal/oauth.NewServer) into the route
+// table. Called once at startup, before the first request hits the
+// router. nil disables the OAuth surface entirely.
+//
+// Like SetMCPTransport, this MUST be called before setupRouter
+// runs (which it does on first request). Calling it later is a
+// no-op because chi routes are immutable post-mount.
+func (s *Server) SetOAuthServer(srv *oauth.Server) {
+	s.oauthServer = srv
+}
+
+// registerOAuthRoutes mounts the OAuth endpoints on r. Called from
+// setupRouter at the same level as the MCP routes. No-op when
+// either cloud mode is off or SetOAuthServer was never called —
+// keeps self-hosted deployments free of OAuth-server surface they
+// can't use anyway (no canonical audience, no DCR clients).
+//
+// The discovery document at /.well-known/oauth-authorization-server
+// continues to be served by registerMCPRoutes — it lives there
+// because it was the 501 stub from TASK-950, and replacing it in
+// place keeps the URL stable for clients that already discovered
+// the chain. The OAuth-server routes added here are the four flow
+// endpoints; metadata + protected-resource doc are mounted earlier.
+func (s *Server) registerOAuthRoutes(r interface {
+	Get(pattern string, h http.HandlerFunc)
+	Post(pattern string, h http.HandlerFunc)
+}) {
+	if s.oauthServer == nil || !s.IsCloud() {
+		return
+	}
+	r.Post("/oauth/register", s.handleOAuthRegister)
+	r.Get("/oauth/authorize", s.handleOAuthAuthorize)
+	r.Post("/oauth/authorize/decide", s.handleOAuthAuthorizeDecide)
+	r.Post("/oauth/token", s.handleOAuthToken)
+}
+
+// =====================================================================
+// /oauth/register — Dynamic Client Registration (RFC 7591)
+// =====================================================================
+
+// dcrRequest is the wire shape DCR clients post. Only the fields
+// pad cares about are declared; RFC 7591 §2 lists many more
+// (logo_uri, client_uri, contacts, tos_uri, policy_uri, …) but
+// they're either advisory display metadata or related to flows we
+// don't run. Accept and ignore unknown fields rather than rejecting
+// — RFC 7591 §3.2 explicitly says servers SHOULD allow extra fields.
+type dcrRequest struct {
+	ClientName              string   `json:"client_name"`
+	RedirectURIs            []string `json:"redirect_uris"`
+	GrantTypes              []string `json:"grant_types,omitempty"`
+	ResponseTypes           []string `json:"response_types,omitempty"`
+	TokenEndpointAuthMethod string   `json:"token_endpoint_auth_method,omitempty"`
+	Scopes                  string   `json:"scope,omitempty"` // RFC 7591 §2: space-delimited
+	LogoURI                 string   `json:"logo_uri,omitempty"`
+}
+
+// dcrResponse is the wire shape returned to a successful register.
+// RFC 7591 §3.2 mandates client_id + client_id_issued_at; we echo
+// back the validated metadata so clients can verify it matches
+// what they sent.
+type dcrResponse struct {
+	ClientID                string   `json:"client_id"`
+	ClientIDIssuedAt        int64    `json:"client_id_issued_at"`
+	ClientName              string   `json:"client_name,omitempty"`
+	RedirectURIs            []string `json:"redirect_uris"`
+	GrantTypes              []string `json:"grant_types"`
+	ResponseTypes           []string `json:"response_types"`
+	TokenEndpointAuthMethod string   `json:"token_endpoint_auth_method"`
+	Scope                   string   `json:"scope,omitempty"`
+	LogoURI                 string   `json:"logo_uri,omitempty"`
+}
+
+// dcrError matches RFC 7591 §3.2.2's error response shape.
+type dcrError struct {
+	Code    string `json:"error"`
+	Message string `json:"error_description,omitempty"`
+}
+
+// handleOAuthRegister implements RFC 7591 Dynamic Client Registration.
+// Public clients only — no client_secret is generated or returned.
+// PKCE is the only authentication path (compose pattern in
+// internal/oauth/server.go enforces it).
+//
+// fosite has no built-in DCR endpoint, so this is hand-written.
+// Validation rules:
+//
+//   - redirect_uris MUST be non-empty (RFC 7591 §2 + OAuth 2.1's
+//     exact-match requirement).
+//   - Each redirect_uri MUST be an absolute URI without a fragment.
+//   - grant_types defaults to ["authorization_code", "refresh_token"]
+//     if absent. Only these two are accepted; any other rejected.
+//   - response_types defaults to ["code"]; only "code" accepted.
+//   - token_endpoint_auth_method defaults to "none" (public client).
+//     "client_secret_basic" / "client_secret_post" are rejected
+//     because we don't issue secrets.
+//   - scope: tokens are space-delimited per RFC 6749 §3.3 and the
+//     allowed set is pad:read / pad:write / pad:admin (TASK-953
+//     adds the workspace allow-list scopes).
+func (s *Server) handleOAuthRegister(w http.ResponseWriter, r *http.Request) {
+	if !s.IsCloud() || s.oauthServer == nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	var input dcrRequest
+	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+		writeDCRError(w, http.StatusBadRequest, "invalid_client_metadata",
+			"Request body must be JSON: "+err.Error())
+		return
+	}
+
+	if len(input.RedirectURIs) == 0 {
+		writeDCRError(w, http.StatusBadRequest, "invalid_redirect_uri",
+			"redirect_uris is required and must be non-empty")
+		return
+	}
+	for _, raw := range input.RedirectURIs {
+		if err := validateRegisterRedirectURI(raw); err != nil {
+			writeDCRError(w, http.StatusBadRequest, "invalid_redirect_uri", err.Error())
+			return
+		}
+	}
+
+	grants := input.GrantTypes
+	if len(grants) == 0 {
+		grants = []string{"authorization_code", "refresh_token"}
+	}
+	for _, g := range grants {
+		if g != "authorization_code" && g != "refresh_token" {
+			writeDCRError(w, http.StatusBadRequest, "invalid_client_metadata",
+				"unsupported grant_type: "+g)
+			return
+		}
+	}
+
+	responseTypes := input.ResponseTypes
+	if len(responseTypes) == 0 {
+		responseTypes = []string{"code"}
+	}
+	for _, rt := range responseTypes {
+		if rt != "code" {
+			writeDCRError(w, http.StatusBadRequest, "invalid_client_metadata",
+				"unsupported response_type: "+rt)
+			return
+		}
+	}
+
+	authMethod := input.TokenEndpointAuthMethod
+	if authMethod == "" {
+		authMethod = "none"
+	}
+	if authMethod != "none" {
+		writeDCRError(w, http.StatusBadRequest, "invalid_client_metadata",
+			"only token_endpoint_auth_method=none is supported (public clients only)")
+		return
+	}
+
+	scopes := splitScopeString(input.Scopes)
+	if len(scopes) == 0 {
+		scopes = []string{"pad:read", "pad:write"}
+	}
+	for _, sc := range scopes {
+		if !isAllowedRegisterScope(sc) {
+			writeDCRError(w, http.StatusBadRequest, "invalid_client_metadata",
+				"scope not allowed: "+sc)
+			return
+		}
+	}
+
+	created, err := s.store.CreateOAuthClient(models.OAuthClientCreate{
+		Name:                    input.ClientName,
+		RedirectURIs:            input.RedirectURIs,
+		GrantTypes:              grants,
+		ResponseTypes:           responseTypes,
+		TokenEndpointAuthMethod: authMethod,
+		Scopes:                  scopes,
+		Public:                  true,
+		LogoURL:                 input.LogoURI,
+	})
+	if err != nil {
+		writeInternalError(w, fmt.Errorf("oauth: create client: %w", err))
+		return
+	}
+
+	resp := dcrResponse{
+		ClientID:                created.ID,
+		ClientIDIssuedAt:        created.CreatedAt.Unix(),
+		ClientName:              created.Name,
+		RedirectURIs:            created.RedirectURIs,
+		GrantTypes:              created.GrantTypes,
+		ResponseTypes:           created.ResponseTypes,
+		TokenEndpointAuthMethod: created.TokenEndpointAuthMethod,
+		Scope:                   strings.Join(created.Scopes, " "),
+		LogoURI:                 created.LogoURL,
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+// validateRegisterRedirectURI enforces OAuth 2.1's exact-match
+// requirement at registration time (matching is at /authorize time;
+// here we just verify the URI is well-formed). Reject:
+//
+//   - relative URIs (no scheme)
+//   - URIs with a fragment (#) — OAuth 2.1 §2.3.3 disallows
+//   - http:// URIs not pointing at localhost / 127.0.0.1 — public
+//     deployments can't use plain HTTP, and an attacker registering
+//     http://attacker.com would intercept codes
+func validateRegisterRedirectURI(raw string) error {
+	if raw == "" {
+		return errors.New("redirect_uri must be non-empty")
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("redirect_uri parse: %w", err)
+	}
+	if u.Scheme == "" || u.Host == "" {
+		return errors.New("redirect_uri must be an absolute URI")
+	}
+	if u.Fragment != "" {
+		return errors.New("redirect_uri must not contain a fragment")
+	}
+	if u.Scheme == "http" {
+		host := u.Hostname()
+		if host != "localhost" && host != "127.0.0.1" && host != "::1" {
+			return errors.New("redirect_uri must use https for non-loopback hosts")
+		}
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		// Allow custom-scheme URIs (e.g. claude://oauth/callback)
+		// because Anthropic's connector flow uses them. Block only
+		// the "obviously wrong" schemes (file:, javascript:, data:).
+		switch u.Scheme {
+		case "file", "javascript", "data", "vbscript":
+			return errors.New("redirect_uri scheme not permitted: " + u.Scheme)
+		}
+	}
+	return nil
+}
+
+// isAllowedRegisterScope is the v1 allow-list. TASK-953 widens
+// this to include workspace-scoped scopes (pad:workspaces:slug,…).
+func isAllowedRegisterScope(s string) bool {
+	switch s {
+	case "pad:read", "pad:write", "pad:admin":
+		return true
+	}
+	return false
+}
+
+// splitScopeString parses RFC 6749 §3.3 space-delimited scope.
+// Single space is the canonical separator; multi-spaces from
+// hand-typed input are tolerated.
+func splitScopeString(raw string) []string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+	out := []string{}
+	for _, p := range strings.Split(raw, " ") {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// writeDCRError emits the RFC 7591 §3.2.2 error response shape.
+func writeDCRError(w http.ResponseWriter, status int, code, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(dcrError{Code: code, Message: msg})
+}
+
+// =====================================================================
+// /oauth/authorize — start auth-code flow
+// =====================================================================
+
+// handleOAuthAuthorize is the entry point for the authorization-code
+// flow. fosite validates the request shape; if the user is logged
+// in we render the inline consent stub (TODO TASK-952), otherwise we
+// 302-redirect to the login page with a `redirect=` param so the
+// post-login flow returns here (TASK-998 plumbed the pad-cloud
+// callback to honor it).
+//
+// Behavior on errors:
+//
+//   - fosite-validation errors → fosite's WriteAuthorizeError
+//     produces a redirect to the client's redirect_uri with the
+//     OAuth error params.
+//   - missing-user (no session): 302 → /login?redirect=<self>.
+//     The current request's full URL (path + query) is
+//     URL-encoded into the redirect param.
+//   - canonical-audience mismatch: surfaced via fosite's
+//     audienceMatchingStrategy → invalid_request.
+func (s *Server) handleOAuthAuthorize(w http.ResponseWriter, r *http.Request) {
+	if !s.IsCloud() || s.oauthServer == nil {
+		http.NotFound(w, r)
+		return
+	}
+	ctx := r.Context()
+
+	ar, err := s.oauthServer.Provider().NewAuthorizeRequest(ctx, r)
+	if err != nil {
+		s.oauthServer.Provider().WriteAuthorizeError(ctx, w, ar, err)
+		return
+	}
+
+	// User must be logged in to grant consent. SessionAuth runs
+	// in the parent middleware chain and falls through gracefully
+	// when no cookie is present — at this point currentUser(r)
+	// returns the resolved user or nil.
+	user := currentUser(r)
+	if user == nil {
+		// 302 → /login?redirect=/oauth/authorize?<original-query>.
+		// The login page (web/src/routes/login/+page.svelte) +
+		// pad-cloud's OAuth callback (TASK-998) honor `redirect=`
+		// for relative paths.
+		dest := "/oauth/authorize"
+		if r.URL.RawQuery != "" {
+			dest += "?" + r.URL.RawQuery
+		}
+		loginURL := "/login?redirect=" + url.QueryEscape(dest)
+		http.Redirect(w, r, loginURL, http.StatusFound)
+		return
+	}
+
+	// Render the inline consent stub. TODO(TASK-952): replace with
+	// the SvelteKit /oauth/consent page that surfaces workspace
+	// allow-list selection (TASK-953) + per-app branding.
+	s.renderConsentStub(w, r, ar, user)
+}
+
+// =====================================================================
+// /oauth/authorize/decide — process consent decision
+// =====================================================================
+
+// handleOAuthAuthorizeDecide processes the consent decision posted
+// from the inline consent stub. Validates a form-bound CSRF token
+// (the same __Host-pad_csrf cookie the SPA uses, but read from a
+// hidden form field instead of a header), then either runs fosite's
+// authorize-response flow (approve) or writes an access_denied
+// redirect (deny).
+//
+// The decision endpoint is what an attacker would target via a
+// cross-origin POST trying to silently grant consent on a victim's
+// behalf. The CSRF token check binds the POST to the original
+// browser context. Same defense the SPA uses elsewhere, just
+// rendered via form field rather than header because the consent
+// stub is server-rendered HTML, not SPA fetch().
+//
+// On approve: ar.GrantScope() each requested scope (auto-approve
+// all in the v1 stub), ar.GrantAudience(canonical), then run
+// fosite. On deny: WriteAuthorizeError with ErrAccessDenied.
+func (s *Server) handleOAuthAuthorizeDecide(w http.ResponseWriter, r *http.Request) {
+	if !s.IsCloud() || s.oauthServer == nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	user := currentUser(r)
+	if user == nil {
+		// Session expired between consent render + decision POST.
+		// Fall back to login redirect with the decision page's URL
+		// — when the user logs back in they'll re-render the consent
+		// (whose underlying request will be carried via the form
+		// fields they're about to submit).
+		http.Redirect(w, r, "/login", http.StatusFound)
+		return
+	}
+
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, "Invalid form body", http.StatusBadRequest)
+		return
+	}
+
+	// CSRF: form field must match the __Host-pad_csrf cookie. Same
+	// double-submit pattern the API uses, but with the token in a
+	// hidden form input rather than a header (consent is server-
+	// rendered HTML, not SPA fetch).
+	if err := s.validateConsentCSRFToken(r); err != nil {
+		writeError(w, http.StatusForbidden, "csrf_error", err.Error())
+		return
+	}
+
+	ctx := r.Context()
+	ar, err := s.oauthServer.Provider().NewAuthorizeRequest(ctx, r)
+	if err != nil {
+		s.oauthServer.Provider().WriteAuthorizeError(ctx, w, ar, err)
+		return
+	}
+
+	decision := r.FormValue("decision")
+	if decision == "deny" {
+		s.oauthServer.Provider().WriteAuthorizeError(ctx, w, ar,
+			fosite.ErrAccessDenied.WithHint("The user denied the consent."))
+		return
+	}
+	if decision != "approve" {
+		writeError(w, http.StatusBadRequest, "invalid_request",
+			"decision must be 'approve' or 'deny'")
+		return
+	}
+
+	// v1 stub: auto-approve every requested scope. TASK-952's real
+	// consent UI lets the user toggle per-scope, and TASK-953 adds
+	// the workspace allow-list selection that gates which workspaces
+	// the issued token can reach.
+	for _, sc := range ar.GetRequestedScopes() {
+		ar.GrantScope(sc)
+	}
+	for _, aud := range ar.GetRequestedAudience() {
+		ar.GrantAudience(aud)
+	}
+
+	// Build the session that fosite serializes alongside the code.
+	// The opaque token's signature ties back to this; introspection
+	// (sub-PR D) reads back the same Subject for the bearer-auth
+	// gate on /mcp (sub-PR E).
+	session := oauth.NewSession(user.ID)
+
+	resp, err := s.oauthServer.Provider().NewAuthorizeResponse(ctx, ar, session)
+	if err != nil {
+		s.oauthServer.Provider().WriteAuthorizeError(ctx, w, ar, err)
+		return
+	}
+
+	s.oauthServer.Provider().WriteAuthorizeResponse(ctx, w, ar, resp)
+}
+
+// =====================================================================
+// /oauth/token — code exchange + refresh-token rotation
+// =====================================================================
+
+// handleOAuthToken handles the token endpoint for both
+// authorization_code and refresh_token grant types. fosite's
+// NewAccessRequest does the heavy lifting: validates client_id,
+// looks up the auth code (or refresh token), verifies the PKCE
+// code_verifier (S256-required by Config.EnforcePKCE +
+// EnablePKCEPlainChallengeMethod=false in NewServer), confirms the
+// audience matches (custom strategy from audience.go).
+//
+// Refresh-token rotation is implicit: fosite's flow_refresh.go
+// calls Storage.RotateRefreshToken before issuing the new pair,
+// which under our adapter revokes the entire grant family
+// (matches fosite's reference MemoryStore behaviour, locked in
+// by sub-PR A round 2 and sub-PR B round 2 of Codex review).
+//
+// On error fosite's WriteAccessError writes the JSON OAuth error
+// body; on success WriteAccessResponse writes
+// {access_token, token_type, expires_in, refresh_token, scope}.
+func (s *Server) handleOAuthToken(w http.ResponseWriter, r *http.Request) {
+	if !s.IsCloud() || s.oauthServer == nil {
+		http.NotFound(w, r)
+		return
+	}
+	ctx := r.Context()
+
+	// Empty session for fosite to populate from storage. The auth
+	// code's stored session_data carries the user's Subject; fosite
+	// hydrates this via Storage.GetAuthorizationCodeSession during
+	// /token exchange.
+	session := oauth.NewSession("")
+
+	ar, err := s.oauthServer.Provider().NewAccessRequest(ctx, r, session)
+	if err != nil {
+		s.oauthServer.Provider().WriteAccessError(ctx, w, ar, err)
+		return
+	}
+
+	// Mirror /authorize's grant: the access response derives from
+	// the granted scope/audience set on the request. fosite preserves
+	// these from the underlying auth-code grant for the refresh path.
+	for _, sc := range ar.GetRequestedScopes() {
+		ar.GrantScope(sc)
+	}
+	for _, aud := range ar.GetRequestedAudience() {
+		ar.GrantAudience(aud)
+	}
+
+	resp, err := s.oauthServer.Provider().NewAccessResponse(ctx, ar)
+	if err != nil {
+		s.oauthServer.Provider().WriteAccessError(ctx, w, ar, err)
+		return
+	}
+
+	s.oauthServer.Provider().WriteAccessResponse(ctx, w, ar, resp)
+}
+
+// =====================================================================
+// Inline consent stub — TODO(TASK-952): replace with real UI
+// =====================================================================
+
+// consentTmpl is the inline-HTML consent screen rendered by
+// /oauth/authorize when the user is logged in. Deliberately ugly —
+// TASK-952 replaces this with the SvelteKit /oauth/consent page
+// that surfaces workspace allow-list selection (TASK-953) + proper
+// branding. The stub is just enough to drive the auth-code flow
+// end-to-end for testing during the OAuth-server build-out.
+//
+// Form action POSTs to /oauth/authorize/decide with a hidden CSRF
+// token + a hidden copy of every original /authorize query param.
+// The decision is "approve" (the primary button) or "deny".
+//
+// Style note: any future caller that updates this template MUST
+// keep the {{.CSRF}} field's auto-escape disabled — it's pre-
+// validated as hex in setCSRFCookie / validateConsentCSRFToken,
+// and the html/template package's default escaping would otherwise
+// double-escape the hex chars. We use {{.CSRF}} (escaped) since
+// hex IS safe for HTML attributes.
+var consentTmpl = template.Must(template.New("consent").Parse(`<!doctype html>
+<html><head><meta charset="utf-8"><title>Authorize {{.ClientName}}</title>
+<style>
+body { font: 14px system-ui; max-width: 480px; margin: 4em auto; padding: 0 1em; color: #333; }
+h1 { font-size: 1.4em; }
+.client { display: flex; align-items: center; gap: .75em; margin: 1em 0; padding: 1em;
+          border: 1px solid #ddd; border-radius: 8px; background: #fafafa; }
+.client img { width: 48px; height: 48px; border-radius: 8px; }
+ul { padding-left: 1.4em; } li { margin: .25em 0; }
+.actions { margin-top: 2em; display: flex; gap: 1em; }
+button { padding: .75em 1.5em; border-radius: 6px; border: 1px solid #888;
+         font-size: 1em; cursor: pointer; }
+button.primary { background: #2563eb; color: white; border-color: #2563eb; }
+.footer { margin-top: 2em; font-size: .85em; color: #888; }
+</style></head>
+<body>
+<h1>Authorize {{.ClientName}}?</h1>
+<div class="client">
+  {{if .LogoURL}}<img src="{{.LogoURL}}" alt="">{{end}}
+  <div>
+    <strong>{{.ClientName}}</strong><br>
+    <small>Wants to access your Pad account as {{.Username}}</small>
+  </div>
+</div>
+<p>Permissions requested:</p>
+<ul>{{range .Scopes}}<li><code>{{.}}</code></li>{{end}}</ul>
+<form method="POST" action="/oauth/authorize/decide">
+  <input type="hidden" name="csrf_token" value="{{.CSRF}}">
+  {{range $k, $vs := .HiddenFields}}{{range $vs}}<input type="hidden" name="{{$k}}" value="{{.}}">{{end}}{{end}}
+  <div class="actions">
+    <button type="submit" name="decision" value="deny">Deny</button>
+    <button type="submit" name="decision" value="approve" class="primary">Approve</button>
+  </div>
+</form>
+<p class="footer">Inline consent stub — TASK-952 replaces with the production UI.</p>
+</body></html>`))
+
+type consentData struct {
+	ClientName   string
+	Username     string
+	LogoURL      string
+	Scopes       []string
+	CSRF         string
+	HiddenFields url.Values
+}
+
+// renderConsentStub draws the inline approval page. The CSRF token
+// is the existing __Host-pad_csrf cookie value; the consent decision
+// handler validates the form-submitted copy against the cookie via
+// validateConsentCSRFToken.
+//
+// If the cookie isn't set yet (rare — the user is logged in, so the
+// session creation path has already issued one), we mint one here
+// so the form always carries a valid token.
+func (s *Server) renderConsentStub(w http.ResponseWriter, r *http.Request, ar fosite.AuthorizeRequester, user *models.User) {
+	csrf := readOrSetConsentCSRF(w, r, s.secureCookies)
+
+	logo := ""
+	if dc, ok := ar.GetClient().(*fosite.DefaultClient); ok && dc != nil {
+		// fosite.DefaultClient doesn't expose LogoURL; fetch the row
+		// directly so we can show the logo if registered.
+		if c, err := s.store.GetOAuthClient(ar.GetClient().GetID()); err == nil {
+			logo = c.LogoURL
+		}
+	}
+
+	clientName := ar.GetClient().GetID()
+	if c, err := s.store.GetOAuthClient(ar.GetClient().GetID()); err == nil && c.Name != "" {
+		clientName = c.Name
+	}
+
+	// Mirror every original query param into the form so the POST
+	// can re-validate via fosite.NewAuthorizeRequest with the same
+	// inputs. r.URL.Query() returns a parsed map with the original
+	// values intact.
+	hidden := r.URL.Query()
+	hidden.Del("csrf_token") // never round-trip this; we render fresh
+
+	data := consentData{
+		ClientName:   clientName,
+		Username:     user.Name,
+		LogoURL:      logo,
+		Scopes:       []string(ar.GetRequestedScopes()),
+		CSRF:         csrf,
+		HiddenFields: hidden,
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	// Cache-Control: no-store — the consent page carries a CSRF
+	// token tied to the user's session; serving a cached copy to a
+	// different user would let them complete the flow with someone
+	// else's identity.
+	w.Header().Set("Cache-Control", "no-store")
+	if err := consentTmpl.Execute(w, data); err != nil {
+		// Already streaming HTML; logging is the most we can do.
+		writeInternalError(w, fmt.Errorf("oauth: render consent: %w", err))
+	}
+}
+
+// readOrSetConsentCSRF reads the current __Host-pad_csrf cookie or
+// mints a new one if absent. The cookie's value is what gets
+// rendered into the consent form's hidden field; validateConsentCSRFToken
+// reads it back from both cookie + form to close the double-submit
+// loop.
+func readOrSetConsentCSRF(w http.ResponseWriter, r *http.Request, secure bool) string {
+	if c, err := r.Cookie(csrfCookieName(secure)); err == nil && c.Value != "" {
+		return c.Value
+	}
+	// generateCSRFToken from middleware_csrf.go.
+	token := generateCSRFToken()
+	http.SetCookie(w, &http.Cookie{
+		Name:     csrfCookieName(secure),
+		Value:    token,
+		Path:     "/",
+		MaxAge:   int(webSessionTTL.Seconds()),
+		HttpOnly: false,
+		Secure:   secure,
+		SameSite: http.SameSiteLaxMode,
+	})
+	return token
+}
+
+// validateConsentCSRFToken implements the form-bound double-submit
+// pattern. Reads the __Host-pad_csrf cookie, reads the csrf_token
+// form field, compares them in constant time. Both must be the
+// expected hex length so an attacker can't flood with mismatched
+// equal-prefix values.
+//
+// Why duplicate middleware_csrf.go's logic instead of reusing it:
+// the existing CSRFProtect middleware reads from the X-CSRF-Token
+// header (SPA convention), but the consent stub is server-rendered
+// HTML where the natural carrier is a form field. Same security
+// model, different transport.
+func (s *Server) validateConsentCSRFToken(r *http.Request) error {
+	cookie, err := r.Cookie(csrfCookieName(s.secureCookies))
+	if err != nil || cookie.Value == "" {
+		return errors.New("missing CSRF cookie")
+	}
+	form := r.FormValue("csrf_token")
+	if form == "" {
+		return errors.New("missing csrf_token form field")
+	}
+	const expectedLen = csrfTokenLen * 2 // hex
+	if len(cookie.Value) != expectedLen || len(form) != expectedLen {
+		return errors.New("CSRF token mismatch")
+	}
+	if subtle.ConstantTimeCompare([]byte(cookie.Value), []byte(form)) != 1 {
+		return errors.New("CSRF token mismatch")
+	}
+	return nil
+}
+
+// =====================================================================
+// Helpers shared with handlers_well_known.go for the discovery doc
+// =====================================================================
+
+// authServerIssuerURL returns the canonical issuer URL for this
+// authorization server — what /.well-known/oauth-authorization-server
+// emits as `issuer`. Sourced from cfg.AuthServerURL (the
+// PAD_AUTH_SERVER_URL env var); falls back to the request host
+// for local dev. See handlers_well_known.go's existing fallback.
+func (s *Server) authServerIssuerURL(r *http.Request) string {
+	if s.mcpAuthServerURL != "" {
+		return strings.TrimRight(s.mcpAuthServerURL, "/")
+	}
+	if r != nil && r.Host != "" {
+		return "https://" + r.Host
+	}
+	return ""
+}
+
+// Compile-time guard: oauth.NewSession returns a fosite-compatible
+// type so we can pass it to NewAccessRequest / NewAuthorizeResponse
+// without the call sites importing fosite.Session.
+var _ fosite.Session = (*oauth.Session)(nil)
+
+// dummyContextSilencer keeps the context import live in case future
+// adds (e.g. cancellation propagation through fosite calls) drop it.
+var _ = context.Background

--- a/internal/server/handlers_oauth_test.go
+++ b/internal/server/handlers_oauth_test.go
@@ -530,11 +530,15 @@ func TestOAuth_Authorize_AcceptsResourceOnly(t *testing.T) {
 }
 
 // TestOAuth_AuthorizationServerMetadata_OmitsUnimplementedEndpoints
-// pins Codex review #372 round 1 fix #2: the discovery doc must
-// NOT advertise revocation_endpoint or introspection_endpoint
-// until sub-PR D (TASK-1026) actually mounts those handlers.
-// Advertised-but-404 endpoints are worse than absent ones — RFC
-// 8414 §2 says they're optional, so omitting is spec-compliant.
+// pins Codex review #372 round 1 fix #2 + round 2 fix #2: the
+// discovery doc must NOT advertise revocation_endpoint /
+// introspection_endpoint (sub-PR D wires those) or
+// authorization_response_iss_parameter_supported (RFC 9207 — fosite
+// v0.49 doesn't add iss to the redirect, so claiming support would
+// mislead RFC 9207-aware clients).
+//
+// Advertised-but-broken metadata is worse than absent metadata —
+// RFC 8414 §2 marks all four fields OPTIONAL.
 func TestOAuth_AuthorizationServerMetadata_OmitsUnimplementedEndpoints(t *testing.T) {
 	srv, _ := oauthEnabledTestServer(t)
 
@@ -550,10 +554,43 @@ func TestOAuth_AuthorizationServerMetadata_OmitsUnimplementedEndpoints(t *testin
 		"introspection_endpoint",
 		"revocation_endpoint_auth_methods_supported",
 		"introspection_endpoint_auth_methods_supported",
+		"authorization_response_iss_parameter_supported",
 	} {
 		if _, ok := doc[k]; ok {
-			t.Errorf("doc must NOT advertise %q until sub-PR D ships the handler; got %v", k, doc[k])
+			t.Errorf("doc must NOT advertise %q (handler/feature not implemented); got %v", k, doc[k])
 		}
+	}
+}
+
+// TestOAuth_Register_RateLimited pins Codex review #372 round 2:
+// /oauth/register is open by RFC 7591 design but must be rate-
+// limited so an attacker can't flood the oauth_clients table.
+// Reuses the Register limiter (5/hour/IP, burst 5), so the 6th
+// request from the same IP within an hour returns 429.
+//
+// All requests share the test harness's "192.0.2.1" RemoteAddr,
+// so the limiter buckets per-IP work as expected. testServer's
+// fresh Server has fresh limiters, so other tests don't leak
+// budget across.
+func TestOAuth_Register_RateLimited(t *testing.T) {
+	srv, _ := oauthEnabledTestServer(t)
+
+	body := map[string]any{
+		"client_name":   "Spammer",
+		"redirect_uris": []string{"https://app.test/cb"},
+	}
+
+	// First 5 within the burst window must succeed.
+	for i := 0; i < 5; i++ {
+		rr := doRequest(srv, "POST", "/oauth/register", body)
+		if rr.Code != http.StatusCreated {
+			t.Fatalf("request %d: expected 201, got %d (body: %s)", i+1, rr.Code, rr.Body.String())
+		}
+	}
+	// 6th must trip the limiter.
+	rr := doRequest(srv, "POST", "/oauth/register", body)
+	if rr.Code != http.StatusTooManyRequests {
+		t.Fatalf("6th request: expected 429 (rate-limited), got %d (body: %s)", rr.Code, rr.Body.String())
 	}
 }
 

--- a/internal/server/handlers_oauth_test.go
+++ b/internal/server/handlers_oauth_test.go
@@ -562,6 +562,33 @@ func TestOAuth_AuthorizationServerMetadata_OmitsUnimplementedEndpoints(t *testin
 	}
 }
 
+// TestOAuth_AuthorizationServerMetadata_503WhenOAuthDisabled pins
+// Codex review #372 round 3: the discovery doc lives in the MCP
+// route group while the /oauth/* handlers live in their own group.
+// A cloud deployment with PAD_MCP_PUBLIC_URL unset gets the MCP
+// routes mounted (so the discovery doc is reachable) but NOT the
+// OAuth handlers (cmd/pad/main.go skips oauth.NewServer wiring
+// because there's no canonical audience). Without the gate, the
+// doc would 200 with /oauth/{register,authorize,token} URLs that
+// 404 — worse for clients than no document at all.
+//
+// Fail-loud 503 lets ops detect the misconfiguration immediately.
+func TestOAuth_AuthorizationServerMetadata_503WhenOAuthDisabled(t *testing.T) {
+	srv := testServer(t)
+	srv.SetCloudMode("test-secret")
+	// Mount MCP transport (so the discovery route is registered)
+	// but DO NOT call SetOAuthServer — simulating the
+	// PAD_MCP_PUBLIC_URL-unset path in cmd/pad/main.go.
+	stub := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {})
+	srv.SetMCPTransport(stub, "https://mcp.test.example", "https://app.test.example")
+
+	rr := doRequest(srv, "GET", "/.well-known/oauth-authorization-server", nil)
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503 fail-loud when oauthServer is nil, got %d (body: %s)",
+			rr.Code, rr.Body.String())
+	}
+}
+
 // TestOAuth_Register_RateLimited pins Codex review #372 round 2:
 // /oauth/register is open by RFC 7591 design but must be rate-
 // limited so an attacker can't flood the oauth_clients table.

--- a/internal/server/handlers_oauth_test.go
+++ b/internal/server/handlers_oauth_test.go
@@ -493,6 +493,70 @@ func TestOAuth_FullAuthCodeFlow_PKCE(t *testing.T) {
 	}
 }
 
+// TestOAuth_Authorize_AcceptsResourceOnly pins Codex review #372
+// round 1 fix: real RFC 8707 clients (Claude Desktop / Cursor /
+// ChatGPT) send `resource=` not `audience=`. fosite v0.49 only
+// reads the `audience` form key, so without translation the
+// audienceMatchingStrategy sees an empty needle and rejects
+// every authorize request from a real-world client.
+//
+// This test sends ONLY `resource=` (no `audience=`) and asserts
+// the request reaches the consent stub successfully — i.e.
+// translateResourceToAudience populated fosite's expected key.
+func TestOAuth_Authorize_AcceptsResourceOnly(t *testing.T) {
+	srv, _ := oauthEnabledTestServer(t)
+	clientID := registerTestClient(t, srv, "https://app.test/cb")
+	_, sessionToken := loginTestUser(t, srv)
+
+	verifier := "verifier-the-quick-brown-fox-1234567890-abcdef"
+	challenge := s256Challenge(verifier)
+
+	// Note: ONLY resource= here — no audience=. RFC 8707 form.
+	q := url.Values{
+		"client_id":             {clientID},
+		"response_type":         {"code"},
+		"redirect_uri":          {"https://app.test/cb"},
+		"scope":                 {"pad:read"},
+		"resource":              {testCanonicalAudience},
+		"code_challenge":        {challenge},
+		"code_challenge_method": {"S256"},
+		"state":                 {"resource-only-state"},
+	}
+	rr := doAuthedRequest(srv, "GET", "/oauth/authorize?"+q.Encode(), nil, sessionToken)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 (consent stub) for resource-only request; got %d (Location: %s)",
+			rr.Code, rr.Header().Get("Location"))
+	}
+}
+
+// TestOAuth_AuthorizationServerMetadata_OmitsUnimplementedEndpoints
+// pins Codex review #372 round 1 fix #2: the discovery doc must
+// NOT advertise revocation_endpoint or introspection_endpoint
+// until sub-PR D (TASK-1026) actually mounts those handlers.
+// Advertised-but-404 endpoints are worse than absent ones — RFC
+// 8414 §2 says they're optional, so omitting is spec-compliant.
+func TestOAuth_AuthorizationServerMetadata_OmitsUnimplementedEndpoints(t *testing.T) {
+	srv, _ := oauthEnabledTestServer(t)
+
+	rr := doRequest(srv, "GET", "/.well-known/oauth-authorization-server", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	var doc map[string]any
+	parseJSON(t, rr, &doc)
+
+	for _, k := range []string{
+		"revocation_endpoint",
+		"introspection_endpoint",
+		"revocation_endpoint_auth_methods_supported",
+		"introspection_endpoint_auth_methods_supported",
+	} {
+		if _, ok := doc[k]; ok {
+			t.Errorf("doc must NOT advertise %q until sub-PR D ships the handler; got %v", k, doc[k])
+		}
+	}
+}
+
 func TestOAuth_Token_RejectsMissingPKCEVerifier(t *testing.T) {
 	srv, _ := oauthEnabledTestServer(t)
 	_, sessionToken := loginTestUser(t, srv)

--- a/internal/server/handlers_oauth_test.go
+++ b/internal/server/handlers_oauth_test.go
@@ -189,10 +189,10 @@ func TestOAuth_Register_RejectsMissingRedirectURIs(t *testing.T) {
 func TestOAuth_Register_RejectsBadRedirectURIShapes(t *testing.T) {
 	srv, _ := oauthEnabledTestServer(t)
 	cases := map[string]string{
-		"relative":              "/oauth/cb",
-		"http+non-loopback":     "http://attacker.example/cb",
-		"fragment":              "https://app.test/cb#x",
-		"javascript scheme":     "javascript:alert(1)",
+		"relative":          "/oauth/cb",
+		"http+non-loopback": "http://attacker.example/cb",
+		"fragment":          "https://app.test/cb#x",
+		"javascript scheme": "javascript:alert(1)",
 	}
 	for name, badURI := range cases {
 		t.Run(name, func(t *testing.T) {
@@ -326,10 +326,10 @@ func TestOAuth_Authorize_RejectsAudienceMismatch(t *testing.T) {
 	challenge := s256Challenge(verifier)
 
 	q := url.Values{
-		"client_id":             {clientID},
-		"response_type":         {"code"},
-		"redirect_uri":          {"https://app.test/cb"},
-		"scope":                 {"pad:read"},
+		"client_id":     {clientID},
+		"response_type": {"code"},
+		"redirect_uri":  {"https://app.test/cb"},
+		"scope":         {"pad:read"},
 		// Wrong audience — neither matches canonical. fosite's
 		// AudienceMatchingStrategy from sub-PR B rejects.
 		"audience":              {"https://other.example/mcp"},

--- a/internal/server/handlers_oauth_test.go
+++ b/internal/server/handlers_oauth_test.go
@@ -1,0 +1,671 @@
+package server
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/oauth"
+)
+
+// HTTP-handler tests for the OAuth 2.1 authorization server (PLAN-943
+// TASK-1025 sub-PR C).
+//
+// What's covered here:
+//
+//   - /.well-known/oauth-authorization-server: replaces the 501 stub
+//     from TASK-950 with real RFC 8414 metadata; pin the shape so a
+//     future field tweak is caught fast.
+//   - /oauth/register (DCR): happy path + each validation gate.
+//   - /oauth/authorize: redirects to /login when no session;
+//     renders consent stub when logged in; rejects on bad audience.
+//   - /oauth/authorize/decide: CSRF-token-required (form-bound);
+//     denies on decision=deny; runs fosite + redirects on approve.
+//   - /oauth/token: full auth-code → token round-trip via PKCE.
+//
+// The full Claude-Desktop-end-to-end (DCR → authorize → token →
+// /mcp call) lands in sub-PR E's e2e test once MCPBearerAuth gains
+// the OAuth introspection branch. This file covers the OAuth-server
+// layer in isolation.
+
+const (
+	testCanonicalAudience = "https://mcp.test.example/mcp"
+	testAuthServerURL     = "https://app.test.example"
+)
+
+// oauthEnabledTestServer builds a Server with cloud mode + a real
+// internal/oauth.Server backed by the test store. Returns the
+// Server so each test can drive doRequest helpers, plus the
+// underlying *oauth.Server in case a test wants to seed clients or
+// inspect storage state directly.
+func oauthEnabledTestServer(t *testing.T) (*Server, *oauth.Server) {
+	t.Helper()
+	srv := testServer(t)
+	srv.SetCloudMode("test-secret")
+	// Stub MCP transport so SetMCPTransport's URL fields are populated;
+	// the OAuth handlers read mcpAuthServerURL via authServerIssuerURL.
+	stub := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {})
+	srv.SetMCPTransport(stub, testCanonicalAudience[:strings.LastIndex(testCanonicalAudience, "/")], testAuthServerURL)
+
+	o, err := oauth.NewServer(oauth.Config{
+		Store:           srv.store,
+		HMACSecret:      bytes32ForTest(),
+		AllowedAudience: testCanonicalAudience,
+	})
+	if err != nil {
+		t.Fatalf("oauth.NewServer: %v", err)
+	}
+	srv.SetOAuthServer(o)
+	return srv, o
+}
+
+func bytes32ForTest() []byte {
+	out := make([]byte, 32)
+	for i := range out {
+		out[i] = byte(i + 1)
+	}
+	return out
+}
+
+// =====================================================================
+// Discovery doc — replaces TASK-950's 501 stub
+// =====================================================================
+
+func TestOAuth_AuthorizationServerMetadata_PopulatedShape(t *testing.T) {
+	srv, _ := oauthEnabledTestServer(t)
+
+	rr := doRequest(srv, "GET", "/.well-known/oauth-authorization-server", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 (replaced from 501 stub), got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+
+	var doc map[string]any
+	parseJSON(t, rr, &doc)
+
+	wantStr := map[string]string{
+		"issuer":                 testAuthServerURL,
+		"authorization_endpoint": testAuthServerURL + "/oauth/authorize",
+		"token_endpoint":         testAuthServerURL + "/oauth/token",
+		"registration_endpoint":  testAuthServerURL + "/oauth/register",
+	}
+	for k, want := range wantStr {
+		if got, _ := doc[k].(string); got != want {
+			t.Errorf("%s: got %q, want %q", k, got, want)
+		}
+	}
+
+	// Critical compliance bits Claude Desktop reads on connect.
+	if !sliceContainsString(doc["code_challenge_methods_supported"], "S256") {
+		t.Error("code_challenge_methods_supported missing S256")
+	}
+	if sliceContainsString(doc["code_challenge_methods_supported"], "plain") {
+		t.Error("code_challenge_methods_supported must NOT include plain (we enforce S256-only)")
+	}
+	if !sliceContainsString(doc["response_types_supported"], "code") {
+		t.Error("response_types_supported missing 'code'")
+	}
+	if !sliceContainsString(doc["grant_types_supported"], "authorization_code") {
+		t.Error("grant_types_supported missing authorization_code")
+	}
+	if !sliceContainsString(doc["grant_types_supported"], "refresh_token") {
+		t.Error("grant_types_supported missing refresh_token")
+	}
+	if !sliceContainsString(doc["token_endpoint_auth_methods_supported"], "none") {
+		t.Error("token_endpoint_auth_methods_supported missing 'none' (public clients only)")
+	}
+	if doc["resource_indicators_supported"] != true {
+		t.Error("resource_indicators_supported must be true (RFC 8707)")
+	}
+}
+
+func sliceContainsString(v any, want string) bool {
+	if arr, ok := v.([]any); ok {
+		for _, x := range arr {
+			if s, _ := x.(string); s == want {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// =====================================================================
+// /oauth/register — DCR (RFC 7591)
+// =====================================================================
+
+func TestOAuth_Register_HappyPath(t *testing.T) {
+	srv, _ := oauthEnabledTestServer(t)
+
+	rr := doRequest(srv, "POST", "/oauth/register", map[string]any{
+		"client_name":   "Test Client",
+		"redirect_uris": []string{"https://app.test/cb", "claude://oauth/callback"},
+	})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+
+	var resp map[string]any
+	parseJSON(t, rr, &resp)
+	if resp["client_id"] == "" {
+		t.Error("missing client_id")
+	}
+	if resp["client_id_issued_at"] == nil {
+		t.Error("missing client_id_issued_at")
+	}
+	// Defaults applied per the handler.
+	if !sliceContainsString(resp["grant_types"], "authorization_code") ||
+		!sliceContainsString(resp["grant_types"], "refresh_token") {
+		t.Errorf("grant_types defaults wrong: %v", resp["grant_types"])
+	}
+	if !sliceContainsString(resp["response_types"], "code") {
+		t.Errorf("response_types default wrong: %v", resp["response_types"])
+	}
+	if resp["token_endpoint_auth_method"] != "none" {
+		t.Errorf("token_endpoint_auth_method default wrong: %v", resp["token_endpoint_auth_method"])
+	}
+}
+
+func TestOAuth_Register_RejectsMissingRedirectURIs(t *testing.T) {
+	srv, _ := oauthEnabledTestServer(t)
+	rr := doRequest(srv, "POST", "/oauth/register", map[string]any{
+		"client_name": "No URIs",
+	})
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", rr.Code)
+	}
+	var resp map[string]any
+	parseJSON(t, rr, &resp)
+	if resp["error"] != "invalid_redirect_uri" {
+		t.Errorf("error code: got %v want invalid_redirect_uri", resp["error"])
+	}
+}
+
+func TestOAuth_Register_RejectsBadRedirectURIShapes(t *testing.T) {
+	srv, _ := oauthEnabledTestServer(t)
+	cases := map[string]string{
+		"relative":              "/oauth/cb",
+		"http+non-loopback":     "http://attacker.example/cb",
+		"fragment":              "https://app.test/cb#x",
+		"javascript scheme":     "javascript:alert(1)",
+	}
+	for name, badURI := range cases {
+		t.Run(name, func(t *testing.T) {
+			rr := doRequest(srv, "POST", "/oauth/register", map[string]any{
+				"redirect_uris": []string{badURI},
+			})
+			if rr.Code != http.StatusBadRequest {
+				t.Errorf("%s: expected 400, got %d (body: %s)", name, rr.Code, rr.Body.String())
+			}
+		})
+	}
+}
+
+func TestOAuth_Register_RejectsNonPublicClientAuth(t *testing.T) {
+	srv, _ := oauthEnabledTestServer(t)
+	rr := doRequest(srv, "POST", "/oauth/register", map[string]any{
+		"redirect_uris":              []string{"https://app.test/cb"},
+		"token_endpoint_auth_method": "client_secret_basic",
+	})
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for non-public-client auth method, got %d", rr.Code)
+	}
+}
+
+func TestOAuth_Register_RejectsUnknownGrantType(t *testing.T) {
+	srv, _ := oauthEnabledTestServer(t)
+	rr := doRequest(srv, "POST", "/oauth/register", map[string]any{
+		"redirect_uris": []string{"https://app.test/cb"},
+		"grant_types":   []string{"client_credentials"},
+	})
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("expected 400 for unsupported grant_type, got %d", rr.Code)
+	}
+}
+
+func TestOAuth_Register_NotMountedOutsideCloudMode(t *testing.T) {
+	srv := testServer(t) // no SetCloudMode, no SetOAuthServer
+	rr := doRequest(srv, "POST", "/oauth/register", map[string]any{
+		"redirect_uris": []string{"https://app.test/cb"},
+	})
+	// The route group is cloud-mode-gated; falls through to the SPA
+	// catch-all (200 with HTML index in self-host mode), or 404 in
+	// the test harness without a SPA.
+	if rr.Code == http.StatusCreated {
+		t.Errorf("DCR endpoint must NOT be reachable outside cloud mode; got 201")
+	}
+}
+
+// =====================================================================
+// /oauth/authorize — login redirect + consent stub
+// =====================================================================
+
+func TestOAuth_Authorize_RedirectsToLoginWhenNoSession(t *testing.T) {
+	srv, _ := oauthEnabledTestServer(t)
+	// Register a client to make the request well-formed.
+	clientID := registerTestClient(t, srv, "https://app.test/cb")
+
+	verifier := "code-verifier-abc123-must-be-43-to-128-chars-long"
+	challenge := s256Challenge(verifier)
+
+	q := url.Values{
+		"client_id":             {clientID},
+		"response_type":         {"code"},
+		"redirect_uri":          {"https://app.test/cb"},
+		"scope":                 {"pad:read"},
+		"resource":              {testCanonicalAudience},
+		"audience":              {testCanonicalAudience}, // fosite reads `audience` form param
+		"code_challenge":        {challenge},
+		"code_challenge_method": {"S256"},
+		"state":                 {"client-csrf-state"},
+	}
+
+	rr := doRequest(srv, "GET", "/oauth/authorize?"+q.Encode(), nil)
+	if rr.Code != http.StatusFound {
+		t.Fatalf("expected 302 to /login, got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+	loc := rr.Header().Get("Location")
+	if !strings.HasPrefix(loc, "/login?redirect=") {
+		t.Errorf("Location should redirect to /login?redirect=...; got %q", loc)
+	}
+	if !strings.Contains(loc, url.QueryEscape("/oauth/authorize?")) {
+		t.Errorf("redirect= must encode /oauth/authorize?...; got %q", loc)
+	}
+}
+
+func TestOAuth_Authorize_RendersConsentStubWhenLoggedIn(t *testing.T) {
+	srv, _ := oauthEnabledTestServer(t)
+	clientID := registerTestClient(t, srv, "https://app.test/cb")
+	user, sessionToken := loginTestUser(t, srv)
+
+	verifier := "code-verifier-abc123-must-be-43-to-128-chars-long"
+	challenge := s256Challenge(verifier)
+
+	q := url.Values{
+		"client_id":             {clientID},
+		"response_type":         {"code"},
+		"redirect_uri":          {"https://app.test/cb"},
+		"scope":                 {"pad:read pad:write"},
+		"resource":              {testCanonicalAudience},
+		"audience":              {testCanonicalAudience},
+		"code_challenge":        {challenge},
+		"code_challenge_method": {"S256"},
+		"state":                 {"client-state"},
+	}
+
+	rr := doAuthedRequest(srv, "GET", "/oauth/authorize?"+q.Encode(), nil, sessionToken)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 with consent HTML, got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+	body := rr.Body.String()
+	if !strings.Contains(body, "<form method=\"POST\" action=\"/oauth/authorize/decide\"") {
+		t.Error("consent stub must POST to /oauth/authorize/decide")
+	}
+	if !strings.Contains(body, `name="csrf_token"`) {
+		t.Error("consent stub must include csrf_token hidden field")
+	}
+	if !strings.Contains(body, "pad:read") || !strings.Contains(body, "pad:write") {
+		t.Error("consent stub must list requested scopes")
+	}
+	if !strings.Contains(body, user.Name) {
+		t.Errorf("consent stub must surface the username %q for clarity", user.Name)
+	}
+}
+
+func TestOAuth_Authorize_RejectsAudienceMismatch(t *testing.T) {
+	srv, _ := oauthEnabledTestServer(t)
+	clientID := registerTestClient(t, srv, "https://app.test/cb")
+	_, sessionToken := loginTestUser(t, srv)
+
+	verifier := "code-verifier-abc123-must-be-43-to-128-chars-long"
+	challenge := s256Challenge(verifier)
+
+	q := url.Values{
+		"client_id":             {clientID},
+		"response_type":         {"code"},
+		"redirect_uri":          {"https://app.test/cb"},
+		"scope":                 {"pad:read"},
+		// Wrong audience — neither matches canonical. fosite's
+		// AudienceMatchingStrategy from sub-PR B rejects.
+		"audience":              {"https://other.example/mcp"},
+		"code_challenge":        {challenge},
+		"code_challenge_method": {"S256"},
+	}
+
+	rr := doAuthedRequest(srv, "GET", "/oauth/authorize?"+q.Encode(), nil, sessionToken)
+	// fosite's WriteAuthorizeError redirects to the client's
+	// redirect_uri with error params (so the client can surface).
+	// fosite uses 303 See Other per RFC 7231 for non-idempotent
+	// result redirects (authorize_error.go:68).
+	if rr.Code != http.StatusSeeOther && rr.Code != http.StatusFound {
+		t.Fatalf("expected 303/302 with OAuth error, got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+	loc := rr.Header().Get("Location")
+	if !strings.HasPrefix(loc, "https://app.test/cb") {
+		t.Errorf("error redirect should target client redirect_uri; got %q", loc)
+	}
+	if !strings.Contains(loc, "error=invalid_request") {
+		t.Errorf("expected error=invalid_request in error redirect; got %q", loc)
+	}
+}
+
+// =====================================================================
+// /oauth/authorize/decide — consent processing
+// =====================================================================
+
+func TestOAuth_AuthorizeDecide_RejectsMissingCSRFToken(t *testing.T) {
+	srv, _ := oauthEnabledTestServer(t)
+	_, sessionToken := loginTestUser(t, srv)
+	clientID := registerTestClient(t, srv, "https://app.test/cb")
+
+	form := url.Values{
+		"client_id":             {clientID},
+		"response_type":         {"code"},
+		"redirect_uri":          {"https://app.test/cb"},
+		"scope":                 {"pad:read"},
+		"code_challenge":        {s256Challenge("abc-12345-the-quick-brown-fox-1234567890")},
+		"code_challenge_method": {"S256"},
+		"audience":              {testCanonicalAudience},
+		"state":                 {"test-state-12345"}, // fosite requires ≥8 chars
+		"decision":              {"approve"},
+		// Deliberately no csrf_token.
+	}
+
+	req := httptest.NewRequest("POST", "/oauth/authorize/decide", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("User-Agent", testSessionUA)
+	req.AddCookie(&http.Cookie{Name: sessionCookieName(srv.secureCookies), Value: sessionToken})
+	req.RemoteAddr = "192.0.2.1:1234"
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Errorf("expected 403 for missing csrf_token, got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+}
+
+func TestOAuth_AuthorizeDecide_DenyRedirectsAccessDenied(t *testing.T) {
+	srv, _ := oauthEnabledTestServer(t)
+	_, sessionToken := loginTestUser(t, srv)
+	clientID := registerTestClient(t, srv, "https://app.test/cb")
+	csrfTok := readCSRFFromCookie(t, srv, sessionToken)
+
+	form := url.Values{
+		"client_id":             {clientID},
+		"response_type":         {"code"},
+		"redirect_uri":          {"https://app.test/cb"},
+		"scope":                 {"pad:read"},
+		"code_challenge":        {s256Challenge("abc-12345-the-quick-brown-fox-1234567890")},
+		"code_challenge_method": {"S256"},
+		"audience":              {testCanonicalAudience},
+		"state":                 {"test-state-12345"},
+		"decision":              {"deny"},
+		"csrf_token":            {csrfTok},
+	}
+	rr := postFormWithCookie(srv, "/oauth/authorize/decide", form, sessionToken, csrfTok)
+	// fosite uses 303 See Other for OAuth redirects.
+	if rr.Code != http.StatusSeeOther && rr.Code != http.StatusFound {
+		t.Fatalf("expected 303/302 with access_denied, got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+	loc := rr.Header().Get("Location")
+	if !strings.Contains(loc, "error=access_denied") {
+		t.Errorf("Location should carry error=access_denied; got %q", loc)
+	}
+}
+
+// =====================================================================
+// Full /authorize → /token round-trip with PKCE
+// =====================================================================
+
+func TestOAuth_FullAuthCodeFlow_PKCE(t *testing.T) {
+	srv, _ := oauthEnabledTestServer(t)
+	_, sessionToken := loginTestUser(t, srv)
+	clientID := registerTestClient(t, srv, "https://app.test/cb")
+	csrfTok := readCSRFFromCookie(t, srv, sessionToken)
+
+	// Step 1: POST /oauth/authorize/decide with decision=approve.
+	verifier := "verifier-1234567890-abcdef-the-quick-brown-fox-jumps"
+	challenge := s256Challenge(verifier)
+
+	form := url.Values{
+		"client_id":             {clientID},
+		"response_type":         {"code"},
+		"redirect_uri":          {"https://app.test/cb"},
+		"code_challenge":        {challenge},
+		"code_challenge_method": {"S256"},
+		"scope":                 {"pad:read"},
+		"audience":              {testCanonicalAudience},
+		"state":                 {"client-csrf-state"},
+		"decision":              {"approve"},
+		"csrf_token":            {csrfTok},
+	}
+	rr := postFormWithCookie(srv, "/oauth/authorize/decide", form, sessionToken, csrfTok)
+	// fosite uses 303 See Other for OAuth redirects.
+	if rr.Code != http.StatusSeeOther && rr.Code != http.StatusFound {
+		t.Fatalf("decide expected 303/302, got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+	loc := rr.Header().Get("Location")
+	cbURL, err := url.Parse(loc)
+	if err != nil {
+		t.Fatalf("parse callback Location: %v", err)
+	}
+	code := cbURL.Query().Get("code")
+	if code == "" {
+		t.Fatalf("callback URL missing code param: %s", loc)
+	}
+	if cbURL.Query().Get("state") != "client-csrf-state" {
+		t.Errorf("state not echoed: got %q", cbURL.Query().Get("state"))
+	}
+
+	// Step 2: POST /oauth/token with PKCE verifier + audience.
+	tokenForm := url.Values{
+		"grant_type":    {"authorization_code"},
+		"code":          {code},
+		"client_id":     {clientID},
+		"redirect_uri":  {"https://app.test/cb"},
+		"code_verifier": {verifier},
+		"audience":      {testCanonicalAudience},
+	}
+	tr := httptest.NewRequest("POST", "/oauth/token", strings.NewReader(tokenForm.Encode()))
+	tr.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	tr.RemoteAddr = "192.0.2.1:1234"
+	trr := httptest.NewRecorder()
+	srv.ServeHTTP(trr, tr)
+	if trr.Code != http.StatusOK {
+		t.Fatalf("token expected 200, got %d (body: %s)", trr.Code, trr.Body.String())
+	}
+
+	var resp map[string]any
+	parseJSON(t, trr, &resp)
+	if resp["access_token"] == "" || resp["access_token"] == nil {
+		t.Errorf("missing access_token: %v", resp)
+	}
+	if resp["refresh_token"] == "" || resp["refresh_token"] == nil {
+		t.Errorf("missing refresh_token (RefreshTokenScopes=[] should issue on every grant): %v", resp["refresh_token"])
+	}
+	if resp["token_type"] != "bearer" {
+		t.Errorf("token_type should be bearer, got %v", resp["token_type"])
+	}
+}
+
+func TestOAuth_Token_RejectsMissingPKCEVerifier(t *testing.T) {
+	srv, _ := oauthEnabledTestServer(t)
+	_, sessionToken := loginTestUser(t, srv)
+	clientID := registerTestClient(t, srv, "https://app.test/cb")
+	csrfTok := readCSRFFromCookie(t, srv, sessionToken)
+
+	verifier := "verifier-1234567890-abcdef-the-quick-brown-fox-jumps"
+	challenge := s256Challenge(verifier)
+
+	form := url.Values{
+		"client_id":             {clientID},
+		"response_type":         {"code"},
+		"redirect_uri":          {"https://app.test/cb"},
+		"scope":                 {"pad:read"},
+		"code_challenge":        {challenge},
+		"code_challenge_method": {"S256"},
+		"audience":              {testCanonicalAudience},
+		"state":                 {"test-state-12345"},
+		"decision":              {"approve"},
+		"csrf_token":            {csrfTok},
+	}
+	rr := postFormWithCookie(srv, "/oauth/authorize/decide", form, sessionToken, csrfTok)
+	loc := rr.Header().Get("Location")
+	cbURL, _ := url.Parse(loc)
+	code := cbURL.Query().Get("code")
+
+	// Token exchange WITHOUT code_verifier — must fail.
+	tokenForm := url.Values{
+		"grant_type":   {"authorization_code"},
+		"code":         {code},
+		"client_id":    {clientID},
+		"redirect_uri": {"https://app.test/cb"},
+		"audience":     {testCanonicalAudience},
+		// Deliberately no code_verifier.
+	}
+	tr := httptest.NewRequest("POST", "/oauth/token", strings.NewReader(tokenForm.Encode()))
+	tr.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	tr.RemoteAddr = "192.0.2.1:1234"
+	trr := httptest.NewRecorder()
+	srv.ServeHTTP(trr, tr)
+	if trr.Code == http.StatusOK {
+		t.Errorf("expected non-200 for missing PKCE verifier; got %d (body: %s)", trr.Code, trr.Body.String())
+	}
+}
+
+// =====================================================================
+// Helpers
+// =====================================================================
+
+// registerTestClient calls /oauth/register and returns the client_id.
+func registerTestClient(t *testing.T, srv *Server, redirectURI string) string {
+	t.Helper()
+	rr := doRequest(srv, "POST", "/oauth/register", map[string]any{
+		"client_name":   "Test",
+		"redirect_uris": []string{redirectURI},
+	})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("registerTestClient: %d (body: %s)", rr.Code, rr.Body.String())
+	}
+	var resp map[string]any
+	parseJSON(t, rr, &resp)
+	id, _ := resp["client_id"].(string)
+	if id == "" {
+		t.Fatalf("registerTestClient: empty client_id")
+	}
+	return id
+}
+
+// testSessionUA is the User-Agent the test session is bound to.
+// SessionAuth (middleware_auth.go:186) hashes the request's UA
+// against the session's stored hash; mismatch silently drops the
+// session (returns w/o currentUser populated). Tests using
+// doAuthedRequest must send this exact value as User-Agent.
+const testSessionUA = "oauth-test-ua/1.0"
+
+// loginTestUser creates a user + session, returns the user + the
+// raw session token suitable for AddCookie.
+func loginTestUser(t *testing.T, srv *Server) (*models.User, string) {
+	t.Helper()
+	user, err := srv.store.CreateUser(models.UserCreate{
+		Email:    "oauth-test@example.com",
+		Name:     "OAuth Tester",
+		Password: "pw-test-12345",
+	})
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	tok, err := srv.store.CreateSession(user.ID, "test", "192.0.2.1", testSessionUA, webSessionTTL)
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	return user, tok
+}
+
+// doAuthedRequest is like doRequest but with a session cookie + the
+// matching User-Agent attached (SessionAuth UA-binding, see
+// middleware_auth.go:186).
+func doAuthedRequest(srv *Server, method, path string, body any, sessionToken string) *httptest.ResponseRecorder {
+	var bodyReader *strings.Reader
+	if body != nil {
+		b, _ := json.Marshal(body)
+		bodyReader = strings.NewReader(string(b))
+	}
+	var req *http.Request
+	if bodyReader != nil {
+		req = httptest.NewRequest(method, path, bodyReader)
+		req.Header.Set("Content-Type", "application/json")
+	} else {
+		req = httptest.NewRequest(method, path, nil)
+	}
+	req.Header.Set("User-Agent", testSessionUA)
+	req.AddCookie(&http.Cookie{Name: sessionCookieName(srv.secureCookies), Value: sessionToken})
+	req.RemoteAddr = "192.0.2.1:1234"
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	return rr
+}
+
+// postFormWithCookie POSTs an x-www-form-urlencoded body with both
+// a session cookie and the matching CSRF cookie set, plus the
+// session-bound User-Agent.
+func postFormWithCookie(srv *Server, path string, form url.Values, sessionToken, csrfTok string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest("POST", path, strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("User-Agent", testSessionUA)
+	req.AddCookie(&http.Cookie{Name: sessionCookieName(srv.secureCookies), Value: sessionToken})
+	req.AddCookie(&http.Cookie{Name: csrfCookieName(srv.secureCookies), Value: csrfTok})
+	req.RemoteAddr = "192.0.2.1:1234"
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	return rr
+}
+
+// readCSRFFromCookie hits any consent-rendering endpoint that sets
+// the CSRF cookie on first visit, returns the token. We use
+// /oauth/authorize because it's the natural source — the consent
+// stub renders + sets the cookie.
+//
+// Returns the raw cookie value (hex string).
+func readCSRFFromCookie(t *testing.T, srv *Server, sessionToken string) string {
+	t.Helper()
+	clientID := registerTestClient(t, srv, "https://app.test/cb")
+	verifier := "verifier-the-quick-brown-fox-1234567890-abcdef-1234"
+	challenge := s256Challenge(verifier)
+	q := url.Values{
+		"client_id":             {clientID},
+		"response_type":         {"code"},
+		"redirect_uri":          {"https://app.test/cb"},
+		"scope":                 {"pad:read"},
+		"code_challenge":        {challenge},
+		"code_challenge_method": {"S256"},
+		"audience":              {testCanonicalAudience},
+		// fosite requires state to be ≥8 chars (entropy guard);
+		// authorize_request_handler.go validates this on every flow.
+		"state": {"helper-state-12345"},
+	}
+	rr := doAuthedRequest(srv, "GET", "/oauth/authorize?"+q.Encode(), nil, sessionToken)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("readCSRFFromCookie: authorize render = %d (Location: %s, body: %s)", rr.Code, rr.Header().Get("Location"), rr.Body.String())
+	}
+	for _, c := range rr.Result().Cookies() {
+		if c.Name == csrfCookieName(srv.secureCookies) {
+			return c.Value
+		}
+	}
+	t.Fatal("readCSRFFromCookie: no csrf cookie in response")
+	return ""
+}
+
+// s256Challenge computes the base64url(no-padding, SHA256(verifier))
+// per RFC 7636 §4.2. PKCE clients use this to derive code_challenge
+// from code_verifier.
+func s256Challenge(verifier string) string {
+	sum := sha256.Sum256([]byte(verifier))
+	return base64.RawURLEncoding.EncodeToString(sum[:])
+}

--- a/internal/server/handlers_well_known.go
+++ b/internal/server/handlers_well_known.go
@@ -157,16 +157,16 @@ func (s *Server) handleOAuthAuthorizationServer(w http.ResponseWriter, r *http.R
 	// revocation_endpoint + introspection_endpoint here" as a
 	// follow-up.
 	doc := authServerMetadata{
-		Issuer:                                     issuer,
-		AuthorizationEndpoint:                      issuer + "/oauth/authorize",
-		TokenEndpoint:                              issuer + "/oauth/token",
-		RegistrationEndpoint:                       issuer + "/oauth/register",
-		ResponseTypesSupported:                     []string{"code"},
-		GrantTypesSupported:                        []string{"authorization_code", "refresh_token"},
-		CodeChallengeMethodsSupported:              []string{"S256"},
-		TokenEndpointAuthMethodsSupported:          []string{"none"},
-		ScopesSupported:             []string{"pad:read", "pad:write", "pad:admin"},
-		ResourceIndicatorsSupported: true,
+		Issuer:                            issuer,
+		AuthorizationEndpoint:             issuer + "/oauth/authorize",
+		TokenEndpoint:                     issuer + "/oauth/token",
+		RegistrationEndpoint:              issuer + "/oauth/register",
+		ResponseTypesSupported:            []string{"code"},
+		GrantTypesSupported:               []string{"authorization_code", "refresh_token"},
+		CodeChallengeMethodsSupported:     []string{"S256"},
+		TokenEndpointAuthMethodsSupported: []string{"none"},
+		ScopesSupported:                   []string{"pad:read", "pad:write", "pad:admin"},
+		ResourceIndicatorsSupported:       true,
 		// authorization_response_iss_parameter_supported (RFC 9207)
 		// is intentionally OMITTED. Advertising it would imply that
 		// /authorize redirects carry iss=<issuer> in the response

--- a/internal/server/handlers_well_known.go
+++ b/internal/server/handlers_well_known.go
@@ -147,9 +147,19 @@ func (s *Server) handleOAuthAuthorizationServer(w http.ResponseWriter, r *http.R
 		GrantTypesSupported:                        []string{"authorization_code", "refresh_token"},
 		CodeChallengeMethodsSupported:              []string{"S256"},
 		TokenEndpointAuthMethodsSupported:          []string{"none"},
-		ScopesSupported:                            []string{"pad:read", "pad:write", "pad:admin"},
-		ResourceIndicatorsSupported:                true,
-		AuthorizationResponseIssParameterSupported: true,
+		ScopesSupported:             []string{"pad:read", "pad:write", "pad:admin"},
+		ResourceIndicatorsSupported: true,
+		// authorization_response_iss_parameter_supported (RFC 9207)
+		// is intentionally OMITTED. Advertising it would imply that
+		// /authorize redirects carry iss=<issuer> in the response
+		// query string — but fosite v0.49 doesn't add it natively
+		// and we don't post-process WriteAuthorizeResponse to inject
+		// it. RFC 9207-aware clients (currently rare; not yet
+		// required by Claude Desktop) would treat the missing
+		// parameter as a protocol violation and reject the response.
+		// Codex review #372 round 2 caught the discrepancy; we'll
+		// add the parameter in a future PR alongside any RFC 9207
+		// requirement we encounter from a client.
 	}
 	w.Header().Set("Content-Type", "application/json")
 	// Same 1-hour cache as the protected-resource doc.
@@ -168,17 +178,16 @@ func (s *Server) handleOAuthAuthorizationServer(w http.ResponseWriter, r *http.R
 // omitted entirely (RFC 8414 §2 marks them OPTIONAL) so clients
 // don't dial endpoints that 404.
 type authServerMetadata struct {
-	Issuer                                     string   `json:"issuer"`
-	AuthorizationEndpoint                      string   `json:"authorization_endpoint"`
-	TokenEndpoint                              string   `json:"token_endpoint"`
-	RegistrationEndpoint                       string   `json:"registration_endpoint"`
-	ResponseTypesSupported                     []string `json:"response_types_supported"`
-	GrantTypesSupported                        []string `json:"grant_types_supported"`
-	CodeChallengeMethodsSupported              []string `json:"code_challenge_methods_supported"`
-	TokenEndpointAuthMethodsSupported          []string `json:"token_endpoint_auth_methods_supported"`
-	ScopesSupported                            []string `json:"scopes_supported"`
-	ResourceIndicatorsSupported                bool     `json:"resource_indicators_supported"`
-	AuthorizationResponseIssParameterSupported bool     `json:"authorization_response_iss_parameter_supported"`
+	Issuer                            string   `json:"issuer"`
+	AuthorizationEndpoint             string   `json:"authorization_endpoint"`
+	TokenEndpoint                     string   `json:"token_endpoint"`
+	RegistrationEndpoint              string   `json:"registration_endpoint"`
+	ResponseTypesSupported            []string `json:"response_types_supported"`
+	GrantTypesSupported               []string `json:"grant_types_supported"`
+	CodeChallengeMethodsSupported     []string `json:"code_challenge_methods_supported"`
+	TokenEndpointAuthMethodsSupported []string `json:"token_endpoint_auth_methods_supported"`
+	ScopesSupported                   []string `json:"scopes_supported"`
+	ResourceIndicatorsSupported       bool     `json:"resource_indicators_supported"`
 }
 
 // protectedResourceMetadata is the RFC 9728 wire format. Field names

--- a/internal/server/handlers_well_known.go
+++ b/internal/server/handlers_well_known.go
@@ -84,31 +84,96 @@ func (s *Server) handleOAuthProtectedResource(w http.ResponseWriter, r *http.Req
 	_ = json.NewEncoder(w).Encode(doc)
 }
 
-// handleOAuthAuthorizationServerStub is the placeholder for RFC 8414
-// "OAuth 2.0 Authorization Server Metadata" on the auth-server vhost.
-// TASK-951 will fill this in with the real /oauth/{authorize, token,
-// register, revoke, introspect} endpoint URLs + supported response
-// types, grant types, PKCE methods, etc.
+// handleOAuthAuthorizationServer serves RFC 8414 "OAuth 2.0
+// Authorization Server Metadata" at /.well-known/oauth-authorization-server.
 //
-// We mount the stub now so the discovery chain is complete from the
-// MCP client's perspective: they hit /.well-known/oauth-protected-
-// resource (this PR), follow authorization_servers[0] to /.well-known/
-// oauth-authorization-server, and get a 501 with a clear message
-// rather than a 404 that would suggest misconfiguration.
+// Replaces the 501 stub from TASK-950 with the real document
+// describing pad's auth-code + refresh + PKCE-S256 flow. Claude
+// Desktop and other MCP clients fetch this after following the
+// authorization_servers[] pointer in the protected-resource doc;
+// the document tells them which endpoint URLs to use, which grant
+// types are accepted, what scopes the server understands, etc.
 //
-// Once TASK-951 ships, replace the body with the real metadata
-// document.
-func (s *Server) handleOAuthAuthorizationServerStub(w http.ResponseWriter, _ *http.Request) {
+// What's enabled:
+//
+//   - response_types: ["code"]                — auth-code flow only
+//   - grant_types:    ["authorization_code", "refresh_token"]
+//   - PKCE:           required (S256 only — Config.EnablePKCEPlainChallengeMethod=false)
+//   - client auth:    none (public clients only — PKCE-authenticated)
+//   - resource indicators (RFC 8707): supported, mandatory per audienceMatchingStrategy
+//   - registration:   open DCR (RFC 7591)
+//
+// Excluded:
+//
+//   - id_token / OpenID — not declared in scopes_supported
+//   - implicit grant — deprecated in OAuth 2.1
+//   - client credentials — public-clients-only model
+//   - device-code grant — not relevant for MCP-over-HTTPS
+//
+// URLs are derived from cfg.AuthServerURL (PAD_AUTH_SERVER_URL) at
+// startup; falls back to the request scheme + host so local-dev
+// works without env vars.
+//
+// This handler is mounted under the cloud-mode gate (same group as
+// /.well-known/oauth-protected-resource). It's intentionally
+// unauthenticated — RFC 8414 §3 explicitly says metadata MUST be
+// available without authentication.
+func (s *Server) handleOAuthAuthorizationServer(w http.ResponseWriter, r *http.Request) {
+	issuer := s.authServerIssuerURL(r)
+	if issuer == "" {
+		// Same fail-loud branch as the protected-resource doc:
+		// without an issuer the document would mislead clients
+		// about the canonical URL. 503 lets ops detect the
+		// misconfiguration faster than a 200 with stub URLs would.
+		writeError(w, http.StatusServiceUnavailable, "config_error",
+			"OAuth authorization server URL is not configured")
+		return
+	}
+
+	doc := authServerMetadata{
+		Issuer:                                     issuer,
+		AuthorizationEndpoint:                      issuer + "/oauth/authorize",
+		TokenEndpoint:                              issuer + "/oauth/token",
+		RegistrationEndpoint:                       issuer + "/oauth/register",
+		RevocationEndpoint:                         issuer + "/oauth/revoke",     // sub-PR D wires the handler
+		IntrospectionEndpoint:                      issuer + "/oauth/introspect", // sub-PR D wires the handler
+		ResponseTypesSupported:                     []string{"code"},
+		GrantTypesSupported:                        []string{"authorization_code", "refresh_token"},
+		CodeChallengeMethodsSupported:              []string{"S256"},
+		TokenEndpointAuthMethodsSupported:          []string{"none"},
+		RevocationEndpointAuthMethodsSupported:     []string{"none"},
+		IntrospectionEndpointAuthMethodsSupported:  []string{"none"},
+		ScopesSupported:                            []string{"pad:read", "pad:write", "pad:admin"},
+		ResourceIndicatorsSupported:                true,
+		AuthorizationResponseIssParameterSupported: true,
+	}
 	w.Header().Set("Content-Type", "application/json")
-	// Retry-After helps well-behaved clients back off rather than
-	// hammering us until TASK-951 lands. 3600 seconds is generous
-	// enough to absorb a deploy window without being annoyingly long.
-	w.Header().Set("Retry-After", "3600")
-	w.WriteHeader(http.StatusNotImplemented)
-	_ = json.NewEncoder(w).Encode(map[string]any{
-		"error":             "not_implemented",
-		"error_description": "OAuth authorization server is not yet enabled on this deployment. Tracked under PLAN-943 TASK-951.",
-	})
+	// Same 1-hour cache as the protected-resource doc.
+	w.Header().Set("Cache-Control", "public, max-age=3600")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(doc)
+}
+
+// authServerMetadata is the RFC 8414 wire shape. Only the fields
+// pad populates are declared. RFC 8414 §2 lists many more
+// (jwks_uri, ui_locales_supported, op_policy_uri, …) but they're
+// optional and not relevant to opaque-token deployments.
+type authServerMetadata struct {
+	Issuer                                     string   `json:"issuer"`
+	AuthorizationEndpoint                      string   `json:"authorization_endpoint"`
+	TokenEndpoint                              string   `json:"token_endpoint"`
+	RegistrationEndpoint                       string   `json:"registration_endpoint"`
+	RevocationEndpoint                         string   `json:"revocation_endpoint"`
+	IntrospectionEndpoint                      string   `json:"introspection_endpoint"`
+	ResponseTypesSupported                     []string `json:"response_types_supported"`
+	GrantTypesSupported                        []string `json:"grant_types_supported"`
+	CodeChallengeMethodsSupported              []string `json:"code_challenge_methods_supported"`
+	TokenEndpointAuthMethodsSupported          []string `json:"token_endpoint_auth_methods_supported"`
+	RevocationEndpointAuthMethodsSupported     []string `json:"revocation_endpoint_auth_methods_supported"`
+	IntrospectionEndpointAuthMethodsSupported  []string `json:"introspection_endpoint_auth_methods_supported"`
+	ScopesSupported                            []string `json:"scopes_supported"`
+	ResourceIndicatorsSupported                bool     `json:"resource_indicators_supported"`
+	AuthorizationResponseIssParameterSupported bool     `json:"authorization_response_iss_parameter_supported"`
 }
 
 // protectedResourceMetadata is the RFC 9728 wire format. Field names

--- a/internal/server/handlers_well_known.go
+++ b/internal/server/handlers_well_known.go
@@ -119,6 +119,24 @@ func (s *Server) handleOAuthProtectedResource(w http.ResponseWriter, r *http.Req
 // unauthenticated — RFC 8414 §3 explicitly says metadata MUST be
 // available without authentication.
 func (s *Server) handleOAuthAuthorizationServer(w http.ResponseWriter, r *http.Request) {
+	// Gate on oauthServer being mounted (Codex review #372 round 3):
+	// the discovery doc lives in the MCP route group, while the
+	// /oauth/* handlers live in the OAuth route group. Cloud
+	// deployments without PAD_MCP_PUBLIC_URL set get the discovery
+	// route mounted (registerMCPRoutes) but NOT the OAuth handlers
+	// (registerOAuthRoutes nil-checks oauthServer). Without this
+	// gate, the document would 200 with URLs that 404 — worse than
+	// no document.
+	//
+	// 503 with a clear error code lets ops detect the
+	// misconfiguration faster than a misleading 200 + clients can
+	// retry with backoff.
+	if s.oauthServer == nil {
+		writeError(w, http.StatusServiceUnavailable, "config_error",
+			"OAuth authorization server is not enabled on this deployment")
+		return
+	}
+
 	issuer := s.authServerIssuerURL(r)
 	if issuer == "" {
 		// Same fail-loud branch as the protected-resource doc:

--- a/internal/server/handlers_well_known.go
+++ b/internal/server/handlers_well_known.go
@@ -130,19 +130,23 @@ func (s *Server) handleOAuthAuthorizationServer(w http.ResponseWriter, r *http.R
 		return
 	}
 
+	// Sub-PR D (TASK-1026) wires /oauth/revoke + /oauth/introspect.
+	// Until then, OMIT those fields from the metadata rather than
+	// advertising URLs that 404 — RFC 8414 §2 lists them as OPTIONAL,
+	// and emitting them prematurely would mislead clients into
+	// calling endpoints that don't exist. Codex review #372 round 1
+	// caught the gap. Sub-PR D's PR description includes "populate
+	// revocation_endpoint + introspection_endpoint here" as a
+	// follow-up.
 	doc := authServerMetadata{
 		Issuer:                                     issuer,
 		AuthorizationEndpoint:                      issuer + "/oauth/authorize",
 		TokenEndpoint:                              issuer + "/oauth/token",
 		RegistrationEndpoint:                       issuer + "/oauth/register",
-		RevocationEndpoint:                         issuer + "/oauth/revoke",     // sub-PR D wires the handler
-		IntrospectionEndpoint:                      issuer + "/oauth/introspect", // sub-PR D wires the handler
 		ResponseTypesSupported:                     []string{"code"},
 		GrantTypesSupported:                        []string{"authorization_code", "refresh_token"},
 		CodeChallengeMethodsSupported:              []string{"S256"},
 		TokenEndpointAuthMethodsSupported:          []string{"none"},
-		RevocationEndpointAuthMethodsSupported:     []string{"none"},
-		IntrospectionEndpointAuthMethodsSupported:  []string{"none"},
 		ScopesSupported:                            []string{"pad:read", "pad:write", "pad:admin"},
 		ResourceIndicatorsSupported:                true,
 		AuthorizationResponseIssParameterSupported: true,
@@ -158,19 +162,20 @@ func (s *Server) handleOAuthAuthorizationServer(w http.ResponseWriter, r *http.R
 // pad populates are declared. RFC 8414 §2 lists many more
 // (jwks_uri, ui_locales_supported, op_policy_uri, …) but they're
 // optional and not relevant to opaque-token deployments.
+//
+// revocation_endpoint + introspection_endpoint will be added by
+// sub-PR D (TASK-1026) when the handlers ship. Until then they're
+// omitted entirely (RFC 8414 §2 marks them OPTIONAL) so clients
+// don't dial endpoints that 404.
 type authServerMetadata struct {
 	Issuer                                     string   `json:"issuer"`
 	AuthorizationEndpoint                      string   `json:"authorization_endpoint"`
 	TokenEndpoint                              string   `json:"token_endpoint"`
 	RegistrationEndpoint                       string   `json:"registration_endpoint"`
-	RevocationEndpoint                         string   `json:"revocation_endpoint"`
-	IntrospectionEndpoint                      string   `json:"introspection_endpoint"`
 	ResponseTypesSupported                     []string `json:"response_types_supported"`
 	GrantTypesSupported                        []string `json:"grant_types_supported"`
 	CodeChallengeMethodsSupported              []string `json:"code_challenge_methods_supported"`
 	TokenEndpointAuthMethodsSupported          []string `json:"token_endpoint_auth_methods_supported"`
-	RevocationEndpointAuthMethodsSupported     []string `json:"revocation_endpoint_auth_methods_supported"`
-	IntrospectionEndpointAuthMethodsSupported  []string `json:"introspection_endpoint_auth_methods_supported"`
 	ScopesSupported                            []string `json:"scopes_supported"`
 	ResourceIndicatorsSupported                bool     `json:"resource_indicators_supported"`
 	AuthorizationResponseIssParameterSupported bool     `json:"authorization_response_iss_parameter_supported"`

--- a/internal/server/middleware_ratelimit.go
+++ b/internal/server/middleware_ratelimit.go
@@ -246,14 +246,40 @@ func (s *Server) RateLimit(next http.Handler) http.Handler {
 		}
 
 		path := r.URL.Path
+		ip := clientIP(r)
 
-		// Only rate-limit API endpoints
-		if !strings.HasPrefix(path, "/api/") {
+		// OAuth 2.1 registration endpoint (PLAN-943 TASK-1025).
+		// /oauth/register is open by RFC 7591 design — Claude
+		// Desktop / Cursor self-register without prior auth — but
+		// without a limiter an attacker can flood the oauth_clients
+		// table. Reuse the Register limiter (5/min/IP), same shape
+		// as /api/v1/auth/register's protection. Codex review #372
+		// round 2.
+		//
+		// Other /oauth/* endpoints (authorize, token, decide) ride
+		// session cookies (authorize) or are PKCE-bound to a stored
+		// code (token), so flooding them just spends CPU. They go
+		// through fosite's own internal protections + the future
+		// TASK-959 /mcp limiter; explicit /oauth/* limits beyond
+		// /register can land alongside that work.
+		if path == "/oauth/register" {
+			l := s.rateLimiters.Register.getLimiter(ip)
+			if !l.Allow() {
+				slog.Warn("rate limited", "ip", ip, "path", path, "limiter", "oauth_register")
+				writeRateLimitResponse(w, s.rateLimiters.Register.config)
+				return
+			}
 			next.ServeHTTP(w, r)
 			return
 		}
 
-		ip := clientIP(r)
+		// Only rate-limit API endpoints below this point — the rest
+		// of the OAuth surface + the SPA static files don't ride
+		// the /api/* path.
+		if !strings.HasPrefix(path, "/api/") {
+			next.ServeHTTP(w, r)
+			return
+		}
 
 		// Auth-specific rate limits
 		if strings.HasPrefix(path, "/api/v1/auth/") {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -588,10 +588,18 @@ func (s *Server) setupRouter() {
 	// /login). RequireAuth is intentionally NOT used — /oauth/authorize
 	// must be reachable anonymously to trigger the login redirect.
 	//
+	// RateLimit gates /oauth/register specifically (per Codex review
+	// #372 round 2 — the DCR endpoint is open by RFC 7591 design,
+	// but unlimited writes to oauth_clients are an obvious DoS
+	// surface). The middleware short-circuits other /oauth/* paths
+	// because they're either session-bound or PKCE-bound; explicit
+	// per-endpoint limits arrive with TASK-959.
+	//
 	// No-op when SetOAuthServer hasn't been called or cloud mode is off.
 	r.Group(func(r chi.Router) {
 		r.Use(s.requireCloudMode)
 		r.Use(s.SessionAuth)
+		r.Use(s.RateLimit)
 		s.registerOAuthRoutes(r)
 	})
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -27,6 +27,7 @@ import (
 	"github.com/PerpetualSoftware/pad/internal/events"
 	"github.com/PerpetualSoftware/pad/internal/metrics"
 	"github.com/PerpetualSoftware/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/oauth"
 	"github.com/PerpetualSoftware/pad/internal/store"
 	"github.com/PerpetualSoftware/pad/internal/webhooks"
 )
@@ -81,6 +82,14 @@ type Server struct {
 	mcpTransport     http.Handler
 	mcpPublicURL     string // canonical public URL of the MCP vhost (e.g. https://mcp.getpad.dev)
 	mcpAuthServerURL string // canonical URL of the OAuth auth server (e.g. https://app.getpad.dev), TASK-951
+
+	// OAuth 2.1 authorization server (PLAN-943 TASK-1024 sub-PR B,
+	// HTTP handlers in TASK-1025 sub-PR C). Wired via SetOAuthServer
+	// at startup when the deployment is in cloud mode + has the
+	// fosite-backed server constructed. nil disables the OAuth
+	// surface — registerOAuthRoutes nil-checks so the routes don't
+	// mount on self-hosted deployments. See handlers_oauth.go.
+	oauthServer *oauth.Server
 
 	// storageInfoCache memoizes per-workspace storage usage summaries
 	// behind a short TTL (storageInfoTTL). Reduces DB load on the
@@ -563,6 +572,28 @@ func (s *Server) setupRouter() {
 	// No-op when SetMCPTransport hasn't been called or cloud mode is
 	// off — see registerMCPRoutes for the gating.
 	s.registerMCPRoutes(r)
+
+	// OAuth 2.1 authorization-server flow endpoints (PLAN-943
+	// TASK-1025 sub-PR C). /oauth/{register,authorize,token,
+	// authorize/decide} mounted alongside /mcp + /.well-known/*,
+	// outside /api/v1's auth-required group. CSRF middleware runs
+	// only on /api/* paths so /oauth/* is naturally exempt; the
+	// consent-decision endpoint adds its own form-token check
+	// using the existing __Host-pad_csrf cookie.
+	//
+	// SessionAuth runs in this group so /oauth/authorize can detect
+	// whether the user is logged in via the __Host-pad_session
+	// cookie. SessionAuth falls through gracefully when no cookie
+	// is present (handlers see currentUser(r)==nil and redirect to
+	// /login). RequireAuth is intentionally NOT used — /oauth/authorize
+	// must be reachable anonymously to trigger the login redirect.
+	//
+	// No-op when SetOAuthServer hasn't been called or cloud mode is off.
+	r.Group(func(r chi.Router) {
+		r.Use(s.requireCloudMode)
+		r.Use(s.SessionAuth)
+		s.registerOAuthRoutes(r)
+	})
 
 	// Prometheus scrape endpoint — exempt from the standard auth/CSRF stack
 	// (Prometheus can't present a session cookie or pass a CSRF header), but


### PR DESCRIPTION
## Summary

Third of 5 sub-PRs landing the OAuth 2.1 authorization server (PLAN-943). Mounts the **three flow-driving HTTP endpoints** over the fosite-backed server from sub-PR B, replaces the TASK-950 501 stub with the real RFC 8414 discovery doc, and ships an inline-HTML consent stub so the auth-code flow runs end-to-end.

**Endpoints added** (all cloud-mode-gated, mounted top-level alongside \`/mcp\`):

| Endpoint | Purpose |
|---|---|
| \`POST /oauth/register\` | RFC 7591 DCR. Hand-written. Public clients only. |
| \`GET /oauth/authorize\` | Starts auth-code flow. Renders consent stub or 302 → \`/login?redirect=<self>\` |
| \`POST /oauth/authorize/decide\` | Processes consent decision. Form-bound CSRF check. |
| \`POST /oauth/token\` | Code + refresh-token exchange. PKCE-S256 + RFC 8707 verified by fosite. |

Plus: \`/.well-known/oauth-authorization-server\` now serves real RFC 8414 metadata (replaces the 501 stub from TASK-950).

## Compliance posture

| Requirement | Where |
|---|---|
| **PKCE-S256 required** | sub-PR B's fosite Config (\`EnforcePKCE=true, EnablePKCEPlainChallengeMethod=false\`); test \`TestOAuth_Token_RejectsMissingPKCEVerifier\` |
| **RFC 8707 audience binding** | sub-PR B's audienceMatchingStrategy; test \`TestOAuth_Authorize_RejectsAudienceMismatch\` |
| **Public clients only** | DCR rejects \`token_endpoint_auth_method != none\`; client.Public=true everywhere |
| **OAuth 2.1 redirect-URI exact match** | fosite validates; DCR additionally validates URI shape (no fragment, https or loopback-http or custom-scheme, blocks \`javascript:\` etc.) |
| **Refresh-token rotation** | sub-PR B's \`RefreshTokenScopes=[]\` issues on every grant; sub-PR A's \`RotateRefreshToken\` revokes the entire grant family |
| **Single-use auth code** | sub-PR A's \`InvalidateAuthorizationCode\` + fosite's flow_authorize_code_token.go |

## Inline consent stub (TASK-952 placeholder)

Minimal HTML form with Approve/Deny buttons + a hidden CSRF token. Auto-grants every requested scope. Marked \`TODO(TASK-952)\` — TASK-952's real UI lands later with workspace allow-list selection (TASK-953).

CSRF posture: \`middleware_csrf.go\` runs only on \`/api/*\` paths so \`/oauth/*\` is naturally exempt. The consent-decision endpoint adds its own form-token check using the same \`__Host-pad_csrf\` cookie the SPA uses — token in a hidden form field rather than header. Same security model, different transport.

## Wiring in \`cmd/pad/main.go\`

\`oauthpkg.NewServer\` wired in cloud mode using \`cfg.EncryptionKey\` as HMAC secret + \`cfg.MCPPublicURL+/mcp\` as \`AllowedAudience\`. Conditional on \`PAD_MCP_PUBLIC_URL\` being set — the OAuth surface needs a canonical audience to bind tokens to. Without it, an explicit \`slog.Warn\` documents the skipped wiring.

## Tests (12, all passing)

- **Discovery doc**: \`TestOAuth_AuthorizationServerMetadata_PopulatedShape\` pins RFC 8414 fields including S256-only PKCE methods + \`resource_indicators_supported=true\`
- **DCR (6)**: happy path; missing redirect_uris; bad redirect-URI shapes (relative, non-loopback http, fragment, \`javascript:\`); non-public client auth method rejected; unknown grant type rejected; not mounted outside cloud mode
- **/authorize (3)**: redirects to /login when no session; renders consent stub when logged in; rejects audience mismatch (cross-server replay defense)
- **/authorize/decide (2)**: rejects missing csrf_token; deny produces \`access_denied\` redirect
- **Full PKCE flow (1)**: end-to-end \`/authorize/decide\` (approve) → \`/token\` with code_verifier → 200 with access+refresh tokens
- **/token (1)**: rejects missing PKCE verifier

Replaces \`TestMCP_AuthServerStub_Returns501\` from TASK-950 with \`TestMCP_AuthServerMetadata_Mounted\`.

## Out of scope (subsequent sub-PRs)

| Sub-PR | Task | Brings |
|---|---|---|
| D | TASK-1026 | \`/oauth/revoke\` + \`/oauth/introspect\` HTTP handlers |
| E | TASK-1027 | \`MCPBearerAuth\` OAuth introspection branch + \`/api/v1/oauth/clients/{id}/public-info\` |

## Test plan

- [x] \`go test ./...\` — all green locally (SQLite); Postgres via CI
- [x] \`make install\` — clean; server restarts without regression
- [ ] \`/codex review --loop\`