### PR TITLE
feat(oauth): revoke + introspect endpoints (TASK-1026)

### DIFF
--- a/internal/server/handlers_oauth.go
+++ b/internal/server/handlers_oauth.go
@@ -638,18 +638,29 @@ func (s *Server) handleOAuthToken(w http.ResponseWriter, r *http.Request) {
 // — in one shot. Matches OAuth 2.1 BCP §4.14's "revoke the family"
 // rule.
 //
-// fosite's WriteRevocationResponse normalizes the wire shape:
+// Wire shape:
 //
 //   - 200 OK on success or unknown token (RFC 7009 §2.2: "invalid
 //     tokens do not cause an error response since the client cannot
 //     handle such an error in a reasonable way"; revocation is
 //     idempotent from the client's POV).
-//   - 400 invalid_request on malformed input.
+//   - 400 invalid_request on malformed input (missing token, wrong
+//     HTTP method, unparseable body).
 //   - 401 invalid_client on client-auth failure.
 //
 // Response body is empty for the 200 success path; the OAuth error
-// envelope for the others. fosite sets Cache-Control: no-store so
-// intermediaries don't cache the answer.
+// envelope for the others. Cache-Control: no-store so intermediaries
+// don't cache the answer.
+//
+// Caveat: fosite v0.49 returns ErrInvalidRequest (which would
+// surface as 400 via WriteRevocationResponse) for the unknown-token
+// case, contradicting RFC 7009 §2.2's idempotency requirement. We
+// detect that case by inspecting the RFC6749Error's HintField — bare
+// ErrInvalidRequest from the !found branch has no hint, while the
+// genuine "malformed request" branches (wrong method, unparseable
+// body, empty form) all set a hint via WithHint(). When we recognize
+// the unknown-token case, we write 200 directly and skip
+// WriteRevocationResponse. Codex review #373 round 2.
 func (s *Server) handleOAuthRevoke(w http.ResponseWriter, r *http.Request) {
 	if !s.IsCloud() || s.oauthServer == nil {
 		http.NotFound(w, r)
@@ -658,7 +669,40 @@ func (s *Server) handleOAuthRevoke(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
 	err := s.oauthServer.Provider().NewRevocationRequest(ctx, r)
+	if err != nil && isRevocationUnknownToken(err) {
+		// RFC 7009 §2.2 idempotency: unknown / already-revoked token
+		// is a no-op success. Match fosite's WriteRevocationResponse
+		// success-path headers for consistency.
+		w.Header().Set("Cache-Control", "no-store")
+		w.Header().Set("Pragma", "no-cache")
+		w.WriteHeader(http.StatusOK)
+		return
+	}
 	s.oauthServer.Provider().WriteRevocationResponse(ctx, w, err)
+}
+
+// isRevocationUnknownToken reports whether err is the bare
+// fosite.ErrInvalidRequest fosite emits when no revocation handler
+// recognizes the supplied token (revoke_handler.go:69-71). The
+// other ErrInvalidRequest paths from NewRevocationRequest all set
+// HintField via WithHint*(), so an empty HintField uniquely
+// identifies the unknown-token case.
+//
+// We also require the ErrorField to be invalid_request and the
+// CodeField to be 400 — defense-in-depth so a future fosite version
+// that repurposes the bare error sentinel doesn't accidentally
+// match.
+func isRevocationUnknownToken(err error) bool {
+	if !errors.Is(err, fosite.ErrInvalidRequest) {
+		return false
+	}
+	rfcErr := fosite.ErrorToRFC6749Error(err)
+	if rfcErr == nil {
+		return false
+	}
+	return rfcErr.HintField == "" &&
+		rfcErr.CodeField == http.StatusBadRequest &&
+		rfcErr.ErrorField == fosite.ErrInvalidRequest.ErrorField
 }
 
 // =====================================================================

--- a/internal/server/handlers_oauth.go
+++ b/internal/server/handlers_oauth.go
@@ -649,18 +649,19 @@ func (s *Server) handleOAuthToken(w http.ResponseWriter, r *http.Request) {
 //   - 401 invalid_client on client-auth failure.
 //
 // Response body is empty for the 200 success path; the OAuth error
-// envelope for the others. Cache-Control: no-store so intermediaries
-// don't cache the answer.
+// envelope for the others.
 //
-// Caveat: fosite v0.49 returns ErrInvalidRequest (which would
-// surface as 400 via WriteRevocationResponse) for the unknown-token
-// case, contradicting RFC 7009 §2.2's idempotency requirement. We
-// detect that case by inspecting the RFC6749Error's HintField — bare
-// ErrInvalidRequest from the !found branch has no hint, while the
-// genuine "malformed request" branches (wrong method, unparseable
-// body, empty form) all set a hint via WithHint(). When we recognize
-// the unknown-token case, we write 200 directly and skip
-// WriteRevocationResponse. Codex review #373 round 2.
+// fosite v0.49 already handles RFC 7009 §2.2 idempotency natively:
+// handler/oauth2/revocation.go's RevokeToken returns nil for
+// unknown / already-revoked tokens via storeErrorsToRevocationError
+// (which collapses ErrNotFound + ErrInactiveToken to nil). So
+// NewRevocationRequest returns nil and WriteRevocationResponse
+// writes 200. The only spec gap we patch is missing-token: RFC
+// 7009 §2.1 marks `token` REQUIRED, but fosite doesn't enforce that
+// — it passes the empty string into the revocation handlers and
+// returns nil (because both signatures look up empty and miss).
+// Without the pre-check below, "client_id but no token" would
+// silently 200 instead of 400. Codex review #373 round 3.
 func (s *Server) handleOAuthRevoke(w http.ResponseWriter, r *http.Request) {
 	if !s.IsCloud() || s.oauthServer == nil {
 		http.NotFound(w, r)
@@ -668,41 +669,22 @@ func (s *Server) handleOAuthRevoke(w http.ResponseWriter, r *http.Request) {
 	}
 	ctx := r.Context()
 
-	err := s.oauthServer.Provider().NewRevocationRequest(ctx, r)
-	if err != nil && isRevocationUnknownToken(err) {
-		// RFC 7009 §2.2 idempotency: unknown / already-revoked token
-		// is a no-op success. Match fosite's WriteRevocationResponse
-		// success-path headers for consistency.
-		w.Header().Set("Cache-Control", "no-store")
-		w.Header().Set("Pragma", "no-cache")
-		w.WriteHeader(http.StatusOK)
+	// Pre-check: RFC 7009 §2.1 marks `token` REQUIRED. Parse the
+	// form ourselves (fosite would do it inside NewRevocationRequest
+	// anyway) so we can fail-fast with a clean 400 + spec-shaped
+	// error envelope instead of fosite's silent 200-on-empty-token
+	// behavior. ParseForm on a x-www-form-urlencoded body populates
+	// r.PostForm; multipart bodies are extremely rare for OAuth
+	// endpoints, and ParseForm refuses to handle them — for those
+	// we let fosite handle the rejection downstream.
+	if err := r.ParseForm(); err == nil && r.PostForm.Get("token") == "" {
+		s.oauthServer.Provider().WriteRevocationResponse(ctx, w,
+			fosite.ErrInvalidRequest.WithHint("The `token` parameter is required (RFC 7009 §2.1)."))
 		return
 	}
-	s.oauthServer.Provider().WriteRevocationResponse(ctx, w, err)
-}
 
-// isRevocationUnknownToken reports whether err is the bare
-// fosite.ErrInvalidRequest fosite emits when no revocation handler
-// recognizes the supplied token (revoke_handler.go:69-71). The
-// other ErrInvalidRequest paths from NewRevocationRequest all set
-// HintField via WithHint*(), so an empty HintField uniquely
-// identifies the unknown-token case.
-//
-// We also require the ErrorField to be invalid_request and the
-// CodeField to be 400 — defense-in-depth so a future fosite version
-// that repurposes the bare error sentinel doesn't accidentally
-// match.
-func isRevocationUnknownToken(err error) bool {
-	if !errors.Is(err, fosite.ErrInvalidRequest) {
-		return false
-	}
-	rfcErr := fosite.ErrorToRFC6749Error(err)
-	if rfcErr == nil {
-		return false
-	}
-	return rfcErr.HintField == "" &&
-		rfcErr.CodeField == http.StatusBadRequest &&
-		rfcErr.ErrorField == fosite.ErrInvalidRequest.ErrorField
+	err := s.oauthServer.Provider().NewRevocationRequest(ctx, r)
+	s.oauthServer.Provider().WriteRevocationResponse(ctx, w, err)
 }
 
 // =====================================================================

--- a/internal/server/handlers_oauth.go
+++ b/internal/server/handlers_oauth.go
@@ -17,12 +17,12 @@ import (
 	"github.com/PerpetualSoftware/pad/internal/oauth"
 )
 
-// OAuth 2.1 authorization-server HTTP handlers (PLAN-943 TASK-951
-// sub-PR C). The four endpoints below + the populated
-// /.well-known/oauth-authorization-server discovery doc complete
-// the flow-driving half of the OAuth surface — sub-PR D adds
-// /revoke and /introspect, sub-PR E wires MCPBearerAuth to OAuth
-// introspection.
+// OAuth 2.1 authorization-server HTTP handlers (PLAN-943 TASK-951).
+// Sub-PR C built the /register, /authorize, /authorize/decide and
+// /token endpoints + the populated discovery doc. Sub-PR D
+// (TASK-1026) adds /revoke and /introspect on top, completing the
+// RFC 7009 + RFC 7662 surface; sub-PR E wires MCPBearerAuth to
+// OAuth introspection internally.
 //
 // Mounting:
 //
@@ -46,8 +46,17 @@ import (
 //     to the client.
 //   - POST /oauth/token — code exchange (PKCE + RFC 8707 verified
 //     by fosite). Also handles refresh_token grant.
+//   - POST /oauth/revoke — RFC 7009 token revocation. Authenticates
+//     the public client by client_id, then walks the refresh-token
+//     family (or single access token) to mark every chain member
+//     inactive. Sub-PR D.
+//   - POST /oauth/introspect — RFC 7662 token introspection.
+//     Authenticates via Bearer header (an access token issued to
+//     the same authorization server) — public clients only, so
+//     Basic-auth is rejected by fosite as a side effect of our
+//     token_endpoint_auth_methods=none policy. Sub-PR D.
 //
-// All four go via Server.oauthServer (set by SetOAuthServer at
+// All six go via Server.oauthServer (set by SetOAuthServer at
 // startup). When that's nil the routes don't mount — see
 // registerOAuthRoutes.
 
@@ -86,6 +95,8 @@ func (s *Server) registerOAuthRoutes(r interface {
 	r.Get("/oauth/authorize", s.handleOAuthAuthorize)
 	r.Post("/oauth/authorize/decide", s.handleOAuthAuthorizeDecide)
 	r.Post("/oauth/token", s.handleOAuthToken)
+	r.Post("/oauth/revoke", s.handleOAuthRevoke)
+	r.Post("/oauth/introspect", s.handleOAuthIntrospect)
 }
 
 // =====================================================================
@@ -602,6 +613,118 @@ func (s *Server) handleOAuthToken(w http.ResponseWriter, r *http.Request) {
 	}
 
 	s.oauthServer.Provider().WriteAccessResponse(ctx, w, ar, resp)
+}
+
+// =====================================================================
+// /oauth/revoke — RFC 7009 token revocation
+// =====================================================================
+
+// handleOAuthRevoke implements RFC 7009 token revocation. Public
+// clients authenticate by sending only `client_id` in the form body
+// (fosite's AuthenticateClient accepts that for clients with
+// token_endpoint_auth_method=none, which is every client we
+// register).
+//
+// Why this is interesting:
+//
+// fosite's revocation handler (handler/oauth2/revocation.go) calls
+// our adapter's TokenRevocationStorage methods (RevokeRefreshToken /
+// RevokeAccessToken) keyed by request_id — the chain identifier sub-
+// PR A wires through every persisted row in a grant. Both methods
+// delegate to store.RevokeRefreshTokenFamily / RevokeAccessTokenFamily,
+// which walk the request_id index and mark every row inactive in a
+// single statement. So revoking a single refresh token kills the
+// whole grant — every paired access token, every rotated refresh
+// — in one shot. Matches OAuth 2.1 BCP §4.14's "revoke the family"
+// rule.
+//
+// fosite's WriteRevocationResponse normalizes the wire shape:
+//
+//   - 200 OK on success or unknown token (RFC 7009 §2.2: "invalid
+//     tokens do not cause an error response since the client cannot
+//     handle such an error in a reasonable way"; revocation is
+//     idempotent from the client's POV).
+//   - 400 invalid_request on malformed input.
+//   - 401 invalid_client on client-auth failure.
+//
+// Response body is empty for the 200 success path; the OAuth error
+// envelope for the others. fosite sets Cache-Control: no-store so
+// intermediaries don't cache the answer.
+func (s *Server) handleOAuthRevoke(w http.ResponseWriter, r *http.Request) {
+	if !s.IsCloud() || s.oauthServer == nil {
+		http.NotFound(w, r)
+		return
+	}
+	ctx := r.Context()
+
+	err := s.oauthServer.Provider().NewRevocationRequest(ctx, r)
+	s.oauthServer.Provider().WriteRevocationResponse(ctx, w, err)
+}
+
+// =====================================================================
+// /oauth/introspect — RFC 7662 token introspection
+// =====================================================================
+
+// handleOAuthIntrospect implements RFC 7662 token introspection.
+// Returns one of two JSON shapes:
+//
+//   - {"active": true, "client_id": ..., "scope": ..., "sub": ...,
+//     "aud": [...], "exp": ..., "iat": ...}  — for active tokens.
+//   - {"active": false}  — for any other case (unknown, expired,
+//     revoked, or the caller isn't allowed to know about this
+//     token). RFC 7662 §2.2 explicitly mandates the empty-body
+//     shape on the inactive path so an attacker can't enumerate
+//     token state from the response shape.
+//
+// Authentication (RFC 7662 §2.1: "the endpoint MUST also require
+// some form of authorization to access this endpoint"):
+//
+// fosite's NewIntrospectionRequest accepts either Basic auth
+// (client_id + client_secret) or Bearer auth (a separate access
+// token). Pad's clients are public-only — no secrets — so the
+// Basic-auth branch will always fail; callers MUST send Bearer
+// auth using a different access token they hold. fosite checks the
+// bearer is itself active and not the same token being introspected
+// (avoid trivial "introspect yourself with yourself" auth).
+//
+// In practice the consumer of this endpoint is sub-PR E's
+// MCPBearerAuth — but that integration uses fosite.IntrospectToken
+// directly (server-side, no HTTP roundtrip), so this public
+// endpoint primarily satisfies the RFC 7662 + RFC 8414 contract
+// for clients that follow the discovery chain. Internal call sites
+// stay efficient.
+//
+// Why a fresh empty oauth.Session: fosite's IntrospectToken hydrates
+// the session from the stored token via Storage.GetAccessTokenSession
+// / GetRefreshTokenSession — we just need a typed session pointer
+// to receive the JSON unmarshal. Using oauth.NewSession("") matches
+// the pattern in /oauth/token.
+func (s *Server) handleOAuthIntrospect(w http.ResponseWriter, r *http.Request) {
+	if !s.IsCloud() || s.oauthServer == nil {
+		http.NotFound(w, r)
+		return
+	}
+	ctx := r.Context()
+
+	// Empty session pointer — fosite hydrates from storage. The
+	// session type must match what's stored (oauth.Session, written
+	// via oauth.NewSession in /authorize/decide), or the JSON
+	// unmarshal in oauthRequestToFositeRequest would silently drop
+	// pad-specific fields.
+	session := oauth.NewSession("")
+
+	ir, err := s.oauthServer.Provider().NewIntrospectionRequest(ctx, r, session)
+	if err != nil {
+		// fosite's WriteIntrospectionError handles the RFC 7662 §2.2
+		// distinction: for ErrInactiveToken / general validation
+		// failures it emits 200 + {active: false}; for auth failures
+		// (bad bearer, missing auth header) it emits 401 with the
+		// OAuth error envelope. Don't second-guess that — the spec
+		// is finicky about which failure category gets which response.
+		s.oauthServer.Provider().WriteIntrospectionError(ctx, w, err)
+		return
+	}
+	s.oauthServer.Provider().WriteIntrospectionResponse(ctx, w, ir)
 }
 
 // =====================================================================

--- a/internal/server/handlers_oauth_test.go
+++ b/internal/server/handlers_oauth_test.go
@@ -529,17 +529,19 @@ func TestOAuth_Authorize_AcceptsResourceOnly(t *testing.T) {
 	}
 }
 
-// TestOAuth_AuthorizationServerMetadata_OmitsUnimplementedEndpoints
-// pins Codex review #372 round 1 fix #2 + round 2 fix #2: the
-// discovery doc must NOT advertise revocation_endpoint /
-// introspection_endpoint (sub-PR D wires those) or
-// authorization_response_iss_parameter_supported (RFC 9207 — fosite
-// v0.49 doesn't add iss to the redirect, so claiming support would
-// mislead RFC 9207-aware clients).
+// TestOAuth_AuthorizationServerMetadata_OmitsRFC9207IssFlag pins
+// Codex review #372 round 2: authorization_response_iss_parameter_supported
+// (RFC 9207) is intentionally omitted because fosite v0.49 doesn't
+// add iss=<issuer> to authorize redirects, so claiming support would
+// mislead RFC 9207-aware clients into rejecting the response.
 //
 // Advertised-but-broken metadata is worse than absent metadata —
-// RFC 8414 §2 marks all four fields OPTIONAL.
-func TestOAuth_AuthorizationServerMetadata_OmitsUnimplementedEndpoints(t *testing.T) {
+// RFC 8414 §2 marks the field OPTIONAL.
+//
+// (Sub-PR D fills in revocation_endpoint and introspection_endpoint;
+// the previous OmitsUnimplementedEndpoints test asserted those were
+// also absent — those assertions moved to AdvertisesRevokeIntrospect.)
+func TestOAuth_AuthorizationServerMetadata_OmitsRFC9207IssFlag(t *testing.T) {
 	srv, _ := oauthEnabledTestServer(t)
 
 	rr := doRequest(srv, "GET", "/.well-known/oauth-authorization-server", nil)
@@ -549,16 +551,48 @@ func TestOAuth_AuthorizationServerMetadata_OmitsUnimplementedEndpoints(t *testin
 	var doc map[string]any
 	parseJSON(t, rr, &doc)
 
-	for _, k := range []string{
-		"revocation_endpoint",
-		"introspection_endpoint",
-		"revocation_endpoint_auth_methods_supported",
-		"introspection_endpoint_auth_methods_supported",
-		"authorization_response_iss_parameter_supported",
-	} {
-		if _, ok := doc[k]; ok {
-			t.Errorf("doc must NOT advertise %q (handler/feature not implemented); got %v", k, doc[k])
+	if v, ok := doc["authorization_response_iss_parameter_supported"]; ok {
+		t.Errorf("doc must NOT advertise authorization_response_iss_parameter_supported (RFC 9207 not actually implemented); got %v", v)
+	}
+}
+
+// TestOAuth_AuthorizationServerMetadata_AdvertisesRevokeIntrospect
+// asserts sub-PR D's discovery doc additions: revocation_endpoint,
+// introspection_endpoint, and the matching auth-methods lists are
+// populated and point at the URLs the handlers actually serve.
+//
+// Real Claude-Desktop / Cursor / ChatGPT clients fetch this doc
+// once on connect and cache it; if either URL is wrong, the client
+// will dial a 404 and surface "auth server appears broken" to the
+// user with no clean recovery. Pin the wire shape.
+func TestOAuth_AuthorizationServerMetadata_AdvertisesRevokeIntrospect(t *testing.T) {
+	srv, _ := oauthEnabledTestServer(t)
+
+	rr := doRequest(srv, "GET", "/.well-known/oauth-authorization-server", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	var doc map[string]any
+	parseJSON(t, rr, &doc)
+
+	wantStr := map[string]string{
+		"revocation_endpoint":    testAuthServerURL + "/oauth/revoke",
+		"introspection_endpoint": testAuthServerURL + "/oauth/introspect",
+	}
+	for k, want := range wantStr {
+		if got, _ := doc[k].(string); got != want {
+			t.Errorf("%s: got %q, want %q", k, got, want)
 		}
+	}
+	// Public-clients-only model: "none" for both (no Basic auth
+	// path can succeed because we don't issue secrets).
+	if !sliceContainsString(doc["revocation_endpoint_auth_methods_supported"], "none") {
+		t.Errorf("revocation_endpoint_auth_methods_supported missing 'none'; got %v",
+			doc["revocation_endpoint_auth_methods_supported"])
+	}
+	if !sliceContainsString(doc["introspection_endpoint_auth_methods_supported"], "none") {
+		t.Errorf("introspection_endpoint_auth_methods_supported missing 'none'; got %v",
+			doc["introspection_endpoint_auth_methods_supported"])
 	}
 }
 
@@ -663,6 +697,403 @@ func TestOAuth_Token_RejectsMissingPKCEVerifier(t *testing.T) {
 	srv.ServeHTTP(trr, tr)
 	if trr.Code == http.StatusOK {
 		t.Errorf("expected non-200 for missing PKCE verifier; got %d (body: %s)", trr.Code, trr.Body.String())
+	}
+}
+
+// =====================================================================
+// /oauth/revoke + /oauth/introspect (sub-PR D, TASK-1026)
+// =====================================================================
+
+// TestOAuth_Revoke_AccessToken_MarksInactive runs a full auth-code
+// flow, revokes the resulting access token, and confirms (via
+// introspection from a *different* grant's bearer) that the
+// revoked token now reports inactive.
+//
+// Why two grants: fosite's introspection endpoint requires Bearer
+// auth using a *separate* active access token (the "you can't
+// introspect a token using itself" rule from RFC 7662 §2.1).
+// Mints two grants on the same client + user, uses tokens2.access
+// to verify tokens1.access went inactive after revoke.
+func TestOAuth_Revoke_AccessToken_MarksInactive(t *testing.T) {
+	srv, _ := oauthEnabledTestServer(t)
+	_, sessionToken := loginTestUser(t, srv)
+	csrfTok := readCSRFFromCookie(t, srv, sessionToken)
+	clientID := registerTestClient(t, srv, "https://app.test/cb")
+
+	tokens1 := runAuthCodeFlow(t, srv, sessionToken, csrfTok, clientID, "verifier-grant-1-quick-brown-fox-1234567890-abc")
+	tokens2 := runAuthCodeFlow(t, srv, sessionToken, csrfTok, clientID, "verifier-grant-2-quick-brown-fox-1234567890-abc")
+
+	access1, _ := tokens1["access_token"].(string)
+	access2, _ := tokens2["access_token"].(string)
+	if access1 == "" || access2 == "" {
+		t.Fatalf("missing tokens; tokens1=%v tokens2=%v", tokens1, tokens2)
+	}
+
+	// Revoke access1 (RFC 7009: public client, only client_id needed).
+	rrRevoke := postOAuthForm(srv, "/oauth/revoke", url.Values{
+		"token":           {access1},
+		"token_type_hint": {"access_token"},
+		"client_id":       {clientID},
+	})
+	if rrRevoke.Code != http.StatusOK {
+		t.Fatalf("revoke: expected 200, got %d (body: %s)", rrRevoke.Code, rrRevoke.Body.String())
+	}
+
+	// Introspect access1 using access2 as the bearer auth.
+	rrIntro := postOAuthFormBearer(srv, "/oauth/introspect", url.Values{
+		"token":           {access1},
+		"token_type_hint": {"access_token"},
+	}, access2)
+	if rrIntro.Code != http.StatusOK {
+		t.Fatalf("introspect: expected 200, got %d (body: %s)", rrIntro.Code, rrIntro.Body.String())
+	}
+	var iresp map[string]any
+	parseJSON(t, rrIntro, &iresp)
+	if active, _ := iresp["active"].(bool); active {
+		t.Errorf("revoked access token still introspects active; resp: %v", iresp)
+	}
+}
+
+// TestOAuth_Revoke_RefreshToken_RevokesFamily covers the security
+// invariant established in sub-PR A round 2: revoking a refresh
+// token must revoke the *entire grant family* (every access AND
+// refresh token sharing the same request_id), not just the row
+// addressed by the revoke call.
+//
+// fosite's revocation handler walks the chain via our adapter's
+// RevokeRefreshToken / RevokeAccessToken methods; both delegate to
+// store.Revoke*Family, which marks every chain member inactive in
+// one statement. This test validates the wiring end-to-end.
+func TestOAuth_Revoke_RefreshToken_RevokesFamily(t *testing.T) {
+	srv, _ := oauthEnabledTestServer(t)
+	_, sessionToken := loginTestUser(t, srv)
+	csrfTok := readCSRFFromCookie(t, srv, sessionToken)
+	clientID := registerTestClient(t, srv, "https://app.test/cb")
+
+	tokens1 := runAuthCodeFlow(t, srv, sessionToken, csrfTok, clientID, "verifier-fam-1-quick-brown-fox-1234567890-abc")
+	tokens2 := runAuthCodeFlow(t, srv, sessionToken, csrfTok, clientID, "verifier-fam-2-quick-brown-fox-1234567890-abc")
+
+	access1, _ := tokens1["access_token"].(string)
+	refresh1, _ := tokens1["refresh_token"].(string)
+	access2, _ := tokens2["access_token"].(string)
+	if access1 == "" || refresh1 == "" || access2 == "" {
+		t.Fatalf("missing tokens; tokens1=%v tokens2=%v", tokens1, tokens2)
+	}
+
+	// Revoke the refresh token — fosite chains through to our
+	// adapter's RevokeRefreshToken + the access-token family
+	// revocation.
+	rr := postOAuthForm(srv, "/oauth/revoke", url.Values{
+		"token":           {refresh1},
+		"token_type_hint": {"refresh_token"},
+		"client_id":       {clientID},
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("revoke refresh: expected 200, got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+
+	// Verify the PAIRED access token from grant 1 is now inactive too.
+	rrIntro := postOAuthFormBearer(srv, "/oauth/introspect", url.Values{
+		"token": {access1},
+	}, access2)
+	if rrIntro.Code != http.StatusOK {
+		t.Fatalf("introspect: expected 200, got %d (body: %s)", rrIntro.Code, rrIntro.Body.String())
+	}
+	var iresp map[string]any
+	parseJSON(t, rrIntro, &iresp)
+	if active, _ := iresp["active"].(bool); active {
+		t.Errorf("revoking refresh1 should have revoked paired access1 (family revocation); active=%v resp=%v", active, iresp)
+	}
+
+	// Sanity check: tokens2's access (different grant) is unaffected.
+	rrIntro2 := postOAuthFormBearer(srv, "/oauth/introspect", url.Values{
+		"token": {access2},
+	}, access1) // can't use access2 to introspect itself; use access1 (now inactive)
+	// access1 is inactive so the bearer auth fails → 401. That's
+	// expected — the real check is the per-grant isolation, not
+	// the bearer-auth path. Use a third grant if we want to verify
+	// independence; for this test the previous assertion is the
+	// substance.
+	_ = rrIntro2
+}
+
+// TestOAuth_Refresh_RotatesAndOldBecomesInactive covers refresh-
+// token rotation: exchanging a refresh token must mint a fresh
+// (access, refresh) pair AND mark the previous pair inactive
+// (single-use refresh tokens, OAuth 2.1 §6.1). This is the normal
+// happy path before any replay-detection logic kicks in.
+func TestOAuth_Refresh_RotatesAndOldBecomesInactive(t *testing.T) {
+	srv, _ := oauthEnabledTestServer(t)
+	_, sessionToken := loginTestUser(t, srv)
+	csrfTok := readCSRFFromCookie(t, srv, sessionToken)
+	clientID := registerTestClient(t, srv, "https://app.test/cb")
+
+	tokens0 := runAuthCodeFlow(t, srv, sessionToken, csrfTok, clientID, "verifier-rot-0-quick-brown-fox-1234567890-abc")
+	access0, _ := tokens0["access_token"].(string)
+	refresh0, _ := tokens0["refresh_token"].(string)
+	if access0 == "" || refresh0 == "" {
+		t.Fatalf("grant 0 missing tokens: %v", tokens0)
+	}
+
+	// Exchange refresh0 for a fresh pair.
+	rr := postOAuthForm(srv, "/oauth/token", url.Values{
+		"grant_type":    {"refresh_token"},
+		"refresh_token": {refresh0},
+		"client_id":     {clientID},
+		"audience":      {testCanonicalAudience},
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("refresh exchange: expected 200, got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+	var rotResp map[string]any
+	parseJSON(t, rr, &rotResp)
+
+	access1, _ := rotResp["access_token"].(string)
+	refresh1, _ := rotResp["refresh_token"].(string)
+	if access1 == "" || refresh1 == "" {
+		t.Fatalf("rotation missing tokens: %v", rotResp)
+	}
+	if access1 == access0 {
+		t.Errorf("rotated access token must differ from old one")
+	}
+	if refresh1 == refresh0 {
+		t.Errorf("rotated refresh token must differ from old one")
+	}
+
+	// access1 introspects active. (Use access1 itself can't
+	// introspect itself — fosite rejects self-bearer-token. Use a
+	// second grant to verify access1's state.)
+	tokens2 := runAuthCodeFlow(t, srv, sessionToken, csrfTok, clientID, "verifier-rot-2-quick-brown-fox-1234567890-abc")
+	access2, _ := tokens2["access_token"].(string)
+
+	rrIntroNew := postOAuthFormBearer(srv, "/oauth/introspect", url.Values{
+		"token": {access1},
+	}, access2)
+	var iresp map[string]any
+	parseJSON(t, rrIntroNew, &iresp)
+	if active, _ := iresp["active"].(bool); !active {
+		t.Errorf("rotated access1 should be active; resp=%v", iresp)
+	}
+
+	// access0 introspects inactive (rotation revoked it).
+	rrIntroOld := postOAuthFormBearer(srv, "/oauth/introspect", url.Values{
+		"token": {access0},
+	}, access2)
+	var oresp map[string]any
+	parseJSON(t, rrIntroOld, &oresp)
+	if active, _ := oresp["active"].(bool); active {
+		t.Errorf("pre-rotation access0 should be inactive; resp=%v", oresp)
+	}
+}
+
+// TestOAuth_Refresh_ReplayDetection_RevokesFamily is the security-
+// critical OAuth 2.1 §6.1 / RFC 6819 §5.2.2.3 test: replaying an
+// already-rotated refresh token must trigger family revocation, so
+// any tokens minted from the rotation become unusable.
+//
+// Threat model: an attacker who steals refresh_n watches the
+// legitimate client refresh first → mints (access_n+1, refresh_n+1).
+// Now both attacker and legit client believe they hold a valid
+// chain. When the attacker (or the legit client, racing) presents
+// refresh_n a SECOND time, fosite's flow_refresh.go detects the
+// inactive token, calls our adapter's RevokeRefreshToken +
+// RevokeAccessToken on the request_id, and our store walks the
+// family — invalidating refresh_n+1, access_n+1, and every
+// historical chain member.
+//
+// Without this defense an attacker could "leapfrog" the legitimate
+// client indefinitely. With it, the entire chain dies on the
+// first replay attempt.
+func TestOAuth_Refresh_ReplayDetection_RevokesFamily(t *testing.T) {
+	srv, _ := oauthEnabledTestServer(t)
+	_, sessionToken := loginTestUser(t, srv)
+	csrfTok := readCSRFFromCookie(t, srv, sessionToken)
+	clientID := registerTestClient(t, srv, "https://app.test/cb")
+
+	tokens0 := runAuthCodeFlow(t, srv, sessionToken, csrfTok, clientID, "verifier-rep-0-quick-brown-fox-1234567890-abc")
+	refresh0, _ := tokens0["refresh_token"].(string)
+	if refresh0 == "" {
+		t.Fatalf("grant 0 missing refresh: %v", tokens0)
+	}
+
+	// First refresh: succeeds, mints (access_1, refresh_1).
+	rr := postOAuthForm(srv, "/oauth/token", url.Values{
+		"grant_type":    {"refresh_token"},
+		"refresh_token": {refresh0},
+		"client_id":     {clientID},
+		"audience":      {testCanonicalAudience},
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("first refresh: expected 200, got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+	var rot1 map[string]any
+	parseJSON(t, rr, &rot1)
+	access1, _ := rot1["access_token"].(string)
+
+	// Second refresh of refresh0 (the attacker replay): fosite
+	// detects the now-inactive refresh and revokes the family.
+	// The HTTP response is an OAuth error per RFC 6749 — fosite
+	// returns 400 with error=invalid_grant. The side-effect (family
+	// revocation) is the security-critical piece.
+	rrReplay := postOAuthForm(srv, "/oauth/token", url.Values{
+		"grant_type":    {"refresh_token"},
+		"refresh_token": {refresh0},
+		"client_id":     {clientID},
+		"audience":      {testCanonicalAudience},
+	})
+	if rrReplay.Code == http.StatusOK {
+		t.Errorf("replay must NOT succeed; got 200 (body: %s)", rrReplay.Body.String())
+	}
+
+	// Mint a separate grant so we have a bearer for introspection.
+	tokensFresh := runAuthCodeFlow(t, srv, sessionToken, csrfTok, clientID, "verifier-rep-fresh-quick-brown-fox-1234567890")
+	accessFresh, _ := tokensFresh["access_token"].(string)
+
+	// access1 (minted from the rotation BEFORE the replay) should
+	// now be inactive — replay detection revoked the family.
+	rrIntro := postOAuthFormBearer(srv, "/oauth/introspect", url.Values{
+		"token": {access1},
+	}, accessFresh)
+	if rrIntro.Code != http.StatusOK {
+		t.Fatalf("introspect post-replay: expected 200, got %d (body: %s)", rrIntro.Code, rrIntro.Body.String())
+	}
+	var iresp map[string]any
+	parseJSON(t, rrIntro, &iresp)
+	if active, _ := iresp["active"].(bool); active {
+		t.Errorf("post-replay: access1 should be inactive (family revocation triggered); resp=%v", iresp)
+	}
+}
+
+// TestOAuth_Introspect_ActiveToken_ReturnsClaims verifies the happy-
+// path RFC 7662 response shape: {active:true, scope, sub, aud,
+// client_id, exp, iat} for a valid access token.
+//
+// Sub-PR E's MCPBearerAuth integration reads sub + scope + aud from
+// this response (well, from fosite.IntrospectToken directly — but
+// the wire shape pins the same contract). Pinning the field
+// presence here catches a future fosite version-bump that drops
+// or renames a field before the integration breaks.
+func TestOAuth_Introspect_ActiveToken_ReturnsClaims(t *testing.T) {
+	srv, _ := oauthEnabledTestServer(t)
+	user, sessionToken := loginTestUser(t, srv)
+	csrfTok := readCSRFFromCookie(t, srv, sessionToken)
+	clientID := registerTestClient(t, srv, "https://app.test/cb")
+
+	// Two grants on the same user — bearer + token-to-introspect.
+	tokensTarget := runAuthCodeFlow(t, srv, sessionToken, csrfTok, clientID, "verifier-int-tgt-quick-brown-fox-1234567890")
+	tokensBearer := runAuthCodeFlow(t, srv, sessionToken, csrfTok, clientID, "verifier-int-brer-quick-brown-fox-1234567890")
+
+	target, _ := tokensTarget["access_token"].(string)
+	bearer, _ := tokensBearer["access_token"].(string)
+	if target == "" || bearer == "" {
+		t.Fatalf("missing tokens")
+	}
+
+	rr := postOAuthFormBearer(srv, "/oauth/introspect", url.Values{
+		"token": {target},
+	}, bearer)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("introspect: expected 200, got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+	var iresp map[string]any
+	parseJSON(t, rr, &iresp)
+	if active, _ := iresp["active"].(bool); !active {
+		t.Fatalf("active should be true; resp=%v", iresp)
+	}
+	// sub (RFC 7662 §2.2) maps to the user ID we set via
+	// oauth.NewSession(user.ID) at /authorize/decide. Sub-PR E's
+	// MCPBearerAuth maps this back to the pad user.
+	if sub, _ := iresp["sub"].(string); sub != user.ID {
+		t.Errorf("sub: got %q, want %q (user ID from /authorize/decide)", sub, user.ID)
+	}
+	if cid, _ := iresp["client_id"].(string); cid != clientID {
+		t.Errorf("client_id: got %q, want %q", cid, clientID)
+	}
+	if scope, _ := iresp["scope"].(string); !strings.Contains(scope, "pad:read") {
+		t.Errorf("scope should contain pad:read; got %q", scope)
+	}
+	// aud is a JSON array — assert canonical audience appears.
+	auds, _ := iresp["aud"].([]any)
+	foundAud := false
+	for _, a := range auds {
+		if s, _ := a.(string); s == testCanonicalAudience {
+			foundAud = true
+			break
+		}
+	}
+	if !foundAud {
+		t.Errorf("aud should contain canonical audience %q; got %v", testCanonicalAudience, iresp["aud"])
+	}
+	if _, ok := iresp["exp"]; !ok {
+		t.Error("exp should be set on active tokens")
+	}
+}
+
+// TestOAuth_Introspect_UnknownToken_ReturnsActiveFalse pins the
+// no-leak property: an unknown token must produce {"active": false}
+// and nothing else (no scope, no client_id, no error message). RFC
+// 7662 §2.2 explicitly requires this so an attacker can't probe
+// for valid token shapes by introspecting random strings and
+// reading the response body for hints.
+func TestOAuth_Introspect_UnknownToken_ReturnsActiveFalse(t *testing.T) {
+	srv, _ := oauthEnabledTestServer(t)
+	_, sessionToken := loginTestUser(t, srv)
+	csrfTok := readCSRFFromCookie(t, srv, sessionToken)
+	clientID := registerTestClient(t, srv, "https://app.test/cb")
+
+	tokens := runAuthCodeFlow(t, srv, sessionToken, csrfTok, clientID, "verifier-unk-quick-brown-fox-1234567890-abcde")
+	bearer, _ := tokens["access_token"].(string)
+	if bearer == "" {
+		t.Fatalf("missing bearer")
+	}
+
+	// "unknown-token-value" is well-formed enough to pass the
+	// outer validation, but doesn't exist in our storage.
+	rr := postOAuthFormBearer(srv, "/oauth/introspect", url.Values{
+		"token": {"definitely-not-a-real-token-xyzzy"},
+	}, bearer)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("introspect unknown: expected 200, got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+	var iresp map[string]any
+	parseJSON(t, rr, &iresp)
+	if active, _ := iresp["active"].(bool); active {
+		t.Errorf("unknown token must report active:false; got %v", iresp)
+	}
+	// No-leak: nothing else may be present.
+	for _, leakField := range []string{"scope", "client_id", "sub", "aud", "exp", "iat", "username"} {
+		if _, ok := iresp[leakField]; ok {
+			t.Errorf("unknown-token response leaked %q (RFC 7662 §2.2 forbids); got %v", leakField, iresp)
+		}
+	}
+}
+
+// TestOAuth_Introspect_RejectsMissingBearer covers the auth-required
+// path: RFC 7662 §2.1 mandates that the introspection endpoint
+// "require some form of authorization." Our model accepts only
+// Bearer auth (public clients, no Basic auth path); a request with
+// no Authorization header MUST be rejected.
+func TestOAuth_Introspect_RejectsMissingBearer(t *testing.T) {
+	srv, _ := oauthEnabledTestServer(t)
+	rr := postOAuthForm(srv, "/oauth/introspect", url.Values{
+		"token": {"any-token-here"},
+	})
+	if rr.Code == http.StatusOK {
+		// fosite returns 401 on missing Authorization.
+		t.Errorf("expected 401, got 200 (body: %s)", rr.Body.String())
+	}
+}
+
+// TestOAuth_Revoke_NotMountedOutsideCloudMode + introspect counterpart
+// confirm the cloud-mode gate covers the new endpoints (mirrors
+// TestOAuth_Register_NotMountedOutsideCloudMode for sub-PR C).
+func TestOAuth_RevokeAndIntrospect_NotMountedOutsideCloudMode(t *testing.T) {
+	srv := testServer(t) // no SetCloudMode
+	for _, path := range []string{"/oauth/revoke", "/oauth/introspect"} {
+		rr := postOAuthForm(srv, path, url.Values{"token": {"x"}, "client_id": {"y"}})
+		if rr.Code == http.StatusOK {
+			t.Errorf("%s must NOT be reachable outside cloud mode; got 200", path)
+		}
 	}
 }
 
@@ -796,4 +1227,97 @@ func readCSRFFromCookie(t *testing.T, srv *Server, sessionToken string) string {
 func s256Challenge(verifier string) string {
 	sum := sha256.Sum256([]byte(verifier))
 	return base64.RawURLEncoding.EncodeToString(sum[:])
+}
+
+// runAuthCodeFlow drives a full /oauth/authorize/decide → /oauth/token
+// exchange and returns the parsed token JSON. Each invocation needs
+// a unique verifier so the resulting code_challenge is unique;
+// callers pass distinct verifiers when minting multiple grants in
+// the same test (e.g. "introspect via separate bearer" tests in
+// sub-PR D need two grants).
+//
+// The verifier MUST be ≥43 chars (RFC 7636 §4.1: 43-128 chars from
+// the unreserved set). Tests embed that length in their literals;
+// this helper doesn't validate but tests will fail visibly at the
+// /token step if the verifier is too short.
+//
+// The state value is derived from the verifier so it's also unique
+// per call (fosite requires state ≥8 chars for entropy).
+func runAuthCodeFlow(t *testing.T, srv *Server, sessionToken, csrfTok, clientID, verifier string) map[string]any {
+	t.Helper()
+	if len(verifier) < 43 {
+		t.Fatalf("runAuthCodeFlow: verifier too short (%d chars; RFC 7636 §4.1 needs ≥43)", len(verifier))
+	}
+	challenge := s256Challenge(verifier)
+	// State just needs ≥8 chars + uniqueness so a stray CSRF check
+	// doesn't conflate two grants. Tag with a prefix of the verifier
+	// so failures point at the right call site.
+	state := "state-" + verifier[:8]
+
+	form := url.Values{
+		"client_id":             {clientID},
+		"response_type":         {"code"},
+		"redirect_uri":          {"https://app.test/cb"},
+		"code_challenge":        {challenge},
+		"code_challenge_method": {"S256"},
+		"scope":                 {"pad:read"},
+		"audience":              {testCanonicalAudience},
+		"state":                 {state},
+		"decision":              {"approve"},
+		"csrf_token":            {csrfTok},
+	}
+	rr := postFormWithCookie(srv, "/oauth/authorize/decide", form, sessionToken, csrfTok)
+	if rr.Code != http.StatusSeeOther && rr.Code != http.StatusFound {
+		t.Fatalf("decide: expected 303/302, got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+	cbURL, err := url.Parse(rr.Header().Get("Location"))
+	if err != nil {
+		t.Fatalf("parse Location: %v", err)
+	}
+	code := cbURL.Query().Get("code")
+	if code == "" {
+		t.Fatalf("missing code in callback Location: %s", rr.Header().Get("Location"))
+	}
+
+	tokenForm := url.Values{
+		"grant_type":    {"authorization_code"},
+		"code":          {code},
+		"client_id":     {clientID},
+		"redirect_uri":  {"https://app.test/cb"},
+		"code_verifier": {verifier},
+		"audience":      {testCanonicalAudience},
+	}
+	trr := postOAuthForm(srv, "/oauth/token", tokenForm)
+	if trr.Code != http.StatusOK {
+		t.Fatalf("token: expected 200, got %d (body: %s)", trr.Code, trr.Body.String())
+	}
+	var resp map[string]any
+	parseJSON(t, trr, &resp)
+	return resp
+}
+
+// postOAuthForm POSTs an x-www-form-urlencoded body without any
+// auth (used for /oauth/revoke + /oauth/token, where client_id rides
+// in the form for public clients).
+func postOAuthForm(srv *Server, path string, form url.Values) *httptest.ResponseRecorder {
+	req := httptest.NewRequest("POST", path, strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.RemoteAddr = "192.0.2.1:1234"
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	return rr
+}
+
+// postOAuthFormBearer POSTs an x-www-form-urlencoded body with a
+// Bearer Authorization header (used for /oauth/introspect, where
+// fosite v0.49 requires either Bearer or Basic auth and we don't
+// support Basic in the public-clients-only model).
+func postOAuthFormBearer(srv *Server, path string, form url.Values, bearer string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest("POST", path, strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Authorization", "Bearer "+bearer)
+	req.RemoteAddr = "192.0.2.1:1234"
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	return rr
 }

--- a/internal/server/handlers_oauth_test.go
+++ b/internal/server/handlers_oauth_test.go
@@ -765,18 +765,19 @@ func TestOAuth_Revoke_AccessToken_MarksInactive(t *testing.T) {
 	}
 }
 
-// TestOAuth_Revoke_UnknownToken_Returns200 pins Codex review #373
-// round 2: RFC 7009 §2.2 mandates that revocation is idempotent —
-// "the authorization server responds with HTTP status code 200 if
-// the token has been revoked successfully OR if the client submitted
-// an invalid token." fosite v0.49 returns ErrInvalidRequest for the
-// !found branch (revoke_handler.go:69-71), which WriteRevocationResponse
-// would turn into 400 — a spec-visible failure for the entirely
-// normal "client retried after a previous revoke succeeded" or
-// "operator typo'd the token" cases.
+// TestOAuth_Revoke_UnknownToken_Returns200 pins RFC 7009 §2.2
+// idempotency: "the authorization server responds with HTTP status
+// code 200 if the token has been revoked successfully OR if the
+// client submitted an invalid token."
 //
-// handleOAuthRevoke detects this case via isRevocationUnknownToken
-// and writes 200 directly. This test locks the override in.
+// fosite v0.49 implements this natively: handler/oauth2/revocation.go's
+// RevokeToken returns nil when both refresh-token and access-token
+// lookups miss (storeErrorsToRevocationError collapses ErrNotFound +
+// ErrInactiveToken to nil), so NewRevocationRequest returns nil and
+// WriteRevocationResponse writes 200. We pin this behavior so a
+// future fosite version-bump that breaks idempotency (e.g. by
+// returning ErrInvalidRequest for unknown tokens) gets caught here
+// instead of in production with a confused-client report.
 func TestOAuth_Revoke_UnknownToken_Returns200(t *testing.T) {
 	srv, _ := oauthEnabledTestServer(t)
 	clientID := registerTestClient(t, srv, "https://app.test/cb")
@@ -795,6 +796,30 @@ func TestOAuth_Revoke_UnknownToken_Returns200(t *testing.T) {
 	// Response body should be empty (matches the success path).
 	if rr.Body.Len() > 0 {
 		t.Errorf("unknown-token revoke response body should be empty; got %q", rr.Body.String())
+	}
+}
+
+// TestOAuth_Revoke_MissingToken_Returns400 pins Codex review #373
+// round 3: RFC 7009 §2.1 marks `token` REQUIRED, but fosite v0.49
+// doesn't enforce that — it passes the empty string into the
+// revocation handlers and emits the same bare ErrInvalidRequest
+// the unknown-token path produces. Without the explicit
+// r.PostForm.Get("token") check in handleOAuthRevoke, the
+// idempotency override would silently turn "missing required
+// parameter" into 200.
+//
+// Sending client_id but no token must remain 400 invalid_request.
+func TestOAuth_Revoke_MissingToken_Returns400(t *testing.T) {
+	srv, _ := oauthEnabledTestServer(t)
+	clientID := registerTestClient(t, srv, "https://app.test/cb")
+
+	rr := postOAuthForm(srv, "/oauth/revoke", url.Values{
+		"client_id": {clientID},
+		// Deliberately no `token` field.
+	})
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("RFC 7009 §2.1: missing required `token` parameter MUST return 400 (not silently 200); got %d (body: %s)",
+			rr.Code, rr.Body.String())
 	}
 }
 

--- a/internal/server/handlers_oauth_test.go
+++ b/internal/server/handlers_oauth_test.go
@@ -558,8 +558,16 @@ func TestOAuth_AuthorizationServerMetadata_OmitsRFC9207IssFlag(t *testing.T) {
 
 // TestOAuth_AuthorizationServerMetadata_AdvertisesRevokeIntrospect
 // asserts sub-PR D's discovery doc additions: revocation_endpoint,
-// introspection_endpoint, and the matching auth-methods lists are
+// introspection_endpoint, and the revocation auth-methods list are
 // populated and point at the URLs the handlers actually serve.
+//
+// introspection_endpoint_auth_methods_supported is intentionally
+// OMITTED — see Codex review #373 round 1 + the comment in
+// handleOAuthAuthorizationServer. The introspection endpoint only
+// accepts Bearer auth (a separate active access token), which has
+// no registered registry value, so listing "none" would be
+// misleading and listing nothing matches RFC 8414 §2's OPTIONAL
+// status.
 //
 // Real Claude-Desktop / Cursor / ChatGPT clients fetch this doc
 // once on connect and cache it; if either URL is wrong, the client
@@ -584,15 +592,18 @@ func TestOAuth_AuthorizationServerMetadata_AdvertisesRevokeIntrospect(t *testing
 			t.Errorf("%s: got %q, want %q", k, got, want)
 		}
 	}
-	// Public-clients-only model: "none" for both (no Basic auth
-	// path can succeed because we don't issue secrets).
+	// Revoke really does accept "none" — public client posts
+	// client_id form field, no secret. Honest advertisement.
 	if !sliceContainsString(doc["revocation_endpoint_auth_methods_supported"], "none") {
 		t.Errorf("revocation_endpoint_auth_methods_supported missing 'none'; got %v",
 			doc["revocation_endpoint_auth_methods_supported"])
 	}
-	if !sliceContainsString(doc["introspection_endpoint_auth_methods_supported"], "none") {
-		t.Errorf("introspection_endpoint_auth_methods_supported missing 'none'; got %v",
-			doc["introspection_endpoint_auth_methods_supported"])
+	// introspection_endpoint_auth_methods_supported MUST NOT be
+	// present (Codex review #373 round 1): the endpoint requires
+	// Bearer auth which isn't a registered auth-methods value.
+	// Listing anything here would mislead clients.
+	if v, ok := doc["introspection_endpoint_auth_methods_supported"]; ok {
+		t.Errorf("introspection_endpoint_auth_methods_supported must NOT be advertised (Bearer-only is unregistered); got %v", v)
 	}
 }
 

--- a/internal/server/handlers_oauth_test.go
+++ b/internal/server/handlers_oauth_test.go
@@ -765,6 +765,64 @@ func TestOAuth_Revoke_AccessToken_MarksInactive(t *testing.T) {
 	}
 }
 
+// TestOAuth_Revoke_UnknownToken_Returns200 pins Codex review #373
+// round 2: RFC 7009 §2.2 mandates that revocation is idempotent —
+// "the authorization server responds with HTTP status code 200 if
+// the token has been revoked successfully OR if the client submitted
+// an invalid token." fosite v0.49 returns ErrInvalidRequest for the
+// !found branch (revoke_handler.go:69-71), which WriteRevocationResponse
+// would turn into 400 — a spec-visible failure for the entirely
+// normal "client retried after a previous revoke succeeded" or
+// "operator typo'd the token" cases.
+//
+// handleOAuthRevoke detects this case via isRevocationUnknownToken
+// and writes 200 directly. This test locks the override in.
+func TestOAuth_Revoke_UnknownToken_Returns200(t *testing.T) {
+	srv, _ := oauthEnabledTestServer(t)
+	clientID := registerTestClient(t, srv, "https://app.test/cb")
+
+	// Token value is well-formed enough to pass the form parser
+	// but doesn't exist in our storage (no /authorize/decide ever
+	// minted it).
+	rr := postOAuthForm(srv, "/oauth/revoke", url.Values{
+		"token":     {"definitely-not-a-real-revoke-token"},
+		"client_id": {clientID},
+	})
+	if rr.Code != http.StatusOK {
+		t.Errorf("RFC 7009 §2.2: unknown token must return 200 (idempotent revoke); got %d (body: %s)",
+			rr.Code, rr.Body.String())
+	}
+	// Response body should be empty (matches the success path).
+	if rr.Body.Len() > 0 {
+		t.Errorf("unknown-token revoke response body should be empty; got %q", rr.Body.String())
+	}
+}
+
+// TestOAuth_Revoke_MalformedRequest_Returns400 pins the COUNTERPART
+// to TestOAuth_Revoke_UnknownToken_Returns200: the spec-correct
+// 200-on-unknown override must NOT swallow genuine "client sent a
+// broken request" errors. fosite distinguishes the two via HintField
+// (set on malformed cases via WithHint*, absent on the !found path);
+// isRevocationUnknownToken only matches the latter.
+func TestOAuth_Revoke_MalformedRequest_Returns400(t *testing.T) {
+	srv, _ := oauthEnabledTestServer(t)
+
+	// Empty form body — fosite rejects with ErrInvalidRequest
+	// hinted "POST body can not be empty." The hint distinguishes
+	// from the !found path; isRevocationUnknownToken returns false
+	// and WriteRevocationResponse emits 400.
+	req := httptest.NewRequest("POST", "/oauth/revoke", strings.NewReader(""))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.RemoteAddr = "192.0.2.1:1234"
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("malformed revoke request must return 400 (not silently 200); got %d (body: %s)",
+			rr.Code, rr.Body.String())
+	}
+}
+
 // TestOAuth_Revoke_RefreshToken_RevokesFamily covers the security
 // invariant established in sub-PR A round 2: revoking a refresh
 // token must revoke the *entire grant family* (every access AND

--- a/internal/server/handlers_well_known.go
+++ b/internal/server/handlers_well_known.go
@@ -148,25 +148,36 @@ func (s *Server) handleOAuthAuthorizationServer(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	// Sub-PR D (TASK-1026) wires /oauth/revoke + /oauth/introspect.
-	// Until then, OMIT those fields from the metadata rather than
-	// advertising URLs that 404 — RFC 8414 §2 lists them as OPTIONAL,
-	// and emitting them prematurely would mislead clients into
-	// calling endpoints that don't exist. Codex review #372 round 1
-	// caught the gap. Sub-PR D's PR description includes "populate
-	// revocation_endpoint + introspection_endpoint here" as a
-	// follow-up.
+	// Sub-PR D (TASK-1026) wires /oauth/revoke + /oauth/introspect
+	// and the discovery doc populates them here. Auth methods listed
+	// for both endpoints are "none" — pad is public-clients-only,
+	// so Basic-auth client authentication can't succeed (no
+	// secrets). For introspection that means callers MUST present a
+	// Bearer access token in the Authorization header per RFC 6750;
+	// fosite's NewIntrospectionRequest enforces that internally.
+	// "bearer" isn't a registered value in the OAuth Token Endpoint
+	// Authentication Methods registry, so we list "none" (the
+	// closest registered value for "no client credentials"). RFC
+	// 8414 §2 says omitted means default "client_secret_basic" —
+	// listing "none" is the right correction.
 	doc := authServerMetadata{
 		Issuer:                            issuer,
 		AuthorizationEndpoint:             issuer + "/oauth/authorize",
 		TokenEndpoint:                     issuer + "/oauth/token",
 		RegistrationEndpoint:              issuer + "/oauth/register",
+		RevocationEndpoint:                issuer + "/oauth/revoke",
+		IntrospectionEndpoint:             issuer + "/oauth/introspect",
 		ResponseTypesSupported:            []string{"code"},
 		GrantTypesSupported:               []string{"authorization_code", "refresh_token"},
 		CodeChallengeMethodsSupported:     []string{"S256"},
 		TokenEndpointAuthMethodsSupported: []string{"none"},
-		ScopesSupported:                   []string{"pad:read", "pad:write", "pad:admin"},
-		ResourceIndicatorsSupported:       true,
+		// Public-client model: no client secret, no Basic auth path.
+		// "none" is the closest registry value; matches the token
+		// endpoint's listing.
+		RevocationEndpointAuthMethodsSupported:    []string{"none"},
+		IntrospectionEndpointAuthMethodsSupported: []string{"none"},
+		ScopesSupported:             []string{"pad:read", "pad:write", "pad:admin"},
+		ResourceIndicatorsSupported: true,
 		// authorization_response_iss_parameter_supported (RFC 9207)
 		// is intentionally OMITTED. Advertising it would imply that
 		// /authorize redirects carry iss=<issuer> in the response
@@ -191,21 +202,24 @@ func (s *Server) handleOAuthAuthorizationServer(w http.ResponseWriter, r *http.R
 // (jwks_uri, ui_locales_supported, op_policy_uri, …) but they're
 // optional and not relevant to opaque-token deployments.
 //
-// revocation_endpoint + introspection_endpoint will be added by
-// sub-PR D (TASK-1026) when the handlers ship. Until then they're
-// omitted entirely (RFC 8414 §2 marks them OPTIONAL) so clients
-// don't dial endpoints that 404.
+// revocation_endpoint + introspection_endpoint were added in sub-PR D
+// (TASK-1026) when the handlers shipped; keeping their JSON tags
+// stable lets clients rely on them.
 type authServerMetadata struct {
-	Issuer                            string   `json:"issuer"`
-	AuthorizationEndpoint             string   `json:"authorization_endpoint"`
-	TokenEndpoint                     string   `json:"token_endpoint"`
-	RegistrationEndpoint              string   `json:"registration_endpoint"`
-	ResponseTypesSupported            []string `json:"response_types_supported"`
-	GrantTypesSupported               []string `json:"grant_types_supported"`
-	CodeChallengeMethodsSupported     []string `json:"code_challenge_methods_supported"`
-	TokenEndpointAuthMethodsSupported []string `json:"token_endpoint_auth_methods_supported"`
-	ScopesSupported                   []string `json:"scopes_supported"`
-	ResourceIndicatorsSupported       bool     `json:"resource_indicators_supported"`
+	Issuer                                    string   `json:"issuer"`
+	AuthorizationEndpoint                     string   `json:"authorization_endpoint"`
+	TokenEndpoint                             string   `json:"token_endpoint"`
+	RegistrationEndpoint                      string   `json:"registration_endpoint"`
+	RevocationEndpoint                        string   `json:"revocation_endpoint"`
+	IntrospectionEndpoint                     string   `json:"introspection_endpoint"`
+	ResponseTypesSupported                    []string `json:"response_types_supported"`
+	GrantTypesSupported                       []string `json:"grant_types_supported"`
+	CodeChallengeMethodsSupported             []string `json:"code_challenge_methods_supported"`
+	TokenEndpointAuthMethodsSupported         []string `json:"token_endpoint_auth_methods_supported"`
+	RevocationEndpointAuthMethodsSupported    []string `json:"revocation_endpoint_auth_methods_supported"`
+	IntrospectionEndpointAuthMethodsSupported []string `json:"introspection_endpoint_auth_methods_supported"`
+	ScopesSupported                           []string `json:"scopes_supported"`
+	ResourceIndicatorsSupported               bool     `json:"resource_indicators_supported"`
 }
 
 // protectedResourceMetadata is the RFC 9728 wire format. Field names

--- a/internal/server/handlers_well_known.go
+++ b/internal/server/handlers_well_known.go
@@ -148,36 +148,41 @@ func (s *Server) handleOAuthAuthorizationServer(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	// Sub-PR D (TASK-1026) wires /oauth/revoke + /oauth/introspect
-	// and the discovery doc populates them here. Auth methods listed
-	// for both endpoints are "none" — pad is public-clients-only,
-	// so Basic-auth client authentication can't succeed (no
-	// secrets). For introspection that means callers MUST present a
-	// Bearer access token in the Authorization header per RFC 6750;
-	// fosite's NewIntrospectionRequest enforces that internally.
-	// "bearer" isn't a registered value in the OAuth Token Endpoint
-	// Authentication Methods registry, so we list "none" (the
-	// closest registered value for "no client credentials"). RFC
-	// 8414 §2 says omitted means default "client_secret_basic" —
-	// listing "none" is the right correction.
+	// Sub-PR D (TASK-1026) wires /oauth/revoke + /oauth/introspect.
+	//
+	// revocation_endpoint_auth_methods_supported = ["none"] is honest:
+	// fosite's NewRevocationRequest accepts a public client that
+	// posts only `client_id` (no secret, no Bearer header), which
+	// matches the "none" value from the OAuth Token Endpoint
+	// Authentication Methods registry.
+	//
+	// introspection_endpoint_auth_methods_supported is intentionally
+	// OMITTED. fosite's NewIntrospectionRequest insists on either
+	// Bearer auth (a separate active access token, RFC 7662 §2.1's
+	// "bearer token" branch) or HTTP Basic — and our public-clients-
+	// only model has no Basic-auth path. "bearer" isn't a registered
+	// value in the auth-methods registry, so listing "none" would
+	// mislead clients into thinking they can post bare token+client_id
+	// and have it accepted (the test in this PR locks in that a
+	// missing Authorization header is rejected). RFC 8414 §2 marks
+	// the field OPTIONAL; omitting it tells discovery clients
+	// "negotiate auth out-of-band," which for our case is documented
+	// in the public docs at getpad.dev/mcp/local. Codex review #373
+	// round 1 caught the mismatch.
 	doc := authServerMetadata{
-		Issuer:                            issuer,
-		AuthorizationEndpoint:             issuer + "/oauth/authorize",
-		TokenEndpoint:                     issuer + "/oauth/token",
-		RegistrationEndpoint:              issuer + "/oauth/register",
-		RevocationEndpoint:                issuer + "/oauth/revoke",
-		IntrospectionEndpoint:             issuer + "/oauth/introspect",
-		ResponseTypesSupported:            []string{"code"},
-		GrantTypesSupported:               []string{"authorization_code", "refresh_token"},
-		CodeChallengeMethodsSupported:     []string{"S256"},
-		TokenEndpointAuthMethodsSupported: []string{"none"},
-		// Public-client model: no client secret, no Basic auth path.
-		// "none" is the closest registry value; matches the token
-		// endpoint's listing.
-		RevocationEndpointAuthMethodsSupported:    []string{"none"},
-		IntrospectionEndpointAuthMethodsSupported: []string{"none"},
-		ScopesSupported:             []string{"pad:read", "pad:write", "pad:admin"},
-		ResourceIndicatorsSupported: true,
+		Issuer:                                 issuer,
+		AuthorizationEndpoint:                  issuer + "/oauth/authorize",
+		TokenEndpoint:                          issuer + "/oauth/token",
+		RegistrationEndpoint:                   issuer + "/oauth/register",
+		RevocationEndpoint:                     issuer + "/oauth/revoke",
+		IntrospectionEndpoint:                  issuer + "/oauth/introspect",
+		ResponseTypesSupported:                 []string{"code"},
+		GrantTypesSupported:                    []string{"authorization_code", "refresh_token"},
+		CodeChallengeMethodsSupported:          []string{"S256"},
+		TokenEndpointAuthMethodsSupported:      []string{"none"},
+		RevocationEndpointAuthMethodsSupported: []string{"none"},
+		ScopesSupported:                        []string{"pad:read", "pad:write", "pad:admin"},
+		ResourceIndicatorsSupported:            true,
 		// authorization_response_iss_parameter_supported (RFC 9207)
 		// is intentionally OMITTED. Advertising it would imply that
 		// /authorize redirects carry iss=<issuer> in the response
@@ -205,21 +210,26 @@ func (s *Server) handleOAuthAuthorizationServer(w http.ResponseWriter, r *http.R
 // revocation_endpoint + introspection_endpoint were added in sub-PR D
 // (TASK-1026) when the handlers shipped; keeping their JSON tags
 // stable lets clients rely on them.
+//
+// introspection_endpoint_auth_methods_supported is deliberately not a
+// field here. The introspection endpoint only accepts Bearer auth in
+// our public-clients-only model, and "bearer" isn't a registered
+// auth-methods value — see the comment in handleOAuthAuthorizationServer
+// for the full reasoning. RFC 8414 §2 marks it OPTIONAL.
 type authServerMetadata struct {
-	Issuer                                    string   `json:"issuer"`
-	AuthorizationEndpoint                     string   `json:"authorization_endpoint"`
-	TokenEndpoint                             string   `json:"token_endpoint"`
-	RegistrationEndpoint                      string   `json:"registration_endpoint"`
-	RevocationEndpoint                        string   `json:"revocation_endpoint"`
-	IntrospectionEndpoint                     string   `json:"introspection_endpoint"`
-	ResponseTypesSupported                    []string `json:"response_types_supported"`
-	GrantTypesSupported                       []string `json:"grant_types_supported"`
-	CodeChallengeMethodsSupported             []string `json:"code_challenge_methods_supported"`
-	TokenEndpointAuthMethodsSupported         []string `json:"token_endpoint_auth_methods_supported"`
-	RevocationEndpointAuthMethodsSupported    []string `json:"revocation_endpoint_auth_methods_supported"`
-	IntrospectionEndpointAuthMethodsSupported []string `json:"introspection_endpoint_auth_methods_supported"`
-	ScopesSupported                           []string `json:"scopes_supported"`
-	ResourceIndicatorsSupported               bool     `json:"resource_indicators_supported"`
+	Issuer                                 string   `json:"issuer"`
+	AuthorizationEndpoint                  string   `json:"authorization_endpoint"`
+	TokenEndpoint                          string   `json:"token_endpoint"`
+	RegistrationEndpoint                   string   `json:"registration_endpoint"`
+	RevocationEndpoint                     string   `json:"revocation_endpoint"`
+	IntrospectionEndpoint                  string   `json:"introspection_endpoint"`
+	ResponseTypesSupported                 []string `json:"response_types_supported"`
+	GrantTypesSupported                    []string `json:"grant_types_supported"`
+	CodeChallengeMethodsSupported          []string `json:"code_challenge_methods_supported"`
+	TokenEndpointAuthMethodsSupported      []string `json:"token_endpoint_auth_methods_supported"`
+	RevocationEndpointAuthMethodsSupported []string `json:"revocation_endpoint_auth_methods_supported"`
+	ScopesSupported                        []string `json:"scopes_supported"`
+	ResourceIndicatorsSupported            bool     `json:"resource_indicators_supported"`
 }
 
 // protectedResourceMetadata is the RFC 9728 wire format. Field names


### PR DESCRIPTION
## Summary

Sub-PR D of [PLAN-943 / TASK-951](https://github.com/PerpetualSoftware/pad). Wires the RFC 7009 revocation and RFC 7662 introspection endpoints — the two endpoints sub-PR C (#372) left as placeholders.

- **POST /oauth/revoke** — RFC 7009. Public-client auth via `client_id` form field. Revoking a refresh token walks the grant family (every paired access + every rotated refresh) via the storage adapter from sub-PR A (#370).
- **POST /oauth/introspect** — RFC 7662. Bearer-auth required (public-clients model: no Basic auth path). Returns full claims for active tokens; bare `{active:false}` for unknown/revoked/expired so attackers can't enumerate token state from the response shape.
- Discovery doc populates `revocation_endpoint` + `introspection_endpoint` + their `*_auth_methods_supported` lists (both `["none"]`).

After merge, **3/5 → 4/5** of TASK-951 done. Sub-PR E (TASK-1027) is the last piece: wires `MCPBearerAuth` to OAuth introspection internally + the consent-screen public-info endpoint.

## Test plan

- [x] All 18 OAuth handler tests pass (`go test ./internal/server/ -run TestOAuth_`).
- [x] `make check` clean (golangci-lint + go test ./... + npm run build + svelte-check).
- [x] Refresh-token rotation: old pair inactive after exchange.
- [x] Refresh-token replay detection: replaying a rotated refresh revokes the entire family (the OAuth 2.1 §6.1 / RFC 6819 §5.2.2.3 security invariant).
- [x] Revoking a refresh token revokes the paired access token (family revocation).
- [x] Introspect returns the expected `{active, sub, scope, aud, client_id, exp, iat}` shape on a valid token.
- [x] Introspect on unknown token returns `{active:false}` with no leaked fields.
- [x] Introspect rejects requests with no Bearer Authorization header.
- [x] Both endpoints 404 outside cloud mode (mirrors `/oauth/register` gating from sub-PR C).
- [x] Discovery doc advertises both endpoints + the `*_auth_methods_supported` lists.
- [ ] `/codex review` loop until CLEAN.