### PR TITLE
chore(e2e): blog screenshot capture spec + shared seed helpers (TASK-1031)

### DIFF
--- a/web/e2e/blog-screenshots.spec.ts
+++ b/web/e2e/blog-screenshots.spec.ts
@@ -1,0 +1,115 @@
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { mkdir } from 'node:fs/promises';
+import { test } from './fixtures';
+import { seedRealisticContent, seedConventions, type ConventionInput } from './lib/demo-seed';
+
+/**
+ * Blog post screenshot capture.
+ *
+ * Gated on PAD_BLOG_SCREENSHOTS=1 — runs only when explicitly requested,
+ * never as part of the normal e2e suite. Each describe block owns one
+ * blog post: it seeds whatever content the post's screenshots need, then
+ * captures into ../../pad-web/static/blog/<slug>/ so the marketing site
+ * picks them up at build time.
+ *
+ * Re-run via:
+ *   make build-go && cd web && PAD_BLOG_SCREENSHOTS=1 \
+ *     npx playwright test blog-screenshots --project=desktop-chromium
+ *
+ * Conventions for adding a new post's shots:
+ *   1. Add a describe block keyed by the post's slug.
+ *   2. test.beforeAll seeds the post-specific content.
+ *   3. Capture each view with captureView(), naming files NN-shortname.png.
+ *   4. Reference in the post body as ![alt](/blog/<slug>/NN-shortname.png).
+ *
+ * Theme: dark (matches getpad.dev's marketing site). Viewport 1440x900.
+ */
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PAD_REPO_ROOT = resolve(HERE, '..', '..');
+// pad-web is a sibling of the pad repo (per CLAUDE.md / CONVE-159).
+const PAD_WEB_STATIC_BLOG = resolve(PAD_REPO_ROOT, '..', 'pad-web', 'static', 'blog');
+
+const enabled = process.env.PAD_BLOG_SCREENSHOTS === '1';
+
+test.describe.configure({ mode: 'serial' });
+
+// ─── BLOG-1007: Conventions and Playbooks ────────────────────────────────────
+
+test.describe('BLOG-1007 conventions-and-playbooks', () => {
+	test.skip(!enabled, 'set PAD_BLOG_SCREENSHOTS=1 to regenerate blog screenshots');
+
+	test.use({ viewport: { width: 1440, height: 900 }, colorScheme: 'dark' });
+
+	const POST_SLUG = 'conventions-and-playbooks';
+	const OUT_DIR = resolve(PAD_WEB_STATIC_BLOG, POST_SLUG);
+
+	test.beforeAll(async () => {
+		await mkdir(OUT_DIR, { recursive: true });
+	});
+
+	test('seed + capture', async ({ page, fixture, request }) => {
+		// Seed (8 items + 5 conventions) + two screenshots is more than 30s.
+		test.setTimeout(120_000);
+
+		// Realistic background content so the sidebar / dashboard look lived-in.
+		await seedRealisticContent(fixture, request);
+
+		// 4 conventions from BLOG-1007's "five worth stealing" section.
+		// The 5th example — "Conventional commit format" — already ships
+		// in the startup template's starter pack, so seeding it again
+		// would create a near-duplicate ("Use conventional commit format"
+		// vs "Conventional commit format") in the screenshot. Letting
+		// the template's version stand alone keeps the page tidy and
+		// reinforces the post's point that the Library + starter pack
+		// already cover the common stuff.
+		const POST_CONVENTIONS: ConventionInput[] = [
+			{
+				title: 'Run make install after backend changes',
+				trigger: 'on-implement',
+				priority: 'must',
+				scope: 'backend'
+			},
+			{
+				title: 'Tasks should be PR-sized',
+				trigger: 'always',
+				priority: 'should'
+			},
+			{
+				title: 'Never wipe data without confirmation',
+				trigger: 'always',
+				priority: 'must'
+			},
+			{
+				title: 'Document related repos in CLAUDE.md',
+				trigger: 'always',
+				priority: 'should'
+			}
+		];
+		await seedConventions(fixture, request, POST_CONVENTIONS);
+
+		const wsPath = `/${fixture.adminUsername}/${fixture.workspaceSlug}`;
+
+		const captureView = async (path: string, outFile: string, anchorSelector: string) => {
+			await page.goto(path);
+			await page.waitForLoadState('domcontentloaded');
+			await page.waitForSelector(anchorSelector, { state: 'visible', timeout: 15_000 });
+			// Settle delay covers SSE-driven re-renders.
+			await page.waitForTimeout(800);
+			await page.screenshot({ path: resolve(OUT_DIR, outFile), fullPage: false });
+		};
+
+		// 1. Conventions board — shows the 5 seeded conventions grouped by trigger.
+		await captureView(`${wsPath}/conventions`, '01-conventions-board.png', 'h1, h2');
+
+		// 2. Library — conventions tab. No activations yet, so the screenshot
+		//    shows the catalog in its "ready to install" state, which is
+		//    what a new visitor sees.
+		await captureView(
+			`${wsPath}/library?tab=conventions`,
+			'02-library-conventions.png',
+			'h1, h2'
+		);
+	});
+});

--- a/web/e2e/lib/demo-seed.ts
+++ b/web/e2e/lib/demo-seed.ts
@@ -1,0 +1,244 @@
+import type { APIRequestContext } from '@playwright/test';
+import type { SuiteFixture } from '../fixtures';
+
+/**
+ * Shared seeding helpers for screenshot specs.
+ *
+ * Two consumers today:
+ *   - e2e/screenshots.spec.ts          (README hero shots)
+ *   - e2e/blog-screenshots.spec.ts     (per-blog-post shots)
+ *
+ * Each helper hits the same REST endpoints the web UI uses, so the
+ * resulting items behave identically to ones a human creates via the
+ * dashboard.
+ */
+
+// `fields` is a JSON-encoded string on the wire (see
+// internal/models/item.go ItemCreate). Stringify it once.
+const enc = (obj: Record<string, unknown>) => JSON.stringify(obj);
+
+function authHeaders(fixture: SuiteFixture) {
+	return {
+		Authorization: `Bearer ${fixture.apiToken}`,
+		'Content-Type': 'application/json'
+	};
+}
+
+/**
+ * Realistic-looking project: one active plan, half a dozen tasks across
+ * statuses + priorities, a couple of ideas. Designed to make the
+ * dashboard's "Active Plans" widget show a non-zero progress bar and
+ * give the board view meaningful columns.
+ *
+ * Idempotent enough for `reuseExistingServer: true` local re-runs:
+ * each call will create *additional* items, but the screenshots only
+ * care that there's *some* content. If you need a clean slate, point
+ * Playwright at a fresh PAD_E2E_DATA_DIR.
+ */
+export async function seedRealisticContent(fixture: SuiteFixture, request: APIRequestContext) {
+	const ws = fixture.workspaceSlug;
+	const headers = authHeaders(fixture);
+
+	// 1. Active plan
+	const planResp = await request.post(`/api/v1/workspaces/${ws}/collections/plans/items`, {
+		headers,
+		data: {
+			title: 'v0.2 — Collaboration',
+			fields: enc({ status: 'active' }),
+			content: 'Real-time multiplayer editing, team invites, and shared views.'
+		}
+	});
+	if (!planResp.ok()) {
+		throw new Error(`plan create failed (${planResp.status()}): ${await planResp.text()}`);
+	}
+	const plan = (await planResp.json()) as { id?: string };
+	if (!plan.id) throw new Error('plan create succeeded but response missing id');
+
+	// 2. Tasks — explicit mix of status / priority / parent linkage
+	const tasks: { title: string; fields: Record<string, string>; parent?: string }[] = [
+		{
+			title: 'Fix OAuth redirect bug',
+			fields: { status: 'in-progress', priority: 'high', effort: 'm' },
+			parent: plan.id
+		},
+		{
+			title: 'Add rate limiting to API endpoints',
+			fields: { status: 'in-progress', priority: 'high', effort: 'l' },
+			parent: plan.id
+		},
+		{
+			title: 'Refactor auth middleware',
+			fields: { status: 'open', priority: 'medium', effort: 'm' }
+		},
+		{
+			title: 'Add SSO support for enterprise users',
+			fields: { status: 'open', priority: 'medium', effort: 'xl' },
+			parent: plan.id
+		},
+		{
+			title: 'Document the deploy pipeline',
+			fields: { status: 'open', priority: 'low', effort: 's' }
+		},
+		{
+			title: 'Update Go to 1.26',
+			fields: { status: 'done', priority: 'medium', effort: 's' }
+		},
+		{
+			title: 'Set up CI security scanning',
+			fields: { status: 'done', priority: 'high', effort: 's' },
+			parent: plan.id
+		}
+	];
+
+	for (const t of tasks) {
+		const resp = await request.post(`/api/v1/workspaces/${ws}/collections/tasks/items`, {
+			headers,
+			data: {
+				title: t.title,
+				fields: enc(t.fields),
+				...(t.parent ? { parent_id: t.parent } : {})
+			}
+		});
+		if (!resp.ok()) {
+			throw new Error(`task ${t.title} failed (${resp.status()}): ${await resp.text()}`);
+		}
+	}
+
+	// 3. Ideas — a couple, varied state
+	const ideas: { title: string; fields: Record<string, string> }[] = [
+		{ title: 'Real-time presence indicators', fields: { status: 'exploring', impact: 'high' } },
+		{ title: 'Slack integration for notifications', fields: { status: 'new', impact: 'medium' } }
+	];
+	for (const idea of ideas) {
+		const resp = await request.post(`/api/v1/workspaces/${ws}/collections/ideas/items`, {
+			headers,
+			data: { title: idea.title, fields: enc(idea.fields) }
+		});
+		if (!resp.ok()) {
+			throw new Error(`idea ${idea.title} failed (${resp.status()}): ${await resp.text()}`);
+		}
+	}
+}
+
+export interface ConventionInput {
+	title: string;
+	trigger: string;
+	priority: 'must' | 'should' | 'nice-to-have';
+	scope?: 'all' | 'backend' | 'frontend' | 'mobile' | 'docs' | 'devops';
+	role?: string;
+	content?: string;
+}
+
+/**
+ * Bulk-create conventions in the workspace. Mirrors the inline-create
+ * flow in web/src/routes/[username]/[workspace]/conventions/+page.svelte
+ * but skips the form UX.
+ */
+export async function seedConventions(
+	fixture: SuiteFixture,
+	request: APIRequestContext,
+	conventions: ConventionInput[]
+) {
+	const ws = fixture.workspaceSlug;
+	const headers = authHeaders(fixture);
+
+	for (const c of conventions) {
+		const fields: Record<string, string> = {
+			status: 'active',
+			trigger: c.trigger,
+			priority: c.priority,
+			scope: c.scope ?? 'all'
+		};
+		if (c.role) fields.role = c.role;
+
+		const resp = await request.post(`/api/v1/workspaces/${ws}/collections/conventions/items`, {
+			headers,
+			data: {
+				title: c.title,
+				fields: enc(fields),
+				...(c.content ? { content: c.content } : {})
+			}
+		});
+		if (!resp.ok()) {
+			throw new Error(`convention "${c.title}" failed (${resp.status()}): ${await resp.text()}`);
+		}
+	}
+}
+
+interface LibraryConvention {
+	title: string;
+	content: string;
+	category: string;
+	trigger: string;
+	surfaces?: string[];
+	enforcement: 'must' | 'should' | 'nice-to-have';
+	commands?: string[];
+}
+
+interface ConventionLibraryResponse {
+	categories: { name: string; conventions: LibraryConvention[] }[];
+}
+
+/**
+ * Activate one or more conventions from the curated /convention-library.
+ * Mirrors api.library.activate() in web/src/lib/api/client.ts — this
+ * is a simple POST to the conventions collection with the library
+ * convention's data (no dedicated /activate endpoint exists; the web
+ * UI does the same thing).
+ *
+ * Pass library titles exactly as they appear in `pad library list`.
+ */
+export async function activateLibraryConventions(
+	fixture: SuiteFixture,
+	request: APIRequestContext,
+	titles: string[]
+) {
+	const ws = fixture.workspaceSlug;
+	const headers = authHeaders(fixture);
+
+	const libraryResp = await request.get('/api/v1/convention-library', { headers });
+	if (!libraryResp.ok()) {
+		throw new Error(`library fetch failed (${libraryResp.status()}): ${await libraryResp.text()}`);
+	}
+	const library = (await libraryResp.json()) as ConventionLibraryResponse;
+	const byTitle = new Map<string, LibraryConvention>();
+	for (const cat of library.categories) {
+		for (const conv of cat.conventions) byTitle.set(conv.title, conv);
+	}
+
+	for (const title of titles) {
+		const conv = byTitle.get(title);
+		if (!conv) {
+			const available = [...byTitle.keys()].slice(0, 10).join(', ');
+			throw new Error(`library convention "${title}" not found. First few available: ${available}`);
+		}
+
+		const resp = await request.post(`/api/v1/workspaces/${ws}/collections/conventions/items`, {
+			headers,
+			data: {
+				title: conv.title,
+				content: conv.content,
+				fields: enc({
+					status: 'active',
+					category: conv.category,
+					trigger: conv.trigger,
+					scope: conv.surfaces?.[0] ?? 'all',
+					priority: conv.enforcement,
+					enforcement: conv.enforcement,
+					surfaces: conv.surfaces,
+					commands: conv.commands ?? [],
+					convention: {
+						category: conv.category,
+						trigger: conv.trigger,
+						surfaces: conv.surfaces,
+						enforcement: conv.enforcement,
+						commands: conv.commands ?? []
+					}
+				})
+			}
+		});
+		if (!resp.ok()) {
+			throw new Error(`activate "${title}" failed (${resp.status()}): ${await resp.text()}`);
+		}
+	}
+}

--- a/web/e2e/screenshots.spec.ts
+++ b/web/e2e/screenshots.spec.ts
@@ -1,7 +1,8 @@
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { mkdir } from 'node:fs/promises';
-import { test, type SuiteFixture } from './fixtures';
+import { test } from './fixtures';
+import { seedRealisticContent } from './lib/demo-seed';
 
 /**
  * README screenshot capture.
@@ -64,7 +65,7 @@ test.describe('README screenshots', () => {
 		// holds an open SSE connection — we use targeted waits below.
 		test.setTimeout(120_000);
 
-		await seedDemoContent(fixture, request);
+		await seedRealisticContent(fixture, request);
 
 		const wsPath = `/${fixture.adminUsername}/${fixture.workspaceSlug}`;
 
@@ -96,106 +97,5 @@ test.describe('README screenshots', () => {
 	});
 });
 
-/**
- * Seed a realistic-looking project: one active plan, half a dozen tasks
- * spread across statuses + priorities (so the board has meaningful columns
- * and the list has variety), and a couple of ideas. All linked to the plan
- * so the dashboard's "Active Plans" widget shows a non-zero progress bar.
- */
-async function seedDemoContent(
-	fixture: SuiteFixture,
-	request: Parameters<Parameters<typeof test>[1]>[0]['request']
-) {
-	const ws = fixture.workspaceSlug;
-	const headers = {
-		Authorization: `Bearer ${fixture.apiToken}`,
-		'Content-Type': 'application/json'
-	};
-
-	// `fields` is a JSON-encoded string on the wire (see
-	// internal/models/item.go ItemCreate). Stringify it once.
-	const enc = (obj: Record<string, string>) => JSON.stringify(obj);
-
-	// 1. Active plan
-	const planResp = await request.post(`/api/v1/workspaces/${ws}/collections/plans/items`, {
-		headers,
-		data: {
-			title: 'v0.2 — Collaboration',
-			fields: enc({ status: 'active' }),
-			content: 'Real-time multiplayer editing, team invites, and shared views.'
-		}
-	});
-	if (!planResp.ok()) {
-		throw new Error(`plan create failed (${planResp.status()}): ${await planResp.text()}`);
-	}
-	const plan = (await planResp.json()) as { id?: string };
-	if (!plan.id) throw new Error('plan create succeeded but response missing id');
-
-	// 2. Tasks — explicit mix of status / priority / parent linkage
-	const tasks: { title: string; fields: Record<string, string>; parent?: string }[] = [
-		{
-			title: 'Fix OAuth redirect bug',
-			fields: { status: 'in-progress', priority: 'high', effort: 'm' },
-			parent: plan.id
-		},
-		{
-			title: 'Add rate limiting to API endpoints',
-			fields: { status: 'in-progress', priority: 'high', effort: 'l' },
-			parent: plan.id
-		},
-		{
-			title: 'Refactor auth middleware',
-			fields: { status: 'open', priority: 'medium', effort: 'm' }
-		},
-		{
-			title: 'Add SSO support for enterprise users',
-			fields: { status: 'open', priority: 'medium', effort: 'xl' },
-			parent: plan.id
-		},
-		{
-			title: 'Document the deploy pipeline',
-			fields: { status: 'open', priority: 'low', effort: 's' }
-		},
-		{
-			title: 'Update Go to 1.26',
-			fields: { status: 'done', priority: 'medium', effort: 's' }
-		},
-		{
-			title: 'Set up CI security scanning',
-			fields: { status: 'done', priority: 'high', effort: 's' },
-			parent: plan.id
-		}
-	];
-
-	for (const t of tasks) {
-		const resp = await request.post(`/api/v1/workspaces/${ws}/collections/tasks/items`, {
-			headers,
-			data: {
-				title: t.title,
-				fields: enc(t.fields),
-				...(t.parent ? { parent_id: t.parent } : {})
-			}
-		});
-		if (!resp.ok()) {
-			throw new Error(`task ${t.title} failed (${resp.status()}): ${await resp.text()}`);
-		}
-	}
-
-	// 3. Ideas — a couple, varied state
-	const ideas: { title: string; fields: Record<string, string> }[] = [
-		{
-			title: 'Real-time presence indicators',
-			fields: { status: 'exploring', impact: 'high' }
-		},
-		{ title: 'Slack integration for notifications', fields: { status: 'new', impact: 'medium' } }
-	];
-	for (const idea of ideas) {
-		const resp = await request.post(`/api/v1/workspaces/${ws}/collections/ideas/items`, {
-			headers,
-			data: { title: idea.title, fields: enc(idea.fields) }
-		});
-		if (!resp.ok()) {
-			throw new Error(`idea ${idea.title} failed (${resp.status()}): ${await resp.text()}`);
-		}
-	}
-}
+// seedRealisticContent now lives in ./lib/demo-seed.ts and is shared with
+// blog-screenshots.spec.ts.


### PR DESCRIPTION
## Summary

- New `web/e2e/lib/demo-seed.ts` extracts the realistic-content seed from `screenshots.spec.ts` into a shared module, plus adds two new helpers (`seedConventions`, `activateLibraryConventions`) for blog-post-specific seeding.
- New `web/e2e/blog-screenshots.spec.ts` (gated on `PAD_BLOG_SCREENSHOTS=1`) — one `test.describe` per blog post, captures into `../../pad-web/static/blog/<slug>/`. First consumer is BLOG-1007 (Conventions and Playbooks).
- Refactored `web/e2e/screenshots.spec.ts` to import from the shared lib. No behavior change.

Companion publish helper at `pad-web/scripts/blog-publish.mjs` (already shipped, commits `08bbca0` + `7edb36f`) handles export from Pad attachments → pad-web static folder.

## Why

Building the screenshot pipeline once means every future blog post can ship with on-brand, on-current-version captures via:

```bash
make build-go && cd web && PAD_BLOG_SCREENSHOTS=1 \
  npx playwright test blog-screenshots --project=desktop-chromium
```

Two posts already used this: [the manifesto](https://getpad.dev/blog/built-for-makers) (no screenshots) and [Conventions and Playbooks](https://getpad.dev/blog/conventions-and-playbooks) (two screenshots). 18+ remaining posts in the editorial calendar will reuse it.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.json` — clean for e2e files (pre-existing tiptap typing issues elsewhere are unrelated)
- [x] Regression: `PAD_SCREENSHOTS=1 npx playwright test screenshots.spec.ts --project=desktop-chromium` — README capture flow still passes after the refactor
- [x] New: `PAD_BLOG_SCREENSHOTS=1 npx playwright test blog-screenshots --project=desktop-chromium` — captures two PNGs to `pad-web/static/blog/conventions-and-playbooks/`
- [ ] CI green
- [ ] Codex CLI review CLEAN (per CONVE-735)

Refs TASK-1031.