### PR TITLE
feat(oauth): MCPBearerAuth OAuth integration + public-info (TASK-1027) — closes TASK-951

### DIFF
--- a/internal/oauth/server.go
+++ b/internal/oauth/server.go
@@ -1,6 +1,7 @@
 package oauth
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"time"
@@ -234,6 +235,57 @@ func (s *Server) Storage() *Storage {
 // before fosite's downstream validation runs.
 func (s *Server) AllowedAudience() string {
 	return s.cfg.AllowedAudience
+}
+
+// IntrospectToken validates an opaque OAuth access token without
+// going through the public RFC 7662 HTTP endpoint. Used by sub-PR E's
+// MCPBearerAuth middleware to gate /mcp on OAuth-issued tokens —
+// server-side, no roundtrip, no client-auth dance.
+//
+// Returns:
+//
+//   - ar: the AccessRequester with session hydrated. The session's
+//     Subject is the pad user ID (set in /authorize/decide via
+//     oauth.NewSession(user.ID)); GetGrantedScopes / GetGrantedAudience
+//     return the values fosite persisted at grant time.
+//   - tokenUse: fosite.AccessToken or fosite.RefreshToken. Resource-
+//     server callers MUST reject anything other than AccessToken;
+//     refresh tokens are not valid bearers for protected-resource
+//     calls.
+//   - err: fosite.ErrInactiveToken / fosite.ErrNotFound when the
+//     token is invalid; a wrapped storage error otherwise.
+//
+// Why a wrapper rather than calling fosite directly: fosite.Fosite's
+// IntrospectToken isn't on the OAuth2Provider interface — it's on
+// the concrete *Fosite type. compose.Compose returns OAuth2Provider
+// (interface) but the underlying value is always *Fosite (compose.go:38
+// hardcodes the constructor). Type-asserting at every call site would
+// scatter the dependency on this implementation detail; centralizing
+// it here keeps the boundary clean and gives us a single place to
+// fail loudly if a future fosite version-bump changes the return
+// type.
+//
+// Hint: fosite.AccessToken — if the token is actually a refresh
+// token, fosite tries the access-token strategy first, fails, then
+// falls through to the refresh-token strategy. The returned tokenUse
+// reports the actual kind, which the caller is expected to validate.
+func (s *Server) IntrospectToken(ctx context.Context, token string) (fosite.AccessRequester, fosite.TokenUse, error) {
+	f, ok := s.provider.(*fosite.Fosite)
+	if !ok {
+		// Defensive: compose.Compose has hardcoded *Fosite as the
+		// concrete return type since fosite v0.1.0. If a future
+		// version changes that we want to fail loudly, not silently
+		// fall through to a refused-everything state.
+		return nil, "", fmt.Errorf("oauth: provider type-assertion to *fosite.Fosite failed; got %T (compose.Compose internals changed?)", s.provider)
+	}
+	// Empty session pointer — fosite hydrates from storage. The
+	// session type must match what's stored (oauth.Session, written
+	// via oauth.NewSession in /authorize/decide), or the JSON
+	// unmarshal in oauthRequestToFositeRequest would silently drop
+	// pad-specific fields.
+	session := NewSession("")
+	tokenUse, ar, err := f.IntrospectToken(ctx, token, fosite.AccessToken, session)
+	return ar, tokenUse, err
 }
 
 // Compile-time guard: NewStorage produces a value that satisfies the

--- a/internal/server/handlers_mcp_test.go
+++ b/internal/server/handlers_mcp_test.go
@@ -691,6 +691,45 @@ func TestMCP_OAuthScopeReadOnly_StashesPadReadScope(t *testing.T) {
 	}
 }
 
+// TestOAuthScopesToJSON_FailClosedOnEmpty pins Codex review #375
+// round 1: OAuth's `scope` parameter is optional per RFC 6749 §3.3,
+// so fosite can hand back a token with empty granted scopes. Without
+// the fail-closed mapping in oauthScopesToJSON, that empty list
+// would serialize to `[]` — which tokenScopeAllows interprets as
+// the legacy "unrestricted" PAT shape, granting write access.
+//
+// The fix maps empty → JSON `null`, which tokenScopeAllows denies
+// via its "scopes == nil" branch. This test asserts both halves of
+// the contract: oauthScopesToJSON produces null, and tokenScopeAllows
+// then denies for every method.
+func TestOAuthScopesToJSON_FailClosedOnEmpty(t *testing.T) {
+	got := oauthScopesToJSON(nil)
+	if got != "null" {
+		t.Errorf("nil scopes: got %q, want %q", got, "null")
+	}
+	gotEmpty := oauthScopesToJSON([]string{})
+	if gotEmpty != "null" {
+		t.Errorf("empty scopes: got %q, want %q", gotEmpty, "null")
+	}
+
+	// Routing through tokenScopeAllows must produce false for all
+	// methods — pin the end-to-end contract, not just the helper.
+	for _, method := range []string{
+		http.MethodGet, http.MethodPost, http.MethodPatch, http.MethodDelete,
+	} {
+		if tokenScopeAllows(got, method, "/api/v1/items") {
+			t.Errorf("empty OAuth scopes must deny %s; tokenScopeAllows returned true", method)
+		}
+	}
+
+	// Sanity: non-empty OAuth scopes round-trip the canonical JSON
+	// form (regression — the fail-closed path must NOT extend to
+	// the populated case).
+	if got := oauthScopesToJSON([]string{"pad:read"}); got != `["pad:read"]` {
+		t.Errorf("populated scopes: got %q, want %q", got, `["pad:read"]`)
+	}
+}
+
 // =====================================================================
 // /api/v1/oauth/clients/{id}/public-info (sub-PR E, TASK-1027)
 // =====================================================================

--- a/internal/server/handlers_mcp_test.go
+++ b/internal/server/handlers_mcp_test.go
@@ -3,10 +3,12 @@ package server
 import (
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 
 	"github.com/PerpetualSoftware/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/oauth"
 )
 
 // TestMCP_CloudModeOff_RoutesAbsent verifies the negative case:
@@ -375,6 +377,537 @@ func mcpEnabledTestServer(t *testing.T) *Server {
 	})
 	srv.SetMCPTransport(stub, "https://mcp.test.example", "https://app.test.example")
 	return srv
+}
+
+// =====================================================================
+// /mcp ↔ OAuth integration (sub-PR E, TASK-1027)
+// =====================================================================
+
+// mcpAndOAuthEnabledTestServer builds a server with BOTH the MCP
+// transport stub AND the fosite-backed OAuth server wired. The two
+// surfaces share the same canonical audience (testCanonicalAudience
+// from handlers_oauth_test.go), so a token issued by the OAuth flow
+// is valid against the MCP gate.
+//
+// Stub captures the user attached to the request context so tests
+// can assert "the OAuth bearer routed the right user through" in
+// addition to "the auth gate accepted the bearer."
+func mcpAndOAuthEnabledTestServer(t *testing.T) (srv *Server, transport *mcpStubTransport) {
+	t.Helper()
+	srv = testServer(t)
+	srv.SetCloudMode("test-secret")
+
+	transport = &mcpStubTransport{}
+	srv.SetMCPTransport(http.HandlerFunc(transport.serve),
+		strings.TrimSuffix(testCanonicalAudience, "/mcp"),
+		testAuthServerURL)
+
+	o, err := newTestOAuthServer(t, srv)
+	if err != nil {
+		t.Fatalf("oauth.NewServer: %v", err)
+	}
+	srv.SetOAuthServer(o)
+	return srv, transport
+}
+
+// mcpStubTransport is a recording stub for the /mcp Streamable-HTTP
+// surface. Captures the user attached to context so tests can
+// distinguish "auth gate let the request through" from "auth gate
+// attached the right identity." A misrouted request shows up as
+// SeenUserID == "" (stub never reached / no user in context).
+type mcpStubTransport struct {
+	Called      bool
+	SeenUserID  string
+	SeenScopes  string
+	SeenIsToken bool
+}
+
+func (t *mcpStubTransport) serve(w http.ResponseWriter, r *http.Request) {
+	t.Called = true
+	if u, ok := CurrentUserFromContext(r.Context()); ok && u != nil {
+		t.SeenUserID = u.ID
+	}
+	t.SeenScopes = TokenScopesFromContext(r.Context())
+	t.SeenIsToken = IsAPITokenFromContext(r.Context())
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{}}`))
+}
+
+// TestMCP_OAuthAccessToken_Authenticates is the primary happy-path
+// test for sub-PR E: a token minted by the full /authorize → /token
+// flow authenticates against /mcp, attaches the right user to
+// context, and stashes scopes via WithTokenScopes so the in-process
+// dispatcher can enforce per-tool checks.
+func TestMCP_OAuthAccessToken_Authenticates(t *testing.T) {
+	srv, transport := mcpAndOAuthEnabledTestServer(t)
+	user, sessionToken := loginTestUser(t, srv)
+	csrfTok := readCSRFFromCookie(t, srv, sessionToken)
+	clientID := registerTestClient(t, srv, "https://app.test/cb")
+
+	tokens := runAuthCodeFlow(t, srv, sessionToken, csrfTok, clientID,
+		"verifier-mcp-quick-brown-fox-jumps-over-lazy-dog-1234")
+	access, _ := tokens["access_token"].(string)
+	if access == "" {
+		t.Fatalf("missing access token: %v", tokens)
+	}
+
+	req := httptest.NewRequest("POST", "/mcp", strings.NewReader(`{"jsonrpc":"2.0","id":1}`))
+	req.Header.Set("Authorization", "Bearer "+access)
+	req.Header.Set("Content-Type", "application/json")
+	req.RemoteAddr = "192.0.2.1:1234"
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 from OAuth-authed /mcp, got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+	if !transport.Called {
+		t.Fatal("transport stub never called — auth or routing failed silently")
+	}
+	if transport.SeenUserID != user.ID {
+		t.Errorf("user not attached: got %q, want %q", transport.SeenUserID, user.ID)
+	}
+	if !transport.SeenIsToken {
+		t.Error("ctxIsAPIToken should be true for OAuth-authed requests (mirrors PAT path)")
+	}
+	// Scopes must be the JSON-array form tokenScopeAllows expects.
+	// runAuthCodeFlow grants pad:read, so that's what we should see.
+	if !strings.Contains(transport.SeenScopes, "pad:read") {
+		t.Errorf("scopes not stashed correctly; got %q want JSON array containing pad:read", transport.SeenScopes)
+	}
+}
+
+// TestMCP_OAuthAccessToken_AudienceMismatch_Rejected pins the
+// RFC 8707 anti-replay defense: even if a token is otherwise valid,
+// /mcp rejects it when the granted audience doesn't include the
+// resource server's canonical URL.
+//
+// Strategy: mint a token normally (audience matches the OAuth
+// server's canonical = testCanonicalAudience), then swap the
+// Server's oauthServer for one with a DIFFERENT canonical so the
+// MCP gate's AllowedAudience() returns a value that doesn't match
+// the token's stored aud claim. fosite.IntrospectToken still
+// validates the token (storage isn't audience-bound), but our
+// post-introspection check in handleMCPOAuthAuth rejects.
+//
+// This is belt-and-suspenders: in normal operation,
+// audienceMatchingStrategy on the grant side refuses to mint
+// tokens for non-canonical audiences. The resource-server check
+// here defends against scenarios where the auth server is
+// compromised, misconfigured, or shared across multiple resources.
+func TestMCP_OAuthAccessToken_AudienceMismatch_Rejected(t *testing.T) {
+	// Step 1: build a normal MCP+OAuth server matched to
+	// testCanonicalAudience and mint a token through the standard
+	// helper.
+	srv, _ := mcpAndOAuthEnabledTestServer(t)
+	_, sessionToken := loginTestUser(t, srv)
+	csrfTok := readCSRFFromCookie(t, srv, sessionToken)
+	clientID := registerTestClient(t, srv, "https://app.test/cb")
+
+	tokens := runAuthCodeFlow(t, srv, sessionToken, csrfTok, clientID,
+		"verifier-audmismatch-quick-brown-fox-jumps-over-lazy-")
+	access, _ := tokens["access_token"].(string)
+	if access == "" {
+		t.Fatalf("missing access token: %v", tokens)
+	}
+
+	// Step 2: swap in an OAuth server with a different canonical
+	// audience. The token we just minted has
+	// granted_audience=testCanonicalAudience, but the new gate
+	// expects something else.
+	mismatched, err := oauth.NewServer(oauth.Config{
+		Store:           srv.store,
+		HMACSecret:      bytes32ForTest(),
+		AllowedAudience: "https://mcp.unrelated.example/mcp",
+	})
+	if err != nil {
+		t.Fatalf("oauth.NewServer (mismatched): %v", err)
+	}
+	srv.SetOAuthServer(mismatched)
+
+	// Step 3: try to use the token at /mcp — must reject.
+	req := httptest.NewRequest("POST", "/mcp", strings.NewReader(`{}`))
+	req.Header.Set("Authorization", "Bearer "+access)
+	req.RemoteAddr = "192.0.2.1:1234"
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("audience mismatch must produce 401; got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+	// WWW-Authenticate must still point at discovery so the client
+	// knows how to recover.
+	if rr.Header().Get("WWW-Authenticate") == "" {
+		t.Error("audience-mismatch 401 must still emit WWW-Authenticate")
+	}
+}
+
+// TestMCP_OAuthRefreshToken_RejectedAtMCP pins the rule that refresh
+// tokens are NOT valid bearers for resource calls. RFC 6749 §1.5
+// distinguishes refresh tokens (used to obtain access tokens) from
+// access tokens (used to access protected resources). A client that
+// accidentally puts the refresh token in the Authorization header
+// must NOT authenticate.
+func TestMCP_OAuthRefreshToken_RejectedAtMCP(t *testing.T) {
+	srv, _ := mcpAndOAuthEnabledTestServer(t)
+	_, sessionToken := loginTestUser(t, srv)
+	csrfTok := readCSRFFromCookie(t, srv, sessionToken)
+	clientID := registerTestClient(t, srv, "https://app.test/cb")
+
+	tokens := runAuthCodeFlow(t, srv, sessionToken, csrfTok, clientID,
+		"verifier-refresh-token-quick-brown-fox-jumps-over-laz")
+	refresh, _ := tokens["refresh_token"].(string)
+	if refresh == "" {
+		t.Fatalf("missing refresh token: %v", tokens)
+	}
+
+	req := httptest.NewRequest("POST", "/mcp", strings.NewReader(`{}`))
+	req.Header.Set("Authorization", "Bearer "+refresh)
+	req.RemoteAddr = "192.0.2.1:1234"
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("refresh token must NOT authenticate /mcp; got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+}
+
+// TestMCP_RevokedOAuthToken_Rejected pins the rule that revocation
+// takes effect immediately at the resource server. Mints a token,
+// revokes it via /oauth/revoke, then confirms /mcp rejects.
+//
+// This is the primary security guarantee of the family-revocation
+// flow that sub-PRs A + D wired: a revoke call must invalidate
+// every bearer in the chain.
+func TestMCP_RevokedOAuthToken_Rejected(t *testing.T) {
+	srv, _ := mcpAndOAuthEnabledTestServer(t)
+	_, sessionToken := loginTestUser(t, srv)
+	csrfTok := readCSRFFromCookie(t, srv, sessionToken)
+	clientID := registerTestClient(t, srv, "https://app.test/cb")
+
+	tokens := runAuthCodeFlow(t, srv, sessionToken, csrfTok, clientID,
+		"verifier-revoke-mcp-quick-brown-fox-jumps-over-lazy-d")
+	access, _ := tokens["access_token"].(string)
+	if access == "" {
+		t.Fatalf("missing access token: %v", tokens)
+	}
+
+	// Revoke via /oauth/revoke (RFC 7009). Public client → only
+	// client_id needed.
+	rrRevoke := postOAuthForm(srv, "/oauth/revoke", url.Values{
+		"token":     {access},
+		"client_id": {clientID},
+	})
+	if rrRevoke.Code != http.StatusOK {
+		t.Fatalf("revoke: expected 200, got %d (body: %s)", rrRevoke.Code, rrRevoke.Body.String())
+	}
+
+	// Use the revoked token at /mcp — must 401.
+	req := httptest.NewRequest("POST", "/mcp", strings.NewReader(`{}`))
+	req.Header.Set("Authorization", "Bearer "+access)
+	req.RemoteAddr = "192.0.2.1:1234"
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("revoked token must NOT authenticate /mcp; got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+}
+
+// TestMCP_PATPath_StillWorks regresses the original TASK-950 PAT
+// auth path. Sub-PR E added an OAuth branch; the PAT branch must
+// keep working unchanged so existing CLI / Claude-Code-on-self-host
+// users don't see a regression.
+func TestMCP_PATPath_StillWorks(t *testing.T) {
+	srv, transport := mcpAndOAuthEnabledTestServer(t)
+
+	user, err := srv.store.CreateUser(models.UserCreate{
+		Email:    "pat-regression@example.com",
+		Name:     "PAT Regression",
+		Password: "pw-test-12345",
+	})
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	ws, err := srv.store.CreateWorkspace(models.WorkspaceCreate{Name: "PAT Test WS"})
+	if err != nil {
+		t.Fatalf("CreateWorkspace: %v", err)
+	}
+	tok, err := srv.store.CreateAPIToken(user.ID, models.APITokenCreate{
+		Name: "regression-token", WorkspaceID: ws.ID,
+	}, 30, 0)
+	if err != nil {
+		t.Fatalf("CreateAPIToken: %v", err)
+	}
+
+	req := httptest.NewRequest("POST", "/mcp", strings.NewReader(`{}`))
+	req.Header.Set("Authorization", "Bearer "+tok.Token)
+	req.RemoteAddr = "192.0.2.1:1234"
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("PAT path broken by OAuth integration: got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+	if transport.SeenUserID != user.ID {
+		t.Errorf("PAT path should attach user; got %q want %q", transport.SeenUserID, user.ID)
+	}
+}
+
+// TestMCP_OAuthScopeReadOnly_StashesPadReadScope confirms that an
+// OAuth token granted only `pad:read` reaches the in-process
+// dispatcher with that scope stashed in the canonical JSON-array
+// form. Pairs with the tokenScopeAllows pad:* extension — together
+// they ensure that an OAuth read-only token can NOT drive write
+// MCP tools.
+//
+// This test exercises only the MCPBearerAuth-side stash; the
+// dispatcher-side enforcement is covered by
+// TestTokenScopeAllows_PublicWrapper / token_scopes_test.go.
+func TestMCP_OAuthScopeReadOnly_StashesPadReadScope(t *testing.T) {
+	srv, transport := mcpAndOAuthEnabledTestServer(t)
+	_, sessionToken := loginTestUser(t, srv)
+	csrfTok := readCSRFFromCookie(t, srv, sessionToken)
+	clientID := registerTestClient(t, srv, "https://app.test/cb")
+
+	tokens := runAuthCodeFlow(t, srv, sessionToken, csrfTok, clientID,
+		"verifier-readonly-quick-brown-fox-jumps-over-lazy-dog")
+	access, _ := tokens["access_token"].(string)
+
+	req := httptest.NewRequest("POST", "/mcp", strings.NewReader(`{}`))
+	req.Header.Set("Authorization", "Bearer "+access)
+	req.RemoteAddr = "192.0.2.1:1234"
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 (auth passes — scope check is dispatcher-side), got %d", rr.Code)
+	}
+	// runAuthCodeFlow grants `pad:read` (single scope). Stash should
+	// be the JSON-array equivalent.
+	want := `["pad:read"]`
+	if transport.SeenScopes != want {
+		t.Errorf("scopes stash: got %q, want %q", transport.SeenScopes, want)
+	}
+}
+
+// =====================================================================
+// /api/v1/oauth/clients/{id}/public-info (sub-PR E, TASK-1027)
+// =====================================================================
+
+// TestOAuthClientPublicInfo_HappyPath confirms the consent-screen
+// support endpoint returns the four whitelisted fields and matches
+// what was registered.
+func TestOAuthClientPublicInfo_HappyPath(t *testing.T) {
+	srv, _ := oauthEnabledTestServer(t)
+	_, sessionToken := loginTestUser(t, srv)
+
+	// Register via the public DCR endpoint so the test exercises the
+	// full create → read round-trip a real client would do.
+	rrReg := doRequest(srv, "POST", "/oauth/register", map[string]any{
+		"client_name":   "Test Connector",
+		"redirect_uris": []string{"https://app.test/cb", "claude://oauth/callback"},
+		"logo_uri":      "https://test.example/logo.png",
+	})
+	if rrReg.Code != http.StatusCreated {
+		t.Fatalf("register: %d (body: %s)", rrReg.Code, rrReg.Body.String())
+	}
+	var regResp map[string]any
+	parseJSON(t, rrReg, &regResp)
+	clientID, _ := regResp["client_id"].(string)
+	if clientID == "" {
+		t.Fatal("DCR returned empty client_id")
+	}
+
+	rr := doAuthedRequest(srv, "GET",
+		"/api/v1/oauth/clients/"+clientID+"/public-info", nil, sessionToken)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("public-info: %d (body: %s)", rr.Code, rr.Body.String())
+	}
+	var info map[string]any
+	parseJSON(t, rr, &info)
+
+	if got, _ := info["client_id"].(string); got != clientID {
+		t.Errorf("client_id: got %q want %q", got, clientID)
+	}
+	if got, _ := info["client_name"].(string); got != "Test Connector" {
+		t.Errorf("client_name: got %q want Test Connector", got)
+	}
+	if got, _ := info["logo_uri"].(string); got != "https://test.example/logo.png" {
+		t.Errorf("logo_uri: got %q", got)
+	}
+	uris, _ := info["redirect_uris"].([]any)
+	if len(uris) != 2 {
+		t.Errorf("redirect_uris: got %v, want 2 entries", uris)
+	}
+
+	// Leak surface: nothing else should be present.
+	for _, leakField := range []string{
+		"grant_types", "response_types", "token_endpoint_auth_method",
+		"scope", "client_id_issued_at",
+	} {
+		if _, ok := info[leakField]; ok {
+			t.Errorf("public-info leaked %q (whitelist surface only); got %v", leakField, info[leakField])
+		}
+	}
+}
+
+// TestOAuthClientPublicInfo_UnknownClient_404 confirms an unknown
+// client ID gets 404, not 401 (caller IS authenticated; the resource
+// just doesn't exist).
+func TestOAuthClientPublicInfo_UnknownClient_404(t *testing.T) {
+	srv, _ := oauthEnabledTestServer(t)
+	_, sessionToken := loginTestUser(t, srv)
+
+	rr := doAuthedRequest(srv, "GET",
+		"/api/v1/oauth/clients/no-such-client/public-info", nil, sessionToken)
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("expected 404 for unknown client, got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+}
+
+// TestOAuthClientPublicInfo_Unauthenticated_401 confirms the auth
+// gate works — reading client metadata requires a session, so an
+// attacker can't enumerate registered clients pre-login.
+//
+// Setup quirk: pad's auth bootstrap path lets requests through when
+// no users exist (setup_required mode for first-admin creation). We
+// have to seed a user so the system is past setup, even though we
+// don't use that user's session in the actual request.
+func TestOAuthClientPublicInfo_Unauthenticated_401(t *testing.T) {
+	srv, _ := oauthEnabledTestServer(t)
+	// Seed a user so the system isn't in setup_required mode (which
+	// auto-allows everything). Discard the session — we want this
+	// request to land WITHOUT auth to verify the gate.
+	_, _ = loginTestUser(t, srv)
+	clientID := registerTestClient(t, srv, "https://app.test/cb")
+
+	rr := doRequest(srv, "GET",
+		"/api/v1/oauth/clients/"+clientID+"/public-info", nil)
+	if rr.Code == http.StatusOK {
+		t.Errorf("public-info must require auth; got 200 (body: %s)", rr.Body.String())
+	}
+}
+
+// TestOAuthClientPublicInfo_NotMountedOutsideCloudMode confirms the
+// cloud-mode gate covers the endpoint — self-hosted deployments
+// without the OAuth surface don't expose it.
+func TestOAuthClientPublicInfo_NotMountedOutsideCloudMode(t *testing.T) {
+	srv := testServer(t)
+	_, sessionToken := loginTestUser(t, srv)
+
+	rr := doAuthedRequest(srv, "GET",
+		"/api/v1/oauth/clients/anything/public-info", nil, sessionToken)
+	// requireCloudMode returns 404 outside cloud mode.
+	if rr.Code == http.StatusOK {
+		t.Errorf("public-info must NOT be reachable outside cloud mode; got 200")
+	}
+}
+
+// =====================================================================
+// E2E simulation: discovery → DCR → authorize → token → /mcp call
+// =====================================================================
+
+// TestE2E_ClaudeDesktopFlow simulates the sequence Claude Desktop
+// (and any RFC 9728 / RFC 7591 / OAuth 2.1 client) walks on first
+// connect:
+//
+//  1. POST /mcp without a token → 401 + WWW-Authenticate pointing
+//     at the protected-resource discovery doc.
+//  2. GET .well-known/oauth-protected-resource → resource +
+//     authorization_servers.
+//  3. GET .well-known/oauth-authorization-server → endpoint URLs.
+//  4. POST /oauth/register (DCR) → client_id.
+//  5. POST /oauth/authorize/decide (consent stub) → authorization
+//     code.
+//  6. POST /oauth/token → access + refresh tokens.
+//  7. POST /mcp with the access token → 200 + transport reached
+//     with the right user context.
+//
+// Without sub-PR E, the final /mcp call would 401 because
+// MCPBearerAuth only validated PATs. The full chain pinned here is
+// what makes the OAuth surface end-to-end usable; if any single
+// hop breaks, the whole connector experience breaks for every
+// MCP-aware client. Worth one slow integration test.
+func TestE2E_ClaudeDesktopFlow(t *testing.T) {
+	srv, transport := mcpAndOAuthEnabledTestServer(t)
+	user, sessionToken := loginTestUser(t, srv)
+
+	// 1. Unauthenticated /mcp → 401 + WWW-Authenticate.
+	rr1 := doRequest(srv, "POST", "/mcp", map[string]any{
+		"jsonrpc": "2.0", "id": 1, "method": "initialize",
+	})
+	if rr1.Code != http.StatusUnauthorized {
+		t.Fatalf("step 1: expected 401, got %d", rr1.Code)
+	}
+	if !strings.Contains(rr1.Header().Get("WWW-Authenticate"), "resource_metadata=") {
+		t.Fatalf("step 1: missing resource_metadata pointer; got %q", rr1.Header().Get("WWW-Authenticate"))
+	}
+
+	// 2. Protected-resource discovery doc.
+	rr2 := doRequest(srv, "GET", "/.well-known/oauth-protected-resource", nil)
+	if rr2.Code != http.StatusOK {
+		t.Fatalf("step 2: discovery doc %d", rr2.Code)
+	}
+
+	// 3. Authorization-server discovery doc.
+	rr3 := doRequest(srv, "GET", "/.well-known/oauth-authorization-server", nil)
+	if rr3.Code != http.StatusOK {
+		t.Fatalf("step 3: auth-server doc %d", rr3.Code)
+	}
+	var asDoc map[string]any
+	parseJSON(t, rr3, &asDoc)
+	regEndpoint, _ := asDoc["registration_endpoint"].(string)
+	if !strings.Contains(regEndpoint, "/oauth/register") {
+		t.Fatalf("step 3: bad registration_endpoint %q", regEndpoint)
+	}
+
+	// 4. DCR.
+	clientID := registerTestClient(t, srv, "https://app.test/cb")
+
+	// 5 + 6: full authorize → token via the helper.
+	csrfTok := readCSRFFromCookie(t, srv, sessionToken)
+	tokens := runAuthCodeFlow(t, srv, sessionToken, csrfTok, clientID,
+		"verifier-e2e-quick-brown-fox-jumps-over-the-lazy-dog")
+	access, _ := tokens["access_token"].(string)
+	refresh, _ := tokens["refresh_token"].(string)
+	if access == "" || refresh == "" {
+		t.Fatalf("step 6: missing tokens %v", tokens)
+	}
+
+	// 7. /mcp with the access token.
+	req := httptest.NewRequest("POST", "/mcp",
+		strings.NewReader(`{"jsonrpc":"2.0","id":2,"method":"tools/list"}`))
+	req.Header.Set("Authorization", "Bearer "+access)
+	req.Header.Set("Content-Type", "application/json")
+	req.RemoteAddr = "192.0.2.1:1234"
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("step 7: /mcp expected 200, got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+	if !transport.Called {
+		t.Fatal("step 7: transport not reached")
+	}
+	if transport.SeenUserID != user.ID {
+		t.Errorf("step 7: user mismatch — got %q want %q", transport.SeenUserID, user.ID)
+	}
+}
+
+// newTestOAuthServer builds an internal/oauth.Server matched to the
+// test harness's canonical audience (testCanonicalAudience). Used by
+// mcpAndOAuthEnabledTestServer to wire OAuth alongside the MCP stub.
+//
+// Extracted so the audience-mismatch test can build the same shape
+// with a different audience.
+func newTestOAuthServer(t *testing.T, srv *Server) (*oauth.Server, error) {
+	t.Helper()
+	return oauth.NewServer(oauth.Config{
+		Store:           srv.store,
+		HMACSecret:      bytes32ForTest(),
+		AllowedAudience: testCanonicalAudience,
+	})
 }
 
 // sliceEqual reports whether a and b have the same elements in the

--- a/internal/server/handlers_oauth_clients.go
+++ b/internal/server/handlers_oauth_clients.go
@@ -1,0 +1,102 @@
+package server
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/PerpetualSoftware/pad/internal/store"
+)
+
+// /api/v1/oauth/clients/{id}/public-info — non-sensitive OAuth client
+// metadata for the consent screen (TASK-952) and the OAuth-intent
+// banner on /login + /register (TASK-1001, already shipped).
+//
+// Why a separate endpoint vs. reusing the DCR registration response:
+//
+// DCR's response (sub-PR C's handleOAuthRegister) is the one-shot
+// document a registering client receives at registration time. The
+// consent UI later needs the same fields — name, logo, redirect URIs
+// — but on a different device / browser session, AFTER registration.
+// A read endpoint is the only sane way to fetch the row without
+// re-running registration (which would create a new row with a new
+// client_id every time and break the OAuth flow).
+//
+// Auth + scope:
+//
+//   - Logged-in users only. No Bearer-token bypass — the consent
+//     screen runs with a session cookie, the OAuth-intent banner
+//     runs after a login, and the metadata is non-sensitive enough
+//     that requiring auth (vs. open-public) primarily prevents
+//     unauthenticated enumeration of the oauth_clients table.
+//   - Any logged-in user can read any client's public-info. The
+//     four fields here (client_id, client_name, logo_uri, redirect_uris)
+//     are deliberately the only ones — no scopes, no grant types,
+//     no created_at, nothing that could fingerprint OAuth-server
+//     behaviour or leak when an integration was set up.
+//   - Cloud-mode-only: self-hosted deployments don't host an OAuth
+//     surface, so this endpoint serves no purpose there. The route
+//     is mounted under requireCloudMode at the registration site
+//     (server.go), which 404s outside cloud mode.
+//
+// Wire shape:
+//
+//	GET /api/v1/oauth/clients/{id}/public-info
+//	200 OK
+//	{
+//	  "client_id":     "abc-...",
+//	  "client_name":   "Claude Desktop",
+//	  "logo_uri":      "https://anthropic.com/logo.png",
+//	  "redirect_uris": ["claude://oauth/callback", "https://app.claude.ai/cb"]
+//	}
+//	404 — unknown client
+//
+// Why explicit fields rather than embedding the full models.OAuthClient:
+// the model carries grant_types / response_types / token_endpoint_auth_method
+// / scope / created_at, which are operational details of the OAuth
+// server and not relevant to consent UX. A typed response struct
+// pins the leak surface; a future model field (e.g. a client_secret
+// for confidential clients) won't accidentally appear here.
+type oauthClientPublicInfo struct {
+	ClientID     string   `json:"client_id"`
+	ClientName   string   `json:"client_name"`
+	LogoURI      string   `json:"logo_uri,omitempty"`
+	RedirectURIs []string `json:"redirect_uris"`
+}
+
+// handleOAuthClientPublicInfo serves the public metadata for a
+// registered OAuth client. Auth-required at the route level (see
+// the /api/v1 group in server.go); cloud-mode-gated at the route
+// level (requireCloudMode wraps the registration).
+//
+// Returns 404 if the client is unknown — explicitly, not 401, so
+// authorized callers can distinguish "this client doesn't exist"
+// from "you're not allowed to see this client" (the latter never
+// happens — every logged-in user can see every client's public
+// info).
+func (s *Server) handleOAuthClientPublicInfo(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	if id == "" {
+		writeError(w, http.StatusBadRequest, "invalid_request", "client id is required")
+		return
+	}
+
+	client, err := s.store.GetOAuthClient(id)
+	if err != nil {
+		if errors.Is(err, store.ErrOAuthNotFound) {
+			writeError(w, http.StatusNotFound, "not_found", "client not found")
+			return
+		}
+		writeInternalError(w, err)
+		return
+	}
+
+	resp := oauthClientPublicInfo{
+		ClientID:     client.ID,
+		ClientName:   client.Name,
+		LogoURI:      client.LogoURL,
+		RedirectURIs: append([]string(nil), client.RedirectURIs...),
+	}
+	writeJSON(w, http.StatusOK, resp)
+}

--- a/internal/server/middleware_auth.go
+++ b/internal/server/middleware_auth.go
@@ -683,10 +683,21 @@ func clearSessionCookie(w http.ResponseWriter, secure bool) {
 // tokenScopeAllows checks if the token's scopes permit the given HTTP method
 // and path. Scopes are stored as a JSON array of strings.
 //
-// Supported scopes:
+// Supported scopes (PAT vocabulary):
 //   - "*"       — full access
 //   - "read"    — GET/HEAD/OPTIONS only
 //   - "write"   — all methods
+//
+// Supported scopes (OAuth 2.1 / RFC 6749 vocabulary, sub-PR E TASK-1027):
+//   - "pad:read"  — equivalent to PAT "read"
+//   - "pad:write" — equivalent to PAT "write"
+//   - "pad:admin" — equivalent to PAT "*"
+//
+// MCPBearerAuth's OAuth introspection branch translates fosite's
+// space-separated scope string into the same JSON-array stash form
+// PAT auth uses, so the same policy applies to both transports. This
+// keeps MCP tool authorization centralized: a `pad:read` OAuth token
+// can drive read tools; a `pad:write` OAuth token can drive any.
 //
 // Policy (deny-by-default whitelist):
 //   - Empty scope string → allow (legacy DB rows where the column was never
@@ -738,9 +749,9 @@ func tokenScopeAllows(scopesJSON, method, path string) bool {
 	var unknown []string
 	for _, scope := range scopes {
 		switch scope {
-		case "*", "write":
+		case "*", "write", "pad:write", "pad:admin":
 			allowed = true
-		case "read":
+		case "read", "pad:read":
 			if method == http.MethodGet || method == http.MethodHead || method == http.MethodOptions {
 				allowed = true
 			}

--- a/internal/server/middleware_mcp_auth.go
+++ b/internal/server/middleware_mcp_auth.go
@@ -298,15 +298,35 @@ func audienceContains(haystack []string, needle string) bool {
 }
 
 // oauthScopesToJSON serializes fosite's granted-scope slice to the
-// JSON array form tokenScopeAllows expects. nil / empty → `[]` (the
-// "explicit unrestricted legacy form" — but in practice OAuth
-// introspection always returns at least one scope because /authorize
-// requires `scope=` and /authorize/decide grants every requested
-// scope). json.Marshal can't fail on a []string, so we ignore the
-// error and the result string is always a valid JSON array.
+// JSON array form tokenScopeAllows expects.
+//
+// Crucial fail-closed: nil / empty granted scopes map to JSON `null`
+// (which tokenScopeAllows denies via the "scopes == nil" branch),
+// NOT to `[]` (which the same function would accept as the legacy
+// "unrestricted" PAT form). Codex review #375 round 1 caught the
+// bug: OAuth's `scope` parameter is optional per RFC 6749 §3.3, so
+// a client can run the auth-code flow without requesting any scopes
+// — fosite hands back a token with no granted scopes, and without
+// this guard MCPBearerAuth would treat that token as unrestricted
+// (because `[]` is the legacy PAT shape). Mapping empty OAuth
+// scopes to `null` instead routes them through the deny path.
+//
+// Note: in the production setup, sub-PR C's handleOAuthRegister
+// defaults a registered client's scope set to `pad:read pad:write`
+// when DCR omits it, and audienceMatchingStrategy refuses any
+// authorize-side request with an unrecognized audience. So the
+// "empty granted scopes" path is hard to hit through the public
+// endpoints — but defense-in-depth at the resource server is the
+// right policy regardless.
+//
+// json.Marshal can't fail on a []string, so we ignore the error
+// and the result string is always valid JSON.
 func oauthScopesToJSON(scopes []string) string {
 	if len(scopes) == 0 {
-		return "[]"
+		// Fail closed: route empty OAuth scopes through
+		// tokenScopeAllows's deny path, NOT the legacy `[]`
+		// unrestricted-PAT path.
+		return "null"
 	}
 	b, _ := json.Marshal(scopes)
 	return string(b)

--- a/internal/server/middleware_mcp_auth.go
+++ b/internal/server/middleware_mcp_auth.go
@@ -3,8 +3,12 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"log/slog"
 	"net/http"
 	"strings"
+
+	"github.com/ory/fosite"
 )
 
 // MCPBearerAuth is the auth gate for the /mcp Streamable HTTP endpoint.
@@ -22,17 +26,32 @@ import (
 //  3. Valid token → user attached to context via WithCurrentUser; next
 //     handler runs.
 //
-// Note for TASK-951:
+// Two token paths (sub-PR E, TASK-1027):
 //
-// This middleware is the single integration point for OAuth-issued
-// tokens. The PAT-first cut shipping with TASK-950 calls
-// store.ValidateToken (the existing pad_*-prefixed PAT path); when
-// TASK-951 lands, this function gains a branch that tries OAuth
-// introspection first (RFC 7662 lookup against the auth-server's
-// /oauth/introspect endpoint) and falls back to PAT validation. The
-// 401 + WWW-Authenticate envelope below stays identical — only the
-// token-validation step changes. Keeping the auth path centralized
-// here means TASK-951 doesn't need to touch handlers_mcp.go.
+//   - PAT (`pad_<60-hex-chars>`) → store.ValidateToken. The original
+//     TASK-950 path; PATs predate the OAuth server and continue to
+//     work as a developer / CLI escape hatch.
+//   - OAuth opaque (anything else) → s.oauthServer.IntrospectToken.
+//     fosite-issued from the /oauth/token flow that sub-PRs A-D
+//     wired. RFC 8707 audience binding is enforced here so a token
+//     issued for a different resource can't replay against /mcp.
+//
+// The branch is chosen on token shape, not on header content: the
+// PAT prefix-and-length check is cheap and unambiguous (no real
+// OAuth opaque token starts with `pad_` because fosite uses base64
+// of the HMAC, never that prefix). PATs that don't validate fall
+// through to the same 401 envelope the OAuth path uses — clients
+// re-running discovery will see the same WWW-Authenticate pointer
+// either way.
+//
+// Why introspect server-side rather than via the public /oauth/introspect
+// HTTP endpoint: pad-cloud is the resource server AND the auth
+// server, so a roundtrip would be pointless overhead. Calling
+// fosite's IntrospectToken directly skips HTTP parsing, client-auth
+// negotiation, and JSON encoding/decoding — and doesn't require
+// minting a separate "introspection bearer" for the resource server.
+// The public HTTP endpoint exists for spec-compliant external
+// clients but isn't on the hot path here.
 //
 // Why a dedicated middleware (not the existing TokenAuth):
 //
@@ -59,77 +78,238 @@ func (s *Server) MCPBearerAuth(next http.Handler) http.Handler {
 			return
 		}
 
-		// Format gate matching TokenAuth's check (middleware_auth.go:103).
-		// Rejecting at the prefix avoids a DB lookup for obviously-
-		// malformed tokens — a small but meaningful win under any
-		// volume of unauth probes.
-		if !strings.HasPrefix(token, "pad_") || len(token) != 68 {
+		// PAT path: prefix `pad_` + 68 chars total (4 prefix + 64 hex
+		// secret). Cheap shape gate before the DB lookup. Anything
+		// else falls into the OAuth introspection branch.
+		if strings.HasPrefix(token, "pad_") && len(token) == 68 {
+			s.handleMCPPATAuth(w, r, token, next)
+			return
+		}
+
+		// OAuth introspection path. Requires sub-PR B's NewServer
+		// + sub-PRs A/C/D for the storage and flow endpoints to be
+		// wired. Cloud-mode-without-OAuth deployments (rare:
+		// PAD_MCP_PUBLIC_URL set but no encryption-key wiring) get a
+		// clean reject rather than a confusing fall-through.
+		if s.oauthServer == nil {
 			s.writeMCPUnauthorized(w, r, "invalid_token", "Token format not recognized.")
 			return
 		}
-
-		apiToken, err := s.store.ValidateToken(token)
-		if err != nil {
-			// A DB error during token validation is a server-side
-			// problem, not the client's fault. 500 (not 401) so MCP
-			// clients don't churn through reconnect loops on a backend
-			// outage. No WWW-Authenticate header — re-running
-			// discovery wouldn't help.
-			writeError(w, http.StatusInternalServerError, "internal_error", "Token validation failed.")
-			return
-		}
-		if apiToken == nil {
-			s.writeMCPUnauthorized(w, r, "invalid_token", "Token is invalid or expired.")
-			return
-		}
-
-		// Resolve the user. Workspace-scope binding (apiToken.WorkspaceID)
-		// is intentionally NOT pinned here for user-owned PATs — the
-		// downstream RequireWorkspaceAccess middleware (when handlers
-		// run in-process via HTTPHandlerDispatcher) checks
-		// GetWorkspaceMember instead, matching the v0.2 design where
-		// a PAT grants access to whichever workspace its owning user
-		// belongs to. TASK-953 introduces a per-token allowed_workspaces[]
-		// allow-list which IS enforced here once it lands; for now,
-		// membership is the gate.
-		if apiToken.UserID == "" {
-			// Legacy workspace-scoped tokens (no user_id) predate the
-			// user-token refactor. They still authenticate the existing
-			// API surface — see handlers_events.go:52 — but the MCP
-			// transport requires a user identity (every audit log entry,
-			// every "who created this item", etc.). Reject cleanly.
-			s.writeMCPUnauthorized(w, r, "invalid_token", "MCP requires a user-owned token. Legacy workspace-scoped tokens are not supported here.")
-			return
-		}
-		user, err := s.store.GetUser(apiToken.UserID)
-		if err != nil || user == nil {
-			s.writeMCPUnauthorized(w, r, "invalid_token", "Token references an unknown user.")
-			return
-		}
-
-		ctx := WithCurrentUser(r.Context(), user)
-		// Mirror TokenAuth's ctxIsAPIToken signal so downstream
-		// handlers that distinguish session vs token auth see the same
-		// shape they would on /api/v1/*. Cheap, future-proof.
-		ctx = context.WithValue(ctx, ctxIsAPIToken, true)
-		// Stash the token's scopes so the in-process MCP dispatcher
-		// (internal/mcp/dispatch_http.go) can enforce per-tool scope
-		// checks. Without this, a PAT with `["read"]` scope can drive
-		// write MCP tools because the synthesized in-process request
-		// looks pre-authenticated to the handler tree, bypassing
-		// TokenAuth's chain-level scopeAllows check. Codex review
-		// #369 round 1.
-		ctx = WithTokenScopes(ctx, apiToken.Scopes)
-
-		// Surface near-expiry warning headers the same way TokenAuth
-		// does (middleware_auth.go:125). MCP clients can read them,
-		// but more importantly: the existing handlers_auth.go logic
-		// expects the warning to fire consistently regardless of
-		// transport.
-		setTokenExpiryWarning(w, apiToken)
-
-		next.ServeHTTP(w, r.WithContext(ctx))
+		s.handleMCPOAuthAuth(w, r, token, next)
 	})
+}
+
+// handleMCPPATAuth runs the original TASK-950 PAT validation path.
+// Extracted from MCPBearerAuth so the OAuth branch reads cleanly
+// without a deeply-nested if/else; behaviour identical to the
+// pre-sub-PR-E single-path version.
+func (s *Server) handleMCPPATAuth(w http.ResponseWriter, r *http.Request, token string, next http.Handler) {
+	apiToken, err := s.store.ValidateToken(token)
+	if err != nil {
+		// A DB error during token validation is a server-side
+		// problem, not the client's fault. 500 (not 401) so MCP
+		// clients don't churn through reconnect loops on a backend
+		// outage. No WWW-Authenticate header — re-running
+		// discovery wouldn't help.
+		writeError(w, http.StatusInternalServerError, "internal_error", "Token validation failed.")
+		return
+	}
+	if apiToken == nil {
+		s.writeMCPUnauthorized(w, r, "invalid_token", "Token is invalid or expired.")
+		return
+	}
+
+	// Resolve the user. Workspace-scope binding (apiToken.WorkspaceID)
+	// is intentionally NOT pinned here for user-owned PATs — the
+	// downstream RequireWorkspaceAccess middleware (when handlers
+	// run in-process via HTTPHandlerDispatcher) checks
+	// GetWorkspaceMember instead, matching the v0.2 design where
+	// a PAT grants access to whichever workspace its owning user
+	// belongs to. TASK-953 introduces a per-token allowed_workspaces[]
+	// allow-list which IS enforced here once it lands; for now,
+	// membership is the gate.
+	if apiToken.UserID == "" {
+		// Legacy workspace-scoped tokens (no user_id) predate the
+		// user-token refactor. They still authenticate the existing
+		// API surface — see handlers_events.go:52 — but the MCP
+		// transport requires a user identity (every audit log entry,
+		// every "who created this item", etc.). Reject cleanly.
+		s.writeMCPUnauthorized(w, r, "invalid_token", "MCP requires a user-owned token. Legacy workspace-scoped tokens are not supported here.")
+		return
+	}
+	user, err := s.store.GetUser(apiToken.UserID)
+	if err != nil || user == nil {
+		s.writeMCPUnauthorized(w, r, "invalid_token", "Token references an unknown user.")
+		return
+	}
+
+	ctx := WithCurrentUser(r.Context(), user)
+	// Mirror TokenAuth's ctxIsAPIToken signal so downstream
+	// handlers that distinguish session vs token auth see the same
+	// shape they would on /api/v1/*. Cheap, future-proof.
+	ctx = context.WithValue(ctx, ctxIsAPIToken, true)
+	// Stash the token's scopes so the in-process MCP dispatcher
+	// (internal/mcp/dispatch_http.go) can enforce per-tool scope
+	// checks. Without this, a PAT with `["read"]` scope can drive
+	// write MCP tools because the synthesized in-process request
+	// looks pre-authenticated to the handler tree, bypassing
+	// TokenAuth's chain-level scopeAllows check. Codex review
+	// #369 round 1.
+	ctx = WithTokenScopes(ctx, apiToken.Scopes)
+
+	// Surface near-expiry warning headers the same way TokenAuth
+	// does (middleware_auth.go:125). MCP clients can read them,
+	// but more importantly: the existing handlers_auth.go logic
+	// expects the warning to fire consistently regardless of
+	// transport.
+	setTokenExpiryWarning(w, apiToken)
+
+	next.ServeHTTP(w, r.WithContext(ctx))
+}
+
+// handleMCPOAuthAuth runs introspection against the OAuth server
+// for any non-PAT bearer. Validates:
+//
+//   - Token is recognized (storage lookup) and active.
+//   - Token kind is access_token (refresh tokens can't authorize a
+//     resource call — RFC 6749 §1.5 calls them "credentials used to
+//     obtain access tokens," not bearers themselves).
+//   - Granted audience contains the canonical MCP URL (RFC 8707
+//     anti-replay). A token issued for a different resource MUST
+//     NOT pass even if otherwise valid.
+//   - Subject is set + resolves to a real user row.
+//
+// On success, attaches user + scopes to context exactly like the
+// PAT path. The dispatcher's per-tool scope check
+// (TokenScopeAllows from middleware_auth.go) recognizes the OAuth
+// scope vocabulary (pad:read / pad:write / pad:admin) alongside
+// the legacy PAT vocabulary, so MCP tools see one uniform policy
+// regardless of which transport issued the bearer.
+func (s *Server) handleMCPOAuthAuth(w http.ResponseWriter, r *http.Request, token string, next http.Handler) {
+	ar, tokenUse, err := s.oauthServer.IntrospectToken(r.Context(), token)
+	if err != nil {
+		// fosite returns ErrInactiveToken / ErrNotFound for unknown
+		// or revoked tokens; ErrInvalidTokenFormat for "not even an
+		// HMAC value." All of those collapse to the same 401 here —
+		// we don't need to distinguish for the client (re-running
+		// discovery + re-auth handles every recovery path).
+		// Storage errors (DB outage, etc.) ALSO collapse here rather
+		// than to 500: from a security standpoint we can't validate
+		// the token, so the client must NOT proceed; from a client
+		// UX standpoint a transient 401 + retry is no worse than a
+		// 500 + retry, and the spec-shape WWW-Authenticate keeps
+		// discovery agents on rails.
+		if !errors.Is(err, fosite.ErrInactiveToken) && !errors.Is(err, fosite.ErrNotFound) {
+			// Log non-validation errors so ops can spot DB / config
+			// problems via existing alerting.
+			slog.Warn("oauth introspect failed", "error", err)
+		}
+		s.writeMCPUnauthorized(w, r, "invalid_token", "Token is invalid or expired.")
+		return
+	}
+	if ar == nil {
+		// Defensive: fosite's contract says either err or ar is set,
+		// but a mocked dispatcher could violate that. 401 on the
+		// safe side.
+		s.writeMCPUnauthorized(w, r, "invalid_token", "Token is invalid or expired.")
+		return
+	}
+
+	// Refresh tokens are NOT valid bearers for resource calls. RFC
+	// 6749 §1.5: "refresh tokens are credentials used to obtain
+	// access tokens." A client misconfigured to send the refresh
+	// token in the Authorization header would otherwise look
+	// authenticated — reject explicitly.
+	if tokenUse != fosite.AccessToken {
+		s.writeMCPUnauthorized(w, r, "invalid_token", "Refresh tokens cannot authorize MCP requests; use the access token.")
+		return
+	}
+
+	// RFC 8707 audience binding (anti-replay). The canonical
+	// audience is what /authorize/decide grants on every token
+	// (audience.go's audienceMatchingStrategy enforces it on the
+	// grant side); this check is the corresponding resource-server
+	// gate. Without it, a token issued for resource=https://other.example
+	// would silently authorize on /mcp because we have no other
+	// boundary that distinguishes resources. Belt-and-suspenders:
+	// the grant-side check should already prevent foreign audiences,
+	// but the resource server validating its own incoming tokens is
+	// the spec's primary defense.
+	canonical := s.oauthServer.AllowedAudience()
+	if canonical == "" {
+		// Misconfigured server — no canonical audience to check
+		// against. Fail-closed: refuse the token rather than
+		// fall through to "any audience is fine."
+		slog.Error("oauth server has no canonical audience; refusing all OAuth tokens at /mcp")
+		s.writeMCPUnauthorized(w, r, "invalid_token", "OAuth server is misconfigured.")
+		return
+	}
+	if !audienceContains(ar.GetGrantedAudience(), canonical) {
+		s.writeMCPUnauthorized(w, r, "invalid_token", "Token audience does not match this resource.")
+		return
+	}
+
+	// Subject is the pad user ID, set in /authorize/decide via
+	// oauth.NewSession(user.ID). An empty subject would mean the
+	// grant flow shipped without a user identity, which sub-PR C's
+	// renderConsentStub guards against (only logged-in users reach
+	// /authorize/decide). Defense in depth: reject anyway.
+	session := ar.GetSession()
+	if session == nil {
+		s.writeMCPUnauthorized(w, r, "invalid_token", "Token has no session.")
+		return
+	}
+	userID := session.GetSubject()
+	if userID == "" {
+		s.writeMCPUnauthorized(w, r, "invalid_token", "Token has no subject.")
+		return
+	}
+	user, err := s.store.GetUser(userID)
+	if err != nil || user == nil {
+		// User was deleted between grant and use, OR the storage
+		// layer is failing. Either way, the bearer can't represent
+		// a valid identity — reject.
+		s.writeMCPUnauthorized(w, r, "invalid_token", "Token references an unknown user.")
+		return
+	}
+
+	ctx := WithCurrentUser(r.Context(), user)
+	ctx = context.WithValue(ctx, ctxIsAPIToken, true)
+	// Translate fosite's space-separated scope string into the
+	// JSON-array form the existing scope-policy check expects.
+	// tokenScopeAllows recognizes pad:read / pad:write / pad:admin
+	// alongside the legacy PAT scopes, so the same per-method
+	// policy applies to OAuth-issued tokens.
+	ctx = WithTokenScopes(ctx, oauthScopesToJSON(ar.GetGrantedScopes()))
+
+	next.ServeHTTP(w, r.WithContext(ctx))
+}
+
+// audienceContains reports whether haystack contains needle. Tiny
+// helper avoiding the slices package import for one call site (and
+// keeping the test surface for "audience match" in one place).
+func audienceContains(haystack []string, needle string) bool {
+	for _, a := range haystack {
+		if a == needle {
+			return true
+		}
+	}
+	return false
+}
+
+// oauthScopesToJSON serializes fosite's granted-scope slice to the
+// JSON array form tokenScopeAllows expects. nil / empty → `[]` (the
+// "explicit unrestricted legacy form" — but in practice OAuth
+// introspection always returns at least one scope because /authorize
+// requires `scope=` and /authorize/decide grants every requested
+// scope). json.Marshal can't fail on a []string, so we ignore the
+// error and the result string is always a valid JSON array.
+func oauthScopesToJSON(scopes []string) string {
+	if len(scopes) == 0 {
+		return "[]"
+	}
+	b, _ := json.Marshal(scopes)
+	return string(b)
 }
 
 // extractBearer parses an Authorization header value. Returns the

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -768,6 +768,20 @@ func (s *Server) setupRouter() {
 			// Invitations (outside workspace scope)
 			r.Post("/invitations/{code}/accept", s.handleAcceptInvitation)
 
+			// OAuth client public-info (PLAN-943 TASK-1027 sub-PR E).
+			// Read-only consent-screen support for OAuth clients
+			// registered via /oauth/register. Auth-required (inherits
+			// RequireAuth from the parent group); cloud-mode-gated so
+			// self-hosted deployments without an OAuth server don't
+			// expose a hollow endpoint. Returns four non-sensitive
+			// fields (client_id, client_name, logo_uri, redirect_uris)
+			// — see handlers_oauth_clients.go for the full leak-surface
+			// rationale.
+			r.Group(func(r chi.Router) {
+				r.Use(s.requireCloudMode)
+				r.Get("/oauth/clients/{id}/public-info", s.handleOAuthClientPublicInfo)
+			})
+
 			// Share link resolution (outside workspace scope, no auth required)
 			r.Get("/s/{token}", s.handleResolveShareLink)
 

--- a/internal/server/token_scopes_test.go
+++ b/internal/server/token_scopes_test.go
@@ -69,6 +69,30 @@ func TestTokenScopeAllows(t *testing.T) {
 		{"unknown+read blocks POST", `["docs","read"]`, http.MethodPost, "/api/v1/test", false},
 		{"unknown+wildcard still allows POST", `["docs","*"]`, http.MethodPost, "/api/v1/test", true},
 		{"unknown+write still allows DELETE", `["docs","write"]`, http.MethodDelete, "/api/v1/test", true},
+
+		// OAuth scope vocabulary (sub-PR E, TASK-1027). MCPBearerAuth
+		// stashes fosite-issued scopes as JSON arrays alongside PAT
+		// scopes, so the same policy applies. Asserts the read/write/
+		// admin mappings hold under the OAuth namespace.
+		{"pad:read allows GET", `["pad:read"]`, http.MethodGet, "/api/v1/test", true},
+		{"pad:read allows HEAD", `["pad:read"]`, http.MethodHead, "/api/v1/test", true},
+		{"pad:read allows OPTIONS", `["pad:read"]`, http.MethodOptions, "/api/v1/test", true},
+		{"pad:read blocks POST", `["pad:read"]`, http.MethodPost, "/api/v1/test", false},
+		{"pad:read blocks PATCH", `["pad:read"]`, http.MethodPatch, "/api/v1/test", false},
+		{"pad:read blocks DELETE", `["pad:read"]`, http.MethodDelete, "/api/v1/test", false},
+		{"pad:write allows GET", `["pad:write"]`, http.MethodGet, "/api/v1/test", true},
+		{"pad:write allows POST", `["pad:write"]`, http.MethodPost, "/api/v1/test", true},
+		{"pad:write allows DELETE", `["pad:write"]`, http.MethodDelete, "/api/v1/test", true},
+		{"pad:write allows PATCH", `["pad:write"]`, http.MethodPatch, "/api/v1/test", true},
+		{"pad:admin allows POST", `["pad:admin"]`, http.MethodPost, "/api/v1/test", true},
+		{"pad:admin allows DELETE", `["pad:admin"]`, http.MethodDelete, "/api/v1/test", true},
+		// Multi-scope OAuth grants (the realistic shape — DCR clients
+		// usually request all scopes they might need).
+		{"pad:read+pad:write allows POST", `["pad:read","pad:write"]`, http.MethodPost, "/api/v1/test", true},
+		{"pad:read+pad:write allows GET", `["pad:read","pad:write"]`, http.MethodGet, "/api/v1/test", true},
+		// PAT + OAuth scope mixed (defensive — shouldn't happen in
+		// practice but the policy should still work).
+		{"read+pad:write allows POST", `["read","pad:write"]`, http.MethodPost, "/api/v1/test", true},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Sub-PR E of [TASK-951](https://github.com/PerpetualSoftware/pad). Closes the OAuth server build-out by:

- **MCPBearerAuth ↔ OAuth wiring**: `/mcp` now accepts both PATs (`pad_…`) and OAuth-issued opaque access tokens. Server-side fosite introspection (no HTTP roundtrip), with full RFC 8707 audience binding, refresh-token rejection, and revocation enforcement.
- **`/api/v1/oauth/clients/{id}/public-info`**: read-only consent-screen support endpoint returning `{client_id, client_name, logo_uri, redirect_uris}`. Auth-required, cloud-mode-gated, 404s on unknown clients.
- **`pad:*` scope policy**: `tokenScopeAllows` now recognizes `pad:read` / `pad:write` / `pad:admin` alongside the legacy PAT vocabulary, so MCP tool authorization is uniform regardless of which transport issued the bearer.

After merge, **TASK-951 closes** (5/5 sub-PRs done).

## Test plan

- [x] All 10 new MCP+OAuth integration tests pass.
- [x] All 4 public-info tests pass (happy / 404 / 401 / 404-outside-cloud).
- [x] Token scope policy tests extended for `pad:*` scopes (12 new cases).
- [x] PAT regression test (`TestMCP_PATPath_StillWorks`) confirms the original path still works.
- [x] E2E test: simulated Claude Desktop sequence (`401 → discovery → DCR → authorize → token → /mcp 200`) reaches the transport with the right user.
- [x] Audience mismatch produces 401 even when the token is otherwise valid (RFC 8707 anti-replay).
- [x] Refresh tokens cannot authenticate `/mcp` (RFC 6749 §1.5).
- [x] Revoked tokens cannot authenticate `/mcp` (revocation takes effect at the resource server).
- [x] `make check` clean (golangci-lint + go test ./... + npm run build + svelte-check).
- [ ] `/codex review` loop until CLEAN.

## TASK-951 sub-PR roll-up

| Sub-PR | Task     | PR    | Commit    |
|--------|----------|-------|-----------|
| A      | TASK-1023 | #370  | 2a00775   |
| B      | TASK-1024 | #371  | f6eeee4   |
| C      | TASK-1025 | #372  | 48776a3   |
| D      | TASK-1026 | #373  | 4250fb1   |
| E      | TASK-1027 | (this) | (pending) |