### PR TITLE
feat(mcp): per-token rate limit on /mcp (TASK-959)

### DIFF
--- a/internal/server/handlers_mcp_test.go
+++ b/internal/server/handlers_mcp_test.go
@@ -942,20 +942,17 @@ func TestE2E_ClaudeDesktopFlow(t *testing.T) {
 // limit: a single token gets ~burst requests through immediately,
 // then 429s once the bucket is empty.
 //
-// Drives through MCPBearerAuth directly with a stub transport so
-// the test doesn't need to validate a real OAuth/PAT — the rate
-// limiter runs BEFORE auth validation and uses SHA-256(bearer) as
-// the bucket key, so an invalid bearer is enough to exercise the
-// limiter (and the path still 401s afterwards on the auth side,
-// which is fine for the rate-limit assertion).
+// Uses a real PAT so the rate-limit check fires (the limiter runs
+// AFTER ValidateToken — Codex review #378 round 1 — to bound the
+// limiter map to valid-token hashes only).
 func TestMCPRateLimit_PerToken_BucketEnforced(t *testing.T) {
 	srv := mcpEnabledTestServer(t)
+	pat := mustCreatePATForTest(t, srv, "rate-limit-bucket")
 
-	bearer := "Bearer pad_" + strings.Repeat("a", 64) // shape-valid PAT, will fail validation
 	got429 := false
 	for i := 0; i < 30; i++ {
 		req := httptest.NewRequest("POST", "/mcp", strings.NewReader(`{}`))
-		req.Header.Set("Authorization", bearer)
+		req.Header.Set("Authorization", "Bearer "+pat)
 		req.RemoteAddr = "192.0.2.1:1234"
 		rr := httptest.NewRecorder()
 		srv.ServeHTTP(rr, req)
@@ -980,16 +977,16 @@ func TestMCPRateLimit_PerToken_BucketEnforced(t *testing.T) {
 // token.
 //
 // Strategy: drain token1 to 429, then verify token2 still gets
-// through. Both tokens share the same shape-validation failure
-// (the rate limiter doesn't care about validity), so both progress
-// through MCPBearerAuth identically except for the bucket key.
+// through. Two real PATs so the rate-limit check fires for both.
 func TestMCPRateLimit_PerToken_TwoTokensIndependent(t *testing.T) {
 	srv := mcpEnabledTestServer(t)
+	pat1 := mustCreatePATForTest(t, srv, "rate-limit-pat-1")
+	pat2 := mustCreatePATForTest(t, srv, "rate-limit-pat-2")
 
 	hammer := func(bearer string) (rrs []*httptest.ResponseRecorder) {
 		for i := 0; i < 30; i++ {
 			req := httptest.NewRequest("POST", "/mcp", strings.NewReader(`{}`))
-			req.Header.Set("Authorization", bearer)
+			req.Header.Set("Authorization", "Bearer "+bearer)
 			req.RemoteAddr = "192.0.2.1:1234"
 			rr := httptest.NewRecorder()
 			srv.ServeHTTP(rr, req)
@@ -1002,7 +999,7 @@ func TestMCPRateLimit_PerToken_TwoTokensIndependent(t *testing.T) {
 	}
 
 	// Drain token1 until 429.
-	rr1s := hammer("Bearer pad_" + strings.Repeat("1", 64))
+	rr1s := hammer(pat1)
 	if last := rr1s[len(rr1s)-1]; last.Code != http.StatusTooManyRequests {
 		t.Fatalf("token1: expected to hit 429; final status %d", last.Code)
 	}
@@ -1011,7 +1008,7 @@ func TestMCPRateLimit_PerToken_TwoTokensIndependent(t *testing.T) {
 	// worth of requests.
 	for i := 0; i < 20; i++ {
 		req := httptest.NewRequest("POST", "/mcp", strings.NewReader(`{}`))
-		req.Header.Set("Authorization", "Bearer pad_"+strings.Repeat("2", 64))
+		req.Header.Set("Authorization", "Bearer "+pat2)
 		req.RemoteAddr = "192.0.2.1:1234"
 		rr := httptest.NewRecorder()
 		srv.ServeHTTP(rr, req)
@@ -1019,6 +1016,74 @@ func TestMCPRateLimit_PerToken_TwoTokensIndependent(t *testing.T) {
 			t.Errorf("token2 hit 429 at request %d — buckets must be independent per-token", i+1)
 			break
 		}
+	}
+}
+
+// TestMCPRateLimit_InvalidBearerNotRateLimited pins the post-auth-
+// validation property (Codex review #378 round 1): a bearer that
+// fails token validation must NOT consume a per-token bucket. The
+// limiter map only fills with valid-token hashes, bounding memory
+// under random-bearer spam.
+//
+// 50 invalid bearers in a row — each one should 401 cleanly, none
+// should 429 (because validation rejected before the limiter runs).
+func TestMCPRateLimit_InvalidBearerNotRateLimited(t *testing.T) {
+	srv := mcpEnabledTestServer(t)
+
+	// Shape-valid but unknown PAT — passes the prefix+length check,
+	// then fails store.ValidateToken (no row).
+	bearer := "Bearer pad_" + strings.Repeat("a", 64)
+	for i := 0; i < 50; i++ {
+		req := httptest.NewRequest("POST", "/mcp", strings.NewReader(`{}`))
+		req.Header.Set("Authorization", bearer)
+		req.RemoteAddr = "192.0.2.1:1234"
+		rr := httptest.NewRecorder()
+		srv.ServeHTTP(rr, req)
+		if rr.Code == http.StatusTooManyRequests {
+			t.Errorf("invalid bearer must NOT be rate-limited (always 401); got 429 at request %d", i+1)
+			break
+		}
+		if rr.Code != http.StatusUnauthorized {
+			t.Fatalf("invalid bearer: expected 401, got %d (body: %s)", rr.Code, rr.Body.String())
+		}
+	}
+}
+
+// TestMCPRateLimit_LimiterMapBoundedByValidTokensOnly is the
+// memory-DoS regression test for Codex review #378 round 1. After
+// 100 distinct invalid bearers, the per-token limiter map MUST
+// contain zero entries (or only ours from setup). Without the
+// post-auth-validation guard, every distinct bearer would create
+// a new entry in the map, growing it unbounded under random-bearer
+// spam.
+func TestMCPRateLimit_LimiterMapBoundedByValidTokensOnly(t *testing.T) {
+	srv := mcpEnabledTestServer(t)
+
+	if srv.rateLimiters == nil || srv.rateLimiters.MCPPerToken == nil {
+		t.Fatal("rate limiters not configured")
+	}
+
+	// Snapshot map size before.
+	srv.rateLimiters.MCPPerToken.mu.Lock()
+	beforeCount := len(srv.rateLimiters.MCPPerToken.limiters)
+	srv.rateLimiters.MCPPerToken.mu.Unlock()
+
+	// Spam 100 distinct invalid bearers.
+	for i := 0; i < 100; i++ {
+		bearer := "Bearer pad_" + strings.Repeat(string(rune('a'+(i%26))), 64)
+		req := httptest.NewRequest("POST", "/mcp", strings.NewReader(`{}`))
+		req.Header.Set("Authorization", bearer)
+		req.RemoteAddr = "192.0.2.1:1234"
+		srv.ServeHTTP(httptest.NewRecorder(), req)
+	}
+
+	srv.rateLimiters.MCPPerToken.mu.Lock()
+	afterCount := len(srv.rateLimiters.MCPPerToken.limiters)
+	srv.rateLimiters.MCPPerToken.mu.Unlock()
+
+	if afterCount != beforeCount {
+		t.Errorf("limiter map grew under invalid-bearer spam: before=%d, after=%d (must be equal — invalid bearers MUST NOT create entries)",
+			beforeCount, afterCount)
 	}
 }
 
@@ -1081,12 +1146,12 @@ func TestMCPRateLimit_NoBearer_NotCounted(t *testing.T) {
 // no actionable text.
 func TestMCPRateLimit_429EnvelopeShape(t *testing.T) {
 	srv := mcpEnabledTestServer(t)
+	pat := mustCreatePATForTest(t, srv, "rate-limit-envelope")
 
-	bearer := "Bearer pad_" + strings.Repeat("e", 64)
 	var limited *httptest.ResponseRecorder
 	for i := 0; i < 30; i++ {
 		req := httptest.NewRequest("POST", "/mcp", strings.NewReader(`{}`))
-		req.Header.Set("Authorization", bearer)
+		req.Header.Set("Authorization", "Bearer "+pat)
 		req.RemoteAddr = "192.0.2.1:1234"
 		rr := httptest.NewRecorder()
 		srv.ServeHTTP(rr, req)
@@ -1543,6 +1608,41 @@ func callWorkspaceViaOAuth(t *testing.T, srv *Server, access, workspaceSlug stri
 	rr := httptest.NewRecorder()
 	srv.MCPBearerAuth(inner).ServeHTTP(rr, req)
 	return rr
+}
+
+// mustCreatePATForTest creates a real PAT against a fresh user +
+// workspace. Returns the raw token string suitable for the
+// Authorization: Bearer header.
+//
+// Used by the TASK-959 rate-limit tests, which need real (validation-
+// passing) tokens because the post-auth-validation guard means
+// invalid bearers don't fill the limiter map. The label arg lets
+// tests use distinct emails so multiple PATs in one test file don't
+// collide on the unique email constraint.
+func mustCreatePATForTest(t *testing.T, srv *Server, label string) string {
+	t.Helper()
+	user, err := srv.store.CreateUser(models.UserCreate{
+		Email:    label + "@example.com",
+		Name:     "Rate Limit Tester " + label,
+		Password: "pw-test-12345",
+	})
+	if err != nil {
+		t.Fatalf("CreateUser(%q): %v", label, err)
+	}
+	ws, err := srv.store.CreateWorkspace(models.WorkspaceCreate{
+		Name: "Rate WS " + label,
+	})
+	if err != nil {
+		t.Fatalf("CreateWorkspace(%q): %v", label, err)
+	}
+	tok, err := srv.store.CreateAPIToken(user.ID, models.APITokenCreate{
+		Name:        "rate-test-" + label,
+		WorkspaceID: ws.ID,
+	}, 30, 0)
+	if err != nil {
+		t.Fatalf("CreateAPIToken(%q): %v", label, err)
+	}
+	return tok.Token
 }
 
 // mustCreateUserForTest creates a user for tests that need a user

--- a/internal/server/handlers_mcp_test.go
+++ b/internal/server/handlers_mcp_test.go
@@ -935,6 +935,221 @@ func TestE2E_ClaudeDesktopFlow(t *testing.T) {
 }
 
 // =====================================================================
+// Per-token rate limit on /mcp (TASK-959)
+// =====================================================================
+
+// TestMCPRateLimit_PerToken_BucketEnforced verifies the basic rate
+// limit: a single token gets ~burst requests through immediately,
+// then 429s once the bucket is empty.
+//
+// Drives through MCPBearerAuth directly with a stub transport so
+// the test doesn't need to validate a real OAuth/PAT — the rate
+// limiter runs BEFORE auth validation and uses SHA-256(bearer) as
+// the bucket key, so an invalid bearer is enough to exercise the
+// limiter (and the path still 401s afterwards on the auth side,
+// which is fine for the rate-limit assertion).
+func TestMCPRateLimit_PerToken_BucketEnforced(t *testing.T) {
+	srv := mcpEnabledTestServer(t)
+
+	bearer := "Bearer pad_" + strings.Repeat("a", 64) // shape-valid PAT, will fail validation
+	got429 := false
+	for i := 0; i < 30; i++ {
+		req := httptest.NewRequest("POST", "/mcp", strings.NewReader(`{}`))
+		req.Header.Set("Authorization", bearer)
+		req.RemoteAddr = "192.0.2.1:1234"
+		rr := httptest.NewRecorder()
+		srv.ServeHTTP(rr, req)
+		if rr.Code == http.StatusTooManyRequests {
+			got429 = true
+			// Verify Retry-After is set on the rate-limited response.
+			if ra := rr.Header().Get("Retry-After"); ra == "" || ra == "0" {
+				t.Errorf("429 must include Retry-After; got %q", ra)
+			}
+			break
+		}
+	}
+	if !got429 {
+		t.Errorf("expected 429 within 30 requests on a single token bucket (60/min, burst 20); never saw it")
+	}
+}
+
+// TestMCPRateLimit_PerToken_TwoTokensIndependent pins the per-token
+// isolation property: two different bearers MUST have independent
+// buckets, even if the user is the same. Otherwise a runaway agent
+// on one token would burn through the user's quota for every other
+// token.
+//
+// Strategy: drain token1 to 429, then verify token2 still gets
+// through. Both tokens share the same shape-validation failure
+// (the rate limiter doesn't care about validity), so both progress
+// through MCPBearerAuth identically except for the bucket key.
+func TestMCPRateLimit_PerToken_TwoTokensIndependent(t *testing.T) {
+	srv := mcpEnabledTestServer(t)
+
+	hammer := func(bearer string) (rrs []*httptest.ResponseRecorder) {
+		for i := 0; i < 30; i++ {
+			req := httptest.NewRequest("POST", "/mcp", strings.NewReader(`{}`))
+			req.Header.Set("Authorization", bearer)
+			req.RemoteAddr = "192.0.2.1:1234"
+			rr := httptest.NewRecorder()
+			srv.ServeHTTP(rr, req)
+			rrs = append(rrs, rr)
+			if rr.Code == http.StatusTooManyRequests {
+				break
+			}
+		}
+		return
+	}
+
+	// Drain token1 until 429.
+	rr1s := hammer("Bearer pad_" + strings.Repeat("1", 64))
+	if last := rr1s[len(rr1s)-1]; last.Code != http.StatusTooManyRequests {
+		t.Fatalf("token1: expected to hit 429; final status %d", last.Code)
+	}
+
+	// Token2 must still be fresh — zero 429s in its first burst-
+	// worth of requests.
+	for i := 0; i < 20; i++ {
+		req := httptest.NewRequest("POST", "/mcp", strings.NewReader(`{}`))
+		req.Header.Set("Authorization", "Bearer pad_"+strings.Repeat("2", 64))
+		req.RemoteAddr = "192.0.2.1:1234"
+		rr := httptest.NewRecorder()
+		srv.ServeHTTP(rr, req)
+		if rr.Code == http.StatusTooManyRequests {
+			t.Errorf("token2 hit 429 at request %d — buckets must be independent per-token", i+1)
+			break
+		}
+	}
+}
+
+// TestMCPRateLimit_DiscoveryDocsExempt verifies the per-token
+// limiter is NOT applied to /.well-known/oauth-* paths. Discovery
+// docs are polled by MCP clients before any token exists; they
+// shouldn't share a bucket and they shouldn't even attempt to look
+// for a Bearer header. The rate limiter sits inside MCPBearerAuth,
+// which only runs on /mcp — so by construction the discovery
+// routes never hit it. This test pins that wiring.
+func TestMCPRateLimit_DiscoveryDocsExempt(t *testing.T) {
+	srv := mcpEnabledTestServer(t)
+
+	// Hammer the protected-resource discovery doc 50 times; expect
+	// zero 429s.
+	for i := 0; i < 50; i++ {
+		req := httptest.NewRequest("GET", "/.well-known/oauth-protected-resource", nil)
+		req.RemoteAddr = "192.0.2.1:1234"
+		rr := httptest.NewRecorder()
+		srv.ServeHTTP(rr, req)
+		if rr.Code == http.StatusTooManyRequests {
+			t.Errorf("discovery doc must NOT be rate-limited; got 429 at request %d", i+1)
+			break
+		}
+		if rr.Code != http.StatusOK {
+			t.Fatalf("discovery doc: expected 200, got %d", rr.Code)
+		}
+	}
+}
+
+// TestMCPRateLimit_NoBearer_NotCounted verifies that a request
+// without a Bearer header fails with 401 BEFORE the rate-limit
+// check (because the limiter key would be empty otherwise, and
+// every no-bearer request would share a bucket — defeating the
+// per-token model).
+//
+// Concretely: 50 no-bearer requests should all 401, never 429.
+func TestMCPRateLimit_NoBearer_NotCounted(t *testing.T) {
+	srv := mcpEnabledTestServer(t)
+
+	for i := 0; i < 50; i++ {
+		req := httptest.NewRequest("POST", "/mcp", strings.NewReader(`{}`))
+		req.RemoteAddr = "192.0.2.1:1234"
+		rr := httptest.NewRecorder()
+		srv.ServeHTTP(rr, req)
+		if rr.Code == http.StatusTooManyRequests {
+			t.Errorf("no-bearer request must NOT be rate-limited (always 401); got 429 at request %d", i+1)
+			break
+		}
+	}
+}
+
+// TestMCPRateLimit_429EnvelopeShape pins the wire shape of the 429
+// response: MCP-style `{error: {code, message}}` JSON envelope plus
+// the standard rate-limit headers (Retry-After, X-RateLimit-Limit,
+// X-RateLimit-Remaining).
+//
+// MCP clients (Claude Desktop, Cursor) parse this body to surface
+// the message; without the envelope they'd render a raw 429 with
+// no actionable text.
+func TestMCPRateLimit_429EnvelopeShape(t *testing.T) {
+	srv := mcpEnabledTestServer(t)
+
+	bearer := "Bearer pad_" + strings.Repeat("e", 64)
+	var limited *httptest.ResponseRecorder
+	for i := 0; i < 30; i++ {
+		req := httptest.NewRequest("POST", "/mcp", strings.NewReader(`{}`))
+		req.Header.Set("Authorization", bearer)
+		req.RemoteAddr = "192.0.2.1:1234"
+		rr := httptest.NewRecorder()
+		srv.ServeHTTP(rr, req)
+		if rr.Code == http.StatusTooManyRequests {
+			limited = rr
+			break
+		}
+	}
+	if limited == nil {
+		t.Fatal("never hit 429")
+	}
+
+	if ra := limited.Header().Get("Retry-After"); ra == "" {
+		t.Error("Retry-After header missing")
+	}
+	if l := limited.Header().Get("X-RateLimit-Limit"); l == "" {
+		t.Error("X-RateLimit-Limit header missing")
+	}
+	if r := limited.Header().Get("X-RateLimit-Remaining"); r != "0" {
+		t.Errorf("X-RateLimit-Remaining: got %q, want 0", r)
+	}
+	if ct := limited.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type: got %q, want application/json", ct)
+	}
+
+	var body map[string]any
+	parseJSON(t, limited, &body)
+	errObj, _ := body["error"].(map[string]any)
+	if errObj == nil {
+		t.Fatalf("body missing error object: %v", body)
+	}
+	if code, _ := errObj["code"].(string); code != "rate_limited" {
+		t.Errorf("error.code: got %q, want %q", code, "rate_limited")
+	}
+}
+
+// TestHashTokenForLimiter pins the helper's deterministic, length-
+// stable, non-collision-by-prefix output: same input → same hash;
+// different inputs → different hashes; empty input → empty-input
+// hash (caller is expected to skip empty bearers, but the helper
+// itself must not panic).
+func TestHashTokenForLimiter(t *testing.T) {
+	a := hashTokenForLimiter("token-a")
+	b := hashTokenForLimiter("token-b")
+	a2 := hashTokenForLimiter("token-a")
+
+	if len(a) != 64 {
+		t.Errorf("hash length: got %d, want 64 (sha256 hex)", len(a))
+	}
+	if a != a2 {
+		t.Error("hash not deterministic across calls")
+	}
+	if a == b {
+		t.Error("different inputs should produce different hashes")
+	}
+	// Empty bearer: helper still produces a hash (caller skips empty
+	// before calling, but defense-in-depth — no panic).
+	if got := hashTokenForLimiter(""); len(got) != 64 {
+		t.Errorf("empty bearer hash length: got %d, want 64", len(got))
+	}
+}
+
+// =====================================================================
 // Workspace allow-list gate (TASK-953)
 // =====================================================================
 

--- a/internal/server/handlers_mcp_test.go
+++ b/internal/server/handlers_mcp_test.go
@@ -1049,6 +1049,60 @@ func TestMCPRateLimit_InvalidBearerNotRateLimited(t *testing.T) {
 	}
 }
 
+// TestMCPRateLimit_OAuthRefreshTokenNotCounted pins Codex review
+// #378 round 2: the OAuth-path rate limit must run AFTER all
+// validation gates (refresh-vs-access, audience match, user lookup)
+// so an active-but-not-authorized bearer (e.g. refresh token used
+// against /mcp) doesn't create a limiter bucket. Without this guard
+// an attacker holding a valid refresh token could spam /mcp 429
+// times to fill a bucket and then stop receiving the intended 401
+// invalid_token error.
+//
+// Strategy: mint a real refresh token via the full OAuth flow,
+// hammer /mcp with it 50 times, assert every response is 401 (not
+// 429) AND the limiter map size is unchanged.
+func TestMCPRateLimit_OAuthRefreshTokenNotCounted(t *testing.T) {
+	srv, _ := mcpAndOAuthEnabledTestServer(t)
+	_, sessionToken := loginTestUser(t, srv)
+	csrfTok := readCSRFFromCookie(t, srv, sessionToken)
+	clientID := registerTestClient(t, srv, "https://app.test/cb")
+
+	tokens := runAuthCodeFlow(t, srv, sessionToken, csrfTok, clientID,
+		"verifier-rl-refresh-quick-brown-fox-jumps-over-the-l")
+	refresh, _ := tokens["refresh_token"].(string)
+	if refresh == "" {
+		t.Fatalf("missing refresh token: %v", tokens)
+	}
+
+	srv.rateLimiters.MCPPerToken.mu.Lock()
+	beforeCount := len(srv.rateLimiters.MCPPerToken.limiters)
+	srv.rateLimiters.MCPPerToken.mu.Unlock()
+
+	for i := 0; i < 50; i++ {
+		req := httptest.NewRequest("POST", "/mcp", strings.NewReader(`{}`))
+		req.Header.Set("Authorization", "Bearer "+refresh)
+		req.RemoteAddr = "192.0.2.1:1234"
+		rr := httptest.NewRecorder()
+		srv.ServeHTTP(rr, req)
+		if rr.Code == http.StatusTooManyRequests {
+			t.Errorf("refresh-token bearer must NOT be rate-limited (always 401); got 429 at request %d", i+1)
+			break
+		}
+		if rr.Code != http.StatusUnauthorized {
+			t.Fatalf("refresh-token bearer: expected 401, got %d (body: %s)", rr.Code, rr.Body.String())
+		}
+	}
+
+	srv.rateLimiters.MCPPerToken.mu.Lock()
+	afterCount := len(srv.rateLimiters.MCPPerToken.limiters)
+	srv.rateLimiters.MCPPerToken.mu.Unlock()
+
+	if afterCount != beforeCount {
+		t.Errorf("limiter map grew under refresh-token spam: before=%d, after=%d (must be equal — rate-limiter must run AFTER refresh-token rejection)",
+			beforeCount, afterCount)
+	}
+}
+
 // TestMCPRateLimit_LimiterMapBoundedByValidTokensOnly is the
 // memory-DoS regression test for Codex review #378 round 1. After
 // 100 distinct invalid bearers, the per-token limiter map MUST

--- a/internal/server/middleware_mcp_auth.go
+++ b/internal/server/middleware_mcp_auth.go
@@ -121,18 +121,6 @@ func (s *Server) handleMCPPATAuth(w http.ResponseWriter, r *http.Request, token 
 		return
 	}
 
-	// Per-token rate limit (TASK-959). Runs AFTER ValidateToken
-	// rather than before so the limiter map only fills with
-	// valid-token hashes — Codex review #378 round 1 caught the
-	// memory-DoS risk where a pre-auth check would create a new
-	// bucket for every distinct bearer string (including random
-	// garbage spam). Auth validation is a single DB lookup; the
-	// CPU cost of running it before rate limiting is small enough
-	// that the bounded-map property wins on the trade-off.
-	if !s.checkMCPRateLimit(w, r, token) {
-		return
-	}
-
 	// Resolve the user. Workspace-scope binding (apiToken.WorkspaceID)
 	// is intentionally NOT pinned here for user-owned PATs — the
 	// downstream RequireWorkspaceAccess middleware (when handlers
@@ -154,6 +142,19 @@ func (s *Server) handleMCPPATAuth(w http.ResponseWriter, r *http.Request, token 
 	user, err := s.store.GetUser(apiToken.UserID)
 	if err != nil || user == nil {
 		s.writeMCPUnauthorized(w, r, "invalid_token", "Token references an unknown user.")
+		return
+	}
+
+	// Per-token rate limit (TASK-959). Runs AFTER ALL PAT validation
+	// gates pass: ValidateToken, the legacy-workspace-scoped guard,
+	// and the GetUser lookup. Codex review #378 round 3 caught the
+	// gap where rate-limiting between ValidateToken and these later
+	// gates would create limiter buckets for active-but-not-
+	// authorized tokens (legacy workspace-scoped tokens with no
+	// UserID, tokens whose user row was deleted between issuance
+	// and use). Symmetric to the OAuth path's positioning — both
+	// paths run the rate limit at the very end of their happy path.
+	if !s.checkMCPRateLimit(w, r, token) {
 		return
 	}
 

--- a/internal/server/middleware_mcp_auth.go
+++ b/internal/server/middleware_mcp_auth.go
@@ -229,14 +229,6 @@ func (s *Server) handleMCPOAuthAuth(w http.ResponseWriter, r *http.Request, toke
 		return
 	}
 
-	// Per-token rate limit (TASK-959). Runs AFTER fosite validates
-	// the token — same reasoning as the PAT path: limiter map only
-	// fills with valid-token hashes, bounding memory under bearer-
-	// string spam (Codex review #378 round 1).
-	if !s.checkMCPRateLimit(w, r, token) {
-		return
-	}
-
 	// Refresh tokens are NOT valid bearers for resource calls. RFC
 	// 6749 §1.5: "refresh tokens are credentials used to obtain
 	// access tokens." A client misconfigured to send the refresh
@@ -292,6 +284,20 @@ func (s *Server) handleMCPOAuthAuth(w http.ResponseWriter, r *http.Request, toke
 		// layer is failing. Either way, the bearer can't represent
 		// a valid identity — reject.
 		s.writeMCPUnauthorized(w, r, "invalid_token", "Token references an unknown user.")
+		return
+	}
+
+	// Per-token rate limit (TASK-959). Runs AFTER ALL OAuth
+	// validation gates pass: introspection, refresh-vs-access
+	// check, RFC 8707 audience match, subject presence, user
+	// lookup. Codex review #378 round 2 caught the gap where
+	// rate-limiting between IntrospectToken and these later gates
+	// would create limiter buckets for active-but-not-authorized
+	// tokens (refresh tokens used as bearers, wrong-audience
+	// tokens, deleted users). Moving the check to the very end
+	// of the OAuth happy path ensures the limiter map only
+	// contains tokens that would otherwise reach next.ServeHTTP.
+	if !s.checkMCPRateLimit(w, r, token) {
 		return
 	}
 

--- a/internal/server/middleware_mcp_auth.go
+++ b/internal/server/middleware_mcp_auth.go
@@ -80,27 +80,6 @@ func (s *Server) MCPBearerAuth(next http.Handler) http.Handler {
 			return
 		}
 
-		// Rate limit per-token BEFORE auth validation. Reasons:
-		//
-		//   - The limiter key is SHA-256(bearer), so the bucket
-		//     identifies a specific token regardless of whether
-		//     it's valid right now (revoked tokens still hash to
-		//     the same key).
-		//   - A token making 60 invalid-after-revoke calls in a
-		//     minute is just as expensive as 60 valid calls — the
-		//     auth path does a DB lookup either way. Limiting before
-		//     auth validation defends the validation step itself.
-		//   - An attacker rotating bearer values (random garbage)
-		//     hits a different key per request, so this gate
-		//     doesn't catch unauthenticated spam — but the limiter
-		//     map's retention bounds the memory footprint, and the
-		//     authentication path then 401s the spam cheaply.
-		//
-		// PLAN-943 TASK-959.
-		if !s.checkMCPRateLimit(w, r, token) {
-			return
-		}
-
 		// PAT path: prefix `pad_` + 68 chars total (4 prefix + 64 hex
 		// secret). Cheap shape gate before the DB lookup. Anything
 		// else falls into the OAuth introspection branch.
@@ -139,6 +118,18 @@ func (s *Server) handleMCPPATAuth(w http.ResponseWriter, r *http.Request, token 
 	}
 	if apiToken == nil {
 		s.writeMCPUnauthorized(w, r, "invalid_token", "Token is invalid or expired.")
+		return
+	}
+
+	// Per-token rate limit (TASK-959). Runs AFTER ValidateToken
+	// rather than before so the limiter map only fills with
+	// valid-token hashes — Codex review #378 round 1 caught the
+	// memory-DoS risk where a pre-auth check would create a new
+	// bucket for every distinct bearer string (including random
+	// garbage spam). Auth validation is a single DB lookup; the
+	// CPU cost of running it before rate limiting is small enough
+	// that the bounded-map property wins on the trade-off.
+	if !s.checkMCPRateLimit(w, r, token) {
 		return
 	}
 
@@ -235,6 +226,14 @@ func (s *Server) handleMCPOAuthAuth(w http.ResponseWriter, r *http.Request, toke
 		// but a mocked dispatcher could violate that. 401 on the
 		// safe side.
 		s.writeMCPUnauthorized(w, r, "invalid_token", "Token is invalid or expired.")
+		return
+	}
+
+	// Per-token rate limit (TASK-959). Runs AFTER fosite validates
+	// the token — same reasoning as the PAT path: limiter map only
+	// fills with valid-token hashes, bounding memory under bearer-
+	// string spam (Codex review #378 round 1).
+	if !s.checkMCPRateLimit(w, r, token) {
 		return
 	}
 

--- a/internal/server/middleware_mcp_auth.go
+++ b/internal/server/middleware_mcp_auth.go
@@ -80,6 +80,27 @@ func (s *Server) MCPBearerAuth(next http.Handler) http.Handler {
 			return
 		}
 
+		// Rate limit per-token BEFORE auth validation. Reasons:
+		//
+		//   - The limiter key is SHA-256(bearer), so the bucket
+		//     identifies a specific token regardless of whether
+		//     it's valid right now (revoked tokens still hash to
+		//     the same key).
+		//   - A token making 60 invalid-after-revoke calls in a
+		//     minute is just as expensive as 60 valid calls — the
+		//     auth path does a DB lookup either way. Limiting before
+		//     auth validation defends the validation step itself.
+		//   - An attacker rotating bearer values (random garbage)
+		//     hits a different key per request, so this gate
+		//     doesn't catch unauthenticated spam — but the limiter
+		//     map's retention bounds the memory footprint, and the
+		//     authentication path then 401s the spam cheaply.
+		//
+		// PLAN-943 TASK-959.
+		if !s.checkMCPRateLimit(w, r, token) {
+			return
+		}
+
 		// PAT path: prefix `pad_` + 68 chars total (4 prefix + 64 hex
 		// secret). Cheap shape gate before the DB lookup. Anything
 		// else falls into the OAuth introspection branch.

--- a/internal/server/middleware_ratelimit.go
+++ b/internal/server/middleware_ratelimit.go
@@ -1,6 +1,9 @@
 package server
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"log/slog"
 	"math"
 	"net"
@@ -144,6 +147,20 @@ type RateLimiters struct {
 	// valid challenge_token can grind through the small recovery-code
 	// space before the 5-minute challenge expires.
 	RecoveryCode *ipRateLimiter
+	// MCPPerToken caps requests per individual bearer token on /mcp.
+	// PLAN-943 / TASK-959: per-token (not per-IP) buckets so that
+	// office-NAT-shared users don't share a quota, and a runaway
+	// agent on one token can't burn through a user's entire quota
+	// for other tokens. Keyed by SHA-256(bearer) so the raw token
+	// never lives in the limiter map.
+	//
+	// 60 requests / minute / token, burst 20. Sized for chatty
+	// usage (Claude Desktop sends `tools/list` + a handful of tool
+	// calls per session) without leaving headroom for sustained
+	// abuse. Retention 5 minutes — long enough to remember a quiet
+	// token between calls, short enough that the limiter doesn't
+	// hold dead tokens forever after revocation.
+	MCPPerToken *ipRateLimiter
 }
 
 // NewRateLimiters creates rate limiters with sensible defaults.
@@ -210,13 +227,32 @@ func NewRateLimiters() *RateLimiters {
 			Rate:  rate.Limit(6.0 / 3600.0),
 			Burst: 6,
 		}),
+		// MCP per-token: 60 req/min sustained, burst 20. PLAN-943
+		// TASK-959. 60/60 = 1 req/sec — written with explicit math
+		// rather than `rate.Limit(1)` so adjacent limiters' "X /
+		// 60" idiom stays consistent at a glance, but staticcheck
+		// SA4000 flags identical-numerator-denominator division —
+		// hence the explicit literal.
+		// The 5-minute retention lets the limiter forget dead
+		// tokens reasonably quickly after revocation while still
+		// surviving idle periods between tool calls.
+		MCPPerToken: newIPRateLimiter(rateLimitConfig{
+			Rate:      rate.Limit(1.0), // 60 req/min = 1 req/sec
+			Burst:     20,
+			Retention: 5 * time.Minute,
+		}),
 	}
 }
 
 // Stop drains the cleanup goroutine of every limiter in the bundle. Called
 // from Server.Stop() so test cleanup (and graceful shutdown) doesn't leak
-// the 9 forever-sleeping goroutines NewRateLimiters spawns. Safe to call
+// the forever-sleeping goroutines NewRateLimiters spawns. Safe to call
 // on a nil receiver and idempotent per-limiter via stopOnce. See BUG-851.
+//
+// New limiters added to RateLimiters MUST be added to this list too —
+// otherwise their cleanup goroutine leaks across Server lifetimes,
+// reproducing BUG-851 the first time a test runner exhausts its
+// goroutine quota.
 func (rls *RateLimiters) Stop() {
 	if rls == nil {
 		return
@@ -231,6 +267,7 @@ func (rls *RateLimiters) Stop() {
 		rls.API,
 		rls.Search,
 		rls.RecoveryCode,
+		rls.MCPPerToken,
 	} {
 		rl.Stop() // nil-safe via the receiver guard in (*ipRateLimiter).Stop
 	}
@@ -376,6 +413,87 @@ func clientIP(r *http.Request) string {
 		return host
 	}
 	return r.RemoteAddr
+}
+
+// checkMCPRateLimit applies the per-token bucket on /mcp requests
+// (PLAN-943 TASK-959). Returns true if the request is allowed
+// through; false if rate-limited (in which case the 429 response
+// has already been written and the caller MUST return immediately).
+//
+// bearer is the raw Authorization Bearer value extracted by
+// extractBearer. We hash it with SHA-256 before using it as a
+// limiter map key so the raw token never lives in the limiter's
+// memory across requests.
+//
+// Behaviour:
+//
+//   - Empty bearer (caller bug; the auth path should have rejected
+//     before reaching here) → allow through to keep the limiter
+//     from masking a real bug.
+//   - Limiters not initialized (testServer with no NewRateLimiters
+//     call) → allow through.
+//   - Bucket exhausted → 429 with Retry-After + MCP error envelope.
+//
+// Per-token (not per-IP / per-user) keying matches the task spec:
+// office-NAT'd users don't share a quota, and a runaway agent on
+// one token can't burn the user's quota for other tokens.
+func (s *Server) checkMCPRateLimit(w http.ResponseWriter, r *http.Request, bearer string) bool {
+	if s.rateLimiters == nil || s.rateLimiters.MCPPerToken == nil || bearer == "" {
+		return true
+	}
+	key := hashTokenForLimiter(bearer)
+	l := s.rateLimiters.MCPPerToken.getLimiter(key)
+	if !l.Allow() {
+		slog.Warn("mcp rate limited", "path", r.URL.Path, "limiter", "mcp_per_token")
+		writeMCPRateLimit(w, r, s.rateLimiters.MCPPerToken.config)
+		return false
+	}
+	return true
+}
+
+// hashTokenForLimiter returns a SHA-256 hex digest of the bearer
+// token, suitable for use as a rate-limiter map key. The hash means
+// the limiter's in-memory map never holds the raw token even though
+// it persists for the bucket's retention window. Hex (not base64)
+// because the limiter's other keys are IP strings and a uniform
+// hex encoding makes log scrapers' life easier.
+func hashTokenForLimiter(bearer string) string {
+	sum := sha256.Sum256([]byte(bearer))
+	return hex.EncodeToString(sum[:])
+}
+
+// writeMCPRateLimit emits a 429 response with the MCP-shaped JSON
+// envelope plus the standard rate-limit headers. Mirrors
+// writeRateLimitResponse's headers but uses the MCP error envelope
+// instead of the API one — MCP clients (Claude Desktop, Cursor, …)
+// expect `{error: {code, message}}` and the standard envelope's
+// `{error: {...}}` happens to match, but emitting via the MCP path
+// keeps the contract clearer if either side ever diverges.
+//
+// Retry-After is computed from the limiter's refill rate (the same
+// math writeRateLimitResponse uses) so a client doing exponential
+// backoff hits a sane window.
+func writeMCPRateLimit(w http.ResponseWriter, _ *http.Request, cfg rateLimitConfig) {
+	retryAfter := int(math.Ceil(1.0 / float64(cfg.Rate)))
+	if retryAfter < 1 {
+		retryAfter = 1
+	}
+	if retryAfter > 3600 {
+		retryAfter = 3600
+	}
+	limitPerMinute := int(math.Ceil(float64(cfg.Rate) * 60))
+
+	w.Header().Set("Retry-After", strconv.Itoa(retryAfter))
+	w.Header().Set("X-RateLimit-Limit", strconv.Itoa(limitPerMinute))
+	w.Header().Set("X-RateLimit-Remaining", "0")
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusTooManyRequests)
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"error": map[string]string{
+			"code":    "rate_limited",
+			"message": "Too many requests. Please try again later.",
+		},
+	})
 }
 
 // writeRateLimitResponse sends a 429 response with Retry-After and X-RateLimit-* headers.


### PR DESCRIPTION
## Summary

Adds a per-token rate limit to /mcp's auth middleware. Closes PLAN-943's "runaway agent burns through user quota" gap.

- **60 req/min / token, burst 20** — chatty enough for real agent traffic, tight enough to bound abuse.
- **Per-token, not per-IP** — office-NAT'd users don't share buckets; a runaway agent on one token doesn't drain a user's other tokens.
- **Limiter key = SHA-256(bearer)** — raw tokens never live in the limiter map.
- **5-minute retention** — long enough to survive idle gaps between tool calls; short enough to forget revoked tokens quickly.
- **Discovery docs exempt** (`/.well-known/oauth-*` aren't gated; they're polled before any token exists).
- **No-bearer requests 401 before the limiter** — bare-bones DoS doesn't fill a (necessarily-empty) bucket key.

## 429 wire shape

- `Retry-After: <seconds>` (computed from the refill rate).
- `X-RateLimit-Limit`, `X-RateLimit-Remaining: 0`.
- Body: MCP-shaped `{"error": {"code": "rate_limited", "message": "..."}}` so Claude Desktop / Cursor surface a sensible message.

## Test plan

- [x] `make check` clean (lint + go test ./... + npm run build + svelte-check).
- [x] 6 new TestMCPRateLimit_* / TestHashTokenForLimiter tests pass.
- [x] All existing OAuth + MCP tests still pass.
- [ ] `/codex review` loop until CLEAN.

## Out of scope

- LLM-cost-aware quotas (some tools pull large item sets and burn far more than one bucket-tick).
- Real-time abuse detection.
- Per-IP pre-auth limiter on /mcp (defends against invalid-bearer flooding) — a follow-up if real abuse appears.