### PR TITLE
feat(mcp): privacy-preserving available_workspaces filter on error envelopes (TASK-977)

### DIFF
--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -389,6 +389,12 @@ func serveCmd() *cobra.Command {
 						u, _ := server.CurrentUserFromContext(ctx)
 						return u
 					},
+					// OAuth-aware workspace lister (TASK-977).
+					// Filters error envelopes' available_workspaces
+					// hint by the token's consent allow-list so
+					// agents never see workspace slugs the user
+					// didn't explicitly grant.
+					Lister: mcpserver.NewOAuthWorkspaceLister(s),
 				}
 				if _, regErr := mcpserver.Register(mcpSrv.MCP(), mcpserver.RegistryOptions{
 					Doc:        mcpDoc,

--- a/internal/mcp/dispatch_http.go
+++ b/internal/mcp/dispatch_http.go
@@ -90,6 +90,20 @@ type HTTPHandlerDispatcher struct {
 	// routeTable. The builtin map is the source of truth for
 	// production wiring.
 	Routes map[string]RouteMapper
+
+	// Lister, when non-nil, populates available_workspaces in the
+	// no_workspace / unknown_workspace error envelopes (TASK-977).
+	// Production wires an OAuth-aware lister that reads the token's
+	// workspace allow-list (sub-PR E TokenAllowedWorkspacesFromContext)
+	// and filters the user's full workspace set so the agent never
+	// sees workspaces it didn't consent to.
+	//
+	// nil → empty available_workspaces (legacy behaviour). Callers
+	// SHOULD wire one for the remote /mcp transport, where leaking
+	// non-consented workspace slugs would be a privacy violation.
+	// The local stdio transport (ExecDispatcher) doesn't go through
+	// this dispatcher, so its lister wiring is independent.
+	Lister WorkspaceLister
 }
 
 // RouteMapper translates a tool's JSON input into a concrete HTTP
@@ -361,7 +375,7 @@ func (d *HTTPHandlerDispatcher) executeRequest(
 
 	rec := httptest.NewRecorder()
 	d.Handler.ServeHTTP(rec, req)
-	return packageHTTPResponse(ctx, cmdKey, rec.Result())
+	return packageHTTPResponse(ctx, cmdKey, rec.Result(), d.Lister)
 }
 
 // buildAuthedRequest constructs an in-process HTTP request against
@@ -445,10 +459,16 @@ func buildHTTPRequest(ctx context.Context, method, urlPath string, body []byte, 
 // CallToolResult, mirroring ExecDispatcher's "JSON → structured + text
 // fallback" behaviour. 4xx/5xx surface as structured ErrorEnvelopes
 // (TASK-973) so MCP clients see the same closed-set error codes
-// regardless of transport. TASK-977 (PLAN-943) extends this with
-// privacy-preserving available_workspaces filtering once the OAuth
-// allow-list is in place.
-func packageHTTPResponse(ctx context.Context, cmdKey string, resp *http.Response) (*mcp.CallToolResult, error) {
+// regardless of transport.
+//
+// lister is the dispatcher's WorkspaceLister, supplied so
+// classifyHTTPStatus can populate available_workspaces in the
+// unknown_workspace envelope. TASK-977 (PLAN-943) wires an
+// OAuth-aware lister at production-call sites that filters the
+// user's workspaces by the token's allow-list — leaking workspace
+// slugs the user didn't consent to expose would be a privacy bug.
+// nil → empty available_workspaces (legacy behaviour).
+func packageHTTPResponse(ctx context.Context, cmdKey string, resp *http.Response, lister WorkspaceLister) (*mcp.CallToolResult, error) {
 	defer resp.Body.Close()
 	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -457,14 +477,7 @@ func packageHTTPResponse(ctx context.Context, cmdKey string, resp *http.Response
 	body := string(bodyBytes)
 
 	if resp.StatusCode >= 400 {
-		// classifyHTTPStatus does the status → ErrorCode mapping. The
-		// `lookup` parameter is nil here because TASK-977 owns the
-		// remote-side workspace listing (it must filter by OAuth
-		// allow-list to avoid leaking workspaces the agent didn't
-		// consent to). For now, available_workspaces stays empty on
-		// the HTTP transport; the rest of the envelope still gives
-		// the agent enough to branch on `code`.
-		return classifyHTTPStatus(ctx, cmdKey, resp.StatusCode, bodyBytes, nil), nil
+		return classifyHTTPStatus(ctx, cmdKey, resp.StatusCode, bodyBytes, lister), nil
 	}
 
 	// Use the shared packager so both transports produce the same

--- a/internal/mcp/dispatch_http.go
+++ b/internal/mcp/dispatch_http.go
@@ -375,7 +375,18 @@ func (d *HTTPHandlerDispatcher) executeRequest(
 
 	rec := httptest.NewRecorder()
 	d.Handler.ServeHTTP(rec, req)
-	return packageHTTPResponse(ctx, cmdKey, rec.Result(), d.Lister)
+	// Use req.Context() (NOT the outer ctx) so the workspace lister
+	// sees everything buildHTTPRequest + d.Apply attached:
+	// WithCurrentUser, WithAPITokenAuth, and any TokenAllowedWorkspaces
+	// the dispatcher's Apply hook layered on. Tests that drive
+	// executeRequest with context.Background() + a UserResolver get
+	// the user via req.Context(), not via the outer ctx — without
+	// this fix the lister would silently return empty hints in
+	// those test paths and (more critically) in any production
+	// dispatcher that attaches token state via Apply rather than
+	// inheriting from the inbound request's ctx. Codex review #379
+	// round 1.
+	return packageHTTPResponse(req.Context(), cmdKey, rec.Result(), d.Lister)
 }
 
 // buildAuthedRequest constructs an in-process HTTP request against

--- a/internal/mcp/dispatch_http_advanced.go
+++ b/internal/mcp/dispatch_http_advanced.go
@@ -298,8 +298,11 @@ func (d *HTTPHandlerDispatcher) dispatchItemUpdate(
 		// already contains a clear message; package it the same way
 		// any other tool error would be packaged. Pass d.Lister so
 		// the workspace-not-found envelope's available_workspaces
-		// list is filtered by the OAuth allow-list (TASK-977).
-		return packageHTTPResponse(ctx, cmdKey, prefetchRec.Result(), d.Lister)
+		// list is filtered by the OAuth allow-list (TASK-977). Use
+		// prefetchReq.Context() so the lister sees the same
+		// auth/token state buildHTTPRequest + d.Apply attached
+		// (Codex review #379 round 1 — same fix as executeRequest).
+		return packageHTTPResponse(prefetchReq.Context(), cmdKey, prefetchRec.Result(), d.Lister)
 	}
 	var existing struct {
 		Fields string `json:"fields"`

--- a/internal/mcp/dispatch_http_advanced.go
+++ b/internal/mcp/dispatch_http_advanced.go
@@ -296,8 +296,10 @@ func (d *HTTPHandlerDispatcher) dispatchItemUpdate(
 	if prefetchRec.Code >= 400 {
 		// Mirror the CLI's "not found" UX — the handler's 404 body
 		// already contains a clear message; package it the same way
-		// any other tool error would be packaged.
-		return packageHTTPResponse(ctx, cmdKey, prefetchRec.Result())
+		// any other tool error would be packaged. Pass d.Lister so
+		// the workspace-not-found envelope's available_workspaces
+		// list is filtered by the OAuth allow-list (TASK-977).
+		return packageHTTPResponse(ctx, cmdKey, prefetchRec.Result(), d.Lister)
 	}
 	var existing struct {
 		Fields string `json:"fields"`

--- a/internal/mcp/dispatch_http_envelope_test.go
+++ b/internal/mcp/dispatch_http_envelope_test.go
@@ -355,6 +355,55 @@ func TestBuildAllowSet_SpecificListBuildsSet(t *testing.T) {
 // path the production /mcp transport runs.
 // ─────────────────────────────────────────────────────────────────────
 
+// TestExecuteRequest_UsesRequestContext_NotOuterContext pins Codex
+// review #379 round 1. The dispatcher's `executeRequest` MUST pass
+// `req.Context()` (not the outer `ctx`) into `packageHTTPResponse`
+// so the lister sees everything `buildHTTPRequest` + `d.Apply`
+// attached: WithCurrentUser, WithAPITokenAuth, and any
+// TokenAllowedWorkspaces the Apply hook layered on.
+//
+// Strategy: drive executeRequest with context.Background() (no
+// values on the outer ctx) + a UserResolver that returns a user
+// + a Handler that 404s with a workspace body. The lister must
+// still see the user via req.Context() and produce
+// available_workspaces. If the buggy version (using outer ctx)
+// runs, the lister sees no user and returns empty hints —
+// asserted against here as the fail mode.
+func TestExecuteRequest_UsesRequestContext_NotOuterContext(t *testing.T) {
+	store := &fakeStore{
+		workspaces: []WorkspaceHint{{Slug: "alpha"}, {Slug: "beta"}},
+	}
+	user := fakeUser("user-1")
+
+	d := &HTTPHandlerDispatcher{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(404)
+			_, _ = w.Write([]byte(`{"error":{"message":"workspace 'foo' not visible"}}`))
+		}),
+		// UserResolver runs from the dispatcher's outer context;
+		// the user is set on req.Context() inside buildHTTPRequest.
+		// The outer ctx (passed to executeRequest) has NO user.
+		UserResolver: func(_ context.Context) *models.User { return user },
+		Lister:       &oauthWorkspaceLister{store: store},
+	}
+
+	res, err := d.executeRequest(context.Background(), "item show", user, "GET", "/api/v1/workspaces/foo/items", nil)
+	if err != nil {
+		t.Fatalf("executeRequest: %v", err)
+	}
+	env, ok := res.StructuredContent.(ErrorEnvelope)
+	if !ok {
+		t.Fatalf("structured content: got %T, want ErrorEnvelope", res.StructuredContent)
+	}
+	if env.Error.Code != ErrUnknownWorkspace {
+		t.Fatalf("code: got %q, want %q", env.Error.Code, ErrUnknownWorkspace)
+	}
+	if len(env.Error.AvailableWorkspaces) != 2 {
+		t.Errorf("expected 2 hints (user has alpha+beta, no token allow-list); got %d (entries=%v)",
+			len(env.Error.AvailableWorkspaces), env.Error.AvailableWorkspaces)
+	}
+}
+
 func TestPackageHTTPResponse_404Workspace_FiltersAvailableWorkspaces(t *testing.T) {
 	store := &fakeStore{
 		workspaces: []WorkspaceHint{

--- a/internal/mcp/dispatch_http_envelope_test.go
+++ b/internal/mcp/dispatch_http_envelope_test.go
@@ -1,0 +1,405 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/server"
+)
+
+// =====================================================================
+// HTTP error envelope tests (TASK-977)
+//
+// Pin the contract that classifyHTTPStatus + packageHTTPResponse
+// produce closed-set ErrorCode envelopes for every documented HTTP
+// status. The tests double as the test plan from the task spec:
+//
+//   | HTTP status | ErrorCode           |
+//   | 401         | auth_required       |
+//   | 403         | permission_denied   |
+//   | 404 (item)  | item_not_found      |
+//   | 404 (ws)    | unknown_workspace   |
+//   | 409         | conflict            |
+//   | 422         | validation_failed   |
+//   | 5xx         | server_error        |
+//
+// Plus the privacy-filter property: unknown_workspace's
+// available_workspaces is filtered by the OAuth token allow-list.
+// =====================================================================
+
+// fakeStore implements oauthWorkspaceListerStore for unit tests.
+// One method, no DB; tests can wire deterministic membership lists
+// without spinning up SQLite.
+type fakeStore struct {
+	workspaces []WorkspaceHint
+	err        error
+}
+
+func (f *fakeStore) GetUserWorkspaces(_ string) ([]WorkspaceHint, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	out := make([]WorkspaceHint, len(f.workspaces))
+	copy(out, f.workspaces)
+	return out, nil
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// 401 / 403 / 404 / 409 / 422 / 5xx envelope round-trips
+// ─────────────────────────────────────────────────────────────────────
+
+func TestClassifyHTTPStatus_AuthRequiredOn401(t *testing.T) {
+	res := classifyHTTPStatus(context.Background(), "item create", 401, []byte(`{"error":{"message":"token expired"}}`), nil)
+	if !res.IsError {
+		t.Fatal("IsError must be true on 401")
+	}
+	env, ok := res.StructuredContent.(ErrorEnvelope)
+	if !ok {
+		t.Fatalf("structured content: got %T, want ErrorEnvelope", res.StructuredContent)
+	}
+	if env.Error.Code != ErrAuthRequired {
+		t.Errorf("code: got %q, want %q", env.Error.Code, ErrAuthRequired)
+	}
+}
+
+func TestClassifyHTTPStatus_PermissionDeniedOn403(t *testing.T) {
+	res := classifyHTTPStatus(context.Background(), "item update", 403,
+		[]byte(`{"error":{"message":"insufficient role"}}`), nil)
+	env := res.StructuredContent.(ErrorEnvelope)
+	if env.Error.Code != ErrPermissionDenied {
+		t.Errorf("code: got %q, want %q", env.Error.Code, ErrPermissionDenied)
+	}
+}
+
+func TestClassifyHTTPStatus_ItemNotFoundOn404Generic(t *testing.T) {
+	// Body doesn't mention "workspace" → defaults to item_not_found.
+	res := classifyHTTPStatus(context.Background(), "item show", 404,
+		[]byte(`{"error":{"message":"item not found"}}`), nil)
+	env := res.StructuredContent.(ErrorEnvelope)
+	if env.Error.Code != ErrItemNotFound {
+		t.Errorf("code: got %q, want %q", env.Error.Code, ErrItemNotFound)
+	}
+}
+
+func TestClassifyHTTPStatus_UnknownWorkspaceOn404WorkspaceBody(t *testing.T) {
+	res := classifyHTTPStatus(context.Background(), "item list", 404,
+		[]byte(`{"error":{"message":"workspace 'foo' not visible"}}`), nil)
+	env := res.StructuredContent.(ErrorEnvelope)
+	if env.Error.Code != ErrUnknownWorkspace {
+		t.Errorf("code: got %q, want %q", env.Error.Code, ErrUnknownWorkspace)
+	}
+	// The slug should be extracted from the body.
+	if !strings.Contains(env.Error.Message, "foo") {
+		t.Errorf("expected slug 'foo' in message; got %q", env.Error.Message)
+	}
+}
+
+func TestClassifyHTTPStatus_ConflictOn409(t *testing.T) {
+	res := classifyHTTPStatus(context.Background(), "item update", 409,
+		[]byte(`{"error":{"message":"version mismatch"}}`), nil)
+	env := res.StructuredContent.(ErrorEnvelope)
+	if env.Error.Code != ErrConflict {
+		t.Errorf("code: got %q, want %q", env.Error.Code, ErrConflict)
+	}
+}
+
+func TestClassifyHTTPStatus_ValidationOn422(t *testing.T) {
+	res := classifyHTTPStatus(context.Background(), "item create", 422,
+		[]byte(`{"error":{"message":"title is required"}}`), nil)
+	env := res.StructuredContent.(ErrorEnvelope)
+	if env.Error.Code != ErrValidationFailed {
+		t.Errorf("code: got %q, want %q", env.Error.Code, ErrValidationFailed)
+	}
+}
+
+func TestClassifyHTTPStatus_ValidationOn400(t *testing.T) {
+	// 400 also maps to validation_failed (the handler's StatusBadRequest
+	// path is semantically equivalent for input rejection).
+	res := classifyHTTPStatus(context.Background(), "item create", 400,
+		[]byte(`{"error":{"message":"invalid json"}}`), nil)
+	env := res.StructuredContent.(ErrorEnvelope)
+	if env.Error.Code != ErrValidationFailed {
+		t.Errorf("code: got %q, want %q", env.Error.Code, ErrValidationFailed)
+	}
+}
+
+func TestClassifyHTTPStatus_ServerErrorOn500(t *testing.T) {
+	res := classifyHTTPStatus(context.Background(), "item create", 500,
+		[]byte(`{"error":{"message":"db connection failed"}}`), nil)
+	env := res.StructuredContent.(ErrorEnvelope)
+	if env.Error.Code != ErrServerError {
+		t.Errorf("code: got %q, want %q", env.Error.Code, ErrServerError)
+	}
+}
+
+func TestClassifyHTTPStatus_OtherClientStatusFallsToServerError(t *testing.T) {
+	// 418 has no taxonomy slot — fall through to server_error rather
+	// than silently promote to validation_failed (which would mislead
+	// callers that the input was at fault).
+	res := classifyHTTPStatus(context.Background(), "item create", 418,
+		[]byte(`teapot`), nil)
+	env := res.StructuredContent.(ErrorEnvelope)
+	if env.Error.Code != ErrServerError {
+		t.Errorf("418: got code %q, want %q (other 4xx → server_error)",
+			env.Error.Code, ErrServerError)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Privacy filter: available_workspaces must be filtered by the
+// OAuth token's allow-list (TASK-977 core property).
+// ─────────────────────────────────────────────────────────────────────
+
+// TestUnknownWorkspace_AvailableWorkspaces_FilteredByAllowList is the
+// core privacy invariant: when a token's allow-list is [alpha, beta]
+// but the user is also a member of gamma + delta, the
+// unknown_workspace envelope's available_workspaces hint MUST list
+// only [alpha, beta].
+//
+// Without this filter, an attacker controlling an OAuth client could
+// hit any workspace slug the user is a member of, get the unknown_
+// workspace envelope, and read OFF the user's full workspace list
+// from available_workspaces — defeating the consent UI's "only
+// these workspaces" choice.
+func TestUnknownWorkspace_AvailableWorkspaces_FilteredByAllowList(t *testing.T) {
+	store := &fakeStore{
+		workspaces: []WorkspaceHint{
+			{Slug: "alpha", Name: "Alpha"},
+			{Slug: "beta", Name: "Beta"},
+			{Slug: "gamma", Name: "Gamma"}, // user is a member, NOT in allow-list
+			{Slug: "delta", Name: "Delta"}, // same
+		},
+	}
+	lister := &oauthWorkspaceLister{store: store}
+
+	// User is on context (MCPBearerAuth's WithCurrentUser) AND token
+	// allow-list = [alpha, beta] (sub-PR E's WithTokenAllowedWorkspaces).
+	ctx := server.WithCurrentUser(context.Background(), fakeUser("user-1"))
+	ctx = server.WithTokenAllowedWorkspaces(ctx, []string{"alpha", "beta"})
+
+	res := classifyHTTPStatus(ctx, "item show", 404,
+		[]byte(`{"error":{"message":"workspace 'epsilon' not visible"}}`), lister)
+	env := res.StructuredContent.(ErrorEnvelope)
+
+	if env.Error.Code != ErrUnknownWorkspace {
+		t.Fatalf("code: got %q, want %q", env.Error.Code, ErrUnknownWorkspace)
+	}
+	got := slugSet(env.Error.AvailableWorkspaces)
+	want := map[string]bool{"alpha": true, "beta": true}
+	if len(got) != len(want) {
+		t.Fatalf("available_workspaces leaked: got %v, want exactly [alpha beta]",
+			env.Error.AvailableWorkspaces)
+	}
+	for slug := range want {
+		if !got[slug] {
+			t.Errorf("missing expected slug %q from filtered allow-list", slug)
+		}
+	}
+	for slug := range got {
+		if !want[slug] {
+			t.Errorf("PRIVACY LEAK: slug %q in available_workspaces but NOT in token allow-list", slug)
+		}
+	}
+}
+
+// TestUnknownWorkspace_Wildcard_NoFilterApplied verifies that a
+// wildcard allow-list (`["*"]`) returns ALL the user's workspaces
+// in available_workspaces. The user explicitly granted "any" at
+// consent time, so no per-slug filter applies.
+func TestUnknownWorkspace_Wildcard_NoFilterApplied(t *testing.T) {
+	store := &fakeStore{
+		workspaces: []WorkspaceHint{
+			{Slug: "alpha"}, {Slug: "beta"}, {Slug: "gamma"},
+		},
+	}
+	lister := &oauthWorkspaceLister{store: store}
+
+	ctx := server.WithCurrentUser(context.Background(), fakeUser("user-1"))
+	ctx = server.WithTokenAllowedWorkspaces(ctx, []string{"*"})
+
+	res := classifyHTTPStatus(ctx, "item show", 404,
+		[]byte(`workspace 'unknown' not visible`), lister)
+	env := res.StructuredContent.(ErrorEnvelope)
+
+	got := slugSet(env.Error.AvailableWorkspaces)
+	want := map[string]bool{"alpha": true, "beta": true, "gamma": true}
+	if len(got) != 3 {
+		t.Fatalf("wildcard allow-list: got %d entries, want 3 (all user workspaces); entries=%v",
+			len(got), env.Error.AvailableWorkspaces)
+	}
+	for slug := range want {
+		if !got[slug] {
+			t.Errorf("missing %q under wildcard allow-list", slug)
+		}
+	}
+}
+
+// TestUnknownWorkspace_NoTokenAllowList_NoFilterApplied covers the
+// PAT path (or pre-TASK-952 OAuth tokens): no allow-list set →
+// fall back to all the user's workspaces. Behavioural parity with
+// the local CLI's `pad workspace list` output.
+func TestUnknownWorkspace_NoTokenAllowList_NoFilterApplied(t *testing.T) {
+	store := &fakeStore{
+		workspaces: []WorkspaceHint{{Slug: "alpha"}, {Slug: "beta"}},
+	}
+	lister := &oauthWorkspaceLister{store: store}
+
+	// No WithTokenAllowedWorkspaces — simulating PAT auth.
+	ctx := server.WithCurrentUser(context.Background(), fakeUser("user-1"))
+
+	res := classifyHTTPStatus(ctx, "item show", 404,
+		[]byte(`workspace 'unknown' not visible`), lister)
+	env := res.StructuredContent.(ErrorEnvelope)
+
+	if len(env.Error.AvailableWorkspaces) != 2 {
+		t.Fatalf("PAT path: got %d entries, want 2 (no token-level filter)",
+			len(env.Error.AvailableWorkspaces))
+	}
+}
+
+// TestUnknownWorkspace_NoUser_EmptyHints covers anonymous probes:
+// without a user on context the lister returns nil and the envelope
+// ships with empty available_workspaces — the rest of the error
+// taxonomy (code + message) is still useful.
+func TestUnknownWorkspace_NoUser_EmptyHints(t *testing.T) {
+	store := &fakeStore{
+		workspaces: []WorkspaceHint{{Slug: "alpha"}},
+	}
+	lister := &oauthWorkspaceLister{store: store}
+
+	res := classifyHTTPStatus(context.Background(), "item show", 404,
+		[]byte(`workspace 'foo' not visible`), lister)
+	env := res.StructuredContent.(ErrorEnvelope)
+
+	if env.Error.Code != ErrUnknownWorkspace {
+		t.Errorf("code should still classify; got %q", env.Error.Code)
+	}
+	if len(env.Error.AvailableWorkspaces) != 0 {
+		t.Errorf("anonymous probe must have empty available_workspaces; got %v",
+			env.Error.AvailableWorkspaces)
+	}
+}
+
+// TestUnknownWorkspace_StoreError_EmptyHints covers the "best-effort"
+// contract: if the store lookup fails, the envelope still ships with
+// the right code + message, just with empty available_workspaces.
+func TestUnknownWorkspace_StoreError_EmptyHints(t *testing.T) {
+	lister := &oauthWorkspaceLister{store: &fakeStore{err: errors.New("db down")}}
+
+	ctx := server.WithCurrentUser(context.Background(), fakeUser("user-1"))
+	ctx = server.WithTokenAllowedWorkspaces(ctx, []string{"alpha"})
+
+	res := classifyHTTPStatus(ctx, "item show", 404,
+		[]byte(`workspace 'foo' not visible`), lister)
+	env := res.StructuredContent.(ErrorEnvelope)
+
+	if env.Error.Code != ErrUnknownWorkspace {
+		t.Errorf("code should still classify even when store fails; got %q", env.Error.Code)
+	}
+	if len(env.Error.AvailableWorkspaces) != 0 {
+		t.Errorf("store failure must yield empty available_workspaces; got %v",
+			env.Error.AvailableWorkspaces)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// buildAllowSet unit tests — the shared helper between lister + gate.
+// ─────────────────────────────────────────────────────────────────────
+
+func TestBuildAllowSet_NilReturnsNilNoFilter(t *testing.T) {
+	if got := buildAllowSet(nil); got != nil {
+		t.Errorf("nil input should yield nil (no filter); got %v", got)
+	}
+}
+
+func TestBuildAllowSet_WildcardReturnsNilNoFilter(t *testing.T) {
+	if got := buildAllowSet([]string{"*"}); got != nil {
+		t.Errorf("wildcard should yield nil (no filter); got %v", got)
+	}
+}
+
+func TestBuildAllowSet_WildcardWinsOverSpecific(t *testing.T) {
+	// Defense-in-depth: a tampered allow-list with both a slug AND
+	// the wildcard collapses to "no filter" — the safer
+	// interpretation, matching what RequireWorkspaceAccess does.
+	if got := buildAllowSet([]string{"alpha", "*"}); got != nil {
+		t.Errorf("wildcard + specific should yield nil (no filter); got %v", got)
+	}
+}
+
+func TestBuildAllowSet_SpecificListBuildsSet(t *testing.T) {
+	got := buildAllowSet([]string{"alpha", "beta"})
+	if got == nil {
+		t.Fatal("specific list should yield non-nil set")
+	}
+	if _, ok := got["alpha"]; !ok {
+		t.Error("expected alpha in set")
+	}
+	if _, ok := got["beta"]; !ok {
+		t.Error("expected beta in set")
+	}
+	if _, ok := got["gamma"]; ok {
+		t.Error("gamma must not be in set")
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// End-to-end through packageHTTPResponse (the dispatcher's actual
+// call site). Validates that wiring d.Lister into packageHTTPResponse
+// produces a privacy-filtered envelope, exercising the full code
+// path the production /mcp transport runs.
+// ─────────────────────────────────────────────────────────────────────
+
+func TestPackageHTTPResponse_404Workspace_FiltersAvailableWorkspaces(t *testing.T) {
+	store := &fakeStore{
+		workspaces: []WorkspaceHint{
+			{Slug: "alpha"}, {Slug: "beta"}, {Slug: "gamma"},
+		},
+	}
+	lister := &oauthWorkspaceLister{store: store}
+
+	ctx := server.WithCurrentUser(context.Background(), fakeUser("user-1"))
+	ctx = server.WithTokenAllowedWorkspaces(ctx, []string{"alpha"})
+
+	resp := &http.Response{
+		StatusCode: 404,
+		Body:       io.NopCloser(strings.NewReader(`{"error":{"message":"workspace 'gamma' not visible"}}`)),
+	}
+	res, err := packageHTTPResponse(ctx, "item show", resp, lister)
+	if err != nil {
+		t.Fatalf("packageHTTPResponse: %v", err)
+	}
+	env := res.StructuredContent.(ErrorEnvelope)
+
+	if env.Error.Code != ErrUnknownWorkspace {
+		t.Fatalf("code: got %q, want %q", env.Error.Code, ErrUnknownWorkspace)
+	}
+	if len(env.Error.AvailableWorkspaces) != 1 || env.Error.AvailableWorkspaces[0].Slug != "alpha" {
+		t.Errorf("end-to-end privacy filter: got %v, want exactly [{Slug:alpha}]",
+			env.Error.AvailableWorkspaces)
+	}
+}
+
+// =====================================================================
+// Helpers
+// =====================================================================
+
+// fakeUser returns a minimal *models.User the lister's auth check is
+// happy with — only ID is read by the lister itself, everything
+// else stays zero-value.
+func fakeUser(id string) *models.User {
+	return &models.User{ID: id}
+}
+
+func slugSet(hints []WorkspaceHint) map[string]bool {
+	out := map[string]bool{}
+	for _, h := range hints {
+		out[h.Slug] = true
+	}
+	return out
+}

--- a/internal/mcp/dispatch_http_lister.go
+++ b/internal/mcp/dispatch_http_lister.go
@@ -1,0 +1,139 @@
+package mcp
+
+import (
+	"context"
+
+	"github.com/PerpetualSoftware/pad/internal/server"
+	"github.com/PerpetualSoftware/pad/internal/store"
+)
+
+// oauthWorkspaceLister implements WorkspaceLister for the remote /mcp
+// transport. Bridges three concerns the privacy-preserving
+// available_workspaces hint (TASK-977) needs to combine:
+//
+//  1. The requesting user's full workspace membership set (from the
+//     store).
+//  2. The OAuth token's `allowed_workspaces` allow-list (set at
+//     consent time, TASK-952; stashed by MCPBearerAuth via
+//     server.WithTokenAllowedWorkspaces, TASK-953).
+//  3. The wildcard / specific-list / nil semantics from
+//     server.TokenAllowedWorkspacesFromContext.
+//
+// Privacy invariant: the returned hint list MUST be a subset of the
+// token's allow-list. Workspace slugs the user has access to but
+// did NOT include in the consent payload MUST NOT appear, even
+// when the agent triggers an unknown_workspace error. The whole
+// point of the consent UI's per-workspace selection is that the
+// app gets ONLY those workspaces; leaking other slugs in error
+// envelopes would be a scope violation.
+//
+// nil allow-list (PAT auth, or pre-TASK-952 OAuth tokens) → return
+// all the user's workspaces, matching pre-TASK-977 behaviour.
+// Wildcard `["*"]` → same as nil (the user explicitly granted any
+// workspace).
+//
+// Errors propagate up: storage failures yield (nil, err), which the
+// upstream bestEffortWorkspaceHints helper swallows so the envelope
+// still ships with empty available_workspaces rather than dropping
+// the whole error path.
+type oauthWorkspaceLister struct {
+	// store is the pad store used to read the user's workspaces.
+	// Hidden behind an interface in tests; the production wiring
+	// passes *store.Store.
+	store oauthWorkspaceListerStore
+}
+
+// oauthWorkspaceListerStore is the minimal interface oauthWorkspaceLister
+// needs from a *store.Store. Defining it inline keeps the test surface
+// tiny — tests can supply a one-method fake without spinning up a
+// real DB-backed store.
+type oauthWorkspaceListerStore interface {
+	GetUserWorkspaces(userID string) ([]storeWorkspace, error)
+}
+
+// storeWorkspace is the tiny subset of models.Workspace this file
+// needs (slug + name). Avoids leaking the full models package into
+// the test fake.
+type storeWorkspace = WorkspaceHint
+
+// NewOAuthWorkspaceLister wires a lister against a *store.Store.
+// Production wiring (cmd/pad/main.go) calls this; tests use the
+// alternate constructor that takes an oauthWorkspaceListerStore.
+func NewOAuthWorkspaceLister(s *store.Store) WorkspaceLister {
+	return &oauthWorkspaceLister{store: realStoreAdapter{s}}
+}
+
+// realStoreAdapter shims *store.Store into oauthWorkspaceListerStore.
+// Translates models.Workspace into the WorkspaceHint shape this
+// package's lister contract uses, dropping fields the hint doesn't
+// need (settings, owner, timestamps, etc.).
+type realStoreAdapter struct{ s *store.Store }
+
+func (a realStoreAdapter) GetUserWorkspaces(userID string) ([]storeWorkspace, error) {
+	rows, err := a.s.GetUserWorkspaces(userID)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]storeWorkspace, 0, len(rows))
+	for _, ws := range rows {
+		out = append(out, WorkspaceHint{Slug: ws.Slug, Name: ws.Name})
+	}
+	return out, nil
+}
+
+// ListWorkspaces returns the workspaces the agent is allowed to
+// see in error-envelope hints, filtered by the OAuth allow-list.
+//
+// Behaviour by token state (read from ctx):
+//
+//   - No user on context → empty list. Anonymous probes against
+//     /mcp shouldn't reach a tool dispatch in the first place
+//     (MCPBearerAuth 401s before that), but a defensive empty
+//     list keeps the helper safe to call from error paths.
+//   - PAT auth (allow-list nil) → return all of the user's
+//     workspaces. PATs don't have a workspace allow-list at all.
+//   - Wildcard allow-list (`["*"]`) → return all of the user's
+//     workspaces. The user explicitly granted "any."
+//   - Specific allow-list (`["foo", "bar"]`) → intersect with the
+//     user's memberships. Workspaces not in the allow-list are
+//     dropped, even if the user is a member of them.
+func (l *oauthWorkspaceLister) ListWorkspaces(ctx context.Context) ([]WorkspaceHint, error) {
+	user, ok := server.CurrentUserFromContext(ctx)
+	if !ok || user == nil {
+		return nil, nil
+	}
+	all, err := l.store.GetUserWorkspaces(user.ID)
+	if err != nil {
+		return nil, err
+	}
+	allowed := server.TokenAllowedWorkspacesFromContext(ctx)
+	if allowList := buildAllowSet(allowed); allowList != nil {
+		filtered := make([]WorkspaceHint, 0, len(all))
+		for _, ws := range all {
+			if _, ok := allowList[ws.Slug]; ok {
+				filtered = append(filtered, ws)
+			}
+		}
+		return filtered, nil
+	}
+	return all, nil
+}
+
+// buildAllowSet returns nil for the "no token-level filter" cases
+// (nil allow-list, or wildcard) and a slug-set otherwise. Matches
+// the three return-shape contract of TokenAllowedWorkspacesFromContext.
+func buildAllowSet(allowed []string) map[string]struct{} {
+	if allowed == nil {
+		return nil
+	}
+	for _, entry := range allowed {
+		if entry == "*" {
+			return nil
+		}
+	}
+	out := make(map[string]struct{}, len(allowed))
+	for _, slug := range allowed {
+		out[slug] = struct{}{}
+	}
+	return out
+}

--- a/internal/mcp/dispatch_http_test.go
+++ b/internal/mcp/dispatch_http_test.go
@@ -686,7 +686,7 @@ func TestPackageHTTPResponse_StructuredJSONOnSuccess(t *testing.T) {
 		StatusCode: http.StatusOK,
 		Body:       io.NopCloser(strings.NewReader(`{"ref":"TASK-1"}`)),
 	}
-	res, err := packageHTTPResponse(context.Background(), "item create", resp)
+	res, err := packageHTTPResponse(context.Background(), "item create", resp, nil)
 	if err != nil {
 		t.Fatalf("packageHTTPResponse: %v", err)
 	}
@@ -703,7 +703,7 @@ func TestPackageHTTPResponse_TextFallbackOnNonJSON(t *testing.T) {
 		StatusCode: http.StatusOK,
 		Body:       io.NopCloser(strings.NewReader("hello world")),
 	}
-	res, err := packageHTTPResponse(context.Background(), "item create", resp)
+	res, err := packageHTTPResponse(context.Background(), "item create", resp, nil)
 	if err != nil {
 		t.Fatalf("packageHTTPResponse: %v", err)
 	}


### PR DESCRIPTION
## Summary

Closes PLAN-943. HTTPHandlerDispatcher's `unknown_workspace` error envelope now populates `available_workspaces` filtered by the OAuth token's consent allow-list (TASK-952), so an agent never sees workspace slugs the user didn't explicitly grant.

- `HTTPHandlerDispatcher.Lister` field — production wires `NewOAuthWorkspaceLister(s)`.
- `oauthWorkspaceLister` reads `CurrentUserFromContext` + `TokenAllowedWorkspacesFromContext`, intersects with the user's full membership set.
- Wildcard (`["*"]`) / nil (PAT auth) → no filter. Specific list → filter applied.
- `packageHTTPResponse` threads the lister through to `classifyHTTPStatus`.

## Privacy invariant

Token allow-list `[alpha, beta]` + user member of `[alpha, beta, gamma, delta]` → envelope shows ONLY `[alpha, beta]`. Pinned by `TestUnknownWorkspace_AvailableWorkspaces_FilteredByAllowList`.

Without this filter, an attacker controlling an OAuth client could probe random slugs to read off the user's full workspace list from `available_workspaces`, defeating the consent UI's per-workspace selection.

## Test plan

- [x] 8 envelope round-trip tests for every documented HTTP status (401, 403, 404 item, 404 workspace, 409, 400, 422, 5xx, 418 fallback).
- [x] 5 privacy-filter tests (specific list, wildcard, no-allow-list, no-user, store-error).
- [x] 4 `buildAllowSet` helper unit tests.
- [x] 1 end-to-end test through `packageHTTPResponse`.
- [x] All existing OAuth + MCP tests still pass.
- [x] `make check` clean.
- [ ] `/codex review` loop until CLEAN.

## Out of scope

- Filling in `field`/`expected`/`got` on validation_failed envelopes from handler bodies. Pad's `writeError` doesn't return that level of detail; the envelope's Hint just carries the raw body. Would require a handler-side refactor.
- `required_role`/`current_role` on permission_denied — same: handler bodies don't surface this.
- `current_version` on conflict envelopes — same.

## PLAN-943 status after merge

| Task     | Status |
|----------|--------|
| TASK-950 (mount /mcp + discovery) | ✅ |
| TASK-951 (OAuth 2.1 server)       | ✅ |
| TASK-952 (consent UI)             | ✅ |
| TASK-953 (allow-list + role)      | ✅ |
| TASK-959 (rate limiting)          | ✅ |
| **TASK-977 (workspace filter)**   | ✅ |

PLAN-943 is **complete** after this merges.