### PR TITLE
fix(mcp): publish PAD_MCP_PUBLIC_URL verbatim as canonical resource (no /mcp suffix)

### DIFF
--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -426,7 +426,21 @@ func serveCmd() *cobra.Command {
 				// when the cloud deployment has a configured MCP
 				// public URL — the OAuth server's audience strategy
 				// rejects every request unless tokens are bound to
-				// cfg.MCPPublicURL + "/mcp" (the canonical resource).
+				// cfg.MCPPublicURL (the canonical resource URL the
+				// operator published).
+				//
+				// We treat cfg.MCPPublicURL as the canonical resource
+				// URL exactly — no path suffix appended. Per the MCP
+				// authorization spec the client compares the URL it
+				// was given against the discovery doc's `resource`
+				// field; a mismatch is a hard reject. So if the
+				// operator publishes "https://mcp.getpad.dev" (matches
+				// industry convention — mcp.stripe.com, mcp.linear.app,
+				// etc.), tokens are audience-bound to that exact
+				// string. The transport itself is internally mounted
+				// at /mcp on the chi router; pad-cloud's nginx router
+				// rewrites mcp.* root → /mcp transparently so external
+				// clients see a single canonical URL.
 				//
 				// HMAC secret reuses cfg.EncryptionKey, the same
 				// 32-byte hex key cloud deployments already require
@@ -437,7 +451,7 @@ func serveCmd() *cobra.Command {
 					oauthSrv, oauthErr := oauthpkg.NewServer(oauthpkg.Config{
 						Store:           s,
 						HMACSecret:      keyBytes,
-						AllowedAudience: strings.TrimRight(cfg.MCPPublicURL, "/") + "/mcp",
+						AllowedAudience: strings.TrimRight(cfg.MCPPublicURL, "/"),
 					})
 					if oauthErr != nil {
 						return fmt.Errorf("init OAuth server: %w", oauthErr)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -67,7 +67,7 @@ type Config struct {
 	// production, set them to the canonical public URLs so the
 	// metadata document matches the cert and the URL agents paste into
 	// Claude Desktop.
-	MCPPublicURL  string `toml:"mcp_public_url"`  // Canonical URL of the MCP vhost, e.g. https://mcp.getpad.dev. Concatenated with /mcp + /.well-known/oauth-protected-resource.
+	MCPPublicURL  string `toml:"mcp_public_url"`  // Canonical URL clients paste into their MCP client (e.g. https://mcp.getpad.dev — matches mcp.stripe.com / mcp.linear.app convention). Published verbatim as RFC 9728 `resource` and used as the OAuth audience binding; pad mounts the transport internally at /mcp and pad-cloud's nginx router transparently rewrites mcp.* root → /mcp so external clients see a single canonical URL regardless of internal path.
 	AuthServerURL string `toml:"auth_server_url"` // Canonical URL of the OAuth authorization server (TASK-951), e.g. https://app.getpad.dev. Embedded in protected-resource metadata's authorization_servers field.
 
 	// Encryption

--- a/internal/server/handlers_mcp_test.go
+++ b/internal/server/handlers_mcp_test.go
@@ -72,8 +72,8 @@ func TestMCP_DiscoveryDoc_PopulatedFromConfig(t *testing.T) {
 	var doc protectedResourceMetadata
 	parseJSON(t, rr, &doc)
 
-	if doc.Resource != "https://mcp.test.example/mcp" {
-		t.Errorf("Resource: got %q, want %q", doc.Resource, "https://mcp.test.example/mcp")
+	if doc.Resource != testCanonicalAudience {
+		t.Errorf("Resource: got %q, want %q", doc.Resource, testCanonicalAudience)
 	}
 	if len(doc.AuthorizationServers) != 1 || doc.AuthorizationServers[0] != "https://app.test.example" {
 		t.Errorf("AuthorizationServers: got %v, want [https://app.test.example]", doc.AuthorizationServers)
@@ -398,8 +398,10 @@ func mcpAndOAuthEnabledTestServer(t *testing.T) (srv *Server, transport *mcpStub
 	srv.SetCloudMode("test-secret")
 
 	transport = &mcpStubTransport{}
+	// testCanonicalAudience IS the canonical resource URL post-fix
+	// (no /mcp suffix to strip).
 	srv.SetMCPTransport(http.HandlerFunc(transport.serve),
-		strings.TrimSuffix(testCanonicalAudience, "/mcp"),
+		testCanonicalAudience,
 		testAuthServerURL)
 
 	o, err := newTestOAuthServer(t, srv)

--- a/internal/server/handlers_oauth_test.go
+++ b/internal/server/handlers_oauth_test.go
@@ -35,7 +35,12 @@ import (
 // layer in isolation.
 
 const (
-	testCanonicalAudience = "https://mcp.test.example/mcp"
+	// Canonical resource URL the test fixtures advertise + bind tokens to.
+	// No /mcp suffix — matches the post-fix semantic where MCPPublicURL
+	// is published verbatim as the RFC 9728 resource (mcp.stripe.com /
+	// mcp.linear.app convention). The actual transport still mounts at
+	// /mcp internally on the chi router.
+	testCanonicalAudience = "https://mcp.test.example"
 	testAuthServerURL     = "https://app.test.example"
 )
 
@@ -50,8 +55,10 @@ func oauthEnabledTestServer(t *testing.T) (*Server, *oauth.Server) {
 	srv.SetCloudMode("test-secret")
 	// Stub MCP transport so SetMCPTransport's URL fields are populated;
 	// the OAuth handlers read mcpAuthServerURL via authServerIssuerURL.
+	// Pass testCanonicalAudience directly — post-fix it IS the canonical
+	// resource URL (no /mcp suffix to strip).
 	stub := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {})
-	srv.SetMCPTransport(stub, testCanonicalAudience[:strings.LastIndex(testCanonicalAudience, "/")], testAuthServerURL)
+	srv.SetMCPTransport(stub, testCanonicalAudience, testAuthServerURL)
 
 	o, err := oauth.NewServer(oauth.Config{
 		Store:           srv.store,

--- a/internal/server/handlers_well_known.go
+++ b/internal/server/handlers_well_known.go
@@ -30,7 +30,7 @@ import (
 // Output:
 //
 //	{
-//	  "resource": "https://mcp.getpad.dev/mcp",
+//	  "resource": "https://mcp.getpad.dev",
 //	  "authorization_servers": ["https://app.getpad.dev"],
 //	  "bearer_methods_supported": ["header"],
 //	  "scopes_supported": ["pad:read", "pad:write", "pad:admin"]
@@ -38,16 +38,29 @@ import (
 //
 // resource and authorization_servers come from runtime config wired at
 // startup via SetMCPTransport (cmd/pad/main.go reads PAD_MCP_PUBLIC_URL
-// and PAD_AUTH_SERVER_URL). When unset, we fall back to deriving from
-// the request scheme + host so local testing without those env vars
-// still produces a valid document; ops should always set them in
-// production so the doc matches the public URL the cert covers.
+// and PAD_AUTH_SERVER_URL). When PAD_MCP_PUBLIC_URL is unset we fall
+// back to deriving from the request scheme + host so local testing
+// without those env vars still produces a valid document; ops should
+// always set PAD_MCP_PUBLIC_URL in production so the doc matches the
+// public URL the cert covers.
+//
+// PAD_MCP_PUBLIC_URL is published verbatim as the `resource` field —
+// no /mcp suffix is appended. The MCP authorization spec requires
+// clients to verify the URL they were given matches `resource` exactly;
+// auto-suffixing would force operators publishing the bare hostname
+// (the industry convention — mcp.stripe.com, mcp.linear.app, etc.)
+// into a mismatch and Claude Desktop / Cursor would reject. The
+// transport is internally mounted at /mcp on the chi router; pad-cloud's
+// nginx router transparently rewrites mcp.* root → /mcp so external
+// clients see a single canonical URL regardless of internal path.
 func (s *Server) handleOAuthProtectedResource(w http.ResponseWriter, r *http.Request) {
 	resource := strings.TrimRight(s.mcpPublicURL, "/")
 	if resource == "" {
+		// Fallback for local dev where PAD_MCP_PUBLIC_URL isn't set.
+		// Use r.Host as-is; the operator who cares about the path
+		// shape should set the env var explicitly.
 		resource = "https://" + r.Host
 	}
-	resource = resource + "/mcp"
 
 	authServer := strings.TrimRight(s.mcpAuthServerURL, "/")
 	if authServer == "" {


### PR DESCRIPTION
## Summary

Per the MCP authorization spec the client MUST verify the URL it was given matches the discovery doc's `resource` field exactly; pad's auto-suffixing of `/mcp` to `MCPPublicURL` was forcing operators publishing the bare hostname (industry convention — `mcp.stripe.com`, `mcp.linear.app`, `mcp.atlassian.com`) into a permanent client-side mismatch. Concrete symptom: pasting `https://mcp.getpad.dev` into Claude Desktop fails the resource-mismatch check even though the rest of the OAuth chain works.

This PR drops the `/mcp` suffix at both production sites:
- `cmd/pad/main.go` — `AllowedAudience` for the OAuth server constructor uses `cfg.MCPPublicURL` verbatim. Tokens are now audience-bound to the canonical URL the operator publishes.
- `internal/server/handlers_well_known.go` — protected-resource discovery doc's `resource` field is the bare `mcpPublicURL`.

The transport mount is unchanged — pad still serves at `/mcp` on the chi router; pad-cloud's nginx router (PR #28) transparently rewrites `mcp.*` root → `/mcp` so external clients see a single canonical URL regardless of the internal HTTP path. Audience binding is just a string match — it doesn't have to equal the internal mount path.

`config.go`'s `MCPPublicURL` doc updated to reflect the new "operator owns the canonical URL" semantic. Operators who want the old `/mcp`-suffixed shape just include it in `PAD_MCP_PUBLIC_URL`.

## Test plan

- [x] `testCanonicalAudience` flipped from `https://mcp.test.example/mcp` to `https://mcp.test.example`
- [x] Two `SetMCPTransport` call sites that previously stripped `/mcp` simplified to pass `testCanonicalAudience` directly
- [x] `TestMCP_DiscoveryDoc_PopulatedFromConfig` updated to use the symbolic constant
- [x] All other test sites (audience= form fields, aud claim checks, mismatch fixtures) keep working unchanged because they reference `testCanonicalAudience` symbolically
- [x] `make check` clean (lint + all Go tests + web build)
- [x] Codex review CLEAN round 1 (focused on whether dropping the suffix breaks any audience-binding security guarantee — it doesn't; all four code paths are aligned on the trimmed `MCPPublicURL`)
- [ ] Post-deploy: `curl -fsS https://mcp.getpad.dev/.well-known/oauth-protected-resource | jq .resource` returns `"https://mcp.getpad.dev"` (was `"https://mcp.getpad.dev/mcp"`)
- [ ] Post-deploy: pasting bare `https://mcp.getpad.dev` into Claude Desktop completes the connector flow

## Operator note

Existing tokens minted before this deploy are audience-bound to the OLD canonical (`https://mcp.getpad.dev/mcp`) and will be rejected after the upgrade. Connectors will need to re-authorize. This is a deliberate one-time blast since the install is brand new (no significant tokens minted yet).