### PR TITLE
fix(oauth): treat empty-path/root trailing slash as equivalent in audience matching

### DIFF
--- a/internal/oauth/audience.go
+++ b/internal/oauth/audience.go
@@ -3,6 +3,7 @@ package oauth
 import (
 	"errors"
 	"fmt"
+	"net/url"
 	"strings"
 
 	"github.com/ory/fosite"
@@ -32,6 +33,56 @@ import (
 // `audience=` form before invoking the provider, so the flow lines
 // up cleanly with this strategy.
 
+// NormalizeAudience returns the canonical comparison form of an
+// audience URI: trims a trailing "/" ONLY when the URI's path
+// component is the root ("/" by itself), leaving every other
+// trailing slash intact.
+//
+// Why exactly the root case: RFC 3986 §6.2.3 (Scheme-Based
+// Normalization) declares that for HTTP-scheme URIs an empty path
+// component is equivalent to a single "/". So
+// "https://host" ≡ "https://host/" and we must accept both. But
+// "https://host/foo" and "https://host/foo/" are NOT equivalent
+// — they're distinct resources (one's a "file", the other a
+// "directory" namespace). Collapsing those would let a token
+// minted for "/foo/" pass an audience check expecting "/foo"
+// (and vice versa), which is a real audience-confusion attack
+// surface. Codex review #386 round 1 caught the over-broad trim
+// that motivated this version.
+//
+// Why we need this at all: real OAuth clients vary in how they
+// reconstruct the resource indicator. Claude Desktop's connector
+// parses the URL the user pasted, URL-canonicalizes empty path → "/",
+// and emits resource=https://mcp.example/ even when the operator's
+// published canonical is https://mcp.example. A naive string compare
+// rejects these as distinct audiences and the connector flow dies
+// on "Requested audience X is not the canonical audience Y" — even
+// though, per the spec, they ARE the same audience.
+//
+// We don't touch case, default ports, or percent-encoding —
+// URI normalization can get arbitrarily thorny and each of those
+// is its own decision. Root-path trailing slash is the one case
+// both unambiguously safe per the spec AND observed in the wild.
+//
+// Exported so the resource-server-side audience check (in
+// internal/server/middleware_mcp_auth.go) and the AS-side
+// audienceMatchingStrategy share a single normalization rule. If
+// the rule ever drifts between the two sides, tokens that the AS
+// minted will start failing at the RS — silent breakage.
+func NormalizeAudience(s string) string {
+	u, err := url.Parse(s)
+	// Only normalize when we have a parseable URL with a real host
+	// AND the path is exactly the root "/". Anything else (parse
+	// failures, hostless strings like "/" alone, paths like "/foo"
+	// or "/foo/", or URIs carrying a query/fragment) is returned
+	// byte-exact so we don't change semantics for cases the spec
+	// doesn't declare equivalent.
+	if err != nil || u.Host == "" || u.Path != "/" || u.RawQuery != "" || u.Fragment != "" {
+		return s
+	}
+	return strings.TrimSuffix(s, "/")
+}
+
 // audienceMatchingStrategy returns a fosite.AudienceMatchingStrategy
 // that enforces "every requested audience must equal the configured
 // canonical audience, and no other audience is permitted." Closes
@@ -45,7 +96,8 @@ import (
 //     PLAN-943's TASK-950 + sub-PR C wiring guarantees /authorize and
 //     /token always carry it. Empty here means a misconfigured
 //     handler shipped a request without the param — fail loudly.
-//   - If any element of `needle` isn't equal to canonical, fail.
+//   - If any element of `needle` isn't equal to canonical (after
+//     trailing-slash normalization — see NormalizeAudience), fail.
 //     This rejects multi-audience tokens or audiences pointing
 //     elsewhere (the cross-server replay defense).
 //   - Else, succeed.
@@ -70,10 +122,13 @@ func audienceMatchingStrategy(canonical string) fosite.AudienceMatchingStrategy 
 			return fosite.ErrServerError.WithHint("OAuth server has no canonical audience configured.")
 		}
 
-		// Haystack (client.Audience) must include canonical. Without
-		// this, a DCR client registered before audience-population
-		// shipped (sub-PR C work) could still drive flows. Reject.
-		if !slicesContains(haystack, canonical) {
+		canonicalNorm := NormalizeAudience(canonical)
+
+		// Haystack (client.Audience) must include canonical (after
+		// trailing-slash normalization). Without this, a DCR client
+		// registered before audience-population shipped (sub-PR C
+		// work) could still drive flows. Reject.
+		if !audienceListContainsNormalized(haystack, canonicalNorm) {
 			return fosite.ErrInvalidRequest.WithHintf(
 				"Client is not authorized for the canonical audience %q.",
 				canonical,
@@ -90,7 +145,7 @@ func audienceMatchingStrategy(canonical string) fosite.AudienceMatchingStrategy 
 			)
 		}
 		for _, n := range needle {
-			if n != canonical {
+			if NormalizeAudience(n) != canonicalNorm {
 				return fosite.ErrInvalidRequest.WithHintf(
 					"Requested audience %q is not the canonical audience %q.",
 					n, canonical,
@@ -102,12 +157,14 @@ func audienceMatchingStrategy(canonical string) fosite.AudienceMatchingStrategy 
 	}
 }
 
-// slicesContains is a tiny helper avoiding the slices package import
-// (the rest of internal/oauth/ doesn't need it). Returns true if s
-// has an element equal to v.
-func slicesContains(s []string, v string) bool {
-	for _, x := range s {
-		if x == v {
+// audienceListContainsNormalized reports whether haystack contains an
+// element that compares equal to needleNorm after trailing-slash
+// normalization. Caller is responsible for normalizing the needle
+// before calling (the haystack side is normalized inline so the
+// caller doesn't have to allocate a copy of the haystack).
+func audienceListContainsNormalized(haystack []string, needleNorm string) bool {
+	for _, x := range haystack {
+		if NormalizeAudience(x) == needleNorm {
 			return true
 		}
 	}

--- a/internal/oauth/server_test.go
+++ b/internal/oauth/server_test.go
@@ -217,6 +217,109 @@ func TestAudienceStrategy_AcceptsCanonicalOnly(t *testing.T) {
 	}
 }
 
+// TestAudienceStrategy_TrailingSlashEquivalence pins the fix for the
+// real-world bug Claude Desktop hit against pad: the connector parses
+// the URL the user pasted (e.g. "https://mcp.getpad.dev"), URL-parses
+// it (which canonicalizes empty path → "/"), and emits the resource
+// indicator as "https://mcp.getpad.dev/" — with a trailing slash that
+// pad's canonical "https://mcp.getpad.dev" doesn't have. Per RFC 3986
+// §6.2.3 those forms are equivalent for the HTTP scheme; without
+// trailing-slash normalization the strict string compare rejects
+// every real-client request and the connector loops on
+// "Requested audience X is not the canonical audience Y."
+//
+// Matrix locks in all four (canonical-with-or-without-slash) ×
+// (needle-with-or-without-slash) combinations so a future refactor
+// that drops the normalization regresses the test, not production.
+func TestAudienceStrategy_TrailingSlashEquivalence(t *testing.T) {
+	cases := []struct {
+		name      string
+		canonical string
+		needle    string
+	}{
+		{"both bare", "https://mcp.test.example", "https://mcp.test.example"},
+		{"canonical bare, needle slashed", "https://mcp.test.example", "https://mcp.test.example/"},
+		{"canonical slashed, needle bare", "https://mcp.test.example/", "https://mcp.test.example"},
+		{"both slashed", "https://mcp.test.example/", "https://mcp.test.example/"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			strat := audienceMatchingStrategy(tc.canonical)
+			if err := strat([]string{tc.canonical}, []string{tc.needle}); err != nil {
+				t.Errorf("canonical=%q needle=%q must compare equal; got %v", tc.canonical, tc.needle, err)
+			}
+		})
+	}
+}
+
+// TestNormalizeAudience pins the boundaries of the slash-trim helper.
+// Codex review #386 round 1 caught an over-broad earlier version that
+// trimmed every trailing "/", which would have made
+// "https://host/mcp" and "https://host/mcp/" compare equal — distinct
+// HTTP resources collapsing to one audience is a real confusion-attack
+// surface. The fixed version trims ONLY when the URI's path component
+// is the root.
+func TestNormalizeAudience(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		// Root-case equivalence (the whole reason the helper exists).
+		{"https://host", "https://host"},
+		{"https://host/", "https://host"},
+		{"http://host:8080", "http://host:8080"},
+		{"http://host:8080/", "http://host:8080"},
+
+		// Non-root paths are NOT equivalent — `/foo` and `/foo/` are
+		// distinct HTTP resources. MUST stay byte-exact.
+		{"https://host/mcp", "https://host/mcp"},
+		{"https://host/mcp/", "https://host/mcp/"},
+		{"https://host/foo/bar", "https://host/foo/bar"},
+		{"https://host/foo/bar/", "https://host/foo/bar/"},
+
+		// Edge cases that must not change semantics:
+		//   - hostless strings (parse but no host) stay as-is
+		//   - empty stays empty
+		//   - URLs with query or fragment stay as-is even on root
+		{"", ""},
+		{"/", "/"},
+		{"https://host/?q=x", "https://host/?q=x"},
+		{"https://host/#frag", "https://host/#frag"},
+
+		// Unparseable inputs return as-is (defensive — matching
+		// continues to fail string-equally rather than throwing).
+		{"::not-a-url::", "::not-a-url::"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			if got := NormalizeAudience(tc.in); got != tc.want {
+				t.Errorf("NormalizeAudience(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestAudienceStrategy_PathSlashIsNotEquivalent guards Codex #386
+// round 1 directly at the strategy layer: even with normalization
+// active, a token requested for a path-slashed audience must NOT
+// pass when the canonical is the unslashed path form (and vice
+// versa). The strict reject is what stops the audience-confusion
+// attack the round-1 review flagged.
+func TestAudienceStrategy_PathSlashIsNotEquivalent(t *testing.T) {
+	cases := []struct{ canonical, needle string }{
+		{"https://host/mcp", "https://host/mcp/"},
+		{"https://host/mcp/", "https://host/mcp"},
+		{"https://host/foo/bar", "https://host/foo/bar/"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.canonical+"_vs_"+tc.needle, func(t *testing.T) {
+			strat := audienceMatchingStrategy(tc.canonical)
+			if err := strat([]string{tc.canonical}, []string{tc.needle}); err == nil {
+				t.Errorf("canonical=%q needle=%q must NOT compare equal (path-slash distinction)", tc.canonical, tc.needle)
+			}
+		})
+	}
+}
+
 func TestAudienceStrategy_RejectsMultipleAudiences(t *testing.T) {
 	// Even if one of the requested audiences is canonical, having
 	// extras is rejected — RFC 8707 audience-restriction means

--- a/internal/server/middleware_mcp_auth.go
+++ b/internal/server/middleware_mcp_auth.go
@@ -335,12 +335,21 @@ func (s *Server) handleMCPOAuthAuth(w http.ResponseWriter, r *http.Request, toke
 	next.ServeHTTP(w, r.WithContext(ctx))
 }
 
-// audienceContains reports whether haystack contains needle. Tiny
-// helper avoiding the slices package import for one call site (and
-// keeping the test surface for "audience match" in one place).
+// audienceContains reports whether haystack contains needle, treating
+// scheme-equivalent forms as equal via oauth.NormalizeAudience.
+//
+// Why normalize: real OAuth clients reconstruct the resource indicator
+// from the URL the user pasted, and URL parsing canonicalizes empty
+// path → "/" — so a client given `https://mcp.example` may emit
+// `https://mcp.example/` as the audience. RFC 3986 §6.2.3 declares
+// these equivalent for HTTP scheme; pad's AS-side audienceMatchingStrategy
+// applies the same trim. Mirroring the rule here keeps the AS and RS
+// in lockstep — without it, tokens the AS minted (with the requested
+// audience stored verbatim) would fail validation at /mcp.
 func audienceContains(haystack []string, needle string) bool {
+	needleNorm := oauth.NormalizeAudience(needle)
 	for _, a := range haystack {
-		if a == needle {
+		if oauth.NormalizeAudience(a) == needleNorm {
 			return true
 		}
 	}


### PR DESCRIPTION
## Summary

Pasting bare `https://mcp.getpad.dev` into Claude Desktop fails with:
> Requested audience 'https://mcp.getpad.dev/' is not the canonical audience 'https://mcp.getpad.dev'.

Trailing slash mismatch. Claude's connector parses the URL the user pasted, URL-canonicalizes empty path → `/`, and emits `resource=https://mcp.getpad.dev/` even when the operator's published canonical is `https://mcp.getpad.dev`. RFC 3986 §6.2.3 declares those equivalent for HTTP scheme; pad's strict string compare didn't.

Adds `NormalizeAudience(s)` and applies it on both sides of every audience comparison:
- **AS side** (`internal/oauth/audience.go`): `audienceMatchingStrategy` normalizes the canonical, then checks each needle and the haystack against it.
- **RS side** (`internal/server/middleware_mcp_auth.go`): `audienceContains` (the `/mcp` gate) normalizes both sides too — keeps AS and RS in lockstep.

Per Codex review, normalization is restricted to URIs whose path is exactly the root (`/`). An over-broad earlier draft trimmed every trailing `/` which would have made `https://host/mcp` and `https://host/mcp/` compare equal — distinct HTTP resources collapsing to one audience is a real audience-confusion attack surface. The boundary is enforced via `url.Parse`: only normalize when `u.Host` is non-empty AND `u.Path == "/"` AND there's no query/fragment.

## Test plan

- [x] `TestNormalizeAudience` pins both branches: root case trims (`https://host/` → `https://host`), non-root paths stay byte-exact (`/mcp` ≠ `/mcp/`, `/foo/bar` ≠ `/foo/bar/`), hostless / query / fragment / unparseable all return as-is
- [x] `TestAudienceStrategy_TrailingSlashEquivalence` pins all 4 (canonical-with-or-without-slash) × (needle-with-or-without-slash) combinations on the strategy layer
- [x] `TestAudienceStrategy_PathSlashIsNotEquivalent` directly guards the audience-confusion attack surface — `/mcp` vs `/mcp/` must NOT compare equal
- [x] `make check` clean
- [x] Codex review CLEAN round 2 (round 1 caught the over-broad trim → addressed by restricting to root-path)
- [ ] Post-deploy: pasting bare `https://mcp.getpad.dev` into Claude Desktop completes the connector flow