### PR TITLE
fix(oauth): CSP nonce on consent screen so the inline UI-state script can run

### DIFF
--- a/internal/server/handlers_oauth.go
+++ b/internal/server/handlers_oauth.go
@@ -1157,7 +1157,7 @@ button.primary:hover:not(:disabled) { background: #1e54d4; }
   </div>
 </form>
 
-<script>
+<script nonce="{{.Nonce}}">
 (function(){
   var wildcard = document.getElementById('ws-wildcard');
   var wsBoxes = document.querySelectorAll('input.ws-checkbox');
@@ -1206,6 +1206,18 @@ type consentData struct {
 	DefaultTier   string // "read" / "write" / "admin" — initially-checked radio
 	CSRF          string
 	HiddenFields  url.Values
+
+	// Nonce authorizes the inline UI-state <script> in the consent
+	// template under the strict CSP pad serves on every response
+	// (script-src 'self' — no 'unsafe-inline'). Without this, the
+	// browser blocks the script and the Allow button stays disabled
+	// from its initial render even when the user picks workspaces,
+	// because nothing flips disabled=false. renderConsent generates
+	// the nonce per request, sets a matching CSP header before
+	// writing the body, and passes the value here. Same pattern the
+	// SvelteKit bootstrap path uses — see server.go's nonce CSP
+	// override in the SPA route.
+	Nonce string
 }
 
 // consentWorkspaceRow renders one workspace checkbox row with the
@@ -1308,6 +1320,21 @@ func (s *Server) renderConsent(w http.ResponseWriter, r *http.Request, ar fosite
 	// round 1 caught the gap.
 	hidden := allowlistedAuthorizeParams(r.URL.Query())
 
+	// Per-request nonce so the consent template's inline UI-state
+	// <script> can run under pad's strict CSP (script-src 'self', no
+	// 'unsafe-inline'). Without overriding the default header here,
+	// the SecurityHeaders middleware leaves CSP at its strict baseline,
+	// the browser blocks the inline script, and the Allow button stays
+	// disabled from its initial render even after the user picks
+	// workspaces (nothing flips disabled=false). Same shape the
+	// SvelteKit bootstrap path in server.go uses — strict-dynamic lets
+	// the trusted script dynamically import additional code without
+	// listing every path in the host-list.
+	nonce := generateCSPNonce()
+	w.Header().Set("Content-Security-Policy", fmt.Sprintf(
+		"default-src 'self'; script-src 'self' 'nonce-%s' 'strict-dynamic'; script-src-attr 'none'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'",
+		nonce))
+
 	data := consentData{
 		ClientName:    clientName,
 		ClientLogoURL: logo,
@@ -1319,6 +1346,7 @@ func (s *Server) renderConsent(w http.ResponseWriter, r *http.Request, ar fosite
 		DefaultTier:   defaultTier,
 		CSRF:          csrf,
 		HiddenFields:  hidden,
+		Nonce:         nonce,
 	}
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	// Cache-Control: no-store — the page carries a CSRF token tied

--- a/internal/server/handlers_oauth_test.go
+++ b/internal/server/handlers_oauth_test.go
@@ -4,9 +4,11 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
+	"html"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -604,6 +606,97 @@ func TestOAuth_Authorize_AcceptsNoResource_DefaultsToCanonical(t *testing.T) {
 		t.Fatalf("expected 200 (consent stub) for no-resource request; got %d (Location: %s, Body: %s)",
 			rr.Code, rr.Header().Get("Location"), rr.Body.String())
 	}
+}
+
+// TestOAuth_ConsentScreen_NonceCSPLetsInlineScriptRun pins the fix
+// for the bug where the consent screen rendered with the Allow
+// button stuck disabled. The button starts disabled and is enabled
+// by an inline <script> when the user picks workspaces; pad serves
+// every response with strict CSP (script-src 'self' — no
+// 'unsafe-inline'), so without a per-request nonce the browser
+// blocked the script and disabled=true persisted from initial render.
+//
+// The fix generates a nonce per consent render, sets a
+// CSP override on the response that authorizes that nonce
+// (script-src 'self' 'nonce-X' 'strict-dynamic'), and threads the
+// same nonce into the <script> tag's nonce attribute. This test
+// pins:
+//
+//  1. A CSP header is set with a nonce-* token in script-src (proof
+//     the strict baseline didn't pass through unmodified).
+//  2. The body's <script ...> tag carries a nonce attribute matching
+//     the value in the CSP header (proof the two are linked — drift
+//     would re-introduce the bug).
+//
+// Without (1), the browser blocks. Without (2), the browser blocks
+// even WITH the CSP override. Both are necessary.
+func TestOAuth_ConsentScreen_NonceCSPLetsInlineScriptRun(t *testing.T) {
+	srv, _ := oauthEnabledTestServer(t)
+	clientID := registerTestClient(t, srv, "https://app.test/cb")
+	_, sessionToken := loginTestUser(t, srv)
+
+	verifier := "verifier-the-quick-brown-fox-1234567890-abcdef"
+	challenge := s256Challenge(verifier)
+	q := url.Values{
+		"client_id":             {clientID},
+		"response_type":         {"code"},
+		"redirect_uri":          {"https://app.test/cb"},
+		"scope":                 {"pad:read"},
+		"code_challenge":        {challenge},
+		"code_challenge_method": {"S256"},
+		"state":                 {"nonce-csp-state"},
+	}
+	rr := doAuthedRequest(srv, "GET", "/oauth/authorize?"+q.Encode(), nil, sessionToken)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 (consent stub); got %d", rr.Code)
+	}
+
+	csp := rr.Header().Get("Content-Security-Policy")
+	if csp == "" {
+		t.Fatal("consent response must set Content-Security-Policy")
+	}
+	// Extract the nonce from the script-src directive. Format is
+	// `'nonce-<base64>'`; the base64 alphabet includes +, /, and =.
+	cspRe := regexp.MustCompile(`'nonce-([A-Za-z0-9+/=]+)'`)
+	cspMatches := cspRe.FindStringSubmatch(csp)
+	if len(cspMatches) != 2 {
+		t.Fatalf("CSP must include a 'nonce-...' token in script-src; got: %s", csp)
+	}
+	cspNonce := cspMatches[1]
+
+	// Extract the nonce from the rendered <script> tag. html/template
+	// HTML-escapes attribute values (e.g. base64 '+' renders as
+	// '&#43;'), so we extract the on-the-wire form, unescape it, and
+	// compare against the raw CSP nonce. Fail-loud if the two don't
+	// match — drift would re-introduce the original bug (nonce in
+	// header but not in tag = browser blocks).
+	body := rr.Body.String()
+	bodyRe := regexp.MustCompile(`<script nonce="([^"]+)">`)
+	bodyMatches := bodyRe.FindStringSubmatch(body)
+	if len(bodyMatches) != 2 {
+		t.Fatalf("body must contain a <script nonce=\"...\"> tag; CSP=%s\nbody snippet: %s",
+			csp, snippetAround(body, "<script", 200))
+	}
+	bodyNonce := html.UnescapeString(bodyMatches[1])
+	if bodyNonce != cspNonce {
+		t.Errorf("script tag nonce %q (escaped %q) must match CSP nonce %q",
+			bodyNonce, bodyMatches[1], cspNonce)
+	}
+}
+
+// snippetAround returns up to N bytes of body around the first
+// occurrence of marker, or "(marker not found)". Used by the nonce
+// test for diagnostic output without dumping the entire HTML page.
+func snippetAround(body, marker string, n int) string {
+	i := strings.Index(body, marker)
+	if i < 0 {
+		return "(marker not found)"
+	}
+	end := i + n
+	if end > len(body) {
+		end = len(body)
+	}
+	return body[i:end]
 }
 
 // TestOAuth_AuthorizationServerMetadata_OmitsRFC9207IssFlag pins


### PR DESCRIPTION
## Summary

Pasting `https://mcp.getpad.dev` into Claude Desktop now reaches pad's consent screen, but the Allow button stays **disabled** even when the user selects workspaces. Cause: the consent template ships UI-state JS in an inline `<script>` block (flips `disabled=false` on selection, drives the wildcard mutual-exclusion warning), but pad's strict response CSP is `script-src 'self'` with no `'unsafe-inline'` and no nonce — the browser silently blocks the inline script and the button stays at its initial `disabled=true`.

Adopts the same nonce + strict-dynamic CSP pattern pad already uses for the SvelteKit SPA bootstrap (see `server.go`'s SPA route): `renderConsent` generates a per-request nonce, sets a CSP override that authorizes that nonce (`script-src 'self' 'nonce-X' 'strict-dynamic'`) before writing the body, and threads the same nonce into the template's `<script>` tag's `nonce` attribute.

This is per-handler — overrides the `SecurityHeaders` middleware on the consent response only; every other endpoint keeps the strict no-nonce baseline.

## Test plan

- [x] `TestOAuth_ConsentScreen_NonceCSPLetsInlineScriptRun` pins both: (1) CSP carries a `'nonce-...'` token in script-src, (2) body's `<script>` tag carries the SAME nonce after `html.UnescapeString` (base64 `+` round-trips as `&#43;` via `html/template` attribute escaping)
- [x] Test stress-passed 50× to confirm robustness against `+`/`/` in nonces
- [x] `make check` clean
- [x] Codex review CLEAN round 2 (round 1 verdict CLEAN on security; flagged a test-expectation issue with HTML-escaped `+` → fixed by extracting + unescaping)
- [ ] Post-deploy: paste bare `https://mcp.getpad.dev` into Claude Desktop, reach consent screen, pick a workspace, Allow button enables, click Allow, OAuth completes