### PR TITLE
fix(dockerfile): pass version metadata via build args (TASK-1080)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,32 @@ COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
 COPY --from=web-builder /app/web/build ./web/build
+
+# Build metadata. All three are caller-passed via --build-arg (see
+# pad-cloud/scripts/build-pad.sh for the production wrapper that
+# resolves them from the host's pad checkout).
+#
+# Why all three are passed in vs. computed inside the container:
+#
+#   - .dockerignore intentionally excludes .git/, so an in-container
+#     `git rev-parse` substitution returns empty (with `2>/dev/null`
+#     swallowing the error) — the previous Dockerfile shipped "dev"
+#     forever because of this. We don't want to add .git/ to the
+#     context just for this; pre-computing on the host is the
+#     standard pattern.
+#   - `date` would work in-container but a fresh `date` value on
+#     every build invalidates layer caching for this RUN. Passing
+#     as ARG lets the caller decide cache semantics.
+#
+# Defaults are deliberately ugly-but-honest so a `docker build .`
+# without args produces a binary whose pad_version makes the
+# misconfiguration obvious ("dev (unknown)") rather than hiding it.
 ARG VERSION=dev
-RUN CGO_ENABLED=0 go build -ldflags="-s -w -X main.version=${VERSION} -X main.commit=$(git rev-parse --short HEAD 2>/dev/null) -X main.buildTime=$(date -u +%Y-%m-%dT%H:%M:%SZ)" -o pad ./cmd/pad
+ARG COMMIT=unknown
+ARG BUILD_TIME=
+RUN CGO_ENABLED=0 go build \
+    -ldflags="-s -w -X main.version=${VERSION} -X main.commit=${COMMIT} -X main.buildTime=${BUILD_TIME}" \
+    -o pad ./cmd/pad
 
 # Stage 3: Runtime
 FROM alpine:3.21


### PR DESCRIPTION
## Summary

Every Docker build of pad has been shipping a binary with `commit=""` because the previous Dockerfile ran `git rev-parse --short HEAD 2>/dev/null` INSIDE the build container, but `.dockerignore` intentionally excludes `.git/`. The substitution silently produced an empty string, `fullVersion()` collapsed to just `version`, and `pad_meta` returned `pad_version: "dev"` with no commit metadata. Caught during Claude Desktop dogfooding when bug reports had no way to identify which build they were hitting.

Two fixes available: add `.git/` to the build context (rejected — operator does not want `.git` in the image), or pre-compute on the host and pass via `--build-arg` (this PR). The wrapper that does the host-side computation lands separately in pad-cloud.

`date` substitution worked (alpine has `date`), but had a worse problem: a fresh `date` value invalidates layer caching for this RUN on every build. Moving to ARG lets the caller decide cache semantics.

Defaults are deliberately ugly-but-honest — `docker build .` without args produces `"dev (unknown)"` rather than hiding the misconfiguration.

## Test plan

- [x] Sanity-checked all four input combinations of `fullVersion()` (defaults, all-set, version+commit only, commit-empty) — output shapes are clean for each
- [x] `make check` passes (no Go code changes — exists for safety)
- [x] Codex review CLEAN — Codex built a real binary with the new ldflags and confirmed `pad --version` returns `"dev (unknown)"` for defaults and `"0.1.0-rc.5 (40f636e 2026-05-03T00:15:00Z)"` for the all-set case
- [ ] Post pad-cloud wrapper PR + deploy: `pad_meta` returns a non-`"dev"` `pad_version` carrying the actual commit

## Out of scope

The pad-cloud `docker-compose.yml` change to forward env vars + a `scripts/build-pad.sh` wrapper that resolves the metadata from the operator's pad checkout — separate PR in pad-cloud once this lands.