### PR TITLE
fix(auth): full-page navigation for server-owned redirect targets (BUG-1083)

### DIFF
--- a/web/src/lib/auth/redirect.ts
+++ b/web/src/lib/auth/redirect.ts
@@ -13,6 +13,95 @@
 export const DEFAULT_REDIRECT = '/console';
 
 /**
+ * Path prefixes the Go server owns directly — these are NOT SvelteKit
+ * routes, so post-auth navigation MUST use a full-page `window.location`
+ * navigation rather than `goto()`.
+ *
+ * See `internal/server/server.go`'s `setupRouter`: each entry below maps
+ * to a chi route group (or middleware-gated route) registered BEFORE the
+ * SvelteKit catch-all that serves the SPA. If post-auth code uses
+ * SvelteKit's client-side `goto()` to navigate to one of these, the
+ * router never finds a matching SPA route and falls into the
+ * `[username]/[workspace]` catch-all, which renders "No dashboard data
+ * available." That's BUG-1083 — an unauthenticated user hitting
+ * `/oauth/authorize` got bounced through `/login` and on successful
+ * sign-in the SPA tried to handle the `/oauth/authorize?...` redirect
+ * itself, parsing it as `username="oauth"`, `workspace="authorize"`.
+ *
+ * Keep this list in sync with the route groups mounted before the SPA
+ * catch-all. New entries belong here whenever a Go-only route prefix is
+ * added that a `?redirect=` flow might legitimately target.
+ */
+const SERVER_OWNED_PATH_PREFIXES = [
+	'/oauth/', // /oauth/authorize, /oauth/token, /oauth/register, etc. (PLAN-943)
+	'/api/', // REST API + SSE
+	'/.well-known/', // OAuth + MCP discovery docs
+	'/mcp', // MCP transport endpoints (cloud mode)
+	'/metrics' // Prometheus scrape endpoint
+];
+
+/**
+ * Returns true when `path` targets a route the Go server handles
+ * directly (and the SvelteKit SPA does NOT have a matching route for).
+ *
+ * Callers should prefer `navigateToRedirectTarget` over hand-rolling the
+ * branch — that helper picks the right navigation primitive for both
+ * cases.
+ *
+ * Pure path comparison; does not parse the URL or look at the query
+ * string. Inputs MUST already be validated against `validateRedirect`
+ * (i.e. start with `/`, not `//`, not `/\`).
+ */
+export function isServerOwnedPath(path: string): boolean {
+	if (!path || !path.startsWith('/')) return false;
+	for (const prefix of SERVER_OWNED_PATH_PREFIXES) {
+		if (path === prefix || path.startsWith(prefix)) return true;
+		// Allow the bare prefix without trailing slash too — `/mcp` and
+		// `/metrics` are exact endpoints, not prefixes, so check for an
+		// exact match against the trimmed form. `/oauth` (no trailing
+		// slash, no query) is NOT a real route and would 404, but treat
+		// it as server-owned for safety: a 404 from the Go side is a
+		// better failure mode than the SPA catch-all rendering an empty
+		// dashboard for `username="oauth"`.
+		const trimmed = prefix.endsWith('/') ? prefix.slice(0, -1) : prefix;
+		if (path === trimmed || path.startsWith(trimmed + '?')) return true;
+	}
+	return false;
+}
+
+/**
+ * Navigate to a post-auth redirect target.
+ *
+ * Picks `window.location.replace` for paths the Go server owns
+ * (`/oauth/...`, `/api/...`, etc.) and SvelteKit's `goto()` for SPA
+ * routes. `replace` (vs `assign`) matches the existing
+ * `goto(target, { replaceState: true })` semantics — the user should
+ * not be able to back-button into `/login` after a successful sign-in.
+ *
+ * Why not always use `window.location.replace`: the SPA's session +
+ * workspace stores are pre-loaded by the time post-auth code runs, so
+ * staying within the SPA for SPA-bound destinations skips a hard
+ * reload (faster, fewer round-trips, preserves any hydrated state).
+ *
+ * Returns a promise so callers can `await` it; the server-owned branch
+ * resolves immediately because `window.location.replace` doesn't
+ * actually return until navigation tears down the page.
+ */
+export async function navigateToRedirectTarget(target: string): Promise<void> {
+	if (isServerOwnedPath(target)) {
+		if (typeof window !== 'undefined') {
+			window.location.replace(target);
+		}
+		return;
+	}
+	// Lazy-import goto so this helper is safe to call from non-SvelteKit
+	// contexts (e.g. unit tests, SSR tooling) — `$app/navigation` errors
+	// out at import time outside a SvelteKit page module.
+	const { goto } = await import('$app/navigation');
+	await goto(target, { replaceState: true });
+}
+
+/**
  * Validate the `redirect` query param and return a safe relative path.
  *
  * Returns DEFAULT_REDIRECT (`/console`) for missing, malformed, or

--- a/web/src/routes/login/+page.svelte
+++ b/web/src/routes/login/+page.svelte
@@ -3,7 +3,6 @@
 	import { page } from '$app/stores';
 	import { api } from '$lib/api/client';
 	import { authStore } from '$lib/stores/auth.svelte';
-	import { goto } from '$app/navigation';
 	import SetupRequiredNotice from '$lib/components/auth/SetupRequiredNotice.svelte';
 	import AuthHeader from '$lib/components/auth/AuthHeader.svelte';
 	import AuthFooter from '$lib/components/auth/AuthFooter.svelte';
@@ -14,7 +13,7 @@
 		getLastAuthMethod,
 		type AuthMethod
 	} from '$lib/auth/lastMethod';
-	import { validateRedirect, redirectQueryFragment } from '$lib/auth/redirect';
+	import { navigateToRedirectTarget, redirectQueryFragment, validateRedirect } from '$lib/auth/redirect';
 
 	let email = $state('');
 	let password = $state('');
@@ -143,7 +142,7 @@
 				return;
 			}
 			if (session.authenticated) {
-				goto(redirectTarget, { replaceState: true });
+				await navigateToRedirectTarget(redirectTarget);
 				return;
 			}
 		} catch {}
@@ -173,7 +172,7 @@
 
 			recordAuthMethod('password');
 			await authStore.load();
-			await goto(redirectTarget, { replaceState: true });
+			await navigateToRedirectTarget(redirectTarget);
 		} catch (err: unknown) {
 			if (err instanceof Error) {
 				error = err.message || 'Invalid email or password.';
@@ -206,7 +205,7 @@
 
 			recordAuthMethod('password');
 			await authStore.load();
-			await goto(redirectTarget, { replaceState: true });
+			await navigateToRedirectTarget(redirectTarget);
 		} catch (err: unknown) {
 			if (err instanceof Error) {
 				error = err.message || 'Invalid code. Please try again.';

--- a/web/src/routes/register/+page.svelte
+++ b/web/src/routes/register/+page.svelte
@@ -2,7 +2,6 @@
 	import { onMount } from 'svelte';
 	import { page } from '$app/stores';
 	import { api } from '$lib/api/client';
-	import { goto } from '$app/navigation';
 	import SetupRequiredNotice from '$lib/components/auth/SetupRequiredNotice.svelte';
 	import AuthHeader from '$lib/components/auth/AuthHeader.svelte';
 	import AuthFooter from '$lib/components/auth/AuthFooter.svelte';
@@ -14,7 +13,7 @@
 		getLastAuthMethod,
 		type AuthMethod
 	} from '$lib/auth/lastMethod';
-	import { validateRedirect, redirectQueryFragment } from '$lib/auth/redirect';
+	import { navigateToRedirectTarget, redirectQueryFragment, validateRedirect } from '$lib/auth/redirect';
 
 	let name = $state('');
 	let username = $state('');
@@ -68,7 +67,7 @@
 				return;
 			}
 			if (session?.authenticated) {
-				goto(redirectTarget, { replaceState: true });
+				await navigateToRedirectTarget(redirectTarget);
 				return;
 			}
 		} catch {}
@@ -154,7 +153,7 @@
 		try {
 			await api.auth.register(email, name, password, username || undefined);
 			recordAuthMethod('password');
-			await goto(redirectTarget, { replaceState: true });
+			await navigateToRedirectTarget(redirectTarget);
 		} catch (err: unknown) {
 			if (err instanceof Error) {
 				error = err.message || 'Registration failed.';


### PR DESCRIPTION
## Summary

Fixes [BUG-1083](https://app.getpad.dev/dave/pad/bugs/the-oauth-sign-in-process-does-not-work-right): unauthenticated users hitting \`/oauth/authorize\` saw "No dashboard data available." instead of the consent screen after signing in.

**Root cause.** When an unauth'd user hits \`/oauth/authorize?...\`, the Go handler 302s to \`/login?redirect=/oauth/authorize?...\` (correct). After successful sign-in, \`login/+page.svelte\` was using \`goto(redirectTarget, { replaceState: true })\` — SvelteKit's *client-side* router. \`/oauth/authorize\` isn't a SvelteKit route (it's owned by the Go server), so SvelteKit fell into the \`[username]/[workspace]\` catchall, parsed the URL as \`username="oauth"\` + \`workspace="authorize"\`, failed to load that workspace, and rendered the empty-dashboard fallback. Already-signed-in users were unaffected because the Go handler renders consent inline without bouncing through the SPA.

**Fix.** Add \`isServerOwnedPath()\` + \`navigateToRedirectTarget()\` helpers in \`web/src/lib/auth/redirect.ts\`. The helper picks \`window.location.replace\` for paths the Go server owns (\`/oauth/\`, \`/api/\`, \`/.well-known/\`, \`/mcp\`, \`/metrics\`) and \`goto()\` for genuine SPA routes. \`replace\` (not \`assign\`) matches the prior \`replaceState: true\` semantics — back-button doesn't return to \`/login\`.

Five call sites swapped: \`login/+page.svelte\` (onMount auth-check, password submit, 2FA verify) and \`register/+page.svelte\` (onMount auth-check, register submit). \`goto\` import is no longer needed in either file.

Part of [PLAN-943](https://app.getpad.dev/dave/pad/plans/pad-cloud-as-a-remote-mcp-server-oauth-2-1-connectors).

## Test plan

- [x] \`make check\` — golangci-lint, full Go test suite, govulncheck, npm audit, svelte-check (0 errors)
- [x] OAuth-specific Go tests: \`go test ./internal/server/ -run 'OAuth|Authorize|Login'\` (passes, 28.5s)
- [x] Codex review on uncommitted diff: CLEAN
- [ ] Manual repro in cloud mode: sign out → visit \`/oauth/authorize?response_type=code&client_id=...&redirect_uri=...&code_challenge=...&code_challenge_method=S256&state=...&scope=pad:read&resource=...\` → expect redirect to \`/login?redirect=...\` → sign in → land on consent screen (not "No dashboard data available")
- [ ] Manual repro: same flow but starting from \`/register\` instead of \`/login\` (the cloud sign-up path)
- [ ] Manual sanity: signed-in user hitting \`/oauth/authorize\` directly still goes straight to consent (unaffected — never bounces through SPA)
- [ ] Manual sanity: regular login with no \`?redirect=\` still lands on \`/console\` (default redirect target stays SPA-bound)