### PR TITLE
fix(mcp): bundle BUG-1081 (star/unstar JSON) + BUG-1082 (suggested_next orphans) + TASK-1076 (workspace auto-default)

### DIFF
--- a/internal/mcp/dispatch_http.go
+++ b/internal/mcp/dispatch_http.go
@@ -275,6 +275,21 @@ func (d *HTTPHandlerDispatcher) Dispatch(ctx context.Context, cmdPath, _ []strin
 		}
 	}
 
+	// Preprocess input: workspace auto-default from OAuth-token
+	// allow-list (TASK-1076). When a tool call doesn't carry an
+	// explicit `workspace` param, try to default from the resolved
+	// workspaces the lister returns. Single resolved workspace →
+	// inject; otherwise leave alone (the route mapper will surface
+	// a "missing required input" error if the route needs it,
+	// which is informative enough for agents to retry with an
+	// explicit param). Routes that don't need workspace (like
+	// `pad_workspace list`) just see an extra unused field — harmless.
+	//
+	// Caller-passed workspace ALWAYS wins. Tests + non-OAuth paths
+	// (no Lister wired) skip the injection entirely so behavior
+	// stays unchanged for them.
+	input = d.maybeInjectWorkspace(ctx, input)
+
 	// Special-case routes that need read-modify-write or other
 	// in-handler prefetches. These live as methods on the dispatcher
 	// because they need the Handler reference; the simple route

--- a/internal/mcp/dispatch_http_advanced.go
+++ b/internal/mcp/dispatch_http_advanced.go
@@ -401,3 +401,53 @@ func hasFieldChanges(input map[string]any) bool {
 	}
 	return false
 }
+
+// maybeInjectWorkspace defaults the `workspace` input from the
+// dispatcher's WorkspaceLister when the caller didn't pass one
+// explicitly (TASK-1076).
+//
+// The lister already encodes the right policy via the OAuth-token
+// allow-list (internal/mcp/dispatch_http_lister.go):
+//
+//   - PAT auth (no allow-list)        → all of the user's workspaces
+//   - Wildcard token (`["*"]`)        → all of the user's workspaces
+//   - Specific allow-list             → intersection with the user's
+//     memberships
+//
+// Inject ONLY when exactly one workspace results — that's the case
+// where defaulting is unambiguous. Zero (no memberships, or
+// allow-list disjoint from memberships) → leave alone; the route
+// mapper's "missing required input" error is the agent's signal to
+// pass workspace= explicitly. Multiple → also leave alone; agents
+// should pick which workspace they mean rather than the dispatcher
+// silently choosing one (the latter would be a real audience-confusion
+// hazard for write operations).
+//
+// Caller-passed workspace ALWAYS wins (the early-return on the
+// existing-value branch). Lister == nil paths (tests + non-OAuth
+// transports) skip injection entirely so behavior stays unchanged
+// for them — no Lister means no defaulting policy to apply.
+//
+// Mutations are applied to a copy; the caller's input map is not
+// modified in place.
+func (d *HTTPHandlerDispatcher) maybeInjectWorkspace(
+	ctx context.Context,
+	input map[string]any,
+) map[string]any {
+	if d.Lister == nil {
+		return input
+	}
+	if existing, ok := input["workspace"].(string); ok && existing != "" {
+		return input
+	}
+	workspaces, err := d.Lister.ListWorkspaces(ctx)
+	if err != nil || len(workspaces) != 1 {
+		return input
+	}
+	out := make(map[string]any, len(input)+1)
+	for k, v := range input {
+		out[k] = v
+	}
+	out["workspace"] = workspaces[0].Slug
+	return out
+}

--- a/internal/mcp/dispatch_http_workspace_default_test.go
+++ b/internal/mcp/dispatch_http_workspace_default_test.go
@@ -1,0 +1,119 @@
+package mcp
+
+// Tests for TASK-1076's workspace auto-default. Pins the four-case
+// matrix the task spec called out:
+//
+//   1. Single resolved workspace, no caller param → inject
+//   2. Single resolved workspace, caller passed workspace=other →
+//      caller wins (no silent override)
+//   3. Multiple resolved workspaces, no caller param → leave alone
+//   4. Zero resolved workspaces, no caller param → leave alone
+//
+// Plus two operational cases that aren't in the formal matrix but
+// would silently break behavior if regressed:
+//
+//   - No Lister wired → leave alone (tests / non-OAuth paths)
+//   - Lister returns error → leave alone (don't poison input on
+//     transient store hiccup)
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// fakeLister satisfies WorkspaceLister with a fixed return value.
+// Used to exercise each matrix case without spinning up a real store.
+type fakeLister struct {
+	workspaces []WorkspaceHint
+	err        error
+}
+
+func (f *fakeLister) ListWorkspaces(ctx context.Context) ([]WorkspaceHint, error) {
+	return f.workspaces, f.err
+}
+
+func TestMaybeInjectWorkspace_SingleWorkspace_Injects(t *testing.T) {
+	d := &HTTPHandlerDispatcher{
+		Lister: &fakeLister{workspaces: []WorkspaceHint{{Slug: "only", Name: "Only Workspace"}}},
+	}
+	got := d.maybeInjectWorkspace(context.Background(), map[string]any{})
+	if got["workspace"] != "only" {
+		t.Errorf("expected workspace='only' injected, got %v", got["workspace"])
+	}
+}
+
+func TestMaybeInjectWorkspace_CallerWins_OverSingleWorkspace(t *testing.T) {
+	d := &HTTPHandlerDispatcher{
+		Lister: &fakeLister{workspaces: []WorkspaceHint{{Slug: "default-one"}}},
+	}
+	got := d.maybeInjectWorkspace(context.Background(), map[string]any{"workspace": "explicit"})
+	if got["workspace"] != "explicit" {
+		t.Errorf("explicit workspace= must win over default; got %v", got["workspace"])
+	}
+}
+
+func TestMaybeInjectWorkspace_MultipleWorkspaces_NoInject(t *testing.T) {
+	d := &HTTPHandlerDispatcher{
+		Lister: &fakeLister{workspaces: []WorkspaceHint{{Slug: "a"}, {Slug: "b"}}},
+	}
+	got := d.maybeInjectWorkspace(context.Background(), map[string]any{})
+	if _, present := got["workspace"]; present {
+		t.Errorf("multiple workspaces must NOT auto-inject (ambiguous); got %v", got["workspace"])
+	}
+}
+
+func TestMaybeInjectWorkspace_ZeroWorkspaces_NoInject(t *testing.T) {
+	d := &HTTPHandlerDispatcher{
+		Lister: &fakeLister{workspaces: nil},
+	}
+	got := d.maybeInjectWorkspace(context.Background(), map[string]any{})
+	if _, present := got["workspace"]; present {
+		t.Errorf("zero workspaces must NOT inject; got %v", got["workspace"])
+	}
+}
+
+func TestMaybeInjectWorkspace_NilLister_NoInject(t *testing.T) {
+	// Tests + non-OAuth transports leave Lister nil. The injection
+	// must be a no-op so existing behavior is preserved.
+	d := &HTTPHandlerDispatcher{Lister: nil}
+	in := map[string]any{"foo": "bar"}
+	got := d.maybeInjectWorkspace(context.Background(), in)
+	if _, present := got["workspace"]; present {
+		t.Errorf("nil Lister must NOT inject; got %v", got["workspace"])
+	}
+	if got["foo"] != "bar" {
+		t.Errorf("nil Lister must preserve other input keys; got %v", got)
+	}
+}
+
+func TestMaybeInjectWorkspace_ListerError_NoInject(t *testing.T) {
+	// Transient store error from the lister must fall through to
+	// "no inject" — don't fail the whole tool call on a hiccup, let
+	// the route mapper's eventual error speak for itself if the
+	// route needs workspace.
+	d := &HTTPHandlerDispatcher{
+		Lister: &fakeLister{err: errors.New("simulated store failure")},
+	}
+	got := d.maybeInjectWorkspace(context.Background(), map[string]any{})
+	if _, present := got["workspace"]; present {
+		t.Errorf("lister error must NOT inject; got %v", got["workspace"])
+	}
+}
+
+func TestMaybeInjectWorkspace_CopyOnWrite(t *testing.T) {
+	// The helper must NOT mutate the caller's input map in place —
+	// callers (the dispatch flow) hold the original reference and
+	// surface it in error logs / tool results.
+	d := &HTTPHandlerDispatcher{
+		Lister: &fakeLister{workspaces: []WorkspaceHint{{Slug: "only"}}},
+	}
+	in := map[string]any{}
+	out := d.maybeInjectWorkspace(context.Background(), in)
+	if _, present := in["workspace"]; present {
+		t.Error("input map must not be mutated in place")
+	}
+	if out["workspace"] != "only" {
+		t.Errorf("returned map must carry the injected value; got %v", out["workspace"])
+	}
+}

--- a/internal/server/handlers_dashboard.go
+++ b/internal/server/handlers_dashboard.go
@@ -680,13 +680,85 @@ func (s *Server) handleGetDashboard(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// BUG-1082: orphan branch. The active-plan loop above only
+	// surfaces items that are children of an active plan — workspaces
+	// without active plans (or in-progress / high-priority items
+	// outside their active plans) get an empty suggested_next, which
+	// burned us during dogfooding when the obvious answer was
+	// "continue your one in-progress task."
+	//
+	// Scan everything else for:
+	//   - in-progress, unblocked, not already a candidate (catches
+	//     in-progress orphans regardless of priority — agents should
+	//     suggest continuing what's already in flight).
+	//   - open with high or critical priority, unblocked, not already
+	//     a candidate (catches the "important standalone item" case
+	//     without flooding with low-priority orphans).
+	//
+	// Orphans rank LOWER than active-plan candidates so existing
+	// behavior is preserved for plan-driven workspaces — the orphan
+	// branch only surfaces when nothing else does (or pads out the
+	// suggestion list).
+	seen := make(map[string]struct{}, len(candidates))
+	for _, c := range candidates {
+		seen[c.item.ID] = struct{}{}
+	}
+	for _, item := range allItems {
+		if _, dup := seen[item.ID]; dup {
+			continue
+		}
+		// Skip non-tasks (the active-plan loop walks plan children;
+		// the orphan branch is similarly task-shaped). isCollectionVisible
+		// + collection-task gating mirrors the active-plan branch's
+		// shape so behaviour stays consistent.
+		if !isCollectionVisible(item.CollectionID, visibleIDs) {
+			continue
+		}
+		if !s.isItemVisibleToGuest(r, workspaceID, &item, dashFullCollIDs, dashGrantedItemIDs) {
+			continue
+		}
+		taskStatus := extractFieldValue(item.Fields, "status")
+		isInProgress := isActiveStatus(taskStatus)
+		isOpen := taskStatus == "open"
+		if !isInProgress && !isOpen {
+			continue
+		}
+		pri := extractFieldValue(item.Fields, "priority")
+		// Open orphans must be high or critical to surface — open
+		// in-progress items always do (continuing-work signal beats
+		// priority gating).
+		if !isInProgress && pri != "high" && pri != "critical" {
+			continue
+		}
+		if s.itemBlockedByActive(workspaceID, item.ID, ctxMap, visibleIDs, r, dashFullCollIDs, dashGrantedItemIDs) {
+			continue
+		}
+		candidates = append(candidates, suggestion{
+			item:       item,
+			plan:       "", // empty plan name signals orphan in the reason text below
+			status:     taskStatus,
+			priority:   priorityRank(pri),
+			inProgress: isInProgress,
+		})
+	}
+
 	// Sort: in-progress first, then by priority rank within each
-	// bucket. Lower rank = higher priority.
+	// bucket, then plan-children before orphans so the existing
+	// "active-plan continuation" suggestion stays at the top when
+	// both are present. Lower rank = higher priority.
 	sort.Slice(candidates, func(i, j int) bool {
 		if candidates[i].inProgress != candidates[j].inProgress {
 			return candidates[i].inProgress
 		}
-		return candidates[i].priority < candidates[j].priority
+		if candidates[i].priority != candidates[j].priority {
+			return candidates[i].priority < candidates[j].priority
+		}
+		// Same in-progress + priority: prefer plan-children (non-empty
+		// .plan) over orphans (empty .plan) so the more-contextful
+		// suggestion ranks first.
+		iPlan := candidates[i].plan != ""
+		jPlan := candidates[j].plan != ""
+		return iPlan && !jPlan
 	})
 
 	// Take top 3
@@ -697,10 +769,15 @@ func (s *Server) handleGetDashboard(w http.ResponseWriter, r *http.Request) {
 	for _, c := range candidates[:limit] {
 		pri := extractFieldValue(c.item.Fields, "priority")
 		var reason string
-		if c.inProgress {
+		switch {
+		case c.inProgress && c.plan != "":
 			reason = "In-progress task in active plan \"" + c.plan + "\""
-		} else {
+		case c.inProgress:
+			reason = "In-progress task"
+		case c.plan != "":
 			reason = "Open task in active plan \"" + c.plan + "\""
+		default:
+			reason = "Open task"
 		}
 		if pri != "" {
 			reason += " (" + pri + " priority)"

--- a/internal/server/handlers_dashboard_test.go
+++ b/internal/server/handlers_dashboard_test.go
@@ -642,11 +642,17 @@ func TestDashboardSuggestedNext_FiltersBlockedItems(t *testing.T) {
 	}
 }
 
+// TestDashboardSuggestedNextNoPlans pins BUG-1082's orphan branch:
+// pre-fix this test asserted that a workspace with no active plans
+// returns empty suggested_next. That was the bug — the dashboard
+// gave agents zero guidance even when an obvious high-priority open
+// task existed. Post-fix the orphan branch surfaces high-priority
+// open items even outside any plan.
 func TestDashboardSuggestedNextNoPlans(t *testing.T) {
 	srv := testServer(t)
 	slug := createWSWithCollections(t, srv)
 
-	// Create tasks but no active plans
+	// High-priority open task with no active plan parent.
 	createItem(t, srv, slug, "tasks", map[string]interface{}{
 		"title":  "Orphan Task",
 		"fields": `{"status":"open","priority":"high"}`,
@@ -654,16 +660,29 @@ func TestDashboardSuggestedNextNoPlans(t *testing.T) {
 
 	resp := getDashboard(t, srv, slug)
 
-	if len(resp.SuggestedNext) != 0 {
-		t.Errorf("expected 0 suggested_next without active plans, got %d", len(resp.SuggestedNext))
+	if len(resp.SuggestedNext) != 1 {
+		t.Fatalf("expected 1 suggested_next (high-priority orphan), got %d: %+v",
+			len(resp.SuggestedNext), resp.SuggestedNext)
+	}
+	if got := resp.SuggestedNext[0].ItemTitle; got != "Orphan Task" {
+		t.Errorf("expected Orphan Task, got %q", got)
+	}
+	// Reason should NOT name a plan since there isn't one.
+	if reason := resp.SuggestedNext[0].Reason; strings.Contains(reason, "active plan") {
+		t.Errorf("orphan reason should not reference an active plan; got %q", reason)
 	}
 }
 
+// TestDashboardSuggestedNextFromPlannedPlan: tasks under a NOT-active
+// plan rank as orphans (since their plan parent doesn't trigger the
+// active-plan loop). Pre-BUG-1082 they were invisible.
 func TestDashboardSuggestedNextFromPlannedPlan(t *testing.T) {
 	srv := testServer(t)
 	slug := createWSWithCollections(t, srv)
 
-	// Planned plan — should NOT contribute to suggested_next
+	// Planned (not active) plan — tasks under it are functionally
+	// orphans for the active-plan loop. The orphan branch should
+	// surface high-priority ones.
 	plan := createItem(t, srv, slug, "plans", map[string]interface{}{
 		"title":  "Planned Plan",
 		"fields": `{"status":"planned"}`,
@@ -676,8 +695,76 @@ func TestDashboardSuggestedNextFromPlannedPlan(t *testing.T) {
 
 	resp := getDashboard(t, srv, slug)
 
-	if len(resp.SuggestedNext) != 0 {
-		t.Errorf("expected 0 suggested_next from planned plan, got %d", len(resp.SuggestedNext))
+	if len(resp.SuggestedNext) != 1 {
+		t.Fatalf("expected 1 suggested_next (orphan-of-planned-plan), got %d: %+v",
+			len(resp.SuggestedNext), resp.SuggestedNext)
+	}
+	if got := resp.SuggestedNext[0].ItemTitle; got != "Task in Planned Plan" {
+		t.Errorf("expected Task in Planned Plan, got %q", got)
+	}
+}
+
+// TestDashboardSuggestedNextOrphan_InProgressBeatsPriority pins
+// BUG-1082's gating rule for the orphan branch: in-progress items
+// surface regardless of priority, but open items must be high or
+// critical to surface (avoids flooding suggestions with low-priority
+// open work). The "continue what's in flight" signal beats priority.
+func TestDashboardSuggestedNextOrphan_InProgressBeatsPriority(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	// Low-priority in-progress orphan should surface.
+	createItem(t, srv, slug, "tasks", map[string]interface{}{
+		"title":  "Low-Pri In-Progress Orphan",
+		"fields": `{"status":"in-progress","priority":"low"}`,
+	})
+	// Low-priority OPEN orphan should NOT surface.
+	createItem(t, srv, slug, "tasks", map[string]interface{}{
+		"title":  "Low-Pri Open Orphan",
+		"fields": `{"status":"open","priority":"low"}`,
+	})
+
+	resp := getDashboard(t, srv, slug)
+
+	if len(resp.SuggestedNext) != 1 {
+		t.Fatalf("expected exactly 1 suggested_next (in-progress only), got %d: %+v",
+			len(resp.SuggestedNext), resp.SuggestedNext)
+	}
+	if got := resp.SuggestedNext[0].ItemTitle; got != "Low-Pri In-Progress Orphan" {
+		t.Errorf("expected in-progress orphan, got %q", got)
+	}
+}
+
+// TestDashboardSuggestedNextOrphan_RanksBelowActivePlan pins the
+// rank order: when both an active-plan candidate AND an orphan
+// candidate exist at the same in-progress / priority bucket, the
+// active-plan one comes first (more contextful).
+func TestDashboardSuggestedNextOrphan_RanksBelowActivePlan(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	plan := createItem(t, srv, slug, "plans", map[string]interface{}{
+		"title":  "Active Plan",
+		"fields": `{"status":"active"}`,
+	})
+	createItem(t, srv, slug, "tasks", map[string]interface{}{
+		"title":  "In Active Plan",
+		"fields": `{"status":"in-progress","priority":"medium","parent":"` + plan.ID + `"}`,
+	})
+	createItem(t, srv, slug, "tasks", map[string]interface{}{
+		"title":  "Orphan",
+		"fields": `{"status":"in-progress","priority":"medium"}`,
+	})
+
+	resp := getDashboard(t, srv, slug)
+
+	if len(resp.SuggestedNext) < 2 {
+		t.Fatalf("expected ≥2 suggested_next, got %d: %+v",
+			len(resp.SuggestedNext), resp.SuggestedNext)
+	}
+	if got := resp.SuggestedNext[0].ItemTitle; got != "In Active Plan" {
+		t.Errorf("expected active-plan candidate first, got %q (full list: %+v)",
+			got, resp.SuggestedNext)
 	}
 }
 

--- a/internal/server/handlers_stars.go
+++ b/internal/server/handlers_stars.go
@@ -58,7 +58,18 @@ func (s *Server) handleStarItem(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 
-	w.WriteHeader(http.StatusNoContent)
+	// Return a structured success body so MCP clients consuming this
+	// through HTTPHandlerDispatcher get a non-empty signal (BUG-1081).
+	// Pre-fix this returned 204 No Content — RESTfully fine, but the
+	// MCP transport surfaces empty bodies as empty tool results, which
+	// gives agents no confirmation the operation landed. The shape
+	// ({ref, starred}) matches BUG-989's original spec for these
+	// actions and the broader "return enough info to be the next
+	// source of truth" pattern that note/decide adopted.
+	writeJSON(w, http.StatusOK, map[string]any{
+		"ref":     item.Ref,
+		"starred": true,
+	})
 }
 
 // handleUnstarItem removes a star from an item for the authenticated user.
@@ -114,7 +125,12 @@ func (s *Server) handleUnstarItem(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 
-	w.WriteHeader(http.StatusNoContent)
+	// Same structured-body pattern as handleStarItem — see BUG-1081
+	// rationale there.
+	writeJSON(w, http.StatusOK, map[string]any{
+		"ref":     item.Ref,
+		"starred": false,
+	})
 }
 
 // handleListStarredItems returns all starred items for the authenticated user in a workspace.

--- a/internal/server/handlers_stars_test.go
+++ b/internal/server/handlers_stars_test.go
@@ -1,0 +1,130 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// TestStarUnstar_ReturnsStructuredJSON pins BUG-1081's fix: pre-fix
+// both endpoints returned 204 No Content with an empty body, which
+// the MCP HTTPHandlerDispatcher surfaced as an empty tool result —
+// agents had no signal whether the operation landed. Post-fix both
+// return 200 OK with `{ref, starred}` so MCP clients see a non-empty
+// response that confirms the toggle.
+//
+// Pin both directions of the toggle (star + unstar) so a future PR
+// that re-introduces 204 (or drops the JSON branch) regresses the
+// test rather than the user.
+func TestStarUnstar_ReturnsStructuredJSON(t *testing.T) {
+	srv := testServer(t)
+
+	// Seed workspace + item via the no-users-exist path (no auth
+	// required — the workspace creation handler accepts requests in
+	// that mode and grants implicit owner). Star handlers DO require
+	// a real user, so we mint one + an API token after seeding,
+	// then use Bearer auth for the star calls (Bearer bypasses
+	// CSRF — see middleware_csrf.go:73).
+	slug := createWSWithCollections(t, srv)
+	rr := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections/tasks/items",
+		map[string]interface{}{"title": "Star me", "fields": `{"status":"open"}`})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("seed item: %d %s", rr.Code, rr.Body.String())
+	}
+	var item models.Item
+	parseJSON(t, rr, &item)
+	if item.Ref == "" {
+		t.Fatalf("seed item has no ref")
+	}
+
+	user, err := srv.store.CreateUser(models.UserCreate{
+		Email:    "star-test@example.com",
+		Name:     "Star Tester",
+		Password: "pw-test-12345",
+	})
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	// Tokens are workspace-scoped at the schema level — pull the
+	// workspace ID out of the seeded slug.
+	ws, err := srv.store.GetWorkspaceBySlug(slug)
+	if err != nil {
+		t.Fatalf("GetWorkspaceBySlug: %v", err)
+	}
+	if err := srv.store.AddWorkspaceMember(ws.ID, user.ID, "owner"); err != nil {
+		t.Fatalf("AddWorkspaceMember: %v", err)
+	}
+	tok, err := srv.store.CreateAPIToken(user.ID, models.APITokenCreate{
+		Name:        "star-test",
+		WorkspaceID: ws.ID,
+	}, 0, 0)
+	if err != nil {
+		t.Fatalf("CreateAPIToken: %v", err)
+	}
+
+	starCall := func(method string) *httptest.ResponseRecorder {
+		t.Helper()
+		req := httptest.NewRequest(method, "/api/v1/workspaces/"+slug+"/items/"+item.Slug+"/star", nil)
+		req.Header.Set("Authorization", "Bearer "+tok.Token)
+		req.RemoteAddr = "127.0.0.1:0"
+		rec := httptest.NewRecorder()
+		srv.ServeHTTP(rec, req)
+		return rec
+	}
+
+	// Star: expect 200 + {ref, starred:true}, NOT 204 with empty body.
+	rr = starCall("POST")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("star: expected 200, got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+	if rr.Body.Len() == 0 {
+		t.Fatal("star: body is empty — BUG-1081 regression (was 204 No Content pre-fix)")
+	}
+	var starResp map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &starResp); err != nil {
+		t.Fatalf("parse star response: %v (body: %s)", err, rr.Body.String())
+	}
+	if got := starResp["ref"]; got != item.Ref {
+		t.Errorf("star: expected ref=%q, got %v", item.Ref, got)
+	}
+	if got := starResp["starred"]; got != true {
+		t.Errorf("star: expected starred=true, got %v", got)
+	}
+
+	// Unstar: same shape, with starred:false.
+	rr = starCall("DELETE")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("unstar: expected 200, got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+	if rr.Body.Len() == 0 {
+		t.Fatal("unstar: body is empty — BUG-1081 regression")
+	}
+	var unstarResp map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &unstarResp); err != nil {
+		t.Fatalf("parse unstar response: %v (body: %s)", err, rr.Body.String())
+	}
+	if got := unstarResp["ref"]; got != item.Ref {
+		t.Errorf("unstar: expected ref=%q, got %v", item.Ref, got)
+	}
+	if got := unstarResp["starred"]; got != false {
+		t.Errorf("unstar: expected starred=false, got %v", got)
+	}
+
+	// Sanity — content-type should be JSON. If a future change drops
+	// the writeJSON helper for a bare WriteHeader, this catches it.
+	for _, op := range []string{"POST", "DELETE"} {
+		rr = starCall(op)
+		ct := rr.Header().Get("Content-Type")
+		if !strings.HasPrefix(ct, "application/json") {
+			t.Errorf("%s /star: expected application/json content-type, got %q", op, ct)
+		}
+	}
+
+	// Quiet the unused import warning in case `bytes` ever drops.
+	_ = bytes.NewReader
+}


### PR DESCRIPTION
## Summary

Three independent fixes from Claude Desktop's second-round MCP review, bundled because they all polish the same MCP-tool-call user experience.

### BUG-1081 — star/unstar return structured JSON
`handleStarItem` / `handleUnstarItem` previously returned 204 No Content. The MCP HTTPHandlerDispatcher passes through whatever the handler wrote — empty body + 204 → empty MCP tool result. Now both return `200 OK` with `{ref, starred: bool}`.

### BUG-1082 — suggested_next surfaces orphans
The candidate loop only walked active-plan children. Workspaces without active plans (or with in-progress / high-priority items outside their active plans) got an empty `suggested_next` even when "continue your in-progress task" was the obvious answer. Added an orphan branch that scans for in-progress items (any priority — continuation always beats priority) and high/critical-priority open items not already in the active-plan candidates. Orphans rank lower than plan-children so existing plan-driven behavior is preserved.

### TASK-1076 — workspace auto-default from OAuth allow-list
Dispatcher now calls `maybeInjectWorkspace` after the existing `--assign` / `--role` resolution. When the OAuth lister returns exactly one workspace, the dispatcher injects it into `input["workspace"]` so callers don't have to pass it on every tool call. Caller-passed workspace ALWAYS wins. Multi-workspace tokens still require explicit choice (silently picking would be an audience-confusion hazard for write operations). Reuses the existing `oauthWorkspaceLister` so the OAuth allow-list policy lives in one place.

## Test plan

- [x] `TestStarUnstar_ReturnsStructuredJSON` — pins {ref, starred} shape on both endpoints; negative-controlled (revert handler → test fails on first assertion)
- [x] `TestDashboardSuggestedNextNoPlans` + `TestDashboardSuggestedNextFromPlannedPlan` reframed from pin-the-old-bug to pin-the-new-correct-behavior
- [x] `TestDashboardSuggestedNextOrphan_InProgressBeatsPriority` + `TestDashboardSuggestedNextOrphan_RanksBelowActivePlan` pin the new gating + ordering
- [x] `TestMaybeInjectWorkspace_*` — 7 cases covering the four-case spec matrix + nil-lister + lister-error + copy-on-write
- [x] `make check` clean (lint + all Go tests + web build)
- [x] Codex review CLEAN round 1 — focused on whether the auto-default opens any audience-confusion attack surface beyond the existing OAuth allow-list (it doesn't; we only auto-inject when the resolved set collapses to one, and the lister already encodes the right policy)
- [ ] Post-deploy: Claude Desktop sees `pad_workspace list` returning 200, `pad_item star TASK-N` returning `{ref, starred:true}`, `pad_project dashboard` returning a suggested_next with the in-progress task even when no plans exist, and tool calls with single-workspace OAuth tokens succeeding without explicit workspace=