### PR TITLE
fix(mcp): normalize error envelope shape + extend code taxonomy + actionable hints (TASK-1077/1078/1079)

### DIFF
--- a/internal/mcp/catalog.go
+++ b/internal/mcp/catalog.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"fmt"
 	"sort"
 	"strings"
 
@@ -149,9 +150,11 @@ func (env ActionEnv) Dispatch(ctx context.Context, cmdPath []string, input map[s
 	pathStr := strings.Join(cmdPath, " ")
 	cmdInfo, ok := env.Doc.Commands[pathStr]
 	if !ok {
-		return mcp.NewToolResultErrorf(
-			"action mapped to unknown cmdPath %q (catalog/cmdhelp drift)",
-			pathStr), nil
+		return NewErrorResult(ErrorPayload{
+			Code:    ErrServerError,
+			Message: fmt.Sprintf("action mapped to unknown cmdPath %q (catalog/cmdhelp drift)", pathStr),
+			Hint:    "Catalog action's cmdPath doesn't appear in the cmdhelp Doc — programmer error in the catalog. File a bug.",
+		}), nil
 	}
 	cliArgs, err := BuildCLIArgs(cmdInfo, input, env.Workspace.Get(), env.RootFlags)
 	if err != nil {
@@ -379,16 +382,20 @@ func sortedActionNames(def ToolDef) []string {
 // has no `action` field. Lists the valid actions inline so agents can
 // retry with a correct value.
 func errMissingAction(def ToolDef) *mcp.CallToolResult {
-	return mcp.NewToolResultErrorf(
-		"%s: missing required field 'action'. Valid actions: %s",
-		def.Name, strings.Join(sortedActionNames(def), ", "))
+	return NewErrorResult(ErrorPayload{
+		Code:    ErrValidationFailed,
+		Message: fmt.Sprintf("%s: missing required field 'action'", def.Name),
+		Hint:    "Pass `action=<verb>`. Valid actions: " + strings.Join(sortedActionNames(def), ", "),
+	})
 }
 
 // errUnknownAction is the structured result returned when `action` is
 // set but not in the tool's action table. Same listing as
 // errMissingAction so agents can self-correct.
 func errUnknownAction(def ToolDef, action string) *mcp.CallToolResult {
-	return mcp.NewToolResultErrorf(
-		"%s: unknown action %q. Valid actions: %s",
-		def.Name, action, strings.Join(sortedActionNames(def), ", "))
+	return NewErrorResult(ErrorPayload{
+		Code:    ErrValidationFailed,
+		Message: fmt.Sprintf("%s: unknown action %q", def.Name, action),
+		Hint:    "Valid actions: " + strings.Join(sortedActionNames(def), ", "),
+	})
 }

--- a/internal/mcp/catalog_item.go
+++ b/internal/mcp/catalog_item.go
@@ -379,11 +379,22 @@ func joinSorted(ss []string) string {
 }
 
 // errStructured wraps a Go error into the standard MCP tool-error
-// shape with a stable identifier prefix (e.g. "pad_item.link").
-// Local helper — avoids leaking actionFn-specific formatting up to
-// every caller.
+// envelope (TASK-1077) with a stable identifier prefix (e.g.
+// "pad_item.link"). Local helper — avoids leaking actionFn-specific
+// formatting up to every caller.
+//
+// All catalog-level validation errors that flow through here go to
+// ErrValidationFailed because every current call site is "the agent
+// passed bad input" (missing link_type, missing refs, unknown
+// link_type, etc.). If a future call site needs a different code,
+// give it its own helper rather than overloading this one — keeps
+// the code-per-call-site mapping explicit.
 func errStructured(prefix string, err error) *mcp.CallToolResult {
-	return mcp.NewToolResultErrorf("%s: %s", prefix, err.Error())
+	return NewErrorResult(ErrorPayload{
+		Code:    ErrValidationFailed,
+		Message: fmt.Sprintf("%s: %s", prefix, err.Error()),
+		Hint:    "Check the input shape against the tool's schema.",
+	})
 }
 
 // actionItemBulkUpdate translates the catalog's `refs: array<string>`

--- a/internal/mcp/catalog_item_test.go
+++ b/internal/mcp/catalog_item_test.go
@@ -139,8 +139,12 @@ func TestPadItemLink_UnknownLinkType(t *testing.T) {
 	if !res.IsError {
 		t.Fatalf("expected IsError, got %s", textOf(res))
 	}
+	// Post-TASK-1077 the message lives inside the structured envelope
+	// (quotes are JSON-escaped in the wire form). Substring on the
+	// bad-value token is sufficient; the literal-quoted form has
+	// backslashes around it.
 	msg := textOf(res)
-	if !strings.Contains(msg, `unknown link_type "totally-invalid"`) {
+	if !strings.Contains(msg, `totally-invalid`) {
 		t.Errorf("message %q should name the bad value", msg)
 	}
 }

--- a/internal/mcp/catalog_test.go
+++ b/internal/mcp/catalog_test.go
@@ -235,8 +235,11 @@ func TestMakeFanOutHandler_UnknownAction(t *testing.T) {
 	if !res.IsError {
 		t.Errorf("expected IsError=true for unknown action")
 	}
+	// Post-TASK-1077 the error result is a structured envelope; the
+	// text content is the JSON-encoded body. Look for the action name
+	// (escaped because it's inside JSON) and the listed valid action.
 	msg := textOf(res)
-	if !strings.Contains(msg, `unknown action "nope"`) {
+	if !strings.Contains(msg, `nope`) {
 		t.Errorf("error message %q does not name the bad action", msg)
 	}
 	if !strings.Contains(msg, "foo") {
@@ -299,8 +302,12 @@ func TestActionEnv_Dispatch_UnknownCmdPath(t *testing.T) {
 	if !res.IsError {
 		t.Fatalf("expected IsError=true for unknown cmdPath")
 	}
-	if !strings.Contains(textOf(res), `unknown cmdPath "item ghost"`) {
-		t.Errorf("error message %q should name the missing cmdPath", textOf(res))
+	// Post-TASK-1077 the message is JSON-encoded inside the structured
+	// envelope (escaped quotes around "item ghost"). Check for the
+	// path tokens individually rather than the literal-quoted form.
+	msg := textOf(res)
+	if !strings.Contains(msg, `item ghost`) {
+		t.Errorf("error message %q should name the missing cmdPath", msg)
 	}
 }
 

--- a/internal/mcp/dispatch_http.go
+++ b/internal/mcp/dispatch_http.go
@@ -215,10 +215,18 @@ var noRemoteEquivalent = map[string]string{
 //     synthesized request, and execute through the handler chain.
 func (d *HTTPHandlerDispatcher) Dispatch(ctx context.Context, cmdPath, _ []string) (*mcp.CallToolResult, error) {
 	if d.Handler == nil {
-		return mcp.NewToolResultError("HTTPHandlerDispatcher: Handler not configured"), nil
+		return NewErrorResult(ErrorPayload{
+			Code:    ErrServerError,
+			Message: "HTTPHandlerDispatcher: Handler not configured",
+			Hint:    "Wire d.Handler before invoking Dispatch (programmer error).",
+		}), nil
 	}
 	if d.UserResolver == nil {
-		return mcp.NewToolResultError("HTTPHandlerDispatcher: UserResolver not configured"), nil
+		return NewErrorResult(ErrorPayload{
+			Code:    ErrServerError,
+			Message: "HTTPHandlerDispatcher: UserResolver not configured",
+			Hint:    "Wire d.UserResolver before invoking Dispatch (programmer error).",
+		}), nil
 	}
 
 	cmdKey := strings.Join(cmdPath, " ")
@@ -231,15 +239,20 @@ func (d *HTTPHandlerDispatcher) Dispatch(ctx context.Context, cmdPath, _ []strin
 	// agent a hint about WHY (and, for the github / attachment
 	// commands, the alternative path).
 	if rationale, local := noRemoteEquivalent[cmdKey]; local {
-		return mcp.NewToolResultErrorf(
-			"%s: no remote equivalent — CLI-only command (%s)",
-			cmdKey, rationale,
-		), nil
+		return NewErrorResult(ErrorPayload{
+			Code:    ErrValidationFailed,
+			Message: fmt.Sprintf("%s: no remote equivalent — CLI-only command", cmdKey),
+			Hint:    rationale,
+		}), nil
 	}
 
 	user := d.UserResolver(ctx)
 	if user == nil {
-		return mcp.NewToolResultErrorf("%s: no authenticated user in context", cmdKey), nil
+		return NewErrorResult(ErrorPayload{
+			Code:    ErrAuthRequired,
+			Message: fmt.Sprintf("%s: no authenticated user in context", cmdKey),
+			Hint:    "Re-authenticate (Claude Desktop: reconnect connector; CLI: pad auth login).",
+		}), nil
 	}
 
 	input := DispatchInputFromContext(ctx)
@@ -257,7 +270,8 @@ func (d *HTTPHandlerDispatcher) Dispatch(ctx context.Context, cmdPath, _ []strin
 		var err error
 		input, err = d.resolveAssignName(ctx, user, input)
 		if err != nil {
-			return mcp.NewToolResultErrorf("%s: resolve --assign: %s", cmdKey, err.Error()), nil
+			return validationFailedResult(cmdKey, "resolve --assign: "+err.Error(),
+				"Pass `assign=<user-name|email>` matching a workspace member, or `assigned_user_id=<uuid>` directly."), nil
 		}
 	}
 
@@ -271,7 +285,8 @@ func (d *HTTPHandlerDispatcher) Dispatch(ctx context.Context, cmdPath, _ []strin
 		var err error
 		input, err = d.resolveRoleSlug(ctx, user, input)
 		if err != nil {
-			return mcp.NewToolResultErrorf("%s: resolve --role: %s", cmdKey, err.Error()), nil
+			return validationFailedResult(cmdKey, "resolve --role: "+err.Error(),
+				"Pass `role=<slug>` matching an existing agent role, or `agent_role_id=<uuid>` directly."), nil
 		}
 	}
 
@@ -353,15 +368,17 @@ func (d *HTTPHandlerDispatcher) Dispatch(ctx context.Context, cmdPath, _ []strin
 		// wired into the HTTP route table. The registry intentionally
 		// advertises every safe leaf command from PLAN-942's tool
 		// surface; the route table grows incrementally.
-		return mcp.NewToolResultErrorf(
-			"%s: not yet implemented over HTTP transport "+
-				"(see internal/mcp/dispatch_http.go routeTable)", cmdKey,
-		), nil
+		return NewErrorResult(ErrorPayload{
+			Code:    ErrServerError,
+			Message: fmt.Sprintf("%s: not yet implemented over HTTP transport", cmdKey),
+			Hint:    "This command is registered as an MCP tool but no route mapper has been wired in internal/mcp/dispatch_http_routes.go. File a feature request or use the CLI/stdio MCP path.",
+		}), nil
 	}
 
 	method, urlPath, body, err := mapper(input)
 	if err != nil {
-		return mcp.NewToolResultErrorf("%s: %s", cmdKey, err.Error()), nil
+		return validationFailedResult(cmdKey, err.Error(),
+			"Check the input shape against the tool's schema (most route-mapper errors are missing required path placeholders)."), nil
 	}
 
 	return d.executeRequest(ctx, cmdKey, user, method, urlPath, body)
@@ -386,7 +403,19 @@ func (d *HTTPHandlerDispatcher) executeRequest(
 ) (*mcp.CallToolResult, error) {
 	req, err := d.buildAuthedRequest(ctx, method, urlPath, body, user)
 	if err != nil {
-		return mcp.NewToolResultErrorf("%s: build request: %s", cmdKey, err.Error()), nil
+		// Most build-request failures are scope-rejection from
+		// buildAuthedRequest's TokenScopeAllows check (PATCH on a
+		// read-only token, etc.). Surface as permission_denied so
+		// agents see the same code as a backend 403, not a
+		// generic server_error.
+		if strings.HasPrefix(err.Error(), "permission_denied:") {
+			return NewErrorResult(ErrorPayload{
+				Code:    ErrPermissionDenied,
+				Message: fmt.Sprintf("%s: %s", cmdKey, err.Error()),
+				Hint:    "Token scope does not permit this operation. Re-issue with the required scopes (read for GET; write for POST/PATCH; admin for workspace settings).",
+			}), nil
+		}
+		return dispatcherErrorResult(cmdKey, "build request", err), nil
 	}
 
 	rec := httptest.NewRecorder()
@@ -542,7 +571,7 @@ func packageHTTPResponse(ctx context.Context, cmdKey string, resp *http.Response
 	defer resp.Body.Close()
 	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return mcp.NewToolResultErrorf("%s: read response: %s", cmdKey, err.Error()), nil
+		return dispatcherErrorResult(cmdKey, "read response", err), nil
 	}
 	body := string(bodyBytes)
 

--- a/internal/mcp/dispatch_http_advanced.go
+++ b/internal/mcp/dispatch_http_advanced.go
@@ -262,10 +262,12 @@ func (d *HTTPHandlerDispatcher) dispatchItemUpdate(
 	workspace, _ := input["workspace"].(string)
 	ref, _ := input["ref"].(string)
 	if workspace == "" {
-		return mcp.NewToolResultErrorf("%s: workspace is required", cmdKey), nil
+		return validationFailedResult(cmdKey, "workspace is required",
+			"Pass `workspace=<slug>` or set a session default via pad_set_workspace."), nil
 	}
 	if ref == "" {
-		return mcp.NewToolResultErrorf("%s: ref is required", cmdKey), nil
+		return validationFailedResult(cmdKey, "ref is required",
+			"Pass `ref=<TASK-N>` (or whichever item ref to update)."), nil
 	}
 
 	itemPath := "/api/v1/workspaces/" + url.PathEscape(workspace) +
@@ -289,7 +291,7 @@ func (d *HTTPHandlerDispatcher) dispatchItemUpdate(
 	// hook) sees this prefetch the same as a top-level dispatch.
 	prefetchReq, err := d.buildAuthedRequest(ctx, http.MethodGet, itemPath, nil, user)
 	if err != nil {
-		return mcp.NewToolResultErrorf("%s: build prefetch request: %s", cmdKey, err.Error()), nil
+		return dispatcherErrorResult(cmdKey, "build prefetch request", err), nil
 	}
 	prefetchRec := httptest.NewRecorder()
 	d.Handler.ServeHTTP(prefetchRec, prefetchReq)
@@ -308,7 +310,7 @@ func (d *HTTPHandlerDispatcher) dispatchItemUpdate(
 		Fields string `json:"fields"`
 	}
 	if err := json.Unmarshal(prefetchRec.Body.Bytes(), &existing); err != nil {
-		return mcp.NewToolResultErrorf("%s: parse current item: %s", cmdKey, err.Error()), nil
+		return dispatcherErrorResult(cmdKey, "parse current item", err), nil
 	}
 
 	// Step 2: Build the PATCH payload.
@@ -336,8 +338,7 @@ func (d *HTTPHandlerDispatcher) dispatchItemUpdate(
 		merged := map[string]any{}
 		if existing.Fields != "" && existing.Fields != "{}" {
 			if err := json.Unmarshal([]byte(existing.Fields), &merged); err != nil {
-				return mcp.NewToolResultErrorf(
-					"%s: parse existing fields JSON: %s", cmdKey, err.Error()), nil
+				return dispatcherErrorResult(cmdKey, "parse existing fields JSON", err), nil
 			}
 		}
 		for _, key := range []string{"status", "priority", "category", "parent"} {
@@ -348,7 +349,8 @@ func (d *HTTPHandlerDispatcher) dispatchItemUpdate(
 		if rawFields, ok := input["field"]; ok {
 			extra, err := parseFieldKVP(rawFields)
 			if err != nil {
-				return mcp.NewToolResultErrorf("%s: parse --field: %s", cmdKey, err.Error()), nil
+				return validationFailedResult(cmdKey, "parse --field: "+err.Error(),
+					"--field expects key=value entries (string array or single string)."), nil
 			}
 			for k, v := range extra {
 				merged[k] = v
@@ -362,7 +364,7 @@ func (d *HTTPHandlerDispatcher) dispatchItemUpdate(
 		liftFieldsToColumns(merged, payload)
 		fieldsJSON, err := json.Marshal(merged)
 		if err != nil {
-			return mcp.NewToolResultErrorf("%s: encode merged fields: %s", cmdKey, err.Error()), nil
+			return dispatcherErrorResult(cmdKey, "encode merged fields", err), nil
 		}
 		fieldsStr := string(fieldsJSON)
 		payload["fields"] = fieldsStr
@@ -370,7 +372,7 @@ func (d *HTTPHandlerDispatcher) dispatchItemUpdate(
 
 	body, err := json.Marshal(payload)
 	if err != nil {
-		return mcp.NewToolResultErrorf("%s: encode body: %s", cmdKey, err.Error()), nil
+		return dispatcherErrorResult(cmdKey, "encode body", err), nil
 	}
 
 	// Step 3: PATCH.

--- a/internal/mcp/dispatch_http_attachments.go
+++ b/internal/mcp/dispatch_http_attachments.go
@@ -2,13 +2,13 @@ package mcp
 
 import (
 	"context"
+	"fmt"
 	goMime "mime"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"path/filepath"
 	"strconv"
-	"strings"
 
 	"github.com/mark3labs/mcp-go/mcp"
 
@@ -40,21 +40,22 @@ func (d *HTTPHandlerDispatcher) dispatchAttachmentList(
 	const cmdKey = "attachment list"
 	workspace, _ := input["workspace"].(string)
 	if workspace == "" {
-		return mcp.NewToolResultErrorf("%s: workspace is required", cmdKey), nil
+		return validationFailedResult(cmdKey, "workspace is required",
+			"Pass `workspace=<slug>` or set a session default via pad_set_workspace."), nil
 	}
 
 	attached, _ := input["attached"].(bool)
 	unattached, _ := input["unattached"].(bool)
 	if attached && unattached {
-		return mcp.NewToolResultErrorf(
-			"%s: --attached and --unattached are mutually exclusive", cmdKey,
-		), nil
+		return validationFailedResult(cmdKey,
+			"attached and unattached are mutually exclusive",
+			"Pass at most one of `attached=true` or `unattached=true`."), nil
 	}
 	itemRef, _ := input["item"].(string)
 	if itemRef != "" && unattached {
-		return mcp.NewToolResultErrorf(
-			"%s: --item and --unattached are mutually exclusive", cmdKey,
-		), nil
+		return validationFailedResult(cmdKey,
+			"item and unattached are mutually exclusive",
+			"`item=<ref>` filters to that item's attachments; `unattached=true` filters to attachments NOT linked to any item. Drop one."), nil
 	}
 
 	q := url.Values{}
@@ -86,7 +87,8 @@ func (d *HTTPHandlerDispatcher) dispatchAttachmentList(
 	if itemRef != "" {
 		resolved, err := d.resolveItemRef(ctx, user, workspace, itemRef)
 		if err != nil {
-			return mcp.NewToolResultErrorf("%s: resolve --item: %s", cmdKey, err.Error()), nil
+			return validationFailedResult(cmdKey, "resolve --item: "+err.Error(),
+				fmt.Sprintf("Verify item %q exists in workspace %q (use pad_item search / list).", itemRef, workspace)), nil
 		}
 		q.Set("item_id", resolved.ID)
 	}
@@ -119,11 +121,13 @@ func (d *HTTPHandlerDispatcher) dispatchAttachmentShow(
 	const cmdKey = "attachment show"
 	workspace, _ := input["workspace"].(string)
 	if workspace == "" {
-		return mcp.NewToolResultErrorf("%s: workspace is required", cmdKey), nil
+		return validationFailedResult(cmdKey, "workspace is required",
+			"Pass `workspace=<slug>` or set a session default via pad_set_workspace."), nil
 	}
 	attachmentID, _ := input["attachment_id"].(string)
 	if attachmentID == "" {
-		return mcp.NewToolResultErrorf("%s: attachment_id is required", cmdKey), nil
+		return validationFailedResult(cmdKey, "attachment_id is required",
+			"Pass `attachment_id=<id>` (use pad_item show to see an item's attachments)."), nil
 	}
 
 	urlPath := "/api/v1/workspaces/" + url.PathEscape(workspace) +
@@ -134,17 +138,14 @@ func (d *HTTPHandlerDispatcher) dispatchAttachmentShow(
 
 	req, err := d.buildAuthedRequest(ctx, http.MethodHead, urlPath, nil, user)
 	if err != nil {
-		return mcp.NewToolResultErrorf("%s: build request: %s", cmdKey, err.Error()), nil
+		return dispatcherErrorResult(cmdKey, "build request", err), nil
 	}
 	rec := httptest.NewRecorder()
 	d.Handler.ServeHTTP(rec, req)
 
 	if rec.Code >= 400 {
-		body := strings.TrimSpace(rec.Body.String())
-		if body == "" {
-			body = http.StatusText(rec.Code)
-		}
-		return mcp.NewToolResultErrorf("pad %s failed: %s", cmdKey, body), nil
+		return upstreamHTTPErrorResult(ctx, cmdKey, "fetch attachment metadata", urlPath,
+			rec.Code, rec.Body.Bytes(), d.Lister, ResourceAttachment, attachmentID), nil
 	}
 
 	headers := rec.Result().Header

--- a/internal/mcp/dispatch_http_envelope_test.go
+++ b/internal/mcp/dispatch_http_envelope_test.go
@@ -129,11 +129,16 @@ func TestClassifyHTTPStatus_ValidationOn400(t *testing.T) {
 }
 
 func TestClassifyHTTPStatus_ServerErrorOn500(t *testing.T) {
+	// TASK-1078: 5xx now classifies as upstream_error (transient
+	// backend failure), distinct from server_error (catch-all for
+	// dispatcher internal failures and un-mapped 4xx). The split lets
+	// agents tell "retry the upstream" from "fix the request" /
+	// "file a bug."
 	res := classifyHTTPStatus(context.Background(), "item create", 500,
 		[]byte(`{"error":{"message":"db connection failed"}}`), nil)
 	env := res.StructuredContent.(ErrorEnvelope)
-	if env.Error.Code != ErrServerError {
-		t.Errorf("code: got %q, want %q", env.Error.Code, ErrServerError)
+	if env.Error.Code != ErrUpstreamError {
+		t.Errorf("code: got %q, want %q", env.Error.Code, ErrUpstreamError)
 	}
 }
 

--- a/internal/mcp/dispatch_http_envelope_uniform_test.go
+++ b/internal/mcp/dispatch_http_envelope_uniform_test.go
@@ -1,0 +1,283 @@
+package mcp
+
+// Tests for TASK-1077 / 1078 / 1079 — pin the uniform error envelope
+// shape across every HTTP-dispatcher tool.
+//
+// Pre-fix some dispatchers (note, decide, project next, bulk-update)
+// emitted plain-string errors via NewToolResultErrorf. Post-fix every
+// error path goes through validationFailedResult / dispatcherErrorResult
+// / upstreamHTTPErrorResult, which all wrap the standard envelope:
+//
+//	{"error": {"code": "...", "message": "...", "hint": "..."}}
+//
+// This test parameterizes over each dispatcher's missing-required-input
+// error path because that's the cheapest reproducible failure case
+// (no need to mock a backend handler) and the path most agents will
+// hit when learning the surface.
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// TestDispatcher_AllErrorsUseStructuredEnvelope walks every special-
+// case dispatcher + each link command and asserts that calling them
+// without the required workspace/ref/etc. produces a structured
+// {error: {code, message, hint}} envelope — never a bare string.
+//
+// New dispatchers that emit errors via NewToolResultErrorf will fail
+// this test, which is the regression gate TASK-1077 wants.
+func TestDispatcher_AllErrorsUseStructuredEnvelope(t *testing.T) {
+	user := &models.User{ID: "u-1", Name: "Tester"}
+	d := &HTTPHandlerDispatcher{
+		Handler:      errorHandler(t, "must not call backend"),
+		UserResolver: fixedUserResolver(user),
+	}
+
+	cases := []struct {
+		name     string
+		cmdPath  []string
+		input    map[string]any
+		wantCode ErrorCode // expected envelope code
+	}{
+		// Missing workspace on every workspace-required dispatcher.
+		// The cmdPath list mirrors the special-case switch in
+		// HTTPHandlerDispatcher.Dispatch — adding a new entry there
+		// without a matching case here is a smell.
+		{"item update no workspace", []string{"item", "update"}, map[string]any{}, ErrValidationFailed},
+		{"item deps no workspace", []string{"item", "deps"}, map[string]any{}, ErrValidationFailed},
+		{"item related no workspace", []string{"item", "related"}, map[string]any{}, ErrValidationFailed},
+		{"item implemented-by no workspace", []string{"item", "implemented-by"}, map[string]any{}, ErrValidationFailed},
+		{"item bulk-update no workspace", []string{"item", "bulk-update"}, map[string]any{}, ErrValidationFailed},
+		{"item note no workspace", []string{"item", "note"}, map[string]any{}, ErrValidationFailed},
+		{"item decide no workspace", []string{"item", "decide"}, map[string]any{}, ErrValidationFailed},
+		{"project ready no workspace", []string{"project", "ready"}, map[string]any{}, ErrValidationFailed},
+		{"project stale no workspace", []string{"project", "stale"}, map[string]any{}, ErrValidationFailed},
+		{"project next no workspace", []string{"project", "next"}, map[string]any{}, ErrValidationFailed},
+		{"project standup no workspace", []string{"project", "standup"}, map[string]any{}, ErrValidationFailed},
+		{"project changelog no workspace", []string{"project", "changelog"}, map[string]any{}, ErrValidationFailed},
+		{"attachment list no workspace", []string{"attachment", "list"}, map[string]any{}, ErrValidationFailed},
+		{"attachment show no workspace", []string{"attachment", "show"}, map[string]any{}, ErrValidationFailed},
+
+		// Link commands — workspace required, then refs.
+		{"item block no workspace", []string{"item", "block"}, map[string]any{}, ErrValidationFailed},
+		{"item blocked-by no workspace", []string{"item", "blocked-by"}, map[string]any{}, ErrValidationFailed},
+		{"item unblock no workspace", []string{"item", "unblock"}, map[string]any{}, ErrValidationFailed},
+
+		// Library commands.
+		{"library activate no workspace", []string{"library", "activate"}, map[string]any{}, ErrValidationFailed},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := WithDispatchInput(context.Background(), tc.input)
+			res, err := d.Dispatch(ctx, tc.cmdPath, nil)
+			if err != nil {
+				t.Fatalf("Dispatch protocol error: %v", err)
+			}
+			if res == nil {
+				t.Fatal("nil result")
+			}
+			if !res.IsError {
+				t.Errorf("expected IsError=true; result=%+v", res)
+			}
+			env := unwrapErrorEnvelope(t, res)
+			if env.Error.Code != tc.wantCode {
+				t.Errorf("code: got %q, want %q (full envelope: %+v)",
+					env.Error.Code, tc.wantCode, env.Error)
+			}
+			if env.Error.Message == "" {
+				t.Error("envelope missing Message")
+			}
+			if env.Error.Hint == "" {
+				t.Error("envelope missing Hint — agents need actionable recovery text (TASK-1079)")
+			}
+			// Hints should NOT be the literal "404 page not found" /
+			// "page not found" passthrough that triggered Bug 17.
+			if strings.EqualFold(env.Error.Hint, "404 page not found") ||
+				strings.EqualFold(env.Error.Hint, "page not found") {
+				t.Errorf("hint is the raw HTTP status text — not actionable (Bug 17 / TASK-1079): %q",
+					env.Error.Hint)
+			}
+		})
+	}
+}
+
+// TestClassifyHTTPStatus_KindAware pins TASK-1078's resource-kind
+// classification — 404s split into item_not_found / unknown_workspace /
+// not_found based on what the dispatcher was reading, instead of the
+// pre-fix blanket item_not_found.
+func TestClassifyHTTPStatus_KindAware(t *testing.T) {
+	cases := []struct {
+		name     string
+		kind     ResourceKind
+		wantCode ErrorCode
+	}{
+		{"item lookup → item_not_found", ResourceItem, ErrItemNotFound},
+		{"workspace lookup → unknown_workspace", ResourceWorkspace, ErrUnknownWorkspace},
+		{"collection lookup → not_found", ResourceCollection, ErrNotFound},
+		{"listing route → not_found", ResourceListing, ErrNotFound},
+		{"link target → not_found", ResourceLink, ErrNotFound},
+		{"attachment → not_found", ResourceAttachment, ErrNotFound},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res := classifyHTTPStatusKind(context.Background(),
+				"item show", "/api/v1/workspaces/foo/items/TASK-7",
+				404, []byte("404 page not found"), nil, tc.kind, "TASK-7")
+			env, ok := res.StructuredContent.(ErrorEnvelope)
+			if !ok {
+				t.Fatalf("expected ErrorEnvelope, got %T", res.StructuredContent)
+			}
+			if env.Error.Code != tc.wantCode {
+				t.Errorf("code: got %q, want %q", env.Error.Code, tc.wantCode)
+			}
+		})
+	}
+}
+
+// TestClassifyHTTPStatus_HintsAreActionable pins TASK-1079's hint
+// improvements: hints reference the actual route + ref (or workspace
+// slug) the dispatcher was reading, and never just dump the upstream
+// "404 page not found" passthrough.
+func TestClassifyHTTPStatus_HintsAreActionable(t *testing.T) {
+	cases := []struct {
+		name             string
+		kind             ResourceKind
+		ref              string
+		route            string
+		body             []byte
+		mustContain      []string
+		mustNotContainEq string // forbid this as the WHOLE hint
+	}{
+		{
+			name:        "item 404 hint references the ref + recovery tools",
+			kind:        ResourceItem,
+			ref:         "TASK-7",
+			route:       "/api/v1/workspaces/foo/items/TASK-7",
+			body:        []byte("404 page not found"),
+			mustContain: []string{"TASK-7", "/api/v1/workspaces/foo/items/TASK-7", "pad_item"},
+		},
+		{
+			name:        "collection 404 hint suggests the listing tool + names route",
+			kind:        ResourceCollection,
+			ref:         "tasks",
+			route:       "/api/v1/workspaces/foo/collections/tasks",
+			body:        []byte("404 page not found"),
+			mustContain: []string{"pad_collection list", "/api/v1/workspaces/foo/collections/tasks"},
+		},
+		{
+			name:        "5xx hint suggests retry + flags as transient",
+			kind:        ResourceItem, // kind doesn't matter for 5xx
+			ref:         "TASK-7",
+			route:       "/api/v1/workspaces/foo/items/TASK-7",
+			body:        []byte(`{"error":{"message":"db down"}}`),
+			mustContain: []string{"transient", "retry", "500"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			status := 404
+			if strings.Contains(tc.name, "5xx") {
+				status = 500
+			}
+			res := classifyHTTPStatusKind(context.Background(),
+				"test cmd", tc.route, status, tc.body, nil, tc.kind, tc.ref)
+			env := res.StructuredContent.(ErrorEnvelope)
+			if env.Error.Hint == "" {
+				t.Fatal("hint is empty")
+			}
+			for _, want := range tc.mustContain {
+				if !strings.Contains(env.Error.Hint, want) {
+					t.Errorf("hint missing %q; got %q", want, env.Error.Hint)
+				}
+			}
+			// Forbid the bare "404 page not found" passthrough that
+			// triggered Bug 17.
+			if env.Error.Hint == "404 page not found" {
+				t.Errorf("hint is the raw HTTP status text passthrough (Bug 17 regression)")
+			}
+		})
+	}
+}
+
+// TestExtractUpstreamMessage covers each shape the helper handles —
+// envelope happy path, chi default 404, and the safe-fallback cases.
+//
+// Codex review #387 round 1 caught that the pre-fix fallback returned
+// the raw body verbatim, which would forward arbitrary upstream JSON
+// (potentially including tokens / passwords / debug dumps) into the
+// hint surface. Post-fix non-envelope bodies return "" — the hint
+// surface omits the upstream-message clause entirely and operators
+// debugging unstructured upstream errors check the pad container
+// logs instead.
+func TestExtractUpstreamMessage(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		// Happy path — pad's writeError envelope shape.
+		{"envelope happy path", `{"error":{"message":"workspace not visible"}}`, "workspace not visible"},
+		{"envelope with sibling fields", `{"error":{"message":"db down"},"code":"db_err"}`, "db down"},
+
+		// chi's default NotFound body — known-zero-value, drop it.
+		{"chi 404 literal", "404 page not found", ""},
+		{"chi 404 with trailing newline", "404 page not found\n", ""},
+
+		// Empty / whitespace input → empty output.
+		{"empty", "", ""},
+		{"whitespace only", "   ", ""},
+
+		// Safe fallbacks: anything we can't recognize as the structured
+		// envelope returns "" rather than leaking the raw body.
+		{"empty inner message", `{"error":{"message":""}}`, ""},
+		{"missing inner message field", `{"error":{}}`, ""},
+		{"unparseable", "not json at all", ""},
+		{"wrong shape", `{"unrelated":"shape"}`, ""},
+		{"html debug dump with token-like content", `<html>internal stack trace with token=abc</html>`, ""},
+		{"sensitive-looking JSON (NOT envelope shape)", `{"secret":"abc","token":"xyz"}`, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := extractUpstreamMessage(tc.in); got != tc.want {
+				t.Errorf("extractUpstreamMessage(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// unwrapErrorEnvelope extracts the structured ErrorEnvelope from a
+// CallToolResult. Test helper — fails fast if the result isn't shaped
+// like a structured envelope (which is the whole regression we're
+// guarding against).
+func unwrapErrorEnvelope(t *testing.T, res *mcp.CallToolResult) ErrorEnvelope {
+	t.Helper()
+	if res == nil {
+		t.Fatal("result is nil")
+	}
+	if env, ok := res.StructuredContent.(ErrorEnvelope); ok {
+		return env
+	}
+	// Fallback: parse the JSON content. Some helpers use
+	// NewErrorResult which sets StructuredContent directly; others
+	// might not have the typed struct populated — try to round-trip
+	// from the text content for robustness.
+	if len(res.Content) > 0 {
+		if tc, ok := res.Content[0].(mcp.TextContent); ok {
+			var env ErrorEnvelope
+			if err := json.Unmarshal([]byte(tc.Text), &env); err == nil && env.Error.Code != "" {
+				return env
+			}
+			t.Fatalf("text content isn't a parseable ErrorEnvelope: %s", tc.Text)
+		}
+	}
+	t.Fatalf("result has no parseable error envelope; result=%+v", res)
+	return ErrorEnvelope{}
+}

--- a/internal/mcp/dispatch_http_links.go
+++ b/internal/mcp/dispatch_http_links.go
@@ -186,25 +186,32 @@ func (d *HTTPHandlerDispatcher) dispatchCreateItemLink(
 ) (*mcp.CallToolResult, error) {
 	workspace, _ := input["workspace"].(string)
 	if workspace == "" {
-		return mcp.NewToolResultErrorf("%s: workspace is required", spec.cmdKey), nil
+		return validationFailedResult(spec.cmdKey, "workspace is required",
+			"Pass `workspace=<slug>` or set a session default via pad_set_workspace."), nil
 	}
 
 	urlRef, _ := input[spec.urlRefKey].(string)
 	if urlRef == "" {
-		return mcp.NewToolResultErrorf("%s: %s is required", spec.cmdKey, spec.urlRefKey), nil
+		return validationFailedResult(spec.cmdKey,
+			fmt.Sprintf("%s is required", spec.urlRefKey),
+			fmt.Sprintf("Pass `%s=<TASK-N>` (the source side of the link).", spec.urlRefKey)), nil
 	}
 	bodyRef, _ := input[spec.bodyTargetRefKey].(string)
 	if bodyRef == "" {
-		return mcp.NewToolResultErrorf("%s: %s is required", spec.cmdKey, spec.bodyTargetRefKey), nil
+		return validationFailedResult(spec.cmdKey,
+			fmt.Sprintf("%s is required", spec.bodyTargetRefKey),
+			fmt.Sprintf("Pass `%s=<TASK-N>` (the target side of the link).", spec.bodyTargetRefKey)), nil
 	}
 
 	urlItem, err := d.resolveItemRef(ctx, user, workspace, urlRef)
 	if err != nil {
-		return mcp.NewToolResultErrorf("%s: %s", spec.cmdKey, err.Error()), nil
+		return validationFailedResult(spec.cmdKey, err.Error(),
+			fmt.Sprintf("Verify item %q exists in workspace %q (use pad_item search / list).", urlRef, workspace)), nil
 	}
 	bodyItem, err := d.resolveItemRef(ctx, user, workspace, bodyRef)
 	if err != nil {
-		return mcp.NewToolResultErrorf("%s: %s", spec.cmdKey, err.Error()), nil
+		return validationFailedResult(spec.cmdKey, err.Error(),
+			fmt.Sprintf("Verify item %q exists in workspace %q (use pad_item search / list).", bodyRef, workspace)), nil
 	}
 
 	payload := map[string]any{
@@ -213,7 +220,7 @@ func (d *HTTPHandlerDispatcher) dispatchCreateItemLink(
 	}
 	body, err := json.Marshal(payload)
 	if err != nil {
-		return mcp.NewToolResultErrorf("%s: encode body: %s", spec.cmdKey, err.Error()), nil
+		return dispatcherErrorResult(spec.cmdKey, "encode body", err), nil
 	}
 
 	urlPath := "/api/v1/workspaces/" + url.PathEscape(workspace) +
@@ -238,36 +245,44 @@ func (d *HTTPHandlerDispatcher) dispatchDeleteItemLink(
 ) (*mcp.CallToolResult, error) {
 	workspace, _ := input["workspace"].(string)
 	if workspace == "" {
-		return mcp.NewToolResultErrorf("%s: workspace is required", spec.cmdKey), nil
+		return validationFailedResult(spec.cmdKey, "workspace is required",
+			"Pass `workspace=<slug>` or set a session default via pad_set_workspace."), nil
 	}
 
 	urlRef, _ := input[spec.urlRefKey].(string)
 	if urlRef == "" {
-		return mcp.NewToolResultErrorf("%s: %s is required", spec.cmdKey, spec.urlRefKey), nil
+		return validationFailedResult(spec.cmdKey,
+			fmt.Sprintf("%s is required", spec.urlRefKey),
+			fmt.Sprintf("Pass `%s=<TASK-N>` (the source side of the link to remove).", spec.urlRefKey)), nil
 	}
 	bodyRef, _ := input[spec.bodyTargetRefKey].(string)
 	if bodyRef == "" {
-		return mcp.NewToolResultErrorf("%s: %s is required", spec.cmdKey, spec.bodyTargetRefKey), nil
+		return validationFailedResult(spec.cmdKey,
+			fmt.Sprintf("%s is required", spec.bodyTargetRefKey),
+			fmt.Sprintf("Pass `%s=<TASK-N>` (the target side of the link to remove).", spec.bodyTargetRefKey)), nil
 	}
 
 	urlItem, err := d.resolveItemRef(ctx, user, workspace, urlRef)
 	if err != nil {
-		return mcp.NewToolResultErrorf("%s: %s", spec.cmdKey, err.Error()), nil
+		return validationFailedResult(spec.cmdKey, err.Error(),
+			fmt.Sprintf("Verify item %q exists in workspace %q.", urlRef, workspace)), nil
 	}
 	bodyItem, err := d.resolveItemRef(ctx, user, workspace, bodyRef)
 	if err != nil {
-		return mcp.NewToolResultErrorf("%s: %s", spec.cmdKey, err.Error()), nil
+		return validationFailedResult(spec.cmdKey, err.Error(),
+			fmt.Sprintf("Verify item %q exists in workspace %q.", bodyRef, workspace)), nil
 	}
 
 	links, err := d.listItemLinks(ctx, user, workspace, urlItem.Slug)
 	if err != nil {
-		return mcp.NewToolResultErrorf("%s: %s", spec.cmdKey, err.Error()), nil
+		return dispatcherErrorResult(spec.cmdKey, "list links", err), nil
 	}
 
 	canonicalType, normErr := models.NormalizeItemLinkType(spec.linkType)
 	if normErr != nil {
 		// Programming error — only canonical types belong in itemLinkSpecs.
-		return mcp.NewToolResultErrorf("%s: invalid link type %q", spec.cmdKey, spec.linkType), nil
+		return dispatcherErrorResult(spec.cmdKey, "validate link type",
+			fmt.Errorf("invalid link type %q", spec.linkType)), nil
 	}
 
 	var linkID string
@@ -285,10 +300,12 @@ func (d *HTTPHandlerDispatcher) dispatchDeleteItemLink(
 		}
 	}
 	if linkID == "" {
-		return mcp.NewToolResultErrorf(
-			"%s: no %s relationship found between %s and %s",
-			spec.cmdKey, spec.linkType, urlRef, bodyRef,
-		), nil
+		return NewErrorResult(ErrorPayload{
+			Code: ErrNotFound,
+			Message: fmt.Sprintf("%s: no %s relationship found between %s and %s",
+				spec.cmdKey, spec.linkType, urlRef, bodyRef),
+			Hint: fmt.Sprintf("Use pad_item action=deps to see existing relationships on %q.", urlRef),
+		}), nil
 	}
 
 	urlPath := "/api/v1/workspaces/" + url.PathEscape(workspace) +
@@ -319,11 +336,13 @@ func (d *HTTPHandlerDispatcher) dispatchItemDeps(
 	const cmdKey = "item deps"
 	workspace, _ := input["workspace"].(string)
 	if workspace == "" {
-		return mcp.NewToolResultErrorf("%s: workspace is required", cmdKey), nil
+		return validationFailedResult(cmdKey, "workspace is required",
+			"Pass `workspace=<slug>` or set a session default via pad_set_workspace."), nil
 	}
 	ref, _ := input["ref"].(string)
 	if ref == "" {
-		return mcp.NewToolResultErrorf("%s: ref is required", cmdKey), nil
+		return validationFailedResult(cmdKey, "ref is required",
+			"Pass `ref=<TASK-N>` (the item whose dependencies you're querying)."), nil
 	}
 
 	urlPath := "/api/v1/workspaces/" + url.PathEscape(workspace) +
@@ -368,20 +387,23 @@ func (d *HTTPHandlerDispatcher) dispatchItemRelated(
 	const cmdKey = "item related"
 	workspace, _ := input["workspace"].(string)
 	if workspace == "" {
-		return mcp.NewToolResultErrorf("%s: workspace is required", cmdKey), nil
+		return validationFailedResult(cmdKey, "workspace is required",
+			"Pass `workspace=<slug>` or set a session default via pad_set_workspace."), nil
 	}
 	ref, _ := input["ref"].(string)
 	if ref == "" {
-		return mcp.NewToolResultErrorf("%s: ref is required", cmdKey), nil
+		return validationFailedResult(cmdKey, "ref is required",
+			"Pass `ref=<TASK-N>` (the item whose related items you're querying)."), nil
 	}
 
 	item, err := d.fetchItem(ctx, user, workspace, ref)
 	if err != nil {
-		return mcp.NewToolResultErrorf("%s: %s", cmdKey, err.Error()), nil
+		return validationFailedResult(cmdKey, err.Error(),
+			fmt.Sprintf("Verify item %q exists in workspace %q.", ref, workspace)), nil
 	}
 	links, err := d.listItemLinks(ctx, user, workspace, item.Slug)
 	if err != nil {
-		return mcp.NewToolResultErrorf("%s: %s", cmdKey, err.Error()), nil
+		return dispatcherErrorResult(cmdKey, "list links", err), nil
 	}
 
 	groups := buildRelatedGroups(item, links)
@@ -412,20 +434,23 @@ func (d *HTTPHandlerDispatcher) dispatchItemImplementedBy(
 	const cmdKey = "item implemented-by"
 	workspace, _ := input["workspace"].(string)
 	if workspace == "" {
-		return mcp.NewToolResultErrorf("%s: workspace is required", cmdKey), nil
+		return validationFailedResult(cmdKey, "workspace is required",
+			"Pass `workspace=<slug>` or set a session default via pad_set_workspace."), nil
 	}
 	ref, _ := input["ref"].(string)
 	if ref == "" {
-		return mcp.NewToolResultErrorf("%s: ref is required", cmdKey), nil
+		return validationFailedResult(cmdKey, "ref is required",
+			"Pass `ref=<TASK-N>` (the item whose implementers you're querying)."), nil
 	}
 
 	item, err := d.fetchItem(ctx, user, workspace, ref)
 	if err != nil {
-		return mcp.NewToolResultErrorf("%s: %s", cmdKey, err.Error()), nil
+		return validationFailedResult(cmdKey, err.Error(),
+			fmt.Sprintf("Verify item %q exists in workspace %q.", ref, workspace)), nil
 	}
 	links, err := d.listItemLinks(ctx, user, workspace, item.Slug)
 	if err != nil {
-		return mcp.NewToolResultErrorf("%s: %s", cmdKey, err.Error()), nil
+		return dispatcherErrorResult(cmdKey, "list links", err), nil
 	}
 
 	results := incomingImplementedBy(item, links)
@@ -450,7 +475,7 @@ func (d *HTTPHandlerDispatcher) dispatchItemImplementedBy(
 func packageStructuredResponse(cmdKey string, payload any) (*mcp.CallToolResult, error) {
 	body, err := json.Marshal(payload)
 	if err != nil {
-		return mcp.NewToolResultErrorf("%s: encode response: %s", cmdKey, err.Error()), nil
+		return dispatcherErrorResult(cmdKey, "encode response", err), nil
 	}
 	var decoded any
 	if err := json.Unmarshal(body, &decoded); err != nil {

--- a/internal/mcp/dispatch_http_project.go
+++ b/internal/mcp/dispatch_http_project.go
@@ -87,25 +87,23 @@ func (d *HTTPHandlerDispatcher) fetchDashboardJSON(
 ) (map[string]any, *mcp.CallToolResult) {
 	workspace, _ := input["workspace"].(string)
 	if workspace == "" {
-		return nil, mcp.NewToolResultErrorf("%s: workspace is required", cmdKey)
+		return nil, validationFailedResult(cmdKey, "workspace is required",
+			"Pass `workspace=<slug>` or set a session default via pad_set_workspace.")
 	}
 	path := "/api/v1/workspaces/" + url.PathEscape(workspace) + "/dashboard"
 	req, err := d.buildAuthedRequest(ctx, http.MethodGet, path, nil, user)
 	if err != nil {
-		return nil, mcp.NewToolResultErrorf("%s: build dashboard request: %s", cmdKey, err.Error())
+		return nil, dispatcherErrorResult(cmdKey, "build dashboard request", err)
 	}
 	rec := httptest.NewRecorder()
 	d.Handler.ServeHTTP(rec, req)
 	if rec.Code >= 400 {
-		body := strings.TrimSpace(rec.Body.String())
-		if body == "" {
-			body = http.StatusText(rec.Code)
-		}
-		return nil, mcp.NewToolResultErrorf("%s: %d %s", cmdKey, rec.Code, body)
+		return nil, upstreamHTTPErrorResult(ctx, cmdKey, "fetch dashboard", path,
+			rec.Code, rec.Body.Bytes(), d.Lister, ResourceWorkspace, workspace)
 	}
 	var dash map[string]any
 	if err := json.Unmarshal(rec.Body.Bytes(), &dash); err != nil {
-		return nil, mcp.NewToolResultErrorf("%s: parse dashboard: %s", cmdKey, err.Error())
+		return nil, dispatcherErrorResult(cmdKey, "parse dashboard", err)
 	}
 	return dash, nil
 }
@@ -197,30 +195,55 @@ func (d *HTTPHandlerDispatcher) dispatchItemBulkUpdate(
 
 	workspace, _ := input["workspace"].(string)
 	if workspace == "" {
-		return mcp.NewToolResultErrorf("%s: workspace is required", cmdKey), nil
+		return validationFailedResult(cmdKey, "workspace is required",
+			"Pass `workspace=<slug>` or set a session default via pad_set_workspace."), nil
 	}
 
 	refs, err := bulkUpdateRefs(input["ref"])
 	if err != nil {
-		return mcp.NewToolResultErrorf("%s: %s", cmdKey, err.Error()), nil
+		return validationFailedResult(cmdKey, err.Error(),
+			"Pass `ref` as a string or array of TASK-N / BUG-N / etc. refs."), nil
 	}
 	if len(refs) == 0 {
-		return mcp.NewToolResultErrorf("%s: at least one ref is required", cmdKey), nil
+		return validationFailedResult(cmdKey, "at least one ref is required",
+			"Pass at least one item ref (e.g. ref=[\"TASK-7\",\"TASK-8\"])."), nil
 	}
 
 	status, _ := input["status"].(string)
 	priority, _ := input["priority"].(string)
 	if status == "" && priority == "" {
-		return mcp.NewToolResultErrorf("%s: at least one of --status or --priority is required", cmdKey), nil
+		return validationFailedResult(cmdKey, "at least one of status or priority is required",
+			"Pass `status=<value>` and/or `priority=<value>` to specify what to update."), nil
 	}
 
 	type bulkResult struct {
-		Ref     string `json:"ref"`
-		Updated bool   `json:"updated"`
-		Error   string `json:"error,omitempty"`
+		Ref     string        `json:"ref"`
+		Updated bool          `json:"updated"`
+		Error   *ErrorPayload `json:"error,omitempty"`
 	}
 	results := make([]bulkResult, 0, len(refs))
 	successes := 0
+
+	// rowError builds a per-row ErrorPayload. Reuses the same shape
+	// the top-level error envelope uses — agents see consistent
+	// {code, message, hint} per failed row instead of bare strings
+	// (BUG-1077 / Bug 15: bulk-update was the partially-fixed case
+	// that surfaced this requirement).
+	rowError := func(code ErrorCode, msg, hint string) *ErrorPayload {
+		return &ErrorPayload{Code: code, Message: msg, Hint: hint}
+	}
+	rowDispatcherError := func(op string, err error) *ErrorPayload {
+		return rowError(ErrServerError, fmt.Sprintf("%s failed", op),
+			fmt.Sprintf("Internal: %s — %s", op, err.Error()))
+	}
+	rowUpstreamError := func(op, route string, status int, body []byte, ref string) *ErrorPayload {
+		res := classifyHTTPStatusKind(ctx, cmdKey, route, status, body, d.Lister, ResourceItem, ref)
+		env := envelopeFrom(res)
+		if op != "" && env.Error.Message != "" {
+			env.Error.Message = fmt.Sprintf("%s (%s)", env.Error.Message, op)
+		}
+		return &env.Error
+	}
 
 	for _, ref := range refs {
 		// Per-item RMW: GET, merge fields, PATCH. Same shape
@@ -231,7 +254,7 @@ func (d *HTTPHandlerDispatcher) dispatchItemBulkUpdate(
 
 		getReq, err := d.buildAuthedRequest(ctx, http.MethodGet, itemPath, nil, user)
 		if err != nil {
-			results = append(results, bulkResult{Ref: ref, Error: fmt.Sprintf("build request: %s", err.Error())})
+			results = append(results, bulkResult{Ref: ref, Error: rowDispatcherError("build request", err)})
 			continue
 		}
 		getRec := httptest.NewRecorder()
@@ -239,7 +262,7 @@ func (d *HTTPHandlerDispatcher) dispatchItemBulkUpdate(
 		if getRec.Code >= 400 {
 			results = append(results, bulkResult{
 				Ref:   ref,
-				Error: fmt.Sprintf("read item: %d %s", getRec.Code, strings.TrimSpace(getRec.Body.String())),
+				Error: rowUpstreamError("read item", itemPath, getRec.Code, getRec.Body.Bytes(), ref),
 			})
 			continue
 		}
@@ -247,14 +270,14 @@ func (d *HTTPHandlerDispatcher) dispatchItemBulkUpdate(
 			Fields string `json:"fields"`
 		}
 		if err := json.Unmarshal(getRec.Body.Bytes(), &existing); err != nil {
-			results = append(results, bulkResult{Ref: ref, Error: fmt.Sprintf("parse item: %s", err.Error())})
+			results = append(results, bulkResult{Ref: ref, Error: rowDispatcherError("parse item", err)})
 			continue
 		}
 
 		merged := map[string]any{}
 		if existing.Fields != "" && existing.Fields != "{}" {
 			if err := json.Unmarshal([]byte(existing.Fields), &merged); err != nil {
-				results = append(results, bulkResult{Ref: ref, Error: fmt.Sprintf("parse existing fields: %s", err.Error())})
+				results = append(results, bulkResult{Ref: ref, Error: rowDispatcherError("parse existing fields", err)})
 				continue
 			}
 		}
@@ -266,19 +289,19 @@ func (d *HTTPHandlerDispatcher) dispatchItemBulkUpdate(
 		}
 		fieldsJSON, err := json.Marshal(merged)
 		if err != nil {
-			results = append(results, bulkResult{Ref: ref, Error: fmt.Sprintf("encode fields: %s", err.Error())})
+			results = append(results, bulkResult{Ref: ref, Error: rowDispatcherError("encode fields", err)})
 			continue
 		}
 		fieldsStr := string(fieldsJSON)
 		patchBody, err := json.Marshal(map[string]any{"fields": fieldsStr})
 		if err != nil {
-			results = append(results, bulkResult{Ref: ref, Error: fmt.Sprintf("encode body: %s", err.Error())})
+			results = append(results, bulkResult{Ref: ref, Error: rowDispatcherError("encode body", err)})
 			continue
 		}
 
 		patchReq, err := d.buildAuthedRequest(ctx, http.MethodPatch, itemPath, patchBody, user)
 		if err != nil {
-			results = append(results, bulkResult{Ref: ref, Error: fmt.Sprintf("build PATCH: %s", err.Error())})
+			results = append(results, bulkResult{Ref: ref, Error: rowDispatcherError("build PATCH", err)})
 			continue
 		}
 		patchRec := httptest.NewRecorder()
@@ -286,7 +309,7 @@ func (d *HTTPHandlerDispatcher) dispatchItemBulkUpdate(
 		if patchRec.Code >= 400 {
 			results = append(results, bulkResult{
 				Ref:   ref,
-				Error: fmt.Sprintf("update: %d %s", patchRec.Code, strings.TrimSpace(patchRec.Body.String())),
+				Error: rowUpstreamError("update item", itemPath, patchRec.Code, patchRec.Body.Bytes(), ref),
 			})
 			continue
 		}
@@ -368,20 +391,23 @@ func (d *HTTPHandlerDispatcher) dispatchItemNote(
 	ref, _ := input["ref"].(string)
 	summary, _ := input["summary"].(string)
 	if workspace == "" {
-		return mcp.NewToolResultErrorf("%s: workspace is required", cmdKey), nil
+		return validationFailedResult(cmdKey, "workspace is required",
+			"Pass `workspace=<slug>` or set a session default via pad_set_workspace."), nil
 	}
 	if ref == "" {
-		return mcp.NewToolResultErrorf("%s: ref is required", cmdKey), nil
+		return validationFailedResult(cmdKey, "ref is required",
+			"Pass `ref=<TASK-N>` (or whichever item ref the note targets)."), nil
 	}
 	if summary == "" {
-		return mcp.NewToolResultErrorf("%s: summary is required", cmdKey), nil
+		return validationFailedResult(cmdKey, "summary is required",
+			"Pass `summary=<short text>` describing the note."), nil
 	}
 	details, _ := input["details"].(string)
 	details = strings.TrimSpace(details)
 
 	itemPath := "/api/v1/workspaces/" + url.PathEscape(workspace) +
 		"/items/" + url.PathEscape(ref)
-	currentFields, errRes := d.prefetchItemFields(ctx, user, cmdKey, itemPath)
+	currentFields, errRes := d.prefetchItemFields(ctx, user, cmdKey, itemPath, ref)
 	if errRes != nil {
 		return errRes, nil
 	}
@@ -394,12 +420,12 @@ func (d *HTTPHandlerDispatcher) dispatchItemNote(
 		CreatedBy: userActorLabel(user),
 	})
 	if err != nil {
-		return mcp.NewToolResultErrorf("%s: append note: %s", cmdKey, err.Error()), nil
+		return dispatcherErrorResult(cmdKey, "append note", err), nil
 	}
 
 	body, err := json.Marshal(map[string]any{"fields": updated})
 	if err != nil {
-		return mcp.NewToolResultErrorf("%s: encode body: %s", cmdKey, err.Error()), nil
+		return dispatcherErrorResult(cmdKey, "encode body", err), nil
 	}
 	return d.executeRequest(ctx, cmdKey, user, http.MethodPatch, itemPath, body)
 }
@@ -418,20 +444,23 @@ func (d *HTTPHandlerDispatcher) dispatchItemDecide(
 	ref, _ := input["ref"].(string)
 	decision, _ := input["decision"].(string)
 	if workspace == "" {
-		return mcp.NewToolResultErrorf("%s: workspace is required", cmdKey), nil
+		return validationFailedResult(cmdKey, "workspace is required",
+			"Pass `workspace=<slug>` or set a session default via pad_set_workspace."), nil
 	}
 	if ref == "" {
-		return mcp.NewToolResultErrorf("%s: ref is required", cmdKey), nil
+		return validationFailedResult(cmdKey, "ref is required",
+			"Pass `ref=<TASK-N>` (or whichever item ref the decision targets)."), nil
 	}
 	if decision == "" {
-		return mcp.NewToolResultErrorf("%s: decision is required", cmdKey), nil
+		return validationFailedResult(cmdKey, "decision is required",
+			"Pass `decision=<short text>` describing the decision."), nil
 	}
 	rationale, _ := input["rationale"].(string)
 	rationale = strings.TrimSpace(rationale)
 
 	itemPath := "/api/v1/workspaces/" + url.PathEscape(workspace) +
 		"/items/" + url.PathEscape(ref)
-	currentFields, errRes := d.prefetchItemFields(ctx, user, cmdKey, itemPath)
+	currentFields, errRes := d.prefetchItemFields(ctx, user, cmdKey, itemPath, ref)
 	if errRes != nil {
 		return errRes, nil
 	}
@@ -444,12 +473,12 @@ func (d *HTTPHandlerDispatcher) dispatchItemDecide(
 		CreatedBy: userActorLabel(user),
 	})
 	if err != nil {
-		return mcp.NewToolResultErrorf("%s: append decision: %s", cmdKey, err.Error()), nil
+		return dispatcherErrorResult(cmdKey, "append decision", err), nil
 	}
 
 	body, err := json.Marshal(map[string]any{"fields": updated})
 	if err != nil {
-		return mcp.NewToolResultErrorf("%s: encode body: %s", cmdKey, err.Error()), nil
+		return dispatcherErrorResult(cmdKey, "encode body", err), nil
 	}
 	return d.executeRequest(ctx, cmdKey, user, http.MethodPatch, itemPath, body)
 }
@@ -462,29 +491,30 @@ func (d *HTTPHandlerDispatcher) dispatchItemDecide(
 // Used by note/decide which append into the existing fields blob —
 // they need the current value so AppendImplementationNote /
 // AppendDecisionLogEntry can preserve other entries.
+//
+// ref is the item ref the caller was looking up; threaded through to
+// the error envelope so agents see e.g. "Item TASK-7 not found"
+// rather than a bare 404 (TASK-1078 / TASK-1079).
 func (d *HTTPHandlerDispatcher) prefetchItemFields(
 	ctx context.Context,
 	user *models.User,
-	cmdKey, itemPath string,
+	cmdKey, itemPath, ref string,
 ) (string, *mcp.CallToolResult) {
 	req, err := d.buildAuthedRequest(ctx, http.MethodGet, itemPath, nil, user)
 	if err != nil {
-		return "", mcp.NewToolResultErrorf("%s: build prefetch: %s", cmdKey, err.Error())
+		return "", dispatcherErrorResult(cmdKey, "build prefetch", err)
 	}
 	rec := httptest.NewRecorder()
 	d.Handler.ServeHTTP(rec, req)
 	if rec.Code >= 400 {
-		body := strings.TrimSpace(rec.Body.String())
-		if body == "" {
-			body = http.StatusText(rec.Code)
-		}
-		return "", mcp.NewToolResultErrorf("%s: prefetch: %d %s", cmdKey, rec.Code, body)
+		return "", upstreamHTTPErrorResult(ctx, cmdKey, "prefetch item", itemPath,
+			rec.Code, rec.Body.Bytes(), d.Lister, ResourceItem, ref)
 	}
 	var existing struct {
 		Fields string `json:"fields"`
 	}
 	if err := json.Unmarshal(rec.Body.Bytes(), &existing); err != nil {
-		return "", mcp.NewToolResultErrorf("%s: parse current item: %s", cmdKey, err.Error())
+		return "", dispatcherErrorResult(cmdKey, "parse current item", err)
 	}
 	return existing.Fields, nil
 }
@@ -544,10 +574,9 @@ func (d *HTTPHandlerDispatcher) dispatchLibraryList(
 	wantConventions := typ == "" || typ == "conventions"
 	wantPlaybooks := typ == "" || typ == "playbooks"
 	if !wantConventions && !wantPlaybooks {
-		return mcp.NewToolResultErrorf(
-			"%s: unknown --type %q (expected: conventions, playbooks, or empty for both)",
-			cmdKey, typ,
-		), nil
+		return validationFailedResult(cmdKey,
+			fmt.Sprintf("unknown --type %q", typ),
+			"Pass `type=conventions`, `type=playbooks`, or omit for both."), nil
 	}
 
 	var conventions any
@@ -593,20 +622,17 @@ func (d *HTTPHandlerDispatcher) fetchLibraryEndpoint(
 ) (any, *mcp.CallToolResult) {
 	req, err := d.buildAuthedRequest(ctx, http.MethodGet, path, nil, user)
 	if err != nil {
-		return nil, mcp.NewToolResultErrorf("%s: build %s: %s", cmdKey, path, err.Error())
+		return nil, dispatcherErrorResult(cmdKey, "build "+path, err)
 	}
 	rec := httptest.NewRecorder()
 	d.Handler.ServeHTTP(rec, req)
 	if rec.Code >= 400 {
-		body := strings.TrimSpace(rec.Body.String())
-		if body == "" {
-			body = http.StatusText(rec.Code)
-		}
-		return nil, mcp.NewToolResultErrorf("%s: %s: %d %s", cmdKey, path, rec.Code, body)
+		return nil, upstreamHTTPErrorResult(ctx, cmdKey, "fetch "+path, path,
+			rec.Code, rec.Body.Bytes(), d.Lister, ResourceListing, "")
 	}
 	var decoded any
 	if err := json.Unmarshal(rec.Body.Bytes(), &decoded); err != nil {
-		return nil, mcp.NewToolResultErrorf("%s: parse %s: %s", cmdKey, path, err.Error())
+		return nil, dispatcherErrorResult(cmdKey, "parse "+path, err)
 	}
 	return decoded, nil
 }

--- a/internal/mcp/dispatch_http_slice4.go
+++ b/internal/mcp/dispatch_http_slice4.go
@@ -47,7 +47,7 @@ func (d *HTTPHandlerDispatcher) dispatchProjectNext(
 	// shape MCP host validators expect.
 	body, err := json.Marshal(suggestions)
 	if err != nil {
-		return mcp.NewToolResultErrorf("%s: marshal suggestions: %s", cmdKey, err.Error()), nil
+		return dispatcherErrorResult(cmdKey, "marshal suggestions", err), nil
 	}
 	return packageJSONResult(string(body)), nil
 }
@@ -80,7 +80,8 @@ func (d *HTTPHandlerDispatcher) dispatchProjectStandup(
 	const cmdKey = "project standup"
 	workspace, _ := input["workspace"].(string)
 	if workspace == "" {
-		return mcp.NewToolResultErrorf("%s: workspace is required", cmdKey), nil
+		return validationFailedResult(cmdKey, "workspace is required",
+			"Pass `workspace=<slug>` or set a session default via pad_set_workspace."), nil
 	}
 
 	days := 1
@@ -211,7 +212,8 @@ func (d *HTTPHandlerDispatcher) dispatchProjectChangelog(
 	const cmdKey = "project changelog"
 	workspace, _ := input["workspace"].(string)
 	if workspace == "" {
-		return mcp.NewToolResultErrorf("%s: workspace is required", cmdKey), nil
+		return validationFailedResult(cmdKey, "workspace is required",
+			"Pass `workspace=<slug>` or set a session default via pad_set_workspace."), nil
 	}
 
 	since, _ := input["since"].(string)
@@ -225,10 +227,9 @@ func (d *HTTPHandlerDispatcher) dispatchProjectChangelog(
 	if since != "" {
 		parsed, err := time.Parse("2006-01-02", since)
 		if err != nil {
-			return mcp.NewToolResultErrorf(
-				"%s: invalid --since date %q (expected YYYY-MM-DD): %s",
-				cmdKey, since, err.Error(),
-			), nil
+			return validationFailedResult(cmdKey,
+				fmt.Sprintf("invalid --since date %q: %s", since, err.Error()),
+				"Pass `since=YYYY-MM-DD` (e.g. since=2026-04-01)."), nil
 		}
 		cutoff = parsed
 	} else {
@@ -521,11 +522,13 @@ func (d *HTTPHandlerDispatcher) dispatchLibraryActivate(
 	const cmdKey = "library activate"
 	workspace, _ := input["workspace"].(string)
 	if workspace == "" {
-		return mcp.NewToolResultErrorf("%s: workspace is required", cmdKey), nil
+		return validationFailedResult(cmdKey, "workspace is required",
+			"Pass `workspace=<slug>` or set a session default via pad_set_workspace."), nil
 	}
 	title, _ := input["title"].(string)
 	if title == "" {
-		return mcp.NewToolResultErrorf("%s: title is required", cmdKey), nil
+		return validationFailedResult(cmdKey, "title is required",
+			"Pass `title=<library-item-title>` matching an entry in the convention or playbook library."), nil
 	}
 
 	if conv := collections.GetLibraryConvention(title); conv != nil {
@@ -537,7 +540,7 @@ func (d *HTTPHandlerDispatcher) dispatchLibraryActivate(
 			Commands:    conv.Commands,
 		})
 		if err != nil {
-			return mcp.NewToolResultErrorf("%s: build convention fields: %s", cmdKey, err.Error()), nil
+			return dispatcherErrorResult(cmdKey, "build convention fields", err), nil
 		}
 		return d.postLibraryItem(ctx, user, workspace, "conventions", cmdKey, conv.Title, conv.Content, fieldsJSON)
 	}
@@ -550,14 +553,16 @@ func (d *HTTPHandlerDispatcher) dispatchLibraryActivate(
 		}
 		fieldsJSON, err := json.Marshal(fields)
 		if err != nil {
-			return mcp.NewToolResultErrorf("%s: encode playbook fields: %s", cmdKey, err.Error()), nil
+			return dispatcherErrorResult(cmdKey, "encode playbook fields", err), nil
 		}
 		return d.postLibraryItem(ctx, user, workspace, "playbooks", cmdKey, pb.Title, pb.Content, string(fieldsJSON))
 	}
 
-	return mcp.NewToolResultErrorf(
-		"%s: not found in convention or playbook library: %q", cmdKey, title,
-	), nil
+	return NewErrorResult(ErrorPayload{
+		Code:    ErrNotFound,
+		Message: fmt.Sprintf("%s: %q not found in convention or playbook library", cmdKey, title),
+		Hint:    "Use `pad_project action=library-list` to enumerate available titles.",
+	}), nil
 }
 
 // postLibraryItem POSTs an ItemCreate body into the named
@@ -578,7 +583,7 @@ func (d *HTTPHandlerDispatcher) postLibraryItem(
 	}
 	body, err := json.Marshal(payload)
 	if err != nil {
-		return mcp.NewToolResultErrorf("%s: encode body: %s", cmdKey, err.Error()), nil
+		return dispatcherErrorResult(cmdKey, "encode body", err), nil
 	}
 	urlPath := "/api/v1/workspaces/" + url.PathEscape(workspace) +
 		"/collections/" + url.PathEscape(collection) + "/items"

--- a/internal/mcp/dispatch_http_test.go
+++ b/internal/mcp/dispatch_http_test.go
@@ -631,8 +631,27 @@ func TestHTTPHandlerDispatcher_HandlerErrorSurfacesAsToolError(t *testing.T) {
 	if !res.IsError {
 		t.Errorf("expected IsError when handler returns 400, got %#v", res)
 	}
-	if !containsToolText(res, "Title is required") {
-		t.Errorf("error should propagate handler stderr; got %#v", res)
+	// Pre-TASK-1077 the handler's raw response body ("Title is
+	// required") was passed through into the error envelope's hint.
+	// Post-fix the body is a non-envelope JSON ({"error":"Title is
+	// required"} — note: error is a string, not an object) so
+	// extractUpstreamMessage's safe-fallback drops it. The envelope
+	// still surfaces the validation_failed code + the route + a
+	// generic recovery hint, so agents know what to do; only the raw
+	// body content is dropped.
+	//
+	// If the upstream handler emits the structured shape
+	// {"error":{"message":"Title is required"}}, the inner message
+	// IS lifted into the hint — see TestExtractUpstreamMessage's
+	// envelope happy path. The pad codebase's writeError emits that
+	// shape; the bare-string shape this test uses is a deliberate
+	// anti-pattern repro.
+	env, ok := res.StructuredContent.(ErrorEnvelope)
+	if !ok {
+		t.Fatalf("expected ErrorEnvelope, got %T", res.StructuredContent)
+	}
+	if env.Error.Code != ErrValidationFailed {
+		t.Errorf("expected validation_failed code, got %q", env.Error.Code)
 	}
 }
 

--- a/internal/mcp/errors.go
+++ b/internal/mcp/errors.go
@@ -62,9 +62,19 @@ const (
 	ErrPermissionDenied ErrorCode = "permission_denied"
 
 	// ErrItemNotFound fires when an item ref / slug doesn't resolve.
-	// Future enhancement: populate `available_collections` or recent
-	// items as a hint (deferred to TASK-977).
+	// Distinct from ErrNotFound: this code is reserved for the
+	// specific case where a tool was looking up an item by ref
+	// (e.g. pad_item show TASK-7 against a missing ref). The hint
+	// then references pad_item search / list as recovery paths.
 	ErrItemNotFound ErrorCode = "item_not_found"
+
+	// ErrNotFound fires for resource-shaped 404s that AREN'T item
+	// lookups — workspace doesn't exist, collection list returns
+	// 404, dashboard route 404s, etc. Pre-TASK-1078 these all
+	// collapsed to ErrItemNotFound, which misled agents into
+	// thinking an item was the missing thing. Recovery is
+	// "verify the slug / path you passed", not "search for items."
+	ErrNotFound ErrorCode = "not_found"
 
 	// ErrValidationFailed fires on bad input — required field missing,
 	// enum value out of range, malformed JSON. HTTP: 422.
@@ -74,10 +84,35 @@ const (
 	// state (e.g. version mismatch on update). HTTP: 409.
 	ErrConflict ErrorCode = "conflict"
 
+	// ErrWorkspaceRequired fires when a tool needs a workspace
+	// context but the OAuth token's allow-list contains zero or
+	// multiple workspaces (no unambiguous auto-default available
+	// per TASK-1076). The hint points at pad_workspace list +
+	// passing workspace= explicitly. Distinct from ErrNoWorkspace
+	// (which is the local-CLI "no .pad.toml found" case).
+	ErrWorkspaceRequired ErrorCode = "workspace_required"
+
+	// ErrBackendUnreachable fires when the dispatcher's synthesized
+	// HTTP request never reaches a meaningful response — connection
+	// refused, DNS failure, upstream service down. Pre-TASK-1078
+	// these collapsed into ErrServerError with bare status text;
+	// distinguishing them lets agents decide "retry" vs "tell the
+	// user the backend is down" vs "fix the request."
+	ErrBackendUnreachable ErrorCode = "backend_unreachable"
+
+	// ErrUpstreamError fires on 5xx responses from the backend
+	// where a structured body was returned. Distinct from
+	// ErrBackendUnreachable (transport never completed) and from
+	// ErrServerError (catch-all for anything we don't have a code
+	// for). Hint includes a body excerpt so the agent has a chance
+	// of recognizing transient vs persistent failures.
+	ErrUpstreamError ErrorCode = "upstream_error"
+
 	// ErrServerError is the catch-all for unexpected failures —
-	// 5xx from HTTP, unknown stderr patterns from exec. The wrapped
-	// message preserves the underlying detail for debugging without
-	// promising any structured shape.
+	// dispatcher internal errors (build request failed, parse
+	// response failed, marshal failed), unknown stderr patterns
+	// from exec, etc. The wrapped message preserves the underlying
+	// detail for debugging without promising any structured shape.
 	ErrServerError ErrorCode = "server_error"
 )
 
@@ -480,13 +515,92 @@ func isLineStart(s string, i int) bool {
 // envelope's Message.
 // ─────────────────────────────────────────────────────────────────────
 
-// classifyHTTPStatus turns an HTTP error response into a structured
-// envelope. body is the raw response body (may be empty); cmdKey is
-// the dotted command path for debugging context. lookup is optional
-// — supply the dispatcher's WorkspaceLister so 404 (workspace) /
-// 403 / etc. can populate available_workspaces when relevant.
+// ResourceKind hints what shape of resource a dispatcher was reading
+// when it hit an error. Drives 404 classification (item_not_found vs
+// not_found) and the contextual hint text per code (TASK-1078 +
+// TASK-1079).
+//
+// The dispatcher knows exactly what it was reading (an item, a
+// workspace, a collection list, etc.); the classifier doesn't need
+// to guess from URL paths or body strings.
+type ResourceKind string
+
+const (
+	// ResourceUnknown is the legacy "we don't know what was being
+	// read" sentinel — call sites that haven't been retrofitted yet
+	// pass this and get the pre-TASK-1078 behaviour (404 →
+	// item_not_found by default unless body says workspace).
+	ResourceUnknown ResourceKind = ""
+
+	// ResourceItem signals an item-by-ref lookup (pad_item show /
+	// update / delete / star / etc.). 404 → item_not_found with
+	// pad_item search / list as the recovery hint.
+	ResourceItem ResourceKind = "item"
+
+	// ResourceWorkspace signals a workspace-level read or write
+	// (pad_workspace * actions, pad_project dashboard, etc.).
+	// 404 → unknown_workspace with available_workspaces enrichment.
+	ResourceWorkspace ResourceKind = "workspace"
+
+	// ResourceCollection signals a collection-shaped read
+	// (pad_collection list / show, item-list-by-collection).
+	// 404 → not_found with the collection-name in the hint.
+	ResourceCollection ResourceKind = "collection"
+
+	// ResourceListing signals a generic listing endpoint where
+	// 404 means the parent route doesn't exist (NOT "no rows" —
+	// list endpoints return 200 with [] for that case). Used for
+	// pad_workspace list, pad_role list, pad_project dashboard.
+	ResourceListing ResourceKind = "listing"
+
+	// ResourceLink signals a link create/delete operation. 404 →
+	// not_found with the link-target ref in the hint.
+	ResourceLink ResourceKind = "link"
+
+	// ResourceAttachment signals an attachment metadata read.
+	// 404 → not_found with the attachment_id in the hint.
+	ResourceAttachment ResourceKind = "attachment"
+)
+
+// classifyHTTPStatus is the legacy entry point preserved for callers
+// that don't know their resource kind. New callers should use
+// classifyHTTPStatusKind directly.
 func classifyHTTPStatus(ctx context.Context, cmdKey string, status int, body []byte, lookup WorkspaceLister) *mcp.CallToolResult {
+	return classifyHTTPStatusKind(ctx, cmdKey, "", status, body, lookup, ResourceUnknown, "")
+}
+
+// classifyHTTPStatusKind turns an HTTP error response into a structured
+// envelope, using the dispatcher's known resource context to emit the
+// right error code and an actionable hint (TASK-1078 / TASK-1079).
+//
+// Parameters:
+//
+//   - ctx, cmdKey, lookup — same as classifyHTTPStatus.
+//   - route — the URL path the dispatcher hit, e.g.
+//     "/api/v1/workspaces/foo/items/TASK-7". Used in hint text so
+//     agents know which path failed without parsing the message.
+//     May be empty when the caller doesn't have a route handy
+//     (legacy classifyHTTPStatus path).
+//   - status, body — same as classifyHTTPStatus.
+//   - kind — what shape of resource was being read. Drives both
+//     the code selection (404 splits item_not_found / unknown_workspace
+//     / not_found) and the hint text per code.
+//   - refOrSlug — the specific identifier the dispatcher was looking
+//     up (a TASK-N ref for items, a workspace slug for workspaces,
+//     etc.). Used in the hint so an agent reading "Item ref TASK-7
+//     not found in workspace foo" knows exactly what to fix. May be
+//     empty.
+func classifyHTTPStatusKind(
+	ctx context.Context,
+	cmdKey, route string,
+	status int,
+	body []byte,
+	lookup WorkspaceLister,
+	kind ResourceKind,
+	refOrSlug string,
+) *mcp.CallToolResult {
 	bodyText := strings.TrimSpace(string(body))
+	bodyMessage := extractUpstreamMessage(bodyText)
 	if bodyText == "" {
 		bodyText = http.StatusText(status)
 	}
@@ -496,61 +610,35 @@ func classifyHTTPStatus(ctx context.Context, cmdKey string, status int, body []b
 		return NewErrorResult(ErrorPayload{
 			Code:    ErrAuthRequired,
 			Message: "Authentication required.",
-			Hint:    bodyText,
+			Hint:    authHintFor(bodyMessage, route),
 		})
 	case http.StatusForbidden:
 		return NewErrorResult(ErrorPayload{
 			Code:    ErrPermissionDenied,
 			Message: "Permission denied for this operation.",
-			Hint:    bodyText,
+			Hint:    permissionHintFor(bodyMessage, route),
 		})
 	case http.StatusNotFound:
-		// Without inspecting the URL we can't tell workspace-404 vs
-		// item-404 with certainty; the body usually says. Default to
-		// item_not_found and let TASK-977 refine when the remote
-		// transport can provide URL-aware classification.
-		if strings.Contains(strings.ToLower(bodyText), "workspace") {
-			// Try to pull the slug out of the body so the message
-			// names it (e.g. body="workspace 'foo' not visible" →
-			// "Workspace \"foo\" is not visible..."). Falls back to
-			// the body in Hint when no slug parses.
-			slug := extractUnknownWorkspaceSlug(bodyText)
-			res := unknownWorkspaceResult(ctx, slug, lookup)
-			// unknownWorkspaceResult uses the available_workspaces
-			// hint line; preserve the original handler body in Hint
-			// so debug detail isn't lost. Concatenate when both
-			// exist so neither hides the other.
-			env := envelopeFrom(res)
-			if env.Error.Hint == "" {
-				env.Error.Hint = bodyText
-			} else {
-				env.Error.Hint = bodyText + " — " + env.Error.Hint
-			}
-			return NewErrorResult(env.Error)
-		}
-		return NewErrorResult(ErrorPayload{
-			Code:    ErrItemNotFound,
-			Message: "Item not found.",
-			Hint:    bodyText,
-		})
+		return classify404(ctx, cmdKey, route, bodyText, bodyMessage, lookup, kind, refOrSlug)
 	case http.StatusConflict:
 		return NewErrorResult(ErrorPayload{
 			Code:    ErrConflict,
 			Message: "Conflict — current state changed beneath this update.",
-			Hint:    bodyText,
+			Hint:    conflictHintFor(bodyMessage, route),
 		})
 	case http.StatusUnprocessableEntity, http.StatusBadRequest:
 		return NewErrorResult(ErrorPayload{
 			Code:    ErrValidationFailed,
 			Message: "Validation failed.",
-			Hint:    bodyText,
+			Hint:    validationHintFor(bodyMessage, route),
 		})
 	}
 
 	if status >= 500 {
 		return NewErrorResult(ErrorPayload{
-			Code:    ErrServerError,
-			Message: fmt.Sprintf("pad %s failed: %s", cmdKey, bodyText),
+			Code:    ErrUpstreamError,
+			Message: fmt.Sprintf("pad %s failed: backend returned %d", cmdKey, status),
+			Hint:    upstreamHintFor(bodyMessage, route, status),
 		})
 	}
 	// Other 4xx without a specific mapping — surface as server_error
@@ -558,6 +646,346 @@ func classifyHTTPStatus(ctx context.Context, cmdKey string, status int, body []b
 	// promoting them to validation_failed; that would mislead callers.
 	return NewErrorResult(ErrorPayload{
 		Code:    ErrServerError,
-		Message: fmt.Sprintf("pad %s failed (HTTP %d): %s", cmdKey, status, bodyText),
+		Message: fmt.Sprintf("pad %s failed (HTTP %d)", cmdKey, status),
+		Hint:    serverHintFor(bodyMessage, route, status),
 	})
+}
+
+// classify404 splits HTTP 404 by ResourceKind into the right code +
+// hint. Called from classifyHTTPStatusKind only — extracted so the
+// 404-shaped logic doesn't dominate the parent switch statement.
+func classify404(
+	ctx context.Context,
+	cmdKey, route, bodyText, bodyMessage string,
+	lookup WorkspaceLister,
+	kind ResourceKind,
+	refOrSlug string,
+) *mcp.CallToolResult {
+	// Workspace-shaped 404s: route through the existing
+	// unknown_workspace path so available_workspaces enrichment fires.
+	// Body-string sniffing is the legacy fallback for callers that
+	// pass ResourceUnknown.
+	if kind == ResourceWorkspace ||
+		(kind == ResourceUnknown && strings.Contains(strings.ToLower(bodyText), "workspace")) {
+		slug := refOrSlug
+		if slug == "" {
+			slug = extractUnknownWorkspaceSlug(bodyText)
+		}
+		res := unknownWorkspaceResult(ctx, slug, lookup)
+		env := envelopeFrom(res)
+		// Layer in a route-aware hint suffix so the agent sees the
+		// path that 404'd in addition to the workspace-list hint.
+		extra := workspaceMissingHint(slug, route, bodyMessage)
+		if env.Error.Hint == "" {
+			env.Error.Hint = extra
+		} else if extra != "" {
+			env.Error.Hint = extra + " — " + env.Error.Hint
+		}
+		return NewErrorResult(env.Error)
+	}
+	switch kind {
+	case ResourceItem:
+		return NewErrorResult(ErrorPayload{
+			Code:    ErrItemNotFound,
+			Message: "Item not found.",
+			Hint:    itemMissingHint(refOrSlug, route, bodyMessage),
+		})
+	case ResourceUnknown:
+		// Legacy fallback — preserved so call sites that haven't
+		// been retrofitted yet keep the pre-TASK-1078 code mapping.
+		// Use itemMissingHint (NOT raw bodyText) so the safe-extracted
+		// bodyMessage is the only upstream content forwarded, matching
+		// the privacy contract extractUpstreamMessage establishes
+		// (Codex review #387 round 2 caught the residual leak from
+		// the previous bare-`bodyText` Hint).
+		return NewErrorResult(ErrorPayload{
+			Code:    ErrItemNotFound,
+			Message: "Item not found.",
+			Hint:    itemMissingHint(refOrSlug, route, bodyMessage),
+		})
+	default:
+		// All other resource kinds (collection, listing, link,
+		// attachment) get the generic not_found code with a
+		// kind-aware hint.
+		return NewErrorResult(ErrorPayload{
+			Code:    ErrNotFound,
+			Message: notFoundMessageFor(kind, refOrSlug),
+			Hint:    notFoundHintFor(kind, refOrSlug, route, bodyMessage),
+		})
+	}
+}
+
+// extractUpstreamMessage pulls a human-readable message out of an
+// upstream error body. Three return shapes:
+//
+//   - Pad's structured envelope ({error:{message:...}}) → return the
+//     inner message verbatim. This is the common case for any 4xx /
+//     5xx pad emits internally (every handler uses writeError which
+//     produces this shape).
+//   - chi's default 404 body ("404 page not found") → return "" so
+//     the hint omits the upstream-message clause entirely. The
+//     literal text has zero diagnostic value (Bug 17) and forwarding
+//     it doesn't help anyone.
+//   - Anything else → return "". Per Codex review #387 round 1, the
+//     pre-fix fallback returned the raw body — which would forward
+//     non-envelope upstream JSON / HTML / debug dumps, including any
+//     tokens / passwords / internal-only fields the backend might
+//     surface in a 5xx. Refusing to forward unstructured bodies is
+//     the safer default; operators debugging a non-envelope upstream
+//     can read the pad container logs, agents don't need the raw
+//     body to recover.
+//
+// Trailing whitespace is trimmed before classification because chi's
+// "404 page not found" body ships with a trailing newline and the
+// EqualFold check needs to match it byte-for-byte.
+func extractUpstreamMessage(body string) string {
+	body = strings.TrimSpace(body)
+	if body == "" {
+		return ""
+	}
+	if strings.EqualFold(body, "404 page not found") {
+		return ""
+	}
+	var env struct {
+		Error struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal([]byte(body), &env); err == nil && env.Error.Message != "" {
+		return env.Error.Message
+	}
+	return ""
+}
+
+// itemMissingHint is the per-error-code hint generator for
+// ErrItemNotFound. References the actual ref + route so the agent
+// can pin the failure without re-parsing the message, plus points
+// at the next-step recovery tools.
+func itemMissingHint(ref, route, bodyMsg string) string {
+	parts := []string{}
+	if ref != "" {
+		parts = append(parts, fmt.Sprintf("Item %q not found.", ref))
+	} else {
+		parts = append(parts, "Item not found at the requested ref.")
+	}
+	if route != "" {
+		parts = append(parts, fmt.Sprintf("Route: %s.", route))
+	}
+	parts = append(parts, "Try `pad_item search` or `pad_item list` to find the right ref.")
+	if bodyMsg != "" && !strings.EqualFold(bodyMsg, "404 page not found") {
+		parts = append(parts, fmt.Sprintf("Backend: %s", bodyMsg))
+	}
+	return strings.Join(parts, " ")
+}
+
+// workspaceMissingHint generates the route-aware suffix appended to
+// the standard unknown_workspace envelope's available_workspaces line.
+func workspaceMissingHint(slug, route, bodyMsg string) string {
+	parts := []string{}
+	if slug != "" {
+		parts = append(parts, fmt.Sprintf("Workspace %q not visible.", slug))
+	}
+	if route != "" {
+		parts = append(parts, fmt.Sprintf("Route: %s.", route))
+	}
+	if bodyMsg != "" && !strings.EqualFold(bodyMsg, "404 page not found") {
+		parts = append(parts, fmt.Sprintf("Backend: %s", bodyMsg))
+	}
+	return strings.Join(parts, " ")
+}
+
+// notFoundMessageFor returns a kind-aware short message for the
+// not_found code. Falls back to a generic "Resource not found" when
+// the kind doesn't match a specialized case.
+func notFoundMessageFor(kind ResourceKind, refOrSlug string) string {
+	switch kind {
+	case ResourceCollection:
+		if refOrSlug != "" {
+			return fmt.Sprintf("Collection %q not found.", refOrSlug)
+		}
+		return "Collection not found."
+	case ResourceLink:
+		return "Link target not found."
+	case ResourceAttachment:
+		if refOrSlug != "" {
+			return fmt.Sprintf("Attachment %q not found.", refOrSlug)
+		}
+		return "Attachment not found."
+	case ResourceListing:
+		return "Listing endpoint did not respond."
+	}
+	return "Resource not found."
+}
+
+// notFoundHintFor generates the actionable hint for ErrNotFound.
+// References the route + ref/slug + suggests verification of the
+// path the caller passed.
+func notFoundHintFor(kind ResourceKind, refOrSlug, route, bodyMsg string) string {
+	parts := []string{}
+	switch kind {
+	case ResourceCollection:
+		parts = append(parts, "Verify the collection slug exists; use `pad_collection list` to enumerate.")
+	case ResourceLink:
+		parts = append(parts, fmt.Sprintf("Verify the target ref %q exists.", refOrSlug))
+	case ResourceAttachment:
+		parts = append(parts, "Verify the attachment_id from the parent item.")
+	case ResourceListing:
+		parts = append(parts, "Verify the route matches the server's API surface (build version may be stale).")
+	default:
+		parts = append(parts, "Verify the path you passed.")
+	}
+	if route != "" {
+		parts = append(parts, fmt.Sprintf("Route: %s.", route))
+	}
+	if bodyMsg != "" && !strings.EqualFold(bodyMsg, "404 page not found") {
+		parts = append(parts, fmt.Sprintf("Backend: %s", bodyMsg))
+	}
+	return strings.Join(parts, " ")
+}
+
+// authHintFor generates the actionable hint for ErrAuthRequired.
+// Distinct from the upstream body — agents see "fix your auth", not
+// the literal upstream JSON envelope (Bug 19).
+func authHintFor(bodyMsg, route string) string {
+	parts := []string{"Re-authenticate (Claude Desktop: reconnect the connector; CLI: `pad auth login`)."}
+	if route != "" {
+		parts = append(parts, fmt.Sprintf("Route: %s.", route))
+	}
+	if bodyMsg != "" {
+		parts = append(parts, fmt.Sprintf("Backend: %s", bodyMsg))
+	}
+	return strings.Join(parts, " ")
+}
+
+// permissionHintFor generates the actionable hint for
+// ErrPermissionDenied. References the route + the inner backend
+// message (which often names the missing role / workspace).
+func permissionHintFor(bodyMsg, route string) string {
+	parts := []string{"Insufficient role for this operation."}
+	if route != "" {
+		parts = append(parts, fmt.Sprintf("Route: %s.", route))
+	}
+	if bodyMsg != "" {
+		parts = append(parts, fmt.Sprintf("Backend: %s", bodyMsg))
+	}
+	return strings.Join(parts, " ")
+}
+
+// conflictHintFor generates the actionable hint for ErrConflict.
+func conflictHintFor(bodyMsg, route string) string {
+	parts := []string{"Re-read the current item state and retry the update."}
+	if route != "" {
+		parts = append(parts, fmt.Sprintf("Route: %s.", route))
+	}
+	if bodyMsg != "" {
+		parts = append(parts, fmt.Sprintf("Backend: %s", bodyMsg))
+	}
+	return strings.Join(parts, " ")
+}
+
+// validationHintFor generates the actionable hint for
+// ErrValidationFailed. The backend message usually pinpoints the
+// field, so it's prioritized.
+func validationHintFor(bodyMsg, route string) string {
+	parts := []string{}
+	if bodyMsg != "" {
+		parts = append(parts, fmt.Sprintf("Backend: %s", bodyMsg))
+	}
+	if route != "" {
+		parts = append(parts, fmt.Sprintf("Route: %s.", route))
+	}
+	parts = append(parts, "Adjust the input shape and retry.")
+	return strings.Join(parts, " ")
+}
+
+// upstreamHintFor generates the actionable hint for ErrUpstreamError.
+// 5xx responses are usually transient; the hint encodes that bias.
+func upstreamHintFor(bodyMsg, route string, status int) string {
+	parts := []string{
+		fmt.Sprintf("Backend returned %d.", status),
+		"Usually transient — retry once or check pad logs for the underlying error.",
+	}
+	if route != "" {
+		parts = append(parts, fmt.Sprintf("Route: %s.", route))
+	}
+	if bodyMsg != "" && bodyMsg != http.StatusText(status) {
+		parts = append(parts, fmt.Sprintf("Backend: %s", bodyMsg))
+	}
+	return strings.Join(parts, " ")
+}
+
+// serverHintFor generates the actionable hint for ErrServerError.
+// Catch-all — surface enough for an agent to file a bug report.
+func serverHintFor(bodyMsg, route string, status int) string {
+	parts := []string{fmt.Sprintf("Unexpected status %d from backend.", status)}
+	if route != "" {
+		parts = append(parts, fmt.Sprintf("Route: %s.", route))
+	}
+	if bodyMsg != "" {
+		parts = append(parts, fmt.Sprintf("Backend: %s", bodyMsg))
+	}
+	return strings.Join(parts, " ")
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Helpers for non-HTTP error paths (TASK-1077 — replace plain-string
+// NewToolResultErrorf with structured envelopes uniformly).
+// ─────────────────────────────────────────────────────────────────────
+
+// validationFailedResult wraps a "missing required input" or other
+// caller-input error into the structured envelope. cmdKey identifies
+// which tool was invoked; msg is the human-readable issue (e.g.
+// "workspace is required", "ref is required"); fixHint is the
+// recovery suggestion.
+func validationFailedResult(cmdKey, msg, fixHint string) *mcp.CallToolResult {
+	return NewErrorResult(ErrorPayload{
+		Code:    ErrValidationFailed,
+		Message: fmt.Sprintf("%s: %s", cmdKey, msg),
+		Hint:    fixHint,
+	})
+}
+
+// dispatcherErrorResult wraps an internal dispatcher failure
+// (build request, encode body, parse response, marshal merged
+// fields, etc.) into the structured envelope. These shouldn't
+// happen at runtime — they're usually programmer errors or
+// genuinely unexpected I/O failures.
+//
+// op is a short verb describing what failed ("build prefetch
+// request", "encode body", "parse current item"); err is the
+// underlying error — its message goes in the hint so debugging
+// info isn't lost.
+func dispatcherErrorResult(cmdKey, op string, err error) *mcp.CallToolResult {
+	hint := fmt.Sprintf("Internal: %s — %s", op, err.Error())
+	return NewErrorResult(ErrorPayload{
+		Code:    ErrServerError,
+		Message: fmt.Sprintf("%s: %s failed", cmdKey, op),
+		Hint:    hint,
+	})
+}
+
+// upstreamHTTPErrorResult is the canonical wrapper for "the
+// dispatcher made an HTTP call that returned a non-2xx" cases
+// outside the main executeRequest/packageHTTPResponse pipeline
+// (in-handler prefetches, link create/delete, project dispatchers,
+// etc.). Routes the failure through classifyHTTPStatusKind so the
+// shape matches the main pipeline exactly — agents see the same
+// envelope regardless of which dispatcher path produced it.
+func upstreamHTTPErrorResult(
+	ctx context.Context,
+	cmdKey, op, route string,
+	status int,
+	body []byte,
+	lookup WorkspaceLister,
+	kind ResourceKind,
+	refOrSlug string,
+) *mcp.CallToolResult {
+	res := classifyHTTPStatusKind(ctx, cmdKey, route, status, body, lookup, kind, refOrSlug)
+	// Layer the per-call op verb into the message so a "prefetch"
+	// failure surfaces distinct from a top-level "execute" failure.
+	env := envelopeFrom(res)
+	if op != "" && env.Error.Message != "" {
+		env.Error.Message = fmt.Sprintf("%s (%s)", env.Error.Message, op)
+	}
+	return NewErrorResult(env.Error)
 }

--- a/internal/mcp/errors_test.go
+++ b/internal/mcp/errors_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
-	"strings"
 	"testing"
 
 	"github.com/mark3labs/mcp-go/mcp"
@@ -170,8 +169,13 @@ func TestClassifyHTTPStatus(t *testing.T) {
 		{"409_conflict", http.StatusConflict, "version mismatch", ErrConflict},
 		{"422_validation", http.StatusUnprocessableEntity, "title required", ErrValidationFailed},
 		{"400_validation", http.StatusBadRequest, "bad input", ErrValidationFailed},
-		{"500_server", http.StatusInternalServerError, "boom", ErrServerError},
-		{"503_server", http.StatusServiceUnavailable, "down", ErrServerError},
+		// TASK-1078: 5xx now maps to upstream_error (distinct from
+		// server_error, which is reserved for dispatcher internal
+		// failures + un-mapped 4xx). Pre-fix every 5xx collapsed to
+		// ErrServerError; the new code lets agents distinguish
+		// "backend hiccup, retry" from "dispatcher bug, escalate."
+		{"500_upstream", http.StatusInternalServerError, "boom", ErrUpstreamError},
+		{"503_upstream", http.StatusServiceUnavailable, "down", ErrUpstreamError},
 		{"418_other", http.StatusTeapot, "weird", ErrServerError},
 	}
 	for _, tc := range cases {
@@ -185,13 +189,23 @@ func TestClassifyHTTPStatus(t *testing.T) {
 			if env.Error.Code != tc.wantCode {
 				t.Errorf("Code = %q, want %q", env.Error.Code, tc.wantCode)
 			}
-			// Body fragment should appear somewhere in the envelope —
-			// either in Hint (typical) or Message (server_error path).
-			combined := env.Error.Hint + " " + env.Error.Message
-			if tc.body != "" && !strings.Contains(combined, tc.body) {
-				t.Errorf("envelope should preserve body %q somewhere; got message=%q hint=%q",
-					tc.body, env.Error.Message, env.Error.Hint)
-			}
+			// Body fragment preservation contract changed in TASK-1077:
+			// pre-fix the raw body was always copied into Hint, which
+			// would leak unstructured upstream output (Codex review #387
+			// round 1). Post-fix only structured-envelope-shaped bodies
+			// have their inner message lifted; unstructured bodies are
+			// dropped to avoid leaking tokens / debug dumps.
+			//
+			// Each test case above passes a bare string body — those
+			// hit the safe-fallback path and don't appear in the
+			// envelope. The unknown_workspace branch can also legitimately
+			// emit an empty Hint (no upstream message AND no extractable
+			// slug AND no lister wired). This test asserts the code
+			// mapping; body preservation specifically is tested in
+			// TestExtractUpstreamMessage with structured input, and hint
+			// shape per code is tested in
+			// TestClassifyHTTPStatus_HintsAreActionable.
+			_ = env.Error.Hint
 		})
 	}
 }


### PR DESCRIPTION
## Summary

Three improvements bundled because they all touch the same dispatcher error-emission surface; landing them piecemeal would churn the same lines repeatedly.

### TASK-1077 — uniform envelope shape
Pre-fix some dispatchers (note, decide, project next, bulk-update per-row) emitted plain-string errors via `mcp.NewToolResultErrorf`. Same underlying 404 surfaced in three different shapes across the surface. Three new helpers in `errors.go` (`validationFailedResult`, `dispatcherErrorResult`, `upstreamHTTPErrorResult`) replace every plain-string site with the structured `{error: {code, message, hint}}` envelope. Bulk-update's per-row `Error string` field flipped to `Error *ErrorPayload`.

### TASK-1078 — kind-aware error codes
Pre-fix every 404 collapsed to `item_not_found`; pre-fix every 5xx collapsed to `server_error`. New `ResourceKind` enum + `classifyHTTPStatusKind` lets dispatchers tell the classifier what was being read, so 404s split into `item_not_found` / `unknown_workspace` / `not_found`, and 5xx splits into `upstream_error` (transient backend) vs `server_error` (catch-all for dispatcher internal failures + un-mapped 4xx). New codes: `ErrNotFound`, `ErrUpstreamError`, `ErrBackendUnreachable`, `ErrWorkspaceRequired`.

### TASK-1079 — actionable hints
Pre-fix `hint` was `"404 page not found"` (chi's NotFound body) or the upstream JSON envelope re-stringified. Per-code hint generators now reference the actual route + ref + recovery tools. `extractUpstreamMessage` parses the structured envelope and lifts the inner message; non-envelope bodies return empty (per Codex review #387 round 1, returning the raw body would forward arbitrary upstream JSON / HTML / debug dumps including potential tokens).

## Test plan

- [x] `TestDispatcher_AllErrorsUseStructuredEnvelope` walks every special-case + link dispatcher's missing-required-input error path; pins the envelope shape uniformly. New dispatchers using `NewToolResultErrorf` will fail this test (regression gate).
- [x] `TestClassifyHTTPStatus_KindAware` pins each `ResourceKind` → expected `ErrorCode` mapping for 404s.
- [x] `TestClassifyHTTPStatus_HintsAreActionable` pins that hints reference the actual route + ref + recovery tools, AND forbids the bare `"404 page not found"` passthrough.
- [x] `TestExtractUpstreamMessage` covers 12 input shapes including the safe-fallback cases.
- [x] Existing tests updated for the new shapes.
- [x] `make check` clean.
- [x] **Codex review CLEAN at round 3** — round 1 caught 2 issues (`catalog_item.go` still using `NewToolResultErrorf`; `extractUpstreamMessage` raw-body fallback could leak), round 2 caught 1 residual leak (`classify404`'s `ResourceUnknown` branch still surfaced raw `bodyText`), round 3 confirmed all addressed.

## Behavior diff agents will observe

| Call | Before | After |
|---|---|---|
| `pad_item show TASK-MISSING` | `code: item_not_found, hint: "404 page not found"` | `code: item_not_found, hint: "Item \"TASK-MISSING\" not found. Route: ... Try pad_item search or pad_item list to find the right ref."` |
| `pad_workspace list` (route 404) | `code: item_not_found, hint: "404 page not found"` | `code: unknown_workspace, hint: "Route: ... Available workspaces: docapp, pad-web."` |
| Backend 500 | `code: server_error, message: "pad ... failed: <body>"` | `code: upstream_error, hint: "Backend returned 500. Usually transient — retry once or check pad logs ..."` |
| `pad_item note` no workspace | bare string `"item note: workspace is required"` | `code: validation_failed, hint: "Pass workspace=<slug> or set a session default via pad_set_workspace."` |
| `pad_item bulk-update` per-row 404 | `error: "read item: 404 404 page not found"` (bare string) | `error: { code: item_not_found, message: ..., hint: ... }` (per-row envelope) |

Closes TASK-1077, TASK-1078, TASK-1079.