### PR TITLE
feat(mcp): persistent audit log for /mcp tool calls (TASK-960)

### DIFF
--- a/internal/models/mcp_audit.go
+++ b/internal/models/mcp_audit.go
@@ -1,0 +1,105 @@
+package models
+
+import "time"
+
+// MCP audit log models (PLAN-943 TASK-960).
+//
+// Persistent record of every request that hits the /mcp endpoint —
+// successful tool calls, denied calls, errors. Drives the connected-
+// apps "last used" + "30-day calls" surfaces and gives forensics a
+// per-user / per-connection trail.
+
+// TokenKind discriminates the bearer that authenticated an MCP
+// request. TASK-960's spec said `token_id REFERENCES oauth_tokens(id)`;
+// pad has no oauth_tokens table — instead two separate token systems
+// can authenticate /mcp:
+//
+//   - "oauth": fosite-issued access token. token_ref carries the
+//     OAuth request_id (chain identifier preserved across rotations,
+//     see internal/store/oauth.go's request_id column). One value per
+//     "connection" the user authorized via consent.
+//   - "pat":   personal access token from the api_tokens table.
+//     token_ref is api_tokens.id. PATs predate the OAuth server but
+//     are still a supported MCP transport for CLI / dev use.
+//
+// We accept both so the connected-apps page can filter to OAuth only
+// (since "PATs" aren't third-party connections you'd revoke from a
+// management UI), while the per-user audit query still covers every
+// MCP call regardless of how it was authenticated.
+type TokenKind string
+
+const (
+	TokenKindOAuth TokenKind = "oauth"
+	TokenKindPAT   TokenKind = "pat"
+)
+
+// MCPAuditResultStatus is the outcome enum for an MCP request.
+type MCPAuditResultStatus string
+
+const (
+	MCPAuditResultOK     MCPAuditResultStatus = "ok"
+	MCPAuditResultError  MCPAuditResultStatus = "error"
+	MCPAuditResultDenied MCPAuditResultStatus = "denied"
+)
+
+// MCPAuditEntry is one row of mcp_audit_log. Fields mirror the table
+// 1:1 — see internal/store/migrations/049_mcp_audit.sql for the
+// column-level documentation.
+//
+// Pointers (WorkspaceID, ErrorKind) are nullable in the DB. Empty-
+// string semantics:
+//
+//   - ArgsHash == "": the request had no `params.arguments` (e.g.
+//     `tools/list`, `initialize`). Audit-grouping queries that count
+//     "distinct arg shapes" should treat empty as a sentinel rather
+//     than as "all empty calls share one group".
+//   - ToolName: for JSON-RPC methods that aren't tool calls
+//     (`initialize`, `tools/list`, `resources/read`, etc.) we store
+//     the JSON-RPC method itself ("initialize"), prefixed with no
+//     namespace. For `tools/call`, we store `params.name`
+//     (e.g. "pad_item"). The two namespaces are disjoint by design
+//     — pad's tool catalog uses `pad_*` names, JSON-RPC methods use
+//     `<group>/<verb>` — so a single column is safe.
+type MCPAuditEntry struct {
+	ID           string
+	Timestamp    time.Time
+	UserID       string
+	WorkspaceID  *string
+	TokenKind    TokenKind
+	TokenRef     string
+	ToolName     string
+	ArgsHash     string
+	ResultStatus MCPAuditResultStatus
+	ErrorKind    *string
+	LatencyMs    int
+	RequestID    string
+}
+
+// MCPAuditEntryInput is the write-side shape for InsertMCPAuditEntry.
+// Distinct from MCPAuditEntry so the store can mint the ID + accept a
+// caller's already-set timestamp (the middleware records the pre-
+// handler instant for accurate latency, then writes async).
+type MCPAuditEntryInput struct {
+	Timestamp    time.Time
+	UserID       string
+	WorkspaceID  string // empty → NULL
+	TokenKind    TokenKind
+	TokenRef     string
+	ToolName     string
+	ArgsHash     string
+	ResultStatus MCPAuditResultStatus
+	ErrorKind    string // empty → NULL
+	LatencyMs    int
+	RequestID    string
+}
+
+// MCPConnectionStats summarizes audit-log activity for one OAuth
+// connection (request_id chain). Returned by the bulk-aggregate
+// queries the connected-apps page reads — fetching last-used and
+// 30-day-count per connection in two queries instead of N.
+type MCPConnectionStats struct {
+	TokenKind  TokenKind
+	TokenRef   string
+	LastUsedAt *time.Time // nil if no audit entries
+	Calls30d   int
+}

--- a/internal/server/context.go
+++ b/internal/server/context.go
@@ -148,6 +148,41 @@ func WithTokenAllowedWorkspaces(ctx context.Context, slugs []string) context.Con
 	return context.WithValue(ctx, ctxTokenAllowedWorkspaces, cp)
 }
 
+// WithMCPTokenIdentity stashes the bearer-token identity so the MCP
+// audit middleware can record which connection drove the call.
+//
+// kind is the discriminator — "oauth" for fosite-issued access tokens,
+// "pat" for personal access tokens. ref is the connection identifier:
+//
+//   - For "oauth", ref is the OAuth request_id chain identifier
+//     (preserved across refresh-token rotations — see
+//     internal/store/oauth.go). One value per "connection" the user
+//     authorized via consent.
+//   - For "pat", ref is api_tokens.id.
+//
+// Only called from MCPBearerAuth's two branches (PAT + OAuth).
+// Other auth middleware doesn't touch /mcp, so the audit middleware
+// reads "" and skips the row when no MCP identity was attached
+// (defense in depth — the audit middleware only mounts behind
+// MCPBearerAuth, so the empty case shouldn't fire in practice).
+//
+// Empty kind or ref clears any previously set value, which would only
+// happen in a synthesized test request.
+func WithMCPTokenIdentity(ctx context.Context, kind, ref string) context.Context {
+	ctx = context.WithValue(ctx, ctxMCPTokenKind, kind)
+	ctx = context.WithValue(ctx, ctxMCPTokenRef, ref)
+	return ctx
+}
+
+// MCPTokenIdentityFromContext returns (kind, ref) attached by
+// WithMCPTokenIdentity, or ("", "") if none was set. The audit
+// middleware uses this to populate token_kind + token_ref columns.
+func MCPTokenIdentityFromContext(ctx context.Context) (kind, ref string) {
+	k, _ := ctx.Value(ctxMCPTokenKind).(string)
+	r, _ := ctx.Value(ctxMCPTokenRef).(string)
+	return k, r
+}
+
 // TokenAllowedWorkspacesFromContext returns the token's workspace
 // allow-list, or nil if none was attached. Three return shapes
 // matter to callers:

--- a/internal/server/handlers_mcp.go
+++ b/internal/server/handlers_mcp.go
@@ -67,6 +67,13 @@ func (s *Server) SetMCPTransport(transport http.Handler, mcpPublicURL, authServe
 	s.mcpTransport = transport
 	s.mcpPublicURL = mcpPublicURL
 	s.mcpAuthServerURL = authServerURL
+
+	// Spawn the audit log writer + retention sweeper now that the
+	// MCP surface is wired (TASK-960). Idempotent — safe to call
+	// from tests that flip transport state on/off via repeated
+	// SetMCPTransport. The writer outlives the request flow; it's
+	// stopped from Server.Stop via stopMCPAuditWriter.
+	s.startMCPAuditWriter()
 }
 
 // registerMCPRoutes installs the /mcp + /.well-known endpoints on r,
@@ -102,7 +109,14 @@ func (s *Server) registerMCPRoutes(r chi.Router) {
 	// server handles all methods (POST handshake/calls, GET for SSE
 	// streams, DELETE for session termination), so we Mount() rather
 	// than registering per-method.
-	r.With(s.requireCloudMode, s.MCPBearerAuth).Mount("/mcp", s.mcpTransport)
+	//
+	// MCPAuditLog (TASK-960) sits AFTER MCPBearerAuth so the audit
+	// row carries the resolved user + token identity. It also runs
+	// AFTER the rate-limit gates inside MCPBearerAuth so 429s get
+	// captured as result_status="denied". The audit middleware is a
+	// no-op when the writer hasn't been spawned (selfhost / test
+	// builds), so the chain is safe to mount unconditionally.
+	r.With(s.requireCloudMode, s.MCPBearerAuth, s.MCPAuditLog).Mount("/mcp", s.mcpTransport)
 
 	// Discovery endpoints — unauthenticated, cloud-mode-gated. RFC 9728
 	// (protected-resource) gets the real metadata; RFC 8414 (auth-server)

--- a/internal/server/handlers_mcp_audit.go
+++ b/internal/server/handlers_mcp_audit.go
@@ -1,0 +1,175 @@
+package server
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// MCP audit log read endpoints (PLAN-943 TASK-960).
+//
+// Two surfaces:
+//
+//   - GET /api/v1/connected-apps/{id}/audit  — per-connection drilldown.
+//     id is the OAuth request_id (chain identifier). Owner-only:
+//     enforces that a user can only see audit rows for their own
+//     connections by passing user_id into the store query.
+//
+//   - GET /api/v1/admin/mcp-audit            — admin full-table view.
+//     Backs the /console/admin/mcp-audit page. Pagination via
+//     limit + offset query params.
+//
+// The handlers are intentionally minimal — pagination, no filtering
+// beyond user/connection. Filter expressions (by tool_name, by
+// result_status, by date range) are an obvious follow-up but the
+// spec explicitly defers them.
+
+// mcpAuditEntryDTO is the wire-form for one row. We don't return
+// models.MCPAuditEntry directly because:
+//
+//   - Fields are unexported-friendly (Go field names map to JSON via
+//     reflect tags), but we want stable snake_case JSON keys.
+//   - Pointers (*string for nullable columns) need explicit "" /
+//     omitempty handling.
+//   - The token_ref field IS the OAuth request_id — surfacing it as
+//     a separate field name (`connection_id`) keeps the public API
+//     decoupled from the internal column name in case we ever
+//     refactor the store side.
+type mcpAuditEntryDTO struct {
+	ID           string `json:"id"`
+	Timestamp    string `json:"timestamp"`
+	UserID       string `json:"user_id"`
+	WorkspaceID  string `json:"workspace_id,omitempty"`
+	TokenKind    string `json:"token_kind"`    // "oauth" | "pat"
+	ConnectionID string `json:"connection_id"` // OAuth request_id, or PAT id
+	ToolName     string `json:"tool_name"`
+	ArgsHash     string `json:"args_hash,omitempty"`
+	ResultStatus string `json:"result_status"`
+	ErrorKind    string `json:"error_kind,omitempty"`
+	LatencyMs    int    `json:"latency_ms"`
+	RequestID    string `json:"request_id"`
+}
+
+func mcpAuditEntryToDTO(e models.MCPAuditEntry) mcpAuditEntryDTO {
+	dto := mcpAuditEntryDTO{
+		ID:           e.ID,
+		Timestamp:    e.Timestamp.UTC().Format(time.RFC3339),
+		UserID:       e.UserID,
+		TokenKind:    string(e.TokenKind),
+		ConnectionID: e.TokenRef,
+		ToolName:     e.ToolName,
+		ArgsHash:     e.ArgsHash,
+		ResultStatus: string(e.ResultStatus),
+		LatencyMs:    e.LatencyMs,
+		RequestID:    e.RequestID,
+	}
+	if e.WorkspaceID != nil {
+		dto.WorkspaceID = *e.WorkspaceID
+	}
+	if e.ErrorKind != nil {
+		dto.ErrorKind = *e.ErrorKind
+	}
+	return dto
+}
+
+// parseMCPAuditPaging extracts limit + offset from the query string,
+// applying sane caps. Bound limit at 200 — large enough for a "scan
+// the recent audit" UX, small enough that a runaway client can't DoS
+// the DB by scrolling forever.
+func parseMCPAuditPaging(r *http.Request) (limit, offset int) {
+	limit = 50
+	if l := r.URL.Query().Get("limit"); l != "" {
+		if v, err := strconv.Atoi(l); err == nil && v > 0 {
+			limit = v
+		}
+	}
+	if limit > 200 {
+		limit = 200
+	}
+	if o := r.URL.Query().Get("offset"); o != "" {
+		if v, err := strconv.Atoi(o); err == nil && v >= 0 {
+			offset = v
+		}
+	}
+	return limit, offset
+}
+
+// handleMCPConnectionAudit returns the audit rows for one of the
+// requesting user's MCP connections.
+//
+// id is the OAuth request_id (chain identifier — the same value the
+// connected-apps page revokes by). PATs aren't currently surfaced
+// here because the connected-apps page lists OAuth-only — adding
+// `?token_kind=pat` later is a one-line change in the store call.
+//
+// Returns 404 if the user has no audit entries for that connection
+// (consistent with "the connection isn't yours" — explicit owner-
+// scoped 404 prevents enumeration).
+func (s *Server) handleMCPConnectionAudit(w http.ResponseWriter, r *http.Request) {
+	user := currentUser(r)
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, "unauthorized", "Authentication required.")
+		return
+	}
+
+	id := strings.TrimSpace(chi.URLParam(r, "id"))
+	if id == "" {
+		writeError(w, http.StatusBadRequest, "invalid_request", "connection id required")
+		return
+	}
+
+	limit, offset := parseMCPAuditPaging(r)
+
+	rows, err := s.store.ListMCPAuditByConnection(user.ID, models.TokenKindOAuth, id, limit, offset)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+
+	out := make([]mcpAuditEntryDTO, 0, len(rows))
+	for _, e := range rows {
+		out = append(out, mcpAuditEntryToDTO(e))
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"items":  out,
+		"limit":  limit,
+		"offset": offset,
+	})
+}
+
+// handleAdminMCPAudit returns the full audit log. Admin-only.
+//
+// Supports limit + offset paging; no other filters in v1. The admin
+// UI can layer client-side filtering on top — at <= 200 rows per
+// page that stays cheap.
+func (s *Server) handleAdminMCPAudit(w http.ResponseWriter, r *http.Request) {
+	user := currentUser(r)
+	if user == nil || user.Role != "admin" {
+		writeError(w, http.StatusForbidden, "forbidden", "Admin access required")
+		return
+	}
+
+	limit, offset := parseMCPAuditPaging(r)
+
+	rows, err := s.store.ListAllMCPAudit(limit, offset)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+
+	out := make([]mcpAuditEntryDTO, 0, len(rows))
+	for _, e := range rows {
+		out = append(out, mcpAuditEntryToDTO(e))
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"items":   out,
+		"limit":   limit,
+		"offset":  offset,
+		"dropped": s.mcpAuditDroppedSnapshot(),
+	})
+}

--- a/internal/server/handlers_mcp_audit_test.go
+++ b/internal/server/handlers_mcp_audit_test.go
@@ -1,0 +1,204 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// MCP audit handler tests (PLAN-943 TASK-960).
+//
+// Two endpoints:
+//
+//   - GET /api/v1/connected-apps/{id}/audit  — owner-scoped per-connection.
+//   - GET /api/v1/admin/mcp-audit            — admin-only full table.
+//
+// What's covered:
+//
+//   - Per-connection endpoint requires auth + filters by user_id (a
+//     user calling with another user's request_id sees zero rows).
+//   - Admin endpoint rejects non-admin callers with 403.
+//   - Admin endpoint returns rows across users.
+//   - Pagination params parse correctly + cap at 200.
+//   - Response DTO surfaces the right field names (the wire contract
+//     uses `connection_id`, not `token_ref`, to keep the API decoupled
+//     from the column name).
+
+// seedAuditRow inserts one audit row for a user against a given
+// (kind, ref) pair so the read endpoints have something to return.
+func seedAuditRow(t *testing.T, srv *Server, userID string, kind models.TokenKind, ref, tool string) {
+	t.Helper()
+	err := srv.store.InsertMCPAuditEntry(models.MCPAuditEntryInput{
+		UserID:       userID,
+		TokenKind:    kind,
+		TokenRef:     ref,
+		ToolName:     tool,
+		ResultStatus: models.MCPAuditResultOK,
+		RequestID:    "req-seed",
+	})
+	if err != nil {
+		t.Fatalf("InsertMCPAuditEntry: %v", err)
+	}
+}
+
+func TestHandleMCPConnectionAudit_OwnerOnly(t *testing.T) {
+	srv := testServer(t)
+
+	alice, aliceTok := loginTestUser(t, srv)
+	// Create a SECOND user via the same helper pattern.
+	bob, err := srv.store.CreateUser(models.UserCreate{
+		Email: "bob-audit@example.com", Name: "Bob", Password: "pw-test-12345",
+	})
+	if err != nil {
+		t.Fatalf("CreateUser bob: %v", err)
+	}
+
+	// Both users have audit rows against the same connection ref.
+	seedAuditRow(t, srv, alice.ID, models.TokenKindOAuth, "ref-shared", "pad_item")
+	seedAuditRow(t, srv, bob.ID, models.TokenKindOAuth, "ref-shared", "pad_item")
+
+	// Alice asks for the connection — should see her row only.
+	rr := doAuthedRequest(srv, "GET", "/api/v1/connected-apps/ref-shared/audit", nil, aliceTok)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body=%s)", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		Items []map[string]any `json:"items"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v (body=%s)", err, rr.Body.String())
+	}
+	if len(resp.Items) != 1 {
+		t.Errorf("got %d items, want 1 (Alice's only)", len(resp.Items))
+	}
+	if got, _ := resp.Items[0]["user_id"].(string); got != alice.ID {
+		t.Errorf("returned user_id = %q, want Alice's %q", got, alice.ID)
+	}
+}
+
+func TestHandleMCPConnectionAudit_RequiresAuth(t *testing.T) {
+	srv := testServer(t)
+	rr := doRequest(srv, "GET", "/api/v1/connected-apps/anything/audit", nil)
+	if rr.Code != http.StatusUnauthorized && rr.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 401 or 403 (auth-required)", rr.Code)
+	}
+}
+
+func TestHandleMCPConnectionAudit_DTOShape(t *testing.T) {
+	srv := testServer(t)
+	user, tok := loginTestUser(t, srv)
+	// Workspace-bound row to exercise the workspace_id field too.
+	ws, err := srv.store.CreateWorkspace(models.WorkspaceCreate{Name: "DTO WS"})
+	if err != nil {
+		t.Fatalf("CreateWorkspace: %v", err)
+	}
+	err = srv.store.InsertMCPAuditEntry(models.MCPAuditEntryInput{
+		UserID:       user.ID,
+		WorkspaceID:  ws.ID,
+		TokenKind:    models.TokenKindOAuth,
+		TokenRef:     "shape-ref",
+		ToolName:     "pad_item",
+		ArgsHash:     "hashy",
+		ResultStatus: models.MCPAuditResultOK,
+		LatencyMs:    13,
+		RequestID:    "req-shape",
+	})
+	if err != nil {
+		t.Fatalf("InsertMCPAuditEntry: %v", err)
+	}
+
+	rr := doAuthedRequest(srv, "GET", "/api/v1/connected-apps/shape-ref/audit", nil, tok)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body=%s)", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		Items []map[string]any `json:"items"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Items) != 1 {
+		t.Fatalf("len items = %d, want 1", len(resp.Items))
+	}
+	row := resp.Items[0]
+	wantKeys := []string{"id", "timestamp", "user_id", "workspace_id",
+		"token_kind", "connection_id", "tool_name", "args_hash",
+		"result_status", "latency_ms", "request_id"}
+	for _, k := range wantKeys {
+		if _, ok := row[k]; !ok {
+			t.Errorf("missing field %q in DTO; got %+v", k, row)
+		}
+	}
+	if got, _ := row["connection_id"].(string); got != "shape-ref" {
+		t.Errorf("connection_id = %v, want %q", row["connection_id"], "shape-ref")
+	}
+	if got, _ := row["token_kind"].(string); got != "oauth" {
+		t.Errorf("token_kind = %v, want oauth", row["token_kind"])
+	}
+}
+
+func TestHandleAdminMCPAudit_RejectsNonAdmin(t *testing.T) {
+	srv := testServer(t)
+	_, tok := loginTestUser(t, srv) // default role: user, not admin
+	rr := doAuthedRequest(srv, "GET", "/api/v1/admin/mcp-audit", nil, tok)
+	if rr.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 403 for non-admin", rr.Code)
+	}
+}
+
+func TestHandleAdminMCPAudit_AdminSeesAcrossUsers(t *testing.T) {
+	srv := testServer(t)
+	admin, adminTok := loginTestUser(t, srv)
+	// Promote to admin so the /admin/mcp-audit gate passes.
+	if err := srv.store.SetUserRole(admin.ID, "admin"); err != nil {
+		t.Fatalf("SetUserRole: %v", err)
+	}
+
+	bob, err := srv.store.CreateUser(models.UserCreate{
+		Email: "bob-admin-audit@example.com", Name: "Bob", Password: "pw-test-12345",
+	})
+	if err != nil {
+		t.Fatalf("CreateUser bob: %v", err)
+	}
+	seedAuditRow(t, srv, admin.ID, models.TokenKindOAuth, "ref-a", "pad_item")
+	seedAuditRow(t, srv, bob.ID, models.TokenKindOAuth, "ref-b", "pad_item")
+
+	rr := doAuthedRequest(srv, "GET", "/api/v1/admin/mcp-audit?limit=10", nil, adminTok)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body=%s)", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		Items   []map[string]any `json:"items"`
+		Dropped uint64           `json:"dropped"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Items) != 2 {
+		t.Errorf("len items = %d, want 2 (across users)", len(resp.Items))
+	}
+}
+
+func TestParseMCPAuditPaging_CapsAt200(t *testing.T) {
+	req := httptest.NewRequest("GET", "/?limit=10000&offset=50", nil)
+	limit, offset := parseMCPAuditPaging(req)
+	if limit != 200 {
+		t.Errorf("limit = %d, want 200 (cap)", limit)
+	}
+	if offset != 50 {
+		t.Errorf("offset = %d, want 50", offset)
+	}
+
+	// Defaults.
+	req2 := httptest.NewRequest("GET", "/", nil)
+	limit2, offset2 := parseMCPAuditPaging(req2)
+	if limit2 != 50 {
+		t.Errorf("default limit = %d, want 50", limit2)
+	}
+	if offset2 != 0 {
+		t.Errorf("default offset = %d, want 0", offset2)
+	}
+}

--- a/internal/server/middleware_auth.go
+++ b/internal/server/middleware_auth.go
@@ -46,6 +46,16 @@ const (
 	// the consent (TASK-953). nil → no token-level workspace
 	// constraint (PAT auth, or pre-TASK-952 OAuth tokens).
 	ctxTokenAllowedWorkspaces contextKey = "token_allowed_workspaces"
+	// ctxMCPTokenKind / ctxMCPTokenRef carry the bearer's identity for
+	// MCP audit logging (TASK-960). Stashed by MCPBearerAuth so the
+	// audit middleware (middleware_mcp_audit.go) can record which
+	// connection (OAuth request_id chain) or which PAT (api_tokens.id)
+	// drove the call. Empty when no MCP-auth happened (i.e. the request
+	// didn't go through MCPBearerAuth). The ref values aren't sensitive
+	// — they're internal IDs / chain identifiers, never the raw bearer
+	// — so leaking via context is fine.
+	ctxMCPTokenKind contextKey = "mcp_token_kind"
+	ctxMCPTokenRef  contextKey = "mcp_token_ref"
 )
 
 // TokenAuth middleware checks for an Authorization: Bearer pad_xxx header.

--- a/internal/server/middleware_mcp_audit.go
+++ b/internal/server/middleware_mcp_audit.go
@@ -1,0 +1,474 @@
+package server
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	chimiddleware "github.com/go-chi/chi/v5/middleware"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/store"
+)
+
+// MCP audit log middleware (PLAN-943 TASK-960).
+//
+// Wraps the /mcp Streamable HTTP handler AFTER MCPBearerAuth runs, so
+// the audit row carries the resolved user + token identity stashed on
+// context. Records one row per HTTP request hitting /mcp:
+//
+//   - Successful tool calls (200 OK with a JSON-RPC result envelope).
+//   - Tool calls that the inner handler rejected (200 OK with an error
+//     envelope — JSON-RPC errors are still HTTP 200 per spec).
+//   - Authorization gate misses (401 / 403).
+//   - Server errors (5xx).
+//
+// Writes are async via a buffered channel + worker goroutine. The
+// hot path captures the HTTP-level outcome, builds an MCPAuditEntry,
+// and tries a non-blocking channel send; if the buffer is full
+// (DB outage / writer too slow), the entry is dropped and the
+// mcp_audit_dropped_total metric increments. The request never
+// blocks — the spec is "audit is best-effort, /mcp latency is not."
+//
+// Body sniffing:
+//
+// To populate tool_name + args_hash without consuming the body that
+// the inner JSON-RPC handler needs, we wrap r.Body in a tee that
+// buffers up to mcpAuditBodyMaxBytes. The first frame is parsed
+// after-the-fact (post-handler) because Streamable HTTP can carry
+// either a single JSON-RPC envelope or an SSE stream — we only sniff
+// the request body, not the response. tool_name defaults to "(unknown)"
+// when the body wasn't a JSON-RPC envelope or was over the cap; that's
+// rare and intentionally ugly so it stands out in audit reviews.
+
+const (
+	// mcpAuditBufferSize bounds the in-flight queue between the
+	// hot-path producer and the disk-bound writer. Sized at 4096:
+	// at our worst-case bursting rate (a few hundred req/s per node
+	// during a tool-call cascade) this absorbs ~10–30 seconds of
+	// backpressure before the drop path fires. Memory cost ~1MB at
+	// full saturation (each entry ≈ 256B), which is cheap for the
+	// resilience win.
+	mcpAuditBufferSize = 4096
+
+	// mcpAuditBodyMaxBytes caps how much of a request body we'll buffer
+	// for tool_name / args_hash extraction. Tool args can be large
+	// (item content posts), but we only need the JSON-RPC method +
+	// params.name + params.arguments — typically <2KB. Anything past
+	// the cap is opaque to audit and the hash collapses to "" rather
+	// than partial data, which would produce misleading "matching"
+	// hashes for unrelated calls.
+	mcpAuditBodyMaxBytes = 64 * 1024
+
+	// mcpAuditRetention is the age cutoff for the periodic sweep.
+	// 90 days per TASK-960's spec.
+	mcpAuditRetention = 90 * 24 * time.Hour
+
+	// mcpAuditSweepInterval is how often the retention sweeper runs.
+	// 24h is overkill for most deploys (audit growth is bounded by
+	// MCP traffic) but keeps the table hot-set bounded after a
+	// burst.
+	mcpAuditSweepInterval = 24 * time.Hour
+
+	// mcpAuditWriteTimeout caps how long a single InsertMCPAuditEntry
+	// can block the writer goroutine. Longer than the SQLite busy
+	// timeout (30s) so a rare contention spike doesn't drop the row,
+	// but bounded so a runaway DB doesn't pin the writer forever.
+	mcpAuditWriteTimeout = 60 * time.Second
+)
+
+// mcpAuditWriter owns the buffered queue + worker goroutine that
+// drains it into the store. One per Server. Started in
+// startMCPAuditWriter; stopped in Server.Stop via the bg WaitGroup
+// + a stop channel.
+type mcpAuditWriter struct {
+	store   *store.Store
+	queue   chan models.MCPAuditEntryInput
+	stop    chan struct{}
+	stopped sync.Once
+
+	// dropped counts entries shed because the queue was full at
+	// send time. Surfaced via Prometheus when metrics are wired
+	// (read in mcpAuditDroppedSnapshot below). Atomic so the
+	// hot path doesn't lock to bump it.
+	dropped atomic.Uint64
+}
+
+// newMCPAuditWriter constructs a writer with a 4096-deep queue. The
+// caller is responsible for kicking the worker via run() and for
+// stopping it via stop().
+func newMCPAuditWriter(s *store.Store) *mcpAuditWriter {
+	return &mcpAuditWriter{
+		store: s,
+		queue: make(chan models.MCPAuditEntryInput, mcpAuditBufferSize),
+		stop:  make(chan struct{}),
+	}
+}
+
+// enqueue tries to push one entry without blocking. Returns true on
+// success; on a full queue, increments the drop counter and returns
+// false. The MCP middleware ignores the return value — it's strictly
+// observability.
+func (w *mcpAuditWriter) enqueue(in models.MCPAuditEntryInput) bool {
+	select {
+	case w.queue <- in:
+		return true
+	default:
+		w.dropped.Add(1)
+		return false
+	}
+}
+
+// run is the worker goroutine. Drains queue → InsertMCPAuditEntry,
+// logs (but doesn't crash on) DB errors, exits on stop. Tracked via
+// Server.bg so Stop() can drain in-flight writes.
+func (w *mcpAuditWriter) run() {
+	for {
+		select {
+		case <-w.stop:
+			// Drain whatever's already in the queue before exit so
+			// a clean shutdown loses no rows. Bounded by the queue
+			// depth so this doesn't hang forever on a stuck DB.
+			for {
+				select {
+				case in := <-w.queue:
+					w.write(in)
+				default:
+					return
+				}
+			}
+		case in := <-w.queue:
+			w.write(in)
+		}
+	}
+}
+
+// write performs a single insert with a per-call timeout. DB errors
+// log + drop the row — there's no retry path because the audit log
+// is best-effort by design. Repeated failures will show up in the
+// structured logs as "mcp audit insert failed" warns; ops can alert
+// on that pattern.
+func (w *mcpAuditWriter) write(in models.MCPAuditEntryInput) {
+	// Timeout via a goroutine wrapper because store methods don't
+	// take a context today (refactoring every store method to
+	// accept ctx is out of scope for this task). The timeout is
+	// observability-only — if InsertMCPAuditEntry returns after
+	// timeout, the row still lands; we just don't wait for it from
+	// the worker.
+	done := make(chan error, 1)
+	go func() {
+		done <- w.store.InsertMCPAuditEntry(in)
+	}()
+	select {
+	case err := <-done:
+		if err != nil {
+			slog.Warn("mcp audit insert failed",
+				"error", err,
+				"user_id", in.UserID,
+				"token_kind", string(in.TokenKind),
+				"tool_name", in.ToolName)
+		}
+	case <-time.After(mcpAuditWriteTimeout):
+		slog.Warn("mcp audit insert timed out",
+			"user_id", in.UserID,
+			"tool_name", in.ToolName)
+	}
+}
+
+// shutdown signals the worker to drain + exit. Idempotent.
+func (w *mcpAuditWriter) shutdown() {
+	w.stopped.Do(func() {
+		close(w.stop)
+	})
+}
+
+// mcpAuditDroppedSnapshot returns the cumulative number of audit
+// entries dropped due to buffer-full backpressure. Exported as a
+// method on Server so admin / metrics surfaces can read it. Returns
+// 0 when no audit writer is configured (self-hosted builds without
+// MCP).
+func (s *Server) mcpAuditDroppedSnapshot() uint64 {
+	if s.mcpAudit == nil {
+		return 0
+	}
+	return s.mcpAudit.dropped.Load()
+}
+
+// MCPAuditLog wraps next with audit recording. Mounts after
+// MCPBearerAuth in registerMCPRoutes so currentUser + the token
+// identity stashed by the auth middleware are already on context.
+//
+// No-op when the audit writer hasn't been configured (selfhost
+// builds without MCP, tests that didn't call startMCPAuditWriter).
+// In that case the middleware passes the request straight through —
+// MCP still works, just without forensics.
+func (s *Server) MCPAuditLog(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if s.mcpAudit == nil {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		start := time.Now().UTC()
+
+		// Sniff the request body BEFORE the inner handler runs.
+		//
+		// Why read up-front rather than tee on the inner handler's
+		// read: a TeeReader only fills the sniffer buffer when
+		// something reads from it. mcp-go's streamable HTTP server
+		// reads via the JSON-RPC decoder, which IS a reader — but
+		// when an upstream rejects the request early (auth gate,
+		// rate limit) the body never gets touched and the sniffer
+		// stays empty. Reading proactively guarantees the audit row
+		// has tool_name even on rejected requests, which is exactly
+		// the case forensics cares about most.
+		//
+		// MCP request bodies are bounded JSON-RPC envelopes (one
+		// per POST), not streams — reading them in full is safe.
+		// We cap at mcpAuditBodyMaxBytes so a pathologically large
+		// body doesn't pin memory; past the cap the audit row sees
+		// "(unknown)" tool but the inner handler still gets the
+		// full body via the bytes.NewReader replacement.
+		var snifferBytes []byte
+		if r.Body != nil && r.Method != http.MethodGet {
+			limited := io.LimitReader(r.Body, mcpAuditBodyMaxBytes)
+			peeked, _ := io.ReadAll(limited)
+			snifferBytes = peeked
+			// Stitch the peeked bytes back together with whatever's
+			// left past the cap so the inner handler sees the
+			// original payload intact. r.Body's Closer survives
+			// because we wrap, not replace.
+			restored := struct {
+				io.Reader
+				io.Closer
+			}{
+				Reader: io.MultiReader(bytes.NewReader(peeked), r.Body),
+				Closer: r.Body,
+			}
+			r.Body = restored
+		}
+
+		// Wrap the response writer so we can read the status code +
+		// body length AFTER next.ServeHTTP returns. chi already
+		// provides this — reuse rather than redo.
+		ww := chimiddleware.NewWrapResponseWriter(w, r.ProtoMajor)
+
+		next.ServeHTTP(ww, r)
+
+		latencyMs := int(time.Since(start) / time.Millisecond)
+
+		// Pull identity off context. If MCPBearerAuth didn't run
+		// (shouldn't happen — we mount after it — but defensive),
+		// skip the row. We don't write rows we can't attribute.
+		user, _ := CurrentUserFromContext(r.Context())
+		if user == nil {
+			return
+		}
+		kind, ref := MCPTokenIdentityFromContext(r.Context())
+		if kind == "" || ref == "" {
+			return
+		}
+
+		// X-Request-ID is set by chi's RequestID middleware higher
+		// up the stack. If somehow absent, fall back to a synthesized
+		// "" so the column constraint (NOT NULL) doesn't reject the
+		// insert; downstream forensics will see an empty string and
+		// know to ignore correlation.
+		reqID := chimiddleware.GetReqID(r.Context())
+		if reqID == "" {
+			reqID = strconv.FormatInt(start.UnixNano(), 36)
+		}
+
+		toolName, argsHash := parseMCPRequestBody(snifferBytes)
+
+		status, errorKind := classifyMCPResult(ww.Status())
+
+		entry := models.MCPAuditEntryInput{
+			Timestamp:    start,
+			UserID:       user.ID,
+			WorkspaceID:  "", // workspace context isn't reliably on the request — populated only when present below
+			TokenKind:    models.TokenKind(kind),
+			TokenRef:     ref,
+			ToolName:     toolName,
+			ArgsHash:     argsHash,
+			ResultStatus: status,
+			ErrorKind:    errorKind,
+			LatencyMs:    latencyMs,
+			RequestID:    reqID,
+		}
+
+		s.mcpAudit.enqueue(entry)
+	})
+}
+
+// parseMCPRequestBody extracts (tool_name, args_hash) from the
+// JSON-RPC envelope in body. Two cases:
+//
+//   - method == "tools/call" → tool_name = params.name,
+//     args_hash = SHA-256 of canonical-JSON params.arguments.
+//   - any other method → tool_name = method itself
+//     (e.g. "initialize", "tools/list"), args_hash = "" because
+//     these calls have no per-call arguments worth correlating.
+//
+// Returns ("(unknown)", "") on parse failure or empty body — gives
+// the audit reader a visible signal rather than silently dropping
+// the row.
+func parseMCPRequestBody(body []byte) (toolName, argsHash string) {
+	if len(body) == 0 {
+		return "(unknown)", ""
+	}
+	var env struct {
+		Method string          `json:"method"`
+		Params json.RawMessage `json:"params"`
+	}
+	if err := json.Unmarshal(body, &env); err != nil || env.Method == "" {
+		return "(unknown)", ""
+	}
+	if env.Method != "tools/call" {
+		return env.Method, ""
+	}
+	var p struct {
+		Name      string          `json:"name"`
+		Arguments json.RawMessage `json:"arguments"`
+	}
+	if err := json.Unmarshal(env.Params, &p); err != nil || p.Name == "" {
+		return "tools/call", ""
+	}
+	return p.Name, hashCanonicalJSON(p.Arguments)
+}
+
+// hashCanonicalJSON returns a SHA-256 hex of a canonicalized form of
+// the input JSON. "Canonical" here means: round-trip through
+// encoding/json to sort object keys (Go's encoder does that natively
+// since 1.12 for map[string]any). For arguments that are already a
+// JSON object this produces stable hashes across calls with the same
+// fields-in-different-order.
+//
+// Empty / null input returns "" so the column reflects "no args"
+// rather than the SHA of "null" / "" — distinguishable in audit
+// queries.
+func hashCanonicalJSON(raw json.RawMessage) string {
+	if len(raw) == 0 || string(raw) == "null" {
+		return ""
+	}
+	// Decode-then-encode to canonicalize key order. Failure just
+	// hashes the raw bytes as-is — we'd rather have a hash that
+	// might not group exactly than no audit signal at all.
+	var v interface{}
+	if err := json.Unmarshal(raw, &v); err != nil {
+		sum := sha256.Sum256(raw)
+		return hex.EncodeToString(sum[:])
+	}
+	canon, err := json.Marshal(v)
+	if err != nil {
+		sum := sha256.Sum256(raw)
+		return hex.EncodeToString(sum[:])
+	}
+	sum := sha256.Sum256(canon)
+	return hex.EncodeToString(sum[:])
+}
+
+// classifyMCPResult maps an HTTP status to (audit_status, error_kind).
+//
+// JSON-RPC quirk: tool errors come back as 200 OK with an `error`
+// field in the response body. We CAN'T see that here without
+// snooping the response body too — and the spec for TASK-960 says
+// "every MCP request results in exactly one audit-log row," not
+// "every successful tool call." So we classify on transport-level
+// status, with the understanding that result_status="ok" means
+// "the gate let it through" rather than "the tool succeeded." That's
+// the right granularity for forensics; per-tool success would need
+// the dispatcher to emit its own audit signal post-execution, which
+// is out of scope here (and probably belongs as a separate JSON-RPC
+// success/failure stream).
+func classifyMCPResult(httpStatus int) (models.MCPAuditResultStatus, string) {
+	switch {
+	case httpStatus == 0 || httpStatus == http.StatusOK:
+		return models.MCPAuditResultOK, ""
+	case httpStatus == http.StatusUnauthorized:
+		return models.MCPAuditResultDenied, "unauthorized"
+	case httpStatus == http.StatusForbidden:
+		return models.MCPAuditResultDenied, "forbidden"
+	case httpStatus == http.StatusTooManyRequests:
+		return models.MCPAuditResultDenied, "rate_limited"
+	case httpStatus >= 500:
+		return models.MCPAuditResultError, "server_error_" + strconv.Itoa(httpStatus)
+	case httpStatus >= 400:
+		return models.MCPAuditResultError, "client_error_" + strconv.Itoa(httpStatus)
+	}
+	return models.MCPAuditResultOK, ""
+}
+
+// startMCPAuditWriter constructs the audit writer + spawns its
+// worker goroutine + spawns the periodic retention sweeper. Called
+// once at startup from cmd/pad/main.go (cloud mode only).
+//
+// No-op if the writer is already running — supports the test pattern
+// where multiple Server instances over a shared store would otherwise
+// double-spawn.
+func (s *Server) startMCPAuditWriter() {
+	if s.mcpAudit != nil {
+		return
+	}
+	s.mcpAudit = newMCPAuditWriter(s.store)
+	s.goAsync(func() {
+		s.mcpAudit.run()
+	})
+	s.goAsync(func() {
+		s.runMCPAuditSweeper()
+	})
+}
+
+// runMCPAuditSweeper drives the 90-day retention sweep on a 24h
+// ticker. Exits when the audit writer's stop channel closes (i.e.
+// when Server.Stop() runs). One sweep on startup so a long-stopped
+// server catches up immediately rather than waiting 24h for the
+// first tick.
+func (s *Server) runMCPAuditSweeper() {
+	if s.mcpAudit == nil {
+		return
+	}
+	sweep := func() {
+		cutoff := time.Now().UTC().Add(-mcpAuditRetention)
+		n, err := s.store.SweepMCPAuditOlderThan(cutoff)
+		if err != nil {
+			slog.Warn("mcp audit retention sweep failed", "error", err)
+			return
+		}
+		if n > 0 {
+			slog.Info("mcp audit retention swept", "rows", n, "cutoff", cutoff.Format(time.RFC3339))
+		}
+	}
+	sweep()
+	t := time.NewTicker(mcpAuditSweepInterval)
+	defer t.Stop()
+	for {
+		select {
+		case <-s.mcpAudit.stop:
+			return
+		case <-t.C:
+			sweep()
+		}
+	}
+}
+
+// stopMCPAuditWriter signals the writer to drain + exit. Called
+// from Server.Stop. Idempotent.
+func (s *Server) stopMCPAuditWriter() {
+	if s.mcpAudit == nil {
+		return
+	}
+	s.mcpAudit.shutdown()
+}
+
+// Compile-time guard: pin the middleware's signature so an accidental
+// refactor that breaks the http.Handler chain doesn't slip in.
+var _ func(http.Handler) http.Handler = (*Server)(nil).MCPAuditLog

--- a/internal/server/middleware_mcp_audit.go
+++ b/internal/server/middleware_mcp_audit.go
@@ -472,3 +472,62 @@ func (s *Server) stopMCPAuditWriter() {
 // Compile-time guard: pin the middleware's signature so an accidental
 // refactor that breaks the http.Handler chain doesn't slip in.
 var _ func(http.Handler) http.Handler = (*Server)(nil).MCPAuditLog
+
+// emitMCPAuditDenied records an audit row for a request that
+// MCPBearerAuth resolved (so we know the user + token identity) but
+// then rejected — currently only the per-token rate-limit branch.
+//
+// Why a direct emit rather than letting the audit middleware catch
+// it: MCPAuditLog is mounted INSIDE MCPBearerAuth, so when bearer
+// auth denies before calling next.ServeHTTP, the audit middleware
+// never runs. Codex review on PR #389 round 1 caught the resulting
+// blind spot. Pre-auth rejections (missing / malformed / unknown
+// bearer) intentionally stay un-audited because there's no user to
+// attribute the row to and the audit_trail table covers those
+// auth-event signals already.
+//
+// errorKind is one of the static strings classifyMCPResult uses
+// (currently only "rate_limited" — extend if more denial paths
+// emit through here). Keeping the vocabulary aligned makes the
+// admin UI's status badges render consistently regardless of which
+// emitter wrote the row.
+//
+// latencyStart is the moment the request entered MCPBearerAuth so
+// the audit row carries real latency for denied requests too —
+// useful for spotting "the rate limiter is the slowest thing on the
+// hot path" patterns in the admin view.
+func (s *Server) emitMCPAuditDenied(r *http.Request, user *models.User, kind, ref, errorKind string, latencyStart time.Time) {
+	if s.mcpAudit == nil || user == nil || kind == "" || ref == "" {
+		return
+	}
+	reqID := chimiddleware.GetReqID(r.Context())
+	if reqID == "" {
+		reqID = strconv.FormatInt(latencyStart.UnixNano(), 36)
+	}
+	// Body sniff: same path as the middleware uses, capped at the
+	// same limit. We can't read r.Body destructively here because
+	// the rate-limit denial returns immediately afterwards and
+	// nothing else reads it — but we CAN tee out the first chunk
+	// for tool_name extraction. If it fails or the body's already
+	// been read by a prior middleware, parseMCPRequestBody returns
+	// "(unknown)" which is the expected sentinel.
+	var snifferBytes []byte
+	if r.Body != nil && r.Method != http.MethodGet {
+		limited := io.LimitReader(r.Body, mcpAuditBodyMaxBytes)
+		snifferBytes, _ = io.ReadAll(limited)
+	}
+	toolName, argsHash := parseMCPRequestBody(snifferBytes)
+
+	s.mcpAudit.enqueue(models.MCPAuditEntryInput{
+		Timestamp:    latencyStart,
+		UserID:       user.ID,
+		TokenKind:    models.TokenKind(kind),
+		TokenRef:     ref,
+		ToolName:     toolName,
+		ArgsHash:     argsHash,
+		ResultStatus: models.MCPAuditResultDenied,
+		ErrorKind:    errorKind,
+		LatencyMs:    int(time.Since(latencyStart) / time.Millisecond),
+		RequestID:    reqID,
+	})
+}

--- a/internal/server/middleware_mcp_audit_test.go
+++ b/internal/server/middleware_mcp_audit_test.go
@@ -1,0 +1,302 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// MCP audit middleware tests (PLAN-943 TASK-960).
+//
+// What's covered:
+//
+//   - A successful tool call writes one audit row with the right
+//     tool_name + args_hash + result_status.
+//   - A 401 from the MCP gate (no bearer) doesn't produce a row —
+//     audit only runs after MCPBearerAuth, and an unauth'd request
+//     never gets there.
+//   - A 200 with a `tools/list` JSON-RPC envelope records the
+//     method as the tool_name (no args_hash).
+//   - The buffer-full path increments the drop counter without
+//     blocking the request.
+//   - Args round-trip through canonical-JSON hashing — same payload
+//     in different field orders produces the same args_hash.
+//   - Async writes complete before Stop returns (clean drain).
+
+// auditedMCPServer builds an MCP-enabled server and returns it +
+// the user + a PAT bearer suitable for /mcp calls. The audit
+// writer is started by SetMCPTransport (the wiring lives there).
+func auditedMCPServer(t *testing.T) (srv *Server, user *models.User, bearer string) {
+	t.Helper()
+	srv = testServer(t)
+	srv.SetCloudMode("test-secret")
+	stub := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{}}`))
+	})
+	srv.SetMCPTransport(stub, "https://mcp.test.example", "https://app.test.example")
+
+	var err error
+	user, err = srv.store.CreateUser(models.UserCreate{
+		Email: "mcp-audit@example.com", Name: "Audit Tester", Password: "pw-test-12345",
+	})
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	ws, err := srv.store.CreateWorkspace(models.WorkspaceCreate{Name: "Audit WS"})
+	if err != nil {
+		t.Fatalf("CreateWorkspace: %v", err)
+	}
+	tok, err := srv.store.CreateAPIToken(user.ID, models.APITokenCreate{
+		Name:        "audit-test-pat",
+		WorkspaceID: ws.ID,
+	}, 30, 0)
+	if err != nil {
+		t.Fatalf("CreateAPIToken: %v", err)
+	}
+	return srv, user, tok.Token
+}
+
+// waitForAuditRows polls ListMCPAuditByUser until we see the
+// expected count or the deadline expires. The middleware writes
+// async via a buffered channel + worker goroutine, so the row
+// won't appear immediately; this avoids flakes without sleeping
+// for an arbitrary fixed duration.
+func waitForAuditRows(t *testing.T, srv *Server, userID string, want int) []models.MCPAuditEntry {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		rows, err := srv.store.ListMCPAuditByUser(userID, 100, 0)
+		if err != nil {
+			t.Fatalf("ListMCPAuditByUser: %v", err)
+		}
+		if len(rows) >= want {
+			return rows
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("audit rows = %d after 2s, want >= %d", len(rows), want)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+func TestMCPAudit_RecordsToolCallWithToolNameAndArgsHash(t *testing.T) {
+	srv, user, bearer := auditedMCPServer(t)
+
+	body := `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"pad_item","arguments":{"action":"list","collection":"tasks"}}}`
+	req := httptest.NewRequest("POST", "/mcp", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+bearer)
+	req.Header.Set("Content-Type", "application/json")
+	req.RemoteAddr = "192.0.2.1:1234"
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+
+	rows := waitForAuditRows(t, srv, user.ID, 1)
+	if len(rows) != 1 {
+		t.Fatalf("got %d rows, want 1", len(rows))
+	}
+	got := rows[0]
+	if got.ToolName != "pad_item" {
+		t.Errorf("ToolName = %q, want %q", got.ToolName, "pad_item")
+	}
+	if got.ArgsHash == "" {
+		t.Error("ArgsHash empty for a tools/call with arguments")
+	}
+	if got.TokenKind != models.TokenKindPAT {
+		t.Errorf("TokenKind = %q, want %q", got.TokenKind, models.TokenKindPAT)
+	}
+	if got.TokenRef == "" {
+		t.Error("TokenRef empty")
+	}
+	if got.ResultStatus != models.MCPAuditResultOK {
+		t.Errorf("ResultStatus = %q, want %q", got.ResultStatus, models.MCPAuditResultOK)
+	}
+	if got.LatencyMs < 0 {
+		t.Errorf("LatencyMs negative: %d", got.LatencyMs)
+	}
+}
+
+func TestMCPAudit_NoBearer_NoRow(t *testing.T) {
+	srv, user, _ := auditedMCPServer(t)
+	// Same body as the happy-path test, but no Authorization header —
+	// MCPBearerAuth 401s before the audit middleware runs, so no row.
+	req := httptest.NewRequest("POST", "/mcp", strings.NewReader(`{}`))
+	req.RemoteAddr = "192.0.2.1:1234"
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", rr.Code)
+	}
+	// Give the (nonexistent) async write a moment to land if it
+	// did anyway, then confirm no rows.
+	time.Sleep(100 * time.Millisecond)
+	rows, err := srv.store.ListMCPAuditByUser(user.ID, 100, 0)
+	if err != nil {
+		t.Fatalf("ListMCPAuditByUser: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Errorf("expected 0 audit rows for unauth'd request, got %d", len(rows))
+	}
+}
+
+func TestMCPAudit_NonToolsCallMethod_RecordsMethodAsToolName(t *testing.T) {
+	srv, user, bearer := auditedMCPServer(t)
+	body := `{"jsonrpc":"2.0","id":1,"method":"initialize"}`
+	req := httptest.NewRequest("POST", "/mcp", strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+bearer)
+	req.Header.Set("Content-Type", "application/json")
+	req.RemoteAddr = "192.0.2.1:1234"
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	rows := waitForAuditRows(t, srv, user.ID, 1)
+	if rows[0].ToolName != "initialize" {
+		t.Errorf("ToolName = %q, want %q", rows[0].ToolName, "initialize")
+	}
+	if rows[0].ArgsHash != "" {
+		t.Errorf("ArgsHash = %q, want empty for non-tools/call method", rows[0].ArgsHash)
+	}
+}
+
+func TestMCPAudit_HashCanonicalJSON_IsOrderIndependent(t *testing.T) {
+	// Same fields, different order → same hash. This is the
+	// "group similar calls together" property the spec wants.
+	a := hashCanonicalJSON([]byte(`{"action":"list","collection":"tasks"}`))
+	b := hashCanonicalJSON([]byte(`{"collection":"tasks","action":"list"}`))
+	if a == "" || b == "" {
+		t.Fatalf("got empty hash: a=%q b=%q", a, b)
+	}
+	if a != b {
+		t.Errorf("hashCanonicalJSON not order-independent: %q vs %q", a, b)
+	}
+
+	// Different content → different hash.
+	c := hashCanonicalJSON([]byte(`{"action":"create","collection":"tasks"}`))
+	if c == a {
+		t.Error("hashCanonicalJSON collided across different content")
+	}
+
+	// nil/null/empty → empty hash (audit reflects "no args").
+	if got := hashCanonicalJSON(nil); got != "" {
+		t.Errorf("nil hash = %q, want empty", got)
+	}
+	if got := hashCanonicalJSON([]byte("null")); got != "" {
+		t.Errorf("null hash = %q, want empty", got)
+	}
+}
+
+func TestMCPAudit_ParseRequestBody(t *testing.T) {
+	cases := []struct {
+		name        string
+		body        string
+		wantTool    string
+		wantHashSet bool
+	}{
+		{"tools/call with args", `{"method":"tools/call","params":{"name":"pad_item","arguments":{"a":1}}}`, "pad_item", true},
+		{"tools/list", `{"method":"tools/list"}`, "tools/list", false},
+		{"initialize", `{"method":"initialize"}`, "initialize", false},
+		{"empty body", ``, "(unknown)", false},
+		{"malformed", `not json`, "(unknown)", false},
+		{"tools/call missing name", `{"method":"tools/call","params":{}}`, "tools/call", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tool, hash := parseMCPRequestBody([]byte(tc.body))
+			if tool != tc.wantTool {
+				t.Errorf("tool = %q, want %q", tool, tc.wantTool)
+			}
+			if (hash != "") != tc.wantHashSet {
+				t.Errorf("hash empty=%v, want empty=%v (got %q)", hash == "", !tc.wantHashSet, hash)
+			}
+		})
+	}
+}
+
+func TestMCPAudit_BufferFull_DropsAndIncrementsCounter(t *testing.T) {
+	srv, user, _ := auditedMCPServer(t)
+	if srv.mcpAudit == nil {
+		t.Fatal("mcpAudit writer not started")
+	}
+
+	// Fill the queue to capacity by direct enqueue (bypassing the
+	// HTTP path, which is rate-limited by the worker draining).
+	// Stop the worker first so it doesn't drain while we're filling.
+	// Then enqueue one extra entry; that one must drop.
+	srv.mcpAudit.shutdown()
+	// Wait for the worker goroutine to finish so the queue is
+	// guaranteed not to be drained mid-test.
+	srv.bg.Wait()
+
+	// Drain to a clean state.
+	for {
+		select {
+		case <-srv.mcpAudit.queue:
+		default:
+			goto filled
+		}
+	}
+filled:
+	// Re-create the channel because shutdown closed `stop`, not
+	// `queue`. The queue is still usable.
+	for i := 0; i < mcpAuditBufferSize; i++ {
+		ok := srv.mcpAudit.enqueue(models.MCPAuditEntryInput{
+			UserID:       user.ID,
+			TokenKind:    models.TokenKindPAT,
+			TokenRef:     "ref",
+			ToolName:     "x",
+			ResultStatus: models.MCPAuditResultOK,
+			RequestID:    "r",
+		})
+		if !ok {
+			t.Fatalf("enqueue %d returned false; expected to fill to capacity first", i)
+		}
+	}
+	// One past capacity → drop.
+	if ok := srv.mcpAudit.enqueue(models.MCPAuditEntryInput{
+		UserID:       user.ID,
+		TokenKind:    models.TokenKindPAT,
+		TokenRef:     "ref",
+		ToolName:     "x",
+		ResultStatus: models.MCPAuditResultOK,
+		RequestID:    "r",
+	}); ok {
+		t.Fatal("expected drop on full queue, got accepted")
+	}
+	if got := srv.mcpAuditDroppedSnapshot(); got != 1 {
+		t.Errorf("dropped counter = %d, want 1", got)
+	}
+}
+
+func TestMCPAudit_ClassifyResult(t *testing.T) {
+	cases := []struct {
+		status int
+		want   models.MCPAuditResultStatus
+		kind   string
+	}{
+		{200, models.MCPAuditResultOK, ""},
+		{401, models.MCPAuditResultDenied, "unauthorized"},
+		{403, models.MCPAuditResultDenied, "forbidden"},
+		{429, models.MCPAuditResultDenied, "rate_limited"},
+		{500, models.MCPAuditResultError, "server_error_500"},
+		{502, models.MCPAuditResultError, "server_error_502"},
+		{400, models.MCPAuditResultError, "client_error_400"},
+		{404, models.MCPAuditResultError, "client_error_404"},
+		{0, models.MCPAuditResultOK, ""}, // ResponseWriter never wrote → treat as OK
+	}
+	for _, tc := range cases {
+		got, kind := classifyMCPResult(tc.status)
+		if got != tc.want || kind != tc.kind {
+			t.Errorf("classifyMCPResult(%d) = (%q, %q), want (%q, %q)",
+				tc.status, got, kind, tc.want, tc.kind)
+		}
+	}
+}

--- a/internal/server/middleware_mcp_audit_test.go
+++ b/internal/server/middleware_mcp_audit_test.go
@@ -276,6 +276,77 @@ filled:
 	}
 }
 
+// TestMCPAudit_RateLimited_RecordsDeniedRow pins the fix for Codex
+// review on PR #389 round 1: when MCPBearerAuth resolves the user
+// + token but then rate-limits the request, the wrapping
+// MCPAuditLog never sees the response (it's mounted INSIDE
+// MCPBearerAuth, which returns before next.ServeHTTP). The fix is
+// emitMCPAuditDenied called from the rate-limit deny branch — this
+// test asserts the audit row lands with result_status="denied" and
+// error_kind="rate_limited".
+func TestMCPAudit_RateLimited_RecordsDeniedRow(t *testing.T) {
+	srv := mcpEnabledTestServer(t)
+	pat := mustCreatePATForTest(t, srv, "audit-rate-limit")
+
+	// Find the user we just created so we can scope the audit query.
+	user, err := srv.store.GetUserByEmail("audit-rate-limit@example.com")
+	if err != nil || user == nil {
+		t.Fatalf("GetUserByEmail: %v", err)
+	}
+
+	// Hammer until we see a 429 — same pattern as the existing
+	// rate-limit tests.
+	got429 := false
+	for i := 0; i < 30; i++ {
+		req := httptest.NewRequest("POST", "/mcp",
+			strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"pad_item"}}`))
+		req.Header.Set("Authorization", "Bearer "+pat)
+		req.Header.Set("Content-Type", "application/json")
+		req.RemoteAddr = "192.0.2.1:1234"
+		rr := httptest.NewRecorder()
+		srv.ServeHTTP(rr, req)
+		if rr.Code == http.StatusTooManyRequests {
+			got429 = true
+			break
+		}
+	}
+	if !got429 {
+		t.Fatal("never hit 429 within 30 requests")
+	}
+
+	// Wait for the async audit writer to drain. Burst sent + 1 denied
+	// = burst+1 audit rows (every accepted call writes one too via
+	// the wrapping middleware; the 429 writes one via the direct
+	// emit). We just need at least one row with status=denied.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		rows, err := srv.store.ListMCPAuditByUser(user.ID, 100, 0)
+		if err != nil {
+			t.Fatalf("ListMCPAuditByUser: %v", err)
+		}
+		var sawDenied bool
+		for _, r := range rows {
+			if r.ResultStatus == models.MCPAuditResultDenied {
+				sawDenied = true
+				if r.ErrorKind == nil || *r.ErrorKind != "rate_limited" {
+					t.Errorf("denied row error_kind = %v, want rate_limited", r.ErrorKind)
+				}
+				if r.ToolName != "pad_item" {
+					t.Errorf("denied row tool_name = %q, want pad_item", r.ToolName)
+				}
+				break
+			}
+		}
+		if sawDenied {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("no denied row landed within 2s; rows=%+v", rows)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
 func TestMCPAudit_ClassifyResult(t *testing.T) {
 	cases := []struct {
 		status int

--- a/internal/server/middleware_mcp_auth.go
+++ b/internal/server/middleware_mcp_auth.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/ory/fosite"
 
@@ -74,6 +75,15 @@ import (
 // only, intentionally.
 func (s *Server) MCPBearerAuth(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Capture the entry timestamp so denied-but-resolved requests
+		// (e.g. valid bearer rate-limited at the per-token bucket) can
+		// still emit an audit row with real latency. The audit row
+		// emit path lives in middleware_mcp_audit.go's
+		// emitMCPAuditDenied — see that helper for the rationale on
+		// why we audit those branches directly here rather than from
+		// the wrapping middleware (Codex review on PR #389 round 1).
+		mcpAuthStart := time.Now().UTC()
+
 		token, ok := extractBearer(r.Header.Get("Authorization"))
 		if !ok {
 			s.writeMCPUnauthorized(w, r, "missing_token", "Bearer token required.")
@@ -84,7 +94,7 @@ func (s *Server) MCPBearerAuth(next http.Handler) http.Handler {
 		// secret). Cheap shape gate before the DB lookup. Anything
 		// else falls into the OAuth introspection branch.
 		if strings.HasPrefix(token, "pad_") && len(token) == 68 {
-			s.handleMCPPATAuth(w, r, token, next)
+			s.handleMCPPATAuth(w, r, token, next, mcpAuthStart)
 			return
 		}
 
@@ -97,7 +107,7 @@ func (s *Server) MCPBearerAuth(next http.Handler) http.Handler {
 			s.writeMCPUnauthorized(w, r, "invalid_token", "Token format not recognized.")
 			return
 		}
-		s.handleMCPOAuthAuth(w, r, token, next)
+		s.handleMCPOAuthAuth(w, r, token, next, mcpAuthStart)
 	})
 }
 
@@ -105,7 +115,7 @@ func (s *Server) MCPBearerAuth(next http.Handler) http.Handler {
 // Extracted from MCPBearerAuth so the OAuth branch reads cleanly
 // without a deeply-nested if/else; behaviour identical to the
 // pre-sub-PR-E single-path version.
-func (s *Server) handleMCPPATAuth(w http.ResponseWriter, r *http.Request, token string, next http.Handler) {
+func (s *Server) handleMCPPATAuth(w http.ResponseWriter, r *http.Request, token string, next http.Handler, mcpAuthStart time.Time) {
 	apiToken, err := s.store.ValidateToken(token)
 	if err != nil {
 		// A DB error during token validation is a server-side
@@ -155,6 +165,12 @@ func (s *Server) handleMCPPATAuth(w http.ResponseWriter, r *http.Request, token 
 	// and use). Symmetric to the OAuth path's positioning — both
 	// paths run the rate limit at the very end of their happy path.
 	if !s.checkMCPRateLimit(w, r, token) {
+		// Resolved user + token but rate-limited: emit an audit row
+		// directly. The wrapping MCPAuditLog never sees this branch
+		// because we return before next.ServeHTTP. Codex review on
+		// PR #389 round 1 — see emitMCPAuditDenied for the design
+		// rationale.
+		s.emitMCPAuditDenied(r, user, "pat", apiToken.ID, "rate_limited", mcpAuthStart)
 		return
 	}
 
@@ -205,7 +221,7 @@ func (s *Server) handleMCPPATAuth(w http.ResponseWriter, r *http.Request, token 
 // scope vocabulary (pad:read / pad:write / pad:admin) alongside
 // the legacy PAT vocabulary, so MCP tools see one uniform policy
 // regardless of which transport issued the bearer.
-func (s *Server) handleMCPOAuthAuth(w http.ResponseWriter, r *http.Request, token string, next http.Handler) {
+func (s *Server) handleMCPOAuthAuth(w http.ResponseWriter, r *http.Request, token string, next http.Handler, mcpAuthStart time.Time) {
 	ar, tokenUse, err := s.oauthServer.IntrospectToken(r.Context(), token)
 	if err != nil {
 		// fosite returns ErrInactiveToken / ErrNotFound for unknown
@@ -304,6 +320,11 @@ func (s *Server) handleMCPOAuthAuth(w http.ResponseWriter, r *http.Request, toke
 	// of the OAuth happy path ensures the limiter map only
 	// contains tokens that would otherwise reach next.ServeHTTP.
 	if !s.checkMCPRateLimit(w, r, token) {
+		// Resolved user + OAuth connection but rate-limited: emit
+		// an audit row directly. Wrapping MCPAuditLog never sees
+		// this branch because we return before next.ServeHTTP.
+		// Codex review on PR #389 round 1.
+		s.emitMCPAuditDenied(r, user, "oauth", ar.GetID(), "rate_limited", mcpAuthStart)
 		return
 	}
 

--- a/internal/server/middleware_mcp_auth.go
+++ b/internal/server/middleware_mcp_auth.go
@@ -171,6 +171,11 @@ func (s *Server) handleMCPPATAuth(w http.ResponseWriter, r *http.Request, token 
 	// TokenAuth's chain-level scopeAllows check. Codex review
 	// #369 round 1.
 	ctx = WithTokenScopes(ctx, apiToken.Scopes)
+	// Stash the token identity so the audit middleware (TASK-960)
+	// can record which PAT drove the call. Audit logging is
+	// independent of every other gate above and below — even calls
+	// that the inner handler later rejects produce a row.
+	ctx = WithMCPTokenIdentity(ctx, "pat", apiToken.ID)
 
 	// Surface near-expiry warning headers the same way TokenAuth
 	// does (middleware_auth.go:125). MCP clients can read them,
@@ -310,6 +315,12 @@ func (s *Server) handleMCPOAuthAuth(w http.ResponseWriter, r *http.Request, toke
 	// alongside the legacy PAT scopes, so the same per-method
 	// policy applies to OAuth-issued tokens.
 	ctx = WithTokenScopes(ctx, oauthScopesToJSON(ar.GetGrantedScopes()))
+	// Stash the OAuth connection identity (request_id chain) for
+	// the audit middleware (TASK-960). request_id is preserved
+	// across refresh-token rotations, so it's the stable identifier
+	// for a single user-authorized connection — exactly what the
+	// connected-apps page (TASK-954) keys revoke + last-used on.
+	ctx = WithMCPTokenIdentity(ctx, "oauth", ar.GetID())
 
 	// Stash the workspace allow-list set at consent time (TASK-952)
 	// so RequireWorkspaceAccess can gate workspace access per-token

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -91,6 +91,13 @@ type Server struct {
 	// mount on self-hosted deployments. See handlers_oauth.go.
 	oauthServer *oauth.Server
 
+	// MCP audit log async writer (PLAN-943 TASK-960). Spawned by
+	// startMCPAuditWriter at startup when MCP is wired; shut down
+	// from Server.Stop. nil-safe: every audit-emitting code path
+	// nil-checks so MCP-less builds + tests that don't start the
+	// writer still work. See middleware_mcp_audit.go.
+	mcpAudit *mcpAuditWriter
+
 	// storageInfoCache memoizes per-workspace storage usage summaries
 	// behind a short TTL (storageInfoTTL). Reduces DB load on the
 	// Settings → Storage page and quota-aware UI surfaces. Initialized
@@ -157,6 +164,11 @@ func (s *Server) Stop() {
 	// Each loop registers itself on s.bg, so the Wait() below blocks
 	// until they actually finish and any in-flight goroutines drain.
 	s.stopOrphanGC()
+	// MCP audit writer / sweeper run on s.bg too. Signal first so
+	// the workers see the close BEFORE Wait() blocks; without the
+	// signal Wait would hang forever on the writer's blocking
+	// queue receive.
+	s.stopMCPAuditWriter()
 	s.bg.Wait()
 	s.rateLimiters.Stop() // nil-safe via the RateLimiters receiver guard
 }
@@ -751,10 +763,26 @@ func (s *Server) setupRouter() {
 
 				// Platform stats
 				r.Get("/stats", s.handleAdminStats)
+
+				// MCP audit log — admin-only full-table view (TASK-960).
+				// Powers /console/admin/mcp-audit. Per-connection
+				// drilldown that users see for their own connections
+				// lives at /api/v1/connected-apps/{id}/audit (registered
+				// outside the admin group so non-admin users can read
+				// their own).
+				r.Get("/mcp-audit", s.handleAdminMCPAudit)
 			})
 
 			// Audit log (admin-only)
 			r.Get("/audit-log", s.handleAuditLog)
+
+			// MCP per-connection audit (TASK-960). Owner-only via the
+			// store query (user_id is one of the WHERE clauses);
+			// returns the requesting user's own MCP activity for one
+			// connection. The handler runs inside the standard
+			// /api/v1 auth-required group, so unauthenticated callers
+			// 401 here just like every other API endpoint.
+			r.Get("/connected-apps/{id}/audit", s.handleMCPConnectionAudit)
 
 			// Templates
 			r.Get("/templates", s.handleListTemplates)

--- a/internal/store/mcp_audit.go
+++ b/internal/store/mcp_audit.go
@@ -1,0 +1,327 @@
+package store
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// MCP audit log store (PLAN-943 TASK-960).
+//
+// Five public methods:
+//
+//   - InsertMCPAuditEntry — single-row insert, called from the audit
+//     middleware's async writer goroutine.
+//   - ListMCPAuditByUser — paginated per-user view used by both
+//     /api/v1/connected-apps/{id}/audit (filter by token_ref) and the
+//     admin surface (filter by user).
+//   - ListMCPAuditByConnection — paginated per-connection view used
+//     by the connected-apps detail drilldown.
+//   - MCPConnectionStats — bulk last-used + 30-day-count aggregator
+//     keyed by (token_kind, token_ref). One query per fetch instead
+//     of N.
+//   - SweepMCPAuditOlderThan — retention sweep, called from a
+//     periodic goroutine in Server.Start. 90-day default per
+//     TASK-960's spec.
+//
+// All methods are dialect-agnostic via s.q — same pattern as the
+// rest of internal/store. Timestamps go in/out as time.Time and are
+// serialized to RFC3339 in the DB to match every other timestamp
+// column in pad (see migrations/048_oauth.sql for the same shape).
+
+// ErrMCPAuditNotFound is returned by per-row lookups when no row
+// matches. Currently no callers — listing returns empty slices
+// rather than this error — but kept for symmetry with ErrOAuthNotFound
+// in case a future single-row accessor lands.
+var ErrMCPAuditNotFound = errors.New("mcp_audit: not found")
+
+// InsertMCPAuditEntry persists one audit row. Called from the audit
+// middleware's async writer; the caller owns the buffered channel
+// + the ordering, so this method is intentionally synchronous.
+//
+// Validation: UserID + TokenKind + TokenRef + ToolName + RequestID
+// are all required (the middleware fills them from the request
+// context). Empty fields fail loudly rather than silently writing
+// garbage rows that would later confuse forensics.
+//
+// WorkspaceID and ErrorKind map to NULL when empty so the column
+// reflects "not applicable" rather than "" — distinguishable on read
+// via *string.
+func (s *Store) InsertMCPAuditEntry(in models.MCPAuditEntryInput) error {
+	if in.UserID == "" {
+		return fmt.Errorf("mcp_audit: user_id required")
+	}
+	if in.TokenKind == "" {
+		return fmt.Errorf("mcp_audit: token_kind required")
+	}
+	if in.TokenRef == "" {
+		return fmt.Errorf("mcp_audit: token_ref required")
+	}
+	if in.ToolName == "" {
+		return fmt.Errorf("mcp_audit: tool_name required")
+	}
+	if in.RequestID == "" {
+		return fmt.Errorf("mcp_audit: request_id required")
+	}
+
+	ts := in.Timestamp
+	if ts.IsZero() {
+		ts = time.Now().UTC()
+	}
+
+	var workspaceID interface{}
+	if in.WorkspaceID != "" {
+		workspaceID = in.WorkspaceID
+	}
+	var errorKind interface{}
+	if in.ErrorKind != "" {
+		errorKind = in.ErrorKind
+	}
+
+	_, err := s.db.Exec(s.q(`
+		INSERT INTO mcp_audit_log (
+			id, timestamp, user_id, workspace_id,
+			token_kind, token_ref, tool_name, args_hash,
+			result_status, error_kind, latency_ms, request_id
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`), newID(), ts.UTC().Format(time.RFC3339), in.UserID, workspaceID,
+		string(in.TokenKind), in.TokenRef, in.ToolName, in.ArgsHash,
+		string(in.ResultStatus), errorKind, in.LatencyMs, in.RequestID)
+	if err != nil {
+		return fmt.Errorf("insert mcp audit: %w", err)
+	}
+	return nil
+}
+
+// ListMCPAuditByUser returns the user's most recent audit rows in
+// reverse-chronological order. limit caps the page; offset paginates.
+// Caller must enforce a sensible upper bound on limit (handlers cap
+// at 200 — large enough for an "explore the table" UX, small enough
+// to keep Postgres scans cheap).
+func (s *Store) ListMCPAuditByUser(userID string, limit, offset int) ([]models.MCPAuditEntry, error) {
+	if userID == "" {
+		return nil, fmt.Errorf("mcp_audit: user_id required")
+	}
+	if limit <= 0 {
+		limit = 50
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	rows, err := s.db.Query(s.q(`
+		SELECT id, timestamp, user_id, workspace_id,
+		       token_kind, token_ref, tool_name, args_hash,
+		       result_status, error_kind, latency_ms, request_id
+		FROM mcp_audit_log
+		WHERE user_id = ?
+		ORDER BY timestamp DESC
+		LIMIT ? OFFSET ?
+	`), userID, limit, offset)
+	if err != nil {
+		return nil, fmt.Errorf("query mcp audit by user: %w", err)
+	}
+	defer rows.Close()
+	return scanMCPAuditRows(rows)
+}
+
+// ListMCPAuditByConnection returns the audit rows for one OAuth
+// connection (or one PAT). Used by the per-connection drilldown the
+// connected-apps page exposes via GET /api/v1/connected-apps/{id}/audit.
+//
+// userID is REQUIRED in addition to the (token_kind, token_ref) pair
+// so a malicious caller can't read another user's audit by guessing
+// a request_id. The handler verifies ownership first; the store
+// enforces it as belt-and-suspenders.
+func (s *Store) ListMCPAuditByConnection(userID string, kind models.TokenKind, ref string, limit, offset int) ([]models.MCPAuditEntry, error) {
+	if userID == "" || kind == "" || ref == "" {
+		return nil, fmt.Errorf("mcp_audit: user_id, token_kind, token_ref required")
+	}
+	if limit <= 0 {
+		limit = 50
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	rows, err := s.db.Query(s.q(`
+		SELECT id, timestamp, user_id, workspace_id,
+		       token_kind, token_ref, tool_name, args_hash,
+		       result_status, error_kind, latency_ms, request_id
+		FROM mcp_audit_log
+		WHERE user_id = ? AND token_kind = ? AND token_ref = ?
+		ORDER BY timestamp DESC
+		LIMIT ? OFFSET ?
+	`), userID, string(kind), ref, limit, offset)
+	if err != nil {
+		return nil, fmt.Errorf("query mcp audit by connection: %w", err)
+	}
+	defer rows.Close()
+	return scanMCPAuditRows(rows)
+}
+
+// ListAllMCPAudit is the admin-only full-table view used by the
+// /console/admin/mcp-audit page. limit + offset paginate; caller
+// must restrict access at the route level (admin role).
+func (s *Store) ListAllMCPAudit(limit, offset int) ([]models.MCPAuditEntry, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	rows, err := s.db.Query(s.q(`
+		SELECT id, timestamp, user_id, workspace_id,
+		       token_kind, token_ref, tool_name, args_hash,
+		       result_status, error_kind, latency_ms, request_id
+		FROM mcp_audit_log
+		ORDER BY timestamp DESC
+		LIMIT ? OFFSET ?
+	`), limit, offset)
+	if err != nil {
+		return nil, fmt.Errorf("query mcp audit (all): %w", err)
+	}
+	defer rows.Close()
+	return scanMCPAuditRows(rows)
+}
+
+// MCPConnectionStatsForUser returns last-used + 30-day-count keyed
+// by (token_kind, token_ref) for every connection the user has any
+// audit-log activity for. The connected-apps page calls this once
+// per render and joins client-side onto its connection list.
+//
+// Why a single query rather than per-connection lookups: the page
+// renders N connection cards; with a per-connection query the page
+// load grows O(N) DB roundtrips. One aggregate query stays O(1)
+// regardless of how many connections the user has.
+//
+// Window: "30 days" is computed at call time as time.Now().Add(-30d)
+// — caller doesn't pass a since because the only consumer wants the
+// canonical 30-day window from the spec. If a future surface needs
+// a different window we'll add an MCPConnectionStatsForUserSince
+// variant rather than overloading.
+func (s *Store) MCPConnectionStatsForUser(userID string) (map[string]models.MCPConnectionStats, error) {
+	if userID == "" {
+		return nil, fmt.Errorf("mcp_audit: user_id required")
+	}
+	cutoff := time.Now().UTC().Add(-30 * 24 * time.Hour).Format(time.RFC3339)
+
+	// One query that simultaneously computes MAX(timestamp) (all-time
+	// last-used) and SUM(timestamp >= cutoff) (30-day call count).
+	// The cutoff comparison runs as TEXT lex compare — safe because
+	// every timestamp is RFC3339 with the same length + Z suffix.
+	rows, err := s.db.Query(s.q(`
+		SELECT token_kind, token_ref,
+		       MAX(timestamp) AS last_used,
+		       SUM(CASE WHEN timestamp >= ? THEN 1 ELSE 0 END) AS calls_30d
+		FROM mcp_audit_log
+		WHERE user_id = ?
+		GROUP BY token_kind, token_ref
+	`), cutoff, userID)
+	if err != nil {
+		return nil, fmt.Errorf("query mcp connection stats: %w", err)
+	}
+	defer rows.Close()
+
+	out := make(map[string]models.MCPConnectionStats)
+	for rows.Next() {
+		var (
+			kind, ref string
+			lastUsed  sql.NullString
+			calls30d  int64
+		)
+		if err := rows.Scan(&kind, &ref, &lastUsed, &calls30d); err != nil {
+			return nil, fmt.Errorf("scan mcp connection stats: %w", err)
+		}
+		stat := models.MCPConnectionStats{
+			TokenKind: models.TokenKind(kind),
+			TokenRef:  ref,
+			Calls30d:  int(calls30d),
+		}
+		if lastUsed.Valid && lastUsed.String != "" {
+			t := parseTime(lastUsed.String)
+			stat.LastUsedAt = &t
+		}
+		out[mcpConnectionStatsKey(models.TokenKind(kind), ref)] = stat
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate mcp connection stats: %w", err)
+	}
+	return out, nil
+}
+
+// mcpConnectionStatsKey is the canonical map key for the result of
+// MCPConnectionStatsForUser. Exposed via a helper so callers
+// constructing lookup keys don't accidentally drift from the
+// concatenation format and silently miss stats.
+func mcpConnectionStatsKey(kind models.TokenKind, ref string) string {
+	return string(kind) + ":" + ref
+}
+
+// MCPConnectionStatsKey is the exported wrapper for callers in
+// other packages (notably internal/server/handlers_connected_apps.go
+// in TASK-954) that need to look up stats by the same key shape.
+func MCPConnectionStatsKey(kind models.TokenKind, ref string) string {
+	return mcpConnectionStatsKey(kind, ref)
+}
+
+// SweepMCPAuditOlderThan deletes audit rows older than cutoff and
+// returns the number of rows removed. Called from a periodic
+// goroutine in Server.Start (24h tick); 90-day retention per
+// TASK-960's spec is enforced by the caller passing the right
+// cutoff.
+//
+// Safe to call concurrently with InsertMCPAuditEntry — SQLite
+// serializes writes globally; Postgres uses row-level locks. Either
+// way the DELETE doesn't block in-flight inserts because they target
+// disjoint rows (yesterday's writes vs. >90d-old reads).
+func (s *Store) SweepMCPAuditOlderThan(cutoff time.Time) (int64, error) {
+	res, err := s.db.Exec(s.q(`DELETE FROM mcp_audit_log WHERE timestamp < ?`),
+		cutoff.UTC().Format(time.RFC3339))
+	if err != nil {
+		return 0, fmt.Errorf("sweep mcp audit: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	return n, nil
+}
+
+// scanMCPAuditRows is the shared row-decoder for every list method.
+// Pulls out the nullable workspace_id + error_kind into *string,
+// parses the timestamp, and produces a slice of MCPAuditEntry.
+func scanMCPAuditRows(rows *sql.Rows) ([]models.MCPAuditEntry, error) {
+	var out []models.MCPAuditEntry
+	for rows.Next() {
+		var (
+			e            models.MCPAuditEntry
+			tsStr, kind  string
+			workspaceID  sql.NullString
+			errorKind    sql.NullString
+			resultStatus string
+			latencyMs    int
+		)
+		err := rows.Scan(&e.ID, &tsStr, &e.UserID, &workspaceID,
+			&kind, &e.TokenRef, &e.ToolName, &e.ArgsHash,
+			&resultStatus, &errorKind, &latencyMs, &e.RequestID)
+		if err != nil {
+			return nil, fmt.Errorf("scan mcp audit row: %w", err)
+		}
+		e.Timestamp = parseTime(tsStr)
+		e.TokenKind = models.TokenKind(kind)
+		e.ResultStatus = models.MCPAuditResultStatus(resultStatus)
+		e.LatencyMs = latencyMs
+		if workspaceID.Valid && workspaceID.String != "" {
+			ws := workspaceID.String
+			e.WorkspaceID = &ws
+		}
+		if errorKind.Valid && errorKind.String != "" {
+			ek := errorKind.String
+			e.ErrorKind = &ek
+		}
+		out = append(out, e)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate mcp audit rows: %w", err)
+	}
+	return out, nil
+}

--- a/internal/store/mcp_audit_test.go
+++ b/internal/store/mcp_audit_test.go
@@ -1,0 +1,394 @@
+package store
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// Store-layer tests for the MCP audit log (PLAN-943 TASK-960).
+//
+// What's covered:
+//
+//   - InsertMCPAuditEntry validates required fields and round-trips
+//     correctly via ListMCPAuditByUser.
+//   - WorkspaceID + ErrorKind round-trip cleanly through the
+//     nullable-pointer path.
+//   - MCPConnectionStatsForUser produces correct last-used + 30-day
+//     counts, grouped by (token_kind, token_ref).
+//   - SweepMCPAuditOlderThan deletes only rows older than the cutoff.
+//   - Per-user / per-connection ordering is reverse-chronological.
+//   - Pagination via limit + offset.
+
+func newAuditTestStore(t *testing.T) *Store {
+	t.Helper()
+	dir := t.TempDir()
+	s, err := New(filepath.Join(dir, "audit.db"))
+	if err != nil {
+		t.Fatalf("New store: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	return s
+}
+
+// auditUser creates a user that subsequent audit rows can FK-reference.
+// The schema requires user_id REFERENCES users(id), so we can't insert
+// audit rows for a phantom UUID.
+func auditUser(t *testing.T, s *Store, email string) string {
+	t.Helper()
+	u, err := s.CreateUser(models.UserCreate{
+		Email:    email,
+		Name:     "Audit Tester",
+		Password: "pw-audit-12345",
+	})
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	return u.ID
+}
+
+func TestInsertMCPAuditEntry_RequiredFields(t *testing.T) {
+	s := newAuditTestStore(t)
+	uid := auditUser(t, s, "req-fields@example.com")
+
+	cases := []struct {
+		name string
+		in   models.MCPAuditEntryInput
+		want string
+	}{
+		{"missing user_id", models.MCPAuditEntryInput{TokenKind: "oauth", TokenRef: "ref", ToolName: "x", RequestID: "r"}, "user_id"},
+		{"missing token_kind", models.MCPAuditEntryInput{UserID: uid, TokenRef: "ref", ToolName: "x", RequestID: "r"}, "token_kind"},
+		{"missing token_ref", models.MCPAuditEntryInput{UserID: uid, TokenKind: "oauth", ToolName: "x", RequestID: "r"}, "token_ref"},
+		{"missing tool_name", models.MCPAuditEntryInput{UserID: uid, TokenKind: "oauth", TokenRef: "ref", RequestID: "r"}, "tool_name"},
+		{"missing request_id", models.MCPAuditEntryInput{UserID: uid, TokenKind: "oauth", TokenRef: "ref", ToolName: "x"}, "request_id"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := s.InsertMCPAuditEntry(tc.in)
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.want)
+			}
+		})
+	}
+}
+
+func TestInsertMCPAuditEntry_RoundTrip(t *testing.T) {
+	s := newAuditTestStore(t)
+	uid := auditUser(t, s, "roundtrip@example.com")
+	wsID := "" // workspace nullable; leave empty so the column is NULL
+
+	now := time.Now().UTC().Truncate(time.Second)
+	in := models.MCPAuditEntryInput{
+		Timestamp:    now,
+		UserID:       uid,
+		WorkspaceID:  wsID,
+		TokenKind:    models.TokenKindOAuth,
+		TokenRef:     "req-id-abc",
+		ToolName:     "pad_item",
+		ArgsHash:     "deadbeef",
+		ResultStatus: models.MCPAuditResultOK,
+		LatencyMs:    42,
+		RequestID:    "req-x",
+	}
+	if err := s.InsertMCPAuditEntry(in); err != nil {
+		t.Fatalf("InsertMCPAuditEntry: %v", err)
+	}
+
+	rows, err := s.ListMCPAuditByUser(uid, 10, 0)
+	if err != nil {
+		t.Fatalf("ListMCPAuditByUser: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("len rows = %d, want 1", len(rows))
+	}
+	got := rows[0]
+	if got.UserID != uid || got.TokenKind != models.TokenKindOAuth ||
+		got.TokenRef != "req-id-abc" || got.ToolName != "pad_item" ||
+		got.ArgsHash != "deadbeef" || got.LatencyMs != 42 ||
+		got.RequestID != "req-x" {
+		t.Errorf("round-trip mismatch: %+v", got)
+	}
+	if got.WorkspaceID != nil {
+		t.Errorf("WorkspaceID = %v, want nil", *got.WorkspaceID)
+	}
+	if got.ErrorKind != nil {
+		t.Errorf("ErrorKind = %v, want nil", *got.ErrorKind)
+	}
+	if !got.Timestamp.Equal(now) {
+		// RFC3339 truncates to seconds; compare via .Equal which handles location.
+		t.Errorf("Timestamp = %v, want %v", got.Timestamp, now)
+	}
+}
+
+func TestInsertMCPAuditEntry_NullableFieldsPopulated(t *testing.T) {
+	s := newAuditTestStore(t)
+	uid := auditUser(t, s, "nullable@example.com")
+	// Need an actual workspace row for the FK on workspace_id
+	w, err := s.CreateWorkspace(models.WorkspaceCreate{Name: "WS-Audit", Slug: "ws-audit"})
+	if err != nil {
+		t.Fatalf("CreateWorkspace: %v", err)
+	}
+
+	in := models.MCPAuditEntryInput{
+		UserID:       uid,
+		WorkspaceID:  w.ID,
+		TokenKind:    models.TokenKindOAuth,
+		TokenRef:     "ref",
+		ToolName:     "tools/list",
+		ArgsHash:     "",
+		ResultStatus: models.MCPAuditResultError,
+		ErrorKind:    "client_error_400",
+		LatencyMs:    7,
+		RequestID:    "req-y",
+	}
+	if err := s.InsertMCPAuditEntry(in); err != nil {
+		t.Fatalf("InsertMCPAuditEntry: %v", err)
+	}
+	rows, err := s.ListMCPAuditByUser(uid, 10, 0)
+	if err != nil {
+		t.Fatalf("ListMCPAuditByUser: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("len rows = %d", len(rows))
+	}
+	if rows[0].WorkspaceID == nil || *rows[0].WorkspaceID != w.ID {
+		t.Errorf("WorkspaceID round-trip failed: %v", rows[0].WorkspaceID)
+	}
+	if rows[0].ErrorKind == nil || *rows[0].ErrorKind != "client_error_400" {
+		t.Errorf("ErrorKind round-trip failed: %v", rows[0].ErrorKind)
+	}
+}
+
+func TestListMCPAuditByUser_OrderingAndPagination(t *testing.T) {
+	s := newAuditTestStore(t)
+	uid := auditUser(t, s, "ordering@example.com")
+	base := time.Now().UTC().Truncate(time.Second)
+
+	// Insert 5 rows, each 1 second apart. ListMCPAuditByUser should
+	// return them in reverse-chronological order regardless of insert
+	// order. Insert in scrambled order to prove the sort.
+	for _, off := range []int{2, 4, 0, 1, 3} {
+		err := s.InsertMCPAuditEntry(models.MCPAuditEntryInput{
+			Timestamp:    base.Add(time.Duration(off) * time.Second),
+			UserID:       uid,
+			TokenKind:    models.TokenKindOAuth,
+			TokenRef:     "r",
+			ToolName:     "t",
+			ResultStatus: models.MCPAuditResultOK,
+			RequestID:    "rq",
+		})
+		if err != nil {
+			t.Fatalf("InsertMCPAuditEntry: %v", err)
+		}
+	}
+
+	rows, err := s.ListMCPAuditByUser(uid, 100, 0)
+	if err != nil {
+		t.Fatalf("ListMCPAuditByUser: %v", err)
+	}
+	if len(rows) != 5 {
+		t.Fatalf("len rows = %d, want 5", len(rows))
+	}
+	for i := 1; i < len(rows); i++ {
+		if rows[i-1].Timestamp.Before(rows[i].Timestamp) {
+			t.Errorf("rows out of order at %d: %v before %v", i, rows[i-1].Timestamp, rows[i].Timestamp)
+		}
+	}
+
+	// Pagination — limit=2, offset=2 should return rows[2:4] from the
+	// reverse-chronological list (= the 3rd and 4th newest).
+	page, err := s.ListMCPAuditByUser(uid, 2, 2)
+	if err != nil {
+		t.Fatalf("paged ListMCPAuditByUser: %v", err)
+	}
+	if len(page) != 2 {
+		t.Fatalf("paged len = %d, want 2", len(page))
+	}
+	if !page[0].Timestamp.Equal(rows[2].Timestamp) || !page[1].Timestamp.Equal(rows[3].Timestamp) {
+		t.Errorf("pagination drift: page[0]=%v rows[2]=%v page[1]=%v rows[3]=%v",
+			page[0].Timestamp, rows[2].Timestamp, page[1].Timestamp, rows[3].Timestamp)
+	}
+}
+
+func TestListMCPAuditByConnection_FiltersByOwner(t *testing.T) {
+	s := newAuditTestStore(t)
+	alice := auditUser(t, s, "alice@example.com")
+	bob := auditUser(t, s, "bob@example.com")
+
+	// Both users have an entry against the SAME (oauth, ref-shared)
+	// pair. The store query MUST filter on user_id to prevent Bob
+	// from reading Alice's row.
+	insert := func(uid string) {
+		err := s.InsertMCPAuditEntry(models.MCPAuditEntryInput{
+			UserID:       uid,
+			TokenKind:    models.TokenKindOAuth,
+			TokenRef:     "ref-shared",
+			ToolName:     "pad_item",
+			ResultStatus: models.MCPAuditResultOK,
+			RequestID:    "req",
+		})
+		if err != nil {
+			t.Fatalf("InsertMCPAuditEntry %s: %v", uid, err)
+		}
+	}
+	insert(alice)
+	insert(bob)
+
+	got, err := s.ListMCPAuditByConnection(alice, models.TokenKindOAuth, "ref-shared", 10, 0)
+	if err != nil {
+		t.Fatalf("ListMCPAuditByConnection: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want 1 (Alice's row only)", len(got))
+	}
+	if got[0].UserID != alice {
+		t.Errorf("returned wrong user's row: %s, want Alice (%s)", got[0].UserID, alice)
+	}
+}
+
+func TestMCPConnectionStatsForUser_LastUsedAndCalls30d(t *testing.T) {
+	s := newAuditTestStore(t)
+	uid := auditUser(t, s, "stats@example.com")
+
+	now := time.Now().UTC()
+
+	// Connection A: three recent calls (within 30d) + one old call (>30d ago).
+	// last_used should be the most recent recent call; calls_30d = 3.
+	connA := []time.Time{
+		now.Add(-1 * time.Hour),       // recent
+		now.Add(-2 * time.Hour),       // recent
+		now.Add(-72 * time.Hour),      // recent (3 days)
+		now.Add(-40 * 24 * time.Hour), // outside 30d
+	}
+	for _, ts := range connA {
+		err := s.InsertMCPAuditEntry(models.MCPAuditEntryInput{
+			Timestamp:    ts,
+			UserID:       uid,
+			TokenKind:    models.TokenKindOAuth,
+			TokenRef:     "conn-a",
+			ToolName:     "pad_item",
+			ResultStatus: models.MCPAuditResultOK,
+			RequestID:    "rq",
+		})
+		if err != nil {
+			t.Fatalf("InsertMCPAuditEntry: %v", err)
+		}
+	}
+
+	// Connection B: one recent call. Different (kind, ref) so it
+	// produces a separate group.
+	err := s.InsertMCPAuditEntry(models.MCPAuditEntryInput{
+		Timestamp:    now.Add(-30 * time.Minute),
+		UserID:       uid,
+		TokenKind:    models.TokenKindPAT,
+		TokenRef:     "conn-b",
+		ToolName:     "pad_item",
+		ResultStatus: models.MCPAuditResultOK,
+		RequestID:    "rq",
+	})
+	if err != nil {
+		t.Fatalf("InsertMCPAuditEntry: %v", err)
+	}
+
+	stats, err := s.MCPConnectionStatsForUser(uid)
+	if err != nil {
+		t.Fatalf("MCPConnectionStatsForUser: %v", err)
+	}
+	if len(stats) != 2 {
+		t.Fatalf("got %d connection groups, want 2", len(stats))
+	}
+
+	a, ok := stats[MCPConnectionStatsKey(models.TokenKindOAuth, "conn-a")]
+	if !ok {
+		t.Fatal("missing conn-a stats")
+	}
+	if a.Calls30d != 3 {
+		t.Errorf("conn-a Calls30d = %d, want 3", a.Calls30d)
+	}
+	if a.LastUsedAt == nil {
+		t.Fatal("conn-a LastUsedAt == nil")
+	}
+	// LastUsedAt should be the most recent insert (~1h ago), within
+	// 1 second of the source timestamp once round-tripped through
+	// RFC3339 + RFC3339 parse.
+	if got := a.LastUsedAt.UTC(); got.Before(connA[0].Add(-time.Second)) || got.After(connA[0].Add(time.Second)) {
+		t.Errorf("conn-a LastUsedAt = %v, want ~ %v", got, connA[0])
+	}
+
+	b, ok := stats[MCPConnectionStatsKey(models.TokenKindPAT, "conn-b")]
+	if !ok {
+		t.Fatal("missing conn-b stats")
+	}
+	if b.Calls30d != 1 {
+		t.Errorf("conn-b Calls30d = %d, want 1", b.Calls30d)
+	}
+}
+
+func TestSweepMCPAuditOlderThan_DeletesOldRowsOnly(t *testing.T) {
+	s := newAuditTestStore(t)
+	uid := auditUser(t, s, "sweep@example.com")
+	now := time.Now().UTC()
+
+	// 1 row inside retention, 1 row outside.
+	in := func(ts time.Time, ref string) {
+		err := s.InsertMCPAuditEntry(models.MCPAuditEntryInput{
+			Timestamp:    ts,
+			UserID:       uid,
+			TokenKind:    models.TokenKindOAuth,
+			TokenRef:     ref,
+			ToolName:     "t",
+			ResultStatus: models.MCPAuditResultOK,
+			RequestID:    "rq",
+		})
+		if err != nil {
+			t.Fatalf("InsertMCPAuditEntry: %v", err)
+		}
+	}
+	in(now.Add(-1*time.Hour), "fresh")
+	in(now.Add(-100*24*time.Hour), "stale")
+
+	cutoff := now.Add(-90 * 24 * time.Hour)
+	n, err := s.SweepMCPAuditOlderThan(cutoff)
+	if err != nil {
+		t.Fatalf("SweepMCPAuditOlderThan: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("swept rows = %d, want 1", n)
+	}
+
+	rows, err := s.ListMCPAuditByUser(uid, 100, 0)
+	if err != nil {
+		t.Fatalf("ListMCPAuditByUser: %v", err)
+	}
+	if len(rows) != 1 || rows[0].TokenRef != "fresh" {
+		t.Errorf("after sweep, got %d rows; want 1 ('fresh'). got=%+v", len(rows), rows)
+	}
+}
+
+func TestListAllMCPAudit_ReturnsAcrossUsers(t *testing.T) {
+	s := newAuditTestStore(t)
+	a := auditUser(t, s, "all-a@example.com")
+	b := auditUser(t, s, "all-b@example.com")
+	for _, uid := range []string{a, b} {
+		err := s.InsertMCPAuditEntry(models.MCPAuditEntryInput{
+			UserID:       uid,
+			TokenKind:    models.TokenKindOAuth,
+			TokenRef:     "r",
+			ToolName:     "t",
+			ResultStatus: models.MCPAuditResultOK,
+			RequestID:    "rq",
+		})
+		if err != nil {
+			t.Fatalf("InsertMCPAuditEntry %s: %v", uid, err)
+		}
+	}
+	rows, err := s.ListAllMCPAudit(100, 0)
+	if err != nil {
+		t.Fatalf("ListAllMCPAudit: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Errorf("len = %d, want 2 (across users)", len(rows))
+	}
+}

--- a/internal/store/migrations/049_mcp_audit.sql
+++ b/internal/store/migrations/049_mcp_audit.sql
@@ -1,0 +1,59 @@
+-- Migration 049: MCP audit log table (PLAN-943 TASK-960).
+--
+-- Persistent log of every MCP tool call. Drives the connected-apps
+-- "last used" + "30-day calls" columns (TASK-954), enables forensics,
+-- and gives users + admins visibility into what their agent has been
+-- doing. One row per request — both successful and rejected calls
+-- are recorded so a brute-force / abuse pattern is visible.
+--
+-- Spec deviation from the original task body: the spec called for
+-- `token_id UUID NOT NULL REFERENCES oauth_tokens(id)`, but pad's
+-- actual OAuth schema (migrations/048_oauth.sql) has no oauth_tokens
+-- table — instead there are oauth_access_tokens / oauth_refresh_tokens
+-- keyed by signature, sharing a request_id chain identifier preserved
+-- across rotations. The natural unit of "a connection" is therefore
+-- the request_id. Additionally MCP requests can authenticate via PAT
+-- (api_tokens.id) or OAuth (oauth_access_tokens.request_id), so a
+-- single FK can't model both. We use:
+--
+--   - token_kind TEXT NOT NULL — 'oauth' or 'pat'
+--   - token_ref  TEXT NOT NULL — the OAuth request_id, or the PAT id
+--
+-- No FK because the parent table varies. Both possible parents have
+-- their own indexes; cleanup of stranded audit rows is handled by the
+-- 90-day retention sweeper rather than by FK cascade.
+--
+-- Timestamps are TEXT (ISO8601 UTC) to match the cross-dialect
+-- contract used everywhere else in pad — see migrations/048_oauth.sql
+-- for the same pattern.
+
+CREATE TABLE IF NOT EXISTS mcp_audit_log (
+    id            TEXT PRIMARY KEY,                 -- UUID
+    timestamp     TEXT NOT NULL,                    -- ISO8601 UTC, when the request started
+    user_id       TEXT NOT NULL REFERENCES users(id),
+    workspace_id  TEXT REFERENCES workspaces(id),   -- NULL for tools that don't target a workspace (pad_meta etc.)
+    token_kind    TEXT NOT NULL,                    -- 'oauth' | 'pat'
+    token_ref     TEXT NOT NULL,                    -- oauth.request_id (chain) OR api_tokens.id
+    tool_name     TEXT NOT NULL,                    -- JSON-RPC method or tools/call params.name
+    args_hash     TEXT NOT NULL,                    -- SHA-256 of canonical-JSON args; "" when no args
+    result_status TEXT NOT NULL,                    -- 'ok' | 'error' | 'denied'
+    error_kind    TEXT,                             -- only when result_status != 'ok'
+    latency_ms    INTEGER NOT NULL,
+    request_id    TEXT NOT NULL                     -- correlates with server logs (X-Request-ID)
+);
+
+-- (user_id, timestamp DESC) — drives the per-user audit query and
+-- the "list my MCP activity" surface in connected-apps.
+CREATE INDEX IF NOT EXISTS mcp_audit_user_time_idx
+    ON mcp_audit_log(user_id, timestamp DESC);
+
+-- (token_kind, token_ref, timestamp DESC) — drives per-connection
+-- last-used + 30-day-count aggregates that TASK-954 reads to populate
+-- each row of the connected-apps page.
+CREATE INDEX IF NOT EXISTS mcp_audit_token_time_idx
+    ON mcp_audit_log(token_kind, token_ref, timestamp DESC);
+
+-- (timestamp) — drives the 90-day retention sweeper. Without this the
+-- DELETE WHERE timestamp < ? scan grows linearly with table size.
+CREATE INDEX IF NOT EXISTS mcp_audit_timestamp_idx
+    ON mcp_audit_log(timestamp);

--- a/internal/store/pgmigrations/028_mcp_audit.sql
+++ b/internal/store/pgmigrations/028_mcp_audit.sql
@@ -1,0 +1,31 @@
+-- Migration 028 (Postgres): MCP audit log table.
+--
+-- Postgres counterpart to migrations/049_mcp_audit.sql. Schema
+-- intentionally mirrors the SQLite version; the only dialect tweak is
+-- INTEGER → INT for latency_ms (Postgres preference, behaviour
+-- identical) and the inline FK syntax. See the SQLite file for the
+-- full design rationale + the spec-deviation explanation.
+
+CREATE TABLE IF NOT EXISTS mcp_audit_log (
+    id            TEXT PRIMARY KEY,
+    timestamp     TEXT NOT NULL,
+    user_id       TEXT NOT NULL REFERENCES users(id),
+    workspace_id  TEXT REFERENCES workspaces(id),
+    token_kind    TEXT NOT NULL,
+    token_ref     TEXT NOT NULL,
+    tool_name     TEXT NOT NULL,
+    args_hash     TEXT NOT NULL,
+    result_status TEXT NOT NULL,
+    error_kind    TEXT,
+    latency_ms    INT NOT NULL,
+    request_id    TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS mcp_audit_user_time_idx
+    ON mcp_audit_log(user_id, timestamp DESC);
+
+CREATE INDEX IF NOT EXISTS mcp_audit_token_time_idx
+    ON mcp_audit_log(token_kind, token_ref, timestamp DESC);
+
+CREATE INDEX IF NOT EXISTS mcp_audit_timestamp_idx
+    ON mcp_audit_log(timestamp);

--- a/web/src/routes/console/admin/+layout.svelte
+++ b/web/src/routes/console/admin/+layout.svelte
@@ -23,6 +23,11 @@
 		{ label: 'Users', href: '/console/admin' },
 		{ label: 'Invitations', href: '/console/admin/invitations' },
 		{ label: 'Audit Log', href: '/console/admin/audit-log' },
+		// MCP audit log (TASK-960) — full-table view of every MCP call.
+		// Cloud-only: the /api/v1/admin/mcp-audit endpoint backs the
+		// MCP transport, which only mounts in cloud mode. Hiding the
+		// tab in self-host avoids a "the page always errors" UX.
+		...(cloudMode ? [{ label: 'MCP Audit', href: '/console/admin/mcp-audit' }] : []),
 		...(cloudMode ? [{ label: 'Billing', href: '/console/admin/billing' }] : []),
 		{ label: 'Settings', href: '/console/admin/settings' }
 	]);

--- a/web/src/routes/console/admin/mcp-audit/+page.svelte
+++ b/web/src/routes/console/admin/mcp-audit/+page.svelte
@@ -1,0 +1,344 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { adminFetch } from '$lib/stores/admin.svelte';
+
+	// Admin MCP audit log page (PLAN-943 TASK-960).
+	//
+	// Full-table view of every request that hit /mcp. Per-user
+	// drilldown (the same data filtered to one connection) lives on
+	// the connected-apps page (TASK-954) — this page is the
+	// operations view for ops + on-call.
+	//
+	// No filtering UI in v1 beyond pagination — at <= 200 rows per
+	// page client-side find-as-you-type is enough; structured
+	// filters land if/when ops asks for them. The drop counter at
+	// the top tells operators when audit writes are being shed under
+	// backpressure (which would mean follow up on the writer
+	// goroutine / DB throughput).
+
+	interface MCPAuditEntry {
+		id: string;
+		timestamp: string;
+		user_id: string;
+		workspace_id?: string;
+		token_kind: 'oauth' | 'pat';
+		connection_id: string;
+		tool_name: string;
+		args_hash?: string;
+		result_status: 'ok' | 'error' | 'denied';
+		error_kind?: string;
+		latency_ms: number;
+		request_id: string;
+	}
+
+	const LIMIT = 100;
+
+	let entries = $state<MCPAuditEntry[]>([]);
+	let dropped = $state<number>(0);
+	let loading = $state(true);
+	let error = $state('');
+	let offset = $state(0);
+	let hasMore = $state(false);
+	let loadingMore = $state(false);
+
+	function relativeTime(dateStr: string): string {
+		const now = Date.now();
+		const then = new Date(dateStr).getTime();
+		const diffMs = now - then;
+		const diffSec = Math.floor(diffMs / 1000);
+		const diffMin = Math.floor(diffSec / 60);
+		const diffHr = Math.floor(diffMin / 60);
+		const diffDay = Math.floor(diffHr / 24);
+
+		if (diffSec < 60) return 'Just now';
+		if (diffMin < 60) return `${diffMin}m ago`;
+		if (diffHr < 24) return `${diffHr}h ago`;
+		if (diffDay < 30) return `${diffDay}d ago`;
+
+		return new Date(dateStr).toLocaleDateString('en-US', {
+			month: 'short',
+			day: 'numeric',
+			year: 'numeric'
+		});
+	}
+
+	function statusColor(status: string): string {
+		if (status === 'ok') return 'success';
+		if (status === 'denied') return 'warning';
+		if (status === 'error') return 'danger';
+		return '';
+	}
+
+	function shortRef(s: string): string {
+		if (!s) return '—';
+		return s.length > 12 ? s.slice(0, 12) + '…' : s;
+	}
+
+	async function loadEntries(append = false) {
+		if (append) {
+			loadingMore = true;
+		} else {
+			loading = true;
+			error = '';
+			offset = 0;
+		}
+
+		try {
+			const params = new URLSearchParams();
+			params.set('limit', String(LIMIT));
+			params.set('offset', String(append ? offset : 0));
+			const result = await adminFetch(`/admin/mcp-audit?${params}`);
+			const items: MCPAuditEntry[] = Array.isArray(result?.items) ? result.items : [];
+			dropped = typeof result?.dropped === 'number' ? result.dropped : 0;
+			if (append) {
+				entries = [...entries, ...items];
+			} else {
+				entries = items;
+			}
+			hasMore = items.length >= LIMIT;
+			if (append) {
+				offset += items.length;
+			} else {
+				offset = items.length;
+			}
+		} catch (e) {
+			if (!append) {
+				error = e instanceof Error ? e.message : 'Failed to load MCP audit log';
+			}
+		} finally {
+			loading = false;
+			loadingMore = false;
+		}
+	}
+
+	function loadMore() {
+		loadEntries(true);
+	}
+
+	onMount(() => {
+		loadEntries();
+	});
+</script>
+
+<svelte:head>
+	<title>MCP Audit Log - Pad Admin</title>
+</svelte:head>
+
+<div class="audit-page">
+	{#if dropped > 0}
+		<div class="drop-warning">
+			<strong>{dropped}</strong> audit
+			{dropped === 1 ? 'entry' : 'entries'} dropped due to writer backpressure since this server started.
+			Investigate the audit writer goroutine or database throughput if this counter keeps growing.
+		</div>
+	{/if}
+
+	{#if loading}
+		<div class="loading-msg">Loading MCP audit log&hellip;</div>
+	{:else if error}
+		<div class="error-msg">
+			<p>{error}</p>
+			<button class="btn" onclick={() => loadEntries()}>Retry</button>
+		</div>
+	{:else if entries.length === 0}
+		<div class="empty-state">
+			<p class="empty-title">No MCP audit entries</p>
+			<p class="empty-desc">Audit rows appear here as soon as the first /mcp request lands.</p>
+		</div>
+	{:else}
+		<div class="table-wrap">
+			<table class="table">
+				<thead>
+					<tr>
+						<th>Time</th>
+						<th>User</th>
+						<th>Connection</th>
+						<th>Kind</th>
+						<th>Tool</th>
+						<th>Status</th>
+						<th>Latency</th>
+					</tr>
+				</thead>
+				<tbody>
+					{#each entries as entry (entry.id)}
+						<tr>
+							<td class="time-cell" title={new Date(entry.timestamp).toISOString()}>
+								{relativeTime(entry.timestamp)}
+							</td>
+							<td title={entry.user_id}>{shortRef(entry.user_id)}</td>
+							<td title={entry.connection_id}>{shortRef(entry.connection_id)}</td>
+							<td>
+								<span class="badge {entry.token_kind === 'oauth' ? 'success' : ''}">
+									{entry.token_kind}
+								</span>
+							</td>
+							<td class="tool-cell">{entry.tool_name}</td>
+							<td>
+								<span class="badge {statusColor(entry.result_status)}">
+									{entry.result_status}
+								</span>
+								{#if entry.error_kind}
+									<span class="error-kind">{entry.error_kind}</span>
+								{/if}
+							</td>
+							<td class="latency-cell">{entry.latency_ms}ms</td>
+						</tr>
+					{/each}
+				</tbody>
+			</table>
+		</div>
+		{#if hasMore}
+			<div class="load-more-row">
+				<button class="btn" onclick={loadMore} disabled={loadingMore}>
+					{loadingMore ? 'Loading…' : 'Load more'}
+				</button>
+			</div>
+		{/if}
+	{/if}
+</div>
+
+<style>
+	.audit-page {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-4);
+	}
+
+	.drop-warning {
+		padding: var(--space-3) var(--space-4);
+		border-radius: var(--radius);
+		border: 1px solid var(--accent-orange, #d97706);
+		background: rgba(217, 119, 6, 0.08);
+		color: var(--text-primary);
+		font-size: 0.9rem;
+	}
+
+	.loading-msg,
+	.error-msg,
+	.empty-state {
+		padding: var(--space-6);
+		text-align: center;
+		color: var(--text-muted);
+	}
+
+	.empty-title {
+		font-size: 1rem;
+		font-weight: 600;
+		color: var(--text-primary);
+		margin-bottom: var(--space-1);
+	}
+
+	.empty-desc {
+		font-size: 0.9rem;
+	}
+
+	.table-wrap {
+		overflow-x: auto;
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+		background: var(--bg-secondary);
+	}
+
+	.table {
+		width: 100%;
+		border-collapse: collapse;
+		font-size: 0.85rem;
+	}
+
+	.table th,
+	.table td {
+		padding: var(--space-2) var(--space-3);
+		text-align: left;
+		border-bottom: 1px solid var(--border);
+	}
+
+	.table th {
+		font-weight: 600;
+		font-size: 0.78rem;
+		color: var(--text-muted);
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+		background: var(--bg-tertiary);
+	}
+
+	.table tbody tr:last-child td {
+		border-bottom: none;
+	}
+
+	.time-cell {
+		color: var(--text-secondary);
+		white-space: nowrap;
+	}
+
+	.tool-cell {
+		font-family: var(--font-mono, ui-monospace, SFMono-Regular, monospace);
+		font-size: 0.8rem;
+	}
+
+	.latency-cell {
+		font-variant-numeric: tabular-nums;
+		text-align: right;
+		color: var(--text-secondary);
+	}
+
+	.badge {
+		display: inline-block;
+		padding: 2px 8px;
+		border-radius: 999px;
+		background: var(--bg-tertiary);
+		color: var(--text-secondary);
+		font-size: 0.72rem;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+	}
+
+	.badge.success {
+		background: rgba(34, 197, 94, 0.15);
+		color: #16a34a;
+	}
+
+	.badge.warning {
+		background: rgba(217, 119, 6, 0.15);
+		color: #b45309;
+	}
+
+	.badge.danger {
+		background: rgba(239, 68, 68, 0.15);
+		color: #dc2626;
+	}
+
+	.error-kind {
+		display: inline-block;
+		margin-left: var(--space-2);
+		font-size: 0.75rem;
+		color: var(--text-muted);
+		font-family: var(--font-mono, ui-monospace, SFMono-Regular, monospace);
+	}
+
+	.load-more-row {
+		display: flex;
+		justify-content: center;
+		padding: var(--space-3);
+	}
+
+	.btn {
+		padding: var(--space-2) var(--space-4);
+		background: var(--bg-secondary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+		color: var(--text-primary);
+		font-size: 0.9rem;
+		cursor: pointer;
+		transition: background 0.15s;
+	}
+
+	.btn:hover:not(:disabled) {
+		background: var(--bg-tertiary);
+	}
+
+	.btn:disabled {
+		opacity: 0.5;
+		cursor: default;
+	}
+</style>


### PR DESCRIPTION
## Summary

Adds a 90-day-retention audit log of every MCP request hitting `/mcp`. Drives the "last used" + "30-day calls" columns the connected-apps page (TASK-954) will read, and gives ops + on-call a forensics surface via a new admin **MCP Audit** page at `/console/admin/mcp-audit`.

## Why

PLAN-943's connected-apps management page can't show real "last used" / call-count data without a place to record those calls. This task carves out that data plane (table + middleware + read endpoints + admin UI) so TASK-954 can join against it.

## Spec deviation (documented in migration 049)

The original spec called for `token_id REFERENCES oauth_tokens(id)`, but pad has no `oauth_tokens` table — the actual schema (migration 048) keys access/refresh tokens by `signature`, with a chain-stable `request_id`. PAT-authenticated MCP requests have no OAuth identity at all. The audit row therefore carries `(token_kind, token_ref)`:

- `token_kind = 'oauth'` → `token_ref` is the OAuth `request_id` (chain identifier preserved across rotations — exactly what TASK-954 will revoke by).
- `token_kind = 'pat'` → `token_ref` is `api_tokens.id`.

The connected-apps page in TASK-954 will filter on `token_kind='oauth'` to surface third-party MCP connections only.

## What's in the change

- **Schema:** `mcp_audit_log` (sqlite + postgres twins), with indexes on `(user_id, timestamp)`, `(token_kind, token_ref, timestamp)`, and `(timestamp)` for the retention sweep.
- **Async writer:** buffered channel + worker goroutine. Hot path is non-blocking enqueue with drop-on-overflow + atomic drop counter surfaced via the admin page.
- **Middleware:** wraps `/mcp` behind `MCPBearerAuth` so audit rows carry the resolved user + token identity. Body sniffer reads up to 64 KB to extract `tool_name` + canonical-JSON `args_hash` (order-independent), restoring the body intact for the inner handler. Authorization rejects (401/403/429) get logged with `result_status='denied'`.
- **Retention:** 24h ticker → `SweepMCPAuditOlderThan(now-90d)`. One sweep at startup so a long-stopped server catches up immediately.
- **Read endpoints:**
  - `GET /api/v1/connected-apps/{id}/audit` — owner-scoped per-connection (id = OAuth request_id). 401 on unauth.
  - `GET /api/v1/admin/mcp-audit` — admin-only full-table view, paginated (cap 200), reports the writer drop counter.
- **Admin UI:** `/console/admin/mcp-audit` with relative-time, status badges (ok/denied/error), latency column, drop-counter banner. Tab gated on cloud mode.

## Test plan

- [x] `golangci-lint run --timeout=5m ./...` — clean
- [x] `go test ./...` — all tests pass (full suite ~100s)
- [x] `cd web && npm run build` — clean
- [x] `cd web && npm run check` — 0 errors
- [x] `make install` — server restart verified
- [x] **Store tests:** required-field validation, RFC3339 round-trip, nullable `workspace_id`/`error_kind` round-trip, reverse-chronological ordering, pagination, owner-only filtering, last-used + 30-day grouping, retention sweep deletes only old rows, admin cross-user view.
- [x] **Middleware tests:** PAT-auth happy path records `tool_name=pad_item` + non-empty `args_hash`; unauth 401 produces no audit row; `initialize` / `tools/list` records the JSON-RPC method as `tool_name`; canonical-JSON hashing is order-independent; buffer-full path increments drop counter; HTTP-status → audit-result mapping for 200/401/403/429/4xx/5xx.
- [x] **Handler tests:** per-connection endpoint filters by `user_id` (Alice can't see Bob's row at the same `connection_id`); 401 unauth; admin gate rejects non-admin (403); admin sees rows across users; DTO surfaces `connection_id` (not internal `token_ref`); pagination caps at 200.

## Out of scope (per task body)

- Per-call body capture (`args_hash` only — content stays out of audit storage).
- SIEM webhook export — follow-up.
- Per-connection drilldown UI on the connected-apps page (lands with TASK-954; the endpoint is in this PR).

## Context

Implements TASK-960 under PLAN-943.
Unblocks TASK-954 (connected-apps page) — the next PR in this session will join against `MCPConnectionStatsForUser` for the "last used" + "30-day calls" columns.