### PR TITLE
feat(connected-apps): user-facing OAuth connection management page (TASK-954)

### DIFF
--- a/internal/models/connected_apps.go
+++ b/internal/models/connected_apps.go
@@ -1,0 +1,83 @@
+package models
+
+import "time"
+
+// Connected-apps models (PLAN-943 TASK-954).
+//
+// A "connected app" is one OAuth client (Claude Desktop, Cursor, …)
+// that the user has authorized to act on their behalf via the MCP
+// surface. Each user-authorized OAuth flow produces one connection,
+// identified by the OAuth grant chain's request_id (preserved across
+// refresh-token rotations — see internal/store/oauth.go for the
+// chain semantics). Revoking a connection invalidates every token in
+// that chain so the next /mcp call from that client gets 401.
+
+// CapabilityTier classifies the granted scopes into a coarse,
+// user-readable bucket. Used by the connected-apps page so users
+// don't have to read raw OAuth scope strings to understand what a
+// given client can do.
+type CapabilityTier string
+
+const (
+	CapabilityTierReadOnly   CapabilityTier = "read_only"
+	CapabilityTierReadWrite  CapabilityTier = "read_write"
+	CapabilityTierFullAccess CapabilityTier = "full_access" // includes pad:admin
+	CapabilityTierUnknown    CapabilityTier = "unknown"     // empty / unparseable scopes
+)
+
+// OAuthConnection is one row of the connected-apps page. Joins
+// oauth_access_tokens (the active grant) → oauth_clients (the DCR
+// metadata). The audit-log enrichments (LastUsedAt + Calls30d) come
+// from a separate aggregate query against mcp_audit_log so the page
+// loads in two queries instead of N+1.
+//
+// One value per OAuth grant chain — the connections list deduplicates
+// across refresh-token rotations because every chain member shares
+// the same RequestID.
+type OAuthConnection struct {
+	// RequestID is the OAuth grant chain identifier — preserved
+	// across refresh-token rotations and used as the public ID for
+	// revoke + audit drilldown ("connection_id" on the wire).
+	RequestID string
+
+	// ClientID / ClientName / LogoURL / RedirectURIs come from the
+	// DCR registration metadata (oauth_clients table). ClientName is
+	// what shows on the consent screen + connected-apps cards
+	// (e.g. "Claude Desktop").
+	ClientID     string
+	ClientName   string
+	LogoURL      string
+	RedirectURIs []string
+
+	// AllowedWorkspaces is the workspace allow-list set at consent
+	// time (TASK-952). Three shapes:
+	//   - nil — pre-TASK-952 token (no consent payload). Treated as
+	//     "any workspace the user belongs to."
+	//   - ["*"] — wildcard (user explicitly granted any).
+	//   - explicit slugs — the user's selection.
+	// The page renders chips per slug, or an "Any workspace" badge
+	// for nil / wildcard.
+	AllowedWorkspaces []string
+
+	// GrantedScopes is the raw space-separated scope string fosite
+	// recorded at grant time. Surfaced in the per-connection expand
+	// drilldown alongside CapabilityTier so power users can see the
+	// exact policy.
+	GrantedScopes string
+
+	// CapabilityTier is the human-readable bucket derived from
+	// GrantedScopes (read_only / read_write / full_access / unknown).
+	CapabilityTier CapabilityTier
+
+	// ConnectedAt is the earliest requested_at across the chain —
+	// when the user originally authorized this connection. Survives
+	// refresh-token rotation because every chain member shares the
+	// same request_id and the MIN over the chain stays anchored.
+	ConnectedAt time.Time
+
+	// LastUsedAt + Calls30d come from MCPConnectionStatsForUser
+	// (TASK-960's audit-log aggregate). Nil LastUsedAt means "no
+	// audit entries yet" — the page renders "—" instead of a date.
+	LastUsedAt *time.Time
+	Calls30d   int
+}

--- a/internal/server/handlers_connected_apps.go
+++ b/internal/server/handlers_connected_apps.go
@@ -1,0 +1,214 @@
+package server
+
+import (
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/store"
+)
+
+// Connected-apps endpoints (PLAN-943 TASK-954).
+//
+// Two endpoints:
+//
+//   - GET    /api/v1/connected-apps       — list active OAuth connections
+//                                            (one per grant chain) for
+//                                            the requesting user.
+//   - DELETE /api/v1/connected-apps/{id}  — revoke one connection.
+//                                            id is the OAuth request_id
+//                                            chain identifier.
+//
+// Auth: inherits the standard /api/v1 chain (TokenAuth + SessionAuth +
+// RequireAuth). Owner-scoped via the store: every method takes user.ID
+// so a malicious caller can't see / revoke another user's connections.
+//
+// Cloud-mode-gated at the route level: self-hosted deployments don't
+// run the OAuth surface, so these endpoints would return empty lists
+// + ErrConnectionNotFound 404s. Mounting outside cloud mode would be
+// confusing — the routes are mounted under requireCloudMode at the
+// registration site (server.go).
+
+// connectedAppDTO is the wire-form for one connection. Distinct from
+// models.OAuthConnection so the API contract stays decoupled from
+// internal field names.
+//
+// Field rationale:
+//   - id = OAuth request_id chain identifier. Public face of the
+//     connection — used as the URL path param for revoke + audit
+//     drilldown.
+//   - allowed_workspaces is sent verbatim — nil + ["*"] both mean
+//     "any workspace"; the UI handles the rendering. Sending the
+//     raw shape lets the page show the actual chip list when an
+//     explicit subset was granted.
+//   - scope_string is the raw fosite-style scope string (e.g.
+//     "pad:read pad:write"). Surfaced in the per-connection expand
+//     drilldown so power users can see the exact policy.
+//   - capability_tier is the coarse-bucketed tier the page renders
+//     as a badge. Mapping documented in store.classifyCapabilityTier.
+type connectedAppDTO struct {
+	ID                string   `json:"id"`
+	ClientID          string   `json:"client_id"`
+	ClientName        string   `json:"client_name"`
+	LogoURI           string   `json:"logo_uri,omitempty"`
+	RedirectURIs      []string `json:"redirect_uris,omitempty"`
+	AllowedWorkspaces []string `json:"allowed_workspaces"`
+	ScopeString       string   `json:"scope_string"`
+	CapabilityTier    string   `json:"capability_tier"`
+	ConnectedAt       string   `json:"connected_at"`
+	LastUsedAt        string   `json:"last_used_at,omitempty"`
+	Calls30d          int      `json:"calls_30d"`
+}
+
+func connectionToDTO(c models.OAuthConnection, stats *models.MCPConnectionStats) connectedAppDTO {
+	dto := connectedAppDTO{
+		ID:                c.RequestID,
+		ClientID:          c.ClientID,
+		ClientName:        c.ClientName,
+		LogoURI:           c.LogoURL,
+		RedirectURIs:      c.RedirectURIs,
+		AllowedWorkspaces: c.AllowedWorkspaces,
+		ScopeString:       c.GrantedScopes,
+		CapabilityTier:    string(c.CapabilityTier),
+		ConnectedAt:       c.ConnectedAt.UTC().Format(time.RFC3339),
+		Calls30d:          0,
+	}
+	if stats != nil {
+		dto.Calls30d = stats.Calls30d
+		if stats.LastUsedAt != nil {
+			dto.LastUsedAt = stats.LastUsedAt.UTC().Format(time.RFC3339)
+		}
+	}
+	return dto
+}
+
+// handleListConnectedApps returns every active OAuth connection the
+// requesting user has authorized, enriched with last-used + 30-day
+// call counts from the MCP audit log (TASK-960).
+//
+// Single response shape; no pagination. A user's connection count
+// is bounded by the small number of MCP clients they've authorized
+// (Claude Desktop, Cursor, occasional one-offs) — paging would add
+// noise without solving any real load problem.
+func (s *Server) handleListConnectedApps(w http.ResponseWriter, r *http.Request) {
+	user := currentUser(r)
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, "unauthorized", "Authentication required.")
+		return
+	}
+
+	conns, err := s.store.ListUserOAuthConnections(user.ID)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+
+	// Enrich with audit-log aggregates. One bulk query — see
+	// MCPConnectionStatsForUser's doc comment for the rationale.
+	stats, err := s.store.MCPConnectionStatsForUser(user.ID)
+	if err != nil {
+		// Soft-fail on the audit lookup: the page is more useful
+		// with empty last-used columns than not at all. Log so ops
+		// notice if the audit table is broken, but proceed.
+		slog.Warn("connected-apps: audit stats lookup failed", "error", err, "user_id", user.ID)
+		stats = nil
+	}
+
+	out := make([]connectedAppDTO, 0, len(conns))
+	for _, c := range conns {
+		var statPtr *models.MCPConnectionStats
+		if stats != nil {
+			if v, ok := stats[store.MCPConnectionStatsKey(models.TokenKindOAuth, c.RequestID)]; ok {
+				statPtr = &v
+			}
+		}
+		out = append(out, connectionToDTO(c, statPtr))
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"items": out,
+	})
+}
+
+// handleRevokeConnectedApp invalidates every token in the OAuth
+// grant chain identified by the URL id parameter, after verifying
+// ownership.
+//
+// 404 vs 403:
+//   - Unknown chain → 404 ("not_found").
+//   - Chain belongs to a DIFFERENT user → also 404 — distinct from
+//     403 to prevent enumeration ("can I tell from the response
+//     code that THIS request_id exists, just not for me?"). The
+//     store returns ErrConnectionNotFound for both cases for the
+//     same reason.
+//
+// Idempotent: the store's Revoke* methods don't error on already-
+// revoked chains, so a double-click on the Revoke button just
+// returns a clean 204 the second time.
+//
+// Records an audit_trail entry via CreateActivity so the existing
+// /api/v1/audit-log page picks up the revoke. action="oauth_connection_revoked",
+// actor="user", metadata carries the client_id for forensics.
+func (s *Server) handleRevokeConnectedApp(w http.ResponseWriter, r *http.Request) {
+	user := currentUser(r)
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, "unauthorized", "Authentication required.")
+		return
+	}
+
+	id := strings.TrimSpace(chi.URLParam(r, "id"))
+	if id == "" {
+		writeError(w, http.StatusBadRequest, "invalid_request", "connection id required")
+		return
+	}
+
+	// Pre-revoke lookup so the audit trail can carry the client_id.
+	// Cheap (we'd need to hit the table anyway via Revoke). Failure
+	// here doesn't block the revoke — we'll just record an audit row
+	// without the client metadata.
+	var clientID string
+	if conns, err := s.store.ListUserOAuthConnections(user.ID); err == nil {
+		for _, c := range conns {
+			if c.RequestID == id {
+				clientID = c.ClientID
+				break
+			}
+		}
+	}
+
+	if err := s.store.RevokeUserOAuthConnection(user.ID, id); err != nil {
+		if errors.Is(err, store.ErrConnectionNotFound) {
+			writeError(w, http.StatusNotFound, "not_found", "Connection not found.")
+			return
+		}
+		writeInternalError(w, err)
+		return
+	}
+
+	// Best-effort audit-trail entry. Failure here doesn't undo the
+	// revoke — the OAuth token chain is already inactive.
+	meta := map[string]string{"connection_id": id}
+	if clientID != "" {
+		meta["client_id"] = clientID
+	}
+	metaJSON, _ := json.Marshal(meta)
+	if _, err := s.store.CreateActivity(models.Activity{
+		Action:    "oauth_connection_revoked",
+		Actor:     "user",
+		Source:    "web",
+		UserID:    user.ID,
+		Metadata:  string(metaJSON),
+		IPAddress: clientIP(r),
+		UserAgent: r.UserAgent(),
+	}); err != nil {
+		slog.Warn("connected-apps: audit log write failed", "error", err, "user_id", user.ID, "connection_id", id)
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/internal/server/handlers_connected_apps_test.go
+++ b/internal/server/handlers_connected_apps_test.go
@@ -1,0 +1,295 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// doAuthedDeleteWithCSRF issues a DELETE with both the session
+// cookie + the CSRF double-submit pair. The session-cookie code path
+// requires CSRF on every state-changing method; tests that bypass
+// the API token route through SessionAuth need to attach both
+// halves of the double-submit pair to clear CSRFProtect.
+//
+// The CSRF token must match in cookie + header (CSRFProtect's
+// double-submit check) and be 64 hex chars (TASK-659 length gate).
+func doAuthedDeleteWithCSRF(srv *Server, path string, sessionToken string) *httptest.ResponseRecorder {
+	const testCSRF = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	req := httptest.NewRequest("DELETE", path, nil)
+	req.Header.Set("User-Agent", testSessionUA)
+	req.AddCookie(&http.Cookie{Name: sessionCookieName(srv.secureCookies), Value: sessionToken})
+	req.AddCookie(&http.Cookie{Name: csrfCookieName(srv.secureCookies), Value: testCSRF})
+	req.Header.Set("X-CSRF-Token", testCSRF)
+	req.RemoteAddr = "192.0.2.1:1234"
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	return rr
+}
+
+// Connected-apps handler tests (PLAN-943 TASK-954).
+//
+// What's covered:
+//
+//   - GET /api/v1/connected-apps requires cloud mode (404 outside).
+//   - List returns only the requesting user's connections.
+//   - DTO surfaces the right field names + populates last_used /
+//     calls_30d from the audit-log enrichment.
+//   - DELETE 404s when the chain belongs to another user (no 403
+//     enumeration leak).
+//   - DELETE 204s on success and on a second idempotent call.
+//   - DELETE writes an audit_trail entry (action="oauth_connection_revoked").
+
+// connectedAppsTestServer builds a cloud-mode server with one OAuth
+// client + helpers to seed grant chains. Returns the server + the
+// client_id so tests can pass it to seedAccessChain.
+func connectedAppsTestServer(t *testing.T) (*Server, string) {
+	t.Helper()
+	srv := testServer(t)
+	srv.SetCloudMode("test-secret")
+	c, err := srv.store.CreateOAuthClient(models.OAuthClientCreate{
+		Name:                    "Claude Desktop",
+		RedirectURIs:            []string{"https://example.test/cb"},
+		GrantTypes:              []string{"authorization_code", "refresh_token"},
+		ResponseTypes:           []string{"code"},
+		TokenEndpointAuthMethod: "none",
+		Scopes:                  []string{"pad:read", "pad:write"},
+		Public:                  true,
+	})
+	if err != nil {
+		t.Fatalf("CreateOAuthClient: %v", err)
+	}
+	return srv, c.ID
+}
+
+// seedGrantChain inserts one access-token row in a chain. Returns
+// the request_id so tests can revoke / list / audit by it.
+func seedGrantChain(t *testing.T, srv *Server, clientID, userID, requestID, sessionData, scopes string) {
+	t.Helper()
+	if err := srv.store.CreateAccessToken(models.OAuthRequest{
+		Signature:     newSignatureForTest(),
+		RequestID:     requestID,
+		RequestedAt:   time.Now().UTC(),
+		ClientID:      clientID,
+		GrantedScopes: scopes,
+		SessionData:   sessionData,
+		Subject:       userID,
+	}); err != nil {
+		t.Fatalf("CreateAccessToken: %v", err)
+	}
+}
+
+func newSignatureForTest() string {
+	// Same shape as fosite would mint — just unique within the test
+	// (the store treats it as opaque text).
+	return "sig-" + time.Now().Format("150405.000000000")
+}
+
+func TestHandleListConnectedApps_RequiresCloudMode(t *testing.T) {
+	srv := testServer(t) // no SetCloudMode
+	_, tok := loginTestUser(t, srv)
+	rr := doAuthedRequest(srv, "GET", "/api/v1/connected-apps", nil, tok)
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404 (no cloud mode)", rr.Code)
+	}
+}
+
+func TestHandleListConnectedApps_ReturnsOnlyOwnConnections(t *testing.T) {
+	srv, clientID := connectedAppsTestServer(t)
+	alice, aliceTok := loginTestUser(t, srv)
+	bob, err := srv.store.CreateUser(models.UserCreate{
+		Email: "bob-conn-handler@example.com", Name: "Bob", Password: "pw-test-12345",
+	})
+	if err != nil {
+		t.Fatalf("CreateUser bob: %v", err)
+	}
+
+	seedGrantChain(t, srv, clientID, alice.ID, "alice-chain",
+		`{"extra":{"allowed_workspaces":["docapp"]}}`, "pad:read pad:write")
+	seedGrantChain(t, srv, clientID, bob.ID, "bob-chain", "", "pad:read")
+
+	rr := doAuthedRequest(srv, "GET", "/api/v1/connected-apps", nil, aliceTok)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body=%s)", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		Items []map[string]any `json:"items"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Items) != 1 {
+		t.Fatalf("len items = %d, want 1 (Alice's only)", len(resp.Items))
+	}
+	if got, _ := resp.Items[0]["id"].(string); got != "alice-chain" {
+		t.Errorf("id = %v, want alice-chain", resp.Items[0]["id"])
+	}
+}
+
+func TestHandleListConnectedApps_DTOShapeAndAuditEnrichment(t *testing.T) {
+	srv, clientID := connectedAppsTestServer(t)
+	user, tok := loginTestUser(t, srv)
+
+	seedGrantChain(t, srv, clientID, user.ID, "shape-chain",
+		`{"extra":{"allowed_workspaces":["alpha","beta"]}}`, "pad:read pad:write")
+
+	// Seed a couple of audit rows so calls_30d > 0 + last_used populates.
+	insertAudit := func(ts time.Time) {
+		err := srv.store.InsertMCPAuditEntry(models.MCPAuditEntryInput{
+			Timestamp:    ts,
+			UserID:       user.ID,
+			TokenKind:    models.TokenKindOAuth,
+			TokenRef:     "shape-chain",
+			ToolName:     "pad_item",
+			ResultStatus: models.MCPAuditResultOK,
+			RequestID:    "req",
+		})
+		if err != nil {
+			t.Fatalf("InsertMCPAuditEntry: %v", err)
+		}
+	}
+	now := time.Now().UTC()
+	insertAudit(now.Add(-1 * time.Hour))
+	insertAudit(now.Add(-30 * time.Minute))
+
+	rr := doAuthedRequest(srv, "GET", "/api/v1/connected-apps", nil, tok)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	var resp struct {
+		Items []map[string]any `json:"items"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Items) != 1 {
+		t.Fatalf("len items = %d, want 1", len(resp.Items))
+	}
+	row := resp.Items[0]
+
+	wantKeys := []string{"id", "client_id", "client_name", "allowed_workspaces",
+		"scope_string", "capability_tier", "connected_at", "calls_30d"}
+	for _, k := range wantKeys {
+		if _, ok := row[k]; !ok {
+			t.Errorf("missing field %q; got %+v", k, row)
+		}
+	}
+	if got, _ := row["client_name"].(string); got != "Claude Desktop" {
+		t.Errorf("client_name = %v, want Claude Desktop", row["client_name"])
+	}
+	if got, _ := row["capability_tier"].(string); got != "read_write" {
+		t.Errorf("capability_tier = %v, want read_write", row["capability_tier"])
+	}
+	if got, _ := row["calls_30d"].(float64); got != 2 {
+		t.Errorf("calls_30d = %v, want 2", row["calls_30d"])
+	}
+	if got, _ := row["last_used_at"].(string); got == "" {
+		t.Errorf("last_used_at is empty; want a timestamp")
+	}
+	allowed, _ := row["allowed_workspaces"].([]any)
+	if len(allowed) != 2 {
+		t.Errorf("allowed_workspaces len = %d, want 2", len(allowed))
+	}
+}
+
+func TestHandleRevokeConnectedApp_OwnerOnly(t *testing.T) {
+	srv, clientID := connectedAppsTestServer(t)
+	alice, aliceTok := loginTestUser(t, srv)
+	bob, err := srv.store.CreateUser(models.UserCreate{
+		Email: "bob-revoke@example.com", Name: "Bob", Password: "pw-test-12345",
+	})
+	if err != nil {
+		t.Fatalf("CreateUser bob: %v", err)
+	}
+	seedGrantChain(t, srv, clientID, bob.ID, "bobs-chain", "", "pad:read")
+
+	// Alice tries to revoke Bob's chain → 404 (not 403 — anti-enumeration).
+	rr := doAuthedDeleteWithCSRF(srv, "/api/v1/connected-apps/bobs-chain", aliceTok)
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("Alice revoking Bob's chain: status = %d, want 404", rr.Code)
+	}
+
+	// Bob's chain is still active.
+	conns, err := srv.store.ListUserOAuthConnections(bob.ID)
+	if err != nil {
+		t.Fatalf("ListUserOAuthConnections bob: %v", err)
+	}
+	if len(conns) != 1 {
+		t.Errorf("after Alice's failed revoke, Bob's chains = %d, want 1", len(conns))
+	}
+	_ = alice
+}
+
+func TestHandleRevokeConnectedApp_HappyPathAndIdempotent(t *testing.T) {
+	srv, clientID := connectedAppsTestServer(t)
+	user, tok := loginTestUser(t, srv)
+	seedGrantChain(t, srv, clientID, user.ID, "revoke-me", "", "pad:read")
+
+	// First revoke → 204.
+	rr := doAuthedDeleteWithCSRF(srv, "/api/v1/connected-apps/revoke-me", tok)
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("first revoke status = %d, want 204 (body=%s)", rr.Code, rr.Body.String())
+	}
+
+	// Confirm gone from list.
+	rr2 := doAuthedRequest(srv, "GET", "/api/v1/connected-apps", nil, tok)
+	if rr2.Code != http.StatusOK {
+		t.Fatalf("list after revoke: status = %d, want 200", rr2.Code)
+	}
+	var resp struct {
+		Items []any `json:"items"`
+	}
+	if err := json.Unmarshal(rr2.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Items) != 0 {
+		t.Errorf("after revoke, list len = %d, want 0", len(resp.Items))
+	}
+
+	// Second revoke → still 204 (idempotent).
+	rr3 := doAuthedDeleteWithCSRF(srv, "/api/v1/connected-apps/revoke-me", tok)
+	if rr3.Code != http.StatusNoContent {
+		t.Errorf("idempotent second revoke status = %d, want 204", rr3.Code)
+	}
+}
+
+func TestHandleRevokeConnectedApp_UnknownChain(t *testing.T) {
+	srv, _ := connectedAppsTestServer(t)
+	_, tok := loginTestUser(t, srv)
+	rr := doAuthedDeleteWithCSRF(srv, "/api/v1/connected-apps/no-such-chain", tok)
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", rr.Code)
+	}
+}
+
+func TestHandleRevokeConnectedApp_WritesAuditTrail(t *testing.T) {
+	srv, clientID := connectedAppsTestServer(t)
+	user, tok := loginTestUser(t, srv)
+	seedGrantChain(t, srv, clientID, user.ID, "audit-trail-chain", "", "pad:read")
+
+	rr := doAuthedDeleteWithCSRF(srv, "/api/v1/connected-apps/audit-trail-chain", tok)
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("revoke status = %d, want 204", rr.Code)
+	}
+
+	// Verify the audit_trail entry landed via the existing ListAuditLog
+	// store method. action = oauth_connection_revoked.
+	entries, err := srv.store.ListAuditLog(models.AuditLogParams{
+		Action: "oauth_connection_revoked",
+		Days:   1,
+		Limit:  10,
+	})
+	if err != nil {
+		t.Fatalf("ListAuditLog: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("audit entries = %d, want 1", len(entries))
+	}
+	if entries[0].UserID != user.ID {
+		t.Errorf("audit user_id = %q, want %q", entries[0].UserID, user.ID)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -784,6 +784,18 @@ func (s *Server) setupRouter() {
 			// 401 here just like every other API endpoint.
 			r.Get("/connected-apps/{id}/audit", s.handleMCPConnectionAudit)
 
+			// Connected-apps management (TASK-954). Lists every
+			// active OAuth grant chain the user has authorized
+			// (Claude Desktop, Cursor, …) and lets them revoke one.
+			// Cloud-mode-gated because OAuth is a cloud-only
+			// surface — self-hosted deployments would always see
+			// an empty list.
+			r.Group(func(r chi.Router) {
+				r.Use(s.requireCloudMode)
+				r.Get("/connected-apps", s.handleListConnectedApps)
+				r.Delete("/connected-apps/{id}", s.handleRevokeConnectedApp)
+			})
+
 			// Templates
 			r.Get("/templates", s.handleListTemplates)
 

--- a/internal/store/connected_apps.go
+++ b/internal/store/connected_apps.go
@@ -1,0 +1,379 @@
+package store
+
+import (
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// Connected-apps store layer (PLAN-943 TASK-954).
+//
+// Two operations the connected-apps page needs:
+//
+//   - ListUserOAuthConnections — every active OAuth grant chain the
+//     user authorized, deduplicated by request_id, joined to the
+//     DCR client metadata, enriched from the MCP audit log with
+//     last-used + 30-day-count.
+//   - RevokeUserOAuthConnection — verify the chain belongs to the
+//     user, then call RevokeRefreshTokenFamily + RevokeAccessTokenFamily
+//     so the next /mcp call from that client gets 401.
+//
+// Both methods read from the existing oauth_* tables (migration 048)
+// and the mcp_audit_log table (migration 049 from TASK-960). No new
+// schema lands here.
+
+// ErrConnectionNotFound is returned by RevokeUserOAuthConnection when
+// no active grant chain matches (userID, requestID). Either the
+// requestID is wrong / fabricated, or it belongs to a different user.
+// Handlers map to 404 — explicit owner-scoped 404 prevents a malicious
+// caller from enumerating chain identifiers via 403-vs-404 distinction.
+var ErrConnectionNotFound = errors.New("connected_apps: connection not found")
+
+// ListUserOAuthConnections returns every OAuth connection the user
+// has active. "Active" means at least one access OR refresh token
+// in the chain still has active=TRUE — revoked chains drop off the
+// list immediately rather than lingering.
+//
+// Implementation walks oauth_access_tokens grouped by request_id,
+// taking MIN(requested_at) as ConnectedAt + the most recent row's
+// session_data + granted_scopes (which carry the consent allow-list
+// and scope policy). Joins to oauth_clients for the DCR metadata.
+//
+// The audit-log enrichments (LastUsedAt + Calls30d) come from the
+// caller — we return MCPConnectionStatsForUser separately so the
+// caller can call both methods in parallel if they want, and so the
+// store layer doesn't require the audit table to be present (this
+// method works on a fresh install with no audit rows yet).
+//
+// Sort: ConnectedAt DESC so newest authorizations land at the top of
+// the page, which matches every other "list of things I've added"
+// surface in pad.
+func (s *Store) ListUserOAuthConnections(userID string) ([]models.OAuthConnection, error) {
+	if userID == "" {
+		return nil, fmt.Errorf("connected_apps: user_id required")
+	}
+
+	// Pull every active access token row for the user. We GROUP later
+	// in Go because SQLite doesn't support DISTINCT ON and the
+	// GROUP BY semantics for picking-the-newest-row-per-group differ
+	// across SQLite + Postgres in ways that aren't worth abstracting.
+	// The user's connection count is bounded (each user authorizes
+	// a handful of clients, not thousands), so the in-memory dedup
+	// is cheap.
+	rows, err := s.db.Query(s.q(`
+		SELECT request_id, client_id, requested_at, session_data, granted_scopes
+		FROM oauth_access_tokens
+		WHERE subject = ? AND active = ?
+		ORDER BY request_id, requested_at DESC
+	`), userID, true)
+	if err != nil {
+		return nil, fmt.Errorf("query user connections (access): %w", err)
+	}
+	defer rows.Close()
+
+	type chainAgg struct {
+		clientID      string
+		earliest      time.Time
+		newest        time.Time
+		newestSession string
+		newestScopes  string
+	}
+	chains := make(map[string]*chainAgg)
+	for rows.Next() {
+		var (
+			reqID, clientID, sessionData, scopes string
+			requestedAt                          string
+		)
+		if err := rows.Scan(&reqID, &clientID, &requestedAt, &sessionData, &scopes); err != nil {
+			return nil, fmt.Errorf("scan user connection (access): %w", err)
+		}
+		ts := parseTime(requestedAt)
+		c, ok := chains[reqID]
+		if !ok {
+			c = &chainAgg{
+				clientID:      clientID,
+				earliest:      ts,
+				newest:        ts,
+				newestSession: sessionData,
+				newestScopes:  scopes,
+			}
+			chains[reqID] = c
+			continue
+		}
+		if ts.Before(c.earliest) {
+			c.earliest = ts
+		}
+		if ts.After(c.newest) {
+			c.newest = ts
+			c.newestSession = sessionData
+			c.newestScopes = scopes
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate user connections (access): %w", err)
+	}
+
+	// A grant chain may exist in oauth_refresh_tokens with no
+	// surviving access row (e.g. the access token expired but the
+	// refresh hasn't been used yet). Walk refresh too so the page
+	// shows those connections — otherwise a user who hasn't made a
+	// call in a while would see an empty list right after a token
+	// expiry.
+	rrows, err := s.db.Query(s.q(`
+		SELECT request_id, client_id, requested_at, session_data, granted_scopes
+		FROM oauth_refresh_tokens
+		WHERE subject = ? AND active = ?
+		ORDER BY request_id, requested_at DESC
+	`), userID, true)
+	if err != nil {
+		return nil, fmt.Errorf("query user connections (refresh): %w", err)
+	}
+	defer rrows.Close()
+	for rrows.Next() {
+		var (
+			reqID, clientID, sessionData, scopes string
+			requestedAt                          string
+		)
+		if err := rrows.Scan(&reqID, &clientID, &requestedAt, &sessionData, &scopes); err != nil {
+			return nil, fmt.Errorf("scan user connection (refresh): %w", err)
+		}
+		ts := parseTime(requestedAt)
+		c, ok := chains[reqID]
+		if !ok {
+			c = &chainAgg{
+				clientID:      clientID,
+				earliest:      ts,
+				newest:        ts,
+				newestSession: sessionData,
+				newestScopes:  scopes,
+			}
+			chains[reqID] = c
+			continue
+		}
+		if ts.Before(c.earliest) {
+			c.earliest = ts
+		}
+		if ts.After(c.newest) {
+			c.newest = ts
+			c.newestSession = sessionData
+			c.newestScopes = scopes
+		}
+	}
+	if err := rrows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate user connections (refresh): %w", err)
+	}
+
+	if len(chains) == 0 {
+		return []models.OAuthConnection{}, nil
+	}
+
+	// Hydrate the client metadata in one batch per unique client_id.
+	// Most users have <10 distinct clients so the per-row roundtrip
+	// is fine; if it ever isn't we can switch to an IN clause.
+	clientCache := make(map[string]*models.OAuthClient)
+	for _, c := range chains {
+		if _, hit := clientCache[c.clientID]; hit {
+			continue
+		}
+		client, err := s.GetOAuthClient(c.clientID)
+		if err != nil {
+			if errors.Is(err, ErrOAuthNotFound) {
+				clientCache[c.clientID] = nil // sentinel: client deleted
+				continue
+			}
+			return nil, fmt.Errorf("hydrate client %q: %w", c.clientID, err)
+		}
+		clientCache[c.clientID] = client
+	}
+
+	out := make([]models.OAuthConnection, 0, len(chains))
+	for reqID, c := range chains {
+		client := clientCache[c.clientID]
+		conn := models.OAuthConnection{
+			RequestID:         reqID,
+			ClientID:          c.clientID,
+			ConnectedAt:       c.earliest,
+			GrantedScopes:     c.newestScopes,
+			CapabilityTier:    classifyCapabilityTier(c.newestScopes),
+			AllowedWorkspaces: parseAllowedWorkspacesFromSession(c.newestSession),
+		}
+		if client != nil {
+			conn.ClientName = client.Name
+			conn.LogoURL = client.LogoURL
+			conn.RedirectURIs = append([]string(nil), client.RedirectURIs...)
+		} else {
+			// Client row was deleted but the grant chain survived
+			// (DeleteOAuthClient cascades, so this is rare). Surface
+			// a placeholder name so the row is still revokable from
+			// the UI rather than invisible.
+			conn.ClientName = "(deleted client)"
+		}
+		out = append(out, conn)
+	}
+
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].ConnectedAt.After(out[j].ConnectedAt)
+	})
+	return out, nil
+}
+
+// RevokeUserOAuthConnection invalidates every token in the OAuth
+// grant chain identified by requestID, after verifying the chain
+// belongs to userID.
+//
+// Implementation:
+//  1. Look up any access OR refresh row in the chain whose subject
+//     matches userID. If none, return ErrConnectionNotFound — either
+//     the requestID is bogus or it's not theirs to revoke.
+//  2. Call RevokeRefreshTokenFamily + RevokeAccessTokenFamily —
+//     both walk the request_id index and flip every chain row
+//     inactive. Handlers wrapping this call write an audit_trail
+//     row recording who revoked what.
+//
+// Idempotent: revoking an already-revoked chain returns nil (the
+// ownership check matches the inactive rows too because we don't
+// filter on active=TRUE there). That's the right shape for a
+// destructive UX — a user double-clicking "Revoke" shouldn't see
+// "already revoked" errors.
+//
+// Side effect note: the chain rows stay in the DB with active=FALSE
+// after this call. They're not deleted because audit / introspection
+// surfaces still want to see "this token existed and was revoked at
+// time X." Cleanup of long-revoked rows is a separate concern.
+func (s *Store) RevokeUserOAuthConnection(userID, requestID string) error {
+	if userID == "" || requestID == "" {
+		return fmt.Errorf("connected_apps: user_id and request_id required")
+	}
+
+	// Belt-and-suspenders ownership check across BOTH token tables.
+	// We don't use ListUserOAuthConnections because that filters to
+	// active=TRUE — we want to allow re-revoking an already-revoked
+	// chain idempotently.
+	var subject string
+	err := s.db.QueryRow(s.q(`
+		SELECT subject FROM oauth_access_tokens
+		WHERE request_id = ?
+		LIMIT 1
+	`), requestID).Scan(&subject)
+	if err == sql.ErrNoRows {
+		// Try refresh tokens — chain might exist there only.
+		err = s.db.QueryRow(s.q(`
+			SELECT subject FROM oauth_refresh_tokens
+			WHERE request_id = ?
+			LIMIT 1
+		`), requestID).Scan(&subject)
+	}
+	if err == sql.ErrNoRows {
+		return ErrConnectionNotFound
+	}
+	if err != nil {
+		return fmt.Errorf("verify connection ownership: %w", err)
+	}
+	if subject != userID {
+		// Don't leak "this exists but isn't yours" — return the same
+		// not-found error so a malicious caller probing requestIDs
+		// can't enumerate chains by 403-vs-404 distinction.
+		return ErrConnectionNotFound
+	}
+
+	if err := s.RevokeRefreshTokenFamily(requestID); err != nil {
+		return fmt.Errorf("revoke refresh family: %w", err)
+	}
+	if err := s.RevokeAccessTokenFamily(requestID); err != nil {
+		return fmt.Errorf("revoke access family: %w", err)
+	}
+	return nil
+}
+
+// classifyCapabilityTier maps a fosite-style space-separated scope
+// string into a coarse user-readable bucket. Currently three tiers:
+//
+//   - read_only:    only `pad:read` (or no write/admin scopes).
+//   - read_write:   `pad:write` granted (regardless of read).
+//   - full_access:  `pad:admin` granted.
+//   - unknown:      empty / no recognized pad: scopes.
+//
+// Any future scope vocabulary additions land here.
+func classifyCapabilityTier(scopes string) models.CapabilityTier {
+	if scopes == "" {
+		return models.CapabilityTierUnknown
+	}
+	parts := strings.Fields(scopes)
+	var hasRead, hasWrite, hasAdmin bool
+	for _, p := range parts {
+		switch p {
+		case "pad:read":
+			hasRead = true
+		case "pad:write":
+			hasWrite = true
+		case "pad:admin":
+			hasAdmin = true
+		}
+	}
+	switch {
+	case hasAdmin:
+		return models.CapabilityTierFullAccess
+	case hasWrite:
+		return models.CapabilityTierReadWrite
+	case hasRead:
+		return models.CapabilityTierReadOnly
+	}
+	return models.CapabilityTierUnknown
+}
+
+// parseAllowedWorkspacesFromSession extracts the workspace allow-list
+// from a serialized fosite session. The producer side
+// (oauth.Session.SetAllowedWorkspaces in /authorize/decide) stashes
+// the list under the "allowed_workspaces" key in DefaultSession.Extra.
+// JSON round-trip mangles []string into []interface{}, so we accept
+// both shapes here — same as oauth.Session.AllowedWorkspaces.
+//
+// Returns nil for missing key (pre-TASK-952 token); empty []string
+// for an explicit empty list (would be unusual but distinguishable
+// from "unset"); the slug list otherwise. The handler surfaces
+// nil + ["*"] as "Any workspace"; anything else as chips.
+//
+// Defensive: any parse failure returns nil rather than propagating
+// — a malformed session payload shouldn't 500 the connected-apps
+// page. Worst case the user sees "Any workspace" instead of the
+// actual chip list, which is a less-bad failure mode than a broken
+// page.
+func parseAllowedWorkspacesFromSession(sessionData string) []string {
+	if sessionData == "" {
+		return nil
+	}
+	// fosite serializes the session as JSON. We only care about
+	// session.Extra.allowed_workspaces — peek into that path
+	// without depending on the fosite types.
+	var outer struct {
+		Extra map[string]interface{} `json:"extra"`
+	}
+	if err := json.Unmarshal([]byte(sessionData), &outer); err != nil || outer.Extra == nil {
+		return nil
+	}
+	raw, ok := outer.Extra["allowed_workspaces"]
+	if !ok {
+		return nil
+	}
+	switch v := raw.(type) {
+	case []string:
+		out := make([]string, len(v))
+		copy(out, v)
+		return out
+	case []interface{}:
+		out := make([]string, 0, len(v))
+		for _, e := range v {
+			if s, ok := e.(string); ok && s != "" {
+				out = append(out, s)
+			}
+		}
+		return out
+	}
+	return nil
+}

--- a/internal/store/connected_apps_test.go
+++ b/internal/store/connected_apps_test.go
@@ -1,0 +1,291 @@
+package store
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// Connected-apps store tests (PLAN-943 TASK-954).
+//
+// What's covered:
+//
+//   - ListUserOAuthConnections deduplicates a chain across multiple
+//     access-token rows (refresh-token rotation produces siblings).
+//   - The list filters on subject — Bob can't see Alice's connections.
+//   - Active=FALSE chains drop off the list immediately.
+//   - Connected_at is the earliest timestamp in the chain.
+//   - GrantedScopes + AllowedWorkspaces hydrate from the newest row's
+//     session_data + granted_scopes (revoked rows ignored on read).
+//   - classifyCapabilityTier maps scope vocabulary to read_only /
+//     read_write / full_access / unknown.
+//   - parseAllowedWorkspacesFromSession round-trips both []string
+//     and []interface{} (post-JSON) shapes.
+//   - RevokeUserOAuthConnection: ownership check returns NotFound
+//     for stranger's chains; idempotent for already-revoked.
+
+func newConnectedTestStore(t *testing.T) *Store {
+	t.Helper()
+	dir := t.TempDir()
+	s, err := New(filepath.Join(dir, "conn.db"))
+	if err != nil {
+		t.Fatalf("New store: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	return s
+}
+
+// seedClient creates an oauth_clients row so chains have something
+// to FK against. Returns the client ID.
+func seedClient(t *testing.T, s *Store, name string) string {
+	t.Helper()
+	c, err := s.CreateOAuthClient(models.OAuthClientCreate{
+		Name:                    name,
+		RedirectURIs:            []string{"https://example.test/cb"},
+		GrantTypes:              []string{"authorization_code", "refresh_token"},
+		ResponseTypes:           []string{"code"},
+		TokenEndpointAuthMethod: "none",
+		Scopes:                  []string{"pad:read", "pad:write"},
+		Public:                  true,
+	})
+	if err != nil {
+		t.Fatalf("CreateOAuthClient: %v", err)
+	}
+	return c.ID
+}
+
+// seedUser creates a user that subsequent oauth tokens can use as
+// their `subject`.
+func seedUser(t *testing.T, s *Store, email string) string {
+	t.Helper()
+	u, err := s.CreateUser(models.UserCreate{
+		Email:    email,
+		Name:     "Conn Tester",
+		Password: "pw-conn-12345",
+	})
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	return u.ID
+}
+
+// seedAccess inserts an access-token row in the chain identified by
+// requestID. ts is the requested_at timestamp; sessionData + scopes
+// land on the row. Returns the signature it minted.
+func seedAccess(t *testing.T, s *Store, requestID, clientID, subject string, ts time.Time, sessionData, scopes string, active bool) string {
+	t.Helper()
+	sig := newID()
+	err := s.CreateAccessToken(models.OAuthRequest{
+		Signature:     sig,
+		RequestID:     requestID,
+		RequestedAt:   ts,
+		ClientID:      clientID,
+		GrantedScopes: scopes,
+		SessionData:   sessionData,
+		Subject:       subject,
+	})
+	if err != nil {
+		t.Fatalf("CreateAccessToken: %v", err)
+	}
+	if !active {
+		// CreateAccessToken always inserts active=TRUE; flip if needed.
+		if err := s.RevokeAccessTokenFamily(requestID); err != nil {
+			t.Fatalf("RevokeAccessTokenFamily: %v", err)
+		}
+	}
+	return sig
+}
+
+func TestListUserOAuthConnections_DeduplicatesChain(t *testing.T) {
+	s := newConnectedTestStore(t)
+	uid := seedUser(t, s, "list-dedup@example.com")
+	clientID := seedClient(t, s, "Claude Desktop")
+
+	now := time.Now().UTC().Truncate(time.Second)
+	// Three access rows in the SAME chain (refresh-token rotation
+	// scenario). Different requested_at; same request_id.
+	sessionData := `{"extra":{"allowed_workspaces":["docapp"]}}`
+	seedAccess(t, s, "chain-1", clientID, uid, now.Add(-3*time.Hour), sessionData, "pad:read pad:write", true)
+	seedAccess(t, s, "chain-1", clientID, uid, now.Add(-2*time.Hour), sessionData, "pad:read pad:write", true)
+	seedAccess(t, s, "chain-1", clientID, uid, now.Add(-1*time.Hour), sessionData, "pad:read pad:write", true)
+
+	conns, err := s.ListUserOAuthConnections(uid)
+	if err != nil {
+		t.Fatalf("ListUserOAuthConnections: %v", err)
+	}
+	if len(conns) != 1 {
+		t.Fatalf("got %d connections, want 1 (deduplicated chain)", len(conns))
+	}
+	c := conns[0]
+	if c.RequestID != "chain-1" {
+		t.Errorf("RequestID = %q, want chain-1", c.RequestID)
+	}
+	if c.ClientName != "Claude Desktop" {
+		t.Errorf("ClientName = %q, want Claude Desktop", c.ClientName)
+	}
+	if c.CapabilityTier != models.CapabilityTierReadWrite {
+		t.Errorf("CapabilityTier = %q, want read_write", c.CapabilityTier)
+	}
+	if !c.ConnectedAt.Equal(now.Add(-3 * time.Hour)) {
+		t.Errorf("ConnectedAt = %v, want earliest chain timestamp %v", c.ConnectedAt, now.Add(-3*time.Hour))
+	}
+	if len(c.AllowedWorkspaces) != 1 || c.AllowedWorkspaces[0] != "docapp" {
+		t.Errorf("AllowedWorkspaces = %v, want [docapp]", c.AllowedWorkspaces)
+	}
+}
+
+func TestListUserOAuthConnections_FiltersBySubject(t *testing.T) {
+	s := newConnectedTestStore(t)
+	alice := seedUser(t, s, "alice-conn@example.com")
+	bob := seedUser(t, s, "bob-conn@example.com")
+	clientID := seedClient(t, s, "Cursor")
+
+	now := time.Now().UTC()
+	seedAccess(t, s, "alice-chain", clientID, alice, now, "", "pad:read", true)
+	seedAccess(t, s, "bob-chain", clientID, bob, now, "", "pad:read", true)
+
+	aliceConns, err := s.ListUserOAuthConnections(alice)
+	if err != nil {
+		t.Fatalf("ListUserOAuthConnections(alice): %v", err)
+	}
+	if len(aliceConns) != 1 || aliceConns[0].RequestID != "alice-chain" {
+		t.Errorf("Alice should see only alice-chain, got %+v", aliceConns)
+	}
+
+	bobConns, err := s.ListUserOAuthConnections(bob)
+	if err != nil {
+		t.Fatalf("ListUserOAuthConnections(bob): %v", err)
+	}
+	if len(bobConns) != 1 || bobConns[0].RequestID != "bob-chain" {
+		t.Errorf("Bob should see only bob-chain, got %+v", bobConns)
+	}
+}
+
+func TestListUserOAuthConnections_ExcludesInactiveChains(t *testing.T) {
+	s := newConnectedTestStore(t)
+	uid := seedUser(t, s, "inactive@example.com")
+	clientID := seedClient(t, s, "Test Client")
+	now := time.Now().UTC()
+
+	seedAccess(t, s, "active-chain", clientID, uid, now, "", "pad:read", true)
+	seedAccess(t, s, "revoked-chain", clientID, uid, now, "", "pad:read", false)
+
+	conns, err := s.ListUserOAuthConnections(uid)
+	if err != nil {
+		t.Fatalf("ListUserOAuthConnections: %v", err)
+	}
+	if len(conns) != 1 {
+		t.Fatalf("got %d connections, want 1 (revoked chain excluded)", len(conns))
+	}
+	if conns[0].RequestID != "active-chain" {
+		t.Errorf("got RequestID %q, want active-chain", conns[0].RequestID)
+	}
+}
+
+func TestRevokeUserOAuthConnection_OwnershipCheck(t *testing.T) {
+	s := newConnectedTestStore(t)
+	alice := seedUser(t, s, "revoke-alice@example.com")
+	bob := seedUser(t, s, "revoke-bob@example.com")
+	clientID := seedClient(t, s, "Revoke Tester")
+	now := time.Now().UTC()
+
+	seedAccess(t, s, "alice-only", clientID, alice, now, "", "pad:read", true)
+
+	// Bob can't revoke Alice's chain — should get NotFound (not 403,
+	// to prevent enumeration via 403-vs-404 distinction).
+	if err := s.RevokeUserOAuthConnection(bob, "alice-only"); err != ErrConnectionNotFound {
+		t.Errorf("Bob revoking Alice's chain: got err=%v, want ErrConnectionNotFound", err)
+	}
+
+	// Alice's chain is still active after Bob's failed attempt.
+	conns, err := s.ListUserOAuthConnections(alice)
+	if err != nil {
+		t.Fatalf("ListUserOAuthConnections after failed revoke: %v", err)
+	}
+	if len(conns) != 1 {
+		t.Errorf("after Bob's failed revoke, Alice's chain count = %d, want 1", len(conns))
+	}
+
+	// Alice CAN revoke her own.
+	if err := s.RevokeUserOAuthConnection(alice, "alice-only"); err != nil {
+		t.Errorf("Alice revoking her own chain: %v", err)
+	}
+	conns, err = s.ListUserOAuthConnections(alice)
+	if err != nil {
+		t.Fatalf("ListUserOAuthConnections after revoke: %v", err)
+	}
+	if len(conns) != 0 {
+		t.Errorf("after Alice's revoke, chain count = %d, want 0", len(conns))
+	}
+}
+
+func TestRevokeUserOAuthConnection_Idempotent(t *testing.T) {
+	s := newConnectedTestStore(t)
+	uid := seedUser(t, s, "idem@example.com")
+	clientID := seedClient(t, s, "Idem Tester")
+	seedAccess(t, s, "idem-chain", clientID, uid, time.Now().UTC(), "", "pad:read", true)
+
+	if err := s.RevokeUserOAuthConnection(uid, "idem-chain"); err != nil {
+		t.Errorf("first revoke: %v", err)
+	}
+	if err := s.RevokeUserOAuthConnection(uid, "idem-chain"); err != nil {
+		t.Errorf("second revoke (idempotent): %v", err)
+	}
+}
+
+func TestRevokeUserOAuthConnection_UnknownChain(t *testing.T) {
+	s := newConnectedTestStore(t)
+	uid := seedUser(t, s, "unknown@example.com")
+	if err := s.RevokeUserOAuthConnection(uid, "no-such-chain"); err != ErrConnectionNotFound {
+		t.Errorf("unknown chain: got err=%v, want ErrConnectionNotFound", err)
+	}
+}
+
+func TestClassifyCapabilityTier(t *testing.T) {
+	cases := []struct {
+		scopes string
+		want   models.CapabilityTier
+	}{
+		{"", models.CapabilityTierUnknown},
+		{"pad:read", models.CapabilityTierReadOnly},
+		{"pad:read pad:write", models.CapabilityTierReadWrite},
+		{"pad:write", models.CapabilityTierReadWrite},
+		{"pad:read pad:write pad:admin", models.CapabilityTierFullAccess},
+		{"pad:admin", models.CapabilityTierFullAccess},
+		{"openid email", models.CapabilityTierUnknown},
+	}
+	for _, tc := range cases {
+		if got := classifyCapabilityTier(tc.scopes); got != tc.want {
+			t.Errorf("classifyCapabilityTier(%q) = %q, want %q", tc.scopes, got, tc.want)
+		}
+	}
+}
+
+func TestParseAllowedWorkspacesFromSession(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{"empty", "", nil},
+		{"missing extra key", `{"extra":{}}`, nil},
+		{"string slice", `{"extra":{"allowed_workspaces":["alpha","beta"]}}`, []string{"alpha", "beta"}},
+		{"wildcard", `{"extra":{"allowed_workspaces":["*"]}}`, []string{"*"}},
+		{"non-string elements skipped", `{"extra":{"allowed_workspaces":["alpha",42,"beta"]}}`, []string{"alpha", "beta"}},
+		{"malformed", `not json`, nil},
+	}
+	for _, tc := range cases {
+		got := parseAllowedWorkspacesFromSession(tc.in)
+		if len(got) != len(tc.want) {
+			t.Errorf("%s: len = %d, want %d (got %v)", tc.name, len(got), len(tc.want), got)
+			continue
+		}
+		for i := range got {
+			if got[i] != tc.want[i] {
+				t.Errorf("%s: [%d] = %q, want %q", tc.name, i, got[i], tc.want[i])
+			}
+		}
+	}
+}

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -48,7 +48,8 @@ import type {
 	ServerCapabilities,
 	WorkspaceStorageInfo,
 	AttachmentListFilters,
-	AttachmentListResponse
+	AttachmentListResponse,
+	ConnectedApp
 } from '$lib/types';
 
 const BASE = '/api/v1';
@@ -952,6 +953,19 @@ export const api = {
 
 	server: {
 		capabilities: () => request<ServerCapabilities>('/server/capabilities')
+	},
+
+	// ── Connected apps (TASK-954) ────────────────────────────────────────────
+	//
+	// Lists every active OAuth grant chain the user has authorized
+	// (Claude Desktop, Cursor, …) and lets them revoke one. Cloud-mode-
+	// only — the route returns 404 outside cloud mode, the page hides
+	// the nav link in self-host.
+
+	connectedApps: {
+		list: () => request<{ items: ConnectedApp[] }>('/connected-apps'),
+		revoke: (id: string) =>
+			request<void>(`/connected-apps/${encodeURIComponent(id)}`, { method: 'DELETE' })
 	},
 
 	// ── Admin ────────────────────────────────────────────────────────────────

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -902,6 +902,33 @@ export interface AttachmentListFilters {
 	offset?: number;
 }
 
+// Connected apps (TASK-954) — one OAuth grant chain the user has
+// authorized via the consent flow. The `id` is the OAuth request_id
+// (chain identifier preserved across refresh-token rotations) — used
+// as the URL path param for revoke + audit drilldown.
+//
+// allowed_workspaces: nil / undefined / ["*"] all mean "any workspace
+// the user belongs to"; the page renders the appropriate badge.
+// Otherwise the array is the explicit slug list the user picked at
+// consent time.
+//
+// last_used_at and calls_30d come from the MCP audit log enrichment
+// (TASK-960). last_used_at is empty when no audit entries exist for
+// this connection — the page renders "—" instead of a date.
+export interface ConnectedApp {
+	id: string;
+	client_id: string;
+	client_name: string;
+	logo_uri?: string;
+	redirect_uris?: string[];
+	allowed_workspaces?: string[] | null;
+	scope_string: string;
+	capability_tier: 'read_only' | 'read_write' | 'full_access' | 'unknown';
+	connected_at: string;
+	last_used_at?: string;
+	calls_30d: number;
+}
+
 // ─── Helper functions ────────────────────────────────────────────────────────
 
 export function parseFields(item: Item): Record<string, any> {

--- a/web/src/routes/console/+layout.svelte
+++ b/web/src/routes/console/+layout.svelte
@@ -54,6 +54,13 @@
 						Settings
 					</a>
 					{#if authStore.cloudMode}
+						<a
+							href="/console/connected-apps"
+							class="nav-link"
+							class:active={isActive('/console/connected-apps')}
+						>
+							Connected Apps
+						</a>
 						<a href="/console/billing" class="nav-link" class:active={isActive('/console/billing')}>
 							Billing
 						</a>

--- a/web/src/routes/console/+layout.svelte
+++ b/web/src/routes/console/+layout.svelte
@@ -47,7 +47,15 @@
 			<div class="nav-left">
 				<a href="/console" class="nav-logo">Pad</a>
 				<div class="nav-links">
-					<a href="/console" class="nav-link" class:active={isActive('/console') && !isActive('/console/settings') && !isActive('/console/billing') && !isActive('/console/admin')}>
+					<a
+						href="/console"
+						class="nav-link"
+						class:active={isActive('/console') &&
+							!isActive('/console/settings') &&
+							!isActive('/console/billing') &&
+							!isActive('/console/admin') &&
+							!isActive('/console/connected-apps')}
+					>
 						Workspaces
 					</a>
 					<a href="/console/settings" class="nav-link" class:active={isActive('/console/settings')}>

--- a/web/src/routes/console/connected-apps/+page.svelte
+++ b/web/src/routes/console/connected-apps/+page.svelte
@@ -162,8 +162,11 @@
 		<div class="empty-state">
 			<p class="empty-title">No connected apps yet.</p>
 			<p class="empty-desc">
-				See the <a href="/connect">connect guide</a> to set up Claude Desktop, Cursor,
-				or another MCP client.
+				See the
+				<a href="https://getpad.dev/connect" target="_blank" rel="noopener noreferrer"
+					>connect guide</a
+				>
+				to set up Claude Desktop, Cursor, or another MCP client.
 			</p>
 		</div>
 	{:else}

--- a/web/src/routes/console/connected-apps/+page.svelte
+++ b/web/src/routes/console/connected-apps/+page.svelte
@@ -1,0 +1,704 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { api } from '$lib/api/client';
+	import type { ConnectedApp } from '$lib/types';
+
+	// Connected Apps page (TASK-954). Lists every active OAuth grant
+	// chain the user has authorized via the MCP API and lets them
+	// revoke any of them. Revocation is immediate and irreversible
+	// (the request_id chain is dropped server-side), so the confirm
+	// modal exists to make that point obvious.
+
+	let apps = $state<ConnectedApp[]>([]);
+	let loading = $state(true);
+	let error = $state('');
+
+	let expanded = $state<Record<string, boolean>>({});
+	let chipsExpanded = $state<Record<string, boolean>>({});
+
+	// Modal state — single modal at a time, keyed by the target app id.
+	let confirmTarget = $state<ConnectedApp | null>(null);
+	let revoking = $state(false);
+	let revokeError = $state('');
+
+	const TIER_LABELS: Record<ConnectedApp['capability_tier'], string> = {
+		read_only: 'Read only',
+		read_write: 'Read & write',
+		full_access: 'Full access',
+		unknown: 'Unknown'
+	};
+
+	function tierClass(tier: ConnectedApp['capability_tier']): string {
+		if (tier === 'read_write') return 'tier-blue';
+		if (tier === 'full_access') return 'tier-orange';
+		return 'tier-gray';
+	}
+
+	function relativeTime(dateStr: string | undefined): string {
+		if (!dateStr) return '—';
+		const now = Date.now();
+		const then = new Date(dateStr).getTime();
+		if (Number.isNaN(then)) return '—';
+		const diffMs = Math.max(0, now - then);
+		const diffSec = Math.floor(diffMs / 1000);
+		const diffMin = Math.floor(diffSec / 60);
+		const diffHr = Math.floor(diffMin / 60);
+		const diffDay = Math.floor(diffHr / 24);
+
+		if (diffSec < 60) return 'Just now';
+		if (diffMin < 60) return `${diffMin} minute${diffMin === 1 ? '' : 's'} ago`;
+		if (diffHr < 24) return `${diffHr} hour${diffHr === 1 ? '' : 's'} ago`;
+		if (diffDay < 30) return `${diffDay} day${diffDay === 1 ? '' : 's'} ago`;
+
+		return new Date(dateStr).toLocaleDateString('en-US', {
+			month: 'short',
+			day: 'numeric',
+			year: 'numeric'
+		});
+	}
+
+	function initials(name: string): string {
+		const parts = (name || '?').trim().split(/\s+/).filter(Boolean);
+		if (parts.length === 0) return '?';
+		if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+		return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+	}
+
+	function isAnyWorkspace(ws: string[] | null | undefined): boolean {
+		if (ws == null) return true;
+		if (ws.length === 0) return true;
+		if (ws.length === 1 && ws[0] === '*') return true;
+		return false;
+	}
+
+	function callsLabel(n: number): string {
+		if (!n || n <= 0) return 'No activity in 30d';
+		return `${n} ${n === 1 ? 'call' : 'calls'} in 30d`;
+	}
+
+	async function loadApps() {
+		loading = true;
+		error = '';
+		try {
+			const result = await api.connectedApps.list();
+			apps = Array.isArray(result?.items) ? result.items : [];
+		} catch (e) {
+			error = e instanceof Error ? e.message : 'Failed to load connected apps';
+		} finally {
+			loading = false;
+		}
+	}
+
+	function toggleDetails(id: string) {
+		expanded[id] = !expanded[id];
+	}
+
+	function toggleChips(id: string) {
+		chipsExpanded[id] = !chipsExpanded[id];
+	}
+
+	function openConfirm(app: ConnectedApp) {
+		confirmTarget = app;
+		revokeError = '';
+	}
+
+	function closeConfirm() {
+		if (revoking) return;
+		confirmTarget = null;
+		revokeError = '';
+	}
+
+	async function confirmRevoke() {
+		if (!confirmTarget) return;
+		revoking = true;
+		revokeError = '';
+		const targetId = confirmTarget.id;
+		try {
+			await api.connectedApps.revoke(targetId);
+			confirmTarget = null;
+			await loadApps();
+		} catch (e) {
+			revokeError = e instanceof Error ? e.message : 'Failed to revoke app';
+		} finally {
+			revoking = false;
+		}
+	}
+
+	function onBackdropClick(e: MouseEvent) {
+		if (e.target === e.currentTarget) closeConfirm();
+	}
+
+	$effect(() => {
+		if (!confirmTarget) return;
+		function onKey(e: KeyboardEvent) {
+			if (e.key === 'Escape') closeConfirm();
+		}
+		window.addEventListener('keydown', onKey);
+		return () => window.removeEventListener('keydown', onKey);
+	});
+
+	onMount(() => {
+		loadApps();
+	});
+</script>
+
+<div class="page">
+	<header class="page-header">
+		<h1>Connected apps</h1>
+		<p class="page-desc">
+			Apps and assistants that can act on your behalf via the MCP API. Revoking an app
+			immediately invalidates its access.
+		</p>
+	</header>
+
+	{#if loading}
+		<div class="loading-msg">Loading&hellip;</div>
+	{:else if error}
+		<div class="error-msg">
+			<p>{error}</p>
+			<button class="btn" onclick={loadApps}>Retry</button>
+		</div>
+	{:else if apps.length === 0}
+		<div class="empty-state">
+			<p class="empty-title">No connected apps yet.</p>
+			<p class="empty-desc">
+				See the <a href="/connect">connect guide</a> to set up Claude Desktop, Cursor,
+				or another MCP client.
+			</p>
+		</div>
+	{:else}
+		<div class="apps-list">
+			{#each apps as app (app.id)}
+				{@const anyWs = isAnyWorkspace(app.allowed_workspaces)}
+				{@const wsList = anyWs ? [] : (app.allowed_workspaces ?? [])}
+				{@const showAllChips = chipsExpanded[app.id]}
+				{@const visibleChips = showAllChips ? wsList : wsList.slice(0, 3)}
+				{@const extraChips = Math.max(0, wsList.length - 3)}
+				<article class="app-card">
+					<div class="app-main">
+						<div class="app-logo">
+							{#if app.logo_uri}
+								<img src={app.logo_uri} alt="" />
+							{:else}
+								<span class="logo-initials">{initials(app.client_name)}</span>
+							{/if}
+						</div>
+						<div class="app-body">
+							<div class="app-title-row">
+								<h2 class="app-title">{app.client_name}</h2>
+								<span class="badge {tierClass(app.capability_tier)}">
+									{TIER_LABELS[app.capability_tier]}
+								</span>
+							</div>
+
+							<div class="chip-row">
+								{#if anyWs}
+									<span class="chip chip-any">Any workspace</span>
+								{:else}
+									{#each visibleChips as ws (ws)}
+										<span class="chip">{ws}</span>
+									{/each}
+									{#if !showAllChips && extraChips > 0}
+										<button
+											type="button"
+											class="chip chip-more"
+											onclick={() => toggleChips(app.id)}
+										>
+											+{extraChips}
+										</button>
+									{:else if showAllChips && wsList.length > 3}
+										<button
+											type="button"
+											class="chip chip-more"
+											onclick={() => toggleChips(app.id)}
+										>
+											Show less
+										</button>
+									{/if}
+								{/if}
+							</div>
+
+							<dl class="meta">
+								<div class="meta-item">
+									<dt>Connected</dt>
+									<dd title={new Date(app.connected_at).toISOString()}>
+										{relativeTime(app.connected_at)}
+									</dd>
+								</div>
+								<div class="meta-item">
+									<dt>Last used</dt>
+									<dd title={app.last_used_at ? new Date(app.last_used_at).toISOString() : ''}>
+										{relativeTime(app.last_used_at)}
+									</dd>
+								</div>
+								<div class="meta-item">
+									<dt>Activity</dt>
+									<dd>{callsLabel(app.calls_30d)}</dd>
+								</div>
+							</dl>
+
+							<button
+								type="button"
+								class="details-toggle"
+								onclick={() => toggleDetails(app.id)}
+								aria-expanded={!!expanded[app.id]}
+							>
+								{expanded[app.id] ? 'Hide details' : 'Details'}
+							</button>
+
+							{#if expanded[app.id]}
+								<div class="details">
+									<div class="detail-row">
+										<span class="detail-label">Scopes</span>
+										<code class="detail-value">{app.scope_string || '—'}</code>
+									</div>
+									<div class="detail-row">
+										<span class="detail-label">Allowed workspaces</span>
+										<span class="detail-value">
+											{#if anyWs}
+												Any workspace
+											{:else}
+												{wsList.join(', ')}
+											{/if}
+										</span>
+									</div>
+									<div class="detail-row">
+										<span class="detail-label">Redirect URIs</span>
+										<div class="detail-value">
+											{#if app.redirect_uris && app.redirect_uris.length > 0}
+												{#each app.redirect_uris as uri (uri)}
+													<code class="uri">{uri}</code>
+												{/each}
+											{:else}
+												&mdash;
+											{/if}
+										</div>
+									</div>
+								</div>
+							{/if}
+						</div>
+					</div>
+
+					<div class="app-actions">
+						<button class="btn btn-danger" onclick={() => openConfirm(app)}>Revoke</button>
+					</div>
+				</article>
+			{/each}
+		</div>
+	{/if}
+</div>
+
+{#if confirmTarget}
+	<div
+		class="modal-backdrop"
+		role="presentation"
+		onclick={onBackdropClick}
+	>
+		<div class="modal" role="dialog" aria-modal="true" aria-labelledby="revoke-title">
+			<h3 id="revoke-title" class="modal-title">Revoke {confirmTarget.client_name}?</h3>
+			<p class="modal-body">
+				The app will lose access immediately. This can&rsquo;t be undone.
+			</p>
+			{#if revokeError}
+				<p class="modal-error">{revokeError}</p>
+			{/if}
+			<div class="modal-actions">
+				<button class="btn" onclick={closeConfirm} disabled={revoking}>Cancel</button>
+				<button class="btn btn-danger" onclick={confirmRevoke} disabled={revoking}>
+					{revoking ? 'Revoking…' : 'Revoke'}
+				</button>
+			</div>
+		</div>
+	</div>
+{/if}
+
+<style>
+	.page {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-6);
+	}
+
+	.page-header h1 {
+		margin: 0 0 var(--space-2) 0;
+		font-size: 1.5rem;
+		font-weight: 700;
+		color: var(--text-primary);
+		letter-spacing: -0.01em;
+	}
+
+	.page-desc {
+		margin: 0;
+		font-size: 0.9rem;
+		color: var(--text-secondary);
+		max-width: 60ch;
+	}
+
+	/* States */
+	.loading-msg {
+		color: var(--text-muted);
+		padding: var(--space-6) 0;
+		text-align: center;
+		font-size: 0.9rem;
+	}
+
+	.error-msg {
+		color: #ef4444;
+		padding: var(--space-4) var(--space-6);
+		background: var(--bg-secondary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: var(--space-3);
+	}
+
+	.error-msg p {
+		margin: 0;
+		font-size: 0.85rem;
+	}
+
+	.empty-state {
+		padding: var(--space-8) var(--space-6);
+		text-align: center;
+		background: var(--bg-secondary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+	}
+
+	.empty-title {
+		margin: 0 0 var(--space-2) 0;
+		font-size: 1rem;
+		font-weight: 600;
+		color: var(--text-primary);
+	}
+
+	.empty-desc {
+		margin: 0;
+		font-size: 0.9rem;
+		color: var(--text-secondary);
+	}
+
+	/* List */
+	.apps-list {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-3);
+	}
+
+	.app-card {
+		display: flex;
+		gap: var(--space-4);
+		padding: var(--space-4);
+		background: var(--bg-secondary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+		align-items: flex-start;
+	}
+
+	.app-main {
+		display: flex;
+		gap: var(--space-4);
+		flex: 1;
+		min-width: 0;
+	}
+
+	.app-logo {
+		flex-shrink: 0;
+		width: 48px;
+		height: 48px;
+		border-radius: var(--radius);
+		background: var(--bg-tertiary);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		overflow: hidden;
+	}
+
+	.app-logo img {
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+	}
+
+	.logo-initials {
+		font-size: 1rem;
+		font-weight: 600;
+		color: var(--text-secondary);
+	}
+
+	.app-body {
+		flex: 1;
+		min-width: 0;
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-2);
+	}
+
+	.app-title-row {
+		display: flex;
+		align-items: center;
+		gap: var(--space-2);
+		flex-wrap: wrap;
+	}
+
+	.app-title {
+		margin: 0;
+		font-size: 1rem;
+		font-weight: 600;
+		color: var(--text-primary);
+	}
+
+	.chip-row {
+		display: flex;
+		gap: var(--space-1);
+		flex-wrap: wrap;
+	}
+
+	.chip {
+		display: inline-block;
+		padding: 2px 8px;
+		border-radius: 999px;
+		background: var(--bg-tertiary);
+		color: var(--text-secondary);
+		font-size: 0.75rem;
+		font-weight: 500;
+		font-family: var(--font-mono, ui-monospace, SFMono-Regular, monospace);
+		border: 1px solid var(--border);
+	}
+
+	.chip-any {
+		font-family: inherit;
+		background: rgba(59, 130, 246, 0.1);
+		color: var(--accent-blue, #3b82f6);
+		border-color: rgba(59, 130, 246, 0.3);
+	}
+
+	button.chip-more {
+		cursor: pointer;
+		font-family: inherit;
+	}
+
+	button.chip-more:hover {
+		color: var(--text-primary);
+	}
+
+	.meta {
+		display: flex;
+		gap: var(--space-4);
+		flex-wrap: wrap;
+		margin: 0;
+		padding: 0;
+	}
+
+	.meta-item {
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+		min-width: 0;
+	}
+
+	.meta-item dt {
+		font-size: 0.7rem;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+		color: var(--text-muted);
+		margin: 0;
+	}
+
+	.meta-item dd {
+		font-size: 0.85rem;
+		color: var(--text-secondary);
+		margin: 0;
+	}
+
+	.details-toggle {
+		align-self: flex-start;
+		background: none;
+		border: none;
+		padding: 0;
+		color: var(--accent-blue, #3b82f6);
+		font-size: 0.8rem;
+		cursor: pointer;
+		font-weight: 500;
+	}
+
+	.details-toggle:hover {
+		text-decoration: underline;
+	}
+
+	.details {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-2);
+		margin-top: var(--space-2);
+		padding: var(--space-3);
+		background: var(--bg-tertiary);
+		border-radius: var(--radius);
+		border: 1px solid var(--border);
+	}
+
+	.detail-row {
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+	}
+
+	.detail-label {
+		font-size: 0.7rem;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+		color: var(--text-muted);
+	}
+
+	.detail-value {
+		font-size: 0.85rem;
+		color: var(--text-secondary);
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+		word-break: break-all;
+	}
+
+	code.detail-value,
+	code.uri {
+		font-family: var(--font-mono, ui-monospace, SFMono-Regular, monospace);
+		font-size: 0.8rem;
+	}
+
+	.app-actions {
+		flex-shrink: 0;
+	}
+
+	/* Badges */
+	.badge {
+		display: inline-block;
+		padding: 2px 8px;
+		border-radius: 999px;
+		font-size: 0.72rem;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+		background: var(--bg-tertiary);
+		color: var(--text-secondary);
+	}
+
+	.badge.tier-gray {
+		background: rgba(148, 163, 184, 0.15);
+		color: var(--text-secondary);
+	}
+
+	.badge.tier-blue {
+		background: rgba(59, 130, 246, 0.15);
+		color: var(--accent-blue, #3b82f6);
+	}
+
+	.badge.tier-orange {
+		background: rgba(217, 119, 6, 0.15);
+		color: var(--accent-orange, #d97706);
+	}
+
+	/* Buttons */
+	.btn {
+		padding: var(--space-2) var(--space-4);
+		background: var(--bg-secondary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+		color: var(--text-primary);
+		font-size: 0.85rem;
+		font-weight: 500;
+		cursor: pointer;
+		transition: background 0.15s, color 0.15s, border-color 0.15s;
+	}
+
+	.btn:hover:not(:disabled) {
+		background: var(--bg-tertiary);
+	}
+
+	.btn:disabled {
+		opacity: 0.5;
+		cursor: default;
+	}
+
+	.btn-danger {
+		color: #ef4444;
+		border-color: rgba(239, 68, 68, 0.4);
+	}
+
+	.btn-danger:hover:not(:disabled) {
+		background: rgba(239, 68, 68, 0.1);
+		border-color: #ef4444;
+	}
+
+	/* Modal */
+	.modal-backdrop {
+		position: fixed;
+		inset: 0;
+		background: rgba(0, 0, 0, 0.5);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		padding: var(--space-4);
+		z-index: 100;
+	}
+
+	.modal {
+		background: var(--bg-primary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+		padding: var(--space-5);
+		max-width: 420px;
+		width: 100%;
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-3);
+		box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+	}
+
+	.modal-title {
+		margin: 0;
+		font-size: 1rem;
+		font-weight: 600;
+		color: var(--text-primary);
+	}
+
+	.modal-body {
+		margin: 0;
+		font-size: 0.9rem;
+		color: var(--text-secondary);
+	}
+
+	.modal-error {
+		margin: 0;
+		font-size: 0.85rem;
+		color: #ef4444;
+		padding: var(--space-2) var(--space-3);
+		background: rgba(239, 68, 68, 0.08);
+		border: 1px solid rgba(239, 68, 68, 0.3);
+		border-radius: var(--radius);
+	}
+
+	.modal-actions {
+		display: flex;
+		justify-content: flex-end;
+		gap: var(--space-2);
+		margin-top: var(--space-2);
+	}
+
+	@media (max-width: 640px) {
+		.app-card {
+			flex-direction: column;
+		}
+
+		.app-actions {
+			align-self: stretch;
+		}
+
+		.app-actions .btn {
+			width: 100%;
+		}
+	}
+</style>


### PR DESCRIPTION
## Summary

Adds **/console/connected-apps** — the user-facing page where a logged-in user can see every OAuth grant chain they've authorized via the MCP consent flow (Claude Desktop, Cursor, …) and revoke any of them. Joins to the DCR client metadata for the display name + logo, and to the MCP audit log (TASK-960, just merged in #389) for the "last used" + "30-day calls" columns.

## Why

Closes the loop on PLAN-943's MCP cloud surface: users can now self-serve revocation when they want to disconnect an assistant, see at a glance which workspaces each connection has access to, and tell which ones are actively being used.

## What's in the change

### Store
- `internal/store/connected_apps.go`
  - `ListUserOAuthConnections(userID)` walks `oauth_access_tokens` + `oauth_refresh_tokens`, dedups by `request_id` (the chain identifier preserved across refresh-token rotations), hydrates client metadata, parses `session_data` for the workspace allow-list, classifies `granted_scopes` into a coarse capability tier.
  - `RevokeUserOAuthConnection(userID, requestID)` verifies ownership via the existing `subject` denormalized column. Stranger's chains return `ErrConnectionNotFound` (anti-enumeration — same shape as truly unknown chains so a malicious caller can't 403-vs-404 distinguish). On success, calls `RevokeRefreshTokenFamily` + `RevokeAccessTokenFamily` so the next /mcp call from that client gets 401. Idempotent for re-revoke.

### Models
- `internal/models/connected_apps.go` — `OAuthConnection` + `CapabilityTier` enum (`read_only` / `read_write` / `full_access` / `unknown`).

### REST API (cloud-mode-gated)
- `GET /api/v1/connected-apps` — list, enriched with `MCPConnectionStatsForUser` for `last_used_at` + `calls_30d`. Audit lookup soft-fails so a broken audit table degrades to "no last-used data" instead of breaking the page.
- `DELETE /api/v1/connected-apps/{id}` — revoke. 204 on success + on idempotent re-revoke. 404 on stranger's-chain or unknown-chain (anti-enumeration). Records `oauth_connection_revoked` in the existing audit_trail via `CreateActivity`.

### Web UI
- `web/src/routes/console/connected-apps/+page.svelte` (new) — per-app card with logo or initials avatar, name, capability badge (Read only / Read & write / Full access), workspace chips with `+N` expander (or "Any workspace" when null/`["*"]`), connected/last-used relative times, 30-day call count, "Details" expander revealing full scope string + workspace list + redirect URIs, Revoke → confirm modal with Escape + backdrop dismissal → optimistic list refresh, friendly empty state linking to `/connect`.
- `web/src/routes/console/+layout.svelte` — "Connected Apps" nav link, cloud-mode-gated (between Settings and Billing).
- `web/src/lib/api/client.ts` + `types/index.ts` — typed client + `ConnectedApp` interface.

## Test plan

- [x] `golangci-lint run --timeout=5m ./...` — clean
- [x] `go test ./...` — all tests pass
- [x] `cd web && npm run build` — clean
- [x] `cd web && npm run check` — 0 errors (6 pre-existing warnings unrelated to this PR)
- [x] `make install` — server restart verified
- [x] **Store tests:** chain dedup across rotation siblings, subject filtering (Bob can't see Alice's), inactive chains excluded immediately, `ConnectedAt` = earliest timestamp in the chain, ownership check on revoke (Bob revoking Alice's chain → NotFound), idempotent re-revoke, unknown chain → NotFound, capability tier mapping for empty / read / write / admin / unknown vocabularies, `session_data` allowed_workspaces parsing (both `[]string` and JSON `[]interface{}` round-trips).
- [x] **Handler tests:** cloud-mode gate returns 404 outside cloud mode, list filters to owner only, DTO surfaces all expected fields with correct shape, audit enrichment populates `last_used_at` + `calls_30d`, revoke owner-only returns 404 (not 403), happy-path 204 + idempotent second 204, unknown chain 404, `oauth_connection_revoked` lands in audit_trail.

## Out of scope (per task body)

- Per-call audit drill-down on the connected-apps card (the per-connection endpoint already exists from TASK-960; surfacing it as inline drilldown is a follow-up).
- Connection rename (e.g. "Claude Desktop on my laptop" vs "…on my work machine") — defer until users ask.
- Bulk revoke — single-revoke is fine for v1.

## Context

Implements TASK-954 under PLAN-943.
Stacks on top of #389 (TASK-960) which landed the `mcp_audit_log` table that powers the `last_used_at` + `calls_30d` columns.

Together these two PRs close out the user-facing portion of PLAN-943's "Pad Cloud as a remote MCP server" workstream.