### PR TITLE
fix(timeline): drop \xff cursor sentinel that broke Postgres pagination (BUG-1086)

### DIFF
--- a/internal/server/handlers_timeline.go
+++ b/internal/server/handlers_timeline.go
@@ -38,18 +38,38 @@ func (s *Server) handleListItemTimeline(w http.ResponseWriter, r *http.Request) 
 	}
 
 	// Cursor: fetch entries before this (timestamp, id) pair.
-	// Defaults to now + a future-biased ID to include "just now" entries on first page.
+	//
+	// Three cases:
+	//   1. Neither before nor before_id supplied (true first page) →
+	//      beforeID = "" tells the store to drop the id predicate entirely.
+	//   2. Both before and before_id supplied (normal cursor pagination) →
+	//      passed straight through.
+	//   3. before supplied without before_id (malformed/external client) →
+	//      use a UUID-safe upper-bound sentinel ("g" sorts after any
+	//      lowercase-hex UUID character in every reasonable collation) so
+	//      same-second entries aren't silently dropped.
+	//
+	// The previous code defaulted beforeID to "\xff" in all three cases.
+	// That worked on SQLite but Postgres rejects "\xff" as an invalid UTF-8
+	// byte sequence (SQLSTATE 22021), causing every timeline load to 500.
+	// See BUG-1086.
 	before := time.Now().UTC().Add(time.Minute)
-	beforeID := "\xff" // sorts after all UUIDs on first page
+	beforeID := ""
+	hasBefore := false
 	if v := r.URL.Query().Get("before"); v != "" {
 		if t, err := time.Parse(time.RFC3339Nano, v); err == nil {
 			before = t
+			hasBefore = true
 		} else if t, err := time.Parse(time.RFC3339, v); err == nil {
 			before = t
+			hasBefore = true
 		}
 	}
 	if v := r.URL.Query().Get("before_id"); v != "" {
 		beforeID = v
+	}
+	if hasBefore && beforeID == "" {
+		beforeID = "g" // > any UUID character lex-wise; valid UTF-8
 	}
 
 	// Over-fetch per source (3x limit) to compensate for entries removed by

--- a/internal/store/activities.go
+++ b/internal/store/activities.go
@@ -198,16 +198,31 @@ func (s *Store) ListDocumentActivity(documentID string, params models.ActivityLi
 
 // ListDocumentActivityBeforeTime returns activities for a document created before the given time,
 // ordered newest-first, limited to `limit` results. Used for cursor-based timeline pagination.
+//
+// When beforeID is empty (first page / no cursor), the secondary id tie-breaker
+// is omitted. See ListCommentsBeforeTime for the rationale (BUG-1086).
 func (s *Store) ListDocumentActivityBeforeTime(documentID string, before time.Time, beforeID string, limit int) ([]models.Activity, error) {
 	ts := before.Format(time.RFC3339)
-	rows, err := s.db.Query(s.q(`
-		SELECT a.id, COALESCE(a.workspace_id, ''), COALESCE(a.document_id, ''), a.action, a.actor, a.source, a.metadata, COALESCE(a.user_id, ''), a.created_at, COALESCE(u.name, ''), COALESCE(a.ip_address, ''), COALESCE(a.user_agent, '')
-		FROM activities a
-		LEFT JOIN users u ON a.user_id = u.id
-		WHERE a.document_id = ? AND (a.created_at < ? OR (a.created_at = ? AND a.id < ?))
-		ORDER BY a.created_at DESC, a.id DESC
-		LIMIT ?
-	`), documentID, ts, ts, beforeID, limit)
+	const selectCols = `a.id, COALESCE(a.workspace_id, ''), COALESCE(a.document_id, ''), a.action, a.actor, a.source, a.metadata, COALESCE(a.user_id, ''), a.created_at, COALESCE(u.name, ''), COALESCE(a.ip_address, ''), COALESCE(a.user_agent, '')`
+	const orderLimit = `ORDER BY a.created_at DESC, a.id DESC LIMIT ?`
+
+	var rows *sql.Rows
+	var err error
+	if beforeID == "" {
+		rows, err = s.db.Query(s.q(`
+			SELECT `+selectCols+`
+			FROM activities a
+			LEFT JOIN users u ON a.user_id = u.id
+			WHERE a.document_id = ? AND a.created_at < ?
+			`+orderLimit), documentID, ts, limit)
+	} else {
+		rows, err = s.db.Query(s.q(`
+			SELECT `+selectCols+`
+			FROM activities a
+			LEFT JOIN users u ON a.user_id = u.id
+			WHERE a.document_id = ? AND (a.created_at < ? OR (a.created_at = ? AND a.id < ?))
+			`+orderLimit), documentID, ts, ts, beforeID, limit)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/internal/store/comments.go
+++ b/internal/store/comments.go
@@ -103,16 +103,33 @@ func (s *Store) ListComments(itemID string) ([]models.Comment, error) {
 
 // ListCommentsBeforeTime returns comments for an item created before the given time,
 // ordered newest-first, limited to `limit` results. Used for cursor-based timeline pagination.
+//
+// When beforeID is empty (first page / no cursor), the secondary id tie-breaker
+// is omitted. Earlier code passed a "\xff" sentinel intended to sort after any
+// UUID, but Postgres rejects that as an invalid UTF-8 byte sequence in a TEXT
+// bind parameter (SQLSTATE 22021). See BUG-1086.
 func (s *Store) ListCommentsBeforeTime(itemID string, before time.Time, beforeID string, limit int) ([]models.Comment, error) {
 	ts := before.Format(time.RFC3339)
-	rows, err := s.db.Query(s.q(`
-		SELECT c.id, c.item_id, c.workspace_id, c.author, c.body,
+	const selectCols = `c.id, c.item_id, c.workspace_id, c.author, c.body,
 		       c.created_by, c.source, COALESCE(c.activity_id, ''), COALESCE(c.parent_id, ''),
-		       c.created_at, c.updated_at
-		FROM comments c
-		WHERE c.item_id = ? AND (c.created_at < ? OR (c.created_at = ? AND c.id < ?))
-		ORDER BY c.created_at DESC, c.id DESC
-		LIMIT ?`), itemID, ts, ts, beforeID, limit)
+		       c.created_at, c.updated_at`
+	const orderLimit = `ORDER BY c.created_at DESC, c.id DESC LIMIT ?`
+
+	var rows *sql.Rows
+	var err error
+	if beforeID == "" {
+		rows, err = s.db.Query(s.q(`
+			SELECT `+selectCols+`
+			FROM comments c
+			WHERE c.item_id = ? AND c.created_at < ?
+			`+orderLimit), itemID, ts, limit)
+	} else {
+		rows, err = s.db.Query(s.q(`
+			SELECT `+selectCols+`
+			FROM comments c
+			WHERE c.item_id = ? AND (c.created_at < ? OR (c.created_at = ? AND c.id < ?))
+			`+orderLimit), itemID, ts, ts, beforeID, limit)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("list comments before time: %w", err)
 	}

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -1905,15 +1905,29 @@ func (s *Store) ListItemVersionsResolved(itemID, currentContent string) ([]model
 
 // ListItemVersionsBeforeTime returns versions for an item created before the given time,
 // ordered newest-first, limited to `limit` results. Used for cursor-based timeline pagination.
+//
+// When beforeID is empty (first page / no cursor), the secondary id tie-breaker
+// is omitted. See ListCommentsBeforeTime for the rationale (BUG-1086).
 func (s *Store) ListItemVersionsBeforeTime(itemID string, before time.Time, beforeID string, limit int) ([]models.Version, error) {
 	ts := before.Format(time.RFC3339)
-	rows, err := s.db.Query(s.q(`
-		SELECT id, item_id, content, change_summary, created_by, source, is_diff, created_at
-		FROM item_versions
-		WHERE item_id = ? AND (created_at < ? OR (created_at = ? AND id < ?))
-		ORDER BY created_at DESC, id DESC
-		LIMIT ?
-	`), itemID, ts, ts, beforeID, limit)
+	const selectCols = `id, item_id, content, change_summary, created_by, source, is_diff, created_at`
+	const orderLimit = `ORDER BY created_at DESC, id DESC LIMIT ?`
+
+	var rows *sql.Rows
+	var err error
+	if beforeID == "" {
+		rows, err = s.db.Query(s.q(`
+			SELECT `+selectCols+`
+			FROM item_versions
+			WHERE item_id = ? AND created_at < ?
+			`+orderLimit), itemID, ts, limit)
+	} else {
+		rows, err = s.db.Query(s.q(`
+			SELECT `+selectCols+`
+			FROM item_versions
+			WHERE item_id = ? AND (created_at < ? OR (created_at = ? AND id < ?))
+			`+orderLimit), itemID, ts, ts, beforeID, limit)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/internal/store/timeline_pagination_test.go
+++ b/internal/store/timeline_pagination_test.go
@@ -1,0 +1,186 @@
+package store
+
+import (
+	"testing"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// Regression coverage for BUG-1086.
+//
+// The timeline handler previously seeded `beforeID` with the literal byte "\xff"
+// to act as a sentinel that "sorts after any UUID". That worked on SQLite (which
+// doesn't validate TEXT against UTF-8), but Postgres rejected it with
+// SQLSTATE 22021 — `invalid byte sequence for encoding "UTF8": 0xff`, surfacing
+// as a 500 every time the timeline tab loaded on pad cloud.
+//
+// The fix: when there is no cursor (first page), the store omits the id
+// tie-breaker from the WHERE clause entirely. These tests exercise both the
+// no-cursor path (the previously-broken case) and the real-cursor path on
+// whichever backend `testStore` is configured for, so `make test-pg` covers
+// the actual failure mode.
+
+// timelineFixture creates a workspace, collection, item, and three comments
+// spaced 1 second apart. Returns the item plus the comment slice
+// (ordered oldest → newest).
+func timelineFixture(t *testing.T, s *Store) (*models.Item, []models.Comment) {
+	t.Helper()
+	ws := createTestWorkspace(t, s, "Timeline")
+	coll := createTestCollection(t, s, ws.ID, "Tasks")
+	item := createTestItem(t, s, ws.ID, coll.ID, "Test item", "")
+
+	var comments []models.Comment
+	for i, body := range []string{"first", "second", "third"} {
+		c, err := s.CreateComment(ws.ID, item.ID, models.CommentCreate{
+			Body:      body,
+			Author:    "Tester",
+			CreatedBy: "user",
+			Source:    "web",
+		})
+		if err != nil {
+			t.Fatalf("create comment %d: %v", i, err)
+		}
+		comments = append(comments, *c)
+		// CreatedAt is RFC3339 (second precision) — sleep so each comment
+		// gets a distinct timestamp and pagination is deterministic.
+		time.Sleep(1100 * time.Millisecond)
+	}
+	return item, comments
+}
+
+func TestListCommentsBeforeTime_NoCursor(t *testing.T) {
+	s := testStore(t)
+	item, comments := timelineFixture(t, s)
+
+	// First-page query: no cursor. Pre-fix this passed beforeID = "\xff" and
+	// blew up on Postgres with SQLSTATE 22021. Now we pass "".
+	got, err := s.ListCommentsBeforeTime(item.ID, time.Now().UTC().Add(time.Minute), "", 10)
+	if err != nil {
+		t.Fatalf("ListCommentsBeforeTime first page: %v", err)
+	}
+	if len(got) != len(comments) {
+		t.Fatalf("expected %d comments, got %d", len(comments), len(got))
+	}
+	// Newest first.
+	if got[0].Body != "third" || got[len(got)-1].Body != "first" {
+		t.Errorf("unexpected order: %q .. %q", got[0].Body, got[len(got)-1].Body)
+	}
+}
+
+func TestListCommentsBeforeTime_WithCursor(t *testing.T) {
+	s := testStore(t)
+	item, comments := timelineFixture(t, s)
+
+	// Paginate "before" the newest comment using a real (timestamp, id) cursor.
+	cursor := comments[2] // newest
+	got, err := s.ListCommentsBeforeTime(item.ID, cursor.CreatedAt, cursor.ID, 10)
+	if err != nil {
+		t.Fatalf("ListCommentsBeforeTime cursor page: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 comments before cursor, got %d", len(got))
+	}
+	if got[0].Body != "second" || got[1].Body != "first" {
+		t.Errorf("unexpected order on cursor page: %q, %q", got[0].Body, got[1].Body)
+	}
+}
+
+// TestListCommentsBeforeTime_SameSecondCursor exercises the path where a
+// caller passes a `before` timestamp together with an upper-bound id sentinel
+// (e.g. "g") rather than an exact cursor id. The query must still include
+// rows whose created_at equals that second — equivalent to the legacy
+// "before=now,beforeID=\xff" semantics that BUG-1086 broke.
+func TestListCommentsBeforeTime_SameSecondCursor(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "SameSecond")
+	coll := createTestCollection(t, s, ws.ID, "Tasks")
+	item := createTestItem(t, s, ws.ID, coll.ID, "Same-second", "")
+
+	// Three comments back-to-back with no sleep — they will share a second
+	// at RFC3339 precision (which is what the store stores).
+	for _, body := range []string{"a", "b", "c"} {
+		if _, err := s.CreateComment(ws.ID, item.ID, models.CommentCreate{
+			Body:      body,
+			Author:    "Tester",
+			CreatedBy: "user",
+			Source:    "web",
+		}); err != nil {
+			t.Fatalf("create %s: %v", body, err)
+		}
+	}
+
+	// Cursor at "now" with "g" sentinel — must include all 3 same-second rows.
+	got, err := s.ListCommentsBeforeTime(item.ID, time.Now().UTC(), "g", 10)
+	if err != nil {
+		t.Fatalf("ListCommentsBeforeTime same-second cursor: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("same-second cursor should include all 3 rows, got %d", len(got))
+	}
+}
+
+func TestListCommentsBeforeTime_LimitRespected(t *testing.T) {
+	s := testStore(t)
+	item, _ := timelineFixture(t, s)
+
+	got, err := s.ListCommentsBeforeTime(item.ID, time.Now().UTC().Add(time.Minute), "", 2)
+	if err != nil {
+		t.Fatalf("ListCommentsBeforeTime: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("limit=2 expected 2 rows, got %d", len(got))
+	}
+}
+
+func TestListDocumentActivityBeforeTime_NoCursor(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Activity")
+	doc := createTestDoc(t, s, ws.ID, "Doc", "content")
+
+	for _, action := range []string{"created", "viewed", "edited"} {
+		if _, err := s.CreateActivity(models.Activity{
+			WorkspaceID: ws.ID,
+			DocumentID:  doc.ID,
+			Action:      action,
+			Actor:       "user",
+			Source:      "web",
+		}); err != nil {
+			t.Fatalf("create activity %s: %v", action, err)
+		}
+	}
+
+	got, err := s.ListDocumentActivityBeforeTime(doc.ID, time.Now().UTC().Add(time.Minute), "", 10)
+	if err != nil {
+		t.Fatalf("ListDocumentActivityBeforeTime first page: %v", err)
+	}
+	if len(got) < 3 {
+		t.Fatalf("expected at least 3 activities, got %d", len(got))
+	}
+}
+
+func TestListItemVersionsBeforeTime_NoCursor(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Versions")
+	coll := createTestCollection(t, s, ws.ID, "Tasks")
+	item := createTestItem(t, s, ws.ID, coll.ID, "Versioned", "v1 content")
+
+	// UpdateItem creates a version snapshot. Two updates → two extra versions.
+	if _, err := s.UpdateItem(item.ID, models.ItemUpdate{Content: strPtr("v2 content")}); err != nil {
+		t.Fatalf("update v2: %v", err)
+	}
+	time.Sleep(1100 * time.Millisecond)
+	if _, err := s.UpdateItem(item.ID, models.ItemUpdate{Content: strPtr("v3 content")}); err != nil {
+		t.Fatalf("update v3: %v", err)
+	}
+
+	got, err := s.ListItemVersionsBeforeTime(item.ID, time.Now().UTC().Add(time.Minute), "", 10)
+	if err != nil {
+		t.Fatalf("ListItemVersionsBeforeTime first page: %v", err)
+	}
+	if len(got) == 0 {
+		t.Fatal("expected at least 1 version, got 0")
+	}
+}
+
+func strPtr(s string) *string { return &s }


### PR DESCRIPTION
## Summary

- **BUG-1086**: every timeline tab load on pad cloud returned 500 with `pq: invalid byte sequence for encoding "UTF8": 0xff (22021)`. Root cause was `internal/server/handlers_timeline.go:43` defaulting the cursor's `beforeID` to a literal `\xff` byte intended to "sort after any UUID" — fine on SQLite, fatal on Postgres' UTF-8-validating TEXT bind.
- Removes the sentinel and branches the three `*BeforeTime` store queries on `beforeID == ""` so the no-cursor path emits a clean `WHERE created_at < ?` with no id predicate.
- Distinguishes three handler cases: true first page → `""`, normal cursor → unchanged, `before`-only cursor → `"g"` sentinel (UUID-safe, valid UTF-8) so same-second rows aren't silently dropped — that last case is a regression Codex review caught on round 1.

## Test plan

- [x] `go test ./internal/store/ -run 'TestList(Comments|DocumentActivity|ItemVersions)BeforeTime'` — 6/6 on SQLite
- [x] `make test-pg` against local Postgres container — 6/6 on real Postgres
- [x] Full `./internal/store` and `./internal/server` suites green on Postgres
- [x] Empirical reproduction: standalone probe `db.Query("SELECT 1 WHERE $1::text < $2::text", "abc", "\xff")` returns the exact bug error against the same Postgres
- [x] `make install` + `GET /api/v1/workspaces/docapp/items/BUG-1086/timeline` → HTTP 200 with comments rendered
- [x] Codex review loop: round 1 caught the same-second-drop regression, round 2 returned CLEAN