### PR TITLE
fix(workspaces): scope admin's personal workspace list to memberships (BUG-982)

### DIFF
--- a/internal/server/handlers_workspaces.go
+++ b/internal/server/handlers_workspaces.go
@@ -136,8 +136,15 @@ func (s *Server) handleListTemplates(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleListWorkspaces(w http.ResponseWriter, r *http.Request) {
 	user := currentUser(r)
 
-	// If a user is authenticated and is not an admin, scope to their memberships.
-	if user != nil && user.Role != "admin" {
+	// Authenticated users — including admins — see only workspaces they're
+	// a member of (which includes ones they own, since owners get a
+	// workspace_members row at creation time). Server admins previously got
+	// the unfiltered list here, which leaked workspace metadata into their
+	// "shared with me" switcher even though they weren't members
+	// (BUG-982). Cross-tenant visibility for admins is available through
+	// the admin panel routes (/api/v1/admin/...), which call
+	// ListWorkspaces() directly with the appropriate auth gate.
+	if user != nil {
 		workspaces, err := s.store.GetUserWorkspaces(user.ID)
 		if err != nil {
 			writeInternalError(w, err)
@@ -150,15 +157,9 @@ func (s *Server) handleListWorkspaces(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Admin users (or fresh-install with no users) see all workspaces.
-	// Pass user ID when available so sort_order is included.
-	var workspaces []models.Workspace
-	var err error
-	if user != nil {
-		workspaces, err = s.store.ListWorkspacesForUser(user.ID)
-	} else {
-		workspaces, err = s.store.ListWorkspaces()
-	}
+	// Pre-auth / fresh-install bootstrap: list everything so the setup
+	// flow can find any seeded workspace.
+	workspaces, err := s.store.ListWorkspaces()
 	if err != nil {
 		writeInternalError(w, err)
 		return

--- a/internal/server/handlers_workspaces_test.go
+++ b/internal/server/handlers_workspaces_test.go
@@ -1,0 +1,140 @@
+package server
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// TestListWorkspaces_AdminScopedToMembership is the regression for BUG-982.
+//
+// Before the fix, handleListWorkspaces routed admin users through an
+// unfiltered store query that returned every non-deleted workspace,
+// regardless of membership. The admin's "workspace switcher" therefore
+// showed workspaces they had no member row for, labeled as "shared with
+// me" by the frontend even though they were not actually shared.
+//
+// After the fix, admins go through GetUserWorkspaces like every other
+// authenticated user. Cross-tenant visibility is available via the
+// admin panel routes (/api/v1/admin/...), not the personal switcher.
+func TestListWorkspaces_AdminScopedToMembership(t *testing.T) {
+	srv := testServer(t)
+
+	// 1. Bootstrap an admin (the first user is auto-admin).
+	adminToken := bootstrapFirstUser(t, srv, "admin@test.com", "Admin")
+
+	// 2. Register a regular user via admin-driven signup.
+	rr := doRequestWithCookie(srv, "POST", "/api/v1/auth/register", map[string]string{
+		"email":    "alice@test.com",
+		"name":     "Alice",
+		"password": "correct-horse-battery-staple",
+	}, adminToken)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("register alice: expected 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	// 3. Alice logs in and creates her own workspace. The handler
+	// auto-adds her as the owner member, so she sees it; nobody else
+	// should.
+	aliceToken := loginUser(t, srv, "alice@test.com", "correct-horse-battery-staple")
+	rr = doRequestWithCookie(srv, "POST", "/api/v1/workspaces", map[string]string{
+		"name": "Alice's Private Workspace",
+	}, aliceToken)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create alice workspace: expected 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var aliceWS models.Workspace
+	parseJSON(t, rr, &aliceWS)
+
+	// 4. Admin lists workspaces. Pre-fix: Alice's workspace appears.
+	// Post-fix: it does not, because the admin is not a member.
+	rr = doRequestWithCookie(srv, "GET", "/api/v1/workspaces", nil, adminToken)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("admin list workspaces: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var adminWorkspaces []models.Workspace
+	parseJSON(t, rr, &adminWorkspaces)
+	for _, ws := range adminWorkspaces {
+		if ws.ID == aliceWS.ID {
+			t.Fatalf("BUG-982 regression: admin saw Alice's workspace %q in personal listing without being a member", ws.Slug)
+		}
+	}
+
+	// 5. Sanity: Alice DOES see her workspace.
+	rr = doRequestWithCookie(srv, "GET", "/api/v1/workspaces", nil, aliceToken)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("alice list workspaces: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var aliceWorkspaces []models.Workspace
+	parseJSON(t, rr, &aliceWorkspaces)
+	if !containsWorkspace(aliceWorkspaces, aliceWS.ID) {
+		t.Fatal("owner should see their own workspace in personal listing")
+	}
+
+	// 6. Add the admin as an editor member of Alice's workspace —
+	// now the admin SHOULD see it (they are an actual member).
+	adminUser, err := srv.store.GetUserByEmail("admin@test.com")
+	if err != nil || adminUser == nil {
+		t.Fatal("failed to find admin user")
+	}
+	if err := srv.store.AddWorkspaceMember(aliceWS.ID, adminUser.ID, "editor"); err != nil {
+		t.Fatalf("add admin as editor: %v", err)
+	}
+	rr = doRequestWithCookie(srv, "GET", "/api/v1/workspaces", nil, adminToken)
+	parseJSON(t, rr, &adminWorkspaces)
+	if !containsWorkspace(adminWorkspaces, aliceWS.ID) {
+		t.Fatal("admin should see workspaces they are an explicit member of")
+	}
+}
+
+// TestListWorkspaces_RegularUserScopedToMembership confirms the
+// pre-existing behavior for non-admin users is unchanged: they only see
+// workspaces they own or have been added to.
+func TestListWorkspaces_RegularUserScopedToMembership(t *testing.T) {
+	srv := testServer(t)
+
+	adminToken := bootstrapFirstUser(t, srv, "admin@test.com", "Admin")
+
+	// Admin creates their own workspace.
+	rr := doRequestWithCookie(srv, "POST", "/api/v1/workspaces", map[string]string{
+		"name": "Admin's Private Workspace",
+	}, adminToken)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create admin workspace: %d %s", rr.Code, rr.Body.String())
+	}
+	var adminWS models.Workspace
+	parseJSON(t, rr, &adminWS)
+
+	// Register Bob.
+	rr = doRequestWithCookie(srv, "POST", "/api/v1/auth/register", map[string]string{
+		"email":    "bob@test.com",
+		"name":     "Bob",
+		"password": "correct-horse-battery-staple",
+	}, adminToken)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("register bob: %d %s", rr.Code, rr.Body.String())
+	}
+
+	bobToken := loginUser(t, srv, "bob@test.com", "correct-horse-battery-staple")
+
+	// Bob has no workspaces.
+	rr = doRequestWithCookie(srv, "GET", "/api/v1/workspaces", nil, bobToken)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("bob list: %d %s", rr.Code, rr.Body.String())
+	}
+	var bobWorkspaces []models.Workspace
+	parseJSON(t, rr, &bobWorkspaces)
+	if containsWorkspace(bobWorkspaces, adminWS.ID) {
+		t.Fatal("bob (no membership) should not see admin's workspace")
+	}
+}
+
+func containsWorkspace(list []models.Workspace, id string) bool {
+	for _, ws := range list {
+		if ws.ID == id {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/store/workspace_members.go
+++ b/internal/store/workspace_members.go
@@ -383,6 +383,7 @@ func (s *Store) GetUserWorkspaces(userID string) ([]models.Workspace, error) {
 		ws.CreatedAt = parseTime(createdAt)
 		ws.UpdatedAt = parseTime(updatedAt)
 		ws.DeletedAt = parseTimePtr(deletedAt)
+		ws.HydrateDerivedFields()
 		result = append(result, ws)
 	}
 	if err := rows.Err(); err != nil {
@@ -436,6 +437,7 @@ func (s *Store) GetUserWorkspaces(userID string) ([]models.Workspace, error) {
 		ws.UpdatedAt = parseTime(updatedAt)
 		ws.DeletedAt = parseTimePtr(deletedAt)
 		ws.IsGuest = true
+		ws.HydrateDerivedFields()
 		result = append(result, ws)
 	}
 	if err := guestRows.Err(); err != nil {

--- a/internal/store/workspaces.go
+++ b/internal/store/workspaces.go
@@ -7,36 +7,18 @@ import (
 	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
+// ListWorkspaces returns every non-deleted workspace, unordered by user.
+// This is intended for admin-panel cross-tenant views and the
+// pre-auth/fresh-install bootstrap. End-user workspace switchers should
+// call GetUserWorkspaces instead, which scopes to the user's memberships.
 func (s *Store) ListWorkspaces() ([]models.Workspace, error) {
-	return s.ListWorkspacesForUser("")
-}
-
-// ListWorkspacesForUser returns all workspaces (admin view), with per-user
-// sort_order from workspace_members when userID is provided.
-func (s *Store) ListWorkspacesForUser(userID string) ([]models.Workspace, error) {
-	var rows *sql.Rows
-	var err error
-
-	if userID != "" {
-		rows, err = s.db.Query(s.q(`
-			SELECT w.id, w.name, w.slug, w.owner_id, COALESCE(ou.username, ''), w.description, w.settings, w.created_at, w.updated_at,
-			       COALESCE(wm.sort_order, 0)
-			FROM workspaces w
-			LEFT JOIN workspace_members wm ON wm.workspace_id = w.id AND wm.user_id = ?
-			LEFT JOIN users ou ON ou.id = w.owner_id
-			WHERE w.deleted_at IS NULL
-			ORDER BY COALESCE(wm.sort_order, 0) ASC, w.name ASC
-		`), userID)
-	} else {
-		rows, err = s.db.Query(s.q(`
-			SELECT w.id, w.name, w.slug, w.owner_id, COALESCE(ou.username, ''), w.description, w.settings, w.created_at, w.updated_at,
-			       0 as sort_order
-			FROM workspaces w
-			LEFT JOIN users ou ON ou.id = w.owner_id
-			WHERE w.deleted_at IS NULL
-			ORDER BY w.name ASC
-		`))
-	}
+	rows, err := s.db.Query(s.q(`
+		SELECT w.id, w.name, w.slug, w.owner_id, COALESCE(ou.username, ''), w.description, w.settings, w.created_at, w.updated_at
+		FROM workspaces w
+		LEFT JOIN users ou ON ou.id = w.owner_id
+		WHERE w.deleted_at IS NULL
+		ORDER BY w.name ASC
+	`))
 	if err != nil {
 		return nil, err
 	}
@@ -46,7 +28,7 @@ func (s *Store) ListWorkspacesForUser(userID string) ([]models.Workspace, error)
 	for rows.Next() {
 		var w models.Workspace
 		var createdAt, updatedAt string
-		if err := rows.Scan(&w.ID, &w.Name, &w.Slug, &w.OwnerID, &w.OwnerUsername, &w.Description, &w.Settings, &createdAt, &updatedAt, &w.SortOrder); err != nil {
+		if err := rows.Scan(&w.ID, &w.Name, &w.Slug, &w.OwnerID, &w.OwnerUsername, &w.Description, &w.Settings, &createdAt, &updatedAt); err != nil {
 			return nil, err
 		}
 		w.CreatedAt = parseTime(createdAt)


### PR DESCRIPTION
## Summary

- **BUG-982**: server admins saw every non-deleted workspace in their personal switcher (rendered as "shared with me" by the frontend) regardless of membership. Filed by the admin who noticed the leak; the underlying mechanism would have leaked workspace metadata to any future admin.
- Drops the admin special-case in \`handleListWorkspaces\` so admins go through \`GetUserWorkspaces\` like everyone else. Cross-tenant visibility for admins is still available via the admin-panel routes (\`/api/v1/admin/...\`) which call \`ListWorkspaces()\` directly with the appropriate auth gate.
- Drive-by cleanups: hydrate workspace context fields in \`GetUserWorkspaces\` (parity with prior admin behavior); delete the unused-after-this \`ListWorkspacesForUser\` store function whose name implied filtering it didn't perform — pure footgun for any future code that grepped by name.

### Out of scope (next Plan)

\`middleware_auth.go:449\` still grants server admins implicit \`owner\` role on every workspace they navigate to. This PR closes the **listing** leak. The deeper concern in BUG-982's body — that on pad-cloud, admin access to other tenants should require an explicit auditable escalation flow — gets its own Plan parented to PLAN-259 (Security Review).

## Test plan

- [x] New \`internal/server/handlers_workspaces_test.go\`:
  - \`TestListWorkspaces_AdminScopedToMembership\` — admin who isn't a member doesn't see Alice's workspace; adding admin as editor restores visibility
  - \`TestListWorkspaces_RegularUserScopedToMembership\` — confirms non-admin behavior unchanged
- [x] Both pass on SQLite (\`go test\`) and on real Postgres (\`make test-pg\`)
- [x] Full \`./internal/server\` and \`./internal/store\` suites stay green on both backends
- [x] \`make install\` clean; smoke against running server confirms admin's listing returns only their own workspaces (14 workspaces, all owned by admin in this single-user local setup)