### PR TITLE
feat(auth): expose mcp_public_url on /auth/session (TASK-1113)

### DIFF
--- a/internal/server/handlers_auth.go
+++ b/internal/server/handlers_auth.go
@@ -117,15 +117,22 @@ func (s *Server) setupStatePayload(setupMethod string) map[string]interface{} {
 		"setup_method":   setupMethod,
 		"auth_method":    authMethodPassword,
 		"cloud_mode":     s.cloudMode,
+		"mcp_public_url": s.mcpPublicURL,
 	}
 }
 
 func (s *Server) sessionStatePayload(authenticated bool, user *models.User) map[string]interface{} {
+	// mcp_public_url is the canonical URL clients paste into their MCP-capable
+	// agent (e.g. "https://mcp.getpad.dev"). Empty string when PAD_MCP_PUBLIC_URL
+	// is unset — the web UI uses presence/absence as the gate that drives the
+	// connect banner mode (Remote MCP vs CLI install). Always emitted, never
+	// omitted, so the frontend can rely on a string value.
 	payload := map[string]interface{}{
 		"authenticated":  authenticated,
 		"setup_required": false,
 		"auth_method":    authMethodPassword,
 		"cloud_mode":     s.cloudMode,
+		"mcp_public_url": s.mcpPublicURL,
 	}
 	if authenticated {
 		payload["user"] = sessionUserPayload(user)

--- a/internal/server/handlers_auth_test.go
+++ b/internal/server/handlers_auth_test.go
@@ -51,6 +51,14 @@ func TestAuthBootstrapFlow(t *testing.T) {
 	if _, ok := session["needs_setup"]; ok {
 		t.Error("did not expect deprecated needs_setup field")
 	}
+	// mcp_public_url is always present (even pre-setup) so the web UI can
+	// render the right onboarding flow before the first admin exists. Empty
+	// when PAD_MCP_PUBLIC_URL is unset (the default for this test server).
+	if got, ok := session["mcp_public_url"]; !ok {
+		t.Error("expected mcp_public_url field in setup-state session payload")
+	} else if got != "" {
+		t.Errorf("expected mcp_public_url='' when PAD_MCP_PUBLIC_URL unset, got %v", got)
+	}
 
 	token := bootstrapFirstUser(t, srv, "admin@test.com", "Admin")
 
@@ -72,6 +80,33 @@ func TestAuthBootstrapFlow(t *testing.T) {
 	}
 	if session["setup_required"] != false {
 		t.Errorf("expected setup_required=false after bootstrap, got %v", session["setup_required"])
+	}
+	if got, ok := session["mcp_public_url"]; !ok {
+		t.Error("expected mcp_public_url field in authenticated session payload")
+	} else if got != "" {
+		t.Errorf("expected mcp_public_url='' when PAD_MCP_PUBLIC_URL unset, got %v", got)
+	}
+}
+
+// When PAD_MCP_PUBLIC_URL is configured (e.g. on Pad Cloud), the
+// /auth/session response must echo the URL verbatim so the web UI can
+// gate the Remote-MCP connect banner on its presence.
+func TestAuthSessionEmitsMCPPublicURLWhenConfigured(t *testing.T) {
+	srv := testServer(t)
+	// Same-package access to the unexported field — equivalent to what
+	// SetMCPTransport sets at startup, but without spawning the audit
+	// writer goroutine that this test doesn't need.
+	srv.mcpPublicURL = "https://mcp.test.example"
+
+	rr := doRequest(srv, "GET", "/api/v1/auth/session", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("session check: expected 200, got %d", rr.Code)
+	}
+
+	var session map[string]interface{}
+	parseJSON(t, rr, &session)
+	if session["mcp_public_url"] != "https://mcp.test.example" {
+		t.Errorf("expected mcp_public_url='https://mcp.test.example', got %v", session["mcp_public_url"])
 	}
 }
 

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -126,6 +126,11 @@ export interface AuthSession {
 	setup_method?: 'local_cli' | 'docker_exec' | 'cloud';
 	auth_method: 'password' | 'cloud';
 	cloud_mode?: boolean;
+	// mcp_public_url is the canonical URL clients paste into their MCP-capable
+	// agent (e.g. "https://mcp.getpad.dev"). Empty string when PAD_MCP_PUBLIC_URL
+	// is unset on the server — UI code should use the empty string as the gate
+	// for "Remote MCP not exposed by this instance, fall back to CLI flow."
+	mcp_public_url: string;
 	user?: { id: string; email: string; username: string; name: string; role: string; plan?: string };
 }
 

--- a/web/src/lib/stores/auth.svelte.ts
+++ b/web/src/lib/stores/auth.svelte.ts
@@ -19,6 +19,11 @@ export const authStore = {
 	get userId() { return session?.user?.id ?? ''; },
 	get authenticated() { return session?.authenticated ?? false; },
 	get cloudMode() { return session?.cloud_mode ?? false; },
+	// mcpPublicUrl is the canonical URL clients paste into their MCP-capable
+	// agent. Empty string ('') when PAD_MCP_PUBLIC_URL is unset on the server.
+	// Components that conditionally render Remote-MCP onboarding UI should
+	// branch on `authStore.mcpPublicUrl !== ''`.
+	get mcpPublicUrl() { return session?.mcp_public_url ?? ''; },
 	get loading() { return loading; },
 
 	async load() {


### PR DESCRIPTION
## Summary

Adds `mcp_public_url` to the `/auth/session` response so the web UI knows whether this Pad instance exposes a Remote MCP server. Also adds the parallel `authStore.mcpPublicUrl` getter on the frontend.

Empty string when `PAD_MCP_PUBLIC_URL` is unset — never null, never absent — so consumers can rely on `mcpPublicUrl !== ''` as the "MCP available" gate.

## Context

Implements `TASK-1113` under `PLAN-1111` (Connect banner: Remote MCP for cloud workspaces). Unblocks `TASK-1114` (banner two-mode refactor), which branches on this field to decide whether to render the Remote-MCP onboarding banner or the existing CLI-install banner.

## Changes

- `internal/server/handlers_auth.go` — both `setupStatePayload` (pre-bootstrap) and `sessionStatePayload` (post-bootstrap) now emit `mcp_public_url` from `s.mcpPublicURL`
- `internal/server/handlers_auth_test.go` — assert `mcp_public_url` is present + empty when unset (both pre/post bootstrap), present + verbatim when configured
- `web/src/lib/api/client.ts` — `AuthSession.mcp_public_url: string` (required — server always emits it)
- `web/src/lib/stores/auth.svelte.ts` — new `mcpPublicUrl` getter mirroring the existing `cloudMode` pattern

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./internal/server/ -run TestAuthBootstrapFlow` — passes (now also asserts the new field)
- [x] `go test ./internal/server/ -run TestAuthSessionEmitsMCPPublicURLWhenConfigured` — new test passes
- [x] `make check` — clean (lint + tests + web build, 0 errors)
- [x] `cd web && npm run build` — clean

## Notes

- The task description listed `web/src/lib/types/index.ts` as the file to edit; the type actually lives in `web/src/lib/api/client.ts`. Edited there.
- New test directly sets `srv.mcpPublicURL` (same-package access) instead of calling `SetMCPTransport`, which would also spawn the audit-writer goroutine that this test doesn't need.