### PR TITLE
feat(dashboard): broaden agent-activity signal to include MCP source (TASK-1112)

### DIFF
--- a/internal/server/handlers_dashboard.go
+++ b/internal/server/handlers_dashboard.go
@@ -23,11 +23,14 @@ type DashboardResponse struct {
 	Attention      []DashboardAttention  `json:"attention"`
 	RecentActivity []DashboardActivity   `json:"recent_activity"`
 	SuggestedNext  []DashboardSuggestion `json:"suggested_next"`
-	// HasCLISource is true when any non-deleted item in the workspace was
-	// created via the CLI. Drives the "connect your local project" banner
-	// auto-hide — once true, the user is wired up and the banner stops
-	// nagging them on this workspace.
-	HasCLISource bool `json:"has_cli_source"`
+	// HasAgentActivity is true when any non-deleted item in the workspace
+	// was created via an agent surface — direct CLI or Remote MCP (both
+	// paths persist source='cli'; future MCP-distinct attribution would
+	// land as source='mcp', which the underlying query also matches).
+	// Drives the "connect an agent" banner auto-hide — once true, the
+	// workspace's agent loop is wired up and the banner stops nagging
+	// the user on this workspace.
+	HasAgentActivity bool `json:"has_agent_activity"`
 }
 
 type DashboardActiveItem struct {
@@ -287,17 +290,17 @@ func (s *Server) handleGetDashboard(w http.ResponseWriter, r *http.Request) {
 		SuggestedNext:  []DashboardSuggestion{},
 	}
 
-	// Cheap EXISTS query — drives the connect-CLI banner's auto-hide on the
-	// web side. Filtered by the same visibility set used elsewhere in this
-	// handler (dashCollIDs / dashItemIDs) so a guest can't infer the
-	// existence of CLI-sourced items in collections they don't have access
-	// to. See WorkspaceHasCLISource for the rationale.
-	hasCLI, err := s.store.WorkspaceHasCLISource(workspaceID, dashCollIDs, dashItemIDs)
+	// Cheap EXISTS query — drives the connect-agent banner's auto-hide on
+	// the web side. Filtered by the same visibility set used elsewhere in
+	// this handler (dashCollIDs / dashItemIDs) so a guest can't infer the
+	// existence of agent-sourced items in collections they don't have
+	// access to. See WorkspaceHasAgentActivity for the rationale.
+	hasAgent, err := s.store.WorkspaceHasAgentActivity(workspaceID, dashCollIDs, dashItemIDs)
 	if err != nil {
 		writeInternalError(w, err)
 		return
 	}
-	resp.HasCLISource = hasCLI
+	resp.HasAgentActivity = hasAgent
 
 	// Summary: items grouped by collection slug and status field
 	allItems, err := s.store.ListItems(workspaceID, models.ItemListParams{CollectionIDs: dashCollIDs, ItemIDs: dashItemIDs})

--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -270,7 +270,8 @@ func (s *Server) handleCreateItem(w http.ResponseWriter, r *http.Request) {
 	// reflects which client created it. Without this, items created via
 	// the CLI would persist as 'web' (the column default) since the CLI's
 	// ItemCreate body has no Source field set, and downstream signals like
-	// the dashboard's has_cli_source flag (TASK-862) would never flip on.
+	// the dashboard's has_agent_activity flag (TASK-862) would never flip
+	// on.
 	// If a client explicitly sent a source in the body (e.g. an agent
 	// marking itself as 'skill'), respect it.
 	if input.Source == "" {

--- a/internal/server/handlers_items_test.go
+++ b/internal/server/handlers_items_test.go
@@ -1037,7 +1037,7 @@ func TestItemCrossCollectionListing(t *testing.T) {
 // AFTER persisting (for SSE / activity logs). With the fix, the handler
 // now backfills input.Source from actorFromRequest before calling
 // store.CreateItem, so items created with a Bearer auth header land as
-// source='cli'. Without it, the dashboard's has_cli_source signal
+// source='cli'. Without it, the dashboard's has_agent_activity signal
 // (TASK-862) would never flip on for normal CLI usage.
 //
 // The bearer-auth test uses a real bootstrapped session token because

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -2105,10 +2105,20 @@ func (s *Store) GetDeletedItemsWithCollection(workspaceID string, itemIDs []stri
 	return results, rows.Err()
 }
 
-// WorkspaceHasCLISource reports whether any non-deleted item VISIBLE to the
-// caller was created via the CLI (source='cli'). Used by the dashboard to
-// auto-hide the "connect your local project" banner once a user has wired
-// up the CLI.
+// WorkspaceHasAgentActivity reports whether any non-deleted item VISIBLE
+// to the caller was created via an agent surface — direct CLI invocation
+// or the Remote MCP transport. Used by the dashboard to auto-hide the
+// "connect an agent" banner once a workspace's agent loop is wired up.
+//
+// "Agent activity" is the union of two source values:
+//
+//   - source='cli': set by both the direct `pad` CLI and the
+//     HTTPHandlerDispatcher used by the Remote MCP transport, which
+//     deliberately mirrors CLI attribution (see dispatch_http_test.go).
+//     Today, this single value covers both surfaces.
+//   - source='mcp': reserved for future code paths that may want to
+//     distinguish MCP attribution from CLI. Included here defensively so
+//     the query keeps working if attribution is later split.
 //
 // Visibility filtering matches the dashboard's existing model (see
 // handleGetDashboard): an item counts when its collection is in
@@ -2119,7 +2129,7 @@ func (s *Store) GetDeletedItemsWithCollection(workspaceID string, itemIDs []stri
 // returns false without hitting the DB — symmetric with ListItems.
 //
 // Backed by EXISTS so it short-circuits on the first match.
-func (s *Store) WorkspaceHasCLISource(workspaceID string, collectionIDs, itemIDs []string) (bool, error) {
+func (s *Store) WorkspaceHasAgentActivity(workspaceID string, collectionIDs, itemIDs []string) (bool, error) {
 	// Symmetric early-exit with ListItems: caller signaled no visibility.
 	if collectionIDs != nil && len(collectionIDs) == 0 && len(itemIDs) == 0 {
 		return false, nil
@@ -2128,7 +2138,7 @@ func (s *Store) WorkspaceHasCLISource(workspaceID string, collectionIDs, itemIDs
 	query := `
 		SELECT EXISTS(
 			SELECT 1 FROM items
-			WHERE workspace_id = ? AND source = 'cli' AND deleted_at IS NULL
+			WHERE workspace_id = ? AND source IN ('cli', 'mcp') AND deleted_at IS NULL
 	`
 	args := []interface{}{workspaceID}
 
@@ -2164,7 +2174,7 @@ func (s *Store) WorkspaceHasCLISource(workspaceID string, collectionIDs, itemIDs
 
 	var has bool
 	if err := s.db.QueryRow(s.q(query), args...).Scan(&has); err != nil {
-		return false, fmt.Errorf("workspace has cli source: %w", err)
+		return false, fmt.Errorf("workspace has agent activity: %w", err)
 	}
 	return has, nil
 }

--- a/internal/store/items_test.go
+++ b/internal/store/items_test.go
@@ -2218,21 +2218,21 @@ func TestItemVersionCreation(t *testing.T) {
 	}
 }
 
-func TestWorkspaceHasCLISource(t *testing.T) {
+func TestWorkspaceHasAgentActivity(t *testing.T) {
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Connect Banner")
 	col := createTestCollection(t, s, ws.ID, "Tasks")
 
 	// Empty workspace — false.
-	has, err := s.WorkspaceHasCLISource(ws.ID, nil, nil)
+	has, err := s.WorkspaceHasAgentActivity(ws.ID, nil, nil)
 	if err != nil {
-		t.Fatalf("WorkspaceHasCLISource: %v", err)
+		t.Fatalf("WorkspaceHasAgentActivity: %v", err)
 	}
 	if has {
 		t.Fatal("expected false on empty workspace")
 	}
 
-	// Non-cli items shouldn't flip it on.
+	// Non-agent items (web, skill) shouldn't flip it on.
 	for _, src := range []string{"web", "skill"} {
 		_, err := s.CreateItem(ws.ID, col.ID, models.ItemCreate{
 			Title:  fmt.Sprintf("From %s", src),
@@ -2243,9 +2243,9 @@ func TestWorkspaceHasCLISource(t *testing.T) {
 			t.Fatalf("create %s item: %v", src, err)
 		}
 	}
-	has, err = s.WorkspaceHasCLISource(ws.ID, nil, nil)
+	has, err = s.WorkspaceHasAgentActivity(ws.ID, nil, nil)
 	if err != nil {
-		t.Fatalf("WorkspaceHasCLISource (non-cli): %v", err)
+		t.Fatalf("WorkspaceHasAgentActivity (non-agent): %v", err)
 	}
 	if has {
 		t.Fatal("expected false when only web/skill items exist")
@@ -2260,9 +2260,9 @@ func TestWorkspaceHasCLISource(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create cli item: %v", err)
 	}
-	has, err = s.WorkspaceHasCLISource(ws.ID, nil, nil)
+	has, err = s.WorkspaceHasAgentActivity(ws.ID, nil, nil)
 	if err != nil {
-		t.Fatalf("WorkspaceHasCLISource (with cli): %v", err)
+		t.Fatalf("WorkspaceHasAgentActivity (with cli): %v", err)
 	}
 	if !has {
 		t.Fatal("expected true after a cli-sourced item exists")
@@ -2272,12 +2272,38 @@ func TestWorkspaceHasCLISource(t *testing.T) {
 	if err := s.DeleteItem(cliItem.ID); err != nil {
 		t.Fatalf("delete cli item: %v", err)
 	}
-	has, err = s.WorkspaceHasCLISource(ws.ID, nil, nil)
+	has, err = s.WorkspaceHasAgentActivity(ws.ID, nil, nil)
 	if err != nil {
-		t.Fatalf("WorkspaceHasCLISource (after delete): %v", err)
+		t.Fatalf("WorkspaceHasAgentActivity (after delete): %v", err)
 	}
 	if has {
 		t.Fatal("expected false after the only cli item was deleted")
+	}
+
+	// An item with source='mcp' (reserved for future MCP-distinct
+	// attribution — not currently emitted by any code path; today MCP
+	// activity persists as source='cli' per dispatch_http_test.go) should
+	// also flip the signal on, so the query stays correct if attribution
+	// is later split.
+	mcpItem, err := s.CreateItem(ws.ID, col.ID, models.ItemCreate{
+		Title:  "From MCP",
+		Fields: `{"status":"open"}`,
+		Source: "mcp",
+	})
+	if err != nil {
+		t.Fatalf("create mcp item: %v", err)
+	}
+	has, err = s.WorkspaceHasAgentActivity(ws.ID, nil, nil)
+	if err != nil {
+		t.Fatalf("WorkspaceHasAgentActivity (with mcp): %v", err)
+	}
+	if !has {
+		t.Fatal("expected true after a mcp-sourced item exists")
+	}
+	// Clean up so the workspace-isolation case below reflects only the
+	// other-ws CLI item it inserts.
+	if err := s.DeleteItem(mcpItem.ID); err != nil {
+		t.Fatalf("delete mcp item: %v", err)
 	}
 
 	// Workspace isolation — a cli item in another workspace must not leak.
@@ -2290,21 +2316,22 @@ func TestWorkspaceHasCLISource(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("create other-ws cli item: %v", err)
 	}
-	has, err = s.WorkspaceHasCLISource(ws.ID, nil, nil)
+	has, err = s.WorkspaceHasAgentActivity(ws.ID, nil, nil)
 	if err != nil {
-		t.Fatalf("WorkspaceHasCLISource (after other-ws cli): %v", err)
+		t.Fatalf("WorkspaceHasAgentActivity (after other-ws cli): %v", err)
 	}
 	if has {
 		t.Fatal("a cli item in a different workspace must not flip ours on")
 	}
 }
 
-// TestWorkspaceHasCLISourceVisibility covers the visibility filter so a
-// guest with restricted access can't infer the existence of CLI items in
-// collections they don't have visibility into. Codex flagged this as a
-// P2 leak during PR #284 review — without filtering, has_cli_source
-// reflected the whole workspace regardless of caller visibility.
-func TestWorkspaceHasCLISourceVisibility(t *testing.T) {
+// TestWorkspaceHasAgentActivityVisibility covers the visibility filter
+// so a guest with restricted access can't infer the existence of
+// agent-sourced items in collections they don't have visibility into.
+// Codex flagged this as a P2 leak during PR #284 review — without
+// filtering, has_agent_activity reflected the whole workspace regardless
+// of caller visibility.
+func TestWorkspaceHasAgentActivityVisibility(t *testing.T) {
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Visibility")
 	visibleColl := createTestCollection(t, s, ws.ID, "Visible")
@@ -2330,7 +2357,7 @@ func TestWorkspaceHasCLISourceVisibility(t *testing.T) {
 	}
 
 	// Unfiltered (full-visibility caller) sees the CLI item.
-	has, err := s.WorkspaceHasCLISource(ws.ID, nil, nil)
+	has, err := s.WorkspaceHasAgentActivity(ws.ID, nil, nil)
 	if err != nil {
 		t.Fatalf("unfiltered: %v", err)
 	}
@@ -2340,7 +2367,7 @@ func TestWorkspaceHasCLISourceVisibility(t *testing.T) {
 
 	// Caller with only the VISIBLE collection in scope must NOT see the
 	// CLI item that lives in a hidden collection.
-	has, err = s.WorkspaceHasCLISource(ws.ID, []string{visibleColl.ID}, nil)
+	has, err = s.WorkspaceHasAgentActivity(ws.ID, []string{visibleColl.ID}, nil)
 	if err != nil {
 		t.Fatalf("visible-coll only: %v", err)
 	}
@@ -2350,7 +2377,7 @@ func TestWorkspaceHasCLISourceVisibility(t *testing.T) {
 
 	// Item-level grant on the hidden CLI item should expose it via the
 	// guest-item path even when the collection isn't in scope.
-	has, err = s.WorkspaceHasCLISource(ws.ID, []string{visibleColl.ID}, []string{hiddenCLI.ID})
+	has, err = s.WorkspaceHasAgentActivity(ws.ID, []string{visibleColl.ID}, []string{hiddenCLI.ID})
 	if err != nil {
 		t.Fatalf("with item grant: %v", err)
 	}
@@ -2360,7 +2387,7 @@ func TestWorkspaceHasCLISourceVisibility(t *testing.T) {
 
 	// Non-nil empty collectionIDs + no item grants = no visibility =
 	// short-circuit false (matches ListItems' early-exit semantics).
-	has, err = s.WorkspaceHasCLISource(ws.ID, []string{}, nil)
+	has, err = s.WorkspaceHasAgentActivity(ws.ID, []string{}, nil)
 	if err != nil {
 		t.Fatalf("empty visibility: %v", err)
 	}

--- a/web/src/lib/components/ConnectBanner.svelte
+++ b/web/src/lib/components/ConnectBanner.svelte
@@ -12,9 +12,10 @@
 	let { wsSlug, serverUrl, workspaceName = '' }: Props = $props();
 
 	// `null` = unknown (still loading, banner stays hidden to avoid a flash);
-	// `true` = workspace already has at least one CLI-sourced item, auto-hide;
-	// `false` = no CLI source detected, show the banner.
-	let hasCliSource = $state<boolean | null>(null);
+	// `true` = workspace already has at least one agent-sourced item (CLI
+	//          or Remote MCP), auto-hide;
+	// `false` = no agent activity detected, show the banner.
+	let hasAgentActivity = $state<boolean | null>(null);
 	let dismissed = $state(false);
 	let connectOpen = $state(false);
 
@@ -33,8 +34,8 @@
 		}
 	});
 
-	// Fetch `has_cli_source` for a specific slug. Two safeguards against
-	// stale responses overwriting fresher ones:
+	// Fetch `has_agent_activity` for a specific slug. Two safeguards
+	// against stale responses overwriting fresher ones:
 	//
 	// 1. A monotonic sequence id captured at call time — only the LATEST
 	//    request's result is applied. This handles same-workspace races,
@@ -47,33 +48,33 @@
 	// Failures fall back to `false` (fail-open: better to show the banner
 	// than to hide it on a transient error).
 	let fetchSeq = 0;
-	function refreshHasCliSource(slug: string) {
+	function refreshHasAgentActivity(slug: string) {
 		if (!slug) return;
 		const mySeq = ++fetchSeq;
-		hasCliSource = null;
+		hasAgentActivity = null;
 		api.dashboard
 			.get(slug)
 			.then((d) => {
 				if (mySeq !== fetchSeq) return; // a newer request superseded us
 				if (slug !== wsSlug) return; // workspace changed under us
-				hasCliSource = d.has_cli_source;
+				hasAgentActivity = d.has_agent_activity;
 			})
 			.catch(() => {
 				if (mySeq !== fetchSeq) return;
 				if (slug !== wsSlug) return;
-				hasCliSource = false;
+				hasAgentActivity = false;
 			});
 	}
 
 	// Effect B — refetch on workspace change. Per CONVE-606, kept separate
 	// from the localStorage sync above.
 	$effect(() => {
-		refreshHasCliSource(wsSlug);
+		refreshHasAgentActivity(wsSlug);
 	});
 
 	// Effect C — refetch when the modal CLOSES. The user's most common
 	// flow is: see banner → open modal → copy command → run it in their
-	// terminal → close the modal. By that point a CLI-sourced item has
+	// terminal → close the modal. By that point an agent-sourced item has
 	// almost certainly landed; a fresh fetch makes the banner auto-hide
 	// in-session instead of waiting for a route change or page reload.
 	// `$effect.pre` + a tracked previous value matches the transition
@@ -84,13 +85,13 @@
 	let prevConnectOpen = $state(false);
 	$effect.pre(() => {
 		if (prevConnectOpen && !connectOpen) {
-			refreshHasCliSource(wsSlug);
+			refreshHasAgentActivity(wsSlug);
 		}
 		prevConnectOpen = connectOpen;
 	});
 
 	let visible = $derived(
-		!!wsSlug && !dismissed && hasCliSource === false && !connectOpen
+		!!wsSlug && !dismissed && hasAgentActivity === false && !connectOpen
 	);
 
 	function dismiss(event: MouseEvent) {

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -623,7 +623,12 @@ export interface DashboardResponse {
 		collection: string;
 		reason: string;
 	}[];
-	has_cli_source: boolean;
+	// has_agent_activity is true when any item in the workspace was created
+	// by an agent surface (CLI or Remote MCP — both persist source='cli'
+	// today; future MCP-distinct attribution lands as source='mcp', which
+	// the underlying store query also matches). Drives the connect-agent
+	// banner's auto-hide.
+	has_agent_activity: boolean;
 }
 
 // ─── Incremental Sync ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Renames `has_cli_source` to `has_agent_activity` across the stack and broadens the underlying SQL to match `source IN ('cli', 'mcp')`. Same banner-auto-hide behavior, more honest name, future-proof against MCP attribution being split out from CLI.

## Context

Implements `TASK-1112` under `PLAN-1111` (Connect banner: Remote MCP for cloud workspaces). Unblocks `TASK-1114` (banner two-mode refactor).

## Architectural finding (worth knowing)

Today, MCP-sourced items already persist as `source='cli'` — the `HTTPHandlerDispatcher` deliberately mirrors CLI attribution per `dispatch_http_test.go:821`'s contract. So the existing query was already covering the right rows; it was just badly named. This PR fixes the name and widens the SQL defensively against future attribution changes (no current code path writes `source='mcp'`).

## Changes

**Backend**
- `internal/store/items.go` — `WorkspaceHasCLISource` → `WorkspaceHasAgentActivity`; SQL: `source = 'cli'` → `source IN ('cli', 'mcp')`; doc-comment expanded to describe both surfaces
- `internal/server/handlers_dashboard.go` — `HasCLISource` field → `HasAgentActivity`; JSON tag `has_cli_source` → `has_agent_activity`; call site + comments updated
- `internal/server/handlers_items.go`, `handlers_items_test.go` — comment references updated
- `internal/store/items_test.go` — test functions renamed; new sub-case in `TestWorkspaceHasAgentActivity` asserts `source='mcp'` also flips the signal on

**Frontend**
- `web/src/lib/types/index.ts` — `has_cli_source: boolean` → `has_agent_activity: boolean` (with a doc comment)
- `web/src/lib/components/ConnectBanner.svelte` — local state `hasCliSource` → `hasAgentActivity`; fn `refreshHasCliSource` → `refreshHasAgentActivity`; comments updated. The `pad-cli-banner-dismissed-${wsSlug}` localStorage key is intentionally **left unchanged** in this PR — TASK-1114 owns the rename + soft-migration read of the old key

## Test plan

- [x] `make check` — clean (golangci-lint + go test ./... + svelte-check + npm run build), 0 errors
- [x] `go test ./internal/store/ -run TestWorkspaceHasAgentActivity` — passes (incl. new MCP source case)
- [x] `go test ./internal/store/ -run TestWorkspaceHasAgentActivityVisibility` — passes
- [x] `cd web && npm run build` — clean
- [x] Grepped for any leftover `has_cli_source` / `HasCLISource` / `hasCliSource` / `WorkspaceHasCLISource` / `refreshHasCliSource` — zero matches in `internal/`, `cmd/`, `web/src/`

## Notes

The TypeScript `DashboardData` field was already non-optional (`has_cli_source: boolean`); kept the same shape for `has_agent_activity`. The web build's `web/build/` artifacts contain the pre-rename code and will be regenerated on next `make build` — not regenerating in this PR keeps the diff focused on source.