### PR TITLE
feat(web): add ConnectMCPModal + wire into ConnectBanner (TASK-1115)

### DIFF
--- a/web/src/lib/components/ConnectBanner.svelte
+++ b/web/src/lib/components/ConnectBanner.svelte
@@ -98,24 +98,28 @@
 		refreshHasAgentActivity(wsSlug);
 	});
 
-	// Effect C — CLI mode only. Refetch when the modal CLOSES because the
-	// user's typical CLI flow is: see banner → open modal → copy command
-	// → run it in their terminal → close the modal. By that point an
+	// Effect C — refetch when the CLI modal CLOSES (regardless of banner
+	// mode). The user's typical CLI flow is: open modal → copy command →
+	// run it in their terminal → close the modal. By that point an
 	// agent-sourced item has almost certainly landed; the fresh fetch
 	// makes the banner auto-hide in-session instead of waiting for a
 	// route change.
 	//
-	// In MCP mode this refetch doesn't help: the user leaves the page
-	// entirely (off to Claude Desktop / Cursor / Windsurf to paste the
-	// URL and authorize). The first MCP-sourced item lands minutes later,
-	// after the user is gone — the SSE feed + workspace-change fetch
-	// (Effect B) catches it on the next visit.
-	let prevConnectOpen = $state(false);
+	// We gate on the CLI modal specifically (not `connectOpen`) because:
+	//
+	// - MCP modal close: the user has gone off to a separate agent client
+	//   (Claude Desktop / Cursor / Windsurf) to paste the URL — refetching
+	//   right now doesn't help; their first MCP-sourced item lands minutes
+	//   later via SSE / Effect B on the next visit.
+	// - CLI modal close in MCP mode: reachable via "Prefer the CLI? →" in
+	//   the MCP modal. If the user switched to CLI and ran the install,
+	//   the same refetch logic applies — refetching helps.
+	let prevCliOpen = $state(false);
 	$effect.pre(() => {
-		if (mode === 'cli' && prevConnectOpen && !connectOpen) {
+		if (prevCliOpen && !cliOpen) {
 			refreshHasAgentActivity(wsSlug);
 		}
-		prevConnectOpen = connectOpen;
+		prevCliOpen = cliOpen;
 	});
 
 	let visible = $derived(

--- a/web/src/lib/components/ConnectBanner.svelte
+++ b/web/src/lib/components/ConnectBanner.svelte
@@ -2,6 +2,7 @@
 	import { browser } from '$app/environment';
 	import { api } from '$lib/api/client';
 	import { authStore } from '$lib/stores/auth.svelte';
+	import ConnectMCPModal from './ConnectMCPModal.svelte';
 	import ConnectWorkspaceModal from './ConnectWorkspaceModal.svelte';
 
 	interface Props {
@@ -18,7 +19,13 @@
 	// `false` = no agent activity detected, show the banner.
 	let hasAgentActivity = $state<boolean | null>(null);
 	let dismissed = $state(false);
-	let connectOpen = $state(false);
+	// Two independent modal states because the user can flip between them
+	// via "Prefer the CLI? →" in the MCP modal — both can be closed, only
+	// one open at a time. The visibility predicate ORs both so the banner
+	// hides while either is mounted.
+	let mcpOpen = $state(false);
+	let cliOpen = $state(false);
+	let connectOpen = $derived(mcpOpen || cliOpen);
 
 	// Banner mode is gated on the server-exposed MCP public URL rather than
 	// `cloudMode` directly: it's true on Pad Cloud AND on any self-host that
@@ -112,17 +119,7 @@
 	});
 
 	let visible = $derived(
-		!!wsSlug &&
-			!dismissed &&
-			hasAgentActivity === false &&
-			!connectOpen &&
-			// Transitional gate (TASK-1114 → TASK-1115): the MCP-mode copy
-			// + CTA + icon are wired up below and ready to render, but the
-			// modal that the click should open (ConnectMCPModal) ships in
-			// TASK-1115. Showing the MCP banner now would promise "zero
-			// install" and route to the CLI flow — strictly worse than
-			// showing nothing. Removed when TASK-1115 mounts the new modal.
-			mode === 'cli'
+		!!wsSlug && !dismissed && hasAgentActivity === false && !connectOpen
 	);
 
 	function dismiss(event: MouseEvent) {
@@ -139,7 +136,18 @@
 	}
 
 	function openModal() {
-		connectOpen = true;
+		if (mode === 'mcp') {
+			mcpOpen = true;
+		} else {
+			cliOpen = true;
+		}
+	}
+
+	// Called from ConnectMCPModal when the user clicks "Prefer the CLI? →".
+	// The MCP modal closes itself before invoking this; we just open the
+	// CLI modal in response.
+	function switchMcpToCli() {
+		cliOpen = true;
 	}
 </script>
 
@@ -223,14 +231,24 @@
 {/if}
 
 <!--
-	ConnectWorkspaceModal is the CLI install flow. The MCP-mode banner
-	is suppressed entirely (see the `mode === 'cli'` clause in `visible`)
-	until TASK-1115 ships ConnectMCPModal.svelte — at which point the
-	gate is removed and the new modal mounts conditionally on
-	`mode === 'mcp'` here.
+	Both modals are always declared so a transient mode flip while the
+	user has one open doesn't unmount it mid-interaction. Each tracks an
+	independent `open` state; the parent's `connectOpen` derived value is
+	true while EITHER is open (so the banner hides during interaction).
+
+	The MCP modal's "Prefer the CLI? →" link calls `onSwitchToCli`, which
+	opens the CLI modal — the MCP modal closes itself first via its own
+	internal handler so the two never overlap visually.
 -->
+<ConnectMCPModal
+	bind:open={mcpOpen}
+	mcpPublicUrl={authStore.mcpPublicUrl}
+	{workspaceName}
+	onSwitchToCli={switchMcpToCli}
+/>
+
 <ConnectWorkspaceModal
-	bind:open={connectOpen}
+	bind:open={cliOpen}
 	{serverUrl}
 	workspaceSlug={wsSlug}
 	{workspaceName}

--- a/web/src/lib/components/ConnectMCPModal.svelte
+++ b/web/src/lib/components/ConnectMCPModal.svelte
@@ -1,0 +1,417 @@
+<script lang="ts">
+	import { toastStore } from '$lib/stores/toast.svelte';
+	import { copyToClipboard } from '$lib/utils/clipboard';
+
+	// Per-client setup metadata for the "choose your client" grid.
+	// Keep the entries in install-friction order (least → most setup).
+	// Subtitles are intentionally short — one descriptor each, no marketing.
+	// Doc URLs match the existing per-client pages on getpad.dev/docs/mcp.
+	const CLIENTS: { id: string; name: string; subtitle: string; href: string }[] = [
+		{
+			id: 'claude-desktop',
+			name: 'Claude Desktop',
+			subtitle: 'Web + Desktop',
+			href: 'https://getpad.dev/docs/mcp/claude-desktop'
+		},
+		{
+			id: 'cursor',
+			name: 'Cursor',
+			subtitle: 'AI code editor',
+			href: 'https://getpad.dev/docs/mcp/cursor'
+		},
+		{
+			id: 'windsurf',
+			name: 'Windsurf',
+			subtitle: 'AI code editor',
+			href: 'https://getpad.dev/docs/mcp/windsurf'
+		},
+		{
+			id: 'chatgpt',
+			name: 'ChatGPT',
+			subtitle: 'Connectors (Pro/Enterprise)',
+			href: 'https://getpad.dev/docs/mcp/chatgpt'
+		}
+	];
+
+	interface Props {
+		open: boolean;
+		// Required — the canonical URL the user pastes into their agent
+		// client. Sourced upstream from authStore.mcpPublicUrl so the modal
+		// works for any deployment that exposes a public MCP URL (Cloud or
+		// self-host with PAD_MCP_PUBLIC_URL set), not just Pad Cloud.
+		mcpPublicUrl: string;
+		workspaceName?: string;
+		// Optional — when present, footer renders a "Prefer the CLI? →"
+		// affordance that closes this modal and asks the parent to open
+		// the CLI install modal instead. Parent owns both modal states;
+		// this component never directly mounts ConnectWorkspaceModal.
+		onSwitchToCli?: () => void;
+	}
+
+	let {
+		open = $bindable(),
+		mcpPublicUrl,
+		workspaceName = '',
+		onSwitchToCli
+	}: Props = $props();
+
+	async function handleCopy() {
+		const success = await copyToClipboard(mcpPublicUrl);
+		if (success) {
+			toastStore.show('Copied to clipboard', 'success');
+		} else {
+			toastStore.show('Failed to copy', 'error');
+		}
+	}
+
+	function handleKeydown(e: KeyboardEvent) {
+		if (e.key === 'Escape' && open) {
+			open = false;
+		}
+	}
+
+	function switchToCli() {
+		open = false;
+		onSwitchToCli?.();
+	}
+
+	// Documentation link target. Until TASK-1117 ships getpad.dev/mcp/remote,
+	// fall back to the broader docs hub at /docs/mcp. Swap to /mcp/remote
+	// once that page lands.
+	const DOCS_HREF = 'https://getpad.dev/docs/mcp';
+	const CONNECTED_APPS_HREF = '/console/connected-apps';
+</script>
+
+<svelte:window onkeydown={handleKeydown} />
+
+{#if open}
+	<!-- svelte-ignore a11y_click_events_have_key_events -->
+	<!-- svelte-ignore a11y_no_static_element_interactions -->
+	<div class="overlay" onclick={() => (open = false)}>
+		<div class="modal" onclick={(e) => e.stopPropagation()}>
+			<div class="modal-header">
+				<h2>
+					{#if workspaceName}
+						Connect an AI agent to {workspaceName}
+					{:else}
+						Connect an AI agent to this workspace
+					{/if}
+				</h2>
+				<button class="close-btn" type="button" onclick={() => (open = false)}>&#10005;</button>
+			</div>
+
+			<div class="modal-body">
+				<p class="intro-copy">
+					Paste this URL into any MCP-capable AI client. Sign in with your Pad
+					account when prompted, and your agent can read and write everything
+					in this workspace through natural conversation.
+				</p>
+
+				<!-- Step 1 — Copy URL -->
+				<section class="step">
+					<span class="section-label">Step 1 — Copy this URL</span>
+
+					<div class="code-block">
+						<pre>{mcpPublicUrl}</pre>
+						<button
+							class="copy-btn-small"
+							type="button"
+							title="Copy URL"
+							onclick={handleCopy}
+						>
+							<svg
+								width="14"
+								height="14"
+								viewBox="0 0 24 24"
+								fill="none"
+								stroke="currentColor"
+								stroke-width="2"
+								stroke-linecap="round"
+								stroke-linejoin="round"
+							>
+								<rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+								<path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+							</svg>
+						</button>
+					</div>
+				</section>
+
+				<!-- Step 2 — Choose your client -->
+				<section class="step">
+					<span class="section-label">Step 2 — Set it up in your client</span>
+
+					<div class="client-grid">
+						{#each CLIENTS as client (client.id)}
+							<a
+								class="client-card"
+								href={client.href}
+								target="_blank"
+								rel="noopener noreferrer"
+							>
+								<div class="client-card-text">
+									<span class="client-name">{client.name}</span>
+									<span class="client-subtitle">{client.subtitle}</span>
+								</div>
+								<svg
+									class="client-arrow"
+									width="14"
+									height="14"
+									viewBox="0 0 24 24"
+									fill="none"
+									stroke="currentColor"
+									stroke-width="2"
+									stroke-linecap="round"
+									stroke-linejoin="round"
+									aria-hidden="true"
+								>
+									<path d="M7 17L17 7" />
+									<path d="M7 7h10v10" />
+								</svg>
+							</a>
+						{/each}
+					</div>
+				</section>
+
+				<!-- Footer links -->
+				<div class="modal-footer-links">
+					<a href={CONNECTED_APPS_HREF}>Connected agents</a>
+					<span class="footer-sep">&middot;</span>
+					<a href={DOCS_HREF} target="_blank" rel="noopener noreferrer">Documentation</a>
+					{#if onSwitchToCli}
+						<span class="footer-sep">&middot;</span>
+						<button class="footer-link-btn" type="button" onclick={switchToCli}>
+							Prefer the CLI? &rarr;
+						</button>
+					{/if}
+				</div>
+			</div>
+		</div>
+	</div>
+{/if}
+
+<style>
+	.overlay {
+		position: fixed;
+		inset: 0;
+		background: rgba(0, 0, 0, 0.5);
+		z-index: 50;
+		display: flex;
+		justify-content: center;
+		align-items: flex-start;
+		padding-top: 10vh;
+	}
+
+	.modal {
+		width: 100%;
+		max-width: 560px;
+		background: var(--bg-secondary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius-lg);
+		box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
+		overflow: hidden;
+		max-height: 85vh;
+		display: flex;
+		flex-direction: column;
+	}
+
+	.modal-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: var(--space-4) var(--space-5);
+		border-bottom: 1px solid var(--border);
+		flex-shrink: 0;
+	}
+
+	.modal-header h2 {
+		margin: 0;
+		font-size: 1.1em;
+		font-weight: 600;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.close-btn {
+		background: none;
+		border: none;
+		color: var(--text-muted);
+		font-size: 1em;
+		cursor: pointer;
+		padding: var(--space-1);
+		border-radius: var(--radius-sm);
+		line-height: 1;
+		flex-shrink: 0;
+	}
+
+	.close-btn:hover {
+		color: var(--text-primary);
+		background: var(--bg-hover);
+	}
+
+	.modal-body {
+		padding: var(--space-5);
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-5);
+		overflow-y: auto;
+	}
+
+	.intro-copy {
+		margin: 0;
+		font-size: 0.9em;
+		color: var(--text-secondary);
+		line-height: 1.5;
+	}
+
+	.section-label {
+		display: block;
+		font-size: 0.75em;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		color: var(--text-muted);
+		margin-bottom: var(--space-3);
+	}
+
+	.step {
+		display: flex;
+		flex-direction: column;
+	}
+
+	/* Code block — same shape as ConnectWorkspaceModal so the modals feel
+	   like siblings. Single-line URL gets the same padding + monospace
+	   treatment as the multi-line CLI install commands there. */
+	.code-block {
+		position: relative;
+		background: var(--bg-tertiary);
+		border-radius: var(--radius);
+		padding: var(--space-3) var(--space-9) var(--space-3) var(--space-3);
+		min-height: 0;
+	}
+
+	.code-block pre {
+		margin: 0;
+		font-family: var(--font-mono);
+		font-size: 0.82em;
+		color: var(--text-primary);
+		white-space: pre-wrap;
+		word-break: break-all;
+		line-height: 1.5;
+	}
+
+	.copy-btn-small {
+		position: absolute;
+		top: var(--space-2);
+		right: var(--space-2);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		background: none;
+		border: none;
+		color: var(--text-muted);
+		cursor: pointer;
+		padding: 4px;
+		border-radius: var(--radius-sm);
+		flex-shrink: 0;
+	}
+
+	.copy-btn-small:hover {
+		color: var(--accent-blue);
+		background: var(--bg-hover);
+	}
+
+	/* Client grid — 2-col on desktop, 1-col on narrow viewports. */
+	.client-grid {
+		display: grid;
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+		gap: var(--space-2);
+	}
+
+	.client-card {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: var(--space-2);
+		padding: var(--space-3);
+		background: var(--bg-tertiary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+		text-decoration: none;
+		color: inherit;
+		transition: border-color 0.15s, background 0.15s;
+	}
+
+	.client-card:hover {
+		border-color: var(--accent-blue);
+		background: color-mix(in srgb, var(--accent-blue) 4%, var(--bg-tertiary));
+	}
+
+	.client-card-text {
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+		min-width: 0;
+	}
+
+	.client-name {
+		font-size: 0.9em;
+		font-weight: 600;
+		color: var(--text-primary);
+	}
+
+	.client-subtitle {
+		font-size: 0.78em;
+		color: var(--text-muted);
+	}
+
+	.client-arrow {
+		color: var(--text-muted);
+		flex-shrink: 0;
+	}
+
+	.client-card:hover .client-arrow {
+		color: var(--accent-blue);
+	}
+
+	.modal-footer-links {
+		display: flex;
+		align-items: center;
+		flex-wrap: wrap;
+		gap: var(--space-2);
+		padding-top: var(--space-3);
+		border-top: 1px solid var(--border);
+		font-size: 0.82em;
+	}
+
+	.modal-footer-links a,
+	.modal-footer-links .footer-link-btn {
+		color: var(--text-muted);
+		text-decoration: none;
+		background: none;
+		border: none;
+		padding: 0;
+		font: inherit;
+		cursor: pointer;
+	}
+
+	.modal-footer-links a:hover,
+	.modal-footer-links .footer-link-btn:hover {
+		color: var(--accent-blue);
+		text-decoration: underline;
+	}
+
+	.footer-sep {
+		color: var(--border);
+	}
+
+	@media (max-width: 480px) {
+		.modal-header h2 {
+			white-space: normal;
+			font-size: 1em;
+		}
+		.client-grid {
+			grid-template-columns: 1fr;
+		}
+	}
+</style>


### PR DESCRIPTION
## Summary

Ships the Remote MCP onboarding modal. On any deployment that exposes a public MCP URL, the MCP-mode banner from #395 now opens a real modal showing the canonical URL + per-client setup links instead of falling back to the CLI install flow.

## Context

Implements `TASK-1115` under `PLAN-1111`. Depends on `TASK-1114` (banner two-mode refactor — shipped in #395).

## What ships

**`web/src/lib/components/ConnectMCPModal.svelte` (new)** — minimal layout per the plan:

- Header: "Connect an AI agent to {workspaceName}"
- Step 1: copy-URL block — value sourced from the `mcpPublicUrl` prop (upstream `authStore.mcpPublicUrl`), never hardcoded. Works for self-hosted deploys with `PAD_MCP_PUBLIC_URL` set, not just Pad Cloud.
- Step 2: 4 client cards (Claude Desktop, Cursor, Windsurf, ChatGPT) → each links to its existing `getpad.dev/docs/mcp/<client>` page
- Footer: Connected agents (in-app `/console/connected-apps`) · Documentation (`getpad.dev/docs/mcp` — fallback until TASK-1117 ships `/mcp/remote`) · "Prefer the CLI? →" (callback to parent)
- Escape + overlay click both close
- Mobile: client grid collapses to 1-col, header h2 wraps

**`web/src/lib/components/ConnectBanner.svelte`** — wires the new modal:

- Imports `ConnectMCPModal`
- Splits `connectOpen` into independent `mcpOpen` + `cliOpen` states; the parent's `connectOpen` becomes a `$derived` (mcpOpen || cliOpen) so the banner hides while either modal is open
- `openModal()` routes to the right modal based on `mode`
- New `switchMcpToCli()` callback handler — passed to `ConnectMCPModal` as `onSwitchToCli`. The MCP modal closes itself before invoking, so the two never overlap.
- The transitional `mode === 'cli'` visibility gate from TASK-1114 is removed — its reason for existing (no MCP modal) is gone.

## Test plan

- [x] `make check` — clean, 0 errors, 703 files (one more than before — confirms the new file is picked up)
- [x] Svelte MCP autofixer on new component — `issues: []` AND `suggestions: []` (zero of either)
- [x] Svelte MCP autofixer on updated banner — `issues: []`
- [x] Manual verification of the parent-owns-both-states pattern: clicking "Prefer the CLI? →" closes MCP modal AND opens CLI modal in one frame

## Notes

- Documentation link uses `getpad.dev/docs/mcp` as a temporary fallback. TASK-1117 ships `getpad.dev/mcp/remote` and at that point a one-line edit in this component swaps the `DOCS_HREF` constant.
- ConnectMCPModal does NOT directly mount ConnectWorkspaceModal — instead it emits a callback. This keeps modal-state ownership with the banner (single source of truth for "which modal, if any, is open").
- The CSS mirrors `ConnectWorkspaceModal`'s shape (overlay, modal frame, code-block, copy-btn, footer links) so the two modals feel like siblings.