### PR TITLE
chore(web): point ConnectMCPModal docs link at /mcp/remote (TASK-1117 follow-up)

### DIFF
--- a/web/src/lib/components/ConnectMCPModal.svelte
+++ b/web/src/lib/components/ConnectMCPModal.svelte
@@ -75,10 +75,10 @@
 		onSwitchToCli?.();
 	}
 
-	// Documentation link target. Until TASK-1117 ships getpad.dev/mcp/remote,
-	// fall back to the broader docs hub at /docs/mcp. Swap to /mcp/remote
-	// once that page lands.
-	const DOCS_HREF = 'https://getpad.dev/docs/mcp';
+	// Documentation link target. Lives at getpad.dev/mcp/remote since
+	// TASK-1117 (pad-web PR #80) — the canonical Remote MCP landing page,
+	// sibling to /mcp/local.
+	const DOCS_HREF = 'https://getpad.dev/mcp/remote';
 	const CONNECTED_APPS_HREF = '/console/connected-apps';
 </script>
 


### PR DESCRIPTION
## Summary

One-line companion to pad-web PR #80 (just merged). `ConnectMCPModal.svelte` had `DOCS_HREF` set to a temporary `getpad.dev/docs/mcp` fallback because the canonical landing didn't exist yet. With `/mcp/remote` now live as the proper sibling to `/mcp/local`, the modal points there.

## Context

TASK-1117 spawned a sister PR in pad-web (PerpetualSoftware/pad-web#80) that moved the docs landing to `/mcp/remote`. The previous URL `/docs/mcp` is no longer served — explicit owner waiver on the redirect (page was <24h old).

## Changes

- `web/src/lib/components/ConnectMCPModal.svelte` — `DOCS_HREF` from `https://getpad.dev/docs/mcp` → `https://getpad.dev/mcp/remote`. Comment updated to reflect current state instead of "TASK-1117 fallback."

## Test plan

- [x] `make check` — clean
- [x] No other consumers of the constant

## Notes

Tiny chore PR — closes the cross-repo loop opened when TASK-1115 (PR #396) shipped the modal with a TODO link target.