### PR TITLE
feat(metrics): MCP + OAuth observability metrics for /mcp (TASK-961)

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -5,6 +5,7 @@ package metrics
 
 import (
 	"database/sql"
+	"log/slog"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
@@ -25,6 +26,33 @@ type Metrics struct {
 	// EventBus metrics
 	EventBusPublishTotal *prometheus.Counter
 	EventBusSubscribers  *prometheus.Gauge
+
+	// MCP traffic metrics (PLAN-943 TASK-961). Wired from
+	// internal/server/middleware_mcp_audit.go (per-request seam) and
+	// internal/server/middleware_mcp_auth.go + middleware_auth.go
+	// (denial seams).
+	//
+	// Cardinality note for MCPToolCallsTotal: the user_id label is
+	// bounded by the cloud-deployment user count (target hundreds-to-
+	// low-thousands during alpha) and the tool label is bounded by the
+	// catalog (~7 tools today). 1000 users × 7 tools × 4 statuses =
+	// 28k series, well within Prometheus' comfort zone. If we ever
+	// open the surface to a much larger user set, drop the user_id
+	// label and lean on the audit log for per-user forensics — the
+	// audit row already carries that data without a series-explosion
+	// risk.
+	MCPToolCallsTotal    *prometheus.CounterVec
+	MCPToolCallDuration  *prometheus.HistogramVec
+	MCPAuthzDenialsTotal *prometheus.CounterVec
+	MCPActiveSessions    prometheus.Gauge
+
+	// OAuth flow metrics (PLAN-943 TASK-961). Wired from
+	// internal/server/handlers_oauth.go (per-handler seams) and
+	// internal/oauth/storage.go (revocation TTL observation).
+	OAuthFlowsTotal            *prometheus.CounterVec
+	OAuthFlowDuration          *prometheus.HistogramVec
+	OAuthTokenRevocationsTotal *prometheus.CounterVec
+	OAuthTokenTTLSeconds       prometheus.Histogram
 }
 
 // New creates a new Metrics instance with a custom registry and registers
@@ -68,6 +96,100 @@ func New() *Metrics {
 		Help: "Current number of event bus subscribers.",
 	})
 
+	// =====================================================================
+	// MCP traffic metrics (PLAN-943 TASK-961)
+	// =====================================================================
+
+	mcpToolCallsTotal := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "pad_mcp_tool_calls_total",
+		Help: "Total number of MCP tool-call requests by user, tool, and outcome status.",
+	}, []string{"user_id", "tool", "status"})
+
+	// Buckets target the latency spread we expect for MCP tool calls:
+	// trivial reads (pad_meta) settle in single-digit ms, item lookups
+	// in tens of ms, search / dashboard aggregations in hundreds of
+	// ms. The default Prometheus buckets bottom out at 5ms which is
+	// already too coarse for the fast path; this set adds 1ms and 2ms
+	// buckets so we can see the floor of cache-hit reads, and tops
+	// out at 30s to catch runaway dispatches without producing a
+	// useless +Inf-only signal.
+	mcpToolCallDuration := prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "pad_mcp_tool_call_duration_seconds",
+		Help:    "MCP tool-call duration in seconds by tool.",
+		Buckets: []float64{0.001, 0.002, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30},
+	}, []string{"tool"})
+
+	// reason vocabulary, populated from the documented seams:
+	//   - "audience_mismatch"          (middleware_mcp_auth.go)
+	//   - "rate_limited"               (middleware_mcp_audit.go emitMCPAuditDenied)
+	//   - "workspace_not_in_allowlist" (middleware_auth.go RequireWorkspaceAccess)
+	//   - "not_a_member"               (middleware_auth.go RequireWorkspaceAccess)
+	//   - "tier_mismatch"              (reserved; emitted when scope-policy denies an MCP-origin call)
+	mcpAuthzDenialsTotal := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "pad_mcp_authz_denials_total",
+		Help: "Total number of /mcp authorization denials by reason.",
+	}, []string{"reason"})
+
+	// mcp_active_sessions tracks Streamable HTTP sessions inferred
+	// from the JSON-RPC `initialize` method (open) and HTTP DELETE
+	// (close per MCP spec). Caveat: a session that drops without a
+	// DELETE (client crash, network blip) leaves the gauge inflated
+	// until the server restarts. Future work could add a TTL sweep
+	// keyed on session-id, but for v1 the simple +1/-1 signal is
+	// useful enough for alerting on anomalous session counts.
+	mcpActiveSessions := prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "pad_mcp_active_sessions",
+		Help: "Number of currently-open MCP Streamable HTTP sessions.",
+	})
+
+	// =====================================================================
+	// OAuth flow metrics (PLAN-943 TASK-961)
+	// =====================================================================
+
+	// stage vocabulary:
+	//   - "started"   — /oauth/authorize rendered the consent page
+	//   - "completed" — /oauth/authorize/decide approved
+	//   - "abandoned" — /oauth/authorize/decide denied
+	//   - "failed"    — error path in either /authorize or /authorize/decide
+	oauthFlowsTotal := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "pad_oauth_flows_total",
+		Help: "Total number of OAuth authorization flow events by stage.",
+	}, []string{"stage"})
+
+	// Per-handler durations let ops spot a slow consent render (DB
+	// lookups for the user's workspace list) vs a slow code-exchange
+	// (fosite signing + storage round-trip). Buckets mirror the MCP
+	// histogram for cross-comparison.
+	oauthFlowDuration := prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "pad_oauth_flow_duration_seconds",
+		Help:    "Duration of OAuth flow handlers in seconds by stage (authorize / decide / token / revoke).",
+		Buckets: []float64{0.001, 0.002, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30},
+	}, []string{"stage"})
+
+	// reason vocabulary:
+	//   - "user_initiated" — caller hit /oauth/revoke directly
+	//   - "rotated"        — refresh-token rotation revoked the parent family
+	//   - "replayed"       — replay-detection revoked the family
+	// The latter two emit from internal/oauth/storage.go via the
+	// OnTokenRevoked observer hook; reasons not yet wired stay zero
+	// until their seams are added.
+	oauthTokenRevocationsTotal := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "pad_oauth_token_revocations_total",
+		Help: "Total number of OAuth token revocations by reason.",
+	}, []string{"reason"})
+
+	// Token TTL ranges from "revoked seconds after issuance" (theft
+	// detection, accidental revoke) to "natural expiry at the issued
+	// lifetime" (typically ~1h for access tokens, ~30d for refresh).
+	// Buckets span sub-minute through 60d so the histogram captures
+	// both fast-revocation events and long-lived refresh-token
+	// lifetimes.
+	oauthTokenTTLSeconds := prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name:    "pad_oauth_token_ttl_seconds",
+		Help:    "Distribution of OAuth token lifetimes (issuance to revocation/expiry) in seconds.",
+		Buckets: []float64{10, 60, 300, 900, 3600, 21600, 86400, 7 * 86400, 30 * 86400, 60 * 86400},
+	})
+
 	reg.MustRegister(
 		httpRequestsTotal,
 		httpRequestDuration,
@@ -75,16 +197,32 @@ func New() *Metrics {
 		sseConnectionsActive,
 		eventBusPublishTotal,
 		eventBusSubscribers,
+		mcpToolCallsTotal,
+		mcpToolCallDuration,
+		mcpAuthzDenialsTotal,
+		mcpActiveSessions,
+		oauthFlowsTotal,
+		oauthFlowDuration,
+		oauthTokenRevocationsTotal,
+		oauthTokenTTLSeconds,
 	)
 
 	return &Metrics{
-		Registry:             reg,
-		HTTPRequestsTotal:    httpRequestsTotal,
-		HTTPRequestDuration:  httpRequestDuration,
-		HTTPResponseSize:     httpResponseSize,
-		SSEConnectionsActive: &sseConnectionsActive,
-		EventBusPublishTotal: &eventBusPublishTotal,
-		EventBusSubscribers:  &eventBusSubscribers,
+		Registry:                   reg,
+		HTTPRequestsTotal:          httpRequestsTotal,
+		HTTPRequestDuration:        httpRequestDuration,
+		HTTPResponseSize:           httpResponseSize,
+		SSEConnectionsActive:       &sseConnectionsActive,
+		EventBusPublishTotal:       &eventBusPublishTotal,
+		EventBusSubscribers:        &eventBusSubscribers,
+		MCPToolCallsTotal:          mcpToolCallsTotal,
+		MCPToolCallDuration:        mcpToolCallDuration,
+		MCPAuthzDenialsTotal:       mcpAuthzDenialsTotal,
+		MCPActiveSessions:          mcpActiveSessions,
+		OAuthFlowsTotal:            oauthFlowsTotal,
+		OAuthFlowDuration:          oauthFlowDuration,
+		OAuthTokenRevocationsTotal: oauthTokenRevocationsTotal,
+		OAuthTokenTTLSeconds:       oauthTokenTTLSeconds,
 	}
 }
 
@@ -144,4 +282,68 @@ func (c *dbStatsCollector) Collect(ch chan<- prometheus.Metric) {
 	ch <- prometheus.MustNewConstMetric(dbInUseDesc, prometheus.GaugeValue, float64(stats.InUse))
 	ch <- prometheus.MustNewConstMetric(dbWaitCountDesc, prometheus.CounterValue, float64(stats.WaitCount))
 	ch <- prometheus.MustNewConstMetric(dbWaitDurationDesc, prometheus.CounterValue, stats.WaitDuration.Seconds())
+}
+
+// =====================================================================
+// OAuth active-token gauge (PLAN-943 TASK-961)
+// =====================================================================
+
+// OAuthActiveTokensProvider returns the current count of active OAuth
+// access tokens. Implemented by *store.Store.CountActiveOAuthAccessTokens.
+//
+// Defined as a function-typed alias rather than an interface so cmd/pad
+// can wire a method value (no interface adapter ceremony) and tests can
+// pass a closure that returns a fixed number without needing a fake
+// store.
+type OAuthActiveTokensProvider func() (int64, error)
+
+// RegisterOAuthActiveTokensCollector exposes pad_oauth_active_tokens as
+// a callback-driven gauge. Pulled on every scrape — same pattern as the
+// db-stats collector — so the count is always fresh and we never spawn
+// a polling goroutine.
+//
+// Provider errors are logged and the sample is OMITTED for that scrape
+// (no metric emitted on the channel). Why not NewInvalidMetric: that
+// path makes Registry.Gather() return an error, which promhttp's
+// default handler turns into an HTTP 500 — failing the entire scrape
+// including every other metric on the registry. A transient SQLite
+// blip should drop ONE gauge for one scrape, not the whole observability
+// surface. Prometheus tolerates a missing series cleanly (renders as
+// a gap; alerting rules can use absent() or stale-for thresholds).
+//
+// Codex review on the TASK-961 PR caught the prior NewInvalidMetric
+// approach — original comment claimed Prometheus would drop the NaN,
+// but the actual behavior is whole-scrape failure.
+func (m *Metrics) RegisterOAuthActiveTokensCollector(provider OAuthActiveTokensProvider) {
+	if provider == nil {
+		return
+	}
+	m.Registry.MustRegister(&oauthActiveTokensCollector{provider: provider})
+}
+
+type oauthActiveTokensCollector struct {
+	provider OAuthActiveTokensProvider
+}
+
+var oauthActiveTokensDesc = prometheus.NewDesc(
+	"pad_oauth_active_tokens",
+	"Number of active (non-revoked, non-pruned) OAuth access tokens.",
+	nil, nil,
+)
+
+func (c *oauthActiveTokensCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- oauthActiveTokensDesc
+}
+
+func (c *oauthActiveTokensCollector) Collect(ch chan<- prometheus.Metric) {
+	count, err := c.provider()
+	if err != nil {
+		// Log + skip. Emitting NewInvalidMetric here would surface as
+		// an error from Registry.Gather() and fail the entire scrape
+		// via promhttp's default error handler — a single misbehaving
+		// store call must not take out every unrelated metric.
+		slog.Warn("oauth active-tokens collector: provider failed; skipping sample for this scrape", "error", err)
+		return
+	}
+	ch <- prometheus.MustNewConstMetric(oauthActiveTokensDesc, prometheus.GaugeValue, float64(count))
 }

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"database/sql"
+	"errors"
 	"strings"
 	"testing"
 
@@ -37,6 +38,32 @@ func TestNew(t *testing.T) {
 		t.Fatal("EventBusSubscribers should not be nil")
 	}
 
+	// TASK-961: MCP / OAuth metrics constructed alongside the others.
+	if m.MCPToolCallsTotal == nil {
+		t.Fatal("MCPToolCallsTotal should not be nil")
+	}
+	if m.MCPToolCallDuration == nil {
+		t.Fatal("MCPToolCallDuration should not be nil")
+	}
+	if m.MCPAuthzDenialsTotal == nil {
+		t.Fatal("MCPAuthzDenialsTotal should not be nil")
+	}
+	if m.MCPActiveSessions == nil {
+		t.Fatal("MCPActiveSessions should not be nil")
+	}
+	if m.OAuthFlowsTotal == nil {
+		t.Fatal("OAuthFlowsTotal should not be nil")
+	}
+	if m.OAuthFlowDuration == nil {
+		t.Fatal("OAuthFlowDuration should not be nil")
+	}
+	if m.OAuthTokenRevocationsTotal == nil {
+		t.Fatal("OAuthTokenRevocationsTotal should not be nil")
+	}
+	if m.OAuthTokenTTLSeconds == nil {
+		t.Fatal("OAuthTokenTTLSeconds should not be nil")
+	}
+
 	// Verify all metrics can be gathered without error
 	families, err := m.Registry.Gather()
 	if err != nil {
@@ -54,6 +81,268 @@ func TestNew(t *testing.T) {
 	if !found {
 		t.Fatal("Expected Go runtime metrics to be registered")
 	}
+}
+
+// TestMCPMetrics_IncrementsAndHistogramBuckets exercises the
+// MCP-side metrics surface end-to-end: each metric must accept
+// observations and return them through Gather. Verifies the
+// histogram bucket choices are sensible (a 100ms call should land
+// under the 250ms bucket).
+func TestMCPMetrics_IncrementsAndHistogramBuckets(t *testing.T) {
+	m := New()
+
+	m.MCPToolCallsTotal.WithLabelValues("user-1", "pad_item", "ok").Inc()
+	m.MCPToolCallsTotal.WithLabelValues("user-1", "pad_item", "ok").Inc()
+	m.MCPToolCallsTotal.WithLabelValues("user-2", "pad_search", "denied").Inc()
+
+	m.MCPToolCallDuration.WithLabelValues("pad_item").Observe(0.1)
+	m.MCPToolCallDuration.WithLabelValues("pad_item").Observe(2.0)
+
+	m.MCPAuthzDenialsTotal.WithLabelValues("audience_mismatch").Inc()
+	m.MCPAuthzDenialsTotal.WithLabelValues("rate_limited").Inc()
+
+	m.MCPActiveSessions.Inc()
+	m.MCPActiveSessions.Inc()
+	m.MCPActiveSessions.Dec()
+
+	families, err := m.Registry.Gather()
+	if err != nil {
+		t.Fatalf("Gather failed: %v", err)
+	}
+
+	expected := map[string]float64{
+		// counter sums
+		"pad_mcp_tool_calls_total":           3,
+		"pad_mcp_authz_denials_total":        2,
+		"pad_mcp_active_sessions":            1,
+		"pad_mcp_tool_call_duration_seconds": 2, // sample count
+	}
+	for _, f := range families {
+		want, ok := expected[f.GetName()]
+		if !ok {
+			continue
+		}
+		switch f.GetType() {
+		case io_prometheus_client.MetricType_COUNTER:
+			var sum float64
+			for _, m := range f.GetMetric() {
+				sum += m.GetCounter().GetValue()
+			}
+			if sum != want {
+				t.Errorf("counter %s: got %v, want %v", f.GetName(), sum, want)
+			}
+		case io_prometheus_client.MetricType_GAUGE:
+			var sum float64
+			for _, m := range f.GetMetric() {
+				sum += m.GetGauge().GetValue()
+			}
+			if sum != want {
+				t.Errorf("gauge %s: got %v, want %v", f.GetName(), sum, want)
+			}
+		case io_prometheus_client.MetricType_HISTOGRAM:
+			var samples uint64
+			for _, m := range f.GetMetric() {
+				samples += m.GetHistogram().GetSampleCount()
+			}
+			if float64(samples) != want {
+				t.Errorf("histogram %s sample count: got %v, want %v", f.GetName(), samples, want)
+			}
+		}
+		delete(expected, f.GetName())
+	}
+	for name := range expected {
+		t.Errorf("metric %s not found in gathered families", name)
+	}
+
+	// Bucket sanity: the 0.1s observation must land in the 0.25s bucket
+	// (or earlier). Walk the histogram metric to confirm.
+	for _, f := range families {
+		if f.GetName() != "pad_mcp_tool_call_duration_seconds" {
+			continue
+		}
+		for _, mm := range f.GetMetric() {
+			h := mm.GetHistogram()
+			var hit bool
+			for _, b := range h.GetBucket() {
+				if b.GetUpperBound() == 0.25 && b.GetCumulativeCount() >= 1 {
+					hit = true
+					break
+				}
+			}
+			if !hit {
+				t.Errorf("histogram bucket 0.25s should have observed the 0.1s sample (buckets: %+v)", h.GetBucket())
+			}
+		}
+	}
+}
+
+// TestOAuthMetrics_IncrementsAndHistogramBuckets mirrors the MCP test
+// for the OAuth-flow surface. Same shape, different metric set.
+func TestOAuthMetrics_IncrementsAndHistogramBuckets(t *testing.T) {
+	m := New()
+
+	m.OAuthFlowsTotal.WithLabelValues("started").Inc()
+	m.OAuthFlowsTotal.WithLabelValues("completed").Inc()
+	m.OAuthFlowsTotal.WithLabelValues("abandoned").Inc()
+
+	m.OAuthFlowDuration.WithLabelValues("authorize").Observe(0.05)
+	m.OAuthFlowDuration.WithLabelValues("token").Observe(0.2)
+
+	m.OAuthTokenRevocationsTotal.WithLabelValues("user_initiated").Inc()
+	m.OAuthTokenRevocationsTotal.WithLabelValues("rotated").Inc()
+
+	m.OAuthTokenTTLSeconds.Observe(3600) // 1h — natural-expiry
+	m.OAuthTokenTTLSeconds.Observe(45)   // sub-minute → caught by the 60s bucket
+
+	families, err := m.Registry.Gather()
+	if err != nil {
+		t.Fatalf("Gather failed: %v", err)
+	}
+
+	expected := map[string]float64{
+		"pad_oauth_flows_total":             3,
+		"pad_oauth_token_revocations_total": 2,
+		"pad_oauth_flow_duration_seconds":   2, // sample count
+		"pad_oauth_token_ttl_seconds":       2, // sample count
+	}
+	for _, f := range families {
+		want, ok := expected[f.GetName()]
+		if !ok {
+			continue
+		}
+		switch f.GetType() {
+		case io_prometheus_client.MetricType_COUNTER:
+			var sum float64
+			for _, mm := range f.GetMetric() {
+				sum += mm.GetCounter().GetValue()
+			}
+			if sum != want {
+				t.Errorf("counter %s: got %v, want %v", f.GetName(), sum, want)
+			}
+		case io_prometheus_client.MetricType_HISTOGRAM:
+			var samples uint64
+			for _, mm := range f.GetMetric() {
+				samples += mm.GetHistogram().GetSampleCount()
+			}
+			if float64(samples) != want {
+				t.Errorf("histogram %s sample count: got %v, want %v", f.GetName(), samples, want)
+			}
+		}
+		delete(expected, f.GetName())
+	}
+	for name := range expected {
+		t.Errorf("metric %s not found in gathered families", name)
+	}
+
+	// TTL bucket sanity: 60s bucket should have observed the 45s sample.
+	for _, f := range families {
+		if f.GetName() != "pad_oauth_token_ttl_seconds" {
+			continue
+		}
+		for _, mm := range f.GetMetric() {
+			h := mm.GetHistogram()
+			var hit bool
+			for _, b := range h.GetBucket() {
+				if b.GetUpperBound() == 60 && b.GetCumulativeCount() >= 1 {
+					hit = true
+					break
+				}
+			}
+			if !hit {
+				t.Errorf("histogram bucket 60s should have observed the 45s sample (buckets: %+v)", h.GetBucket())
+			}
+		}
+	}
+}
+
+// TestRegisterOAuthActiveTokensCollector verifies the callback-driven
+// gauge produces a fresh value on each Gather and survives provider
+// errors without panicking the registry.
+func TestRegisterOAuthActiveTokensCollector(t *testing.T) {
+	m := New()
+
+	var count int64 = 7
+	m.RegisterOAuthActiveTokensCollector(func() (int64, error) {
+		return count, nil
+	})
+
+	families, err := m.Registry.Gather()
+	if err != nil {
+		t.Fatalf("Gather failed: %v", err)
+	}
+	got := findGaugeValue(families, "pad_oauth_active_tokens")
+	if got != 7 {
+		t.Errorf("first scrape: got %v, want 7", got)
+	}
+
+	// Mutate the source — next scrape should reflect it.
+	count = 12
+	families, err = m.Registry.Gather()
+	if err != nil {
+		t.Fatalf("Gather failed: %v", err)
+	}
+	got = findGaugeValue(families, "pad_oauth_active_tokens")
+	if got != 12 {
+		t.Errorf("second scrape: got %v, want 12", got)
+	}
+
+	// Nil provider is a no-op (defensive: cmd/pad shouldn't pass nil
+	// but a future caller might).
+	m2 := New()
+	m2.RegisterOAuthActiveTokensCollector(nil)
+	if _, err := m2.Registry.Gather(); err != nil {
+		t.Fatalf("nil-provider Gather should not error: %v", err)
+	}
+}
+
+// TestRegisterOAuthActiveTokensCollector_ErrorIsScrapeSafe pins the
+// behavior Codex flagged on PR review: a provider error must NOT
+// fail Registry.Gather() (which would break the entire /metrics
+// scrape via promhttp's default handler). The contract is "skip
+// the sample, log the error, let every other metric through."
+func TestRegisterOAuthActiveTokensCollector_ErrorIsScrapeSafe(t *testing.T) {
+	m := New()
+	m.RegisterOAuthActiveTokensCollector(func() (int64, error) {
+		return 0, errors.New("simulated DB outage")
+	})
+
+	families, err := m.Registry.Gather()
+	if err != nil {
+		t.Fatalf("Gather must NOT propagate provider errors (would fail entire scrape): %v", err)
+	}
+
+	// The active-tokens series should be absent on this scrape.
+	if got := findGaugeValue(families, "pad_oauth_active_tokens"); got != -1 {
+		t.Errorf("on provider error: expected metric absent (sentinel -1), got %v", got)
+	}
+
+	// Other metrics (e.g. Go runtime) MUST still be present — this is
+	// the whole point of skipping rather than NewInvalidMetric'ing.
+	var sawGoMetric bool
+	for _, f := range families {
+		if strings.HasPrefix(f.GetName(), "go_") {
+			sawGoMetric = true
+			break
+		}
+	}
+	if !sawGoMetric {
+		t.Error("provider error should not suppress unrelated metrics")
+	}
+}
+
+// findGaugeValue is a small lookup helper for the OAuth active-tokens
+// test. Returns -1 when the metric isn't present so callers can spot
+// "missing" distinct from "zero."
+func findGaugeValue(families []*io_prometheus_client.MetricFamily, name string) float64 {
+	for _, f := range families {
+		if f.GetName() != name {
+			continue
+		}
+		for _, m := range f.GetMetric() {
+			return m.GetGauge().GetValue()
+		}
+	}
+	return -1
 }
 
 func TestRegisterDBCollector(t *testing.T) {

--- a/internal/oauth/server_test.go
+++ b/internal/oauth/server_test.go
@@ -769,6 +769,156 @@ func TestStorage_RequesterToOAuthRequest_RejectsMissingClient(t *testing.T) {
 }
 
 // =====================================================================
+// Revocation observer (PLAN-943 TASK-961)
+// =====================================================================
+
+// TestStorage_RevocationObserver_FiresOnAccessTokenRevoke pins the
+// contract metrics depend on: when fosite calls RevokeAccessToken on
+// our adapter, the configured observer fires with kind="user_initiated"
+// and a positive TTL derived from the revoked family's oldest
+// requested_at.
+func TestStorage_RevocationObserver_FiresOnAccessTokenRevoke(t *testing.T) {
+	s := testStoreOAuth(t)
+
+	// Seed a client + access token row with a known issuance time.
+	c, err := s.CreateOAuthClient(models.OAuthClientCreate{
+		Name:                    "Test",
+		RedirectURIs:            []string{"https://example.test/cb"},
+		GrantTypes:              []string{"authorization_code"},
+		ResponseTypes:           []string{"code"},
+		TokenEndpointAuthMethod: "none",
+		Scopes:                  []string{"pad:read"},
+		Public:                  true,
+	})
+	if err != nil {
+		t.Fatalf("CreateOAuthClient: %v", err)
+	}
+
+	issuedAt := time.Now().UTC().Add(-30 * time.Minute).Truncate(time.Second)
+	if err := s.CreateAccessToken(models.OAuthRequest{
+		Signature:   "sig-1",
+		RequestID:   "req-1",
+		RequestedAt: issuedAt,
+		ClientID:    c.ID,
+		Scopes:      "pad:read",
+		Audience:    "https://mcp.test.example/mcp",
+		Active:      true,
+		Subject:     "user-x",
+	}); err != nil {
+		t.Fatalf("CreateAccessToken: %v", err)
+	}
+
+	storage := NewStorage(s, "https://mcp.test.example/mcp")
+
+	var (
+		gotKind string
+		gotTTL  time.Duration
+		fired   int
+	)
+	storage.SetRevocationObserver(func(kind string, ttl time.Duration) {
+		fired++
+		gotKind = kind
+		gotTTL = ttl
+	})
+
+	if err := storage.RevokeAccessToken(context.Background(), "req-1"); err != nil {
+		t.Fatalf("RevokeAccessToken: %v", err)
+	}
+
+	if fired != 1 {
+		t.Errorf("observer fired %d times, want 1", fired)
+	}
+	if gotKind != "user_initiated" {
+		t.Errorf("kind: got %q, want %q", gotKind, "user_initiated")
+	}
+	// TTL should be ~30 minutes (allow generous slack for slow CI +
+	// timestamp truncation).
+	if gotTTL < 25*time.Minute || gotTTL > 35*time.Minute {
+		t.Errorf("ttl: got %v, want ~30m", gotTTL)
+	}
+}
+
+// TestStorage_RevocationObserver_FiresOnRotation covers the second
+// emit path: fosite's RotateRefreshToken (called during /oauth/token
+// refresh exchange) revokes the parent family and our adapter must
+// signal that with kind="rotated".
+func TestStorage_RevocationObserver_FiresOnRotation(t *testing.T) {
+	s := testStoreOAuth(t)
+
+	c, err := s.CreateOAuthClient(models.OAuthClientCreate{
+		Name:                    "Test",
+		RedirectURIs:            []string{"https://example.test/cb"},
+		GrantTypes:              []string{"authorization_code", "refresh_token"},
+		ResponseTypes:           []string{"code"},
+		TokenEndpointAuthMethod: "none",
+		Scopes:                  []string{"pad:read"},
+		Public:                  true,
+	})
+	if err != nil {
+		t.Fatalf("CreateOAuthClient: %v", err)
+	}
+
+	issuedAt := time.Now().UTC().Add(-5 * time.Minute).Truncate(time.Second)
+	if err := s.CreateAccessToken(models.OAuthRequest{
+		Signature: "acc-1", RequestID: "fam-1", RequestedAt: issuedAt,
+		ClientID: c.ID, Audience: "https://mcp.test.example/mcp", Active: true,
+	}); err != nil {
+		t.Fatalf("CreateAccessToken: %v", err)
+	}
+	if err := s.CreateRefreshToken(models.OAuthRequest{
+		Signature: "ref-1", RequestID: "fam-1", RequestedAt: issuedAt,
+		ClientID: c.ID, Audience: "https://mcp.test.example/mcp", Active: true,
+	}); err != nil {
+		t.Fatalf("CreateRefreshToken: %v", err)
+	}
+
+	storage := NewStorage(s, "https://mcp.test.example/mcp")
+	var observed []string
+	storage.SetRevocationObserver(func(kind string, _ time.Duration) {
+		observed = append(observed, kind)
+	})
+
+	if err := storage.RotateRefreshToken(context.Background(), "fam-1", "ref-1"); err != nil {
+		t.Fatalf("RotateRefreshToken: %v", err)
+	}
+
+	if len(observed) != 1 || observed[0] != "rotated" {
+		t.Errorf("observer kinds: got %v, want [rotated]", observed)
+	}
+}
+
+// TestStorage_RevocationObserver_NilSafe verifies that an unset
+// observer is a no-op — callers shouldn't have to wire one to use
+// the storage adapter (selfhost / tests / non-metrics builds).
+func TestStorage_RevocationObserver_NilSafe(t *testing.T) {
+	s := testStoreOAuth(t)
+	c, err := s.CreateOAuthClient(models.OAuthClientCreate{
+		Name:                    "Test",
+		RedirectURIs:            []string{"https://example.test/cb"},
+		GrantTypes:              []string{"authorization_code"},
+		ResponseTypes:           []string{"code"},
+		TokenEndpointAuthMethod: "none",
+		Scopes:                  []string{"pad:read"},
+		Public:                  true,
+	})
+	if err != nil {
+		t.Fatalf("CreateOAuthClient: %v", err)
+	}
+	if err := s.CreateAccessToken(models.OAuthRequest{
+		Signature: "sig-1", RequestID: "req-1", RequestedAt: time.Now().UTC(),
+		ClientID: c.ID, Audience: "https://mcp.test.example/mcp", Active: true,
+	}); err != nil {
+		t.Fatalf("CreateAccessToken: %v", err)
+	}
+
+	storage := NewStorage(s, "https://mcp.test.example/mcp")
+	// No SetRevocationObserver call — should not panic.
+	if err := storage.RevokeAccessToken(context.Background(), "req-1"); err != nil {
+		t.Fatalf("RevokeAccessToken (no observer): %v", err)
+	}
+}
+
+// =====================================================================
 // Helpers
 // =====================================================================
 

--- a/internal/oauth/storage.go
+++ b/internal/oauth/storage.go
@@ -51,6 +51,62 @@ import (
 type Storage struct {
 	store             *store.Store
 	canonicalAudience string
+
+	// onTokenRevoked is an optional observer that fires AFTER each
+	// successful access-token family revocation. Wired by cmd/pad
+	// from internal/metrics so the OAuth surface stays metrics-naive
+	// (no Prometheus import in this package).
+	//
+	// kind is one of:
+	//   - "user_initiated" — caller hit /oauth/revoke
+	//   - "rotated"        — refresh-rotation revoked the parent family
+	//   - "replayed"       — replay-detection (refresh used twice)
+	//
+	// ttl is wall-clock age of the oldest token in the revoked family.
+	// Zero when the lookup couldn't determine an issuance time (no
+	// rows, parse failure) — observers should treat zero as "no
+	// observation to record."
+	//
+	// Best-effort: failures from the lookup or the observer must not
+	// block revocation. The store's revoke-then-observe ordering means
+	// the on-disk state is correct even if we crash mid-observation.
+	onTokenRevoked func(kind string, ttl time.Duration)
+}
+
+// SetRevocationObserver wires a callback that fires after each
+// access-token family revocation. Optional — leaving it unset is
+// equivalent to wiring a no-op. Replacing a previously-set observer
+// is allowed; cmd/pad calls this once at startup. Concurrent calls
+// to SetRevocationObserver during traffic are not synchronized —
+// callers responsible for one-shot wiring before serving requests.
+func (s *Storage) SetRevocationObserver(fn func(kind string, ttl time.Duration)) {
+	s.onTokenRevoked = fn
+}
+
+// observeRevocation looks up the oldest active-token issuance time
+// for the family and fires the configured observer. Always called
+// AFTER the family has been flagged inactive in storage so a slow
+// observer never blocks revocation latency.
+func (s *Storage) observeRevocation(requestID, kind string) {
+	if s.onTokenRevoked == nil {
+		return
+	}
+	issuedAt, err := s.store.OldestAccessTokenIssuedAtByRequestID(requestID)
+	if err != nil || issuedAt.IsZero() {
+		// No matching family (already pruned), parse failure, or
+		// transient store error — record nothing rather than emit a
+		// bogus zero/negative duration. Observability noise is worse
+		// than a missed datapoint.
+		return
+	}
+	ttl := time.Since(issuedAt)
+	if ttl < 0 {
+		// Clock skew between issuance and revocation — clamp to zero
+		// rather than poison the histogram with negative observations
+		// (Prometheus accepts them but the bucket math is meaningless).
+		ttl = 0
+	}
+	s.onTokenRevoked(kind, ttl)
 }
 
 // NewStorage wraps a *store.Store as a fosite-compatible adapter.
@@ -283,7 +339,14 @@ func (s *Storage) DeleteRefreshTokenSession(_ context.Context, signature string)
 // signatureToRotate is fosite's hint about which row triggered the
 // rotation; the store layer ignores it and revokes by request_id.
 func (s *Storage) RotateRefreshToken(_ context.Context, requestID, signatureToRotate string) error {
-	return s.store.RotateRefreshToken(requestID, signatureToRotate)
+	if err := s.store.RotateRefreshToken(requestID, signatureToRotate); err != nil {
+		return err
+	}
+	// TASK-961: report rotation-induced revocation to the observability
+	// hook. Distinct kind label so dashboards can separate "user clicked
+	// revoke" from "client refreshed and we naturally rolled the family."
+	s.observeRevocation(requestID, "rotated")
+	return nil
 }
 
 // =====================================================================
@@ -294,6 +357,12 @@ func (s *Storage) RotateRefreshToken(_ context.Context, requestID, signatureToRo
 // given requestID and marks every one inactive. Called by fosite's
 // /oauth/revoke handler (sub-PR D wires the endpoint) and by the
 // rotation flow's replay-detection branch.
+//
+// No metrics observation here: when fosite revokes a grant family
+// from /oauth/revoke or replay-detection, it pairs RevokeRefreshToken
+// with RevokeAccessToken — emitting from both would double-count.
+// We let the access-side emitter own the reporting and keep this
+// path lean.
 func (s *Storage) RevokeRefreshToken(_ context.Context, requestID string) error {
 	return s.store.RevokeRefreshTokenFamily(requestID)
 }
@@ -301,8 +370,21 @@ func (s *Storage) RevokeRefreshToken(_ context.Context, requestID string) error 
 // RevokeAccessToken mirrors RevokeRefreshToken for access tokens.
 // fosite calls these in pairs when revoking a grant (the unified
 // "revoke the whole family" behaviour).
+//
+// TASK-961: emits an observability signal AFTER the family is
+// flagged inactive in storage. The default kind here is
+// "user_initiated" because /oauth/revoke is the dominant caller —
+// fosite's replay-detection path also routes through this method,
+// so the label is best-effort rather than ground truth (Codex
+// could later differentiate via a context-carried hint, but the
+// gross signal "tokens are getting revoked" matters more than the
+// per-cause split for v1 alerting).
 func (s *Storage) RevokeAccessToken(_ context.Context, requestID string) error {
-	return s.store.RevokeAccessTokenFamily(requestID)
+	if err := s.store.RevokeAccessTokenFamily(requestID); err != nil {
+		return err
+	}
+	s.observeRevocation(requestID, "user_initiated")
+	return nil
 }
 
 // =====================================================================

--- a/internal/server/handlers_oauth.go
+++ b/internal/server/handlers_oauth.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/ory/fosite"
 
@@ -69,8 +70,14 @@ import (
 // Like SetMCPTransport, this MUST be called before setupRouter
 // runs (which it does on first request). Calling it later is a
 // no-op because chi routes are immutable post-mount.
+//
+// Side effect (TASK-961): triggers wireOAuthMetricsObserver, which
+// attaches the OAuth-specific Prometheus collectors when metrics
+// are also wired. Order-independent — safe to call before or after
+// SetMetrics; wireOAuthMetricsObserver no-ops until both are present.
 func (s *Server) SetOAuthServer(srv *oauth.Server) {
 	s.oauthServer = srv
+	s.wireOAuthMetricsObserver()
 }
 
 // registerOAuthRoutes mounts the OAuth endpoints on r. Called from
@@ -81,6 +88,28 @@ func (s *Server) SetOAuthServer(srv *oauth.Server) {
 //
 // The discovery document at /.well-known/oauth-authorization-server
 // continues to be served by registerMCPRoutes — it lives there
+// recordOAuthFlow bumps the pad_oauth_flows_total counter with the
+// supplied stage label. No-op when metrics aren't wired (selfhost /
+// tests). Stage vocabulary documented at MCP-961's metric registration
+// site (internal/metrics/metrics.go).
+func (s *Server) recordOAuthFlow(stage string) {
+	if s.metrics == nil {
+		return
+	}
+	s.metrics.OAuthFlowsTotal.WithLabelValues(stage).Inc()
+}
+
+// observeOAuthFlowDuration records the elapsed time since `start` for
+// the given stage. Designed to be `defer`'d at the top of each OAuth
+// flow handler so every exit path — happy or error — gets observed.
+// No-op when metrics aren't wired.
+func (s *Server) observeOAuthFlowDuration(stage string, start time.Time) {
+	if s.metrics == nil {
+		return
+	}
+	s.metrics.OAuthFlowDuration.WithLabelValues(stage).Observe(time.Since(start).Seconds())
+}
+
 // because it was the 501 stub from TASK-950, and replacing it in
 // place keeps the URL stable for clients that already discovered
 // the chain. The OAuth-server routes added here are the four flow
@@ -487,6 +516,14 @@ func translateResourceToAudience(r *http.Request, canonical string) {
 //   - canonical-audience mismatch: surfaced via fosite's
 //     audienceMatchingStrategy → invalid_request.
 func (s *Server) handleOAuthAuthorize(w http.ResponseWriter, r *http.Request) {
+	// TASK-961: wrap the whole handler in a duration timer so the
+	// histogram captures every exit path (404, parse error, login
+	// redirect, consent render). Stage-counter emission is per-branch
+	// because "started" only fires when consent actually renders;
+	// login redirects are pre-flow and shouldn't count as starts.
+	start := time.Now()
+	defer s.observeOAuthFlowDuration("authorize", start)
+
 	if !s.IsCloud() || s.oauthServer == nil {
 		http.NotFound(w, r)
 		return
@@ -504,6 +541,10 @@ func (s *Server) handleOAuthAuthorize(w http.ResponseWriter, r *http.Request) {
 
 	ar, err := s.oauthServer.Provider().NewAuthorizeRequest(ctx, r)
 	if err != nil {
+		// TASK-961: malformed authorize request (bad client_id, missing
+		// redirect_uri, audience mismatch). Counts as "failed" — these
+		// never reach a consent screen so they're not "started" either.
+		s.recordOAuthFlow("failed")
 		s.oauthServer.Provider().WriteAuthorizeError(ctx, w, ar, err)
 		return
 	}
@@ -518,6 +559,11 @@ func (s *Server) handleOAuthAuthorize(w http.ResponseWriter, r *http.Request) {
 		// The login page (web/src/routes/login/+page.svelte) +
 		// pad-cloud's OAuth callback (TASK-998) honor `redirect=`
 		// for relative paths.
+		//
+		// Intentionally NOT counted as "started" — the user might
+		// abandon at the login screen. The flow only truly begins
+		// once they reach (and render) the consent page on the
+		// post-login round-trip.
 		dest := "/oauth/authorize"
 		if r.URL.RawQuery != "" {
 			dest += "?" + r.URL.RawQuery
@@ -526,6 +572,13 @@ func (s *Server) handleOAuthAuthorize(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, loginURL, http.StatusFound)
 		return
 	}
+
+	// TASK-961: consent render is the canonical "flow started" signal —
+	// the user has identified themselves AND fosite has accepted the
+	// authorize request. From here the only outcomes are
+	// completed/abandoned (via /authorize/decide) or silent abandon
+	// (close the tab — invisible to us, an expected gap).
+	s.recordOAuthFlow("started")
 
 	// Render the consent UI (TASK-952). Loads the user's workspaces
 	// + filters tier radios to the intersection of {pad:read,
@@ -572,6 +625,11 @@ func (s *Server) handleOAuthAuthorize(w http.ResponseWriter, r *http.Request) {
 //  5. NewAuthorizeResponse persists the request + session and
 //     redirects to the client's redirect_uri with the auth code.
 func (s *Server) handleOAuthAuthorizeDecide(w http.ResponseWriter, r *http.Request) {
+	// TASK-961: per-handler duration for the decide stage. Stage
+	// counter emits per-branch below: completed / abandoned / failed.
+	start := time.Now()
+	defer s.observeOAuthFlowDuration("decide", start)
+
 	if !s.IsCloud() || s.oauthServer == nil {
 		http.NotFound(w, r)
 		return
@@ -589,6 +647,7 @@ func (s *Server) handleOAuthAuthorizeDecide(w http.ResponseWriter, r *http.Reque
 	}
 
 	if err := r.ParseForm(); err != nil {
+		s.recordOAuthFlow("failed")
 		http.Error(w, "Invalid form body", http.StatusBadRequest)
 		return
 	}
@@ -598,6 +657,7 @@ func (s *Server) handleOAuthAuthorizeDecide(w http.ResponseWriter, r *http.Reque
 	// hidden form input rather than a header (consent is server-
 	// rendered HTML, not SPA fetch).
 	if err := s.validateConsentCSRFToken(r); err != nil {
+		s.recordOAuthFlow("failed")
 		writeError(w, http.StatusForbidden, "csrf_error", err.Error())
 		return
 	}
@@ -608,17 +668,24 @@ func (s *Server) handleOAuthAuthorizeDecide(w http.ResponseWriter, r *http.Reque
 	ctx := r.Context()
 	ar, err := s.oauthServer.Provider().NewAuthorizeRequest(ctx, r)
 	if err != nil {
+		s.recordOAuthFlow("failed")
 		s.oauthServer.Provider().WriteAuthorizeError(ctx, w, ar, err)
 		return
 	}
 
 	decision := r.FormValue("decision")
 	if decision == "deny" {
+		// TASK-961: explicit user denial → "abandoned". Distinct from
+		// "failed" so dashboards can surface user-facing trust signal
+		// (high abandonment % = clients asking for too much, or
+		// confusing consent UI).
+		s.recordOAuthFlow("abandoned")
 		s.oauthServer.Provider().WriteAuthorizeError(ctx, w, ar,
 			fosite.ErrAccessDenied.WithHint("The user denied the consent."))
 		return
 	}
 	if decision != "approve" {
+		s.recordOAuthFlow("failed")
 		writeError(w, http.StatusBadRequest, "invalid_request",
 			"decision must be 'approve' or 'deny'")
 		return
@@ -633,6 +700,7 @@ func (s *Server) handleOAuthAuthorizeDecide(w http.ResponseWriter, r *http.Reque
 		// is rarely re-driven manually). The OAuth client will see the
 		// 400, NOT a redirect to redirect_uri, because the user never
 		// reached the "real" /authorize/decide → fosite flow.
+		s.recordOAuthFlow("failed")
 		writeError(w, http.StatusBadRequest, "invalid_request", vErr.Error())
 		return
 	}
@@ -655,10 +723,18 @@ func (s *Server) handleOAuthAuthorizeDecide(w http.ResponseWriter, r *http.Reque
 
 	resp, err := s.oauthServer.Provider().NewAuthorizeResponse(ctx, ar, session)
 	if err != nil {
+		s.recordOAuthFlow("failed")
 		s.oauthServer.Provider().WriteAuthorizeError(ctx, w, ar, err)
 		return
 	}
 
+	// TASK-961: happy path — auth code minted, redirect issued.
+	// "completed" doesn't guarantee the client successfully exchanges
+	// the code for a token; the /token handler emits its own duration
+	// observation but no separate stage label (an exchange failure
+	// after a completed consent is a rare client bug, not a flow-
+	// level signal).
+	s.recordOAuthFlow("completed")
 	s.oauthServer.Provider().WriteAuthorizeResponse(ctx, w, ar, resp)
 }
 
@@ -768,6 +844,14 @@ func (s *Server) parseConsentPayload(r *http.Request, ar fosite.AuthorizeRequest
 // body; on success WriteAccessResponse writes
 // {access_token, token_type, expires_in, refresh_token, scope}.
 func (s *Server) handleOAuthToken(w http.ResponseWriter, r *http.Request) {
+	// TASK-961: duration only — no stage counter. The "completed"
+	// counter on /authorize/decide is the canonical flow-completion
+	// signal; counting again here would double-tally happy paths and
+	// the refresh-token rotation path (which doesn't go through
+	// /authorize at all) would be miscounted as a "completion."
+	start := time.Now()
+	defer s.observeOAuthFlowDuration("token", start)
+
 	if !s.IsCloud() || s.oauthServer == nil {
 		http.NotFound(w, r)
 		return
@@ -864,6 +948,15 @@ func (s *Server) handleOAuthToken(w http.ResponseWriter, r *http.Request) {
 // Without the pre-check below, "client_id but no token" would
 // silently 200 instead of 400. Codex review #373 round 3.
 func (s *Server) handleOAuthRevoke(w http.ResponseWriter, r *http.Request) {
+	// TASK-961: duration always observed. The revocation counter
+	// itself is emitted from internal/oauth/storage.go's
+	// RevokeAccessToken via the SetRevocationObserver hook, so we
+	// count the actual storage mutation rather than the HTTP entry —
+	// that way RFC 7009's "200 even on unknown token" idempotent
+	// path doesn't inflate the revocation count.
+	start := time.Now()
+	defer s.observeOAuthFlowDuration("revoke", start)
+
 	if !s.IsCloud() || s.oauthServer == nil {
 		http.NotFound(w, r)
 		return

--- a/internal/server/middleware_auth.go
+++ b/internal/server/middleware_auth.go
@@ -411,6 +411,14 @@ func (s *Server) RequireWorkspaceAccess(next http.Handler) http.Handler {
 		// UUID which resolveWorkspace just translated. Slug-vs-slug
 		// is the right comparison.
 		if !tokenAllowedWorkspaceMatches(r.Context(), ws.Slug) {
+			// TASK-961: count workspace-allow-list denials so the
+			// MCP dashboard can flag tokens hitting workspaces outside
+			// their consent scope. Gated on MCP-origin requests only
+			// (presence of MCP token identity in context) so non-MCP
+			// /api/v1 traffic — which can't even reach this gate
+			// today, but might in a future PAT-with-allow-list world
+			// — doesn't pollute the MCP-specific counter.
+			s.recordMCPAuthzDenial(r, "workspace_not_in_allowlist")
 			writeError(w, http.StatusForbidden, "permission_denied",
 				"Token is not authorized for this workspace")
 			return
@@ -466,6 +474,11 @@ func (s *Server) RequireWorkspaceAccess(next http.Handler) http.Handler {
 				return
 			}
 			if !hasGrants {
+				// TASK-961: not_a_member denial — counts only when the
+				// request originated from the /mcp surface (otherwise
+				// the regular /api/v1 403s would inflate the MCP-
+				// specific counter).
+				s.recordMCPAuthzDenial(r, "not_a_member")
 				writeError(w, http.StatusForbidden, "forbidden", "You are not a member of this workspace")
 				return
 			}
@@ -484,6 +497,31 @@ func (s *Server) RequireWorkspaceAccess(next http.Handler) http.Handler {
 func workspaceRole(r *http.Request) string {
 	v, _ := r.Context().Value(ctxWorkspaceRole).(string)
 	return v
+}
+
+// recordMCPAuthzDenial bumps the pad_mcp_authz_denials_total counter
+// when the request originated from the MCP surface. The discriminator
+// is the presence of an MCPTokenIdentity in the request context —
+// MCPBearerAuth stashes that for every authenticated /mcp request, and
+// no other entry point sets it.
+//
+// Called from middleware that runs DOWNSTREAM of MCPBearerAuth (the
+// in-process MCP dispatcher routes through the API handler tree, so
+// /api/v1/* middleware sees the same context). Called sites must pass
+// a reason string from the documented vocabulary in
+// internal/metrics/metrics.go's MCPAuthzDenialsTotal comment.
+//
+// No-op when metrics aren't wired (selfhost / tests) or when the
+// request didn't come through MCP — keeps the metric MCP-specific
+// without forcing every caller to repeat the gate.
+func (s *Server) recordMCPAuthzDenial(r *http.Request, reason string) {
+	if s.metrics == nil {
+		return
+	}
+	if kind, _ := MCPTokenIdentityFromContext(r.Context()); kind == "" {
+		return
+	}
+	s.metrics.MCPAuthzDenialsTotal.WithLabelValues(reason).Inc()
 }
 
 // requireRole checks if the user's workspace role meets the minimum

--- a/internal/server/middleware_mcp_audit.go
+++ b/internal/server/middleware_mcp_audit.go
@@ -306,7 +306,53 @@ func (s *Server) MCPAuditLog(next http.Handler) http.Handler {
 		}
 
 		s.mcpAudit.enqueue(entry)
+
+		// TASK-961: emit Prometheus metrics for the same hot path the
+		// audit row covers. Same data, different consumer:
+		//   - audit log → forensics, per-row drill-down, retention 90d
+		//   - metrics  → real-time dashboards, alerting, no per-user PII
+		// Fired AFTER enqueue so a metrics misconfigure (nil registry
+		// in test builds) can't accidentally drop the audit row.
+		s.recordMCPCallMetrics(toolName, string(status), user.ID, time.Since(start), r, ww.Status())
 	})
+}
+
+// recordMCPCallMetrics fans the audit-row data out to Prometheus.
+// No-op when metrics aren't wired (selfhost / tests). Kept separate
+// from MCPAuditLog so the audit hot path stays focused on its own
+// concerns and metrics maintenance touches one method.
+//
+// Session gauge accounting: MCP Streamable HTTP carries session
+// lifecycle through method names + HTTP verbs:
+//   - tool method "initialize"     → session opens (+1)
+//   - HTTP DELETE on /mcp           → session closes per spec (-1)
+//
+// Anything else is a per-message call inside an existing session
+// (no gauge change). The gauge is intentionally cheap — best-effort
+// accounting for a "do we have anomalous open sessions?" alert,
+// not a transaction log.
+func (s *Server) recordMCPCallMetrics(tool, status, userID string, dur time.Duration, r *http.Request, httpStatus int) {
+	if s.metrics == nil {
+		return
+	}
+	s.metrics.MCPToolCallsTotal.WithLabelValues(userID, tool, status).Inc()
+	// Histogram is per-tool only — duration distributions per user
+	// would explode the series count without a clear analytical
+	// payoff (alerts care about p95 latency per tool, not per user).
+	s.metrics.MCPToolCallDuration.WithLabelValues(tool).Observe(dur.Seconds())
+
+	// Session lifecycle. We only adjust on successful calls (2xx);
+	// a failed initialize doesn't actually open a session, and a
+	// failed DELETE didn't close one. classifyMCPResult collapses
+	// HTTP 200 + 0 to "ok" so this matches the audit row's status.
+	if httpStatus == http.StatusOK || httpStatus == 0 {
+		switch {
+		case tool == "initialize":
+			s.metrics.MCPActiveSessions.Inc()
+		case r.Method == http.MethodDelete:
+			s.metrics.MCPActiveSessions.Dec()
+		}
+	}
 }
 
 // parseMCPRequestBody extracts (tool_name, args_hash) from the
@@ -530,4 +576,12 @@ func (s *Server) emitMCPAuditDenied(r *http.Request, user *models.User, kind, re
 		LatencyMs:    int(time.Since(latencyStart) / time.Millisecond),
 		RequestID:    reqID,
 	})
+
+	// TASK-961: mirror the denial into the authz-denials counter so
+	// dashboards and alerts can react in real time. The errorKind
+	// vocabulary already matches the metric's reason label by design
+	// (see metrics.go's MCPAuthzDenialsTotal comment for the contract).
+	if s.metrics != nil && errorKind != "" {
+		s.metrics.MCPAuthzDenialsTotal.WithLabelValues(errorKind).Inc()
+	}
 }

--- a/internal/server/middleware_mcp_auth.go
+++ b/internal/server/middleware_mcp_auth.go
@@ -281,6 +281,16 @@ func (s *Server) handleMCPOAuthAuth(w http.ResponseWriter, r *http.Request, toke
 		return
 	}
 	if !audienceContains(ar.GetGrantedAudience(), canonical) {
+		// TASK-961: audience-mismatch is a primary spec-compliance
+		// signal — count it explicitly so dashboards distinguish
+		// "client misconfigured the resource indicator" from generic
+		// 401s. Fires BEFORE the response so a slow metrics path
+		// can't delay the reject. The MCPAuditLog wrapper never sees
+		// this branch because we return before next.ServeHTTP, so
+		// the metric is the only real-time signal for these denials.
+		if s.metrics != nil {
+			s.metrics.MCPAuthzDenialsTotal.WithLabelValues("audience_mismatch").Inc()
+		}
 		s.writeMCPUnauthorized(w, r, "invalid_token", "Token audience does not match this resource.")
 		return
 	}

--- a/internal/server/middleware_mcp_metrics_test.go
+++ b/internal/server/middleware_mcp_metrics_test.go
@@ -1,0 +1,203 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	io_prometheus_client "github.com/prometheus/client_model/go"
+
+	"github.com/PerpetualSoftware/pad/internal/metrics"
+)
+
+// Tests for the MCP/OAuth metric emit helpers wired in PLAN-943 TASK-961.
+// We unit-test the helper methods rather than the full middleware
+// pipelines because:
+//
+//   - The audit middleware needs a started writer + store; covering the
+//     metric side via the helper avoids re-importing all that test scaffolding.
+//   - The helpers ARE the metric contract — every emit path goes through
+//     them, so verifying their behaviour pins the visible metrics shape.
+
+// TestRecordMCPCallMetrics_HappyPath verifies the standard tool-call
+// fan-out: counter +1 per call, latency histogram observation, no
+// session-gauge change for ordinary tool calls.
+func TestRecordMCPCallMetrics_HappyPath(t *testing.T) {
+	s := &Server{metrics: metrics.New()}
+	r := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+
+	s.recordMCPCallMetrics("pad_item", "ok", "user-1", 50*time.Millisecond, r, http.StatusOK)
+	s.recordMCPCallMetrics("pad_item", "ok", "user-1", 100*time.Millisecond, r, http.StatusOK)
+
+	got := counterValue(t, s.metrics.MCPToolCallsTotal.WithLabelValues("user-1", "pad_item", "ok"))
+	if got != 2 {
+		t.Errorf("MCPToolCallsTotal: got %v, want 2", got)
+	}
+
+	// Histogram should have 2 observations under the pad_item label.
+	families, _ := s.metrics.Registry.Gather()
+	var samples uint64
+	for _, f := range families {
+		if f.GetName() != "pad_mcp_tool_call_duration_seconds" {
+			continue
+		}
+		for _, mm := range f.GetMetric() {
+			samples += mm.GetHistogram().GetSampleCount()
+		}
+	}
+	if samples != 2 {
+		t.Errorf("MCPToolCallDuration sample count: got %d, want 2", samples)
+	}
+
+	// Active sessions gauge unchanged (tool != initialize, method !=
+	// DELETE).
+	if got := gaugeValueOrZero(t, s.metrics.MCPActiveSessions); got != 0 {
+		t.Errorf("MCPActiveSessions: got %v, want 0", got)
+	}
+}
+
+// TestRecordMCPCallMetrics_SessionLifecycle covers the gauge logic
+// for initialize / DELETE lifecycle signals.
+func TestRecordMCPCallMetrics_SessionLifecycle(t *testing.T) {
+	s := &Server{metrics: metrics.New()}
+
+	post := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	del := httptest.NewRequest(http.MethodDelete, "/mcp", nil)
+
+	// initialize on POST → +1
+	s.recordMCPCallMetrics("initialize", "ok", "u", time.Millisecond, post, http.StatusOK)
+	// another initialize → +1
+	s.recordMCPCallMetrics("initialize", "ok", "u", time.Millisecond, post, http.StatusOK)
+	// DELETE on /mcp → -1 (regardless of inferred tool name)
+	s.recordMCPCallMetrics("(unknown)", "ok", "u", time.Millisecond, del, http.StatusOK)
+
+	if got := gaugeValueOrZero(t, s.metrics.MCPActiveSessions); got != 1 {
+		t.Errorf("MCPActiveSessions after 2 initialize + 1 DELETE: got %v, want 1", got)
+	}
+
+	// Failed initialize (5xx) must NOT bump the gauge — a 500 didn't
+	// open a real session.
+	s.recordMCPCallMetrics("initialize", "error", "u", time.Millisecond, post, http.StatusInternalServerError)
+	if got := gaugeValueOrZero(t, s.metrics.MCPActiveSessions); got != 1 {
+		t.Errorf("MCPActiveSessions after failed initialize: got %v, want 1 (unchanged)", got)
+	}
+}
+
+// TestRecordMCPCallMetrics_NilMetrics verifies the helper is a clean
+// no-op when metrics aren't wired (selfhost / tests that don't build
+// a registry). No panic is the only assertion that matters.
+func TestRecordMCPCallMetrics_NilMetrics(t *testing.T) {
+	s := &Server{metrics: nil}
+	r := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	s.recordMCPCallMetrics("pad_item", "ok", "u", time.Second, r, http.StatusOK)
+}
+
+// TestRecordMCPAuthzDenial_GatedOnMCPOrigin verifies the discriminator:
+// the counter only increments when the request context carries an MCP
+// token identity (set by MCPBearerAuth). Non-MCP requests must be
+// silently skipped so /api/v1 traffic doesn't pollute the MCP-specific
+// counter.
+func TestRecordMCPAuthzDenial_GatedOnMCPOrigin(t *testing.T) {
+	s := &Server{metrics: metrics.New()}
+
+	// Request without MCP identity → no-op.
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/workspaces/foo/items", nil)
+	s.recordMCPAuthzDenial(r, "not_a_member")
+	if got := counterValue(t, s.metrics.MCPAuthzDenialsTotal.WithLabelValues("not_a_member")); got != 0 {
+		t.Errorf("non-MCP request must not increment counter, got %v", got)
+	}
+
+	// Request with MCP identity → counter increments.
+	ctx := WithMCPTokenIdentity(context.Background(), "oauth", "req-123")
+	r = httptest.NewRequest(http.MethodGet, "/api/v1/workspaces/foo/items", nil).WithContext(ctx)
+	s.recordMCPAuthzDenial(r, "not_a_member")
+	if got := counterValue(t, s.metrics.MCPAuthzDenialsTotal.WithLabelValues("not_a_member")); got != 1 {
+		t.Errorf("MCP-origin request: got %v, want 1", got)
+	}
+}
+
+// TestObserveOAuthFlowDuration covers the OAuth handler-side
+// duration helper. Verifies the histogram captures the elapsed time
+// under the right stage label.
+func TestObserveOAuthFlowDuration(t *testing.T) {
+	s := &Server{metrics: metrics.New()}
+
+	// Sleep is too racy for CI; just observe a fixed-past start.
+	start := time.Now().Add(-100 * time.Millisecond)
+	s.observeOAuthFlowDuration("authorize", start)
+
+	families, _ := s.metrics.Registry.Gather()
+	var samples uint64
+	var found bool
+	for _, f := range families {
+		if f.GetName() != "pad_oauth_flow_duration_seconds" {
+			continue
+		}
+		for _, mm := range f.GetMetric() {
+			// Locate the metric for our stage label.
+			for _, lp := range mm.GetLabel() {
+				if lp.GetName() == "stage" && lp.GetValue() == "authorize" {
+					samples += mm.GetHistogram().GetSampleCount()
+					found = true
+				}
+			}
+		}
+	}
+	if !found {
+		t.Fatal("OAuthFlowDuration histogram missing stage=authorize series")
+	}
+	if samples != 1 {
+		t.Errorf("OAuthFlowDuration{authorize} sample count: got %d, want 1", samples)
+	}
+}
+
+// TestRecordOAuthFlow covers the OAuth-flow stage counter.
+func TestRecordOAuthFlow(t *testing.T) {
+	s := &Server{metrics: metrics.New()}
+	s.recordOAuthFlow("started")
+	s.recordOAuthFlow("started")
+	s.recordOAuthFlow("completed")
+	s.recordOAuthFlow("abandoned")
+	s.recordOAuthFlow("failed")
+
+	cases := map[string]float64{
+		"started":   2,
+		"completed": 1,
+		"abandoned": 1,
+		"failed":    1,
+	}
+	for stage, want := range cases {
+		got := counterValue(t, s.metrics.OAuthFlowsTotal.WithLabelValues(stage))
+		if got != want {
+			t.Errorf("OAuthFlowsTotal{%s}: got %v, want %v", stage, got, want)
+		}
+	}
+}
+
+// counterValue is a tiny helper that pulls the float value out of a
+// Prometheus counter.
+func counterValue(t *testing.T, c interface {
+	Write(*io_prometheus_client.Metric) error
+}) float64 {
+	t.Helper()
+	var m io_prometheus_client.Metric
+	if err := c.Write(&m); err != nil {
+		t.Fatalf("counter Write: %v", err)
+	}
+	return m.GetCounter().GetValue()
+}
+
+// gaugeValueOrZero pulls the gauge value or returns 0 when the
+// underlying metric hasn't been touched yet.
+func gaugeValueOrZero(t *testing.T, g interface {
+	Write(*io_prometheus_client.Metric) error
+}) float64 {
+	t.Helper()
+	var m io_prometheus_client.Metric
+	if err := g.Write(&m); err != nil {
+		t.Fatalf("gauge Write: %v", err)
+	}
+	return m.GetGauge().GetValue()
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -91,6 +91,13 @@ type Server struct {
 	// mount on self-hosted deployments. See handlers_oauth.go.
 	oauthServer *oauth.Server
 
+	// oauthMetricsWired records whether wireOAuthMetricsObserver has
+	// already attached the active-tokens callback collector. Re-
+	// registering would panic via prometheus.MustRegister, so the flag
+	// guards the one-shot registration. The TTL observer side is
+	// idempotent (just a function-pointer set) and runs unconditionally.
+	oauthMetricsWired bool
+
 	// MCP audit log async writer (PLAN-943 TASK-960). Spawned by
 	// startMCPAuditWriter at startup when MCP is wired; shut down
 	// from Server.Stop. nil-safe: every audit-emitting code path
@@ -431,8 +438,45 @@ func (s *Server) SetSecureCookies(secure bool) {
 
 // SetMetrics attaches Prometheus metrics to the server.
 // Must be called before the first request is served.
+//
+// Side effect (TASK-961): when both metrics AND the OAuth server are
+// wired, this also attaches the OAuth-active-tokens callback collector
+// and the revocation TTL observer. Order-independent — both
+// SetMetrics and SetOAuthServer call wireOAuthMetricsObserver, which
+// no-ops until both prerequisites are present.
 func (s *Server) SetMetrics(m *metrics.Metrics) {
 	s.metrics = m
+	s.wireOAuthMetricsObserver()
+}
+
+// wireOAuthMetricsObserver attaches the OAuth metrics that need both
+// the metrics registry AND the OAuth server: the active-tokens
+// callback collector (reads via the store) and the per-revocation
+// TTL observer (fires from internal/oauth/storage.go on every
+// access-token family revocation).
+//
+// Idempotent — re-registering the same collector would panic via
+// prometheus.MustRegister, so we guard with a flag. Setting the
+// observer multiple times is harmless (just replaces the function
+// pointer).
+//
+// Why this lives on Server rather than in cmd/pad: it composes two
+// optional Server fields whose set-order isn't guaranteed by the
+// boot sequence, and centralizing the wiring here keeps the cmd/pad
+// startup path declarative ("set X, set Y") without an explicit
+// "now wire the cross-cut" call.
+func (s *Server) wireOAuthMetricsObserver() {
+	if s.metrics == nil || s.oauthServer == nil {
+		return
+	}
+	if !s.oauthMetricsWired {
+		s.metrics.RegisterOAuthActiveTokensCollector(s.store.CountActiveOAuthAccessTokens)
+		s.oauthMetricsWired = true
+	}
+	s.oauthServer.Storage().SetRevocationObserver(func(kind string, ttl time.Duration) {
+		s.metrics.OAuthTokenRevocationsTotal.WithLabelValues(kind).Inc()
+		s.metrics.OAuthTokenTTLSeconds.Observe(ttl.Seconds())
+	})
 }
 
 // SetMetricsToken configures the static bearer token required to scrape

--- a/internal/store/oauth.go
+++ b/internal/store/oauth.go
@@ -435,6 +435,68 @@ func (s *Store) RevokeRefreshTokenFamily(requestID string) error {
 	return nil
 }
 
+// CountActiveOAuthAccessTokens returns the number of access-token rows
+// with active=1. Backs the pad_oauth_active_tokens gauge (TASK-961).
+//
+// Caveat: the schema does not store an expires_at column — fosite
+// computes expiry from session_data at introspection time. Counting
+// active=1 therefore over-reports: tokens that have aged past their
+// TTL but haven't been pruned (and haven't been re-introspected since
+// expiry) still appear active here. For an operational gauge that's
+// fine — "tokens we still consider valid storage-side" is exactly the
+// signal ops want for capacity / abuse alerting. A future expiry
+// sweeper would reduce the gap; until then the count is an upper
+// bound rather than ground truth.
+func (s *Store) CountActiveOAuthAccessTokens() (int64, error) {
+	var n int64
+	err := s.db.QueryRow(s.q(`
+		SELECT COUNT(*) FROM oauth_access_tokens WHERE active = ?
+	`), true).Scan(&n)
+	if err != nil {
+		return 0, fmt.Errorf("count active oauth access tokens: %w", err)
+	}
+	return n, nil
+}
+
+// OldestAccessTokenIssuedAtByRequestID returns the requested_at of the
+// earliest access token in the family identified by requestID. Used
+// by the OAuth revocation path (TASK-961) to observe token TTL —
+// "how long was this token alive before it got revoked?"
+//
+// Why MIN(requested_at) rather than per-row reporting: a single grant
+// family typically holds one access token at a time (the refresh-
+// rotation flow revokes the prior one before issuing the new one),
+// but the "rotated" code path briefly stages two during the swap.
+// Using the oldest row's timestamp gives a meaningful "lifetime of
+// the original grant" measurement that doesn't oscillate based on
+// rotation timing.
+//
+// Returns ErrOAuthNotFound when the family has no rows (already
+// pruned, or revoke called with an unknown request_id). Callers may
+// safely treat that as "no observation to record."
+func (s *Store) OldestAccessTokenIssuedAtByRequestID(requestID string) (time.Time, error) {
+	if requestID == "" {
+		return time.Time{}, fmt.Errorf("oauth: requestID required")
+	}
+	var raw sql.NullString
+	err := s.db.QueryRow(s.q(`
+		SELECT MIN(requested_at) FROM oauth_access_tokens WHERE request_id = ?
+	`), requestID).Scan(&raw)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return time.Time{}, ErrOAuthNotFound
+		}
+		return time.Time{}, fmt.Errorf("query oldest access token: %w", err)
+	}
+	if !raw.Valid {
+		// MIN returns NULL when the family has zero rows. SQLite drops
+		// the row through a single QueryRow.Scan rather than ErrNoRows
+		// because the aggregate "produces" exactly one (null) row.
+		return time.Time{}, ErrOAuthNotFound
+	}
+	return parseTime(raw.String), nil
+}
+
 // RevokeAccessTokenFamily mirrors RevokeRefreshTokenFamily for
 // access tokens. fosite calls these in pairs when revoking by
 // request_id (the unified RevokeRefreshToken / RevokeAccessToken

--- a/internal/store/oauth_test.go
+++ b/internal/store/oauth_test.go
@@ -302,6 +302,106 @@ func TestOAuth_AccessToken_CRUDAndDelete(t *testing.T) {
 	}
 }
 
+// TestOAuth_CountActiveOAuthAccessTokens covers the helper that
+// backs the pad_oauth_active_tokens metric (PLAN-943 TASK-961).
+// Verifies the count tracks insertions, ignores inactive rows, and
+// returns 0 when the table is empty.
+func TestOAuth_CountActiveOAuthAccessTokens(t *testing.T) {
+	s := testStore(t)
+	c := newTestClient(t, s)
+
+	// Empty table → 0.
+	n, err := s.CountActiveOAuthAccessTokens()
+	if err != nil {
+		t.Fatalf("CountActiveOAuthAccessTokens (empty): %v", err)
+	}
+	if n != 0 {
+		t.Errorf("empty table count: got %d, want 0", n)
+	}
+
+	// Two active tokens.
+	for i, sig := range []string{"sig-a", "sig-b"} {
+		req := newTestRequest(c.ID, sig, "req-"+sig)
+		_ = i
+		if err := s.CreateAccessToken(req); err != nil {
+			t.Fatalf("CreateAccessToken[%s]: %v", sig, err)
+		}
+	}
+
+	n, err = s.CountActiveOAuthAccessTokens()
+	if err != nil {
+		t.Fatalf("CountActiveOAuthAccessTokens (2 active): %v", err)
+	}
+	if n != 2 {
+		t.Errorf("after 2 inserts: got %d, want 2", n)
+	}
+
+	// Revoke one family — count drops by 1.
+	if err := s.RevokeAccessTokenFamily("req-sig-a"); err != nil {
+		t.Fatalf("RevokeAccessTokenFamily: %v", err)
+	}
+	n, err = s.CountActiveOAuthAccessTokens()
+	if err != nil {
+		t.Fatalf("CountActiveOAuthAccessTokens (1 active): %v", err)
+	}
+	if n != 1 {
+		t.Errorf("after revoke: got %d, want 1", n)
+	}
+}
+
+// TestOAuth_OldestAccessTokenIssuedAtByRequestID covers the helper that
+// drives the pad_oauth_token_ttl_seconds histogram (TASK-961). The
+// "oldest" semantic is the meaningful one across rotation churn — even
+// if a family briefly stages two access tokens during a refresh swap,
+// the original issuance time gives the right "lifetime of this grant"
+// signal.
+func TestOAuth_OldestAccessTokenIssuedAtByRequestID(t *testing.T) {
+	s := testStore(t)
+	c := newTestClient(t, s)
+
+	// Empty: ErrOAuthNotFound (the SELECT MIN over an empty family
+	// returns NULL → mapped to NotFound).
+	_, err := s.OldestAccessTokenIssuedAtByRequestID("missing-req")
+	if !errors.Is(err, ErrOAuthNotFound) {
+		t.Errorf("missing family: expected ErrOAuthNotFound, got %v", err)
+	}
+
+	// Empty requestID: argument-validation error, NOT ErrOAuthNotFound
+	// (the latter would mask a caller bug as a no-op).
+	_, err = s.OldestAccessTokenIssuedAtByRequestID("")
+	if err == nil || errors.Is(err, ErrOAuthNotFound) {
+		t.Errorf("empty requestID: expected validation error, got %v", err)
+	}
+
+	// Two tokens in the same family with distinct timestamps. Older
+	// timestamp wins.
+	older := time.Now().UTC().Add(-2 * time.Hour).Truncate(time.Second)
+	newer := time.Now().UTC().Add(-30 * time.Minute).Truncate(time.Second)
+
+	req1 := newTestRequest(c.ID, "sig-old", "req-fam")
+	req1.RequestedAt = older
+	if err := s.CreateAccessToken(req1); err != nil {
+		t.Fatalf("CreateAccessToken older: %v", err)
+	}
+	req2 := newTestRequest(c.ID, "sig-new", "req-fam")
+	req2.RequestedAt = newer
+	if err := s.CreateAccessToken(req2); err != nil {
+		t.Fatalf("CreateAccessToken newer: %v", err)
+	}
+
+	got, err := s.OldestAccessTokenIssuedAtByRequestID("req-fam")
+	if err != nil {
+		t.Fatalf("OldestAccessTokenIssuedAtByRequestID: %v", err)
+	}
+	// Allow ± 1s slack for backend timestamp granularity (Postgres
+	// truncates to microseconds; SQLite stores RFC3339 which we
+	// round to seconds via parseTime).
+	delta := got.Sub(older)
+	if delta < -time.Second || delta > time.Second {
+		t.Errorf("got %v, want %v (delta %v)", got, older, delta)
+	}
+}
+
 // ------------------------------------------------------------
 // Refresh tokens — rotation + family revocation (the security-critical part)
 // ------------------------------------------------------------

--- a/monitoring/grafana/mcp.json
+++ b/monitoring/grafana/mcp.json
@@ -1,0 +1,290 @@
+{
+  "__comment": "Grafana dashboard for pad MCP + OAuth observability (PLAN-943 TASK-961). Import via Grafana UI or provisioned dashboards. Datasource is templated — set $datasource on import to your Prometheus source. Refresh interval: 30s. Time range default: last 6h.",
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "MCP traffic + OAuth flow observability for pad-cloud. Pairs with the audit log at /console/admin/mcp-audit for per-row drill-down.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "id": 100,
+      "panels": [],
+      "title": "MCP traffic",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "MCP tool-call rate broken out by tool. Spikes here without a corresponding active-sessions change usually means one client looping; cross-reference the audit log.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "line", "fillOpacity": 10, "lineWidth": 1 },
+          "unit": "reqps"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 1 },
+      "id": 1,
+      "options": { "legend": { "displayMode": "table", "placement": "right", "calcs": ["mean", "max"] } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum by (tool) (rate(pad_mcp_tool_calls_total[5m]))",
+          "legendFormat": "{{tool}}",
+          "refId": "A"
+        }
+      ],
+      "title": "MCP tool-call rate by tool",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "p50 / p95 / p99 tool-call latency. Watch p99 — the audit log records latency_ms per row but doesn't aggregate.",
+      "fieldConfig": { "defaults": { "unit": "s" } },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 1 },
+      "id": 2,
+      "options": { "legend": { "displayMode": "table", "placement": "right" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "histogram_quantile(0.50, sum by (le, tool) (rate(pad_mcp_tool_call_duration_seconds_bucket[5m])))",
+          "legendFormat": "p50 {{tool}}",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "histogram_quantile(0.95, sum by (le, tool) (rate(pad_mcp_tool_call_duration_seconds_bucket[5m])))",
+          "legendFormat": "p95 {{tool}}",
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "histogram_quantile(0.99, sum by (le, tool) (rate(pad_mcp_tool_call_duration_seconds_bucket[5m])))",
+          "legendFormat": "p99 {{tool}}",
+          "refId": "C"
+        }
+      ],
+      "title": "MCP tool-call latency (p50/p95/p99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Per-status outcome breakdown. Sustained spikes in 'denied' or 'error' usually pair with an attention item in the audit log.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "bars", "fillOpacity": 60, "stacking": { "mode": "normal" } },
+          "unit": "reqps"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 9 },
+      "id": 3,
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum by (status) (rate(pad_mcp_tool_calls_total[5m]))",
+          "legendFormat": "{{status}}",
+          "refId": "A"
+        }
+      ],
+      "title": "MCP outcomes by status",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Authorization denials by reason. Sustained 'audience_mismatch' = client misconfigured; sustained 'rate_limited' = consider raising the per-token bucket; sustained 'workspace_not_in_allowlist' = client requesting workspaces the user didn't grant.",
+      "fieldConfig": { "defaults": { "unit": "reqps" } },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 9 },
+      "id": 4,
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum by (reason) (rate(pad_mcp_authz_denials_total[5m]))",
+          "legendFormat": "{{reason}}",
+          "refId": "A"
+        }
+      ],
+      "title": "MCP authorization denials by reason",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Active Streamable HTTP sessions (initialize - DELETE). Drift up over time? Probably client crashes; expected to recover at server restart.",
+      "fieldConfig": { "defaults": { "unit": "short" } },
+      "gridPos": { "h": 6, "w": 8, "x": 0, "y": 17 },
+      "id": 5,
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "pad_mcp_active_sessions",
+          "legendFormat": "active sessions",
+          "refId": "A"
+        }
+      ],
+      "title": "MCP active sessions",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Top users by tool-call rate over the last 5 minutes. High-cardinality panel — useful for spotting one client driving most of the load.",
+      "fieldConfig": { "defaults": { "unit": "reqps" } },
+      "gridPos": { "h": 6, "w": 16, "x": 8, "y": 17 },
+      "id": 6,
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "topk(10, sum by (user_id) (rate(pad_mcp_tool_calls_total[5m])))",
+          "legendFormat": "{{user_id}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Top 10 MCP users by tool-call rate",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 23 },
+      "id": 200,
+      "panels": [],
+      "title": "OAuth flows",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Authorization-flow stage transitions. Healthy ratio: completed >> abandoned >> failed. A sudden 'failed' spike = clients with bad config; sustained high 'abandoned' = consent UI clarity issue.",
+      "fieldConfig": { "defaults": { "unit": "reqps" } },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 24 },
+      "id": 7,
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum by (stage) (rate(pad_oauth_flows_total[5m]))",
+          "legendFormat": "{{stage}}",
+          "refId": "A"
+        }
+      ],
+      "title": "OAuth flow events by stage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "p95 latency per OAuth handler. Slow 'token' = fosite signing or DB; slow 'authorize' = workspace-list fetch.",
+      "fieldConfig": { "defaults": { "unit": "s" } },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 24 },
+      "id": 8,
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "histogram_quantile(0.95, sum by (le, stage) (rate(pad_oauth_flow_duration_seconds_bucket[5m])))",
+          "legendFormat": "p95 {{stage}}",
+          "refId": "A"
+        }
+      ],
+      "title": "OAuth flow latency (p95)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Active access tokens (active=1 in storage). Caveat: includes tokens past their expires_in but not yet pruned; expected to be an upper bound.",
+      "fieldConfig": { "defaults": { "unit": "short" } },
+      "gridPos": { "h": 6, "w": 8, "x": 0, "y": 32 },
+      "id": 9,
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "pad_oauth_active_tokens",
+          "legendFormat": "active tokens",
+          "refId": "A"
+        }
+      ],
+      "title": "OAuth active tokens",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Token revocations by reason. Sudden 'rotated' spike = clients churning refresh tokens (expected on bursts); 'replayed' is the canary for theft detection.",
+      "fieldConfig": { "defaults": { "unit": "reqps" } },
+      "gridPos": { "h": 6, "w": 8, "x": 8, "y": 32 },
+      "id": 10,
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum by (reason) (rate(pad_oauth_token_revocations_total[5m]))",
+          "legendFormat": "{{reason}}",
+          "refId": "A"
+        }
+      ],
+      "title": "OAuth token revocations by reason",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "description": "Token TTL distribution at revocation time. p50 near the configured access-token TTL = healthy natural-expiry pattern; p50 near zero = something is revoking tokens immediately (likely abuse mitigation or misconfig).",
+      "fieldConfig": { "defaults": { "unit": "s" } },
+      "gridPos": { "h": 6, "w": 8, "x": 16, "y": 32 },
+      "id": 11,
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(pad_oauth_token_ttl_seconds_bucket[1h])))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(pad_oauth_token_ttl_seconds_bucket[1h])))",
+          "legendFormat": "p95",
+          "refId": "B"
+        }
+      ],
+      "title": "OAuth token TTL at revocation (p50/p95)",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["pad", "mcp", "oauth"],
+  "templating": {
+    "list": [
+      {
+        "current": { "selected": false, "text": "Prometheus", "value": "Prometheus" },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": { "from": "now-6h", "to": "now" },
+  "timezone": "",
+  "title": "Pad — MCP + OAuth observability",
+  "uid": "pad-mcp-oauth",
+  "version": 1,
+  "weekStart": ""
+}


### PR DESCRIPTION
## Summary

Closes TASK-961. Plug MCP traffic + OAuth flow events into pad's existing `internal/metrics` Prometheus surface, plus a Grafana dashboard at `monitoring/grafana/mcp.json`.

- **Counters:** `pad_mcp_tool_calls_total{user_id,tool,status}`, `pad_mcp_authz_denials_total{reason}`, `pad_oauth_flows_total{stage}`, `pad_oauth_token_revocations_total{reason}`
- **Histograms:** `pad_mcp_tool_call_duration_seconds{tool}`, `pad_oauth_flow_duration_seconds{stage}`, `pad_oauth_token_ttl_seconds`
- **Gauges:** `pad_mcp_active_sessions`, `pad_oauth_active_tokens` (callback collector mirroring `dbStatsCollector`)

## Wiring seams

- `MCPAuditLog` middleware → tool calls, latency histogram, session +/-1 on `initialize` / HTTP DELETE
- `emitMCPAuditDenied` → `rate_limited` denial
- `MCPBearerAuth` → `audience_mismatch` denial
- `RequireWorkspaceAccess` (gated on MCP-origin via context) → `workspace_not_in_allowlist` + `not_a_member`
- OAuth handlers → per-stage `started/completed/abandoned/failed` + per-handler durations
- `internal/oauth/storage.go` `RevokeAccessToken` + `RotateRefreshToken` → revocation counter (`user_initiated`/`rotated`) + TTL histogram, via a new `SetRevocationObserver` hook so the OAuth package stays metrics-naive
- `cmd/pad/main.go` plumbs both observers via `Server.wireOAuthMetricsObserver()` called from `SetMetrics` and `SetOAuthServer` for order-independence

## Codex round-1 fix

Codex caught one HIGH issue in review (fixed in same commit): the active-tokens collector originally emitted `NewInvalidMetric` on provider error, which makes `Registry.Gather()` return an error and fails the **entire** `/metrics` scrape via promhttp's default handler. Switched to log + skip-the-sample so a transient SQLite blip drops one gauge for one scrape rather than the whole observability surface. Round 2: CLEAN.

## Known scope limits (deferrals)

- `mcp_authz_denials_total{reason="tier_mismatch"}` is reserved in the label vocabulary but not yet emitted — natural seam is the in-process MCP dispatcher's per-tool scope check (`internal/mcp/dispatch_http.go`), held for a follow-up.
- `pad_oauth_active_tokens` counts `WHERE active=1` only — schema has no `expires_at` column (fosite computes expiry from `session_data` at introspection time), so the gauge is an upper bound.
- `pad_mcp_active_sessions` uses `initialize`/+1, DELETE/-1 sniffing — sessions that drop without DELETE leave the gauge inflated until restart.

All three are documented in `internal/metrics/metrics.go` comments + the dashboard panel descriptions.

## Test plan

- [x] `go test ./internal/metrics/... ./internal/store/... ./internal/oauth/... ./internal/server/...` — all green
- [x] `make check` (golangci-lint + go test ./... + cd web && npm run build) — clean
- [x] `make install` — server restarts cleanly with metrics endpoint live
- [x] Codex review loop converged to CLEAN in 2 rounds