### PR TITLE
feat(metrics): emit mcp_authz_denials_total{reason=tier_mismatch} (TASK-1119)

### DIFF
--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -395,6 +395,14 @@ func serveCmd() *cobra.Command {
 					// agents never see workspace slugs the user
 					// didn't explicitly grant.
 					Lister: mcpserver.NewOAuthWorkspaceLister(s),
+					// Tier-mismatch observability (TASK-1119).
+					// Bumps pad_mcp_authz_denials_total{reason="tier_mismatch"}
+					// when the dispatcher's per-tool scope check
+					// rejects a synthesized request. No-op until
+					// metrics are wired; safe to attach unconditionally
+					// because Server.RecordMCPTierMismatch nil-checks
+					// internally.
+					OnScopeDenied: srv.RecordMCPTierMismatch,
 				}
 				if _, regErr := mcpserver.Register(mcpSrv.MCP(), mcpserver.RegistryOptions{
 					Doc:        mcpDoc,

--- a/internal/mcp/dispatch_http.go
+++ b/internal/mcp/dispatch_http.go
@@ -92,6 +92,28 @@ type HTTPHandlerDispatcher struct {
 	// production wiring.
 	Routes map[string]RouteMapper
 
+	// OnScopeDenied, when non-nil, fires every time buildAuthedRequest
+	// rejects a synthesized request because the API token's scope does
+	// not permit the requested method on the resource (TASK-1119
+	// follow-up to TASK-961). The callback gets the same (method,
+	// urlPath) the dispatcher was about to send so the observer can
+	// add useful labels if needed; today it backs the
+	// pad_mcp_authz_denials_total{reason="tier_mismatch"} counter.
+	//
+	// Why a callback rather than importing internal/metrics directly:
+	// internal/mcp depends on internal/server, but adding an
+	// internal/metrics import here would create a circular concern —
+	// server already owns metrics wiring, and the dispatcher's role is
+	// "translate tool args → in-process HTTP request." Keeping it
+	// metrics-naive (matches the OAuth Storage SetRevocationObserver
+	// pattern from TASK-961) lets cmd/pad attach the observer at
+	// startup without coupling.
+	//
+	// nil → no observer; the existing permission_denied error envelope
+	// still flows up to the caller unchanged. Tests that don't care
+	// about metrics can leave this unset.
+	OnScopeDenied func(method, urlPath string)
+
 	// Lister, when non-nil, populates available_workspaces in the
 	// no_workspace / unknown_workspace error envelopes (TASK-977).
 	// Production wires an OAuth-aware lister that reads the token's
@@ -470,6 +492,14 @@ func (d *HTTPHandlerDispatcher) buildAuthedRequest(
 	user *models.User,
 ) (*http.Request, error) {
 	if scopes := server.TokenScopesFromContext(ctx); !server.TokenScopeAllows(scopes, method, urlPath) {
+		// TASK-1119: fire the optional observability hook BEFORE
+		// returning so the caller's error path is unchanged. Best-
+		// effort — a panicking observer is the observer's bug; we
+		// don't recover() because that would mask metric-wiring
+		// breakage in tests where panics are the right signal.
+		if d.OnScopeDenied != nil {
+			d.OnScopeDenied(method, urlPath)
+		}
 		return nil, fmt.Errorf("permission_denied: token scope does not permit %s on this resource", method)
 	}
 	req, err := buildHTTPRequest(ctx, method, urlPath, body, user)

--- a/internal/mcp/dispatch_http_test.go
+++ b/internal/mcp/dispatch_http_test.go
@@ -356,6 +356,115 @@ func TestHTTPHandlerDispatcher_ScopeEnforcement_NoScopeContextAllows(t *testing.
 	}
 }
 
+// TestHTTPHandlerDispatcher_OnScopeDenied_FiresOnce pins the
+// observability hook added in TASK-1119: when a synthesized request
+// fails the scope check, the dispatcher must invoke OnScopeDenied
+// exactly once with the (method, urlPath) it was about to send. Backs
+// the pad_mcp_authz_denials_total{reason="tier_mismatch"} metric.
+func TestHTTPHandlerDispatcher_OnScopeDenied_FiresOnce(t *testing.T) {
+	user := &models.User{ID: "user-1", Name: "Dave", Email: "dave@example.com"}
+	rec := &recordingHandler{t: t}
+
+	type observed struct {
+		method  string
+		urlPath string
+	}
+	var calls []observed
+
+	d := &HTTPHandlerDispatcher{
+		Handler:      rec,
+		UserResolver: fixedUserResolver(user),
+		OnScopeDenied: func(method, urlPath string) {
+			calls = append(calls, observed{method: method, urlPath: urlPath})
+		},
+	}
+
+	// Read-only scope + a write tool — same fixture the existing
+	// scope-deny test uses, but verifies the observer side now too.
+	ctx := server.WithTokenScopes(context.Background(), `["read"]`)
+	ctx = WithDispatchInput(ctx, map[string]any{
+		"workspace":  "docapp",
+		"collection": "tasks",
+		"title":      "Should Be Rejected",
+	})
+
+	res, err := d.Dispatch(ctx, []string{"item", "create"}, nil)
+	if err != nil {
+		t.Fatalf("Dispatch: %v", err)
+	}
+	if !res.IsError {
+		t.Fatalf("expected IsError result for read-scoped POST; got success: %#v", res)
+	}
+
+	if len(calls) != 1 {
+		t.Fatalf("OnScopeDenied: got %d calls, want 1 (calls=%+v)", len(calls), calls)
+	}
+	if calls[0].method != http.MethodPost {
+		t.Errorf("OnScopeDenied method: got %q, want %q", calls[0].method, http.MethodPost)
+	}
+	if !strings.HasPrefix(calls[0].urlPath, "/api/v1/workspaces/docapp/collections/tasks") {
+		t.Errorf("OnScopeDenied urlPath: got %q, want prefix /api/v1/workspaces/docapp/collections/tasks", calls[0].urlPath)
+	}
+}
+
+// TestHTTPHandlerDispatcher_OnScopeDenied_NotFiredOnAllow guards
+// against the inverse mistake: if the scope check passes, the observer
+// MUST NOT fire (otherwise dashboards would treat allowed traffic as
+// denied — false-positive that masks real abuse).
+func TestHTTPHandlerDispatcher_OnScopeDenied_NotFiredOnAllow(t *testing.T) {
+	user := &models.User{ID: "user-1", Name: "Dave", Email: "dave@example.com"}
+	rec := &recordingHandler{t: t, wantStatus: http.StatusOK, respBody: `{"items":[]}`}
+
+	var fired int
+	d := &HTTPHandlerDispatcher{
+		Handler:       rec,
+		UserResolver:  fixedUserResolver(user),
+		OnScopeDenied: func(string, string) { fired++ },
+	}
+
+	ctx := server.WithTokenScopes(context.Background(), `["read"]`)
+	ctx = WithDispatchInput(ctx, map[string]any{"workspace": "docapp"})
+
+	res, err := d.Dispatch(ctx, []string{"item", "list"}, nil)
+	if err != nil {
+		t.Fatalf("Dispatch: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("read-scoped GET should succeed; got error: %#v", res)
+	}
+	if fired != 0 {
+		t.Errorf("OnScopeDenied fired on allowed request: got %d calls, want 0", fired)
+	}
+}
+
+// TestHTTPHandlerDispatcher_OnScopeDenied_NilSafe verifies the hook is
+// optional — leaving it unset must not panic, even on the deny path.
+func TestHTTPHandlerDispatcher_OnScopeDenied_NilSafe(t *testing.T) {
+	user := &models.User{ID: "user-1", Name: "Dave", Email: "dave@example.com"}
+	rec := &recordingHandler{t: t}
+
+	d := &HTTPHandlerDispatcher{
+		Handler:      rec,
+		UserResolver: fixedUserResolver(user),
+		// OnScopeDenied intentionally unset.
+	}
+
+	ctx := server.WithTokenScopes(context.Background(), `["read"]`)
+	ctx = WithDispatchInput(ctx, map[string]any{
+		"workspace":  "docapp",
+		"collection": "tasks",
+		"title":      "x",
+	})
+
+	res, err := d.Dispatch(ctx, []string{"item", "create"}, nil)
+	if err != nil {
+		t.Fatalf("Dispatch: %v", err)
+	}
+	if !res.IsError {
+		t.Fatalf("expected IsError on deny path; got %#v", res)
+	}
+}
+
 func TestMapItemCreate_ExplicitFieldOverridesNamedFlag(t *testing.T) {
 	// Last-write-wins: an explicit --field status=blocked should
 	// override a separate --status=in-progress on the same call.

--- a/internal/server/middleware_auth.go
+++ b/internal/server/middleware_auth.go
@@ -499,6 +499,30 @@ func workspaceRole(r *http.Request) string {
 	return v
 }
 
+// RecordMCPTierMismatch bumps the pad_mcp_authz_denials_total counter
+// with reason="tier_mismatch" (TASK-1119). Wired from
+// internal/mcp/dispatch_http.go's OnScopeDenied callback — every
+// dispatcher invocation is by construction MCP-origin (only the /mcp
+// surface routes through HTTPHandlerDispatcher), so unlike
+// recordMCPAuthzDenial below this helper does NOT need a context
+// gate.
+//
+// Exported for cross-package wiring (cmd/pad attaches it as the
+// dispatcher observer at startup). The (method, urlPath) arguments
+// match the dispatcher's callback signature so callers can wire with
+// a one-liner; we currently ignore them because the metric only
+// labels by reason.
+//
+// No-op when metrics aren't wired (selfhost / tests).
+func (s *Server) RecordMCPTierMismatch(method, urlPath string) {
+	_ = method
+	_ = urlPath
+	if s.metrics == nil {
+		return
+	}
+	s.metrics.MCPAuthzDenialsTotal.WithLabelValues("tier_mismatch").Inc()
+}
+
 // recordMCPAuthzDenial bumps the pad_mcp_authz_denials_total counter
 // when the request originated from the MCP surface. The discriminator
 // is the presence of an MCPTokenIdentity in the request context —

--- a/internal/server/middleware_mcp_metrics_test.go
+++ b/internal/server/middleware_mcp_metrics_test.go
@@ -94,6 +94,34 @@ func TestRecordMCPCallMetrics_NilMetrics(t *testing.T) {
 	s.recordMCPCallMetrics("pad_item", "ok", "u", time.Second, r, http.StatusOK)
 }
 
+// TestRecordMCPTierMismatch covers the dispatcher-side observer added
+// in TASK-1119: every call increments
+// pad_mcp_authz_denials_total{reason="tier_mismatch"} unconditionally
+// (no MCP-origin gate — the dispatcher is by construction MCP-only).
+// Also verifies nil-metrics safety.
+func TestRecordMCPTierMismatch(t *testing.T) {
+	s := &Server{metrics: metrics.New()}
+
+	s.RecordMCPTierMismatch(http.MethodPost, "/api/v1/workspaces/x/items")
+	s.RecordMCPTierMismatch(http.MethodDelete, "/api/v1/workspaces/x/items/y")
+
+	got := counterValue(t, s.metrics.MCPAuthzDenialsTotal.WithLabelValues("tier_mismatch"))
+	if got != 2 {
+		t.Errorf("MCPAuthzDenialsTotal{tier_mismatch}: got %v, want 2", got)
+	}
+
+	// Other reasons untouched — sanity check the wiring didn't fan out.
+	for _, r := range []string{"audience_mismatch", "rate_limited", "workspace_not_in_allowlist", "not_a_member"} {
+		if got := counterValue(t, s.metrics.MCPAuthzDenialsTotal.WithLabelValues(r)); got != 0 {
+			t.Errorf("MCPAuthzDenialsTotal{%s}: got %v, want 0 (untouched)", r, got)
+		}
+	}
+
+	// Nil metrics → no panic.
+	s2 := &Server{metrics: nil}
+	s2.RecordMCPTierMismatch(http.MethodPost, "/whatever")
+}
+
 // TestRecordMCPAuthzDenial_GatedOnMCPOrigin verifies the discriminator:
 // the counter only increments when the request context carries an MCP
 // token identity (set by MCPBearerAuth). Non-MCP requests must be


### PR DESCRIPTION
## Summary

Wire the dispatcher-side scope-deny seam into `pad_mcp_authz_denials_total`, completing the denial-reason vocabulary documented in TASK-961 (PR #398). Tier-mismatch denials on /mcp tool calls now show up under `{reason=\"tier_mismatch\"}` in the Grafana dashboard.

## How

- `internal/mcp/dispatch_http.go` — added optional `OnScopeDenied(method, urlPath)` callback on `HTTPHandlerDispatcher`, fired from `buildAuthedRequest` right before returning the existing `permission_denied` error. Control flow unchanged.
- `internal/server/middleware_auth.go` — public `Server.RecordMCPTierMismatch` helper that bumps the counter (no MCP-origin context gate — the dispatcher is by construction MCP-only).
- `cmd/pad/main.go` — wire `dispatcher.OnScopeDenied = srv.RecordMCPTierMismatch`. Safe unconditional attach because the helper nil-checks metrics internally (mirrors the OAuth observer wiring from TASK-961).

## Context

Implements TASK-1119 under PLAN-943. Follow-up to TASK-961 (PR #398).

## Test plan
- [x] Three new dispatcher tests (`TestHTTPHandlerDispatcher_OnScopeDenied_FiresOnce`, `_NotFiredOnAllow`, `_NilSafe`)
- [x] Server-side `TestRecordMCPTierMismatch` covering the counter increment, untouched-reason isolation, and nil-metrics safety
- [x] `make check` clean (golangci-lint + go test ./... + web build, 0 errors)