### PR TITLE
feat(metrics): session-id-keyed TTL sweep for mcp_active_sessions (TASK-1120)

### DIFF
--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -45,6 +45,7 @@ import (
 	"github.com/PerpetualSoftware/pad/internal/server"
 	"github.com/PerpetualSoftware/pad/internal/store"
 	"github.com/PerpetualSoftware/pad/internal/webhooks"
+	"github.com/google/uuid"
 	mcptransport "github.com/mark3labs/mcp-go/server"
 	"github.com/redis/go-redis/v9"
 	"golang.org/x/term"
@@ -417,10 +418,24 @@ func serveCmd() *cobra.Command {
 				// Stateless mode: every Streamable HTTP request stands
 				// alone, Bearer is the auth, no session resumption to
 				// manage. Matches the spike's verified shape.
+				// Stateless transport: every request stands alone; Bearer is the
+				// auth; no session resumption. mcp-go's WithStateLess(true)
+				// would do this exactly, BUT it wires StatelessSessionIdManager
+				// whose Generate() returns "" — so the response never carries
+				// Mcp-Session-Id, which makes the active-sessions tracker
+				// (TASK-1120) unobservable in production.
+				//
+				// Use a generate-only manager instead: every initialize gets a
+				// unique UUID on the response (so the tracker can key on it),
+				// but Validate accepts ANY incoming header value (including
+				// empty / arbitrary), so clients that never echo the
+				// session-id behave exactly as they did under the original
+				// WithStateLess(true) setup. Codex review on PR #400 round 1
+				// caught the gauge-stays-at-zero gap.
 				streamable := mcptransport.NewStreamableHTTPServer(
 					mcpSrv.MCP(),
 					mcptransport.WithEndpointPath("/mcp"),
-					mcptransport.WithStateLess(true),
+					mcptransport.WithSessionIdManager(&padMCPGenerateOnlySessionIDManager{}),
 				)
 				// TASK-1120: optional env-driven overrides for the
 				// mcp-active-sessions tracker. Both default to the
@@ -1241,6 +1256,43 @@ workspaces with no owner).`,
 		},
 	}
 	return cmd
+}
+
+// padMCPGenerateOnlySessionIDManager is the SessionIdManager used for
+// the /mcp Streamable HTTP transport (TASK-1120). It produces a fresh
+// UUID on every initialize so the response carries Mcp-Session-Id
+// (which the active-sessions tracker reads), but accepts ANY incoming
+// session-id value — including empty strings — without rejection.
+//
+// This intentionally diverges from both shipped mcp-go managers:
+//
+//   - StatelessSessionIdManager: Generate() returns "" → tracker can't
+//     observe sessions in production. Original choice; broken for
+//     observability after TASK-1120.
+//   - StatelessGeneratingSessionIdManager: Generate() works, BUT
+//     Validate() rejects clients that don't echo the spec'd UUID
+//     prefix → breaking change for any client previously running
+//     under WithStateLess(true) that didn't track session-id.
+//
+// We're truly stateless server-side (no DB, no map of session IDs to
+// validate against), so accepting any incoming value is correct: the
+// "session" is purely a per-request observability label and the
+// server doesn't depend on any client honoring it. Termination is a
+// no-op for the same reason — there's no per-session state to free
+// when DELETE arrives, and the active-sessions tracker handles its
+// own bookkeeping.
+type padMCPGenerateOnlySessionIDManager struct{}
+
+func (padMCPGenerateOnlySessionIDManager) Generate() string {
+	return "pad-mcp-" + uuid.NewString()
+}
+
+func (padMCPGenerateOnlySessionIDManager) Validate(string) (isTerminated bool, err error) {
+	return false, nil
+}
+
+func (padMCPGenerateOnlySessionIDManager) Terminate(string) (isNotAllowed bool, err error) {
+	return false, nil
 }
 
 // humanBytes formats a byte count with the smallest IEC unit that

--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -422,6 +422,15 @@ func serveCmd() *cobra.Command {
 					mcptransport.WithEndpointPath("/mcp"),
 					mcptransport.WithStateLess(true),
 				)
+				// TASK-1120: optional env-driven overrides for the
+				// mcp-active-sessions tracker. Both default to the
+				// package values (30m TTL, 5m sweep) when unset. Must
+				// be applied BEFORE SetMCPTransport, which spawns the
+				// tracker — calling after has no effect.
+				srv.SetMCPSessionTrackerConfig(
+					parseDurationEnv("PAD_MCP_SESSION_TTL", 0),
+					parseDurationEnv("PAD_MCP_SESSION_SWEEP_INTERVAL", 0),
+				)
 				srv.SetMCPTransport(streamable, cfg.MCPPublicURL, cfg.AuthServerURL)
 				slog.Info("MCP /mcp transport mounted",
 					"public_url", cfg.MCPPublicURL,

--- a/internal/server/handlers_mcp.go
+++ b/internal/server/handlers_mcp.go
@@ -74,6 +74,15 @@ func (s *Server) SetMCPTransport(transport http.Handler, mcpPublicURL, authServe
 	// SetMCPTransport. The writer outlives the request flow; it's
 	// stopped from Server.Stop via stopMCPAuditWriter.
 	s.startMCPAuditWriter()
+
+	// Spawn the session tracker + periodic sweeper (PLAN-943
+	// TASK-1120). Replaces the naive +1/-1 active-sessions gauge
+	// accounting that drifted upward on crashed clients. Idempotent
+	// like startMCPAuditWriter. ttl + sweep interval are tuned via
+	// PAD_MCP_SESSION_TTL / PAD_MCP_SESSION_SWEEP_INTERVAL by
+	// cmd/pad through SetMCPSessionTrackerConfig before this call;
+	// otherwise the package defaults (ttl=30m, sweep=5m) apply.
+	s.startMCPSessionTracker()
 }
 
 // registerMCPRoutes installs the /mcp + /.well-known endpoints on r,

--- a/internal/server/middleware_mcp_audit.go
+++ b/internal/server/middleware_mcp_audit.go
@@ -314,6 +314,22 @@ func (s *Server) MCPAuditLog(next http.Handler) http.Handler {
 		// Fired AFTER enqueue so a metrics misconfigure (nil registry
 		// in test builds) can't accidentally drop the audit row.
 		s.recordMCPCallMetrics(toolName, string(status), user.ID, time.Since(start), r, ww.Status())
+
+		// TASK-1120: session-id-keyed accounting for the
+		// pad_mcp_active_sessions gauge. Replaces the naive
+		// "tool==initialize → +1, method==DELETE → -1" logic that
+		// used to live in recordMCPCallMetrics — that path drifted
+		// upward on crashed clients. The tracker keys by Mcp-Session-Id
+		// and a periodic sweeper evicts stale entries past the TTL,
+		// so the gauge converges on reality even when clients vanish
+		// without a clean DELETE.
+		//
+		// Pulling the headers via closures (rather than passing the
+		// http.Header values) lets trackMCPSession be tested with
+		// plain map[string]string fixtures without spinning up a
+		// full http.Request — the seam matches the helper's signature
+		// in middleware_mcp_session.go.
+		s.trackMCPSession(r.Header.Get, ww.Header().Get, r.Method, ww.Status())
 	})
 }
 
@@ -322,16 +338,15 @@ func (s *Server) MCPAuditLog(next http.Handler) http.Handler {
 // from MCPAuditLog so the audit hot path stays focused on its own
 // concerns and metrics maintenance touches one method.
 //
-// Session gauge accounting: MCP Streamable HTTP carries session
-// lifecycle through method names + HTTP verbs:
-//   - tool method "initialize"     → session opens (+1)
-//   - HTTP DELETE on /mcp           → session closes per spec (-1)
-//
-// Anything else is a per-message call inside an existing session
-// (no gauge change). The gauge is intentionally cheap — best-effort
-// accounting for a "do we have anomalous open sessions?" alert,
-// not a transaction log.
-func (s *Server) recordMCPCallMetrics(tool, status, userID string, dur time.Duration, r *http.Request, httpStatus int) {
+// Session-gauge accounting moved to trackMCPSession in TASK-1120 —
+// the previous "tool==initialize → +1, method==DELETE → -1" logic
+// drifted upward on crashed clients. The tracker keys by
+// Mcp-Session-Id with a TTL sweeper, so the gauge converges on
+// reality without depending on a clean shutdown handshake. The r
+// + httpStatus parameters stay in the signature for now — callers
+// already plumb them and a future per-status histogram would want
+// them back — they're explicitly unused via the underscore names.
+func (s *Server) recordMCPCallMetrics(tool, status, userID string, dur time.Duration, _ *http.Request, _ int) {
 	if s.metrics == nil {
 		return
 	}
@@ -340,19 +355,6 @@ func (s *Server) recordMCPCallMetrics(tool, status, userID string, dur time.Dura
 	// would explode the series count without a clear analytical
 	// payoff (alerts care about p95 latency per tool, not per user).
 	s.metrics.MCPToolCallDuration.WithLabelValues(tool).Observe(dur.Seconds())
-
-	// Session lifecycle. We only adjust on successful calls (2xx);
-	// a failed initialize doesn't actually open a session, and a
-	// failed DELETE didn't close one. classifyMCPResult collapses
-	// HTTP 200 + 0 to "ok" so this matches the audit row's status.
-	if httpStatus == http.StatusOK || httpStatus == 0 {
-		switch {
-		case tool == "initialize":
-			s.metrics.MCPActiveSessions.Inc()
-		case r.Method == http.MethodDelete:
-			s.metrics.MCPActiveSessions.Dec()
-		}
-	}
 }
 
 // parseMCPRequestBody extracts (tool_name, args_hash) from the

--- a/internal/server/middleware_mcp_audit_test.go
+++ b/internal/server/middleware_mcp_audit_test.go
@@ -232,6 +232,11 @@ func TestMCPAudit_BufferFull_DropsAndIncrementsCounter(t *testing.T) {
 	// Stop the worker first so it doesn't drain while we're filling.
 	// Then enqueue one extra entry; that one must drop.
 	srv.mcpAudit.shutdown()
+	// TASK-1120: SetMCPTransport (called by auditedMCPServer setup)
+	// also spawned the session-tracker sweeper on srv.bg. Without
+	// shutting that down too, srv.bg.Wait() below would block on the
+	// sweeper's 5-minute ticker. Mirror what Server.Stop() does.
+	srv.stopMCPSessionTracker()
 	// Wait for the worker goroutine to finish so the queue is
 	// guaranteed not to be drained mid-test.
 	srv.bg.Wait()

--- a/internal/server/middleware_mcp_metrics_test.go
+++ b/internal/server/middleware_mcp_metrics_test.go
@@ -58,30 +58,26 @@ func TestRecordMCPCallMetrics_HappyPath(t *testing.T) {
 	}
 }
 
-// TestRecordMCPCallMetrics_SessionLifecycle covers the gauge logic
-// for initialize / DELETE lifecycle signals.
-func TestRecordMCPCallMetrics_SessionLifecycle(t *testing.T) {
+// TestRecordMCPCallMetrics_DoesNotTouchSessionGauge pins the
+// TASK-1120 invariant: recordMCPCallMetrics must NOT mutate the
+// active-sessions gauge directly. The gauge is now owned by the
+// session tracker (middleware_mcp_session.go) keyed on
+// Mcp-Session-Id, so the audit-side helper deliberately drops the
+// initialize/DELETE accounting it used to do. If a future refactor
+// re-adds gauge updates here, the resulting double-counting would
+// silently corrupt the dashboard — this test is the canary.
+func TestRecordMCPCallMetrics_DoesNotTouchSessionGauge(t *testing.T) {
 	s := &Server{metrics: metrics.New()}
-
 	post := httptest.NewRequest(http.MethodPost, "/mcp", nil)
 	del := httptest.NewRequest(http.MethodDelete, "/mcp", nil)
 
-	// initialize on POST → +1
 	s.recordMCPCallMetrics("initialize", "ok", "u", time.Millisecond, post, http.StatusOK)
-	// another initialize → +1
 	s.recordMCPCallMetrics("initialize", "ok", "u", time.Millisecond, post, http.StatusOK)
-	// DELETE on /mcp → -1 (regardless of inferred tool name)
 	s.recordMCPCallMetrics("(unknown)", "ok", "u", time.Millisecond, del, http.StatusOK)
-
-	if got := gaugeValueOrZero(t, s.metrics.MCPActiveSessions); got != 1 {
-		t.Errorf("MCPActiveSessions after 2 initialize + 1 DELETE: got %v, want 1", got)
-	}
-
-	// Failed initialize (5xx) must NOT bump the gauge — a 500 didn't
-	// open a real session.
 	s.recordMCPCallMetrics("initialize", "error", "u", time.Millisecond, post, http.StatusInternalServerError)
-	if got := gaugeValueOrZero(t, s.metrics.MCPActiveSessions); got != 1 {
-		t.Errorf("MCPActiveSessions after failed initialize: got %v, want 1 (unchanged)", got)
+
+	if got := gaugeValueOrZero(t, s.metrics.MCPActiveSessions); got != 0 {
+		t.Errorf("recordMCPCallMetrics must not touch MCPActiveSessions; got %v", got)
 	}
 }
 

--- a/internal/server/middleware_mcp_session.go
+++ b/internal/server/middleware_mcp_session.go
@@ -1,0 +1,277 @@
+package server
+
+import (
+	"log/slog"
+	"sync"
+	"time"
+)
+
+// MCP session tracker (PLAN-943 TASK-1120).
+//
+// Replaces the naive "+1 on initialize, -1 on HTTP DELETE" gauge
+// accounting that TASK-961 shipped. The naive scheme drifted up over
+// time because clients that crash, lose network, or restart mid-
+// session never emit the spec'd DELETE — the gauge was monotonically
+// non-decreasing under real-world failures.
+//
+// This tracker keeps an in-memory map keyed by the canonical
+// `Mcp-Session-Id` header (set by mcp-go's StreamableHTTPServer on
+// every initialize response and echoed by the client on every
+// subsequent request). Every request that carries a session-id
+// touches the entry's lastSeen; explicit DELETE evicts; and a
+// periodic sweeper evicts entries older than the configured TTL.
+//
+// Gauge semantics:
+//
+//   - The active-sessions Prometheus gauge is set to len(sessions)
+//     by the onChange callback on every state-changing op. Set
+//     (not Inc/Dec) so concurrent observers always see a value
+//     consistent with the post-op map state — no possibility of
+//     gauge ≠ map size after a sweep evicts N at once.
+//   - onChange fires only when the size actually changes, so a
+//     touch on an existing entry doesn't churn the gauge.
+//
+// Bounds:
+//
+//   - One tracker per Server (see s.mcpSessions, wired by
+//     startMCPSessionTracker). Cross-process aggregation is not in
+//     scope; pad-cloud's Prometheus federates per-node series and
+//     the dashboard sums by job.
+//   - The map can grow unbounded between sweeps if a flood of
+//     sessions opens with no DELETE; bounded in practice by the
+//     OAuth token-issuance rate × the TTL window, which is
+//     sub-MB even pessimistically. If we ever see this become a
+//     real cap, the sweeper interval can be lowered without API
+//     impact.
+
+const (
+	// defaultMCPSessionTTL is the default eviction window. Conservative
+	// enough that a long-idle agent session (Claude Desktop sitting
+	// open overnight while the user is in meetings) doesn't get
+	// double-counted, but tight enough that a crashed client clears
+	// within an hour. Override via PAD_MCP_SESSION_TTL.
+	defaultMCPSessionTTL = 30 * time.Minute
+
+	// defaultMCPSessionSweepInterval is how often the sweeper walks
+	// the map. Smaller than the TTL so a crashed session is evicted
+	// within ttl + sweep_interval at worst. Override via
+	// PAD_MCP_SESSION_SWEEP_INTERVAL.
+	defaultMCPSessionSweepInterval = 5 * time.Minute
+)
+
+// mcpSessionTracker is the session lifecycle bookkeeper described
+// above. Field-level concurrency: mu guards sessions; ttl is
+// immutable post-construction; stop is signalled-once via stopped.
+type mcpSessionTracker struct {
+	mu       sync.Mutex
+	sessions map[string]time.Time
+
+	ttl      time.Duration
+	stop     chan struct{}
+	stopped  sync.Once
+	onChange func(count int)
+}
+
+// newMCPSessionTracker constructs a tracker with the given TTL and
+// optional onChange callback. ttl <= 0 falls back to the default;
+// onChange may be nil (the tracker still works, just without gauge
+// updates — useful in tests).
+func newMCPSessionTracker(ttl time.Duration, onChange func(count int)) *mcpSessionTracker {
+	if ttl <= 0 {
+		ttl = defaultMCPSessionTTL
+	}
+	return &mcpSessionTracker{
+		sessions: make(map[string]time.Time),
+		ttl:      ttl,
+		stop:     make(chan struct{}),
+		onChange: onChange,
+	}
+}
+
+// touch inserts or refreshes an entry. No-op on empty id (defensive:
+// callers pre-filter, but a missing header should never bump anything).
+// Fires onChange only when the size actually changes (insert, not
+// refresh) so the gauge doesn't churn on every per-session tool call.
+func (t *mcpSessionTracker) touch(id string) {
+	if id == "" {
+		return
+	}
+	t.mu.Lock()
+	_, existed := t.sessions[id]
+	t.sessions[id] = time.Now().UTC()
+	n := len(t.sessions)
+	t.mu.Unlock()
+	if !existed && t.onChange != nil {
+		t.onChange(n)
+	}
+}
+
+// evict removes an entry. No-op on empty id or unknown id. Fires
+// onChange only when an entry was actually removed.
+func (t *mcpSessionTracker) evict(id string) {
+	if id == "" {
+		return
+	}
+	t.mu.Lock()
+	_, existed := t.sessions[id]
+	delete(t.sessions, id)
+	n := len(t.sessions)
+	t.mu.Unlock()
+	if existed && t.onChange != nil {
+		t.onChange(n)
+	}
+}
+
+// sweep walks the map, evicts entries older than ttl, and returns
+// the eviction count. onChange fires once at the end with the new
+// total — single observation regardless of how many were evicted,
+// which avoids spurious gauge oscillation on a large sweep.
+func (t *mcpSessionTracker) sweep() int {
+	cutoff := time.Now().UTC().Add(-t.ttl)
+	t.mu.Lock()
+	var evicted int
+	for id, last := range t.sessions {
+		if last.Before(cutoff) {
+			delete(t.sessions, id)
+			evicted++
+		}
+	}
+	n := len(t.sessions)
+	t.mu.Unlock()
+	if evicted > 0 && t.onChange != nil {
+		t.onChange(n)
+	}
+	return evicted
+}
+
+// size returns the current entry count. Used by tests and by
+// startMCPSessionTracker's initial gauge prime.
+func (t *mcpSessionTracker) size() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return len(t.sessions)
+}
+
+// run drives the periodic sweeper at the given interval. Exits on
+// stop. Tracked via Server.bg so Stop() can drain in-flight sweeps
+// before the process exits.
+func (t *mcpSessionTracker) run(interval time.Duration) {
+	if interval <= 0 {
+		interval = defaultMCPSessionSweepInterval
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-t.stop:
+			return
+		case <-ticker.C:
+			if n := t.sweep(); n > 0 {
+				slog.Debug("mcp session sweep evicted stale entries", "evicted", n, "remaining", t.size())
+			}
+		}
+	}
+}
+
+// shutdown signals the sweeper to exit. Idempotent — safe to call
+// from Server.Stop alongside other shutdown paths that may have
+// already fired during a test that exercises shutdown twice.
+func (t *mcpSessionTracker) shutdown() {
+	t.stopped.Do(func() {
+		close(t.stop)
+	})
+}
+
+// SetMCPSessionTrackerConfig stashes ttl + sweep-interval overrides
+// for the session tracker before it's started. Either may be 0 to
+// keep the package default. Must be called before SetMCPTransport
+// (which spawns the tracker via startMCPSessionTracker); calling
+// after has no effect because the tracker reads these fields once
+// at construction time.
+//
+// Wired by cmd/pad from PAD_MCP_SESSION_TTL /
+// PAD_MCP_SESSION_SWEEP_INTERVAL so operators can tune the gauge's
+// staleness floor without recompiling.
+func (s *Server) SetMCPSessionTrackerConfig(ttl, sweepInterval time.Duration) {
+	s.mcpSessionTTL = ttl
+	s.mcpSessionSweepInterval = sweepInterval
+}
+
+// startMCPSessionTracker constructs the tracker + spawns the sweep
+// goroutine. Called once at startup from SetMCPTransport (alongside
+// startMCPAuditWriter). No-op if already started — supports the
+// test pattern where multiple Server instances over a shared store
+// would otherwise double-spawn.
+//
+// Reads ttl + sweep interval from the Server fields populated by
+// SetMCPSessionTrackerConfig. Zero values fall back to the package
+// defaults.
+func (s *Server) startMCPSessionTracker() {
+	if s.mcpSessions != nil {
+		return
+	}
+	onChange := func(int) {} // no-op default — replaced below if metrics are wired
+	if s.metrics != nil {
+		gauge := s.metrics.MCPActiveSessions
+		onChange = func(n int) {
+			gauge.Set(float64(n))
+		}
+	}
+	s.mcpSessions = newMCPSessionTracker(s.mcpSessionTTL, onChange)
+	sweepInterval := s.mcpSessionSweepInterval
+	s.goAsync(func() {
+		s.mcpSessions.run(sweepInterval)
+	})
+}
+
+// stopMCPSessionTracker signals the sweeper to exit. Called from
+// Server.Stop. Idempotent.
+func (s *Server) stopMCPSessionTracker() {
+	if s.mcpSessions == nil {
+		return
+	}
+	s.mcpSessions.shutdown()
+}
+
+// trackMCPSession is the per-request hook the audit middleware calls
+// after next.ServeHTTP. It pulls the session id from the response
+// header (set by mcp-go on initialize responses) or the request
+// header (echoed by the client on subsequent requests), then either
+// touches or evicts based on the request method.
+//
+// Method semantics:
+//   - HTTP DELETE on /mcp is the spec'd session-end signal. Evict
+//     unconditionally; failed DELETEs don't matter (the client
+//     considers the session over either way).
+//   - Anything else is a per-message call; touch updates lastSeen.
+//
+// Status filter: only touch on successful or unknown-status responses
+// (httpStatus 0 covers the no-status case from inner handlers that
+// never called WriteHeader). A failed initialize doesn't open a
+// session — touching anyway would re-introduce the original drift bug
+// in a subtler form. classifyMCPResult collapses 0+200 to "ok" for
+// the audit row's status, so this matches the audit row's view.
+//
+// No-op when the tracker isn't wired (selfhost / tests).
+const mcpSessionIDHeader = "Mcp-Session-Id"
+
+func (s *Server) trackMCPSession(reqHeader, respHeader func(string) string, method string, httpStatus int) {
+	if s.mcpSessions == nil {
+		return
+	}
+	id := respHeader(mcpSessionIDHeader)
+	if id == "" {
+		id = reqHeader(mcpSessionIDHeader)
+	}
+	if id == "" {
+		return
+	}
+	if method == "DELETE" {
+		s.mcpSessions.evict(id)
+		return
+	}
+	if httpStatus != 0 && (httpStatus < 200 || httpStatus >= 300) {
+		return
+	}
+	s.mcpSessions.touch(id)
+}

--- a/internal/server/middleware_mcp_session.go
+++ b/internal/server/middleware_mcp_session.go
@@ -92,43 +92,61 @@ func newMCPSessionTracker(ttl time.Duration, onChange func(count int)) *mcpSessi
 // callers pre-filter, but a missing header should never bump anything).
 // Fires onChange only when the size actually changes (insert, not
 // refresh) so the gauge doesn't churn on every per-session tool call.
+//
+// Critical: onChange is called WHILE holding mu, not after the
+// unlock. Codex round 1 on PR #400 caught the race — releasing the
+// lock before the callback lets two concurrent inserts compute
+// (n=1, n=2) under the lock, then race to write Set(1) and Set(2)
+// on the gauge. Last writer wins on the gauge, but the map state
+// is "2 sessions" — gauge would permanently disagree with size.
+// Holding the lock serializes the (compute n, observe n) pair so
+// every onChange invocation reflects a consistent map snapshot.
+//
+// Safety: onChange is the gauge.Set closure wired by
+// startMCPSessionTracker; it doesn't reach back into the tracker so
+// there's no re-entrancy risk. If a future caller wires an onChange
+// that DID re-enter (e.g. calls touch from the callback), this will
+// deadlock — that's a deliberate trade-off (correctness over
+// re-entrancy) and the deadlock is a clear failure mode rather than
+// silent metric corruption.
 func (t *mcpSessionTracker) touch(id string) {
 	if id == "" {
 		return
 	}
 	t.mu.Lock()
+	defer t.mu.Unlock()
 	_, existed := t.sessions[id]
 	t.sessions[id] = time.Now().UTC()
-	n := len(t.sessions)
-	t.mu.Unlock()
 	if !existed && t.onChange != nil {
-		t.onChange(n)
+		t.onChange(len(t.sessions))
 	}
 }
 
 // evict removes an entry. No-op on empty id or unknown id. Fires
-// onChange only when an entry was actually removed.
+// onChange only when an entry was actually removed. See touch's
+// comment for why onChange runs under the lock.
 func (t *mcpSessionTracker) evict(id string) {
 	if id == "" {
 		return
 	}
 	t.mu.Lock()
+	defer t.mu.Unlock()
 	_, existed := t.sessions[id]
 	delete(t.sessions, id)
-	n := len(t.sessions)
-	t.mu.Unlock()
 	if existed && t.onChange != nil {
-		t.onChange(n)
+		t.onChange(len(t.sessions))
 	}
 }
 
 // sweep walks the map, evicts entries older than ttl, and returns
 // the eviction count. onChange fires once at the end with the new
 // total — single observation regardless of how many were evicted,
-// which avoids spurious gauge oscillation on a large sweep.
+// which avoids spurious gauge oscillation on a large sweep. Same
+// lock-held-across-callback contract as touch / evict.
 func (t *mcpSessionTracker) sweep() int {
 	cutoff := time.Now().UTC().Add(-t.ttl)
 	t.mu.Lock()
+	defer t.mu.Unlock()
 	var evicted int
 	for id, last := range t.sessions {
 		if last.Before(cutoff) {
@@ -136,10 +154,8 @@ func (t *mcpSessionTracker) sweep() int {
 			evicted++
 		}
 	}
-	n := len(t.sessions)
-	t.mu.Unlock()
 	if evicted > 0 && t.onChange != nil {
-		t.onChange(n)
+		t.onChange(len(t.sessions))
 	}
 	return evicted
 }

--- a/internal/server/middleware_mcp_session_test.go
+++ b/internal/server/middleware_mcp_session_test.go
@@ -181,6 +181,72 @@ func TestMCPSessionTracker_ConcurrentTouchEvict(t *testing.T) {
 	}
 }
 
+// TestMCPSessionTracker_OnChangeUnderLock pins the Codex round-1 fix
+// for the race where onChange ran AFTER the mutex was released:
+// concurrent touches could compute (n=1, n=2) under the lock then
+// race the callback writes, leaving the gauge at 1 while the map
+// holds 2 entries (last writer wins on the gauge but loses the
+// observation order).
+//
+// We assert by recording (size, observation) pairs from inside the
+// callback. With the lock held across onChange, every observation
+// matches the actual map size at observation time — no `recorded[i] <
+// recorded[i-1]` after a sequence of pure inserts.
+func TestMCPSessionTracker_OnChangeUnderLock(t *testing.T) {
+	const goroutines = 32
+	const opsPerGoroutine = 50
+
+	var (
+		mu       sync.Mutex
+		observed []int
+	)
+	tr := newMCPSessionTracker(time.Hour, func(n int) {
+		mu.Lock()
+		observed = append(observed, n)
+		mu.Unlock()
+	})
+
+	var wg sync.WaitGroup
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			// Each goroutine touches a unique id repeatedly. Only the
+			// first touch fires onChange; the rest are refreshes.
+			id := "sess-touch-" + string(rune('A'+g))
+			for i := 0; i < opsPerGoroutine; i++ {
+				tr.touch(id)
+			}
+		}(g)
+	}
+	wg.Wait()
+
+	// Exactly `goroutines` onChange invocations (one per first-touch).
+	if got := len(observed); got != goroutines {
+		t.Fatalf("onChange invocations: got %d, want %d", got, goroutines)
+	}
+
+	// With the lock held, observations form a strictly monotonic
+	// sequence 1, 2, 3, ... goroutines (one per insert, no reorder).
+	// Without the fix, a race would let observations land out of order
+	// and this assertion would fail intermittently under -race.
+	for i, n := range observed {
+		want := i + 1
+		if n != want {
+			t.Errorf("observed[%d] = %d, want %d (sequence: %v)", i, n, want, observed)
+			break
+		}
+	}
+
+	// Final map size matches the last observation.
+	if got := tr.size(); got != goroutines {
+		t.Errorf("final size: got %d, want %d", got, goroutines)
+	}
+	if observed[len(observed)-1] != goroutines {
+		t.Errorf("last observation: got %d, want %d", observed[len(observed)-1], goroutines)
+	}
+}
+
 // TestMCPSessionTracker_RunStopsCleanly verifies the run() loop
 // exits promptly after shutdown(). Uses a tight sweep interval so
 // the goroutine has cycled at least once before we stop it.

--- a/internal/server/middleware_mcp_session_test.go
+++ b/internal/server/middleware_mcp_session_test.go
@@ -1,0 +1,360 @@
+package server
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/metrics"
+)
+
+// Tests for the MCP session tracker (PLAN-943 TASK-1120). The tracker
+// replaces the naive +1/-1 active-sessions accounting with a map
+// keyed by Mcp-Session-Id plus a periodic TTL sweeper. These tests
+// exercise the tracker in isolation; the trackMCPSession seam that
+// the audit middleware uses gets its own tests below so the
+// integration contract is also pinned.
+
+// TestMCPSessionTracker_TouchInsertsAndDeduplicates pins the touch
+// semantics: first insert fires onChange (gauge bump), repeat
+// touches refresh lastSeen but do NOT fire onChange (no gauge churn
+// per per-session tool call).
+func TestMCPSessionTracker_TouchInsertsAndDeduplicates(t *testing.T) {
+	var fired int
+	var lastCount int
+	tr := newMCPSessionTracker(time.Minute, func(n int) {
+		fired++
+		lastCount = n
+	})
+
+	tr.touch("sess-a")
+	if fired != 1 || lastCount != 1 {
+		t.Errorf("after first touch: fired=%d count=%d, want fired=1 count=1", fired, lastCount)
+	}
+
+	tr.touch("sess-a") // refresh — must NOT bump
+	if fired != 1 {
+		t.Errorf("repeat touch must not fire onChange; fired=%d, want 1", fired)
+	}
+
+	tr.touch("sess-b")
+	if fired != 2 || lastCount != 2 {
+		t.Errorf("after second distinct touch: fired=%d count=%d, want fired=2 count=2", fired, lastCount)
+	}
+
+	if got := tr.size(); got != 2 {
+		t.Errorf("size: got %d, want 2", got)
+	}
+}
+
+// TestMCPSessionTracker_TouchEmptyIDIsNoOp guards against a stray
+// empty header dropping a phantom entry into the map.
+func TestMCPSessionTracker_TouchEmptyIDIsNoOp(t *testing.T) {
+	var fired int
+	tr := newMCPSessionTracker(time.Minute, func(int) { fired++ })
+
+	tr.touch("")
+	if tr.size() != 0 {
+		t.Errorf("empty id must not insert; size=%d", tr.size())
+	}
+	if fired != 0 {
+		t.Errorf("empty id must not fire onChange; fired=%d", fired)
+	}
+}
+
+// TestMCPSessionTracker_EvictRemovesAndFires verifies evict bumps
+// onChange ONLY when an entry was actually present.
+func TestMCPSessionTracker_EvictRemovesAndFires(t *testing.T) {
+	var fired int
+	var lastCount int
+	tr := newMCPSessionTracker(time.Minute, func(n int) {
+		fired++
+		lastCount = n
+	})
+
+	tr.touch("sess-a") // fires once
+	tr.evict("sess-a") // fires again
+	if fired != 2 || lastCount != 0 {
+		t.Errorf("after touch+evict: fired=%d count=%d, want fired=2 count=0", fired, lastCount)
+	}
+
+	// Evict an unknown id — must NOT fire (would create false-positive
+	// gauge churn on benign DELETEs from clients that already lost
+	// their session record).
+	tr.evict("never-existed")
+	if fired != 2 {
+		t.Errorf("evict of unknown id must not fire onChange; fired=%d", fired)
+	}
+}
+
+// TestMCPSessionTracker_SweepEvictsStale exercises the TTL sweeper:
+// entries older than ttl are removed, recent entries survive, and a
+// single onChange observation fires per sweep regardless of how many
+// entries are evicted (avoids spurious gauge oscillation).
+func TestMCPSessionTracker_SweepEvictsStale(t *testing.T) {
+	var fired int
+	tr := newMCPSessionTracker(50*time.Millisecond, func(int) { fired++ })
+
+	// Three "old" entries directly written into the map below the
+	// touch path so we control the lastSeen exactly. Touch first to
+	// register, then rewind their timestamps.
+	tr.touch("old-1")
+	tr.touch("old-2")
+	tr.touch("old-3")
+	tr.touch("fresh")
+	firedAfterTouches := fired
+
+	rewind := time.Now().UTC().Add(-time.Hour)
+	tr.mu.Lock()
+	tr.sessions["old-1"] = rewind
+	tr.sessions["old-2"] = rewind
+	tr.sessions["old-3"] = rewind
+	tr.mu.Unlock()
+
+	evicted := tr.sweep()
+	if evicted != 3 {
+		t.Errorf("sweep evicted %d, want 3", evicted)
+	}
+	if got := tr.size(); got != 1 {
+		t.Errorf("size after sweep: got %d, want 1 (only 'fresh' should remain)", got)
+	}
+	// Single onChange observation per sweep — fired exactly once on top
+	// of the touch-time observations.
+	if fired != firedAfterTouches+1 {
+		t.Errorf("sweep onChange: got %d total fires (was %d after touches), want exactly one more",
+			fired, firedAfterTouches)
+	}
+
+	// Sweep again with nothing stale → no fire, no eviction.
+	prev := fired
+	if got := tr.sweep(); got != 0 {
+		t.Errorf("idle sweep evicted %d, want 0", got)
+	}
+	if fired != prev {
+		t.Errorf("idle sweep must not fire onChange; got %d additional fires", fired-prev)
+	}
+}
+
+// TestMCPSessionTracker_NilOnChangeIsSafe verifies the tracker works
+// without an onChange callback (used by tests / non-metrics builds).
+func TestMCPSessionTracker_NilOnChangeIsSafe(t *testing.T) {
+	tr := newMCPSessionTracker(time.Minute, nil)
+	tr.touch("a")
+	tr.touch("b")
+	tr.evict("a")
+	tr.sweep() // no panic
+	if got := tr.size(); got != 1 {
+		t.Errorf("size: got %d, want 1", got)
+	}
+}
+
+// TestMCPSessionTracker_ConcurrentTouchEvict exercises the mutex
+// under concurrent load. Run with -race in CI; the assertion here
+// is just that the final size is what the call counts say it should
+// be.
+func TestMCPSessionTracker_ConcurrentTouchEvict(t *testing.T) {
+	tr := newMCPSessionTracker(time.Minute, nil)
+
+	const goroutines = 16
+	const iterations = 200
+
+	var wg sync.WaitGroup
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			id := "sess-" + string(rune('A'+g))
+			for i := 0; i < iterations; i++ {
+				tr.touch(id)
+				if i%4 == 0 {
+					tr.evict(id)
+				}
+			}
+		}(g)
+	}
+	wg.Wait()
+
+	// Every goroutine ends with at least one final touch (i loops
+	// to 199; 199 % 4 != 0), so each id should be present.
+	if got := tr.size(); got != goroutines {
+		t.Errorf("size after concurrent ops: got %d, want %d", got, goroutines)
+	}
+}
+
+// TestMCPSessionTracker_RunStopsCleanly verifies the run() loop
+// exits promptly after shutdown(). Uses a tight sweep interval so
+// the goroutine has cycled at least once before we stop it.
+func TestMCPSessionTracker_RunStopsCleanly(t *testing.T) {
+	tr := newMCPSessionTracker(time.Minute, nil)
+
+	done := make(chan struct{})
+	go func() {
+		tr.run(5 * time.Millisecond)
+		close(done)
+	}()
+
+	// Let the loop tick at least once.
+	time.Sleep(20 * time.Millisecond)
+	tr.shutdown()
+
+	select {
+	case <-done:
+		// expected
+	case <-time.After(time.Second):
+		t.Fatal("run() did not exit within 1s of shutdown()")
+	}
+
+	// Idempotent — calling shutdown twice must not panic on a
+	// double channel close.
+	tr.shutdown()
+}
+
+// TestServer_TrackMCPSession_LifecycleHappyPath covers the
+// integration seam the audit middleware uses: trackMCPSession
+// pulls the session-id from the response header (initialize) or
+// request header (subsequent calls), touches on success, evicts on
+// DELETE.
+func TestServer_TrackMCPSession_LifecycleHappyPath(t *testing.T) {
+	s := &Server{metrics: metrics.New()}
+	s.startMCPSessionTracker()
+	defer s.stopMCPSessionTracker()
+
+	// Helper to build closure-based header readers from a map.
+	header := func(m map[string]string) func(string) string {
+		return func(k string) string { return m[k] }
+	}
+
+	// 1. initialize → response carries the session-id, request doesn't.
+	s.trackMCPSession(
+		header(map[string]string{}),
+		header(map[string]string{"Mcp-Session-Id": "sess-123"}),
+		"POST",
+		200,
+	)
+	if got := gaugeValueOrZero(t, s.metrics.MCPActiveSessions); got != 1 {
+		t.Errorf("after initialize: gauge=%v, want 1", got)
+	}
+
+	// 2. Subsequent tool call → request carries the echoed session-id.
+	s.trackMCPSession(
+		header(map[string]string{"Mcp-Session-Id": "sess-123"}),
+		header(map[string]string{}),
+		"POST",
+		200,
+	)
+	if got := gaugeValueOrZero(t, s.metrics.MCPActiveSessions); got != 1 {
+		t.Errorf("after tool call: gauge=%v, want 1 (unchanged — same session)", got)
+	}
+
+	// 3. DELETE → evicts.
+	s.trackMCPSession(
+		header(map[string]string{"Mcp-Session-Id": "sess-123"}),
+		header(map[string]string{}),
+		"DELETE",
+		200,
+	)
+	if got := gaugeValueOrZero(t, s.metrics.MCPActiveSessions); got != 0 {
+		t.Errorf("after DELETE: gauge=%v, want 0", got)
+	}
+}
+
+// TestServer_TrackMCPSession_FailedInitializeDoesNotOpen guards
+// against the bug the original v1 logic also tried to handle: a 500
+// on initialize must NOT register a session.
+func TestServer_TrackMCPSession_FailedInitializeDoesNotOpen(t *testing.T) {
+	s := &Server{metrics: metrics.New()}
+	s.startMCPSessionTracker()
+	defer s.stopMCPSessionTracker()
+
+	noHeader := func(string) string { return "" }
+	withHeader := func(v string) func(string) string {
+		return func(k string) string {
+			if k == "Mcp-Session-Id" {
+				return v
+			}
+			return ""
+		}
+	}
+
+	// 5xx on initialize: tracker must skip even though a session-id
+	// would be present in the response (mcp-go may have set one
+	// before the handler errored).
+	s.trackMCPSession(noHeader, withHeader("sess-fail"), "POST", 500)
+	if got := gaugeValueOrZero(t, s.metrics.MCPActiveSessions); got != 0 {
+		t.Errorf("after failed initialize: gauge=%v, want 0", got)
+	}
+}
+
+// TestServer_TrackMCPSession_NoIDIsNoOp verifies a request with no
+// Mcp-Session-Id in either header doesn't churn the tracker. Covers
+// the corner where the inner handler returned an error before
+// mcp-go got to set the response header.
+func TestServer_TrackMCPSession_NoIDIsNoOp(t *testing.T) {
+	s := &Server{metrics: metrics.New()}
+	s.startMCPSessionTracker()
+	defer s.stopMCPSessionTracker()
+
+	noHeader := func(string) string { return "" }
+	s.trackMCPSession(noHeader, noHeader, "POST", 200)
+
+	if s.mcpSessions.size() != 0 {
+		t.Errorf("no-id call must not insert; tracker size=%d", s.mcpSessions.size())
+	}
+}
+
+// TestServer_TrackMCPSession_NilTrackerIsSafe verifies the helper is
+// a clean no-op on Servers that never wired the tracker (selfhost /
+// tests).
+func TestServer_TrackMCPSession_NilTrackerIsSafe(t *testing.T) {
+	s := &Server{metrics: metrics.New()}
+	// Intentionally NOT calling startMCPSessionTracker.
+	noHeader := func(string) string { return "" }
+	s.trackMCPSession(noHeader, noHeader, "POST", 200) // no panic
+}
+
+// TestServer_StartMCPSessionTracker_Idempotent guards the
+// "called twice from a test that flips MCP transport state" path.
+// First call wires the tracker; second is a no-op.
+func TestServer_StartMCPSessionTracker_Idempotent(t *testing.T) {
+	s := &Server{metrics: metrics.New()}
+	s.startMCPSessionTracker()
+	tracker1 := s.mcpSessions
+	s.startMCPSessionTracker()
+	if s.mcpSessions != tracker1 {
+		t.Error("second startMCPSessionTracker re-created the tracker (expected no-op)")
+	}
+	s.stopMCPSessionTracker()
+	s.bg.Wait()
+}
+
+// TestServer_TrackMCPSession_DeleteEvictsOnAnyStatus pins the spec
+// behavior: the client considers the session over once it sends
+// DELETE, so the server should evict regardless of the response
+// status. Otherwise a transient 5xx on the DELETE path would leave
+// the session pinned in the gauge until TTL eviction.
+func TestServer_TrackMCPSession_DeleteEvictsOnAnyStatus(t *testing.T) {
+	s := &Server{metrics: metrics.New()}
+	s.startMCPSessionTracker()
+	defer s.stopMCPSessionTracker()
+
+	withHeader := func(v string) func(string) string {
+		return func(k string) string {
+			if k == "Mcp-Session-Id" {
+				return v
+			}
+			return ""
+		}
+	}
+
+	// Open a session.
+	s.trackMCPSession(func(string) string { return "" }, withHeader("sess-x"), "POST", 200)
+	if got := gaugeValueOrZero(t, s.metrics.MCPActiveSessions); got != 1 {
+		t.Fatalf("setup: want 1, got %v", got)
+	}
+
+	// DELETE that came back 500 — still evicts.
+	s.trackMCPSession(withHeader("sess-x"), func(string) string { return "" }, "DELETE", 500)
+	if got := gaugeValueOrZero(t, s.metrics.MCPActiveSessions); got != 0 {
+		t.Errorf("after failed DELETE: gauge=%v, want 0 (evict on any DELETE status)", got)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -105,6 +105,17 @@ type Server struct {
 	// writer still work. See middleware_mcp_audit.go.
 	mcpAudit *mcpAuditWriter
 
+	// MCP session tracker (PLAN-943 TASK-1120). Replaces the naive
+	// +1/-1 active-sessions accounting from TASK-961. Wired by
+	// startMCPSessionTracker (called from SetMCPTransport in cloud
+	// mode); shut down from Server.Stop alongside the audit writer.
+	// nil-safe: trackMCPSession + the gauge-update path both
+	// nil-check so non-cloud builds + tests run without the tracker.
+	// See middleware_mcp_session.go.
+	mcpSessions             *mcpSessionTracker
+	mcpSessionTTL           time.Duration // 0 → defaultMCPSessionTTL
+	mcpSessionSweepInterval time.Duration // 0 → defaultMCPSessionSweepInterval
+
 	// storageInfoCache memoizes per-workspace storage usage summaries
 	// behind a short TTL (storageInfoTTL). Reduces DB load on the
 	// Settings → Storage page and quota-aware UI surfaces. Initialized
@@ -176,6 +187,10 @@ func (s *Server) Stop() {
 	// signal Wait would hang forever on the writer's blocking
 	// queue receive.
 	s.stopMCPAuditWriter()
+	// MCP session tracker (TASK-1120) runs its sweeper on s.bg too.
+	// Order with the audit writer doesn't matter — both are
+	// independent goroutines; we just need the close BEFORE Wait().
+	s.stopMCPSessionTracker()
 	s.bg.Wait()
 	s.rateLimiters.Stop() // nil-safe via the RateLimiters receiver guard
 }


### PR DESCRIPTION
## Summary

Replaces the naive +1/-1 active-sessions accounting from TASK-961 (PR #398) with a session-id-keyed map plus a periodic TTL sweeper. Closes the \"gauge drifts upward on crashed clients\" caveat documented in the metric's help text + the Grafana panel description.

## How

- **`internal/server/middleware_mcp_session.go`** (new) — `mcpSessionTracker` is an in-memory map keyed by `Mcp-Session-Id` (the canonical header set by mcp-go's `StreamableHTTPServer` on `initialize` responses and echoed by the client on every subsequent request). Touch updates lastSeen on insert + refresh; evict removes; periodic sweeper evicts entries older than the TTL.
- **Gauge semantics:** `Set(len(sessions))` via an onChange callback — single consistent observation per state-changing op, no risk of gauge drifting from map size on a multi-evict sweep.
- **Lifecycle:** spawned by `SetMCPTransport` (alongside `startMCPAuditWriter`), shut down from `Server.Stop`. Idempotent on both sides.
- **Configurable** via `PAD_MCP_SESSION_TTL` (default 30m) and `PAD_MCP_SESSION_SWEEP_INTERVAL` (default 5m). cmd/pad calls `Server.SetMCPSessionTrackerConfig` before `SetMCPTransport`.
- **`recordMCPCallMetrics`** no longer touches the active-sessions gauge — the tracker owns it now.
- **`MCPAuditLog`** middleware calls `trackMCPSession` after `next.ServeHTTP` (single new line in the audit hot path).
- **`TestMCPAudit_BufferFull_DropsAndIncrementsCounter`** updated to also shut down the session tracker before `bg.Wait()`, since `SetMCPTransport` now spawns two goroutines on `srv.bg`.

## Context

Implements TASK-1120 under PLAN-943. Follow-up to TASK-961 (PR #398).

## Test plan

16 tests, all green under `-race`:

- Tracker unit: touch insert/dedup, empty-id no-op, evict remove/non-existent, sweep eviction with single onChange, nil-onChange safety, concurrent touch/evict, `run()` clean shutdown.
- Server-side integration: lifecycle happy path (initialize → call → DELETE leaves gauge at 0), failed initialize doesn't open, no-session-id no-op, nil tracker safety, idempotent start, DELETE evicts on any status (transient 5xx on shutdown still counts).
- Regression guard: `TestRecordMCPCallMetrics_DoesNotTouchSessionGauge` pins that the audit-side helper has migrated off the gauge.

- [x] `go test ./... -race` — clean
- [x] `make check` (golangci-lint + go test ./... + web build) — clean