### PR TITLE
feat(mobile): consolidate topbar + search palette UX (IDEA-1121)

### DIFF
--- a/web/src/lib/components/editor/Editor.svelte
+++ b/web/src/lib/components/editor/Editor.svelte
@@ -803,7 +803,19 @@
 
 </script>
 
-{#if isMobile && keyboardVisible && editor}
+<!--
+	Gate on editorFocused, not just keyboardVisible (TASK-1124 follow-up).
+	`keyboardVisible` flips true whenever the on-screen keyboard appears
+	for ANY input — including the global CommandPalette's search input
+	and any other input on the page. Without the editorFocused gate this
+	mobile toolbar (z-index 100) would float over the search palette
+	(z-index 50) whenever the user typed in search on a page that has a
+	tiptap editor mounted. The component already tracks editorFocused via
+	the editor's own focus/blur events (declared at line 308, wired at
+	lines 658-659) — this just makes the toolbar visibility actually
+	consult it.
+-->
+{#if isMobile && keyboardVisible && editor && editorFocused}
 	{@const _tick = editorTick}
 	{@const listItemType = getActiveListItemType()}
 	{@const canIndent = canIndentListItem(listItemType)}

--- a/web/src/lib/components/layout/TopBar.svelte
+++ b/web/src/lib/components/layout/TopBar.svelte
@@ -916,10 +916,29 @@
 		list hides workspaces off-screen. Swap the list + add + reorder
 		buttons for a single WorkspaceSwitcher trigger that opens a full-
 		width BottomSheet (see TASK-637). Reorder is available on desktop.
+
+		As of IDEA-1121 / TASK-1122 the mobile TopBar is the SOLE mobile
+		header — it renders regardless of sidebar state (see +layout.svelte).
+		The previous slim in-content `.mobile-header` (hamburger + switcher)
+		was deleted; the hamburger lives here in the .topbar-left slot,
+		replacing the PadLogo on mobile so the chrome stays a single coherent
+		bar across both sidebar-open and sidebar-closed states.
 	-->
 	<header class="topbar topbar-mobile">
 		<div class="topbar-left">
-			<PadLogo />
+			<button
+				class="mobile-hamburger"
+				onclick={() => uiStore.toggleSidebar()}
+				aria-label={uiStore.sidebarOpen ? 'Close sidebar' : 'Open sidebar'}
+				aria-expanded={uiStore.sidebarOpen}
+				title={uiStore.sidebarOpen ? 'Close sidebar' : 'Open sidebar'}
+			>
+				<svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">
+					<rect y="3" width="20" height="2" rx="1" fill="currentColor"/>
+					<rect y="9" width="20" height="2" rx="1" fill="currentColor"/>
+					<rect y="15" width="20" height="2" rx="1" fill="currentColor"/>
+				</svg>
+			</button>
 		</div>
 		<div class="mobile-switcher-slot">
 			<!--
@@ -930,6 +949,29 @@
 			-->
 			<WorkspaceSwitcher mobile={true} />
 		</div>
+		<!--
+			Mobile-only search trigger (IDEA-1121 / TASK-1122). Desktop has
+			the sidebar's search button + ⌘K hotkey; mobile had no search
+			affordance until this button. Opens the global CommandPalette
+			mounted in +layout.svelte via uiStore.openSearch().
+
+			Also calls uiStore.onNavigate() — which closes the sidebar on
+			mobile (ui.svelte.ts:87) — so picking a search result doesn't
+			leave the sidebar overlay covering the destination page. Mirrors
+			the desktop sidebar's search button (Sidebar.svelte:522). Caught
+			by Codex review of the IDEA-1121 work.
+		-->
+		<button
+			class="mobile-search-btn"
+			onclick={() => { uiStore.openSearch(); uiStore.onNavigate(); }}
+			aria-label="Search"
+			title="Search"
+		>
+			<svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+				<circle cx="7" cy="7" r="4.5" stroke="currentColor" stroke-width="1.5"/>
+				<path d="M10.5 10.5L13.5 13.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+			</svg>
+		</button>
 		{#if authStore.user}
 			<div class="user-menu-container">
 				<button
@@ -1357,6 +1399,61 @@
 	}
 	.collapse-btn:hover {
 		opacity: 1;
+		color: var(--text-primary);
+		background: var(--bg-hover);
+	}
+
+	/*
+		Mobile-only search button (IDEA-1121 / TASK-1122). Sized and
+		styled to match .collapse-btn so the mobile right cluster reads
+		as a coherent set of icon controls. Only ever rendered inside
+		the .topbar-mobile <header>, so no media query needed here.
+	*/
+	.mobile-search-btn {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 28px;
+		height: 28px;
+		border-radius: var(--radius-sm);
+		color: var(--text-muted);
+		cursor: pointer;
+		padding: 0;
+		background: none;
+		border: none;
+		transition: color 0.15s, background 0.15s;
+	}
+	.mobile-search-btn:hover {
+		color: var(--text-primary);
+		background: var(--bg-hover);
+	}
+
+	/*
+		Mobile-only hamburger (IDEA-1121 / TASK-1122). Replaces the desktop
+		PadLogo in the .topbar-left slot on mobile because the hamburger is
+		the universal mobile-app primary affordance and space is tight. Calls
+		uiStore.toggleSidebar() — works in both directions (open when
+		closed, close when open) so a user who opens the sidebar can dismiss
+		it from the same button without hunting for an X. Slightly larger
+		than the icon buttons on the right (32×32 vs 28×28) because it's the
+		primary nav target — easier to thumb-tap and matches typical mobile
+		hamburger sizing. Color tokens mirror the right-cluster icon buttons.
+	*/
+	.mobile-hamburger {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 32px;
+		height: 32px;
+		border-radius: var(--radius-sm);
+		color: var(--text-secondary);
+		cursor: pointer;
+		padding: 0;
+		background: none;
+		border: none;
+		transition: color 0.15s, background 0.15s;
+	}
+	.mobile-hamburger:hover {
 		color: var(--text-primary);
 		background: var(--bg-hover);
 	}

--- a/web/src/lib/components/search/CommandPalette.svelte
+++ b/web/src/lib/components/search/CommandPalette.svelte
@@ -71,6 +71,28 @@
 		}
 	});
 
+	/*
+		Body-scroll lock while the palette is open (TASK-1124 follow-up).
+		Prevents the page underneath from scrolling — both for general
+		modal-correctness reasons and so the underlying page's sticky
+		elements can't shift into view behind the overlay.
+
+		Critical: only lock `overflow`, NOT `touch-action`. Setting
+		`touch-action: none` on body kills scrolling on every descendant
+		too — touches starting on .results would walk up the ancestor
+		chain, find `none` on body, and the browser refuses to scroll
+		ANY element. `overflow: hidden` alone is enough to stop body
+		scroll while leaving child overflow:auto regions scrollable.
+	*/
+	$effect(() => {
+		if (!uiStore.searchOpen) return;
+		const prevOverflow = document.body.style.overflow;
+		document.body.style.overflow = 'hidden';
+		return () => {
+			document.body.style.overflow = prevOverflow;
+		};
+	});
+
 	function buildFilters(offset = 0): SearchFilters {
 		const filters: SearchFilters = {
 			workspace: workspaceStore.current?.slug,
@@ -320,6 +342,23 @@
 					<span class="search-spinner"></span>
 				{/if}
 				<kbd class="search-hint">esc</kbd>
+				<!--
+					Mobile-only close button (TASK-1124). On mobile the palette
+					is a full-screen takeover so there's no overlay area to
+					tap-to-dismiss, and the `esc` hint is useless without a
+					keyboard. CSS hides this on desktop and hides .search-hint
+					on mobile so each surface gets the right affordance.
+				-->
+				<button
+					class="mobile-close"
+					onclick={() => uiStore.closeSearch()}
+					aria-label="Close search"
+					title="Close"
+				>
+					<svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">
+						<path d="M5 5L15 15M15 5L5 15" stroke="currentColor" stroke-width="1.75" stroke-linecap="round"/>
+					</svg>
+				</button>
 			</div>
 
 			<!-- Filter chips -->
@@ -868,5 +907,115 @@
 		overflow: hidden;
 		text-overflow: ellipsis;
 		white-space: nowrap;
+	}
+
+	/*
+		Mobile-only close button (TASK-1124). Hidden on desktop where the
+		`esc` keyboard hint suffices; visible on mobile where there's no
+		keyboard and the full-screen palette has no overlay area to dismiss
+		via tap-outside. Sized to match the .mobile-hamburger / icon-button
+		vocabulary used elsewhere in the mobile chrome.
+	*/
+	.mobile-close {
+		display: none;
+		align-items: center;
+		justify-content: center;
+		width: 32px;
+		height: 32px;
+		border-radius: var(--radius-sm);
+		color: var(--text-secondary);
+		background: none;
+		border: none;
+		cursor: pointer;
+		padding: 0;
+		flex-shrink: 0;
+		transition: color 0.15s, background 0.15s;
+	}
+	.mobile-close:hover {
+		color: var(--text-primary);
+		background: var(--bg-hover);
+	}
+
+	/*
+		Mobile UX overrides for the CommandPalette (IDEA-1121 / TASK-1124).
+		Desktop is byte-identical above this rule — every property here is
+		scoped to ≤768px (the same breakpoint uiStore.isMobile uses, so JS
+		layout decisions and CSS layout stay in sync).
+
+		Key changes:
+
+		• Full-screen takeover. The palette fills the viewport (no rounded
+		  corners, no shadow, no max-width / max-height) so the search input
+		  anchors at the very top. With the input at the top, the on-screen
+		  keyboard pops up from the bottom and the input never has to scroll
+		  to stay visible — eliminating the "things shift when keyboard
+		  appears" problem the centered desktop layout has on phones.
+
+		• 100dvh (dynamic viewport height) instead of 100vh. On iOS Safari
+		  15+ and modern Chrome, `dvh` shrinks when the on-screen keyboard
+		  is shown, so the palette is sized to the *visible* viewport above
+		  the keyboard rather than the full screen behind it. This is what
+		  actually makes the layout stop fighting the keyboard. Older
+		  browsers fall back to the standard viewport (treats as vh).
+
+		• 16px input font. Below 16px iOS Safari auto-zooms the page on
+		  focus, which is the root cause of a separate "everything jumps"
+		  jitter when tapping the input. Forcing 16px on mobile is the
+		  standard mobile-web fix.
+
+		• Hide the `esc` kbd hint, show the X close button. The hint is
+		  meaningless without a hardware keyboard; the X gives users a clear
+		  tap target since the full-screen palette leaves no overlay to
+		  tap-outside.
+	*/
+	@media (max-width: 768px) {
+		.overlay {
+			padding-top: 0;
+			/*
+				Belt-and-braces with the JS body-scroll lock: even if iOS
+				somehow drags the body, the overlay itself can't scroll its
+				own contents. The palette below is height: 100dvh so it
+				exactly fills the overlay; nothing should ever overflow.
+			*/
+			overflow: hidden;
+			overscroll-behavior: contain;
+		}
+		.palette {
+			max-width: none;
+			max-height: 100dvh;
+			height: 100dvh;
+			width: 100%;
+			border: none;
+			border-radius: 0;
+			box-shadow: none;
+		}
+		.search-input {
+			/* iOS Safari skips its focus-zoom only when font-size ≥ 16px. */
+			font-size: 16px;
+		}
+		.search-hint {
+			display: none;
+		}
+		.mobile-close {
+			display: flex;
+		}
+		/*
+			Pin .results as the SOLE scroll target inside the palette so
+			the search-row stays at the top regardless of result-list
+			length. `flex: 1; min-height: 0` lets the flex item shrink
+			below its content size (without min-height: 0, an item with
+			overflow: auto in a flex column refuses to shrink and the
+			whole palette ends up taller than 100dvh — which is what made
+			the input scroll off-screen in the first reported bug).
+			`overscroll-behavior: contain` prevents bounce-scroll from
+			chaining out to the body, which on iOS would re-trigger the
+			scroll-to-input quirk we're trying to suppress.
+		*/
+		.results {
+			flex: 1;
+			min-height: 0;
+			overscroll-behavior: contain;
+			-webkit-overflow-scrolling: touch;
+		}
 	}
 </style>

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -9,7 +9,6 @@
 	import { titleStore } from '$lib/stores/title.svelte';
 	import Sidebar from '$lib/components/layout/Sidebar.svelte';
 	import TopBar from '$lib/components/layout/TopBar.svelte';
-	import WorkspaceSwitcher from '$lib/components/layout/WorkspaceSwitcher.svelte';
 	import CommandPalette from '$lib/components/search/CommandPalette.svelte';
 	import ToastContainer from '$lib/components/common/ToastContainer.svelte';
 	import CreateWorkspaceModal from '$lib/components/layout/CreateWorkspaceModal.svelte';
@@ -167,7 +166,18 @@
 {:else if isAuthPage || isSharePage || isConsolePage}
 	{@render children()}
 {:else}
-	{#if uiStore.isMobile && uiStore.sidebarOpen}
+	{#if uiStore.isMobile}
+		<!--
+			Mobile chrome: a single, always-rendered <TopBar mobile /> (IDEA-1121 /
+			TASK-1122). The previous design rendered TopBar only when the sidebar
+			was open and patched in a slim hamburger-only `.mobile-header` inside
+			.main-content for the sidebar-closed case. That two-header split meant
+			every mobile chrome feature (search, notifications, etc.) had to be
+			added in two places. Consolidated to one bar; the hamburger lives in
+			the TopBar's .topbar-left slot and toggles the sidebar in both
+			directions. .app-layout below pads top by --topbar-height on mobile so
+			content doesn't slide under the fixed bar.
+		-->
 		<TopBar mobile />
 	{/if}
 	<div class="app-layout">
@@ -201,20 +211,6 @@
 				</button>
 			{/if}
 			<main class="main-content">
-				{#if uiStore.isMobile && !uiStore.sidebarOpen}
-					<div class="mobile-header">
-						<button class="hamburger" onclick={() => uiStore.openSidebar()} aria-label="Open sidebar">
-							<svg width="20" height="20" viewBox="0 0 20 20" fill="none">
-								<rect y="3" width="20" height="2" rx="1" fill="currentColor"/>
-								<rect y="9" width="20" height="2" rx="1" fill="currentColor"/>
-								<rect y="15" width="20" height="2" rx="1" fill="currentColor"/>
-							</svg>
-						</button>
-						<div class="mobile-switcher-slot">
-							<WorkspaceSwitcher mobile />
-						</div>
-					</div>
-				{/if}
 				{@render children()}
 			</main>
 		</div>
@@ -246,34 +242,19 @@
 		overflow-y: auto;
 		min-width: 0;
 	}
-	.mobile-header {
-		display: flex;
-		align-items: center;
-		gap: var(--space-3);
-		padding: var(--space-3) var(--space-4);
-		border-bottom: 1px solid var(--border);
-		background: var(--bg-secondary);
-		position: sticky;
-		top: 0;
-		z-index: 5;
-	}
-	.hamburger {
-		padding: var(--space-1);
-		border-radius: var(--radius-sm);
-		color: var(--text-secondary);
-		display: flex;
-		align-items: center;
-		justify-content: center;
-	}
-	.hamburger:hover {
-		background: var(--bg-hover);
-		color: var(--text-primary);
-	}
-	.mobile-switcher-slot {
-		flex: 1;
-		min-width: 0;
-		display: flex;
-		align-items: center;
+	/*
+		Mobile: the consolidated <TopBar mobile /> is rendered as a sibling
+		of .app-layout and uses position: fixed (z-index 35). Without an
+		offset the .app-layout content would slide under the bar. Pad the
+		layout's top by --topbar-height on the same breakpoint that
+		uiStore.isMobile uses (≤768px) so the chrome stacks cleanly. The
+		Sidebar already accounts for --topbar-height itself in its mobile
+		fixed positioning, so the fix lives here on the layout container.
+	*/
+	@media (max-width: 768px) {
+		.app-layout {
+			padding-top: var(--topbar-height);
+		}
 	}
 	/*
 		Expand tabs (both .topbar-expand-btn and .sidebar-expand-btn).

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -1190,11 +1190,19 @@
 		border-bottom: 1px solid transparent;
 		transition: border-color 0.15s ease;
 	}
-	@media (max-width: 768px) {
-		.sticky-header {
-			top: 45px;
-		}
-	}
+	/*
+		Historical note (TASK-1124): there used to be a `@media (max-width:
+		768px) { .sticky-header { top: 45px; } }` rule here that pushed the
+		breadcrumb 45px below the top of its scroll container — to clear the
+		old slim `.mobile-header` (hamburger + switcher) that lived inside
+		.main-content on mobile. After the IDEA-1121 mobile chrome
+		consolidation, that header no longer exists; the topbar is now
+		`position: fixed` outside .main-content and .app-layout pads itself
+		by --topbar-height on mobile, so the breadcrumb's scroll container
+		already starts below the topbar. `top: 0` is correct on both
+		surfaces now — the override is removed to close the gap that the
+		stale 45px offset was producing.
+	*/
 
 	/* Breadcrumb */
 	.breadcrumb {


### PR DESCRIPTION
## Summary

- **Consolidate mobile chrome into one always-rendered `<TopBar mobile />`**. The previous design rendered the full TopBar only when the sidebar was open and patched in a slim inline `.mobile-header` (hamburger + switcher) when it was closed — every mobile-chrome feature had to be added in two places. The hamburger now lives in TopBar's left slot (replacing the desktop logo on mobile) and toggles the sidebar in both directions.
- **Add a mobile search-icon button to the topbar** (the original IDEA-1121 ask) wired to `uiStore.openSearch()` + `uiStore.onNavigate()` so picking a result doesn't leave the sidebar covering the destination page (caught by Codex review, mirrors `Sidebar.svelte:522`).
- **CommandPalette mobile UX**: full-screen takeover (`100dvh`, no max-width / shadow / border-radius) so the input anchors at the top instead of fighting a vertically-centered layout against the on-screen keyboard. 16px input font defeats iOS Safari focus-zoom; `.mobile-close` X button replaces the useless `esc` kbd hint; body-scroll lock effect prevents background scroll. `.results` pinned as the sole scroll target with `flex: 1; min-height: 0`.
- **Editor toolbar leak fix**: the `.mobile-toolbar` (z-index 100) was rendering whenever the on-screen keyboard appeared for *any* input, including the global search palette on item-detail pages. Gated the render condition on `editorFocused` (already tracked via `editor.on('focus')`/`on('blur')`) so it only appears when the editor itself is focused.
- **Breadcrumb stale-offset cleanup**: removed the `@media (max-width: 768px) { .sticky-header { top: 45px } }` workaround in `[collection]/[slug]/+page.svelte` — that 45px was clearing the now-deleted slim mobile header. `top: 0` is correct on both surfaces under the new layout.

All mobile-only CSS sits behind `@media (max-width: 768px)` matching `uiStore.isMobile`'s breakpoint — desktop is byte-identical.

Refs: IDEA-1121, TASK-1122, TASK-1124

## Test plan

- [ ] Mobile (≤768px): topbar with hamburger + workspace switcher + search icon + avatar is visible in **both** sidebar-open and sidebar-closed states.
- [ ] Mobile: tap hamburger → sidebar opens; tap again → closes.
- [ ] Mobile: tap search icon → CommandPalette opens full-screen, input pinned at top, X close button visible.
- [ ] Mobile: with sidebar open, tap search icon, pick a result → navigation succeeds AND sidebar is closed at the destination.
- [ ] Mobile: type a query, scroll the results list — input stays at the top, results scroll smoothly.
- [ ] Mobile (item-detail page with tiptap editor): open search → keyboard appears → editor's mobile toolbar does NOT appear over the palette.
- [ ] Mobile (item-detail page): tap into the editor → editor toolbar appears as expected (regression check).
- [ ] Mobile (item-detail page): breadcrumb sits flush against the bottom of the topbar — no gap; stays stuck there when scrolling.
- [ ] Desktop (>768px): topbar, sidebar, command palette, editor toolbar all unchanged from main.
- [ ] CI: `make check` (golangci-lint + go test + svelte-check + web build) passes.