### PR TITLE
feat(collections): seed IDEA-1/PLAN-2/TASK-3/DOC-4 in startup workspaces (TASK-1133)

### DIFF
--- a/internal/collections/templates.go
+++ b/internal/collections/templates.go
@@ -370,6 +370,11 @@ var templates = []WorkspaceTemplate{
 		Description: "Tasks, Ideas, Plans, Docs, Conventions, Playbooks",
 		Icon:        "\U0001F680", // 🚀
 		Collections: Defaults(),
+		// SeedItems run before Conventions/Playbooks in the bootstrap loop
+		// (see store.SeedCollectionsFromTemplate), so the workspace-scoped
+		// item_number sequence produces IDEA-1, PLAN-2, TASK-3, DOC-4.
+		// The post-signup hint names IDEA-1 specifically.
+		SeedItems:   StartupOnboardingItems(),
 		Conventions: SoftwareStarterConventions(),
 		Playbooks:   SoftwareStarterPlaybooks(),
 	},

--- a/internal/collections/templates_onboarding.go
+++ b/internal/collections/templates_onboarding.go
@@ -59,7 +59,7 @@ looking for thoroughness — I'm looking for momentum.
 
 When it feels like I've got enough here to be useful, run
 ` + "`pad project dashboard`" + ` so I can see what we built, and point me at
-the web UI so I can poke around there too. Then mark this idea done.
+the web UI so I can poke around there too. Then mark this idea implemented.
 
 ## A few things to know about Pad
 
@@ -105,7 +105,7 @@ idea so I can come back to it. The collection isn't precious; capturing
 the thought is.
 
 When we've got something useful, run ` + "`pad project dashboard`" + ` so I can
-see it. Then mark me done — or delete me, I'm not precious either.
+see it. Then mark me completed — or delete me, I'm not precious either.
 `
 
 // taskOnboardingBody is the body of TASK-3. Angle: "something concrete
@@ -158,8 +158,8 @@ If what I'm describing is more "I want to do X" than "I want to remember
 how X works," capture it as an idea or a task instead — those are for
 action, this is for memory.
 
-When we've got the doc, show it back to me so I can read it. Then mark
-me done — or delete me, I'm not precious.
+When we've got the doc, show it back to me so I can read it. Then archive
+me — or delete me, I'm not precious.
 `
 
 // StartupOnboardingItems returns the four onboarding seed items that ship

--- a/internal/collections/templates_onboarding.go
+++ b/internal/collections/templates_onboarding.go
@@ -1,0 +1,201 @@
+package collections
+
+// Onboarding seed items for new software-category workspaces.
+//
+// Every fresh `startup` workspace ships with one seed item per user-facing
+// collection (Ideas, Plans, Tasks, Docs). Each is a first-person note from
+// the workspace owner's future self that an agent can fetch and meaningfully
+// converse around. The post-signup hint points users at IDEA-1 first because
+// "I want to start using Pad" is itself an idea, but any of the four is a
+// viable entry point for `/pad let's discuss <REF>`.
+//
+// Design philosophy (see PLAN-1131, DOC-1139):
+//
+//   - No marker, no skill detection, no schema fields. Bodies are plain
+//     markdown. The seeder picks them based on the template — same way it
+//     already picks conventions and playbooks.
+//
+//   - Bodies are inserted *before* conventions and playbooks (the existing
+//     seeder loop in store/collections.go runs SeedItems first), so the
+//     workspace-scoped item_number sequence lands at IDEA-1 / PLAN-2 /
+//     TASK-3 / DOC-4 — discoverable, predictable refs the post-signup hint
+//     can name without computation.
+//
+//   - The four bodies cross-reference each other in plain language ("if it's
+//     bigger, make a plan; if it's earlier, catch it as an idea") so a user
+//     fetching any one of them learns the conceptual shape of the others.
+//     Doc takes a different angle (knowledge capture, not action).
+//
+// Scope: software defaults only — startup template (Tasks, Ideas, Plans,
+// Docs collections). Scrum and product templates have different collection
+// sets (Backlog/Sprints/Bugs and Features/Feedback/Roadmap respectively)
+// and need their own bodies; tracked as follow-up under PLAN-1131.
+// People-category templates (hiring, interviewing) are tracked under
+// PLAN-1140.
+
+// ideaOnboardingBody is the body of IDEA-1 — the primary agent-invocable
+// onboarding entry point. The post-signup hint names this ref specifically.
+const ideaOnboardingBody = `# Welcome — let's get this place set up
+
+I just made this workspace. It's where I'm going to keep track of what
+I'm working on: the plans I have going, the tasks I need to do, ideas
+I want to come back to, the occasional doc.
+
+If you're reading this, it's because I asked you to. I'd like your help
+getting started — not with a tutorial, just by talking through what I'm
+working on right now and capturing it here as we go.
+
+## What I'd find useful
+
+Ask me what I'm working on. Listen for the shape of it — the project,
+where I am with it, what's in front of me this week. As things come up
+in what I tell you, capture them here using ` + "`pad`" + `. A plan, a few tasks
+under it, maybe an idea or two I want to remember. Use my actual project,
+not toy data. Don't ask permission for every little thing — just narrate
+briefly what you're capturing as you go, the way a good notetaker would.
+
+If at any point I want you to stop or skip ahead, do that. I'm not
+looking for thoroughness — I'm looking for momentum.
+
+When it feels like I've got enough here to be useful, run
+` + "`pad project dashboard`" + ` so I can see what we built, and point me at
+the web UI so I can poke around there too. Then mark this idea done.
+
+## A few things to know about Pad
+
+- Items have IDs like TASK-3, IDEA-7, PLAN-2 — that's how I'll refer to them.
+- ` + "`pad project next`" + ` will tell me what to work on.
+- ` + "`pad project dashboard`" + ` shows the state of everything.
+- ` + "`pad item search \"term\"`" + ` finds anything by content.
+- ` + "`pad <anything>`" + ` in a /pad-aware agent session is how I'll talk to you
+  in the future — same as I just did to bring you here.
+
+## If I've already done this before
+
+If you look around the workspace and see I already have plans, tasks,
+ideas of my own — I'm not new, I just re-opened you. Don't redo any
+of this. Recap what's in the dashboard, remind me what I can do, and
+let me get back to work.
+
+That's it. Thanks for the help.
+`
+
+// planOnboardingBody is the body of PLAN-2. Angle: "something brewing
+// that's bigger than one task."
+const planOnboardingBody = `# A plan I haven't written yet
+
+This is where my bigger pieces of work live — anything that takes more
+than a single change or has multiple steps. A plan has a goal at the top,
+tasks under it, and a status. It's where I think out loud about a chunk
+of work before splitting it into tasks.
+
+## What I'd find useful
+
+If you're with me through this item, I've probably got something brewing
+— a feature, a refactor, a milestone, a launch — that's too big for a
+single task. Help me think through it: what's the goal in plain language,
+what's in scope, what's out, what's the rough sequence, what has to happen
+first. As we work it out, capture it as a real plan and split off tasks
+under it. Use my actual project, not toy data.
+
+If what I'm describing turns out to be small enough to just be one task,
+capture it that way and skip the plan. If it's earlier than that — more
+"I wonder if we should do X" than "we're doing X" — capture it as an
+idea so I can come back to it. The collection isn't precious; capturing
+the thought is.
+
+When we've got something useful, run ` + "`pad project dashboard`" + ` so I can
+see it. Then mark me done — or delete me, I'm not precious either.
+`
+
+// taskOnboardingBody is the body of TASK-3. Angle: "something concrete
+// on my plate, low ceremony."
+const taskOnboardingBody = `# A task I haven't named yet
+
+These are the bite-sized things — PR-sized, ideally. A single change, a
+single decision, a single thing I can finish in one go. Tasks can live
+under a plan or stand alone. When I run ` + "`pad project next`" + ` I usually get
+pointed at one of these.
+
+## What I'd find useful
+
+If you're with me through this item, I've probably got something specific
+in mind — a bug to fix, a small feature, a chore — and I want to capture
+it without too much ceremony. Help me name it, set a priority, and figure
+out whether it belongs under a plan or stands alone. If a couple of
+related tasks come up while we talk, that might be the start of a plan;
+we can spin one up and link them.
+
+If it's bigger than one task can hold, we'll make a plan instead. If
+it's earlier than action — still a question, not a commitment — we'll
+catch it as an idea.
+
+When we're done, run ` + "`pad project next`" + ` so I can see what to work on
+first. Then mark me done — or delete me, I'm not precious.
+`
+
+// docOnboardingBody is the body of DOC-4. Angle: "knowledge capture,
+// not action."
+const docOnboardingBody = `# A doc I haven't written yet
+
+This is where I write things down that I'll need later — architecture
+notes, decisions, runbooks, retros, the conventions I haven't quite
+formalized yet. Docs are searchable like everything else, and they don't
+have a status in the same way tasks do; they exist until they're stale,
+then I update or archive them.
+
+## What I'd find useful
+
+If you're with me through this item, I probably want to write something
+down so I don't have to figure it out again next month. Help me figure
+out what kind of doc this is — an architecture sketch, a decision record,
+a how-to, a retro — and what should go in it. Ask the questions a future
+me (or a teammate joining the project later) would want answered. Capture
+as we go; the trick with docs is writing them the moment something's
+fresh, not three months later when I've forgotten the details.
+
+If what I'm describing is more "I want to do X" than "I want to remember
+how X works," capture it as an idea or a task instead — those are for
+action, this is for memory.
+
+When we've got the doc, show it back to me so I can read it. Then mark
+me done — or delete me, I'm not precious.
+`
+
+// StartupOnboardingItems returns the four onboarding seed items that ship
+// in a fresh `startup` workspace. The order matters: items are inserted in
+// this slice's order before conventions/playbooks, so the workspace-scoped
+// item_number sequence lands at IDEA-1 / PLAN-2 / TASK-3 / DOC-4.
+//
+// Only valid for templates that ship the canonical software defaults
+// (Ideas, Plans, Tasks, Docs collections). Scrum and product templates use
+// different collection sets and need their own onboarding bodies — see
+// PLAN-1131 follow-ups.
+func StartupOnboardingItems() []SeedItem {
+	return []SeedItem{
+		{
+			CollectionSlug: "ideas",
+			Title:          "Welcome — let's get this place set up",
+			Content:        ideaOnboardingBody,
+			Fields:         `{"status":"new"}`,
+		},
+		{
+			CollectionSlug: "plans",
+			Title:          "A plan I haven't written yet",
+			Content:        planOnboardingBody,
+			Fields:         `{"status":"planned"}`,
+		},
+		{
+			CollectionSlug: "tasks",
+			Title:          "A task I haven't named yet",
+			Content:        taskOnboardingBody,
+			Fields:         `{"status":"open"}`,
+		},
+		{
+			CollectionSlug: "docs",
+			Title:          "A doc I haven't written yet",
+			Content:        docOnboardingBody,
+			Fields:         `{"status":"draft"}`,
+		},
+	}
+}

--- a/internal/collections/templates_test.go
+++ b/internal/collections/templates_test.go
@@ -183,6 +183,79 @@ func TestSoftwareTemplatesShipStarterPacks(t *testing.T) {
 	}
 }
 
+// TestStartupOnboardingItemsOrderAndShape verifies that StartupOnboardingItems
+// returns the four onboarding seeds in the order Ideas, Plans, Tasks, Docs —
+// the order that produces the IDEA-1 / PLAN-2 / TASK-3 / DOC-4 ref sequence
+// in a fresh workspace. Each item must have a non-empty title, body, and a
+// status field set in Fields. If the order or collection slugs ever drift,
+// the post-signup hint copy (which names IDEA-1) and the design doc
+// (DOC-1139) silently desync.
+func TestStartupOnboardingItemsOrderAndShape(t *testing.T) {
+	items := StartupOnboardingItems()
+	want := []struct {
+		Slug, Status string
+	}{
+		{"ideas", "new"},
+		{"plans", "planned"},
+		{"tasks", "open"},
+		{"docs", "draft"},
+	}
+
+	if len(items) != len(want) {
+		t.Fatalf("StartupOnboardingItems returned %d items, want %d", len(items), len(want))
+	}
+
+	for i, it := range items {
+		if it.CollectionSlug != want[i].Slug {
+			t.Errorf("item[%d] CollectionSlug = %q, want %q", i, it.CollectionSlug, want[i].Slug)
+		}
+		if it.Title == "" {
+			t.Errorf("item[%d] (%s) has empty Title", i, it.CollectionSlug)
+		}
+		if it.Content == "" {
+			t.Errorf("item[%d] (%s) has empty Content", i, it.CollectionSlug)
+		}
+		// Status must appear in the Fields JSON. Naive substring check is
+		// enough — the schema validates the full payload elsewhere.
+		wantStatus := `"status":"` + want[i].Status + `"`
+		if !contains(it.Fields, wantStatus) {
+			t.Errorf("item[%d] (%s) Fields = %q, want it to contain %s", i, it.CollectionSlug, it.Fields, wantStatus)
+		}
+	}
+}
+
+// TestStartupTemplateShipsOnboardingSeedItems verifies the startup template
+// references StartupOnboardingItems on its SeedItems field. This is what
+// makes a fresh `pad workspace init --template startup` produce the
+// IDEA-1 / PLAN-2 / TASK-3 / DOC-4 sequence rather than starting at CONVE-1.
+func TestStartupTemplateShipsOnboardingSeedItems(t *testing.T) {
+	tmpl := GetTemplate("startup")
+	if tmpl == nil {
+		t.Fatal("startup template missing")
+	}
+	if len(tmpl.SeedItems) != len(StartupOnboardingItems()) {
+		t.Errorf("startup template SeedItems = %d items, want %d (the onboarding seeds)", len(tmpl.SeedItems), len(StartupOnboardingItems()))
+	}
+	// The first SeedItem MUST go to ideas — it's IDEA-1, what the
+	// post-signup hint names. If this drifts, the hint silently points
+	// at the wrong (or missing) item.
+	if len(tmpl.SeedItems) > 0 && tmpl.SeedItems[0].CollectionSlug != "ideas" {
+		t.Errorf("startup SeedItems[0].CollectionSlug = %q, want %q (IDEA-1 must be first)", tmpl.SeedItems[0].CollectionSlug, "ideas")
+	}
+}
+
+// contains is a local substring helper to keep the templates_test.go file
+// dependency-free. The standard library's strings.Contains would also work;
+// keeping this local matches the file's existing style.
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}
+
 // TestGroupTemplatesByCategory verifies the grouping helper used by CLI
 // and web pickers: canonical category order, only visible templates, and
 // every visible template lands in exactly one group.

--- a/internal/store/items_test.go
+++ b/internal/store/items_test.go
@@ -429,6 +429,64 @@ func TestSeedCollectionsFromTemplateRecoversPartialInit(t *testing.T) {
 	}
 }
 
+// TestSeedCollectionsFromTemplateStartupRefSequence verifies the central
+// invariant of the onboarding seed design: a fresh `startup` workspace
+// produces refs IDEA-1, PLAN-2, TASK-3, DOC-4 — in that order — for the
+// four onboarding seed items. The post-signup hint copy points users at
+// IDEA-1 specifically, so the ref sequence MUST be stable: if conventions
+// or playbooks ever leak in front of the SeedItems loop, IDEA-1 won't be
+// the first item and the hint silently misfires.
+func TestSeedCollectionsFromTemplateStartupRefSequence(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Startup Refs")
+
+	if err := s.SeedCollectionsFromTemplate(ws.ID, "startup"); err != nil {
+		t.Fatalf("seed startup template: %v", err)
+	}
+
+	// Look up each onboarding seed by collection + title and assert its
+	// item_number. Title-based lookup is robust against accidental
+	// re-ordering inside collection lists.
+	type expected struct {
+		Slug, Title string
+		WantItemNum int
+	}
+	want := []expected{
+		{"ideas", "Welcome — let's get this place set up", 1},
+		{"plans", "A plan I haven't written yet", 2},
+		{"tasks", "A task I haven't named yet", 3},
+		{"docs", "A doc I haven't written yet", 4},
+	}
+
+	for _, w := range want {
+		items, err := s.ListItems(ws.ID, models.ItemListParams{CollectionSlug: w.Slug})
+		if err != nil {
+			t.Fatalf("list %s: %v", w.Slug, err)
+		}
+		var found *models.Item
+		for i := range items {
+			if items[i].Title == w.Title {
+				found = &items[i]
+				break
+			}
+		}
+		if found == nil {
+			t.Errorf("expected seed item %q in %q collection, not found", w.Title, w.Slug)
+			continue
+		}
+		if found.ItemNumber == nil {
+			t.Errorf("seed item %q in %q: ItemNumber is nil", w.Title, w.Slug)
+			continue
+		}
+		if *found.ItemNumber != w.WantItemNum {
+			t.Errorf("seed item %q in %q: ItemNumber = %d, want %d (drift in seeding order means the post-signup hint will point at the wrong ref)", w.Title, w.Slug, *found.ItemNumber, w.WantItemNum)
+		}
+		if found.Content == "" {
+			t.Errorf("seed item %q in %q: empty Content (body lost between template and store)", w.Title, w.Slug)
+		}
+	}
+}
+
 // TestSeedCollectionsFromTemplateIdempotentWithSeedItems verifies that re-running
 // the seed function across a pre-existing workspace does NOT duplicate seed items.
 // This invariant is what lets the server's startup auto-upgrade safely iterate


### PR DESCRIPTION
## Summary

A fresh `pad workspace init --template startup` now seeds **four onboarding items** — one per user-facing collection — that any agent can fetch and meaningfully converse around.

| Ref | Collection | Angle |
|---|---|---|
| **IDEA-1** | Ideas | Welcome / *what are you working on?* — the post-signup hint will name this specifically |
| **PLAN-2** | Plans | *something brewing that's bigger than one task* |
| **TASK-3** | Tasks | *something concrete on my plate, low ceremony* |
| **DOC-4** | Docs | *knowledge capture, not action* |

Bodies are first-person notes from the workspace owner's future self — pulled verbatim from DOC-1139.

## Design philosophy (no cheating)

- **No marker.** Plain markdown. The skill detects nothing.
- **No skill detection logic.** The existing `pad item show <REF>` + agent-reads-the-body flow is the entire mechanism.
- **No schema fields.** Same SeedItem mechanism that already ships starter conventions and playbooks.
- **No tutorial framework.** Word-audit clean of *tutorial / lesson / step / walkthrough / guide*.

## Why this works without code changes downstream

The existing seeder (`store.SeedCollectionsFromTemplate`) already iterates `SeedItems` **before** conventions and playbooks. Workspace-scoped `item_number` is monotonic + atomic, so adding the four onboarding items as the startup template's `SeedItems` naturally lands them at refs `IDEA-1 / PLAN-2 / TASK-3 / DOC-4`. The conventions and playbooks slide to higher numbers.

`TestSeedCollectionsFromTemplateStartupRefSequence` locks the invariant. Drift means the post-signup hint silently misfires.

## Scope (intentionally narrow)

- Startup template only.
- **Out of scope:** scrum and product templates have different collection sets (Backlog/Sprints/Bugs and Features/Feedback/Roadmap), so their seed bodies need to be separately authored — follow-up under PLAN-1131.
- **Out of scope:** people-category templates (hiring, interviewing) — separately tracked under PLAN-1140.

## Context

Implements TASK-1133 under PLAN-1131. Bodies finalized in DOC-1139.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/collections/` — all pass, including 2 new tests:
  - `TestStartupOnboardingItemsOrderAndShape` — locks order + collection slugs + status fields
  - `TestStartupTemplateShipsOnboardingSeedItems` — startup template references the helper
- [x] `go test ./internal/store/` — all pass, including 1 new test:
  - `TestSeedCollectionsFromTemplateStartupRefSequence` — IDEA-1 / PLAN-2 / TASK-3 / DOC-4 land at item_numbers 1-4
- [x] `make check` clean (lint + tests + web build)
- [x] No mention of "tutorial," "lesson," "walkthrough," or "guide" in any seed body
- [x] Existing tests still pass (idempotency, recovery, etc.)