### PR TITLE
feat(onboarding): surface IDEA-1 trigger phrase across CLI and web UI (TASK-1134)

### DIFF
--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -841,9 +841,26 @@ func setupCmd() *cobra.Command {
 			green := color.New(color.FgGreen).SprintFunc()
 			fmt.Printf("%s First admin account created\n", green("✓"))
 			fmt.Printf("%s Logged in as %s (%s)\n", green("✓"), resp.User.Name, resp.User.Email)
+			printIdeaOneTriggerHint()
 			return nil
 		},
 	}
+}
+
+// printIdeaOneTriggerHint surfaces the trigger phrase that points a fresh
+// agent session at the seeded IDEA-1 onboarding item. The phrase is named
+// (not generic) so a copy-paste lands deterministically on the right ref
+// in software-category workspaces. People-category and other templates
+// will need a template-aware version of this hint — tracked under
+// PLAN-1140 (the people-category onboarding plan).
+func printIdeaOneTriggerHint() {
+	bold := color.New(color.Bold)
+	cyan := color.New(color.FgCyan)
+
+	fmt.Println()
+	bold.Println("To get started:")
+	fmt.Printf("  Open a fresh agent session (Claude Code, Cursor, etc.) and say:\n")
+	fmt.Printf("  %s\n", cyan.Sprint("use pad to get IDEA-1"))
 }
 
 func loginCmd() *cobra.Command {
@@ -1787,8 +1804,14 @@ func printOnboardingHints(cfg *config.Config) {
 
 	fmt.Println()
 	bold.Println("Get started:")
+	// IDEA-1 is the seeded onboarding entry point in software-category
+	// workspaces (`startup` template); naming it specifically here avoids
+	// a generic "your first item" copy that would force the user to
+	// figure out the ref themselves. Other templates seed different
+	// primary-entry refs (REQ-1 / APP-1 / …); making this template-aware
+	// is tracked under PLAN-1140.
+	fmt.Printf("  %s  %s\n", cyan.Sprint("/pad"), "use pad to get IDEA-1")
 	fmt.Printf("  %s  %s\n", cyan.Sprint("/pad"), "scan this codebase and set up my workspace")
-	fmt.Printf("  %s  %s\n", cyan.Sprint("/pad"), "what conventions should this project follow?")
 	fmt.Printf("  %s  %s\n", cyan.Sprint("/pad"), "create a plan for what I'm working on")
 	fmt.Println()
 	fmt.Printf("Or open the web UI at %s\n", bold.Sprint(cfg.BrowserURL()))

--- a/web/src/lib/components/OnboardingIdeaBanner.svelte
+++ b/web/src/lib/components/OnboardingIdeaBanner.svelte
@@ -1,0 +1,144 @@
+<script lang="ts">
+	import { copyToClipboard } from '$lib/utils/clipboard';
+
+	interface Props {
+		/** Workspace slug — used to link "View IDEA-1" into the right URL. */
+		wsSlug: string;
+		/** Workspace owner username — used to build the IDEA-1 deep link. */
+		username: string;
+		/** Slug of the seeded IDEA-1 (the workspace bootstrap creates it
+		 *  with this slug). Defaults to the canonical seed slug; passing
+		 *  it explicitly keeps the component decoupled from the seeder. */
+		ideaSlug?: string;
+	}
+
+	let { wsSlug, username, ideaSlug = 'welcome-lets-get-this-place-set-up' }: Props = $props();
+
+	const TRIGGER_PHRASE = 'use pad to get IDEA-1';
+
+	let copied = $state(false);
+
+	async function copyTrigger() {
+		const ok = await copyToClipboard(TRIGGER_PHRASE);
+		if (ok) {
+			copied = true;
+			setTimeout(() => {
+				copied = false;
+			}, 1500);
+		}
+	}
+</script>
+
+<div class="idea-banner">
+	<div class="idea-banner-icon" aria-hidden="true">💡</div>
+	<div class="idea-banner-body">
+		<h2>Your workspace has an idea waiting.</h2>
+		<p>
+			Open a fresh agent session — Claude Code, Cursor, Codex, whatever you have —
+			and say:
+		</p>
+		<div class="trigger-row">
+			<code class="trigger-phrase">{TRIGGER_PHRASE}</code>
+			<button class="copy-btn" type="button" onclick={copyTrigger} title="Copy to clipboard">
+				{copied ? 'Copied!' : 'Copy'}
+			</button>
+		</div>
+		<p class="idea-banner-footnote">
+			IDEA-1 is a note from your future self to whoever's helping you set up. The
+			agent will read it and walk through your project with you, capturing what
+			you tell it as plans, tasks, and ideas — using your real work, not toy data.
+			<a href="/{username}/{wsSlug}/ideas/{ideaSlug}">Read it first</a> if you'd
+			like to see what's there.
+		</p>
+	</div>
+</div>
+
+<style>
+	.idea-banner {
+		display: flex;
+		gap: var(--space-4);
+		align-items: flex-start;
+		background: color-mix(in srgb, var(--accent-blue) 8%, var(--bg-secondary));
+		border: 1px solid color-mix(in srgb, var(--accent-blue) 30%, var(--border));
+		border-radius: var(--radius);
+		padding: var(--space-5);
+		max-width: 600px;
+	}
+
+	.idea-banner-icon {
+		font-size: 1.6em;
+		line-height: 1;
+		margin-top: 2px;
+		flex-shrink: 0;
+	}
+
+	.idea-banner-body {
+		flex: 1;
+		min-width: 0;
+	}
+
+	.idea-banner-body h2 {
+		font-size: 1.05em;
+		font-weight: 600;
+		color: var(--text-primary);
+		margin: 0 0 var(--space-2) 0;
+	}
+
+	.idea-banner-body p {
+		font-size: 0.92em;
+		color: var(--text-secondary);
+		margin: 0 0 var(--space-3) 0;
+		line-height: 1.5;
+	}
+
+	.trigger-row {
+		display: flex;
+		align-items: center;
+		gap: var(--space-2);
+		margin-bottom: var(--space-3);
+		flex-wrap: wrap;
+	}
+
+	.trigger-phrase {
+		background: var(--bg-primary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius-sm);
+		padding: var(--space-2) var(--space-3);
+		font-size: 0.95em;
+		color: var(--text-primary);
+		font-family: var(--font-mono, monospace);
+		user-select: all;
+	}
+
+	.copy-btn {
+		background: var(--bg-tertiary);
+		border: 1px solid var(--border);
+		color: var(--text-primary);
+		font-size: 0.85em;
+		cursor: pointer;
+		padding: var(--space-2) var(--space-3);
+		border-radius: var(--radius-sm);
+		white-space: nowrap;
+	}
+
+	.copy-btn:hover {
+		background: var(--bg-primary);
+		border-color: var(--accent-blue);
+	}
+
+	.idea-banner-footnote {
+		font-size: 0.85em !important;
+		color: var(--text-muted) !important;
+		margin: 0 !important;
+		line-height: 1.5;
+	}
+
+	.idea-banner-footnote a {
+		color: var(--accent-blue);
+		text-decoration: none;
+	}
+
+	.idea-banner-footnote a:hover {
+		text-decoration: underline;
+	}
+</style>

--- a/web/src/routes/[username]/[workspace]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/+page.svelte
@@ -8,6 +8,7 @@
 	import { syncService } from '$lib/services/sync.svelte';
 	import { relativeTime } from '$lib/utils/markdown';
 	import OnboardingChecklist from '$lib/components/OnboardingChecklist.svelte';
+	import OnboardingIdeaBanner from '$lib/components/OnboardingIdeaBanner.svelte';
 	import ConnectWorkspaceModal from '$lib/components/ConnectWorkspaceModal.svelte';
 	import { titleStore } from '$lib/stores/title.svelte';
 	import type { DashboardResponse, Collection } from '$lib/types';
@@ -21,6 +22,13 @@
 	let pollTimer: ReturnType<typeof setInterval> | undefined;
 	let onboardingDismissed = $state(false);
 	let connectOpen = $state(false);
+
+	// Status of the seeded IDEA-1 onboarding entry. Drives the
+	// OnboardingIdeaBanner gate: shown only while the user hasn't yet
+	// engaged with the agent (status === 'new'). null = not yet checked /
+	// no IDEA-1 exists in this workspace (e.g. an empty-template or
+	// non-software-category workspace).
+	let ideaOneStatus = $state<string | null>(null);
 
 	// Sync dismissed state from localStorage when workspace changes
 	$effect(() => {
@@ -89,6 +97,38 @@
 			// allow partial render
 		} finally {
 			loading = false;
+		}
+		// Refresh the seeded IDEA-1 status alongside each dashboard load.
+		// Cheap (single-row lookup, indexed by ref) and self-correcting:
+		// once the user engages the agent and IDEA-1 leaves status=new,
+		// the next poll silently hides the banner.
+		void loadIdeaOne(slug);
+	}
+
+	// loadIdeaOne fetches the seeded IDEA-1 entry's status. A 404 (or any
+	// error) leaves ideaOneStatus null, which keeps the banner hidden —
+	// workspaces that don't ship an onboarding seed should never see the
+	// banner. Errors are intentionally silent: the dashboard is the
+	// primary surface, and a broken sub-fetch should not throw the
+	// dashboard render off.
+	async function loadIdeaOne(slug: string) {
+		try {
+			const item = await api.items.get(slug, 'IDEA-1');
+			// item.fields is a JSON string per the API shape (see Item.fields
+			// in lib/types). Empty / malformed payloads collapse to '' so
+			// the banner stays hidden rather than flashing on bad data.
+			let status = '';
+			if (item?.fields) {
+				try {
+					const parsed = JSON.parse(item.fields) as Record<string, unknown>;
+					if (typeof parsed.status === 'string') status = parsed.status;
+				} catch {
+					/* leave status empty */
+				}
+			}
+			ideaOneStatus = status;
+		} catch {
+			ideaOneStatus = null;
 		}
 	}
 
@@ -200,6 +240,17 @@
 		</header>
 
 		<!-- 2. Onboarding -->
+		<!-- IDEA-1 banner: shown only while the seeded onboarding entry is
+		     still untouched (status === 'new'). Once the user engages the
+		     agent and the status flips, the banner disappears on the next
+		     dashboard poll. The OnboardingChecklist below remains gated on
+		     totalItems === 0 — its surface is empty/non-templated workspaces;
+		     this banner is the surface for templated (seeded) workspaces. -->
+		{#if ideaOneStatus === 'new' && !onboardingDismissed}
+			<div class="onboarding-wrapper">
+				<OnboardingIdeaBanner {wsSlug} {username} />
+			</div>
+		{/if}
 		{#if totalItems === 0 && !onboardingDismissed}
 			<div class="onboarding-wrapper">
 				<OnboardingChecklist {wsSlug} {username} byCollection={dashboard.summary.by_collection} ondismiss={dismissOnboarding} />

--- a/web/src/routes/[username]/[workspace]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/+page.svelte
@@ -111,14 +111,29 @@
 	// banner. Errors are intentionally silent: the dashboard is the
 	// primary surface, and a broken sub-fetch should not throw the
 	// dashboard render off.
+	//
+	// IMPORTANT: server-side ResolveItem (in store.GetItemByRef) falls
+	// back from PREFIX-NUMBER to a number-only lookup when the prefix
+	// doesn't match any collection in the workspace. In a non-software
+	// workspace (hiring, interviewing, …), `IDEA-1` would resolve to
+	// whatever item has item_number=1 (REQ-1 / APP-1 / etc.) — and
+	// rendering the banner against that item would link to a missing
+	// /ideas/... page and confuse the user. We pin to the exact ref
+	// before trusting the result.
 	async function loadIdeaOne(slug: string) {
 		try {
 			const item = await api.items.get(slug, 'IDEA-1');
+			// Guard against ResolveItem's prefix→number-only fallback: only
+			// accept the result if it is the actual seeded IDEA-1.
+			if (!item || item.collection_prefix !== 'IDEA' || item.item_number !== 1) {
+				ideaOneStatus = null;
+				return;
+			}
 			// item.fields is a JSON string per the API shape (see Item.fields
 			// in lib/types). Empty / malformed payloads collapse to '' so
 			// the banner stays hidden rather than flashing on bad data.
 			let status = '';
-			if (item?.fields) {
+			if (item.fields) {
 				try {
 					const parsed = JSON.parse(item.fields) as Record<string, unknown>;
 					if (typeof parsed.status === 'string') status = parsed.status;

--- a/web/src/routes/[username]/[workspace]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/+page.svelte
@@ -55,7 +55,13 @@
 	// the dashboard to refetch + re-render — a visible flicker. Wrap in
 	// `untrack` so the only tracked dep is `wsSlug` from the if-check.
 	$effect(() => {
-		if (wsSlug) untrack(() => load(wsSlug));
+		if (wsSlug) {
+			// Reset banner state immediately on workspace change so a stale
+			// `new` status from the previous workspace can't briefly render
+			// the IDEA-1 banner before loadIdeaOne resolves for the new one.
+			ideaOneStatus = null;
+			untrack(() => load(wsSlug));
+		}
 	});
 
 	// Workspace home shows only the workspace-level title — clear section/item.
@@ -123,6 +129,13 @@
 	async function loadIdeaOne(slug: string) {
 		try {
 			const item = await api.items.get(slug, 'IDEA-1');
+			// Drop the response if the user navigated to a different
+			// workspace while we were waiting on the network. Otherwise a
+			// slow request from workspace A (where IDEA-1 is `new`) could
+			// land after the user is on workspace B and incorrectly flip
+			// the banner on. Mirrors the standard "was this still the
+			// active request" pattern.
+			if (slug !== wsSlug) return;
 			// Guard against ResolveItem's prefix→number-only fallback: only
 			// accept the result if it is the actual seeded IDEA-1.
 			if (!item || item.collection_prefix !== 'IDEA' || item.item_number !== 1) {
@@ -143,7 +156,9 @@
 			}
 			ideaOneStatus = status;
 		} catch {
-			ideaOneStatus = null;
+			// Same race-guard applies on the error path: only clear if this
+			// is still the active workspace.
+			if (slug === wsSlug) ideaOneStatus = null;
 		}
 	}
 


### PR DESCRIPTION
## Summary

Make the seeded onboarding entry point (IDEA-1, shipped by [#402](https://github.com/PerpetualSoftware/pad/pull/402)) discoverable without prior knowledge. Per CONVE-191 (full-stack thinking), surfaces the trigger phrase on **CLI** and **web UI** simultaneously.

## CLI surfaces

- **`pad auth setup` success message** — closes with a clear next step:
  > **To get started:**
  > Open a fresh agent session (Claude Code, Cursor, etc.) and say:
  > `use pad to get IDEA-1`

  New helper `printIdeaOneTriggerHint()` so future templates can reuse the shape.

- **`printOnboardingHints`** (used after `pad init` / `pad workspace init` creates a workspace) — leads with the trigger phrase before the existing /pad prompt suggestions. Named ref (IDEA-1) instead of generic copy so paste lands deterministically.

## Web UI surface

- New **`OnboardingIdeaBanner.svelte`** component. Renders on the workspace dashboard whenever IDEA-1 is in `status=new`. Trigger phrase shown verbatim, with a copy button and a "Read it first" deep link.
- Dashboard fetches IDEA-1 alongside its existing dashboard + collections calls (cheap, indexed by ref). Re-checks on every poll (30s) + sync signal — self-correcting: the moment the agent flips IDEA-1 out of `new`, the banner disappears on the next refresh.
- Existing `OnboardingChecklist` gate (`totalItems === 0`) **left untouched**. It still serves empty / non-templated workspaces; the new banner is the templated-workspace surface.

## Why hardcoded "IDEA-1"

PLAN-1131's scope is software-category templates only. People-category templates (`hiring`, `interviewing`) will seed different primary-entry refs (REQ-1, APP-1) and need a template-aware version of this hint — explicitly tracked under PLAN-1140 as a follow-up.

## Context

Implements TASK-1134 under PLAN-1131. Builds on [#402](https://github.com/PerpetualSoftware/pad/pull/402) which seeded IDEA-1 in fresh `startup` workspaces.

## Test plan

- [x] `go build ./...` clean
- [x] `make check` clean (lint + tests + web build)
- [x] `npx svelte-check` 0 errors (warnings all pre-existing)
- [x] Svelte autofixer clean on the new component
- [x] Word audit: no "tutorial / lesson / walkthrough / guide / step-by-step" in any of the new copy
- [x] No new tests added — both surfaces are pure copy/render; existing dashboard + auth tests still pass

## Manual verification (after merge + `make install`)

1. Spin up a fresh workspace via `pad workspace init --template startup`
2. Visit the dashboard — verify the IDEA-1 banner shows
3. `pad item update IDEA-1 --status exploring` — refresh, verify banner disappears
4. Run `pad auth setup` on a fresh DB — verify the trigger phrase prints