### PR TITLE
test(mcp): lock down IDEA-1 onboarding body verbatim through the resource pipeline (TASK-1136)

### DIFF
--- a/internal/mcp/resources_test.go
+++ b/internal/mcp/resources_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/PerpetualSoftware/pad/internal/collections"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 )
@@ -241,6 +242,124 @@ func TestFormatItemAsMarkdown_HandlesEmptyFields(t *testing.T) {
 func TestFormatItemAsMarkdown_RejectsInvalidJSON(t *testing.T) {
 	if _, err := formatItemAsMarkdown(`not json`); err == nil {
 		t.Errorf("expected error on invalid JSON")
+	}
+}
+
+// TestReadItem_PreservesIDEAOneOnboardingBodyVerbatim is a contract test
+// for the full pipeline that MCP clients (Claude Desktop, Cursor,
+// Windsurf, …) traverse when an agent says "use pad to get IDEA-1":
+//
+//  1. The MCP resource handler dispatches `pad item show IDEA-1
+//     --format json` via the fetcher.
+//  2. `formatItemAsMarkdown` composes a markdown document from the
+//     JSON response — heading + fields + body.
+//
+// The contract: the body the workspace seeder ships in
+// `collections.StartupOnboardingItems()` (PLAN-1131 / DOC-1139) MUST
+// reach the agent verbatim. Drift here means agents see a truncated
+// or reformatted onboarding script, breaking the seeded experience
+// silently — exactly the kind of regression the task surfaces.
+//
+// This test pulls the IDEA-1 body from the collections package
+// directly, simulates the `pad item show --format json` envelope,
+// runs it through readItem, and asserts every meaningful section is
+// preserved. Specifically guarded:
+//
+//   - The opening greeting and the "What I'd find useful" section
+//     (tells the agent how to behave).
+//   - The schema-valid "mark this idea implemented" instruction —
+//     guards against the round-1 fix on PR #402 silently regressing
+//     to "mark me done" (which is invalid for the Ideas collection).
+//   - The "If I've already done this before" section (the body's
+//     idempotency contract for re-runs).
+//   - Code-fenced commands (backtick `pad project dashboard` etc.)
+//     and em-dashes — the kind of characters a bad transformation
+//     might mangle.
+func TestReadItem_PreservesIDEAOneOnboardingBodyVerbatim(t *testing.T) {
+	seeds := collections.StartupOnboardingItems()
+	var ideaSeed *collections.SeedItem
+	for i := range seeds {
+		if seeds[i].CollectionSlug == "ideas" {
+			ideaSeed = &seeds[i]
+			break
+		}
+	}
+	if ideaSeed == nil {
+		t.Fatal("expected an Ideas seed item in StartupOnboardingItems; the onboarding seeder shape changed and this test (and the design contract it locks down) needs to follow")
+	}
+
+	envelope := map[string]any{
+		"ref":             "IDEA-1",
+		"title":           ideaSeed.Title,
+		"fields":          ideaSeed.Fields,
+		"content":         ideaSeed.Content,
+		"collection_slug": "ideas",
+	}
+	envBytes, err := json.Marshal(envelope)
+	if err != nil {
+		t.Fatalf("marshal envelope: %v", err)
+	}
+
+	f := &fakeFetcher{stdout: string(envBytes)}
+	r := &resources{fetcher: f}
+	req := mcp.ReadResourceRequest{}
+	req.Params.URI = "pad://workspace/docapp/items/IDEA-1"
+
+	contents, err := r.readItem(context.Background(), req)
+	if err != nil {
+		t.Fatalf("readItem: %v", err)
+	}
+	if len(contents) != 1 {
+		t.Fatalf("expected 1 ResourceContents, got %d", len(contents))
+	}
+	tc, ok := contents[0].(mcp.TextResourceContents)
+	if !ok {
+		t.Fatalf("expected TextResourceContents, got %T", contents[0])
+	}
+
+	// The composed heading wraps the body. The body's own H1 (the
+	// seeded title) follows in the body section — not stripped.
+	wantHeading := "# IDEA-1: " + ideaSeed.Title
+	if !strings.Contains(tc.Text, wantHeading) {
+		t.Errorf("composed markdown missing heading %q; got:\n%s", wantHeading, tc.Text)
+	}
+
+	// The full body must be present verbatim. Substring-checking the
+	// entire body (rather than asserting equality of the composed
+	// document) lets future revisions of `formatItemAsMarkdown` reorder
+	// metadata bullets / parent-link rendering without breaking this
+	// contract — the contract is on the body content, not on layout.
+	if !strings.Contains(tc.Text, ideaSeed.Content) {
+		t.Errorf("composed markdown does not contain the full IDEA-1 onboarding body verbatim; the resource pipeline is mangling content somewhere.\n\nwant body to appear:\n%s\n\ngot:\n%s", ideaSeed.Content, tc.Text)
+	}
+
+	// Specific sections we depend on agent-side. Failing any of these
+	// means the body shape changed and the design doc / hint copy may
+	// have drifted out of sync — failure should prompt a re-read of
+	// PLAN-1131 / DOC-1139 before "fixing" the test.
+	requiredFragments := []string{
+		"# Welcome — let's get this place set up", // body's own H1, kept distinct from the resource heading
+		"## What I'd find useful",                 // tells the agent how to behave
+		"Then mark this idea implemented",         // schema-valid terminal status — guards round-1 fix on PR #402
+		"## If I've already done this before",     // body-side idempotency contract for re-runs
+		"`pad project dashboard`",                 // code-fenced command must survive
+	}
+	for _, frag := range requiredFragments {
+		if !strings.Contains(tc.Text, frag) {
+			t.Errorf("composed markdown missing required fragment %q; the IDEA-1 body shape may have drifted from PLAN-1131 / DOC-1139", frag)
+		}
+	}
+
+	// Status field must surface in the metadata bullets so MCP clients
+	// that surface fields prominently (resource listings) can show that
+	// IDEA-1 is `new` and the user hasn't engaged yet.
+	if !strings.Contains(tc.Text, "- **status:** new") {
+		t.Errorf("composed markdown missing `- **status:** new` field row; metadata rendering broke")
+	}
+
+	wantArgs := []string{"item", "show", "IDEA-1", "--workspace", "docapp", "--format", "json"}
+	if !equalSlice(f.gotArgs, wantArgs) {
+		t.Errorf("dispatched args = %v, want %v", f.gotArgs, wantArgs)
 	}
 }
 


### PR DESCRIPTION
## Summary

Verifies the existing `pad://workspace/{ws}/items/{ref}` resource pipeline preserves the IDEA-1 onboarding body verbatim from the workspace seeder (DOC-1139) through to MCP clients (Claude Desktop, Cursor, Windsurf). Test-only — no production code changes.

## What's covered

The new test pulls the IDEA-1 body from `collections.StartupOnboardingItems()` directly, runs it through the MCP resource pipeline (`readItem` → `formatItemAsMarkdown`), and asserts:

- Composed heading `# IDEA-1: <title>` is present.
- Full body content appears **verbatim** (substring match, so future `formatItemAsMarkdown` layout tweaks can land without breaking this contract).
- Specific sections agents depend on:
  - `## What I'd find useful` — the behavior contract for the agent.
  - `Then mark this idea implemented` — schema-valid terminal status. Guards the round-1 Codex fix from PR #402 from silently regressing to `mark me done` (invalid for the Ideas collection).
  - `## If I've already done this before` — idempotency contract for re-runs.
  - `` `pad project dashboard` `` — code-fenced commands survive intact.
- `- **status:** new` field row in metadata.
- Dispatched CLI args use `--format json` (NOT `--format markdown`, which only emits the body — known gap caught on TASK-946).

## Why test-only

The task spec anticipated this outcome:
> *"This task may turn out to be a no-op if both pathways already work. If so, close with a comment confirming verification, no code change required."*

Both pathways already work — the existing pipeline composes the full markdown document from the JSON envelope. Adding the targeted contract test is the cheap way to keep it that way.

## Context

Implements TASK-1136 under PLAN-1131. Pairs with the seeder (PR #402) and dashboard hint (PR #403).

## Test plan

- [x] `go test -run TestReadItem_PreservesIDEAOneOnboardingBodyVerbatim ./internal/mcp/` — pass
- [x] `make check` clean (lint + tests + web build)
- [x] Test exercises the actual seed body (no hardcoded copy that could drift)