### PR TITLE
docs(onboarding): document IDEA-1 trigger phrase across README, CLAUDE.md, and /pad skill (TASK-1138)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,6 +107,14 @@ pad auth reset-password user@example.com  # Generate reset link (admin fallback)
 # CLI auto-attaches auth token to all API requests
 ```
 
+After `pad auth setup` (and after `pad init` / `pad workspace init` for any subsequent workspace), the success output points new users at the seeded onboarding entry point. Open a fresh agent session in the workspace's directory and say:
+
+```
+use pad to get IDEA-1
+```
+
+`startup`-template workspaces seed `IDEA-1` (plus `PLAN-2`, `TASK-3`, `DOC-4`) as a first-person note from the workspace owner's future self. Any of the four is a viable entry point for `/pad let's discuss <REF>`; `IDEA-1` is the one the post-signup hint surfaces because *"I want to start using Pad"* is itself an idea. See `internal/collections/templates_onboarding.go` for the bodies, and PLAN-1131 for the design history.
+
 ### Workspace membership
 ```bash
 pad workspace members                         # List workspace members

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,7 +107,7 @@ pad auth reset-password user@example.com  # Generate reset link (admin fallback)
 # CLI auto-attaches auth token to all API requests
 ```
 
-After `pad auth setup` (and after `pad init` / `pad workspace init` for any subsequent workspace), the success output points new users at the seeded onboarding entry point. Open a fresh agent session in the workspace's directory and say:
+After a `startup`-template workspace is created (via `pad init` or `pad workspace init` — note that `pad auth setup` only creates the admin account, not a workspace), the success output points new users at the seeded onboarding entry point. Open a fresh agent session in the workspace's directory and say:
 
 ```
 use pad to get IDEA-1

--- a/README.md
+++ b/README.md
@@ -30,6 +30,14 @@ pad server open             # opens the web UI at localhost:7777
 
 `pad init` is the smart entry point — it auto-detects what's needed, walks you through each step, and is safe to re-run anytime (it skips finished steps and prints a status summary).
 
+Then, in a fresh agent session in your project, say:
+
+```
+use pad to get IDEA-1
+```
+
+Your new workspace ships with a thoughtful first idea — IDEA-1 — that the agent reads and uses to help you get set up around your actual project. It's the fastest way to go from empty workspace to "okay, this is mine."
+
 ## Why Pad?
 
 Tools like Linear, Jira, and Notion are built for teams on the cloud. Pad is built for **developers on their machine** — and for the AI agents working alongside them.

--- a/skills/pad/SKILL.md
+++ b/skills/pad/SKILL.md
@@ -176,6 +176,7 @@ Items can carry image and file attachments. They appear in item content as `![al
 **Onboarding:**
 - "set up my workspace" / "onboard me" / "scan this codebase" → Onboarding workflow (see below). The software templates' onboarding step still scans the codebase; non-software workspaces run their own template-specific onboarding.
 - "what conventions should this workspace follow?" → Run the workspace's onboarding playbook if one exists, otherwise suggest conventions from the library.
+- **"use pad to get IDEA-1"** (or any of `PLAN-2` / `TASK-3` / `DOC-4` in a fresh `startup` workspace) → Fetch the named seed item with `pad item show <REF> --format markdown` and let its body guide you. Each is a first-person note from the workspace owner's future self that asks you to capture their actual project. There is no special "onboarding mode" — it's just an item you read and act on like any other. Once the user has captured something useful, run `pad project dashboard` so they see what got built, point them at the web UI, and update the seed item's status to its terminal value (Ideas: `implemented`, Plans: `completed`, Tasks: `done`, Docs: `archived`) so the dashboard hint disappears.
 
 ## Before Performing Work
 


### PR DESCRIPTION
## Summary

Document the IDEA-1 onboarding entry point across the three doc surfaces a fresh user / agent might consult. Closes the documentation gate of PLAN-1131.

## Surfaces

**README.md** — Quick Start gains a follow-up paragraph after \`pad init\`:
> *"Then, in a fresh agent session in your project, say: \`use pad to get IDEA-1\`. Your new workspace ships with a thoughtful first idea — IDEA-1 — that the agent reads and uses to help you get set up around your actual project."*

**CLAUDE.md** — Authentication section gets a paragraph after \`pad auth setup\` walking developers + agents through the trigger phrase. Enumerates the four seeded refs (IDEA-1 / PLAN-2 / TASK-3 / DOC-4) and points at \`internal/collections/templates_onboarding.go\` (source of truth) and PLAN-1131 (design history).

**skills/pad/SKILL.md** — Adds a bullet under the Onboarding routing section: an explicit \"use pad to get IDEA-1\" trigger plus schema-aware terminal-status guidance per collection (Ideas → \`implemented\`, Plans → \`completed\`, Tasks → \`done\`, Docs → \`archived\`). Frames the seed items as ordinary items the agent reads and acts on — preserving the no-marker / no-skill-detection design.

## What's NOT in this PR

**pad-web (../pad-web)** is intentionally not touched. CONVE-159 is firm: the marketing site lives in a separate SvelteKit repo. **TASK-1142 spawned** to pick up the pad-web getting-started flow as a follow-up.

## Word audit

Zero occurrences of *tutorial / lesson / walkthrough / guide / step-by-step* in any of the new copy. Wording mirrors the in-product hints from PR #403 so docs and UI don't drift.

## Context

Implements TASK-1138, the documentation gate of PLAN-1131. With this merged, PLAN-1131 is shippable end-to-end:

| Ref | Title | Status |
|---|---|---|
| ✅ TASK-1132 | Design seed bodies | done |
| ✅ TASK-1133 | Seed on workspace creation | done (PR #402) |
| ✅ TASK-1134 | Post-setup UX hint | done (PR #403) |
| ❌ TASK-1135 | Skill detection | cancelled |
| ✅ TASK-1136 | MCP surface verify | done (PR #404) |
| ✅ TASK-1137 | E2E walkthrough test | done (PR #405) |
| 🟢 TASK-1138 | **Document the entry point** | this PR |

## Test plan

- [x] \`make check\` clean (lint + tests + web build all green)
- [x] Word audit on all three files
- [x] Wording cross-checked against PR #403's in-product copy and PR #402's seed bodies