### PR TITLE
fix(cli): pad auth setup hint should point at pad init, not nonexistent IDEA-1 (TASK-1143)

### DIFF
--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -841,26 +841,27 @@ func setupCmd() *cobra.Command {
 			green := color.New(color.FgGreen).SprintFunc()
 			fmt.Printf("%s First admin account created\n", green("✓"))
 			fmt.Printf("%s Logged in as %s (%s)\n", green("✓"), resp.User.Name, resp.User.Email)
-			printIdeaOneTriggerHint()
+			printPostSetupNextStepsHint()
 			return nil
 		},
 	}
 }
 
-// printIdeaOneTriggerHint surfaces the trigger phrase that points a fresh
-// agent session at the seeded IDEA-1 onboarding item. The phrase is named
-// (not generic) so a copy-paste lands deterministically on the right ref
-// in software-category workspaces. People-category and other templates
-// will need a template-aware version of this hint — tracked under
-// PLAN-1140 (the people-category onboarding plan).
-func printIdeaOneTriggerHint() {
+// printPostSetupNextStepsHint walks the freshly-bootstrapped admin to the
+// next step that actually does something useful: creating a workspace.
+// The IDEA-1 trigger phrase belongs in `printOnboardingHints` (which runs
+// after `pad init` / `pad workspace init`) — by then the workspace
+// exists and IDEA-1 is seeded. Calling out the trigger phrase here would
+// have sent users at a nonexistent ref (TASK-1143 / Codex review of PR
+// #406).
+func printPostSetupNextStepsHint() {
 	bold := color.New(color.Bold)
 	cyan := color.New(color.FgCyan)
 
 	fmt.Println()
-	bold.Println("To get started:")
-	fmt.Printf("  Open a fresh agent session (Claude Code, Cursor, etc.) and say:\n")
-	fmt.Printf("  %s\n", cyan.Sprint("use pad to get IDEA-1"))
+	bold.Println("Next:")
+	fmt.Printf("  Run %s in your project directory to create your first workspace.\n", cyan.Sprint("pad init"))
+	fmt.Printf("  The success message will tell you how to kick off your first agent session.\n")
 }
 
 func loginCmd() *cobra.Command {


### PR DESCRIPTION
## Summary

PR #403 (TASK-1134) added \`printIdeaOneTriggerHint()\` to the \`pad auth setup\` success path. But \`pad auth setup\` only creates the first admin account — no workspace. IDEA-1 is only seeded when a startup-template workspace is created (via \`pad init\` / \`pad workspace init\`). A user following the original hint immediately would have hit \"workspace not found\" / \"item not found\".

Caught by Codex during review of PR #406. TASK-1143 was spawned then to keep that PR docs-only; this is the corresponding behavior fix.

## What changes

**Old hint** (after \`pad auth setup\`):

> To get started:
>   Open a fresh agent session (Claude Code, Cursor, etc.) and say:
>   use pad to get IDEA-1

**New hint**:

> Next:
>   Run \`pad init\` in your project directory to create your first workspace.
>   The success message will tell you how to kick off your first agent session.

The IDEA-1 trigger phrase still surfaces in \`printOnboardingHints\` (which runs after \`pad init\` / \`pad workspace init\`) — by then the workspace exists and the trigger phrase resolves correctly.

Renamed \`printIdeaOneTriggerHint\` → \`printPostSetupNextStepsHint\` since the hint no longer names IDEA-1 directly.

## Why Option 2 over Option 1 (drop the hint)

Option 1 was \"just delete the hint.\" Option 2 keeps it but reframes — gives the user a direct next step (\`pad init\`) instead of leaving them at a green checkmark wondering what to do.

## Context

Follow-up under PLAN-1131. Closes the loose end Codex found during PR #406 review.

## Test plan

- [x] \`make check\` clean (lint + tests + web build)
- [x] Hint wording matches CLAUDE.md / README — workspace creation precedes trigger phrase everywhere