### PR TITLE
feat(collections): seed onboarding items + explicit prefixes for scrum + product templates (TASK-1149)

### DIFF
--- a/internal/collections/templates.go
+++ b/internal/collections/templates.go
@@ -513,8 +513,10 @@ var templates = []WorkspaceTemplate{
 			playbooksCollection(5, SoftwarePlaybookTriggers, SoftwarePlaybookScopes),
 		},
 		// SeedItems run before Conventions/Playbooks in the bootstrap loop
-		// so refs land at BACK-1 / SPRINT-2 / BUG-3 / DOC-4. The post-signup
-		// hint will name BACK-1 specifically. (PLAN-1146 / DOC-1152.)
+		// so refs land at BACK-1 / SPRINT-2 / BUG-3 / DOC-4. The CLI hint
+		// and dashboard banner are still hardcoded to IDEA-1 from PR #403;
+		// TASK-1150 makes them template-aware so a fresh scrum workspace
+		// promotes BACK-1. (PLAN-1146 / DOC-1152.)
 		SeedItems:   ScrumOnboardingItems(),
 		Conventions: SoftwareStarterConventions(),
 		Playbooks:   SoftwareStarterPlaybooks(),
@@ -650,8 +652,10 @@ var templates = []WorkspaceTemplate{
 			playbooksCollection(5, SoftwarePlaybookTriggers, SoftwarePlaybookScopes),
 		},
 		// SeedItems run before Conventions/Playbooks in the bootstrap loop
-		// so refs land at FEAT-1 / FB-2 / ROAD-3 / DOC-4. The post-signup
-		// hint will name FEAT-1 specifically. (PLAN-1146 / DOC-1153.)
+		// so refs land at FEAT-1 / FB-2 / ROAD-3 / DOC-4. The CLI hint and
+		// dashboard banner are still hardcoded to IDEA-1 from PR #403;
+		// TASK-1150 makes them template-aware so a fresh product workspace
+		// promotes FEAT-1. (PLAN-1146 / DOC-1153.)
 		SeedItems:   ProductOnboardingItems(),
 		Conventions: SoftwareStarterConventions(),
 		Playbooks:   SoftwareStarterPlaybooks(),

--- a/internal/collections/templates.go
+++ b/internal/collections/templates.go
@@ -387,6 +387,7 @@ var templates = []WorkspaceTemplate{
 			{
 				Name:        "Backlog",
 				Slug:        "backlog",
+				Prefix:      "BACK", // explicit so DerivePrefix doesn't yield "BACKL"
 				Icon:        "\U0001F4CB",
 				Description: "Product backlog items for sprint planning",
 				SortOrder:   0,
@@ -430,6 +431,7 @@ var templates = []WorkspaceTemplate{
 			{
 				Name:        "Sprints",
 				Slug:        "sprints",
+				Prefix:      "SPRINT", // explicit so DerivePrefix doesn't yield "SPRIN"
 				Icon:        "\U0001F3C3",
 				Description: "Sprint cycles with goals and timelines",
 				SortOrder:   1,
@@ -510,6 +512,10 @@ var templates = []WorkspaceTemplate{
 			conventionsCollection(4, SoftwareConventionTriggers, SoftwareConventionScopes),
 			playbooksCollection(5, SoftwarePlaybookTriggers, SoftwarePlaybookScopes),
 		},
+		// SeedItems run before Conventions/Playbooks in the bootstrap loop
+		// so refs land at BACK-1 / SPRINT-2 / BUG-3 / DOC-4. The post-signup
+		// hint will name BACK-1 specifically. (PLAN-1146 / DOC-1152.)
+		SeedItems:   ScrumOnboardingItems(),
 		Conventions: SoftwareStarterConventions(),
 		Playbooks:   SoftwareStarterPlaybooks(),
 	},
@@ -522,6 +528,7 @@ var templates = []WorkspaceTemplate{
 			{
 				Name:        "Features",
 				Slug:        "features",
+				Prefix:      "FEAT", // explicit so DerivePrefix doesn't yield "FEATU"
 				Icon:        "\u2728",
 				Description: "Track feature development from proposal to launch",
 				SortOrder:   0,
@@ -560,6 +567,7 @@ var templates = []WorkspaceTemplate{
 			{
 				Name:        "Feedback",
 				Slug:        "feedback",
+				Prefix:      "FB", // explicit so DerivePrefix doesn't yield "FEEDB". Same prefix as hiring's Feedback collection — fine since templates never coexist in a single workspace.
 				Icon:        "\U0001F4AC",
 				Description: "Collect and prioritize user feedback",
 				SortOrder:   1,
@@ -603,6 +611,7 @@ var templates = []WorkspaceTemplate{
 			{
 				Name:        "Roadmap Items",
 				Slug:        "roadmap-items",
+				Prefix:      "ROAD", // explicit so DerivePrefix doesn't yield the multi-word "RI" initials
 				Icon:        "\U0001F5FA\uFE0F",
 				Description: "Plan and communicate product direction",
 				SortOrder:   2,
@@ -640,6 +649,10 @@ var templates = []WorkspaceTemplate{
 			conventionsCollection(4, SoftwareConventionTriggers, SoftwareConventionScopes),
 			playbooksCollection(5, SoftwarePlaybookTriggers, SoftwarePlaybookScopes),
 		},
+		// SeedItems run before Conventions/Playbooks in the bootstrap loop
+		// so refs land at FEAT-1 / FB-2 / ROAD-3 / DOC-4. The post-signup
+		// hint will name FEAT-1 specifically. (PLAN-1146 / DOC-1153.)
+		SeedItems:   ProductOnboardingItems(),
 		Conventions: SoftwareStarterConventions(),
 		Playbooks:   SoftwareStarterPlaybooks(),
 	},

--- a/internal/collections/templates_onboarding_product.go
+++ b/internal/collections/templates_onboarding_product.go
@@ -4,10 +4,18 @@ package collections
 //
 // Same mechanism as the startup + scrum onboarding seeds: one seed
 // item per user-facing collection, agent-invocable, written
-// first-person from the workspace owner's future self. The
-// post-signup hint will name FEAT-1 because Features are product's
-// spine — but any of FEAT-1 / FB-2 / ROAD-3 / DOC-4 is a viable
-// entry point for `/pad let's discuss <REF>`.
+// first-person from the workspace owner's future self. Any of
+// FEAT-1 / FB-2 / ROAD-3 / DOC-4 is a viable entry point for
+// `/pad let's discuss <REF>`.
+//
+// Status of the post-signup hint that names the primary entry: as of
+// this PR (TASK-1149) the CLI hint and dashboard banner are still
+// hardcoded to IDEA-1 — they were shipped against the startup template
+// only (PR #403). TASK-1150 makes those template-aware so a fresh
+// product workspace surfaces "use pad to get FEAT-1" rather than
+// IDEA-1. Until TASK-1150 lands, the bodies are still reachable via
+// direct fetch (`pad item show FEAT-1`) but the dashboard banner
+// doesn't promote them.
 //
 // Bodies and design rationale: DOC-1153 (PLAN-1146).
 //
@@ -140,7 +148,8 @@ delete me, I'm not precious.
 // ship in a fresh `product` workspace. The order matters: items are
 // inserted in this slice's order before conventions/playbooks, so
 // the workspace-scoped item_number sequence lands at FEAT-1 / FB-2 /
-// ROAD-3 / DOC-4. The post-signup hint will name FEAT-1 specifically.
+// ROAD-3 / DOC-4. FEAT-1 is the designated primary — TASK-1150 will
+// wire the post-signup hint and dashboard banner to surface it.
 //
 // Features is the primary entry — uncontested. Roadmap is the
 // strategic frame above features; feedback is the signal source

--- a/internal/collections/templates_onboarding_product.go
+++ b/internal/collections/templates_onboarding_product.go
@@ -1,0 +1,176 @@
+package collections
+
+// Onboarding seed items for new product-template workspaces.
+//
+// Same mechanism as the startup + scrum onboarding seeds: one seed
+// item per user-facing collection, agent-invocable, written
+// first-person from the workspace owner's future self. The
+// post-signup hint will name FEAT-1 because Features are product's
+// spine — but any of FEAT-1 / FB-2 / ROAD-3 / DOC-4 is a viable
+// entry point for `/pad let's discuss <REF>`.
+//
+// Bodies and design rationale: DOC-1153 (PLAN-1146).
+//
+// Schema-valid terminal verbs per collection (locked at design time
+// to prevent the round-1 regression on PR #402):
+//   - Features      → status `shipped`
+//   - Feedback      → status `shipped` (closed when the change ships)
+//   - Roadmap Items → status `completed`
+//   - Docs          → status `archived`
+
+const productFeatureOnboardingBody = `# Welcome — let's start shaping what we're going to ship
+
+I just made this product workspace. It's where I'm going to keep
+track of what we're building: features moving through the build
+funnel, feedback we're collecting from users, roadmap commitments,
+and docs.
+
+If you're reading this, it's because I asked you to. I'd like your
+help getting started — not with a tutorial, just by talking through
+what we're actually building and capturing it here as we go.
+
+## What I'd find useful
+
+Ask me what we're working on. Listen for the shape of the product
+— what we just shipped, what's in research, what's queued up, where
+the user signals are pulling us. As things come up, capture them
+here. Features for things we're building, feedback for signals
+worth remembering, roadmap items for the bigger bets we're placing,
+docs when a decision needs to outlive the conversation.
+
+Use the actual product, not a toy example. Don't ask permission for
+every little thing — narrate what you're capturing as you go.
+
+When we've got enough here to be useful, run ` + "`pad project dashboard`" + `
+so I can see the build funnel, and point me at the web UI. Then
+mark me shipped.
+
+## A few things to know about Pad
+
+- Items have IDs like FEAT-7, FB-3, ROAD-2 — that's how I'll
+  refer to them.
+- ` + "`pad project next`" + ` will tell me what to work on.
+- ` + "`pad project dashboard`" + ` shows the state of the build funnel.
+- ` + "`pad item search \"term\"`" + ` finds anything by content.
+- ` + "`pad <anything>`" + ` in a /pad-aware agent session is how I'll talk
+  to you in the future.
+
+## If I've already done this before
+
+If you look around and see I already have features, feedback,
+roadmap items of my own — I'm not new, I just re-opened you. Don't
+redo any of this. Recap what's in the dashboard and let me get
+back to work.
+`
+
+const productFeedbackOnboardingBody = `# A piece of feedback I haven't captured yet
+
+This is where user signals live — quotes, tickets, recurring
+complaints, requests we want to remember. Feedback closes its
+lifecycle when the change it inspired actually ships.
+
+## What I'd find useful
+
+If you're with me through this item, I've probably just heard
+something useful from a user — a sales call quote, a support
+ticket, a pattern across multiple complaints. Help me capture it
+without losing the texture: who said it (or which segment), what
+they said in their words, what they wanted, what context they were
+in. Don't editorialize — the value of feedback is the unfiltered
+signal.
+
+If the feedback is concrete enough to act on right now, fine —
+it'll surface as a feature. If it's a recurring theme worth a
+bigger bet, it might fold into a roadmap item. Capture the signal
+first; sort the rest out later.
+
+When the change motivated by this feedback actually goes out, mark
+me shipped. Or delete me — I'm not precious.
+`
+
+const productRoadmapOnboardingBody = `# A roadmap commitment I haven't placed yet
+
+This is where the bigger bets live — quarter-or-larger commitments
+that organize feature work into themes. Roadmap items aren't
+features; they're frames around features.
+
+## What I'd find useful
+
+If you're with me through this item, I'm probably thinking about a
+chunk of work bigger than one feature. A theme ("self-serve
+onboarding"), an initiative ("cut p99 latency by half"), a strategic
+bet. Help me think through it: what's the bet, why now, what
+features ladder up to it, what would success look like in plain
+language, what we're explicitly choosing NOT to do at this level.
+
+If what I'm describing fits in a single PR or a single feature,
+that's a feature, not a roadmap item. If it's a vague aspiration
+without enough shape to commit, it might be earlier than that — a
+doc, a feedback theme to watch.
+
+When the work actually lands, mark me completed. Or delete me, I'm
+not precious.
+`
+
+const productDocOnboardingBody = `# A doc I haven't written yet
+
+This is where I write things down that I'll need later —
+architecture decisions, postmortems, the user-research synthesis I
+want available when we're spec'ing the next feature.
+
+## What I'd find useful
+
+If you're with me through this item, I probably want to write
+something down so I don't have to figure it out again next quarter.
+Help me figure out what kind of doc this is — a decision record, a
+research synthesis, a runbook, a postmortem — and what should go in
+it. Capture as we go; the trick with docs is writing them the
+moment something's fresh, not three quarters later when the context
+has evaporated.
+
+If what I'm describing is more "we should ship this" than "we should
+remember this," capture it as a feature or feedback instead. This
+is for memory.
+
+When we've got the doc, show it back to me. Then archive me — or
+delete me, I'm not precious.
+`
+
+// ProductOnboardingItems returns the four onboarding seed items that
+// ship in a fresh `product` workspace. The order matters: items are
+// inserted in this slice's order before conventions/playbooks, so
+// the workspace-scoped item_number sequence lands at FEAT-1 / FB-2 /
+// ROAD-3 / DOC-4. The post-signup hint will name FEAT-1 specifically.
+//
+// Features is the primary entry — uncontested. Roadmap is the
+// strategic frame above features; feedback is the signal source
+// below. Features are the unit of building work, the natural first
+// thing a product workspace's owner thinks about.
+func ProductOnboardingItems() []SeedItem {
+	return []SeedItem{
+		{
+			CollectionSlug: "features",
+			Title:          "Welcome — let's start shaping what we're going to ship",
+			Content:        productFeatureOnboardingBody,
+			Fields:         `{"status":"proposed"}`,
+		},
+		{
+			CollectionSlug: "feedback",
+			Title:          "A piece of feedback I haven't captured yet",
+			Content:        productFeedbackOnboardingBody,
+			Fields:         `{"status":"new"}`,
+		},
+		{
+			CollectionSlug: "roadmap-items",
+			Title:          "A roadmap commitment I haven't placed yet",
+			Content:        productRoadmapOnboardingBody,
+			Fields:         `{"status":"planned"}`,
+		},
+		{
+			CollectionSlug: "docs",
+			Title:          "A doc I haven't written yet",
+			Content:        productDocOnboardingBody,
+			Fields:         `{"status":"draft"}`,
+		},
+	}
+}

--- a/internal/collections/templates_onboarding_scrum.go
+++ b/internal/collections/templates_onboarding_scrum.go
@@ -5,10 +5,17 @@ package collections
 // Same mechanism as the startup template's onboarding seeds (see
 // templates_onboarding.go and DOC-1139): one seed item per user-facing
 // collection, agent-invocable, written first-person from the workspace
-// owner's future self. The post-signup hint will name BACK-1 because
-// "I want to start tracking what we're going to build" is itself a
-// backlog item — but any of BACK-1 / SPRINT-2 / BUG-3 / DOC-4 is a
+// owner's future self. Any of BACK-1 / SPRINT-2 / BUG-3 / DOC-4 is a
 // viable entry point for `/pad let's discuss <REF>`.
+//
+// Status of the post-signup hint that names the primary entry: as of
+// this PR (TASK-1149) the CLI hint and dashboard banner are still
+// hardcoded to IDEA-1 — they were shipped against the startup template
+// only (PR #403). TASK-1150 makes those template-aware so a fresh scrum
+// workspace surfaces "use pad to get BACK-1" rather than IDEA-1.
+// Until TASK-1150 lands, the bodies are still reachable via direct
+// fetch (`pad item show BACK-1`) but the dashboard banner doesn't
+// promote them.
 //
 // Bodies and design rationale: DOC-1152 (PLAN-1146).
 //
@@ -139,7 +146,8 @@ delete me, I'm not precious.
 // in a fresh `scrum` workspace. The order matters: items are inserted
 // in this slice's order before conventions/playbooks, so the
 // workspace-scoped item_number sequence lands at BACK-1 / SPRINT-2 /
-// BUG-3 / DOC-4. The post-signup hint will name BACK-1 specifically.
+// BUG-3 / DOC-4. BACK-1 is the designated primary — TASK-1150 will
+// wire the post-signup hint and dashboard banner to surface it.
 //
 // Backlog is the primary entry rather than Sprints because work
 // originates in the backlog; sprints organize what's already there.

--- a/internal/collections/templates_onboarding_scrum.go
+++ b/internal/collections/templates_onboarding_scrum.go
@@ -1,0 +1,175 @@
+package collections
+
+// Onboarding seed items for new scrum-template workspaces.
+//
+// Same mechanism as the startup template's onboarding seeds (see
+// templates_onboarding.go and DOC-1139): one seed item per user-facing
+// collection, agent-invocable, written first-person from the workspace
+// owner's future self. The post-signup hint will name BACK-1 because
+// "I want to start tracking what we're going to build" is itself a
+// backlog item — but any of BACK-1 / SPRINT-2 / BUG-3 / DOC-4 is a
+// viable entry point for `/pad let's discuss <REF>`.
+//
+// Bodies and design rationale: DOC-1152 (PLAN-1146).
+//
+// Schema-valid terminal verbs per collection (locked at design time
+// to prevent the round-1 regression on PR #402):
+//   - Backlog → status `done`
+//   - Sprints → status `completed`
+//   - Bugs    → status `resolved` (or `wontfix`)
+//   - Docs    → status `archived`
+
+const scrumBacklogOnboardingBody = `# Welcome — let's start tracking what we're going to build
+
+I just made this scrum workspace. It's where I'm going to keep track
+of what the team is building: the backlog of work waiting to be picked
+up, the sprints we're organizing it into, the bugs we're chasing
+down, and the docs we want to keep.
+
+If you're reading this, it's because I asked you to. I'd like your
+help getting started — not with a tutorial, just by talking through
+what's actually on our plate and capturing it here as we go.
+
+## What I'd find useful
+
+Ask me what the team is working on. Listen for the shape of it —
+what's in flight, what's queued up, what's loose. As things come up,
+capture them here. Backlog items for work-to-do, sprints when we
+batch them up, bugs when we hit them, docs when we figure something
+out worth remembering. Use my actual project, not toy data.
+
+If something's small enough that we'll do it this sprint, capture it
+as a backlog item with status ` + "`ready`" + `. If we're already in a sprint,
+mark it ` + "`in_sprint`" + `. If it's broken code, that's a bug, not a backlog
+item. Don't ask permission for every little thing — narrate briefly
+what you're capturing as you go.
+
+When we've got enough here to be useful, run ` + "`pad project dashboard`" + `
+so I can see what we built, and point me at the web UI. Then mark
+this backlog item done.
+
+## A few things to know about Pad
+
+- Items have IDs like BACK-3, SPRINT-7, BUG-12 — that's how I'll
+  refer to them.
+- ` + "`pad project next`" + ` will tell me what to work on.
+- ` + "`pad project dashboard`" + ` shows the state of everything.
+- ` + "`pad item search \"term\"`" + ` finds anything by content.
+- ` + "`pad <anything>`" + ` in a /pad-aware agent session is how I'll talk
+  to you in the future.
+
+## If I've already done this before
+
+If you look around and see I already have a backlog, sprints,
+bugs of my own — I'm not new, I just re-opened you. Don't redo
+any of this. Recap what's in the dashboard and let me get back
+to work.
+`
+
+const scrumSprintOnboardingBody = `# A sprint I haven't planned yet
+
+This is where my sprint cycles live — start dates, end dates, goals.
+A sprint pulls a batch of backlog items (and sometimes bugs) into a
+focused window.
+
+## What I'd find useful
+
+If you're with me through this item, I'm probably about to plan a
+sprint. Help me think through it: what's the goal in plain language,
+which backlog items are coming in, what's the start and end date,
+what we're explicitly NOT doing this sprint. Pull from the existing
+backlog rather than making up new work.
+
+If the work I'm describing isn't sprint-shaped — it's a single quick
+fix, or it's bigger than two weeks — capture it as a backlog item
+or as a separate plan instead. Sprints earn their weight by holding
+multiple items toward a shared outcome.
+
+When the sprint's planned, run ` + "`pad project dashboard`" + ` so I can see
+the shape of it. Then mark me completed when the sprint actually
+ends — or delete me, I'm not precious.
+`
+
+const scrumBugOnboardingBody = `# A bug I haven't filed yet
+
+Bugs live here, separate from feature work. They have their own
+lifecycle — triaged, fixing, resolved, wontfix — because broken
+things deserve a different conversation than new things.
+
+## What I'd find useful
+
+If you're with me through this item, something's probably broken or
+behaving wrong. Help me capture it: what's broken, what should
+happen, what does happen, how to reproduce, severity. Be specific —
+"login fails" is a worse bug report than "OAuth callback drops
+state= param when redirecting from /authorize, browser shows blank
+page."
+
+If the issue is small enough we'll just fix it now, that's fine —
+file the bug anyway. Future-me will want the trail.
+
+When it's fixed, mark me resolved (or wontfix if we decided not to
+fix). Or delete me, I'm not precious.
+`
+
+const scrumDocOnboardingBody = `# A doc I haven't written yet
+
+This is where I write things down that I'll need later —
+architecture notes, decisions, retros, runbooks, the team norms
+that aren't quite formal conventions yet.
+
+## What I'd find useful
+
+If you're with me through this item, I probably want to write
+something down so I don't have to figure it out again next sprint.
+Help me figure out what kind of doc this is — an architecture
+sketch, a sprint retro, a runbook, a decision record — and what
+should go in it. Capture as we go; the trick with docs is writing
+them the moment something's fresh, not three sprints later.
+
+If what I'm describing is more action than memory — "we should fix
+this" or "let's add this feature" — capture it as a backlog item
+or a bug instead. This is for memory.
+
+When we've got the doc, show it back to me. Then archive me — or
+delete me, I'm not precious.
+`
+
+// ScrumOnboardingItems returns the four onboarding seed items that ship
+// in a fresh `scrum` workspace. The order matters: items are inserted
+// in this slice's order before conventions/playbooks, so the
+// workspace-scoped item_number sequence lands at BACK-1 / SPRINT-2 /
+// BUG-3 / DOC-4. The post-signup hint will name BACK-1 specifically.
+//
+// Backlog is the primary entry rather than Sprints because work
+// originates in the backlog; sprints organize what's already there.
+// "I want to start tracking what we're going to build" is itself a
+// backlog item.
+func ScrumOnboardingItems() []SeedItem {
+	return []SeedItem{
+		{
+			CollectionSlug: "backlog",
+			Title:          "Welcome — let's start tracking what we're going to build",
+			Content:        scrumBacklogOnboardingBody,
+			Fields:         `{"status":"new"}`,
+		},
+		{
+			CollectionSlug: "sprints",
+			Title:          "A sprint I haven't planned yet",
+			Content:        scrumSprintOnboardingBody,
+			Fields:         `{"status":"planning"}`,
+		},
+		{
+			CollectionSlug: "bugs",
+			Title:          "A bug I haven't filed yet",
+			Content:        scrumBugOnboardingBody,
+			Fields:         `{"status":"new"}`,
+		},
+		{
+			CollectionSlug: "docs",
+			Title:          "A doc I haven't written yet",
+			Content:        scrumDocOnboardingBody,
+			Fields:         `{"status":"draft"}`,
+		},
+	}
+}

--- a/internal/collections/templates_test.go
+++ b/internal/collections/templates_test.go
@@ -244,6 +244,155 @@ func TestStartupTemplateShipsOnboardingSeedItems(t *testing.T) {
 	}
 }
 
+// TestScrumOnboardingItemsOrderAndShape — sister to startup's test for
+// the scrum template (PLAN-1146, DOC-1152). Locks down the order +
+// collection slugs + status fields so the post-signup hint copy
+// (which will name BACK-1) doesn't silently desync.
+func TestScrumOnboardingItemsOrderAndShape(t *testing.T) {
+	items := ScrumOnboardingItems()
+	want := []struct {
+		Slug, Status string
+	}{
+		{"backlog", "new"},
+		{"sprints", "planning"},
+		{"bugs", "new"},
+		{"docs", "draft"},
+	}
+
+	if len(items) != len(want) {
+		t.Fatalf("ScrumOnboardingItems returned %d items, want %d", len(items), len(want))
+	}
+
+	for i, it := range items {
+		if it.CollectionSlug != want[i].Slug {
+			t.Errorf("item[%d] CollectionSlug = %q, want %q", i, it.CollectionSlug, want[i].Slug)
+		}
+		if it.Title == "" {
+			t.Errorf("item[%d] (%s) has empty Title", i, it.CollectionSlug)
+		}
+		if it.Content == "" {
+			t.Errorf("item[%d] (%s) has empty Content", i, it.CollectionSlug)
+		}
+		wantStatus := `"status":"` + want[i].Status + `"`
+		if !contains(it.Fields, wantStatus) {
+			t.Errorf("item[%d] (%s) Fields = %q, want it to contain %s", i, it.CollectionSlug, it.Fields, wantStatus)
+		}
+	}
+}
+
+// TestProductOnboardingItemsOrderAndShape — sister test for the product
+// template (PLAN-1146, DOC-1153). Locks the FEAT-1 / FB-2 / ROAD-3 /
+// DOC-4 sequence.
+func TestProductOnboardingItemsOrderAndShape(t *testing.T) {
+	items := ProductOnboardingItems()
+	want := []struct {
+		Slug, Status string
+	}{
+		{"features", "proposed"},
+		{"feedback", "new"},
+		{"roadmap-items", "planned"},
+		{"docs", "draft"},
+	}
+
+	if len(items) != len(want) {
+		t.Fatalf("ProductOnboardingItems returned %d items, want %d", len(items), len(want))
+	}
+
+	for i, it := range items {
+		if it.CollectionSlug != want[i].Slug {
+			t.Errorf("item[%d] CollectionSlug = %q, want %q", i, it.CollectionSlug, want[i].Slug)
+		}
+		if it.Title == "" {
+			t.Errorf("item[%d] (%s) has empty Title", i, it.CollectionSlug)
+		}
+		if it.Content == "" {
+			t.Errorf("item[%d] (%s) has empty Content", i, it.CollectionSlug)
+		}
+		wantStatus := `"status":"` + want[i].Status + `"`
+		if !contains(it.Fields, wantStatus) {
+			t.Errorf("item[%d] (%s) Fields = %q, want it to contain %s", i, it.CollectionSlug, it.Fields, wantStatus)
+		}
+	}
+}
+
+// TestScrumProductTemplatesShipOnboardingSeedItems mirrors the startup
+// version — verifies the templates' SeedItems fields wire to their
+// onboarding helpers.
+func TestScrumProductTemplatesShipOnboardingSeedItems(t *testing.T) {
+	cases := []struct {
+		Name            string
+		WantSeedFn      func() []SeedItem
+		WantPrimarySlug string
+	}{
+		{Name: "scrum", WantSeedFn: ScrumOnboardingItems, WantPrimarySlug: "backlog"},
+		{Name: "product", WantSeedFn: ProductOnboardingItems, WantPrimarySlug: "features"},
+	}
+
+	for _, c := range cases {
+		tmpl := GetTemplate(c.Name)
+		if tmpl == nil {
+			t.Errorf("%s template missing", c.Name)
+			continue
+		}
+		want := c.WantSeedFn()
+		if len(tmpl.SeedItems) != len(want) {
+			t.Errorf("%s template SeedItems = %d items, want %d", c.Name, len(tmpl.SeedItems), len(want))
+			continue
+		}
+		// The first SeedItem MUST go to the template's primary entry
+		// collection (BACK-1 for scrum, FEAT-1 for product). If this
+		// drifts, the post-signup hint silently names a different
+		// (or missing) item.
+		if len(tmpl.SeedItems) > 0 && tmpl.SeedItems[0].CollectionSlug != c.WantPrimarySlug {
+			t.Errorf("%s SeedItems[0].CollectionSlug = %q, want %q (primary entry must be first)", c.Name, tmpl.SeedItems[0].CollectionSlug, c.WantPrimarySlug)
+		}
+	}
+}
+
+// TestScrumProductTemplatesUseExplicitFriendlyPrefixes guards the
+// prefix-fix precondition from PLAN-1146: scrum and product collection
+// definitions set explicit Prefix values rather than relying on
+// DerivePrefix, which would yield awkward refs like BACKL / SPRIN /
+// FEATU / FEEDB / RI. Drift here means the seeded refs no longer match
+// the bodies' "use pad to get BACK-1" copy.
+func TestScrumProductTemplatesUseExplicitFriendlyPrefixes(t *testing.T) {
+	cases := []struct {
+		Template string
+		Slug     string
+		WantPfx  string
+	}{
+		{"scrum", "backlog", "BACK"},
+		{"scrum", "sprints", "SPRINT"},
+		{"product", "features", "FEAT"},
+		{"product", "feedback", "FB"},
+		{"product", "roadmap-items", "ROAD"},
+	}
+
+	for _, c := range cases {
+		tmpl := GetTemplate(c.Template)
+		if tmpl == nil {
+			t.Errorf("%s template missing", c.Template)
+			continue
+		}
+		var got string
+		var found bool
+		for _, coll := range tmpl.Collections {
+			if coll.Slug == c.Slug {
+				got = coll.Prefix
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("%s template missing collection %q", c.Template, c.Slug)
+			continue
+		}
+		if got != c.WantPfx {
+			t.Errorf("%s.%s.Prefix = %q, want %q (rely on derivation and you'll get an awkward ref)", c.Template, c.Slug, got, c.WantPfx)
+		}
+	}
+}
+
 // contains is a local substring helper to keep the templates_test.go file
 // dependency-free. The standard library's strings.Contains would also work;
 // keeping this local matches the file's existing style.

--- a/internal/store/items_test.go
+++ b/internal/store/items_test.go
@@ -488,6 +488,109 @@ func TestSeedCollectionsFromTemplateStartupRefSequence(t *testing.T) {
 	}
 }
 
+// TestSeedCollectionsFromTemplateScrumRefSequence is the scrum-template
+// sibling of TestSeedCollectionsFromTemplateStartupRefSequence. Locks
+// down the BACK-1 / SPRINT-2 / BUG-3 / DOC-4 sequence for fresh scrum
+// workspaces — same reasoning as the startup version: drift here
+// silently misfires the post-signup hint, which will name BACK-1.
+func TestSeedCollectionsFromTemplateScrumRefSequence(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Scrum Refs")
+
+	if err := s.SeedCollectionsFromTemplate(ws.ID, "scrum"); err != nil {
+		t.Fatalf("seed scrum template: %v", err)
+	}
+
+	type expected struct {
+		Slug, Title string
+		WantItemNum int
+		WantPrefix  string
+	}
+	want := []expected{
+		{"backlog", "Welcome — let's start tracking what we're going to build", 1, "BACK"},
+		{"sprints", "A sprint I haven't planned yet", 2, "SPRINT"},
+		{"bugs", "A bug I haven't filed yet", 3, "BUG"},
+		{"docs", "A doc I haven't written yet", 4, "DOC"},
+	}
+
+	for _, w := range want {
+		items, err := s.ListItems(ws.ID, models.ItemListParams{CollectionSlug: w.Slug})
+		if err != nil {
+			t.Fatalf("list %s: %v", w.Slug, err)
+		}
+		var found *models.Item
+		for i := range items {
+			if items[i].Title == w.Title {
+				found = &items[i]
+				break
+			}
+		}
+		if found == nil {
+			t.Errorf("expected scrum seed %q in %q, not found", w.Title, w.Slug)
+			continue
+		}
+		if found.ItemNumber == nil || *found.ItemNumber != w.WantItemNum {
+			t.Errorf("scrum seed %q in %q: ItemNumber = %v, want %d (seeding order regressed)", w.Title, w.Slug, found.ItemNumber, w.WantItemNum)
+		}
+		if found.CollectionPrefix != w.WantPrefix {
+			t.Errorf("scrum seed %q in %q: CollectionPrefix = %q, want %q (templates.go's explicit Prefix may have drifted; see PLAN-1146 prefix precondition)", w.Title, w.Slug, found.CollectionPrefix, w.WantPrefix)
+		}
+		if found.Content == "" {
+			t.Errorf("scrum seed %q in %q: empty Content", w.Title, w.Slug)
+		}
+	}
+}
+
+// TestSeedCollectionsFromTemplateProductRefSequence is the
+// product-template sibling. Locks FEAT-1 / FB-2 / ROAD-3 / DOC-4.
+func TestSeedCollectionsFromTemplateProductRefSequence(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Product Refs")
+
+	if err := s.SeedCollectionsFromTemplate(ws.ID, "product"); err != nil {
+		t.Fatalf("seed product template: %v", err)
+	}
+
+	type expected struct {
+		Slug, Title string
+		WantItemNum int
+		WantPrefix  string
+	}
+	want := []expected{
+		{"features", "Welcome — let's start shaping what we're going to ship", 1, "FEAT"},
+		{"feedback", "A piece of feedback I haven't captured yet", 2, "FB"},
+		{"roadmap-items", "A roadmap commitment I haven't placed yet", 3, "ROAD"},
+		{"docs", "A doc I haven't written yet", 4, "DOC"},
+	}
+
+	for _, w := range want {
+		items, err := s.ListItems(ws.ID, models.ItemListParams{CollectionSlug: w.Slug})
+		if err != nil {
+			t.Fatalf("list %s: %v", w.Slug, err)
+		}
+		var found *models.Item
+		for i := range items {
+			if items[i].Title == w.Title {
+				found = &items[i]
+				break
+			}
+		}
+		if found == nil {
+			t.Errorf("expected product seed %q in %q, not found", w.Title, w.Slug)
+			continue
+		}
+		if found.ItemNumber == nil || *found.ItemNumber != w.WantItemNum {
+			t.Errorf("product seed %q in %q: ItemNumber = %v, want %d (seeding order regressed)", w.Title, w.Slug, found.ItemNumber, w.WantItemNum)
+		}
+		if found.CollectionPrefix != w.WantPrefix {
+			t.Errorf("product seed %q in %q: CollectionPrefix = %q, want %q (templates.go's explicit Prefix may have drifted; see PLAN-1146 prefix precondition)", w.Title, w.Slug, found.CollectionPrefix, w.WantPrefix)
+		}
+		if found.Content == "" {
+			t.Errorf("product seed %q in %q: empty Content", w.Title, w.Slug)
+		}
+	}
+}
+
 // TestSeedCollectionsFromTemplateIdempotentWithSeedItems verifies that re-running
 // the seed function across a pre-existing workspace does NOT duplicate seed items.
 // This invariant is what lets the server's startup auto-upgrade safely iterate


### PR DESCRIPTION
## Summary

Extends PLAN-1131's onboarding mechanism to the remaining software-category templates. After this lands:

- fresh `pad workspace init --template scrum`   → **BACK-1 / SPRINT-2 / BUG-3 / DOC-4**
- fresh `pad workspace init --template product` → **FEAT-1 / FB-2 / ROAD-3 / DOC-4**

Each is a first-person note from the workspace owner's future self — agent-invocable via `/pad let's discuss <REF>`, with schema-aware terminal verbs ("mark me done" / "completed" / "shipped" / "archived"), no "tutorial" / "lesson" language. Bodies pulled verbatim from DOC-1152 (scrum) and DOC-1153 (product) — the design DOCs from the parallel Planner pass.

## Precondition fix: explicit Prefix on 5 collections

The current `DerivePrefix` logic yields awkward refs for several collection names; this PR sets `Prefix:` explicitly to mirror the hiring template's pattern:

| Collection | Was (derived) | Now (explicit) |
|---|---|---|
| Backlog | `BACKL` | **`BACK`** |
| Sprints | `SPRIN` | **`SPRINT`** |
| Features | `FEATU` | **`FEAT`** |
| Feedback | `FEEDB` | **`FB`** |
| Roadmap Items | `RI` | **`ROAD`** |

Without this, the design-doc bodies' "use pad to get BACK-1" copy would silently disagree with what the seeder actually produces (`BACKL-1`, etc.). Forward-only fix — existing scrum/product workspaces (if any) keep their derived prefixes; the seeder doesn't migrate.

## Tests

`internal/collections/templates_test.go` (new):
- `TestScrumOnboardingItemsOrderAndShape` — locks order + slugs + status fields
- `TestProductOnboardingItemsOrderAndShape` — same for product
- `TestScrumProductTemplatesShipOnboardingSeedItems` — templates wire up correctly
- `TestScrumProductTemplatesUseExplicitFriendlyPrefixes` — locks the prefix precondition (drift here means seeded refs no longer match the bodies)

`internal/store/items_test.go` (new):
- `TestSeedCollectionsFromTemplateScrumRefSequence` — full integration: seeded refs land at item_numbers 1-4 with the right prefix
- `TestSeedCollectionsFromTemplateProductRefSequence` — same for product

Existing `TestSeedCollectionsFromTemplateStartupRefSequence` still passes — startup template untouched.

## Context

Implements TASK-1149 under PLAN-1146. Bodies finalized in DOC-1152 + DOC-1153.

## Test plan

- [x] `go test ./internal/collections/ ./internal/store/` clean (4 new tests pass)
- [x] `make check` clean (lint + tests + web build)
- [x] No `tutorial / lesson / walkthrough / step / step-by-step / first / next` in any of the 8 new bodies
- [x] Existing startup onboarding flow (PLAN-1131) still works — no template-shape changes there