### PR TITLE
feat(onboarding): make banner + CLI hint template-aware (TASK-1150)

### DIFF
--- a/cmd/pad/init.go
+++ b/cmd/pad/init.go
@@ -212,7 +212,7 @@ Examples:
 				fmt.Fprintf(os.Stderr, "Note: --workspace %q overrides positional name %q.\n", workspaceFlag, args[0])
 			}
 
-			ws, newlyCreated, err := ensureWorkspace(client, cfg, cwd, wsName, workspaceFlag, templateFlag)
+			ws, newlyCreated, createdTemplate, err := ensureWorkspace(client, cfg, cwd, wsName, workspaceFlag, templateFlag)
 			if err != nil {
 				return err
 			}
@@ -230,7 +230,7 @@ Examples:
 			if !actioned {
 				printInitStatus(client, cfg, ws, skillResults)
 			} else if newlyCreated {
-				printOnboardingHints(cfg)
+				printOnboardingHints(cfg, createdTemplate)
 			}
 
 			return nil
@@ -245,14 +245,16 @@ Examples:
 
 // ensureWorkspace checks if the current directory is linked to a workspace.
 // If not, it creates or links one. Returns the workspace, whether it was newly
-// created, and any error.
+// created, the resolved template name (empty when no workspace was created
+// in this call — link paths reuse an existing workspace's settings), and
+// any error.
 //
 // When wsSlug is non-empty, the caller has explicitly identified a workspace
 // by slug (typically `pad init --workspace <slug>`). In that mode we will
 // ONLY attach to a workspace with that exact slug — never silently fall
 // through to "create a new workspace named after the slug." This is the
 // keystone behavior for the web-first onboarding flow (IDEA-750/PLAN-859).
-func ensureWorkspace(client *cli.Client, cfg *config.Config, cwd, name, wsSlug, templateFlag string) (*models.Workspace, bool, error) {
+func ensureWorkspace(client *cli.Client, cfg *config.Config, cwd, name, wsSlug, templateFlag string) (*models.Workspace, bool, string, error) {
 	green := color.New(color.FgGreen)
 	bold := color.New(color.Bold)
 	dim := color.New(color.Faint)
@@ -266,7 +268,7 @@ func ensureWorkspace(client *cli.Client, cfg *config.Config, cwd, name, wsSlug, 
 	// workspace.
 	if wsSlug != "" {
 		if existingSlug != "" && existingSlug != wsSlug {
-			return nil, false, fmt.Errorf(
+			return nil, false, "", fmt.Errorf(
 				"this directory is already linked to workspace %q; refusing to relink to %q.\n"+
 					"Remove or edit the existing .pad.toml, or run from a different directory",
 				existingSlug, wsSlug)
@@ -276,35 +278,35 @@ func ensureWorkspace(client *cli.Client, cfg *config.Config, cwd, name, wsSlug, 
 		if err != nil {
 			var apiErr *cli.APIError
 			if errors.As(err, &apiErr) && apiErr.Code == "not_found" {
-				return nil, false, fmt.Errorf(
+				return nil, false, "", fmt.Errorf(
 					"workspace %q not found on %s.\n"+
 						"Check the slug, or run 'pad workspace list' to see available workspaces",
 					wsSlug, cfg.BaseURL())
 			}
-			return nil, false, fmt.Errorf(
+			return nil, false, "", fmt.Errorf(
 				"look up workspace %q on %s: %w", wsSlug, cfg.BaseURL(), err)
 		}
 
 		// Already linked to this exact slug — idempotent, no-op.
 		if existingSlug == wsSlug {
-			return ws, false, nil
+			return ws, false, "", nil
 		}
 
 		if err := cli.WriteWorkspaceLink(cwd, ws.Slug); err != nil {
-			return nil, false, fmt.Errorf("write .pad.toml: %w", err)
+			return nil, false, "", fmt.Errorf("write .pad.toml: %w", err)
 		}
 		green.Print("✓ ")
 		fmt.Printf("Linked to existing workspace %s %s\n",
 			bold.Sprint(ws.Name),
 			dim.Sprintf("(slug: %s)", ws.Slug))
-		return ws, false, nil
+		return ws, false, "", nil
 	}
 
 	// ── Name-driven path (legacy interactive behavior) ────────
 	if existingSlug != "" {
 		ws, err := client.GetWorkspace(existingSlug)
 		if err == nil && ws != nil {
-			return ws, false, nil
+			return ws, false, "", nil
 		}
 		// Linked but workspace doesn't exist on server — fall through to create/link.
 	}
@@ -323,13 +325,13 @@ func ensureWorkspace(client *cli.Client, cfg *config.Config, cwd, name, wsSlug, 
 
 	if ws != nil {
 		if err := cli.WriteWorkspaceLink(cwd, ws.Slug); err != nil {
-			return nil, false, fmt.Errorf("write .pad.toml: %w", err)
+			return nil, false, "", fmt.Errorf("write .pad.toml: %w", err)
 		}
 		green.Print("✓ ")
 		fmt.Printf("Linked to existing workspace %s %s\n",
 			bold.Sprint(ws.Name),
 			dim.Sprintf("(slug: %s)", ws.Slug))
-		return ws, false, nil
+		return ws, false, "", nil
 	}
 
 	// Create new workspace. When the caller didn't pass --template:
@@ -344,7 +346,7 @@ func ensureWorkspace(client *cli.Client, cfg *config.Config, cwd, name, wsSlug, 
 		if canPromptForTemplate() {
 			picked, perr := pickTemplateInteractive(os.Stdin, os.Stdout)
 			if perr != nil {
-				return nil, false, perr
+				return nil, false, "", perr
 			}
 			effectiveTemplate = picked
 		} else {
@@ -356,11 +358,11 @@ func ensureWorkspace(client *cli.Client, cfg *config.Config, cwd, name, wsSlug, 
 		Template: effectiveTemplate,
 	})
 	if err != nil {
-		return nil, false, fmt.Errorf("create workspace: %w", err)
+		return nil, false, "", fmt.Errorf("create workspace: %w", err)
 	}
 
 	if err := cli.WriteWorkspaceLink(cwd, ws.Slug); err != nil {
-		return nil, false, fmt.Errorf("write .pad.toml: %w", err)
+		return nil, false, "", fmt.Errorf("write .pad.toml: %w", err)
 	}
 
 	tmplMsg := ""
@@ -374,7 +376,7 @@ func ensureWorkspace(client *cli.Client, cfg *config.Config, cwd, name, wsSlug, 
 		tmplMsg)
 	fmt.Printf("  Linked to %s\n", bold.Sprint(cwd))
 
-	return ws, true, nil
+	return ws, true, effectiveTemplate, nil
 }
 
 // skillResult tracks what ensureSkills did.

--- a/cmd/pad/init_test.go
+++ b/cmd/pad/init_test.go
@@ -65,7 +65,7 @@ func TestEnsureWorkspaceSlugAttachExisting(t *testing.T) {
 	client := cli.NewClientFromURL(server.URL)
 	cfg := remoteCfg(server.URL)
 
-	ws, created, err := ensureWorkspace(client, cfg, project, "ignored-name", "my-cool-project", "")
+	ws, created, _, err := ensureWorkspace(client, cfg, project, "ignored-name", "my-cool-project", "")
 	if err != nil {
 		t.Fatalf("ensureWorkspace: %v", err)
 	}
@@ -112,7 +112,7 @@ func TestEnsureWorkspaceSlugNotFound(t *testing.T) {
 	client := cli.NewClientFromURL(server.URL)
 	cfg := remoteCfg(server.URL)
 
-	_, _, err := ensureWorkspace(client, cfg, project, "ignored-name", "missing-slug", "")
+	_, _, _, err := ensureWorkspace(client, cfg, project, "ignored-name", "missing-slug", "")
 	if err == nil {
 		t.Fatal("expected error when workspace slug is missing")
 	}
@@ -148,7 +148,7 @@ func TestEnsureWorkspaceSlugRefusesClobber(t *testing.T) {
 	client := cli.NewClientFromURL(server.URL)
 	cfg := remoteCfg(server.URL)
 
-	_, _, err := ensureWorkspace(client, cfg, project, "ignored", "my-cool-project", "")
+	_, _, _, err := ensureWorkspace(client, cfg, project, "ignored", "my-cool-project", "")
 	if err == nil {
 		t.Fatal("expected error when CWD is already linked to a different workspace")
 	}
@@ -195,7 +195,7 @@ func TestEnsureWorkspaceSlugIdempotent(t *testing.T) {
 	client := cli.NewClientFromURL(server.URL)
 	cfg := remoteCfg(server.URL)
 
-	ws, created, err := ensureWorkspace(client, cfg, project, "x", "my-cool-project", "")
+	ws, created, _, err := ensureWorkspace(client, cfg, project, "x", "my-cool-project", "")
 	if err != nil {
 		t.Fatalf("ensureWorkspace: %v", err)
 	}
@@ -229,7 +229,7 @@ func TestEnsureWorkspaceNameDrivenStillWorks(t *testing.T) {
 	client := cli.NewClientFromURL(server.URL)
 	cfg := remoteCfg(server.URL)
 
-	ws, created, err := ensureWorkspace(client, cfg, project, "Legacy Name", "", "")
+	ws, created, _, err := ensureWorkspace(client, cfg, project, "Legacy Name", "", "")
 	if err != nil {
 		t.Fatalf("ensureWorkspace: %v", err)
 	}

--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -1608,7 +1608,7 @@ a workspace in one step.`,
 				fmt.Fprintf(os.Stderr, "Note: --workspace %q overrides positional name %q.\n", workspaceFlag, args[0])
 			}
 
-			ws, newlyCreated, err := ensureWorkspace(client, cfg, cwd, name, workspaceFlag, templateFlag)
+			ws, newlyCreated, createdTemplate, err := ensureWorkspace(client, cfg, cwd, name, workspaceFlag, templateFlag)
 			if err != nil {
 				return err
 			}
@@ -1620,7 +1620,7 @@ a workspace in one step.`,
 			offerSkillInstall()
 
 			if newlyCreated {
-				printOnboardingHints(cfg)
+				printOnboardingHints(cfg, createdTemplate)
 			}
 			return nil
 		},
@@ -1798,25 +1798,45 @@ func readChoice() string {
 	return strings.TrimSpace(input)
 }
 
-func printOnboardingHints(cfg *config.Config) {
+func printOnboardingHints(cfg *config.Config, templateName string) {
 	bold := color.New(color.Bold)
 	dim := color.New(color.Faint)
 	cyan := color.New(color.FgCyan)
 
 	fmt.Println()
 	bold.Println("Get started:")
-	// IDEA-1 is the seeded onboarding entry point in software-category
-	// workspaces (`startup` template); naming it specifically here avoids
-	// a generic "your first item" copy that would force the user to
-	// figure out the ref themselves. Other templates seed different
-	// primary-entry refs (REQ-1 / APP-1 / …); making this template-aware
-	// is tracked under PLAN-1140.
-	fmt.Printf("  %s  %s\n", cyan.Sprint("/pad"), "use pad to get IDEA-1")
+	// Surface the seeded onboarding entry-point ref per template
+	// (IDEA-1 / BACK-1 / FEAT-1 / …). Templates that don't ship the
+	// IDEA-1-style first-person onboarding pattern (hiring,
+	// interviewing, demo, custom user templates) skip this line —
+	// they fall through to the generic /pad prompts instead.
+	if ref := onboardingPrimaryRef(templateName); ref != "" {
+		fmt.Printf("  %s  use pad to get %s\n", cyan.Sprint("/pad"), ref)
+	}
 	fmt.Printf("  %s  %s\n", cyan.Sprint("/pad"), "scan this codebase and set up my workspace")
 	fmt.Printf("  %s  %s\n", cyan.Sprint("/pad"), "create a plan for what I'm working on")
 	fmt.Println()
 	fmt.Printf("Or open the web UI at %s\n", bold.Sprint(cfg.BrowserURL()))
 	fmt.Println(dim.Sprint("Run 'pad project dashboard' to see your project dashboard"))
+}
+
+// onboardingPrimaryRef returns the seeded onboarding entry-point ref
+// for a template (e.g. "IDEA-1" for startup, "BACK-1" for scrum).
+// Returns "" for templates without the IDEA-1-style onboarding flow,
+// for empty/unknown templates, or for custom user templates.
+//
+// Wraps the collections-package lookup; centralized here so the CLI
+// has a single call site (printOnboardingHints) rather than reaching
+// into the templates registry directly.
+func onboardingPrimaryRef(templateName string) string {
+	if templateName == "" {
+		return ""
+	}
+	tmpl := collections.GetTemplate(templateName)
+	if tmpl == nil {
+		return ""
+	}
+	return tmpl.OnboardingPrimaryRef
 }
 
 // --- onboard ---

--- a/internal/collections/templates.go
+++ b/internal/collections/templates.go
@@ -99,6 +99,19 @@ type WorkspaceTemplate struct {
 	Conventions []SeedConvention // Domain-specific conventions seeded with the workspace
 	Playbooks   []SeedPlaybook   // Domain-specific playbooks seeded with the workspace
 	SeedItems   []SeedItem       // Optional sample items to create after collections
+
+	// OnboardingPrimaryRef names the seeded item the post-signup hint
+	// should surface as the agent-onboarding entry point (e.g. "IDEA-1"
+	// for startup, "BACK-1" for scrum, "FEAT-1" for product).
+	//
+	// Empty for templates that don't ship the IDEA-1-style first-person
+	// onboarding pattern — hiring / interviewing have example items +
+	// manual-trigger playbooks instead, demo has its own seeded shape.
+	// The CLI's printOnboardingHints and the web dashboard banner skip
+	// the hint entirely when this is empty.
+	//
+	// PLAN-1131 / PLAN-1146 / DOC-1139 / DOC-1152 / DOC-1153.
+	OnboardingPrimaryRef string
 }
 
 // SeedItem defines a sample item to seed into a workspace.
@@ -374,9 +387,10 @@ var templates = []WorkspaceTemplate{
 		// (see store.SeedCollectionsFromTemplate), so the workspace-scoped
 		// item_number sequence produces IDEA-1, PLAN-2, TASK-3, DOC-4.
 		// The post-signup hint names IDEA-1 specifically.
-		SeedItems:   StartupOnboardingItems(),
-		Conventions: SoftwareStarterConventions(),
-		Playbooks:   SoftwareStarterPlaybooks(),
+		SeedItems:            StartupOnboardingItems(),
+		OnboardingPrimaryRef: "IDEA-1",
+		Conventions:          SoftwareStarterConventions(),
+		Playbooks:            SoftwareStarterPlaybooks(),
 	},
 	{
 		Name:        "scrum",
@@ -514,12 +528,12 @@ var templates = []WorkspaceTemplate{
 		},
 		// SeedItems run before Conventions/Playbooks in the bootstrap loop
 		// so refs land at BACK-1 / SPRINT-2 / BUG-3 / DOC-4. The CLI hint
-		// and dashboard banner are still hardcoded to IDEA-1 from PR #403;
-		// TASK-1150 makes them template-aware so a fresh scrum workspace
-		// promotes BACK-1. (PLAN-1146 / DOC-1152.)
-		SeedItems:   ScrumOnboardingItems(),
-		Conventions: SoftwareStarterConventions(),
-		Playbooks:   SoftwareStarterPlaybooks(),
+		// and dashboard banner read OnboardingPrimaryRef to surface BACK-1
+		// per workspace template. (PLAN-1146 / DOC-1152.)
+		SeedItems:            ScrumOnboardingItems(),
+		OnboardingPrimaryRef: "BACK-1",
+		Conventions:          SoftwareStarterConventions(),
+		Playbooks:            SoftwareStarterPlaybooks(),
 	},
 	{
 		Name:        "product",
@@ -653,12 +667,12 @@ var templates = []WorkspaceTemplate{
 		},
 		// SeedItems run before Conventions/Playbooks in the bootstrap loop
 		// so refs land at FEAT-1 / FB-2 / ROAD-3 / DOC-4. The CLI hint and
-		// dashboard banner are still hardcoded to IDEA-1 from PR #403;
-		// TASK-1150 makes them template-aware so a fresh product workspace
-		// promotes FEAT-1. (PLAN-1146 / DOC-1153.)
-		SeedItems:   ProductOnboardingItems(),
-		Conventions: SoftwareStarterConventions(),
-		Playbooks:   SoftwareStarterPlaybooks(),
+		// dashboard banner read OnboardingPrimaryRef to surface FEAT-1 per
+		// workspace template. (PLAN-1146 / DOC-1153.)
+		SeedItems:            ProductOnboardingItems(),
+		OnboardingPrimaryRef: "FEAT-1",
+		Conventions:          SoftwareStarterConventions(),
+		Playbooks:            SoftwareStarterPlaybooks(),
 	},
 	hiringTemplate(),
 	interviewingTemplate(),

--- a/internal/collections/templates_test.go
+++ b/internal/collections/templates_test.go
@@ -349,6 +349,43 @@ func TestScrumProductTemplatesShipOnboardingSeedItems(t *testing.T) {
 	}
 }
 
+// TestTemplatesDeclareOnboardingPrimaryRef verifies the templates that
+// ship the IDEA-1-style onboarding flow have OnboardingPrimaryRef set
+// (so the CLI hint and dashboard banner can read it). Drift here means
+// a template advertises onboarding seeds via SeedItems but doesn't
+// declare which one is "primary" — the CLI hint + dashboard wouldn't
+// know which ref to surface.
+//
+// Templates that intentionally don't ship the IDEA-1-style pattern
+// (hiring, interviewing — see PLAN-1140 paused; demo) MUST leave
+// OnboardingPrimaryRef empty so the CLI hint stays silent for them.
+func TestTemplatesDeclareOnboardingPrimaryRef(t *testing.T) {
+	cases := []struct {
+		Template string
+		WantRef  string // "" means "must be empty"
+	}{
+		{"startup", "IDEA-1"},
+		{"scrum", "BACK-1"},
+		{"product", "FEAT-1"},
+		// Hiring + interviewing intentionally don't declare a primary
+		// (PLAN-1140 paused — agent-onboarding pattern doesn't fit).
+		{"hiring", ""},
+		{"interviewing", ""},
+		// Demo is hidden + has its own seeded shape.
+		{"demo", ""},
+	}
+	for _, c := range cases {
+		tmpl := GetTemplate(c.Template)
+		if tmpl == nil {
+			t.Errorf("%s template missing", c.Template)
+			continue
+		}
+		if tmpl.OnboardingPrimaryRef != c.WantRef {
+			t.Errorf("%s.OnboardingPrimaryRef = %q, want %q", c.Template, tmpl.OnboardingPrimaryRef, c.WantRef)
+		}
+	}
+}
+
 // TestScrumProductTemplatesUseExplicitFriendlyPrefixes guards the
 // prefix-fix precondition from PLAN-1146: scrum and product collection
 // definitions set explicit Prefix values rather than relying on

--- a/internal/server/handlers_dashboard.go
+++ b/internal/server/handlers_dashboard.go
@@ -31,6 +31,61 @@ type DashboardResponse struct {
 	// workspace's agent loop is wired up and the banner stops nagging
 	// the user on this workspace.
 	HasAgentActivity bool `json:"has_agent_activity"`
+	// OnboardingSeed identifies the seeded onboarding entry point for
+	// the workspace (e.g. IDEA-1 for `startup`, BACK-1 for `scrum`,
+	// FEAT-1 for `product`) when present and untouched. The web UI's
+	// dashboard banner reads this to surface the right "use pad to get
+	// <REF>" trigger phrase per template, then hides itself once the
+	// user (or agent) updates the seed out of its initial status.
+	// Nil for workspaces that didn't seed an onboarding primary
+	// (empty template, hiring/interviewing example items, etc.).
+	OnboardingSeed *DashboardOnboardingSeed `json:"onboarding_seed,omitempty"`
+}
+
+// DashboardOnboardingSeed is the dashboard-side projection of a
+// seeded onboarding entry. The web banner uses Ref + Slug (link) and
+// gates rendering on Active.
+type DashboardOnboardingSeed struct {
+	Ref            string `json:"ref"`
+	Title          string `json:"title"`
+	Slug           string `json:"slug"`
+	CollectionSlug string `json:"collection_slug"`
+	Status         string `json:"status"`
+	// Active is true while the seed is still in its initial (untouched)
+	// status — the moment the agent or user flips it to anything else,
+	// the banner should disappear. Computed server-side so the frontend
+	// doesn't need a per-collection "what's the initial status" map.
+	Active bool `json:"active"`
+}
+
+// onboardingPrimaryCollectionSlugs is the set of collection slugs that
+// can host a seeded onboarding primary. Only items from these
+// collections are eligible to be surfaced as the dashboard's onboarding
+// seed. Mirrors the templates that ship `OnboardingPrimaryRef` —
+// hiring/interviewing example items live in different collections and
+// are intentionally excluded.
+//
+// When a new template adds an IDEA-1-style onboarding flow, append its
+// primary-entry collection slug here. The collection package's
+// `OnboardingPrimaryRef` field on `WorkspaceTemplate` is the canonical
+// source — cross-reference when adding.
+var onboardingPrimaryCollectionSlugs = map[string]bool{
+	"ideas":    true, // startup → IDEA-1
+	"backlog":  true, // scrum → BACK-1
+	"features": true, // product → FEAT-1
+}
+
+// onboardingInitialStatus returns the schema-default initial status for
+// each primary-entry collection. The dashboard treats a seed as
+// "active" (banner-eligible) only while its status equals this value.
+// Mirrors the schemas defined in `internal/collections/`:
+//   - Ideas:    Default "new"     (collection.go Defaults)
+//   - Backlog:  Default "new"     (templates.go scrum)
+//   - Features: Default "proposed" (templates.go product)
+var onboardingInitialStatus = map[string]string{
+	"ideas":    "new",
+	"backlog":  "new",
+	"features": "proposed",
 }
 
 type DashboardActiveItem struct {
@@ -321,6 +376,30 @@ func (s *Server) handleGetDashboard(w http.ResponseWriter, r *http.Request) {
 			status = "unknown"
 		}
 		resp.Summary.ByCollection[collSlug][status]++
+
+		// Identify the seeded onboarding primary entry. Match shape:
+		// item_number=1 + system-template provenance + lives in a
+		// known onboarding-primary collection. The first match wins —
+		// item_number is workspace-scoped + monotonic so there's only
+		// one item with item_number=1 per workspace anyway.
+		if resp.OnboardingSeed == nil &&
+			item.ItemNumber != nil && *item.ItemNumber == 1 &&
+			item.Source == "template" && item.CreatedBy == "system" &&
+			onboardingPrimaryCollectionSlugs[collSlug] {
+			itemStatus := extractFieldValue(item.Fields, "status")
+			ref := ""
+			if item.CollectionPrefix != "" {
+				ref = item.CollectionPrefix + "-" + strconv.Itoa(*item.ItemNumber)
+			}
+			resp.OnboardingSeed = &DashboardOnboardingSeed{
+				Ref:            ref,
+				Title:          item.Title,
+				Slug:           item.Slug,
+				CollectionSlug: collSlug,
+				Status:         itemStatus,
+				Active:         onboardingInitialStatus[collSlug] == itemStatus,
+			}
+		}
 	}
 
 	// Active items: items currently being worked on (not initial state, not terminal state)

--- a/internal/server/handlers_dashboard_test.go
+++ b/internal/server/handlers_dashboard_test.go
@@ -90,6 +90,143 @@ func TestDashboardEmpty(t *testing.T) {
 	}
 }
 
+// TestDashboardOnboardingSeed_StartupTemplate verifies the dashboard
+// surfaces the seeded onboarding primary entry for `startup` workspaces.
+// The web banner reads OnboardingSeed.Active to decide whether to show
+// itself; locking the field's shape down here is what keeps the banner
+// reliable across templates.
+func TestDashboardOnboardingSeed_StartupTemplate(t *testing.T) {
+	srv := testServer(t)
+
+	// Create a workspace with an explicit template so the seeder lands
+	// the four onboarding items (PLAN-1131).
+	rr := doRequest(srv, "POST", "/api/v1/workspaces", map[string]string{
+		"name":     "Onboarding Seed Startup",
+		"template": "startup",
+	})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create workspace: %d %s", rr.Code, rr.Body.String())
+	}
+	var ws models.Workspace
+	parseJSON(t, rr, &ws)
+
+	resp := getDashboard(t, srv, ws.Slug)
+
+	if resp.OnboardingSeed == nil {
+		t.Fatal("expected OnboardingSeed to be populated for startup template; got nil — the dashboard banner will never appear")
+	}
+	if resp.OnboardingSeed.Ref != "IDEA-1" {
+		t.Errorf("OnboardingSeed.Ref = %q, want %q", resp.OnboardingSeed.Ref, "IDEA-1")
+	}
+	if resp.OnboardingSeed.CollectionSlug != "ideas" {
+		t.Errorf("OnboardingSeed.CollectionSlug = %q, want %q", resp.OnboardingSeed.CollectionSlug, "ideas")
+	}
+	if resp.OnboardingSeed.Status != "new" {
+		t.Errorf("OnboardingSeed.Status = %q, want %q (initial status from schema)", resp.OnboardingSeed.Status, "new")
+	}
+	if !resp.OnboardingSeed.Active {
+		t.Error("OnboardingSeed.Active = false, want true (seed is in initial status, banner should show)")
+	}
+	if resp.OnboardingSeed.Title == "" {
+		t.Error("OnboardingSeed.Title is empty — the banner needs a title to render")
+	}
+	if resp.OnboardingSeed.Slug == "" {
+		t.Error("OnboardingSeed.Slug is empty — the 'Read it first' deep link will break")
+	}
+}
+
+// TestDashboardOnboardingSeed_ScrumTemplate is the scrum sibling.
+// Locks BACK-1 + Active=true.
+func TestDashboardOnboardingSeed_ScrumTemplate(t *testing.T) {
+	srv := testServer(t)
+	rr := doRequest(srv, "POST", "/api/v1/workspaces", map[string]string{
+		"name":     "Onboarding Seed Scrum",
+		"template": "scrum",
+	})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create workspace: %d %s", rr.Code, rr.Body.String())
+	}
+	var ws models.Workspace
+	parseJSON(t, rr, &ws)
+
+	resp := getDashboard(t, srv, ws.Slug)
+	if resp.OnboardingSeed == nil {
+		t.Fatal("scrum: expected OnboardingSeed populated, got nil")
+	}
+	if resp.OnboardingSeed.Ref != "BACK-1" {
+		t.Errorf("scrum OnboardingSeed.Ref = %q, want %q (PLAN-1146 prefix precondition: explicit BACK prefix on Backlog collection)", resp.OnboardingSeed.Ref, "BACK-1")
+	}
+	if resp.OnboardingSeed.CollectionSlug != "backlog" {
+		t.Errorf("scrum OnboardingSeed.CollectionSlug = %q, want %q", resp.OnboardingSeed.CollectionSlug, "backlog")
+	}
+	if !resp.OnboardingSeed.Active {
+		t.Error("scrum OnboardingSeed.Active = false, want true")
+	}
+}
+
+// TestDashboardOnboardingSeed_ProductTemplate is the product sibling.
+func TestDashboardOnboardingSeed_ProductTemplate(t *testing.T) {
+	srv := testServer(t)
+	rr := doRequest(srv, "POST", "/api/v1/workspaces", map[string]string{
+		"name":     "Onboarding Seed Product",
+		"template": "product",
+	})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create workspace: %d %s", rr.Code, rr.Body.String())
+	}
+	var ws models.Workspace
+	parseJSON(t, rr, &ws)
+
+	resp := getDashboard(t, srv, ws.Slug)
+	if resp.OnboardingSeed == nil {
+		t.Fatal("product: expected OnboardingSeed populated, got nil")
+	}
+	if resp.OnboardingSeed.Ref != "FEAT-1" {
+		t.Errorf("product OnboardingSeed.Ref = %q, want %q", resp.OnboardingSeed.Ref, "FEAT-1")
+	}
+	if resp.OnboardingSeed.CollectionSlug != "features" {
+		t.Errorf("product OnboardingSeed.CollectionSlug = %q, want %q", resp.OnboardingSeed.CollectionSlug, "features")
+	}
+	if !resp.OnboardingSeed.Active {
+		t.Error("product OnboardingSeed.Active = false, want true")
+	}
+}
+
+// TestDashboardOnboardingSeed_HiringTemplate verifies the dashboard
+// does NOT mark hiring's example items as the onboarding seed —
+// hiring's REQ-1 is a placeholder example, not an IDEA-1-style
+// agent-onboarding script (see PLAN-1140 paused). Banner should
+// stay hidden for these workspaces.
+func TestDashboardOnboardingSeed_HiringTemplate(t *testing.T) {
+	srv := testServer(t)
+	rr := doRequest(srv, "POST", "/api/v1/workspaces", map[string]string{
+		"name":     "Onboarding Seed Hiring",
+		"template": "hiring",
+	})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create workspace: %d %s", rr.Code, rr.Body.String())
+	}
+	var ws models.Workspace
+	parseJSON(t, rr, &ws)
+
+	resp := getDashboard(t, srv, ws.Slug)
+	if resp.OnboardingSeed != nil {
+		t.Errorf("hiring: expected OnboardingSeed=nil (REQ-1 is example data, not an onboarding entry); got %+v", resp.OnboardingSeed)
+	}
+}
+
+// TestDashboardOnboardingSeed_EmptyWorkspace verifies that a workspace
+// without a template (no SeedItems) reports no onboarding seed.
+func TestDashboardOnboardingSeed_EmptyWorkspace(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv) // empty template path
+
+	resp := getDashboard(t, srv, slug)
+	if resp.OnboardingSeed != nil {
+		t.Errorf("empty-template workspace: expected OnboardingSeed=nil, got %+v", resp.OnboardingSeed)
+	}
+}
+
 func TestDashboardSummary(t *testing.T) {
 	srv := testServer(t)
 	slug := createWSWithCollections(t, srv)

--- a/web/src/lib/components/OnboardingIdeaBanner.svelte
+++ b/web/src/lib/components/OnboardingIdeaBanner.svelte
@@ -2,24 +2,30 @@
 	import { copyToClipboard } from '$lib/utils/clipboard';
 
 	interface Props {
-		/** Workspace slug — used to link "View IDEA-1" into the right URL. */
+		/** Workspace slug — used to link the seeded item into the right URL. */
 		wsSlug: string;
-		/** Workspace owner username — used to build the IDEA-1 deep link. */
+		/** Workspace owner username — used to build the deep link. */
 		username: string;
-		/** Slug of the seeded IDEA-1 (the workspace bootstrap creates it
-		 *  with this slug). Defaults to the canonical seed slug; passing
-		 *  it explicitly keeps the component decoupled from the seeder. */
-		ideaSlug?: string;
+		/** The seeded primary-entry ref (e.g. "IDEA-1", "BACK-1", "FEAT-1").
+		 *  Drives the trigger phrase the user copies. The dashboard handler
+		 *  computes this per workspace based on the seeded item; the
+		 *  component just renders it. */
+		primaryRef: string;
+		/** Slug of the seeded item — used for the "Read it first" link. */
+		ideaSlug: string;
+		/** Collection slug the seeded item lives in (ideas / backlog /
+		 *  features). Used to build the deep-link path. */
+		collectionSlug: string;
 	}
 
-	let { wsSlug, username, ideaSlug = 'welcome-lets-get-this-place-set-up' }: Props = $props();
+	let { wsSlug, username, primaryRef, ideaSlug, collectionSlug }: Props = $props();
 
-	const TRIGGER_PHRASE = 'use pad to get IDEA-1';
+	let triggerPhrase = $derived(`use pad to get ${primaryRef}`);
 
 	let copied = $state(false);
 
 	async function copyTrigger() {
-		const ok = await copyToClipboard(TRIGGER_PHRASE);
+		const ok = await copyToClipboard(triggerPhrase);
 		if (ok) {
 			copied = true;
 			setTimeout(() => {
@@ -32,23 +38,23 @@
 <div class="idea-banner">
 	<div class="idea-banner-icon" aria-hidden="true">💡</div>
 	<div class="idea-banner-body">
-		<h2>Your workspace has an idea waiting.</h2>
+		<h2>Your workspace has a starting point waiting.</h2>
 		<p>
 			Open a fresh agent session — Claude Code, Cursor, Codex, whatever you have —
 			and say:
 		</p>
 		<div class="trigger-row">
-			<code class="trigger-phrase">{TRIGGER_PHRASE}</code>
+			<code class="trigger-phrase">{triggerPhrase}</code>
 			<button class="copy-btn" type="button" onclick={copyTrigger} title="Copy to clipboard">
 				{copied ? 'Copied!' : 'Copy'}
 			</button>
 		</div>
 		<p class="idea-banner-footnote">
-			IDEA-1 is a note from your future self to whoever's helping you set up. The
-			agent will read it and walk through your project with you, capturing what
-			you tell it as plans, tasks, and ideas — using your real work, not toy data.
-			<a href="/{username}/{wsSlug}/ideas/{ideaSlug}">Read it first</a> if you'd
-			like to see what's there.
+			{primaryRef} is a note from your future self to whoever's helping you set up.
+			The agent will read it and walk through your project with you, capturing
+			what you tell it — using your real work, not toy data.
+			<a href="/{username}/{wsSlug}/{collectionSlug}/{ideaSlug}">Read it first</a>
+			if you'd like to see what's there.
 		</p>
 	</div>
 </div>

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -629,6 +629,22 @@ export interface DashboardResponse {
 	// the underlying store query also matches). Drives the connect-agent
 	// banner's auto-hide.
 	has_agent_activity: boolean;
+	// onboarding_seed identifies the seeded onboarding entry for the
+	// workspace (e.g. IDEA-1 for `startup`, BACK-1 for `scrum`,
+	// FEAT-1 for `product`). Present + active drives the
+	// OnboardingIdeaBanner. Absent = no IDEA-1-style onboarding seed
+	// in this workspace (empty template, hiring/interviewing example
+	// items, etc.); banner stays hidden. Computed server-side.
+	onboarding_seed?: {
+		ref: string;
+		title: string;
+		slug: string;
+		collection_slug: string;
+		status: string;
+		// active is true while the seed is still in its initial
+		// (untouched) status — banner shows only when this is true.
+		active: boolean;
+	};
 }
 
 // ─── Incremental Sync ────────────────────────────────────────────────────────

--- a/web/src/routes/[username]/[workspace]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/+page.svelte
@@ -23,12 +23,13 @@
 	let onboardingDismissed = $state(false);
 	let connectOpen = $state(false);
 
-	// Status of the seeded IDEA-1 onboarding entry. Drives the
-	// OnboardingIdeaBanner gate: shown only while the user hasn't yet
-	// engaged with the agent (status === 'new'). null = not yet checked /
-	// no IDEA-1 exists in this workspace (e.g. an empty-template or
-	// non-software-category workspace).
-	let ideaOneStatus = $state<string | null>(null);
+	// The dashboard response carries an `onboarding_seed` field when the
+	// workspace has a seeded onboarding primary (IDEA-1 / BACK-1 / FEAT-1
+	// per template). The OnboardingIdeaBanner shows only when that seed
+	// is still active (status equals its initial value — agent has not
+	// yet engaged). The server computes `active` so the frontend doesn't
+	// need a per-collection "what's the initial status" map.
+	let onboardingSeed = $derived(dashboard?.onboarding_seed);
 
 	// Sync dismissed state from localStorage when workspace changes
 	$effect(() => {
@@ -55,13 +56,7 @@
 	// the dashboard to refetch + re-render — a visible flicker. Wrap in
 	// `untrack` so the only tracked dep is `wsSlug` from the if-check.
 	$effect(() => {
-		if (wsSlug) {
-			// Reset banner state immediately on workspace change so a stale
-			// `new` status from the previous workspace can't briefly render
-			// the IDEA-1 banner before loadIdeaOne resolves for the new one.
-			ideaOneStatus = null;
-			untrack(() => load(wsSlug));
-		}
+		if (wsSlug) untrack(() => load(wsSlug));
 	});
 
 	// Workspace home shows only the workspace-level title — clear section/item.
@@ -103,62 +98,6 @@
 			// allow partial render
 		} finally {
 			loading = false;
-		}
-		// Refresh the seeded IDEA-1 status alongside each dashboard load.
-		// Cheap (single-row lookup, indexed by ref) and self-correcting:
-		// once the user engages the agent and IDEA-1 leaves status=new,
-		// the next poll silently hides the banner.
-		void loadIdeaOne(slug);
-	}
-
-	// loadIdeaOne fetches the seeded IDEA-1 entry's status. A 404 (or any
-	// error) leaves ideaOneStatus null, which keeps the banner hidden —
-	// workspaces that don't ship an onboarding seed should never see the
-	// banner. Errors are intentionally silent: the dashboard is the
-	// primary surface, and a broken sub-fetch should not throw the
-	// dashboard render off.
-	//
-	// IMPORTANT: server-side ResolveItem (in store.GetItemByRef) falls
-	// back from PREFIX-NUMBER to a number-only lookup when the prefix
-	// doesn't match any collection in the workspace. In a non-software
-	// workspace (hiring, interviewing, …), `IDEA-1` would resolve to
-	// whatever item has item_number=1 (REQ-1 / APP-1 / etc.) — and
-	// rendering the banner against that item would link to a missing
-	// /ideas/... page and confuse the user. We pin to the exact ref
-	// before trusting the result.
-	async function loadIdeaOne(slug: string) {
-		try {
-			const item = await api.items.get(slug, 'IDEA-1');
-			// Drop the response if the user navigated to a different
-			// workspace while we were waiting on the network. Otherwise a
-			// slow request from workspace A (where IDEA-1 is `new`) could
-			// land after the user is on workspace B and incorrectly flip
-			// the banner on. Mirrors the standard "was this still the
-			// active request" pattern.
-			if (slug !== wsSlug) return;
-			// Guard against ResolveItem's prefix→number-only fallback: only
-			// accept the result if it is the actual seeded IDEA-1.
-			if (!item || item.collection_prefix !== 'IDEA' || item.item_number !== 1) {
-				ideaOneStatus = null;
-				return;
-			}
-			// item.fields is a JSON string per the API shape (see Item.fields
-			// in lib/types). Empty / malformed payloads collapse to '' so
-			// the banner stays hidden rather than flashing on bad data.
-			let status = '';
-			if (item.fields) {
-				try {
-					const parsed = JSON.parse(item.fields) as Record<string, unknown>;
-					if (typeof parsed.status === 'string') status = parsed.status;
-				} catch {
-					/* leave status empty */
-				}
-			}
-			ideaOneStatus = status;
-		} catch {
-			// Same race-guard applies on the error path: only clear if this
-			// is still the active workspace.
-			if (slug === wsSlug) ideaOneStatus = null;
 		}
 	}
 
@@ -270,15 +209,23 @@
 		</header>
 
 		<!-- 2. Onboarding -->
-		<!-- IDEA-1 banner: shown only while the seeded onboarding entry is
-		     still untouched (status === 'new'). Once the user engages the
-		     agent and the status flips, the banner disappears on the next
-		     dashboard poll. The OnboardingChecklist below remains gated on
-		     totalItems === 0 — its surface is empty/non-templated workspaces;
-		     this banner is the surface for templated (seeded) workspaces. -->
-		{#if ideaOneStatus === 'new' && !onboardingDismissed}
+		<!-- Onboarding seed banner: shown only while the seeded primary entry
+		     is still untouched (server returns active=true when its status
+		     equals the schema initial value). Once the user engages the
+		     agent and the status flips, the next dashboard poll returns
+		     active=false and the banner disappears. The OnboardingChecklist
+		     below remains gated on totalItems === 0 — its surface is empty
+		     / non-templated workspaces; this banner is the surface for
+		     templated (seeded) workspaces. -->
+		{#if onboardingSeed?.active && !onboardingDismissed}
 			<div class="onboarding-wrapper">
-				<OnboardingIdeaBanner {wsSlug} {username} />
+				<OnboardingIdeaBanner
+					{wsSlug}
+					{username}
+					primaryRef={onboardingSeed.ref}
+					ideaSlug={onboardingSeed.slug}
+					collectionSlug={onboardingSeed.collection_slug}
+				/>
 			</div>
 		{/if}
 		{#if totalItems === 0 && !onboardingDismissed}


### PR DESCRIPTION
## Summary

The IDEA-1 trigger phrase is no longer hardcoded. Fresh scrum workspaces surface **\"use pad to get BACK-1\"**, product workspaces surface **\"use pad to get FEAT-1\"**, and any future template that ships an agent-onboarding seed declares its primary ref once and gets the banner / hint for free.

## How it works

1. **`WorkspaceTemplate.OnboardingPrimaryRef`** — new string field, the canonical declaration. Set per template that ships the pattern:

   | Template | OnboardingPrimaryRef |
   |---|---|
   | startup | `IDEA-1` |
   | scrum | `BACK-1` |
   | product | `FEAT-1` |
   | hiring / interviewing / demo | *(empty — pattern doesn't apply)* |

2. **Server (dashboard handler)** identifies the seeded primary by walking items: `item_number=1` + `source=\"template\"` + `created_by=\"system\"` + `collection_slug ∈ {ideas, backlog, features}`. The collection-slug whitelist is what keeps hiring's REQ-1 (also seeded with item_number=1) from being flagged as an onboarding entry — those are example items, not agent scripts.

   Response gains an `onboarding_seed` field with `ref / title / slug / collection_slug / status / active`. Server computes `active=true` iff the status still equals the schema initial value.

3. **CLI** — `printOnboardingHints` accepts the template name + reads `OnboardingPrimaryRef`. Templates without a declared primary skip the line entirely (so hiring's `pad init` success doesn't promise a non-existent ref).

4. **Web frontend** — dashboard reads `dashboard.onboarding_seed`, gates the banner on `active=true`, passes ref/slug/collection to `OnboardingIdeaBanner` as props. No more hardcoded IDEA-1.

## What gets simpler

- Dropped ~50 lines of `loadIdeaOne` complexity from `+page.svelte` (separate fetch, race-guards, collection-prefix verification). The dashboard poll itself now carries `onboarding_seed.active` so the banner state lives entirely in the dashboard response.

## What's tested

- 5 new dashboard tests covering startup / scrum / product / hiring (no-banner) / empty (no-banner).
- 1 new templates test (\`TestTemplatesDeclareOnboardingPrimaryRef\`) locking the per-template values + explicit emptiness for hiring/interviewing/demo.
- Existing tests updated for ensureWorkspace's new return signature.

## Context

Implements TASK-1150 under PLAN-1146. Closes the visibility gap from PR #408 (Codex round 1 finding) — fresh scrum/product workspaces now actually surface their seeded onboarding entry in both UI surfaces.

## Test plan

- [x] \`make check\` clean (lint + tests + web build)
- [x] \`go test -run TestDashboardOnboardingSeed ./internal/server/\` — 5 tests pass
- [x] \`go test -run TestTemplatesDeclareOnboardingPrimaryRef ./internal/collections/\` — passes
- [x] Existing onboarding flow tests (PLAN-1131) still pass
- [x] Existing dashboard tests still pass (\`TestDashboardEmpty\`, \`TestDashboardSummary\`, etc.)