### PR TITLE
fix(console): add mobile hamburger menu + scrollable admin tabs (BUG-1118)

### DIFF
--- a/web/src/routes/console/+layout.svelte
+++ b/web/src/routes/console/+layout.svelte
@@ -7,6 +7,7 @@
 
 	let { children } = $props();
 	let ready = $state(false);
+	let mobileMenuOpen = $state(false);
 
 	onMount(async () => {
 		try {
@@ -24,6 +25,14 @@
 
 	let currentPath = $derived(page.url.pathname as string);
 
+	// Auto-close the mobile menu whenever the route changes. Kept as its own
+	// single-purpose effect per CONVE-606 (split reactive effects) so the
+	// route-change concern doesn't get tangled with anything else.
+	$effect(() => {
+		void currentPath;
+		mobileMenuOpen = false;
+	});
+
 	function isActive(path: string): boolean {
 		if (path === '/console') return currentPath === '/console';
 		return currentPath.startsWith(path);
@@ -35,21 +44,70 @@
 		goto('/login');
 	}
 
+	function closeMobileMenu() {
+		mobileMenuOpen = false;
+	}
+
+	function handleWindowKeydown(event: KeyboardEvent) {
+		if (event.key === 'Escape' && mobileMenuOpen) {
+			mobileMenuOpen = false;
+		}
+	}
+
+	function handleWindowClick(event: MouseEvent) {
+		if (!mobileMenuOpen) return;
+		const target = event.target as HTMLElement | null;
+		if (!target) return;
+		if (!target.closest('.console-nav')) {
+			mobileMenuOpen = false;
+		}
+	}
+
 	let initial = $derived(
 		authStore.user?.name?.charAt(0)?.toUpperCase() ??
 		authStore.user?.email?.charAt(0)?.toUpperCase() ?? '?'
 	);
 </script>
 
+<svelte:window onkeydown={handleWindowKeydown} onclick={handleWindowClick} />
+
 {#if ready}
 	<div class="console-layout">
 		<nav class="console-nav">
 			<div class="nav-left">
 				<a href="/console" class="nav-logo">Pad</a>
-				<div class="nav-links">
+				<button
+					class="mobile-hamburger"
+					onclick={() => (mobileMenuOpen = !mobileMenuOpen)}
+					aria-label={mobileMenuOpen ? 'Close menu' : 'Open menu'}
+					aria-expanded={mobileMenuOpen}
+					aria-controls="console-nav-links"
+					title={mobileMenuOpen ? 'Close menu' : 'Open menu'}
+				>
+					{#if mobileMenuOpen}
+						<svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">
+							<path d="M4 4L16 16" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+							<path d="M16 4L4 16" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+						</svg>
+					{:else}
+						<svg width="20" height="20" viewBox="0 0 20 20" fill="none" aria-hidden="true">
+							<rect y="3" width="20" height="2" rx="1" fill="currentColor"/>
+							<rect y="9" width="20" height="2" rx="1" fill="currentColor"/>
+							<rect y="15" width="20" height="2" rx="1" fill="currentColor"/>
+						</svg>
+					{/if}
+				</button>
+				<div
+					id="console-nav-links"
+					class="nav-links"
+					class:open={mobileMenuOpen}
+					role="menu"
+				>
 					<a
 						href="/console"
 						class="nav-link"
+						role="menuitem"
+						onclick={closeMobileMenu}
 						class:active={isActive('/console') &&
 							!isActive('/console/settings') &&
 							!isActive('/console/billing') &&
@@ -58,23 +116,43 @@
 					>
 						Workspaces
 					</a>
-					<a href="/console/settings" class="nav-link" class:active={isActive('/console/settings')}>
+					<a
+						href="/console/settings"
+						class="nav-link"
+						role="menuitem"
+						onclick={closeMobileMenu}
+						class:active={isActive('/console/settings')}
+					>
 						Settings
 					</a>
 					{#if authStore.cloudMode}
 						<a
 							href="/console/connected-apps"
 							class="nav-link"
+							role="menuitem"
+							onclick={closeMobileMenu}
 							class:active={isActive('/console/connected-apps')}
 						>
 							Connected Apps
 						</a>
-						<a href="/console/billing" class="nav-link" class:active={isActive('/console/billing')}>
+						<a
+							href="/console/billing"
+							class="nav-link"
+							role="menuitem"
+							onclick={closeMobileMenu}
+							class:active={isActive('/console/billing')}
+						>
 							Billing
 						</a>
 					{/if}
 					{#if authStore.user?.role === 'admin'}
-						<a href="/console/admin" class="nav-link" class:active={isActive('/console/admin')}>
+						<a
+							href="/console/admin"
+							class="nav-link"
+							role="menuitem"
+							onclick={closeMobileMenu}
+							class:active={isActive('/console/admin')}
+						>
 							Admin
 						</a>
 					{/if}
@@ -101,6 +179,7 @@
 	}
 
 	.console-nav {
+		position: relative;
 		display: flex;
 		align-items: center;
 		justify-content: space-between;
@@ -126,6 +205,32 @@
 
 	.nav-logo:hover {
 		text-decoration: none;
+	}
+
+	/*
+		Hamburger button — hidden on desktop, shown on mobile. Mirrors
+		TopBar.svelte's `.mobile-hamburger` (32×32, --text-secondary, hover
+		with --bg-hover) so the chrome feels consistent with the main app
+		shell. See BUG-1118.
+	*/
+	.mobile-hamburger {
+		display: none;
+		align-items: center;
+		justify-content: center;
+		width: 32px;
+		height: 32px;
+		border-radius: var(--radius-sm);
+		color: var(--text-secondary);
+		cursor: pointer;
+		padding: 0;
+		background: none;
+		border: none;
+		transition: color 0.15s, background 0.15s;
+	}
+
+	.mobile-hamburger:hover {
+		color: var(--text-primary);
+		background: var(--bg-hover);
 	}
 
 	.nav-links {
@@ -207,13 +312,18 @@
 		padding: var(--space-8) var(--space-6);
 	}
 
+	@keyframes dropdown-in {
+		from { opacity: 0; transform: translateY(-4px); }
+		to { opacity: 1; transform: translateY(0); }
+	}
+
 	@media (max-width: 640px) {
 		.console-nav {
 			padding: 0 var(--space-4);
 		}
 
 		.nav-left {
-			gap: var(--space-4);
+			gap: var(--space-2);
 		}
 
 		.user-name {
@@ -222,6 +332,55 @@
 
 		.console-main {
 			padding: var(--space-6) var(--space-4);
+		}
+
+		.mobile-hamburger {
+			display: flex;
+		}
+
+		/*
+			On mobile the .nav-links row turns into a dropdown panel below
+			the navbar. Hidden by default; .open shows it. Visual style
+			mirrors TopBar.svelte's `.user-dropdown` (BUG-1118).
+		*/
+		.nav-links {
+			display: none;
+			position: absolute;
+			top: calc(100% + 6px);
+			left: 0;
+			right: 0;
+			flex-direction: column;
+			align-items: stretch;
+			gap: 0;
+			background: var(--bg-secondary);
+			border: 1px solid var(--border);
+			border-radius: var(--radius-lg);
+			box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
+			z-index: 50;
+			overflow: hidden;
+			padding: var(--space-1) 0;
+		}
+
+		.nav-links.open {
+			display: flex;
+			animation: dropdown-in 0.12s ease-out;
+		}
+
+		.nav-link {
+			display: block;
+			width: 100%;
+			padding: var(--space-3) var(--space-4);
+			border-radius: 0;
+			font-size: 0.9rem;
+		}
+
+		.nav-link:hover {
+			background: var(--bg-hover);
+		}
+
+		.nav-link.active {
+			color: var(--text-primary);
+			background: var(--bg-tertiary);
 		}
 	}
 </style>

--- a/web/src/routes/console/admin/+layout.svelte
+++ b/web/src/routes/console/admin/+layout.svelte
@@ -134,4 +134,26 @@
 		color: var(--text-primary);
 		border-bottom-color: var(--accent-blue);
 	}
+
+	/*
+		Mobile: keep the tab-bar visual identity but allow horizontal
+		scroll so all tabs are reachable on narrow viewports without
+		wrapping or clipping. Mirrors the overflow-x:auto pattern used
+		elsewhere in the app (e.g. Editor.svelte). See BUG-1118.
+	*/
+	@media (max-width: 640px) {
+		.admin-tabs {
+			overflow-x: auto;
+			-webkit-overflow-scrolling: touch;
+			flex-wrap: nowrap;
+			scrollbar-width: none;
+		}
+		.admin-tabs::-webkit-scrollbar {
+			display: none;
+		}
+		.admin-tab {
+			flex-shrink: 0;
+			white-space: nowrap;
+		}
+	}
 </style>


### PR DESCRIPTION
## Summary

- The `/console` navbar's horizontal pill row crammed/clipped on narrow viewports — adds a hamburger toggle (≤640px) that opens a full-width dropdown panel mirroring `TopBar.svelte`'s `.user-dropdown` style.
- The admin sub-tab strip wrapped/clipped on the same breakpoint — make it horizontally scrollable (`overflow-x: auto`, momentum scroll, hidden scrollbar, `flex-shrink: 0` tabs) while preserving the active-tab underline.
- Desktop layout unchanged on both files.

Closes BUG-1118.

### Behavior on mobile (≤640px)

**Console navbar:** hamburger (32×32, same SVG/sizing as `TopBar.svelte`'s `.mobile-hamburger`, switches to ✕ when open) → dropdown panel below the navbar containing Workspaces / Settings / Connected Apps / Billing / Admin (admin/cloud-mode visibility preserved). Closes on link click, Escape, outside-click, and route change. Route-change auto-close kept as its own single-purpose `\$effect` per CONVE-606. a11y wired: `aria-expanded`, `aria-controls`, `aria-label`, `role=menu`/`menuitem`.

**Admin sub-tabs:** strip becomes a horizontally-scrollable bar (matches the `overflow-x: auto` pattern in `Editor.svelte`); all tabs stay reachable without wrapping or clipping.

## Test plan

- [x] `make check` (golangci-lint + go test + web build) — all pass
- [x] `svelte-check` — 0 errors, 0 new warnings
- [x] Codex review (round 1) — CLEAN, 0 findings
- [x] `make install` — server restarts, `/console` returns 200 with new bundle
- [ ] Manual: open `/console` at ≤640px width, verify hamburger toggles dropdown, links navigate + close menu, Escape closes, outside-click closes, route change closes
- [ ] Manual: navigate to `/console/admin` at ≤640px, verify the tab strip scrolls horizontally and active-tab underline stays correct
- [ ] Manual: open `/console` at >640px, verify desktop pill row + admin tab row are unchanged