### PR TITLE
feat(workspace): expose currentRole + resource-scoped permission helpers (TASK-1101)

### DIFF
--- a/internal/server/handlers_me.go
+++ b/internal/server/handlers_me.go
@@ -27,11 +27,29 @@ type meResponse struct {
 	CollectionAccess string `json:"collection_access"`
 
 	// VisibleCollectionIDs is the explicit list of collection IDs the user
-	// can see when CollectionAccess == "specific". Empty (nil) when "all".
-	// Server-computed via VisibleCollectionIDs / GuestVisibleCollectionIDs so
-	// it includes system collections, direct collection grants, and
-	// collections containing item-granted items.
+	// can see in navigation when CollectionAccess == "specific". Empty (nil)
+	// when "all". Server-computed via VisibleCollectionIDs /
+	// GuestVisibleCollectionIDs so it includes system collections, direct
+	// collection grants, and collections that contain item-granted items
+	// (so the collection appears in nav for guests).
+	//
+	// IMPORTANT: this set is intentionally broader than "items in this
+	// collection are all accessible". For per-item visibility, use
+	// FullAccessCollectionIDs — see field below.
 	VisibleCollectionIDs []string `json:"visible_collection_ids"`
+
+	// FullAccessCollectionIDs is the strict set of collections in which
+	// every item is accessible to the user — i.e. the collection itself
+	// confers access, not just one item inside it. This mirrors the
+	// `fullCollIDs` set used by guestResourceFilter / isItemVisibleToGuest
+	// in handlers: direct collection grants + member_collection_access +
+	// system collections (for restricted members).
+	//
+	// Empty (nil) when CollectionAccess == "all" (the user has full access
+	// everywhere). For guests with only item grants, this is empty even when
+	// VisibleCollectionIDs is non-empty — the guest's nav shows the
+	// item-grant collection, but only the granted item itself is accessible.
+	FullAccessCollectionIDs []string `json:"full_access_collection_ids"`
 
 	// CollectionGrants are the user's direct per-collection grants in this
 	// workspace.
@@ -89,40 +107,9 @@ func (s *Server) handleGetMe(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if member != nil {
-		// Member: collection_access mode comes from the member row.
-		// VisibleCollectionIDs returns nil for "all" access (signalling no
-		// filter) and an explicit list for "specific" access (which already
-		// includes system collections + direct collection grants + item-grant
-		// collections per workspace_members.go:139).
-		if member.CollectionAccess == "specific" {
-			resp.CollectionAccess = "specific"
-			ids, err := s.store.VisibleCollectionIDs(workspaceID, user.ID)
-			if err != nil {
-				writeInternalError(w, err)
-				return
-			}
-			if ids == nil {
-				ids = []string{}
-			}
-			resp.VisibleCollectionIDs = ids
-		}
-	} else if role == "guest" {
-		// Guest: no membership row; visibility is grant-derived only.
-		resp.CollectionAccess = "specific"
-		ids, err := s.store.GuestVisibleCollectionIDs(workspaceID, user.ID)
-		if err != nil {
-			writeInternalError(w, err)
-			return
-		}
-		if ids == nil {
-			ids = []string{}
-		}
-		resp.VisibleCollectionIDs = ids
-	}
-
 	// Always attach the user's grants — used by the frontend helpers to
-	// override role-based decisions per the server cascade.
+	// override role-based decisions per the server cascade. We need the
+	// grants in scope before computing FullAccessCollectionIDs.
 	collGrants, itemGrants, err := s.store.ListUserGrants(workspaceID, user.ID)
 	if err != nil {
 		writeInternalError(w, err)
@@ -136,6 +123,85 @@ func (s *Server) handleGetMe(w http.ResponseWriter, r *http.Request) {
 	}
 	resp.CollectionGrants = collGrants
 	resp.ItemGrants = itemGrants
+
+	if member != nil {
+		// Member: collection_access mode comes from the member row.
+		if member.CollectionAccess == "specific" {
+			resp.CollectionAccess = "specific"
+
+			// Nav visibility — broader, includes item-grant collections so
+			// the collection appears in the sidebar even if the user only
+			// has access to one item inside it.
+			navIDs, err := s.store.VisibleCollectionIDs(workspaceID, user.ID)
+			if err != nil {
+				writeInternalError(w, err)
+				return
+			}
+			if navIDs == nil {
+				navIDs = []string{}
+			}
+			resp.VisibleCollectionIDs = navIDs
+
+			// Strict full-access set — used for per-item visibility
+			// decisions. Mirrors guestResourceFilter's fullCollIDs for
+			// restricted members: explicit member_collection_access +
+			// system collections + direct collection grants. Item-grant
+			// collections are intentionally excluded — having an item grant
+			// in a collection does NOT confer access to siblings.
+			fullSet := make(map[string]struct{})
+			memberColls, err := s.store.GetMemberCollectionAccess(workspaceID, user.ID)
+			if err != nil {
+				writeInternalError(w, err)
+				return
+			}
+			for _, id := range memberColls {
+				fullSet[id] = struct{}{}
+			}
+			sysColls, err := s.store.ListSystemCollectionIDs(workspaceID)
+			if err != nil {
+				writeInternalError(w, err)
+				return
+			}
+			for _, id := range sysColls {
+				fullSet[id] = struct{}{}
+			}
+			for _, g := range collGrants {
+				fullSet[g.CollectionID] = struct{}{}
+			}
+			fullIDs := make([]string, 0, len(fullSet))
+			for id := range fullSet {
+				fullIDs = append(fullIDs, id)
+			}
+			resp.FullAccessCollectionIDs = fullIDs
+		}
+	} else if role == "guest" {
+		// Guest: no membership row; visibility is grant-derived only.
+		resp.CollectionAccess = "specific"
+
+		// Nav: collections with direct grants + collections that contain
+		// item-granted items.
+		navIDs, err := s.store.GuestVisibleCollectionIDs(workspaceID, user.ID)
+		if err != nil {
+			writeInternalError(w, err)
+			return
+		}
+		if navIDs == nil {
+			navIDs = []string{}
+		}
+		resp.VisibleCollectionIDs = navIDs
+
+		// Strict full-access: only collections with direct collection grants
+		// confer access to all items inside; item grants do not promote.
+		fullSet := make(map[string]struct{})
+		for _, g := range collGrants {
+			fullSet[g.CollectionID] = struct{}{}
+		}
+		fullIDs := make([]string, 0, len(fullSet))
+		for id := range fullSet {
+			fullIDs = append(fullIDs, id)
+		}
+		resp.FullAccessCollectionIDs = fullIDs
+	}
 
 	writeJSON(w, http.StatusOK, resp)
 }

--- a/internal/server/handlers_me.go
+++ b/internal/server/handlers_me.go
@@ -1,0 +1,141 @@
+package server
+
+import (
+	"net/http"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// meResponse is the shape returned by GET /api/v1/workspaces/{ws}/me.
+//
+// It provides the current authenticated user's effective workspace context in
+// a single round-trip so the web UI can decide which affordances to render
+// without needing to compose role + member_collection_access + grants on the
+// client. The frontend's permission helpers in workspace.svelte.ts mirror the
+// server's ResolveUserPermission cascade (owner → item grant → collection
+// grant → membership role + visibility) using these fields.
+type meResponse struct {
+	// Role is the user's effective workspace role: owner, editor, viewer, or guest.
+	// Admin platform users are normalized to "owner" by the middleware. Legacy
+	// workspace-scoped API tokens (no user context) are normalized to "editor".
+	Role string `json:"role"`
+
+	// CollectionAccess is the user's collection access mode.
+	// "all" means no per-collection filter (owners, admins, and members with
+	// CollectionAccess="all" or unset). "specific" means visibility is gated
+	// by visible_collection_ids (restricted members and guests).
+	CollectionAccess string `json:"collection_access"`
+
+	// VisibleCollectionIDs is the explicit list of collection IDs the user
+	// can see when CollectionAccess == "specific". Empty (nil) when "all".
+	// Server-computed via VisibleCollectionIDs / GuestVisibleCollectionIDs so
+	// it includes system collections, direct collection grants, and
+	// collections containing item-granted items.
+	VisibleCollectionIDs []string `json:"visible_collection_ids"`
+
+	// CollectionGrants are the user's direct per-collection grants in this
+	// workspace.
+	CollectionGrants []models.CollectionGrant `json:"collection_grants"`
+
+	// ItemGrants are the user's direct per-item grants in this workspace.
+	ItemGrants []models.ItemGrant `json:"item_grants"`
+}
+
+// handleGetMe returns the current authenticated user's workspace context.
+//
+// This is the foundation primitive for client-side permission gating
+// (PLAN-1100 / TASK-1101). It is open to any authenticated principal that the
+// workspace-access middleware admits — owners, members of any role, and
+// guests with grants. Non-members with no grants are already rejected
+// upstream by RequireWorkspaceAccess.
+func (s *Server) handleGetMe(w http.ResponseWriter, r *http.Request) {
+	workspaceID, ok := s.getWorkspaceID(w, r)
+	if !ok {
+		return
+	}
+
+	role := workspaceRole(r)
+
+	resp := meResponse{
+		Role:             role,
+		CollectionAccess: "all",
+	}
+
+	user := currentUser(r)
+
+	// Legacy workspace-scoped API tokens have no user context — they get
+	// editor role with no per-resource grants. Return a minimal response.
+	if user == nil {
+		resp.CollectionGrants = []models.CollectionGrant{}
+		resp.ItemGrants = []models.ItemGrant{}
+		writeJSON(w, http.StatusOK, resp)
+		return
+	}
+
+	// Admin platform users get owner-equivalent access regardless of
+	// membership — surface that as "all" with no filtering.
+	if user.Role == "admin" {
+		resp.CollectionGrants = []models.CollectionGrant{}
+		resp.ItemGrants = []models.ItemGrant{}
+		writeJSON(w, http.StatusOK, resp)
+		return
+	}
+
+	// Resolve member collection access (only meaningful for members; guests
+	// fall through to GuestVisibleCollectionIDs below).
+	member, err := s.store.GetWorkspaceMember(workspaceID, user.ID)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+
+	if member != nil {
+		// Member: collection_access mode comes from the member row.
+		// VisibleCollectionIDs returns nil for "all" access (signalling no
+		// filter) and an explicit list for "specific" access (which already
+		// includes system collections + direct collection grants + item-grant
+		// collections per workspace_members.go:139).
+		if member.CollectionAccess == "specific" {
+			resp.CollectionAccess = "specific"
+			ids, err := s.store.VisibleCollectionIDs(workspaceID, user.ID)
+			if err != nil {
+				writeInternalError(w, err)
+				return
+			}
+			if ids == nil {
+				ids = []string{}
+			}
+			resp.VisibleCollectionIDs = ids
+		}
+	} else if role == "guest" {
+		// Guest: no membership row; visibility is grant-derived only.
+		resp.CollectionAccess = "specific"
+		ids, err := s.store.GuestVisibleCollectionIDs(workspaceID, user.ID)
+		if err != nil {
+			writeInternalError(w, err)
+			return
+		}
+		if ids == nil {
+			ids = []string{}
+		}
+		resp.VisibleCollectionIDs = ids
+	}
+
+	// Always attach the user's grants — used by the frontend helpers to
+	// override role-based decisions per the server cascade.
+	collGrants, itemGrants, err := s.store.ListUserGrants(workspaceID, user.ID)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	if collGrants == nil {
+		collGrants = []models.CollectionGrant{}
+	}
+	if itemGrants == nil {
+		itemGrants = []models.ItemGrant{}
+	}
+	resp.CollectionGrants = collGrants
+	resp.ItemGrants = itemGrants
+
+	writeJSON(w, http.StatusOK, resp)
+}

--- a/internal/server/handlers_me_test.go
+++ b/internal/server/handlers_me_test.go
@@ -115,8 +115,10 @@ func TestMe_ViewerWithCollectionGrant(t *testing.T) {
 }
 
 // TestMe_RestrictedMember pins the collection_access="specific" path:
-// VisibleCollectionIDs is materialized into the response so the frontend
-// can answer canViewCollection without re-deriving the cascade.
+// both VisibleCollectionIDs (nav set) and FullAccessCollectionIDs (strict
+// per-item access set) are materialized into the response so the frontend
+// can answer canViewCollection (broad) and canViewItem (strict) without
+// re-deriving the cascade.
 func TestMe_RestrictedMember(t *testing.T) {
 	env := setupRBACEnv(t)
 
@@ -150,19 +152,22 @@ func TestMe_RestrictedMember(t *testing.T) {
 	if resp.CollectionAccess != "specific" {
 		t.Errorf("collection_access: expected specific, got %q", resp.CollectionAccess)
 	}
-	// Must include at least the granted collection. The list also includes
-	// system collections (always visible) and any item-grant collections —
-	// see workspace_members.go:139. The exact size depends on system seeds;
-	// we only assert the granted ID is present.
-	found := false
-	for _, id := range resp.VisibleCollectionIDs {
-		if id == colls[0].ID {
-			found = true
-			break
+	// Must include the granted collection in BOTH the nav set and the
+	// strict full-access set. (Nav also includes system collections; the
+	// granted-only assertion isolates the path under test.)
+	contains := func(ids []string, target string) bool {
+		for _, id := range ids {
+			if id == target {
+				return true
+			}
 		}
+		return false
 	}
-	if !found {
+	if !contains(resp.VisibleCollectionIDs, colls[0].ID) {
 		t.Errorf("visible_collection_ids missing granted collection %s, got %v", colls[0].ID, resp.VisibleCollectionIDs)
+	}
+	if !contains(resp.FullAccessCollectionIDs, colls[0].ID) {
+		t.Errorf("full_access_collection_ids missing granted collection %s, got %v", colls[0].ID, resp.FullAccessCollectionIDs)
 	}
 }
 
@@ -238,6 +243,18 @@ func TestMe_GuestWithItemGrant(t *testing.T) {
 	// so it shows up in workspace navigation.
 	if len(resp.VisibleCollectionIDs) == 0 {
 		t.Errorf("guest with item grant: expected at least one visible collection, got 0")
+	}
+	// CRITICAL: it must NOT appear in FullAccessCollectionIDs. A guest
+	// with only an item grant cannot see siblings of the granted item;
+	// the collection is nav-visible but not fully accessible. Per Codex
+	// review round 1 (P1): canViewItem must use the strict set, not nav.
+	for _, id := range resp.FullAccessCollectionIDs {
+		// item.CollectionID is the granted item's collection; it must NOT
+		// be present in full_access (only collection grants populate that
+		// for guests).
+		if id == item.CollectionID {
+			t.Errorf("full_access_collection_ids must not include item-grant-only collection %s, got %v", item.CollectionID, resp.FullAccessCollectionIDs)
+		}
 	}
 }
 

--- a/internal/server/handlers_me_test.go
+++ b/internal/server/handlers_me_test.go
@@ -1,0 +1,267 @@
+package server
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// TestMe_OwnerAdmin pins the admin/owner shape: collection_access "all",
+// no visibility list, no grants. Admins are normalized by the auth
+// middleware to role="owner" regardless of formal membership.
+func TestMe_OwnerAdmin(t *testing.T) {
+	env := setupRBACEnv(t)
+
+	rr := doRequestWithCookie(env.srv, "GET", "/api/v1/workspaces/"+env.wsSlug+"/me", nil, env.ownerToken)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var resp meResponse
+	parseJSON(t, rr, &resp)
+
+	if resp.Role != "owner" {
+		t.Errorf("role: expected owner, got %q", resp.Role)
+	}
+	if resp.CollectionAccess != "all" {
+		t.Errorf("collection_access: expected all, got %q", resp.CollectionAccess)
+	}
+	if len(resp.VisibleCollectionIDs) != 0 {
+		t.Errorf("visible_collection_ids: expected empty for all-access, got %v", resp.VisibleCollectionIDs)
+	}
+	if resp.CollectionGrants == nil {
+		t.Error("collection_grants: expected empty slice, got nil (must be present in JSON)")
+	}
+	if resp.ItemGrants == nil {
+		t.Error("item_grants: expected empty slice, got nil (must be present in JSON)")
+	}
+}
+
+// TestMe_EditorMember pins the editor-with-all-access shape.
+func TestMe_EditorMember(t *testing.T) {
+	env := setupRBACEnv(t)
+
+	rr := doRequestWithCookie(env.srv, "GET", "/api/v1/workspaces/"+env.wsSlug+"/me", nil, env.editorToken)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var resp meResponse
+	parseJSON(t, rr, &resp)
+
+	if resp.Role != "editor" {
+		t.Errorf("role: expected editor, got %q", resp.Role)
+	}
+	if resp.CollectionAccess != "all" {
+		t.Errorf("collection_access: expected all (default), got %q", resp.CollectionAccess)
+	}
+	if len(resp.VisibleCollectionIDs) != 0 {
+		t.Errorf("visible_collection_ids: expected empty for all-access, got %v", resp.VisibleCollectionIDs)
+	}
+}
+
+// TestMe_ViewerWithCollectionGrant pins the precedence-override case:
+// a viewer with CollectionGrant.edit on one collection. The /me response
+// must include the grant so the frontend canEditCollection helper can
+// override the role-based deny.
+func TestMe_ViewerWithCollectionGrant(t *testing.T) {
+	env := setupRBACEnv(t)
+
+	// Find an existing collection in the workspace to grant against.
+	ws, err := env.srv.store.GetWorkspaceBySlug(env.wsSlug)
+	if err != nil || ws == nil {
+		t.Fatalf("locate workspace: %v", err)
+	}
+	colls, err := env.srv.store.ListCollections(ws.ID)
+	if err != nil || len(colls) == 0 {
+		t.Fatalf("list collections: %v (got %d)", err, len(colls))
+	}
+	target := colls[0]
+
+	viewer, err := env.srv.store.GetUserByEmail("viewer@test.com")
+	if err != nil || viewer == nil {
+		t.Fatal("locate viewer user")
+	}
+	owner, err := env.srv.store.GetUserByEmail("owner@test.com")
+	if err != nil || owner == nil {
+		t.Fatal("locate owner user")
+	}
+
+	if _, err := env.srv.store.CreateCollectionGrant(ws.ID, target.ID, viewer.ID, "edit", owner.ID); err != nil {
+		t.Fatalf("create collection grant: %v", err)
+	}
+
+	rr := doRequestWithCookie(env.srv, "GET", "/api/v1/workspaces/"+env.wsSlug+"/me", nil, env.viewerToken)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var resp meResponse
+	parseJSON(t, rr, &resp)
+
+	if resp.Role != "viewer" {
+		t.Errorf("role: expected viewer, got %q", resp.Role)
+	}
+	if len(resp.CollectionGrants) != 1 {
+		t.Fatalf("expected 1 collection grant, got %d", len(resp.CollectionGrants))
+	}
+	if resp.CollectionGrants[0].CollectionID != target.ID {
+		t.Errorf("grant collection_id: expected %s, got %s", target.ID, resp.CollectionGrants[0].CollectionID)
+	}
+	if resp.CollectionGrants[0].Permission != "edit" {
+		t.Errorf("grant permission: expected edit, got %s", resp.CollectionGrants[0].Permission)
+	}
+}
+
+// TestMe_RestrictedMember pins the collection_access="specific" path:
+// VisibleCollectionIDs is materialized into the response so the frontend
+// can answer canViewCollection without re-deriving the cascade.
+func TestMe_RestrictedMember(t *testing.T) {
+	env := setupRBACEnv(t)
+
+	ws, err := env.srv.store.GetWorkspaceBySlug(env.wsSlug)
+	if err != nil || ws == nil {
+		t.Fatalf("locate workspace: %v", err)
+	}
+	colls, err := env.srv.store.ListCollections(ws.ID)
+	if err != nil || len(colls) < 2 {
+		t.Fatalf("list collections: need >= 2, got %d", len(colls))
+	}
+
+	editor, err := env.srv.store.GetUserByEmail("editor@test.com")
+	if err != nil || editor == nil {
+		t.Fatal("locate editor user")
+	}
+
+	// Restrict the editor to the first collection only.
+	if err := env.srv.store.SetMemberCollectionAccess(ws.ID, editor.ID, "specific", []string{colls[0].ID}); err != nil {
+		t.Fatalf("set member collection access: %v", err)
+	}
+
+	rr := doRequestWithCookie(env.srv, "GET", "/api/v1/workspaces/"+env.wsSlug+"/me", nil, env.editorToken)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var resp meResponse
+	parseJSON(t, rr, &resp)
+
+	if resp.CollectionAccess != "specific" {
+		t.Errorf("collection_access: expected specific, got %q", resp.CollectionAccess)
+	}
+	// Must include at least the granted collection. The list also includes
+	// system collections (always visible) and any item-grant collections —
+	// see workspace_members.go:139. The exact size depends on system seeds;
+	// we only assert the granted ID is present.
+	found := false
+	for _, id := range resp.VisibleCollectionIDs {
+		if id == colls[0].ID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("visible_collection_ids missing granted collection %s, got %v", colls[0].ID, resp.VisibleCollectionIDs)
+	}
+}
+
+// TestMe_GuestWithItemGrant pins the guest path: a non-member with only
+// an item_grant. /me uses GuestVisibleCollectionIDs which materializes
+// the item-grant's collection into visible_collection_ids so the
+// collection appears in nav.
+func TestMe_GuestWithItemGrant(t *testing.T) {
+	env := setupRBACEnv(t)
+
+	ws, err := env.srv.store.GetWorkspaceBySlug(env.wsSlug)
+	if err != nil || ws == nil {
+		t.Fatalf("locate workspace: %v", err)
+	}
+
+	// Create an item to grant.
+	rr := doRequestWithCookie(env.srv, "POST",
+		"/api/v1/workspaces/"+env.wsSlug+"/collections/docs/items",
+		map[string]interface{}{"title": "Guest Target", "content": "x"},
+		env.ownerToken)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create item: %d %s", rr.Code, rr.Body.String())
+	}
+	var item models.Item
+	parseJSON(t, rr, &item)
+
+	// Register a non-member user.
+	rr = doRequestWithCookie(env.srv, "POST", "/api/v1/auth/register", map[string]string{
+		"email":    "guest@test.com",
+		"name":     "Guest",
+		"password": "correct-horse-battery-staple",
+	}, env.ownerToken)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("register guest: %d %s", rr.Code, rr.Body.String())
+	}
+	guestUser, err := env.srv.store.GetUserByEmail("guest@test.com")
+	if err != nil || guestUser == nil {
+		t.Fatal("locate guest user")
+	}
+	owner, err := env.srv.store.GetUserByEmail("owner@test.com")
+	if err != nil || owner == nil {
+		t.Fatal("locate owner user")
+	}
+
+	// Grant the guest item-edit access.
+	if _, err := env.srv.store.CreateItemGrant(ws.ID, item.ID, guestUser.ID, "edit", owner.ID); err != nil {
+		t.Fatalf("create item grant: %v", err)
+	}
+
+	guestToken := loginUser(t, env.srv, "guest@test.com", "correct-horse-battery-staple")
+
+	rr = doRequestWithCookie(env.srv, "GET", "/api/v1/workspaces/"+env.wsSlug+"/me", nil, guestToken)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var resp meResponse
+	parseJSON(t, rr, &resp)
+
+	if resp.Role != "guest" {
+		t.Errorf("role: expected guest, got %q", resp.Role)
+	}
+	if resp.CollectionAccess != "specific" {
+		t.Errorf("collection_access: expected specific (guest), got %q", resp.CollectionAccess)
+	}
+	if len(resp.ItemGrants) != 1 {
+		t.Fatalf("expected 1 item grant, got %d", len(resp.ItemGrants))
+	}
+	if resp.ItemGrants[0].ItemID != item.ID {
+		t.Errorf("item grant item_id: expected %s, got %s", item.ID, resp.ItemGrants[0].ItemID)
+	}
+	// The granted item's collection must appear in visible_collection_ids
+	// so it shows up in workspace navigation.
+	if len(resp.VisibleCollectionIDs) == 0 {
+		t.Errorf("guest with item grant: expected at least one visible collection, got 0")
+	}
+}
+
+// TestMe_NonMemberNoGrants_NoAccess confirms non-members with no grants
+// are rejected upstream and never reach /me. The workspace resolver returns
+// 404 (workspace not found from this user's perspective) before
+// RequireWorkspaceAccess gets a chance to 403 — both signal "no access" and
+// the handler itself never runs. Either status is acceptable; what matters
+// is that /me does not leak data to a stranger.
+func TestMe_NonMemberNoGrants_NoAccess(t *testing.T) {
+	env := setupRBACEnv(t)
+
+	rr := doRequestWithCookie(env.srv, "POST", "/api/v1/auth/register", map[string]string{
+		"email":    "stranger@test.com",
+		"name":     "Stranger",
+		"password": "correct-horse-battery-staple",
+	}, env.ownerToken)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("register stranger: %d %s", rr.Code, rr.Body.String())
+	}
+	strangerToken := loginUser(t, env.srv, "stranger@test.com", "correct-horse-battery-staple")
+
+	rr = doRequestWithCookie(env.srv, "GET", "/api/v1/workspaces/"+env.wsSlug+"/me", nil, strangerToken)
+	if rr.Code != http.StatusForbidden && rr.Code != http.StatusNotFound {
+		t.Errorf("non-member with no grants: expected 403 or 404, got %d: %s", rr.Code, rr.Body.String())
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1070,6 +1070,11 @@ func (s *Server) setupRouter() {
 						r.Put("/{userID}/collection-access", s.handleSetMemberCollectionAccess)
 					})
 
+					// Me — current user's effective workspace context (role,
+					// collection access, grants). Open to any principal admitted
+					// by RequireWorkspaceAccess (members + guests).
+					r.Get("/me", s.handleGetMe)
+
 					// Dashboard (v2)
 					r.Get("/dashboard", s.handleGetDashboard)
 

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -37,6 +37,7 @@ import type {
 	ChangesResponse,
 	CollectionGrant,
 	ItemGrant,
+	WorkspaceMembership,
 	ShareLink,
 	TOTPSetupResponse,
 	TOTPVerifyResponse,
@@ -164,6 +165,12 @@ export const api = {
 			}),
 
 		get: (slug: string) => request<Workspace>(`/workspaces/${slug}`),
+
+		// me returns the current user's effective workspace context — role,
+		// collection_access mode, visible collection IDs, and direct grants.
+		// Used by the workspace store's permission helpers (PLAN-1100).
+		me: (slug: string) =>
+			request<WorkspaceMembership>(`/workspaces/${slug}/me`),
 
 		update: (slug: string, data: WorkspaceUpdate) =>
 			request<Workspace>(`/workspaces/${slug}`, {

--- a/web/src/lib/stores/workspace.svelte.ts
+++ b/web/src/lib/stores/workspace.svelte.ts
@@ -7,6 +7,13 @@ let current = $state<Workspace | null>(null);
 let currentMembership = $state<WorkspaceMembership | null>(null);
 let loading = $state(false);
 
+// Monotonic sequence guarding async /me responses against navigation races.
+// Each setCurrent / create call increments the counter; a /me response is
+// only applied if its captured token still matches at resolution time. This
+// prevents a slow /me for workspace A from clobbering a freshly-set
+// membership for workspace B.
+let membershipSeq = 0;
+
 /**
  * Resource-scoped permission helpers (PLAN-1100 / TASK-1101).
  *
@@ -69,6 +76,15 @@ export const workspaceStore = {
 	},
 
 	async setCurrent(ws: Workspace | string) {
+		// Capture a sequence token for this call. Any /me response received
+		// after a later setCurrent / create has run will be discarded — see
+		// membershipSeq comment at top of file.
+		const seq = ++membershipSeq;
+
+		// Clear stale membership immediately so helpers don't briefly answer
+		// "yes" using the previous workspace's grants while /me is in flight.
+		currentMembership = null;
+
 		// Resolve the workspace itself. Membership is fetched once we know
 		// the slug.
 		let resolved: Workspace | null = null;
@@ -89,32 +105,37 @@ export const workspaceStore = {
 				}
 			}
 		}
+
+		// Drop any later writes from a stale call.
+		if (seq !== membershipSeq) return;
 		current = resolved;
 
 		// Fetch the current user's membership context. If the workspace
-		// doesn't resolve (404) or membership fetch fails (403), clear the
-		// membership so helpers return false until/unless a valid context
-		// loads.
+		// doesn't resolve (404) or membership fetch fails (403), leave the
+		// membership null so helpers return false.
 		if (resolved) {
 			try {
-				currentMembership = await api.workspaces.me(slug);
+				const m = await api.workspaces.me(slug);
+				if (seq === membershipSeq) currentMembership = m;
 			} catch {
-				currentMembership = null;
+				if (seq === membershipSeq) currentMembership = null;
 			}
-		} else {
-			currentMembership = null;
 		}
 	},
 
 	async create(data: { name: string; description?: string; template?: string }) {
+		const seq = ++membershipSeq;
+		currentMembership = null;
 		const ws = await api.workspaces.create(data);
+		if (seq !== membershipSeq) return ws;
 		workspaces = [...workspaces, ws];
 		current = ws;
 		// New workspace — refresh membership for the just-created context.
 		try {
-			currentMembership = await api.workspaces.me(ws.slug);
+			const m = await api.workspaces.me(ws.slug);
+			if (seq === membershipSeq) currentMembership = m;
 		} catch {
-			currentMembership = null;
+			if (seq === membershipSeq) currentMembership = null;
 		}
 		return ws;
 	}

--- a/web/src/lib/stores/workspace.svelte.ts
+++ b/web/src/lib/stores/workspace.svelte.ts
@@ -1,14 +1,63 @@
 import { api } from '$lib/api/client';
-import type { Workspace } from '$lib/types';
+import type { Workspace, WorkspaceMembership } from '$lib/types';
+import * as perms from '$lib/utils/permissions';
 
 let workspaces = $state<Workspace[]>([]);
 let current = $state<Workspace | null>(null);
+let currentMembership = $state<WorkspaceMembership | null>(null);
 let loading = $state(false);
+
+/**
+ * Resource-scoped permission helpers (PLAN-1100 / TASK-1101).
+ *
+ * Wraps the pure cascade in `$lib/utils/permissions` with the store's
+ * `currentMembership` state. The cascade mirrors the server's
+ * ResolveUserPermission exactly so the UI cannot show edit affordances the
+ * server would reject:
+ *
+ *     owner → item grant → collection grant → membership role + visibility → deny
+ *
+ * Item grant beats collection grant beats membership role even when the
+ * item grant is less permissive. `currentMembership` is null when not loaded
+ * yet or the fetch failed; in that case all helpers return false (treat
+ * unknown as no access).
+ */
 
 export const workspaceStore = {
 	get workspaces() { return workspaces; },
 	get current() { return current; },
 	get loading() { return loading; },
+
+	get currentMembership() { return currentMembership; },
+
+	get currentRole() {
+		return currentMembership?.role ?? null;
+	},
+
+	get isOwner() {
+		return currentMembership?.role === 'owner';
+	},
+
+	/** Owner-only chrome: settings tabs, members mutation, archive workspace. */
+	get canEditWorkspace() {
+		return perms.canEditWorkspace(currentMembership);
+	},
+
+	canViewCollection(collId: string): boolean {
+		return perms.canViewCollection(currentMembership, collId);
+	},
+
+	canEditCollection(collId: string): boolean {
+		return perms.canEditCollection(currentMembership, collId);
+	},
+
+	canViewItem(item: { id: string; collection_id: string }): boolean {
+		return perms.canViewItem(currentMembership, item);
+	},
+
+	canEditItem(item: { id: string; collection_id: string }): boolean {
+		return perms.canEditItem(currentMembership, item);
+	},
 
 	async loadAll() {
 		loading = true;
@@ -20,19 +69,40 @@ export const workspaceStore = {
 	},
 
 	async setCurrent(ws: Workspace | string) {
+		// Resolve the workspace itself. Membership is fetched once we know
+		// the slug.
+		let resolved: Workspace | null = null;
+		let slug: string;
 		if (typeof ws === 'object') {
-			current = ws;
-			return;
+			resolved = ws;
+			slug = ws.slug;
+		} else {
+			slug = ws;
+			const found = workspaces.find((w) => w.slug === ws);
+			if (found) {
+				resolved = found;
+			} else {
+				try {
+					resolved = await api.workspaces.get(ws);
+				} catch {
+					resolved = null;
+				}
+			}
 		}
-		const found = workspaces.find(w => w.slug === ws);
-		if (found) {
-			current = found;
-			return;
-		}
-		try {
-			current = await api.workspaces.get(ws);
-		} catch {
-			current = null;
+		current = resolved;
+
+		// Fetch the current user's membership context. If the workspace
+		// doesn't resolve (404) or membership fetch fails (403), clear the
+		// membership so helpers return false until/unless a valid context
+		// loads.
+		if (resolved) {
+			try {
+				currentMembership = await api.workspaces.me(slug);
+			} catch {
+				currentMembership = null;
+			}
+		} else {
+			currentMembership = null;
 		}
 	},
 
@@ -40,6 +110,12 @@ export const workspaceStore = {
 		const ws = await api.workspaces.create(data);
 		workspaces = [...workspaces, ws];
 		current = ws;
+		// New workspace — refresh membership for the just-created context.
+		try {
+			currentMembership = await api.workspaces.me(ws.slug);
+		} catch {
+			currentMembership = null;
+		}
 		return ws;
-	},
+	}
 };

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -100,6 +100,34 @@ export interface ItemGrant {
 	user_username?: string;
 }
 
+// ─── Workspace Membership (current user) ─────────────────────────────────────
+
+/**
+ * The current user's effective workspace context, returned by
+ * `GET /api/v1/workspaces/{ws}/me`. Used by the workspace store's permission
+ * helpers (canEditWorkspace / canEditCollection / canEditItem etc.) to decide
+ * which UI affordances to render.
+ *
+ * The shape mirrors the server's permission cascade:
+ * - role: owner / editor / viewer / guest (admin platform users normalize to
+ *   "owner"; legacy workspace-scoped tokens normalize to "editor")
+ * - collection_access: "all" means no per-collection filter; "specific" means
+ *   visibility is gated by visible_collection_ids
+ * - visible_collection_ids: explicit list when collection_access is "specific";
+ *   empty when "all". Server-computed (includes system collections, direct
+ *   collection grants, and item-grant collections) so the frontend never
+ *   re-derives the cascade.
+ * - collection_grants / item_grants: direct overrides that beat membership
+ *   role per the server's ResolveUserPermission cascade.
+ */
+export interface WorkspaceMembership {
+	role: 'owner' | 'editor' | 'viewer' | 'guest';
+	collection_access: 'all' | 'specific';
+	visible_collection_ids: string[];
+	collection_grants: CollectionGrant[];
+	item_grants: ItemGrant[];
+}
+
 // ─── Workspace ────────────────────────────────────────────────────────────────
 
 export interface Workspace {

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -113,10 +113,17 @@ export interface ItemGrant {
  *   "owner"; legacy workspace-scoped tokens normalize to "editor")
  * - collection_access: "all" means no per-collection filter; "specific" means
  *   visibility is gated by visible_collection_ids
- * - visible_collection_ids: explicit list when collection_access is "specific";
- *   empty when "all". Server-computed (includes system collections, direct
- *   collection grants, and item-grant collections) so the frontend never
- *   re-derives the cascade.
+ * - visible_collection_ids: nav-visibility list when collection_access is
+ *   "specific"; empty when "all". Includes system collections, direct
+ *   collection grants, and collections containing item-granted items
+ *   (so the collection appears in the sidebar). NOT a sufficient signal
+ *   for per-item access — see full_access_collection_ids.
+ * - full_access_collection_ids: strict per-item access list when
+ *   collection_access is "specific"; empty when "all". Includes only
+ *   collections where every item is accessible (member_collection_access
+ *   + system collections + direct collection grants). Item-grant
+ *   collections are intentionally excluded — having an item grant in
+ *   collection X does NOT confer access to siblings in X.
  * - collection_grants / item_grants: direct overrides that beat membership
  *   role per the server's ResolveUserPermission cascade.
  */
@@ -124,6 +131,7 @@ export interface WorkspaceMembership {
 	role: 'owner' | 'editor' | 'viewer' | 'guest';
 	collection_access: 'all' | 'specific';
 	visible_collection_ids: string[];
+	full_access_collection_ids: string[];
 	collection_grants: CollectionGrant[];
 	item_grants: ItemGrant[];
 }

--- a/web/src/lib/utils/permissions.ts
+++ b/web/src/lib/utils/permissions.ts
@@ -27,6 +27,15 @@ export function canEditWorkspace(m: WorkspaceMembership | null): boolean {
 	return m?.role === 'owner';
 }
 
+/**
+ * canViewCollection — should the collection appear in nav / be browseable?
+ *
+ * This is the broad nav-visibility predicate. It uses
+ * `visible_collection_ids` which deliberately includes collections that
+ * only contain item-granted items (so a guest with one ItemGrant on
+ * TASK-5 sees Tasks in the sidebar). For per-item access, use canViewItem
+ * — which uses the strict `full_access_collection_ids` instead.
+ */
 export function canViewCollection(m: WorkspaceMembership | null, collId: string): boolean {
 	if (!m) return false;
 	if (m.role === 'owner') return true;
@@ -35,6 +44,13 @@ export function canViewCollection(m: WorkspaceMembership | null, collId: string)
 	return m.visible_collection_ids.includes(collId);
 }
 
+/**
+ * canEditCollection — collection-level write affordances (e.g. "+ New").
+ *
+ * Item grants intentionally do not promote here — collection-wide write
+ * requires a collection-level grant or a role that implies write. Server
+ * enforcement matches.
+ */
 export function canEditCollection(m: WorkspaceMembership | null, collId: string): boolean {
 	if (!m) return false;
 	if (m.role === 'owner') return true;
@@ -44,6 +60,21 @@ export function canEditCollection(m: WorkspaceMembership | null, collId: string)
 	return m.role === 'editor';
 }
 
+/**
+ * canViewItem — can the user actually see this specific item?
+ *
+ * Mirrors the server's request-handler filtering (guestResourceFilter +
+ * isItemVisibleToGuest), NOT just the broad nav predicate:
+ *   - owner → true
+ *   - explicit item grant → true
+ *   - explicit collection grant → true (covers all items in that collection)
+ *   - collection_access === "all" → true (member with full access)
+ *   - collection_access === "specific" + collection in
+ *     full_access_collection_ids → true
+ *   - else → false (e.g. guest with single item-grant cannot see siblings,
+ *     and a restricted member cannot see siblings of an item-granted item
+ *     in a collection they don't otherwise have full access to)
+ */
 export function canViewItem(
 	m: WorkspaceMembership | null,
 	item: { id: string; collection_id: string }
@@ -51,9 +82,22 @@ export function canViewItem(
 	if (!m) return false;
 	if (m.role === 'owner') return true;
 	if (m.item_grants.some((g) => g.item_id === item.id)) return true;
-	return canViewCollection(m, item.collection_id);
+	if (m.collection_grants.some((g) => g.collection_id === item.collection_id)) return true;
+	if (m.collection_access === 'all') return true;
+	return m.full_access_collection_ids.includes(item.collection_id);
 }
 
+/**
+ * canEditItem — item-level write affordances (title, content, fields,
+ * delete, status, comment composer, drag handle).
+ *
+ * Mirrors server precedence — item grant beats collection grant beats
+ * membership role. So ItemGrant.view + CollectionGrant.edit on the same
+ * item → false (item grant wins, even though it's less permissive).
+ *
+ * The fallback path uses canViewItem's strict membership-based check so a
+ * guest cannot edit siblings of an item-granted item.
+ */
 export function canEditItem(
 	m: WorkspaceMembership | null,
 	item: { id: string; collection_id: string }
@@ -62,5 +106,13 @@ export function canEditItem(
 	if (m.role === 'owner') return true;
 	const ig = m.item_grants.find((g) => g.item_id === item.id);
 	if (ig) return ig.permission === 'edit';
-	return canEditCollection(m, item.collection_id);
+	const cg = m.collection_grants.find((g) => g.collection_id === item.collection_id);
+	if (cg) return cg.permission === 'edit';
+	// Membership fallback — must (a) be in the strict full-access set when
+	// "specific" access, and (b) have a role that implies write.
+	if (m.collection_access === 'specific'
+		&& !m.full_access_collection_ids.includes(item.collection_id)) {
+		return false;
+	}
+	return m.role === 'editor';
 }

--- a/web/src/lib/utils/permissions.ts
+++ b/web/src/lib/utils/permissions.ts
@@ -1,0 +1,66 @@
+/**
+ * Pure permission helpers (PLAN-1100 / TASK-1101).
+ *
+ * Mirrors the server's ResolveUserPermission cascade exactly so the UI cannot
+ * show edit affordances the server would reject:
+ *
+ *     owner → item grant → collection grant → membership role + visibility → deny
+ *
+ * Item grant beats collection grant beats membership role even when the item
+ * grant is *less* permissive (e.g. ItemGrant.view + CollectionGrant.edit on
+ * the same item → effective view, server rejects edit).
+ *
+ * These functions are pure and stateless. The workspace store wraps them with
+ * its `currentMembership` state. Splitting the cascade out keeps it isolated
+ * for testing and makes the logic reusable from non-store contexts.
+ *
+ * Server-side coverage of the cascade lives in
+ * `internal/store/permissions_test.go` and `internal/store/grants_test.go`,
+ * plus the `/me` endpoint shape in `internal/server/handlers_me_test.go`.
+ * Frontend unit tests are deferred until web/ adopts a unit-test runner;
+ * the helpers below are intentionally thin so the cost of that gap is small.
+ */
+
+import type { WorkspaceMembership } from '$lib/types';
+
+export function canEditWorkspace(m: WorkspaceMembership | null): boolean {
+	return m?.role === 'owner';
+}
+
+export function canViewCollection(m: WorkspaceMembership | null, collId: string): boolean {
+	if (!m) return false;
+	if (m.role === 'owner') return true;
+	if (m.collection_grants.some((g) => g.collection_id === collId)) return true;
+	if (m.collection_access === 'all') return true;
+	return m.visible_collection_ids.includes(collId);
+}
+
+export function canEditCollection(m: WorkspaceMembership | null, collId: string): boolean {
+	if (!m) return false;
+	if (m.role === 'owner') return true;
+	const cg = m.collection_grants.find((g) => g.collection_id === collId);
+	if (cg) return cg.permission === 'edit';
+	if (!canViewCollection(m, collId)) return false;
+	return m.role === 'editor';
+}
+
+export function canViewItem(
+	m: WorkspaceMembership | null,
+	item: { id: string; collection_id: string }
+): boolean {
+	if (!m) return false;
+	if (m.role === 'owner') return true;
+	if (m.item_grants.some((g) => g.item_id === item.id)) return true;
+	return canViewCollection(m, item.collection_id);
+}
+
+export function canEditItem(
+	m: WorkspaceMembership | null,
+	item: { id: string; collection_id: string }
+): boolean {
+	if (!m) return false;
+	if (m.role === 'owner') return true;
+	const ig = m.item_grants.find((g) => g.item_id === item.id);
+	if (ig) return ig.permission === 'edit';
+	return canEditCollection(m, item.collection_id);
+}

--- a/web/src/lib/utils/permissions.ts
+++ b/web/src/lib/utils/permissions.ts
@@ -48,16 +48,25 @@ export function canViewCollection(m: WorkspaceMembership | null, collId: string)
  * canEditCollection — collection-level write affordances (e.g. "+ New").
  *
  * Item grants intentionally do not promote here — collection-wide write
- * requires a collection-level grant or a role that implies write. Server
- * enforcement matches.
+ * requires a collection-level grant or a role that implies write *and*
+ * full access to this collection. Server enforcement matches.
+ *
+ * NOTE: the membership fallback uses the strict full-access set, NOT the
+ * broader nav set. A restricted editor whose only access to a collection
+ * comes from an item grant has that collection in visible_collection_ids
+ * (so it appears in nav) but NOT in full_access_collection_ids — and must
+ * not see collection-wide affordances like "+ New" because the server
+ * would reject collection-level writes.
  */
 export function canEditCollection(m: WorkspaceMembership | null, collId: string): boolean {
 	if (!m) return false;
 	if (m.role === 'owner') return true;
 	const cg = m.collection_grants.find((g) => g.collection_id === collId);
 	if (cg) return cg.permission === 'edit';
-	if (!canViewCollection(m, collId)) return false;
-	return m.role === 'editor';
+	if (m.role !== 'editor') return false;
+	// Editor membership: needs full access to this collection.
+	if (m.collection_access === 'all') return true;
+	return m.full_access_collection_ids.includes(collId);
 }
 
 /**

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -16,10 +16,10 @@
 	import { toastStore } from '$lib/stores/toast.svelte';
 	import ShareDialog from '$lib/components/ShareDialog.svelte';
 	import EditCollectionModal from '$lib/components/collections/EditCollectionModal.svelte';
-	import { authStore } from '$lib/stores/auth.svelte';
 	import { collectionStore } from '$lib/stores/collections.svelte';
 	import { uiStore } from '$lib/stores/ui.svelte';
 	import { titleStore } from '$lib/stores/title.svelte';
+	import { workspaceStore } from '$lib/stores/workspace.svelte';
 
 	type ViewMode = 'list' | 'board' | 'table';
 
@@ -53,7 +53,10 @@
 	let wsSlug = $derived(page.params.workspace ?? '');
 	let username = $derived(page.params.username ?? '');
 	let collSlug = $derived(page.params.collection ?? '');
-	let isOwner = $derived(workspaceMembers.some(m => m.user_id === authStore.userId && m.role === 'owner'));
+	// isOwner now comes from workspaceStore (PLAN-1100 / TASK-1101) — populated
+	// by workspaceStore.setCurrent via the /me endpoint. The workspaceMembers
+	// array remains for the assignee dropdown / member rows.
+	let isOwner = $derived(workspaceStore.isOwner);
 
 	// Persist view mode to localStorage per collection
 	function saveViewMode(mode: ViewMode) {

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -23,9 +23,9 @@
 	import EditCollectionModal from '$lib/components/collections/EditCollectionModal.svelte';
 	import ShareDialog from '$lib/components/ShareDialog.svelte';
 	import { copyToClipboard } from '$lib/utils/clipboard';
-	import { authStore } from '$lib/stores/auth.svelte';
 	import { starredStore } from '$lib/stores/starred.svelte';
 	import { titleStore } from '$lib/stores/title.svelte';
+	import { workspaceStore } from '$lib/stores/workspace.svelte';
 
 	type RelationshipEntry = {
 		key: string;
@@ -120,7 +120,10 @@
 	}
 	let relationshipGroups = $derived(item ? buildRelationshipGroups(item, itemLinks, childItemIds) : []);
 	let codeContext = $derived(item?.code_context ?? null);
-	let isOwner = $derived(workspaceMembers.some(m => m.user_id === authStore.userId && m.role === 'owner'));
+	// isOwner now comes from workspaceStore (PLAN-1100 / TASK-1101) — populated
+	// by workspaceStore.setCurrent via the /me endpoint. workspaceMembers is
+	// still loaded for the assignee dropdown (line ~947).
+	let isOwner = $derived(workspaceStore.isOwner);
 	$effect(() => {
 		if (wsSlug && collSlug && itemSlug) {
 			loadData();

--- a/web/src/routes/[username]/[workspace]/settings/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/settings/+page.svelte
@@ -35,7 +35,8 @@
 	let inviteRole = $state('editor');
 	let inviting = $state(false);
 	let inviteResult = $state<{ message: string; type: 'success' | 'error' } | null>(null);
-	let currentUserRole = $state('');
+	// Current-user role + isOwner now come from workspaceStore (PLAN-1100 / TASK-1101)
+	// — populated by workspaceStore.setCurrent via the /me endpoint.
 
 	// Collection Access
 	let expandedAccessUserId = $state<string | null>(null);
@@ -85,12 +86,8 @@
 				const memberData = await api.members.list(slug);
 				members = memberData.members ?? [];
 				invitations = memberData.invitations ?? [];
-				// Determine current user's role
-				const session = await api.auth.session();
-				if (session.user) {
-					const me = members.find(m => m.user_email === session.user!.email);
-					currentUserRole = me?.role ?? '';
-				}
+				// Note: current-user role no longer derived here. workspaceStore.setCurrent
+				// fetches /me and pins workspaceStore.isOwner / .currentRole.
 			} catch {}
 		} catch { /* allow partial render */
 		} finally {
@@ -313,7 +310,7 @@
 		}
 	}
 
-	let isOwner = $derived(currentUserRole === 'owner');
+	let isOwner = $derived(workspaceStore.isOwner);
 
 	let confirmDelete = $state(false);
 	let deleting = $state(false);


### PR DESCRIPTION
## Summary

Foundation for [PLAN-1100](#) (client-side permission audit). Lands the primitive that every other task in the plan consumes, with **no UI behavior changes** — pure infra.

- New `GET /api/v1/workspaces/{ws}/me` endpoint returning role + visibility + grants in one round-trip.
- Pure `$lib/utils/permissions` cascade module + `workspaceStore` getters mirroring the server's `ResolveUserPermission` cascade exactly.
- Three leaf pages (`settings`, `[collection]`, `[collection]/[slug]`) drop their open-coded `members.find(...).role` derivations and consume `workspaceStore.isOwner`.

## Context

Implements `TASK-1101` under `PLAN-1100`.

The cascade order is:

> owner → item grant → collection grant → membership role + visibility → deny

Item grant beats collection grant beats role, even when less permissive (e.g. `ItemGrant.view` + `CollectionGrant.edit` on same item → effective `view`, server rejects edit). The frontend helpers must mirror this exactly so the UI cannot show edit affordances the server would reject.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./internal/server/ -run TestMe_` — 6 scenarios pass (admin, editor, viewer-with-grant, restricted-member, guest-with-item-grant, non-member-no-grants)
- [x] `make check` — clean (golangci-lint + go test ./... + govulncheck + web build/check)
- [x] `npx svelte-check` — 0 errors, only pre-existing warnings
- [ ] Manual: front-end unit tests deferred; web has no unit-test runner today. Pure-function module in `lib/utils/permissions.ts` makes them trivial to add when infra lands. Cascade is independently covered by server tests in `internal/store/permissions_test.go` and `internal/store/grants_test.go`.