### PR TITLE
feat(settings): gate collection management UI to owners (TASK-1103)

### DIFF
--- a/web/src/routes/[username]/[workspace]/settings/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/settings/+page.svelte
@@ -683,7 +683,7 @@
 					<div class="coll-list">
 						{#each collections as coll (coll.id)}
 							{@const schema = parseSchema(coll)}
-							<button class="card coll-card coll-card-btn" onclick={() => (editingCollection = coll)}>
+							{#snippet collCardBody()}
 								<div class="coll-header">
 									<span class="coll-icon">{coll.icon || '#'}</span>
 									<span class="coll-name">{coll.name}</span>
@@ -692,7 +692,9 @@
 									{#if coll.is_default}
 										<span class="badge">default</span>
 									{/if}
-									<span class="edit-hint">Edit</span>
+									{#if isOwner}
+										<span class="edit-hint">Edit</span>
+									{/if}
 								</div>
 								{#if schema.fields.length > 0}
 									<div class="field-tags">
@@ -701,20 +703,37 @@
 										{/each}
 									</div>
 								{/if}
-							</button>
+							{/snippet}
+							<!-- Owner-only: card opens the edit modal. Non-owners see
+							     the same card content but as a non-interactive div
+							     (server requires owner role for collection update/delete
+							     — handlers_collections.go:113, :164). -->
+							{#if isOwner}
+								<button class="card coll-card coll-card-btn" onclick={() => (editingCollection = coll)}>
+									{@render collCardBody()}
+								</button>
+							{:else}
+								<div class="card coll-card">
+									{@render collCardBody()}
+								</div>
+							{/if}
 						{/each}
 					</div>
 				{/if}
-				<button class="btn btn-create" onclick={() => (showCreateModal = true)}>
-					+ Create Collection
-				</button>
-				<CreateCollectionModal
-					open={showCreateModal}
-					{wsSlug}
-					oncreated={handleCollectionCreated}
-					onclose={() => (showCreateModal = false)}
-				/>
-				{#if editingCollection}
+				<!-- Server requires owner role for collection create
+				     (handlers_collections.go:48). UI matches. -->
+				{#if isOwner}
+					<button class="btn btn-create" onclick={() => (showCreateModal = true)}>
+						+ Create Collection
+					</button>
+					<CreateCollectionModal
+						open={showCreateModal}
+						{wsSlug}
+						oncreated={handleCollectionCreated}
+						onclose={() => (showCreateModal = false)}
+					/>
+				{/if}
+				{#if editingCollection && isOwner}
 					<EditCollectionModal
 						open={true}
 						collection={editingCollection}


### PR DESCRIPTION
## Summary

Settings → Collections currently shows "+ Create Collection" and clickable edit cards to all roles. Server is owner-only on create/update/delete (handlers_collections.go:48, :113, :164). UI now matches.

- Collection cards: clickable button for owners, non-interactive div for others (same content visible).
- "Edit" hint and "+ Create Collection" button hidden for non-owners.
- CreateCollectionModal / EditCollectionModal mount only for owners.

## Context

Implements \`TASK-1103\` under \`PLAN-1100\`. Builds on TASK-1101's \`workspaceStore.isOwner\`.

Note: spec floated "create gated to editor+", but server is owner-only. Aligned UI to server (server is the security boundary).

## Test plan

- [x] make check clean
- [ ] Manual three-role smoke test deferred to HT-1157