### PR TITLE
feat(item-detail): gate write affordances on canEditItem (TASK-1105)

### DIFF
--- a/web/src/lib/components/editor/Editor.svelte
+++ b/web/src/lib/components/editor/Editor.svelte
@@ -472,7 +472,12 @@
 				transformPastedText: true,
 				transformCopiedText: true,
 			}),
-			BlockDragHandle,
+			// BlockDragHandle registers a drag-to-reorder UI in the prose
+			// mirror view that is NOT gated on tiptap's `editable` flag —
+			// its handle can still drag/dispatch transactions even when
+			// `editable=false`. Exclude entirely in read-only mode so the
+			// handle is never injected (PLAN-1100 / TASK-1105 round 3).
+			...(editable ? [BlockDragHandle] : []),
 			AttachmentImage.configure({
 				getDownloadUrl: getAttachmentUrl,
 				workspaceSlug: wsSlug,

--- a/web/src/lib/components/editor/Editor.svelte
+++ b/web/src/lib/components/editor/Editor.svelte
@@ -815,7 +815,7 @@
 	lines 658-659) — this just makes the toolbar visibility actually
 	consult it.
 -->
-{#if isMobile && keyboardVisible && editor && editorFocused}
+{#if editable && isMobile && keyboardVisible && editor && editorFocused}
 	{@const _tick = editorTick}
 	{@const listItemType = getActiveListItemType()}
 	{@const canIndent = canIndentListItem(listItemType)}
@@ -843,7 +843,7 @@
 
 <div class="editor-wrapper">
 	<div bind:this={element} class="editor-content prose"></div>
-	{#if editor && editorTick >= 0 && editor.isActive('table')}
+	{#if editable && editor && editorTick >= 0 && editor.isActive('table')}
 		{@const tpos = getTableToolbarPos()}
 		{#if tpos}
 			<!-- svelte-ignore a11y_no_static_element_interactions -->

--- a/web/src/lib/components/editor/RawMarkdownEditor.svelte
+++ b/web/src/lib/components/editor/RawMarkdownEditor.svelte
@@ -2,9 +2,11 @@
 	let {
 		content = '',
 		onUpdate,
+		readonly = false,
 	}: {
 		content?: string;
 		onUpdate?: (markdown: string) => void;
+		readonly?: boolean;
 	} = $props();
 
 	let localContent = $state('');
@@ -37,6 +39,7 @@
 	oninput={handleInput}
 	class="raw-textarea"
 	spellcheck="false"
+	{readonly}
 ></textarea>
 
 <style>

--- a/web/src/lib/components/fields/FieldEditor.svelte
+++ b/web/src/lib/components/fields/FieldEditor.svelte
@@ -7,6 +7,12 @@ Usage:
 ```svelte
 <FieldEditor {field} {value} onchange={(v) => handleChange(v)} />
 ```
+
+Pass `readonly={true}` to render a display-only view — used by item detail
+pages when the current user lacks edit permission on the item
+(PLAN-1100 / TASK-1105). Display mode renders the value with the same
+visual language as the editor but with no inputs, dropdowns, or mutation
+handlers — onchange is never called.
 -->
 <script lang="ts">
 	import type { FieldDef } from '$lib/types';
@@ -16,9 +22,10 @@ Usage:
 		field: FieldDef;
 		value: any;
 		onchange: (value: any) => void;
+		readonly?: boolean;
 	}
 
-	let { field, value, onchange }: Props = $props();
+	let { field, value, onchange, readonly = false }: Props = $props();
 
 	// ── Viewport detection ───────────────────────────────────────────────
 	// On mobile the absolute-positioned select dropdown can clip at the
@@ -177,7 +184,48 @@ Usage:
 
 <svelte:window onclick={handleWindowClick} />
 
-{#if field.type === 'select'}
+{#if readonly}
+	<!--
+		Display-only mode (PLAN-1100 / TASK-1105). No inputs, no dropdowns,
+		no mutation handlers — value rendered with the same visual language
+		as the editor's idle state. Maps each field type to a non-interactive
+		representation; the empty case renders an em-dash to match how the
+		select/date triggers display "no value".
+	-->
+	{#if field.type === 'select'}
+		<div class="readonly-display">
+			{#if value && getStatusColor(value)}
+				<span class="color-dot" style:background={getStatusColor(value)}></span>
+			{/if}
+			<span class="select-label">{value ? formatLabel(value) : '—'}</span>
+		</div>
+	{:else if field.type === 'checkbox'}
+		<div class="readonly-display">
+			<span>{value ? 'Yes' : 'No'}</span>
+		</div>
+	{:else if field.type === 'date'}
+		<div class="readonly-display">
+			<span>{value ? formatDate(value) : '—'}</span>
+		</div>
+	{:else if field.type === 'number'}
+		<div class="readonly-display">
+			<span>{value ?? '—'}{value != null && field.suffix ? field.suffix : ''}</span>
+		</div>
+	{:else if field.type === 'url'}
+		<div class="readonly-display">
+			{#if value}
+				<a href={value} target="_blank" rel="noopener noreferrer" class="url-readonly">{value}</a>
+			{:else}
+				<span>—</span>
+			{/if}
+		</div>
+	{:else}
+		<div class="readonly-display">
+			<span>{value ?? '—'}</span>
+		</div>
+	{/if}
+
+{:else if field.type === 'select'}
 	{#snippet selectOptions()}
 		{#if field.options}
 			{#each field.options as option, i (option)}
@@ -378,6 +426,29 @@ Usage:
 {/if}
 
 <style>
+	/* ── Readonly display ─────────────────────────────────────────────── */
+
+	.readonly-display {
+		display: flex;
+		align-items: center;
+		gap: var(--space-2);
+		padding: var(--space-1) var(--space-2);
+		min-height: 30px;
+		font-size: 0.88em;
+		color: var(--text-primary);
+	}
+
+	.url-readonly {
+		color: var(--accent-blue);
+		text-decoration: none;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	.url-readonly:hover {
+		text-decoration: underline;
+	}
+
 	/* ── Shared input styles ──────────────────────────────────────────── */
 
 	.field-input {

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -294,8 +294,10 @@
 		} finally {
 			loading = false;
 
-			// Auto-start title editing for newly created items
-			if (page.url.searchParams.get('new') === '1' && item) {
+			// Auto-start title editing for newly created items.
+			// Guarded on canEdit (PLAN-1100 / TASK-1105) so a read-only user
+			// can't trigger the title textarea by appending ?new=1.
+			if (page.url.searchParams.get('new') === '1' && item && canEdit) {
 				// Clean up the URL param first, then focus title after DOM settles
 				goto(`/${username}/${wsSlug}/${collSlug}/${itemSlug}`, { replaceState: true, noScroll: true });
 				await startEditTitle();
@@ -304,7 +306,7 @@
 	}
 
 	async function startEditTitle() {
-		if (!item) return;
+		if (!item || !canEdit) return;
 		titleDraft = item.title;
 		editingTitle = true;
 		// Wait for the DOM to render the textarea, then focus + select all

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -1036,7 +1036,15 @@
 						<RawMarkdownEditor content={item.content ?? ''} onUpdate={handleRawContentUpdate} readonly={!canEdit} />
 					{/key}
 				{:else}
-					{#key item.id}
+					<!--
+						Key on canEdit so the Editor is reconstructed when the user
+						gains/loses edit permission. BlockDragHandle (and any future
+						extensions whose registration is gated on `editable`) are
+						decided at construction time — without re-keying, an editor
+						mounted before /me resolves would never gain the drag handle
+						even after canEdit flips true. Per Codex review round 4.
+					-->
+					{#key `${item.id}:${canEdit}`}
 						<Editor content={editorContent} onUpdate={handleContentUpdate} editable={canEdit} onEditor={(e) => editorInstance = e} />
 					{/key}
 					{#if canEdit}

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -296,10 +296,10 @@
 
 			// Capture the auto-edit intent — actual trigger lives in the
 			// $effect below so it can fire even if /me (which feeds canEdit)
-			// resolves AFTER loadData() finishes. One-shot.
-			if (page.url.searchParams.get('new') === '1') {
-				pendingNewItemEdit = true;
-			}
+			// resolves AFTER loadData() finishes. One-shot. Always reassign
+			// (true OR false) so a stale flag from a previous ?new=1 load
+			// can't fire on a subsequent non-new item load — Codex round 6.
+			pendingNewItemEdit = page.url.searchParams.get('new') === '1';
 		}
 	}
 

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -124,6 +124,11 @@
 	// by workspaceStore.setCurrent via the /me endpoint. workspaceMembers is
 	// still loaded for the assignee dropdown (line ~947).
 	let isOwner = $derived(workspaceStore.isOwner);
+	// Per-item edit predicate (PLAN-1100 / TASK-1105). Mirrors the server's
+	// ResolveUserPermission cascade: owner → item grant → collection grant
+	// → role + visibility. Drives title / content / FieldEditor / delete /
+	// status affordance gating below.
+	let canEdit = $derived(item ? workspaceStore.canEditItem(item) : false);
 	$effect(() => {
 		if (wsSlug && collSlug && itemSlug) {
 			loadData();
@@ -748,10 +753,13 @@
 					onkeydown={handleTitleKeydown}
 					oninput={(e) => autoResizeTitle(e.currentTarget)}
 				></textarea>
-			{:else}
+			{:else if canEdit}
 				<button class="title" onclick={startEditTitle}>
 					{item.title}
 				</button>
+			{:else}
+				<!-- Read-only title (PLAN-1100 / TASK-1105) — no click-to-edit. -->
+				<h1 class="title title-readonly">{item.title}</h1>
 			{/if}
 		</div>
 
@@ -836,20 +844,22 @@
 					Share
 				</button>
 			{/if}
-			{#if confirmDelete}
-				<span class="delete-confirm">
-					Delete this item?
-					<button class="delete-confirm-btn yes" disabled={deleting} onclick={handleDelete}>
-						{deleting ? '...' : 'Yes'}
+			{#if canEdit}
+				{#if confirmDelete}
+					<span class="delete-confirm">
+						Delete this item?
+						<button class="delete-confirm-btn yes" disabled={deleting} onclick={handleDelete}>
+							{deleting ? '...' : 'Yes'}
+						</button>
+						<button class="delete-confirm-btn no" onclick={() => { confirmDelete = false; }}>
+							No
+						</button>
+					</span>
+				{:else}
+					<button class="action-btn delete-btn" onclick={() => { confirmDelete = true; }}>
+						Delete
 					</button>
-					<button class="delete-confirm-btn no" onclick={() => { confirmDelete = false; }}>
-						No
-					</button>
-				</span>
-			{:else}
-				<button class="action-btn delete-btn" onclick={() => { confirmDelete = true; }}>
-					Delete
-				</button>
+				{/if}
 			{/if}
 		</div>
 
@@ -924,6 +934,7 @@
 									{field}
 									value={rawFieldValue}
 									onchange={(v) => updateField(field.key, v)}
+									readonly={!canEdit}
 								/>
 							</div>
 						</div>
@@ -938,19 +949,32 @@
 					<div class="field-row">
 						<span class="field-label">Assigned to</span>
 						<div class="field-value">
-							<select
-								class="assignment-select"
-								value={item.assigned_user_id ?? ''}
-								onchange={(e) => {
-									const val = (e.target as HTMLSelectElement).value;
-									updateAssignedUser(val || null);
-								}}
-							>
-								<option value="">Unassigned</option>
-								{#each workspaceMembers as member (member.user_id)}
-									<option value={member.user_id}>{member.user_name}</option>
-								{/each}
-							</select>
+							{#if canEdit}
+								<select
+									class="assignment-select"
+									value={item.assigned_user_id ?? ''}
+									onchange={(e) => {
+										const val = (e.target as HTMLSelectElement).value;
+										updateAssignedUser(val || null);
+									}}
+								>
+									<option value="">Unassigned</option>
+									{#each workspaceMembers as member (member.user_id)}
+										<option value={member.user_id}>{member.user_name}</option>
+									{/each}
+								</select>
+							{:else}
+								<!-- Read-only display (PLAN-1100 / TASK-1105). Assignment
+								     mutations go through api.items.update which is
+								     server-gated on edit permission. -->
+								<span class="assignment-readonly">
+									{#if item?.assigned_user_id}
+										{workspaceMembers.find(m => m.user_id === item!.assigned_user_id)?.user_name ?? '—'}
+									{:else}
+										Unassigned
+									{/if}
+								</span>
+							{/if}
 						</div>
 					</div>
 				{/if}
@@ -958,19 +982,30 @@
 					<div class="field-row">
 						<span class="field-label">Role</span>
 						<div class="field-value">
-							<select
-								class="assignment-select"
-								value={item.agent_role_id ?? ''}
-								onchange={(e) => {
-									const val = (e.target as HTMLSelectElement).value;
-									updateAgentRole(val || null);
-								}}
-							>
-								<option value="">No role</option>
-								{#each agentRoles as role (role.id)}
-									<option value={role.id}>{role.icon ? role.icon + ' ' : ''}{role.name}</option>
-								{/each}
-							</select>
+							{#if canEdit}
+								<select
+									class="assignment-select"
+									value={item.agent_role_id ?? ''}
+									onchange={(e) => {
+										const val = (e.target as HTMLSelectElement).value;
+										updateAgentRole(val || null);
+									}}
+								>
+									<option value="">No role</option>
+									{#each agentRoles as role (role.id)}
+										<option value={role.id}>{role.icon ? role.icon + ' ' : ''}{role.name}</option>
+									{/each}
+								</select>
+							{:else}
+								<span class="assignment-readonly">
+									{#if item?.agent_role_id}
+										{@const r = agentRoles.find(r => r.id === item!.agent_role_id)}
+										{r ? `${r.icon ? r.icon + ' ' : ''}${r.name}` : '—'}
+									{:else}
+										No role
+									{/if}
+								</span>
+							{/if}
 						</div>
 					</div>
 				{/if}
@@ -994,19 +1029,21 @@
 				</div>
 				{#if rawMode}
 					{#key item.id}
-						<RawMarkdownEditor content={item.content ?? ''} onUpdate={handleRawContentUpdate} />
+						<RawMarkdownEditor content={item.content ?? ''} onUpdate={handleRawContentUpdate} readonly={!canEdit} />
 					{/key}
 				{:else}
 					{#key item.id}
-						<Editor content={editorContent} onUpdate={handleContentUpdate} editable={true} onEditor={(e) => editorInstance = e} />
+						<Editor content={editorContent} onUpdate={handleContentUpdate} editable={canEdit} onEditor={(e) => editorInstance = e} />
 					{/key}
-					<EditorBubbleMenu
-						editor={editorInstance}
-						{wsSlug}
-						collections={collectionStore.collections}
-						onItemCreated={() => collectionStore.loadItems(wsSlug)}
-					/>
-					<EditorLinkPopover editor={editorInstance} />
+					{#if canEdit}
+						<EditorBubbleMenu
+							editor={editorInstance}
+							{wsSlug}
+							collections={collectionStore.collections}
+							onItemCreated={() => collectionStore.loadItems(wsSlug)}
+						/>
+						<EditorLinkPopover editor={editorInstance} />
+					{/if}
 				{/if}
 			</div>
 		</div>
@@ -1291,6 +1328,27 @@
 	}
 	.title:hover {
 		background: var(--bg-secondary);
+	}
+	/* Read-only title for users without canEditItem (PLAN-1100 / TASK-1105).
+	   Removes the click-to-edit affordance: no hover background, no
+	   text-cursor, default heading flow. */
+	.title-readonly {
+		cursor: default;
+		margin: 0;
+		font-weight: 700;
+	}
+	.title-readonly:hover {
+		background: none;
+	}
+	/* Assignment fallback display for read-only mode. Mirrors the height
+	   and padding of the live `.assignment-select` so the row doesn't
+	   reflow when the user gains/loses edit permission. */
+	.assignment-readonly {
+		display: inline-flex;
+		align-items: center;
+		min-height: 30px;
+		color: var(--text-primary);
+		font-size: 0.88em;
 	}
 	.title-input {
 		font-size: 1.6em;

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -294,16 +294,27 @@
 		} finally {
 			loading = false;
 
-			// Auto-start title editing for newly created items.
-			// Guarded on canEdit (PLAN-1100 / TASK-1105) so a read-only user
-			// can't trigger the title textarea by appending ?new=1.
-			if (page.url.searchParams.get('new') === '1' && item && canEdit) {
-				// Clean up the URL param first, then focus title after DOM settles
-				goto(`/${username}/${wsSlug}/${collSlug}/${itemSlug}`, { replaceState: true, noScroll: true });
-				await startEditTitle();
+			// Capture the auto-edit intent — actual trigger lives in the
+			// $effect below so it can fire even if /me (which feeds canEdit)
+			// resolves AFTER loadData() finishes. One-shot.
+			if (page.url.searchParams.get('new') === '1') {
+				pendingNewItemEdit = true;
 			}
 		}
 	}
+
+	// Handle the ?new=1 auto-edit-title flow reactively. canEdit may flip
+	// from false → true after loadData() resolves (workspace layout fires
+	// workspaceStore.setCurrent without awaiting it, so /me can land after
+	// the page mounts). Per Codex review round 5.
+	let pendingNewItemEdit = $state(false);
+	$effect(() => {
+		if (pendingNewItemEdit && item && canEdit && !loading) {
+			pendingNewItemEdit = false;
+			goto(`/${username}/${wsSlug}/${collSlug}/${itemSlug}`, { replaceState: true, noScroll: true });
+			startEditTitle();
+		}
+	});
 
 	async function startEditTitle() {
 		if (!item || !canEdit) return;

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -808,39 +808,41 @@
 			>
 				Timeline
 			</button>
-			<div class="move-wrapper">
-				<button class="action-btn" onclick={() => { showMoveMenu = !showMoveMenu; }} disabled={moving}>
-					{moving ? 'Moving...' : 'Move to...'}
-				</button>
-				{#snippet moveOptions()}
-					{#each moveTargets as target (target.slug)}
-						<button class="move-option" onclick={() => handleMove(target.slug)}>
-							{#if target.icon}<span class="move-icon">{target.icon}</span>{/if}
-							{target.name}
-						</button>
-					{/each}
-				{/snippet}
-				{#if isMobile && showMoveMenu}
-					<!--
-						Gate the mobile sheet on `showMoveMenu` so BottomSheet (and
-						its global keydown listener) isn't mounted when the menu is
-						closed. Same pattern fix as ReactionPicker.
-					-->
-					<BottomSheet
-						open={showMoveMenu}
-						onclose={() => (showMoveMenu = false)}
-						title="Move to…"
-					>
-						<div class="move-sheet-body">
+			{#if canEdit}
+				<div class="move-wrapper">
+					<button class="action-btn" onclick={() => { showMoveMenu = !showMoveMenu; }} disabled={moving}>
+						{moving ? 'Moving...' : 'Move to...'}
+					</button>
+					{#snippet moveOptions()}
+						{#each moveTargets as target (target.slug)}
+							<button class="move-option" onclick={() => handleMove(target.slug)}>
+								{#if target.icon}<span class="move-icon">{target.icon}</span>{/if}
+								{target.name}
+							</button>
+						{/each}
+					{/snippet}
+					{#if isMobile && showMoveMenu}
+						<!--
+							Gate the mobile sheet on `showMoveMenu` so BottomSheet (and
+							its global keydown listener) isn't mounted when the menu is
+							closed. Same pattern fix as ReactionPicker.
+						-->
+						<BottomSheet
+							open={showMoveMenu}
+							onclose={() => (showMoveMenu = false)}
+							title="Move to…"
+						>
+							<div class="move-sheet-body">
+								{@render moveOptions()}
+							</div>
+						</BottomSheet>
+					{:else if showMoveMenu}
+						<div class="move-dropdown">
 							{@render moveOptions()}
 						</div>
-					</BottomSheet>
-				{:else if showMoveMenu}
-					<div class="move-dropdown">
-						{@render moveOptions()}
-					</div>
-				{/if}
-			</div>
+					{/if}
+				</div>
+			{/if}
 			{#if isOwner}
 				<button class="action-btn" onclick={() => { shareDialogOpen = true; }}>
 					Share
@@ -1072,7 +1074,7 @@
 											{#if entry.status}
 												<span class="link-status">{formatFieldDisplay(entry.status)}</span>
 											{/if}
-											{#if entry.linkId}
+											{#if entry.linkId && canEdit}
 												<button class="link-delete-btn" title="Remove relationship" onclick={() => handleDeleteLink(entry.linkId)}>×</button>
 											{/if}
 										</span>
@@ -1085,8 +1087,8 @@
 			</div>
 		{/if}
 
-		<!-- Add Relationship -->
-		{#if item}
+		<!-- Add Relationship — gated on canEdit (PLAN-1100 / TASK-1105). -->
+		{#if item && canEdit}
 			<div class="add-relationship-section">
 				{#if !showAddLink}
 					<button class="add-relationship-btn" onclick={() => { showAddLink = true; }}>


### PR DESCRIPTION
## Summary

Item detail page hides title-edit, content editor, FieldEditor inputs, delete button, and assignment dropdowns when the user lacks edit on this specific item.

Per-item gate via \`workspaceStore.canEditItem(item)\` — handles guests with single \`ItemGrant.edit\` (full edit on that one item, read-only on siblings) and the precedence regression where \`ItemGrant.view\` + \`CollectionGrant.edit\` on the same item resolves to read-only.

- FieldEditor: new \`readonly\` prop with display-only branches per field type.
- RawMarkdownEditor: new \`readonly\` prop on the underlying textarea.
- Editor: \`editable={canEdit}\`; EditorBubbleMenu / EditorLinkPopover only mount when editable.
- Title: read-only h1 when \`!canEdit\`.
- Assignment + role dropdowns: swap to read-only display spans.

## Context

Implements \`TASK-1105\` under \`PLAN-1100\`.

## Test plan

- [x] make check clean (svelte-check 0 errors)
- [ ] Manual three-role smoke test deferred to HT-1157