### PR TITLE
feat(comments): gate composer/replies/reactions/delete on canEditItem (TASK-1107)

### DIFF
--- a/web/src/lib/components/timeline/ItemTimeline.svelte
+++ b/web/src/lib/components/timeline/ItemTimeline.svelte
@@ -3,6 +3,7 @@
 	import { api } from '$lib/api/client';
 	import { sseService } from '$lib/services/sse.svelte';
 	import { authStore } from '$lib/stores/auth.svelte';
+	import { workspaceStore } from '$lib/stores/workspace.svelte';
 	import type { TimelineEntry, TimelineResponse, Item } from '$lib/types';
 	import TimelineCommentCard from './TimelineCommentCard.svelte';
 	import TimelineActivityCard from './TimelineActivityCard.svelte';
@@ -14,9 +15,26 @@
 		currentContent: string;
 		items?: Item[];
 		onRestore?: (item: Item) => void;
+		/**
+		 * itemId + collectionId let the timeline answer
+		 * `workspaceStore.canEditItem(...)` for write-affordance gating.
+		 * Optional — when missing, the composer / reply / reaction / delete
+		 * controls fall back to "no edit" (PLAN-1100 / TASK-1107). The slug
+		 * page already has the full item, so always passes both.
+		 */
+		itemId?: string;
+		collectionId?: string;
 	}
 
-	let { wsSlug, itemSlug, currentContent, items = [], onRestore }: Props = $props();
+	let { wsSlug, itemSlug, currentContent, items = [], onRestore, itemId, collectionId }: Props = $props();
+
+	// Resolve canEditItem reactively; falls to false if itemId/collectionId
+	// aren't supplied (e.g. an older caller).
+	let canEdit = $derived(
+		itemId && collectionId
+			? workspaceStore.canEditItem({ id: itemId, collection_id: collectionId })
+			: false
+	);
 
 	let entries: TimelineEntry[] = $state([]);
 	let hasMore: boolean = $state(false);
@@ -208,27 +226,31 @@
 		{/if}
 	</header>
 
-	<!-- Comment compose -->
-	<div class="compose">
-		<textarea
-			class="compose-input"
-			placeholder="Write a comment..."
-			bind:value={newBody}
-			onkeydown={handleKeydown}
-			disabled={submitting}
-		></textarea>
-		<div class="compose-actions">
-			<span class="shortcut-hint">Ctrl+Enter to submit</span>
-			<button
-				class="submit-btn"
-				type="button"
-				disabled={!newBody.trim() || submitting}
-				onclick={submitComment}
-			>
-				{submitting ? 'Posting...' : 'Comment'}
-			</button>
+	<!-- Comment compose — gated on canEditItem (PLAN-1100 / TASK-1107).
+	     Read-only viewers / guests with view-only grants see the timeline
+	     thread but cannot post; the composer is hidden entirely. -->
+	{#if canEdit}
+		<div class="compose">
+			<textarea
+				class="compose-input"
+				placeholder="Write a comment..."
+				bind:value={newBody}
+				onkeydown={handleKeydown}
+				disabled={submitting}
+			></textarea>
+			<div class="compose-actions">
+				<span class="shortcut-hint">Ctrl+Enter to submit</span>
+				<button
+					class="submit-btn"
+					type="button"
+					disabled={!newBody.trim() || submitting}
+					onclick={submitComment}
+				>
+					{submitting ? 'Posting...' : 'Comment'}
+				</button>
+			</div>
 		</div>
-	</div>
+	{/if}
 
 	{#if loading && entries.length === 0}
 		<div class="loading">
@@ -256,6 +278,7 @@
 								{wsSlug}
 								{items}
 								{currentUserId}
+								{canEdit}
 								onDelete={handleDelete}
 								onReply={handleReply}
 								onReaction={handleReaction}

--- a/web/src/lib/components/timeline/TimelineCommentCard.svelte
+++ b/web/src/lib/components/timeline/TimelineCommentCard.svelte
@@ -9,13 +9,22 @@
 		username?: string;
 		items: Item[];
 		currentUserId?: string;
+		/**
+		 * canEdit gates write affordances on this comment: reply button,
+		 * reaction picker / per-reaction toggle, and delete (PLAN-1100 /
+		 * TASK-1107). Existing reactions still render with counts so
+		 * read-only viewers see who reacted; they just can't react
+		 * themselves. Default true preserves behavior in callers that
+		 * don't pass it.
+		 */
+		canEdit?: boolean;
 		onDelete: (commentId: string) => void;
 		onReply: (commentId: string, body: string) => void | Promise<void>;
 		onReaction: (commentId: string, emoji: string) => void;
 		onRemoveReaction: (commentId: string, emoji: string) => void;
 	}
 
-	let { comment, wsSlug, username = '', items, currentUserId = '', onDelete, onReply, onReaction, onRemoveReaction }: Props = $props();
+	let { comment, wsSlug, username = '', items, currentUserId = '', canEdit = true, onDelete, onReply, onReaction, onRemoveReaction }: Props = $props();
 
 	let showReplyForm = $state(false);
 	let replyBody = $state('');
@@ -131,17 +140,19 @@
 		<span class="source-badge">{getSourceLabel(comment.source)}</span>
 		<span class="spacer"></span>
 		<span class="timestamp" title={new Date(comment.created_at).toLocaleString()}>{relativeTime(comment.created_at)}</span>
-		<button
-			class="delete-btn"
-			type="button"
-			onclick={() => onDelete(comment.id)}
-			title="Delete comment"
-		>
-			<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-				<polyline points="3 6 5 6 21 6" />
-				<path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
-			</svg>
-		</button>
+		{#if canEdit}
+			<button
+				class="delete-btn"
+				type="button"
+				onclick={() => onDelete(comment.id)}
+				title="Delete comment"
+			>
+				<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+					<polyline points="3 6 5 6 21 6" />
+					<path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+				</svg>
+			</button>
+		{/if}
 	</div>
 
 	{#if comment.activity_id}
@@ -153,6 +164,11 @@
 	</div>
 
 	<div class="comment-footer">
+		<!--
+			Existing reactions render with counts for everyone (read-only
+			viewers see who reacted). The toggle / picker are gated on
+			canEdit (PLAN-1100 / TASK-1107) — viewers cannot react.
+		-->
 		<div class="reactions-row">
 				{#each reactionGroups as group (group.emoji)}
 					<button
@@ -160,20 +176,25 @@
 						class:mine={hasMyReaction(comment.reactions, group.emoji)}
 						type="button"
 						title={group.actors.join(', ')}
-						onclick={() => toggleReaction(group.emoji)}
+						disabled={!canEdit}
+						onclick={canEdit ? () => toggleReaction(group.emoji) : undefined}
 					>
 						<span class="reaction-emoji">{group.emoji}</span>
 						<span class="reaction-count">{group.count}</span>
 					</button>
 				{/each}
-				<ReactionPicker onSelect={handleAddReaction} />
+				{#if canEdit}
+					<ReactionPicker onSelect={handleAddReaction} />
+				{/if}
 		</div>
-		<button class="reply-btn" type="button" onclick={() => { showReplyForm = !showReplyForm; }}>
-			Reply
-		</button>
+		{#if canEdit}
+			<button class="reply-btn" type="button" onclick={() => { showReplyForm = !showReplyForm; }}>
+				Reply
+			</button>
+		{/if}
 	</div>
 
-	{#if showReplyForm}
+	{#if showReplyForm && canEdit}
 		<div class="reply-compose">
 			<textarea
 				class="reply-input"
@@ -206,17 +227,19 @@
 						{/if}
 						<span class="spacer"></span>
 						<span class="timestamp" title={new Date(reply.created_at).toLocaleString()}>{relativeTime(reply.created_at)}</span>
-						<button
-							class="delete-btn"
-							type="button"
-							onclick={() => onDelete(reply.id)}
-							title="Delete reply"
-						>
-							<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-								<polyline points="3 6 5 6 21 6" />
-								<path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
-							</svg>
-						</button>
+						{#if canEdit}
+							<button
+								class="delete-btn"
+								type="button"
+								onclick={() => onDelete(reply.id)}
+								title="Delete reply"
+							>
+								<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+									<polyline points="3 6 5 6 21 6" />
+									<path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+								</svg>
+							</button>
+						{/if}
 					</div>
 
 					<div class="reply-body prose">
@@ -230,13 +253,16 @@
 									class:mine={hasMyReaction(reply.reactions, group.emoji)}
 									type="button"
 									title={group.actors.join(', ')}
-									onclick={() => toggleReplyReaction(reply, group.emoji)}
+									disabled={!canEdit}
+									onclick={canEdit ? () => toggleReplyReaction(reply, group.emoji) : undefined}
 								>
 									<span class="reaction-emoji">{group.emoji}</span>
 									<span class="reaction-count">{group.count}</span>
 								</button>
 							{/each}
-							<ReactionPicker onSelect={(emoji) => handleAddReplyReaction(reply, emoji)} />
+							{#if canEdit}
+								<ReactionPicker onSelect={(emoji) => handleAddReplyReaction(reply, emoji)} />
+							{/if}
 						</div>
 				</div>
 			{/each}

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -1170,6 +1170,8 @@
 				currentContent={item.content ?? ''}
 				items={collectionStore.items ?? []}
 				onRestore={handleVersionRestore}
+				itemId={item.id}
+				collectionId={item.collection_id}
 			/>
 		</div>
 


### PR DESCRIPTION
## Summary

Comment timeline gates composer, reply, reaction picker/toggle, and delete on \`canEditItem\`. Existing reactions still render with counts so read-only viewers see who reacted — they just can't react themselves.

## Note on file paths

TASK-1107's original spec referenced \`CommentThread.svelte\`, but that file is unused. The real comment UI lives in \`ItemTimeline.svelte\` + \`TimelineCommentCard.svelte\`. PLAN-1100 was updated to reflect this earlier in the audit.

## Context

Implements \`TASK-1107\` under \`PLAN-1100\`.

## Test plan

- [x] make check clean
- [ ] Manual three-role smoke test deferred to HT-1157