### PR TITLE
fix(layout): let Cmd+F fall through to browser-native find on item views (BUG-986)

### DIFF
--- a/web/src/lib/stores/ui.svelte.ts
+++ b/web/src/lib/stores/ui.svelte.ts
@@ -9,7 +9,7 @@ let detailPanelOpen = $state(browser ? localStorage.getItem('pad-detail-panel') 
 let createWorkspaceOpen = $state(false);
 let quickAddRequested = $state(false);
 let quickAddTargetSlug = $state<string | null>(null);
-let collectionSearchRequested = $state(false);
+let collectionSearchHandler = $state<(() => void) | null>(null);
 
 if (browser) {
 	window.addEventListener('resize', () => {
@@ -77,10 +77,15 @@ export const uiStore = {
 	requestQuickAdd(collectionSlug?: string) { quickAddTargetSlug = collectionSlug ?? null; quickAddRequested = true; },
 	clearQuickAddRequest() { quickAddRequested = false; quickAddTargetSlug = null; },
 
-	// Collection search (Cmd+F) trigger — collection page watches this
-	get collectionSearchRequested() { return collectionSearchRequested; },
-	requestCollectionSearch() { collectionSearchRequested = true; },
-	clearCollectionSearchRequest() { collectionSearchRequested = false; },
+	// Collection search (Cmd+F) registry — pages that want to handle Cmd+F
+	// register a handler on mount and unregister on destroy. The layout's
+	// global keydown handler only calls preventDefault when a handler is
+	// registered, so on pages without one (e.g. item view) Cmd+F falls
+	// through to the browser's native find. (BUG-986)
+	get hasCollectionSearchHandler() { return collectionSearchHandler !== null; },
+	triggerCollectionSearch() { collectionSearchHandler?.(); },
+	registerCollectionSearch(handler: () => void) { collectionSearchHandler = handler; },
+	unregisterCollectionSearch() { collectionSearchHandler = null; },
 
 	/** Close sidebar on mobile after navigation */
 	onNavigate() {

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -131,8 +131,14 @@
 			return;
 		}
 		if (isMod(e) && e.key === 'f') {
-			e.preventDefault();
-			uiStore.requestCollectionSearch();
+			// Only intercept Cmd+F if a page has registered a handler (e.g. the
+			// collection list page opens its filter search). On other pages —
+			// notably item/document views — let it fall through to the browser's
+			// native find so users can search the document contents. (BUG-986)
+			if (uiStore.hasCollectionSearchHandler) {
+				e.preventDefault();
+				uiStore.triggerCollectionSearch();
+			}
 			return;
 		}
 		if (e.key === '?' && !isInputFocused()) {

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -788,15 +788,18 @@
 		focusedIndex = -1;
 	});
 
-	// Watch for Cmd+F signal from layout
+	// Register a Cmd+F handler with the layout while this page is mounted.
+	// The layout only intercepts Cmd+F when a handler is registered, so on
+	// pages without one (e.g. item view) it falls through to browser-native
+	// find. (BUG-986)
 	$effect(() => {
-		if (uiStore.collectionSearchRequested) {
-			uiStore.clearCollectionSearchRequest();
+		uiStore.registerCollectionSearch(() => {
 			if (!filtersOpen) {
 				filtersOpen = true;
 			}
 			requestAnimationFrame(() => searchInputEl?.focus());
-		}
+		});
+		return () => uiStore.unregisterCollectionSearch();
 	});
 
 	function handlePageKeydown(e: KeyboardEvent) {


### PR DESCRIPTION
## Summary

Fixes **BUG-986** — Cmd+F was being intercepted globally and routed through a flag the collection list page polled, but on item/document views nothing watched the flag while `e.preventDefault()` had already blocked the browser's native find. Users had no way to search inside a doc.

Inverted the model from "always intercept, broadcast a flag" to "only intercept when a page registers a handler":

- `web/src/lib/stores/ui.svelte.ts` — replaced the `collectionSearchRequested` boolean flag with a `collectionSearchHandler` registry (`registerCollectionSearch` / `unregisterCollectionSearch` / `triggerCollectionSearch` / `hasCollectionSearchHandler`).
- `web/src/routes/+layout.svelte` — Cmd+F only calls `e.preventDefault()` and dispatches when `uiStore.hasCollectionSearchHandler` is true; otherwise it falls through to the browser.
- `web/src/routes/[username]/[workspace]/[collection]/+page.svelte` — registers the existing filters-open + focus-search behaviour in an `$effect` and unregisters it via the effect cleanup so it's only active while the page is mounted.

**Result:**
- Collection list view: Cmd+F still opens the filter search (unchanged).
- Item / document view: Cmd+F falls through to browser-native find — document contents are searchable again.
- Other pages (dashboard, settings, etc.): also fall through (side benefit).

## Codex review

CLEAN on round 1 (per CONVE-735) — Codex inspected all three changed files plus surrounding context, ran `npm run check` itself (0 errors), and returned no findings.

## Test plan

- [ ] Collection list (e.g. Tasks): Cmd+F opens the filter search bar (unchanged).
- [ ] Item view (e.g. BUG-986): Cmd+F opens the browser's native find bar and searches the document content.
- [ ] Navigate back to the collection list: Cmd+F still opens the filter search (handler re-registered on mount).
- [ ] Dashboard / settings / other pages: Cmd+F falls through to browser-native find.
- [ ] `make check` passes locally (Go tests, lint, web build, svelte-check 0 errors). ✓