### PR TITLE
feat(auth): first-run logs-token bootstrap flow (TASK-1167)

### DIFF
--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -685,6 +685,37 @@ func serveCmd() *cobra.Command {
 				}
 			}
 
+			// First-run bootstrap token (TASK-1167 / PLAN-1166).
+			//
+			// Three branches by current state:
+			//
+			//   1. UserCount > 0 → mop up any stale token file left by a
+			//      previous successful bootstrap whose os.Remove somehow
+			//      failed (D4). No banner.
+			//   2. UserCount == 0 + self-host → ensure a token exists,
+			//      load it into the server, log the banner so the
+			//      operator can grab it from `docker logs`. Failures are
+			//      WARN-and-continue (D7) — never abort startup.
+			//   3. UserCount == 0 + cloud mode → no-op (D10). Cloud
+			//      bootstrap stays loopback-only.
+			if userCount, ucErr := s.UserCount(); ucErr != nil {
+				slog.Warn("could not check user count for bootstrap token wiring", "error", ucErr)
+			} else if userCount > 0 {
+				if cleanupErr := server.CleanupStaleBootstrapToken(cfg.DataDir); cleanupErr != nil {
+					slog.Warn("stale bootstrap token cleanup failed", "error", cleanupErr)
+				}
+			} else if !cfg.IsCloudServer() {
+				token, tokenPath, terr := server.EnsureBootstrapToken(cfg.DataDir)
+				if terr != nil {
+					slog.Warn("first-run bootstrap token unavailable; falling back to loopback-only setup",
+						"error", terr,
+						"hint", "operator can run `pad auth setup` from inside the container")
+				} else {
+					srv.SetBootstrapToken(token, tokenPath)
+					logBootstrapBanner(token, cfg, tokenPath)
+				}
+			}
+
 			// Graceful shutdown: listen for SIGINT/SIGTERM
 			ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 			defer stop()
@@ -729,6 +760,46 @@ func serveCmd() *cobra.Command {
 	cmd.Flags().IntVar(&port, "port", 7777, "port to listen on")
 
 	return cmd
+}
+
+// logBootstrapBanner emits a single multi-line INFO log entry pointing the
+// operator at the /setup#token=<x> URL they need to visit to claim the
+// first admin. The banner is greppable by "Pad first-run setup" so log
+// aggregators can surface it. Token is in a URL fragment (#token=) so it
+// is never transmitted to the server in HTTP requests — only the
+// browser sees it. The frontend strips it from the URL via
+// history.replaceState on mount and submits via the X-Bootstrap-Token
+// header.
+//
+// See TASK-1167 / PLAN-1166. Called only on first start with zero
+// users in self-host mode.
+func logBootstrapBanner(token string, cfg *config.Config, tokenPath string) {
+	host := cfg.Host
+	switch host {
+	case "", "0.0.0.0", "::", "[::]":
+		// PAD_HOST not bound to a specific interface — render as
+		// <your-host> placeholder in the banner since we don't know
+		// which network interface the operator wants to reach this
+		// instance from.
+		host = "<your-host>"
+	}
+	url := fmt.Sprintf("http://%s:%d/setup#token=%s", host, cfg.Port, token)
+	banner := fmt.Sprintf(`
+========================================================================
+  Pad first-run setup
+========================================================================
+
+  No users exist yet. To create the first admin account, visit:
+
+      %s
+
+  This token is one-time. After the first admin is created the token
+  is consumed and this banner stops appearing.
+
+  To regenerate, delete %s and restart.
+
+========================================================================`, url, tokenPath)
+	slog.Info(banner)
 }
 
 // --- stop ---

--- a/internal/server/bootstrap.go
+++ b/internal/server/bootstrap.go
@@ -1,0 +1,203 @@
+package server
+
+// First-run bootstrap token (TASK-1167 / PLAN-1166).
+//
+// Pad's POST /api/v1/auth/bootstrap is loopback-gated by default — see
+// requestIsLoopback in handlers_auth.go. That works fine for local installs
+// and `docker exec`, but fails the homelab UX: in a container, "loopback"
+// is inside the container, so a user pointing their browser at
+// http://<unraid-host>:7777/setup can never claim the first admin.
+//
+// This file implements the logs-token escape hatch: on first start with no
+// users in self-host mode (cloud mode is excluded — D10), the server
+// generates a one-time token, persists it to <DataDir>/.bootstrap-token
+// (mode 0600), and logs it in a banner the operator can grab from
+// `docker logs`. The token is required via the X-Bootstrap-Token header
+// (header-only, never query — F6) and bypasses the loopback gate iff
+// !cloudMode. After the first admin is successfully created the token is
+// consumed (in-memory cleared + file deleted).
+//
+// Concurrency: handleBootstrap takes s.bootstrapMu for the entire
+// validate-token → check-UserCount → CreateUser → consume sequence (F5).
+// Two simultaneous valid-token requests with different emails would
+// otherwise create two admins from one token; the mutex serializes them
+// so only the first wins.
+
+import (
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// bootstrapTokenFilename is the on-disk filename within DataDir.
+const bootstrapTokenFilename = ".bootstrap-token"
+
+// BootstrapTokenHeader is the HTTP header carrying the token. POST
+// /api/v1/auth/bootstrap accepts the token via this header only — never
+// via a query parameter — to keep it out of access logs and proxy/CDN
+// records (F6 / D9).
+const BootstrapTokenHeader = "X-Bootstrap-Token"
+
+// BootstrapTokenPath returns the on-disk path for the bootstrap token file.
+func BootstrapTokenPath(dataDir string) string {
+	return filepath.Join(dataDir, bootstrapTokenFilename)
+}
+
+// EnsureBootstrapToken generates a fresh first-run bootstrap token (or
+// loads the existing one if a valid file is already present). Returns
+// the token string + the absolute path it was written to. Caller wires
+// both into the Server via SetBootstrapToken.
+//
+// Generation uses the same atomic-create-via-temp+hardlink pattern as
+// EnsureEncryptionKey in internal/config/config.go so two simultaneous
+// startups can't clobber each other's file.
+//
+// On failure (read-only data dir, permission denied, etc.) the caller
+// should treat this as non-fatal (D7) — log a warning, continue with
+// no token. The user falls back to the loopback-only bootstrap path
+// (`docker exec pad pad auth setup`).
+func EnsureBootstrapToken(dataDir string) (token, path string, err error) {
+	tokenPath := BootstrapTokenPath(dataDir)
+
+	// File exists: load. Reject world/group permissions so an operator
+	// who cat'd the token to /tmp doesn't accidentally hand it to other
+	// local users (security parity with encryption.key).
+	if info, statErr := os.Stat(tokenPath); statErr == nil {
+		if runtime.GOOS != "windows" && info.Mode().Perm()&0077 != 0 {
+			return "", tokenPath, fmt.Errorf("bootstrap token %s has mode %o (group/other bits set); run `chmod 600 %s` to restrict",
+				tokenPath, info.Mode().Perm(), tokenPath)
+		}
+		data, rerr := os.ReadFile(tokenPath)
+		if rerr != nil {
+			return "", tokenPath, fmt.Errorf("read bootstrap token: %w", rerr)
+		}
+		t := strings.TrimSpace(string(data))
+		if t == "" {
+			return "", tokenPath, fmt.Errorf("bootstrap token file %s is empty; delete it to regenerate", tokenPath)
+		}
+		return t, tokenPath, nil
+	} else if !errors.Is(statErr, os.ErrNotExist) {
+		return "", tokenPath, fmt.Errorf("stat bootstrap token: %w", statErr)
+	}
+
+	// Tighten DataDir before dropping the token in.
+	if mkErr := os.MkdirAll(dataDir, 0700); mkErr != nil {
+		return "", tokenPath, fmt.Errorf("create data dir for bootstrap token: %w", mkErr)
+	}
+
+	// 32 bytes from crypto/rand → base64url, no padding (~43 chars).
+	raw := make([]byte, 32)
+	if _, rerr := rand.Read(raw); rerr != nil {
+		return "", tokenPath, fmt.Errorf("generate bootstrap token: %w", rerr)
+	}
+	t := base64.RawURLEncoding.EncodeToString(raw)
+
+	// Atomic temp+hardlink — see EnsureEncryptionKey for the rationale.
+	tmpSuffix := make([]byte, 8)
+	if _, rerr := rand.Read(tmpSuffix); rerr != nil {
+		return "", tokenPath, fmt.Errorf("generate bootstrap token temp suffix: %w", rerr)
+	}
+	tmpPath := tokenPath + ".tmp." + base64.RawURLEncoding.EncodeToString(tmpSuffix)
+	if werr := os.WriteFile(tmpPath, []byte(t+"\n"), 0600); werr != nil {
+		return "", tokenPath, fmt.Errorf("write bootstrap token temp: %w", werr)
+	}
+	defer os.Remove(tmpPath) // best-effort cleanup; harmless on the winning path
+
+	if lerr := os.Link(tmpPath, tokenPath); lerr != nil {
+		if errors.Is(lerr, os.ErrExist) {
+			// Lost a race against a sibling startup. Read the winner's token.
+			data, rerr := os.ReadFile(tokenPath)
+			if rerr != nil {
+				return "", tokenPath, fmt.Errorf("reload bootstrap token after race: %w", rerr)
+			}
+			return strings.TrimSpace(string(data)), tokenPath, nil
+		}
+		return "", tokenPath, fmt.Errorf("link bootstrap token to %s: %w", tokenPath, lerr)
+	}
+
+	return t, tokenPath, nil
+}
+
+// CleanupStaleBootstrapToken removes a token file left behind by a previous
+// run that completed bootstrap but failed to delete the file. Called at
+// startup when UserCount > 0 (D4). Best-effort; silently ignores
+// not-found.
+func CleanupStaleBootstrapToken(dataDir string) error {
+	err := os.Remove(BootstrapTokenPath(dataDir))
+	if err != nil && errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	return err
+}
+
+// SetBootstrapToken wires the in-memory token + on-disk path into the
+// Server. Called once at startup from cmd/pad/main.go after
+// EnsureBootstrapToken succeeds. Empty token is allowed (means: no
+// token configured — used when EnsureBootstrapToken failed or when the
+// instance is in cloud mode).
+func (s *Server) SetBootstrapToken(token, path string) {
+	s.bootstrapMu.Lock()
+	defer s.bootstrapMu.Unlock()
+	s.bootstrapToken = token
+	s.bootstrapTokenPath = path
+}
+
+// hasBootstrapToken reports whether a bootstrap token is currently
+// configured. Lock-aware — safe to call without holding s.bootstrapMu.
+// Used by handleSessionCheck to decide whether to advertise
+// setup_method=logs_token.
+func (s *Server) hasBootstrapToken() bool {
+	s.bootstrapMu.Lock()
+	defer s.bootstrapMu.Unlock()
+	return s.bootstrapToken != ""
+}
+
+// checkBootstrapToken validates the X-Bootstrap-Token header on r against
+// the in-memory token using a constant-time comparison. Returns false if
+// no token is configured or the header is missing/wrong.
+//
+// Caller MUST hold s.bootstrapMu — handleBootstrap takes the lock for
+// the entire validate-token → check-UserCount → CreateUser → consume
+// sequence (F5).
+func (s *Server) checkBootstrapToken(r *http.Request) bool {
+	if s.bootstrapToken == "" {
+		return false
+	}
+	provided := r.Header.Get(BootstrapTokenHeader)
+	if provided == "" {
+		return false
+	}
+	// Use constant-time comparison so the response time can't leak
+	// per-character feedback to an attacker grinding through guesses.
+	return subtle.ConstantTimeCompare([]byte(provided), []byte(s.bootstrapToken)) == 1
+}
+
+// consumeBootstrapToken clears the in-memory token and deletes the on-disk
+// file. Called after the first admin is successfully created.
+//
+// Caller MUST hold s.bootstrapMu.
+//
+// File-removal failure is logged by the caller (we return the error) but
+// the in-memory token is cleared regardless — once consumption starts the
+// token is "spent" from the server's perspective even if the rm syscall
+// fails (defense-in-depth: a stale file with a no-longer-accepted token
+// is harmless; the next startup's CleanupStaleBootstrapToken call mops it
+// up).
+func (s *Server) consumeBootstrapToken() error {
+	s.bootstrapToken = ""
+	if s.bootstrapTokenPath == "" {
+		return nil
+	}
+	err := os.Remove(s.bootstrapTokenPath)
+	if err != nil && errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	return err
+}

--- a/internal/server/bootstrap_test.go
+++ b/internal/server/bootstrap_test.go
@@ -1,0 +1,279 @@
+package server
+
+import (
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// TestEnsureBootstrapToken_GeneratesAndPersists verifies a fresh data
+// directory yields a freshly-generated token written with mode 0600 in
+// the expected on-disk location.
+func TestEnsureBootstrapToken_GeneratesAndPersists(t *testing.T) {
+	dir := t.TempDir()
+	token, path, err := EnsureBootstrapToken(dir)
+	if err != nil {
+		t.Fatalf("EnsureBootstrapToken: %v", err)
+	}
+	if token == "" {
+		t.Fatal("token is empty")
+	}
+	// 32 bytes base64url-no-padding ≈ 43 chars. Allow a little wiggle
+	// for any future encoding tweak but reject anything obviously short.
+	if len(token) < 40 {
+		t.Fatalf("token length = %d, want >= 40 (32 bytes base64url-no-padding)", len(token))
+	}
+	if path != filepath.Join(dir, ".bootstrap-token") {
+		t.Fatalf("path = %q, want %q", path, filepath.Join(dir, ".bootstrap-token"))
+	}
+
+	// File exists, mode 0600.
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat token file: %v", err)
+	}
+	if runtime.GOOS != "windows" {
+		if got := info.Mode().Perm(); got != 0600 {
+			t.Fatalf("token file mode = %o, want 0600", got)
+		}
+	}
+
+	// File contents match returned token (with a trailing newline; the
+	// loader trims it).
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read token file: %v", err)
+	}
+	if got := strings.TrimSpace(string(data)); got != token {
+		t.Fatalf("file contents = %q, want %q", got, token)
+	}
+}
+
+// TestEnsureBootstrapToken_LoadsExisting verifies a second call against
+// the same data directory returns the same token (D1: persists across
+// restarts; do not regenerate).
+func TestEnsureBootstrapToken_LoadsExisting(t *testing.T) {
+	dir := t.TempDir()
+	first, _, err := EnsureBootstrapToken(dir)
+	if err != nil {
+		t.Fatalf("first ensure: %v", err)
+	}
+	second, _, err := EnsureBootstrapToken(dir)
+	if err != nil {
+		t.Fatalf("second ensure: %v", err)
+	}
+	if first != second {
+		t.Fatalf("token regenerated across calls: %q vs %q", first, second)
+	}
+}
+
+// TestEnsureBootstrapToken_RejectsOverlyPermissiveFile mirrors the
+// EnsureEncryptionKey check — an operator who accidentally chmods the
+// token file 0644 hands the secret to other local users on a multi-user
+// host, which defeats the whole point of the file-system gate.
+func TestEnsureBootstrapToken_RejectsOverlyPermissiveFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission bits are POSIX-only")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".bootstrap-token")
+	if err := os.WriteFile(path, []byte("hand-seeded-token\n"), 0644); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+
+	_, _, err := EnsureBootstrapToken(dir)
+	if err == nil {
+		t.Fatal("expected error for 0644 token file, got nil")
+	}
+	// The error formats the mode as %o ("644"), not %04o ("0644"). Match
+	// what's actually emitted so the test pins the user-facing message.
+	if !strings.Contains(err.Error(), "mode 644") || !strings.Contains(err.Error(), "chmod 600") {
+		t.Fatalf("error = %q, want it to mention the bad mode and the chmod fix", err.Error())
+	}
+}
+
+// TestEnsureBootstrapToken_EmptyFileIsAnError protects against a partially-
+// created token file being silently treated as valid (which would leave
+// any X-Bootstrap-Token: "" request matching).
+func TestEnsureBootstrapToken_EmptyFileIsAnError(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".bootstrap-token")
+	if err := os.WriteFile(path, []byte(""), 0600); err != nil {
+		t.Fatalf("seed empty file: %v", err)
+	}
+	_, _, err := EnsureBootstrapToken(dir)
+	if err == nil {
+		t.Fatal("expected error for empty token file, got nil")
+	}
+	if !strings.Contains(err.Error(), "empty") {
+		t.Fatalf("error = %q, want it to mention the file is empty", err.Error())
+	}
+}
+
+// TestEnsureBootstrapToken_ReadOnlyDataDir verifies D7: failure to persist
+// is reported as an error (caller treats it as non-fatal at startup).
+// Server must NOT abort startup over this — the caller's responsibility
+// is to log a warning and proceed with no token.
+func TestEnsureBootstrapToken_ReadOnlyDataDir(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission bits are POSIX-only")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("running as root bypasses the read-only check")
+	}
+	parent := t.TempDir()
+	dir := filepath.Join(parent, "data")
+	if err := os.Mkdir(dir, 0500); err != nil {
+		t.Fatalf("mkdir read-only: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0700) }) // allow t.TempDir cleanup
+
+	_, _, err := EnsureBootstrapToken(dir)
+	if err == nil {
+		t.Fatal("expected error on read-only data dir, got nil")
+	}
+}
+
+// TestEnsureBootstrapToken_ConcurrentRace ensures the temp+hardlink
+// pattern protects against two simultaneous startups racing on the same
+// data directory. Both should converge on identical tokens — the loser
+// reads the winner's fully-written file.
+func TestEnsureBootstrapToken_ConcurrentRace(t *testing.T) {
+	dir := t.TempDir()
+	const N = 8
+
+	tokens := make([]string, N)
+	errs := make([]error, N)
+	var wg sync.WaitGroup
+	wg.Add(N)
+	for i := 0; i < N; i++ {
+		go func(idx int) {
+			defer wg.Done()
+			tok, _, err := EnsureBootstrapToken(dir)
+			tokens[idx] = tok
+			errs[idx] = err
+		}(i)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("goroutine %d: %v", i, err)
+		}
+	}
+	for i := 1; i < N; i++ {
+		if tokens[i] != tokens[0] {
+			t.Fatalf("goroutine %d got %q, want %q (winner)", i, tokens[i], tokens[0])
+		}
+	}
+}
+
+// TestCleanupStaleBootstrapToken covers the D4 path: a token file left
+// behind by a previous successful bootstrap whose `os.Remove` somehow
+// failed. Startup with UserCount > 0 is supposed to mop it up.
+func TestCleanupStaleBootstrapToken(t *testing.T) {
+	dir := t.TempDir()
+
+	// No file → no error.
+	if err := CleanupStaleBootstrapToken(dir); err != nil {
+		t.Fatalf("cleanup of missing file: %v", err)
+	}
+
+	// Seed a stale file → cleanup deletes it.
+	path := filepath.Join(dir, ".bootstrap-token")
+	if err := os.WriteFile(path, []byte("stale\n"), 0600); err != nil {
+		t.Fatalf("seed stale: %v", err)
+	}
+	if err := CleanupStaleBootstrapToken(dir); err != nil {
+		t.Fatalf("cleanup of stale file: %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("stale file still exists after cleanup: stat err = %v", err)
+	}
+}
+
+// TestServer_BootstrapTokenLifecycle covers the in-memory state on the
+// Server: SetBootstrapToken plumbs values, hasBootstrapToken reports
+// presence, checkBootstrapToken validates the header, consume clears
+// in-memory + removes the file.
+func TestServer_BootstrapTokenLifecycle(t *testing.T) {
+	dir := t.TempDir()
+	tokenPath := filepath.Join(dir, ".bootstrap-token")
+	if err := os.WriteFile(tokenPath, []byte("real-token-value\n"), 0600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	srv := &Server{}
+
+	// Empty by default.
+	if srv.hasBootstrapToken() {
+		t.Fatal("hasBootstrapToken() = true on fresh server, want false")
+	}
+
+	srv.SetBootstrapToken("real-token-value", tokenPath)
+	if !srv.hasBootstrapToken() {
+		t.Fatal("hasBootstrapToken() = false after SetBootstrapToken, want true")
+	}
+
+	// Header validation.
+	srv.bootstrapMu.Lock()
+	defer srv.bootstrapMu.Unlock()
+
+	r := httptest.NewRequest("POST", "/api/v1/auth/bootstrap", nil)
+	if srv.checkBootstrapToken(r) {
+		t.Fatal("checkBootstrapToken with no header returned true")
+	}
+	r.Header.Set(BootstrapTokenHeader, "wrong-token")
+	if srv.checkBootstrapToken(r) {
+		t.Fatal("checkBootstrapToken with wrong token returned true")
+	}
+	r.Header.Set(BootstrapTokenHeader, "real-token-value")
+	if !srv.checkBootstrapToken(r) {
+		t.Fatal("checkBootstrapToken with correct header returned false")
+	}
+
+	// Consume clears in-memory and removes file.
+	if err := srv.consumeBootstrapToken(); err != nil {
+		t.Fatalf("consumeBootstrapToken: %v", err)
+	}
+	if srv.bootstrapToken != "" {
+		t.Fatal("bootstrapToken not cleared after consume")
+	}
+	if _, err := os.Stat(tokenPath); !os.IsNotExist(err) {
+		t.Fatalf("token file still exists after consume: stat err = %v", err)
+	}
+
+	// Subsequent check returns false (token is "" and header would no longer match).
+	r.Header.Set(BootstrapTokenHeader, "real-token-value")
+	if srv.checkBootstrapToken(r) {
+		t.Fatal("checkBootstrapToken after consume returned true")
+	}
+
+	// Consume is idempotent (file already gone).
+	if err := srv.consumeBootstrapToken(); err != nil {
+		t.Fatalf("second consume: %v", err)
+	}
+}
+
+// TestServer_BootstrapTokenHeaderOnly_NoQuerySupport pins the API contract
+// that the token is accepted via X-Bootstrap-Token only (F6). A token in
+// ?token=<x> must not satisfy checkBootstrapToken — that path lives on the
+// frontend GET and is scrubbed by replaceState; the POST endpoint never
+// reads from the query.
+func TestServer_BootstrapTokenHeaderOnly_NoQuerySupport(t *testing.T) {
+	srv := &Server{}
+	srv.SetBootstrapToken("real-token-value", "")
+
+	srv.bootstrapMu.Lock()
+	defer srv.bootstrapMu.Unlock()
+
+	r := httptest.NewRequest("POST", "/api/v1/auth/bootstrap?token=real-token-value", nil)
+	// No header set → must reject regardless of query content.
+	if srv.checkBootstrapToken(r) {
+		t.Fatal("checkBootstrapToken accepted query-only token (security regression)")
+	}
+}

--- a/internal/server/handlers_auth.go
+++ b/internal/server/handlers_auth.go
@@ -22,6 +22,12 @@ const (
 	setupMethodLocalCLI   = "local_cli"
 	setupMethodDockerExec = "docker_exec"
 	setupMethodCloud      = "cloud"
+	// setupMethodLogsToken is returned by handleSessionCheck when a
+	// first-run bootstrap token is loaded (self-host, UserCount==0). It
+	// tells the frontend's SetupRequiredNotice to render the "paste your
+	// bootstrap token from the container logs" branch instead of the
+	// CLI-only instructions. See TASK-1167 / PLAN-1166.
+	setupMethodLogsToken = "logs_token"
 )
 
 var emailRegexp = regexp.MustCompile(`^[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}$`)
@@ -291,9 +297,27 @@ func (s *Server) createAuthSession(w http.ResponseWriter, r *http.Request, user 
 }
 
 // handleBootstrap creates the first admin account for a fresh instance.
-// It is only allowed from loopback-local requests so setup must happen
-// on the server host or from inside the container.
+//
+// Default gate is loopback-only: setup must happen on the server host
+// or from inside the container.
+//
+// Self-host (non-cloud) mode also accepts a one-time first-run token
+// supplied via the X-Bootstrap-Token header — the "logs token" path that
+// makes Docker / Unraid bootstrapping possible without `docker exec`.
+// See TASK-1167 / PLAN-1166 and the bootstrap.go file for details.
+//
+// Cloud mode NEVER accepts the token bypass (D2/D10 — F2 from codex
+// review). A cloud bootstrap must come over loopback from the same
+// host as part of the operator's provisioning workflow.
+//
+// The mutex wraps the entire validate → UserCount-check → CreateUser →
+// consume sequence (F5). Without it, two simultaneous valid-token
+// requests with different emails could each pass validation and end up
+// creating two admins from one token.
 func (s *Server) handleBootstrap(w http.ResponseWriter, r *http.Request) {
+	s.bootstrapMu.Lock()
+	defer s.bootstrapMu.Unlock()
+
 	if s.cloudMode {
 		// Allow bootstrap in cloud mode ONLY when no users exist yet.
 		// A fresh cloud instance needs at least one admin before OAuth can work.
@@ -302,10 +326,16 @@ func (s *Server) handleBootstrap(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusForbidden, "forbidden", "Bootstrap is disabled in cloud mode — users register via OAuth or invitation")
 			return
 		}
-	}
-	if !requestIsLoopback(r) {
-		writeError(w, http.StatusForbidden, "forbidden", "Bootstrap is only allowed from localhost on the server host")
-		return
+		if !requestIsLoopback(r) {
+			writeError(w, http.StatusForbidden, "forbidden", "Bootstrap is only allowed from localhost on the server host")
+			return
+		}
+	} else {
+		// Self-host: loopback OR valid first-run token (header-only).
+		if !requestIsLoopback(r) && !s.checkBootstrapToken(r) {
+			writeError(w, http.StatusForbidden, "forbidden", "Bootstrap is only allowed from localhost or with a valid bootstrap token")
+			return
+		}
 	}
 
 	var input struct {
@@ -371,6 +401,18 @@ func (s *Server) handleBootstrap(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "internal_error", "Failed to create user")
 		return
+	}
+
+	// Consume the first-run bootstrap token. We hold s.bootstrapMu, so
+	// this serializes with any concurrent bootstrap attempt — that
+	// goroutine will see an empty in-memory token and bail with 403.
+	// Cloud mode never loaded one in the first place; the no-op cost
+	// of calling it there is a single mutex-locked nil string write +
+	// stat-failure rm. File-removal failure is logged but does not
+	// surface to the caller; the bootstrap itself succeeded, and a
+	// stale token file is cleaned up on the next startup (D4).
+	if cerr := s.consumeBootstrapToken(); cerr != nil {
+		slog.Warn("bootstrap token consume: file removal failed (in-memory token cleared regardless)", "error", cerr)
 	}
 
 	token, err := s.createAuthSession(w, r, user, cliSessionTTL)
@@ -657,9 +699,17 @@ func (s *Server) handleSessionCheck(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// No users → needs setup (first-time experience)
+	// No users → needs setup (first-time experience). Self-host with a
+	// loaded first-run bootstrap token surfaces setup_method=logs_token
+	// so the frontend renders the "paste token from container logs"
+	// branch in SetupRequiredNotice. Cloud mode never loads a token
+	// (D10), so it falls through to the existing local_cli value.
 	if count == 0 {
-		writeJSON(w, http.StatusOK, s.setupStatePayload(setupMethodLocalCLI))
+		method := setupMethodLocalCLI
+		if !s.cloudMode && s.hasBootstrapToken() {
+			method = setupMethodLogsToken
+		}
+		writeJSON(w, http.StatusOK, s.setupStatePayload(method))
 		return
 	}
 

--- a/internal/server/handlers_auth_bootstrap_token_test.go
+++ b/internal/server/handlers_auth_bootstrap_token_test.go
@@ -1,0 +1,395 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+// Tests for the first-run logs-token bootstrap flow (TASK-1167 / PLAN-1166).
+// These tests pin the security-critical contracts that codex review
+// surfaced before implementation:
+//
+//   - F2: cloud mode never accepts the token bypass.
+//   - F5: concurrent valid-token requests cannot create multiple admins.
+//   - F6: token is accepted via X-Bootstrap-Token header only — never via
+//     ?token= query.
+//   - F9: cloud mode never advertises setup_method=logs_token.
+//
+// Plus regression-safe coverage of the existing loopback gate and the
+// session-check setup_method response.
+
+const testBootstrapToken = "test-bootstrap-token-fixed-value"
+
+// configureBootstrapToken seeds a known token on the server so tests don't
+// depend on the random generator. The on-disk file is created in a temp
+// dir so the consume-removes-file assertion has a real file to delete.
+func configureBootstrapToken(t *testing.T, srv *Server) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".bootstrap-token")
+	if err := os.WriteFile(path, []byte(testBootstrapToken+"\n"), 0600); err != nil {
+		t.Fatalf("seed token file: %v", err)
+	}
+	srv.SetBootstrapToken(testBootstrapToken, path)
+	return path
+}
+
+func bootstrapBody(email string) map[string]string {
+	return map[string]string{
+		"email":    email,
+		"name":     "Admin",
+		"password": "correct-horse-battery-staple",
+	}
+}
+
+// doRequestWithHeadersFromAddr lets us combine arbitrary headers with a
+// non-loopback remote-addr. Existing helpers cover one or the other but
+// not both.
+func doRequestWithHeadersFromAddr(srv *Server, method, path string, body interface{}, headers map[string]string, remoteAddr string) *httptest.ResponseRecorder {
+	var bodyReader io.Reader
+	if body != nil {
+		data, _ := json.Marshal(body)
+		bodyReader = bytes.NewReader(data)
+	}
+	req := httptest.NewRequest(method, path, bodyReader)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	req.RemoteAddr = remoteAddr
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	return rr
+}
+
+// TestBootstrapToken_NonLoopback_HeaderAccepted is the happy path: a
+// non-loopback peer presents the correct X-Bootstrap-Token header and
+// the bootstrap succeeds, the file is deleted, and the in-memory token
+// is cleared.
+func TestBootstrapToken_NonLoopback_HeaderAccepted(t *testing.T) {
+	srv := testServer(t)
+	tokenPath := configureBootstrapToken(t, srv)
+
+	rr := doRequestWithHeadersFromAddr(srv, "POST", "/api/v1/auth/bootstrap",
+		bootstrapBody("admin@test.com"),
+		map[string]string{BootstrapTokenHeader: testBootstrapToken},
+		"192.0.2.1:1234")
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("expected 201 with valid header, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	// File deleted.
+	if _, err := os.Stat(tokenPath); !os.IsNotExist(err) {
+		t.Fatalf("token file still exists after bootstrap: stat err = %v", err)
+	}
+	// In-memory cleared.
+	if srv.hasBootstrapToken() {
+		t.Fatal("hasBootstrapToken() = true after consume, want false")
+	}
+}
+
+// TestBootstrapToken_NonLoopback_NoHeader pins the loopback-only default
+// for self-host without a token configured (regression coverage —
+// existing behavior must not change).
+func TestBootstrapToken_NonLoopback_NoHeader(t *testing.T) {
+	srv := testServer(t)
+	configureBootstrapToken(t, srv)
+
+	rr := doRequest(srv, "POST", "/api/v1/auth/bootstrap", bootstrapBody("admin@test.com"))
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 without header, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+// TestBootstrapToken_NonLoopback_WrongHeader covers wrong-token rejection.
+func TestBootstrapToken_NonLoopback_WrongHeader(t *testing.T) {
+	srv := testServer(t)
+	configureBootstrapToken(t, srv)
+
+	rr := doRequestWithHeadersFromAddr(srv, "POST", "/api/v1/auth/bootstrap",
+		bootstrapBody("admin@test.com"),
+		map[string]string{BootstrapTokenHeader: "wrong-token"},
+		"192.0.2.1:1234")
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 with wrong token, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+// TestBootstrapToken_NonLoopback_QueryRejected pins the F6 contract: token
+// must NOT be accepted via ?token= query, only via X-Bootstrap-Token
+// header. This prevents the secret from landing in any caller's access
+// log, browser history, or proxy log.
+func TestBootstrapToken_NonLoopback_QueryRejected(t *testing.T) {
+	srv := testServer(t)
+	configureBootstrapToken(t, srv)
+
+	// No header — only query param. Must be rejected.
+	rr := doRequest(srv, "POST",
+		"/api/v1/auth/bootstrap?token="+testBootstrapToken,
+		bootstrapBody("admin@test.com"))
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 with token in query (header-only contract), got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+// TestBootstrapToken_Replay_AfterConsume verifies that once the first
+// admin is created, the same token cannot be reused — even by the same
+// client.
+func TestBootstrapToken_Replay_AfterConsume(t *testing.T) {
+	srv := testServer(t)
+	configureBootstrapToken(t, srv)
+
+	// Round 1 — succeeds.
+	rr := doRequestWithHeadersFromAddr(srv, "POST", "/api/v1/auth/bootstrap",
+		bootstrapBody("admin@test.com"),
+		map[string]string{BootstrapTokenHeader: testBootstrapToken},
+		"192.0.2.1:1234")
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("first bootstrap: expected 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	// Round 2 — same token replayed. After consume it's been cleared in
+	// memory + the file is deleted, so the validate path returns false
+	// and we fall back to the loopback gate (which fails: non-loopback
+	// peer). UserCount > 0 also bails the inner check, but we expect
+	// the outer gate to win first with 403.
+	rr = doRequestWithHeadersFromAddr(srv, "POST", "/api/v1/auth/bootstrap",
+		bootstrapBody("second@test.com"),
+		map[string]string{BootstrapTokenHeader: testBootstrapToken},
+		"192.0.2.1:1234")
+	if rr.Code == http.StatusCreated {
+		t.Fatalf("replay succeeded with consumed token: %s", rr.Body.String())
+	}
+}
+
+// TestBootstrapToken_CloudMode_NoBypass pins the F2 contract: a fresh
+// cloud instance with UserCount=0 + a token configured + a non-loopback
+// peer presenting the correct header → still 403. Cloud bootstrap
+// remains loopback-only regardless of token state.
+//
+// In production, cmd/pad/main.go never calls EnsureBootstrapToken when
+// the instance is in cloud mode (D10), so the token would never even be
+// loaded. This test forces the token in anyway to pin the
+// defense-in-depth check inside handleBootstrap itself.
+func TestBootstrapToken_CloudMode_NoBypass(t *testing.T) {
+	srv := testServer(t)
+	srv.SetCloudMode("test-cloud-secret")
+	configureBootstrapToken(t, srv)
+
+	rr := doRequestWithHeadersFromAddr(srv, "POST", "/api/v1/auth/bootstrap",
+		bootstrapBody("admin@test.com"),
+		map[string]string{BootstrapTokenHeader: testBootstrapToken},
+		"192.0.2.1:1234")
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("cloud-mode token bypass leaked! expected 403, got %d: %s", rr.Code, rr.Body.String())
+	}
+	// Token must still be present (consume only fires on success).
+	if !srv.hasBootstrapToken() {
+		t.Fatal("token was consumed on a rejected cloud-mode bootstrap")
+	}
+}
+
+// TestBootstrapToken_ConcurrentRace pins the F5 contract: N simultaneous
+// requests with the correct token + different emails must produce
+// exactly one success. The mutex in handleBootstrap serializes the
+// validate → check-UserCount → CreateUser → consume sequence so the
+// loser sees an empty in-memory token after the winner consumes.
+func TestBootstrapToken_ConcurrentRace(t *testing.T) {
+	srv := testServer(t)
+	configureBootstrapToken(t, srv)
+
+	const N = 8
+	var (
+		successes int32
+		failures  int32
+	)
+	var wg sync.WaitGroup
+	wg.Add(N)
+	for i := 0; i < N; i++ {
+		go func(idx int) {
+			defer wg.Done()
+			email := "admin" + string(rune('0'+idx)) + "@test.com"
+			rr := doRequestWithHeadersFromAddr(srv, "POST", "/api/v1/auth/bootstrap",
+				bootstrapBody(email),
+				map[string]string{BootstrapTokenHeader: testBootstrapToken},
+				"192.0.2.1:1234")
+			if rr.Code == http.StatusCreated {
+				atomic.AddInt32(&successes, 1)
+			} else {
+				atomic.AddInt32(&failures, 1)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	if successes != 1 {
+		t.Fatalf("expected exactly 1 successful bootstrap, got %d (failures: %d)", successes, failures)
+	}
+	if failures != N-1 {
+		t.Fatalf("expected %d failures, got %d", N-1, failures)
+	}
+	// And exactly 1 admin in the DB.
+	count, err := srv.store.UserCount()
+	if err != nil {
+		t.Fatalf("UserCount: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected 1 admin after concurrent race, got %d (this is the F5 multi-admin bug)", count)
+	}
+}
+
+// TestBootstrapToken_SessionCheck_LogsToken pins the setup_method value
+// returned by /api/v1/auth/session when a token is configured and no
+// users exist — the frontend's SetupRequiredNotice branches on this to
+// render the "paste your bootstrap token from the container logs" UI.
+func TestBootstrapToken_SessionCheck_LogsToken(t *testing.T) {
+	srv := testServer(t)
+	configureBootstrapToken(t, srv)
+
+	rr := doRequest(srv, "GET", "/api/v1/auth/session", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("session check: expected 200, got %d", rr.Code)
+	}
+	var session map[string]interface{}
+	parseJSON(t, rr, &session)
+	if session["setup_required"] != true {
+		t.Errorf("expected setup_required=true with no users, got %v", session["setup_required"])
+	}
+	if session["setup_method"] != "logs_token" {
+		t.Errorf("expected setup_method=logs_token when token is loaded + no users, got %v", session["setup_method"])
+	}
+}
+
+// TestBootstrapToken_SessionCheck_LocalCLI_NoToken pins the existing
+// fallback: when no token is configured (e.g. read-only data dir per
+// D7), the session payload returns the existing local_cli value.
+func TestBootstrapToken_SessionCheck_LocalCLI_NoToken(t *testing.T) {
+	srv := testServer(t)
+	// Note: NOT calling configureBootstrapToken — leaves token empty.
+
+	rr := doRequest(srv, "GET", "/api/v1/auth/session", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("session check: expected 200, got %d", rr.Code)
+	}
+	var session map[string]interface{}
+	parseJSON(t, rr, &session)
+	if session["setup_method"] != "local_cli" {
+		t.Errorf("expected setup_method=local_cli with no token loaded, got %v", session["setup_method"])
+	}
+}
+
+// TestBootstrapToken_SessionCheck_CloudMode_NoLogsToken pins the F9
+// contract: cloud-mode session must NEVER advertise logs_token, even if
+// a token is somehow loaded (shouldn't happen via cmd/pad/main.go but
+// the handler must defend itself anyway).
+func TestBootstrapToken_SessionCheck_CloudMode_NoLogsToken(t *testing.T) {
+	srv := testServer(t)
+	srv.SetCloudMode("test-cloud-secret")
+	configureBootstrapToken(t, srv)
+
+	rr := doRequest(srv, "GET", "/api/v1/auth/session", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("session check: expected 200, got %d", rr.Code)
+	}
+	var session map[string]interface{}
+	parseJSON(t, rr, &session)
+	if session["setup_method"] == "logs_token" {
+		t.Fatalf("cloud-mode advertised setup_method=logs_token (F9 regression)")
+	}
+}
+
+// TestBootstrapToken_CORSPreflightAllowsHeader pins the CORS contract: a
+// browser submitting from a configured cross-origin must succeed at
+// preflight for the X-Bootstrap-Token header. The default same-origin
+// case doesn't trigger preflight, so this test specifically configures
+// CORS to exercise the preflight path.
+func TestBootstrapToken_CORSPreflightAllowsHeader(t *testing.T) {
+	srv := testServer(t)
+	srv.SetCORSOrigins("https://other.example.com")
+
+	req := httptest.NewRequest("OPTIONS", "/api/v1/auth/bootstrap", nil)
+	req.Header.Set("Origin", "https://other.example.com")
+	req.Header.Set("Access-Control-Request-Method", "POST")
+	req.Header.Set("Access-Control-Request-Headers", "X-Bootstrap-Token, Content-Type")
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK && rr.Code != http.StatusNoContent {
+		t.Fatalf("preflight: expected 200/204, got %d: %s", rr.Code, rr.Body.String())
+	}
+	allowed := rr.Header().Get("Access-Control-Allow-Headers")
+	if allowed == "" {
+		t.Fatal("preflight response missing Access-Control-Allow-Headers")
+	}
+	// Allow header is comma-separated; chi/cors echoes the request set if
+	// they're all in the configured list. Check the bootstrap header
+	// specifically.
+	if !containsHeader(allowed, "X-Bootstrap-Token") {
+		t.Fatalf("Access-Control-Allow-Headers missing X-Bootstrap-Token: %q", allowed)
+	}
+}
+
+// containsHeader does a case-insensitive comma-separated lookup.
+func containsHeader(allowed, want string) bool {
+	// Lowercase compare on the simple case — preflight responses typically
+	// lower-case the echo. Use strings.EqualFold-style match per token.
+	for _, part := range splitCSV(allowed) {
+		if equalFoldASCII(part, want) {
+			return true
+		}
+	}
+	return false
+}
+
+func splitCSV(s string) []string {
+	out := []string{}
+	start := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] == ',' {
+			out = append(out, trimSpaceASCII(s[start:i]))
+			start = i + 1
+		}
+	}
+	out = append(out, trimSpaceASCII(s[start:]))
+	return out
+}
+
+func trimSpaceASCII(s string) string {
+	i, j := 0, len(s)
+	for i < j && (s[i] == ' ' || s[i] == '\t') {
+		i++
+	}
+	for j > i && (s[j-1] == ' ' || s[j-1] == '\t') {
+		j--
+	}
+	return s[i:j]
+}
+
+func equalFoldASCII(a, b string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := 0; i < len(a); i++ {
+		ca, cb := a[i], b[i]
+		if 'A' <= ca && ca <= 'Z' {
+			ca += 32
+		}
+		if 'A' <= cb && cb <= 'Z' {
+			cb += 32
+		}
+		if ca != cb {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/server/middleware_logging.go
+++ b/internal/server/middleware_logging.go
@@ -3,10 +3,35 @@ package server
 import (
 	"log/slog"
 	"net/http"
+	"regexp"
 	"time"
 
 	chimiddleware "github.com/go-chi/chi/v5/middleware"
 )
+
+// redactedQueryKeys are query-string keys whose values must never appear
+// in request logs. The server's POST endpoints reject these via header-
+// only contracts, but a misuse via GET (e.g. an operator pasting
+// /setup?token=<x> instead of using the fragment form, or a bug in a
+// future feature that accepts the same key) would otherwise persist
+// the secret in `logs/server.log` AND in any log-aggregation pipeline.
+//
+// Add new entries here whenever a new sensitive query key is
+// introduced. The list is intentionally short — most secrets should
+// move to the request body or a header instead.
+var redactedQueryKeys = regexp.MustCompile(`(?i)(\b(?:token|password|secret|api[_-]?key)=)[^&]*`)
+
+// redactQueryString replaces sensitive query-key values with REDACTED
+// while leaving the rest of the query string intact for diagnostics.
+// Operates on the raw query string to avoid the alphabetization that
+// url.Values.Encode() would impose (which would break log diffing
+// against the actual request).
+func redactQueryString(raw string) string {
+	if raw == "" {
+		return raw
+	}
+	return redactedQueryKeys.ReplaceAllString(raw, "${1}REDACTED")
+}
 
 // StructuredLogger is a chi-compatible request logger that writes structured
 // log entries via slog. It replaces chi's default Logger middleware.
@@ -40,7 +65,7 @@ func StructuredLogger(next http.Handler) http.Handler {
 		}
 
 		if r.URL.RawQuery != "" {
-			attrs = append(attrs, slog.String("query", r.URL.RawQuery))
+			attrs = append(attrs, slog.String("query", redactQueryString(r.URL.RawQuery)))
 		}
 
 		slog.LogAttrs(r.Context(), level, "http request", attrs...)

--- a/internal/server/middleware_logging_test.go
+++ b/internal/server/middleware_logging_test.go
@@ -1,0 +1,91 @@
+package server
+
+import "testing"
+
+// TestRedactQueryString covers the F6 leak guard: sensitive keys (token,
+// password, secret, api_key / api-key) must have their values replaced
+// with REDACTED before the structured request logger writes them to
+// disk. Other keys must be untouched so logs remain useful for
+// diagnosis.
+func TestRedactQueryString(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "empty",
+			in:   "",
+			want: "",
+		},
+		{
+			name: "no sensitive keys",
+			in:   "ref=TASK-5&limit=20",
+			want: "ref=TASK-5&limit=20",
+		},
+		{
+			name: "token alone",
+			in:   "token=abc123",
+			want: "token=REDACTED",
+		},
+		{
+			name: "token mid-string",
+			in:   "ref=TASK-5&token=abc123&limit=20",
+			want: "ref=TASK-5&token=REDACTED&limit=20",
+		},
+		{
+			name: "token at end",
+			in:   "ref=TASK-5&token=abc123",
+			want: "ref=TASK-5&token=REDACTED",
+		},
+		{
+			name: "case-insensitive",
+			in:   "TOKEN=abc123",
+			want: "TOKEN=REDACTED",
+		},
+		{
+			name: "password",
+			in:   "password=hunter2",
+			want: "password=REDACTED",
+		},
+		{
+			name: "secret",
+			in:   "secret=topsecret",
+			want: "secret=REDACTED",
+		},
+		{
+			name: "api_key underscore",
+			in:   "api_key=abc",
+			want: "api_key=REDACTED",
+		},
+		{
+			name: "api-key dash",
+			in:   "api-key=abc",
+			want: "api-key=REDACTED",
+		},
+		{
+			name: "apikey contiguous",
+			in:   "apikey=abc",
+			want: "apikey=REDACTED",
+		},
+		{
+			name: "preserves multiple non-sensitive keys",
+			in:   "ref=TASK-5&token=abc&filter=open&limit=20",
+			want: "ref=TASK-5&token=REDACTED&filter=open&limit=20",
+		},
+		{
+			name: "lookalike key not redacted",
+			in:   "tokenizer=on&ref=TASK-5",
+			want: "tokenizer=on&ref=TASK-5",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := redactQueryString(tc.in)
+			if got != tc.want {
+				t.Fatalf("redactQueryString(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -158,6 +158,22 @@ type Server struct {
 	// SQLite WAL write against TempDir RemoveAll, leaving "directory not
 	// empty" cleanup errors in CI. See BUG-842.
 	bg sync.WaitGroup
+
+	// First-run bootstrap token (TASK-1167 / PLAN-1166). When non-empty,
+	// handleBootstrap accepts the value via the X-Bootstrap-Token header
+	// from non-loopback peers (self-host mode only — cloud mode never
+	// loads or honors a token, D2/D10). Wired at startup via
+	// SetBootstrapToken; cleared by consumeBootstrapToken after the first
+	// admin is created.
+	//
+	// The mutex protects the token field AND the entire validate-token →
+	// check-UserCount → CreateUser → consume sequence in handleBootstrap.
+	// Two simultaneous valid-token requests with different emails would
+	// otherwise create two admins from one token (F5). Bootstrap happens
+	// once per install, so the contention window is irrelevant.
+	bootstrapMu        sync.Mutex
+	bootstrapToken     string
+	bootstrapTokenPath string
 }
 
 // goAsync spawns fn in a goroutine that's tracked by s.bg, so Stop() can
@@ -699,7 +715,7 @@ func (s *Server) setupRouter() {
 		r.Use(cors.Handler(cors.Options{
 			AllowedOrigins: parseCORSOrigins(s.corsOrigins),
 			AllowedMethods: []string{"GET", "POST", "PATCH", "PUT", "DELETE", "OPTIONS"},
-			AllowedHeaders: []string{"Accept", "Authorization", "Content-Type", "X-CSRF-Token", "X-Share-Password"},
+			AllowedHeaders: []string{"Accept", "Authorization", "Content-Type", "X-CSRF-Token", "X-Share-Password", "X-Bootstrap-Token"},
 			// Credentials flag is gated on an operator explicitly listing
 			// PAD_CORS_ORIGINS. The CLI uses Bearer tokens so the default
 			// "no CORS_ORIGINS set" path doesn't need credential sharing;

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -124,7 +124,12 @@ export interface HealthResponse {
 export interface AuthSession {
 	authenticated: boolean;
 	setup_required: boolean;
-	setup_method?: 'local_cli' | 'docker_exec' | 'cloud';
+	// 'logs_token' added in TASK-1167 for the first-run logs-token bootstrap
+	// flow. Self-host servers with no users + a loaded bootstrap token surface
+	// this value so SetupRequiredNotice renders the "paste your bootstrap
+	// token from the container logs" branch instead of the local-CLI
+	// instructions. Cloud mode never advertises 'logs_token' (D10/F9).
+	setup_method?: 'local_cli' | 'docker_exec' | 'cloud' | 'logs_token';
 	auth_method: 'password' | 'cloud';
 	cloud_mode?: boolean;
 	// mcp_public_url is the canonical URL clients paste into their MCP-capable
@@ -701,6 +706,26 @@ export const api = {
 			request<{ user: { id: string; email: string; username: string; name: string; role: string }; token: string }>('/auth/register', {
 				method: 'POST',
 				body: JSON.stringify({ email, name, password, ...(username ? { username } : {}), ...(invitation_code ? { invitation_code } : {}) })
+			}),
+		// First-run bootstrap with a logs-token (TASK-1167). The token is
+		// transmitted via the X-Bootstrap-Token header — never the URL or
+		// query string — to keep it out of access logs, proxy logs, and
+		// browser history (F6 / D9). Same response shape as register, so
+		// the caller can reuse the post-registration redirect logic.
+		//
+		// Content-Type is set explicitly here because request() builds its
+		// default headers BEFORE spreading caller options, so any caller-
+		// provided `headers` object replaces the defaults entirely. The
+		// /auth/bootstrap endpoint is pre-auth and CSRF-exempt, so no
+		// X-CSRF-Token is needed.
+		bootstrap: (email: string, name: string, password: string, token: string) =>
+			request<{ user: { id: string; email: string; username: string; name: string; role: string }; token: string }>('/auth/bootstrap', {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					'X-Bootstrap-Token': token
+				},
+				body: JSON.stringify({ email, name, password })
 			}),
 		checkUsername: (username: string) =>
 			request<{ available: boolean; reason: string | null; message: string | null }>(`/auth/check-username?username=${encodeURIComponent(username)}`),

--- a/web/src/lib/components/auth/SetupRequiredNotice.svelte
+++ b/web/src/lib/components/auth/SetupRequiredNotice.svelte
@@ -1,5 +1,10 @@
 <script lang="ts">
-	type SetupMethod = 'local_cli' | 'docker_exec' | 'cloud' | undefined;
+	// 'logs_token' added in TASK-1167 / PLAN-1166: the server returns this
+	// value when running self-host with no users + a loaded first-run
+	// bootstrap token. It tells the user to grab the token from container
+	// logs and finish setup at /setup#token=<x>. Cloud mode never returns
+	// 'logs_token' (D10/F9).
+	type SetupMethod = 'local_cli' | 'docker_exec' | 'cloud' | 'logs_token' | undefined;
 
 	let {
 		setupMethod,
@@ -19,6 +24,28 @@
 
 	{#if setupMethod === 'cloud'}
 		<p class="body">Finish the hosted Pad Cloud setup flow before signing in.</p>
+	{:else if setupMethod === 'logs_token'}
+		<p class="body">
+			This Pad instance is fresh. The first-run bootstrap token was logged on startup —
+			grab it from your container logs and finish setup in your browser.
+		</p>
+
+		<div class="instructions">
+			<div class="instruction">
+				<p class="instruction-label">Find the token</p>
+				<code>docker logs &lt;container&gt; 2&gt;&amp;1 | grep -A1 'Pad first-run setup'</code>
+			</div>
+
+			<div class="instruction">
+				<p class="instruction-label">Then continue setup</p>
+				<a href="/setup">Open setup page</a>
+			</div>
+		</div>
+
+		<p class="hint">
+			You can also paste the URL printed in the logs directly — it points at
+			<code>/setup</code> with the token in the URL fragment.
+		</p>
 	{:else}
 		<p class="body">Initialize Pad on the server host first, then come back here.</p>
 

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -24,6 +24,7 @@
 	let isAuthPage = $derived(
 		page.url.pathname === '/login'
 		|| page.url.pathname === '/register'
+		|| page.url.pathname === '/setup'
 		|| page.url.pathname === '/forgot-password'
 		|| page.url.pathname.startsWith('/reset-password/')
 		|| page.url.pathname.startsWith('/join/')

--- a/web/src/routes/join/[code]/+page.svelte
+++ b/web/src/routes/join/[code]/+page.svelte
@@ -11,7 +11,7 @@
 	let code = $derived(page.params.code ?? '');
 	let status = $state<'loading' | 'login' | 'register' | 'accepting' | 'error' | 'setup' | '2fa'>('loading');
 	let errorMsg = $state('');
-	let setupMethod = $state<'local_cli' | 'docker_exec' | 'cloud' | undefined>(undefined);
+	let setupMethod = $state<'local_cli' | 'docker_exec' | 'cloud' | 'logs_token' | undefined>(undefined);
 
 	// Auth form state
 	let mode = $state<'login' | 'register'>('register');

--- a/web/src/routes/login/+page.svelte
+++ b/web/src/routes/login/+page.svelte
@@ -19,7 +19,7 @@
 	let password = $state('');
 	let error = $state('');
 	let setupRequired = $state(false);
-	let setupMethod = $state<'local_cli' | 'docker_exec' | 'cloud' | undefined>(undefined);
+	let setupMethod = $state<'local_cli' | 'docker_exec' | 'cloud' | 'logs_token' | undefined>(undefined);
 	let loading = $state(false);
 
 	let cloudMode = $state(false);

--- a/web/src/routes/register/+page.svelte
+++ b/web/src/routes/register/+page.svelte
@@ -22,7 +22,7 @@
 	let confirmPassword = $state('');
 	let error = $state('');
 	let setupRequired = $state(false);
-	let setupMethod = $state<'local_cli' | 'docker_exec' | 'cloud' | undefined>(undefined);
+	let setupMethod = $state<'local_cli' | 'docker_exec' | 'cloud' | 'logs_token' | undefined>(undefined);
 	let loading = $state(false);
 
 	let usernameManuallyEdited = $state(false);

--- a/web/src/routes/setup/+page.svelte
+++ b/web/src/routes/setup/+page.svelte
@@ -1,0 +1,360 @@
+<script lang="ts">
+	// TASK-1167 / PLAN-1166 — first-run bootstrap page.
+	//
+	// This is the browser surface for the one-time logs-token bootstrap that
+	// lets a Docker / Unraid operator claim the first admin without
+	// `docker exec`. The server prints a token to its container logs, the
+	// operator copies it into either:
+	//
+	//   1. the URL fragment (`/setup#token=<TOKEN>`) — convenient deep link;
+	//      we scrub the fragment from the address bar on mount so the secret
+	//      doesn't linger in browser history / screenshots (F10), or
+	//   2. the paste-prompt input on this page when they navigate here
+	//      without a fragment.
+	//
+	// The token never goes in a query string, never in a request URL — only
+	// the X-Bootstrap-Token header on POST /api/v1/auth/bootstrap (see
+	// api.auth.bootstrap()). If the token is rejected (403 — expired, already
+	// used, or wrong) we clear the in-memory copy and revert to the paste
+	// prompt so the operator can grab a fresh token from the logs and recover
+	// in place (F12).
+	import { onMount } from 'svelte';
+	import { goto } from '$app/navigation';
+	import { api, PadApiError } from '$lib/api/client';
+	import { authStore } from '$lib/stores/auth.svelte';
+	import AuthHeader from '$lib/components/auth/AuthHeader.svelte';
+	import AuthFooter from '$lib/components/auth/AuthFooter.svelte';
+
+	// ── Token state ──────────────────────────────────────────────────────────
+	//
+	// `token` is the only place the bootstrap secret lives in component
+	// state. It's never written to a URL, query, or any storage.
+	//
+	// Read the fragment SYNCHRONOUSLY at component init (gated for SSR) and
+	// scrub it from the address bar before the first paint. onMount runs
+	// after paint, which would leave a window for the user to copy or
+	// screenshot the URL.
+	let token = $state('');
+	let pastedToken = $state('');
+
+	if (typeof window !== 'undefined') {
+		const hash = window.location.hash;
+		if (hash.startsWith('#token=')) {
+			const raw = hash.slice('#token='.length);
+			// decodeURIComponent so an operator who URL-encoded the token
+			// (e.g. via a copy/paste tool that escapes special chars) still
+			// gets a usable string. Falls back to the raw value if decoding
+			// throws on a malformed sequence.
+			try {
+				token = decodeURIComponent(raw);
+			} catch {
+				token = raw;
+			}
+			// Scrub the fragment from the URL bar before paint so the
+			// secret doesn't survive in browser history, screen recordings,
+			// or screenshots (F10). replaceState keeps the navigation
+			// entry — we just rewrite its URL.
+			history.replaceState({}, '', '/setup');
+		}
+	}
+
+	// ── Form state ───────────────────────────────────────────────────────────
+	let email = $state('');
+	let name = $state('');
+	let password = $state('');
+	let confirmPassword = $state('');
+	let error = $state('');
+	let loading = $state(false);
+	let sessionChecked = $state(false);
+
+	onMount(async () => {
+		// If the user already has a session, /setup is a no-op for them —
+		// route to the app root. Mirrors the register page's pattern of
+		// going through authStore so a logout → /setup navigation gets
+		// fresh session data instead of a stale cached value.
+		try {
+			const session = await authStore.ensureLoaded();
+			if (session?.authenticated) {
+				await goto('/');
+				return;
+			}
+		} catch {
+			// Network / parse error — treat as unauthenticated and let the
+			// user proceed. The bootstrap POST will surface a real error if
+			// the server is actually unhealthy.
+		} finally {
+			sessionChecked = true;
+		}
+	});
+
+	function handlePasteSubmit() {
+		error = '';
+		const trimmed = pastedToken.trim();
+		if (!trimmed) {
+			error = 'Please paste your bootstrap token.';
+			return;
+		}
+		token = trimmed;
+		pastedToken = '';
+	}
+
+	function validate(): string | null {
+		if (!email.trim()) return 'Please enter your email.';
+		const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+		if (!emailRegex.test(email)) return 'Please enter a valid email address.';
+		if (!name.trim()) return 'Please enter your name.';
+		if (password.length < 8) return 'Password must be at least 8 characters.';
+		if (password !== confirmPassword) return 'Passwords do not match.';
+		return null;
+	}
+
+	async function handleSubmit() {
+		error = '';
+		const validationError = validate();
+		if (validationError) {
+			error = validationError;
+			return;
+		}
+
+		loading = true;
+		try {
+			await api.auth.bootstrap(email, name, password, token);
+			// Bootstrap success — server has set the session cookie. Reload
+			// the auth store so subsequent navigations see the new session.
+			await authStore.load();
+			await goto('/');
+		} catch (err: unknown) {
+			// 403: token rejected (expired / already used / wrong). Clear
+			// the in-memory token, drop back to the paste prompt, and
+			// surface an actionable message so the operator can grab a
+			// fresh token from the container logs (F12).
+			if (err instanceof PadApiError && err.code === 'forbidden') {
+				token = '';
+				password = '';
+				confirmPassword = '';
+				error =
+					'This token is invalid, expired, or already used. Get a fresh token from your container logs and paste it below.';
+			} else if (err instanceof Error) {
+				error = err.message || 'Bootstrap failed.';
+			} else {
+				error = 'Bootstrap failed.';
+			}
+		} finally {
+			loading = false;
+		}
+	}
+
+	function handleKeydown(event: KeyboardEvent) {
+		if (event.key === 'Enter') {
+			handleSubmit();
+		}
+	}
+
+	function handlePasteKeydown(event: KeyboardEvent) {
+		if (event.key === 'Enter') {
+			handlePasteSubmit();
+		}
+	}
+</script>
+
+<AuthHeader cloudMode={authStore.cloudMode} />
+
+<div class="setup-page" class:cloud-mode={authStore.cloudMode}>
+	<div class="setup-card">
+		{#if !authStore.cloudMode}
+			<h1 class="logo">Pad</h1>
+		{/if}
+
+		{#if !sessionChecked}
+			<p class="subtitle">Loading…</p>
+		{:else if !token}
+			<p class="subtitle">Paste your bootstrap token</p>
+			<p class="hint">
+				Look for the token printed in your container logs when the server
+				started. It looks like a long random string.
+			</p>
+
+			<div class="form">
+				<input
+					type="text"
+					placeholder="Bootstrap token"
+					bind:value={pastedToken}
+					onkeydown={handlePasteKeydown}
+					disabled={loading}
+					autocomplete="off"
+					spellcheck="false"
+				/>
+
+				{#if error}
+					<p class="error">{error}</p>
+				{/if}
+
+				<button onclick={handlePasteSubmit} disabled={loading}>Continue</button>
+			</div>
+		{:else}
+			<p class="subtitle">Create the first admin account</p>
+			<p class="hint">
+				This account will own the workspace and can invite other users.
+			</p>
+
+			<div class="form">
+				<input
+					type="email"
+					placeholder="Email"
+					bind:value={email}
+					onkeydown={handleKeydown}
+					disabled={loading}
+					autocomplete="email"
+				/>
+
+				<input
+					type="text"
+					placeholder="Name"
+					bind:value={name}
+					onkeydown={handleKeydown}
+					disabled={loading}
+					autocomplete="name"
+				/>
+
+				<input
+					type="password"
+					placeholder="Password (min. 8 characters)"
+					bind:value={password}
+					onkeydown={handleKeydown}
+					disabled={loading}
+					autocomplete="new-password"
+				/>
+
+				<input
+					type="password"
+					placeholder="Confirm password"
+					bind:value={confirmPassword}
+					onkeydown={handleKeydown}
+					disabled={loading}
+					autocomplete="new-password"
+				/>
+
+				{#if error}
+					<p class="error">{error}</p>
+				{/if}
+
+				<button onclick={handleSubmit} disabled={loading}>
+					{#if loading}
+						Creating admin account…
+					{:else}
+						Create admin account
+					{/if}
+				</button>
+			</div>
+		{/if}
+	</div>
+
+	<AuthFooter cloudMode={authStore.cloudMode} />
+</div>
+
+<style>
+	.setup-page {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		min-height: 100vh;
+		background: var(--bg-primary);
+		padding: var(--space-4);
+	}
+
+	.setup-page.cloud-mode {
+		padding-top: 4rem;
+	}
+
+	.setup-card {
+		width: 100%;
+		max-width: 360px;
+		background: var(--bg-secondary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius-lg);
+		padding: var(--space-10) var(--space-8);
+		text-align: center;
+	}
+
+	.logo {
+		font-size: 2rem;
+		font-weight: 700;
+		color: var(--text-primary);
+		letter-spacing: -0.02em;
+		margin-bottom: var(--space-2);
+	}
+
+	.subtitle {
+		color: var(--text-muted);
+		font-size: 0.9rem;
+		margin-bottom: var(--space-4);
+	}
+
+	.hint {
+		color: var(--text-muted);
+		font-size: 0.8rem;
+		margin-bottom: var(--space-6);
+		line-height: 1.5;
+	}
+
+	.form {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-4);
+	}
+
+	input {
+		width: 100%;
+		padding: var(--space-3) var(--space-4);
+		background: var(--bg-tertiary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+		color: var(--text-primary);
+		font-size: 0.95rem;
+		font-family: var(--font-ui);
+		outline: none;
+		transition: border-color 0.15s;
+	}
+
+	input::placeholder {
+		color: var(--text-muted);
+	}
+
+	input:focus {
+		border-color: var(--accent-blue);
+	}
+
+	input:disabled {
+		opacity: 0.6;
+	}
+
+	.error {
+		color: #ef4444;
+		font-size: 0.85rem;
+		text-align: left;
+	}
+
+	button {
+		width: 100%;
+		padding: var(--space-3) var(--space-4);
+		background: var(--accent-blue);
+		color: #fff;
+		border: none;
+		border-radius: var(--radius);
+		font-size: 0.95rem;
+		font-weight: 500;
+		font-family: var(--font-ui);
+		cursor: pointer;
+		transition: opacity 0.15s;
+	}
+
+	button:hover:not(:disabled) {
+		opacity: 0.9;
+	}
+
+	button:disabled {
+		opacity: 0.6;
+		cursor: not-allowed;
+	}
+</style>


### PR DESCRIPTION
## Summary

Adds a one-time first-run bootstrap token so a Pad operator can claim the first admin from a remote browser — currently impossible inside Docker / Unraid without `docker exec` because of the loopback-only gate. Closes TASK-1167. Foundation for PLAN-1166 (Pad on Unraid).

- **Backend**: `internal/server/bootstrap.go` generates / persists / validates / consumes the token. Cloud-mode/self-host branch split in `handleBootstrap` (D2/F2). Mutex-serialized validate → UserCount-check → CreateUser → consume sequence (F5). `setup_method: "logs_token"` on `/auth/session` for self-host fresh installs (F9). Query-string redaction in the request logger (F6). `X-Bootstrap-Token` added to CORS allow-list.
- **Frontend**: new `/setup` page reads token from URL fragment (browser-only, never hits the server — F10), `history.replaceState`s to scrub before paint, submits via `X-Bootstrap-Token` header. Error-recovery on 403 reverts to paste-prompt UI with the token cleared (F12). `SetupRequiredNotice` gains a `logs_token` branch with copy-able `docker logs` snippet.
- **Process**: design plan went through 7 rounds of codex review (12 defects caught + fixed pre-implementation). Code-review pass on the actual diff returned CLEAN on round 1.

Cloud mode behavior unchanged — token never loaded, never honored.

## Test plan

- [x] `go test ./...` — full Go suite passes (113s)
- [x] `make check` — lint + tests + web build all green
- [x] `make install` — server restarts cleanly with the new startup logic
- [x] **F5 concurrent-race pin**: 8 simultaneous valid-token requests → exactly 1 success, 7 failures, 1 admin in DB
- [x] **F2 cloud-mode no-bypass pin**: cloud + token + non-loopback → 403, token preserved
- [x] **F6 redaction pin**: `?token=<x>` lands as `query="token=REDACTED"` in logs
- [x] **F9 cloud session pin**: cloud + UserCount=0 + token loaded → `setup_method` is NOT `logs_token`
- [x] **F8 layout-bypass pin**: `/setup` is in the auth-page allowlist
- [x] CORS preflight allows `X-Bootstrap-Token`
- [x] Token file mode 0600 enforced; rejects 0644 with helpful error
- [x] Concurrent file-creation race serializes via temp+hardlink (mirrors `EnsureEncryptionKey`)
- [ ] Manual smoke test on real Unraid container (deferred to TASK-1171 in PLAN-1166)

## Out of scope

- Postgres/Redis variant of the Unraid template (separate plan)
- Generalizing this flow to replace `pad auth setup` TTY prompts on local installs (filed as IDEA-1179)