### PR TITLE
feat(docker): PUID/PGID entrypoint shim for Unraid (TASK-1168)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,15 @@ PAD_ENCRYPTION_KEY=
 #   10.0.0.5   → bind to a specific LAN IP
 # PAD_BIND_ADDR=127.0.0.1
 
+# OPTIONAL — Container UID/GID for the pad process (Docker only).
+# Default: 1000/1000 with docker-compose; 99/100 with raw `docker run`
+# (Unraid `nobody:users` convention). Set these to match your host
+# volume's ownership to avoid permission errors on /data writes.
+# Must be POSITIVE integers — 0 (root) is rejected by the entrypoint.
+# See docker-entrypoint.sh.
+# PUID=1000
+# PGID=1000
+
 # OPTIONAL — Redis auth (docker-compose.prod.yml only).
 # If set, Redis starts with `--requirepass` and Pad connects with the password.
 # REDIS_PASSWORD=

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -154,6 +154,11 @@ dockers_v2:
     dockerfile: Dockerfile.goreleaser
     extra_files:
       - web/build
+      # docker-entrypoint.sh is the PUID/PGID remapping shim
+      # (TASK-1168). Without listing it here goreleaser builds a
+      # context that lacks the file and Dockerfile.goreleaser's COPY
+      # step fails — the published GHCR image would never build.
+      - docker-entrypoint.sh
     platforms:
       - linux/amd64
       - linux/arm64

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,22 +42,53 @@ RUN CGO_ENABLED=0 go build \
 
 # Stage 3: Runtime
 FROM alpine:3.21
-RUN apk add --no-cache ca-certificates tzdata
+# ca-certificates: TLS roots for outbound HTTPS (e.g. Maileroo email).
+# tzdata: timezone names for Go's time package.
+# shadow: provides usermod / groupmod (BusyBox's adduser/addgroup don't
+#         ship modify equivalents — needed by docker-entrypoint.sh).
+# su-exec: lightweight alpine equivalent of gosu — execs the target in
+#          the same process so SIGTERM propagates correctly. Used by the
+#          entrypoint shim AND by the conditional healthcheck below.
+RUN apk add --no-cache ca-certificates tzdata shadow su-exec
 COPY --from=go-builder /app/pad /usr/local/bin/pad
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
-# Create a non-root user (uid 1000) and data directory owned by it
-RUN adduser -D -u 1000 -h /home/pad pad \
+# In-image `pad` user/group at uid/gid 1000 — the entrypoint shim remaps
+# these to match PUID/PGID at container start (defaults 99/100, the
+# Unraid `nobody:users` convention). The actual numeric IDs can be
+# anything; 1000 is just the historical default.
+RUN addgroup -g 1000 pad \
+    && adduser -D -u 1000 -G pad -h /home/pad pad \
     && mkdir -p /data \
     && chown -R pad:pad /data
 ENV PAD_DATA_DIR=/data
 ENV PAD_HOST=0.0.0.0
 
-USER pad
+# IMPORTANT: NO `USER pad` directive — container starts as root so the
+# entrypoint shim can chown /data + remap user/group ids before
+# dropping privileges via `su-exec pad`. See TASK-1168 / PLAN-1166.
+
 EXPOSE 7777
 VOLUME /data
 
-HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-    CMD wget -q --spider http://localhost:7777/api/v1/health || exit 1
+# Healthcheck adapts to the caller's chosen execution model:
+#
+#   • Default invocation (container starts as root, entrypoint drops to pad):
+#     healthcheck runs as ROOT (Docker uses the image USER, which is root
+#     because we removed the USER directive). Wrap with su-exec so it
+#     matches the main process's unprivileged UID.
+#
+#   • `docker run --user 1234` invocation: healthcheck ALSO runs as 1234.
+#     `su-exec pad ...` would fail because 1234 lacks the privilege to
+#     switch to user `pad`. Just run wget directly in that branch.
+#
+# start-period bumped 10s → 60s. The always-chown-R policy (D4) means a
+# user restoring a backup with a large attachment store can legitimately
+# spend tens of seconds in the entrypoint before pad starts listening;
+# 60s covers ~600k files at 10k files/sec on local SSD.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
+    CMD sh -c 'if [ "$(id -u)" = "0" ]; then exec su-exec pad wget -q --spider http://localhost:7777/api/v1/health; fi; exec wget -q --spider http://localhost:7777/api/v1/health'
 
-ENTRYPOINT ["pad"]
+ENTRYPOINT ["docker-entrypoint.sh", "pad"]
 CMD ["server", "start"]

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,19 +1,32 @@
 FROM alpine:3.21
-RUN apk add --no-cache ca-certificates tzdata
+# Keep this package set in lockstep with Dockerfile (the local build
+# variant) — both images must support the same docker-entrypoint.sh
+# behavior. See Dockerfile for per-package rationale and TASK-1168 /
+# PLAN-1166 for the broader design.
+RUN apk add --no-cache ca-certificates tzdata shadow su-exec
 # dockers_v2 organizes goreleaser-built binaries under ${TARGETPLATFORM}/pad
 # (e.g. linux/amd64/pad, linux/arm64/pad). buildx sets TARGETPLATFORM
 # automatically per platform when the image is built.
 ARG TARGETPLATFORM
 COPY ${TARGETPLATFORM}/pad /usr/local/bin/pad
-RUN adduser -D -u 1000 -h /home/pad pad \
+# docker-entrypoint.sh must be listed in .goreleaser.yaml's
+# `dockers_v2.extra_files` for goreleaser to include it in the build
+# context — without that the COPY below fails.
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+RUN addgroup -g 1000 pad \
+    && adduser -D -u 1000 -G pad -h /home/pad pad \
     && mkdir -p /data \
     && chown -R pad:pad /data
 ENV PAD_DATA_DIR=/data
 ENV PAD_HOST=0.0.0.0
-USER pad
+# NO `USER pad` — container starts as root, entrypoint drops privileges.
 EXPOSE 7777
 VOLUME /data
-HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-    CMD wget -q --spider http://localhost:7777/api/v1/health || exit 1
-ENTRYPOINT ["pad"]
+# Conditional healthcheck (root → su-exec; non-root → direct wget) and
+# 60s start-period to absorb a slow chown -R on large data volumes.
+# See Dockerfile for the full rationale.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
+    CMD sh -c 'if [ "$(id -u)" = "0" ]; then exec su-exec pad wget -q --spider http://localhost:7777/api/v1/health; fi; exec wget -q --spider http://localhost:7777/api/v1/health'
+ENTRYPOINT ["docker-entrypoint.sh", "pad"]
 CMD ["server", "start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,19 @@ services:
       # Override by setting PAD_BIND_ADDR=0.0.0.0 (or a specific LAN IP) in .env.
       - "${PAD_BIND_ADDR:-127.0.0.1}:7777:7777"
     environment:
+      # Container UID/GID for the pad process. Default to 1000/1000 for
+      # backward compat with existing compose deploys whose volumes were
+      # created under the previous USER pad (uid 1000) image. Override to
+      # match your host volume's ownership if different.
+      #
+      # ${VAR-default} (no colon), not ${VAR:-default}. Compose follows
+      # shell-like semantics — colon form would silently convert PUID=
+      # or PGID= in .env to 1000, masking operator typos. Colon-less lets
+      # explicit-empty values reach the entrypoint, which rejects them
+      # with a clear error (matches docker-entrypoint.sh's own
+      # ${VAR-99} convention).
+      PUID: "${PUID-1000}"
+      PGID: "${PGID-1000}"
       PAD_HOST: "0.0.0.0"
       PAD_PORT: "7777"
       PAD_DB_DRIVER: "postgres"
@@ -55,11 +68,23 @@ services:
         condition: service_healthy
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://localhost:7777/api/v1/health"]
+      # Conditional: root → su-exec to pad; non-root → direct wget.
+      # Mirrors the Dockerfile HEALTHCHECK so `docker run --user 1234`
+      # pass-through still reports healthy.
+      #
+      # NOTE: $$(id -u), not $(id -u) — Compose performs $-interpolation
+      # on YAML strings BEFORE the value reaches the container. Single
+      # `$` would be parsed as a Compose variable reference; `$$` escapes
+      # to a literal `$` so the shell inside the container sees `$(id -u)`.
+      test: ["CMD-SHELL", "if [ \"$$(id -u)\" = \"0\" ]; then exec su-exec pad wget -q --spider http://localhost:7777/api/v1/health; fi; exec wget -q --spider http://localhost:7777/api/v1/health"]
       interval: 10s
       timeout: 5s
       retries: 3
-      start_period: 10s
+      # Bumped 10s → 60s. The always-chown-R policy in the entrypoint
+      # means a user restoring a backup with a large attachment store
+      # can spend tens of seconds before pad starts listening — 10s
+      # would mark the container unhealthy mid-startup.
+      start_period: 60s
 
   postgres:
     image: postgres:17-alpine

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,103 @@
+#!/bin/sh
+# docker-entrypoint.sh — UID/GID remapping shim for the pad container.
+#
+# Allows operators to run pad as their host's preferred uid/gid by setting
+# PUID and PGID env vars at container start. Mainly for Unraid users
+# (default 99/100 = nobody:users) but useful on Synology / TrueNAS / any
+# Docker host where the appdata volume is owned by something other than
+# uid 1000.
+#
+# Pattern adopted from LinuxServer.io. See TASK-1168 / PLAN-1166.
+#
+# Compatibility: /bin/sh (BusyBox-compatible). No bash-isms.
+
+set -e
+
+# Pass-through path: caller specified a uid via `docker run --user`. They
+# know what they want; we don't try to outsmart them. No chown, no
+# privilege drop — just exec the target program directly.
+if [ "$(id -u)" != "0" ]; then
+    exec "$@"
+fi
+
+# Remap path: container started as root (the default).
+#
+# Use ${VAR-default} (no colon), not ${VAR:-default}. The colon form
+# substitutes the default when VAR is unset OR empty, which would silently
+# accept `docker run -e PUID= -e PGID=` and mask a real operator typo.
+# The colon-less form only substitutes when VAR is unset, so an explicit
+# empty value falls through to validation and is rejected.
+PUID="${PUID-99}"
+PGID="${PGID-100}"
+
+# Validate: must be positive integers. Rejecting 0 explicitly is critical
+# — PUID=0 (root) or PGID=0 (root group) would defeat the unprivileged-
+# user invariant the whole shim exists to enforce. Empty / non-numeric
+# also fail loudly so an operator typo doesn't silently default.
+case "$PUID" in
+    ''|*[!0-9]*)
+        echo "docker-entrypoint: PUID must be a positive integer, got '$PUID'" >&2
+        exit 1
+        ;;
+esac
+case "$PGID" in
+    ''|*[!0-9]*)
+        echo "docker-entrypoint: PGID must be a positive integer, got '$PGID'" >&2
+        exit 1
+        ;;
+esac
+if [ "$PUID" = "0" ]; then
+    echo "docker-entrypoint: PUID=0 (root) is rejected — set a non-zero uid to keep pad unprivileged" >&2
+    exit 1
+fi
+if [ "$PGID" = "0" ]; then
+    echo "docker-entrypoint: PGID=0 (root group) is rejected — set a non-zero gid to keep pad unprivileged" >&2
+    exit 1
+fi
+
+# Remap the in-image `pad` user/group only when values differ — skips
+# the noisy "id changed" log entry on every warm restart in the steady
+# state.
+#
+# Use `id -u/-g pad` (BusyBox supports both flags) rather than
+# `getent group pad`: getent lives in the optional `musl-utils` package
+# on alpine, NOT in BusyBox's default applet list, so the entrypoint
+# would crash before chown/exec on a fresh `apk add` install that
+# didn't include it.
+current_uid="$(id -u pad)"
+current_gid="$(id -g pad)"
+if [ "$current_gid" != "$PGID" ]; then
+    groupmod -o -g "$PGID" pad
+fi
+if [ "$current_uid" != "$PUID" ] || [ "$current_gid" != "$PGID" ]; then
+    # Combined -u + -g ensures the user's /etc/passwd primary-gid field
+    # is updated to PGID even when only the group renumber happened.
+    # `groupmod` alone changes the group's gid but leaves the user's
+    # /etc/passwd line referencing the OLD gid number — su-exec would
+    # then launch pad with the wrong process gid.
+    usermod -o -u "$PUID" -g "$PGID" pad
+fi
+
+# Always chown -R the data directory.
+#
+# Statting only `/data` itself is unsafe: a user who restored a backup
+# tarball might have /data owned by the target uid but /data/pad.db,
+# /data/encryption.key, or /data/attachments/* owned differently, and a
+# shallow check would skip the recursive chown — leaving pad unable to
+# read its own DB. The few seconds of chown cost on warm restart with
+# large attachment stores is the correct trade for guaranteed correctness.
+#
+# Warn-and-continue (not fail-fast). chown -R can fail on individual
+# files for non-fatal reasons (immutable bits, root-squashed NFS,
+# partial permission gaps). Refusing to start pad over any single
+# failed file would lock the operator out of an otherwise-fine /data.
+# chown's per-file errors hit stderr already (visible in `docker logs`);
+# the trailing aggregated warning surfaces a single clear "investigate
+# this" line. The `||` form is set-e-safe.
+chown -R "$PUID:$PGID" /data \
+    || echo "docker-entrypoint: warning: chown -R /data had errors (see above). pad will start anyway; some files may not be writable." >&2
+
+# Drop privileges and exec. su-exec replaces the shell process so signals
+# (SIGTERM, SIGINT) propagate to the pad process correctly — without
+# this, docker stop's SIGTERM would hit the shell instead of pad.
+exec su-exec pad "$@"


### PR DESCRIPTION
## Summary

Adds a tiny `/bin/sh` entrypoint shim that lets operators run pad as their host's preferred uid/gid via `PUID`/`PGID` env vars. Solves the classic Unraid appdata-ownership-mismatch first-run failure (in-image uid 1000 can't write to a host volume owned by nobody:users 99:100). Reusable on Synology / QNAP / TrueNAS. Closes TASK-1168. Foundation for PLAN-1166 (Pad on Unraid).

- **`docker-entrypoint.sh`** (NEW): root-only chown + remap + drop-privileges via `su-exec`. Non-root invocations (`docker run --user`) pass through. Rejects PUID=0, PGID=0, empty, and non-numeric values. Always runs `chown -R` with warn-and-continue (correctness > warm-restart latency on backup-restore with mixed-ownership files).
- **`Dockerfile` + `Dockerfile.goreleaser`**: install `shadow` + `su-exec`, copy script, drop `USER pad`. Conditional healthcheck adapts to root vs `--user`. Start-period 10s → 60s to absorb slow chown on large stores.
- **`.goreleaser.yaml`**: add `docker-entrypoint.sh` to `dockers_v2.extra_files` (otherwise the published GHCR image build would fail).
- **`docker-compose.yml`**: PUID/PGID env (default 1000/1000 for backward compat); compose-specific healthcheck escapes `$$(id -u)` for the YAML interpolation gotcha.
- **`.env.example`**: documents PUID/PGID.

Independent of #424 (TASK-1167) — both feed into PLAN-1166 but neither depends on the other.

## Process

11 rounds of codex pre-implementation design review caught:
- gid bug where `groupmod` alone leaves `/etc/passwd`'s primary-gid stale
- Compose interpolation gotcha (`\$\$(id -u)` not `\$(id -u)` in YAML)
- `getent` missing from default alpine BusyBox
- Shell `\${VAR:-}` silently masking explicit empty values
- Healthcheck regressing to root after USER drop
- `su-exec` failing for `--user` non-root pass-through
- Many more — see commit message

Code-review pass on the actual diff: CLEAN on round 1.

## Behavior changes (worth calling out)

- Container starts as **root** (USER directive removed). Entrypoint drops to pad before exec'ing the binary. Standard PUID/PGID pattern.
- Default uids: **99/100 with raw `docker run`** (Unraid convention); **1000/1000 via docker-compose** (backward compat for existing deploys).
- Healthcheck `start-period` bumped 10s → 60s (absorbs slow `chown -R` on restored backups with large attachment stores).

## Test plan

- [x] `docker build -f Dockerfile -t pad:bootstrap-test .` — succeeds
- [x] **Default**: `docker run --rm pad:test` → uid=99 gid=100, /data owned 99:100
- [x] **PUID=1000 PGID=1000**: → uid=1000 gid=1000, /data owned 1000:1000 (F10 gid-fix pin)
- [x] **`--user 1234` pass-through**: → uid=1234, no chown, no su-exec attempt
- [x] **PUID=0 rejected**: exits 1 with clear "rejected — set a non-zero uid" error
- [x] **PUID=abc rejected**: exits 1 with "must be a positive integer" error
- [x] **PUID= (empty) rejected**: exits 1 with same error (validation pin)
- [x] **PGID=0 rejected**: exits 1 with "rejected — set a non-zero gid" error
- [x] `make check` — lint + tests + web build all green
- [x] `codex` review on uncommitted diff — CLEAN
- [ ] Manual smoke test on a real Unraid container (deferred to TASK-1171)
- [ ] Multi-arch goreleaser snapshot build (verify Dockerfile.goreleaser + extra_files; deferred to release)

## Image size delta

~1.3 MB (shadow ~1.3 MB + su-exec ~13 KB). Slight overshoot of my own <1 MB target but acceptable for the feature value — won't be noticed by operators.

## Out of scope

- Real Unraid smoke test (TASK-1171)
- Updating the Unraid XML template to surface PUID/PGID fields (TASK-1169)
- Adding shellcheck to `make check` (separate task)