### PR TITLE
fix(auth): emit first-run bootstrap banner to stderr with real newlines (BUG-1182)

### DIFF
--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -798,8 +798,29 @@ func logBootstrapBanner(token string, cfg *config.Config, tokenPath string) {
 
   To regenerate, delete %s and restart.
 
-========================================================================`, url, tokenPath)
-	slog.Info(banner)
+========================================================================
+`, url, tokenPath)
+
+	// BUG-1182: bypass slog for the banner. slog's text handler is
+	// contractually one-line-per-record and escapes literal newlines as
+	// `\n`, which renders the multi-line banner as a single wide line in
+	// `docker logs` — exactly the surface where operators look for it.
+	// Banner-style operator output isn't structured logging; stderr is the
+	// conventional channel for it (kubectl / docker / helm / systemd all
+	// do this). docker logs captures stderr alongside stdout, so the
+	// banner stays visible.
+	fmt.Fprint(os.Stderr, banner)
+
+	// Companion structured log so log aggregators that parse slog JSON
+	// still record the event. Deliberately does NOT include the URL or
+	// token — those are in the stderr banner where the operator looks
+	// for them. Repeating the URL as a parseable structured field would
+	// give log aggregators an easy-to-extract token, which is precisely
+	// what the URL-fragment design (TASK-1167 F10) is trying to avoid.
+	// Operators / agents that want the token programmatically should
+	// read the token_path file directly.
+	slog.Info("first-run bootstrap setup banner emitted to stderr — see container logs",
+		"token_path", tokenPath)
 }
 
 // --- stop ---


### PR DESCRIPTION
## Summary

slog's text handler is contractually one-line-per-record and escapes literal newlines as \`\n\`. The multi-line bootstrap banner rendered as a single wide line in \`docker logs\` — exactly the surface where operators look for the token. Closes BUG-1182.

Switches the banner to \`fmt.Fprint(os.Stderr, banner)\` (real newlines), with a companion \`slog.Info\` one-liner so structured-log aggregators still record the event without the cosmetic banner content.

## Privacy detail

The companion slog log deliberately does **NOT** include the URL or token in structured fields. Doing so would expose the token as a parseable value to any log aggregator that ingests the JSON stream — defeating the URL-fragment design (TASK-1167 F10) that keeps the token off-server. Operators / agents wanting the token programmatically read the on-disk file at \`token_path\`.

## Caught during

Dave's TASK-1171 smoke test against \`v0.3.0-rc.1\` on a real Unraid box. Sample log output before the fix (one wide line per banner emission, escaped \`\n\` characters):

\`\`\`
time=… level=INFO msg="\n=========…\n  Pad first-run setup\n========\n\n  No users exist yet…\n\n      http://<your-host>:7777/setup#token=…\n\n  This token is one-time…"
\`\`\`

After the fix: ASCII box renders with actual newlines in \`docker logs\`; structured-log consumers see a one-line companion record pointing at \`token_path\` for programmatic access.

## Going into v0.3.0-rc.2

Folding into rc.2 rather than holding for stable so the smoke test gets to validate the fixed banner before v0.3.0 ships.

## Test plan

- [x] \`make check\` — lint + tests + web build pass
- [x] Local \`pad server start\` smoke: banner renders with real newlines, structured companion log appears below
- [x] Companion slog log has only \`token_path\` field, no URL/token leakage
- [ ] Unraid container smoke against \`:0.3.0-rc.2\` (deferred until release lands)