### PR TITLE
refactor(e2e): extract demo data into shared module (TASK-1201)

### DIFF
--- a/web/e2e/lib/demo-data.ts
+++ b/web/e2e/lib/demo-data.ts
@@ -1,0 +1,164 @@
+/**
+ * Shared demo data — single source of truth for "what a real-feeling Pad
+ * workspace looks like."
+ *
+ * Two consumers today:
+ *   - web/e2e/lib/demo-seed.ts        (Playwright fixture seeder; turns
+ *                                      this data into HTTP POSTs against a
+ *                                      live pad server)
+ *   - pad-remotion/src/data/demoItems.ts (Remotion compositions; uses
+ *                                      this data to populate kanban cards
+ *                                      and context-stream ghosts)
+ *
+ * pad-remotion lives in a sibling repo, so it carries a copy of this file
+ * rather than a path import. Keep the shapes and titles identical — when
+ * you change anything here, mirror the change in pad-remotion. A CI drift
+ * check is a possible follow-up if this duplication starts to bite.
+ */
+
+export interface DemoPlan {
+	/** Plan title rendered in cards / scenes. */
+	title: string;
+	/** Pad plan status (`active`, `planned`, `completed`, `paused`). */
+	status: string;
+	/** Markdown body — short, marketing-friendly. */
+	content: string;
+}
+
+export interface DemoTask {
+	title: string;
+	/** Pad task status (`open`, `in-progress`, `done`, `cancelled`). */
+	status: string;
+	/** Pad task priority (`low`, `medium`, `high`, `critical`). */
+	priority: string;
+	/** Pad effort estimate (`xs`, `s`, `m`, `l`, `xl`). */
+	effort?: string;
+	/**
+	 * Whether this task is parented to `demoPlan`. The seeder maps this to
+	 * the freshly-created plan id; pad-remotion uses it to render
+	 * parent-child link visuals.
+	 */
+	parentToPlan?: boolean;
+}
+
+export interface DemoIdea {
+	title: string;
+	/** Pad idea status (`new`, `exploring`, `planned`, `implemented`, `rejected`). */
+	status: string;
+	/** Pad idea impact (`low`, `medium`, `high`). */
+	impact: string;
+}
+
+export interface DemoConvention {
+	title: string;
+	/** Pad convention trigger (`always`, `on-implement`, `on-commit`, ...). */
+	trigger: string;
+	priority: 'must' | 'should' | 'nice-to-have';
+	/** Defaults to `all` when omitted. */
+	scope?: 'all' | 'backend' | 'frontend' | 'mobile' | 'docs' | 'devops';
+}
+
+/**
+ * Active plan with non-zero progress for the dashboard "Active Plans" widget.
+ */
+export const demoPlan: DemoPlan = {
+	title: 'v0.2 — Collaboration',
+	status: 'active',
+	content: 'Real-time multiplayer editing, team invites, and shared views.'
+};
+
+/**
+ * Realistic mix of statuses, priorities, parent linkage. Designed so the
+ * board view shows meaningful columns and the dashboard's plan progress
+ * widget reads non-zero (3 of 5 plan-linked tasks are in-flight or done).
+ */
+export const demoTasks: DemoTask[] = [
+	{
+		title: 'Fix OAuth redirect bug',
+		status: 'in-progress',
+		priority: 'high',
+		effort: 'm',
+		parentToPlan: true
+	},
+	{
+		title: 'Add rate limiting to API endpoints',
+		status: 'in-progress',
+		priority: 'high',
+		effort: 'l',
+		parentToPlan: true
+	},
+	{
+		title: 'Refactor auth middleware',
+		status: 'open',
+		priority: 'medium',
+		effort: 'm'
+	},
+	{
+		title: 'Add SSO support for enterprise users',
+		status: 'open',
+		priority: 'medium',
+		effort: 'xl',
+		parentToPlan: true
+	},
+	{
+		title: 'Document the deploy pipeline',
+		status: 'open',
+		priority: 'low',
+		effort: 's'
+	},
+	{
+		title: 'Update Go to 1.26',
+		status: 'done',
+		priority: 'medium',
+		effort: 's'
+	},
+	{
+		title: 'Set up CI security scanning',
+		status: 'done',
+		priority: 'high',
+		effort: 's',
+		parentToPlan: true
+	}
+];
+
+/**
+ * Two ideas at different stages — gives the ideas page something to render.
+ */
+export const demoIdeas: DemoIdea[] = [
+	{ title: 'Real-time presence indicators', status: 'exploring', impact: 'high' },
+	{ title: 'Slack integration for notifications', status: 'new', impact: 'medium' }
+];
+
+/**
+ * A handful of conventions covering the common triggers. Used by
+ * pad-remotion's ContextScene to populate ghost-card streams; not
+ * currently consumed by demo-seed.ts (which calls `seedConventions`
+ * directly with caller-supplied input), but lives here so the shared
+ * data shape is complete.
+ */
+export const demoConventions: DemoConvention[] = [
+	{
+		title: 'Run tests before pushing',
+		trigger: 'on-commit',
+		priority: 'must',
+		scope: 'all'
+	},
+	{
+		title: 'Use conventional commit format',
+		trigger: 'on-commit',
+		priority: 'should',
+		scope: 'all'
+	},
+	{
+		title: 'Tasks should be PR-sized',
+		trigger: 'on-plan',
+		priority: 'should',
+		scope: 'all'
+	},
+	{
+		title: 'Codex review every PR before merge',
+		trigger: 'on-pr-create',
+		priority: 'must',
+		scope: 'all'
+	}
+];

--- a/web/e2e/lib/demo-seed.ts
+++ b/web/e2e/lib/demo-seed.ts
@@ -1,5 +1,6 @@
 import type { APIRequestContext } from '@playwright/test';
 import type { SuiteFixture } from '../fixtures';
+import { demoIdeas, demoPlan, demoTasks, type DemoTask } from './demo-data';
 
 /**
  * Shared seeding helpers for screenshot specs.
@@ -11,6 +12,11 @@ import type { SuiteFixture } from '../fixtures';
  * Each helper hits the same REST endpoints the web UI uses, so the
  * resulting items behave identically to ones a human creates via the
  * dashboard.
+ *
+ * The static "what a realistic workspace looks like" data lives in
+ * ./demo-data.ts so pad-remotion (sibling repo) can consume the same
+ * shape without depending on Playwright. Update demo-data.ts and mirror
+ * the change in pad-remotion when adding/removing items.
  */
 
 // `fields` is a JSON-encoded string on the wire (see
@@ -25,6 +31,19 @@ function authHeaders(fixture: SuiteFixture) {
 }
 
 /**
+ * Build the on-the-wire `fields` object for a demo task. Filters out
+ * undefined effort so we don't post `effort: undefined` JSON.
+ */
+function taskFields(t: DemoTask): Record<string, string> {
+	const fields: Record<string, string> = {
+		status: t.status,
+		priority: t.priority
+	};
+	if (t.effort) fields.effort = t.effort;
+	return fields;
+}
+
+/**
  * Realistic-looking project: one active plan, half a dozen tasks across
  * statuses + priorities, a couple of ideas. Designed to make the
  * dashboard's "Active Plans" widget show a non-zero progress bar and
@@ -34,6 +53,8 @@ function authHeaders(fixture: SuiteFixture) {
  * each call will create *additional* items, but the screenshots only
  * care that there's *some* content. If you need a clean slate, point
  * Playwright at a fresh PAD_E2E_DATA_DIR.
+ *
+ * Data sourced from ./demo-data.ts.
  */
 export async function seedRealisticContent(fixture: SuiteFixture, request: APIRequestContext) {
 	const ws = fixture.workspaceSlug;
@@ -43,9 +64,9 @@ export async function seedRealisticContent(fixture: SuiteFixture, request: APIRe
 	const planResp = await request.post(`/api/v1/workspaces/${ws}/collections/plans/items`, {
 		headers,
 		data: {
-			title: 'v0.2 — Collaboration',
-			fields: enc({ status: 'active' }),
-			content: 'Real-time multiplayer editing, team invites, and shared views.'
+			title: demoPlan.title,
+			fields: enc({ status: demoPlan.status }),
+			content: demoPlan.content
 		}
 	});
 	if (!planResp.ok()) {
@@ -55,48 +76,14 @@ export async function seedRealisticContent(fixture: SuiteFixture, request: APIRe
 	if (!plan.id) throw new Error('plan create succeeded but response missing id');
 
 	// 2. Tasks — explicit mix of status / priority / parent linkage
-	const tasks: { title: string; fields: Record<string, string>; parent?: string }[] = [
-		{
-			title: 'Fix OAuth redirect bug',
-			fields: { status: 'in-progress', priority: 'high', effort: 'm' },
-			parent: plan.id
-		},
-		{
-			title: 'Add rate limiting to API endpoints',
-			fields: { status: 'in-progress', priority: 'high', effort: 'l' },
-			parent: plan.id
-		},
-		{
-			title: 'Refactor auth middleware',
-			fields: { status: 'open', priority: 'medium', effort: 'm' }
-		},
-		{
-			title: 'Add SSO support for enterprise users',
-			fields: { status: 'open', priority: 'medium', effort: 'xl' },
-			parent: plan.id
-		},
-		{
-			title: 'Document the deploy pipeline',
-			fields: { status: 'open', priority: 'low', effort: 's' }
-		},
-		{
-			title: 'Update Go to 1.26',
-			fields: { status: 'done', priority: 'medium', effort: 's' }
-		},
-		{
-			title: 'Set up CI security scanning',
-			fields: { status: 'done', priority: 'high', effort: 's' },
-			parent: plan.id
-		}
-	];
-
-	for (const t of tasks) {
+	for (const t of demoTasks) {
+		const parent = t.parentToPlan ? plan.id : undefined;
 		const resp = await request.post(`/api/v1/workspaces/${ws}/collections/tasks/items`, {
 			headers,
 			data: {
 				title: t.title,
-				fields: enc(t.fields),
-				...(t.parent ? { parent_id: t.parent } : {})
+				fields: enc(taskFields(t)),
+				...(parent ? { parent_id: parent } : {})
 			}
 		});
 		if (!resp.ok()) {
@@ -105,14 +92,13 @@ export async function seedRealisticContent(fixture: SuiteFixture, request: APIRe
 	}
 
 	// 3. Ideas — a couple, varied state
-	const ideas: { title: string; fields: Record<string, string> }[] = [
-		{ title: 'Real-time presence indicators', fields: { status: 'exploring', impact: 'high' } },
-		{ title: 'Slack integration for notifications', fields: { status: 'new', impact: 'medium' } }
-	];
-	for (const idea of ideas) {
+	for (const idea of demoIdeas) {
 		const resp = await request.post(`/api/v1/workspaces/${ws}/collections/ideas/items`, {
 			headers,
-			data: { title: idea.title, fields: enc(idea.fields) }
+			data: {
+				title: idea.title,
+				fields: enc({ status: idea.status, impact: idea.impact })
+			}
 		});
 		if (!resp.ok()) {
 			throw new Error(`idea ${idea.title} failed (${resp.status()}): ${await resp.text()}`);


### PR DESCRIPTION
## Summary

Lift the static "realistic workspace" demo data out of `seedRealisticContent` (in `web/e2e/lib/demo-seed.ts`) into a new sibling module `web/e2e/lib/demo-data.ts`. This makes the data consumable by `pad-remotion` (sibling repo, used to render the homepage hero animation) without dragging in Playwright as a dependency.

Wire-shape compatibility is preserved exactly:

| Item | Behavior |
|---|---|
| `demoPlan` | Same title (`v0.2 — Collaboration`), status (`active`), content |
| `demoTasks` | Same 7 tasks in same order; same `status` / `priority` / `effort`; same parent-to-plan linkage (now expressed via `parentToPlan: boolean` and mapped to the freshly-created plan id by the seeder) |
| `demoIdeas` | Same 2 ideas with same fields |

`demoConventions` is also exported (4 representative entries — `on-commit`, `on-plan`, `on-pr-create`) for the `pad-remotion` ContextScene to render ghost-cards. `demo-seed.ts` itself doesn't consume it, but the shape lives here so the shared module is complete.

## Context

- **Parent task:** TASK-1201 — Extract demo-seed data into shared module consumable by E2E + pad-remotion
- **Parent plan:** PLAN-1198 — Pad-Remotion: hero marketing video v1
- **Concept doc:** IDEA-1197

### Cross-repo strategy (the task's open question)

> If pad-remotion is a separate repo and we don't want a path dependency, copy the file once and add a CI/lint check that flags drift. Decide during implementation.

Decision: **copy-with-manual-sync**. pad-remotion is a distinct git repo, so a path import / symlink is fragile; an npm workspace is overkill for two consumers. The shared file is small and stable. A CI drift check is a possible follow-up if this duplication starts to bite (deferred — not flagged as a blocking task).

The companion pad-remotion file (`src/data/demoItems.ts`) lands as a separate PR in `PerpetualSoftware/pad-remotion` immediately after this one merges.

## Test plan

- [x] `make check` (golangci-lint + go test + cd web && npm run build) — clean
- [x] `cd web && PAD_SCREENSHOTS=1 npx playwright test e2e/screenshots.spec.ts --project=desktop-chromium` — passes (4.0s); `seedRealisticContent` runs end-to-end against the embedded test server
- [x] Dashboard/board/list/table screenshots regenerated identically (reverted; not part of the diff)
- [x] No behavior change for existing E2E specs that don't set `PAD_SCREENSHOTS=1`