### PR TITLE
feat(auth): browser-based pad auth setup via /setup#token deep link (TASK-1216)

### DIFF
--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -951,10 +951,17 @@ func openBrowser(url string) error {
 // --- auth commands ---
 
 func setupCmd() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "setup",
 		Short: "Initialize a fresh Pad instance with the first admin account",
-		RunE: func(cmd *cobra.Command, args []string) error {
+		Long: `Initialize a fresh Pad instance with the first admin account.
+
+By default the CLI hands the operator a deep link into the browser-based
+/setup form (which uses password managers, HTML5 email validation, and the
+live strength meter). If the browser path won't work — headless server
+without an SSH tunnel, broken X11, etc. — re-run with --cli-prompt for the
+legacy in-terminal email/name/password prompts.`,
+		RunE: func(cmd *cobra.Command, args []string) (retErr error) {
 			cfg := getConfig()
 			if !cfg.IsConfigured() {
 				// Allow host-local bootstrap on a pristine machine before the
@@ -968,6 +975,14 @@ func setupCmd() *cobra.Command {
 					return fmt.Errorf("remote Pad instances must be initialized on the server host with 'pad auth setup'")
 				}
 			}
+
+			// Honour the same Cancelled. + exit-130 path as login when the
+			// user hits Ctrl+C during the browser flow's polling loop.
+			defer func() {
+				if isCancellation(retErr) {
+					cancelInit()
+				}
+			}()
 
 			if err := cli.EnsureServer(cfg); err != nil {
 				return err
@@ -987,21 +1002,89 @@ func setupCmd() *cobra.Command {
 				return nil
 			}
 
-			resp, err := promptAndBootstrap(client)
-			if err != nil {
-				return err
+			cliPrompt, _ := cmd.Flags().GetBool("cli-prompt")
+			if cliPrompt {
+				return runCLISetup(cfg, client)
 			}
-			if err := saveCredentials(cfg, resp); err != nil {
-				return err
-			}
-
-			green := color.New(color.FgGreen).SprintFunc()
-			fmt.Printf("%s First admin account created\n", green("✓"))
-			fmt.Printf("%s Logged in as %s (%s)\n", green("✓"), resp.User.Name, resp.User.Email)
-			printPostSetupNextStepsHint()
-			return nil
+			return runBrowserSetup(cmd.Context(), cfg, client)
 		},
 	}
+	// --cli-prompt is the deliberate hedge from IDEA-1179 / TASK-1216: we
+	// don't believe a CLI fallback is needed (Pad is fundamentally a
+	// network-accessible web service — if the operator can't reach the
+	// browser flow on localhost, their setup is misconfigured), but
+	// keeping the flag is zero-cost and gives users a workaround if a
+	// concrete blocker shows up. Each --cli-prompt usage is a signal we
+	// should rethink the assumption.
+	cmd.Flags().Bool("cli-prompt", false, "Use the legacy in-terminal email/name/password prompts instead of the browser /setup flow.")
+	return cmd
+}
+
+// runBrowserSetup drives the browser-based first-admin bootstrap and then
+// chains a CLI auth-session login so the user ends up authenticated on
+// the CLI — mirroring the post-condition of the legacy --cli-prompt path
+// (Bootstrap returns a token and we save credentials in one shot). Two
+// browser approvals — one to create the admin, one to authorize the CLI
+// — but each is a single click in a browser the operator already has
+// open, and the alternative (telling them to manually run `pad auth
+// login` afterwards) is a worse UX.
+func runBrowserSetup(ctx context.Context, cfg *config.Config, client *cli.Client) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	bootstrapCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+	defer signal.Stop(sigCh)
+	go func() {
+		select {
+		case <-sigCh:
+			cancel()
+		case <-bootstrapCtx.Done():
+		}
+	}()
+
+	if err := cli.RunBrowserBootstrap(bootstrapCtx, client, cfg); err != nil {
+		// Map ctx cancellation to the canonical errCancelled sentinel so
+		// the deferred isCancellation() check in the parent RunE routes
+		// us through "Cancelled." + exit 130 instead of cobra's generic
+		// error path.
+		if errors.Is(err, context.Canceled) {
+			return errCancelled
+		}
+		return err
+	}
+
+	green := color.New(color.FgGreen).SprintFunc()
+	fmt.Printf("  %s First admin account created\n", green("✓"))
+	fmt.Println()
+	fmt.Println("  Authenticating the CLI…")
+	if err := doBrowserLogin(client, cfg); err != nil {
+		return err
+	}
+	printPostSetupNextStepsHint()
+	return nil
+}
+
+// runCLISetup is the legacy in-terminal admin bootstrap, reachable via
+// `pad auth setup --cli-prompt`. Kept verbatim from the pre-TASK-1216
+// behavior so users with broken browser paths have a working escape
+// hatch.
+func runCLISetup(cfg *config.Config, client *cli.Client) error {
+	resp, err := promptAndBootstrap(client)
+	if err != nil {
+		return err
+	}
+	if err := saveCredentials(cfg, resp); err != nil {
+		return err
+	}
+
+	green := color.New(color.FgGreen).SprintFunc()
+	fmt.Printf("%s First admin account created\n", green("✓"))
+	fmt.Printf("%s Logged in as %s (%s)\n", green("✓"), resp.User.Name, resp.User.Email)
+	printPostSetupNextStepsHint()
+	return nil
 }
 
 // printPostSetupNextStepsHint walks the freshly-bootstrapped admin to the

--- a/internal/cli/bootstrap.go
+++ b/internal/cli/bootstrap.go
@@ -62,6 +62,11 @@ var bootstrapPollTimeout = 5 * time.Minute
 // setup_required: false), an error if the helper can't proceed (no token
 // configured, token file unreadable, timeout, ctx cancelled).
 //
+// Callers in this PR: only setupCmd (`pad auth setup`). TASK-1217 adds
+// `pad init` as the second caller — until that lands, `pad init` keeps
+// using the legacy promptAndBootstrap path. Splitting the wiring across
+// two PRs is deliberate (CONVE-2 "tasks should be PR-sized").
+//
 // On success the server has a first admin but the CLI has not been issued
 // any credentials — the browser owns the session cookie. Callers that
 // want the CLI to be authenticated afterwards should chain a CLI-auth-
@@ -69,8 +74,8 @@ var bootstrapPollTimeout = 5 * time.Minute
 //
 // The helper is idempotent: if the server already reports
 // setup_required: false on entry, it returns nil immediately without
-// touching the token file or printing anything. That matters for `pad init`
-// against a server where setup is already done.
+// touching the token file or printing anything. That matters for any
+// caller invoking it against a server where setup is already done.
 func RunBrowserBootstrap(ctx context.Context, client *Client, cfg *config.Config) error {
 	if client == nil {
 		return errors.New("RunBrowserBootstrap: nil client")

--- a/internal/cli/bootstrap.go
+++ b/internal/cli/bootstrap.go
@@ -1,0 +1,219 @@
+package cli
+
+// Browser-driven first-admin bootstrap (TASK-1216 / IDEA-1179).
+//
+// `pad auth setup` and `pad init` previously prompted for email / name /
+// password in the terminal, calling POST /api/v1/auth/bootstrap directly.
+// That worked but lost out to the browser /setup flow on every UX axis:
+// no password manager, no HTML5 email validation, no live strength meter.
+//
+// TASK-1167 / PLAN-1166 shipped a logs-token bootstrap so Docker / Unraid
+// operators can claim the first admin from a remote browser. That same
+// token sits at <DataDir>/.bootstrap-token on a local install, and the
+// CLI runs as the same UID as the server, so we can read it directly and
+// hand the operator a deep link into the same browser flow.
+//
+// RunBrowserBootstrap is the helper. It checks /api/v1/auth/session, reads
+// the token if one is configured, prints the /setup URL, and polls until
+// the session check reports setup_required: false (or 5 minutes elapses).
+// Caller (setupCmd / pad init) is responsible for wiring up SIGINT to the
+// passed-in context and for any post-bootstrap login plumbing.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/fatih/color"
+
+	"github.com/PerpetualSoftware/pad/internal/config"
+)
+
+// bootstrapTokenFilename mirrors internal/server/bootstrap.go's constant of
+// the same name. Kept in sync rather than imported because internal/cli
+// otherwise has no dependency on internal/server, and the filename is a
+// trivial stable contract — both places own it together. If this ever
+// drifts, the symptom is "bootstrap token file not found" on a server that
+// did generate one, which is an immediate, loud failure.
+const bootstrapTokenFilename = ".bootstrap-token"
+
+// bootstrapPollInterval is how often the helper re-checks /api/v1/auth/session
+// once the URL has been printed. 2s matches doBrowserLogin's CLI auth poll
+// cadence — slow enough to not hammer the server, fast enough that the
+// "✓ Setup complete" line lands within a couple seconds of the operator
+// finishing the form. var (not const) so the test suite can shrink it for
+// timing-sensitive assertions without making real users wait minutes.
+var bootstrapPollInterval = 2 * time.Second
+
+// bootstrapPollTimeout caps how long RunBrowserBootstrap waits for the
+// browser side to finish. 5 minutes is generous for an interactive admin
+// form and short enough that an abandoned terminal doesn't sit waiting
+// indefinitely. The caller's SIGINT path can cut this short via ctx.
+// var (not const) so tests can exercise the timeout branch in
+// milliseconds.
+var bootstrapPollTimeout = 5 * time.Minute
+
+// RunBrowserBootstrap walks the operator through the browser-based first-
+// admin bootstrap. Returns nil on success (server has flipped to
+// setup_required: false), an error if the helper can't proceed (no token
+// configured, token file unreadable, timeout, ctx cancelled).
+//
+// On success the server has a first admin but the CLI has not been issued
+// any credentials — the browser owns the session cookie. Callers that
+// want the CLI to be authenticated afterwards should chain a CLI-auth-
+// session login (see doBrowserLogin in cmd/pad/main.go) once this returns.
+//
+// The helper is idempotent: if the server already reports
+// setup_required: false on entry, it returns nil immediately without
+// touching the token file or printing anything. That matters for `pad init`
+// against a server where setup is already done.
+func RunBrowserBootstrap(ctx context.Context, client *Client, cfg *config.Config) error {
+	if client == nil {
+		return errors.New("RunBrowserBootstrap: nil client")
+	}
+	if cfg == nil {
+		return errors.New("RunBrowserBootstrap: nil config")
+	}
+
+	session, err := client.CheckSession()
+	if err != nil {
+		return fmt.Errorf("check server status: %w", err)
+	}
+	if !session.SetupRequired {
+		// Already bootstrapped — nothing to do.
+		return nil
+	}
+
+	url, err := buildBootstrapURL(cfg, session.SetupMethod)
+	if err != nil {
+		return err
+	}
+
+	bold := color.New(color.Bold).SprintFunc()
+	fmt.Println()
+	fmt.Println("  Open this URL in your browser to finish setup:")
+	fmt.Println()
+	fmt.Printf("  %s\n", bold(url))
+	fmt.Println()
+	fmt.Println("  Waiting for setup to complete (Ctrl+C to cancel)...")
+
+	if err := pollUntilSetupDone(ctx, client); err != nil {
+		return err
+	}
+
+	green := color.New(color.FgGreen).SprintFunc()
+	fmt.Printf("  %s Setup complete\n", green("✓"))
+	return nil
+}
+
+// buildBootstrapURL constructs the /setup URL the operator should open.
+//
+// setup_method dispatch (kept in sync with handleSessionCheck in
+// internal/server/handlers_auth.go):
+//
+//   - "logs_token" — server generated a one-time token and persisted it to
+//     <DataDir>/.bootstrap-token. We read it and hand the operator a deep
+//     link with the token in the URL fragment (#token=...). The fragment
+//     is scrubbed from the address bar by /setup's onMount before paint
+//     so the secret doesn't survive in browser history (TASK-1167 F10).
+//
+//   - "open" — operator started the server with PAD_BYPASS_SETUP_TOKEN=true
+//     on a self-host deployment. The /setup form works directly, no token
+//     needed. We just print the bare /setup URL.
+//
+//   - "local_cli" or "" — the server failed to provision a bootstrap token
+//     (read-only DataDir, etc.) and the bypass flag isn't set, so the only
+//     working path is the loopback-gated POST /api/v1/auth/bootstrap. The
+//     browser flow can't proceed; tell the user to use --cli-prompt.
+//
+//   - anything else — newer server speaking a method this CLI doesn't know.
+//     Bail loudly with the same --cli-prompt fallback hint.
+func buildBootstrapURL(cfg *config.Config, setupMethod string) (string, error) {
+	base := cfg.BrowserURL()
+
+	switch setupMethod {
+	case "logs_token":
+		token, err := readBootstrapToken(cfg.DataDir)
+		if err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("%s/setup#token=%s", base, token), nil
+
+	case "open":
+		return base + "/setup", nil
+
+	case "", "local_cli":
+		return "", fmt.Errorf("server has no bootstrap token configured (setup_method=%q); re-run with --cli-prompt to use the legacy TTY flow", setupMethod)
+
+	default:
+		return "", fmt.Errorf("server reported unknown setup_method=%q; this CLI may be older than the server. Re-run with --cli-prompt to use the legacy TTY flow", setupMethod)
+	}
+}
+
+// readBootstrapToken reads <DataDir>/.bootstrap-token. The file is created
+// by EnsureBootstrapToken in internal/server/bootstrap.go with mode 0600
+// and contains the base64url-encoded token followed by a trailing newline.
+//
+// Errors are wrapped with the absolute path so the operator can find the
+// file (or confirm it's actually missing) without guessing where DataDir
+// resolves to. The "--cli-prompt" hint is appended because that's the
+// recoverable fallback for every failure mode here (file consumed already,
+// permissions wrong, DataDir on a read-only mount).
+func readBootstrapToken(dataDir string) (string, error) {
+	path := filepath.Join(dataDir, bootstrapTokenFilename)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", fmt.Errorf("bootstrap token file %s not found — the server may have already consumed it, or token generation failed at startup. Re-run with --cli-prompt to use the legacy TTY flow", path)
+		}
+		return "", fmt.Errorf("read bootstrap token %s: %w (re-run with --cli-prompt to use the legacy TTY flow)", path, err)
+	}
+	token := strings.TrimSpace(string(data))
+	if token == "" {
+		return "", fmt.Errorf("bootstrap token file %s is empty; delete it and restart the server, or re-run with --cli-prompt to use the legacy TTY flow", path)
+	}
+	return token, nil
+}
+
+// pollUntilSetupDone tickets every bootstrapPollInterval and returns nil
+// the first time CheckSession reports setup_required: false. Returns
+// ctx.Err() on caller cancellation, a wrapped timeout error after
+// bootstrapPollTimeout elapses inside the helper. Transient CheckSession
+// errors are tolerated — we keep polling, since a momentary network blip
+// during the human form-filling window is almost always recoverable.
+// Only ctx.Done() and the timeout end the loop.
+//
+// The internal timeout is a separate timer rather than a wrapped
+// context.WithTimeout so caller-ctx cancellation surfaces as ctx.Err()
+// (DeadlineExceeded or Canceled) instead of being misreported as the
+// helper's own 5-minute timeout.
+func pollUntilSetupDone(ctx context.Context, client *Client) error {
+	timeout := time.NewTimer(bootstrapPollTimeout)
+	defer timeout.Stop()
+
+	ticker := time.NewTicker(bootstrapPollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-timeout.C:
+			return fmt.Errorf("timed out waiting for setup after %s. Re-run when finished, or use --cli-prompt for the legacy TTY flow", bootstrapPollTimeout)
+		case <-ticker.C:
+			session, err := client.CheckSession()
+			if err != nil {
+				// Transient — keep polling. A stable disconnect will surface as
+				// the timeout above; a one-off will recover on the next tick.
+				continue
+			}
+			if !session.SetupRequired {
+				return nil
+			}
+		}
+	}
+}

--- a/internal/cli/bootstrap_test.go
+++ b/internal/cli/bootstrap_test.go
@@ -1,0 +1,348 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/config"
+)
+
+// fakeSessionServer returns an httptest.Server whose /api/v1/auth/session
+// handler responds with the SessionResponse produced by `gen` (called once
+// per request so tests can flip setup_required mid-poll). On any other
+// path it 404s — caller is responsible for not hitting other endpoints.
+func fakeSessionServer(t *testing.T, gen func() SessionResponse) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/auth/session" {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(gen())
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// newTestConfig points DataDir at a fresh tmp dir and BrowserURL at the
+// given test server. Most tests want both wired up together.
+func newTestConfig(t *testing.T, browserURL string) *config.Config {
+	t.Helper()
+	cfg := config.DefaultConfig()
+	cfg.DataDir = t.TempDir()
+	// BrowserURL prefers cfg.URL when set, which sidesteps the
+	// host-rewriting branch and gives us a stable URL to assert on.
+	cfg.URL = browserURL
+	return cfg
+}
+
+// writeBootstrapToken drops a token file at <dataDir>/.bootstrap-token in
+// the same shape EnsureBootstrapToken would produce — token + trailing
+// newline, mode 0600 — so readBootstrapToken sees what it expects.
+func writeBootstrapToken(t *testing.T, dataDir, token string) {
+	t.Helper()
+	path := filepath.Join(dataDir, bootstrapTokenFilename)
+	if err := os.WriteFile(path, []byte(token+"\n"), 0600); err != nil {
+		t.Fatalf("write bootstrap token: %v", err)
+	}
+}
+
+// TestRunBrowserBootstrap_Idempotent confirms the helper is a no-op when
+// the server already reports setup_required: false — important for
+// `pad init` against a server where setup is already done. Should not
+// touch the token file.
+func TestRunBrowserBootstrap_Idempotent(t *testing.T) {
+	srv := fakeSessionServer(t, func() SessionResponse {
+		return SessionResponse{Authenticated: true, SetupRequired: false}
+	})
+	cfg := newTestConfig(t, srv.URL)
+	client := NewClientFromURL(srv.URL)
+
+	// Deliberately do NOT write a token file. If the helper short-circuits
+	// correctly on setup_required: false, it should never need to read it.
+	if err := RunBrowserBootstrap(context.Background(), client, cfg); err != nil {
+		t.Fatalf("RunBrowserBootstrap returned %v on already-bootstrapped server, want nil", err)
+	}
+}
+
+// TestRunBrowserBootstrap_LogsTokenSuccess covers the happy path:
+// setup_required: true with a valid token on disk, server flips to
+// setup_required: false on the second poll, helper returns nil.
+func TestRunBrowserBootstrap_LogsTokenSuccess(t *testing.T) {
+	withFastPolling(t, 10*time.Millisecond, 5*time.Second)
+
+	var calls atomic.Int32
+	srv := fakeSessionServer(t, func() SessionResponse {
+		// First call (initial CheckSession): setup_required: true.
+		// Subsequent polls: setup_required: false on the 2nd poll-tick to
+		// keep the test fast.
+		n := calls.Add(1)
+		if n <= 2 {
+			return SessionResponse{SetupRequired: true, SetupMethod: "logs_token"}
+		}
+		return SessionResponse{Authenticated: false, SetupRequired: false}
+	})
+	cfg := newTestConfig(t, srv.URL)
+	writeBootstrapToken(t, cfg.DataDir, "test-token-abc")
+
+	client := NewClientFromURL(srv.URL)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := RunBrowserBootstrap(ctx, client, cfg)
+	if err != nil {
+		t.Fatalf("RunBrowserBootstrap: %v", err)
+	}
+	// Sanity: we should have made at least 2 calls (initial + at least one
+	// poll). The exact count depends on tick timing but 2 is the floor.
+	if calls.Load() < 2 {
+		t.Fatalf("expected at least 2 session calls, got %d", calls.Load())
+	}
+}
+
+// TestRunBrowserBootstrap_OpenMode covers PAD_BYPASS_SETUP_TOKEN=true:
+// no token file required, helper should still print a /setup URL and
+// poll to completion.
+func TestRunBrowserBootstrap_OpenMode(t *testing.T) {
+	withFastPolling(t, 10*time.Millisecond, 5*time.Second)
+
+	var calls atomic.Int32
+	srv := fakeSessionServer(t, func() SessionResponse {
+		n := calls.Add(1)
+		if n <= 2 {
+			return SessionResponse{SetupRequired: true, SetupMethod: "open"}
+		}
+		return SessionResponse{SetupRequired: false}
+	})
+	cfg := newTestConfig(t, srv.URL)
+	// Deliberately no token file — open mode shouldn't need one.
+
+	client := NewClientFromURL(srv.URL)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := RunBrowserBootstrap(ctx, client, cfg); err != nil {
+		t.Fatalf("RunBrowserBootstrap (open mode): %v", err)
+	}
+}
+
+// TestRunBrowserBootstrap_TokenMissing — server says setup_method=logs_token
+// but the file isn't on disk. Helper should fail loudly with a path-aware
+// error directing the user at --cli-prompt.
+func TestRunBrowserBootstrap_TokenMissing(t *testing.T) {
+	srv := fakeSessionServer(t, func() SessionResponse {
+		return SessionResponse{SetupRequired: true, SetupMethod: "logs_token"}
+	})
+	cfg := newTestConfig(t, srv.URL)
+	// No writeBootstrapToken — file is absent.
+
+	client := NewClientFromURL(srv.URL)
+	err := RunBrowserBootstrap(context.Background(), client, cfg)
+	if err == nil {
+		t.Fatal("RunBrowserBootstrap returned nil with missing token, want error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "--cli-prompt") {
+		t.Errorf("error %q should mention --cli-prompt fallback", msg)
+	}
+	if !strings.Contains(msg, bootstrapTokenFilename) {
+		t.Errorf("error %q should mention the token filename %q for operator guidance", msg, bootstrapTokenFilename)
+	}
+}
+
+// TestRunBrowserBootstrap_TokenEmpty — file exists but is empty (0 bytes
+// or only whitespace). EnsureBootstrapToken would never produce this, but
+// a corrupted file or partial write deserves a clear error rather than
+// silently building a `#token=` URL with an empty token.
+func TestRunBrowserBootstrap_TokenEmpty(t *testing.T) {
+	srv := fakeSessionServer(t, func() SessionResponse {
+		return SessionResponse{SetupRequired: true, SetupMethod: "logs_token"}
+	})
+	cfg := newTestConfig(t, srv.URL)
+	writeBootstrapToken(t, cfg.DataDir, "   ")
+
+	client := NewClientFromURL(srv.URL)
+	err := RunBrowserBootstrap(context.Background(), client, cfg)
+	if err == nil {
+		t.Fatal("RunBrowserBootstrap returned nil with empty token, want error")
+	}
+	if !strings.Contains(err.Error(), "empty") {
+		t.Errorf("error %q should call out empty token", err.Error())
+	}
+}
+
+// TestRunBrowserBootstrap_LocalCLIMethod — the server failed to provision
+// a bootstrap token (read-only DataDir, etc.) and the bypass flag isn't
+// set, so setup_method=local_cli. Helper can't drive the browser flow;
+// must fail with a --cli-prompt hint.
+func TestRunBrowserBootstrap_LocalCLIMethod(t *testing.T) {
+	srv := fakeSessionServer(t, func() SessionResponse {
+		return SessionResponse{SetupRequired: true, SetupMethod: "local_cli"}
+	})
+	cfg := newTestConfig(t, srv.URL)
+
+	client := NewClientFromURL(srv.URL)
+	err := RunBrowserBootstrap(context.Background(), client, cfg)
+	if err == nil {
+		t.Fatal("RunBrowserBootstrap returned nil with setup_method=local_cli, want error")
+	}
+	if !strings.Contains(err.Error(), "--cli-prompt") {
+		t.Errorf("error %q should mention --cli-prompt fallback", err.Error())
+	}
+}
+
+// TestRunBrowserBootstrap_UnknownMethod — newer server speaking a method
+// this CLI doesn't know about. Helper should bail with a clear "this CLI
+// may be older than the server" error rather than silently mishandling it.
+func TestRunBrowserBootstrap_UnknownMethod(t *testing.T) {
+	srv := fakeSessionServer(t, func() SessionResponse {
+		return SessionResponse{SetupRequired: true, SetupMethod: "future_method"}
+	})
+	cfg := newTestConfig(t, srv.URL)
+
+	client := NewClientFromURL(srv.URL)
+	err := RunBrowserBootstrap(context.Background(), client, cfg)
+	if err == nil {
+		t.Fatal("RunBrowserBootstrap returned nil with unknown setup_method, want error")
+	}
+	if !strings.Contains(err.Error(), "future_method") {
+		t.Errorf("error %q should echo back the unknown method for diagnosis", err.Error())
+	}
+}
+
+// withFastPolling shrinks the helper's tick interval and timeout to
+// millisecond scale for the duration of a test, then restores them.
+// Required for asserting on the timeout-error branch (5-min default
+// would make the test hang forever) and for keeping the happy-path
+// assertions fast.
+func withFastPolling(t *testing.T, interval, timeout time.Duration) {
+	t.Helper()
+	prevInterval := bootstrapPollInterval
+	prevTimeout := bootstrapPollTimeout
+	bootstrapPollInterval = interval
+	bootstrapPollTimeout = timeout
+	t.Cleanup(func() {
+		bootstrapPollInterval = prevInterval
+		bootstrapPollTimeout = prevTimeout
+	})
+}
+
+// TestRunBrowserBootstrap_TimeoutFires asserts the helper's own internal
+// timeout branch surfaces a friendly, actionable error (not just a context
+// error). Distinct from the ContextCancelled test below: that one drives
+// cancellation from the caller's context; this one fires the helper's
+// 5-minute (here: 100ms) safety timer.
+func TestRunBrowserBootstrap_TimeoutFires(t *testing.T) {
+	withFastPolling(t, 10*time.Millisecond, 100*time.Millisecond)
+
+	srv := fakeSessionServer(t, func() SessionResponse {
+		// Server never finishes setup — forces the helper into its timeout.
+		return SessionResponse{SetupRequired: true, SetupMethod: "logs_token"}
+	})
+	cfg := newTestConfig(t, srv.URL)
+	writeBootstrapToken(t, cfg.DataDir, "tok")
+
+	client := NewClientFromURL(srv.URL)
+	err := RunBrowserBootstrap(context.Background(), client, cfg)
+	if err == nil {
+		t.Fatal("RunBrowserBootstrap returned nil after internal timeout, want error")
+	}
+	// Should be the friendly "timed out" error, NOT context.DeadlineExceeded
+	// — the latter would mean the helper conflated caller cancellation with
+	// its own internal timer (the bug the prior round caught).
+	if errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("err = %v: helper conflated its own timeout with caller-ctx cancellation", err)
+	}
+	if !strings.Contains(err.Error(), "timed out") {
+		t.Errorf("err = %q, want a 'timed out' message", err.Error())
+	}
+	if !strings.Contains(err.Error(), "--cli-prompt") {
+		t.Errorf("err = %q should mention --cli-prompt fallback", err.Error())
+	}
+}
+
+// TestRunBrowserBootstrap_ContextCancelled — operator hits Ctrl+C while
+// the helper is polling. The caller's context is cancelled; helper should
+// return ctx.Err() promptly so the outer command can exit cleanly.
+func TestRunBrowserBootstrap_ContextCancelled(t *testing.T) {
+	srv := fakeSessionServer(t, func() SessionResponse {
+		// Always say setup-required, so the helper polls forever absent
+		// cancellation.
+		return SessionResponse{SetupRequired: true, SetupMethod: "logs_token"}
+	})
+	cfg := newTestConfig(t, srv.URL)
+	writeBootstrapToken(t, cfg.DataDir, "tok")
+
+	client := NewClientFromURL(srv.URL)
+
+	// Cancel after 100ms — well inside the 2s tick interval, so we're
+	// asserting the select branch fires on ctx.Done(), not on a stale
+	// tick.
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	err := RunBrowserBootstrap(ctx, client, cfg)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("RunBrowserBootstrap returned nil after ctx cancellation, want error")
+	}
+	// Should propagate the context error verbatim (DeadlineExceeded here).
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("err = %v, want context.DeadlineExceeded", err)
+	}
+	// And it should return promptly — within roughly the tick interval.
+	// 3s gives generous headroom on a slow CI box.
+	if elapsed > 3*time.Second {
+		t.Errorf("RunBrowserBootstrap took %s to honour ctx cancellation, want <3s", elapsed)
+	}
+}
+
+// TestBuildBootstrapURL_LogsTokenFragment locks down the token-in-fragment
+// shape: /setup#token=<TOKEN>. The fragment-not-query choice is load-
+// bearing — fragments aren't sent to the server, never appear in access
+// logs, and /setup scrubs them from the address bar before paint. A
+// regression here that quietly switched to ?token= would defeat all of
+// that.
+func TestBuildBootstrapURL_LogsTokenFragment(t *testing.T) {
+	cfg := newTestConfig(t, "http://example.test:7777")
+	writeBootstrapToken(t, cfg.DataDir, "abc123")
+
+	got, err := buildBootstrapURL(cfg, "logs_token")
+	if err != nil {
+		t.Fatalf("buildBootstrapURL: %v", err)
+	}
+	want := "http://example.test:7777/setup#token=abc123"
+	if got != want {
+		t.Errorf("buildBootstrapURL = %q, want %q", got, want)
+	}
+}
+
+// TestReadBootstrapToken_TrimsTrailingNewline — EnsureBootstrapToken
+// writes "<token>\n", so a faithful read must strip the trailing newline
+// (and any incidental whitespace). Otherwise the URL would carry a stray
+// %0A and the server's constant-time compare would reject it.
+func TestReadBootstrapToken_TrimsTrailingNewline(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, bootstrapTokenFilename), []byte("hello-token\n"), 0600); err != nil {
+		t.Fatalf("write token: %v", err)
+	}
+	got, err := readBootstrapToken(dir)
+	if err != nil {
+		t.Fatalf("readBootstrapToken: %v", err)
+	}
+	if got != "hello-token" {
+		t.Errorf("readBootstrapToken = %q, want %q", got, "hello-token")
+	}
+}


### PR DESCRIPTION
## Summary

Replace `pad auth setup`'s in-terminal email/name/password prompts with a deep link into the existing browser `/setup#token=<x>` flow. Implements the auth-setup half of [IDEA-1179](https://github.com/PerpetualSoftware/pad) — unifies the local-CLI install path onto the same flow Unraid / Docker users already see (shipped in TASK-1167 / PLAN-1166).

The mechanism (logs-token bootstrap, `/setup` route, `/api/v1/auth/session`) is unchanged. This PR is purely the CLI side.

## What changed

- **New helper** `internal/cli/bootstrap.go::RunBrowserBootstrap`:
  - Reads `<DataDir>/.bootstrap-token`, prints `<BrowserURL>/setup#token=<TOKEN>` (token in fragment — never query — scrubbed from address bar by `/setup`'s onMount before paint).
  - Polls `/api/v1/auth/session` every 2s, returns nil when `setup_required: false`.
  - Internal 5-minute timeout uses a separate `time.Timer` (not a wrapped `context.WithTimeout`) so caller cancellation surfaces as `ctx.Err()` instead of the helper's friendly timeout-error message — distinguishing user Ctrl+C from "browser side took too long" matters for the CLI exit code.
  - Idempotent — short-circuits on `setup_required: false` without touching the token file.
  - Dispatches on `session.setup_method`: `logs_token` reads the token, `open` (PAD_BYPASS_SETUP_TOKEN=true) prints the bare `/setup` URL, anything else returns an actionable error pointing at `--cli-prompt`.

- **`pad auth setup` rewired** to call the helper, then chain `doBrowserLogin` so the user ends up authenticated on the CLI (preserves the post-condition of the legacy `--cli-prompt` path). Two browser approvals — admin creation, CLI auth-session — but each is a single click in a browser the operator already has open.

- **`--cli-prompt` flag** preserves the legacy in-terminal prompts as a zero-cost hedge per IDEA-1179. We don't believe a CLI fallback is needed (Pad is fundamentally a network-accessible web service), but the flag costs nothing and gives users a workaround if a concrete blocker shows up.

- **Existing `promptAndBootstrap` / `readPassword`** kept in place — TASK-1217 will audit removal once `pad init` is also on the new flow.

## Tests

`internal/cli/bootstrap_test.go` covers:
- Idempotent session check (no token-file access on already-bootstrapped server)
- `logs_token` happy path (server flips to `setup_required: false` mid-poll)
- `open` mode (PAD_BYPASS_SETUP_TOKEN=true)
- Missing token file → error with path + `--cli-prompt` hint
- Empty token file → error
- `setup_method=local_cli` and unknown method → error
- Internal timeout fires with friendly message (NOT context.DeadlineExceeded — guards against a regression that was caught during this PR)
- Caller-ctx cancellation propagates `ctx.Err()` directly
- `/setup#token=` fragment shape (locks down the load-bearing fragment-not-query choice)
- Token file trailing-newline trim (matches `EnsureBootstrapToken`'s write format)

`bootstrapPollInterval` and `bootstrapPollTimeout` are `var` (not `const`) so the timeout-branch test runs in 100ms instead of 5min.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./...` — all pass (new tests in 0.26s)
- [x] `make lint` — 0 issues
- [x] `make web-check` — 0 errors
- [x] `pad auth setup --help` — flag and Long description render correctly
- [ ] Manual end-to-end: fresh server → `pad auth setup` → click URL → fill form → CLI prints `✓ Setup complete` and chains login (deferred to local install after merge)
- [ ] Manual: `pad auth setup --cli-prompt` → identical to today's behavior (deferred to local install after merge)

## Out of scope

- `pad init` integration → TASK-1217 (sequential follow-up, blocked by this).
- Post-`/setup` workspace-creation dead-end → captured as IDEA-1215.
- Removing `promptAndBootstrap` / `readPassword` → deferred to TASK-1217's caller audit.

## Pre-existing issues not addressed

`make vuln` reports 4 Go-stdlib vulns (templates XSS, net NUL panic, http2 SETTINGS_MAX_FRAME_SIZE) on `go1.26.2`. Confirmed pre-existing on `main` — separate maintenance concern (Go toolchain bump).