### PR TITLE
feat(init): browser-based admin setup in pad init via /setup#token (TASK-1217)

### DIFF
--- a/cmd/pad/init.go
+++ b/cmd/pad/init.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -21,6 +22,7 @@ import (
 
 func padInitCmd() *cobra.Command {
 	var templateFlag string
+	var cliPromptFlag bool
 
 	cmd := &cobra.Command{
 		Use:   "init [name]",
@@ -147,16 +149,45 @@ Examples:
 					fmt.Println(bold.Sprint("Create admin account"))
 				}
 				fmt.Println()
-				resp, err := promptAndBootstrap(client)
-				if err != nil {
-					return err
+
+				if cliPromptFlag {
+					// Legacy --cli-prompt path: in-terminal email/name/password
+					// prompts. Same Bootstrap call the pre-TASK-1217 flow used,
+					// kept verbatim as a zero-cost hedge per IDEA-1179.
+					resp, err := promptAndBootstrap(client)
+					if err != nil {
+						return err
+					}
+					if err := saveCredentials(cfg, resp); err != nil {
+						return err
+					}
+					green.Print("✓ ")
+					fmt.Printf("Admin account created — logged in as %s (%s)\n", resp.User.Name, resp.User.Email)
+					fmt.Println()
+				} else {
+					// Default browser path. RunBrowserBootstrap returns once
+					// the server reports setup_required: false but the CLI
+					// has no credentials — the browser owns the session
+					// cookie. Chain doBrowserLogin afterwards so the rest
+					// of pad init (workspace creation, etc.) can hit
+					// authenticated endpoints.
+					//
+					// SIGINT is already handled by installInitCancelHandler
+					// at the top of this RunE — it short-circuits the whole
+					// process via os.Exit(130), so the helper doesn't need
+					// its own signal-aware context. Background suffices.
+					if err := cli.RunBrowserBootstrap(context.Background(), client, cfg); err != nil {
+						return err
+					}
+					green.Print("✓ ")
+					fmt.Println("First admin account created")
+					fmt.Println()
+					fmt.Println("  Authenticating the CLI…")
+					if err := doBrowserLogin(client, cfg); err != nil {
+						return fmt.Errorf("login: %w", err)
+					}
+					fmt.Println()
 				}
-				if err := saveCredentials(cfg, resp); err != nil {
-					return err
-				}
-				green.Print("✓ ")
-				fmt.Printf("Admin account created — logged in as %s (%s)\n", resp.User.Name, resp.User.Email)
-				fmt.Println()
 
 				// Refresh client with credentials
 				client = cli.NewClientFromURL(cfg.BaseURL())
@@ -234,6 +265,12 @@ Examples:
 	}
 
 	cmd.Flags().StringVar(&templateFlag, "template", "", "workspace template (omit for interactive picker; run 'pad workspace init --list-templates' to see all)")
+	// --cli-prompt is the same hedge `pad auth setup` exposes (TASK-1216 /
+	// IDEA-1179). When the browser path won't work — broken X11, headless
+	// box without an SSH tunnel — this falls back to the legacy in-
+	// terminal email/name/password prompts for the admin-creation step.
+	// Workspace creation (cwd-bound) stays CLI in either case.
+	cmd.Flags().BoolVar(&cliPromptFlag, "cli-prompt", false, "Use the legacy in-terminal email/name/password prompts for the admin-account step instead of the browser /setup flow.")
 	return cmd
 }
 


### PR DESCRIPTION
## Summary

Wire `pad init`'s Step 3 (admin creation) to the `cli.RunBrowserBootstrap` helper shipped in [#432 (TASK-1216)](https://github.com/PerpetualSoftware/pad/pull/432). Closes the second half of [IDEA-1179](https://github.com/PerpetualSoftware/pad) — local-CLI install path now hits the same browser-based `/setup` form Unraid users already use.

Workspace creation stays CLI — `pad init` is intrinsically directory-bound (writes `.pad.toml`, links cwd to a workspace), and that's what the browser flow can't do.

## What changed

- **Step 3 of `padInitCmd`** (`cmd/pad/init.go`) now branches on a new `--cli-prompt` flag:
  - **Default (browser path):** call `cli.RunBrowserBootstrap` → print success → chain `doBrowserLogin` so the CLI ends up authenticated. Without the chained login, subsequent steps (workspace creation, etc.) would 401.
  - **`--cli-prompt`:** identical to the pre-TASK-1217 behavior — `promptAndBootstrap` + `saveCredentials`. Zero-cost hedge per IDEA-1179.

- **SIGINT handling unchanged.** `installInitCancelHandler` at the top of the RunE already calls `os.Exit(130)` directly on Ctrl+C, so the helper doesn't need its own signal-aware context — `context.Background()` is fine.

## Helper-call audit (per task spec)

`promptAndBootstrap` and `readPassword` are still reached:
- `pad auth setup --cli-prompt` → `promptAndBootstrap` → `readPassword`
- `pad init --cli-prompt` → `promptAndBootstrap` → `readPassword`
- `pad auth login --interactive` (`doInteractiveLogin`) → `readPassword`

All three keep their callers, so no helpers are removed in this PR. The two `--cli-prompt` paths exist by design as the IDEA-1179 hedge.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./...` — all pass (existing init tests cover `ensureWorkspace` end-to-end; the new branch is a thin wrapper around the helper, which has 9 dedicated tests in `internal/cli/bootstrap_test.go` from PR #432)
- [x] `make lint` — 0 issues
- [x] `make web-check` — 0 errors
- [x] `pad init --help` — both `--template` and `--cli-prompt` flags render correctly
- [ ] Manual: fresh server in TTY → `pad init` → click URL → fill form → see template picker → see workspace created (deferred to local install after merge)
- [ ] Manual: `pad init --cli-prompt` → identical to pre-TASK-1217 behavior (deferred to local install after merge)

## Out of scope

- Removing `promptAndBootstrap` / `readPassword` — they have legitimate callers under `--cli-prompt` and `--interactive`. Left as-is.
- Post-`/setup` workspace dead-end → captured as IDEA-1215.

## Pre-existing issues not addressed

`make vuln` reports 4 Go-stdlib vulns on `go1.26.2` (also flagged on PR #432). Pre-existing on `main`, separate maintenance concern.