### PR TITLE
fix(auth): TokenAuth falls through invalid Bearer on public API paths (BUG-1227)

### DIFF
--- a/internal/server/middleware_auth.go
+++ b/internal/server/middleware_auth.go
@@ -62,7 +62,14 @@ const (
 // If a valid token is found, the associated workspace ID is stored in the
 // request context. If no token header is present the request passes through
 // unchanged (existing localhost behaviour). Invalid or expired tokens
-// receive a 401 response.
+// receive a 401 response — UNLESS the request targets a path in
+// isPublicAPIPath (login, /auth/session, password reset, share links,
+// health), in which case the request falls through unauthenticated so
+// the caller can recover from a stale token. Without that fallthrough a
+// developer with a stale `~/.pad/credentials.json` (e.g. after wiping a
+// test DB) would see "Invalid or expired session" on every CLI command,
+// including the very endpoints needed to log in again. See BUG-1227 and
+// the matching IP-change-revoked branch below for the same pattern.
 func (s *Server) TokenAuth(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		auth := r.Header.Get("Authorization")
@@ -74,7 +81,7 @@ func (s *Server) TokenAuth(next http.Handler) http.Handler {
 
 		// Expect "Bearer pad_<64 hex chars>" or "Bearer padsess_<64 hex chars>"
 		if !strings.HasPrefix(auth, "Bearer ") {
-			writeError(w, http.StatusUnauthorized, "unauthorized", "Invalid authorization header format")
+			rejectInvalidBearer(w, r, next, "unauthorized", "Invalid authorization header format")
 			return
 		}
 
@@ -89,7 +96,7 @@ func (s *Server) TokenAuth(next http.Handler) http.Handler {
 				return
 			}
 			if session == nil {
-				writeError(w, http.StatusUnauthorized, "unauthorized", "Invalid or expired session")
+				rejectInvalidBearer(w, r, next, "unauthorized", "Invalid or expired session")
 				return
 			}
 			// Session binding: validate User-Agent hasn't changed
@@ -126,7 +133,7 @@ func (s *Server) TokenAuth(next http.Handler) http.Handler {
 
 		// API token
 		if !strings.HasPrefix(token, "pad_") || len(token) != 68 {
-			writeError(w, http.StatusUnauthorized, "unauthorized", "Invalid token format")
+			rejectInvalidBearer(w, r, next, "unauthorized", "Invalid token format")
 			return
 		}
 
@@ -136,7 +143,7 @@ func (s *Server) TokenAuth(next http.Handler) http.Handler {
 			return
 		}
 		if apiToken == nil {
-			writeError(w, http.StatusUnauthorized, "unauthorized", "Invalid or expired token")
+			rejectInvalidBearer(w, r, next, "unauthorized", "Invalid or expired token")
 			return
 		}
 
@@ -232,6 +239,23 @@ func (s *Server) SessionAuth(next http.Handler) http.Handler {
 		ctx := context.WithValue(r.Context(), ctxCurrentUser, session.User)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
+}
+
+// rejectInvalidBearer writes a 401 with the given code/message UNLESS
+// the request targets a path in isPublicAPIPath, in which case it falls
+// through to the next handler unauthenticated. The fallthrough is the
+// recovery hatch that lets a stale Bearer token still reach
+// /api/v1/auth/session, /login, /forgot-password, etc. — without it a
+// stale `~/.pad/credentials.json` (e.g. after wiping a test DB) would
+// 401 every CLI command, including the ones needed to recover. Mirrors
+// the existing isPublicAPIPath fallthrough in the IP-change-revoked
+// branch (BUG-1227).
+func rejectInvalidBearer(w http.ResponseWriter, r *http.Request, next http.Handler, code, message string) {
+	if isPublicAPIPath(r.URL.Path) {
+		next.ServeHTTP(w, r)
+		return
+	}
+	writeError(w, http.StatusUnauthorized, code, message)
 }
 
 // isPublicAPIPath reports whether the given request path is an API

--- a/internal/server/middleware_auth_public_paths_test.go
+++ b/internal/server/middleware_auth_public_paths_test.go
@@ -1,0 +1,154 @@
+package server
+
+// BUG-1227 — TokenAuth must not 401 public API paths on a stale/invalid
+// Bearer token. Until this fix, any developer with a stale credential in
+// `~/.pad/credentials.json` (typically after wiping a test DB) saw
+// "Invalid or expired session" on every CLI invocation — including the
+// very endpoints needed to recover (/auth/session, /auth/login,
+// /auth/forgot-password). The matching IP-change-revoked branch in the
+// same file already had the right behavior; these tests pin it for the
+// invalid/malformed Bearer paths as well.
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// doRequestWithBearer dispatches a request with an Authorization: Bearer
+// header set. The existing test helpers in server_test.go don't take a
+// token parameter, and re-dispatching there would double-execute the
+// request, so we mint a fresh request here.
+func doRequestWithBearer(srv *Server, method, path, bearer string, body interface{}) *httptest.ResponseRecorder {
+	var bodyReader io.Reader
+	if body != nil {
+		data, _ := json.Marshal(body)
+		bodyReader = bytes.NewReader(data)
+	}
+	req := httptest.NewRequest(method, path, bodyReader)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	req.Header.Set("Authorization", "Bearer "+bearer)
+	req.RemoteAddr = "127.0.0.1:1234"
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	return rec
+}
+
+// TestTokenAuth_PublicPath_InvalidSessionFallsThrough — the canonical
+// repro for BUG-1227. A `padsess_*` Bearer that doesn't validate must
+// NOT cause /api/v1/auth/session to 401; the request must reach
+// handleSessionCheck and return the public payload (setup_required: true
+// on a fresh server).
+func TestTokenAuth_PublicPath_InvalidSessionFallsThrough(t *testing.T) {
+	srv := testServer(t)
+
+	rec := doRequestWithBearer(srv, "GET", "/api/v1/auth/session",
+		"padsess_0000000000000000000000000000000000000000000000000000000000000000", nil)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("/auth/session with invalid session Bearer: expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	// Sanity: handler ran and returned the public setup-state payload.
+	var resp map[string]interface{}
+	parseJSON(t, rec, &resp)
+	if resp["setup_required"] != true {
+		t.Errorf("expected setup_required=true on fresh server, got %v", resp["setup_required"])
+	}
+}
+
+// TestTokenAuth_PublicPath_MalformedAuthHeaderFallsThrough — an
+// Authorization header that doesn't even start with "Bearer " (caller
+// somehow sent garbage) must also fall through on public paths. Pre-fix
+// this 401'd at the format-check before token parsing.
+func TestTokenAuth_PublicPath_MalformedAuthHeaderFallsThrough(t *testing.T) {
+	srv := testServer(t)
+
+	req := httptest.NewRequest("GET", "/api/v1/auth/session", nil)
+	req.RemoteAddr = "127.0.0.1:1234"
+	req.Header.Set("Authorization", "NotBearer something-else")
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("/auth/session with malformed Authorization: expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestTokenAuth_PublicPath_InvalidAPITokenFormatFallsThrough — a Bearer
+// that's neither padsess_* nor a valid pad_* shape (wrong length, wrong
+// prefix) must also fall through on public paths. Symmetry with the
+// session-token branch.
+func TestTokenAuth_PublicPath_InvalidAPITokenFormatFallsThrough(t *testing.T) {
+	srv := testServer(t)
+
+	rec := doRequestWithBearer(srv, "GET", "/api/v1/auth/session", "totally-not-a-pad-token", nil)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("/auth/session with invalid token format: expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestTokenAuth_PublicPath_InvalidAPITokenFallsThrough — a `pad_*`
+// Bearer of the right shape but not matching any live API token must
+// fall through on public paths. (Caller saved a token, the server's
+// token table got wiped, caller now wants to re-auth.)
+func TestTokenAuth_PublicPath_InvalidAPITokenFallsThrough(t *testing.T) {
+	srv := testServer(t)
+
+	// pad_<64 hex chars> is the format ValidateToken expects. We use 64
+	// zeros so it parses past the format check but fails the lookup.
+	bogus := "pad_0000000000000000000000000000000000000000000000000000000000000000"
+	rec := doRequestWithBearer(srv, "GET", "/api/v1/auth/session", bogus, nil)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("/auth/session with invalid pad_ Bearer: expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestTokenAuth_PublicPath_LoginRecoversWithStaleBearer — the realistic
+// recovery flow: caller has a stale Bearer in their credentials, hits
+// /auth/login with valid email+password in the body. The login handler
+// must run and succeed; it must NOT be blocked by the middleware
+// rejecting the stale Bearer. This is the actual user-visible bug in
+// BUG-1227 — without this fallthrough the user can't even log in to
+// fix their stale credentials.
+func TestTokenAuth_PublicPath_LoginRecoversWithStaleBearer(t *testing.T) {
+	srv := testServer(t)
+	// Bootstrap a real user so we have valid creds to log in with.
+	bootstrapFirstUser(t, srv, "user@example.com", "User")
+
+	rec := doRequestWithBearer(srv, "POST", "/api/v1/auth/login",
+		"padsess_dead0000000000000000000000000000000000000000000000000000000000",
+		map[string]string{
+			"email":    "user@example.com",
+			"password": "correct-horse-battery-staple",
+		})
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("/auth/login with stale Bearer + valid creds: expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestTokenAuth_ProtectedPath_StillRejectsInvalidBearer — regression
+// guard. The fix only relaxes public paths; protected endpoints must
+// still 401 on an invalid Bearer or the security model is broken.
+// Hits a workspace endpoint after an admin exists, so RequireAuth is
+// engaged.
+func TestTokenAuth_ProtectedPath_StillRejectsInvalidBearer(t *testing.T) {
+	srv := testServer(t)
+	// Bootstrap so RequireAuth gates non-public paths (it short-circuits
+	// when UserCount == 0 to allow first-time setup).
+	bootstrapFirstUser(t, srv, "admin@example.com", "Admin")
+
+	rec := doRequestWithBearer(srv, "GET", "/api/v1/workspaces",
+		"padsess_dead0000000000000000000000000000000000000000000000000000000000", nil)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("protected /workspaces with invalid Bearer: expected 401, got %d: %s", rec.Code, rec.Body.String())
+	}
+}


### PR DESCRIPTION
## Summary

Closes [BUG-1227](https://github.com/PerpetualSoftware/pad). `TokenAuth` middleware was rejecting any invalid/malformed Bearer with 401 *before* dispatch — including on paths in `isPublicAPIPath` (`/api/v1/auth/*`, `/health`, share links, public plan-limits). The result: a stale credential in `~/.pad/credentials.json` (typical after wiping a test DB) made every CLI invocation 401 on the very first `CheckSession()` call, including the endpoints needed to recover (login, password reset). The only fix was manually deleting the credentials file.

## What changed

The matching IP-change-revoked branch in the same file (`middleware_auth.go:114-117`) already had the right pattern: when the path is public, fall through to the handler unauthenticated. This PR mirrors that across the four invalid-Bearer branches:

- Authorization header doesn't start with `Bearer `
- `padsess_*` token doesn't validate (stale/wiped session)
- `pad_*` token format wrong (length, prefix)
- `pad_*` token doesn't match a live API token

Extracted into a small `rejectInvalidBearer` helper so the policy is visible in one place.

## Reproduction

Before:
```
$ curl -H "Authorization: Bearer padsess_BOGUS" /api/v1/auth/session
{"error":{"code":"unauthorized","message":"Invalid or expired session"}}    # 401
```

After:
```
$ curl -H "Authorization: Bearer padsess_BOGUS" /api/v1/auth/session
{"setup_required":true, ...}                                                 # 200 — handler runs
```

## Tests

`internal/server/middleware_auth_public_paths_test.go` covers:

- ✅ `/auth/session` with stale `padsess_*` Bearer → 200 with public payload (the canonical repro)
- ✅ `/auth/session` with malformed `Authorization` → 200
- ✅ `/auth/session` with garbage token format → 200
- ✅ `/auth/session` with non-matching `pad_*` token → 200
- ✅ `/auth/login` with stale Bearer + valid creds → 200 (the actual user-visible recovery scenario)
- ✅ Protected `/workspaces` with invalid Bearer → still 401 (**regression guard**)

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `make lint` — 0 issues
- [x] `go test ./...` — all pass (full suite, ~115s for the server package)
- [x] `make web-check` — 0 errors
- [x] Manual: `curl -H "Authorization: Bearer padsess_BOGUS" /api/v1/auth/session` → 200 with `setup_required` payload
- [ ] Manual after merge: `pad init` against a server with a wiped DB but stale creds → succeeds without needing to delete `~/.pad/credentials.json`

## Origin and scope

Pre-existing bug, not introduced by TASK-1216 / TASK-1217. The new bootstrap flows just made it more visible because anyone testing fresh-install scenarios is likely to wipe DBs and end up with stale creds.

Related: **IDEA-1226** (per-server credentials in `credentials.json`) — the proper design fix that ensures stale tokens for one server don't even get attempted on another. This BUG fix is the safety net that complements that idea: even with per-server credentials, a wiped DB on the *correct* server still results in stale tokens, and this fallthrough is the recovery hatch.

## Pre-existing issues NOT addressed

`make vuln` reports the same 4 Go-stdlib vulns flagged on PRs #432/#433 (`go1.26.2`). Pre-existing on `main`, separate Go-toolchain bump task.