### PR TITLE
feat(cli): per-server credentials with v1 → v2 migration (TASK-1228)

### DIFF
--- a/cmd/pad/init.go
+++ b/cmd/pad/init.go
@@ -196,8 +196,11 @@ Examples:
 
 			// ── Step 4: Authentication ────────────────────────────────
 			if !session.Authenticated && !session.SetupRequired {
-				// Check if we have saved credentials that still work
-				creds, _ := cli.LoadCredentials()
+				// Check if we have saved credentials for THIS server that
+				// still work. Per-server lookup (TASK-1228) — credentials
+				// for other servers are silently ignored here.
+				store, _ := cli.LoadStore()
+				creds := store.Get(cfg.BaseURL())
 				if creds != nil && creds.Token != "" {
 					client.SetAuthToken(creds.Token)
 					user, err := client.GetCurrentUser()
@@ -501,8 +504,9 @@ func printInitStatus(client *cli.Client, cfg *config.Config, ws *models.Workspac
 	}
 	fmt.Println(serverAddr)
 
-	// Auth
-	creds, _ := cli.LoadCredentials()
+	// Auth — entry for the configured server only
+	store, _ := cli.LoadStore()
+	creds := store.Get(cfg.BaseURL())
 	if creds != nil && creds.Email != "" {
 		green.Print("  ✓ Logged in  ")
 		fmt.Println(creds.Email)

--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -1126,8 +1126,11 @@ func loginCmd() *cobra.Command {
 			}
 			client := cli.NewClientFromURL(cfg.BaseURL())
 
-			// Check if already logged in with valid session
-			creds, _ := cli.LoadCredentials()
+			// Check if already logged in with valid session for THIS
+			// server. Per-server lookup (TASK-1228) — saved credentials
+			// for other servers don't short-circuit this login.
+			store, _ := cli.LoadStore()
+			creds := store.Get(cfg.BaseURL())
 			if creds != nil && creds.Token != "" {
 				client.SetAuthToken(creds.Token)
 				user, err := client.GetCurrentUser()
@@ -1228,14 +1231,19 @@ func doBrowserLogin(client *cli.Client, cfg *config.Config) error {
 
 			switch status.Status {
 			case "approved":
-				// Save credentials
-				if err := cli.SaveCredentials(&cli.Credentials{
-					ServerURL: cfg.BaseURL(),
-					Token:     status.Token,
-					UserID:    status.User.ID,
-					Email:     status.User.Email,
-					Name:      status.User.Name,
-				}); err != nil {
+				// Save credentials keyed by this server URL so other
+				// servers' tokens stay intact (TASK-1228).
+				store, err := cli.LoadStore()
+				if err != nil {
+					return fmt.Errorf("load credentials: %w", err)
+				}
+				store.Set(cfg.BaseURL(), &cli.Credentials{
+					Token:  status.Token,
+					UserID: status.User.ID,
+					Email:  status.User.Email,
+					Name:   status.User.Name,
+				})
+				if err := store.Save(); err != nil {
 					return fmt.Errorf("save credentials: %w", err)
 				}
 
@@ -1420,13 +1428,17 @@ func promptAndBootstrap(client *cli.Client) (*cli.LoginResponse, error) {
 }
 
 func saveCredentials(cfg *config.Config, resp *cli.LoginResponse) error {
-	if err := cli.SaveCredentials(&cli.Credentials{
-		ServerURL: cfg.BaseURL(),
-		Token:     resp.Token,
-		UserID:    resp.User.ID,
-		Email:     resp.User.Email,
-		Name:      resp.User.Name,
-	}); err != nil {
+	store, err := cli.LoadStore()
+	if err != nil {
+		return fmt.Errorf("load credentials: %w", err)
+	}
+	store.Set(cfg.BaseURL(), &cli.Credentials{
+		Token:  resp.Token,
+		UserID: resp.User.ID,
+		Email:  resp.User.Email,
+		Name:   resp.User.Name,
+	})
+	if err := store.Save(); err != nil {
 		return fmt.Errorf("save credentials: %w", err)
 	}
 	return nil
@@ -1471,9 +1483,18 @@ func logoutCmd() *cobra.Command {
 			// Try to invalidate server-side session
 			_ = client.Logout()
 
-			// Delete local credentials
-			if err := cli.DeleteCredentials(); err != nil {
-				return fmt.Errorf("delete credentials: %w", err)
+			// Delete only the entry for THIS server. Other servers'
+			// credentials stay intact (TASK-1228 — pre-fix behavior wiped
+			// the whole file). If the entry isn't present, Delete is a
+			// silent no-op which matches what the user expects from
+			// `pad auth logout` against an unauthed server.
+			store, err := cli.LoadStore()
+			if err != nil {
+				return fmt.Errorf("load credentials: %w", err)
+			}
+			store.Delete(cfg.BaseURL())
+			if err := store.Save(); err != nil {
+				return fmt.Errorf("save credentials: %w", err)
 			}
 
 			green := color.New(color.FgGreen).SprintFunc()
@@ -1488,16 +1509,20 @@ func whoamiCmd() *cobra.Command {
 		Use:   "whoami",
 		Short: "Show current user info",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			creds, err := cli.LoadCredentials()
+			cfg := getConfiguredConfig()
+
+			// Per-server lookup (TASK-1228). The store may have entries
+			// for other servers — we only care about the configured one.
+			store, err := cli.LoadStore()
 			if err != nil {
 				return fmt.Errorf("load credentials: %w", err)
 			}
+			creds := store.Get(cfg.BaseURL())
 			if creds == nil || creds.Token == "" {
 				fmt.Println("Not logged in. Run 'pad auth login'.")
 				return nil
 			}
 
-			cfg := getConfiguredConfig()
 			if err := cli.EnsureServer(cfg); err != nil {
 				return err
 			}

--- a/cmd/pad/server_info.go
+++ b/cmd/pad/server_info.go
@@ -120,14 +120,20 @@ func collectServerInfo(cfg *config.Config) (*serverInfoReport, error) {
 	}
 	report.Auth.CredentialsPath = credsPath
 
-	creds, err := cli.LoadCredentials()
+	// Per-server lookup (TASK-1228). credentials.json may contain entries
+	// for other servers; we only consider the one matching cfg.BaseURL().
+	// CredentialsMatchServer is structurally true-when-present here —
+	// kept in the report for backward compat with consumers/tests
+	// asserting on the field.
+	store, err := cli.LoadStore()
 	if err != nil {
 		return nil, fmt.Errorf("load credentials: %w", err)
 	}
+	creds := store.Get(cfg.BaseURL())
 	if creds != nil {
 		report.Auth.CredentialsPresent = true
 		report.Auth.CredentialsServerURL = creds.ServerURL
-		report.Auth.CredentialsMatchServer = normalizeURL(creds.ServerURL) == normalizeURL(cfg.BaseURL())
+		report.Auth.CredentialsMatchServer = true
 	}
 
 	client := cli.NewClientFromURL(cfg.BaseURL())
@@ -200,10 +206,6 @@ func readPID(path string) (int, bool) {
 		return 0, false
 	}
 	return pid, true
-}
-
-func normalizeURL(raw string) string {
-	return strings.TrimRight(strings.TrimSpace(raw), "/")
 }
 
 func printServerInfo(report *serverInfoReport) {

--- a/cmd/pad/server_info_test.go
+++ b/cmd/pad/server_info_test.go
@@ -55,13 +55,14 @@ func TestCollectServerInfoRemoteAuthenticated(t *testing.T) {
 	}))
 	defer server.Close()
 
-	if err := cli.SaveCredentials(&cli.Credentials{
-		ServerURL: server.URL,
-		Token:     "padsess_test",
-		UserID:    "user-1",
-		Email:     "dave@example.com",
-		Name:      "Dave",
-	}); err != nil {
+	store := &cli.CredentialStore{}
+	store.Set(server.URL, &cli.Credentials{
+		Token:  "padsess_test",
+		UserID: "user-1",
+		Email:  "dave@example.com",
+		Name:   "Dave",
+	})
+	if err := store.Save(); err != nil {
 		t.Fatalf("save credentials: %v", err)
 	}
 

--- a/internal/cli/client.go
+++ b/internal/cli/client.go
@@ -54,9 +54,15 @@ func NewClientFromURL(baseURL string) *Client {
 		},
 	}
 
-	// Auto-load credentials if available
-	if creds, err := LoadCredentials(); err == nil && creds != nil {
-		c.authToken = creds.Token
+	// Auto-load credentials for THIS server URL if any are saved. We use
+	// the original baseURL (without the /api/v1 suffix added below) so
+	// the lookup matches what login/save commands key on. Credentials
+	// for other servers are left untouched in the store — see TASK-1228
+	// / IDEA-1226 for the per-server design.
+	if store, err := LoadStore(); err == nil {
+		if creds := store.Get(baseURL); creds != nil {
+			c.authToken = creds.Token
+		}
 	}
 
 	// Auto-load agent name from .pad.toml if available

--- a/internal/cli/credentials.go
+++ b/internal/cli/credentials.go
@@ -1,19 +1,73 @@
 package cli
 
+// Per-server credentials store (TASK-1228 / IDEA-1226).
+//
+// `~/.pad/credentials.json` previously held a single login blob:
+//
+//   {"server_url": "...", "token": "padsess_...", "user_id": "...", ...}
+//
+// That works for one Pad instance per developer machine, but breaks the
+// real workflow of one developer on multiple instances (apm/ → cloud,
+// target/ → local, testing/ → staging). Switching among them with
+// `pad init --url <other>` would clobber the single entry, so going back
+// to a previously-authed server meant logging in again.
+//
+// v2 keys credentials by canonical server URL:
+//
+//   {
+//     "version": 2,
+//     "credentials": {
+//       "https://app.getpad.dev":      {"token": "...", "user_id": "...", ...},
+//       "http://127.0.0.1:7777":       {"token": "...", "user_id": "...", ...},
+//       "https://pad-staging:7777":    {"token": "...", "user_id": "...", ...}
+//     }
+//   }
+//
+// Reads transparently migrate v1 → v2 in memory; the next Save writes v2.
+// We deliberately do NOT save-on-read so reads stay side-effect free —
+// the migration becomes durable on the first login/logout/setup.
+//
+// Single-server users see no behavior change: one entry, same shape per
+// entry, identical UX.
+//
+// No top-level `default` field. The configured server URL
+// (cfg.BaseURL() from ~/.pad/config.toml or --url) is always the
+// authoritative answer for "which server am I targeting" — a separate
+// `default` would create a second source of truth and the split-brain
+// bugs that follow. The v2 schema can be extended later if a use case
+// shows up; the current map shape is forward compatible.
+
 import (
 	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
-// Credentials stores the logged-in user's session info.
+// credentialsVersion is what new saves write. Bump and add a migration
+// branch in LoadStore when the on-disk shape changes.
+const credentialsVersion = 2
+
+// Credentials is the per-server login blob. The `server_url` JSON tag is
+// kept (with omitempty) so v1 files still parse during the migration
+// path; in v2 the URL is the map key and the field is redundant — Set
+// mirrors the key into the field so consumers reading the value alone
+// still see a consistent ServerURL.
 type Credentials struct {
-	ServerURL string `json:"server_url"`
+	ServerURL string `json:"server_url,omitempty"`
 	Token     string `json:"token"`
 	UserID    string `json:"user_id"`
 	Email     string `json:"email"`
 	Name      string `json:"name"`
+}
+
+// CredentialStore is the on-disk shape of `~/.pad/credentials.json` (v2).
+// Keyed by canonical server URL (trailing slash + surrounding whitespace
+// stripped — see normalizeServerURL).
+type CredentialStore struct {
+	Version     int                     `json:"version"`
+	Credentials map[string]*Credentials `json:"credentials"`
 }
 
 // CredentialsPath returns ~/.pad/credentials.json.
@@ -30,9 +84,16 @@ func credentialsPath() (string, error) {
 	return CredentialsPath()
 }
 
-// LoadCredentials reads the credentials file. Returns nil if the file
-// doesn't exist (not an error — just means not logged in).
-func LoadCredentials() (*Credentials, error) {
+// LoadStore reads the credentials file and returns a usable
+// CredentialStore. Returns an empty (but non-nil) store if the file
+// doesn't exist — that's not an error, just "nothing logged in
+// anywhere." Migrates v1 single-blob format to v2 in memory; v1 files
+// stay v1 on disk until the first Save (which always writes v2).
+//
+// LoadStore is the only intended way to read credentials. Internal
+// callers that need a single server's entry should call
+// LoadStore().Get(url).
+func LoadStore() (*CredentialStore, error) {
 	path, err := credentialsPath()
 	if err != nil {
 		return nil, err
@@ -41,31 +102,126 @@ func LoadCredentials() (*Credentials, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, nil
+			return newEmptyStore(), nil
 		}
 		return nil, fmt.Errorf("read credentials: %w", err)
 	}
 
-	var creds Credentials
-	if err := json.Unmarshal(data, &creds); err != nil {
+	if len(strings.TrimSpace(string(data))) == 0 {
+		return newEmptyStore(), nil
+	}
+
+	// Detect format. v1 has a top-level `token` string; v2 has a
+	// top-level `credentials` object. Probe with a generic map so a
+	// garbage file fails loudly here rather than silently parsing as
+	// "empty v2."
+	var probe map[string]json.RawMessage
+	if err := json.Unmarshal(data, &probe); err != nil {
 		return nil, fmt.Errorf("parse credentials: %w", err)
 	}
-	return &creds, nil
+	if _, hasToken := probe["token"]; hasToken {
+		return migrateV1(data)
+	}
+	return parseV2(data)
 }
 
-// SaveCredentials writes credentials to disk with 0600 permissions.
-func SaveCredentials(creds *Credentials) error {
+// migrateV1 reads a v1 single-blob file and returns an in-memory v2 store
+// keyed by the legacy ServerURL. A v1 file with an empty server_url is
+// treated as "no usable credentials" (returns an empty store) — that's
+// the only safe interpretation, since we have no key to file the entry
+// under. The on-disk file is unchanged; callers triggering Save (login,
+// logout, setup) will write v2.
+func migrateV1(data []byte) (*CredentialStore, error) {
+	var legacy Credentials
+	if err := json.Unmarshal(data, &legacy); err != nil {
+		return nil, fmt.Errorf("parse v1 credentials: %w", err)
+	}
+	store := newEmptyStore()
+	if normalizeServerURL(legacy.ServerURL) != "" && legacy.Token != "" {
+		store.Set(legacy.ServerURL, &legacy)
+	}
+	return store, nil
+}
+
+// parseV2 unmarshals a v2 file. Tolerates a missing or zero version
+// field and a nil credentials map by normalizing both — anything else
+// (malformed JSON, wrong types) surfaces as an error.
+func parseV2(data []byte) (*CredentialStore, error) {
+	var store CredentialStore
+	if err := json.Unmarshal(data, &store); err != nil {
+		return nil, fmt.Errorf("parse v2 credentials: %w", err)
+	}
+	if store.Credentials == nil {
+		store.Credentials = map[string]*Credentials{}
+	}
+	if store.Version == 0 {
+		store.Version = credentialsVersion
+	}
+	return &store, nil
+}
+
+func newEmptyStore() *CredentialStore {
+	return &CredentialStore{
+		Version:     credentialsVersion,
+		Credentials: map[string]*Credentials{},
+	}
+}
+
+// Get returns the credential for the given server URL, or nil if none
+// exists. URL is canonicalized (trailing slash + whitespace stripped)
+// before lookup. Nil-receiver safe — callers can write
+// `store.Get(url)` without a prior nil check on store.
+func (s *CredentialStore) Get(serverURL string) *Credentials {
+	if s == nil || s.Credentials == nil {
+		return nil
+	}
+	return s.Credentials[normalizeServerURL(serverURL)]
+}
+
+// Set adds or replaces the credential for the given server URL. The
+// canonical URL is mirrored into the value's ServerURL field so a
+// caller reading the credential standalone still sees a consistent
+// URL. Passing a nil credential is a no-op (use Delete to remove).
+func (s *CredentialStore) Set(serverURL string, c *Credentials) {
+	if c == nil {
+		return
+	}
+	if s.Credentials == nil {
+		s.Credentials = map[string]*Credentials{}
+	}
+	key := normalizeServerURL(serverURL)
+	c.ServerURL = key
+	s.Credentials[key] = c
+}
+
+// Delete removes the credential for the given server URL. No-op if the
+// entry isn't present, or if the receiver is nil.
+func (s *CredentialStore) Delete(serverURL string) {
+	if s == nil || s.Credentials == nil {
+		return
+	}
+	delete(s.Credentials, normalizeServerURL(serverURL))
+}
+
+// Save writes the store to disk in v2 format with mode 0600. Always
+// writes the current version constant — even if the store was loaded
+// from v1, this is the migration moment.
+func (s *CredentialStore) Save() error {
 	path, err := credentialsPath()
 	if err != nil {
 		return err
 	}
 
-	// Ensure directory exists
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		return fmt.Errorf("create credentials directory: %w", err)
 	}
 
-	data, err := json.MarshalIndent(creds, "", "  ")
+	s.Version = credentialsVersion
+	if s.Credentials == nil {
+		s.Credentials = map[string]*Credentials{}
+	}
+
+	data, err := json.MarshalIndent(s, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshal credentials: %w", err)
 	}
@@ -76,15 +232,27 @@ func SaveCredentials(creds *Credentials) error {
 	return nil
 }
 
-// DeleteCredentials removes the credentials file.
-func DeleteCredentials() error {
+// WipeCredentialsFile removes ~/.pad/credentials.json entirely. Distinct
+// from CredentialStore.Delete (which removes a single server's entry)
+// — used by tests and any future "pad auth wipe" that wants a clean
+// slate. Silently succeeds if the file is already absent.
+func WipeCredentialsFile() error {
 	path, err := credentialsPath()
 	if err != nil {
 		return err
 	}
-
 	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("delete credentials: %w", err)
 	}
 	return nil
+}
+
+// normalizeServerURL canonicalizes a server URL for use as a credential
+// key. Trailing slash and surrounding whitespace are stripped; nothing
+// else is touched (no scheme normalization, no port-canonicalization
+// — those are deliberate, since differently-spelled URLs may legitimately
+// reach different servers). Mirrors normalizeURL in cmd/pad/server_info.go
+// so the two stay consistent.
+func normalizeServerURL(u string) string {
+	return strings.TrimRight(strings.TrimSpace(u), "/")
 }

--- a/internal/cli/credentials_test.go
+++ b/internal/cli/credentials_test.go
@@ -1,0 +1,401 @@
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// withTempHome chroots ~/.pad to a fresh tempdir for the test. CredentialsPath
+// resolves via os.UserHomeDir → $HOME, so a t.Setenv("HOME", ...) is enough
+// to fully isolate the test from the real credentials.json.
+func withTempHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	return home
+}
+
+func writeCredsFile(t *testing.T, home, body string) string {
+	t.Helper()
+	dir := filepath.Join(home, ".pad")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("mkdir ~/.pad: %v", err)
+	}
+	path := filepath.Join(dir, "credentials.json")
+	if err := os.WriteFile(path, []byte(body), 0600); err != nil {
+		t.Fatalf("write credentials: %v", err)
+	}
+	return path
+}
+
+// readCredsFile returns the on-disk JSON of credentials.json. Used to
+// assert post-Save behavior — confirms the v2 format actually lands on
+// disk rather than just living in memory.
+func readCredsFile(t *testing.T, home string) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(home, ".pad", "credentials.json"))
+	if err != nil {
+		t.Fatalf("read credentials: %v", err)
+	}
+	return string(data)
+}
+
+// TestLoadStore_FileMissingReturnsEmptyStore — fresh machine, no creds
+// file. LoadStore must return a usable empty store, not nil-or-error,
+// so callers can chain Get without a nil check.
+func TestLoadStore_FileMissingReturnsEmptyStore(t *testing.T) {
+	withTempHome(t)
+
+	store, err := LoadStore()
+	if err != nil {
+		t.Fatalf("LoadStore on missing file: %v", err)
+	}
+	if store == nil {
+		t.Fatal("LoadStore returned nil on missing file; want empty store")
+	}
+	if len(store.Credentials) != 0 {
+		t.Errorf("expected empty credentials map, got %d entries", len(store.Credentials))
+	}
+	if got := store.Get("http://anywhere"); got != nil {
+		t.Errorf("Get on empty store returned %v, want nil", got)
+	}
+}
+
+// TestLoadStore_EmptyFileReturnsEmptyStore — credentials.json exists but
+// is empty (zero bytes / whitespace). Should be treated like the
+// missing-file case rather than a parse error, since the user probably
+// `> credentials.json` to recover from a corrupt state.
+func TestLoadStore_EmptyFileReturnsEmptyStore(t *testing.T) {
+	home := withTempHome(t)
+	writeCredsFile(t, home, "")
+
+	store, err := LoadStore()
+	if err != nil {
+		t.Fatalf("LoadStore on empty file: %v", err)
+	}
+	if got := len(store.Credentials); got != 0 {
+		t.Errorf("expected 0 entries, got %d", got)
+	}
+}
+
+// TestLoadStore_V1MigratesInMemory — the canonical v1 file format
+// migrates to a single-entry v2 store keyed by the legacy server_url.
+// Read is side-effect-free: the on-disk file stays v1 until something
+// triggers Save.
+func TestLoadStore_V1MigratesInMemory(t *testing.T) {
+	home := withTempHome(t)
+	v1Body := `{
+		"server_url": "http://127.0.0.1:7777",
+		"token": "padsess_v1token",
+		"user_id": "u-1",
+		"email": "dave@example.com",
+		"name": "Dave"
+	}`
+	path := writeCredsFile(t, home, v1Body)
+
+	store, err := LoadStore()
+	if err != nil {
+		t.Fatalf("LoadStore: %v", err)
+	}
+	creds := store.Get("http://127.0.0.1:7777")
+	if creds == nil {
+		t.Fatalf("expected v1 entry to migrate; got nil for http://127.0.0.1:7777")
+	}
+	if creds.Token != "padsess_v1token" {
+		t.Errorf("token after migration = %q, want padsess_v1token", creds.Token)
+	}
+	if creds.Email != "dave@example.com" {
+		t.Errorf("email after migration = %q, want dave@example.com", creds.Email)
+	}
+
+	// On-disk file should be unchanged — read is side-effect free.
+	onDisk, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("re-read credentials.json: %v", err)
+	}
+	if !strings.Contains(string(onDisk), `"server_url"`) {
+		t.Errorf("expected v1 file to remain on disk after read, got: %s", onDisk)
+	}
+	if strings.Contains(string(onDisk), `"version"`) {
+		t.Errorf("read should not have rewritten file to v2; got: %s", onDisk)
+	}
+}
+
+// TestLoadStore_V1WithEmptyTokenIsEmptyStore — v1 file with an empty
+// token (or empty server_url) is unusable, so we treat it as no
+// credentials saved. Avoids surfacing a phantom entry keyed by "" or
+// holding an empty token that callers would have to defensively check.
+func TestLoadStore_V1WithEmptyTokenIsEmptyStore(t *testing.T) {
+	home := withTempHome(t)
+	writeCredsFile(t, home, `{"server_url": "http://x:7777", "token": ""}`)
+
+	store, err := LoadStore()
+	if err != nil {
+		t.Fatalf("LoadStore: %v", err)
+	}
+	if got := len(store.Credentials); got != 0 {
+		t.Errorf("expected 0 entries from empty-token v1, got %d", got)
+	}
+}
+
+// TestLoadStore_V1MigrationDurableOnSave — the in-memory migration
+// becomes durable when the caller triggers Save. The file should
+// transition from v1 to v2 with the same data preserved, no entries
+// lost.
+func TestLoadStore_V1MigrationDurableOnSave(t *testing.T) {
+	home := withTempHome(t)
+	writeCredsFile(t, home, `{
+		"server_url": "http://127.0.0.1:7777",
+		"token": "padsess_v1token",
+		"user_id": "u-1",
+		"email": "dave@example.com",
+		"name": "Dave"
+	}`)
+
+	store, err := LoadStore()
+	if err != nil {
+		t.Fatalf("LoadStore: %v", err)
+	}
+	if err := store.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	// Re-read raw and parse as v2 to confirm format.
+	body := readCredsFile(t, home)
+	var roundTrip CredentialStore
+	if err := json.Unmarshal([]byte(body), &roundTrip); err != nil {
+		t.Fatalf("post-save parse: %v\nbody: %s", err, body)
+	}
+	if roundTrip.Version != credentialsVersion {
+		t.Errorf("post-save version = %d, want %d", roundTrip.Version, credentialsVersion)
+	}
+	if got := roundTrip.Credentials["http://127.0.0.1:7777"]; got == nil {
+		t.Fatalf("post-save missing entry for original server URL; body: %s", body)
+	} else if got.Token != "padsess_v1token" {
+		t.Errorf("post-save token = %q, want padsess_v1token", got.Token)
+	}
+
+	// The legacy top-level "token" must NOT remain in the v2 file.
+	if strings.Contains(body, `"token": "padsess_v1token"`) && !strings.Contains(body, `"credentials"`) {
+		t.Errorf("v2 file unexpectedly retained legacy top-level token: %s", body)
+	}
+	if !strings.Contains(body, `"version": 2`) {
+		t.Errorf("v2 file missing version marker: %s", body)
+	}
+}
+
+// TestLoadStore_V2RoundTrip — a v2 file written by an earlier session
+// reads back identical entries.
+func TestLoadStore_V2RoundTrip(t *testing.T) {
+	home := withTempHome(t)
+	v2Body := `{
+		"version": 2,
+		"credentials": {
+			"http://127.0.0.1:7777": {
+				"server_url": "http://127.0.0.1:7777",
+				"token": "padsess_local",
+				"user_id": "u-1",
+				"email": "dave@local",
+				"name": "Local Dave"
+			},
+			"https://app.getpad.dev": {
+				"server_url": "https://app.getpad.dev",
+				"token": "padsess_cloud",
+				"user_id": "u-2",
+				"email": "dave@cloud",
+				"name": "Cloud Dave"
+			}
+		}
+	}`
+	writeCredsFile(t, home, v2Body)
+
+	store, err := LoadStore()
+	if err != nil {
+		t.Fatalf("LoadStore: %v", err)
+	}
+	if got := store.Get("http://127.0.0.1:7777"); got == nil || got.Token != "padsess_local" {
+		t.Errorf("local entry: got %+v, want token=padsess_local", got)
+	}
+	if got := store.Get("https://app.getpad.dev"); got == nil || got.Token != "padsess_cloud" {
+		t.Errorf("cloud entry: got %+v, want token=padsess_cloud", got)
+	}
+	if got := store.Get("http://nowhere"); got != nil {
+		t.Errorf("Get on absent server returned %+v, want nil", got)
+	}
+}
+
+// TestStore_Set_AddAndReplace — Set adds a new entry on first call,
+// replaces it on a second call with the same key. Mirrors the URL into
+// the value's ServerURL field for consumer consistency.
+func TestStore_Set_AddAndReplace(t *testing.T) {
+	store := newEmptyStore()
+	store.Set("http://x:7777", &Credentials{Token: "first", Email: "a@a"})
+	store.Set("http://x:7777", &Credentials{Token: "second", Email: "b@b"})
+
+	got := store.Get("http://x:7777")
+	if got == nil {
+		t.Fatal("Get returned nil after Set")
+	}
+	if got.Token != "second" {
+		t.Errorf("token = %q, want second (replace failed)", got.Token)
+	}
+	if got.Email != "b@b" {
+		t.Errorf("email = %q, want b@b", got.Email)
+	}
+	// Set must mirror the URL into the value's ServerURL field.
+	if got.ServerURL != "http://x:7777" {
+		t.Errorf("ServerURL on stored value = %q, want http://x:7777", got.ServerURL)
+	}
+}
+
+// TestStore_Delete_KeepsSiblings — Delete removes only the targeted
+// entry. This is the keystone behavior of TASK-1228: `pad auth logout`
+// against one server must not touch the others.
+func TestStore_Delete_KeepsSiblings(t *testing.T) {
+	store := newEmptyStore()
+	store.Set("http://a:7777", &Credentials{Token: "a"})
+	store.Set("http://b:7777", &Credentials{Token: "b"})
+	store.Set("http://c:7777", &Credentials{Token: "c"})
+
+	store.Delete("http://b:7777")
+
+	if store.Get("http://b:7777") != nil {
+		t.Error("expected b entry to be deleted")
+	}
+	if store.Get("http://a:7777") == nil || store.Get("http://c:7777") == nil {
+		t.Errorf("Delete b removed sibling(s): a=%v c=%v",
+			store.Get("http://a:7777"), store.Get("http://c:7777"))
+	}
+}
+
+// TestStore_DeleteAbsent_NoOp — Delete on a missing key must not panic
+// or error. Matches the UX of `pad auth logout` against a server you
+// were never logged into.
+func TestStore_DeleteAbsent_NoOp(t *testing.T) {
+	store := newEmptyStore()
+	store.Delete("http://never-existed")
+	if got := len(store.Credentials); got != 0 {
+		t.Errorf("expected 0 entries, got %d", got)
+	}
+}
+
+// TestStore_NilReceiverSafe — Get on a nil store returns nil instead of
+// panicking. NewClientFromURL relies on this so a LoadStore failure
+// degrades gracefully (no auth token attached) rather than crashing
+// the CLI on every command.
+func TestStore_NilReceiverSafe(t *testing.T) {
+	var store *CredentialStore
+	if got := store.Get("http://anywhere"); got != nil {
+		t.Errorf("nil-receiver Get returned %+v, want nil", got)
+	}
+	// Delete should also be a no-op on nil. Asserting it doesn't panic
+	// is the assertion — if it panics, the test fails.
+	store.Delete("http://anywhere")
+}
+
+// TestStore_URLNormalization — trailing slashes and surrounding
+// whitespace must canonicalize so http://x:7777 and http://x:7777/ hit
+// the same bucket. cfg.BrowserURL() trims trailing slash; user-typed
+// --url flags often don't.
+func TestStore_URLNormalization(t *testing.T) {
+	store := newEmptyStore()
+	store.Set("http://x:7777/", &Credentials{Token: "with-slash"})
+
+	// Trailing slash variant should find the entry too.
+	if got := store.Get("http://x:7777"); got == nil || got.Token != "with-slash" {
+		t.Errorf("Get on slash-trimmed key: got %+v, want token=with-slash", got)
+	}
+	// As should a leading-whitespace variant.
+	if got := store.Get("  http://x:7777  "); got == nil {
+		t.Errorf("Get on whitespace variant returned nil")
+	}
+
+	// And only one entry should exist (Set with a different formatting
+	// of the same canonical URL must replace, not duplicate).
+	store.Set("http://x:7777", &Credentials{Token: "no-slash"})
+	if got := len(store.Credentials); got != 1 {
+		t.Errorf("expected 1 entry after canonical-equivalent Set, got %d", got)
+	}
+}
+
+// TestStore_Save_PreservesAllEntries — Save round-trips multiple
+// servers without losing any entries. Direct test of the multi-server
+// invariant: switching between servers via login/logout must not
+// clobber each other's credentials.
+func TestStore_Save_PreservesAllEntries(t *testing.T) {
+	withTempHome(t)
+
+	store := newEmptyStore()
+	store.Set("http://a:7777", &Credentials{Token: "a", Email: "a@a"})
+	store.Set("http://b:7777", &Credentials{Token: "b", Email: "b@b"})
+	store.Set("http://c:7777", &Credentials{Token: "c", Email: "c@c"})
+
+	if err := store.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	reloaded, err := LoadStore()
+	if err != nil {
+		t.Fatalf("LoadStore: %v", err)
+	}
+	for _, key := range []string{"http://a:7777", "http://b:7777", "http://c:7777"} {
+		if got := reloaded.Get(key); got == nil {
+			t.Errorf("entry for %q lost across Save/Load", key)
+		}
+	}
+}
+
+// TestStore_Save_FilePermissionsAre0600 — credentials.json must be 0600
+// so other local users can't read tokens. Defends against a regression
+// where Save loosens the permissions during the write (e.g. someone
+// accidentally writes via a path that isn't atomic + 0600).
+func TestStore_Save_FilePermissionsAre0600(t *testing.T) {
+	home := withTempHome(t)
+	store := newEmptyStore()
+	store.Set("http://x:7777", &Credentials{Token: "t"})
+	if err := store.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	info, err := os.Stat(filepath.Join(home, ".pad", "credentials.json"))
+	if err != nil {
+		t.Fatalf("stat credentials.json: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0600 {
+		t.Errorf("credentials.json mode = %o, want 0600", got)
+	}
+}
+
+// TestWipeCredentialsFile — removes the file entirely. Distinct from
+// CredentialStore.Delete (which removes one entry). Idempotent.
+func TestWipeCredentialsFile(t *testing.T) {
+	home := withTempHome(t)
+	writeCredsFile(t, home, `{"version": 2, "credentials": {}}`)
+
+	if err := WipeCredentialsFile(); err != nil {
+		t.Fatalf("WipeCredentialsFile: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".pad", "credentials.json")); !os.IsNotExist(err) {
+		t.Errorf("credentials.json still exists after Wipe; stat err=%v", err)
+	}
+	// Idempotent — second wipe on absent file must succeed.
+	if err := WipeCredentialsFile(); err != nil {
+		t.Errorf("WipeCredentialsFile (second call): %v", err)
+	}
+}
+
+// TestLoadStore_GarbageFileErrors — a malformed credentials.json is
+// reported as an error, not silently treated as empty. We don't want
+// `pad auth login` writing to a file we can't safely interpret —
+// that'd lose user data.
+func TestLoadStore_GarbageFileErrors(t *testing.T) {
+	home := withTempHome(t)
+	writeCredsFile(t, home, "not json at all {[}")
+
+	if _, err := LoadStore(); err == nil {
+		t.Error("LoadStore on garbage file: expected error, got nil")
+	}
+}


### PR DESCRIPTION
## Summary

Implements [IDEA-1226](https://github.com/PerpetualSoftware/pad). `~/.pad/credentials.json` is now a map keyed by server URL so one developer machine can stay logged in to multiple Pad instances simultaneously. `pad init --url <other>` no longer clobbers previously-authed servers; `pad auth logout` only removes the configured server's entry.

Complements [BUG-1227](https://github.com/PerpetualSoftware/pad) (already merged): that PR was the safety net for stale tokens; this PR is the design fix that prevents them in the first place when switching between servers.

## On-disk format change

**v2 (new):**
```json
{
  "version": 2,
  "credentials": {
    "https://app.getpad.dev":  {"token": "...", "user_id": "...", ...},
    "http://127.0.0.1:7777":   {"token": "...", "user_id": "...", ...}
  }
}
```

**v1 (legacy, read-only):** `{"server_url": "...", "token": "...", ...}`

Reads transparently migrate v1 → v2 in memory; writes always emit v2. Migration becomes durable on the first `Save()` (login/logout/setup) — reads stay side-effect-free, so binary upgrades don't rewrite the file just for being run.

## API

Replaces `LoadCredentials` / `SaveCredentials` / `DeleteCredentials` with a `CredentialStore` type:
- `LoadStore() (*CredentialStore, error)`
- `(s).Get(serverURL) *Credentials` — nil-receiver safe
- `(s).Set(serverURL, *Credentials)` — adds or replaces
- `(s).Delete(serverURL)` — keeps siblings intact
- `(s).Save() error`
- `WipeCredentialsFile() error` — file-level wipe (replaces `DeleteCredentials`)

URL canonicalization (trailing slash + whitespace strip) is built in. The previously-redundant `normalizeURL` in `cmd/pad/server_info.go` was removed.

**No `default` field.** The configured server (`cfg.BaseURL()`) is always the source of truth for "which server am I targeting." Avoids two-source-of-truth bugs.

## Behavioral changes

- `pad init --url <other>` against a server you've authed to before reuses the saved credential
- `pad auth logout` removes only the configured server's entry
- `pad auth whoami` reads only the entry matching the configured server
- **Single-server users see no behavior change** — one entry, identical UX

## Files touched

- `internal/cli/credentials.go` — full rewrite (~220 LOC)
- `internal/cli/credentials_test.go` — new (~330 LOC, 15 tests)
- `internal/cli/client.go` — `NewClientFromURL` auto-attach uses per-server lookup
- `cmd/pad/main.go` — 5 callsites migrated (login fast-path, doBrowserLogin save, saveCredentials helper, logout, whoami)
- `cmd/pad/init.go` — 2 callsites (Step 4 already-authed check, printInitStatus)
- `cmd/pad/server_info.go` — credentials lookup + drop unused `normalizeURL` helper
- `cmd/pad/server_info_test.go` — test setup uses store API

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `make lint` — 0 issues
- [x] `go test ./...` — full suite green (15 new tests, no existing tests modified)
- [x] `make web-check` — 0 errors
- [x] Manual smoke: v1 file on disk + binary upgrade → file unchanged on read-only commands (side-effect-free reads confirmed)
- [ ] Manual after merge: `pad init --url <serverA>`, `pad init --url <serverB>`, `pad init --url <serverA>` again — no re-auth needed (deferred to local install)
- [ ] Manual after merge: `pad auth logout` against server A leaves server B's entry intact (deferred to local install)

## Tests added

`internal/cli/credentials_test.go`:

- `TestLoadStore_FileMissingReturnsEmptyStore` — fresh machine, callers don't need nil checks
- `TestLoadStore_EmptyFileReturnsEmptyStore` — handles `> credentials.json`
- `TestLoadStore_V1MigratesInMemory` — v1 read works; on-disk file unchanged
- `TestLoadStore_V1WithEmptyTokenIsEmptyStore` — phantom entries avoided
- `TestLoadStore_V1MigrationDurableOnSave` — first save flips to v2 with data preserved
- `TestLoadStore_V2RoundTrip` — multi-entry v2 file reads correctly
- `TestStore_Set_AddAndReplace` — replacement semantics + URL mirror
- `TestStore_Delete_KeepsSiblings` — **the keystone multi-server invariant**
- `TestStore_DeleteAbsent_NoOp` — `pad auth logout` on unauthed server
- `TestStore_NilReceiverSafe` — graceful degradation in `NewClientFromURL`
- `TestStore_URLNormalization` — trailing slash + whitespace canonicalization
- `TestStore_Save_PreservesAllEntries` — multi-server round-trip across file boundary
- `TestStore_Save_FilePermissionsAre0600` — defends against perm regression
- `TestWipeCredentialsFile` — file-level wipe + idempotent
- `TestLoadStore_GarbageFileErrors` — fail loud, never silently lose data

## Pre-existing issues NOT addressed

`make vuln` reports the same 4 Go-stdlib vulns (go1.26.2) as PRs #432/#433/#434. Pre-existing on `main`, separate Go-toolchain bump task.

## Out of scope (per IDEA-1226 design)

- Multi-account-per-server (work + personal on the same Pad instance) — captured in IDEA-1226's "Optional later" section. v2 schema is forward-compatible if/when that use case shows up.
- `pad auth list` to enumerate configured servers — useful future feature.