### PR TITLE
feat(web): show PR state badge on item cards (TASK-1230)

### DIFF
--- a/web/src/lib/components/collections/ItemCard.svelte
+++ b/web/src/lib/components/collections/ItemCard.svelte
@@ -33,7 +33,27 @@
 		!!onStatusClick && !!statusOptions && statusOptions.length > 1 && !!fields.status
 	);
 
+	let pullRequest = $derived(item.code_context?.pull_request);
+
 	let pulsing = $state(false);
+
+	function prStateColor(state: string): string {
+		switch (state?.toUpperCase()) {
+			case 'OPEN': return 'var(--accent-green)';
+			case 'MERGED': return 'var(--accent-purple, #8b5cf6)';
+			case 'CLOSED': return 'var(--accent-red, #ef4444)';
+			case 'DRAFT': return 'var(--text-muted)';
+			default: return 'var(--text-muted)';
+		}
+	}
+
+	function openPullRequest(e: MouseEvent) {
+		e.preventDefault();
+		e.stopPropagation();
+		if (pullRequest?.url) {
+			window.open(pullRequest.url, '_blank', 'noopener,noreferrer');
+		}
+	}
 
 	function cycleStatus(e: MouseEvent) {
 		e.preventDefault();
@@ -81,6 +101,17 @@
 </script>
 
 <a href={itemUrl} class="item-card" class:compact class:focused>
+	{#if pullRequest}
+		<button
+			type="button"
+			class="pr-badge"
+			style:background={prStateColor(pullRequest.state)}
+			onclick={openPullRequest}
+			title="#{pullRequest.number} {pullRequest.title} ({(pullRequest.state ?? '').toLowerCase()})"
+		>
+			#{pullRequest.number}
+		</button>
+	{/if}
 	<div class="card-top-row">
 		<button
 			class="star-btn"
@@ -154,6 +185,7 @@
 
 <style>
 	.item-card {
+		position: relative;
 		display: flex;
 		flex-direction: column;
 		gap: var(--space-2);
@@ -164,6 +196,34 @@
 		text-decoration: none;
 		color: inherit;
 		transition: background 0.1s;
+	}
+
+	.pr-badge {
+		position: absolute;
+		top: -6px;
+		right: -6px;
+		z-index: 1;
+		border: 1px solid var(--bg-primary);
+		border-radius: 10px;
+		padding: 1px 7px;
+		font-family: var(--font-mono);
+		font-size: 0.7em;
+		font-weight: 600;
+		line-height: 1.4;
+		color: #fff;
+		cursor: pointer;
+		white-space: nowrap;
+		box-shadow: 0 1px 3px rgba(0, 0, 0, 0.25);
+		transition: transform 0.1s, filter 0.1s;
+	}
+
+	.pr-badge:hover {
+		filter: brightness(1.1);
+		transform: scale(1.05);
+	}
+
+	.pr-badge:active {
+		transform: scale(0.95);
 	}
 
 	.item-card:hover,


### PR DESCRIPTION
## Summary

- Render a state-colored pill badge in the top-right corner of `ItemCard.svelte` whenever an item has a linked GitHub PR
- Pill overlaps the card border ("sticker on card" feel); click opens the PR in a new tab and does NOT navigate to the item
- Visible in both default and compact card variants; tooltip shows PR number + title + state

## Context

Implements [`IDEA-1214`](pad://workspace/.../items/IDEA-1214). PR data is read from `item.code_context?.pull_request`, which the server already derives from `fields.github_pr` via `ExtractItemCodeContext` (`internal/models/item.go:154`). No new types, helpers, or API calls.

State → color mapping (CSS):
- `OPEN`    → `var(--accent-green)`
- `MERGED`  → `var(--accent-purple, #8b5cf6)`
- `CLOSED`  → `var(--accent-red, #ef4444)`
- `DRAFT`   → `var(--text-muted)`
- default   → `var(--text-muted)`

Implementation matches the existing `.star-btn` pattern in the same file: a `<button>` (NOT a nested anchor — the card is already wrapped in `<a class="item-card">`) with `e.preventDefault()` + `e.stopPropagation()`, then `window.open(pr.url, '_blank', 'noopener,noreferrer')`.

## Out of scope (tracked separately)

- **Stale-state refresh** — the badge reflects whatever `pad github status` last synced; it may show `OPEN` after a PR is merged. Tracked as a sibling task under IDEA-1214.
- **Govulncheck baseline** — `make check` runs `govulncheck` which flags 4 pre-existing Go stdlib vulnerabilities (GO-2026-4982 / 4980 / 4971 / 4918) on the `go1.26.2` baseline. Tracked under TASK-1232. Unrelated to this PR.

## Test plan

- [x] `golangci-lint run --timeout=5m ./...` — 0 issues
- [x] `go test ./...` — all pass
- [x] `cd web && npm run build` — clean
- [x] `svelte-check` (via the svelte MCP autofixer + npx svelte-check) — 0 errors
- [ ] Manual: open the web UI on a workspace with linked PRs (Pad's own workspace has many — e.g. items linked via `pad github link`), confirm:
  - Badge appears top-right, overlapping border
  - Color matches PR state
  - Click opens PR in new tab without navigating to item
  - Renders identically on board (compact) and list views
  - Tooltip on hover

## Files

- `web/src/lib/components/collections/ItemCard.svelte` — +60 lines: `pullRequest` derived rune, `prStateColor()` helper, `openPullRequest()` handler, `<button class="pr-badge">` block, CSS for `.pr-badge` (and `position: relative` on `.item-card`)