### PR TITLE
chore(web)(deps): bump diff 8.0.3 → 9.0.0 (TASK-1239)

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -20,7 +20,7 @@
 				"@tiptap/pm": "^3.20.4",
 				"@tiptap/starter-kit": "^3.22.5",
 				"@tiptap/suggestion": "^3.22.5",
-				"diff": "^8.0.3",
+				"diff": "^9.0.0",
 				"dompurify": "^3.4.2",
 				"lowlight": "^3.3.0",
 				"mermaid": "^11.14.0",
@@ -2707,9 +2707,9 @@
 			}
 		},
 		"node_modules/diff": {
-			"version": "8.0.3",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-8.0.3.tgz",
-			"integrity": "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==",
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
+			"integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.3.1"

--- a/web/package.json
+++ b/web/package.json
@@ -44,7 +44,7 @@
 		"@tiptap/pm": "^3.20.4",
 		"@tiptap/starter-kit": "^3.22.5",
 		"@tiptap/suggestion": "^3.22.5",
-		"diff": "^8.0.3",
+		"diff": "^9.0.0",
 		"dompurify": "^3.4.2",
 		"lowlight": "^3.3.0",
 		"mermaid": "^11.14.0",


### PR DESCRIPTION
## Summary

- Bump `diff` (jsdiff) **8.0.3 → 9.0.0** in `web/package.json`.
- Closes [TASK-1239](https://github.com/PerpetualSoftware/pad/blob/main/internal/store/migrations) — Tier 3 child of [PLAN-1240](../) (deferred dependabot bumps from the 2026-05-08 sweep).
- Supersedes the dependabot PR #214 (will auto-close on merge).

## Risk assessment

Surface area in this repo: **one** import site, `web/src/lib/components/versions/DiffView.svelte`, using only `diffLines()` and the `Change` type.

Every breaking change in [v9.0.0](https://github.com/kpdecker/jsdiff/blob/master/release-notes.md#900) is confined to **patch parse/format functions** (`parsePatch`, `formatPatch`, `reversePatch`, `StructuredPatch`). None of those are imported anywhere in the codebase. ES5 support drop is irrelevant — Vite/SvelteKit ships modern JS.

The fields `DiffView` accesses on each `Change` (`value`, `added`, `removed`) have been stable since v6 (when `added`/`removed` became guaranteed booleans). Verified with a runtime smoke-test on diff@9.0.0 — same shape, same behavior.

## Test plan

- [x] `make check` — golangci-lint + `go test ./...` + `npm run build` + `npm run check` all green
- [x] Runtime smoke-test of `diffLines()` v9 API shape (`value: string`, `added: boolean`, `removed: boolean`)
- [x] Manual: opened item with version history, confirmed DiffView renders correctly (line numbers, +/- markers, context separators, stats)

## Notes

This is the lowest-risk item in the [PLAN-1240](../) Tier 3 bucket. Remaining children (`marked`, `typescript`, `node`, `vite-plugin-svelte`) need more care and will land separately.