### PR TITLE
chore(web)(deps): bump typescript 5.9.3 → 6.0.3 (TASK-1236)

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -38,7 +38,7 @@
 				"marked": "^18.0.3",
 				"svelte": "^5.55.5",
 				"svelte-check": "^4.4.7",
-				"typescript": "^5.9.3",
+				"typescript": "^6.0.3",
 				"vite": "^7.3.1"
 			}
 		},
@@ -3885,9 +3885,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "5.9.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+			"integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {

--- a/web/package.json
+++ b/web/package.json
@@ -25,7 +25,7 @@
 		"marked": "^18.0.3",
 		"svelte": "^5.55.5",
 		"svelte-check": "^4.4.7",
-		"typescript": "^5.9.3",
+		"typescript": "^6.0.3",
 		"vite": "^7.3.1"
 	},
 	"overrides": {

--- a/web/src/lib/components/editor/block-drag-handle.ts
+++ b/web/src/lib/components/editor/block-drag-handle.ts
@@ -13,6 +13,15 @@ import { Extension } from '@tiptap/core';
 import type { Editor } from '@tiptap/core';
 import { Plugin, PluginKey } from '@tiptap/pm/state';
 import type { EditorView } from '@tiptap/pm/view';
+// Side-effect imports to register tiptap command-type augmentations on
+// `@tiptap/core`'s `ChainedCommands` interface in this file's compilation
+// context. Required since TS 6 stopped propagating module augmentations
+// across files that don't import the augmenting modules themselves —
+// `setParagraph`, `setHeading`, `toggleBulletList`, `toggleOrderedList`,
+// `toggleCodeBlock`, `toggleBlockquote`, `liftListItem` are contributed by
+// starter-kit; `toggleTaskList` is contributed by extension-task-list.
+import '@tiptap/starter-kit';
+import '@tiptap/extension-task-list';
 import { TURN_INTO_ITEMS } from './block-types';
 
 const LIST_CONTAINERS = new Set(['bulletList', 'orderedList', 'taskList']);


### PR DESCRIPTION
## Summary

- Bump `typescript` **5.9.3 → 6.0.3** (latest stable).
- Closes [TASK-1236](../) — Tier 3 child of [PLAN-1240](../).
- Supersedes dependabot PR #213.
- One small companion fix in `block-drag-handle.ts` to re-register TipTap module augmentations (TS 6 stopped propagating them across non-importing files).

## Triage outcome

Per the task body's recipe (< 5 errors → fix and ship):

- `svelte-check` (5.9 → 6.0): **0 → 0 errors** across 714 files
- `tsc --noEmit` (5.9 → 6.0): **0 → 9 errors** in *one* file
- After fix: **0 / 0** in both checkers

The 9 errors were all `TS2339` "Property X does not exist on type 'ChainedCommands'" in `web/src/lib/components/editor/block-drag-handle.ts` for `setParagraph`, `setHeading`, `toggleBulletList`, `toggleOrderedList`, `toggleTaskList`, `toggleCodeBlock`, `toggleBlockquote`. These methods are added to `@tiptap/core`'s `ChainedCommands` interface via TypeScript module augmentation in the respective extension packages.

**Why TS 6 surfaced this:** TypeScript 6 tightened propagation of declaration-merging augmentations across the project graph. A file using augmented types now needs to ensure the augmenting module is imported (directly or transitively) in its own compilation context. Previously, having those imports somewhere else in the project (e.g. `Editor.svelte`) was enough.

**The fix:** add side-effect imports of `@tiptap/starter-kit` and `@tiptap/extension-task-list` at the top of `block-drag-handle.ts`. The modules are already loaded at runtime by `Editor.svelte`, so this adds **nothing** to the bundle — it just re-registers the type augmentations in this file's compilation context.

## Verification

- [x] `make check` — golangci-lint + `go test ./...` + `npm run build` + `svelte-check` all pass with 0 errors.
- [x] `npx tsc --noEmit` (direct compiler check) — 0 errors.
- [x] **Manual UI verify** — hovered the editor drag handle, opened the block context menu, exercised every "Turn into" command (paragraph / H1 / H2 / H3 / bullet / ordered / task / code / quote), drag-reordered blocks. All commands fire correctly at runtime, confirming the side-effect imports don't change behavior.

## Test plan

- [ ] CI green (Go, Go-PG, Web, E2E Playwright)
- [ ] Codex CLEAN

## Notes

Third item in [PLAN-1240](../) Tier 3 (3/5 done). Note that TASK-1238 (`@sveltejs/vite-plugin-svelte` v6→v7) likely needed the TS bump as a prerequisite, per the original task body's "sibling considerations" — that one's now unblocked.