### PR TITLE
chore(deps): bump Node 22 → 24 (Dockerfile + CI workflows) (TASK-1235)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,7 @@ jobs:
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: "22"
+          node-version: "24"
           cache: "npm"
           cache-dependency-path: web/package-lock.json
 
@@ -174,7 +174,7 @@ jobs:
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: "22"
+          node-version: "24"
           cache: "npm"
           cache-dependency-path: web/package-lock.json
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: "22"
+          node-version: "24"
           cache: "npm"
           cache-dependency-path: web/package-lock.json
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build web UI
-FROM node:22-alpine AS web-builder
+FROM node:24-alpine AS web-builder
 WORKDIR /app/web
 COPY web/package.json web/package-lock.json ./
 RUN npm ci


### PR DESCRIPTION
## Summary

- Bumps all 4 Node version pins **22 → 24** in lockstep:
  - `Dockerfile` (production image): `node:22-alpine` → `node:24-alpine`
  - `.github/workflows/ci.yml` (Web + E2E jobs)
  - `.github/workflows/release.yml` (release pipeline)
- Closes [TASK-1235](../) — final actionable item in [PLAN-1240](../) Tier 3.
- Supersedes dependabot PR #209.

## Why 24, not 25 (dependabot's pick) or 26

Today is 2026-05-08. Per the [official Node.js release schedule](https://github.com/nodejs/Release/blob/main/schedule.json):

| Version | Released | LTS Start | EOL | Notes |
|---|---|---|---|---|
| 22 | 2024-04-24 | 2024-10-29 | 2027-04-30 | Current pin |
| **24** | 2025-05-06 | **2025-10-28** | **2028-04-30** | **This PR** — LTS, ~1 year battle-tested |
| 25 | 2025-10-15 | (never) | **2026-06-01** | Dependabot's pick — EOL in 3 weeks 🔥 |
| 26 | 2026-04-22 | 2026-10-28 | 2029-04-30 | Released 16 days ago, not yet LTS |

Going to 25 would mean re-bumping in 3 weeks. Waiting for 26-LTS (5 months out) leaves the deferred-bumps backlog open longer than necessary. **24 is already LTS, supported through April 2028, and has had a year of production exposure** — strictly the safer trajectory.

If we want 26-LTS later, that's a single-line follow-up PR in October.

## Verification

- [x] `docker build --target web-builder -t pad:node24-test .` — clean build on `node:24-alpine`. `npm ci` + `npm run build` complete in 17.5s.
- [x] `make check` — golangci-lint + `go test ./...` + `npm run build` + svelte-check, 0 errors, 6 pre-existing warnings (none related to this change).

## Test plan

- [ ] CI green (Go, Go-PG, Web, E2E Playwright) — this PR is the first to actually run CI on Node 24, so CI itself is the cross-environment validation
- [ ] Codex CLEAN

## Notes

This closes out [PLAN-1240](../) Tier 3 except for TASK-1238 (`@sveltejs/vite-plugin-svelte` 6 → 7), which is a separate cascading concern.