### PR TITLE
fix(web): break sse↔sync circular dep via callback inversion (TASK-1242)

### DIFF
--- a/web/src/lib/services/sse.svelte.ts
+++ b/web/src/lib/services/sse.svelte.ts
@@ -16,6 +16,7 @@ export interface ItemEvent {
 }
 
 type ItemEventCallback = (event: ItemEvent) => void;
+type SyncRequiredCallback = () => void;
 
 const ITEM_EVENTS = [
 	'item_created',
@@ -36,6 +37,7 @@ function createSSEService() {
 	let eventSource: EventSource | null = null;
 	let currentWorkspace: string = '';
 	const callbacks = new SvelteSet<ItemEventCallback>();
+	const syncRequiredCallbacks = new SvelteSet<SyncRequiredCallback>();
 
 	function connect(workspaceSlug: string) {
 		// If already connected to the same workspace, don't reconnect.
@@ -74,13 +76,18 @@ function createSSEService() {
 
 		// Handle sync_required: server's replay buffer couldn't cover the gap.
 		// Trigger an immediate sync rather than waiting for a visibility change,
-		// so the UI stays fresh even when the tab is actively visible.
+		// so the UI stays fresh even when the tab is actively visible. Fires
+		// out via onSyncRequired() subscribers (currently syncService) — the
+		// callback inversion keeps this module free of any sync.svelte import,
+		// breaking the circular dep that previously required a dynamic import
+		// here. (Rolldown flagged the dynamic import as ineffective because
+		// sync.svelte is statically imported from 5 routes/components anyway,
+		// so it's always in the main chunk — see TASK-1242.)
 		eventSource.addEventListener('sync_required', () => {
 			needsSync = true;
-			// Dynamic import to avoid circular dependency
-			import('./sync.svelte').then(({ syncService }) => {
-				syncService.triggerSync();
-			});
+			for (const cb of syncRequiredCallbacks) {
+				cb();
+			}
 		});
 
 		// Handle unauthorized: the server's periodic membership revalidation
@@ -135,6 +142,22 @@ function createSSEService() {
 		};
 	}
 
+	/**
+	 * Subscribe to `sync_required` events from the server. Fires when the
+	 * server's replay buffer couldn't cover a reconnect gap and the client
+	 * needs to do a fresh sync. Returns an unsubscribe function.
+	 *
+	 * Used by syncService to drive `triggerSync()` without sse.svelte
+	 * having to import sync.svelte (which would form a circular dep —
+	 * sync.svelte already statically imports sseService).
+	 */
+	function onSyncRequired(callback: SyncRequiredCallback): () => void {
+		syncRequiredCallbacks.add(callback);
+		return () => {
+			syncRequiredCallbacks.delete(callback);
+		};
+	}
+
 	function clearSyncFlag() {
 		needsSync = false;
 	}
@@ -153,6 +176,7 @@ function createSSEService() {
 		disconnect,
 		reconnect,
 		onItemEvent,
+		onSyncRequired,
 		clearSyncFlag
 	};
 }

--- a/web/src/lib/services/sync.svelte.ts
+++ b/web/src/lib/services/sync.svelte.ts
@@ -64,6 +64,18 @@ function createSyncService() {
 				onTabResume();
 			}
 		});
+
+		// Subscribe to server-driven sync_required events. The callback
+		// inversion (sync subscribes via sseService.onSyncRequired instead
+		// of sse calling syncService.triggerSync directly) is what lets
+		// sse.svelte.ts stay free of any sync.svelte import — sync already
+		// imports sseService statically, so a reverse import would create
+		// a cycle. Previously broken with a dynamic `import('./sync.svelte')`
+		// call inside sse, which Rolldown correctly flagged as ineffective
+		// (see TASK-1242).
+		sseService.onSyncRequired(() => {
+			triggerSync();
+		});
 	}
 
 	async function setWorkspace(slug: string) {


### PR DESCRIPTION
## Summary

Cleans up the `INEFFECTIVE_DYNAMIC_IMPORT` warning that Rolldown surfaced in [PLAN-1240](../) / [TASK-1238](../) (Vite 8 bump), by replacing the dynamic-import-as-circular-dep-workaround with proper callback inversion.

Closes [TASK-1242](../). Spawned [TASK-1243](../) for an unrelated SSE-subscription gap discovered during manual verify.

## The bug

Rolldown reported:

> `[INEFFECTIVE_DYNAMIC_IMPORT]` `src/lib/services/sync.svelte.ts` is dynamically imported by `src/lib/services/sse.svelte.ts` but also statically imported by `ChildItems.svelte`, `[workspace]/+layout.svelte`, `[workspace]/+page.svelte`, `[collection]/+page.svelte`, `[collection]/[slug]/+page.svelte`. **Dynamic import will not move module into another chunk.**

## The actual root cause (different from the task body's first-cut diagnosis)

The dynamic import wasn't there for code-splitting — its inline comment explicitly said *"to avoid circular dependency"*. And indeed:

- `sync.svelte.ts` statically imports `sseService` (uses `.needsSync`, `.clearSyncFlag()`, `.status`, `.lastEventTime`)
- `sse.svelte.ts` was the cycle-breaker, deferring its single use of `syncService.triggerSync()` to a runtime `import('./sync.svelte').then(...)`

So **converting the dynamic import to static** (the task body's first option) would have **re-introduced the circular dep**. The fix needed to break the cycle, not just paper over the warning.

## The fix: callback inversion

Mirror the existing `onItemEvent` callback pattern. Have `sseService` expose `onSyncRequired(callback)`, and have `syncService` subscribe in its `init()` instead of `sseService` calling `syncService` directly.

```
Before: sse  →(dynamic import)→ sync   ──╮
        sync ─(static import)─→ sse  ←──╯  (circular, papered over)

After:  sse exposes onSyncRequired()
        sync subscribes on init() — receives `sync_required` pings
        sse has zero imports of sync.svelte.ts (static or dynamic)
```

## Verification

- [x] `npm run build` — `INEFFECTIVE_DYNAMIC_IMPORT` warning gone; build dropped from 5.91s → **2.90s**
- [x] `make check` — golangci-lint + `go test ./...` + `npm run build` + svelte-check, 0 errors, same 6 pre-existing warnings
- [x] **Manual verify** — collection page real-time updates work, child-item progress updates work, comment/reaction events work, timeline updates work

## Out of scope

During manual verify I noticed the **item detail page** (`[collection]/[slug]/+page.svelte`) never subscribed to `sseService.onItemEvent` — live title/field updates from other clients don't propagate until manual refresh. That's a **pre-existing bug**, not introduced by this PR or any recent dep work. Filed as **TASK-1243** with a sketched fix.

## Test plan

- [ ] CI green (Go, Go-PG, Web, E2E Playwright)
- [ ] Codex CLEAN