### PR TITLE
fix(web): subscribe item detail page to live SSE updates (TASK-1243)

### DIFF
--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -193,11 +193,21 @@
 		unsubscribeSSE = sseService.onItemEvent(async (event) => {
 			if (!item || event.item_id !== item.id) return;
 
-			// Same edit-conflict guards as the onSync handler below. While
-			// the user is actively editing the title or has a pending
-			// content save in flight, skip the update — they'll catch up
-			// on the next idle event (and the syncService onTabResume
-			// path also covers anything they miss).
+			// Archive is destructive and must NOT be gated by the
+			// edit-conflict guard below — a user editing a since-archived
+			// item should be redirected immediately. Their in-flight save
+			// will fail against the archived row, and silently keeping
+			// them on a non-existent item is worse than discarding the
+			// edit. Per Codex review round 2.
+			if (event.type === 'item_archived') {
+				goto(`/${username}/${wsSlug}/${collSlug}`);
+				return;
+			}
+
+			// Non-destructive updates: skip if the user is actively
+			// editing the title or has a pending content save in flight.
+			// They'll catch up on the next idle event (and the
+			// syncService onTabResume path also covers anything missed).
 			if (saveStatus === 'saving' || editingTitle) return;
 
 			// Capture the item this event was scoped to *before* awaiting.
@@ -223,13 +233,6 @@
 					}
 					break;
 				}
-				case 'item_archived': {
-					// Match onSync's deletion behavior — the item is no
-					// longer addressable here; bounce back to the
-					// collection list.
-					goto(`/${username}/${wsSlug}/${collSlug}`);
-					break;
-				}
 				case 'item_restored': {
 					try {
 						const updated = await api.items.get(reqWsSlug, reqItemSlug);
@@ -245,10 +248,20 @@
 
 		unsubscribeSync = syncService.onSync(async (result) => {
 			if (!wsSlug || !itemSlug || !item) return;
-			// Don't refresh if the user is actively editing
-			if (saveStatus === 'saving' || editingTitle) return;
 
 			if (result.type === 'caught_up') return;
+
+			// Deletion is destructive and must run even if the user is
+			// editing — same reasoning as the SSE handler's archive case.
+			// Check this BEFORE the edit-conflict guard so a deleted item
+			// doesn't sit there gated by an in-flight save.
+			if (result.type === 'incremental' && result.changes.deleted.includes(item.id)) {
+				goto(`/${username}/${wsSlug}/${collSlug}`);
+				return;
+			}
+
+			// Don't refresh non-destructive updates if the user is actively editing
+			if (saveStatus === 'saving' || editingTitle) return;
 
 			// Capture the item this sync was scoped to *before* awaiting.
 			// Same race guard as the SSE handler above and loadData() —
@@ -271,11 +284,6 @@
 					const links = await api.links.list(reqWsSlug, updated.slug).catch(() => []);
 					if (!item || item.id !== reqItemId) return;
 					itemLinks = links;
-				}
-				// Check if our item was deleted
-				if (result.changes.deleted.includes(reqItemId)) {
-					// Item was deleted — navigate back to collection
-					goto(`/${username}/${wsSlug}/${collSlug}`);
 				}
 				return;
 			}

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -4,6 +4,7 @@
 	import { api } from '$lib/api/client';
 	import { collectionStore } from '$lib/stores/collections.svelte';
 	import { syncService } from '$lib/services/sync.svelte';
+	import { sseService } from '$lib/services/sse.svelte';
 	import Editor from '$lib/components/editor/Editor.svelte';
 	import EditorBubbleMenu from '$lib/components/editor/EditorBubbleMenu.svelte';
 	import EditorLinkPopover from '$lib/components/editor/EditorLinkPopover.svelte';
@@ -146,6 +147,7 @@
 
 	// Sync coordinator — refresh item data on tab resume
 	let unsubscribeSync: (() => void) | null = null;
+	let unsubscribeSSE: (() => void) | null = null;
 	let unsubscribeBeforePrint: (() => void) | null = null;
 
 	// Print header/footer state (PLAN-620 / TASK-623). Initialized on mount
@@ -169,6 +171,64 @@
 		const handler = () => refreshPrintMeta();
 		window.addEventListener('beforeprint', handler);
 		unsubscribeBeforePrint = () => window.removeEventListener('beforeprint', handler);
+
+		// Live SSE updates for THIS item's title / fields / archive state.
+		// Mirrors the onSync handler below — same edit-conflict guards
+		// (saveStatus / editingTitle) and same content-preservation
+		// pattern (the editor owns content; replacing it would clobber
+		// in-flight edits). The detail page previously had no live
+		// subscription, so title/field changes from another client (or
+		// session) didn't propagate until a manual refresh — TASK-1243.
+		//
+		// Comments, reactions, timeline events, and child-item updates
+		// already have their own subscriptions inside CommentThread.svelte,
+		// ItemTimeline.svelte, and ChildItems.svelte respectively — we
+		// only handle item_updated / item_archived / item_restored for
+		// the parent item itself here.
+		//
+		// KNOWN LIMITATION: live content-sync is intentionally NOT handled.
+		// Replacing item.content while the editor is mounted would clobber
+		// the user's in-flight document. A proper fix needs editor-dirty-
+		// state integration; tracked separately.
+		unsubscribeSSE = sseService.onItemEvent(async (event) => {
+			if (!item || event.item_id !== item.id) return;
+
+			// Same edit-conflict guards as the onSync handler below. While
+			// the user is actively editing the title or has a pending
+			// content save in flight, skip the update — they'll catch up
+			// on the next idle event (and the syncService onTabResume
+			// path also covers anything they miss).
+			if (saveStatus === 'saving' || editingTitle) return;
+
+			switch (event.type) {
+				case 'item_updated': {
+					try {
+						const updated = await api.items.get(wsSlug, itemSlug);
+						item = { ...updated, content: item.content };
+						itemLinks = await api.links.list(wsSlug, updated.slug).catch(() => []);
+					} catch {
+						// Ignore — will catch up on next event
+					}
+					break;
+				}
+				case 'item_archived': {
+					// Match onSync's deletion behavior — the item is no
+					// longer addressable here; bounce back to the
+					// collection list.
+					goto(`/${username}/${wsSlug}/${collSlug}`);
+					break;
+				}
+				case 'item_restored': {
+					try {
+						const updated = await api.items.get(wsSlug, itemSlug);
+						item = { ...updated, content: item.content };
+					} catch {
+						// Ignore — will catch up on next event
+					}
+					break;
+				}
+			}
+		});
 
 		unsubscribeSync = syncService.onSync(async (result) => {
 			if (!wsSlug || !itemSlug || !item) return;
@@ -213,6 +273,7 @@
 
 	onDestroy(() => {
 		unsubscribeSync?.();
+		unsubscribeSSE?.();
 		unsubscribeBeforePrint?.();
 		editorStore.resetForDoc();
 		collectionStore.setActiveItem(null);

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -200,12 +200,24 @@
 			// path also covers anything they miss).
 			if (saveStatus === 'saving' || editingTitle) return;
 
+			// Capture the item this event was scoped to *before* awaiting.
+			// Otherwise a navigation that completes during the in-flight
+			// request would let the resolved fetch clobber the new item
+			// (TASK-754-style race guard, mirrored from loadData()).
+			const reqItemId = item.id;
+			const reqWsSlug = wsSlug;
+			const reqItemSlug = itemSlug;
+
 			switch (event.type) {
 				case 'item_updated': {
 					try {
-						const updated = await api.items.get(wsSlug, itemSlug);
+						const updated = await api.items.get(reqWsSlug, reqItemSlug);
+						// Bail if the user navigated away before this resolved.
+						if (!item || item.id !== reqItemId) return;
 						item = { ...updated, content: item.content };
-						itemLinks = await api.links.list(wsSlug, updated.slug).catch(() => []);
+						const links = await api.links.list(reqWsSlug, updated.slug).catch(() => []);
+						if (!item || item.id !== reqItemId) return;
+						itemLinks = links;
 					} catch {
 						// Ignore — will catch up on next event
 					}
@@ -220,7 +232,8 @@
 				}
 				case 'item_restored': {
 					try {
-						const updated = await api.items.get(wsSlug, itemSlug);
+						const updated = await api.items.get(reqWsSlug, reqItemSlug);
+						if (!item || item.id !== reqItemId) return;
 						item = { ...updated, content: item.content };
 					} catch {
 						// Ignore — will catch up on next event
@@ -237,33 +250,47 @@
 
 			if (result.type === 'caught_up') return;
 
+			// Capture the item this sync was scoped to *before* awaiting.
+			// Same race guard as the SSE handler above and loadData() —
+			// a navigation that completes mid-flight must not let a stale
+			// resolution clobber the newly-loaded item.
+			const reqItemId = item.id;
+			const reqWsSlug = wsSlug;
+			const reqItemSlug = itemSlug;
+
 			if (result.type === 'incremental') {
 				// Check if our item is in the changed set
-				const updated = result.changes.updated.find(i => i.id === item!.id);
+				const updated = result.changes.updated.find(i => i.id === reqItemId);
 				if (updated) {
 					// Merge server state without disrupting the editor
+					if (!item || item.id !== reqItemId) return;
 					item = {
 						...updated,
-						content: item!.content
+						content: item.content
 					};
-					itemLinks = await api.links.list(wsSlug, updated.slug).catch(() => []);
+					const links = await api.links.list(reqWsSlug, updated.slug).catch(() => []);
+					if (!item || item.id !== reqItemId) return;
+					itemLinks = links;
 				}
 				// Check if our item was deleted
-				if (result.changes.deleted.includes(item!.id)) {
+				if (result.changes.deleted.includes(reqItemId)) {
 					// Item was deleted — navigate back to collection
 					goto(`/${username}/${wsSlug}/${collSlug}`);
-}
+				}
 				return;
 			}
 
 			// Full refresh fallback
 			try {
-				const updated = await api.items.get(wsSlug, itemSlug);
+				const updated = await api.items.get(reqWsSlug, reqItemSlug);
+				if (!item || item.id !== reqItemId) return;
 				item = {
 					...updated,
-					content: item!.content
+					content: item.content
 				};
-				itemLinks = await api.links.list(wsSlug, updated.slug).catch(() => []);
+				const links = await api.links.list(reqWsSlug, updated.slug).catch(() => []);
+				if (!item || item.id !== reqItemId) return;
+				itemLinks = links;
 				syncService.markSynced(); // Advance cursor now that reload succeeded
 			} catch {
 				// Ignore — will catch up on next event


### PR DESCRIPTION
## Summary

Fixes a pre-existing gap: the item detail page never subscribed to `sseService.onItemEvent`, so live changes to the parent item's title / fields / archive state didn't propagate until manual refresh. Discovered while manually verifying [TASK-1242](../) (callback inversion).

Closes [TASK-1243](../).

## Why this was missed

Pad's SSE subscriptions are scattered across the components that render each piece of state, not centralized. Most pieces of the item detail page already had subscriptions in place via their child components:

| Component | Subscribes? |
|---|---|
| `CommentThread.svelte` | ✓ comments + reactions |
| `ItemTimeline.svelte` | ✓ timeline events |
| `ChildItems.svelte` | ✓ children status + progress |
| `[collection]/[slug]/+page.svelte` (parent item) | ❌ **was missing** |

Just the **parent item itself** (title, fields, status, archive) had no subscription. Easy to miss because everything *else* visible on the page was reactive.

## The fix

Mirror the existing `syncService.onSync` handler that lives ~30 lines below in the same `onMount`. Same guards (`saveStatus === 'saving' || editingTitle`), same content-preservation pattern (`content: item.content`), same archive→navigate behavior.

```ts
unsubscribeSSE = sseService.onItemEvent(async (event) => {
    if (!item || event.item_id !== item.id) return;
    if (saveStatus === 'saving' || editingTitle) return;

    switch (event.type) {
        case 'item_updated':   /* re-fetch, preserve local content */
        case 'item_archived':  /* navigate back to collection list */
        case 'item_restored':  /* re-fetch, preserve local content */
    }
});
```

## Lifecycle correctness

SvelteKit reuses the `+page.svelte` component instance when navigating between items in the same collection, so `onMount` runs once per route entry and `onDestroy` runs once per route exit. The single mount-time subscription handles cross-item navigation correctly via the `event.item_id !== item.id` filter — closure reads of `$state` / `$derived` values pick up the new item on each event fire (no stale-closure bug).

The collection page re-subscribes on every `wsSlug`/`collSlug` change because *its* closure captures locals as `const`s. Different pattern, same correctness — the detail-page handler reads `item.id` straight from `$state`, so a single subscription is the right shape here.

## Verification

- [x] `make check` — golangci-lint + `go test ./...` + `npm run build` + svelte-check, 0 errors, same 6 pre-existing warnings
- [x] **Manual two-tab verify** — opened the same item in two tabs, edited title in tab A → tab B updated within ~1s without refresh. Edited a field → updated. Archived → tab B redirected to collection list. Typed in tab B's editor while tab A was also editing → typing was not disrupted (the saveStatus / editingTitle guards prevent SSE from interrupting in-flight edits).

## Known limitation (out of scope, deliberate)

**Live content sync is intentionally NOT handled.** Replacing `item.content` while the Tiptap editor is mounted would either drop keystrokes or fight the editor's internal state machine. The conservative behavior here matches what `syncService.onSync` already does on tab-resume — same trade-off, kept consistent.

A proper fix lands in one of two follow-ups:

1. **Conservative:** integrate with editor dirty-state to apply remote content when editor is clean (covers "I edit my own doc on two tabs"). Limited UX; doesn't help cross-user.
2. **Forward-looking:** Yjs + `@tiptap/extension-collaboration` for true Google-Docs-style real-time co-edit (presence, cursors, character-level sync, no conflict prompts).

Pad is going with option 2 — separate IDEA being filed.

## Test plan

- [ ] CI green (Go, Go-PG, Web, E2E Playwright)
- [ ] Codex CLEAN