### PR TITLE
fix(editor): add NodeView update() hook to MermaidCodeBlock (TASK-1249)

### DIFF
--- a/web/src/lib/components/editor/Editor.svelte
+++ b/web/src/lib/components/editor/Editor.svelte
@@ -3,6 +3,7 @@
 	import { page } from '$app/state';
 	import { Editor, mergeAttributes } from '@tiptap/core';
 	import { Plugin } from '@tiptap/pm/state';
+	import type { Node as ProseMirrorNode } from '@tiptap/pm/model';
 	import StarterKit from '@tiptap/starter-kit';
 	import TaskList from '@tiptap/extension-task-list';
 	import TaskItem from '@tiptap/extension-task-item';
@@ -248,9 +249,41 @@
 					queueMermaidRender(source, diagram);
 				}
 
+				// Closure state for update(): track last-rendered source + the
+				// language at NodeView creation time. ProseMirror only recreates
+				// the NodeView on node identity change (replace/retype) — text
+				// edits inside the same node hit update(), so we re-queue a
+				// mermaid render whenever the source text changes. See BUG-1246.
+				let lastSource = source;
+				const initialLang = lang;
+
 				return {
 					dom: wrapper,
 					contentDOM: code,
+					// Re-render the diagram when the node's text content changes.
+					// Typed via NodeView['update'] from prosemirror-view: the param
+					// is a ProseMirror Node (not the DOM Node global). Returning
+					// `true` accepts the in-place update; `false` forces ProseMirror
+					// to tear down + recreate this NodeView, which we want when
+					// the language attribute flips into/out of `mermaid` because
+					// the DOM shape (wrapper + diagram + toggle) is mermaid-only.
+					update(updatedNode: ProseMirrorNode) {
+						if (updatedNode.type.name !== 'codeBlock') return false;
+						if (updatedNode.attrs.language !== initialLang) return false;
+
+						const newSource = updatedNode.textContent?.trim() ?? '';
+						if (newSource !== lastSource) {
+							lastSource = newSource;
+							if (newSource) {
+								queueMermaidRender(newSource, diagram);
+							} else {
+								// Empty source: clear any stale SVG / error state.
+								diagram.textContent = '';
+								diagram.classList.remove('mermaid-error');
+							}
+						}
+						return true;
+					},
 					// Critical: tell ProseMirror to ignore DOM mutations outside
 					// the contentDOM (code element). Without this, inserting the
 					// mermaid SVG triggers ProseMirror's MutationObserver → re-parse

--- a/web/src/lib/components/editor/Editor.svelte
+++ b/web/src/lib/components/editor/Editor.svelte
@@ -38,10 +38,24 @@
 				const id = `mmd-${Math.random().toString(36).slice(2, 10)}`;
 				const { svg } = await m.default.render(id, source);
 				target.innerHTML = svg;
+				// A successful render means the source is now valid — drop any
+				// error styling left over from a prior failed render.
+				target.classList.remove('mermaid-error');
 			} catch {
 				target.textContent = '⚠ Invalid Mermaid syntax';
 				target.classList.add('mermaid-error');
 			}
+		});
+	}
+
+	// Chain a diagram-clear through the shared mermaid render queue so it
+	// executes AFTER any still-pending renders for the same target. Without
+	// this, an in-flight queueMermaidRender() could overwrite a synchronous
+	// clear with stale SVG.
+	function queueMermaidClear(target: HTMLElement) {
+		renderQueue = renderQueue.then(() => {
+			target.textContent = '';
+			target.classList.remove('mermaid-error');
 		});
 	}
 
@@ -278,8 +292,9 @@
 								queueMermaidRender(newSource, diagram);
 							} else {
 								// Empty source: clear any stale SVG / error state.
-								diagram.textContent = '';
-								diagram.classList.remove('mermaid-error');
+								// Routed through the render queue so a pending
+								// queueMermaidRender can't overwrite us afterward.
+								queueMermaidClear(diagram);
 							}
 						}
 						return true;


### PR DESCRIPTION
## Summary
Mermaid diagrams previously froze on the SVG generated when the NodeView was first created. ProseMirror only recreates a NodeView on node identity change; in-place text edits don't trigger that, and the existing factory had no `update()` hook to re-queue a render. This adds the hook so the diagram tracks live source edits.

Resolves [BUG-1246](https://pad.getpad.dev/) — a hard blocker for Yjs collab (PLAN-1248) where remote ops will constantly mutate mermaid source text mid-view.

## Context
Implements `TASK-1249` under PLAN-1248 (Phase 0 — Production prerequisites). Pattern verified in the TASK-1245 spike sandbox (iteration 3) at `/dev/yjs-sandbox`; productionized here with precise `ProseMirror Node` typing instead of the spike's `any`.

## Behavior
- `update(updatedNode)` returns `false` on type mismatch or when the `language` attr flips into/out of `mermaid` — different DOM shape, so ProseMirror must tear down + recreate the NodeView.
- Returns `true` (in-place update accepted) when same-node + same-lang; re-queues `queueMermaidRender` only when `textContent` actually changed.
- Empty source clears the diagram element and removes the `mermaid-error` class.
- Toggle state (showing source vs diagram) survives across updates because the wrapper isn't recreated.

## Test plan
- [x] `npm run check` — 0 errors (only pre-existing warnings)
- [x] `npm run build` — clean
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./...` — all pass
- [ ] Manual: open item with mermaid block in two tabs, edit source via `< >` toggle, diagram re-renders on idle in both
- [ ] Manual: empty out source → diagram clears
- [ ] Manual: flip language `mermaid` → `js` → fresh code block NodeView (no diagram)