### PR TITLE
fix(editor): add NodeView update() hook to AttachmentChip (TASK-1251)

### DIFF
--- a/web/src/lib/components/editor/attachment-chip.ts
+++ b/web/src/lib/components/editor/attachment-chip.ts
@@ -380,10 +380,12 @@ export const AttachmentChip = Node.create<AttachmentChipOptions>({
 					if (newFilename !== currentFilename) {
 						currentFilename = newFilename;
 						refreshFilenameDom();
-						// Filename feeds the fallback icon when MIME is
-						// unknown — re-derive in that case so a rename
-						// shows the right extension icon.
-						if (!currentMime) refreshIcon();
+						// Filename feeds the fallback icon whenever the MIME
+						// path doesn't produce a specific icon — both MIME
+						// unknown AND MIME known-but-unmapped (e.g. generic
+						// application/octet-stream). Always recomputing is
+						// idempotent for MIMEs with a definitive icon.
+						refreshIcon();
 					}
 
 					return true;

--- a/web/src/lib/components/editor/attachment-chip.ts
+++ b/web/src/lib/components/editor/attachment-chip.ts
@@ -27,6 +27,7 @@
  */
 
 import { Node, mergeAttributes } from '@tiptap/core';
+import type { Node as ProseMirrorNode } from '@tiptap/pm/model';
 import {
 	type AttachmentUrlBuilder,
 	type AttachmentVariant,
@@ -231,20 +232,74 @@ export const AttachmentChip = Node.create<AttachmentChipOptions>({
 
 	addNodeView() {
 		return ({ node }) => {
-			const uuid = (node.attrs.uuid as string | null) ?? '';
-			const filename = (node.attrs.filename as string | null) ?? '';
+			// Mutable closure state — kept in sync via update() so attr
+			// changes (peer Yjs ops once collab lands, future programmatic
+			// rename/swap commands, etc.) refresh the live chip in place
+			// instead of forcing ProseMirror to destroy and recreate the
+			// NodeView. Same hazard pattern as BUG-1246 / TASK-1250.
+			let currentUuid = (node.attrs.uuid as string | null) ?? '';
+			let currentFilename = (node.attrs.filename as string | null) ?? '';
+			let currentMime: string | null = null;
 
 			const wrapper = document.createElement('a');
 			wrapper.className = 'file-chip';
 			wrapper.target = '_blank';
 			wrapper.rel = 'noopener noreferrer';
 			wrapper.contentEditable = 'false';
-			if (uuid) {
-				wrapper.href = this.options.getDownloadUrl(uuid);
-				wrapper.setAttribute('data-attachment-id', uuid);
-			}
-			if (filename) wrapper.setAttribute('data-filename', filename);
-			if (filename) wrapper.download = filename;
+
+			const iconEl = document.createElement('span');
+			iconEl.className = 'file-chip-icon';
+			iconEl.setAttribute('aria-hidden', 'true');
+
+			const nameEl = document.createElement('span');
+			nameEl.className = 'file-chip-name';
+
+			const sizeEl = document.createElement('span');
+			sizeEl.className = 'file-chip-size';
+			// Empty until metadata resolves; CSS hides empty separator span.
+
+			wrapper.append(iconEl, nameEl, sizeEl);
+
+			const refreshHref = (): void => {
+				if (currentUuid) {
+					wrapper.href = this.options.getDownloadUrl(currentUuid);
+					wrapper.setAttribute('data-attachment-id', currentUuid);
+				} else {
+					wrapper.removeAttribute('href');
+					wrapper.removeAttribute('data-attachment-id');
+				}
+			};
+
+			const refreshFilenameDom = (): void => {
+				if (currentFilename) {
+					wrapper.setAttribute('data-filename', currentFilename);
+					wrapper.download = currentFilename;
+				} else {
+					wrapper.removeAttribute('data-filename');
+					wrapper.removeAttribute('download');
+				}
+				nameEl.textContent = currentFilename || 'attachment';
+			};
+
+			// Icon resolution mirrors the original logic: prefer the MIME
+			// category icon when HEAD has resolved AND it produced a
+			// non-empty result (iconForMime returns '' for unknown MIME).
+			// Otherwise fall back to the filename-extension heuristic so
+			// the chip is never left iconless.
+			const refreshIcon = (): void => {
+				if (currentMime) {
+					const refined = iconForMime(currentMime);
+					if (refined) {
+						iconEl.textContent = refined;
+						return;
+					}
+				}
+				iconEl.textContent = iconForFilename(currentFilename);
+			};
+
+			refreshHref();
+			refreshFilenameDom();
+			refreshIcon();
 
 			// Explicit click handler → window.open. Editor.svelte installs a
 			// global anchor-click suppressor that calls preventDefault on
@@ -252,36 +307,21 @@ export const AttachmentChip = Node.create<AttachmentChipOptions>({
 			// in edit mode); without this handler the chip's anchor
 			// navigation would also be eaten and clicking the chip would
 			// silently do nothing. Mirrors the pattern AttachmentImage uses
-			// for its lightbox click. stopImmediatePropagation prevents the
-			// global suppressor from running afterwards.
+			// for its lightbox click. Reads currentUuid (mutable) so a peer
+			// Yjs op swapping the chip's target is honoured at click time.
 			wrapper.addEventListener('click', (event) => {
 				if (event.detail > 1) return; // double-click → fall through
-				if (!uuid) return;
+				if (!currentUuid) return;
 				event.preventDefault();
 				event.stopPropagation();
 				if (typeof window !== 'undefined') {
 					window.open(
-						this.options.getDownloadUrl(uuid),
+						this.options.getDownloadUrl(currentUuid),
 						'_blank',
 						'noopener,noreferrer',
 					);
 				}
 			});
-
-			const iconEl = document.createElement('span');
-			iconEl.className = 'file-chip-icon';
-			iconEl.setAttribute('aria-hidden', 'true');
-			iconEl.textContent = iconForFilename(filename);
-
-			const nameEl = document.createElement('span');
-			nameEl.className = 'file-chip-name';
-			nameEl.textContent = filename || 'attachment';
-
-			const sizeEl = document.createElement('span');
-			sizeEl.className = 'file-chip-size';
-			// Empty until metadata resolves; CSS hides empty separator span.
-
-			wrapper.append(iconEl, nameEl, sizeEl);
 
 			// Async metadata enrichment via HEAD. Server registers HEAD
 			// alongside GET (chi doesn't auto-route HEAD to GET handlers),
@@ -291,21 +331,64 @@ export const AttachmentChip = Node.create<AttachmentChipOptions>({
 			// survives undo/redo. Skip the fetch when no workspace context
 			// is available (e.g. headless rendering) — the chip still works,
 			// just without size/icon refinement.
-			if (uuid && this.options.workspaceSlug) {
+			//
+			// `forUuid` is captured at call time so a probe in flight does
+			// not trample state for a NEW uuid that landed via update()
+			// while we were awaiting HEAD.
+			const probeMetadata = (forUuid: string): void => {
+				if (!forUuid || !this.options.workspaceSlug) return;
 				fetchAttachmentMetadata(
 					this.options.workspaceSlug,
-					uuid,
+					forUuid,
 					this.options.getDownloadUrl,
 				).then((meta) => {
 					if (!meta) return;
-					const refined = iconForMime(meta.mime);
-					if (refined) iconEl.textContent = refined;
+					if (currentUuid !== forUuid) return; // superseded
+					currentMime = meta.mime;
+					refreshIcon();
 					const size = formatBytes(meta.size);
-					if (size) sizeEl.textContent = `· ${size}`;
+					sizeEl.textContent = size ? `· ${size}` : '';
 				});
-			}
+			};
 
-			return { dom: wrapper };
+			probeMetadata(currentUuid);
+
+			return {
+				dom: wrapper,
+				// Refresh the live chip in place when attrs change. Without
+				// this, ProseMirror destroys + recreates the NodeView on any
+				// attr update — fine today (no in-tab attr-change source for
+				// chips), but the upcoming Yjs collab work makes peer-driven
+				// uuid/filename changes the common case. Same shape as
+				// AttachmentImage's update() hook (TASK-1250).
+				update(updatedNode: ProseMirrorNode) {
+					if (updatedNode.type.name !== node.type.name) return false;
+
+					const newUuid = (updatedNode.attrs.uuid as string | null) ?? '';
+					const newFilename = (updatedNode.attrs.filename as string | null) ?? '';
+
+					if (newUuid !== currentUuid) {
+						currentUuid = newUuid;
+						// New uuid ⇒ stale MIME / size; reset until HEAD probe
+						// returns for the new identifier.
+						currentMime = null;
+						sizeEl.textContent = '';
+						refreshHref();
+						refreshIcon();
+						probeMetadata(newUuid);
+					}
+					if (newFilename !== currentFilename) {
+						currentFilename = newFilename;
+						refreshFilenameDom();
+						// Filename feeds the fallback icon when MIME is
+						// unknown — re-derive in that case so a rename
+						// shows the right extension icon.
+						if (!currentMime) refreshIcon();
+					}
+
+					return true;
+				},
+			};
 		};
 	},
 


### PR DESCRIPTION
## Summary
Audit of AttachmentChip's NodeView confirmed the same gap pattern as BUG-1246 (mermaid) and TASK-1250 (attachment-image): closure-captured `uuid` + `filename`, no `update()` hook, so any attr change forced ProseMirror to destroy + recreate the NodeView. No in-tab source of attr changes today (no rotate/crop equivalent on chips), but the upcoming Yjs collab work makes peer-driven uuid/filename swaps the common case — destroying the NodeView on every keystroke of a remote rename would flicker the chip and jump the cursor.

## Context
Implements `TASK-1251` under PLAN-1248 (Phase 0 — Production prerequisites). This completes the Phase 0 NodeView audit; the Yjs collab work in Phases 1-5 can now proceed without remount-induced UX regressions on any of the three rich NodeViews.

## Behavior
- `update(updatedNode)` returns `false` on type mismatch (defensive), `true` otherwise — keeps the NodeView alive.
- Promoted `uuid`/`filename` from `const` to `let` (`currentUuid`/`currentFilename`); added `currentMime` to track the resolved MIME across attr changes.
- On uuid change: refresh `href` + `data-attachment-id`, reset MIME + size pending re-probe, re-fire HEAD metadata fetch with an in-flight guard (`probeUuid !== currentUuid → bail`).
- On filename change: refresh `data-filename`, `download`, visible name, and (only when MIME unknown) re-derive the filename-extension fallback icon.
- Click handler reads `currentUuid` so a peer-swapped chip target opens the new attachment, not the captured original.
- Helper functions `refreshHref()` / `refreshFilenameDom()` / `refreshIcon()` consolidate DOM updates so the initial paint and the update path share one code path.

## Test plan
- [x] `npm run check` — 0 errors
- [x] `npm run build` — clean
- [x] `go build ./... && go vet ./... && go test ./...` — all pass
- [ ] Manual: item with chip-rendered attachment displays correctly (icon, filename, size after HEAD)
- [ ] Manual (post-Phase 2): two tabs, rename attachment metadata in tab A → chip name updates in tab B without remount