### PR TITLE
feat(store): add Yjs op-log table + store methods (TASK-1252)

### DIFF
--- a/internal/models/yjs_update.go
+++ b/internal/models/yjs_update.go
@@ -1,0 +1,21 @@
+package models
+
+import "time"
+
+// YjsUpdate is a single appended Yjs binary update for an item.
+//
+// Rows live in the `item_yjs_updates` op-log added in PLAN-1248. The
+// dumb-relay WebSocket server (TASK-1254) appends one row per peer
+// update; on reconnect, clients replay rows since their last known ID
+// and resume seamlessly. UpdateData is the raw output of Yjs's
+// encodeStateAsUpdate / mergeUpdates — opaque to the server. SchemaVersion
+// is stamped from the client at append time and drives TASK-1268's
+// snapshot-and-rebuild flow when a Tiptap minor bump changes the
+// underlying ProseMirror schema between releases.
+type YjsUpdate struct {
+	ID            int64     `json:"id"`
+	ItemID        string    `json:"item_id"`
+	UpdateData    []byte    `json:"update_data"`
+	SchemaVersion string    `json:"schema_version"`
+	CreatedAt     time.Time `json:"created_at"`
+}

--- a/internal/store/migrations/050_yjs_op_log.sql
+++ b/internal/store/migrations/050_yjs_op_log.sql
@@ -1,0 +1,53 @@
+-- Migration 050: Yjs collaborative-editing operation log (PLAN-1248 TASK-1252).
+--
+-- Persistence layer for the dumb-relay WebSocket server in PLAN-1248. Every
+-- Y.Doc binary update (whether produced by a browser editor, a future
+-- designated-applier conversion of a CLI/API content edit, etc.) is appended
+-- here so:
+--
+--   1. A reconnecting client can replay updates since its last known ID,
+--   2. A cold room can rebuild its in-memory Y.Doc from disk,
+--   3. The schema-version stamp catches Tiptap minor bumps that change the
+--      underlying ProseMirror schema (TASK-1268's snapshot-and-rebuild path).
+--
+-- Markdown remains the canonical content source — `items.content` is the
+-- materialised view kept fresh by the 5s idle flush. This op-log is the
+-- *operational* substrate for live collaboration; it can be pruned (and
+-- the canonical markdown survives untouched in items.content).
+--
+-- Schema notes:
+--   id              Monotonic. AUTOINCREMENT (not just INTEGER PRIMARY KEY)
+--                   so a deleted row's rowid is never reused — clients hold
+--                   IDs across disconnects and must not see "the same id"
+--                   meaning two different ops. Postgres mirror uses BIGSERIAL.
+--   item_id         FK with ON DELETE CASCADE. Deleting an item must reclaim
+--                   its op-log; callers don't need to manually purge.
+--   update_data     Raw Yjs binary update (BLOB on SQLite, BYTEA on Postgres).
+--                   Format is whatever Y.encodeStateAsUpdate / mergeUpdates
+--                   produces — opaque to the server.
+--   schema_version  Stamp set at append time. The current SCHEMA_VERSION
+--                   constant is owned by the client (web/src/lib/collab/);
+--                   a mismatch on connect triggers TASK-1268's rebuild flow.
+--   created_at      ISO8601 UTC TEXT, the cross-dialect convention used
+--                   everywhere else in pad (see migrations/047_attachments.sql).
+--                   Drives PruneYjsUpdatesBefore.
+
+CREATE TABLE IF NOT EXISTS item_yjs_updates (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    item_id         TEXT NOT NULL REFERENCES items(id) ON DELETE CASCADE,
+    update_data     BLOB NOT NULL,
+    schema_version  TEXT NOT NULL,
+    created_at      TEXT NOT NULL
+);
+
+-- Hot path: load all updates for a room, ordered by id, optionally above a
+-- cursor. The index covers WHERE item_id = ? AND id > ? ORDER BY id ASC
+-- without a separate sort.
+CREATE INDEX IF NOT EXISTS idx_yjs_updates_item_id
+    ON item_yjs_updates(item_id, id);
+
+-- Prune path: DELETE FROM item_yjs_updates WHERE item_id = ? AND created_at < ?
+-- benefits from a (item_id, created_at) index; we already get item_id
+-- locality from the index above plus the FK constraint, and prune is a
+-- background operation so a single index is enough. If the prune sweeper
+-- ever shows up as hot, add (item_id, created_at).

--- a/internal/store/pgmigrations/029_yjs_op_log.sql
+++ b/internal/store/pgmigrations/029_yjs_op_log.sql
@@ -1,0 +1,19 @@
+-- Postgres mirror of migrations/050_yjs_op_log.sql (PLAN-1248 TASK-1252).
+-- See the SQLite migration for full architectural context.
+--
+-- Differences from the SQLite migration:
+--   - id is BIGSERIAL (vs. INTEGER PRIMARY KEY AUTOINCREMENT). Same monotonic
+--     contract — Postgres sequences never reuse a value.
+--   - update_data is BYTEA (vs. BLOB).
+--   - created_at remains TEXT (ISO8601 UTC) per pad's cross-dialect convention.
+
+CREATE TABLE IF NOT EXISTS item_yjs_updates (
+    id              BIGSERIAL PRIMARY KEY,
+    item_id         TEXT NOT NULL REFERENCES items(id) ON DELETE CASCADE,
+    update_data     BYTEA NOT NULL,
+    schema_version  TEXT NOT NULL,
+    created_at      TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_yjs_updates_item_id
+    ON item_yjs_updates(item_id, id);

--- a/internal/store/yjs_updates.go
+++ b/internal/store/yjs_updates.go
@@ -21,6 +21,20 @@ import (
 // server-side NOT NULL — a Yjs update of zero bytes is a no-op (its
 // presence in the op-log would be misleading) and a blank itemID would
 // cascade-detach if the item were ever deleted.
+//
+// CONTRACT: callers MUST serialize AppendYjsUpdate per item_id.
+// Concurrent appends to the same item across multiple goroutines /
+// transactions can produce cursor gaps under Postgres because BIGSERIAL
+// ids are allocation-ordered, not commit-order: a slower transaction
+// can hold a smaller id while a faster one commits a larger id first.
+// A reader that advances its cursor past the visible larger id would
+// later miss the smaller id when it eventually commits. The dumb-relay
+// room manager (TASK-1255) is the sole writer per item by design, so
+// the contract is upheld at the application layer; this method does
+// NOT take an advisory lock or otherwise serialize internally so it
+// stays cheap when the caller already holds the per-room mutex. If a
+// future multi-replica deployment lands (deferred IDEA), this contract
+// must be re-enforced via Redis-side leadership or per-item locks.
 func (s *Store) AppendYjsUpdate(itemID string, data []byte, schemaVersion string) (int64, error) {
 	if itemID == "" {
 		return 0, errors.New("AppendYjsUpdate: itemID is required")

--- a/internal/store/yjs_updates.go
+++ b/internal/store/yjs_updates.go
@@ -1,0 +1,141 @@
+package store
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// AppendYjsUpdate persists a single Yjs binary update for an item and
+// returns the new monotonic id. Callers (the WebSocket relay and the
+// designated-applier path) treat the returned id as the cursor every
+// reconnecting peer compares against to resume from a known point.
+//
+// schemaVersion is stamped per row. A mismatch on reconnect triggers
+// TASK-1268's rebuild flow.
+//
+// Empty inputs (zero-length update_data, blank itemID, blank
+// schemaVersion) are validated up front rather than relying on the
+// server-side NOT NULL — a Yjs update of zero bytes is a no-op (its
+// presence in the op-log would be misleading) and a blank itemID would
+// cascade-detach if the item were ever deleted.
+func (s *Store) AppendYjsUpdate(itemID string, data []byte, schemaVersion string) (int64, error) {
+	if itemID == "" {
+		return 0, errors.New("AppendYjsUpdate: itemID is required")
+	}
+	if len(data) == 0 {
+		return 0, errors.New("AppendYjsUpdate: data must be non-empty")
+	}
+	if schemaVersion == "" {
+		return 0, errors.New("AppendYjsUpdate: schemaVersion is required")
+	}
+
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	// Postgres needs RETURNING; SQLite gives us the new rowid via
+	// LastInsertId. Same insert payload either way.
+	if s.dialect.Driver() == DriverPostgres {
+		query := s.dialect.Rebind(`
+			INSERT INTO item_yjs_updates (item_id, update_data, schema_version, created_at)
+			VALUES (?, ?, ?, ?)
+			RETURNING id
+		`)
+		var id int64
+		if err := s.db.QueryRow(query, itemID, data, schemaVersion, now).Scan(&id); err != nil {
+			return 0, fmt.Errorf("append yjs update (postgres): %w", err)
+		}
+		return id, nil
+	}
+
+	res, err := s.db.Exec(
+		`INSERT INTO item_yjs_updates (item_id, update_data, schema_version, created_at)
+		 VALUES (?, ?, ?, ?)`,
+		itemID, data, schemaVersion, now,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("append yjs update (sqlite): %w", err)
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		return 0, fmt.Errorf("append yjs update (last insert id): %w", err)
+	}
+	return id, nil
+}
+
+// LoadYjsUpdatesSince returns the Yjs op-log rows for an item with id
+// strictly greater than sinceID, ordered by id ascending.
+//
+// A sinceID of 0 returns every row. The WebSocket relay uses this on a
+// fresh room to rebuild the in-memory Y.Doc, and on reconnect to ship
+// any updates that arrived while the client was offline.
+func (s *Store) LoadYjsUpdatesSince(itemID string, sinceID int64) ([]models.YjsUpdate, error) {
+	if itemID == "" {
+		return nil, errors.New("LoadYjsUpdatesSince: itemID is required")
+	}
+
+	query := s.dialect.Rebind(`
+		SELECT id, item_id, update_data, schema_version, created_at
+		FROM item_yjs_updates
+		WHERE item_id = ? AND id > ?
+		ORDER BY id ASC
+	`)
+
+	rows, err := s.db.Query(query, itemID, sinceID)
+	if err != nil {
+		return nil, fmt.Errorf("load yjs updates: %w", err)
+	}
+	defer rows.Close()
+
+	var updates []models.YjsUpdate
+	for rows.Next() {
+		var (
+			u         models.YjsUpdate
+			createdAt string
+		)
+		if err := rows.Scan(&u.ID, &u.ItemID, &u.UpdateData, &u.SchemaVersion, &createdAt); err != nil {
+			return nil, fmt.Errorf("scan yjs update: %w", err)
+		}
+		// Tolerate either RFC3339 or a cleaner subset; we only ever
+		// write RFC3339 in AppendYjsUpdate, but SQLite's CURRENT_TIMESTAMP
+		// idiom uses "2006-01-02 15:04:05" — accepting both keeps any
+		// future test fixture or operator-written row from blowing up
+		// the load path.
+		if t, err := time.Parse(time.RFC3339, createdAt); err == nil {
+			u.CreatedAt = t
+		} else if t, err := time.Parse("2006-01-02 15:04:05", createdAt); err == nil {
+			u.CreatedAt = t.UTC()
+		}
+		updates = append(updates, u)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate yjs updates: %w", err)
+	}
+	return updates, nil
+}
+
+// PruneYjsUpdatesBefore deletes op-log rows for an item with created_at
+// strictly before the given cutoff and returns the row count removed.
+//
+// Used by the eventual GC sweeper (out of scope for this task) to
+// reclaim space after a successful markdown snapshot makes the older
+// op-log rows redundant. items.content remains canonical, so pruning
+// is safe — at most we lose the ability to do live op-replay for very
+// old peer reconnects, who will fall back to the markdown snapshot.
+func (s *Store) PruneYjsUpdatesBefore(itemID string, before time.Time) (int64, error) {
+	if itemID == "" {
+		return 0, errors.New("PruneYjsUpdatesBefore: itemID is required")
+	}
+	cutoff := before.UTC().Format(time.RFC3339)
+	query := s.dialect.Rebind(`DELETE FROM item_yjs_updates WHERE item_id = ? AND created_at < ?`)
+	res, err := s.db.Exec(query, itemID, cutoff)
+	if err != nil {
+		return 0, fmt.Errorf("prune yjs updates: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("prune yjs updates (rows affected): %w", err)
+	}
+	return n, nil
+}

--- a/internal/store/yjs_updates_test.go
+++ b/internal/store/yjs_updates_test.go
@@ -1,0 +1,191 @@
+package store
+
+import (
+	"bytes"
+	"testing"
+	"time"
+)
+
+// TestYjsUpdatesAppendAndLoad verifies AppendYjsUpdate returns monotonic
+// IDs and LoadYjsUpdatesSince filters strictly above the cursor.
+func TestYjsUpdatesAppendAndLoad(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Test")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+	item := createTestItem(t, s, ws.ID, col.ID, "Task A", "")
+
+	id1, err := s.AppendYjsUpdate(item.ID, []byte{1, 2, 3}, "1")
+	if err != nil {
+		t.Fatalf("AppendYjsUpdate #1: %v", err)
+	}
+	if id1 == 0 {
+		t.Fatalf("expected non-zero id, got %d", id1)
+	}
+
+	id2, err := s.AppendYjsUpdate(item.ID, []byte{4, 5, 6, 7}, "1")
+	if err != nil {
+		t.Fatalf("AppendYjsUpdate #2: %v", err)
+	}
+	if id2 <= id1 {
+		t.Fatalf("expected id2 (%d) > id1 (%d)", id2, id1)
+	}
+
+	// sinceID = 0 returns everything in order.
+	all, err := s.LoadYjsUpdatesSince(item.ID, 0)
+	if err != nil {
+		t.Fatalf("LoadYjsUpdatesSince(0): %v", err)
+	}
+	if len(all) != 2 {
+		t.Fatalf("want 2 updates, got %d", len(all))
+	}
+	if all[0].ID != id1 || all[1].ID != id2 {
+		t.Fatalf("ordering mismatch: ids=[%d,%d] want [%d,%d]", all[0].ID, all[1].ID, id1, id2)
+	}
+	if !bytes.Equal(all[0].UpdateData, []byte{1, 2, 3}) {
+		t.Fatalf("payload mismatch on row 1: got %v", all[0].UpdateData)
+	}
+	if !bytes.Equal(all[1].UpdateData, []byte{4, 5, 6, 7}) {
+		t.Fatalf("payload mismatch on row 2: got %v", all[1].UpdateData)
+	}
+	if all[0].SchemaVersion != "1" {
+		t.Fatalf("schema version mismatch: got %q", all[0].SchemaVersion)
+	}
+	if all[0].CreatedAt.IsZero() {
+		t.Fatalf("created_at should be parsed, got zero time")
+	}
+
+	// sinceID = id1 returns only the second row.
+	since, err := s.LoadYjsUpdatesSince(item.ID, id1)
+	if err != nil {
+		t.Fatalf("LoadYjsUpdatesSince(id1): %v", err)
+	}
+	if len(since) != 1 || since[0].ID != id2 {
+		t.Fatalf("want [%d] since id1, got %+v", id2, since)
+	}
+
+	// sinceID >= newest returns empty (caught up).
+	caughtUp, err := s.LoadYjsUpdatesSince(item.ID, id2)
+	if err != nil {
+		t.Fatalf("LoadYjsUpdatesSince(id2): %v", err)
+	}
+	if len(caughtUp) != 0 {
+		t.Fatalf("want 0 updates after newest, got %d", len(caughtUp))
+	}
+}
+
+// TestYjsUpdatesValidation rejects empty itemID, empty data, or empty
+// schemaVersion. We do this in Go rather than relying on the NOT NULL
+// constraint so callers fail fast with a clear error message.
+func TestYjsUpdatesValidation(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Test")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+	item := createTestItem(t, s, ws.ID, col.ID, "Task A", "")
+
+	if _, err := s.AppendYjsUpdate("", []byte{1}, "1"); err == nil {
+		t.Errorf("expected error for empty itemID")
+	}
+	if _, err := s.AppendYjsUpdate(item.ID, nil, "1"); err == nil {
+		t.Errorf("expected error for nil data")
+	}
+	if _, err := s.AppendYjsUpdate(item.ID, []byte{}, "1"); err == nil {
+		t.Errorf("expected error for empty data")
+	}
+	if _, err := s.AppendYjsUpdate(item.ID, []byte{1}, ""); err == nil {
+		t.Errorf("expected error for empty schemaVersion")
+	}
+	if _, err := s.LoadYjsUpdatesSince("", 0); err == nil {
+		t.Errorf("expected error for empty itemID on load")
+	}
+	if _, err := s.PruneYjsUpdatesBefore("", time.Now()); err == nil {
+		t.Errorf("expected error for empty itemID on prune")
+	}
+}
+
+// TestYjsUpdatesPrune removes only rows older than the cutoff for the
+// given item, leaving newer rows + other items untouched.
+func TestYjsUpdatesPrune(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Test")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+	item := createTestItem(t, s, ws.ID, col.ID, "Task A", "")
+	other := createTestItem(t, s, ws.ID, col.ID, "Task B", "")
+
+	// Append three rows for `item`. created_at is set to now() inside
+	// AppendYjsUpdate, so they all share approximately the same timestamp.
+	for i := 0; i < 3; i++ {
+		if _, err := s.AppendYjsUpdate(item.ID, []byte{byte(i)}, "1"); err != nil {
+			t.Fatalf("seed %d: %v", i, err)
+		}
+	}
+	// One row for `other` to verify we don't cross-prune.
+	if _, err := s.AppendYjsUpdate(other.ID, []byte{99}, "1"); err != nil {
+		t.Fatalf("seed other: %v", err)
+	}
+
+	// Cutoff strictly in the future → all three of `item`'s rows should
+	// match created_at < cutoff and be pruned.
+	n, err := s.PruneYjsUpdatesBefore(item.ID, time.Now().Add(1*time.Hour))
+	if err != nil {
+		t.Fatalf("Prune: %v", err)
+	}
+	if n != 3 {
+		t.Fatalf("want 3 pruned, got %d", n)
+	}
+
+	left, err := s.LoadYjsUpdatesSince(item.ID, 0)
+	if err != nil {
+		t.Fatalf("LoadYjsUpdatesSince after prune: %v", err)
+	}
+	if len(left) != 0 {
+		t.Fatalf("want 0 rows after full prune, got %d", len(left))
+	}
+
+	// `other`'s row must be untouched.
+	otherLeft, err := s.LoadYjsUpdatesSince(other.ID, 0)
+	if err != nil {
+		t.Fatalf("LoadYjsUpdatesSince other: %v", err)
+	}
+	if len(otherLeft) != 1 {
+		t.Fatalf("cross-pruned other; want 1 row, got %d", len(otherLeft))
+	}
+}
+
+// TestYjsUpdatesCascadeOnItemDelete confirms ON DELETE CASCADE wipes
+// op-log rows when their parent item is deleted. Without this, item
+// deletion would leave orphaned binary blobs on disk indefinitely.
+func TestYjsUpdatesCascadeOnItemDelete(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Test")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+	item := createTestItem(t, s, ws.ID, col.ID, "Task A", "")
+
+	if _, err := s.AppendYjsUpdate(item.ID, []byte{1, 2, 3}, "1"); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	// Sanity: row exists.
+	pre, err := s.LoadYjsUpdatesSince(item.ID, 0)
+	if err != nil {
+		t.Fatalf("pre-delete load: %v", err)
+	}
+	if len(pre) != 1 {
+		t.Fatalf("want 1 row before delete, got %d", len(pre))
+	}
+
+	// Delete the item. DeleteItem does a soft delete by default; we want
+	// the FK cascade to fire, so we hard-delete via the underlying SQL.
+	// (The op-log GC for soft-deleted items is a separate concern that
+	// PLAN-1248's Phase 5 sweeper will handle.)
+	if _, err := s.db.Exec(s.dialect.Rebind(`DELETE FROM items WHERE id = ?`), item.ID); err != nil {
+		t.Fatalf("hard delete item: %v", err)
+	}
+
+	post, err := s.LoadYjsUpdatesSince(item.ID, 0)
+	if err != nil {
+		t.Fatalf("post-delete load: %v", err)
+	}
+	if len(post) != 0 {
+		t.Fatalf("want 0 rows after cascade, got %d", len(post))
+	}
+}


### PR DESCRIPTION
## Summary
Adds the `item_yjs_updates` op-log table (mirrored across SQLite + Postgres) and the four store methods the upcoming WebSocket relay (TASK-1254) and rebuild flow (TASK-1268) will call. Schema-only + Go API: no consumers wired yet, but every method is independently usable and tested.

## Context
First task of Phase 1 (Backend foundation) under PLAN-1248. Persistence layer for the dumb-relay collab server. Markdown remains canonical (`items.content` kept fresh by the 5s idle flush in TASK-1261); the op-log is the operational substrate for live collab and can be pruned freely.

## Schema
- `id`              `INTEGER PRIMARY KEY AUTOINCREMENT` (SQLite) / `BIGSERIAL` (Postgres) — monotonic, never reused, serves as the reconnect cursor
- `item_id`         FK with `ON DELETE CASCADE` so item deletion reclaims op-log space automatically
- `update_data`     `BLOB` (SQLite) / `BYTEA` (Postgres) — raw Yjs binary update, opaque to the server
- `schema_version`  per-row stamp; mismatch on connect drives TASK-1268's rebuild flow
- `created_at`      ISO8601 UTC `TEXT` (cross-dialect convention)

## Store API
- `AppendYjsUpdate(itemID, data, schemaVersion) (int64, error)` — validated, returns new monotonic id (`RETURNING` on Postgres, `LastInsertId` on SQLite)
- `LoadYjsUpdatesSince(itemID, sinceID int64) ([]YjsUpdate, error)` — strict `id > sinceID`, ordered ASC; `sinceID=0` returns everything (cold-room rebuild)
- `PruneYjsUpdatesBefore(itemID, before time.Time) (int64, error)` — scoped delete, returns count

## Test plan
- [x] `go build ./... && go vet ./...` — clean
- [x] `go test ./internal/store/ -run TestYjsUpdates -count=1` — 4 tests pass
- [x] `go test ./...` — full suite green
- [x] `npm run check` — 0 errors
- [x] Cascade-on-item-delete verified (hard DELETE on items wipes op-log rows)
- [ ] Postgres: smoke-tested via dialect path; full PG verification deferred to CI's `make test-pg` job

## Out of scope
- Compaction / GC scheduler (Phase 5 sweeper task)
- Any WS or room-manager logic (TASK-1253 onward)