### PR TITLE
feat(collab): add OpBus interface + in-process MemoryOpBus (TASK-1253)

### DIFF
--- a/internal/collab/bus.go
+++ b/internal/collab/bus.go
@@ -1,0 +1,110 @@
+// Package collab provides the server-side substrate for real-time
+// collaborative editing of item content via Yjs (PLAN-1248).
+//
+// The package centers on a "dumb relay" model: the server never
+// understands the Y.Doc structure or applies CRDT operations on its
+// own — it only persists raw binary updates (in the op-log added by
+// TASK-1252) and broadcasts them to peers connected to the same item.
+// All CRDT logic lives in the browser via @tiptap/y-tiptap.
+//
+// Wiring:
+//
+//	WebSocket handler (TASK-1254)  ─┐
+//	                                │  Publish(OpEvent)
+//	                                ▼
+//	                            ┌──────┐
+//	                            │ OpBus│ ← in-process MemoryOpBus
+//	                            └──────┘   (RedisOpBus is a future
+//	                                ▲       drop-in for multi-replica
+//	                                │       deploys, deferred IDEA)
+//	                  Subscribe(itemID)
+//	                                │
+//	WebSocket handler (other peer)  ┘
+//
+// OpBus only handles the broadcast leg. Persistence (op-log append,
+// snapshot rebuild) lives in the room manager (TASK-1255) so the bus
+// stays focused on fan-out.
+package collab
+
+// OpEvent is a single message broadcast across an item's collab room.
+//
+// Fields:
+//   - ItemID    target item; the bus filters subscribers by this.
+//   - ClientID  Yjs client id of the originating peer. The dumb relay
+//               does not interpret it, but the designated-applier
+//               election (TASK-1257) uses it to break ties when
+//               multiple peers could supply a markdown snapshot.
+//   - Type      coarse classifier — "sync" carries Y.Doc updates that
+//               must be persisted to the op-log; "awareness" carries
+//               cursor/presence ephemera that must NOT be persisted.
+//   - Data      raw y-protocol message; opaque to the server.
+//   - Timestamp UnixMilli when the message entered the bus. Set
+//               automatically on Publish if zero.
+type OpEvent struct {
+	ItemID    string
+	ClientID  uint64
+	Type      string
+	Data      []byte
+	Timestamp int64
+}
+
+// OpEvent.Type values. Kept narrow on purpose — the server should not
+// need to know about more than the handful of categories that change
+// its own behavior (persist vs broadcast-only). New y-protocol message
+// types should map to one of these unless the server actively needs to
+// distinguish them.
+const (
+	// OpTypeSync carries a Y.Doc binary update. Persisted to the
+	// op-log (TASK-1252) on broadcast so reconnecting peers can
+	// replay since their last cursor.
+	OpTypeSync = "sync"
+
+	// OpTypeAwareness carries cursor / selection / presence info
+	// (CollaborationCursor extension, TASK-1264). Broadcast only —
+	// NEVER persisted, since presence is meaningless after the
+	// originating client disconnects.
+	OpTypeAwareness = "awareness"
+)
+
+// OpBus is the cross-instance pub/sub interface for collab broadcasts.
+// MemoryOpBus is the production implementation for single-instance
+// deployments (every shipping target today: self-hosted single Go
+// binary, pad-cloud single replica). A future RedisOpBus would
+// implement the same interface for multi-replica fanout — that's
+// scoped as a separate IDEA filed at PLAN-1248 close, since the
+// dumb-relay design intentionally keeps Redis off the self-host
+// dependency surface.
+//
+// Channels returned by Subscribe MUST be drained promptly. Slow
+// subscribers — peers whose channel buffer fills before the consumer
+// reads — have new events dropped (with a warning log) rather than
+// blocking the publisher. This mirrors internal/events.MemoryBus and
+// keeps the broadcast loop responsive even when one socket is
+// momentarily backed up by the OS write buffer.
+type OpBus interface {
+	// Subscribe registers a subscriber for the given item and returns a
+	// buffered channel of OpEvents. Caller is responsible for calling
+	// Unsubscribe (typically in a defer) so the channel is closed and
+	// the slot reclaimed.
+	Subscribe(itemID string) chan OpEvent
+
+	// Unsubscribe removes a subscriber and closes its channel. Safe to
+	// call with an already-removed channel — no-op in that case.
+	Unsubscribe(ch chan OpEvent)
+
+	// Publish broadcasts an event to every subscriber whose itemID
+	// matches event.ItemID. Non-blocking: full subscriber channels
+	// drop the event with a warning. event.Timestamp is set to
+	// time.Now().UnixMilli() if zero.
+	Publish(event OpEvent)
+
+	// SubscriberCount returns the number of active subscribers for the
+	// given item. Useful for room-manager TTL accounting (TASK-1255 —
+	// when the count hits 0, the room enters its 60s grace window).
+	SubscriberCount(itemID string) int
+
+	// Close shuts down the bus and closes every active subscriber
+	// channel. After Close, Subscribe / Publish are undefined; callers
+	// must not invoke them.
+	Close()
+}

--- a/internal/collab/bus_test.go
+++ b/internal/collab/bus_test.go
@@ -1,0 +1,272 @@
+package collab
+
+import (
+	"bytes"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestMemoryOpBusSubscribeAndPublish verifies basic fan-out: a
+// subscriber receives every event for its itemID and ignores events
+// for other items.
+func TestMemoryOpBusSubscribeAndPublish(t *testing.T) {
+	bus := NewMemoryOpBus()
+	defer bus.Close()
+
+	chA := bus.Subscribe("item-a")
+	chB := bus.Subscribe("item-b")
+
+	bus.Publish(OpEvent{ItemID: "item-a", Type: OpTypeSync, Data: []byte{1}})
+	bus.Publish(OpEvent{ItemID: "item-b", Type: OpTypeSync, Data: []byte{2}})
+	bus.Publish(OpEvent{ItemID: "item-a", Type: OpTypeAwareness, Data: []byte{3}})
+
+	got := drain(chA, 2)
+	if len(got) != 2 {
+		t.Fatalf("subA: want 2 events, got %d", len(got))
+	}
+	if got[0].Type != OpTypeSync || !bytes.Equal(got[0].Data, []byte{1}) {
+		t.Errorf("subA[0] mismatch: %+v", got[0])
+	}
+	if got[1].Type != OpTypeAwareness || !bytes.Equal(got[1].Data, []byte{3}) {
+		t.Errorf("subA[1] mismatch: %+v", got[1])
+	}
+	if got[0].Timestamp == 0 {
+		t.Errorf("Timestamp should be auto-stamped on Publish")
+	}
+
+	gotB := drain(chB, 1)
+	if len(gotB) != 1 || !bytes.Equal(gotB[0].Data, []byte{2}) {
+		t.Fatalf("subB: want 1 event with data [2], got %+v", gotB)
+	}
+}
+
+// TestMemoryOpBusUnsubscribeClosesChannel confirms Unsubscribe removes
+// the subscriber AND closes its channel, so handler `for ev := range
+// ch { ... }` loops exit cleanly.
+func TestMemoryOpBusUnsubscribeClosesChannel(t *testing.T) {
+	bus := NewMemoryOpBus()
+	defer bus.Close()
+
+	ch := bus.Subscribe("item-a")
+	if bus.SubscriberCount("item-a") != 1 {
+		t.Fatalf("want 1 subscriber, got %d", bus.SubscriberCount("item-a"))
+	}
+
+	bus.Unsubscribe(ch)
+	if bus.SubscriberCount("item-a") != 0 {
+		t.Fatalf("want 0 subscribers after Unsubscribe, got %d", bus.SubscriberCount("item-a"))
+	}
+
+	// Reading from a closed channel returns the zero value with ok=false.
+	if _, ok := <-ch; ok {
+		t.Errorf("channel should be closed after Unsubscribe")
+	}
+
+	// Idempotent: a second Unsubscribe is a no-op (no panic).
+	bus.Unsubscribe(ch)
+}
+
+// TestMemoryOpBusSlowSubscriberDrops verifies that a subscriber whose
+// channel buffer is full has events dropped instead of blocking the
+// publisher. Without this, one stuck consumer would back-pressure the
+// entire collab room.
+func TestMemoryOpBusSlowSubscriberDrops(t *testing.T) {
+	bus := NewMemoryOpBus()
+	defer bus.Close()
+
+	ch := bus.Subscribe("item-a")
+
+	// Fill the buffer (default 64) without draining.
+	for i := 0; i < 64; i++ {
+		bus.Publish(OpEvent{ItemID: "item-a", Type: OpTypeSync, Data: []byte{byte(i)}})
+	}
+
+	// One more Publish — this MUST NOT block. We exercise the drop path
+	// by giving Publish a hard wall-clock budget; without the
+	// non-blocking select, this would hang the test.
+	done := make(chan struct{})
+	go func() {
+		bus.Publish(OpEvent{ItemID: "item-a", Type: OpTypeSync, Data: []byte{0xff}})
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Publish blocked on a slow subscriber instead of dropping")
+	}
+
+	// Confirm the buffer still has the original 64 entries (the dropped
+	// 65th is ABSENT — drop path is silent at the data level, only logs).
+	got := drain(ch, 64)
+	if len(got) != 64 {
+		t.Fatalf("want 64 events drained, got %d", len(got))
+	}
+}
+
+// TestMemoryOpBusSubscriberCount tracks the count across subscribe
+// and unsubscribe.
+func TestMemoryOpBusSubscriberCount(t *testing.T) {
+	bus := NewMemoryOpBus()
+	defer bus.Close()
+
+	if c := bus.SubscriberCount("item-a"); c != 0 {
+		t.Errorf("empty bus: want 0, got %d", c)
+	}
+
+	chA1 := bus.Subscribe("item-a")
+	chA2 := bus.Subscribe("item-a")
+	chB := bus.Subscribe("item-b")
+
+	if c := bus.SubscriberCount("item-a"); c != 2 {
+		t.Errorf("two on item-a: want 2, got %d", c)
+	}
+	if c := bus.SubscriberCount("item-b"); c != 1 {
+		t.Errorf("one on item-b: want 1, got %d", c)
+	}
+	if c := bus.SubscriberCount("item-c"); c != 0 {
+		t.Errorf("none on item-c: want 0, got %d", c)
+	}
+
+	bus.Unsubscribe(chA1)
+	if c := bus.SubscriberCount("item-a"); c != 1 {
+		t.Errorf("after one unsub: want 1, got %d", c)
+	}
+
+	bus.Unsubscribe(chA2)
+	bus.Unsubscribe(chB)
+	if c := bus.SubscriberCount("item-a"); c != 0 {
+		t.Errorf("after all unsub item-a: want 0, got %d", c)
+	}
+	if c := bus.SubscriberCount("item-b"); c != 0 {
+		t.Errorf("after all unsub item-b: want 0, got %d", c)
+	}
+}
+
+// TestMemoryOpBusCloseClosesAllChannels confirms Close cleans up
+// every subscriber, regardless of which item they were watching.
+func TestMemoryOpBusCloseClosesAllChannels(t *testing.T) {
+	bus := NewMemoryOpBus()
+
+	chA := bus.Subscribe("item-a")
+	chB := bus.Subscribe("item-b")
+
+	bus.Close()
+
+	if _, ok := <-chA; ok {
+		t.Errorf("chA should be closed after bus.Close")
+	}
+	if _, ok := <-chB; ok {
+		t.Errorf("chB should be closed after bus.Close")
+	}
+	if c := bus.SubscriberCount("item-a"); c != 0 {
+		t.Errorf("after Close: want 0 subscribers on item-a, got %d", c)
+	}
+}
+
+// TestMemoryOpBusConcurrentPublish confirms the bus survives many
+// concurrent publishers without panicking or tripping the race
+// detector on the subscriber map. Some events legitimately get dropped
+// under contention (that's the slow-subscriber-drop contract — a
+// dedicated test exercises that path), so we don't assert "all events
+// received" here; the goal is race-cleanliness, not zero loss.
+func TestMemoryOpBusConcurrentPublish(t *testing.T) {
+	bus := NewMemoryOpBus()
+	defer bus.Close()
+
+	ch := bus.Subscribe("item-a")
+
+	const writers = 8
+	const each = 50
+	const want = writers * each
+
+	// Drain continuously so the buffer doesn't sit full for long and
+	// every publisher gets to make progress. Stop when publishers are
+	// done AND the channel is empty.
+	stopDrain := make(chan struct{})
+	receivedCh := make(chan int, 1)
+	go func() {
+		count := 0
+		for {
+			select {
+			case _, ok := <-ch:
+				if !ok {
+					receivedCh <- count
+					return
+				}
+				count++
+			case <-stopDrain:
+				// Drain remaining buffered events without blocking.
+				for {
+					select {
+					case _, ok := <-ch:
+						if !ok {
+							receivedCh <- count
+							return
+						}
+						count++
+					default:
+						receivedCh <- count
+						return
+					}
+				}
+			}
+		}
+	}()
+
+	var wg sync.WaitGroup
+	for w := 0; w < writers; w++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for i := 0; i < each; i++ {
+				bus.Publish(OpEvent{
+					ItemID:   "item-a",
+					ClientID: uint64(id),
+					Type:     OpTypeSync,
+					Data:     []byte{byte(i)},
+				})
+			}
+		}(w)
+	}
+	wg.Wait()
+	// Give the drain goroutine a beat to flush anything still buffered
+	// before signalling stop. This isn't strictly required for race
+	// cleanliness but keeps the received-count meaningful for the
+	// sanity assertion below.
+	time.Sleep(50 * time.Millisecond)
+	close(stopDrain)
+
+	select {
+	case got := <-receivedCh:
+		// Sanity: at least some events landed. Exact count varies
+		// because of the legitimate slow-consumer drop path.
+		if got == 0 {
+			t.Fatalf("want at least one event received, got 0 (publish path appears broken)")
+		}
+		if got > want {
+			t.Fatalf("got more events than published: %d > %d", got, want)
+		}
+		t.Logf("concurrent publish: %d/%d events delivered (drops are expected and OK)", got, want)
+	case <-time.After(5 * time.Second):
+		t.Fatal("drain goroutine did not return")
+	}
+}
+
+// drain reads up to n events from ch with a short timeout so a
+// missing/slow event doesn't hang the test.
+func drain(ch chan OpEvent, n int) []OpEvent {
+	out := make([]OpEvent, 0, n)
+	for i := 0; i < n; i++ {
+		select {
+		case ev, ok := <-ch:
+			if !ok {
+				return out
+			}
+			out = append(out, ev)
+		case <-time.After(1 * time.Second):
+			return out
+		}
+	}
+	return out
+}

--- a/internal/collab/memory_bus.go
+++ b/internal/collab/memory_bus.go
@@ -1,0 +1,135 @@
+package collab
+
+import (
+	"log/slog"
+	"sync"
+	"time"
+)
+
+// subscriber wraps a delivery channel with the item filter it cares
+// about. We map *chan to *subscriber (rather than chan→itemID) so
+// MemoryOpBus.Unsubscribe is O(1) and so future enhancements (per-sub
+// metrics, last-activity timestamps) have a place to live.
+type memSubscriber struct {
+	ch     chan OpEvent
+	itemID string
+}
+
+// MemoryOpBus is the in-process OpBus implementation used in every
+// shipping target today (single-binary self-hosted, single-replica
+// pad-cloud). Mirrors the shape of internal/events.MemoryBus so a
+// future RedisOpBus is a drop-in: same Subscribe/Publish/Close
+// surface, same slow-subscriber drop semantics, same cleanup order.
+type MemoryOpBus struct {
+	mu          sync.RWMutex
+	subscribers map[chan OpEvent]*memSubscriber
+}
+
+// NewMemoryOpBus returns a ready-to-use in-process bus.
+func NewMemoryOpBus() *MemoryOpBus {
+	return &MemoryOpBus{
+		subscribers: make(map[chan OpEvent]*memSubscriber),
+	}
+}
+
+// Subscribe registers a subscriber for itemID and returns a buffered
+// channel. Buffer size matches internal/events.MemoryBus (64) — tuned
+// against an SSE workload but suitable for collab too: even a chatty
+// editor produces ops at human-keystroke pace, so 64 events of
+// headroom comfortably covers any momentary write-stall on the
+// receiving WebSocket without pushing memory pressure into the bus.
+func (b *MemoryOpBus) Subscribe(itemID string) chan OpEvent {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	ch := make(chan OpEvent, 64)
+	b.subscribers[ch] = &memSubscriber{
+		ch:     ch,
+		itemID: itemID,
+	}
+	return ch
+}
+
+// Unsubscribe removes a subscriber and closes its channel. No-op when
+// the channel is unknown — a double-Unsubscribe (e.g. handler defer
+// firing after Close has already cleaned up) is safe.
+func (b *MemoryOpBus) Unsubscribe(ch chan OpEvent) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if _, ok := b.subscribers[ch]; ok {
+		delete(b.subscribers, ch)
+		close(ch)
+	}
+}
+
+// Publish fans an event out to every subscriber whose itemID matches.
+// Non-blocking: a slow subscriber whose buffer is full has new events
+// dropped (logged at warn level so operators can spot a stuck client)
+// rather than back-pressuring the broadcast loop. The room manager
+// (TASK-1255) is responsible for closing genuinely unhealthy peers;
+// the bus only protects itself from one bad consumer poisoning every
+// other.
+func (b *MemoryOpBus) Publish(event OpEvent) {
+	if event.Timestamp == 0 {
+		event.Timestamp = time.Now().UnixMilli()
+	}
+
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	for _, sub := range b.subscribers {
+		if sub.itemID != event.ItemID {
+			continue
+		}
+		select {
+		case sub.ch <- event:
+		default:
+			slog.Warn(
+				"collab: dropping op for slow subscriber",
+				"type", event.Type,
+				"item_id", event.ItemID,
+				"client_id", event.ClientID,
+			)
+		}
+	}
+}
+
+// SubscriberCount returns the number of active subscribers whose
+// itemID matches. Used by the room manager to decide when the active
+// peer count has dropped to zero (room enters its 60s grace before
+// teardown) and when it climbs from zero (room comes back live).
+func (b *MemoryOpBus) SubscriberCount(itemID string) int {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	n := 0
+	for _, sub := range b.subscribers {
+		if sub.itemID == itemID {
+			n++
+		}
+	}
+	return n
+}
+
+// Close shuts down the bus. All subscriber channels are closed under
+// the same write-lock that gates Publish/Subscribe so a final inflight
+// Publish can't race a Close into delivering on a closed channel.
+//
+// After Close returns, the bus must not be used. Subscribe will leak
+// goroutines blocked on the closed channel; Publish becomes a no-op
+// over an empty subscriber map but is otherwise undefined.
+func (b *MemoryOpBus) Close() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	for ch := range b.subscribers {
+		delete(b.subscribers, ch)
+		close(ch)
+	}
+}
+
+// Compile-time assertion that MemoryOpBus satisfies OpBus. Catches a
+// drifted interface signature at build time rather than at the first
+// caller site.
+var _ OpBus = (*MemoryOpBus)(nil)

--- a/internal/collab/memory_bus.go
+++ b/internal/collab/memory_bus.go
@@ -64,15 +64,58 @@ func (b *MemoryOpBus) Unsubscribe(ch chan OpEvent) {
 }
 
 // Publish fans an event out to every subscriber whose itemID matches.
+//
 // Non-blocking: a slow subscriber whose buffer is full has new events
 // dropped (logged at warn level so operators can spot a stuck client)
-// rather than back-pressuring the broadcast loop. The room manager
-// (TASK-1255) is responsible for closing genuinely unhealthy peers;
-// the bus only protects itself from one bad consumer poisoning every
-// other.
+// rather than back-pressuring the broadcast loop. One stuck consumer
+// must NEVER poison every other peer in the same room.
+//
+// Recovery contract for dropped sync events:
+//
+// The room manager (TASK-1255) is the bus's only consumer in
+// production. It reads from each subscriber channel and writes to the
+// owning peer's WebSocket. A full channel means that peer's
+// WebSocket write is backed up — slow network, blocked client,
+// half-broken socket, etc. The room manager is responsible for
+// detecting that condition (e.g. via the channel-len threshold
+// exposed by the room health check, TASK-1255 + TASK-1256) and
+// force-closing the slow peer's WebSocket. A fresh reconnect then
+// replays everything the peer missed by loading op-log rows since
+// the peer's last known id (TASK-1252 + Yjs state-vector
+// negotiation). Awareness drops are unrecoverable, but presence is
+// ephemeral so that's fine — sync drops are the only case that
+// matters for correctness, and they're recoverable via the
+// op-log + reconnect path.
+//
+// The bus deliberately does NOT take corrective action itself: it
+// has no concept of WHICH peer owns which channel and no way to
+// signal a force-close. That's the room manager's domain.
+//
+// Mutation contract for OpEvent.Data:
+//
+// Data is cloned at the publish boundary so subscribers (and any
+// other publisher) cannot affect each other through a shared backing
+// array. Subscribers MUST treat their received Data as read-only —
+// mutating one subscriber's view would still mutate every other
+// subscriber's, since they share the same clone. Cloning per
+// subscriber would push that cost onto every fan-out; the chosen
+// trade-off is "one allocation per Publish, immutability by
+// convention on the read side".
 func (b *MemoryOpBus) Publish(event OpEvent) {
 	if event.Timestamp == 0 {
 		event.Timestamp = time.Now().UnixMilli()
+	}
+
+	// Clone Data so a publisher's later buffer reuse cannot mutate
+	// what subscribers observe. One allocation per Publish is cheaper
+	// than a corrupted Yjs decode somewhere downstream — and the
+	// gorilla/websocket ReadMessage caller IS allowed to reuse its
+	// read buffer between messages, so we must not assume the input
+	// slice is owned by us.
+	if event.Data != nil {
+		cloned := make([]byte, len(event.Data))
+		copy(cloned, event.Data)
+		event.Data = cloned
 	}
 
 	b.mu.RLock()


### PR DESCRIPTION
## Summary
Adds the `internal/collab` package with the `OpBus` pub/sub interface and `MemoryOpBus` — the in-process implementation used by every shipping target today. Mirrors `internal/events.MemoryBus` shape so a future `RedisOpBus` is a drop-in for multi-replica deployments (deferred IDEA per the PLAN-1248 body).

## Context
Phase 1, second task under PLAN-1248. Pure infrastructure addition: the bus has no consumers in main yet — those land in TASK-1254 (WS handler) and TASK-1255 (room manager). Approved upfront: ship infra-without-consumer for this Plan rather than gating each PR on its caller.

## Design
- `OpEvent` carries `ItemID` (fan-out filter), `ClientID` (Yjs client id, used by future designated-applier election), `Type` (`sync` → persisted by room manager, `awareness` → broadcast-only), `Data` (opaque y-protocol message), `Timestamp` (auto-stamped on Publish).
- `MemoryOpBus`: 64-event buffered subscriber channels; non-blocking Publish drops events for slow subscribers with a warn log (room manager is responsible for closing unhealthy peers); idempotent Unsubscribe; Close cleans up under the write lock so a final inflight Publish can't race into delivering on a closed channel.
- Compile-time interface assertion (`var _ OpBus = (*MemoryOpBus)(nil)`) catches drift at build.

## Test plan
- [x] `go build ./... && go vet ./...` — clean
- [x] `go test ./internal/collab/ -race -count=1` — 6 tests pass, no race detector hits
- [x] `go test ./...` — full suite green
- [x] Tests cover: per-item fan-out, unsubscribe-closes-channel, slow-consumer drop without blocking, SubscriberCount accuracy, Close cleanup, concurrent-publishers race-cleanliness

## Out of scope
- `RedisOpBus` (separate IDEA at PLAN-1248 close)
- WS handler / room manager (TASK-1254 / TASK-1255)