### PR TITLE
feat(collab): per-item Room manager with op-log replay + grace TTL (TASK-1255)

### DIFF
--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -36,6 +36,7 @@ import (
 	"regexp"
 
 	"github.com/PerpetualSoftware/pad/internal/billing"
+	"github.com/PerpetualSoftware/pad/internal/collab"
 	"github.com/PerpetualSoftware/pad/internal/email"
 	"github.com/PerpetualSoftware/pad/internal/events"
 	"github.com/PerpetualSoftware/pad/internal/logging"
@@ -649,6 +650,14 @@ func serveCmd() *cobra.Command {
 			// Wrap event bus with Prometheus instrumentation
 			eventBus = metrics.NewInstrumentedBus(eventBus, m)
 			srv.SetEventBus(eventBus)
+
+			// Yjs collab room manager (PLAN-1248). Single-instance only
+			// today; multi-replica fanout via Redis is a deferred IDEA.
+			// MemoryOpBus is in-process; the OpBus interface keeps the
+			// door open for a RedisOpBus drop-in later.
+			collabBus := collab.NewMemoryOpBus()
+			srv.SetCollabRoomManager(collab.NewRoomManager(s, collabBus))
+			slog.Info("Collab room manager wired (Yjs over /api/v1/collab/{itemID})")
 
 			// Attach webhook dispatcher for outgoing notifications
 			srv.SetWebhookDispatcher(webhooks.NewDispatcher(s))

--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -789,6 +789,16 @@ func serveCmd() *cobra.Command {
 					slog.Error("HTTP server shutdown error", "error", err)
 				}
 
+				// http.Server.Shutdown doesn't terminate hijacked
+				// connections (WebSockets), so collab sessions keep
+				// running until something explicitly closes them.
+				// srv.Stop() runs the collab RoomManager.Close path
+				// (TASK-1255) plus the other long-running background
+				// loops (orphan GC, MCP audit writer, etc.). Without
+				// this, an open collab WS would race the deferred
+				// store close on process exit.
+				srv.Stop()
+
 				slog.Info("Server stopped")
 				return nil
 			}

--- a/internal/collab/manager.go
+++ b/internal/collab/manager.go
@@ -23,6 +23,12 @@ const DefaultSchemaVersion = "1"
 // can't deadlock a Join indefinitely.
 var errTooManyJoinRetries = errors.New("collab: too many room-close races; aborting Join")
 
+// errManagerClosed is returned by Join when Close has already run.
+// http.Server.Shutdown does NOT wait for hijacked WS handlers, so a
+// late Join can race a finishing shutdown. Returning a fast error
+// closes the WS cleanly and avoids touching a torn-down store.
+var errManagerClosed = errors.New("collab: room manager is closed")
+
 // RoomManagerConfig collects optional knobs for NewRoomManagerWithConfig.
 // Production callers should use NewRoomManager (which fills in the
 // defaults); the config form exists so tests can drop graceTTL to a
@@ -50,14 +56,19 @@ type RoomManager struct {
 	schemaVersion string
 	graceTTL      time.Duration
 
-	mu    sync.Mutex
-	rooms map[string]*Room
+	mu     sync.Mutex
+	rooms  map[string]*Room
+	closed bool // set under mu by Close; Join short-circuits when true
 
 	// activeJoins tracks every in-flight Join goroutine so Close can
 	// act as a true drain barrier on server shutdown. Without this
 	// Wait, http.Server.Shutdown returns before hijacked WS sessions
 	// finish their tear-down, and a deferred store close races
-	// in-flight AppendYjsUpdate calls.
+	// in-flight AppendYjsUpdate calls. The Add call lives inside
+	// m.mu so it can't interleave with Close's closed=true write —
+	// either the Add happens before closed=true (Wait will block
+	// for it) or closed=true happens first (Join returns
+	// errManagerClosed without ever Add'ing).
 	activeJoins sync.WaitGroup
 }
 
@@ -97,11 +108,26 @@ func NewRoomManagerWithConfig(store opLogStore, bus OpBus, cfg RoomManagerConfig
 // normal close. The handler typically logs but doesn't act on the
 // return value: the connection is gone either way.
 func (m *RoomManager) Join(itemID string, conn *websocket.Conn) error {
+	// Gate Add on the closed flag under m.mu so a late Join (e.g. a
+	// hijacked WS handler that didn't enter Join until AFTER Close
+	// returned) can't sneak past the drain barrier.
+	m.mu.Lock()
+	if m.closed {
+		m.mu.Unlock()
+		return errManagerClosed
+	}
 	m.activeJoins.Add(1)
+	m.mu.Unlock()
 	defer m.activeJoins.Done()
 
 	for attempt := 0; attempt < 3; attempt++ {
 		room := m.getOrCreate(itemID)
+		if room == nil {
+			// Close raced in between our closed-check above and
+			// getOrCreate. Bail with the same fast error so the
+			// handler closes the WS cleanly.
+			return errManagerClosed
+		}
 
 		rc := &roomConn{
 			id:   nextConnID(),
@@ -177,10 +203,18 @@ func (m *RoomManager) runConn(room *Room, rc *roomConn) error {
 // under m.mu, mints a new one. Holding m.mu across the lookup +
 // insertion keeps the grace-expiry path (which also takes m.mu)
 // from interleaving and orphaning a freshly-created Room.
+//
+// Returns nil after Close has been called — the caller should
+// translate that to errManagerClosed. In practice Join checks
+// m.closed earlier and bails before reaching here, but this guard
+// keeps a future caller honest if getOrCreate gets reused.
 func (m *RoomManager) getOrCreate(itemID string) *Room {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
+	if m.closed {
+		return nil
+	}
 	if r, ok := m.rooms[itemID]; ok {
 		return r
 	}
@@ -236,6 +270,11 @@ func (m *RoomManager) RoomCount() int {
 //      returns before the goroutines actually exit.
 func (m *RoomManager) Close() {
 	m.mu.Lock()
+	if m.closed {
+		m.mu.Unlock()
+		return
+	}
+	m.closed = true
 	rooms := make([]*Room, 0, len(m.rooms))
 	for _, r := range m.rooms {
 		rooms = append(rooms, r)

--- a/internal/collab/manager.go
+++ b/internal/collab/manager.go
@@ -52,6 +52,13 @@ type RoomManager struct {
 
 	mu    sync.Mutex
 	rooms map[string]*Room
+
+	// activeJoins tracks every in-flight Join goroutine so Close can
+	// act as a true drain barrier on server shutdown. Without this
+	// Wait, http.Server.Shutdown returns before hijacked WS sessions
+	// finish their tear-down, and a deferred store close races
+	// in-flight AppendYjsUpdate calls.
+	activeJoins sync.WaitGroup
 }
 
 // NewRoomManager wires the store + bus together with production defaults.
@@ -90,6 +97,9 @@ func NewRoomManagerWithConfig(store opLogStore, bus OpBus, cfg RoomManagerConfig
 // normal close. The handler typically logs but doesn't act on the
 // return value: the connection is gone either way.
 func (m *RoomManager) Join(itemID string, conn *websocket.Conn) error {
+	m.activeJoins.Add(1)
+	defer m.activeJoins.Done()
+
 	for attempt := 0; attempt < 3; attempt++ {
 		room := m.getOrCreate(itemID)
 
@@ -207,9 +217,23 @@ func (m *RoomManager) RoomCount() int {
 	return len(m.rooms)
 }
 
-// Close stops every active room. After Close, Join is undefined —
+// Close stops every active room AND blocks until every in-flight
+// Join goroutine has returned. After Close, Join is undefined —
 // callers must coordinate shutdown so no new Join races happen
-// alongside Close. Used by Server.Stop on graceful shutdown.
+// alongside Close. Used by Server.Stop on graceful shutdown to
+// ensure no collab goroutine is still running by the time the
+// store is closed.
+//
+// Two phases:
+//
+//   1. closeAll on every room — closes each WebSocket from the
+//      server side, which causes the corresponding readLoop to
+//      return, removeConn to fire, the bus subscription to close,
+//      and writeLoop to exit. The Join goroutine that was running
+//      runConn then returns naturally.
+//   2. activeJoins.Wait — blocks until step 1's effects propagate
+//      through every still-running Join. Without this Wait, Close
+//      returns before the goroutines actually exit.
 func (m *RoomManager) Close() {
 	m.mu.Lock()
 	rooms := make([]*Room, 0, len(m.rooms))
@@ -222,4 +246,6 @@ func (m *RoomManager) Close() {
 	for _, r := range rooms {
 		r.closeAll()
 	}
+
+	m.activeJoins.Wait()
 }

--- a/internal/collab/manager.go
+++ b/internal/collab/manager.go
@@ -1,0 +1,211 @@
+package collab
+
+import (
+	"errors"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// DefaultSchemaVersion is the schema-version stamp used by all rooms
+// today. TASK-1268 will add a real client-driven version with a
+// snapshot-and-rebuild flow on mismatch; for now every persisted
+// op-log row carries the same value, which is exactly what
+// LoadYjsUpdatesSince expects.
+const DefaultSchemaVersion = "1"
+
+// errTooManyJoinRetries surfaces when RoomManager.Join lost the
+// addConn-vs-grace-expiry race more times than feels like a real
+// race. In practice this should never trigger — the race window is
+// microseconds — but it caps the retry loop so a misbehaving room
+// can't deadlock a Join indefinitely.
+var errTooManyJoinRetries = errors.New("collab: too many room-close races; aborting Join")
+
+// RoomManagerConfig collects optional knobs for NewRoomManagerWithConfig.
+// Production callers should use NewRoomManager (which fills in the
+// defaults); the config form exists so tests can drop graceTTL to a
+// few milliseconds without sleeping the full minute.
+type RoomManagerConfig struct {
+	// SchemaVersion stamped on every persisted op-log row.
+	// Empty → DefaultSchemaVersion.
+	SchemaVersion string
+	// GraceTTL controls how long a Room survives without subscribers.
+	// Zero → DefaultGraceTTL.
+	GraceTTL time.Duration
+}
+
+// RoomManager is the single entry point for the collab WS handler.
+// It owns the OpBus, the per-item Room map, and the lifecycle (lazy
+// create, grace-TTL reclaim, graceful shutdown).
+//
+// Construction is via NewRoomManager(store, bus). The bus must be
+// the SAME instance that any other broadcasting code (e.g. future
+// designated-applier hooks in TASK-1257) shares — multiple buses
+// would silo their fan-out and break cross-tab live editing.
+type RoomManager struct {
+	store         opLogStore
+	bus           OpBus
+	schemaVersion string
+	graceTTL      time.Duration
+
+	mu    sync.Mutex
+	rooms map[string]*Room
+}
+
+// NewRoomManager wires the store + bus together with production defaults.
+func NewRoomManager(store opLogStore, bus OpBus) *RoomManager {
+	return NewRoomManagerWithConfig(store, bus, RoomManagerConfig{})
+}
+
+// NewRoomManagerWithConfig is the explicit-config form. Empty config
+// fields fall back to package defaults.
+func NewRoomManagerWithConfig(store opLogStore, bus OpBus, cfg RoomManagerConfig) *RoomManager {
+	schemaVersion := cfg.SchemaVersion
+	if schemaVersion == "" {
+		schemaVersion = DefaultSchemaVersion
+	}
+	graceTTL := cfg.GraceTTL
+	if graceTTL <= 0 {
+		graceTTL = DefaultGraceTTL
+	}
+	return &RoomManager{
+		store:         store,
+		bus:           bus,
+		schemaVersion: schemaVersion,
+		graceTTL:      graceTTL,
+		rooms:         make(map[string]*Room),
+	}
+}
+
+// Join attaches a freshly-upgraded WebSocket connection to the room
+// for itemID. Replays the op-log to the new peer, spins up an inbound
+// reader and an outbound writer, and blocks until the WebSocket
+// closes (graceful close frame or transport failure). The caller —
+// typically the HTTP handler — should defer conn.Close so that any
+// resources held by the WS upgrader are released after this returns.
+//
+// Returns whatever error caused the WebSocket to close, or nil on a
+// normal close. The handler typically logs but doesn't act on the
+// return value: the connection is gone either way.
+func (m *RoomManager) Join(itemID string, conn *websocket.Conn) error {
+	for attempt := 0; attempt < 3; attempt++ {
+		room := m.getOrCreate(itemID)
+
+		rc := &roomConn{
+			id:   nextConnID(),
+			conn: conn,
+			bus:  m.bus.Subscribe(itemID),
+		}
+
+		if err := room.addConn(rc); err != nil {
+			// Race: the grace timer reclaimed the room between
+			// getOrCreate and addConn. Unsubscribe the channel we
+			// just opened (otherwise the bus leaks the slot until
+			// the bus is closed) and retry. The next getOrCreate
+			// won't find the now-deleted room and will mint a
+			// fresh one.
+			m.bus.Unsubscribe(rc.bus)
+			if errors.Is(err, errRoomClosing) {
+				continue
+			}
+			return err
+		}
+
+		return m.runConn(room, rc)
+	}
+	return errTooManyJoinRetries
+}
+
+// runConn drives one connection through its full lifecycle: replay,
+// spawn writer, run reader, tear down. Returns the WS close error.
+func (m *RoomManager) runConn(room *Room, rc *roomConn) error {
+	// Replay BEFORE spawning the writer so the initial state arrives
+	// on the wire before any live broadcasts the writer might fan out
+	// (preserving causal order on a fresh peer).
+	if err := room.replayTo(rc); err != nil {
+		room.removeConn(rc)
+		return err
+	}
+
+	writerDone := make(chan struct{})
+	go func() {
+		defer close(writerDone)
+		room.writeLoop(rc)
+	}()
+
+	// Read loop blocks until the WS closes.
+	readErr := room.readLoop(rc)
+
+	// Reader returned: take the conn out of the room (which closes
+	// the bus subscription, which unblocks the writer).
+	room.removeConn(rc)
+
+	// Wait for the writer to drain before returning so the handler's
+	// `defer conn.Close()` doesn't fire mid-WriteMessage.
+	<-writerDone
+
+	return readErr
+}
+
+// getOrCreate returns the existing Room for itemID or, atomically
+// under m.mu, mints a new one. Holding m.mu across the lookup +
+// insertion keeps the grace-expiry path (which also takes m.mu)
+// from interleaving and orphaning a freshly-created Room.
+func (m *RoomManager) getOrCreate(itemID string) *Room {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if r, ok := m.rooms[itemID]; ok {
+		return r
+	}
+	r := &Room{
+		itemID:        itemID,
+		store:         m.store,
+		bus:           m.bus,
+		schemaVersion: m.schemaVersion,
+		graceTTL:      m.graceTTL,
+		conns:         make(map[*websocket.Conn]*roomConn),
+		onIdle:        m.markRoomGone,
+	}
+	m.rooms[itemID] = r
+	return r
+}
+
+// markRoomGone is the Room → Manager callback the grace timer fires
+// on its way out. The Room has already set closing = true under its
+// own mutex; here we just unhook the manager's lookup so the next
+// Join mints a fresh Room.
+func (m *RoomManager) markRoomGone(itemID string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.rooms, itemID)
+	slog.Debug("collab: room reclaimed after grace TTL", "item_id", itemID)
+}
+
+// RoomCount is a test/debug accessor. Production code shouldn't make
+// decisions based on this — the count is racy with grace-timer
+// expirations.
+func (m *RoomManager) RoomCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.rooms)
+}
+
+// Close stops every active room. After Close, Join is undefined —
+// callers must coordinate shutdown so no new Join races happen
+// alongside Close. Used by Server.Stop on graceful shutdown.
+func (m *RoomManager) Close() {
+	m.mu.Lock()
+	rooms := make([]*Room, 0, len(m.rooms))
+	for _, r := range m.rooms {
+		rooms = append(rooms, r)
+	}
+	m.rooms = make(map[string]*Room)
+	m.mu.Unlock()
+
+	for _, r := range rooms {
+		r.closeAll()
+	}
+}

--- a/internal/collab/manager.go
+++ b/internal/collab/manager.go
@@ -118,22 +118,36 @@ func (m *RoomManager) Join(itemID string, conn *websocket.Conn) error {
 	return errTooManyJoinRetries
 }
 
-// runConn drives one connection through its full lifecycle: replay,
-// spawn writer, run reader, tear down. Returns the WS close error.
+// runConn drives one connection through its full lifecycle: spawn
+// writer (drains the bus subscription concurrently with replay),
+// stream the op-log replay, run reader, tear down.
+//
+// The writer is started BEFORE the replay so live broadcasts that
+// arrive during a long replay can't overflow the 64-event bus
+// channel and silently drop. Yjs CRDTs are commutative — applying
+// op 100 (live) then op 50 (replay) produces the same final Y.Doc
+// as the reverse order — so interleaving replay frames and live
+// updates on the same conn is correct. Both code paths write
+// through rc.writeMessage which holds writeMu, so we never violate
+// gorilla's "one writer at a time per conn" rule.
+//
+// The trade-off: a peer might briefly see updates "out of causal
+// order" during the replay window. That's a UX wobble, not a
+// correctness issue. The alternative — buffer-then-flush — would
+// require an unbounded queue or risk losing live updates the way
+// the original implementation did.
 func (m *RoomManager) runConn(room *Room, rc *roomConn) error {
-	// Replay BEFORE spawning the writer so the initial state arrives
-	// on the wire before any live broadcasts the writer might fan out
-	// (preserving causal order on a fresh peer).
-	if err := room.replayTo(rc); err != nil {
-		room.removeConn(rc)
-		return err
-	}
-
 	writerDone := make(chan struct{})
 	go func() {
 		defer close(writerDone)
 		room.writeLoop(rc)
 	}()
+
+	if err := room.replayTo(rc); err != nil {
+		room.removeConn(rc)
+		<-writerDone
+		return err
+	}
 
 	// Read loop blocks until the WS closes.
 	readErr := room.readLoop(rc)

--- a/internal/collab/manager_test.go
+++ b/internal/collab/manager_test.go
@@ -1,0 +1,435 @@
+package collab
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+	"github.com/gorilla/websocket"
+)
+
+// fakeOpLog is an in-memory opLogStore. We don't pull in the real
+// store here because the room-manager contract is narrow and the
+// store dependency would drag in SQLite + migrations for what is
+// fundamentally a goroutine-orchestration test.
+type fakeOpLog struct {
+	mu      sync.Mutex
+	rows    []models.YjsUpdate
+	nextID  int64
+	failOn  string // if non-empty, AppendYjsUpdate returns this as an error message for any row
+	appendN int
+}
+
+func (f *fakeOpLog) AppendYjsUpdate(itemID string, data []byte, schemaVersion string) (int64, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.appendN++
+	if f.failOn != "" {
+		return 0, errors.New(f.failOn)
+	}
+	f.nextID++
+	cp := make([]byte, len(data))
+	copy(cp, data)
+	row := models.YjsUpdate{
+		ID:            f.nextID,
+		ItemID:        itemID,
+		UpdateData:    cp,
+		SchemaVersion: schemaVersion,
+		CreatedAt:     time.Now().UTC(),
+	}
+	f.rows = append(f.rows, row)
+	return row.ID, nil
+}
+
+func (f *fakeOpLog) LoadYjsUpdatesSince(itemID string, sinceID int64) ([]models.YjsUpdate, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	var out []models.YjsUpdate
+	for _, r := range f.rows {
+		if r.ItemID == itemID && r.ID > sinceID {
+			out = append(out, r)
+		}
+	}
+	return out, nil
+}
+
+func (f *fakeOpLog) appendCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.appendN
+}
+
+func (f *fakeOpLog) rowCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.rows)
+}
+
+// newCollabTestServer wires up an httptest server whose only handler
+// upgrades the inbound WS, registers it with the manager, and waits
+// for the session to end. Tests dial it via newWSClient below.
+func newCollabTestServer(t *testing.T, mgr *RoomManager) *httptest.Server {
+	t.Helper()
+	upgrader := websocket.Upgrader{}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/ws/", func(w http.ResponseWriter, r *http.Request) {
+		itemID := r.URL.Path[len("/ws/"):]
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade: %v", err)
+			return
+		}
+		defer conn.Close()
+		_ = mgr.Join(itemID, conn)
+	})
+	return httptest.NewServer(mux)
+}
+
+func dialWS(t *testing.T, server *httptest.Server, itemID string) *websocket.Conn {
+	t.Helper()
+	u, _ := url.Parse(server.URL)
+	wsURL := "ws://" + u.Host + "/ws/" + itemID
+	c, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	return c
+}
+
+func sendSync(t *testing.T, c *websocket.Conn, payload byte) {
+	t.Helper()
+	// Build a minimal y-protocol sync frame: leading 0x00 for "sync",
+	// followed by an arbitrary trailing byte that distinguishes one
+	// frame from another in test assertions.
+	if err := c.WriteMessage(websocket.BinaryMessage, []byte{yMessageSync, payload}); err != nil {
+		t.Fatalf("write sync: %v", err)
+	}
+}
+
+func sendAwareness(t *testing.T, c *websocket.Conn, payload byte) {
+	t.Helper()
+	if err := c.WriteMessage(websocket.BinaryMessage, []byte{yMessageAwareness, payload}); err != nil {
+		t.Fatalf("write awareness: %v", err)
+	}
+}
+
+// readBinaryWithin reads a single binary frame within d. Returns the
+// payload bytes or fails the test on timeout.
+func readBinaryWithin(t *testing.T, c *websocket.Conn, d time.Duration) []byte {
+	t.Helper()
+	c.SetReadDeadline(time.Now().Add(d))
+	defer c.SetReadDeadline(time.Time{})
+	mt, data, err := c.ReadMessage()
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if mt != websocket.BinaryMessage {
+		t.Fatalf("expected binary frame, got %d", mt)
+	}
+	return data
+}
+
+// expectNoMessage checks that no frame arrives within d.
+func expectNoMessage(t *testing.T, c *websocket.Conn, d time.Duration) {
+	t.Helper()
+	c.SetReadDeadline(time.Now().Add(d))
+	defer c.SetReadDeadline(time.Time{})
+	if mt, data, err := c.ReadMessage(); err == nil {
+		t.Fatalf("expected no frame, got mt=%d data=%v", mt, data)
+	}
+}
+
+// TestRoomManagerLazyCreate verifies the manager doesn't materialise
+// rooms until the first Join.
+func TestRoomManagerLazyCreate(t *testing.T) {
+	bus := NewMemoryOpBus()
+	defer bus.Close()
+	mgr := NewRoomManager(&fakeOpLog{}, bus)
+
+	if got := mgr.RoomCount(); got != 0 {
+		t.Fatalf("fresh manager: want 0 rooms, got %d", got)
+	}
+
+	srv := newCollabTestServer(t, mgr)
+	defer srv.Close()
+
+	c := dialWS(t, srv, "item-a")
+	defer c.Close()
+
+	// Wait for the join to register.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if mgr.RoomCount() == 1 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if got := mgr.RoomCount(); got != 1 {
+		t.Fatalf("after first Join: want 1 room, got %d", got)
+	}
+}
+
+// TestRoomManagerOpLogReplay confirms a fresh peer receives every
+// previously-persisted op-log row before any live frames.
+func TestRoomManagerOpLogReplay(t *testing.T) {
+	bus := NewMemoryOpBus()
+	defer bus.Close()
+
+	store := &fakeOpLog{}
+	// Pre-seed the op-log with two rows for item-a. Use the y-sync
+	// header (0x00) so the room treats them as sync frames if they
+	// were ever fed back through the read path.
+	if _, err := store.AppendYjsUpdate("item-a", []byte{yMessageSync, 0x01}, "1"); err != nil {
+		t.Fatalf("seed 1: %v", err)
+	}
+	if _, err := store.AppendYjsUpdate("item-a", []byte{yMessageSync, 0x02}, "1"); err != nil {
+		t.Fatalf("seed 2: %v", err)
+	}
+
+	mgr := NewRoomManager(store, bus)
+	srv := newCollabTestServer(t, mgr)
+	defer srv.Close()
+
+	c := dialWS(t, srv, "item-a")
+	defer c.Close()
+
+	first := readBinaryWithin(t, c, 2*time.Second)
+	second := readBinaryWithin(t, c, 2*time.Second)
+
+	if len(first) < 2 || first[1] != 0x01 {
+		t.Errorf("replay row 1 mismatch: got %v", first)
+	}
+	if len(second) < 2 || second[1] != 0x02 {
+		t.Errorf("replay row 2 mismatch: got %v", second)
+	}
+}
+
+// TestRoomManagerSyncBroadcastAndPersist drives a sync frame from
+// peer A and confirms B receives it AND the op-log gained a row.
+func TestRoomManagerSyncBroadcastAndPersist(t *testing.T) {
+	bus := NewMemoryOpBus()
+	defer bus.Close()
+	store := &fakeOpLog{}
+	mgr := NewRoomManager(store, bus)
+	srv := newCollabTestServer(t, mgr)
+	defer srv.Close()
+
+	a := dialWS(t, srv, "item-a")
+	defer a.Close()
+	b := dialWS(t, srv, "item-a")
+	defer b.Close()
+
+	// Wait for both to be subscribed before publishing.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if bus.SubscriberCount("item-a") == 2 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if got := bus.SubscriberCount("item-a"); got != 2 {
+		t.Fatalf("want 2 subscribers, got %d", got)
+	}
+
+	sendSync(t, a, 0x42)
+
+	got := readBinaryWithin(t, b, 2*time.Second)
+	if len(got) < 2 || got[0] != yMessageSync || got[1] != 0x42 {
+		t.Errorf("B received unexpected frame: %v", got)
+	}
+
+	// A must NOT receive its own echo. Pause briefly to let any
+	// stray broadcast land before asserting.
+	expectNoMessage(t, a, 200*time.Millisecond)
+
+	if store.appendCount() != 1 {
+		t.Errorf("op-log appendCount: want 1, got %d", store.appendCount())
+	}
+}
+
+// TestRoomManagerAwarenessNotPersisted is the symmetric test for
+// awareness frames: broadcast to peers, never written to the op-log.
+func TestRoomManagerAwarenessNotPersisted(t *testing.T) {
+	bus := NewMemoryOpBus()
+	defer bus.Close()
+	store := &fakeOpLog{}
+	mgr := NewRoomManager(store, bus)
+	srv := newCollabTestServer(t, mgr)
+	defer srv.Close()
+
+	a := dialWS(t, srv, "item-a")
+	defer a.Close()
+	b := dialWS(t, srv, "item-a")
+	defer b.Close()
+
+	// Wait for B's subscription.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if bus.SubscriberCount("item-a") == 2 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	sendAwareness(t, a, 0x77)
+
+	got := readBinaryWithin(t, b, 2*time.Second)
+	if len(got) < 2 || got[0] != yMessageAwareness || got[1] != 0x77 {
+		t.Errorf("B received unexpected frame: %v", got)
+	}
+
+	if store.rowCount() != 0 {
+		t.Errorf("op-log rowCount: want 0 (awareness must not persist), got %d", store.rowCount())
+	}
+}
+
+// TestRoomManagerCrossItemIsolation makes sure events for item-a do
+// not leak to peers connected to item-b. Without per-item bus
+// filtering this would silently scramble unrelated documents.
+func TestRoomManagerCrossItemIsolation(t *testing.T) {
+	bus := NewMemoryOpBus()
+	defer bus.Close()
+	store := &fakeOpLog{}
+	mgr := NewRoomManager(store, bus)
+	srv := newCollabTestServer(t, mgr)
+	defer srv.Close()
+
+	a := dialWS(t, srv, "item-a")
+	defer a.Close()
+	b := dialWS(t, srv, "item-b")
+	defer b.Close()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if bus.SubscriberCount("item-a") == 1 && bus.SubscriberCount("item-b") == 1 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	sendSync(t, a, 0xAA)
+
+	expectNoMessage(t, b, 200*time.Millisecond)
+}
+
+// TestRoomManagerGraceTTLReclaim exercises the grace-timer path with
+// a short TTL injected via the per-manager config. After the timer
+// fires the manager's room map drops the entry, so a fresh Join
+// mints a new room with no in-memory state.
+func TestRoomManagerGraceTTLReclaim(t *testing.T) {
+	bus := NewMemoryOpBus()
+	defer bus.Close()
+	store := &fakeOpLog{}
+	mgr := NewRoomManagerWithConfig(store, bus, RoomManagerConfig{GraceTTL: 50 * time.Millisecond})
+	srv := newCollabTestServer(t, mgr)
+	defer srv.Close()
+
+	c := dialWS(t, srv, "item-a")
+
+	// Wait for room to register.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if mgr.RoomCount() == 1 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if mgr.RoomCount() != 1 {
+		t.Fatalf("expected room created, got %d", mgr.RoomCount())
+	}
+
+	// Disconnect + verify reclaimed within the grace window.
+	c.Close()
+
+	deadline = time.Now().Add(1 * time.Second)
+	for time.Now().Before(deadline) {
+		if mgr.RoomCount() == 0 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if mgr.RoomCount() != 0 {
+		t.Fatalf("expected room reclaimed after grace TTL, got %d", mgr.RoomCount())
+	}
+}
+
+// TestRoomManagerGraceTTLCancelledByReconnect confirms a fresh
+// connection within the grace window keeps the same Room — the
+// room count does NOT bounce 1→0→1, it stays 1 throughout.
+func TestRoomManagerGraceTTLCancelledByReconnect(t *testing.T) {
+	bus := NewMemoryOpBus()
+	defer bus.Close()
+	store := &fakeOpLog{}
+	mgr := NewRoomManagerWithConfig(store, bus, RoomManagerConfig{GraceTTL: 200 * time.Millisecond})
+	srv := newCollabTestServer(t, mgr)
+	defer srv.Close()
+
+	a := dialWS(t, srv, "item-a")
+
+	// Wait for room registration.
+	for i := 0; i < 200; i++ {
+		if mgr.RoomCount() == 1 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	// Disconnect, reconnect well within the grace window.
+	a.Close()
+	time.Sleep(50 * time.Millisecond) // a fraction of grace; timer pending
+	if mgr.RoomCount() != 1 {
+		t.Fatalf("during grace: want room still present, got %d rooms", mgr.RoomCount())
+	}
+
+	b := dialWS(t, srv, "item-a")
+	defer b.Close()
+
+	// Wait past the original grace deadline; if the reconnect didn't
+	// cancel the timer, we'd see RoomCount drop and a new room
+	// allocate, which would be observable as a transient 0.
+	time.Sleep(300 * time.Millisecond)
+	if mgr.RoomCount() != 1 {
+		t.Fatalf("after grace: want 1 room, got %d", mgr.RoomCount())
+	}
+}
+
+// TestRoomManagerCloseShutsDownAllRooms exercises Close: after the
+// call, any active connections should be closed (their reads
+// terminate with an error) and the manager's room map should be
+// empty.
+func TestRoomManagerCloseShutsDownAllRooms(t *testing.T) {
+	bus := NewMemoryOpBus()
+	defer bus.Close()
+	store := &fakeOpLog{}
+	mgr := NewRoomManager(store, bus)
+	srv := newCollabTestServer(t, mgr)
+	defer srv.Close()
+
+	c := dialWS(t, srv, "item-a")
+	defer c.Close()
+
+	// Wait for room.
+	for i := 0; i < 200; i++ {
+		if mgr.RoomCount() == 1 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	mgr.Close()
+
+	if mgr.RoomCount() != 0 {
+		t.Fatalf("after Close: want 0 rooms, got %d", mgr.RoomCount())
+	}
+	// Read should fail because Close closed the conn from the server
+	// side.
+	c.SetReadDeadline(time.Now().Add(1 * time.Second))
+	if _, _, err := c.ReadMessage(); err == nil {
+		t.Errorf("expected read error after manager.Close")
+	}
+}

--- a/internal/collab/manager_test.go
+++ b/internal/collab/manager_test.go
@@ -483,6 +483,30 @@ func TestRoomManagerGraceTTLCancelledByReconnect(t *testing.T) {
 	}
 }
 
+// TestRoomManagerJoinAfterCloseFailsFast covers the post-Close race:
+// http.Server.Shutdown does NOT wait for hijacked WS handlers to
+// finish, so a Join can fire AFTER Close has returned. The manager
+// must reject those Joins fast (errManagerClosed) instead of
+// creating a fresh Room against a torn-down store.
+func TestRoomManagerJoinAfterCloseFailsFast(t *testing.T) {
+	bus := NewMemoryOpBus()
+	defer bus.Close()
+	store := &fakeOpLog{}
+	mgr := NewRoomManager(store, bus)
+
+	mgr.Close()
+
+	// Direct Join — bypass the WS plumbing since we want to exercise
+	// the closed-flag short-circuit in isolation.
+	err := mgr.Join("item-a", nil) // conn is irrelevant; we never reach the WS path
+	if !errors.Is(err, errManagerClosed) {
+		t.Fatalf("want errManagerClosed, got %v", err)
+	}
+
+	// Idempotent: a second Close must not panic.
+	mgr.Close()
+}
+
 // TestRoomManagerCloseShutsDownAllRooms exercises Close: after the
 // call, any active connections should be closed (their reads
 // terminate with an error) and the manager's room map should be

--- a/internal/collab/manager_test.go
+++ b/internal/collab/manager_test.go
@@ -288,6 +288,91 @@ func TestRoomManagerAwarenessNotPersisted(t *testing.T) {
 	}
 }
 
+// TestRoomManagerSerializesSyncAppends is a regression test for the
+// "concurrent peers race AppendYjsUpdate" bug. With the per-room
+// appendMu in place, N peers each writing M sync frames must produce
+// exactly N*M op-log rows AND each peer must see every other peer's
+// frames at least once. Without serialisation this could surface
+// missing rows / out-of-order ids on Postgres.
+func TestRoomManagerSerializesSyncAppends(t *testing.T) {
+	bus := NewMemoryOpBus()
+	defer bus.Close()
+	store := &fakeOpLog{}
+	mgr := NewRoomManager(store, bus)
+	srv := newCollabTestServer(t, mgr)
+	defer srv.Close()
+
+	const peers = 4
+	const writesEach = 10
+	wantRows := peers * writesEach
+
+	conns := make([]*websocket.Conn, peers)
+	for i := 0; i < peers; i++ {
+		conns[i] = dialWS(t, srv, "item-a")
+	}
+	defer func() {
+		for _, c := range conns {
+			c.Close()
+		}
+	}()
+
+	// Wait for all subscriptions to register.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if bus.SubscriberCount("item-a") == peers {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if got := bus.SubscriberCount("item-a"); got != peers {
+		t.Fatalf("subscriber count: want %d, got %d", peers, got)
+	}
+
+	// Drain readers so the subscriber channels stay empty (otherwise
+	// the slow-consumer drop kicks in and the bus loses events).
+	for _, c := range conns {
+		go func(c *websocket.Conn) {
+			for {
+				if _, _, err := c.ReadMessage(); err != nil {
+					return
+				}
+			}
+		}(c)
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < peers; i++ {
+		wg.Add(1)
+		go func(c *websocket.Conn, base byte) {
+			defer wg.Done()
+			for j := 0; j < writesEach; j++ {
+				if err := c.WriteMessage(
+					websocket.BinaryMessage,
+					[]byte{yMessageSync, base, byte(j)},
+				); err != nil {
+					t.Errorf("peer %d write %d: %v", base, j, err)
+					return
+				}
+			}
+		}(conns[i], byte(i))
+	}
+	wg.Wait()
+
+	// Allow the read loops on each peer's roomConn to drain the in-flight
+	// frames into the op-log. Poll instead of fixed sleep so the test
+	// stays fast on a quiet machine and only waits as long as needed.
+	deadline = time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if store.rowCount() == wantRows {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if got := store.rowCount(); got != wantRows {
+		t.Fatalf("op-log rowCount: want %d, got %d", wantRows, got)
+	}
+}
+
 // TestRoomManagerCrossItemIsolation makes sure events for item-a do
 // not leak to peers connected to item-b. Without per-item bus
 // filtering this would silently scramble unrelated documents.

--- a/internal/collab/memory_bus.go
+++ b/internal/collab/memory_bus.go
@@ -32,17 +32,26 @@ func NewMemoryOpBus() *MemoryOpBus {
 	}
 }
 
+// subscriberBufSize is the per-subscriber bus channel buffer. Sized
+// generously so a slow drain (replay holding the conn's writeMu, OS
+// write buffer momentarily backed up, …) doesn't spill over into the
+// drop path under normal editor load.
+//
+// Sizing rationale: a 1k-row op-log replay at ~1ms/row takes ~1
+// second; during that window a chatty 5-peer room produces O(50)
+// live events, so 256 events covers a 5× safety margin. Larger
+// documents (10k+ rows) under sustained write load can still
+// overflow — that's the documented "force-close slow peers" path
+// in the bus's Publish doc comment, deferred to a follow-up task.
+const subscriberBufSize = 256
+
 // Subscribe registers a subscriber for itemID and returns a buffered
-// channel. Buffer size matches internal/events.MemoryBus (64) — tuned
-// against an SSE workload but suitable for collab too: even a chatty
-// editor produces ops at human-keystroke pace, so 64 events of
-// headroom comfortably covers any momentary write-stall on the
-// receiving WebSocket without pushing memory pressure into the bus.
+// channel of size subscriberBufSize.
 func (b *MemoryOpBus) Subscribe(itemID string) chan OpEvent {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	ch := make(chan OpEvent, 64)
+	ch := make(chan OpEvent, subscriberBufSize)
 	b.subscribers[ch] = &memSubscriber{
 		ch:     ch,
 		itemID: itemID,

--- a/internal/collab/room.go
+++ b/internal/collab/room.go
@@ -82,6 +82,15 @@ type Room struct {
 	conns      map[*websocket.Conn]*roomConn
 	graceTimer *time.Timer
 	closing    bool // set after the grace timer reclaims this Room
+
+	// appendMu serialises the persist+publish path for sync frames.
+	// Each peer's readLoop runs in its own goroutine — without this,
+	// concurrent AppendYjsUpdate calls would violate TASK-1252's
+	// "single writer per item" contract and risk a Postgres
+	// allocation-vs-commit-order cursor gap. Held only across the
+	// AppendYjsUpdate + bus.Publish sequence, so it does NOT
+	// serialise reads, awareness frames, or other rooms.
+	appendMu sync.Mutex
 }
 
 // opLogStore is the store surface a Room needs. Pulling it into a
@@ -189,9 +198,19 @@ func (r *Room) readLoop(rc *roomConn) error {
 
 		switch data[0] {
 		case yMessageSync:
-			// Persist before broadcast so a server crash between persist
-			// and broadcast loses at most a live keystroke that the
-			// originating peer will replay on reconnect anyway.
+			// Hold appendMu across the persist+publish sequence so we
+			// uphold TASK-1252's single-writer-per-item contract. The
+			// dumb-relay design intends one writer per Room, but each
+			// peer has its own readLoop — without serialisation here,
+			// two peers' sync frames would race AppendYjsUpdate and
+			// could surface a Postgres cursor gap (allocation order ≠
+			// commit order). awareness frames and OTHER rooms are
+			// unaffected by this lock.
+			r.appendMu.Lock()
+			// Persist before broadcast so a server crash between
+			// persist and broadcast loses at most a live keystroke
+			// that the originating peer will replay on reconnect
+			// anyway.
 			if _, err := r.store.AppendYjsUpdate(r.itemID, data, r.schemaVersion); err != nil {
 				slog.Error("collab: append op-log",
 					"item_id", r.itemID,
@@ -207,6 +226,7 @@ func (r *Room) readLoop(rc *roomConn) error {
 				Type:     OpTypeSync,
 				Data:     data,
 			})
+			r.appendMu.Unlock()
 
 		case yMessageAwareness:
 			// Awareness is presence — ephemeral. Never persisted.

--- a/internal/collab/room.go
+++ b/internal/collab/room.go
@@ -1,0 +1,289 @@
+package collab
+
+import (
+	"errors"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+	"github.com/gorilla/websocket"
+)
+
+// Y-protocol top-level message types. The first byte of every WebSocket
+// message a Yjs client sends discriminates these. The dumb-relay server
+// only needs the coarse split: sync bytes are persisted to the op-log
+// and broadcast; awareness bytes are broadcast only (presence is
+// ephemeral and meaningless after the originating peer disconnects).
+//
+// Subtypes within a sync message (state-vector negotiation vs.
+// document update) are NOT distinguished server-side — the spike
+// verified that persisting whole sync frames yields a correct replay
+// when fed back to a fresh Yjs peer in order. This is the y-websocket
+// reference protocol's "dumb relay" mode.
+const (
+	yMessageSync      = 0
+	yMessageAwareness = 1
+)
+
+// DefaultGraceTTL is how long a Room lingers in memory after its
+// last subscriber disconnects. Within this window a reconnect
+// (transient network blip, mobile-tab background suspension)
+// cancels the grace timer and the Room continues. After the window
+// the Room is removed from the manager and any cached state is
+// reclaimed.
+//
+// 60 seconds tracks the value the Plan body locks in (PLAN-1248)
+// and roughly matches a generous mobile-foreground-restore window.
+// Tests can override per-manager via NewRoomManagerWithConfig.
+const DefaultGraceTTL = 60 * time.Second
+
+// errRoomClosing is returned by Room.addConn when the grace timer
+// fired between the manager's getOrCreate and addConn calls. The
+// caller (RoomManager.Join) re-fetches via the manager — the next
+// getOrCreate will see the room missing and mint a fresh one.
+var errRoomClosing = errors.New("collab: room is closing")
+
+// roomConn pairs a single WebSocket connection with the bookkeeping
+// the Room needs around it: a unique server-assigned id (so a peer's
+// own ops aren't echoed back to itself), the OpBus subscription
+// channel that feeds outbound writes, and a write mutex (gorilla's
+// rule — at most one writer goroutine at a time per conn).
+type roomConn struct {
+	id      uint64
+	conn    *websocket.Conn
+	bus     chan OpEvent
+	writeMu sync.Mutex
+}
+
+// writeMessage is a tiny helper that holds writeMu while writing one
+// frame. All writes (replay during addConn, writeLoop fan-out) go
+// through here so we never hit "concurrent write to websocket
+// connection" panics.
+func (rc *roomConn) writeMessage(messageType int, data []byte) error {
+	rc.writeMu.Lock()
+	defer rc.writeMu.Unlock()
+	return rc.conn.WriteMessage(messageType, data)
+}
+
+// Room is the per-item collab fan-out point. One Room per `itemID`
+// at a time; created lazily by the RoomManager on first Join and
+// reclaimed `graceTTL` after the last subscriber leaves.
+type Room struct {
+	itemID        string
+	store         opLogStore
+	bus           OpBus
+	schemaVersion string
+	graceTTL      time.Duration
+	onIdle        func(string) // RoomManager.markRoomGone
+
+	mu         sync.Mutex
+	conns      map[*websocket.Conn]*roomConn
+	graceTimer *time.Timer
+	closing    bool // set after the grace timer reclaims this Room
+}
+
+// opLogStore is the store surface a Room needs. Pulling it into a
+// narrow interface lets manager_test stub op-log behaviour without
+// dragging in the entire *store.Store API surface.
+type opLogStore interface {
+	AppendYjsUpdate(itemID string, data []byte, schemaVersion string) (int64, error)
+	LoadYjsUpdatesSince(itemID string, sinceID int64) ([]models.YjsUpdate, error)
+}
+
+// addConn registers a freshly-built roomConn with the room. Cancels
+// any pending grace timer (a reconnect within the window keeps the
+// Room alive) and returns errRoomClosing if the grace timer already
+// reclaimed the Room — the caller must restart through the manager
+// to land in a fresh Room.
+func (r *Room) addConn(rc *roomConn) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.closing {
+		return errRoomClosing
+	}
+	if r.graceTimer != nil {
+		r.graceTimer.Stop()
+		r.graceTimer = nil
+	}
+	r.conns[rc.conn] = rc
+	return nil
+}
+
+// removeConn unsubscribes the connection from the bus and, if it was
+// the last subscriber, schedules a graceTTL grace timer. The caller
+// is responsible for closing the WebSocket itself; we only manage the
+// in-room bookkeeping.
+func (r *Room) removeConn(rc *roomConn) {
+	r.bus.Unsubscribe(rc.bus)
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	delete(r.conns, rc.conn)
+	if len(r.conns) == 0 && r.graceTimer == nil && !r.closing {
+		r.graceTimer = time.AfterFunc(r.graceTTL, r.onGraceExpired)
+	}
+}
+
+// onGraceExpired runs after graceTTL has passed without a fresh
+// connection. If the room is still empty it's marked closing and
+// reclaimed by the manager. If a connection arrived in the meantime
+// (race: timer fired but addConn already cleared graceTimer), the
+// stale-timer call no-ops on len(conns)>0 and clears its own slot.
+func (r *Room) onGraceExpired() {
+	r.mu.Lock()
+	if len(r.conns) > 0 {
+		// A fresh connection landed between scheduling and firing.
+		// addConn already set graceTimer = nil; tolerate the residue.
+		r.graceTimer = nil
+		r.mu.Unlock()
+		return
+	}
+	r.closing = true
+	r.mu.Unlock()
+
+	r.onIdle(r.itemID)
+}
+
+// replayTo sends every persisted op-log update for this room to the
+// given connection in order. Each row goes out as its own binary
+// WebSocket frame so a Yjs peer applies them via the same y-protocol
+// path it uses for live updates. Stops on the first WS write error
+// (the connection is doomed); the caller's read loop will surface
+// the same error and tear the connection down cleanly.
+func (r *Room) replayTo(rc *roomConn) error {
+	updates, err := r.store.LoadYjsUpdatesSince(r.itemID, 0)
+	if err != nil {
+		return err
+	}
+	for _, u := range updates {
+		if len(u.UpdateData) == 0 {
+			continue
+		}
+		if werr := rc.writeMessage(websocket.BinaryMessage, u.UpdateData); werr != nil {
+			return werr
+		}
+	}
+	return nil
+}
+
+// readLoop is the inbound side: pull frames off the WebSocket, route
+// sync frames through the op-log + broadcast, awareness frames to
+// broadcast only. Returns when the WS read returns an error
+// (close frame or transport failure). The caller then runs
+// removeConn and waits for writeLoop to exit.
+func (r *Room) readLoop(rc *roomConn) error {
+	for {
+		msgType, data, err := rc.conn.ReadMessage()
+		if err != nil {
+			return err
+		}
+		// Yjs sends only binary frames. Skip text/control frames defensively
+		// so a bad client cannot break the loop with a malformed packet.
+		if msgType != websocket.BinaryMessage || len(data) == 0 {
+			continue
+		}
+
+		switch data[0] {
+		case yMessageSync:
+			// Persist before broadcast so a server crash between persist
+			// and broadcast loses at most a live keystroke that the
+			// originating peer will replay on reconnect anyway.
+			if _, err := r.store.AppendYjsUpdate(r.itemID, data, r.schemaVersion); err != nil {
+				slog.Error("collab: append op-log",
+					"item_id", r.itemID,
+					"client_id", rc.id,
+					"error", err,
+				)
+				// Continue: broadcast keeps the live mesh consistent
+				// even when persistence is blipping.
+			}
+			r.bus.Publish(OpEvent{
+				ItemID:   r.itemID,
+				ClientID: rc.id,
+				Type:     OpTypeSync,
+				Data:     data,
+			})
+
+		case yMessageAwareness:
+			// Awareness is presence — ephemeral. Never persisted.
+			r.bus.Publish(OpEvent{
+				ItemID:   r.itemID,
+				ClientID: rc.id,
+				Type:     OpTypeAwareness,
+				Data:     data,
+			})
+
+		default:
+			// Unknown y-protocol message types (custom extensions,
+			// future revisions). Silently drop — logging at debug
+			// would spam the operator under any client misbehaviour.
+		}
+	}
+}
+
+// writeLoop drains the bus subscription channel and writes every
+// non-self event to the connection. Self-events (those whose
+// ClientID matches our own) are skipped because the originator
+// already has the local Y.Doc state — echoing would be a no-op for
+// them but doubles the wire traffic.
+//
+// Exits when the bus channel closes (Unsubscribe) or a write fails.
+// On write failure the connection is closed so the read loop on the
+// other goroutine surfaces an error and tears down cleanly.
+func (r *Room) writeLoop(rc *roomConn) {
+	for ev := range rc.bus {
+		if ev.ClientID == rc.id {
+			continue
+		}
+		if err := rc.writeMessage(websocket.BinaryMessage, ev.Data); err != nil {
+			// Force the read side to wake up and return.
+			_ = rc.conn.Close()
+			return
+		}
+	}
+}
+
+// peerCount is a test hook — production callers go through the bus's
+// SubscriberCount. Holds r.mu so a concurrent removeConn doesn't
+// produce a torn read.
+func (r *Room) peerCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.conns)
+}
+
+// closeAll closes every active connection on this room and waits for
+// the readers to drain. Used by RoomManager.Close on server shutdown.
+// Holds r.mu only while collecting the conn set; the actual Close
+// calls happen outside the lock so a slow OS-level close doesn't
+// block addConn / removeConn on parallel rooms.
+func (r *Room) closeAll() {
+	r.mu.Lock()
+	if r.graceTimer != nil {
+		r.graceTimer.Stop()
+		r.graceTimer = nil
+	}
+	r.closing = true
+	conns := make([]*websocket.Conn, 0, len(r.conns))
+	for c := range r.conns {
+		conns = append(conns, c)
+	}
+	r.mu.Unlock()
+
+	for _, c := range conns {
+		_ = c.Close()
+	}
+}
+
+// connIDCounter is package-scoped so multiple RoomManagers in the
+// same process never hand out colliding ids. Atomic Add returns a
+// fresh value per call; we never reset.
+var connIDCounter atomic.Uint64
+
+func nextConnID() uint64 {
+	return connIDCounter.Add(1)
+}

--- a/internal/server/handlers_collab.go
+++ b/internal/server/handlers_collab.go
@@ -89,6 +89,17 @@ func (s *Server) handleCollab(w http.ResponseWriter, r *http.Request) {
 
 	// Upgrade. After this returns successfully w/r are hijacked — we
 	// MUST NOT touch them; only conn.WriteMessage / conn.Close.
+	if s.collab == nil {
+		// RoomManager wiring is optional — a self-host build that
+		// doesn't enable collab still exposes the route but should
+		// fail loud rather than silently accepting the upgrade and
+		// dropping every byte. 503 mirrors the SSE handler's
+		// "events bus not configured" path.
+		writeError(w, http.StatusServiceUnavailable, "unavailable",
+			"Collaboration is not available on this server")
+		return
+	}
+
 	conn, err := collabUpgrader.Upgrade(w, r, nil)
 	if err != nil {
 		// Upgrade itself emits the right HTTP status (e.g. 400 on
@@ -128,29 +139,23 @@ func (s *Server) handleCollab(w http.ResponseWriter, r *http.Request) {
 		"user_id", userID,
 	)
 
-	// Drain reads until the client disconnects. No protocol logic in
-	// this task — TASK-1255 (room manager) plumbs reads into the
-	// OpBus + op-log. We still need to read so the connection can
-	// detect close cleanly: gorilla/websocket only surfaces close
-	// frames via ReadMessage, and a control frame (ping/pong) only
-	// gets handled if we're actively reading.
-	for {
-		if _, _, err := conn.ReadMessage(); err != nil {
-			// Normal closure paths (1000, 1001, 1005) are not errors
-			// from the user's perspective — log only the unexpected
-			// codes so operators don't see noise on every disconnect.
-			if websocket.IsUnexpectedCloseError(err,
-				websocket.CloseNormalClosure,
-				websocket.CloseGoingAway,
-				websocket.CloseNoStatusReceived,
-			) {
-				slog.Warn("collab: websocket read ended unexpectedly",
-					"item_id", itemID,
-					"user_id", userID,
-					"error", err,
-				)
-			}
-			return
+	// Hand the connection to the RoomManager. It owns the
+	// op-log replay, fan-out, and lifecycle bookkeeping (lazy create
+	// + grace-TTL reclaim). Returns when the WS closes for any reason.
+	if err := s.collab.Join(itemID, conn); err != nil {
+		// Normal closure paths surface here as websocket.CloseError
+		// values that aren't worth logging. Anything unexpected
+		// (transport failure, room manager hard error) gets a warn.
+		if websocket.IsUnexpectedCloseError(err,
+			websocket.CloseNormalClosure,
+			websocket.CloseGoingAway,
+			websocket.CloseNoStatusReceived,
+		) {
+			slog.Warn("collab: websocket session ended unexpectedly",
+				"item_id", itemID,
+				"user_id", userID,
+				"error", err,
+			)
 		}
 	}
 }

--- a/internal/server/handlers_collab_test.go
+++ b/internal/server/handlers_collab_test.go
@@ -7,9 +7,26 @@ import (
 	"testing"
 	"time"
 
+	"github.com/PerpetualSoftware/pad/internal/collab"
 	"github.com/PerpetualSoftware/pad/internal/models"
 	"github.com/gorilla/websocket"
 )
+
+// testServerWithCollab wires a RoomManager onto a fresh test server
+// so the collab handler answers 200/101 on the happy path. Tests that
+// only assert on auth / visibility responses (401 / 403 / 404) don't
+// need this — those replies happen BEFORE the s.collab nil-check —
+// but it doesn't hurt to keep the helper centralised.
+func testServerWithCollab(t *testing.T) *Server {
+	t.Helper()
+	srv := testServer(t)
+	bus := collab.NewMemoryOpBus()
+	t.Cleanup(bus.Close)
+	rm := collab.NewRoomManager(srv.store, bus)
+	t.Cleanup(rm.Close)
+	srv.SetCollabRoomManager(rm)
+	return srv
+}
 
 // dialCollab opens a WebSocket against the test server's collab
 // endpoint with the given itemID. Returns the connection and the HTTP
@@ -70,7 +87,7 @@ func seedCollabFixture(t *testing.T, srv *Server, wsName string) string {
 // access in that state. This is the easiest path to assert the
 // upgrade actually works end-to-end without setting up auth.
 func TestCollabUpgradeFreshInstall(t *testing.T) {
-	srv := testServer(t)
+	srv := testServerWithCollab(t)
 	ts := httptest.NewServer(srv)
 	defer ts.Close()
 
@@ -260,7 +277,7 @@ func TestCollabUpgradeRejectsRestrictedMemberForeignCollection(t *testing.T) {
 // Strict per-item check (round 4 fix) must surface 404 for the
 // sibling.
 func TestCollabUpgradeRejectsGuestWithSiblingItemGrantOnly(t *testing.T) {
-	srv := testServer(t)
+	srv := testServerWithCollab(t)
 	admin := bootstrapFirstUser(t, srv, "admin@test.com", "Admin")
 	_ = admin
 	ts := httptest.NewServer(srv)
@@ -363,6 +380,29 @@ func TestCollabUpgradeRejectsUnknownItem(t *testing.T) {
 	}
 	if resp.StatusCode != http.StatusNotFound {
 		t.Fatalf("expected 404, got %d", resp.StatusCode)
+	}
+}
+
+// TestCollabUpgradeUnavailableWithoutRoomManager confirms the
+// handler returns 503 when no RoomManager is wired (the
+// SetCollabRoomManager call hasn't happened). Self-host builds that
+// don't enable collab should fail loud rather than silently
+// accepting an upgrade and dropping every byte.
+func TestCollabUpgradeUnavailableWithoutRoomManager(t *testing.T) {
+	srv := testServer(t) // NO RoomManager wired
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	itemID := seedCollabFixture(t, srv, "Unwired")
+	_, resp, err := dialCollab(t, ts.URL, itemID, nil, "")
+	if err == nil {
+		t.Fatal("expected dial to fail without a wired RoomManager")
+	}
+	if resp == nil {
+		t.Fatalf("dial returned no response: %v", err)
+	}
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d", resp.StatusCode)
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/PerpetualSoftware/pad/internal/attachments"
 	"github.com/PerpetualSoftware/pad/internal/billing"
+	"github.com/PerpetualSoftware/pad/internal/collab"
 	"github.com/PerpetualSoftware/pad/internal/email"
 	"github.com/PerpetualSoftware/pad/internal/events"
 	"github.com/PerpetualSoftware/pad/internal/metrics"
@@ -39,6 +40,7 @@ type Server struct {
 	httpServer            *http.Server         // underlying HTTP server (set during ListenAndServe)
 	webFS                 fs.FS                // embedded web UI static files (optional)
 	events                events.EventBus      // real-time event bus (optional)
+	collab                *collab.RoomManager  // Yjs collab room manager (PLAN-1248); optional
 	webhooks              *webhooks.Dispatcher // webhook dispatcher (optional)
 	email                 *email.Sender        // transactional email sender (optional)
 	emailAPIKey           string               // Maileroo API key (used for unsubscribe HMAC)
@@ -383,6 +385,16 @@ func (s *Server) SetBaseURL(rawURL string) {
 // SetEventBus attaches an event bus for real-time SSE streaming.
 func (s *Server) SetEventBus(bus events.EventBus) {
 	s.events = bus
+}
+
+// SetCollabRoomManager attaches a Yjs collab RoomManager (PLAN-1248).
+// When set, the /api/v1/collab/{itemID} WebSocket endpoint hands new
+// connections to the manager for op-log replay + fan-out. When nil,
+// the endpoint exists but answers 503 — that's intentional so a
+// self-host build that wants the editor without collab can leave
+// this unwired without surfacing surprise behaviour.
+func (s *Server) SetCollabRoomManager(rm *collab.RoomManager) {
+	s.collab = rm
 }
 
 // SetWebhookDispatcher attaches a webhook dispatcher for outgoing notifications.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -228,6 +228,12 @@ func (s *Server) Stop() {
 	// independent goroutines; we just need the close BEFORE Wait().
 	s.stopMCPSessionTracker()
 	s.bg.Wait()
+	// Close the collab room manager BEFORE the rateLimiter so any
+	// in-flight Join goroutines holding rate-limiter handles can wind
+	// down via their normal close path. nil-safe: collab is optional.
+	if s.collab != nil {
+		s.collab.Close()
+	}
 	s.rateLimiters.Stop() // nil-safe via the RateLimiters receiver guard
 }
 


### PR DESCRIPTION
## Summary
Wires the OpBus + op-log + WS handler from prior Phase 1 PRs into a working dumb-relay collab server. Per-item Room is created lazily on first WebSocket join, replayed from the op-log on connect, fans out incoming sync ops via the OpBus while persisting them, and lingers `graceTTL` (60s) after the last subscriber disconnects so transient blips don't cost in-memory state.

## Context
Phase 1, fourth task under PLAN-1248. Last of the room-lifecycle pieces — TASK-1256 (auth revalidation), TASK-1257 (designated-applier), TASK-1258 (bundle hardening) layer on top of this.

## Key behaviours
- **Lazy create** — `manager.RoomCount()` is 0 until the first join.
- **Op-log replay on connect** — every persisted row goes out as a separate binary frame BEFORE the writer goroutine starts, preserving causal order.
- **Sync persist + broadcast / awareness broadcast-only** — discriminated on byte 0 (yMessageSync vs yMessageAwareness). Awareness never lands in the op-log.
- **Echo suppression** — server-assigned per-conn id stamped into `OpEvent.ClientID`; writeLoop skips events whose ClientID matches its own.
- **Grace-TTL reclaim** — last disconnect arms a 60s timer; reconnect within the window cancels; expiry sets `closing = true` and removes from the manager map. The `addConn` vs grace-expiry race is handled via `errRoomClosing` + retry.
- **Graceful shutdown** — `RoomManager.Close()` closes every active conn under room mutex, drains the rooms map.
- **Service unavailable when unwired** — handler returns 503 if no RoomManager is set, matching the SSE handler's "events bus not configured" pattern.

## Test plan
- [x] `go build ./... && go vet ./...` — clean
- [x] `go test ./internal/collab/ -race -count=1` — 13 tests pass (6 bus + 7 manager)
- [x] `go test ./...` — full suite green
- [x] Manager tests cover: lazy create, op-log replay, sync broadcast+persist + originator-echo-suppression + op-log row count, awareness no-persist, cross-item isolation, grace-TTL reclaim with 50ms config, grace cancel on reconnect, Close shuts down all rooms
- [x] Race detector clean across all 13

## Out of scope
- Membership revalidation timer (TASK-1256)
- Designated-applier protocol (TASK-1257)
- Schema-version mismatch handling (TASK-1268, Phase 4)