### PR TITLE
feat(collab): designated-applier protocol for external content updates (TASK-1257)

### DIFF
--- a/internal/collab/applier.go
+++ b/internal/collab/applier.go
@@ -83,6 +83,16 @@ type ControlMessage struct {
 	// Markdown carries the new item content for applier_request.
 	// Omitted on applier_ack.
 	Markdown string `json:"markdown,omitempty"`
+
+	// ExpiresAtMillis is the Unix-millis timestamp after which the
+	// browser MUST drop a queued applier_request without applying.
+	// Set by the server on every applier_request to "now +
+	// applierFirstTimeout"; closes the late-apply hazard where a
+	// backgrounded tab eventually wakes up and overwrites newer
+	// edits with stale markdown after the server has already
+	// retried with a different applier (or fallen back). Client
+	// enforcement lives in TASK-1263. Omitted on applier_ack.
+	ExpiresAtMillis int64 `json:"expires_at_millis,omitempty"`
 }
 
 // pendingApplierAck pairs the channel a PATCH handler is waiting on
@@ -159,10 +169,17 @@ func (m *RoomManager) ApplyExternalContent(itemID string, markdown string) error
 		// traffic uses BinaryMessage exclusively, so the browser's
 		// ws.onmessage handler can branch on event.data type
 		// (string vs ArrayBuffer) without an extra prefix byte.
+		//
+		// ExpiresAt is computed per attempt — the SAME request_id
+		// might be sent on a retry (we cancel + re-register so a
+		// late ack from the previous attempt isn't accidentally
+		// accepted, but the request_id stays stable so log lines
+		// thread together).
 		msg := ControlMessage{
-			Type:      ControlMessageApplierRequest,
-			RequestID: requestID,
-			Markdown:  markdown,
+			Type:            ControlMessageApplierRequest,
+			RequestID:       requestID,
+			Markdown:        markdown,
+			ExpiresAtMillis: time.Now().Add(timeouts[attempt]).UnixMilli(),
 		}
 		payload, err := json.Marshal(msg)
 		if err != nil {
@@ -186,7 +203,10 @@ func (m *RoomManager) ApplyExternalContent(itemID string, markdown string) error
 		case <-ackCh:
 			// Success: the applier propagated Y.Doc updates via the
 			// regular sync path before sending the ack, so all peers
-			// are now on the new state.
+			// are now on the new state. Drop the pending-ack entry
+			// so the room's pendingAcks map doesn't grow unbounded
+			// across the lifetime of the room.
+			room.cancelPendingAck(requestID)
 			return nil
 		case <-time.After(timeouts[attempt]):
 			room.cancelPendingAck(requestID)
@@ -195,7 +215,11 @@ func (m *RoomManager) ApplyExternalContent(itemID string, markdown string) error
 				"client_id", applier.id,
 				"attempt", attempt+1,
 			)
-			// Fall through to next attempt.
+			// Fall through to next attempt. Any late-arriving ack
+			// for this request_id from the timed-out conn is
+			// rejected because we just cancelled the entry; the
+			// browser is also expected to drop the stale request
+			// via its expires_at_millis check (TASK-1263).
 		}
 	}
 

--- a/internal/collab/applier.go
+++ b/internal/collab/applier.go
@@ -1,0 +1,317 @@
+package collab
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/gorilla/websocket"
+)
+
+// Designated-applier protocol (TASK-1257).
+//
+// The dumb-relay design keeps Y.Doc semantics in the browser. When a
+// CLI / API / MCP caller updates an item's content while a co-edit
+// session is active, the server can't write items.content directly —
+// the connected browser tabs would overwrite it on the next 5s flush
+// using their (now stale) Y.Doc state.
+//
+// The fix is to nominate one connected tab as the "designated
+// applier". The server sends it a JSON control message with the new
+// markdown; the browser does editor.commands.setContent(markdown),
+// which the y-tiptap binding translates into Y.Doc updates that
+// propagate via the regular sync path. Once the applier acks, every
+// peer is on the new state.
+//
+// Election: longest-connected wins. Stable choice (the longest
+// connection has the most authoritative cumulative Y.Doc state) and
+// minimal flicker — newer tabs probably don't have the full history
+// yet on a fresh reconnect.
+//
+// Failure: if the chosen applier doesn't ack within
+// applierFirstTimeout, retry with the next-longest-connected client
+// (applierRetryTimeout). If no client acks after both attempts,
+// caller falls back to direct items.content write — the current
+// editors will overwrite it on next flush (data loss vs. graceful
+// degradation; the documented contract is "best-effort under
+// active co-edit, direct write is the worst case").
+
+const (
+	// applierMaxAttempts caps the retry loop. Two is the sweet spot:
+	// covers a single slow tab AND a tab that disconnected mid-flow.
+	// More attempts mostly just delay the fall-back path.
+	applierMaxAttempts = 2
+
+	// controlMessageType values. The browser (TASK-1263) writes a
+	// matching applier_ack on completion; any other type the server
+	// might add later goes through the same TextMessage envelope.
+	ControlMessageApplierRequest = "applier_request"
+	ControlMessageApplierAck     = "applier_ack"
+)
+
+// applierFirstTimeoutVar / applierRetryTimeoutVar are vars (rather
+// than consts) so test helpers can shrink them to a few hundred ms.
+// Production code reads them via applierFirstTimeout / applierRetryTimeout
+// helpers below, which keep the const-style call sites stable.
+var (
+	// applierFirstTimeoutVar is the first-attempt budget. Generous
+	// so a tab that just regained focus has time to apply + ack.
+	applierFirstTimeoutVar = 30 * time.Second
+
+	// applierRetryTimeoutVar is shorter — by retry time we already
+	// know the room has at least one slow / stale client; don't
+	// double-pay the wait.
+	applierRetryTimeoutVar = 15 * time.Second
+)
+
+func applierFirstTimeout() time.Duration { return applierFirstTimeoutVar }
+func applierRetryTimeout() time.Duration { return applierRetryTimeoutVar }
+
+// ControlMessage is the JSON envelope the server and the browser
+// exchange over WebSocket TextMessage frames. Y-protocol traffic
+// stays on BinaryMessage so the discriminator at the read-loop level
+// is the message type itself, not a payload byte.
+type ControlMessage struct {
+	Type      string `json:"type"`
+	RequestID string `json:"request_id,omitempty"`
+
+	// Markdown carries the new item content for applier_request.
+	// Omitted on applier_ack.
+	Markdown string `json:"markdown,omitempty"`
+}
+
+// pendingApplierAck pairs the channel a PATCH handler is waiting on
+// with the conn the ack is expected from. Storing the expected conn
+// lets the readLoop reject acks from other peers in the same room
+// (defence in depth — a hostile peer shouldn't be able to forge an
+// ack on someone else's request).
+type pendingApplierAck struct {
+	expectedConn *websocket.Conn
+	ch           chan struct{}
+}
+
+// Sentinel errors for ApplyExternalContent. Callers (the items PATCH
+// handler) translate these to the appropriate fall-back action.
+var (
+	// ErrNoActiveRoom — no Room exists for this itemID. The caller
+	// should write items.content directly.
+	ErrNoActiveRoom = errors.New("collab: no active room for item")
+
+	// ErrNoApplierAvailable — a Room exists but has no live conns
+	// to nominate (e.g. mid-grace-TTL window). Caller falls back to
+	// direct write.
+	ErrNoApplierAvailable = errors.New("collab: no live conn available to apply")
+
+	// ErrAllAppliersTimedOut — every attempt timed out without an
+	// ack. Caller falls back to direct write and (depending on
+	// preference) logs a warn so operators can see degraded sessions.
+	ErrAllAppliersTimedOut = errors.New("collab: all designated appliers timed out")
+)
+
+// ApplyExternalContent routes an external content update through a
+// designated applier when an active room exists. Returns nil on
+// successful ack; one of the sentinel errors above otherwise so the
+// caller can decide whether to fall back to a direct write.
+//
+// The function blocks until ack OR all attempts time out — the PATCH
+// handler stays open during this window and the caller sees the
+// final outcome on return.
+func (m *RoomManager) ApplyExternalContent(itemID string, markdown string) error {
+	m.mu.Lock()
+	if m.closed {
+		m.mu.Unlock()
+		return ErrManagerClosed()
+	}
+	room := m.rooms[itemID]
+	m.mu.Unlock()
+
+	if room == nil {
+		return ErrNoActiveRoom
+	}
+
+	requestID := uuid.NewString()
+	timeouts := []time.Duration{applierFirstTimeout(), applierRetryTimeout()}
+
+	tried := make(map[*websocket.Conn]struct{})
+	for attempt := 0; attempt < applierMaxAttempts; attempt++ {
+		applier := room.pickApplier(tried)
+		if applier == nil {
+			// No more candidates left.
+			if attempt == 0 {
+				return ErrNoApplierAvailable
+			}
+			return ErrAllAppliersTimedOut
+		}
+		tried[applier.conn] = struct{}{}
+
+		ackCh, registerErr := room.registerPendingAck(requestID, applier.conn)
+		if registerErr != nil {
+			// Race: room closed between pickApplier and registration.
+			return registerErr
+		}
+
+		// Send the applier_request as a TextMessage. y-protocol
+		// traffic uses BinaryMessage exclusively, so the browser's
+		// ws.onmessage handler can branch on event.data type
+		// (string vs ArrayBuffer) without an extra prefix byte.
+		msg := ControlMessage{
+			Type:      ControlMessageApplierRequest,
+			RequestID: requestID,
+			Markdown:  markdown,
+		}
+		payload, err := json.Marshal(msg)
+		if err != nil {
+			room.cancelPendingAck(requestID)
+			return fmt.Errorf("marshal applier_request: %w", err)
+		}
+		if err := applier.writeMessage(websocket.TextMessage, payload); err != nil {
+			// Conn write failed (slow / dead). Drop the pending ack
+			// and try the next applier.
+			room.cancelPendingAck(requestID)
+			slog.Warn("collab: applier_request write failed; trying next",
+				"item_id", itemID,
+				"client_id", applier.id,
+				"error", err,
+			)
+			continue
+		}
+
+		// Wait for the ack OR timeout.
+		select {
+		case <-ackCh:
+			// Success: the applier propagated Y.Doc updates via the
+			// regular sync path before sending the ack, so all peers
+			// are now on the new state.
+			return nil
+		case <-time.After(timeouts[attempt]):
+			room.cancelPendingAck(requestID)
+			slog.Warn("collab: applier_request timed out; will retry next applier",
+				"item_id", itemID,
+				"client_id", applier.id,
+				"attempt", attempt+1,
+			)
+			// Fall through to next attempt.
+		}
+	}
+
+	return ErrAllAppliersTimedOut
+}
+
+// ErrManagerClosed exposes the manager's internal closed-flag error
+// to callers via a public sentinel they can wrap. The internal
+// errManagerClosed (in manager.go) is unexported so tests can't
+// errors.Is against it directly.
+func ErrManagerClosed() error { return errManagerClosed }
+
+// pickApplier returns the longest-connected roomConn that hasn't
+// already been tried, or nil if there are no candidates left. The
+// stable ordering (sort by connectedAt asc) ensures successive
+// attempts hit increasingly-younger clients without skipping any.
+func (r *Room) pickApplier(tried map[*websocket.Conn]struct{}) *roomConn {
+	r.mu.Lock()
+	candidates := make([]*roomConn, 0, len(r.conns))
+	for _, rc := range r.conns {
+		if _, skip := tried[rc.conn]; skip {
+			continue
+		}
+		candidates = append(candidates, rc)
+	}
+	r.mu.Unlock()
+
+	if len(candidates) == 0 {
+		return nil
+	}
+	// Stable: longest-connected first; tiebreak on conn id (which
+	// is monotonic within the process).
+	sort.SliceStable(candidates, func(i, j int) bool {
+		if !candidates[i].connectedAt.Equal(candidates[j].connectedAt) {
+			return candidates[i].connectedAt.Before(candidates[j].connectedAt)
+		}
+		return candidates[i].id < candidates[j].id
+	})
+	return candidates[0]
+}
+
+// registerPendingAck creates an entry in the room's pending-acks map
+// keyed on requestID, with the expected ack source set to
+// expectedConn. Returns the channel the caller should select on, or
+// an error if the room is no longer accepting requests.
+func (r *Room) registerPendingAck(requestID string, expectedConn *websocket.Conn) (<-chan struct{}, error) {
+	r.mu.Lock()
+	closing := r.closing
+	r.mu.Unlock()
+	if closing {
+		return nil, errRoomClosing
+	}
+
+	r.pendingMu.Lock()
+	defer r.pendingMu.Unlock()
+	if _, exists := r.pendingAcks[requestID]; exists {
+		// Caller bug — request_ids are UUIDs in production; collision
+		// is effectively impossible.
+		return nil, fmt.Errorf("collab: duplicate request_id %s", requestID)
+	}
+	ch := make(chan struct{}, 1)
+	r.pendingAcks[requestID] = &pendingApplierAck{
+		expectedConn: expectedConn,
+		ch:           ch,
+	}
+	return ch, nil
+}
+
+// cancelPendingAck removes a request from the pending-acks map. Used
+// after a timeout / write failure to free the slot before retrying.
+func (r *Room) cancelPendingAck(requestID string) {
+	r.pendingMu.Lock()
+	delete(r.pendingAcks, requestID)
+	r.pendingMu.Unlock()
+}
+
+// routeApplierAck signals the channel waiting on requestID, but
+// only if the ack came from the expected conn (defence in depth).
+// Called by readLoop on receipt of an applier_ack control message.
+func (r *Room) routeApplierAck(requestID string, fromConn *websocket.Conn) {
+	r.pendingMu.Lock()
+	pending, ok := r.pendingAcks[requestID]
+	r.pendingMu.Unlock()
+	if !ok {
+		return // unknown / already-cancelled request_id
+	}
+	if pending.expectedConn != fromConn {
+		slog.Warn("collab: applier_ack from unexpected conn; ignoring",
+			"request_id", requestID,
+		)
+		return
+	}
+	select {
+	case pending.ch <- struct{}{}:
+	default:
+		// Already signalled; this is a duplicate ack — common when
+		// the applier retries after a transient send failure.
+	}
+}
+
+// applierConnCount is a test/debug accessor — number of conns in
+// the room that could be picked as appliers. Holds r.mu so a
+// concurrent removeConn doesn't produce a torn read.
+func (r *Room) applierConnCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.conns)
+}
+
+// applierMutexLockOrder is a documentation marker — the mutex order
+// for the designated-applier paths is:
+//
+//   r.mu (room state) > r.pendingMu (ack tracking)
+//
+// Acquire in that order; release in reverse. registerPendingAck and
+// routeApplierAck hold ONLY pendingMu (no r.mu reentry), so no
+// inversion is possible there. The closing/conns checks that need
+// r.mu run BEFORE the pendingMu acquisition.
+var _ = sync.Mutex{}

--- a/internal/collab/applier_test.go
+++ b/internal/collab/applier_test.go
@@ -1,0 +1,330 @@
+package collab
+
+import (
+	"encoding/json"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// runApplierEcho spawns a goroutine that reads all incoming TextMessage
+// frames on conn, looks for applier_request, and immediately responds
+// with applier_ack. Returns a stop function that closes the conn.
+func runApplierEcho(t *testing.T, conn *websocket.Conn) func() {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			mt, data, err := conn.ReadMessage()
+			if err != nil {
+				return
+			}
+			if mt != websocket.TextMessage {
+				continue
+			}
+			var ctl ControlMessage
+			if err := json.Unmarshal(data, &ctl); err != nil {
+				continue
+			}
+			if ctl.Type != ControlMessageApplierRequest {
+				continue
+			}
+			ack := ControlMessage{
+				Type:      ControlMessageApplierAck,
+				RequestID: ctl.RequestID,
+			}
+			payload, _ := json.Marshal(ack)
+			if err := conn.WriteMessage(websocket.TextMessage, payload); err != nil {
+				return
+			}
+		}
+	}()
+	return func() {
+		_ = conn.Close()
+		<-done
+	}
+}
+
+// TestApplyExternalContentNoActiveRoom returns ErrNoActiveRoom when
+// the manager doesn't know about the item yet.
+func TestApplyExternalContentNoActiveRoom(t *testing.T) {
+	bus := NewMemoryOpBus()
+	defer bus.Close()
+	mgr := NewRoomManager(&fakeOpLog{}, bus)
+	defer mgr.Close()
+
+	err := mgr.ApplyExternalContent("item-a", "# new content")
+	if !errors.Is(err, ErrNoActiveRoom) {
+		t.Fatalf("want ErrNoActiveRoom, got %v", err)
+	}
+}
+
+// TestApplyExternalContentHappyPath: one connected applier echoes the
+// ack immediately; ApplyExternalContent returns nil within a few ms.
+func TestApplyExternalContentHappyPath(t *testing.T) {
+	bus := NewMemoryOpBus()
+	defer bus.Close()
+	mgr := NewRoomManager(&fakeOpLog{}, bus)
+	defer mgr.Close()
+
+	srv := newCollabTestServer(t, mgr)
+	defer srv.Close()
+
+	conn := dialWS(t, srv, "item-a")
+	stop := runApplierEcho(t, conn)
+	defer stop()
+
+	// Wait for the room to register the conn.
+	for i := 0; i < 200; i++ {
+		if mgr.RoomCount() == 1 && bus.SubscriberCount("item-a") == 1 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- mgr.ApplyExternalContent("item-a", "# new content")
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("happy path: want nil, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("ApplyExternalContent did not return within 2s on happy path")
+	}
+}
+
+// TestApplyExternalContentTimeoutsThenFails simulates a connected
+// applier that NEVER acks. The first attempt should run until
+// applierFirstTimeout fires, the retry until applierRetryTimeout
+// (with the same conn re-tried only if no other appliers exist;
+// here there's just one, so the second attempt picks no candidate
+// and we get ErrAllAppliersTimedOut).
+func TestApplyExternalContentTimeoutsThenFails(t *testing.T) {
+	// Shrink timeouts so the test runs in seconds, not minutes.
+	origFirst, origRetry := applierFirstTimeoutVar, applierRetryTimeoutVar
+	applierFirstTimeoutTest := 80 * time.Millisecond
+	applierRetryTimeoutTest := 40 * time.Millisecond
+	swapApplierTimeouts(applierFirstTimeoutTest, applierRetryTimeoutTest)
+	defer swapApplierTimeouts(origFirst, origRetry)
+
+	bus := NewMemoryOpBus()
+	defer bus.Close()
+	mgr := NewRoomManager(&fakeOpLog{}, bus)
+	defer mgr.Close()
+
+	srv := newCollabTestServer(t, mgr)
+	defer srv.Close()
+
+	conn := dialWS(t, srv, "item-a")
+	defer conn.Close()
+	// NO applier echo — frames are dropped on the floor by the
+	// drainer, so applier_request never produces an ack.
+	go func() {
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}()
+
+	for i := 0; i < 200; i++ {
+		if bus.SubscriberCount("item-a") == 1 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	start := time.Now()
+	err := mgr.ApplyExternalContent("item-a", "# new content")
+	elapsed := time.Since(start)
+
+	if !errors.Is(err, ErrAllAppliersTimedOut) {
+		t.Fatalf("want ErrAllAppliersTimedOut, got %v", err)
+	}
+	// First attempt's timeout fires (~80ms). The retry loop then
+	// looks for another applier, finds none (only one conn was
+	// dialed), and returns immediately. Floor at firstTimeout,
+	// ceiling well below firstTimeout + retryTimeout.
+	if elapsed < applierFirstTimeoutTest {
+		t.Errorf("returned too fast: %v < %v", elapsed, applierFirstTimeoutTest)
+	}
+}
+
+// TestApplyExternalContentTimeoutThenSecondAcks: first applier never
+// responds, second one does — the retry should hit the second
+// applier and succeed.
+func TestApplyExternalContentTimeoutThenSecondAcks(t *testing.T) {
+	origFirst, origRetry := applierFirstTimeoutVar, applierRetryTimeoutVar
+	swapApplierTimeouts(80*time.Millisecond, 1*time.Second)
+	defer swapApplierTimeouts(origFirst, origRetry)
+
+	bus := NewMemoryOpBus()
+	defer bus.Close()
+	mgr := NewRoomManager(&fakeOpLog{}, bus)
+	defer mgr.Close()
+
+	srv := newCollabTestServer(t, mgr)
+	defer srv.Close()
+
+	// First conn: no echo, just drains.
+	first := dialWS(t, srv, "item-a")
+	defer first.Close()
+	go func() {
+		for {
+			if _, _, err := first.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}()
+
+	// Wait so the second conn has a strictly later connectedAt.
+	time.Sleep(15 * time.Millisecond)
+
+	// Second conn: echoes acks. Because pickApplier sorts by
+	// connectedAt asc, `first` is chosen for attempt 1; `second`
+	// for the retry.
+	second := dialWS(t, srv, "item-a")
+	stop := runApplierEcho(t, second)
+	defer stop()
+
+	for i := 0; i < 200; i++ {
+		if bus.SubscriberCount("item-a") == 2 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- mgr.ApplyExternalContent("item-a", "# new content")
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("retry path: want nil, got %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("retry path did not complete within 3s")
+	}
+}
+
+// TestApplyExternalContentRejectsAckFromUnexpectedConn confirms the
+// expectedConn check in routeApplierAck. We wire two conns; the FIRST
+// is the chosen applier; the SECOND tries to forge an ack for the
+// first's request. The forgery should be ignored, and the request
+// should still time out.
+func TestApplyExternalContentRejectsAckFromUnexpectedConn(t *testing.T) {
+	origFirst, origRetry := applierFirstTimeoutVar, applierRetryTimeoutVar
+	swapApplierTimeouts(120*time.Millisecond, 60*time.Millisecond)
+	defer swapApplierTimeouts(origFirst, origRetry)
+
+	bus := NewMemoryOpBus()
+	defer bus.Close()
+	mgr := NewRoomManager(&fakeOpLog{}, bus)
+	defer mgr.Close()
+
+	srv := newCollabTestServer(t, mgr)
+	defer srv.Close()
+
+	// First conn — chosen applier (longest-connected) but does NOT
+	// auto-ack. We capture the inbound request_id and forge the ack
+	// from the OTHER conn.
+	first := dialWS(t, srv, "item-a")
+	defer first.Close()
+	requestIDCh := make(chan string, 1)
+	go func() {
+		for {
+			mt, data, err := first.ReadMessage()
+			if err != nil {
+				return
+			}
+			if mt != websocket.TextMessage {
+				continue
+			}
+			var ctl ControlMessage
+			if err := json.Unmarshal(data, &ctl); err != nil {
+				continue
+			}
+			if ctl.Type == ControlMessageApplierRequest {
+				select {
+				case requestIDCh <- ctl.RequestID:
+				default:
+				}
+			}
+		}
+	}()
+
+	time.Sleep(15 * time.Millisecond)
+	second := dialWS(t, srv, "item-a")
+	defer second.Close()
+	go func() {
+		for {
+			if _, _, err := second.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}()
+
+	for i := 0; i < 200; i++ {
+		if bus.SubscriberCount("item-a") == 2 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- mgr.ApplyExternalContent("item-a", "# new content")
+	}()
+
+	// Wait for the request_id to surface, then forge the ack from
+	// the SECOND conn — this should be ignored by the room.
+	var reqID string
+	select {
+	case reqID = <-requestIDCh:
+	case <-time.After(1 * time.Second):
+		t.Fatal("did not capture applier_request on first conn")
+	}
+
+	forge := ControlMessage{Type: ControlMessageApplierAck, RequestID: reqID}
+	payload, _ := json.Marshal(forge)
+	if err := second.WriteMessage(websocket.TextMessage, payload); err != nil {
+		t.Fatalf("forge write: %v", err)
+	}
+
+	// The forged ack must NOT unblock ApplyExternalContent. It
+	// should run to its timeout (and on the retry, since `second`
+	// also doesn't honestly ack, the second attempt will also
+	// time out).
+	select {
+	case err := <-done:
+		if !errors.Is(err, ErrAllAppliersTimedOut) {
+			t.Fatalf("forged ack must not satisfy ApplyExternalContent; got err=%v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("Apply did not return; forged ack should have been rejected and timeouts honoured")
+	}
+}
+
+// swapApplierTimeouts is a small test-only mutator. The package
+// constants are *not* exported as vars so the swap goes through a
+// dedicated helper that lives only in test builds. We accept a
+// brief mutex / shared-state hand-wave here because the tests run
+// serially within the package by default.
+var applierTimeoutMu sync.Mutex
+
+func swapApplierTimeouts(first, retry time.Duration) {
+	applierTimeoutMu.Lock()
+	defer applierTimeoutMu.Unlock()
+	applierFirstTimeoutVar = first
+	applierRetryTimeoutVar = retry
+}

--- a/internal/collab/applier_test.go
+++ b/internal/collab/applier_test.go
@@ -217,6 +217,122 @@ func TestApplyExternalContentTimeoutThenSecondAcks(t *testing.T) {
 	}
 }
 
+// TestApplyExternalContentCleansPendingAcksOnSuccess ensures the
+// per-room pendingAcks map doesn't leak entries across successful
+// applies — without the cancel-on-success cleanup, every external
+// update would retain a request_id + channel + conn pointer for the
+// rest of the room's lifetime.
+func TestApplyExternalContentCleansPendingAcksOnSuccess(t *testing.T) {
+	bus := NewMemoryOpBus()
+	defer bus.Close()
+	mgr := NewRoomManager(&fakeOpLog{}, bus)
+	defer mgr.Close()
+
+	srv := newCollabTestServer(t, mgr)
+	defer srv.Close()
+
+	conn := dialWS(t, srv, "item-a")
+	stop := runApplierEcho(t, conn)
+	defer stop()
+
+	for i := 0; i < 200; i++ {
+		if bus.SubscriberCount("item-a") == 1 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	for i := 0; i < 5; i++ {
+		if err := mgr.ApplyExternalContent("item-a", "# rev"); err != nil {
+			t.Fatalf("apply %d: %v", i, err)
+		}
+	}
+
+	// Drill into the room to count pending entries — this is a
+	// white-box assertion against the cleanup contract.
+	mgr.mu.Lock()
+	room := mgr.rooms["item-a"]
+	mgr.mu.Unlock()
+	if room == nil {
+		t.Fatal("room missing after applies")
+	}
+	room.pendingMu.Lock()
+	left := len(room.pendingAcks)
+	room.pendingMu.Unlock()
+	if left != 0 {
+		t.Fatalf("pendingAcks leaked across applies: %d entries left", left)
+	}
+}
+
+// TestApplyExternalContentSendsExpiresAt confirms the server stamps
+// the applier_request with an expires_at_millis. Defends against
+// a regression where the field is silently dropped — the browser
+// (TASK-1263) needs it to refuse late-arriving requests.
+func TestApplyExternalContentSendsExpiresAt(t *testing.T) {
+	bus := NewMemoryOpBus()
+	defer bus.Close()
+	mgr := NewRoomManager(&fakeOpLog{}, bus)
+	defer mgr.Close()
+
+	srv := newCollabTestServer(t, mgr)
+	defer srv.Close()
+
+	conn := dialWS(t, srv, "item-a")
+	defer conn.Close()
+
+	captured := make(chan ControlMessage, 1)
+	go func() {
+		for {
+			mt, data, err := conn.ReadMessage()
+			if err != nil {
+				return
+			}
+			if mt != websocket.TextMessage {
+				continue
+			}
+			var ctl ControlMessage
+			if err := json.Unmarshal(data, &ctl); err != nil {
+				continue
+			}
+			if ctl.Type == ControlMessageApplierRequest {
+				select {
+				case captured <- ctl:
+				default:
+				}
+				// Honest ack so ApplyExternalContent returns.
+				ack := ControlMessage{Type: ControlMessageApplierAck, RequestID: ctl.RequestID}
+				payload, _ := json.Marshal(ack)
+				_ = conn.WriteMessage(websocket.TextMessage, payload)
+			}
+		}
+	}()
+
+	for i := 0; i < 200; i++ {
+		if bus.SubscriberCount("item-a") == 1 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	if err := mgr.ApplyExternalContent("item-a", "# new"); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	select {
+	case msg := <-captured:
+		if msg.ExpiresAtMillis == 0 {
+			t.Errorf("expires_at_millis must be set on applier_request")
+		}
+		// Sanity: must be in the future.
+		if msg.ExpiresAtMillis < time.Now().UnixMilli() {
+			t.Errorf("expires_at_millis must be in the future, got %d (now=%d)",
+				msg.ExpiresAtMillis, time.Now().UnixMilli())
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("did not capture applier_request")
+	}
+}
+
 // TestApplyExternalContentRejectsAckFromUnexpectedConn confirms the
 // expectedConn check in routeApplierAck. We wire two conns; the FIRST
 // is the chosen applier; the SECOND tries to forge an ack for the

--- a/internal/collab/manager.go
+++ b/internal/collab/manager.go
@@ -130,9 +130,10 @@ func (m *RoomManager) Join(itemID string, conn *websocket.Conn) error {
 		}
 
 		rc := &roomConn{
-			id:   nextConnID(),
-			conn: conn,
-			bus:  m.bus.Subscribe(itemID),
+			id:          nextConnID(),
+			conn:        conn,
+			bus:         m.bus.Subscribe(itemID),
+			connectedAt: time.Now(),
 		}
 
 		if err := room.addConn(rc); err != nil {
@@ -225,6 +226,7 @@ func (m *RoomManager) getOrCreate(itemID string) *Room {
 		schemaVersion: m.schemaVersion,
 		graceTTL:      m.graceTTL,
 		conns:         make(map[*websocket.Conn]*roomConn),
+		pendingAcks:   make(map[string]*pendingApplierAck),
 		onIdle:        m.markRoomGone,
 	}
 	m.rooms[itemID] = r

--- a/internal/collab/room.go
+++ b/internal/collab/room.go
@@ -1,6 +1,7 @@
 package collab
 
 import (
+	"encoding/json"
 	"errors"
 	"log/slog"
 	"sync"
@@ -48,13 +49,16 @@ var errRoomClosing = errors.New("collab: room is closing")
 // roomConn pairs a single WebSocket connection with the bookkeeping
 // the Room needs around it: a unique server-assigned id (so a peer's
 // own ops aren't echoed back to itself), the OpBus subscription
-// channel that feeds outbound writes, and a write mutex (gorilla's
-// rule — at most one writer goroutine at a time per conn).
+// channel that feeds outbound writes, a write mutex (gorilla's
+// rule — at most one writer goroutine at a time per conn), and the
+// connect timestamp used by the designated-applier election to pick
+// the longest-connected peer.
 type roomConn struct {
-	id      uint64
-	conn    *websocket.Conn
-	bus     chan OpEvent
-	writeMu sync.Mutex
+	id          uint64
+	conn        *websocket.Conn
+	bus         chan OpEvent
+	writeMu     sync.Mutex
+	connectedAt time.Time
 }
 
 // writeMessage is a tiny helper that holds writeMu while writing one
@@ -91,6 +95,17 @@ type Room struct {
 	// AppendYjsUpdate + bus.Publish sequence, so it does NOT
 	// serialise reads, awareness frames, or other rooms.
 	appendMu sync.Mutex
+
+	// pendingMu + pendingAcks track in-flight designated-applier
+	// requests (TASK-1257). Each entry is a request_id → expected
+	// applier conn + ack channel. Server-side PATCH handlers create
+	// an entry, send the applier_request control message to the
+	// chosen conn, and Wait on the channel; the readLoop on that
+	// conn receives an applier_ack JSON frame and signals the
+	// channel. The expectedConn check prevents an unrelated peer
+	// from spoofing acks for someone else's request.
+	pendingMu   sync.Mutex
+	pendingAcks map[string]*pendingApplierAck
 }
 
 // opLogStore is the store surface a Room needs. Pulling it into a
@@ -190,8 +205,18 @@ func (r *Room) readLoop(rc *roomConn) error {
 		if err != nil {
 			return err
 		}
-		// Yjs sends only binary frames. Skip text/control frames defensively
-		// so a bad client cannot break the loop with a malformed packet.
+
+		// TextMessage frames carry JSON control messages (currently
+		// just designated-applier acks; future entries can extend
+		// the same envelope without disturbing the y-protocol path).
+		if msgType == websocket.TextMessage {
+			r.handleControlMessage(rc, data)
+			continue
+		}
+
+		// Yjs sends only binary frames. Skip anything else (control
+		// frames are already handled above) defensively so a bad
+		// client can't break the loop with a malformed packet.
 		if msgType != websocket.BinaryMessage || len(data) == 0 {
 			continue
 		}
@@ -264,6 +289,29 @@ func (r *Room) writeLoop(rc *roomConn) {
 			_ = rc.conn.Close()
 			return
 		}
+	}
+}
+
+// handleControlMessage dispatches a TextMessage frame received from
+// a peer. Today the only valid type is applier_ack (TASK-1257); any
+// other type is dropped silently so a future client extension can
+// add new control types without older servers blowing up.
+func (r *Room) handleControlMessage(rc *roomConn, data []byte) {
+	var ctl ControlMessage
+	if err := json.Unmarshal(data, &ctl); err != nil {
+		// Malformed JSON — drop. We don't log at warn here because
+		// a bad client could otherwise spam logs by sending
+		// arbitrary text frames.
+		return
+	}
+	switch ctl.Type {
+	case ControlMessageApplierAck:
+		if ctl.RequestID == "" {
+			return
+		}
+		r.routeApplierAck(ctl.RequestID, rc.conn)
+	default:
+		// Unknown control type — drop.
 	}
 }
 

--- a/internal/server/handlers_collab.go
+++ b/internal/server/handlers_collab.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/PerpetualSoftware/pad/internal/collab"
 	"github.com/PerpetualSoftware/pad/internal/models"
 	"github.com/go-chi/chi/v5"
 	"github.com/gorilla/websocket"
@@ -296,6 +297,67 @@ func (s *Server) collabRevalidationLoop(
 func isAccessDenial(err error) bool {
 	var sErr *statusError
 	return errors.As(err, &sErr)
+}
+
+// applyContentViaCollab routes an external content update through a
+// connected browser tab via the collab room manager's
+// designated-applier protocol. Returns nil when an applier acked
+// successfully (caller should suppress the direct items.content
+// write); any error means "fall back to direct write".
+//
+// Errors are categorised + logged at the right level so operators
+// can see when degraded paths fire. Returning the error rather than
+// silently swallowing lets callers add their own telemetry / metrics
+// later without re-deriving the categorisation.
+func (s *Server) applyContentViaCollab(r *http.Request, itemID, markdown string) error {
+	if s.collab == nil {
+		return errors.New("collab not configured")
+	}
+	err := s.collab.ApplyExternalContent(itemID, markdown)
+	switch {
+	case err == nil:
+		// Caller suppresses the direct write.
+		return nil
+
+	case errors.Is(err, collab.ErrNoActiveRoom):
+		// No live editors — direct write is the right thing.
+		// Common case for CLI updates outside a co-edit session;
+		// no log to keep noise down.
+		return err
+
+	case errors.Is(err, collab.ErrNoApplierAvailable):
+		// Room exists (mid-grace-TTL) but has no live conn to
+		// apply through. Direct write is correct.
+		return err
+
+	case errors.Is(err, collab.ErrAllAppliersTimedOut):
+		slog.Warn("collab: all designated appliers timed out; falling back to direct items.content write",
+			"item_id", itemID,
+			"actor", actorIDFromRequest(r),
+		)
+		return err
+
+	default:
+		slog.Warn("collab: applier path failed; falling back to direct items.content write",
+			"item_id", itemID,
+			"error", err,
+		)
+		return err
+	}
+}
+
+// actorIDFromRequest returns a non-empty identity string for the
+// caller when one is available — user id, token id, or empty. Used
+// in slog calls where we want SOMETHING actor-shaped without
+// caring about the precise auth path.
+func actorIDFromRequest(r *http.Request) string {
+	if u := currentUser(r); u != nil {
+		return u.ID
+	}
+	if tw := tokenWorkspaceID(r); tw != "" {
+		return "token-ws:" + tw
+	}
+	return ""
 }
 
 // statusError lets authorizeCollabAccess return a typed error that

--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -470,6 +470,33 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Designated-applier routing (PLAN-1248 TASK-1257). When the
+	// PATCH body sets the content field AND an active collab room
+	// exists for this item, route the new markdown through a
+	// connected browser tab instead of writing items.content
+	// directly. The chosen tab does editor.commands.setContent,
+	// which the y-tiptap binding translates into Y.Doc updates that
+	// propagate via the regular sync path; items.content gets
+	// refreshed via the next 5s idle flush (TASK-1261).
+	//
+	// Without this hop, the connected browsers' Y.Doc state would
+	// silently overwrite items.content on the next flush and the
+	// CLI / API caller's update would be lost.
+	//
+	// Field-only PATCHes (input.Content == nil) skip this branch
+	// entirely; they continue straight to UpdateItem unchanged.
+	if input.Content != nil && s.collab != nil {
+		if err := s.applyContentViaCollab(r, item.ID, *input.Content); err == nil {
+			// Applier propagated the change; suppress the direct
+			// items.content write. Other input fields (title,
+			// fields, status) still flow through UpdateItem below.
+			input.Content = nil
+		}
+		// Any error path (no room, no applier, all timed out, etc.)
+		// falls through to direct write — graceful degradation. The
+		// helper logs the specifics so operators see degraded paths.
+	}
+
 	updated, err := s.store.UpdateItem(item.ID, input)
 	if err != nil {
 		writeInternalError(w, err)


### PR DESCRIPTION
## Summary
The keystone task for CLI / API / MCP integration during co-edit sessions. When a content update arrives via PATCH and at least one browser tab is connected to the item's collab room, the server routes the new markdown through that tab via a new JSON control protocol — the browser does `editor.commands.setContent(markdown)`, the y-tiptap binding translates that into Y.Doc updates, and CRDT propagation handles the rest.

Without this hop, connected browsers' Y.Doc state would silently overwrite `items.content` on the next 5s idle flush and the CLI / API / MCP caller's update would be lost.

## Context
Phase 1, sixth task under PLAN-1248. Closes the Plan body's "single most important architectural piece" for cross-surface integration. PR #455 is the last Phase 1 task before backend bundle hardening (TASK-1258) and the start of Phase 2 (frontend wiring).

## Behaviour
- **No room (no live editors):** `ApplyExternalContent` returns `ErrNoActiveRoom` → handler falls back to direct write, status quo.
- **One connected tab, fast ack:** chosen by longest-connected-wins; control message → setContent → ack within ms; PATCH returns 200.
- **First tab silent, second tab acks:** retry path (`applierMaxAttempts = 2`) picks the second-longest-connected; succeeds.
- **All tabs timeout:** logged at warn; falls back to direct write so the caller doesn't lose their update.
- **Forged ack from unrelated peer:** rejected by the room's `expectedConn` check.

## Test plan
- [x] `go build ./... && go vet ./...` — clean
- [x] `go test ./internal/collab/ -race -count=1` — all 19 tests pass (5 new applier + 14 existing)
- [x] `go test ./...` — full suite green
- [x] Manual integration: pending Phase 2's client-side handler (TASK-1263). Server-side ack flow is verified by the unit tests.

## Out of scope
- Client-side ack handler (TASK-1263)
- Schema-version handling on applier path (TASK-1268, Phase 4)