### PR TITLE
feat(collab): 5s-idle + on-disconnect markdown flush (TASK-1260)

### DIFF
--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -493,7 +493,18 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 	// post-write snapshot for the response. Per Codex review round 9.
 	var fullWriteHandled bool
 	var fullWriteUpdated *models.Item
-	if input.Content != nil && s.collab != nil {
+	// `?source=collab-snapshot` opts out of the applier-routing path so
+	// a connected collab tab can flush its Y.Doc-derived markdown to
+	// items.content WITHOUT looping back through ApplyExternalContent
+	// (which would ask this same tab to apply, ack, and then strip
+	// input.Content — leaving items.content unchanged). The flag is
+	// trustworthy because the caller already has edit access (else the
+	// PATCH would 401/403); the bypass just skips a defensive
+	// re-routing that's only useful for EXTERNAL content updates.
+	// Per TASK-1260 / PLAN-1248.
+	collabSnapshot := r.URL.Query().Get("source") == "collab-snapshot"
+
+	if input.Content != nil && s.collab != nil && !collabSnapshot {
 		// applyContentViaCollab calls directWrite ONLY on the no-
 		// room/no-applier paths (where pruning the op-log is safe
 		// and we need to land items.content under the per-item

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -337,6 +337,33 @@ export const api = {
 				body: JSON.stringify(data)
 			}),
 
+		/**
+		 * flushCollabContent PATCHes items.content with the
+		 * `?source=collab-snapshot` query param so the server
+		 * skips the applier-routing path. Used by the editor's
+		 * 5s-idle + on-disconnect flush (TASK-1260) — the
+		 * connected tab IS the canonical source of truth for
+		 * Y.Doc state, and routing through the applier would
+		 * loop the request back to itself.
+		 *
+		 * `keepalive` is passed straight to fetch so the
+		 * unmount / beforeunload flush path can outlive the
+		 * page lifecycle (browser holds the request open until
+		 * it completes or hits the ~64KB body cap; markdown
+		 * bodies are well under that for typical items).
+		 */
+		flushCollabContent: (
+			ws: string,
+			slug: string,
+			content: string,
+			opts?: { keepalive?: boolean },
+		) =>
+			request<Item>(`/workspaces/${ws}/items/${slug}?source=collab-snapshot`, {
+				method: 'PATCH',
+				body: JSON.stringify({ content }),
+				keepalive: opts?.keepalive,
+			}),
+
 		delete: (ws: string, slug: string) =>
 			request<void>(`/workspaces/${ws}/items/${slug}`, {
 				method: 'DELETE'

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -1579,44 +1579,53 @@
 						class="mode-btn"
 						class:active={rawMode}
 						onclick={async () => {
-							// When toggling FROM rich+collab TO raw,
-							// the editor's live markdown is the
-							// canonical state. Synchronously flush
-							// it to items.content via the collab-
-							// snapshot bypass BEFORE activating raw
-							// mode. Without this, a user who toggles
-							// to raw and immediately navigates away
-							// (without typing) would never persist
-							// the live Y.Doc snapshot — items.content
-							// would stay frozen at the prior 5s
-							// tick. The await ensures the PATCH is
-							// in flight (and lastFlushedContent is
-							// seeded) before any subsequent raw
-							// debounce can race it. Per Codex review
-							// round 4.
-							//
-							// rawSeedMarkdown is also set so
-							// RawMarkdownEditor mounts with the live
-							// markdown rather than stale
-							// items.content (in case the user types
-							// before the flush response lands).
+							// Toggle rich+collab → raw. We need to
+							// land the live Y.Doc state in
+							// items.content BEFORE activating raw
+							// mode so the raw editor (and any
+							// subsequent navigation) sees the
+							// current markdown. The provider stays
+							// connected during the await, which means
+							// a concurrent peer (e.g. same user's
+							// other tab) can keep editing the Y.Doc
+							// while we flush — those edits would be
+							// lost from the seed if we captured md
+							// once. Loop-flush until stable: re-read
+							// the editor's current markdown after
+							// each PATCH; if it changed, flush again.
+							// Capped at 3 iterations to bound the
+							// transition under aggressive concurrent
+							// typing. Per Codex review round 5.
 							if (collabProvider && editorInstance && item) {
+								const ws = wsSlug;
+								const itemId = item.id;
+								const ed = editorInstance;
 								try {
-									const md = (editorInstance.storage as any).markdown?.getMarkdown?.();
-									if (typeof md === 'string') {
-										rawSeedMarkdown = md;
-										const ws = wsSlug;
-										const itemId = item.id;
+									let md = (ed.storage as any).markdown?.getMarkdown?.();
+									for (let i = 0; i < 3; i++) {
+										if (typeof md !== 'string') break;
 										// keepalive=true so the
 										// PATCH outlives a fast
 										// post-toggle navigation.
 										await runCollabFlush(ws, itemId, md, true);
+										const mdAfter = (ed.storage as any).markdown?.getMarkdown?.();
+										if (mdAfter === md) break;
+										md = mdAfter;
 									}
+									if (typeof md === 'string') rawSeedMarkdown = md;
 								} catch {
 									// Fall through; RawMarkdownEditor
 									// will seed from item.content.
 								}
 							}
+							// Cancel any pending timer-driven flush
+							// scheduled by edits during the await
+							// window — left armed, it would fire
+							// post-rawMode and PATCH a stale rich
+							// markdown over a subsequent raw save.
+							// Per Codex review round 5.
+							clearTimeout(collabFlushTimer);
+							collabFlushTimer = undefined;
 							rawMode = true;
 						}}
 						title="Raw markdown editor"

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -16,7 +16,7 @@
 	import ItemTimeline from '$lib/components/timeline/ItemTimeline.svelte';
 	import ChildItems from '$lib/components/ChildItems.svelte';
 	import { goto } from '$app/navigation';
-	import { relativeTime, wikiLinksToMarkdown, markdownToWikiLinks, cleanBrokenLinks } from '$lib/utils/markdown';
+	import { relativeTime, wikiLinksToMarkdown, markdownToWikiLinks, cleanBrokenLinks, unescapeDocLinks } from '$lib/utils/markdown';
 	import { toastStore } from '$lib/stores/toast.svelte';
 	import { editorStore } from '$lib/stores/editor.svelte';
 	import type { Item, Collection, CollectionSettings, QuickAction, ItemLink, AgentRole } from '$lib/types';
@@ -464,6 +464,11 @@
 	$effect(() => {
 		if (!collabKey) return;
 		const itemId = collabKey;
+		// Snapshot the workspace alongside the itemId. activeCollabContext
+		// is what the timer-driven + cleanup-driven flushes target so
+		// they always PATCH the right URL even after navigation.
+		const ctx = { wsSlug, itemId };
+		activeCollabContext = ctx;
 
 		const doc = new Y.Doc();
 		const provider = new CollabProvider(itemId, doc, {
@@ -509,12 +514,16 @@
 			// downstream consumers (search, share-page, exports,
 			// API readers) read items.content; without this flush a
 			// user closing the tab right after typing would leave
-			// items.content frozen at the prior 5s tick. keepalive=
-			// true lets the request outlive the page lifecycle.
-			// Per TASK-1260.
-			flushCollabNow(true);
+			// items.content frozen at the prior 5s tick. We pass
+			// the captured ctx (NOT live reactive state) so a
+			// navigation that already updated `item` and `wsSlug`
+			// doesn't mis-route this flush to a different item.
+			// keepalive=true lets the request outlive the page
+			// lifecycle. Per TASK-1260.
+			flushCollabNow(ctx, true);
 			provider.destroy();
 			doc.destroy();
+			if (activeCollabContext === ctx) activeCollabContext = null;
 			// Defensive — only clear the slot if it still holds the
 			// pair we created. A reactive churn that swapped a new
 			// pair in before this cleanup ran shouldn't get clobbered.
@@ -532,7 +541,8 @@
 	$effect(() => {
 		if (typeof window === 'undefined') return;
 		const onBeforeUnload = () => {
-			if (collabProvider) flushCollabNow(true);
+			const ctx = activeCollabContext;
+			if (ctx) flushCollabNow(ctx, true);
 		};
 		window.addEventListener('beforeunload', onBeforeUnload);
 		return () => window.removeEventListener('beforeunload', onBeforeUnload);
@@ -702,51 +712,68 @@
 		}, 1200);
 	}
 
+	// activeCollabContext holds the (workspace, item) the currently-
+	// connected provider was minted against. Capturing this at
+	// $effect-body time (NOT at flush time) makes the flush path
+	// resistant to navigation: if the user moves to a new item
+	// between schedule and fire, the timer-driven and cleanup-driven
+	// flushes still PATCH the OLD item's URL with its OLD markdown,
+	// so we never cross-write one item's content into another. Per
+	// Codex review round 1.
+	let activeCollabContext: { wsSlug: string; itemId: string } | null = null;
+
 	function scheduleCollabFlush(markdown: string) {
 		clearTimeout(collabFlushTimer);
+		const ctx = activeCollabContext;
+		if (!ctx) return;
 		collabFlushTimer = setTimeout(() => {
 			collabFlushTimer = undefined;
-			void runCollabFlush(markdown, false);
+			void runCollabFlush(ctx.wsSlug, ctx.itemId, markdown, false);
 		}, COLLAB_FLUSH_IDLE_MS);
 	}
 
 	// runCollabFlush PATCHes items.content via the
-	// `?source=collab-snapshot` bypass. Returns true if a request
-	// actually fired (markdown differed from lastFlushedContent),
-	// false if the dedupe skipped it. Set `keepalive` for the
-	// unmount / beforeunload path so the request can outlive the
-	// page lifecycle.
-	async function runCollabFlush(markdown: string, keepalive: boolean): Promise<boolean> {
-		if (!item) return false;
+	// `?source=collab-snapshot` bypass. Takes ws/item from the
+	// captured context (NOT live reactive state) so a navigation in
+	// flight doesn't mis-route the PATCH to a different item. Returns
+	// true if a request fired, false if dedupe skipped it.
+	async function runCollabFlush(
+		ws: string,
+		itemId: string,
+		markdown: string,
+		keepalive: boolean,
+	): Promise<boolean> {
 		const allItems = collectionStore.items ?? [];
-		let toSave = markdown;
+		let toSave = unescapeDocLinks(markdown);
 		if (allItems.length > 0) {
 			toSave = markdownToWikiLinks(toSave, allItems);
 		}
 		toSave = cleanBrokenLinks(toSave);
-		// Dedupe: skip the PATCH if our last successful flush already
-		// landed this exact content. Multiple connected tabs would
-		// otherwise each fire a redundant PATCH after every shared
-		// edit converges.
+		// Dedupe: skip the PATCH if our last successful flush
+		// already landed this exact content. Multiple connected
+		// tabs would otherwise each fire a redundant PATCH after
+		// every shared edit converges.
 		if (lastFlushedContent === toSave) return false;
-		const reqItemId = item.id;
 		try {
 			saveStatus = 'saving';
 			editorStore.setLastSaveTime(Date.now());
-			await api.items.flushCollabContent(wsSlug, reqItemId, toSave, { keepalive });
+			await api.items.flushCollabContent(ws, itemId, toSave, { keepalive });
 			lastFlushedContent = toSave;
-			if (item && item.id === reqItemId) {
+			// UI-state updates only matter when the user is still
+			// looking at this item. After navigation, item.id has
+			// already moved on and the new item owns saveStatus.
+			if (item && item.id === itemId) {
 				editorStore.setLastSaveTime(Date.now());
 				editorStore.setDirty(false);
 				showSaved();
 			}
 			return true;
 		} catch {
-			if (item && item.id === reqItemId) {
+			if (item && item.id === itemId) {
 				saveStatus = 'idle';
 				// Quiet on the unmount path (no UI to show toast in)
-				// but log so dropped flushes are diagnosable from
-				// devtools when investigating "items.content stale".
+				// but visible during foreground edits so a stuck
+				// save is diagnosable.
 				if (!keepalive) toastStore.show('Failed to save content', 'error');
 			}
 			return false;
@@ -754,9 +781,13 @@
 	}
 
 	// flushCollabNow fires the pending flush IMMEDIATELY (cancelling
-	// the 5s timer). Used by $effect cleanup + beforeunload to land
-	// any in-flight markdown before the provider tears down.
-	function flushCollabNow(keepalive: boolean): boolean {
+	// the 5s timer). Takes the explicit ctx the cleanup captured —
+	// reading editorInstance.storage at this instant is correct
+	// because Svelte runs parent $effect cleanups BEFORE child
+	// {#key}-driven unmounts, so the OLD editor (whose markdown we
+	// want) is still mounted. Used by $effect cleanup + beforeunload
+	// to land any in-flight markdown before the provider tears down.
+	function flushCollabNow(ctx: { wsSlug: string; itemId: string }, keepalive: boolean): boolean {
 		clearTimeout(collabFlushTimer);
 		collabFlushTimer = undefined;
 		if (!editorInstance) return false;
@@ -767,9 +798,9 @@
 			return false;
 		}
 		// runCollabFlush is async but its return value is irrelevant
-		// for the synchronous callers — fire-and-forget under
+		// for synchronous callers — fire-and-forget under
 		// keepalive=true is the contract on the unmount path.
-		void runCollabFlush(md, keepalive);
+		void runCollabFlush(ctx.wsSlug, ctx.itemId, md, keepalive);
 		return true;
 	}
 

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -327,8 +327,16 @@
 		// debounce too. Per Codex review round 10.
 		clearTimeout(contentDebounceTimer);
 		contentDebounceTimer = undefined;
+		clearTimeout(collabFlushTimer);
+		collabFlushTimer = undefined;
 		rawSeedMarkdown = null;
 		rawPendingMarkdown = null;
+		// lastFlushedContent is per-item; resetting prevents the
+		// dedupe from incorrectly suppressing the first flush on
+		// the next item (which happens to share the same markdown
+		// as the last flush of the previous item — vanishingly
+		// unlikely but trivial to defend).
+		lastFlushedContent = null;
 		// Reset transient save UI state too. Without this, a stale
 		// raw PATCH that gets discarded by the new race guard
 		// (item.id mismatch) leaves saveStatus pinned at 'saving' on
@@ -496,6 +504,15 @@
 		collabProvider = provider;
 
 		return () => {
+			// Best-effort flush of items.content BEFORE we tear the
+			// provider down. The Y.Doc + op-log are canonical, but
+			// downstream consumers (search, share-page, exports,
+			// API readers) read items.content; without this flush a
+			// user closing the tab right after typing would leave
+			// items.content frozen at the prior 5s tick. keepalive=
+			// true lets the request outlive the page lifecycle.
+			// Per TASK-1260.
+			flushCollabNow(true);
 			provider.destroy();
 			doc.destroy();
 			// Defensive — only clear the slot if it still holds the
@@ -504,6 +521,21 @@
 			if (ydoc === doc) ydoc = null;
 			if (collabProvider === provider) collabProvider = null;
 		};
+	});
+
+	// beforeunload: same flush as $effect cleanup, but routed
+	// through the page lifecycle so navigation off-site (close tab,
+	// reload, follow external link) lands the markdown snapshot
+	// before the WS dies. fetch keepalive: true is the modern
+	// equivalent of sendBeacon for non-POST requests; supports up to
+	// ~64KB body which dwarfs typical markdown items.
+	$effect(() => {
+		if (typeof window === 'undefined') return;
+		const onBeforeUnload = () => {
+			if (collabProvider) flushCollabNow(true);
+		};
+		window.addEventListener('beforeunload', onBeforeUnload);
+		return () => window.removeEventListener('beforeunload', onBeforeUnload);
 	});
 
 	// Handle the ?new=1 auto-edit-title flow reactively. canEdit may flip
@@ -616,20 +648,31 @@
 		}
 	}
 
+	// Tracks the last markdown we successfully PATCHed to items.content
+	// in collab-flush mode. Lets the idle-fire dedupe redundant flushes
+	// across multiple connected tabs that all converge on the same
+	// Y.Doc state — without this, every tab fires its own 5s flush
+	// after every shared edit, multiplying server PATCH load by the
+	// peer count.
+	let lastFlushedContent: string | null = null;
+
+	// 5s-idle timer for the collab flush path. Distinct from
+	// contentDebounceTimer (which the legacy non-collab and raw-mode
+	// paths still use) so the two firings don't trample each other on
+	// rapid mode toggles.
+	let collabFlushTimer: ReturnType<typeof setTimeout> | undefined;
+	const COLLAB_FLUSH_IDLE_MS = 5_000;
+
 	function handleContentUpdate(markdown: string) {
-		// Suppress the legacy 1.2s autosave when the collab provider
-		// owns this editor's content. Routing the PATCH through the
-		// server while a provider is connected would loop the
-		// applier protocol back to this same tab (a no-op
-		// round-trip), then set input.Content = nil server-side so
-		// items.content never gets the snapshot — leaving canonical
-		// markdown stale for search / share-page / API consumers.
-		// TASK-1260 introduces the proper 5s idle flush that bypasses
-		// applier with a `?source=collab-flush` semantic; this guard
-		// is the temporary stop-gap for the inter-PR window. Per
-		// Codex review round 4.
+		// Collab-active path: 5s idle flush of items.content via the
+		// `?source=collab-snapshot` bypass (server skips the applier
+		// loop, writes items.content directly). Y.Doc op-log is
+		// canonical for live state; items.content stays "reasonably
+		// fresh" for search / share-page / API consumers. Per
+		// TASK-1260 / PLAN-1248.
 		if (collabProvider) {
 			editorStore.setDirty(true);
+			scheduleCollabFlush(markdown);
 			return;
 		}
 		clearTimeout(contentDebounceTimer);
@@ -657,6 +700,77 @@
 				toastStore.show('Failed to save content', 'error');
 			});
 		}, 1200);
+	}
+
+	function scheduleCollabFlush(markdown: string) {
+		clearTimeout(collabFlushTimer);
+		collabFlushTimer = setTimeout(() => {
+			collabFlushTimer = undefined;
+			void runCollabFlush(markdown, false);
+		}, COLLAB_FLUSH_IDLE_MS);
+	}
+
+	// runCollabFlush PATCHes items.content via the
+	// `?source=collab-snapshot` bypass. Returns true if a request
+	// actually fired (markdown differed from lastFlushedContent),
+	// false if the dedupe skipped it. Set `keepalive` for the
+	// unmount / beforeunload path so the request can outlive the
+	// page lifecycle.
+	async function runCollabFlush(markdown: string, keepalive: boolean): Promise<boolean> {
+		if (!item) return false;
+		const allItems = collectionStore.items ?? [];
+		let toSave = markdown;
+		if (allItems.length > 0) {
+			toSave = markdownToWikiLinks(toSave, allItems);
+		}
+		toSave = cleanBrokenLinks(toSave);
+		// Dedupe: skip the PATCH if our last successful flush already
+		// landed this exact content. Multiple connected tabs would
+		// otherwise each fire a redundant PATCH after every shared
+		// edit converges.
+		if (lastFlushedContent === toSave) return false;
+		const reqItemId = item.id;
+		try {
+			saveStatus = 'saving';
+			editorStore.setLastSaveTime(Date.now());
+			await api.items.flushCollabContent(wsSlug, reqItemId, toSave, { keepalive });
+			lastFlushedContent = toSave;
+			if (item && item.id === reqItemId) {
+				editorStore.setLastSaveTime(Date.now());
+				editorStore.setDirty(false);
+				showSaved();
+			}
+			return true;
+		} catch {
+			if (item && item.id === reqItemId) {
+				saveStatus = 'idle';
+				// Quiet on the unmount path (no UI to show toast in)
+				// but log so dropped flushes are diagnosable from
+				// devtools when investigating "items.content stale".
+				if (!keepalive) toastStore.show('Failed to save content', 'error');
+			}
+			return false;
+		}
+	}
+
+	// flushCollabNow fires the pending flush IMMEDIATELY (cancelling
+	// the 5s timer). Used by $effect cleanup + beforeunload to land
+	// any in-flight markdown before the provider tears down.
+	function flushCollabNow(keepalive: boolean): boolean {
+		clearTimeout(collabFlushTimer);
+		collabFlushTimer = undefined;
+		if (!editorInstance) return false;
+		let md: string;
+		try {
+			md = (editorInstance.storage as any).markdown?.getMarkdown?.() ?? '';
+		} catch {
+			return false;
+		}
+		// runCollabFlush is async but its return value is irrelevant
+		// for the synchronous callers — fire-and-forget under
+		// keepalive=true is the contract on the unmount path.
+		void runCollabFlush(md, keepalive);
+		return true;
 	}
 
 	// Latest raw markdown that hasn't yet been PATCHed. Tracked

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -754,27 +754,44 @@
 		// tabs would otherwise each fire a redundant PATCH after
 		// every shared edit converges.
 		if (lastFlushedContent === toSave) return false;
-		try {
+
+		// UI mutations only fire when:
+		//   - This is a foreground (user-driven) flush (!keepalive),
+		//     AND
+		//   - The user is still looking at the item we're flushing
+		//     (item.id === itemId).
+		// Background (keepalive=true) cleanup flushes after
+		// navigation MUST NOT touch saveStatus / lastSaveTime —
+		// those slots belong to whatever item the user is now on,
+		// and stamping them from a stale flush leaves the new page
+		// pinned in 'Saving...' indefinitely. Per Codex review
+		// round 2.
+		const isForegroundCurrent = (): boolean =>
+			!keepalive && !!item && item.id === itemId;
+
+		if (isForegroundCurrent()) {
 			saveStatus = 'saving';
 			editorStore.setLastSaveTime(Date.now());
+		}
+		try {
 			await api.items.flushCollabContent(ws, itemId, toSave, { keepalive });
-			lastFlushedContent = toSave;
-			// UI-state updates only matter when the user is still
-			// looking at this item. After navigation, item.id has
-			// already moved on and the new item owns saveStatus.
+			// lastFlushedContent is per-item; only seed it if the
+			// item we just flushed is still the active one.
+			// Otherwise a stale flush could pollute the new page's
+			// dedupe state.
 			if (item && item.id === itemId) {
+				lastFlushedContent = toSave;
+			}
+			if (isForegroundCurrent()) {
 				editorStore.setLastSaveTime(Date.now());
 				editorStore.setDirty(false);
 				showSaved();
 			}
 			return true;
 		} catch {
-			if (item && item.id === itemId) {
+			if (isForegroundCurrent()) {
 				saveStatus = 'idle';
-				// Quiet on the unmount path (no UI to show toast in)
-				// but visible during foreground edits so a stuck
-				// save is diagnosable.
-				if (!keepalive) toastStore.show('Failed to save content', 'error');
+				toastStore.show('Failed to save content', 'error');
 			}
 			return false;
 		}

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -746,17 +746,29 @@
 		}, COLLAB_FLUSH_IDLE_MS);
 	}
 
+	// CollabFlushResult discriminates the three outcomes runCollabFlush
+	// can produce so callers can act on them differently:
+	//   - 'flushed' — PATCH succeeded; items.content now matches.
+	//   - 'deduped' — skipped because lastFlushedContent already
+	//     matched; items.content is ALREADY at this content (the
+	//     previous successful flush put it there). Treated by the
+	//     rich→raw toggle as equivalent to 'flushed' for seeding
+	//     purposes — both mean "server has this markdown."
+	//   - 'failed' — PATCH errored. The toggle path bails so we
+	//     don't enter raw mode with stale state.
+	// Per Codex review round 8.
+	type CollabFlushResult = 'flushed' | 'deduped' | 'failed';
+
 	// runCollabFlush PATCHes items.content via the
 	// `?source=collab-snapshot` bypass. Takes ws/item from the
 	// captured context (NOT live reactive state) so a navigation in
-	// flight doesn't mis-route the PATCH to a different item. Returns
-	// true if a request fired, false if dedupe skipped it.
+	// flight doesn't mis-route the PATCH to a different item.
 	async function runCollabFlush(
 		ws: string,
 		itemId: string,
 		markdown: string,
 		keepalive: boolean,
-	): Promise<boolean> {
+	): Promise<CollabFlushResult> {
 		const allItems = collectionStore.items ?? [];
 		let toSave = unescapeDocLinks(markdown);
 		if (allItems.length > 0) {
@@ -766,8 +778,10 @@
 		// Dedupe: skip the PATCH if our last successful flush
 		// already landed this exact content. Multiple connected
 		// tabs would otherwise each fire a redundant PATCH after
-		// every shared edit converges.
-		if (lastFlushedContent === toSave) return false;
+		// every shared edit converges. Returns 'deduped' (NOT
+		// 'failed') so callers can distinguish "no work needed"
+		// from a real error. Per Codex review round 8.
+		if (lastFlushedContent === toSave) return 'deduped';
 
 		// UI mutations only fire when:
 		//   - This is a foreground (user-driven) flush (!keepalive),
@@ -801,13 +815,13 @@
 				editorStore.setDirty(false);
 				showSaved();
 			}
-			return true;
+			return 'flushed';
 		} catch {
 			if (isForegroundCurrent()) {
 				saveStatus = 'idle';
 				toastStore.show('Failed to save content', 'error');
 			}
-			return false;
+			return 'failed';
 		}
 	}
 
@@ -1615,28 +1629,46 @@
 								const itemId = item.id;
 								const ed = editorInstance;
 								try {
-									// lastFlushed tracks markdown we
-									// have actually PATCHed to
-									// items.content (runCollabFlush
-									// returns true). On PATCH failure
-									// it stays at its prior value so
-									// rawSeedMarkdown never holds
-									// state the server never
-									// received. Per Codex review
-									// round 7.
+									// keepalive=false on the explicit
+									// toggle — the await is
+									// foreground/synchronous and
+									// keepalive's ~64KB body cap can
+									// reject larger payloads,
+									// silently leaving items.content
+									// stale. Cleanup-driven flushes
+									// still use keepalive=true; this
+									// path doesn't need it because
+									// the user clicked a button and
+									// is expecting to wait. Per
+									// Codex review round 8.
 									let md = (ed.storage as any).markdown?.getMarkdown?.();
 									let lastFlushed: string | null = null;
+									let aborted = false;
 									for (let i = 0; i < 3; i++) {
 										if (typeof md !== 'string') break;
-										// keepalive=true so the
-										// PATCH outlives a fast
-										// post-toggle navigation.
-										const ok = await runCollabFlush(ws, itemId, md, true);
-										if (ok) lastFlushed = md;
+										const result = await runCollabFlush(ws, itemId, md, false);
+										if (result === 'failed') {
+											// PATCH errored — refuse
+											// to enter raw mode
+											// rather than silently
+											// seed from stale state.
+											// runCollabFlush already
+											// surfaced the toast.
+											// Per Codex review round 8.
+											aborted = true;
+											break;
+										}
+										// 'flushed' or 'deduped' —
+										// items.content matches md.
+										// Treat both as a successful
+										// flush for seeding purposes.
+										lastFlushed = md;
+										if (result === 'deduped') break;
 										const mdAfter = (ed.storage as any).markdown?.getMarkdown?.();
 										if (mdAfter === md) break;
 										md = mdAfter;
 									}
+									if (aborted) return;
 									// Bail if the user navigated to a
 									// different item while we were
 									// awaiting flushes — applying

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -872,6 +872,14 @@
 			api.items.update(wsSlug, reqItemId, { content: toSave }).then((updated) => {
 				if (!item || item.id !== reqItemId) return;
 				editorStore.setLastSaveTime(Date.now());
+				// Raw saves change items.content via a path the
+				// collab dedupe doesn't see. Without resetting
+				// lastFlushedContent, a later collab flush could
+				// dedupe a content == lastFlushedContent that no
+				// longer reflects server state and skip the PATCH,
+				// leaving items.content stuck on the raw save.
+				// Per Codex review round 7.
+				lastFlushedContent = null;
 				// Stale-response guard: only swap in the server's
 				// snapshot when no newer raw edit landed during the
 				// PATCH. Otherwise RawMarkdownEditor's content-prop
@@ -954,6 +962,12 @@
 						return false;
 					}
 					editorStore.setLastSaveTime(Date.now());
+					// Raw saves change items.content via a path the
+					// collab dedupe doesn't see; reset
+					// lastFlushedContent so a future collab flush
+					// can't skip a real PATCH. Per Codex review
+					// round 7.
+					lastFlushedContent = null;
 					// Only swap in the server's snapshot when no
 					// newer raw edit arrived during the await.
 					// RawMarkdownEditor mirrors `item.content` into
@@ -1601,26 +1615,15 @@
 								const itemId = item.id;
 								const ed = editorInstance;
 								try {
-									// lastFlushed tracks the markdown
-									// we have actually PATCHed to
-									// items.content. Seeding raw mode
-									// from anything else would let
-									// rapid concurrent peer edits
-									// (e.g. same user's other tab
-									// typing) leave the raw editor
-									// holding state that doesn't exist
-									// server-side; an immediate
-									// navigation would lose those
-									// edits. Only the LAST FLUSHED
-									// markdown is safe to seed; if a
-									// peer is still typing past our
-									// 3-iteration cap, items.content
-									// lags Y.Doc briefly until the
-									// peer's own 5s flush catches up
-									// — but at least raw mode shows
-									// state consistent with
-									// items.content. Per Codex review
-									// round 6.
+									// lastFlushed tracks markdown we
+									// have actually PATCHed to
+									// items.content (runCollabFlush
+									// returns true). On PATCH failure
+									// it stays at its prior value so
+									// rawSeedMarkdown never holds
+									// state the server never
+									// received. Per Codex review
+									// round 7.
 									let md = (ed.storage as any).markdown?.getMarkdown?.();
 									let lastFlushed: string | null = null;
 									for (let i = 0; i < 3; i++) {
@@ -1628,12 +1631,19 @@
 										// keepalive=true so the
 										// PATCH outlives a fast
 										// post-toggle navigation.
-										await runCollabFlush(ws, itemId, md, true);
-										lastFlushed = md;
+										const ok = await runCollabFlush(ws, itemId, md, true);
+										if (ok) lastFlushed = md;
 										const mdAfter = (ed.storage as any).markdown?.getMarkdown?.();
 										if (mdAfter === md) break;
 										md = mdAfter;
 									}
+									// Bail if the user navigated to a
+									// different item while we were
+									// awaiting flushes — applying
+									// rawMode + rawSeedMarkdown to
+									// the new page would be wrong.
+									// Per Codex review round 7.
+									if (!item || item.id !== itemId) return;
 									if (lastFlushed !== null) rawSeedMarkdown = lastFlushed;
 								} catch {
 									// Fall through; RawMarkdownEditor

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -520,7 +520,21 @@
 			// doesn't mis-route this flush to a different item.
 			// keepalive=true lets the request outlive the page
 			// lifecycle. Per TASK-1260.
-			flushCollabNow(ctx, true);
+			//
+			// EXCEPTION: skip the flush if the cleanup is firing
+			// because the user just toggled INTO raw mode. The
+			// raw-button onclick already pre-populated
+			// rawPendingMarkdown with the live editor markdown, so
+			// the 1.2s raw debounce will land items.content cleanly.
+			// A keepalive collab-snapshot PATCH from here is
+			// fire-and-forget and can arrive AFTER the raw save —
+			// clobbering newer raw edits with the older Y.Doc
+			// snapshot. The other cleanup triggers (item nav,
+			// canEdit flip, page unmount) all benefit from the
+			// flush. Per Codex review round 3.
+			if (!rawMode) {
+				flushCollabNow(ctx, true);
+			}
 			provider.destroy();
 			doc.destroy();
 			if (activeCollabContext === ctx) activeCollabContext = null;

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -1601,18 +1601,40 @@
 								const itemId = item.id;
 								const ed = editorInstance;
 								try {
+									// lastFlushed tracks the markdown
+									// we have actually PATCHed to
+									// items.content. Seeding raw mode
+									// from anything else would let
+									// rapid concurrent peer edits
+									// (e.g. same user's other tab
+									// typing) leave the raw editor
+									// holding state that doesn't exist
+									// server-side; an immediate
+									// navigation would lose those
+									// edits. Only the LAST FLUSHED
+									// markdown is safe to seed; if a
+									// peer is still typing past our
+									// 3-iteration cap, items.content
+									// lags Y.Doc briefly until the
+									// peer's own 5s flush catches up
+									// — but at least raw mode shows
+									// state consistent with
+									// items.content. Per Codex review
+									// round 6.
 									let md = (ed.storage as any).markdown?.getMarkdown?.();
+									let lastFlushed: string | null = null;
 									for (let i = 0; i < 3; i++) {
 										if (typeof md !== 'string') break;
 										// keepalive=true so the
 										// PATCH outlives a fast
 										// post-toggle navigation.
 										await runCollabFlush(ws, itemId, md, true);
+										lastFlushed = md;
 										const mdAfter = (ed.storage as any).markdown?.getMarkdown?.();
 										if (mdAfter === md) break;
 										md = mdAfter;
 									}
-									if (typeof md === 'string') rawSeedMarkdown = md;
+									if (lastFlushed !== null) rawSeedMarkdown = lastFlushed;
 								} catch {
 									// Fall through; RawMarkdownEditor
 									// will seed from item.content.

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -1578,35 +1578,39 @@
 					<button
 						class="mode-btn"
 						class:active={rawMode}
-						onclick={() => {
+						onclick={async () => {
 							// When toggling FROM rich+collab TO raw,
 							// the editor's live markdown is the
-							// canonical state — items.content has
-							// been intentionally stale since
-							// handleContentUpdate is suppressed
-							// while the provider is connected
-							// (TASK-1260 will close this with a
-							// proper 5s flush). Capture the live
-							// markdown so RawMarkdownEditor seeds
-							// from Y.Doc state rather than stale
-							// items.content. Per Codex review round
-							// 9.
-							if (collabProvider && editorInstance) {
+							// canonical state. Synchronously flush
+							// it to items.content via the collab-
+							// snapshot bypass BEFORE activating raw
+							// mode. Without this, a user who toggles
+							// to raw and immediately navigates away
+							// (without typing) would never persist
+							// the live Y.Doc snapshot — items.content
+							// would stay frozen at the prior 5s
+							// tick. The await ensures the PATCH is
+							// in flight (and lastFlushedContent is
+							// seeded) before any subsequent raw
+							// debounce can race it. Per Codex review
+							// round 4.
+							//
+							// rawSeedMarkdown is also set so
+							// RawMarkdownEditor mounts with the live
+							// markdown rather than stale
+							// items.content (in case the user types
+							// before the flush response lands).
+							if (collabProvider && editorInstance && item) {
 								try {
 									const md = (editorInstance.storage as any).markdown?.getMarkdown?.();
 									if (typeof md === 'string') {
 										rawSeedMarkdown = md;
-										// Pre-populate the pending
-										// queue so the first
-										// auto-save actually
-										// persists the live state
-										// to items.content (the
-										// no-room path will then
-										// prune the op-log + write
-										// items.content under the
-										// per-item lock).
-										rawPendingMarkdown = md;
-										editorStore.setDirty(true);
+										const ws = wsSlug;
+										const itemId = item.id;
+										// keepalive=true so the
+										// PATCH outlives a fast
+										// post-toggle navigation.
+										await runCollabFlush(ws, itemId, md, true);
 									}
 								} catch {
 									// Fall through; RawMarkdownEditor


### PR DESCRIPTION
## Summary

Replaces TASK-1259's temporary autosave suppression with a proper 5s-idle markdown flush. Under collab, Y.Doc remains canonical for live state; items.content stays reasonably fresh for search / share-page / API consumers via a debounced PATCH that bypasses the applier-routing path.

## Mechanism

- **Server**: handleUpdateItem accepts `?source=collab-snapshot` and skips applyContentViaCollab when set (the connected tab IS canonical; the applier loop would just round-trip back to itself and strip input.Content).
- **Client**: handleContentUpdate now branches on collabProvider:
  - Active: 5s idle timer → PATCH via new api.items.flushCollabContent (uses bypass param).
  - Inactive: existing 1.2s debounce path unchanged.
- **Dedupe**: lastFlushedContent guards against redundant per-peer PATCHes when N tabs converge on the same Y.Doc state.
- **On-disconnect flush**: $effect cleanup + beforeunload both call flushCollabNow(keepalive=true) so the markdown lands before the WS dies.
- **Race guards**: reqItemId captured before each await; loadData clears the flush timer + lastFlushedContent.

## Context

Implements TASK-1260 under PLAN-1248. Closes the items.content staleness gap introduced in TASK-1259.

## Test plan
- [x] make check — clean (lint + go test + web build + svelte-check)
- [ ] Manual: type, wait 5s, observe single PATCH with ?source=collab-snapshot in DevTools Network
- [ ] Manual: type, navigate away within 5s; verify items.content updated server-side via \`pad item show\`
- [ ] Manual: two tabs editing concurrently; verify dedupe (only one PATCH per converged state)