### PR TITLE
feat(collab): presence carets with deterministic user colors (TASK-1263)

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -13,6 +13,7 @@
 				"@tiptap/extension-bubble-menu": "^3.22.5",
 				"@tiptap/extension-code-block-lowlight": "^3.22.5",
 				"@tiptap/extension-collaboration": "3.22.5",
+				"@tiptap/extension-collaboration-caret": "3.22.5",
 				"@tiptap/extension-link": "^3.22.5",
 				"@tiptap/extension-placeholder": "^3.22.5",
 				"@tiptap/extension-table": "^3.22.5",
@@ -791,6 +792,21 @@
 				"@tiptap/pm": "3.22.5",
 				"@tiptap/y-tiptap": "^3.0.2",
 				"yjs": "^13"
+			}
+		},
+		"node_modules/@tiptap/extension-collaboration-caret": {
+			"version": "3.22.5",
+			"resolved": "https://registry.npmjs.org/@tiptap/extension-collaboration-caret/-/extension-collaboration-caret-3.22.5.tgz",
+			"integrity": "sha512-+2kOIb661vW16nh5ecSNw4vcRFdove1thkNkKJGGcwaTyORJ0Hc4Pds+tSc3dc9GxZw0bvwwAvX7bPdflnls6A==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/ueberdosis"
+			},
+			"peerDependencies": {
+				"@tiptap/core": "3.22.5",
+				"@tiptap/pm": "3.22.5",
+				"@tiptap/y-tiptap": "^3.0.2"
 			}
 		},
 		"node_modules/@tiptap/extension-document": {

--- a/web/package.json
+++ b/web/package.json
@@ -36,6 +36,7 @@
 		"@tiptap/extension-bubble-menu": "^3.22.5",
 		"@tiptap/extension-code-block-lowlight": "^3.22.5",
 		"@tiptap/extension-collaboration": "3.22.5",
+		"@tiptap/extension-collaboration-caret": "3.22.5",
 		"@tiptap/extension-link": "^3.22.5",
 		"@tiptap/extension-placeholder": "^3.22.5",
 		"@tiptap/extension-table": "^3.22.5",

--- a/web/src/lib/collab/cursorColor.ts
+++ b/web/src/lib/collab/cursorColor.ts
@@ -1,0 +1,82 @@
+/**
+ * Deterministic user → hex colour for collab presence cursors
+ * (TASK-1263, PLAN-1248).
+ *
+ * Same user ID always maps to the same colour across sessions / tabs /
+ * devices, so a teammate's cursor doesn't visually rebrand on every
+ * reconnect. The hash is intentionally simple — collisions across
+ * a small workspace are tolerable and the alternative (colour
+ * negotiation via awareness) adds protocol complexity for no payoff
+ * at v1 scale.
+ *
+ * Output is `#rrggbb` rather than `hsl(...)` because y-tiptap's
+ * default selectionRender appends a literal `70` (alpha hex) to the
+ * user's colour string and only validates `#rrggbb` — see Codex
+ * review round 1 [P2]. Computing the hue in HSL space and converting
+ * to hex gives us the readability of a clamped saturation/lightness
+ * band while staying inside y-tiptap's accepted format.
+ *
+ * Saturation/lightness are clamped to a band that's readable on both
+ * light and dark editor backgrounds. The hue covers the full circle.
+ */
+
+const SATURATION = 0.65; // 0..1
+const LIGHTNESS = 0.55; // 0..1
+
+/**
+ * djb2-ish 32-bit string hash. Stable, fast, and good enough for
+ * spreading short user-ID strings across the hue circle. Returns a
+ * non-negative 32-bit integer.
+ */
+function hashString(s: string): number {
+	let h = 5381;
+	for (let i = 0; i < s.length; i++) {
+		// `<< 5` + add ≡ multiply by 33; XOR mixes the new char in.
+		h = ((h << 5) + h) ^ s.charCodeAt(i);
+	}
+	// Force unsigned by masking to 32 bits.
+	return h >>> 0;
+}
+
+/**
+ * Convert HSL (h: 0..360, s/l: 0..1) → `#rrggbb`. Standard formula
+ * (CSS Color Module 3, Annex A). Values are clamped at integer-byte
+ * resolution which is what hex requires anyway.
+ */
+function hslToHex(h: number, s: number, l: number): string {
+	const c = (1 - Math.abs(2 * l - 1)) * s;
+	const hp = h / 60;
+	const x = c * (1 - Math.abs((hp % 2) - 1));
+	let r1 = 0, g1 = 0, b1 = 0;
+	if (hp < 1) { r1 = c; g1 = x; }
+	else if (hp < 2) { r1 = x; g1 = c; }
+	else if (hp < 3) { g1 = c; b1 = x; }
+	else if (hp < 4) { g1 = x; b1 = c; }
+	else if (hp < 5) { r1 = x; b1 = c; }
+	else { r1 = c; b1 = x; }
+	const m = l - c / 2;
+	const toByte = (v: number) =>
+		Math.max(0, Math.min(255, Math.round((v + m) * 255)))
+			.toString(16)
+			.padStart(2, '0');
+	return `#${toByte(r1)}${toByte(g1)}${toByte(b1)}`;
+}
+
+/**
+ * Map a user identifier (typically `user.id`) to a `#rrggbb` colour
+ * string suitable for the `color` field on the Tiptap
+ * CollaborationCaret extension. The output is always exactly 7
+ * characters (`#` + 6 hex digits), which is what y-tiptap's default
+ * selectionRender expects when it appends an alpha byte.
+ *
+ * Guaranteed: `userColor(x) === userColor(x)` for any string `x`.
+ *
+ * Empty / null / undefined inputs fall back to a neutral grey rather
+ * than throwing — better UX than a coloured cursor for "anonymous"
+ * presence states (e.g. mid-auth).
+ */
+export function userColor(userID: string | null | undefined): string {
+	if (!userID) return '#999999';
+	const hue = hashString(userID) % 360;
+	return hslToHex(hue, SATURATION, LIGHTNESS);
+}

--- a/web/src/lib/components/editor/Editor.svelte
+++ b/web/src/lib/components/editor/Editor.svelte
@@ -6,6 +6,8 @@
 	import type { Node as ProseMirrorNode } from '@tiptap/pm/model';
 	import StarterKit from '@tiptap/starter-kit';
 	import { Collaboration } from '@tiptap/extension-collaboration';
+	import { CollaborationCaret } from '@tiptap/extension-collaboration-caret';
+	import type { Awareness } from 'y-protocols/awareness';
 	import type * as Y from 'yjs';
 	import TaskList from '@tiptap/extension-task-list';
 	import TaskItem from '@tiptap/extension-task-item';
@@ -345,6 +347,8 @@
 		content = '',
 		editable = true,
 		ydoc,
+		awareness,
+		collabUser,
 		onUpdate,
 		onEditor,
 	}: {
@@ -367,6 +371,25 @@
 		 * accepts the constructed Y.Doc from there.
 		 */
 		ydoc?: Y.Doc;
+		/**
+		 * Optional y-protocols `Awareness` instance from the same
+		 * provider that owns `ydoc` (TASK-1263). When supplied
+		 * alongside `collabUser`, the editor registers the
+		 * CollaborationCaret extension to render remote peers'
+		 * carets + selections. Without it (or without a `ydoc`),
+		 * the cursor extension is omitted and the editor behaves
+		 * identically to single-user mode.
+		 */
+		awareness?: Awareness;
+		/**
+		 * Local user identity broadcast over awareness so peers can
+		 * label our caret. `name` is what shows in the cursor label;
+		 * `color` is the deterministic `#rrggbb` from `cursorColor.ts`
+		 * (hex is required because y-tiptap's default selectionRender
+		 * appends an alpha-hex byte and only validates hex). Both
+		 * are required when `awareness` is set.
+		 */
+		collabUser?: { name: string; color: string };
 		onUpdate?: (markdown: string) => void;
 		onEditor?: (editor: Editor) => void;
 	} = $props();
@@ -585,6 +608,26 @@
 			// shape is grep-able from a future RedisOpBus / multi-Doc
 			// path that might want a different field name per item.
 			...(ydoc ? [Collaboration.configure({ document: ydoc, field: 'default' })] : []),
+			// Presence cursors + remote selections (TASK-1263). Only
+			// register when both ydoc AND a usable awareness/user
+			// pair are present — `awareness` alone with no ydoc is
+			// nonsensical (the y-tiptap binding needs a Y.Doc) and
+			// missing user info would render an unlabelled stranger.
+			// CollaborationCaret v3 (the renamed
+			// extension-collaboration-cursor — see docs) takes a
+			// `provider`-shaped object exposing `awareness`. The full
+			// CollabProvider qualifies, but tiptap only reads
+			// `.awareness`, so we hand a minimal duck-typed object
+			// instead — keeps the editor decoupled from our
+			// CollabProvider class shape.
+			...(ydoc && awareness && collabUser
+				? [
+						CollaborationCaret.configure({
+							provider: { awareness },
+							user: collabUser,
+						}),
+					]
+				: []),
 			AttachmentUpload.configure({
 				upload: async (file) => {
 					if (!wsSlug) {
@@ -1407,5 +1450,52 @@
 	.mt-btn-add {
 		font-size: 1.1em;
 		color: var(--accent-blue);
+	}
+
+	/* CollaborationCaret presence (TASK-1263 / PLAN-1248). Styles
+	   the remote-peer carets and selections rendered by the
+	   @tiptap/extension-collaboration-caret default builders. The
+	   user's color comes through inline via `border-color` /
+	   `background-color` on the caret span and a light tint on the
+	   selection wrapper. */
+	.editor-content :global(.collaboration-carets__caret) {
+		position: relative;
+		margin-left: -1px;
+		margin-right: -1px;
+		border-left: 1px solid;
+		border-right: 1px solid;
+		word-break: normal;
+		/* `pointer-events: none` would make the caret unhoverable
+		   AND hide it from selection toolbars but that's fine — we
+		   no longer rely on hover for the label (Codex review
+		   round 1 [P2]: the caret is 1-2px wide so hover is
+		   effectively unreachable anyway). The label is now always
+		   visible while the peer is active, and the caret stays
+		   click-through so it doesn't intercept text-selection or
+		   click-to-place-cursor. */
+		pointer-events: none;
+	}
+	.editor-content :global(.collaboration-carets__label) {
+		position: absolute;
+		top: -1.4em;
+		left: -1px;
+		font-size: 11px;
+		font-weight: 600;
+		line-height: 1;
+		color: #fff;
+		padding: 0.2em 0.4em;
+		border-radius: 3px 3px 3px 0;
+		white-space: nowrap;
+		user-select: none;
+		pointer-events: none;
+	}
+	/* Remote-peer selection highlight. y-tiptap's default
+	   selection builder applies `ProseMirror-yjs-selection` AND an
+	   inline `background-color: <userColor>70` (where `70` is alpha
+	   hex). We don't override the inline color here — that's
+	   already coloured per-user — but a base rule keeps the
+	   selection visible if the inline style fails to parse. */
+	.editor-content :global(.ProseMirror-yjs-selection) {
+		background-color: rgba(125, 125, 125, 0.18);
 	}
 </style>

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -12,6 +12,8 @@
 	import type { Editor as EditorType } from '@tiptap/core';
 	import * as Y from 'yjs';
 	import { CollabProvider, type CollabConnectionState } from '$lib/collab/wsProvider.svelte';
+	import { userColor } from '$lib/collab/cursorColor';
+	import { authStore } from '$lib/stores/auth.svelte';
 	import FieldEditor from '$lib/components/fields/FieldEditor.svelte';
 	import ItemTimeline from '$lib/components/timeline/ItemTimeline.svelte';
 	import ChildItems from '$lib/components/ChildItems.svelte';
@@ -488,6 +490,26 @@
 	let ydoc = $state<Y.Doc | null>(null);
 	let collabProvider = $state<CollabProvider | null>(null);
 	const collabKey = $derived(item && canEdit && !rawMode ? item.id : null);
+
+	// Local user identity broadcast over awareness for the
+	// CollaborationCaret extension (TASK-1263). Colour is a
+	// deterministic hash of user.id so the same user gets the same
+	// hue across sessions / tabs / devices. The route is gated by
+	// the root auth check, so by the time the editor mounts
+	// `authStore.user` is reliably populated; we still return
+	// `undefined` for the unauthenticated path so the editor can
+	// safely omit the cursor extension. If the auth race ever does
+	// matter in practice we'd add `authStore.user?.id` to the
+	// Editor's `{#key}` so a late user load remounts with cursors
+	// enabled.
+	const collabUserState = $derived(
+		authStore.user
+			? {
+					name: authStore.user.name || authStore.user.username || 'Someone',
+					color: userColor(authStore.user.id),
+				}
+			: undefined,
+	);
 
 	$effect(() => {
 		if (!collabKey) return;
@@ -1902,6 +1924,8 @@
 								onUpdate={handleContentUpdate}
 								editable={true}
 								ydoc={ydoc}
+								awareness={collabProvider?.awareness}
+								collabUser={collabUserState}
 								onEditor={(e) => editorInstance = e}
 							/>
 						{/key}


### PR DESCRIPTION
## Summary
- Renders remote peers' carets + selections in the collab-mode editor via \`@tiptap/extension-collaboration-caret@3.22.5\` (the v3 rename of \`extension-collaboration-cursor\`)
- New \`cursorColor.ts\` deterministic hash → \`#rrggbb\` (hex required because y-tiptap's default selectionRender appends an alpha-hex byte and only validates hex)
- Editor.svelte takes optional \`awareness\` + \`collabUser\` props; only registers the caret extension when ydoc + awareness + user are all present
- +page.svelte derives \`collabUserState\` from authStore.user and threads it + \`collabProvider.awareness\` into \`<Editor>\`

Closes TASK-1263.

## Test plan
- [x] \`make check\` passes
- [ ] Manual: two browsers (different users) editing same item — verify each sees the other's coloured caret + label
- [ ] Manual: same user, two tabs — verify same color in both
- [ ] Manual: peer disconnects — verify caret disappears
- [ ] Manual: alone — verify no extra cursor visible

## Codex review
- Round 1 [P2]: HSL color broke y-tiptap's default selectionRender (appends '70' alpha hex; only validates hex) — fixed (HSL → hex conversion)
- Round 1 [P2]: hover label was unreachable due to pointer-events: none on caret — fixed (label always visible)
- Round 1 [NIT]: misleading auth fallback comment — fixed
- Round 2 [P2]: cursorColor.ts was untracked — fixed (staged)
- Round 2 [NIT]: leftover \"HSL\" in JSDoc — fixed
- Round 3: CLEAN