### PR TITLE
feat(versions): VersionSource attribution + collab coexistence (TASK-1267)

### DIFF
--- a/internal/models/item.go
+++ b/internal/models/item.go
@@ -535,8 +535,18 @@ type ItemUpdate struct {
 	AgentRoleID    *string `json:"agent_role_id,omitempty"`
 	LastModifiedBy string  `json:"last_modified_by,omitempty"`
 	Source         string  `json:"source,omitempty"`
-	ChangeSummary  string  `json:"change_summary,omitempty"`
-	Comment        *string `json:"comment,omitempty"`
+	// VersionSource overrides the per-version-row Source attribution
+	// without mutating `items.source`. When unset (the common case),
+	// the version row inherits the same value as `items.source`
+	// (whatever Source ends up being). When set, the version row
+	// uses VersionSource and `items.source` is left alone — used by
+	// the collab 5s-flush PATCH handler so an auto-flush doesn't
+	// re-attribute a CLI/MCP-created item to "collab-snapshot" and
+	// silently flip it out of `WorkspaceHasAgentActivity`'s count.
+	// Per Codex review round 3 of TASK-1267 [P2].
+	VersionSource string  `json:"version_source,omitempty"`
+	ChangeSummary string  `json:"change_summary,omitempty"`
+	Comment       *string `json:"comment,omitempty"`
 	// ClearAssignedUser / ClearAgentRole allow explicitly setting to NULL
 	// (since nil pointer means "don't change" in partial updates)
 	ClearAssignedUser bool `json:"clear_assigned_user,omitempty"`

--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -504,6 +504,25 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 	// Per TASK-1260 / PLAN-1248.
 	collabSnapshot := r.URL.Query().Get("source") == "collab-snapshot"
 
+	// Stamp the per-version-row attribution so the Versions panel /
+	// `pad history` views can distinguish auto-flush snapshots from
+	// the user's explicit edits. Without this, every collab-driven
+	// 5s flush would land as Source="web" (UpdateItem's default
+	// when input.Source is empty — see store/items.go's UpdateItem),
+	// triggering the per-(actor, source) throttle and silently
+	// suppressing follow-up snapshots from a long editing session.
+	//
+	// IMPORTANT: this uses VersionSource (not Source) so the
+	// attribution lands on the version row only and does NOT mutate
+	// `items.source`. Mutating items.source would silently flip a
+	// CLI/MCP-created item out of `WorkspaceHasAgentActivity`'s
+	// `source IN ('cli', 'mcp')` filter just because the user
+	// happened to open the editor and trigger a 5s auto-flush. Per
+	// Codex round 3 of TASK-1267 [P2].
+	if collabSnapshot && input.VersionSource == "" {
+		input.VersionSource = "collab-snapshot"
+	}
+
 	if input.Content != nil && s.collab != nil && !collabSnapshot {
 		// applyContentViaCollab calls directWrite ONLY on the no-
 		// room/no-applier paths (where pruning the op-log is safe

--- a/internal/server/handlers_items_collab_versions_test.go
+++ b/internal/server/handlers_items_collab_versions_test.go
@@ -1,0 +1,149 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// TestCollabSnapshotHTTPSourceStamping is a regression guard for
+// TASK-1267 (PLAN-1248 version-diff coexistence verification),
+// covering the HTTP-handler layer specifically.
+//
+// The web client's collab 5s-flush PATCH sends:
+//
+//	PATCH /workspaces/{ws}/items/{slug}?source=collab-snapshot
+//	{ "content": "..." }
+//
+// The body has no `source` field — the indicator is the query
+// parameter. The handler must stamp `input.VersionSource =
+// "collab-snapshot"` before calling `Store.UpdateItem`, otherwise
+// UpdateItem's default coerces an empty source to "web" on the
+// version row and the per-(actor, source) version-snapshot throttle
+// suppresses every collab-driven version row that follows the
+// user's last manual web edit. We use VersionSource (not Source)
+// so the auto-flush doesn't also mutate items.source.
+//
+// This test:
+//
+//  1. Creates an item via the standard PATCH/POST endpoints.
+//  2. PATCHes with body content + ?source=collab-snapshot query.
+//  3. Reads the version list and asserts at least one row exists
+//     with `Source == "collab-snapshot"`.
+//
+// Sister test in store/items_collab_versions_test.go covers the
+// downstream diff-reconstruction path; this one covers the
+// handler-to-store boundary that round-2 Codex review identified
+// as the missing link.
+func TestCollabSnapshotHTTPSourceStamping(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	// Long, mostly-identical markdown so the version row exercises
+	// reverse-patch storage on at least one transition.
+	filler := strings.Repeat("Lorem ipsum dolor sit amet, consectetur adipiscing elit. ", 20)
+	v1 := filler + "\n\nSection: original heading\nContent line one.\n"
+	v2 := filler + "\n\nSection: revised heading\nContent line one.\n"
+
+	// Step 1: create the item with content v1, sourced as "cli" so
+	// the first PATCH's Source attribution differs and bypasses the
+	// per-(actor, source) throttle.
+	rr := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections/tasks/items", map[string]interface{}{
+		"title":   "Collab versioning HTTP test",
+		"content": v1,
+		"source":  "cli",
+		"fields":  `{"status":"open"}`,
+	})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create item: expected 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var created models.Item
+	parseJSON(t, rr, &created)
+
+	// One-second sleep so the next version row gets a distinct
+	// RFC3339-second timestamp.
+	time.Sleep(1100 * time.Millisecond)
+
+	// Step 2: PATCH with the collab-snapshot query param. The body
+	// intentionally has NO `source` field — that's how the real web
+	// flush calls the endpoint (api/client.ts uses keepalive + a
+	// bare {content} body, relying on the query param for routing).
+	rr = doRequest(srv, "PATCH",
+		"/api/v1/workspaces/"+slug+"/items/"+created.Slug+"?source=collab-snapshot",
+		map[string]interface{}{"content": v2},
+	)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("PATCH ?source=collab-snapshot: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	// Step 3: list versions through the same HTTP path the web UI
+	// uses, and verify the collab-snapshot row was written with
+	// the right Source attribution.
+	rr = doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/items/"+created.Slug+"/versions", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("list versions: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var versions []models.Version
+	if err := json.Unmarshal(rr.Body.Bytes(), &versions); err != nil {
+		t.Fatalf("decode versions: %v", err)
+	}
+
+	var foundCollabRow bool
+	for _, v := range versions {
+		if v.Source == "collab-snapshot" {
+			foundCollabRow = true
+			break
+		}
+	}
+	if !foundCollabRow {
+		t.Errorf(
+			"no version row with Source=\"collab-snapshot\" after a "+
+				"`?source=collab-snapshot` PATCH. The handler is "+
+				"supposed to stamp input.VersionSource from the query "+
+				"param before calling Store.UpdateItem (TASK-1267); "+
+				"without that stamp, every collab 5s-flush would land "+
+				"as Source=\"web\" and the per-(actor, source) version "+
+				"throttle would silently suppress every snapshot after "+
+				"the user's last manual web edit. Got %d version rows "+
+				"with sources: %v",
+			len(versions), sourcesOf(versions),
+		)
+	}
+
+	// Bonus assertion: items.source should still be "cli" — the
+	// auto-flush MUST NOT mutate the persisted item source. Per
+	// Codex round 3 of TASK-1267 [P2]: WorkspaceHasAgentActivity
+	// counts items by `source IN ('cli', 'mcp')`, so a CLI-created
+	// item that gets opened and auto-flushed in the editor would
+	// silently flip out of the agent-activity tally if the handler
+	// stamped Source instead of VersionSource.
+	rr = doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/items/"+created.Slug, nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("get item: expected 200, got %d", rr.Code)
+	}
+	var refetched models.Item
+	parseJSON(t, rr, &refetched)
+	if refetched.Source != "cli" {
+		t.Errorf(
+			"items.source after collab-snapshot PATCH: want %q "+
+				"(unchanged from creation), got %q. The auto-flush "+
+				"must NOT re-attribute items.source — that field "+
+				"feeds WorkspaceHasAgentActivity which only counts "+
+				"`source IN ('cli', 'mcp')`. Use VersionSource for "+
+				"the version-row attribution.",
+			"cli", refetched.Source,
+		)
+	}
+}
+
+func sourcesOf(versions []models.Version) []string {
+	out := make([]string, 0, len(versions))
+	for _, v := range versions {
+		out = append(out, v.Source)
+	}
+	return out
+}

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -866,7 +866,13 @@ func (s *Store) UpdateItem(id string, input models.ItemUpdate) (*models.Item, er
 		if createdBy == "" {
 			createdBy = "user"
 		}
-		source := input.Source
+		// VersionSource takes precedence so the per-version-row
+		// attribution can differ from the (persisted) item source.
+		// See ItemUpdate.VersionSource doc comment + TASK-1267.
+		source := input.VersionSource
+		if source == "" {
+			source = input.Source
+		}
 		if source == "" {
 			source = "web"
 		}

--- a/internal/store/items_collab_versions_test.go
+++ b/internal/store/items_collab_versions_test.go
@@ -1,0 +1,192 @@
+package store
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// TestCollabSnapshotPreservesVersionDiff is a regression guard for
+// TASK-1267 (PLAN-1248 version-diff coexistence verification).
+//
+// The 5s collab-snapshot flush (TASK-1260) PATCHes items.content
+// through the same `Store.UpdateItem` path as any other content
+// write. The version-diff feature reads `items.content` snapshots
+// over time — those snapshots are the canonical record consumed by
+// the Versions panel and `pad history` views. This test exercises
+// the full happy path:
+//
+//  1. Create item with content "v1" sourced as "cli" (so the
+//     first UpdateItem with Source="web" isn't throttled by the
+//     per-(actor, source) gate in shouldCreateItemVersion).
+//  2. Update content to "v2" with `Source: "web"` after a brief
+//     sleep (the version table orders by RFC3339-second created_at;
+//     back-to-back writes inside one second tie and the
+//     newest→oldest walk becomes order-dependent on row insertion).
+//  3. Update content to "v3" with `VersionSource: "collab-snapshot"`
+//     after another brief sleep — simulating a 5s flush. We use
+//     VersionSource (matching what the HTTP handler does in
+//     production for `?source=collab-snapshot`) so the version
+//     row's Source attribution is "collab-snapshot" while
+//     items.source is left alone.
+//  4. List versions and reconstruct each via the diff/patch chain.
+//     Locate the row written for each PATCH by `Source` rather
+//     than positional index, since the create-time row is also
+//     in the list.
+//  5. Assert the v2 row reconstructs to "v1-content" (snapshot
+//     before that write), the v3 row reconstructs to "v2-content".
+//  6. Verify at least one of the rows was actually stored as a
+//     reverse-patch (`IsDiff: true`) — the test contents are long
+//     and mostly-identical specifically so `diff.IsDiffSmaller`
+//     keeps them as patches. Without that, the test would never
+//     exercise the diff/reconstruction path that motivates this
+//     coexistence check.
+//
+// If a future change makes collab-snapshot writes bypass version
+// snapshotting (e.g. by hitting a separate write path that doesn't
+// run UpdateItem), this test fails. That's the regression we want
+// to catch — markdown remains canonical for non-edit consumers
+// (search, exports, share-page, MCP, version diff) is a load-
+// bearing invariant of PLAN-1248's architecture.
+func TestCollabSnapshotPreservesVersionDiff(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Collab Versions Test")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+
+	// Long, mostly-identical markdown blocks. The 80-char filler
+	// line dwarfs any patch describing the single-line change, so
+	// `diff.IsDiffSmaller` will keep these as reverse-patches and
+	// the test actually exercises the patch-reconstruction path.
+	// Per Codex review round 1 [P2].
+	filler := strings.Repeat("Lorem ipsum dolor sit amet, consectetur adipiscing elit. ", 20)
+	v1 := filler + "\n\nSection: original heading\nContent line one.\n"
+	v2 := filler + "\n\nSection: original heading\nContent line one updated.\n"
+	v3 := filler + "\n\nSection: revised heading\nContent line one updated.\n"
+
+	// Step 1: create with Source="cli". CreateItem inserts an
+	// initial version row with this source; the next UpdateItem
+	// with Source="web" then differs from the most-recent version's
+	// source, bypassing the per-(actor, source) throttle in
+	// shouldCreateItemVersion. Without this differentiation the
+	// "v1→v2" row would be silently throttled away. Per Codex
+	// review round 1 [P2].
+	item, err := s.CreateItem(ws.ID, col.ID, models.ItemCreate{
+		Title:   "Versioned Item",
+		Content: v1,
+		Fields:  `{"status":"open"}`,
+		Source:  "cli",
+	})
+	if err != nil {
+		t.Fatalf("CreateItem: %v", err)
+	}
+
+	// One-second sleep between writes so each version row gets a
+	// distinct `created_at`. RFC3339-second resolution + back-to-
+	// back updates would otherwise tie and the newest→oldest walk
+	// would depend on row-insertion order rather than time. Per
+	// Codex review round 1 [P2].
+	time.Sleep(1100 * time.Millisecond)
+
+	// Step 2: web write to v2.
+	_, err = s.UpdateItem(item.ID, models.ItemUpdate{
+		Content:        &v2,
+		LastModifiedBy: "user",
+		Source:         "web",
+	})
+	if err != nil {
+		t.Fatalf("UpdateItem v2 (web): %v", err)
+	}
+
+	time.Sleep(1100 * time.Millisecond)
+
+	// Step 3: collab-snapshot write to v3. We use VersionSource
+	// (matching what the HTTP handler does in production for
+	// `?source=collab-snapshot` PATCHes — see handlers_items.go)
+	// so the version row's Source attribution is "collab-snapshot"
+	// while items.source stays whatever it was. The source change
+	// also bypasses the per-(actor, source) throttle.
+	_, err = s.UpdateItem(item.ID, models.ItemUpdate{
+		Content:        &v3,
+		LastModifiedBy: "user",
+		VersionSource:  "collab-snapshot",
+	})
+	if err != nil {
+		t.Fatalf("UpdateItem v3 (collab-snapshot): %v", err)
+	}
+
+	// Step 4: read back the resolved version chain.
+	resolved, err := s.ListItemVersionsResolved(item.ID, v3)
+	if err != nil {
+		t.Fatalf("ListItemVersionsResolved: %v", err)
+	}
+	if len(resolved) < 3 {
+		t.Fatalf("expected at least 3 version rows (initial + 2 updates), got %d", len(resolved))
+	}
+
+	// Locate the rows by Source so the assertions don't depend on
+	// the relative ordering of the create-time row vs. the update
+	// rows. Per Codex review round 1 [P2].
+	rowBySource := map[string]models.Version{}
+	for _, v := range resolved {
+		// Take the most recent row per source — there's only one
+		// per source in this test, but be defensive.
+		if _, seen := rowBySource[v.Source]; !seen {
+			rowBySource[v.Source] = v
+		}
+	}
+
+	// Step 5: each version row records what items.content was
+	// IMMEDIATELY BEFORE the update that created the row (see
+	// items.go line ~885: `versionContent := existing.Content`).
+	// After ListItemVersionsResolved unwinds the diff chain, each
+	// row's `Content` is that pre-update string. Concretely:
+	//   - cli row content = v1  (initial state from CreateItem)
+	//   - web row content = v1  (state before the v2 UpdateItem)
+	//   - collab-snapshot row content = v2  (state before the v3 UpdateItem)
+	cliRow, ok := rowBySource["cli"]
+	if !ok {
+		t.Fatalf("no version row with Source=cli; got rows %+v", rowBySource)
+	}
+	if cliRow.Content != v1 {
+		t.Errorf("cli row Content: want v1 (len %d), got len %d", len(v1), len(cliRow.Content))
+	}
+
+	webRow, ok := rowBySource["web"]
+	if !ok {
+		t.Fatalf("no version row with Source=web; the v1→v2 web update was throttled away — the test no longer covers what it claims to. Got rows %+v", rowBySource)
+	}
+	if webRow.Content != v1 {
+		t.Errorf("web row resolved Content: want v1, got %d-byte string", len(webRow.Content))
+	}
+
+	collabRow, ok := rowBySource["collab-snapshot"]
+	if !ok {
+		t.Fatalf("no version row with Source=collab-snapshot; the v3 collab-snapshot update did NOT create a version row. This is the actual regression TASK-1267 watches for — collab-snapshot writes must remain in the version-diff path. Got rows %+v", rowBySource)
+	}
+	if collabRow.Content != v2 {
+		t.Errorf("collab-snapshot row resolved Content: want v2, got %d-byte string", len(collabRow.Content))
+	}
+
+	// Step 6: at least one of the update rows should have been
+	// stored as a reverse-patch on disk (not just full content),
+	// confirming the diff/reconstruction path is actually
+	// exercised. We re-fetch the raw rows because
+	// ListItemVersionsResolved sets IsDiff=false on every row
+	// after applying the patch.
+	raw, err := s.ListItemVersions(item.ID)
+	if err != nil {
+		t.Fatalf("ListItemVersions: %v", err)
+	}
+	sawDiff := false
+	for _, v := range raw {
+		if v.IsDiff {
+			sawDiff = true
+			break
+		}
+	}
+	if !sawDiff {
+		t.Errorf("expected at least one version row stored as a reverse-patch (IsDiff=true); test contents are too small or too dissimilar to exercise the diff path. Bump the filler size.")
+	}
+}


### PR DESCRIPTION
## Summary
- Adds \`ItemUpdate.VersionSource\`: overrides per-version-row \`Source\` attribution WITHOUT mutating \`items.source\`
- \`Store.UpdateItem\` prefers \`VersionSource\` over \`Source\` for version-row creation; falls back to \`Source\` then \`\"web\"\`
- \`handlers_items.go\` stamps \`input.VersionSource = \"collab-snapshot\"\` for \`?source=collab-snapshot\` PATCHes
- Adds two tests: store-level reverse-patch reconstruction; HTTP-level integration test verifying both the version-row attribution AND that \`items.source\` stays unchanged

The motivating bug: without this, every collab 5s-flush would land as \`Source=\"web\"\` on the version row, triggering the per-(actor, source) throttle and silently suppressing every snapshot following the user's last manual web edit. Naive fix would mutate \`items.source\` on every auto-flush, silently flipping CLI/MCP-created items out of \`WorkspaceHasAgentActivity\`'s \`source IN ('cli', 'mcp')\` count — \`VersionSource\` keeps that separation.

Closes TASK-1267.

## Test plan
- [x] \`go test ./internal/store -run TestCollabSnapshotPreservesVersionDiff\` passes
- [x] \`go test ./internal/server -run TestCollabSnapshotHTTPSourceStamping\` passes
- [x] Verified injection: stashing the handler stamp fails the HTTP test; reverting the VersionSource→Source split flips \`items.source\` and fails the bonus assertion
- [x] \`make check\` passes

## Codex review
- Round 1: 3 P2s (tests didn't account for create-time initial version source, content too small to exercise reverse-patch, RFC3339-second created_at ties) — fixed
- Round 2 [P2]: test simulated collab-snapshot via \`Source\` directly, but production handler didn't actually stamp the source — fixed by stamping in the handler + new HTTP test
- Round 3 [P2]: stamping \`Source\` mutated \`items.source\` on every auto-flush, breaking \`WorkspaceHasAgentActivity\` — fixed via new \`VersionSource\` field
- Round 4: CLEAN, with NIT to update lingering comments — fixed