### PR TITLE
feat(collab): schema-version handshake + mismatch rebuild (TASK-1268)

### DIFF
--- a/internal/collab/manager.go
+++ b/internal/collab/manager.go
@@ -10,11 +10,20 @@ import (
 )
 
 // DefaultSchemaVersion is the schema-version stamp used by all rooms
-// today. TASK-1268 will add a real client-driven version with a
-// snapshot-and-rebuild flow on mismatch; for now every persisted
-// op-log row carries the same value, which is exactly what
-// LoadYjsUpdatesSince expects.
+// today. TASK-1268 plumbs the rebuild flow: each Join's announced
+// client version is checked against the latest op-log row's stamp
+// and the room manager prunes the op-log when they diverge. The
+// constant itself bumps in lockstep with the web client's
+// `web/src/lib/collab/schemaVersion.ts` SCHEMA_VERSION on any
+// breaking change to the Tiptap extension set or Y.Doc shape.
 const DefaultSchemaVersion = "1"
+
+// SchemaVersion exposes the version this manager stamps on persisted
+// op-log rows. The HTTP collab handler uses it to validate incoming
+// `?schema_version=...` query params before upgrading the WebSocket —
+// a client running a different version is rejected at the upgrade
+// stage rather than admitted and silently corrupting the op-log.
+func (m *RoomManager) SchemaVersion() string { return m.schemaVersion }
 
 // errTooManyJoinRetries surfaces when RoomManager.Join lost the
 // addConn-vs-grace-expiry race more times than feels like a real
@@ -178,6 +187,25 @@ func (m *RoomManager) Join(itemID string, conn *websocket.Conn) error {
 		// before the long-lived readLoop so concurrent peers can
 		// edit simultaneously. Per Codex review round 5.
 		itemLock.Lock()
+
+		// Schema-mismatch rebuild (TASK-1268). Inside the per-item
+		// setup lock so a concurrent PruneAndApply / fresh Join
+		// can't race the prune-then-replay sequence: any peer that
+		// arrives in this window blocks here until we either prune
+		// or proceed cleanly. We check the LATEST persisted
+		// schema_version (LatestYjsUpdateSchemaVersion), and if it
+		// disagrees with our current m.schemaVersion we wipe the
+		// op-log for this item via PruneYjsUpdatesBefore with a
+		// far-future cutoff. items.content is canonical and is
+		// preserved — the client's lazy-seed path (TASK-1261) will
+		// re-encode it into ops at the new schema version on its
+		// next idle tick.
+		if err := m.maybeRebuildOnSchemaMismatch(itemID); err != nil {
+			itemLock.Unlock()
+			m.bus.Unsubscribe(rc.bus)
+			return err
+		}
+
 		if err := room.addConn(rc); err != nil {
 			itemLock.Unlock()
 			// Race: the grace timer reclaimed the room between
@@ -196,6 +224,44 @@ func (m *RoomManager) Join(itemID string, conn *websocket.Conn) error {
 		return m.runConn(room, rc, itemLock)
 	}
 	return errTooManyJoinRetries
+}
+
+// distantFuture is the prune-everything cutoff we hand to
+// PruneYjsUpdatesBefore. The store's prune is a strict-less-than on
+// created_at; any row written with a sane RFC3339 timestamp will
+// satisfy `created_at < 9999-01-01`.
+var distantFuture = time.Date(9999, 1, 1, 0, 0, 0, 0, time.UTC)
+
+// maybeRebuildOnSchemaMismatch implements the TASK-1268 rebuild flow.
+//
+// Reads the latest persisted op-log row's schema_version for itemID.
+// If a row exists AND its version differs from the manager's current
+// `schemaVersion`, the entire op-log for the item is pruned. Caller
+// MUST hold the per-item setup lock so a concurrent peer's replayTo
+// can't load the soon-to-be-pruned rows.
+//
+// Returns nil on the no-rows path and on the matched-version path —
+// both are "nothing to do". A real DB error from either step short-
+// circuits Join with the same error so the WS upgrade fails loudly.
+func (m *RoomManager) maybeRebuildOnSchemaMismatch(itemID string) error {
+	latest, ok, err := m.store.LatestYjsUpdateSchemaVersion(itemID)
+	if err != nil {
+		return err
+	}
+	if !ok || latest == m.schemaVersion {
+		return nil
+	}
+	pruned, err := m.store.PruneYjsUpdatesBefore(itemID, distantFuture)
+	if err != nil {
+		return err
+	}
+	slog.Info("collab: schema-version mismatch; pruned op-log",
+		"item_id", itemID,
+		"server_version", m.schemaVersion,
+		"persisted_version", latest,
+		"rows_pruned", pruned,
+	)
+	return nil
 }
 
 // runConn drives one connection through its full lifecycle: spawn

--- a/internal/collab/manager_test.go
+++ b/internal/collab/manager_test.go
@@ -58,6 +58,41 @@ func (f *fakeOpLog) LoadYjsUpdatesSince(itemID string, sinceID int64) ([]models.
 	return out, nil
 }
 
+// LatestYjsUpdateSchemaVersion mirrors the production store: returns
+// the most recent op-log row's schema_version for an item, or
+// (false) when no rows exist. The fake walks rows[] in append order
+// and returns the latest matching entry — same semantic as the
+// store's `ORDER BY id DESC LIMIT 1`.
+func (f *fakeOpLog) LatestYjsUpdateSchemaVersion(itemID string) (string, bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for i := len(f.rows) - 1; i >= 0; i-- {
+		if f.rows[i].ItemID == itemID {
+			return f.rows[i].SchemaVersion, true, nil
+		}
+	}
+	return "", false, nil
+}
+
+// PruneYjsUpdatesBefore deletes every row for itemID whose CreatedAt
+// is strictly less than the cutoff. The schema-mismatch rebuild path
+// passes a far-future cutoff so this becomes "delete every row".
+func (f *fakeOpLog) PruneYjsUpdatesBefore(itemID string, before time.Time) (int64, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	kept := f.rows[:0]
+	var pruned int64
+	for _, r := range f.rows {
+		if r.ItemID == itemID && r.CreatedAt.Before(before) {
+			pruned++
+			continue
+		}
+		kept = append(kept, r)
+	}
+	f.rows = kept
+	return pruned, nil
+}
+
 func (f *fakeOpLog) appendCount() int {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -541,4 +576,149 @@ func TestRoomManagerCloseShutsDownAllRooms(t *testing.T) {
 	if _, _, err := c.ReadMessage(); err == nil {
 		t.Errorf("expected read error after manager.Close")
 	}
+}
+
+// TestRoomManagerSchemaMismatchPrunes is the TASK-1268 happy-path
+// regression test. When a peer joins an item whose persisted op-log
+// rows are stamped with a different schema version than the
+// manager's current one, the room manager prunes the entire op-log
+// for that item before replay so the new client doesn't replay
+// (potentially incompatible) old-schema ops.
+func TestRoomManagerSchemaMismatchPrunes(t *testing.T) {
+	bus := NewMemoryOpBus()
+	defer bus.Close()
+
+	store := &fakeOpLog{}
+	// Pre-seed two rows stamped with the OLD schema version.
+	if _, err := store.AppendYjsUpdate("item-a", []byte{yMessageSync, 0x01}, "1"); err != nil {
+		t.Fatalf("seed 1: %v", err)
+	}
+	if _, err := store.AppendYjsUpdate("item-a", []byte{yMessageSync, 0x02}, "1"); err != nil {
+		t.Fatalf("seed 2: %v", err)
+	}
+
+	// Manager runs at version "2" — first new-version client to
+	// arrive should trigger the prune.
+	mgr := NewRoomManagerWithConfig(store, bus, RoomManagerConfig{
+		SchemaVersion: "2",
+	})
+	srv := newCollabTestServer(t, mgr)
+	defer srv.Close()
+
+	c := dialWS(t, srv, "item-a")
+	defer c.Close()
+
+	// After the prune, the op-log replay sends NOTHING. Confirm by
+	// setting a short read deadline and asserting we time out
+	// rather than receiving stale rows.
+	c.SetReadDeadline(time.Now().Add(300 * time.Millisecond))
+	if _, _, err := c.ReadMessage(); err == nil {
+		t.Errorf("expected no replay frames after schema-mismatch prune; got one")
+	}
+
+	// Op-log should be empty for item-a. The store's rowCount
+	// reflects the post-prune state (we pruned in maybeRebuildOnSchemaMismatch).
+	if rc := store.rowCount(); rc != 0 {
+		t.Errorf("after schema-mismatch prune: want 0 rows, got %d", rc)
+	}
+}
+
+// TestRoomManagerSchemaCleanVersionPreservesOpLog is the negative
+// case: when the persisted version matches the manager's, no prune
+// runs and the replay path is undisturbed.
+func TestRoomManagerSchemaCleanVersionPreservesOpLog(t *testing.T) {
+	bus := NewMemoryOpBus()
+	defer bus.Close()
+
+	store := &fakeOpLog{}
+	if _, err := store.AppendYjsUpdate("item-a", []byte{yMessageSync, 0x01}, "1"); err != nil {
+		t.Fatalf("seed 1: %v", err)
+	}
+
+	// Manager and persisted rows agree on "1".
+	mgr := NewRoomManagerWithConfig(store, bus, RoomManagerConfig{
+		SchemaVersion: "1",
+	})
+	srv := newCollabTestServer(t, mgr)
+	defer srv.Close()
+
+	c := dialWS(t, srv, "item-a")
+	defer c.Close()
+
+	// Replay should land normally — single row.
+	first := readBinaryWithin(t, c, 2*time.Second)
+	if len(first) < 2 || first[1] != 0x01 {
+		t.Errorf("replay row 1 mismatch: got %v", first)
+	}
+
+	if rc := store.rowCount(); rc != 1 {
+		t.Errorf("on clean-version connect: op-log should be untouched (want 1 row), got %d", rc)
+	}
+}
+
+// TestRoomManagerSchemaPostRebuildClean confirms that after a
+// rebuild fires once, subsequent connects on the same item are
+// clean: the post-prune append carries the new schema version,
+// LatestYjsUpdateSchemaVersion now reads as "2", and a second peer
+// connecting with version "2" does NOT re-trigger the prune.
+func TestRoomManagerSchemaPostRebuildClean(t *testing.T) {
+	bus := NewMemoryOpBus()
+	defer bus.Close()
+
+	store := &fakeOpLog{}
+	if _, err := store.AppendYjsUpdate("item-a", []byte{yMessageSync, 0x01}, "1"); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	mgr := NewRoomManagerWithConfig(store, bus, RoomManagerConfig{
+		SchemaVersion: "2",
+	})
+	srv := newCollabTestServer(t, mgr)
+	defer srv.Close()
+
+	// First connect: triggers the prune.
+	c1 := dialWS(t, srv, "item-a")
+
+	// Wait for the prune to actually land. RoomCount() == 1 isn't a
+	// prune-completion barrier (getOrCreate publishes the room
+	// BEFORE maybeRebuildOnSchemaMismatch runs), so poll the store
+	// state directly. Per Codex review round 1 NIT.
+	for i := 0; i < 200; i++ {
+		if store.rowCount() == 0 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	if rc := store.rowCount(); rc != 0 {
+		t.Errorf("after first join (mismatch): want 0 rows, got %d", rc)
+	}
+
+	// Have c1 send a sync frame so the post-prune op-log gets a row
+	// stamped at the manager's "2".
+	if err := c1.WriteMessage(websocket.BinaryMessage, []byte{yMessageSync, 0x55}); err != nil {
+		t.Fatalf("write live frame: %v", err)
+	}
+	for i := 0; i < 200; i++ {
+		if store.rowCount() == 1 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if rc := store.rowCount(); rc != 1 {
+		t.Fatalf("post-rebuild append: want 1 row, got %d", rc)
+	}
+
+	// Second connect on the same item: persisted version is now
+	// "2", manager is "2", so no prune. The single row must
+	// replay to the new peer untouched.
+	c2 := dialWS(t, srv, "item-a")
+	defer c2.Close()
+
+	got := readBinaryWithin(t, c2, 2*time.Second)
+	if len(got) < 2 || got[1] != 0x55 {
+		t.Errorf("post-rebuild replay row mismatch: got %v", got)
+	}
+
+	c1.Close()
 }

--- a/internal/collab/room.go
+++ b/internal/collab/room.go
@@ -114,6 +114,13 @@ type Room struct {
 type opLogStore interface {
 	AppendYjsUpdate(itemID string, data []byte, schemaVersion string) (int64, error)
 	LoadYjsUpdatesSince(itemID string, sinceID int64) ([]models.YjsUpdate, error)
+	// LatestYjsUpdateSchemaVersion + PruneYjsUpdatesBefore power the
+	// schema-mismatch rebuild flow (TASK-1268). The room manager
+	// checks the most recent op-log row's stamp on Join and prunes
+	// the entire item's op-log when the persisted version no longer
+	// matches the server's current SCHEMA_VERSION.
+	LatestYjsUpdateSchemaVersion(itemID string) (string, bool, error)
+	PruneYjsUpdatesBefore(itemID string, before time.Time) (int64, error)
 }
 
 // addConn registers a freshly-built roomConn with the room. Cancels

--- a/internal/server/handlers_collab.go
+++ b/internal/server/handlers_collab.go
@@ -117,6 +117,30 @@ func (s *Server) handleCollab(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Schema-version handshake (TASK-1268, PLAN-1248). The client
+	// announces its SCHEMA_VERSION via `?schema_version=...`; if it
+	// doesn't match the server's current value we reject the upgrade
+	// outright. Admitting a mismatched client and silently letting it
+	// stamp old (or future) ops onto the op-log would corrupt the
+	// rebuild flow's ability to detect mismatches — the server's
+	// stamp is supposed to mark the era of every persisted row.
+	//
+	// The empty-query path is treated as legacy-compatible "version
+	// 1" rather than a hard error so older bundles served from a
+	// browser cache during a deploy don't fail with cryptic 400s
+	// before the user has a chance to refresh. The compatibility
+	// shim only covers v1 — once we ever bump past it, missing
+	// schema_version is rejected.
+	clientSchemaVersion := r.URL.Query().Get("schema_version")
+	if clientSchemaVersion == "" {
+		clientSchemaVersion = "1"
+	}
+	if clientSchemaVersion != s.collab.SchemaVersion() {
+		writeError(w, http.StatusBadRequest, "schema_mismatch",
+			"This editor is incompatible with the server. Please refresh the page.")
+		return
+	}
+
 	conn, err := collabUpgrader.Upgrade(w, r, nil)
 	if err != nil {
 		// Upgrade itself emits the right HTTP status (e.g. 400 on

--- a/internal/server/handlers_collab_test.go
+++ b/internal/server/handlers_collab_test.go
@@ -521,6 +521,73 @@ func TestCollabUpgradeUnavailableWithoutRoomManager(t *testing.T) {
 	}
 }
 
+// TestCollabUpgradeRejectsSchemaVersionMismatch is the TASK-1268
+// negative-handshake regression: a client announcing a different
+// SCHEMA_VERSION than the server runs must be 400'd before the WS
+// upgrade. Admitting a mismatched client and letting it stamp ops
+// onto the op-log would corrupt the rebuild flow's mismatch
+// detection (the server's stamp is supposed to mark each op-log
+// row's era).
+func TestCollabUpgradeRejectsSchemaVersionMismatch(t *testing.T) {
+	srv := testServerWithCollab(t)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	itemID := seedCollabFixture(t, srv, "SchemaMismatch")
+
+	// Server's RoomManager is at "1" (DefaultSchemaVersion); send "9"
+	// to force a mismatch. We hit the HTTP path directly rather than
+	// through dialCollab so we can read the JSON error body.
+	resp, err := http.Get(ts.URL + "/api/v1/collab/" + itemID + "?schema_version=9")
+	if err != nil {
+		t.Fatalf("http get: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400 on schema mismatch, got %d", resp.StatusCode)
+	}
+	// We deliberately don't lock to the exact JSON shape (which
+	// could shift if the writeError envelope changes) — the
+	// status code is the load-bearing assertion.
+}
+
+// TestCollabUpgradeAcceptsExplicitMatchingSchemaVersion confirms the
+// happy path of the handshake: a client that sends a schema_version
+// matching the server's value is upgraded normally.
+func TestCollabUpgradeAcceptsExplicitMatchingSchemaVersion(t *testing.T) {
+	srv := testServerWithCollab(t)
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	itemID := seedCollabFixture(t, srv, "SchemaMatch")
+
+	// Server's RoomManager runs at "1" (DefaultSchemaVersion). The
+	// client announces "1" too — must be accepted.
+	u, _ := url.Parse(ts.URL)
+	wsURL := "ws://" + u.Host + "/api/v1/collab/" + itemID + "?schema_version=1"
+	dialer := websocket.Dialer{HandshakeTimeout: 3 * time.Second}
+	conn, resp, err := dialer.Dial(wsURL, nil)
+	if err != nil {
+		body := ""
+		if resp != nil {
+			body = "status=" + resp.Status
+		}
+		t.Fatalf("dial: %v (%s)", err, body)
+	}
+	defer conn.Close()
+	if resp.StatusCode != http.StatusSwitchingProtocols {
+		t.Fatalf("expected 101 Switching Protocols, got %d", resp.StatusCode)
+	}
+	if err := conn.WriteControl(
+		websocket.CloseMessage,
+		websocket.FormatCloseMessage(websocket.CloseNormalClosure, "bye"),
+		time.Now().Add(1*time.Second),
+	); err != nil {
+		t.Fatalf("write close: %v", err)
+	}
+}
+
 // TestCollabUpgradeMissingItemIDBadRequest exercises the bad-request
 // branch — chi's URL pattern requires the {itemID} segment to be
 // present, so the route just won't match without it. This test is

--- a/internal/store/yjs_updates.go
+++ b/internal/store/yjs_updates.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"database/sql"
 	"errors"
 	"fmt"
 	"time"
@@ -127,6 +128,42 @@ func (s *Store) LoadYjsUpdatesSince(itemID string, sinceID int64) ([]models.YjsU
 		return nil, fmt.Errorf("iterate yjs updates: %w", err)
 	}
 	return updates, nil
+}
+
+// LatestYjsUpdateSchemaVersion returns the `schema_version` of the
+// most recently appended op-log row for an item. The boolean is false
+// when no rows exist yet (a fresh item, or one whose op-log was just
+// pruned). Used by the schema-mismatch rebuild flow (TASK-1268,
+// PLAN-1248): if the latest persisted version differs from the
+// server's current SCHEMA_VERSION, the room manager prunes the
+// op-log before replaying so the new-schema client doesn't replay
+// old-schema ops that may be incompatible.
+//
+// We pick "most recent" rather than "any row" so a server that wrote
+// some old-version rows then was rolled back, then forward again,
+// still detects the mismatch from the row(s) that matter most.
+func (s *Store) LatestYjsUpdateSchemaVersion(itemID string) (string, bool, error) {
+	if itemID == "" {
+		return "", false, errors.New("LatestYjsUpdateSchemaVersion: itemID is required")
+	}
+	query := s.dialect.Rebind(`
+		SELECT schema_version
+		FROM item_yjs_updates
+		WHERE item_id = ?
+		ORDER BY id DESC
+		LIMIT 1
+	`)
+	var version string
+	if err := s.db.QueryRow(query, itemID).Scan(&version); err != nil {
+		// sql.ErrNoRows is the well-known "no rows" path; surface it
+		// as ok=false rather than an error so callers don't have to
+		// import database/sql just for this check.
+		if errors.Is(err, sql.ErrNoRows) {
+			return "", false, nil
+		}
+		return "", false, fmt.Errorf("latest yjs schema version: %w", err)
+	}
+	return version, true, nil
 }
 
 // PruneYjsUpdatesBefore deletes op-log rows for an item with created_at

--- a/web/src/lib/collab/schemaVersion.ts
+++ b/web/src/lib/collab/schemaVersion.ts
@@ -1,0 +1,34 @@
+/**
+ * Client-side Tiptap schema version stamp (TASK-1268, PLAN-1248).
+ *
+ * The CollabProvider sends this on every WebSocket connect via a
+ * `?schema_version=...` query parameter. The server (1) rejects the
+ * upgrade outright if the value doesn't match its own
+ * `DefaultSchemaVersion`, and (2) prunes the op-log on first
+ * mismatched-vs-persisted connect so the new client doesn't replay
+ * old-schema ops that may be incompatible.
+ *
+ * **Bump rule.** Any of these changes is a breaking schema bump and
+ * REQUIRES incrementing this constant + the matching
+ * `internal/collab/manager.go::DefaultSchemaVersion` in the same
+ * commit:
+ *
+ *   - Adding/removing a Tiptap extension whose ProseMirror schema
+ *     contributes nodes or marks (e.g. swapping StarterKit for a
+ *     custom kit, adding a TaskList that wasn't there before).
+ *   - A coordinated `@tiptap/core` + `@tiptap/extension-collaboration`
+ *     + `@tiptap/y-tiptap` minor bump that the changelog flags as a
+ *     ProseMirror node-spec change.
+ *   - Changing the Y.Doc top-level fragment shape (e.g. moving
+ *     content from `'default'` to `'body'`).
+ *
+ * Pure CSS, UI, or behavioural changes that don't alter the
+ * persisted document shape DO NOT bump this value. When in doubt,
+ * load an item edited under the old version after your change and
+ * confirm the rendered tree is identical.
+ *
+ * **Why a string, not a number.** Future tags may want suffixes
+ * (e.g. `'2-rc1'`) without changing the equality semantics. The
+ * server treats it as an opaque exact-match string.
+ */
+export const SCHEMA_VERSION = '1';

--- a/web/src/lib/collab/wsProvider.svelte.ts
+++ b/web/src/lib/collab/wsProvider.svelte.ts
@@ -27,6 +27,7 @@ import * as syncProtocol from 'y-protocols/sync';
 import * as awarenessProtocol from 'y-protocols/awareness';
 import * as encoding from 'lib0/encoding';
 import * as decoding from 'lib0/decoding';
+import { SCHEMA_VERSION } from './schemaVersion';
 
 /** First-byte discriminators on the wire. Must match the constants in
  *  `internal/collab/room.go` (yMessageSync / yMessageAwareness). */
@@ -728,5 +729,12 @@ function defaultCollabUrl(itemID: string): string {
 		throw new Error('CollabProvider: cannot derive URL outside the browser');
 	}
 	const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
-	return `${proto}//${location.host}/api/v1/collab/${encodeURIComponent(itemID)}`;
+	// Always announce the client's SCHEMA_VERSION (TASK-1268). The
+	// server validates this BEFORE upgrading the WebSocket; a
+	// mismatch returns an HTTP 400 so the user sees a real error
+	// rather than a silently-degraded session. The server also uses
+	// the per-item rebuild path internally if any persisted op-log
+	// rows are stamped with an older version.
+	const params = new URLSearchParams({ schema_version: SCHEMA_VERSION });
+	return `${proto}//${location.host}/api/v1/collab/${encodeURIComponent(itemID)}?${params.toString()}`;
 }


### PR DESCRIPTION
## Summary
- Client announces \`SCHEMA_VERSION\` on every WS connect via \`?schema_version=...\`; server validates against \`RoomManager.SchemaVersion()\` before upgrading; mismatch → 400 \`schema_mismatch\`
- New \`web/src/lib/collab/schemaVersion.ts\` with documented bump rule
- \`RoomManager.Join\` setup-phase prunes the per-item op-log when the latest persisted row's \`schema_version\` disagrees with the manager's; items.content is canonical so the lazy-seed path (TASK-1261) re-encodes it into ops at the new schema
- New store method \`LatestYjsUpdateSchemaVersion\`
- Empty query coerces to legacy \`'1'\` for graceful deploys; will become a hard 400 on the first server bump past v1

Closes TASK-1268.

## Test plan
- [x] \`go test ./internal/collab\` and \`./internal/server\` pass
- [x] Three new manager tests: mismatch-prunes / clean-version-preserves / post-rebuild-clean
- [x] Two new handler tests: rejects-schema-mismatch (400) / accepts-explicit-match (101)
- [x] \`make check\` passes

## Codex review
- Round 1: CLEAN with two NITs (RoomCount-based polling barrier in test was non-deterministic; doc-comment got split by inserted tests) — both fixed.