### PR TITLE
docs: collab adds no container deps + PLAN-1248 cleanup (TASK-1272)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -270,6 +270,16 @@ binary protocol). The relevant code lives in:
 - `web/src/lib/collab/wsProvider.svelte.ts` — client provider
 - `web/src/lib/collab/schemaVersion.ts` — client schema-version stamp
 
+**Collab requires no additional container deps; the single Go binary
+remains the self-hosted shape.** The dumb-relay design (server
+persists raw Yjs binary updates without parsing them) means there's
+no Yjs Go port to vendor and no separate sync-server process to run.
+The op-log lives in the same SQLite/Postgres as everything else, and
+the WebSocket relay is part of the main HTTP listener. Multi-instance
+Redis fanout is deliberately out of scope for v1 (single-instance
+everywhere); when horizontal scaling is needed it lands as a separate
+IDEA, not a self-host complication.
+
 ### Tiptap multi-package coordinated bumps
 
 The Y.Doc/ProseMirror schema is shared across three Tiptap packages:


### PR DESCRIPTION
## Summary
Documentation-only:
- CLAUDE.md \"Real-time collaboration\" section now states that the dumb-relay design preserves the single-Go-binary self-hosted shape (no Yjs Go port, no separate sync server, no Redis)
- Verified \`web/src/routes/dev/yjs-sandbox/\` does NOT exist on main — it was spike-only on \`feat/yjs-tiptap-spike\` and was deliberately not cherry-picked into productionization work
- Audited \`web/package.json\`: every yjs / tiptap / y-protocols dep is consumed by production code

The \`feat/yjs-tiptap-spike\` branch can now be deleted; productionization is complete.

Closes TASK-1272.

## Test plan
- [x] \`make check\` passes (no behaviour change)