### PR TITLE
feat(collab): periodic op-log GC sweeper (TASK-1309)

### DIFF
--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -659,6 +659,18 @@ func serveCmd() *cobra.Command {
 			srv.SetCollabRoomManager(collab.NewRoomManager(s, collabBus))
 			slog.Info("Collab room manager wired (Yjs over /api/v1/collab/{itemID})")
 
+			// Op-log prune sweeper (TASK-1309). Periodic background
+			// loop that deletes Yjs op-log rows older than minAge.
+			// Defaults: 1h interval, 24h minAge — both override-able
+			// via env (PAD_OPLOG_GC_INTERVAL=5m for tests where you
+			// want to see the sweep land within a CI run, etc.).
+			oplogGCInterval := parseDurationEnv("PAD_OPLOG_GC_INTERVAL", 0)
+			oplogGCMinAge := parseDurationEnv("PAD_OPLOG_GC_MIN_AGE", 0)
+			if oplogGCInterval != 0 || oplogGCMinAge != 0 {
+				srv.SetOpLogGCConfig(oplogGCInterval, oplogGCMinAge)
+			}
+			srv.StartOpLogGC()
+
 			// Attach webhook dispatcher for outgoing notifications
 			srv.SetWebhookDispatcher(webhooks.NewDispatcher(s))
 

--- a/internal/collab/manager.go
+++ b/internal/collab/manager.go
@@ -243,14 +243,54 @@ var distantFuture = time.Date(9999, 1, 1, 0, 0, 0, 0, time.UTC)
 // Returns nil on the no-rows path and on the matched-version path —
 // both are "nothing to do". A real DB error from either step short-
 // circuits Join with the same error so the WS upgrade fails loudly.
+//
+// **Data loss disclosure.** When the latest op-log row's id exceeds
+// `items.content_flushed_op_log_id` for the item (i.e. unflushed
+// edits exist), the prune is unrecoverable: those ops are stamped
+// with the OLD schema and can't be replayed against the new schema
+// regardless of where they're stored. Lazy-seed (TASK-1261) will
+// repopulate the Y.Doc from items.content, which is stale relative
+// to the unflushed ops. We log a warn so operators see when a
+// schema bump is dropping unsaved client edits. Per Codex review of
+// TASK-1309 round 4 [P2].
 func (m *RoomManager) maybeRebuildOnSchemaMismatch(itemID string) error {
-	latest, ok, err := m.store.LatestYjsUpdateSchemaVersion(itemID)
+	latest, latestID, ok, err := m.store.LatestYjsUpdateSchemaVersion(itemID)
 	if err != nil {
 		return err
 	}
 	if !ok || latest == m.schemaVersion {
 		return nil
 	}
+
+	// Pre-prune watermark check. Unflushed ops would be lost; we
+	// can't avoid the loss (old-schema ops can't migrate forward),
+	// but we surface it.
+	flushedID, flushedOK, err := m.store.GetItemContentFlushedOpLogID(itemID)
+	if err != nil {
+		// Watermark read failed — proceed with the prune (we still
+		// have to: the schema-mismatch case is non-negotiable) but
+		// log the failure separately.
+		slog.Warn("collab: schema-mismatch rebuild: watermark read failed",
+			"item_id", itemID,
+			"error", err,
+		)
+	} else if !flushedOK || latestID > flushedID {
+		// flushedOK==false → never flushed, every op is unflushed.
+		// latestID > flushedID → some ops past the watermark.
+		// We can't avoid the prune here (old-schema ops can't replay
+		// in the new schema regardless of where they're stored), but
+		// the WARN tells operators a schema bump dropped some
+		// unsaved client edits — they may want to investigate which
+		// items were affected and contact the affected users.
+		// Per Codex review of TASK-1309 round 4 [P2].
+		slog.Warn("collab: schema-mismatch rebuild will drop unflushed ops",
+			"item_id", itemID,
+			"latest_op_log_id", latestID,
+			"content_flushed_op_log_id", flushedID,
+			"watermark_set", flushedOK,
+		)
+	}
+
 	pruned, err := m.store.PruneYjsUpdatesBefore(itemID, distantFuture)
 	if err != nil {
 		return err
@@ -262,6 +302,149 @@ func (m *RoomManager) maybeRebuildOnSchemaMismatch(itemID string) error {
 		"rows_pruned", pruned,
 	)
 	return nil
+}
+
+// DefaultPruneMinAge is the floor age for op-log dormancy in the
+// periodic prune sweeper (TASK-1309). An item must have NO op-log
+// rows newer than `now - minAge` to be eligible. 24 hours covers
+// every realistic mobile-suspend / network-blip / lock-screen
+// interval and leaves headroom for travel-on-flaky-wifi reconnects.
+//
+// Pass `0` (or any non-positive value) to PruneSweep to fall back
+// to this default.
+const DefaultPruneMinAge = 24 * time.Hour
+
+// PruneSweepResult records what one PruneSweep accomplished. Surfaced
+// to the server-level periodic ticker so it can log a one-line
+// summary per sweep.
+type PruneSweepResult struct {
+	// ItemsScanned: items returned by the dormancy query at sweep
+	// start. Some of these may turn out to be non-dormant by the
+	// time we acquire their per-item lock and run the conditional
+	// delete; those count toward ItemsSkipped, not ItemsPruned.
+	ItemsScanned int
+	// ItemsPruned: items where the conditional DELETE actually
+	// removed rows (i.e. confirmed dormant under the lock).
+	ItemsPruned int
+	// ItemsSkipped: items that became non-dormant between the
+	// candidate query and the conditional DELETE (a peer reconnected
+	// and wrote a row), or that were skipped because an active
+	// in-memory Room exists (covers the grace-TTL window after the
+	// last peer disconnected).
+	ItemsSkipped int
+	// RowsPruned: total rows deleted across all pruned items.
+	RowsPruned int64
+	// Errors: per-item prune failures. Sweep continues past errors
+	// so a single broken item doesn't block GC for the whole table.
+	Errors int
+}
+
+// PruneSweep finds every item whose ENTIRE op-log is older than
+// `minAge` and prunes the whole op-log for those items under the
+// per-item lock. Returns a summary.
+//
+// **Why whole-log only.** Yjs op streams are causally linked: a
+// recent op can reference structs created in older ops. Prefix-
+// pruning (delete old rows, keep recent) corrupts replay because
+// the suffix's references can't be resolved. Per Codex review of
+// the original TASK-1309 [P1]. Whole-log prune is safe because the
+// next cold connect lazy-seeds from items.content (TASK-1261),
+// producing a fresh self-consistent Y.Doc.
+//
+// `minAge` is the minimum age of the NEWEST op-log row for an item
+// to be considered dormant. Pass 0 to use DefaultPruneMinAge.
+//
+// Coordination:
+//   - Per-item lock matches the lock Join takes for its addConn +
+//     replayTo critical section; a fresh peer can't race the
+//     prune-then-replay sequence.
+//   - In-memory active Room check before the prune skips items
+//     where peers are still attached (the grace-TTL window after
+//     the last conn dropped also counts as "active" — the room
+//     could come back via grace-cancel-on-reconnect).
+//   - Conditional DELETE in the store re-checks dormancy
+//     atomically. If a row was appended between the candidate
+//     query and the DELETE (e.g. a sneaky readLoop write under
+//     appendMu), the DELETE deletes nothing.
+//
+// Per TASK-1309 (PLAN-1248).
+func (m *RoomManager) PruneSweep(minAge time.Duration) (PruneSweepResult, error) {
+	var res PruneSweepResult
+
+	if minAge <= 0 {
+		minAge = DefaultPruneMinAge
+	}
+	cutoff := time.Now().Add(-minAge)
+
+	items, err := m.store.ListDormantOpLogItemsBefore(cutoff)
+	if err != nil {
+		return res, err
+	}
+	res.ItemsScanned = len(items)
+
+	for _, itemID := range items {
+		// Bail early if Close has fired — no point pruning a
+		// store the manager is winding down.
+		m.mu.Lock()
+		closed := m.closed
+		hasRoom := m.rooms[itemID] != nil
+		m.mu.Unlock()
+		if closed {
+			return res, nil
+		}
+		if hasRoom {
+			// Active Room (or grace-TTL pending). Skip — the
+			// next sweep can pick this item up if the room
+			// goes idle by then. Active rooms naturally accrue
+			// new op-log rows that would defeat dormancy
+			// anyway; skipping here is just a fast-path before
+			// taking the per-item lock.
+			res.ItemsSkipped++
+			continue
+		}
+
+		lock := m.itemLock(itemID)
+		lock.Lock()
+
+		// Re-check active room under the lock. A Join could have
+		// raced between our outer check and this lock acquisition;
+		// the lock now serialises us against any in-flight Join's
+		// addConn+replayTo, but a Join that has already created
+		// the Room and released the lock could have left m.rooms
+		// non-nil. (Joins hold the lock across replay; once
+		// released, the room is live.)
+		m.mu.Lock()
+		hasRoom = m.rooms[itemID] != nil
+		m.mu.Unlock()
+		if hasRoom {
+			lock.Unlock()
+			res.ItemsSkipped++
+			continue
+		}
+
+		// Conditional DELETE: deletes everything for itemID iff
+		// no row >= cutoff exists. n=0 means a recent row was
+		// appended between the candidate query and now; that's
+		// fine, just a skip.
+		n, err := m.store.PruneItemOpLogIfDormantBefore(itemID, cutoff)
+		lock.Unlock()
+
+		if err != nil {
+			slog.Warn("collab: prune sweep: per-item prune failed",
+				"item_id", itemID,
+				"error", err,
+			)
+			res.Errors++
+			continue
+		}
+		if n == 0 {
+			res.ItemsSkipped++
+			continue
+		}
+		res.RowsPruned += n
+		res.ItemsPruned++
+	}
+	return res, nil
 }
 
 // runConn drives one connection through its full lifecycle: spawn

--- a/internal/collab/manager_test.go
+++ b/internal/collab/manager_test.go
@@ -2,6 +2,7 @@ package collab
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -23,6 +24,26 @@ type fakeOpLog struct {
 	nextID  int64
 	failOn  string // if non-empty, AppendYjsUpdate returns this as an error message for any row
 	appendN int
+
+	// contentFlushedIDs simulates the items.content_flushed_op_log_id
+	// watermark per item (TASK-1309 round 4). Tests populate this
+	// to exercise the schema-mismatch + sweeper paths that consult
+	// it. Missing key = NULL watermark = "never flushed".
+	contentFlushedIDs map[string]int64
+
+	// onListDormantHook fires once per call to
+	// ListDormantOpLogItemsBefore, AFTER the listing scan but BEFORE
+	// the result is returned to the caller. Used by tests that
+	// simulate a row being appended in the race window between
+	// "candidate query returns" and "PruneItemOpLogIfDormantBefore
+	// runs under the per-item lock". The hook receives the locked
+	// store so it can mutate rows directly. nil = no-op.
+	//
+	// Per Codex review of TASK-1309 round 2 NIT:
+	// TestPruneSweepSkipsRowAddedMidSweep wasn't actually exercising
+	// the conditional-DELETE path because it inserted the recent row
+	// before the listing query.
+	onListDormantHook func(f *fakeOpLog)
 }
 
 func (f *fakeOpLog) AppendYjsUpdate(itemID string, data []byte, schemaVersion string) (int64, error) {
@@ -59,19 +80,32 @@ func (f *fakeOpLog) LoadYjsUpdatesSince(itemID string, sinceID int64) ([]models.
 }
 
 // LatestYjsUpdateSchemaVersion mirrors the production store: returns
-// the most recent op-log row's schema_version for an item, or
+// the most recent op-log row's schema_version AND id for an item, or
 // (false) when no rows exist. The fake walks rows[] in append order
 // and returns the latest matching entry — same semantic as the
 // store's `ORDER BY id DESC LIMIT 1`.
-func (f *fakeOpLog) LatestYjsUpdateSchemaVersion(itemID string) (string, bool, error) {
+func (f *fakeOpLog) LatestYjsUpdateSchemaVersion(itemID string) (string, int64, bool, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	for i := len(f.rows) - 1; i >= 0; i-- {
 		if f.rows[i].ItemID == itemID {
-			return f.rows[i].SchemaVersion, true, nil
+			return f.rows[i].SchemaVersion, f.rows[i].ID, true, nil
 		}
 	}
-	return "", false, nil
+	return "", 0, false, nil
+}
+
+// GetItemContentFlushedOpLogID returns the per-item watermark as
+// configured by the test via fakeOpLog.contentFlushedIDs (a map
+// itemID → id). Missing key = NULL watermark, returned as (0, false).
+func (f *fakeOpLog) GetItemContentFlushedOpLogID(itemID string) (int64, bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.contentFlushedIDs == nil {
+		return 0, false, nil
+	}
+	v, ok := f.contentFlushedIDs[itemID]
+	return v, ok, nil
 }
 
 // PruneYjsUpdatesBefore deletes every row for itemID whose CreatedAt
@@ -91,6 +125,64 @@ func (f *fakeOpLog) PruneYjsUpdatesBefore(itemID string, before time.Time) (int6
 	}
 	f.rows = kept
 	return pruned, nil
+}
+
+// ListDormantOpLogItemsBefore returns item_ids whose entire op-log
+// is older than the cutoff. Mirrors the production store's
+// `GROUP BY item_id HAVING MAX(created_at) < ?`. The fake doesn't
+// model the items.content_flushed_op_log_id watermark — tests that need it
+// run against the real store via the server-level GC test.
+func (f *fakeOpLog) ListDormantOpLogItemsBefore(before time.Time) ([]string, error) {
+	f.mu.Lock()
+	// Compute MAX(created_at) per item_id; collect items where MAX < cutoff.
+	maxByItem := map[string]time.Time{}
+	for _, r := range f.rows {
+		if cur, ok := maxByItem[r.ItemID]; !ok || r.CreatedAt.After(cur) {
+			maxByItem[r.ItemID] = r.CreatedAt
+		}
+	}
+	var ids []string
+	for id, mx := range maxByItem {
+		if mx.Before(before) {
+			ids = append(ids, id)
+		}
+	}
+	hook := f.onListDormantHook
+	f.mu.Unlock()
+	// Fire the test hook (if any) AFTER the listing has been
+	// computed but BEFORE returning, simulating a row appended in
+	// the candidate-query→DELETE race window.
+	if hook != nil {
+		hook(f)
+	}
+	return ids, nil
+}
+
+// PruneItemOpLogIfDormantBefore atomically deletes every row for
+// itemID iff no row exists with CreatedAt >= cutoff. Returns the
+// count deleted.
+func (f *fakeOpLog) PruneItemOpLogIfDormantBefore(itemID string, before time.Time) (int64, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	// First pass: is the item still dormant?
+	for _, r := range f.rows {
+		if r.ItemID == itemID && !r.CreatedAt.Before(before) {
+			// A recent row exists — abort, don't delete anything.
+			return 0, nil
+		}
+	}
+	// Second pass: delete every row for this item.
+	kept := f.rows[:0]
+	var deleted int64
+	for _, r := range f.rows {
+		if r.ItemID == itemID {
+			deleted++
+			continue
+		}
+		kept = append(kept, r)
+	}
+	f.rows = kept
+	return deleted, nil
 }
 
 func (f *fakeOpLog) appendCount() int {
@@ -721,4 +813,295 @@ func TestRoomManagerSchemaPostRebuildClean(t *testing.T) {
 	}
 
 	c1.Close()
+}
+
+// TestPruneSweepRemovesDormantItems is the TASK-1309 happy-path test:
+// a sweep finds items whose entire op-log is older than minAge and
+// prunes them whole. Items with ANY recent activity are preserved
+// completely (no prefix-pruning — Yjs causal references would break
+// per the Codex P1 finding).
+func TestPruneSweepRemovesDormantItems(t *testing.T) {
+	bus := NewMemoryOpBus()
+	defer bus.Close()
+
+	store := &fakeOpLog{}
+	mgr := NewRoomManager(store, bus)
+	defer mgr.Close()
+
+	// Item A: two old rows + one fresh row → mixed, NOT dormant.
+	// Whole-log prune is unsafe here (suffix references prefix
+	// structs in real Yjs). All three rows must survive.
+	now := time.Now()
+	store.mu.Lock()
+	store.rows = append(store.rows,
+		fakeYjsRow("item-a", []byte{yMessageSync, 0x01}, "1", now.Add(-48*time.Hour)),
+		fakeYjsRow("item-a", []byte{yMessageSync, 0x02}, "1", now.Add(-30*time.Hour)),
+		fakeYjsRow("item-a", []byte{yMessageSync, 0x03}, "1", now.Add(-1*time.Hour)),
+	)
+	// Item B: one fresh row → not dormant. Survives.
+	store.rows = append(store.rows,
+		fakeYjsRow("item-b", []byte{yMessageSync, 0x04}, "1", now.Add(-2*time.Hour)),
+	)
+	// Item C: two old rows, no recent activity → DORMANT. Whole
+	// op-log gets pruned; cold reconnect lazy-seeds from
+	// items.content (TASK-1261).
+	store.rows = append(store.rows,
+		fakeYjsRow("item-c", []byte{yMessageSync, 0x05}, "1", now.Add(-72*time.Hour)),
+		fakeYjsRow("item-c", []byte{yMessageSync, 0x06}, "1", now.Add(-50*time.Hour)),
+	)
+	store.mu.Unlock()
+
+	res, err := mgr.PruneSweep(24 * time.Hour)
+	if err != nil {
+		t.Fatalf("PruneSweep: %v", err)
+	}
+
+	// Only item-c is dormant (MAX(created_at) < cutoff).
+	if got := res.ItemsScanned; got != 1 {
+		t.Errorf("ItemsScanned: want 1 (only c is dormant), got %d", got)
+	}
+	if got := res.ItemsPruned; got != 1 {
+		t.Errorf("ItemsPruned: want 1, got %d", got)
+	}
+	if got := res.RowsPruned; got != 2 {
+		t.Errorf("RowsPruned: want 2 (c's whole op-log), got %d", got)
+	}
+	if got := res.Errors; got != 0 {
+		t.Errorf("Errors: want 0, got %d", got)
+	}
+
+	// Surviving rows: item-a's three + item-b's one. item-c gone.
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	if got := len(store.rows); got != 4 {
+		t.Fatalf("after prune: want 4 surviving rows (3 from item-a + 1 from item-b), got %d", got)
+	}
+	byItem := map[string]int{}
+	for _, r := range store.rows {
+		byItem[r.ItemID]++
+	}
+	if byItem["item-a"] != 3 {
+		t.Errorf("item-a: want 3 surviving rows (whole-log preserved because non-dormant), got %d", byItem["item-a"])
+	}
+	if byItem["item-b"] != 1 {
+		t.Errorf("item-b: want 1 surviving row, got %d", byItem["item-b"])
+	}
+	if byItem["item-c"] != 0 {
+		t.Errorf("item-c: want 0 surviving rows (dormant, whole-log pruned), got %d", byItem["item-c"])
+	}
+}
+
+// TestPruneSweepDefaultMinAge verifies that passing minAge=0 falls
+// back to DefaultPruneMinAge rather than treating the cutoff as
+// "now" (which would prune every row in the table).
+func TestPruneSweepDefaultMinAge(t *testing.T) {
+	bus := NewMemoryOpBus()
+	defer bus.Close()
+
+	store := &fakeOpLog{}
+	mgr := NewRoomManager(store, bus)
+	defer mgr.Close()
+
+	// One row, 1 hour old. With DefaultPruneMinAge=24h this row
+	// should be PRESERVED. If the implementation accidentally used
+	// `time.Now()` as the cutoff, the row would be deleted.
+	now := time.Now()
+	store.mu.Lock()
+	store.rows = append(store.rows,
+		fakeYjsRow("item-a", []byte{yMessageSync, 0x01}, "1", now.Add(-1*time.Hour)),
+	)
+	store.mu.Unlock()
+
+	res, err := mgr.PruneSweep(0)
+	if err != nil {
+		t.Fatalf("PruneSweep: %v", err)
+	}
+	if res.RowsPruned != 0 {
+		t.Errorf("with default minAge, 1-hour-old row should survive; got RowsPruned=%d", res.RowsPruned)
+	}
+	if got := store.rowCount(); got != 1 {
+		t.Errorf("rows after sweep: want 1, got %d", got)
+	}
+}
+
+// TestPruneSweepEmpty handles the no-eligible-rows case cleanly.
+func TestPruneSweepEmpty(t *testing.T) {
+	bus := NewMemoryOpBus()
+	defer bus.Close()
+
+	store := &fakeOpLog{}
+	mgr := NewRoomManager(store, bus)
+	defer mgr.Close()
+
+	res, err := mgr.PruneSweep(24 * time.Hour)
+	if err != nil {
+		t.Fatalf("PruneSweep: %v", err)
+	}
+	if res.ItemsScanned != 0 || res.RowsPruned != 0 || res.Errors != 0 {
+		t.Errorf("empty store should produce zero counters, got %+v", res)
+	}
+}
+
+// TestPruneSweepBailsOnClose ensures a sweep mid-loop respects a
+// concurrent Close — once the manager is closed, the sweep stops
+// iterating remaining items rather than continuing to touch a
+// torn-down store.
+func TestPruneSweepBailsOnClose(t *testing.T) {
+	bus := NewMemoryOpBus()
+	defer bus.Close()
+
+	store := &fakeOpLog{}
+	mgr := NewRoomManager(store, bus)
+
+	now := time.Now()
+	store.mu.Lock()
+	for i := 0; i < 10; i++ {
+		itemID := fmt.Sprintf("item-%d", i)
+		store.rows = append(store.rows,
+			fakeYjsRow(itemID, []byte{yMessageSync, byte(i)}, "1", now.Add(-48*time.Hour)),
+		)
+	}
+	store.mu.Unlock()
+
+	// Pre-close the manager: the sweep should bail on the first
+	// per-item iteration. Close() runs synchronously here so the
+	// closed flag is set before PruneSweep starts.
+	mgr.Close()
+
+	res, err := mgr.PruneSweep(24 * time.Hour)
+	if err != nil {
+		t.Fatalf("PruneSweep: %v", err)
+	}
+	// ItemsScanned reflects the initial query (which ran before
+	// the closed-flag check), but no items should have been
+	// pruned because the per-item loop bailed immediately.
+	if res.ItemsScanned != 10 {
+		t.Errorf("ItemsScanned: want 10 (query ran), got %d", res.ItemsScanned)
+	}
+	if res.RowsPruned != 0 {
+		t.Errorf("RowsPruned after Close: want 0, got %d", res.RowsPruned)
+	}
+}
+
+// TestPruneSweepSkipsActiveRoom verifies the dormant-item check
+// honours an in-memory active Room — even if the database query
+// returned the item as dormant, an existing Room means we shouldn't
+// prune. (Active rooms can buffer awareness state, hold a grace
+// timer, etc.; a fresh peer reconnecting via grace would expect to
+// find the prior op-log intact.)
+func TestPruneSweepSkipsActiveRoom(t *testing.T) {
+	bus := NewMemoryOpBus()
+	defer bus.Close()
+
+	store := &fakeOpLog{}
+	mgr := NewRoomManager(store, bus)
+	defer mgr.Close()
+
+	// Seed one dormant item.
+	now := time.Now()
+	store.mu.Lock()
+	store.rows = append(store.rows,
+		fakeYjsRow("item-a", []byte{yMessageSync, 0x01}, "1", now.Add(-48*time.Hour)),
+	)
+	store.mu.Unlock()
+
+	// Create a room for item-a directly. We don't need a real WS;
+	// just having the entry in m.rooms is enough to trigger the
+	// active-room skip.
+	mgr.mu.Lock()
+	mgr.rooms["item-a"] = &Room{
+		itemID: "item-a",
+		store:  store,
+		bus:    bus,
+		conns:  make(map[*websocket.Conn]*roomConn),
+	}
+	mgr.mu.Unlock()
+
+	res, err := mgr.PruneSweep(24 * time.Hour)
+	if err != nil {
+		t.Fatalf("PruneSweep: %v", err)
+	}
+
+	if res.ItemsPruned != 0 {
+		t.Errorf("ItemsPruned: want 0 (active room blocks prune), got %d", res.ItemsPruned)
+	}
+	if res.ItemsSkipped != 1 {
+		t.Errorf("ItemsSkipped: want 1 (item-a skipped due to active room), got %d", res.ItemsSkipped)
+	}
+	if got := store.rowCount(); got != 1 {
+		t.Errorf("rows after sweep: want 1 (active room preserved), got %d", got)
+	}
+}
+
+// TestPruneSweepSkipsRowAddedMidSweep exercises the mid-sweep race
+// window: the dormancy listing returns item-a (it WAS dormant at
+// query time), but a row gets appended before PruneItemOpLogIfDormantBefore
+// runs under the per-item lock. The conditional DELETE in the store
+// must re-check dormancy at SQL level and refuse to delete.
+//
+// We simulate the race via the onListDormantHook on fakeOpLog,
+// which fires after the listing is computed but before
+// PruneSweep iterates. The hook injects a recent row that the
+// candidate-list already committed to but that the conditional
+// DELETE must catch.
+//
+// Per Codex review of TASK-1309 round 2 NIT.
+func TestPruneSweepSkipsRowAddedMidSweep(t *testing.T) {
+	bus := NewMemoryOpBus()
+	defer bus.Close()
+
+	store := &fakeOpLog{}
+	mgr := NewRoomManager(store, bus)
+	defer mgr.Close()
+
+	// Seed a single old row → item-a IS dormant at query time.
+	now := time.Now()
+	store.mu.Lock()
+	store.rows = append(store.rows,
+		fakeYjsRow("item-a", []byte{yMessageSync, 0x01}, "1", now.Add(-48*time.Hour)),
+	)
+	// Inject a recent row in the race window — listing already
+	// computed, but per-item DELETE hasn't run yet.
+	store.onListDormantHook = func(f *fakeOpLog) {
+		f.mu.Lock()
+		f.rows = append(f.rows,
+			fakeYjsRow("item-a", []byte{yMessageSync, 0x02}, "1", now.Add(-1*time.Hour)),
+		)
+		f.mu.Unlock()
+	}
+	store.mu.Unlock()
+
+	res, err := mgr.PruneSweep(24 * time.Hour)
+	if err != nil {
+		t.Fatalf("PruneSweep: %v", err)
+	}
+
+	// item-a was returned by the listing (1 candidate scanned),
+	// but the conditional DELETE saw the newly-appended row and
+	// refused. Expect 1 scanned, 0 pruned, 1 skipped.
+	if res.ItemsScanned != 1 {
+		t.Errorf("ItemsScanned: want 1 (listing saw dormant item), got %d", res.ItemsScanned)
+	}
+	if res.ItemsPruned != 0 {
+		t.Errorf("ItemsPruned: want 0 (conditional DELETE refused), got %d", res.ItemsPruned)
+	}
+	if res.ItemsSkipped != 1 {
+		t.Errorf("ItemsSkipped: want 1 (DELETE returned 0 rows), got %d", res.ItemsSkipped)
+	}
+	if got := store.rowCount(); got != 2 {
+		t.Errorf("rows after sweep: want 2 (both preserved), got %d", got)
+	}
+}
+
+// fakeYjsRow constructs a single row for the fakeOpLog seeding helpers.
+// The store assigns ids in production; tests don't depend on them.
+func fakeYjsRow(itemID string, data []byte, schemaVersion string, createdAt time.Time) models.YjsUpdate {
+	cp := make([]byte, len(data))
+	copy(cp, data)
+	return models.YjsUpdate{
+		ItemID:        itemID,
+		UpdateData:    cp,
+		SchemaVersion: schemaVersion,
+		CreatedAt:     createdAt.UTC(),
+	}
 }

--- a/internal/collab/room.go
+++ b/internal/collab/room.go
@@ -118,9 +118,24 @@ type opLogStore interface {
 	// schema-mismatch rebuild flow (TASK-1268). The room manager
 	// checks the most recent op-log row's stamp on Join and prunes
 	// the entire item's op-log when the persisted version no longer
-	// matches the server's current SCHEMA_VERSION.
-	LatestYjsUpdateSchemaVersion(itemID string) (string, bool, error)
+	// matches the server's current SCHEMA_VERSION. The latest row's
+	// id is returned alongside the version so the rebuild can detect
+	// when it's about to drop unflushed edits and log a warning.
+	LatestYjsUpdateSchemaVersion(itemID string) (string, int64, bool, error)
 	PruneYjsUpdatesBefore(itemID string, before time.Time) (int64, error)
+	// GetItemContentFlushedOpLogID returns the per-item flush
+	// watermark (TASK-1309). Returns (0, false) for items with NULL
+	// watermark or no row.
+	GetItemContentFlushedOpLogID(itemID string) (int64, bool, error)
+	// ListDormantOpLogItemsBefore + PruneItemOpLogIfDormantBefore
+	// power the periodic prune sweep (TASK-1309). Selects items
+	// whose ENTIRE op-log is older than cutoff AND whose
+	// items.content has captured every op-log row (id watermark);
+	// conditional DELETE re-checks dormancy atomically. See
+	// yjs_updates.go for why prefix-pruning is unsafe (Yjs causal
+	// references).
+	ListDormantOpLogItemsBefore(before time.Time) ([]string, error)
+	PruneItemOpLogIfDormantBefore(itemID string, before time.Time) (int64, error)
 }
 
 // addConn registers a freshly-built roomConn with the room. Cancels

--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -519,7 +519,18 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 	// `source IN ('cli', 'mcp')` filter just because the user
 	// happened to open the editor and trigger a 5s auto-flush. Per
 	// Codex round 3 of TASK-1267 [P2].
-	if collabSnapshot && input.VersionSource == "" {
+	//
+	// **Force-override** when the query param is set, even if the
+	// body sent a different VersionSource. Otherwise a buggy or
+	// malicious client could send `?source=collab-snapshot` (which
+	// triggers the applier-bypass) with `"version_source":"cli"`
+	// in the body, sneaking a stale browser snapshot through the
+	// op-log GC watermark check (TASK-1309 round 5 [P1] keys on
+	// VersionSource to gate watermark advancement). The query
+	// param is the trustworthy server-side signal; the body
+	// VersionSource is client-attacker-controlled. Per Codex round
+	// 6 of TASK-1309 [P2].
+	if collabSnapshot {
 		input.VersionSource = "collab-snapshot"
 	}
 

--- a/internal/server/handlers_items_collab_versions_test.go
+++ b/internal/server/handlers_items_collab_versions_test.go
@@ -140,6 +140,77 @@ func TestCollabSnapshotHTTPSourceStamping(t *testing.T) {
 	}
 }
 
+// TestCollabSnapshotQueryOverridesBodyVersionSource is the TASK-1309
+// round-6 [P2] regression: a `?source=collab-snapshot` query MUST
+// override any `version_source` field in the PATCH body. Otherwise
+// a buggy/malicious client could send the query (which triggers
+// the applier-bypass path and reaches Store.UpdateItem directly)
+// with `version_source: "cli"` in the body, sneaking a stale
+// browser snapshot through the op-log GC watermark policy
+// (TASK-1309 round 5 only advances the watermark when
+// VersionSource != "collab-snapshot").
+//
+// We assert the version row's Source column is "collab-snapshot"
+// even when the body claims something else.
+func TestCollabSnapshotQueryOverridesBodyVersionSource(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	rr := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections/tasks/items", map[string]interface{}{
+		"title":   "Override test",
+		"content": "v1",
+		"source":  "cli",
+		"fields":  `{"status":"open"}`,
+	})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create: %d %s", rr.Code, rr.Body.String())
+	}
+	var created models.Item
+	parseJSON(t, rr, &created)
+
+	time.Sleep(1100 * time.Millisecond)
+
+	// PATCH with the dangerous combo: query says collab-snapshot,
+	// body claims version_source=cli (which would otherwise sneak
+	// past the gate and advance the watermark).
+	rr = doRequest(srv, "PATCH",
+		"/api/v1/workspaces/"+slug+"/items/"+created.Slug+"?source=collab-snapshot",
+		map[string]interface{}{
+			"content":        "v2",
+			"version_source": "cli", // attacker / buggy override
+		},
+	)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("PATCH: %d %s", rr.Code, rr.Body.String())
+	}
+
+	// The version row written for this PATCH must record source as
+	// "collab-snapshot" — the query-param signal wins.
+	rr = doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/items/"+created.Slug+"/versions", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("list versions: %d", rr.Code)
+	}
+	var versions []models.Version
+	parseJSON(t, rr, &versions)
+
+	var foundCollabRow bool
+	for _, v := range versions {
+		if v.Source == "collab-snapshot" {
+			foundCollabRow = true
+			break
+		}
+	}
+	if !foundCollabRow {
+		t.Errorf(
+			"query-param `?source=collab-snapshot` must override body "+
+				"`version_source`; got version sources: %v. The body "+
+				"claimed cli but the trusted query param said "+
+				"collab-snapshot, which is the GC-safe attribution.",
+			sourcesOf(versions),
+		)
+	}
+}
+
 func sourcesOf(versions []models.Version) []string {
 	out := make([]string, 0, len(versions))
 	for _, v := range versions {

--- a/internal/server/oplog_gc.go
+++ b/internal/server/oplog_gc.go
@@ -1,0 +1,145 @@
+package server
+
+import (
+	"log/slog"
+	"sync"
+	"time"
+)
+
+// Default knobs for the periodic Yjs op-log prune sweeper (TASK-1309).
+// Operators override via env vars wired in cmd/pad/main.go.
+//
+//   - Interval: how often the sweep runs. 1 hour balances "responsive
+//     cleanup" against "negligible overhead". A long-lived item that
+//     hasn't been edited in days won't see its op-log grow further,
+//     so a slow sweep is fine.
+//   - MinAge: minimum age of an op-log row before it's eligible for
+//     pruning. 24 hours covers every realistic disconnect-and-reconnect
+//     window (mobile suspend, lock-screen, travel-on-flaky-wifi). Rows
+//     younger than this stay so a peer that just dropped can replay
+//     normally on reconnect.
+const (
+	defaultOpLogGCInterval = 1 * time.Hour
+	defaultOpLogGCMinAge   = 24 * time.Hour
+)
+
+// opLogGCConfig captures the runtime knobs for the periodic loop.
+// Stored on Server via SetOpLogGCConfig so cmd/pad and tests can
+// override defaults independently. Mirrors the structure of
+// orphanGCConfig (TASK-886) — same lifecycle pattern, separate
+// goroutine, separate stop channel.
+type opLogGCConfig struct {
+	mu       sync.Mutex
+	interval time.Duration
+	minAge   time.Duration
+	stop     chan struct{}
+	running  bool
+}
+
+// SetOpLogGCConfig overrides the default sweep interval (1h) and
+// minimum row age (24h). Pass 0 for either to keep the package
+// default. Must be called before StartOpLogGC; calling after the
+// loop has started silently no-ops since the goroutine captured the
+// values at start.
+func (s *Server) SetOpLogGCConfig(interval, minAge time.Duration) {
+	s.opLogGC.mu.Lock()
+	defer s.opLogGC.mu.Unlock()
+	if interval > 0 {
+		s.opLogGC.interval = interval
+	}
+	if minAge > 0 {
+		s.opLogGC.minAge = minAge
+	}
+}
+
+// StartOpLogGC kicks off the periodic prune-sweep loop. Idempotent —
+// calling twice silently no-ops. Must be called AFTER
+// SetCollabRoomManager; the loop checks for a wired room manager
+// before each tick and just returns if collab isn't enabled, so a
+// no-collab build is safe.
+//
+// The loop is tracked by Server.bg so Stop() drains it before the
+// process exits / SQLite is closed (BUG-842 invariant — same
+// reasoning as orphan GC).
+func (s *Server) StartOpLogGC() {
+	s.opLogGC.mu.Lock()
+	if s.opLogGC.running {
+		s.opLogGC.mu.Unlock()
+		return
+	}
+	if s.opLogGC.interval == 0 {
+		s.opLogGC.interval = defaultOpLogGCInterval
+	}
+	if s.opLogGC.minAge == 0 {
+		s.opLogGC.minAge = defaultOpLogGCMinAge
+	}
+	s.opLogGC.stop = make(chan struct{})
+	s.opLogGC.running = true
+	interval := s.opLogGC.interval
+	minAge := s.opLogGC.minAge
+	stop := s.opLogGC.stop
+	s.opLogGC.mu.Unlock()
+
+	slog.Info("op-log GC started",
+		"interval", interval.String(),
+		"min_age", minAge.String(),
+	)
+
+	s.bg.Add(1)
+	go func() {
+		defer s.bg.Done()
+		t := time.NewTicker(interval)
+		defer t.Stop()
+		for {
+			select {
+			case <-stop:
+				return
+			case <-t.C:
+				s.runOpLogGCTick(minAge)
+			}
+		}
+	}()
+}
+
+// stopOpLogGC signals the loop to exit. Called from Server.Stop().
+// Safe to call when the loop never started.
+func (s *Server) stopOpLogGC() {
+	s.opLogGC.mu.Lock()
+	defer s.opLogGC.mu.Unlock()
+	if !s.opLogGC.running {
+		return
+	}
+	close(s.opLogGC.stop)
+	s.opLogGC.running = false
+}
+
+// runOpLogGCTick is one tick of the periodic loop. No outer timeout
+// because PruneSweep itself is bounded by the size of the candidate
+// list (one DB query + one DELETE per item, both indexed) — unlike
+// orphan GC which can scan the whole filesystem. If a future
+// regression makes a sweep slow, that's a signal to add a deadline
+// here, not a default.
+//
+// Logged at info on success, warn on failure. Quiet (no log line)
+// when nothing was eligible — operators don't want hourly "0 rows
+// pruned" lines on a quiet server.
+func (s *Server) runOpLogGCTick(minAge time.Duration) {
+	if s.collab == nil {
+		return
+	}
+	res, err := s.collab.PruneSweep(minAge)
+	if err != nil {
+		slog.Warn("op-log GC sweep failed", "error", err)
+		return
+	}
+	if res.RowsPruned == 0 && res.Errors == 0 && res.ItemsSkipped == 0 {
+		return
+	}
+	slog.Info("op-log GC sweep",
+		"items_scanned", res.ItemsScanned,
+		"items_pruned", res.ItemsPruned,
+		"items_skipped", res.ItemsSkipped,
+		"rows_pruned", res.RowsPruned,
+		"errors", res.Errors,
+	)
+}

--- a/internal/server/oplog_gc_test.go
+++ b/internal/server/oplog_gc_test.go
@@ -1,0 +1,324 @@
+package server
+
+import (
+	"testing"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/collab"
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// TestOpLogGC_PrunesDormantItems is the TASK-1309 server-level
+// happy-path test: configure the GC for a short interval + minAge,
+// seed two items — one fully dormant (all rows old), one mixed
+// (recent activity) — start the loop, observe the dormant item's
+// op-log fully pruned and the mixed item's preserved.
+//
+// Whole-log prune of dormant items only — prefix-pruning a mixed
+// item would corrupt Yjs replay (causal references). Per Codex
+// review of TASK-1309 [P1].
+//
+// Times here are tight (10ms ticks, 1min minAge) because the test
+// is driving the real ticker. Test parameters are NOT representative
+// of production defaults — those are 1h / 24h.
+func TestOpLogGC_PrunesDormantItems(t *testing.T) {
+	srv := testServerWithCollab(t)
+
+	// Seed: workspace + collection + two items.
+	ws, err := srv.store.CreateWorkspace(models.WorkspaceCreate{Name: "OpLogGC"})
+	if err != nil {
+		t.Fatalf("CreateWorkspace: %v", err)
+	}
+	col, err := srv.store.CreateCollection(ws.ID, models.CollectionCreate{
+		Name:   "Tasks",
+		Schema: `{"fields":[]}`,
+	})
+	if err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	// Both items have non-empty content so the GC watermark columns
+	// (content_flushed_op_log_id and content_flushed_at) are populated
+	// at creation. The id watermark starts at 0 because there are no
+	// op-log rows yet — we'll backdate it past the seeded op-log
+	// MAX(id) below to simulate a successful server-driven flush
+	// covering those rows. The mixed item gets a recent op-log row
+	// that breaks dormancy regardless of the watermark.
+	dormant, err := srv.store.CreateItem(ws.ID, col.ID, models.ItemCreate{
+		Title: "Dormant", Fields: `{}`, Content: "snapshot",
+	})
+	if err != nil {
+		t.Fatalf("CreateItem dormant: %v", err)
+	}
+	mixed, err := srv.store.CreateItem(ws.ID, col.ID, models.ItemCreate{
+		Title: "Mixed", Fields: `{}`, Content: "snapshot",
+	})
+	if err != nil {
+		t.Fatalf("CreateItem mixed: %v", err)
+	}
+
+	// Hand-crafted INSERTs with explicit timestamps — production
+	// AppendYjsUpdate stamps time.Now() so we can't backdate via it.
+	old := time.Now().Add(-2 * time.Hour).UTC().Format(time.RFC3339)
+	fresh := time.Now().UTC().Format(time.RFC3339)
+	exec := func(itemID string, payload byte, ts string) int64 {
+		t.Helper()
+		res, err := srv.store.DB().Exec(
+			`INSERT INTO item_yjs_updates (item_id, update_data, schema_version, created_at) VALUES (?, ?, ?, ?)`,
+			itemID, []byte{0, payload}, "1", ts,
+		)
+		if err != nil {
+			t.Fatalf("seed insert: %v", err)
+		}
+		id, err := res.LastInsertId()
+		if err != nil {
+			t.Fatalf("LastInsertId: %v", err)
+		}
+		return id
+	}
+	// Dormant item: two old rows. The second LastInsertId is the
+	// MAX op-log id we need the watermark to cover.
+	exec(dormant.ID, 0x01, old)
+	dormantMaxID := exec(dormant.ID, 0x02, old)
+	// Mixed item: one old, one fresh — NOT eligible (whole-log
+	// prune would corrupt the suffix's references to the prefix).
+	exec(mixed.ID, 0x03, old)
+	exec(mixed.ID, 0x04, fresh)
+
+	// Bump the dormant item's content_flushed_op_log_id watermark
+	// past the highest seeded op-log id, simulating a successful
+	// flush that captured both old rows. CreateItem set it to 0,
+	// which would otherwise leave the candidate query thinking
+	// these rows aren't covered yet.
+	if _, err := srv.store.DB().Exec(
+		`UPDATE items SET content_flushed_op_log_id = ? WHERE id = ?`,
+		dormantMaxID, dormant.ID,
+	); err != nil {
+		t.Fatalf("update dormant watermark: %v", err)
+	}
+
+	// minAge = 1 minute → all rows older than 60s ago are
+	// candidates' MAX. Dormant item qualifies; mixed doesn't.
+	srv.SetOpLogGCConfig(10*time.Millisecond, 1*time.Minute)
+	srv.StartOpLogGC()
+	t.Cleanup(srv.Stop)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		dormantRows, err := srv.store.LoadYjsUpdatesSince(dormant.ID, 0)
+		if err != nil {
+			t.Fatalf("LoadYjsUpdatesSince dormant: %v", err)
+		}
+		mixedRows, err := srv.store.LoadYjsUpdatesSince(mixed.ID, 0)
+		if err != nil {
+			t.Fatalf("LoadYjsUpdatesSince mixed: %v", err)
+		}
+		// Dormant item should be fully pruned (0 rows); mixed
+		// should be preserved completely (2 rows).
+		if len(dormantRows) == 0 && len(mixedRows) == 2 {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	dormantRows, _ := srv.store.LoadYjsUpdatesSince(dormant.ID, 0)
+	mixedRows, _ := srv.store.LoadYjsUpdatesSince(mixed.ID, 0)
+	t.Fatalf("after 2s: dormant=%d (want 0), mixed=%d (want 2)",
+		len(dormantRows), len(mixedRows))
+}
+
+// TestOpLogGC_StartIsIdempotent confirms calling StartOpLogGC twice
+// only spawns one goroutine. Without the guard, Stop() would block
+// forever on the second goroutine that never received its stop
+// signal.
+func TestOpLogGC_StartIsIdempotent(t *testing.T) {
+	srv := testServerWithCollab(t)
+
+	// 1h interval = the loop never actually fires during the test;
+	// we just want to exercise the running-flag check.
+	srv.SetOpLogGCConfig(1*time.Hour, 24*time.Hour)
+	srv.StartOpLogGC()
+	srv.StartOpLogGC() // second call must be a no-op
+	srv.StartOpLogGC() // third call too
+
+	// Stop should drain in well under a second; if a second
+	// goroutine was spawned without a matching stop channel,
+	// Stop() would hang and the test would time out.
+	done := make(chan struct{})
+	go func() {
+		srv.Stop()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stop() did not return within 2s — likely a leaked GC goroutine")
+	}
+}
+
+// TestOpLogGC_PreservesUnflushedItem is the TASK-1309 round-2 P1
+// guard: an item with op-log rows that have NOT yet been captured
+// by a items.content flush must NOT be pruned, even if the rows
+// are dormant by age. The id watermark `items.content_flushed_op_log_id`
+// must be >= MAX(op-log.id) before the GC proceeds.
+//
+// The motivating scenario: user types, op-log appends succeed, the
+// browser/process dies before the next 5s collab-snapshot flush
+// can land. The op-log is now the only durable record of those
+// edits. After 24h the dormancy threshold ticks; without the
+// watermark check, the GC would silently delete the unflushed
+// edits.
+func TestOpLogGC_PreservesUnflushedItem(t *testing.T) {
+	srv := testServerWithCollab(t)
+
+	ws, err := srv.store.CreateWorkspace(models.WorkspaceCreate{Name: "OpLogGC"})
+	if err != nil {
+		t.Fatalf("CreateWorkspace: %v", err)
+	}
+	col, err := srv.store.CreateCollection(ws.ID, models.CollectionCreate{
+		Name:   "Tasks",
+		Schema: `{"fields":[]}`,
+	})
+	if err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	// Start with empty content so both watermark columns
+	// (content_flushed_op_log_id and content_flushed_at) are NULL.
+	// CreateItem only sets them when content is non-empty. This
+	// represents the worst case: the item has never had a successful
+	// content flush.
+	item, err := srv.store.CreateItem(ws.ID, col.ID, models.ItemCreate{
+		Title: "Unflushed", Fields: `{}`, Content: "",
+	})
+	if err != nil {
+		t.Fatalf("CreateItem: %v", err)
+	}
+
+	// Backdate two op-log rows. Both are well past minAge.
+	old := time.Now().Add(-2 * time.Hour).UTC().Format(time.RFC3339)
+	for _, payload := range []byte{0x01, 0x02} {
+		if _, err := srv.store.DB().Exec(
+			`INSERT INTO item_yjs_updates (item_id, update_data, schema_version, created_at) VALUES (?, ?, ?, ?)`,
+			item.ID, []byte{0, payload}, "1", old,
+		); err != nil {
+			t.Fatalf("seed row: %v", err)
+		}
+	}
+
+	srv.SetOpLogGCConfig(10*time.Millisecond, 1*time.Minute)
+	srv.StartOpLogGC()
+	t.Cleanup(srv.Stop)
+
+	// Give the sweeper plenty of ticks. content_flushed_op_log_id
+	// is NULL on this item, so the candidate query MUST exclude it
+	// and the rows should still be there.
+	time.Sleep(200 * time.Millisecond)
+
+	rows, err := srv.store.LoadYjsUpdatesSince(item.ID, 0)
+	if err != nil {
+		t.Fatalf("LoadYjsUpdatesSince: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("unflushed item must be preserved: want 2 op-log rows, got %d", len(rows))
+	}
+}
+
+// TestOpLogGC_BackfillDoesNotCertifyUnflushed verifies the migration
+// 052 backfill rule: items that ALREADY HAVE op-log rows must NOT
+// have their content_flushed_op_log_id (or content_flushed_at)
+// watermark backfilled to updated_at.
+// Doing so would risk certifying an unflushed op-log row as
+// "captured" by items.content — the sweeper would then delete the
+// only durable copy.
+//
+// We can't run the migration in isolation in a test, but we can
+// verify the equivalent end-state: an item with op-log rows but
+// NULL watermark columns is preserved by the sweeper. Insert a
+// row and a backdated op-log row directly, then explicitly NULL
+// out the watermark to simulate the post-migration "items with
+// op-log rows stay at NULL" outcome.
+//
+// Per Codex review of TASK-1309 round 3 [P1]: original backfill
+// using `updated_at` could certify unflushed rows.
+func TestOpLogGC_BackfillDoesNotCertifyUnflushed(t *testing.T) {
+	srv := testServerWithCollab(t)
+
+	ws, err := srv.store.CreateWorkspace(models.WorkspaceCreate{Name: "OpLogGC"})
+	if err != nil {
+		t.Fatalf("CreateWorkspace: %v", err)
+	}
+	col, err := srv.store.CreateCollection(ws.ID, models.CollectionCreate{
+		Name:   "Tasks",
+		Schema: `{"fields":[]}`,
+	})
+	if err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	item, err := srv.store.CreateItem(ws.ID, col.ID, models.ItemCreate{
+		Title: "Pre-migration", Fields: `{}`, Content: "stale snapshot",
+	})
+	if err != nil {
+		t.Fatalf("CreateItem: %v", err)
+	}
+
+	// Simulate pre-migration state: item exists with content + op-log
+	// rows + a metadata-only PATCH that bumped updated_at PAST the
+	// op-log row's created_at. The migration would see updated_at
+	// > op-log MAX and naively backfill the watermark columns to
+	// updated_at — but items.content is still stale relative to
+	// the op-log row. Force the post-migration "stay NULL"
+	// outcome by clearing both watermark columns directly.
+	old := time.Now().Add(-2 * time.Hour).UTC().Format(time.RFC3339)
+	if _, err := srv.store.DB().Exec(
+		`INSERT INTO item_yjs_updates (item_id, update_data, schema_version, created_at) VALUES (?, ?, ?, ?)`,
+		item.ID, []byte{0, 0x01}, "1", old,
+	); err != nil {
+		t.Fatalf("seed op-log: %v", err)
+	}
+	// Bump updated_at AFTER the op-log row (simulating a metadata-
+	// only PATCH at T_meta > T_op). NULL the watermark columns to
+	// simulate the post-migration outcome for items with op-log
+	// rows.
+	now := time.Now().UTC().Format(time.RFC3339)
+	if _, err := srv.store.DB().Exec(
+		`UPDATE items SET updated_at = ?, content_flushed_at = NULL, content_flushed_op_log_id = NULL WHERE id = ?`,
+		now, item.ID,
+	); err != nil {
+		t.Fatalf("simulate metadata patch: %v", err)
+	}
+
+	srv.SetOpLogGCConfig(10*time.Millisecond, 1*time.Minute)
+	srv.StartOpLogGC()
+	t.Cleanup(srv.Stop)
+
+	// Sweeper should see content_flushed_op_log_id IS NULL and skip the
+	// item. Op-log row must survive — it represents a real edit
+	// that items.content does NOT contain.
+	time.Sleep(200 * time.Millisecond)
+
+	rows, err := srv.store.LoadYjsUpdatesSince(item.ID, 0)
+	if err != nil {
+		t.Fatalf("LoadYjsUpdatesSince: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("pre-migration unflushed row must survive (NULL watermark); got %d rows", len(rows))
+	}
+}
+
+// TestOpLogGC_NoCollabIsNoop verifies the server can run StartOpLogGC
+// without a collab room manager wired (no-collab build path). The
+// goroutine spawns but every tick is a no-op.
+func TestOpLogGC_NoCollabIsNoop(t *testing.T) {
+	srv := testServer(t) // NOT testServerWithCollab — no room manager
+	srv.SetOpLogGCConfig(10*time.Millisecond, 1*time.Minute)
+	srv.StartOpLogGC()
+	t.Cleanup(srv.Stop)
+
+	// Let a few ticks happen; the goroutine should see s.collab==nil
+	// and just return without touching the store.
+	time.Sleep(100 * time.Millisecond)
+
+	// If we got here without panic / data race / store touch, the
+	// no-collab path is clean. Nothing else to assert; the absence
+	// of badness IS the test.
+	_ = collab.DefaultPruneMinAge // keep the import alive
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -138,6 +138,12 @@ type Server struct {
 	// the loop to exit and waits for it via the bg WaitGroup.
 	orphanGC orphanGCConfig
 
+	// opLogGC holds the periodic-sweep config + lifecycle for the
+	// Yjs op-log prune sweeper (TASK-1309). Mirrors orphanGC's
+	// pattern. Configured via SetOpLogGCConfig + started via
+	// StartOpLogGC; Stop() signals the loop via stopOpLogGC.
+	opLogGC opLogGCConfig
+
 	// inFlightUploadHashes tracks content_hash values for uploads
 	// that have called AttachmentStore.Put but not yet inserted the
 	// attachments row. Without this, the orphan GC could delete a
@@ -218,6 +224,9 @@ func (s *Server) Stop() {
 	// Each loop registers itself on s.bg, so the Wait() below blocks
 	// until they actually finish and any in-flight goroutines drain.
 	s.stopOrphanGC()
+	// Yjs op-log prune sweeper (TASK-1309). Same lifecycle pattern;
+	// signals BEFORE Wait() so the goroutine sees the close and exits.
+	s.stopOpLogGC()
 	// MCP audit writer / sweeper run on s.bg too. Signal first so
 	// the workers see the close BEFORE Wait() blocks; without the
 	// signal Wait would hang forever on the writer's blocking
@@ -227,13 +236,20 @@ func (s *Server) Stop() {
 	// Order with the audit writer doesn't matter — both are
 	// independent goroutines; we just need the close BEFORE Wait().
 	s.stopMCPSessionTracker()
-	s.bg.Wait()
-	// Close the collab room manager BEFORE the rateLimiter so any
-	// in-flight Join goroutines holding rate-limiter handles can wind
-	// down via their normal close path. nil-safe: collab is optional.
+	// Close the collab room manager BEFORE bg.Wait() so any in-flight
+	// op-log GC sweep (TASK-1309) blocked on a per-item lock behind
+	// an active Join can drain. collab.Close() tears down the Joins
+	// (their WS readLoops return, runConn unwinds, itemLocks
+	// release), which unblocks the GC's per-item PruneItemOpLogIfDormantBefore
+	// call. Without this ordering, Stop() can deadlock: GC waits on
+	// itemLock; Join holds itemLock until WS closes; WS only closes
+	// when collab.Close() runs; collab.Close() only runs after
+	// bg.Wait(); bg.Wait() never returns because GC is stuck.
+	// Per Codex review of TASK-1309 [P2]. nil-safe: collab is optional.
 	if s.collab != nil {
 		s.collab.Close()
 	}
+	s.bg.Wait()
 	s.rateLimiters.Stop() // nil-safe via the RateLimiters receiver guard
 }
 

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -137,16 +137,34 @@ func (s *Store) tryCreateItem(id, workspaceID, collectionID, slug, ts, fields, t
 	}
 
 	// Compute and insert the next item_number atomically within the lock.
+	// content_flushed_at + content_flushed_op_log_id are the op-log GC
+	// watermarks (TASK-1309). The id column is authoritative — sweeper
+	// uses strict id comparison to avoid second-granularity timestamp
+	// false positives. Both set iff content is non-empty:
+	//   - timestamp = creation time (informational)
+	//   - id = 0 (vacuously safe — there are no op-log rows yet, so
+	//     "covers all rows up to id 0" never gates anything until the
+	//     first op-log row arrives, at which point this item is
+	//     non-dormant by virtue of having a recent row)
+	// Empty content → both NULL; sweeper treats NULL as "never flushed"
+	// and skips pruning.
+	var contentFlushedAt interface{}
+	var contentFlushedOpLogID interface{}
+	if input.Content != "" {
+		contentFlushedAt = ts
+		contentFlushedOpLogID = int64(0)
+	}
 	_, err = tx.Exec(s.q(`
 		INSERT INTO items (id, workspace_id, collection_id, title, slug, content, fields, tags,
 		                   pinned, sort_order, parent_id, assigned_user_id, agent_role_id, role_sort_order,
-		                   created_by, last_modified_by, source, item_number, created_at, updated_at)
+		                   created_by, last_modified_by, source, item_number, created_at, updated_at,
+		                   content_flushed_at, content_flushed_op_log_id)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?, ?, 0, ?, ?, ?,
 		        (SELECT COALESCE(MAX(item_number), 0) + 1 FROM items WHERE workspace_id = ?),
-		        ?, ?)
+		        ?, ?, ?, ?)
 	`), id, workspaceID, collectionID, input.Title, slug, input.Content, fields, tags,
 		s.dialect.BoolToInt(input.Pinned), input.ParentID, input.AssignedUserID, input.AgentRoleID,
-		createdBy, createdBy, source, workspaceID, ts, ts)
+		createdBy, createdBy, source, workspaceID, ts, ts, contentFlushedAt, contentFlushedOpLogID)
 	if err != nil {
 		return err
 	}
@@ -927,6 +945,34 @@ func (s *Store) UpdateItem(id string, input models.ItemUpdate) (*models.Item, er
 	if input.Content != nil {
 		sets = append(sets, "content = ?")
 		args = append(args, *input.Content)
+		// Bump the human-readable timestamp on every content
+		// update — this is informational and never gates GC.
+		sets = append(sets, "content_flushed_at = ?")
+		args = append(args, ts)
+
+		// Op-log GC watermark policy (TASK-1309 round 5 [P1]):
+		// only advance content_flushed_op_log_id from server-driven
+		// full-content writes (CLI / MCP / applier-direct-write /
+		// version-restore / PruneAndApply). Browser collab-snapshot
+		// PATCHes are NOT eligible because they can't prove their
+		// markdown captures every peer op:
+		//
+		//   Tab A's Y.Doc is at op N. Peer B's op N+1 commits to
+		//   the op-log. Tab A's 5s flush PATCHes stale markdown
+		//   derived from its op-N view. If we advanced the watermark
+		//   to MAX(op-log.id) = N+1 here, the sweeper would later
+		//   prune op N+1 — the only durable copy of peer B's edit.
+		//
+		// VersionSource == "collab-snapshot" is the marker the
+		// HTTP handler sets for browser flushes (TASK-1267). All
+		// other content writes either rebuild content from full
+		// op-log state (PruneAndApply) or replace it wholesale
+		// (CLI / version restore) — those CAN safely stamp the
+		// watermark to MAX(op-log.id) at write time.
+		if input.VersionSource != "collab-snapshot" {
+			sets = append(sets, "content_flushed_op_log_id = (SELECT COALESCE(MAX(id), 0) FROM item_yjs_updates WHERE item_id = ?)")
+			args = append(args, id)
+		}
 	}
 	if input.Fields != nil {
 		sets = append(sets, "fields = ?")

--- a/internal/store/items_collab_versions_test.go
+++ b/internal/store/items_collab_versions_test.go
@@ -190,3 +190,66 @@ func TestCollabSnapshotPreservesVersionDiff(t *testing.T) {
 		t.Errorf("expected at least one version row stored as a reverse-patch (IsDiff=true); test contents are too small or too dissimilar to exercise the diff path. Bump the filler size.")
 	}
 }
+
+// TestCollabSnapshotDoesNotAdvanceOpLogWatermark is a regression
+// guard for TASK-1309 round 5 [P1]: a browser collab-snapshot
+// PATCH (VersionSource="collab-snapshot") must NOT advance the
+// items.content_flushed_op_log_id watermark, because the flusher's
+// markdown can't be proven to capture every peer's ops.
+//
+// Other content writes (no VersionSource, or any other value) DO
+// advance the watermark — those paths reconstruct content from the
+// full op-log state (PruneAndApply) or replace it wholesale (CLI
+// write, version restore).
+func TestCollabSnapshotDoesNotAdvanceOpLogWatermark(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Watermark Test")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+	item := createTestItem(t, s, ws.ID, col.ID, "Item", "v1")
+
+	// Seed an op-log row directly so the item has a non-zero
+	// MAX(op-log.id). Production AppendYjsUpdate stamps an id via
+	// AUTOINCREMENT/BIGSERIAL.
+	if _, err := s.AppendYjsUpdate(item.ID, []byte{0x00, 0x01}, "1"); err != nil {
+		t.Fatalf("AppendYjsUpdate: %v", err)
+	}
+
+	// Browser collab-snapshot PATCH path: VersionSource="collab-snapshot".
+	// items.content gets updated, but content_flushed_op_log_id
+	// must stay at 0 (the value CreateItem set with no ops at the time).
+	v2 := "v2"
+	_, err := s.UpdateItem(item.ID, models.ItemUpdate{
+		Content:        &v2,
+		LastModifiedBy: "user",
+		VersionSource:  "collab-snapshot",
+	})
+	if err != nil {
+		t.Fatalf("UpdateItem (collab-snapshot): %v", err)
+	}
+	id1, ok, err := s.GetItemContentFlushedOpLogID(item.ID)
+	if err != nil {
+		t.Fatalf("GetItemContentFlushedOpLogID: %v", err)
+	}
+	if !ok || id1 != 0 {
+		t.Errorf("after collab-snapshot PATCH: watermark must stay at 0 (got %d, ok=%v); browser flushes can't prove peer-op coverage", id1, ok)
+	}
+
+	// Server-driven write (no VersionSource): watermark MUST advance
+	// to MAX(op-log.id). Our seeded row has id 1 (or close to it).
+	v3 := "v3"
+	_, err = s.UpdateItem(item.ID, models.ItemUpdate{
+		Content:        &v3,
+		LastModifiedBy: "user",
+		Source:         "cli",
+	})
+	if err != nil {
+		t.Fatalf("UpdateItem (cli): %v", err)
+	}
+	id2, ok, err := s.GetItemContentFlushedOpLogID(item.ID)
+	if err != nil {
+		t.Fatalf("GetItemContentFlushedOpLogID after cli: %v", err)
+	}
+	if !ok || id2 < 1 {
+		t.Errorf("after server-driven write: watermark must advance past 0 (got %d, ok=%v)", id2, ok)
+	}
+}

--- a/internal/store/migrations/051_yjs_op_log_created_at_idx.sql
+++ b/internal/store/migrations/051_yjs_op_log_created_at_idx.sql
@@ -1,0 +1,23 @@
+-- Migration 051: composite index on item_yjs_updates(item_id, created_at)
+-- for the periodic op-log prune sweeper (TASK-1309).
+--
+-- The candidate query for the sweeper is:
+--   SELECT item_id FROM item_yjs_updates
+--   GROUP BY item_id HAVING MAX(created_at) < ?
+--
+-- Without this index, that query is a full table scan: the existing
+-- (item_id, id) index from migration 050 covers the live-replay path
+-- (`WHERE item_id = ? AND id > ? ORDER BY id ASC`) but is useless for
+-- aggregating MAX(created_at). The sweeper is the only feature that
+-- aggregates by created_at across all items, and it'll be running on
+-- exactly the table that grows fastest under collab load.
+--
+-- (item_id, created_at) — vs. just (created_at) — also speeds up the
+-- per-item prune that follows the candidate query:
+--   DELETE FROM item_yjs_updates WHERE item_id = ?
+--     AND NOT EXISTS (SELECT 1 ... WHERE item_id = ? AND created_at >= ?)
+--
+-- Per Codex review of TASK-1309 [P2].
+
+CREATE INDEX IF NOT EXISTS idx_yjs_updates_item_id_created_at
+    ON item_yjs_updates(item_id, created_at);

--- a/internal/store/migrations/052_items_content_flushed_at.sql
+++ b/internal/store/migrations/052_items_content_flushed_at.sql
@@ -1,0 +1,83 @@
+-- Migration 052: items.content_flushed_at + items.content_flushed_op_log_id
+-- watermarks for op-log GC safety (TASK-1309).
+--
+-- The collab op-log GC sweeper deletes a dormant item's entire op-log
+-- on the assumption that items.content is canonical (captures
+-- everything the op-log has). That assumption holds iff items.content
+-- was actually updated AFTER every op-log row was appended.
+--
+-- The 5s collab-snapshot flush is best-effort: a browser/process death
+-- between an op-log append and the next flush leaves the op-log as the
+-- only durable record of those edits. Without a flush watermark, the
+-- GC would happily delete the op-log on the 24h dormancy threshold and
+-- silently lose the unsaved edits.
+--
+-- `content_flushed_op_log_id` is the AUTHORITATIVE GC watermark:
+-- MAX(item_yjs_updates.id) covered by the most recent server-driven
+-- full-content write to items.content. Strict id comparison in the
+-- sweeper (`MAX(u.id) <= i.content_flushed_op_log_id`) avoids both
+-- second-granularity timestamp false-positives (Codex round 4 [P1])
+-- AND the browser-flush-stamps-stale-content race (Codex round 5
+-- [P1]: only server-driven writes advance this column).
+--
+-- `content_flushed_at` is a SECONDARY informational timestamp. It is
+-- updated on every content write (including browser flushes) and
+-- exists for human-readable diagnostics ("when was this last
+-- flushed?"). The GC does NOT consult it.
+--
+-- NULL on either column means "never flushed since this column
+-- existed". The GC treats NULL as "don't touch" — pre-migration
+-- items keep their op-logs forever until a future content update
+-- bumps the watermark. Per Codex review of TASK-1309 round 2 [P1].
+
+ALTER TABLE items ADD COLUMN content_flushed_at TEXT;
+
+-- content_flushed_op_log_id is the AUTHORITATIVE op-log GC watermark.
+-- It records the highest item_yjs_updates.id covered by the most
+-- recent items.content write. The sweeper requires
+-- `MAX(op-log.id) <= items.content_flushed_op_log_id` before
+-- pruning — strict id comparison, monotonic, no clock-skew or
+-- second-granularity-equality issues that wall-clock timestamps
+-- carry. Per Codex review of TASK-1309 round 4 [P1].
+--
+-- content_flushed_at (TEXT timestamp) above is retained for human-
+-- readable diagnostics; it is NOT consulted by the sweeper.
+ALTER TABLE items ADD COLUMN content_flushed_op_log_id INTEGER;
+
+-- Backfill: only items that DON'T already have op-log rows can be
+-- safely declared "flushed" via the updated_at backfill. For items
+-- WITH op-log rows, we can't tell from migration time whether
+-- updated_at was bumped by a content change (which would have
+-- captured the ops into items.content) or by a metadata-only PATCH
+-- (which would not have). Backfilling those would risk certifying
+-- an unflushed op as flushed and letting the GC sweeper delete the
+-- only durable copy of an edit. Per Codex review of TASK-1309
+-- round 3 [P1].
+--
+-- Items WITHOUT op-log rows have nothing the sweeper would touch;
+-- backfilling their watermark is harmless and unblocks future
+-- content updates from setting it.
+--
+-- Items WITH op-log rows stay at NULL until the first post-migration
+-- content update (Store.UpdateItem with input.Content != nil) sets
+-- the watermark. Until then the sweeper can't prune them — that's
+-- the safe default.
+UPDATE items
+SET content_flushed_at = updated_at
+WHERE content != ''
+  AND NOT EXISTS (
+    SELECT 1 FROM item_yjs_updates u WHERE u.item_id = items.id
+  );
+
+-- content_flushed_op_log_id backfill: items with no op-log rows can
+-- be safely set to 0 (vacuously covers nothing, but they have no
+-- rows anyway — never appear in the candidate query). Items WITH
+-- op-log rows stay NULL until the first post-migration content
+-- write, by which time UpdateItem stamps the column with
+-- MAX(item_yjs_updates.id) via subquery.
+UPDATE items
+SET content_flushed_op_log_id = 0
+WHERE content != ''
+  AND NOT EXISTS (
+    SELECT 1 FROM item_yjs_updates u WHERE u.item_id = items.id
+  );

--- a/internal/store/pgmigrations/030_yjs_op_log_created_at_idx.sql
+++ b/internal/store/pgmigrations/030_yjs_op_log_created_at_idx.sql
@@ -1,0 +1,5 @@
+-- Postgres mirror of migrations/051_yjs_op_log_created_at_idx.sql
+-- (PLAN-1248 TASK-1309). See the SQLite migration for full context.
+
+CREATE INDEX IF NOT EXISTS idx_yjs_updates_item_id_created_at
+    ON item_yjs_updates(item_id, created_at);

--- a/internal/store/pgmigrations/031_items_content_flushed_at.sql
+++ b/internal/store/pgmigrations/031_items_content_flushed_at.sql
@@ -1,0 +1,19 @@
+-- Postgres mirror of migrations/052_items_content_flushed_at.sql
+-- (PLAN-1248 TASK-1309). See the SQLite migration for full context.
+
+ALTER TABLE items ADD COLUMN IF NOT EXISTS content_flushed_at TEXT;
+
+-- See SQLite migration for the watermark column rationale (Codex
+-- review of TASK-1309 round 4 [P1]: timestamp comparison is unsafe
+-- at second granularity).
+ALTER TABLE items ADD COLUMN IF NOT EXISTS content_flushed_op_log_id BIGINT;
+
+-- See SQLite migration for why items with existing op-log rows stay
+-- at NULL (Codex review of TASK-1309 round 3 [P1]).
+UPDATE items
+SET content_flushed_at = updated_at,
+    content_flushed_op_log_id = 0
+WHERE content != ''
+  AND NOT EXISTS (
+    SELECT 1 FROM item_yjs_updates u WHERE u.item_id = items.id
+  );

--- a/internal/store/yjs_updates.go
+++ b/internal/store/yjs_updates.go
@@ -130,50 +130,213 @@ func (s *Store) LoadYjsUpdatesSince(itemID string, sinceID int64) ([]models.YjsU
 	return updates, nil
 }
 
-// LatestYjsUpdateSchemaVersion returns the `schema_version` of the
-// most recently appended op-log row for an item. The boolean is false
-// when no rows exist yet (a fresh item, or one whose op-log was just
-// pruned). Used by the schema-mismatch rebuild flow (TASK-1268,
-// PLAN-1248): if the latest persisted version differs from the
-// server's current SCHEMA_VERSION, the room manager prunes the
-// op-log before replaying so the new-schema client doesn't replay
-// old-schema ops that may be incompatible.
+// LatestYjsUpdateSchemaVersion returns the `schema_version` AND `id`
+// of the most recently appended op-log row for an item. The boolean
+// is false when no rows exist yet (a fresh item, or one whose op-log
+// was just pruned).
 //
-// We pick "most recent" rather than "any row" so a server that wrote
-// some old-version rows then was rolled back, then forward again,
-// still detects the mismatch from the row(s) that matter most.
-func (s *Store) LatestYjsUpdateSchemaVersion(itemID string) (string, bool, error) {
+// Used by the schema-mismatch rebuild flow (TASK-1268, PLAN-1248):
+// if the latest persisted version differs from the server's current
+// SCHEMA_VERSION, the room manager prunes the op-log before
+// replaying so the new-schema client doesn't replay old-schema ops
+// that may be incompatible. The id is also returned so the rebuild
+// can compare against items.content_flushed_op_log_id and log
+// loudly when the prune is dropping unflushed edits — the user
+// can't recover them (old-schema ops can't replay in new schema)
+// but operators should see when this happens. Per Codex review of
+// TASK-1309 round 4 [P2].
+//
+// We pick "most recent" rather than "any row" so a server that
+// wrote some old-version rows then was rolled back, then forward
+// again, still detects the mismatch from the row(s) that matter
+// most.
+func (s *Store) LatestYjsUpdateSchemaVersion(itemID string) (string, int64, bool, error) {
 	if itemID == "" {
-		return "", false, errors.New("LatestYjsUpdateSchemaVersion: itemID is required")
+		return "", 0, false, errors.New("LatestYjsUpdateSchemaVersion: itemID is required")
 	}
 	query := s.dialect.Rebind(`
-		SELECT schema_version
+		SELECT schema_version, id
 		FROM item_yjs_updates
 		WHERE item_id = ?
 		ORDER BY id DESC
 		LIMIT 1
 	`)
 	var version string
-	if err := s.db.QueryRow(query, itemID).Scan(&version); err != nil {
+	var rowID int64
+	if err := s.db.QueryRow(query, itemID).Scan(&version, &rowID); err != nil {
 		// sql.ErrNoRows is the well-known "no rows" path; surface it
 		// as ok=false rather than an error so callers don't have to
 		// import database/sql just for this check.
 		if errors.Is(err, sql.ErrNoRows) {
-			return "", false, nil
+			return "", 0, false, nil
 		}
-		return "", false, fmt.Errorf("latest yjs schema version: %w", err)
+		return "", 0, false, fmt.Errorf("latest yjs schema version: %w", err)
 	}
-	return version, true, nil
+	return version, rowID, true, nil
+}
+
+// GetItemContentFlushedOpLogID returns the value of
+// items.content_flushed_op_log_id for an item — the highest op-log
+// id known to be reflected in items.content, or (0, false) if the
+// item has never been flushed (NULL column value or item missing).
+//
+// Used by the schema-mismatch rebuild path (TASK-1268) to detect
+// when an unsafe prune is about to drop unflushed edits. Per Codex
+// review of TASK-1309 round 4 [P2].
+func (s *Store) GetItemContentFlushedOpLogID(itemID string) (int64, bool, error) {
+	if itemID == "" {
+		return 0, false, errors.New("GetItemContentFlushedOpLogID: itemID is required")
+	}
+	query := s.dialect.Rebind(`
+		SELECT content_flushed_op_log_id FROM items WHERE id = ?
+	`)
+	var (
+		v   sql.NullInt64
+		err = s.db.QueryRow(query, itemID).Scan(&v)
+	)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return 0, false, nil
+		}
+		return 0, false, fmt.Errorf("get content flushed op log id: %w", err)
+	}
+	if !v.Valid {
+		return 0, false, nil
+	}
+	return v.Int64, true, nil
+}
+
+// ListDormantOpLogItemsBefore returns the distinct item_ids whose
+// ENTIRE op-log is older than the given cutoff AND whose
+// items.content_flushed_op_log_id covers every persisted op-log
+// row's id. Both conditions are required for the periodic prune
+// sweeper (TASK-1309) to safely delete the op-log:
+//
+//  1. **Dormancy** (`MAX(op-log.created_at) < cutoff`): no recent
+//     edits, so any new connect should pick up the canonical state
+//     from items.content via lazy-seed (TASK-1261) rather than
+//     replaying the live op stream.
+//
+//  2. **Flush coverage** (`MAX(op-log.id) <=
+//     items.content_flushed_op_log_id`): items.content actually
+//     contains every edit the op-log persisted. The id is a
+//     monotonic AUTOINCREMENT/BIGSERIAL — strict id comparison
+//     avoids the false-positive that wall-clock timestamp
+//     comparison admits at second granularity (Codex review of
+//     TASK-1309 round 4 [P1]).
+//
+// Without the flush-coverage check, a browser/process death between
+// an op-log append and the next 5s collab-snapshot flush would
+// leave unflushed edits stuck in the op-log; the GC would delete
+// them on the dormancy threshold and the next cold connect would
+// lazy-seed stale markdown.
+//
+// Items with NULL content_flushed_op_log_id are excluded (never-
+// flushed, can't safely prune). Items with non-NULL but stale id
+// (older than MAX op-log id) are also excluded.
+//
+// IMPORTANT: returns "all rows are dormant AND flushed" candidates
+// only. Yjs op streams are causally linked, so prefix-pruning
+// corrupts replay. Whole-log prune of dormant+flushed items is the
+// safe operation — future cold connects then lazy-seed from
+// items.content, producing a fresh, self-consistent Y.Doc.
+//
+// Returns an empty slice when no item qualifies (no error). Caller
+// iterates the list, takes per-item locks, and calls
+// PruneItemOpLogIfDormantBefore — which atomically re-checks
+// dormancy. The id watermark is monotonically non-decreasing so
+// the JOIN-time check trivially holds under the lock.
+func (s *Store) ListDormantOpLogItemsBefore(before time.Time) ([]string, error) {
+	cutoff := before.UTC().Format(time.RFC3339)
+	query := s.dialect.Rebind(`
+		SELECT u.item_id
+		FROM item_yjs_updates u
+		JOIN items i ON u.item_id = i.id
+		WHERE i.content_flushed_op_log_id IS NOT NULL
+		GROUP BY u.item_id, i.content_flushed_op_log_id
+		HAVING MAX(u.created_at) < ?
+		   AND MAX(u.id) <= i.content_flushed_op_log_id
+	`)
+	rows, err := s.db.Query(query, cutoff)
+	if err != nil {
+		return nil, fmt.Errorf("list dormant op-log items: %w", err)
+	}
+	defer rows.Close()
+
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("scan item id: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate item ids: %w", err)
+	}
+	return ids, nil
+}
+
+// PruneItemOpLogIfDormantBefore atomically deletes every op-log row
+// for itemID IFF no row exists with created_at >= cutoff. Returns
+// the count deleted (0 if the item turned out to be non-dormant).
+//
+// This is the safe replacement for "list-then-prune" in the GC
+// sweeper. Without the conditional NOT EXISTS check, a row appended
+// by a live readLoop between the candidate-list query and the
+// per-item DELETE would be deleted along with the older rows,
+// corrupting the active session's op stream. The conditional DELETE
+// is atomic at the SQL layer: either every row of the item gets
+// deleted (no recent row at evaluation time) or none do.
+//
+// Per Codex review of TASK-1309 [P1].
+func (s *Store) PruneItemOpLogIfDormantBefore(itemID string, before time.Time) (int64, error) {
+	if itemID == "" {
+		return 0, errors.New("PruneItemOpLogIfDormantBefore: itemID is required")
+	}
+	cutoff := before.UTC().Format(time.RFC3339)
+	query := s.dialect.Rebind(`
+		DELETE FROM item_yjs_updates
+		WHERE item_id = ?
+		  AND NOT EXISTS (
+		    SELECT 1 FROM item_yjs_updates
+		    WHERE item_id = ? AND created_at >= ?
+		  )
+	`)
+	res, err := s.db.Exec(query, itemID, itemID, cutoff)
+	if err != nil {
+		return 0, fmt.Errorf("prune dormant op-log: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("prune dormant op-log (rows affected): %w", err)
+	}
+	return n, nil
 }
 
 // PruneYjsUpdatesBefore deletes op-log rows for an item with created_at
 // strictly before the given cutoff and returns the row count removed.
 //
-// Used by the eventual GC sweeper (out of scope for this task) to
-// reclaim space after a successful markdown snapshot makes the older
-// op-log rows redundant. items.content remains canonical, so pruning
-// is safe — at most we lose the ability to do live op-replay for very
-// old peer reconnects, who will fall back to the markdown snapshot.
+// **Not safe as a generic GC primitive** — Yjs op streams are
+// causally linked, so deleting older rows while keeping newer ones
+// corrupts replay (the suffix's references to pruned-prefix structs
+// can't be resolved). This method is retained ONLY for callers that
+// guarantee the suffix doesn't depend on the prefix:
+//
+//   - The schema-mismatch rebuild path (TASK-1268) calls it with a
+//     far-future cutoff to wipe the entire op-log on a version
+//     change — same effective behaviour as the GC sweeper, just
+//     reached via a different signal.
+//   - PruneAndApply's direct-write fallback (TASK-1257) — the
+//     caller guarantees no live readLoop is appending while the
+//     prune+items.content-write runs.
+//
+// New callers SHOULD use ListDormantOpLogItemsBefore +
+// PruneItemOpLogIfDormantBefore, which enforce the dormant-only
+// invariant + flush-watermark check at the SQL layer.
+//
+// Per Codex review of TASK-1309 — comment was previously stale,
+// describing future GC use that turned out to be unsafe.
 func (s *Store) PruneYjsUpdatesBefore(itemID string, before time.Time) (int64, error) {
 	if itemID == "" {
 		return 0, errors.New("PruneYjsUpdatesBefore: itemID is required")


### PR DESCRIPTION
## Summary

Periodic background sweeper that prunes Yjs op-log rows for items that are both **dormant** (no recent activity) AND **fully flushed** (items.content has captured every op-log row). Whole-log only — Yjs op streams are causally linked, so prefix-pruning would corrupt replay; future cold connects lazy-seed from items.content via TASK-1261.

DOC-1307 motivated this: 5000-row op-log on a single item produced 45-second p50 cold-reconnect latency. Without GC, busy items grow unboundedly.

Closes TASK-1309.

## Watermark policy

- New \`items.content_flushed_op_log_id\` column — monotonic, id-based, no clock-skew or second-granularity false-positives.
- **Advanced only by server-driven writes** (CLI / MCP / version restore / PruneAndApply) via atomic subquery in the same UPDATE.
- **Browser collab-snapshot flushes do NOT advance it** — they can't prove their markdown captured peer ops; letting them stamp would risk later GC-pruning unsynced peer edits.
- \`?source=collab-snapshot\` query param force-overrides body \`version_source\` so a malicious/buggy client can't bypass the gate.
- \`content_flushed_at\` (TEXT timestamp) retained for human-readable diagnostics; not consulted by GC.

## Coordination

- Per-item lock (matches Join's setup lock) prevents the prune from racing fresh-peer replayTo.
- Atomic conditional DELETE re-checks dormancy at SQL level so a row appended mid-sweep aborts the prune.
- Active-room skip (in-memory check before lock + under lock).
- Stop ordering: \`collab.Close()\` runs BEFORE \`bg.Wait()\` so a GC goroutine waiting on itemLock behind an active Join can drain.
- Schema-mismatch rebuild (TASK-1268) logs WARN when it drops unflushed ops — unavoidable data loss on schema bumps but visible.

## Files

- \`internal/store/yjs_updates.go\` — \`ListDormantOpLogItemsBefore\`, \`PruneItemOpLogIfDormantBefore\`, \`GetItemContentFlushedOpLogID\`, \`LatestYjsUpdateSchemaVersion\` extended to return id
- \`internal/store/items.go\` — UpdateItem advances watermark via subquery only when \`VersionSource != \"collab-snapshot\"\`; CreateItem sets to 0 on non-empty content
- \`internal/store/migrations/051_yjs_op_log_created_at_idx.sql\` — \`(item_id, created_at)\` composite index
- \`internal/store/migrations/052_items_content_flushed_at.sql\` — both watermark columns; backfill skips items with existing op-log rows
- \`internal/store/pgmigrations/030...\` and \`031...\` — Postgres mirrors
- \`internal/collab/manager.go\` — \`PruneSweep\` + \`PruneSweepResult\` + watermark-aware schema-mismatch warn
- \`internal/server/oplog_gc.go\` — periodic ticker mirroring orphan_gc.go pattern
- \`cmd/pad/main.go\` — \`PAD_OPLOG_GC_INTERVAL\` / \`PAD_OPLOG_GC_MIN_AGE\` env vars

## Test plan
- [x] \`make check\` passes
- [x] 6 \`RoomManager.PruneSweep\` tests
- [x] 5 \`Server.OpLogGC\` tests
- [x] \`TestCollabSnapshotDoesNotAdvanceOpLogWatermark\` (store-level)
- [x] \`TestCollabSnapshotQueryOverridesBodyVersionSource\` (server-level, body-attacker regression)

## Codex review

**Seven rounds.** Caught 5 P1s and 4 P2s I would have shipped under self-review:

1. Prefix-prune corrupts Yjs replay [P1]
2. Stop ordering deadlock [P2]
3. Missing index on created_at [P2]
4. Best-effort flush ⇒ data loss for unflushed ops [P1]
5. Backfill over-certifies via metadata-PATCH-bumped updated_at [P1]
6. Second-granularity timestamp comparison admits false positives [P1]
7. Schema-mismatch path also drops unflushed ops silently [P2]
8. Browser flush stamping watermark beyond its Y.Doc state [P1]
9. Body \`version_source\` bypasses server policy [P2]

Round 7: CLEAN with two stale-comment NITs (fixed).