### PR TITLE
feat(collab): op-log cursor protocol — force-refresh + watermark advance (TASK-1319)

### DIFF
--- a/internal/collab/applier.go
+++ b/internal/collab/applier.go
@@ -52,6 +52,29 @@ const (
 	// might add later goes through the same TextMessage envelope.
 	ControlMessageApplierRequest = "applier_request"
 	ControlMessageApplierAck     = "applier_ack"
+
+	// ControlMessageOpLogCursor advertises the highest item_yjs_updates.id
+	// the receiving peer should now consider applied. Sent by the server:
+	//   - immediately after a fresh peer's replay completes (cursor =
+	//     highest replayed id, or current MAX if no rows existed),
+	//   - after every successful AppendYjsUpdate (cursor = the new id),
+	//     so each peer's persisted-state knowledge stays current without
+	//     a polling round-trip.
+	// Clients persist the value per-tab in sessionStorage and announce
+	// it on reconnect via `?since=<id>`. Per TASK-1319.
+	ControlMessageOpLogCursor = "op_log_cursor"
+
+	// ControlMessageForceRefresh tells the client to discard its local
+	// Y.Doc, recreate an empty one, and rely on the lazy-seed path
+	// (TASK-1261) to re-encode items.content into ops. Sent when a
+	// reconnecting client's `?since=<id>` is below MIN(item_yjs_updates.id)
+	// — the rows it expected to replay have been pruned (op-log GC,
+	// schema-rebuild, or PruneAndApply), and replaying from the new
+	// MIN would be a corrupt patch on a stale Y.Doc state. The server
+	// closes the WebSocket immediately after sending the frame; the
+	// client is expected to surface a toast and reconnect with
+	// `?since=0`. Per TASK-1319.
+	ControlMessageForceRefresh = "force_refresh"
 )
 
 // applierFirstTimeoutVar / applierRetryTimeoutVar are vars (rather
@@ -93,6 +116,11 @@ type ControlMessage struct {
 	// retried with a different applier (or fallen back). Client
 	// enforcement lives in TASK-1263. Omitted on applier_ack.
 	ExpiresAtMillis int64 `json:"expires_at_millis,omitempty"`
+
+	// OpLogID carries the highest item_yjs_updates.id the receiving
+	// peer should treat as applied. Set on op_log_cursor frames
+	// (TASK-1319). Omitted on every other control type.
+	OpLogID int64 `json:"op_log_id,omitempty"`
 }
 
 // pendingApplierAck pairs the channel a PATCH handler is waiting on

--- a/internal/collab/applier.go
+++ b/internal/collab/applier.go
@@ -119,8 +119,15 @@ type ControlMessage struct {
 
 	// OpLogID carries the highest item_yjs_updates.id the receiving
 	// peer should treat as applied. Set on op_log_cursor frames
-	// (TASK-1319). Omitted on every other control type.
-	OpLogID int64 `json:"op_log_id,omitempty"`
+	// (TASK-1319). NO omitempty: a legitimate cursor of 0 (empty
+	// op-log session) would otherwise serialize as
+	// `{"type":"op_log_cursor"}` and the client's strict-type
+	// validation would drop it as 'missing op_log_id', leaving
+	// the session unanchored. Per Codex round 22 [P1] of TASK-1319.
+	// applier_request / applier_ack frames don't read this field;
+	// the trailing `,"op_log_id":0` they carry is ignored by the
+	// client's discriminated dispatch.
+	OpLogID int64 `json:"op_log_id"`
 }
 
 // pendingApplierAck pairs the channel a PATCH handler is waiting on

--- a/internal/collab/bus.go
+++ b/internal/collab/bus.go
@@ -46,6 +46,15 @@ type OpEvent struct {
 	Type      string
 	Data      []byte
 	Timestamp int64
+	// OpLogID is the persisted item_yjs_updates.id assigned by
+	// AppendYjsUpdate when this event was a sync frame. Zero for
+	// awareness frames (never persisted) and for the rare sync
+	// frame whose append failed (logged at error; broadcast still
+	// fires so the live mesh stays consistent). Used by writeLoop
+	// to piggyback an op_log_cursor control frame after the binary
+	// frame so peers track their applied-cursor without a round
+	// trip. Per TASK-1319.
+	OpLogID int64
 }
 
 // OpEvent.Type values. Kept narrow on purpose — the server should not

--- a/internal/collab/manager.go
+++ b/internal/collab/manager.go
@@ -139,6 +139,13 @@ func NewRoomManagerWithConfig(store opLogStore, bus OpBus, cfg RoomManagerConfig
 	}
 }
 
+// ErrForceRefreshSent is returned by Join when the client's
+// announced `?since=<id>` was below MIN(item_yjs_updates.id) — rows
+// it expected to replay have been pruned. The handler has already
+// emitted a force_refresh JSON control frame; the caller should
+// close the conn cleanly. Per TASK-1319.
+var ErrForceRefreshSent = errors.New("collab: client cursor below op-log MIN; force_refresh sent")
+
 // Join attaches a freshly-upgraded WebSocket connection to the room
 // for itemID. Replays the op-log to the new peer, spins up an inbound
 // reader and an outbound writer, and blocks until the WebSocket
@@ -146,10 +153,17 @@ func NewRoomManagerWithConfig(store opLogStore, bus OpBus, cfg RoomManagerConfig
 // typically the HTTP handler — should defer conn.Close so that any
 // resources held by the WS upgrader are released after this returns.
 //
+// `since` is the client's announced highest-applied op-log id (parsed
+// from `?since=<id>` on the upgrade URL). When non-zero AND below
+// MIN(item_yjs_updates.id) for this item, Join sends a force_refresh
+// control frame and returns ErrForceRefreshSent — the client must
+// discard local Y.Doc state and reconnect with `?since=0`. Per
+// TASK-1319.
+//
 // Returns whatever error caused the WebSocket to close, or nil on a
 // normal close. The handler typically logs but doesn't act on the
 // return value: the connection is gone either way.
-func (m *RoomManager) Join(itemID string, conn *websocket.Conn) error {
+func (m *RoomManager) Join(itemID string, conn *websocket.Conn, since int64) error {
 	// Gate Add on the closed flag under m.mu so a late Join (e.g. a
 	// hijacked WS handler that didn't enter Join until AFTER Close
 	// returned) can't sneak past the drain barrier.
@@ -206,6 +220,34 @@ func (m *RoomManager) Join(itemID string, conn *websocket.Conn) error {
 			return err
 		}
 
+		// Resume-cursor / force_refresh check (TASK-1319). Run
+		// inside the per-item lock AFTER the schema rebuild so a
+		// post-rebuild empty op-log (which has no MIN) is treated
+		// the same as a fresh item — `since` is harmless because
+		// nothing was pruned out from under it. When MIN exists
+		// AND the announced cursor is below it, the client's
+		// expected suffix is unrecoverable: send force_refresh
+		// and bail. The conn is the caller's to Close.
+		if since > 0 {
+			minID, hasMin, merr := m.store.MinOpLogID(itemID)
+			if merr != nil {
+				itemLock.Unlock()
+				m.bus.Unsubscribe(rc.bus)
+				return merr
+			}
+			if hasMin && since < minID {
+				slog.Info("collab: client cursor below op-log MIN; sending force_refresh",
+					"item_id", itemID,
+					"since", since,
+					"min_id", minID,
+				)
+				_ = sendForceRefreshFrame(conn)
+				itemLock.Unlock()
+				m.bus.Unsubscribe(rc.bus)
+				return ErrForceRefreshSent
+			}
+		}
+
 		if err := room.addConn(rc); err != nil {
 			itemLock.Unlock()
 			// Race: the grace timer reclaimed the room between
@@ -221,7 +263,7 @@ func (m *RoomManager) Join(itemID string, conn *websocket.Conn) error {
 			return err
 		}
 
-		return m.runConn(room, rc, itemLock)
+		return m.runConn(room, rc, itemLock, since)
 	}
 	return errTooManyJoinRetries
 }
@@ -465,14 +507,14 @@ func (m *RoomManager) PruneSweep(minAge time.Duration) (PruneSweepResult, error)
 // correctness issue. The alternative — buffer-then-flush — would
 // require an unbounded queue or risk losing live updates the way
 // the original implementation did.
-func (m *RoomManager) runConn(room *Room, rc *roomConn, itemLock *sync.Mutex) error {
+func (m *RoomManager) runConn(room *Room, rc *roomConn, itemLock *sync.Mutex, since int64) error {
 	writerDone := make(chan struct{})
 	go func() {
 		defer close(writerDone)
 		room.writeLoop(rc)
 	}()
 
-	replayErr := room.replayTo(rc)
+	highestReplayed, replayErr := room.replayTo(rc, since)
 	// Release the per-item setup lock before the long-lived readLoop
 	// so concurrent peers + future PruneAndApply calls aren't gated
 	// on this conn's full lifetime.
@@ -482,6 +524,43 @@ func (m *RoomManager) runConn(room *Room, rc *roomConn, itemLock *sync.Mutex) er
 		room.removeConn(rc)
 		<-writerDone
 		return replayErr
+	}
+
+	// Anchor the client's resume cursor (TASK-1319). If the replay
+	// produced rows, advertise the highest id we sent. If not — a
+	// fresh item, an empty op-log after a recent prune, or an
+	// up-to-date `since` cursor that already covered every row —
+	// look up the current MAX and use that. Best-effort: a write
+	// error here mirrors any other writeMessage error and the read
+	// loop will tear the conn down.
+	cursorID := highestReplayed
+	if cursorID == 0 {
+		if maxID, ok, merr := m.store.MaxOpLogID(room.itemID); merr != nil {
+			slog.Warn("collab: lookup MaxOpLogID for initial cursor failed",
+				"item_id", room.itemID,
+				"error", merr,
+			)
+		} else if ok {
+			cursorID = maxID
+		}
+		// `since > 0` callers might already be ahead of the
+		// server's MAX (e.g. they had ops the server didn't —
+		// the on-open state push will reconcile). Fall back to
+		// `since` so we don't accidentally regress the client's
+		// stored cursor.
+		if cursorID < since {
+			cursorID = since
+		}
+	}
+	// cursorID == 0 is a legitimate value for a never-touched item;
+	// emit it anyway so the client clears any stale sessionStorage
+	// entry from an earlier life of this item id.
+	if err := room.sendOpLogCursor(rc, cursorID); err != nil {
+		// Treat a cursor write failure the same as a replay
+		// write failure — the conn is doomed.
+		room.removeConn(rc)
+		<-writerDone
+		return err
 	}
 
 	// Read loop blocks until the WS closes.

--- a/internal/collab/manager.go
+++ b/internal/collab/manager.go
@@ -235,11 +235,27 @@ func (m *RoomManager) Join(itemID string, conn *websocket.Conn, since int64) err
 				m.bus.Unsubscribe(rc.bus)
 				return merr
 			}
-			if hasMin && since < minID {
-				slog.Info("collab: client cursor below op-log MIN; sending force_refresh",
+			// `since > 0` means the client claims to have applied
+			// at least one persisted op locally. Two ways that
+			// claim is incompatible with the current op-log:
+			//   - No rows exist (`!hasMin`): the entire op-log
+			//     was pruned (PruneAndApply, schema rebuild, or
+			//     dormant GC). The client's Y.Doc is built on top
+			//     of ops that no longer exist; admitting it would
+			//     let its on-open `Y.encodeStateAsUpdate` write
+			//     resurrect the stale pre-prune document and
+			//     overwrite items.content on the next flush.
+			//   - `since < minID`: rows the client expected to
+			//     replay have been pruned (the same hazard, just
+			//     with a non-empty post-prune suffix).
+			// Both branches force_refresh. Per Codex round 2 [P1].
+			needsRefresh := !hasMin || since < minID
+			if needsRefresh {
+				slog.Info("collab: client cursor incompatible with op-log; sending force_refresh",
 					"item_id", itemID,
 					"since", since,
 					"min_id", minID,
+					"has_min", hasMin,
 				)
 				_ = sendForceRefreshFrame(conn)
 				itemLock.Unlock()

--- a/internal/collab/manager.go
+++ b/internal/collab/manager.go
@@ -530,31 +530,24 @@ func (m *RoomManager) runConn(room *Room, rc *roomConn, itemLock *sync.Mutex, si
 		return replayErr
 	}
 
-	// Anchor the client's resume cursor (TASK-1319). If the replay
-	// produced rows, advertise the highest id we sent. If not — a
-	// fresh item, an empty op-log after a recent prune, or an
-	// up-to-date `since` cursor that already covered every row —
-	// look up the current MAX and use that. Best-effort: a write
-	// error here mirrors any other writeMessage error and the read
-	// loop will tear the conn down.
+	// Anchor the client's resume cursor (TASK-1319). The cursor
+	// MUST NEVER advertise an id whose binary frame this conn
+	// hasn't actually delivered, otherwise a disconnect right after
+	// the cursor leaves the client's persisted resume cursor
+	// pointing past unreplayed rows. Two safe sources only:
+	//   - `highestReplayed`: an id we just sent the binary frame
+	//     for during replayTo.
+	//   - `since`: the client's announced cursor — the client has
+	//     already applied that op-log id locally, so re-advertising
+	//     it never regresses past content.
+	// We deliberately do NOT consult MAX(op-log.id) here: a live
+	// op that landed during replay would be reflected in MAX but
+	// hasn't been broadcast through this conn's writeLoop yet, and
+	// a cursor=MAX would let the client persist a value that
+	// outpaces its received binary frames. Per Codex round 6 [P1].
 	cursorID := highestReplayed
-	if cursorID == 0 {
-		if maxID, ok, merr := m.store.MaxOpLogID(room.itemID); merr != nil {
-			slog.Warn("collab: lookup MaxOpLogID for initial cursor failed",
-				"item_id", room.itemID,
-				"error", merr,
-			)
-		} else if ok {
-			cursorID = maxID
-		}
-		// `since > 0` callers might already be ahead of the
-		// server's MAX (e.g. they had ops the server didn't —
-		// the on-open state push will reconcile). Fall back to
-		// `since` so we don't accidentally regress the client's
-		// stored cursor.
-		if cursorID < since {
-			cursorID = since
-		}
+	if cursorID < since {
+		cursorID = since
 	}
 	// cursorID == 0 is a legitimate value for a never-touched item;
 	// emit it anyway so the client clears any stale sessionStorage

--- a/internal/collab/manager.go
+++ b/internal/collab/manager.go
@@ -639,6 +639,33 @@ func (m *RoomManager) RoomCount() int {
 // peers' Y.Doc state cannot be invalidated safely.
 var ErrRoomActiveDuringPrune = errors.New("collab: room became active during prune attempt")
 
+// UnderItemLock runs fn while the per-item setup lock for itemID is
+// held — the SAME lock Join's addConn+replayTo acquires and the SAME
+// lock PruneAndApply runs its prune+write under. Used by the items
+// PATCH handler's collab-snapshot validation path so the
+// MIN(op-log.id) check and the items.content write are atomic
+// w.r.t. concurrent prunes (PruneAndApply, schema rebuild, dormant
+// GC's per-item DELETE). Without this serialization, a prune
+// landing between the check and the write lets the stale
+// collab-snapshot overwrite canonical content. Per Codex round 13
+// [P1] of TASK-1319.
+//
+// Best-effort with a fast bail-out: if Close has fired the lock
+// goroutine returns ErrManagerClosed without invoking fn. fn's
+// own error (if any) is returned verbatim.
+func (m *RoomManager) UnderItemLock(itemID string, fn func() error) error {
+	m.mu.Lock()
+	if m.closed {
+		m.mu.Unlock()
+		return errManagerClosed
+	}
+	m.mu.Unlock()
+	lock := m.itemLock(itemID)
+	lock.Lock()
+	defer lock.Unlock()
+	return fn()
+}
+
 // PruneAndApply runs applyFn under the per-item setup lock so it is
 // strictly serialised with any in-flight Join's addConn+replayTo for
 // the same itemID. Used by the items PATCH handler to prune the

--- a/internal/collab/manager.go
+++ b/internal/collab/manager.go
@@ -1,6 +1,7 @@
 package collab
 
 import (
+	"encoding/json"
 	"errors"
 	"log/slog"
 	"sync"
@@ -545,35 +546,39 @@ func (m *RoomManager) runConn(room *Room, rc *roomConn, itemLock *sync.Mutex, si
 	// hasn't been broadcast through this conn's writeLoop yet, and
 	// a cursor=MAX would let the client persist a value that
 	// outpaces its received binary frames. Per Codex round 6 [P1].
+	// Acquire writeMu across the read-max + cursor-send +
+	// replayDone-flip so writeLoop's per-event critical section
+	// (round 22) cannot interleave a record-vs-read window.
+	// Holding the lock means: any in-flight writeLoop event
+	// finishes its record/send before we read max; any subsequent
+	// event sees replayDone=true and emits its own live cursor.
+	// Per Codex round 22 [P1] of TASK-1319.
+	rc.writeMu.Lock()
 	cursorID := highestReplayed
 	if cursorID < since {
 		cursorID = since
 	}
-	// Fold in the highest live op id whose binary frame writeLoop
-	// fanned out during the replay window. Without this, a live op
-	// landed (applied to the client's Y.Doc) but its cursor was
-	// suppressed (replayDone gate); the initial cursor would still
-	// only cover replay/since, leaving the client cursor below its
-	// applied state. On empty-replay sessions the client would
-	// then trip its `cursor=0 + remoteSyncApplied` force_refresh
-	// path. Per Codex round 21 [P1] of TASK-1319.
 	if liveMax := rc.maxLiveOpLogIDDuringReplay.Load(); liveMax > cursorID {
 		cursorID = liveMax
 	}
-	// cursorID == 0 is a legitimate value for a never-touched item;
-	// emit it anyway so the client clears any stale sessionStorage
-	// entry from an earlier life of this item id.
-	if err := room.sendOpLogCursor(rc, cursorID); err != nil {
-		// Treat a cursor write failure the same as a replay
-		// write failure — the conn is doomed.
+	payload, perr := json.Marshal(ControlMessage{
+		Type:    ControlMessageOpLogCursor,
+		OpLogID: cursorID,
+	})
+	if perr != nil {
+		rc.writeMu.Unlock()
 		room.removeConn(rc)
 		<-writerDone
-		return err
+		return perr
 	}
-	// Replay + initial cursor are committed; allow writeLoop to
-	// resume cursor advancement on subsequent live ops. Per Codex
-	// round 5 [P1] of TASK-1319.
+	if werr := rc.conn.WriteMessage(websocket.TextMessage, payload); werr != nil {
+		rc.writeMu.Unlock()
+		room.removeConn(rc)
+		<-writerDone
+		return werr
+	}
 	rc.replayDone.Store(true)
+	rc.writeMu.Unlock()
 
 	// Read loop blocks until the WS closes.
 	readErr := room.readLoop(rc)

--- a/internal/collab/manager.go
+++ b/internal/collab/manager.go
@@ -549,6 +549,17 @@ func (m *RoomManager) runConn(room *Room, rc *roomConn, itemLock *sync.Mutex, si
 	if cursorID < since {
 		cursorID = since
 	}
+	// Fold in the highest live op id whose binary frame writeLoop
+	// fanned out during the replay window. Without this, a live op
+	// landed (applied to the client's Y.Doc) but its cursor was
+	// suppressed (replayDone gate); the initial cursor would still
+	// only cover replay/since, leaving the client cursor below its
+	// applied state. On empty-replay sessions the client would
+	// then trip its `cursor=0 + remoteSyncApplied` force_refresh
+	// path. Per Codex round 21 [P1] of TASK-1319.
+	if liveMax := rc.maxLiveOpLogIDDuringReplay.Load(); liveMax > cursorID {
+		cursorID = liveMax
+	}
 	// cursorID == 0 is a legitimate value for a never-touched item;
 	// emit it anyway so the client clears any stale sessionStorage
 	// entry from an earlier life of this item id.

--- a/internal/collab/manager.go
+++ b/internal/collab/manager.go
@@ -179,76 +179,49 @@ func (m *RoomManager) Join(itemID string, conn *websocket.Conn, since int64) err
 	itemLock := m.itemLock(itemID)
 
 	for attempt := 0; attempt < 3; attempt++ {
-		room := m.getOrCreate(itemID)
-		if room == nil {
-			// Close raced in between our closed-check above and
-			// getOrCreate. Bail with the same fast error so the
-			// handler closes the WS cleanly.
-			return errManagerClosed
-		}
-
-		rc := &roomConn{
-			id:          nextConnID(),
-			conn:        conn,
-			bus:         m.bus.Subscribe(itemID),
-			connectedAt: time.Now(),
-		}
-
-		// Hold the per-item lock across addConn + replayTo so a
-		// concurrent PruneAndApply (CLI / MCP / API direct write
-		// while we're mid-setup) can't pull stale op-log rows out
-		// from under our feet. The lock is released inside runConn
-		// before the long-lived readLoop so concurrent peers can
-		// edit simultaneously. Per Codex review round 5.
+		// Acquire the per-item setup lock BEFORE creating the room
+		// so the schema-rebuild + force_refresh checks below can
+		// run without leaking an empty m.rooms entry on bail-out.
+		// Per Codex round 5 [P2] of TASK-1319.
 		itemLock.Lock()
 
-		// Schema-mismatch rebuild (TASK-1268). Inside the per-item
-		// setup lock so a concurrent PruneAndApply / fresh Join
-		// can't race the prune-then-replay sequence: any peer that
-		// arrives in this window blocks here until we either prune
-		// or proceed cleanly. We check the LATEST persisted
-		// schema_version (LatestYjsUpdateSchemaVersion), and if it
-		// disagrees with our current m.schemaVersion we wipe the
-		// op-log for this item via PruneYjsUpdatesBefore with a
-		// far-future cutoff. items.content is canonical and is
-		// preserved — the client's lazy-seed path (TASK-1261) will
-		// re-encode it into ops at the new schema version on its
-		// next idle tick.
+		// Schema-mismatch rebuild (TASK-1268). Runs before the
+		// room is created so a rebuild-then-bail path can't leave
+		// an orphan room behind; the rebuild itself is a store-
+		// only mutation that doesn't depend on the in-memory Room.
+		// Concurrent fresh Joins for this item block on itemLock,
+		// so a peer arriving in this window sees the post-rebuild
+		// op-log when it gets its turn.
 		if err := m.maybeRebuildOnSchemaMismatch(itemID); err != nil {
 			itemLock.Unlock()
-			m.bus.Unsubscribe(rc.bus)
 			return err
 		}
 
 		// Resume-cursor / force_refresh check (TASK-1319). Run
-		// inside the per-item lock AFTER the schema rebuild so a
-		// post-rebuild empty op-log (which has no MIN) is treated
-		// the same as a fresh item — `since` is harmless because
-		// nothing was pruned out from under it. When MIN exists
-		// AND the announced cursor is below it, the client's
-		// expected suffix is unrecoverable: send force_refresh
-		// and bail. The conn is the caller's to Close.
+		// AFTER the schema rebuild so a post-rebuild empty op-log
+		// (which has no MIN) is treated correctly.
+		//
+		// `since > 0` means the client claims to have applied at
+		// least one persisted op locally. Two ways that claim is
+		// incompatible with the current op-log:
+		//   - No rows exist (`!hasMin`): the entire op-log was
+		//     pruned (PruneAndApply, schema rebuild, or dormant
+		//     GC). The client's Y.Doc is built on top of ops that
+		//     no longer exist; admitting it would let its on-open
+		//     `Y.encodeStateAsUpdate` write resurrect the stale
+		//     pre-prune document and overwrite items.content on
+		//     the next flush.
+		//   - `since < minID`: rows the client expected to replay
+		//     have been pruned (the same hazard, just with a
+		//     non-empty post-prune suffix).
+		// Both branches force_refresh and bail BEFORE we touch
+		// m.rooms — no orphan-room leak. Per Codex round 5 [P2].
 		if since > 0 {
 			minID, hasMin, merr := m.store.MinOpLogID(itemID)
 			if merr != nil {
 				itemLock.Unlock()
-				m.bus.Unsubscribe(rc.bus)
 				return merr
 			}
-			// `since > 0` means the client claims to have applied
-			// at least one persisted op locally. Two ways that
-			// claim is incompatible with the current op-log:
-			//   - No rows exist (`!hasMin`): the entire op-log
-			//     was pruned (PruneAndApply, schema rebuild, or
-			//     dormant GC). The client's Y.Doc is built on top
-			//     of ops that no longer exist; admitting it would
-			//     let its on-open `Y.encodeStateAsUpdate` write
-			//     resurrect the stale pre-prune document and
-			//     overwrite items.content on the next flush.
-			//   - `since < minID`: rows the client expected to
-			//     replay have been pruned (the same hazard, just
-			//     with a non-empty post-prune suffix).
-			// Both branches force_refresh. Per Codex round 2 [P1].
 			needsRefresh := !hasMin || since < minID
 			if needsRefresh {
 				slog.Info("collab: client cursor incompatible with op-log; sending force_refresh",
@@ -259,9 +232,24 @@ func (m *RoomManager) Join(itemID string, conn *websocket.Conn, since int64) err
 				)
 				_ = sendForceRefreshFrame(conn)
 				itemLock.Unlock()
-				m.bus.Unsubscribe(rc.bus)
 				return ErrForceRefreshSent
 			}
+		}
+
+		room := m.getOrCreate(itemID)
+		if room == nil {
+			// Close raced in between our closed-check above and
+			// getOrCreate. Bail with the same fast error so the
+			// handler closes the WS cleanly.
+			itemLock.Unlock()
+			return errManagerClosed
+		}
+
+		rc := &roomConn{
+			id:          nextConnID(),
+			conn:        conn,
+			bus:         m.bus.Subscribe(itemID),
+			connectedAt: time.Now(),
 		}
 
 		if err := room.addConn(rc); err != nil {
@@ -578,6 +566,10 @@ func (m *RoomManager) runConn(room *Room, rc *roomConn, itemLock *sync.Mutex, si
 		<-writerDone
 		return err
 	}
+	// Replay + initial cursor are committed; allow writeLoop to
+	// resume cursor advancement on subsequent live ops. Per Codex
+	// round 5 [P1] of TASK-1319.
+	rc.replayDone.Store(true)
 
 	// Read loop blocks until the WS closes.
 	readErr := room.readLoop(rc)

--- a/internal/collab/manager_test.go
+++ b/internal/collab/manager_test.go
@@ -1446,3 +1446,88 @@ func TestRoomManagerForceRefreshOnEmptyOpLogWithSince(t *testing.T) {
 		t.Fatalf("type: want %q, got %q", ControlMessageForceRefresh, cursor.Type)
 	}
 }
+
+// TestRoomManagerCursorSuppressedDuringReplay is the round 5 [P1]
+// regression: a live op broadcast during the replay window MUST NOT
+// generate an op_log_cursor TextMessage to a peer mid-replay. If it
+// did, a client disconnecting after that cursor but before the rest
+// of the replay rows would persist a cursor pointing past unreplayed
+// rows.
+//
+// We exercise the path by:
+//   - seeding 3 rows so peer B's replay has work to do,
+//   - waiting for B to subscribe AND start replay,
+//   - sending a sync from peer A (live op id=4) — broadcast lands in
+//     B's bus channel, processed by B's writeLoop concurrently with
+//     replayTo's writes.
+// The assertion is loose-but-decisive: B sees no op_log_cursor frame
+// with id == 4 BEFORE all four binary frames have arrived. After
+// replay completes the post-replay cursor (id=3) and then live cursor
+// (id=4) flow normally.
+func TestRoomManagerCursorSuppressedDuringReplay(t *testing.T) {
+	bus := NewMemoryOpBus()
+	defer bus.Close()
+	store := &fakeOpLog{}
+	for i := byte(1); i <= 3; i++ {
+		if _, err := store.AppendYjsUpdate("item-a", []byte{yMessageSync, i}, "1"); err != nil {
+			t.Fatalf("seed %d: %v", i, err)
+		}
+	}
+	mgr := NewRoomManager(store, bus)
+	srv := newCollabTestServer(t, mgr)
+	defer srv.Close()
+
+	a := dialWS(t, srv, "item-a")
+	defer a.Close()
+	// Drain A's replay (3 binary) + post-replay cursor frame.
+	_ = readBinaryWithin(t, a, time.Second)
+	_ = readBinaryWithin(t, a, time.Second)
+	_ = readBinaryWithin(t, a, time.Second)
+	_ = readControlWithin(t, a, time.Second)
+
+	b := dialWS(t, srv, "item-a")
+	defer b.Close()
+
+	// Push a live op from A while B is still in setup.
+	sendSync(t, a, 0xFF)
+
+	// B is racing replay + the live op fan-out. Read frames in
+	// order until we've collected all 4 expected binary frames
+	// (3 replayed + 1 live) and the post-replay + live cursor
+	// frames. If a cursor frame for id=4 arrives BEFORE all
+	// binary frames are accounted for, this is the regression.
+	binarySeen := 0
+	cursorIDsAtPoint := make([]int64, 0, 3)
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		b.SetReadDeadline(deadline)
+		mt, data, err := b.ReadMessage()
+		if err != nil {
+			break
+		}
+		if mt == websocket.BinaryMessage {
+			binarySeen++
+			continue
+		}
+		if mt != websocket.TextMessage {
+			continue
+		}
+		var msg ControlMessage
+		if jerr := json.Unmarshal(data, &msg); jerr != nil {
+			continue
+		}
+		if msg.Type != ControlMessageOpLogCursor {
+			continue
+		}
+		// Snapshot how many binaries we'd seen at the time this
+		// cursor arrived. A live cursor with id=4 must only come
+		// AFTER all 4 binaries are accounted for.
+		cursorIDsAtPoint = append(cursorIDsAtPoint, msg.OpLogID)
+		if msg.OpLogID == 4 && binarySeen < 4 {
+			t.Errorf("cursor id=4 arrived after only %d/4 binary frames; replay-mid cursor leaked", binarySeen)
+		}
+	}
+	if binarySeen != 4 {
+		t.Errorf("binary frames seen: want 4, got %d", binarySeen)
+	}
+}

--- a/internal/collab/manager_test.go
+++ b/internal/collab/manager_test.go
@@ -1,11 +1,13 @@
 package collab
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -185,6 +187,41 @@ func (f *fakeOpLog) PruneItemOpLogIfDormantBefore(itemID string, before time.Tim
 	return deleted, nil
 }
 
+// MinOpLogID + MaxOpLogID power TASK-1319's resume-cursor protocol.
+func (f *fakeOpLog) MinOpLogID(itemID string) (int64, bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	var minID int64
+	found := false
+	for _, r := range f.rows {
+		if r.ItemID != itemID {
+			continue
+		}
+		if !found || r.ID < minID {
+			minID = r.ID
+			found = true
+		}
+	}
+	return minID, found, nil
+}
+
+func (f *fakeOpLog) MaxOpLogID(itemID string) (int64, bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	var maxID int64
+	found := false
+	for _, r := range f.rows {
+		if r.ItemID != itemID {
+			continue
+		}
+		if !found || r.ID > maxID {
+			maxID = r.ID
+			found = true
+		}
+	}
+	return maxID, found, nil
+}
+
 func (f *fakeOpLog) appendCount() int {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -212,15 +249,33 @@ func newCollabTestServer(t *testing.T, mgr *RoomManager) *httptest.Server {
 			return
 		}
 		defer conn.Close()
-		_ = mgr.Join(itemID, conn)
+		// `?since=N` forwards the resume cursor into Join (TASK-1319).
+		// Empty / unparseable → 0, matching the production handler.
+		var since int64
+		if raw := r.URL.Query().Get("since"); raw != "" {
+			if v, perr := strconv.ParseInt(raw, 10, 64); perr == nil && v > 0 {
+				since = v
+			}
+		}
+		_ = mgr.Join(itemID, conn, since)
 	})
 	return httptest.NewServer(mux)
 }
 
 func dialWS(t *testing.T, server *httptest.Server, itemID string) *websocket.Conn {
 	t.Helper()
+	return dialWSSince(t, server, itemID, 0)
+}
+
+// dialWSSince is the resume-cursor variant: appends `?since=<id>` to
+// the WS URL so the test exercises the TASK-1319 force_refresh path.
+func dialWSSince(t *testing.T, server *httptest.Server, itemID string, since int64) *websocket.Conn {
+	t.Helper()
 	u, _ := url.Parse(server.URL)
 	wsURL := "ws://" + u.Host + "/ws/" + itemID
+	if since > 0 {
+		wsURL += "?since=" + strconv.FormatInt(since, 10)
+	}
 	c, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
 	if err != nil {
 		t.Fatalf("dial: %v", err)
@@ -249,25 +304,47 @@ func sendAwareness(t *testing.T, c *websocket.Conn, payload byte) {
 // payload bytes or fails the test on timeout.
 func readBinaryWithin(t *testing.T, c *websocket.Conn, d time.Duration) []byte {
 	t.Helper()
-	c.SetReadDeadline(time.Now().Add(d))
+	deadline := time.Now().Add(d)
+	c.SetReadDeadline(deadline)
 	defer c.SetReadDeadline(time.Time{})
-	mt, data, err := c.ReadMessage()
-	if err != nil {
-		t.Fatalf("read: %v", err)
+	for {
+		mt, data, err := c.ReadMessage()
+		if err != nil {
+			t.Fatalf("read: %v", err)
+		}
+		// Drain TASK-1319 op_log_cursor TextMessage frames so the
+		// existing binary-frame assertions stay focused on Y.Doc
+		// payload semantics.
+		if mt == websocket.TextMessage {
+			c.SetReadDeadline(deadline)
+			continue
+		}
+		if mt != websocket.BinaryMessage {
+			t.Fatalf("expected binary frame, got %d", mt)
+		}
+		return data
 	}
-	if mt != websocket.BinaryMessage {
-		t.Fatalf("expected binary frame, got %d", mt)
-	}
-	return data
 }
 
-// expectNoMessage checks that no frame arrives within d.
+// expectNoMessage checks that no NON-cursor frame arrives within d.
+// Cursor TextMessage frames (TASK-1319) are drained without failing
+// the assertion — they're metadata, not Y.Doc payload — and the
+// caller's intent is "no peer ops leaked through."
 func expectNoMessage(t *testing.T, c *websocket.Conn, d time.Duration) {
 	t.Helper()
-	c.SetReadDeadline(time.Now().Add(d))
+	deadline := time.Now().Add(d)
+	c.SetReadDeadline(deadline)
 	defer c.SetReadDeadline(time.Time{})
-	if mt, data, err := c.ReadMessage(); err == nil {
-		t.Fatalf("expected no frame, got mt=%d data=%v", mt, data)
+	for {
+		mt, data, err := c.ReadMessage()
+		if err != nil {
+			return // timeout / close — exactly what we expected
+		}
+		if mt == websocket.TextMessage {
+			c.SetReadDeadline(deadline)
+			continue
+		}
+		t.Fatalf("expected no payload frame, got mt=%d data=%v", mt, data)
 	}
 }
 
@@ -625,7 +702,7 @@ func TestRoomManagerJoinAfterCloseFailsFast(t *testing.T) {
 
 	// Direct Join — bypass the WS plumbing since we want to exercise
 	// the closed-flag short-circuit in isolation.
-	err := mgr.Join("item-a", nil) // conn is irrelevant; we never reach the WS path
+	err := mgr.Join("item-a", nil, 0) // conn is irrelevant; we never reach the WS path
 	if !errors.Is(err, errManagerClosed) {
 		t.Fatalf("want errManagerClosed, got %v", err)
 	}
@@ -663,10 +740,18 @@ func TestRoomManagerCloseShutsDownAllRooms(t *testing.T) {
 		t.Fatalf("after Close: want 0 rooms, got %d", mgr.RoomCount())
 	}
 	// Read should fail because Close closed the conn from the server
-	// side.
+	// side. Drain the post-replay op_log_cursor TextMessage
+	// (TASK-1319) so we hit the close, not a normal read.
 	c.SetReadDeadline(time.Now().Add(1 * time.Second))
-	if _, _, err := c.ReadMessage(); err == nil {
-		t.Errorf("expected read error after manager.Close")
+	for {
+		mt, _, err := c.ReadMessage()
+		if err != nil {
+			break
+		}
+		if mt == websocket.BinaryMessage {
+			t.Errorf("unexpected payload frame after manager.Close")
+			break
+		}
 	}
 }
 
@@ -700,12 +785,19 @@ func TestRoomManagerSchemaMismatchPrunes(t *testing.T) {
 	c := dialWS(t, srv, "item-a")
 	defer c.Close()
 
-	// After the prune, the op-log replay sends NOTHING. Confirm by
-	// setting a short read deadline and asserting we time out
-	// rather than receiving stale rows.
+	// After the prune, the op-log replay sends NO BINARY frames.
+	// The post-replay op_log_cursor TextMessage (TASK-1319) is
+	// expected; everything else means the prune didn't take.
 	c.SetReadDeadline(time.Now().Add(300 * time.Millisecond))
-	if _, _, err := c.ReadMessage(); err == nil {
-		t.Errorf("expected no replay frames after schema-mismatch prune; got one")
+	for {
+		mt, _, err := c.ReadMessage()
+		if err != nil {
+			break
+		}
+		if mt == websocket.BinaryMessage {
+			t.Errorf("expected no replay binary frames after schema-mismatch prune; got one")
+			break
+		}
 	}
 
 	// Op-log should be empty for item-a. The store's rowCount
@@ -1103,5 +1195,228 @@ func fakeYjsRow(itemID string, data []byte, schemaVersion string, createdAt time
 		UpdateData:    cp,
 		SchemaVersion: schemaVersion,
 		CreatedAt:     createdAt.UTC(),
+	}
+}
+
+// readControlWithin reads frames off the conn within d, drains
+// payload (binary) frames, and returns the FIRST TextMessage parsed
+// as a ControlMessage. Tests use this to assert the post-replay
+// op_log_cursor frame and force_refresh frame land cleanly.
+func readControlWithin(t *testing.T, c *websocket.Conn, d time.Duration) ControlMessage {
+	t.Helper()
+	deadline := time.Now().Add(d)
+	c.SetReadDeadline(deadline)
+	defer c.SetReadDeadline(time.Time{})
+	for {
+		mt, data, err := c.ReadMessage()
+		if err != nil {
+			t.Fatalf("read control: %v", err)
+		}
+		if mt == websocket.TextMessage {
+			var msg ControlMessage
+			if err := json.Unmarshal(data, &msg); err != nil {
+				t.Fatalf("unmarshal control: %v (raw=%q)", err, data)
+			}
+			return msg
+		}
+		// Skip binary replay frames; the cursor is what we want.
+		c.SetReadDeadline(deadline)
+	}
+}
+
+// TestRoomManagerInitialOpLogCursorAfterReplay confirms a fresh peer
+// receives an op_log_cursor TextMessage after replay so its
+// sessionStorage cursor is anchored without a round trip. Per TASK-1319.
+func TestRoomManagerInitialOpLogCursorAfterReplay(t *testing.T) {
+	bus := NewMemoryOpBus()
+	defer bus.Close()
+	store := &fakeOpLog{}
+	if _, err := store.AppendYjsUpdate("item-a", []byte{yMessageSync, 0x01}, "1"); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if _, err := store.AppendYjsUpdate("item-a", []byte{yMessageSync, 0x02}, "1"); err != nil {
+		t.Fatalf("seed 2: %v", err)
+	}
+	mgr := NewRoomManager(store, bus)
+	srv := newCollabTestServer(t, mgr)
+	defer srv.Close()
+
+	c := dialWS(t, srv, "item-a")
+	defer c.Close()
+
+	// Drain the two replay binary frames.
+	_ = readBinaryWithin(t, c, time.Second)
+	_ = readBinaryWithin(t, c, time.Second)
+
+	// Now the cursor frame must arrive, anchored at the highest
+	// replayed id (2 after two seeds).
+	cursor := readControlWithin(t, c, time.Second)
+	if cursor.Type != ControlMessageOpLogCursor {
+		t.Fatalf("type: want %q, got %q", ControlMessageOpLogCursor, cursor.Type)
+	}
+	if cursor.OpLogID != 2 {
+		t.Errorf("op_log_id: want 2, got %d", cursor.OpLogID)
+	}
+}
+
+// TestRoomManagerInitialCursorEmptyOpLog confirms a fresh peer joining
+// an item with no persisted ops still receives an op_log_cursor frame
+// with id 0 — clears any stale sessionStorage cursor from an earlier
+// life of this item id. Per TASK-1319.
+func TestRoomManagerInitialCursorEmptyOpLog(t *testing.T) {
+	bus := NewMemoryOpBus()
+	defer bus.Close()
+	mgr := NewRoomManager(&fakeOpLog{}, bus)
+	srv := newCollabTestServer(t, mgr)
+	defer srv.Close()
+
+	c := dialWS(t, srv, "item-a")
+	defer c.Close()
+
+	cursor := readControlWithin(t, c, time.Second)
+	if cursor.Type != ControlMessageOpLogCursor {
+		t.Fatalf("type: want %q, got %q", ControlMessageOpLogCursor, cursor.Type)
+	}
+	if cursor.OpLogID != 0 {
+		t.Errorf("op_log_id: want 0 (empty op-log), got %d", cursor.OpLogID)
+	}
+}
+
+// TestRoomManagerForceRefreshOnStaleSince exercises the resume-cursor
+// safety path: a client announcing `?since=N` where N is below
+// MIN(item_yjs_updates.id) gets a force_refresh frame and a closed
+// conn. Per TASK-1319.
+func TestRoomManagerForceRefreshOnStaleSince(t *testing.T) {
+	bus := NewMemoryOpBus()
+	defer bus.Close()
+	store := &fakeOpLog{}
+	// Seed two rows then prune the older one so MIN(id) > 1.
+	if _, err := store.AppendYjsUpdate("item-a", []byte{yMessageSync, 0x01}, "1"); err != nil {
+		t.Fatalf("seed 1: %v", err)
+	}
+	if _, err := store.AppendYjsUpdate("item-a", []byte{yMessageSync, 0x02}, "1"); err != nil {
+		t.Fatalf("seed 2: %v", err)
+	}
+	// Manually drop row id=1 to simulate a partial prune. The fake's
+	// rows slice is in-place; we reuse the same field write semantics
+	// as PruneYjsUpdatesBefore would.
+	store.mu.Lock()
+	kept := store.rows[:0]
+	for _, r := range store.rows {
+		if r.ID != 1 {
+			kept = append(kept, r)
+		}
+	}
+	store.rows = kept
+	store.mu.Unlock()
+
+	mgr := NewRoomManager(store, bus)
+	srv := newCollabTestServer(t, mgr)
+	defer srv.Close()
+
+	// Client claims it has applied id=0 (no rows seen) but server's
+	// MIN is now 2 — wait, since=0 is special-cased as "fresh client"
+	// and skips the force_refresh check. Use since=1 instead — below
+	// MIN=2 so the protocol fires.
+	c := dialWSSince(t, srv, "item-a", 1)
+	defer c.Close()
+
+	cursor := readControlWithin(t, c, time.Second)
+	if cursor.Type != ControlMessageForceRefresh {
+		t.Fatalf("type: want %q, got %q", ControlMessageForceRefresh, cursor.Type)
+	}
+	// After the force_refresh frame the server closes; the next
+	// read should error.
+	c.SetReadDeadline(time.Now().Add(500 * time.Millisecond))
+	if _, _, err := c.ReadMessage(); err == nil {
+		t.Errorf("expected close after force_refresh; got another frame")
+	}
+}
+
+// TestRoomManagerSinceAtOrAboveMinReplaysDelta confirms a client
+// resuming with `?since=N` where N >= MIN gets only the rows with
+// id > N (delta replay), not the entire op-log. Per TASK-1319.
+func TestRoomManagerSinceAtOrAboveMinReplaysDelta(t *testing.T) {
+	bus := NewMemoryOpBus()
+	defer bus.Close()
+	store := &fakeOpLog{}
+	for i := byte(1); i <= 4; i++ {
+		if _, err := store.AppendYjsUpdate("item-a", []byte{yMessageSync, i}, "1"); err != nil {
+			t.Fatalf("seed %d: %v", i, err)
+		}
+	}
+	mgr := NewRoomManager(store, bus)
+	srv := newCollabTestServer(t, mgr)
+	defer srv.Close()
+
+	// since=2 → expect rows id 3 and 4 only (two binary frames),
+	// then a cursor frame at id 4.
+	c := dialWSSince(t, srv, "item-a", 2)
+	defer c.Close()
+
+	got1 := readBinaryWithin(t, c, time.Second)
+	if len(got1) < 2 || got1[1] != 0x03 {
+		t.Errorf("first replayed payload: want byte 0x03, got %v", got1)
+	}
+	got2 := readBinaryWithin(t, c, time.Second)
+	if len(got2) < 2 || got2[1] != 0x04 {
+		t.Errorf("second replayed payload: want byte 0x04, got %v", got2)
+	}
+
+	// No more binary frames — the cursor should be next.
+	cursor := readControlWithin(t, c, time.Second)
+	if cursor.Type != ControlMessageOpLogCursor || cursor.OpLogID != 4 {
+		t.Errorf("cursor: want type=op_log_cursor id=4, got type=%q id=%d", cursor.Type, cursor.OpLogID)
+	}
+}
+
+// TestRoomManagerSyncCursorBroadcast confirms that after a peer
+// pushes a sync frame, the originator gets an op_log_cursor frame
+// with the new id (so it can advance its session-storage cursor)
+// AND every other peer also gets one piggybacked on the broadcast
+// (so they stay in lockstep without a round trip).
+func TestRoomManagerSyncCursorBroadcast(t *testing.T) {
+	bus := NewMemoryOpBus()
+	defer bus.Close()
+	store := &fakeOpLog{}
+	mgr := NewRoomManager(store, bus)
+	srv := newCollabTestServer(t, mgr)
+	defer srv.Close()
+
+	a := dialWS(t, srv, "item-a")
+	defer a.Close()
+	b := dialWS(t, srv, "item-a")
+	defer b.Close()
+
+	// Drain initial cursor frames on both peers.
+	_ = readControlWithin(t, a, time.Second)
+	_ = readControlWithin(t, b, time.Second)
+
+	// Wait for both subscriptions to register so the broadcast is
+	// guaranteed to reach B.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if bus.SubscriberCount("item-a") == 2 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	sendSync(t, a, 0x42)
+
+	// A (originator) gets a cursor frame with the new id (1).
+	cursorA := readControlWithin(t, a, time.Second)
+	if cursorA.Type != ControlMessageOpLogCursor || cursorA.OpLogID != 1 {
+		t.Errorf("originator cursor: want op_log_cursor id=1, got type=%q id=%d", cursorA.Type, cursorA.OpLogID)
+	}
+
+	// B receives the binary fan-out plus a cursor frame at id=1.
+	gotB := readBinaryWithin(t, b, time.Second)
+	if len(gotB) < 2 || gotB[1] != 0x42 {
+		t.Errorf("peer payload: %v", gotB)
+	}
+	cursorB := readControlWithin(t, b, time.Second)
+	if cursorB.Type != ControlMessageOpLogCursor || cursorB.OpLogID != 1 {
+		t.Errorf("peer cursor: want op_log_cursor id=1, got type=%q id=%d", cursorB.Type, cursorB.OpLogID)
 	}
 }

--- a/internal/collab/manager_test.go
+++ b/internal/collab/manager_test.go
@@ -1460,6 +1460,7 @@ func TestRoomManagerForceRefreshOnEmptyOpLogWithSince(t *testing.T) {
 //   - sending a sync from peer A (live op id=4) — broadcast lands in
 //     B's bus channel, processed by B's writeLoop concurrently with
 //     replayTo's writes.
+//
 // The assertion is loose-but-decisive: B sees no op_log_cursor frame
 // with id == 4 BEFORE all four binary frames have arrived. After
 // replay completes the post-replay cursor (id=3) and then live cursor
@@ -1497,7 +1498,6 @@ func TestRoomManagerCursorSuppressedDuringReplay(t *testing.T) {
 	// frames. If a cursor frame for id=4 arrives BEFORE all
 	// binary frames are accounted for, this is the regression.
 	binarySeen := 0
-	cursorIDsAtPoint := make([]int64, 0, 3)
 	deadline := time.Now().Add(2 * time.Second)
 	for {
 		b.SetReadDeadline(deadline)
@@ -1519,10 +1519,9 @@ func TestRoomManagerCursorSuppressedDuringReplay(t *testing.T) {
 		if msg.Type != ControlMessageOpLogCursor {
 			continue
 		}
-		// Snapshot how many binaries we'd seen at the time this
-		// cursor arrived. A live cursor with id=4 must only come
-		// AFTER all 4 binaries are accounted for.
-		cursorIDsAtPoint = append(cursorIDsAtPoint, msg.OpLogID)
+		// A live cursor with id=4 must only arrive AFTER all 4
+		// binary frames are accounted for; otherwise replay-mid
+		// cursor advancement leaked through.
 		if msg.OpLogID == 4 && binarySeen < 4 {
 			t.Errorf("cursor id=4 arrived after only %d/4 binary frames; replay-mid cursor leaked", binarySeen)
 		}

--- a/internal/collab/manager_test.go
+++ b/internal/collab/manager_test.go
@@ -1420,3 +1420,29 @@ func TestRoomManagerSyncCursorBroadcast(t *testing.T) {
 		t.Errorf("peer cursor: want op_log_cursor id=1, got type=%q id=%d", cursorB.Type, cursorB.OpLogID)
 	}
 }
+
+// TestRoomManagerForceRefreshOnEmptyOpLogWithSince exercises the
+// branch added in Codex round 2 [P1] of TASK-1319: a client
+// announces `?since=N>0` against an item whose ENTIRE op-log has
+// been pruned (PruneAndApply, schema rebuild, or dormant GC). MIN
+// is undefined, so the original `hasMin && since < minID` predicate
+// would have admitted the connection — and the client's on-open
+// `Y.encodeStateAsUpdate` write would have resurrected the stale
+// pre-prune document.
+func TestRoomManagerForceRefreshOnEmptyOpLogWithSince(t *testing.T) {
+	bus := NewMemoryOpBus()
+	defer bus.Close()
+	store := &fakeOpLog{}
+	mgr := NewRoomManager(store, bus)
+	srv := newCollabTestServer(t, mgr)
+	defer srv.Close()
+
+	// No seed rows — empty op-log, simulating post-prune state.
+	c := dialWSSince(t, srv, "item-a", 5)
+	defer c.Close()
+
+	cursor := readControlWithin(t, c, time.Second)
+	if cursor.Type != ControlMessageForceRefresh {
+		t.Fatalf("type: want %q, got %q", ControlMessageForceRefresh, cursor.Type)
+	}
+}

--- a/internal/collab/room.go
+++ b/internal/collab/room.go
@@ -262,28 +262,6 @@ func (r *Room) replayTo(rc *roomConn, since int64) (int64, error) {
 	return highest, nil
 }
 
-// sendOpLogCursor emits an op_log_cursor JSON control frame to the
-// given conn. Best-effort: any write error is returned to the caller
-// (typically discarded — a doomed conn will surface the same error
-// elsewhere and the read loop will tear down). Per TASK-1319.
-func (r *Room) sendOpLogCursor(rc *roomConn, opLogID int64) error {
-	payload, err := json.Marshal(ControlMessage{
-		Type:    ControlMessageOpLogCursor,
-		OpLogID: opLogID,
-	})
-	if err != nil {
-		// json.Marshal of a pure-scalar struct cannot fail in
-		// practice; log defensively rather than swallow.
-		slog.Warn("collab: marshal op_log_cursor failed",
-			"item_id", r.itemID,
-			"client_id", rc.id,
-			"error", err,
-		)
-		return err
-	}
-	return rc.writeMessage(websocket.TextMessage, payload)
-}
-
 // sendForceRefreshFrame writes a force_refresh control message on the
 // conn. Used by the resume-cursor protocol when the client's
 // announced `?since=<id>` is below MIN(item_yjs_updates.id) — the
@@ -365,24 +343,13 @@ func (r *Room) readLoop(rc *roomConn) error {
 				OpLogID:  persistedID,
 			})
 			r.appendMu.Unlock()
-
-			// Notify the originator of its new cursor. writeLoop
-			// skips self events (no echo of the binary frame) so
-			// without this the originating peer would never see the
-			// id its own ops were assigned. Best-effort: a write
-			// error here is the same signal the readLoop would hit
-			// on its next ReadMessage and tear down cleanly.
-			if persistedID > 0 {
-				if cerr := r.sendOpLogCursor(rc, persistedID); cerr != nil {
-					// readLoop will hit the same conn error on its
-					// next iteration; just record at debug.
-					slog.Debug("collab: send op_log_cursor to originator failed",
-						"item_id", r.itemID,
-						"client_id", rc.id,
-						"error", cerr,
-					)
-				}
-			}
+			// Originator cursor delivery is handled by writeLoop:
+			// it processes the self event from rc.bus, skips the
+			// binary echo, and emits the cursor frame for OpLogID.
+			// Sending the cursor from here (the original design)
+			// could overtake older peer ops queued in rc.bus and
+			// let the client persist a cursor past undelivered
+			// binaries — the round-23 [P1] hazard.
 
 		case yMessageAwareness:
 			// Awareness is presence — ephemeral. Never persisted.
@@ -412,9 +379,15 @@ func (r *Room) readLoop(rc *roomConn) error {
 // other goroutine surfaces an error and tears down cleanly.
 func (r *Room) writeLoop(rc *roomConn) {
 	for ev := range rc.bus {
-		if ev.ClientID == rc.id {
-			continue
-		}
+		isSelf := ev.ClientID == rc.id
+		// `isSelf`: we skip the binary echo (the originator already
+		// has the Y.Doc state) but STILL process the cursor logic
+		// below. Routing the originator's cursor through the bus
+		// FIFO is what enforces "older peer ops dispatched first."
+		// Sending it from readLoop directly (the previous design)
+		// could overtake a peer op already buffered in this conn's
+		// rc.bus, letting the client persist a cursor past
+		// undelivered binaries. Per Codex round 23 [P1] of TASK-1319.
 
 		// Hold writeMu across the entire per-event sequence —
 		// binary frame, replayDone observation, AND either cursor
@@ -429,10 +402,12 @@ func (r *Room) writeLoop(rc *roomConn) {
 		// record would be lost. Per Codex round 22 [P1] of
 		// TASK-1319.
 		rc.writeMu.Lock()
-		if err := rc.conn.WriteMessage(websocket.BinaryMessage, ev.Data); err != nil {
-			rc.writeMu.Unlock()
-			_ = rc.conn.Close()
-			return
+		if !isSelf {
+			if err := rc.conn.WriteMessage(websocket.BinaryMessage, ev.Data); err != nil {
+				rc.writeMu.Unlock()
+				_ = rc.conn.Close()
+				return
+			}
 		}
 		if ev.Type == OpTypeSync && ev.OpLogID > 0 {
 			if rc.replayDone.Load() {

--- a/internal/collab/room.go
+++ b/internal/collab/room.go
@@ -145,15 +145,18 @@ type opLogStore interface {
 	// references).
 	ListDormantOpLogItemsBefore(before time.Time) ([]string, error)
 	PruneItemOpLogIfDormantBefore(itemID string, before time.Time) (int64, error)
-	// MinOpLogID + MaxOpLogID power the resume-cursor / force-refresh
-	// + watermark-advancement protocol (TASK-1319). MinOpLogID is
-	// consulted when a reconnecting client announces `?since=<id>`:
-	// id < MIN means rows it expected to replay have been pruned, so
-	// the server sends ControlMessageForceRefresh and closes. MaxOpLogID
-	// powers the initial cursor frame after replay so the client knows
-	// where the head is even when no rows existed at replay time.
+	// MinOpLogID powers the resume-cursor / force-refresh check
+	// (TASK-1319): when a reconnecting client announces `?since=<id>`
+	// and that id is below MIN, rows it expected to replay have
+	// been pruned and the server sends ControlMessageForceRefresh.
+	// MaxOpLogID is intentionally NOT on this interface — earlier
+	// versions used it to populate the initial cursor when replay
+	// produced no rows, but Codex round 6 [P1] caught the race
+	// between MaxOpLogID and an in-flight broadcast: the cursor
+	// could advertise an id whose binary frame hadn't been
+	// delivered through this conn's writeLoop yet. The initial
+	// cursor now strictly uses `max(highestReplayed, since)`.
 	MinOpLogID(itemID string) (int64, bool, error)
-	MaxOpLogID(itemID string) (int64, bool, error)
 }
 
 // addConn registers a freshly-built roomConn with the room. Cancels

--- a/internal/collab/room.go
+++ b/internal/collab/room.go
@@ -136,6 +136,15 @@ type opLogStore interface {
 	// references).
 	ListDormantOpLogItemsBefore(before time.Time) ([]string, error)
 	PruneItemOpLogIfDormantBefore(itemID string, before time.Time) (int64, error)
+	// MinOpLogID + MaxOpLogID power the resume-cursor / force-refresh
+	// + watermark-advancement protocol (TASK-1319). MinOpLogID is
+	// consulted when a reconnecting client announces `?since=<id>`:
+	// id < MIN means rows it expected to replay have been pruned, so
+	// the server sends ControlMessageForceRefresh and closes. MaxOpLogID
+	// powers the initial cursor frame after replay so the client knows
+	// where the head is even when no rows existed at replay time.
+	MinOpLogID(itemID string) (int64, bool, error)
+	MaxOpLogID(itemID string) (int64, bool, error)
 }
 
 // addConn registers a freshly-built roomConn with the room. Cancels
@@ -194,26 +203,82 @@ func (r *Room) onGraceExpired() {
 	r.onIdle(r.itemID)
 }
 
-// replayTo sends every persisted op-log update for this room to the
-// given connection in order. Each row goes out as its own binary
-// WebSocket frame so a Yjs peer applies them via the same y-protocol
-// path it uses for live updates. Stops on the first WS write error
-// (the connection is doomed); the caller's read loop will surface
-// the same error and tear the connection down cleanly.
-func (r *Room) replayTo(rc *roomConn) error {
-	updates, err := r.store.LoadYjsUpdatesSince(r.itemID, 0)
+// replayTo sends every persisted op-log update for this room with id
+// strictly greater than `since` to the given connection in order. Each
+// row goes out as its own binary WebSocket frame so a Yjs peer applies
+// them via the same y-protocol path it uses for live updates. Stops on
+// the first WS write error (the connection is doomed); the caller's
+// read loop will surface the same error and tear the connection down
+// cleanly.
+//
+// `since == 0` is the fresh-client path (replay everything). The
+// caller is responsible for the prerequisite check that `since`
+// isn't below the current MIN(id) — an out-of-range cursor means
+// rows the client expected have been pruned and the response should
+// be a force_refresh, not a partial replay.
+//
+// Returns the highest replayed id (or 0 when no rows landed) so the
+// caller can emit a follow-on op_log_cursor frame anchoring the
+// client's resume point. Per TASK-1319.
+func (r *Room) replayTo(rc *roomConn, since int64) (int64, error) {
+	updates, err := r.store.LoadYjsUpdatesSince(r.itemID, since)
 	if err != nil {
-		return err
+		return 0, err
 	}
+	var highest int64
 	for _, u := range updates {
 		if len(u.UpdateData) == 0 {
 			continue
 		}
 		if werr := rc.writeMessage(websocket.BinaryMessage, u.UpdateData); werr != nil {
-			return werr
+			return highest, werr
+		}
+		if u.ID > highest {
+			highest = u.ID
 		}
 	}
-	return nil
+	return highest, nil
+}
+
+// sendOpLogCursor emits an op_log_cursor JSON control frame to the
+// given conn. Best-effort: any write error is returned to the caller
+// (typically discarded — a doomed conn will surface the same error
+// elsewhere and the read loop will tear down). Per TASK-1319.
+func (r *Room) sendOpLogCursor(rc *roomConn, opLogID int64) error {
+	payload, err := json.Marshal(ControlMessage{
+		Type:    ControlMessageOpLogCursor,
+		OpLogID: opLogID,
+	})
+	if err != nil {
+		// json.Marshal of a pure-scalar struct cannot fail in
+		// practice; log defensively rather than swallow.
+		slog.Warn("collab: marshal op_log_cursor failed",
+			"item_id", r.itemID,
+			"client_id", rc.id,
+			"error", err,
+		)
+		return err
+	}
+	return rc.writeMessage(websocket.TextMessage, payload)
+}
+
+// sendForceRefreshFrame writes a force_refresh control message on the
+// conn. Used by the resume-cursor protocol when the client's
+// announced `?since=<id>` is below MIN(item_yjs_updates.id) — the
+// only safe response is to tell the client to discard local Y.Doc
+// state and lazy-seed from items.content. The caller closes the
+// conn after this returns. Per TASK-1319.
+func sendForceRefreshFrame(conn *websocket.Conn) error {
+	payload, err := json.Marshal(ControlMessage{
+		Type: ControlMessageForceRefresh,
+	})
+	if err != nil {
+		return err
+	}
+	// Set a short write deadline: a doomed conn shouldn't block the
+	// upgrade-time check indefinitely.
+	_ = conn.SetWriteDeadline(time.Now().Add(closeFrameDeadline))
+	return conn.WriteMessage(websocket.TextMessage, payload)
 }
 
 // readLoop is the inbound side: pull frames off the WebSocket, route
@@ -258,22 +323,44 @@ func (r *Room) readLoop(rc *roomConn) error {
 			// persist and broadcast loses at most a live keystroke
 			// that the originating peer will replay on reconnect
 			// anyway.
-			if _, err := r.store.AppendYjsUpdate(r.itemID, data, r.schemaVersion); err != nil {
+			persistedID, err := r.store.AppendYjsUpdate(r.itemID, data, r.schemaVersion)
+			if err != nil {
 				slog.Error("collab: append op-log",
 					"item_id", r.itemID,
 					"client_id", rc.id,
 					"error", err,
 				)
 				// Continue: broadcast keeps the live mesh consistent
-				// even when persistence is blipping.
+				// even when persistence is blipping. persistedID == 0
+				// → no cursor frame is emitted by writeLoop for this
+				// event (we'd be advertising a fictional id).
 			}
 			r.bus.Publish(OpEvent{
 				ItemID:   r.itemID,
 				ClientID: rc.id,
 				Type:     OpTypeSync,
 				Data:     data,
+				OpLogID:  persistedID,
 			})
 			r.appendMu.Unlock()
+
+			// Notify the originator of its new cursor. writeLoop
+			// skips self events (no echo of the binary frame) so
+			// without this the originating peer would never see the
+			// id its own ops were assigned. Best-effort: a write
+			// error here is the same signal the readLoop would hit
+			// on its next ReadMessage and tear down cleanly.
+			if persistedID > 0 {
+				if cerr := r.sendOpLogCursor(rc, persistedID); cerr != nil {
+					// readLoop will hit the same conn error on its
+					// next iteration; just record at debug.
+					slog.Debug("collab: send op_log_cursor to originator failed",
+						"item_id", r.itemID,
+						"client_id", rc.id,
+						"error", cerr,
+					)
+				}
+			}
 
 		case yMessageAwareness:
 			// Awareness is presence — ephemeral. Never persisted.
@@ -310,6 +397,16 @@ func (r *Room) writeLoop(rc *roomConn) {
 			// Force the read side to wake up and return.
 			_ = rc.conn.Close()
 			return
+		}
+		// Track the receiver's applied cursor when a sync frame
+		// has a persisted id. Awareness frames and frames whose
+		// AppendYjsUpdate failed (OpLogID == 0) do NOT advance the
+		// receiver's cursor — neither was persisted. Per TASK-1319.
+		if ev.Type == OpTypeSync && ev.OpLogID > 0 {
+			if err := r.sendOpLogCursor(rc, ev.OpLogID); err != nil {
+				_ = rc.conn.Close()
+				return
+			}
 		}
 	}
 }

--- a/internal/collab/room.go
+++ b/internal/collab/room.go
@@ -415,35 +415,48 @@ func (r *Room) writeLoop(rc *roomConn) {
 		if ev.ClientID == rc.id {
 			continue
 		}
-		if err := rc.writeMessage(websocket.BinaryMessage, ev.Data); err != nil {
-			// Force the read side to wake up and return.
+
+		// Hold writeMu across the entire per-event sequence —
+		// binary frame, replayDone observation, AND either cursor
+		// send (replayDone) or maxLive record (!replayDone). With
+		// the same lock used by runConn's post-replay cursor
+		// write, runConn observes either:
+		//   - this event's record (we ran first), OR
+		//   - this event's send (replayDone flipped before we
+		//     got the lock, so we publish a normal live cursor).
+		// Without the wider lock, runConn could read maxLive
+		// AFTER we wrote the binary but BEFORE we recorded — the
+		// record would be lost. Per Codex round 22 [P1] of
+		// TASK-1319.
+		rc.writeMu.Lock()
+		if err := rc.conn.WriteMessage(websocket.BinaryMessage, ev.Data); err != nil {
+			rc.writeMu.Unlock()
 			_ = rc.conn.Close()
 			return
 		}
-		// Track the receiver's applied cursor when a sync frame
-		// has a persisted id. Awareness frames and frames whose
-		// AppendYjsUpdate failed (OpLogID == 0) do NOT advance the
-		// receiver's cursor — neither was persisted. Per TASK-1319.
-		//
-		// During replay (replayDone == false) we suppress cursor
-		// frames so a live op broadcast mid-replay can't bump the
-		// client's persisted cursor past replay rows it hasn't
-		// received yet. The post-replay cursor frame in runConn
-		// flips replayDone, after which live ops resume cursor
-		// advancement. Per Codex round 5 [P1].
-		//
-		// The suppressed id is recorded so runConn can fold the
-		// highest live id into the post-replay cursor. Otherwise
-		// a live op that landed binary-applied client-side during
-		// the replay window would leave the client's cursor below
-		// its applied state. Per Codex round 21 [P1].
 		if ev.Type == OpTypeSync && ev.OpLogID > 0 {
 			if rc.replayDone.Load() {
-				if err := r.sendOpLogCursor(rc, ev.OpLogID); err != nil {
+				payload, perr := json.Marshal(ControlMessage{
+					Type:    ControlMessageOpLogCursor,
+					OpLogID: ev.OpLogID,
+				})
+				if perr != nil {
+					slog.Warn("collab: marshal op_log_cursor failed",
+						"item_id", r.itemID,
+						"client_id", rc.id,
+						"error", perr,
+					)
+				} else if werr := rc.conn.WriteMessage(websocket.TextMessage, payload); werr != nil {
+					rc.writeMu.Unlock()
 					_ = rc.conn.Close()
 					return
 				}
 			} else {
+				// CAS-loop into the suppressed-cursor max so
+				// runConn's read after replay sees the latest
+				// id. Held under writeMu so an external read
+				// won't observe a stale value while we're still
+				// in this critical section.
 				for {
 					prev := rc.maxLiveOpLogIDDuringReplay.Load()
 					if ev.OpLogID <= prev {
@@ -455,6 +468,7 @@ func (r *Room) writeLoop(rc *roomConn) {
 				}
 			}
 		}
+		rc.writeMu.Unlock()
 	}
 }
 

--- a/internal/collab/room.go
+++ b/internal/collab/room.go
@@ -68,6 +68,16 @@ type roomConn struct {
 	// resume cursor pointing past unreplayed rows. Per Codex round
 	// 5 [P1] of TASK-1319.
 	replayDone atomic.Bool
+	// maxLiveOpLogIDDuringReplay records the highest persisted op-log
+	// id whose binary frame this conn's writeLoop fanned out before
+	// `replayDone` flipped true. The post-replay initial cursor uses
+	// max(highestReplayed, since, this) so a live op that was applied
+	// to the client's Y.Doc during the replay window doesn't leave
+	// the client cursor pointing below the highest applied op — that
+	// mismatch would trip the client's `cursor=0 + remoteSyncApplied`
+	// force_refresh path on empty-replay sessions and discard
+	// buffered pre-anchor edits. Per Codex round 21 [P1] of TASK-1319.
+	maxLiveOpLogIDDuringReplay atomic.Int64
 }
 
 // writeMessage is a tiny helper that holds writeMu while writing one
@@ -421,10 +431,28 @@ func (r *Room) writeLoop(rc *roomConn) {
 		// received yet. The post-replay cursor frame in runConn
 		// flips replayDone, after which live ops resume cursor
 		// advancement. Per Codex round 5 [P1].
-		if ev.Type == OpTypeSync && ev.OpLogID > 0 && rc.replayDone.Load() {
-			if err := r.sendOpLogCursor(rc, ev.OpLogID); err != nil {
-				_ = rc.conn.Close()
-				return
+		//
+		// The suppressed id is recorded so runConn can fold the
+		// highest live id into the post-replay cursor. Otherwise
+		// a live op that landed binary-applied client-side during
+		// the replay window would leave the client's cursor below
+		// its applied state. Per Codex round 21 [P1].
+		if ev.Type == OpTypeSync && ev.OpLogID > 0 {
+			if rc.replayDone.Load() {
+				if err := r.sendOpLogCursor(rc, ev.OpLogID); err != nil {
+					_ = rc.conn.Close()
+					return
+				}
+			} else {
+				for {
+					prev := rc.maxLiveOpLogIDDuringReplay.Load()
+					if ev.OpLogID <= prev {
+						break
+					}
+					if rc.maxLiveOpLogIDDuringReplay.CompareAndSwap(prev, ev.OpLogID) {
+						break
+					}
+				}
 			}
 		}
 	}

--- a/internal/collab/room.go
+++ b/internal/collab/room.go
@@ -59,6 +59,15 @@ type roomConn struct {
 	bus         chan OpEvent
 	writeMu     sync.Mutex
 	connectedAt time.Time
+	// replayDone is set after replayTo + the initial post-replay
+	// op_log_cursor frame have been written. writeLoop suppresses
+	// op_log_cursor frames before this flips so live ops broadcast
+	// during the replay window don't advance the client's cursor
+	// past replay rows it hasn't yet seen — disconnecting mid-replay
+	// after a single live cursor would otherwise leave the client's
+	// resume cursor pointing past unreplayed rows. Per Codex round
+	// 5 [P1] of TASK-1319.
+	replayDone atomic.Bool
 }
 
 // writeMessage is a tiny helper that holds writeMu while writing one
@@ -402,7 +411,14 @@ func (r *Room) writeLoop(rc *roomConn) {
 		// has a persisted id. Awareness frames and frames whose
 		// AppendYjsUpdate failed (OpLogID == 0) do NOT advance the
 		// receiver's cursor — neither was persisted. Per TASK-1319.
-		if ev.Type == OpTypeSync && ev.OpLogID > 0 {
+		//
+		// During replay (replayDone == false) we suppress cursor
+		// frames so a live op broadcast mid-replay can't bump the
+		// client's persisted cursor past replay rows it hasn't
+		// received yet. The post-replay cursor frame in runConn
+		// flips replayDone, after which live ops resume cursor
+		// advancement. Per Codex round 5 [P1].
+		if ev.Type == OpTypeSync && ev.OpLogID > 0 && rc.replayDone.Load() {
 			if err := r.sendOpLogCursor(rc, ev.OpLogID); err != nil {
 				_ = rc.conn.Close()
 				return

--- a/internal/models/item.go
+++ b/internal/models/item.go
@@ -547,6 +547,25 @@ type ItemUpdate struct {
 	VersionSource string  `json:"version_source,omitempty"`
 	ChangeSummary string  `json:"change_summary,omitempty"`
 	Comment       *string `json:"comment,omitempty"`
+	// OpLogCursor is the highest item_yjs_updates.id the calling client
+	// has applied into its local Y.Doc (TASK-1319). Used by the
+	// collab-snapshot flush PATCH to advance the op-log GC watermark
+	// (`items.content_flushed_op_log_id`) when, and only when, the
+	// cursor matches the current MAX(item_yjs_updates.id) for the item.
+	//
+	// **Why a pointer.** A nil cursor means "the caller didn't claim
+	// to know"; the watermark stays put. *0 means "I have nothing"
+	// (e.g. a fresh editor whose op-log is empty); when MAX is also 0
+	// the watermark advances to 0 (a no-op stamp) — but practical
+	// flushes always have *some* op-log id, so this branch rarely
+	// matters.
+	//
+	// Only honoured when VersionSource == "collab-snapshot". Other
+	// content writes (CLI / MCP / version restore / PruneAndApply)
+	// already advance the watermark to MAX(op-log.id) at write time
+	// because they reconstruct or replace items.content wholesale.
+	// Per TASK-1319.
+	OpLogCursor *int64 `json:"op_log_cursor,omitempty"`
 	// ClearAssignedUser / ClearAgentRole allow explicitly setting to NULL
 	// (since nil pointer means "don't change" in partial updates)
 	ClearAssignedUser bool `json:"clear_assigned_user,omitempty"`

--- a/internal/server/handlers_collab.go
+++ b/internal/server/handlers_collab.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"math/rand"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/PerpetualSoftware/pad/internal/collab"
@@ -141,6 +142,22 @@ func (s *Server) handleCollab(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// `?since=<id>` is the resume-cursor announce (TASK-1319). The
+	// client tells us the highest item_yjs_updates.id its local
+	// Y.Doc has applied; if that id is below the current MIN, the
+	// expected suffix has been pruned and the room manager sends a
+	// `force_refresh` JSON control frame after the upgrade (we need
+	// the conn to write the JSON, hence post-upgrade). Empty / blank
+	// / unparseable values are tolerated as 0 (treat as fresh
+	// client) so older bundles served from a browser cache during a
+	// deploy still get a working session.
+	var sinceID int64
+	if raw := r.URL.Query().Get("since"); raw != "" {
+		if v, perr := strconv.ParseInt(raw, 10, 64); perr == nil && v > 0 {
+			sinceID = v
+		}
+	}
+
 	conn, err := collabUpgrader.Upgrade(w, r, nil)
 	if err != nil {
 		// Upgrade itself emits the right HTTP status (e.g. 400 on
@@ -193,7 +210,13 @@ func (s *Server) handleCollab(w http.ResponseWriter, r *http.Request) {
 	// Hand the connection to the RoomManager. It owns the
 	// op-log replay, fan-out, and lifecycle bookkeeping (lazy create
 	// + grace-TTL reclaim). Returns when the WS closes for any reason.
-	if err := s.collab.Join(itemID, conn); err != nil {
+	if err := s.collab.Join(itemID, conn, sinceID); err != nil {
+		// ErrForceRefreshSent is the protocol's normal close-after-
+		// notify path — the JSON frame is already on the wire and
+		// the client knows what to do. Don't warn.
+		if errors.Is(err, collab.ErrForceRefreshSent) {
+			return
+		}
 		// Normal closure paths surface here as websocket.CloseError
 		// values that aren't worth logging. Anything unexpected
 		// (transport failure, room manager hard error) gets a warn.

--- a/internal/server/handlers_collab_test.go
+++ b/internal/server/handlers_collab_test.go
@@ -466,8 +466,23 @@ func TestCollabMembershipRevalidationClosesOnRevoke(t *testing.T) {
 	// jittered across [0, interval) — worst case is ~30ms — so
 	// 2 seconds is wildly generous. A timeout here means the WS is
 	// still open, which is the bug being regression-tested.
+	//
+	// Drain initial control frames (the post-replay op_log_cursor
+	// from TASK-1319) until either an error surfaces (the close
+	// we want) or the deadline trips. Without the drain the very
+	// first read returns the cursor TextMessage and the test would
+	// false-pass on a still-open connection.
 	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
-	_, _, readErr := conn.ReadMessage()
+	var readErr error
+	for {
+		_, _, err := conn.ReadMessage()
+		if err != nil {
+			readErr = err
+			break
+		}
+		// A control/data frame slipped through before the close —
+		// keep reading until we see the close.
+	}
 	if readErr == nil {
 		t.Fatal("expected read error after membership revocation; got none (WS still open)")
 	}

--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -3,6 +3,7 @@ package server
 import (
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -16,6 +17,14 @@ import (
 	"github.com/PerpetualSoftware/pad/internal/items"
 	"github.com/PerpetualSoftware/pad/internal/models"
 )
+
+// errStaleCollabSnapshot signals an UnderItemLock-wrapped
+// collab-snapshot validation rejected the PATCH because the
+// caller's op_log_cursor was incompatible with the current op-log
+// (cursor>0 + empty op-log, or cursor<MIN). The handler unwraps
+// this via errors.Is and returns 409 Conflict. Per Codex round 13
+// [P1] of TASK-1319.
+var errStaleCollabSnapshot = errors.New("collab-snapshot: cursor incompatible with op-log")
 
 // handleListItems lists all items across collections in a workspace.
 func (s *Server) handleListItems(w http.ResponseWriter, r *http.Request) {
@@ -545,30 +554,71 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 	// (`forceRefreshInFlight`) covers the common case but an
 	// already-in-flight fetch can race a force_refresh and reach
 	// this handler with stale content. Per Codex round 10 [P1].
-	if collabSnapshot && input.Content != nil && input.OpLogCursor != nil {
+	// Collab-snapshot path (TASK-1319). Run validation + UpdateItem
+	// under the per-item collab setup lock so concurrent prunes
+	// (PruneAndApply, schema rebuild, dormant GC) cannot land
+	// between the cursor check and the items.content write — that
+	// race would let a stale snapshot overwrite canonical content
+	// the prune just installed. Per Codex round 13 [P1].
+	if collabSnapshot && input.Content != nil && s.collab != nil {
+		err := s.collab.UnderItemLock(item.ID, func() error {
+			if input.OpLogCursor != nil {
+				minID, hasMin, merr := s.store.MinOpLogID(item.ID)
+				if merr != nil {
+					return merr
+				}
+				// Reject any incompatible cursor:
+				//   - cursor > 0 against an empty op-log (entire
+				//     log pruned). Flushing tab's Y.Doc was built
+				//     on rows that no longer exist.
+				//   - cursor < MIN against a non-empty op-log
+				//     (includes cursor=0 + non-empty: a Y.Doc
+				//     populated by replay binaries whose previous
+				//     session never received the post-replay
+				//     cursor frame). Per round 12 [P1].
+				var stale bool
+				switch {
+				case !hasMin && *input.OpLogCursor > 0:
+					stale = true
+				case hasMin && *input.OpLogCursor < minID:
+					stale = true
+				}
+				if stale {
+					slog.Info("collab-snapshot: rejecting PATCH; cursor incompatible with op-log",
+						"item_id", item.ID,
+						"cursor", *input.OpLogCursor,
+						"min_id", minID,
+						"has_min", hasMin,
+					)
+					return errStaleCollabSnapshot
+				}
+			}
+			updated, uerr := s.store.UpdateItem(item.ID, input)
+			if uerr != nil {
+				return uerr
+			}
+			fullWriteHandled = true
+			fullWriteUpdated = updated
+			return nil
+		})
+		if err != nil {
+			if errors.Is(err, errStaleCollabSnapshot) {
+				writeError(w, http.StatusConflict, "stale_collab_snapshot",
+					"This editor's view is out of sync with the server; please reload.")
+				return
+			}
+			writeInternalError(w, err)
+			return
+		}
+	} else if collabSnapshot && input.Content != nil && input.OpLogCursor != nil {
+		// Fallback for the collab-disabled build (s.collab == nil): no
+		// concurrent prunes happen, so the un-locked check is
+		// race-free here. The cursor gate semantics are unchanged.
 		minID, hasMin, merr := s.store.MinOpLogID(item.ID)
 		if merr != nil {
 			writeInternalError(w, merr)
 			return
 		}
-		// Reject any incompatible cursor:
-		//   - cursor > 0 against an empty op-log (entire log
-		//     pruned: PruneAndApply, schema rebuild, dormant GC).
-		//     The flushing tab's Y.Doc was built on rows that no
-		//     longer exist.
-		//   - cursor < MIN against a non-empty op-log. The cursor
-		//     points below the surviving prefix; rows the client
-		//     expected to anchor against have been pruned. This
-		//     branch ALSO catches cursor=0 against a non-empty
-		//     op-log: a stateful Y.Doc whose previous session
-		//     never received a cursor frame (network blip during
-		//     the post-replay cursor write) reconnects with
-		//     cursor=0, sends Y.encodeStateAsUpdate of stale
-		//     local state on the WS open, then the next 5s flush
-		//     PATCHes that stale-derived markdown back to
-		//     canonical items.content. Rejecting cursor=0 +
-		//     hasMin closes the corruption path. Per Codex round
-		//     12 [P1] of TASK-1319.
 		var stale bool
 		switch {
 		case !hasMin && *input.OpLogCursor > 0:

--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -551,19 +551,32 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 			writeInternalError(w, merr)
 			return
 		}
-		// Mirror the WS-upgrade force_refresh predicate: a
-		// non-zero cursor is incompatible with the current op-log
-		// when EITHER the op-log is empty (entire log pruned —
-		// PruneAndApply, schema rebuild, dormant GC) OR the cursor
-		// is below MIN. Either way the flushing tab's Y.Doc was
-		// built on rows that no longer exist; its markdown is
-		// stale relative to canonical content.
-		//
-		// A cursor of 0 falls through (older clients, fresh
-		// editor with no ops yet) — the store's CASE clause leaves
-		// the watermark alone in that case, so no over-advancement
-		// is possible. Per Codex round 11 [P1] of TASK-1319.
-		if *input.OpLogCursor > 0 && (!hasMin || *input.OpLogCursor < minID) {
+		// Reject any incompatible cursor:
+		//   - cursor > 0 against an empty op-log (entire log
+		//     pruned: PruneAndApply, schema rebuild, dormant GC).
+		//     The flushing tab's Y.Doc was built on rows that no
+		//     longer exist.
+		//   - cursor < MIN against a non-empty op-log. The cursor
+		//     points below the surviving prefix; rows the client
+		//     expected to anchor against have been pruned. This
+		//     branch ALSO catches cursor=0 against a non-empty
+		//     op-log: a stateful Y.Doc whose previous session
+		//     never received a cursor frame (network blip during
+		//     the post-replay cursor write) reconnects with
+		//     cursor=0, sends Y.encodeStateAsUpdate of stale
+		//     local state on the WS open, then the next 5s flush
+		//     PATCHes that stale-derived markdown back to
+		//     canonical items.content. Rejecting cursor=0 +
+		//     hasMin closes the corruption path. Per Codex round
+		//     12 [P1] of TASK-1319.
+		var stale bool
+		switch {
+		case !hasMin && *input.OpLogCursor > 0:
+			stale = true
+		case hasMin && *input.OpLogCursor < minID:
+			stale = true
+		}
+		if stale {
 			slog.Info("collab-snapshot: rejecting PATCH; cursor incompatible with op-log",
 				"item_id", item.ID,
 				"cursor", *input.OpLogCursor,

--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -551,17 +551,24 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 			writeInternalError(w, merr)
 			return
 		}
-		// Only reject when MIN exists AND cursor is below it. An
-		// empty op-log (`!hasMin`) means no peer ops exist —
-		// every browser-flush is trivially caught up. A cursor of
-		// 0 is also fine (older clients, or fresh editor) — the
-		// store's CASE clause leaves the watermark alone in that
-		// case.
-		if hasMin && *input.OpLogCursor < minID {
-			slog.Info("collab-snapshot: rejecting PATCH; cursor below op-log MIN",
+		// Mirror the WS-upgrade force_refresh predicate: a
+		// non-zero cursor is incompatible with the current op-log
+		// when EITHER the op-log is empty (entire log pruned —
+		// PruneAndApply, schema rebuild, dormant GC) OR the cursor
+		// is below MIN. Either way the flushing tab's Y.Doc was
+		// built on rows that no longer exist; its markdown is
+		// stale relative to canonical content.
+		//
+		// A cursor of 0 falls through (older clients, fresh
+		// editor with no ops yet) — the store's CASE clause leaves
+		// the watermark alone in that case, so no over-advancement
+		// is possible. Per Codex round 11 [P1] of TASK-1319.
+		if *input.OpLogCursor > 0 && (!hasMin || *input.OpLogCursor < minID) {
+			slog.Info("collab-snapshot: rejecting PATCH; cursor incompatible with op-log",
 				"item_id", item.ID,
 				"cursor", *input.OpLogCursor,
 				"min_id", minID,
+				"has_min", hasMin,
 			)
 			writeError(w, http.StatusConflict, "stale_collab_snapshot",
 				"This editor's view is out of sync with the server; please reload.")

--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -534,6 +534,41 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 		input.VersionSource = "collab-snapshot"
 	}
 
+	// Server-side gate: reject collab-snapshot PATCHes whose
+	// op_log_cursor is below MIN(item_yjs_updates.id). Such a
+	// cursor proves the flushing tab's Y.Doc was built on op-log
+	// rows that no longer exist (PruneAndApply, schema rebuild,
+	// dormant GC, or post-force_refresh races). The markdown the
+	// PATCH carries is, by definition, stale relative to the
+	// canonical content; accepting it would overwrite items.content
+	// from a known-bad source. The client-side guard
+	// (`forceRefreshInFlight`) covers the common case but an
+	// already-in-flight fetch can race a force_refresh and reach
+	// this handler with stale content. Per Codex round 10 [P1].
+	if collabSnapshot && input.Content != nil && input.OpLogCursor != nil {
+		minID, hasMin, merr := s.store.MinOpLogID(item.ID)
+		if merr != nil {
+			writeInternalError(w, merr)
+			return
+		}
+		// Only reject when MIN exists AND cursor is below it. An
+		// empty op-log (`!hasMin`) means no peer ops exist —
+		// every browser-flush is trivially caught up. A cursor of
+		// 0 is also fine (older clients, or fresh editor) — the
+		// store's CASE clause leaves the watermark alone in that
+		// case.
+		if hasMin && *input.OpLogCursor < minID {
+			slog.Info("collab-snapshot: rejecting PATCH; cursor below op-log MIN",
+				"item_id", item.ID,
+				"cursor", *input.OpLogCursor,
+				"min_id", minID,
+			)
+			writeError(w, http.StatusConflict, "stale_collab_snapshot",
+				"This editor's view is out of sync with the server; please reload.")
+			return
+		}
+	}
+
 	if input.Content != nil && s.collab != nil && !collabSnapshot {
 		// applyContentViaCollab calls directWrite ONLY on the no-
 		// room/no-applier paths (where pruning the op-log is safe

--- a/internal/server/handlers_items_collab_versions_test.go
+++ b/internal/server/handlers_items_collab_versions_test.go
@@ -321,3 +321,39 @@ func TestCollabSnapshotAcceptsCursorAtOrAboveMin(t *testing.T) {
 		t.Fatalf("expected 200 OK for cursor>=MIN; got %d %s", rr.Code, rr.Body.String())
 	}
 }
+
+// TestCollabSnapshotRejectsCursorOnEmptyOpLog mirrors the WS
+// force_refresh predicate at the HTTP layer (Codex round 11 [P1]
+// of TASK-1319). A non-zero cursor against an item whose op-log
+// is entirely empty is, by construction, stale: the rows the
+// client claims to have applied no longer exist. Reject 409.
+func TestCollabSnapshotRejectsCursorOnEmptyOpLog(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	rr := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections/tasks/items", map[string]interface{}{
+		"title":   "Empty oplog test",
+		"content": "v1",
+		"source":  "cli",
+		"fields":  `{"status":"open"}`,
+	})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create: %d %s", rr.Code, rr.Body.String())
+	}
+	var created models.Item
+	parseJSON(t, rr, &created)
+
+	// No op-log seed — the table is empty for this item. Cursor=42
+	// is a non-zero claim that can't be reconciled.
+	cursor := int64(42)
+	rr = doRequest(srv, "PATCH",
+		"/api/v1/workspaces/"+slug+"/items/"+created.Slug+"?source=collab-snapshot",
+		map[string]interface{}{
+			"content":       "stale-empty-oplog-content",
+			"op_log_cursor": cursor,
+		},
+	)
+	if rr.Code != http.StatusConflict {
+		t.Fatalf("expected 409 Conflict for non-zero cursor on empty op-log; got %d %s", rr.Code, rr.Body.String())
+	}
+}

--- a/internal/server/handlers_items_collab_versions_test.go
+++ b/internal/server/handlers_items_collab_versions_test.go
@@ -357,3 +357,44 @@ func TestCollabSnapshotRejectsCursorOnEmptyOpLog(t *testing.T) {
 		t.Fatalf("expected 409 Conflict for non-zero cursor on empty op-log; got %d %s", rr.Code, rr.Body.String())
 	}
 }
+
+// TestCollabSnapshotRejectsCursorZeroOnNonEmptyOpLog (round 12
+// [P1] of TASK-1319): a stateful tab whose previous session
+// disconnected before receiving any op_log_cursor frame ends up
+// with sessionStorage cursor=0 but a non-empty Y.Doc derived from
+// prior replay binaries. On flush, it carries cursor=0 alongside
+// Y.Doc-derived markdown. Without the gate, items.content would
+// be overwritten by the stale view.
+func TestCollabSnapshotRejectsCursorZeroOnNonEmptyOpLog(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	rr := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections/tasks/items", map[string]interface{}{
+		"title":   "Cursor zero stale test",
+		"content": "v1",
+		"source":  "cli",
+		"fields":  `{"status":"open"}`,
+	})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create: %d %s", rr.Code, rr.Body.String())
+	}
+	var created models.Item
+	parseJSON(t, rr, &created)
+
+	// Seed an op-log row so MIN is non-zero.
+	if _, err := srv.store.AppendYjsUpdate(created.ID, []byte{0x00, 0x01}, "1"); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	cursor := int64(0)
+	rr = doRequest(srv, "PATCH",
+		"/api/v1/workspaces/"+slug+"/items/"+created.Slug+"?source=collab-snapshot",
+		map[string]interface{}{
+			"content":       "stale-zero-cursor-content",
+			"op_log_cursor": cursor,
+		},
+	)
+	if rr.Code != http.StatusConflict {
+		t.Fatalf("expected 409 Conflict for cursor=0 on non-empty op-log; got %d %s", rr.Code, rr.Body.String())
+	}
+}

--- a/internal/server/handlers_items_collab_versions_test.go
+++ b/internal/server/handlers_items_collab_versions_test.go
@@ -218,3 +218,106 @@ func sourcesOf(versions []models.Version) []string {
 	}
 	return out
 }
+
+// TestCollabSnapshotRejectsCursorBelowMin is the TASK-1319 round 10
+// [P1] regression: a collab-snapshot PATCH whose op_log_cursor is
+// below the current MIN(item_yjs_updates.id) MUST be rejected at
+// the handler with 409. Such a cursor proves the flushing tab's
+// Y.Doc was built on op-log rows that no longer exist (PruneAndApply,
+// schema rebuild, dormant GC, or the post-force_refresh race window
+// where a server-side rejection is the only authoritative gate).
+// Accepting it would overwrite items.content with markdown derived
+// from a known-bad source.
+func TestCollabSnapshotRejectsCursorBelowMin(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	rr := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections/tasks/items", map[string]interface{}{
+		"title":   "Stale cursor test",
+		"content": "v1",
+		"source":  "cli",
+		"fields":  `{"status":"open"}`,
+	})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create: %d %s", rr.Code, rr.Body.String())
+	}
+	var created models.Item
+	parseJSON(t, rr, &created)
+
+	// Seed three op-log rows then drop ids 1+2 to simulate a
+	// post-PruneAndApply state where MIN(id) = 3.
+	for i := 1; i <= 3; i++ {
+		if _, err := srv.store.AppendYjsUpdate(created.ID, []byte{0x00, byte(i)}, "1"); err != nil {
+			t.Fatalf("seed %d: %v", i, err)
+		}
+	}
+	// Truncate via the public API: prune everything older than now,
+	// then re-append two rows so MIN advances past the originals.
+	if _, err := srv.store.PruneYjsUpdatesBefore(created.ID, time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("prune: %v", err)
+	}
+	for i := 4; i <= 5; i++ {
+		if _, err := srv.store.AppendYjsUpdate(created.ID, []byte{0x00, byte(i)}, "1"); err != nil {
+			t.Fatalf("re-seed %d: %v", i, err)
+		}
+	}
+	// MIN is now id=4. Cursor=2 is below MIN → handler must 409.
+
+	cursor := int64(2)
+	rr = doRequest(srv, "PATCH",
+		"/api/v1/workspaces/"+slug+"/items/"+created.Slug+"?source=collab-snapshot",
+		map[string]interface{}{
+			"content":       "stale-flush-content",
+			"op_log_cursor": cursor,
+		},
+	)
+	if rr.Code != http.StatusConflict {
+		t.Fatalf("expected 409 Conflict for stale cursor; got %d %s", rr.Code, rr.Body.String())
+	}
+
+	// items.content must NOT have been written. Re-fetch and assert.
+	rr = doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/items/"+created.Slug, nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("GET: %d", rr.Code)
+	}
+	var got models.Item
+	parseJSON(t, rr, &got)
+	if got.Content == "stale-flush-content" {
+		t.Errorf("items.content was overwritten with stale-flush-content; the handler accepted a sub-MIN cursor PATCH")
+	}
+}
+
+// TestCollabSnapshotAcceptsCursorAtOrAboveMin is the negative test:
+// a cursor at or above MIN passes the gate.
+func TestCollabSnapshotAcceptsCursorAtOrAboveMin(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	rr := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections/tasks/items", map[string]interface{}{
+		"title":   "Healthy cursor test",
+		"content": "v1",
+		"source":  "cli",
+		"fields":  `{"status":"open"}`,
+	})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create: %d %s", rr.Code, rr.Body.String())
+	}
+	var created models.Item
+	parseJSON(t, rr, &created)
+
+	id1, err := srv.store.AppendYjsUpdate(created.ID, []byte{0x00, 0x01}, "1")
+	if err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	cursor := id1 // cursor == MIN — caught up.
+	rr = doRequest(srv, "PATCH",
+		"/api/v1/workspaces/"+slug+"/items/"+created.Slug+"?source=collab-snapshot",
+		map[string]interface{}{
+			"content":       "fresh-content",
+			"op_log_cursor": cursor,
+		},
+	)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 OK for cursor>=MIN; got %d %s", rr.Code, rr.Body.String())
+	}
+}

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -969,9 +969,38 @@ func (s *Store) UpdateItem(id string, input models.ItemUpdate) (*models.Item, er
 		// op-log state (PruneAndApply) or replace it wholesale
 		// (CLI / version restore) — those CAN safely stamp the
 		// watermark to MAX(op-log.id) at write time.
+		//
+		// **Cursor-gated browser flush** (TASK-1319). Browser
+		// flushes carry an OpLogCursor recording the highest
+		// op-log id their Y.Doc has applied. When that cursor
+		// equals the current MAX(item_yjs_updates.id), the
+		// flusher has demonstrably captured every persisted op
+		// and we advance the watermark to that id. When the
+		// cursor is below MAX, peer ops outside the flusher's
+		// view exist; the watermark stays put so the GC sweeper
+		// cannot delete them. When the cursor is missing (older
+		// clients, malformed bodies) we behave as before — no
+		// advancement.
 		if input.VersionSource != "collab-snapshot" {
 			sets = append(sets, "content_flushed_op_log_id = (SELECT COALESCE(MAX(id), 0) FROM item_yjs_updates WHERE item_id = ?)")
 			args = append(args, id)
+		} else if input.OpLogCursor != nil {
+			// Conditional advance: the SQL UPDATE stamps the
+			// caller's cursor IFF that cursor still matches the
+			// current MAX(op-log.id) at COMMIT time. A peer op
+			// that lands between the client computing its
+			// cursor and this UPDATE running causes MAX to be
+			// strictly greater than the cursor, the predicate
+			// fails, and the watermark expression evaluates to
+			// the existing column value (a no-op). Never
+			// regresses, never over-advances.
+			sets = append(sets,
+				"content_flushed_op_log_id = CASE "+
+					"WHEN ? = (SELECT COALESCE(MAX(id), 0) FROM item_yjs_updates WHERE item_id = ?) "+
+					"THEN ? "+
+					"ELSE content_flushed_op_log_id "+
+					"END")
+			args = append(args, *input.OpLogCursor, id, *input.OpLogCursor)
 		}
 	}
 	if input.Fields != nil {

--- a/internal/store/items_collab_versions_test.go
+++ b/internal/store/items_collab_versions_test.go
@@ -253,3 +253,146 @@ func TestCollabSnapshotDoesNotAdvanceOpLogWatermark(t *testing.T) {
 		t.Errorf("after server-driven write: watermark must advance past 0 (got %d, ok=%v)", id2, ok)
 	}
 }
+
+// TestCollabSnapshotCursorMatchesMaxAdvancesWatermark is the TASK-1319
+// happy path: a browser flush whose `OpLogCursor` matches the current
+// MAX(op-log.id) demonstrates the markdown captures every persisted
+// op, so the GC watermark advances. Closes the browser-only-edited-
+// items-never-GC'd hole left by TASK-1309.
+func TestCollabSnapshotCursorMatchesMaxAdvancesWatermark(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Cursor Watermark Test")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+	item := createTestItem(t, s, ws.ID, col.ID, "Item", "v1")
+
+	// Seed two ops; MAX(id) will be 2 after this.
+	id1, err := s.AppendYjsUpdate(item.ID, []byte{0x00, 0x01}, "1")
+	if err != nil {
+		t.Fatalf("AppendYjsUpdate 1: %v", err)
+	}
+	id2, err := s.AppendYjsUpdate(item.ID, []byte{0x00, 0x02}, "1")
+	if err != nil {
+		t.Fatalf("AppendYjsUpdate 2: %v", err)
+	}
+	_ = id1
+
+	// Browser flush with cursor = MAX → watermark advances.
+	v2 := "v2"
+	cursor := id2
+	_, err = s.UpdateItem(item.ID, models.ItemUpdate{
+		Content:        &v2,
+		LastModifiedBy: "user",
+		VersionSource:  "collab-snapshot",
+		OpLogCursor:    &cursor,
+	})
+	if err != nil {
+		t.Fatalf("UpdateItem (collab-snapshot, cursor==MAX): %v", err)
+	}
+	got, ok, err := s.GetItemContentFlushedOpLogID(item.ID)
+	if err != nil {
+		t.Fatalf("GetItemContentFlushedOpLogID: %v", err)
+	}
+	if !ok || got != id2 {
+		t.Errorf("cursor==MAX flush: want watermark=%d, got %d (ok=%v)", id2, got, ok)
+	}
+}
+
+// TestCollabSnapshotCursorBelowMaxLeavesWatermark confirms a cursor
+// below the current MAX (peer ops the flusher hasn't seen) does NOT
+// advance the watermark — the SQL CASE clause's equality check fails
+// and the column keeps its prior value. Per TASK-1319.
+func TestCollabSnapshotCursorBelowMaxLeavesWatermark(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Cursor Below Test")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+	item := createTestItem(t, s, ws.ID, col.ID, "Item", "v1")
+
+	id1, err := s.AppendYjsUpdate(item.ID, []byte{0x00, 0x01}, "1")
+	if err != nil {
+		t.Fatalf("AppendYjsUpdate 1: %v", err)
+	}
+	if _, err := s.AppendYjsUpdate(item.ID, []byte{0x00, 0x02}, "1"); err != nil {
+		t.Fatalf("AppendYjsUpdate 2: %v", err)
+	}
+
+	// Cursor=id1 (one row behind MAX). Watermark should NOT advance.
+	v2 := "v2"
+	cursor := id1
+	_, err = s.UpdateItem(item.ID, models.ItemUpdate{
+		Content:        &v2,
+		LastModifiedBy: "user",
+		VersionSource:  "collab-snapshot",
+		OpLogCursor:    &cursor,
+	})
+	if err != nil {
+		t.Fatalf("UpdateItem (collab-snapshot, cursor<MAX): %v", err)
+	}
+	got, ok, err := s.GetItemContentFlushedOpLogID(item.ID)
+	if err != nil {
+		t.Fatalf("GetItemContentFlushedOpLogID: %v", err)
+	}
+	if !ok || got != 0 {
+		t.Errorf("cursor<MAX flush: watermark must stay at 0 (got %d, ok=%v); peer ops outside the flusher's view exist", got, ok)
+	}
+}
+
+// TestCollabSnapshotNoCursorLeavesWatermark — backwards-compat check:
+// a collab-snapshot PATCH without OpLogCursor (older client) preserves
+// the conservative TASK-1309 behaviour (watermark unchanged).
+func TestCollabSnapshotNoCursorLeavesWatermark(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "No Cursor Test")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+	item := createTestItem(t, s, ws.ID, col.ID, "Item", "v1")
+
+	if _, err := s.AppendYjsUpdate(item.ID, []byte{0x00, 0x01}, "1"); err != nil {
+		t.Fatalf("AppendYjsUpdate: %v", err)
+	}
+
+	v2 := "v2"
+	_, err := s.UpdateItem(item.ID, models.ItemUpdate{
+		Content:        &v2,
+		LastModifiedBy: "user",
+		VersionSource:  "collab-snapshot",
+		// OpLogCursor: nil
+	})
+	if err != nil {
+		t.Fatalf("UpdateItem: %v", err)
+	}
+	got, ok, _ := s.GetItemContentFlushedOpLogID(item.ID)
+	if !ok || got != 0 {
+		t.Errorf("no cursor: watermark must stay at 0 (got %d, ok=%v)", got, ok)
+	}
+}
+
+// TestMinAndMaxOpLogIDEmptyAndPopulated covers the two store helpers
+// the resume-cursor protocol depends on.
+func TestMinAndMaxOpLogIDEmptyAndPopulated(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Min Max Test")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+	item := createTestItem(t, s, ws.ID, col.ID, "Item", "v1")
+
+	if _, ok, err := s.MinOpLogID(item.ID); err != nil || ok {
+		t.Errorf("empty MinOpLogID: want ok=false, got ok=%v err=%v", ok, err)
+	}
+	if _, ok, err := s.MaxOpLogID(item.ID); err != nil || ok {
+		t.Errorf("empty MaxOpLogID: want ok=false, got ok=%v err=%v", ok, err)
+	}
+
+	id1, err := s.AppendYjsUpdate(item.ID, []byte{0x00, 0x01}, "1")
+	if err != nil {
+		t.Fatalf("append 1: %v", err)
+	}
+	id2, err := s.AppendYjsUpdate(item.ID, []byte{0x00, 0x02}, "1")
+	if err != nil {
+		t.Fatalf("append 2: %v", err)
+	}
+
+	if got, ok, err := s.MinOpLogID(item.ID); err != nil || !ok || got != id1 {
+		t.Errorf("MinOpLogID after seed: want %d, got %d (ok=%v err=%v)", id1, got, ok, err)
+	}
+	if got, ok, err := s.MaxOpLogID(item.ID); err != nil || !ok || got != id2 {
+		t.Errorf("MaxOpLogID after seed: want %d, got %d (ok=%v err=%v)", id2, got, ok, err)
+	}
+}

--- a/internal/store/yjs_updates.go
+++ b/internal/store/yjs_updates.go
@@ -175,6 +175,59 @@ func (s *Store) LatestYjsUpdateSchemaVersion(itemID string) (string, int64, bool
 	return version, rowID, true, nil
 }
 
+// MinOpLogID returns MIN(id) of the persisted op-log rows for an
+// item. ok is false when no rows exist (a freshly-pruned or never-
+// touched item). Used by the resume-cursor protocol (TASK-1319): a
+// reconnecting client announces its last known op-log id via
+// `?since=`; if that id is below MIN, rows it expected to replay
+// have been pruned and the server signals a force-refresh instead
+// of a degraded delta replay.
+func (s *Store) MinOpLogID(itemID string) (int64, bool, error) {
+	if itemID == "" {
+		return 0, false, errors.New("MinOpLogID: itemID is required")
+	}
+	query := s.dialect.Rebind(`
+		SELECT MIN(id) FROM item_yjs_updates WHERE item_id = ?
+	`)
+	var v sql.NullInt64
+	if err := s.db.QueryRow(query, itemID).Scan(&v); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return 0, false, nil
+		}
+		return 0, false, fmt.Errorf("min op-log id: %w", err)
+	}
+	if !v.Valid {
+		return 0, false, nil
+	}
+	return v.Int64, true, nil
+}
+
+// MaxOpLogID returns MAX(id) of the persisted op-log rows for an
+// item. ok is false when no rows exist. Used by the watermark-
+// advancement check on collab-snapshot flush (TASK-1319): the
+// server advances `items.content_flushed_op_log_id` only when the
+// caller's claimed cursor matches MAX, proving the flushed markdown
+// captures every persisted op.
+func (s *Store) MaxOpLogID(itemID string) (int64, bool, error) {
+	if itemID == "" {
+		return 0, false, errors.New("MaxOpLogID: itemID is required")
+	}
+	query := s.dialect.Rebind(`
+		SELECT MAX(id) FROM item_yjs_updates WHERE item_id = ?
+	`)
+	var v sql.NullInt64
+	if err := s.db.QueryRow(query, itemID).Scan(&v); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return 0, false, nil
+		}
+		return 0, false, fmt.Errorf("max op-log id: %w", err)
+	}
+	if !v.Valid {
+		return 0, false, nil
+	}
+	return v.Int64, true, nil
+}
+
 // GetItemContentFlushedOpLogID returns the value of
 // items.content_flushed_op_log_id for an item — the highest op-log
 // id known to be reflected in items.content, or (0, false) if the

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -356,13 +356,28 @@ export const api = {
 			ws: string,
 			slug: string,
 			content: string,
-			opts?: { keepalive?: boolean },
-		) =>
-			request<Item>(`/workspaces/${ws}/items/${slug}?source=collab-snapshot`, {
+			opts?: { keepalive?: boolean; opLogCursor?: number },
+		) => {
+			const body: { content: string; op_log_cursor?: number } = { content };
+			// `op_log_cursor` (TASK-1319) is the highest
+			// item_yjs_updates.id this tab has applied. The server
+			// advances `items.content_flushed_op_log_id` only when
+			// the cursor matches the current MAX(op-log.id) — proving
+			// the markdown captures every persisted op. Cursors below
+			// MAX leave the watermark untouched (peer ops outside this
+			// tab's view exist; the GC sweeper must not delete them).
+			// Omit the field entirely on legacy callers / cursors of 0
+			// (the server treats absent as "no claim", same outcome
+			// as the conservative TASK-1309 default).
+			if (opts?.opLogCursor !== undefined && opts.opLogCursor > 0) {
+				body.op_log_cursor = opts.opLogCursor;
+			}
+			return request<Item>(`/workspaces/${ws}/items/${slug}?source=collab-snapshot`, {
 				method: 'PATCH',
-				body: JSON.stringify({ content }),
+				body: JSON.stringify(body),
 				keepalive: opts?.keepalive,
-			}),
+			});
+		},
 
 		delete: (ws: string, slug: string) =>
 			request<void>(`/workspaces/${ws}/items/${slug}`, {

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -366,10 +366,16 @@ export const api = {
 			// the markdown captures every persisted op. Cursors below
 			// MAX leave the watermark untouched (peer ops outside this
 			// tab's view exist; the GC sweeper must not delete them).
-			// Omit the field entirely on legacy callers / cursors of 0
-			// (the server treats absent as "no claim", same outcome
-			// as the conservative TASK-1309 default).
-			if (opts?.opLogCursor !== undefined && opts.opLogCursor > 0) {
+			//
+			// Always include the cursor when the caller passed it,
+			// INCLUDING zero. The server's stale-snapshot gate
+			// (round 12 [P1]) needs to see cursor=0 explicitly to
+			// reject flushes from clients whose Y.Doc is populated
+			// but whose cursor was never anchored (network blip
+			// during the post-replay cursor write). Omitting on 0
+			// would silently bypass the gate. Per Codex round 13
+			// [P1] of TASK-1319.
+			if (opts?.opLogCursor !== undefined) {
 				body.op_log_cursor = opts.opLogCursor;
 			}
 			return request<Item>(`/workspaces/${ws}/items/${slug}?source=collab-snapshot`, {

--- a/web/src/lib/collab/wsProvider.svelte.ts
+++ b/web/src/lib/collab/wsProvider.svelte.ts
@@ -245,6 +245,25 @@ export class CollabProvider {
 	 */
 	lastOpLogID = $state(0);
 
+	/**
+	 * True after the server has sent ANY op_log_cursor control frame
+	 * in this provider's lifetime — including the initial post-
+	 * replay cursor of 0 against an empty op-log. The boolean
+	 * distinguishes "I've heard from the server about its op-log
+	 * state" (safe to send local edits) from "I've heard nothing"
+	 * (network drop happened between replay binaries and the
+	 * post-replay cursor frame; my Y.Doc may be populated by
+	 * server rows but I have no anchor — propagating local edits
+	 * derived from this state can corrupt items.content via the
+	 * next 5s flush). Gating `handleDocUpdate` on this flag closes
+	 * the residual "stale Y.Doc + cursor 0" send path. Per Codex
+	 * round 14 [P1] of TASK-1319.
+	 *
+	 * Reset on `force_refresh` (the provider is destroyed there
+	 * anyway) and on construction.
+	 */
+	private cursorAnchored = false;
+
 	private ws: WebSocket | null = null;
 	private readonly WebSocketImpl: typeof WebSocket;
 	private readonly onApplierRequest?: ApplierRequestHandler;
@@ -309,6 +328,27 @@ export class CollabProvider {
 			// otherwise we'd echo every remote keystroke back to the
 			// server (which would persist + rebroadcast it again).
 			if (origin === this) return;
+			// Cursor-anchor gate (TASK-1319 round 14 [P1]). If the
+			// server has not yet confirmed our position in its op-log
+			// (no op_log_cursor frame received in this session), our
+			// Y.Doc may be populated by replay binaries whose
+			// trailing cursor frame got lost to a network blip.
+			// Sending local edits in that state lets the server
+			// append + originator-cursor back, after which the next
+			// flush would carry an "anchored" cursor and pass the
+			// server's MIN check — overwriting items.content with
+			// markdown derived from the stale-Y.Doc base. Buffer
+			// edits locally instead; when a cursor arrives (or the
+			// provider rebuilds via force_refresh), the next user
+			// input fires handleDocUpdate again and we send normally.
+			//
+			// The trade-off: if a network blip persists indefinitely,
+			// local edits sit in the editor but never reach the
+			// server. That's acceptable — the user is offline either
+			// way; the provider's reconnect loop will eventually
+			// either (a) resync and propagate, or (b) trigger
+			// force_refresh and the user gets a clean rebuild.
+			if (!this.cursorAnchored) return;
 			const enc = encoding.createEncoder();
 			encoding.writeVarUint(enc, MESSAGE_SYNC);
 			syncProtocol.writeUpdate(enc, update);
@@ -736,6 +776,14 @@ export class CollabProvider {
 					return;
 				}
 				if (msg.op_log_id < 0) return;
+				// Anchor the session: any cursor frame — including
+				// the initial post-replay cursor=0 against an empty
+				// op-log — proves the server has finished its
+				// replay-time view of the op-log. handleDocUpdate
+				// gates on this so local edits can't propagate
+				// before the server has weighed in. Per Codex
+				// round 14 [P1].
+				this.cursorAnchored = true;
 				// Never regress the cursor: the server's INITIAL
 				// post-replay cursor frame can in theory follow a
 				// MORE-RECENT live op the previous incarnation

--- a/web/src/lib/collab/wsProvider.svelte.ts
+++ b/web/src/lib/collab/wsProvider.svelte.ts
@@ -715,11 +715,25 @@ export class CollabProvider {
 				// continue (our `?since=<id>` was below MIN). Clear
 				// the persisted cursor so a downstream rebuild
 				// starts fresh, then notify the page so it can
-				// recreate the editor on a clean Y.Doc. The server
-				// closes the conn after this frame; our onClose
-				// fires regardless of order.
+				// recreate the editor on a clean Y.Doc.
 				clearStoredCursor(this.itemID);
 				this.lastOpLogID = 0;
+				// Destroy this provider SYNCHRONOUSLY before
+				// invoking the page-level handler. Without this,
+				// the consumer's recovery path is async (e.g.
+				// awaits an items.get refetch before swapping
+				// providers); meanwhile our own onClose handler
+				// schedules a reconnect that races the recovery,
+				// re-opens with `?since=0`, and pushes
+				// `Y.encodeStateAsUpdate` of the (still-stale)
+				// local Y.Doc — recreating exactly the
+				// stale-content corruption force_refresh was
+				// meant to prevent. destroy() sets
+				// `this.destroyed = true` so scheduleReconnect
+				// short-circuits, removes window/document
+				// listeners, and closes the socket. Per Codex
+				// round 6 [P1].
+				this.destroy();
 				if (this.onForceRefresh) {
 					try {
 						this.onForceRefresh();

--- a/web/src/lib/collab/wsProvider.svelte.ts
+++ b/web/src/lib/collab/wsProvider.svelte.ts
@@ -375,18 +375,20 @@ export class CollabProvider {
 				// position.
 				if (this.preAnchorUpdates.length >= CollabProvider.MAX_PRE_ANCHOR_UPDATES) {
 					// Pathological case: anchor never arrives. The
-					// buffer would grow unbounded. Trigger a
-					// force-refresh-equivalent rebuild so the user
-					// recovers instead of accumulating un-flushable
-					// state. Clearing the buffer here prevents a
-					// runaway memory leak; the rebuild path is the
-					// authoritative recovery.
-					this.preAnchorUpdates = [];
+					// buffer would grow unbounded. Destroy this
+					// provider SYNCHRONOUSLY before invoking the
+					// recovery callback so a late op_log_cursor
+					// can't anchor and flush the partial buffer
+					// (the dropped prefix would reintroduce the
+					// causal-missing-update bug). Per Codex round
+					// 16 [P2] of TASK-1319.
 					console.warn(
 						'collab: pre-anchor buffer overflow; triggering recovery',
 					);
 					clearStoredCursor(this.itemID);
 					this.lastOpLogID = 0;
+					this.preAnchorUpdates = [];
+					this.destroy();
 					try {
 						this.onForceRefresh?.();
 					} catch (err) {

--- a/web/src/lib/collab/wsProvider.svelte.ts
+++ b/web/src/lib/collab/wsProvider.svelte.ts
@@ -273,7 +273,28 @@ export class CollabProvider {
 		// `since=<id>` query string is appended in connect() each
 		// time so a reconnect after some live edits announces a
 		// fresher cursor than the page-load value.
-		this.lastOpLogID = readStoredCursor(itemID);
+		//
+		// **Cursor invariant**: lastOpLogID > 0 IFF Y.Doc has applied
+		// server-acked ops. The Y.Doc isn't persisted across page
+		// reload — every `new CollabProvider(itemID, new Y.Doc(), ...)`
+		// mints an empty Y.Doc. A non-zero stored cursor against a
+		// fresh empty Y.Doc would announce `?since=N`, the server
+		// would replay only id > N, and the client would be missing
+		// rows 1..N from its Y.Doc. Reset the stored cursor to 0 in
+		// that case so the server replays from scratch. Per Codex
+		// round 13 [P1] of TASK-1319.
+		const storedCursor = readStoredCursor(itemID);
+		const ydocStateVector = Y.encodeStateVector(ydoc);
+		// An empty Y.Doc's state vector is the single VARINT 0 byte
+		// (0x00); anything longer means at least one client id has
+		// state.
+		const ydocIsEmpty = ydocStateVector.length <= 1;
+		if (storedCursor > 0 && ydocIsEmpty) {
+			clearStoredCursor(itemID);
+			this.lastOpLogID = 0;
+		} else {
+			this.lastOpLogID = storedCursor;
+		}
 		// `url` is the BASE URL (no `since=` appended). connect()
 		// re-derives the connect URL on every attempt so the
 		// `since=<id>` parameter reflects the current cursor. Test
@@ -565,10 +586,27 @@ export class CollabProvider {
 		// wasteful and TASK-1265's mobile-reconnect work can replace
 		// it with a buffered-queue approach; for v1 the simplicity
 		// wins.
-		const enc3 = encoding.createEncoder();
-		encoding.writeVarUint(enc3, MESSAGE_SYNC);
-		syncProtocol.writeUpdate(enc3, Y.encodeStateAsUpdate(this.ydoc));
-		this.send(encoding.toUint8Array(enc3));
+		//
+		// **Skip when cursor is unanchored** (lastOpLogID === 0).
+		// A non-empty Y.Doc with no server-acked cursor is a known-
+		// stale combination (network blip during the post-replay
+		// cursor write left us holding replay-applied state that
+		// the server may have since pruned). Sending
+		// Y.encodeStateAsUpdate in that case can resurrect ops the
+		// server has pruned and corrupt items.content on the next
+		// flush. The server's replay (and the lazy-seed path's
+		// items.content fallback) repopulates Y.Doc canonically;
+		// we don't need to push our state to recover. Truly local-
+		// only edits from before any successful sync are uncommon
+		// (the editor only mounts after the route loads, by which
+		// time we've at least connected once); the trade-off here
+		// favours correctness. Per Codex round 13 [P1] of TASK-1319.
+		if (this.lastOpLogID > 0) {
+			const enc3 = encoding.createEncoder();
+			encoding.writeVarUint(enc3, MESSAGE_SYNC);
+			syncProtocol.writeUpdate(enc3, Y.encodeStateAsUpdate(this.ydoc));
+			this.send(encoding.toUint8Array(enc3));
+		}
 
 		// Broadcast our local awareness state (if any) so peers see
 		// us right away. With no local state set this is a no-op.

--- a/web/src/lib/collab/wsProvider.svelte.ts
+++ b/web/src/lib/collab/wsProvider.svelte.ts
@@ -791,7 +791,23 @@ export class CollabProvider {
 				// reply — encoder still has the leading message-type
 				// byte (length == 1) and we skip the send.
 				if (encoding.length(enc) > 1) {
-					this.send(encoding.toUint8Array(enc));
+					// readSyncMessage writes a reply only on
+					// inbound syncStep1 (the encoder gets a
+					// syncStep2 payload appended). Suppress that
+					// reply while the session is unanchored — the
+					// reply embeds our current Y.Doc state, and
+					// pushing it pre-anchor would let stale
+					// Y.Doc state reach the server before the
+					// cursor=0 + remoteSyncApplied force_refresh
+					// recovery has a chance to fire. The peer
+					// will pick up our state via the buffered
+					// pre-anchor flush once the cursor anchors,
+					// or via the lazy-seed rebuild after
+					// force_refresh. Per Codex round 20 [P1] of
+					// TASK-1319.
+					if (this.cursorAnchored) {
+						this.send(encoding.toUint8Array(enc));
+					}
 				}
 				if (subtype === syncProtocol.messageYjsSyncStep2) {
 					this.synced = true;

--- a/web/src/lib/collab/wsProvider.svelte.ts
+++ b/web/src/lib/collab/wsProvider.svelte.ts
@@ -282,6 +282,18 @@ export class CollabProvider {
 	private preAnchorUpdates: Uint8Array[] = [];
 	private static readonly MAX_PRE_ANCHOR_UPDATES = 1000;
 
+	/**
+	 * Tracks whether the server has applied a sync update to our
+	 * Y.Doc (replay binary or live peer op). Distinguishes
+	 * "Y.Doc has remote-derived state" (suspect on cursor=0
+	 * because the server's op-log is now empty — points to a
+	 * mid-session prune) from "Y.Doc has only local pre-anchor
+	 * edits" (safe — those were typed locally and the buffer
+	 * holds them for replay on anchor). Per Codex round 19 [P1]
+	 * of TASK-1319.
+	 */
+	private remoteSyncApplied = false;
+
 	private ws: WebSocket | null = null;
 	private readonly WebSocketImpl: typeof WebSocket;
 	private readonly onApplierRequest?: ApplierRequestHandler;
@@ -763,6 +775,13 @@ export class CollabProvider {
 
 		switch (messageType) {
 			case MESSAGE_SYNC: {
+				// Mark that the server applied SOMETHING to our
+				// Y.Doc. Distinguishes "remote replay landed" from
+				// "only local edits in Y.Doc" so the cursor=0 +
+				// non-empty-Y.Doc safety check (round 18) doesn't
+				// false-positive on legitimate local pre-anchor
+				// edits. Per Codex round 19 [P1].
+				this.remoteSyncApplied = true;
 				const enc = encoding.createEncoder();
 				encoding.writeVarUint(enc, MESSAGE_SYNC);
 				const subtype = syncProtocol.readSyncMessage(decoder, enc, this.ydoc, this);
@@ -844,12 +863,21 @@ export class CollabProvider {
 				//
 				// Trigger force-refresh recovery instead. Per Codex
 				// round 18 [P1] of TASK-1319.
-				if (!this.cursorAnchored && msg.op_log_id === 0) {
-					const sv = Y.encodeStateVector(this.ydoc);
-					if (sv.length > 1) {
-						console.warn(
-							'collab: cursor=0 received against non-empty Y.Doc; treating as force_refresh',
-						);
+				if (!this.cursorAnchored && msg.op_log_id === 0 && this.remoteSyncApplied) {
+					// Remote replay binaries reached us before this
+					// cursor=0 frame, but the server now reports an
+					// empty op-log — a prune happened mid-session.
+					// Y.Doc holds pre-prune state. Recover.
+					//
+					// We GATE on remoteSyncApplied so legitimate
+					// local pre-anchor edits (user typed before the
+					// initial cursor=0 of an empty op-log arrived)
+					// don't trip this branch — those updates live in
+					// preAnchorUpdates and will flush on anchor.
+					// Per Codex round 19 [P1] of TASK-1319.
+					console.warn(
+						'collab: cursor=0 received against remote-applied Y.Doc; treating as force_refresh',
+					);
 						clearStoredCursor(this.itemID);
 						this.lastOpLogID = 0;
 						this.preAnchorUpdates = [];

--- a/web/src/lib/collab/wsProvider.svelte.ts
+++ b/web/src/lib/collab/wsProvider.svelte.ts
@@ -264,6 +264,24 @@ export class CollabProvider {
 	 */
 	private cursorAnchored = false;
 
+	/**
+	 * Buffer of local Yjs updates that fired before
+	 * `cursorAnchored` flipped true. Each entry is the raw
+	 * `update` Uint8Array from `ydoc.on('update', ...)`. On
+	 * anchor we flush them in order so the server gets every
+	 * causally-required struct — Yjs ops are incremental and a
+	 * silently-dropped keystroke can leave later ops referencing
+	 * structs no peer has. Per Codex round 15 [P1] of TASK-1319.
+	 *
+	 * Capped because in pathological "anchor never arrives"
+	 * scenarios the buffer could grow unbounded; once we cross
+	 * the cap we trigger `force_refresh`-equivalent recovery via
+	 * the onForceRefresh handler so the user gets a clean
+	 * rebuild rather than a stale-then-divergent session.
+	 */
+	private preAnchorUpdates: Uint8Array[] = [];
+	private static readonly MAX_PRE_ANCHOR_UPDATES = 1000;
+
 	private ws: WebSocket | null = null;
 	private readonly WebSocketImpl: typeof WebSocket;
 	private readonly onApplierRequest?: ApplierRequestHandler;
@@ -348,7 +366,37 @@ export class CollabProvider {
 			// way; the provider's reconnect loop will eventually
 			// either (a) resync and propagate, or (b) trigger
 			// force_refresh and the user gets a clean rebuild.
-			if (!this.cursorAnchored) return;
+			if (!this.cursorAnchored) {
+				// Buffer for replay on anchor (round 15 [P1]).
+				// Yjs updates are causal — silently dropping one
+				// keystroke makes later ops reference structs no
+				// peer can resolve. Saving them ensures the full
+				// chain reaches the server once it confirms our
+				// position.
+				if (this.preAnchorUpdates.length >= CollabProvider.MAX_PRE_ANCHOR_UPDATES) {
+					// Pathological case: anchor never arrives. The
+					// buffer would grow unbounded. Trigger a
+					// force-refresh-equivalent rebuild so the user
+					// recovers instead of accumulating un-flushable
+					// state. Clearing the buffer here prevents a
+					// runaway memory leak; the rebuild path is the
+					// authoritative recovery.
+					this.preAnchorUpdates = [];
+					console.warn(
+						'collab: pre-anchor buffer overflow; triggering recovery',
+					);
+					clearStoredCursor(this.itemID);
+					this.lastOpLogID = 0;
+					try {
+						this.onForceRefresh?.();
+					} catch (err) {
+						console.warn('collab: onForceRefresh threw on overflow', err);
+					}
+					return;
+				}
+				this.preAnchorUpdates.push(update);
+				return;
+			}
 			const enc = encoding.createEncoder();
 			encoding.writeVarUint(enc, MESSAGE_SYNC);
 			syncProtocol.writeUpdate(enc, update);
@@ -783,7 +831,23 @@ export class CollabProvider {
 				// gates on this so local edits can't propagate
 				// before the server has weighed in. Per Codex
 				// round 14 [P1].
+				const wasAnchored = this.cursorAnchored;
 				this.cursorAnchored = true;
+				// Flush buffered pre-anchor updates in order so
+				// causal Yjs ops aren't silently dropped — sending
+				// only later updates would let the server (and
+				// peers) miss intervening structs. Per Codex round
+				// 15 [P1].
+				if (!wasAnchored && this.preAnchorUpdates.length > 0) {
+					const buffered = this.preAnchorUpdates;
+					this.preAnchorUpdates = [];
+					for (const upd of buffered) {
+						const enc = encoding.createEncoder();
+						encoding.writeVarUint(enc, MESSAGE_SYNC);
+						syncProtocol.writeUpdate(enc, upd);
+						this.send(encoding.toUint8Array(enc));
+					}
+				}
 				// Never regress the cursor: the server's INITIAL
 				// post-replay cursor frame can in theory follow a
 				// MORE-RECENT live op the previous incarnation

--- a/web/src/lib/collab/wsProvider.svelte.ts
+++ b/web/src/lib/collab/wsProvider.svelte.ts
@@ -677,21 +677,24 @@ export class CollabProvider {
 		// it with a buffered-queue approach; for v1 the simplicity
 		// wins.
 		//
-		// **Skip when cursor is unanchored** (lastOpLogID === 0).
-		// A non-empty Y.Doc with no server-acked cursor is a known-
-		// stale combination (network blip during the post-replay
-		// cursor write left us holding replay-applied state that
-		// the server may have since pruned). Sending
+		// **Skip when the session is unanchored** (cursorAnchored
+		// false). A non-empty Y.Doc with no server-acked cursor is
+		// a known-stale combination (network blip during the
+		// post-replay cursor write left us holding replay-applied
+		// state that the server may have since pruned). Sending
 		// Y.encodeStateAsUpdate in that case can resurrect ops the
 		// server has pruned and corrupt items.content on the next
 		// flush. The server's replay (and the lazy-seed path's
 		// items.content fallback) repopulates Y.Doc canonically;
-		// we don't need to push our state to recover. Truly local-
-		// only edits from before any successful sync are uncommon
-		// (the editor only mounts after the route loads, by which
-		// time we've at least connected once); the trade-off here
-		// favours correctness. Per Codex round 13 [P1] of TASK-1319.
-		if (this.lastOpLogID > 0) {
+		// we don't need to push our state to recover.
+		//
+		// Anchored at cursor=0 IS valid — that's the legitimate
+		// 'server has nothing in op-log yet' case. Local edits
+		// made during a brief offline window before reconnect
+		// MUST go out via this catch-up path; gating on
+		// `lastOpLogID > 0` instead would leave them stranded.
+		// Per Codex round 17 [P2] of TASK-1319.
+		if (this.cursorAnchored) {
 			const enc3 = encoding.createEncoder();
 			encoding.writeVarUint(enc3, MESSAGE_SYNC);
 			syncProtocol.writeUpdate(enc3, Y.encodeStateAsUpdate(this.ydoc));

--- a/web/src/lib/collab/wsProvider.svelte.ts
+++ b/web/src/lib/collab/wsProvider.svelte.ts
@@ -83,6 +83,80 @@ export type ApplierRequestHandler = (
 ) => boolean | Promise<boolean>;
 
 /**
+ * Callback fired when the server sends a `force_refresh` control
+ * frame (TASK-1319). The reconnecting client's `?since=<id>` was
+ * below the server's MIN(item_yjs_updates.id) — rows it expected
+ * to replay have been pruned (op-log GC, schema rebuild, or
+ * PruneAndApply), so reconnecting from local Y.Doc state would
+ * produce a corrupt patch. The handler should:
+ *
+ *   1. Call `provider.destroy()`.
+ *   2. Discard the local `Y.Doc` and create a fresh one.
+ *   3. Build a new provider against the fresh doc — its lazy-seed
+ *      path (TASK-1261) will re-encode `items.content` into ops at
+ *      the current schema version.
+ *   4. Show the user a toast explaining what happened.
+ *
+ * Receiving this callback means the provider has already cleared
+ * its sessionStorage cursor; do NOT try to keep using the existing
+ * provider/doc after it fires.
+ */
+export type ForceRefreshHandler = () => void;
+
+/**
+ * Per-tab op-log cursor protocol (TASK-1319).
+ *
+ * `sessionStorage` is per-tab and survives page reload (which
+ * matches the "the editor reload should pick up where the user
+ * left off" UX) but dies with the tab — no cross-tab leakage of
+ * a stale cursor that might force-refresh a different tab. Keys
+ * are namespaced + scoped to the item id so multi-item editing
+ * sessions in the same tab don't collide.
+ *
+ * `localStorage` was deliberately rejected: shared between tabs of
+ * the same item, Tab A advancing the cursor would leave Tab B with
+ * a value that doesn't match Tab B's Y.Doc state, and B's next
+ * reconnect would land on a stale-cursor force_refresh even though
+ * B has been a stable session the whole time.
+ */
+const CURSOR_STORAGE_PREFIX = 'pad:collab:cursor:';
+
+function cursorStorageKey(itemID: string): string {
+	return `${CURSOR_STORAGE_PREFIX}${itemID}`;
+}
+
+function readStoredCursor(itemID: string): number {
+	if (typeof sessionStorage === 'undefined') return 0;
+	try {
+		const raw = sessionStorage.getItem(cursorStorageKey(itemID));
+		if (!raw) return 0;
+		const n = Number.parseInt(raw, 10);
+		return Number.isFinite(n) && n >= 0 ? n : 0;
+	} catch {
+		// sessionStorage can throw in privacy-mode iframes / quota cases.
+		return 0;
+	}
+}
+
+function writeStoredCursor(itemID: string, id: number): void {
+	if (typeof sessionStorage === 'undefined') return;
+	try {
+		sessionStorage.setItem(cursorStorageKey(itemID), String(id));
+	} catch {
+		// Quota / privacy mode — best effort.
+	}
+}
+
+function clearStoredCursor(itemID: string): void {
+	if (typeof sessionStorage === 'undefined') return;
+	try {
+		sessionStorage.removeItem(cursorStorageKey(itemID));
+	} catch {
+		// Best effort.
+	}
+}
+
+/**
  * Public connection state surfaced to UX (TASK-1264 pending-sync
  * indicator). Strictly more informative than `connected` + `synced`
  * because it distinguishes the initial handshake from a mid-session
@@ -117,6 +191,13 @@ export interface CollabProviderOptions {
 	 * after timeout). Production callers always set this.
 	 */
 	onApplierRequest?: ApplierRequestHandler;
+	/**
+	 * Force-refresh handler (TASK-1319). See `ForceRefreshHandler`.
+	 * Required for production: without it, a force_refresh frame
+	 * silently destroys the socket without telling the page,
+	 * leaving the editor on stale state.
+	 */
+	onForceRefresh?: ForceRefreshHandler;
 }
 
 export class CollabProvider {
@@ -147,9 +228,27 @@ export class CollabProvider {
 	 */
 	state = $state<CollabConnectionState>('connecting');
 
+	/**
+	 * Highest op-log id this provider has been notified of by the
+	 * server (TASK-1319). Initialised from sessionStorage so a page
+	 * reload picks up where the previous incarnation left off, and
+	 * persisted on every op_log_cursor control frame so a subsequent
+	 * reconnect can announce `?since=<id>` and either get a delta
+	 * replay (efficient) or a force_refresh (the rows it expected
+	 * have been pruned).
+	 *
+	 * Reactive so a future UX consumer can show "X ops applied" or
+	 * gate a flush button on `lastOpLogID === serverMaxOpLogID`. Read
+	 * by the items-PATCH `?source=collab-snapshot` flush so the
+	 * server can advance the GC watermark when this cursor matches
+	 * MAX(op-log.id).
+	 */
+	lastOpLogID = $state(0);
+
 	private ws: WebSocket | null = null;
 	private readonly WebSocketImpl: typeof WebSocket;
 	private readonly onApplierRequest?: ApplierRequestHandler;
+	private readonly onForceRefresh?: ForceRefreshHandler;
 	private destroyed = false;
 	private reconnectAttempts = 0;
 	private reconnectTimer: ReturnType<typeof setTimeout> | undefined;
@@ -168,8 +267,21 @@ export class CollabProvider {
 		this.awareness = new awarenessProtocol.Awareness(ydoc);
 
 		this.WebSocketImpl = options.WebSocketImpl ?? globalThis.WebSocket;
-		this.url = options.url ?? defaultCollabUrl(itemID);
 		this.onApplierRequest = options.onApplierRequest;
+		this.onForceRefresh = options.onForceRefresh;
+		// Restore the per-tab cursor BEFORE the first connect. The
+		// `since=<id>` query string is appended in connect() each
+		// time so a reconnect after some live edits announces a
+		// fresher cursor than the page-load value.
+		this.lastOpLogID = readStoredCursor(itemID);
+		// `url` is the BASE URL (no `since=` appended). connect()
+		// re-derives the connect URL on every attempt so the
+		// `since=<id>` parameter reflects the current cursor. Test
+		// callers passing `options.url` get to override with their
+		// own URL — the test stub doesn't care about the cursor
+		// query string, and re-deriving from a custom URL would be
+		// wrong (we'd append `since=` to whatever they provided).
+		this.url = options.url ?? defaultCollabBaseUrl(itemID);
 
 		this.handleDocUpdate = (update, origin) => {
 			// Skip ops that came from us applying a server message —
@@ -393,7 +505,7 @@ export class CollabProvider {
 
 		let ws: WebSocket;
 		try {
-			ws = new this.WebSocketImpl(this.url);
+			ws = new this.WebSocketImpl(this.connectUrl());
 		} catch (err) {
 			// Construction can throw on a malformed URL; reschedule
 			// instead of swallowing — same surface the runtime would
@@ -560,7 +672,13 @@ export class CollabProvider {
 	};
 
 	private async handleControlMessage(raw: string, sourceWs: WebSocket | null): Promise<void> {
-		let msg: { type?: string; request_id?: string; markdown?: string; expires_at_millis?: number };
+		let msg: {
+			type?: string;
+			request_id?: string;
+			markdown?: string;
+			expires_at_millis?: number;
+			op_log_id?: number;
+		};
 		try {
 			msg = JSON.parse(raw);
 		} catch {
@@ -569,6 +687,52 @@ export class CollabProvider {
 		}
 
 		switch (msg.type) {
+			case 'op_log_cursor': {
+				// TASK-1319: server announces the highest persisted
+				// op-log id we should now consider applied. Persist
+				// per-tab so a reconnect (or page reload) can
+				// announce `?since=<id>` and either get a delta
+				// replay or a force_refresh.
+				if (typeof msg.op_log_id !== 'number' || !Number.isFinite(msg.op_log_id)) {
+					console.warn('collab: op_log_cursor missing op_log_id');
+					return;
+				}
+				if (msg.op_log_id < 0) return;
+				// Never regress the cursor: the server's INITIAL
+				// post-replay cursor frame can in theory follow a
+				// MORE-RECENT live op the previous incarnation
+				// already wrote out (race window between the
+				// async post-replay cursor write and a concurrent
+				// AppendYjsUpdate that the bus already broadcast).
+				// Taking the max guards against that.
+				if (msg.op_log_id <= this.lastOpLogID) return;
+				this.lastOpLogID = msg.op_log_id;
+				writeStoredCursor(this.itemID, msg.op_log_id);
+				return;
+			}
+			case 'force_refresh': {
+				// TASK-1319: server has decided we can't safely
+				// continue (our `?since=<id>` was below MIN). Clear
+				// the persisted cursor so a downstream rebuild
+				// starts fresh, then notify the page so it can
+				// recreate the editor on a clean Y.Doc. The server
+				// closes the conn after this frame; our onClose
+				// fires regardless of order.
+				clearStoredCursor(this.itemID);
+				this.lastOpLogID = 0;
+				if (this.onForceRefresh) {
+					try {
+						this.onForceRefresh();
+					} catch (err) {
+						console.warn('collab: onForceRefresh threw', err);
+					}
+				} else {
+					console.warn(
+						'collab: received force_refresh but no onForceRefresh handler is installed; editor will be on stale state',
+					);
+				}
+				return;
+			}
 			case 'applier_request': {
 				if (!msg.request_id || typeof msg.markdown !== 'string') {
 					console.warn('collab: applier_request missing required fields');
@@ -706,6 +870,25 @@ export class CollabProvider {
 		}
 	}
 
+	/**
+	 * Compute the URL to connect to on this attempt. The base URL
+	 * is the (immutable) collab endpoint with `schema_version`
+	 * already encoded; we additionally append `since=<id>` whenever
+	 * `lastOpLogID > 0` so the server can:
+	 *   - replay only the rows past our cursor (efficient resume), OR
+	 *   - send `force_refresh` if our cursor is below MIN (rows
+	 *     pruned out from under us) and close the conn.
+	 *
+	 * Skipping the param when `lastOpLogID === 0` matches the
+	 * server's "treat as fresh client" branch and keeps test fixtures
+	 * that hard-code the base URL working as-is.
+	 */
+	private connectUrl(): string {
+		if (this.lastOpLogID <= 0) return this.url;
+		const sep = this.url.includes('?') ? '&' : '?';
+		return `${this.url}${sep}since=${this.lastOpLogID}`;
+	}
+
 	private closeSocket(code: number, reason: string): void {
 		const ws = this.ws;
 		if (!ws) return;
@@ -724,7 +907,7 @@ export class CollabProvider {
 	}
 }
 
-function defaultCollabUrl(itemID: string): string {
+function defaultCollabBaseUrl(itemID: string): string {
 	if (typeof window === 'undefined' || typeof location === 'undefined') {
 		throw new Error('CollabProvider: cannot derive URL outside the browser');
 	}
@@ -735,6 +918,10 @@ function defaultCollabUrl(itemID: string): string {
 	// rather than a silently-degraded session. The server also uses
 	// the per-item rebuild path internally if any persisted op-log
 	// rows are stamped with an older version.
+	//
+	// `since=<id>` is NOT in the base URL; it's appended per-attempt
+	// by `connectUrl()` so a reconnect after live edits announces the
+	// freshest cursor available. Per TASK-1319.
 	const params = new URLSearchParams({ schema_version: SCHEMA_VERSION });
 	return `${proto}//${location.host}/api/v1/collab/${encodeURIComponent(itemID)}?${params.toString()}`;
 }

--- a/web/src/lib/collab/wsProvider.svelte.ts
+++ b/web/src/lib/collab/wsProvider.svelte.ts
@@ -829,6 +829,42 @@ export class CollabProvider {
 					return;
 				}
 				if (msg.op_log_id < 0) return;
+				// Pre-anchor sanity check: cursor=0 means the
+				// server's op-log is currently empty. If this Y.Doc
+				// already has state at this moment, those ops came
+				// from somewhere — almost certainly replay binaries
+				// from a previous connection within this provider's
+				// life that didn't reach the post-replay cursor
+				// frame, followed by a server-side prune
+				// (PruneAndApply, schema rebuild, dormant GC) during
+				// our disconnect. Letting this anchor would mark a
+				// stale Y.Doc as authoritative; the next send-on-open
+				// or flush would resurrect pre-prune state and
+				// overwrite canonical items.content.
+				//
+				// Trigger force-refresh recovery instead. Per Codex
+				// round 18 [P1] of TASK-1319.
+				if (!this.cursorAnchored && msg.op_log_id === 0) {
+					const sv = Y.encodeStateVector(this.ydoc);
+					if (sv.length > 1) {
+						console.warn(
+							'collab: cursor=0 received against non-empty Y.Doc; treating as force_refresh',
+						);
+						clearStoredCursor(this.itemID);
+						this.lastOpLogID = 0;
+						this.preAnchorUpdates = [];
+						this.destroy();
+						try {
+							this.onForceRefresh?.();
+						} catch (err) {
+							console.warn(
+								'collab: onForceRefresh threw on stale cursor=0',
+								err,
+							);
+						}
+						return;
+					}
+				}
 				// Anchor the session: any cursor frame — including
 				// the initial post-replay cursor=0 against an empty
 				// op-log — proves the server has finished its

--- a/web/src/lib/collab/wsProvider.svelte.ts
+++ b/web/src/lib/collab/wsProvider.svelte.ts
@@ -878,20 +878,19 @@ export class CollabProvider {
 					console.warn(
 						'collab: cursor=0 received against remote-applied Y.Doc; treating as force_refresh',
 					);
-						clearStoredCursor(this.itemID);
-						this.lastOpLogID = 0;
-						this.preAnchorUpdates = [];
-						this.destroy();
-						try {
-							this.onForceRefresh?.();
-						} catch (err) {
-							console.warn(
-								'collab: onForceRefresh threw on stale cursor=0',
-								err,
-							);
-						}
-						return;
+					clearStoredCursor(this.itemID);
+					this.lastOpLogID = 0;
+					this.preAnchorUpdates = [];
+					this.destroy();
+					try {
+						this.onForceRefresh?.();
+					} catch (err) {
+						console.warn(
+							'collab: onForceRefresh threw on stale cursor=0',
+							err,
+						);
 					}
+					return;
 				}
 				// Anchor the session: any cursor frame — including
 				// the initial post-replay cursor=0 against an empty

--- a/web/src/lib/collab/wsProvider.svelte.ts
+++ b/web/src/lib/collab/wsProvider.svelte.ts
@@ -775,16 +775,23 @@ export class CollabProvider {
 
 		switch (messageType) {
 			case MESSAGE_SYNC: {
-				// Mark that the server applied SOMETHING to our
-				// Y.Doc. Distinguishes "remote replay landed" from
-				// "only local edits in Y.Doc" so the cursor=0 +
-				// non-empty-Y.Doc safety check (round 18) doesn't
-				// false-positive on legitimate local pre-anchor
-				// edits. Per Codex round 19 [P1].
-				this.remoteSyncApplied = true;
 				const enc = encoding.createEncoder();
 				encoding.writeVarUint(enc, MESSAGE_SYNC);
 				const subtype = syncProtocol.readSyncMessage(decoder, enc, this.ydoc, this);
+				// Mark that the server applied an UPDATE to our
+				// Y.Doc, NOT just a sync handshake. syncStep1 only
+				// carries a state vector — it doesn't apply state
+				// — so flagging it would false-positive the
+				// cursor=0 + non-empty-Y.Doc safety check on a
+				// peer's syncStep1 arriving pre-anchor. Only the
+				// step2 / update subtypes mutate Y.Doc state.
+				// Per Codex round 21 [P1] of TASK-1319.
+				if (
+					subtype === syncProtocol.messageYjsSyncStep2 ||
+					subtype === syncProtocol.messageYjsUpdate
+				) {
+					this.remoteSyncApplied = true;
+				}
 				// readSyncMessage writes a reply only when the inbound
 				// frame was a syncStep1 (encoder gets a syncStep2
 				// payload appended). For step2 / update there's no

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -619,7 +619,41 @@
 				// Codex round 2 [P1].
 				clearTimeout(collabFlushTimer);
 				collabFlushTimer = undefined;
-				forceRefreshNonce += 1;
+				// Refresh items.content from the server BEFORE
+				// rebuilding the Y.Doc. Without this, the lazy
+				// seed (TASK-1261) on the new doc reads the
+				// possibly-stale page-state cache of item.content
+				// and re-encodes that into a fresh op-log; the
+				// next flush then overwrites canonical server
+				// content with our stale view. The await is
+				// fire-and-forget at the call site; we bump the
+				// nonce only after the GET resolves so the
+				// cleanup→rebuild sequence sees fresh content. A
+				// failed fetch falls through to the bump anyway
+				// (better an editor session against possibly-
+				// stale content than no editor session at all);
+				// the user is already showing the toast about a
+				// refresh. Per Codex round 4 [P1].
+				const refreshCtx = ctx;
+				void api.items
+					.get(refreshCtx.wsSlug, refreshCtx.itemId)
+					.then((fresh) => {
+						// Apply only if the user is still on this
+						// item; a navigation away should not stamp
+						// fresh content into the OTHER item's slot.
+						if (item && item.id === refreshCtx.itemId) {
+							item = fresh;
+						}
+					})
+					.catch((err) => {
+						console.warn(
+							'collab: force_refresh item refetch failed; rebuilding against cached content',
+							err,
+						);
+					})
+					.finally(() => {
+						forceRefreshNonce += 1;
+					});
 			},
 		});
 

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -503,6 +503,16 @@
 	// teardown still runs its flush. Per Codex review round 1 [P1]
 	// of TASK-1319.
 	let skipFlushOnNextCleanup = false;
+	// forceRefreshInFlight blocks any new collab-snapshot flush from
+	// being scheduled (or surviving) while the page is mid-recovery
+	// from a server force_refresh. Without it, an in-flight refetch +
+	// pending nonce bump leaves the stale editor mounted; a local
+	// edit during that window arms a NEW collabFlushTimer that fires
+	// before cleanup runs and PATCHes stale Y.Doc-derived markdown
+	// back to canonical items.content. Reset to false at the END of
+	// the new collab $effect run (after rebuild completes). Per
+	// Codex round 7 [P1] of TASK-1319.
+	let forceRefreshInFlight = false;
 	const collabKey = $derived(item && canEdit && !rawMode ? item.id : null);
 
 	// Local user identity broadcast over awareness for the
@@ -611,6 +621,7 @@
 				// canonical items.content the fresh provider is
 				// supposed to lazy-seed from.
 				skipFlushOnNextCleanup = true;
+				forceRefreshInFlight = true;
 				// Cancel any in-flight 5s flush timer too. The
 				// cleanup-skip flag only covers the cleanup path;
 				// a timer that already armed before force_refresh
@@ -659,6 +670,11 @@
 
 		ydoc = doc;
 		collabProvider = provider;
+		// A fresh provider has been wired; the force-refresh
+		// recovery window (if any) has closed. Local edits from
+		// this point can safely schedule flushes again. Per Codex
+		// round 7 [P1] of TASK-1319.
+		forceRefreshInFlight = false;
 
 		return () => {
 			// Best-effort flush of items.content BEFORE we tear the
@@ -989,6 +1005,12 @@
 
 	function scheduleCollabFlush(markdown: string) {
 		clearTimeout(collabFlushTimer);
+		// Force-refresh recovery in flight: block any new flush
+		// scheduling. The provider is destroyed but the editor
+		// component is still mounted (cleanup hasn't run yet); a
+		// local edit during this window must NOT arm a flush timer
+		// against the stale Y.Doc state. Per Codex round 7 [P1].
+		if (forceRefreshInFlight) return;
 		const ctx = activeCollabContext;
 		if (!ctx) return;
 		collabFlushTimer = setTimeout(() => {

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -2002,7 +2002,7 @@
 							/>
 						{/key}
 					{:else if ydoc}
-						{#key `${item.id}:true`}
+						{#key `${item.id}:true:${forceRefreshNonce}`}
 							<Editor
 								content={editorContent}
 								onUpdate={handleContentUpdate}

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -1105,6 +1105,17 @@
 				keepalive,
 				opLogCursor,
 			});
+			// Post-await force_refresh check: a force_refresh
+			// frame can arrive WHILE the PATCH is in flight
+			// (server already accepted, items.content already
+			// overwritten — the server-side gate covers the
+			// happens-before case where MIN had advanced past
+			// our cursor by the time the request landed). At
+			// minimum, refuse to record this flush as
+			// authoritative locally — don't seed lastFlushedContent
+			// or update saveStatus from a known-stale base. Per
+			// Codex round 10 [P1].
+			if (forceRefreshInFlight) return 'skipped';
 			// lastFlushedContent is per-item; only seed it if the
 			// item we just flushed is still the active one.
 			// Otherwise a stale flush could pollute the new page's

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -1042,6 +1042,13 @@
 		markdown: string,
 		keepalive: boolean,
 	): Promise<CollabFlushResult> {
+		// Force-refresh recovery is in flight: any markdown derived
+		// from the soon-to-be-discarded Y.Doc is, by definition,
+		// stale relative to the canonical server content. Skipping
+		// here covers every direct caller (beforeunload, raw-toggle,
+		// flushCollabNow) without needing per-call-site guards. Per
+		// Codex round 8 [P1] of TASK-1319.
+		if (forceRefreshInFlight) return 'deduped';
 		const allItems = collectionStore.items ?? [];
 		let toSave = unescapeDocLinks(markdown);
 		if (allItems.length > 0) {

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -496,6 +496,13 @@
 	// from items.content via the lazy-seed path. The previous
 	// provider's onForceRefresh handler does the bumping.
 	let forceRefreshNonce = $state(0);
+	// skipFlushOnNextCleanup is the flag the provider's onForceRefresh
+	// handler sets so the next collab $effect cleanup tears down
+	// without flushing the (known-stale) Y.Doc-derived markdown.
+	// Reset at the start of each cleanup so a subsequent normal
+	// teardown still runs its flush. Per Codex review round 1 [P1]
+	// of TASK-1319.
+	let skipFlushOnNextCleanup = false;
 	const collabKey = $derived(item && canEdit && !rawMode ? item.id : null);
 
 	// Local user identity broadcast over awareness for the
@@ -593,6 +600,17 @@
 					'Editor refreshed — rejoining with the latest content from the server.',
 					'info',
 				);
+				// Mark this provider's effect cleanup as a
+				// force-refresh tear-down so the cleanup path
+				// SKIPS the trailing collab-snapshot flush. Per
+				// Codex review round 1 [P1] of TASK-1319: a
+				// force_refresh means the local Y.Doc state is
+				// known stale (its cursor was below MIN, so the
+				// rows it would replay no longer exist); flushing
+				// the Y.Doc-derived markdown would overwrite the
+				// canonical items.content the fresh provider is
+				// supposed to lazy-seed from.
+				skipFlushOnNextCleanup = true;
 				forceRefreshNonce += 1;
 			},
 		});
@@ -624,7 +642,13 @@
 			// snapshot. The other cleanup triggers (item nav,
 			// canEdit flip, page unmount) all benefit from the
 			// flush. Per Codex review round 3.
-			if (!rawMode) {
+			// Force-refresh tear-down skips the flush — the local
+			// Y.Doc is known stale and flushing it would overwrite
+			// canonical items.content. Per Codex review round 1
+			// [P1] of TASK-1319.
+			const skipFlush = skipFlushOnNextCleanup;
+			skipFlushOnNextCleanup = false;
+			if (!rawMode && !skipFlush) {
 				flushCollabNow(ctx, true);
 			}
 			provider.destroy();

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -611,6 +611,14 @@
 				// canonical items.content the fresh provider is
 				// supposed to lazy-seed from.
 				skipFlushOnNextCleanup = true;
+				// Cancel any in-flight 5s flush timer too. The
+				// cleanup-skip flag only covers the cleanup path;
+				// a timer that already armed before force_refresh
+				// fired would otherwise PATCH the (stale) Y.Doc-
+				// derived markdown after the cleanup ran. Per
+				// Codex round 2 [P1].
+				clearTimeout(collabFlushTimer);
+				collabFlushTimer = undefined;
 				forceRefreshNonce += 1;
 			},
 		});

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -655,15 +655,33 @@
 						if (item && item.id === refreshCtx.itemId) {
 							item = fresh;
 						}
+						// Refetch succeeded → safe to rebuild.
+						forceRefreshNonce += 1;
 					})
 					.catch((err) => {
+						// Refetch failed — we cannot guarantee the
+						// cached `item.content` reflects canonical
+						// server state. Rebuilding here would
+						// lazy-seed a fresh Y.Doc from the cached
+						// (possibly-stale) content, then the next
+						// flush would PATCH that stale content
+						// back to the server — recreating the
+						// corruption force_refresh was meant to
+						// prevent. Surface a hard error and ask
+						// the user to reload manually instead.
+						// The provider is already destroyed so
+						// the editor is read-only effectively;
+						// forceRefreshInFlight stays true so any
+						// in-flight or scheduled flush is blocked.
+						// Per Codex round 17 [P1] of TASK-1319.
 						console.warn(
-							'collab: force_refresh item refetch failed; rebuilding against cached content',
+							'collab: force_refresh item refetch failed; refusing to auto-rebuild',
 							err,
 						);
-					})
-					.finally(() => {
-						forceRefreshNonce += 1;
+						toastStore.show(
+							'Could not refresh editor — please reload the page.',
+							'error',
+						);
 					});
 			},
 		});

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -1030,7 +1030,13 @@
 	//   - 'failed' — PATCH errored. The toggle path bails so we
 	//     don't enter raw mode with stale state.
 	// Per Codex review round 8.
-	type CollabFlushResult = 'flushed' | 'deduped' | 'failed';
+	// 'skipped' is the TASK-1319 force_refresh-recovery path: the
+	// flush was blocked because the local Y.Doc state is known
+	// stale relative to the canonical server content. Distinct
+	// from 'deduped' (server already has this markdown) so callers
+	// like the rich→raw toggle can refuse to seed from the stale
+	// markdown rather than silently propagate it.
+	type CollabFlushResult = 'flushed' | 'deduped' | 'failed' | 'skipped';
 
 	// runCollabFlush PATCHes items.content via the
 	// `?source=collab-snapshot` bypass. Takes ws/item from the
@@ -1048,7 +1054,7 @@
 		// here covers every direct caller (beforeunload, raw-toggle,
 		// flushCollabNow) without needing per-call-site guards. Per
 		// Codex round 8 [P1] of TASK-1319.
-		if (forceRefreshInFlight) return 'deduped';
+		if (forceRefreshInFlight) return 'skipped';
 		const allItems = collectionStore.items ?? [];
 		let toSave = unescapeDocLinks(markdown);
 		if (allItems.length > 0) {
@@ -1978,14 +1984,27 @@
 									for (let i = 0; i < 3; i++) {
 										if (typeof md !== 'string') break;
 										const result = await runCollabFlush(ws, itemId, md, false);
-										if (result === 'failed') {
-											// PATCH errored — refuse
-											// to enter raw mode
-											// rather than silently
-											// seed from stale state.
-											// runCollabFlush already
-											// surfaced the toast.
-											// Per Codex review round 8.
+										if (result === 'failed' || result === 'skipped') {
+											// 'failed' — PATCH errored;
+											//   runCollabFlush already
+											//   surfaced the toast.
+											// 'skipped' — force_refresh
+											//   recovery is in flight,
+											//   the Y.Doc-derived md is
+											//   known stale (TASK-1319
+											//   round 9 [P1]); seeding
+											//   raw mode from it would
+											//   silently overwrite the
+											//   canonical server content
+											//   on the next raw save.
+											// Either way, refuse to
+											// enter raw mode.
+											if (result === 'skipped') {
+												toastStore.show(
+													'Editor is recovering — try Markdown again in a moment.',
+													'info',
+												);
+											}
 											aborted = true;
 											break;
 										}

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -489,6 +489,13 @@
 	// post-raw-save markdown). Per Codex review round 2.
 	let ydoc = $state<Y.Doc | null>(null);
 	let collabProvider = $state<CollabProvider | null>(null);
+	// forceRefreshNonce drives Y.Doc/provider recreation when the
+	// server signals our resume cursor was stale (TASK-1319). The
+	// collab $effect reads it as a reactive dependency, so bumping
+	// the value tears down the current provider+doc and rebuilds
+	// from items.content via the lazy-seed path. The previous
+	// provider's onForceRefresh handler does the bumping.
+	let forceRefreshNonce = $state(0);
 	const collabKey = $derived(item && canEdit && !rawMode ? item.id : null);
 
 	// Local user identity broadcast over awareness for the
@@ -514,6 +521,14 @@
 	$effect(() => {
 		if (!collabKey) return;
 		const itemId = collabKey;
+		// Track forceRefreshNonce so a bump from the provider's
+		// onForceRefresh handler tears this effect's old provider+doc
+		// down via the cleanup return and rebuilds fresh. Reading
+		// the rune is enough — Svelte 5 records the dependency. The
+		// _ underscore name silences "unused" lints; the side effect
+		// is the dependency tracking itself. Per TASK-1319.
+		const _refreshNonce = forceRefreshNonce;
+		void _refreshNonce;
 		// Snapshot the workspace alongside the itemId. activeCollabContext
 		// is what the timer-driven + cleanup-driven flushes target so
 		// they always PATCH the right URL even after navigation.
@@ -558,6 +573,27 @@
 					console.warn('collab: setContent failed', err);
 					return false;
 				}
+			},
+			// Force-refresh handler (TASK-1319). Fires when the
+			// server detects our `?since=<id>` is below the current
+			// MIN(item_yjs_updates.id) — the rows we expected to
+			// replay have been pruned (op-log GC, schema rebuild,
+			// PruneAndApply), so reconnecting from local state
+			// would corrupt the Y.Doc. Recovery: bump the
+			// `collabKey` so the $effect cleanup tears down the
+			// provider+doc, then a fresh provider+doc rebuilds from
+			// items.content via the lazy-seed path (TASK-1261).
+			//
+			// We don't explicitly call `provider.destroy()` here —
+			// the WS is already closing on the server side and the
+			// $effect cleanup runs that destroy as part of swapping
+			// in the new provider.
+			onForceRefresh: () => {
+				toastStore.show(
+					'Editor refreshed — rejoining with the latest content from the server.',
+					'info',
+				);
+				forceRefreshNonce += 1;
 			},
 		});
 
@@ -951,7 +987,23 @@
 			editorStore.setLastSaveTime(Date.now());
 		}
 		try {
-			await api.items.flushCollabContent(ws, itemId, toSave, { keepalive });
+			// Pass the provider's per-tab op-log cursor (TASK-1319) so
+			// the server can advance the GC watermark when this tab is
+			// caught up to MAX(op-log.id). When the cursor is below
+			// MAX (peer ops not yet applied here) the server leaves
+			// the watermark untouched — the GC sweeper must not delete
+			// rows this markdown doesn't reflect. The cursor reflects
+			// the provider tracking THIS item; if a navigation has
+			// already swapped to another item the foreground flush
+			// path bails earlier on dedupe and this code doesn't run.
+			const opLogCursor =
+				collabProvider && collabProvider.itemID === itemId
+					? collabProvider.lastOpLogID
+					: undefined;
+			await api.items.flushCollabContent(ws, itemId, toSave, {
+				keepalive,
+				opLogCursor,
+			});
 			// lastFlushedContent is per-item; only seed it if the
 			// item we just flushed is still the active one.
 			// Otherwise a stale flush could pollute the new page's


### PR DESCRIPTION
## Summary

Closes the two holes left by TASK-1309:

1. **Long-disconnected tab + external-write race** — a reconnecting tab whose `?since=<id>` is below the server's `MIN(item_yjs_updates.id)` gets a `force_refresh` control frame instead of a corrupt delta replay. Client recreates Y.Doc, lazy-seeds from `items.content`.

2. **Browser-only-edited items never GC'd** — browser `?source=collab-snapshot` flushes now carry `op_log_cursor`. The store advances `items.content_flushed_op_log_id` only when that cursor matches the current `MAX(op-log.id)` (cursor==MAX proves the markdown captures every persisted op).

## Mechanism

- Server attaches `op_log_cursor` JSON control frames after replay, after every `AppendYjsUpdate` (to the originator), and piggybacked on every peer's binary fan-out.
- Client persists per-tab in `sessionStorage` (deliberately NOT `localStorage` — avoids cross-tab cursor leakage that would force-refresh otherwise-stable tabs).
- `since=0` means "fresh client"; only `since>0 && since<MIN` triggers force-refresh.
- Watermark advancement uses a SQL `CASE` clause that re-evaluates `MAX` at COMMIT time, so a peer op landing between client-side cursor capture and the UPDATE leaves the watermark untouched.

## Implements

`TASK-1319` under `PLAN-1248`. Builds on `TASK-1309`.

## Test plan

- [x] go build ./... — clean
- [x] go vet ./... — clean
- [x] go test ./... — all green (incl. 5 new collab tests + 4 new store tests)
- [x] make check — clean
- [x] web build — clean
- [ ] Manual: dial WS with stale `?since=`, observe force_refresh + reconnect with toast
- [ ] Manual: single-peer item edit for >24h then idle, GC sweeper picks it up