### PR TITLE
feat(web): add sanitizeHtmlBlock with iframe-host allowlist (TASK-1323)

### DIFF
--- a/web/src/lib/utils/markdown.ts
+++ b/web/src/lib/utils/markdown.ts
@@ -160,6 +160,109 @@ export function sanitizeMarkdownHtml(html: string): string {
 	});
 }
 
+// HTML block allowlist. Permits everything markdown allows plus structural
+// elements (section/article/figure/etc.), media (iframe/video/audio), and
+// inline `style`. Used only by `sanitizeHtmlBlock` — the markdown surface
+// (comments + rendered item bodies) keeps the tighter allowlist above.
+const HTML_BLOCK_ALLOWED_TAGS = [
+	...MARKDOWN_ALLOWED_TAGS,
+	'iframe',
+	'section', 'article', 'aside', 'header', 'footer', 'main', 'nav',
+	'figure', 'figcaption', 'picture', 'source',
+	'video', 'audio'
+] as const;
+
+// Additional attributes for HTML blocks. Inline `style` is permitted here
+// (intentionally — styled callouts, custom typography, embed wrappers are
+// the whole point of HTML blocks). Media + iframe attributes cover the
+// embed allowlist hosts. DOMPurify's URL filter still strips javascript:
+// from any href/src.
+const HTML_BLOCK_ALLOWED_ATTR = [
+	...MARKDOWN_ALLOWED_ATTR,
+	'style',
+	// iframe attributes
+	'frameborder', 'allow', 'allowfullscreen', 'loading', 'referrerpolicy', 'sandbox',
+	// media attributes (autoplay deliberately omitted — embedded autoplay
+	// is hostile to the reader and the embed hosts handle it via their own
+	// query parameters when intentional)
+	'controls', 'loop', 'muted', 'playsinline', 'poster', 'preload'
+] as const;
+
+/**
+ * iframe `src` allowlist — only iframes pointing at one of these embed
+ * hosts survive sanitization. Adding a new host = one PR amending this
+ * array + a test case. Keep it small.
+ *
+ * The leading `^https:` is intentional: http: embeds are rejected (no
+ * mixed-content for embeds), and the host literals match the canonical
+ * embed URLs each provider documents.
+ */
+const IFRAME_HOST_ALLOWLIST: readonly RegExp[] = [
+	/^https:\/\/(www\.)?youtube(-nocookie)?\.com\/embed\//,
+	/^https:\/\/player\.vimeo\.com\/video\//,
+	/^https:\/\/(www\.)?loom\.com\/embed\//,
+	/^https:\/\/codesandbox\.io\/embed\//
+];
+
+/**
+ * Returns true iff `src` matches one of the {@link IFRAME_HOST_ALLOWLIST}
+ * regexes. Trims whitespace; case sensitivity is delegated to each regex
+ * (currently all anchored to lowercase `https://`, matching DOMPurify's
+ * URL normalization).
+ */
+export function isAllowedIframeSrc(src: string): boolean {
+	const trimmed = src.trim();
+	return IFRAME_HOST_ALLOWLIST.some(re => re.test(trimmed));
+}
+
+/**
+ * Sanitize raw HTML for rendering inside an HTML block node. Different
+ * from `sanitizeMarkdownHtml`: permits iframes (allowlisted hosts only),
+ * inline `style`, and additional structural/media tags. Strips scripts,
+ * inline event handlers, javascript:/data: URLs, and any iframe whose
+ * `src` fails {@link isAllowedIframeSrc}.
+ *
+ * SSR-safe: returns "" when `window` is undefined, mirroring
+ * `sanitizeMarkdownHtml`.
+ *
+ * Storage is NOT modified — sanitization is render-time only. The user's
+ * raw HTML stays in the editor's node attrs so they can inspect/edit
+ * exactly what they typed (including content this function strips).
+ */
+export function sanitizeHtmlBlock(html: string): string {
+	if (typeof window === 'undefined') return '';
+	// DOMPurify's tag allowlist accepts iframes here, but we need a host
+	// allowlist on top — that lives in this hook. Synchronous sanitize +
+	// try/finally cleanup means the hook never leaks across calls (and
+	// JavaScript's single-threaded execution rules out interleaving with
+	// concurrent sanitizeMarkdownHtml calls).
+	// DOMPurify's UponSanitizeElementHook signature widens currentNode to
+	// Node (not Element) since text/comment nodes also pass through. We
+	// only act on iframes — narrow safely via nodeName before touching
+	// attribute APIs.
+	const hook = (currentNode: Node) => {
+		if (currentNode.nodeName === 'IFRAME') {
+			const el = currentNode as Element;
+			const src = el.getAttribute('src') ?? '';
+			if (!isAllowedIframeSrc(src)) {
+				el.parentNode?.removeChild(el);
+			}
+		}
+	};
+	DOMPurify.addHook('uponSanitizeElement', hook);
+	try {
+		return DOMPurify.sanitize(html, {
+			ALLOWED_TAGS: [...HTML_BLOCK_ALLOWED_TAGS],
+			ALLOWED_ATTR: [...HTML_BLOCK_ALLOWED_ATTR],
+			ALLOW_DATA_ATTR: false,
+			ADD_ATTR: ['target'],
+			ALLOWED_URI_REGEXP: /^(?:(?:https?|mailto|ftp|tel):|[^a-z]|[a-z+.\-]+(?:[^a-z+.\-:]|$))/i
+		});
+	} finally {
+		DOMPurify.removeHook('uponSanitizeElement');
+	}
+}
+
 /**
  * Escape HTML-significant characters so a user-controlled string can be
  * safely interpolated into attribute values / text nodes.


### PR DESCRIPTION
## Summary

Adds `sanitizeHtmlBlock` and `isAllowedIframeSrc` to `web/src/lib/utils/markdown.ts`, a second client-side sanitizer scoped to the future `htmlBlock` node type (TASK-1324). Separate from `sanitizeMarkdownHtml` so the comment / rendered-markdown surface keeps its tighter allowlist.

Key differences from the markdown sanitizer:
- Permits `<iframe>`, but only when `src` matches one of four embed hosts (YouTube, Vimeo, Loom, CodeSandbox). Enforced via a one-shot `uponSanitizeElement` DOMPurify hook scoped to the call (`addHook` → `sanitize` → `removeHook` in a try/finally).
- Permits inline `style` attributes (styled callouts are the use case).
- Adds structural tags (`section`, `article`, `aside`, `header`, `footer`, `main`, `nav`, `figure`, `figcaption`, `picture`, `source`) and media tags (`video`, `audio`).
- `autoplay` deliberately not permitted — embed providers handle autoplay via query params when intentional, and embedded autoplay is hostile to readers.

## Context

Implements `TASK-1323` under `PLAN-1322` (HTML blocks — sanitized rich-content islands inside items). This is the foundation task; TASK-1324 (htmlBlock node + markdown round-trip) is the first consumer.

No call site changes — the new function isn't used yet. Adding it as a separate PR keeps the policy review surface minimal and lets TASK-1324's diff focus on the editor integration.

## Test plan

- [x] `cd web && npm run check` — clean (0 errors)
- [x] `cd web && npm run build` — clean (built in 7s)
- [x] No regression to `sanitizeMarkdownHtml`: file diff shows function untouched
- [x] No new DOMPurify hooks register globally: hook is added/removed within the synchronous `sanitizeHtmlBlock` call; verified no other `addHook` callers in `web/src` (`grep` clean)
- [ ] Integration smoke (TASK-1324) will exercise the function through a real htmlBlock NodeView; a console smoke via `sanitizeHtmlBlock(...)` in DevTools is sufficient until then

## Acceptance criteria mapping

| Criterion | Verified by |
|---|---|
| Strips `<script>`, `on*` handlers, `javascript:` URLs | DOMPurify defaults + the existing `ALLOWED_URI_REGEXP` regex |
| Allows YouTube/Vimeo/Loom/CodeSandbox iframes | `IFRAME_HOST_ALLOWLIST` regex array |
| Strips iframes with non-allowlisted src | `uponSanitizeElement` hook calls `parentNode.removeChild` |
| Allows inline `style` | `HTML_BLOCK_ALLOWED_ATTR` includes `style` |
| `isAllowedIframeSrc` true/false matches the spec | Function reads from same `IFRAME_HOST_ALLOWLIST` |
| SSR-safe `""` fallback | Mirrors `sanitizeMarkdownHtml`'s `typeof window === 'undefined'` guard |
| No regression on comments | `sanitizeMarkdownHtml` not touched |