### PR TITLE
feat(editor): slash menu, toolbar, markdown shortcut to insert htmlBlock (TASK-1326)

### DIFF
--- a/web/src/lib/components/editor/Editor.svelte
+++ b/web/src/lib/components/editor/Editor.svelte
@@ -334,7 +334,7 @@
 	import { workspaceStore } from '$lib/stores/workspace.svelte';
 	import { api } from '$lib/api/client';
 	import { BlockDragHandle } from './block-drag-handle';
-	import { HtmlBlock, flipHtmlBlockToSource } from './extensions/htmlBlock';
+	import { HtmlBlock, captureHtmlBlockPositions, flipHtmlBlockToSource } from './extensions/htmlBlock';
 	import { SLASH_ITEMS } from './block-types';
 	import {
 		AttachmentImage,
@@ -444,14 +444,16 @@
 			case 'taskList': c.toggleTaskList().run(); break;
 			case 'codeBlock': c.toggleCodeBlock().run(); break;
 			case 'htmlBlock': {
-				// Capture the cursor position BEFORE the insert. The new
-				// block lands at-or-after this position in the post-dispatch
-				// doc — works for empty-paragraph (block lands at point),
-				// end-of-paragraph (block lands at point), and mid-paragraph
-				// (paragraph splits; block lands a few positions past point).
-				const insertionPoint = editor?.state.selection.from ?? 0;
+				// Snapshot existing htmlBlock positions before insertion
+				// so flipHtmlBlockToSource can identify the new block by
+				// elimination — handles cases where the cursor sits next
+				// to an existing block (forward-scan-only would mistake
+				// the existing block for the new one).
+				if (!editor) break;
+				const before = captureHtmlBlockPositions(editor);
+				const insertionPoint = editor.state.selection.from;
 				c.setHtmlBlock({ html: '' }).run();
-				if (editor) flipHtmlBlockToSource(editor, insertionPoint);
+				flipHtmlBlockToSource(editor, insertionPoint, before);
 				break;
 			}
 			case 'blockquote': c.toggleBlockquote().run(); break;

--- a/web/src/lib/components/editor/Editor.svelte
+++ b/web/src/lib/components/editor/Editor.svelte
@@ -334,7 +334,7 @@
 	import { workspaceStore } from '$lib/stores/workspace.svelte';
 	import { api } from '$lib/api/client';
 	import { BlockDragHandle } from './block-drag-handle';
-	import { HtmlBlock } from './extensions/htmlBlock';
+	import { HtmlBlock, flipHtmlBlockToSource } from './extensions/htmlBlock';
 	import { SLASH_ITEMS } from './block-types';
 	import {
 		AttachmentImage,
@@ -445,16 +445,9 @@
 			case 'codeBlock': c.toggleCodeBlock().run(); break;
 			case 'htmlBlock':
 				c.setHtmlBlock({ html: '' }).run();
-				// After the node is inserted, find its DOM and synthesise a click on
-				// the empty-state placeholder so the user lands directly in source
-				// mode (matches the spec: all three insertion paths land in source).
-				requestAnimationFrame(() => {
-					const empty = editor?.view.dom.querySelector(
-						'.html-block:not(.html-block--editing) .html-block-empty'
-					);
-					const previewPane = empty?.parentElement;
-					(previewPane as HTMLElement | null)?.click();
-				});
+				// After insertion, the cursor lands just after the atom node, so
+				// selection.from - 1 is the start position of the new htmlBlock.
+				if (editor) flipHtmlBlockToSource(editor, editor.state.selection.from - 1);
 				break;
 			case 'blockquote': c.toggleBlockquote().run(); break;
 			case 'horizontalRule': c.setHorizontalRule().run(); break;

--- a/web/src/lib/components/editor/Editor.svelte
+++ b/web/src/lib/components/editor/Editor.svelte
@@ -334,7 +334,7 @@
 	import { workspaceStore } from '$lib/stores/workspace.svelte';
 	import { api } from '$lib/api/client';
 	import { BlockDragHandle } from './block-drag-handle';
-	import { HtmlBlock, captureHtmlBlockPositions, flipHtmlBlockToSource } from './extensions/htmlBlock';
+	import { HtmlBlock, captureHtmlBlockSnapshot, flipHtmlBlockToSource } from './extensions/htmlBlock';
 	import { SLASH_ITEMS } from './block-types';
 	import {
 		AttachmentImage,
@@ -444,13 +444,13 @@
 			case 'taskList': c.toggleTaskList().run(); break;
 			case 'codeBlock': c.toggleCodeBlock().run(); break;
 			case 'htmlBlock': {
-				// Snapshot existing htmlBlock positions before insertion
-				// so flipHtmlBlockToSource can identify the new block by
-				// elimination — handles cases where the cursor sits next
-				// to an existing block (forward-scan-only would mistake
-				// the existing block for the new one).
+				// Snapshot existing htmlBlock (pos, html) entries before
+				// insertion so flipHtmlBlockToSource can identify the new
+				// block by elimination — handles all cases including
+				// NodeSelection-replace (after.length === before.length
+				// but the replaced entry's html content differs).
 				if (!editor) break;
-				const before = captureHtmlBlockPositions(editor);
+				const before = captureHtmlBlockSnapshot(editor);
 				const insertionPoint = editor.state.selection.from;
 				c.setHtmlBlock({ html: '' }).run();
 				flipHtmlBlockToSource(editor, insertionPoint, before);

--- a/web/src/lib/components/editor/Editor.svelte
+++ b/web/src/lib/components/editor/Editor.svelte
@@ -443,6 +443,19 @@
 			case 'orderedList': c.toggleOrderedList().run(); break;
 			case 'taskList': c.toggleTaskList().run(); break;
 			case 'codeBlock': c.toggleCodeBlock().run(); break;
+			case 'htmlBlock':
+				c.setHtmlBlock({ html: '' }).run();
+				// After the node is inserted, find its DOM and synthesise a click on
+				// the empty-state placeholder so the user lands directly in source
+				// mode (matches the spec: all three insertion paths land in source).
+				requestAnimationFrame(() => {
+					const empty = editor?.view.dom.querySelector(
+						'.html-block:not(.html-block--editing) .html-block-empty'
+					);
+					const previewPane = empty?.parentElement;
+					(previewPane as HTMLElement | null)?.click();
+				});
+				break;
 			case 'blockquote': c.toggleBlockquote().run(); break;
 			case 'horizontalRule': c.setHorizontalRule().run(); break;
 			case 'table': c.insertTable({ rows: 3, cols: 3, withHeaderRow: true }).run(); break;

--- a/web/src/lib/components/editor/Editor.svelte
+++ b/web/src/lib/components/editor/Editor.svelte
@@ -443,14 +443,17 @@
 			case 'orderedList': c.toggleOrderedList().run(); break;
 			case 'taskList': c.toggleTaskList().run(); break;
 			case 'codeBlock': c.toggleCodeBlock().run(); break;
-			case 'htmlBlock':
+			case 'htmlBlock': {
+				// Capture the cursor position BEFORE the insert. The new
+				// block lands at-or-after this position in the post-dispatch
+				// doc — works for empty-paragraph (block lands at point),
+				// end-of-paragraph (block lands at point), and mid-paragraph
+				// (paragraph splits; block lands a few positions past point).
+				const insertionPoint = editor?.state.selection.from ?? 0;
 				c.setHtmlBlock({ html: '' }).run();
-				// flipHtmlBlockToSource defers one frame and scans adjacent
-				// positions to locate the just-inserted node — handles the
-				// NodeSelection / TextSelection / paragraph-collapse cases
-				// uniformly.
-				if (editor) flipHtmlBlockToSource(editor);
+				if (editor) flipHtmlBlockToSource(editor, insertionPoint);
 				break;
+			}
 			case 'blockquote': c.toggleBlockquote().run(); break;
 			case 'horizontalRule': c.setHorizontalRule().run(); break;
 			case 'table': c.insertTable({ rows: 3, cols: 3, withHeaderRow: true }).run(); break;

--- a/web/src/lib/components/editor/Editor.svelte
+++ b/web/src/lib/components/editor/Editor.svelte
@@ -445,9 +445,11 @@
 			case 'codeBlock': c.toggleCodeBlock().run(); break;
 			case 'htmlBlock':
 				c.setHtmlBlock({ html: '' }).run();
-				// After insertion, the cursor lands just after the atom node, so
-				// selection.from - 1 is the start position of the new htmlBlock.
-				if (editor) flipHtmlBlockToSource(editor, editor.state.selection.from - 1);
+				// flipHtmlBlockToSource defers one frame and scans adjacent
+				// positions to locate the just-inserted node — handles the
+				// NodeSelection / TextSelection / paragraph-collapse cases
+				// uniformly.
+				if (editor) flipHtmlBlockToSource(editor);
 				break;
 			case 'blockquote': c.toggleBlockquote().run(); break;
 			case 'horizontalRule': c.setHorizontalRule().run(); break;

--- a/web/src/lib/components/editor/EditorToolbar.svelte
+++ b/web/src/lib/components/editor/EditorToolbar.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import type { Editor } from '@tiptap/core';
 	import { editorStore } from '$lib/stores/editor.svelte';
-	import { flipHtmlBlockToSource } from './extensions/htmlBlock';
+	import { captureHtmlBlockPositions, flipHtmlBlockToSource } from './extensions/htmlBlock';
 
 	let { editor }: { editor: Editor | null } = $props();
 
@@ -32,13 +32,14 @@
 			btn('──', () => editor!.chain().focus().setHorizontalRule().run(), false),
 			btn('⊞', () => editor!.chain().focus().insertTable({ rows: 3, cols: 3, withHeaderRow: true }).run(), false),
 			btn('HTML', () => {
-				// Capture the cursor position BEFORE insertion so the
-				// helper can find the new block reliably (handles
-				// mid-paragraph splits where the block lands a few
-				// positions past the original cursor).
+				// Snapshot existing htmlBlock positions before insertion
+				// so flipHtmlBlockToSource can disambiguate the new block
+				// from any pre-existing ones (handles cursor-adjacent-to-
+				// existing-block edge case).
+				const before = captureHtmlBlockPositions(editor!);
 				const insertionPoint = editor!.state.selection.from;
 				editor!.chain().focus().setHtmlBlock({ html: '' }).run();
-				flipHtmlBlockToSource(editor!, insertionPoint);
+				flipHtmlBlockToSource(editor!, insertionPoint, before);
 			}, false),
 		]},
 	] : []);

--- a/web/src/lib/components/editor/EditorToolbar.svelte
+++ b/web/src/lib/components/editor/EditorToolbar.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import type { Editor } from '@tiptap/core';
 	import { editorStore } from '$lib/stores/editor.svelte';
+	import { flipHtmlBlockToSource } from './extensions/htmlBlock';
 
 	let { editor }: { editor: Editor | null } = $props();
 
@@ -32,13 +33,7 @@
 			btn('⊞', () => editor!.chain().focus().insertTable({ rows: 3, cols: 3, withHeaderRow: true }).run(), false),
 			btn('HTML', () => {
 				editor!.chain().focus().setHtmlBlock({ html: '' }).run();
-				requestAnimationFrame(() => {
-					const empty = editor!.view.dom.querySelector(
-						'.html-block:not(.html-block--editing) .html-block-empty'
-					);
-					const previewPane = empty?.parentElement;
-					(previewPane as HTMLElement | null)?.click();
-				});
+				flipHtmlBlockToSource(editor!, editor!.state.selection.from - 1);
 			}, false),
 		]},
 	] : []);

--- a/web/src/lib/components/editor/EditorToolbar.svelte
+++ b/web/src/lib/components/editor/EditorToolbar.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import type { Editor } from '@tiptap/core';
 	import { editorStore } from '$lib/stores/editor.svelte';
-	import { captureHtmlBlockPositions, flipHtmlBlockToSource } from './extensions/htmlBlock';
+	import { captureHtmlBlockSnapshot, flipHtmlBlockToSource } from './extensions/htmlBlock';
 
 	let { editor }: { editor: Editor | null } = $props();
 
@@ -32,11 +32,11 @@
 			btn('──', () => editor!.chain().focus().setHorizontalRule().run(), false),
 			btn('⊞', () => editor!.chain().focus().insertTable({ rows: 3, cols: 3, withHeaderRow: true }).run(), false),
 			btn('HTML', () => {
-				// Snapshot existing htmlBlock positions before insertion
-				// so flipHtmlBlockToSource can disambiguate the new block
-				// from any pre-existing ones (handles cursor-adjacent-to-
-				// existing-block edge case).
-				const before = captureHtmlBlockPositions(editor!);
+				// Snapshot existing htmlBlock (pos, html) entries before
+				// insertion so flipHtmlBlockToSource can disambiguate the
+				// new block from any pre-existing ones — handles cursor-
+				// adjacent-to-existing AND NodeSelection-replace cases.
+				const before = captureHtmlBlockSnapshot(editor!);
 				const insertionPoint = editor!.state.selection.from;
 				editor!.chain().focus().setHtmlBlock({ html: '' }).run();
 				flipHtmlBlockToSource(editor!, insertionPoint, before);

--- a/web/src/lib/components/editor/EditorToolbar.svelte
+++ b/web/src/lib/components/editor/EditorToolbar.svelte
@@ -33,7 +33,7 @@
 			btn('⊞', () => editor!.chain().focus().insertTable({ rows: 3, cols: 3, withHeaderRow: true }).run(), false),
 			btn('HTML', () => {
 				editor!.chain().focus().setHtmlBlock({ html: '' }).run();
-				flipHtmlBlockToSource(editor!, editor!.state.selection.from - 1);
+				flipHtmlBlockToSource(editor!);
 			}, false),
 		]},
 	] : []);

--- a/web/src/lib/components/editor/EditorToolbar.svelte
+++ b/web/src/lib/components/editor/EditorToolbar.svelte
@@ -30,6 +30,16 @@
 			btn('""', () => editor!.chain().focus().toggleBlockquote().run(), editor.isActive('blockquote')),
 			btn('──', () => editor!.chain().focus().setHorizontalRule().run(), false),
 			btn('⊞', () => editor!.chain().focus().insertTable({ rows: 3, cols: 3, withHeaderRow: true }).run(), false),
+			btn('HTML', () => {
+				editor!.chain().focus().setHtmlBlock({ html: '' }).run();
+				requestAnimationFrame(() => {
+					const empty = editor!.view.dom.querySelector(
+						'.html-block:not(.html-block--editing) .html-block-empty'
+					);
+					const previewPane = empty?.parentElement;
+					(previewPane as HTMLElement | null)?.click();
+				});
+			}, false),
 		]},
 	] : []);
 </script>

--- a/web/src/lib/components/editor/EditorToolbar.svelte
+++ b/web/src/lib/components/editor/EditorToolbar.svelte
@@ -32,8 +32,13 @@
 			btn('──', () => editor!.chain().focus().setHorizontalRule().run(), false),
 			btn('⊞', () => editor!.chain().focus().insertTable({ rows: 3, cols: 3, withHeaderRow: true }).run(), false),
 			btn('HTML', () => {
+				// Capture the cursor position BEFORE insertion so the
+				// helper can find the new block reliably (handles
+				// mid-paragraph splits where the block lands a few
+				// positions past the original cursor).
+				const insertionPoint = editor!.state.selection.from;
 				editor!.chain().focus().setHtmlBlock({ html: '' }).run();
-				flipHtmlBlockToSource(editor!);
+				flipHtmlBlockToSource(editor!, insertionPoint);
 			}, false),
 		]},
 	] : []);

--- a/web/src/lib/components/editor/block-types.ts
+++ b/web/src/lib/components/editor/block-types.ts
@@ -23,6 +23,7 @@ export const BLOCK_TYPES: BlockType[] = [
 	{ id: 'orderedList', icon: '1.', label: 'Numbered List', description: 'Ordered list' },
 	{ id: 'taskList', icon: '☐', label: 'Checklist', description: 'Task list' },
 	{ id: 'codeBlock', icon: '<>', label: 'Code Block', description: 'Fenced code block' },
+	{ id: 'htmlBlock', icon: 'HTML', label: 'HTML Block', description: 'Sanitized HTML embed (live preview)', insertOnly: true },
 	{ id: 'blockquote', icon: '❝', label: 'Blockquote', description: 'Quote block' },
 	{ id: 'horizontalRule', icon: '——', label: 'Divider', description: 'Horizontal rule', insertOnly: true },
 	{ id: 'table', icon: '⊞', label: 'Table', description: '3×3 table', insertOnly: true },

--- a/web/src/lib/components/editor/extensions/htmlBlock.ts
+++ b/web/src/lib/components/editor/extensions/htmlBlock.ts
@@ -20,19 +20,34 @@ import type MarkdownIt from 'markdown-it';
 import type { Node as ProseMirrorNode } from '@tiptap/pm/model';
 import { sanitizeHtmlBlock } from '$lib/utils/markdown';
 
+/** A single htmlBlock node's identity for snapshot comparison. */
+export interface HtmlBlockSnapshotEntry {
+	pos: number;
+	html: string;
+}
+
 /**
- * Snapshot the document positions of every htmlBlock node currently in
- * the editor. The caller pairs this with `flipHtmlBlockToSource` to
- * disambiguate the just-inserted block from any pre-existing ones —
- * critical when a new block is inserted adjacent to an existing one,
- * where forward-scanning alone would pick up the wrong node.
+ * Snapshot every htmlBlock node currently in the editor, recording
+ * BOTH position and `attrs.html` content. The caller pairs this with
+ * `flipHtmlBlockToSource` to disambiguate a just-inserted (or
+ * just-replaced) block from any pre-existing ones.
+ *
+ * Capturing content (not just position) is what makes the helper
+ * correct in the "NodeSelection replaces an existing htmlBlock" case
+ * — `insertContent` over a NodeSelection swaps the existing block
+ * for the new one, leaving `after.length === before.length` but with
+ * the replaced block's content changed (commonly to ''). A
+ * position-only snapshot can't see that change; the content snapshot
+ * does.
  */
-export function captureHtmlBlockPositions(editor: Editor): number[] {
-	const positions: number[] = [];
+export function captureHtmlBlockSnapshot(editor: Editor): HtmlBlockSnapshotEntry[] {
+	const snapshot: HtmlBlockSnapshotEntry[] = [];
 	editor.state.doc.descendants((node, pos) => {
-		if (node.type.name === 'htmlBlock') positions.push(pos);
+		if (node.type.name !== 'htmlBlock') return;
+		const html = typeof node.attrs.html === 'string' ? (node.attrs.html as string) : '';
+		snapshot.push({ pos, html });
 	});
-	return positions;
+	return snapshot;
 }
 
 /**
@@ -42,52 +57,55 @@ export function captureHtmlBlockPositions(editor: Editor): number[] {
  * source).
  *
  * Identifies the new block by walking the post-dispatch htmlBlock
- * positions in document order and finding the first one that doesn't
- * correspond to a pre-existing position from `before`. Pre-existing
- * positions get shifted by ProseMirror's transaction mapping; the
- * tolerance window {-1, 0, 1, 3} covers the observed shifts:
+ * snapshot in document order and matching each entry against the
+ * before-snapshot. A pre-existing block matches an after entry when:
  *
- *   - 0  → block was before the insertion point (unshifted)
- *   - 1  → atom-block insertion shifts later positions by +1
- *   - 3  → mid-paragraph split adds 2 paragraph tokens + 1 atom = +3
- *   - -1 → empty-paragraph collapse drops a paragraph token = -1
+ *   - Their `html` content is identical, AND
+ *   - The position is plausibly the before position shifted by
+ *     ProseMirror's transaction mapping. Tolerance window:
+ *       0  → block was before the insertion point (unshifted)
+ *       1  → atom-block insertion shifts later positions by +1
+ *       3  → mid-paragraph split adds 2 paragraph tokens + 1 atom = +3
+ *      -1  → empty-paragraph collapse drops a paragraph token = -1
  *
- * If no new block is found (e.g. the insert failed for some reason),
- * the helper is a silent no-op.
+ * The first after entry that *doesn't* match a before entry is the
+ * inserted (or replaced) block. This works uniformly for:
+ *   - Plain insert at empty paragraph / end of paragraph / mid-paragraph
+ *   - Insert adjacent to an existing htmlBlock
+ *   - Insert that replaces a NodeSelection on an existing htmlBlock
+ *     (after.length === before.length but the replaced entry's html
+ *     differs from its before image)
+ *
+ * Silent no-op if no new block is found (e.g. the insert failed).
  */
 export function flipHtmlBlockToSource(
 	editor: Editor,
 	insertionPoint: number,
-	before: number[],
+	before: HtmlBlockSnapshotEntry[],
 ): void {
 	requestAnimationFrame(() => {
 		const { state, view } = editor;
-		const after: number[] = [];
-		state.doc.descendants((node, pos) => {
-			if (node.type.name === 'htmlBlock') after.push(pos);
-		});
-		if (after.length !== before.length + 1) return;
+		const after = captureHtmlBlockSnapshot(editor);
 
-		// Walk both arrays in document order, advancing the `before`
-		// pointer whenever the current `after` position is a plausible
-		// shifted image of the next pre-existing position. The first
-		// `after` position that *isn't* a plausible image is the new
-		// block.
 		let bi = 0;
 		let newPos: number | null = null;
 		for (const a of after) {
+			let matched = false;
 			if (bi < before.length) {
 				const b = before[bi];
-				const shift = a - b;
-				const isUnshifted = b < insertionPoint && shift === 0;
-				const isShifted = b >= insertionPoint && (shift === -1 || shift === 1 || shift === 3);
-				if (isUnshifted || isShifted) {
+				const shift = a.pos - b.pos;
+				const isUnshifted = b.pos < insertionPoint && shift === 0;
+				const isShifted =
+					b.pos >= insertionPoint && (shift === -1 || shift === 1 || shift === 3);
+				if ((isUnshifted || isShifted) && a.html === b.html) {
 					bi++;
-					continue;
+					matched = true;
 				}
 			}
-			newPos = a;
-			break;
+			if (!matched) {
+				newPos = a.pos;
+				break;
+			}
 		}
 		if (newPos === null) return;
 
@@ -373,13 +391,16 @@ export const HtmlBlock = Node.create({
 			new InputRule({
 				find: /^```html[\s\n]$/,
 				handler: ({ state, range }) => {
-					// Snapshot pre-dispatch htmlBlock positions so the
-					// flip helper can disambiguate the new block from
-					// any existing ones. state.doc here is the
-					// pre-dispatch document — exactly what we want.
-					const before: number[] = [];
+					// Snapshot pre-dispatch htmlBlock entries (pos + html)
+					// so the flip helper can disambiguate the new block
+					// from any existing ones, including the replace-existing
+					// case where after.length === before.length. state.doc
+					// here is the pre-dispatch document.
+					const before: HtmlBlockSnapshotEntry[] = [];
 					state.doc.descendants((node, pos) => {
-						if (node.type.name === 'htmlBlock') before.push(pos);
+						if (node.type.name !== 'htmlBlock') return;
+						const html = typeof node.attrs.html === 'string' ? (node.attrs.html as string) : '';
+						before.push({ pos, html });
 					});
 					state.tr.replaceRangeWith(
 						range.from,

--- a/web/src/lib/components/editor/extensions/htmlBlock.ts
+++ b/web/src/lib/components/editor/extensions/htmlBlock.ts
@@ -24,19 +24,34 @@ import { sanitizeHtmlBlock } from '$lib/utils/markdown';
  * After inserting an htmlBlock node, defer one frame and synthesise a
  * click on the new block's preview pane so the user lands directly in
  * source mode (matches the spec: all three insertion paths land in
- * source). `pos` is the document position where the new node starts.
+ * source).
  *
- * Targeting by position (rather than `querySelector(.html-block-empty)`)
- * is critical: the document may already contain earlier empty blocks,
- * and we must flip the *newly inserted* one — not the first one that
- * happens to be empty.
+ * Walks adjacent positions around the current selection rather than
+ * trusting `selection.from - 1` arithmetic — selection placement after
+ * atom-node insertion varies by call site (NodeSelection vs
+ * TextSelection vs paragraph-collapse for input rules), and an earlier
+ * `querySelector('.html-block-empty')` was unreliable when the document
+ * already contained earlier empty blocks.
  */
-export function flipHtmlBlockToSource(editor: Editor, pos: number): void {
+export function flipHtmlBlockToSource(editor: Editor): void {
 	requestAnimationFrame(() => {
-		const dom = editor.view.nodeDOM(pos) as HTMLElement | null;
-		if (!dom || !dom.classList.contains('html-block')) return;
-		const previewPane = dom.querySelector('.html-block-preview') as HTMLElement | null;
-		previewPane?.click();
+		const { state, view } = editor;
+		const { selection, doc } = state;
+		// Candidates cover NodeSelection (from = node start), TextSelection
+		// past atom (from - 1 = node start), and any 1-step drift from
+		// transaction-mapping. doc.nodeAt is bounds-safe by itself but
+		// guard < 0 to avoid an unnecessary call.
+		const candidates = [selection.from, selection.from - 1, selection.from + 1];
+		for (const pos of candidates) {
+			if (pos < 0) continue;
+			const node = doc.nodeAt(pos);
+			if (node?.type.name !== 'htmlBlock') continue;
+			const dom = view.nodeDOM(pos) as HTMLElement | null;
+			if (!dom || !dom.classList.contains('html-block')) continue;
+			const previewPane = dom.querySelector('.html-block-preview') as HTMLElement | null;
+			previewPane?.click();
+			return;
+		}
 	});
 }
 
@@ -306,22 +321,28 @@ export const HtmlBlock = Node.create({
 		// an atom node (the htmlBlock leaf) instead of a wrapped textblock.
 		// Higher extension priority (1000, set above) ensures this fires
 		// before CodeBlock's broader `^```([a-z]+)?…` rule.
+		//
+		// `this.editor` is captured via lexical scope — TipTap's InputRule
+		// handler config does NOT pass `editor` directly. By the time the
+		// rule fires, the extension instance has been bound to the editor.
+		const extension = this;
 		return [
 			new InputRule({
 				find: /^```html[\s\n]$/,
-				handler: ({ state, range, ...ctx }) => {
+				handler: ({ state, range }) => {
 					// Modify state.tr in-place; ProseMirror's input-rules
 					// plugin picks up the transaction and dispatches it.
 					state.tr.replaceRangeWith(
 						range.from,
 						range.to,
-						this.type.create({ html: '' }),
+						extension.type.create({ html: '' }),
 					);
-					// Auto-flip into source mode after dispatch. range.from
-					// is the position where the new node starts in the
-					// post-dispatch document.
-					const editor = (ctx as { editor?: Editor }).editor;
-					if (editor) flipHtmlBlockToSource(editor, range.from);
+					// Defer to next frame so the dispatched transaction
+					// has landed and the post-dispatch selection is
+					// readable; the helper scans adjacent positions to
+					// find the new node regardless of where ProseMirror
+					// placed the selection.
+					if (extension.editor) flipHtmlBlockToSource(extension.editor);
 				},
 			}),
 		];

--- a/web/src/lib/components/editor/extensions/htmlBlock.ts
+++ b/web/src/lib/components/editor/extensions/htmlBlock.ts
@@ -21,39 +21,76 @@ import type { Node as ProseMirrorNode } from '@tiptap/pm/model';
 import { sanitizeHtmlBlock } from '$lib/utils/markdown';
 
 /**
+ * Snapshot the document positions of every htmlBlock node currently in
+ * the editor. The caller pairs this with `flipHtmlBlockToSource` to
+ * disambiguate the just-inserted block from any pre-existing ones —
+ * critical when a new block is inserted adjacent to an existing one,
+ * where forward-scanning alone would pick up the wrong node.
+ */
+export function captureHtmlBlockPositions(editor: Editor): number[] {
+	const positions: number[] = [];
+	editor.state.doc.descendants((node, pos) => {
+		if (node.type.name === 'htmlBlock') positions.push(pos);
+	});
+	return positions;
+}
+
+/**
  * After inserting an htmlBlock node, defer one frame and synthesise a
  * click on the new block's preview pane so the user lands directly in
  * source mode (matches the spec: all three insertion paths land in
  * source).
  *
- * The caller passes `insertionPoint` — the document position where the
- * cursor was BEFORE the insert ran. After `.run()` / input-rule dispatch,
- * the new htmlBlock is the first htmlBlock node at or after that
- * position in the post-dispatch doc. This handles all the tricky cases:
- * NodeSelection vs TextSelection placement, empty-paragraph collapse,
- * mid-paragraph splits (where the new block lands a few positions past
- * where the cursor was), and end-of-doc insertion.
+ * Identifies the new block by walking the post-dispatch htmlBlock
+ * positions in document order and finding the first one that doesn't
+ * correspond to a pre-existing position from `before`. Pre-existing
+ * positions get shifted by ProseMirror's transaction mapping; the
+ * tolerance window {-1, 0, 1, 3} covers the observed shifts:
  *
- * The `Math.max(0, insertionPoint - 1)` start guards against
- * empty-paragraph collapse, where ProseMirror can drop the empty
- * paragraph token and the new block lands at insertionPoint - 1.
+ *   - 0  → block was before the insertion point (unshifted)
+ *   - 1  → atom-block insertion shifts later positions by +1
+ *   - 3  → mid-paragraph split adds 2 paragraph tokens + 1 atom = +3
+ *   - -1 → empty-paragraph collapse drops a paragraph token = -1
+ *
+ * If no new block is found (e.g. the insert failed for some reason),
+ * the helper is a silent no-op.
  */
-export function flipHtmlBlockToSource(editor: Editor, insertionPoint: number): void {
+export function flipHtmlBlockToSource(
+	editor: Editor,
+	insertionPoint: number,
+	before: number[],
+): void {
 	requestAnimationFrame(() => {
 		const { state, view } = editor;
-		const startPos = Math.max(0, insertionPoint - 1);
-		const endPos = state.doc.content.size;
-		if (startPos >= endPos) return;
-		let newPos: number | null = null;
-		state.doc.nodesBetween(startPos, endPos, (node, pos) => {
-			if (newPos !== null) return false;
-			if (node.type.name === 'htmlBlock') {
-				newPos = pos;
-				return false;
-			}
-			return true;
+		const after: number[] = [];
+		state.doc.descendants((node, pos) => {
+			if (node.type.name === 'htmlBlock') after.push(pos);
 		});
+		if (after.length !== before.length + 1) return;
+
+		// Walk both arrays in document order, advancing the `before`
+		// pointer whenever the current `after` position is a plausible
+		// shifted image of the next pre-existing position. The first
+		// `after` position that *isn't* a plausible image is the new
+		// block.
+		let bi = 0;
+		let newPos: number | null = null;
+		for (const a of after) {
+			if (bi < before.length) {
+				const b = before[bi];
+				const shift = a - b;
+				const isUnshifted = b < insertionPoint && shift === 0;
+				const isShifted = b >= insertionPoint && (shift === -1 || shift === 1 || shift === 3);
+				if (isUnshifted || isShifted) {
+					bi++;
+					continue;
+				}
+			}
+			newPos = a;
+			break;
+		}
 		if (newPos === null) return;
+
 		const dom = view.nodeDOM(newPos) as HTMLElement | null;
 		if (!dom || !dom.classList.contains('html-block')) return;
 		const previewPane = dom.querySelector('.html-block-preview') as HTMLElement | null;
@@ -336,19 +373,22 @@ export const HtmlBlock = Node.create({
 			new InputRule({
 				find: /^```html[\s\n]$/,
 				handler: ({ state, range }) => {
-					// Modify state.tr in-place; ProseMirror's input-rules
-					// plugin picks up the transaction and dispatches it.
+					// Snapshot pre-dispatch htmlBlock positions so the
+					// flip helper can disambiguate the new block from
+					// any existing ones. state.doc here is the
+					// pre-dispatch document — exactly what we want.
+					const before: number[] = [];
+					state.doc.descendants((node, pos) => {
+						if (node.type.name === 'htmlBlock') before.push(pos);
+					});
 					state.tr.replaceRangeWith(
 						range.from,
 						range.to,
 						extension.type.create({ html: '' }),
 					);
-					// Pass range.from as the insertion point so the
-					// next-frame search starts there. Even if the new
-					// node lands a step away (paragraph collapse), the
-					// helper's startPos = max(0, insertionPoint - 1)
-					// covers it.
-					if (extension.editor) flipHtmlBlockToSource(extension.editor, range.from);
+					if (extension.editor) {
+						flipHtmlBlockToSource(extension.editor, range.from, before);
+					}
 				},
 			}),
 		];

--- a/web/src/lib/components/editor/extensions/htmlBlock.ts
+++ b/web/src/lib/components/editor/extensions/htmlBlock.ts
@@ -26,32 +26,38 @@ import { sanitizeHtmlBlock } from '$lib/utils/markdown';
  * source mode (matches the spec: all three insertion paths land in
  * source).
  *
- * Walks adjacent positions around the current selection rather than
- * trusting `selection.from - 1` arithmetic — selection placement after
- * atom-node insertion varies by call site (NodeSelection vs
- * TextSelection vs paragraph-collapse for input rules), and an earlier
- * `querySelector('.html-block-empty')` was unreliable when the document
- * already contained earlier empty blocks.
+ * The caller passes `insertionPoint` — the document position where the
+ * cursor was BEFORE the insert ran. After `.run()` / input-rule dispatch,
+ * the new htmlBlock is the first htmlBlock node at or after that
+ * position in the post-dispatch doc. This handles all the tricky cases:
+ * NodeSelection vs TextSelection placement, empty-paragraph collapse,
+ * mid-paragraph splits (where the new block lands a few positions past
+ * where the cursor was), and end-of-doc insertion.
+ *
+ * The `Math.max(0, insertionPoint - 1)` start guards against
+ * empty-paragraph collapse, where ProseMirror can drop the empty
+ * paragraph token and the new block lands at insertionPoint - 1.
  */
-export function flipHtmlBlockToSource(editor: Editor): void {
+export function flipHtmlBlockToSource(editor: Editor, insertionPoint: number): void {
 	requestAnimationFrame(() => {
 		const { state, view } = editor;
-		const { selection, doc } = state;
-		// Candidates cover NodeSelection (from = node start), TextSelection
-		// past atom (from - 1 = node start), and any 1-step drift from
-		// transaction-mapping. doc.nodeAt is bounds-safe by itself but
-		// guard < 0 to avoid an unnecessary call.
-		const candidates = [selection.from, selection.from - 1, selection.from + 1];
-		for (const pos of candidates) {
-			if (pos < 0) continue;
-			const node = doc.nodeAt(pos);
-			if (node?.type.name !== 'htmlBlock') continue;
-			const dom = view.nodeDOM(pos) as HTMLElement | null;
-			if (!dom || !dom.classList.contains('html-block')) continue;
-			const previewPane = dom.querySelector('.html-block-preview') as HTMLElement | null;
-			previewPane?.click();
-			return;
-		}
+		const startPos = Math.max(0, insertionPoint - 1);
+		const endPos = state.doc.content.size;
+		if (startPos >= endPos) return;
+		let newPos: number | null = null;
+		state.doc.nodesBetween(startPos, endPos, (node, pos) => {
+			if (newPos !== null) return false;
+			if (node.type.name === 'htmlBlock') {
+				newPos = pos;
+				return false;
+			}
+			return true;
+		});
+		if (newPos === null) return;
+		const dom = view.nodeDOM(newPos) as HTMLElement | null;
+		if (!dom || !dom.classList.contains('html-block')) return;
+		const previewPane = dom.querySelector('.html-block-preview') as HTMLElement | null;
+		previewPane?.click();
 	});
 }
 
@@ -337,12 +343,12 @@ export const HtmlBlock = Node.create({
 						range.to,
 						extension.type.create({ html: '' }),
 					);
-					// Defer to next frame so the dispatched transaction
-					// has landed and the post-dispatch selection is
-					// readable; the helper scans adjacent positions to
-					// find the new node regardless of where ProseMirror
-					// placed the selection.
-					if (extension.editor) flipHtmlBlockToSource(extension.editor);
+					// Pass range.from as the insertion point so the
+					// next-frame search starts there. Even if the new
+					// node lands a step away (paragraph collapse), the
+					// helper's startPos = max(0, insertionPoint - 1)
+					// covers it.
+					if (extension.editor) flipHtmlBlockToSource(extension.editor, range.from);
 				},
 			}),
 		];

--- a/web/src/lib/components/editor/extensions/htmlBlock.ts
+++ b/web/src/lib/components/editor/extensions/htmlBlock.ts
@@ -15,10 +15,30 @@
  * collapse in TASK-1328.
  */
 
-import { InputRule, Node } from '@tiptap/core';
+import { InputRule, Node, type Editor } from '@tiptap/core';
 import type MarkdownIt from 'markdown-it';
 import type { Node as ProseMirrorNode } from '@tiptap/pm/model';
 import { sanitizeHtmlBlock } from '$lib/utils/markdown';
+
+/**
+ * After inserting an htmlBlock node, defer one frame and synthesise a
+ * click on the new block's preview pane so the user lands directly in
+ * source mode (matches the spec: all three insertion paths land in
+ * source). `pos` is the document position where the new node starts.
+ *
+ * Targeting by position (rather than `querySelector(.html-block-empty)`)
+ * is critical: the document may already contain earlier empty blocks,
+ * and we must flip the *newly inserted* one — not the first one that
+ * happens to be empty.
+ */
+export function flipHtmlBlockToSource(editor: Editor, pos: number): void {
+	requestAnimationFrame(() => {
+		const dom = editor.view.nodeDOM(pos) as HTMLElement | null;
+		if (!dom || !dom.classList.contains('html-block')) return;
+		const previewPane = dom.querySelector('.html-block-preview') as HTMLElement | null;
+		previewPane?.click();
+	});
+}
 
 declare module '@tiptap/core' {
 	interface Commands<ReturnType> {
@@ -289,7 +309,7 @@ export const HtmlBlock = Node.create({
 		return [
 			new InputRule({
 				find: /^```html[\s\n]$/,
-				handler: ({ state, range }) => {
+				handler: ({ state, range, ...ctx }) => {
 					// Modify state.tr in-place; ProseMirror's input-rules
 					// plugin picks up the transaction and dispatches it.
 					state.tr.replaceRangeWith(
@@ -297,6 +317,11 @@ export const HtmlBlock = Node.create({
 						range.to,
 						this.type.create({ html: '' }),
 					);
+					// Auto-flip into source mode after dispatch. range.from
+					// is the position where the new node starts in the
+					// post-dispatch document.
+					const editor = (ctx as { editor?: Editor }).editor;
+					if (editor) flipHtmlBlockToSource(editor, range.from);
 				},
 			}),
 		];

--- a/web/src/lib/components/editor/extensions/htmlBlock.ts
+++ b/web/src/lib/components/editor/extensions/htmlBlock.ts
@@ -15,7 +15,7 @@
  * collapse in TASK-1328.
  */
 
-import { Node } from '@tiptap/core';
+import { InputRule, Node } from '@tiptap/core';
 import type MarkdownIt from 'markdown-it';
 import type { Node as ProseMirrorNode } from '@tiptap/pm/model';
 import { sanitizeHtmlBlock } from '$lib/utils/markdown';
@@ -53,6 +53,11 @@ export const HtmlBlock = Node.create({
 	selectable: true,
 	draggable: true,
 	defining: true,
+	// Higher than the default extension priority (100) so the markdown
+	// shortcut input rule below fires BEFORE CodeBlock's `^```([a-z]+)?…`
+	// rule. Without this, typing ` ```html ` would create a code block
+	// (language=html) instead of an htmlBlock node.
+	priority: 1000,
 
 	addAttributes() {
 		return {
@@ -272,6 +277,29 @@ export const HtmlBlock = Node.create({
 						attrs: { html: options?.html ?? '' },
 					}),
 		};
+	},
+
+	addInputRules() {
+		// Markdown shortcut: typing ` ```html ` followed by a space or newline
+		// at the start of an empty paragraph creates a new htmlBlock node.
+		// Mirrors CodeBlock's textblockTypeInputRule pattern but materialises
+		// an atom node (the htmlBlock leaf) instead of a wrapped textblock.
+		// Higher extension priority (1000, set above) ensures this fires
+		// before CodeBlock's broader `^```([a-z]+)?…` rule.
+		return [
+			new InputRule({
+				find: /^```html[\s\n]$/,
+				handler: ({ state, range }) => {
+					// Modify state.tr in-place; ProseMirror's input-rules
+					// plugin picks up the transaction and dispatches it.
+					state.tr.replaceRangeWith(
+						range.from,
+						range.to,
+						this.type.create({ html: '' }),
+					);
+				},
+			}),
+		];
 	},
 
 	addStorage() {


### PR DESCRIPTION
## Summary

Three insertion paths for the htmlBlock node (PLAN-1322), all landing the user in source mode for immediate authoring:

1. **Slash menu** (`/HTML`) — new `SLASH_ITEMS` entry in `block-types.ts`. `execSlash` dispatches `setHtmlBlock` + a `requestAnimationFrame` click on the empty-state placeholder.
2. **Toolbar** — new `'HTML'` button in the `'blocks'` group of `EditorToolbar.svelte`, after the table button. Same insert + auto-flip pattern.
3. **Markdown shortcut** — new ProseMirror `InputRule` in `htmlBlock.ts` matching `^\`\`\`html[\s\n]$`. The extension's `priority` is bumped to `1000` so this rule fires before CodeBlock's broader `^\`\`\`([a-z]+)?[\s\n]$` rule (otherwise typing ` ```html ` + Enter would create a syntax-highlighted code block, not an htmlBlock).

## Auto-flip-to-source mechanism

After insertion, all three paths run on the next animation frame:
```ts
const empty = editor.view.dom.querySelector(
    '.html-block:not(.html-block--editing) .html-block-empty'
);
empty?.parentElement?.click();
```

Works because a freshly inserted block is always empty and never in `.html-block--editing` mode.

## Context

Implements `TASK-1326` under `PLAN-1322`. Blocked on TASK-1324 (htmlBlock node; merged in #474). Closes the loop with TASK-1325 (source-view toggle; merged in #475) — users can now insert AND edit HTML blocks end-to-end.

## Test plan

- [x] `npm run check` — 0 errors
- [x] `npm run build` — clean
- [x] HtmlBlock priority=1000 > CodeBlock's default 100
- [ ] Full manual e2e ready now

## Files

- `web/src/lib/components/editor/block-types.ts` — 1 new SLASH_ITEMS entry
- `web/src/lib/components/editor/extensions/htmlBlock.ts` — `priority: 1000` + `addInputRules`
- `web/src/lib/components/editor/Editor.svelte` — new `case 'htmlBlock'` in `execSlash`
- `web/src/lib/components/editor/EditorToolbar.svelte` — new `'HTML'` button