### PR TITLE
feat(versions): collapse HTML blocks as semantic units in diff view (TASK-1328)

### DIFF
--- a/web/src/lib/components/versions/DiffView.svelte
+++ b/web/src/lib/components/versions/DiffView.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { diffLines, type Change } from 'diff';
+	import { SvelteSet } from 'svelte/reactivity';
 
 	interface Props {
 		oldContent: string;
@@ -24,10 +25,18 @@
 		newLineNum: number | null;
 	}
 
+	type MidEntry =
+		| { kind: 'line'; line: DiffLine }
+		| { kind: 'htmlBlock'; lines: DiffLine[]; added: number; removed: number; unchanged: number };
+
 	interface DisplayEntry {
-		kind: 'line' | 'separator';
+		kind: 'line' | 'separator' | 'htmlBlock';
 		line?: DiffLine;
 		skipped?: number;
+		lines?: DiffLine[];
+		added?: number;
+		removed?: number;
+		unchanged?: number;
 	}
 
 	/**
@@ -64,57 +73,138 @@
 	}
 
 	/**
-	 * Collapse unchanged lines outside the context window into
-	 * separator entries showing how many lines were skipped.
+	 * Group runs of `\`\`\`html` ... `\`\`\`` lines into a single htmlBlock chunk
+	 * when they contain any added/removed line. Entirely-unchanged blocks are
+	 * passed through as individual lines so the standard context-collapse can
+	 * handle them. Unbalanced fences degrade to plain lines.
 	 */
-	function collapseContext(lines: DiffLine[]): DisplayEntry[] {
-		// Find indices of all changed lines
-		const changedIndices = new Set<number>();
-		for (let i = 0; i < lines.length; i++) {
-			if (lines[i].type !== 'unchanged') {
-				changedIndices.add(i);
-			}
-		}
-
-		// If there are no changes at all, show a short message
-		if (changedIndices.size === 0) {
-			return [{ kind: 'separator', skipped: lines.length }];
-		}
-
-		// Mark which lines should be visible (within CONTEXT_LINES of a change)
-		const visible = new Set<number>();
-		for (const idx of changedIndices) {
-			for (let offset = -CONTEXT_LINES; offset <= CONTEXT_LINES; offset++) {
-				const target = idx + offset;
-				if (target >= 0 && target < lines.length) {
-					visible.add(target);
-				}
-			}
-		}
-
-		const entries: DisplayEntry[] = [];
+	function chunkHtmlBlocks(lines: DiffLine[]): MidEntry[] {
+		const entries: MidEntry[] = [];
+		const fenceOpenRe = /^(`{3,})html$/;
 		let i = 0;
+
 		while (i < lines.length) {
-			if (visible.has(i)) {
-				entries.push({ kind: 'line', line: lines[i] });
-				i++;
-			} else {
-				// Count consecutive hidden lines
-				let skippedCount = 0;
-				while (i < lines.length && !visible.has(i)) {
-					skippedCount++;
-					i++;
+			const match = lines[i].text.match(fenceOpenRe);
+			if (match) {
+				const fence = match[1];
+				// Search forward for matching close fence (exact backtick run, no language)
+				let close = -1;
+				for (let j = i + 1; j < lines.length; j++) {
+					if (lines[j].text === fence) {
+						close = j;
+						break;
+					}
 				}
-				entries.push({ kind: 'separator', skipped: skippedCount });
+
+				if (close !== -1) {
+					const blockLines = lines.slice(i, close + 1);
+					let added = 0;
+					let removed = 0;
+					let unchanged = 0;
+					for (const line of blockLines) {
+						if (line.type === 'added') added++;
+						else if (line.type === 'removed') removed++;
+						else unchanged++;
+					}
+
+					if (added > 0 || removed > 0) {
+						entries.push({ kind: 'htmlBlock', lines: blockLines, added, removed, unchanged });
+					} else {
+						// Entirely unchanged — let context-collapse handle them
+						for (const line of blockLines) {
+							entries.push({ kind: 'line', line });
+						}
+					}
+					i = close + 1;
+					continue;
+				}
+				// Unbalanced fence — fall through to plain line
 			}
+
+			entries.push({ kind: 'line', line: lines[i] });
+			i++;
 		}
 
 		return entries;
 	}
 
+	/**
+	 * Collapse unchanged lines outside the context window into
+	 * separator entries showing how many lines were skipped.
+	 */
+	function collapseContext(entries: MidEntry[]): DisplayEntry[] {
+		// Find indices of all "change" entries (htmlBlock chunks or non-unchanged lines)
+		const changedIndices = new Set<number>();
+		for (let i = 0; i < entries.length; i++) {
+			const e = entries[i];
+			if (e.kind === 'htmlBlock' || (e.kind === 'line' && e.line.type !== 'unchanged')) {
+				changedIndices.add(i);
+			}
+		}
+
+		// If there are no changes at all, count total raw lines and show a single message
+		if (changedIndices.size === 0) {
+			let total = 0;
+			for (const e of entries) {
+				if (e.kind === 'line') total++;
+			}
+			return [{ kind: 'separator', skipped: total }];
+		}
+
+		// Mark which entries should be visible (within CONTEXT_LINES of a change)
+		const visible = new Set<number>();
+		for (const idx of changedIndices) {
+			for (let offset = -CONTEXT_LINES; offset <= CONTEXT_LINES; offset++) {
+				const target = idx + offset;
+				if (target >= 0 && target < entries.length) {
+					visible.add(target);
+				}
+			}
+		}
+
+		const out: DisplayEntry[] = [];
+		let i = 0;
+		while (i < entries.length) {
+			if (visible.has(i)) {
+				const e = entries[i];
+				if (e.kind === 'htmlBlock') {
+					out.push({
+						kind: 'htmlBlock',
+						lines: e.lines,
+						added: e.added,
+						removed: e.removed,
+						unchanged: e.unchanged
+					});
+				} else {
+					out.push({ kind: 'line', line: e.line });
+				}
+				i++;
+			} else {
+				// Count consecutive hidden entries — only `line` entries can be hidden
+				// because htmlBlock entries are always changes (and thus visible).
+				let skippedCount = 0;
+				while (i < entries.length && !visible.has(i)) {
+					if (entries[i].kind === 'line') skippedCount++;
+					i++;
+				}
+				out.push({ kind: 'separator', skipped: skippedCount });
+			}
+		}
+
+		return out;
+	}
+
 	let changes = $derived(diffLines(oldContent, newContent));
 	let diffLineEntries = $derived(buildDiffLines(changes));
-	let displayEntries = $derived(collapseContext(diffLineEntries));
+	let chunkedEntries = $derived(chunkHtmlBlocks(diffLineEntries));
+	let displayEntries = $derived(collapseContext(chunkedEntries));
+
+	const expandedBlocks = new SvelteSet<number>();
+
+	function toggleBlock(idx: number) {
+		if (expandedBlocks.has(idx)) expandedBlocks.delete(idx);
+		else expandedBlocks.add(idx);
+	}
 
 	let stats = $derived.by(() => {
 		let added = 0;
@@ -148,10 +238,44 @@
 	</div>
 
 	<div class="diff-body">
-		{#each displayEntries as entry (entry.kind === 'separator' ? `sep-${displayEntries.indexOf(entry)}` : `line-${entry.line?.oldLineNum ?? 'n'}-${entry.line?.newLineNum ?? 'n'}-${entry.line?.type}`)}
+		{#each displayEntries as entry, idx (idx)}
 			{#if entry.kind === 'separator'}
 				<div class="separator">
 					<span class="separator-text">... {entry.skipped} unchanged {entry.skipped === 1 ? 'line' : 'lines'} ...</span>
+				</div>
+			{:else if entry.kind === 'htmlBlock' && entry.lines}
+				<div class="html-block-chunk">
+					<button
+						type="button"
+						class="html-block-chunk-summary"
+						onclick={() => toggleBlock(idx)}
+						aria-expanded={expandedBlocks.has(idx)}
+					>
+						<span class="html-block-chunk-caret" class:expanded={expandedBlocks.has(idx)}>&#9654;</span>
+						<span>HTML block changed</span>
+						<span class="html-block-chunk-stats">
+							{#if (entry.added ?? 0) > 0}
+								<span class="html-block-chunk-stat-added">+{entry.added}</span>
+							{/if}
+							{#if (entry.removed ?? 0) > 0}
+								<span class="html-block-chunk-stat-removed">-{entry.removed}</span>
+							{/if}
+							({entry.unchanged ?? 0} unchanged)
+						</span>
+						<span class="html-block-chunk-stats">— click to {expandedBlocks.has(idx) ? 'collapse' : 'expand'}</span>
+					</button>
+					{#if expandedBlocks.has(idx)}
+						<div class="html-block-chunk-lines">
+							{#each entry.lines as innerLine (`${idx}-${innerLine.oldLineNum ?? 'n'}-${innerLine.newLineNum ?? 'n'}-${innerLine.type}`)}
+								<div class="diff-line {innerLine.type}">
+									<span class="line-num old-num">{innerLine.oldLineNum ?? ''}</span>
+									<span class="line-num new-num">{innerLine.newLineNum ?? ''}</span>
+									<span class="line-prefix">{innerLine.type === 'added' ? '+' : innerLine.type === 'removed' ? '-' : ' '}</span>
+									<span class="line-content">{innerLine.text}</span>
+								</div>
+							{/each}
+						</div>
+					{/if}
 				</div>
 			{:else if entry.line}
 				<div class="diff-line {entry.line.type}">
@@ -312,5 +436,52 @@
 		font-size: 0.8em;
 		color: var(--text-muted);
 		font-family: var(--font-ui);
+	}
+
+	.html-block-chunk {
+		background: var(--bg-secondary);
+		border-top: 1px solid var(--border);
+		border-bottom: 1px solid var(--border);
+	}
+	.html-block-chunk-summary {
+		display: flex;
+		align-items: center;
+		gap: var(--space-2);
+		padding: var(--space-2) var(--space-3);
+		cursor: pointer;
+		color: var(--text-secondary);
+		font-family: var(--font-ui);
+		font-size: 0.85em;
+		background: transparent;
+		border: none;
+		width: 100%;
+		text-align: left;
+	}
+	.html-block-chunk-summary:hover {
+		background: var(--bg-tertiary);
+	}
+	.html-block-chunk-caret {
+		display: inline-block;
+		width: 0.8em;
+		color: var(--text-muted);
+		transition: transform 0.12s;
+	}
+	.html-block-chunk-caret.expanded {
+		transform: rotate(90deg);
+	}
+	.html-block-chunk-stats {
+		color: var(--text-muted);
+		font-size: 0.95em;
+	}
+	.html-block-chunk-stat-added {
+		color: var(--accent-green);
+		font-weight: 600;
+	}
+	.html-block-chunk-stat-removed {
+		color: var(--accent-red, #ef4444);
+		font-weight: 600;
+	}
+	.html-block-chunk-lines {
+		border-top: 1px solid var(--border);
 	}
 </style>

--- a/web/src/lib/components/versions/DiffView.svelte
+++ b/web/src/lib/components/versions/DiffView.svelte
@@ -73,58 +73,106 @@
 	}
 
 	/**
-	 * Group runs of `\`\`\`html` ... `\`\`\`` lines into a single htmlBlock chunk
-	 * when they contain any added/removed line. Entirely-unchanged blocks are
-	 * passed through as individual lines so the standard context-collapse can
-	 * handle them. Unbalanced fences degrade to plain lines.
+	 * Compute the set of 1-indexed line numbers that fall inside any
+	 * `\`\`\`html` ... fenced block in `content`. Looks for openers via
+	 * `^(\`{3,})html$` and matches an EXACT backtick-run closing fence.
+	 *
+	 * Pre-computed once per side (old / new) so chunkHtmlBlocks can
+	 * decide block membership per-line without re-scanning the merged
+	 * diff stream — which avoids the bug where mismatched fence lengths
+	 * across old vs new (e.g. a body-line addition forces the new fence
+	 * to grow from 3→4 backticks) made a body line look like a closing
+	 * fence in the merged stream.
 	 */
-	function chunkHtmlBlocks(lines: DiffLine[]): MidEntry[] {
-		const entries: MidEntry[] = [];
-		const fenceOpenRe = /^(`{3,})html$/;
-		let i = 0;
-
-		while (i < lines.length) {
-			const match = lines[i].text.match(fenceOpenRe);
-			if (match) {
-				const fence = match[1];
-				// Search forward for matching close fence (exact backtick run, no language)
-				let close = -1;
-				for (let j = i + 1; j < lines.length; j++) {
-					if (lines[j].text === fence) {
-						close = j;
-						break;
-					}
+	function findHtmlBlockLineNumbers(content: string): Set<number> {
+		const inBlock = new Set<number>();
+		const lines = content.split('\n');
+		const openRe = /^(`{3,})html$/;
+		let openFence: string | null = null;
+		for (let i = 0; i < lines.length; i++) {
+			const lineNum = i + 1;
+			const text = lines[i];
+			if (openFence === null) {
+				const m = text.match(openRe);
+				if (m) {
+					openFence = m[1];
+					inBlock.add(lineNum);
 				}
-
-				if (close !== -1) {
-					const blockLines = lines.slice(i, close + 1);
-					let added = 0;
-					let removed = 0;
-					let unchanged = 0;
-					for (const line of blockLines) {
-						if (line.type === 'added') added++;
-						else if (line.type === 'removed') removed++;
-						else unchanged++;
-					}
-
-					if (added > 0 || removed > 0) {
-						entries.push({ kind: 'htmlBlock', lines: blockLines, added, removed, unchanged });
-					} else {
-						// Entirely unchanged — let context-collapse handle them
-						for (const line of blockLines) {
-							entries.push({ kind: 'line', line });
-						}
-					}
-					i = close + 1;
-					continue;
+			} else {
+				inBlock.add(lineNum);
+				if (text === openFence) {
+					openFence = null;
 				}
-				// Unbalanced fence — fall through to plain line
 			}
+		}
+		return inBlock;
+	}
 
-			entries.push({ kind: 'line', line: lines[i] });
-			i++;
+	/**
+	 * Group consecutive DiffLines that belong to an HTML block (in
+	 * either old or new) into a single htmlBlock chunk when the run
+	 * contains any added/removed line. Entirely-unchanged blocks pass
+	 * through as individual lines so the standard context-collapse can
+	 * compress them.
+	 *
+	 * Block membership is decided per-line via the precomputed
+	 * `oldBlockLines` / `newBlockLines` sets:
+	 *   - `removed` lines: in a block iff oldLineNum ∈ oldBlockLines
+	 *   - `added`   lines: in a block iff newLineNum ∈ newBlockLines
+	 *   - `unchanged` lines: in a block iff EITHER side puts them in one
+	 *
+	 * This is robust against fence-length changes across old/new because
+	 * we never match fence lines against each other across sides — each
+	 * side's block ranges are derived from its own content.
+	 */
+	function chunkHtmlBlocks(
+		lines: DiffLine[],
+		oldBlockLines: Set<number>,
+		newBlockLines: Set<number>
+	): MidEntry[] {
+		function isInBlock(line: DiffLine): boolean {
+			if (line.type === 'removed') {
+				return line.oldLineNum !== null && oldBlockLines.has(line.oldLineNum);
+			}
+			if (line.type === 'added') {
+				return line.newLineNum !== null && newBlockLines.has(line.newLineNum);
+			}
+			// unchanged — present on both sides; in a block if either side has it.
+			return (
+				(line.oldLineNum !== null && oldBlockLines.has(line.oldLineNum)) ||
+				(line.newLineNum !== null && newBlockLines.has(line.newLineNum))
+			);
 		}
 
+		const entries: MidEntry[] = [];
+		let i = 0;
+		while (i < lines.length) {
+			if (!isInBlock(lines[i])) {
+				entries.push({ kind: 'line', line: lines[i] });
+				i++;
+				continue;
+			}
+			// Run of consecutive in-block lines.
+			const blockLines: DiffLine[] = [];
+			let added = 0;
+			let removed = 0;
+			let unchanged = 0;
+			while (i < lines.length && isInBlock(lines[i])) {
+				const line = lines[i];
+				blockLines.push(line);
+				if (line.type === 'added') added++;
+				else if (line.type === 'removed') removed++;
+				else unchanged++;
+				i++;
+			}
+			if (added > 0 || removed > 0) {
+				entries.push({ kind: 'htmlBlock', lines: blockLines, added, removed, unchanged });
+			} else {
+				for (const line of blockLines) {
+					entries.push({ kind: 'line', line });
+				}
+			}
+		}
 		return entries;
 	}
 
@@ -196,7 +244,9 @@
 
 	let changes = $derived(diffLines(oldContent, newContent));
 	let diffLineEntries = $derived(buildDiffLines(changes));
-	let chunkedEntries = $derived(chunkHtmlBlocks(diffLineEntries));
+	let oldBlockLines = $derived(findHtmlBlockLineNumbers(oldContent));
+	let newBlockLines = $derived(findHtmlBlockLineNumbers(newContent));
+	let chunkedEntries = $derived(chunkHtmlBlocks(diffLineEntries, oldBlockLines, newBlockLines));
 	let displayEntries = $derived(collapseContext(chunkedEntries));
 
 	const expandedBlocks = new SvelteSet<number>();


### PR DESCRIPTION
## Summary

Adds a chunker to `DiffView.svelte` that groups ` ```html ` fenced-block contents into a single collapsed summary row when the block contains added/removed lines. Avoids tag-soup diffs in the audit trail — reviewing a marketing item or styled email with one HTML island no longer floods the diff with N raw markup lines.

## How it works

```
diffLines(old, new) → buildDiffLines → chunkHtmlBlocks → collapseContext → render
```

**`chunkHtmlBlocks`** walks the line list:
- Detect openers via `/^(\`{3,})html$/`, then look forward for an exact-fence closing line.
- If the block contains any added/removed line → emit one `{ kind: 'htmlBlock', lines, added, removed, unchanged }` entry.
- Entirely-unchanged blocks pass through as individual lines so the existing context-collapse compresses them as ordinary context (no special UI for them).
- Unbalanced fence (no close found) → fall through, plain line. Graceful degradation.

**`collapseContext`** updated to operate on the new `MidEntry[]` (line | htmlBlock). An htmlBlock counts as a change for visibility-window purposes; hidden runs only tally plain lines.

## UX

Summary row: `▶ HTML block changed   +N -M (X unchanged)   click to expand`

Click toggles per-entry expansion via a `SvelteSet<number>` keyed by display index. When expanded, inner lines render via the existing `.diff-line` markup — reuses the line-level diff already computed; no new diff algorithm.

Header stats badge still reads from `diffLineEntries` (the flat list), so total +/- across the whole diff includes changes inside chunks.

## Test plan

- [x] `npm run check` — 0 errors
- [x] `npm run build` — clean
- [x] No regression to existing diff rendering — buildDiffLines unchanged, regular line markup reused
- [ ] Manual: create an item with two ` ```html ` blocks, save baseline, edit one block, save again → diff shows one collapsed summary for the changed block, the unchanged block elides via existing context collapse
- [ ] Manual: click summary → expands to show inner line diff

## Out of scope

- Semantic HTML diff (attribute moved, child reordered) — line-level diff with collapse is enough
- Server-side diff storage changes — `internal/diff/` untouched; this is purely presentation
- Diff-view changes for any other content type — htmlBlock-specific

## Closes PLAN-1322

This is the final task. Plan ships: htmlBlock node + markdown round-trip + render-time sanitization + source-view editor + insertion UX + hidden-content authoring warning + diff collapse.