### PR TITLE
fix(console): mobile hamburger toggles correctly on tap (BUG-1330)

### DIFF
--- a/web/src/routes/console/+layout.svelte
+++ b/web/src/routes/console/+layout.svelte
@@ -76,9 +76,19 @@
 		<nav class="console-nav">
 			<div class="nav-left">
 				<a href="/console" class="nav-logo">Pad</a>
+				<!--
+					stopPropagation: this toggle click MUST NOT reach
+					handleWindowClick. See the BUG-1330 note on the SVG below
+					for the full explanation. The CSS `pointer-events: none`
+					already moves the click target onto the button, but
+					stopping propagation is belt-and-braces — if a future
+					change adds another element inside the button without the
+					same pointer-events guard, the outside-click handler still
+					won't fire on the toggle itself.
+				-->
 				<button
 					class="mobile-hamburger"
-					onclick={() => (mobileMenuOpen = !mobileMenuOpen)}
+					onclick={(e) => { e.stopPropagation(); mobileMenuOpen = !mobileMenuOpen; }}
 					aria-label={mobileMenuOpen ? 'Close menu' : 'Open menu'}
 					aria-expanded={mobileMenuOpen}
 					aria-controls="console-nav-links"
@@ -231,6 +241,26 @@
 	.mobile-hamburger:hover {
 		color: var(--text-primary);
 		background: var(--bg-hover);
+	}
+
+	/*
+		BUG-1330: clicks on the hamburger MUST always land on the button,
+		never on the SVG/rect/path inside it. The SVG content swaps between
+		closed-state (three rects) and open-state (X paths) on toggle, and
+		Svelte 5 syncs the DOM update synchronously between the delegated
+		button onclick and the bubbled `<svelte:window onclick>`. If the
+		click target is one of the inner SVG primitives, by the time
+		handleWindowClick runs the original target is already detached
+		(`isConnected === false`) — `target.closest('.console-nav')` walks
+		up an orphaned subtree and returns null, the "outside-click" branch
+		fires, and the menu slams shut as fast as it opened. Forcing the
+		hamburger SVG and its children to be pointer-event-transparent
+		makes the button the click target, which is never re-rendered.
+		Verified with a Svelte 5 playground repro.
+	*/
+	.mobile-hamburger svg,
+	.mobile-hamburger svg * {
+		pointer-events: none;
 	}
 
 	.nav-links {


### PR DESCRIPTION
## Summary

- Fixes BUG-1330 — the `/console` mobile hamburger button never opened its dropdown on tap.
- Root cause was an SVG-swap-detach race: tapping a `<rect>` inside the closed-state hamburger triggered the toggle's onclick (`mobileMenuOpen = true`), then Svelte 5 synced the `{#if mobileMenuOpen}{:else}{/if}` swap **before** the bubbled `<svelte:window onclick>` listener ran. By that point `event.target.isConnected === false`, `target.closest('.console-nav')` returned null, the outside-click branch fired, and the menu was reset closed in the same tick — visually "never opened."
- Two-layer defensive fix on `web/src/routes/console/+layout.svelte`:
  1. `pointer-events: none` on `.mobile-hamburger svg` and its children — click target is always the button (which is never re-rendered when `mobileMenuOpen` flips).
  2. `e.stopPropagation()` in the toggle's onclick — belt-and-braces, the toggle click can never reach the window listener even if a future change adds an inner element without the same guard.
- Inline comments record the BUG-1330 root cause so the next person to touch this nav doesn't reintroduce the swap.
- TopBar's mobile hamburger is unaffected — its SVG content doesn't swap on toggle, so the detach race never fires there.

Verified the timing in a Svelte 5 playground that mirrors the pattern; the window handler logged `target=rect, isConnected=false, closest(.nav)=NULL` for every tap before the fix.

## Test plan

- [ ] On mobile portrait (≤640px viewport): tap hamburger → dropdown opens with Workspaces / Settings / Billing / Admin / Sign out.
- [ ] Tap hamburger again (X icon now) → dropdown closes.
- [ ] Tap a link inside the dropdown → navigates and dropdown auto-closes (route-change `$effect`).
- [ ] Tap outside the navbar while the dropdown is open → dropdown closes.
- [ ] Press Escape while the dropdown is open → dropdown closes.
- [ ] Desktop (>640px) layout unchanged.
- [x] `make check` passes (0 errors, only pre-existing warnings).

Closes BUG-1330. Tracked task: TASK-1331.