### PR TITLE
fix(web): wire New Collection dashboard card to CreateCollectionModal (BUG-1332)

### DIFF
--- a/web/src/routes/[username]/[workspace]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/+page.svelte
@@ -489,19 +489,26 @@
 	workspaceName={workspaceStore.current?.name ?? ''}
 />
 
-{#if isOwner}
+{#if wsSlug}
+	<!--
+		Mount unconditionally (gated on wsSlug, not isOwner) so an owner editing
+		the modal isn't unmounted mid-edit when the 30s dashboard poll or a sync
+		signal calls load() → workspaceStore.setCurrent(), which transiently
+		clears currentMembership and flips isOwner false until /me resolves.
+		The trigger button is owner-gated above; this matches Sidebar.svelte's
+		pattern, and the server-side owner check (handlers_collections.go:48)
+		remains the enforcement boundary.
+	-->
 	<CreateCollectionModal
 		open={showCreateCollection}
 		{wsSlug}
 		oncreated={() => {
 			showCreateCollection = false;
-			if (wsSlug) {
-				// Refresh dashboard-local data (summary + collections grid) AND
-				// the shared collectionStore the Sidebar/quick-add read from,
-				// matching Sidebar.svelte's create-flow pattern.
-				load(wsSlug, true);
-				collectionStore.loadCollections(wsSlug);
-			}
+			// Refresh dashboard-local data (summary + collections grid) AND
+			// the shared collectionStore the Sidebar/quick-add read from,
+			// matching Sidebar.svelte's create-flow pattern.
+			load(wsSlug, true);
+			collectionStore.loadCollections(wsSlug);
 		}}
 		onclose={() => { showCreateCollection = false; }}
 	/>

--- a/web/src/routes/[username]/[workspace]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/+page.svelte
@@ -10,6 +10,7 @@
 	import OnboardingChecklist from '$lib/components/OnboardingChecklist.svelte';
 	import OnboardingIdeaBanner from '$lib/components/OnboardingIdeaBanner.svelte';
 	import ConnectWorkspaceModal from '$lib/components/ConnectWorkspaceModal.svelte';
+	import CreateCollectionModal from '$lib/components/collections/CreateCollectionModal.svelte';
 	import { titleStore } from '$lib/stores/title.svelte';
 	import type { DashboardResponse, Collection } from '$lib/types';
 
@@ -22,6 +23,7 @@
 	let pollTimer: ReturnType<typeof setInterval> | undefined;
 	let onboardingDismissed = $state(false);
 	let connectOpen = $state(false);
+	let showCreateCollection = $state(false);
 
 	// The dashboard response carries an `onboarding_seed` field when the
 	// workspace has a seeded onboarding primary (IDEA-1 / BACK-1 / FEAT-1
@@ -370,7 +372,11 @@
 						</div>
 					</a>
 				{/each}
-				<a href="/{username}/{wsSlug}/settings" class="coll-card coll-card-new">
+				<button
+					type="button"
+					class="coll-card coll-card-new"
+					onclick={() => { showCreateCollection = true; }}
+				>
 					<div class="coll-card-header">
 						<span class="coll-card-name">
 							<span class="coll-icon">+</span>
@@ -380,7 +386,7 @@
 					<div class="coll-statuses">
 						<span class="coll-status-empty">Create a custom collection</span>
 					</div>
-				</a>
+				</button>
 			</div>
 		</section>
 
@@ -474,6 +480,16 @@
 	serverUrl={typeof window !== 'undefined' ? window.location.origin : ''}
 	workspaceSlug={wsSlug}
 	workspaceName={workspaceStore.current?.name ?? ''}
+/>
+
+<CreateCollectionModal
+	open={showCreateCollection}
+	{wsSlug}
+	oncreated={() => {
+		showCreateCollection = false;
+		if (wsSlug) load(wsSlug, true);
+	}}
+	onclose={() => { showCreateCollection = false; }}
 />
 
 <style>
@@ -879,6 +895,13 @@
 	}
 	.coll-card-new:hover {
 		opacity: 1;
+	}
+	/* Reset <button> defaults so the trigger card matches its sibling <a> cards. */
+	button.coll-card-new {
+		font: inherit;
+		text-align: left;
+		cursor: pointer;
+		width: 100%;
 	}
 
 	/* ── Dual section (Attention + Up Next) ─────────────────────────────── */

--- a/web/src/routes/[username]/[workspace]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/+page.svelte
@@ -11,6 +11,7 @@
 	import OnboardingIdeaBanner from '$lib/components/OnboardingIdeaBanner.svelte';
 	import ConnectWorkspaceModal from '$lib/components/ConnectWorkspaceModal.svelte';
 	import CreateCollectionModal from '$lib/components/collections/CreateCollectionModal.svelte';
+	import { collectionStore } from '$lib/stores/collections.svelte';
 	import { titleStore } from '$lib/stores/title.svelte';
 	import type { DashboardResponse, Collection } from '$lib/types';
 
@@ -24,6 +25,10 @@
 	let onboardingDismissed = $state(false);
 	let connectOpen = $state(false);
 	let showCreateCollection = $state(false);
+	// Mirrors the settings page: server requires owner for collection create
+	// (handlers_collections.go:48), so the dashboard trigger + modal are
+	// owner-gated too. Without this, viewers can open the modal and hit a 403.
+	let isOwner = $derived(workspaceStore.isOwner);
 
 	// The dashboard response carries an `onboarding_seed` field when the
 	// workspace has a seeded onboarding primary (IDEA-1 / BACK-1 / FEAT-1
@@ -372,21 +377,23 @@
 						</div>
 					</a>
 				{/each}
-				<button
-					type="button"
-					class="coll-card coll-card-new"
-					onclick={() => { showCreateCollection = true; }}
-				>
-					<div class="coll-card-header">
-						<span class="coll-card-name">
-							<span class="coll-icon">+</span>
-							New Collection
-						</span>
-					</div>
-					<div class="coll-statuses">
-						<span class="coll-status-empty">Create a custom collection</span>
-					</div>
-				</button>
+				{#if isOwner}
+					<button
+						type="button"
+						class="coll-card coll-card-new"
+						onclick={() => { showCreateCollection = true; }}
+					>
+						<div class="coll-card-header">
+							<span class="coll-card-name">
+								<span class="coll-icon">+</span>
+								New Collection
+							</span>
+						</div>
+						<div class="coll-statuses">
+							<span class="coll-status-empty">Create a custom collection</span>
+						</div>
+					</button>
+				{/if}
 			</div>
 		</section>
 
@@ -482,15 +489,23 @@
 	workspaceName={workspaceStore.current?.name ?? ''}
 />
 
-<CreateCollectionModal
-	open={showCreateCollection}
-	{wsSlug}
-	oncreated={() => {
-		showCreateCollection = false;
-		if (wsSlug) load(wsSlug, true);
-	}}
-	onclose={() => { showCreateCollection = false; }}
-/>
+{#if isOwner}
+	<CreateCollectionModal
+		open={showCreateCollection}
+		{wsSlug}
+		oncreated={() => {
+			showCreateCollection = false;
+			if (wsSlug) {
+				// Refresh dashboard-local data (summary + collections grid) AND
+				// the shared collectionStore the Sidebar/quick-add read from,
+				// matching Sidebar.svelte's create-flow pattern.
+				load(wsSlug, true);
+				collectionStore.loadCollections(wsSlug);
+			}
+		}}
+		onclose={() => { showCreateCollection = false; }}
+	/>
+{/if}
 
 <style>
 	/* ── Layout ─────────────────────────────────────────────────────────── */

--- a/web/src/routes/[username]/[workspace]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/+page.svelte
@@ -25,10 +25,35 @@
 	let onboardingDismissed = $state(false);
 	let connectOpen = $state(false);
 	let showCreateCollection = $state(false);
-	// Mirrors the settings page: server requires owner for collection create
-	// (handlers_collections.go:48), so the dashboard trigger + modal are
-	// owner-gated too. Without this, viewers can open the modal and hit a 403.
-	let isOwner = $derived(workspaceStore.isOwner);
+
+	// Owner-gate state for the New Collection trigger.
+	//
+	// Reading `workspaceStore.isOwner` directly would make the trigger button
+	// flicker visibility every 30 s: the dashboard's silent poll (and sync
+	// signals) call `load()` → `workspaceStore.setCurrent()`, which clears
+	// `currentMembership` to null before `/me` resolves. During that window
+	// `workspaceStore.isOwner` returns false even for owners, hiding the CTA
+	// and dropping any focus on it.
+	//
+	// Two effects per CONVE-606 (split reactive-state sync from route-change
+	// effects): one resets the cache on a real workspace switch, the other
+	// updates it only when membership is definitively known (non-null).
+	// Initial default is `false` so we never flash owner-only UI before /me
+	// confirms ownership. Server enforcement (handlers_collections.go:48)
+	// remains the security boundary; this is purely a stability fix for the
+	// UX gate.
+	let isOwner = $state(false);
+	let lastOwnerSlug: string | null = null;
+	$effect(() => {
+		if (wsSlug !== lastOwnerSlug) {
+			lastOwnerSlug = wsSlug;
+			isOwner = false;
+		}
+	});
+	$effect(() => {
+		const mem = workspaceStore.currentMembership;
+		if (mem !== null) isOwner = mem.role === 'owner';
+	});
 
 	// The dashboard response carries an `onboarding_seed` field when the
 	// workspace has a seeded onboarding primary (IDEA-1 / BACK-1 / FEAT-1


### PR DESCRIPTION
## Summary

- Fixes [BUG-1332](https://github.com/PerpetualSoftware/pad/issues?q=BUG-1332): the "+ New Collection" tile in the workspace dashboard's Collections grid was a plain `<a href=".../settings">`, so clicking it navigated to the workspace Settings page instead of starting the create-collection flow.
- Swapped the anchor for a `<button>` that opens the existing `CreateCollectionModal` — the same pattern `Sidebar.svelte` already uses for its `+` affordance.
- `oncreated` calls `load(wsSlug, true)` so the new collection card appears immediately without a full reload.
- Tiny scoped CSS reset on `button.coll-card-new` (`font`, `text-align`, `cursor`, `width`) so it's visually indistinguishable from the sibling `<a>` cards.

## Test plan

- [x] `make check` — golangci-lint + go test + svelte-check + production build all green (0 errors; existing warnings unrelated)
- [x] `make install` — built, server restarted, reachable
- [ ] Visit workspace dashboard, click the "+ New Collection" card → confirm the `CreateCollectionModal` opens (not a nav to Settings)
- [ ] Create a collection from the modal → confirm it appears in the dashboard grid without a manual reload
- [ ] Cancel/close the modal → confirm dashboard state is unchanged