### PR TITLE
docs: surface --schema flag in SKILL.md + CLAUDE.md (TASK-1336)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,7 +159,8 @@ pad item blocked-by <item> <blocker>
 pad item deps <ref>           # Show dependencies
 pad item unblock <source> <target>
 pad collection list           # List collections
-pad collection create "Name" --fields "key:type[:opts]; ..."
+pad collection create "Name" --fields "key:type[:opts]; ..."  # compact DSL for simple schemas
+pad collection create "Name" --schema '<json>'                # full CollectionSchema (terminal_options, defaults, computed, relations)
 pad item edit <ref>           # Open in $EDITOR
 pad workspace init [--template X]  # Create workspace
 pad agent install [tool]      # Install /pad skill for AI tools

--- a/skills/pad/SKILL.md
+++ b/skills/pad/SKILL.md
@@ -285,7 +285,21 @@ pad item unblock TASK-5 TASK-8        # Remove a dependency
 ### Collections
 ```bash
 pad collection list [--format json]   # List collections with counts
-pad collection create "Name" --fields "key:type[:options]; ..." [--icon "X"]
+
+# Two ways to define the schema:
+# 1. --fields DSL — quick + compact for simple cases (key:type[:options])
+pad collection create "Bugs" --fields "status:select:new,fixing,fixed;severity:select:low,medium,high;component:text"
+
+# 2. --schema JSON — full CollectionSchema; required when you need
+#    terminal_options, custom defaults, computed fields, suffixes, or
+#    relation collections. Prefer this when terminal_options matters
+#    (drives dashboard active/complete counts).
+pad collection create "Marketing" --schema '{"fields":[{"key":"status","type":"select","options":["idea","drafting","published","archived"],"terminal_options":["published","archived"]}]}'
+pad collection create "Marketing" --schema @./schema.json   # file
+cat schema.json | pad collection create "Marketing" --schema -   # stdin
+
+# --fields and --schema are mutually exclusive.
+# Missing `label` on a schema field auto-fills from key (Title Case).
 ```
 
 ### Attachments


### PR DESCRIPTION
## Summary

Surfaces the new `--schema` flag (PR #482, PR #483) in the agent-facing docs so agents reach for it instead of the old `--fields` DSL when terminal_options matters.

## Context

Implements **TASK-1336** under **PLAN-1333** (BUG-1284). Final task TASK-1337 verifies end-to-end via the BUG-1284 repro.

## Changes

- `skills/pad/SKILL.md` — Collections section shows both forms side-by-side; calls out when --schema is required and notes label backfill
- `CLAUDE.md` — adds --schema variant alongside existing --fields example

CLI Long help and MCP tool description were already updated in TASK-1334 / TASK-1335.

## Test plan
- [x] `make check` — clean (docs-only diff, but verified nothing else regressed)
- [x] Spot-checked rendered SKILL.md section