### PR TITLE
fix(api): accept nested object/array for PATCH items fields/tags (BUG-1144)

### DIFF
--- a/internal/models/item.go
+++ b/internal/models/item.go
@@ -1,7 +1,9 @@
 package models
 
 import (
+	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 )
@@ -570,6 +572,105 @@ type ItemUpdate struct {
 	// (since nil pointer means "don't change" in partial updates)
 	ClearAssignedUser bool `json:"clear_assigned_user,omitempty"`
 	ClearAgentRole    bool `json:"clear_agent_role,omitempty"`
+}
+
+// ErrInvalidFieldsType / ErrInvalidTagsType are returned by
+// ItemUpdate.UnmarshalJSON when the inbound `fields` / `tags` value is
+// neither a JSON-encoded string nor the natural object/array shape.
+// Wire handlers surface the sentinel's message verbatim (without the
+// "invalid JSON: ..." wrapper from decodeJSON) so callers see a clean
+// domain-level error instead of leaked Go internals. See BUG-1144.
+var (
+	ErrInvalidFieldsType = errors.New(`"fields" must be a JSON object or a JSON-encoded string`)
+	ErrInvalidTagsType   = errors.New(`"tags" must be a JSON array or a JSON-encoded string`)
+)
+
+// UnmarshalJSON accepts `fields` / `tags` either as the canonical
+// JSON-encoded string shape (matches models.Item.Fields/Tags storage)
+// OR as the natural nested object/array shape any reasonable HTTP
+// client would send. The struct fields stay `*string` and the rest
+// of the pipeline (validation, store writes, web/CLI consumers) is
+// unchanged — we just normalize the wire input here.
+//
+// In-process callers that construct ItemUpdate{} literals never hit
+// this path, so no internal call site needs to change.
+//
+// See BUG-1144 (input side) and BUG-991 (the symmetric response-side
+// dual-emit, fixed at the MCP boundary in PR #364).
+func (u *ItemUpdate) UnmarshalJSON(data []byte) error {
+	// Use an alias to inherit every other field's default unmarshal
+	// behaviour, while shadowing fields/tags with json.RawMessage so we
+	// can inspect the raw shape. The outer fields shadow the embedded
+	// alias's same-named fields because they are less deeply nested.
+	type alias ItemUpdate
+	aux := struct {
+		Fields json.RawMessage `json:"fields,omitempty"`
+		Tags   json.RawMessage `json:"tags,omitempty"`
+		*alias
+	}{alias: (*alias)(u)}
+
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+
+	// The alias decode leaves u.Fields / u.Tags nil (the raw bytes were
+	// captured at the outer level). Re-populate them from the flex parser.
+	fieldsStr, err := flexJSONToString(aux.Fields, '{', ErrInvalidFieldsType)
+	if err != nil {
+		return err
+	}
+	u.Fields = fieldsStr
+
+	tagsStr, err := flexJSONToString(aux.Tags, '[', ErrInvalidTagsType)
+	if err != nil {
+		return err
+	}
+	u.Tags = tagsStr
+
+	return nil
+}
+
+// flexJSONToString accepts a raw JSON value and returns it as a
+// canonical JSON-encoded string. Acceptable inbound shapes:
+//
+//   - absent / empty / null → nil (caller leaves the field unchanged)
+//   - JSON string → passthrough (already the canonical shape)
+//   - JSON object or array (matching expectedStart '{' or '[') → re-marshal to string
+//
+// Any other shape returns errInvalid so the handler surfaces a clean
+// domain-level error instead of a leaked Go unmarshal message.
+func flexJSONToString(raw json.RawMessage, expectedStart byte, errInvalid error) (*string, error) {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return nil, nil
+	}
+	switch trimmed[0] {
+	case '"':
+		// Already a JSON-encoded string — unmarshal to the underlying Go
+		// string so subsequent code that does json.Unmarshal([]byte(*s), ...)
+		// sees the inner JSON, not a re-quoted string.
+		var s string
+		if err := json.Unmarshal(trimmed, &s); err != nil {
+			return nil, errInvalid
+		}
+		return &s, nil
+	case expectedStart:
+		// Object or array — re-marshal to a canonical JSON string so
+		// the downstream string-typed pipeline can json.Unmarshal it
+		// back to a map/slice exactly as if the caller had stringified.
+		var v any
+		if err := json.Unmarshal(trimmed, &v); err != nil {
+			return nil, errInvalid
+		}
+		b, err := json.Marshal(v)
+		if err != nil {
+			return nil, errInvalid
+		}
+		s := string(b)
+		return &s, nil
+	default:
+		return nil, errInvalid
+	}
 }
 
 type ItemListParams struct {

--- a/internal/models/item_test.go
+++ b/internal/models/item_test.go
@@ -1,6 +1,11 @@
 package models
 
-import "testing"
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+)
 
 func TestExtractItemCodeContextFromGitHubPRFields(t *testing.T) {
 	context := ExtractItemCodeContext(`{"github_pr":{"number":42,"url":"https://github.com/PerpetualSoftware/pad/pull/42","title":"Add branch metadata","state":"OPEN","branch":"feat/task-123-branch-pr-metadata","repo":"PerpetualSoftware/pad","updated_at":"2026-04-02T14:00:00Z"}}`)
@@ -224,4 +229,141 @@ func TestApplyItemConventionMetadataPreservesStatusAndWritesAliases(t *testing.T
 	if got := ExtractItemImplementationNotes(fields); got != nil {
 		t.Fatalf("did not expect implementation notes, got %#v", got)
 	}
+}
+
+// TestItemUpdateUnmarshalFlexFields covers BUG-1144: PATCH /items
+// must accept `fields` and `tags` as either a JSON-encoded string
+// (the canonical historical shape) or the natural nested object /
+// array shape any reasonable HTTP client would send.
+func TestItemUpdateUnmarshalFlexFields(t *testing.T) {
+	t.Run("fields as nested object", func(t *testing.T) {
+		var u ItemUpdate
+		if err := json.Unmarshal([]byte(`{"fields":{"reading_time":6,"status":"open"}}`), &u); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if u.Fields == nil {
+			t.Fatal("expected u.Fields to be set")
+		}
+		// Re-decode the canonical string and check semantic equality.
+		var got map[string]any
+		if err := json.Unmarshal([]byte(*u.Fields), &got); err != nil {
+			t.Fatalf("u.Fields not valid JSON: %v (was %q)", err, *u.Fields)
+		}
+		if got["reading_time"].(float64) != 6 || got["status"].(string) != "open" {
+			t.Fatalf("round-trip lost data: %#v", got)
+		}
+	})
+
+	t.Run("fields as JSON-encoded string (back-compat)", func(t *testing.T) {
+		var u ItemUpdate
+		if err := json.Unmarshal([]byte(`{"fields":"{\"reading_time\":6}"}`), &u); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if u.Fields == nil || *u.Fields != `{"reading_time":6}` {
+			t.Fatalf("expected stringified fields passthrough, got %v", u.Fields)
+		}
+	})
+
+	t.Run("fields null leaves pointer nil", func(t *testing.T) {
+		var u ItemUpdate
+		if err := json.Unmarshal([]byte(`{"fields":null}`), &u); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if u.Fields != nil {
+			t.Fatalf("expected nil pointer for null fields, got %q", *u.Fields)
+		}
+	})
+
+	t.Run("fields absent leaves pointer nil", func(t *testing.T) {
+		var u ItemUpdate
+		if err := json.Unmarshal([]byte(`{"title":"hi"}`), &u); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if u.Fields != nil {
+			t.Fatal("expected u.Fields nil when key absent")
+		}
+		if u.Title == nil || *u.Title != "hi" {
+			t.Fatal("title should still decode normally")
+		}
+	})
+
+	t.Run("fields wrong shape returns domain error", func(t *testing.T) {
+		var u ItemUpdate
+		err := json.Unmarshal([]byte(`{"fields":42}`), &u)
+		if err == nil {
+			t.Fatal("expected error for non-object non-string fields")
+		}
+		if !errors.Is(err, ErrInvalidFieldsType) {
+			t.Fatalf("expected ErrInvalidFieldsType, got %v", err)
+		}
+		if strings.Contains(err.Error(), "Go struct field") {
+			t.Fatalf("error leaked Go internals: %q", err.Error())
+		}
+	})
+
+	t.Run("fields as array is invalid (object expected)", func(t *testing.T) {
+		var u ItemUpdate
+		err := json.Unmarshal([]byte(`{"fields":["a","b"]}`), &u)
+		if !errors.Is(err, ErrInvalidFieldsType) {
+			t.Fatalf("expected ErrInvalidFieldsType for array fields, got %v", err)
+		}
+	})
+
+	t.Run("tags as nested array", func(t *testing.T) {
+		var u ItemUpdate
+		if err := json.Unmarshal([]byte(`{"tags":["foo","bar"]}`), &u); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if u.Tags == nil {
+			t.Fatal("expected u.Tags to be set")
+		}
+		var got []string
+		if err := json.Unmarshal([]byte(*u.Tags), &got); err != nil {
+			t.Fatalf("u.Tags not valid JSON: %v (was %q)", err, *u.Tags)
+		}
+		if len(got) != 2 || got[0] != "foo" || got[1] != "bar" {
+			t.Fatalf("round-trip lost data: %#v", got)
+		}
+	})
+
+	t.Run("tags as JSON-encoded string (back-compat)", func(t *testing.T) {
+		var u ItemUpdate
+		if err := json.Unmarshal([]byte(`{"tags":"[\"foo\"]"}`), &u); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if u.Tags == nil || *u.Tags != `["foo"]` {
+			t.Fatalf("expected stringified tags passthrough, got %v", u.Tags)
+		}
+	})
+
+	t.Run("tags as object is invalid (array expected)", func(t *testing.T) {
+		var u ItemUpdate
+		err := json.Unmarshal([]byte(`{"tags":{"x":1}}`), &u)
+		if !errors.Is(err, ErrInvalidTagsType) {
+			t.Fatalf("expected ErrInvalidTagsType for object tags, got %v", err)
+		}
+	})
+
+	t.Run("other fields decode normally", func(t *testing.T) {
+		var u ItemUpdate
+		body := `{"title":"new","content":"body","pinned":true,"source":"web","fields":{"x":1}}`
+		if err := json.Unmarshal([]byte(body), &u); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if u.Title == nil || *u.Title != "new" {
+			t.Fatal("title not decoded")
+		}
+		if u.Content == nil || *u.Content != "body" {
+			t.Fatal("content not decoded")
+		}
+		if u.Pinned == nil || !*u.Pinned {
+			t.Fatal("pinned not decoded")
+		}
+		if u.Source != "web" {
+			t.Fatal("source not decoded")
+		}
+		if u.Fields == nil || *u.Fields != `{"x":1}` {
+			t.Fatalf("fields not normalized, got %v", u.Fields)
+		}
+	})
 }

--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -378,6 +378,17 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 
 	var input models.ItemUpdate
 	if err := decodeJSON(r, &input); err != nil {
+		// Surface the domain-level errors from ItemUpdate.UnmarshalJSON
+		// (BUG-1144) without the "invalid JSON: ..." wrapper from
+		// decodeJSON, so callers see a clean message naming the field.
+		if errors.Is(err, models.ErrInvalidFieldsType) {
+			writeError(w, http.StatusBadRequest, "bad_request", models.ErrInvalidFieldsType.Error())
+			return
+		}
+		if errors.Is(err, models.ErrInvalidTagsType) {
+			writeError(w, http.StatusBadRequest, "bad_request", models.ErrInvalidTagsType.Error())
+			return
+		}
 		writeError(w, http.StatusBadRequest, "bad_request", err.Error())
 		return
 	}

--- a/internal/server/handlers_items_test.go
+++ b/internal/server/handlers_items_test.go
@@ -1123,3 +1123,121 @@ func TestCreateItemSourcePersistedFromAuth(t *testing.T) {
 		}
 	})
 }
+
+// TestPatchItem_FlexibleFieldsShape covers BUG-1144: PATCH must accept
+// `fields` (and `tags`) as a nested JSON object/array in addition to
+// the historical JSON-encoded-string shape. Wrong shapes return a
+// clean domain-level error instead of leaked Go unmarshal internals.
+func TestPatchItem_FlexibleFieldsShape(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	// Seed an item to patch.
+	createResp := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections/tasks/items", map[string]interface{}{
+		"title":  "BUG-1144 fixture",
+		"fields": `{"status":"open","priority":"medium"}`,
+	})
+	if createResp.Code != http.StatusCreated {
+		t.Fatalf("seed: expected 201, got %d: %s", createResp.Code, createResp.Body.String())
+	}
+	var seeded models.Item
+	parseJSON(t, createResp, &seeded)
+
+	t.Run("fields as nested object (the BUG-1144 repro)", func(t *testing.T) {
+		rr := doRequest(srv, "PATCH", "/api/v1/workspaces/"+slug+"/items/"+seeded.Ref, map[string]interface{}{
+			"fields": map[string]interface{}{
+				"status":   "in-progress",
+				"priority": "high",
+			},
+		})
+		if rr.Code != http.StatusOK {
+			t.Fatalf("expected 200 for nested-object fields, got %d: %s", rr.Code, rr.Body.String())
+		}
+		var got models.Item
+		parseJSON(t, rr, &got)
+		var fields map[string]interface{}
+		if err := json.Unmarshal([]byte(got.Fields), &fields); err != nil {
+			t.Fatalf("response fields not valid JSON: %v", err)
+		}
+		if fields["status"] != "in-progress" || fields["priority"] != "high" {
+			t.Fatalf("update didn't apply: %#v", fields)
+		}
+	})
+
+	t.Run("fields as JSON-encoded string still works (back-compat)", func(t *testing.T) {
+		rr := doRequest(srv, "PATCH", "/api/v1/workspaces/"+slug+"/items/"+seeded.Ref, map[string]interface{}{
+			"fields": `{"status":"done","priority":"high"}`,
+		})
+		if rr.Code != http.StatusOK {
+			t.Fatalf("expected 200 for stringified fields, got %d: %s", rr.Code, rr.Body.String())
+		}
+		var got models.Item
+		parseJSON(t, rr, &got)
+		var fields map[string]interface{}
+		json.Unmarshal([]byte(got.Fields), &fields)
+		if fields["status"] != "done" {
+			t.Fatalf("update didn't apply: %#v", fields)
+		}
+	})
+
+	t.Run("fields wrong type returns domain-level error, not Go internals", func(t *testing.T) {
+		rr := doRequest(srv, "PATCH", "/api/v1/workspaces/"+slug+"/items/"+seeded.Ref, map[string]interface{}{
+			"fields": 42,
+		})
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400 for numeric fields, got %d: %s", rr.Code, rr.Body.String())
+		}
+		body := rr.Body.String()
+		// Must NOT leak Go internals.
+		if bytes.Contains([]byte(body), []byte("Go struct field")) {
+			t.Fatalf("response leaked Go internals: %s", body)
+		}
+		if bytes.Contains([]byte(body), []byte("ItemUpdate.fields")) {
+			t.Fatalf("response leaked Go field name: %s", body)
+		}
+		// Must guide the caller toward a fix. The error JSON has its
+		// inner double-quotes escaped, so check for the escaped form.
+		if !bytes.Contains([]byte(body), []byte(`\"fields\" must be a JSON object`)) {
+			t.Fatalf("response missing domain-level message: %s", body)
+		}
+	})
+
+	t.Run("tags as nested array", func(t *testing.T) {
+		rr := doRequest(srv, "PATCH", "/api/v1/workspaces/"+slug+"/items/"+seeded.Ref, map[string]interface{}{
+			"tags": []string{"alpha", "beta"},
+		})
+		if rr.Code != http.StatusOK {
+			t.Fatalf("expected 200 for nested-array tags, got %d: %s", rr.Code, rr.Body.String())
+		}
+		var got models.Item
+		parseJSON(t, rr, &got)
+		var tags []string
+		if err := json.Unmarshal([]byte(got.Tags), &tags); err != nil {
+			t.Fatalf("response tags not valid JSON: %v", err)
+		}
+		if len(tags) != 2 || tags[0] != "alpha" || tags[1] != "beta" {
+			t.Fatalf("update didn't apply: %#v", tags)
+		}
+	})
+
+	t.Run("tags as JSON-encoded string still works", func(t *testing.T) {
+		rr := doRequest(srv, "PATCH", "/api/v1/workspaces/"+slug+"/items/"+seeded.Ref, map[string]interface{}{
+			"tags": `["gamma"]`,
+		})
+		if rr.Code != http.StatusOK {
+			t.Fatalf("expected 200 for stringified tags, got %d: %s", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("tags wrong type returns domain-level error", func(t *testing.T) {
+		rr := doRequest(srv, "PATCH", "/api/v1/workspaces/"+slug+"/items/"+seeded.Ref, map[string]interface{}{
+			"tags": map[string]interface{}{"x": 1},
+		})
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400 for object tags, got %d: %s", rr.Code, rr.Body.String())
+		}
+		if !bytes.Contains(rr.Body.Bytes(), []byte(`\"tags\" must be a JSON array`)) {
+			t.Fatalf("response missing domain-level tags message: %s", rr.Body.String())
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- Resolves **BUG-1144** — `PATCH /api/v1/workspaces/{ws}/items/{ref}` previously required `fields` and `tags` to be JSON-encoded strings on the wire, returning a leaked Go unmarshal error (`json: cannot unmarshal object into Go struct field ItemUpdate.fields of type string`) when callers sent the natural nested-object shape. This is the symmetric input-side counterpart to BUG-991 (response-side, fixed at the MCP boundary in PR #364).
- Custom `ItemUpdate.UnmarshalJSON` accepts **either** the canonical JSON-string shape (back-compat) **or** the natural object/array shape, normalizing to the stringified form the rest of the pipeline already expects. Struct field types stay `*string`, so validation, store writes, and web/CLI consumers are untouched.
- All 15 in-process Go callers construct `ItemUpdate{}` literals and never go through `UnmarshalJSON`, so the change is invisible to them.
- Wrong shapes (`{"fields":42}`, `{"tags":{"x":1}}`) now return HTTP 400 with a domain-level message (`"fields" must be a JSON object or a JSON-encoded string`) via sentinel errors `models.ErrInvalidFieldsType` / `models.ErrInvalidTagsType` that the handler unwraps from `decodeJSON`'s `"invalid JSON: %w"` wrapper.

## Test plan

- [x] `make check` — `golangci-lint`, full `go test ./...`, and `cd web && npm run build` all green
- [x] `TestItemUpdateUnmarshalFlexFields` (10 sub-tests) covers object / array / string / null / absent / wrong-type for both `fields` and `tags`
- [x] `TestPatchItem_FlexibleFieldsShape` (6 sub-tests) exercises the HTTP PATCH path end-to-end and asserts error responses do **not** leak `"Go struct field"` or `"ItemUpdate.fields"`
- [x] Smoke-tested against the live server with the exact BUG-1144 repro curl:
  - `{"fields":{"component":"server","severity":"low","status":"open"}}` → HTTP 200 ✅
  - `{"fields":42}` → HTTP 400 with `"fields" must be a JSON object or a JSON-encoded string` ✅
  - `{"tags":[]}` → HTTP 200 ✅
  - `{"fields":"{\"component\":\"server\",...}"}` (back-compat) → HTTP 200 ✅