### PR TITLE
feat(web): virtualize BoardView cards via content-visibility (TASK-1347)

### DIFF
--- a/web/src/lib/components/collections/BoardView.svelte
+++ b/web/src/lib/components/collections/BoardView.svelte
@@ -491,17 +491,21 @@
 		 * keyword caches the real measured height after first paint so
 		 * later scrolls back to that card don't reflow.
 		 *
-		 * `overflow-clip-margin: 6px` is the fix for ItemCard's
+		 * `overflow-clip-margin: 12px` is the fix for ItemCard's
 		 * `.pr-badge`, which positions itself at `right: -6px` and
 		 * deliberately protrudes past the card's right edge. CSS
 		 * Containment L2 §3.4 / §4 specifies that `content-visibility:
 		 * auto` applies paint containment continuously — including
 		 * on-screen — and paint containment clips ink overflow. Without
 		 * `overflow-clip-margin`, the badge would be clipped flush at
-		 * the wrapper's content box. The 6px margin matches the badge's
-		 * outward offset exactly, so the badge renders unchanged from
-		 * the pre-virtualization layout. Codex round 2 [P2] on PR #489
-		 * caught the spec misreading in round 1's first fix attempt.
+		 * the wrapper's content box. The margin budget:
+		 *   - 6px for the badge's outward offset (`right: -6px`)
+		 *   - ~3px for the badge's `box-shadow: 0 1px 3px` blur radius
+		 *   - ~2px for the hover `transform: scale(1.05)` growth at
+		 *     the typical 25-40px badge width
+		 * 12px covers all three with a small safety margin. Codex
+		 * rounds 2 + 3 on PR #489 walked through the spec misreading
+		 * in round 1 and then the under-sized margin in round 2.
 		 *
 		 * Browser support for `overflow-clip-margin`: Chrome 90+,
 		 * Firefox 102+, Safari 16.4+ — all browsers that ship
@@ -511,7 +515,7 @@
 		 */
 		content-visibility: auto;
 		contain-intrinsic-size: auto 80px;
-		overflow-clip-margin: 6px;
+		overflow-clip-margin: 12px;
 	}
 
 	.card-wrapper:active {

--- a/web/src/lib/components/collections/BoardView.svelte
+++ b/web/src/lib/components/collections/BoardView.svelte
@@ -491,23 +491,27 @@
 		 * keyword caches the real measured height after first paint so
 		 * later scrolls back to that card don't reflow.
 		 *
-		 * ItemCard's `.pr-badge` protrudes 6px past the card's right
-		 * edge (right: -6px) and explicitly relies on overflow staying
-		 * visible. Per CSS Containment Module L2 §4 ("content-visibility"),
-		 * `content-visibility: auto` applies paint containment ONLY when
-		 * the element is "not relevant to the user" — i.e. off-screen,
-		 * when the badge isn't painted in any case. On-screen elements
-		 * receive only layout containment, which does not clip ink
-		 * overflow. We declare `overflow: visible` explicitly here both
-		 * as documentation of intent and as a defense against a future
-		 * style sweep that might add `overflow: hidden` to wrappers and
-		 * silently start clipping the badge. Codex round 1 [P2] on
-		 * PR #489 flagged this concern; the explicit declaration plus
-		 * the spec citation makes the contract auditable.
+		 * `overflow-clip-margin: 6px` is the fix for ItemCard's
+		 * `.pr-badge`, which positions itself at `right: -6px` and
+		 * deliberately protrudes past the card's right edge. CSS
+		 * Containment L2 §3.4 / §4 specifies that `content-visibility:
+		 * auto` applies paint containment continuously — including
+		 * on-screen — and paint containment clips ink overflow. Without
+		 * `overflow-clip-margin`, the badge would be clipped flush at
+		 * the wrapper's content box. The 6px margin matches the badge's
+		 * outward offset exactly, so the badge renders unchanged from
+		 * the pre-virtualization layout. Codex round 2 [P2] on PR #489
+		 * caught the spec misreading in round 1's first fix attempt.
+		 *
+		 * Browser support for `overflow-clip-margin`: Chrome 90+,
+		 * Firefox 102+, Safari 16.4+ — all browsers that ship
+		 * `content-visibility: auto` already ship this. Older browsers
+		 * ignore the property and fall back to the pre-virtualization
+		 * (no-clip) behavior, which is also correct.
 		 */
 		content-visibility: auto;
 		contain-intrinsic-size: auto 80px;
-		overflow: visible;
+		overflow-clip-margin: 6px;
 	}
 
 	.card-wrapper:active {

--- a/web/src/lib/components/collections/BoardView.svelte
+++ b/web/src/lib/components/collections/BoardView.svelte
@@ -490,9 +490,24 @@
 		 * compact mode with status + tags stacked, and the `auto`
 		 * keyword caches the real measured height after first paint so
 		 * later scrolls back to that card don't reflow.
+		 *
+		 * ItemCard's `.pr-badge` protrudes 6px past the card's right
+		 * edge (right: -6px) and explicitly relies on overflow staying
+		 * visible. Per CSS Containment Module L2 §4 ("content-visibility"),
+		 * `content-visibility: auto` applies paint containment ONLY when
+		 * the element is "not relevant to the user" — i.e. off-screen,
+		 * when the badge isn't painted in any case. On-screen elements
+		 * receive only layout containment, which does not clip ink
+		 * overflow. We declare `overflow: visible` explicitly here both
+		 * as documentation of intent and as a defense against a future
+		 * style sweep that might add `overflow: hidden` to wrappers and
+		 * silently start clipping the badge. Codex round 1 [P2] on
+		 * PR #489 flagged this concern; the explicit declaration plus
+		 * the spec citation makes the contract auditable.
 		 */
 		content-visibility: auto;
 		contain-intrinsic-size: auto 80px;
+		overflow: visible;
 	}
 
 	.card-wrapper:active {

--- a/web/src/lib/components/collections/BoardView.svelte
+++ b/web/src/lib/components/collections/BoardView.svelte
@@ -468,6 +468,31 @@
 		-webkit-touch-callout: none;
 		-webkit-user-select: none;
 		user-select: none;
+		/*
+		 * Virtualization (TASK-1347 / PLAN-1343 Phase 1) — mirrors the
+		 * approach landed for ListView in TASK-1346. The browser skips
+		 * layout, style, and paint work for off-screen cards while
+		 * leaving every wrapper mounted, so:
+		 *   - svelte-dnd-action keeps every drop target in the tree
+		 *     (drag-between-columns + drop-into-collapsed-section both
+		 *     rely on the wrapper being present for hit-testing)
+		 *   - column horizontal scroll + column reorder operate on
+		 *     `.kanban-column`, which is unaffected by per-card paint
+		 *     skipping
+		 *   - keyboard focus on an off-screen card still finds the node
+		 *     via querySelector and scrollIntoView rehydrates paint
+		 *
+		 * `.column-cards` is the scrolling ancestor here (overflow-y:
+		 * auto), so content-visibility's near-viewport check uses the
+		 * column as its frame — exactly what per-column virtualization
+		 * needs. `contain-intrinsic-size: auto 80px` is slightly taller
+		 * than the ListView placeholder because board cards render in
+		 * compact mode with status + tags stacked, and the `auto`
+		 * keyword caches the real measured height after first paint so
+		 * later scrolls back to that card don't reflow.
+		 */
+		content-visibility: auto;
+		contain-intrinsic-size: auto 80px;
 	}
 
 	.card-wrapper:active {


### PR DESCRIPTION
## Summary

Per-column virtualization for the kanban board. Adds
\`content-visibility: auto; contain-intrinsic-size: auto 80px;\` to
\`.card-wrapper\` so the browser skips layout/style/paint work for
cards that have scrolled out of their column's viewport.

Mirrors the approach landed in PR #488 (TASK-1346) for ListView —
same trade-offs, same preservation guarantees:

- **DnD between columns** keeps working because every \`.card-wrapper\`
  stays mounted; svelte-dnd-action can still hit-test drop targets
  whether or not the card is on-screen.
- **Column horizontal scroll** (mobile + many-status collections) is
  unaffected — the CSS rule is on the card wrapper, not the column.
- **Column reorder** uses native HTML5 DnD on \`.kanban-column\`
  (separate from the card-level dndzone) — also unaffected.
- **Keyboard focus** on an off-screen card resolves via
  querySelector and scrollIntoView; the browser rehydrates paint
  as the card enters the visible region.

\`.column-cards\` is itself \`overflow-y: auto\`, so
content-visibility's near-viewport check uses the column as its
frame — exactly the per-column behavior the task asks for. Intrinsic
size is \`80px\` (vs. ListView's \`60px\`) because board cards render
with \`compact={true}\` — they stack status + tags taller than the
list row's single-line layout. The \`auto\` keyword caches the real
measured height after first paint so subsequent scrolls don't
reflow.

## Context

Implements \`TASK-1347\` under \`PLAN-1343\` (local-first read
model — Phase 1 virtualization).

## Test plan

- [x] \`make check\` — golangci-lint, \`go test ./...\`, web build,
  svelte-check all green
- [ ] Manual: scroll a column with hundreds of cards, drag between
  columns, drag-reorder columns, keyboard-focus an off-screen card