### PR TITLE
feat(api): add /items-changes?since=<seq> delta endpoint (TASK-1354)

### DIFF
--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -268,9 +268,13 @@ func (s *Server) handleListItemsChanges(w http.ResponseWriter, r *http.Request) 
 		Limit:         limit,
 	}
 
-	// Item-level grants for guests / restricted members — same
-	// guestResourceFilter dance as /items-index.
-	fullCollIDs, grantedItemIDs, grantErr := s.guestResourceFilter(r, workspaceID)
+	// Item-level grants for guests / restricted members. Delta sync
+	// uses the include-deleted-items variant so a tombstone on a
+	// granted item still flows through — without it the grant ID
+	// disappears as soon as the item is soft-deleted, and the
+	// client never learns the row went away (Codex review of
+	// TASK-1354 round 1 [P1]).
+	fullCollIDs, grantedItemIDs, grantErr := s.guestResourceFilterIncludeDeletedItems(r, workspaceID)
 	if grantErr != nil {
 		writeInternalError(w, grantErr)
 		return

--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -186,6 +186,135 @@ func (s *Server) handleListItemsIndex(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// itemChangeRow embeds the standard skinny Item shape and adds a
+// `deleted: bool` flag so clients can distinguish upserts from
+// tombstones in a single response. The boolean is a derived view of
+// the underlying `deleted_at` so old clients that only key off
+// `deleted_at` still work — both fields are populated.
+type itemChangeRow struct {
+	models.Item
+	Deleted bool `json:"deleted"`
+}
+
+// itemsChangesResponse wraps a delta-fetch result.
+//
+//   - changes: rows where `seq > since`, in ascending seq order. Each
+//     row includes `deleted` (true when the row is soft-deleted) so
+//     clients can apply / remove without a second roundtrip.
+//   - cursor: the largest seq in the response, decimal-encoded.
+//     When the response is empty, the server returns the caller's
+//     `since` unchanged so the client doesn't lose position. Treat
+//     the value as opaque (re-pass as `?since=<cursor>` on the next
+//     poll).
+type itemsChangesResponse struct {
+	Changes []itemChangeRow `json:"changes"`
+	Cursor  string          `json:"cursor"`
+}
+
+// handleListItemsChanges is the delta-fetch sibling of
+// handleListItemsIndex. Returns rows that have mutated since the
+// caller's `?since=<seq>` cursor, including tombstones, so a
+// local-first read-model client can resume a workspace without
+// re-fetching the entire index (PLAN-1343 / TASK-1354).
+//
+// Query params:
+//   - since: exclusive seq lower bound (`seq > since`). Defaults to 0
+//     (full delta == full index modulo ordering). Decimal string;
+//     invalid values are 400.
+//   - limit: cap on returned rows. Defaults to
+//     store.DefaultItemChangesLimit (5000), clamped to
+//     store.MaxItemChangesLimit (50000). Invalid values are 400.
+//
+// Auth: same collection-visibility + item-grant filter as
+// /items-index. Soft-deleted rows propagate so they can be removed
+// from the client's local index.
+func (s *Server) handleListItemsChanges(w http.ResponseWriter, r *http.Request) {
+	workspaceID, ok := s.getWorkspaceID(w, r)
+	if !ok {
+		return
+	}
+
+	q := r.URL.Query()
+	sinceStr := q.Get("since")
+	var since int64
+	if sinceStr != "" {
+		v, err := strconv.ParseInt(sinceStr, 10, 64)
+		if err != nil || v < 0 {
+			writeError(w, http.StatusBadRequest, "invalid_cursor", "`since` must be a non-negative integer")
+			return
+		}
+		since = v
+	}
+
+	var limit int
+	if limitStr := q.Get("limit"); limitStr != "" {
+		v, err := strconv.Atoi(limitStr)
+		if err != nil || v <= 0 {
+			writeError(w, http.StatusBadRequest, "invalid_limit", "`limit` must be a positive integer")
+			return
+		}
+		limit = v
+	}
+
+	// Collection visibility filter — same shape as handleListItemsIndex.
+	visibleIDs, err := s.visibleCollectionIDs(r, workspaceID)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	params := store.ItemChangesParams{
+		CollectionIDs: visibleIDs,
+		Since:         since,
+		Limit:         limit,
+	}
+
+	// Item-level grants for guests / restricted members — same
+	// guestResourceFilter dance as /items-index.
+	fullCollIDs, grantedItemIDs, grantErr := s.guestResourceFilter(r, workspaceID)
+	if grantErr != nil {
+		writeInternalError(w, grantErr)
+		return
+	}
+	if len(grantedItemIDs) > 0 {
+		params.CollectionIDs = fullCollIDs
+		params.ItemIDs = grantedItemIDs
+	}
+
+	rows, err := s.store.ListItemsChangesSince(workspaceID, params)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+
+	// Enrich with parent metadata so the local cache rows match the
+	// /items-index payload shape. Soft-deleted parents are skipped by
+	// the underlying GetItem (deleted_at IS NULL), so we don't leak
+	// parent title / ref after the parent itself has been archived.
+	s.enrichItemsWithParent(workspaceID, rows, visibleIDs)
+
+	// Cursor: MAX(seq) in the response. When empty, return `since`
+	// unchanged so the client doesn't regress its position. When
+	// truncated by limit, the cursor sits at the last row's seq so
+	// the next poll resumes there (no overlap, no gap — seq is
+	// strictly monotonic per workspace).
+	cursorSeq := since
+	changes := make([]itemChangeRow, 0, len(rows))
+	for _, it := range rows {
+		if it.Seq > cursorSeq {
+			cursorSeq = it.Seq
+		}
+		changes = append(changes, itemChangeRow{
+			Item:    it,
+			Deleted: it.DeletedAt != nil,
+		})
+	}
+
+	writeJSON(w, http.StatusOK, itemsChangesResponse{
+		Changes: changes,
+		Cursor:  strconv.FormatInt(cursorSeq, 10),
+	})
+}
+
 // handleListCollectionItems lists items within a specific collection.
 func (s *Server) handleListCollectionItems(w http.ResponseWriter, r *http.Request) {
 	workspaceID, ok := s.getWorkspaceID(w, r)

--- a/internal/server/handlers_items_test.go
+++ b/internal/server/handlers_items_test.go
@@ -1602,6 +1602,258 @@ func TestListItemsIndex_ExcludesArchivedByDefault(t *testing.T) {
 	}
 }
 
+// itemsChangesBody mirrors the server-side response wrapper for
+// /items-changes. Local to the test file so the public handler
+// doesn't need to export it. The Changes element embeds Item via
+// the same `models.Item + Deleted bool` shape.
+type itemsChangesBody struct {
+	Changes []struct {
+		models.Item
+		Deleted bool `json:"deleted"`
+	} `json:"changes"`
+	Cursor string `json:"cursor"`
+}
+
+// TestListItemsChanges_FullDeltaFromZero covers the foundational
+// behavior of the delta-fetch endpoint (TASK-1354): three creates,
+// `?since=0`, all three returned in ascending seq order, every row
+// `deleted:false`, cursor = max seq.
+func TestListItemsChanges_FullDeltaFromZero(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	createItem(t, srv, slug, "tasks", map[string]interface{}{"title": "A", "fields": `{"status":"open"}`})
+	createItem(t, srv, slug, "tasks", map[string]interface{}{"title": "B", "fields": `{"status":"open"}`})
+	createItem(t, srv, slug, "tasks", map[string]interface{}{"title": "C", "fields": `{"status":"open"}`})
+
+	rr := doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/items-changes?since=0", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("items-changes since=0: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var resp itemsChangesBody
+	parseJSON(t, rr, &resp)
+
+	if len(resp.Changes) != 3 {
+		t.Fatalf("expected 3 changes, got %d", len(resp.Changes))
+	}
+	// Ascending seq order.
+	for i := 1; i < len(resp.Changes); i++ {
+		if resp.Changes[i].Seq <= resp.Changes[i-1].Seq {
+			t.Fatalf("changes not in ascending seq order: changes[%d].Seq=%d <= changes[%d].Seq=%d", i, resp.Changes[i].Seq, i-1, resp.Changes[i-1].Seq)
+		}
+		if resp.Changes[i].Deleted {
+			t.Fatalf("change[%d] unexpectedly marked deleted", i)
+		}
+	}
+	// Cursor == MAX(seq).
+	cursorSeq, err := strconv.ParseInt(resp.Cursor, 10, 64)
+	if err != nil {
+		t.Fatalf("cursor not decimal int: %q", resp.Cursor)
+	}
+	if cursorSeq != resp.Changes[len(resp.Changes)-1].Seq {
+		t.Fatalf("cursor (%d) should equal max seq in response (%d)", cursorSeq, resp.Changes[len(resp.Changes)-1].Seq)
+	}
+	// Skinny projection: no `content` body in the wire payload.
+	if bytes.Contains(rr.Body.Bytes(), []byte(`"content":"some long body"`)) {
+		t.Fatalf("changes response leaked content body: %s", rr.Body.String())
+	}
+}
+
+// TestListItemsChanges_IncrementalUpdateAndDelete walks the typical
+// resume flow: create three, snapshot cursor, update one, soft-delete
+// one. A poll at the snapshot cursor returns exactly those two rows
+// with `deleted` set correctly.
+func TestListItemsChanges_IncrementalUpdateAndDelete(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	a := createItem(t, srv, slug, "tasks", map[string]interface{}{"title": "A", "fields": `{"status":"open"}`})
+	b := createItem(t, srv, slug, "tasks", map[string]interface{}{"title": "B", "fields": `{"status":"open"}`})
+	createItem(t, srv, slug, "tasks", map[string]interface{}{"title": "C", "fields": `{"status":"open"}`})
+
+	// Snapshot the cursor via /items-index after the three creates.
+	rrSnap := doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/items-index", nil)
+	var snap itemsIndexBody
+	parseJSON(t, rrSnap, &snap)
+	since := snap.Cursor
+
+	// Update A's title.
+	newTitle := "A-updated"
+	rrU := doRequest(srv, "PATCH", "/api/v1/workspaces/"+slug+"/items/"+a.Slug, map[string]interface{}{"title": newTitle})
+	if rrU.Code != http.StatusOK {
+		t.Fatalf("update A: expected 200, got %d: %s", rrU.Code, rrU.Body.String())
+	}
+
+	// Soft-delete B.
+	rrD := doRequest(srv, "DELETE", "/api/v1/workspaces/"+slug+"/items/"+b.Slug, nil)
+	if rrD.Code != http.StatusNoContent {
+		t.Fatalf("delete B: expected 204, got %d: %s", rrD.Code, rrD.Body.String())
+	}
+
+	// Delta poll resumes from the snapshot cursor.
+	rr := doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/items-changes?since="+since, nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("items-changes resume: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var resp itemsChangesBody
+	parseJSON(t, rr, &resp)
+
+	if len(resp.Changes) != 2 {
+		t.Fatalf("expected 2 changes (update + delete), got %d", len(resp.Changes))
+	}
+
+	// Find each by ID and check the deleted flag.
+	var seenA, seenB bool
+	for _, ch := range resp.Changes {
+		switch ch.ID {
+		case a.ID:
+			if ch.Deleted {
+				t.Errorf("A updated: expected deleted=false, got true")
+			}
+			if ch.Title != newTitle {
+				t.Errorf("A updated: expected title=%q, got %q", newTitle, ch.Title)
+			}
+			seenA = true
+		case b.ID:
+			if !ch.Deleted {
+				t.Errorf("B soft-deleted: expected deleted=true, got false")
+			}
+			seenB = true
+		}
+	}
+	if !seenA || !seenB {
+		t.Fatalf("missing expected rows: seenA=%v seenB=%v", seenA, seenB)
+	}
+}
+
+// TestListItemsChanges_CursorRoundtripsCleanly proves "no overlap or
+// gap": after running the delta once, re-polling with the returned
+// cursor as `since` returns zero rows.
+func TestListItemsChanges_CursorRoundtripsCleanly(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	createItem(t, srv, slug, "tasks", map[string]interface{}{"title": "A", "fields": `{"status":"open"}`})
+	createItem(t, srv, slug, "tasks", map[string]interface{}{"title": "B", "fields": `{"status":"open"}`})
+
+	rr1 := doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/items-changes?since=0", nil)
+	var first itemsChangesBody
+	parseJSON(t, rr1, &first)
+	if len(first.Changes) != 2 {
+		t.Fatalf("first poll: expected 2 changes, got %d", len(first.Changes))
+	}
+
+	rr2 := doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/items-changes?since="+first.Cursor, nil)
+	var second itemsChangesBody
+	parseJSON(t, rr2, &second)
+	if len(second.Changes) != 0 {
+		t.Fatalf("second poll at returned cursor should be empty, got %d changes", len(second.Changes))
+	}
+	if second.Cursor != first.Cursor {
+		t.Fatalf("empty poll should preserve cursor: got %q want %q", second.Cursor, first.Cursor)
+	}
+}
+
+// TestListItemsChanges_LimitTruncatesAndCursorResumes covers the
+// `?limit=N` truncation contract: the response holds N rows; cursor
+// equals seq of the last returned row so the client can resume with
+// no overlap or gap.
+func TestListItemsChanges_LimitTruncatesAndCursorResumes(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	for i := 0; i < 5; i++ {
+		createItem(t, srv, slug, "tasks", map[string]interface{}{
+			"title":  "item-" + strconv.Itoa(i),
+			"fields": `{"status":"open"}`,
+		})
+	}
+
+	// First page: limit=2 returns 2 rows; cursor sits at the last
+	// row's seq.
+	rr1 := doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/items-changes?since=0&limit=2", nil)
+	var page1 itemsChangesBody
+	parseJSON(t, rr1, &page1)
+	if len(page1.Changes) != 2 {
+		t.Fatalf("page1: expected 2 rows under limit=2, got %d", len(page1.Changes))
+	}
+	cursorSeq, err := strconv.ParseInt(page1.Cursor, 10, 64)
+	if err != nil {
+		t.Fatalf("page1 cursor not int: %q", page1.Cursor)
+	}
+	if cursorSeq != page1.Changes[len(page1.Changes)-1].Seq {
+		t.Fatalf("page1 cursor (%d) should equal last row seq (%d)", cursorSeq, page1.Changes[len(page1.Changes)-1].Seq)
+	}
+
+	// Resume from the cursor: remaining 3 rows in ascending seq order.
+	rr2 := doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/items-changes?since="+page1.Cursor+"&limit=10", nil)
+	var page2 itemsChangesBody
+	parseJSON(t, rr2, &page2)
+	if len(page2.Changes) != 3 {
+		t.Fatalf("page2: expected 3 remaining rows, got %d", len(page2.Changes))
+	}
+
+	// No overlap: every page2 seq must be strictly greater than the
+	// page1 cursor.
+	for _, ch := range page2.Changes {
+		if ch.Seq <= cursorSeq {
+			t.Errorf("page2 row seq %d <= page1 cursor %d (overlap)", ch.Seq, cursorSeq)
+		}
+	}
+}
+
+// TestListItemsChanges_InvalidParams rejects bad `since` / `limit`
+// values with 400 instead of silently returning the entire workspace.
+func TestListItemsChanges_InvalidParams(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	rr := doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/items-changes?since=abc", nil)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("invalid since: expected 400, got %d: %s", rr.Code, rr.Body.String())
+	}
+	rr = doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/items-changes?since=-5", nil)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("negative since: expected 400, got %d: %s", rr.Code, rr.Body.String())
+	}
+	rr = doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/items-changes?limit=0", nil)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("limit=0: expected 400, got %d: %s", rr.Code, rr.Body.String())
+	}
+	rr = doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/items-changes?limit=-1", nil)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("limit=-1: expected 400, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+// TestListItemsChanges_EmptyWorkspace returns no rows and preserves
+// the caller's cursor.
+func TestListItemsChanges_EmptyWorkspace(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	rr := doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/items-changes?since=0", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("empty workspace: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var resp itemsChangesBody
+	parseJSON(t, rr, &resp)
+	if len(resp.Changes) != 0 {
+		t.Fatalf("expected 0 changes on empty workspace, got %d", len(resp.Changes))
+	}
+	if resp.Cursor != "0" {
+		t.Fatalf("expected cursor=\"0\" on empty workspace with since=0, got %q", resp.Cursor)
+	}
+
+	// Custom since should round-trip when no changes exist.
+	rr = doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/items-changes?since=42", nil)
+	parseJSON(t, rr, &resp)
+	if resp.Cursor != "42" {
+		t.Fatalf("expected cursor to round-trip caller's since=42, got %q", resp.Cursor)
+	}
+}
+
 // TestListItemsIndex_DoesNotShadowItemSlug confirms /items-index lives in
 // a non-conflicting URL space — an item titled "Index" (slug "index") still
 // resolves through /items/{itemSlug}, while /items-index serves the new

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1040,6 +1040,12 @@ func (s *Server) setupRouter() {
 					// item slug under /items/{itemSlug}.
 					r.Get("/items-index", s.handleListItemsIndex)
 
+					// Delta-fetch sibling of /items-index: returns rows
+					// where seq > since, including tombstones, so a
+					// local-first read-model client can resume without
+					// re-downloading the whole index (PLAN-1343 / TASK-1354).
+					r.Get("/items-changes", s.handleListItemsChanges)
+
 					// User grants (all grants for a specific user in this workspace)
 					r.Get("/users/{userID}/grants", s.handleListUserGrants)
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1519,6 +1519,25 @@ func (s *Server) isItemVisibleToGuest(r *http.Request, workspaceID string, item 
 // + direct collection grants as fullCollIDs, plus item grants as grantedItemIDs.
 // This ensures item grants are additive to the member's existing access.
 func (s *Server) guestResourceFilter(r *http.Request, workspaceID string) (fullCollIDs, grantedItemIDs []string, err error) {
+	return s.guestResourceFilterCore(r, workspaceID, false)
+}
+
+// guestResourceFilterIncludeDeletedItems is the delta-sync variant
+// of guestResourceFilter. It uses GuestVisibleResourcesIncludeDeleted
+// under the hood so soft-deleted granted items still surface in the
+// resulting ID set. Used by /items-changes (TASK-1354) so a guest /
+// restricted member with an item-level grant still receives the
+// `deleted:true` row when their granted item is soft-deleted —
+// without this variant the grant ID vanishes before the delta
+// query runs and the client keeps the stale entry forever (Codex
+// review of TASK-1354 round 1 [P1]).
+func (s *Server) guestResourceFilterIncludeDeletedItems(r *http.Request, workspaceID string) (fullCollIDs, grantedItemIDs []string, err error) {
+	return s.guestResourceFilterCore(r, workspaceID, true)
+}
+
+// guestResourceFilterCore is the shared implementation. The
+// includeDeletedItems flag swaps the underlying store query.
+func (s *Server) guestResourceFilterCore(r *http.Request, workspaceID string, includeDeletedItems bool) (fullCollIDs, grantedItemIDs []string, err error) {
 	user := currentUser(r)
 	if user == nil || user.Role == "admin" {
 		return nil, nil, nil
@@ -1538,8 +1557,14 @@ func (s *Server) guestResourceFilter(r *http.Request, workspaceID string) (fullC
 		}
 	}
 
-	// Get grant-based resources
-	grantCollIDs, grantedItemIDs, err := s.store.GuestVisibleResources(workspaceID, user.ID)
+	// Get grant-based resources — delta-sync callers ask for the
+	// include-deleted variant so tombstones can flow through.
+	var grantCollIDs []string
+	if includeDeletedItems {
+		grantCollIDs, grantedItemIDs, err = s.store.GuestVisibleResourcesIncludeDeleted(workspaceID, user.ID)
+	} else {
+		grantCollIDs, grantedItemIDs, err = s.store.GuestVisibleResources(workspaceID, user.ID)
+	}
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/store/collections.go
+++ b/internal/store/collections.go
@@ -297,12 +297,22 @@ func (s *Store) DeleteCollection(id string) error {
 // options are renamed. Each entry in renames maps old_value → new_value
 // for the given field key.
 //
-// Each migration step bumps the workspace-scoped seq so delta-sync
-// clients see the field rewrite (PLAN-1343 / TASK-1352). All rows
-// affected by a single rename step share the same new seq value
-// (MAX+1 at statement start) — that's fine for the cursor contract:
-// a client at cursor < MAX sees them all in one batch, a client at
-// cursor >= MAX sees none, no overlap or gap.
+// Each affected row gets its OWN fresh seq (no two share the same
+// value) so /items-changes pagination is correct even when a
+// rename touches more rows than the page limit. We do this with a
+// per-row UPDATE loop: an earlier single-statement bulk UPDATE gave
+// every row the same MAX(seq)+1, which broke the cursor contract —
+// `limit=N` could cut through an equal-seq group, the cursor would
+// advance to that shared seq, and the next `seq > cursor` poll
+// would permanently miss the remaining rows in the group (Codex
+// review of TASK-1354 round 2 [P1]).
+//
+// Trade-off: O(N) statements instead of O(1) for the bulk path.
+// A schema-option rename is an admin one-off, so even a few
+// thousand rows is acceptable (~1s/1000 rows on a warm SQLite
+// connection). If a future use case demands a higher row budget,
+// switch to an UPDATE..FROM with a ROW_NUMBER() CTE that assigns
+// sequential per-row seqs in a single statement.
 func (s *Store) MigrateItemFieldValues(collectionID string, migrations []models.FieldMigration) (int64, error) {
 	if len(migrations) == 0 {
 		return 0, nil
@@ -339,20 +349,53 @@ func (s *Store) MigrateItemFieldValues(collectionID string, migrations []models.
 			}
 			jsonSet := s.dialect.JSONSet("fields", m.Field)
 			jsonExtract := s.dialect.JSONExtractText("fields", m.Field)
-			result, err := tx.Exec(s.q(fmt.Sprintf(`
-				UPDATE items
-				SET fields = %s,
-				    updated_at = ?,
-				    seq = (SELECT COALESCE(MAX(seq), 0) + 1 FROM items WHERE workspace_id = ?)
+
+			// Step 1: find all matching item IDs. SELECT inside the
+			// same transaction as the subsequent UPDATEs, so we
+			// observe a consistent snapshot of who needs to migrate.
+			idRows, err := tx.Query(s.q(fmt.Sprintf(`
+				SELECT id FROM items
 				WHERE collection_id = ?
 				  AND %s = ?
 				  AND deleted_at IS NULL
-			`, jsonSet, jsonExtract)), newVal, ts, workspaceID, collectionID, oldVal)
+			`, jsonExtract)), collectionID, oldVal)
 			if err != nil {
-				return totalAffected, fmt.Errorf("migrate field %s (%s → %s): %w", m.Field, oldVal, newVal, err)
+				return totalAffected, fmt.Errorf("migrate field %s (%s → %s) list: %w", m.Field, oldVal, newVal, err)
 			}
-			n, _ := result.RowsAffected()
-			totalAffected += n
+			var ids []string
+			for idRows.Next() {
+				var id string
+				if err := idRows.Scan(&id); err != nil {
+					idRows.Close()
+					return totalAffected, fmt.Errorf("migrate field %s scan: %w", m.Field, err)
+				}
+				ids = append(ids, id)
+			}
+			if err := idRows.Err(); err != nil {
+				idRows.Close()
+				return totalAffected, fmt.Errorf("migrate field %s rows: %w", m.Field, err)
+			}
+			idRows.Close()
+
+			// Step 2: update each row individually. Each UPDATE is
+			// a separate statement, so MAX(seq) advances between
+			// them inside the transaction — every row ends up with
+			// a unique sequential seq.
+			updateSQL := s.q(fmt.Sprintf(`
+				UPDATE items
+				SET fields = %s,
+				    updated_at = ?,
+				    seq = `+nextWorkspaceSeqSubquery+`
+				WHERE id = ?
+			`, jsonSet))
+			for _, id := range ids {
+				result, err := tx.Exec(updateSQL, newVal, ts, workspaceID, id)
+				if err != nil {
+					return totalAffected, fmt.Errorf("migrate field %s (%s → %s) row %s: %w", m.Field, oldVal, newVal, id, err)
+				}
+				n, _ := result.RowsAffected()
+				totalAffected += n
+			}
 		}
 	}
 

--- a/internal/store/grants.go
+++ b/internal/store/grants.go
@@ -421,6 +421,70 @@ func (s *Store) GuestVisibleCollectionIDs(workspaceID, userID string) ([]string,
 	return result, nil
 }
 
+// GuestVisibleResourcesIncludeDeleted is the delta-sync variant of
+// GuestVisibleResources: it does NOT filter out soft-deleted items
+// or collections. /items-changes (TASK-1354) must surface a
+// tombstone for any item the client previously saw, including items
+// the user had an item-level grant on. Without this variant, a
+// grant-only user whose granted item gets soft-deleted would see
+// the row vanish from /items-changes with no `deleted:true` signal,
+// and the client would keep the stale entry in its local index
+// forever (Codex review of TASK-1354 round 1 [P1]).
+//
+// Same shape as GuestVisibleResources so the caller can swap them
+// in/out depending on whether the endpoint needs live-state or
+// tombstone-bearing visibility.
+func (s *Store) GuestVisibleResourcesIncludeDeleted(workspaceID, userID string) (fullCollectionIDs []string, grantedItemIDs []string, err error) {
+	// Collections with direct grants — include soft-deleted
+	// collections so the client can flush their items from its
+	// local index via the items query below.
+	rows, err := s.db.Query(s.q(`
+		SELECT DISTINCT cg.collection_id FROM collection_grants cg
+		WHERE cg.workspace_id = ? AND cg.user_id = ?
+	`), workspaceID, userID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("guest collection grants (include deleted): %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, nil, err
+		}
+		fullCollectionIDs = append(fullCollectionIDs, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, nil, err
+	}
+
+	// Item-level grants — INCLUDE soft-deleted items so their
+	// tombstones flow through /items-changes. The grant row itself
+	// is the source of truth for visibility; the item's
+	// deleted_at is what the delta endpoint USES to mark
+	// `deleted:true` on the wire.
+	itemRows, err := s.db.Query(s.q(`
+		SELECT DISTINCT ig.item_id
+		FROM item_grants ig
+		WHERE ig.workspace_id = ? AND ig.user_id = ?
+	`), workspaceID, userID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("guest item grants (include deleted): %w", err)
+	}
+	defer itemRows.Close()
+	for itemRows.Next() {
+		var id string
+		if err := itemRows.Scan(&id); err != nil {
+			return nil, nil, err
+		}
+		grantedItemIDs = append(grantedItemIDs, id)
+	}
+	if err := itemRows.Err(); err != nil {
+		return nil, nil, err
+	}
+
+	return fullCollectionIDs, grantedItemIDs, nil
+}
+
 // GuestVisibleResources returns the two-level visibility for a guest:
 // - fullCollectionIDs: collections where the user has a direct collection grant (full access)
 // - grantedItemIDs: specific item IDs the user has item-level grants on

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -816,6 +816,164 @@ func (s *Store) ListItemsIndex(workspaceID string, params ItemIndexParams) ([]mo
 	return scanItemsIndex(rows)
 }
 
+// ItemChangesParams is the parameter set for ListItemsChangesSince.
+// Mirrors the visibility-filter half of ItemIndexParams (CollectionIDs
+// / ItemIDs) plus the cursor-specific knobs Since / Limit.
+type ItemChangesParams struct {
+	// CollectionIDs is the permission filter for visible collections.
+	// nil = unfiltered. A non-nil empty slice (with empty ItemIDs)
+	// short-circuits to an empty result, matching ListItemsIndex
+	// semantics.
+	CollectionIDs []string
+	// ItemIDs is the item-level grant set (guests / restricted
+	// members can see specific items even outside their collection
+	// scope).
+	ItemIDs []string
+	// Since is the exclusive seq lower bound (returns rows where
+	// `seq > since`).
+	Since int64
+	// Limit caps the returned slice. <=0 means use the default cap
+	// (DefaultItemChangesLimit); values above MaxItemChangesLimit
+	// are clamped.
+	Limit int
+}
+
+// DefaultItemChangesLimit is the default cap on /items-changes
+// responses. 5,000 is enough to drain a typical workspace in one
+// round-trip; clients that need more re-page via the cursor.
+const DefaultItemChangesLimit = 5000
+
+// MaxItemChangesLimit clamps any caller-supplied limit so a runaway
+// `?limit=999999` poll can't materialize the entire workspace
+// (think: months-offline tab).
+const MaxItemChangesLimit = 50000
+
+// ListItemsChangesSince returns the skinny-projection of items that
+// have mutated (create / update / soft-delete / restore) since the
+// given seq cursor, in ascending seq order. Soft-deleted rows ARE
+// included so delta-sync clients can drop tombstoned items from
+// their local index — the scan populates models.Item.DeletedAt for
+// every row so the caller can distinguish upserts from deletes.
+//
+// Auth: same shape as ListItemsIndex — CollectionIDs / ItemIDs gate
+// visibility. A delta from `since=0` over a fully-permitted scope
+// matches the /items-index payload modulo ordering (changes is seq
+// ASC, index is updated_at DESC).
+//
+// Returns at most Limit rows (default DefaultItemChangesLimit,
+// capped at MaxItemChangesLimit). When truncated, the caller's
+// next poll should pass the returned cursor's MAX(seq) as `since`
+// to resume.
+func (s *Store) ListItemsChangesSince(workspaceID string, params ItemChangesParams) ([]models.Item, error) {
+	if params.CollectionIDs != nil && len(params.CollectionIDs) == 0 && len(params.ItemIDs) == 0 {
+		return nil, nil
+	}
+
+	limit := params.Limit
+	if limit <= 0 {
+		limit = DefaultItemChangesLimit
+	}
+	if limit > MaxItemChangesLimit {
+		limit = MaxItemChangesLimit
+	}
+
+	// Same column list as scanItemsIndex plus deleted_at so the caller
+	// can distinguish upserts from tombstones. There is no
+	// `i.deleted_at IS NULL` filter here — that's the whole point of
+	// the delta: soft-deleted rows propagate so clients can remove
+	// them from their local index.
+	query := `
+		SELECT i.id, i.workspace_id, i.collection_id, i.title, i.slug, i.fields, i.tags,
+		       i.pinned, i.sort_order, i.parent_id, i.assigned_user_id, i.agent_role_id, i.role_sort_order,
+		       i.created_by, i.last_modified_by, i.source,
+		       i.item_number, i.seq, i.created_at, i.updated_at, i.deleted_at,
+		       c.slug, c.name, c.icon, c.prefix,
+		       COALESCE(au.name, ''), COALESCE(au.email, ''),
+		       COALESCE(ar.name, ''), COALESCE(ar.slug, ''), COALESCE(ar.icon, '')
+		FROM items i
+		JOIN collections c ON c.id = i.collection_id
+		LEFT JOIN users au ON au.id = i.assigned_user_id
+		LEFT JOIN agent_roles ar ON ar.id = i.agent_role_id
+		WHERE i.workspace_id = ? AND i.seq > ?
+	`
+	args := []interface{}{workspaceID, params.Since}
+
+	if len(params.CollectionIDs) > 0 && len(params.ItemIDs) > 0 {
+		collPlaceholders := make([]string, len(params.CollectionIDs))
+		for i, id := range params.CollectionIDs {
+			collPlaceholders[i] = "?"
+			args = append(args, id)
+		}
+		itemPlaceholders := make([]string, len(params.ItemIDs))
+		for i, id := range params.ItemIDs {
+			itemPlaceholders[i] = "?"
+			args = append(args, id)
+		}
+		query += " AND (i.collection_id IN (" + strings.Join(collPlaceholders, ",") + ") OR i.id IN (" + strings.Join(itemPlaceholders, ",") + "))"
+	} else if len(params.CollectionIDs) > 0 {
+		placeholders := make([]string, len(params.CollectionIDs))
+		for i, id := range params.CollectionIDs {
+			placeholders[i] = "?"
+			args = append(args, id)
+		}
+		query += " AND i.collection_id IN (" + strings.Join(placeholders, ",") + ")"
+	} else if len(params.ItemIDs) > 0 {
+		placeholders := make([]string, len(params.ItemIDs))
+		for i, id := range params.ItemIDs {
+			placeholders[i] = "?"
+			args = append(args, id)
+		}
+		query += " AND i.id IN (" + strings.Join(placeholders, ",") + ")"
+	}
+
+	// Ascending seq is the canonical delta order: the next poll passes
+	// the response's MAX(seq) as `since` and resumes with no gap or
+	// overlap. The supporting index is (workspace_id, seq DESC)
+	// (TASK-1352 migration) — the engine can still use it for ASC
+	// scans, just walked in reverse.
+	query += " ORDER BY i.seq ASC LIMIT ?"
+	args = append(args, limit)
+
+	rows, err := s.db.Query(s.q(query), args...)
+	if err != nil {
+		return nil, fmt.Errorf("list items changes: %w", err)
+	}
+	defer rows.Close()
+
+	return scanItemsChanges(rows)
+}
+
+// scanItemsChanges scans rows from ListItemsChangesSince (skinny
+// projection + deleted_at so callers can distinguish tombstones).
+func scanItemsChanges(rows *sql.Rows) ([]models.Item, error) {
+	var items []models.Item
+	for rows.Next() {
+		var item models.Item
+		var createdAt, updatedAt string
+		var deletedAt *string
+		var pinned bool
+		if err := rows.Scan(
+			&item.ID, &item.WorkspaceID, &item.CollectionID, &item.Title, &item.Slug,
+			&item.Fields, &item.Tags,
+			&pinned, &item.SortOrder, &item.ParentID, &item.AssignedUserID, &item.AgentRoleID, &item.RoleSortOrder,
+			&item.CreatedBy, &item.LastModifiedBy, &item.Source,
+			&item.ItemNumber, &item.Seq, &createdAt, &updatedAt, &deletedAt,
+			&item.CollectionSlug, &item.CollectionName, &item.CollectionIcon, &item.CollectionPrefix,
+			&item.AssignedUserName, &item.AssignedUserEmail,
+			&item.AgentRoleName, &item.AgentRoleSlug, &item.AgentRoleIcon,
+		); err != nil {
+			return nil, err
+		}
+		item.Pinned = pinned
+		item.CreatedAt = parseTime(createdAt)
+		item.UpdatedAt = parseTime(updatedAt)
+		item.DeletedAt = parseTimePtr(deletedAt)
+		hydrateItemComputedMetadata(&item)
+		items = append(items, item)
+	}
+	return items, rows.Err()
+}
+
 // MaxItemSeq returns the largest items.seq across the workspace, or 0
 // if the workspace has no items. This is the cursor floor for the
 // local-first read model (PLAN-1343 / TASK-1353): /items-index hands

--- a/internal/store/items_test.go
+++ b/internal/store/items_test.go
@@ -3132,6 +3132,82 @@ func TestWorkspaceHasAgentActivityVisibility(t *testing.T) {
 	}
 }
 
+// TestGuestVisibleResourcesIncludeDeleted_SurfacesTombstones is the
+// delta-sync correctness test Codex round 1 [P1] on TASK-1354 asked
+// for: when a guest's only access to an item is via an item-level
+// grant, soft-deleting that item must NOT make the grant ID
+// disappear from the delta-sync lookup. Otherwise /items-changes
+// can never emit the `deleted:true` tombstone and the client
+// keeps the stale row forever.
+//
+// We compare both helpers side by side so a future regression on
+// either path fails this test loudly.
+func TestGuestVisibleResourcesIncludeDeleted_SurfacesTombstones(t *testing.T) {
+	s := testStore(t)
+	user := createTestUser(t, s, "guest@example.com", "Guest", "password123")
+	ws := createTestWorkspace(t, s, "Test")
+	// We deliberately DON'T call AddWorkspaceMember here — the
+	// helper under test (GuestVisibleResources / *IncludeDeleted)
+	// just looks up grants for the given user ID and is agnostic
+	// to workspace membership. The server-side role gating
+	// (workspaceRole(r) == "guest") happens in
+	// guestResourceFilter, which delegates to these helpers.
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+
+	// Two items: one stays live, one gets soft-deleted. The guest
+	// has an item-level grant on each.
+	live := createTestItem(t, s, ws.ID, col.ID, "Live", "")
+	doomed := createTestItem(t, s, ws.ID, col.ID, "Doomed", "")
+	if _, err := s.CreateItemGrant(ws.ID, live.ID, user.ID, "viewer", user.ID); err != nil {
+		t.Fatalf("grant live: %v", err)
+	}
+	if _, err := s.CreateItemGrant(ws.ID, doomed.ID, user.ID, "viewer", user.ID); err != nil {
+		t.Fatalf("grant doomed: %v", err)
+	}
+	if err := s.DeleteItem(doomed.ID); err != nil {
+		t.Fatalf("delete doomed: %v", err)
+	}
+
+	// Live variant — filters soft-deleted items. The guest should
+	// only see `live.ID`.
+	_, liveItemIDs, err := s.GuestVisibleResources(ws.ID, user.ID)
+	if err != nil {
+		t.Fatalf("GuestVisibleResources: %v", err)
+	}
+	if got := stringInSlice(liveItemIDs, live.ID); !got {
+		t.Errorf("live variant: missing live item ID %q (got %v)", live.ID, liveItemIDs)
+	}
+	if stringInSlice(liveItemIDs, doomed.ID) {
+		t.Errorf("live variant: should NOT include soft-deleted item, got %v", liveItemIDs)
+	}
+
+	// Delta-sync variant — includes soft-deleted items. The guest
+	// should see BOTH IDs so the tombstone can flow through
+	// /items-changes.
+	_, deltaItemIDs, err := s.GuestVisibleResourcesIncludeDeleted(ws.ID, user.ID)
+	if err != nil {
+		t.Fatalf("GuestVisibleResourcesIncludeDeleted: %v", err)
+	}
+	if !stringInSlice(deltaItemIDs, live.ID) {
+		t.Errorf("delta variant: missing live item ID %q (got %v)", live.ID, deltaItemIDs)
+	}
+	if !stringInSlice(deltaItemIDs, doomed.ID) {
+		t.Errorf("delta variant: MUST include soft-deleted item so client can drop it; got %v", deltaItemIDs)
+	}
+}
+
+// stringInSlice is a tiny test helper — `slices.Contains` would do
+// but keeping the test free of stdlib generics ergonomics so it
+// reads cleanly with the rest of the file.
+func stringInSlice(xs []string, want string) bool {
+	for _, x := range xs {
+		if x == want {
+			return true
+		}
+	}
+	return false
+}
+
 // TestItemSeqMonotonic verifies that the workspace-scoped `seq` column
 // is stamped strictly monotonically across every mutation
 // (create / update / soft-delete / restore). This is the cursor

--- a/internal/store/items_test.go
+++ b/internal/store/items_test.go
@@ -3208,6 +3208,64 @@ func stringInSlice(xs []string, want string) bool {
 	return false
 }
 
+// TestMigrateItemFieldValues_PerRowUniqueSeq guards the
+// /items-changes pagination contract on bulk rewrites (Codex
+// review of TASK-1354 round 2 [P1]). Before the fix, the bulk
+// UPDATE assigned every affected row the same `MAX(seq)+1`. A
+// /items-changes?limit=N poll that cut through that equal-seq
+// group would advance the cursor to the shared seq, and the
+// next `seq > cursor` poll would silently skip the rest of the
+// group.
+//
+// The current implementation issues per-row UPDATEs inside the
+// migration transaction so every row ends up with a strictly
+// unique seq.
+func TestMigrateItemFieldValues_PerRowUniqueSeq(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Test")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+
+	// Five items, all in the same select-option bucket so the
+	// rename touches every row in a single migration step.
+	const n = 5
+	for i := 0; i < n; i++ {
+		_, err := s.CreateItem(ws.ID, col.ID, models.ItemCreate{
+			Title:  fmt.Sprintf("row-%d", i),
+			Fields: `{"status":"open"}`,
+		})
+		if err != nil {
+			t.Fatalf("create item %d: %v", i, err)
+		}
+	}
+
+	affected, err := s.MigrateItemFieldValues(col.ID, []models.FieldMigration{
+		{Field: "status", RenameOptions: map[string]string{"open": "available"}},
+	})
+	if err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if affected != int64(n) {
+		t.Fatalf("expected %d rows affected, got %d", n, affected)
+	}
+
+	items, err := s.ListItems(ws.ID, models.ItemListParams{CollectionSlug: col.Slug})
+	if err != nil {
+		t.Fatalf("list items: %v", err)
+	}
+	if len(items) != n {
+		t.Fatalf("expected %d items in list, got %d", n, len(items))
+	}
+
+	// Every row must have a unique seq.
+	seen := make(map[int64]string, n)
+	for _, it := range items {
+		if prev, dup := seen[it.Seq]; dup {
+			t.Fatalf("duplicate seq=%d shared by items %q and %q (bulk migrate must assign per-row unique seqs for /items-changes pagination)", it.Seq, prev, it.ID)
+		}
+		seen[it.Seq] = it.ID
+	}
+}
+
 // TestItemSeqMonotonic verifies that the workspace-scoped `seq` column
 // is stamped strictly monotonically across every mutation
 // (create / update / soft-delete / restore). This is the cursor

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -6,6 +6,8 @@ import type {
 	CollectionCreate,
 	CollectionUpdate,
 	Item,
+	ItemChangeRow,
+	ItemChangesResponse,
 	ItemCreate,
 	ItemIndexResponse,
 	ItemIndexRow,
@@ -378,6 +380,54 @@ export const api = {
 				return rest;
 			});
 			return { items, total: raw.total, cursor: raw.cursor };
+		},
+
+		/**
+		 * Delta-fetch sibling of `listIndex` (PLAN-1343 / TASK-1354).
+		 *
+		 * Endpoint: `GET /api/v1/workspaces/{ws}/items-changes?since=<cursor>`.
+		 * Returns every row that has mutated since the caller's `since`
+		 * cursor — including soft-deleted tombstones (`deleted: true`) so
+		 * the client can remove them from its local index without a
+		 * second roundtrip. Rows are sorted ascending by `seq`.
+		 *
+		 * Cursor contract: re-pass the response's `cursor` as `since`
+		 * on the next poll for no overlap and no gap. When the response
+		 * is empty the server returns the caller's `since` unchanged
+		 * (position preserved). Treat the value as opaque.
+		 *
+		 * Limit: defaults to the server's `DefaultItemChangesLimit`
+		 * (currently 5000). Clients that need a smaller page (low-RAM
+		 * mobile resume) or a larger one can pass `limit`; the server
+		 * clamps to `MaxItemChangesLimit` (50000). When the response is
+		 * truncated, the returned cursor sits at the last row's seq so
+		 * the client can resume.
+		 */
+		changes: async (
+			ws: string,
+			sinceCursor: string,
+			opts?: { limit?: number }
+		): Promise<ItemChangesResponse> => {
+			const raw = await request<{
+				changes: (ItemChangeRow & { content?: string })[];
+				cursor: string;
+			}>(
+				`/workspaces/${ws}/items-changes${qs({
+					since: sinceCursor,
+					limit: opts?.limit,
+				})}`
+			);
+			// Mirror `listIndex`'s defensive content-strip: the server's
+			// skinny scan omits `i.content`, but the Go zero-value would
+			// serialize as `content: ""` if any non-omitempty wrapper
+			// surfaced it. Strip explicitly so callers never accidentally
+			// spread a delta row into the canonical item store and blank
+			// out the rich-text body.
+			const changes: ItemChangeRow[] = raw.changes.map((row) => {
+				const { content: _ignored, ...rest } = row;
+				return rest;
+			});
+			return { changes, cursor: raw.cursor };
 		},
 
 		create: (ws: string, coll: string, data: ItemCreate) =>

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -472,6 +472,30 @@ export interface ItemIndexResponse {
 	cursor: string;
 }
 
+// ─── Items changes (delta sync) ──────────────────────────────────────────────
+// `ItemChangeRow` is a skinny `ItemIndexRow` with a `deleted` boolean
+// flag so a delta consumer can distinguish upserts from tombstones in
+// one pass. Soft-deleted rows still carry their full skinny payload
+// (deleted_at is populated) — `deleted` is just the derived view of
+// that timestamp.
+export type ItemChangeRow = ItemIndexRow & { deleted: boolean };
+
+// `ItemChangesResponse` wraps a delta-fetch result from
+// `GET /workspaces/{ws}/items-changes?since=<cursor>` (TASK-1354).
+//
+//   - changes: rows where `seq > since`, ascending by `seq`. Each row
+//     includes `deleted` (true when soft-deleted) so the client can
+//     apply or remove without a second roundtrip.
+//   - cursor: the largest `seq` in the response, decimal-encoded.
+//     When the response is empty, the server returns the caller's
+//     `since` unchanged so the client doesn't lose position. Treat
+//     the value as opaque (re-pass as `?since=<cursor>` on the
+//     next poll).
+export interface ItemChangesResponse {
+	changes: ItemChangeRow[];
+	cursor: string;
+}
+
 export interface ItemCreate {
 	title: string;
 	content?: string;


### PR DESCRIPTION
## Summary

Adds the delta-fetch sibling of `/items-index` for the local-first
read model. Clients track the workspace-scoped seq cursor and poll
`/items-changes?since=<cursor>` to apply just the rows that have
mutated, including tombstones — without re-downloading the entire
workspace.

## Context

Implements `TASK-1354` under `PLAN-1343` (Phase 2 of the local-first
read model). Depends on `TASK-1352` (seq column) and `TASK-1353`
(seq cursor on /items-index). See `DOC-1342` design decision #1
for the cursor contract.

## Endpoint

`GET /api/v1/workspaces/{ws}/items-changes?since=<seq>&limit=<n>`

- `since`: exclusive seq lower bound (returns `seq > since`).
  Default `0` → full delta == /items-index modulo ordering.
  Invalid → `400`.
- `limit`: cap on rows. Default `5000`, clamped to `50000`. Invalid → `400`.

Response: `{ changes: [...skinny rows with deleted:bool...], cursor }`.

## Cursor contract

- Rows sorted ASC by `seq` so re-passing the response's `cursor` as
  `since` is no-overlap / no-gap (strict monotonic seq invariant from
  TASK-1352).
- Empty response preserves the caller's `since` (position not lost).
- Truncated-by-limit response sets cursor to the last row's seq.

## What changed

- `internal/store/items.go`: new `ListItemsChangesSince` + scan helper.
  Constants `DefaultItemChangesLimit` (5000) / `MaxItemChangesLimit`
  (50000).
- `internal/server/handlers_items.go`: new `handleListItemsChanges`,
  `itemsChangesResponse`, `itemChangeRow` (embeds `models.Item` +
  `deleted bool`).
- `internal/server/server.go`: route registration at workspace level.
- TypeScript: `ItemChangeRow`, `ItemChangesResponse` types;
  `api.items.changes(ws, sinceCursor, opts?)` client method.

## Tests

Six new server-level tests cover full delta from 0, incremental
update + delete with `deleted` flag, cursor roundtrip (no overlap /
no gap), limit truncation + resume, invalid param rejection (400),
and empty-workspace position preservation.

## Test plan

- [x] `go build ./...` — clean
- [x] `make check` — green (lint + Go tests + web build)
- [x] `go test ./internal/server -run TestListItemsChanges -v` — 6/6 pass