### PR TITLE
feat(web): localIndex in-RAM canonical store (TASK-1355)

### DIFF
--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -750,11 +750,18 @@ func (s *Store) ListItemsIndex(workspaceID string, params ItemIndexParams) ([]mo
 		return nil, nil
 	}
 
+	// `i.deleted_at` is in the projection so the local-first client
+	// (PLAN-1343 / TASK-1355) can distinguish archived rows hydrated
+	// with `IncludeArchived=true` from live rows. When the flag is
+	// false, the WHERE clause filters them out anyway; when it's
+	// true, the field is populated for the soft-deleted subset and
+	// nil for live rows. Mirrors the projection of
+	// ListItemsChangesSince which has always carried this column.
 	query := `
 		SELECT i.id, i.workspace_id, i.collection_id, i.title, i.slug, i.fields, i.tags,
 		       i.pinned, i.sort_order, i.parent_id, i.assigned_user_id, i.agent_role_id, i.role_sort_order,
 		       i.created_by, i.last_modified_by, i.source,
-		       i.item_number, i.seq, i.created_at, i.updated_at,
+		       i.item_number, i.seq, i.created_at, i.updated_at, i.deleted_at,
 		       c.slug, c.name, c.icon, c.prefix,
 		       COALESCE(au.name, ''), COALESCE(au.email, ''),
 		       COALESCE(ar.name, ''), COALESCE(ar.slug, ''), COALESCE(ar.icon, '')
@@ -1078,13 +1085,14 @@ func scanItemsIndex(rows *sql.Rows) ([]models.Item, error) {
 	for rows.Next() {
 		var item models.Item
 		var createdAt, updatedAt string
+		var deletedAt *string
 		var pinned bool
 		if err := rows.Scan(
 			&item.ID, &item.WorkspaceID, &item.CollectionID, &item.Title, &item.Slug,
 			&item.Fields, &item.Tags,
 			&pinned, &item.SortOrder, &item.ParentID, &item.AssignedUserID, &item.AgentRoleID, &item.RoleSortOrder,
 			&item.CreatedBy, &item.LastModifiedBy, &item.Source,
-			&item.ItemNumber, &item.Seq, &createdAt, &updatedAt,
+			&item.ItemNumber, &item.Seq, &createdAt, &updatedAt, &deletedAt,
 			&item.CollectionSlug, &item.CollectionName, &item.CollectionIcon, &item.CollectionPrefix,
 			&item.AssignedUserName, &item.AssignedUserEmail,
 			&item.AgentRoleName, &item.AgentRoleSlug, &item.AgentRoleIcon,
@@ -1094,6 +1102,10 @@ func scanItemsIndex(rows *sql.Rows) ([]models.Item, error) {
 		item.Pinned = pinned
 		item.CreatedAt = parseTime(createdAt)
 		item.UpdatedAt = parseTime(updatedAt)
+		if deletedAt != nil {
+			t := parseTime(*deletedAt)
+			item.DeletedAt = &t
+		}
 		hydrateItemComputedMetadata(&item)
 		items = append(items, item)
 	}

--- a/web/src/lib/stores/localIndex.svelte.ts
+++ b/web/src/lib/stores/localIndex.svelte.ts
@@ -24,10 +24,13 @@
 // workspace-wide read model, and the showArchived toggle is a
 // render-time predicate. `getByCollection` filters them out by default;
 // callers that want to render archived rows pass `{ includeArchived: true }`.
-// `applyDelta` removes a row from the store only when the server flags
-// it as a hard-deleted tombstone (`deleted: true` on the change wire
-// format) — soft-deletes arrive as upserts with `deleted_at` populated,
-// so they stay in the index and just fall out of the default filter.
+//
+// On `/items-changes` deltas, `deleted: true` is the server's derived
+// view of `deleted_at != nil` (a SOFT delete) — the row still carries
+// its full skinny payload, so `applyDelta` upserts it like any other
+// change. Hard deletes (workspace GC, 403 purge from TASK-1360) flow
+// through `remove()` instead, which is the only path that drops a row
+// id from the local index.
 //
 // Strip `content` defensively on every ingest path. The server's skinny
 // `/items-index` and `/items-changes` endpoints already exclude the
@@ -172,10 +175,14 @@ export const localIndex = {
 	},
 
 	/**
-	 * Apply a batch of changes from `/items-changes`. Upserts on
-	 * non-deleted rows, removes on `deleted: true` (hard-delete
-	 * tombstone). Soft-deleted rows arrive as regular upserts with
-	 * `deleted_at` populated, so they stay in the index.
+	 * Apply a batch of changes from `/items-changes`. Always upserts
+	 * — `deleted: true` on a change is the server's derived view of
+	 * `deleted_at != nil` (a SOFT delete) and the row still carries
+	 * its full skinny payload, so it gets stored alongside live rows
+	 * with `deleted_at` populated. The default `getByCollection`
+	 * filter hides those from live views; `{ includeArchived: true }`
+	 * surfaces them. Hard deletes (workspace GC / 403 purge) go
+	 * through `remove()` instead.
 	 *
 	 * Three guards against stale batches (all three caught by Codex
 	 * across review rounds):
@@ -223,12 +230,16 @@ export const localIndex = {
 					continue;
 				}
 			}
-			if (change.deleted) {
-				state.items.delete(change.id);
-			} else {
-				const { deleted: _d, ...row } = change;
-				state.items.set(change.id, toSkinny(row as ItemIndexRow));
-			}
+			// `deleted: true` is the server's derived view of
+			// `deleted_at != nil` — a SOFT delete. The row still carries
+			// its full skinny payload (including `deleted_at`), so we
+			// upsert it like any other change. Hiding archived rows
+			// from default reads is `getByCollection`'s job; this layer
+			// only manages the seq-ordered identity of the row. Hard
+			// deletes (workspace GC / 403 purge) go through the
+			// `remove()` method, not through this batch path.
+			const { deleted: _d, ...row } = change;
+			state.items.set(change.id, toSkinny(row as ItemIndexRow));
 		}
 		state.cursor = newCursor;
 	},
@@ -239,10 +250,27 @@ export const localIndex = {
 	 * `Item`, the caller hands it here to keep the local index fresh
 	 * without waiting for the SSE round-trip). Does NOT touch the
 	 * cursor — that's the job of `applyDelta` / `applySSEEvent`.
+	 *
+	 * Same per-row stale guard as `applyDelta`: if the incoming row's
+	 * `seq` is not strictly greater than the existing row's `seq`,
+	 * skip the write. Without this, a late SSE / out-of-order optimistic
+	 * response could regress a row after a fresher version had already
+	 * landed. Rows or peers missing `seq` (legacy snapshots before
+	 * TASK-1352) overwrite unconditionally — there's no basis to
+	 * compare.
 	 */
 	upsert(ws: string, row: ItemIndexRow | Item): void {
 		const state = ensureState(ws);
-		state.items.set(row.id, toSkinny(row));
+		const next = toSkinny(row);
+		const existing = state.items.get(row.id);
+		if (
+			existing?.seq !== undefined &&
+			next.seq !== undefined &&
+			next.seq <= existing.seq
+		) {
+			return;
+		}
+		state.items.set(row.id, next);
 	},
 
 	/**

--- a/web/src/lib/stores/localIndex.svelte.ts
+++ b/web/src/lib/stores/localIndex.svelte.ts
@@ -19,11 +19,15 @@
 // reactive in its own right. The in-flight bootstrap promise lives
 // in a separate plain Map — no reason to make a Promise reactive.
 //
-// Archived items are held alongside live items by design (see
-// TASK-1357): the store is a workspace-wide read model, and the
-// archived toggle is a render-time predicate the consumer applies via
-// `fields.status`. `applyDelta` removes rows only on the `deleted`
-// tombstone flag (soft-delete) — `status: 'archived'` items remain.
+// Archived items (rows with `deleted_at` set on the server) are held
+// alongside live items by design (see TASK-1357): the store is a
+// workspace-wide read model, and the showArchived toggle is a
+// render-time predicate. `getByCollection` filters them out by default;
+// callers that want to render archived rows pass `{ includeArchived: true }`.
+// `applyDelta` removes a row from the store only when the server flags
+// it as a hard-deleted tombstone (`deleted: true` on the change wire
+// format) — soft-deletes arrive as upserts with `deleted_at` populated,
+// so they stay in the index and just fall out of the default filter.
 //
 // Strip `content` defensively on every ingest path. The server's skinny
 // `/items-index` and `/items-changes` endpoints already exclude the
@@ -143,41 +147,59 @@ export const localIndex = {
 	/**
 	 * Synchronous filtered read by collection slug. Returns a freshly
 	 * allocated array on every call; rely on `$derived` upstream for
-	 * memoization. Includes archived items (they're in the store by
-	 * design) — consumers that want to gate on `fields.status` should
-	 * do so at the render layer (see TASK-1357 wiring).
+	 * memoization.
+	 *
+	 * By default, soft-deleted ("archived") rows are filtered out —
+	 * the store holds them alongside live rows so a `showArchived`
+	 * toggle doesn't need a refetch, but the typical view wants live
+	 * only. Pass `{ includeArchived: true }` for archive views.
 	 */
-	getByCollection(ws: string, collSlug: string): ItemIndexRow[] {
+	getByCollection(
+		ws: string,
+		collSlug: string,
+		opts?: { includeArchived?: boolean },
+	): ItemIndexRow[] {
 		const state = workspaces.get(ws);
 		if (!state) return [];
+		const includeArchived = opts?.includeArchived === true;
 		const out: ItemIndexRow[] = [];
 		for (const row of state.items.values()) {
-			if (row.collection_slug === collSlug) out.push(row);
+			if (row.collection_slug !== collSlug) continue;
+			if (!includeArchived && row.deleted_at) continue;
+			out.push(row);
 		}
 		return out;
 	},
 
 	/**
 	 * Apply a batch of changes from `/items-changes`. Upserts on
-	 * non-deleted rows, removes on `deleted: true` (soft-delete
-	 * tombstone). Archived-status rows stay in the store — `deleted`
-	 * is a different concern.
+	 * non-deleted rows, removes on `deleted: true` (hard-delete
+	 * tombstone). Soft-deleted rows arrive as regular upserts with
+	 * `deleted_at` populated, so they stay in the index.
 	 *
-	 * Two guards against stale batches (Codex P2 on initial review):
+	 * Three guards against stale batches (all three caught by Codex
+	 * across review rounds):
 	 *
 	 *   1. If `newCursor <= state.cursor`, drop the whole batch. The
 	 *      server returns `cursor === since` on empty responses, so an
 	 *      empty no-op trivially short-circuits here.
-	 *   2. Per-row: skip changes whose `seq <= state.cursor` at the
-	 *      START of the call. In normal /items-changes flow the server
-	 *      filters to `seq > since`, but applyDelta is also a public
-	 *      entry point (tests, future replay callers) — if any row in
-	 *      a batch is stale, dropping it prevents overwriting newer
-	 *      state. Rows missing `seq` (legacy snapshots before TASK-1352)
-	 *      pass through unconditionally since we have no basis to
-	 *      compare.
+	 *   2. Per-row vs. cursor: skip changes whose `seq <= state.cursor`
+	 *      at the START of the call. In normal /items-changes flow the
+	 *      server filters to `seq > since`, but applyDelta is also a
+	 *      public entry point (tests, future replay callers) — if any
+	 *      row in a batch is stale, dropping it prevents overwriting
+	 *      newer state.
+	 *   3. Per-row vs. existing row: skip if there is already a row
+	 *      with a higher `seq` in the store. `upsert()` and SSE
+	 *      apply-event paths can store newer rows without touching the
+	 *      cursor, so the cursor alone is not a sufficient floor —
+	 *      a delta that legitimately advances the cursor can still
+	 *      carry a row whose `seq` is older than what we already hold
+	 *      for that id (e.g. SSE arrived first via a different path).
 	 *
-	 * The cursor only advances forward, so a backslide can never lose
+	 * Rows missing `seq` (legacy snapshots before TASK-1352) pass
+	 * through unconditionally — there's no basis to compare. The
+	 * cursor only advances forward, so a backslide can never lose
 	 * progress.
 	 */
 	applyDelta(ws: string, changes: ItemChangeRow[], newCursor: string): void {
@@ -189,11 +211,17 @@ export const localIndex = {
 		if (newCursorNum <= startCursorNum) return;
 
 		for (const change of changes) {
-			// Guard 2: per-row seq check. If a row's seq isn't strictly
-			// greater than what we held at the start, it's stale —
-			// skip. Missing seq is treated as "trust the batch".
-			if (change.seq !== undefined && change.seq <= startCursorNum) {
-				continue;
+			if (change.seq !== undefined) {
+				// Guard 2: row's seq vs. cursor floor.
+				if (change.seq <= startCursorNum) continue;
+				// Guard 3: row's seq vs. existing row.
+				const existing = state.items.get(change.id);
+				if (
+					existing?.seq !== undefined &&
+					change.seq <= existing.seq
+				) {
+					continue;
+				}
 			}
 			if (change.deleted) {
 				state.items.delete(change.id);

--- a/web/src/lib/stores/localIndex.svelte.ts
+++ b/web/src/lib/stores/localIndex.svelte.ts
@@ -10,10 +10,20 @@
 //   - cursor:        the highest workspace-scoped `seq` we have seen
 //   - bootstrapState: 'cold' | 'loading' | 'ready' | 'error'
 //
-// Reactivity: items is a `SvelteMap` (from `svelte/reactivity`) so any
-// `$derived` / `$effect` over `getByCollection` re-runs when the store
-// changes. The per-workspace map itself is `$state`-wrapped so swapping
-// workspaces also triggers downstream reactivity.
+// Reactivity: the outer `workspaces` map is a `SvelteMap`, and
+// `WorkspaceState` is a class whose `cursor` / `bootstrapState`
+// fields are declared with the `$state` rune (Svelte 5 only allows
+// `$state()` at variable-initializer, class-field, or
+// constructor-first-assign sites — not as an arbitrary expression
+// value inside a function). Its `items` is a `SvelteMap`, already
+// reactive in its own right. The in-flight bootstrap promise lives
+// in a separate plain Map — no reason to make a Promise reactive.
+//
+// Archived items are held alongside live items by design (see
+// TASK-1357): the store is a workspace-wide read model, and the
+// archived toggle is a render-time predicate the consumer applies via
+// `fields.status`. `applyDelta` removes rows only on the `deleted`
+// tombstone flag (soft-delete) — `status: 'archived'` items remain.
 //
 // Strip `content` defensively on every ingest path. The server's skinny
 // `/items-index` and `/items-changes` endpoints already exclude the
@@ -32,29 +42,33 @@ import type { Item, ItemChangeRow, ItemIndexRow } from '$lib/types';
 
 export type BootstrapState = 'cold' | 'loading' | 'ready' | 'error';
 
-interface WorkspaceState {
-	items: SvelteMap<string, ItemIndexRow>;
-	cursor: string;
-	bootstrapState: BootstrapState;
-	// In-flight bootstrap promise so concurrent callers coalesce instead
-	// of firing parallel /items-index requests.
-	inflight: Promise<void> | null;
+// `WorkspaceState` is a class so its scalar fields can use the `$state`
+// rune. `$state()` is not legal as an expression value inside a function
+// in Svelte 5 — only at variable-initializer, class-field, or
+// constructor-first-assign sites — so we can't lazily build a reactive
+// plain object in `ensureState`. Wrapping the scalars in class fields
+// gives us the same shape with reactivity intact. `items` is a
+// `SvelteMap`, already reactive by itself.
+class WorkspaceState {
+	items: SvelteMap<string, ItemIndexRow> = new SvelteMap();
+	cursor = $state('0');
+	bootstrapState = $state<BootstrapState>('cold');
 }
 
-// The state is `$state`-wrapped at the module level so reactive
-// consumers (via the public getters below) re-render when a workspace
-// is added or its bootstrapState flips.
-const workspaces = $state(new Map<string, WorkspaceState>());
+// Outer map: reactive (SvelteMap) so consumers re-render when a fresh
+// workspace is hydrated. Each entry's WorkspaceState owns its own
+// per-field reactivity via the class-field $state runes above.
+const workspaces = new SvelteMap<string, WorkspaceState>();
+
+// In-flight bootstrap promises live outside the reactive state — there
+// is no reason to proxy a Promise, and keeping it separate makes the
+// reactive-vs-internal split explicit.
+const inflight = new Map<string, Promise<void>>();
 
 function ensureState(ws: string): WorkspaceState {
 	let state = workspaces.get(ws);
 	if (!state) {
-		state = {
-			items: new SvelteMap<string, ItemIndexRow>(),
-			cursor: '0',
-			bootstrapState: 'cold',
-			inflight: null,
-		};
+		state = new WorkspaceState();
 		workspaces.set(ws, state);
 	}
 	return state;
@@ -80,34 +94,35 @@ function toSkinny(row: ItemIndexRow | Item): ItemIndexRow {
  * Treat empty / non-numeric input as 0 so a fresh workspace's "0"
  * cursor compares correctly against a real response's "12345".
  */
-function cursorGte(a: string, b: string): boolean {
-	const an = Number(a);
-	const bn = Number(b);
-	const ai = Number.isFinite(an) ? an : 0;
-	const bi = Number.isFinite(bn) ? bn : 0;
-	return ai >= bi;
+function cursorAsNum(c: string): number {
+	const n = Number(c);
+	return Number.isFinite(n) ? n : 0;
 }
 
 export const localIndex = {
 	/**
 	 * Hydrate a workspace from `/items-index`. Idempotent: returns the
 	 * same in-flight promise if already loading; resolves immediately
-	 * if already `ready`. On error the state flips to `'error'` and the
-	 * caller can retry by calling `bootstrap` again (the state is
-	 * cleared back to `cold` on retry-entry).
+	 * if already `ready`. On error the state flips to `'error'` and
+	 * the caller can retry by calling `bootstrap` again — the next
+	 * call sees `bootstrapState === 'error'` and proceeds. Archived
+	 * items are included in the snapshot (the store is the canonical
+	 * read model for both live and archived rows; consumers filter).
 	 */
 	async bootstrap(ws: string): Promise<void> {
 		const state = ensureState(ws);
 		if (state.bootstrapState === 'ready') return;
-		if (state.inflight) return state.inflight;
+		const pending = inflight.get(ws);
+		if (pending) return pending;
 
 		state.bootstrapState = 'loading';
-		state.inflight = (async () => {
+		const p = (async () => {
 			try {
 				const resp = await api.items.listIndex(ws, { includeArchived: true });
 				// Replace, don't merge — bootstrap is the authoritative
-				// snapshot at this point. Anything in flight from SSE will
-				// be reconciled on the next applyDelta via seq ordering.
+				// snapshot at this point. Anything in flight from SSE
+				// will be reconciled on the next applyDelta via the
+				// per-row seq check.
 				state.items.clear();
 				for (const row of resp.items) {
 					state.items.set(row.id, toSkinny(row));
@@ -118,19 +133,19 @@ export const localIndex = {
 				state.bootstrapState = 'error';
 				throw err;
 			} finally {
-				state.inflight = null;
+				inflight.delete(ws);
 			}
 		})();
-
-		return state.inflight;
+		inflight.set(ws, p);
+		return p;
 	},
 
 	/**
-	 * Synchronous filtered read. Returns a freshly-allocated array on
-	 * every call; rely on `$derived` upstream for memoization.
-	 * Filters out items that are missing `collection_slug` (defensive —
-	 * the index endpoint always populates it, but a typed
-	 * non-null guard keeps the consumer code clean).
+	 * Synchronous filtered read by collection slug. Returns a freshly
+	 * allocated array on every call; rely on `$derived` upstream for
+	 * memoization. Includes archived items (they're in the store by
+	 * design) — consumers that want to gate on `fields.status` should
+	 * do so at the render layer (see TASK-1357 wiring).
 	 */
 	getByCollection(ws: string, collSlug: string): ItemIndexRow[] {
 		const state = workspaces.get(ws);
@@ -144,13 +159,42 @@ export const localIndex = {
 
 	/**
 	 * Apply a batch of changes from `/items-changes`. Upserts on
-	 * non-deleted rows, removes on `deleted: true`. Cursor only
-	 * advances forward — a server response that backslides (shouldn't
-	 * happen, but harmless to defend) is ignored at the cursor level.
+	 * non-deleted rows, removes on `deleted: true` (soft-delete
+	 * tombstone). Archived-status rows stay in the store — `deleted`
+	 * is a different concern.
+	 *
+	 * Two guards against stale batches (Codex P2 on initial review):
+	 *
+	 *   1. If `newCursor <= state.cursor`, drop the whole batch. The
+	 *      server returns `cursor === since` on empty responses, so an
+	 *      empty no-op trivially short-circuits here.
+	 *   2. Per-row: skip changes whose `seq <= state.cursor` at the
+	 *      START of the call. In normal /items-changes flow the server
+	 *      filters to `seq > since`, but applyDelta is also a public
+	 *      entry point (tests, future replay callers) — if any row in
+	 *      a batch is stale, dropping it prevents overwriting newer
+	 *      state. Rows missing `seq` (legacy snapshots before TASK-1352)
+	 *      pass through unconditionally since we have no basis to
+	 *      compare.
+	 *
+	 * The cursor only advances forward, so a backslide can never lose
+	 * progress.
 	 */
 	applyDelta(ws: string, changes: ItemChangeRow[], newCursor: string): void {
 		const state = ensureState(ws);
+		const startCursorNum = cursorAsNum(state.cursor);
+		const newCursorNum = cursorAsNum(newCursor);
+
+		// Guard 1: whole-batch drop on non-advancing cursor.
+		if (newCursorNum <= startCursorNum) return;
+
 		for (const change of changes) {
+			// Guard 2: per-row seq check. If a row's seq isn't strictly
+			// greater than what we held at the start, it's stale —
+			// skip. Missing seq is treated as "trust the batch".
+			if (change.seq !== undefined && change.seq <= startCursorNum) {
+				continue;
+			}
 			if (change.deleted) {
 				state.items.delete(change.id);
 			} else {
@@ -158,9 +202,7 @@ export const localIndex = {
 				state.items.set(change.id, toSkinny(row as ItemIndexRow));
 			}
 		}
-		if (cursorGte(newCursor, state.cursor)) {
-			state.cursor = newCursor;
-		}
+		state.cursor = newCursor;
 	},
 
 	/**
@@ -209,6 +251,7 @@ export const localIndex = {
 	 */
 	reset(ws: string): void {
 		workspaces.delete(ws);
+		inflight.delete(ws);
 	},
 
 	/** Number of items currently held for a workspace. Test/debug aid. */

--- a/web/src/lib/stores/localIndex.svelte.ts
+++ b/web/src/lib/stores/localIndex.svelte.ts
@@ -114,7 +114,17 @@ export const localIndex = {
 	 * the caller can retry by calling `bootstrap` again — the next
 	 * call sees `bootstrapState === 'error'` and proceeds. Archived
 	 * items are included in the snapshot (the store is the canonical
-	 * read model for both live and archived rows; consumers filter).
+	 * read model for both live and archived rows; consumers filter
+	 * via `{ includeArchived }`).
+	 *
+	 * Merge, don't clear. An optimistic `upsert()` or an SSE-driven
+	 * write can land while the /items-index request is in flight; if
+	 * we cleared and replaced, we'd silently regress those rows to
+	 * the older snapshot value (Codex P2 round 3). Instead, we
+	 * MERGE each response row through the same per-row seq guard
+	 * `upsert` uses, and the cursor only advances forward. The
+	 * cleared-state semantic isn't needed in practice because
+	 * `reset()` is the explicit "drop everything" entry point.
 	 */
 	async bootstrap(ws: string): Promise<void> {
 		const state = ensureState(ws);
@@ -126,15 +136,25 @@ export const localIndex = {
 		const p = (async () => {
 			try {
 				const resp = await api.items.listIndex(ws, { includeArchived: true });
-				// Replace, don't merge — bootstrap is the authoritative
-				// snapshot at this point. Anything in flight from SSE
-				// will be reconciled on the next applyDelta via the
-				// per-row seq check.
-				state.items.clear();
 				for (const row of resp.items) {
-					state.items.set(row.id, toSkinny(row));
+					const next = toSkinny(row);
+					const existing = state.items.get(row.id);
+					if (
+						existing?.seq !== undefined &&
+						next.seq !== undefined &&
+						next.seq <= existing.seq
+					) {
+						continue;
+					}
+					state.items.set(row.id, next);
 				}
-				state.cursor = resp.cursor;
+				// Cursor moves forward only. A fresh /items-index can
+				// occasionally return a cursor below the in-RAM one
+				// (e.g. an SSE delta advanced it during the request);
+				// don't backslide.
+				if (cursorAsNum(resp.cursor) > cursorAsNum(state.cursor)) {
+					state.cursor = resp.cursor;
+				}
 				state.bootstrapState = 'ready';
 			} catch (err) {
 				state.bootstrapState = 'error';

--- a/web/src/lib/stores/localIndex.svelte.ts
+++ b/web/src/lib/stores/localIndex.svelte.ts
@@ -172,6 +172,12 @@ export const localIndex = {
 	 * allocated array on every call; rely on `$derived` upstream for
 	 * memoization.
 	 *
+	 * Sorted `updated_at DESC, id ASC` to match the server's
+	 * /items-index ordering — `SvelteMap` is insertion-ordered, so
+	 * after live `upsert`/`applyDelta` writes the natural iteration
+	 * order would diverge from the bootstrap snapshot. Sorting on
+	 * read keeps consumers stable across mutation paths.
+	 *
 	 * By default, soft-deleted ("archived") rows are filtered out —
 	 * the store holds them alongside live rows so a `showArchived`
 	 * toggle doesn't need a refetch, but the typical view wants live
@@ -191,6 +197,16 @@ export const localIndex = {
 			if (!includeArchived && row.deleted_at) continue;
 			out.push(row);
 		}
+		// Server order is `updated_at DESC, id ASC`. Strings sort
+		// correctly here because `updated_at` is an RFC3339 string —
+		// lexicographic compare equals chronological compare.
+		out.sort((a, b) => {
+			if (a.updated_at !== b.updated_at) {
+				return a.updated_at < b.updated_at ? 1 : -1;
+			}
+			if (a.id === b.id) return 0;
+			return a.id < b.id ? -1 : 1;
+		});
 		return out;
 	},
 

--- a/web/src/lib/stores/localIndex.svelte.ts
+++ b/web/src/lib/stores/localIndex.svelte.ts
@@ -1,0 +1,218 @@
+// localIndex — the in-RAM canonical store for the local-first read model
+// (PLAN-1343 / TASK-1355). Per DOC-1342 design decision #4: the Svelte
+// store owns truth in-RAM. IndexedDB persistence is bolted on in
+// TASK-1356, but readers only ever talk to this store — the IDB layer
+// is hydration + write-behind, never queried directly.
+//
+// Shape: one `WorkspaceState` per workspace slug, lazily created. Each
+// holds:
+//   - items: SvelteMap<itemId, ItemIndexRow>  — keyed by item.id
+//   - cursor:        the highest workspace-scoped `seq` we have seen
+//   - bootstrapState: 'cold' | 'loading' | 'ready' | 'error'
+//
+// Reactivity: items is a `SvelteMap` (from `svelte/reactivity`) so any
+// `$derived` / `$effect` over `getByCollection` re-runs when the store
+// changes. The per-workspace map itself is `$state`-wrapped so swapping
+// workspaces also triggers downstream reactivity.
+//
+// Strip `content` defensively on every ingest path. The server's skinny
+// `/items-index` and `/items-changes` endpoints already exclude the
+// body, but `api.items.listIndex` / `api.items.changes` also strip
+// the always-empty `content: ""` zero-value (see client.ts) — we do
+// the same here so a caller passing a full `Item` (e.g. from
+// `api.items.create` / `update`) cannot accidentally leak the rich
+// body into the local index.
+//
+// All operations except `bootstrap` are synchronous — readers don't
+// `await`, they just read.
+
+import { SvelteMap } from 'svelte/reactivity';
+import { api } from '$lib/api/client';
+import type { Item, ItemChangeRow, ItemIndexRow } from '$lib/types';
+
+export type BootstrapState = 'cold' | 'loading' | 'ready' | 'error';
+
+interface WorkspaceState {
+	items: SvelteMap<string, ItemIndexRow>;
+	cursor: string;
+	bootstrapState: BootstrapState;
+	// In-flight bootstrap promise so concurrent callers coalesce instead
+	// of firing parallel /items-index requests.
+	inflight: Promise<void> | null;
+}
+
+// The state is `$state`-wrapped at the module level so reactive
+// consumers (via the public getters below) re-render when a workspace
+// is added or its bootstrapState flips.
+const workspaces = $state(new Map<string, WorkspaceState>());
+
+function ensureState(ws: string): WorkspaceState {
+	let state = workspaces.get(ws);
+	if (!state) {
+		state = {
+			items: new SvelteMap<string, ItemIndexRow>(),
+			cursor: '0',
+			bootstrapState: 'cold',
+			inflight: null,
+		};
+		workspaces.set(ws, state);
+	}
+	return state;
+}
+
+/**
+ * Strip a row down to the skinny shape. Defensive: discard `content`
+ * if a caller passed a full `Item` rather than an `ItemIndexRow`. The
+ * destructure-rest pattern produces a new shallow copy per call —
+ * matches the discard-by-rest used in `api.items.listIndex` / `changes`.
+ */
+function toSkinny(row: ItemIndexRow | Item): ItemIndexRow {
+	if ('content' in row) {
+		const { content: _ignored, ...rest } = row as Item;
+		return rest as ItemIndexRow;
+	}
+	return row;
+}
+
+/**
+ * Cursors are decimal-encoded `seq` values as opaque strings — but
+ * "monotonic forward" needs a numeric compare, not lexicographic.
+ * Treat empty / non-numeric input as 0 so a fresh workspace's "0"
+ * cursor compares correctly against a real response's "12345".
+ */
+function cursorGte(a: string, b: string): boolean {
+	const an = Number(a);
+	const bn = Number(b);
+	const ai = Number.isFinite(an) ? an : 0;
+	const bi = Number.isFinite(bn) ? bn : 0;
+	return ai >= bi;
+}
+
+export const localIndex = {
+	/**
+	 * Hydrate a workspace from `/items-index`. Idempotent: returns the
+	 * same in-flight promise if already loading; resolves immediately
+	 * if already `ready`. On error the state flips to `'error'` and the
+	 * caller can retry by calling `bootstrap` again (the state is
+	 * cleared back to `cold` on retry-entry).
+	 */
+	async bootstrap(ws: string): Promise<void> {
+		const state = ensureState(ws);
+		if (state.bootstrapState === 'ready') return;
+		if (state.inflight) return state.inflight;
+
+		state.bootstrapState = 'loading';
+		state.inflight = (async () => {
+			try {
+				const resp = await api.items.listIndex(ws, { includeArchived: true });
+				// Replace, don't merge — bootstrap is the authoritative
+				// snapshot at this point. Anything in flight from SSE will
+				// be reconciled on the next applyDelta via seq ordering.
+				state.items.clear();
+				for (const row of resp.items) {
+					state.items.set(row.id, toSkinny(row));
+				}
+				state.cursor = resp.cursor;
+				state.bootstrapState = 'ready';
+			} catch (err) {
+				state.bootstrapState = 'error';
+				throw err;
+			} finally {
+				state.inflight = null;
+			}
+		})();
+
+		return state.inflight;
+	},
+
+	/**
+	 * Synchronous filtered read. Returns a freshly-allocated array on
+	 * every call; rely on `$derived` upstream for memoization.
+	 * Filters out items that are missing `collection_slug` (defensive —
+	 * the index endpoint always populates it, but a typed
+	 * non-null guard keeps the consumer code clean).
+	 */
+	getByCollection(ws: string, collSlug: string): ItemIndexRow[] {
+		const state = workspaces.get(ws);
+		if (!state) return [];
+		const out: ItemIndexRow[] = [];
+		for (const row of state.items.values()) {
+			if (row.collection_slug === collSlug) out.push(row);
+		}
+		return out;
+	},
+
+	/**
+	 * Apply a batch of changes from `/items-changes`. Upserts on
+	 * non-deleted rows, removes on `deleted: true`. Cursor only
+	 * advances forward — a server response that backslides (shouldn't
+	 * happen, but harmless to defend) is ignored at the cursor level.
+	 */
+	applyDelta(ws: string, changes: ItemChangeRow[], newCursor: string): void {
+		const state = ensureState(ws);
+		for (const change of changes) {
+			if (change.deleted) {
+				state.items.delete(change.id);
+			} else {
+				const { deleted: _d, ...row } = change;
+				state.items.set(change.id, toSkinny(row as ItemIndexRow));
+			}
+		}
+		if (cursorGte(newCursor, state.cursor)) {
+			state.cursor = newCursor;
+		}
+	},
+
+	/**
+	 * Single-item upsert. Used by SSE handlers and the optimistic
+	 * post-mutation path (e.g. after `api.items.update` returns a full
+	 * `Item`, the caller hands it here to keep the local index fresh
+	 * without waiting for the SSE round-trip). Does NOT touch the
+	 * cursor — that's the job of `applyDelta` / `applySSEEvent`.
+	 */
+	upsert(ws: string, row: ItemIndexRow | Item): void {
+		const state = ensureState(ws);
+		state.items.set(row.id, toSkinny(row));
+	},
+
+	/**
+	 * Single-item delete by id. Used by SSE archive/delete events and
+	 * the 403-purge path (TASK-1360). Idempotent — removing a missing
+	 * id is a no-op.
+	 */
+	remove(ws: string, id: string): void {
+		const state = workspaces.get(ws);
+		if (!state) return;
+		state.items.delete(id);
+	},
+
+	/** Current cursor for a workspace, or "0" if unhydrated. */
+	cursorFor(ws: string): string {
+		return workspaces.get(ws)?.cursor ?? '0';
+	},
+
+	/**
+	 * Current bootstrap state. Used by route loaders to decide whether
+	 * to render a spinner, the items, or an error. Returns `'cold'`
+	 * for unknown workspaces so first-visit consumers see a sane
+	 * initial value.
+	 */
+	bootstrapStateFor(ws: string): BootstrapState {
+		return workspaces.get(ws)?.bootstrapState ?? 'cold';
+	},
+
+	/**
+	 * Drop all state for a workspace. Used by the 403-purge path
+	 * (TASK-1360) when membership is revoked, and by the
+	 * sign-out flow to keep the next user from seeing the previous
+	 * user's cache. After reset, `bootstrap(ws)` from cold.
+	 */
+	reset(ws: string): void {
+		workspaces.delete(ws);
+	},
+
+	/** Number of items currently held for a workspace. Test/debug aid. */
+	size(ws: string): number {
+		return workspaces.get(ws)?.items.size ?? 0;
+	},
+};

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -424,6 +424,11 @@ export interface Item {
 	source: string;
 	created_at: string;
 	updated_at: string;
+	// `deleted_at` marks soft-deleted ("archived") items. Server `Item.DeletedAt`
+	// uses `omitempty` so this is undefined for live rows and a UTC string for
+	// archived ones. The local-first read model (PLAN-1343) keeps archived
+	// rows alongside live rows; consumers gate on this field at render time.
+	deleted_at?: string | null;
 	collection_slug?: string;
 	collection_name?: string;
 	collection_icon?: string;


### PR DESCRIPTION
## Summary
- New Svelte 5 store `web/src/lib/stores/localIndex.svelte.ts` that owns in-RAM truth for the local-first read model.
- Per-workspace state (SvelteMap of items, opaque seq cursor, bootstrap state) with a small public API: `bootstrap`, `getByCollection`, `applyDelta`, `upsert`, `remove`, `cursorFor`, `bootstrapStateFor`, `reset`.
- Defensive content-strip on every ingest so a caller can't leak `Item.content` into the skinny index.

## Context
Implements `TASK-1355` under `PLAN-1343` (Phase 2: IndexedDB local cache + delta sync). Per `DOC-1342` design decision #4: Svelte store canonical, IDB persistence-only. This task is the pure-in-memory layer; IDB hydration follows in `TASK-1356`.

## Test plan
- [x] `make check` — lint + Go tests + `npm run check` clean
- [x] No regressions in existing collection page (store not wired yet)
- [ ] Integration verified by `TASK-1357` (collection page wiring)