### PR TITLE
feat(web): IndexedDB persistence for localIndex (TASK-1356)

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -25,6 +25,7 @@
 				"@tiptap/y-tiptap": "^3.0.3",
 				"diff": "^9.0.0",
 				"dompurify": "^3.4.2",
+				"idb": "^8.0.3",
 				"lowlight": "^3.3.0",
 				"mermaid": "^11.14.0",
 				"qrcode": "^1.5.4",
@@ -2436,6 +2437,12 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
+		},
+		"node_modules/idb": {
+			"version": "8.0.3",
+			"resolved": "https://registry.npmjs.org/idb/-/idb-8.0.3.tgz",
+			"integrity": "sha512-LtwtVyVYO5BqRvcsKuB2iUMnHwPVByPCXFXOpuU96IZPPoPN6xjOGxZQ74pgSVVLQWtUOYgyeL4GE98BY5D3wg==",
+			"license": "ISC"
 		},
 		"node_modules/import-meta-resolve": {
 			"version": "4.2.0",

--- a/web/package.json
+++ b/web/package.json
@@ -48,6 +48,7 @@
 		"@tiptap/y-tiptap": "^3.0.3",
 		"diff": "^9.0.0",
 		"dompurify": "^3.4.2",
+		"idb": "^8.0.3",
 		"lowlight": "^3.3.0",
 		"mermaid": "^11.14.0",
 		"qrcode": "^1.5.4",

--- a/web/src/lib/stores/localIndex.svelte.ts
+++ b/web/src/lib/stores/localIndex.svelte.ts
@@ -263,14 +263,20 @@ export const localIndex = {
 					}
 					state.bootstrapState = 'ready';
 					// Best-effort persist the cold snapshot to IDB so
-					// the next visit is warm. Atomic so the cursor
-					// can never write without the rows that produced
-					// it (matches applyDelta's persist invariant).
-					persistDelta(
-						ws,
-						resp.items.map(toSkinny),
-						state.cursor,
-					).catch(() => undefined);
+					// the next visit is warm. We persist the POST-MERGE
+					// in-memory rows (not raw `resp.items`), and use
+					// the same atomic rows+cursor write applyDelta does.
+					// Otherwise an SSE/applyDelta that landed during the
+					// in-flight /items-index request could overwrite a
+					// newer row in IDB while the cursor on disk pointed
+					// past the gap, leaving the cache permanently stale
+					// (Codex P1 round 2). Iterating state.items.values()
+					// yields exactly the merged, winning rows.
+					const snapshot: ItemIndexRow[] = [];
+					for (const row of state.items.values()) snapshot.push(row);
+					persistDelta(ws, snapshot, state.cursor).catch(
+						() => undefined,
+					);
 				}
 			} catch (err) {
 				state.bootstrapState = 'error';

--- a/web/src/lib/stores/localIndex.svelte.ts
+++ b/web/src/lib/stores/localIndex.svelte.ts
@@ -40,11 +40,30 @@
 // `api.items.create` / `update`) cannot accidentally leak the rich
 // body into the local index.
 //
-// All operations except `bootstrap` are synchronous — readers don't
-// `await`, they just read.
+// All read operations are synchronous — consumers don't `await`,
+// they just read. `bootstrap` is async because it may hit IDB and
+// the network; mutation methods (`upsert`, `applyDelta`, `remove`)
+// are synchronous from the caller's perspective and write through
+// to IDB in the background (fire-and-forget, never throwing — see
+// `localIndexPersistence`).
+//
+// IDB persistence (TASK-1356): on bootstrap, hydrate from IDB FIRST
+// for an immediate paint, then call `/items-changes?since=<idb-cursor>`
+// to reconcile. On cache miss (IDB empty / unavailable), fall through
+// to the cold-path `/items-index` fetch. Every mutation writes through
+// to IDB so a reload picks up the latest state without a network
+// round-trip. Storage failures are silently swallowed — the store
+// keeps working in-memory.
 
 import { SvelteMap } from 'svelte/reactivity';
 import { api } from '$lib/api/client';
+import {
+	hydrate as persistHydrate,
+	persistCursor,
+	persistRemovals,
+	persistUpserts,
+	wipe as persistWipe,
+} from './localIndexPersistence';
 import type { Item, ItemChangeRow, ItemIndexRow } from '$lib/types';
 
 export type BootstrapState = 'cold' | 'loading' | 'ready' | 'error';
@@ -106,25 +125,57 @@ function cursorAsNum(c: string): number {
 	return Number.isFinite(n) ? n : 0;
 }
 
+/**
+ * Apply a single row to a workspace's items map with the per-row
+ * seq guard. Used by `bootstrap` (both warm and cold paths) and
+ * `upsert`/`applyDelta` indirectly via the existing inline logic.
+ * Returns true if the row was written, false if it was skipped as
+ * stale.
+ */
+function mergeRow(state: WorkspaceState, row: ItemIndexRow | Item): boolean {
+	const next = toSkinny(row);
+	const existing = state.items.get(next.id);
+	if (
+		existing?.seq !== undefined &&
+		next.seq !== undefined &&
+		next.seq <= existing.seq
+	) {
+		return false;
+	}
+	state.items.set(next.id, next);
+	return true;
+}
+
 export const localIndex = {
 	/**
-	 * Hydrate a workspace from `/items-index`. Idempotent: returns the
-	 * same in-flight promise if already loading; resolves immediately
-	 * if already `ready`. On error the state flips to `'error'` and
-	 * the caller can retry by calling `bootstrap` again — the next
-	 * call sees `bootstrapState === 'error'` and proceeds. Archived
-	 * items are included in the snapshot (the store is the canonical
-	 * read model for both live and archived rows; consumers filter
-	 * via `{ includeArchived }`).
+	 * Hydrate a workspace. Idempotent: returns the same in-flight
+	 * promise if already loading; resolves immediately if already
+	 * `'ready'`. On error the state flips to `'error'` and the caller
+	 * can retry by calling `bootstrap` again. Archived items are
+	 * included (the store is the canonical read model for both live
+	 * and archived rows; consumers filter via `{ includeArchived }`).
 	 *
-	 * Merge, don't clear. An optimistic `upsert()` or an SSE-driven
-	 * write can land while the /items-index request is in flight; if
-	 * we cleared and replaced, we'd silently regress those rows to
-	 * the older snapshot value (Codex P2 round 3). Instead, we
-	 * MERGE each response row through the same per-row seq guard
-	 * `upsert` uses, and the cursor only advances forward. The
-	 * cleared-state semantic isn't needed in practice because
-	 * `reset()` is the explicit "drop everything" entry point.
+	 * Two-stage flow (TASK-1356):
+	 *
+	 *   1. WARM PATH — hydrate from IDB. If the cache is populated,
+	 *      copy rows into the in-RAM store, set the cursor from the
+	 *      meta row, and flip `bootstrapState` to `'ready'` *before*
+	 *      any network IO. The UI paints instantly. Then kick off
+	 *      `/items-changes?since=<cursor>` in the background and
+	 *      apply the deltas via `applyDelta` (which write-throughs to
+	 *      IDB on its own). A failed delta-sync doesn't move state
+	 *      back to `'loading'` — the UI keeps working off the cached
+	 *      data and the next reconnect retries.
+	 *
+	 *   2. COLD PATH — IDB miss / unavailable. Fall through to the
+	 *      classic `/items-index` snapshot, then write the result to
+	 *      IDB so the next visit is warm.
+	 *
+	 * Merge-not-clear semantics are preserved: in either path, rows
+	 * are MERGED through the same per-row seq guard `upsert` uses,
+	 * and the cursor only advances forward. An optimistic `upsert()`
+	 * or SSE write that landed while bootstrap was in flight is
+	 * never regressed.
 	 */
 	async bootstrap(ws: string): Promise<void> {
 		const state = ensureState(ws);
@@ -135,27 +186,52 @@ export const localIndex = {
 		state.bootstrapState = 'loading';
 		const p = (async () => {
 			try {
-				const resp = await api.items.listIndex(ws, { includeArchived: true });
-				for (const row of resp.items) {
-					const next = toSkinny(row);
-					const existing = state.items.get(row.id);
-					if (
-						existing?.seq !== undefined &&
-						next.seq !== undefined &&
-						next.seq <= existing.seq
-					) {
-						continue;
+				// Stage 1: warm path. Always try IDB first.
+				const cached = await persistHydrate(ws);
+				const hasCache = cached.items.length > 0;
+				if (hasCache) {
+					for (const row of cached.items) {
+						mergeRow(state, row);
 					}
-					state.items.set(row.id, next);
+					if (cursorAsNum(cached.cursor) > cursorAsNum(state.cursor)) {
+						state.cursor = cached.cursor;
+					}
+					// Flip to ready immediately — the UI paints from
+					// the cache while delta-sync runs.
+					state.bootstrapState = 'ready';
 				}
-				// Cursor moves forward only. A fresh /items-index can
-				// occasionally return a cursor below the in-RAM one
-				// (e.g. an SSE delta advanced it during the request);
-				// don't backslide.
-				if (cursorAsNum(resp.cursor) > cursorAsNum(state.cursor)) {
-					state.cursor = resp.cursor;
+
+				if (hasCache) {
+					// Reconcile cache against server via /items-changes.
+					// Errors here are non-fatal — the cache is the
+					// floor and the next reconnect retries.
+					try {
+						const delta = await api.items.changes(ws, state.cursor);
+						if (delta.changes.length > 0 || delta.cursor !== state.cursor) {
+							localIndex.applyDelta(ws, delta.changes, delta.cursor);
+						}
+					} catch {
+						/* swallow — cache stands, retry on reconnect */
+					}
+				} else {
+					// Stage 2: cold path. /items-index full snapshot.
+					const resp = await api.items.listIndex(ws, {
+						includeArchived: true,
+					});
+					for (const row of resp.items) {
+						mergeRow(state, row);
+					}
+					if (cursorAsNum(resp.cursor) > cursorAsNum(state.cursor)) {
+						state.cursor = resp.cursor;
+					}
+					state.bootstrapState = 'ready';
+					// Best-effort persist the cold snapshot to IDB so
+					// the next visit is warm.
+					persistUpserts(ws, resp.items.map(toSkinny)).catch(
+						() => undefined,
+					);
+					persistCursor(ws, state.cursor).catch(() => undefined);
 				}
-				state.bootstrapState = 'ready';
 			} catch (err) {
 				state.bootstrapState = 'error';
 				throw err;
@@ -253,6 +329,7 @@ export const localIndex = {
 		// Guard 1: whole-batch drop on non-advancing cursor.
 		if (newCursorNum <= startCursorNum) return;
 
+		const written: ItemIndexRow[] = [];
 		for (const change of changes) {
 			if (change.seq !== undefined) {
 				// Guard 2: row's seq vs. cursor floor.
@@ -274,10 +351,18 @@ export const localIndex = {
 			// only manages the seq-ordered identity of the row. Hard
 			// deletes (workspace GC / 403 purge) go through the
 			// `remove()` method, not through this batch path.
-			const { deleted: _d, ...row } = change;
-			state.items.set(change.id, toSkinny(row as ItemIndexRow));
+			const { deleted: _d, ...rest } = change;
+			const skinny = toSkinny(rest as ItemIndexRow);
+			state.items.set(change.id, skinny);
+			written.push(skinny);
 		}
 		state.cursor = newCursor;
+		// Write-through to IDB. Fire-and-forget; storage failures
+		// degrade to in-memory only and never break the read path.
+		if (written.length > 0) {
+			persistUpserts(ws, written).catch(() => undefined);
+		}
+		persistCursor(ws, newCursor).catch(() => undefined);
 	},
 
 	/**
@@ -307,6 +392,9 @@ export const localIndex = {
 			return;
 		}
 		state.items.set(row.id, next);
+		// Write-through to IDB. Fire-and-forget; storage failures
+		// degrade silently.
+		persistUpserts(ws, [next]).catch(() => undefined);
 	},
 
 	/**
@@ -318,6 +406,8 @@ export const localIndex = {
 		const state = workspaces.get(ws);
 		if (!state) return;
 		state.items.delete(id);
+		// Write-through hard-delete to IDB.
+		persistRemovals(ws, [id]).catch(() => undefined);
 	},
 
 	/** Current cursor for a workspace, or "0" if unhydrated. */
@@ -344,6 +434,10 @@ export const localIndex = {
 	reset(ws: string): void {
 		workspaces.delete(ws);
 		inflight.delete(ws);
+		// Drop the persisted cache too — the 403-purge / sign-out
+		// path uses this method, and leaving stale rows on disk
+		// would defeat the point. Fire-and-forget.
+		persistWipe(ws).catch(() => undefined);
 	},
 
 	/** Number of items currently held for a workspace. Test/debug aid. */

--- a/web/src/lib/stores/localIndex.svelte.ts
+++ b/web/src/lib/stores/localIndex.svelte.ts
@@ -230,7 +230,19 @@ export const localIndex = {
 		// namespace. Pass null explicitly for pre-auth / public-share
 		// flows. Codex P? (round 4) caught the leak risk.
 		state.userId = opts.userId;
-		state.bootstrapState = 'loading';
+		// Capture reentry BEFORE flipping bootstrapState to 'loading'
+		// — otherwise the `state.bootstrapState === 'ready'` check
+		// below always reads false and the warm IDB hydrate runs again
+		// on a pendingResync retry. That's bad because IDB writes are
+		// fire-and-forget; re-reading rows whose RAM copy was just
+		// removed but whose IDB delete hasn't landed would resurrect
+		// them. Codex P2 round 7.
+		const reentry =
+			state.bootstrapState === 'ready' && state.pendingResync;
+		// Only flip to 'loading' for first-time bootstrap. A reentry
+		// keeps state='ready' throughout so the UI never blanks while
+		// retrying the reconcile.
+		if (!reentry) state.bootstrapState = 'loading';
 		// Capture the generation at start. If `reset()` runs during
 		// any await below, generation bumps; we then bail out before
 		// re-applying rows or writing the snapshot back, otherwise
@@ -239,13 +251,18 @@ export const localIndex = {
 		const userId = state.userId;
 		const isStale = () => state.generation !== bootstrapGen;
 
-		const p = (async () => {
+		// `slot.p` holds the in-flight promise so the IIFE body's
+		// `finally` can do an identity check against it — see Codex
+		// round 7 P2. We need a level of indirection (the object)
+		// because a bare `const p = ...` puts `p` in the TDZ when the
+		// suspended async body resumes and references it.
+		const slot: { p: Promise<void> | null } = { p: null };
+		slot.p = (async () => {
 			try {
 				// Stage 1: warm path. Always try IDB first. Skip
-				// re-hydration when state is already 'ready' (re-entry
-				// from a `pendingResync` retry); we just need to redo
-				// the reconcile.
-				const reentry = state.bootstrapState === 'ready';
+				// re-hydration when this is a `pendingResync` retry —
+				// the in-RAM state is already authoritative for this
+				// session; we just need to redo the reconcile.
 				const cached = reentry
 					? { items: [], cursor: state.cursor }
 					: await persistHydrate(userId, ws);
@@ -373,11 +390,18 @@ export const localIndex = {
 				state.bootstrapState = 'error';
 				throw err;
 			} finally {
-				inflight.delete(ws);
+				// Identity-checked cleanup: only clear inflight if
+				// THIS promise is the registered one. After a
+				// `reset()` mid-bootstrap, a fresh bootstrap call can
+				// re-occupy the slot before this stale promise's
+				// `finally` runs; deleting unconditionally would
+				// remove the new entry and let a duplicate bootstrap
+				// start (Codex P2 round 7).
+				if (slot.p && inflight.get(ws) === slot.p) inflight.delete(ws);
 			}
 		})();
-		inflight.set(ws, p);
-		return p;
+		inflight.set(ws, slot.p);
+		return slot.p;
 	},
 
 	/**

--- a/web/src/lib/stores/localIndex.svelte.ts
+++ b/web/src/lib/stores/localIndex.svelte.ts
@@ -195,14 +195,18 @@ export const localIndex = {
 	 */
 	async bootstrap(
 		ws: string,
-		opts?: { userId?: string | null },
+		opts: { userId: string | null },
 	): Promise<void> {
 		const state = ensureState(ws);
 		if (state.bootstrapState === 'ready') return;
 		const pending = inflight.get(ws);
 		if (pending) return pending;
 
-		state.userId = opts?.userId ?? null;
+		// `userId` is REQUIRED (not defaulted) so authenticated callers
+		// can't silently land their cache in the shared `anon`
+		// namespace. Pass null explicitly for pre-auth / public-share
+		// flows. Codex P? (round 4) caught the leak risk.
+		state.userId = opts.userId;
 		state.bootstrapState = 'loading';
 		// Capture the generation at start. If `reset()` runs during
 		// any await below, generation bumps; we then bail out before
@@ -407,7 +411,7 @@ export const localIndex = {
 		// Guard 1: whole-batch drop on non-advancing cursor.
 		if (newCursorNum <= startCursorNum) return;
 
-		const written: ItemIndexRow[] = [];
+		const toPersist: ItemIndexRow[] = [];
 		for (const change of changes) {
 			if (change.seq !== undefined) {
 				// Guard 2: row's seq vs. cursor floor.
@@ -418,6 +422,14 @@ export const localIndex = {
 					existing?.seq !== undefined &&
 					change.seq <= existing.seq
 				) {
+					// Existing wins in RAM. Include it in the
+					// persist set so the IDB cursor we're about
+					// to advance doesn't lap a row that may not
+					// be durable yet (upsert's fire-and-forget
+					// IDB write could still be pending / failed
+					// — Codex P? round 4). One redundant put is
+					// cheaper than a missing row on warm boot.
+					toPersist.push(existing);
 					continue;
 				}
 			}
@@ -432,7 +444,7 @@ export const localIndex = {
 			const { deleted: _d, ...rest } = change;
 			const skinny = toSkinny(rest as ItemIndexRow);
 			state.items.set(change.id, skinny);
-			written.push(skinny);
+			toPersist.push(skinny);
 		}
 		state.cursor = newCursor;
 		// Write-through to IDB. ATOMIC: rows + cursor land in a
@@ -442,7 +454,7 @@ export const localIndex = {
 		// in-memory only and never break the read path. Routed
 		// through the workspace's captured `userId` so a different
 		// user signing into the same browser sees their own cache.
-		persistDelta(state.userId, ws, written, newCursor).catch(
+		persistDelta(state.userId, ws, toPersist, newCursor).catch(
 			() => undefined,
 		);
 	},

--- a/web/src/lib/stores/localIndex.svelte.ts
+++ b/web/src/lib/stores/localIndex.svelte.ts
@@ -82,9 +82,9 @@ class WorkspaceState {
 	bootstrapState = $state<BootstrapState>('cold');
 
 	// `userId` is captured on first bootstrap and used to scope the
-	// IDB database name. Null = anonymous (pre-auth bootstrap). It
-	// never changes once set — a different user signing in goes
-	// through `reset()` first, dropping the state.
+	// IDB database name. Null = anonymous (pre-auth bootstrap). A
+	// later bootstrap call with a different userId triggers a reset
+	// (see `bootstrap`) so we never mix caches across users.
 	userId: string | null = null;
 
 	// `generation` is bumped on every `reset()`. Bootstrap captures
@@ -95,6 +95,14 @@ class WorkspaceState {
 	// completed snapshot resurrect just-purged rows (Codex P1
 	// round 3).
 	generation = 0;
+
+	// `pendingResync` is true when the warm-cache path hydrated rows
+	// from IDB but the follow-up /items-changes reconcile didn't
+	// complete (transient network blip). The cache is usable —
+	// `bootstrapState` is `'ready'` so the UI renders — but a later
+	// `bootstrap()` call will retry the delta sync instead of
+	// no-opping. Cleared on successful sync. Codex P2 round 5.
+	pendingResync = $state(false);
 }
 
 // Outer map: reactive (SvelteMap) so consumers re-render when a fresh
@@ -197,8 +205,23 @@ export const localIndex = {
 		ws: string,
 		opts: { userId: string | null },
 	): Promise<void> {
+		// User-mismatch reset BEFORE the early-return checks. Otherwise
+		// a different user signing into the same browser would inherit
+		// the previous user's `ready` state and in-flight promise
+		// (Codex P1 round 5). `ensureState` auto-creates a fresh
+		// WorkspaceState after the reset.
+		const prior = workspaces.get(ws);
+		if (prior && prior.bootstrapState !== 'cold' && prior.userId !== opts.userId) {
+			localIndex.reset(ws);
+		}
+
 		const state = ensureState(ws);
-		if (state.bootstrapState === 'ready') return;
+		// Early return for already-ready states ONLY when there's no
+		// outstanding resync work. A transient delta-sync failure
+		// (network blip) leaves `pendingResync = true`; the next
+		// bootstrap call must retry the reconcile, not no-op. Codex P2
+		// round 5.
+		if (state.bootstrapState === 'ready' && !state.pendingResync) return;
 		const pending = inflight.get(ws);
 		if (pending) return pending;
 
@@ -218,11 +241,17 @@ export const localIndex = {
 
 		const p = (async () => {
 			try {
-				// Stage 1: warm path. Always try IDB first.
-				const cached = await persistHydrate(userId, ws);
+				// Stage 1: warm path. Always try IDB first. Skip
+				// re-hydration when state is already 'ready' (re-entry
+				// from a `pendingResync` retry); we just need to redo
+				// the reconcile.
+				const reentry = state.bootstrapState === 'ready';
+				const cached = reentry
+					? { items: [], cursor: state.cursor }
+					: await persistHydrate(userId, ws);
 				if (isStale()) return;
-				const hasCache = cached.items.length > 0;
-				if (hasCache) {
+				const hasCache = reentry || cached.items.length > 0;
+				if (!reentry && cached.items.length > 0) {
 					for (const row of cached.items) {
 						mergeRow(state, row);
 					}
@@ -230,8 +259,10 @@ export const localIndex = {
 						state.cursor = cached.cursor;
 					}
 					// Flip to ready immediately — the UI paints from
-					// the cache while delta-sync runs.
+					// the cache while delta-sync runs. `pendingResync`
+					// stays true until the reconcile finishes.
 					state.bootstrapState = 'ready';
+					state.pendingResync = true;
 				}
 
 				if (hasCache) {
@@ -269,6 +300,8 @@ export const localIndex = {
 							localIndex.applyDelta(ws, delta.changes, delta.cursor);
 							if (delta.cursor === since) break;
 						}
+						// Reconcile succeeded — cache is fresh as of now.
+						state.pendingResync = false;
 					} catch (err) {
 						if (isStale()) return;
 						if (err instanceof PadApiError && err.code === 'forbidden') {
@@ -277,12 +310,20 @@ export const localIndex = {
 							// (and any registered 403 handler from
 							// TASK-1360) can react.
 							state.bootstrapState = 'error';
+							state.pendingResync = false;
 							state.items.clear();
 							state.cursor = '0';
 							persistWipe(userId, ws).catch(() => undefined);
 							throw err;
 						}
-						/* swallow — cache stands, retry on reconnect */
+						// Transient network failure. Cache stands and
+						// state stays 'ready' so the UI keeps working.
+						// `pendingResync` remains true so the next
+						// bootstrap() call retries (Codex P2 round 5).
+						// Permission revocation that doesn't change
+						// row data is NOT covered here — TASK-1360 and
+						// DOC-1342 decision #3 explicitly punt that in
+						// favor of the 403-on-click purge path.
 					}
 				} else {
 					// Stage 2: cold path. /items-index full snapshot.
@@ -297,6 +338,8 @@ export const localIndex = {
 						state.cursor = resp.cursor;
 					}
 					state.bootstrapState = 'ready';
+					// Cold path is a full snapshot — nothing pending.
+					state.pendingResync = false;
 					// Best-effort persist the cold snapshot to IDB so
 					// the next visit is warm. We persist the POST-MERGE
 					// in-memory rows (not raw `resp.items`), and use

--- a/web/src/lib/stores/localIndex.svelte.ts
+++ b/web/src/lib/stores/localIndex.svelte.ts
@@ -57,9 +57,10 @@
 
 import { SvelteMap } from 'svelte/reactivity';
 import { api } from '$lib/api/client';
+import { PadApiError } from '$lib/api/client';
 import {
 	hydrate as persistHydrate,
-	persistCursor,
+	persistDelta,
 	persistRemovals,
 	persistUpserts,
 	wipe as persistWipe,
@@ -203,14 +204,50 @@ export const localIndex = {
 
 				if (hasCache) {
 					// Reconcile cache against server via /items-changes.
-					// Errors here are non-fatal — the cache is the
-					// floor and the next reconnect retries.
+					// The endpoint is capped at DefaultItemChangesLimit
+					// (5000) per response, so we loop until the cursor
+					// stops advancing — otherwise a cache that's
+					// behind by more than one page would only catch
+					// up by 5000 rows and then `bootstrapState` would
+					// pin at `ready` forever, with no later trigger
+					// to fetch the rest (Codex P2 round 1).
+					//
+					// Auth/authz failures (403) must NOT be swallowed
+					// — the cache is stale-by-permission and showing
+					// it as live is a real correctness bug. Re-throw
+					// 403 so the registered access-revoked handler
+					// (TASK-1360) sees it; the cache reset is its job.
+					// Other network blips are non-fatal — the cache
+					// stands and the next reconnect retries.
 					try {
-						const delta = await api.items.changes(ws, state.cursor);
-						if (delta.changes.length > 0 || delta.cursor !== state.cursor) {
+						// Cap iterations defensively — a healthy server
+						// drains in < 10 pages even for huge gaps; if
+						// something pathological loops without cursor
+						// advance, give up after 50 and let the user's
+						// next visit retry.
+						for (let i = 0; i < 50; i++) {
+							const since = state.cursor;
+							const delta = await api.items.changes(ws, since);
+							if (delta.changes.length === 0 || delta.cursor === since) {
+								// Server returned no new rows AND no
+								// cursor advance — we're caught up.
+								break;
+							}
 							localIndex.applyDelta(ws, delta.changes, delta.cursor);
+							if (delta.cursor === since) break;
 						}
-					} catch {
+					} catch (err) {
+						if (err instanceof PadApiError && err.code === 'forbidden') {
+							// Cache is stale-by-permission. Drop it
+							// here AND surface the error so the caller
+							// (and any registered 403 handler from
+							// TASK-1360) can react.
+							state.bootstrapState = 'error';
+							state.items.clear();
+							state.cursor = '0';
+							persistWipe(ws).catch(() => undefined);
+							throw err;
+						}
 						/* swallow — cache stands, retry on reconnect */
 					}
 				} else {
@@ -226,11 +263,14 @@ export const localIndex = {
 					}
 					state.bootstrapState = 'ready';
 					// Best-effort persist the cold snapshot to IDB so
-					// the next visit is warm.
-					persistUpserts(ws, resp.items.map(toSkinny)).catch(
-						() => undefined,
-					);
-					persistCursor(ws, state.cursor).catch(() => undefined);
+					// the next visit is warm. Atomic so the cursor
+					// can never write without the rows that produced
+					// it (matches applyDelta's persist invariant).
+					persistDelta(
+						ws,
+						resp.items.map(toSkinny),
+						state.cursor,
+					).catch(() => undefined);
 				}
 			} catch (err) {
 				state.bootstrapState = 'error';
@@ -357,12 +397,12 @@ export const localIndex = {
 			written.push(skinny);
 		}
 		state.cursor = newCursor;
-		// Write-through to IDB. Fire-and-forget; storage failures
-		// degrade to in-memory only and never break the read path.
-		if (written.length > 0) {
-			persistUpserts(ws, written).catch(() => undefined);
-		}
-		persistCursor(ws, newCursor).catch(() => undefined);
+		// Write-through to IDB. ATOMIC: rows + cursor land in a
+		// single transaction so the persisted cursor can never
+		// advance past rows that didn't make it to disk (Codex P2
+		// round 1). Fire-and-forget; storage failures degrade to
+		// in-memory only and never break the read path.
+		persistDelta(ws, written, newCursor).catch(() => undefined);
 	},
 
 	/**

--- a/web/src/lib/stores/localIndex.svelte.ts
+++ b/web/src/lib/stores/localIndex.svelte.ts
@@ -288,6 +288,7 @@ export const localIndex = {
 						// something pathological loops without cursor
 						// advance, give up after 50 and let the user's
 						// next visit retry.
+						let caughtUp = false;
 						for (let i = 0; i < 50; i++) {
 							const since = state.cursor;
 							const delta = await api.items.changes(ws, since);
@@ -295,13 +296,24 @@ export const localIndex = {
 							if (delta.changes.length === 0 || delta.cursor === since) {
 								// Server returned no new rows AND no
 								// cursor advance — we're caught up.
+								caughtUp = true;
 								break;
 							}
 							localIndex.applyDelta(ws, delta.changes, delta.cursor);
-							if (delta.cursor === since) break;
+							if (delta.cursor === since) {
+								caughtUp = true;
+								break;
+							}
 						}
-						// Reconcile succeeded — cache is fresh as of now.
-						state.pendingResync = false;
+						// Only mark fresh if the loop reached the
+						// server cursor. Hitting the 50-page cap
+						// without catching up leaves `pendingResync`
+						// true so a later bootstrap call resumes
+						// (Codex P2 round 6). 50 × 5000 = 250,000
+						// rows; we don't expect to hit this in practice
+						// but it's the difference between "stale
+						// forever" and "next visit retries".
+						if (caughtUp) state.pendingResync = false;
 					} catch (err) {
 						if (isStale()) return;
 						if (err instanceof PadApiError && err.code === 'forbidden') {

--- a/web/src/lib/stores/localIndex.svelte.ts
+++ b/web/src/lib/stores/localIndex.svelte.ts
@@ -267,8 +267,16 @@ export const localIndex = {
 					? { items: [], cursor: state.cursor }
 					: await persistHydrate(userId, ws);
 				if (isStale()) return;
-				const hasCache = reentry || cached.items.length > 0;
-				if (!reentry && cached.items.length > 0) {
+				// A populated cache is one we've successfully synced
+				// from before — either there are rows, or the cursor
+				// has moved off the "0" floor (empty workspaces /
+				// guests with item-level grants legitimately have
+				// zero rows but a real cursor). Both deserve the
+				// warm-path fast boot. Codex P2 round 8.
+				const cacheIsPopulated =
+					cached.items.length > 0 || cursorAsNum(cached.cursor) > 0;
+				const hasCache = reentry || cacheIsPopulated;
+				if (!reentry && cacheIsPopulated) {
 					for (const row of cached.items) {
 						mergeRow(state, row);
 					}
@@ -333,11 +341,18 @@ export const localIndex = {
 						if (caughtUp) state.pendingResync = false;
 					} catch (err) {
 						if (isStale()) return;
-						if (err instanceof PadApiError && err.code === 'forbidden') {
-							// Cache is stale-by-permission. Drop it
-							// here AND surface the error so the caller
-							// (and any registered 403 handler from
-							// TASK-1360) can react.
+						// 401 (unauthorized — session expired) and 403
+						// (forbidden — access revoked) both mean the
+						// cached rows are no longer ours to display.
+						// Drop the cache and re-throw so the caller's
+						// redirect / purge handler can react. Other
+						// errors stay transient — cache stands and the
+						// next bootstrap() call retries the reconcile
+						// because `pendingResync` is still true.
+						if (
+							err instanceof PadApiError &&
+							(err.code === 'forbidden' || err.code === 'unauthorized')
+						) {
 							state.bootstrapState = 'error';
 							state.pendingResync = false;
 							state.items.clear();

--- a/web/src/lib/stores/localIndex.svelte.ts
+++ b/web/src/lib/stores/localIndex.svelte.ts
@@ -80,6 +80,21 @@ class WorkspaceState {
 	items: SvelteMap<string, ItemIndexRow> = new SvelteMap();
 	cursor = $state('0');
 	bootstrapState = $state<BootstrapState>('cold');
+
+	// `userId` is captured on first bootstrap and used to scope the
+	// IDB database name. Null = anonymous (pre-auth bootstrap). It
+	// never changes once set — a different user signing in goes
+	// through `reset()` first, dropping the state.
+	userId: string | null = null;
+
+	// `generation` is bumped on every `reset()`. Bootstrap captures
+	// the value at start; if it advances during an await, the
+	// in-flight bootstrap bails out instead of writing/reapplying
+	// rows that belong to a stale identity. Without this, a sign-out
+	// or 403 purge during a slow /items-index request would let the
+	// completed snapshot resurrect just-purged rows (Codex P1
+	// round 3).
+	generation = 0;
 }
 
 // Outer map: reactive (SvelteMap) so consumers re-render when a fresh
@@ -178,17 +193,30 @@ export const localIndex = {
 	 * or SSE write that landed while bootstrap was in flight is
 	 * never regressed.
 	 */
-	async bootstrap(ws: string): Promise<void> {
+	async bootstrap(
+		ws: string,
+		opts?: { userId?: string | null },
+	): Promise<void> {
 		const state = ensureState(ws);
 		if (state.bootstrapState === 'ready') return;
 		const pending = inflight.get(ws);
 		if (pending) return pending;
 
+		state.userId = opts?.userId ?? null;
 		state.bootstrapState = 'loading';
+		// Capture the generation at start. If `reset()` runs during
+		// any await below, generation bumps; we then bail out before
+		// re-applying rows or writing the snapshot back, otherwise
+		// purged data could resurrect (Codex P1 round 3).
+		const bootstrapGen = state.generation;
+		const userId = state.userId;
+		const isStale = () => state.generation !== bootstrapGen;
+
 		const p = (async () => {
 			try {
 				// Stage 1: warm path. Always try IDB first.
-				const cached = await persistHydrate(ws);
+				const cached = await persistHydrate(userId, ws);
+				if (isStale()) return;
 				const hasCache = cached.items.length > 0;
 				if (hasCache) {
 					for (const row of cached.items) {
@@ -228,6 +256,7 @@ export const localIndex = {
 						for (let i = 0; i < 50; i++) {
 							const since = state.cursor;
 							const delta = await api.items.changes(ws, since);
+							if (isStale()) return;
 							if (delta.changes.length === 0 || delta.cursor === since) {
 								// Server returned no new rows AND no
 								// cursor advance — we're caught up.
@@ -237,6 +266,7 @@ export const localIndex = {
 							if (delta.cursor === since) break;
 						}
 					} catch (err) {
+						if (isStale()) return;
 						if (err instanceof PadApiError && err.code === 'forbidden') {
 							// Cache is stale-by-permission. Drop it
 							// here AND surface the error so the caller
@@ -245,7 +275,7 @@ export const localIndex = {
 							state.bootstrapState = 'error';
 							state.items.clear();
 							state.cursor = '0';
-							persistWipe(ws).catch(() => undefined);
+							persistWipe(userId, ws).catch(() => undefined);
 							throw err;
 						}
 						/* swallow — cache stands, retry on reconnect */
@@ -255,6 +285,7 @@ export const localIndex = {
 					const resp = await api.items.listIndex(ws, {
 						includeArchived: true,
 					});
+					if (isStale()) return;
 					for (const row of resp.items) {
 						mergeRow(state, row);
 					}
@@ -274,11 +305,12 @@ export const localIndex = {
 					// yields exactly the merged, winning rows.
 					const snapshot: ItemIndexRow[] = [];
 					for (const row of state.items.values()) snapshot.push(row);
-					persistDelta(ws, snapshot, state.cursor).catch(
+					persistDelta(userId, ws, snapshot, state.cursor).catch(
 						() => undefined,
 					);
 				}
 			} catch (err) {
+				if (isStale()) return;
 				state.bootstrapState = 'error';
 				throw err;
 			} finally {
@@ -407,8 +439,12 @@ export const localIndex = {
 		// single transaction so the persisted cursor can never
 		// advance past rows that didn't make it to disk (Codex P2
 		// round 1). Fire-and-forget; storage failures degrade to
-		// in-memory only and never break the read path.
-		persistDelta(ws, written, newCursor).catch(() => undefined);
+		// in-memory only and never break the read path. Routed
+		// through the workspace's captured `userId` so a different
+		// user signing into the same browser sees their own cache.
+		persistDelta(state.userId, ws, written, newCursor).catch(
+			() => undefined,
+		);
 	},
 
 	/**
@@ -440,7 +476,7 @@ export const localIndex = {
 		state.items.set(row.id, next);
 		// Write-through to IDB. Fire-and-forget; storage failures
 		// degrade silently.
-		persistUpserts(ws, [next]).catch(() => undefined);
+		persistUpserts(state.userId, ws, [next]).catch(() => undefined);
 	},
 
 	/**
@@ -453,7 +489,7 @@ export const localIndex = {
 		if (!state) return;
 		state.items.delete(id);
 		// Write-through hard-delete to IDB.
-		persistRemovals(ws, [id]).catch(() => undefined);
+		persistRemovals(state.userId, ws, [id]).catch(() => undefined);
 	},
 
 	/** Current cursor for a workspace, or "0" if unhydrated. */
@@ -478,12 +514,26 @@ export const localIndex = {
 	 * user's cache. After reset, `bootstrap(ws)` from cold.
 	 */
 	reset(ws: string): void {
+		const prior = workspaces.get(ws);
+		// Bump generation on the prior state object BEFORE deleting
+		// it from the map. Any in-flight bootstrap promise still holds
+		// a reference to `prior` — checking `state.generation !==
+		// bootstrapGen` after each await lets it bail out instead of
+		// writing or re-applying rows that belong to a stale identity
+		// (Codex P1 round 3). Without this, a sign-out / 403 purge
+		// during a slow /items-index request could resurrect just-
+		// purged rows when the snapshot resolved.
+		const priorUserId = prior?.userId ?? null;
+		if (prior) prior.generation += 1;
+
 		workspaces.delete(ws);
 		inflight.delete(ws);
-		// Drop the persisted cache too — the 403-purge / sign-out
-		// path uses this method, and leaving stale rows on disk
-		// would defeat the point. Fire-and-forget.
-		persistWipe(ws).catch(() => undefined);
+
+		// Drop the persisted cache for the workspace's last-known
+		// userId. If a different user later bootstraps the same
+		// workspace, their cache is in a different IDB namespace and
+		// remains untouched, by design.
+		persistWipe(priorUserId, ws).catch(() => undefined);
 	},
 
 	/** Number of items currently held for a workspace. Test/debug aid. */

--- a/web/src/lib/stores/localIndexPersistence.ts
+++ b/web/src/lib/stores/localIndexPersistence.ts
@@ -5,8 +5,15 @@
 // reader path is unaffected — consumers always go through localIndex,
 // never through this module directly.
 //
-// Database shape: one IDB database per workspace, named
-// `pad-local-index-{wsSlug}`. Two object stores:
+// Database shape: one IDB database per (user, workspace) pair, named
+// `pad-local-index-{userId}-{wsSlug}`. Scoping by user is required —
+// the cache is what the user could see last sync, and if a different
+// user signs into the same browser, exposing the previous user's
+// view would be a real correctness/permission leak. Anonymous /
+// bootstrap-time callers (with no user id yet) use the `anon`
+// namespace; those caches are independent of any signed-in user.
+//
+// Two object stores:
 //
 //   items  (keyPath: 'id')   — ItemIndexRow rows, keyed by item.id
 //   meta   (keyPath: 'key')  — { key: 'sync', cursor, schemaVersion }
@@ -52,28 +59,47 @@ interface MetaRow {
 	schemaVersion: number;
 }
 
-// Open IDB connections are cached per workspace. Reopening is a real
-// cost (page-load latency) and only matters when the persistence layer
-// is actually used — most of the test surface lives in memory.
+// Open IDB connections are cached per (user, workspace) pair. The
+// map key matches `dbName()` so cache slots can't collide across
+// user namespaces.
 const dbs = new Map<string, IDBPDatabase>();
 
 function isSupported(): boolean {
 	return typeof indexedDB !== 'undefined';
 }
 
-function dbName(ws: string): string {
-	return `pad-local-index-${ws}`;
+/**
+ * Encode a value so it's safe to embed in an IDB database name.
+ * Names allow any UTF-16 string per spec, but URL-encoding keeps
+ * the on-disk handle predictable in dev tools and avoids surprises
+ * from exotic IDs.
+ */
+function safe(s: string): string {
+	return encodeURIComponent(s);
+}
+
+function dbName(userId: string | null, ws: string): string {
+	const ns = userId ? safe(userId) : 'anon';
+	return `pad-local-index-${ns}-${safe(ws)}`;
+}
+
+function key(userId: string | null, ws: string): string {
+	return dbName(userId, ws);
 }
 
 /**
- * Open the workspace's IDB database, creating object stores on
- * first run. Cached so subsequent calls reuse the connection.
- * Returns null on any storage failure — callers must treat that as
- * "no cache available, fall back to network".
+ * Open the workspace's IDB database for the given user, creating
+ * object stores on first run. Cached so subsequent calls reuse the
+ * connection. Returns null on any storage failure — callers must
+ * treat that as "no cache available, fall back to network".
  */
-async function open(ws: string): Promise<IDBPDatabase | null> {
+async function open(
+	userId: string | null,
+	ws: string,
+): Promise<IDBPDatabase | null> {
 	if (!isSupported()) return null;
-	const cached = dbs.get(ws);
+	const k = key(userId, ws);
+	const cached = dbs.get(k);
 	if (cached) return cached;
 
 	try {
@@ -81,7 +107,7 @@ async function open(ws: string): Promise<IDBPDatabase | null> {
 		// for migrations). We pin it to 1 and use our own
 		// `schemaVersion` row in `meta` for content-shape versioning.
 		// That keeps schema bumps decoupled from idb library quirks.
-		const db = await openDB(dbName(ws), 1, {
+		const db = await openDB(dbName(userId, ws), 1, {
 			upgrade(db) {
 				if (!db.objectStoreNames.contains('items')) {
 					db.createObjectStore('items', { keyPath: 'id' });
@@ -91,7 +117,7 @@ async function open(ws: string): Promise<IDBPDatabase | null> {
 				}
 			},
 		});
-		dbs.set(ws, db);
+		dbs.set(k, db);
 		return db;
 	} catch {
 		return null;
@@ -110,11 +136,14 @@ async function open(ws: string): Promise<IDBPDatabase | null> {
  * Never throws. The caller does the cold-path /items-index fetch when
  * `items` is empty.
  */
-export async function hydrate(ws: string): Promise<HydrateResult> {
+export async function hydrate(
+	userId: string | null,
+	ws: string,
+): Promise<HydrateResult> {
 	const empty: HydrateResult = { items: [], cursor: '0' };
 	if (!isSupported()) return empty;
 
-	const db = await open(ws);
+	const db = await open(userId, ws);
 	if (!db) return empty;
 
 	try {
@@ -128,7 +157,7 @@ export async function hydrate(ws: string): Promise<HydrateResult> {
 		// signal an empty cache. The next bootstrap fully resyncs.
 		if (meta && meta.schemaVersion !== LOCAL_INDEX_SCHEMA_VERSION) {
 			await tx.done.catch(() => undefined);
-			await wipe(ws);
+			await wipe(userId, ws);
 			return empty;
 		}
 
@@ -150,9 +179,13 @@ export async function hydrate(ws: string): Promise<HydrateResult> {
  * cursor lands after). For per-delta writes prefer
  * `persistDelta` which advances rows + cursor atomically.
  */
-export async function persistCursor(ws: string, cursor: string): Promise<void> {
+export async function persistCursor(
+	userId: string | null,
+	ws: string,
+	cursor: string,
+): Promise<void> {
 	if (!isSupported()) return;
-	const db = await open(ws);
+	const db = await open(userId, ws);
 	if (!db) return;
 	try {
 		await db.put('meta', {
@@ -172,11 +205,12 @@ export async function persistCursor(ws: string, cursor: string): Promise<void> {
  * one-shot puts.
  */
 export async function persistUpserts(
+	userId: string | null,
 	ws: string,
 	rows: ItemIndexRow[],
 ): Promise<void> {
 	if (!isSupported() || rows.length === 0) return;
-	const db = await open(ws);
+	const db = await open(userId, ws);
 	if (!db) return;
 	try {
 		const tx = db.transaction('items', 'readwrite');
@@ -204,12 +238,13 @@ export async function persistUpserts(
  * populated); hard removals still go through `persistRemovals`.
  */
 export async function persistDelta(
+	userId: string | null,
 	ws: string,
 	rows: ItemIndexRow[],
 	cursor: string,
 ): Promise<void> {
 	if (!isSupported()) return;
-	const db = await open(ws);
+	const db = await open(userId, ws);
 	if (!db) return;
 	try {
 		const tx = db.transaction(['items', 'meta'], 'readwrite');
@@ -237,11 +272,12 @@ export async function persistDelta(
  * flow through `persistUpserts`.
  */
 export async function persistRemovals(
+	userId: string | null,
 	ws: string,
 	ids: string[],
 ): Promise<void> {
 	if (!isSupported() || ids.length === 0) return;
-	const db = await open(ws);
+	const db = await open(userId, ws);
 	if (!db) return;
 	try {
 		const tx = db.transaction('items', 'readwrite');
@@ -261,20 +297,24 @@ export async function persistRemovals(
  * the schemaVersion doesn't match. Closes the cached connection
  * first so the delete request isn't blocked by a still-open handle.
  */
-export async function wipe(ws: string): Promise<void> {
+export async function wipe(
+	userId: string | null,
+	ws: string,
+): Promise<void> {
 	if (!isSupported()) return;
-	const existing = dbs.get(ws);
+	const k = key(userId, ws);
+	const existing = dbs.get(k);
 	if (existing) {
 		try {
 			existing.close();
 		} catch {
 			/* swallow */
 		}
-		dbs.delete(ws);
+		dbs.delete(k);
 	}
 	try {
 		await new Promise<void>((resolve) => {
-			const req = indexedDB.deleteDatabase(dbName(ws));
+			const req = indexedDB.deleteDatabase(dbName(userId, ws));
 			req.onsuccess = () => resolve();
 			req.onerror = () => resolve();
 			req.onblocked = () => resolve();

--- a/web/src/lib/stores/localIndexPersistence.ts
+++ b/web/src/lib/stores/localIndexPersistence.ts
@@ -1,0 +1,245 @@
+// localIndexPersistence — IndexedDB write-behind layer for localIndex
+// (PLAN-1343 / TASK-1356). Per DOC-1342 design decision #4: the
+// in-RAM Svelte store is canonical; IDB is a hydration source on
+// cold/warm boot and a write-behind cache for every mutation. The
+// reader path is unaffected — consumers always go through localIndex,
+// never through this module directly.
+//
+// Database shape: one IDB database per workspace, named
+// `pad-local-index-{wsSlug}`. Two object stores:
+//
+//   items  (keyPath: 'id')   — ItemIndexRow rows, keyed by item.id
+//   meta   (keyPath: 'key')  — { key: 'sync', cursor, schemaVersion }
+//
+// SCHEMA_VERSION is the local equivalent of the Yjs schemaVersion in
+// `web/src/lib/collab/schemaVersion.ts`. Bump it whenever the
+// `ItemIndexRow` wire shape or store layout changes incompatibly —
+// hydrators will see the mismatch on open and drop the persisted
+// data, forcing a full /items-index resync. The server is the
+// source of truth, so dropping the cache is always safe.
+//
+// All public functions never throw. Storage failures (Safari private
+// mode, browser eviction, quota exceeded) degrade silently to
+// in-memory only operation; the next bootstrap hits /items-index
+// the normal way and the warm-load fast path simply skips.
+//
+// SSR-safe: every IDB call is gated on `typeof indexedDB !== 'undefined'`
+// so SvelteKit's prerender / SSR phase doesn't blow up.
+
+import { openDB, type IDBPDatabase } from 'idb';
+import type { ItemIndexRow } from '$lib/types';
+
+/**
+ * SCHEMA_VERSION is the cache-shape contract. Bump it whenever the
+ * `ItemIndexRow` skinny projection or this module's IDB layout changes
+ * incompatibly — old clients reopening on a new build see the
+ * mismatch and wipe their store, then re-bootstrap from
+ * `/items-index`. Server truth (items.content) is never persisted
+ * here, so a cache wipe loses nothing.
+ */
+export const LOCAL_INDEX_SCHEMA_VERSION = 1;
+
+/** Result of a `hydrate()` call. Empty payload when there's no cache yet. */
+export interface HydrateResult {
+	items: ItemIndexRow[];
+	cursor: string;
+}
+
+/** Shape of the single row stored in the `meta` store. */
+interface MetaRow {
+	key: 'sync';
+	cursor: string;
+	schemaVersion: number;
+}
+
+// Open IDB connections are cached per workspace. Reopening is a real
+// cost (page-load latency) and only matters when the persistence layer
+// is actually used — most of the test surface lives in memory.
+const dbs = new Map<string, IDBPDatabase>();
+
+function isSupported(): boolean {
+	return typeof indexedDB !== 'undefined';
+}
+
+function dbName(ws: string): string {
+	return `pad-local-index-${ws}`;
+}
+
+/**
+ * Open the workspace's IDB database, creating object stores on
+ * first run. Cached so subsequent calls reuse the connection.
+ * Returns null on any storage failure — callers must treat that as
+ * "no cache available, fall back to network".
+ */
+async function open(ws: string): Promise<IDBPDatabase | null> {
+	if (!isSupported()) return null;
+	const cached = dbs.get(ws);
+	if (cached) return cached;
+
+	try {
+		// The version arg to openDB is the IDB-format version (used
+		// for migrations). We pin it to 1 and use our own
+		// `schemaVersion` row in `meta` for content-shape versioning.
+		// That keeps schema bumps decoupled from idb library quirks.
+		const db = await openDB(dbName(ws), 1, {
+			upgrade(db) {
+				if (!db.objectStoreNames.contains('items')) {
+					db.createObjectStore('items', { keyPath: 'id' });
+				}
+				if (!db.objectStoreNames.contains('meta')) {
+					db.createObjectStore('meta', { keyPath: 'key' });
+				}
+			},
+		});
+		dbs.set(ws, db);
+		return db;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Read everything from IDB for a workspace. Returns the persisted
+ * items + cursor, OR an empty result when:
+ *   - IDB isn't supported (SSR, ancient browser),
+ *   - the persisted schemaVersion doesn't match LOCAL_INDEX_SCHEMA_VERSION
+ *     (in which case the store is also wiped as a side effect so the
+ *     next persist write starts fresh),
+ *   - opening or reading fails (storage error, quota issue).
+ *
+ * Never throws. The caller does the cold-path /items-index fetch when
+ * `items` is empty.
+ */
+export async function hydrate(ws: string): Promise<HydrateResult> {
+	const empty: HydrateResult = { items: [], cursor: '0' };
+	if (!isSupported()) return empty;
+
+	const db = await open(ws);
+	if (!db) return empty;
+
+	try {
+		const tx = db.transaction(['items', 'meta'], 'readonly');
+		const meta = (await tx.objectStore('meta').get('sync')) as
+			| MetaRow
+			| undefined;
+
+		// Schema-version mismatch is the "your local cache is from a
+		// previous incompatible build" case. Drop everything and
+		// signal an empty cache. The next bootstrap fully resyncs.
+		if (meta && meta.schemaVersion !== LOCAL_INDEX_SCHEMA_VERSION) {
+			await tx.done.catch(() => undefined);
+			await wipe(ws);
+			return empty;
+		}
+
+		const items = (await tx.objectStore('items').getAll()) as ItemIndexRow[];
+		await tx.done.catch(() => undefined);
+		return {
+			items: items ?? [],
+			cursor: meta?.cursor ?? '0',
+		};
+	} catch {
+		return empty;
+	}
+}
+
+/**
+ * Replace the cursor + schemaVersion meta row. Cheap, called after
+ * every cursor-advancing mutation. Schema version is written every
+ * time so the row stays self-consistent — there's no separate path
+ * to "set version" vs. "set cursor".
+ */
+export async function persistCursor(ws: string, cursor: string): Promise<void> {
+	if (!isSupported()) return;
+	const db = await open(ws);
+	if (!db) return;
+	try {
+		await db.put('meta', {
+			key: 'sync',
+			cursor,
+			schemaVersion: LOCAL_INDEX_SCHEMA_VERSION,
+		} satisfies MetaRow);
+	} catch {
+		/* swallow — best-effort cache */
+	}
+}
+
+/**
+ * Upsert a batch of rows in a single transaction. Used by
+ * `applyDelta`/`bootstrap` write-through. Batching matters when an
+ * SSE flurry arrives — a single tx is much cheaper than N
+ * one-shot puts.
+ */
+export async function persistUpserts(
+	ws: string,
+	rows: ItemIndexRow[],
+): Promise<void> {
+	if (!isSupported() || rows.length === 0) return;
+	const db = await open(ws);
+	if (!db) return;
+	try {
+		const tx = db.transaction('items', 'readwrite');
+		const store = tx.objectStore('items');
+		// Fire-and-forget per-row put; the .done promise waits for them all.
+		for (const row of rows) {
+			store.put(row).catch(() => undefined);
+		}
+		await tx.done;
+	} catch {
+		/* swallow — best-effort cache */
+	}
+}
+
+/**
+ * Delete rows by id (hard remove). Used by `localIndex.remove` for
+ * 403 purge (TASK-1360) and any other hard-delete path. Soft deletes
+ * stay in the cache as upserts with `deleted_at` populated — they
+ * flow through `persistUpserts`.
+ */
+export async function persistRemovals(
+	ws: string,
+	ids: string[],
+): Promise<void> {
+	if (!isSupported() || ids.length === 0) return;
+	const db = await open(ws);
+	if (!db) return;
+	try {
+		const tx = db.transaction('items', 'readwrite');
+		const store = tx.objectStore('items');
+		for (const id of ids) {
+			store.delete(id).catch(() => undefined);
+		}
+		await tx.done;
+	} catch {
+		/* swallow — best-effort cache */
+	}
+}
+
+/**
+ * Drop the IDB database entirely. Used by `localIndex.reset` (403
+ * full-workspace purge / sign-out) and internally by `hydrate` when
+ * the schemaVersion doesn't match. Closes the cached connection
+ * first so the delete request isn't blocked by a still-open handle.
+ */
+export async function wipe(ws: string): Promise<void> {
+	if (!isSupported()) return;
+	const existing = dbs.get(ws);
+	if (existing) {
+		try {
+			existing.close();
+		} catch {
+			/* swallow */
+		}
+		dbs.delete(ws);
+	}
+	try {
+		await new Promise<void>((resolve) => {
+			const req = indexedDB.deleteDatabase(dbName(ws));
+			req.onsuccess = () => resolve();
+			req.onerror = () => resolve();
+			req.onblocked = () => resolve();
+		});
+	} catch {
+		/* swallow */
+	}
+}

--- a/web/src/lib/stores/localIndexPersistence.ts
+++ b/web/src/lib/stores/localIndexPersistence.ts
@@ -144,10 +144,11 @@ export async function hydrate(ws: string): Promise<HydrateResult> {
 }
 
 /**
- * Replace the cursor + schemaVersion meta row. Cheap, called after
- * every cursor-advancing mutation. Schema version is written every
- * time so the row stays self-consistent — there's no separate path
- * to "set version" vs. "set cursor".
+ * Replace the cursor + schemaVersion meta row. Standalone variant
+ * used by the cold-path bootstrap when no row writes are happening
+ * alongside (the snapshot is persisted via `persistUpserts` and the
+ * cursor lands after). For per-delta writes prefer
+ * `persistDelta` which advances rows + cursor atomically.
  */
 export async function persistCursor(ws: string, cursor: string): Promise<void> {
 	if (!isSupported()) return;
@@ -184,6 +185,45 @@ export async function persistUpserts(
 		for (const row of rows) {
 			store.put(row).catch(() => undefined);
 		}
+		await tx.done;
+	} catch {
+		/* swallow — best-effort cache */
+	}
+}
+
+/**
+ * Atomically advance a delta — write upserted rows AND the new
+ * cursor in a single IDB transaction. If the tx fails or is aborted
+ * (browser eviction, quota, tab freeze), nothing is written so the
+ * persisted cursor never overshoots the persisted rows. The next
+ * warm hydrate sees a consistent floor and `/items-changes?since=`
+ * can pick up from there without skipping rows. Codex P2 (round 1)
+ * caught the divergence risk of separate row/cursor writes.
+ *
+ * Soft deletes flow through `rows` (as upserts with `deleted_at`
+ * populated); hard removals still go through `persistRemovals`.
+ */
+export async function persistDelta(
+	ws: string,
+	rows: ItemIndexRow[],
+	cursor: string,
+): Promise<void> {
+	if (!isSupported()) return;
+	const db = await open(ws);
+	if (!db) return;
+	try {
+		const tx = db.transaction(['items', 'meta'], 'readwrite');
+		const itemsStore = tx.objectStore('items');
+		for (const row of rows) {
+			itemsStore.put(row).catch(() => undefined);
+		}
+		tx.objectStore('meta')
+			.put({
+				key: 'sync',
+				cursor,
+				schemaVersion: LOCAL_INDEX_SCHEMA_VERSION,
+			} satisfies MetaRow)
+			.catch(() => undefined);
 		await tx.done;
 	} catch {
 		/* swallow — best-effort cache */


### PR DESCRIPTION
## Summary
- Adds `web/src/lib/stores/localIndexPersistence.ts` — per-workspace IDB layer, schema-versioned, SSR-safe, best-effort.
- Wires it into `localIndex`: bootstrap hydrates from IDB first (instant paint), reconciles via `/items-changes`; cold cache falls through to `/items-index`.
- Every mutation (`upsert`, `applyDelta`, `remove`, `reset`) write-throughs to IDB. Failures degrade silently.

## Context
Implements `TASK-1356` under `PLAN-1343` (Phase 2: IndexedDB local cache + delta sync). Builds on `TASK-1355` (localIndex in-RAM store) and `TASK-1354` (/items-changes endpoint). See `DOC-1342` decision #4: Svelte store canonical, IDB persistence-only.

## Test plan
- [x] `make check` — lint + Go tests + `npm run check` clean
- [x] SSR-safe (every IDB call gated on `typeof indexedDB !== 'undefined'`)
- [ ] Integration verified by `TASK-1357` (collection page wiring) — warm load <500ms target