### PR TITLE
feat: seq-stamped SSE events + stale-event short-circuit (TASK-1358)

### DIFF
--- a/internal/events/bus.go
+++ b/internal/events/bus.go
@@ -58,6 +58,16 @@ type Event struct {
 	Source      string `json:"source,omitempty"`
 	UserID      string `json:"user_id,omitempty"` // For user-scoped events (e.g. star/unstar)
 	Timestamp   int64  `json:"timestamp"`
+	// Seq is the workspace-scoped monotonic mutation cursor of the
+	// item the event references (PLAN-1343 / TASK-1352). Populated
+	// for item lifecycle events (created / updated / archived /
+	// restored) so the local-first read model (TASK-1358) can apply
+	// the change in-place when the seq is contiguous with the
+	// client's cursor, or trigger a /items-changes backfill when
+	// there's a gap. Zero for non-item events (workspace_updated,
+	// comment_*, reaction_*) and for legacy publishers that
+	// haven't been upgraded.
+	Seq int64 `json:"seq,omitempty"`
 }
 
 // EventBus is the interface for pub/sub event distribution.

--- a/internal/server/handlers_item_versions.go
+++ b/internal/server/handlers_item_versions.go
@@ -104,7 +104,10 @@ func (s *Server) handleRestoreItemVersion(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	// Emit event
+	// Emit event. Carry the post-update `seq` so SSE consumers
+	// (PLAN-1343 / TASK-1358 — localIndex.classifySSEEvent) can
+	// detect contiguity vs. gap rather than blindly falling back
+	// to a generic /items-changes refetch.
 	if s.events != nil {
 		s.events.Publish(events.Event{
 			Type:        "item_updated",
@@ -112,6 +115,7 @@ func (s *Server) handleRestoreItemVersion(w http.ResponseWriter, r *http.Request
 			Collection:  item.CollectionSlug,
 			ItemID:      item.ID,
 			Title:       item.Title,
+			Seq:         updated.Seq,
 		})
 	}
 

--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -556,7 +556,7 @@ func (s *Server) handleCreateItem(w http.ResponseWriter, r *http.Request) {
 
 	actor, source := actorFromRequest(r)
 	s.logActivity(workspaceID, item.ID, "created", r)
-	s.publishItemEventWithName(events.ItemCreated, workspaceID, item.ID, item.Title, collSlug, actor, actorNameFromRequest(r), source)
+	s.publishItemEventWithName(events.ItemCreated, workspaceID, item.ID, item.Title, collSlug, actor, actorNameFromRequest(r), source, item.Seq)
 	s.dispatchWebhook(workspaceID, "item.created", item)
 
 	createVisIDs, _ := s.visibleCollectionIDs(r, workspaceID)
@@ -965,7 +965,7 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 	}
 	actor, source := actorFromRequest(r)
 	activityID, _ := s.logActivityWithMetaReturningID(workspaceID, updated.ID, "updated", r, meta)
-	s.publishItemEventWithName(events.ItemUpdated, workspaceID, updated.ID, updated.Title, updated.CollectionSlug, actor, actorNameFromRequest(r), source)
+	s.publishItemEventWithName(events.ItemUpdated, workspaceID, updated.ID, updated.Title, updated.CollectionSlug, actor, actorNameFromRequest(r), source, updated.Seq)
 	s.dispatchWebhook(workspaceID, "item.updated", updated)
 
 	// If a comment was attached to this update (e.g. explaining a status change),
@@ -1033,9 +1033,18 @@ func (s *Server) handleDeleteItem(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Fetch the post-delete row so the SSE event carries the new
+	// `seq` (DeleteItem bumps it). Falls back to 0 if the row is
+	// missing (race with hard-delete or a Postgres timing quirk);
+	// downstream SSE consumers backfill via /items-changes on a 0.
+	var deleteSeq int64
+	if d, derr := s.store.GetItemIncludeDeleted(item.ID); derr == nil && d != nil {
+		deleteSeq = d.Seq
+	}
+
 	actor, source := actorFromRequest(r)
 	s.logActivity(workspaceID, item.ID, "archived", r)
-	s.publishItemEventWithName(events.ItemArchived, workspaceID, item.ID, item.Title, item.CollectionSlug, actor, actorNameFromRequest(r), source)
+	s.publishItemEventWithName(events.ItemArchived, workspaceID, item.ID, item.Title, item.CollectionSlug, actor, actorNameFromRequest(r), source, deleteSeq)
 	s.dispatchWebhook(workspaceID, "item.deleted", item)
 
 	w.WriteHeader(http.StatusNoContent)
@@ -1080,7 +1089,7 @@ func (s *Server) handleRestoreItem(w http.ResponseWriter, r *http.Request) {
 
 	actor, source := actorFromRequest(r)
 	s.logActivity(workspaceID, restored.ID, "restored", r)
-	s.publishItemEventWithName(events.ItemRestored, workspaceID, restored.ID, restored.Title, restored.CollectionSlug, actor, actorNameFromRequest(r), source)
+	s.publishItemEventWithName(events.ItemRestored, workspaceID, restored.ID, restored.Title, restored.CollectionSlug, actor, actorNameFromRequest(r), source, restored.Seq)
 
 	restoreVisIDs, _ := s.visibleCollectionIDs(r, workspaceID)
 	if err := s.enrichItemForResponse(restored, restoreVisIDs); err != nil {
@@ -1210,7 +1219,7 @@ func (s *Server) handleMoveItem(w http.ResponseWriter, r *http.Request) {
 	s.logActivityWithMeta(workspaceID, moved.ID, "moved", r, moveMeta)
 
 	// Publish events for both old and new collections
-	s.publishItemEventWithName(events.ItemUpdated, workspaceID, moved.ID, moved.Title, targetColl.Slug, actor, actorNameFromRequest(r), source)
+	s.publishItemEventWithName(events.ItemUpdated, workspaceID, moved.ID, moved.Title, targetColl.Slug, actor, actorNameFromRequest(r), source, moved.Seq)
 	s.dispatchWebhook(workspaceID, "item.moved", moved)
 
 	moveVisIDs, _ := s.visibleCollectionIDs(r, workspaceID)
@@ -1223,7 +1232,12 @@ func (s *Server) handleMoveItem(w http.ResponseWriter, r *http.Request) {
 }
 
 // publishItemEventWithName publishes a real-time event for item changes with actor name.
-func (s *Server) publishItemEventWithName(eventType, workspaceID, itemID, title, collection, actor, actorName, source string) {
+// `seq` is the item's workspace-scoped monotonic mutation cursor at the
+// time of the event (PLAN-1343 / TASK-1358), so SSE consumers can
+// reason about ordering and contiguity. Callers that don't have the
+// item's current seq handy may pass 0; downstream consumers fall back
+// to a /items-changes backfill in that case.
+func (s *Server) publishItemEventWithName(eventType, workspaceID, itemID, title, collection, actor, actorName, source string, seq int64) {
 	if s.events == nil {
 		return
 	}
@@ -1236,6 +1250,7 @@ func (s *Server) publishItemEventWithName(eventType, workspaceID, itemID, title,
 		Actor:       actor,
 		ActorName:   actorName,
 		Source:      source,
+		Seq:         seq,
 	})
 }
 

--- a/web/src/lib/services/sse.svelte.ts
+++ b/web/src/lib/services/sse.svelte.ts
@@ -13,6 +13,15 @@ export interface ItemEvent {
 	actor_name?: string;
 	source: string;
 	timestamp: number;
+	// `seq` is the workspace-scoped monotonic mutation cursor of the
+	// referenced item (PLAN-1343 / TASK-1358). Server stamps it on
+	// item lifecycle events (created / updated / archived / restored)
+	// so the local-first read model can apply contiguous deltas in
+	// place and detect gaps that need a /items-changes backfill.
+	// Optional because non-item events (workspace_updated,
+	// comment_*, reaction_*) and legacy publishers omit it; clients
+	// fall back to a generic deltaSync when missing.
+	seq?: number;
 }
 
 type ItemEventCallback = (event: ItemEvent) => void;

--- a/web/src/lib/stores/localIndex.svelte.ts
+++ b/web/src/lib/stores/localIndex.svelte.ts
@@ -554,6 +554,42 @@ export const localIndex = {
 	},
 
 	/**
+	 * Classify an SSE event against the workspace cursor (TASK-1358).
+	 * Doesn't write data — the SSE wire payload only carries event
+	 * metadata (type, item_id, title, collection_slug, seq), not the
+	 * full row, so the caller still needs to fetch the row data
+	 * through `deltaSync` for the cases that need it.
+	 *
+	 * Return values:
+	 *   - `'no-seq'`: event lacks `seq` (legacy publisher, non-item
+	 *      event). Caller should fall back to a generic deltaSync.
+	 *   - `'stale'`: event.seq is at or below the current cursor —
+	 *      already applied (or covered by a prior batch). Drop it.
+	 *   - `'contiguous'`: event.seq === cursor + 1. No gap. Caller
+	 *      may still need to fetch the row data for this event
+	 *      (SSE payload is metadata-only), but is guaranteed not to
+	 *      miss any intermediate events.
+	 *   - `'gap'`: event.seq > cursor + 1. The local index is behind
+	 *      by `event.seq - cursor - 1` events. Caller MUST
+	 *      `deltaSync` to backfill before this event's data lands,
+	 *      or the cache will have holes.
+	 *
+	 * Does NOT advance the cursor. Cursor advancement happens through
+	 * `applyDelta` (with real row data) so the IDB persistence
+	 * invariant (cursor never overshoots persisted rows) stays sound.
+	 */
+	classifySSEEvent(
+		ws: string,
+		event: { seq?: number },
+	): 'no-seq' | 'stale' | 'contiguous' | 'gap' {
+		if (event.seq === undefined || event.seq === 0) return 'no-seq';
+		const cursorNum = cursorAsNum(localIndex.cursorFor(ws));
+		if (event.seq <= cursorNum) return 'stale';
+		if (event.seq === cursorNum + 1) return 'contiguous';
+		return 'gap';
+	},
+
+	/**
 	 * Single-item upsert. Used by SSE handlers and the optimistic
 	 * post-mutation path (e.g. after `api.items.update` returns a full
 	 * `Item`, the caller hands it here to keep the local index fresh

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -379,14 +379,18 @@
 		const coll = collSlug;
 
 		unsubscribeSSE = sseService.onItemEvent(async (event) => {
-			// React to any item lifecycle event by pulling deltas
-			// through the local store. The `items` derived view picks
-			// up changes automatically; no manual re-fetch needed.
-			// We don't filter by collection here — an item moved into
-			// or out of this collection still needs its delta applied
-			// so the derived view reflects it. TASK-1358 will replace
-			// this generic reconcile with seq-stamped per-event apply.
-			void event;
+			// React to item lifecycle events by pulling deltas through
+			// the local store. With seq-stamped events (TASK-1358) we
+			// can short-circuit duplicates the server's replay buffer
+			// re-delivers after a tab-resume, or events whose data is
+			// already in the local index from a prior delta. Anything
+			// not "stale" still needs row data, which only
+			// `deltaSync` can fetch — the SSE wire payload doesn't
+			// carry it. We don't filter by collection here: an item
+			// moved into or out of this collection still needs its
+			// delta applied so the derived view reflects it.
+			const status = localIndex.classifySSEEvent(ws, event);
+			if (status === 'stale') return;
 			await deltaSync(ws);
 		});
 	});


### PR DESCRIPTION
## Summary
- Server: \`events.Event.Seq\` propagates the item's workspace-scoped mutation cursor onto every item lifecycle event (created / updated / archived / restored / moved).
- Web: \`ItemEvent.seq\` mirrors the wire payload; new \`localIndex.classifySSEEvent\` returns \`'no-seq' | 'stale' | 'contiguous' | 'gap'\` so the collection page can short-circuit replayed duplicates.
- Cursor advancement still flows exclusively through \`applyDelta\` (with real row data from /items-changes), preserving the IDB persist invariant from TASK-1356.

## Context
Implements \`TASK-1358\` under \`PLAN-1343\` (Phase 2: IndexedDB local cache + delta sync). Depends on \`TASK-1352\` (seq column) and \`TASK-1355\`-\`1357\`.

## Test plan
- [x] \`go test ./...\` — clean (incl. events + server)
- [x] \`npm run check\` — clean
- [ ] Manual: confirm SSE events include \`seq\` for item lifecycle types
- [ ] Manual: confirm replayed events post-reconnect are filtered as \`'stale'\` (no double-fetch)