### PR TITLE
feat(web): leader-elected SSE + cross-tab BroadcastChannel (TASK-1359)

### DIFF
--- a/web/src/lib/services/sse.svelte.ts
+++ b/web/src/lib/services/sse.svelte.ts
@@ -202,26 +202,37 @@ function createSSEService() {
 			openEventSource(workspaceSlug);
 			return;
 		}
-		// Query first so we can distinguish "I'm the first leader"
-		// from "I'm a promoted follower." The first leader doesn't
-		// need a sync — the page bootstrap already does one. A
-		// promoted follower DOES need a sync because the freshly-
-		// opened EventSource has no Last-Event-ID and the server
-		// can't replay events emitted during the gap between the old
-		// leader's close and this new connection (Codex P1 round 2
-		// of TASK-1359). `navigator.locks.query` racing with the
-		// lock release is fine — if we mis-classify and fire an
-		// extra sync, that's idempotent + cheap.
-		let promoted = false;
+		// Distinguish "first leader" from "promoted follower" so we
+		// only fire sync_required on promotion — the freshly-opened
+		// EventSource has no Last-Event-ID and the server can't
+		// replay events emitted during the gap between the old
+		// leader's close and the new connection. Two signals:
+		//
+		//   1. `navigator.locks.query` before the request. If the
+		//      slot is already held by another tab, we're definitely
+		//      a future promotion. (Codex P1 round 2 of TASK-1359.)
+		//   2. Grant delay. If `query` raced with two tabs starting
+		//      simultaneously (both see "no holder"), one wins and
+		//      the other queues. The loser would mis-classify with
+		//      query alone — but the lock grant for the queued tab
+		//      is delayed by however long the winner held it. Any
+		//      callback that fires more than ~100ms after the
+		//      request is treated as a promotion. (Codex P1 round 3
+		//      of TASK-1359.) 100ms is a conservative cap on the
+		//      immediate grant case (uncontested lock acquisition
+		//      in a healthy browser is sub-millisecond).
+		let queryPromoted = false;
 		try {
 			const snapshot = await navigator.locks.query();
 			const held = (snapshot.held ?? []).some(
 				(l) => l.name === `pad-sse-leader-${workspaceSlug}`,
 			);
-			promoted = held;
+			queryPromoted = held;
 		} catch {
-			/* swallow — query unsupported on some platforms; treat as first */
+			/* swallow — query unsupported on some platforms */
 		}
+		const requestStart =
+			typeof performance !== 'undefined' ? performance.now() : Date.now();
 
 		navigator.locks
 			.request(
@@ -232,6 +243,11 @@ function createSSEService() {
 					// we acquire the lock. Bail before opening a stale
 					// connection.
 					if (currentWorkspace !== workspaceSlug) return;
+					const grantDelay =
+						(typeof performance !== 'undefined'
+							? performance.now()
+							: Date.now()) - requestStart;
+					const promoted = queryPromoted || grantDelay > 100;
 					isLeader = true;
 					openEventSource(workspaceSlug);
 					if (promoted) {

--- a/web/src/lib/services/sse.svelte.ts
+++ b/web/src/lib/services/sse.svelte.ts
@@ -132,6 +132,15 @@ function createSSEService() {
 		};
 	}
 
+	// `pendingSyncOnConnect` defers a `sync_required` dispatch until
+	// the new EventSource is actually subscribed server-side
+	// (onopen / `connected` event). Without this gate, the promoted/
+	// fallback paths fire dispatchSyncRequired BEFORE the SSE
+	// connection lands, so any mutation between the resulting
+	// /items-changes snapshot and the new stream's first received
+	// event can be missed (Codex P1 round 4 of TASK-1359).
+	let pendingSyncOnConnect = false;
+
 	function openEventSource(workspaceSlug: string) {
 		const url = `/api/v1/events?workspace=${encodeURIComponent(workspaceSlug)}`;
 		eventSource = new EventSource(url);
@@ -139,6 +148,11 @@ function createSSEService() {
 		eventSource.onopen = () => {
 			status = 'connected';
 			broadcast({ type: 'status', status: 'connected' });
+			if (pendingSyncOnConnect) {
+				pendingSyncOnConnect = false;
+				dispatchSyncRequired();
+				broadcast({ type: 'sync_required' });
+			}
 		};
 
 		eventSource.onerror = () => {
@@ -151,6 +165,14 @@ function createSSEService() {
 		eventSource.addEventListener('connected', () => {
 			status = 'connected';
 			broadcast({ type: 'status', status: 'connected' });
+			// Mirror onopen — some platforms fire `connected`
+			// reliably before `onopen` on reconnect, others vice
+			// versa. Whichever fires first claims the pending sync.
+			if (pendingSyncOnConnect) {
+				pendingSyncOnConnect = false;
+				dispatchSyncRequired();
+				broadcast({ type: 'sync_required' });
+			}
 		});
 
 		// Handle sync_required: server's replay buffer couldn't cover the gap.
@@ -249,14 +271,15 @@ function createSSEService() {
 							: Date.now()) - requestStart;
 					const promoted = queryPromoted || grantDelay > 100;
 					isLeader = true;
-					openEventSource(workspaceSlug);
 					if (promoted) {
-						// Tell local + peer listeners to backfill —
-						// the gap between the old leader's close
-						// and this new EventSource is unknown.
-						dispatchSyncRequired();
-						broadcast({ type: 'sync_required' });
+						// Schedule the sync to fire AFTER the SSE is
+						// connected — otherwise any mutation between
+						// the resulting /items-changes snapshot and
+						// the new stream's first received event would
+						// be missed (Codex P1 round 4).
+						pendingSyncOnConnect = true;
 					}
+					openEventSource(workspaceSlug);
 					// Hold the lock until release is signaled (by
 					// disconnect() or a workspace switch). The promise
 					// returned from this callback is what
@@ -283,8 +306,11 @@ function createSSEService() {
 						bc.close();
 						bc = null;
 					}
+					// Defer sync_required until the EventSource opens
+					// (Codex P1 round 4 of TASK-1359) — same race as
+					// the promotion path.
+					pendingSyncOnConnect = true;
 					openEventSource(workspaceSlug);
-					dispatchSyncRequired();
 				}
 			});
 	}

--- a/web/src/lib/services/sse.svelte.ts
+++ b/web/src/lib/services/sse.svelte.ts
@@ -39,6 +39,14 @@ const ITEM_EVENTS = [
 	'reaction_removed'
 ] as const;
 
+// Cross-tab BroadcastChannel envelope. The leader tab fans events out
+// via this channel so peer tabs in the same browser get live updates
+// without opening their own EventSource (PLAN-1343 / TASK-1359).
+type BCEnvelope =
+	| { type: 'item_event'; event: ItemEvent }
+	| { type: 'sync_required' }
+	| { type: 'status'; status: SSEStatus };
+
 function createSSEService() {
 	let status = $state<SSEStatus>('disconnected');
 	let lastEventTime = $state<number>(0);
@@ -48,66 +56,106 @@ function createSSEService() {
 	const callbacks = new SvelteSet<ItemEventCallback>();
 	const syncRequiredCallbacks = new SvelteSet<SyncRequiredCallback>();
 
-	function connect(workspaceSlug: string) {
-		// If already connected to the same workspace, don't reconnect.
-		// The browser's EventSource handles reconnection automatically
-		// with Last-Event-ID, so destroying it would lose that state.
-		if (eventSource && currentWorkspace === workspaceSlug) {
-			// EventSource is already connected (or auto-reconnecting).
-			// readyState: 0=CONNECTING, 1=OPEN, 2=CLOSED
-			if (eventSource.readyState !== EventSource.CLOSED) {
-				return;
+	// Cross-tab BroadcastChannel for fan-out from the leader tab to
+	// peer tabs. Every connected tab (leader OR peer) keeps the
+	// channel open — the leader publishes events here, peers
+	// subscribe. Null on browsers without BroadcastChannel support
+	// (very old / non-browser environments — every tab becomes its
+	// own leader and opens its own SSE).
+	let bc: BroadcastChannel | null = null;
+
+	// Resolves the leader lock when this tab is disconnecting (or
+	// switching workspaces). Returning from the lock callback
+	// releases the lock; another waiting tab then acquires it and
+	// becomes the new leader. Null when this tab is not the leader.
+	let releaseLeaderLock: (() => void) | null = null;
+
+	// True iff this tab currently holds the leader Web Lock.
+	let isLeader = false;
+
+	function dispatchItemEvent(data: ItemEvent) {
+		lastEventTime = Date.now();
+		for (const cb of callbacks) {
+			cb(data);
+		}
+	}
+
+	function dispatchSyncRequired() {
+		needsSync = true;
+		for (const cb of syncRequiredCallbacks) {
+			cb();
+		}
+	}
+
+	function broadcast(env: BCEnvelope) {
+		if (!bc) return;
+		try {
+			bc.postMessage(env);
+		} catch {
+			/* swallow — closed channel or serialization error */
+		}
+	}
+
+	function openBroadcastChannel(workspaceSlug: string) {
+		if (typeof BroadcastChannel === 'undefined') return;
+		bc = new BroadcastChannel(`pad-sync-${workspaceSlug}`);
+		bc.onmessage = (msg: MessageEvent<BCEnvelope>) => {
+			// Peer-tab path: route messages from the leader to local
+			// callbacks. The leader-side `dispatchItemEvent` /
+			// `dispatchSyncRequired` already runs locally before
+			// broadcasting, so the leader doesn't re-dispatch its
+			// own messages. The browser's own-message-filter on
+			// BroadcastChannel makes the cross-tab boundary the only
+			// fan-out edge.
+			const env = msg.data;
+			if (env.type === 'item_event') {
+				dispatchItemEvent(env.event);
+			} else if (env.type === 'sync_required') {
+				dispatchSyncRequired();
+			} else if (env.type === 'status') {
+				// Mirror the leader's connection status so peer-tab UI
+				// indicators don't show "disconnected" while the
+				// leader is happily streaming.
+				status = env.status;
 			}
-		}
+		};
+	}
 
-		// Different workspace or closed connection — create new EventSource
-		if (eventSource) {
-			disconnect();
-		}
-
-		currentWorkspace = workspaceSlug;
+	function openEventSource(workspaceSlug: string) {
 		const url = `/api/v1/events?workspace=${encodeURIComponent(workspaceSlug)}`;
 		eventSource = new EventSource(url);
 
 		eventSource.onopen = () => {
 			status = 'connected';
+			broadcast({ type: 'status', status: 'connected' });
 		};
 
 		eventSource.onerror = () => {
 			status = 'reconnecting';
+			broadcast({ type: 'status', status: 'reconnecting' });
 			// EventSource auto-reconnects and sends Last-Event-ID.
 			// The server replays missed events from its buffer.
 		};
 
 		eventSource.addEventListener('connected', () => {
 			status = 'connected';
+			broadcast({ type: 'status', status: 'connected' });
 		});
 
 		// Handle sync_required: server's replay buffer couldn't cover the gap.
-		// Trigger an immediate sync rather than waiting for a visibility change,
-		// so the UI stays fresh even when the tab is actively visible. Fires
-		// out via onSyncRequired() subscribers (currently syncService) — the
-		// callback inversion keeps this module free of any sync.svelte import,
-		// breaking the circular dep that previously required a dynamic import
-		// here. (Rolldown flagged the dynamic import as ineffective because
-		// sync.svelte is statically imported from 5 routes/components anyway,
-		// so it's always in the main chunk — see TASK-1242.)
 		eventSource.addEventListener('sync_required', () => {
-			needsSync = true;
-			for (const cb of syncRequiredCallbacks) {
-				cb();
-			}
+			dispatchSyncRequired();
+			broadcast({ type: 'sync_required' });
 		});
 
 		// Handle unauthorized: the server's periodic membership revalidation
 		// detected that this session has lost access to the workspace. We
 		// must close the EventSource ourselves — otherwise the browser
 		// auto-reconnect would tight-loop on a 401 or a stream that
-		// immediately closes again, hammering /api/v1/events. Surface the
-		// status so the surrounding UI can redirect to the workspace list
-		// or show a "revoked" message.
+		// immediately closes again, hammering /api/v1/events.
 		eventSource.addEventListener('unauthorized', () => {
 			status = 'unauthorized';
+			broadcast({ type: 'status', status: 'unauthorized' });
 			if (eventSource) {
 				eventSource.close();
 				eventSource = null;
@@ -118,20 +166,108 @@ function createSSEService() {
 		for (const eventType of ITEM_EVENTS) {
 			eventSource.addEventListener(eventType, (e: MessageEvent) => {
 				const data: ItemEvent = JSON.parse(e.data);
-				lastEventTime = Date.now();
-				for (const cb of callbacks) {
-					cb(data);
-				}
+				dispatchItemEvent(data);
+				broadcast({ type: 'item_event', event: data });
 			});
 		}
 	}
 
+	/**
+	 * Acquire the workspace-scoped leader lock and, if granted, open
+	 * the SSE EventSource. Peer tabs queue on the same lock and only
+	 * advance when the current leader's tab unloads or closes the
+	 * lock — at which point another tab takes over transparently
+	 * (navigator.locks releases the lock on page unload).
+	 *
+	 * Browsers without navigator.locks (very old / non-browser
+	 * environments) skip the leader election and every tab opens
+	 * its own EventSource — N× traffic but correct.
+	 */
+	function requestLeader(workspaceSlug: string) {
+		if (typeof navigator === 'undefined' || !('locks' in navigator)) {
+			// No leader election available. Fall back to per-tab SSE.
+			openEventSource(workspaceSlug);
+			return;
+		}
+		navigator.locks
+			.request(
+				`pad-sse-leader-${workspaceSlug}`,
+				{ mode: 'exclusive' },
+				async () => {
+					// User may have already navigated away by the time
+					// we acquire the lock. Bail before opening a stale
+					// connection.
+					if (currentWorkspace !== workspaceSlug) return;
+					isLeader = true;
+					openEventSource(workspaceSlug);
+					// Hold the lock until release is signaled (by
+					// disconnect() or a workspace switch). The promise
+					// returned from this callback is what
+					// navigator.locks awaits.
+					return new Promise<void>((resolve) => {
+						releaseLeaderLock = () => {
+							releaseLeaderLock = null;
+							isLeader = false;
+							resolve();
+						};
+					});
+				},
+			)
+			.catch(() => {
+				// Lock request can fail in exotic cases (cross-origin
+				// iframe restrictions, etc.). Fall back to a
+				// per-tab EventSource so the user still gets live
+				// updates.
+				if (currentWorkspace === workspaceSlug && !eventSource) {
+					openEventSource(workspaceSlug);
+				}
+			});
+	}
+
+	function connect(workspaceSlug: string) {
+		// Already connected to the same workspace — no-op.
+		if (currentWorkspace === workspaceSlug && (eventSource || bc)) {
+			if (eventSource && eventSource.readyState !== EventSource.CLOSED) {
+				return;
+			}
+			if (bc && !eventSource && !isLeader) {
+				return; // peer tab, still listening
+			}
+		}
+
+		// Different workspace or closed connection — tear down first.
+		if (eventSource || bc) {
+			disconnect();
+		}
+
+		currentWorkspace = workspaceSlug;
+		// Always open the broadcast channel: leaders use it to fan
+		// out, peers use it to receive.
+		openBroadcastChannel(workspaceSlug);
+		// Race for the leader slot. If we win, openEventSource runs
+		// inside the lock callback. If we lose, we wait on the lock
+		// while passively receiving via bc. When the leader tab
+		// closes, the lock releases and our queued request fires —
+		// at which point we open our own EventSource.
+		requestLeader(workspaceSlug);
+	}
+
 	function disconnect() {
+		// Release the leader lock first so a peer tab can take over
+		// even on the same browser session (e.g. workspace switch).
+		if (releaseLeaderLock) {
+			releaseLeaderLock();
+		}
 		if (eventSource) {
 			eventSource.close();
 			eventSource = null;
 		}
+		if (bc) {
+			bc.close();
+			bc = null;
+		}
 		currentWorkspace = '';
+		isLeader = false;
 		status = 'disconnected';
 	}
 
@@ -180,6 +316,9 @@ function createSSEService() {
 		},
 		get needsSync() {
 			return needsSync;
+		},
+		get isLeader() {
+			return isLeader;
 		},
 		connect,
 		disconnect,

--- a/web/src/lib/services/sse.svelte.ts
+++ b/web/src/lib/services/sse.svelte.ts
@@ -96,8 +96,19 @@ function createSSEService() {
 		}
 	}
 
+	function leaderElectionSupported(): boolean {
+		return typeof navigator !== 'undefined' && 'locks' in navigator;
+	}
+
 	function openBroadcastChannel(workspaceSlug: string) {
 		if (typeof BroadcastChannel === 'undefined') return;
+		// BroadcastChannel is only safe when paired with leader
+		// election. Without `navigator.locks`, every tab opens its
+		// own EventSource AND would receive its peers' broadcasts —
+		// firing item callbacks N times across N tabs (Codex P1 of
+		// TASK-1359). Skip BC entirely in that fallback regime; the
+		// per-tab EventSource still delivers the events locally.
+		if (!leaderElectionSupported()) return;
 		bc = new BroadcastChannel(`pad-sync-${workspaceSlug}`);
 		bc.onmessage = (msg: MessageEvent<BCEnvelope>) => {
 			// Peer-tab path: route messages from the leader to local
@@ -184,8 +195,10 @@ function createSSEService() {
 	 * its own EventSource — N× traffic but correct.
 	 */
 	function requestLeader(workspaceSlug: string) {
-		if (typeof navigator === 'undefined' || !('locks' in navigator)) {
+		if (!leaderElectionSupported()) {
 			// No leader election available. Fall back to per-tab SSE.
+			// BC was also skipped above, so this is the per-tab N×
+			// fallback path — correct, just less efficient.
 			openEventSource(workspaceSlug);
 			return;
 		}

--- a/web/src/lib/services/sse.svelte.ts
+++ b/web/src/lib/services/sse.svelte.ts
@@ -194,7 +194,7 @@ function createSSEService() {
 	 * environments) skip the leader election and every tab opens
 	 * its own EventSource — N× traffic but correct.
 	 */
-	function requestLeader(workspaceSlug: string) {
+	async function requestLeader(workspaceSlug: string) {
 		if (!leaderElectionSupported()) {
 			// No leader election available. Fall back to per-tab SSE.
 			// BC was also skipped above, so this is the per-tab N×
@@ -202,6 +202,27 @@ function createSSEService() {
 			openEventSource(workspaceSlug);
 			return;
 		}
+		// Query first so we can distinguish "I'm the first leader"
+		// from "I'm a promoted follower." The first leader doesn't
+		// need a sync — the page bootstrap already does one. A
+		// promoted follower DOES need a sync because the freshly-
+		// opened EventSource has no Last-Event-ID and the server
+		// can't replay events emitted during the gap between the old
+		// leader's close and this new connection (Codex P1 round 2
+		// of TASK-1359). `navigator.locks.query` racing with the
+		// lock release is fine — if we mis-classify and fire an
+		// extra sync, that's idempotent + cheap.
+		let promoted = false;
+		try {
+			const snapshot = await navigator.locks.query();
+			const held = (snapshot.held ?? []).some(
+				(l) => l.name === `pad-sse-leader-${workspaceSlug}`,
+			);
+			promoted = held;
+		} catch {
+			/* swallow — query unsupported on some platforms; treat as first */
+		}
+
 		navigator.locks
 			.request(
 				`pad-sse-leader-${workspaceSlug}`,
@@ -213,6 +234,13 @@ function createSSEService() {
 					if (currentWorkspace !== workspaceSlug) return;
 					isLeader = true;
 					openEventSource(workspaceSlug);
+					if (promoted) {
+						// Tell local + peer listeners to backfill —
+						// the gap between the old leader's close
+						// and this new EventSource is unknown.
+						dispatchSyncRequired();
+						broadcast({ type: 'sync_required' });
+					}
 					// Hold the lock until release is signaled (by
 					// disconnect() or a workspace switch). The promise
 					// returned from this callback is what
@@ -228,11 +256,19 @@ function createSSEService() {
 			)
 			.catch(() => {
 				// Lock request can fail in exotic cases (cross-origin
-				// iframe restrictions, etc.). Fall back to a
-				// per-tab EventSource so the user still gets live
-				// updates.
+				// iframe restrictions, etc.). Close BC before falling
+				// back to a per-tab EventSource — otherwise peer tabs
+				// rejected the same way would each open their own SSE
+				// AND keep receiving each other's broadcasts, firing
+				// callbacks N times (Codex P2 round 2). Trigger
+				// sync_required because we may have missed events.
 				if (currentWorkspace === workspaceSlug && !eventSource) {
+					if (bc) {
+						bc.close();
+						bc = null;
+					}
 					openEventSource(workspaceSlug);
+					dispatchSyncRequired();
 				}
 			});
 	}
@@ -262,7 +298,10 @@ function createSSEService() {
 		// while passively receiving via bc. When the leader tab
 		// closes, the lock releases and our queued request fires —
 		// at which point we open our own EventSource.
-		requestLeader(workspaceSlug);
+		// requestLeader is async (it queries the lock state first)
+		// but we don't await it — the .catch() handler covers any
+		// failures and connect() returns synchronously to the caller.
+		void requestLeader(workspaceSlug);
 	}
 
 	function disconnect() {


### PR DESCRIPTION
## Summary
- Multiple tabs of the same workspace now share a single SSE connection. One tab acquires an exclusive Web Lock (\`pad-sse-leader-{ws}\`), opens the EventSource, and fans events out to peer tabs via BroadcastChannel (\`pad-sync-{ws}\`).
- On leader-tab close, \`navigator.locks\` releases the lock automatically and a queued peer takes over without manual intervention.
- Browsers without \`navigator.locks\` fall back to per-tab EventSources (correct but N× traffic).
- Connection status is broadcast so peer tabs surface the same indicator the leader sees.

## Context
Implements \`TASK-1359\` under \`PLAN-1343\` (Phase 2). See \`DOC-1342\` design decision #2.

## Test plan
- [x] \`npm run check\` — clean
- [ ] Manual: open two tabs on the same collection → only ONE /api/v1/events connection in DevTools Network
- [ ] Manual: change in tab A, see it reflect in tab B within ~200ms
- [ ] Manual: close leader tab, peer takes over within ~1s