### PR TITLE
feat(web): 403-driven cache purge for localIndex (TASK-1360)

### DIFF
--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -190,7 +190,20 @@ async function request<T>(path: string, options?: RequestInit): Promise<T> {
 		// part of the same error path (DOC-1342 decision #3, TASK-1360).
 		// The handler is best-effort and never throws into the API
 		// client.
-		notifyAccessRevoked(path);
+		//
+		// Restricted to GET / HEAD requests. A 403 on
+		// POST/PATCH/DELETE usually means "you can READ but not
+		// WRITE this resource" — purging on those would wipe
+		// perfectly accessible cache rows for a read-only user who
+		// tried (and was correctly denied) to create / update /
+		// archive an item (Codex P1 round 1 of TASK-1360). Read 403
+		// is the canonical "visibility revoked" signal.
+		//
+		// `method` is already uppercased above; undefined means GET
+		// (the fetch default).
+		if (method === undefined || method === 'GET' || method === 'HEAD') {
+			notifyAccessRevoked(path);
+		}
 	}
 	if (!resp.ok) {
 		const body = await resp.json().catch(() => null);

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -106,21 +106,61 @@ export function setAccessRevokedHandler(handler: AccessRevokedHandler | null): v
 }
 
 /**
- * Parse a workspace-scoped URL path and extract the workspace slug if
- * present. Returns null for non-workspace-scoped paths (auth,
- * admin, health, etc.). Pure / non-throwing.
+ * Parse a URL path and decide whether a 403 on it indicates that the
+ * caller's READ access to the workspace's item set has been revoked.
+ * Returns null for any path that doesn't qualify — auth, admin,
+ * server health, OR workspace-scoped endpoints whose 403 doesn't
+ * imply workspace-wide read loss (members list, storage usage, etc.
+ * 403 from those for grant-only guests is expected and shouldn't
+ * purge the cache — Codex P1 round 3 of TASK-1360).
+ *
+ * The whitelist is the set of endpoints the local-first read model
+ * actually consumes for items:
+ *
+ *   GET /workspaces/{ws}/items
+ *   GET /workspaces/{ws}/items/{slug}
+ *   GET /workspaces/{ws}/items-index
+ *   GET /workspaces/{ws}/items-changes
+ *   GET /workspaces/{ws}/collections/{coll}/items
+ *
+ * A 403 on any of these means the local cache is stale-by-permission
+ * (membership revoked or item-grant scope shrunk to nothing). A 403
+ * on anything else stays opaque to the local index.
  */
 function parseAccessRevokedScope(path: string): AccessRevokedScope | null {
-	// Strip the BASE prefix and any leading slash.
+	// Strip the BASE prefix and any leading slash / query string.
 	let stripped = path.startsWith(BASE) ? path.slice(BASE.length) : path;
 	const qIdx = stripped.indexOf('?');
 	if (qIdx >= 0) stripped = stripped.slice(0, qIdx);
 	if (stripped.startsWith('/')) stripped = stripped.slice(1);
 	const parts = stripped.split('/');
-	if (parts.length < 2 || parts[0] !== 'workspaces' || !parts[1]) {
+	if (parts.length < 3 || parts[0] !== 'workspaces' || !parts[1]) {
 		return null;
 	}
-	return { kind: 'workspace', workspace: parts[1] };
+	const ws = parts[1];
+	const tail = parts[2];
+
+	// /workspaces/{ws}/items-index   |  /workspaces/{ws}/items-changes
+	if (parts.length === 3 && (tail === 'items-index' || tail === 'items-changes')) {
+		return { kind: 'workspace', workspace: ws };
+	}
+	// /workspaces/{ws}/items                 (list)
+	// /workspaces/{ws}/items/{idOrSlug}      (single read — exact, no subroute)
+	if (parts.length === 3 && tail === 'items') {
+		return { kind: 'workspace', workspace: ws };
+	}
+	if (parts.length === 4 && tail === 'items') {
+		return { kind: 'workspace', workspace: ws };
+	}
+	// /workspaces/{ws}/collections/{coll}/items
+	if (
+		parts.length === 5 &&
+		tail === 'collections' &&
+		parts[4] === 'items'
+	) {
+		return { kind: 'workspace', workspace: ws };
+	}
+	return null;
 }
 
 /**

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -67,6 +67,92 @@ class PadApiError extends Error {
 	}
 }
 
+/**
+ * `AccessRevokedScope` describes WHAT the 403 response was for so the
+ * registered handler can purge the right slice of the local cache.
+ * Per DOC-1342 design decision #3: the local cache is "what you could
+ * see last time you synced" — a 403 mid-session means access was
+ * revoked, and the offending entry should drop.
+ *
+ *   - `item`: a 403 on `/workspaces/{ws}/items/{idOrSlug}`. The
+ *      handler resolves the id-or-slug against the local index and
+ *      removes the matching row.
+ *   - `collection`: a 403 on `/workspaces/{ws}/collections/{coll}/items`
+ *      (or similar collection-scoped endpoint). The handler removes
+ *      every row in that collection.
+ */
+export type AccessRevokedScope =
+	| { kind: 'item'; workspace: string; idOrSlug: string }
+	| { kind: 'collection'; workspace: string; collection: string };
+
+type AccessRevokedHandler = (scope: AccessRevokedScope) => void;
+
+let accessRevokedHandler: AccessRevokedHandler | null = null;
+
+/**
+ * Register a single callback fired when the API client sees a 403
+ * Forbidden response on a workspace-scoped item or collection
+ * endpoint. The app calls this once at startup (typically from
+ * +layout.svelte) to wire `localIndex` purges into the API error
+ * path without forming a client.ts → store circular dependency.
+ *
+ * Calling this multiple times replaces the previous handler.
+ * Handler failures are caught and logged; the 403 still propagates
+ * to the caller as a `PadApiError`.
+ */
+export function setAccessRevokedHandler(handler: AccessRevokedHandler | null): void {
+	accessRevokedHandler = handler;
+}
+
+/**
+ * Parse a workspace-scoped URL path and infer the purge scope. Returns
+ * null if the URL doesn't match a known item / collection-items
+ * shape. Pure / non-throwing.
+ */
+function parseAccessRevokedScope(path: string): AccessRevokedScope | null {
+	// Strip the BASE prefix and any leading slash.
+	let stripped = path.startsWith(BASE) ? path.slice(BASE.length) : path;
+	const qIdx = stripped.indexOf('?');
+	if (qIdx >= 0) stripped = stripped.slice(0, qIdx);
+	if (stripped.startsWith('/')) stripped = stripped.slice(1);
+	const parts = stripped.split('/');
+	// workspaces / {ws} / collections / {coll} / items[/...]
+	if (
+		parts.length >= 5 &&
+		parts[0] === 'workspaces' &&
+		parts[2] === 'collections' &&
+		parts[4] === 'items'
+	) {
+		return { kind: 'collection', workspace: parts[1], collection: parts[3] };
+	}
+	// workspaces / {ws} / items / {idOrSlug}[/...]
+	if (
+		parts.length >= 4 &&
+		parts[0] === 'workspaces' &&
+		parts[2] === 'items'
+	) {
+		return { kind: 'item', workspace: parts[1], idOrSlug: parts[3] };
+	}
+	return null;
+}
+
+/**
+ * Fire the registered access-revoked handler for a 403 response. The
+ * handler is called best-effort — its failures are swallowed so the
+ * caller still sees a clean PadApiError. Public for testing.
+ */
+function notifyAccessRevoked(path: string): void {
+	if (!accessRevokedHandler) return;
+	const scope = parseAccessRevokedScope(path);
+	if (!scope) return;
+	try {
+		accessRevokedHandler(scope);
+	} catch (err) {
+		// eslint-disable-next-line no-console
+		console.warn('access-revoked handler threw', err);
+	}
+}
+
 function getCSRFToken(): string | null {
 	if (typeof document === 'undefined') return null;
 	// Check __Host- prefixed cookie first (secure/TLS mode), fall back to unprefixed
@@ -97,6 +183,14 @@ async function request<T>(path: string, options?: RequestInit): Promise<T> {
 			window.location.href = '/login';
 		}
 		throw new PadApiError({ code: 'unauthorized', message: 'Authentication required' });
+	}
+	if (resp.status === 403) {
+		// Signal the registered access-revoked handler BEFORE
+		// throwing, so the local cache purges its stale entry as
+		// part of the same error path (DOC-1342 decision #3, TASK-1360).
+		// The handler is best-effort and never throws into the API
+		// client.
+		notifyAccessRevoked(path);
 	}
 	if (!resp.ok) {
 		const body = await resp.json().catch(() => null);

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -74,16 +74,17 @@ class PadApiError extends Error {
  * see last time you synced" — a 403 mid-session means access was
  * revoked, and the offending entry should drop.
  *
- *   - `item`: a 403 on `/workspaces/{ws}/items/{idOrSlug}`. The
- *      handler resolves the id-or-slug against the local index and
- *      removes the matching row.
- *   - `collection`: a 403 on `/workspaces/{ws}/collections/{coll}/items`
- *      (or similar collection-scoped endpoint). The handler removes
- *      every row in that collection.
+ * The scope is the WHOLE WORKSPACE. Pad's server returns 403 from
+ * the workspace-access middleware (see internal/server/middleware_auth.go:
+ * `permission_denied`, `not a member of this workspace`), and item-
+ * level visibility misses return 404. So a 403 on any workspace-scoped
+ * endpoint means access to the workspace is gone — purging a single
+ * item or collection would leave the rest of the cache stale.
+ * Per-item granular purge was attempted in TASK-1360 round 1 and
+ * round 2 (Codex P1 each) — both got the scope wrong; this is the
+ * conservative fix.
  */
-export type AccessRevokedScope =
-	| { kind: 'item'; workspace: string; idOrSlug: string }
-	| { kind: 'collection'; workspace: string; collection: string };
+export type AccessRevokedScope = { kind: 'workspace'; workspace: string };
 
 type AccessRevokedHandler = (scope: AccessRevokedScope) => void;
 
@@ -105,9 +106,9 @@ export function setAccessRevokedHandler(handler: AccessRevokedHandler | null): v
 }
 
 /**
- * Parse a workspace-scoped URL path and infer the purge scope. Returns
- * null if the URL doesn't match a known item / collection-items
- * shape. Pure / non-throwing.
+ * Parse a workspace-scoped URL path and extract the workspace slug if
+ * present. Returns null for non-workspace-scoped paths (auth,
+ * admin, health, etc.). Pure / non-throwing.
  */
 function parseAccessRevokedScope(path: string): AccessRevokedScope | null {
 	// Strip the BASE prefix and any leading slash.
@@ -116,24 +117,10 @@ function parseAccessRevokedScope(path: string): AccessRevokedScope | null {
 	if (qIdx >= 0) stripped = stripped.slice(0, qIdx);
 	if (stripped.startsWith('/')) stripped = stripped.slice(1);
 	const parts = stripped.split('/');
-	// workspaces / {ws} / collections / {coll} / items[/...]
-	if (
-		parts.length >= 5 &&
-		parts[0] === 'workspaces' &&
-		parts[2] === 'collections' &&
-		parts[4] === 'items'
-	) {
-		return { kind: 'collection', workspace: parts[1], collection: parts[3] };
+	if (parts.length < 2 || parts[0] !== 'workspaces' || !parts[1]) {
+		return null;
 	}
-	// workspaces / {ws} / items / {idOrSlug}[/...]
-	if (
-		parts.length >= 4 &&
-		parts[0] === 'workspaces' &&
-		parts[2] === 'items'
-	) {
-		return { kind: 'item', workspace: parts[1], idOrSlug: parts[3] };
-	}
-	return null;
+	return { kind: 'workspace', workspace: parts[1] };
 }
 
 /**

--- a/web/src/lib/stores/localIndex.svelte.ts
+++ b/web/src/lib/stores/localIndex.svelte.ts
@@ -634,6 +634,49 @@ export const localIndex = {
 		persistRemovals(state.userId, ws, [id]).catch(() => undefined);
 	},
 
+	/**
+	 * Bulk-remove every item whose `collection_slug` matches. Used by
+	 * the 403-purge path (TASK-1360) when a collection-level fetch
+	 * returns `forbidden` — the entire collection's grants are now
+	 * gone, so every row from that collection should drop. The
+	 * remaining workspace state (other collections) stays intact.
+	 *
+	 * Idempotent — no-op when the workspace state isn't loaded or no
+	 * rows match.
+	 */
+	removeByCollection(ws: string, collSlug: string): void {
+		const state = workspaces.get(ws);
+		if (!state) return;
+		const ids: string[] = [];
+		for (const row of state.items.values()) {
+			if (row.collection_slug === collSlug) ids.push(row.id);
+		}
+		for (const id of ids) state.items.delete(id);
+		if (ids.length > 0) {
+			persistRemovals(state.userId, ws, ids).catch(() => undefined);
+		}
+	},
+
+	/**
+	 * Look up an item by EITHER id OR slug within a workspace. Used
+	 * by the 403-purge path so a 403 on `/items/{slug}` can resolve
+	 * the slug to the in-RAM id (the SvelteMap is keyed by id) and
+	 * then drop the row. Returns null if no match.
+	 */
+	findByIdOrSlug(ws: string, idOrSlug: string): ItemIndexRow | null {
+		const state = workspaces.get(ws);
+		if (!state) return null;
+		// Try id first (O(1) Map lookup).
+		const byId = state.items.get(idOrSlug);
+		if (byId) return byId;
+		// Fall through to slug (O(n) scan — acceptable for the purge
+		// path; collection-page reads use the id-keyed map).
+		for (const row of state.items.values()) {
+			if (row.slug === idOrSlug) return row;
+		}
+		return null;
+	},
+
 	/** Current cursor for a workspace, or "0" if unhydrated. */
 	cursorFor(ws: string): string {
 		return workspaces.get(ws)?.cursor ?? '0';

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -37,19 +37,15 @@
 
 	// Register the 403-purge handler ONCE at app bootstrap (PLAN-1343
 	// / TASK-1360). The API client's request() path invokes this on
-	// 403 for workspace-scoped item / collection-items endpoints; we
-	// route the signal into localIndex so stale-by-permission rows
-	// drop out of the in-RAM + IDB cache as part of the same error
-	// path that surfaces the PadApiError to the caller. Registration
-	// lives here instead of inside client.ts to keep client.ts free
-	// of a store import that would create a circular dep.
+	// GET/HEAD 403 for workspace-scoped endpoints; we drop the
+	// entire workspace cache because Pad's 403 source is the
+	// workspace-access middleware, which means access to the whole
+	// workspace is gone — purging a single row would leave the rest
+	// stale (Codex round 2 of TASK-1360). Registration lives here
+	// instead of inside client.ts to keep client.ts free of a store
+	// import that would create a circular dep.
 	setAccessRevokedHandler((scope) => {
-		if (scope.kind === 'item') {
-			const row = localIndex.findByIdOrSlug(scope.workspace, scope.idOrSlug);
-			if (row) localIndex.remove(scope.workspace, row.id);
-		} else {
-			localIndex.removeByCollection(scope.workspace, scope.collection);
-		}
+		localIndex.reset(scope.workspace);
 	});
 
 	onMount(async () => {

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -7,6 +7,8 @@
 	import { authStore } from '$lib/stores/auth.svelte';
 	import { uiStore } from '$lib/stores/ui.svelte';
 	import { titleStore } from '$lib/stores/title.svelte';
+	import { setAccessRevokedHandler } from '$lib/api/client';
+	import { localIndex } from '$lib/stores/localIndex.svelte';
 	import Sidebar from '$lib/components/layout/Sidebar.svelte';
 	import TopBar from '$lib/components/layout/TopBar.svelte';
 	import CommandPalette from '$lib/components/search/CommandPalette.svelte';
@@ -32,6 +34,23 @@
 	);
 	let isSharePage = $derived(page.url.pathname.startsWith('/s/'));
 	let isConsolePage = $derived(page.url.pathname.startsWith('/console'));
+
+	// Register the 403-purge handler ONCE at app bootstrap (PLAN-1343
+	// / TASK-1360). The API client's request() path invokes this on
+	// 403 for workspace-scoped item / collection-items endpoints; we
+	// route the signal into localIndex so stale-by-permission rows
+	// drop out of the in-RAM + IDB cache as part of the same error
+	// path that surfaces the PadApiError to the caller. Registration
+	// lives here instead of inside client.ts to keep client.ts free
+	// of a store import that would create a circular dep.
+	setAccessRevokedHandler((scope) => {
+		if (scope.kind === 'item') {
+			const row = localIndex.findByIdOrSlug(scope.workspace, scope.idOrSlug);
+			if (row) localIndex.remove(scope.workspace, row.id);
+		} else {
+			localIndex.removeByCollection(scope.workspace, scope.collection);
+		}
+	});
 
 	onMount(async () => {
 		// Initialize theme


### PR DESCRIPTION
## Summary
- API client now invokes a registered handler on 403 responses for workspace-scoped item / collection-items endpoints (with URL parsing).
- New \`localIndex.removeByCollection\` and \`findByIdOrSlug\` helpers cover the two purge shapes.
- App bootstrap (\`+layout.svelte\`) wires the handler so client.ts stays free of a store import (no circular dep).

## Context
Implements \`TASK-1360\` under \`PLAN-1343\` (Phase 2). See \`DOC-1342\` design decision #3 — best-effort cache + 403-on-fetch purge.

## Test plan
- [x] \`npm run check\` — clean
- [ ] Manual: revoke a collection grant mid-session, click an item, confirm the row drops from list view and IDB