### PR TITLE
feat(web): collection page search uses localSearch (TASK-1364)

### DIFF
--- a/web/src/lib/components/collections/FilterBar.svelte
+++ b/web/src/lib/components/collections/FilterBar.svelte
@@ -163,11 +163,19 @@
 	{/if}
 
 	<div class="search-wrapper">
+		<!--
+			Search hits the local in-memory index (titles + parsed fields)
+			for sub-millisecond typing. Prefix with `body:` or `content:`
+			to fall back to server FTS over the rich-text body — that's
+			the only way to grep content, which doesn't live in the
+			client-side index by design (PLAN-1343 / DOC-1342 Phase 3b).
+		-->
 		<input
 			bind:this={searchInputEl}
 			type="text"
 			class="search-input"
 			placeholder="Search {collection.name.toLowerCase()}..."
+			title="Search titles + fields locally. Prefix with `body:` to search content text."
 			value={searchQuery}
 			oninput={handleSearchInput}
 			onkeydown={(e) => { if (e.key === 'Escape') { onSearchChange(''); searchInputEl?.blur(); } }}

--- a/web/src/lib/stores/localSearch.svelte.ts
+++ b/web/src/lib/stores/localSearch.svelte.ts
@@ -43,6 +43,7 @@
 // stop words). TASK-1364 and TASK-1365 wire consumers.
 
 import MiniSearch from 'minisearch';
+import { SvelteMap } from 'svelte/reactivity';
 import type { ItemIndexRow } from '$lib/types';
 import { parseFields } from '$lib/types';
 
@@ -213,6 +214,21 @@ function buildDoc(row: ItemIndexRow): IndexedDoc {
 
 const indexes = new Map<string, MiniSearch<IndexedDoc>>();
 
+// `epochs` is a reactive per-workspace counter bumped on every index
+// mutation. Consumers (collection page, CommandPalette) read it inside
+// a Svelte 5 `$effect` to re-derive `searchResultIds` automatically
+// when the underlying index changes — without this, an SSE-driven
+// `localIndex.upsert` would update the canonical row list but the
+// search filter Set would go stale and a freshly-matching item could
+// stay hidden, or an edited item that no longer matches could stay
+// visible until the user retyped the query (Codex round 3 P2 of
+// TASK-1364). Reactive `SvelteMap` so per-workspace reads are tracked.
+const epochs = new SvelteMap<string, number>();
+
+function bumpEpoch(ws: string): void {
+	epochs.set(ws, (epochs.get(ws) ?? 0) + 1);
+}
+
 function ensureIndex(ws: string): MiniSearch<IndexedDoc> {
 	let idx = indexes.get(ws);
 	if (!idx) {
@@ -250,6 +266,7 @@ export const localSearch = {
 		// batches the inverted-index updates.
 		if (docs.length > 0) idx.addAll(docs);
 		indexes.set(ws, idx);
+		bumpEpoch(ws);
 	},
 
 	/**
@@ -272,6 +289,7 @@ export const localSearch = {
 		// MiniSearch-recommended pattern for in-place mutation.
 		if (idx.has(doc.id)) idx.discard(doc.id);
 		idx.add(doc);
+		bumpEpoch(ws);
 	},
 
 	/**
@@ -282,7 +300,10 @@ export const localSearch = {
 		if (!ssrSafe()) return;
 		const idx = indexes.get(ws);
 		if (!idx) return;
-		if (idx.has(id)) idx.discard(id);
+		if (idx.has(id)) {
+			idx.discard(id);
+			bumpEpoch(ws);
+		}
 	},
 
 	/**
@@ -292,6 +313,18 @@ export const localSearch = {
 	 */
 	reset(ws: string): void {
 		indexes.delete(ws);
+		epochs.delete(ws);
+	},
+
+	/**
+	 * Reactive per-workspace mutation epoch. Bumped on every successful
+	 * `rebuild` / `upsert` / `remove`. Consumers should READ this inside
+	 * a `$effect` so their derived state (e.g. a `searchResultIds` Set
+	 * that intersects local items with a query) re-runs whenever the
+	 * underlying index changes — Codex round 3 P2 of TASK-1364.
+	 */
+	epoch(ws: string): number {
+		return epochs.get(ws) ?? 0;
 	},
 
 	/**

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -743,32 +743,50 @@
 	}
 
 	function handleSearchChange(query: string) {
+		// Pure setter — the reactive effect below runs the actual search.
+		// Keeping this small means non-input entry points (URL load via
+		// `loadUrlFilters`, programmatic clears) get the same search
+		// behavior without duplicating the local/server dispatch logic
+		// (Codex round 1 P2: shared `?q=body:foo` URLs previously
+		// landed in the local fallback because `loadUrlFilters` set
+		// `searchQuery` directly and never invoked the dispatch).
 		searchQuery = query;
 		updateUrlFilters();
+	}
+
+	// Search dispatch. Tracks `searchQuery` (any entry point that mutates
+	// it — typed input, URL load, programmatic clears), `showArchived`
+	// (re-run local search when archived rows toggle in/out of scope),
+	// and `indexReady` (cold load: query typed before bootstrap finishes;
+	// kick the search once the index hydrates). Body-prefix queries
+	// route to server FTS with a 200ms debounce; everything else hits
+	// the in-memory MiniSearch index synchronously.
+	$effect(() => {
+		void showArchived;
+		void indexReady;
+		const trimmed = searchQuery.trim();
 
 		clearTimeout(searchTimeout);
-		const trimmed = query.trim();
 		if (!trimmed) {
-			searchResultIds = null; // null = no search active, show all items
+			searchResultIds = null; // null = no search active
 			return;
 		}
 
 		// `body:` / `content:` prefix — fall through to the server FTS
-		// endpoint, which searches the rich-text body. Local index does
-		// not hold `content`, so this prefix is the only way to grep
-		// bodies. A short 200ms debounce keeps the network path
-		// hammer-resistant while typing; the local synchronous path
-		// below doesn't need one because each call is <1ms.
+		// endpoint, which searches the rich-text body. The local index
+		// does not hold `content` by design (DOC-1342 decision #4), so
+		// this prefix is the only way to grep bodies. A 200ms debounce
+		// keeps the network path hammer-resistant while typing.
 		if (BODY_SEARCH_PREFIX_RE.test(trimmed)) {
 			const bodyQuery = stripBodyPrefix(trimmed);
 			if (!bodyQuery) {
 				searchResultIds = null;
 				return;
 			}
-			// Clear stale results immediately so the unfiltered fallback
+			// Clear stale results immediately so the substring fallback
 			// renders while the network response is pending.
 			searchResultIds = null;
-			const snapshotQuery = query;
+			const snapshotQuery = trimmed;
 			searchTimeout = setTimeout(async () => {
 				try {
 					const resp = await api.search(bodyQuery, {
@@ -776,41 +794,25 @@
 						collection: collSlug,
 						limit: 200,
 					});
-					if (searchQuery !== snapshotQuery) return;
+					if (searchQuery.trim() !== snapshotQuery) return;
 					searchResultIds = new Set(resp.results.map((r) => r.item.id));
 				} catch {
-					if (searchQuery === snapshotQuery) searchResultIds = null;
+					if (searchQuery.trim() === snapshotQuery) searchResultIds = null;
 				}
 			}, 200);
 			return;
 		}
 
 		// Local path (default). MiniSearch is sub-millisecond for 5,000
-		// rows so we can run it synchronously on every keystroke — no
-		// debounce, no API call. PLAN-1343 Phase 3b acceptance: keystroke
-		// → first results <50ms P95. Archived rows participate when the
-		// `showArchived` toggle is on.
-		const hits = localSearch.search(wsSlug, trimmed, {
-			collection: collSlug,
-			includeArchived: showArchived,
-			limit: 200,
-		});
-		searchResultIds = new Set(hits.map((h) => h.id));
-	}
-
-	// Re-run local search when the toggle that affects its inclusion
-	// rules (showArchived) flips, OR when the index transitions to
-	// 'ready' under an already-typed query (cold load: user typed before
-	// bootstrap finished; once it's ready, populate the result set).
-	// Skipped for the server FTS path because that's handled by the
-	// debounced timer.
-	$effect(() => {
-		void showArchived;
-		void indexReady;
-		const trimmed = searchQuery.trim();
-		if (!trimmed) return;
-		if (BODY_SEARCH_PREFIX_RE.test(trimmed)) return;
-		if (!indexReady) return;
+		// rows — runs synchronously on every dependency change. PLAN-1343
+		// Phase 3b acceptance: keystroke → first results <50ms P95.
+		// When the index isn't ready yet (very narrow cold-load window),
+		// leave `searchResultIds = null` so the substring fallback in
+		// `filteredItems` kicks in until hydrate completes.
+		if (!indexReady) {
+			searchResultIds = null;
+			return;
+		}
 		const hits = localSearch.search(wsSlug, trimmed, {
 			collection: collSlug,
 			includeArchived: showArchived,

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -755,16 +755,22 @@
 	}
 
 	// Search dispatch. Tracks `searchQuery` (any entry point that mutates
-	// it — typed input, URL load, programmatic clears), `showArchived`
-	// (re-run local search when archived rows toggle in/out of scope),
-	// and `indexReady` (cold load: query typed before bootstrap finishes;
-	// kick the search once the index hydrates). Body-prefix queries
-	// route to server FTS with a 200ms debounce; everything else hits
-	// the in-memory MiniSearch index synchronously.
+	// it — typed input, URL load, programmatic clears), `wsSlug` /
+	// `collSlug` (navigation across workspaces or collections must drop
+	// stale results and re-issue against the new route — Codex round 2
+	// P2), `showArchived` (re-run local search when archived rows toggle
+	// in/out of scope), and `indexReady` (cold load: query typed before
+	// bootstrap finishes; kick the search once the index hydrates).
+	// Body-prefix queries route to server FTS with a 200ms debounce;
+	// everything else hits the in-memory MiniSearch index synchronously.
 	$effect(() => {
 		void showArchived;
 		void indexReady;
 		const trimmed = searchQuery.trim();
+		// Snapshot the route at effect-run time so a navigation mid-flight
+		// can't let an old response populate the new route.
+		const snapshotWs = wsSlug;
+		const snapshotColl = collSlug;
 
 		clearTimeout(searchTimeout);
 		if (!trimmed) {
@@ -790,14 +796,29 @@
 			searchTimeout = setTimeout(async () => {
 				try {
 					const resp = await api.search(bodyQuery, {
-						workspace: wsSlug,
-						collection: collSlug,
+						workspace: snapshotWs,
+						collection: snapshotColl,
 						limit: 200,
 					});
-					if (searchQuery.trim() !== snapshotQuery) return;
+					// Stale-response guard: drop the result if the user
+					// navigated away or changed the query while the
+					// request was in flight.
+					if (
+						searchQuery.trim() !== snapshotQuery ||
+						wsSlug !== snapshotWs ||
+						collSlug !== snapshotColl
+					) {
+						return;
+					}
 					searchResultIds = new Set(resp.results.map((r) => r.item.id));
 				} catch {
-					if (searchQuery.trim() === snapshotQuery) searchResultIds = null;
+					if (
+						searchQuery.trim() === snapshotQuery &&
+						wsSlug === snapshotWs &&
+						collSlug === snapshotColl
+					) {
+						searchResultIds = null;
+					}
 				}
 			}, 200);
 			return;
@@ -813,8 +834,8 @@
 			searchResultIds = null;
 			return;
 		}
-		const hits = localSearch.search(wsSlug, trimmed, {
-			collection: collSlug,
+		const hits = localSearch.search(snapshotWs, trimmed, {
+			collection: snapshotColl,
 			includeArchived: showArchived,
 			limit: 200,
 		});

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -766,6 +766,12 @@
 	$effect(() => {
 		void showArchived;
 		void indexReady;
+		// Track the localSearch mutation epoch so SSE-driven upserts /
+		// removes refresh `searchResultIds` while a query is active —
+		// without this, a row created after the query was typed would
+		// stay hidden (and a row edited out of relevance would stay
+		// visible) until the user retyped. Codex round 3 P2 of TASK-1364.
+		void localSearch.epoch(wsSlug);
 		const trimmed = searchQuery.trim();
 		// Snapshot the route at effect-run time so a navigation mid-flight
 		// can't let an old response populate the new route.

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -22,6 +22,7 @@
 	import { workspaceStore } from '$lib/stores/workspace.svelte';
 	import { authStore } from '$lib/stores/auth.svelte';
 	import { localIndex } from '$lib/stores/localIndex.svelte';
+	import { localSearch } from '$lib/stores/localSearch.svelte';
 
 	type ViewMode = 'list' | 'board' | 'table';
 
@@ -624,11 +625,17 @@
 			});
 		}
 
-		// Apply search query (API-backed FTS)
+		// Apply search query. PLAN-1343 Phase 3b: the local path
+		// populates `searchResultIds` synchronously (sub-ms) so the
+		// filter just intersects. The substring fallback below covers
+		// the body:/content: server-FTS path while its 200ms debounce
+		// is in flight — and the very narrow window after a cold
+		// workspace load where indexReady is still false.
 		if (searchQuery.trim() && searchResultIds !== null) {
 			result = result.filter((item) => searchResultIds!.has(item.id));
 		} else if (searchQuery.trim()) {
-			// Fallback to client-side search while API response is pending
+			// Fallback to client-side substring scan while the server
+			// FTS response is pending or the local index is mid-bootstrap.
 			const q = searchQuery.trim().toLowerCase();
 			result = result.filter((item) => {
 				if (item.title.toLowerCase().includes(q)) return true;
@@ -724,34 +731,93 @@
 		updateUrlFilters();
 	}
 
+	// Prefix routes that opt into the server-side FTS path so the rich-text
+	// body is searchable. `body:` / `content:` prefixes hit `/api/v1/search`
+	// (server FTS over `i.content`) since the in-memory localSearch index
+	// only covers titles + parsed fields by design — content bodies live
+	// on the server (DOC-1342 / TASK-1363). PLAN-1343 Phase 3b.
+	const BODY_SEARCH_PREFIX_RE = /^(?:body|content):\s*/i;
+
+	function stripBodyPrefix(query: string): string {
+		return query.replace(BODY_SEARCH_PREFIX_RE, '').trim();
+	}
+
 	function handleSearchChange(query: string) {
 		searchQuery = query;
 		updateUrlFilters();
 
-		// API-backed search with debounce for FTS (searches content, not just titles)
 		clearTimeout(searchTimeout);
-		if (!query.trim()) {
+		const trimmed = query.trim();
+		if (!trimmed) {
 			searchResultIds = null; // null = no search active, show all items
 			return;
 		}
-		// Clear stale results immediately so client-side fallback kicks in
-		searchResultIds = null;
-		const snapshotQuery = query;
-		searchTimeout = setTimeout(async () => {
-			try {
-				const resp = await api.search(snapshotQuery, {
-					workspace: wsSlug,
-					collection: collSlug,
-					limit: 200,
-				});
-				// Discard if query changed while loading
-				if (searchQuery !== snapshotQuery) return;
-				searchResultIds = new Set(resp.results.map((r) => r.item.id));
-			} catch {
-				if (searchQuery === snapshotQuery) searchResultIds = null;
+
+		// `body:` / `content:` prefix — fall through to the server FTS
+		// endpoint, which searches the rich-text body. Local index does
+		// not hold `content`, so this prefix is the only way to grep
+		// bodies. A short 200ms debounce keeps the network path
+		// hammer-resistant while typing; the local synchronous path
+		// below doesn't need one because each call is <1ms.
+		if (BODY_SEARCH_PREFIX_RE.test(trimmed)) {
+			const bodyQuery = stripBodyPrefix(trimmed);
+			if (!bodyQuery) {
+				searchResultIds = null;
+				return;
 			}
-		}, 200);
+			// Clear stale results immediately so the unfiltered fallback
+			// renders while the network response is pending.
+			searchResultIds = null;
+			const snapshotQuery = query;
+			searchTimeout = setTimeout(async () => {
+				try {
+					const resp = await api.search(bodyQuery, {
+						workspace: wsSlug,
+						collection: collSlug,
+						limit: 200,
+					});
+					if (searchQuery !== snapshotQuery) return;
+					searchResultIds = new Set(resp.results.map((r) => r.item.id));
+				} catch {
+					if (searchQuery === snapshotQuery) searchResultIds = null;
+				}
+			}, 200);
+			return;
+		}
+
+		// Local path (default). MiniSearch is sub-millisecond for 5,000
+		// rows so we can run it synchronously on every keystroke — no
+		// debounce, no API call. PLAN-1343 Phase 3b acceptance: keystroke
+		// → first results <50ms P95. Archived rows participate when the
+		// `showArchived` toggle is on.
+		const hits = localSearch.search(wsSlug, trimmed, {
+			collection: collSlug,
+			includeArchived: showArchived,
+			limit: 200,
+		});
+		searchResultIds = new Set(hits.map((h) => h.id));
 	}
+
+	// Re-run local search when the toggle that affects its inclusion
+	// rules (showArchived) flips, OR when the index transitions to
+	// 'ready' under an already-typed query (cold load: user typed before
+	// bootstrap finished; once it's ready, populate the result set).
+	// Skipped for the server FTS path because that's handled by the
+	// debounced timer.
+	$effect(() => {
+		void showArchived;
+		void indexReady;
+		const trimmed = searchQuery.trim();
+		if (!trimmed) return;
+		if (BODY_SEARCH_PREFIX_RE.test(trimmed)) return;
+		if (!indexReady) return;
+		const hits = localSearch.search(wsSlug, trimmed, {
+			collection: collSlug,
+			includeArchived: showArchived,
+			limit: 200,
+		});
+		searchResultIds = new Set(hits.map((h) => h.id));
+	});
 
 	async function handleStatusChange(item: Item, newValue: string) {
 		if (!wsSlug) return;


### PR DESCRIPTION
## Summary

Phase 3b of the local-first read model (PLAN-1343 / DOC-1342): replace the collection page's debounced `api.search` round-trip with `localSearch.search`, making the search box sub-millisecond.

- `handleSearchChange` runs `localSearch.search(...)` synchronously on every keystroke. No debounce — local search is <1ms.
- `body:` / `content:` prefix routes back to the server FTS endpoint (200ms debounce preserved) so the rich-text body stays searchable. The local index intentionally excludes content (DOC-1342 decision #4 — content is server-only).
- New `$effect` re-runs the local search when `showArchived` or `indexReady` flip mid-typing, so cold-load + already-typed queries surface results once the index hydrates and the archived toggle re-evaluates an active query.
- FilterBar input gets a `title=` tooltip documenting the `body:` prefix UX.
- Existing client-side substring fallback now covers two narrow cases: server-FTS in-flight and cold-load bootstrap window.

## Context

Implements `TASK-1364` under `PLAN-1343`. Builds on TASK-1363 (localSearch module).

## Test plan

- [x] `make check` — golangci-lint + go test + svelte-check + npm build all clean
- [ ] Manual: open a collection page, type — results appear with zero network requests
- [ ] Manual: `body:foo` triggers a server `/search` request
- [ ] Manual: toggle `showArchived` while a query is active — results update to include/exclude archived rows