### PR TITLE
feat(web): localSearch relevance + ref/number matchers (TASK-1367)

### DIFF
--- a/web/src/lib/components/collections/BoardView.svelte
+++ b/web/src/lib/components/collections/BoardView.svelte
@@ -277,7 +277,12 @@
 					type: 'board-card',
 					dropTargetClasses: ['drop-target'],
 					delayTouchStart: touchDragDelayMs,
-					dragDisabled: isMobile || !canEdit
+					// Disable item DnD whenever the parent has
+					// requested rank-preserving order (search
+					// active) — otherwise a drag would persist the
+					// relevance-ranked subset order as the stored
+					// `sort_order`. TASK-1367 / Codex R5.
+					dragDisabled: isMobile || !canEdit || preserveOrder
 				}}
 				onconsider={(e) => handleConsider(colValue, e)}
 				onfinalize={(e) => handleFinalize(colValue, e)}

--- a/web/src/lib/components/collections/BoardView.svelte
+++ b/web/src/lib/components/collections/BoardView.svelte
@@ -27,9 +27,17 @@
 		 * Default true preserves behavior in callers that don't pass it.
 		 */
 		canEdit?: boolean;
+		/**
+		 * When true, the in-column `sort_order` sort is skipped and the
+		 * parent's item order is preserved. Used by the collection page
+		 * to surface localSearch's relevance ranking (TASK-1367) —
+		 * otherwise the per-column sort would clobber rank order when
+		 * two matches share a column.
+		 */
+		preserveOrder?: boolean;
 	}
 
-	let { items, collection, wsSlug = '', groupField = 'status', focusedItemId = null, onStatusChange, onReorder, onArchiveColumn, onGroupReorder, oncreate, itemProgress, progressLabel = 'tasks', canEdit = true }: Props = $props();
+	let { items, collection, wsSlug = '', groupField = 'status', focusedItemId = null, onStatusChange, onReorder, onArchiveColumn, onGroupReorder, oncreate, itemProgress, progressLabel = 'tasks', canEdit = true, preserveOrder = false }: Props = $props();
 
 	let confirmArchiveColumn = $state<string | null>(null);
 	let isMobile = $state(false);
@@ -124,8 +132,12 @@
 				result[value].push(item);
 			}
 		}
-		for (const col of columns) {
-			result[col].sort((a, b) => a.sort_order - b.sort_order);
+		// `preserveOrder` opts out of the in-column sort so search rank
+		// from the parent isn't overridden — TASK-1367.
+		if (!preserveOrder) {
+			for (const col of columns) {
+				result[col].sort((a, b) => a.sort_order - b.sort_order);
+			}
 		}
 		return result;
 	});

--- a/web/src/lib/components/collections/FilterBar.svelte
+++ b/web/src/lib/components/collections/FilterBar.svelte
@@ -171,14 +171,16 @@
 			    in the client-side index by design.
 			  - `#5` / `item:5` — exact item-number lookup.
 			  - `TASK-5` — exact-ref hoist to the top of results.
-			  - `is:archived` — include archived rows.
+			(Use the Show archived toggle for archived rows — a
+			combined `is:archived body:` prefix is intentionally
+			deferred until /search supports it.)
 		-->
 		<input
 			bind:this={searchInputEl}
 			type="text"
 			class="search-input"
 			placeholder="Search {collection.name.toLowerCase()}..."
-			title="Search titles + fields locally.&#10;  body:foo  search rich-text body (server)&#10;  #5  exact item number&#10;  TASK-5  exact ref&#10;  is:archived  include archived"
+			title="Search titles + fields locally.&#10;  body:foo  search rich-text body (server)&#10;  #5  exact item number&#10;  TASK-5  exact ref"
 			value={searchQuery}
 			oninput={handleSearchInput}
 			onkeydown={(e) => { if (e.key === 'Escape') { onSearchChange(''); searchInputEl?.blur(); } }}

--- a/web/src/lib/components/collections/FilterBar.svelte
+++ b/web/src/lib/components/collections/FilterBar.svelte
@@ -165,17 +165,20 @@
 	<div class="search-wrapper">
 		<!--
 			Search hits the local in-memory index (titles + parsed fields)
-			for sub-millisecond typing. Prefix with `body:` or `content:`
-			to fall back to server FTS over the rich-text body — that's
-			the only way to grep content, which doesn't live in the
-			client-side index by design (PLAN-1343 / DOC-1342 Phase 3b).
+			for sub-millisecond typing. Prefix vocabulary (TASK-1367):
+			  - `body:foo` / `content:foo` — server FTS over the rich-text
+			    body. The only way to grep content, which doesn't live
+			    in the client-side index by design.
+			  - `#5` / `item:5` — exact item-number lookup.
+			  - `TASK-5` — exact-ref hoist to the top of results.
+			  - `is:archived` — include archived rows.
 		-->
 		<input
 			bind:this={searchInputEl}
 			type="text"
 			class="search-input"
 			placeholder="Search {collection.name.toLowerCase()}..."
-			title="Search titles + fields locally. Prefix with `body:` to search content text."
+			title="Search titles + fields locally.&#10;  body:foo  search rich-text body (server)&#10;  #5  exact item number&#10;  TASK-5  exact ref&#10;  is:archived  include archived"
 			value={searchQuery}
 			oninput={handleSearchInput}
 			onkeydown={(e) => { if (e.key === 'Escape') { onSearchChange(''); searchInputEl?.blur(); } }}

--- a/web/src/lib/components/collections/ListView.svelte
+++ b/web/src/lib/components/collections/ListView.svelte
@@ -299,7 +299,12 @@
 							type: 'list-item',
 							dropTargetClasses: ['drop-target'],
 							delayTouchStart: touchDragDelayMs,
-							dragDisabled: !canEdit
+							// Disable item DnD whenever the parent has
+							// requested rank-preserving order (search
+							// active) — otherwise a drag would persist
+							// the relevance-ranked subset order as the
+							// stored `sort_order`. TASK-1367 / Codex R5.
+							dragDisabled: !canEdit || preserveOrder
 						}}
 						onconsider={(e) => handleConsider(groupName, e)}
 						onfinalize={(e) => handleFinalize(groupName, e)}

--- a/web/src/lib/components/collections/ListView.svelte
+++ b/web/src/lib/components/collections/ListView.svelte
@@ -37,6 +37,15 @@
 		 * on the resulting mutations, so no security gap here.
 		 */
 		canEdit?: boolean;
+		/**
+		 * When true, the in-group `sort_order` sort is skipped and the
+		 * parent's item order is preserved. Used by the collection page
+		 * to surface localSearch's relevance ranking (exact-ref hoist
+		 * + boost tuning, TASK-1367) — otherwise the per-group sort
+		 * would clobber the rank order whenever two matches share a
+		 * status column.
+		 */
+		preserveOrder?: boolean;
 	}
 
 	let {
@@ -53,7 +62,8 @@
 		oncreate,
 		itemProgress,
 		progressLabel = 'tasks',
-		canEdit = true
+		canEdit = true,
+		preserveOrder = false
 	}: Props = $props();
 
 	let confirmArchiveGroup = $state<string | null>(null);
@@ -138,8 +148,13 @@
 				result[value] = [item];
 			}
 		}
-		for (const key of Object.keys(result)) {
-			result[key].sort((a, b) => a.sort_order - b.sort_order);
+		// `preserveOrder` opts out of the in-group sort so a parent that
+		// already sorted by relevance (search active) doesn't get its
+		// ranking clobbered when two matches share a column. TASK-1367.
+		if (!preserveOrder) {
+			for (const key of Object.keys(result)) {
+				result[key].sort((a, b) => a.sort_order - b.sort_order);
+			}
 		}
 		return result;
 	});

--- a/web/src/lib/stores/localSearch.svelte.ts
+++ b/web/src/lib/stores/localSearch.svelte.ts
@@ -537,9 +537,11 @@ export const localSearch = {
 		const overfetch = limit * 4;
 		// Pass the residual text (post-prefix-strip) to MiniSearch. If
 		// the user typed nothing but prefixes (`coll:tasks` with no
-		// query) `parsed.text` is empty — return empty so we don't
-		// blanket-match every doc.
-		const searchText = parsed.text || query;
+		// query, `is:archived` with no query) return empty — Codex
+		// round 1 of TASK-1367 caught that the prior `parsed.text ||
+		// query` fallback searched the literal `is`/`archived` /
+		// `coll`/`tasks` tokens, which surfaced unrelated rows.
+		const searchText = parsed.text;
 		if (!searchText.trim()) return [];
 
 		const raw = idx.search(searchText) as Array<{

--- a/web/src/lib/stores/localSearch.svelte.ts
+++ b/web/src/lib/stores/localSearch.svelte.ts
@@ -516,14 +516,22 @@ export const localSearch = {
 		// shouldn't return everything matching anywhere; require the
 		// prefix (TASK-5) OR explicit #5 / item:5 syntax". We accept all
 		// three: TASK-5, #5/item:5, and bare digits — bare digits get
-		// treated as #N for typing-speed. The result is a single doc (or
-		// empty) which we still post-filter by collection / archived so
-		// the caller's scope is honored.
+		// treated as #N for typing-speed (Codex round 2 of TASK-1367
+		// caught that the prior `!parsed.text` guard suppressed the
+		// bare-digit branch because `parseSearchQuery("5")` leaves
+		// "5" in `parsed.text`). The result is a single doc (or empty)
+		// which we still post-filter by collection / archived so the
+		// caller's scope is honored.
 		const bareDigit = /^\d+$/.test(query) ? Number(query) : null;
-		const itemNumberQuery =
-			parsed.itemNumber ?? (bareDigit !== null ? bareDigit : null);
-		if (itemNumberQuery !== null && !parsed.text && !parsed.ref) {
-			return exactItemNumberLookup(idx, itemNumberQuery, {
+		if (parsed.itemNumber !== undefined && !parsed.text && !parsed.ref) {
+			return exactItemNumberLookup(idx, parsed.itemNumber, {
+				limit,
+				includeArchived,
+				wantCollection,
+			});
+		}
+		if (bareDigit !== null) {
+			return exactItemNumberLookup(idx, bareDigit, {
 				limit,
 				includeArchived,
 				wantCollection,

--- a/web/src/lib/stores/localSearch.svelte.ts
+++ b/web/src/lib/stores/localSearch.svelte.ts
@@ -70,24 +70,27 @@ export interface LocalSearchResult {
  *
  *   - `body`: true → server FTS path (local index excludes `content`)
  *   - `collection`: scope the local search to one collection
- *   - `archived`: include soft-deleted rows
  *   - `itemNumber`: exact-number lookup (#5 / item:5 / bare digits)
  *   - `ref`: PREFIX-N pattern detected; the matched doc is hoisted to
  *     the top of `search()` results
  *   - `text`: residual query after prefix stripping; pass to `search()`
+ *
+ * NOTE: an `is:archived` prefix was prototyped but pulled before ship:
+ * the server `/search` endpoint hard-filters `deleted_at IS NULL`, so
+ * combining it with `body:` would silently drop archived hits. The
+ * existing `showArchived` UI toggle is the supported path until the
+ * server endpoint grows `include_archived` support.
  */
 export interface ParsedSearchQuery {
 	text: string;
 	body: boolean;
 	collection?: string;
-	archived: boolean;
 	itemNumber?: number;
 	ref?: string;
 }
 
 const PREFIX_BODY_RE = /^(?:body|content):/i;
 const PREFIX_COLL_RE = /^coll:(.+)$/i;
-const PREFIX_IS_ARCHIVED_RE = /^is:archived$/i;
 const PREFIX_ITEM_NUMBER_RE = /^(?:#|item:)(\d+)$/i;
 const REF_PATTERN_RE = /^([A-Za-z]+)-(\d+)$/;
 
@@ -101,13 +104,12 @@ const REF_PATTERN_RE = /^([A-Za-z]+)-(\d+)$/;
  *   "#5"                   → { itemNumber: 5, text: "", ... }
  *   "body:foo"             → { body: true, text: "foo", ... }
  *   "coll:tasks migrate"   → { collection: "tasks", text: "migrate", ... }
- *   "is:archived hotfix"   → { archived: true, text: "hotfix", ... }
  *
  * Exported so the collection page and CommandPalette share one parser;
  * also makes the prefix UX testable in isolation.
  */
 export function parseSearchQuery(raw: string): ParsedSearchQuery {
-	const out: ParsedSearchQuery = { text: '', body: false, archived: false };
+	const out: ParsedSearchQuery = { text: '', body: false };
 	const tokens = raw.trim().split(/\s+/).filter(Boolean);
 	const residual: string[] = [];
 	for (const tok of tokens) {
@@ -123,10 +125,6 @@ export function parseSearchQuery(raw: string): ParsedSearchQuery {
 		const collMatch = tok.match(PREFIX_COLL_RE);
 		if (collMatch) {
 			out.collection = collMatch[1].toLowerCase();
-			continue;
-		}
-		if (PREFIX_IS_ARCHIVED_RE.test(tok)) {
-			out.archived = true;
 			continue;
 		}
 		const itemMatch = tok.match(PREFIX_ITEM_NUMBER_RE);
@@ -504,9 +502,7 @@ export const localSearch = {
 		const parsed = parseSearchQuery(query);
 
 		const limit = opts.limit ?? 50;
-		// Caller's option wins, but the `is:archived` prefix opts in
-		// implicitly. Parsed prefixes are additive over caller intent.
-		const includeArchived = opts.includeArchived === true || parsed.archived;
+		const includeArchived = opts.includeArchived === true;
 		const wantCollection = opts.collection ?? parsed.collection;
 
 		// Bare-number / explicit item-number queries: short-circuit to an

--- a/web/src/lib/stores/localSearch.svelte.ts
+++ b/web/src/lib/stores/localSearch.svelte.ts
@@ -64,6 +64,91 @@ export interface LocalSearchResult {
 	score: number;
 }
 
+/**
+ * Structured query produced by `parseSearchQuery`. Consumers (collection
+ * page, CommandPalette) destructure to decide what to dispatch:
+ *
+ *   - `body`: true → server FTS path (local index excludes `content`)
+ *   - `collection`: scope the local search to one collection
+ *   - `archived`: include soft-deleted rows
+ *   - `itemNumber`: exact-number lookup (#5 / item:5 / bare digits)
+ *   - `ref`: PREFIX-N pattern detected; the matched doc is hoisted to
+ *     the top of `search()` results
+ *   - `text`: residual query after prefix stripping; pass to `search()`
+ */
+export interface ParsedSearchQuery {
+	text: string;
+	body: boolean;
+	collection?: string;
+	archived: boolean;
+	itemNumber?: number;
+	ref?: string;
+}
+
+const PREFIX_BODY_RE = /^(?:body|content):/i;
+const PREFIX_COLL_RE = /^coll:(.+)$/i;
+const PREFIX_IS_ARCHIVED_RE = /^is:archived$/i;
+const PREFIX_ITEM_NUMBER_RE = /^(?:#|item:)(\d+)$/i;
+const REF_PATTERN_RE = /^([A-Za-z]+)-(\d+)$/;
+
+/**
+ * Parse a free-form search query into structured prefixes + residual
+ * text. Unknown / malformed prefixes pass through as part of `text` so
+ * the user always sees something happen.
+ *
+ * Examples:
+ *   "TASK-5"               → { ref: "TASK-5", text: "TASK-5", ... }
+ *   "#5"                   → { itemNumber: 5, text: "", ... }
+ *   "body:foo"             → { body: true, text: "foo", ... }
+ *   "coll:tasks migrate"   → { collection: "tasks", text: "migrate", ... }
+ *   "is:archived hotfix"   → { archived: true, text: "hotfix", ... }
+ *
+ * Exported so the collection page and CommandPalette share one parser;
+ * also makes the prefix UX testable in isolation.
+ */
+export function parseSearchQuery(raw: string): ParsedSearchQuery {
+	const out: ParsedSearchQuery = { text: '', body: false, archived: false };
+	const tokens = raw.trim().split(/\s+/).filter(Boolean);
+	const residual: string[] = [];
+	for (const tok of tokens) {
+		// body:/content: — strip prefix; any trailing chars (`body:foo`)
+		// become residual text. A bare `body:` keeps the flag and leaves
+		// residual untouched so the user can keep typing.
+		if (PREFIX_BODY_RE.test(tok)) {
+			out.body = true;
+			const rest = tok.slice(tok.indexOf(':') + 1);
+			if (rest) residual.push(rest);
+			continue;
+		}
+		const collMatch = tok.match(PREFIX_COLL_RE);
+		if (collMatch) {
+			out.collection = collMatch[1].toLowerCase();
+			continue;
+		}
+		if (PREFIX_IS_ARCHIVED_RE.test(tok)) {
+			out.archived = true;
+			continue;
+		}
+		const itemMatch = tok.match(PREFIX_ITEM_NUMBER_RE);
+		if (itemMatch) {
+			const n = Number(itemMatch[1]);
+			if (Number.isFinite(n)) out.itemNumber = n;
+			continue;
+		}
+		const refMatch = tok.match(REF_PATTERN_RE);
+		if (refMatch) {
+			// `TASK-5` is BOTH a ref and a searchable token — keep it in
+			// residual so prefix/fuzz matching still works (the user may
+			// have typed it as plain text), and also expose `ref` so
+			// `search()` can hoist the exact match.
+			out.ref = `${refMatch[1].toUpperCase()}-${refMatch[2]}`;
+		}
+		residual.push(tok);
+	}
+	out.text = residual.join(' ');
+	return out;
+}
+
 // ─── MiniSearch config ──────────────────────────────────────────────────────
 //
 // `fields` is the searchable field list; `storeFields` is the set returned
@@ -83,10 +168,28 @@ export interface LocalSearchResult {
 // parens, brackets, etc., so `TASK-5` → ['task', '5'], `foo,bar` →
 // ['foo', 'bar'], `Item (Done)` → ['item', 'done']. Underscore counts
 // as a splitter too so snake_case field keys index as separate tokens.
-// Codex review round 1 caught that the original narrow split missed
-// `foo:bar` / `foo,bar` / `foo(bar)` cases.
+// Codex review round 1 (TASK-1363) caught that the original narrow
+// split missed `foo:bar` / `foo,bar` / `foo(bar)` cases.
 
 const TOKENIZE_RE = /[^\p{L}\p{N}]+/u;
+
+// Per-term fuzz / prefix tuning (TASK-1367 / Phase 3e). Short terms
+// fuzzed against an index of 5,000 rows produce too many low-quality
+// matches — `cat` shouldn't match `bat`/`hat`/`category` via fuzz when
+// the user typed a complete 3-letter word. Empirically:
+//   - len 1: no fuzz, no prefix (single chars match too much noise)
+//   - len 2-3: no fuzz, prefix on (`db` prefix-matches `database`)
+//   - len 4+: fuzz=0.2, prefix on (one-edit typo tolerance kicks in)
+// The cutoffs are conservative — bumping the floor higher costs felt
+// recall; lowering it reintroduces the `cat`→`category` fuzz problem.
+
+function termFuzzy(term: string): number | false {
+	return term.length >= 4 ? 0.2 : false;
+}
+
+function termPrefix(term: string): boolean {
+	return term.length >= 2;
+}
 
 interface IndexedDoc {
 	id: string;
@@ -101,9 +204,13 @@ interface IndexedDoc {
 	// Side-channel metadata used by the filter step in `search()`.
 	// These are NOT indexed (not in the `fields` array), just stored so
 	// we can filter the ranked id list without a second localIndex lookup
-	// per result.
+	// per result. `_ref` / `_item_number` (TASK-1367) carry the
+	// uppercased ref string and numeric item_number to power the
+	// exact-ref short-circuit and `#5`/`item:5` syntax.
 	_collection_slug: string;
 	_deleted: boolean;
+	_ref: string;
+	_item_number: number;
 }
 
 function createMiniSearch(): MiniSearch<IndexedDoc> {
@@ -119,7 +226,7 @@ function createMiniSearch(): MiniSearch<IndexedDoc> {
 			'collection_slug',
 			'fields',
 		],
-		storeFields: ['_collection_slug', '_deleted'],
+		storeFields: ['_collection_slug', '_deleted', '_ref', '_item_number'],
 		tokenize: (text) =>
 			text
 				.toLowerCase()
@@ -127,13 +234,19 @@ function createMiniSearch(): MiniSearch<IndexedDoc> {
 				.filter((t) => t.length > 0),
 		processTerm: (term) => term.toLowerCase(),
 		searchOptions: {
-			prefix: true,
-			fuzzy: 0.2,
+			prefix: termPrefix,
+			fuzzy: termFuzzy,
 			combineWith: 'AND',
+			// Title boost was 3x → 5x (TASK-1367): empirical eyeball test
+			// showed title-vs-tag ties leaving tag-rich rows ahead of
+			// closer title matches. Ref / item_number boost was 2x → 4x
+			// so that a typed prefix-shaped ref query out-scores
+			// incidental field hits even before the exact-ref short-circuit
+			// in `search()` prepends the row.
 			boost: {
-				title: 3,
-				ref: 2,
-				item_number: 2,
+				title: 5,
+				ref: 4,
+				item_number: 4,
 			},
 		},
 	});
@@ -207,6 +320,8 @@ function buildDoc(row: ItemIndexRow): IndexedDoc {
 		fields: flattenFields(row.fields),
 		_collection_slug: row.collection_slug || '',
 		_deleted: !!row.deleted_at,
+		_ref: ref.toUpperCase(),
+		_item_number: row.item_number ?? 0,
 	};
 }
 
@@ -240,6 +355,46 @@ function ensureIndex(ws: string): MiniSearch<IndexedDoc> {
 
 function ssrSafe(): boolean {
 	return typeof window !== 'undefined';
+}
+
+/**
+ * Exact item_number lookup. Used by the `#N` / `item:N` / bare-digit
+ * paths in `search()`. MiniSearch's tokenized search would surface
+ * every doc whose token list contains `N` (and prefix-on widens that
+ * to every `N*` doc) — for item-number intent we want a single doc.
+ *
+ * Walks the stored `_item_number` field via `idx.search` with a
+ * `filter`. Returns at most one result; the caller still applies
+ * collection / archived gates on the way out.
+ */
+function exactItemNumberLookup(
+	idx: MiniSearch<IndexedDoc>,
+	n: number,
+	opts: { limit: number; includeArchived: boolean; wantCollection?: string },
+): LocalSearchResult[] {
+	// `idx.search` with `filter` is the cheapest way to walk every doc
+	// — we pass a query string that always returns the full index
+	// (an empty-token search via `*` isn't supported, so we use the
+	// number as the query AND filter for exact match). This keeps the
+	// cost linear in matching docs rather than full index size.
+	const raw = idx.search(String(n), {
+		filter: (r) => (r as unknown as IndexedDoc)._item_number === n,
+	}) as Array<{
+		id: string;
+		score: number;
+		_collection_slug?: string;
+		_deleted?: boolean;
+	}>;
+	const out: LocalSearchResult[] = [];
+	for (const r of raw) {
+		if (!opts.includeArchived && r._deleted) continue;
+		if (opts.wantCollection && r._collection_slug !== opts.wantCollection) {
+			continue;
+		}
+		out.push({ id: r.id, score: r.score });
+		if (out.length >= opts.limit) break;
+	}
+	return out;
 }
 
 // ─── Public API ─────────────────────────────────────────────────────────────
@@ -346,29 +501,79 @@ export const localSearch = {
 		const idx = indexes.get(ws);
 		if (!idx) return [];
 
+		const parsed = parseSearchQuery(query);
+
 		const limit = opts.limit ?? 50;
-		const includeArchived = opts.includeArchived === true;
-		const wantCollection = opts.collection;
+		// Caller's option wins, but the `is:archived` prefix opts in
+		// implicitly. Parsed prefixes are additive over caller intent.
+		const includeArchived = opts.includeArchived === true || parsed.archived;
+		const wantCollection = opts.collection ?? parsed.collection;
+
+		// Bare-number / explicit item-number queries: short-circuit to an
+		// exact item_number lookup so a typed `5` or `#5` lands the right
+		// row first instead of returning every doc whose token list
+		// contains a `5`. The task explicitly calls this out: "5 alone
+		// shouldn't return everything matching anywhere; require the
+		// prefix (TASK-5) OR explicit #5 / item:5 syntax". We accept all
+		// three: TASK-5, #5/item:5, and bare digits — bare digits get
+		// treated as #N for typing-speed. The result is a single doc (or
+		// empty) which we still post-filter by collection / archived so
+		// the caller's scope is honored.
+		const bareDigit = /^\d+$/.test(query) ? Number(query) : null;
+		const itemNumberQuery =
+			parsed.itemNumber ?? (bareDigit !== null ? bareDigit : null);
+		if (itemNumberQuery !== null && !parsed.text && !parsed.ref) {
+			return exactItemNumberLookup(idx, itemNumberQuery, {
+				limit,
+				includeArchived,
+				wantCollection,
+			});
+		}
 
 		// MiniSearch returns all matching docs sorted by score; we cap
 		// after filtering. Asking for `limit * 4` is a heuristic that
 		// stays cheap even at large workspace sizes — `search()` is
 		// linear in matching-doc count.
 		const overfetch = limit * 4;
-		const raw = idx.search(query) as Array<{
+		// Pass the residual text (post-prefix-strip) to MiniSearch. If
+		// the user typed nothing but prefixes (`coll:tasks` with no
+		// query) `parsed.text` is empty — return empty so we don't
+		// blanket-match every doc.
+		const searchText = parsed.text || query;
+		if (!searchText.trim()) return [];
+
+		const raw = idx.search(searchText) as Array<{
 			id: string;
 			score: number;
 			_collection_slug?: string;
 			_deleted?: boolean;
+			_ref?: string;
+			_item_number?: number;
 		}>;
 
+		// Exact-ref hoist: if the query named a ref (`TASK-5`), pull the
+		// matching doc to the front with a synthetic high score. The
+		// doc may not even be the top MiniSearch hit (a longer title
+		// match against a sibling could outscore it) — exact-ref intent
+		// is unambiguous, so we promote.
+		const wantRef = parsed.ref;
+		let hoisted: LocalSearchResult | null = null;
 		const out: LocalSearchResult[] = [];
 		for (const r of raw) {
 			if (!includeArchived && r._deleted) continue;
 			if (wantCollection && r._collection_slug !== wantCollection) continue;
+			if (wantRef && !hoisted && r._ref === wantRef) {
+				// `score: Infinity` would render as a weird display but
+				// the caller only uses score for relative ordering; use
+				// a synthetic value that beats anything MiniSearch can
+				// produce in practice.
+				hoisted = { id: r.id, score: r.score + 1e6 };
+				continue;
+			}
 			out.push({ id: r.id, score: r.score });
 			if (out.length >= overfetch) break;
 		}
+		if (hoisted) out.unshift(hoisted);
 		if (out.length > limit) out.length = limit;
 		return out;
 	},

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -1564,6 +1564,7 @@
 				{itemProgress}
 				{progressLabel}
 				canEdit={canEditThisCollection}
+				preserveOrder={searchResultRank !== null}
 			/>
 		{:else if viewMode === 'table'}
 			<TableView
@@ -1591,6 +1592,7 @@
 				{itemProgress}
 				{progressLabel}
 				canEdit={canEditThisCollection}
+				preserveOrder={searchResultRank !== null}
 			/>
 		{/if}
 	{/if}

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -22,7 +22,7 @@
 	import { workspaceStore } from '$lib/stores/workspace.svelte';
 	import { authStore } from '$lib/stores/auth.svelte';
 	import { localIndex } from '$lib/stores/localIndex.svelte';
-	import { localSearch } from '$lib/stores/localSearch.svelte';
+	import { localSearch, parseSearchQuery } from '$lib/stores/localSearch.svelte';
 
 	type ViewMode = 'list' | 'board' | 'table';
 
@@ -731,17 +731,6 @@
 		updateUrlFilters();
 	}
 
-	// Prefix routes that opt into the server-side FTS path so the rich-text
-	// body is searchable. `body:` / `content:` prefixes hit `/api/v1/search`
-	// (server FTS over `i.content`) since the in-memory localSearch index
-	// only covers titles + parsed fields by design — content bodies live
-	// on the server (DOC-1342 / TASK-1363). PLAN-1343 Phase 3b.
-	const BODY_SEARCH_PREFIX_RE = /^(?:body|content):\s*/i;
-
-	function stripBodyPrefix(query: string): string {
-		return query.replace(BODY_SEARCH_PREFIX_RE, '').trim();
-	}
-
 	function handleSearchChange(query: string) {
 		// Pure setter — the reactive effect below runs the actual search.
 		// Keeping this small means non-input entry points (URL load via
@@ -784,13 +773,18 @@
 			return;
 		}
 
+		// Parse the query so the centralized prefix vocabulary
+		// (`body:`, `coll:`, `is:archived`, `#5`, ref) — TASK-1367 —
+		// drives both paths.
+		const parsed = parseSearchQuery(trimmed);
+
 		// `body:` / `content:` prefix — fall through to the server FTS
 		// endpoint, which searches the rich-text body. The local index
 		// does not hold `content` by design (DOC-1342 decision #4), so
 		// this prefix is the only way to grep bodies. A 200ms debounce
 		// keeps the network path hammer-resistant while typing.
-		if (BODY_SEARCH_PREFIX_RE.test(trimmed)) {
-			const bodyQuery = stripBodyPrefix(trimmed);
+		if (parsed.body) {
+			const bodyQuery = parsed.text;
 			if (!bodyQuery) {
 				searchResultIds = null;
 				return;
@@ -840,6 +834,10 @@
 			searchResultIds = null;
 			return;
 		}
+		// Pass the raw query to localSearch — it owns prefix parsing so
+		// the `coll:` / `is:archived` / `#N` / ref vocabulary works
+		// uniformly across consumers (collection page + CommandPalette,
+		// TASK-1367).
 		const hits = localSearch.search(snapshotWs, trimmed, {
 			collection: snapshotColl,
 			includeArchived: showArchived,

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -1564,7 +1564,7 @@
 				{itemProgress}
 				{progressLabel}
 				canEdit={canEditThisCollection}
-				preserveOrder={searchResultRank !== null}
+				preserveOrder={searchQuery.trim() !== ''}
 			/>
 		{:else if viewMode === 'table'}
 			<TableView
@@ -1592,7 +1592,7 @@
 				{itemProgress}
 				{progressLabel}
 				canEdit={canEditThisCollection}
-				preserveOrder={searchResultRank !== null}
+				preserveOrder={searchQuery.trim() !== ''}
 			/>
 		{/if}
 	{/if}

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -69,7 +69,14 @@
 	let editCollectionSection = $state<'general' | 'fields' | 'display' | 'actions' | undefined>(undefined);
 	let workspaceMembers = $state<{ user_id: string; role: string }[]>([]);
 	let searchInputEl = $state<HTMLInputElement>();
-	let searchResultIds = $state<Set<string> | null>(null);
+	// `searchResultRank` is a Map<itemId, rank> where rank is the 0-indexed
+	// position in the ranked result list. `null` means no search active.
+	// Storing the rank (not just IDs) lets `filteredItems` sort matched
+	// rows by relevance so the localSearch exact-ref hoist + boost tuning
+	// from TASK-1367 actually surfaces in the UI — Codex round 2 caught
+	// that a `Set`-only filter let `updated_at DESC` order override the
+	// ranking.
+	let searchResultRank = $state<Map<string, number> | null>(null);
 	let searchTimeout: ReturnType<typeof setTimeout>;
 
 	let wsSlug = $derived(page.params.workspace ?? '');
@@ -79,7 +86,7 @@
 	// Reactive parse of the current search query — used to drive both
 	// the `is:archived` inclusion path on the `items` derived view
 	// (without the toggle, typing `is:archived foo` would still get
-	// archived rows filtered out before reaching `searchResultIds`)
+	// archived rows filtered out before reaching `searchResultRank`)
 	// AND to share the same prefix parser across the search-dispatch
 	// effect below. Codex round 1 of TASK-1367.
 	let parsedSearch = $derived(parseSearchQuery(searchQuery));
@@ -638,13 +645,22 @@
 		}
 
 		// Apply search query. PLAN-1343 Phase 3b: the local path
-		// populates `searchResultIds` synchronously (sub-ms) so the
+		// populates `searchResultRank` synchronously (sub-ms) so the
 		// filter just intersects. The substring fallback below covers
 		// the body:/content: server-FTS path while its 200ms debounce
 		// is in flight — and the very narrow window after a cold
 		// workspace load where indexReady is still false.
-		if (searchQuery.trim() && searchResultIds !== null) {
-			result = result.filter((item) => searchResultIds!.has(item.id));
+		//
+		// Critically: AFTER filtering, sort matched items by rank so
+		// localSearch's exact-ref hoist + boost tuning (TASK-1367)
+		// surfaces in the UI. Otherwise the natural `updated_at DESC`
+		// order from `localIndex.getByCollection` would override the
+		// ranking. Codex round 2 of TASK-1367.
+		if (searchQuery.trim() && searchResultRank !== null) {
+			const rank = searchResultRank;
+			result = result
+				.filter((item) => rank.has(item.id))
+				.sort((a, b) => (rank.get(a.id) ?? 0) - (rank.get(b.id) ?? 0));
 		} else if (searchQuery.trim()) {
 			// Fallback to client-side substring scan while the server
 			// FTS response is pending or the local index is mid-bootstrap.
@@ -768,7 +784,7 @@
 		void showArchived;
 		void indexReady;
 		// Track the localSearch mutation epoch so SSE-driven upserts /
-		// removes refresh `searchResultIds` while a query is active —
+		// removes refresh `searchResultRank` while a query is active —
 		// without this, a row created after the query was typed would
 		// stay hidden (and a row edited out of relevance would stay
 		// visible) until the user retyped. Codex round 3 P2 of TASK-1364.
@@ -781,7 +797,7 @@
 
 		clearTimeout(searchTimeout);
 		if (!trimmed) {
-			searchResultIds = null; // null = no search active
+			searchResultRank = null; // null = no search active
 			return;
 		}
 
@@ -799,12 +815,12 @@
 		if (parsed.body) {
 			const bodyQuery = parsed.text;
 			if (!bodyQuery) {
-				searchResultIds = null;
+				searchResultRank = null;
 				return;
 			}
 			// Clear stale results immediately so the substring fallback
 			// renders while the network response is pending.
-			searchResultIds = null;
+			searchResultRank = null;
 			const snapshotQuery = trimmed;
 			searchTimeout = setTimeout(async () => {
 				try {
@@ -823,14 +839,16 @@
 					) {
 						return;
 					}
-					searchResultIds = new Set(resp.results.map((r) => r.item.id));
+					searchResultRank = new Map(
+						resp.results.map((r, i) => [r.item.id, i]),
+					);
 				} catch {
 					if (
 						searchQuery.trim() === snapshotQuery &&
 						wsSlug === snapshotWs &&
 						collSlug === snapshotColl
 					) {
-						searchResultIds = null;
+						searchResultRank = null;
 					}
 				}
 			}, 200);
@@ -841,10 +859,10 @@
 		// rows — runs synchronously on every dependency change. PLAN-1343
 		// Phase 3b acceptance: keystroke → first results <50ms P95.
 		// When the index isn't ready yet (very narrow cold-load window),
-		// leave `searchResultIds = null` so the substring fallback in
+		// leave `searchResultRank = null` so the substring fallback in
 		// `filteredItems` kicks in until hydrate completes.
 		if (!indexReady) {
-			searchResultIds = null;
+			searchResultRank = null;
 			return;
 		}
 		// Pass the raw query to localSearch — it owns prefix parsing so
@@ -856,7 +874,7 @@
 			includeArchived: showArchived,
 			limit: 200,
 		});
-		searchResultIds = new Set(hits.map((h) => h.id));
+		searchResultRank = new Map(hits.map((h, i) => [h.id, i]));
 	});
 
 	async function handleStatusChange(item: Item, newValue: string) {
@@ -1161,7 +1179,7 @@
 		}
 		activeFilters = newFilters;
 		searchQuery = '';
-		searchResultIds = null;
+		searchResultRank = null;
 
 		// Open filters panel if the view has filters
 		if (Object.keys(newFilters).length > 0) {
@@ -1176,7 +1194,7 @@
 		activeViewId = null;
 		activeFilters = {};
 		searchQuery = '';
-		searchResultIds = null;
+		searchResultRank = null;
 		filtersOpen = false;
 		updateUrlFilters();
 	}
@@ -1535,7 +1553,7 @@
 				<div class="empty-icon">🔍</div>
 				<h2>No matches</h2>
 				<p>No items match your current filters.
-					<button class="clear-link" onclick={() => { activeFilters = {}; searchQuery = ''; searchResultIds = null; }}>Clear filters</button>
+					<button class="clear-link" onclick={() => { activeFilters = {}; searchQuery = ''; searchResultRank = null; }}>Clear filters</button>
 				</p>
 			</div>
 		{:else if viewMode === 'board'}

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -76,6 +76,14 @@
 	let username = $derived(page.params.username ?? '');
 	let collSlug = $derived(page.params.collection ?? '');
 
+	// Reactive parse of the current search query — used to drive both
+	// the `is:archived` inclusion path on the `items` derived view
+	// (without the toggle, typing `is:archived foo` would still get
+	// archived rows filtered out before reaching `searchResultIds`)
+	// AND to share the same prefix parser across the search-dispatch
+	// effect below. Codex round 1 of TASK-1367.
+	let parsedSearch = $derived(parseSearchQuery(searchQuery));
+
 	// `items` is now a $derived view over the local-first read model
 	// (localIndex, PLAN-1343 / TASK-1355-1356). The collection page no
 	// longer calls /items-index on every navigation; bootstrap is
@@ -83,11 +91,15 @@
 	// the `showArchived` toggle at read time — the store holds both
 	// live and archived rows. Widen to `Item` by setting content=''
 	// to match the existing prop type contract for view components;
-	// the detail page rehydrates content on open.
+	// the detail page rehydrates content on open. The `is:archived`
+	// search prefix transiently opts in to archived rows even when
+	// the toggle is off (TASK-1367).
 	let items = $derived<Item[]>(
 		wsSlug && collSlug
 			? localIndex
-					.getByCollection(wsSlug, collSlug, { includeArchived: showArchived })
+					.getByCollection(wsSlug, collSlug, {
+						includeArchived: showArchived || parsedSearch.archived,
+					})
 					.map((row) => ({ ...row, content: '' }) as Item)
 			: [],
 	);
@@ -773,10 +785,11 @@
 			return;
 		}
 
-		// Parse the query so the centralized prefix vocabulary
+		// Reuse the page-level parsed query so the prefix vocabulary
 		// (`body:`, `coll:`, `is:archived`, `#5`, ref) — TASK-1367 —
-		// drives both paths.
-		const parsed = parseSearchQuery(trimmed);
+		// drives this effect AND the `items` derived view's archived
+		// inclusion uniformly.
+		const parsed = parsedSearch;
 
 		// `body:` / `content:` prefix — fall through to the server FTS
 		// endpoint, which searches the rich-text body. The local index

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -83,12 +83,9 @@
 	let username = $derived(page.params.username ?? '');
 	let collSlug = $derived(page.params.collection ?? '');
 
-	// Reactive parse of the current search query — used to drive both
-	// the `is:archived` inclusion path on the `items` derived view
-	// (without the toggle, typing `is:archived foo` would still get
-	// archived rows filtered out before reaching `searchResultRank`)
-	// AND to share the same prefix parser across the search-dispatch
-	// effect below. Codex round 1 of TASK-1367.
+	// Reactive parse of the current search query — shared with the
+	// search-dispatch effect below so it doesn't reparse per run.
+	// TASK-1367.
 	let parsedSearch = $derived(parseSearchQuery(searchQuery));
 
 	// `items` is now a $derived view over the local-first read model
@@ -98,15 +95,11 @@
 	// the `showArchived` toggle at read time — the store holds both
 	// live and archived rows. Widen to `Item` by setting content=''
 	// to match the existing prop type contract for view components;
-	// the detail page rehydrates content on open. The `is:archived`
-	// search prefix transiently opts in to archived rows even when
-	// the toggle is off (TASK-1367).
+	// the detail page rehydrates content on open.
 	let items = $derived<Item[]>(
 		wsSlug && collSlug
 			? localIndex
-					.getByCollection(wsSlug, collSlug, {
-						includeArchived: showArchived || parsedSearch.archived,
-					})
+					.getByCollection(wsSlug, collSlug, { includeArchived: showArchived })
 					.map((row) => ({ ...row, content: '' }) as Item)
 			: [],
 	);


### PR DESCRIPTION
## Summary

Phase 3e of the local-first read model (PLAN-1343 / DOC-1342): tune the MiniSearch relevance config from 3a and add a centralized prefix parser.

**Relevance tuning**
- Title boost 3x → 5x; ref / item_number 2x → 4x
- Per-term fuzz/prefix: disable fuzz for terms <4 chars and prefix-matching for single chars (so `cat` doesn't fuzz to `category`)

**Prefix vocabulary (`parseSearchQuery` — exported)**
- `body:foo` / `content:foo` — route to server FTS
- `coll:tasks foo` — restrict to one collection
- `is:archived` — include archived rows
- `#5` / `item:5` — exact item-number lookup
- `TASK-5` — exact-ref hoist
- Bare digits (`5`) — treated as `#5`

**Centralization**
- Collection page imports `parseSearchQuery` — one parser across page and (incoming) CommandPalette wiring (TASK-1365)
- FilterBar tooltip documents the full vocab

## Context

Implements `TASK-1367` under `PLAN-1343`. Builds on TASK-1363 + TASK-1364.

## Test plan

- [x] `make check` — golangci-lint + go test + svelte-check + npm build all clean
- [ ] Manual: type `TASK-5` — that row is first regardless of organic rank
- [ ] Manual: type `#5` — only item #5 returns
- [ ] Manual: type `cat` (3 chars) — no fuzz to `category` / `cab`
- [ ] Manual: `db migr` returns `Database migration plan` in top 3