### PR TITLE
feat(web): CommandPalette uses localSearch (TASK-1365)

### DIFF
--- a/web/src/lib/components/search/CommandPalette.svelte
+++ b/web/src/lib/components/search/CommandPalette.svelte
@@ -193,11 +193,6 @@
 	}
 
 	function doSearch() {
-		// Re-read the localSearch epoch for the current workspace so
-		// reactive consumers (this $effect-equivalent inside doSearch)
-		// pick up SSE-driven index mutations. Reading inside the
-		// function is enough — the $effect that calls doSearch will
-		// pick this up via dependency tracking.
 		clearTimeout(searchTimeout);
 		const trimmed = query.trim();
 		if (!trimmed) {
@@ -210,10 +205,19 @@
 		}
 
 		const parsed = parseSearchQuery(trimmed);
-		const ready = readyWorkspaces();
 		const currentSlug = workspaceStore.current?.slug;
-		const currentReady =
-			!!currentSlug && localIndex.bootstrapStateFor(currentSlug) === 'ready';
+		// CRITICAL: don't read `localIndex.bootstrapStateFor` or
+		// `localSearch.epoch` for body queries — those reads register
+		// as reactive dependencies of the caller (`$effect`), and an
+		// SSE-driven epoch bump or hydration completion mid-flight
+		// would then re-fire doSearch and wipe an in-flight `loadMore`
+		// append. Body queries are server-authoritative; nothing in
+		// local state can change their result set. Codex round 8 P2
+		// of TASK-1365.
+		const currentReady = parsed.body
+			? true
+			: !!currentSlug && localIndex.bootstrapStateFor(currentSlug) === 'ready';
+		const ready = parsed.body ? [] : readyWorkspaces();
 
 		// Server-only paths:
 		//   - `body:` / `content:` queries — local index doesn't hold

--- a/web/src/lib/components/search/CommandPalette.svelte
+++ b/web/src/lib/components/search/CommandPalette.svelte
@@ -229,31 +229,38 @@
 		if (parsed.body || !currentReady || ready.length === 0) {
 			loading = true;
 			// Snapshot the FULL dispatch scope at request time
-			// (Codex round 4 P2): the response is only valid if every
-			// dimension that determines what we render is still the
-			// same. Otherwise an in-flight server result can clobber
-			// local results once `currentReady` flips, or overwrite a
-			// later set with a different filter/query/toggle.
+			// (Codex rounds 4-5 P2): the response is only valid if
+			// every dimension that determines what we render is still
+			// the same. `isSameDispatch` must READ LIVE state for
+			// readiness — capturing `currentReady` at dispatch left
+			// the check stale once the index hydrated mid-request.
 			const snapshotQuery = trimmed;
 			const snapshotAllWs = searchAllWorkspaces;
-			const snapshotCurrentReady = currentReady;
 			const snapshotBody = parsed.body;
 			const snapshotFilterCollection = filterCollection;
 			const snapshotFilterStatus = filterStatus;
 			const snapshotWsSlug = currentSlug;
-			const isSameDispatch = () =>
-				query.trim() === snapshotQuery &&
-				searchAllWorkspaces === snapshotAllWs &&
-				filterCollection === snapshotFilterCollection &&
-				filterStatus === snapshotFilterStatus &&
-				workspaceStore.current?.slug === snapshotWsSlug &&
-				// Non-body server fetches are only valid while the
-				// current workspace is still NOT ready. Once it
-				// hydrates, the local path becomes correct and the
-				// server response is no longer authoritative.
-				(snapshotBody || !snapshotCurrentReady
-					? (snapshotBody || !currentReady)
-					: true);
+			const isSameDispatch = () => {
+				if (query.trim() !== snapshotQuery) return false;
+				if (searchAllWorkspaces !== snapshotAllWs) return false;
+				if (filterCollection !== snapshotFilterCollection) return false;
+				if (filterStatus !== snapshotFilterStatus) return false;
+				if (workspaceStore.current?.slug !== snapshotWsSlug) return false;
+				// Body queries grep content the local index doesn't
+				// hold, so they're authoritative regardless of
+				// hydration state — only the dimensions checked above
+				// can invalidate them.
+				if (snapshotBody) return true;
+				// Non-body server fetches were triggered because the
+				// current workspace wasn't ready. If it's NOW ready,
+				// the local path is the authoritative source and the
+				// server response is stale. Read live state.
+				const liveCurrentReady =
+					!!snapshotWsSlug &&
+					localIndex.bootstrapStateFor(snapshotWsSlug) === 'ready';
+				if (liveCurrentReady) return false;
+				return true;
+			};
 			searchTimeout = setTimeout(async () => {
 				try {
 					const serverQuery = parsed.body ? parsed.text || trimmed : trimmed;
@@ -387,14 +394,38 @@
 
 	async function loadMore() {
 		if (loadingMore || results.length >= total) return;
+		// Only the server path ever sets `total > results.length` — the
+		// local path pins them equal — so a `loadMore` always means
+		// fetching another server page. The dispatch scope can still
+		// change mid-flight, though: the current workspace can finish
+		// hydrating, the all-workspaces toggle can flip, or the query
+		// / filters can change. Snapshot all of it and bail if any of
+		// these shift before the response lands. Codex round 5 P2.
 		loadingMore = true;
 		const snapshotQuery = query;
+		const snapshotAllWs = searchAllWorkspaces;
 		const snapshotCollection = filterCollection;
 		const snapshotStatus = filterStatus;
+		const snapshotWsSlug = workspaceStore.current?.slug;
 		try {
 			const resp = await api.search(query, buildFilters(results.length));
-			// Discard if query or filters changed while loading
-			if (query !== snapshotQuery || filterCollection !== snapshotCollection || filterStatus !== snapshotStatus) return;
+			if (
+				query !== snapshotQuery ||
+				searchAllWorkspaces !== snapshotAllWs ||
+				filterCollection !== snapshotCollection ||
+				filterStatus !== snapshotStatus ||
+				workspaceStore.current?.slug !== snapshotWsSlug
+			) {
+				return;
+			}
+			// If the current workspace hydrated while the request was
+			// in flight, the main effect has likely already swapped to
+			// the local path and replaced `results`. Appending more
+			// server rows would inject scope-mismatched results.
+			const liveCurrentReady =
+				!!snapshotWsSlug &&
+				localIndex.bootstrapStateFor(snapshotWsSlug) === 'ready';
+			if (liveCurrentReady) return;
 			results = [...results, ...(resp.results ?? [])];
 		} catch {
 			// ignore

--- a/web/src/lib/components/search/CommandPalette.svelte
+++ b/web/src/lib/components/search/CommandPalette.svelte
@@ -354,6 +354,13 @@
 	//     freshly-created items even though the underlying index
 	//     updated. PLAN-1343 / TASK-1365.
 	//
+	// EXCEPTION: body queries don't depend on local index state. They
+	// hit the server, which is the only source of truth for content
+	// text. Skip the readiness / epoch reads for body queries so a
+	// concurrent SSE bump (or hydration completion) can't re-fire
+	// doSearch from offset 0 and wipe an in-flight `loadMore` append.
+	// Codex round 7 P2 of TASK-1365.
+	//
 	// `doSearch` handles the empty-query case internally by clearing
 	// results — so the effect can fire on every transition (including
 	// "user backspaced to empty") without leaving stale results visible.
@@ -363,9 +370,13 @@
 		void searchAllWorkspaces;
 		void filterCollection;
 		void filterStatus;
-		void localIndex.bootstrapStateFor(workspaceStore.current?.slug ?? '');
-		for (const ws of workspaceStore.workspaces) {
-			void localSearch.epoch(ws.slug);
+		const trimmed = query.trim();
+		const parsed = trimmed ? parseSearchQuery(trimmed) : null;
+		if (!parsed?.body) {
+			void localIndex.bootstrapStateFor(workspaceStore.current?.slug ?? '');
+			for (const ws of workspaceStore.workspaces) {
+				void localSearch.epoch(ws.slug);
+			}
 		}
 		doSearch();
 	});

--- a/web/src/lib/components/search/CommandPalette.svelte
+++ b/web/src/lib/components/search/CommandPalette.svelte
@@ -228,17 +228,37 @@
 		// All three use a 200ms debounce on the network call.
 		if (parsed.body || !currentReady || ready.length === 0) {
 			loading = true;
-			// Snapshot the query + scope at dispatch time so a slow
-			// response that lands after the user typed more (or after
-			// the local index hydrated and the path switched to local)
-			// can't clobber the now-current results. Codex round 3 P2.
+			// Snapshot the FULL dispatch scope at request time
+			// (Codex round 4 P2): the response is only valid if every
+			// dimension that determines what we render is still the
+			// same. Otherwise an in-flight server result can clobber
+			// local results once `currentReady` flips, or overwrite a
+			// later set with a different filter/query/toggle.
 			const snapshotQuery = trimmed;
 			const snapshotAllWs = searchAllWorkspaces;
+			const snapshotCurrentReady = currentReady;
+			const snapshotBody = parsed.body;
+			const snapshotFilterCollection = filterCollection;
+			const snapshotFilterStatus = filterStatus;
+			const snapshotWsSlug = currentSlug;
+			const isSameDispatch = () =>
+				query.trim() === snapshotQuery &&
+				searchAllWorkspaces === snapshotAllWs &&
+				filterCollection === snapshotFilterCollection &&
+				filterStatus === snapshotFilterStatus &&
+				workspaceStore.current?.slug === snapshotWsSlug &&
+				// Non-body server fetches are only valid while the
+				// current workspace is still NOT ready. Once it
+				// hydrates, the local path becomes correct and the
+				// server response is no longer authoritative.
+				(snapshotBody || !snapshotCurrentReady
+					? (snapshotBody || !currentReady)
+					: true);
 			searchTimeout = setTimeout(async () => {
 				try {
 					const serverQuery = parsed.body ? parsed.text || trimmed : trimmed;
 					if (!serverQuery.trim()) {
-						if (query.trim() === snapshotQuery) {
+						if (isSameDispatch()) {
 							results = [];
 							total = 0;
 							facets = undefined;
@@ -246,26 +266,19 @@
 						return;
 					}
 					const resp = await api.search(serverQuery, buildFilters(0));
-					// Stale-response guard: if the query has changed or
-					// the toggle has flipped since dispatch, discard.
-					if (
-						query.trim() !== snapshotQuery ||
-						searchAllWorkspaces !== snapshotAllWs
-					) {
-						return;
-					}
+					if (!isSameDispatch()) return;
 					results = resp.results ?? [];
 					total = resp.total ?? 0;
 					facets = resp.facets;
 					selectedIdx = -1;
 				} catch {
-					if (query.trim() === snapshotQuery) {
+					if (isSameDispatch()) {
 						results = [];
 						total = 0;
 						facets = undefined;
 					}
 				} finally {
-					if (query.trim() === snapshotQuery) loading = false;
+					if (isSameDispatch()) loading = false;
 				}
 			}, 200);
 			return;

--- a/web/src/lib/components/search/CommandPalette.svelte
+++ b/web/src/lib/components/search/CommandPalette.svelte
@@ -211,14 +211,22 @@
 
 		const parsed = parseSearchQuery(trimmed);
 		const ready = readyWorkspaces();
+		const currentSlug = workspaceStore.current?.slug;
+		const currentReady =
+			!!currentSlug && localIndex.bootstrapStateFor(currentSlug) === 'ready';
 
 		// Server-only paths:
 		//   - `body:` / `content:` queries — local index doesn't hold
 		//     the rich-text body, server FTS is the only way to grep.
-		//   - No ready workspaces yet (cold session) — fall through to
-		//     the server so the palette still works pre-bootstrap.
-		// In both cases we use a 200ms debounce.
-		if (parsed.body || ready.length === 0) {
+		//   - Current workspace not yet hydrated — fall through to the
+		//     server even if other workspaces are ready, so the user
+		//     never misses results from where they are. The
+		//     `searchAllWorkspaces` toggle is meant to widen, never
+		//     to replace. Codex round 2 P2.
+		//   - No ready workspaces at all (cold session) — fall through
+		//     to the server so the palette still works pre-bootstrap.
+		// All three use a 200ms debounce on the network call.
+		if (parsed.body || !currentReady || ready.length === 0) {
 			loading = true;
 			searchTimeout = setTimeout(async () => {
 				try {
@@ -602,7 +610,16 @@
 				</div>
 			{/if}
 
-			<!-- Filter chips -->
+			<!--
+				Filter chips. Surface in three cases:
+				  1. Server search returned facets (full chip vocabulary).
+				  2. Local path with an active filter — show the active
+				     chip(s) alone so the user can see + clear them.
+				     Without this branch, switching from server → local
+				     with a filter chip selected would hide the chip but
+				     keep filtering, leaving the user no clear way to
+				     remove it. Codex round 2 P2 of TASK-1365.
+			-->
 			{#if facets && query.trim()}
 				<div class="filters-row">
 					<div class="filter-chips">
@@ -640,6 +657,34 @@
 					{#if hasFilters}
 						<button class="clear-filters" onclick={clearFilters}>Clear filters</button>
 					{/if}
+				</div>
+			{:else if hasFilters && query.trim()}
+				<div class="filters-row">
+					<div class="filter-chips">
+						{#if filterCollection}
+							{@const coll = collectionStore.collections.find((c) => c.slug === filterCollection)}
+							<button
+								class="filter-chip active"
+								onclick={() => applyFilter('collection', filterCollection!)}
+							>
+								<span class="chip-icon">{coll?.icon || '📦'}</span>
+								<span class="chip-label">{coll?.name || filterCollection}</span>
+							</button>
+						{/if}
+						{#if filterStatus}
+							<button
+								class="filter-chip status-chip active"
+								onclick={() => applyFilter('status', filterStatus!)}
+							>
+								<span
+									class="chip-dot"
+									style="background: {statusColor(filterStatus)};"
+								></span>
+								<span class="chip-label">{filterStatus.replace(/_/g, ' ')}</span>
+							</button>
+						{/if}
+					</div>
+					<button class="clear-filters" onclick={clearFilters}>Clear filters</button>
 				</div>
 			{/if}
 

--- a/web/src/lib/components/search/CommandPalette.svelte
+++ b/web/src/lib/components/search/CommandPalette.svelte
@@ -3,19 +3,49 @@
 	import { api } from '$lib/api/client';
 	import { workspaceStore } from '$lib/stores/workspace.svelte';
 	import { collectionStore } from '$lib/stores/collections.svelte';
+	import { localIndex } from '$lib/stores/localIndex.svelte';
+	import { localSearch, parseSearchQuery } from '$lib/stores/localSearch.svelte';
 	import { uiStore } from '$lib/stores/ui.svelte';
-	import type { SearchResult, SearchFacets, SearchFilters } from '$lib/types';
+	import type {
+		SearchResult,
+		SearchFacets,
+		SearchFilters,
+		Item,
+		ItemIndexRow,
+	} from '$lib/types';
 	import { getFieldValue, itemUrlId, formatItemRef } from '$lib/types';
 	import { relativeTime } from '$lib/utils/markdown';
 
 	const RECENT_SEARCHES_KEY = 'pad-recent-searches';
 	const MAX_RECENT = 10;
 	const PAGE_SIZE = 20;
+	// Cross-workspace results merged from N ready workspaces — cap the
+	// fan-out so an extreme power user with 50 hydrated workspaces
+	// doesn't pay a 50× O(matching-docs) cost per keystroke. 20 is the
+	// max display anyway (PAGE_SIZE), but pulling the top 60 across
+	// workspaces (20 each from top 3) gives enough headroom for the
+	// merge step to keep representative coverage. PLAN-1343 / TASK-1365.
+	const LOCAL_PER_WS_LIMIT = 20;
+
+	// Augmented result — adds the source workspace so cross-workspace
+	// navigation lands on the right URL. For results returned by the
+	// server `/search` endpoint (single-workspace path), `workspace`
+	// stays undefined and `selectResult` falls back to
+	// `workspaceStore.current`. For local results, the workspace is
+	// resolved from `workspaceStore.workspaces`.
+	interface AugmentedSearchResult extends SearchResult {
+		workspace?: { slug: string; owner_username: string };
+	}
 
 	let query = $state('');
-	let results = $state<SearchResult[]>([]);
+	let results = $state<AugmentedSearchResult[]>([]);
 	let total = $state(0);
 	let facets = $state<SearchFacets | undefined>(undefined);
+	// `searchAllWorkspaces` toggle: when on, search every workspace
+	// whose `localIndex` is `'ready'` in addition to the current one.
+	// Non-ready workspaces fall back to server search transparently.
+	// Stored in localStorage so the toggle survives reloads.
+	let searchAllWorkspaces = $state(loadAllWorkspacesPref());
 	// -1 means "no result armed". The user must press an arrow key (or type a
 	// bare number) before Enter will navigate. See BUG-864.
 	let selectedIdx = $state(-1);
@@ -93,9 +123,9 @@
 		};
 	});
 
-	function buildFilters(offset = 0): SearchFilters {
+	function buildFilters(offset = 0, wsSlug?: string): SearchFilters {
 		const filters: SearchFilters = {
-			workspace: workspaceStore.current?.slug,
+			workspace: wsSlug ?? workspaceStore.current?.slug,
 			limit: PAGE_SIZE,
 			offset
 		};
@@ -104,9 +134,73 @@
 		return filters;
 	}
 
+	/**
+	 * Materialize a localSearch `{ id, score }[]` hit list into the
+	 * SearchResult shape consumed by the palette template. Drops hits
+	 * whose row has fallen out of `localIndex` (stale rebuild race) and
+	 * tags each result with its source workspace so cross-workspace
+	 * navigation works. TASK-1365.
+	 */
+	function materializeLocalHits(
+		wsSlug: string,
+		ownerUsername: string,
+		hits: { id: string; score: number }[],
+	): AugmentedSearchResult[] {
+		const out: AugmentedSearchResult[] = [];
+		for (const h of hits) {
+			const row = localIndex.findByIdOrSlug(wsSlug, h.id);
+			if (!row) continue;
+			// `Item` widens `ItemIndexRow` by adding `content` (always ''
+			// since the local index doesn't carry the rich-text body).
+			// The CommandPalette only reads title/fields/ref/etc., so an
+			// empty content body is fine — and matches the same widening
+			// pattern the collection page uses at TASK-1357.
+			const item: Item = { ...(row as ItemIndexRow), content: '' } as Item;
+			out.push({
+				item,
+				snippet: '',
+				rank: h.score,
+				workspace: { slug: wsSlug, owner_username: ownerUsername },
+			});
+		}
+		return out;
+	}
+
+	/**
+	 * Identify the workspaces eligible for in-RAM local search:
+	 *   - Always the current workspace if it's `'ready'`.
+	 *   - When `searchAllWorkspaces` is on, every other workspace whose
+	 *     `localIndex.bootstrapStateFor` is `'ready'`.
+	 *
+	 * Non-ready workspaces are NOT included here — they don't have a
+	 * MiniSearch index built yet, and triggering bootstrap from the
+	 * search palette would be surprising. They fall back to server
+	 * search via the alternate path.
+	 */
+	function readyWorkspaces(): { slug: string; owner_username: string }[] {
+		const out: { slug: string; owner_username: string }[] = [];
+		const current = workspaceStore.current;
+		if (current && localIndex.bootstrapStateFor(current.slug) === 'ready') {
+			out.push({ slug: current.slug, owner_username: current.owner_username ?? '' });
+		}
+		if (!searchAllWorkspaces) return out;
+		for (const ws of workspaceStore.workspaces) {
+			if (current && ws.slug === current.slug) continue;
+			if (localIndex.bootstrapStateFor(ws.slug) !== 'ready') continue;
+			out.push({ slug: ws.slug, owner_username: ws.owner_username ?? '' });
+		}
+		return out;
+	}
+
 	function doSearch() {
+		// Re-read the localSearch epoch for the current workspace so
+		// reactive consumers (this $effect-equivalent inside doSearch)
+		// pick up SSE-driven index mutations. Reading inside the
+		// function is enough — the $effect that calls doSearch will
+		// pick this up via dependency tracking.
 		clearTimeout(searchTimeout);
-		if (!query.trim()) {
+		const trimmed = query.trim();
+		if (!trimmed) {
 			results = [];
 			total = 0;
 			facets = undefined;
@@ -114,27 +208,131 @@
 			loading = false;
 			return;
 		}
-		loading = true;
-		searchTimeout = setTimeout(async () => {
-			try {
-				const resp = await api.search(query, buildFilters(0));
-				// Defensive: some backends / error paths can send `null` for
-				// an absent array. Coalesce so downstream `.length` is safe.
-				results = resp.results ?? [];
-				total = resp.total ?? 0;
-				facets = resp.facets;
-				// BUG-864: do NOT auto-arm the first result. The user must
-				// press an arrow key (or type a bare number + Enter) to
-				// trigger navigation.
-				selectedIdx = -1;
-			} catch {
-				results = [];
-				total = 0;
-				facets = undefined;
-			} finally {
-				loading = false;
-			}
-		}, 200);
+
+		const parsed = parseSearchQuery(trimmed);
+		const ready = readyWorkspaces();
+
+		// Server-only paths:
+		//   - `body:` / `content:` queries — local index doesn't hold
+		//     the rich-text body, server FTS is the only way to grep.
+		//   - No ready workspaces yet (cold session) — fall through to
+		//     the server so the palette still works pre-bootstrap.
+		// In both cases we use a 200ms debounce.
+		if (parsed.body || ready.length === 0) {
+			loading = true;
+			searchTimeout = setTimeout(async () => {
+				try {
+					const serverQuery = parsed.body ? parsed.text || trimmed : trimmed;
+					if (!serverQuery.trim()) {
+						results = [];
+						total = 0;
+						facets = undefined;
+						return;
+					}
+					const resp = await api.search(serverQuery, buildFilters(0));
+					results = resp.results ?? [];
+					total = resp.total ?? 0;
+					facets = resp.facets;
+					selectedIdx = -1;
+				} catch {
+					results = [];
+					total = 0;
+					facets = undefined;
+				} finally {
+					loading = false;
+				}
+			}, 200);
+			return;
+		}
+
+		// Local synchronous path. For each ready workspace, run
+		// localSearch.search and materialize to SearchResult shape.
+		// Merge by score descending — ties broken by `updated_at DESC`
+		// for stability. Cap to PAGE_SIZE for the visible list (the
+		// palette already supports a "load more" affordance, but for
+		// in-RAM local search there's no pagination — we either have
+		// all matching rows or we'll never have more, so disable the
+		// "load more" UX by setting `total = results.length`).
+		const merged: AugmentedSearchResult[] = [];
+		for (const ws of ready) {
+			const hits = localSearch.search(ws.slug, trimmed, {
+				collection: filterCollection ?? undefined,
+				limit: LOCAL_PER_WS_LIMIT,
+			});
+			merged.push(...materializeLocalHits(ws.slug, ws.owner_username, hits));
+		}
+		merged.sort((a, b) => {
+			if (b.rank !== a.rank) return b.rank - a.rank;
+			// Stable tie-break by updated_at DESC then id ASC.
+			const aU = a.item.updated_at ?? '';
+			const bU = b.item.updated_at ?? '';
+			if (aU !== bU) return aU < bU ? 1 : -1;
+			return a.item.id < b.item.id ? -1 : 1;
+		});
+
+		// Apply the status filter chip if active. (Collection filter is
+		// passed through to localSearch.search above.)
+		const filtered = filterStatus
+			? merged.filter((r) => getFieldValue(r.item, 'status') === filterStatus)
+			: merged;
+
+		// `total` is `filtered.length` because we don't paginate local
+		// results; everything's in RAM. Truncate the rendered list to
+		// PAGE_SIZE * 2 so cross-workspace power users still see a
+		// representative top slice.
+		results = filtered.slice(0, PAGE_SIZE * 2);
+		total = filtered.length;
+		// Facets are server-only; clear them on the local path so the
+		// chip row hides cleanly.
+		facets = undefined;
+		selectedIdx = -1;
+		loading = false;
+	}
+
+	// Re-run the search whenever any tracked dependency changes:
+	//   - `query` typed by the user (keystroke or recent-search click)
+	//   - `searchAllWorkspaces` toggle
+	//   - Any ready workspace's localSearch epoch (SSE-driven upserts /
+	//     removes) — without this, an open-palette user wouldn't see
+	//     freshly-created items even though the underlying index
+	//     updated. PLAN-1343 / TASK-1365.
+	//
+	// `doSearch` handles the empty-query case internally by clearing
+	// results — so the effect can fire on every transition (including
+	// "user backspaced to empty") without leaving stale results visible.
+	$effect(() => {
+		if (!uiStore.searchOpen) return;
+		void query;
+		void searchAllWorkspaces;
+		void filterCollection;
+		void filterStatus;
+		void localIndex.bootstrapStateFor(workspaceStore.current?.slug ?? '');
+		for (const ws of workspaceStore.workspaces) {
+			void localSearch.epoch(ws.slug);
+		}
+		doSearch();
+	});
+
+	function loadAllWorkspacesPref(): boolean {
+		try {
+			return localStorage.getItem('pad-search-all-workspaces') === 'true';
+		} catch {
+			return false;
+		}
+	}
+
+	function toggleAllWorkspaces() {
+		searchAllWorkspaces = !searchAllWorkspaces;
+		try {
+			localStorage.setItem(
+				'pad-search-all-workspaces',
+				searchAllWorkspaces ? 'true' : 'false',
+			);
+		} catch {
+			// Storage unavailable (private mode, quota) — silently
+			// degrade; the toggle still works for the session.
+		}
+		// The reactive effect picks up the flip; no explicit re-run.
 	}
 
 	async function loadMore() {
@@ -156,18 +354,18 @@
 	}
 
 	function applyFilter(type: 'collection' | 'status', value: string) {
+		// The reactive search effect re-runs on filterCollection /
+		// filterStatus changes, so no explicit doSearch() needed.
 		if (type === 'collection') {
 			filterCollection = filterCollection === value ? null : value;
 		} else {
 			filterStatus = filterStatus === value ? null : value;
 		}
-		doSearch();
 	}
 
 	function clearFilters() {
 		filterCollection = null;
 		filterStatus = null;
-		doSearch();
 	}
 
 	function scrollSelectedIntoView() {
@@ -230,10 +428,15 @@
 		}
 	}
 
-	function selectResult(r: SearchResult) {
+	function selectResult(r: AugmentedSearchResult) {
 		saveRecentSearch(query.trim());
-		const ws = workspaceStore.current?.slug;
-		const wsUsername = workspaceStore.current?.owner_username;
+		// Local (cross-workspace) hits ship their source workspace on
+		// the result. Server hits don't — they implicitly came from the
+		// current workspace because `buildFilters` scopes the request.
+		// Resolve via fallback so both paths work. TASK-1365.
+		const ws = r.workspace?.slug ?? workspaceStore.current?.slug;
+		const wsUsername =
+			r.workspace?.owner_username ?? workspaceStore.current?.owner_username;
 		const collSlug = r.item.collection_slug;
 		if (ws && wsUsername && collSlug) {
 			goto(`/${wsUsername}/${ws}/${collSlug}/${itemUrlId(r.item)}`);
@@ -242,8 +445,9 @@
 	}
 
 	function useRecentSearch(q: string) {
+		// Assignment alone re-triggers the reactive search effect; the
+		// explicit doSearch() call is no longer needed.
 		query = q;
-		doSearch();
 		requestAnimationFrame(() => inputEl?.focus());
 	}
 
@@ -300,13 +504,27 @@
 		}
 	}
 
-	function renderResultCard(r: SearchResult, i: number): { ref: string | null; status: string | undefined; priority: string | undefined } {
+	function renderResultCard(r: AugmentedSearchResult, i: number): { ref: string | null; status: string | undefined; priority: string | undefined } {
+		void i;
 		return {
 			ref: formatItemRef(r.item),
 			status: getFieldValue(r.item, 'status'),
 			priority: getFieldValue(r.item, 'priority')
 		};
 	}
+
+	// Derived: ready workspaces other than the current one. Used to gate
+	// the "search all workspaces" toggle visibility — no point showing
+	// it when the user only has the current workspace hydrated.
+	let otherReadyWorkspaceCount = $derived.by(() => {
+		const current = workspaceStore.current?.slug;
+		let n = 0;
+		for (const ws of workspaceStore.workspaces) {
+			if (ws.slug === current) continue;
+			if (localIndex.bootstrapStateFor(ws.slug) === 'ready') n += 1;
+		}
+		return n;
+	});
 </script>
 
 {#if uiStore.searchOpen}
@@ -334,7 +552,6 @@
 				<input
 					bind:this={inputEl}
 					bind:value={query}
-					oninput={doSearch}
 					placeholder="Search items, collections, docs..."
 					class="search-input"
 				/>
@@ -360,6 +577,26 @@
 					</svg>
 				</button>
 			</div>
+
+			<!--
+				"All workspaces" toggle (TASK-1365). Only surfaced when the
+				user has more than one ready workspace — if you only have
+				the current workspace hydrated, the toggle would be a no-op
+				and just adds chrome.
+			-->
+			{#if otherReadyWorkspaceCount > 0}
+				<div class="scope-row">
+					<button
+						class="scope-toggle"
+						class:active={searchAllWorkspaces}
+						onclick={toggleAllWorkspaces}
+						title="When on, search every workspace that's already loaded this session"
+					>
+						<span class="scope-dot" class:on={searchAllWorkspaces}></span>
+						<span>All workspaces ({otherReadyWorkspaceCount + 1} ready)</span>
+					</button>
+				</div>
+			{/if}
 
 			<!-- Filter chips -->
 			{#if facets && query.trim()}
@@ -636,6 +873,48 @@
 		border-radius: 3px;
 		font-family: var(--font-mono);
 		flex-shrink: 0;
+	}
+
+	/* "All workspaces" scope toggle (TASK-1365) */
+	.scope-row {
+		display: flex;
+		align-items: center;
+		padding: var(--space-1) var(--space-3);
+		border-bottom: 1px solid var(--border);
+		flex-shrink: 0;
+	}
+	.scope-toggle {
+		display: inline-flex;
+		align-items: center;
+		gap: var(--space-2);
+		padding: 2px 8px;
+		border-radius: var(--radius);
+		font-size: 0.75em;
+		color: var(--text-muted);
+		background: none;
+		border: 1px solid transparent;
+		cursor: pointer;
+		transition: all 0.15s ease;
+	}
+	.scope-toggle:hover {
+		background: var(--bg-hover);
+		color: var(--text-secondary);
+	}
+	.scope-toggle.active {
+		color: var(--accent-blue);
+		border-color: color-mix(in srgb, var(--accent-blue) 30%, transparent);
+		background: color-mix(in srgb, var(--accent-blue) 10%, transparent);
+	}
+	.scope-dot {
+		width: 8px;
+		height: 8px;
+		border-radius: 50%;
+		background: var(--text-muted);
+		border: 1px solid var(--border);
+	}
+	.scope-dot.on {
+		background: var(--accent-blue);
+		border-color: var(--accent-blue);
 	}
 
 	/* Filter chips */

--- a/web/src/lib/components/search/CommandPalette.svelte
+++ b/web/src/lib/components/search/CommandPalette.svelte
@@ -228,26 +228,44 @@
 		// All three use a 200ms debounce on the network call.
 		if (parsed.body || !currentReady || ready.length === 0) {
 			loading = true;
+			// Snapshot the query + scope at dispatch time so a slow
+			// response that lands after the user typed more (or after
+			// the local index hydrated and the path switched to local)
+			// can't clobber the now-current results. Codex round 3 P2.
+			const snapshotQuery = trimmed;
+			const snapshotAllWs = searchAllWorkspaces;
 			searchTimeout = setTimeout(async () => {
 				try {
 					const serverQuery = parsed.body ? parsed.text || trimmed : trimmed;
 					if (!serverQuery.trim()) {
-						results = [];
-						total = 0;
-						facets = undefined;
+						if (query.trim() === snapshotQuery) {
+							results = [];
+							total = 0;
+							facets = undefined;
+						}
 						return;
 					}
 					const resp = await api.search(serverQuery, buildFilters(0));
+					// Stale-response guard: if the query has changed or
+					// the toggle has flipped since dispatch, discard.
+					if (
+						query.trim() !== snapshotQuery ||
+						searchAllWorkspaces !== snapshotAllWs
+					) {
+						return;
+					}
 					results = resp.results ?? [];
 					total = resp.total ?? 0;
 					facets = resp.facets;
 					selectedIdx = -1;
 				} catch {
-					results = [];
-					total = 0;
-					facets = undefined;
+					if (query.trim() === snapshotQuery) {
+						results = [];
+						total = 0;
+						facets = undefined;
+					}
 				} finally {
-					loading = false;
+					if (query.trim() === snapshotQuery) loading = false;
 				}
 			}, 200);
 			return;
@@ -256,16 +274,23 @@
 		// Local synchronous path. For each ready workspace, run
 		// localSearch.search and materialize to SearchResult shape.
 		// Merge by score descending — ties broken by `updated_at DESC`
-		// for stability. Cap to PAGE_SIZE for the visible list (the
-		// palette already supports a "load more" affordance, but for
-		// in-RAM local search there's no pagination — we either have
-		// all matching rows or we'll never have more, so disable the
-		// "load more" UX by setting `total = results.length`).
+		// for stability.
+		//
+		// Per-workspace limit: when a status filter chip is active, we
+		// expand the per-workspace pull so the post-fetch
+		// `filterStatus` filter has enough headroom to find matches
+		// outside the top 20 (Codex round 3 P2). The status filter
+		// isn't an index-aware operation on the local path — it walks
+		// the parsed `fields` blob after materialization — so a tight
+		// per-ws cap could drop valid lower-ranked matches.
+		const perWsLimit = filterStatus
+			? LOCAL_PER_WS_LIMIT * 5
+			: LOCAL_PER_WS_LIMIT;
 		const merged: AugmentedSearchResult[] = [];
 		for (const ws of ready) {
 			const hits = localSearch.search(ws.slug, trimmed, {
 				collection: filterCollection ?? undefined,
-				limit: LOCAL_PER_WS_LIMIT,
+				limit: perWsLimit,
 			});
 			merged.push(...materializeLocalHits(ws.slug, ws.owner_username, hits));
 		}

--- a/web/src/lib/components/search/CommandPalette.svelte
+++ b/web/src/lib/components/search/CommandPalette.svelte
@@ -276,12 +276,16 @@
 			? merged.filter((r) => getFieldValue(r.item, 'status') === filterStatus)
 			: merged;
 
-		// `total` is `filtered.length` because we don't paginate local
-		// results; everything's in RAM. Truncate the rendered list to
-		// PAGE_SIZE * 2 so cross-workspace power users still see a
-		// representative top slice.
+		// Truncate the rendered list to PAGE_SIZE * 2 so cross-workspace
+		// power users still see a representative top slice. CRITICAL:
+		// set `total = results.length` so the "Load more" affordance
+		// stays hidden — loadMore hits the server, which would
+		// inject scope-mismatched (and duplicate) rows into the local
+		// result set. Codex round 1 P2. Local results are all in RAM;
+		// if more than `PAGE_SIZE * 2` match, the right answer is a
+		// more specific query, not a paginated fetch.
 		results = filtered.slice(0, PAGE_SIZE * 2);
-		total = filtered.length;
+		total = results.length;
 		// Facets are server-only; clear them on the local path so the
 		// chip row hides cleanly.
 		facets = undefined;

--- a/web/src/lib/components/search/CommandPalette.svelte
+++ b/web/src/lib/components/search/CommandPalette.svelte
@@ -267,7 +267,20 @@
 			};
 			searchTimeout = setTimeout(async () => {
 				try {
-					const serverQuery = parsed.body ? parsed.text || trimmed : trimmed;
+					// Bare `body:` / `content:` with no following text:
+					// `parsed.text` is empty and we'd otherwise fall back
+					// to the raw query (`body:`) and ship that literal
+					// token to the server. Treat as a no-op until the
+					// user keeps typing. Codex round 9 P3 of TASK-1365.
+					if (parsed.body && !parsed.text) {
+						if (isSameDispatch()) {
+							results = [];
+							total = 0;
+							facets = undefined;
+						}
+						return;
+					}
+					const serverQuery = parsed.body ? parsed.text : trimmed;
 					if (!serverQuery.trim()) {
 						if (isSameDispatch()) {
 							results = [];
@@ -424,8 +437,14 @@
 		const snapshotWsSlug = workspaceStore.current?.slug;
 		// Parse once and use the stripped query for the API call so
 		// `body:foo` → page 2 sends `foo`, not the literal `body:foo`.
+		// A bare `body:` / `content:` with no following text is a
+		// no-op — there's nothing to load a second page of.
 		const parsed = parseSearchQuery(query.trim());
-		const serverQuery = parsed.body ? parsed.text || query.trim() : query;
+		if (parsed.body && !parsed.text) {
+			loadingMore = false;
+			return;
+		}
+		const serverQuery = parsed.body ? parsed.text : query;
 		try {
 			const resp = await api.search(serverQuery, buildFilters(results.length));
 			if (

--- a/web/src/lib/components/search/CommandPalette.svelte
+++ b/web/src/lib/components/search/CommandPalette.svelte
@@ -396,19 +396,23 @@
 		if (loadingMore || results.length >= total) return;
 		// Only the server path ever sets `total > results.length` — the
 		// local path pins them equal — so a `loadMore` always means
-		// fetching another server page. The dispatch scope can still
-		// change mid-flight, though: the current workspace can finish
-		// hydrating, the all-workspaces toggle can flip, or the query
-		// / filters can change. Snapshot all of it and bail if any of
-		// these shift before the response lands. Codex round 5 P2.
+		// fetching another server page. Snapshot the dispatch scope
+		// and bail if any of it has shifted before the response lands.
+		// Body queries are always server-authoritative (the local
+		// index doesn't carry content), so they bypass the
+		// live-readiness guard. Codex rounds 5-6 P2.
 		loadingMore = true;
 		const snapshotQuery = query;
 		const snapshotAllWs = searchAllWorkspaces;
 		const snapshotCollection = filterCollection;
 		const snapshotStatus = filterStatus;
 		const snapshotWsSlug = workspaceStore.current?.slug;
+		// Parse once and use the stripped query for the API call so
+		// `body:foo` → page 2 sends `foo`, not the literal `body:foo`.
+		const parsed = parseSearchQuery(query.trim());
+		const serverQuery = parsed.body ? parsed.text || query.trim() : query;
 		try {
-			const resp = await api.search(query, buildFilters(results.length));
+			const resp = await api.search(serverQuery, buildFilters(results.length));
 			if (
 				query !== snapshotQuery ||
 				searchAllWorkspaces !== snapshotAllWs ||
@@ -418,14 +422,17 @@
 			) {
 				return;
 			}
-			// If the current workspace hydrated while the request was
-			// in flight, the main effect has likely already swapped to
-			// the local path and replaced `results`. Appending more
-			// server rows would inject scope-mismatched results.
-			const liveCurrentReady =
-				!!snapshotWsSlug &&
-				localIndex.bootstrapStateFor(snapshotWsSlug) === 'ready';
-			if (liveCurrentReady) return;
+			if (!parsed.body) {
+				// Non-body server paging: if the current workspace
+				// hydrated while the request was in flight, the main
+				// effect has likely already swapped to the local
+				// path and replaced `results`. Appending more server
+				// rows would inject scope-mismatched results.
+				const liveCurrentReady =
+					!!snapshotWsSlug &&
+					localIndex.bootstrapStateFor(snapshotWsSlug) === 'ready';
+				if (liveCurrentReady) return;
+			}
 			results = [...results, ...(resp.results ?? [])];
 		} catch {
 			// ignore


### PR DESCRIPTION
## Summary

Phase 3c of the local-first read model (PLAN-1343 / DOC-1342): wire the global CommandPalette to localSearch.

- Default scope: current workspace's in-memory MiniSearch index, synchronous, no debounce.
- New "All workspaces" toggle: also searches every other workspace whose localIndex is `'ready'`; non-ready workspaces fall back transparently to server search.
- Cross-workspace navigation: each local result carries its source workspace, so `selectResult` lands on the right route.
- Server fallback paths: `body:` / `content:` queries and cold sessions with no ready workspaces.
- Reactive `$effect` re-runs on `query`, `searchAllWorkspaces`, filter chips, and any workspace's `localSearch.epoch` — SSE-driven upserts surface in an open palette without manual refresh.
- Toggle state persists to localStorage; hidden when only one workspace is ready.

## Context

Implements `TASK-1365` under `PLAN-1343`. Builds on TASK-1363 / TASK-1367.

## Test plan

- [x] `make check` — golangci-lint + go test + svelte-check + npm build all clean
- [ ] Manual: open palette, type — no network requests on the current workspace
- [ ] Manual: type `body:foo` — server `/search` is hit
- [ ] Manual: toggle "All workspaces" — results merge from other ready workspaces; toggle persists across reloads
- [ ] Manual: click a cross-workspace result — navigates to the correct workspace