### PR TITLE
fix(ci): lower test-only bcrypt cost + re-enable -race on PRs (BUG-1371)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,13 +68,19 @@ jobs:
         run: go test ./...
 
       - name: Run tests with race detector
-        if: github.ref == 'refs/heads/main'
+        # Runs on both push-to-main AND pull_request. Previously gated to
+        # main only because GitHub Actions minutes were billed on private
+        # repos; the repo is public now, so PR minutes are free and we'd
+        # rather catch race regressions on the contributing branch than
+        # after merge. See BUG-1371 (also dropped test-only bcrypt cost
+        # via TestMain so this step stays well under the 30m budget).
+        #
         # Default 10m is tight: the full server-package suite under -race
         # measures ~13m locally on a developer laptop after BUG-851 (the
         # ipRateLimiter goroutine drain). The PLAN-866 attachment work
         # (image decode/encode/resize across thumbnail + transform tests)
         # pushes total race-step runtime past 20m on the GitHub-hosted
-        # runner — bumped to 30m to give headroom without papering over
+        # runner — kept at 30m to give headroom without papering over
         # an actual hang. Genuine deadlocks would still hit this and
         # produce the goroutine-dump panic.
         run: go test -race -timeout=30m ./...
@@ -118,14 +124,16 @@ jobs:
         run: go test ./... -count=1
 
       - name: Run tests with race detector against PostgreSQL
-        if: github.ref == 'refs/heads/main'
         env:
           PAD_TEST_POSTGRES_URL: "postgres://pad:pad@localhost:5432/pad?sslmode=disable"
-        # See SQLite race-detector step: 30m headroom over the default 10m.
-        # PostgreSQL adds latency on every CREATE/DROP and bcrypt under
-        # -race is ~3s per call — TestSessionIPChange-style tests that
-        # bootstrap a fresh user pay the full cost each time. The PLAN-866
-        # attachment work pushed the cumulative wall over 20m.
+        # Runs on both push-to-main AND pull_request — see SQLite race-step
+        # comment for the public-repo / BUG-1371 reasoning.
+        #
+        # 30m headroom over the default 10m. PostgreSQL adds latency on
+        # every CREATE/DROP, and the PLAN-866 attachment work pushed the
+        # cumulative wall over 20m. The bootstrap-user bcrypt cost that
+        # blew past 30m on main (BUG-1371) is now handled by TestMain
+        # dropping the cost to bcrypt.MinCost for test binaries.
         run: go test -race -timeout=30m ./... -count=1
 
   web:

--- a/internal/server/main_test.go
+++ b/internal/server/main_test.go
@@ -1,0 +1,18 @@
+package server
+
+import (
+	"os"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/store"
+	"golang.org/x/crypto/bcrypt"
+)
+
+// TestMain lowers the bcrypt cost for the whole package. Without this,
+// the suite's many bootstrapFirstUser calls run bcrypt at the production
+// cost under -race (~3s per call), pushing cumulative race-step time past
+// the CI 30m timeout. See BUG-1371.
+func TestMain(m *testing.M) {
+	store.SetBcryptCostForTesting(bcrypt.MinCost)
+	os.Exit(m.Run())
+}

--- a/internal/store/main_test.go
+++ b/internal/store/main_test.go
@@ -1,0 +1,16 @@
+package store
+
+import (
+	"os"
+	"testing"
+
+	"golang.org/x/crypto/bcrypt"
+)
+
+// TestMain lowers the bcrypt cost for the whole package. See BUG-1371
+// and internal/server/main_test.go for context — the same reasoning
+// applies to internal/store tests that call CreateUser directly.
+func TestMain(m *testing.M) {
+	SetBcryptCostForTesting(bcrypt.MinCost)
+	os.Exit(m.Run())
+}

--- a/internal/store/testing_helpers.go
+++ b/internal/store/testing_helpers.go
@@ -1,0 +1,23 @@
+package store
+
+// SetBcryptCostForTesting overrides the bcrypt cost used by CreateUser
+// and UpdateUser for the lifetime of a test binary. It returns a
+// restore function — call it from TestMain (or defer it) to leave
+// the package state clean, though process exit also suffices since
+// the override is local to the test binary.
+//
+// Why this exists: under the race detector, bcrypt.GenerateFromPassword
+// at the production cost (12) takes ~3s per call. The internal/server
+// and internal/store test suites bootstrap dozens of users each; the
+// cumulative cost exceeded the 30m CI -race timeout (BUG-1371). Tests
+// that don't care about hash strength call this once per binary in
+// TestMain to drop the cost to bcrypt.MinCost (= 4), which restores
+// the race step to well under the timeout.
+//
+// Production code MUST NOT call this. The "ForTesting" suffix is the
+// grep signal — any non-test caller is a bug.
+func SetBcryptCostForTesting(cost int) func() {
+	prev := bcryptCost
+	bcryptCost = cost
+	return func() { bcryptCost = prev }
+}

--- a/internal/store/users.go
+++ b/internal/store/users.go
@@ -18,7 +18,13 @@ import (
 
 var usernameCleanRe = regexp.MustCompile(`[^a-z0-9-]+`)
 
-const bcryptCost = 12
+// bcryptCost is the cost factor passed to bcrypt.GenerateFromPassword.
+// It is a var (not const) so tests can lower it via SetBcryptCostForTesting
+// — at the production value of 12, bcrypt takes ~3s per call under the
+// race detector and the cumulative cost across the test suite exceeds
+// the CI -race timeout (see BUG-1371). Production code MUST NOT mutate
+// this directly; the only legitimate writer is a test TestMain.
+var bcryptCost = 12
 
 // user SELECT columns — used by all user queries.
 const userColumns = `id, email, username, name, password_hash, role, avatar_url, totp_secret, totp_enabled, recovery_codes, plan, plan_expires_at, stripe_customer_id, plan_overrides, oauth_providers, password_set, disabled_at, last_active_at, created_at, updated_at`


### PR DESCRIPTION
## Summary

Fixes [BUG-1371](http://localhost:7777). The full `internal/server` test suite under `-race` had grown past the 30m CI timeout, failing every push to main since ~TASK-1354. PRs kept looking green because the `-race` job was gated `if: github.ref == 'refs/heads/main'` and never ran pre-merge.

Root cause: bcrypt at the production cost (12) takes ~3s per call under the race detector, and dozens of tests now bootstrap a user via `bootstrapFirstUser` → `store.CreateUser` → `bcrypt.GenerateFromPassword`. Cumulative bcrypt cost dominated the 30m budget. Different cause from BUG-851 (which was a goroutine leak); that one stays fixed.

Two coordinated changes:

1. **Lower bcrypt cost in test binaries.** `bcryptCost` is now a package var (still package-private). New `SetBcryptCostForTesting(cost) func()` helper lets each test binary's `TestMain` drop the cost to `bcrypt.MinCost`. Production stays at 12 — only test processes mutate it, restricted by naming convention (`ForTesting` suffix).
2. **Re-enable `-race` on pull requests.** The `if: github.ref == 'refs/heads/main'` gate was an Actions-minutes cost control. Repo is public now → PR minutes are free. Better to catch races on the contributing branch than after merge.

## Measured impact

| Step | Before | After |
|---|---|---|
| `go test -race ./internal/server` | 1800s timeout (FAIL) | 830s (13m51s) ✓ |
| `go test ./internal/store` | 808s | 35s |
| `go test ./internal/server` | 192s | 60s |

30m race-step timeout kept intact — it's headroom for genuine deadlocks (which would still produce the goroutine-dump panic the way BUG-851 did).

## Files

- `internal/store/users.go` — `const` → `var bcryptCost`, comment explaining why
- `internal/store/testing_helpers.go` — new `SetBcryptCostForTesting`
- `internal/server/main_test.go` — new `TestMain` that lowers cost
- `internal/store/main_test.go` — same, for the store package's tests
- `.github/workflows/ci.yml` — drop `main`-only gate on both `-race` steps; comments updated

## Test plan

- [x] `make check` clean (lint, full non-race suite, govulncheck, web build)
- [x] `go test -race ./internal/server/` measured at 13m51s — well under 30m
- [x] Codex review CLEAN
- [ ] CI passes on this PR (this is the first run of `-race` on a PR — extra signal that the gate change works)
- [ ] CI passes on `main` after merge