### PR TITLE
feat(web): add ContentSkeleton + ContentError primitives (TASK-1374)

### DIFF
--- a/web/src/lib/components/common/ContentError.svelte
+++ b/web/src/lib/components/common/ContentError.svelte
@@ -1,0 +1,76 @@
+<script lang="ts">
+	interface Props {
+		title?: string;
+		detail?: string;
+		onRetry: () => void;
+		retryLabel?: string;
+	}
+
+	let {
+		title = 'Could not load content',
+		detail,
+		onRetry,
+		retryLabel = 'Try again'
+	}: Props = $props();
+</script>
+
+<div class="content-error" role="alert">
+	<div class="error-icon" aria-hidden="true">⚠️</div>
+	<p class="error-title">{title}</p>
+	{#if detail}
+		<p class="error-detail">{detail}</p>
+	{/if}
+	<button class="retry-btn" onclick={onRetry}>
+		{retryLabel}
+	</button>
+</div>
+
+<style>
+	.content-error {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		padding: var(--space-10) var(--space-6);
+		text-align: center;
+	}
+
+	.error-icon {
+		font-size: 2.5em;
+		margin-bottom: var(--space-4);
+		line-height: 1;
+	}
+
+	.error-title {
+		color: var(--text-primary);
+		font-size: 1em;
+		font-weight: 600;
+		max-width: 400px;
+		margin: 0 0 var(--space-3) 0;
+		line-height: 1.5;
+	}
+
+	.error-detail {
+		color: var(--text-muted);
+		font-size: 0.9em;
+		max-width: 400px;
+		margin: 0 0 var(--space-5) 0;
+		line-height: 1.5;
+	}
+
+	.retry-btn {
+		background: var(--accent-blue);
+		color: #fff;
+		border: none;
+		padding: var(--space-2) var(--space-5);
+		border-radius: var(--radius);
+		font-size: 0.9em;
+		font-weight: 600;
+		cursor: pointer;
+		transition: opacity 0.1s;
+	}
+
+	.retry-btn:hover {
+		opacity: 0.85;
+	}
+</style>

--- a/web/src/lib/components/common/ContentSkeleton.svelte
+++ b/web/src/lib/components/common/ContentSkeleton.svelte
@@ -1,0 +1,89 @@
+<script lang="ts">
+	interface Props {
+		variant?: 'page' | 'inline';
+	}
+
+	let { variant = 'inline' }: Props = $props();
+</script>
+
+<div
+	class="skeleton skeleton-{variant}"
+	role="status"
+	aria-label="Loading content"
+>
+	<div class="bar bar-wide" aria-hidden="true"></div>
+	<div class="bar bar-medium" aria-hidden="true"></div>
+	<div class="bar bar-narrow" aria-hidden="true"></div>
+	{#if variant === 'page'}
+		<div class="bar bar-medium" aria-hidden="true"></div>
+	{/if}
+</div>
+
+<style>
+	.skeleton {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-3);
+	}
+
+	.skeleton-page {
+		align-items: center;
+		padding: var(--space-10) var(--space-6);
+	}
+
+	.skeleton-page .bar {
+		width: 100%;
+		max-width: 600px;
+	}
+
+	.skeleton-inline {
+		padding: var(--space-4) 0;
+		width: 100%;
+	}
+
+	.bar {
+		height: 14px;
+		background: var(--bg-tertiary);
+		border-radius: var(--radius);
+		animation: pulse 1.5s ease-in-out infinite;
+	}
+
+	.bar-wide {
+		width: 70%;
+	}
+
+	.bar-medium {
+		width: 90%;
+	}
+
+	.bar-narrow {
+		width: 50%;
+	}
+
+	.skeleton-page .bar-wide {
+		width: 70%;
+		height: 28px;
+	}
+
+	.skeleton-page .bar-medium {
+		height: 14px;
+	}
+
+	@keyframes pulse {
+		0% {
+			opacity: 1;
+		}
+		50% {
+			opacity: 0.5;
+		}
+		100% {
+			opacity: 1;
+		}
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.bar {
+			animation: none;
+		}
+	}
+</style>


### PR DESCRIPTION
## Summary
Two reusable presentational components for the item-detail loading and error UX work in PLAN-1373:

- **`ContentSkeleton.svelte`** — CSS-only shimmer placeholder with `page` / `inline` variants. Respects `prefers-reduced-motion`. Pure presentational, no Pad-state imports.
- **`ContentError.svelte`** — centered title + optional detail + retry button. Mirrors `EmptyState.svelte`'s visual language.

Both use Svelte 5 runes, design tokens (`var(--bg-tertiary)`, `var(--accent-blue)`, etc.), and a11y attributes (`role="status"` / `role="alert"`, `aria-hidden` on decorative bars/icon).

## Context
Implements `TASK-1374` under `PLAN-1373` (BUG-1372 fix). No wiring yet — `TASK-1375` and `TASK-1376` consume these.

## Test plan
- [x] `make check` — golangci-lint + go test + npm run build clean
- [x] `cd web && npm run check` — 798 files, 0 errors (6 pre-existing warnings unrelated)
- [x] Visual smoke-test deferred to TASK-1375/1376 (which mount these in real contexts)

## Files
- `web/src/lib/components/common/ContentSkeleton.svelte` (new)
- `web/src/lib/components/common/ContentError.svelte` (new)