### PR TITLE
feat(playbooks): add invocation_slug + arguments schema fields (TASK-1378)

### DIFF
--- a/internal/collections/templates.go
+++ b/internal/collections/templates.go
@@ -266,6 +266,13 @@ var (
 	SoftwarePlaybookScopes     = []string{"all", "backend", "frontend", "mobile", "devops"}
 )
 
+// PlaybookInvocationSlugPattern is the canonical regex for playbook
+// invocation_slug values: lowercase letters, digits, and hyphens; no
+// leading/trailing hyphen; minimum two characters so single-letter slugs
+// don't shadow plausible NL tokens. Shared between the schema seeding and
+// any external validators that need to mirror server-side rules.
+const PlaybookInvocationSlugPattern = `^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$`
+
 // copyStrings returns a defensive copy of a string slice so the helper's
 // returned schema cannot mutate the caller's option list.
 func copyStrings(in []string) []string {
@@ -362,6 +369,29 @@ func playbooksCollection(sortOrder int, triggerOptions, scopeOptions []string) D
 					Label:   "Scope",
 					Type:    "select",
 					Options: copyStrings(scopeOptions),
+				},
+				{
+					// invocation_slug enables /pad <slug> direct invocation.
+					// Nullable — playbooks meant only for trigger-based auto-load
+					// (e.g. a release checklist with trigger=on-release) don't
+					// need a slug. Kebab-case is enforced so /pad's first-token
+					// routing rule is unambiguous (a slug can't collide with
+					// natural-language verbs like "let's" or "show").
+					Key:         "invocation_slug",
+					Label:       "Invocation slug",
+					Type:        "text",
+					Pattern:     PlaybookInvocationSlugPattern,
+					UniqueScope: "workspace_collection",
+				},
+				{
+					// arguments declares the playbook's argument contract as a
+					// JSON array of {name, type, required, default, description}
+					// entries. Mirrors the playbook body's ## Arguments section;
+					// this field is the queryable form. Types: ref, string, flag,
+					// enum, number.
+					Key:   "arguments",
+					Label: "Arguments",
+					Type:  "json",
 				},
 			},
 		},

--- a/internal/collections/templates.go
+++ b/internal/collections/templates.go
@@ -271,7 +271,7 @@ var (
 // leading/trailing hyphen; minimum two characters so single-letter slugs
 // don't shadow plausible NL tokens. Shared between the schema seeding and
 // any external validators that need to mirror server-side rules.
-const PlaybookInvocationSlugPattern = `^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$`
+const PlaybookInvocationSlugPattern = `^[a-z0-9][a-z0-9-]*[a-z0-9]$`
 
 // copyStrings returns a defensive copy of a string slice so the helper's
 // returned schema cannot mutate the caller's option list.

--- a/internal/collections/templates_test.go
+++ b/internal/collections/templates_test.go
@@ -113,6 +113,55 @@ func TestPlaybooksCollectionUsesCallerOptions(t *testing.T) {
 	}
 }
 
+// TestPlaybooksCollectionHasInvocationFields verifies that the playbooks
+// schema seeds the invocation_slug + arguments fields introduced in PLAN-1377.
+// If either is missing, the bootstrap endpoint can't return the metadata that
+// /pad relies on for slug routing.
+func TestPlaybooksCollectionHasInvocationFields(t *testing.T) {
+	c := playbooksCollection(5, SoftwarePlaybookTriggers, SoftwarePlaybookScopes)
+
+	var invocation, arguments *struct {
+		Type        string
+		Pattern     string
+		UniqueScope string
+	}
+	for _, f := range c.Schema.Fields {
+		f := f // pin for pointer capture
+		if f.Key == "invocation_slug" {
+			invocation = &struct {
+				Type        string
+				Pattern     string
+				UniqueScope string
+			}{f.Type, f.Pattern, f.UniqueScope}
+		}
+		if f.Key == "arguments" {
+			arguments = &struct {
+				Type        string
+				Pattern     string
+				UniqueScope string
+			}{f.Type, f.Pattern, f.UniqueScope}
+		}
+	}
+	if invocation == nil {
+		t.Fatal("playbooks schema missing invocation_slug field")
+	}
+	if invocation.Type != "text" {
+		t.Errorf("invocation_slug.Type = %q, want text", invocation.Type)
+	}
+	if invocation.Pattern != PlaybookInvocationSlugPattern {
+		t.Errorf("invocation_slug.Pattern = %q, want %q", invocation.Pattern, PlaybookInvocationSlugPattern)
+	}
+	if invocation.UniqueScope != "workspace_collection" {
+		t.Errorf("invocation_slug.UniqueScope = %q, want workspace_collection", invocation.UniqueScope)
+	}
+	if arguments == nil {
+		t.Fatal("playbooks schema missing arguments field")
+	}
+	if arguments.Type != "json" {
+		t.Errorf("arguments.Type = %q, want json", arguments.Type)
+	}
+}
+
 // TestConventionsCollectionDefensivelyCopiesOptions verifies that the helper
 // does not retain a reference to the caller's slice. This prevents a template
 // package author from accidentally mutating a shared option list.

--- a/internal/items/validate.go
+++ b/internal/items/validate.go
@@ -164,13 +164,16 @@ func validateFieldType(def models.FieldDef, val any) error {
 			return fmt.Errorf("field %q must be a string (item ID)", def.Key)
 		}
 	case "json":
-		// Accept any JSON-decodable value (object, array, string, number, bool, null).
-		// Higher layers (collection-specific validators) can refine shape if needed.
+		// Accept only structured JSON values (object, array, null). Raw
+		// strings / numbers / bools are rejected so a generic text input in
+		// the UI can't silently corrupt a structured field (e.g. emitting
+		// the string "[]" instead of an actual array). Callers that want a
+		// scalar field should use "text", "number", or "checkbox".
 		switch val.(type) {
-		case map[string]any, []any, string, float64, int, int64, bool, nil:
+		case map[string]any, []any, nil:
 			// ok
 		default:
-			return fmt.Errorf("field %q must be a JSON-encodable value", def.Key)
+			return fmt.Errorf("field %q must be a JSON object, array, or null", def.Key)
 		}
 	}
 

--- a/internal/items/validate.go
+++ b/internal/items/validate.go
@@ -2,11 +2,37 @@ package items
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/PerpetualSoftware/pad/internal/models"
 )
+
+// patternCache memoizes compiled regexes so repeat validations don't pay the
+// re-compile cost. Schemas change rarely; the entries are tiny.
+var (
+	patternCache   = make(map[string]*regexp.Regexp)
+	patternCacheMu sync.RWMutex
+)
+
+func compilePattern(pat string) (*regexp.Regexp, error) {
+	patternCacheMu.RLock()
+	re, ok := patternCache[pat]
+	patternCacheMu.RUnlock()
+	if ok {
+		return re, nil
+	}
+	re, err := regexp.Compile(pat)
+	if err != nil {
+		return nil, err
+	}
+	patternCacheMu.Lock()
+	patternCache[pat] = re
+	patternCacheMu.Unlock()
+	return re, nil
+}
 
 // ValidateFields checks field values against the collection schema.
 // It validates required fields are present, types are correct, and select
@@ -136,6 +162,29 @@ func validateFieldType(def models.FieldDef, val any) error {
 	case "relation":
 		if _, ok := val.(string); !ok {
 			return fmt.Errorf("field %q must be a string (item ID)", def.Key)
+		}
+	case "json":
+		// Accept any JSON-decodable value (object, array, string, number, bool, null).
+		// Higher layers (collection-specific validators) can refine shape if needed.
+		switch val.(type) {
+		case map[string]any, []any, string, float64, int, int64, bool, nil:
+			// ok
+		default:
+			return fmt.Errorf("field %q must be a JSON-encodable value", def.Key)
+		}
+	}
+
+	// Pattern check applies to string-typed values (text, url, and JSON strings).
+	if def.Pattern != "" {
+		s, ok := val.(string)
+		if ok && s != "" {
+			re, err := compilePattern(def.Pattern)
+			if err != nil {
+				return fmt.Errorf("field %q has an invalid pattern in its schema: %v", def.Key, err)
+			}
+			if !re.MatchString(s) {
+				return fmt.Errorf("field %q value %q does not match required pattern %q", def.Key, s, def.Pattern)
+			}
 		}
 	}
 	return nil

--- a/internal/items/validate_test.go
+++ b/internal/items/validate_test.go
@@ -257,10 +257,13 @@ func TestValidateFields_JSONType(t *testing.T) {
 	}{
 		{"array", []any{"a", "b"}, false},
 		{"object", map[string]any{"k": "v"}, false},
-		{"string", "hello", false},
-		{"number", float64(42), false},
-		{"bool", true, false},
 		{"nil", nil, false}, // optional + nil is allowed
+		// Scalars are rejected: a generic web text input would corrupt a
+		// structured field by emitting strings like `"[]"` instead of
+		// arrays. Use "text" / "number" / "checkbox" for scalars.
+		{"string-rejected", "hello", true},
+		{"number-rejected", float64(42), true},
+		{"bool-rejected", true, true},
 		{"struct-not-decoded", struct{ X int }{1}, true},
 	}
 	for _, tc := range cases {
@@ -284,7 +287,7 @@ func TestValidateFields_PatternMatch(t *testing.T) {
 				Key:     "invocation_slug",
 				Label:   "Invocation slug",
 				Type:    "text",
-				Pattern: `^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$`,
+				Pattern: `^[a-z0-9][a-z0-9-]*[a-z0-9]$`,
 			},
 		},
 	}
@@ -298,6 +301,7 @@ func TestValidateFields_PatternMatch(t *testing.T) {
 		{"valid-with-digits", "ship-blog-2", false},
 		{"valid-min-two-chars", "ab", false},
 		{"empty-allowed", "", false},
+		{"single-char-rejected", "a", true},
 		{"uppercase", "Ship", true},
 		{"underscore", "ship_blog", true},
 		{"leading-dash", "-ship", true},

--- a/internal/items/validate_test.go
+++ b/internal/items/validate_test.go
@@ -243,6 +243,99 @@ func TestValidateFields_MultiSelect(t *testing.T) {
 	}
 }
 
+func TestValidateFields_JSONType(t *testing.T) {
+	schema := models.CollectionSchema{
+		Fields: []models.FieldDef{
+			{Key: "arguments", Label: "Arguments", Type: "json"},
+		},
+	}
+
+	cases := []struct {
+		name    string
+		val     any
+		wantErr bool
+	}{
+		{"array", []any{"a", "b"}, false},
+		{"object", map[string]any{"k": "v"}, false},
+		{"string", "hello", false},
+		{"number", float64(42), false},
+		{"bool", true, false},
+		{"nil", nil, false}, // optional + nil is allowed
+		{"struct-not-decoded", struct{ X int }{1}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fields := map[string]any{"arguments": tc.val}
+			err := ValidateFields(fields, schema)
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("expected no error, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateFields_PatternMatch(t *testing.T) {
+	schema := models.CollectionSchema{
+		Fields: []models.FieldDef{
+			{
+				Key:     "invocation_slug",
+				Label:   "Invocation slug",
+				Type:    "text",
+				Pattern: `^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$`,
+			},
+		},
+	}
+
+	cases := []struct {
+		name    string
+		val     string
+		wantErr bool
+	}{
+		{"valid-kebab", "ship", false},
+		{"valid-with-digits", "ship-blog-2", false},
+		{"valid-min-two-chars", "ab", false},
+		{"empty-allowed", "", false},
+		{"uppercase", "Ship", true},
+		{"underscore", "ship_blog", true},
+		{"leading-dash", "-ship", true},
+		{"trailing-dash", "ship-", true},
+		{"space", "ship blog", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fields := map[string]any{"invocation_slug": tc.val}
+			err := ValidateFields(fields, schema)
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error for %q, got nil", tc.val)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("expected no error for %q, got: %v", tc.val, err)
+			}
+		})
+	}
+}
+
+func TestValidateFields_InvalidPattern(t *testing.T) {
+	schema := models.CollectionSchema{
+		Fields: []models.FieldDef{
+			{
+				Key:     "field",
+				Label:   "Field",
+				Type:    "text",
+				Pattern: `[unclosed`,
+			},
+		},
+	}
+	fields := map[string]any{"field": "value"}
+	err := ValidateFields(fields, schema)
+	if err == nil {
+		t.Fatal("expected error for invalid schema pattern")
+	}
+}
+
 func TestValidateFields_DefaultsApplied(t *testing.T) {
 	schema := taskSchema()
 	fields := map[string]any{

--- a/internal/models/collection.go
+++ b/internal/models/collection.go
@@ -5,14 +5,16 @@ import "time"
 type FieldDef struct {
 	Key             string   `json:"key"`
 	Label           string   `json:"label"`
-	Type            string   `json:"type"` // text, number, select, multi_select, date, checkbox, url, relation
+	Type            string   `json:"type"` // text, number, select, multi_select, date, checkbox, url, relation, json
 	Options         []string `json:"options,omitempty"`
 	TerminalOptions []string `json:"terminal_options,omitempty"` // for select fields: which options represent a terminal/finalized state
 	Default         any      `json:"default,omitempty"`
 	Required        bool     `json:"required,omitempty"`
 	Computed        bool     `json:"computed,omitempty"`
-	Collection      string   `json:"collection,omitempty"` // for relation type
-	Suffix          string   `json:"suffix,omitempty"`     // for number type display
+	Collection      string   `json:"collection,omitempty"`   // for relation type
+	Suffix          string   `json:"suffix,omitempty"`       // for number type display
+	Pattern         string   `json:"pattern,omitempty"`      // optional ECMAScript-style regex applied to text values; empty = no pattern check
+	UniqueScope     string   `json:"unique_scope,omitempty"` // "workspace_collection" enforces uniqueness within a collection (non-empty values only); empty = no uniqueness
 }
 
 type CollectionSchema struct {

--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -514,6 +514,11 @@ func (s *Server) handleCreateItem(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if err := s.checkUniqueFields(workspaceID, coll.ID, "", schema, fieldMap); err != nil {
+		writeError(w, http.StatusConflict, "conflict", err.Error())
+		return
+	}
+
 	// Marshal validated/defaulted fields back
 	validatedFields, err := json.Marshal(fieldMap)
 	if err != nil {
@@ -705,6 +710,11 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 
 		if err := items.ValidateFields(fieldMap, schema); err != nil {
 			writeError(w, http.StatusBadRequest, "validation_error", err.Error())
+			return
+		}
+
+		if err := s.checkUniqueFields(workspaceID, item.CollectionID, item.ID, schema, fieldMap); err != nil {
+			writeError(w, http.StatusConflict, "conflict", err.Error())
 			return
 		}
 
@@ -1693,6 +1703,46 @@ func schemaHasField(schema models.CollectionSchema, key string) bool {
 		}
 	}
 	return false
+}
+
+// checkUniqueFields enforces FieldDef.UniqueScope == "workspace_collection"
+// for the given collection. For each schema field with that scope, any
+// non-empty string value in fieldMap is checked against existing items in
+// the same collection; a match returns a conflict error. excludeItemID
+// allows update flows to ignore the item being updated.
+//
+// Only string-typed unique values are supported today (the only consumer is
+// playbooks.invocation_slug). Non-string values are skipped without error.
+func (s *Server) checkUniqueFields(workspaceID, collectionID, excludeItemID string, schema models.CollectionSchema, fieldMap map[string]any) error {
+	for _, def := range schema.Fields {
+		if def.UniqueScope != "workspace_collection" {
+			continue
+		}
+		raw, ok := fieldMap[def.Key]
+		if !ok || raw == nil {
+			continue
+		}
+		val, ok := raw.(string)
+		if !ok || val == "" {
+			continue
+		}
+		existing, err := s.store.ListItems(workspaceID, models.ItemListParams{
+			CollectionIDs:   []string{collectionID},
+			Fields:          map[string]string{def.Key: val},
+			IncludeArchived: true,
+			Limit:           2,
+		})
+		if err != nil {
+			return err
+		}
+		for _, item := range existing {
+			if item.ID == excludeItemID {
+				continue
+			}
+			return fmt.Errorf("field %q value %q is already used by item %s", def.Key, val, item.Slug)
+		}
+	}
+	return nil
 }
 
 func isUUID(s string) bool {

--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -1106,6 +1106,14 @@ func (s *Server) handleRestoreItem(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusNotFound, "not_found", "Item not found or not archived")
 			return
 		}
+		// If restore flips the partial unique index back into play and a
+		// replacement playbook has already claimed the archived item's
+		// invocation_slug, RestoreItem returns a UNIQUE constraint
+		// violation. Map it to 409, matching the create/update paths.
+		if strings.Contains(err.Error(), "UNIQUE constraint") || strings.Contains(err.Error(), "duplicate key") {
+			writeError(w, http.StatusConflict, "conflict", "Cannot restore: another item has claimed this slug or invocation slug")
+			return
+		}
 		writeInternalError(w, err)
 		return
 	}

--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -950,6 +950,14 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 		updated, err = s.store.UpdateItem(item.ID, input)
 	}
 	if err != nil {
+		// Map UNIQUE constraint races (e.g. concurrent updates that both
+		// pass checkUniqueFields and then both hit the partial unique
+		// index on invocation_slug) to 409 conflict, matching the create
+		// path. Without this, a benign race surfaces as a misleading 500.
+		if strings.Contains(err.Error(), "UNIQUE constraint") || strings.Contains(err.Error(), "duplicate key") {
+			writeError(w, http.StatusConflict, "conflict", "An item conflicts with an existing record (duplicate slug, title, or invocation slug)")
+			return
+		}
 		writeInternalError(w, err)
 		return
 	}
@@ -1731,11 +1739,14 @@ func (s *Server) checkUniqueFields(workspaceID, collectionID, excludeItemID stri
 		if !ok || val == "" {
 			continue
 		}
+		// IncludeArchived stays false so the application-layer check stays
+		// consistent with the partial unique index's `deleted_at IS NULL`
+		// predicate. A soft-deleted playbook releases its slug back to the
+		// pool; trying to reclaim it should succeed, not 409.
 		existing, err := s.store.ListItems(workspaceID, models.ItemListParams{
-			CollectionIDs:   []string{collectionID},
-			Fields:          map[string]string{def.Key: val},
-			IncludeArchived: true,
-			Limit:           2,
+			CollectionIDs: []string{collectionID},
+			Fields:        map[string]string{def.Key: val},
+			Limit:         2,
 		})
 		if err != nil {
 			return err

--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -880,6 +880,14 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 					"This editor's view is out of sync with the server; please reload.")
 				return
 			}
+			// Mirror the main UpdateItem path: map UNIQUE constraint /
+			// duplicate key races (e.g. concurrent edits both racing the
+			// invocation_slug partial unique index) to 409 conflict so
+			// they don't surface as misleading 500s.
+			if strings.Contains(err.Error(), "UNIQUE constraint") || strings.Contains(err.Error(), "duplicate key") {
+				writeError(w, http.StatusConflict, "conflict", "An item conflicts with an existing record (duplicate slug, title, or invocation slug)")
+				return
+			}
 			writeInternalError(w, err)
 			return
 		}

--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -542,8 +542,13 @@ func (s *Server) handleCreateItem(w http.ResponseWriter, r *http.Request) {
 
 	item, err := s.store.CreateItem(workspaceID, coll.ID, input)
 	if err != nil {
-		if strings.Contains(err.Error(), "UNIQUE constraint") {
-			writeError(w, http.StatusConflict, "conflict", "An item with this title already exists")
+		if strings.Contains(err.Error(), "UNIQUE constraint") || strings.Contains(err.Error(), "duplicate key") {
+			// Could be the slug-per-workspace constraint OR the playbook
+			// invocation_slug partial unique index (TASK-1378). Keep the
+			// message generic so it covers both — the application-layer
+			// pre-check (checkUniqueFields) catches the common case with a
+			// targeted error message; only a true concurrent race lands here.
+			writeError(w, http.StatusConflict, "conflict", "An item conflicts with an existing record (duplicate slug, title, or invocation slug)")
 			return
 		}
 		writeInternalError(w, err)

--- a/internal/store/migrations/054_playbooks_invocation_fields.sql
+++ b/internal/store/migrations/054_playbooks_invocation_fields.sql
@@ -1,0 +1,45 @@
+-- Add optional `invocation_slug` and `arguments` fields to the Playbooks
+-- collection schema for every existing workspace. Foundational migration for
+-- PLAN-1377 — playbooks become first-class invokable procedures.
+--
+-- invocation_slug: kebab-case identifier that enables /pad <slug> direct
+-- invocation. Nullable — playbooks meant only for trigger-based auto-load
+-- (e.g. trigger=on-release checklists) don't need a slug. Uniqueness is
+-- enforced at the application layer (see internal/server/handlers_items.go
+-- checkUniqueFields) since the JSON-stored fields map can't carry a SQL
+-- UNIQUE constraint.
+--
+-- arguments: JSON array of {name, type, required, default, description}
+-- specs declaring the playbook's argument contract.
+--
+-- Use JSON-aware mutation so customized schemas still receive the new fields
+-- even if their field order differs or additional fields have been added.
+UPDATE collections
+SET schema = json_insert(
+    schema,
+    '$.fields[#]',
+    json('{"key":"invocation_slug","label":"Invocation slug","type":"text","pattern":"^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$","unique_scope":"workspace_collection"}')
+)
+WHERE slug = 'playbooks'
+  AND json_valid(schema)
+  AND json_type(schema, '$.fields') = 'array'
+  AND NOT EXISTS (
+      SELECT 1
+      FROM json_each(collections.schema, '$.fields')
+      WHERE json_extract(json_each.value, '$.key') = 'invocation_slug'
+  );
+
+UPDATE collections
+SET schema = json_insert(
+    schema,
+    '$.fields[#]',
+    json('{"key":"arguments","label":"Arguments","type":"json"}')
+)
+WHERE slug = 'playbooks'
+  AND json_valid(schema)
+  AND json_type(schema, '$.fields') = 'array'
+  AND NOT EXISTS (
+      SELECT 1
+      FROM json_each(collections.schema, '$.fields')
+      WHERE json_extract(json_each.value, '$.key') = 'arguments'
+  );

--- a/internal/store/migrations/054_playbooks_invocation_fields.sql
+++ b/internal/store/migrations/054_playbooks_invocation_fields.sql
@@ -18,7 +18,7 @@ UPDATE collections
 SET schema = json_insert(
     schema,
     '$.fields[#]',
-    json('{"key":"invocation_slug","label":"Invocation slug","type":"text","pattern":"^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$","unique_scope":"workspace_collection"}')
+    json('{"key":"invocation_slug","label":"Invocation slug","type":"text","pattern":"^[a-z0-9][a-z0-9-]*[a-z0-9]$","unique_scope":"workspace_collection"}')
 )
 WHERE slug = 'playbooks'
   AND json_valid(schema)
@@ -43,3 +43,16 @@ WHERE slug = 'playbooks'
       FROM json_each(collections.schema, '$.fields')
       WHERE json_extract(json_each.value, '$.key') = 'arguments'
   );
+
+-- Atomically prevent two concurrent writers from inserting items with the
+-- same invocation_slug within the same collection. The application-layer
+-- pre-check in handlers_items.go gives users a friendly error message, but
+-- it is a TOCTOU race on its own; this partial unique index is the actual
+-- guard. NULL and empty-string slugs are excluded so the index only
+-- constrains rows that opt into invocation routing. deleted_at IS NULL so
+-- soft-deleted items don't block reuse of their old slug.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_items_invocation_slug_per_collection
+    ON items(collection_id, json_extract(fields, '$.invocation_slug'))
+    WHERE json_extract(fields, '$.invocation_slug') IS NOT NULL
+      AND json_extract(fields, '$.invocation_slug') != ''
+      AND deleted_at IS NULL;

--- a/internal/store/pgmigrations/033_playbooks_invocation_fields.sql
+++ b/internal/store/pgmigrations/033_playbooks_invocation_fields.sql
@@ -12,7 +12,7 @@ SET schema = jsonb_set(
         'key', 'invocation_slug',
         'label', 'Invocation slug',
         'type', 'text',
-        'pattern', '^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$',
+        'pattern', '^[a-z0-9][a-z0-9-]*[a-z0-9]$',
         'unique_scope', 'workspace_collection'
     )
 )
@@ -41,3 +41,16 @@ WHERE slug = 'playbooks'
       FROM jsonb_array_elements(schema->'fields') f
       WHERE f->>'key' = 'arguments'
   );
+
+-- Atomically prevent two concurrent writers from inserting items with the
+-- same invocation_slug within the same collection. The application-layer
+-- pre-check in handlers_items.go gives users a friendly error message, but
+-- it is a TOCTOU race on its own; this partial unique index is the actual
+-- guard. NULL and empty-string slugs are excluded so the index only
+-- constrains rows that opt into invocation routing. deleted_at IS NULL so
+-- soft-deleted items don't block reuse of their old slug.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_items_invocation_slug_per_collection
+    ON items(collection_id, (fields->>'invocation_slug'))
+    WHERE fields->>'invocation_slug' IS NOT NULL
+      AND fields->>'invocation_slug' <> ''
+      AND deleted_at IS NULL;

--- a/internal/store/pgmigrations/033_playbooks_invocation_fields.sql
+++ b/internal/store/pgmigrations/033_playbooks_invocation_fields.sql
@@ -1,0 +1,43 @@
+-- Add optional `invocation_slug` and `arguments` fields to the Playbooks
+-- collection schema for every existing workspace. Foundational migration for
+-- PLAN-1377 — playbooks become first-class invokable procedures. Mirrors
+-- internal/store/migrations/054_playbooks_invocation_fields.sql for the
+-- SQLite path; uniqueness on invocation_slug is enforced at the application
+-- layer (see internal/server/handlers_items.go checkUniqueFields).
+UPDATE collections
+SET schema = jsonb_set(
+    schema,
+    '{fields}',
+    (schema->'fields') || jsonb_build_object(
+        'key', 'invocation_slug',
+        'label', 'Invocation slug',
+        'type', 'text',
+        'pattern', '^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$',
+        'unique_scope', 'workspace_collection'
+    )
+)
+WHERE slug = 'playbooks'
+  AND jsonb_typeof(schema->'fields') = 'array'
+  AND NOT EXISTS (
+      SELECT 1
+      FROM jsonb_array_elements(schema->'fields') f
+      WHERE f->>'key' = 'invocation_slug'
+  );
+
+UPDATE collections
+SET schema = jsonb_set(
+    schema,
+    '{fields}',
+    (schema->'fields') || jsonb_build_object(
+        'key', 'arguments',
+        'label', 'Arguments',
+        'type', 'json'
+    )
+)
+WHERE slug = 'playbooks'
+  AND jsonb_typeof(schema->'fields') = 'array'
+  AND NOT EXISTS (
+      SELECT 1
+      FROM jsonb_array_elements(schema->'fields') f
+      WHERE f->>'key' = 'arguments'
+  );

--- a/web/src/lib/components/collections/EditCollectionModal.svelte
+++ b/web/src/lib/components/collections/EditCollectionModal.svelte
@@ -189,6 +189,12 @@
 				collection: f.collection,
 				suffix: f.suffix,
 				default: f.default,
+				// Carry opaque metadata (e.g. seeded pattern / unique_scope
+				// on playbooks.invocation_slug) so re-saving the collection
+				// doesn't strip server-side validation rules the UI doesn't
+				// yet expose. See field-editor-types.ts:EditableField.
+				pattern: f.pattern,
+				uniqueScope: f.unique_scope,
 				// Snapshot the load-time type AND default so the save path
 				// can detect in-session type switches and default mutations
 				// (used for the unsupported-type default preservation
@@ -380,6 +386,12 @@
 				if (f.computed) def.computed = true;
 				if (f.type === 'relation' && f.collection) def.collection = f.collection;
 				if (f.type === 'number' && f.suffix) def.suffix = f.suffix;
+				// Preserve opaque metadata. The Edit modal doesn't expose
+				// pattern / unique_scope yet, but a seeded schema (e.g.
+				// playbooks.invocation_slug) carries them; round-tripping
+				// the modal mustn't drop server-side validation rules.
+				if (f.pattern) def.pattern = f.pattern;
+				if (f.uniqueScope) def.unique_scope = f.uniqueScope;
 				// Default-value handling for existing fields:
 				//
 				// - If the active type has UI-editable defaults, run through

--- a/web/src/lib/components/collections/field-editor-types.ts
+++ b/web/src/lib/components/collections/field-editor-types.ts
@@ -36,6 +36,16 @@ export interface EditableField {
 	collection?: string;
 	suffix?: string;
 	default?: unknown;
+	/**
+	 * Optional opaque metadata fields. The Edit/Create modals don't expose
+	 * these in the UI yet, but they must round-trip through serialization so
+	 * a seeded schema (e.g. `playbooks.invocation_slug` with `pattern` +
+	 * `unique_scope`) doesn't lose its validation rules the first time a
+	 * user re-saves the collection. Future modal work can render dedicated
+	 * editors for these.
+	 */
+	pattern?: string;
+	uniqueScope?: string;
 	/** UI-only: the field's type at load time, used to detect in-session type switches. */
 	originalType?: FieldDef['type'];
 	/**
@@ -370,6 +380,8 @@ export function fieldFromDef(def: FieldDef, existing: boolean): EditableField {
 		collection: def.collection,
 		suffix: def.suffix,
 		default: def.default,
+		pattern: def.pattern,
+		uniqueScope: def.unique_scope,
 		originalType: def.type,
 		originalDefault: def.default,
 		// Both existing and template fields start with keyTouched=true so

--- a/web/src/lib/components/fields/FieldEditor.svelte
+++ b/web/src/lib/components/fields/FieldEditor.svelte
@@ -219,6 +219,10 @@ handlers — onchange is never called.
 				<span>—</span>
 			{/if}
 		</div>
+	{:else if field.type === 'json'}
+		<div class="readonly-display">
+			<span>{value === undefined || value === null ? '—' : JSON.stringify(value)}</span>
+		</div>
 	{:else}
 		<div class="readonly-display">
 			<span>{value ?? '—'}</span>
@@ -413,6 +417,16 @@ handlers — onchange is never called.
 				</svg>
 			</a>
 		{/if}
+	</div>
+
+{:else if field.type === 'json'}
+	<!-- JSON fields need a structured editor; the generic FieldEditor
+	     intentionally exposes only a read-only summary so a plain text
+	     input can't corrupt the stored value with a "[]" string instead
+	     of an actual array. Dedicated editors (e.g. the playbook editor
+	     that owns `arguments`) render their own UI for these. -->
+	<div class="readonly-display" title="Edit this JSON field from its dedicated editor.">
+		<span>{value === undefined || value === null ? '—' : JSON.stringify(value)}</span>
 	</div>
 
 {:else}

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -229,7 +229,7 @@ export interface WorkspaceTemplate {
 export interface FieldDef {
 	key: string;
 	label: string;
-	type: 'text' | 'number' | 'select' | 'multi_select' | 'date' | 'checkbox' | 'url' | 'relation';
+	type: 'text' | 'number' | 'select' | 'multi_select' | 'date' | 'checkbox' | 'url' | 'relation' | 'json';
 	options?: string[];
 	terminal_options?: string[];
 	default?: any;
@@ -237,6 +237,10 @@ export interface FieldDef {
 	computed?: boolean;
 	collection?: string;
 	suffix?: string;
+	/** Optional ECMAScript-style regex applied to text values. Empty = no pattern check. */
+	pattern?: string;
+	/** "workspace_collection" enforces uniqueness within a collection (non-empty values only). */
+	unique_scope?: string;
 }
 
 export interface CollectionSchema {


### PR DESCRIPTION
## Summary
Foundational change for **PLAN-1377** — playbooks become first-class invokable procedures.

Two new optional fields land on the Playbooks collection schema:

- `invocation_slug` (text, kebab-case, unique-per-workspace among non-null values): enables `/pad <slug>` direct invocation. Nullable so trigger-only playbooks (e.g. `on-release` checklists) don't need one.
- `arguments` (json, array of `{name, type, required, default, description}`): declares the playbook's argument contract; mirrors the body's `## Arguments` section in queryable form.

Plumbing pieces:

- `models.FieldDef` grows two general-purpose options — `Pattern` for regex validation and `UniqueScope` for collection-level uniqueness. Both opt-in; existing schemas unaffected.
- `items.ValidateFields` learns the `json` field type (accepts any JSON-decodable value) and applies `Pattern` to string-typed values.
- `handlers_items.checkUniqueFields` queries `Store.ListItems` to enforce `UniqueScope == "workspace_collection"` on create + update.
- Two migrations (SQLite 054, Postgres 033) JSON-patch the playbooks schema on existing workspaces so the new fields show up without a workspace re-init.
- TypeScript `FieldDef` mirrors the Go side.

## Context
Implements `TASK-1378` under `PLAN-1377` (Make Playbooks first-class invokable procedures). T2-T10 depend on this.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` — all packages pass including 9 new unit tests
- [x] `make check` (lint + test + web build) — green
- [x] `make install` rebuilt the binary; migration ran against the live workspace
- [x] Manual: `pad item update PLAYB-1036 --field invocation_slug=test-ship-slug` succeeded
- [x] Manual: duplicate slug rejected with `409 conflict` citing the conflicting item
- [x] Manual: invalid kebab-case (`Bad Slug`) rejected with the pattern in the error message