### PR TITLE
feat(bootstrap): single-roundtrip /pad context-load endpoint (TASK-1379)

### DIFF
--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -147,6 +147,7 @@ func newRootCmd() *cobra.Command {
 		dbCmd(),
 		completionCmd(),
 		mcpCmd(),
+		bootstrapCmd(),
 	)
 
 	rootCmd.SetHelpCommand(helpCmd())
@@ -4070,6 +4071,140 @@ func searchCmd() *cobra.Command {
 	cmd.Flags().IntVar(&offset, "offset", 0, "skip this many results (for pagination)")
 
 	return cmd
+}
+
+// --- bootstrap ---
+
+// bootstrapCmd returns the agent bootstrap blob — the consolidated
+// workspace + user + collections + always-on conventions + roles +
+// playbook metadata + dashboard + recent activity payload (PLAN-1377 /
+// TASK-1379). One CLI call replaces the four /pad context-loading calls
+// the skill used to make at every invocation. Output is JSON by default
+// so the skill can pipe it into context directly.
+func bootstrapCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "bootstrap",
+		Short: "Print the agent bootstrap blob (workspace + collections + conventions + roles + playbooks + dashboard) in one round-trip",
+		Long: `Print the consolidated agent bootstrap blob for the current workspace.
+
+The blob carries everything the /pad skill needs to start a session:
+
+  - Workspace identity (slug, name, id)
+  - The calling user (name, email, id)
+  - Collections (with schemas)
+  - Always-on, active conventions (full body — must-follow rules)
+  - Agent roles
+  - Playbooks (METADATA ONLY — full bodies load on invocation)
+  - Dashboard (active items, attention, suggested next)
+  - Recent activity (last 24h, capped)
+
+Use --format json for machine consumption (default). Use --format markdown
+for a readable summary.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, _ := getClient()
+			ws := getWorkspace()
+
+			raw, err := client.GetAgentBootstrap(ws)
+			if err != nil {
+				return err
+			}
+
+			if formatFlag == "markdown" {
+				return printBootstrapMarkdown(raw)
+			}
+			// JSON is the canonical wire format — the /pad skill consumes
+			// it directly, and table mode for a deeply nested blob would
+			// be more confusing than helpful. Treat anything-but-markdown
+			// as JSON.
+			return cli.PrintJSON(raw)
+		},
+	}
+}
+
+// printBootstrapMarkdown renders a human-friendly summary of the bootstrap
+// blob. Intended for quick inspection from the terminal; the canonical
+// machine format is JSON. Keep this terse — anyone wanting full detail
+// should use --format json.
+func printBootstrapMarkdown(raw []byte) error {
+	var b struct {
+		Workspace struct {
+			Slug string `json:"slug"`
+			Name string `json:"name"`
+		} `json:"workspace"`
+		User struct {
+			Name  string `json:"name"`
+			Email string `json:"email"`
+		} `json:"user"`
+		Collections []struct {
+			Slug   string `json:"slug"`
+			Name   string `json:"name"`
+			Prefix string `json:"prefix"`
+		} `json:"collections"`
+		Conventions []struct {
+			Ref      string `json:"ref"`
+			Title    string `json:"title"`
+			Priority string `json:"priority"`
+		} `json:"conventions"`
+		Roles []struct {
+			Slug string `json:"slug"`
+			Name string `json:"name"`
+		} `json:"roles"`
+		Playbooks []struct {
+			Ref            string `json:"ref"`
+			Title          string `json:"title"`
+			InvocationSlug string `json:"invocation_slug"`
+			Trigger        string `json:"trigger"`
+			Summary        string `json:"summary"`
+		} `json:"playbooks"`
+	}
+	if err := json.Unmarshal(raw, &b); err != nil {
+		return fmt.Errorf("decode bootstrap response: %w", err)
+	}
+
+	fmt.Printf("# Workspace %s (%s)\n", b.Workspace.Name, b.Workspace.Slug)
+	if b.User.Name != "" {
+		fmt.Printf("Signed in as %s <%s>\n\n", b.User.Name, b.User.Email)
+	} else {
+		fmt.Println()
+	}
+
+	fmt.Printf("## Collections (%d)\n", len(b.Collections))
+	for _, c := range b.Collections {
+		fmt.Printf("- %s (%s) — prefix %s\n", c.Name, c.Slug, c.Prefix)
+	}
+	fmt.Println()
+
+	fmt.Printf("## Always-on conventions (%d)\n", len(b.Conventions))
+	for _, c := range b.Conventions {
+		fmt.Printf("- [%s] %s — %s\n", c.Ref, c.Title, c.Priority)
+	}
+	fmt.Println()
+
+	fmt.Printf("## Agent roles (%d)\n", len(b.Roles))
+	for _, r := range b.Roles {
+		fmt.Printf("- %s (%s)\n", r.Name, r.Slug)
+	}
+	fmt.Println()
+
+	fmt.Printf("## Playbooks (%d)\n", len(b.Playbooks))
+	for _, p := range b.Playbooks {
+		invocation := "—"
+		if p.InvocationSlug != "" {
+			invocation = "/pad " + p.InvocationSlug
+		}
+		fmt.Printf("- [%s] %s\n  invoke: %s   trigger: %s\n", p.Ref, p.Title, invocation, defaultIfEmpty(p.Trigger, "—"))
+		if p.Summary != "" {
+			fmt.Printf("  %s\n", p.Summary)
+		}
+	}
+	return nil
+}
+
+func defaultIfEmpty(v, fallback string) string {
+	if v == "" {
+		return fallback
+	}
+	return v
 }
 
 // --- status ---

--- a/internal/cli/client.go
+++ b/internal/cli/client.go
@@ -247,6 +247,19 @@ func (c *Client) GetDashboard(wsSlug string) (json.RawMessage, error) {
 	return result, c.get("/workspaces/"+wsSlug+"/dashboard", &result)
 }
 
+// --- Bootstrap ---
+
+// GetAgentBootstrap returns the consolidated bootstrap blob — workspace +
+// user + collections + always-on conventions + roles + playbook metadata +
+// dashboard + recent activity — in one round-trip. Mirrors the HTTP
+// endpoint at /workspaces/{ws}/agent/bootstrap (PLAN-1377 / TASK-1379).
+// The AgentBootstrap type lives in the server package, so the CLI keeps it
+// as raw JSON and delegates parsing to the caller.
+func (c *Client) GetAgentBootstrap(wsSlug string) (json.RawMessage, error) {
+	var result json.RawMessage
+	return result, c.get("/workspaces/"+wsSlug+"/agent/bootstrap", &result)
+}
+
 // --- Search ---
 
 // SearchItems performs a cross-workspace search. Pass q, workspace, etc. via params.

--- a/internal/server/handlers_bootstrap.go
+++ b/internal/server/handlers_bootstrap.go
@@ -137,13 +137,21 @@ func (s *Server) BuildAgentBootstrap(workspaceID string, user *models.User, r *h
 		}
 	}
 
-	// Resolve visibility once so collections/conventions/playbooks all
-	// project the same authorized view. nil visibleIDs means "no
+	// Resolve visibility once so collections/conventions/playbooks/roles
+	// all project the same authorized view. nil visibleIDs means "no
 	// restriction" — a full workspace member (or a nil-r caller that
-	// has already verified access out-of-band).
+	// has already verified access out-of-band). For guests with
+	// item-level grants, we also need ItemIDs filtering so a grant to
+	// one specific playbook doesn't leak the whole collection.
 	var visibleIDs []string
+	var grantedItemIDs []string
+	var fullCollIDs []string
 	if r != nil {
 		visibleIDs, err = s.visibleCollectionIDs(r, workspaceID)
+		if err != nil {
+			return nil, err
+		}
+		fullCollIDs, grantedItemIDs, err = s.guestResourceFilter(r, workspaceID)
 		if err != nil {
 			return nil, err
 		}
@@ -167,12 +175,23 @@ func (s *Server) BuildAgentBootstrap(workspaceID string, user *models.User, r *h
 	}
 	out.Collections = collections
 
-	// Conventions — only the always-on, active set, restricted to the
-	// caller's visible conventions collection. trigger-specific
-	// conventions load on demand when their trigger fires.
+	// Build the (collectionIDs, itemIDs) tuple the sub-queries should
+	// project through. When the caller has item-level grants, switch to
+	// the full-coll vs granted-item filter — same shape handleListItems
+	// uses. Without grants, fall back to collection-level visibility.
+	subCollIDs := visibleIDs
+	var subItemIDs []string
+	if len(grantedItemIDs) > 0 {
+		subCollIDs = fullCollIDs
+		subItemIDs = grantedItemIDs
+	}
+
+	// Conventions — only the always-on, active set, restricted by the
+	// caller's authorized view. A guest with a grant to one specific
+	// convention item gets only that item, not the whole always-on set.
 	conventionsCollVisible := visibleIDs == nil || isCollectionSlugVisible(out.Collections, "conventions")
 	if conventionsCollVisible {
-		convs, cerr := s.collectAlwaysOnConventions(workspaceID)
+		convs, cerr := s.collectAlwaysOnConventions(workspaceID, subCollIDs, subItemIDs)
 		if cerr != nil {
 			return nil, cerr
 		}
@@ -181,8 +200,10 @@ func (s *Server) BuildAgentBootstrap(workspaceID string, user *models.User, r *h
 		out.Conventions = []AgentBootstrapConvention{}
 	}
 
-	// Agent roles — workspace-scoped, not collection-bound. Visible to
-	// any principal admitted into the workspace.
+	// Agent roles — workspace-scoped, not collection-bound. Item counts
+	// MUST be recomputed from the visible item set for restricted
+	// callers so a guest can't infer hidden activity by role. Mirrors
+	// handleListAgentRoles.
 	roles, err := s.store.ListAgentRoles(workspaceID)
 	if err != nil {
 		return nil, err
@@ -190,15 +211,32 @@ func (s *Server) BuildAgentBootstrap(workspaceID string, user *models.User, r *h
 	if roles == nil {
 		roles = []models.AgentRole{}
 	}
+	if visibleIDs != nil {
+		visibleItems, vierr := s.store.ListItems(workspaceID, models.ItemListParams{
+			CollectionIDs: subCollIDs,
+			ItemIDs:       subItemIDs,
+		})
+		if vierr != nil {
+			return nil, vierr
+		}
+		roleCounts := make(map[string]int)
+		for _, item := range visibleItems {
+			if item.AgentRoleID != nil && *item.AgentRoleID != "" {
+				roleCounts[*item.AgentRoleID]++
+			}
+		}
+		for i := range roles {
+			roles[i].ItemCount = roleCounts[roles[i].ID]
+		}
+	}
 	out.Roles = roles
 
-	// Playbooks (metadata only) — restricted to callers who can see the
-	// playbooks collection. Like conventions, this is a collection-level
-	// gate: if the caller can't see the playbooks collection at all,
-	// they get an empty list.
+	// Playbooks (metadata only) — restricted to the caller's authorized
+	// view. A guest granted one specific playbook item sees that one,
+	// not the whole collection.
 	playbooksCollVisible := visibleIDs == nil || isCollectionSlugVisible(out.Collections, "playbooks")
 	if playbooksCollVisible {
-		playbooks, perr := s.collectPlaybookMetadata(workspaceID)
+		playbooks, perr := s.collectPlaybookMetadata(workspaceID, subCollIDs, subItemIDs)
 		if perr != nil {
 			return nil, perr
 		}
@@ -230,9 +268,16 @@ func (s *Server) BuildAgentBootstrap(workspaceID string, user *models.User, r *h
 // collectAlwaysOnConventions returns the active, always-on conventions for
 // a workspace, projected into the bootstrap-friendly shape. Sorted by
 // priority (must > should > nice-to-have) then by ref for stable order.
-func (s *Server) collectAlwaysOnConventions(workspaceID string) ([]AgentBootstrapConvention, error) {
+//
+// collIDs / itemIDs scope the underlying ListItems call: nil collIDs
+// means "no restriction" (full member); non-nil collIDs + non-nil
+// itemIDs is the guest-with-item-grants shape from guestResourceFilter.
+// A guest granted access to a single convention only sees that one.
+func (s *Server) collectAlwaysOnConventions(workspaceID string, collIDs []string, itemIDs []string) ([]AgentBootstrapConvention, error) {
 	items, err := s.store.ListItems(workspaceID, models.ItemListParams{
 		CollectionSlug: "conventions",
+		CollectionIDs:  collIDs,
+		ItemIDs:        itemIDs,
 		Fields: map[string]string{
 			"status":  "active",
 			"trigger": "always",
@@ -292,9 +337,16 @@ func conventionPriorityRank(p string) int {
 
 // collectPlaybookMetadata returns every playbook in the workspace projected
 // down to the metadata shape. Bodies are NOT included.
-func (s *Server) collectPlaybookMetadata(workspaceID string) ([]AgentBootstrapPlaybookMeta, error) {
+//
+// collIDs / itemIDs scope the underlying ListItems call: nil collIDs
+// means "no restriction" (full member); non-nil collIDs + non-nil
+// itemIDs is the guest-with-item-grants shape from guestResourceFilter.
+// A guest granted access to a single playbook only sees that one.
+func (s *Server) collectPlaybookMetadata(workspaceID string, collIDs []string, itemIDs []string) ([]AgentBootstrapPlaybookMeta, error) {
 	items, err := s.store.ListItems(workspaceID, models.ItemListParams{
 		CollectionSlug: "playbooks",
+		CollectionIDs:  collIDs,
+		ItemIDs:        itemIDs,
 	})
 	if err != nil {
 		return nil, err

--- a/internal/server/handlers_bootstrap.go
+++ b/internal/server/handlers_bootstrap.go
@@ -91,14 +91,31 @@ type AgentBootstrapPlaybookMeta struct {
 // than this isn't relevant to "what's happening now."
 const recentActivityWindow = 24 * time.Hour
 
+// isCollectionSlugVisible reports whether the named collection survived
+// the visibility filter. Used by the bootstrap path to gate
+// convention/playbook queries on whether the caller can see those
+// collections at all. The slice we're checking is already-filtered, so
+// presence implies visibility.
+func isCollectionSlugVisible(filtered []models.Collection, slug string) bool {
+	for _, c := range filtered {
+		if c.Slug == slug {
+			return true
+		}
+	}
+	return false
+}
+
 // BuildAgentBootstrap assembles the bootstrap blob from store queries.
 // This is the single canonical code path; the HTTP handler, the MCP
 // resource handler, and the MCP `pad_set_workspace` embed all call this.
 //
-// r is used for the dashboard sub-build (which depends on guest grant
-// filtering); pass the live request. Pass nil to skip dashboard inclusion
-// — useful for callers that don't have a request context (e.g. the MCP
-// in-process dispatcher could synthesize one but doesn't yet).
+// r is the live request — used for the dashboard sub-build AND to
+// resolve the calling principal's collection visibility / guest grant
+// filter. Pass nil only when no request context is available (e.g. a
+// future MCP in-process dispatcher synthesizing its own ACL context);
+// in that case the bootstrap returns the full workspace view, which is
+// safe ONLY for callers that have already verified full-member access
+// out-of-band. Production HTTP/MCP paths MUST pass the live request.
 func (s *Server) BuildAgentBootstrap(workspaceID string, user *models.User, r *http.Request) (*AgentBootstrap, error) {
 	ws, err := s.store.GetWorkspaceByID(workspaceID)
 	if err != nil {
@@ -120,29 +137,52 @@ func (s *Server) BuildAgentBootstrap(workspaceID string, user *models.User, r *h
 		}
 	}
 
-	// Collections — keep the same shape ListCollections returns. The agent
-	// uses these to know what's available in the workspace and dispatch
-	// pad item commands by collection slug.
+	// Resolve visibility once so collections/conventions/playbooks all
+	// project the same authorized view. nil visibleIDs means "no
+	// restriction" — a full workspace member (or a nil-r caller that
+	// has already verified access out-of-band).
+	var visibleIDs []string
+	if r != nil {
+		visibleIDs, err = s.visibleCollectionIDs(r, workspaceID)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Collections — keep the same shape ListCollections returns, filtered
+	// by visibility so a guest only sees collections they're permitted
+	// into. Mirrors handleListCollections.
 	collections, err := s.store.ListCollections(workspaceID)
 	if err != nil {
 		return nil, err
 	}
+	if visibleIDs != nil {
+		filtered := make([]models.Collection, 0, len(collections))
+		for _, c := range collections {
+			if isCollectionVisible(c.ID, visibleIDs) {
+				filtered = append(filtered, c)
+			}
+		}
+		collections = filtered
+	}
 	out.Collections = collections
 
-	// Conventions — only the always-on, active set. trigger-specific
-	// conventions load on demand when their trigger fires (e.g. an
-	// `on-implement` convention is read just-in-time before code-edit
-	// work). Including only the must-follow always-on set keeps the
-	// bootstrap small without losing the rules the agent MUST know up
-	// front.
-	convs, err := s.collectAlwaysOnConventions(workspaceID)
-	if err != nil {
-		return nil, err
+	// Conventions — only the always-on, active set, restricted to the
+	// caller's visible conventions collection. trigger-specific
+	// conventions load on demand when their trigger fires.
+	conventionsCollVisible := visibleIDs == nil || isCollectionSlugVisible(out.Collections, "conventions")
+	if conventionsCollVisible {
+		convs, cerr := s.collectAlwaysOnConventions(workspaceID)
+		if cerr != nil {
+			return nil, cerr
+		}
+		out.Conventions = convs
+	} else {
+		out.Conventions = []AgentBootstrapConvention{}
 	}
-	out.Conventions = convs
 
-	// Agent roles — workspace-scoped role definitions so the agent can
-	// pick the right role for a given task without an extra lookup.
+	// Agent roles — workspace-scoped, not collection-bound. Visible to
+	// any principal admitted into the workspace.
 	roles, err := s.store.ListAgentRoles(workspaceID)
 	if err != nil {
 		return nil, err
@@ -152,15 +192,20 @@ func (s *Server) BuildAgentBootstrap(workspaceID string, user *models.User, r *h
 	}
 	out.Roles = roles
 
-	// Playbooks (metadata only) — the agent uses this list to (a) route
-	// /pad <slug> invocations and (b) recognize trigger-based auto-load
-	// candidates by intent (e.g. "let's cut a release" → match a playbook
-	// whose trigger is on-release).
-	playbooks, err := s.collectPlaybookMetadata(workspaceID)
-	if err != nil {
-		return nil, err
+	// Playbooks (metadata only) — restricted to callers who can see the
+	// playbooks collection. Like conventions, this is a collection-level
+	// gate: if the caller can't see the playbooks collection at all,
+	// they get an empty list.
+	playbooksCollVisible := visibleIDs == nil || isCollectionSlugVisible(out.Collections, "playbooks")
+	if playbooksCollVisible {
+		playbooks, perr := s.collectPlaybookMetadata(workspaceID)
+		if perr != nil {
+			return nil, perr
+		}
+		out.Playbooks = playbooks
+	} else {
+		out.Playbooks = []AgentBootstrapPlaybookMeta{}
 	}
-	out.Playbooks = playbooks
 
 	// Dashboard — recreate via the existing handler logic if a request
 	// context is available. The shape is identical to `GET /dashboard`

--- a/internal/server/handlers_bootstrap.go
+++ b/internal/server/handlers_bootstrap.go
@@ -1,0 +1,402 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"sort"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// AgentBootstrap is the single response struct returned by the bootstrap
+// endpoint. It consolidates the four /pad context-loading calls (workspace,
+// collections, conventions, roles + playbooks) the agent skill used to make
+// at every invocation into one round-trip — roughly 200-400ms saved on every
+// /pad command.
+//
+// PLAN-1377 TASK-1379. Same struct is exposed via three MCP surfaces in
+// TASK-1380: a `pad://workspace/{ws}/bootstrap` resource, an embedded blob
+// in `pad_set_workspace`'s response, and an on-demand `pad_meta.action=bootstrap`
+// refresh.
+type AgentBootstrap struct {
+	Workspace      AgentBootstrapWorkspace      `json:"workspace"`
+	User           AgentBootstrapUser           `json:"user"`
+	Collections    []models.Collection          `json:"collections"`
+	Conventions    []AgentBootstrapConvention   `json:"conventions"`
+	Roles          []models.AgentRole           `json:"roles"`
+	Playbooks      []AgentBootstrapPlaybookMeta `json:"playbooks"`
+	Dashboard      *DashboardResponse           `json:"dashboard,omitempty"`
+	RecentActivity []DashboardActivity          `json:"recent_activity"`
+}
+
+// AgentBootstrapWorkspace is the minimal workspace projection (slug + name
+// + id) the agent needs to address the workspace in subsequent calls.
+type AgentBootstrapWorkspace struct {
+	ID   string `json:"id"`
+	Slug string `json:"slug"`
+	Name string `json:"name"`
+}
+
+// AgentBootstrapUser is the calling user's projection. Email is included
+// so agents can sign generated commits or reference the human; ID is
+// included so MCP servers can scope per-user data without an extra lookup.
+type AgentBootstrapUser struct {
+	ID    string `json:"id"`
+	Name  string `json:"name"`
+	Email string `json:"email"`
+}
+
+// AgentBootstrapConvention is a convention item with its body content so
+// agents can read and follow it without a second round-trip. Only
+// always-on, active conventions are returned — the curated must-follow
+// set. trigger-specific conventions load on demand when their trigger
+// fires.
+type AgentBootstrapConvention struct {
+	Ref      string `json:"ref"`
+	Title    string `json:"title"`
+	Slug     string `json:"slug"`
+	Content  string `json:"content"`
+	Priority string `json:"priority,omitempty"`
+	Scope    string `json:"scope,omitempty"`
+	Trigger  string `json:"trigger,omitempty"`
+}
+
+// AgentBootstrapPlaybookMeta is the lightweight playbook projection
+// returned at bootstrap. Bodies (which can be 5-10KB each) are
+// deliberately excluded; the agent loads a body on demand via
+// `pad playbook show <slug>` only when a playbook is actually invoked.
+// Keeping this metadata-only keeps the bootstrap payload small (~80
+// bytes per entry) so a workspace with dozens of playbooks doesn't blow
+// out the agent's context budget on a /pad greeting.
+type AgentBootstrapPlaybookMeta struct {
+	Ref            string `json:"ref"`
+	Title          string `json:"title"`
+	Slug           string `json:"slug"`
+	InvocationSlug string `json:"invocation_slug,omitempty"`
+	Trigger        string `json:"trigger,omitempty"`
+	Scope          string `json:"scope,omitempty"`
+	Status         string `json:"status,omitempty"`
+	// HasArguments is true when the playbook declares an arguments spec
+	// in its fields. The full spec is delivered on demand at invocation.
+	HasArguments bool `json:"has_arguments"`
+	// Summary is a short prose hint about what the playbook does, taken
+	// from the first non-heading non-empty paragraph of the body. Capped
+	// at ~240 chars so the bootstrap stays small.
+	Summary string `json:"summary,omitempty"`
+}
+
+// recentActivityWindow caps how far back the bootstrap reaches for the
+// recent_activity tail. Bootstrap is a context-load call — anything older
+// than this isn't relevant to "what's happening now."
+const recentActivityWindow = 24 * time.Hour
+
+// BuildAgentBootstrap assembles the bootstrap blob from store queries.
+// This is the single canonical code path; the HTTP handler, the MCP
+// resource handler, and the MCP `pad_set_workspace` embed all call this.
+//
+// r is used for the dashboard sub-build (which depends on guest grant
+// filtering); pass the live request. Pass nil to skip dashboard inclusion
+// — useful for callers that don't have a request context (e.g. the MCP
+// in-process dispatcher could synthesize one but doesn't yet).
+func (s *Server) BuildAgentBootstrap(workspaceID string, user *models.User, r *http.Request) (*AgentBootstrap, error) {
+	ws, err := s.store.GetWorkspaceByID(workspaceID)
+	if err != nil {
+		return nil, err
+	}
+
+	out := &AgentBootstrap{
+		Workspace: AgentBootstrapWorkspace{
+			ID:   ws.ID,
+			Slug: ws.Slug,
+			Name: ws.Name,
+		},
+	}
+	if user != nil {
+		out.User = AgentBootstrapUser{
+			ID:    user.ID,
+			Name:  user.Name,
+			Email: user.Email,
+		}
+	}
+
+	// Collections — keep the same shape ListCollections returns. The agent
+	// uses these to know what's available in the workspace and dispatch
+	// pad item commands by collection slug.
+	collections, err := s.store.ListCollections(workspaceID)
+	if err != nil {
+		return nil, err
+	}
+	out.Collections = collections
+
+	// Conventions — only the always-on, active set. trigger-specific
+	// conventions load on demand when their trigger fires (e.g. an
+	// `on-implement` convention is read just-in-time before code-edit
+	// work). Including only the must-follow always-on set keeps the
+	// bootstrap small without losing the rules the agent MUST know up
+	// front.
+	convs, err := s.collectAlwaysOnConventions(workspaceID)
+	if err != nil {
+		return nil, err
+	}
+	out.Conventions = convs
+
+	// Agent roles — workspace-scoped role definitions so the agent can
+	// pick the right role for a given task without an extra lookup.
+	roles, err := s.store.ListAgentRoles(workspaceID)
+	if err != nil {
+		return nil, err
+	}
+	if roles == nil {
+		roles = []models.AgentRole{}
+	}
+	out.Roles = roles
+
+	// Playbooks (metadata only) — the agent uses this list to (a) route
+	// /pad <slug> invocations and (b) recognize trigger-based auto-load
+	// candidates by intent (e.g. "let's cut a release" → match a playbook
+	// whose trigger is on-release).
+	playbooks, err := s.collectPlaybookMetadata(workspaceID)
+	if err != nil {
+		return nil, err
+	}
+	out.Playbooks = playbooks
+
+	// Dashboard — recreate via the existing handler logic if a request
+	// context is available. The shape is identical to `GET /dashboard`
+	// so the web UI dashboard page can consume bootstrap directly and
+	// retire its dedicated fetch.
+	if r != nil {
+		dash, derr := s.buildDashboardResponse(workspaceID, r)
+		if derr == nil {
+			out.Dashboard = dash
+			if dash != nil {
+				out.RecentActivity = capRecentActivity(dash.RecentActivity, recentActivityWindow)
+			}
+		}
+	}
+	if out.RecentActivity == nil {
+		out.RecentActivity = []DashboardActivity{}
+	}
+
+	return out, nil
+}
+
+// collectAlwaysOnConventions returns the active, always-on conventions for
+// a workspace, projected into the bootstrap-friendly shape. Sorted by
+// priority (must > should > nice-to-have) then by ref for stable order.
+func (s *Server) collectAlwaysOnConventions(workspaceID string) ([]AgentBootstrapConvention, error) {
+	items, err := s.store.ListItems(workspaceID, models.ItemListParams{
+		CollectionSlug: "conventions",
+		Fields: map[string]string{
+			"status":  "active",
+			"trigger": "always",
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]AgentBootstrapConvention, 0, len(items))
+	for _, it := range items {
+		fields := map[string]any{}
+		_ = json.Unmarshal([]byte(it.Fields), &fields)
+		strField := func(k string) string {
+			if v, ok := fields[k].(string); ok {
+				return v
+			}
+			return ""
+		}
+		out = append(out, AgentBootstrapConvention{
+			Ref:      it.Ref,
+			Title:    it.Title,
+			Slug:     it.Slug,
+			Content:  it.Content,
+			Priority: strField("priority"),
+			Scope:    strField("scope"),
+			Trigger:  strField("trigger"),
+		})
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		pi := conventionPriorityRank(out[i].Priority)
+		pj := conventionPriorityRank(out[j].Priority)
+		if pi != pj {
+			return pi < pj
+		}
+		return out[i].Ref < out[j].Ref
+	})
+	return out, nil
+}
+
+// conventionPriorityRank ranks convention priority strings
+// (must > should > nice-to-have). Lower rank = higher priority. Unknown
+// values rank last so untyped data doesn't dominate the head of the list.
+// Distinct from the task `priorityRank` in handlers_dashboard.go because
+// conventions and tasks have disjoint priority vocabularies.
+func conventionPriorityRank(p string) int {
+	switch p {
+	case "must":
+		return 0
+	case "should":
+		return 1
+	case "nice-to-have":
+		return 2
+	default:
+		return 3
+	}
+}
+
+// collectPlaybookMetadata returns every playbook in the workspace projected
+// down to the metadata shape. Bodies are NOT included.
+func (s *Server) collectPlaybookMetadata(workspaceID string) ([]AgentBootstrapPlaybookMeta, error) {
+	items, err := s.store.ListItems(workspaceID, models.ItemListParams{
+		CollectionSlug: "playbooks",
+	})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]AgentBootstrapPlaybookMeta, 0, len(items))
+	for _, it := range items {
+		fields := map[string]any{}
+		_ = json.Unmarshal([]byte(it.Fields), &fields)
+		strField := func(k string) string {
+			if v, ok := fields[k].(string); ok {
+				return v
+			}
+			return ""
+		}
+		args, hasArgs := fields["arguments"]
+		// Treat empty arrays / objects as "no arguments declared". A
+		// playbook with an empty arguments array is functionally
+		// identical to one that omits the field entirely.
+		if hasArgs {
+			switch v := args.(type) {
+			case []any:
+				hasArgs = len(v) > 0
+			case map[string]any:
+				hasArgs = len(v) > 0
+			case nil:
+				hasArgs = false
+			}
+		}
+		out = append(out, AgentBootstrapPlaybookMeta{
+			Ref:            it.Ref,
+			Title:          it.Title,
+			Slug:           it.Slug,
+			InvocationSlug: strField("invocation_slug"),
+			Trigger:        strField("trigger"),
+			Scope:          strField("scope"),
+			Status:         strField("status"),
+			HasArguments:   hasArgs,
+			Summary:        playbookSummary(it.Content),
+		})
+	}
+	// Stable order: invocation_slug-bearing first (the user-facing,
+	// directly-callable set), then alphabetic by title within each group.
+	sort.SliceStable(out, func(i, j int) bool {
+		ai := out[i].InvocationSlug != ""
+		aj := out[j].InvocationSlug != ""
+		if ai != aj {
+			return ai
+		}
+		return out[i].Title < out[j].Title
+	})
+	return out, nil
+}
+
+// playbookSummary extracts a short prose hint from a playbook body. Picks
+// the first non-heading non-empty paragraph and caps at ~240 chars so the
+// bootstrap stays compact.
+func playbookSummary(body string) string {
+	const maxLen = 240
+	const ellipsis = "…"
+	for _, line := range splitLines(body) {
+		trimmed := trimLeadingSpaces(line)
+		if trimmed == "" {
+			continue
+		}
+		// Skip markdown headings — they're labels, not summaries.
+		if len(trimmed) > 0 && trimmed[0] == '#' {
+			continue
+		}
+		if len(trimmed) > maxLen {
+			return trimmed[:maxLen-len(ellipsis)] + ellipsis
+		}
+		return trimmed
+	}
+	return ""
+}
+
+// splitLines is a small dependency-free helper. We avoid bufio.Scanner
+// here because the typical body is small (under 50KB) and allocating a
+// scanner per playbook is wasteful at this scale.
+func splitLines(s string) []string {
+	out := []string{}
+	start := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\n' {
+			out = append(out, s[start:i])
+			start = i + 1
+		}
+	}
+	if start < len(s) {
+		out = append(out, s[start:])
+	}
+	return out
+}
+
+func trimLeadingSpaces(s string) string {
+	i := 0
+	for i < len(s) && (s[i] == ' ' || s[i] == '\t') {
+		i++
+	}
+	return s[i:]
+}
+
+// capRecentActivity returns the activity events that fall within the
+// bootstrap's recency window. Dashboard's recent_activity may extend
+// further back; bootstrap deliberately trims to keep the payload tight.
+//
+// DashboardActivity.CreatedAt is a pre-formatted RFC3339-shaped string
+// (set in handleGetDashboard with `a.CreatedAt.Format("2006-01-02T15:04:05Z")`),
+// so we parse it back to time.Time for the comparison. Entries that fail
+// to parse are kept defensively — losing them silently because of a format
+// glitch would be a worse outcome than carrying a slightly older event.
+func capRecentActivity(in []DashboardActivity, window time.Duration) []DashboardActivity {
+	if len(in) == 0 {
+		return []DashboardActivity{}
+	}
+	cutoff := time.Now().Add(-window)
+	out := make([]DashboardActivity, 0, len(in))
+	for _, a := range in {
+		t, err := time.Parse("2006-01-02T15:04:05Z", a.CreatedAt)
+		if err != nil {
+			if t, err = time.Parse(time.RFC3339, a.CreatedAt); err != nil {
+				out = append(out, a)
+				continue
+			}
+		}
+		if t.Before(cutoff) {
+			continue
+		}
+		out = append(out, a)
+	}
+	return out
+}
+
+// handleGetBootstrap is the HTTP handler for `GET
+// /api/v1/workspaces/{ws}/agent/bootstrap`. It returns the consolidated
+// AgentBootstrap blob in one round-trip so the /pad skill can replace its
+// four context-loading CLI calls with one.
+func (s *Server) handleGetBootstrap(w http.ResponseWriter, r *http.Request) {
+	workspaceID, ok := s.getWorkspaceID(w, r)
+	if !ok {
+		return
+	}
+	user := currentUser(r)
+	bootstrap, err := s.BuildAgentBootstrap(workspaceID, user, r)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, bootstrap)
+}

--- a/internal/server/handlers_bootstrap.go
+++ b/internal/server/handlers_bootstrap.go
@@ -201,9 +201,8 @@ func (s *Server) BuildAgentBootstrap(workspaceID string, user *models.User, r *h
 	}
 
 	// Agent roles — workspace-scoped, not collection-bound. Item counts
-	// MUST be recomputed from the visible item set for restricted
-	// callers so a guest can't infer hidden activity by role. Mirrors
-	// handleListAgentRoles.
+	// MUST be recomputed below for restricted callers from the same
+	// visible item set used for collection counts.
 	roles, err := s.store.ListAgentRoles(workspaceID)
 	if err != nil {
 		return nil, err
@@ -211,6 +210,14 @@ func (s *Server) BuildAgentBootstrap(workspaceID string, user *models.User, r *h
 	if roles == nil {
 		roles = []models.AgentRole{}
 	}
+
+	// For restricted callers, compute the visible item set ONCE and use
+	// it to (a) recompute role counts and (b) recompute collection
+	// item_count, both of which are otherwise computed across the whole
+	// workspace by their respective ListX queries and would leak
+	// hidden activity to a guest. Full members (visibleIDs == nil)
+	// skip the recompute — the store-side counts are already correct
+	// for them.
 	if visibleIDs != nil {
 		visibleItems, vierr := s.store.ListItems(workspaceID, models.ItemListParams{
 			CollectionIDs: subCollIDs,
@@ -220,11 +227,27 @@ func (s *Server) BuildAgentBootstrap(workspaceID string, user *models.User, r *h
 			return nil, vierr
 		}
 		roleCounts := make(map[string]int)
+		collItemCounts := make(map[string]int)
 		for _, item := range visibleItems {
 			if item.AgentRoleID != nil && *item.AgentRoleID != "" {
 				roleCounts[*item.AgentRoleID]++
 			}
+			collItemCounts[item.CollectionID]++
 		}
+		// Rewrite collection counts from the visible set.
+		// active_item_count needs each collection's done-rules to be
+		// accurate; recomputing it correctly is expensive (see
+		// dashboard's buildDoneContextMap) and the bootstrap consumers
+		// don't depend on it. Set it equal to item_count so restricted
+		// callers see a self-consistent number rather than a leaked
+		// full-workspace value. Full members keep the store-side
+		// active_item_count untouched.
+		for i := range out.Collections {
+			c := &out.Collections[i]
+			c.ItemCount = collItemCounts[c.ID]
+			c.ActiveItemCount = collItemCounts[c.ID]
+		}
+		// Overlay role counts.
 		for i := range roles {
 			roles[i].ItemCount = roleCounts[roles[i].ID]
 		}

--- a/internal/server/handlers_bootstrap_test.go
+++ b/internal/server/handlers_bootstrap_test.go
@@ -1,0 +1,173 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+// TestBootstrapEmptyWorkspace verifies the bootstrap blob returns the
+// scaffolding for a workspace with no items beyond the template seeds.
+// The /pad skill relies on this single call replacing four separate
+// context-loading calls; any of the expected keys missing would silently
+// break greeting behavior.
+func TestBootstrapEmptyWorkspace(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	rr := doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/agent/bootstrap", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("bootstrap: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var b AgentBootstrap
+	parseJSON(t, rr, &b)
+
+	if b.Workspace.Slug != slug {
+		t.Errorf("workspace.slug = %q, want %q", b.Workspace.Slug, slug)
+	}
+	if b.Workspace.Name == "" {
+		t.Error("workspace.name empty")
+	}
+
+	if len(b.Collections) == 0 {
+		t.Error("collections empty — template seed must produce at least Tasks/Ideas/Plans/Docs/Conventions/Playbooks")
+	}
+
+	// Roles is non-nil by contract — agents iterate it without nil-checks.
+	if b.Roles == nil {
+		t.Error("roles is nil; should be an empty slice")
+	}
+
+	// RecentActivity is non-nil by contract.
+	if b.RecentActivity == nil {
+		t.Error("recent_activity is nil; should be an empty slice")
+	}
+}
+
+// TestBootstrapEmptyArraysNotNull verifies the JSON wire shape: arrays
+// must serialize as [] not null so the agent skill can iterate without
+// defensive nil checks.
+func TestBootstrapEmptyArraysNotNull(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	rr := doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/agent/bootstrap", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("bootstrap: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(rr.Body.Bytes(), &raw); err != nil {
+		t.Fatalf("decode raw: %v", err)
+	}
+
+	for _, key := range []string{"collections", "conventions", "roles", "playbooks", "recent_activity"} {
+		val, ok := raw[key]
+		if !ok {
+			t.Errorf("missing key %q in bootstrap response", key)
+			continue
+		}
+		s := string(val)
+		if s == "null" {
+			t.Errorf("bootstrap.%s serialized as null; want []", key)
+		}
+	}
+}
+
+// TestBootstrapIncludesPlaybookMetadata verifies that a seeded playbook
+// item flows into the bootstrap's playbooks array with the right
+// projection — slug, invocation_slug, has_arguments — without leaking
+// the body (which is intentionally omitted from bootstrap for size).
+func TestBootstrapIncludesPlaybookMetadata(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	// Create a playbook with an invocation_slug + arguments.
+	createItem(t, srv, slug, "playbooks", map[string]interface{}{
+		"title":   "Test playbook",
+		"content": "First paragraph — used as the summary.\n\nSecond paragraph (ignored).",
+		"fields":  `{"status":"active","trigger":"manual","invocation_slug":"test-bp","arguments":[{"name":"target","type":"ref","required":true}]}`,
+	})
+
+	rr := doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/agent/bootstrap", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("bootstrap: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var b AgentBootstrap
+	parseJSON(t, rr, &b)
+
+	var found *AgentBootstrapPlaybookMeta
+	for i := range b.Playbooks {
+		if b.Playbooks[i].InvocationSlug == "test-bp" {
+			found = &b.Playbooks[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("bootstrap.playbooks missing test-bp; got %+v", b.Playbooks)
+	}
+	if found.Title != "Test playbook" {
+		t.Errorf("playbook.title = %q, want %q", found.Title, "Test playbook")
+	}
+	if !found.HasArguments {
+		t.Error("playbook.has_arguments = false, want true (arguments list was non-empty)")
+	}
+	if found.Summary == "" {
+		t.Error("playbook.summary empty; expected the first body paragraph")
+	}
+}
+
+// TestPlaybookSummaryPrefersFirstParagraph isolates the summary extraction
+// from the bootstrap path so the rule (skip headings, take first non-empty
+// paragraph, cap at ~240 chars) doesn't drift silently.
+func TestPlaybookSummaryPrefersFirstParagraph(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			name: "skips-headings",
+			body: "# Title\n\n## Overview\n\nThis is the first prose line.",
+			want: "This is the first prose line.",
+		},
+		{
+			name: "trims-leading-whitespace",
+			body: "   Indented summary line.",
+			want: "Indented summary line.",
+		},
+		{
+			name: "empty-body",
+			body: "",
+			want: "",
+		},
+		{
+			name: "headings-only",
+			body: "# A\n## B\n### C",
+			want: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := playbookSummary(tc.body)
+			if got != tc.want {
+				t.Errorf("playbookSummary() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+
+	// Long bodies must be truncated. Verify capping puts an ellipsis on
+	// the end so callers can detect truncation visually.
+	long := ""
+	for i := 0; i < 100; i++ {
+		long += "abcdefghij"
+	}
+	got := playbookSummary(long)
+	if len(got) > 240 {
+		t.Errorf("long summary not capped at 240 chars; got %d", len(got))
+	}
+	if got[len(got)-len("…"):] != "…" {
+		t.Errorf("truncated summary missing ellipsis: %q", got)
+	}
+}

--- a/internal/server/handlers_dashboard.go
+++ b/internal/server/handlers_dashboard.go
@@ -276,19 +276,30 @@ func (s *Server) handleGetDashboard(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-
-	// Compute collection visibility once for the entire dashboard
-	visibleIDs, err := s.visibleCollectionIDs(r, workspaceID)
+	resp, err := s.buildDashboardResponse(workspaceID, r)
 	if err != nil {
 		writeInternalError(w, err)
 		return
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// buildDashboardResponse is the canonical dashboard-assembly path. The
+// HTTP handler (handleGetDashboard) is now a thin wrapper around it, and
+// the bootstrap endpoint (TASK-1379) calls it directly so the bootstrap
+// blob carries the same dashboard data the dedicated endpoint returns —
+// without forcing a second HTTP round-trip.
+func (s *Server) buildDashboardResponse(workspaceID string, r *http.Request) (*DashboardResponse, error) {
+	// Compute collection visibility once for the entire dashboard
+	visibleIDs, err := s.visibleCollectionIDs(r, workspaceID)
+	if err != nil {
+		return nil, err
 	}
 
 	// For guests, compute item-level grant filtering
 	dashFullCollIDs, dashGrantedItemIDs, dashGrantErr := s.guestResourceFilter(r, workspaceID)
 	if dashGrantErr != nil {
-		writeInternalError(w, dashGrantErr)
-		return
+		return nil, dashGrantErr
 	}
 	dashGrantedItemSet := make(map[string]bool, len(dashGrantedItemIDs))
 	for _, id := range dashGrantedItemIDs {
@@ -310,8 +321,7 @@ func (s *Server) handleGetDashboard(w http.ResponseWriter, r *http.Request) {
 	// Build a schema map for terminal status lookups
 	collections, err := s.store.ListCollections(workspaceID)
 	if err != nil {
-		writeInternalError(w, err)
-		return
+		return nil, err
 	}
 	// Build the done-context map from ALL workspace collections before
 	// visibility filtering. The dashboard may surface item-level grants
@@ -352,16 +362,14 @@ func (s *Server) handleGetDashboard(w http.ResponseWriter, r *http.Request) {
 	// access to. See WorkspaceHasAgentActivity for the rationale.
 	hasAgent, err := s.store.WorkspaceHasAgentActivity(workspaceID, dashCollIDs, dashItemIDs)
 	if err != nil {
-		writeInternalError(w, err)
-		return
+		return nil, err
 	}
 	resp.HasAgentActivity = hasAgent
 
 	// Summary: items grouped by collection slug and status field
 	allItems, err := s.store.ListItems(workspaceID, models.ItemListParams{CollectionIDs: dashCollIDs, ItemIDs: dashItemIDs})
 	if err != nil {
-		writeInternalError(w, err)
-		return
+		return nil, err
 	}
 
 	resp.Summary.TotalItems = len(allItems)
@@ -956,7 +964,7 @@ func (s *Server) handleGetDashboard(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	writeJSON(w, http.StatusOK, resp)
+	return &resp, nil
 }
 
 // extractFieldValue extracts a string value from a JSON fields string.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1172,6 +1172,15 @@ func (s *Server) setupRouter() {
 					// Dashboard (v2)
 					r.Get("/dashboard", s.handleGetDashboard)
 
+					// Agent bootstrap (PLAN-1377 / TASK-1379) — single
+					// round-trip that returns workspace + user +
+					// collections + always-on conventions + roles +
+					// playbook metadata + dashboard + recent activity.
+					// Replaces the four /pad context-loading calls the
+					// skill used to make. Same shape via the MCP
+					// surfaces in TASK-1380.
+					r.Get("/agent/bootstrap", s.handleGetBootstrap)
+
 					// Incremental sync — returns items changed since a timestamp
 					r.Get("/changes", s.handleGetChanges)
 				})


### PR DESCRIPTION
## Summary
Implements the agent bootstrap surface for **PLAN-1377**. One HTTP call replaces the four separate context-loading invocations (`workspace` + `collections` + `conventions` + `roles + playbooks`) the `/pad` skill used to make, cutting ~200-400ms of startup latency on every `/pad` command.

**Wire shape:**
- `GET /api/v1/workspaces/{ws}/agent/bootstrap` returns `AgentBootstrap`:
  - `workspace { slug, name, id }`
  - `user { name, email, id }`
  - `collections [...]`
  - `conventions [...always-on, status=active]` (full bodies — must-follow rules)
  - `roles [...]`
  - `playbooks [metadata-only — slug, invocation_slug, trigger, summary, has_arguments]`
  - `dashboard {...}` (active items, attention, suggested next)
  - `recent_activity [... last 24h]`
- `pad bootstrap [--format json|markdown]` CLI wrapper.

**Implementation notes:**
- Single source of truth: `Server.BuildAgentBootstrap`. The HTTP handler is a thin wrapper; TASK-1380 will reuse it from three MCP surfaces.
- Dashboard reuse: `handleGetDashboard` refactored to call a new `buildDashboardResponse(workspaceID, r) (*DashboardResponse, error)`. Bootstrap calls the builder directly.
- Playbook bodies are deliberately **not** included — metadata only (~80 bytes/entry vs 5-10KB). Full bodies load on invocation.
- Convention bodies **are** included for the always-on/active subset; trigger-specific conventions stay load-on-demand.
- Empty slices serialize as `[]` not `null`.

## Context
Implements `TASK-1379` under `PLAN-1377` (Make Playbooks first-class invokable procedures). T3-T10 depend on this.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` — all packages pass, including 4 new bootstrap tests
- [x] `make check` (lint + test + web build) — green
- [x] Manual: `pad bootstrap --format markdown` returns a readable summary
- [x] Manual: `pad bootstrap --format json` returns the wire blob with non-null empty arrays