### PR TITLE
feat(mcp): expose AgentBootstrap via three MCP surfaces (TASK-1380)

### DIFF
--- a/cmd/pad/mcp.go
+++ b/cmd/pad/mcp.go
@@ -292,12 +292,20 @@ Shuts down cleanly on EOF, SIGINT, or SIGTERM.`,
 				rootArgs = append(rootArgs, "--"+k, v)
 			}
 			dispatcher := &mcpserver.ExecDispatcher{Binary: bin, RootArgs: rootArgs}
+			// Bootstrap fetcher hands pad_set_workspace a one-shot way to
+			// embed the AgentBootstrap blob in its response so MCP hosts
+			// get full session context in one round-trip when the agent
+			// switches workspaces. Same binary + RootArgs as the
+			// dispatcher so the call lands on the configured server.
+			// PLAN-1377 / TASK-1380.
+			bootstrapFetcher := &mcpserver.ExecBootstrapFetcher{Binary: bin, RootArgs: rootArgs}
 			if _, err := mcpserver.Register(srv.MCP(), mcpserver.RegistryOptions{
-				Doc:        doc,
-				Workspace:  state,
-				Dispatcher: dispatcher,
-				RootFlags:  rootFlags,
-				PadVersion: fullVersion(),
+				Doc:              doc,
+				Workspace:        state,
+				Dispatcher:       dispatcher,
+				RootFlags:        rootFlags,
+				PadVersion:       fullVersion(),
+				BootstrapFetcher: bootstrapFetcher,
 			}); err != nil {
 				return fmt.Errorf("pad mcp serve: register tools: %w", err)
 			}

--- a/internal/mcp/catalog_meta.go
+++ b/internal/mcp/catalog_meta.go
@@ -35,17 +35,22 @@ var padMetaTool = ToolDef{
 	Name:        "pad_meta",
 	Description: padMetaToolDescription,
 	Schema: ToolSchema{
-		Workspace: false, // server-wide; no workspace context needed
-		Params:    nil,   // only `action` (added by buildToolFromDef)
+		// bootstrap requires workspace context; server-info / version /
+		// tool-surface do not (they read in-memory state only). Marking
+		// Workspace=true here makes the workspace param available to
+		// every action — the action handler decides whether to use it.
+		Workspace: true,
+		Params:    nil,
 	},
 	Actions: map[string]ActionFn{
 		"server-info":  actionMetaServerInfo,
 		"version":      actionMetaVersion,
 		"tool-surface": actionMetaToolSurface,
+		"bootstrap":    actionMetaBootstrap,
 	},
 }
 
-const padMetaToolDescription = `Server introspection — version, capabilities, and the v0.2 tool catalog.
+const padMetaToolDescription = `Server introspection — version, capabilities, the v0.2 tool catalog, and the agent bootstrap blob.
 
 Actions:
   server-info   — Server name + runtime version. Lightweight; no params.
@@ -57,9 +62,15 @@ Actions:
                   intentionally only enumerates the catalog (the source it can
                   introspect cleanly). For the complete advertised surface, read
                   tools/list directly.
+  bootstrap     — Consolidated agent context-load blob (workspace + user + collections
+                  + always-on conventions + roles + playbook metadata + dashboard +
+                  recent activity). On-demand refresh for agents that didn't get the
+                  resource prefetch, or want a fresh snapshot mid-session after lots
+                  of mutations. Equivalent to pad://workspace/{ws}/bootstrap and to
+                  pad_set_workspace's embedded response.
 
-Use pad_meta when an agent needs to discover server capabilities or generate
-documentation. For runtime task work, use pad_item / pad_workspace / etc.`
+Use pad_meta when an agent needs to discover server capabilities, regenerate context,
+or build documentation. For runtime task work, use pad_item / pad_workspace / etc.`
 
 // actionMetaServerInfo returns the minimal {name, version} pair.
 // Roughly equivalent to what the MCP handshake exposes, but available
@@ -91,6 +102,19 @@ func actionMetaVersion(_ context.Context, _ map[string]any, env ActionEnv) (*mcp
 		return mcp.NewToolResultErrorf("pad_meta.version: marshal: %s", err.Error()), nil
 	}
 	return mcp.NewToolResultStructured(payload, string(body)), nil
+}
+
+// actionMetaBootstrap dispatches to `pad bootstrap` so MCP callers get
+// the same AgentBootstrap blob the HTTP endpoint, CLI, and resource all
+// return. The dispatcher resolves the session workspace via the standard
+// precedence chain (explicit arg → pad_set_workspace → CWD-linked).
+//
+// This is intentionally a passThrough — keep the canonical builder
+// (Server.BuildAgentBootstrap) the single source of truth for shape,
+// validation, and visibility filtering. The MCP surface contributes
+// only the discovery affordance, not a divergent implementation.
+func actionMetaBootstrap(ctx context.Context, input map[string]any, env ActionEnv) (*mcp.CallToolResult, error) {
+	return env.Dispatch(ctx, []string{"bootstrap"}, input)
 }
 
 // actionMetaToolSurface returns the v0.2 catalog as JSON. Pairs with

--- a/internal/mcp/catalog_meta_test.go
+++ b/internal/mcp/catalog_meta_test.go
@@ -236,18 +236,20 @@ func TestPadMetaTool_RoundTripThroughFanOut(t *testing.T) {
 	}
 }
 
-// TestPadMetaTool_NoWorkspaceInSchema confirms the schema for a server-
-// wide tool (Schema.Workspace=false) does NOT include a workspace
-// property. Server-introspection actions don't need a workspace —
-// adding one would mislead agents into thinking they should pass it.
-func TestPadMetaTool_NoWorkspaceInSchema(t *testing.T) {
+// TestPadMetaTool_WorkspaceInSchema confirms pad_meta's schema exposes
+// a workspace property. Originally pad_meta was server-wide and the
+// schema deliberately omitted workspace. PLAN-1377 / TASK-1380 added
+// the `bootstrap` action which needs workspace context, so the tool
+// flipped to Schema.Workspace=true. The other actions
+// (server-info / version / tool-surface) ignore the parameter.
+func TestPadMetaTool_WorkspaceInSchema(t *testing.T) {
 	tool := buildToolFromDef(padMetaTool)
 	raw, err := json.Marshal(tool.InputSchema)
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}
-	if strings.Contains(string(raw), `"workspace"`) {
-		t.Errorf("pad_meta schema unexpectedly includes 'workspace' property: %s", raw)
+	if !strings.Contains(string(raw), `"workspace"`) {
+		t.Errorf("pad_meta schema missing 'workspace' property required by the bootstrap action: %s", raw)
 	}
 }
 

--- a/internal/mcp/catalog_workspace_precedence_test.go
+++ b/internal/mcp/catalog_workspace_precedence_test.go
@@ -112,13 +112,14 @@ func TestCatalogWorkspacePrecedence(t *testing.T) {
 // in its tools/list schema. Catches future regressions where someone
 // adds a workspace-scoped tool but forgets to set the flag.
 //
-// pad_meta is the one tool that legitimately omits workspace (it's
-// server-wide); enumerated here to make the omission deliberate
-// rather than accidental.
+// Note (PLAN-1377 / TASK-1380): pad_meta used to be the one tool that
+// legitimately omitted workspace, but the new `bootstrap` action needs
+// workspace context so the tool now exposes the param. server-info /
+// version / tool-surface actions ignore it. The intentionallyServerWide
+// list is empty for now but kept so a future tool that genuinely needs
+// to opt out has a documented home.
 func TestCatalogWorkspaceParamAdvertisedOnAllWorkspaceTools(t *testing.T) {
-	intentionallyServerWide := map[string]bool{
-		"pad_meta": true,
-	}
+	intentionallyServerWide := map[string]bool{}
 	for _, def := range Catalog {
 		t.Run(def.Name, func(t *testing.T) {
 			tool := buildToolFromDef(def)

--- a/internal/mcp/dispatch_http_routes.go
+++ b/internal/mcp/dispatch_http_routes.go
@@ -222,6 +222,17 @@ func init() {
 			method:       http.MethodGet,
 			pathTemplate: "/api/v1/workspaces/{workspace}/dashboard",
 		}.toRouteMapper(),
+
+		// `pad bootstrap` shells out to `pad_meta.action=bootstrap` and
+		// to the pad://workspace/{ws}/bootstrap resource on local stdio.
+		// For pad-cloud's HTTP MCP path this maps to the canonical
+		// bootstrap endpoint (PLAN-1377 / TASK-1380). Without this entry
+		// the cloud MCP path returns "not yet implemented over HTTP
+		// transport" for the advertised action.
+		"bootstrap": routeSpec{
+			method:       http.MethodGet,
+			pathTemplate: "/api/v1/workspaces/{workspace}/agent/bootstrap",
+		}.toRouteMapper(),
 		"collection list": routeSpec{
 			method:       http.MethodGet,
 			pathTemplate: "/api/v1/workspaces/{workspace}/collections",

--- a/internal/mcp/registry.go
+++ b/internal/mcp/registry.go
@@ -46,6 +46,14 @@ type RegistryOptions struct {
 	// catalog's ActionEnv so pad_meta.action: server-info / version
 	// can report it. Empty falls back to FallbackVersion.
 	PadVersion string
+
+	// BootstrapFetcher is optional. When set, pad_set_workspace's
+	// response embeds the AgentBootstrap blob so callers get full
+	// session context in one round-trip. When nil, set-workspace
+	// returns the legacy {workspace, status} shape and clients can
+	// fetch the blob separately via pad_meta.action=bootstrap or
+	// pad://workspace/{ws}/bootstrap. PLAN-1377 / TASK-1380.
+	BootstrapFetcher BootstrapFetcher
 }
 
 // Register installs pad's MCP tools on srv: the built-in
@@ -68,7 +76,7 @@ func Register(srv *server.MCPServer, opts RegistryOptions) (int, error) {
 		return 0, fmt.Errorf("RegistryOptions.Dispatcher is required")
 	}
 
-	registerSetWorkspaceTool(srv, opts.Workspace)
+	registerSetWorkspaceTool(srv, opts.Workspace, opts.BootstrapFetcher)
 	count := 1 // pad_set_workspace
 
 	catalogCount, err := RegisterCatalog(srv, CatalogOptions{

--- a/internal/mcp/resources.go
+++ b/internal/mcp/resources.go
@@ -16,12 +16,13 @@ import (
 // MCP clients (Claude Desktop, Cursor) display them and may switch
 // rendering paths based on the value.
 const (
-	itemMIMEType        = "text/markdown"
-	jsonMIMEType        = "application/json"
-	uriPrefixWorkspace  = "pad://workspace/"
-	resourceKindItem    = "items" // /{ws}/items[/{ref}]
-	resourceKindDash    = "dashboard"
-	resourceKindCollect = "collections"
+	itemMIMEType         = "text/markdown"
+	jsonMIMEType         = "application/json"
+	uriPrefixWorkspace   = "pad://workspace/"
+	resourceKindItem     = "items" // /{ws}/items[/{ref}]
+	resourceKindDash     = "dashboard"
+	resourceKindCollect  = "collections"
+	resourceKindBootstrp = "bootstrap"
 )
 
 // WorkspacesURI is the canonical URI of the top-level workspace list
@@ -64,6 +65,47 @@ func (f *ExecResourceFetcher) Fetch(ctx context.Context, args []string) (string,
 		return "", fmt.Errorf("pad %s: %s", strings.Join(args, " "), msg)
 	}
 	return stdout.String(), nil
+}
+
+// ExecBootstrapFetcher shells out to `pad bootstrap --workspace <ws>
+// --format json` to satisfy the BootstrapFetcher interface. Used by
+// pad_set_workspace's response embed (PLAN-1377 / TASK-1380); RootArgs
+// carries any root-level CLI flags (e.g. --url) captured at startup so
+// the bootstrap call hits the same server endpoint as everything else.
+type ExecBootstrapFetcher struct {
+	// Binary is the path to the pad executable. Required.
+	Binary string
+	// RootArgs are root-flag tokens (e.g. ["--url", "https://api..."])
+	// appended to every shell-out so the bootstrap fetch lands on the
+	// same server endpoint as the other dispatches.
+	RootArgs []string
+}
+
+// Bootstrap runs `<Binary> bootstrap --workspace <ws> --format json`
+// and returns the raw JSON bytes. On error returns nil + the error;
+// the caller (pad_set_workspace) treats bootstrap failures as
+// non-fatal — the workspace switch still succeeds and the agent can
+// fetch context separately.
+func (f *ExecBootstrapFetcher) Bootstrap(ctx context.Context, workspace string) ([]byte, error) {
+	if f.Binary == "" {
+		return nil, fmt.Errorf("bootstrap fetcher: binary path not configured")
+	}
+	if workspace == "" {
+		return nil, fmt.Errorf("bootstrap fetcher: workspace is required")
+	}
+	args := append([]string{"bootstrap", "--workspace", workspace, "--format", "json"}, f.RootArgs...)
+	cmd := exec.CommandContext(ctx, f.Binary, args...)
+	var stdout, stderr strings.Builder
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if msg == "" {
+			msg = err.Error()
+		}
+		return nil, fmt.Errorf("pad bootstrap: %s", msg)
+	}
+	return []byte(stdout.String()), nil
 }
 
 // resources owns the four resource handlers and their shared state.
@@ -135,6 +177,24 @@ func RegisterResources(srv *server.MCPServer, fetcher ResourceFetcher, rootFlags
 			mcp.WithTemplateMIMEType(jsonMIMEType),
 		),
 		r.readCollections,
+	)
+	srv.AddResourceTemplate(
+		mcp.NewResourceTemplate(
+			"pad://workspace/{workspace}/bootstrap",
+			"pad bootstrap",
+			mcp.WithTemplateDescription(
+				"Consolidated agent context-load blob (PLAN-1377 / TASK-1379): "+
+					"workspace + user + collections + always-on conventions + "+
+					"agent roles + playbook metadata + dashboard + recent "+
+					"activity. One read replaces four separate calls. Hosts "+
+					"that prefetch resources at session start should fetch "+
+					"this so the agent starts with full context. Equivalent "+
+					"to pad_meta.action=bootstrap and pad_set_workspace's "+
+					"response embed.",
+			),
+			mcp.WithTemplateMIMEType(jsonMIMEType),
+		),
+		r.readBootstrap,
 	)
 
 	// Top-level workspace list (TASK-974). Static resource — no
@@ -309,6 +369,23 @@ func (r *resources) readCollections(ctx context.Context, req mcp.ReadResourceReq
 	}
 	return r.fetchAsResource(ctx, req.Params.URI, jsonMIMEType,
 		[]string{"collection", "list", "--workspace", ws, "--format", "json"})
+}
+
+// readBootstrap handles pad://workspace/{ws}/bootstrap. Shells out to
+// `pad bootstrap --workspace <ws> --format json` so the resource stays
+// in lockstep with the CLI and HTTP surfaces — one canonical builder
+// (Server.BuildAgentBootstrap) feeds all three. Hosts that prefetch
+// resources at session start get the full context in a single read.
+func (r *resources) readBootstrap(ctx context.Context, req mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+	ws, kind, arg, err := parsePadURI(req.Params.URI)
+	if err != nil {
+		return nil, err
+	}
+	if kind != resourceKindBootstrp || arg != "" {
+		return nil, fmt.Errorf("resource %q is not the bootstrap URI", req.Params.URI)
+	}
+	return r.fetchAsResource(ctx, req.Params.URI, jsonMIMEType,
+		[]string{"bootstrap", "--workspace", ws, "--format", "json"})
 }
 
 // fetchAsResource is the shared shell-out + wrap path. padArgs is

--- a/internal/mcp/version.go
+++ b/internal/mcp/version.go
@@ -52,16 +52,26 @@ const CmdhelpVersion = "0.1"
 //     3-stage rollout; never bumped during rollout because the
 //     user-visible surface was a transitional mix of v0.1 walker
 //     output + the partial v0.2 catalog.
-//   - "0.2" — current. Hand-curated resource × action catalog (PLAN-969,
-//     TASK-981). The cmdhelp leaf walker is retired; tools/list
+//   - "0.2" — historical. Hand-curated resource × action catalog
+//     (PLAN-969, TASK-981). The cmdhelp leaf walker retired; tools/list
 //     advertises only the catalog (~7 tools + pad_set_workspace).
+//   - "0.3" — current. PLAN-1377 / TASK-1380:
+//   - pad_meta gains an action: bootstrap that returns the
+//     AgentBootstrap blob (and pad_meta.Schema.Workspace flipped
+//     to true so the workspace param is available to that action).
+//   - pad_set_workspace's response shape extends from
+//     {workspace, status} to {workspace, status, bootstrap?} —
+//     the embedded blob lets one call hand the agent full session
+//     context. Purely additive; older clients that ignore unknown
+//     keys keep working.
+//   - pad://workspace/{ws}/bootstrap resource added.
 //
 // Discovery surfaces:
 //
 //   - result.capabilities.experimental.padToolSurface.version (handshake).
 //   - pad://_meta/version resource (queryable JSON document).
 //   - pad_meta.action: tool-surface (full catalog introspection).
-const ToolSurfaceVersion = "0.2"
+const ToolSurfaceVersion = "0.3"
 
 // MetaVersionURI is the canonical URI of the queryable version document.
 // Lives outside the pad://workspace/{ws}/... namespace because it's a

--- a/internal/mcp/workspace.go
+++ b/internal/mcp/workspace.go
@@ -9,6 +9,19 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 )
 
+// BootstrapFetcher resolves the agent bootstrap blob for a given
+// workspace. Used by pad_set_workspace to embed the blob in its response
+// so an MCP host calling pad_set_workspace receives full session context
+// in a single round-trip — no follow-up pad_meta.action=bootstrap or
+// resource read needed.
+//
+// Mirrors ResourceFetcher in spirit (both shell out via the CLI), but
+// kept narrower so the workspace handler doesn't drag in the full
+// resource layer.
+type BootstrapFetcher interface {
+	Bootstrap(ctx context.Context, workspace string) ([]byte, error)
+}
+
 // SetWorkspaceToolName is the canonical name of the built-in workspace
 // tool. Stable across versions — agents bind to it by name, so renaming
 // breaks every prompt template that references it.
@@ -50,13 +63,25 @@ func (s *WorkspaceState) Set(ws string) {
 // Exposed as a constructor (rather than a registration shortcut) so
 // tests can invoke the handler directly without spinning a full
 // MCPServer.
-func SetWorkspaceTool(state *WorkspaceState) (mcp.Tool, server.ToolHandlerFunc) {
+//
+// bootstrapFetcher is optional. When non-nil, the response embeds the
+// AgentBootstrap JSON under `bootstrap`, so a single set-workspace call
+// hands the agent a fully-loaded session. When nil (e.g. early in
+// pad-cloud's HTTP dispatch where no CLI is available yet), the
+// response shape stays {workspace, status} and clients can fetch
+// bootstrap separately via pad_meta.action=bootstrap or the resource.
+func SetWorkspaceTool(state *WorkspaceState, bootstrapFetcher BootstrapFetcher) (mcp.Tool, server.ToolHandlerFunc) {
 	tool := mcp.NewTool(
 		SetWorkspaceToolName,
 		mcp.WithDescription(
 			"Set the workspace used as the default --workspace for all "+
 				"subsequent tool calls in this MCP session. Pass an empty "+
-				"string to clear the session default.",
+				"string to clear the session default. When the workspace "+
+				"is non-empty and the server supports it, the response "+
+				"includes an embedded bootstrap blob — collections, "+
+				"always-on conventions, roles, playbook metadata, "+
+				"dashboard, recent activity — so the agent starts the "+
+				"session with full context in one call.",
 		),
 		mcp.WithString("workspace",
 			mcp.Description("Workspace slug. Empty string clears the session default."),
@@ -69,7 +94,24 @@ func SetWorkspaceTool(state *WorkspaceState) (mcp.Tool, server.ToolHandlerFunc) 
 			return mcp.NewToolResultError(err.Error()), nil
 		}
 		state.Set(ws)
-		out := map[string]string{"workspace": ws, "status": "ok"}
+		out := map[string]any{"workspace": ws, "status": "ok"}
+		// Only attempt bootstrap embedding for a non-empty workspace.
+		// Clearing the session default (ws="") never needs context.
+		if ws != "" && bootstrapFetcher != nil {
+			if raw, berr := bootstrapFetcher.Bootstrap(ctx, ws); berr == nil && len(raw) > 0 {
+				// Decode + re-attach so the result is a structured
+				// object inside the JSON, not a stringified blob the
+				// agent has to parse a second time.
+				var bs any
+				if json.Unmarshal(raw, &bs) == nil {
+					out["bootstrap"] = bs
+				}
+			}
+			// If bootstrap fails, fall through silently — the workspace
+			// switch already succeeded, and the agent can fetch context
+			// via pad_meta.action=bootstrap on its own. We deliberately
+			// don't fail the whole call on a bootstrap glitch.
+		}
 		b, _ := json.Marshal(out)
 		return mcp.NewToolResultText(string(b)), nil
 	}
@@ -77,7 +119,7 @@ func SetWorkspaceTool(state *WorkspaceState) (mcp.Tool, server.ToolHandlerFunc) 
 }
 
 // registerSetWorkspaceTool installs the built-in workspace tool on srv.
-func registerSetWorkspaceTool(srv *server.MCPServer, state *WorkspaceState) {
-	tool, handler := SetWorkspaceTool(state)
+func registerSetWorkspaceTool(srv *server.MCPServer, state *WorkspaceState, fetcher BootstrapFetcher) {
+	tool, handler := SetWorkspaceTool(state, fetcher)
 	srv.AddTool(tool, handler)
 }

--- a/internal/mcp/workspace_test.go
+++ b/internal/mcp/workspace_test.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 	"sync"
 	"testing"
@@ -50,7 +51,7 @@ func TestWorkspaceState_ConcurrentAccessRaceFree(t *testing.T) {
 
 func TestSetWorkspaceTool_HandlerUpdatesState(t *testing.T) {
 	state := NewWorkspaceState("")
-	tool, handler := SetWorkspaceTool(state)
+	tool, handler := SetWorkspaceTool(state, nil)
 
 	if tool.Name != SetWorkspaceToolName {
 		t.Errorf("tool name = %q, want %q", tool.Name, SetWorkspaceToolName)
@@ -75,7 +76,7 @@ func TestSetWorkspaceTool_EmptyStringClears(t *testing.T) {
 	// session default. If this regresses, agents can't go back to
 	// "no default workspace" mid-session.
 	state := NewWorkspaceState("docapp")
-	_, handler := SetWorkspaceTool(state)
+	_, handler := SetWorkspaceTool(state, nil)
 
 	req := mcp.CallToolRequest{}
 	req.Params.Arguments = map[string]any{"workspace": ""}
@@ -93,7 +94,7 @@ func TestSetWorkspaceTool_EmptyStringClears(t *testing.T) {
 
 func TestSetWorkspaceTool_MissingArgReturnsError(t *testing.T) {
 	state := NewWorkspaceState("untouched")
-	_, handler := SetWorkspaceTool(state)
+	_, handler := SetWorkspaceTool(state, nil)
 
 	req := mcp.CallToolRequest{}
 	req.Params.Arguments = map[string]any{}
@@ -129,4 +130,126 @@ func asText(c mcp.Content) string {
 		return tc.Text
 	}
 	return ""
+}
+
+// stubBootstrapFetcher is a deterministic BootstrapFetcher for tests:
+// it captures the workspace it was asked about and returns a canned
+// JSON body so the response-embed shape can be asserted without
+// spinning up a real pad binary.
+type stubBootstrapFetcher struct {
+	calledWith string
+	body       []byte
+	err        error
+}
+
+func (s *stubBootstrapFetcher) Bootstrap(_ context.Context, workspace string) ([]byte, error) {
+	s.calledWith = workspace
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.body, nil
+}
+
+// TestSetWorkspaceTool_EmbedsBootstrap verifies the response carries
+// the structured bootstrap blob when a fetcher is supplied. PLAN-1377
+// / TASK-1380 — pad_set_workspace's response shape extends from
+// {workspace, status} to include `bootstrap`, so a single call hands
+// the agent full session context.
+func TestSetWorkspaceTool_EmbedsBootstrap(t *testing.T) {
+	state := NewWorkspaceState("")
+	fetcher := &stubBootstrapFetcher{
+		body: []byte(`{"workspace":{"slug":"docapp","name":"Pad"}}`),
+	}
+	_, handler := SetWorkspaceTool(state, fetcher)
+
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]any{"workspace": "docapp"}
+	res, err := handler(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("expected success, got IsError")
+	}
+	if fetcher.calledWith != "docapp" {
+		t.Errorf("fetcher.calledWith = %q, want docapp", fetcher.calledWith)
+	}
+
+	body := ""
+	for _, c := range res.Content {
+		body += asText(c)
+	}
+	var out map[string]any
+	if err := json.Unmarshal([]byte(body), &out); err != nil {
+		t.Fatalf("decode response: %v\n%s", err, body)
+	}
+	if got, _ := out["workspace"].(string); got != "docapp" {
+		t.Errorf("response workspace = %v, want docapp", out["workspace"])
+	}
+	bs, ok := out["bootstrap"].(map[string]any)
+	if !ok {
+		t.Fatalf("response missing bootstrap object; got %#v", out)
+	}
+	ws, ok := bs["workspace"].(map[string]any)
+	if !ok {
+		t.Fatalf("bootstrap missing workspace; got %#v", bs)
+	}
+	if ws["slug"] != "docapp" {
+		t.Errorf("bootstrap.workspace.slug = %v, want docapp", ws["slug"])
+	}
+}
+
+// TestSetWorkspaceTool_BootstrapErrorFallsThrough verifies a bootstrap
+// fetcher failure doesn't break the workspace switch. Agents can
+// always retry the bootstrap via pad_meta.action=bootstrap.
+func TestSetWorkspaceTool_BootstrapErrorFallsThrough(t *testing.T) {
+	state := NewWorkspaceState("")
+	fetcher := &stubBootstrapFetcher{err: context.DeadlineExceeded}
+	_, handler := SetWorkspaceTool(state, fetcher)
+
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]any{"workspace": "docapp"}
+	res, err := handler(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("workspace switch should succeed even when bootstrap fails")
+	}
+	if state.Get() != "docapp" {
+		t.Errorf("state.Get() = %q, want docapp (the switch must commit)", state.Get())
+	}
+	body := ""
+	for _, c := range res.Content {
+		body += asText(c)
+	}
+	var out map[string]any
+	if err := json.Unmarshal([]byte(body), &out); err != nil {
+		t.Fatalf("decode response: %v\n%s", err, body)
+	}
+	if _, has := out["bootstrap"]; has {
+		t.Errorf("bootstrap should be omitted when the fetcher errors; got %#v", out)
+	}
+}
+
+// TestSetWorkspaceTool_EmptyWorkspaceSkipsBootstrap verifies that
+// clearing the session default (workspace="") doesn't trigger a
+// bootstrap fetch. Bootstrap is meaningless without a workspace.
+func TestSetWorkspaceTool_EmptyWorkspaceSkipsBootstrap(t *testing.T) {
+	state := NewWorkspaceState("docapp")
+	fetcher := &stubBootstrapFetcher{body: []byte(`{}`)}
+	_, handler := SetWorkspaceTool(state, fetcher)
+
+	req := mcp.CallToolRequest{}
+	req.Params.Arguments = map[string]any{"workspace": ""}
+	res, err := handler(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("clearing should succeed")
+	}
+	if fetcher.calledWith != "" {
+		t.Errorf("fetcher.Bootstrap was called with %q; should not be invoked on clear", fetcher.calledWith)
+	}
 }


### PR DESCRIPTION
## Summary
PLAN-1377 T3: Expose the bootstrap blob (from TASK-1379) via the three MCP surfaces the agent specs name. One canonical builder (`Server.BuildAgentBootstrap`), three discovery paths.

**Surfaces:**
1. **Resource:** `pad://workspace/{ws}/bootstrap` — hosts that prefetch resources at session start (Claude Desktop, Cursor) get full context cheaply.
2. **Tool action:** `pad_meta.action=bootstrap` — mid-session refresh for agents that didn't get the prefetch.
3. **`pad_set_workspace` response embed:** response payload extends from `{workspace, status}` to `{workspace, status, bootstrap}` when a `BootstrapFetcher` is wired in.

**Plumbing:**
- New `BootstrapFetcher` interface + `ExecBootstrapFetcher` impl shelling out to `pad bootstrap`.
- `RegistryOptions.BootstrapFetcher` (optional) — `cmd/pad/mcp.go` wires `ExecBootstrapFetcher`.
- `pad_meta.Schema.Workspace` flipped to true so the workspace param is available to the bootstrap action.
- `ToolSurfaceVersion` bumped 0.2 → 0.3 with detailed changelog.

## Context
Implements `TASK-1380` under `PLAN-1377` (Make Playbooks first-class invokable procedures).

## Test plan
- [x] `go build ./...` / `go vet ./...` clean
- [x] `go test ./...` — MCP package passes including 3 new tests; full suite green
- [x] `make check` (lint + test + web build) — green after gofmt
- [x] `make install` rebuilt binary