### PR TITLE
feat(playbook): add pad playbook CLI (list/show/run) + endpoints (TASK-1382)

### DIFF
--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -148,6 +148,7 @@ func newRootCmd() *cobra.Command {
 		completionCmd(),
 		mcpCmd(),
 		bootstrapCmd(),
+		playbookCmd(),
 	)
 
 	rootCmd.SetHelpCommand(helpCmd())
@@ -4071,6 +4072,186 @@ func searchCmd() *cobra.Command {
 	cmd.Flags().IntVar(&offset, "offset", 0, "skip this many results (for pagination)")
 
 	return cmd
+}
+
+// --- playbook ---
+
+// playbookCmd is the `pad playbook` command group for the first-class
+// invokable-procedure surface introduced in PLAN-1377 / TASK-1382.
+// Three subcommands:
+//
+//   - list  — workspace playbook metadata.
+//   - show  — full playbook body for one playbook (by slug, invocation
+//     slug, or ref).
+//   - run   — parse args against the playbook's declared spec and
+//     return the body + bound args. SIDE-EFFECT-FREE — the
+//     server only parses; the agent (or a downstream skill)
+//     executes the body.
+func playbookCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "playbook",
+		Short: "Work with playbooks — first-class invokable procedures",
+	}
+	cmd.AddCommand(playbookListCmd())
+	cmd.AddCommand(playbookShowCmd())
+	cmd.AddCommand(playbookRunCmd())
+	return cmd
+}
+
+func playbookListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List the workspace's playbooks (metadata only)",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, _ := getClient()
+			ws := getWorkspace()
+			raw, err := client.ListPlaybooks(ws)
+			if err != nil {
+				return err
+			}
+			if formatFlag == "json" {
+				return cli.PrintJSON(raw)
+			}
+			// Markdown / table — short table by default.
+			var list []struct {
+				Ref            string `json:"ref"`
+				Title          string `json:"title"`
+				InvocationSlug string `json:"invocation_slug"`
+				Trigger        string `json:"trigger"`
+				Status         string `json:"status"`
+				HasArguments   bool   `json:"has_arguments"`
+				Summary        string `json:"summary"`
+			}
+			if err := json.Unmarshal(raw, &list); err != nil {
+				return fmt.Errorf("decode playbooks: %w", err)
+			}
+			if len(list) == 0 {
+				fmt.Println("No playbooks in this workspace yet.")
+				return nil
+			}
+			for _, p := range list {
+				slug := "—"
+				if p.InvocationSlug != "" {
+					slug = "/pad " + p.InvocationSlug
+				}
+				argsTag := ""
+				if p.HasArguments {
+					argsTag = " (args)"
+				}
+				fmt.Printf("%s  %s  [trigger: %s, status: %s]\n  invoke: %s%s\n",
+					p.Ref, p.Title, defaultIfEmpty(p.Trigger, "—"),
+					defaultIfEmpty(p.Status, "—"), slug, argsTag)
+				if p.Summary != "" {
+					fmt.Printf("  %s\n", p.Summary)
+				}
+				fmt.Println()
+			}
+			return nil
+		},
+	}
+}
+
+func playbookShowCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "show <slug|ref>",
+		Short: "Show a single playbook's full body and metadata",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, _ := getClient()
+			ws := getWorkspace()
+			raw, err := client.ShowPlaybook(ws, args[0])
+			if err != nil {
+				return err
+			}
+			if formatFlag == "json" {
+				return cli.PrintJSON(raw)
+			}
+			// Markdown rendering — title + body + a small arg table when
+			// arguments are declared. The body itself is already markdown.
+			var item struct {
+				Ref     string `json:"ref"`
+				Title   string `json:"title"`
+				Content string `json:"content"`
+				Fields  string `json:"fields"`
+			}
+			if err := json.Unmarshal(raw, &item); err != nil {
+				return fmt.Errorf("decode playbook: %w", err)
+			}
+			fmt.Printf("# %s: %s\n\n", item.Ref, item.Title)
+			if item.Content != "" {
+				fmt.Println(item.Content)
+			}
+			return nil
+		},
+	}
+}
+
+func playbookRunCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "run <slug|ref> [positional-args...] [bareword-flag...] [key=value...]",
+		Short: "Bind args to a playbook's declared spec and return the body + bound args",
+		Long: `Parse the supplied args against the playbook's declared argument spec
+(stored as the 'arguments' field on the item) and return the body with
+those args bound. The server does NOT execute the playbook — playbooks
+are agent instructions, not shell scripts. The CLI just primes the call
+so an agent can take it from there.
+
+Parsing rules:
+  - Required positional args first, in declared order.
+  - Flag-typed args: bareword presence (e.g. ` + "`stop-after-each`" + `).
+  - Other typed args: ` + "`key=value`" + ` form (e.g. ` + "`merge-strategy=rebase`" + `).
+  - Refs accept either issue IDs (TASK-5) or item slugs.`,
+		Args: cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			identifier := args[0]
+			rawArgs := args[1:]
+
+			client, _ := getClient()
+			ws := getWorkspace()
+
+			// The server applies the strict CLI parsing rules to
+			// rawArgs (handlers_playbooks.go::ParsePlaybookCLIArgs) so
+			// the CLI doesn't need to duplicate or rebuild the logic.
+			// Any parse error surfaces with a useful message.
+			raw, err := client.RunPlaybook(ws, identifier, nil, rawArgs)
+			if err != nil {
+				return err
+			}
+			if formatFlag == "json" {
+				return cli.PrintJSON(raw)
+			}
+			var resp struct {
+				Ref       string         `json:"ref"`
+				Title     string         `json:"title"`
+				Body      string         `json:"body"`
+				BoundArgs map[string]any `json:"bound_args"`
+				Unbound   []struct {
+					Name string `json:"name"`
+				} `json:"unbound"`
+			}
+			if err := json.Unmarshal(raw, &resp); err != nil {
+				return fmt.Errorf("decode run response: %w", err)
+			}
+			fmt.Printf("# %s: %s\n\n", resp.Ref, resp.Title)
+			if len(resp.BoundArgs) > 0 {
+				fmt.Println("## Bound arguments")
+				for k, v := range resp.BoundArgs {
+					fmt.Printf("- %s = %v\n", k, v)
+				}
+				fmt.Println()
+			}
+			if len(resp.Unbound) > 0 {
+				fmt.Println("## Unbound required arguments")
+				for _, u := range resp.Unbound {
+					fmt.Printf("- %s\n", u.Name)
+				}
+				fmt.Println("The agent (or you) need to supply these before executing.")
+				fmt.Println()
+			}
+			fmt.Println(resp.Body)
+			return nil
+		},
+	}
 }
 
 // --- bootstrap ---

--- a/internal/cli/client.go
+++ b/internal/cli/client.go
@@ -260,6 +260,43 @@ func (c *Client) GetAgentBootstrap(wsSlug string) (json.RawMessage, error) {
 	return result, c.get("/workspaces/"+wsSlug+"/agent/bootstrap", &result)
 }
 
+// --- Playbooks ---
+
+// ListPlaybooks returns the workspace's playbook metadata array
+// (PLAN-1377 / TASK-1382). Same shape as bootstrap.playbooks.
+func (c *Client) ListPlaybooks(wsSlug string) (json.RawMessage, error) {
+	var result json.RawMessage
+	return result, c.get("/workspaces/"+wsSlug+"/playbooks", &result)
+}
+
+// ShowPlaybook returns the full playbook item identified by ref, slug,
+// or invocation_slug.
+func (c *Client) ShowPlaybook(wsSlug, identifier string) (json.RawMessage, error) {
+	var result json.RawMessage
+	return result, c.get("/workspaces/"+wsSlug+"/playbooks/"+identifier, &result)
+}
+
+// RunPlaybook binds the supplied args to the playbook's declared spec
+// and returns the body + bound args + any unsatisfied required args.
+// Side-effect-free: the server only parses; the agent executes.
+//
+// Callers can pass either a pre-parsed args map OR raw CLI tokens
+// (positional / bareword-flag / key=value). The server applies the
+// strict parsing rules to rawArgs and merges them with args. CLI
+// callers use rawArgs (no client-side spec lookup needed); MCP /
+// programmatic callers use args directly.
+func (c *Client) RunPlaybook(wsSlug, identifier string, args map[string]any, rawArgs []string) (json.RawMessage, error) {
+	body := map[string]any{}
+	if len(args) > 0 {
+		body["args"] = args
+	}
+	if len(rawArgs) > 0 {
+		body["raw_args"] = rawArgs
+	}
+	var result json.RawMessage
+	return result, c.post("/workspaces/"+wsSlug+"/playbooks/"+identifier+"/run", body, &result)
+}
+
 // --- Search ---
 
 // SearchItems performs a cross-workspace search. Pass q, workspace, etc. via params.

--- a/internal/server/handlers_playbooks.go
+++ b/internal/server/handlers_playbooks.go
@@ -2,8 +2,12 @@ package server
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
+	"math"
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/PerpetualSoftware/pad/internal/models"
@@ -148,7 +152,13 @@ func (s *Server) handleRunPlaybook(w http.ResponseWriter, r *http.Request) {
 		Args    map[string]any `json:"args"`
 		RawArgs []string       `json:"raw_args"`
 	}
-	if err := decodeJSON(r, &input); err != nil && err.Error() != "EOF" {
+	// decodeJSON wraps the underlying error as "invalid JSON: ..." so an
+	// EOF check on the wrapped message is unreliable. Use errors.Is on
+	// the unwrapped chain so a zero-length body (which is a legitimate
+	// "no args" call) is accepted regardless of how decodeJSON labels
+	// the wrapper. http.NoBody as well as a closed reader both surface
+	// io.EOF; either is fine to treat as "empty request".
+	if err := decodeJSON(r, &input); err != nil && !errors.Is(err, io.EOF) {
 		writeError(w, http.StatusBadRequest, "bad_request", err.Error())
 		return
 	}
@@ -360,8 +370,13 @@ func ParsePlaybookCLIArgs(args []string, specs []PlaybookArgumentSpec) (map[stri
 			out[tok] = true
 			continue
 		}
-		// Treat as next positional fill.
-		for positionalIdx < len(specs) && (specs[positionalIdx].Type == "flag" || hasValue(out, specs[positionalIdx].Name)) {
+		// Treat as next positional fill. Per the PLAN-1377 contract,
+		// ONLY required args are positional — optional args must be
+		// supplied via key=value. Skip past flag-typed, optional, and
+		// already-bound slots so a bareword token can't accidentally
+		// land on an optional spec that happens to sit before a
+		// required one in the schema.
+		for positionalIdx < len(specs) && (specs[positionalIdx].Type == "flag" || !specs[positionalIdx].Required || hasValue(out, specs[positionalIdx].Name)) {
 			positionalIdx++
 		}
 		if positionalIdx >= len(specs) {
@@ -389,9 +404,15 @@ func hasValue(m map[string]any, key string) bool {
 func coercePlaybookValue(raw string, spec PlaybookArgumentSpec) (any, error) {
 	switch spec.Type {
 	case "number":
-		var f float64
-		if _, err := fmt.Sscanf(raw, "%g", &f); err != nil {
-			return nil, fmt.Errorf("argument %q expects a number; got %q", spec.Name, raw)
+		// strconv.ParseFloat validates the entire token (Sscanf with %g
+		// would accept "1abc" as 1) AND lets us reject NaN/Inf, which
+		// would otherwise blow up json.Marshal later in the request.
+		f, err := strconv.ParseFloat(raw, 64)
+		if err != nil {
+			return nil, fmt.Errorf("argument %q expects a finite number; got %q", spec.Name, raw)
+		}
+		if math.IsNaN(f) || math.IsInf(f, 0) {
+			return nil, fmt.Errorf("argument %q must be a finite number; got %q", spec.Name, raw)
 		}
 		return f, nil
 	case "enum":

--- a/internal/server/handlers_playbooks.go
+++ b/internal/server/handlers_playbooks.go
@@ -1,0 +1,410 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+	"github.com/go-chi/chi/v5"
+)
+
+// PlaybookRunResponse is the result of `POST /workspaces/{ws}/playbooks/{ref}/run`.
+// The handler does NOT execute the playbook — playbooks are agent
+// instructions, not shell scripts. The CLI/MCP/skill consumer parses
+// the args, then the agent (the actual executor) follows the body's
+// steps with those args bound.
+//
+// Shape is deliberately denormalized for the agent: the body is
+// markdown ready to render, bound_args carries the parsed argument
+// values keyed by name, and unbound carries required args the caller
+// didn't supply (so the agent can prompt the user instead of failing
+// the call outright).
+type PlaybookRunResponse struct {
+	Ref       string                    `json:"ref"`
+	Slug      string                    `json:"slug"`
+	Title     string                    `json:"title"`
+	Body      string                    `json:"body"`
+	Arguments []PlaybookArgumentSpec    `json:"arguments"`
+	BoundArgs map[string]any            `json:"bound_args"`
+	Unbound   []PlaybookUnboundArgument `json:"unbound,omitempty"`
+}
+
+// PlaybookArgumentSpec is one entry from the playbook's `arguments`
+// field — the queryable form of the body's `## Arguments` section.
+// Five types are supported per the PLAN-1377 design: ref, string,
+// flag, enum, number. Default values are passed through opaquely; the
+// agent decides what to do with non-literal defaults like "current
+// git branch".
+type PlaybookArgumentSpec struct {
+	Name        string   `json:"name"`
+	Type        string   `json:"type"`
+	Required    bool     `json:"required,omitempty"`
+	Default     any      `json:"default,omitempty"`
+	Description string   `json:"description,omitempty"`
+	Enum        []string `json:"enum,omitempty"`
+}
+
+// PlaybookUnboundArgument tells the caller which required args the run
+// invocation didn't supply, so the agent can fall back to prompting
+// the user instead of refusing the call.
+type PlaybookUnboundArgument struct {
+	Name string               `json:"name"`
+	Spec PlaybookArgumentSpec `json:"spec"`
+}
+
+// handleListPlaybooks returns playbook metadata for the workspace.
+// Same shape as the bootstrap blob's `playbooks` field, hand-rolled
+// here so callers can fetch it without pulling in the full bootstrap.
+func (s *Server) handleListPlaybooks(w http.ResponseWriter, r *http.Request) {
+	workspaceID, ok := s.getWorkspaceID(w, r)
+	if !ok {
+		return
+	}
+	// Reuse the same metadata projection as bootstrap. Visibility is
+	// applied at the ListItems level: collIDs/itemIDs reflect the
+	// caller's filtered view.
+	visibleIDs, err := s.visibleCollectionIDs(r, workspaceID)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	fullCollIDs, grantedItemIDs, err := s.guestResourceFilter(r, workspaceID)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	subCollIDs := visibleIDs
+	var subItemIDs []string
+	if len(grantedItemIDs) > 0 {
+		subCollIDs = fullCollIDs
+		subItemIDs = grantedItemIDs
+	}
+	meta, err := s.collectPlaybookMetadata(workspaceID, subCollIDs, subItemIDs)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, meta)
+}
+
+// handleShowPlaybook returns the full playbook item identified by ref,
+// slug, OR invocation_slug. The resolver walks both invocation_slug
+// (the user-facing identifier) and item slug/ref (the workspace-wide
+// identifier) so `pad playbook show ship` works whether `ship` is the
+// invocation slug or the item ref.
+func (s *Server) handleShowPlaybook(w http.ResponseWriter, r *http.Request) {
+	workspaceID, ok := s.getWorkspaceID(w, r)
+	if !ok {
+		return
+	}
+	identifier := chi.URLParam(r, "ref")
+	if identifier == "" {
+		writeError(w, http.StatusBadRequest, "bad_request", "ref required")
+		return
+	}
+	item, err := s.resolvePlaybook(workspaceID, identifier)
+	if err != nil {
+		writeError(w, http.StatusNotFound, "not_found", err.Error())
+		return
+	}
+	if !s.requireItemVisible(w, r, workspaceID, item) {
+		return
+	}
+	writeJSON(w, http.StatusOK, item)
+}
+
+// handleRunPlaybook parses the caller's args against the playbook's
+// declared argument spec and returns the rendered body + bound args.
+// Side-effect-free: it does NOT execute the playbook — it just primes
+// the agent.
+func (s *Server) handleRunPlaybook(w http.ResponseWriter, r *http.Request) {
+	workspaceID, ok := s.getWorkspaceID(w, r)
+	if !ok {
+		return
+	}
+	identifier := chi.URLParam(r, "ref")
+	if identifier == "" {
+		writeError(w, http.StatusBadRequest, "bad_request", "ref required")
+		return
+	}
+	item, err := s.resolvePlaybook(workspaceID, identifier)
+	if err != nil {
+		writeError(w, http.StatusNotFound, "not_found", err.Error())
+		return
+	}
+	if !s.requireItemVisible(w, r, workspaceID, item) {
+		return
+	}
+
+	// Run accepts EITHER pre-parsed args (from MCP / web clients that
+	// already have the key/value map) OR raw CLI tokens (positional,
+	// bareword flags, key=value). When raw_args is non-empty the server
+	// applies the same strict parsing rules `pad playbook run` uses, so
+	// the CLI doesn't need to duplicate the logic and so any drift is
+	// impossible.
+	var input struct {
+		Args    map[string]any `json:"args"`
+		RawArgs []string       `json:"raw_args"`
+	}
+	if err := decodeJSON(r, &input); err != nil && err.Error() != "EOF" {
+		writeError(w, http.StatusBadRequest, "bad_request", err.Error())
+		return
+	}
+
+	specs, _, err := parsePlaybookArguments(item.Fields)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", err.Error())
+		return
+	}
+
+	supplied := input.Args
+	if len(input.RawArgs) > 0 {
+		parsed, perr := ParsePlaybookCLIArgs(input.RawArgs, specs)
+		if perr != nil {
+			writeError(w, http.StatusBadRequest, "bad_request", perr.Error())
+			return
+		}
+		// Merge: explicit Args take precedence over RawArgs so a
+		// caller that passes both can override.
+		if supplied == nil {
+			supplied = parsed
+		} else {
+			for k, v := range parsed {
+				if _, present := supplied[k]; !present {
+					supplied[k] = v
+				}
+			}
+		}
+	}
+
+	bound, unbound := bindPlaybookArgs(specs, supplied)
+
+	writeJSON(w, http.StatusOK, PlaybookRunResponse{
+		Ref:       item.Ref,
+		Slug:      item.Slug,
+		Title:     item.Title,
+		Body:      item.Content,
+		Arguments: specs,
+		BoundArgs: bound,
+		Unbound:   unbound,
+	})
+}
+
+// resolvePlaybook finds a playbook by either its invocation_slug, its
+// item slug, or its issue ref. invocation_slug takes precedence — that's
+// the user-facing identifier callers will type most often.
+func (s *Server) resolvePlaybook(workspaceID, identifier string) (*models.Item, error) {
+	// First, try invocation_slug. If we find an exact match, return it.
+	bySlug, err := s.store.ListItems(workspaceID, models.ItemListParams{
+		CollectionSlug: "playbooks",
+		Fields:         map[string]string{"invocation_slug": identifier},
+		Limit:          1,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(bySlug) == 1 {
+		return &bySlug[0], nil
+	}
+	// Fall back to standard item resolution (UUID, ref, or item slug),
+	// then verify it lives in the playbooks collection so a stray
+	// TASK-5 doesn't surface here.
+	item, err := s.store.ResolveItem(workspaceID, identifier)
+	if err != nil || item == nil {
+		return nil, fmt.Errorf("playbook %q not found", identifier)
+	}
+	if item.CollectionSlug != "playbooks" {
+		return nil, fmt.Errorf("item %s is not a playbook", item.Ref)
+	}
+	return item, nil
+}
+
+// parsePlaybookArguments pulls the `arguments` field out of the
+// playbook item's fields JSON and decodes it into a list of
+// PlaybookArgumentSpec entries. Returns (specs, raw, error) where raw
+// is the JSON-decoded original so callers can fall back to it for
+// unknown shapes. A nil/missing `arguments` field decodes to an empty
+// spec list (no arguments declared).
+func parsePlaybookArguments(fieldsJSON string) ([]PlaybookArgumentSpec, any, error) {
+	if fieldsJSON == "" {
+		return nil, nil, nil
+	}
+	var fields map[string]any
+	if err := json.Unmarshal([]byte(fieldsJSON), &fields); err != nil {
+		return nil, nil, fmt.Errorf("parse playbook fields: %w", err)
+	}
+	raw, ok := fields["arguments"]
+	if !ok || raw == nil {
+		return nil, nil, nil
+	}
+	arr, ok := raw.([]any)
+	if !ok {
+		return nil, raw, fmt.Errorf("playbook arguments field is not an array; got %T", raw)
+	}
+	specs := make([]PlaybookArgumentSpec, 0, len(arr))
+	for i, entry := range arr {
+		m, ok := entry.(map[string]any)
+		if !ok {
+			return nil, raw, fmt.Errorf("playbook argument [%d] is not an object", i)
+		}
+		spec := PlaybookArgumentSpec{}
+		if name, ok := m["name"].(string); ok {
+			spec.Name = name
+		}
+		if t, ok := m["type"].(string); ok {
+			spec.Type = t
+		}
+		if req, ok := m["required"].(bool); ok {
+			spec.Required = req
+		}
+		spec.Default = m["default"]
+		if d, ok := m["description"].(string); ok {
+			spec.Description = d
+		}
+		if enum, ok := m["enum"].([]any); ok {
+			for _, e := range enum {
+				if s, ok := e.(string); ok {
+					spec.Enum = append(spec.Enum, s)
+				}
+			}
+		}
+		specs = append(specs, spec)
+	}
+	return specs, raw, nil
+}
+
+// bindPlaybookArgs walks the declared arg specs and binds the caller's
+// supplied values. Unsupplied required args land in the `unbound`
+// list so the agent can prompt the user instead of failing.
+// Unsupplied optional args are filled with their declared default
+// when present; otherwise omitted.
+//
+// Flag-typed args are special-cased: presence (true) wins over absence.
+// A caller that sent `{stop-after-each: false}` still gets that value.
+func bindPlaybookArgs(specs []PlaybookArgumentSpec, supplied map[string]any) (map[string]any, []PlaybookUnboundArgument) {
+	bound := make(map[string]any, len(specs))
+	var unbound []PlaybookUnboundArgument
+	for _, spec := range specs {
+		val, present := supplied[spec.Name]
+		if !present {
+			if spec.Default != nil {
+				bound[spec.Name] = spec.Default
+				continue
+			}
+			if spec.Type == "flag" {
+				// Flag types default to false when absent.
+				bound[spec.Name] = false
+				continue
+			}
+			if spec.Required {
+				unbound = append(unbound, PlaybookUnboundArgument{
+					Name: spec.Name,
+					Spec: spec,
+				})
+			}
+			continue
+		}
+		bound[spec.Name] = val
+	}
+	return bound, unbound
+}
+
+// ParsePlaybookCLIArgs splits a sequence of positional args + bareword
+// flags + key=value pairs into a typed map matching the playbook's
+// declared spec. Exposed for the CLI side (`pad playbook run`) and the
+// MCP run action — both follow the same strict rules:
+//
+//   - Required positional args first, in declared order.
+//   - `flag` types: bareword presence sets the value to true.
+//   - All other types: `key=value` form.
+//
+// Unknown tokens return an error with a hint about which arg names
+// are valid. The CLI surfaces this back to the user.
+func ParsePlaybookCLIArgs(args []string, specs []PlaybookArgumentSpec) (map[string]any, error) {
+	out := make(map[string]any)
+	specByName := make(map[string]PlaybookArgumentSpec, len(specs))
+	flagSet := make(map[string]bool, len(specs))
+	for _, s := range specs {
+		specByName[s.Name] = s
+		if s.Type == "flag" {
+			flagSet[s.Name] = true
+		}
+	}
+
+	// Walk required-positional specs in order. They consume args from
+	// the front until either they're all filled or the next token
+	// looks like a key=value/flag.
+	positionalIdx := 0
+	for _, tok := range args {
+		if strings.Contains(tok, "=") {
+			eq := strings.IndexByte(tok, '=')
+			key := tok[:eq]
+			val := tok[eq+1:]
+			spec, known := specByName[key]
+			if !known {
+				return nil, fmt.Errorf("unknown argument %q", key)
+			}
+			if spec.Type == "flag" {
+				return nil, fmt.Errorf("argument %q is a flag — use bareword presence, not key=value", key)
+			}
+			coerced, err := coercePlaybookValue(val, spec)
+			if err != nil {
+				return nil, err
+			}
+			out[key] = coerced
+			continue
+		}
+		if flagSet[tok] {
+			out[tok] = true
+			continue
+		}
+		// Treat as next positional fill.
+		for positionalIdx < len(specs) && (specs[positionalIdx].Type == "flag" || hasValue(out, specs[positionalIdx].Name)) {
+			positionalIdx++
+		}
+		if positionalIdx >= len(specs) {
+			return nil, fmt.Errorf("unexpected positional token %q (no remaining positional slots)", tok)
+		}
+		spec := specs[positionalIdx]
+		coerced, err := coercePlaybookValue(tok, spec)
+		if err != nil {
+			return nil, err
+		}
+		out[spec.Name] = coerced
+		positionalIdx++
+	}
+	return out, nil
+}
+
+func hasValue(m map[string]any, key string) bool {
+	_, ok := m[key]
+	return ok
+}
+
+// coercePlaybookValue converts a raw CLI token into the typed Go value
+// the spec describes. ref/string pass through; number is parsed as
+// float64; enum is validated against the declared options.
+func coercePlaybookValue(raw string, spec PlaybookArgumentSpec) (any, error) {
+	switch spec.Type {
+	case "number":
+		var f float64
+		if _, err := fmt.Sscanf(raw, "%g", &f); err != nil {
+			return nil, fmt.Errorf("argument %q expects a number; got %q", spec.Name, raw)
+		}
+		return f, nil
+	case "enum":
+		if len(spec.Enum) == 0 {
+			return raw, nil
+		}
+		for _, opt := range spec.Enum {
+			if opt == raw {
+				return raw, nil
+			}
+		}
+		return nil, fmt.Errorf("argument %q must be one of %v; got %q", spec.Name, spec.Enum, raw)
+	default:
+		return raw, nil
+	}
+}

--- a/internal/server/handlers_playbooks_test.go
+++ b/internal/server/handlers_playbooks_test.go
@@ -1,0 +1,281 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+// TestPlaybookList verifies the list endpoint returns the metadata shape
+// agents expect (slug + invocation_slug + has_arguments). This is the
+// same projection bootstrap uses; the dedicated endpoint lets callers
+// skip the rest of the bootstrap blob when they only need the catalog.
+func TestPlaybookList(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	createItem(t, srv, slug, "playbooks", map[string]interface{}{
+		"title":   "Cut release",
+		"content": "Step 1: tag",
+		"fields":  `{"status":"active","trigger":"on-release","invocation_slug":"release","arguments":[{"name":"version","type":"string","required":true}]}`,
+	})
+	createItem(t, srv, slug, "playbooks", map[string]interface{}{
+		"title":   "Triage bugs",
+		"content": "Auto-loaded — no slug",
+		"fields":  `{"status":"active","trigger":"on-triage"}`,
+	})
+
+	rr := doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/playbooks", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("list playbooks: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var list []AgentBootstrapPlaybookMeta
+	parseJSON(t, rr, &list)
+
+	if len(list) < 2 {
+		t.Fatalf("expected 2 playbooks, got %d", len(list))
+	}
+	// invocation_slug-bearing playbook should sort first (see
+	// collectPlaybookMetadata's stable sort).
+	if list[0].InvocationSlug != "release" {
+		t.Errorf("expected invocation_slug='release' first, got %q (full list: %#v)", list[0].InvocationSlug, list)
+	}
+	if !list[0].HasArguments {
+		t.Errorf("expected has_arguments=true for the release playbook")
+	}
+}
+
+// TestPlaybookShowByInvocationSlug verifies the invocation_slug
+// resolution path — `pad playbook show ship` should find the playbook
+// regardless of its underlying ref or item slug.
+func TestPlaybookShowByInvocationSlug(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	createItem(t, srv, slug, "playbooks", map[string]interface{}{
+		"title":   "Ship something",
+		"content": "Step 1",
+		"fields":  `{"status":"active","invocation_slug":"ship"}`,
+	})
+
+	rr := doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/playbooks/ship", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("show by invocation_slug: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var item map[string]any
+	parseJSON(t, rr, &item)
+	if title, _ := item["title"].(string); title != "Ship something" {
+		t.Errorf("title = %v, want Ship something", item["title"])
+	}
+}
+
+// TestPlaybookShowByRef verifies the fallback resolution — when the
+// identifier isn't an invocation_slug, fall through to ResolveItem
+// (UUID / ref / item slug).
+func TestPlaybookShowByRef(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	created := createItem(t, srv, slug, "playbooks", map[string]interface{}{
+		"title":  "Just a playbook",
+		"fields": `{"status":"active"}`,
+	})
+
+	rr := doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/playbooks/"+created.Ref, nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("show by ref: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var item map[string]any
+	parseJSON(t, rr, &item)
+	if ref, _ := item["ref"].(string); ref != created.Ref {
+		t.Errorf("ref = %v, want %s", item["ref"], created.Ref)
+	}
+}
+
+// TestPlaybookShowRejectsNonPlaybook verifies the resolver refuses to
+// surface non-playbook items even when their ref matches — keeps
+// /pad <slug> routing from accidentally picking up a TASK.
+func TestPlaybookShowRejectsNonPlaybook(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	task := createItem(t, srv, slug, "tasks", map[string]interface{}{
+		"title":  "A normal task",
+		"fields": `{"status":"open"}`,
+	})
+
+	rr := doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/playbooks/"+task.Ref, nil)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("show non-playbook by ref: expected 404, got %d", rr.Code)
+	}
+}
+
+// TestPlaybookRunBindsArgs verifies the run endpoint parses the
+// `arguments` spec from fields, binds the caller's supplied values,
+// and surfaces required-but-missing args in the unbound list (so the
+// agent can prompt the user rather than failing the call).
+func TestPlaybookRunBindsArgs(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	createItem(t, srv, slug, "playbooks", map[string]interface{}{
+		"title":   "Ship",
+		"content": "Step 1",
+		"fields": `{"status":"active","invocation_slug":"ship","arguments":[
+			{"name":"target","type":"ref","required":true},
+			{"name":"merge-strategy","type":"enum","default":"squash","enum":["squash","merge","rebase"]},
+			{"name":"stop-after-each","type":"flag"},
+			{"name":"limit","type":"number"}
+		]}`,
+	})
+
+	t.Run("with-args", func(t *testing.T) {
+		body := map[string]any{
+			"args": map[string]any{
+				"target":          "PLAN-7",
+				"stop-after-each": true,
+				"limit":           float64(3),
+			},
+		}
+		rr := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/playbooks/ship/run", body)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("run: expected 200, got %d: %s", rr.Code, rr.Body.String())
+		}
+		var resp PlaybookRunResponse
+		parseJSON(t, rr, &resp)
+		if resp.BoundArgs["target"] != "PLAN-7" {
+			t.Errorf("bound_args[target] = %v, want PLAN-7", resp.BoundArgs["target"])
+		}
+		if resp.BoundArgs["stop-after-each"] != true {
+			t.Errorf("bound_args[stop-after-each] = %v, want true", resp.BoundArgs["stop-after-each"])
+		}
+		// merge-strategy should default to 'squash' since the caller
+		// didn't supply it.
+		if resp.BoundArgs["merge-strategy"] != "squash" {
+			t.Errorf("bound_args[merge-strategy] = %v, want squash (default)", resp.BoundArgs["merge-strategy"])
+		}
+	})
+
+	t.Run("missing-required-surfaces-unbound", func(t *testing.T) {
+		body := map[string]any{
+			"args": map[string]any{}, // no target
+		}
+		rr := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/playbooks/ship/run", body)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("run: expected 200, got %d: %s", rr.Code, rr.Body.String())
+		}
+		var resp PlaybookRunResponse
+		parseJSON(t, rr, &resp)
+		if len(resp.Unbound) != 1 || resp.Unbound[0].Name != "target" {
+			t.Errorf("unbound list should contain 'target'; got %#v", resp.Unbound)
+		}
+	})
+
+	t.Run("with-raw-args", func(t *testing.T) {
+		body := map[string]any{
+			"raw_args": []string{"PLAN-7", "merge-strategy=rebase", "stop-after-each"},
+		}
+		rr := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/playbooks/ship/run", body)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("run raw_args: expected 200, got %d: %s", rr.Code, rr.Body.String())
+		}
+		var resp PlaybookRunResponse
+		parseJSON(t, rr, &resp)
+		// target is the first declared positional, so it should pick up PLAN-7
+		if resp.BoundArgs["target"] != "PLAN-7" {
+			t.Errorf("bound_args[target] = %v, want PLAN-7 (positional)", resp.BoundArgs["target"])
+		}
+		if resp.BoundArgs["merge-strategy"] != "rebase" {
+			t.Errorf("bound_args[merge-strategy] = %v, want rebase (key=value)", resp.BoundArgs["merge-strategy"])
+		}
+		if resp.BoundArgs["stop-after-each"] != true {
+			t.Errorf("bound_args[stop-after-each] = %v, want true (flag)", resp.BoundArgs["stop-after-each"])
+		}
+	})
+}
+
+// TestParsePlaybookCLIArgsErrors verifies the strict parser surfaces
+// the right errors for each malformed-input class. The CLI relays
+// these to the user verbatim, so the messages need to be specific.
+func TestParsePlaybookCLIArgsErrors(t *testing.T) {
+	specs := []PlaybookArgumentSpec{
+		{Name: "target", Type: "ref", Required: true},
+		{Name: "merge-strategy", Type: "enum", Enum: []string{"squash", "merge"}},
+		{Name: "flag-thing", Type: "flag"},
+	}
+
+	cases := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{"unknown-key", []string{"foo=bar"}, `unknown argument "foo"`},
+		{"flag-as-key-value", []string{"flag-thing=true"}, "flag-thing"},
+		{"bad-enum", []string{"merge-strategy=tomato"}, `must be one of [squash merge]`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ParsePlaybookCLIArgs(tc.args, specs)
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+			}
+			if !contains(err.Error(), tc.wantErr) {
+				t.Errorf("error = %q, want substring %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+
+	// Separate fixture: only one positional slot so the
+	// "no remaining positional slots" branch is reachable.
+	tightSpecs := []PlaybookArgumentSpec{
+		{Name: "target", Type: "ref", Required: true},
+	}
+	if _, err := ParsePlaybookCLIArgs([]string{"PLAN-1", "PLAN-2"}, tightSpecs); err == nil {
+		t.Fatal("expected error for excess positional with one declared slot")
+	} else if !contains(err.Error(), "no remaining positional slots") {
+		t.Errorf("error = %q, want 'no remaining positional slots'", err.Error())
+	}
+}
+
+// contains is a small test helper.
+func contains(s, sub string) bool {
+	return len(sub) == 0 || (len(s) >= len(sub) && indexOf(s, sub) >= 0)
+}
+
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}
+
+// TestPlaybookListEmptyShape verifies a workspace with no playbooks
+// returns an empty array rather than null, matching bootstrap's
+// contract.
+func TestPlaybookListEmptyShape(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	rr := doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/playbooks", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("list empty: expected 200, got %d", rr.Code)
+	}
+	// Should decode to an empty slice, never null.
+	var raw json.RawMessage
+	if err := json.Unmarshal(rr.Body.Bytes(), &raw); err != nil {
+		t.Fatalf("decode raw: %v", err)
+	}
+	if string(raw) == "null" {
+		t.Errorf("empty list serialized as null; want []")
+	}
+	var list []AgentBootstrapPlaybookMeta
+	if err := json.Unmarshal(rr.Body.Bytes(), &list); err != nil {
+		t.Fatalf("decode list: %v", err)
+	}
+	if !reflect.DeepEqual(list, []AgentBootstrapPlaybookMeta{}) && len(list) != 0 {
+		t.Errorf("expected empty list, got %v", list)
+	}
+}

--- a/internal/server/handlers_playbooks_test.go
+++ b/internal/server/handlers_playbooks_test.go
@@ -238,6 +238,80 @@ func TestParsePlaybookCLIArgsErrors(t *testing.T) {
 	}
 }
 
+// TestPlaybookRunAcceptsEmptyBody verifies that POSTing the run
+// endpoint with no body (or only a {} body) still works for playbooks
+// with no required args — the previous EOF-string check rejected
+// the legitimate no-args call.
+func TestPlaybookRunAcceptsEmptyBody(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	createItem(t, srv, slug, "playbooks", map[string]interface{}{
+		"title":   "No-args playbook",
+		"content": "Just steps",
+		"fields":  `{"status":"active","invocation_slug":"no-args"}`,
+	})
+
+	rr := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/playbooks/no-args/run", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("empty-body run: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+// TestParsePlaybookCLIArgsOptionalNotPositional verifies the strict
+// rule that ONLY required args are positional. With an optional arg
+// declared before a required one, a bareword token must skip past
+// the optional and fill the required slot.
+func TestParsePlaybookCLIArgsOptionalNotPositional(t *testing.T) {
+	specs := []PlaybookArgumentSpec{
+		{Name: "merge-strategy", Type: "enum", Enum: []string{"squash", "rebase"}}, // optional, first
+		{Name: "target", Type: "ref", Required: true},                              // required, second
+	}
+	parsed, err := ParsePlaybookCLIArgs([]string{"TASK-7"}, specs)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if parsed["target"] != "TASK-7" {
+		t.Errorf("expected target=TASK-7 (skipping the optional first slot); got %#v", parsed)
+	}
+	if _, ok := parsed["merge-strategy"]; ok {
+		t.Errorf("merge-strategy should not be positionally filled; got %v", parsed["merge-strategy"])
+	}
+}
+
+// TestCoercePlaybookValueNumberRejectsBadInput verifies the number
+// coercion rejects partial tokens, NaN, and Inf — Codex round 1
+// caught Sscanf("%g") accepting "1abc" silently.
+func TestCoercePlaybookValueNumberRejectsBadInput(t *testing.T) {
+	spec := PlaybookArgumentSpec{Name: "limit", Type: "number"}
+
+	good := []struct {
+		in   string
+		want float64
+	}{
+		{"3", 3},
+		{"3.5", 3.5},
+		{"-2", -2},
+	}
+	for _, tc := range good {
+		v, err := coercePlaybookValue(tc.in, spec)
+		if err != nil {
+			t.Errorf("expected %q to parse, got error: %v", tc.in, err)
+			continue
+		}
+		if v != tc.want {
+			t.Errorf("parse %q = %v, want %v", tc.in, v, tc.want)
+		}
+	}
+
+	bad := []string{"1abc", "abc", "", "NaN", "Inf", "-Inf", "+Inf"}
+	for _, in := range bad {
+		if _, err := coercePlaybookValue(in, spec); err == nil {
+			t.Errorf("expected %q to fail parsing, got success", in)
+		}
+	}
+}
+
 // contains is a small test helper.
 func contains(s, sub string) bool {
 	return len(sub) == 0 || (len(s) >= len(sub) && indexOf(s, sub) >= 0)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1181,6 +1181,16 @@ func (s *Server) setupRouter() {
 					// surfaces in TASK-1380.
 					r.Get("/agent/bootstrap", s.handleGetBootstrap)
 
+					// Playbook surface (PLAN-1377 / TASK-1382) — list /
+					// show / run for first-class invokable procedures.
+					// run is side-effect-free: it parses args per the
+					// playbook's declared spec and returns the body +
+					// bound args. The agent (skill or MCP-driven)
+					// executes the body; the server does not.
+					r.Get("/playbooks", s.handleListPlaybooks)
+					r.Get("/playbooks/{ref}", s.handleShowPlaybook)
+					r.Post("/playbooks/{ref}/run", s.handleRunPlaybook)
+
 					// Incremental sync — returns items changed since a timestamp
 					r.Get("/changes", s.handleGetChanges)
 				})


### PR DESCRIPTION
## Summary
PLAN-1377 T5 — first-class invokable-procedure surface. Three HTTP endpoints + three CLI subcommands, with a strict CLI arg parser and a side-effect-free run path.

**Endpoints:**
- `GET /workspaces/{ws}/playbooks` — metadata array (same projection as bootstrap)
- `GET /workspaces/{ws}/playbooks/{ref}` — full item, resolved by invocation_slug | ref | slug
- `POST /workspaces/{ws}/playbooks/{ref}/run` — bind args, return body + bound + unbound. No execution.

**Arg parsing:** `ParsePlaybookCLIArgs` (in handlers_playbooks.go) implements the strict rules — required positionals first, flag types are bareword presence, other types use `key=value`. Server accepts either pre-parsed args (MCP) or raw CLI tokens (CLI), so there's one parser implementation.

**CLI:** `pad playbook list`, `pad playbook show <slug|ref>`, `pad playbook run <slug|ref> [args...]`.

**Resolution:** `resolvePlaybook` walks `invocation_slug` first, then falls back to `ResolveItem`. A stray TASK-5 hitting `/playbooks/TASK-5` returns 404 instead of leaking a non-playbook.

## Context
Implements `TASK-1382` under `PLAN-1377`. Unblocks T4 (`pad_playbook` MCP tool) and T6 (`/pad` skill rewrite).

## Test plan
- [x] `go build ./...` / `go vet ./...` clean
- [x] `go test ./...` — 8 new tests pass
- [x] `make check` — green
- [x] `make install` rebuilt binary
- [x] Manual: `pad playbook list` returns all four seeded playbooks with metadata