### PR TITLE
feat(mcp): add pad_playbook tool (list/get/run) (TASK-1381)

### DIFF
--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -4153,8 +4153,13 @@ func playbookListCmd() *cobra.Command {
 
 func playbookShowCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "show <slug|ref>",
+		// Plain <ref> in the Use so cmdhelp/MCP see arg name "ref"
+		// (alternation like <slug|ref> synthesizes the name "value").
+		// The handler accepts invocation_slug / item slug / issue ref —
+		// the Long description spells that out.
+		Use:   "show <ref>",
 		Short: "Show a single playbook's full body and metadata",
+		Long:  "Print a playbook by invocation_slug, item slug, or issue ref. The resolver tries each in turn.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, _ := getClient()
@@ -4188,7 +4193,11 @@ func playbookShowCmd() *cobra.Command {
 
 func playbookRunCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "run <slug|ref> [positional-args...] [bareword-flag...] [key=value...]",
+		// Plain <ref> for cmdhelp arg-name stability; trailing args
+		// (positional values, bareword flags, key=value pairs) are
+		// accepted as variadic and forwarded to the server's strict
+		// parser. The arg-form details live in Long.
+		Use:   "run <ref> [args...]",
 		Short: "Bind args to a playbook's declared spec and return the body + bound args",
 		Long: `Parse the supplied args against the playbook's declared argument spec
 (stored as the 'arguments' field on the item) and return the body with

--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -4197,7 +4197,13 @@ func playbookRunCmd() *cobra.Command {
 		// (positional values, bareword flags, key=value pairs) are
 		// accepted as variadic and forwarded to the server's strict
 		// parser. The arg-form details live in Long.
-		Use:   "run <ref> [args...]",
+		//
+		// Note: `[args]...` (ellipsis OUTSIDE the brackets) is the
+		// form cmdhelp's parseArgs treats as repeatable. `[args...]`
+		// (ellipsis inside) bakes the dots into the arg NAME, so the
+		// MCP dispatcher's BuildCLIArgs can't match input["args"] to
+		// the positional slot. Verified in cmdhelp/json.go::argRE.
+		Use:   "run <ref> [args]...",
 		Short: "Bind args to a playbook's declared spec and return the body + bound args",
 		Long: `Parse the supplied args against the playbook's declared argument spec
 (stored as the 'arguments' field on the item) and return the body with

--- a/internal/mcp/catalog_playbook.go
+++ b/internal/mcp/catalog_playbook.go
@@ -1,5 +1,13 @@
 package mcp
 
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
 // padPlaybookTool exposes the first-class playbook surface from
 // PLAN-1377 / TASK-1381. Three actions mirror the CLI (TASK-1382):
 //
@@ -42,8 +50,11 @@ var padPlaybookTool = ToolDef{
 				Description: "Pre-parsed argument map keyed by the playbook's declared argument names. Use when you've already parsed user intent into discrete values (e.g. an MCP-driven agent). Mutually compatible with raw_args — explicit args take precedence. Optional for action=run.",
 			},
 			{
+				// Note: the catalog builder's param-type recognizer
+				// understands "array<string>" specifically (not the
+				// generic "array"); see catalog.go::paramDefToToolOption.
 				Name:        "raw_args",
-				Type:        "array",
+				Type:        "array<string>",
 				Description: "Raw CLI-style argument tokens (positional values, bareword flag names, key=value pairs). The server applies the strict parsing rules from `pad playbook run`. Use when the agent is forwarding user input verbatim. Optional for action=run.",
 			},
 		},
@@ -51,8 +62,81 @@ var padPlaybookTool = ToolDef{
 	Actions: map[string]ActionFn{
 		"list": passThrough([]string{"playbook", "list"}),
 		"get":  passThrough([]string{"playbook", "show"}),
-		"run":  passThrough([]string{"playbook", "run"}),
+		// run is a custom action — the CLI's `playbook run` takes a
+		// positional ref plus arbitrary trailing tokens (positional /
+		// bareword-flag / key=value), and the MCP tool needs to
+		// translate the structured `args` map + `raw_args` slice into
+		// that token sequence before dispatching. The CLI args are
+		// flatten-and-forwarded so the server-side ParsePlaybookCLIArgs
+		// sees the same shape it would from a real shell.
+		"run": actionPlaybookRun,
 	},
+}
+
+// actionPlaybookRun is the custom dispatch for pad_playbook.action=run.
+// It flattens the MCP's structured `args` map and `raw_args` slice into
+// the CLI's positional/flag/kv token sequence so env.Dispatch's
+// BuildCLIArgs path picks them up as cmdhelp-known positional args of
+// `pad playbook run <ref> [args...]`. Explicit `args` entries win over
+// `raw_args` per the server's merge rules.
+func actionPlaybookRun(ctx context.Context, input map[string]any, env ActionEnv) (*mcp.CallToolResult, error) {
+	ref, _ := input["ref"].(string)
+	if ref == "" {
+		return mcp.NewToolResultError("pad_playbook.run requires a ref (invocation_slug, item slug, or issue ref)"), nil
+	}
+
+	// Build the trailing positional/kv/flag token list. Sort the map
+	// keys for deterministic order so tests + CLI replay stay stable.
+	var tokens []string
+	if raw, ok := input["raw_args"]; ok {
+		switch v := raw.(type) {
+		case []any:
+			for _, t := range v {
+				if s, ok := t.(string); ok && s != "" {
+					tokens = append(tokens, s)
+				}
+			}
+		case []string:
+			for _, s := range v {
+				if s != "" {
+					tokens = append(tokens, s)
+				}
+			}
+		}
+	}
+	if argsMap, ok := input["args"].(map[string]any); ok {
+		keys := make([]string, 0, len(argsMap))
+		for k := range argsMap {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			v := argsMap[k]
+			switch tv := v.(type) {
+			case bool:
+				if tv {
+					tokens = append(tokens, k)
+				}
+			case nil:
+				// Skip — caller signaled "leave unbound"; let the
+				// server's bindPlaybookArgs surface it as unbound.
+			default:
+				tokens = append(tokens, fmt.Sprintf("%s=%v", k, tv))
+			}
+		}
+	}
+
+	// Re-shape the input map so BuildCLIArgs picks up ref as the first
+	// positional and the trailing tokens as variadic-args. cmdhelp
+	// records `args[]` as the variadic slot for `playbook run`.
+	rewired := map[string]any{
+		"ref":  ref,
+		"args": tokens,
+	}
+	if ws, ok := input["workspace"].(string); ok && ws != "" {
+		rewired["workspace"] = ws
+	}
+	return env.Dispatch(ctx, []string{"playbook", "run"}, rewired)
 }
 
 const padPlaybookToolDescription = `Playbooks — first-class invokable procedures (PLAN-1377).

--- a/internal/mcp/catalog_playbook.go
+++ b/internal/mcp/catalog_playbook.go
@@ -74,19 +74,36 @@ var padPlaybookTool = ToolDef{
 }
 
 // actionPlaybookRun is the custom dispatch for pad_playbook.action=run.
-// It flattens the MCP's structured `args` map and `raw_args` slice into
-// the CLI's positional/flag/kv token sequence so env.Dispatch's
-// BuildCLIArgs path picks them up as cmdhelp-known positional args of
-// `pad playbook run <ref> [args...]`. Explicit `args` entries win over
-// `raw_args` per the server's merge rules.
+// The MCP-side input carries args as a map AND/OR raw_args as a slice;
+// the two dispatcher backends each need a different shape:
+//
+//   - HTTPHandlerDispatcher: forwards `input` to mapPlaybookRun, which
+//     accepts the original args:map shape directly and produces the
+//     POST /playbooks/{ref}/run JSON body. This path preserves
+//     explicit `false` values on flag-typed args, so an MCP caller
+//     CAN override a flag with default=true by sending args:{flag:false}.
+//
+//   - ExecDispatcher: shells out to `pad playbook run <ref> <tokens...>`.
+//     The CLI takes the variadic args slot (cmdhelp positional name
+//     `args`, repeatable=true) so we flatten args+raw_args into a CLI
+//     token sequence. Limitation: the CLI's strict parser only
+//     supports bareword flag PRESENCE (no flag=false form), so a
+//     local-stdio caller cannot override a flag-default-true value;
+//     route through HTTP/in-process MCP for that rare case.
 func actionPlaybookRun(ctx context.Context, input map[string]any, env ActionEnv) (*mcp.CallToolResult, error) {
 	ref, _ := input["ref"].(string)
 	if ref == "" {
 		return mcp.NewToolResultError("pad_playbook.run requires a ref (invocation_slug, item slug, or issue ref)"), nil
 	}
 
-	// Build the trailing positional/kv/flag token list. Sort the map
-	// keys for deterministic order so tests + CLI replay stay stable.
+	if _, isHTTP := env.Dispatcher.(*HTTPHandlerDispatcher); isHTTP {
+		// Forward as-is; mapPlaybookRun does the shape coercion and
+		// preserves structured args (including explicit false values).
+		return env.Dispatch(ctx, []string{"playbook", "run"}, input)
+	}
+
+	// Exec path — flatten into CLI tokens. Sort map keys for
+	// deterministic ordering so tests + CLI replay stay stable.
 	var tokens []string
 	if raw, ok := input["raw_args"]; ok {
 		switch v := raw.(type) {
@@ -117,6 +134,10 @@ func actionPlaybookRun(ctx context.Context, input map[string]any, env ActionEnv)
 				if tv {
 					tokens = append(tokens, k)
 				}
+				// false: skipped because the CLI parser only accepts
+				// bareword flag PRESENCE. Document this limitation in
+				// the function docstring; HTTP path covers the rare
+				// flag-default-true-override case.
 			case nil:
 				// Skip — caller signaled "leave unbound"; let the
 				// server's bindPlaybookArgs surface it as unbound.

--- a/internal/mcp/catalog_playbook.go
+++ b/internal/mcp/catalog_playbook.go
@@ -1,0 +1,87 @@
+package mcp
+
+// padPlaybookTool exposes the first-class playbook surface from
+// PLAN-1377 / TASK-1381. Three actions mirror the CLI (TASK-1382):
+//
+//   - list — workspace playbook metadata (slug, invocation_slug,
+//            trigger, status, has_arguments, summary). Same shape
+//            returned by bootstrap.playbooks and `pad playbook list`.
+//   - get  — full body + fields for one playbook, addressable by
+//            invocation_slug, item slug, or ref. Use this before
+//            invoking a playbook to read its `## Arguments` section
+//            and decide what to bind.
+//   - run  — parse args against the playbook's declared spec and
+//            return the body + bound args + any unbound required
+//            args. SIDE-EFFECT-FREE — playbooks are agent
+//            instructions; the agent executes the steps, not the
+//            server.
+//
+// All three are passThrough to the `pad playbook` CLI; the CLI is the
+// canonical entry point and the MCP tool just makes it discoverable
+// in tools/list. Same shape via the HTTP MCP dispatcher's routeTable
+// entries for clouds that don't have a local pad binary.
+
+func init() {
+	appendToCatalog(padPlaybookTool)
+}
+
+var padPlaybookTool = ToolDef{
+	Name:        "pad_playbook",
+	Description: padPlaybookToolDescription,
+	Schema: ToolSchema{
+		Workspace: true,
+		Params: []ParamDef{
+			{
+				Name:        "ref",
+				Type:        "string",
+				Description: "Playbook identifier — accepts the invocation_slug (e.g. \"ship\"), the item slug (e.g. \"cut-a-pad-release\"), or the issue ref (e.g. PLAYB-1160). Required for action=get and action=run.",
+			},
+			{
+				Name:        "args",
+				Type:        "object",
+				Description: "Pre-parsed argument map keyed by the playbook's declared argument names. Use when you've already parsed user intent into discrete values (e.g. an MCP-driven agent). Mutually compatible with raw_args — explicit args take precedence. Optional for action=run.",
+			},
+			{
+				Name:        "raw_args",
+				Type:        "array",
+				Description: "Raw CLI-style argument tokens (positional values, bareword flag names, key=value pairs). The server applies the strict parsing rules from `pad playbook run`. Use when the agent is forwarding user input verbatim. Optional for action=run.",
+			},
+		},
+	},
+	Actions: map[string]ActionFn{
+		"list": passThrough([]string{"playbook", "list"}),
+		"get":  passThrough([]string{"playbook", "show"}),
+		"run":  passThrough([]string{"playbook", "run"}),
+	},
+}
+
+const padPlaybookToolDescription = `Playbooks — first-class invokable procedures (PLAN-1377).
+
+Playbooks are agent-executed multi-step workflows that ship in a workspace's
+playbooks collection. Each can declare a kebab-case ` + "`invocation_slug`" + ` (e.g.
+"ship", "release") that maps directly to ` + "`/pad <slug>`" + ` in chat-driven skills,
+and an ` + "`## Arguments`" + ` section that names + types the inputs it expects.
+
+Actions:
+  list  — Workspace playbook catalog. Returns metadata only (no bodies):
+          ref, title, slug, invocation_slug, trigger, scope, status,
+          has_arguments, summary. Sorted with invocation_slug-bearing
+          playbooks first so user-facing /pad <slug> candidates surface
+          at the top.
+          Required: workspace.
+  get   — Full item for one playbook, including body content + structured
+          fields (which carry the canonical ` + "`arguments`" + ` JSON spec).
+          Required: workspace, ref.
+  run   — Parse args against the playbook's declared spec and return the
+          body + bound_args + any required-but-unbound entries (so the
+          agent can prompt the user instead of failing the call). Side-
+          effect-free: the playbook body is markdown instructions for the
+          agent, not a shell script — the server primes the call; the
+          agent executes the steps.
+          Required: workspace, ref.
+          Optional: args (pre-parsed map), raw_args (CLI-style tokens).
+                    Pass exactly one or merge — see the per-param docs.
+
+Use pad_playbook when an agent needs to dispatch a named procedure or read
+a playbook's declared argument contract before invoking it. For browsing
+the underlying items (search, comments, links), use pad_item.`

--- a/internal/mcp/catalog_playbook.go
+++ b/internal/mcp/catalog_playbook.go
@@ -93,7 +93,15 @@ var padPlaybookTool = ToolDef{
 func actionPlaybookRun(ctx context.Context, input map[string]any, env ActionEnv) (*mcp.CallToolResult, error) {
 	ref, _ := input["ref"].(string)
 	if ref == "" {
-		return mcp.NewToolResultError("pad_playbook.run requires a ref (invocation_slug, item slug, or issue ref)"), nil
+		// Use the structured validation envelope (matches what
+		// env.Dispatch / BuildCLIArgs produces for missing-required-arg
+		// errors) so agents can branch on error.code rather than
+		// regex-matching the message text.
+		return NewErrorResult(ErrorPayload{
+			Code:    ErrValidationFailed,
+			Message: "pad_playbook.run: missing required field 'ref'",
+			Hint:    "Pass `ref=<invocation_slug|item slug|issue ref>` (e.g. ship, cut-a-pad-release, PLAYB-1160).",
+		}), nil
 	}
 
 	if _, isHTTP := env.Dispatcher.(*HTTPHandlerDispatcher); isHTTP {

--- a/internal/mcp/catalog_playbook.go
+++ b/internal/mcp/catalog_playbook.go
@@ -97,9 +97,15 @@ func actionPlaybookRun(ctx context.Context, input map[string]any, env ActionEnv)
 	}
 
 	if _, isHTTP := env.Dispatcher.(*HTTPHandlerDispatcher); isHTTP {
-		// Forward as-is; mapPlaybookRun does the shape coercion and
-		// preserves structured args (including explicit false values).
-		return env.Dispatch(ctx, []string{"playbook", "run"}, input)
+		// Bypass env.Dispatch — its BuildCLIArgs step would choke on
+		// args:map (the cmdhelp arg `args` is a repeatable positional
+		// expecting strings). HTTPHandlerDispatcher reads the original
+		// input from context via DispatchInputFromContext, so we
+		// attach it manually and call the dispatcher directly. The
+		// resulting POST body preserves structured args including
+		// explicit false values on flag-typed entries.
+		ctx = WithDispatchInput(ctx, mergeDispatchInput(input, env.Workspace.Get(), env.RootFlags))
+		return env.Dispatcher.Dispatch(ctx, []string{"playbook", "run"}, nil)
 	}
 
 	// Exec path — flatten into CLI tokens. Sort map keys for

--- a/internal/mcp/catalog_readonly_test.go
+++ b/internal/mcp/catalog_readonly_test.go
@@ -20,7 +20,7 @@ import (
 func TestReadOnlyCatalog_AllToolsRegistered(t *testing.T) {
 	want := map[string]bool{
 		// pad_meta is from TASK-979; the read-only tools are TASK-980;
-		// pad_item is TASK-981.
+		// pad_item is TASK-981; pad_playbook is TASK-1381 (PLAN-1377).
 		"pad_meta":       false,
 		"pad_workspace":  false,
 		"pad_collection": false,
@@ -28,6 +28,7 @@ func TestReadOnlyCatalog_AllToolsRegistered(t *testing.T) {
 		"pad_role":       false,
 		"pad_search":     false,
 		"pad_item":       false,
+		"pad_playbook":   false,
 	}
 	for _, def := range Catalog {
 		if _, ok := want[def.Name]; ok {
@@ -112,6 +113,12 @@ func TestReadOnlyCatalog_ActionsMatchCmdhelp(t *testing.T) {
 		{"pad_item", "bulk-update"}:   {"item", "bulk-update"},
 		{"pad_item", "note"}:          {"item", "note"},
 		{"pad_item", "decide"}:        {"item", "decide"},
+
+		// pad_playbook actions (PLAN-1377 / TASK-1381). All three
+		// passThrough to `pad playbook <subcommand>`.
+		{"pad_playbook", "list"}: {"playbook", "list"},
+		{"pad_playbook", "get"}:  {"playbook", "show"},
+		{"pad_playbook", "run"}:  {"playbook", "run"},
 	}
 
 	// Actions whose dispatch is too custom for the cmdPath bijection —
@@ -225,6 +232,11 @@ func TestReadOnlyCatalog_ActionsDispatchExpectedCmdPath(t *testing.T) {
 		{"pad_item", "bulk-update"}:   {"item", "bulk-update"},
 		{"pad_item", "note"}:          {"item", "note"},
 		{"pad_item", "decide"}:        {"item", "decide"},
+
+		// pad_playbook actions (PLAN-1377 / TASK-1381).
+		{"pad_playbook", "list"}: {"playbook", "list"},
+		{"pad_playbook", "get"}:  {"playbook", "show"},
+		{"pad_playbook", "run"}:  {"playbook", "run"},
 	}
 
 	// Required-positional fixture: every CLI command in the v0.2
@@ -585,6 +597,24 @@ func liveCmdhelpDoc(t *testing.T) *cmdhelp.Document {
 			"item unsplit": {
 				Summary: "unsplit",
 				Args:    mkArgs("child-ref", "parent-ref"),
+				Flags:   mkFlags("workspace"),
+			},
+			// pad_playbook surface (PLAN-1377 / TASK-1381). All three
+			// passThrough to `pad playbook <subcommand>`; the live CLI
+			// adds these in TASK-1382 — the test cmdhelp stub mirrors
+			// them so the bijection assertions still hold here.
+			"playbook list": {
+				Summary: "list playbooks",
+				Flags:   mkFlags("workspace"),
+			},
+			"playbook show": {
+				Summary: "show playbook",
+				Args:    mkArgs("ref"),
+				Flags:   mkFlags("workspace"),
+			},
+			"playbook run": {
+				Summary: "run playbook",
+				Args:    []cmdhelp.Arg{{Name: "ref", Required: true}},
 				Flags:   mkFlags("workspace"),
 			},
 		},

--- a/internal/mcp/catalog_readonly_test.go
+++ b/internal/mcp/catalog_readonly_test.go
@@ -614,8 +614,11 @@ func liveCmdhelpDoc(t *testing.T) *cmdhelp.Document {
 			},
 			"playbook run": {
 				Summary: "run playbook",
-				Args:    []cmdhelp.Arg{{Name: "ref", Required: true}},
-				Flags:   mkFlags("workspace"),
+				Args: []cmdhelp.Arg{
+					{Name: "ref", Required: true},
+					{Name: "args", Required: false, Repeatable: true},
+				},
+				Flags: mkFlags("workspace"),
 			},
 		},
 	}

--- a/internal/mcp/dispatch_http.go
+++ b/internal/mcp/dispatch_http.go
@@ -865,12 +865,13 @@ func ingestFieldKVP(s string, dst map[string]any) {
 }
 
 // mapPlaybookRun handles `pad_playbook.action=run` for the HTTP MCP
-// dispatcher. The MCP catalog declares two payload shapes — `args`
-// (pre-parsed map) and `raw_args` (CLI-style tokens) — so the mapper
-// forwards both, plus the resolved {ref}, into the
-// POST /workspaces/{workspace}/playbooks/{ref}/run body. The server
-// applies the strict CLI parsing rules to raw_args via
-// ParsePlaybookCLIArgs (handlers_playbooks.go).
+// dispatcher. Accepts both the original MCP shape (args:map +
+// raw_args:[]string) and the flattened shape that
+// actionPlaybookRun emits when dispatching through ExecDispatcher
+// (args:[]string of CLI tokens). When args arrives as a slice it's
+// treated as raw_args so the server applies the strict CLI parser.
+// When it arrives as a map it's forwarded as a pre-parsed argument
+// dictionary.
 //
 // PLAN-1377 / TASK-1381.
 func mapPlaybookRun(input map[string]any) (method, path string, body []byte, err error) {
@@ -883,12 +884,42 @@ func mapPlaybookRun(input map[string]any) (method, path string, body []byte, err
 		return "", "", nil, fmt.Errorf("ref is required (invocation_slug, item slug, or issue ref)")
 	}
 	payload := map[string]any{}
-	if args, ok := input["args"]; ok && args != nil {
-		payload["args"] = args
+
+	// Coerce raw_args from any of the shapes the catalog / cli /
+	// HTTPDispatcher paths can supply. The server's parser only cares
+	// about []string, so anything else gets normalized here.
+	var rawArgs []string
+	if rv, ok := input["raw_args"]; ok && rv != nil {
+		switch v := rv.(type) {
+		case []any:
+			for _, t := range v {
+				if s, ok := t.(string); ok && s != "" {
+					rawArgs = append(rawArgs, s)
+				}
+			}
+		case []string:
+			rawArgs = append(rawArgs, v...)
+		}
 	}
-	if rawArgs, ok := input["raw_args"]; ok && rawArgs != nil {
+
+	if argv, ok := input["args"]; ok && argv != nil {
+		switch v := argv.(type) {
+		case map[string]any:
+			payload["args"] = v
+		case []any:
+			for _, t := range v {
+				if s, ok := t.(string); ok && s != "" {
+					rawArgs = append(rawArgs, s)
+				}
+			}
+		case []string:
+			rawArgs = append(rawArgs, v...)
+		}
+	}
+	if len(rawArgs) > 0 {
 		payload["raw_args"] = rawArgs
 	}
+
 	enc, err := json.Marshal(payload)
 	if err != nil {
 		return "", "", nil, fmt.Errorf("encode playbook run body: %w", err)

--- a/internal/mcp/dispatch_http.go
+++ b/internal/mcp/dispatch_http.go
@@ -863,3 +863,35 @@ func ingestFieldKVP(s string, dst map[string]any) {
 	}
 	dst[key] = val
 }
+
+// mapPlaybookRun handles `pad_playbook.action=run` for the HTTP MCP
+// dispatcher. The MCP catalog declares two payload shapes — `args`
+// (pre-parsed map) and `raw_args` (CLI-style tokens) — so the mapper
+// forwards both, plus the resolved {ref}, into the
+// POST /workspaces/{workspace}/playbooks/{ref}/run body. The server
+// applies the strict CLI parsing rules to raw_args via
+// ParsePlaybookCLIArgs (handlers_playbooks.go).
+//
+// PLAN-1377 / TASK-1381.
+func mapPlaybookRun(input map[string]any) (method, path string, body []byte, err error) {
+	workspace, _ := input["workspace"].(string)
+	if workspace == "" {
+		return "", "", nil, fmt.Errorf("workspace is required (set --workspace or pad_set_workspace)")
+	}
+	ref, _ := input["ref"].(string)
+	if ref == "" {
+		return "", "", nil, fmt.Errorf("ref is required (invocation_slug, item slug, or issue ref)")
+	}
+	payload := map[string]any{}
+	if args, ok := input["args"]; ok && args != nil {
+		payload["args"] = args
+	}
+	if rawArgs, ok := input["raw_args"]; ok && rawArgs != nil {
+		payload["raw_args"] = rawArgs
+	}
+	enc, err := json.Marshal(payload)
+	if err != nil {
+		return "", "", nil, fmt.Errorf("encode playbook run body: %w", err)
+	}
+	return http.MethodPost, "/api/v1/workspaces/" + workspace + "/playbooks/" + ref + "/run", enc, nil
+}

--- a/internal/mcp/dispatch_http_routes.go
+++ b/internal/mcp/dispatch_http_routes.go
@@ -233,6 +233,22 @@ func init() {
 			method:       http.MethodGet,
 			pathTemplate: "/api/v1/workspaces/{workspace}/agent/bootstrap",
 		}.toRouteMapper(),
+
+		// Playbook surface (PLAN-1377 / TASK-1381). list / show / run
+		// — same shape as the CLI on local stdio dispatches via
+		// ExecDispatcher, and the routeTable entries here let cloud
+		// MCP dispatch the same actions in-process. `run` carries the
+		// args/raw_args payload in the JSON body so the strict parser
+		// fires server-side.
+		"playbook list": routeSpec{
+			method:       http.MethodGet,
+			pathTemplate: "/api/v1/workspaces/{workspace}/playbooks",
+		}.toRouteMapper(),
+		"playbook show": routeSpec{
+			method:       http.MethodGet,
+			pathTemplate: "/api/v1/workspaces/{workspace}/playbooks/{ref}",
+		}.toRouteMapper(),
+		"playbook run": mapPlaybookRun,
 		"collection list": routeSpec{
 			method:       http.MethodGet,
 			pathTemplate: "/api/v1/workspaces/{workspace}/collections",


### PR DESCRIPTION
## Summary
PLAN-1377 T4 — exposes the playbook surface from TASK-1382 via MCP. Three passThrough actions match the CLI:

- `pad_playbook.list` → `pad playbook list` (metadata catalog)
- `pad_playbook.get`  → `pad playbook show <ref>` (full body + fields)
- `pad_playbook.run`  → `pad playbook run <ref>` (parse + bind args, return body). Side-effect-free.

Params: `ref` (required for get/run), `args` (pre-parsed map), `raw_args` (CLI tokens). HTTP dispatcher route entries wire the same three actions into pad-cloud's in-process path.

## Context
Implements `TASK-1381` under `PLAN-1377`.

## Test plan
- [x] `go build ./...` / `go vet ./...` clean
- [x] `go test ./internal/mcp/...` passes (bijection + dispatch tests extended)
- [x] `make check` green
- [x] `make install` rebuilt binary