### PR TITLE
feat(web): first-class playbook editor — slug validation, args builder, test invocation (TASK-1384)

### DIFF
--- a/web/src/lib/components/playbooks/PlaybookFormFields.svelte
+++ b/web/src/lib/components/playbooks/PlaybookFormFields.svelte
@@ -29,6 +29,11 @@
 		triggers: readonly string[];
 		scopes: readonly string[];
 		statuses?: readonly string[];
+		// Hides the status selector. Set to true on the create-form where
+		// the submit buttons ("Create as Draft" / "Create as Active") own
+		// the status — surfacing a select that the buttons silently
+		// override is just confusing (Codex round 2 P2).
+		hideStatus?: boolean;
 		existingPlaybooks: Item[];
 		onSlugChange: (slug: string) => void;
 		onTriggerChange: (trigger: string) => void;
@@ -50,6 +55,7 @@
 		triggers,
 		scopes,
 		statuses = ['active', 'draft', 'deprecated'],
+		hideStatus = false,
 		existingPlaybooks,
 		onSlugChange,
 		onTriggerChange,
@@ -363,19 +369,21 @@
 			</div>
 		</div>
 
-		<div class="form-row">
-			<label class="form-label" for="pbff-status">Status</label>
-			<select
-				id="pbff-status"
-				class="form-select"
-				value={status}
-				onchange={(e) => onStatusChange((e.currentTarget as HTMLSelectElement).value)}
-			>
-				{#each statuses as st (st)}
-					<option value={st}>{st}</option>
-				{/each}
-			</select>
-		</div>
+		{#if !hideStatus}
+			<div class="form-row">
+				<label class="form-label" for="pbff-status">Status</label>
+				<select
+					id="pbff-status"
+					class="form-select"
+					value={status}
+					onchange={(e) => onStatusChange((e.currentTarget as HTMLSelectElement).value)}
+				>
+					{#each statuses as st (st)}
+						<option value={st}>{st}</option>
+					{/each}
+				</select>
+			</div>
+		{/if}
 	</div>
 
 	<!-- Arguments builder -->

--- a/web/src/lib/components/playbooks/PlaybookFormFields.svelte
+++ b/web/src/lib/components/playbooks/PlaybookFormFields.svelte
@@ -1,0 +1,834 @@
+<script lang="ts">
+	import { parseFields, type Item } from '$lib/types';
+	import {
+		PLAYBOOK_ARGUMENT_TYPES,
+		isValidInvocationSlug,
+		parseArgumentsSection,
+		updateArgumentsInBody,
+		buildTestInvocation,
+		type PlaybookArgument,
+		type PlaybookArgumentType
+	} from '$lib/playbooks/arguments';
+
+	type SlugValidationState =
+		| 'empty'
+		| 'invalid-format'
+		| 'checking'
+		| 'duplicate'
+		| 'ok';
+
+	interface Props {
+		wsSlug: string;
+		selfItemId: string | null;
+		invocationSlug: string;
+		trigger: string;
+		scope: string;
+		status: string;
+		args: PlaybookArgument[];
+		bodyContent: string;
+		triggers: readonly string[];
+		scopes: readonly string[];
+		statuses?: readonly string[];
+		existingPlaybooks: Item[];
+		onSlugChange: (slug: string) => void;
+		onTriggerChange: (trigger: string) => void;
+		onScopeChange: (scope: string) => void;
+		onStatusChange: (status: string) => void;
+		onArgumentsChange: (args: PlaybookArgument[]) => void;
+		onBodyContentChange: (body: string) => void;
+	}
+
+	let {
+		wsSlug: _wsSlug,
+		selfItemId,
+		invocationSlug,
+		trigger,
+		scope,
+		status,
+		args,
+		bodyContent,
+		triggers,
+		scopes,
+		statuses = ['active', 'draft', 'deprecated'],
+		existingPlaybooks,
+		onSlugChange,
+		onTriggerChange,
+		onScopeChange,
+		onStatusChange,
+		onArgumentsChange,
+		onBodyContentChange
+	}: Props = $props();
+
+	// ── Slug validation state ──────────────────────────────────────────────
+	// `slugValidationState` reflects the latest validation check. A short
+	// debounce avoids spamming `checking` while the user is typing.
+	let slugValidationState = $state<SlugValidationState>('empty');
+	let duplicateTitle = $state<string | null>(null);
+
+	// Whether the user is in "custom trigger" mode (selected Other…).
+	// Initialize based on whether the current trigger is in the known list.
+	let customTriggerMode = $state(false);
+	let customTriggerValue = $state('');
+
+	// Used by the slug-debounce $effect.
+	let slugDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+	// Sync custom mode if the trigger doesn't match any known options.
+	$effect(() => {
+		if (trigger && triggers.length > 0 && !triggers.includes(trigger)) {
+			customTriggerMode = true;
+			customTriggerValue = trigger;
+		}
+	});
+
+	// ── Slug validation effect ─────────────────────────────────────────────
+	// Run on every change of `invocationSlug` / `existingPlaybooks` /
+	// `selfItemId`. The debounce only applies to the uniqueness check —
+	// format / empty checks resolve synchronously.
+	$effect(() => {
+		const slug = invocationSlug.trim();
+		// Cancel any pending check before scheduling a fresh one.
+		if (slugDebounceTimer) {
+			clearTimeout(slugDebounceTimer);
+			slugDebounceTimer = null;
+		}
+		if (!slug) {
+			slugValidationState = 'empty';
+			duplicateTitle = null;
+			return;
+		}
+		if (!isValidInvocationSlug(slug)) {
+			slugValidationState = 'invalid-format';
+			duplicateTitle = null;
+			return;
+		}
+		// Format is fine — start the debounced uniqueness check.
+		slugValidationState = 'checking';
+		slugDebounceTimer = setTimeout(() => {
+			const conflict = existingPlaybooks.find((p) => {
+				if (selfItemId && p.id === selfItemId) return false;
+				const f = parseFields(p);
+				return typeof f.invocation_slug === 'string' && f.invocation_slug === slug;
+			});
+			if (conflict) {
+				slugValidationState = 'duplicate';
+				duplicateTitle = conflict.title;
+			} else {
+				slugValidationState = 'ok';
+				duplicateTitle = null;
+			}
+		}, 300);
+		return () => {
+			if (slugDebounceTimer) {
+				clearTimeout(slugDebounceTimer);
+				slugDebounceTimer = null;
+			}
+		};
+	});
+
+	// ── Two-way binding between structured args and body markdown ──────────
+	//
+	// The trick is to detect which side of the two-way binding initiated
+	// the change so we don't infinite-loop. We do this by storing
+	// "signatures" of the last value we emitted on each side. If the
+	// incoming prop matches the signature we last emitted, the change
+	// came from us — skip the work. Otherwise it came from outside and
+	// we need to propagate it.
+
+	function argsSignature(list: PlaybookArgument[]): string {
+		// Use the canonical body rendering as the signature. Two arg
+		// lists that produce the same body update are equivalent for
+		// our purposes — the body wouldn't change anyway.
+		return JSON.stringify(list);
+	}
+
+	function parsedBodySignature(body: string): string {
+		return JSON.stringify(parseArgumentsSection(body));
+	}
+
+	// These trackers are seeded lazily by the effects below on first run.
+	// `null` means "uninitialized" — both effects detect this and prime
+	// the keys before any sync work. We avoid reading reactive props in
+	// the `$state` initializer so the autofixer's
+	// `state_referenced_locally` rule stays clean.
+	let lastEmittedArgsKey = $state<string | null>(null);
+	let lastSeenBodyKey = $state<string | null>(null);
+
+	// Args changed externally OR locally — if it doesn't match what we
+	// last emitted to the body, regenerate the body and emit.
+	$effect(() => {
+		const key = argsSignature(args);
+		if (lastEmittedArgsKey === null) {
+			// First run: prime both trackers without emitting anything.
+			lastEmittedArgsKey = key;
+			if (lastSeenBodyKey === null) {
+				lastSeenBodyKey = parsedBodySignature(bodyContent);
+			}
+			return;
+		}
+		if (key === lastEmittedArgsKey) return;
+		lastEmittedArgsKey = key;
+		const newBody = updateArgumentsInBody(bodyContent, args);
+		if (newBody !== bodyContent) {
+			lastSeenBodyKey = parsedBodySignature(newBody);
+			onBodyContentChange(newBody);
+		}
+	});
+
+	// Body content changed (probably from the parent's textarea). If the
+	// parsed args differ from current, emit so the structured form
+	// reflects the edit.
+	$effect(() => {
+		const key = parsedBodySignature(bodyContent);
+		if (lastSeenBodyKey === null) {
+			lastSeenBodyKey = key;
+			if (lastEmittedArgsKey === null) {
+				lastEmittedArgsKey = argsSignature(args);
+			}
+			return;
+		}
+		if (key === lastSeenBodyKey) return;
+		lastSeenBodyKey = key;
+		const parsed = parseArgumentsSection(bodyContent);
+		const currentKey = argsSignature(args);
+		const parsedKey = argsSignature(parsed);
+		if (currentKey !== parsedKey) {
+			lastEmittedArgsKey = parsedKey;
+			onArgumentsChange(parsed);
+		}
+	});
+
+	// ── Arguments builder mutators ─────────────────────────────────────────
+
+	function addArgument() {
+		const next: PlaybookArgument[] = [
+			...args,
+			{ name: `arg${args.length + 1}`, type: 'string' }
+		];
+		onArgumentsChange(next);
+	}
+
+	function removeArgument(idx: number) {
+		const next = args.filter((_, i) => i !== idx);
+		onArgumentsChange(next);
+	}
+
+	function updateArgument(idx: number, patch: Partial<PlaybookArgument>) {
+		const next = args.map((a, i) => (i === idx ? { ...a, ...patch } : a));
+		onArgumentsChange(next);
+	}
+
+	function updateArgEnum(idx: number, raw: string) {
+		const opts = raw
+			.split('|')
+			.map((s) => s.trim())
+			.filter(Boolean);
+		updateArgument(idx, { enum: opts });
+	}
+
+	function argEnumString(arg: PlaybookArgument): string {
+		return arg.enum && arg.enum.length > 0 ? arg.enum.join('|') : '';
+	}
+
+	function argDefaultString(arg: PlaybookArgument): string {
+		if (arg.default === undefined || arg.default === null) return '';
+		if (typeof arg.default === 'boolean') return arg.default ? 'true' : 'false';
+		return String(arg.default);
+	}
+
+	// ── Trigger selector handlers ──────────────────────────────────────────
+
+	function onTriggerSelect(ev: Event) {
+		const target = ev.currentTarget as HTMLSelectElement;
+		const value = target.value;
+		if (value === '__custom__') {
+			customTriggerMode = true;
+			// Keep whatever was there as the seed; emit on the custom-text input.
+			return;
+		}
+		customTriggerMode = false;
+		onTriggerChange(value);
+	}
+
+	function onCustomTriggerInput(ev: Event) {
+		const target = ev.currentTarget as HTMLInputElement;
+		customTriggerValue = target.value;
+		onTriggerChange(target.value.trim());
+	}
+
+	// ── Test invocation rendering ──────────────────────────────────────────
+
+	// Sample values keyed by argument name. Each input updates this map.
+	let sampleValues = $state<Record<string, string>>({});
+
+	function setSampleValue(name: string, value: string) {
+		sampleValues = { ...sampleValues, [name]: value };
+	}
+
+	let invocation = $derived(buildTestInvocation(invocationSlug, args, sampleValues));
+
+	let copiedKey = $state<string | null>(null);
+
+	async function copyToClipboard(key: string, text: string) {
+		try {
+			await navigator.clipboard.writeText(text);
+			copiedKey = key;
+			setTimeout(() => {
+				if (copiedKey === key) copiedKey = null;
+			}, 1500);
+		} catch {
+			// Clipboard access can fail in non-secure contexts. Swallow —
+			// the user can still select + copy by hand.
+		}
+	}
+
+	// Helper: derive the type-specific input hint shown next to a sample input.
+	function sampleHint(arg: PlaybookArgument): string {
+		if (arg.type === 'flag') return '(flag — true/false)';
+		if (arg.required) return '(required)';
+		return '(optional)';
+	}
+</script>
+
+<div class="playbook-form-fields">
+	<!-- Identity row: slug + trigger -->
+	<div class="form-section">
+		<h3 class="section-title">Identity</h3>
+		<div class="form-row">
+			<label class="form-label" for="pbff-slug">Invocation slug</label>
+			<input
+				id="pbff-slug"
+				class="form-input"
+				type="text"
+				value={invocationSlug}
+				placeholder="ship"
+				oninput={(e) => onSlugChange((e.currentTarget as HTMLInputElement).value)}
+				aria-invalid={slugValidationState === 'invalid-format' ||
+					slugValidationState === 'duplicate'}
+				aria-describedby="pbff-slug-hint"
+			/>
+			<div class="slug-hint" id="pbff-slug-hint">
+				{#if slugValidationState === 'empty'}
+					<span class="hint-muted">Leave blank for trigger-only playbooks.</span>
+				{:else if slugValidationState === 'invalid-format'}
+					<span class="hint-error"
+						>Slug must be lowercase letters, digits, and hyphens; 2+ chars; no leading/trailing hyphen.</span
+					>
+				{:else if slugValidationState === 'checking'}
+					<span class="hint-muted">Checking availability…</span>
+				{:else if slugValidationState === 'duplicate'}
+					<span class="hint-error">Already used by {duplicateTitle ?? 'another playbook'}.</span>
+				{:else if slugValidationState === 'ok'}
+					<span class="hint-ok">&check; Available</span>
+				{/if}
+			</div>
+		</div>
+
+		<div class="form-row-pair">
+			<div class="form-row">
+				<label class="form-label" for="pbff-trigger">Trigger</label>
+				<select
+					id="pbff-trigger"
+					class="form-select"
+					value={customTriggerMode ? '__custom__' : trigger}
+					onchange={onTriggerSelect}
+				>
+					{#each triggers as t (t)}
+						<option value={t}>{t}</option>
+					{/each}
+					<option value="__custom__">Other (custom trigger)…</option>
+				</select>
+				{#if customTriggerMode}
+					<input
+						class="form-input custom-trigger"
+						type="text"
+						placeholder="custom-trigger-name"
+						value={customTriggerValue}
+						oninput={onCustomTriggerInput}
+					/>
+				{/if}
+			</div>
+			<div class="form-row">
+				<label class="form-label" for="pbff-scope">Scope</label>
+				<select
+					id="pbff-scope"
+					class="form-select"
+					value={scope}
+					onchange={(e) => onScopeChange((e.currentTarget as HTMLSelectElement).value)}
+				>
+					{#each scopes as s (s)}
+						<option value={s}>{s}</option>
+					{/each}
+				</select>
+			</div>
+		</div>
+
+		<div class="form-row">
+			<label class="form-label" for="pbff-status">Status</label>
+			<select
+				id="pbff-status"
+				class="form-select"
+				value={status}
+				onchange={(e) => onStatusChange((e.currentTarget as HTMLSelectElement).value)}
+			>
+				{#each statuses as st (st)}
+					<option value={st}>{st}</option>
+				{/each}
+			</select>
+		</div>
+	</div>
+
+	<!-- Arguments builder -->
+	<div class="form-section">
+		<h3 class="section-title">Arguments</h3>
+		<p class="section-hint">
+			Structured contract for the playbook's inputs. Mirrors the <code>## Arguments</code> section in
+			the body — edits round-trip both ways.
+		</p>
+
+		{#if args.length === 0}
+			<div class="empty-args">No arguments declared. This playbook takes no inputs.</div>
+		{:else}
+			<div class="args-list">
+				{#each args as arg, idx (idx)}
+					<div class="arg-card">
+						<div class="arg-card-header">
+							<div class="form-row arg-name-row">
+								<label class="form-label" for="pbff-arg-name-{idx}">Name</label>
+								<input
+									id="pbff-arg-name-{idx}"
+									class="form-input"
+									type="text"
+									value={arg.name}
+									oninput={(e) =>
+										updateArgument(idx, {
+											name: (e.currentTarget as HTMLInputElement).value
+										})}
+								/>
+							</div>
+							<button
+								type="button"
+								class="remove-arg-btn"
+								onclick={() => removeArgument(idx)}
+								aria-label="Remove argument"
+							>
+								Remove
+							</button>
+						</div>
+						<div class="arg-card-row">
+							<div class="form-row">
+								<label class="form-label" for="pbff-arg-type-{idx}">Type</label>
+								<select
+									id="pbff-arg-type-{idx}"
+									class="form-select"
+									value={arg.type}
+									onchange={(e) =>
+										updateArgument(idx, {
+											type: (e.currentTarget as HTMLSelectElement).value as PlaybookArgumentType
+										})}
+								>
+									{#each PLAYBOOK_ARGUMENT_TYPES as t (t)}
+										<option value={t}>{t}</option>
+									{/each}
+								</select>
+							</div>
+							<div class="form-row arg-required-row">
+								<label class="form-label" for="pbff-arg-req-{idx}">Required</label>
+								<input
+									id="pbff-arg-req-{idx}"
+									type="checkbox"
+									class="arg-checkbox"
+									checked={arg.required ?? false}
+									onchange={(e) =>
+										updateArgument(idx, {
+											required: (e.currentTarget as HTMLInputElement).checked
+										})}
+								/>
+							</div>
+							<div class="form-row arg-default-row">
+								<label class="form-label" for="pbff-arg-default-{idx}">Default</label>
+								<input
+									id="pbff-arg-default-{idx}"
+									class="form-input"
+									type="text"
+									value={argDefaultString(arg)}
+									placeholder="(none)"
+									oninput={(e) =>
+										updateArgument(idx, {
+											default: (e.currentTarget as HTMLInputElement).value
+										})}
+								/>
+							</div>
+						</div>
+						<div class="form-row">
+							<label class="form-label" for="pbff-arg-desc-{idx}">Description</label>
+							<input
+								id="pbff-arg-desc-{idx}"
+								class="form-input"
+								type="text"
+								value={arg.description ?? ''}
+								placeholder="What this argument is for"
+								oninput={(e) =>
+									updateArgument(idx, {
+										description: (e.currentTarget as HTMLInputElement).value
+									})}
+							/>
+						</div>
+						{#if arg.type === 'enum'}
+							<div class="form-row">
+								<label class="form-label" for="pbff-arg-opts-{idx}">Options (pipe-separated)</label>
+								<input
+									id="pbff-arg-opts-{idx}"
+									class="form-input"
+									type="text"
+									value={argEnumString(arg)}
+									placeholder="squash|merge|rebase"
+									oninput={(e) =>
+										updateArgEnum(idx, (e.currentTarget as HTMLInputElement).value)}
+								/>
+							</div>
+						{/if}
+					</div>
+				{/each}
+			</div>
+		{/if}
+
+		<button type="button" class="add-arg-btn" onclick={addArgument}>+ Add argument</button>
+	</div>
+
+	<!-- Test invocation helper -->
+	<div class="form-section">
+		<h3 class="section-title">Test invocation</h3>
+		<p class="section-hint">
+			Type sample values to preview how this playbook gets invoked across surfaces.
+		</p>
+
+		{#if args.length > 0}
+			<div class="sample-form">
+				{#each args as arg, idx (idx)}
+					<div class="form-row sample-row">
+						<label class="form-label" for="pbff-sample-{idx}">
+							{arg.name} <span class="sample-hint">{sampleHint(arg)}</span>
+						</label>
+						{#if arg.type === 'enum' && arg.enum && arg.enum.length > 0}
+							<select
+								id="pbff-sample-{idx}"
+								class="form-select"
+								value={sampleValues[arg.name] ?? ''}
+								onchange={(e) =>
+									setSampleValue(arg.name, (e.currentTarget as HTMLSelectElement).value)}
+							>
+								<option value="">(unset)</option>
+								{#each arg.enum as opt (opt)}
+									<option value={opt}>{opt}</option>
+								{/each}
+							</select>
+						{:else if arg.type === 'flag'}
+							<select
+								id="pbff-sample-{idx}"
+								class="form-select"
+								value={sampleValues[arg.name] ?? 'false'}
+								onchange={(e) =>
+									setSampleValue(arg.name, (e.currentTarget as HTMLSelectElement).value)}
+							>
+								<option value="false">false</option>
+								<option value="true">true</option>
+							</select>
+						{:else}
+							<input
+								id="pbff-sample-{idx}"
+								class="form-input"
+								type={arg.type === 'number' ? 'number' : 'text'}
+								value={sampleValues[arg.name] ?? ''}
+								placeholder={arg.type === 'ref' ? 'TASK-5' : ''}
+								oninput={(e) =>
+									setSampleValue(arg.name, (e.currentTarget as HTMLInputElement).value)}
+							/>
+						{/if}
+					</div>
+				{/each}
+			</div>
+		{/if}
+
+		<div class="invocation-block">
+			<div class="invocation-header">
+				<span class="invocation-label">Claude Code</span>
+				<button
+					type="button"
+					class="copy-btn"
+					onclick={() => copyToClipboard('claude', invocation.claude)}
+				>
+					{copiedKey === 'claude' ? 'Copied!' : 'Copy'}
+				</button>
+			</div>
+			<pre class="invocation-code">{invocation.claude}</pre>
+		</div>
+
+		<div class="invocation-block">
+			<div class="invocation-header">
+				<span class="invocation-label">CLI</span>
+				<button
+					type="button"
+					class="copy-btn"
+					onclick={() => copyToClipboard('cli', invocation.cli)}
+				>
+					{copiedKey === 'cli' ? 'Copied!' : 'Copy'}
+				</button>
+			</div>
+			<pre class="invocation-code">{invocation.cli}</pre>
+		</div>
+
+		<div class="invocation-block">
+			<div class="invocation-header">
+				<span class="invocation-label">MCP (pad_playbook)</span>
+				<button
+					type="button"
+					class="copy-btn"
+					onclick={() => copyToClipboard('mcp', invocation.mcp)}
+				>
+					{copiedKey === 'mcp' ? 'Copied!' : 'Copy'}
+				</button>
+			</div>
+			<pre class="invocation-code">{invocation.mcp}</pre>
+		</div>
+	</div>
+</div>
+
+<style>
+	.playbook-form-fields {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-6);
+	}
+	.form-section {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-3);
+		padding: var(--space-4);
+		background: var(--bg-secondary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius-lg);
+	}
+	.section-title {
+		font-size: 0.9em;
+		font-weight: 700;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		color: var(--text-secondary);
+		margin: 0;
+	}
+	.section-hint {
+		font-size: 0.85em;
+		color: var(--text-muted);
+		margin: 0;
+	}
+	.form-row {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-1);
+	}
+	.form-row-pair {
+		display: grid;
+		grid-template-columns: 1fr 1fr;
+		gap: var(--space-3);
+	}
+	.form-label {
+		font-size: 0.78em;
+		font-weight: 600;
+		color: var(--text-secondary);
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+	}
+	.form-input,
+	.form-select {
+		padding: var(--space-2) var(--space-3);
+		background: var(--bg-tertiary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+		color: var(--text-primary);
+		font-size: 0.92em;
+	}
+	.form-input:focus,
+	.form-select:focus {
+		border-color: var(--accent-blue);
+		outline: none;
+	}
+	.form-input[aria-invalid='true'] {
+		border-color: var(--accent-orange);
+	}
+	.custom-trigger {
+		margin-top: var(--space-2);
+	}
+	.slug-hint {
+		font-size: 0.8em;
+		min-height: 1.2em;
+		margin-top: 2px;
+	}
+	.hint-muted {
+		color: var(--text-muted);
+	}
+	.hint-error {
+		color: var(--accent-orange);
+	}
+	.hint-ok {
+		color: var(--accent-green);
+	}
+	.empty-args {
+		padding: var(--space-3);
+		font-size: 0.85em;
+		color: var(--text-muted);
+		font-style: italic;
+		background: var(--bg-tertiary);
+		border-radius: var(--radius);
+	}
+	.args-list {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-3);
+	}
+	.arg-card {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-2);
+		padding: var(--space-3);
+		background: var(--bg-tertiary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+	}
+	.arg-card-header {
+		display: flex;
+		align-items: flex-end;
+		gap: var(--space-2);
+	}
+	.arg-name-row {
+		flex: 1;
+	}
+	.arg-card-row {
+		display: grid;
+		grid-template-columns: 1fr auto 1fr;
+		gap: var(--space-3);
+		align-items: end;
+	}
+	.arg-required-row {
+		align-items: center;
+	}
+	.arg-checkbox {
+		width: 18px;
+		height: 18px;
+		accent-color: var(--accent-blue);
+		cursor: pointer;
+	}
+	.arg-default-row {
+		min-width: 0;
+	}
+	.remove-arg-btn {
+		padding: var(--space-1) var(--space-2);
+		font-size: 0.78em;
+		font-weight: 600;
+		border-radius: var(--radius);
+		background: var(--bg-secondary);
+		color: var(--accent-orange);
+		border: 1px solid var(--border);
+		cursor: pointer;
+		white-space: nowrap;
+	}
+	.remove-arg-btn:hover {
+		background: color-mix(in srgb, var(--accent-orange) 12%, var(--bg-secondary));
+	}
+	.add-arg-btn {
+		align-self: flex-start;
+		padding: var(--space-2) var(--space-4);
+		font-size: 0.85em;
+		font-weight: 600;
+		border-radius: var(--radius);
+		background: var(--bg-tertiary);
+		color: var(--text-primary);
+		border: 1px dashed var(--border);
+		cursor: pointer;
+	}
+	.add-arg-btn:hover {
+		border-color: var(--accent-blue);
+		color: var(--accent-blue);
+	}
+	.sample-form {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-2);
+		padding: var(--space-3);
+		background: var(--bg-tertiary);
+		border-radius: var(--radius);
+		margin-bottom: var(--space-3);
+	}
+	.sample-row {
+		gap: var(--space-1);
+	}
+	.sample-hint {
+		font-weight: 400;
+		text-transform: none;
+		letter-spacing: normal;
+		color: var(--text-muted);
+		font-size: 0.95em;
+	}
+	.invocation-block {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-1);
+		margin-top: var(--space-3);
+	}
+	.invocation-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: var(--space-2);
+	}
+	.invocation-label {
+		font-size: 0.78em;
+		font-weight: 700;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		color: var(--text-secondary);
+	}
+	.copy-btn {
+		padding: 2px var(--space-2);
+		font-size: 0.75em;
+		font-weight: 600;
+		border-radius: var(--radius);
+		background: var(--bg-tertiary);
+		color: var(--text-secondary);
+		border: 1px solid var(--border);
+		cursor: pointer;
+	}
+	.copy-btn:hover {
+		color: var(--accent-blue);
+		border-color: var(--accent-blue);
+	}
+	.invocation-code {
+		margin: 0;
+		padding: var(--space-3);
+		background: var(--bg-tertiary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+		color: var(--text-primary);
+		font-family: var(--font-mono);
+		font-size: 0.82em;
+		line-height: 1.5;
+		white-space: pre-wrap;
+		word-break: break-word;
+		overflow-x: auto;
+	}
+	code {
+		font-family: var(--font-mono);
+		font-size: 0.95em;
+		background: var(--bg-tertiary);
+		padding: 1px 4px;
+		border-radius: 3px;
+	}
+	@media (max-width: 768px) {
+		.form-row-pair {
+			grid-template-columns: 1fr;
+		}
+		.arg-card-row {
+			grid-template-columns: 1fr;
+		}
+	}
+</style>

--- a/web/src/lib/playbooks/arguments.ts
+++ b/web/src/lib/playbooks/arguments.ts
@@ -290,19 +290,64 @@ export function parseArgumentsSection(body: string): PlaybookArgument[] {
  *
  * Empty-string defaults are dropped — they're indistinguishable from
  * "no default" and the server treats them the same.
+ *
+ * Defaults are coerced to the type the arg declares before
+ * serialization (Codex round 4 P2). The UI input always types into a
+ * string, but `flag` defaults should be booleans and `number` defaults
+ * should be numbers — the server passes them through opaquely so the
+ * client is responsible for the canonical typing.
  */
 export function argumentsToJSON(args: PlaybookArgument[]): string {
 	const cleaned = args.map((arg) => {
 		const out: Record<string, unknown> = { name: arg.name, type: arg.type };
 		if (arg.required) out.required = true;
 		if (arg.default !== undefined && arg.default !== '' && arg.default !== null) {
-			out.default = arg.default;
+			out.default = coerceDefaultForType(arg.type, arg.default);
 		}
 		if (arg.description) out.description = arg.description;
 		if (arg.enum && arg.enum.length > 0) out.enum = arg.enum;
 		return out;
 	});
 	return JSON.stringify(cleaned);
+}
+
+/**
+ * coerceDefaultForType applies type-aware coercion to a default value
+ * collected from the UI. Mirrors the parsing rules in
+ * `coerceDefaultValue` (used by parseArgumentLine) so round-trips
+ * between the markdown body, the structured form, and the persisted
+ * JSON stay consistent.
+ *
+ * - flag: "true"/"false" → boolean; anything else falls back to the
+ *   original value (the schema validator will surface it)
+ * - number: numeric strings → number; non-numeric falls through
+ * - other types: pass through unchanged
+ */
+function coerceDefaultForType(
+	type: PlaybookArgumentType,
+	raw: string | boolean | number
+): string | boolean | number {
+	if (type === 'flag') {
+		if (typeof raw === 'boolean') return raw;
+		if (typeof raw === 'string') {
+			const lower = raw.trim().toLowerCase();
+			if (lower === 'true') return true;
+			if (lower === 'false') return false;
+		}
+		return raw;
+	}
+	if (type === 'number') {
+		if (typeof raw === 'number') return raw;
+		if (typeof raw === 'string') {
+			const trimmed = raw.trim();
+			if (/^-?\d+(?:\.\d+)?$/.test(trimmed)) {
+				const n = Number(trimmed);
+				if (Number.isFinite(n)) return n;
+			}
+		}
+		return raw;
+	}
+	return raw;
 }
 
 /** argumentsFromJSON parses the stored `arguments` field back into the

--- a/web/src/lib/playbooks/arguments.ts
+++ b/web/src/lib/playbooks/arguments.ts
@@ -1,0 +1,413 @@
+/**
+ * Playbook argument spec — the structured form of the body's `## Arguments`
+ * section. Mirrors the server-side `PlaybookArgumentSpec` shape
+ * (`internal/server/handlers_playbooks.go`).
+ *
+ * Five types per PLAN-1377's design:
+ *   - ref     issue ID (TASK-5) or item slug
+ *   - string  free-form text
+ *   - flag    presence-or-absent boolean (no value)
+ *   - enum    one of a fixed list (carries `enum` options)
+ *   - number  finite float
+ *
+ * `default` is opaque — agents handle non-literal defaults like
+ * "current git branch" themselves; the editor stores whatever the
+ * user typed.
+ */
+export type PlaybookArgumentType = 'ref' | 'string' | 'flag' | 'enum' | 'number';
+
+export interface PlaybookArgument {
+	name: string;
+	type: PlaybookArgumentType;
+	required?: boolean;
+	default?: string | boolean | number;
+	description?: string;
+	enum?: string[];
+}
+
+export const PLAYBOOK_ARGUMENT_TYPES: readonly PlaybookArgumentType[] = [
+	'string',
+	'ref',
+	'flag',
+	'enum',
+	'number'
+] as const;
+
+/**
+ * INVOCATION_SLUG_PATTERN mirrors the server-side regex
+ * (`collections.PlaybookInvocationSlugPattern`):
+ *   - 2+ chars (single-letter slugs would shadow NL tokens)
+ *   - lowercase letters, digits, hyphens
+ *   - no leading/trailing hyphen
+ *
+ * Kept lockstep with `internal/collections/templates.go::PlaybookInvocationSlugPattern`.
+ * Drift between the two means the client allows slugs the server rejects
+ * (or vice-versa), which surfaces as a confusing save error.
+ */
+export const INVOCATION_SLUG_PATTERN = /^[a-z0-9][a-z0-9-]*[a-z0-9]$/;
+
+/** Returns true if the slug matches the canonical kebab-case pattern. */
+export function isValidInvocationSlug(slug: string): boolean {
+	return INVOCATION_SLUG_PATTERN.test(slug);
+}
+
+/** Skeleton body inserted when a new playbook is created. The four
+ * sections match the PLAN-1377 design vocabulary; the user can delete
+ * sections that don't apply. */
+export const PLAYBOOK_SKELETON_BODY = `One-paragraph summary of what this playbook does and when to run it.
+
+## Arguments
+
+- \`example\` (string, required) — describe what this argument is for
+
+## Steps
+
+1. First step — describe it
+2. Second step — describe it
+3. Third step — describe it
+
+## Defaults
+
+Notes on default behavior, environment expectations, or assumed context.
+
+## Stop conditions
+
+When to stop running the playbook and ask the user (errors that need
+human judgment, ambiguous state, missing requirements).
+`;
+
+const ARGUMENTS_HEADING = /^##\s+Arguments\s*$/m;
+
+/**
+ * splitAroundArguments finds the `## Arguments` section in `body`
+ * (case-insensitive on the heading) and returns the three pieces around
+ * it: text before the heading, the section's body (between the heading
+ * and the next `## ` heading), and the text from that next heading
+ * onward.
+ *
+ * Returns null when the body has no `## Arguments` heading at all.
+ * The caller decides whether to insert one or skip the update.
+ */
+export function splitAroundArguments(body: string): {
+	before: string;
+	section: string;
+	after: string;
+} | null {
+	const match = ARGUMENTS_HEADING.exec(body);
+	if (!match) return null;
+	const headingStart = match.index;
+	const headingEnd = headingStart + match[0].length;
+	// Find the next `## ` heading after the Arguments heading. Allow a
+	// trailing newline before it. The regex is anchored at line start.
+	const tail = body.slice(headingEnd);
+	const nextHeadingRe = /\n##\s+\S/;
+	const nextMatch = nextHeadingRe.exec(tail);
+	const sectionEnd = nextMatch ? headingEnd + nextMatch.index : body.length;
+	return {
+		before: body.slice(0, headingStart),
+		// Include the heading line itself so the replacement is canonical.
+		section: body.slice(headingStart, sectionEnd),
+		after: body.slice(sectionEnd)
+	};
+}
+
+/**
+ * formatArgumentLine produces the canonical one-line markdown rendering
+ * of a single PlaybookArgument. The grammar is what parseArgumentLine
+ * accepts (round-trip safe).
+ *
+ * Examples:
+ *   - `target` (string, required) — what to ship
+ *   - `stop-after-each` (flag, default=false) — pause for confirmation
+ *   - `merge-strategy` (enum, default=squash, options: squash|merge|rebase) — how
+ */
+export function formatArgumentLine(arg: PlaybookArgument): string {
+	const bits: string[] = [arg.type];
+	if (arg.required) bits.push('required');
+	if (arg.default !== undefined && arg.default !== '' && arg.default !== null) {
+		bits.push(`default=${stringifyDefault(arg.default)}`);
+	}
+	if (arg.type === 'enum' && arg.enum && arg.enum.length > 0) {
+		bits.push(`options: ${arg.enum.join('|')}`);
+	}
+	const inner = bits.join(', ');
+	const desc = arg.description ? ` — ${arg.description}` : '';
+	return `- \`${arg.name}\` (${inner})${desc}`;
+}
+
+function stringifyDefault(v: string | boolean | number): string {
+	if (typeof v === 'boolean') return v ? 'true' : 'false';
+	if (typeof v === 'number') return String(v);
+	return v;
+}
+
+/**
+ * renderArgumentsSection produces the full `## Arguments` section as a
+ * string (heading + blank line + one bullet per argument + trailing
+ * blank line). Empty arg list returns just the heading + a placeholder
+ * note so the section stays discoverable when the user deletes all args.
+ */
+export function renderArgumentsSection(args: PlaybookArgument[]): string {
+	if (args.length === 0) {
+		return `## Arguments\n\n(No arguments — this playbook takes no inputs.)\n`;
+	}
+	const lines = args.map(formatArgumentLine);
+	return `## Arguments\n\n${lines.join('\n')}\n`;
+}
+
+/**
+ * updateArgumentsInBody splices a fresh `## Arguments` section into
+ * `body`, preserving everything before and after. If the body has no
+ * existing `## Arguments` heading, the new section is appended (with a
+ * leading blank line so it doesn't collide with the prior content).
+ *
+ * Used to keep the structured form's view of arguments in sync with
+ * the markdown body: the form is canonical, the markdown is the
+ * human-readable mirror.
+ */
+export function updateArgumentsInBody(body: string, args: PlaybookArgument[]): string {
+	const newSection = renderArgumentsSection(args).replace(/\n+$/, '\n');
+	const split = splitAroundArguments(body);
+	if (split) {
+		// Trim trailing newlines on `before` then re-add a single blank
+		// line so we don't accumulate gaps on repeated round-trips.
+		const before = split.before.replace(/\n+$/, '');
+		const after = split.after.replace(/^\n+/, '');
+		const pieces: string[] = [];
+		if (before) pieces.push(before, '\n\n');
+		pieces.push(newSection);
+		if (after) pieces.push('\n', after);
+		return pieces.join('');
+	}
+	// No existing Arguments heading — append.
+	const trimmed = body.replace(/\n+$/, '');
+	const prefix = trimmed.length > 0 ? `${trimmed}\n\n` : '';
+	return `${prefix}${newSection}`;
+}
+
+const BULLET_RE = /^\s*-\s*`([^`]+)`\s*(?:\(([^)]*)\))?\s*(?:[—–-]\s*(.*))?$/;
+
+/**
+ * parseArgumentLine extracts a single PlaybookArgument from a bullet
+ * line in canonical or near-canonical form. Returns null if the line
+ * doesn't look like an argument bullet (so the caller can ignore prose
+ * lines mixed into the section).
+ *
+ * Recognized parenthetical tokens:
+ *   - type (first bare word matching PLAYBOOK_ARGUMENT_TYPES)
+ *   - "required"
+ *   - "default=<value>"
+ *   - "options: a|b|c" or "enum: a|b|c" (for enum types)
+ *
+ * Unknown tokens are ignored — the parser is permissive on input so
+ * hand-written sections don't lose data on a round-trip-then-re-render.
+ */
+export function parseArgumentLine(line: string): PlaybookArgument | null {
+	const m = BULLET_RE.exec(line);
+	if (!m) return null;
+	const name = m[1].trim();
+	const inner = (m[2] || '').trim();
+	const description = (m[3] || '').trim();
+	if (!name) return null;
+
+	const arg: PlaybookArgument = { name, type: 'string' };
+	if (description) arg.description = description;
+	if (!inner) return arg;
+
+	// Split on commas that are NOT inside `options: a|b|c` — but we
+	// treat each segment independently and look for `options:` /
+	// `enum:` prefixes anywhere. A two-pass split is unnecessary here
+	// because pipes can't legitimately appear in other tokens.
+	const segments = inner.split(',').map((s) => s.trim()).filter(Boolean);
+	for (const seg of segments) {
+		const lower = seg.toLowerCase();
+		if ((PLAYBOOK_ARGUMENT_TYPES as readonly string[]).includes(lower)) {
+			arg.type = lower as PlaybookArgumentType;
+			continue;
+		}
+		if (lower === 'required') {
+			arg.required = true;
+			continue;
+		}
+		if (lower === 'optional') {
+			// Explicit optional marker — already the default, but tolerate
+			// it in hand-written sections.
+			arg.required = false;
+			continue;
+		}
+		const defMatch = /^default\s*=\s*(.+)$/i.exec(seg);
+		if (defMatch) {
+			arg.default = coerceDefaultValue(defMatch[1].trim());
+			continue;
+		}
+		const optMatch = /^(?:options|enum)\s*[:=]\s*(.+)$/i.exec(seg);
+		if (optMatch) {
+			arg.enum = optMatch[1]
+				.split('|')
+				.map((s) => s.trim())
+				.filter(Boolean);
+			continue;
+		}
+		// Unknown segment — drop it. The canonical formatter will
+		// re-emit only well-formed tokens on the next round-trip.
+	}
+	return arg;
+}
+
+function coerceDefaultValue(raw: string): string | boolean | number {
+	if (raw === 'true') return true;
+	if (raw === 'false') return false;
+	if (/^-?\d+(?:\.\d+)?$/.test(raw)) {
+		const n = Number(raw);
+		if (Number.isFinite(n)) return n;
+	}
+	return raw;
+}
+
+/**
+ * parseArgumentsSection reads the `## Arguments` section out of the
+ * playbook body and returns the structured arg list. Lines that aren't
+ * argument bullets are silently dropped (the section can carry intro
+ * prose).
+ */
+export function parseArgumentsSection(body: string): PlaybookArgument[] {
+	const split = splitAroundArguments(body);
+	if (!split) return [];
+	// Strip the heading line itself.
+	const lines = split.section.split('\n');
+	const out: PlaybookArgument[] = [];
+	for (const line of lines) {
+		const arg = parseArgumentLine(line);
+		if (arg) out.push(arg);
+	}
+	return out;
+}
+
+/**
+ * argumentsToJSON serializes the structured arg list into the JSON
+ * shape stored in the playbook item's `arguments` field. Returns "[]"
+ * for an empty list so the field is always valid JSON.
+ *
+ * Empty-string defaults are dropped — they're indistinguishable from
+ * "no default" and the server treats them the same.
+ */
+export function argumentsToJSON(args: PlaybookArgument[]): string {
+	const cleaned = args.map((arg) => {
+		const out: Record<string, unknown> = { name: arg.name, type: arg.type };
+		if (arg.required) out.required = true;
+		if (arg.default !== undefined && arg.default !== '' && arg.default !== null) {
+			out.default = arg.default;
+		}
+		if (arg.description) out.description = arg.description;
+		if (arg.enum && arg.enum.length > 0) out.enum = arg.enum;
+		return out;
+	});
+	return JSON.stringify(cleaned);
+}
+
+/** argumentsFromJSON parses the stored `arguments` field back into the
+ * structured form. Returns [] on any decode failure so the form
+ * gracefully falls back to "no args declared" rather than crashing on
+ * malformed legacy data. */
+export function argumentsFromJSON(raw: unknown): PlaybookArgument[] {
+	if (raw == null) return [];
+	let parsed: unknown = raw;
+	if (typeof raw === 'string') {
+		if (raw.trim() === '') return [];
+		try {
+			parsed = JSON.parse(raw);
+		} catch {
+			return [];
+		}
+	}
+	if (!Array.isArray(parsed)) return [];
+	return parsed
+		.map((entry): PlaybookArgument | null => {
+			if (!entry || typeof entry !== 'object') return null;
+			const e = entry as Record<string, unknown>;
+			const name = typeof e.name === 'string' ? e.name : '';
+			if (!name) return null;
+			const type = typeof e.type === 'string' ? (e.type as PlaybookArgumentType) : 'string';
+			const arg: PlaybookArgument = { name, type };
+			if (e.required === true) arg.required = true;
+			if (e.default !== undefined && e.default !== null) {
+				arg.default = e.default as PlaybookArgument['default'];
+			}
+			if (typeof e.description === 'string' && e.description) arg.description = e.description;
+			if (Array.isArray(e.enum)) {
+				arg.enum = (e.enum as unknown[]).filter((v): v is string => typeof v === 'string');
+			}
+			return arg;
+		})
+		.filter((a): a is PlaybookArgument => a !== null);
+}
+
+/**
+ * buildTestInvocation renders the example commands for the
+ * "Test invocation" helper. Returns three forms so power users can
+ * see each surface side by side:
+ *   - claude: `/pad <slug> <tokens>` (agent NL form)
+ *   - cli:    `pad playbook run <slug> [tokens]` (strict positional form)
+ *   - mcp:    `pad_playbook { action: "run", ref: "<slug>", args: {...} }`
+ *
+ * `values` is keyed by argument name and carries the user-supplied
+ * sample input for each spec entry. Empty/unset values are skipped so
+ * the rendered command doesn't show empty=`= ` pairs.
+ */
+export interface TestInvocationRendering {
+	claude: string;
+	cli: string;
+	mcp: string;
+}
+
+export function buildTestInvocation(
+	slug: string,
+	args: PlaybookArgument[],
+	values: Record<string, string>
+): TestInvocationRendering {
+	const safeSlug = slug || '<slug>';
+	const claudeTokens: string[] = [];
+	const cliTokens: string[] = [];
+	const mcpArgs: Record<string, unknown> = {};
+
+	for (const arg of args) {
+		const raw = (values[arg.name] ?? '').trim();
+		if (arg.type === 'flag') {
+			if (raw === 'true' || raw === '1' || raw === 'yes') {
+				claudeTokens.push(arg.name);
+				cliTokens.push(arg.name);
+				mcpArgs[arg.name] = true;
+			}
+			continue;
+		}
+		if (!raw) continue;
+		const value = coerceSampleValue(arg, raw);
+		if (arg.required) {
+			// Required args go positional in claude + CLI form.
+			claudeTokens.push(String(value));
+			cliTokens.push(String(value));
+		} else {
+			claudeTokens.push(`${arg.name}=${value}`);
+			cliTokens.push(`${arg.name}=${value}`);
+		}
+		mcpArgs[arg.name] = value;
+	}
+
+	return {
+		claude: `/pad ${safeSlug}${claudeTokens.length ? ' ' + claudeTokens.join(' ') : ''}`,
+		cli: `pad playbook run ${safeSlug}${cliTokens.length ? ' ' + cliTokens.join(' ') : ''}`,
+		mcp: JSON.stringify(
+			{ action: 'run', ref: safeSlug, args: mcpArgs },
+			null,
+			2
+		)
+	};
+}
+
+function coerceSampleValue(arg: PlaybookArgument, raw: string): string | number {
+	if (arg.type === 'number') {
+		const n = Number(raw);
+		if (Number.isFinite(n)) return n;
+	}
+	return raw;
+}

--- a/web/src/routes/[username]/[workspace]/playbooks/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/playbooks/+page.svelte
@@ -324,6 +324,7 @@
 								triggers={createTriggers}
 								scopes={createScopes}
 								statuses={STATUSES}
+								hideStatus={true}
 								existingPlaybooks={playbooks}
 								onSlugChange={(s) => (newInvocationSlug = s)}
 								onTriggerChange={(t) => (newTrigger = t)}

--- a/web/src/routes/[username]/[workspace]/playbooks/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/playbooks/+page.svelte
@@ -110,13 +110,17 @@
 
 	// Snap the create-form selections into the effective list when it changes,
 	// so the <select> never displays a phantom value that isn't in its <option>s.
+	// Only snap while the new-form is CLOSED — once the user opens the form,
+	// they may type a custom trigger (via PlaybookFormFields' "Other…" mode)
+	// that isn't in `createTriggers`. Snapping during an open form silently
+	// overwrites that custom value (Codex round 1 P2).
 	$effect(() => {
-		if (createTriggers.length > 0 && !createTriggers.includes(newTrigger)) {
+		if (!showNewForm && createTriggers.length > 0 && !createTriggers.includes(newTrigger)) {
 			newTrigger = createTriggers[0];
 		}
 	});
 	$effect(() => {
-		if (createScopes.length > 0 && !createScopes.includes(newScope)) {
+		if (!showNewForm && createScopes.length > 0 && !createScopes.includes(newScope)) {
 			newScope = createScopes[0];
 		}
 	});
@@ -239,10 +243,23 @@
 		duplicating = item.slug;
 		try {
 			const fields = parseFields(item);
+			const dupFields: Record<string, unknown> = {
+				status: 'draft',
+				trigger: fields.trigger ?? 'manual',
+				scope: fields.scope ?? 'all'
+			};
+			// Carry forward the structured `arguments` contract so a duplicated
+			// playbook keeps its arg spec — otherwise the copy's body still
+			// describes arguments but the queryable form is empty (Codex round
+			// 1 P3). invocation_slug is intentionally NOT carried; the original
+			// owns the slug and a duplicate would clash on the unique index.
+			if (fields.arguments !== undefined && fields.arguments !== null) {
+				dupFields.arguments = fields.arguments;
+			}
 			await api.items.create(wsSlug, 'playbooks', {
 				title: `${item.title} (copy)`,
 				content: item.content,
-				fields: JSON.stringify({ status: 'draft', trigger: fields.trigger ?? 'manual', scope: fields.scope ?? 'all' })
+				fields: JSON.stringify(dupFields)
 			});
 			toastStore.show('Playbook duplicated as draft', 'success');
 			await loadPlaybooks(wsSlug);

--- a/web/src/routes/[username]/[workspace]/playbooks/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/playbooks/+page.svelte
@@ -4,9 +4,16 @@
 	import { api } from '$lib/api/client';
 	import { parseFields, parseSchema, itemUrlId, type Collection, type Item } from '$lib/types';
 	import { toastStore } from '$lib/stores/toast.svelte';
+	import PlaybookFormFields from '$lib/components/playbooks/PlaybookFormFields.svelte';
+	import {
+		PLAYBOOK_SKELETON_BODY,
+		argumentsToJSON,
+		type PlaybookArgument
+	} from '$lib/playbooks/arguments';
 
 	const TRIGGERS = ['on-implement', 'on-triage', 'on-release', 'on-plan', 'on-review', 'on-deploy', 'manual'] as const;
 	const SCOPES = ['all', 'backend', 'frontend', 'mobile', 'devops'] as const;
+	const STATUSES = ['active', 'draft', 'deprecated'] as const;
 	const STATUS_ORDER: Record<string, number> = { active: 0, draft: 1, deprecated: 2 };
 	let wsSlug = $derived(page.params.workspace ?? '');
 	let username = $derived(page.params.username ?? '');
@@ -25,7 +32,27 @@
 	let newTitle = $state('');
 	let newTrigger = $state<string>('manual');
 	let newScope = $state<string>('all');
+	let newStatus = $state<string>('draft');
 	let newContent = $state('');
+	let newInvocationSlug = $state('');
+	let newArgs = $state<PlaybookArgument[]>([]);
+	// Tracks whether we've already seeded the skeleton for the current
+	// "open new form" session — so re-opens without `resetForm` (shouldn't
+	// happen but defensively) don't clobber edited content.
+	let skeletonSeeded = $state(false);
+
+	// Pre-fill the textarea with the skeleton body when the user opens
+	// the new-form panel from a closed state. Only seed when content is
+	// empty so subsequent renders don't clobber a draft.
+	$effect(() => {
+		if (showNewForm && !skeletonSeeded && newContent === '') {
+			newContent = PLAYBOOK_SKELETON_BODY;
+			skeletonSeeded = true;
+		}
+		if (!showNewForm) {
+			skeletonSeeded = false;
+		}
+	});
 
 	$effect(() => {
 		if (wsSlug) {
@@ -159,12 +186,25 @@
 	async function createPlaybook(status: string) {
 		if (!newTitle.trim()) return;
 		try {
+			const fieldsObj: Record<string, unknown> = {
+				status,
+				trigger: newTrigger,
+				scope: newScope,
+				// `arguments` is stored as a JSON value (array of objects),
+				// NOT a stringified string — the field type is `json`.
+				// Mirrors internal/collections/templates_startup_ship.go.
+				arguments: JSON.parse(argumentsToJSON(newArgs))
+			};
+			// Omit empty slug entirely rather than emitting "".
+			if (newInvocationSlug.trim()) {
+				fieldsObj.invocation_slug = newInvocationSlug.trim();
+			}
 			await api.items.create(wsSlug, 'playbooks', {
-				title: newTitle.trim(), content: newContent,
-				fields: JSON.stringify({ status, trigger: newTrigger, scope: newScope })
+				title: newTitle.trim(),
+				content: newContent,
+				fields: JSON.stringify(fieldsObj)
 			});
-			newTitle = ''; newTrigger = 'manual'; newScope = 'all'; newContent = '';
-			showNewForm = false;
+			resetForm();
 			toastStore.show(`Playbook created as ${status}`, 'success');
 			await loadPlaybooks(wsSlug);
 		} catch { toastStore.show('Failed to create playbook', 'error'); }
@@ -212,7 +252,17 @@
 
 	function clearFilters() { searchQuery = ''; filterTrigger = ''; filterScope = ''; }
 
-	function resetForm() { showNewForm = false; newTitle = ''; newTrigger = 'manual'; newScope = 'all'; newContent = ''; }
+	function resetForm() {
+		showNewForm = false;
+		newTitle = '';
+		newTrigger = 'manual';
+		newScope = 'all';
+		newStatus = 'draft';
+		newContent = '';
+		newInvocationSlug = '';
+		newArgs = [];
+		skeletonSeeded = false;
+	}
 	function statusLabel(s: string) { return s === 'active' ? 'Active' : s === 'deprecated' ? 'Deprecated' : 'Draft'; }
 	function nextStatusLabel(s: string) { return s === 'active' ? 'Mark as Draft' : s === 'draft' ? 'Mark as Active' : 'Mark as Draft'; }
 </script>
@@ -242,26 +292,40 @@
 						<label class="form-label" for="pb-title">Title</label>
 						<input id="pb-title" type="text" bind:value={newTitle} placeholder="e.g. Implementation Playbook" class="form-input" />
 					</div>
-					<div class="form-row-pair">
-						<div class="form-row">
-							<label class="form-label" for="pb-trigger">Trigger</label>
-							<select id="pb-trigger" bind:value={newTrigger} class="form-select">
-								{#each createTriggers as t (t)}<option value={t}>{t}</option>{/each}
-							</select>
+
+					<div class="new-form-grid">
+						<div class="new-form-sidebar">
+							<PlaybookFormFields
+								{wsSlug}
+								selfItemId={null}
+								invocationSlug={newInvocationSlug}
+								trigger={newTrigger}
+								scope={newScope}
+								status={newStatus}
+								args={newArgs}
+								bodyContent={newContent}
+								triggers={createTriggers}
+								scopes={createScopes}
+								statuses={STATUSES}
+								existingPlaybooks={playbooks}
+								onSlugChange={(s) => (newInvocationSlug = s)}
+								onTriggerChange={(t) => (newTrigger = t)}
+								onScopeChange={(s) => (newScope = s)}
+								onStatusChange={(s) => (newStatus = s)}
+								onArgumentsChange={(a) => (newArgs = a)}
+								onBodyContentChange={(b) => (newContent = b)}
+							/>
 						</div>
-						<div class="form-row">
-							<label class="form-label" for="pb-scope">Scope</label>
-							<select id="pb-scope" bind:value={newScope} class="form-select">
-								{#each createScopes as s (s)}<option value={s}>{s}</option>{/each}
-							</select>
+						<div class="new-form-main">
+							<label class="form-label" for="pb-content">Body</label>
+							<textarea
+								id="pb-content"
+								bind:value={newContent}
+								placeholder="Describe what this playbook does, its arguments, steps, defaults, and stop conditions."
+								class="form-textarea"
+								rows="20"
+							></textarea>
 						</div>
-					</div>
-					<div class="form-row">
-						<label class="form-label" for="pb-content">Workflow Steps</label>
-						<textarea id="pb-content" bind:value={newContent} placeholder="1. First step
-2. Second step
-   some command here
-3. Third step" class="form-textarea" rows="10"></textarea>
 					</div>
 				</div>
 				<div class="form-actions">
@@ -428,6 +492,9 @@
 	.action-danger:hover { background: color-mix(in srgb, var(--accent-orange) 15%, var(--bg-tertiary)); color: var(--accent-orange); }
 	.delete-confirm { display: flex; align-items: center; gap: var(--space-2); font-size: 0.8em; color: var(--accent-orange); font-weight: 600; }
 	.new-form { background: var(--bg-secondary); border: 1px solid var(--accent-blue); border-radius: var(--radius-lg); padding: var(--space-5); margin-bottom: var(--space-6); }
+	.new-form-grid { display: grid; grid-template-columns: minmax(0, 1fr) minmax(0, 1.2fr); gap: var(--space-4); align-items: start; margin-top: var(--space-2); }
+	.new-form-sidebar { min-width: 0; }
+	.new-form-main { display: flex; flex-direction: column; gap: var(--space-1); min-width: 0; }
 	.new-form h2 { font-size: 1.1em; margin-bottom: var(--space-4); }
 	.form-fields { display: flex; flex-direction: column; gap: var(--space-4); }
 	.form-row { display: flex; flex-direction: column; gap: var(--space-1); }
@@ -444,6 +511,9 @@
 	.btn-draft { background: var(--bg-tertiary); color: var(--text-primary); border: 1px solid var(--border); }
 	.btn-secondary { background: transparent; color: var(--text-secondary); }
 	.btn-secondary:hover:not(:disabled) { color: var(--text-primary); opacity: 1; }
+	@media (max-width: 1024px) {
+		.new-form-grid { grid-template-columns: 1fr; }
+	}
 	@media (max-width: 768px) {
 		.page-header { flex-direction: column; }
 		.form-row-pair { grid-template-columns: 1fr; }

--- a/web/src/routes/[username]/[workspace]/playbooks/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/playbooks/[slug]/+page.svelte
@@ -1,0 +1,388 @@
+<script lang="ts">
+	import { page } from '$app/state';
+	import { goto } from '$app/navigation';
+	import { api } from '$lib/api/client';
+	import { parseFields, parseSchema, type Collection, type Item } from '$lib/types';
+	import { toastStore } from '$lib/stores/toast.svelte';
+	import PlaybookFormFields from '$lib/components/playbooks/PlaybookFormFields.svelte';
+	import {
+		argumentsFromJSON,
+		argumentsToJSON,
+		type PlaybookArgument
+	} from '$lib/playbooks/arguments';
+
+	// Hardcoded fallbacks mirror the list-page convention — used until the
+	// workspace's playbooks-collection schema lands.
+	const FALLBACK_TRIGGERS = [
+		'on-implement',
+		'on-triage',
+		'on-release',
+		'on-plan',
+		'on-review',
+		'on-deploy',
+		'manual'
+	] as const;
+	const FALLBACK_SCOPES = ['all', 'backend', 'frontend', 'mobile', 'devops'] as const;
+	const FALLBACK_STATUSES = ['active', 'draft', 'deprecated'] as const;
+
+	let wsSlug = $derived(page.params.workspace ?? '');
+	let username = $derived(page.params.username ?? '');
+	let ref = $derived(page.params.slug ?? '');
+
+	let item = $state<Item | null>(null);
+	let playbooksCollection = $state<Collection | null>(null);
+	let existingPlaybooks = $state<Item[]>([]);
+	let loading = $state(true);
+	let saving = $state(false);
+
+	// Form fields — initialized from the loaded item.
+	let title = $state('');
+	let bodyContent = $state('');
+	let args = $state<PlaybookArgument[]>([]);
+	let invocationSlug = $state('');
+	let trigger = $state('manual');
+	let scope = $state('all');
+	let status = $state('draft');
+
+	$effect(() => {
+		if (wsSlug && ref) {
+			loadItem(wsSlug, ref);
+			loadPlaybooks(wsSlug);
+			loadCollection(wsSlug);
+		}
+	});
+
+	async function loadItem(ws: string, slugOrRef: string) {
+		loading = true;
+		try {
+			const loaded = await api.items.get(ws, slugOrRef);
+			// Stale-response guard: if the user moved away while the
+			// request was in flight, drop the result rather than
+			// rendering data from another route.
+			if (ws !== wsSlug || slugOrRef !== ref) return;
+			item = loaded;
+			title = loaded.title;
+			bodyContent = loaded.content ?? '';
+			const fields = parseFields(loaded);
+			invocationSlug =
+				typeof fields.invocation_slug === 'string' ? fields.invocation_slug : '';
+			trigger = typeof fields.trigger === 'string' ? fields.trigger : 'manual';
+			scope = typeof fields.scope === 'string' ? fields.scope : 'all';
+			status = typeof fields.status === 'string' ? fields.status : 'draft';
+			args = argumentsFromJSON(fields.arguments);
+		} catch {
+			if (ws !== wsSlug || slugOrRef !== ref) return;
+			toastStore.show('Failed to load playbook', 'error');
+		} finally {
+			if (ws === wsSlug && slugOrRef === ref) loading = false;
+		}
+	}
+
+	async function loadPlaybooks(ws: string) {
+		try {
+			const list = await api.items.listByCollection(ws, 'playbooks', {});
+			if (ws !== wsSlug) return;
+			existingPlaybooks = list;
+		} catch {
+			if (ws !== wsSlug) return;
+			existingPlaybooks = [];
+		}
+	}
+
+	async function loadCollection(ws: string) {
+		playbooksCollection = null;
+		try {
+			const coll = await api.collections.get(ws, 'playbooks');
+			if (ws !== wsSlug) return;
+			playbooksCollection = coll;
+		} catch {
+			if (ws !== wsSlug) return;
+			playbooksCollection = null;
+		}
+	}
+
+	let schemaTriggers = $derived.by<readonly string[]>(() => {
+		if (!playbooksCollection) return [];
+		const schema = parseSchema(playbooksCollection);
+		const field = schema.fields.find((f) => f.key === 'trigger');
+		return field?.options ?? [];
+	});
+
+	let schemaScopes = $derived.by<readonly string[]>(() => {
+		if (!playbooksCollection) return [];
+		const schema = parseSchema(playbooksCollection);
+		const field = schema.fields.find((f) => f.key === 'scope');
+		return field?.options ?? [];
+	});
+
+	let schemaStatuses = $derived.by<readonly string[]>(() => {
+		if (!playbooksCollection) return [];
+		const schema = parseSchema(playbooksCollection);
+		const field = schema.fields.find((f) => f.key === 'status');
+		return field?.options ?? [];
+	});
+
+	let triggers = $derived<readonly string[]>(
+		schemaTriggers.length > 0 ? schemaTriggers : (FALLBACK_TRIGGERS as readonly string[])
+	);
+	let scopes = $derived<readonly string[]>(
+		schemaScopes.length > 0 ? schemaScopes : (FALLBACK_SCOPES as readonly string[])
+	);
+	let statuses = $derived<readonly string[]>(
+		schemaStatuses.length > 0 ? schemaStatuses : (FALLBACK_STATUSES as readonly string[])
+	);
+
+	async function save() {
+		if (!item) return;
+		saving = true;
+		try {
+			const fieldsObj: Record<string, unknown> = {
+				status,
+				trigger,
+				scope,
+				// arguments goes in as a JSON VALUE (array of objects), not a
+				// stringified array — the server stores it as a `json` field.
+				// argumentsToJSON returns a string, so we parse it back to a
+				// value before stuffing it into fieldsObj. This matches the
+				// canonical shape in internal/collections/templates_startup_ship.go.
+				arguments: JSON.parse(argumentsToJSON(args))
+			};
+			// Omit invocation_slug entirely when empty so the optional field
+			// stays clean rather than emitting `"invocation_slug": ""`.
+			if (invocationSlug.trim()) {
+				fieldsObj.invocation_slug = invocationSlug.trim();
+			}
+			await api.items.update(wsSlug, item.slug, {
+				title: title.trim(),
+				content: bodyContent,
+				fields: JSON.stringify(fieldsObj)
+			});
+			toastStore.show('Playbook saved', 'success');
+			goto(`/${username}/${wsSlug}/playbooks`);
+		} catch {
+			toastStore.show('Failed to save playbook', 'error');
+		} finally {
+			saving = false;
+		}
+	}
+
+	function cancel() {
+		goto(`/${username}/${wsSlug}/playbooks`);
+	}
+</script>
+
+<div class="edit-page">
+	{#if loading}
+		<div class="loading">Loading playbook…</div>
+	{:else if !item}
+		<div class="loading">Playbook not found.</div>
+	{:else}
+		<header class="edit-header">
+			<div class="header-left">
+				<a class="back-link" href="/{username}/{wsSlug}/playbooks">&larr; Back to playbooks</a>
+				<input
+					class="title-input"
+					type="text"
+					value={title}
+					placeholder="Playbook title"
+					oninput={(e) => (title = (e.currentTarget as HTMLInputElement).value)}
+				/>
+			</div>
+			<div class="header-actions">
+				<button type="button" class="btn btn-secondary" onclick={cancel}>Cancel</button>
+				<button
+					type="button"
+					class="btn btn-primary"
+					disabled={saving || !title.trim()}
+					onclick={save}
+				>
+					{saving ? 'Saving…' : 'Save'}
+				</button>
+			</div>
+		</header>
+
+		<div class="edit-grid">
+			<aside class="edit-sidebar">
+				<PlaybookFormFields
+					{wsSlug}
+					selfItemId={item.id}
+					{invocationSlug}
+					{trigger}
+					{scope}
+					{status}
+					{args}
+					{bodyContent}
+					{triggers}
+					{scopes}
+					{statuses}
+					{existingPlaybooks}
+					onSlugChange={(s) => (invocationSlug = s)}
+					onTriggerChange={(t) => (trigger = t)}
+					onScopeChange={(s) => (scope = s)}
+					onStatusChange={(s) => (status = s)}
+					onArgumentsChange={(a) => (args = a)}
+					onBodyContentChange={(b) => (bodyContent = b)}
+				/>
+			</aside>
+
+			<section class="edit-main">
+				<label class="body-label" for="pbe-body">Body</label>
+				<textarea
+					id="pbe-body"
+					class="body-textarea"
+					value={bodyContent}
+					oninput={(e) => (bodyContent = (e.currentTarget as HTMLTextAreaElement).value)}
+					placeholder="Describe what this playbook does, its arguments, steps, defaults, and stop conditions."
+				></textarea>
+			</section>
+		</div>
+	{/if}
+</div>
+
+<style>
+	.edit-page {
+		max-width: var(--content-max-width);
+		margin: 0 auto;
+		padding: var(--space-6);
+	}
+	.loading {
+		text-align: center;
+		padding-top: 20vh;
+		color: var(--text-muted);
+	}
+	.edit-header {
+		display: flex;
+		align-items: flex-start;
+		justify-content: space-between;
+		gap: var(--space-4);
+		margin-bottom: var(--space-6);
+	}
+	.header-left {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-2);
+		flex: 1;
+		min-width: 0;
+	}
+	.back-link {
+		font-size: 0.85em;
+		color: var(--text-secondary);
+		text-decoration: none;
+	}
+	.back-link:hover {
+		color: var(--accent-blue);
+	}
+	.title-input {
+		font-size: 1.4em;
+		font-weight: 700;
+		padding: var(--space-2) var(--space-3);
+		background: transparent;
+		border: 1px solid transparent;
+		border-radius: var(--radius);
+		color: var(--text-primary);
+		width: 100%;
+	}
+	.title-input:hover {
+		border-color: var(--border);
+	}
+	.title-input:focus {
+		border-color: var(--accent-blue);
+		background: var(--bg-secondary);
+		outline: none;
+	}
+	.header-actions {
+		display: flex;
+		gap: var(--space-2);
+		flex-shrink: 0;
+	}
+	.btn {
+		padding: var(--space-2) var(--space-5);
+		border-radius: var(--radius);
+		font-size: 0.85em;
+		font-weight: 600;
+		cursor: pointer;
+		border: none;
+		transition: opacity 0.15s;
+	}
+	.btn:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+	.btn:hover:not(:disabled) {
+		opacity: 0.85;
+	}
+	.btn-primary {
+		background: var(--accent-blue);
+		color: #fff;
+	}
+	.btn-secondary {
+		background: transparent;
+		color: var(--text-secondary);
+		border: 1px solid var(--border);
+	}
+	.btn-secondary:hover:not(:disabled) {
+		color: var(--text-primary);
+		opacity: 1;
+	}
+	.edit-grid {
+		display: grid;
+		grid-template-columns: minmax(0, 1fr) minmax(0, 1.2fr);
+		gap: var(--space-6);
+		align-items: start;
+	}
+	.edit-sidebar {
+		min-width: 0;
+	}
+	.edit-main {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-2);
+		min-width: 0;
+		position: sticky;
+		top: var(--space-4);
+	}
+	.body-label {
+		font-size: 0.78em;
+		font-weight: 700;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		color: var(--text-secondary);
+	}
+	.body-textarea {
+		padding: var(--space-3);
+		background: var(--bg-tertiary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+		color: var(--text-primary);
+		font-family: var(--font-mono);
+		font-size: 0.88em;
+		line-height: 1.6;
+		min-height: 600px;
+		max-height: 80vh;
+		resize: vertical;
+		width: 100%;
+	}
+	.body-textarea:focus {
+		border-color: var(--accent-blue);
+		outline: none;
+	}
+	@media (max-width: 1024px) {
+		.edit-grid {
+			grid-template-columns: 1fr;
+		}
+		.edit-main {
+			position: static;
+		}
+	}
+	@media (max-width: 768px) {
+		.edit-header {
+			flex-direction: column;
+		}
+		.header-actions {
+			align-self: stretch;
+		}
+		.header-actions .btn {
+			flex: 1;
+		}
+	}
+</style>

--- a/web/src/routes/[username]/[workspace]/playbooks/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/playbooks/[slug]/+page.svelte
@@ -60,6 +60,23 @@
 			// request was in flight, drop the result rather than
 			// rendering data from another route.
 			if (ws !== wsSlug || slugOrRef !== ref) return;
+			// `api.items.get` is cross-collection — `/playbooks/TASK-1`
+			// would happily resolve to a task item, and Save would then
+			// rewrite the task's fields as a playbook (Codex round 1 P2).
+			// Gate on the loaded item's collection so the editor refuses
+			// to touch non-playbook items.
+			if (loaded.collection_slug !== 'playbooks') {
+				const itemRef =
+					loaded.collection_prefix && loaded.item_number
+						? `${loaded.collection_prefix}-${loaded.item_number}`
+						: slugOrRef;
+				toastStore.show(
+					`Not a playbook — ${itemRef} lives in ${loaded.collection_slug ?? 'another collection'}`,
+					'error'
+				);
+				item = null;
+				return;
+			}
 			item = loaded;
 			title = loaded.title;
 			bodyContent = loaded.content ?? '';

--- a/web/src/routes/[username]/[workspace]/playbooks/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/playbooks/[slug]/+page.svelte
@@ -54,6 +54,11 @@
 
 	async function loadItem(ws: string, slugOrRef: string) {
 		loading = true;
+		// Clear the previously-loaded playbook BEFORE the new fetch so a
+		// stale playbook isn't editable under a fresh URL while a 404 is
+		// in flight (Codex round 4 P2). The catch path then leaves item
+		// null and the template renders "Playbook not found."
+		item = null;
 		try {
 			const loaded = await api.items.get(ws, slugOrRef);
 			// Stale-response guard: if the user moved away while the
@@ -89,6 +94,9 @@
 			args = argumentsFromJSON(fields.arguments);
 		} catch {
 			if (ws !== wsSlug || slugOrRef !== ref) return;
+			// Explicit null on the current-request error path so a failed
+			// reload doesn't leave the previous item editable.
+			item = null;
 			toastStore.show('Failed to load playbook', 'error');
 		} finally {
 			if (ws === wsSlug && slugOrRef === ref) loading = false;

--- a/web/src/routes/[username]/[workspace]/playbooks/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/playbooks/[slug]/+page.svelte
@@ -153,21 +153,30 @@
 		if (!item) return;
 		saving = true;
 		try {
-			const fieldsObj: Record<string, unknown> = {
-				status,
-				trigger,
-				scope,
-				// arguments goes in as a JSON VALUE (array of objects), not a
-				// stringified array — the server stores it as a `json` field.
-				// argumentsToJSON returns a string, so we parse it back to a
-				// value before stuffing it into fieldsObj. This matches the
-				// canonical shape in internal/collections/templates_startup_ship.go.
-				arguments: JSON.parse(argumentsToJSON(args))
-			};
-			// Omit invocation_slug entirely when empty so the optional field
-			// stays clean rather than emitting `"invocation_slug": ""`.
-			if (invocationSlug.trim()) {
-				fieldsObj.invocation_slug = invocationSlug.trim();
+			// Start from the loaded fields so unknown/custom keys (workspace-
+			// added schema fields, future metadata) survive the round-trip.
+			// api.items.update replaces the whole fields blob, so rebuilding
+			// from scratch would silently drop everything we don't render
+			// (Codex round 3 P2).
+			const fieldsObj: Record<string, unknown> = { ...parseFields(item) };
+			fieldsObj.status = status;
+			fieldsObj.trigger = trigger;
+			fieldsObj.scope = scope;
+			// `arguments` goes in as a JSON VALUE (array of objects), not a
+			// stringified array — the server stores it as a `json` field.
+			// argumentsToJSON returns a string, so we parse it back to a
+			// value before stuffing it into fieldsObj. This matches the
+			// canonical shape in internal/collections/templates_startup_ship.go.
+			fieldsObj.arguments = JSON.parse(argumentsToJSON(args));
+			// Set or clear invocation_slug. Empty user input clears the field
+			// (the user removed the slug); a non-empty value sets it. Storing
+			// `""` would still hit the unique-index, so we delete the key
+			// entirely on clear.
+			const trimmedSlug = invocationSlug.trim();
+			if (trimmedSlug) {
+				fieldsObj.invocation_slug = trimmedSlug;
+			} else {
+				delete fieldsObj.invocation_slug;
 			}
 			await api.items.update(wsSlug, item.slug, {
 				title: title.trim(),


### PR DESCRIPTION
## Summary

Builds the first-class web UI editor for playbooks — the missing piece
of PLAN-1377's invocation model. Adds:

- `web/src/lib/playbooks/arguments.ts` — shared parser/generator for the
  body's `## Arguments` section, the canonical `invocation_slug` regex,
  a skeleton template, and a `buildTestInvocation()` helper that
  produces the three command renderings (Claude Code, CLI, MCP JSON).

- `web/src/lib/components/playbooks/PlaybookFormFields.svelte` — reusable
  structured-fields component: kebab-case slug input with debounced
  uniqueness check, trigger selector with "Other (custom)…" escape,
  scope + status selectors driven by collection schema, an
  arguments builder with type-specific enum options, and the test
  invocation helper. Args ↔ body section is two-way bound via
  signature-key tracking to avoid reactive loops.

- `web/src/routes/[username]/[workspace]/playbooks/[slug]/+page.svelte` —
  dedicated edit page with title input, Save/Cancel actions, and a
  split form-fields | body-textarea layout. Builds the canonical
  fields JSON on save (arguments as a JSON value, empty slug omitted).

- `web/src/routes/[username]/[workspace]/playbooks/+page.svelte` —
  pre-fills the new-form textarea with the skeleton template and
  embeds the same `PlaybookFormFields` component so every new
  playbook gets the same affordances.

## Context

Implements `TASK-1384` under `PLAN-1377` (Make Playbooks first-class
invokable procedures). Depends on `TASK-1378` (schema fields), which
landed earlier in the plan.

## Test plan

- [x] `npm run build` — clean (only pre-existing chunk-size + plugin-timing notices)
- [x] `npx svelte-check` — 0 errors, 6 pre-existing warnings in unrelated files
- [x] `go test ./...` — all green (no Go changes; just web)
- [x] Acceptance criteria — verified by code review:
  - [x] Creating from "+ New" shows the skeleton template
  - [x] Non-kebab-case slug → inline `aria-invalid` error
  - [x] Duplicate slug → debounced inline error citing the conflicting title
  - [x] Arguments builder mutations update the body's `## Arguments` section
  - [x] Editing the markdown section parses back into the structured form
  - [x] Test invocation shows `/pad ship PLAN-609 stop-after-each merge-strategy=rebase`