### PR TITLE
feat(collections): widen LibraryPlaybook with InvocationSlug + Arguments (TASK-1398)

### DIFF
--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -5756,11 +5756,20 @@ Examples:
 			}
 
 			if foundPlaybook != nil {
-				// Build fields JSON for playbook
+				// Build fields JSON for playbook. Forward invocation_slug
+				// and arguments only when set so legacy library entries
+				// (which leave them empty) seed unchanged. Mirrors the
+				// shape ShipPlaybook() writes in templates_startup_ship.go.
 				fields := map[string]interface{}{
 					"status":  "active",
 					"trigger": foundPlaybook.Trigger,
 					"scope":   foundPlaybook.Scope,
+				}
+				if foundPlaybook.InvocationSlug != "" {
+					fields["invocation_slug"] = foundPlaybook.InvocationSlug
+				}
+				if len(foundPlaybook.Arguments) > 0 {
+					fields["arguments"] = foundPlaybook.Arguments
 				}
 				fieldsJSON, _ := json.Marshal(fields)
 

--- a/internal/cli/client.go
+++ b/internal/cli/client.go
@@ -366,12 +366,18 @@ type PlaybookCategory struct {
 }
 
 // LibraryPlaybook holds a pre-built playbook definition.
+//
+// InvocationSlug and Arguments are PLAN-1377's invocation surface and
+// must round-trip through `pad library activate` so a library entry
+// that declares them produces a `/pad <slug>`-routable workspace item.
 type LibraryPlaybook struct {
-	Title    string `json:"title"`
-	Content  string `json:"content"`
-	Category string `json:"category"`
-	Trigger  string `json:"trigger"`
-	Scope    string `json:"scope"`
+	Title          string           `json:"title"`
+	Content        string           `json:"content"`
+	Category       string           `json:"category"`
+	Trigger        string           `json:"trigger"`
+	Scope          string           `json:"scope"`
+	InvocationSlug string           `json:"invocation_slug,omitempty"`
+	Arguments      []map[string]any `json:"arguments,omitempty"`
 }
 
 // GetPlaybookLibrary fetches the playbook library from the server.

--- a/internal/collections/playbook_library.go
+++ b/internal/collections/playbook_library.go
@@ -2,12 +2,18 @@ package collections
 
 // LibraryPlaybook holds a pre-built playbook definition that can be
 // activated (created as an item) in a workspace's Playbooks collection.
+//
+// InvocationSlug and Arguments are PLAN-1377's invocation surface. When
+// set, the library entry becomes user-callable as `/pad <slug>`. Leave
+// both unset for trigger-only checklist playbooks (legacy shape).
 type LibraryPlaybook struct {
-	Title    string `json:"title"`
-	Content  string `json:"content"`
-	Category string `json:"category"` // workflow, planning, quality, operations
-	Trigger  string `json:"trigger"`  // on-implement, on-triage, on-release, on-plan, on-review, on-deploy, manual
-	Scope    string `json:"scope"`    // all, backend, frontend, etc.
+	Title          string           `json:"title"`
+	Content        string           `json:"content"`
+	Category       string           `json:"category"`                  // workflow, planning, quality, operations
+	Trigger        string           `json:"trigger"`                   // on-implement, on-triage, on-release, on-plan, on-review, on-deploy, manual
+	Scope          string           `json:"scope"`                     // all, backend, frontend, etc.
+	InvocationSlug string           `json:"invocation_slug,omitempty"` // kebab-case slug for `/pad <slug>` routing
+	Arguments      []map[string]any `json:"arguments,omitempty"`       // argument spec mirroring the body's `## Arguments` section
 }
 
 // PlaybookCategory groups related playbooks under a named category.

--- a/internal/collections/templates.go
+++ b/internal/collections/templates.go
@@ -213,20 +213,33 @@ func seedConventionFromLibrary(c LibraryConvention) SeedConvention {
 }
 
 // seedPlaybookFromLibrary converts a LibraryPlaybook into a SeedPlaybook.
+//
+// InvocationSlug and Arguments are forwarded into the seeded item's
+// Fields JSON only when set, mirroring ShipPlaybook()'s shape
+// (templates_startup_ship.go::ShipPlaybook). Library entries that
+// leave them empty produce the legacy trigger-only field set, so
+// activation behavior is backward-compatible.
 func seedPlaybookFromLibrary(p LibraryPlaybook) SeedPlaybook {
 	scope := p.Scope
 	if scope == "" {
 		scope = "all"
 	}
-	fields, _ := json.Marshal(map[string]string{
+	fields := map[string]any{
 		"status":  "active",
 		"trigger": p.Trigger,
 		"scope":   scope,
-	})
+	}
+	if p.InvocationSlug != "" {
+		fields["invocation_slug"] = p.InvocationSlug
+	}
+	if len(p.Arguments) > 0 {
+		fields["arguments"] = p.Arguments
+	}
+	encoded, _ := json.Marshal(fields)
 	return SeedPlaybook{
 		Title:   p.Title,
 		Content: p.Content,
-		Fields:  string(fields),
+		Fields:  string(encoded),
 	}
 }
 

--- a/internal/mcp/dispatch_http_slice4.go
+++ b/internal/mcp/dispatch_http_slice4.go
@@ -546,10 +546,20 @@ func (d *HTTPHandlerDispatcher) dispatchLibraryActivate(
 	}
 
 	if pb := collections.GetLibraryPlaybook(title); pb != nil {
+		// Forward invocation_slug + arguments only when set so legacy
+		// library entries (none of which carry them) seed with the
+		// original three-field shape. Mirrors ShipPlaybook() and the
+		// CLI activate path in cmd/pad/main.go's libraryActivate.
 		fields := map[string]any{
 			"status":  "active",
 			"trigger": pb.Trigger,
 			"scope":   pb.Scope,
+		}
+		if pb.InvocationSlug != "" {
+			fields["invocation_slug"] = pb.InvocationSlug
+		}
+		if len(pb.Arguments) > 0 {
+			fields["arguments"] = pb.Arguments
 		}
 		fieldsJSON, err := json.Marshal(fields)
 		if err != nil {


### PR DESCRIPTION
## Summary

Adds two optional fields to `LibraryPlaybook`:
- `InvocationSlug` — kebab-case slug for `/pad <slug>` routing (per PLAN-1377)
- `Arguments` — argument spec mirroring the body's `## Arguments` section

Both fields are tagged with `omitempty` so existing library entries (none of which set them) serialize unchanged. `seedPlaybookFromLibrary()` now forwards both into the seeded item's `Fields` JSON only when set, matching the shape `ShipPlaybook()` already writes.

## Context

Foundational task in PLAN-1397 — unblocks T2 through T6 of the playbook library overhaul.

## Test plan
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./...` — all tests pass
- [x] No web changes; web build untouched (verified via baseline pre-flight)
- [x] `omitempty` confirmed on both new fields so legacy entries round-trip unchanged