### PR TITLE
feat(web): surface invocation_slug + arg count on library playbook cards (TASK-1399)

### DIFF
--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -887,19 +887,31 @@ export const api = {
 
 		getPlaybooks: () => request<PlaybookLibraryResponse>('/playbook-library'),
 
-		activatePlaybook: (ws: string, playbook: LibraryPlaybook) =>
-			request<Item>(`/workspaces/${ws}/collections/playbooks/items`, {
+		activatePlaybook: (ws: string, playbook: LibraryPlaybook) => {
+			// Forward invocation_slug + arguments only when set so legacy
+			// library entries (without them) seed with the original
+			// three-field shape. Mirrors ShipPlaybook() in
+			// internal/collections/templates_startup_ship.go.
+			const fields: Record<string, unknown> = {
+				status: 'active',
+				trigger: playbook.trigger,
+				scope: playbook.scope
+			};
+			if (playbook.invocation_slug) {
+				fields.invocation_slug = playbook.invocation_slug;
+			}
+			if (playbook.arguments && playbook.arguments.length > 0) {
+				fields.arguments = playbook.arguments;
+			}
+			return request<Item>(`/workspaces/${ws}/collections/playbooks/items`, {
 				method: 'POST',
 				body: JSON.stringify({
 					title: playbook.title,
 					content: playbook.content,
-					fields: JSON.stringify({
-						status: 'active',
-						trigger: playbook.trigger,
-						scope: playbook.scope
-					})
+					fields: JSON.stringify(fields)
 				})
-			})
+			});
+		}
 	},
 
 	// ── Raw requests ──────────────────────────────────────────────────────────

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -812,12 +812,25 @@ export interface ConventionLibraryResponse {
 
 // ─── Playbook Library ────────────────────────────────────────────────────────
 
+export interface LibraryPlaybookArgument {
+	name: string;
+	type: string;
+	required?: boolean;
+	default?: unknown;
+	description?: string;
+	enum?: string[];
+}
+
 export interface LibraryPlaybook {
 	title: string;
 	content: string;
 	category: string;
 	trigger: string;
 	scope: string;
+	/** PLAN-1377 invocation surface — kebab-case slug for `/pad <slug>` routing. */
+	invocation_slug?: string;
+	/** Argument spec mirroring the body's `## Arguments` section. */
+	arguments?: LibraryPlaybookArgument[];
 }
 
 export interface PlaybookCategory {

--- a/web/src/routes/[username]/[workspace]/library/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/library/+page.svelte
@@ -214,8 +214,14 @@
 								<div class="card-body">
 									<h3 class="card-title">{playbook.title}</h3>
 									<div class="badges">
+										{#if playbook.invocation_slug}
+											<span class="badge slug" title="Invoke via `/pad {playbook.invocation_slug}`">/pad {playbook.invocation_slug}</span>
+										{/if}
 										<span class="badge trigger">{playbook.trigger}</span>
 										<span class="badge scope">{playbook.scope}</span>
+										{#if playbook.arguments && playbook.arguments.length > 0}
+											<span class="badge args" title="Accepts {playbook.arguments.length} argument{playbook.arguments.length === 1 ? '' : 's'}">{playbook.arguments.length} arg{playbook.arguments.length === 1 ? '' : 's'}</span>
+										{/if}
 									</div>
 									<p class="card-content card-steps">{previewSteps(playbook.content)}</p>
 								</div>
@@ -322,6 +328,13 @@
 	.badge.trigger { background: color-mix(in srgb, var(--accent-blue) 20%, transparent); color: var(--accent-blue); }
 	.badge.scope { background: color-mix(in srgb, var(--accent-purple) 20%, transparent); color: var(--accent-purple); }
 	.badge.priority { color: #fff; }
+	/* PLAN-1377 invocation surface — slug chip signals "this playbook is callable as /pad <slug>". */
+	.badge.slug {
+		background: color-mix(in srgb, var(--accent-green) 18%, transparent);
+		color: var(--accent-green);
+		font-family: var(--font-mono, ui-monospace, SFMono-Regular, monospace);
+	}
+	.badge.args { background: color-mix(in srgb, var(--accent-amber) 20%, transparent); color: var(--accent-amber); }
 
 	.card-action { display: flex; justify-content: flex-end; }
 

--- a/web/src/routes/[username]/[workspace]/library/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/library/+page.svelte
@@ -215,7 +215,7 @@
 									<h3 class="card-title">{playbook.title}</h3>
 									<div class="badges">
 										{#if playbook.invocation_slug}
-											<span class="badge slug" title="Invoke via `/pad {playbook.invocation_slug}`">/pad {playbook.invocation_slug}</span>
+											<span class="badge slug" title={`Invoke via /pad ${playbook.invocation_slug}`}>/pad {playbook.invocation_slug}</span>
 										{/if}
 										<span class="badge trigger">{playbook.trigger}</span>
 										<span class="badge scope">{playbook.scope}</span>


### PR DESCRIPTION
## Summary

Surfaces the PLAN-1377 invocation surface (added to the Go struct in T1 / #527) on the library UI:
- `/pad <slug>` chip on playbook cards when `invocation_slug` is set (mono font, green)
- `N arg{s}` badge when `arguments` is non-empty (amber)
- Activate payload forwards both fields into the seeded item's `fields` JSON when set

Both badges are conditional, so trigger-only library entries (the current 9 entries — none set the new fields) render unchanged. The new chips light up automatically for the invokable entries landing in T3-T5.

## Context

T2 of PLAN-1397 — depends on T1 (#527, merged). Closes the loop on the Codex P2 from T1 round 1 (web client was the remaining of three activation paths that dropped the new fields).

## Test plan
- [x] `npm run build` — clean
- [x] svelte-autofixer reports no issues on the changed component
- [x] Legacy library cards (no slug, no args) render unchanged — the new badge blocks are conditional
- [ ] Manual: after T3 lands, the `ship` library card should render the `/pad ship` chip and `5 args` badge (verified by activating in a non-startup workspace template)