### PR TITLE
feat(library): add ship playbook to library, shared body with startup seed (TASK-1400)

### DIFF
--- a/internal/collections/playbook_library.go
+++ b/internal/collections/playbook_library.go
@@ -30,6 +30,23 @@ func PlaybookLibrary() []PlaybookCategory {
 			Name:        "workflow",
 			Description: "Core development workflows",
 			Playbooks: []LibraryPlaybook{
+				// `ship` is the headline invokable example from PLAN-1377.
+				// Library entry and startup-template seed share the same
+				// body + argument spec (shipPlaybookBody /
+				// shipPlaybookArguments) so updates live in one place.
+				// Title matches ShipPlaybook()'s SeedPlaybook so the
+				// library UI's activePlaybookTitles set (matched by
+				// title) renders this as "Active" in `startup`
+				// workspaces where it's already seeded.
+				{
+					Title:          "Ship tasks",
+					Category:       "workflow",
+					Trigger:        "manual",
+					Scope:          "all",
+					InvocationSlug: "ship",
+					Arguments:      shipPlaybookArguments,
+					Content:        shipPlaybookBody,
+				},
 				{
 					Title:    "Implementation Workflow",
 					Category: "workflow",


### PR DESCRIPTION
## Summary

Adds the `ship` playbook to the library so it's discoverable from any workspace template — not just `startup`. Single source of truth: the library entry and the startup-seed `ShipPlaybook()` share the same `shipPlaybookBody` + `shipPlaybookArguments` package-level constants.

- Library entry references the existing `shipPlaybookBody` / `shipPlaybookArguments` (no body duplication)
- Title `"Ship tasks"` matches `ShipPlaybook()`'s seed so startup workspaces see it as "Active" (UI's `activePlaybookTitles` is title-keyed)
- Placement: top of the existing `workflow` category. T6 will rearrange.

## Context

T3 of PLAN-1397. Depends on T1 (#527, merged) for `InvocationSlug` / `Arguments` on `LibraryPlaybook`. T2 (#528, merged) wired the UI chips so the new `/pad ship` chip + `5 args` badge will render automatically.

## Test plan
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./internal/collections/...` — clean
- [x] Smoke test (run locally + deleted): `PlaybookLibrary()` returns ship by `invocation_slug=ship`; body is the same object as `shipPlaybookBody`; 5 arguments declared
- [ ] Manual after merge: `pad workspace init --template scrum` → library shows ship as activatable; `pad workspace init --template startup` → library shows ship as "Active"
- [x] Permanent regression test deferred to T7 per plan