### PR TITLE
refactor(library): archive 9 pre-PLAN-1377 playbook bodies, rebuild library as invokable-first (TASK-1403)

### DIFF
--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -5678,7 +5678,7 @@ in the appropriate collection (conventions or playbooks) with all fields set.
 
 Examples:
   pad library activate "Commit after task completion"    # Activates a convention
-  pad library activate "Implementation Workflow"         # Activates a playbook`,
+  pad library activate "Ship tasks"                      # Activates a playbook`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, _ := getClient()

--- a/internal/collections/playbook_library.go
+++ b/internal/collections/playbook_library.go
@@ -23,12 +23,21 @@ type PlaybookCategory struct {
 	Playbooks   []LibraryPlaybook `json:"playbooks"`
 }
 
-// PlaybookLibrary returns all pre-defined playbook categories with their playbooks.
+// PlaybookLibrary returns all pre-defined playbook categories with their
+// playbooks. As of PLAN-1397's invokable-first overhaul (TASK-1403), the
+// library teaches the PLAN-1377 invocation model from the first card:
+// every active entry declares an `InvocationSlug` so the library doubles
+// as the discovery surface for `/pad <slug>` workflows.
+//
+// The pre-PLAN-1377 trigger-only checklist entries (9 in total) live in
+// playbook_library_archive.go and are no longer surfaced. Per-entry
+// "convert to invokable" / "promote to convention" / "retire" decisions
+// are tracked in IDEA-1396.
 func PlaybookLibrary() []PlaybookCategory {
 	return []PlaybookCategory{
 		{
-			Name:        "workflow",
-			Description: "Core development workflows",
+			Name:        "agent-workflows",
+			Description: "Invokable agent workflows — `/pad <slug>` procedures with structured arguments",
 			Playbooks: []LibraryPlaybook{
 				// `ship` is the headline invokable example from PLAN-1377.
 				// Library entry and startup-template seed share the same
@@ -40,7 +49,7 @@ func PlaybookLibrary() []PlaybookCategory {
 				// workspaces where it's already seeded.
 				{
 					Title:          "Ship tasks",
-					Category:       "workflow",
+					Category:       "agent-workflows",
 					Trigger:        "manual",
 					Scope:          "all",
 					InvocationSlug: "ship",
@@ -56,163 +65,6 @@ func PlaybookLibrary() []PlaybookCategory {
 				// body implies. Body + arguments live in
 				// playbook_library_decompose.go.
 				DecomposePlaybook(),
-				{
-					Title:    "Implementation Workflow",
-					Category: "workflow",
-					Trigger:  "on-implement",
-					Scope:    "all",
-					Content: `1. Claim the task — update its status to in-progress
-2. Load context — read related docs, architecture decisions, and linked items for background
-3. Create an isolated workspace — use a feature branch or worktree to keep changes separate
-4. Implement the changes — follow project conventions
-5. Verify your work — run the project's test suite and build process
-6. Self-review — check your diff for debug code, missing error handling, and unintended changes
-7. Commit with a clear message — describe what changed and why, reference the task
-
-` + "\U0001F4A1 Ask your AI agent to customize this playbook for your specific project tools and workflow.",
-				},
-				{
-					Title:    "Code Review Process",
-					Category: "workflow",
-					Trigger:  "on-review",
-					Scope:    "all",
-					Content: `1. Read the context — review the PR description and linked task for intent
-2. Understand the scope — what should this change do, and what shouldn't it touch?
-3. Review for correctness — does the code do what it claims?
-4. Review for robustness — error handling, edge cases, security considerations
-5. Review for maintainability — clear naming, reasonable complexity, adequate comments
-6. Check test coverage — are the important paths tested?
-7. Provide actionable feedback — be specific, suggest alternatives, distinguish blockers from nits
-
-` + "\U0001F4A1 Ask your AI agent to customize this playbook for your specific project tools and workflow.",
-				},
-			},
-		},
-		{
-			Name:        "planning",
-			Description: "Planning and triage workflows",
-			Playbooks: []LibraryPlaybook{
-				{
-					Title:    "Plan Creation",
-					Category: "planning",
-					Trigger:  "on-plan",
-					Scope:    "all",
-					Content: `1. Review current state — check the roadmap, active plans, and recent progress
-2. Define the goal — what does success look like for this plan?
-3. Identify the work — list everything that needs to happen
-4. Break into tasks — each task should be independently completable (one branch, one PR)
-5. Estimate effort — flag tasks that seem too large and split them
-6. Order by dependency — what must happen before what?
-7. Set targets — define when the plan should start and end
-8. Create the items — build the plan and its tasks in the project tracker
-
-` + "\U0001F4A1 Ask your AI agent to customize this playbook for your specific project tools and workflow.",
-				},
-				{
-					Title:    "Bug Triage",
-					Category: "planning",
-					Trigger:  "on-triage",
-					Scope:    "all",
-					Content: `1. Reproduce the issue — confirm it's real and understand the conditions
-2. Assess impact — how many users are affected? Is there a workaround?
-3. Determine severity — critical (broken for everyone), high (significant impact), medium (inconvenient), low (cosmetic)
-4. Check for duplicates — search existing tasks for similar reports
-5. Capture the details — create a task with: steps to reproduce, expected vs actual behavior, severity
-6. Link related items — connect to relevant plans, architecture docs, or prior work
-7. Prioritize — decide if it needs immediate attention or can be scheduled
-
-` + "\U0001F4A1 Ask your AI agent to customize this playbook for your specific project tools and workflow.",
-				},
-			},
-		},
-		{
-			Name:        "quality",
-			Description: "Quality and improvement workflows",
-			Playbooks: []LibraryPlaybook{
-				{
-					Title:    "Retrospective",
-					Category: "quality",
-					Trigger:  "manual",
-					Scope:    "all",
-					Content: `1. Gather the data — load the completed plan and all its tasks
-2. What shipped — list everything that was completed
-3. What was deferred — list anything that was planned but postponed
-4. What went well — identify practices, tools, or decisions that helped
-5. What could improve — identify friction, surprises, or mistakes
-6. Action items — concrete changes for the next plan
-7. Save and share — document the retrospective for future reference
-
-` + "\U0001F4A1 Ask your AI agent to customize this playbook for your specific project tools and workflow.",
-				},
-				{
-					Title:    "Onboarding to a Project",
-					Category: "quality",
-					Trigger:  "manual",
-					Scope:    "all",
-					Content: `1. Read the architecture — understand the tech stack, structure, and key patterns
-2. Read the roadmap — understand where the project is and where it's going
-3. Review active work — check current plans, in-progress tasks, and recent activity
-4. Set up the environment — get the project building and running locally
-5. Read the conventions — understand the team's rules and expectations
-6. Pick a starter task — choose something small to build familiarity
-7. Ask questions — don't guess, clarify unclear architecture or conventions
-
-` + "\U0001F4A1 Ask your AI agent to customize this playbook for your specific project tools and workflow.",
-				},
-			},
-		},
-		{
-			Name:        "operations",
-			Description: "Release, deployment, and incident workflows",
-			Playbooks: []LibraryPlaybook{
-				{
-					Title:    "Release Process",
-					Category: "operations",
-					Trigger:  "on-release",
-					Scope:    "all",
-					Content: `1. Verify completeness — confirm all planned tasks are done or explicitly deferred
-2. Run the full test suite — no skipped or failing tests
-3. Generate changelog — summarize what's new, fixed, and changed from completed tasks
-4. Update version — bump version numbers as appropriate
-5. Create the release — tag, branch, or package as your project requires
-6. Verify in staging — deploy to a non-production environment first
-7. Ship it — deploy to production
-8. Monitor — watch for errors and regressions after release
-
-` + "\U0001F4A1 Ask your AI agent to customize this playbook for your specific project tools and workflow.",
-				},
-				{
-					Title:    "Deployment",
-					Category: "operations",
-					Trigger:  "on-deploy",
-					Scope:    "all",
-					Content: `1. Pre-flight check — verify CI is passing and the build is ready
-2. Back up current state — ensure you can roll back if needed
-3. Deploy to staging — verify in a non-production environment
-4. Run smoke tests — confirm critical paths work
-5. Deploy to production — follow your deployment process
-6. Verify production — spot-check key functionality
-7. Monitor — watch logs and metrics for 15-30 minutes
-8. Communicate — let the team know what was deployed
-
-` + "\U0001F4A1 Ask your AI agent to customize this playbook for your specific project tools and workflow.",
-				},
-				{
-					Title:    "Incident Response",
-					Category: "operations",
-					Trigger:  "manual",
-					Scope:    "all",
-					Content: `1. Assess the situation — what's broken, who's affected, how severe?
-2. Communicate — let the team know there's an active incident
-3. Mitigate — can you reduce impact quickly? (rollback, feature flag, redirect)
-4. Investigate — find the root cause
-5. Fix — implement and verify the fix
-6. Recover — restore full service and verify
-7. Document — capture what happened, timeline, root cause, and fix
-8. Follow up — create tasks for preventive measures
-
-` + "\U0001F4A1 Ask your AI agent to customize this playbook for your specific project tools and workflow.",
-				},
 			},
 		},
 	}

--- a/internal/collections/playbook_library_archive.go
+++ b/internal/collections/playbook_library_archive.go
@@ -1,0 +1,174 @@
+package collections
+
+// archivedPlaybooks holds the pre-PLAN-1377 library playbook bodies that
+// were retired from the active library surface as part of PLAN-1397's
+// invokable-first overhaul (TASK-1403).
+//
+// These entries stay compiled (so they're greppable, refactor-safe, and
+// one rename away from coming back) but are NOT returned by
+// PlaybookLibrary(). Per-entry disposition decisions — "convert to
+// invokable", "promote to convention", or "retire entirely" — are
+// tracked in IDEA-1396 (Pre-PLAN-1377 library playbook bodies —
+// candidates for rewrite, convention promotion, or retirement).
+//
+// If a future PLAN converts one of these to an invokable playbook,
+// pull the body from here, wrap it with InvocationSlug + Arguments,
+// and add it back to PlaybookLibrary(). The archive file shrinks
+// accordingly. If a body is determined to be obsolete, delete the
+// entry and update IDEA-1396 with the rationale.
+//
+// The function is unexported and unused by the production code path;
+// the underscore-assignment at the bottom keeps it referenced so
+// `unused` linters don't flag the file. Future migrations that want
+// to introspect or selectively re-activate archived bodies can call
+// archivedPlaybooks() directly from package code.
+func archivedPlaybooks() []LibraryPlaybook {
+	return []LibraryPlaybook{
+		{
+			Title:    "Implementation Workflow",
+			Category: "workflow",
+			Trigger:  "on-implement",
+			Scope:    "all",
+			Content: `1. Claim the task — update its status to in-progress
+2. Load context — read related docs, architecture decisions, and linked items for background
+3. Create an isolated workspace — use a feature branch or worktree to keep changes separate
+4. Implement the changes — follow project conventions
+5. Verify your work — run the project's test suite and build process
+6. Self-review — check your diff for debug code, missing error handling, and unintended changes
+7. Commit with a clear message — describe what changed and why, reference the task
+
+` + "\U0001F4A1 Ask your AI agent to customize this playbook for your specific project tools and workflow.",
+		},
+		{
+			Title:    "Code Review Process",
+			Category: "workflow",
+			Trigger:  "on-review",
+			Scope:    "all",
+			Content: `1. Read the context — review the PR description and linked task for intent
+2. Understand the scope — what should this change do, and what shouldn't it touch?
+3. Review for correctness — does the code do what it claims?
+4. Review for robustness — error handling, edge cases, security considerations
+5. Review for maintainability — clear naming, reasonable complexity, adequate comments
+6. Check test coverage — are the important paths tested?
+7. Provide actionable feedback — be specific, suggest alternatives, distinguish blockers from nits
+
+` + "\U0001F4A1 Ask your AI agent to customize this playbook for your specific project tools and workflow.",
+		},
+		{
+			Title:    "Plan Creation",
+			Category: "planning",
+			Trigger:  "on-plan",
+			Scope:    "all",
+			Content: `1. Review current state — check the roadmap, active plans, and recent progress
+2. Define the goal — what does success look like for this plan?
+3. Identify the work — list everything that needs to happen
+4. Break into tasks — each task should be independently completable (one branch, one PR)
+5. Estimate effort — flag tasks that seem too large and split them
+6. Order by dependency — what must happen before what?
+7. Set targets — define when the plan should start and end
+8. Create the items — build the plan and its tasks in the project tracker
+
+` + "\U0001F4A1 Ask your AI agent to customize this playbook for your specific project tools and workflow.",
+		},
+		{
+			Title:    "Bug Triage",
+			Category: "planning",
+			Trigger:  "on-triage",
+			Scope:    "all",
+			Content: `1. Reproduce the issue — confirm it's real and understand the conditions
+2. Assess impact — how many users are affected? Is there a workaround?
+3. Determine severity — critical (broken for everyone), high (significant impact), medium (inconvenient), low (cosmetic)
+4. Check for duplicates — search existing tasks for similar reports
+5. Capture the details — create a task with: steps to reproduce, expected vs actual behavior, severity
+6. Link related items — connect to relevant plans, architecture docs, or prior work
+7. Prioritize — decide if it needs immediate attention or can be scheduled
+
+` + "\U0001F4A1 Ask your AI agent to customize this playbook for your specific project tools and workflow.",
+		},
+		{
+			Title:    "Retrospective",
+			Category: "quality",
+			Trigger:  "manual",
+			Scope:    "all",
+			Content: `1. Gather the data — load the completed plan and all its tasks
+2. What shipped — list everything that was completed
+3. What was deferred — list anything that was planned but postponed
+4. What went well — identify practices, tools, or decisions that helped
+5. What could improve — identify friction, surprises, or mistakes
+6. Action items — concrete changes for the next plan
+7. Save and share — document the retrospective for future reference
+
+` + "\U0001F4A1 Ask your AI agent to customize this playbook for your specific project tools and workflow.",
+		},
+		{
+			Title:    "Onboarding to a Project",
+			Category: "quality",
+			Trigger:  "manual",
+			Scope:    "all",
+			Content: `1. Read the architecture — understand the tech stack, structure, and key patterns
+2. Read the roadmap — understand where the project is and where it's going
+3. Review active work — check current plans, in-progress tasks, and recent activity
+4. Set up the environment — get the project building and running locally
+5. Read the conventions — understand the team's rules and expectations
+6. Pick a starter task — choose something small to build familiarity
+7. Ask questions — don't guess, clarify unclear architecture or conventions
+
+` + "\U0001F4A1 Ask your AI agent to customize this playbook for your specific project tools and workflow.",
+		},
+		{
+			Title:    "Release Process",
+			Category: "operations",
+			Trigger:  "on-release",
+			Scope:    "all",
+			Content: `1. Verify completeness — confirm all planned tasks are done or explicitly deferred
+2. Run the full test suite — no skipped or failing tests
+3. Generate changelog — summarize what's new, fixed, and changed from completed tasks
+4. Update version — bump version numbers as appropriate
+5. Create the release — tag, branch, or package as your project requires
+6. Verify in staging — deploy to a non-production environment first
+7. Ship it — deploy to production
+8. Monitor — watch for errors and regressions after release
+
+` + "\U0001F4A1 Ask your AI agent to customize this playbook for your specific project tools and workflow.",
+		},
+		{
+			Title:    "Deployment",
+			Category: "operations",
+			Trigger:  "on-deploy",
+			Scope:    "all",
+			Content: `1. Pre-flight check — verify CI is passing and the build is ready
+2. Back up current state — ensure you can roll back if needed
+3. Deploy to staging — verify in a non-production environment
+4. Run smoke tests — confirm critical paths work
+5. Deploy to production — follow your deployment process
+6. Verify production — spot-check key functionality
+7. Monitor — watch logs and metrics for 15-30 minutes
+8. Communicate — let the team know what was deployed
+
+` + "\U0001F4A1 Ask your AI agent to customize this playbook for your specific project tools and workflow.",
+		},
+		{
+			Title:    "Incident Response",
+			Category: "operations",
+			Trigger:  "manual",
+			Scope:    "all",
+			Content: `1. Assess the situation — what's broken, who's affected, how severe?
+2. Communicate — let the team know there's an active incident
+3. Mitigate — can you reduce impact quickly? (rollback, feature flag, redirect)
+4. Investigate — find the root cause
+5. Fix — implement and verify the fix
+6. Recover — restore full service and verify
+7. Document — capture what happened, timeline, root cause, and fix
+8. Follow up — create tasks for preventive measures
+
+` + "\U0001F4A1 Ask your AI agent to customize this playbook for your specific project tools and workflow.",
+		},
+	}
+}
+
+// _ = archivedPlaybooks is a deliberate package-level reference that
+// keeps the archive helper compiled even though no production code
+// calls it. Without this, `go vet`/`unused` would flag the symbol —
+// the whole point of the archive is to keep the bodies discoverable
+// for future migrations, so the linter quiet-down is intentional.
+var _ = archivedPlaybooks

--- a/internal/collections/playbook_library_decompose.go
+++ b/internal/collections/playbook_library_decompose.go
@@ -157,7 +157,7 @@ var decomposePlaybookArguments = []map[string]any{
 func DecomposePlaybook() LibraryPlaybook {
 	return LibraryPlaybook{
 		Title:          "Decompose a plan into tasks",
-		Category:       "workflow",
+		Category:       "agent-workflows",
 		Trigger:        "manual",
 		Scope:          "all",
 		InvocationSlug: "decompose",

--- a/internal/collections/playbook_library_plan.go
+++ b/internal/collections/playbook_library_plan.go
@@ -194,7 +194,7 @@ var planPlaybookArguments = []map[string]any{
 func PlanPlaybook() LibraryPlaybook {
 	return LibraryPlaybook{
 		Title:          "Plan a new initiative",
-		Category:       "workflow",
+		Category:       "agent-workflows",
 		Trigger:        "manual",
 		Scope:          "all",
 		InvocationSlug: "plan",

--- a/internal/collections/templates.go
+++ b/internal/collections/templates.go
@@ -186,9 +186,17 @@ var softwareStarterConventionTitles = []string{
 
 // softwareStarterPlaybookTitles names the library playbooks that ship in the
 // software templates' starter pack.
+//
+// PLAN-1397's invokable-first overhaul (TASK-1403) retired the
+// pre-PLAN-1377 trigger-only entries ("Implementation Workflow",
+// "Code Review Process", etc.) from the library. The replacements are
+// the invokable workflow trio. `startup` separately prepends `ship`
+// (templates.go:~440), so we list `plan` and `decompose` here — every
+// software workspace gets the three together without duplicating the
+// `ship` seed for startup specifically.
 var softwareStarterPlaybookTitles = []string{
-	"Implementation Workflow",
-	"Code Review Process",
+	"Plan a new initiative",
+	"Decompose a plan into tasks",
 }
 
 // seedConventionFromLibrary converts a LibraryConvention into a SeedConvention

--- a/internal/mcp/dispatch_http_slice4_test.go
+++ b/internal/mcp/dispatch_http_slice4_test.go
@@ -350,7 +350,13 @@ func TestDispatch_LibraryActivate_ConventionByTitle(t *testing.T) {
 func TestDispatch_LibraryActivate_PlaybookByTitle_FallsThroughConventionLookup(t *testing.T) {
 	// A playbook title — the dispatcher should NOT find it in
 	// conventions, then fall through to the playbook library.
-	const wantTitle = "Implementation Workflow"
+	//
+	// PLAN-1397 (TASK-1403) retired the pre-PLAN-1377 trigger-only
+	// entries; "Ship tasks" is the headline invokable that still
+	// resolves through the library and still carries trigger + scope
+	// in its activation payload (plus invocation_slug + arguments,
+	// which this test doesn't assert on — those are covered separately).
+	const wantTitle = "Ship tasks"
 
 	mux := http.NewServeMux()
 	posted := ""
@@ -360,7 +366,7 @@ func TestDispatch_LibraryActivate_PlaybookByTitle_FallsThroughConventionLookup(t
 		posted = string(buf)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
-		_, _ = w.Write([]byte(`{"id":"pb-1","title":"Implementation Workflow"}`))
+		_, _ = w.Write([]byte(`{"id":"pb-1","title":"Ship tasks"}`))
 	})
 
 	d := &HTTPHandlerDispatcher{Handler: mux, UserResolver: fixedUserResolver(&models.User{ID: "u"})}


### PR DESCRIPTION
## Summary

Retires the legacy trigger-only library entries from the public surface and rebuilds the registry as invokable-first.

- New file `playbook_library_archive.go` holds all 9 retired bodies in a package-private `archivedPlaybooks()` helper. Compiled, greppable, refactor-safe — per-entry disposition decisions tracked in IDEA-1396.
- `PlaybookLibrary()` rebuilt as a single `agent-workflows` category containing ship + plan + decompose. The library now teaches the PLAN-1377 invocation model from the first card.
- `softwareStarterPlaybookTitles` updated from the retired pair to "Plan a new initiative" + "Decompose a plan into tasks" so software workspaces still seed a real starter pack. Startup separately prepends `ship`, so every software workspace now gets the full invokable trio.
- Test + CLI-help fixture references to "Implementation Workflow" updated to "Ship tasks" — T6's verify section flagged these.

## Context

T6 of PLAN-1397. Depends on T3 (#529), T4 (#530), T5 (#531) — all merged. The library is never empty because ship, plan, decompose are already in place.

## Test plan
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./...` — all packages green (MCP test fixture switched to "Ship tasks" since "Implementation Workflow" no longer resolves)
- [x] grep audit: only the archive file, the playbook_library_plan historical comment, and the unrelated demo-seed item in templates.go:868 still reference the retired titles
- [ ] Manual after merge: `pad workspace init --template scrum`, open library — only the 3 invokable entries appear under "agent-workflows"
- [ ] Manual after merge: `pad workspace init --template startup` — ship pre-seeded as Active, plan + decompose appear as activatable in library

## What's deliberately NOT changed

- Pre-existing workspaces' already-activated copies of the 9 retired entries (they live in workspace data, not library code — only future activations affected).
- `templates.go:868` demo-seed item titled "Implementation Workflow" — workspace-data fixture in a demo template, not library-driven; retitling out of scope here.