### PR TITLE
docs+test: closes the PLAN-1397 library overhaul loop (TASK-1404)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -250,6 +250,8 @@ Playbooks are first-class invokable procedures. They live in the `playbooks` col
 
 **Seeded `ship` playbook.** The `startup` template ships a generic `ship` playbook (`invocation_slug=ship`) derived from the personal `/ship-tasks` slash command. Fresh `pad workspace init --template startup` workspaces get it as PLAYB-N out of the box. See `internal/collections/templates_startup_ship.go` for the body + de-personalization choices.
 
+**Library — discovery surface for invokable playbooks.** Per PLAN-1397's invokable-first overhaul, the playbook library (web UI: `/[username]/[workspace]/library?tab=playbooks`; JSON: `GET /api/v1/playbook-library`) carries the three canonical invokable workflow playbooks — **`/pad ship`**, **`/pad plan`**, **`/pad decompose`** — under a single `agent-workflows` category. Each library card surfaces a `/pad <slug>` chip and an `N args` badge so the invocation model is visible before activation. Software templates auto-seed `plan` + `decompose` via `softwareStarterPlaybookTitles`; `startup` separately prepends `ship` so all three land together at workspace init. The pre-PLAN-1377 trigger-only checklist entries (Implementation Workflow, Code Review Process, Plan Creation, Bug Triage, Retrospective, Onboarding to a Project, Release Process, Deployment, Incident Response) are stashed in `playbook_library_archive.go::archivedPlaybooks()` — compiled but not surfaced; per-entry "convert / promote to convention / retire" decisions tracked in IDEA-1396.
+
 **Web UI editor.** `web/src/routes/[username]/[workspace]/playbooks/[slug]/+page.svelte` is the dedicated playbook editor — kebab-case slug input with debounced uniqueness check, structured arguments builder that round-trips with the body's `## Arguments` section, trigger selector with custom-trigger escape, and a "Test invocation" helper that renders `/pad`, `pad playbook run`, and `pad_playbook` MCP JSON forms from a slug + sample inputs. The reusable component lives at `web/src/lib/components/playbooks/PlaybookFormFields.svelte` and the shared parser/generator at `web/src/lib/playbooks/arguments.ts`.
 
 **Code map:**
@@ -257,11 +259,15 @@ Playbooks are first-class invokable procedures. They live in the `playbooks` col
 - `internal/server/handlers_playbooks.go` — `pad playbook list|show|run` HTTP handlers; `ParsePlaybookCLIArgs`, `resolvePlaybook`.
 - `internal/server/handlers_bootstrap.go` — `pad bootstrap`; embeds playbook metadata.
 - `internal/mcp/catalog_playbook.go` — `pad_playbook` MCP tool catalog entry.
-- `internal/collections/templates.go` — playbooks collection schema (`invocation_slug` + `arguments` fields).
-- `internal/collections/templates_startup_ship.go` — the seeded `ship` playbook.
+- `internal/collections/templates.go` — playbooks collection schema (`invocation_slug` + `arguments` fields); `softwareStarterPlaybookTitles` (auto-seed lineup for software templates).
+- `internal/collections/templates_startup_ship.go` — the seeded `ship` playbook (`ShipPlaybook()`, `shipPlaybookBody`, `shipPlaybookArguments`).
+- `internal/collections/playbook_library.go` — the invokable-first library (`PlaybookLibrary()`, `LibraryPlaybook` struct with `InvocationSlug` + `Arguments`).
+- `internal/collections/playbook_library_plan.go` — the `plan` library entry (`PlanPlaybook()`).
+- `internal/collections/playbook_library_decompose.go` — the `decompose` library entry (`DecomposePlaybook()`).
+- `internal/collections/playbook_library_archive.go` — retired pre-PLAN-1377 bodies; not surfaced, but compiled for future migrations (IDEA-1396).
 - `web/src/lib/playbooks/arguments.ts` — `## Arguments` parser/generator, `INVOCATION_SLUG_PATTERN`, `buildTestInvocation`.
 
-See `PLAN-1377` and `IDEA-1368` in this workspace for the design history.
+See `PLAN-1377` (invocation model) and `PLAN-1397` (library overhaul) in this workspace for the design history.
 
 ## Testing
 

--- a/internal/collections/playbook_library_test.go
+++ b/internal/collections/playbook_library_test.go
@@ -5,25 +5,23 @@ import (
 	"testing"
 )
 
-// knownPlaybookTriggers is the set of trigger values the workspace
-// playbook schemas accept (software domain). Used to catch typos in
-// library entries that would seed an invalid trigger value into a
-// workspace at activation time.
+// knownPlaybookTriggers is the set of trigger values the software
+// playbook schema accepts, sourced directly from SoftwarePlaybookTriggers
+// in templates.go. Used to catch typos in library entries that would
+// seed an invalid trigger value into a software workspace at activation.
 //
-// Kept independent of the schema's actual options list because the
-// schema is workspace-scoped and configurable per template; the
-// library entries we ship MUST stay within this safe baseline.
-var knownPlaybookTriggers = map[string]bool{
-	"on-implement":     true,
-	"on-review":        true,
-	"on-plan":          true,
-	"on-triage":        true,
-	"on-release":       true,
-	"on-deploy":        true,
-	"on-pr-create":     true,
-	"on-task-complete": true,
-	"manual":           true,
-	"always":           true,
+// Sourced from SoftwarePlaybookTriggers (not from a copy) so the test
+// stays in sync if the schema's option list ever changes — the
+// assertion can only drift if the schema itself widens. Library
+// entries we ship MUST stay within this safe baseline; templates
+// shipping non-software triggers (e.g. on-candidate-advance for hiring)
+// would need their own library scoped to that template.
+func buildKnownPlaybookTriggers() map[string]bool {
+	out := make(map[string]bool, len(SoftwarePlaybookTriggers))
+	for _, t := range SoftwarePlaybookTriggers {
+		out[t] = true
+	}
+	return out
 }
 
 // TestPlaybookLibrary_InvokableEntriesPresent asserts that PlaybookLibrary()
@@ -69,14 +67,16 @@ func TestPlaybookLibrary_InvokableEntriesPresent(t *testing.T) {
 }
 
 // TestPlaybookLibrary_AllTriggersKnown asserts every library entry's
-// Trigger field is one of the known values. Catches typos that would
-// seed an invalid trigger into a workspace at activation time.
+// Trigger field is one of the values SoftwarePlaybookTriggers accepts.
+// Catches typos that would seed an invalid trigger into a software
+// workspace at activation time.
 func TestPlaybookLibrary_AllTriggersKnown(t *testing.T) {
+	known := buildKnownPlaybookTriggers()
 	for _, cat := range PlaybookLibrary() {
 		for _, pb := range cat.Playbooks {
-			if !knownPlaybookTriggers[pb.Trigger] {
+			if !known[pb.Trigger] {
 				t.Errorf("playbook %q has unknown trigger %q — must be one of %s",
-					pb.Title, pb.Trigger, knownTriggersList())
+					pb.Title, pb.Trigger, knownTriggersList(known))
 			}
 		}
 	}
@@ -137,11 +137,11 @@ func TestPlaybookLibraryArchive_BodiesCompiled(t *testing.T) {
 	}
 }
 
-// knownTriggersList returns the sorted-ish set of accepted triggers
-// for assertion-failure messages.
-func knownTriggersList() string {
-	keys := make([]string, 0, len(knownPlaybookTriggers))
-	for k := range knownPlaybookTriggers {
+// knownTriggersList returns the accepted-triggers set as a comma-joined
+// string for assertion-failure messages.
+func knownTriggersList(known map[string]bool) string {
+	keys := make([]string, 0, len(known))
+	for k := range known {
 		keys = append(keys, k)
 	}
 	return strings.Join(keys, ", ")

--- a/internal/collections/playbook_library_test.go
+++ b/internal/collections/playbook_library_test.go
@@ -1,0 +1,148 @@
+package collections
+
+import (
+	"strings"
+	"testing"
+)
+
+// knownPlaybookTriggers is the set of trigger values the workspace
+// playbook schemas accept (software domain). Used to catch typos in
+// library entries that would seed an invalid trigger value into a
+// workspace at activation time.
+//
+// Kept independent of the schema's actual options list because the
+// schema is workspace-scoped and configurable per template; the
+// library entries we ship MUST stay within this safe baseline.
+var knownPlaybookTriggers = map[string]bool{
+	"on-implement":     true,
+	"on-review":        true,
+	"on-plan":          true,
+	"on-triage":        true,
+	"on-release":       true,
+	"on-deploy":        true,
+	"on-pr-create":     true,
+	"on-task-complete": true,
+	"manual":           true,
+	"always":           true,
+}
+
+// TestPlaybookLibrary_InvokableEntriesPresent asserts that PlaybookLibrary()
+// returns the three invokable workflow playbooks introduced by PLAN-1397
+// (ship, plan, decompose) and that their schema-widened fields
+// (InvocationSlug + Arguments) are populated.
+//
+// Regression guard: if PLAN-1397's struct widening (T1) got partially
+// reverted, or if T6's library rebuild accidentally dropped one of the
+// three, this test catches it before the library ships empty/broken
+// to a fresh workspace.
+func TestPlaybookLibrary_InvokableEntriesPresent(t *testing.T) {
+	wantSlugs := map[string]bool{
+		"ship":      false,
+		"plan":      false,
+		"decompose": false,
+	}
+
+	invokableCount := 0
+	for _, cat := range PlaybookLibrary() {
+		for _, pb := range cat.Playbooks {
+			if pb.InvocationSlug == "" {
+				continue
+			}
+			invokableCount++
+			if _, expected := wantSlugs[pb.InvocationSlug]; expected {
+				wantSlugs[pb.InvocationSlug] = true
+			}
+			if len(pb.Arguments) == 0 {
+				t.Errorf("playbook %q (slug=%s) has invocation_slug but no arguments — declare at least one in `## Arguments`", pb.Title, pb.InvocationSlug)
+			}
+		}
+	}
+
+	if invokableCount < 3 {
+		t.Errorf("expected at least 3 invokable library entries; got %d", invokableCount)
+	}
+	for slug, present := range wantSlugs {
+		if !present {
+			t.Errorf("invokable playbook with slug %q missing from PlaybookLibrary()", slug)
+		}
+	}
+}
+
+// TestPlaybookLibrary_AllTriggersKnown asserts every library entry's
+// Trigger field is one of the known values. Catches typos that would
+// seed an invalid trigger into a workspace at activation time.
+func TestPlaybookLibrary_AllTriggersKnown(t *testing.T) {
+	for _, cat := range PlaybookLibrary() {
+		for _, pb := range cat.Playbooks {
+			if !knownPlaybookTriggers[pb.Trigger] {
+				t.Errorf("playbook %q has unknown trigger %q — must be one of %s",
+					pb.Title, pb.Trigger, knownTriggersList())
+			}
+		}
+	}
+}
+
+// TestPlaybookLibrary_ShipBodyShared confirms the library `ship` entry
+// and the startup template's ShipPlaybook() seed share the same body
+// constant — the whole point of T3 was to avoid body duplication.
+//
+// If a future refactor inadvertently copies the body, the assertion
+// here flips, prompting a re-share.
+func TestPlaybookLibrary_ShipBodyShared(t *testing.T) {
+	var libraryShip *LibraryPlaybook
+	for _, cat := range PlaybookLibrary() {
+		for i := range cat.Playbooks {
+			if cat.Playbooks[i].InvocationSlug == "ship" {
+				libraryShip = &cat.Playbooks[i]
+				break
+			}
+		}
+		if libraryShip != nil {
+			break
+		}
+	}
+	if libraryShip == nil {
+		t.Fatal("ship not found in PlaybookLibrary() — see TestPlaybookLibrary_InvokableEntriesPresent")
+	}
+	seed := ShipPlaybook()
+	if libraryShip.Content != seed.Content {
+		t.Error("library ship.Content diverges from ShipPlaybook() seed body — they should share shipPlaybookBody")
+	}
+	if seed.Title != libraryShip.Title {
+		t.Errorf("library ship.Title %q != ShipPlaybook seed title %q — drift will break activePlaybookTitles matching in the library UI",
+			libraryShip.Title, seed.Title)
+	}
+}
+
+// TestPlaybookLibraryArchive_BodiesCompiled keeps the archive helper
+// referenced. If a future refactor removes the `var _ = archivedPlaybooks`
+// reference AND nobody else calls the function, the `unused` linter
+// would flag it — this test makes the intent explicit and the failure
+// mode loud.
+func TestPlaybookLibraryArchive_BodiesCompiled(t *testing.T) {
+	got := archivedPlaybooks()
+	if len(got) == 0 {
+		t.Fatal("archivedPlaybooks() returned empty slice — were the 9 pre-PLAN-1377 bodies accidentally removed?")
+	}
+	// Spot-check: at least the headline retired title is present.
+	var sawImpl bool
+	for _, pb := range got {
+		if pb.Title == "Implementation Workflow" {
+			sawImpl = true
+			break
+		}
+	}
+	if !sawImpl {
+		t.Error(`archivedPlaybooks() missing "Implementation Workflow" — the canonical retired entry`)
+	}
+}
+
+// knownTriggersList returns the sorted-ish set of accepted triggers
+// for assertion-failure messages.
+func knownTriggersList() string {
+	keys := make([]string, 0, len(knownPlaybookTriggers))
+	for k := range knownPlaybookTriggers {
+		keys = append(keys, k)
+	}
+	return strings.Join(keys, ", ")
+}

--- a/skills/pad/SKILL.md
+++ b/skills/pad/SKILL.md
@@ -192,8 +192,8 @@ Items can carry image and file attachments. They appear in item content as `![al
 **Hard rule for agents:** NEVER read files directly from `~/.pad/attachments/<storage_key>`. That bypasses workspace ACLs, doesn't work on Pad Cloud / remote / Postgres deployments, skips the variant pipeline (thumbnails, EXIF strip, server-side rotate/crop), and breaks when storage moves to S3. Always go through `pad attachment view|show|list|download` so the request is authenticated and works on every Pad install.
 
 **Planning:**
-- "let's create a plan" → Multi-step planning workflow (see below)
-- "break plan 2 into tasks" → Decompose a plan into task items
+- "let's create a plan" → `/pad plan <topic>` if the `plan` playbook is activated; otherwise inline workflow (see below)
+- "break plan 2 into tasks" → `/pad decompose PLAN-2` if the `decompose` playbook is activated; otherwise inline workflow
 - "what's blocking us?" → Analyze open items and dependencies
 
 **Ideation:**
@@ -463,6 +463,10 @@ All commands support `--format json` (for parsing) or `--format table` (default,
 
 ### Planning: "Let's create a plan"
 
+**Canonical entry point: `/pad plan <topic>`** — when the workspace has the `plan` invokable playbook activated (visible in the bootstrap's `playbooks` array with `invocation_slug=plan`), invoke that. It's the structured, argument-bound version of the workflow below and walks the user through goal/scope/breakdown with confirmation checkpoints. The `plan` library entry seeds automatically for software templates (`softwareStarterPlaybookTitles`); workspaces using non-software templates can activate it from the library UI.
+
+If the `plan` playbook isn't activated, fall back to the inline workflow:
+
 1. **Load context:** `pad project dashboard --format json`, `pad item list plans --all --format json`
 2. **Understand current state:** What plans exist? What's active? What's completed?
 3. **Propose outline:** Present plan title + 1-line summary. Ask for feedback.
@@ -476,6 +480,10 @@ All commands support `--format json` (for parsing) or `--format table` (default,
 8. **Ask before creating each item.** Don't bulk-create without approval.
 
 ### Decomposition: "Break plan X into tasks"
+
+**Canonical entry point: `/pad decompose <PLAN-ref>`** — when the workspace has the `decompose` invokable playbook activated (bootstrap's `playbooks` array with `invocation_slug=decompose`), invoke that. It accepts `target` (the plan ref), `dry-run` (propose without creating), and `collection` (default=tasks) and handles reconciliation against existing children, dependency wiring, and per-task confirmation. Like `plan`, it auto-seeds for software templates.
+
+If the `decompose` playbook isn't activated, fall back to the inline workflow:
 
 1. **Load the plan:** `pad item show PLAN-2 --format markdown`
 2. **Analyze the content** for actionable work items


### PR DESCRIPTION
## Summary

Final pass on PLAN-1397's playbook library overhaul.

**Tests** — new `internal/collections/playbook_library_test.go` with 4 regression guards:
- ship + plan + decompose all present by `invocation_slug`, with non-empty Arguments
- Every library entry's `Trigger` is a canonical value
- Library `ship` body and `ShipPlaybook()` seed share the same constant (no drift)
- `archivedPlaybooks()` is non-empty and still contains the canonical retired title

**CLAUDE.md** — added a "Library — discovery surface" subsection, expanded the Playbooks Code map with the 4 new/refactored library files, cross-referenced PLAN-1397.

**skills/pad/SKILL.md** — Planning + Decomposition workflows now name `/pad plan` and `/pad decompose` as canonical entry points with the inline workflow as fallback. The high-level intent list updated to match. (SKILL.md ships in the binary; `make install` distributes it.)

## Context

T7 of PLAN-1397. Depends on T1-T6 — all merged. This is the closer.

## Test plan
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./...` — all packages green
- [x] New regression tests all pass: TestPlaybookLibrary_InvokableEntriesPresent, TestPlaybookLibrary_AllTriggersKnown, TestPlaybookLibrary_ShipBodyShared, TestPlaybookLibraryArchive_BodiesCompiled
- [ ] Manual after merge: `make install` distributes the SKILL.md update to fresh agent sessions