### PR TITLE
refactor(bootstrap): dedup recent_activity, drop convention slug, cap dashboard arrays (TASK-1413)

### DIFF
--- a/internal/server/handlers_bootstrap.go
+++ b/internal/server/handlers_bootstrap.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"sort"
 	"strings"
-	"time"
 
 	"github.com/PerpetualSoftware/pad/internal/models"
 )
@@ -21,14 +20,13 @@ import (
 // in `pad_set_workspace`'s response, and an on-demand `pad_meta.action=bootstrap`
 // refresh.
 type AgentBootstrap struct {
-	Workspace      AgentBootstrapWorkspace      `json:"workspace"`
-	User           AgentBootstrapUser           `json:"user"`
-	Collections    []BootstrapCollection        `json:"collections"`
-	Conventions    []AgentBootstrapConvention   `json:"conventions"`
-	Roles          []models.AgentRole           `json:"roles"`
-	Playbooks      []AgentBootstrapPlaybookMeta `json:"playbooks"`
-	Dashboard      *DashboardResponse           `json:"dashboard,omitempty"`
-	RecentActivity []DashboardActivity          `json:"recent_activity"`
+	Workspace   AgentBootstrapWorkspace      `json:"workspace"`
+	User        AgentBootstrapUser           `json:"user"`
+	Collections []BootstrapCollection        `json:"collections"`
+	Conventions []AgentBootstrapConvention   `json:"conventions"`
+	Roles       []models.AgentRole           `json:"roles"`
+	Playbooks   []AgentBootstrapPlaybookMeta `json:"playbooks"`
+	Dashboard   *BootstrapDashboard          `json:"dashboard,omitempty"`
 }
 
 // BootstrapCollection is the lightweight collection projection delivered
@@ -116,10 +114,12 @@ type AgentBootstrapUser struct {
 // always-on, active conventions are returned — the curated must-follow
 // set. trigger-specific conventions load on demand when their trigger
 // fires.
+//
+// `slug` was dropped in PLAN-1410 / TASK-1413: the agent addresses
+// items by `ref` (CONVE-N) — slug was dead weight.
 type AgentBootstrapConvention struct {
 	Ref      string `json:"ref"`
 	Title    string `json:"title"`
-	Slug     string `json:"slug"`
 	Content  string `json:"content"`
 	Priority string `json:"priority,omitempty"`
 	Scope    string `json:"scope,omitempty"`
@@ -150,10 +150,37 @@ type AgentBootstrapPlaybookMeta struct {
 	Summary string `json:"summary,omitempty"`
 }
 
-// recentActivityWindow caps how far back the bootstrap reaches for the
-// recent_activity tail. Bootstrap is a context-load call — anything older
-// than this isn't relevant to "what's happening now."
-const recentActivityWindow = 24 * time.Hour
+// BootstrapDashboard is the bootstrap-side dashboard projection. It
+// embeds *DashboardResponse so the wire shape stays compatible with the
+// `GET /dashboard` endpoint (same field names, same nesting), then adds
+// two overflow counts that report how many entries were trimmed from
+// the bootstrap's capped views.
+//
+// Why a wrapper rather than mutating DashboardResponse: the cap is
+// bootstrap-only — `pad project dashboard` and the web UI's dashboard
+// page consume the FULL set, unchanged. PLAN-1410 / TASK-1413.
+type BootstrapDashboard struct {
+	*DashboardResponse
+	// AttentionOverflowCount is len(original attention) - cap, or
+	// omitted when nothing was trimmed. The agent reads this to decide
+	// whether to suggest pulling the full set via `pad project dashboard`.
+	AttentionOverflowCount int `json:"attention_overflow_count,omitempty"`
+	// RecentActivityOverflowCount mirrors AttentionOverflowCount for the
+	// recent_activity tail.
+	RecentActivityOverflowCount int `json:"recent_activity_overflow_count,omitempty"`
+}
+
+// bootstrapAttentionCap and bootstrapRecentActivityCap clamp the
+// dashboard's `attention` and `recent_activity` arrays in the bootstrap
+// projection. 5 is the practical surfacing depth for an agent greeting
+// or status pass — anything beyond is too much for a single response
+// to render conversationally; the agent should pivot to the full
+// `pad project dashboard` query when the overflow count signals more
+// work to consider. PLAN-1410.
+const (
+	bootstrapAttentionCap      = 5
+	bootstrapRecentActivityCap = 5
+)
 
 // isCollectionSlugVisible reports whether the named collection survived
 // the visibility filter. Used by the bootstrap path to gate
@@ -347,20 +374,14 @@ func (s *Server) BuildAgentBootstrap(workspaceID string, user *models.User, r *h
 	}
 
 	// Dashboard — recreate via the existing handler logic if a request
-	// context is available. The shape is identical to `GET /dashboard`
-	// so the web UI dashboard page can consume bootstrap directly and
-	// retire its dedicated fetch.
+	// context is available, then wrap in BootstrapDashboard so the
+	// bootstrap-side cap on `attention` and `recent_activity` (with
+	// overflow counts) doesn't leak into the `GET /dashboard` contract.
 	if r != nil {
 		dash, derr := s.buildDashboardResponse(workspaceID, r)
-		if derr == nil {
-			out.Dashboard = dash
-			if dash != nil {
-				out.RecentActivity = capRecentActivity(dash.RecentActivity, recentActivityWindow)
-			}
+		if derr == nil && dash != nil {
+			out.Dashboard = capBootstrapDashboard(dash)
 		}
-	}
-	if out.RecentActivity == nil {
-		out.RecentActivity = []DashboardActivity{}
 	}
 
 	return out, nil
@@ -400,7 +421,6 @@ func (s *Server) collectAlwaysOnConventions(workspaceID string, collIDs []string
 		out = append(out, AgentBootstrapConvention{
 			Ref:      it.Ref,
 			Title:    it.Title,
-			Slug:     it.Slug,
 			Content:  it.Content,
 			Priority: strField("priority"),
 			Scope:    strField("scope"),
@@ -550,33 +570,25 @@ func trimLeadingSpaces(s string) string {
 	return s[i:]
 }
 
-// capRecentActivity returns the activity events that fall within the
-// bootstrap's recency window. Dashboard's recent_activity may extend
-// further back; bootstrap deliberately trims to keep the payload tight.
+// capBootstrapDashboard wraps a DashboardResponse with the bootstrap's
+// per-section caps. The underlying *DashboardResponse is shallow-copied
+// before the slice headers are reslized so the caller's pointer (used by
+// the dashboard endpoint elsewhere) sees its original full-length
+// arrays unchanged. The slice backing arrays are shared — we only
+// trim the view, no allocation needed for the truncated portion.
 //
-// DashboardActivity.CreatedAt is a pre-formatted RFC3339-shaped string
-// (set in handleGetDashboard with `a.CreatedAt.Format("2006-01-02T15:04:05Z")`),
-// so we parse it back to time.Time for the comparison. Entries that fail
-// to parse are kept defensively — losing them silently because of a format
-// glitch would be a worse outcome than carrying a slightly older event.
-func capRecentActivity(in []DashboardActivity, window time.Duration) []DashboardActivity {
-	if len(in) == 0 {
-		return []DashboardActivity{}
+// Returns a non-nil *BootstrapDashboard even when both caps are
+// untriggered, so the agent always sees a consistent shape.
+func capBootstrapDashboard(d *DashboardResponse) *BootstrapDashboard {
+	copied := *d
+	out := &BootstrapDashboard{DashboardResponse: &copied}
+	if n := len(copied.Attention) - bootstrapAttentionCap; n > 0 {
+		copied.Attention = copied.Attention[:bootstrapAttentionCap]
+		out.AttentionOverflowCount = n
 	}
-	cutoff := time.Now().Add(-window)
-	out := make([]DashboardActivity, 0, len(in))
-	for _, a := range in {
-		t, err := time.Parse("2006-01-02T15:04:05Z", a.CreatedAt)
-		if err != nil {
-			if t, err = time.Parse(time.RFC3339, a.CreatedAt); err != nil {
-				out = append(out, a)
-				continue
-			}
-		}
-		if t.Before(cutoff) {
-			continue
-		}
-		out = append(out, a)
+	if n := len(copied.RecentActivity) - bootstrapRecentActivityCap; n > 0 {
+		copied.RecentActivity = copied.RecentActivity[:bootstrapRecentActivityCap]
+		out.RecentActivityOverflowCount = n
 	}
 	return out
 }

--- a/internal/server/handlers_bootstrap_test.go
+++ b/internal/server/handlers_bootstrap_test.go
@@ -40,9 +40,14 @@ func TestBootstrapEmptyWorkspace(t *testing.T) {
 		t.Error("roles is nil; should be an empty slice")
 	}
 
-	// RecentActivity is non-nil by contract.
-	if b.RecentActivity == nil {
-		t.Error("recent_activity is nil; should be an empty slice")
+	// Dashboard is populated when a request context is available;
+	// recent_activity lives inside it (the top-level duplicate was
+	// retired in PLAN-1410 / TASK-1413). On the empty-workspace path
+	// dashboard may itself be nil if buildDashboardResponse returns
+	// an empty/error result — the agent tolerates that via the
+	// omitempty tag, so we don't assert non-nil here.
+	if b.Dashboard != nil && b.Dashboard.RecentActivity == nil {
+		t.Error("dashboard.recent_activity is nil; should be an empty slice")
 	}
 }
 
@@ -63,7 +68,10 @@ func TestBootstrapEmptyArraysNotNull(t *testing.T) {
 		t.Fatalf("decode raw: %v", err)
 	}
 
-	for _, key := range []string{"collections", "conventions", "roles", "playbooks", "recent_activity"} {
+	// PLAN-1410 / TASK-1413: the top-level `recent_activity` key was
+	// retired (duplicate of dashboard.recent_activity). The remaining
+	// top-level array fields must still serialize as [] not null.
+	for _, key := range []string{"collections", "conventions", "roles", "playbooks"} {
 		val, ok := raw[key]
 		if !ok {
 			t.Errorf("missing key %q in bootstrap response", key)
@@ -73,6 +81,12 @@ func TestBootstrapEmptyArraysNotNull(t *testing.T) {
 		if s == "null" {
 			t.Errorf("bootstrap.%s serialized as null; want []", key)
 		}
+	}
+
+	// Guard against accidental reintroduction of the duplicate
+	// top-level recent_activity field.
+	if _, ok := raw["recent_activity"]; ok {
+		t.Errorf("top-level recent_activity reappeared in bootstrap response; it should live only under dashboard")
 	}
 }
 
@@ -135,12 +149,13 @@ func TestBootstrapIncludesPlaybookMetadata(t *testing.T) {
 //
 //	TASK-1411 — 16 KiB (baseline benchmark added; fixture at 13,861 bytes)
 //	TASK-1412 — 11 KiB (slim BootstrapCollection projection; fixture at 8,992 bytes — collections section dropped from 8,848 to 3,979 bytes)
+//	TASK-1413 — 8 KiB  (dedup top-level recent_activity, drop convention slug, cap dashboard.attention/recent_activity to 5 with overflow counts; fixture at 6,355 bytes — total dropped another 2,637 bytes)
 //
-// The next PRs in PLAN-1410 tighten this further (TASK-1413's dedup +
-// caps; TASK-1417's final measurement). The constant intentionally
-// lives next to the test that consumes it so PRs touching the bootstrap
-// shape see the budget in the diff.
-const bootstrapSizeBudget = 11 * 1024
+// The remaining PRs in PLAN-1410 are skill-side trims that don't affect
+// the bootstrap response shape, plus TASK-1417's final measurement
+// step. The constant intentionally lives next to the test that consumes
+// it so PRs touching the bootstrap shape see the budget in the diff.
+const bootstrapSizeBudget = 8 * 1024
 
 // TestBootstrapSizeBudget locks in a payload-size budget for the
 // bootstrap response so future regressions are caught at PR time.
@@ -240,16 +255,30 @@ func seedBootstrapSizeFixture(t *testing.T, srv *Server, wsSlug string) {
 // Diagnostic only — not part of any production contract. Sized for
 // readability in `go test -v` output.
 func bootstrapSectionBytes(b AgentBootstrap) []string {
-	return []string{
-		fmt.Sprintf("workspace:       %d bytes", jsonLen(b.Workspace)),
-		fmt.Sprintf("user:            %d bytes", jsonLen(b.User)),
-		fmt.Sprintf("collections:     %d bytes (%d items)", jsonLen(b.Collections), len(b.Collections)),
-		fmt.Sprintf("conventions:     %d bytes (%d items)", jsonLen(b.Conventions), len(b.Conventions)),
-		fmt.Sprintf("roles:           %d bytes (%d items)", jsonLen(b.Roles), len(b.Roles)),
-		fmt.Sprintf("playbooks:       %d bytes (%d items)", jsonLen(b.Playbooks), len(b.Playbooks)),
-		fmt.Sprintf("dashboard:       %d bytes", jsonLen(b.Dashboard)),
-		fmt.Sprintf("recent_activity: %d bytes (%d items)", jsonLen(b.RecentActivity), len(b.RecentActivity)),
+	lines := []string{
+		fmt.Sprintf("workspace:   %d bytes", jsonLen(b.Workspace)),
+		fmt.Sprintf("user:        %d bytes", jsonLen(b.User)),
+		fmt.Sprintf("collections: %d bytes (%d items)", jsonLen(b.Collections), len(b.Collections)),
+		fmt.Sprintf("conventions: %d bytes (%d items)", jsonLen(b.Conventions), len(b.Conventions)),
+		fmt.Sprintf("roles:       %d bytes (%d items)", jsonLen(b.Roles), len(b.Roles)),
+		fmt.Sprintf("playbooks:   %d bytes (%d items)", jsonLen(b.Playbooks), len(b.Playbooks)),
+		fmt.Sprintf("dashboard:   %d bytes", jsonLen(b.Dashboard)),
 	}
+	// Surface the caps' effect when triggered so the trim's value is
+	// legible from CI output as PLAN-1410's later PRs land.
+	if b.Dashboard != nil {
+		if b.Dashboard.AttentionOverflowCount > 0 {
+			lines = append(lines, fmt.Sprintf(
+				"  └─ attention capped: %d shown, %d overflow",
+				len(b.Dashboard.Attention), b.Dashboard.AttentionOverflowCount))
+		}
+		if b.Dashboard.RecentActivityOverflowCount > 0 {
+			lines = append(lines, fmt.Sprintf(
+				"  └─ recent_activity capped: %d shown, %d overflow",
+				len(b.Dashboard.RecentActivity), b.Dashboard.RecentActivityOverflowCount))
+		}
+	}
+	return lines
 }
 
 // jsonLen marshals v to compact JSON and returns the byte count. Test
@@ -262,6 +291,92 @@ func jsonLen(v interface{}) int {
 		return -1
 	}
 	return len(out)
+}
+
+// TestCapBootstrapDashboard isolates the bootstrap dashboard cap logic
+// from the rest of the bootstrap pipeline so the contract (cap to N,
+// surface overflow count, leave the source pointer untouched) doesn't
+// drift silently. PLAN-1410 / TASK-1413.
+func TestCapBootstrapDashboard(t *testing.T) {
+	// Helper: make a DashboardResponse with N attention + M recent_activity.
+	mk := func(attN, recN int) *DashboardResponse {
+		attention := make([]DashboardAttention, attN)
+		for i := range attention {
+			attention[i] = DashboardAttention{Type: "stalled", ItemRef: fmt.Sprintf("TASK-%d", i)}
+		}
+		recent := make([]DashboardActivity, recN)
+		for i := range recent {
+			recent[i] = DashboardActivity{Action: "updated", ItemSlug: fmt.Sprintf("item-%d", i)}
+		}
+		return &DashboardResponse{Attention: attention, RecentActivity: recent}
+	}
+
+	t.Run("under-cap-no-overflow", func(t *testing.T) {
+		d := mk(2, 3)
+		out := capBootstrapDashboard(d)
+		if out == nil {
+			t.Fatal("expected non-nil result even when nothing trimmed")
+		}
+		if got := len(out.Attention); got != 2 {
+			t.Errorf("attention len = %d, want 2 (under cap, no trim)", got)
+		}
+		if out.AttentionOverflowCount != 0 {
+			t.Errorf("attention_overflow_count = %d, want 0", out.AttentionOverflowCount)
+		}
+		if got := len(out.RecentActivity); got != 3 {
+			t.Errorf("recent_activity len = %d, want 3", got)
+		}
+		if out.RecentActivityOverflowCount != 0 {
+			t.Errorf("recent_activity_overflow_count = %d, want 0", out.RecentActivityOverflowCount)
+		}
+	})
+
+	t.Run("over-cap-truncates-and-counts-overflow", func(t *testing.T) {
+		d := mk(bootstrapAttentionCap+8, bootstrapRecentActivityCap+3)
+		out := capBootstrapDashboard(d)
+		if got := len(out.Attention); got != bootstrapAttentionCap {
+			t.Errorf("attention len = %d, want %d (capped)", got, bootstrapAttentionCap)
+		}
+		if out.AttentionOverflowCount != 8 {
+			t.Errorf("attention_overflow_count = %d, want 8", out.AttentionOverflowCount)
+		}
+		if got := len(out.RecentActivity); got != bootstrapRecentActivityCap {
+			t.Errorf("recent_activity len = %d, want %d (capped)", got, bootstrapRecentActivityCap)
+		}
+		if out.RecentActivityOverflowCount != 3 {
+			t.Errorf("recent_activity_overflow_count = %d, want 3", out.RecentActivityOverflowCount)
+		}
+	})
+
+	t.Run("source-pointer-unchanged", func(t *testing.T) {
+		// Defensive contract: callers downstream of buildDashboardResponse
+		// (the dashboard endpoint itself) must see their full-length
+		// arrays. The cap mutates a shallow copy.
+		d := mk(bootstrapAttentionCap+5, bootstrapRecentActivityCap+5)
+		origAttLen := len(d.Attention)
+		origRecLen := len(d.RecentActivity)
+
+		_ = capBootstrapDashboard(d)
+
+		if got := len(d.Attention); got != origAttLen {
+			t.Errorf("source Attention mutated: len = %d, want %d", got, origAttLen)
+		}
+		if got := len(d.RecentActivity); got != origRecLen {
+			t.Errorf("source RecentActivity mutated: len = %d, want %d", got, origRecLen)
+		}
+	})
+
+	t.Run("exact-cap-no-overflow", func(t *testing.T) {
+		// Boundary: len == cap should not flag overflow.
+		d := mk(bootstrapAttentionCap, bootstrapRecentActivityCap)
+		out := capBootstrapDashboard(d)
+		if out.AttentionOverflowCount != 0 {
+			t.Errorf("attention_overflow_count at exact cap = %d, want 0", out.AttentionOverflowCount)
+		}
+		if out.RecentActivityOverflowCount != 0 {
+			t.Errorf("recent_activity_overflow_count at exact cap = %d, want 0", out.RecentActivityOverflowCount)
+		}
+	})
 }
 
 // TestPlaybookSummaryPrefersFirstParagraph isolates the summary extraction

--- a/skills/pad/SKILL.md
+++ b/skills/pad/SKILL.md
@@ -37,8 +37,7 @@ The returned `AgentBootstrap` blob carries everything the skill needs to start a
 - `conventions [...]` — full bodies of `trigger=always, status=active` items. **Must-follow project rules.**
 - `roles [...]` — agent roles configured in the workspace
 - `playbooks [...]` — METADATA ONLY: `ref`, `title`, `slug`, `invocation_slug`, `trigger`, `scope`, `status`, `has_arguments`, `summary`. Full bodies load on invocation via `pad playbook show <slug>`.
-- `dashboard {...}` — active items, attention, suggested next, recent activity
-- `recent_activity [...]` — capped to the last 24h
+- `dashboard {...}` — active items, attention, suggested next, recent activity. `attention` and `recent_activity` are capped to 5 entries each; `attention_overflow_count` and `recent_activity_overflow_count` report how many were trimmed (use `pad project dashboard` to pull the full set when overflow > 0).
 
 If the conventions list includes items, treat them as project rules you must follow. The vocabulary depends on the workspace domain — a software workspace ships rules like "use conventional commit format," a hiring workspace ships rules like "anonymize candidate names in exports," a research workspace ships rules like "always cite sources." Follow whatever the workspace has configured.
 


### PR DESCRIPTION
## Summary

Three bundled handler-level cleanups against [PLAN-1410](../)'s bootstrap shape. Combined fixture savings: **8,992 → 6,355 bytes (−29%)**.

1. **Drop duplicate top-level `recent_activity`** — bit-for-bit identical to `dashboard.recent_activity`. Removed the field + `capRecentActivity` helper + `recentActivityWindow` constant + the now-unused `time` import. **−1,751 bytes.**
2. **Drop `slug` from `AgentBootstrapConvention`** — agents address by `ref` (CONVE-N); slug was dead weight. **−78 bytes.**
3. **Cap `dashboard.attention` + `dashboard.recent_activity` to 5 in bootstrap** — new `BootstrapDashboard` wrapper embeds `*DashboardResponse` (same wire shape) and adds `attention_overflow_count` + `recent_activity_overflow_count` (omitempty when zero). Cap applied via `capBootstrapDashboard` which **shallow-copies** the `DashboardResponse` so the dashboard endpoint and web UI see their original full-length arrays unchanged. **−789 bytes** (recent_activity capped 9 → 5 on fixture; attention untouched, fixture has 0 attention items).

## Context

Third PR in PLAN-1410. Bundles three small handler-level cleanups that together remove the bulk of the bootstrap's accidental waste: the duplicate field, dead-weight identifier, and the unbounded array growth from a busy dashboard.

## Wire-shape changes

**`AgentBootstrap`**:
```diff
 type AgentBootstrap struct {
-    Dashboard      *DashboardResponse           `json:"dashboard,omitempty"`
-    RecentActivity []DashboardActivity          `json:"recent_activity"`
+    Dashboard      *BootstrapDashboard          `json:"dashboard,omitempty"`
 }
```

**`AgentBootstrapConvention`**:
```diff
 type AgentBootstrapConvention struct {
     Ref      string `json:"ref"`
     Title    string `json:"title"`
-    Slug     string `json:"slug"`
     Content  string `json:"content"`
     ...
 }
```

**`BootstrapDashboard`** (new):
```go
type BootstrapDashboard struct {
    *DashboardResponse                       // embedded — same fields, same nesting
    AttentionOverflowCount      int `json:"attention_overflow_count,omitempty"`
    RecentActivityOverflowCount int `json:"recent_activity_overflow_count,omitempty"`
}
```

The `GET /dashboard` endpoint shape is **unchanged** — caps + overflow counts live only in the bootstrap projection.

## Test coverage

- New `TestCapBootstrapDashboard` (4 subtests):
  - `under-cap-no-overflow` — short arrays, no truncation, no overflow counts.
  - `over-cap-truncates-and-counts-overflow` — long arrays truncated to cap, overflow counts match the delta.
  - `source-pointer-unchanged` — caller's pointer (used by the dashboard endpoint) sees its full-length arrays.
  - `exact-cap-no-overflow` — boundary case at `len == cap` doesn't flag overflow.
- `TestBootstrapEmptyArraysNotNull` updated: top-level `recent_activity` removed from required keys, plus a guard against accidental reintroduction.
- `TestBootstrapEmptyWorkspace` updated: removed the `b.RecentActivity` nil-check; added a defensive check on `dashboard.recent_activity`.
- `bootstrapSectionBytes` now surfaces the cap effect on success runs ("recent_activity capped: 5 shown, 4 overflow") so the trim's value is legible from CI output.

## Measured impact

Against the `TestBootstrapSizeBudget` fixture:

| Section          | Before (TASK-1412) | After (TASK-1413) | Delta            |
|------------------|-------------------:|------------------:|-----------------:|
| collections      | 3,979 b            | 3,979 b           | unchanged        |
| conventions      | 609 b              | 531 b             | −78 b (slug)     |
| dashboard        | 2,251 b            | 1,462 b           | −789 b (cap)     |
| recent_activity (top-level) | 1,751 b | — | −1,751 b (removed) |
| **total**        | **8,992 b**        | **6,355 b**       | **−2,637 b (−29%)** |

`bootstrapSizeBudget` tightened **11 KiB → 8 KiB**. Cumulative win vs the TASK-1411 baseline: **13,861 → 6,355 b (−54%)**.

## Out of scope (handled by later PLAN-1410 PRs)

- Skill-file trim (TASK-1414/1415/1416).
- Final measurement (TASK-1417).
- `ToolSurfaceVersion` 0.3 → 0.4 (TASK-1418 — landed last so all shape changes are reviewed in isolation but announced under one contract version).

## Test plan

- [x] `go build ./...` — clean
- [x] `make check` — golangci-lint 0 issues, all Go tests pass, govulncheck clean, web build clean
- [x] `TestBootstrapSizeBudget` reports **6,355 bytes** against the 8 KiB budget
- [x] `TestCapBootstrapDashboard` (4 subtests) — all pass
- [x] `TestBootstrapEmptyWorkspace`, `TestBootstrapEmptyArraysNotNull`, `TestBootstrapIncludesPlaybookMetadata` all pass against the new shape