### PR TITLE
chore(bootstrap): tighten size budget 8 KiB → 7 KiB to lock in PLAN-1410's win (TASK-1417)

### DIFF
--- a/internal/server/handlers_bootstrap_test.go
+++ b/internal/server/handlers_bootstrap_test.go
@@ -150,12 +150,13 @@ func TestBootstrapIncludesPlaybookMetadata(t *testing.T) {
 //	TASK-1411 — 16 KiB (baseline benchmark added; fixture at 13,861 bytes)
 //	TASK-1412 — 11 KiB (slim BootstrapCollection projection; fixture at 8,992 bytes — collections section dropped from 8,848 to 3,979 bytes)
 //	TASK-1413 — 8 KiB  (dedup top-level recent_activity, drop convention slug, cap dashboard.attention/recent_activity to 5 with overflow counts; fixture at 6,355 bytes — total dropped another 2,637 bytes)
+//	TASK-1417 — 7 KiB  (close-out: bootstrap shape work complete, fixture still at 6,355 bytes; locks in the cumulative -54.2% win with ~12.8% headroom for routine schema reordering)
 //
-// The remaining PRs in PLAN-1410 are skill-side trims that don't affect
-// the bootstrap response shape, plus TASK-1417's final measurement
-// step. The constant intentionally lives next to the test that consumes
-// it so PRs touching the bootstrap shape see the budget in the diff.
-const bootstrapSizeBudget = 8 * 1024
+// PLAN-1410 followups land their own wins under their own budget
+// ratchets (e.g. IDEA-1421's dashboard sub-array caps). The constant
+// intentionally lives next to the test that consumes it so PRs
+// touching the bootstrap shape see the budget in the diff.
+const bootstrapSizeBudget = 7 * 1024
 
 // TestBootstrapSizeBudget locks in a payload-size budget for the
 // bootstrap response so future regressions are caught at PR time.


### PR DESCRIPTION
## Summary

PLAN-1410 close-out: tightens `bootstrapSizeBudget` from **8 KiB → 7 KiB** to lock in the cumulative shape-and-skill win measured across [PLAN-1410](../) (TASK-1411 through TASK-1416). The companion measurement (per-section bytes + pre/post per-invocation totals) was recorded directly into PLAN-1410's body via `pad item update PLAN-1410 --stdin` — that's the canonical home for plan results, not the PR body or commit message.

## Why now

The fixture has measured **6,355 bytes** since TASK-1413 landed. The 8 KiB budget left ~29% headroom — too loose for a ratchet whose purpose is to detect shape regressions. 7 KiB keeps ~12.8% headroom: tight enough to catch any meaningful shape regression (reintroducing a duplicated field, un-capping a dashboard array, re-stringifying schema), loose enough to absorb routine schema reordering or single-field additions without false alarms.

## Cumulative PLAN-1410 measurements

### Fixture (`TestBootstrapSizeBudget`) — bootstrap shape held constant

| | TASK-1411 baseline | Post | Delta |
|---|---:|---:|---:|
| collections | 8,848 b | 3,979 b | **−55%** |
| conventions | 609 b | 531 b | −13% |
| dashboard | 2,251 b | 1,462 b | **−35%** (cap) |
| top-level recent_activity | 1,751 b | — | removed |
| **total** | **13,861 b** | **6,355 b** | **−54.2%** |

Budget ratchet: 16 KiB → 11 KiB → 8 KiB → **7 KiB** (this PR).

### Live docapp

| | Pre | Post | Delta |
|---|---:|---:|---:|
| `skills/pad/SKILL.md` | 40,193 b | 29,840 b | −25.8% |
| `pad bootstrap` | 52,033 b | 33,375 b | −35.9% |
| **Combined per `/pad`** | **92,226 b** | **63,215 b** | **−31.5%** |

## Target vs actual

Target was ~43% per-invocation reduction; live achieved **31.5%**. The shortfall is workspace-scale-dependent: docapp has 11.2 KB of conventions (load-bearing, out of scope) and ~5.2 KB of uncapped dashboard sub-arrays. At fixture scale (workspace activity held constant), the shape work alone delivered **−54.2%**.

## Follow-up

**IDEA-1421 — "Next-round bootstrap trim — cap remaining dashboard arrays"** filed. Extends the `capBootstrapDashboard` projection from TASK-1413 to cap `active_items` / `active_plans` / `by_role` / `suggested_next` with parallel overflow counts. Estimated ~3 KB additional live reduction; backwards-compatible (additive fields only, no `ToolSurfaceVersion` bump required).

## Test plan

- [x] `make check` — golangci-lint 0 issues, all Go tests pass (`TestBootstrapSizeBudget` reports 6,355 b against the new 7 KiB / 7,168 b budget, ~12.8% headroom), govulncheck clean, web build clean.
- [x] PLAN-1410 body updated with the Result section via `pad item update PLAN-1410 --stdin`.
- [x] IDEA-1421 filed and linked from the PLAN body's Follow-up section.

## Out of scope

- `ToolSurfaceVersion` 0.3 → 0.4 bump — that's TASK-1418, the last PR in PLAN-1410.