### PR TITLE
refactor(bootstrap): slim Roles projection (BootstrapRole struct) (TASK-1423)

### DIFF
--- a/internal/server/handlers_bootstrap.go
+++ b/internal/server/handlers_bootstrap.go
@@ -24,7 +24,7 @@ type AgentBootstrap struct {
 	User        AgentBootstrapUser           `json:"user"`
 	Collections []BootstrapCollection        `json:"collections"`
 	Conventions []AgentBootstrapConvention   `json:"conventions"`
-	Roles       []models.AgentRole           `json:"roles"`
+	Roles       []BootstrapRole              `json:"roles"`
 	Playbooks   []AgentBootstrapPlaybookMeta `json:"playbooks"`
 	Dashboard   *BootstrapDashboard          `json:"dashboard,omitempty"`
 }
@@ -90,6 +90,45 @@ func projectBootstrapCollection(c models.Collection) BootstrapCollection {
 		out.Schema = json.RawMessage(s)
 	}
 	return out
+}
+
+// BootstrapRole is the lightweight role projection delivered in the
+// agent bootstrap response. Distinct from models.AgentRole: drops
+// fields the /pad skill never reads (id, workspace_id, created_at,
+// updated_at) and the unused tools column. Same drop-pattern as
+// BootstrapCollection — agent addresses roles by slug; UUIDs and
+// timestamps are dead weight at context-load time.
+//
+// Fields preserved are exactly what the /pad skill consumes:
+//   - slug — addressing (e.g. `--role <slug>` on item create/update)
+//   - name / description / icon — greeting + role-picker rendering
+//   - item_count — surface-area count in role-queue greetings
+//   - sort_order — preserves the workspace's authored role ordering
+//
+// PLAN-1410 / TASK-1423. Mirror of TASK-1412's BootstrapCollection
+// projection.
+type BootstrapRole struct {
+	Slug        string `json:"slug"`
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	Icon        string `json:"icon,omitempty"`
+	SortOrder   int    `json:"sort_order"`
+	ItemCount   int    `json:"item_count"`
+}
+
+// projectBootstrapRole converts a models.AgentRole into the slim
+// bootstrap projection. Stateless — the role count recompute for
+// restricted callers happens upstream and writes into c.ItemCount
+// before this projection runs.
+func projectBootstrapRole(r models.AgentRole) BootstrapRole {
+	return BootstrapRole{
+		Slug:        r.Slug,
+		Name:        r.Name,
+		Description: r.Description,
+		Icon:        r.Icon,
+		SortOrder:   r.SortOrder,
+		ItemCount:   r.ItemCount,
+	}
 }
 
 // AgentBootstrapWorkspace is the minimal workspace projection (slug + name
@@ -365,18 +404,26 @@ func (s *Server) BuildAgentBootstrap(workspaceID string, user *models.User, r *h
 			c.ItemCount = collItemCounts[c.ID]
 			c.ActiveItemCount = collItemCounts[c.ID]
 		}
-		// Overlay role counts.
+		// Overlay role counts. Same shape as collections above — mutate
+		// the local `roles` slice (models.AgentRole) here before the
+		// bootstrap projection below, keyed by AgentRole.ID which the
+		// projection drops.
 		for i := range roles {
 			roles[i].ItemCount = roleCounts[roles[i].ID]
 		}
 	}
-	out.Roles = roles
 
-	// Project collections into the slim bootstrap shape now that
-	// counts (above) have been recomputed for restricted callers.
+	// Project collections AND roles into their slim bootstrap shapes
+	// now that counts (above) have been recomputed for restricted
+	// callers. Both projections drop UUIDs / workspace IDs / timestamps;
+	// the agent addresses them by slug.
 	out.Collections = make([]BootstrapCollection, 0, len(collections))
 	for _, c := range collections {
 		out.Collections = append(out.Collections, projectBootstrapCollection(c))
+	}
+	out.Roles = make([]BootstrapRole, 0, len(roles))
+	for _, r := range roles {
+		out.Roles = append(out.Roles, projectBootstrapRole(r))
 	}
 
 	// Playbooks (metadata only) — restricted to the caller's authorized

--- a/internal/server/handlers_bootstrap_test.go
+++ b/internal/server/handlers_bootstrap_test.go
@@ -92,6 +92,77 @@ func TestBootstrapEmptyArraysNotNull(t *testing.T) {
 	}
 }
 
+// TestBootstrapRoleProjection verifies the BootstrapRole wire shape
+// after PLAN-1410 / TASK-1423 trimmed it. Seeds one role and asserts:
+//
+//   - The projection's expected fields (slug/name/description/icon/
+//     item_count/sort_order) are present and correct.
+//   - The dropped fields (id, workspace_id, tools, created_at,
+//     updated_at) are NOT present in the marshalled JSON.
+//
+// The negative check is the load-bearing part — without it, a future
+// refactor that "fixes" the projection by re-adding a UUID would
+// pass all the positive assertions silently. Mirrors the contract
+// that TestBootstrapEmptyArraysNotNull guards on the dedup side.
+func TestBootstrapRoleProjection(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	// Create a role via the agent-roles endpoint so the workspace
+	// has one populated entry to project.
+	rr := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/agent-roles", map[string]interface{}{
+		"name":        "Planner",
+		"description": "Breaks down ideas, designs approaches",
+		"icon":        "🧠",
+	})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create role: expected 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	// Fetch the bootstrap and unmarshal into a permissive shape so we
+	// can also detect the presence of fields that should NOT be there.
+	rr = doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/agent/bootstrap", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("bootstrap: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var raw struct {
+		Roles []map[string]json.RawMessage `json:"roles"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &raw); err != nil {
+		t.Fatalf("decode roles: %v", err)
+	}
+	if len(raw.Roles) != 1 {
+		t.Fatalf("expected exactly 1 role, got %d", len(raw.Roles))
+	}
+	role := raw.Roles[0]
+
+	// Positive: required projection fields are present.
+	want := map[string]string{
+		"slug":        `"planner"`,
+		"name":        `"Planner"`,
+		"description": `"Breaks down ideas, designs approaches"`,
+		"item_count":  `0`,
+	}
+	for key, expected := range want {
+		got, ok := role[key]
+		if !ok {
+			t.Errorf("missing required projection field %q", key)
+			continue
+		}
+		if string(got) != expected {
+			t.Errorf("role.%s = %s, want %s", key, string(got), expected)
+		}
+	}
+
+	// Negative: dropped fields must NOT appear.
+	for _, key := range []string{"id", "workspace_id", "tools", "created_at", "updated_at"} {
+		if _, ok := role[key]; ok {
+			t.Errorf("role.%s leaked into the bootstrap projection; should have been dropped by TASK-1423", key)
+		}
+	}
+}
+
 // TestBootstrapIncludesPlaybookMetadata verifies that a seeded playbook
 // item flows into the bootstrap's playbooks array with the right
 // projection — slug, invocation_slug, has_arguments — without leaking


### PR DESCRIPTION
## Summary

Slims the bootstrap response's `roles` section with a new `BootstrapRole` projection struct — same drop-pattern as TASK-1412's `BootstrapCollection`. Drops `id`, `workspace_id`, `tools`, `created_at`, `updated_at`; keeps `slug`, `name`, `description`, `icon`, `sort_order`, `item_count`.

## Context

Ninth PR in [PLAN-1410](../). Second of the three "comprehensive v0.4 envelope" trims (after TASK-1422's dashboard caps). After this lands, TASK-1424 (schema label + sort_order trim) and then TASK-1418 (ToolSurfaceVersion bump) close out the plan.

## Wire-shape change

```diff
 type AgentBootstrap struct {
     ...
-    Roles []models.AgentRole `json:"roles"`
+    Roles []BootstrapRole    `json:"roles"`
 }

 type BootstrapRole struct {
+    Slug        string `json:"slug"`
+    Name        string `json:"name"`
+    Description string `json:"description,omitempty"`
+    Icon        string `json:"icon,omitempty"`
+    SortOrder   int    `json:"sort_order"`
+    ItemCount   int    `json:"item_count"`
+}
```

`models.AgentRole.Tools` has no consumer outside the store CRUD (grep confirms — only `internal/store/agent_roles.go` references it). On docapp it's `""` on all three roles. Dropped from the bootstrap projection; can be added back if/when an agent-side use case appears.

## BuildAgentBootstrap reorder

The role-count recompute for restricted callers keys by `AgentRole.ID`, which the projection drops. Same reorder pattern as TASK-1412's collections refactor — `roles` stays in `models.AgentRole` shape through the recompute, then projects to `[]BootstrapRole` in a final pass alongside the collections projection.

## Test coverage

- **New `TestBootstrapRoleProjection`** — seeds one role via the agent-roles endpoint and verifies the wire shape with both positive and **negative** assertions. The negative check (id/workspace_id/tools/created_at/updated_at MUST NOT appear) is the load-bearing part — without it, a future refactor that re-adds a UUID would pass the positive assertions silently. Mirrors `TestBootstrapEmptyArraysNotNull`'s "guard against reappearance" pattern.
- `TestBootstrapEmptyWorkspace`, `TestBootstrapEmptyArraysNotNull`, `TestBootstrapSizeBudget`, `TestBootstrapIncludesPlaybookMetadata`, `TestCapBootstrapDashboard`, `TestPlaybookSummaryPrefersFirstParagraph` all still pass.

## Measurements

Fixture (`TestBootstrapSizeBudget`) unchanged at **7,823 bytes** — the fixture seeds 0 roles, so the projection change doesn't affect the size budget (roles section was already 2 bytes `"[]"`).

Live docapp expected savings: roles section was 1,066 bytes for 3 roles; ~30-40% drop expected from removing per-role UUIDs + timestamps (~350 b).

## Out of scope (handled by remaining PLAN-1410 PRs)

- Schema `label` + `sort_order` trim — TASK-1424.
- `ToolSurfaceVersion` 0.3 → 0.4 bump — TASK-1418 (the final PR in PLAN-1410, blocked on this + 1424).

## Test plan

- [x] `make check` — golangci-lint 0 issues, all Go tests pass, govulncheck clean, web build clean.
- [x] `TestBootstrapRoleProjection` (positive + negative assertions) passes.
- [x] All existing bootstrap tests still pass.