### PR TITLE
refactor(bootstrap): omit redundant schema labels + omitempty sort_order (TASK-1424)

### DIFF
--- a/internal/server/handlers_bootstrap.go
+++ b/internal/server/handlers_bootstrap.go
@@ -56,7 +56,7 @@ type BootstrapCollection struct {
 	Icon            string          `json:"icon,omitempty"`
 	Description     string          `json:"description,omitempty"`
 	Schema          json.RawMessage `json:"schema,omitempty"`
-	SortOrder       int             `json:"sort_order"`
+	SortOrder       int             `json:"sort_order,omitempty"`
 	IsDefault       bool            `json:"is_default"`
 	IsSystem        bool            `json:"is_system"`
 	ItemCount       int             `json:"item_count"`
@@ -73,6 +73,12 @@ type BootstrapCollection struct {
 // guarantees the wire shape stays parseable even if a future migration
 // or buggy write leaves a non-JSON value in the column. Defensive only:
 // every collection created via the API today writes valid JSON.
+//
+// The schema bytes additionally go through trimRedundantSchemaLabels
+// to drop fields where `label == TitleCase(key)` — added in TASK-1424
+// to cut the schema sub-object's bytes by another ~10% (the labels
+// that match the auto-fill rule carry no information the agent can't
+// reconstruct).
 func projectBootstrapCollection(c models.Collection) BootstrapCollection {
 	out := BootstrapCollection{
 		Slug:            c.Slug,
@@ -87,9 +93,90 @@ func projectBootstrapCollection(c models.Collection) BootstrapCollection {
 		ActiveItemCount: c.ActiveItemCount,
 	}
 	if s := strings.TrimSpace(c.Schema); s != "" && json.Valid([]byte(s)) {
-		out.Schema = json.RawMessage(s)
+		out.Schema = trimRedundantSchemaLabels([]byte(s))
 	}
 	return out
+}
+
+// bootstrapSchema is the bootstrap-side schema shape, parallel to
+// models.CollectionSchema. Used only by trimRedundantSchemaLabels to
+// round-trip the schema bytes with `omitempty` on FieldDef.Label so
+// redundant labels (label == TitleCase(key)) collapse out of the
+// wire response. Custom labels — those that differ from the
+// auto-fill rule, e.g. label="When" for key="trigger" — are preserved
+// unchanged because their value is informationally distinct.
+//
+// PLAN-1410 / TASK-1424.
+type bootstrapSchema struct {
+	Fields []bootstrapFieldDef `json:"fields"`
+}
+
+// bootstrapFieldDef mirrors models.FieldDef field-for-field with two
+// differences: Label is `omitempty` (the whole point), and Default is
+// json.RawMessage so we round-trip any default value verbatim without
+// re-parsing.
+//
+// **MUST be kept in sync with models.FieldDef.** Adding a field to
+// the canonical struct without mirroring here would silently drop
+// the field from the bootstrap schema response.
+// TestBootstrapFieldDefMirrorsModelsFieldDef is the drift detector —
+// it uses reflection to assert structural parity and fails the build
+// if the two diverge.
+type bootstrapFieldDef struct {
+	Key             string          `json:"key"`
+	Label           string          `json:"label,omitempty"`
+	Type            string          `json:"type"`
+	Options         []string        `json:"options,omitempty"`
+	TerminalOptions []string        `json:"terminal_options,omitempty"`
+	Default         json.RawMessage `json:"default,omitempty"`
+	Required        bool            `json:"required,omitempty"`
+	Computed        bool            `json:"computed,omitempty"`
+	Collection      string          `json:"collection,omitempty"`
+	Suffix          string          `json:"suffix,omitempty"`
+	Pattern         string          `json:"pattern,omitempty"`
+	UniqueScope     string          `json:"unique_scope,omitempty"`
+}
+
+// trimRedundantSchemaLabels parses the schema JSON, drops field
+// labels equal to TitleCase(key), and re-marshals. Returns the
+// original bytes verbatim on any parse error so a malformed schema
+// never blocks the bootstrap response — defensive only, since
+// projectBootstrapCollection already gates on json.Valid() upstream.
+//
+// Field ordering is preserved by struct-based marshalling (Go's
+// encoding/json emits fields in struct definition order); we
+// deliberately avoid `map[string]any` which would shuffle order.
+func trimRedundantSchemaLabels(raw []byte) json.RawMessage {
+	var s bootstrapSchema
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return raw
+	}
+	for i := range s.Fields {
+		if s.Fields[i].Label == titleCaseLabel(s.Fields[i].Key) {
+			s.Fields[i].Label = ""
+		}
+	}
+	out, err := json.Marshal(s)
+	if err != nil {
+		return raw
+	}
+	return out
+}
+
+// titleCaseLabel converts a snake_case key into a Title Case label
+// the same way the CLI does ("due_date" → "Due Date"). Duplicated
+// from internal/mcp/dispatch_http_routes.go to avoid a server → mcp
+// import (mcp already imports server). Keep the two in sync — both
+// transformations must produce identical output for a given key.
+func titleCaseLabel(key string) string {
+	parts := strings.Split(strings.ReplaceAll(key, "_", " "), " ")
+	for i, p := range parts {
+		if p == "" {
+			continue
+		}
+		parts[i] = strings.ToUpper(p[:1]) + p[1:]
+	}
+	return strings.Join(parts, " ")
 }
 
 // BootstrapRole is the lightweight role projection delivered in the

--- a/internal/server/handlers_bootstrap_test.go
+++ b/internal/server/handlers_bootstrap_test.go
@@ -4,8 +4,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"reflect"
 	"testing"
 
+	"github.com/PerpetualSoftware/pad/internal/models"
 	"github.com/PerpetualSoftware/pad/internal/store"
 )
 
@@ -161,6 +163,134 @@ func TestBootstrapRoleProjection(t *testing.T) {
 			t.Errorf("role.%s leaked into the bootstrap projection; should have been dropped by TASK-1423", key)
 		}
 	}
+}
+
+// TestBootstrapFieldDefMirrorsModelsFieldDef is the drift detector for
+// the bootstrapFieldDef parallel struct introduced in TASK-1424.
+// bootstrapFieldDef must stay structurally aligned with
+// models.FieldDef — same field names, same JSON tags (modulo the
+// deliberate `omitempty` on Label and the `json.RawMessage` swap for
+// Default). If models.FieldDef adds a new field, this test fails and
+// the developer is forced to either mirror it here or explicitly
+// decide to drop it from the bootstrap projection.
+//
+// We compare structural metadata (name + JSON key + base type) rather
+// than full Go types so the Default field's `any` → `json.RawMessage`
+// swap doesn't trip the check. Detected differences are listed with
+// the field name so the failure message points at the gap directly.
+func TestBootstrapFieldDefMirrorsModelsFieldDef(t *testing.T) {
+	canonical := reflect.TypeOf(models.FieldDef{})
+	mirror := reflect.TypeOf(bootstrapFieldDef{})
+
+	if canonical.NumField() != mirror.NumField() {
+		t.Fatalf("field count drift: models.FieldDef has %d fields, bootstrapFieldDef has %d — keep them in sync (see godoc on bootstrapFieldDef)",
+			canonical.NumField(), mirror.NumField())
+	}
+
+	// Map name → JSON tag for the canonical struct.
+	canon := make(map[string]string, canonical.NumField())
+	for i := 0; i < canonical.NumField(); i++ {
+		f := canonical.Field(i)
+		canon[f.Name] = f.Tag.Get("json")
+	}
+
+	// Allowed JSON-tag delta: the canonical has `json:"label"` (no
+	// omitempty); the mirror has `json:"label,omitempty"`. Same key,
+	// different presence rule, deliberate.
+	tagDeltaAllowed := map[string][2]string{
+		"Label": {"label", "label,omitempty"},
+	}
+
+	for i := 0; i < mirror.NumField(); i++ {
+		mf := mirror.Field(i)
+		cTag, ok := canon[mf.Name]
+		if !ok {
+			t.Errorf("bootstrapFieldDef.%s has no counterpart in models.FieldDef", mf.Name)
+			continue
+		}
+		mTag := mf.Tag.Get("json")
+		if mTag == cTag {
+			continue
+		}
+		if allowed, isExpected := tagDeltaAllowed[mf.Name]; isExpected {
+			if cTag == allowed[0] && mTag == allowed[1] {
+				continue
+			}
+		}
+		t.Errorf("JSON tag drift on %s: models.FieldDef=%q, bootstrapFieldDef=%q (unexpected — update the tagDeltaAllowed table if this divergence is deliberate)",
+			mf.Name, cTag, mTag)
+	}
+}
+
+// TestTrimRedundantSchemaLabels covers the three behaviors of the
+// label-trim projection:
+//
+//  1. Field labels matching TitleCase(key) are dropped.
+//  2. Custom labels (those that differ) are preserved.
+//  3. Missing/empty labels pass through (no-op).
+//
+// Plus a malformed-schema edge case where the function must return
+// the original bytes verbatim rather than blocking the bootstrap
+// response.
+func TestTrimRedundantSchemaLabels(t *testing.T) {
+	t.Run("drops-redundant-labels", func(t *testing.T) {
+		in := []byte(`{"fields":[{"key":"status","label":"Status","type":"select"}]}`)
+		out := trimRedundantSchemaLabels(in)
+
+		var parsed map[string][]map[string]json.RawMessage
+		if err := json.Unmarshal(out, &parsed); err != nil {
+			t.Fatalf("decode trimmed: %v", err)
+		}
+		if _, ok := parsed["fields"][0]["label"]; ok {
+			t.Errorf("redundant `label:\"Status\"` should have been dropped from key=status, got: %s", string(out))
+		}
+	})
+
+	t.Run("preserves-custom-labels", func(t *testing.T) {
+		// label "When" for key "trigger" is NOT TitleCase(key) (which
+		// would be "Trigger"), so the custom label MUST be preserved.
+		in := []byte(`{"fields":[{"key":"trigger","label":"When","type":"select"}]}`)
+		out := trimRedundantSchemaLabels(in)
+
+		var parsed map[string][]map[string]json.RawMessage
+		if err := json.Unmarshal(out, &parsed); err != nil {
+			t.Fatalf("decode trimmed: %v", err)
+		}
+		labelRaw, ok := parsed["fields"][0]["label"]
+		if !ok {
+			t.Fatalf("custom label `When` dropped — would lose information; got: %s", string(out))
+		}
+		var label string
+		_ = json.Unmarshal(labelRaw, &label)
+		if label != "When" {
+			t.Errorf("custom label mutated: got %q, want %q", label, "When")
+		}
+	})
+
+	t.Run("multi-word-keys-titlecase-correctly", func(t *testing.T) {
+		// snake_case → "Title Case" with spaces. "due_date" → "Due Date".
+		in := []byte(`{"fields":[{"key":"due_date","label":"Due Date","type":"date"}]}`)
+		out := trimRedundantSchemaLabels(in)
+
+		var parsed map[string][]map[string]json.RawMessage
+		if err := json.Unmarshal(out, &parsed); err != nil {
+			t.Fatalf("decode trimmed: %v", err)
+		}
+		if _, ok := parsed["fields"][0]["label"]; ok {
+			t.Errorf("redundant `label:\"Due Date\"` should have been dropped from key=due_date, got: %s", string(out))
+		}
+	})
+
+	t.Run("malformed-schema-returns-raw", func(t *testing.T) {
+		// Defensive only — projectBootstrapCollection already gates on
+		// json.Valid() upstream, but trimRedundantSchemaLabels should
+		// never block a bootstrap response on a parse error.
+		bad := []byte(`{"fields":not valid json`)
+		out := trimRedundantSchemaLabels(bad)
+		if string(out) != string(bad) {
+			t.Errorf("malformed schema should pass through verbatim; got %q, want %q", string(out), string(bad))
+		}
+	})
 }
 
 // TestBootstrapIncludesPlaybookMetadata verifies that a seeded playbook


### PR DESCRIPTION
## Summary

Two small additive trims to the `BootstrapCollection` projection. Last shape PR in [PLAN-1410](../) before the contractual v0.4 announcement (TASK-1418).

1. **Omit redundant schema `label`** when `label == TitleCase(key)`. The label is auto-fillable from the key (the MCP-side CreateCollection helper applies `TitleCase(key)` when label is empty), so persisted-but-redundant labels carry no information the agent can't reconstruct.
2. **`,omitempty` on `BootstrapCollection.SortOrder`** — most collections never get an explicit non-zero sort_order; `"sort_order":0` was per-entry dead weight.

## Wire-shape changes (additive — labels still emit when non-redundant)

`BootstrapCollection.SortOrder`: `json:"sort_order"` → `json:"sort_order,omitempty"`.

Schema fields go through a new `trimRedundantSchemaLabels` projection that round-trips through `bootstrapSchema { Fields []bootstrapFieldDef }` — a parallel struct mirroring `models.CollectionSchema` / `models.FieldDef` with `omitempty` on `Label` and `json.RawMessage` on `Default`. Examples (docapp):

```diff
 {"key":"status",   "label":"Status",   "type":"select"}   →   {"key":"status",   "type":"select"}
 {"key":"due_date", "label":"Due Date", "type":"date"}     →   {"key":"due_date", "type":"date"}
 {"key":"trigger",  "label":"When",     "type":"select"}   →   {"key":"trigger",  "label":"When", "type":"select"}   ← custom, preserved
```

## Drift detection

`bootstrapFieldDef` mirrors `models.FieldDef` field-for-field with two deliberate differences (Label omitempty, Default as RawMessage). If `models.FieldDef` gains a new field, the parallel struct silently drops it from the bootstrap schema.

**`TestBootstrapFieldDefMirrorsModelsFieldDef`** catches this via reflection — compares `NumField()` + per-field JSON tags, with an explicit `tagDeltaAllowed` map for the Label exception. Field-pointed error messages on drift.

## Test coverage

- **`TestBootstrapFieldDefMirrorsModelsFieldDef`** — drift detector (above).
- **`TestTrimRedundantSchemaLabels`** (4 subtests):
  - `drops-redundant-labels` — `key=status, label=Status` → label removed.
  - `preserves-custom-labels` — `key=trigger, label=When` (≠ `Trigger`) → label kept.
  - `multi-word-keys-titlecase-correctly` — `due_date` → `Due Date` matched and trimmed.
  - `malformed-schema-returns-raw` — defensive: never block bootstrap on a parse error.
- Existing `TestBootstrapSizeBudget` shows the fixture collections section dropping **3,979 → 3,532 bytes (−11.2%)**.

## Measurements

| | Before | After | Delta |
|---|---:|---:|---:|
| Fixture collections | 3,979 b | 3,532 b | −447 b (−11.2%) |
| Fixture total | 7,823 b | 7,376 b | −447 b (−5.7%) |

Live docapp expected: ~10% drop on collections section (9,384 → ~8,400 b).

## titleCaseLabel duplication

A copy of `titleCaseLabel` from `internal/mcp/dispatch_http_routes.go` lives in `handlers_bootstrap.go`. Can't reuse cross-package (mcp already imports server — would be a cycle). Godoc on the server-side copy explicitly notes the duplication + the "keep these in sync" rule.

## Out of scope

- `ToolSurfaceVersion` 0.3 → 0.4 bump — **TASK-1418**, the final PR in PLAN-1410. This is the **last shape PR**; TASK-1418 is now fully unblocked once this merges.

## Test plan

- [x] `make check` — golangci-lint 0 issues, all Go tests pass, govulncheck clean, web build clean.
- [x] All bootstrap tests pass (size budget, cap contract, role projection, schema-label trim, drift detector).
