### PR TITLE
fix(web): scroll restoration via SvelteKit snapshot API (BUG-1425)

### DIFF
--- a/web/src/lib/scroll/restore.svelte.ts
+++ b/web/src/lib/scroll/restore.svelte.ts
@@ -1,0 +1,455 @@
+// Page-level scroll-position restoration that survives async content loading.
+//
+// Background — BUG-1425 / TASK-755
+// ────────────────────────────────
+// SvelteKit's built-in scroll restoration runs synchronously right after the
+// page is mounted. Almost every page in this app fetches its data inside the
+// component (in `loadData()` / `$effect`), not in a `+page.ts` `load`
+// function, so when the user back-navigates the document is still skeleton-
+// height when restoration fires — the saved scrollY gets clamped to ~0.
+//
+// TASK-755 worked around this on the collection listing page only, using a
+// bespoke localStorage entry + double-RAF restore gated on `loading`. The
+// item detail page (and everything else) was never covered, hence BUG-1425.
+//
+// This module replaces TASK-755's bespoke code with a reusable helper built
+// on SvelteKit's `snapshot` API. Each page that wants scroll restoration
+// calls `createScrollRestoration` and re-exports the resulting `snapshot`
+// object. The factory layers:
+//
+//   1. SvelteKit snapshot (sessionStorage, per history entry). Canonical
+//      path. Capture runs on navigate-away; restore runs on back/forward.
+//      Per-entry semantics naturally distinguish "back to where I was"
+//      from "fresh nav to the same URL."
+//   2. A `ready()` gate. SvelteKit may call `restore(y)` synchronously
+//      after the page mounts (or after params change, for routes that
+//      reuse a component instance), but we don't want to scroll until
+//      the page's data has rendered. The caller's `ready()` is the
+//      single source of truth for "content matches the URL." For pages
+//      that reload on URL change, the caller should verify both
+//      `!loading` AND that the content's identity matches the URL —
+//      e.g. `item?.slug === itemSlug` on the item detail page. For
+//      pages that don't reload on URL change (e.g. roles), a plain
+//      `!loading` is fine; the helper fires as soon as ready is true.
+//   3. Double `requestAnimationFrame`. Same trick as TASK-755 — gives
+//      layout one extra frame to settle after content paints before
+//      calling `scrollTo`, so the offset isn't clamped by stale
+//      heights.
+//   4. Per-key one-shot guard (`restoredKey`). For routes that reuse a
+//      component instance across URLs, the lifetime-scoped `restored`
+//      boolean from round 1 blocked the second back-nav. Keying the
+//      guard by `persistKey()` lets each new URL get a fresh shot.
+//   5. Optional `persistKey` localStorage fallback. sessionStorage is
+//      per-tab; closing and reopening a tab (or the workspace
+//      switcher's TASK-754 cross-tab `goto()` route restoration) loses
+//      the snapshot. The fallback fires on mount AND on every
+//      persistKey change, and clears `pending`/`restoredKey` on each
+//      key transition so a return-to-previously-restored-URL works.
+
+import type { Snapshot } from '@sveltejs/kit';
+import { onDestroy } from 'svelte';
+
+// The app's primary scroll container lives in the root layout
+// (`.main-content { overflow-y: auto }`), not `window`. Capturing
+// `window.scrollY` always yields 0 and `window.scrollTo` is a no-op
+// — which silently broke TASK-755's listing restore AND every round
+// of BUG-1425 fixes until the diagnostic logging caught it.
+//
+// `getScrollTarget()` returns the element to operate on. We look up
+// `.main-content` lazily so the function works for any caller within
+// the workspace layout; for pages outside the layout it falls back
+// to `window`. The lookup is cheap and re-runs on every capture /
+// restore so DOM swaps between mounts are handled.
+function getScrollTarget(): HTMLElement | Window | null {
+	if (typeof document === 'undefined') return null;
+	const el = document.querySelector<HTMLElement>('.main-content');
+	if (el) return el;
+	if (typeof window !== 'undefined') return window;
+	return null;
+}
+
+function readScrollY(target: HTMLElement | Window | null): number {
+	if (!target) return 0;
+	if (target instanceof Window) return target.scrollY;
+	return target.scrollTop;
+}
+
+function writeScrollY(target: HTMLElement | Window | null, y: number) {
+	if (!target) return;
+	target.scrollTo({ top: y, behavior: 'instant' as ScrollBehavior });
+}
+
+export interface ScrollRestorationOptions {
+	/**
+	 * Returns true once the page's primary content matches the current
+	 * URL and is rendered enough to scroll to a saved offset. Read
+	 * inside a `$effect`, so it must touch reactive state.
+	 *
+	 * For routes that reuse a component instance across URLs (e.g.
+	 * `[coll]/[slug]` for every item), include an identity check so
+	 * `ready()` returns false while the previous URL's content is still
+	 * rendered. Example for the item page:
+	 *
+	 * ```ts
+	 * ready: () => !loading && item?.slug === itemSlug
+	 * ```
+	 *
+	 * For pages that don't reload on URL change, a plain `!loading` is
+	 * sufficient — the restore fires as soon as ready is true.
+	 */
+	ready: () => boolean;
+	/**
+	 * Optional cross-session/cross-tab persistence key, AND the per-route
+	 * identity used for the one-shot guard. When provided:
+	 *
+	 *   - Capture mirrors `scrollY` to `localStorage[key()]` so a tab
+	 *     close + re-entry via the workspace switcher (TASK-754) still
+	 *     restores position.
+	 *   - The restore effect gates its one-shot fire by `key()`, so
+	 *     routes that reuse a component instance across URLs get a
+	 *     fresh restore for each new entry.
+	 *   - On every `key()` change the LS fallback re-reads and the
+	 *     `pending`/`restoredKey` state is cleared, so returning to a
+	 *     previously-restored key re-arms correctly.
+	 *
+	 * Return `null` to skip persistence and use lifetime-scoped one-shot
+	 * semantics (one restore per component instance — appropriate for
+	 * routes that always remount on entry).
+	 */
+	persistKey?: () => string | null;
+}
+
+export interface ScrollRestoration {
+	snapshot: Snapshot<number>;
+}
+
+/**
+ * Wire scroll-position restoration into a `+page.svelte`.
+ *
+ * ```svelte
+ * <script lang="ts">
+ *   import { createScrollRestoration } from '$lib/scroll/restore.svelte';
+ *
+ *   let loading = $state(true);
+ *   let item = $state<Item | null>(null);
+ *
+ *   const restoration = createScrollRestoration({
+ *     ready: () => !loading && item?.slug === itemSlug,
+ *     persistKey: () => `pad-last-scroll-${wsSlug}-${page.url.pathname}`,
+ *   });
+ *   export const snapshot = restoration.snapshot;
+ * </script>
+ * ```
+ *
+ * Must be called at the top level of a component's `<script>` block so
+ * the `$effect` calls inside have a component context.
+ */
+export function createScrollRestoration(
+	opts: ScrollRestorationOptions,
+): ScrollRestoration {
+	// Parked restore value waiting for ready(). Stored together with the
+	// `persistKey` captured at restore-time so a value saved for entry A
+	// can't apply later to entry B.
+	let pending = $state<{ y: number; key: string | null } | null>(null);
+
+	// The persistKey value that snapshot.restore was last called with
+	// (or `undefined` if never called). The LS fallback uses this to
+	// detect "a SvelteKit snapshot has already been provided for this
+	// entry — don't overwrite it with a stale LS value." A bare boolean
+	// like the previous `snapshotRestoreCalled` was unsafe: the LS
+	// `$effect` reset it on every key change, blowing away a signal set
+	// by a snapshot.restore that beat the effect to the microtask queue
+	// (Codex BUG-1425 round 5 P1).
+	let snapshotKey: string | null | undefined = undefined;
+
+	// Per-key one-shot guard. `undefined` = never restored (or just
+	// reset after a fresh snapshot.restore or key change); a string/null
+	// value = already restored for that key. Non-reactive on purpose: a
+	// previous version made this a $state boolean that the gated effect
+	// wrote to, which invalidated itself and cancelled the RAF via
+	// cleanup-then-rerun (Codex round 1 of BUG-1425). Writing a plain
+	// variable doesn't establish a dependency.
+	let restoredKey: string | null | undefined = undefined;
+
+	// Mount status. RAF lifetime is decoupled from any effect cleanup so
+	// unrelated re-runs can't cancel an in-flight restore; the inner RAF
+	// callback checks `alive` AND re-reads `persistKey()` to bail if the
+	// route changed mid-flight.
+	let alive = true;
+	onDestroy(() => {
+		alive = false;
+	});
+
+	// localStorage fallback. Fires on mount AND on every `persistKey()`
+	// change so workspace-switcher `goto()` navigations that reuse the
+	// component instance (no popstate, no snapshot.restore) still pick
+	// up a saved scroll position.
+	//
+	// On each key transition the effect re-arms by clearing
+	// `restoredKey`, then defers one microtask so SvelteKit has a
+	// chance to call snapshot.restore first. The microtask checks
+	// `snapshotKey === key` to skip when snapshot won the race — that's
+	// the per-key signal that survives effect re-runs (vs. the bare
+	// boolean we used previously, which Codex round 5 P1 caught us
+	// blowing away here).
+	//
+	// `pending` is intentionally NOT cleared on key change: pending
+	// values for the previous key are filtered by the gated effect's
+	// `pending.key !== key` check, and clearing would clobber a
+	// snapshot.restore that beat the effect's microtask. If the new
+	// key has its own snapshot OR an LS value, those will overwrite
+	// `pending` in due course; if it has neither, the old pending
+	// stays parked but inert.
+	if (opts.persistKey) {
+		let lastSeenKey: string | null | undefined = undefined;
+		$effect(() => {
+			const key = opts.persistKey!(); // track persistKey result
+			if (key === lastSeenKey) return; // dedupe re-runs on unchanged key
+			lastSeenKey = key;
+			// Re-arm the per-key one-shot so a return-to-previously-
+			// restored URL fires again.
+			restoredKey = undefined;
+			// Invalidate `snapshotKey` when it's not for the new key.
+			// This lets goto-return-to-previously-restored (no popstate,
+			// no fresh snapshot.restore) re-read LS instead of skipping.
+			// If snapshot.restore for the NEW key already fired before
+			// this effect (popstate beat the effect to the microtask
+			// queue), `snapshotKey === key` and we preserve it.
+			// Codex BUG-1425 round 6 P1.
+			if (snapshotKey !== key) {
+				snapshotKey = undefined;
+			}
+			// Clear `pending` when it's for an old key. Stale pending
+			// would otherwise block the LS read for the new key (the
+			// `pending.key === key` skip below) AND, if it happens to
+			// match the new key by coincidence, fire stale offset.
+			// Pending for the CURRENT key is preserved — a snapshot.
+			// restore that beat the effect populated it, and the LS
+			// microtask will honor `snapshotKey === key` to no-op.
+			if (pending !== null && pending.key !== key) {
+				pending = null;
+			}
+			// Defer one microtask so SvelteKit has a chance to call
+			// snapshot.restore for this entry first.
+			queueMicrotask(() => {
+				// Bail if the user navigated yet again before drain.
+				if (key !== lastSeenKey) return;
+				// Snapshot already won for this key — don't overwrite.
+				if (snapshotKey === key) return;
+				// Already have a pending value for this key from a
+				// snapshot.restore that arrived between the sync body
+				// above and this microtask. (We only skip LS in this
+				// case; we don't return early on stale pending because
+				// the sync body above already cleared it.)
+				if (pending !== null && pending.key === key) return;
+				try {
+					if (!key) return;
+					const raw = localStorage.getItem(key);
+					if (!raw) return;
+					const y = Number(raw);
+					if (!Number.isFinite(y) || y <= 0) return;
+					pending = { y, key };
+				} catch {
+					// localStorage unavailable — silent no-op.
+				}
+			});
+		});
+	}
+
+	// Gated restore. Reads `pending`, `ready()`, and the current
+	// `persistKey()` — all tracked, so it re-fires when any of them
+	// changes.
+	//
+	// Firing rules:
+	//   - `pending` must be set and its captured key matches current
+	//     persistKey (otherwise the value was saved for a different
+	//     entry).
+	//   - `ready()` returns true (caller is responsible for verifying
+	//     content matches URL — see ScrollRestorationOptions).
+	//   - The current key must not already be in `restoredKey`.
+	//
+	// Then schedule a double-RAF and call scrollTo, with an inner
+	// `alive` + key-drift check so an in-flight RAF can't scroll a
+	// page the user has since navigated away from.
+	//
+	// IMPORTANT — never write `pending` from inside this effect. It's
+	// tracked here; the write would invalidate the effect and Svelte's
+	// cleanup-then-rerun semantics would cancel the queued RAF before
+	// scrollTo fires (BUG-1425 round 1 regression).
+	$effect(() => {
+		if (pending === null) return;
+		const key = opts.persistKey?.() ?? null;
+		if (pending.key !== key) return; // pending saved for a different entry
+		if (!opts.ready()) return;
+		if (restoredKey === key) return; // already restored for this key
+
+		const y = pending.y;
+		restoredKey = key;
+
+		// Retry-until-tall-enough-AND-stable scroll loop.
+		//
+		// `ready()` going true means data has arrived, but Tiptap renders
+		// content across many frames AND some property-card fields
+		// (relationships, children counts, computed fields) populate
+		// asynchronously AFTER the initial body render. At the moment
+		// of our first scrollTo, .main-content's scrollHeight is a
+		// fraction of its eventual size; scrollTo(y) clamps to the
+		// current max. Worse, if we exit the loop as soon as scrollY
+		// hits y but content ABOVE us keeps growing (property card
+		// taking another 200px once relationships resolve), the layout
+		// shifts down and we end up visually too far down the page —
+		// scrollY=y now points at a different DOM position than at
+		// save time. BUG-1425 round 11.
+		//
+		// The loop continues until BOTH conditions hold:
+		//   (a) actual scroll reached the saved y, AND
+		//   (b) scrollHeight has been unchanged for `STABLE_FRAMES`
+		//       consecutive frames (~250ms).
+		//
+		// On every frame we re-issue scrollTo(y) so growth ABOVE the
+		// target shifts us back to the correct DOM position. Bail
+		// outs:
+		//   - alive=false (component unmounted),
+		//   - pending was cancelled or the route drifted,
+		//   - user scrolled to a position we didn't set (they're
+		//     driving — stop fighting them),
+		//   - 2s overall budget exhausted.
+		const startTime = performance.now();
+		const budgetMs = 2000;
+		const STABLE_FRAMES = 15; // ~250ms at 60fps
+		let lastApplied = -1;
+		let lastScrollHeight = -1;
+		let stableFrames = 0;
+		// User-input detection for the "user is driving" bail. We can't
+		// use a scrollY diff for this because the browser's default
+		// `overflow-anchor: auto` adjusts scrollTop when content layout
+		// shifts (e.g., ChildItems' loading spinner being replaced by
+		// the full sections grows content above us and the browser
+		// silently bumps scrollY to keep the visible anchor stable).
+		// That browser-driven scroll change isn't user input but our
+		// previous diff check treated it as one and bailed mid-restore,
+		// leaving the user 200-400px past their target. BUG-1425 round 12.
+		let userScrolled = false;
+		const markUserScroll = () => {
+			userScrolled = true;
+		};
+		const isScrollKey = (e: KeyboardEvent) =>
+			e.key === 'ArrowUp' ||
+			e.key === 'ArrowDown' ||
+			e.key === 'ArrowLeft' ||
+			e.key === 'ArrowRight' ||
+			e.key === 'PageUp' ||
+			e.key === 'PageDown' ||
+			e.key === 'Home' ||
+			e.key === 'End' ||
+			e.key === ' ';
+		const handleKey = (e: KeyboardEvent) => {
+			if (isScrollKey(e)) userScrolled = true;
+		};
+		window.addEventListener('wheel', markUserScroll, { passive: true });
+		window.addEventListener('touchmove', markUserScroll, { passive: true });
+		window.addEventListener('keydown', handleKey, { passive: true });
+		const cleanupListeners = () => {
+			window.removeEventListener('wheel', markUserScroll);
+			window.removeEventListener('touchmove', markUserScroll);
+			window.removeEventListener('keydown', handleKey);
+		};
+
+		const tryScroll = () => {
+			if (!alive) {
+				cleanupListeners();
+				return;
+			}
+			// Abort if pending was cancelled or the route drifted.
+			if (pending === null || pending.key !== key || pending.y !== y) {
+				cleanupListeners();
+				return;
+			}
+			if (userScrolled) {
+				cleanupListeners();
+				return;
+			}
+
+			const target = getScrollTarget();
+			if (!target) {
+				cleanupListeners();
+				return;
+			}
+
+			const scrollable: HTMLElement | Element =
+				target instanceof Window
+					? document.documentElement
+					: (target as HTMLElement);
+			const currentScrollHeight = scrollable.scrollHeight;
+			if (currentScrollHeight !== lastScrollHeight) {
+				stableFrames = 0;
+				lastScrollHeight = currentScrollHeight;
+			} else {
+				stableFrames++;
+			}
+
+			writeScrollY(target, y);
+			const after = readScrollY(target);
+			lastApplied = after;
+
+			if (after >= y && stableFrames >= STABLE_FRAMES) {
+				cleanupListeners();
+				return;
+			}
+			if (performance.now() - startTime > budgetMs) {
+				cleanupListeners();
+				return;
+			}
+			requestAnimationFrame(tryScroll);
+		};
+		// Two RAFs before the first attempt to let initial paint settle.
+		requestAnimationFrame(() => requestAnimationFrame(tryScroll));
+	});
+
+	return {
+		snapshot: {
+			capture: () => {
+				const y = readScrollY(getScrollTarget());
+				// Mirror to localStorage for cross-tab restoration. Only
+				// writes meaningful (>0) positions; clears the entry on
+				// y===0 so a stale value can't replay against a user
+				// who is now at the top.
+				if (opts.persistKey) {
+					try {
+						const key = opts.persistKey();
+						if (key) {
+							if (y > 0) localStorage.setItem(key, String(y));
+							else localStorage.removeItem(key);
+						}
+					} catch {
+						// localStorage unavailable — silent no-op.
+					}
+				}
+				return y;
+			},
+			restore: (y) => {
+				const key = opts.persistKey?.() ?? null;
+				// Mark THIS key as snapshot-claimed so the LS fallback's
+				// microtask sees `snapshotKey === key` and skips. This
+				// replaces the unsafe `snapshotRestoreCalled` boolean
+				// (Codex BUG-1425 round 5 P1).
+				snapshotKey = key;
+				// Always reset the per-key guard — even when y is 0 or
+				// invalid — so a subsequent valid restore can fire.
+				restoredKey = undefined;
+				if (typeof y !== 'number' || !Number.isFinite(y) || y <= 0) {
+					// Snapshot says "user was at top" (or invalid).
+					// Clear any pending value (e.g. one populated by the
+					// LS fallback racing ahead of this restore call).
+					// The freshly-arrived snapshot is more authoritative
+					// than the cross-tab LS mirror — if the user
+					// genuinely ended at top, we honor that. Codex
+					// round 5 P2-B.
+					pending = null;
+					return;
+				}
+				pending = { y, key };
+			},
+		},
+	};
+}

--- a/web/src/routes/[username]/[workspace]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/+page.svelte
@@ -13,6 +13,7 @@
 	import CreateCollectionModal from '$lib/components/collections/CreateCollectionModal.svelte';
 	import { collectionStore } from '$lib/stores/collections.svelte';
 	import { titleStore } from '$lib/stores/title.svelte';
+	import { createScrollRestoration } from '$lib/scroll/restore.svelte';
 	import type { DashboardResponse, Collection } from '$lib/types';
 
 	let wsSlug = $derived(page.params.workspace ?? '');
@@ -21,6 +22,16 @@
 	let loading = $state(true);
 	let dashboard = $state<DashboardResponse | null>(null);
 	let collections = $state<Collection[]>([]);
+
+	// Scroll position restoration (BUG-1425). Dashboard renders progressively
+	// (active items, attention list, etc.) — wait for the initial dashboard
+	// fetch before applying a saved offset so the document is tall enough.
+	const scrollRestoration = createScrollRestoration({
+		ready: () => !loading && dashboard !== null,
+		persistKey: () =>
+			wsSlug ? `pad-last-scroll-${wsSlug}-${page.url.pathname}` : null,
+	});
+	export const snapshot = scrollRestoration.snapshot;
 	let pollTimer: ReturnType<typeof setInterval> | undefined;
 	let onboardingDismissed = $state(false);
 	let connectOpen = $state(false);

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -23,6 +23,7 @@
 	import { authStore } from '$lib/stores/auth.svelte';
 	import { localIndex } from '$lib/stores/localIndex.svelte';
 	import { localSearch, parseSearchQuery } from '$lib/stores/localSearch.svelte';
+	import { createScrollRestoration } from '$lib/scroll/restore.svelte';
 
 	type ViewMode = 'list' | 'board' | 'table';
 
@@ -226,149 +227,43 @@
 		if (wsSlug && collSlug) loadCollection(wsSlug, collSlug, showArchived);
 	});
 
-	// ── Scroll position persistence (TASK-755) ─────────────────────────
-	// Save the page scroll (debounced) per workspace+route so the workspace
-	// switcher (TASK-754) brings the user back to where they were scrolled
-	// to. Storage key includes pathname AND search so different filter /
-	// view-mode URLs get their own entries — when filters change the URL,
-	// the entry can't be misapplied to a different view-signature.
+	// ── Scroll position persistence (TASK-755 → BUG-1425) ──────────────
+	// Wire SvelteKit's snapshot API through the shared scroll-restoration
+	// helper. The helper:
+	//   1. Captures scrollY into sessionStorage on navigate-away (per
+	//      history entry — back/forward each get the right offset).
+	//   2. Restores via double-RAF gated on `loading` so the document has
+	//      hydrated enough that scrollTo isn't clamped to ~0.
+	//   3. Mirrors to localStorage under `persistKey` for cross-tab /
+	//      tab-close-reopen restoration (the workspace-switcher TASK-754
+	//      route restore path).
 	//
-	// Restore is gated by pathname (not pathname+search), so:
-	//   - first entry to a collection page restores once,
-	//   - in-page filter toggles do NOT re-restore (avoids teleporting the
-	//     user away from where they currently are scrolling),
-	//   - sidebar nav to another collection and back DOES restore again.
+	// `persistKey` includes pathname, search, and `showArchived` so each
+	// filter / view-mode URL gets its own localStorage entry — toggling
+	// archived (which changes the dataset but not the URL) doesn't apply
+	// a stale offset across the two views.
 	//
 	// Scope is intentionally page-level scroll only. Board view's internal
-	// horizontal (.board-view) and per-column vertical scroll containers
-	// are not yet captured (BoardView would need to expose scroll refs);
-	// page-level scroll still covers the dominant list and table views.
-	// scrollKey includes `showArchived` because it changes the fetched
-	// dataset but is not synced to the URL — saving a scroll position
-	// while in the archived view would otherwise re-apply to the
-	// non-archived view (different items, unrelated offset).
-	let scrollKey = $derived(
-		wsSlug
-			? `pad-last-scroll-${wsSlug}-${page.url.pathname}${page.url.search}${showArchived ? '|archived' : ''}`
-			: ''
-	);
-	let scrollGateKey = $derived(wsSlug ? `${wsSlug}:${page.url.pathname}` : '');
-	let scrollRestoredFor = $state<string | null>(null);
-	let scrollSaveTimer: ReturnType<typeof setTimeout> | undefined;
-	// Pending debounced save state. Tracked alongside the timer so that
-	// when scheduleScrollSave is called with a different `key` than the
-	// pending one, we can FLUSH the prior save instead of cancelling it
-	// (which would silently drop the user's last position on collection A
-	// when they navigate to and scroll on B within the 200ms window).
-	let scrollPendingKey: string | null = null;
-	let scrollPendingY = 0;
-	// RAF id of the in-flight restore (or undefined). Tracked so we can
-	// cancel it on unmount — once this component is destroyed, the inner
-	// RAF's `scrollGateKey === expectedGate` check no longer guards us
-	// (the closure observes the destroyed-component's last-computed value),
-	// so without cancellation a queued restore could scrollTo the next
-	// page after a fast cross-route navigation.
-	let scrollRestoreRAF: number | undefined;
-
-	// Reset the restore-once gate when the pathname changes. Without this,
-	// visiting an empty or not-found collection between two visits to A
-	// would keep `scrollRestoredFor` stuck on A's gate-key and skip the
-	// next restore. Kept in its own effect per CONVE-606.
-	$effect(() => {
-		scrollGateKey;
-		scrollRestoredFor = null;
+	// horizontal scroll container is not captured here.
+	const scrollRestoration = createScrollRestoration({
+		// `collection?.slug === collSlug` is the identity check that
+		// prevents firing against stale content when the same component
+		// instance handles a different collection URL (e.g. /tasks →
+		// /bugs). `length > 0` deliberately omitted (Codex P2 round 2).
+		ready: () => !loading && collection?.slug === collSlug,
+		// persistKey is intentionally pathname-only — filter / view /
+		// archive toggles call `goto({ replaceState: true })` which
+		// rewrites `page.url.search`, and if those were in the key the
+		// helper would treat each filter combo as a separate entry,
+		// clear `pending`, re-read LS, and restore-jump the user mid-
+		// interaction. Codex BUG-1425 round 5 P2-A flagged this as a
+		// regression vs. TASK-755's pathname-only restore gate. We
+		// trade per-filter offset granularity (was per-`?status=open`)
+		// for stable in-page filter behavior.
+		persistKey: () =>
+			wsSlug ? `pad-last-scroll-${wsSlug}-${page.url.pathname}` : null,
 	});
-
-	function flushPendingScrollSave() {
-		const key = scrollPendingKey;
-		if (key === null) return;
-		const y = scrollPendingY;
-		scrollPendingKey = null;
-		try {
-			if (y > 0) {
-				localStorage.setItem(key, String(y));
-			} else {
-				localStorage.removeItem(key);
-			}
-		} catch {
-			// localStorage unavailable; silent no-op.
-		}
-	}
-
-	function scheduleScrollSave() {
-		// Only save AFTER the restore-once effect has had a chance to run
-		// for this pathname. Until then, SvelteKit's auto-scroll-to-top on
-		// navigation would fire a scroll event with y=0 that, if persisted,
-		// would clobber a previously-saved entry before we ever read it.
-		if (scrollRestoredFor !== scrollGateKey) return;
-		// Capture the key and scrollY synchronously at scroll-event time —
-		// not at timer-fire time. If the user changes filters / navigates
-		// within the debounce window, `scrollKey` would be the NEW value at
-		// timer fire and we'd write the old scroll-y into the wrong entry.
-		const key = scrollKey;
-		const y = window.scrollY;
-		if (!key) return;
-
-		// If a different key is pending, flush it before we cancel its
-		// timer — otherwise we'd lose A's last-known position when B's
-		// first scroll arrives within A's debounce window.
-		if (scrollPendingKey !== null && scrollPendingKey !== key) {
-			clearTimeout(scrollSaveTimer);
-			flushPendingScrollSave();
-		}
-
-		clearTimeout(scrollSaveTimer);
-		scrollPendingKey = key;
-		scrollPendingY = y;
-		scrollSaveTimer = setTimeout(flushPendingScrollSave, 200);
-	}
-
-	$effect(() => {
-		if (loading) return;
-		if (!scrollGateKey || !scrollKey) return;
-		if (scrollRestoredFor === scrollGateKey) return;
-		// Capture the gate / key in the closure so the RAF callback can
-		// confirm both still apply before calling window.scrollTo. A fast
-		// follow-up navigation OR an in-page key-changing toggle (filter,
-		// archive) between effect run and RAF execution would otherwise
-		// scroll to an offset that no longer matches the current view.
-		const expectedGate = scrollGateKey;
-		const expectedKey = scrollKey;
-		// Mark the gate as "restore attempted" BEFORE the empty-items
-		// short-circuit so a later items-appear-on-same-gate event (e.g.
-		// the user creates an item in an empty collection, or an in-page
-		// toggle that doesn't change the gate-key produces items) cannot
-		// trigger a delayed unintended restore.
-		scrollRestoredFor = scrollGateKey;
-		if (filteredItems.length === 0) return;
-		try {
-			const raw = localStorage.getItem(expectedKey);
-			if (!raw) return;
-			const y = Number(raw);
-			if (!Number.isFinite(y) || y <= 0) return;
-			// Two RAFs: layout settles after items render, then we scroll.
-			// 'instant' avoids smooth-scroll on what should feel like a
-			// natural restoration of position, not a user-driven jump.
-			// We track the RAF id so onDestroy can cancel a queued restore
-			// — without that, a fast nav off this collection page can
-			// still scroll the next page (the gate check is insufficient
-			// after the component is destroyed; see scrollRestoreRAF docs).
-			scrollRestoreRAF = requestAnimationFrame(() => {
-				scrollRestoreRAF = requestAnimationFrame(() => {
-					scrollRestoreRAF = undefined;
-					// Bail if either the path-level gate or the
-					// URL-state-level key has changed since this restore
-					// was queued. (Filter/archive toggles change the key
-					// without changing the gate, so we need both checks.)
-					if (scrollGateKey !== expectedGate) return;
-					if (scrollKey !== expectedKey) return;
-					window.scrollTo({ top: y, behavior: 'instant' as ScrollBehavior });
-				});
-			});
-		} catch {
-			// localStorage unavailable / parse error — silent no-op.
-		}
-	});
+	export const snapshot = scrollRestoration.snapshot;
 
 	// Reflect the collection name in the browser tab; clear any stale item ref.
 	$effect(() => {
@@ -435,15 +330,9 @@
 	onDestroy(() => {
 		unsubscribeSSE?.();
 		unsubscribeSync?.();
-		// Flush any pending debounced scroll save so the user's last
-		// position isn't silently dropped on unmount (TASK-755).
-		clearTimeout(scrollSaveTimer);
-		flushPendingScrollSave();
-		// Cancel a queued restore so it can't scroll the next page.
-		if (scrollRestoreRAF !== undefined) {
-			cancelAnimationFrame(scrollRestoreRAF);
-			scrollRestoreRAF = undefined;
-		}
+		// Scroll save/restore cleanup is owned by createScrollRestoration
+		// (snapshot.capture fires on navigate-away; the helper's $effect
+		// teardown cancels any in-flight RAF).
 	});
 
 	/**
@@ -1408,7 +1297,7 @@
 	}
 </script>
 
-<svelte:window onkeydown={handlePageKeydown} onscroll={scheduleScrollSave} />
+<svelte:window onkeydown={handlePageKeydown} />
 
 <div class="collection-page" class:board-active={viewMode === 'board'}>
 	{#if loading}

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -33,6 +33,7 @@
 	import { starredStore } from '$lib/stores/starred.svelte';
 	import { titleStore } from '$lib/stores/title.svelte';
 	import { workspaceStore } from '$lib/stores/workspace.svelte';
+	import { createScrollRestoration } from '$lib/scroll/restore.svelte';
 
 	type RelationshipEntry = {
 		key: string;
@@ -58,6 +59,33 @@
 	let collection = $state<Collection | null>(null);
 	let loading = $state(true);
 	let error = $state('');
+
+	// ── Scroll position restoration (BUG-1425) ─────────────────────────
+	// Item detail pages fetch content async (loadData), so SvelteKit's
+	// built-in scroll restoration runs against a still-skeleton document
+	// and clamps the saved offset to ~0. The helper parks the snapshot
+	// value until ready() is true, then double-RAFs and scrolls.
+	//
+	// `ready` requires the loaded item's identity to match the URL
+	// param — otherwise a same-instance route change (item A →
+	// wiki-link to B → back to A) would fire the restore against B's
+	// still-rendered content. The match accepts EITHER the slug form
+	// OR the issue ref (e.g. `TASK-123`) because `itemUrlId()` (in
+	// `$lib/types/index.ts`) prefers refs over slugs when building
+	// links, so most app URLs are `/tasks/TASK-123` rather than
+	// `/tasks/some-slug`. Without the ref alternative, `ready()`
+	// would never become true for ref URLs and the restore would
+	// hang forever. Codex BUG-1425 round 5 P1.
+	const scrollRestoration = createScrollRestoration({
+		ready: () =>
+			!loading &&
+			item !== null &&
+			(item.slug === itemSlug ||
+				`${item.collection_prefix}-${item.item_number}` === itemSlug),
+		persistKey: () =>
+			wsSlug ? `pad-last-scroll-${wsSlug}-${page.url.pathname}` : null,
+	});
+	export const snapshot = scrollRestoration.snapshot;
 
 	let editorInstance = $state<EditorType | null>(null);
 

--- a/web/src/routes/[username]/[workspace]/activity/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/activity/+page.svelte
@@ -5,6 +5,7 @@
 	import { workspaceStore } from '$lib/stores/workspace.svelte';
 	import { titleStore } from '$lib/stores/title.svelte';
 	import { relativeTime } from '$lib/utils/markdown';
+	import { createScrollRestoration } from '$lib/scroll/restore.svelte';
 	import type { Activity, Collection } from '$lib/types';
 
 	let wsSlug = $derived(page.params.workspace ?? '');
@@ -16,6 +17,22 @@
 	let loading = $state(true);
 	let loadingMore = $state(false);
 	let hasMore = $state(true);
+
+	// Scroll position restoration (BUG-1425). Wait for the first page of
+	// activities to render before applying a saved offset. The persistKey
+	// includes the URL so filtered views (`?action=…`) keep their own entry.
+	const scrollRestoration = createScrollRestoration({
+		// `loading` flips true when filters/workspace change (loadActivities
+		// reset path), giving the helper its required ready=false
+		// transition. `length > 0` deliberately omitted (Codex P2): a
+		// late SSE-driven new activity shouldn't re-fire a stale restore.
+		ready: () => !loading,
+		persistKey: () =>
+			wsSlug
+				? `pad-last-scroll-${wsSlug}-${page.url.pathname}${page.url.search}`
+				: null,
+	});
+	export const snapshot = scrollRestoration.snapshot;
 
 	// Filters
 	let filterAction = $state('');

--- a/web/src/routes/[username]/[workspace]/conventions/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/conventions/+page.svelte
@@ -4,6 +4,7 @@
 	import type { Collection, Item, ItemConventionMetadata, ItemCreate } from '$lib/types';
 	import { parseFields, parseSchema } from '$lib/types';
 	import { toastStore } from '$lib/stores/toast.svelte';
+	import { createScrollRestoration } from '$lib/scroll/restore.svelte';
 	import { SvelteSet, SvelteMap } from 'svelte/reactivity';
 
 	const TRIGGERS = ['always','on-task-start','on-task-complete','on-implement','on-commit','on-pr-create','on-plan-start','on-plan-complete','on-plan'] as const;
@@ -34,6 +35,19 @@
 	let conventions = $state<Item[]>([]);
 	let conventionsCollection = $state<Collection | null>(null);
 	let loading = $state(true);
+
+	// Scroll position restoration (BUG-1425).
+	const scrollRestoration = createScrollRestoration({
+		// `conventionsCollection` flips null on workspace change. Length
+		// gate omitted (Codex P2 round 2).
+		ready: () => !loading && conventionsCollection !== null,
+		persistKey: () =>
+			workspace
+				? `pad-last-scroll-${workspace}-${page.url.pathname}${page.url.search}`
+				: null,
+	});
+	export const snapshot = scrollRestoration.snapshot;
+
 	let expandedSlug = $state<string | null>(null);
 	let collapsedGroups = new SvelteSet<string>();
 	let showCreate = $state(false);

--- a/web/src/routes/[username]/[workspace]/library/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/library/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { page } from '$app/state';
 	import { api } from '$lib/api/client';
+	import { createScrollRestoration } from '$lib/scroll/restore.svelte';
 	import type { LibraryCategory, LibraryConvention, PlaybookCategory, LibraryPlaybook, Item } from '$lib/types';
 
 	let wsSlug = $derived(page.params.workspace ?? '');
@@ -11,6 +12,19 @@
 	let activeConventionTitles = $state<Set<string>>(new Set());
 	let activePlaybookTitles = $state<Set<string>>(new Set());
 	let loading = $state(true);
+
+	// Scroll position restoration (BUG-1425). persistKey includes `?tab=…`
+	// so the conventions and playbooks tabs each keep their own offset.
+	const scrollRestoration = createScrollRestoration({
+		// `loading` flips true on workspace change. Length-based gate
+		// omitted (Codex P2 round 2).
+		ready: () => !loading,
+		persistKey: () =>
+			wsSlug
+				? `pad-last-scroll-${wsSlug}-${page.url.pathname}${page.url.search}`
+				: null,
+	});
+	export const snapshot = scrollRestoration.snapshot;
 	let activatingTitle = $state<string | null>(null);
 	let toast = $state<string | null>(null);
 	let activeTab = $state<'conventions' | 'playbooks'>(

--- a/web/src/routes/[username]/[workspace]/playbooks/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/playbooks/+page.svelte
@@ -4,6 +4,7 @@
 	import { api } from '$lib/api/client';
 	import { parseFields, parseSchema, itemUrlId, type Collection, type Item } from '$lib/types';
 	import { toastStore } from '$lib/stores/toast.svelte';
+	import { createScrollRestoration } from '$lib/scroll/restore.svelte';
 	import PlaybookFormFields from '$lib/components/playbooks/PlaybookFormFields.svelte';
 	import {
 		PLAYBOOK_SKELETON_BODY,
@@ -20,6 +21,19 @@
 	let playbooks = $state<Item[]>([]);
 	let playbooksCollection = $state<Collection | null>(null);
 	let loading = $state(true);
+
+	// Scroll position restoration (BUG-1425).
+	const scrollRestoration = createScrollRestoration({
+		// `playbooksCollection` flips null on workspace change. Length
+		// gate omitted (Codex P2 round 2).
+		ready: () => !loading && playbooksCollection !== null,
+		persistKey: () =>
+			wsSlug
+				? `pad-last-scroll-${wsSlug}-${page.url.pathname}${page.url.search}`
+				: null,
+	});
+	export const snapshot = scrollRestoration.snapshot;
+
 	let expandedId = $state<string | null>(null);
 	let showNewForm = $state(false);
 	let deleting = $state<string | null>(null);

--- a/web/src/routes/[username]/[workspace]/playbooks/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/playbooks/[slug]/+page.svelte
@@ -4,6 +4,7 @@
 	import { api } from '$lib/api/client';
 	import { parseFields, parseSchema, type Collection, type Item } from '$lib/types';
 	import { toastStore } from '$lib/stores/toast.svelte';
+	import { createScrollRestoration } from '$lib/scroll/restore.svelte';
 	import PlaybookFormFields from '$lib/components/playbooks/PlaybookFormFields.svelte';
 	import {
 		argumentsFromJSON,
@@ -34,6 +35,25 @@
 	let existingPlaybooks = $state<Item[]>([]);
 	let loading = $state(true);
 	let saving = $state(false);
+
+	// Scroll position restoration (BUG-1425). Form pages are usually short
+	// enough that scroll position isn't critical, but if the body grows the
+	// helper keeps offset preserved on back-nav like the rest of the app.
+	//
+	// The identity guards (item.slug === ref || issue-id === ref) ensure
+	// we don't restore against stale content from a previous playbook
+	// while loadItem() for the new ref is still in flight — same race
+	// as the item detail page (Codex BUG-1425 round 4 P1-B).
+	const scrollRestoration = createScrollRestoration({
+		ready: () =>
+			!loading &&
+			item !== null &&
+			(item.slug === ref ||
+				`${item.collection_prefix}-${item.item_number}` === ref),
+		persistKey: () =>
+			wsSlug ? `pad-last-scroll-${wsSlug}-${page.url.pathname}` : null,
+	});
+	export const snapshot = scrollRestoration.snapshot;
 
 	// Form fields — initialized from the loaded item.
 	let title = $state('');

--- a/web/src/routes/[username]/[workspace]/roles/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/roles/+page.svelte
@@ -6,6 +6,7 @@
 	import { collectionStore } from '$lib/stores/collections.svelte';
 	import { uiStore } from '$lib/stores/ui.svelte';
 	import { itemUrlId } from '$lib/types';
+	import { createScrollRestoration } from '$lib/scroll/restore.svelte';
 	import type { Item, Collection, RoleBoardLane, AgentRole } from '$lib/types';
 	import ItemCard from '$lib/components/collections/ItemCard.svelte';
 	import EmojiPickerButton from '$lib/components/common/EmojiPickerButton.svelte';
@@ -44,6 +45,19 @@
 	let lanes = $state<RoleBoardLane[]>([]);
 	let loading = $state(true);
 	let error = $state('');
+
+	// Scroll position restoration (BUG-1425). Lanes render as a board, so
+	// page-level scroll is dominantly vertical — board-internal horizontal
+	// scroll is out of scope here (same constraint as the collection-page
+	// board view).
+	const scrollRestoration = createScrollRestoration({
+		// `loading` flips true on workspace change. Length gate omitted
+		// (Codex P2 round 2).
+		ready: () => !loading,
+		persistKey: () =>
+			wsSlug ? `pad-last-scroll-${wsSlug}-${page.url.pathname}` : null,
+	});
+	export const snapshot = scrollRestoration.snapshot;
 
 	// Highlight: dim cards not assigned to current user
 	let highlightMine = $state(false);

--- a/web/src/routes/[username]/[workspace]/starred/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/starred/+page.svelte
@@ -5,6 +5,7 @@
 	import { workspaceStore } from '$lib/stores/workspace.svelte';
 	import { collectionStore } from '$lib/stores/collections.svelte';
 	import { starredStore } from '$lib/stores/starred.svelte';
+	import { createScrollRestoration } from '$lib/scroll/restore.svelte';
 	import ItemCard from '$lib/components/collections/ItemCard.svelte';
 	import type { Item, Collection } from '$lib/types';
 
@@ -16,6 +17,17 @@
 	let loading = $state(true);
 	let includeTerminal = $state(false);
 	let loadSeq = 0;
+
+	// Scroll position restoration (BUG-1425).
+	const scrollRestoration = createScrollRestoration({
+		// `loading` flips true when workspace changes (loadData reset),
+		// satisfying the helper's stale-content guard. `length > 0`
+		// omitted per Codex P2 round 2 to avoid late SSE re-fire.
+		ready: () => !loading,
+		persistKey: () =>
+			wsSlug ? `pad-last-scroll-${wsSlug}-${page.url.pathname}` : null,
+	});
+	export const snapshot = scrollRestoration.snapshot;
 
 	// Filter fetched items by current starred state so unstars are reflected immediately.
 	// If the store hasn't loaded yet, trust the API response (it only returns starred items).


### PR DESCRIPTION
## Summary

- Replaces TASK-755's bespoke listing-only scroll restoration with a reusable `createScrollRestoration` helper built on SvelteKit's `snapshot` API.
- Applied across every workspace top-level page (item detail, collection listing, workspace home, activity, starred, library, conventions, playbooks list/detail, roles).
- Fixes BUG-1425 — scroll position not preserved on back-navigation across the app.

## The actual root causes (2 of them)

The helper went through 12 rounds of iteration before working. The final fix relied on 2 insights that diagnostic console.logs revealed:

1. **Wrong scroll target.** `window.scrollY` is permanently 0 in this app because `.main-content` (set by the root layout) is the actual `overflow-y: auto` container. `snapshot.capture` was always saving `y=0`. TASK-755's listing logic had the same bug — it was broken in practice once that CSS landed; we just never noticed because the bug report focused on item pages. Fixed by resolving the scroll target via `getScrollTarget()` which prefers `.main-content` and falls back to `window`.

2. **Wrong bail signal.** Once we targeted `.main-content` and the retry loop fired with the right value, it bailed within 1-2 frames via the \"user scrolled\" detection. The diff check (`current !== lastApplied`) was misfiring on Chrome's default `overflow-anchor: auto`: when ChildItems' loading spinner gets replaced with the full sections (~400px growth above the scroll target), the browser silently bumps scrollTop to preserve the visible anchor. That browser-driven change isn't user input but the diff check treated it as one. Fixed by detecting user input via real `wheel`/`touchmove`/`keydown` listeners.

## Design (`web/src/lib/scroll/restore.svelte.ts`)

`createScrollRestoration({ ready, persistKey? })` returns `{ snapshot }` for the page to re-export as SvelteKit's snapshot contract. Layered:

1. **SvelteKit snapshot** (per-history-entry sessionStorage) for back/forward.
2. **localStorage fallback** for cross-tab / workspace-switcher `goto()` (no popstate) restoration; re-fires per `persistKey` change.
3. **Per-key `restoredKey` one-shot** so routes that reuse a component instance across URLs get fresh restoration on each new entry.
4. **`snapshotKey`** tracks the SvelteKit-claimed key so LS fallback yields to a popstate `snapshot.restore` that beats the effect.
5. **`ready()` gate** — caller-provided predicate. Routes that reload on URL change verify content-vs-URL identity (e.g. `item.slug === itemSlug || issue-id === itemSlug`). `itemUrlId()` prefers refs over slugs so the issue-id branch is the dominant URL shape.
6. **Retry loop** with scrollHeight-stability gate (~250ms) and 2s budget. Per-frame re-scroll handles Tiptap rendering content across many frames + async property-card fields.
7. **User-input bail** via wheel/touchmove/keydown listeners (NOT scrollY diff — see root cause #2).
8. **Scroll target is `.main-content`**, not `window` (root cause #1).

## Per-page integration

Each workspace page calls `createScrollRestoration()` with a `ready()` matching its loading shape and a pathname-keyed `persistKey`. The collection listing's `persistKey` deliberately excludes `?search` and `showArchived` so filter toggles via `goto({replaceState})` don't trigger restore-jumps mid-interaction.

## Diff stats

- 11 files changed, 637 insertions(+), 149 deletions(-)
- New: `web/src/lib/scroll/restore.svelte.ts` (~460 lines with extensive design notes)
- Removed: ~140 lines of TASK-755's bespoke listing localStorage + double-RAF code

## Test plan

- [ ] make check passes locally (golangci-lint, go test, npm run build) ✓ verified
- [ ] svelte-check 0 errors ✓ verified
- [ ] Manual: hard refresh → item detail → scroll → click wiki-link to child → wait → browser back → confirm scroll restored
- [ ] Manual: same on collection listing (with content tall enough to scroll)
- [ ] Manual: same on workspace home (dashboard)
- [ ] Manual: filter toggle on collection listing does NOT cause scroll to jump
- [ ] Manual: workspace switcher cross-workspace nav restores scroll if it was previously stored in LS
- [ ] Manual: page reload (F5) restores scroll via sessionStorage