### PR TITLE
fix(web): await workspace items before Y.Doc seed (BUG-1461)

### DIFF
--- a/web/src/lib/stores/collections.svelte.ts
+++ b/web/src/lib/stores/collections.svelte.ts
@@ -3,14 +3,36 @@ import type { Collection, Item } from '$lib/types';
 
 let collections = $state<Collection[]>([]);
 let items = $state<Item[]>([]);
+// Workspace slug the current `items` array was loaded for. Used to decide
+// whether `items` is stale for a different workspace (BUG-1461). `items` is
+// a single global slot, so without this stamp a navigation from workspace A
+// to workspace B would leave A's items in the store and freshness checks
+// based purely on `items.length` would silently accept them as B's data —
+// causing wiki-link resolution (which scans `items` for title/ref matches)
+// to render `[[X]]` brackets as plain text. Null = no load completed yet
+// for a full workspace; a non-null value pairs the items array with its
+// source workspace.
+let itemsWorkspace = $state<string | null>(null);
 let activeItem = $state<Item | null>(null);
 let loading = $state(false);
 
 export const collectionStore = {
 	get collections() { return collections; },
 	get items() { return items; },
+	get itemsWorkspace() { return itemsWorkspace; },
 	get activeItem() { return activeItem; },
 	get loading() { return loading; },
+
+	/**
+	 * Returns true when `items` was last loaded as a full-workspace list
+	 * (no collection filter) for the given workspace slug. Callers that
+	 * need ALL items for wiki-link resolution should use this gate rather
+	 * than `items.length === 0` — the latter can't distinguish "empty
+	 * workspace" from "stale items from a different workspace."
+	 */
+	itemsAreFreshFor(ws: string): boolean {
+		return itemsWorkspace === ws;
+	},
 
 	get defaultCollections() {
 		return collections.filter(c => c.is_default).sort((a, b) => a.sort_order - b.sort_order);
@@ -34,8 +56,14 @@ export const collectionStore = {
 		try {
 			if (collectionSlug) {
 				items = await api.items.listByCollection(ws, collectionSlug, params);
+				// Partial load — the stored array no longer represents the
+				// full workspace, so invalidate the freshness stamp. A
+				// downstream caller asking `itemsAreFreshFor(ws)` will
+				// correctly trigger a full re-load.
+				itemsWorkspace = null;
 			} else {
 				items = await api.items.list(ws, params);
+				itemsWorkspace = ws;
 			}
 		} finally {
 			loading = false;

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -416,9 +416,26 @@
 		const reqCollSlug = collSlug;
 		const reqItemSlug = itemSlug;
 		try {
+			// Workspace items are needed for wiki-link resolution at Y.Doc
+			// seed time (the $effect ~line 904 below) and for the
+			// non-collab editorContent derived (~line 103 above). Both
+			// silently fall back to raw markdown when the items array is
+			// empty, baking literal `[[X]]` text into the Y.Doc the first
+			// time a fresh item with wiki-links is opened (BUG-1461). We
+			// fold the load into this Promise.all and AWAIT it before
+			// `item` is set so the downstream readers always see a
+			// populated items list paired with the correct workspace.
+			// The freshness gate (workspace-scoped, not length-based) is
+			// what prevents a stale cross-workspace items array from
+			// satisfying a naive `items.length > 0` check after a
+			// workspace switch.
+			const itemsPromise = collectionStore.itemsAreFreshFor(wsSlug)
+				? Promise.resolve()
+				: collectionStore.loadItems(wsSlug);
 			const [itemData, collData] = await Promise.all([
 				api.items.get(wsSlug, itemSlug),
-				api.collections.get(wsSlug, collSlug)
+				api.collections.get(wsSlug, collSlug),
+				itemsPromise
 			]);
 			item = itemData;
 			collection = collData;
@@ -440,10 +457,10 @@
 				computedOverrides = {};
 			}
 
-			// Also load items for wiki-link resolution if not already loaded
-			if ((collectionStore.items ?? []).length === 0) {
-				collectionStore.loadItems(wsSlug);
-			}
+			// Items for wiki-link resolution are now loaded as part of the
+			// Promise.all above so they're awaited before `item` is set
+			// (BUG-1461 — previously this was a fire-and-forget call here,
+			// which raced the Y.Doc seed and could bake `[[X]]` text in).
 
 			// Load links for this item
 			try {


### PR DESCRIPTION
## Summary

- BUG-1461 was filed as "parens inside a wiki reference seem to break it" — actual root cause is an items-load race at Y.Doc seed time, not parens. The reporter's "one wiki-link with parens didn't turn into a link" observation lined up with a wiki-link that happened to contain an em-dash, not parens; all wiki-style links on the affected item (TASK-274 in the apm workspace) fail equally.
- `loadData()` in the slug page fired `collectionStore.loadItems(wsSlug)` fire-and-forget. The Y.Doc seed `$effect` reads `collectionStore.items` to call `wikiLinksToMarkdown`; when the seed fires before items resolves, it falls through to raw markdown and writes literal `[[X]]` text into the Y.Doc. The seed's `fragment.length > 0` gate makes the corruption permanent for that item — subsequent loads skip the seed and the brackets stay as plain text.
- Fold the items load into the initial `Promise.all` and AWAIT it before `item` is set. Gate on a new workspace-scoped freshness helper (`itemsAreFreshFor`) instead of a length-based check, so a stale items array carried over from a previous workspace can't satisfy the guard. `itemsWorkspace` is stamped only on full-workspace loads; collection-scoped loads invalidate it.
- Verified via independent Codex second-opinion review (session `019e28ee`). Codex agreed on the root cause + fix shape and flagged the workspace-scope concern that the final implementation addresses.

## Existing damage

Items whose Y.Doc was already baked before this fix landed stay broken — the seed effect won't re-fire because `fragment.length > 0`. Repair is "edit the item and save": the save round-trip runs `markdownToWikiLinks`, which rewrites the literal `[[X]]` text back to the canonical form. TASK-274 in `apm` is in this state. No automated migration shipped here; the bake-in surface area is bounded (only items first-opened during a slow items-load window) and inline repair on next edit is acceptable for the volume.

## Test plan

- [ ] `npm run build` passes (already verified locally)
- [ ] `make install` clean (already verified locally)
- [ ] Create a fresh item via CLI with wiki-links in `--content` (e.g. `pad item create task "test" --content "See [[TASK-287]] and [[Some Title]]."`), open the web UI page for the first time — wiki-links render as clickable links.
- [ ] Open an existing (pre-fix) item with `[[...]]` content that has NOT yet been viewed in the web UI — wiki-links resolve on first view.
- [ ] Workspace-switch test: open a slug page in workspace A (items load), switch to workspace B, open a slug page there — B's wiki-links resolve against B's items, not A's stale array.
- [ ] Pre-existing bake-in repair: open TASK-274 in `apm`, make any edit, save, reload — `[[X]]` text now renders as links.

BUG-1461 status moved to `fixing`; severity set to `high`, component `ui/editor/collab-seed`.