### PR TITLE
fix(fields,activity): debounce typed-input field saves + collapse same-field activity runs (BUG-1466)

### DIFF
--- a/internal/server/handlers_documents.go
+++ b/internal/server/handlers_documents.go
@@ -435,9 +435,14 @@ func diffFields(oldFields, newFields string) string {
 		changes = append(changes, fmt.Sprintf("%s: %s → %s", key, oldStr, newStr))
 	}
 
-	// Sort for deterministic output
+	// Sort for deterministic output.
 	sort.Strings(changes)
-	return strings.Join(changes, ", ")
+	// "; " matches mergeActivityMeta's joiner and the web timeline parser's
+	// split delimiter (TimelineActivityCard.svelte splits on ';'), so a
+	// multi-field PATCH renders as individual change pills instead of one
+	// unparseable blob. Same delimiter for single-PATCH and merged outputs
+	// lets collapseChanges treat the whole string uniformly.
+	return strings.Join(changes, "; ")
 }
 
 // formatChangeValue renders a JSON-decoded field value as a human-readable

--- a/internal/server/handlers_documents_test.go
+++ b/internal/server/handlers_documents_test.go
@@ -10,8 +10,11 @@ func TestDiffFieldsPrimitives(t *testing.T) {
 		`{"status":"open","priority":"medium"}`,
 		`{"status":"in-progress","priority":"high"}`,
 	)
-	// Order is alphabetical (sort.Strings on the changes slice).
-	want := "priority: medium → high, status: open → in-progress"
+	// Order is alphabetical (sort.Strings on the changes slice). "; " is
+	// the joiner; matches mergeActivityMeta and the web parser's split
+	// delimiter so multi-field PATCHes render as individual change pills
+	// instead of one unparseable blob.
+	want := "priority: medium → high; status: open → in-progress"
 	if got != want {
 		t.Errorf("diffFields primitives:\n  got:  %q\n  want: %q", got, want)
 	}

--- a/internal/store/activities.go
+++ b/internal/store/activities.go
@@ -153,24 +153,33 @@ func collapseChanges(s string) string {
 		// hadTransition is true iff any input entry in the run produced a
 		// display-string transition — i.e. either the initial entry had
 		// from != to, or a subsequent entry's `to` differed from the
-		// run's anchored `from`. Used by the drop step to distinguish:
-		//
-		//   - typed-then-backspaced (BUG-1419 / BUG-1466):
-		//     `c: → t; c: t → ti; c: ti → t; c: t → ` — intermediate
-		//     `to` values ("t", "ti") differ from anchor `from`=""
-		//     → hadTransition=true, from==to, dropped as net no-op.
-		//
-		//   - repeated same-display structured-field replacements
-		//     (Codex review round 2 [P2]):
-		//     `implementation_notes: (1 note) → (1 note); implementation_notes: (1 note) → (1 note)`
-		//     — every `to` equals the anchor `from`, so the display
-		//     trace shows no transition → hadTransition=false, preserved.
-		//     The underlying values DID change (diffFields uses
-		//     reflect.DeepEqual; see TestDiffFieldsSameCardinalityArrayChangeStillReported),
-		//     but that information is lost once formatChangeValue
-		//     summarises both as `(1 note)`. We can't recover it from
-		//     the merged string, but we mustn't pretend nothing happened.
+		// run's anchored `from`. Used together with hasLossySummary
+		// below to decide whether a from==to result is a true net no-op.
 		hadTransition bool
+		// hasLossySummary is true iff ANY entry in the run carried a
+		// `(N items)` / `(object)` / `(1 note)` display value — the
+		// lossy summary form that formatChangeValue emits for
+		// structured fields (handlers_documents.go::formatChangeValue).
+		//
+		// When the display value is lossy, a from==to result CAN'T be
+		// trusted as "no underlying change." Counter-example: editing
+		// implementation_notes from 1 note → 2 notes → 1 different
+		// note collapses to `(1 note) → (1 note)` with hadTransition=true,
+		// but the final note differs from the original — diffFields
+		// emitted both entries because reflect.DeepEqual saw real
+		// changes (see TestDiffFieldsSameCardinalityArrayChangeStillReported).
+		// We can't recover the raw values from the merged string, so
+		// we never drop a run that touched a lossy summary. Per Codex
+		// review round 3 [P2].
+		hasLossySummary bool
+	}
+
+	// isLossySummary detects formatChangeValue's display labels:
+	// `(N items)`, `(1 note)`, `(2 entries)`, `(object)`, etc. The
+	// shape — parenthesised, never produced for primitive values — is
+	// stable across formatChangeValue's known and fallback branches.
+	isLossySummary := func(v string) bool {
+		return len(v) >= 2 && strings.HasPrefix(v, "(") && strings.HasSuffix(v, ")")
 	}
 	parts := strings.Split(s, "; ")
 	entries := make([]entry, 0, len(parts))
@@ -200,6 +209,7 @@ func collapseChanges(s string) string {
 				entries = append(entries, entry{
 					field: field, from: from, to: "",
 					mergedCount: 1, hadTransition: from != "",
+					hasLossySummary: isLossySummary(from),
 				})
 				continue
 			}
@@ -211,6 +221,7 @@ func collapseChanges(s string) string {
 		entries = append(entries, entry{
 			field: field, from: from, to: to,
 			mergedCount: 1, hadTransition: from != to,
+			hasLossySummary: isLossySummary(from) || isLossySummary(to),
 		})
 	}
 
@@ -224,14 +235,15 @@ func collapseChanges(s string) string {
 		if len(collapsed) > 0 {
 			prev := &collapsed[len(collapsed)-1]
 			if prev.raw == "" && prev.field == e.field {
-				// Any deviation from the anchored `from` — by the
-				// incoming entry's own from→to swing OR by its `to`
-				// differing from prev.from — counts as a real
-				// transition. If neither differs, the run is a
-				// repeated same-display structured-field update;
-				// preserve those (see hadTransition comment above).
 				if e.hadTransition || e.to != prev.from {
 					prev.hadTransition = true
+				}
+				// hasLossySummary is sticky across the run: once any
+				// entry brings a lossy display value into the chain,
+				// the merged result can never be safely treated as a
+				// raw-value no-op.
+				if e.hasLossySummary {
+					prev.hasLossySummary = true
 				}
 				prev.to = e.to
 				prev.mergedCount += e.mergedCount
@@ -241,18 +253,24 @@ func collapseChanges(s string) string {
 		collapsed = append(collapsed, e)
 	}
 
-	// Drop only true net no-ops: a collapsed run (mergedCount > 1) whose
-	// from==to AND whose intermediate `to` values transitioned away from
-	// the anchor at some point — i.e. the user typed something and
-	// backspaced back to the original. Single entries are always
-	// preserved (diffFields wouldn't emit them unless reflect.DeepEqual
-	// detected a real change), and runs without hadTransition represent
-	// repeated structured-field updates whose display strings happen to
-	// match — preserve those too. Per Codex review round 1 [P2] +
-	// round 2 [P2].
+	// Drop only true net no-ops, defined as: a collapsed run
+	// (mergedCount > 1) whose from==to, whose intermediate `to` values
+	// transitioned away from the anchor at some point (hadTransition),
+	// AND whose display values are NOT lossy summaries (!hasLossySummary).
+	//
+	// Why each clause:
+	//   - mergedCount > 1: a single entry is preserved because diffFields
+	//     wouldn't emit it unless reflect.DeepEqual detected a real
+	//     change. Only collapsed runs can synthesise a fake from==to.
+	//   - hadTransition: distinguishes a real cancellation from a
+	//     repeated same-display run (Codex round 2 [P2]).
+	//   - !hasLossySummary: a `(1 note) → (2 notes) → (1 note)` run
+	//     visibly transitions and visibly returns, but the underlying
+	//     notes can be entirely different objects — the display labels
+	//     are lossy. Never drop those (Codex round 3 [P2]).
 	kept := collapsed[:0]
 	for _, e := range collapsed {
-		if e.raw == "" && e.mergedCount > 1 && e.from == e.to && e.hadTransition {
+		if e.raw == "" && e.mergedCount > 1 && e.from == e.to && e.hadTransition && !e.hasLossySummary {
 			continue
 		}
 		kept = append(kept, e)

--- a/internal/store/activities.go
+++ b/internal/store/activities.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/PerpetualSoftware/pad/internal/models"
@@ -101,9 +102,9 @@ func mergeActivityMeta(existing, incoming string) string {
 
 	if newChanges != "" {
 		if existChanges != "" {
-			existMap["changes"] = existChanges + "; " + newChanges
+			existMap["changes"] = collapseChanges(existChanges + "; " + newChanges)
 		} else {
-			existMap["changes"] = newChanges
+			existMap["changes"] = collapseChanges(newChanges)
 		}
 	}
 	// If neither had changes, don't add an empty one.
@@ -114,6 +115,124 @@ func mergeActivityMeta(existing, incoming string) string {
 		return existing
 	}
 	return string(result)
+}
+
+// collapseChanges takes a "; "-delimited list of "field: old → new" entries
+// and collapses runs of consecutive same-field entries into a single
+// "field: first-old → last-new" entry. Net no-ops (first-old == last-new
+// after collapse) are dropped entirely.
+//
+// Why: CreateActivityDebounced accumulates changes across PATCHes within
+// the 5-minute cooldown. Before BUG-1466's web-side typing debounce,
+// rapid typing in a structured text field produced 30+ chained
+// per-keystroke entries on a single activity row (visible on BUG-1419's
+// timeline). Even with the debounce in place, two edits to the same
+// field in the same window still read more naturally as one transition.
+//
+// Parsing assumptions:
+//   - Entries are joined by "; " — diffFields uses the same separator so
+//     a single split-by-"; " produces a flat list regardless of whether
+//     the changes string came from one multi-field PATCH or several.
+//   - Each entry has the shape "<field>: <from> → <to>" with " → " (U+2192,
+//     padded) as the arrow. Unparseable entries are preserved verbatim
+//     (they never match a field name, so they never collapse).
+//   - Collapse is run-based, not global: `a:1→2; b:x→y; a:2→3` stays as-is
+//     (interleaved field edits keep their chronology). Easier to reason
+//     about and more accurate as a history.
+func collapseChanges(s string) string {
+	if s == "" {
+		return ""
+	}
+	const arrow = " → "
+	type entry struct {
+		field, from, to string
+		raw             string // preserved verbatim for unparseable entries
+	}
+	parts := strings.Split(s, "; ")
+	entries := make([]entry, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		colonIdx := strings.Index(p, ":")
+		if colonIdx == -1 {
+			entries = append(entries, entry{raw: p})
+			continue
+		}
+		field := strings.TrimSpace(p[:colonIdx])
+		// NB: don't TrimSpace the value-part — diffFields formats it as
+		// " <from> → <to>" with a single leading space (the ": " format
+		// separator). Trimming that leading space breaks arrow detection
+		// when `from` is empty ("→ x" → no match for " → ").
+		valuePart := p[colonIdx+1:]
+		arrowIdx := strings.Index(valuePart, arrow)
+		if arrowIdx == -1 {
+			// Deletion-to-empty case: diffFields renders this as
+			// "<key>: <from> → " which loses its trailing space when
+			// the segment is TrimSpace'd. Catch it via suffix match.
+			if strings.HasSuffix(valuePart, " →") {
+				from := strings.TrimSpace(valuePart[:len(valuePart)-len(" →")])
+				entries = append(entries, entry{field: field, from: from, to: ""})
+				continue
+			}
+			entries = append(entries, entry{raw: p})
+			continue
+		}
+		from := strings.TrimSpace(valuePart[:arrowIdx])
+		to := strings.TrimSpace(valuePart[arrowIdx+len(arrow):])
+		entries = append(entries, entry{field: field, from: from, to: to})
+	}
+
+	// Walk consecutively, extending runs of the same field.
+	collapsed := make([]entry, 0, len(entries))
+	for _, e := range entries {
+		if e.raw != "" {
+			collapsed = append(collapsed, e)
+			continue
+		}
+		if len(collapsed) > 0 {
+			prev := &collapsed[len(collapsed)-1]
+			if prev.raw == "" && prev.field == e.field {
+				prev.to = e.to
+				continue
+			}
+		}
+		collapsed = append(collapsed, e)
+	}
+
+	// Drop net no-ops (typed "tip" then backspaced — first == last).
+	kept := collapsed[:0]
+	for _, e := range collapsed {
+		if e.raw == "" && e.from == e.to {
+			continue
+		}
+		kept = append(kept, e)
+	}
+
+	var sb strings.Builder
+	for i, e := range kept {
+		if i > 0 {
+			sb.WriteString("; ")
+		}
+		if e.raw != "" {
+			sb.WriteString(e.raw)
+			continue
+		}
+		// Match diffFields's format: `"<field>: → <to>"` when from is
+		// empty (one space between ":" and "→"), `"<field>: <from> → <to>"`
+		// otherwise. arrow already carries its own leading space.
+		sb.WriteString(e.field)
+		if e.from == "" {
+			sb.WriteString(":")
+		} else {
+			sb.WriteString(": ")
+			sb.WriteString(e.from)
+		}
+		sb.WriteString(arrow)
+		sb.WriteString(e.to)
+	}
+	return sb.String()
 }
 
 func (s *Store) ListWorkspaceActivity(workspaceID string, params models.ActivityListParams) ([]models.Activity, error) {

--- a/internal/store/activities.go
+++ b/internal/store/activities.go
@@ -147,6 +147,16 @@ func collapseChanges(s string) string {
 	type entry struct {
 		field, from, to string
 		raw             string // preserved verbatim for unparseable entries
+		// mergedCount tracks how many input segments were collapsed into
+		// this entry. Used by the net-no-op drop step to distinguish a
+		// truly canceled run ("typed tip then backspaced", merged=N>1)
+		// from a single structured-field entry that diffFields
+		// intentionally emits with equal display strings
+		// ("implementation_notes: (1 note) → (1 note)" — a same-cardinality
+		// replacement; see TestDiffFieldsSameCardinalityArrayChangeStillReported).
+		// Only collapsed runs (mergedCount > 1) are dropped. Per Codex
+		// review round 1 [P2].
+		mergedCount int
 	}
 	parts := strings.Split(s, "; ")
 	entries := make([]entry, 0, len(parts))
@@ -173,7 +183,7 @@ func collapseChanges(s string) string {
 			// the segment is TrimSpace'd. Catch it via suffix match.
 			if strings.HasSuffix(valuePart, " →") {
 				from := strings.TrimSpace(valuePart[:len(valuePart)-len(" →")])
-				entries = append(entries, entry{field: field, from: from, to: ""})
+				entries = append(entries, entry{field: field, from: from, to: "", mergedCount: 1})
 				continue
 			}
 			entries = append(entries, entry{raw: p})
@@ -181,7 +191,7 @@ func collapseChanges(s string) string {
 		}
 		from := strings.TrimSpace(valuePart[:arrowIdx])
 		to := strings.TrimSpace(valuePart[arrowIdx+len(arrow):])
-		entries = append(entries, entry{field: field, from: from, to: to})
+		entries = append(entries, entry{field: field, from: from, to: to, mergedCount: 1})
 	}
 
 	// Walk consecutively, extending runs of the same field.
@@ -195,16 +205,21 @@ func collapseChanges(s string) string {
 			prev := &collapsed[len(collapsed)-1]
 			if prev.raw == "" && prev.field == e.field {
 				prev.to = e.to
+				prev.mergedCount += e.mergedCount
 				continue
 			}
 		}
 		collapsed = append(collapsed, e)
 	}
 
-	// Drop net no-ops (typed "tip" then backspaced — first == last).
+	// Drop net no-ops only when they result from collapsing a run
+	// (mergedCount > 1). A single entry where from == to is intentional
+	// from diffFields — it's how same-cardinality structured-field
+	// replacements like `(1 note) → (1 note)` are signalled. Dropping
+	// those would silently hide real changes from the activity feed.
 	kept := collapsed[:0]
 	for _, e := range collapsed {
-		if e.raw == "" && e.from == e.to {
+		if e.raw == "" && e.mergedCount > 1 && e.from == e.to {
 			continue
 		}
 		kept = append(kept, e)

--- a/internal/store/activities.go
+++ b/internal/store/activities.go
@@ -148,15 +148,29 @@ func collapseChanges(s string) string {
 		field, from, to string
 		raw             string // preserved verbatim for unparseable entries
 		// mergedCount tracks how many input segments were collapsed into
-		// this entry. Used by the net-no-op drop step to distinguish a
-		// truly canceled run ("typed tip then backspaced", merged=N>1)
-		// from a single structured-field entry that diffFields
-		// intentionally emits with equal display strings
-		// ("implementation_notes: (1 note) → (1 note)" — a same-cardinality
-		// replacement; see TestDiffFieldsSameCardinalityArrayChangeStillReported).
-		// Only collapsed runs (mergedCount > 1) are dropped. Per Codex
-		// review round 1 [P2].
+		// this entry. mergedCount > 1 means at least one merge happened.
 		mergedCount int
+		// hadTransition is true iff any input entry in the run produced a
+		// display-string transition — i.e. either the initial entry had
+		// from != to, or a subsequent entry's `to` differed from the
+		// run's anchored `from`. Used by the drop step to distinguish:
+		//
+		//   - typed-then-backspaced (BUG-1419 / BUG-1466):
+		//     `c: → t; c: t → ti; c: ti → t; c: t → ` — intermediate
+		//     `to` values ("t", "ti") differ from anchor `from`=""
+		//     → hadTransition=true, from==to, dropped as net no-op.
+		//
+		//   - repeated same-display structured-field replacements
+		//     (Codex review round 2 [P2]):
+		//     `implementation_notes: (1 note) → (1 note); implementation_notes: (1 note) → (1 note)`
+		//     — every `to` equals the anchor `from`, so the display
+		//     trace shows no transition → hadTransition=false, preserved.
+		//     The underlying values DID change (diffFields uses
+		//     reflect.DeepEqual; see TestDiffFieldsSameCardinalityArrayChangeStillReported),
+		//     but that information is lost once formatChangeValue
+		//     summarises both as `(1 note)`. We can't recover it from
+		//     the merged string, but we mustn't pretend nothing happened.
+		hadTransition bool
 	}
 	parts := strings.Split(s, "; ")
 	entries := make([]entry, 0, len(parts))
@@ -183,7 +197,10 @@ func collapseChanges(s string) string {
 			// the segment is TrimSpace'd. Catch it via suffix match.
 			if strings.HasSuffix(valuePart, " →") {
 				from := strings.TrimSpace(valuePart[:len(valuePart)-len(" →")])
-				entries = append(entries, entry{field: field, from: from, to: "", mergedCount: 1})
+				entries = append(entries, entry{
+					field: field, from: from, to: "",
+					mergedCount: 1, hadTransition: from != "",
+				})
 				continue
 			}
 			entries = append(entries, entry{raw: p})
@@ -191,7 +208,10 @@ func collapseChanges(s string) string {
 		}
 		from := strings.TrimSpace(valuePart[:arrowIdx])
 		to := strings.TrimSpace(valuePart[arrowIdx+len(arrow):])
-		entries = append(entries, entry{field: field, from: from, to: to, mergedCount: 1})
+		entries = append(entries, entry{
+			field: field, from: from, to: to,
+			mergedCount: 1, hadTransition: from != to,
+		})
 	}
 
 	// Walk consecutively, extending runs of the same field.
@@ -204,6 +224,15 @@ func collapseChanges(s string) string {
 		if len(collapsed) > 0 {
 			prev := &collapsed[len(collapsed)-1]
 			if prev.raw == "" && prev.field == e.field {
+				// Any deviation from the anchored `from` — by the
+				// incoming entry's own from→to swing OR by its `to`
+				// differing from prev.from — counts as a real
+				// transition. If neither differs, the run is a
+				// repeated same-display structured-field update;
+				// preserve those (see hadTransition comment above).
+				if e.hadTransition || e.to != prev.from {
+					prev.hadTransition = true
+				}
 				prev.to = e.to
 				prev.mergedCount += e.mergedCount
 				continue
@@ -212,14 +241,18 @@ func collapseChanges(s string) string {
 		collapsed = append(collapsed, e)
 	}
 
-	// Drop net no-ops only when they result from collapsing a run
-	// (mergedCount > 1). A single entry where from == to is intentional
-	// from diffFields — it's how same-cardinality structured-field
-	// replacements like `(1 note) → (1 note)` are signalled. Dropping
-	// those would silently hide real changes from the activity feed.
+	// Drop only true net no-ops: a collapsed run (mergedCount > 1) whose
+	// from==to AND whose intermediate `to` values transitioned away from
+	// the anchor at some point — i.e. the user typed something and
+	// backspaced back to the original. Single entries are always
+	// preserved (diffFields wouldn't emit them unless reflect.DeepEqual
+	// detected a real change), and runs without hadTransition represent
+	// repeated structured-field updates whose display strings happen to
+	// match — preserve those too. Per Codex review round 1 [P2] +
+	// round 2 [P2].
 	kept := collapsed[:0]
 	for _, e := range collapsed {
-		if e.raw == "" && e.mergedCount > 1 && e.from == e.to {
+		if e.raw == "" && e.mergedCount > 1 && e.from == e.to && e.hadTransition {
 			continue
 		}
 		kept = append(kept, e)

--- a/internal/store/activities_test.go
+++ b/internal/store/activities_test.go
@@ -459,6 +459,29 @@ func TestCollapseChanges(t *testing.T) {
 			in:   "component: → t; implementation_notes: (1 note) → (1 note); component: t → tip",
 			want: "component: → t; implementation_notes: (1 note) → (1 note); component: t → tip",
 		},
+		{
+			name: "repeated same-display structured-field entries preserved",
+			// Codex review round 2 [P2]: two PATCHes that both swapped a
+			// single note for a different single note. Both render as
+			// `(1 note) → (1 note)` because formatChangeValue summarises
+			// by count, but the underlying notes differ each time.
+			// hadTransition stays false through the merge (every `to`
+			// equals the anchor `from`), so the from==to drop rule
+			// doesn't fire — the entry is preserved as a single
+			// "something happened twice on this field" record.
+			in:   "implementation_notes: (1 note) → (1 note); implementation_notes: (1 note) → (1 note)",
+			want: "implementation_notes: (1 note) → (1 note)",
+		},
+		{
+			name: "real swing that nets to zero IS still dropped",
+			// Regression cover for the hadTransition rule: a typed
+			// `foo → bar → foo` run still drops as a net no-op
+			// because intermediate `to=bar` differed from anchor
+			// `from=foo`. Without this, hadTransition would never
+			// flag a "true cancellation" outside the empty-start case.
+			in:   "name: foo → bar; name: bar → foo",
+			want: "",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/store/activities_test.go
+++ b/internal/store/activities_test.go
@@ -370,6 +370,105 @@ func TestCreateActivityDebounced_NoUserID(t *testing.T) {
 	}
 }
 
+func TestCollapseChanges(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "empty",
+			in:   "",
+			want: "",
+		},
+		{
+			name: "single entry unchanged",
+			in:   "status: open → fixed",
+			want: "status: open → fixed",
+		},
+		{
+			name: "different fields preserved",
+			in:   "status: open → fixed; priority: low → high",
+			want: "status: open → fixed; priority: low → high",
+		},
+		{
+			name: "consecutive same-field run collapses to first→last",
+			// The BUG-1419 reproducer: a typed-out value chained per keystroke.
+			in:   "component: → e; component: e → ed; component: ed → edi; component: edi → editor",
+			want: "component: → editor",
+		},
+		{
+			name: "net no-op (typed then backspaced) dropped",
+			// User typed "tip" then backspaced everything — no net change,
+			// no point keeping the entry at all.
+			in:   "component: → t; component: t → ti; component: ti → tip; component: tip → ti; component: ti → t; component: t → ",
+			want: "",
+		},
+		{
+			name: "interleaved fields keep chronology (no global merge)",
+			// Run-based collapse only merges *adjacent* same-field entries;
+			// non-adjacent ones stay split so the timeline preserves the
+			// real edit order.
+			in:   "component: a → b; status: open → fixed; component: b → c",
+			want: "component: a → b; status: open → fixed; component: b → c",
+		},
+		{
+			name: "leading from preserved through run",
+			in:   "component: editor → ueditor; component: ueditor → uieditor; component: uieditor → ui/editor",
+			want: "component: editor → ui/editor",
+		},
+		{
+			name: "unparseable entries preserved verbatim (no field anchor → no collapse)",
+			// Defensive: malformed entries get passed through untouched so
+			// we never silently drop a metadata segment we don't understand.
+			in:   "weird-no-arrow-here; status: open → fixed",
+			want: "weird-no-arrow-here; status: open → fixed",
+		},
+		{
+			name: "trailing/empty segments tolerated",
+			in:   "; status: open → fixed; ; ",
+			want: "status: open → fixed",
+		},
+		{
+			name: "field cleared to empty (deletion to empty value)",
+			// diffFields renders a deletion-to-empty as "<key>: <from> → "
+			// with a trailing space. After segment-level TrimSpace the
+			// trailing space is gone, so the parser falls back to the
+			// "<value> →" suffix branch to recover from="value", to="".
+			in:   "component: ui/editor → ",
+			want: "component: ui/editor → ",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := collapseChanges(tt.in); got != tt.want {
+				t.Errorf("collapseChanges:\n  in:   %q\n  got:  %q\n  want: %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// Regression for the BUG-1466 follow-up: when CreateActivityDebounced
+// merges multiple PATCHes that all hit the same field, the merged
+// `changes` string should collapse into a single first→last entry
+// instead of a 30-step keystroke chain (as seen on BUG-1419's timeline
+// pre-fix).
+func TestMergeActivityMeta_CollapsesSameFieldRun(t *testing.T) {
+	existing := `{"changes":"component: → e; component: e → ed; component: ed → edi"}`
+	incoming := `{"changes":"component: edi → editor"}`
+	got := mergeActivityMeta(existing, incoming)
+	var m map[string]interface{}
+	if err := json.Unmarshal([]byte(got), &m); err != nil {
+		t.Fatalf("failed to parse result: %v", err)
+	}
+	changes, _ := m["changes"].(string)
+	want := "component: → editor"
+	if changes != want {
+		t.Errorf("expected collapsed run, got %q (want %q)", changes, want)
+	}
+}
+
 func TestMergeActivityMeta(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/store/activities_test.go
+++ b/internal/store/activities_test.go
@@ -482,6 +482,26 @@ func TestCollapseChanges(t *testing.T) {
 			in:   "name: foo → bar; name: bar → foo",
 			want: "",
 		},
+		{
+			name: "structured count-return swing preserved (lossy summaries)",
+			// Codex review round 3 [P2]: 1 note A → 2 notes A+B → 1
+			// note B. diffFields emits both transitions; the merged
+			// shape looks like a foo→bar→foo cancellation, but the
+			// final note differs from the original. hasLossySummary
+			// blocks the drop — we can't recover the raw delta from
+			// the merged string, so we preserve the entry.
+			in:   "implementation_notes: (1 note) → (2 notes); implementation_notes: (2 notes) → (1 note)",
+			want: "implementation_notes: (1 note) → (1 note)",
+		},
+		{
+			name: "lossy summary appearing only on one side still pins the run",
+			// Defensive: even if just `to` (or just `from`) is a lossy
+			// label — e.g. clearing a field renders as "(1 note) → " —
+			// the run must be preserved if it ever returns to from==to
+			// via a structured intermediate.
+			in:   "implementation_notes: original_text → (1 note); implementation_notes: (1 note) → original_text",
+			want: "implementation_notes: original_text → original_text",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/store/activities_test.go
+++ b/internal/store/activities_test.go
@@ -438,6 +438,27 @@ func TestCollapseChanges(t *testing.T) {
 			in:   "component: ui/editor → ",
 			want: "component: ui/editor → ",
 		},
+		{
+			name: "single structured-field same-display entry preserved",
+			// Regression for Codex round 1 [P2]: diffFields emits
+			// `implementation_notes: (1 note) → (1 note)` to signal that
+			// a same-cardinality replacement occurred (e.g. one note
+			// swapped for a different note). The display strings collapse
+			// to identical labels because formatChangeValue intentionally
+			// renders array-valued fields by count, not content — but the
+			// underlying data did change. collapseChanges must NOT drop
+			// this entry; only multi-segment runs that collapse to a
+			// from==to result are true no-ops.
+			in:   "implementation_notes: (1 note) → (1 note)",
+			want: "implementation_notes: (1 note) → (1 note)",
+		},
+		{
+			name: "structured-field no-op preserved even when interleaved with a typed run",
+			// Defense in depth: a structured-field same-display entry
+			// must survive when surrounded by a typed-field collapse.
+			in:   "component: → t; implementation_notes: (1 note) → (1 note); component: t → tip",
+			want: "component: → t; implementation_notes: (1 note) → (1 note); component: t → tip",
+		},
 	}
 
 	for _, tt := range tests {

--- a/web/src/lib/components/fields/FieldEditor.svelte
+++ b/web/src/lib/components/fields/FieldEditor.svelte
@@ -195,13 +195,63 @@ handlers — onchange is never called.
 		onchange(v);
 	}
 
-	// Cleanup on unmount: a pending typed value must NOT be lost when
-	// the user navigates away mid-edit. The effect-return is Svelte 5's
-	// cleanup hook — fires on component teardown.
+	// Cleanup on unmount: drop any pending typed save. We deliberately
+	// do NOT flush here:
+	//   - When unmount fires because the parent navigated to an item
+	//     whose schema doesn't include this field key, the parent's
+	//     `item` has already been replaced. Calling onchange now would
+	//     route the save through `updateField`, which reads the CURRENT
+	//     `item` — writing field-A's typed value into item-B (Codex
+	//     review round 3 [P1]).
+	//   - The other unmount cases (route teardown, parent destroy) have
+	//     ambiguous parent state too.
+	// Blur is the supported commit gesture: tabbing out, clicking
+	// elsewhere within the page, or the ±1 buttons — all flush via the
+	// onblur handler before any teardown. Unmount-without-blur means
+	// the user navigated away aggressively; respecting that is safer
+	// than a best-effort write to a context we can't validate.
 	$effect(() => {
 		return () => {
-			flushPendingSave();
+			if (hasPending) {
+				clearTimeout(typingTimer);
+				typingTimer = undefined;
+				pendingValue = undefined;
+				hasPending = false;
+			}
 		};
+	});
+
+	// Drop pending typed value if the parent updates `value` externally
+	// while we have a pending save. The parent could re-prop this
+	// FieldEditor mid-edit for legitimate reasons:
+	//
+	//   - Navigation to a different item within the same route reuses
+	//     the component (same schema, same field.key) with a different
+	//     item's value. Without this guard the pending value would be
+	//     flushed against the parent's `updateField`, which reads the
+	//     CURRENT `item.id` — leaking item A's edit into item B
+	//     (Codex review round 3 [P1]).
+	//   - A collab peer / SSE-driven update of the same field on the
+	//     same item also rebases the prop. The user's in-flight typed
+	//     value is no longer the right answer; drop it rather than
+	//     silently overwrite the peer edit.
+	//
+	// The trade-off: a typed-but-unflushed value is lost when the user
+	// navigates within 500ms. Acceptable — they actively navigated, and
+	// blur (the usual way to leave an input) already flushes eagerly.
+	//
+	// We don't need to distinguish "our save echoing back" from
+	// "external update" because the timer callback clears `hasPending`
+	// BEFORE calling onchange, so by the time this $effect runs in
+	// response to our own save's echo, hasPending is already false.
+	$effect(() => {
+		void value; // track dependency
+		if (hasPending) {
+			clearTimeout(typingTimer);
+			typingTimer = undefined;
+			pendingValue = undefined;
+			hasPending = false;
+		}
 	});
 
 	function handleTextInput(e: Event) {

--- a/web/src/lib/components/fields/FieldEditor.svelte
+++ b/web/src/lib/components/fields/FieldEditor.svelte
@@ -170,7 +170,16 @@ handlers — onchange is never called.
 	const TYPING_DEBOUNCE_MS = 500;
 	let typingTimer: ReturnType<typeof setTimeout> | undefined;
 	let pendingValue: any = undefined;
-	let hasPending = $state(false);
+	// `hasPending` is intentionally a plain let, not $state. It's only
+	// read inside imperative handlers (scheduleSave, flushPendingSave,
+	// handleNumberStep, the value-track $effect, the unmount cleanup)
+	// — never from a template or other reactive context. Making it
+	// $state would establish a reactive dependency from the
+	// value-track $effect onto hasPending: scheduleSave would set
+	// hasPending=true, which would retrigger the $effect, which reads
+	// hasPending and clears it — cancelling every keystroke before the
+	// debounce can fire. Per Codex review round 4 [P1].
+	let hasPending = false;
 
 	function scheduleSave(next: any) {
 		pendingValue = next;

--- a/web/src/lib/components/fields/FieldEditor.svelte
+++ b/web/src/lib/components/fields/FieldEditor.svelte
@@ -217,12 +217,17 @@ handlers — onchange is never called.
 	}
 
 	function handleNumberStep(delta: number) {
-		// ±1 buttons are a discrete action — flush any in-flight typed
-		// value first so it doesn't get clobbered, then fire the step
-		// immediately so the user sees the increment without waiting
-		// on the typing-idle window.
-		flushPendingSave();
-		onchange((Number(value) || 0) + delta);
+		// ±1 buttons are a discrete action that supersedes any in-flight
+		// typed value. Compute the new value from the pending typed value
+		// (if any) BEFORE clearing the timer — `value` is the parent
+		// prop and would lag a freshly-typed pending number until the
+		// flush round-trips back. Per Codex review round 1 [P1].
+		const base = hasPending ? Number(pendingValue) || 0 : Number(value) || 0;
+		clearTimeout(typingTimer);
+		typingTimer = undefined;
+		pendingValue = undefined;
+		hasPending = false;
+		onchange(base + delta);
 	}
 
 	function handleDateInput(e: Event) {

--- a/web/src/lib/components/fields/FieldEditor.svelte
+++ b/web/src/lib/components/fields/FieldEditor.svelte
@@ -148,17 +148,81 @@ handlers — onchange is never called.
 	}
 
 	// ── Input handlers ─────────────────────────────────────────────────────
+	//
+	// Typed inputs (text / number / url) debounce the parent's `onchange`
+	// so each keystroke isn't persisted as a separate item update — that
+	// produced 30-step keystroke chains in the audit log when a user
+	// typed `ui/editor/tiptap` into a `component` field (BUG-1466).
+	//
+	// Discrete inputs (select / date / checkbox / number ±1 buttons) keep
+	// firing immediately — they're single user actions, not typing.
+	//
+	// On blur we flush any pending save eagerly so tabbing out of the
+	// field commits right away instead of waiting out the idle window;
+	// likewise on unmount, so navigating away never drops a typed value.
+	//
+	// Mirrors the markdown content debounce pattern in
+	// routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+	// (`contentDebounceTimer`, 1.2s for content); we use 500ms here
+	// because fields are small and users expect quicker confirmation
+	// than the body editor.
+
+	const TYPING_DEBOUNCE_MS = 500;
+	let typingTimer: ReturnType<typeof setTimeout> | undefined;
+	let pendingValue: any = undefined;
+	let hasPending = $state(false);
+
+	function scheduleSave(next: any) {
+		pendingValue = next;
+		hasPending = true;
+		clearTimeout(typingTimer);
+		typingTimer = setTimeout(() => {
+			typingTimer = undefined;
+			const v = pendingValue;
+			pendingValue = undefined;
+			hasPending = false;
+			onchange(v);
+		}, TYPING_DEBOUNCE_MS);
+	}
+
+	function flushPendingSave() {
+		if (!hasPending) return;
+		clearTimeout(typingTimer);
+		typingTimer = undefined;
+		const v = pendingValue;
+		pendingValue = undefined;
+		hasPending = false;
+		onchange(v);
+	}
+
+	// Cleanup on unmount: a pending typed value must NOT be lost when
+	// the user navigates away mid-edit. The effect-return is Svelte 5's
+	// cleanup hook — fires on component teardown.
+	$effect(() => {
+		return () => {
+			flushPendingSave();
+		};
+	});
 
 	function handleTextInput(e: Event) {
 		const target = e.target as HTMLInputElement;
-		onchange(target.value);
+		scheduleSave(target.value);
 	}
 
 	function handleNumberInput(e: Event) {
 		const target = e.target as HTMLInputElement;
-		if (target.value === '') { onchange(null); return; }
+		if (target.value === '') { scheduleSave(null); return; }
 		const num = Number(target.value);
-		if (!isNaN(num)) onchange(num);
+		if (!isNaN(num)) scheduleSave(num);
+	}
+
+	function handleNumberStep(delta: number) {
+		// ±1 buttons are a discrete action — flush any in-flight typed
+		// value first so it doesn't get clobbered, then fire the step
+		// immediately so the user sees the increment without waiting
+		// on the typing-idle window.
+		flushPendingSave();
+		onchange((Number(value) || 0) + delta);
 	}
 
 	function handleDateInput(e: Event) {
@@ -362,7 +426,7 @@ handlers — onchange is never called.
 			type="button"
 			tabindex={-1}
 			aria-label="Decrease"
-			onclick={() => onchange((Number(value) || 0) - 1)}
+			onclick={() => handleNumberStep(-1)}
 		>
 			<svg width="10" height="10" viewBox="0 0 10 10" fill="none" aria-hidden="true">
 				<line x1="2" y1="5" x2="8" y2="5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" />
@@ -374,6 +438,7 @@ handlers — onchange is never called.
 			inputmode="numeric"
 			value={value ?? ''}
 			oninput={handleNumberInput}
+			onblur={flushPendingSave}
 			placeholder="—"
 		/>
 		{#if field.suffix}
@@ -384,7 +449,7 @@ handlers — onchange is never called.
 			type="button"
 			tabindex={-1}
 			aria-label="Increase"
-			onclick={() => onchange((Number(value) || 0) + 1)}
+			onclick={() => handleNumberStep(1)}
 		>
 			<svg width="10" height="10" viewBox="0 0 10 10" fill="none" aria-hidden="true">
 				<line x1="2" y1="5" x2="8" y2="5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" />
@@ -401,6 +466,7 @@ handlers — onchange is never called.
 			type="url"
 			value={value ?? ''}
 			oninput={handleTextInput}
+			onblur={flushPendingSave}
 			placeholder="https://..."
 		/>
 		{#if value}
@@ -436,6 +502,7 @@ handlers — onchange is never called.
 		type="text"
 		value={value ?? ''}
 		oninput={handleTextInput}
+		onblur={flushPendingSave}
 	/>
 {/if}
 

--- a/web/src/lib/components/fields/FieldEditor.svelte
+++ b/web/src/lib/components/fields/FieldEditor.svelte
@@ -424,13 +424,20 @@ handlers — onchange is never called.
 	</div>
 
 {:else if field.type === 'number'}
-	<!-- Custom number input with +/- buttons -->
+	<!-- Custom number input with +/- buttons.
+	     onmousedown={preventDefault} on the buttons keeps the input
+	     focused across the click — without this, the natural focus
+	     transfer fires the input's onblur (→ flushPendingSave clears
+	     hasPending) BEFORE the button's onclick runs, so
+	     handleNumberStep would read stale `value` from the parent prop.
+	     Per Codex review round 2 [P1]. -->
 	<div class="number-wrapper">
 		<button
 			class="number-btn"
 			type="button"
 			tabindex={-1}
 			aria-label="Decrease"
+			onmousedown={(e) => e.preventDefault()}
 			onclick={() => handleNumberStep(-1)}
 		>
 			<svg width="10" height="10" viewBox="0 0 10 10" fill="none" aria-hidden="true">
@@ -454,6 +461,7 @@ handlers — onchange is never called.
 			type="button"
 			tabindex={-1}
 			aria-label="Increase"
+			onmousedown={(e) => e.preventDefault()}
 			onclick={() => handleNumberStep(1)}
 		>
 			<svg width="10" height="10" viewBox="0 0 10 10" fill="none" aria-hidden="true">


### PR DESCRIPTION
## Summary

Two-layer fix for **BUG-1466** — typing into a structured `text` field (`component`, etc.) on an item's detail page persisted every keystroke as a separate item update. Visible on [BUG-1419](https://github.com/PerpetualSoftware/pad/issues)'s timeline, where typing `ui/editor/tiptap` produced a 30-step chain in the audit metadata:

```
component: → e; component: e → ed; component: ed → edi; ... → ui/editor/tiptap
```

- **Client (`FieldEditor.svelte`)** — debounce typed inputs at 500ms idle, flush on blur, drop pending on external prop change / unmount, mirror the existing markdown content debounce pattern. Discrete inputs (select / date / checkbox, number ±1 buttons) stay immediate.
- **Server (`internal/store/activities.go`)** — collapse same-field runs in merged activity `changes` metadata (`field: first-old → last-new`), drop true net no-ops (typed-then-backspaced), preserve structured-field entries (`(1 note) → (1 note)` is real because `formatChangeValue` is lossy). Also unifies `diffFields`'s joiner from `, ` to `; ` so the web timeline parser renders multi-field PATCHes as individual change pills instead of one unparseable blob.

## Codex review loop

Drove findings to zero across 5 rounds (4 commits of follow-ups), summarised in the commit log:
- Round 1: handleNumberStep stale value; collapseChanges dropped single structured entries.
- Round 2: ±1 button blur/click focus race; repeated same-display structured runs still dropped.
- Round 3: cross-item leak via debounce timer on item-swap; `(1→2→1)` structured count-return swing still dropped.
- Round 4: `$effect` reactively cancelling its own pending state — broke typing entirely.
- Round 5: CLEAN.

## Test plan

- [x] `go test ./...` green (16 new `TestCollapseChanges` cases + `TestMergeActivityMeta_CollapsesSameFieldRun`; existing `TestDiffFieldsPrimitives` updated for new separator).
- [x] `make install` clean; web bundle compiles; svelte-autofixer reports no issues.
- [x] `npm --prefix web run check` passes with only pre-existing warnings.
- [ ] Manual: type a long value into a structured text field on an item detail page; verify the timeline shows ONE activity row with ONE `field: → final-value` change instead of a per-keystroke chain.
- [ ] Manual: with two structured-field PATCHes in the same 5-min window, verify the timeline shows individual change pills (no unparseable blob).
- [ ] Manual: type into a number field, click +/- — verify the typed value isn't lost to the focus-transfer race.
- [ ] Manual: type into a field, navigate to another item within 500ms — verify nothing leaks into the destination item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)