### PR TITLE
fix(editor): match slash menu against id + keywords (BUG-1419)

### DIFF
--- a/web/src/lib/components/editor/Editor.svelte
+++ b/web/src/lib/components/editor/Editor.svelte
@@ -425,7 +425,12 @@
 	function getFilteredSlash() {
 		if (!slashQuery) return SLASH_ITEMS;
 		const q = slashQuery.toLowerCase();
-		return SLASH_ITEMS.filter(i => i.label.toLowerCase().includes(q) || i.description.toLowerCase().includes(q));
+		return SLASH_ITEMS.filter((i) => {
+			const hay = [i.label, i.description, i.id, ...(i.keywords ?? [])]
+				.join(' ')
+				.toLowerCase();
+			return hay.includes(q);
+		});
 	}
 
 	function execSlash(id: string) {

--- a/web/src/lib/components/editor/block-types.ts
+++ b/web/src/lib/components/editor/block-types.ts
@@ -8,6 +8,13 @@ export interface BlockType {
 	icon: string;
 	label: string;
 	description: string;
+	/**
+	 * Search aliases for the slash-command menu. The filter matches the query
+	 * against the label, description, id, and each keyword. Use this for
+	 * common abbreviations the label/description wouldn't otherwise cover
+	 * (e.g. `h2` for "Heading 2", `hr` for "Divider", `todo` for "Checklist").
+	 */
+	keywords?: string[];
 	/** Only available via slash command (insert), not turn-into (convert) */
 	insertOnly?: boolean;
 	/** Only available via turn-into (convert), not slash command (insert) */
@@ -16,17 +23,17 @@ export interface BlockType {
 
 export const BLOCK_TYPES: BlockType[] = [
 	{ id: 'paragraph', icon: 'Aa', label: 'Text', description: 'Plain text', convertOnly: true },
-	{ id: 'heading1', icon: 'H1', label: 'Heading 1', description: 'Large heading' },
-	{ id: 'heading2', icon: 'H2', label: 'Heading 2', description: 'Medium heading' },
-	{ id: 'heading3', icon: 'H3', label: 'Heading 3', description: 'Small heading' },
-	{ id: 'bulletList', icon: '•', label: 'Bullet List', description: 'Unordered list' },
-	{ id: 'orderedList', icon: '1.', label: 'Numbered List', description: 'Ordered list' },
-	{ id: 'taskList', icon: '☐', label: 'Checklist', description: 'Task list' },
-	{ id: 'codeBlock', icon: '<>', label: 'Code Block', description: 'Fenced code block' },
-	{ id: 'htmlBlock', icon: 'HTML', label: 'HTML Block', description: 'Sanitized HTML embed (live preview)', insertOnly: true },
-	{ id: 'blockquote', icon: '❝', label: 'Blockquote', description: 'Quote block' },
-	{ id: 'horizontalRule', icon: '——', label: 'Divider', description: 'Horizontal rule', insertOnly: true },
-	{ id: 'table', icon: '⊞', label: 'Table', description: '3×3 table', insertOnly: true },
+	{ id: 'heading1', icon: 'H1', label: 'Heading 1', description: 'Large heading', keywords: ['h1'] },
+	{ id: 'heading2', icon: 'H2', label: 'Heading 2', description: 'Medium heading', keywords: ['h2'] },
+	{ id: 'heading3', icon: 'H3', label: 'Heading 3', description: 'Small heading', keywords: ['h3'] },
+	{ id: 'bulletList', icon: '•', label: 'Bullet List', description: 'Unordered list', keywords: ['ul', 'bullets', 'unordered'] },
+	{ id: 'orderedList', icon: '1.', label: 'Numbered List', description: 'Ordered list', keywords: ['ol', 'numbered', 'ordered'] },
+	{ id: 'taskList', icon: '☐', label: 'Checklist', description: 'Task list', keywords: ['todo', 'task', 'checkbox', 'check'] },
+	{ id: 'codeBlock', icon: '<>', label: 'Code Block', description: 'Fenced code block', keywords: ['code', 'pre'] },
+	{ id: 'htmlBlock', icon: 'HTML', label: 'HTML Block', description: 'Sanitized HTML embed (live preview)', insertOnly: true, keywords: ['html', 'embed'] },
+	{ id: 'blockquote', icon: '❝', label: 'Blockquote', description: 'Quote block', keywords: ['quote', 'bq'] },
+	{ id: 'horizontalRule', icon: '——', label: 'Divider', description: 'Horizontal rule', insertOnly: true, keywords: ['hr', 'rule', 'separator'] },
+	{ id: 'table', icon: '⊞', label: 'Table', description: '3×3 table', insertOnly: true, keywords: ['tbl', 'grid'] },
 ];
 
 /** Block types available in the slash command menu (excludes convert-only types like "Text") */


### PR DESCRIPTION
## Summary

Fixes BUG-1419 — slash-menu abbreviations like `/h2`, `/ul`, `/hr`, `/todo` no longer auto-close the picker.

- Add optional `keywords?: string[]` to `BlockType` (`web/src/lib/components/editor/block-types.ts`) and populate common abbreviations per block.
- Extend `getFilteredSlash()` in `Editor.svelte` to join `label + description + id + keywords` into a single lowercased haystack and substring-match the query against it.

## Why it was broken

The previous filter matched only `label` + `description`. `"heading 2".includes("h2")` is `false` (the space breaks the substring), and the editor auto-closes the menu when the filter returns zero results — so typing `/h2` made the picker pop and immediately disappear.

## Scope

Pure UI filter change. Y.Doc / ProseMirror persisted shape is unchanged, so no `SCHEMA_VERSION` bump. The "Turn into" context menu (`block-drag-handle.ts`) iterates `TURN_INTO_ITEMS` directly with no filter, so it needs no changes.

## Aliases added

| Block | Keywords |
|---|---|
| Heading 1/2/3 | `h1`, `h2`, `h3` |
| Bullet List | `ul`, `bullets`, `unordered` |
| Numbered List | `ol`, `numbered`, `ordered` |
| Checklist | `todo`, `task`, `checkbox`, `check` |
| Code Block | `code`, `pre` |
| HTML Block | `html`, `embed` |
| Blockquote | `quote`, `bq` |
| Divider | `hr`, `rule`, `separator` |
| Table | `tbl`, `grid` |

## Test plan

- [x] `make install` — web build + Go build green
- [x] `cd web && npm run check` (svelte-check) — 0 errors
- [x] `go test ./...` — all packages pass
- [x] `make lint` (golangci-lint) — 0 issues
- [x] Manual verification in the dev server — typing each alias filters to the expected block and inserts it on Enter; `/asdf` still closes the menu on zero matches.

> **Note on `npm audit`:** `make check` fails on the pre-existing devalue / mermaid / svelte upstream advisories already tracked in **BUG-1465** (`status=fixing`). Unrelated to this change; same situation that landed BUG-1430/1431/1432.