### PR TITLE
feat(urlimport): URL fetcher with SSRF guard + content-type detection (TASK-1469)

### DIFF
--- a/internal/urlimport/detect.go
+++ b/internal/urlimport/detect.go
@@ -1,7 +1,9 @@
 package urlimport
 
 import (
+	"bytes"
 	"encoding/json"
+	"io"
 	"strings"
 )
 
@@ -92,34 +94,97 @@ func looksLikeJSON(body []byte) bool {
 	return false
 }
 
-// isOpenAPIJSON returns true when the body parses as a JSON object that
+// isOpenAPIJSON returns true when the body is a JSON object that
 // declares a top-level `openapi` (3.x) or `swagger` (2.0) key. Other
 // shapes (arrays, primitives) and parse errors return false.
+//
+// Bodies smaller than the sniff cap are fully unmarshalled — fast and
+// definitive. Larger bodies (real OpenAPI specs routinely exceed 64
+// KiB) are streamed through json.Decoder, scanning only top-level
+// keys; if either `openapi` or `swagger` appears we return true
+// without parsing the full document. Skipping descendant values keeps
+// memory bounded even for huge specs.
 func isOpenAPIJSON(body []byte) bool {
-	head := body
-	const cap = 64 * 1024
-	if len(head) > cap {
-		head = head[:cap]
-	}
-	// Try as object first.
-	var top map[string]json.RawMessage
-	if err := json.Unmarshal(head, &top); err == nil {
+	const sniffCap = 64 * 1024
+	if len(body) < sniffCap {
+		var top map[string]json.RawMessage
+		if err := json.Unmarshal(body, &top); err != nil {
+			return false
+		}
 		if _, ok := top["openapi"]; ok {
 			return true
 		}
-		if _, ok := top["swagger"]; ok {
-			return true
-		}
+		_, ok := top["swagger"]
+		return ok
+	}
+	return scanTopLevelJSONKey(body, "openapi") || scanTopLevelJSONKey(body, "swagger")
+}
+
+// scanTopLevelJSONKey returns true if `key` appears as a top-level key
+// in the JSON object encoded in body. It uses json.Decoder so it can
+// terminate early once the key is seen and works on streams that are
+// orders of magnitude larger than the sniff cap. Truncated input
+// returns false.
+func scanTopLevelJSONKey(body []byte, key string) bool {
+	dec := json.NewDecoder(bytes.NewReader(body))
+	tok, err := dec.Token()
+	if err != nil {
 		return false
 	}
-	// If parse failed because the body was truncated mid-object (likely
-	// when len(body) == cap), the json error is unhelpful — fall back to
-	// a YAML-style scan since the keys appear near the top of any
-	// well-formed spec.
-	if len(body) >= cap {
-		return isOpenAPIYAML(head)
+	d, ok := tok.(json.Delim)
+	if !ok || d != '{' {
+		return false
+	}
+	for dec.More() {
+		tok, err := dec.Token()
+		if err != nil {
+			return false
+		}
+		name, ok := tok.(string)
+		if !ok {
+			return false
+		}
+		if name == key {
+			return true
+		}
+		if err := skipJSONValue(dec); err != nil {
+			return false
+		}
 	}
 	return false
+}
+
+// skipJSONValue advances dec past one complete JSON value (object,
+// array, or scalar). Used by scanTopLevelJSONKey to land on the next
+// object key without materializing the intervening value.
+func skipJSONValue(dec *json.Decoder) error {
+	tok, err := dec.Token()
+	if err != nil {
+		return err
+	}
+	d, isDelim := tok.(json.Delim)
+	if !isDelim {
+		return nil // scalar — already consumed.
+	}
+	if d != '{' && d != '[' {
+		return io.ErrUnexpectedEOF
+	}
+	depth := 1
+	for depth > 0 {
+		tok, err := dec.Token()
+		if err != nil {
+			return err
+		}
+		if dd, ok := tok.(json.Delim); ok {
+			switch dd {
+			case '{', '[':
+				depth++
+			case '}', ']':
+				depth--
+			}
+		}
+	}
+	return nil
 }
 
 // isOpenAPIYAML returns true when one of the first ~8 KiB of unindented

--- a/internal/urlimport/detect.go
+++ b/internal/urlimport/detect.go
@@ -1,0 +1,153 @@
+package urlimport
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// DetectedType is the inferred document type returned by Detect. The
+// values match the JSON `detected_type` field returned from the import
+// endpoint.
+type DetectedType string
+
+const (
+	// TypeOpenAPI signals an OpenAPI 3.x or Swagger 2.0 specification —
+	// JSON or YAML.
+	TypeOpenAPI DetectedType = "openapi"
+	// TypeGeneric is the catch-all: HTML, plain text, anything non-spec.
+	// Handled by the Readability/HTML→Markdown converter.
+	TypeGeneric DetectedType = "generic"
+)
+
+// Detect classifies a fetched document by inspecting its Content-Type
+// header and the leading bytes of its body. It returns TypeOpenAPI when
+// the document is a parseable OpenAPI 3.x or Swagger 2.0 spec (JSON or
+// YAML), otherwise TypeGeneric. The function never inspects more than
+// the first ~64 KiB.
+//
+// Per PLAN-1467's converter table the only two converters that ship in
+// v1 are "openapi" and "generic"; anything we can't positively identify
+// as an OpenAPI spec falls back to generic on purpose.
+func Detect(contentType string, body []byte) DetectedType {
+	ct := canonicalMediaType(contentType)
+
+	switch ct {
+	// HTML always goes to generic — no need to JSON-sniff.
+	case "text/html", "application/xhtml+xml":
+		return TypeGeneric
+	}
+
+	// Explicit OpenAPI media types (rarely served, but check first).
+	if ct == "application/vnd.oai.openapi+json" || ct == "application/vnd.oai.openapi" {
+		return TypeOpenAPI
+	}
+	if ct == "application/vnd.oai.openapi+yaml" || ct == "application/x-yaml" || ct == "text/yaml" || ct == "application/yaml" {
+		if isOpenAPIYAML(body) {
+			return TypeOpenAPI
+		}
+	}
+
+	// JSON path — sniff for top-level `openapi` / `swagger` keys.
+	if ct == "application/json" || strings.HasSuffix(ct, "+json") || looksLikeJSON(body) {
+		if isOpenAPIJSON(body) {
+			return TypeOpenAPI
+		}
+	}
+
+	// YAML path — for content-type-less or text/plain responses (common
+	// when serving `openapi.yaml` from a static host) sniff the body.
+	if isOpenAPIYAML(body) {
+		return TypeOpenAPI
+	}
+
+	return TypeGeneric
+}
+
+// canonicalMediaType returns the lower-cased media type stripped of
+// parameters (charset, boundary, etc.).
+func canonicalMediaType(contentType string) string {
+	if contentType == "" {
+		return ""
+	}
+	mt := contentType
+	if i := strings.Index(mt, ";"); i >= 0 {
+		mt = mt[:i]
+	}
+	return strings.ToLower(strings.TrimSpace(mt))
+}
+
+// looksLikeJSON returns true when the body's first non-whitespace byte
+// is `{` or `[`.
+func looksLikeJSON(body []byte) bool {
+	for _, b := range body {
+		switch b {
+		case ' ', '\t', '\r', '\n':
+			continue
+		case '{', '[':
+			return true
+		default:
+			return false
+		}
+	}
+	return false
+}
+
+// isOpenAPIJSON returns true when the body parses as a JSON object that
+// declares a top-level `openapi` (3.x) or `swagger` (2.0) key. Other
+// shapes (arrays, primitives) and parse errors return false.
+func isOpenAPIJSON(body []byte) bool {
+	head := body
+	const cap = 64 * 1024
+	if len(head) > cap {
+		head = head[:cap]
+	}
+	// Try as object first.
+	var top map[string]json.RawMessage
+	if err := json.Unmarshal(head, &top); err == nil {
+		if _, ok := top["openapi"]; ok {
+			return true
+		}
+		if _, ok := top["swagger"]; ok {
+			return true
+		}
+		return false
+	}
+	// If parse failed because the body was truncated mid-object (likely
+	// when len(body) == cap), the json error is unhelpful — fall back to
+	// a YAML-style scan since the keys appear near the top of any
+	// well-formed spec.
+	if len(body) >= cap {
+		return isOpenAPIYAML(head)
+	}
+	return false
+}
+
+// isOpenAPIYAML returns true when one of the first ~8 KiB of unindented
+// (top-level) lines starts with `openapi:` or `swagger:`. We don't pull
+// in a YAML parser because (a) this is a sniff, not a validate, and (b)
+// a partial fetch can produce mid-document garbage that confuses a real
+// parser but doesn't confuse a one-line prefix check.
+func isOpenAPIYAML(body []byte) bool {
+	const cap = 8 * 1024
+	head := body
+	if len(head) > cap {
+		head = head[:cap]
+	}
+	for _, line := range strings.Split(string(head), "\n") {
+		// Top-level keys are not indented; skip indented lines so a
+		// nested `openapi:` value (unlikely but possible) doesn't false-
+		// positive.
+		if len(line) > 0 && (line[0] == ' ' || line[0] == '\t') {
+			continue
+		}
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		lower := strings.ToLower(trimmed)
+		if strings.HasPrefix(lower, "openapi:") || strings.HasPrefix(lower, "swagger:") {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/urlimport/detect_test.go
+++ b/internal/urlimport/detect_test.go
@@ -1,6 +1,9 @@
 package urlimport
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestDetect(t *testing.T) {
 	tests := []struct {
@@ -145,6 +148,69 @@ func TestDetect(t *testing.T) {
 				t.Fatalf("Detect(%q, %q) = %q, want %q", tc.contentType, tc.body, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestDetect_LargeOpenAPIJSON(t *testing.T) {
+	// Real-world OpenAPI specs frequently exceed 64 KiB. The streaming
+	// scanner must find the top-level `openapi` key even when the full
+	// document can't be parsed in memory at sniff time.
+	var b strings.Builder
+	b.WriteString(`{"openapi":"3.0.0","info":{"title":"big","version":"1"},"paths":{`)
+	// Pad with many endpoints so the body is well over 64 KiB.
+	for i := 0; i < 2000; i++ {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		// ~120 bytes per path entry → ~240 KiB total
+		b.WriteString(`"/path/`)
+		b.WriteString(strings.Repeat("a", 10))
+		b.WriteString(`":{"get":{"summary":"`)
+		b.WriteString(strings.Repeat("x", 60))
+		b.WriteString(`","responses":{"200":{"description":"ok"}}}}`)
+	}
+	b.WriteString("}}")
+	body := []byte(b.String())
+	if len(body) < 64*1024 {
+		t.Fatalf("test setup: body is %d bytes, want > 64 KiB", len(body))
+	}
+	if got := Detect("application/json", body); got != TypeOpenAPI {
+		t.Fatalf("Detect = %q, want %q for large OpenAPI JSON (%d bytes)", got, TypeOpenAPI, len(body))
+	}
+}
+
+func TestDetect_LargeOpenAPIJSON_KeyNotFirst(t *testing.T) {
+	// Same large body, but `openapi` is NOT the first top-level key —
+	// proves the streaming scan walks past other keys to find it.
+	var b strings.Builder
+	b.WriteString(`{"info":{"title":"big","version":"1","description":"`)
+	b.WriteString(strings.Repeat("x", 64*1024+10000))
+	b.WriteString(`"},"openapi":"3.0.0","paths":{}}`)
+	body := []byte(b.String())
+	if len(body) < 64*1024 {
+		t.Fatalf("test setup: body is %d bytes, want > 64 KiB", len(body))
+	}
+	if got := Detect("application/json", body); got != TypeOpenAPI {
+		t.Fatalf("Detect = %q, want %q (openapi key after a huge info block)", got, TypeOpenAPI)
+	}
+}
+
+func TestDetect_LargeJSONNotOpenAPI(t *testing.T) {
+	// A huge JSON document that is not an OpenAPI spec must stay generic.
+	var b strings.Builder
+	b.WriteString(`{"name":"big","items":[`)
+	for i := 0; i < 5000; i++ {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		b.WriteString(`{"id":`)
+		b.WriteString(strings.Repeat("9", 20))
+		b.WriteString(`,"value":"x"}`)
+	}
+	b.WriteString(`]}`)
+	body := []byte(b.String())
+	if got := Detect("application/json", body); got != TypeGeneric {
+		t.Fatalf("Detect = %q, want %q for large non-OpenAPI JSON", got, TypeGeneric)
 	}
 }
 

--- a/internal/urlimport/detect_test.go
+++ b/internal/urlimport/detect_test.go
@@ -1,0 +1,166 @@
+package urlimport
+
+import "testing"
+
+func TestDetect(t *testing.T) {
+	tests := []struct {
+		name        string
+		contentType string
+		body        string
+		want        DetectedType
+	}{
+		// HTML — always generic
+		{
+			name:        "html",
+			contentType: "text/html; charset=utf-8",
+			body:        "<html><body>hello</body></html>",
+			want:        TypeGeneric,
+		},
+		{
+			name:        "xhtml",
+			contentType: "application/xhtml+xml",
+			body:        `<?xml version="1.0"?><html xmlns="http://www.w3.org/1999/xhtml"><body>hi</body></html>`,
+			want:        TypeGeneric,
+		},
+		{
+			name:        "html with body that mentions openapi",
+			contentType: "text/html",
+			body:        `<html><body>API: openapi: 3.0.0</body></html>`,
+			want:        TypeGeneric,
+		},
+
+		// OpenAPI JSON
+		{
+			name:        "openapi 3.x json with header",
+			contentType: "application/json",
+			body:        `{"openapi":"3.0.0","info":{"title":"x","version":"1"},"paths":{}}`,
+			want:        TypeOpenAPI,
+		},
+		{
+			name:        "swagger 2.0 json with header",
+			contentType: "application/json",
+			body:        `{"swagger":"2.0","info":{"title":"x","version":"1"},"paths":{}}`,
+			want:        TypeOpenAPI,
+		},
+		{
+			name:        "openapi vendor media type",
+			contentType: "application/vnd.oai.openapi+json",
+			body:        `{}`,
+			want:        TypeOpenAPI,
+		},
+		{
+			name:        "openapi json with no content-type (sniffed)",
+			contentType: "",
+			body:        "  \n{\"openapi\":\"3.0.0\",\"info\":{}}",
+			want:        TypeOpenAPI,
+		},
+		{
+			name:        "openapi json with text/plain content-type (sniffed)",
+			contentType: "text/plain",
+			body:        `{"openapi":"3.0.0"}`,
+			want:        TypeOpenAPI,
+		},
+		{
+			name:        "json that isn't openapi",
+			contentType: "application/json",
+			body:        `{"foo":"bar","data":[1,2,3]}`,
+			want:        TypeGeneric,
+		},
+		{
+			name:        "json array (not an object)",
+			contentType: "application/json",
+			body:        `[{"openapi":"3.0.0"}]`,
+			want:        TypeGeneric,
+		},
+		{
+			name:        "json+ld passes through to sniff",
+			contentType: "application/ld+json",
+			body:        `{"@context":"http://schema.org"}`,
+			want:        TypeGeneric,
+		},
+
+		// OpenAPI YAML
+		{
+			name:        "openapi 3.x yaml",
+			contentType: "application/yaml",
+			body:        "openapi: 3.0.0\ninfo:\n  title: Pet Store\n  version: 1.0.0\npaths: {}\n",
+			want:        TypeOpenAPI,
+		},
+		{
+			name:        "swagger 2.0 yaml",
+			contentType: "text/yaml",
+			body:        "swagger: \"2.0\"\ninfo:\n  title: x\n  version: 1\n",
+			want:        TypeOpenAPI,
+		},
+		{
+			name:        "openapi yaml with leading comments",
+			contentType: "application/x-yaml",
+			body:        "# Comment\n# Another\nopenapi: 3.0.0\n",
+			want:        TypeOpenAPI,
+		},
+		{
+			name:        "yaml that isn't openapi",
+			contentType: "application/yaml",
+			body:        "foo: bar\nbaz: qux\n",
+			want:        TypeGeneric,
+		},
+		{
+			name:        "openapi yaml sniffed from text/plain",
+			contentType: "text/plain",
+			body:        "openapi: 3.0.0\n",
+			want:        TypeOpenAPI,
+		},
+		{
+			name:        "indented openapi key does not match",
+			contentType: "application/yaml",
+			body:        "components:\n  openapi: 3.0.0\n",
+			want:        TypeGeneric,
+		},
+
+		// Edge cases
+		{
+			name:        "empty body",
+			contentType: "",
+			body:        "",
+			want:        TypeGeneric,
+		},
+		{
+			name:        "whitespace-only body",
+			contentType: "",
+			body:        "   \n\t  ",
+			want:        TypeGeneric,
+		},
+		{
+			name:        "content-type with charset param",
+			contentType: "application/json; charset=utf-8",
+			body:        `{"openapi":"3.0.0"}`,
+			want:        TypeOpenAPI,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Detect(tc.contentType, []byte(tc.body))
+			if got != tc.want {
+				t.Fatalf("Detect(%q, %q) = %q, want %q", tc.contentType, tc.body, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCanonicalMediaType(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"text/html", "text/html"},
+		{"text/html; charset=utf-8", "text/html"},
+		{"TEXT/HTML", "text/html"},
+		{"  application/json ", "application/json"},
+		{"", ""},
+	}
+	for _, tc := range tests {
+		if got := canonicalMediaType(tc.in); got != tc.want {
+			t.Errorf("canonicalMediaType(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/internal/urlimport/fetch.go
+++ b/internal/urlimport/fetch.go
@@ -1,0 +1,261 @@
+// Package urlimport fetches remote URLs and converts the response into
+// markdown that can be inserted into a Pad item. The package is the
+// server-side primitive behind the editor's "Insert from URL" toolbar.
+//
+// Fetcher applies a strict SSRF guard, a per-request timeout, and a
+// response-size cap so a malicious or large upstream cannot abuse the
+// in-process HTTP client. The default policy blocks loopback, RFC1918,
+// CGNAT, IPv4 link-local (including 169.254.169.254 cloud-metadata),
+// IPv6 unique local, IPv6 link-local, and the unspecified address.
+//
+// See PLAN-1467 ("Insert from URL — HTML→Markdown utility in the item
+// editor") for the design discussion.
+package urlimport
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// DefaultTimeout caps how long Fetch waits for a single upstream request.
+const DefaultTimeout = 10 * time.Second
+
+// DefaultMaxBytes caps how many response bytes Fetch reads before
+// aborting. 5 MB is a generous ceiling for HTML docs and OpenAPI specs
+// without letting a 200 MB PDF or zip-bomb through.
+const DefaultMaxBytes int64 = 5 * 1024 * 1024
+
+// DefaultMaxRedirects is the redirect-chain limit applied by Fetch. Every
+// hop in the chain is re-validated against the SSRF guard so the initial
+// check cannot be bypassed via a 302 to an internal host.
+const DefaultMaxRedirects = 5
+
+// DefaultUserAgent is the User-Agent header sent with each fetch. Some
+// hosts (Cloudflare, GitHub) serve different content to "default" Go
+// clients vs. branded agents, so we identify as Pad.
+const DefaultUserAgent = "Pad-URLImport/1.0 (+https://getpad.dev)"
+
+// FetchResult is the outcome of a successful Fetch.
+type FetchResult struct {
+	// URL is the final resolved URL after any redirects.
+	URL string
+	// StatusCode is the HTTP status from the upstream.
+	StatusCode int
+	// ContentType is the raw Content-Type header value (with parameters).
+	ContentType string
+	// Body is the response body, capped to MaxBytes.
+	Body []byte
+}
+
+// Fetcher performs SSRF-guarded HTTP GETs.
+//
+// The zero value is not usable — call NewFetcher. Fields are exported
+// only to allow tests to flip AllowLocal; production code should treat
+// the struct as opaque.
+type Fetcher struct {
+	// Transport is the underlying RoundTripper used by the HTTP client.
+	// Tests inject a custom transport to point at httptest servers.
+	Transport http.RoundTripper
+	// Timeout overrides DefaultTimeout when non-zero.
+	Timeout time.Duration
+	// MaxBytes overrides DefaultMaxBytes when positive.
+	MaxBytes int64
+	// MaxRedirects overrides DefaultMaxRedirects when positive.
+	MaxRedirects int
+	// UserAgent overrides DefaultUserAgent when non-empty.
+	UserAgent string
+	// AllowLocal disables the SSRF guard. INTENDED FOR TESTS ONLY —
+	// production handlers must leave this false.
+	AllowLocal bool
+}
+
+// NewFetcher returns a Fetcher with production defaults applied.
+func NewFetcher() *Fetcher {
+	return &Fetcher{
+		Timeout:      DefaultTimeout,
+		MaxBytes:     DefaultMaxBytes,
+		MaxRedirects: DefaultMaxRedirects,
+		UserAgent:    DefaultUserAgent,
+	}
+}
+
+// Fetch performs a GET against rawURL, re-validating every redirect hop
+// and aborting if the response exceeds the size cap. Returns a wrapped
+// error suitable for surfacing to API callers.
+func (f *Fetcher) Fetch(ctx context.Context, rawURL string) (*FetchResult, error) {
+	if !f.AllowLocal {
+		if err := ValidateURL(rawURL); err != nil {
+			return nil, err
+		}
+	}
+
+	maxRedirects := f.MaxRedirects
+	if maxRedirects <= 0 {
+		maxRedirects = DefaultMaxRedirects
+	}
+	timeout := f.Timeout
+	if timeout <= 0 {
+		timeout = DefaultTimeout
+	}
+	maxBytes := f.MaxBytes
+	if maxBytes <= 0 {
+		maxBytes = DefaultMaxBytes
+	}
+	ua := f.UserAgent
+	if ua == "" {
+		ua = DefaultUserAgent
+	}
+
+	client := &http.Client{
+		Timeout:   timeout,
+		Transport: f.Transport,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) >= maxRedirects {
+				return fmt.Errorf("too many redirects (> %d)", maxRedirects)
+			}
+			if !f.AllowLocal {
+				if err := ValidateURL(req.URL.String()); err != nil {
+					return fmt.Errorf("redirect to %s blocked: %w", req.URL.Redacted(), err)
+				}
+			}
+			// Strip Authorization on cross-origin redirects — defense in
+			// depth even though we never set credentials ourselves.
+			if len(via) > 0 && req.URL.Host != via[0].URL.Host {
+				req.Header.Del("Authorization")
+				req.Header.Del("Cookie")
+			}
+			return nil
+		},
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("User-Agent", ua)
+	req.Header.Set("Accept", "text/html, application/xhtml+xml, application/xml;q=0.9, application/json;q=0.9, text/plain;q=0.8, */*;q=0.5")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch %s: %w", redactURL(rawURL), err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("upstream returned status %d for %s", resp.StatusCode, redactURL(rawURL))
+	}
+
+	// Read up to maxBytes+1; one byte over the cap is enough to know
+	// the upstream exceeded the limit.
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("read body: %w", err)
+	}
+	if int64(len(body)) > maxBytes {
+		return nil, fmt.Errorf("response exceeds maximum size of %d bytes", maxBytes)
+	}
+
+	finalURL := rawURL
+	if resp.Request != nil && resp.Request.URL != nil {
+		finalURL = resp.Request.URL.String()
+	}
+
+	return &FetchResult{
+		URL:         finalURL,
+		StatusCode:  resp.StatusCode,
+		ContentType: resp.Header.Get("Content-Type"),
+		Body:        body,
+	}, nil
+}
+
+// ValidateURL applies the SSRF guard: only http(s) schemes, no embedded
+// credentials, hostname must resolve to public IPs only. Returns nil
+// when the URL is safe to fetch.
+func ValidateURL(rawURL string) error {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("invalid URL: %w", err)
+	}
+	switch strings.ToLower(u.Scheme) {
+	case "http", "https":
+		// ok
+	default:
+		return fmt.Errorf("unsupported scheme %q: only http and https are allowed", u.Scheme)
+	}
+	if u.User != nil {
+		return errors.New("URLs with embedded credentials are not allowed")
+	}
+	host := u.Hostname()
+	if host == "" {
+		return errors.New("URL must have a hostname")
+	}
+
+	if ip := net.ParseIP(host); ip != nil {
+		if isPrivateIP(ip) {
+			return fmt.Errorf("URL targets private or reserved IP %s", ip)
+		}
+		return nil
+	}
+
+	ips, err := net.LookupIP(host)
+	if err != nil {
+		return fmt.Errorf("resolve hostname %q: %w", host, err)
+	}
+	if len(ips) == 0 {
+		return fmt.Errorf("hostname %q resolved to no addresses", host)
+	}
+	for _, ip := range ips {
+		if isPrivateIP(ip) {
+			return fmt.Errorf("hostname %q resolves to private/reserved IP %s", host, ip)
+		}
+	}
+	return nil
+}
+
+// isPrivateIP returns true for any IP we refuse to fetch from. This
+// includes loopback, RFC1918, IPv4/IPv6 link-local (catches the AWS/GCP/
+// Azure cloud-metadata IP 169.254.169.254), IPv6 unique-local, CGNAT,
+// and the unspecified address.
+func isPrivateIP(ip net.IP) bool {
+	if ip.IsLoopback() ||
+		ip.IsLinkLocalUnicast() ||
+		ip.IsLinkLocalMulticast() ||
+		ip.IsUnspecified() ||
+		ip.IsPrivate() {
+		return true
+	}
+	// CGNAT (RFC 6598) — not covered by IsPrivate but commonly used on
+	// the LAN side of consumer routers / mobile carriers.
+	if cgnatCIDR.Contains(ip) {
+		return true
+	}
+	return false
+}
+
+// cgnatCIDR is precomputed at init so isPrivateIP stays allocation-free
+// and concurrency-safe (no shared map writes).
+var cgnatCIDR = func() *net.IPNet {
+	_, n, err := net.ParseCIDR("100.64.0.0/10")
+	if err != nil {
+		panic(fmt.Errorf("urlimport: parse cgnat cidr: %w", err))
+	}
+	return n
+}()
+
+// redactURL hides credentials from log/error output. We already reject
+// credential-bearing URLs at validation time, but Go can hand us an
+// already-stripped url.URL via redirects — defensive double check.
+func redactURL(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL
+	}
+	return u.Redacted()
+}

--- a/internal/urlimport/fetch.go
+++ b/internal/urlimport/fetch.go
@@ -89,6 +89,17 @@ func NewFetcher() *Fetcher {
 // Fetch performs a GET against rawURL, re-validating every redirect hop
 // and aborting if the response exceeds the size cap. Returns a wrapped
 // error suitable for surfacing to API callers.
+//
+// The SSRF guard runs in two layers:
+//
+//  1. ValidateURL — fast-fail pre-flight on scheme, credentials,
+//     hostname presence, and IP-literal targets. Does NOT do DNS
+//     resolution; see (2).
+//  2. A custom dialer that resolves the hostname once and checks every
+//     returned IP at dial-time. This is the canonical guard against
+//     DNS rebinding: any hostname-lookup happens inside the dialer and
+//     the result is reused as the dial target, so the IP we vetted is
+//     the IP we connect to.
 func (f *Fetcher) Fetch(ctx context.Context, rawURL string) (*FetchResult, error) {
 	if !f.AllowLocal {
 		if err := ValidateURL(rawURL); err != nil {
@@ -113,9 +124,14 @@ func (f *Fetcher) Fetch(ctx context.Context, rawURL string) (*FetchResult, error
 		ua = DefaultUserAgent
 	}
 
+	transport := f.Transport
+	if transport == nil {
+		transport = newSafeTransport(f.AllowLocal, timeout)
+	}
+
 	client := &http.Client{
 		Timeout:   timeout,
-		Transport: f.Transport,
+		Transport: transport,
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			if len(via) >= maxRedirects {
 				return fmt.Errorf("too many redirects (> %d)", maxRedirects)
@@ -175,9 +191,19 @@ func (f *Fetcher) Fetch(ctx context.Context, rawURL string) (*FetchResult, error
 	}, nil
 }
 
-// ValidateURL applies the SSRF guard: only http(s) schemes, no embedded
-// credentials, hostname must resolve to public IPs only. Returns nil
-// when the URL is safe to fetch.
+// ValidateURL is the pre-flight SSRF guard: it rejects non-http(s)
+// schemes, URLs with embedded credentials, missing hostnames, and
+// IP-literal hosts in private/reserved ranges. It deliberately does
+// NOT do DNS resolution — that happens once at dial-time inside the
+// fetcher's transport (see newSafeTransport), where the resolved IP
+// is both checked and reused as the dial target. Doing DNS here would
+// open a TOCTOU window allowing DNS rebinding: a malicious server
+// returns a public IP for the validation lookup and a private IP for
+// the actual fetch.
+//
+// Callers that just want a quick "is this URL syntactically safe?"
+// check (e.g. UI input validation) can call ValidateURL standalone.
+// Callers that fetch must use Fetcher, which adds the dial-time check.
 func ValidateURL(rawURL string) error {
 	u, err := url.Parse(rawURL)
 	if err != nil {
@@ -201,22 +227,71 @@ func ValidateURL(rawURL string) error {
 		if isPrivateIP(ip) {
 			return fmt.Errorf("URL targets private or reserved IP %s", ip)
 		}
-		return nil
-	}
-
-	ips, err := net.LookupIP(host)
-	if err != nil {
-		return fmt.Errorf("resolve hostname %q: %w", host, err)
-	}
-	if len(ips) == 0 {
-		return fmt.Errorf("hostname %q resolved to no addresses", host)
-	}
-	for _, ip := range ips {
-		if isPrivateIP(ip) {
-			return fmt.Errorf("hostname %q resolves to private/reserved IP %s", host, ip)
-		}
 	}
 	return nil
+}
+
+// newSafeTransport returns an *http.Transport whose DialContext resolves
+// each hostname inside the dialer and validates every returned IP. Only
+// IPs that pass isPrivateIP are dialed, and the connection is made to
+// the resolved IP directly (no second lookup) so the validated IP is
+// the dial target.
+//
+// allowLocal=true (tests only) bypasses the IP check so httptest servers
+// on 127.0.0.1 are reachable.
+func newSafeTransport(allowLocal bool, timeout time.Duration) *http.Transport {
+	dialer := &net.Dialer{
+		Timeout:   timeout,
+		KeepAlive: 30 * time.Second,
+	}
+	resolver := net.DefaultResolver
+	return &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			host, port, err := net.SplitHostPort(addr)
+			if err != nil {
+				return nil, fmt.Errorf("urlimport: split host/port %q: %w", addr, err)
+			}
+
+			// IP literal — already vetted by ValidateURL. Dial directly.
+			if ip := net.ParseIP(host); ip != nil {
+				if !allowLocal && isPrivateIP(ip) {
+					return nil, fmt.Errorf("urlimport: blocked dial to private/reserved IP %s", ip)
+				}
+				return dialer.DialContext(ctx, network, addr)
+			}
+
+			// Hostname — resolve once, validate every IP, dial the first
+			// allowed one. This single resolution is the dial target.
+			ips, err := resolver.LookupIP(ctx, "ip", host)
+			if err != nil {
+				return nil, fmt.Errorf("urlimport: resolve %q: %w", host, err)
+			}
+			if len(ips) == 0 {
+				return nil, fmt.Errorf("urlimport: hostname %q resolved to no addresses", host)
+			}
+			var lastErr error
+			for _, ip := range ips {
+				if !allowLocal && isPrivateIP(ip) {
+					lastErr = fmt.Errorf("urlimport: %q resolves to private/reserved IP %s", host, ip)
+					continue
+				}
+				conn, err := dialer.DialContext(ctx, network, net.JoinHostPort(ip.String(), port))
+				if err == nil {
+					return conn, nil
+				}
+				lastErr = err
+			}
+			if lastErr != nil {
+				return nil, lastErr
+			}
+			return nil, fmt.Errorf("urlimport: no usable address for %q", host)
+		},
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
 }
 
 // isPrivateIP returns true for any IP we refuse to fetch from. This

--- a/internal/urlimport/fetch.go
+++ b/internal/urlimport/fetch.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -57,11 +58,16 @@ type FetchResult struct {
 // Fetcher performs SSRF-guarded HTTP GETs.
 //
 // The zero value is not usable — call NewFetcher. Fields are exported
-// only to allow tests to flip AllowLocal; production code should treat
-// the struct as opaque.
+// only to allow tests to flip AllowLocal and inject a Transport;
+// production code should treat the struct as opaque after creation.
+//
+// Fetcher is safe for concurrent use. The default safe-transport is
+// lazily built on first Fetch and reused for subsequent calls so
+// keep-alive connections aren't leaked.
 type Fetcher struct {
 	// Transport is the underlying RoundTripper used by the HTTP client.
 	// Tests inject a custom transport to point at httptest servers.
+	// When nil, Fetcher builds and caches a safe default.
 	Transport http.RoundTripper
 	// Timeout overrides DefaultTimeout when non-zero.
 	Timeout time.Duration
@@ -74,6 +80,12 @@ type Fetcher struct {
 	// AllowLocal disables the SSRF guard. INTENDED FOR TESTS ONLY —
 	// production handlers must leave this false.
 	AllowLocal bool
+
+	// safeOnce + safeTransport memoize the default transport so we
+	// don't leak per-call *http.Transport instances with their own
+	// idle-connection pools.
+	safeOnce      sync.Once
+	safeTransport *http.Transport
 }
 
 // NewFetcher returns a Fetcher with production defaults applied.
@@ -126,7 +138,7 @@ func (f *Fetcher) Fetch(ctx context.Context, rawURL string) (*FetchResult, error
 
 	transport := f.Transport
 	if transport == nil {
-		transport = newSafeTransport(f.AllowLocal, timeout)
+		transport = f.defaultTransport(timeout)
 	}
 
 	client := &http.Client{
@@ -231,11 +243,30 @@ func ValidateURL(rawURL string) error {
 	return nil
 }
 
+// defaultTransport lazily builds and memoizes the package's safe
+// transport. Reusing one transport across Fetch calls keeps the
+// keep-alive pool bounded and the FD usage flat under load. AllowLocal
+// is captured on first use — callers that want to flip it after the
+// first Fetch should construct a new Fetcher instead.
+func (f *Fetcher) defaultTransport(timeout time.Duration) *http.Transport {
+	f.safeOnce.Do(func() {
+		f.safeTransport = newSafeTransport(f.AllowLocal, timeout)
+	})
+	return f.safeTransport
+}
+
 // newSafeTransport returns an *http.Transport whose DialContext resolves
 // each hostname inside the dialer and validates every returned IP. Only
 // IPs that pass isPrivateIP are dialed, and the connection is made to
 // the resolved IP directly (no second lookup) so the validated IP is
 // the dial target.
+//
+// HTTP/HTTPS proxies are deliberately NOT honored: when a proxy is in
+// use the client connects to the proxy host and the target hostname is
+// never resolved by our dialer, which would silently bypass the SSRF
+// guard. Operators who need an outbound proxy can wire their own
+// trusted transport into Fetcher.Transport instead of relying on
+// HTTP_PROXY/HTTPS_PROXY env vars.
 //
 // allowLocal=true (tests only) bypasses the IP check so httptest servers
 // on 127.0.0.1 are reachable.
@@ -246,7 +277,8 @@ func newSafeTransport(allowLocal bool, timeout time.Duration) *http.Transport {
 	}
 	resolver := net.DefaultResolver
 	return &http.Transport{
-		Proxy: http.ProxyFromEnvironment,
+		// Proxy intentionally nil — see function docstring.
+		Proxy: nil,
 		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
 			host, port, err := net.SplitHostPort(addr)
 			if err != nil {

--- a/internal/urlimport/fetch_test.go
+++ b/internal/urlimport/fetch_test.go
@@ -1,0 +1,222 @@
+package urlimport
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestValidateURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		url     string
+		wantErr bool
+	}{
+		// Schemes
+		{"http public", "http://example.com/foo", false},
+		{"https public", "https://example.com/foo", false},
+		{"file scheme rejected", "file:///etc/passwd", true},
+		{"ftp scheme rejected", "ftp://example.com/foo", true},
+		{"javascript scheme rejected", "javascript:alert(1)", true},
+		{"gopher scheme rejected", "gopher://example.com", true},
+
+		// Credentials
+		{"basic auth rejected", "https://user:pass@example.com/foo", true},
+		{"user-only rejected", "https://user@example.com/foo", true},
+
+		// Hostname
+		{"no host rejected", "https:///foo", true},
+		{"empty host rejected", "https://", true},
+		{"malformed url rejected", "://bad-url", true},
+
+		// IPv4 private ranges
+		{"loopback 127.0.0.1", "http://127.0.0.1/foo", true},
+		{"loopback range 127.5.5.5", "http://127.5.5.5/foo", true},
+		{"rfc1918 10.x", "http://10.0.0.1/foo", true},
+		{"rfc1918 172.16.x", "http://172.16.0.1/foo", true},
+		{"rfc1918 172.31.x boundary", "http://172.31.255.255/foo", true},
+		{"rfc1918 192.168.x", "http://192.168.1.1/foo", true},
+
+		// IPv4 link-local + cloud metadata
+		{"link-local 169.254.x", "http://169.254.1.1/foo", true},
+		{"AWS metadata 169.254.169.254", "http://169.254.169.254/latest/meta-data/", true},
+
+		// IPv4 special / CGNAT
+		{"unspecified 0.0.0.0", "http://0.0.0.0/foo", true},
+		{"cgnat 100.64.x", "http://100.64.0.1/foo", true},
+		{"cgnat 100.127.x boundary", "http://100.127.255.255/foo", true},
+
+		// IPv6
+		{"ipv6 loopback ::1", "http://[::1]/foo", true},
+		{"ipv6 unspecified ::", "http://[::]/foo", true},
+		{"ipv6 link-local fe80::", "http://[fe80::1]/foo", true},
+		{"ipv6 unique-local fc00::", "http://[fc00::1]/foo", true},
+		{"ipv6 unique-local fd00::", "http://[fd00::1]/foo", true},
+
+		// Boundary: a public IPv4 (1.1.1.1 — Cloudflare DNS, well-known public)
+		{"public ipv4 1.1.1.1", "http://1.1.1.1/foo", false},
+
+		// Hostname resolution — these depend on DNS being available; we
+		// only test parse-level cases here and rely on the IP-literal
+		// tests above for guard correctness. example.com is RFC2606 and
+		// always resolves to a public IP when DNS works; if the test
+		// environment has no DNS the test will skip via t.Skip below.
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateURL(tc.url)
+			gotErr := err != nil
+			if gotErr != tc.wantErr {
+				t.Fatalf("ValidateURL(%q): err = %v, wantErr = %v", tc.url, err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestFetch_HappyPath(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_, _ = io.WriteString(w, "<html><body>hello</body></html>")
+	}))
+	defer srv.Close()
+
+	f := NewFetcher()
+	f.AllowLocal = true // httptest binds to 127.0.0.1
+	res, err := f.Fetch(context.Background(), srv.URL)
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if res.StatusCode != 200 {
+		t.Fatalf("status = %d, want 200", res.StatusCode)
+	}
+	if !strings.Contains(res.ContentType, "text/html") {
+		t.Fatalf("content-type = %q, want text/html prefix", res.ContentType)
+	}
+	if !strings.Contains(string(res.Body), "hello") {
+		t.Fatalf("body = %q, want to contain 'hello'", string(res.Body))
+	}
+}
+
+func TestFetch_SSRFRejected(t *testing.T) {
+	// Loopback URL goes straight through ValidateURL — no need for a
+	// server. AllowLocal stays false (the production default).
+	f := NewFetcher()
+	_, err := f.Fetch(context.Background(), "http://127.0.0.1:1/")
+	if err == nil {
+		t.Fatal("Fetch: expected SSRF rejection, got nil")
+	}
+}
+
+func TestFetch_SizeCap(t *testing.T) {
+	// Server streams 2 MB but the cap is 1 KB.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(200)
+		buf := strings.Repeat("A", 1024)
+		for i := 0; i < 2048; i++ {
+			if _, err := io.WriteString(w, buf); err != nil {
+				return
+			}
+		}
+	}))
+	defer srv.Close()
+
+	f := NewFetcher()
+	f.AllowLocal = true
+	f.MaxBytes = 1024
+	_, err := f.Fetch(context.Background(), srv.URL)
+	if err == nil {
+		t.Fatal("Fetch: expected size-cap error, got nil")
+	}
+	if !strings.Contains(err.Error(), "exceeds maximum size") {
+		t.Fatalf("error = %v, want 'exceeds maximum size'", err)
+	}
+}
+
+func TestFetch_Timeout(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(2 * time.Second)
+		w.WriteHeader(200)
+	}))
+	defer srv.Close()
+
+	f := NewFetcher()
+	f.AllowLocal = true
+	f.Timeout = 100 * time.Millisecond
+	_, err := f.Fetch(context.Background(), srv.URL)
+	if err == nil {
+		t.Fatal("Fetch: expected timeout error, got nil")
+	}
+}
+
+func TestFetch_Non2xx(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "nope", 404)
+	}))
+	defer srv.Close()
+
+	f := NewFetcher()
+	f.AllowLocal = true
+	_, err := f.Fetch(context.Background(), srv.URL)
+	if err == nil {
+		t.Fatal("Fetch: expected error for 404, got nil")
+	}
+	if !strings.Contains(err.Error(), "404") {
+		t.Fatalf("error = %v, want to mention status 404", err)
+	}
+}
+
+func TestFetch_RedirectRevalidated(t *testing.T) {
+	// Initial URL is a public IP literal (1.1.1.1) so ValidateURL passes,
+	// but a stubbed transport returns a 302 → 127.0.0.1. The CheckRedirect
+	// closure must re-run ValidateURL and abort the redirect chain.
+	stub := &stubTransport{
+		respond: func(req *http.Request) *http.Response {
+			return &http.Response{
+				StatusCode: http.StatusFound,
+				Header:     http.Header{"Location": []string{"http://127.0.0.1/internal"}},
+				Body:       io.NopCloser(strings.NewReader("")),
+				Request:    req,
+			}
+		},
+	}
+	f := NewFetcher()
+	f.AllowLocal = false
+	f.Transport = stub
+	_, err := f.Fetch(context.Background(), "http://1.1.1.1/foo")
+	if err == nil {
+		t.Fatal("Fetch: expected redirect-to-loopback rejection, got nil")
+	}
+	if !strings.Contains(err.Error(), "redirect") && !strings.Contains(err.Error(), "private") {
+		t.Fatalf("error = %v, want to mention redirect/private", err)
+	}
+}
+
+type stubTransport struct {
+	respond func(*http.Request) *http.Response
+}
+
+func (s *stubTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return s.respond(req), nil
+}
+
+func TestFetch_ContextCancel(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(2 * time.Second)
+	}))
+	defer srv.Close()
+
+	f := NewFetcher()
+	f.AllowLocal = true
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel before calling Fetch
+	_, err := f.Fetch(ctx, srv.URL)
+	if err == nil {
+		t.Fatal("Fetch: expected context-cancel error, got nil")
+	}
+}

--- a/internal/urlimport/fetch_test.go
+++ b/internal/urlimport/fetch_test.go
@@ -60,11 +60,11 @@ func TestValidateURL(t *testing.T) {
 		// Boundary: a public IPv4 (1.1.1.1 — Cloudflare DNS, well-known public)
 		{"public ipv4 1.1.1.1", "http://1.1.1.1/foo", false},
 
-		// Hostname resolution — these depend on DNS being available; we
-		// only test parse-level cases here and rely on the IP-literal
-		// tests above for guard correctness. example.com is RFC2606 and
-		// always resolves to a public IP when DNS works; if the test
-		// environment has no DNS the test will skip via t.Skip below.
+		// Hostnames are NOT resolved here (see ValidateURL docstring on
+		// DNS rebinding). example.com passes the pre-flight; the
+		// dial-time guard inside newSafeTransport is what would catch a
+		// hostname that resolves to a private IP.
+		{"public hostname not resolved at validate", "https://example.com/", false},
 	}
 
 	for _, tc := range tests {
@@ -203,6 +203,23 @@ type stubTransport struct {
 
 func (s *stubTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	return s.respond(req), nil
+}
+
+func TestFetch_DialerBlocksLoopbackHostname(t *testing.T) {
+	// Initial URL passes ValidateURL because the hostname is syntactic-
+	// only and we no longer do DNS in ValidateURL. The dial-time guard
+	// inside newSafeTransport must block dialing the resolved IP if it's
+	// loopback. Use "localhost" which resolves to 127.0.0.1.
+	f := NewFetcher()
+	f.Timeout = 2 * time.Second
+	// AllowLocal=false (production default)
+	_, err := f.Fetch(context.Background(), "http://localhost:1/")
+	if err == nil {
+		t.Fatal("Fetch: expected dial-time SSRF rejection, got nil")
+	}
+	if !strings.Contains(err.Error(), "private") && !strings.Contains(err.Error(), "reserved") {
+		t.Fatalf("error = %v, want to mention private/reserved", err)
+	}
 }
 
 func TestFetch_ContextCancel(t *testing.T) {


### PR DESCRIPTION
## Summary
- New `internal/urlimport` package with SSRF-guarded HTTP GET (`fetch.go`) and content-type/body-prefix detection (`detect.go`) returning `openapi` or `generic`.
- Table-driven SSRF tests (24 cases) + happy-path / size-cap / timeout / non-2xx / context-cancel / redirect re-validation tests for the fetcher.
- Table-driven detection tests (20 cases) covering OpenAPI JSON/YAML, Swagger 2.0, vendor media types, charset-parameter normalization, and negative cases.

## Context
First slice of `PLAN-1467` — *Insert from URL — HTML→Markdown utility in the item editor*. Implements `TASK-1469`. No callers yet; the endpoint that consumes `Fetcher` + `Detect` lands in `TASK-1472`. Package name is `urlimport` because `import` is a reserved word.

## Notes
- Pre-existing baseline failure on `make check`: `npm audit --audit-level=high --omit=dev` fails on `main` due to a Svelte advisory (GHSA-pr6f-5x2q-rwfp + related). This PR does not regress that and does not touch web. CONVE-190's three gates (lint, `go test`, `npm run build`) all pass.

## Test plan
- [x] `golangci-lint run --timeout=5m ./...` — 0 issues
- [x] `go test ./...` — all packages green
- [x] `go test ./internal/urlimport/` — 51 sub-tests pass (`-v` verified)
- [x] `cd web && npm run build` — clean
- [x] SSRF guard rejects loopback, RFC1918, CGNAT, IPv4/IPv6 link-local (incl. 169.254.169.254), IPv6 ULA, unspecified, file://, ftp://, javascript:, and URLs with credentials
- [x] Redirect chain re-validates each hop (stubbed-transport test)