### PR TITLE
feat(server): POST /api/v1/import/url endpoint + integration tests (TASK-1472)

### DIFF
--- a/internal/server/handlers_import.go
+++ b/internal/server/handlers_import.go
@@ -1,0 +1,153 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/urlimport"
+)
+
+// importURLRequest is the POST /api/v1/import/url request body.
+type importURLRequest struct {
+	URL string `json:"url"`
+}
+
+// importURLResponse is the response shape from POST /api/v1/import/url.
+// Side-effect-free: no database writes happen during the call; the
+// client decides whether to splice the markdown into an item.
+type importURLResponse struct {
+	Markdown     string `json:"markdown"`
+	DetectedType string `json:"detected_type"` // "openapi" or "generic"
+	Title        string `json:"title,omitempty"`
+	SourceURL    string `json:"source_url"`   // final URL after redirects
+	FetchedAt    string `json:"fetched_at"`   // RFC3339 timestamp
+	ContentType  string `json:"content_type"` // upstream Content-Type
+}
+
+// importURLFetcher is the package-level Fetcher reused across requests.
+// It owns a memoized safe transport per the urlimport package; building
+// per-request would leak idle-connection pools. Initialized lazily on
+// the first request so tests that swap pkgFetcher in TestMain can do so
+// before any request arrives.
+var pkgFetcher = urlimport.NewFetcher()
+
+// importURLTimeout caps total handler time including conversion.
+// Fetcher's own timeout is the HTTP-level cap; this is the wall-clock
+// budget for the whole pipeline so a pathologically slow converter
+// still releases the connection.
+const importURLTimeout = 30 * time.Second
+
+// handleImportURL implements POST /api/v1/import/url.
+//
+//   - Body:   {"url": "https://..."}
+//   - Result: {"markdown", "detected_type", "title", "source_url",
+//     "fetched_at", "content_type"}
+//
+// Pipeline:
+//  1. Validate URL (scheme/credentials/IP-literal SSRF pre-flight).
+//  2. Fetch with size + time caps and dial-time SSRF re-validation.
+//  3. Detect document type (openapi vs generic).
+//  4. Convert:
+//     - openapi → ConvertOpenAPI. Falls back to ConvertGeneric on
+//     v2 specs or other "openapi-detected but not 3.x" cases so a
+//     misdetected JSON spec still produces usable output.
+//     - generic → ConvertGeneric.
+//
+// Errors:
+//   - 400 for malformed URL, SSRF rejection, size cap exceeded
+//   - 502 for upstream failures (non-2xx, DNS, timeout)
+//   - 422 when the fetched body cannot be converted (rare)
+//
+// The handler never writes to the database. Callers (the editor's
+// "Insert from URL" modal) are responsible for any item updates.
+func (s *Server) handleImportURL(w http.ResponseWriter, r *http.Request) {
+	// RequireAuth middleware already gates the /api/v1 group when users
+	// exist; in the no-user "fresh install" mode the middleware lets
+	// requests through with currentUserID == "". We use the ID only for
+	// log attribution, never for authorization decisions.
+	userID := currentUserID(r)
+
+	var input importURLRequest
+	if err := decodeJSON(r, &input); err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", "Invalid request body")
+		return
+	}
+	if input.URL == "" {
+		writeError(w, http.StatusBadRequest, "bad_request", "url is required")
+		return
+	}
+
+	// Pre-flight URL validation up front — gives a precise 400 instead
+	// of a generic upstream error. The Fetcher also runs ValidateURL
+	// but this lets us distinguish "you typed garbage" from "we tried
+	// to fetch and the server rejected us".
+	//
+	// When the fetcher is configured with AllowLocal (test mode), skip
+	// the pre-flight so httptest's 127.0.0.1 servers stay reachable.
+	// The fetcher itself respects AllowLocal at both validate and dial
+	// time, so the security guard is intact for production callers.
+	if !pkgFetcher.AllowLocal {
+		if err := urlimport.ValidateURL(input.URL); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_url", err.Error())
+			return
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), importURLTimeout)
+	defer cancel()
+
+	fetched, err := pkgFetcher.Fetch(ctx, input.URL)
+	if err != nil {
+		// 502 mirrors the gateway-error pattern used elsewhere for
+		// upstream failures. SSRF rejection from the dial-time guard
+		// is mapped to 400 because the URL is the user's input.
+		status := http.StatusBadGateway
+		code := "fetch_failed"
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			status = http.StatusGatewayTimeout
+			code = "fetch_timeout"
+		}
+		slog.Info("import url fetch failed", "user", userID, "url", input.URL, "error", err)
+		writeError(w, status, code, err.Error())
+		return
+	}
+
+	detected := urlimport.Detect(fetched.ContentType, fetched.Body)
+
+	var result *urlimport.ConvertResult
+	switch detected {
+	case urlimport.TypeOpenAPI:
+		result, err = urlimport.ConvertOpenAPI(fetched.Body, fetched.URL)
+		if err != nil {
+			// Detected as openapi but conversion failed — most common
+			// reason is a Swagger 2.0 spec sniffed as "openapi" but
+			// rejected by ConvertOpenAPI. Fall back to generic so the
+			// user at least gets the raw textual content. Re-classify
+			// the response accordingly so the UI can show the right
+			// affordance.
+			slog.Info("openapi conversion fell back to generic", "user", userID, "url", input.URL, "error", err)
+			result, err = urlimport.ConvertGeneric(fetched.Body, fetched.URL)
+			detected = urlimport.TypeGeneric
+		}
+	default:
+		result, err = urlimport.ConvertGeneric(fetched.Body, fetched.URL)
+	}
+	if err != nil {
+		slog.Info("import url conversion failed", "user", userID, "url", input.URL, "error", err)
+		writeError(w, http.StatusUnprocessableEntity, "conversion_failed", err.Error())
+		return
+	}
+
+	resp := importURLResponse{
+		Markdown:     result.Markdown,
+		DetectedType: string(detected),
+		Title:        result.Title,
+		SourceURL:    fetched.URL,
+		FetchedAt:    time.Now().UTC().Format(time.RFC3339),
+		ContentType:  fetched.ContentType,
+	}
+	writeJSON(w, http.StatusOK, resp)
+}

--- a/internal/server/handlers_import_test.go
+++ b/internal/server/handlers_import_test.go
@@ -1,0 +1,290 @@
+package server
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/urlimport"
+)
+
+// withLocalFetcher replaces the package-level fetcher with one that
+// allows loopback dials so httptest.NewServer addresses (127.0.0.1) can
+// be reached. Restored on test cleanup. Tests use this helper instead
+// of mutating pkgFetcher directly so the restore happens unconditionally.
+func withLocalFetcher(t *testing.T) {
+	t.Helper()
+	orig := pkgFetcher
+	f := urlimport.NewFetcher()
+	f.AllowLocal = true
+	pkgFetcher = f
+	t.Cleanup(func() {
+		pkgFetcher = orig
+	})
+}
+
+func TestImportURL_HTMLHappyPath(t *testing.T) {
+	withLocalFetcher(t)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_, _ = io.WriteString(w, `<!doctype html><html><head><title>Hello</title></head><body><article><h1>Hello world</h1><p>This is body text.</p></article></body></html>`)
+	}))
+	defer upstream.Close()
+
+	srv := testServer(t)
+	rr := doRequest(srv, "POST", "/api/v1/import/url", map[string]string{
+		"url": upstream.URL + "/page",
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+
+	var resp struct {
+		Markdown     string `json:"markdown"`
+		DetectedType string `json:"detected_type"`
+		Title        string `json:"title"`
+		SourceURL    string `json:"source_url"`
+		FetchedAt    string `json:"fetched_at"`
+		ContentType  string `json:"content_type"`
+	}
+	parseJSON(t, rr, &resp)
+	if resp.DetectedType != "generic" {
+		t.Errorf("detected_type = %q, want 'generic'", resp.DetectedType)
+	}
+	if !strings.Contains(resp.Markdown, "Hello world") {
+		t.Errorf("markdown missing 'Hello world':\n%s", resp.Markdown)
+	}
+	if !strings.HasPrefix(resp.SourceURL, upstream.URL) {
+		t.Errorf("source_url = %q, want to start with %q", resp.SourceURL, upstream.URL)
+	}
+	if resp.FetchedAt == "" {
+		t.Error("fetched_at is empty")
+	}
+	if resp.ContentType == "" {
+		t.Error("content_type is empty")
+	}
+}
+
+func TestImportURL_OpenAPIHappyPath(t *testing.T) {
+	withLocalFetcher(t)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/yaml")
+		_, _ = io.WriteString(w, `openapi: 3.0.0
+info:
+  title: Inline API
+  version: "1.0"
+paths:
+  /widgets:
+    get:
+      summary: List widgets
+      responses:
+        '200':
+          description: ok
+`)
+	}))
+	defer upstream.Close()
+
+	srv := testServer(t)
+	rr := doRequest(srv, "POST", "/api/v1/import/url", map[string]string{
+		"url": upstream.URL + "/openapi.yaml",
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+
+	var resp struct {
+		Markdown     string `json:"markdown"`
+		DetectedType string `json:"detected_type"`
+		Title        string `json:"title"`
+	}
+	parseJSON(t, rr, &resp)
+	if resp.DetectedType != "openapi" {
+		t.Errorf("detected_type = %q, want 'openapi'", resp.DetectedType)
+	}
+	if resp.Title != "Inline API" {
+		t.Errorf("title = %q, want 'Inline API'", resp.Title)
+	}
+	wantSubstrings := []string{
+		"# Inline API",
+		"## Endpoints",
+		"`GET /widgets`",
+		"List widgets",
+	}
+	for _, want := range wantSubstrings {
+		if !strings.Contains(resp.Markdown, want) {
+			t.Errorf("markdown missing %q:\n%s", want, resp.Markdown)
+		}
+	}
+}
+
+func TestImportURL_Swagger2FallsBackToGeneric(t *testing.T) {
+	withLocalFetcher(t)
+	// Swagger 2.0 is detected as "openapi" by the sniffer but
+	// ConvertOpenAPI rejects it. The endpoint must fall back to generic
+	// so the user still gets usable output (the raw text).
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/yaml")
+		_, _ = io.WriteString(w, `swagger: "2.0"
+info:
+  title: Legacy
+  version: "1.0"
+paths: {}
+`)
+	}))
+	defer upstream.Close()
+
+	srv := testServer(t)
+	rr := doRequest(srv, "POST", "/api/v1/import/url", map[string]string{
+		"url": upstream.URL,
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		DetectedType string `json:"detected_type"`
+		Markdown     string `json:"markdown"`
+	}
+	parseJSON(t, rr, &resp)
+	if resp.DetectedType != "generic" {
+		t.Errorf("detected_type = %q, want 'generic' after Swagger 2 fallback", resp.DetectedType)
+	}
+	if resp.Markdown == "" {
+		t.Error("markdown is empty")
+	}
+}
+
+func TestImportURL_RejectsSSRF(t *testing.T) {
+	// pkgFetcher NOT replaced with AllowLocal — the default safe fetcher
+	// rejects loopback at validate time. The handler's pre-flight
+	// urlimport.ValidateURL catches this before any I/O.
+	srv := testServer(t)
+	rr := doRequest(srv, "POST", "/api/v1/import/url", map[string]string{
+		"url": "http://127.0.0.1:1/secret",
+	})
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, body = %s, want 400", rr.Code, rr.Body.String())
+	}
+	body := strings.ToLower(rr.Body.String())
+	if !strings.Contains(body, "private") && !strings.Contains(body, "reserved") {
+		t.Errorf("response body = %s, want to mention private/reserved", rr.Body.String())
+	}
+}
+
+func TestImportURL_RejectsNonHTTPScheme(t *testing.T) {
+	srv := testServer(t)
+	rr := doRequest(srv, "POST", "/api/v1/import/url", map[string]string{
+		"url": "file:///etc/passwd",
+	})
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400, body = %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestImportURL_RejectsMissingURL(t *testing.T) {
+	srv := testServer(t)
+	rr := doRequest(srv, "POST", "/api/v1/import/url", map[string]string{})
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400, body = %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestImportURL_RejectsMalformedBody(t *testing.T) {
+	srv := testServer(t)
+	req := httptest.NewRequest("POST", "/api/v1/import/url", strings.NewReader("not json"))
+	req.Header.Set("Content-Type", "application/json")
+	req.RemoteAddr = "192.0.2.1:1234"
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400, body = %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestImportURL_UpstreamErrorIs502(t *testing.T) {
+	withLocalFetcher(t)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "nope", http.StatusInternalServerError)
+	}))
+	defer upstream.Close()
+
+	srv := testServer(t)
+	rr := doRequest(srv, "POST", "/api/v1/import/url", map[string]string{
+		"url": upstream.URL,
+	})
+	if rr.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502, body = %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestImportURL_SizeCapReturns502(t *testing.T) {
+	// Replace the fetcher with one that has a tiny size cap; the
+	// upstream sends more, so the read-time check returns an error
+	// which we surface as 502 (the upstream did something we can't
+	// recover from).
+	orig := pkgFetcher
+	f := urlimport.NewFetcher()
+	f.AllowLocal = true
+	f.MaxBytes = 256
+	pkgFetcher = f
+	t.Cleanup(func() { pkgFetcher = orig })
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, strings.Repeat("A", 4096))
+	}))
+	defer upstream.Close()
+
+	srv := testServer(t)
+	rr := doRequest(srv, "POST", "/api/v1/import/url", map[string]string{
+		"url": upstream.URL,
+	})
+	if rr.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502 for size-cap, body = %s", rr.Code, rr.Body.String())
+	}
+}
+
+// TestImportURL_NoDatabaseSideEffects asserts the endpoint doesn't
+// mutate any items. We import a URL and verify the item count stays
+// at zero (no item creation, no metadata writes).
+func TestImportURL_NoDatabaseSideEffects(t *testing.T) {
+	withLocalFetcher(t)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = io.WriteString(w, `<p>side-effect probe</p>`)
+	}))
+	defer upstream.Close()
+
+	srv := testServer(t)
+	slug := createWSForTest(t, srv)
+
+	// Count items before.
+	rr := doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/items", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("list items before: status = %d", rr.Code)
+	}
+	var beforeItems []map[string]any
+	parseJSON(t, rr, &beforeItems)
+	before := len(beforeItems)
+
+	// Import.
+	rr = doRequest(srv, "POST", "/api/v1/import/url", map[string]string{
+		"url": upstream.URL,
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("import status = %d, body = %s", rr.Code, rr.Body.String())
+	}
+
+	// Count items after.
+	rr = doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/items", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("list items after: status = %d", rr.Code)
+	}
+	var afterItems []map[string]any
+	parseJSON(t, rr, &afterItems)
+	if len(afterItems) != before {
+		t.Errorf("item count changed: before=%d after=%d — endpoint must be side-effect-free", before, len(afterItems))
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -940,6 +940,11 @@ func (s *Server) setupRouter() {
 			// Playbook Library
 			r.Get("/playbook-library", s.handlePlaybookLibrary)
 
+			// URL import — fetch a remote page and return markdown.
+			// Side-effect-free; the client decides what to do with the
+			// markdown. See PLAN-1467 / TASK-1472 / internal/urlimport.
+			r.Post("/import/url", s.handleImportURL)
+
 			// Invitations (outside workspace scope)
 			r.Post("/invitations/{code}/accept", s.handleAcceptInvitation)
 


### PR DESCRIPTION
## Summary
- New \`POST /api/v1/import/url\` endpoint that wires \`internal/urlimport\` Fetcher → Detect → converters.
- Side-effect-free: no DB writes; the editor's "Insert from URL" modal owns any item mutation (TASK-1474).
- 30s wall-clock budget via \`context.WithTimeout\` (Fetcher's own timeout is the HTTP-level cap).
- Swagger 2.0 detected-as-openapi but rejected → falls back to \`ConvertGeneric\` and re-classifies the response.

## Status mapping
- 400 — invalid URL / SSRF / malformed body
- 422 — conversion failed
- 502 — upstream non-2xx / size cap / DNS / TCP error
- 504 — fetch timeout

## Context
Fourth slice of \`PLAN-1467\`. Implements \`TASK-1472\`. Consumes \`urlimport.Fetcher\` + \`urlimport.Detect\` + \`ConvertGeneric\` + \`ConvertOpenAPI\` from earlier PRs.

## Test plan
- [x] \`golangci-lint run --timeout=5m ./...\` — 0 issues
- [x] \`go test ./...\` — all packages green
- [x] \`go test ./internal/server/ -run TestImportURL\` — 9 cases pass (HTML, OpenAPI, Swagger fallback, SSRF, file://, missing/malformed body, upstream 5xx, size cap, no-side-effects)
- [x] \`cd web && npm run build\` — clean