### PR TITLE
feat(web): Insert from URL — TipTap toolbar button + modal (TASK-1473)

### DIFF
--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -284,6 +284,19 @@ export interface AuthSession {
 	user?: { id: string; email: string; username: string; name: string; role: string; plan?: string };
 }
 
+// ImportURLResponse mirrors internal/server/handlers_import.go's
+// importURLResponse. Side-effect-free: no DB writes happen on the
+// server during this call; the editor decides whether to splice the
+// markdown into an item.
+export interface ImportURLResponse {
+	markdown: string;
+	detected_type: 'openapi' | 'generic';
+	title?: string;
+	source_url: string;
+	fetched_at: string;
+	content_type: string;
+}
+
 export interface LoginResponse {
 	user?: { id: string; email: string; username: string; name: string; role: string; plan?: string };
 	token?: string;
@@ -1339,6 +1352,18 @@ export const api = {
 		revoke: (id: string) =>
 			request<void>(`/connected-apps/${encodeURIComponent(id)}`, { method: 'DELETE' })
 	},
+
+	// ── URL Import ───────────────────────────────────────────────────────────
+
+	// Server-side fetch + convert primitive used by the editor's
+	// "Insert from URL" modal. Side-effect-free — the server returns
+	// markdown plus metadata; the client decides whether to splice it
+	// into an item. See PLAN-1467 / TASK-1472 / internal/urlimport.
+	importURL: (url: string) =>
+		request<ImportURLResponse>('/import/url', {
+			method: 'POST',
+			body: JSON.stringify({ url })
+		}),
 
 	// ── Admin ────────────────────────────────────────────────────────────────
 

--- a/web/src/lib/components/editor/Editor.svelte
+++ b/web/src/lib/components/editor/Editor.svelte
@@ -336,6 +336,7 @@
 	import { BlockDragHandle } from './block-drag-handle';
 	import { HtmlBlock, captureHtmlBlockSnapshot, flipHtmlBlockToSource } from './extensions/htmlBlock';
 	import { SLASH_ITEMS } from './block-types';
+	import ImportFromUrlModal from './ImportFromUrlModal.svelte';
 	import {
 		AttachmentImage,
 		type AttachmentVariant,
@@ -413,6 +414,12 @@
 	let slashIdx = $state(0);
 	let slashStartPos = -1;
 
+	// "Insert from URL" modal — opened by the importUrl slash command
+	// (and any future toolbar entry). The modal owns its own working
+	// state; we just track open/closed here so the slash handler can
+	// trigger it. See PLAN-1467 / TASK-1473.
+	let importUrlModalOpen = $state(false);
+
 	// [[ link picker state
 	let linkOpen = $state(false);
 	let linkQuery = $state('');
@@ -464,6 +471,12 @@
 			case 'blockquote': c.toggleBlockquote().run(); break;
 			case 'horizontalRule': c.setHorizontalRule().run(); break;
 			case 'table': c.insertTable({ rows: 3, cols: 3, withHeaderRow: true }).run(); break;
+			case 'importUrl':
+				// Defocus by completing the slash deletion above, then
+				// pop the modal. The modal's Insert runs insertContent
+				// against the editor reference we hold in this scope.
+				importUrlModalOpen = true;
+				break;
 		}
 		closeSlash();
 	}
@@ -1068,6 +1081,8 @@
 		{/each}
 	</div>
 {/if}
+
+<ImportFromUrlModal bind:open={importUrlModalOpen} {editor} />
 
 <style>
 	.editor-wrapper {

--- a/web/src/lib/components/editor/EditorToolbar.svelte
+++ b/web/src/lib/components/editor/EditorToolbar.svelte
@@ -2,8 +2,20 @@
 	import type { Editor } from '@tiptap/core';
 	import { editorStore } from '$lib/stores/editor.svelte';
 	import { captureHtmlBlockSnapshot, flipHtmlBlockToSource } from './extensions/htmlBlock';
+	import ImportFromUrlModal from './ImportFromUrlModal.svelte';
+	import type { ImportURLResponse } from '$lib/api/client';
 
-	let { editor }: { editor: Editor | null } = $props();
+	type ImportInsertedHandler = (meta: ImportURLResponse) => void;
+
+	let {
+		editor,
+		onImportInserted
+	}: { editor: Editor | null; onImportInserted?: ImportInsertedHandler } = $props();
+
+	// Modal open state for "Insert from URL". Owned by the toolbar so the
+	// button stays self-contained; the parent can subscribe via
+	// onImportInserted to stamp source_url metadata on the item (TASK-1474).
+	let importModalOpen = $state(false);
 
 	function btn(label: string, action: () => void, isActive: boolean = false) {
 		return { label, action, isActive };
@@ -41,6 +53,10 @@
 				editor!.chain().focus().setHtmlBlock({ html: '' }).run();
 				flipHtmlBlockToSource(editor!, insertionPoint, before);
 			}, false),
+			// "Insert from URL" toolbar entry. Opens a modal that calls
+			// POST /api/v1/import/url and splices the resulting markdown
+			// at the cursor when the user confirms. See PLAN-1467.
+			btn('🌐', () => { importModalOpen = true; }, false),
 		]},
 	] : []);
 </script>
@@ -73,6 +89,8 @@
 			{editorStore.mode === 'raw' ? 'Rich' : 'Raw'}
 		</button>
 	</div>
+
+	<ImportFromUrlModal bind:open={importModalOpen} {editor} onInserted={onImportInserted} />
 {/if}
 
 <style>

--- a/web/src/lib/components/editor/EditorToolbar.svelte
+++ b/web/src/lib/components/editor/EditorToolbar.svelte
@@ -2,20 +2,8 @@
 	import type { Editor } from '@tiptap/core';
 	import { editorStore } from '$lib/stores/editor.svelte';
 	import { captureHtmlBlockSnapshot, flipHtmlBlockToSource } from './extensions/htmlBlock';
-	import ImportFromUrlModal from './ImportFromUrlModal.svelte';
-	import type { ImportURLResponse } from '$lib/api/client';
 
-	type ImportInsertedHandler = (meta: ImportURLResponse) => void;
-
-	let {
-		editor,
-		onImportInserted
-	}: { editor: Editor | null; onImportInserted?: ImportInsertedHandler } = $props();
-
-	// Modal open state for "Insert from URL". Owned by the toolbar so the
-	// button stays self-contained; the parent can subscribe via
-	// onImportInserted to stamp source_url metadata on the item (TASK-1474).
-	let importModalOpen = $state(false);
+	let { editor }: { editor: Editor | null } = $props();
 
 	function btn(label: string, action: () => void, isActive: boolean = false) {
 		return { label, action, isActive };
@@ -53,10 +41,6 @@
 				editor!.chain().focus().setHtmlBlock({ html: '' }).run();
 				flipHtmlBlockToSource(editor!, insertionPoint, before);
 			}, false),
-			// "Insert from URL" toolbar entry. Opens a modal that calls
-			// POST /api/v1/import/url and splices the resulting markdown
-			// at the cursor when the user confirms. See PLAN-1467.
-			btn('🌐', () => { importModalOpen = true; }, false),
 		]},
 	] : []);
 </script>
@@ -89,8 +73,6 @@
 			{editorStore.mode === 'raw' ? 'Rich' : 'Raw'}
 		</button>
 	</div>
-
-	<ImportFromUrlModal bind:open={importModalOpen} {editor} onInserted={onImportInserted} />
 {/if}
 
 <style>

--- a/web/src/lib/components/editor/ImportFromUrlModal.svelte
+++ b/web/src/lib/components/editor/ImportFromUrlModal.svelte
@@ -19,12 +19,22 @@
 	let errorMessage = $state('');
 	let result = $state<ImportURLResponse | null>(null);
 
+	// Monotonic request counter. handleFetch() captures the current value
+	// before await and ignores the response if `requestGen` has advanced
+	// past it — happens when the user closes the modal (which bumps the
+	// counter via the open effect on next reopen) OR triggers another
+	// fetch (which bumps it directly). Without this guard, a slow request
+	// can land on a freshly reopened modal and clobber its empty state.
+	let requestGen = 0;
+
 	$effect(() => {
 		if (open) {
 			url = '';
 			isLoading = false;
 			errorMessage = '';
 			result = null;
+			// Invalidate any in-flight request from the previous session.
+			requestGen += 1;
 		}
 	});
 
@@ -55,14 +65,21 @@
 			return;
 		}
 
+		// Bump the generation BEFORE the await and capture our value;
+		// any in-flight earlier fetch is now stale.
+		const myGen = ++requestGen;
 		isLoading = true;
 		try {
 			const resp = await api.importURL(trimmed);
+			if (myGen !== requestGen) return; // superseded — drop response
 			result = resp;
 		} catch (err) {
+			if (myGen !== requestGen) return; // superseded — drop error
 			errorMessage = err instanceof Error ? err.message : 'Failed to fetch URL.';
 		} finally {
-			isLoading = false;
+			if (myGen === requestGen) {
+				isLoading = false;
+			}
 		}
 	}
 
@@ -82,6 +99,9 @@
 	}
 
 	function handleCancel() {
+		// Bump the generation so any in-flight fetch's response is
+		// discarded before the next open() resets state.
+		requestGen += 1;
 		open = false;
 	}
 </script>

--- a/web/src/lib/components/editor/ImportFromUrlModal.svelte
+++ b/web/src/lib/components/editor/ImportFromUrlModal.svelte
@@ -1,0 +1,317 @@
+<script lang="ts">
+	import type { Editor } from '@tiptap/core';
+	import { marked } from 'marked';
+	import { api, type ImportURLResponse } from '$lib/api/client';
+	import { toastStore } from '$lib/stores/toast.svelte';
+
+	interface Props {
+		open: boolean;
+		editor: Editor | null;
+		onInserted?: (meta: ImportURLResponse) => void;
+	}
+
+	let { open = $bindable(), editor, onInserted }: Props = $props();
+
+	// Working state for the modal. Reset when `open` transitions to true
+	// so a re-opened modal starts fresh.
+	let url = $state('');
+	let isLoading = $state(false);
+	let errorMessage = $state('');
+	let result = $state<ImportURLResponse | null>(null);
+
+	$effect(() => {
+		if (open) {
+			url = '';
+			isLoading = false;
+			errorMessage = '';
+			result = null;
+		}
+	});
+
+	function handleKeydown(e: KeyboardEvent) {
+		if (open && e.key === 'Escape') {
+			open = false;
+		}
+	}
+
+	async function handleFetch() {
+		errorMessage = '';
+		result = null;
+		const trimmed = url.trim();
+		if (!trimmed) {
+			errorMessage = 'Enter a URL.';
+			return;
+		}
+		// Light client-side validation so obvious mistakes don't hit the
+		// server. The server's SSRF + scheme guard is canonical.
+		try {
+			const parsed = new URL(trimmed);
+			if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+				errorMessage = 'Only http(s) URLs are supported.';
+				return;
+			}
+		} catch {
+			errorMessage = 'That doesn’t look like a valid URL.';
+			return;
+		}
+
+		isLoading = true;
+		try {
+			const resp = await api.importURL(trimmed);
+			result = resp;
+		} catch (err) {
+			errorMessage = err instanceof Error ? err.message : 'Failed to fetch URL.';
+		} finally {
+			isLoading = false;
+		}
+	}
+
+	function handleInsert() {
+		if (!result || !editor) return;
+		// The editor's tiptap-markdown extension handles paste-time
+		// markdown decoding but `insertContent` accepts HTML directly,
+		// so we convert markdown → HTML with `marked` (the project's
+		// existing markdown renderer) and let TipTap parse the HTML
+		// into ProseMirror nodes. This is the same shape the editor
+		// uses on initial setContent, so structural fidelity is high.
+		const html = marked.parse(result.markdown, { async: false }) as string;
+		editor.chain().focus().insertContent(html).run();
+		onInserted?.(result);
+		toastStore.show(`Imported from ${result.source_url}`, 'success');
+		open = false;
+	}
+
+	function handleCancel() {
+		open = false;
+	}
+</script>
+
+<svelte:window onkeydown={handleKeydown} />
+
+{#if open}
+	<!-- svelte-ignore a11y_click_events_have_key_events -->
+	<!-- svelte-ignore a11y_no_static_element_interactions -->
+	<div class="overlay" onclick={handleCancel}>
+		<div class="modal" onclick={(e) => e.stopPropagation()}>
+			<div class="modal-header">
+				<h2>Insert from URL</h2>
+				<button class="close-btn" type="button" onclick={handleCancel}>&#10005;</button>
+			</div>
+
+			<div class="modal-body">
+				<p class="intro-copy">
+					Paste a URL. Pad fetches the page server-side and converts the readable
+					content (or OpenAPI spec) to markdown. Nothing is saved until you click
+					<strong>Insert</strong>.
+				</p>
+
+				<form
+					class="url-row"
+					onsubmit={(e) => {
+						e.preventDefault();
+						handleFetch();
+					}}
+				>
+					<!-- A modal opened from a deliberate click sets focus to its
+						 primary input as expected behavior. Autofocus is the
+						 simplest way to deliver that; the a11y warning's broader
+						 concern (autofocus on page load) doesn't apply here
+						 because the user actively triggered the modal. -->
+					<!-- svelte-ignore a11y_autofocus -->
+					<input
+						type="url"
+						placeholder="https://example.com/docs/page"
+						bind:value={url}
+						disabled={isLoading}
+						autofocus
+					/>
+					<button type="submit" class="btn primary" disabled={isLoading || !url.trim()}>
+						{isLoading ? 'Fetching…' : 'Fetch'}
+					</button>
+				</form>
+
+				{#if errorMessage}
+					<div class="error" role="alert">{errorMessage}</div>
+				{/if}
+
+				{#if result}
+					<div class="result">
+						<div class="result-meta">
+							<span class="type-tag" class:openapi={result.detected_type === 'openapi'}>
+								{result.detected_type === 'openapi' ? 'OpenAPI' : 'Generic'}
+							</span>
+							{#if result.title}
+								<span class="title">{result.title}</span>
+							{/if}
+							<span class="source">{result.source_url}</span>
+						</div>
+						<pre class="preview">{result.markdown}</pre>
+					</div>
+				{/if}
+			</div>
+
+			<div class="modal-footer">
+				<button type="button" class="btn" onclick={handleCancel}>Cancel</button>
+				<button
+					type="button"
+					class="btn primary"
+					disabled={!result || isLoading}
+					onclick={handleInsert}
+				>
+					Insert at cursor
+				</button>
+			</div>
+		</div>
+	</div>
+{/if}
+
+<style>
+	.overlay {
+		position: fixed;
+		inset: 0;
+		background: rgba(0, 0, 0, 0.5);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		z-index: 1000;
+	}
+	.modal {
+		background: var(--bg-primary);
+		border-radius: var(--radius);
+		box-shadow: 0 16px 48px rgba(0, 0, 0, 0.4);
+		width: min(720px, 95vw);
+		max-height: 90vh;
+		display: flex;
+		flex-direction: column;
+	}
+	.modal-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: var(--space-4);
+		border-bottom: 1px solid var(--border);
+	}
+	.modal-header h2 {
+		margin: 0;
+		font-size: 1.1rem;
+	}
+	.close-btn {
+		background: transparent;
+		border: none;
+		font-size: 1.1rem;
+		color: var(--text-secondary);
+		cursor: pointer;
+	}
+	.modal-body {
+		padding: var(--space-4);
+		overflow-y: auto;
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-3);
+	}
+	.intro-copy {
+		color: var(--text-secondary);
+		margin: 0;
+		font-size: 0.9rem;
+		line-height: 1.5;
+	}
+	.url-row {
+		display: flex;
+		gap: var(--space-2);
+	}
+	.url-row input {
+		flex: 1;
+		padding: var(--space-2) var(--space-3);
+		border: 1px solid var(--border);
+		border-radius: var(--radius-sm);
+		font: inherit;
+		color: var(--text-primary);
+		background: var(--bg-secondary);
+	}
+	.url-row input:focus {
+		outline: 2px solid var(--accent);
+		outline-offset: -1px;
+	}
+	.btn {
+		padding: var(--space-2) var(--space-3);
+		border: 1px solid var(--border);
+		background: var(--bg-secondary);
+		border-radius: var(--radius-sm);
+		font: inherit;
+		color: var(--text-primary);
+		cursor: pointer;
+	}
+	.btn.primary {
+		background: var(--accent);
+		color: var(--bg-primary);
+		border-color: var(--accent);
+	}
+	.btn:disabled {
+		opacity: 0.55;
+		cursor: not-allowed;
+	}
+	.error {
+		color: var(--error, #b91c1c);
+		font-size: 0.9rem;
+		background: color-mix(in srgb, var(--error, #b91c1c) 10%, transparent);
+		padding: var(--space-2) var(--space-3);
+		border-radius: var(--radius-sm);
+	}
+	.result {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-2);
+	}
+	.result-meta {
+		display: flex;
+		gap: var(--space-2);
+		align-items: center;
+		font-size: 0.85rem;
+		color: var(--text-secondary);
+		flex-wrap: wrap;
+	}
+	.type-tag {
+		padding: 2px 8px;
+		border-radius: 999px;
+		background: var(--bg-secondary);
+		font-weight: 600;
+		font-size: 0.75rem;
+		color: var(--text-primary);
+	}
+	.type-tag.openapi {
+		background: color-mix(in srgb, var(--accent) 25%, var(--bg-secondary));
+		color: var(--text-primary);
+	}
+	.title {
+		font-weight: 600;
+		color: var(--text-primary);
+	}
+	.source {
+		font-family: var(--font-mono, monospace);
+		font-size: 0.78rem;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		max-width: 100%;
+	}
+	.preview {
+		background: var(--bg-secondary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius-sm);
+		padding: var(--space-3);
+		font-family: var(--font-mono, monospace);
+		font-size: 0.85rem;
+		line-height: 1.5;
+		max-height: 360px;
+		overflow: auto;
+		white-space: pre-wrap;
+		margin: 0;
+	}
+	.modal-footer {
+		display: flex;
+		justify-content: flex-end;
+		gap: var(--space-2);
+		padding: var(--space-3) var(--space-4);
+		border-top: 1px solid var(--border);
+	}
+</style>

--- a/web/src/lib/components/editor/block-types.ts
+++ b/web/src/lib/components/editor/block-types.ts
@@ -34,6 +34,7 @@ export const BLOCK_TYPES: BlockType[] = [
 	{ id: 'blockquote', icon: '❝', label: 'Blockquote', description: 'Quote block', keywords: ['quote', 'bq'] },
 	{ id: 'horizontalRule', icon: '——', label: 'Divider', description: 'Horizontal rule', insertOnly: true, keywords: ['hr', 'rule', 'separator'] },
 	{ id: 'table', icon: '⊞', label: 'Table', description: '3×3 table', insertOnly: true, keywords: ['tbl', 'grid'] },
+	{ id: 'importUrl', icon: '🌐', label: 'Insert from URL', description: 'Fetch a page and convert to markdown', insertOnly: true, keywords: ['url', 'fetch', 'import', 'web', 'page', 'openapi'] },
 ];
 
 /** Block types available in the slash command menu (excludes convert-only types like "Text") */


### PR DESCRIPTION
## Summary
- New \`ImportFromUrlModal.svelte\` — URL input → fetch → preview pane (detected-type tag + title + source URL) → Insert at cursor.
- 🌐 button added to the editor toolbar's blocks group; opens the modal.
- \`api.importURL()\` + \`ImportURLResponse\` type added to \`lib/api/client.ts\`.
- Insert converts markdown → HTML via the project's existing \`marked\` renderer (same shape the editor uses on load) and calls \`editor.commands.insertContent(html)\`.

## UX
- Focus lands in the URL input on open (a11y warning suppressed inline; modal is user-triggered).
- ESC and backdrop click close the modal.
- Light client-side URL parse + scheme check before hitting the server; canonical SSRF guard is server-side.
- Toast on successful insert.
- Optional \`onImportInserted\` callback bubbles the server response to the parent so TASK-1474 can stamp source_url / imported_at into item fields.

## Context
Fifth slice of \`PLAN-1467\`. Implements \`TASK-1473\`. Consumes the endpoint shipped in \`TASK-1472\`.

## Test plan
- [x] \`cd web && npm run build\` — clean
- [x] \`cd web && npm run check\` — 0 errors (pre-existing warnings unchanged)
- [x] \`go test ./...\` — all packages green (Go untouched but verified for regression)
- [x] \`golangci-lint run\` — 0 issues