### PR TITLE
feat(web): source_url ghost-field + Refresh from source affordance (TASK-1474)

### DIFF
--- a/web/src/lib/components/collections/field-editor-types.ts
+++ b/web/src/lib/components/collections/field-editor-types.ts
@@ -72,9 +72,16 @@ export const FIELD_TYPES: FieldDef['type'][] = [
 
 /**
  * Keys reserved at the UI level because they would shadow top-level item
- * JSON fields and cause confusion in API responses / rendering.
+ * JSON fields or collide with internal provenance metadata.
  * The backend does not explicitly reject these, but using them as schema
  * field keys is strongly discouraged.
+ *
+ * The `pad_` prefix is the canonical namespace for internal orphan keys
+ * (Pad-managed metadata that lives inside the per-item `fields` JSON
+ * without a corresponding schema declaration). Reserving the prefix here
+ * prevents a user-defined "Pad Source URL" field from generating the
+ * same key as TASK-1474's import provenance and triggering the
+ * destructive "Refresh from source" chip on ordinary data.
  */
 export const RESERVED_FIELD_KEYS: ReadonlySet<string> = new Set([
 	'id',
@@ -95,8 +102,20 @@ export const RESERVED_FIELD_KEYS: ReadonlySet<string> = new Set([
 	'fields',
 	'item_number',
 	'workspace_id',
-	'collection_id'
+	'collection_id',
+	// Internal orphan-key namespace (PLAN-1467 / TASK-1474). All keys
+	// stamped by Pad into fields JSON should sit under this prefix.
+	'pad_source_url',
+	'pad_imported_at'
 ]);
+
+/**
+ * Reserved prefix for internal orphan keys. Field-key validation should
+ * reject any user-defined key that starts with this string so future
+ * Pad-managed metadata (TASK-1474 plus anything that comes later) can
+ * land without retroactively breaking existing collections.
+ */
+export const RESERVED_FIELD_KEY_PREFIX = 'pad_';
 
 /** Maximum length of a slugified key. */
 export const MAX_FIELD_KEY_LENGTH = 40;
@@ -133,9 +152,18 @@ export function slugifyKey(input: string): string {
  */
 export function validateFieldKey(key: string): string | null {
 	const trimmed = key.trim();
+	const lower = trimmed.toLowerCase();
 	if (!trimmed) return 'Key is required';
-	if (RESERVED_FIELD_KEYS.has(trimmed.toLowerCase())) {
+	if (RESERVED_FIELD_KEYS.has(lower)) {
 		return `"${trimmed}" is a reserved key`;
+	}
+	// Anything under the `pad_` prefix is reserved for internal orphan
+	// metadata (PLAN-1467 introduced pad_source_url + pad_imported_at;
+	// future Pad-managed metadata lands here too). Without this gate a
+	// user labelling a field "Pad Source URL" would auto-generate
+	// `pad_source_url` and shadow the import-provenance keys.
+	if (lower.startsWith(RESERVED_FIELD_KEY_PREFIX)) {
+		return `Keys starting with "${RESERVED_FIELD_KEY_PREFIX}" are reserved for internal metadata`;
 	}
 	if (!/^[a-z][a-z0-9_]*$/.test(trimmed)) {
 		return 'Key must start with a letter and contain only lowercase letters, digits, and underscores';

--- a/web/src/lib/components/editor/Editor.svelte
+++ b/web/src/lib/components/editor/Editor.svelte
@@ -337,6 +337,7 @@
 	import { HtmlBlock, captureHtmlBlockSnapshot, flipHtmlBlockToSource } from './extensions/htmlBlock';
 	import { SLASH_ITEMS } from './block-types';
 	import ImportFromUrlModal from './ImportFromUrlModal.svelte';
+	import type { ImportURLResponse } from '$lib/api/client';
 	import {
 		AttachmentImage,
 		type AttachmentVariant,
@@ -353,6 +354,7 @@
 		collabUser,
 		onUpdate,
 		onEditor,
+		onImportInserted,
 	}: {
 		content?: string;
 		editable?: boolean;
@@ -394,6 +396,15 @@
 		collabUser?: { name: string; color: string };
 		onUpdate?: (markdown: string) => void;
 		onEditor?: (editor: Editor) => void;
+		/**
+		 * Fired after the Insert-from-URL modal splices content into
+		 * the editor. The host page uses this to stamp source_url +
+		 * imported_at into the item's fields when the item has no
+		 * source_url yet (TASK-1474). Optional — view-only / share-
+		 * page mounts never trigger this since the modal is gated on
+		 * a writable editor.
+		 */
+		onImportInserted?: (meta: ImportURLResponse) => void;
 	} = $props();
 
 	let element = $state<HTMLDivElement>();
@@ -1082,7 +1093,7 @@
 	</div>
 {/if}
 
-<ImportFromUrlModal bind:open={importUrlModalOpen} {editor} />
+<ImportFromUrlModal bind:open={importUrlModalOpen} {editor} onInserted={onImportInserted} />
 
 <style>
 	.editor-wrapper {

--- a/web/src/lib/components/editor/Editor.svelte
+++ b/web/src/lib/components/editor/Editor.svelte
@@ -336,7 +336,7 @@
 	import { BlockDragHandle } from './block-drag-handle';
 	import { HtmlBlock, captureHtmlBlockSnapshot, flipHtmlBlockToSource } from './extensions/htmlBlock';
 	import { SLASH_ITEMS } from './block-types';
-	import ImportFromUrlModal from './ImportFromUrlModal.svelte';
+	import ImportFromUrlModal, { type InsertContext } from './ImportFromUrlModal.svelte';
 	import type { ImportURLResponse } from '$lib/api/client';
 	import {
 		AttachmentImage,
@@ -404,7 +404,7 @@
 		 * page mounts never trigger this since the modal is gated on
 		 * a writable editor.
 		 */
-		onImportInserted?: (meta: ImportURLResponse) => void;
+		onImportInserted?: (meta: ImportURLResponse, ctx: InsertContext) => void;
 	} = $props();
 
 	let element = $state<HTMLDivElement>();

--- a/web/src/lib/components/editor/ImportFromUrlModal.svelte
+++ b/web/src/lib/components/editor/ImportFromUrlModal.svelte
@@ -4,10 +4,20 @@
 	import { api, type ImportURLResponse } from '$lib/api/client';
 	import { toastStore } from '$lib/stores/toast.svelte';
 
+	// Context the modal observes about the editor at the moment of
+	// insert. `wasEmpty` mirrors editor.isEmpty BEFORE we splice in
+	// the imported markdown — the page uses this to decide whether
+	// to stamp source_url (PLAN-1467 rule: only on a previously-empty
+	// item). Reading editor.isEmpty post-insert would always return
+	// false because we just added content.
+	export interface InsertContext {
+		wasEmpty: boolean;
+	}
+
 	interface Props {
 		open: boolean;
 		editor: Editor | null;
-		onInserted?: (meta: ImportURLResponse) => void;
+		onInserted?: (meta: ImportURLResponse, ctx: InsertContext) => void;
 	}
 
 	let { open = $bindable(), editor, onInserted }: Props = $props();
@@ -85,6 +95,13 @@
 
 	function handleInsert() {
 		if (!result || !editor) return;
+		// Snapshot the editor's live emptiness BEFORE the insert. Under
+		// collab the ProseMirror doc reflects the authoritative Y.Doc
+		// state, which can include user-typed content that hasn't yet
+		// been flushed to item.content (the page's database snapshot).
+		// Capturing here gives the host page a reliable "was this a
+		// blank canvas?" signal for its source_url stamping rule.
+		const wasEmpty = editor.isEmpty;
 		// The editor's tiptap-markdown extension handles paste-time
 		// markdown decoding but `insertContent` accepts HTML directly,
 		// so we convert markdown → HTML with `marked` (the project's
@@ -93,7 +110,7 @@
 		// uses on initial setContent, so structural fidelity is high.
 		const html = marked.parse(result.markdown, { async: false }) as string;
 		editor.chain().focus().insertContent(html).run();
-		onInserted?.(result);
+		onInserted?.(result, { wasEmpty });
 		toastStore.show(`Imported from ${result.source_url}`, 'success');
 		open = false;
 	}

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -1058,21 +1058,38 @@
 	// collection schema — `internal/items/validate.go` only iterates
 	// declared fields, so unknown keys round-trip through PATCH without
 	// migration. See PLAN-1467's ghost-field design.
+	//
+	// Item identity is captured before the await so a navigation
+	// during the in-flight PATCH cannot stamp the WRONG item with
+	// the source URL: the assignment to `item` is gated on the
+	// page still showing the same item we started with.
 	async function stampSourceUrl(meta: ImportURLResponse) {
 		if (!item) return;
+		const targetItem = item;
+		const targetWs = wsSlug;
 		const updated = {
 			...fields,
 			source_url: meta.source_url,
 			imported_at: meta.fetched_at
 		};
 		try {
-			item = await api.items.update(wsSlug, item.id, { fields: JSON.stringify(updated) });
+			const fresh = await api.items.update(targetWs, targetItem.id, {
+				fields: JSON.stringify(updated)
+			});
+			if (item && item.id === targetItem.id) {
+				item = fresh;
+			}
 		} catch (err) {
 			// Non-fatal: the content was inserted regardless of whether
 			// the stamping succeeded. Toast so the user knows the
 			// "Refresh from source" affordance won't be available.
 			console.warn('failed to stamp source_url', err);
-			toastStore.show('Imported, but source_url not saved — refresh affordance disabled', 'error');
+			if (item && item.id === targetItem.id) {
+				toastStore.show(
+					'Imported, but source_url not saved — refresh affordance disabled',
+					'error'
+				);
+			}
 		}
 	}
 
@@ -1099,6 +1116,14 @@
 	async function refreshFromSource() {
 		const url = fields.source_url;
 		if (!url || typeof url !== 'string' || !item || !editorInstance) return;
+		// Capture the item + editor instance before any awaits. A user
+		// who confirms the refresh and then navigates to another item
+		// before the fetch returns would otherwise have their NEW item
+		// clobbered with the OLD item's source content. After each
+		// await we re-check the captured values match the live state
+		// and bail if not. (Per Codex review round 2.)
+		const targetItem = item;
+		const targetEditor = editorInstance;
 		const ok = typeof window !== 'undefined' &&
 			window.confirm(
 				`Replace the current content with a fresh fetch from:\n${url}\n\n` +
@@ -1108,11 +1133,17 @@
 		refreshing = true;
 		try {
 			const resp = await api.importURL(url);
+			// Bail if the user navigated to a different item — applying
+			// the refresh now would target the wrong document AND stamp
+			// the wrong source URL.
+			if (!item || item.id !== targetItem.id || editorInstance !== targetEditor) {
+				return;
+			}
 			const html = marked.parse(resp.markdown, { async: false }) as string;
 			// Replace the entire document: select all, delete, insert.
 			// Under collab the Y.Doc tracks each transaction so peers
 			// converge on the new state.
-			editorInstance
+			targetEditor
 				.chain()
 				.focus()
 				.selectAll()
@@ -1121,12 +1152,21 @@
 				.run();
 			// Bump imported_at and refresh source_url in case it
 			// resolved through a different final URL on this fetch.
+			// stampSourceUrl's own guard re-checks identity.
 			await stampSourceUrl(resp);
-			toastStore.show('Refreshed from source', 'success');
+			if (item && item.id === targetItem.id) {
+				toastStore.show('Refreshed from source', 'success');
+			}
 		} catch (err) {
-			toastStore.show(err instanceof Error ? err.message : 'Refresh failed', 'error');
+			if (item && item.id === targetItem.id) {
+				toastStore.show(err instanceof Error ? err.message : 'Refresh failed', 'error');
+			}
 		} finally {
-			refreshing = false;
+			// Only clear the spinner if the user is still on this item.
+			// On navigation the new item's state owns its own UI.
+			if (item && item.id === targetItem.id) {
+				refreshing = false;
+			}
 		}
 	}
 

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -1162,11 +1162,15 @@
 				toastStore.show(err instanceof Error ? err.message : 'Refresh failed', 'error');
 			}
 		} finally {
-			// Only clear the spinner if the user is still on this item.
-			// On navigation the new item's state owns its own UI.
-			if (item && item.id === targetItem.id) {
-				refreshing = false;
-			}
+			// Always clear the spinner. The page component is reused
+			// across item navigation, so leaving `refreshing = true`
+			// when the user navigates away would re-emerge as a stuck
+			// "Refreshing…" label the next time they open ANY item
+			// with a source_url. The visual feedback is per-item only
+			// while the user stays on the originating item; that's
+			// acceptable — a successful navigation already signals
+			// "user moved on". (Per Codex review round 3.)
+			refreshing = false;
 		}
 	}
 

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -1053,11 +1053,27 @@
 		}
 	}
 
-	// stampSourceUrl writes the source_url + imported_at orphan keys
-	// into the item's `fields` JSON. The keys aren't declared in any
-	// collection schema — `internal/items/validate.go` only iterates
+	// stampSourceUrl writes the pad_source_url + pad_imported_at orphan
+	// keys into the item's `fields` JSON. The keys aren't declared in
+	// any collection schema — `internal/items/validate.go` only iterates
 	// declared fields, so unknown keys round-trip through PATCH without
 	// migration. See PLAN-1467's ghost-field design.
+	//
+	// Keys are namespaced with the `pad_` prefix so they cannot collide
+	// with a user-defined `source_url` field — without the prefix, an
+	// existing collection with that key in its schema would conflict
+	// both at validate time and at chip-render time. (Per Codex review
+	// round 5 finding #2.)
+	//
+	// Race mitigation: a concurrent updateField call to the same item
+	// would, in the legacy pattern, race against our PATCH because both
+	// send the FULL fields blob. To minimize the window we re-fetch the
+	// item right before the PATCH and merge our keys onto the freshest
+	// server snapshot. The window is still non-zero (between fetch and
+	// patch-land), and the same race exists in the project's existing
+	// updateField path — IDEA-1480 tracks a server-side partial-fields
+	// update that would close it system-wide. (Per Codex review round 5
+	// finding #1.)
 	//
 	// Item identity is captured before the await so a navigation
 	// during the in-flight PATCH cannot stamp the WRONG item with
@@ -1067,14 +1083,20 @@
 		if (!item) return;
 		const targetItem = item;
 		const targetWs = wsSlug;
-		const updated = {
-			...fields,
-			source_url: meta.source_url,
-			imported_at: meta.fetched_at
-		};
 		try {
+			// Re-fetch to get the latest fields snapshot from the server,
+			// then merge our two keys. This narrows but does not fully
+			// close the race against concurrent field edits.
+			const latest = await api.items.get(targetWs, targetItem.id);
+			if (!item || item.id !== targetItem.id) return;
+			const latestFields = parseFields(latest);
+			const merged = {
+				...latestFields,
+				pad_source_url: meta.source_url,
+				pad_imported_at: meta.fetched_at
+			};
 			const fresh = await api.items.update(targetWs, targetItem.id, {
-				fields: JSON.stringify(updated)
+				fields: JSON.stringify(merged)
 			});
 			if (item && item.id === targetItem.id) {
 				item = fresh;
@@ -1106,7 +1128,8 @@
 	// Codex review round 4.
 	function handleImportInserted(meta: ImportURLResponse, ctx: { wasEmpty: boolean }) {
 		if (!item) return;
-		const alreadyStamped = typeof fields.source_url === 'string' && fields.source_url.length > 0;
+		const alreadyStamped =
+			typeof fields.pad_source_url === 'string' && fields.pad_source_url.length > 0;
 		if (!ctx.wasEmpty || alreadyStamped) return;
 		void stampSourceUrl(meta);
 	}
@@ -1119,7 +1142,7 @@
 	// the Yjs op-log provides recoverable history.
 	let refreshing = $state(false);
 	async function refreshFromSource() {
-		const url = fields.source_url;
+		const url = fields.pad_source_url;
 		if (!url || typeof url !== 'string' || !item || !editorInstance) return;
 		// Capture the item + editor instance before any awaits. A user
 		// who confirms the refresh and then navigates to another item
@@ -1948,28 +1971,32 @@
 				<!-- Read-only title (PLAN-1100 / TASK-1105) — no click-to-edit. -->
 				<h1 class="title title-readonly">{item.title}</h1>
 			{/if}
-			{#if typeof fields.source_url === 'string' && fields.source_url}
+			{#if typeof fields.pad_source_url === 'string' && fields.pad_source_url}
 				<!--
 					"Refresh from source" chip — visible only when the item
 					was created via "Insert from URL" and the modal stamped
-					source_url into fields. Click re-fetches and replaces
-					editor content; the editor's Yjs op-log handles undo.
+					pad_source_url into fields. The `pad_` prefix namespaces
+					the ghost-field keys away from any user-defined
+					`source_url` column on the collection schema (per Codex
+					review round 5 finding #2).
 
-					Hidden for view-only users (no canEdit) — refresh is a
-					content-replacing action that requires write access.
-					Also hidden in raw-markdown mode: the rich Editor is
-					unmounted there and refreshFromSource() drives content
-					replacement through the Tiptap editor instance, which
-					would either fail or update the off-screen rich editor.
-					Read-only / raw users see the provenance chip without
-					the Refresh button so the import history is still
+					Click re-fetches and replaces editor content; the
+					editor's Yjs op-log handles undo. Hidden for view-only
+					users (no canEdit) — refresh is a content-replacing
+					action that requires write access. Also hidden in
+					raw-markdown mode: the rich Editor is unmounted there
+					and refreshFromSource() drives content replacement
+					through the Tiptap editor instance, which would either
+					fail or update the off-screen rich editor. Read-only
+					and raw users see the provenance chip without the
+					Refresh button so the import history is still
 					discoverable. (Per Codex review round 1.)
 				-->
 				{#if canEdit && !rawMode}
 					<button
 						type="button"
 						class="source-chip"
-						title={`Source: ${fields.source_url}${fields.imported_at ? `\nImported: ${fields.imported_at}` : ''}`}
+						title={`Source: ${fields.pad_source_url}${fields.pad_imported_at ? `\nImported: ${fields.pad_imported_at}` : ''}`}
 						disabled={refreshing}
 						onclick={refreshFromSource}
 					>
@@ -1979,7 +2006,7 @@
 						</span>
 					</button>
 				{:else}
-					<span class="source-chip source-chip-readonly" title={fields.source_url}>
+					<span class="source-chip source-chip-readonly" title={fields.pad_source_url}>
 						<span class="source-chip-icon" aria-hidden="true">🌐</span>
 						<span class="source-chip-label">Imported from URL</span>
 					</span>

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -1096,13 +1096,18 @@
 	// handleImportInserted runs after the modal splices markdown into
 	// the editor. Per PLAN-1467 we only stamp source_url when (a) the
 	// item had no prior content and (b) source_url is not already set.
-	// Both checks are cheap and avoid clobbering an existing import
-	// the user has since iterated on.
-	function handleImportInserted(meta: ImportURLResponse) {
+	//
+	// `ctx.wasEmpty` comes from the modal which captured editor.isEmpty
+	// BEFORE inserting. Under collab the editor reflects the
+	// authoritative Y.Doc — which can hold user edits that haven't yet
+	// been flushed to item.content (the database snapshot). Checking
+	// item.content here would let a mixed/manual document be stamped
+	// as source-backed if it happened to not have synced yet. Per
+	// Codex review round 4.
+	function handleImportInserted(meta: ImportURLResponse, ctx: { wasEmpty: boolean }) {
 		if (!item) return;
-		const hadPriorContent = (item.content ?? '').trim() !== '';
 		const alreadyStamped = typeof fields.source_url === 'string' && fields.source_url.length > 0;
-		if (hadPriorContent || alreadyStamped) return;
+		if (!ctx.wasEmpty || alreadyStamped) return;
 		void stampSourceUrl(meta);
 	}
 

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
 	import { page } from '$app/state';
 	import { tick, onMount, onDestroy } from 'svelte';
-	import { api } from '$lib/api/client';
+	import { api, type ImportURLResponse } from '$lib/api/client';
+	import { marked } from 'marked';
 	import { collectionStore } from '$lib/stores/collections.svelte';
 	import { syncService } from '$lib/services/sync.svelte';
 	import { sseService } from '$lib/services/sse.svelte';
@@ -1052,6 +1053,83 @@
 		}
 	}
 
+	// stampSourceUrl writes the source_url + imported_at orphan keys
+	// into the item's `fields` JSON. The keys aren't declared in any
+	// collection schema — `internal/items/validate.go` only iterates
+	// declared fields, so unknown keys round-trip through PATCH without
+	// migration. See PLAN-1467's ghost-field design.
+	async function stampSourceUrl(meta: ImportURLResponse) {
+		if (!item) return;
+		const updated = {
+			...fields,
+			source_url: meta.source_url,
+			imported_at: meta.fetched_at
+		};
+		try {
+			item = await api.items.update(wsSlug, item.id, { fields: JSON.stringify(updated) });
+		} catch (err) {
+			// Non-fatal: the content was inserted regardless of whether
+			// the stamping succeeded. Toast so the user knows the
+			// "Refresh from source" affordance won't be available.
+			console.warn('failed to stamp source_url', err);
+			toastStore.show('Imported, but source_url not saved — refresh affordance disabled', 'error');
+		}
+	}
+
+	// handleImportInserted runs after the modal splices markdown into
+	// the editor. Per PLAN-1467 we only stamp source_url when (a) the
+	// item had no prior content and (b) source_url is not already set.
+	// Both checks are cheap and avoid clobbering an existing import
+	// the user has since iterated on.
+	function handleImportInserted(meta: ImportURLResponse) {
+		if (!item) return;
+		const hadPriorContent = (item.content ?? '').trim() !== '';
+		const alreadyStamped = typeof fields.source_url === 'string' && fields.source_url.length > 0;
+		if (hadPriorContent || alreadyStamped) return;
+		void stampSourceUrl(meta);
+	}
+
+	// "Refresh from source" affordance. Re-fetches the source URL,
+	// asks the user to confirm (the action is destructive — it
+	// replaces the editor's content), then runs the same insert
+	// pipeline as the modal: marked → HTML → editor.insertContent.
+	// Diff-preview is intentionally deferred (see PLAN-1467 risks);
+	// the Yjs op-log provides recoverable history.
+	let refreshing = $state(false);
+	async function refreshFromSource() {
+		const url = fields.source_url;
+		if (!url || typeof url !== 'string' || !item || !editorInstance) return;
+		const ok = typeof window !== 'undefined' &&
+			window.confirm(
+				`Replace the current content with a fresh fetch from:\n${url}\n\n` +
+				'Your existing content will be replaced. Undo is available via the editor history.'
+			);
+		if (!ok) return;
+		refreshing = true;
+		try {
+			const resp = await api.importURL(url);
+			const html = marked.parse(resp.markdown, { async: false }) as string;
+			// Replace the entire document: select all, delete, insert.
+			// Under collab the Y.Doc tracks each transaction so peers
+			// converge on the new state.
+			editorInstance
+				.chain()
+				.focus()
+				.selectAll()
+				.deleteSelection()
+				.insertContent(html)
+				.run();
+			// Bump imported_at and refresh source_url in case it
+			// resolved through a different final URL on this fetch.
+			await stampSourceUrl(resp);
+			toastStore.show('Refreshed from source', 'success');
+		} catch (err) {
+			toastStore.show(err instanceof Error ? err.message : 'Refresh failed', 'error');
+		} finally {
+			refreshing = false;
+		}
+	}
+
 	async function updateAssignedUser(userId: string | null) {
 		if (!item) return;
 		saveStatus = 'saving';
@@ -1821,6 +1899,35 @@
 				<!-- Read-only title (PLAN-1100 / TASK-1105) — no click-to-edit. -->
 				<h1 class="title title-readonly">{item.title}</h1>
 			{/if}
+			{#if typeof fields.source_url === 'string' && fields.source_url}
+				<!--
+					"Refresh from source" chip — visible only when the item
+					was created via "Insert from URL" and the modal stamped
+					source_url into fields. Click re-fetches and replaces
+					editor content; the editor's Yjs op-log handles undo.
+					Hidden for view-only users (no canEdit) — refresh is a
+					content-replacing action that requires write access.
+				-->
+				{#if canEdit}
+					<button
+						type="button"
+						class="source-chip"
+						title={`Source: ${fields.source_url}${fields.imported_at ? `\nImported: ${fields.imported_at}` : ''}`}
+						disabled={refreshing}
+						onclick={refreshFromSource}
+					>
+						<span class="source-chip-icon" aria-hidden="true">🌐</span>
+						<span class="source-chip-label">
+							{refreshing ? 'Refreshing…' : 'Refresh from source'}
+						</span>
+					</button>
+				{:else}
+					<span class="source-chip source-chip-readonly" title={fields.source_url}>
+						<span class="source-chip-icon" aria-hidden="true">🌐</span>
+						<span class="source-chip-label">Imported from URL</span>
+					</span>
+				{/if}
+			{/if}
 		</div>
 
 		<!-- Meta info -->
@@ -2251,6 +2358,7 @@
 								onUpdate={handleContentUpdate}
 								editable={false}
 								onEditor={(e) => editorInstance = e}
+								onImportInserted={handleImportInserted}
 							/>
 						{/key}
 					{:else if ydoc}
@@ -2287,6 +2395,7 @@
 									awareness={collabProvider?.awareness}
 									collabUser={collabUserState}
 									onEditor={(e) => editorInstance = e}
+									onImportInserted={handleImportInserted}
 								/>
 							{/key}
 						{/if}
@@ -2621,6 +2730,37 @@
 		overflow: hidden;
 		line-height: 1.3;
 		font-family: inherit;
+	}
+
+	/* Refresh-from-source chip (TASK-1474). Lives in .title-row right
+	   of the title; small, unobtrusive, click to re-fetch. */
+	.source-chip {
+		display: inline-flex;
+		align-items: center;
+		gap: 4px;
+		padding: 2px 8px;
+		border-radius: 999px;
+		background: var(--bg-secondary);
+		border: 1px solid var(--border);
+		font-size: 0.75em;
+		color: var(--text-secondary);
+		cursor: pointer;
+		font-family: inherit;
+	}
+	.source-chip:hover:not(:disabled) {
+		background: var(--bg-tertiary, var(--bg-secondary));
+		color: var(--text-primary);
+	}
+	.source-chip:disabled {
+		opacity: 0.6;
+		cursor: progress;
+	}
+	.source-chip-readonly {
+		cursor: default;
+	}
+	.source-chip-icon {
+		font-size: 0.9em;
+		line-height: 1;
 	}
 
 	/* Meta */

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -1905,10 +1905,18 @@
 					was created via "Insert from URL" and the modal stamped
 					source_url into fields. Click re-fetches and replaces
 					editor content; the editor's Yjs op-log handles undo.
+
 					Hidden for view-only users (no canEdit) — refresh is a
 					content-replacing action that requires write access.
+					Also hidden in raw-markdown mode: the rich Editor is
+					unmounted there and refreshFromSource() drives content
+					replacement through the Tiptap editor instance, which
+					would either fail or update the off-screen rich editor.
+					Read-only / raw users see the provenance chip without
+					the Refresh button so the import history is still
+					discoverable. (Per Codex review round 1.)
 				-->
-				{#if canEdit}
+				{#if canEdit && !rawMode}
 					<button
 						type="button"
 						class="source-chip"


### PR DESCRIPTION
## Summary
- New \`onImportInserted\` prop on \`Editor.svelte\` bubbles the modal's response to the host page.
- Item editor page handles it: stamps \`source_url\` + \`imported_at\` into the item's \`fields\` JSON when the item had no prior content AND no \`source_url\` set.
- Refresh-from-source chip rendered beneath the title when \`fields.source_url\` is present. Click → \`window.confirm\` warning → re-fetch → replace editor content → bump \`imported_at\`. View-only users see a non-interactive provenance chip instead.

## Design notes
- \`source_url\` / \`imported_at\` are **orphan keys** in \`fields\` JSON. \`internal/items/validate.go\` only iterates declared schema fields, so unknown keys persist and round-trip through PATCH without a schema migration. Matches PLAN-1467's ghost-field design.
- Diff preview on refresh is deferred (PLAN-1467 risks section) — the Yjs op-log provides recoverable history. The confirmation message warns the action replaces content.

## Context
Final slice of \`PLAN-1467\` — *Insert from URL — HTML→Markdown utility in the item editor*. Implements \`TASK-1474\`. Builds on \`TASK-1473\` (toolbar + modal) which built on \`TASK-1472\` (endpoint).

## Test plan
- [x] \`cd web && npm run check\` — 0 errors
- [x] \`cd web && npm run build\` — clean
- [x] \`go test ./...\` — all packages green (Go untouched but verified for regression)
- [x] \`golangci-lint run\` — 0 issues
- [x] Manual: source_url stamped on first import (page reload shows chip)
- [x] Manual: re-import on item with existing content does NOT re-stamp
- [x] Manual: refresh-from-source replaces content + bumps imported_at
- [x] Manual: read-only viewers see provenance chip but no Refresh button