### PR TITLE
feat(collections): add blank workspace template + retire auto-upgrade hook (IDEA-1479)

### DIFF
--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -314,18 +314,12 @@ func serveCmd() *cobra.Command {
 				slog.Info("Encrypted plaintext TOTP secrets", "count", n)
 			}
 
-			// Auto-upgrade: ensure all default collections exist in every workspace.
-			// This is safe because SeedDefaultCollections skips collections that already exist.
-			if workspaces, err := s.ListWorkspaces(); err == nil {
-				slog.Info("auto-upgrade: checking workspaces for missing default collections", "count", len(workspaces))
-				for _, ws := range workspaces {
-					if err := s.SeedDefaultCollections(ws.ID); err != nil {
-						slog.Warn("failed to seed defaults for workspace", "workspace", ws.Slug, "error", err)
-					}
-				}
-			} else {
-				slog.Warn("failed to list workspaces for auto-upgrade", "error", err)
-			}
+			// Auto-upgrade hook removed in IDEA-1479. The historical
+			// SeedDefaultCollections backfill was incompatible with templates
+			// that intentionally diverge from Defaults() (e.g. `blank`). Future
+			// changes that need to backfill collections into existing workspaces
+			// should be implemented as explicit migrations in
+			// internal/store/migrations/.
 
 			srv := server.New(s)
 			srv.SetVersion(version, commit, buildTime)

--- a/cmd/pad/templates_picker_test.go
+++ b/cmd/pad/templates_picker_test.go
@@ -129,7 +129,7 @@ func TestPrintGroupedTemplatesIncludesEveryVisibleTemplate(t *testing.T) {
 	var out bytes.Buffer
 	printGroupedTemplates(&out)
 	rendered := out.String()
-	for _, name := range []string{"startup", "scrum", "product", "hiring", "interviewing"} {
+	for _, name := range []string{"startup", "scrum", "product", "hiring", "interviewing", "blank"} {
 		if !strings.Contains(rendered, name) {
 			t.Errorf("grouped template output missing %q:\n%s", name, rendered)
 		}
@@ -139,10 +139,9 @@ func TestPrintGroupedTemplatesIncludesEveryVisibleTemplate(t *testing.T) {
 		t.Errorf("grouped template output leaked hidden template 'demo':\n%s", rendered)
 	}
 	// Category headers should render.
-	if !strings.Contains(rendered, "Software") {
-		t.Errorf("grouped template output missing 'Software' category header")
-	}
-	if !strings.Contains(rendered, "People") {
-		t.Errorf("grouped template output missing 'People' category header")
+	for _, cat := range []string{"Software", "People", "Custom"} {
+		if !strings.Contains(rendered, cat) {
+			t.Errorf("grouped template output missing %q category header", cat)
+		}
 	}
 }

--- a/internal/collections/templates.go
+++ b/internal/collections/templates.go
@@ -16,6 +16,7 @@ const (
 	CategoryContent    = "content"
 	CategoryOperations = "operations"
 	CategoryPersonal   = "personal"
+	CategoryCustom     = "custom"
 )
 
 // CategoryOrder is the canonical display order of categories. Pickers and
@@ -28,6 +29,7 @@ var CategoryOrder = []string{
 	CategoryContent,
 	CategoryOperations,
 	CategoryPersonal,
+	CategoryCustom,
 }
 
 // categoryLabels maps category slugs to their human-readable display labels.
@@ -38,6 +40,7 @@ var categoryLabels = map[string]string{
 	CategoryContent:    "Content",
 	CategoryOperations: "Operations",
 	CategoryPersonal:   "Personal",
+	CategoryCustom:     "Custom",
 }
 
 // CategoryLabel returns the human-readable label for a category slug.
@@ -732,6 +735,18 @@ var templates = []WorkspaceTemplate{
 	},
 	hiringTemplate(),
 	interviewingTemplate(),
+	{
+		Name:        "blank",
+		Category:    CategoryCustom,
+		Description: "Just Conventions & Playbooks — build the rest yourself",
+		Icon:        "\U0001F4DD", // 📝
+		Collections: []DefaultCollection{
+			conventionsCollection(0, SoftwareConventionTriggers, SoftwareConventionScopes),
+			playbooksCollection(1, SoftwarePlaybookTriggers, SoftwarePlaybookScopes),
+		},
+		// No SeedItems, no Conventions, no Playbooks, no OnboardingPrimaryRef —
+		// system rails only. Users build the rest via `pad collection create`.
+	},
 	{
 		Name:        "demo",
 		Category:    CategorySoftware,

--- a/internal/collections/templates_test.go
+++ b/internal/collections/templates_test.go
@@ -818,3 +818,98 @@ func TestSoftwareTemplatesUseSoftwareOptions(t *testing.T) {
 		}
 	}
 }
+
+// TestBlankTemplateShape verifies the blank template (IDEA-1479) ships only
+// the two system collections (Conventions, Playbooks) with no seed items,
+// conventions, playbooks, or OnboardingPrimaryRef. This is the contract: a
+// new workspace with system rails only, no user-facing collections.
+func TestBlankTemplateShape(t *testing.T) {
+	tmpl := GetTemplate("blank")
+	if tmpl == nil {
+		t.Fatal("blank template missing")
+	}
+	if tmpl.Category != CategoryCustom {
+		t.Errorf("blank category = %q, want %q", tmpl.Category, CategoryCustom)
+	}
+	if tmpl.Icon == "" {
+		t.Error("blank template has empty Icon")
+	}
+	if tmpl.Hidden {
+		t.Error("blank template should not be Hidden")
+	}
+	if len(tmpl.Collections) != 2 {
+		t.Fatalf("blank template Collections = %d, want 2 (system only)", len(tmpl.Collections))
+	}
+	wantSlugs := map[string]bool{"conventions": true, "playbooks": true}
+	for _, c := range tmpl.Collections {
+		if !wantSlugs[c.Slug] {
+			t.Errorf("blank template has unexpected collection %q", c.Slug)
+		}
+		if !c.IsSystem {
+			t.Errorf("blank template collection %q must be IsSystem=true", c.Slug)
+		}
+		delete(wantSlugs, c.Slug)
+	}
+	for slug := range wantSlugs {
+		t.Errorf("blank template missing required system collection %q", slug)
+	}
+	if len(tmpl.SeedItems) != 0 {
+		t.Errorf("blank template SeedItems = %d, want 0", len(tmpl.SeedItems))
+	}
+	if len(tmpl.Conventions) != 0 {
+		t.Errorf("blank template Conventions = %d, want 0", len(tmpl.Conventions))
+	}
+	if len(tmpl.Playbooks) != 0 {
+		t.Errorf("blank template Playbooks = %d, want 0", len(tmpl.Playbooks))
+	}
+	if tmpl.OnboardingPrimaryRef != "" {
+		t.Errorf("blank template OnboardingPrimaryRef = %q, want empty", tmpl.OnboardingPrimaryRef)
+	}
+}
+
+// TestBlankTemplateExcludesSoftwareCollections verifies the blank template
+// doesn't accidentally inherit the standard software user-facing collections
+// (tasks/ideas/plans/docs). Drift here means the template no longer solves
+// the motivating use case — agent-self workspaces want zero ghost
+// collections.
+func TestBlankTemplateExcludesSoftwareCollections(t *testing.T) {
+	tmpl := GetTemplate("blank")
+	if tmpl == nil {
+		t.Fatal("blank template missing")
+	}
+	forbidden := []string{"tasks", "ideas", "plans", "docs"}
+	for _, c := range tmpl.Collections {
+		for _, slug := range forbidden {
+			if c.Slug == slug {
+				t.Errorf("blank template leaked software collection %q", slug)
+			}
+		}
+	}
+}
+
+// TestBlankTemplateAppearsInPicker verifies the blank template is surfaced
+// by GroupTemplatesByCategory under a Custom group. The picker iterates
+// this helper, so a missing Custom group would hide the template entirely.
+func TestBlankTemplateAppearsInPicker(t *testing.T) {
+	groups := GroupTemplatesByCategory()
+	var customGroup *CategoryGroup
+	for i, g := range groups {
+		if g.Category == CategoryCustom {
+			customGroup = &groups[i]
+			break
+		}
+	}
+	if customGroup == nil {
+		t.Fatal("GroupTemplatesByCategory did not return a Custom group containing the blank template")
+	}
+	found := false
+	for _, tmpl := range customGroup.Templates {
+		if tmpl.Name == "blank" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("Custom group does not contain the blank template; got %+v", customGroup.Templates)
+	}
+}

--- a/internal/store/collections.go
+++ b/internal/store/collections.go
@@ -415,11 +415,20 @@ func (s *Store) MigrateItemFieldValues(collectionID string, migrations []models.
 // IDEA-1479); preserved as a building block for any future explicit
 // rescue command or migration that wants this behavior.
 func (s *Store) SeedDefaultCollections(workspaceID string) error {
-	existing, err := s.ListCollectionsMinimal(workspaceID)
-	if err != nil {
+	// Use a direct COUNT query rather than ListCollectionsMinimal: the
+	// rescue gate only needs to know whether ANY collection exists, and
+	// the minimal lister's SELECT touches JSON/JSONB columns whose
+	// COALESCE expression doesn't round-trip cleanly on Postgres
+	// (BUG triggered in the IDEA-1479 PR's first Postgres CI run).
+	// COUNT(*) sidesteps that path entirely and is also cheaper.
+	var existing int
+	if err := s.db.QueryRow(
+		s.q(`SELECT COUNT(*) FROM collections WHERE workspace_id = ?`),
+		workspaceID,
+	).Scan(&existing); err != nil {
 		return fmt.Errorf("check existing collections for rescue seed: %w", err)
 	}
-	if len(existing) > 0 {
+	if existing > 0 {
 		// Workspace already has collections — its shape was set by a
 		// template (default, blank, hiring, etc.) or by manual user
 		// edits. Either way, the rescue path doesn't apply.

--- a/internal/store/collections.go
+++ b/internal/store/collections.go
@@ -405,23 +405,15 @@ func (s *Store) MigrateItemFieldValues(collectionID string, migrations []models.
 	return totalAffected, nil
 }
 
-// SeedDefaultCollections is a rescue hook for workspaces that somehow ended
-// up with zero collections — e.g. workspaces created before the seed-on-init
-// flow existed, or a partial init that failed before any collection landed.
-// The server calls it for every workspace at startup as an auto-upgrade.
+// SeedDefaultCollections rescues a workspace that ended up with zero
+// collections by seeding it with the standard Software-shape Defaults().
+// It is intentionally a no-op for workspaces that already have any
+// collections — those have an established shape (from a template or
+// user edits) that the rescue must not clobber.
 //
-// It is intentionally a no-op for workspaces that already have at least one
-// collection (system or user-facing). Without this guard, the hook would
-// re-materialize the standard Software-template collections (Tasks/Ideas/
-// Plans/Docs) into workspaces created from non-default templates on every
-// boot — including the `blank` template (IDEA-1479), which ships only
-// Conventions + Playbooks and would silently grow ghost user-facing
-// collections on each restart.
-//
-// The "zero collections" guard preserves the original backfill intent
-// (rescue truly-empty workspaces) while making the hook safe for the
-// post-templates world where workspaces legitimately diverge from
-// Defaults().
+// No longer called automatically at server startup (removed in
+// IDEA-1479); preserved as a building block for any future explicit
+// rescue command or migration that wants this behavior.
 func (s *Store) SeedDefaultCollections(workspaceID string) error {
 	existing, err := s.ListCollectionsMinimal(workspaceID)
 	if err != nil {

--- a/internal/store/collections.go
+++ b/internal/store/collections.go
@@ -405,7 +405,34 @@ func (s *Store) MigrateItemFieldValues(collectionID string, migrations []models.
 	return totalAffected, nil
 }
 
+// SeedDefaultCollections is a rescue hook for workspaces that somehow ended
+// up with zero collections — e.g. workspaces created before the seed-on-init
+// flow existed, or a partial init that failed before any collection landed.
+// The server calls it for every workspace at startup as an auto-upgrade.
+//
+// It is intentionally a no-op for workspaces that already have at least one
+// collection (system or user-facing). Without this guard, the hook would
+// re-materialize the standard Software-template collections (Tasks/Ideas/
+// Plans/Docs) into workspaces created from non-default templates on every
+// boot — including the `blank` template (IDEA-1479), which ships only
+// Conventions + Playbooks and would silently grow ghost user-facing
+// collections on each restart.
+//
+// The "zero collections" guard preserves the original backfill intent
+// (rescue truly-empty workspaces) while making the hook safe for the
+// post-templates world where workspaces legitimately diverge from
+// Defaults().
 func (s *Store) SeedDefaultCollections(workspaceID string) error {
+	existing, err := s.ListCollectionsMinimal(workspaceID)
+	if err != nil {
+		return fmt.Errorf("check existing collections for rescue seed: %w", err)
+	}
+	if len(existing) > 0 {
+		// Workspace already has collections — its shape was set by a
+		// template (default, blank, hiring, etc.) or by manual user
+		// edits. Either way, the rescue path doesn't apply.
+		return nil
+	}
 	return s.SeedCollectionsFromTemplate(workspaceID, "")
 }
 

--- a/internal/store/collections_test.go
+++ b/internal/store/collections_test.go
@@ -49,6 +49,83 @@ func TestSeedFromBlankTemplate(t *testing.T) {
 	}
 }
 
+// TestBlankWorkspaceSurvivesSeedDefaultCollections is the regression guard
+// for codex round-2: the server runs SeedDefaultCollections against every
+// workspace at startup as an auto-upgrade rescue. Before the fix, that hook
+// unconditionally re-materialized the standard Software-template collections
+// (tasks/ideas/plans/docs) into any workspace missing them — including
+// blank-template workspaces, which would silently grow ghost collections on
+// every server restart. The fix gates the rescue on "workspace has zero
+// collections" so blank (which ships 2 system collections) is a no-op.
+func TestBlankWorkspaceSurvivesSeedDefaultCollections(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Blank Survival Test")
+
+	if err := s.SeedCollectionsFromTemplate(ws.ID, "blank"); err != nil {
+		t.Fatalf("SeedCollectionsFromTemplate(blank) error: %v", err)
+	}
+
+	// Simulate a server restart firing the auto-upgrade hook.
+	if err := s.SeedDefaultCollections(ws.ID); err != nil {
+		t.Fatalf("SeedDefaultCollections error: %v", err)
+	}
+
+	colls, err := s.ListCollections(ws.ID)
+	if err != nil {
+		t.Fatalf("ListCollections error: %v", err)
+	}
+	if len(colls) != 2 {
+		t.Fatalf("blank workspace has %d collections after auto-upgrade, want 2 (Conventions + Playbooks only); got %+v", len(colls), collectionSlugs(colls))
+	}
+	for _, c := range colls {
+		if c.Slug == "tasks" || c.Slug == "ideas" || c.Slug == "plans" || c.Slug == "docs" {
+			t.Errorf("blank workspace acquired user-facing software collection %q after SeedDefaultCollections — auto-upgrade rescue gate is broken", c.Slug)
+		}
+	}
+
+	// And repeated invocations remain no-ops.
+	if err := s.SeedDefaultCollections(ws.ID); err != nil {
+		t.Fatalf("SeedDefaultCollections (second run) error: %v", err)
+	}
+	colls, _ = s.ListCollections(ws.ID)
+	if len(colls) != 2 {
+		t.Errorf("blank workspace has %d collections after second auto-upgrade pass, want 2", len(colls))
+	}
+}
+
+// TestEmptyWorkspaceStillGetsDefaults verifies the rescue path still works
+// for a workspace that genuinely has zero collections — the original intent
+// of the SeedDefaultCollections hook (predates templates; see git blame on
+// cmd/pad/main.go's auto-upgrade block). If a workspace was created before
+// the seed-on-init flow existed, or a partial init failed before any
+// collection landed, the auto-upgrade must still materialize the Software
+// defaults.
+func TestEmptyWorkspaceStillGetsDefaults(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Empty Rescue Test")
+
+	// No SeedCollectionsFromTemplate — workspace starts with zero
+	// collections (simulating a pre-templates-era workspace, or a
+	// partial init).
+	if err := s.SeedDefaultCollections(ws.ID); err != nil {
+		t.Fatalf("SeedDefaultCollections error: %v", err)
+	}
+
+	colls, err := s.ListCollections(ws.ID)
+	if err != nil {
+		t.Fatalf("ListCollections error: %v", err)
+	}
+	slugs := make(map[string]bool, len(colls))
+	for _, c := range colls {
+		slugs[c.Slug] = true
+	}
+	for _, want := range []string{"tasks", "ideas", "plans", "docs", "conventions", "playbooks"} {
+		if !slugs[want] {
+			t.Errorf("empty workspace rescue did not materialize default collection %q (got %v)", want, collectionSlugs(colls))
+		}
+	}
+}
+
 func collectionSlugs(colls []models.Collection) []string {
 	out := make([]string, 0, len(colls))
 	for _, c := range colls {

--- a/internal/store/collections_test.go
+++ b/internal/store/collections_test.go
@@ -1,0 +1,58 @@
+package store
+
+import (
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// TestSeedFromBlankTemplate verifies that bootstrapping a workspace from the
+// blank template (IDEA-1479) produces exactly two collections (Conventions,
+// Playbooks) and zero items. Drift here means the template silently grew
+// (or shrunk) its starter pack and the motivating "agent-self workspace
+// with no ghost collections" use case is no longer protected.
+func TestSeedFromBlankTemplate(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Blank Test")
+
+	if err := s.SeedCollectionsFromTemplate(ws.ID, "blank"); err != nil {
+		t.Fatalf("SeedCollectionsFromTemplate(blank) error: %v", err)
+	}
+
+	colls, err := s.ListCollections(ws.ID)
+	if err != nil {
+		t.Fatalf("ListCollections error: %v", err)
+	}
+	if len(colls) != 2 {
+		t.Fatalf("blank workspace has %d collections, want 2; got %+v", len(colls), collectionSlugs(colls))
+	}
+
+	wantSlugs := map[string]bool{"conventions": true, "playbooks": true}
+	for _, c := range colls {
+		if !wantSlugs[c.Slug] {
+			t.Errorf("blank workspace has unexpected collection slug %q", c.Slug)
+		}
+		delete(wantSlugs, c.Slug)
+	}
+	for slug := range wantSlugs {
+		t.Errorf("blank workspace missing required system collection %q", slug)
+	}
+
+	// No items should be seeded — neither sample items, conventions, nor
+	// playbooks.
+	items, err := s.ListItems(ws.ID, models.ItemListParams{})
+	if err != nil {
+		t.Fatalf("ListItems error: %v", err)
+	}
+	if len(items) != 0 {
+		t.Errorf("blank workspace has %d items, want 0", len(items))
+	}
+}
+
+func collectionSlugs(colls []models.Collection) []string {
+	out := make([]string, 0, len(colls))
+	for _, c := range colls {
+		out = append(out, c.Slug)
+	}
+	return out
+}

--- a/web/src/lib/components/OnboardingChecklist.svelte
+++ b/web/src/lib/components/OnboardingChecklist.svelte
@@ -5,10 +5,22 @@
 		wsSlug: string;
 		username?: string;
 		byCollection: Record<string, Record<string, number>>;
+		// Slugs of collections that actually exist in this workspace. Steps
+		// targeting missing collections (e.g. blank-template workspaces with
+		// no plans/tasks/docs) are filtered out so users don't get
+		// "Collection not found" links.
+		collectionSlugs?: string[];
 		ondismiss?: () => void;
 	}
 
-	let { wsSlug, username = '', byCollection, ondismiss }: Props = $props();
+	let { wsSlug, username = '', byCollection, collectionSlugs, ondismiss }: Props = $props();
+
+	let collectionSet = $derived(new Set(collectionSlugs ?? []));
+	function collectionExists(slug: string): boolean {
+		// If collectionSlugs wasn't provided, fall back to "assume exists"
+		// for backward compat with callers that haven't been updated.
+		return collectionSlugs === undefined ? true : collectionSet.has(slug);
+	}
 
 	let copiedHint = $state<string | null>(null);
 
@@ -29,9 +41,14 @@
 		href: string;
 		done: boolean;
 		hint: string;
+		// Optional gate: if set, this step is only shown when the target
+		// collection exists in the workspace. The conventions step has no
+		// gate because the conventions collection is system-level and
+		// shipped by every template (including blank).
+		requiresCollection?: string;
 	}
 
-	let steps = $derived<Step[]>([
+	let allSteps = $derived<Step[]>([
 		{
 			title: 'Add project conventions',
 			href: `/${username}/${wsSlug}/library`,
@@ -42,24 +59,29 @@
 			title: 'Create your first plan',
 			href: `/${username}/${wsSlug}/plans`,
 			done: collectionHasItems('plans'),
-			hint: '/pad create a plan for what I\'m working on'
+			hint: '/pad create a plan for what I\'m working on',
+			requiresCollection: 'plans'
 		},
 		{
 			title: 'Add a few tasks',
 			href: `/${username}/${wsSlug}/tasks`,
 			done: collectionItemCount('tasks') >= 3,
-			hint: '/pad break down my current work into tasks'
+			hint: '/pad break down my current work into tasks',
+			requiresCollection: 'tasks'
 		},
 		{
 			title: 'Write an architecture doc',
 			href: `/${username}/${wsSlug}/docs`,
 			done: collectionHasItems('docs'),
-			hint: '/pad document the architecture of this project'
+			hint: '/pad document the architecture of this project',
+			requiresCollection: 'docs'
 		}
 	]);
 
+	let steps = $derived(allSteps.filter(s => !s.requiresCollection || collectionExists(s.requiresCollection)));
+
 	let completedCount = $derived(steps.filter((s) => s.done).length);
-	let progressPct = $derived(Math.round((completedCount / steps.length) * 100));
+	let progressPct = $derived(steps.length === 0 ? 0 : Math.round((completedCount / steps.length) * 100));
 
 	async function copyHint(text: string) {
 		const ok = await copyToClipboard(text);

--- a/web/src/lib/components/layout/CreateWorkspaceModal.svelte
+++ b/web/src/lib/components/layout/CreateWorkspaceModal.svelte
@@ -171,16 +171,6 @@
 								</button>
 							{/each}
 						{/each}
-						<button
-							class="template-card"
-							class:selected={selectedTemplate === ''}
-							onclick={() => (selectedTemplate = '')}
-						>
-							<span class="tpl-text">
-								<span class="tpl-name">blank</span>
-								<span class="tpl-desc">Empty workspace</span>
-							</span>
-						</button>
 					</div>
 				{/if}
 			{:else}

--- a/web/src/lib/utils/templates.ts
+++ b/web/src/lib/utils/templates.ts
@@ -11,6 +11,7 @@ export const CATEGORY_ORDER = [
 	'content',
 	'operations',
 	'personal',
+	'custom',
 ] as const;
 
 const CATEGORY_LABELS: Record<string, string> = {
@@ -20,6 +21,7 @@ const CATEGORY_LABELS: Record<string, string> = {
 	content: 'Content',
 	operations: 'Operations',
 	personal: 'Personal',
+	custom: 'Custom',
 };
 
 export function categoryLabel(slug: string | undefined): string {

--- a/web/src/routes/[username]/[workspace]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/+page.svelte
@@ -146,6 +146,7 @@
 
 	let totalItems = $derived(dashboard?.summary.total_items ?? 0);
 	let firstCollection = $derived(collections.filter(c => !c.is_system && c.slug !== 'tasks').sort((a, b) => a.sort_order - b.sort_order)[0]);
+	let hasTasksCollection = $derived(collections.some(c => c.slug === 'tasks'));
 
 	function statusColor(status: string): string {
 		const s = status.toLowerCase().replace(/-/g, '_');
@@ -247,7 +248,9 @@
 				{#if firstCollection}
 					<button class="btn btn-secondary" onclick={() => uiStore.requestQuickAdd(firstCollection.slug)}>{firstCollection.icon} New {firstCollection.name.replace(/s$/, '')}</button>
 				{/if}
-				<button class="btn btn-primary" onclick={() => uiStore.requestQuickAdd('tasks')}>+ New Task</button>
+				{#if hasTasksCollection}
+					<button class="btn btn-primary" onclick={() => uiStore.requestQuickAdd('tasks')}>+ New Task</button>
+				{/if}
 			</div>
 		</header>
 
@@ -273,7 +276,7 @@
 		{/if}
 		{#if totalItems === 0 && !onboardingDismissed}
 			<div class="onboarding-wrapper">
-				<OnboardingChecklist {wsSlug} {username} byCollection={dashboard.summary.by_collection} ondismiss={dismissOnboarding} />
+				<OnboardingChecklist {wsSlug} {username} byCollection={dashboard.summary.by_collection} collectionSlugs={collections.map(c => c.slug)} ondismiss={dismissOnboarding} />
 				<button class="connect-card" type="button" onclick={() => (connectOpen = true)}>
 					<span class="connect-card-icon" aria-hidden="true">
 						<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">


### PR DESCRIPTION
## Summary

Adds a new `blank` workspace template under a new `Custom` category. The blank template ships only the two system collections (Conventions, Playbooks) and is built for agent-self / personal / domain-specific workspaces that don't want the Software default set.

Also retires the startup `SeedDefaultCollections` auto-upgrade hook. The function is preserved as a building block for future explicit rescue migrations but is no longer auto-invoked at server startup.

## Why retire the hook

The historical per-collection backfill semantic ("ensure every workspace has the current `Defaults()`") is fundamentally incompatible with templates that intentionally diverge from `Defaults()`. `blank` is the first such template; future personal/agent-self templates will follow the same pattern.

Future "add a default collection" work should land as an explicit migration in `internal/store/migrations/`, where the migration author chooses which workspaces to backfill — rather than a blanket startup sweep that fights intentional divergence.

## Observable behavior change

The startup log line `auto-upgrade: checking workspaces for missing default collections` is gone. No other operational change.

## Test plan

- [x] `go test ./...` — all PASS
- [x] `go vet ./...` — clean
- [x] `make web` — clean
- [x] 4 codex review passes via review-loop, converged at round 3 (6 findings, all addressed)
- [ ] Manual smoke after merge: create a `blank` workspace via web UI; verify only Conventions + Playbooks; restart server; verify still only those two

## Refs

- IDEA-1479 in the `docapp` Pad workspace
- Orchestrated from the `claude` workspace per DECIS-32's loop