### PR TITLE
refactor(store): collections.settings boundary normalization + scan revert (IDEA-1484 follow-up)

### DIFF
--- a/internal/store/collections.go
+++ b/internal/store/collections.go
@@ -65,13 +65,6 @@ func (s *Store) GetCollection(id string) (*models.Collection, error) {
 	var createdAt, updatedAt string
 	var deletedAt *string
 	var isDefault bool
-	// `collections.settings` is nullable on both drivers (TEXT DEFAULT '{}' on
-	// SQLite, JSONB DEFAULT '{}' on Postgres). A NULL row would fail to scan
-	// directly into a Go string on Postgres with "converting NULL to string
-	// is unsupported". Materialize NULL as "" to preserve the sentinel that
-	// downstream consumers gate on via `if c.Settings != ""`. Same fix shape
-	// as ListCollectionsMinimal — see BUG-1482.
-	var settings sql.NullString
 
 	err := s.db.QueryRow(s.q(`
 		SELECT id, workspace_id, name, slug, prefix, icon, description, schema, settings, sort_order, is_default, is_system, created_at, updated_at, deleted_at
@@ -79,7 +72,7 @@ func (s *Store) GetCollection(id string) (*models.Collection, error) {
 		WHERE id = ? AND deleted_at IS NULL
 	`), id).Scan(
 		&c.ID, &c.WorkspaceID, &c.Name, &c.Slug, &c.Prefix, &c.Icon, &c.Description,
-		&c.Schema, &settings, &c.SortOrder, &isDefault, &c.IsSystem,
+		&c.Schema, &c.Settings, &c.SortOrder, &isDefault, &c.IsSystem,
 		&createdAt, &updatedAt, &deletedAt,
 	)
 	if err == sql.ErrNoRows {
@@ -89,9 +82,6 @@ func (s *Store) GetCollection(id string) (*models.Collection, error) {
 		return nil, fmt.Errorf("get collection: %w", err)
 	}
 
-	if settings.Valid {
-		c.Settings = settings.String
-	}
 	c.IsDefault = isDefault
 	c.CreatedAt = parseTime(createdAt)
 	c.UpdatedAt = parseTime(updatedAt)
@@ -121,16 +111,6 @@ func (s *Store) GetCollectionBySlug(workspaceID, slug string) (*models.Collectio
 // handlers that build a ctxMap for isItemDone). Includes soft-deleted
 // collections so items still attached to them can be evaluated.
 func (s *Store) ListCollectionsMinimal(workspaceID string) ([]models.Collection, error) {
-	// Note: we deliberately avoid `COALESCE(settings, '')` here. On Postgres,
-	// `collections.settings` is JSONB and `COALESCE(jsonb_col, '')` forces a
-	// planner-time cast of `''` to JSON which fails with SQLSTATE 22P02
-	// ("invalid input syntax for type json"), regardless of row contents.
-	// SQLite is type-loose and accepts it, which is why the bug was latent
-	// (BUG-1482). Scanning into sql.NullString is dialect-agnostic and
-	// preserves the historical sentinel: a NULL settings value materializes
-	// as `""`, matching the contract that downstream consumers
-	// (buildDoneContextMap, ListCollections's own scan loop) already gate on
-	// via `if c.Settings != ""`.
 	rows, err := s.db.Query(
 		s.q(`SELECT id, schema, settings FROM collections WHERE workspace_id = ?`),
 		workspaceID,
@@ -142,12 +122,8 @@ func (s *Store) ListCollectionsMinimal(workspaceID string) ([]models.Collection,
 	var result []models.Collection
 	for rows.Next() {
 		var c models.Collection
-		var settings sql.NullString
-		if err := rows.Scan(&c.ID, &c.Schema, &settings); err != nil {
+		if err := rows.Scan(&c.ID, &c.Schema, &c.Settings); err != nil {
 			return nil, fmt.Errorf("scan collection minimal: %w", err)
-		}
-		if settings.Valid {
-			c.Settings = settings.String
 		}
 		result = append(result, c)
 	}
@@ -175,20 +151,12 @@ func (s *Store) ListCollections(workspaceID string) ([]models.Collection, error)
 		var c models.Collection
 		var createdAt, updatedAt string
 		var isDefault bool
-		// Nullable JSONB on Postgres; scan via sql.NullString and materialize
-		// NULL as "" so the downstream `if c.Settings != ""` guard below
-		// (and in handlers_dashboard.buildDoneContextMap) keeps working.
-		// Same fix shape as ListCollectionsMinimal — see BUG-1482.
-		var settings sql.NullString
 		if err := rows.Scan(
 			&c.ID, &c.WorkspaceID, &c.Name, &c.Slug, &c.Prefix, &c.Icon, &c.Description,
-			&c.Schema, &settings, &c.SortOrder, &isDefault, &c.IsSystem,
+			&c.Schema, &c.Settings, &c.SortOrder, &isDefault, &c.IsSystem,
 			&createdAt, &updatedAt, &c.ItemCount,
 		); err != nil {
 			return nil, err
-		}
-		if settings.Valid {
-			c.Settings = settings.String
 		}
 		c.IsDefault = isDefault
 		c.CreatedAt = parseTime(createdAt)

--- a/internal/store/collections.go
+++ b/internal/store/collections.go
@@ -246,8 +246,18 @@ func (s *Store) UpdateCollection(id string, input models.CollectionUpdate) (*mod
 		args = append(args, *input.Schema)
 	}
 	if input.Settings != nil {
+		// Normalize the empty-string sentinel to a valid JSON object before
+		// writing. The NOT NULL DEFAULT '{}' constraint (IDEA-1484) only
+		// fires when the UPDATE omits the column; explicit values are
+		// written verbatim. Postgres rejects `""` at JSONB type-validation;
+		// SQLite would silently store invalid JSON. Same boundary
+		// normalization as ImportWorkspace.
+		settings := *input.Settings
+		if settings == "" {
+			settings = "{}"
+		}
 		sets = append(sets, "settings = ?")
-		args = append(args, *input.Settings)
+		args = append(args, settings)
 	}
 	if input.SortOrder != nil {
 		sets = append(sets, "sort_order = ?")

--- a/internal/store/collections_test.go
+++ b/internal/store/collections_test.go
@@ -17,8 +17,11 @@ import (
 // constraint in place, the `UPDATE collections SET settings = NULL` setup
 // those tests relied on is now a hard write error, and the scenario they
 // guarded (production data legally holding NULL) is no longer reachable.
-// The defensive `sql.NullString` scans in collections.go / export.go
-// remain in place and will be reverted in a separate follow-up PR.
+// The defensive `sql.NullString` scans in collections.go / export.go and
+// the paired import-side `""→"{}"` coercion (along with
+// TestExportImportRoundTripWithEmptyStringSettings) were reverted in the
+// IDEA-1484 follow-up now that the schema constraint is the load-bearing
+// invariant.
 
 // TestCollectionsSettingsNotNullEnforced is the IDEA-1484 outcome guard:
 // after migration 055 / pg 034, attempting to write a literal SQL NULL
@@ -118,67 +121,6 @@ func TestListCollectionsMinimalReturnsSettingsJSON(t *testing.T) {
 	}
 	if !found {
 		t.Fatalf("created collection %q not returned by ListCollectionsMinimal", created.ID)
-	}
-}
-
-// TestExportImportRoundTripWithEmptyStringSettings guards the paired
-// import-side `""→"{}"` coercion at export.go:~210. After IDEA-1484's
-// migration, the source column can no longer hold NULL, but exports of
-// legacy bundles or pre-migration backups may still carry an empty-string
-// settings value (the BUG-1482 sentinel for the previously-nullable
-// column). ImportWorkspace must coerce that back to a valid JSON object
-// before INSERT, otherwise the import would fail on Postgres because `""`
-// is not valid JSONB and downstream consumers gated on
-// `c.Settings != ""` would misinterpret it.
-func TestExportImportRoundTripWithEmptyStringSettings(t *testing.T) {
-	s := testStore(t)
-	owner := createTestUser(t, s, "round-trip-owner@test.com", "Round Trip Owner", "password123")
-	src := createTestWorkspace(t, s, "Export-Import Round Trip Empty Settings")
-
-	if err := s.SeedDefaultCollections(src.ID); err != nil {
-		t.Fatalf("SeedDefaultCollections error: %v", err)
-	}
-
-	exp, err := s.ExportWorkspace(src.Slug)
-	if err != nil {
-		t.Fatalf("ExportWorkspace error: %v", err)
-	}
-
-	// Simulate a legacy export bundle whose collections carry the
-	// empty-string sentinel (originally surfaced by BUG-1482's defensive
-	// `sql.NullString` scan for NULL-settings rows). The IDEA-1484
-	// migration eliminates NULL at the column level, but ImportWorkspace
-	// must still tolerate `""` from older bundles in flight.
-	for i := range exp.Collections {
-		exp.Collections[i].Settings = ""
-	}
-
-	imported, err := s.ImportWorkspace(exp, "round-trip-import-target", owner.ID)
-	if err != nil {
-		t.Fatalf("ImportWorkspace error (BUG-1482 import-side regression): %v", err)
-	}
-	if imported == nil {
-		t.Fatalf("ImportWorkspace returned nil workspace")
-	}
-
-	// Re-read the imported collections and assert they hold valid JSON
-	// (the import-side coercion materialized `""` back to `"{}"`).
-	colls, err := s.ListCollections(imported.ID)
-	if err != nil {
-		t.Fatalf("ListCollections on imported workspace: %v", err)
-	}
-	if len(colls) == 0 {
-		t.Fatalf("imported workspace has 0 collections; expected the round-tripped defaults")
-	}
-	for _, c := range colls {
-		if c.Settings == "" {
-			t.Errorf("imported collection %q: settings should have been coerced from \"\" to a valid JSON object, got empty string", c.ID)
-			continue
-		}
-		var got map[string]any
-		if err := json.Unmarshal([]byte(c.Settings), &got); err != nil {
-			t.Errorf("imported collection %q: settings is not valid JSON: %v (raw=%q)", c.ID, err, c.Settings)
-		}
 	}
 }
 

--- a/internal/store/collections_test.go
+++ b/internal/store/collections_test.go
@@ -17,11 +17,18 @@ import (
 // constraint in place, the `UPDATE collections SET settings = NULL` setup
 // those tests relied on is now a hard write error, and the scenario they
 // guarded (production data legally holding NULL) is no longer reachable.
-// The defensive `sql.NullString` scans in collections.go / export.go and
-// the paired import-side `""→"{}"` coercion (along with
-// TestExportImportRoundTripWithEmptyStringSettings) were reverted in the
-// IDEA-1484 follow-up now that the schema constraint is the load-bearing
-// invariant.
+//
+// The defensive `sql.NullString` scans in collections.go / export.go were
+// reverted in the IDEA-1484 follow-up — direct string scans are safe now
+// that the column cannot hold NULL.
+//
+// The import-side `""→"{}"` coercion in ImportWorkspace is INTENTIONALLY
+// RETAINED. The NOT NULL DEFAULT '{}' constraint only fires when the
+// INSERT omits the column; ImportWorkspace explicitly supplies the value,
+// so a `""` from a legacy bundle or external JSON import would bypass the
+// default and either fail on Postgres (invalid JSONB) or silently store
+// invalid JSON on SQLite. `TestExportImportRoundTripWithEmptyStringSettings`
+// guards that boundary normalization.
 
 // TestCollectionsSettingsNotNullEnforced is the IDEA-1484 outcome guard:
 // after migration 055 / pg 034, attempting to write a literal SQL NULL
@@ -121,6 +128,64 @@ func TestListCollectionsMinimalReturnsSettingsJSON(t *testing.T) {
 	}
 	if !found {
 		t.Fatalf("created collection %q not returned by ListCollectionsMinimal", created.ID)
+	}
+}
+
+// TestExportImportRoundTripWithEmptyStringSettings guards the import-side
+// `""→"{}"` coercion in ImportWorkspace. IDEA-1484 (PR #562) hardened
+// collections.settings to NOT NULL DEFAULT '{}', but the DEFAULT clause
+// only fires when the INSERT omits the column — ImportWorkspace
+// explicitly supplies the value. Without the coercion, a legacy bundle
+// or external JSON payload whose settings is "" would fail at Postgres's
+// JSONB type-validation (and silently store invalid JSON on SQLite).
+// This test simulates the bundle by mutating the in-memory export bundle
+// to inject "" settings, then asserts ImportWorkspace materializes them
+// back to valid JSON on the destination side.
+func TestExportImportRoundTripWithEmptyStringSettings(t *testing.T) {
+	s := testStore(t)
+	owner := createTestUser(t, s, "round-trip-owner@test.com", "Round Trip Owner", "password123")
+	src := createTestWorkspace(t, s, "Export-Import Round Trip Empty Settings")
+
+	if err := s.SeedDefaultCollections(src.ID); err != nil {
+		t.Fatalf("SeedDefaultCollections error: %v", err)
+	}
+
+	exp, err := s.ExportWorkspace(src.Slug)
+	if err != nil {
+		t.Fatalf("ExportWorkspace error: %v", err)
+	}
+
+	// Simulate a legacy/external bundle whose collections carry "" settings.
+	for i := range exp.Collections {
+		exp.Collections[i].Settings = ""
+	}
+
+	imported, err := s.ImportWorkspace(exp, "round-trip-import-target", owner.ID)
+	if err != nil {
+		t.Fatalf("ImportWorkspace error (IDEA-1484 import-side coercion regression): %v", err)
+	}
+	if imported == nil {
+		t.Fatalf("ImportWorkspace returned nil workspace")
+	}
+
+	// Re-read the imported collections and assert they hold valid JSON
+	// (the import-side coercion materialized `""` back to `"{}"`).
+	colls, err := s.ListCollections(imported.ID)
+	if err != nil {
+		t.Fatalf("ListCollections on imported workspace: %v", err)
+	}
+	if len(colls) == 0 {
+		t.Fatalf("imported workspace has 0 collections; expected the round-tripped defaults")
+	}
+	for _, c := range colls {
+		if c.Settings == "" {
+			t.Errorf("imported collection %q: settings should have been coerced from \"\" to a valid JSON object, got empty string", c.ID)
+			continue
+		}
+		var got map[string]any
+		if err := json.Unmarshal([]byte(c.Settings), &got); err != nil {
+			t.Errorf("imported collection %q: settings is not valid JSON: %v (raw=%q)", c.ID, err, c.Settings)
+		}
 	}
 }
 

--- a/internal/store/collections_test.go
+++ b/internal/store/collections_test.go
@@ -54,8 +54,7 @@ func TestCollectionsSettingsNotNullEnforced(t *testing.T) {
 // when an INSERT omits the settings column entirely, the column DEFAULT
 // must materialize as the empty JSON object `{}`. SQLite stores it as
 // TEXT and Postgres stores it as JSONB (which normalizes to `{}` on
-// readback); both surface through GetCollection's defensive scan as the
-// Go string `{}`.
+// readback); both surface through GetCollection as the Go string `{}`.
 func TestCollectionsSettingsDefaultsToEmptyObject(t *testing.T) {
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Settings Default")
@@ -77,6 +76,43 @@ func TestCollectionsSettingsDefaultsToEmptyObject(t *testing.T) {
 	}
 	if got.Settings != "{}" {
 		t.Errorf("expected default settings to materialize as %q, got %q", "{}", got.Settings)
+	}
+}
+
+// TestUpdateCollectionCoercesEmptyStringSettings guards the second
+// boundary normalizer: UpdateCollection writes a `settings=""` PATCH
+// verbatim by default, bypassing the NOT NULL DEFAULT '{}' constraint
+// (which only fires on column-omission, not on explicit values).
+// Postgres would reject `""` at JSONB type-validation; SQLite would
+// silently store invalid JSON. The coercion in UpdateCollection matches
+// the one in ImportWorkspace — both protect the
+// `collections.settings always holds valid JSON` invariant at the API
+// boundary, where the schema constraint alone is not sufficient.
+func TestUpdateCollectionCoercesEmptyStringSettings(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Update Coerce Empty Settings")
+
+	created, err := s.CreateCollection(ws.ID, models.CollectionCreate{
+		Name:     "Things",
+		Slug:     "things-update-coerce",
+		Settings: `{"done_field":"status","done_values":["closed"]}`,
+	})
+	if err != nil {
+		t.Fatalf("CreateCollection error: %v", err)
+	}
+
+	empty := ""
+	updated, err := s.UpdateCollection(created.ID, models.CollectionUpdate{
+		Settings: &empty,
+	})
+	if err != nil {
+		t.Fatalf("UpdateCollection with empty-string settings should coerce, got error: %v", err)
+	}
+	if updated == nil {
+		t.Fatalf("UpdateCollection returned nil")
+	}
+	if updated.Settings != "{}" {
+		t.Errorf("expected UpdateCollection to coerce empty-string settings to %q, got %q", "{}", updated.Settings)
 	}
 }
 

--- a/internal/store/export.go
+++ b/internal/store/export.go
@@ -193,10 +193,25 @@ func (s *Store) ImportWorkspace(data *models.WorkspaceExport, newName string, ow
 		newCollID := newID()
 		collMap[c.ID] = newCollID
 
+		// Coerce empty-string settings to a valid JSON object before insert.
+		// IDEA-1484 (PR #562) hardened collections.settings to NOT NULL
+		// DEFAULT '{}', but this INSERT explicitly supplies the settings
+		// column — so the DEFAULT clause does NOT fire when c.Settings is
+		// "". Without this coercion, Postgres rejects `""` at JSONB
+		// type-validation and SQLite silently stores invalid JSON. Legacy
+		// bundles and plain-JSON workspace imports (handlers_workspaces.go,
+		// handlers_import_bundle.go, cmd/pad/main.go's migrate command) can
+		// still carry "" settings, so normalization belongs at the import
+		// boundary rather than at the schema level.
+		settings := c.Settings
+		if settings == "" {
+			settings = "{}"
+		}
+
 		_, err := tx.Exec(s.q(`
 			INSERT INTO collections (id, workspace_id, name, slug, icon, description, schema, settings, prefix, sort_order, is_default, is_system, created_at, updated_at)
 			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`),
-			newCollID, ws.ID, c.Name, c.Slug, c.Icon, c.Description, c.Schema, c.Settings, c.Prefix, c.SortOrder, s.dialect.BoolToInt(c.IsDefault), s.dialect.BoolToInt(c.IsSystem),
+			newCollID, ws.ID, c.Name, c.Slug, c.Icon, c.Description, c.Schema, settings, c.Prefix, c.SortOrder, s.dialect.BoolToInt(c.IsDefault), s.dialect.BoolToInt(c.IsSystem),
 			c.CreatedAt, c.UpdatedAt)
 		if err != nil {
 			return nil, fmt.Errorf("import collection %s: %w", c.Name, err)

--- a/internal/store/export.go
+++ b/internal/store/export.go
@@ -1,7 +1,6 @@
 package store
 
 import (
-	"database/sql"
 	"fmt"
 	"strings"
 	"time"
@@ -42,18 +41,8 @@ func (s *Store) ExportWorkspace(slug string) (*models.WorkspaceExport, error) {
 	for rows.Next() {
 		var c models.CollectionExport
 		var isDefault, isSystem bool
-		// `collections.settings` is nullable on both drivers; a NULL row
-		// would error out a direct scan into Go string on Postgres
-		// ("converting NULL to string is unsupported"). Materialize NULL
-		// as "" to keep the export's existing sentinel — same fix shape
-		// as ListCollectionsMinimal / GetCollection / ListCollections.
-		// See BUG-1482.
-		var settings sql.NullString
-		if err := rows.Scan(&c.ID, &c.Name, &c.Slug, &c.Icon, &c.Description, &c.Schema, &settings, &c.Prefix, &c.SortOrder, &isDefault, &isSystem, &c.CreatedAt, &c.UpdatedAt); err != nil {
+		if err := rows.Scan(&c.ID, &c.Name, &c.Slug, &c.Icon, &c.Description, &c.Schema, &c.Settings, &c.Prefix, &c.SortOrder, &isDefault, &isSystem, &c.CreatedAt, &c.UpdatedAt); err != nil {
 			return nil, fmt.Errorf("scan collection: %w", err)
-		}
-		if settings.Valid {
-			c.Settings = settings.String
 		}
 		c.IsDefault = isDefault
 		c.IsSystem = isSystem
@@ -204,22 +193,10 @@ func (s *Store) ImportWorkspace(data *models.WorkspaceExport, newName string, ow
 		newCollID := newID()
 		collMap[c.ID] = newCollID
 
-		// Coerce the empty-string sentinel back to a valid JSON object before
-		// insert. Exports of NULL-settings rows surface as `""` per the
-		// store-layer sentinel contract (BUG-1482 round-2); Postgres's JSONB
-		// column rejects `""` at write time, and SQLite would accept it but
-		// then downstream JSON parsers would choke. CreateCollection does the
-		// same coercion on the normal create path; this loop bypasses that
-		// helper for transactional/verbatim import, so we mirror it here.
-		settings := c.Settings
-		if settings == "" {
-			settings = "{}"
-		}
-
 		_, err := tx.Exec(s.q(`
 			INSERT INTO collections (id, workspace_id, name, slug, icon, description, schema, settings, prefix, sort_order, is_default, is_system, created_at, updated_at)
 			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`),
-			newCollID, ws.ID, c.Name, c.Slug, c.Icon, c.Description, c.Schema, settings, c.Prefix, c.SortOrder, s.dialect.BoolToInt(c.IsDefault), s.dialect.BoolToInt(c.IsSystem),
+			newCollID, ws.ID, c.Name, c.Slug, c.Icon, c.Description, c.Schema, c.Settings, c.Prefix, c.SortOrder, s.dialect.BoolToInt(c.IsDefault), s.dialect.BoolToInt(c.IsSystem),
 			c.CreatedAt, c.UpdatedAt)
 		if err != nil {
 			return nil, fmt.Errorf("import collection %s: %w", c.Name, err)

--- a/internal/store/item_stars.go
+++ b/internal/store/item_stars.go
@@ -182,8 +182,7 @@ func (s *Store) buildCollectionDoneContextMap(workspaceID string) (map[string]co
 
 	m := make(map[string]collectionDoneContext)
 	for rows.Next() {
-		var id, rawSchema string
-		var rawSettings sql.NullString
+		var id, rawSchema, rawSettings string
 		if err := rows.Scan(&id, &rawSchema, &rawSettings); err != nil {
 			return nil, err
 		}
@@ -194,8 +193,8 @@ func (s *Store) buildCollectionDoneContextMap(workspaceID string) (map[string]co
 			// rather than silently treating the item as non-terminal.
 			ctx.schema = models.CollectionSchema{}
 		}
-		if rawSettings.Valid && rawSettings.String != "" {
-			_ = json.Unmarshal([]byte(rawSettings.String), &ctx.settings)
+		if rawSettings != "" {
+			_ = json.Unmarshal([]byte(rawSettings), &ctx.settings)
 		}
 		m[id] = ctx
 	}

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -2160,8 +2160,7 @@ func (s *Store) childrenDoneFiltersForCollection(workspaceID, collectionSlug str
 func scanCollectionDoneFilters(rows *sql.Rows) []collectionDoneFilter {
 	var filters []collectionDoneFilter
 	for rows.Next() {
-		var id, schemaJSON string
-		var settingsJSON sql.NullString
+		var id, schemaJSON, settingsJSON string
 		if err := rows.Scan(&id, &schemaJSON, &settingsJSON); err != nil {
 			continue
 		}
@@ -2179,8 +2178,8 @@ func scanCollectionDoneFilters(rows *sql.Rows) []collectionDoneFilter {
 			continue
 		}
 		var settings models.CollectionSettings
-		if settingsJSON.Valid && settingsJSON.String != "" {
-			_ = json.Unmarshal([]byte(settingsJSON.String), &settings)
+		if settingsJSON != "" {
+			_ = json.Unmarshal([]byte(settingsJSON), &settings)
 		}
 		key, values := models.TerminalValuesForDoneField(schema, settings)
 		filters = append(filters, collectionDoneFilter{


### PR DESCRIPTION
## Summary
Closes the IDEA-1484 loop. PR #562 (squash `0766d7e`) hardened `collections.settings` to `NOT NULL DEFAULT '{}'` at the schema level; this follow-up simplifies the reader code and consolidates write-side boundary normalization.

- **Reverted** the defensive `sql.NullString` scans on `collections.settings` at five sites (no longer load-bearing — column cannot hold NULL): `GetCollection`, `ListCollectionsMinimal`, `ListCollections` (collections.go), `ExportWorkspace` (export.go), and the helpers `buildCollectionDoneContextMap` (item_stars.go) + `scanCollectionDoneFilters` (items.go).
- **Retained** the import-side `""→"{}"` coercion in `ImportWorkspace` and **added** the equivalent coercion in `UpdateCollection`. The schema's `DEFAULT '{}'` only fires when the INSERT/UPDATE omits the column; explicit `""` values bypass it (Postgres rejects at JSONB type-validation, SQLite silently stores invalid JSON). These boundary normalizers protect the `settings always holds valid JSON` invariant at every API surface that accepts external data.
- **Tests** — removed the four BUG-1482 NULL-handling regression tests in PR #562 (constraint makes their setup impossible); kept the constraint-outcome tests from PR #562 (`TestCollectionsSettingsNotNullEnforced`, `TestCollectionsSettingsDefaultsToEmptyObject`); kept and updated `TestExportImportRoundTripWithEmptyStringSettings` with explicit boundary-framing; added `TestUpdateCollectionCoercesEmptyStringSettings`.

## Codex review loop
Three rounds with rotated framings:
- **R1 (diff lens)**: caught one P1 — the import-side coercion was reverted incorrectly (commit `6f22f94` restored it).
- **R2 (gap lens)**: caught one P2 — `UpdateCollection` had the same gap on its explicit-value write path (commit `fe862f3` added the coercion).
- **R3 (blast-radius lens)**: surfaced two findings, both pre-existing and out of scope for this PR's contract — filed as follow-ups.

## Known limitations / follow-ups
- **Frontend parseSettings** (`web/src/lib/types/index.ts:1083`) merges defaults only on parse-failure. The legacy `""` fallback that triggered this no longer exists post-PR #562, so existing healthy collections render `layout-undefined`. Pre-existing bug; surfaced by R3. Filed separately.
- **JSON object-shape validation** at JSONB writer boundaries — current coercion handles emptiness but not arbitrary malformed input. Filed separately for uniform treatment across `collections.settings` / `items.fields` / `items.tags` / `views.config`.
- **Sibling-table UPDATE paths** (`UpdateItem`, `UpdateView`) have the same defect class on `items.fields`/`tags` and `views.config`. Pre-existing; appended to the existing sibling-table-hardening IDEA.

## Test plan
- [x] `go test ./...` passes on SQLite default driver.
- [x] `PAD_TEST_POSTGRES_URL=postgres://pad:pad@localhost:5445/pad?sslmode=disable go test ./internal/store/ ./internal/server/` passes on Postgres.
- [x] `go build ./...` and `go vet ./...` clean.
- [x] Boundary-normalizer guards (`TestUpdateCollectionCoercesEmptyStringSettings`, `TestExportImportRoundTripWithEmptyStringSettings`) and constraint-outcome guards (`TestCollectionsSettingsNotNullEnforced`, `TestCollectionsSettingsDefaultsToEmptyObject`) pass on both drivers.
- [ ] CI matrix.

## Refs
- IDEA-1484 / PR #562 (the schema hardening this completes)
- BUG-1482 / PR #561 (the original two-job defense being simplified)
