### PR TITLE
fix(web): merge defaults in parseSettings/parseSchema (IDEA-1487)

### DIFF
--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -1072,23 +1072,23 @@ export function parseFields(item: Item): Record<string, any> {
 	}
 }
 
-const SCHEMA_DEFAULTS: CollectionSchema = { fields: [] };
+const schemaDefaults = (): CollectionSchema => ({ fields: [] });
 
 export function parseSchema(collection: Collection): CollectionSchema {
 	try {
-		return { ...SCHEMA_DEFAULTS, ...JSON.parse(collection.schema) };
+		return { ...schemaDefaults(), ...JSON.parse(collection.schema) };
 	} catch {
-		return { ...SCHEMA_DEFAULTS };
+		return schemaDefaults();
 	}
 }
 
-const SETTINGS_DEFAULTS: CollectionSettings = { layout: 'balanced', default_view: 'list' };
+const settingsDefaults = (): CollectionSettings => ({ layout: 'balanced', default_view: 'list' });
 
 export function parseSettings(collection: Collection): CollectionSettings {
 	try {
-		return { ...SETTINGS_DEFAULTS, ...JSON.parse(collection.settings) };
+		return { ...settingsDefaults(), ...JSON.parse(collection.settings) };
 	} catch {
-		return { ...SETTINGS_DEFAULTS };
+		return settingsDefaults();
 	}
 }
 

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -1115,7 +1115,7 @@ const DEFAULT_TERMINAL_STATUSES = [
 export function getTerminalOptions(collection: Collection): string[] {
 	const schema = parseSchema(collection);
 	const statusField = schema.fields.find((f) => f.key === 'status');
-	return statusField?.terminal_options ?? DEFAULT_TERMINAL_STATUSES;
+	return statusField?.terminal_options ?? [...DEFAULT_TERMINAL_STATUSES];
 }
 
 /** Check if a status value is terminal (finalized) for a given collection. */

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -1072,19 +1072,23 @@ export function parseFields(item: Item): Record<string, any> {
 	}
 }
 
+const SCHEMA_DEFAULTS: CollectionSchema = { fields: [] };
+
 export function parseSchema(collection: Collection): CollectionSchema {
 	try {
-		return JSON.parse(collection.schema);
+		return { ...SCHEMA_DEFAULTS, ...JSON.parse(collection.schema) };
 	} catch {
-		return { fields: [] };
+		return { ...SCHEMA_DEFAULTS };
 	}
 }
 
+const SETTINGS_DEFAULTS: CollectionSettings = { layout: 'balanced', default_view: 'list' };
+
 export function parseSettings(collection: Collection): CollectionSettings {
 	try {
-		return JSON.parse(collection.settings);
+		return { ...SETTINGS_DEFAULTS, ...JSON.parse(collection.settings) };
 	} catch {
-		return { layout: 'balanced', default_view: 'list' };
+		return { ...SETTINGS_DEFAULTS };
 	}
 }
 


### PR DESCRIPTION
## Summary

`parseSettings` and `parseSchema` in `web/src/lib/types/index.ts` previously applied default values only when `JSON.parse()` threw. Post-#562 every `collections.settings` row is the literal string `'{}'` (NULL-backfilled), so parsing succeeds and returns a bare `{}`, leaving downstream `.layout` / `.default_view` / `.fields` reads as `undefined`. Visible result: collection detail pages render with `class="layout-undefined"`; latent: any `parseSchema` consumer would `TypeError` on `schema.fields.find(...)` for a bare-`{}` schema.

This change extracts the defaults to factory functions and merges them before the parsed object on both success and catch paths. Explicit user-set fields still win.

## Plus

- **Symmetric patch on `parseSchema`.** 11 caller sites use `schema.fields.find/.filter`; same risk surface as `parseSettings`. Same fix shape.
- **Factory functions, not const spreads.** R1 codex pass caught shared-mutable-array reference semantics: a module-level `DEFAULTS.fields = []` shared by reference would let one caller's `.push` pollute the next. Defaults are now functions returning fresh objects per call.
- **`getTerminalOptions()` got the same treatment** (`[...DEFAULT_TERMINAL_STATUSES]` on fallback) — same pattern, one function down. R2 codex pass.
- **No new test setup.** `web/package.json` has no Vitest runner — only Playwright e2e. Wiring Vitest is out of scope for a one-line helper fix; gap documented for a future follow-up.
- **`QuickActionsMenu` wire-migration nuance.** `lib/components/common/QuickActionsMenu.svelte` spreads `parseSettings(collection)` into a write-back payload. After this PR, the first quick-action save on any previously-bare collection migrates `{layout, default_view}` into the persisted JSON. Harmless (matches what the UI already rendered against), keeps the spread idiom clean, no strip-defaults-on-write helper to maintain.

## Observable behavior changes

- Collection detail pages no longer render with `class="layout-undefined"`; the `balanced` layout is applied by default.
- Schema-driven views (board / table / list / item-card / filter-bar) no longer risk `TypeError` on collections with bare-`{}` schemas.
- First quick-action save on a previously-bare collection migrates defaults into stored JSON (one-time, idempotent).

## Test plan

- [x] `cd web && npm run build` — passes (adapter-static)
- [x] `cd web && npm run check` — 804 files, 0 errors, 6 pre-existing warnings (all unrelated to diff)
- [ ] CI matrix: Web build, Go (SQLite), Go (Postgres), Playwright e2e
- [ ] Manual visual check on a collection page post-merge
- [ ] Web `npm audit` job pre-existing failure on main (devalue/mermaid/svelte advisories) — document & proceed

## Refs

- IDEA-1487 — surfaced by codex R3 during the IDEA-1484 follow-up revert PR (#563)
- PR #562 — the migration that flipped the wire format from NULL to `'{}'`
- PR #563 — the consumer-simplification revert
- MISTA-45 in claude workspace — the corrective heuristic on schema-change defense removal
