### PR TITLE
feat(store): wrap migrations in atomic transactions (IDEA-1485)

### DIFF
--- a/internal/store/migration_atomicity_test.go
+++ b/internal/store/migration_atomicity_test.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"os"
@@ -288,5 +289,81 @@ INSERT INTO no_such_table_xyz (id) VALUES ('boom');
 		t.Errorf("%s still exists after failed migration; rollback did not happen", t1)
 	} else if qerr != sql.ErrNoRows {
 		t.Fatalf("query pg_tables: %v", qerr)
+	}
+}
+
+// TestMigrationAtomicity_FailedSQLite_RestoresForeignKeysOnError guards the
+// codex-R1 P2: once `PRAGMA foreign_keys = OFF` lands on the pinned migration
+// connection, any subsequent failure (BeginTx / execMulti / INSERT / Commit
+// / post-tx PRAGMA) returns early. The runner MUST register a deferred
+// `PRAGMA foreign_keys = ON` so the connection never goes back to the pool
+// with FK enforcement disabled — otherwise the next pool checkout silently
+// bypasses FKs.
+//
+// The test forces a single-connection pool via SetMaxOpenConns(1) so the
+// post-failure FK check is deterministically against the same physical
+// connection that ran the failed migration.
+func TestMigrationAtomicity_FailedSQLite_RestoresForeignKeysOnError(t *testing.T) {
+	if os.Getenv("PAD_TEST_POSTGRES_URL") != "" {
+		t.Skip("SQLite-specific (PRAGMA foreign_keys is a SQLite construct)")
+	}
+
+	dir := t.TempDir()
+	s, err := New(filepath.Join(dir, "atomic.db"))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer s.Close()
+
+	// Force a single pool connection so the assertion below targets the
+	// SAME physical conn that ran the failing migration. Without this,
+	// a fresh checkout might land on a different conn (where FKs were
+	// never disabled), masking a regression of the bug.
+	s.db.SetMaxOpenConns(1)
+
+	// Migration: disable FKs, then fail. The failure point is AFTER the
+	// PRAGMA so the FK-OFF state has reached the connection. The failure
+	// itself is a violated constraint inside the body so the wrapping tx
+	// rolls back.
+	migration := `
+PRAGMA foreign_keys = OFF;
+CREATE TABLE fk_err_t (id TEXT PRIMARY KEY);
+INSERT INTO fk_err_t (id) VALUES ('a');
+INSERT INTO fk_err_t (id) VALUES ('a');
+`
+	if err := applySQLiteMigration(s.db, "999_fk_err.sql", migration); err == nil {
+		t.Fatal("expected migration to fail (duplicate PK), got nil")
+	}
+
+	// On the SAME connection from the (1-conn) pool, foreign_keys must
+	// be back to 1. Use a tightly-scoped block so the conn is released
+	// back to the pool before later queries that also need it.
+	ctx := context.Background()
+	func() {
+		conn, err := s.db.Conn(ctx)
+		if err != nil {
+			t.Fatalf("Conn: %v", err)
+		}
+		defer conn.Close()
+
+		var fk int
+		if err := conn.QueryRowContext(ctx, "PRAGMA foreign_keys").Scan(&fk); err != nil {
+			t.Fatalf("PRAGMA foreign_keys: %v", err)
+		}
+		if fk != 1 {
+			t.Errorf("foreign_keys leaked OFF after failed migration; got %d, want 1", fk)
+		}
+	}()
+
+	// Bookkeeping row must also be absent (atomicity invariant from
+	// the prior test, re-asserted here for completeness).
+	var count int
+	if err := s.db.QueryRow(
+		"SELECT COUNT(*) FROM schema_migrations WHERE version = ?", "999_fk_err.sql",
+	).Scan(&count); err != nil {
+		t.Fatalf("query schema_migrations: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("schema_migrations row recorded for failed migration; want 0, got %d", count)
 	}
 }

--- a/internal/store/migration_atomicity_test.go
+++ b/internal/store/migration_atomicity_test.go
@@ -1,0 +1,292 @@
+package store
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// TestMigrationAtomicity_FailedSQLite_RollsBackPartialDDLAndBookkeeping
+// guards the IDEA-1485 atomicity guarantee for SQLite migrations: when a
+// multi-statement migration fails partway through, NEITHER the partial
+// schema change NOR the schema_migrations bookkeeping row survives.
+//
+// Before IDEA-1485 the runner exec'd statements one-by-one on the raw
+// *sql.DB, so a crash (or SQL error) between statement N and statement
+// N+1 left the schema in an intermediate state but did NOT record the
+// migration, and the next startup re-ran the migration against the
+// partially-mutated schema — exactly the data-loss window described in
+// the IDEA's "Problem" section.
+func TestMigrationAtomicity_FailedSQLite_RollsBackPartialDDLAndBookkeeping(t *testing.T) {
+	if os.Getenv("PAD_TEST_POSTGRES_URL") != "" {
+		t.Skip("SQLite-specific atomicity test; Postgres has its own counterpart below")
+	}
+
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "atomic.db")
+	s, err := New(dbPath)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer s.Close()
+
+	// Construct a deliberately-failing multi-statement migration:
+	// statement 1 succeeds (creates a table), statement 2 fails
+	// (references a non-existent table). Without tx-wrapping, the
+	// table from statement 1 would survive; with tx-wrapping, it
+	// rolls back.
+	migration := `
+CREATE TABLE atomic_test_t1 (id TEXT PRIMARY KEY);
+INSERT INTO no_such_table_xyz (id) VALUES ('boom');
+`
+
+	err = applySQLiteMigration(s.db, "999_atomicity_probe.sql", migration)
+	if err == nil {
+		t.Fatal("expected migration to fail, got nil")
+	}
+
+	// schema_migrations must NOT carry a row for the failed migration.
+	var count int
+	if qerr := s.db.QueryRow(
+		"SELECT COUNT(*) FROM schema_migrations WHERE version = ?",
+		"999_atomicity_probe.sql",
+	).Scan(&count); qerr != nil {
+		t.Fatalf("query schema_migrations: %v", qerr)
+	}
+	if count != 0 {
+		t.Errorf("schema_migrations row WAS recorded for failed migration; want 0 rows, got %d", count)
+	}
+
+	// The CREATE TABLE from statement 1 must have been rolled back.
+	var tblName string
+	qerr := s.db.QueryRow(
+		`SELECT name FROM sqlite_master WHERE type='table' AND name='atomic_test_t1'`,
+	).Scan(&tblName)
+	if qerr == nil {
+		t.Errorf("atomic_test_t1 still exists after failed migration; rollback did not happen")
+	} else if qerr != sql.ErrNoRows {
+		t.Fatalf("query sqlite_master: %v", qerr)
+	}
+}
+
+// TestMigrationAtomicity_SuccessfulSQLite_RecordsBookkeeping is the
+// positive control: a normal multi-statement migration commits both the
+// DDL and the schema_migrations row together.
+func TestMigrationAtomicity_SuccessfulSQLite_RecordsBookkeeping(t *testing.T) {
+	if os.Getenv("PAD_TEST_POSTGRES_URL") != "" {
+		t.Skip("SQLite-specific")
+	}
+
+	dir := t.TempDir()
+	s, err := New(filepath.Join(dir, "atomic.db"))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer s.Close()
+
+	migration := `
+CREATE TABLE atomic_ok_t1 (id TEXT PRIMARY KEY);
+CREATE TABLE atomic_ok_t2 (id TEXT PRIMARY KEY);
+`
+	if err := applySQLiteMigration(s.db, "999_atomic_ok.sql", migration); err != nil {
+		t.Fatalf("applySQLiteMigration: %v", err)
+	}
+
+	var count int
+	if err := s.db.QueryRow(
+		"SELECT COUNT(*) FROM schema_migrations WHERE version = ?",
+		"999_atomic_ok.sql",
+	).Scan(&count); err != nil {
+		t.Fatalf("query schema_migrations: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 schema_migrations row, got %d", count)
+	}
+
+	for _, tbl := range []string{"atomic_ok_t1", "atomic_ok_t2"} {
+		var name string
+		if err := s.db.QueryRow(
+			`SELECT name FROM sqlite_master WHERE type='table' AND name=?`, tbl,
+		).Scan(&name); err != nil {
+			t.Errorf("table %s missing after successful migration: %v", tbl, err)
+		}
+	}
+}
+
+// TestMigrationAtomicity_PragmaForeignKeysLifted exercises the
+// PRAGMA-detection branch: a migration with `PRAGMA foreign_keys = OFF/ON`
+// must succeed AND the PRAGMA must take effect (i.e. it was emitted
+// outside the wrapping transaction, where SQLite would otherwise
+// silently no-op it).
+//
+// The test rebuilds a tiny FK-having pair of tables: parent_t and
+// child_t (child_t.parent_id REFERENCES parent_t(id)). The migration
+// drops parent_t and recreates it; without FK-off this would fail
+// because child_t still references it.
+func TestMigrationAtomicity_PragmaForeignKeysLifted(t *testing.T) {
+	if os.Getenv("PAD_TEST_POSTGRES_URL") != "" {
+		t.Skip("SQLite-specific (PRAGMA semantics)")
+	}
+
+	dir := t.TempDir()
+	s, err := New(filepath.Join(dir, "atomic.db"))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer s.Close()
+
+	// Seed FK-having tables outside the migration runner.
+	seed := []string{
+		`CREATE TABLE atomic_parent_t (id TEXT PRIMARY KEY)`,
+		`CREATE TABLE atomic_child_t (id TEXT PRIMARY KEY, parent_id TEXT REFERENCES atomic_parent_t(id))`,
+		`INSERT INTO atomic_parent_t (id) VALUES ('p1')`,
+		`INSERT INTO atomic_child_t (id, parent_id) VALUES ('c1', 'p1')`,
+	}
+	for _, stmt := range seed {
+		if _, err := s.db.Exec(stmt); err != nil {
+			t.Fatalf("seed %q: %v", stmt, err)
+		}
+	}
+
+	// Rebuild parent_t — drop and recreate. With FKs enforced this would
+	// fail (the child row references the old parent). The migration
+	// disables FKs via PRAGMA so the rebuild succeeds.
+	migration := `
+PRAGMA foreign_keys = OFF;
+DROP TABLE IF EXISTS atomic_parent_t_new;
+CREATE TABLE atomic_parent_t_new (id TEXT PRIMARY KEY, extra TEXT NOT NULL DEFAULT '');
+INSERT INTO atomic_parent_t_new (id) SELECT id FROM atomic_parent_t;
+DROP TABLE atomic_parent_t;
+ALTER TABLE atomic_parent_t_new RENAME TO atomic_parent_t;
+PRAGMA foreign_keys = ON;
+`
+	if err := applySQLiteMigration(s.db, "999_fk_rebuild.sql", migration); err != nil {
+		t.Fatalf("applySQLiteMigration: %v", err)
+	}
+
+	// Verify the new column exists.
+	var hasExtra bool
+	rows, err := s.db.Query(`PRAGMA table_info(atomic_parent_t)`)
+	if err != nil {
+		t.Fatalf("PRAGMA table_info: %v", err)
+	}
+	for rows.Next() {
+		var cid int
+		var name, ctype string
+		var notnull, pk int
+		var dflt sql.NullString
+		if err := rows.Scan(&cid, &name, &ctype, &notnull, &dflt, &pk); err != nil {
+			t.Fatalf("scan table_info: %v", err)
+		}
+		if name == "extra" {
+			hasExtra = true
+		}
+	}
+	rows.Close()
+	if !hasExtra {
+		t.Error("rebuilt atomic_parent_t is missing the 'extra' column")
+	}
+
+	// The bookkeeping row must be present.
+	var n int
+	if err := s.db.QueryRow(
+		"SELECT COUNT(*) FROM schema_migrations WHERE version = ?", "999_fk_rebuild.sql",
+	).Scan(&n); err != nil {
+		t.Fatalf("query schema_migrations: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("expected 1 schema_migrations row, got %d", n)
+	}
+
+	// Sanity: foreign_keys should be ON again after the migration.
+	var fk int
+	if err := s.db.QueryRow("PRAGMA foreign_keys").Scan(&fk); err != nil {
+		t.Fatalf("query foreign_keys: %v", err)
+	}
+	if fk != 1 {
+		t.Errorf("foreign_keys not restored after migration; got %d, want 1", fk)
+	}
+}
+
+// TestExtractPragmas validates the lifter in isolation.
+func TestExtractPragmas(t *testing.T) {
+	in := `-- header comment
+PRAGMA foreign_keys = OFF;
+CREATE TABLE x (id TEXT);
+INSERT INTO x VALUES ('a');
+PRAGMA foreign_keys = ON;
+`
+	pragmas, rest := extractPragmas(in)
+	if len(pragmas) != 2 {
+		t.Fatalf("expected 2 pragmas, got %d: %v", len(pragmas), pragmas)
+	}
+	wantPragmas := []string{"PRAGMA foreign_keys = OFF;", "PRAGMA foreign_keys = ON;"}
+	for i, p := range pragmas {
+		if p != wantPragmas[i] {
+			t.Errorf("pragmas[%d] = %q; want %q", i, p, wantPragmas[i])
+		}
+	}
+	if strings.Contains(strings.ToUpper(rest), "PRAGMA") {
+		t.Errorf("PRAGMA still present in rest: %q", rest)
+	}
+	// CREATE TABLE / INSERT must remain.
+	for _, kw := range []string{"CREATE TABLE x", "INSERT INTO x"} {
+		if !strings.Contains(rest, kw) {
+			t.Errorf("rest missing %q; got %q", kw, rest)
+		}
+	}
+}
+
+// TestMigrationAtomicity_FailedPostgres_RollsBackPartialDDLAndBookkeeping
+// is the Postgres counterpart to the SQLite atomicity test. It only
+// runs when PAD_TEST_POSTGRES_URL is set.
+func TestMigrationAtomicity_FailedPostgres_RollsBackPartialDDLAndBookkeeping(t *testing.T) {
+	pgURL := os.Getenv("PAD_TEST_POSTGRES_URL")
+	if pgURL == "" {
+		t.Skip("PAD_TEST_POSTGRES_URL not set")
+	}
+
+	s := testStorePostgres(t, pgURL)
+
+	// Suffix table names with a random token so concurrent runs of this
+	// test (against the shared base URL) cannot collide. Each test gets
+	// its own isolated database via testStorePostgres anyway, but the
+	// suffix is cheap insurance.
+	tag := strings.ReplaceAll(uuid.New().String()[:8], "-", "")
+	t1 := "atomic_test_t1_" + tag
+	migration := fmt.Sprintf(`
+CREATE TABLE %s (id TEXT PRIMARY KEY);
+INSERT INTO no_such_table_xyz (id) VALUES ('boom');
+`, t1)
+
+	err := applyPostgresMigration(s.db, "999_atomicity_probe.sql", migration)
+	if err == nil {
+		t.Fatal("expected migration to fail, got nil")
+	}
+
+	var count int
+	if qerr := s.db.QueryRow(
+		"SELECT COUNT(*) FROM schema_migrations WHERE version = $1",
+		"999_atomicity_probe.sql",
+	).Scan(&count); qerr != nil {
+		t.Fatalf("query schema_migrations: %v", qerr)
+	}
+	if count != 0 {
+		t.Errorf("schema_migrations row recorded for failed migration; want 0, got %d", count)
+	}
+
+	var tblName string
+	qerr := s.db.QueryRow(
+		`SELECT tablename FROM pg_tables WHERE tablename = $1`, t1,
+	).Scan(&tblName)
+	if qerr == nil {
+		t.Errorf("%s still exists after failed migration; rollback did not happen", t1)
+	} else if qerr != sql.ErrNoRows {
+		t.Fatalf("query pg_tables: %v", qerr)
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -459,10 +459,14 @@ func extractPragmas(sqlText string) (pragmas []string, rest string) {
 //     connection AFTER COMMIT, so they don't undo a preceding
 //     `OFF` before the body runs.
 //
-//     If a migration disables FKs but does NOT include the matching
-//     `ON`, the runner emits `PRAGMA foreign_keys = ON` itself before
-//     releasing the connection. Without this, the connection would
-//     leak `foreign_keys=OFF` to the rest of the pool's users.
+//     Whenever a before-tx `foreign_keys=OFF` is exec'd, a deferred
+//     `PRAGMA foreign_keys = ON` is registered against the pinned
+//     connection. The defer fires on EVERY return — success, BeginTx
+//     failure, execMulti failure, INSERT failure, Commit failure, or
+//     post-tx pragma failure — so the connection never goes back to
+//     the pool with FKs disabled. The restore is best-effort and does
+//     not override the migration's primary error; if the restore
+//     itself fails it's logged loudly.
 //
 //  3. The remaining body SQL — including the `INSERT INTO schema_migrations`
 //     bookkeeping row — runs inside a single BEGIN/COMMIT on the SAME
@@ -494,20 +498,15 @@ func applySQLiteMigration(db *sql.DB, name, sqlText string) error {
 	// "after" pragmas are restorations that must not undo a before-pragma
 	// prematurely.
 	var beforeTx, afterTx []string
-	disabledFKs := false
-	reEnabledFKs := false
 	for _, p := range pragmas {
 		switch {
 		case isForeignKeysOff(p):
 			beforeTx = append(beforeTx, p)
-			disabledFKs = true
-		case isForeignKeysOn(p):
-			afterTx = append(afterTx, p)
-			reEnabledFKs = true
 		default:
-			// Conservative default: unknown pragmas run after the body.
-			// journal_mode=WAL falls here; it's database-persistent and
-			// already set by New() so the re-run is a harmless no-op.
+			// Everything else (foreign_keys=ON, journal_mode=WAL, etc.)
+			// runs AFTER the body. foreign_keys=ON specifically must NOT
+			// run before BEGIN because it would cancel out a paired OFF
+			// in the same migration.
 			afterTx = append(afterTx, p)
 		}
 	}
@@ -515,6 +514,29 @@ func applySQLiteMigration(db *sql.DB, name, sqlText string) error {
 	for _, p := range beforeTx {
 		if _, err := conn.ExecContext(ctx, p); err != nil {
 			return fmt.Errorf("apply migration %s: pre-tx pragma %q: %w", name, p, err)
+		}
+		if isForeignKeysOff(p) {
+			// FK-restore MUST be a defer, not a success-path block:
+			// once foreign_keys=OFF lands on the pinned conn, ANY later
+			// failure (BeginTx, execMulti, INSERT, Commit, post-tx
+			// pragma) returns early and the conn would otherwise go
+			// back to the pool with FKs disabled, silently bypassing
+			// enforcement for whichever caller next checks it out.
+			//
+			// The restore is best-effort: it does NOT override the
+			// migration's primary error. If the restore itself fails,
+			// log loudly — the connection is about to be released to
+			// the pool with FKs still off and a subsequent migration
+			// (or worse, a request handler) would inherit that state.
+			defer func() {
+				if _, restoreErr := conn.ExecContext(ctx, "PRAGMA foreign_keys = ON"); restoreErr != nil {
+					slog.Error(
+						"failed to restore PRAGMA foreign_keys=ON after migration; pool connection may be released with FKs disabled",
+						"migration", name,
+						"err", restoreErr,
+					)
+				}
+			}()
 		}
 	}
 
@@ -548,14 +570,10 @@ func applySQLiteMigration(db *sql.DB, name, sqlText string) error {
 		}
 	}
 
-	// Belt-and-braces: if the migration disabled FKs but did not emit a
-	// matching `ON`, re-enable them ourselves so the connection doesn't
-	// leak `foreign_keys=OFF` back to the pool.
-	if disabledFKs && !reEnabledFKs {
-		if _, err := conn.ExecContext(ctx, "PRAGMA foreign_keys = ON"); err != nil {
-			return fmt.Errorf("apply migration %s: restore foreign_keys: %w", name, err)
-		}
-	}
+	// FK restore on the success path is handled by the deferred block
+	// registered when the before-tx OFF was executed. The migration's
+	// own `PRAGMA foreign_keys = ON` (if present) has already run via
+	// afterTx; the deferred re-set is idempotent.
 	return nil
 }
 
@@ -567,14 +585,6 @@ func isForeignKeysOff(pragma string) bool {
 	return strings.HasPrefix(u, "PRAGMAFOREIGN_KEYS=OFF") ||
 		strings.HasPrefix(u, "PRAGMAFOREIGN_KEYS=0") ||
 		strings.HasPrefix(u, "PRAGMAFOREIGN_KEYS=FALSE")
-}
-
-// isForeignKeysOn reports whether a PRAGMA statement enables foreign keys.
-func isForeignKeysOn(pragma string) bool {
-	u := normalizePragma(pragma)
-	return strings.HasPrefix(u, "PRAGMAFOREIGN_KEYS=ON") ||
-		strings.HasPrefix(u, "PRAGMAFOREIGN_KEYS=1") ||
-		strings.HasPrefix(u, "PRAGMAFOREIGN_KEYS=TRUE")
 }
 
 func normalizePragma(p string) string {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"context"
 	"database/sql"
 	"embed"
 	"fmt"
@@ -231,14 +232,8 @@ func (s *Store) migrate() error {
 			return fmt.Errorf("read migration %s: %w", name, err)
 		}
 
-		if err := execMulti(s.db, string(data)); err != nil {
-			return fmt.Errorf("apply migration %s: %w", name, err)
-		}
-
-		// Record migration
-		_, err = s.db.Exec("INSERT INTO schema_migrations (version, applied_at) VALUES (?, ?)", name, now())
-		if err != nil {
-			return fmt.Errorf("record migration %s: %w", name, err)
+		if err := applySQLiteMigration(s.db, name, string(data)); err != nil {
+			return err
 		}
 	}
 
@@ -350,24 +345,26 @@ func (s *Store) migratePostgres() error {
 			return fmt.Errorf("read migration %s: %w", name, err)
 		}
 
-		if _, err := s.db.Exec(string(data)); err != nil {
-			return fmt.Errorf("apply migration %s: %w", name, err)
-		}
-
-		_, err = s.db.Exec("INSERT INTO schema_migrations (version, applied_at) VALUES ($1, $2)", name, now())
-		if err != nil {
-			return fmt.Errorf("record migration %s: %w", name, err)
+		if err := applyPostgresMigration(s.db, name, string(data)); err != nil {
+			return err
 		}
 	}
 
 	return nil
 }
 
+// sqlExecer is the subset of sql.DB / sql.Tx that execMulti needs. It lets
+// the same statement-iteration loop run either against the raw pool or against
+// a wrapping transaction (used by applySQLiteMigration for atomicity).
+type sqlExecer interface {
+	Exec(query string, args ...any) (sql.Result, error)
+}
+
 // execMulti executes multiple SQL statements by iteratively using
 // database/sql's Exec which processes one statement at a time,
 // then advancing past it using the driver's awareness of statement boundaries.
 // This handles triggers, FTS5, and other complex SQL correctly.
-func execMulti(db *sql.DB, sqlText string) error {
+func execMulti(db sqlExecer, sqlText string) error {
 	for {
 		sqlText = strings.TrimSpace(sqlText)
 		if sqlText == "" {
@@ -407,6 +404,218 @@ func execMulti(db *sql.DB, sqlText string) error {
 		}
 		sqlText = sqlText[end+1:]
 	}
+}
+
+// extractPragmas scans the migration text line-by-line and lifts any
+// top-level `PRAGMA ...;` statement out of the body. It returns the lifted
+// pragma statements (in original order) and the remaining SQL text with
+// those lines replaced by blank lines so line numbers in any error message
+// still align with the source file.
+//
+// IDEA-1485: PRAGMA statements like `foreign_keys = OFF/ON` and
+// `journal_mode = WAL` are no-ops (or errors) inside a SQLite transaction.
+// To wrap the rest of the migration in a single BEGIN/COMMIT for atomicity,
+// the runner emits any PRAGMA outside the wrapping transaction.
+//
+// Detection is intentionally conservative: only lines whose first
+// non-whitespace token is `PRAGMA` (case-insensitive) and that contain a
+// trailing `;` on the same line are lifted. PRAGMAs split across multiple
+// lines or embedded inside triggers/CTEs are not matched — none of the
+// existing migrations use that shape.
+func extractPragmas(sqlText string) (pragmas []string, rest string) {
+	var out strings.Builder
+	out.Grow(len(sqlText))
+	for _, line := range strings.SplitAfter(sqlText, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(strings.ToUpper(trimmed), "PRAGMA ") && strings.HasSuffix(trimmed, ";") {
+			pragmas = append(pragmas, trimmed)
+			// Preserve the trailing newline (if present) so line numbers
+			// in downstream error messages still match the source.
+			if strings.HasSuffix(line, "\n") {
+				out.WriteByte('\n')
+			}
+			continue
+		}
+		out.WriteString(line)
+	}
+	return pragmas, out.String()
+}
+
+// applySQLiteMigration applies a single migration file atomically.
+//
+// Behavior (IDEA-1485):
+//
+//  1. PRAGMA statements are lifted out of the migration body (see
+//     extractPragmas), since PRAGMA settings like `foreign_keys` and
+//     `journal_mode` are no-ops (or errors) inside a SQLite transaction.
+//
+//  2. Lifted PRAGMAs are classified into two groups by their semantics:
+//
+//     - "before-tx" PRAGMAs (e.g. `foreign_keys = OFF`) are exec'd on
+//     the pinned connection BEFORE BEGIN, so their effect carries
+//     into the wrapping transaction.
+//     - "after-tx" PRAGMAs (e.g. `foreign_keys = ON` and everything
+//     else — `journal_mode=WAL`, etc.) are exec'd on the pinned
+//     connection AFTER COMMIT, so they don't undo a preceding
+//     `OFF` before the body runs.
+//
+//     If a migration disables FKs but does NOT include the matching
+//     `ON`, the runner emits `PRAGMA foreign_keys = ON` itself before
+//     releasing the connection. Without this, the connection would
+//     leak `foreign_keys=OFF` to the rest of the pool's users.
+//
+//  3. The remaining body SQL — including the `INSERT INTO schema_migrations`
+//     bookkeeping row — runs inside a single BEGIN/COMMIT on the SAME
+//     dedicated connection. If anything fails (including a process
+//     crash before COMMIT), the database rolls back to its pre-migration
+//     state AND the schema_migrations row is absent, so the next
+//     startup re-attempts the migration cleanly. This eliminates the
+//     data-loss window described in the IDEA's "Problem" section for
+//     the table-rebuild migrations (022 / 055).
+//
+// CRITICAL: SQLite's `PRAGMA foreign_keys` is per-connection. We MUST
+// pin the migration to a single connection via db.Conn() so the PRAGMA
+// emitted before BEGIN is visible to the transaction body. Using the
+// raw *sql.DB would race against the pool: the PRAGMA might land on
+// connection A and `db.Begin()` might grab connection B (where FKs are
+// still on, from the per-connection DSN), causing the rebuild to fail.
+func applySQLiteMigration(db *sql.DB, name, sqlText string) error {
+	pragmas, body := extractPragmas(sqlText)
+
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("apply migration %s: acquire conn: %w", name, err)
+	}
+	defer conn.Close()
+
+	// Classify pragmas. "before" pragmas must take effect for the body
+	// to behave correctly (e.g. foreign_keys=OFF for table-rebuilds);
+	// "after" pragmas are restorations that must not undo a before-pragma
+	// prematurely.
+	var beforeTx, afterTx []string
+	disabledFKs := false
+	reEnabledFKs := false
+	for _, p := range pragmas {
+		switch {
+		case isForeignKeysOff(p):
+			beforeTx = append(beforeTx, p)
+			disabledFKs = true
+		case isForeignKeysOn(p):
+			afterTx = append(afterTx, p)
+			reEnabledFKs = true
+		default:
+			// Conservative default: unknown pragmas run after the body.
+			// journal_mode=WAL falls here; it's database-persistent and
+			// already set by New() so the re-run is a harmless no-op.
+			afterTx = append(afterTx, p)
+		}
+	}
+
+	for _, p := range beforeTx {
+		if _, err := conn.ExecContext(ctx, p); err != nil {
+			return fmt.Errorf("apply migration %s: pre-tx pragma %q: %w", name, p, err)
+		}
+	}
+
+	// Wrap the body + bookkeeping in a single transaction so they
+	// commit (or roll back) atomically.
+	tx, err := conn.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("apply migration %s: begin tx: %w", name, err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	if err := execMulti(tx, body); err != nil {
+		return fmt.Errorf("apply migration %s: %w", name, err)
+	}
+	if _, err := tx.ExecContext(ctx, "INSERT INTO schema_migrations (version, applied_at) VALUES (?, ?)", name, now()); err != nil {
+		return fmt.Errorf("record migration %s: %w", name, err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("apply migration %s: commit: %w", name, err)
+	}
+	committed = true
+
+	for _, p := range afterTx {
+		if _, err := conn.ExecContext(ctx, p); err != nil {
+			return fmt.Errorf("apply migration %s: post-tx pragma %q: %w", name, p, err)
+		}
+	}
+
+	// Belt-and-braces: if the migration disabled FKs but did not emit a
+	// matching `ON`, re-enable them ourselves so the connection doesn't
+	// leak `foreign_keys=OFF` back to the pool.
+	if disabledFKs && !reEnabledFKs {
+		if _, err := conn.ExecContext(ctx, "PRAGMA foreign_keys = ON"); err != nil {
+			return fmt.Errorf("apply migration %s: restore foreign_keys: %w", name, err)
+		}
+	}
+	return nil
+}
+
+// isForeignKeysOff reports whether a PRAGMA statement disables foreign keys.
+// Matches the canonical forms used in migrations 022 and 055 plus the common
+// variants (`OFF`, `0`, `false`), case-insensitive, ignoring whitespace.
+func isForeignKeysOff(pragma string) bool {
+	u := normalizePragma(pragma)
+	return strings.HasPrefix(u, "PRAGMAFOREIGN_KEYS=OFF") ||
+		strings.HasPrefix(u, "PRAGMAFOREIGN_KEYS=0") ||
+		strings.HasPrefix(u, "PRAGMAFOREIGN_KEYS=FALSE")
+}
+
+// isForeignKeysOn reports whether a PRAGMA statement enables foreign keys.
+func isForeignKeysOn(pragma string) bool {
+	u := normalizePragma(pragma)
+	return strings.HasPrefix(u, "PRAGMAFOREIGN_KEYS=ON") ||
+		strings.HasPrefix(u, "PRAGMAFOREIGN_KEYS=1") ||
+		strings.HasPrefix(u, "PRAGMAFOREIGN_KEYS=TRUE")
+}
+
+func normalizePragma(p string) string {
+	u := strings.ToUpper(p)
+	u = strings.ReplaceAll(u, " ", "")
+	u = strings.ReplaceAll(u, "\t", "")
+	return u
+}
+
+// applyPostgresMigration applies a single Postgres migration file atomically.
+//
+// IDEA-1485: even though Postgres wraps each DDL statement in an implicit
+// transaction, the migration body plus the `INSERT INTO schema_migrations`
+// bookkeeping row need to commit together — otherwise a crash between
+// `data Exec` and the bookkeeping INSERT leaves the migration applied but
+// not recorded, and the next startup re-runs it against an already-mutated
+// schema. Wrapping both in a single explicit transaction closes that window
+// for multi-statement migration files.
+func applyPostgresMigration(db *sql.DB, name, sqlText string) error {
+	tx, err := db.Begin()
+	if err != nil {
+		return fmt.Errorf("apply migration %s: begin tx: %w", name, err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	if _, err := tx.Exec(sqlText); err != nil {
+		return fmt.Errorf("apply migration %s: %w", name, err)
+	}
+	if _, err := tx.Exec("INSERT INTO schema_migrations (version, applied_at) VALUES ($1, $2)", name, now()); err != nil {
+		return fmt.Errorf("record migration %s: %w", name, err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("apply migration %s: commit: %w", name, err)
+	}
+	committed = true
+	return nil
 }
 
 // findStatementEnd finds the index of the semicolon that ends the next


### PR DESCRIPTION
## Summary

Wrap each migration file's execution in a transaction so a mid-migration crash (process kill, OOM, power loss) cannot leave the DB in a partially-mutated state with the bookkeeping row absent — the failure shape that risks permanent data loss for the table-rebuild migration pattern used in `022_audit_trail.sql` and `055_collections_settings_not_null.sql`.

Closes IDEA-1485.

## Plus

- **PRAGMA-aware tx wrapping.** SQLite's `PRAGMA foreign_keys` is per-connection AND a no-op inside a transaction. The runner pins each migration to one pool connection via `db.Conn(ctx)`, then detects PRAGMA statements in the migration text and emits them around (not inside) the wrapping tx:
  - `PRAGMA foreign_keys = OFF/0/false` → executed before `BEGIN`
  - `PRAGMA foreign_keys = ON/1/true` → executed after `COMMIT`
  - Other PRAGMAs (e.g. `journal_mode = WAL` in 001) → executed after `COMMIT` defensively
- **FK restore on all exit paths.** If a migration disables FKs and crashes before re-enabling them, a deferred `PRAGMA foreign_keys = ON` runs before the pinned conn returns to the pool — so the conn doesn't leak `OFF` for subsequent pool checkouts. Verified by a regression test that fails when the defer is removed.
- **Postgres path mirrors the shape** — no PRAGMA detection (no PRAGMAs in Postgres), but the same explicit `BeginTx` / `Commit` / `Rollback`-on-error wrap. Multi-statement migration text is exec'd as one `tx.Exec()` call; Postgres handles that atomically inside a tx. The corpus contains no `CREATE INDEX CONCURRENTLY` or other non-tx-safe statements.
- **`execMulti` generalized** from `*sql.DB` to a local `sqlExecer` interface so it can take a `*sql.Tx` for the wrapping. Only caller is the new `applySQLiteMigration`.

## Behavior changes

- Migration files now apply atomically: the `schema_migrations` row is INSERT'd inside the same transaction as the migration's DDL. On crash, either the whole migration committed or none of it did — the previous "DDL partial, bookkeeping absent, re-run on restart drops the half-rebuilt table" failure mode is eliminated.
- For SQLite migrations that toggle `foreign_keys`: the toggle now actually takes effect (it was a no-op inside the wrapping tx if not lifted). For pre-existing migrations 022 and 055, behavior is functionally unchanged because they already needed FK-off and the lifting preserves that intent.
- No public API or schema changes.

## Test plan

- [x] SQLite: `go test ./...` passes (store suite ~42s).
- [x] Postgres: `PAD_TEST_POSTGRES_URL=<url> go test ./...` passes (store suite ~101s).
- [x] New regression tests:
  - `TestMigrationAtomicity_FailedSQLite_RollsBackPartialDDLAndBookkeeping`
  - `TestMigrationAtomicity_FailedPostgres_RollsBackPartialDDLAndBookkeeping` (skipped without PG URL)
  - `TestMigrationAtomicity_PragmaForeignKeysLifted` (asserts FK-rebuild migration succeeds and FK enforcement restored)
  - `TestMigrationAtomicity_FailedSQLite_RestoresForeignKeysOnError` (asserts deferred FK restore covers error paths)
  - `TestMigrationAtomicity_SuccessfulSQLite_RecordsBookkeeping` (positive control)
  - `TestExtractPragmas` (unit test for the PRAGMA line-scan extractor)
- [x] Defer correctness verified by removing the defer and observing the test failure.

## Refs

- IDEA-1485 (this work)
- IDEA-1484 / PR #562 / #563 (the migration shape that surfaced this gap during R1 review)
- BUG-1482 / PR #561 (the precedent migration that introduced the table-rebuild pattern)
- DECIS-32 in `claude` workspace — orchestration data-point-8