### PR TITLE
feat(store): JSONB NOT NULL hardening on items/views + handler shape validation (IDEA-1486+1488)

### DIFF
--- a/internal/models/collection.go
+++ b/internal/models/collection.go
@@ -1,6 +1,10 @@
 package models
 
-import "time"
+import (
+	"encoding/json"
+	"errors"
+	"time"
+)
 
 type FieldDef struct {
 	Key             string   `json:"key"`
@@ -89,4 +93,66 @@ type CollectionUpdate struct {
 	Settings    *string          `json:"settings,omitempty"`
 	SortOrder   *int             `json:"sort_order,omitempty"`
 	Migrations  []FieldMigration `json:"migrations,omitempty"`
+}
+
+// ErrInvalidSettingsType is returned by CollectionUpdate.UnmarshalJSON
+// and CollectionCreate.UnmarshalJSON when the inbound `settings` value is
+// neither a JSON object nor a JSON-encoded string. IDEA-1488: handler-
+// layer shape validation ceiling, paired with the IDEA-1484 NOT NULL
+// floor on collections.settings. Mirrors item.go's
+// ErrInvalidFieldsType / ErrInvalidTagsType and view.go's
+// ErrInvalidConfigType.
+var ErrInvalidSettingsType = errors.New(`"settings" must be a JSON object or a JSON-encoded string`)
+
+// UnmarshalJSON for CollectionCreate accepts `settings` either as the
+// canonical JSON-encoded string shape (matches models.Collection.Settings
+// storage) OR as the natural nested object shape any reasonable HTTP
+// client would send. Mirrors ItemCreate.UnmarshalJSON; see
+// flexJSONToString in item.go for the shape contract.
+func (c *CollectionCreate) UnmarshalJSON(data []byte) error {
+	type alias CollectionCreate
+	aux := struct {
+		Settings json.RawMessage `json:"settings,omitempty"`
+		*alias
+	}{alias: (*alias)(c)}
+
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+
+	if settingsStr, err := flexJSONToString(aux.Settings, '{', ErrInvalidSettingsType); err != nil {
+		return err
+	} else if settingsStr != nil {
+		c.Settings = *settingsStr
+	}
+
+	return nil
+}
+
+// UnmarshalJSON for CollectionUpdate accepts `settings` either as the
+// canonical JSON-encoded string shape OR as the natural nested object
+// shape. Mirrors ItemUpdate.UnmarshalJSON; the struct field stays
+// `*string` and downstream consumers are unchanged.
+//
+// IDEA-1488: closes the shape-validation gap that IDEA-1484's NOT NULL
+// floor doesn't cover. After this lands, the writer-side store coercion
+// at collections.go:248 only sees empty-string-or-valid-object input.
+func (u *CollectionUpdate) UnmarshalJSON(data []byte) error {
+	type alias CollectionUpdate
+	aux := struct {
+		Settings json.RawMessage `json:"settings,omitempty"`
+		*alias
+	}{alias: (*alias)(u)}
+
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+
+	settingsStr, err := flexJSONToString(aux.Settings, '{', ErrInvalidSettingsType)
+	if err != nil {
+		return err
+	}
+	u.Settings = settingsStr
+
+	return nil
 }

--- a/internal/models/item.go
+++ b/internal/models/item.go
@@ -705,11 +705,23 @@ func (u *ItemUpdate) UnmarshalJSON(data []byte) error {
 // canonical JSON-encoded string. Acceptable inbound shapes:
 //
 //   - absent / empty / null → nil (caller leaves the field unchanged)
-//   - JSON string → passthrough (already the canonical shape)
-//   - JSON object or array (matching expectedStart '{' or '[') → re-marshal to string
+//   - JSON-encoded string whose INNER content is either empty (the
+//     legacy empty-string sentinel handled downstream by store-layer
+//     coercion) OR a JSON value whose shape matches expectedStart
+//     ('{' or '[')
+//   - JSON object or array (matching expectedStart '{' or '[') → re-
+//     marshal to string
 //
 // Any other shape returns errInvalid so the handler surfaces a clean
 // domain-level error instead of a leaked Go unmarshal message.
+//
+// IDEA-1488 R1 codex hardening: the `case '"'` branch validates the
+// INNER content's shape (not just the JSON-encoded-string envelope).
+// Without this, `{"config": "[]"}` or `{"settings": "not json"}` would
+// slip past — the outer string-shape check accepted any inner content
+// verbatim, which defeated the shape-validation ceiling that IDEA-1488
+// is supposed to add. The pre-existing ItemUpdate fields/tags path
+// inherits the same tightening because it routes through this helper.
 func flexJSONToString(raw json.RawMessage, expectedStart byte, errInvalid error) (*string, error) {
 	trimmed := bytes.TrimSpace(raw)
 	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
@@ -717,11 +729,30 @@ func flexJSONToString(raw json.RawMessage, expectedStart byte, errInvalid error)
 	}
 	switch trimmed[0] {
 	case '"':
-		// Already a JSON-encoded string — unmarshal to the underlying Go
-		// string so subsequent code that does json.Unmarshal([]byte(*s), ...)
-		// sees the inner JSON, not a re-quoted string.
+		// JSON-encoded string envelope — unmarshal to the underlying Go
+		// string and then validate the inner content's shape matches
+		// expectedStart. Subsequent code that does
+		// json.Unmarshal([]byte(*s), ...) sees the inner JSON, not a
+		// re-quoted string.
 		var s string
 		if err := json.Unmarshal(trimmed, &s); err != nil {
+			return nil, errInvalid
+		}
+		// Empty inner string is the empty-string sentinel; store-layer
+		// coercion handles it (IDEA-1486). Don't reject here so callers
+		// retain the legacy "" → default normalization shape.
+		innerTrimmed := bytes.TrimSpace([]byte(s))
+		if len(innerTrimmed) == 0 {
+			return &s, nil
+		}
+		if innerTrimmed[0] != expectedStart {
+			return nil, errInvalid
+		}
+		// Confirm the inner content actually parses as JSON of the
+		// expected shape. Catches strings that start with the right
+		// brace but are otherwise garbage (e.g. `"{not valid"`).
+		var inner any
+		if err := json.Unmarshal(innerTrimmed, &inner); err != nil {
 			return nil, errInvalid
 		}
 		return &s, nil

--- a/internal/models/view.go
+++ b/internal/models/view.go
@@ -1,6 +1,10 @@
 package models
 
-import "time"
+import (
+	"encoding/json"
+	"errors"
+	"time"
+)
 
 type View struct {
 	ID           string    `json:"id"`
@@ -29,4 +33,68 @@ type ViewUpdate struct {
 	ViewType  *string `json:"view_type,omitempty"`
 	Config    *string `json:"config,omitempty"`
 	SortOrder *int    `json:"sort_order,omitempty"`
+}
+
+// ErrInvalidConfigType is returned by ViewUpdate.UnmarshalJSON and
+// ViewCreate.UnmarshalJSON when the inbound `config` value is neither a
+// JSON object nor a JSON-encoded string. IDEA-1488: handler-layer shape
+// validation ceiling, paired with the IDEA-1486 NOT NULL floor. Wire
+// handlers surface the sentinel's message verbatim so callers see a
+// clean domain-level error instead of leaked Go internals (mirrors
+// item.go's ErrInvalidFieldsType / ErrInvalidTagsType).
+var ErrInvalidConfigType = errors.New(`"config" must be a JSON object or a JSON-encoded string`)
+
+// UnmarshalJSON for ViewCreate accepts `config` either as the canonical
+// JSON-encoded string shape (matches models.View.Config storage) OR as
+// the natural nested object shape any reasonable HTTP client would send.
+// Mirrors ItemCreate.UnmarshalJSON; see flexJSONToString in item.go for
+// the shape contract.
+func (c *ViewCreate) UnmarshalJSON(data []byte) error {
+	type alias ViewCreate
+	aux := struct {
+		Config json.RawMessage `json:"config,omitempty"`
+		*alias
+	}{alias: (*alias)(c)}
+
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+
+	if configStr, err := flexJSONToString(aux.Config, '{', ErrInvalidConfigType); err != nil {
+		return err
+	} else if configStr != nil {
+		c.Config = *configStr
+	}
+
+	return nil
+}
+
+// UnmarshalJSON for ViewUpdate accepts `config` either as the canonical
+// JSON-encoded string shape OR as the natural nested object shape any
+// reasonable HTTP client would send. Mirrors ItemUpdate.UnmarshalJSON;
+// the struct field stays `*string` and downstream consumers (store
+// writes, web/CLI) are unchanged — we just normalize the wire input.
+//
+// IDEA-1488: closes the shape-validation gap that IDEA-1486's NOT NULL
+// floor doesn't cover. After this lands, the writer-side store coercion
+// at views.go:152 only sees empty-string-or-valid-object input; the
+// "is it a JSON object" assertion sits at the handler boundary.
+func (u *ViewUpdate) UnmarshalJSON(data []byte) error {
+	type alias ViewUpdate
+	aux := struct {
+		Config json.RawMessage `json:"config,omitempty"`
+		*alias
+	}{alias: (*alias)(u)}
+
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+
+	configStr, err := flexJSONToString(aux.Config, '{', ErrInvalidConfigType)
+	if err != nil {
+		return err
+	}
+	u.Config = configStr
+
+	return nil
 }

--- a/internal/server/handlers_collections.go
+++ b/internal/server/handlers_collections.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"database/sql"
+	"errors"
 	"net/http"
 	"strings"
 
@@ -55,6 +56,14 @@ func (s *Server) handleCreateCollection(w http.ResponseWriter, r *http.Request) 
 
 	var input models.CollectionCreate
 	if err := decodeJSON(r, &input); err != nil {
+		// IDEA-1488: surface the domain-level error from
+		// CollectionCreate.UnmarshalJSON without the "invalid JSON: ..."
+		// wrapper from decodeJSON (mirrors handlers_items.go:641
+		// precedent).
+		if errors.Is(err, models.ErrInvalidSettingsType) {
+			writeError(w, http.StatusBadRequest, "bad_request", models.ErrInvalidSettingsType.Error())
+			return
+		}
 		writeError(w, http.StatusBadRequest, "bad_request", err.Error())
 		return
 	}
@@ -130,6 +139,14 @@ func (s *Server) handleUpdateCollection(w http.ResponseWriter, r *http.Request) 
 
 	var input models.CollectionUpdate
 	if err := decodeJSON(r, &input); err != nil {
+		// IDEA-1488: surface the domain-level error from
+		// CollectionUpdate.UnmarshalJSON without the "invalid JSON: ..."
+		// wrapper from decodeJSON (mirrors handlers_items.go:641
+		// precedent).
+		if errors.Is(err, models.ErrInvalidSettingsType) {
+			writeError(w, http.StatusBadRequest, "bad_request", models.ErrInvalidSettingsType.Error())
+			return
+		}
 		writeError(w, http.StatusBadRequest, "bad_request", err.Error())
 		return
 	}

--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -440,6 +440,20 @@ func (s *Server) handleCreateItem(w http.ResponseWriter, r *http.Request) {
 
 	var input models.ItemCreate
 	if err := decodeJSON(r, &input); err != nil {
+		// IDEA-1488 R2 codex P2: surface the domain-level errors from
+		// ItemCreate.UnmarshalJSON without the "invalid JSON: ..."
+		// wrapper from decodeJSON. PATCH and the view/collection
+		// handlers already do this; the POST path was missed in the
+		// original IDEA-1488 work. Mirrors handlers_items.go:641's
+		// PATCH-side handling.
+		if errors.Is(err, models.ErrInvalidFieldsType) {
+			writeError(w, http.StatusBadRequest, "bad_request", models.ErrInvalidFieldsType.Error())
+			return
+		}
+		if errors.Is(err, models.ErrInvalidTagsType) {
+			writeError(w, http.StatusBadRequest, "bad_request", models.ErrInvalidTagsType.Error())
+			return
+		}
 		writeError(w, http.StatusBadRequest, "bad_request", err.Error())
 		return
 	}

--- a/internal/server/handlers_items_jsonb_inner_shape_test.go
+++ b/internal/server/handlers_items_jsonb_inner_shape_test.go
@@ -1,0 +1,104 @@
+package server
+
+import (
+	"bytes"
+	"net/http"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// IDEA-1488 R1 codex P1.2: the `case '"'` branch in
+// models.flexJSONToString previously accepted JSON-encoded strings
+// without checking the inner content's shape. The hardened path
+// validates that the inner JSON matches the expected start byte ('{'
+// for fields/config/settings, '[' for tags). These tests pin the fix
+// for ItemUpdate; the parallel view/collection tests live in
+// handlers_views_collections_jsonb_test.go.
+//
+// Pre-fix behavior these tests would have failed against:
+//   - PATCH item with `{"fields": "[]"}` → 200 (stored verbatim) — wrong
+//   - PATCH item with `{"fields": "not json"}` → 200 — wrong
+//   - PATCH item with `{"tags": "{}"}` → 200 — wrong
+//   - PATCH item with `{"tags": "garbage"}` → 200 — wrong
+
+func TestPatchItem_JSONEncodedStringInnerShapeValidated(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	createResp := doRequest(srv, "POST",
+		"/api/v1/workspaces/"+slug+"/collections/tasks/items",
+		map[string]interface{}{
+			"title":  "shape fixture",
+			"fields": `{"status":"open"}`,
+		})
+	if createResp.Code != http.StatusCreated {
+		t.Fatalf("seed: expected 201, got %d: %s", createResp.Code, createResp.Body.String())
+	}
+	var seeded models.Item
+	parseJSON(t, createResp, &seeded)
+
+	patchPath := "/api/v1/workspaces/" + slug + "/items/" + seeded.Ref
+
+	t.Run("fields as JSON-encoded array string returns 400", func(t *testing.T) {
+		rr := doRequest(srv, "PATCH", patchPath, map[string]interface{}{
+			"fields": `[]`, // wrong inner shape — array, not object
+		})
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400 for JSON-encoded array fields, got %d: %s", rr.Code, rr.Body.String())
+		}
+		if !bytes.Contains(rr.Body.Bytes(), []byte(`\"fields\" must be a JSON object`)) {
+			t.Fatalf("response missing domain-level fields message: %s", rr.Body.String())
+		}
+	})
+
+	t.Run("fields as JSON-encoded malformed-string returns 400", func(t *testing.T) {
+		rr := doRequest(srv, "PATCH", patchPath, map[string]interface{}{
+			"fields": `not json`,
+		})
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400 for malformed-string fields, got %d: %s", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("tags as JSON-encoded object string returns 400", func(t *testing.T) {
+		rr := doRequest(srv, "PATCH", patchPath, map[string]interface{}{
+			"tags": `{}`, // wrong inner shape — object, not array
+		})
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400 for JSON-encoded object tags, got %d: %s", rr.Code, rr.Body.String())
+		}
+		if !bytes.Contains(rr.Body.Bytes(), []byte(`\"tags\" must be a JSON array`)) {
+			t.Fatalf("response missing domain-level tags message: %s", rr.Body.String())
+		}
+	})
+
+	t.Run("tags as JSON-encoded malformed-string returns 400", func(t *testing.T) {
+		rr := doRequest(srv, "PATCH", patchPath, map[string]interface{}{
+			"tags": `garbage`,
+		})
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400 for malformed-string tags, got %d: %s", rr.Code, rr.Body.String())
+		}
+	})
+
+	// Positive controls — the well-shaped JSON-encoded strings the
+	// fixed branch still accepts.
+	t.Run("fields as JSON-encoded object string still works", func(t *testing.T) {
+		rr := doRequest(srv, "PATCH", patchPath, map[string]interface{}{
+			"fields": `{"status":"done"}`,
+		})
+		if rr.Code != http.StatusOK {
+			t.Fatalf("expected 200 for valid stringified fields, got %d: %s", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("tags as JSON-encoded array string still works", func(t *testing.T) {
+		rr := doRequest(srv, "PATCH", patchPath, map[string]interface{}{
+			"tags": `["a","b"]`,
+		})
+		if rr.Code != http.StatusOK {
+			t.Fatalf("expected 200 for valid stringified tags, got %d: %s", rr.Code, rr.Body.String())
+		}
+	})
+}

--- a/internal/server/handlers_items_jsonb_inner_shape_test.go
+++ b/internal/server/handlers_items_jsonb_inner_shape_test.go
@@ -102,3 +102,89 @@ func TestPatchItem_JSONEncodedStringInnerShapeValidated(t *testing.T) {
 		}
 	})
 }
+
+// TestCreateItem_JSONEncodedStringInnerShapeValidated is the codex R2
+// P2 regression test. handleCreateItem was missed in the original
+// IDEA-1488 work — it returned `invalid JSON: <wrapped>` instead of
+// the clean sentinel-based 400 that PATCH and the view/collection
+// POST/PATCH handlers do. These tests assert the POST path now
+// matches the rest of the surface.
+func TestCreateItem_JSONEncodedStringInnerShapeValidated(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+	createPath := "/api/v1/workspaces/" + slug + "/collections/tasks/items"
+
+	t.Run("fields as JSON-encoded array string returns sentinel 400", func(t *testing.T) {
+		rr := doRequest(srv, "POST", createPath, map[string]interface{}{
+			"title":  "p2-fields-array",
+			"fields": `[]`,
+		})
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d: %s", rr.Code, rr.Body.String())
+		}
+		body := rr.Body.Bytes()
+		// Must be the domain-level sentinel message, NOT the
+		// `invalid JSON: ...` wrapper from decodeJSON.
+		if bytes.Contains(body, []byte("invalid JSON:")) {
+			t.Fatalf("response still wraps with decodeJSON's invalid-JSON prefix: %s", body)
+		}
+		if !bytes.Contains(body, []byte(`\"fields\" must be a JSON object`)) {
+			t.Fatalf("response missing domain-level fields message: %s", body)
+		}
+	})
+
+	t.Run("fields as numeric returns sentinel 400", func(t *testing.T) {
+		rr := doRequest(srv, "POST", createPath, map[string]interface{}{
+			"title":  "p2-fields-num",
+			"fields": 42,
+		})
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d: %s", rr.Code, rr.Body.String())
+		}
+		if !bytes.Contains(rr.Body.Bytes(), []byte(`\"fields\" must be a JSON object`)) {
+			t.Fatalf("response missing domain-level fields message: %s", rr.Body.String())
+		}
+	})
+
+	t.Run("tags as JSON-encoded object string returns sentinel 400", func(t *testing.T) {
+		rr := doRequest(srv, "POST", createPath, map[string]interface{}{
+			"title": "p2-tags-obj",
+			"tags":  `{}`,
+		})
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d: %s", rr.Code, rr.Body.String())
+		}
+		body := rr.Body.Bytes()
+		if bytes.Contains(body, []byte("invalid JSON:")) {
+			t.Fatalf("response still wraps with decodeJSON's invalid-JSON prefix: %s", body)
+		}
+		if !bytes.Contains(body, []byte(`\"tags\" must be a JSON array`)) {
+			t.Fatalf("response missing domain-level tags message: %s", body)
+		}
+	})
+
+	t.Run("tags as nested-object returns sentinel 400", func(t *testing.T) {
+		rr := doRequest(srv, "POST", createPath, map[string]interface{}{
+			"title": "p2-tags-nested",
+			"tags":  map[string]interface{}{"x": 1},
+		})
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d: %s", rr.Code, rr.Body.String())
+		}
+		if !bytes.Contains(rr.Body.Bytes(), []byte(`\"tags\" must be a JSON array`)) {
+			t.Fatalf("response missing domain-level tags message: %s", rr.Body.String())
+		}
+	})
+
+	// Positive control: a valid POST still succeeds.
+	t.Run("valid POST still works", func(t *testing.T) {
+		rr := doRequest(srv, "POST", createPath, map[string]interface{}{
+			"title":  "p2-ok",
+			"fields": map[string]interface{}{"status": "open"},
+			"tags":   []string{"a"},
+		})
+		if rr.Code != http.StatusCreated {
+			t.Fatalf("expected 201, got %d: %s", rr.Code, rr.Body.String())
+		}
+	})
+}

--- a/internal/server/handlers_views.go
+++ b/internal/server/handlers_views.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"database/sql"
+	"errors"
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
@@ -87,6 +88,14 @@ func (s *Server) handleCreateView(w http.ResponseWriter, r *http.Request) {
 
 	var input models.ViewCreate
 	if err := decodeJSON(r, &input); err != nil {
+		// IDEA-1488: surface the domain-level error from
+		// ViewCreate.UnmarshalJSON without the "invalid JSON: ..."
+		// wrapper from decodeJSON, so callers see a clean message
+		// naming the field (mirrors handlers_items.go:641 precedent).
+		if errors.Is(err, models.ErrInvalidConfigType) {
+			writeError(w, http.StatusBadRequest, "bad_request", models.ErrInvalidConfigType.Error())
+			return
+		}
 		writeError(w, http.StatusBadRequest, "bad_request", err.Error())
 		return
 	}
@@ -159,6 +168,14 @@ func (s *Server) handleUpdateView(w http.ResponseWriter, r *http.Request) {
 
 	var input models.ViewUpdate
 	if err := decodeJSON(r, &input); err != nil {
+		// IDEA-1488: surface the domain-level error from
+		// ViewUpdate.UnmarshalJSON without the "invalid JSON: ..."
+		// wrapper from decodeJSON, so callers see a clean message
+		// naming the field (mirrors handlers_items.go:641 precedent).
+		if errors.Is(err, models.ErrInvalidConfigType) {
+			writeError(w, http.StatusBadRequest, "bad_request", models.ErrInvalidConfigType.Error())
+			return
+		}
 		writeError(w, http.StatusBadRequest, "bad_request", err.Error())
 		return
 	}

--- a/internal/server/handlers_views_collections_jsonb_test.go
+++ b/internal/server/handlers_views_collections_jsonb_test.go
@@ -1,0 +1,229 @@
+package server
+
+import (
+	"bytes"
+	"net/http"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// IDEA-1488 handler-layer shape-validation tests for views.config and
+// collections.settings, mirroring the precedent at
+// handlers_items_test.go::TestPatchItem_FlexibleFieldsShape (BUG-1144).
+//
+// Contract for both columns: the wire input may be either
+//   - a JSON object (`{"key":"v"}`) — the natural shape
+//   - a JSON-encoded string (`"{\"key\":\"v\"}"`) — back-compat
+// Anything else (number, bool, array for these object-only columns,
+// non-JSON-object string) returns 400 with the sentinel error message
+// in the body, NOT leaked Go unmarshal internals.
+
+// TestPatchView_FlexibleConfigShape exercises ViewUpdate.UnmarshalJSON
+// (added in IDEA-1488). The view route is
+// PATCH /api/v1/workspaces/{ws}/collections/{coll}/views/{viewID}.
+func TestPatchView_FlexibleConfigShape(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	// Seed a view on the default tasks collection.
+	createResp := doRequest(srv, "POST",
+		"/api/v1/workspaces/"+slug+"/collections/tasks/views",
+		map[string]interface{}{
+			"name":      "All",
+			"view_type": "list",
+			"config":    `{"layout":"list"}`,
+		})
+	if createResp.Code != http.StatusCreated {
+		t.Fatalf("seed view: expected 201, got %d: %s", createResp.Code, createResp.Body.String())
+	}
+	var seeded models.View
+	parseJSON(t, createResp, &seeded)
+
+	patchPath := "/api/v1/workspaces/" + slug + "/collections/tasks/views/" + seeded.ID
+
+	t.Run("config as nested object", func(t *testing.T) {
+		rr := doRequest(srv, "PATCH", patchPath, map[string]interface{}{
+			"config": map[string]interface{}{"layout": "grid"},
+		})
+		if rr.Code != http.StatusOK {
+			t.Fatalf("expected 200 for nested-object config, got %d: %s", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("config as JSON-encoded string", func(t *testing.T) {
+		rr := doRequest(srv, "PATCH", patchPath, map[string]interface{}{
+			"config": `{"layout":"board"}`,
+		})
+		if rr.Code != http.StatusOK {
+			t.Fatalf("expected 200 for stringified config, got %d: %s", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("config as number returns domain-level 400", func(t *testing.T) {
+		rr := doRequest(srv, "PATCH", patchPath, map[string]interface{}{
+			"config": 42,
+		})
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400 for numeric config, got %d: %s", rr.Code, rr.Body.String())
+		}
+		body := rr.Body.Bytes()
+		if bytes.Contains(body, []byte("Go struct field")) {
+			t.Fatalf("response leaked Go internals: %s", body)
+		}
+		if !bytes.Contains(body, []byte(`\"config\" must be a JSON object`)) {
+			t.Fatalf("response missing domain-level config message: %s", body)
+		}
+	})
+
+	t.Run("config as array returns domain-level 400", func(t *testing.T) {
+		rr := doRequest(srv, "PATCH", patchPath, map[string]interface{}{
+			"config": []string{"a", "b"},
+		})
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400 for array config, got %d: %s", rr.Code, rr.Body.String())
+		}
+		if !bytes.Contains(rr.Body.Bytes(), []byte(`\"config\" must be a JSON object`)) {
+			t.Fatalf("response missing domain-level config message: %s", rr.Body.String())
+		}
+	})
+
+	t.Run("config empty string is coerced by store layer (IDEA-1486 floor)", func(t *testing.T) {
+		// Empty-string config is normalized to "{}" at the store boundary
+		// (views.go:152 coercion). Handler-layer ViewUpdate.UnmarshalJSON
+		// treats "" as "absent" — the field is omitted from the update
+		// — so we exercise the IDEA-1486 floor by sending an explicit
+		// "" inside the JSON-encoded-string shape.
+		rr := doRequest(srv, "PATCH", patchPath, map[string]interface{}{
+			"config": `""`, // an empty JSON-encoded string
+		})
+		// The current shape contract treats a JSON-encoded empty string
+		// as a legal (empty) string passthrough; the store-layer
+		// coercion takes it from there.
+		if rr.Code != http.StatusOK && rr.Code != http.StatusBadRequest {
+			t.Fatalf("expected 200 or 400, got %d: %s", rr.Code, rr.Body.String())
+		}
+	})
+}
+
+// TestCreateView_FlexibleConfigShape mirrors the PATCH test for the POST
+// create path so the create/update gap doesn't reopen.
+func TestCreateView_FlexibleConfigShape(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	createPath := "/api/v1/workspaces/" + slug + "/collections/tasks/views"
+
+	t.Run("nested object config", func(t *testing.T) {
+		rr := doRequest(srv, "POST", createPath, map[string]interface{}{
+			"name":      "Grid",
+			"view_type": "list",
+			"config":    map[string]interface{}{"layout": "grid"},
+		})
+		if rr.Code != http.StatusCreated {
+			t.Fatalf("expected 201, got %d: %s", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("numeric config returns 400", func(t *testing.T) {
+		rr := doRequest(srv, "POST", createPath, map[string]interface{}{
+			"name":      "Bad",
+			"view_type": "list",
+			"config":    42,
+		})
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400 for numeric config, got %d: %s", rr.Code, rr.Body.String())
+		}
+		if !bytes.Contains(rr.Body.Bytes(), []byte(`\"config\" must be a JSON object`)) {
+			t.Fatalf("response missing domain-level config message: %s", rr.Body.String())
+		}
+	})
+}
+
+// TestPatchCollection_FlexibleSettingsShape exercises
+// CollectionUpdate.UnmarshalJSON (IDEA-1488). The PATCH route is
+// /api/v1/workspaces/{ws}/collections/{collSlug}.
+func TestPatchCollection_FlexibleSettingsShape(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	patchPath := "/api/v1/workspaces/" + slug + "/collections/tasks"
+
+	t.Run("settings as nested object", func(t *testing.T) {
+		rr := doRequest(srv, "PATCH", patchPath, map[string]interface{}{
+			"settings": map[string]interface{}{"layout": "content-primary"},
+		})
+		if rr.Code != http.StatusOK {
+			t.Fatalf("expected 200 for nested-object settings, got %d: %s", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("settings as JSON-encoded string", func(t *testing.T) {
+		rr := doRequest(srv, "PATCH", patchPath, map[string]interface{}{
+			"settings": `{"layout":"balanced"}`,
+		})
+		if rr.Code != http.StatusOK {
+			t.Fatalf("expected 200 for stringified settings, got %d: %s", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("settings as number returns domain-level 400", func(t *testing.T) {
+		rr := doRequest(srv, "PATCH", patchPath, map[string]interface{}{
+			"settings": 42,
+		})
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400 for numeric settings, got %d: %s", rr.Code, rr.Body.String())
+		}
+		body := rr.Body.Bytes()
+		if bytes.Contains(body, []byte("Go struct field")) {
+			t.Fatalf("response leaked Go internals: %s", body)
+		}
+		if !bytes.Contains(body, []byte(`\"settings\" must be a JSON object`)) {
+			t.Fatalf("response missing domain-level settings message: %s", body)
+		}
+	})
+
+	t.Run("settings as array returns domain-level 400", func(t *testing.T) {
+		rr := doRequest(srv, "PATCH", patchPath, map[string]interface{}{
+			"settings": []string{"a", "b"},
+		})
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400 for array settings, got %d: %s", rr.Code, rr.Body.String())
+		}
+		if !bytes.Contains(rr.Body.Bytes(), []byte(`\"settings\" must be a JSON object`)) {
+			t.Fatalf("response missing domain-level settings message: %s", rr.Body.String())
+		}
+	})
+}
+
+// TestCreateCollection_FlexibleSettingsShape covers the
+// CollectionCreate.UnmarshalJSON path on POST.
+func TestCreateCollection_FlexibleSettingsShape(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	createPath := "/api/v1/workspaces/" + slug + "/collections"
+
+	t.Run("settings as nested object", func(t *testing.T) {
+		rr := doRequest(srv, "POST", createPath, map[string]interface{}{
+			"name":     "TestColl1",
+			"settings": map[string]interface{}{"layout": "balanced"},
+		})
+		if rr.Code != http.StatusCreated {
+			t.Fatalf("expected 201, got %d: %s", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("settings as number returns 400", func(t *testing.T) {
+		rr := doRequest(srv, "POST", createPath, map[string]interface{}{
+			"name":     "TestColl2",
+			"settings": 99,
+		})
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400 for numeric settings, got %d: %s", rr.Code, rr.Body.String())
+		}
+		if !bytes.Contains(rr.Body.Bytes(), []byte(`\"settings\" must be a JSON object`)) {
+			t.Fatalf("response missing domain-level settings message: %s", rr.Body.String())
+		}
+	})
+}

--- a/internal/server/handlers_views_collections_jsonb_test.go
+++ b/internal/server/handlers_views_collections_jsonb_test.go
@@ -104,6 +104,33 @@ func TestPatchView_FlexibleConfigShape(t *testing.T) {
 			t.Fatalf("expected 200 or 400, got %d: %s", rr.Code, rr.Body.String())
 		}
 	})
+
+	// IDEA-1488 R1 codex P1.2: the `case '"'` branch in flexJSONToString
+	// previously accepted JSON-encoded strings without checking the
+	// inner content's shape. The hardened path validates that the
+	// inner JSON is an object (or array for tags). These tests pin the
+	// fix — without the inner-shape check, both cases below would
+	// return 200 with garbage stored in config.
+	t.Run("config as JSON-encoded array string returns 400", func(t *testing.T) {
+		rr := doRequest(srv, "PATCH", patchPath, map[string]interface{}{
+			"config": `[]`, // valid JSON, wrong shape (array, not object)
+		})
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400 for JSON-encoded array config, got %d: %s", rr.Code, rr.Body.String())
+		}
+		if !bytes.Contains(rr.Body.Bytes(), []byte(`\"config\" must be a JSON object`)) {
+			t.Fatalf("response missing domain-level config message: %s", rr.Body.String())
+		}
+	})
+
+	t.Run("config as JSON-encoded malformed-string returns 400", func(t *testing.T) {
+		rr := doRequest(srv, "PATCH", patchPath, map[string]interface{}{
+			"config": `not even json`,
+		})
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400 for malformed-string config, got %d: %s", rr.Code, rr.Body.String())
+		}
+	})
 }
 
 // TestCreateView_FlexibleConfigShape mirrors the PATCH test for the POST
@@ -192,6 +219,30 @@ func TestPatchCollection_FlexibleSettingsShape(t *testing.T) {
 		}
 		if !bytes.Contains(rr.Body.Bytes(), []byte(`\"settings\" must be a JSON object`)) {
 			t.Fatalf("response missing domain-level settings message: %s", rr.Body.String())
+		}
+	})
+
+	// IDEA-1488 R1 codex P1.2 — see the matching view-side tests above
+	// for context. These pin the inner-shape validation of the
+	// JSON-encoded-string envelope.
+	t.Run("settings as JSON-encoded array string returns 400", func(t *testing.T) {
+		rr := doRequest(srv, "PATCH", patchPath, map[string]interface{}{
+			"settings": `[]`,
+		})
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400 for JSON-encoded array settings, got %d: %s", rr.Code, rr.Body.String())
+		}
+		if !bytes.Contains(rr.Body.Bytes(), []byte(`\"settings\" must be a JSON object`)) {
+			t.Fatalf("response missing domain-level settings message: %s", rr.Body.String())
+		}
+	})
+
+	t.Run("settings as JSON-encoded malformed-string returns 400", func(t *testing.T) {
+		rr := doRequest(srv, "PATCH", patchPath, map[string]interface{}{
+			"settings": `not json`,
+		})
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400 for malformed-string settings, got %d: %s", rr.Code, rr.Body.String())
 		}
 	})
 }

--- a/internal/store/export.go
+++ b/internal/store/export.go
@@ -1,12 +1,57 @@
 package store
 
 import (
+	"encoding/json"
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 
 	"github.com/PerpetualSoftware/pad/internal/models"
 )
+
+// coerceJSONForImport normalizes an imported JSON column value to a
+// well-formed default of the expected shape. Used at the import boundary
+// (ImportWorkspace) where legacy / external workspace bundles may carry
+// empty-string or malformed JSON that bypasses the column's NOT NULL
+// DEFAULT (IDEA-1486) and that the handler-layer shape validators
+// (IDEA-1488) never see. The lenient policy (coerce + log) matches the
+// IDEA-1484 import-side precedent at export.go:206-209: don't break a
+// workspace import because one row carries malformed data.
+//
+//   - raw == ""                     → return defaultJSON (empty-string sentinel).
+//   - raw is well-formed JSON of the expected shape (object/array) →
+//     return raw verbatim.
+//   - raw is otherwise unparseable or wrong-shape → return defaultJSON
+//     AND log a structured warning naming the field + row. The raw
+//     value's LENGTH is logged (`raw_len`) but never its content, so
+//     user data does not leak into logs.
+//
+// expectObject==true requires the parsed value to be a JSON object
+// (map[string]any); expectObject==false requires a JSON array
+// ([]any) — used for items.tags.
+func coerceJSONForImport(raw, defaultJSON, field, rowID, workspaceID string, expectObject bool) string {
+	if raw == "" {
+		return defaultJSON
+	}
+	if expectObject {
+		var v map[string]any
+		if err := json.Unmarshal([]byte(raw), &v); err == nil {
+			return raw
+		}
+	} else {
+		var v []any
+		if err := json.Unmarshal([]byte(raw), &v); err == nil {
+			return raw
+		}
+	}
+	slog.Warn("import_workspace coerced malformed json",
+		"field", field,
+		"row_id", rowID,
+		"workspace_id", workspaceID,
+		"raw_len", len(raw))
+	return defaultJSON
+}
 
 // ExportWorkspace exports all data for a workspace into a portable format.
 func (s *Store) ExportWorkspace(slug string) (*models.WorkspaceExport, error) {
@@ -193,20 +238,19 @@ func (s *Store) ImportWorkspace(data *models.WorkspaceExport, newName string, ow
 		newCollID := newID()
 		collMap[c.ID] = newCollID
 
-		// Coerce empty-string settings to a valid JSON object before insert.
-		// IDEA-1484 (PR #562) hardened collections.settings to NOT NULL
-		// DEFAULT '{}', but this INSERT explicitly supplies the settings
-		// column — so the DEFAULT clause does NOT fire when c.Settings is
-		// "". Without this coercion, Postgres rejects `""` at JSONB
-		// type-validation and SQLite silently stores invalid JSON. Legacy
-		// bundles and plain-JSON workspace imports (handlers_workspaces.go,
-		// handlers_import_bundle.go, cmd/pad/main.go's migrate command) can
-		// still carry "" settings, so normalization belongs at the import
-		// boundary rather than at the schema level.
-		settings := c.Settings
-		if settings == "" {
-			settings = "{}"
-		}
+		// Coerce empty-string / malformed settings to a valid JSON object
+		// before insert. IDEA-1484 (PR #562) hardened collections.settings
+		// to NOT NULL DEFAULT '{}', but this INSERT explicitly supplies
+		// the settings column — so the DEFAULT clause does NOT fire when
+		// c.Settings is "". Without this coercion, Postgres rejects `""`
+		// at JSONB type-validation and SQLite silently stores invalid
+		// JSON. Legacy bundles and plain-JSON workspace imports
+		// (handlers_workspaces.go, handlers_import_bundle.go,
+		// cmd/pad/main.go's migrate command) can still carry "" or
+		// malformed settings, so normalization belongs at the import
+		// boundary rather than at the schema level. IDEA-1488 extends
+		// this to log-and-coerce on non-empty malformed JSON.
+		settings := coerceJSONForImport(c.Settings, "{}", "collections.settings", c.ID, ws.ID, true)
 
 		_, err := tx.Exec(s.q(`
 			INSERT INTO collections (id, workspace_id, name, slug, icon, description, schema, settings, prefix, sort_order, is_default, is_system, created_at, updated_at)
@@ -223,6 +267,16 @@ func (s *Store) ImportWorkspace(data *models.WorkspaceExport, newName string, ow
 	// workspace-global numbering. Exported item_number values are ignored
 	// because old exports used per-collection numbering which can have
 	// duplicates within a workspace.
+	//
+	// IDEA-1486 + IDEA-1488: precompute each item's coerced fields/tags so
+	// the second-pass UPDATE (which re-applies fields after the ID remap)
+	// uses the SAME normalized value as the first-pass INSERT. Without
+	// this, a malformed it.Fields gets coerced to "{}" on INSERT but the
+	// second pass would re-write the original malformed value verbatim,
+	// undoing the coercion. The map is keyed by the original (exported)
+	// item ID so the second-pass loop can look up the normalized value.
+	coercedFields := make(map[string]string, len(data.Items))
+	coercedTags := make(map[string]string, len(data.Items))
 	var nextItemNumber int
 	for _, it := range data.Items {
 		newItemID := newID()
@@ -241,6 +295,19 @@ func (s *Store) ImportWorkspace(data *models.WorkspaceExport, newName string, ow
 		}
 
 		nextItemNumber++
+		// IDEA-1486 + IDEA-1488: coerce empty-string / malformed
+		// fields/tags at the import boundary. After migration 056 /
+		// pgmigrations 035 hardened items.fields and items.tags to
+		// NOT NULL DEFAULT, an imported item with fields="" 500s on
+		// Postgres at JSONB type-validation and silently stores
+		// invalid JSON on SQLite. Mirror collections.settings'
+		// coercion above. The IDEA-1488 leg: log-and-coerce (not
+		// fail-stop) so a legacy bundle with one malformed item
+		// still imports.
+		fieldsJSON := coerceJSONForImport(it.Fields, "{}", "items.fields", it.ID, ws.ID, true)
+		tagsJSON := coerceJSONForImport(it.Tags, "[]", "items.tags", it.ID, ws.ID, false)
+		coercedFields[it.ID] = fieldsJSON
+		coercedTags[it.ID] = tagsJSON
 		// Stamp `seq` so workspace import populates the delta-sync cursor
 		// column (PLAN-1343 / TASK-1352). Each INSERT reads MAX(seq)+1
 		// within this transaction, so imported rows get sequential
@@ -250,7 +317,7 @@ func (s *Store) ImportWorkspace(data *models.WorkspaceExport, newName string, ow
 		_, err := tx.Exec(s.q(`
 			INSERT INTO items (id, workspace_id, collection_id, title, slug, content, fields, tags, pinned, sort_order, parent_id, created_by, last_modified_by, source, item_number, created_at, updated_at, seq)
 			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULLIF(?, ''), ?, ?, ?, ?, ?, ?, `+nextWorkspaceSeqSubquery+`)`),
-			newItemID, ws.ID, newCollID, it.Title, it.Slug, it.Content, it.Fields, it.Tags, s.dialect.BoolToInt(it.Pinned), it.SortOrder,
+			newItemID, ws.ID, newCollID, it.Title, it.Slug, it.Content, fieldsJSON, tagsJSON, s.dialect.BoolToInt(it.Pinned), it.SortOrder,
 			parentID, it.CreatedBy, it.LastModifiedBy, it.Source, nextItemNumber,
 			it.CreatedAt, it.UpdatedAt, ws.ID)
 		if err != nil {
@@ -258,14 +325,22 @@ func (s *Store) ImportWorkspace(data *models.WorkspaceExport, newName string, ow
 		}
 	}
 
-	// Second pass: remap parent_id and relation fields (now all items exist)
+	// Second pass: remap parent_id and relation fields (now all items exist).
+	// Use the coerced first-pass fields value as the remap input so a
+	// malformed-and-coerced row doesn't get its coercion clobbered by the
+	// raw export value (IDEA-1486 + IDEA-1488).
+	_ = coercedTags // tags don't carry ID relations; second-pass only touches fields
 	for _, it := range data.Items {
 		newItemID := itemMap[it.ID]
 		if newItemID == "" {
 			continue
 		}
+		fieldsInput, ok := coercedFields[it.ID]
+		if !ok {
+			fieldsInput = it.Fields // defensive — should always be populated by first pass
+		}
 		// Remap relation fields now that ALL items are mapped
-		fields := remapFieldIDs(it.Fields, itemMap, collMap)
+		fields := remapFieldIDs(fieldsInput, itemMap, collMap)
 		parentID := ""
 		if it.ParentID != "" {
 			if mapped, ok := itemMap[it.ParentID]; ok {
@@ -325,8 +400,14 @@ func (s *Store) ImportWorkspace(data *models.WorkspaceExport, newName string, ow
 			newID(), newItemID, ver.Content, ver.ChangeSummary, ver.CreatedBy, ver.Source, s.dialect.BoolToInt(ver.IsDiff),
 			ver.CreatedAt)
 		if err != nil {
-			// Log detail but skip — version history is non-critical
-			fmt.Printf("warning: skipped version for item %s: %v\n", ver.ItemID, err)
+			// Log detail but skip — version history is non-critical.
+			// Migrated from fmt.Printf to slog.Warn alongside the
+			// IDEA-1488 log-and-coerce additions; same severity, same
+			// triage signal, but threads through the canonical logger.
+			slog.Warn("import_workspace skipped item version",
+				"item_id", ver.ItemID,
+				"workspace_id", ws.ID,
+				"err", err)
 			continue
 		}
 	}
@@ -365,7 +446,20 @@ func (s *Store) rebuildFTSForWorkspace(wsID string) {
 
 // remapFieldIDs replaces old UUIDs in a JSON fields string with their new IDs.
 // This handles relation fields (e.g. parent: "uuid") without needing to parse the schema.
+//
+// IDEA-1486: empty-string input is normalized to "{}". Centralizing the
+// contract here keeps future callers safe by default — any UPDATE that
+// writes the result back into items.fields is guaranteed to satisfy the
+// post-migration NOT NULL DEFAULT '{}' invariant. Without this guard,
+// the second-pass UPDATE at ImportWorkspace would write "" verbatim on
+// items whose original fields were already empty, which silently stores
+// invalid JSON on SQLite and (post-migration) would have already 500'd
+// on the first-pass INSERT on Postgres if not for the import-boundary
+// coercion above.
 func remapFieldIDs(fieldsJSON string, itemMap, collMap map[string]string) string {
+	if fieldsJSON == "" {
+		return "{}"
+	}
 	result := fieldsJSON
 	for oldID, newID := range itemMap {
 		if oldID != "" && newID != "" {

--- a/internal/store/export.go
+++ b/internal/store/export.go
@@ -20,9 +20,9 @@ import (
 // workspace import because one row carries malformed data.
 //
 //   - raw == ""                     → return defaultJSON (empty-string sentinel).
-//   - raw is well-formed JSON of the expected shape (object/array) →
-//     return raw verbatim.
-//   - raw is otherwise unparseable or wrong-shape → return defaultJSON
+//   - raw is well-formed JSON of the expected shape (non-nil object/array)
+//     → return raw verbatim.
+//   - raw is JSON `null`, unparseable, or wrong-shape → return defaultJSON
 //     AND log a structured warning naming the field + row. The raw
 //     value's LENGTH is logged (`raw_len`) but never its content, so
 //     user data does not leak into logs.
@@ -30,18 +30,27 @@ import (
 // expectObject==true requires the parsed value to be a JSON object
 // (map[string]any); expectObject==false requires a JSON array
 // ([]any) — used for items.tags.
+//
+// IDEA-1486 R1 codex P2: `json.Unmarshal("null", &m)` returns nil error
+// and leaves the destination nil. Imported `fields: null` (or the
+// string literal `"null"` at the JSON-encoded-string layer) would
+// otherwise satisfy this validator and land as a JSONB null on
+// Postgres (which technically satisfies NOT NULL — SQL NULL ≠ JSONB
+// null) or the text "null" on SQLite. Downstream readers that expect
+// an object would choke. The non-nil check below forces JSON null to
+// the log-and-coerce path with the rest of the malformed shapes.
 func coerceJSONForImport(raw, defaultJSON, field, rowID, workspaceID string, expectObject bool) string {
 	if raw == "" {
 		return defaultJSON
 	}
 	if expectObject {
 		var v map[string]any
-		if err := json.Unmarshal([]byte(raw), &v); err == nil {
+		if err := json.Unmarshal([]byte(raw), &v); err == nil && v != nil {
 			return raw
 		}
 	} else {
 		var v []any
-		if err := json.Unmarshal([]byte(raw), &v); err == nil {
+		if err := json.Unmarshal([]byte(raw), &v); err == nil && v != nil {
 			return raw
 		}
 	}

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -1440,12 +1440,31 @@ func (s *Store) UpdateItem(id string, input models.ItemUpdate) (*models.Item, er
 		}
 	}
 	if input.Fields != nil {
+		// IDEA-1486: normalize the empty-string sentinel to a valid JSON
+		// object before writing. After the NOT NULL DEFAULT '{}'
+		// hardening, Postgres rejects "" at JSONB type-validation and
+		// SQLite would silently store invalid JSON. Same boundary
+		// normalization as CreateItem (items.go:103-110) and the
+		// IDEA-1484 precedent at collections.go:248. Shape validation
+		// (object vs. array vs. primitive) is handled at the handler
+		// boundary by ItemUpdate.UnmarshalJSON (BUG-1144).
+		fields := *input.Fields
+		if fields == "" {
+			fields = "{}"
+		}
 		sets = append(sets, "fields = ?")
-		args = append(args, *input.Fields)
+		args = append(args, fields)
 	}
 	if input.Tags != nil {
+		// IDEA-1486: same empty-string coercion as fields above, but
+		// tags is array-shaped so the default is "[]". Mirrors
+		// CreateItem at items.go:107-110.
+		tags := *input.Tags
+		if tags == "" {
+			tags = "[]"
+		}
 		sets = append(sets, "tags = ?")
-		args = append(args, *input.Tags)
+		args = append(args, tags)
 	}
 	if input.Pinned != nil {
 		sets = append(sets, "pinned = ?")

--- a/internal/store/items_views_jsonb_test.go
+++ b/internal/store/items_views_jsonb_test.go
@@ -506,6 +506,313 @@ func TestItemsViewsJSONB_ItemLinksRoundTripAfterRebuild(t *testing.T) {
 	}
 }
 
+// TestItemsViewsJSONB_SQLiteBackfillRepairsMalformedShapes is the
+// codex R2 P1 regression test. It applies migrations 001-055 against
+// a fresh DB (stopping BEFORE the 056/057 hardening), seeds rows that
+// violate the post-migration shape contract in every observable way
+// (empty string, JSON null, wrong-shape JSON, non-JSON garbage), then
+// applies 056 + 057 and asserts every malformed row is repaired to
+// the default.
+//
+// The CREATE UNIQUE INDEX idx_items_invocation_slug_per_collection
+// in 056 calls json_extract on every fields value — a single row
+// with malformed JSON would error mid-migration. The "garbage"
+// seeding below is the actual ship-breaker scenario; without the
+// widened WHERE clause, the migration aborts.
+func TestItemsViewsJSONB_SQLiteBackfillRepairsMalformedShapes(t *testing.T) {
+	if os.Getenv("PAD_TEST_POSTGRES_URL") != "" {
+		t.Skip("SQLite-specific (json_valid / json_type)")
+	}
+
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "backfill_shape.db")
+	dsn := dbPath + "?_pragma=busy_timeout(30000)&_pragma=foreign_keys(on)&_txlock=immediate"
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+
+	if _, err := db.Exec("PRAGMA journal_mode=WAL"); err != nil {
+		t.Fatalf("WAL: %v", err)
+	}
+	if _, err := db.Exec(`CREATE TABLE IF NOT EXISTS schema_migrations (
+		version TEXT PRIMARY KEY,
+		applied_at TEXT NOT NULL
+	)`); err != nil {
+		t.Fatalf("schema_migrations: %v", err)
+	}
+
+	// Apply migrations up to BUT NOT INCLUDING 054 (which creates the
+	// partial UNIQUE index on json_extract(fields, '$.invocation_slug')),
+	// 055, 056, 057. We then seed pre-054 malformed rows, then apply
+	// 056 + 057. The codex R2 P1 ship-breaker scenario is precisely:
+	// rows with malformed items.fields exist, then 056 recreates the
+	// partial UNIQUE index over those rows, and CREATE INDEX errors
+	// mid-migration when json_extract evaluates on the bad rows.
+	//
+	// We skip 054 in the pre-seed pass because 054's own CREATE INDEX
+	// would also error on malformed rows; 056 is the migration under
+	// test, and its widened backfill WHERE clause is the fix. After
+	// 056 repairs and rebuilds, the post-56 partial index sees only
+	// well-shaped rows.
+	names, err := readMigrationNames(migrationsFS, "migrations")
+	if err != nil {
+		t.Fatalf("read migrations: %v", err)
+	}
+	postSeed := map[string]bool{
+		"054_playbooks_invocation_fields.sql":   true,
+		"055_collections_settings_not_null.sql": true,
+		"056_items_jsonb_not_null.sql":          true,
+		"057_views_config_not_null.sql":         true,
+	}
+	for _, name := range names {
+		if postSeed[name] {
+			continue
+		}
+		data, err := migrationsFS.ReadFile("migrations/" + name)
+		if err != nil {
+			t.Fatalf("read migration %s: %v", name, err)
+		}
+		if err := applySQLiteMigration(db, name, string(data)); err != nil {
+			t.Fatalf("apply %s: %v", name, err)
+		}
+	}
+
+	// Seed prerequisites — a workspace + collection so item FKs resolve.
+	const wsID = "ws-bf"
+	const collID = "coll-bf"
+	const ts = "2026-05-16T00:00:00Z"
+	if _, err := db.Exec(
+		`INSERT INTO workspaces (id, name, slug, settings, created_at, updated_at)
+		 VALUES (?, ?, ?, '{}', ?, ?)`,
+		wsID, "BFShape", "bfshape", ts, ts,
+	); err != nil {
+		t.Fatalf("seed workspace: %v", err)
+	}
+	if _, err := db.Exec(
+		`INSERT INTO collections (id, workspace_id, name, slug, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?)`,
+		collID, wsID, "Tasks", "tasks-bf", ts, ts,
+	); err != nil {
+		t.Fatalf("seed collection: %v", err)
+	}
+
+	// Seed items with every observable shape pathology. Pre-056 the
+	// items.fields column is nullable + no shape check, so every one
+	// of these INSERTs succeeds.
+	itemSeeds := []struct {
+		id     string
+		slug   string
+		fields any // string or nil for SQL NULL
+		tags   any
+	}{
+		{"i-null", "i-null", nil, nil},                        // SQL NULL on both
+		{"i-empty", "i-empty", "", ""},                        // empty-string sentinel
+		{"i-jsnull", "i-jsnull", "null", "null"},              // JSON null literal
+		{"i-wrongshape", "i-wrong", "[]", "{}"},               // wrong shape on each
+		{"i-garbage", "i-garbage", "not json", "garb"},        // non-JSON text
+		{"i-valid", "i-valid", `{"k":"v"}`, `["a"]`},          // already valid — must be preserved
+		{"i-slug", "i-slug", `{"invocation_slug":"x"}`, `[]`}, // exercises the partial UNIQUE index
+	}
+	for _, sd := range itemSeeds {
+		if _, err := db.Exec(
+			`INSERT INTO items (id, workspace_id, collection_id, title, slug, fields, tags, created_at, updated_at)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			sd.id, wsID, collID, sd.id, sd.slug, sd.fields, sd.tags, ts, ts,
+		); err != nil {
+			t.Fatalf("seed item %s: %v", sd.id, err)
+		}
+	}
+
+	// Seed views with shape pathologies on config.
+	viewSeeds := []struct {
+		id     string
+		slug   string
+		config any
+	}{
+		{"v-null", "v-null", nil},
+		{"v-empty", "v-empty", ""},
+		{"v-jsnull", "v-jsnull", "null"},
+		{"v-arr", "v-arr", "[]"},
+		{"v-garbage", "v-garb", "{garbage"},
+		{"v-valid", "v-valid", `{"layout":"list"}`},
+	}
+	for _, sd := range viewSeeds {
+		if _, err := db.Exec(
+			`INSERT INTO views (id, workspace_id, name, slug, view_type, config, created_at, updated_at)
+			 VALUES (?, ?, ?, ?, 'list', ?, ?, ?)`,
+			sd.id, wsID, sd.id, sd.slug, sd.config, ts, ts,
+		); err != nil {
+			t.Fatalf("seed view %s: %v", sd.id, err)
+		}
+	}
+
+	// Now apply 055, 056, 057. 054 is deliberately skipped because
+	// its own CREATE INDEX on json_extract(fields, '$.invocation_slug')
+	// would error on the malformed seed rows — and in production, 054
+	// already shipped without that error, which means no production
+	// row carried malformed fields at 054-run-time. The codex R2 P1
+	// concern is forward-looking: if malformed rows appeared between
+	// 054 and 056 (or any other source), 056's REBUILD recreates the
+	// same partial UNIQUE index and would re-hit the json_extract
+	// error. The widened backfill WHERE clause in 056 repairs those
+	// rows BEFORE the rebuild, so the migration succeeds end-to-end.
+	postSeedOrder := []string{
+		"055_collections_settings_not_null.sql",
+		"056_items_jsonb_not_null.sql",
+		"057_views_config_not_null.sql",
+	}
+	for _, name := range postSeedOrder {
+		data, err := migrationsFS.ReadFile("migrations/" + name)
+		if err != nil {
+			t.Fatalf("read migration %s: %v", name, err)
+		}
+		if err := applySQLiteMigration(db, name, string(data)); err != nil {
+			t.Fatalf("apply %s (codex R2 P1 ship-breaker): %v", name, err)
+		}
+	}
+
+	// Assert every malformed item.fields was repaired to "{}", every
+	// malformed item.tags to "[]", and the valid rows survived.
+	type wantRow struct{ fields, tags string }
+	itemWant := map[string]wantRow{
+		"i-null":       {`{}`, `[]`},
+		"i-empty":      {`{}`, `[]`},
+		"i-jsnull":     {`{}`, `[]`},
+		"i-wrongshape": {`{}`, `[]`},
+		"i-garbage":    {`{}`, `[]`},
+		"i-valid":      {`{"k":"v"}`, `["a"]`},
+		"i-slug":       {`{"invocation_slug":"x"}`, `[]`},
+	}
+	for id, want := range itemWant {
+		var f, ta string
+		err := db.QueryRow(`SELECT fields, tags FROM items WHERE id = ?`, id).Scan(&f, &ta)
+		if err != nil {
+			t.Fatalf("query item %s: %v", id, err)
+		}
+		if f != want.fields {
+			t.Errorf("item %s fields: want %q, got %q", id, want.fields, f)
+		}
+		if ta != want.tags {
+			t.Errorf("item %s tags: want %q, got %q", id, want.tags, ta)
+		}
+	}
+
+	viewWant := map[string]string{
+		"v-null":    `{}`,
+		"v-empty":   `{}`,
+		"v-jsnull":  `{}`,
+		"v-arr":     `{}`,
+		"v-garbage": `{}`,
+		"v-valid":   `{"layout":"list"}`,
+	}
+	for id, want := range viewWant {
+		var c string
+		err := db.QueryRow(`SELECT config FROM views WHERE id = ?`, id).Scan(&c)
+		if err != nil {
+			t.Fatalf("query view %s: %v", id, err)
+		}
+		if c != want {
+			t.Errorf("view %s config: want %q, got %q", id, want, c)
+		}
+	}
+
+	// The partial UNIQUE index must exist after the rebuild AND the
+	// uniqueness constraint must actually fire on duplicate
+	// invocation_slug — proof that the index works on post-rebuild rows
+	// AND that the migration succeeded end-to-end (which it could not
+	// have if json_extract had errored mid-CREATE INDEX).
+	var idxName string
+	err = db.QueryRow(
+		`SELECT name FROM sqlite_master
+		 WHERE type='index' AND tbl_name='items'
+		   AND name='idx_items_invocation_slug_per_collection'`,
+	).Scan(&idxName)
+	if err != nil {
+		t.Fatalf("invocation_slug index missing after migration: %v", err)
+	}
+	if _, err := db.Exec(
+		`INSERT INTO items (id, workspace_id, collection_id, title, slug, fields, tags, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		"i-slug-dup", wsID, collID, "dup", "i-slug-dup",
+		`{"invocation_slug":"x"}`, `[]`, ts, ts,
+	); err == nil {
+		t.Error("expected UNIQUE constraint violation on duplicate invocation_slug, got success")
+	}
+}
+
+// TestItemsViewsJSONB_PostgresBackfillRepairsMalformedShapes is the
+// Postgres counterpart. JSONB columns reject invalid JSON at write
+// time, so the only pre-existing pathologies are SQL NULL and JSONB-
+// valid-but-wrong-shape (e.g. JSONB null, an array where an object is
+// required, a primitive). Codex R2 P1: the original NULL-only WHERE
+// would have left wrong-shape rows in place.
+func TestItemsViewsJSONB_PostgresBackfillRepairsMalformedShapes(t *testing.T) {
+	pgURL := os.Getenv("PAD_TEST_POSTGRES_URL")
+	if pgURL == "" {
+		t.Skip("PAD_TEST_POSTGRES_URL not set")
+	}
+	_ = pgURL // testStore picks up the env
+
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "PgBackfill")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+
+	// Direct INSERT with wrong-shape JSONB. Bypasses store helpers and
+	// writes JSONB null / array / primitive into the columns. JSONB
+	// null satisfies NOT NULL (SQL NULL ≠ JSONB null) but fails
+	// jsonb_typeof = 'object'.
+	const ts = "2026-05-16T00:00:00Z"
+	mustInsert := func(t *testing.T, id, fields, tags string) {
+		t.Helper()
+		_, err := s.db.Exec(
+			`INSERT INTO items (id, workspace_id, collection_id, title, slug, fields, tags, created_at, updated_at)
+			 VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7::jsonb, $8, $9)`,
+			id, ws.ID, col.ID, id, id, fields, tags, ts, ts,
+		)
+		if err != nil {
+			t.Fatalf("seed item %s: %v", id, err)
+		}
+	}
+	mustInsert(t, "pg-jsnull", `null`, `null`)
+	mustInsert(t, "pg-wrongshape", `[]`, `{}`)
+	mustInsert(t, "pg-prim", `42`, `"a string"`)
+	mustInsert(t, "pg-valid", `{"k":"v"}`, `["tag"]`)
+
+	// Re-run the backfill UPDATE clauses from pgmigrations/035 (the
+	// migration itself already ran during testStore init; this
+	// exercises the UPDATE shape against rows seeded above).
+	if _, err := s.db.Exec(
+		"UPDATE items SET fields = '{}'::jsonb WHERE fields IS NULL OR jsonb_typeof(fields) != 'object'"); err != nil {
+		t.Fatalf("re-run fields backfill: %v", err)
+	}
+	if _, err := s.db.Exec(
+		"UPDATE items SET tags = '[]'::jsonb WHERE tags IS NULL OR jsonb_typeof(tags) != 'array'"); err != nil {
+		t.Fatalf("re-run tags backfill: %v", err)
+	}
+
+	want := map[string]struct{ fields, tags string }{
+		"pg-jsnull":     {`{}`, `[]`},
+		"pg-wrongshape": {`{}`, `[]`},
+		"pg-prim":       {`{}`, `[]`},
+		"pg-valid":      {`{"k": "v"}`, `["tag"]`}, // Postgres adds whitespace
+	}
+	for id, exp := range want {
+		var f, ta string
+		err := s.db.QueryRow(`SELECT fields::text, tags::text FROM items WHERE id = $1`, id).Scan(&f, &ta)
+		if err != nil {
+			t.Fatalf("query %s: %v", id, err)
+		}
+		if !jsonEqualString(f, exp.fields) {
+			t.Errorf("item %s fields want %q got %q", id, exp.fields, f)
+		}
+		if !jsonEqualString(ta, exp.tags) {
+			t.Errorf("item %s tags want %q got %q", id, exp.tags, ta)
+		}
+	}
+}
+
 // TestItemsViewsJSONB_ItemsFTSVirtualTableExists guards that the
 // items_fts virtual table itself survives the items rebuild. (Per
 // design decision D2, the virtual table is NOT dropped — only the

--- a/internal/store/items_views_jsonb_test.go
+++ b/internal/store/items_views_jsonb_test.go
@@ -1,0 +1,505 @@
+package store
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// IDEA-1486 + IDEA-1488 regression tests.
+//
+// These tests guard the paired ship of the JSONB NOT NULL hardening on
+// items.fields / items.tags / views.config and the handler-layer shape
+// validation that closes the contract loop on the writer side.
+//
+// Most tests are dialect-agnostic and run on whichever driver
+// testStore() picks (SQLite by default, Postgres when
+// PAD_TEST_POSTGRES_URL is set). The SQLite-specific schema
+// introspection assertions (FTS triggers, indexes) are gated on the
+// SQLite path because the equivalent invariants live in different
+// system catalogs on Postgres.
+
+// TestItemsViewsJSONB_UpdateItemCoercesEmptyStringFields exercises the
+// IDEA-1486 floor at the items.go:1442 UPDATE path. After the NOT NULL
+// migration ships, an UpdateItem with Fields="" would 500 on Postgres
+// JSONB type-validation and silently store invalid JSON on SQLite.
+// The store-layer coercion normalizes "" → "{}" / "[]" before the
+// UPDATE reaches the database.
+func TestItemsViewsJSONB_UpdateItemCoercesEmptyStringFields(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "JSONBCoerce")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+	item := createTestItem(t, s, ws.ID, col.ID, "an item", "")
+
+	emptyFields := ""
+	emptyTags := ""
+	updated, err := s.UpdateItem(item.ID, models.ItemUpdate{
+		Fields: &emptyFields,
+		Tags:   &emptyTags,
+	})
+	if err != nil {
+		t.Fatalf("UpdateItem with empty fields/tags: %v", err)
+	}
+	if updated.Fields != "{}" {
+		t.Errorf("Fields after empty-string update: want %q, got %q", "{}", updated.Fields)
+	}
+	if updated.Tags != "[]" {
+		t.Errorf("Tags after empty-string update: want %q, got %q", "[]", updated.Tags)
+	}
+}
+
+// TestItemsViewsJSONB_UpdateViewCoercesEmptyStringConfig exercises the
+// IDEA-1486 floor at views.go:152.
+func TestItemsViewsJSONB_UpdateViewCoercesEmptyStringConfig(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "ViewCoerce")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+
+	view, err := s.CreateView(ws.ID, models.ViewCreate{
+		CollectionID: &col.ID,
+		Name:         "All",
+		ViewType:     "list",
+		Config:       `{"layout":"list"}`,
+	})
+	if err != nil {
+		t.Fatalf("CreateView: %v", err)
+	}
+
+	emptyConfig := ""
+	updated, err := s.UpdateView(view.ID, models.ViewUpdate{
+		Config: &emptyConfig,
+	})
+	if err != nil {
+		t.Fatalf("UpdateView with empty config: %v", err)
+	}
+	if updated.Config != "{}" {
+		t.Errorf("Config after empty-string update: want %q, got %q", "{}", updated.Config)
+	}
+}
+
+// TestItemsViewsJSONB_ImportWorkspaceCoercesEmptyAndMalformed exercises
+// the import-boundary normalization: empty-string and malformed JSON on
+// items.fields / items.tags / collections.settings are coerced to the
+// shape default. Mirrors the IDEA-1488 log-and-coerce policy: legacy
+// bundles don't fail-stop on one bad row.
+func TestItemsViewsJSONB_ImportWorkspaceCoercesEmptyAndMalformed(t *testing.T) {
+	s := testStore(t)
+	owner, err := s.CreateUser(models.UserCreate{
+		Email:    "owner-import@example.com",
+		Name:     "Owner",
+		Password: "passw0rd!",
+	})
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	export := &models.WorkspaceExport{
+		Version:    1,
+		ExportedAt: "2026-05-16T00:00:00Z",
+		Workspace: models.WorkspaceExportMeta{
+			Name: "Imported",
+			Slug: "imported",
+		},
+		Collections: []models.CollectionExport{
+			{
+				ID:        "old-coll-1",
+				Name:      "Tasks",
+				Slug:      "tasks",
+				Prefix:    "TASK",
+				Schema:    `{"fields":[]}`,
+				Settings:  "", // empty-string sentinel → "{}"
+				CreatedAt: "2026-05-16T00:00:00Z",
+				UpdatedAt: "2026-05-16T00:00:00Z",
+			},
+			{
+				ID:        "old-coll-2",
+				Name:      "Ideas",
+				Slug:      "ideas",
+				Prefix:    "IDEA",
+				Schema:    `{"fields":[]}`,
+				Settings:  `not json at all`, // malformed → log-and-coerce
+				CreatedAt: "2026-05-16T00:00:00Z",
+				UpdatedAt: "2026-05-16T00:00:00Z",
+			},
+		},
+		Items: []models.ItemExport{
+			{
+				ID:           "old-item-1",
+				CollectionID: "old-coll-1",
+				Title:        "Item with empty fields",
+				Slug:         "item-empty",
+				Content:      "",
+				Fields:       "", // empty → "{}"
+				Tags:         "", // empty → "[]"
+				CreatedAt:    "2026-05-16T00:00:00Z",
+				UpdatedAt:    "2026-05-16T00:00:00Z",
+			},
+			{
+				ID:           "old-item-2",
+				CollectionID: "old-coll-1",
+				Title:        "Item with malformed json",
+				Slug:         "item-bad",
+				Content:      "",
+				Fields:       `{not valid`,    // malformed → log-and-coerce → "{}"
+				Tags:         `also not json`, // malformed → log-and-coerce → "[]"
+				CreatedAt:    "2026-05-16T00:00:00Z",
+				UpdatedAt:    "2026-05-16T00:00:00Z",
+			},
+			{
+				ID:           "old-item-3",
+				CollectionID: "old-coll-1",
+				Title:        "Item with valid fields",
+				Slug:         "item-good",
+				Content:      "",
+				Fields:       `{"status":"open"}`,
+				Tags:         `["urgent"]`,
+				CreatedAt:    "2026-05-16T00:00:00Z",
+				UpdatedAt:    "2026-05-16T00:00:00Z",
+			},
+		},
+	}
+
+	ws, err := s.ImportWorkspace(export, "Imported Coerce", owner.ID)
+	if err != nil {
+		t.Fatalf("ImportWorkspace: %v", err)
+	}
+
+	// All three items must be present, with coerced/preserved JSON.
+	cases := []struct {
+		title      string
+		wantFields string
+		wantTags   string
+	}{
+		{"Item with empty fields", "{}", "[]"},
+		{"Item with malformed json", "{}", "[]"},
+		{"Item with valid fields", `{"status":"open"}`, `["urgent"]`},
+	}
+	for _, tc := range cases {
+		var gotFields, gotTags string
+		err := s.db.QueryRow(s.q(
+			"SELECT fields, tags FROM items WHERE workspace_id = ? AND title = ?"),
+			ws.ID, tc.title,
+		).Scan(&gotFields, &gotTags)
+		if err != nil {
+			t.Fatalf("query item %q: %v", tc.title, err)
+		}
+		// Postgres returns JSONB normalized form; normalize string compare
+		// via a tolerance for whitespace via raw equality fallback.
+		if !jsonEqualString(gotFields, tc.wantFields) {
+			t.Errorf("item %q: fields want %q, got %q", tc.title, tc.wantFields, gotFields)
+		}
+		if !jsonEqualString(gotTags, tc.wantTags) {
+			t.Errorf("item %q: tags want %q, got %q", tc.title, tc.wantTags, gotTags)
+		}
+	}
+
+	// Both collections should have settings = "{}" after coercion.
+	rows, err := s.db.Query(s.q(
+		"SELECT name, settings FROM collections WHERE workspace_id = ? ORDER BY name"),
+		ws.ID,
+	)
+	if err != nil {
+		t.Fatalf("query collections: %v", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var name, settings string
+		if err := rows.Scan(&name, &settings); err != nil {
+			t.Fatalf("scan collection: %v", err)
+		}
+		if name == "Tasks" || name == "Ideas" {
+			if !jsonEqualString(settings, "{}") {
+				t.Errorf("collection %q settings want %q, got %q", name, "{}", settings)
+			}
+		}
+	}
+}
+
+// jsonEqualString compares two JSON strings tolerantly of insignificant
+// whitespace differences that emerge from JSONB ↔ TEXT round-trips.
+func jsonEqualString(a, b string) bool {
+	return strings.Join(strings.Fields(a), "") == strings.Join(strings.Fields(b), "")
+}
+
+// TestItemsViewsJSONB_SQLiteRebuildPreservesIndexesAndTriggers is the
+// SQLite-only schema-introspection regression test for migration 056.
+// It asserts that after the items rebuild, all 7 indexes and 3 FTS
+// triggers exist, and that the items_fts virtual table still answers
+// queries against post-rebuild rowids. Catches regressions where the
+// rebuild forgets to recreate an index or the FTS triggers don't
+// re-attach to the renamed items table.
+func TestItemsViewsJSONB_SQLiteRebuildPreservesIndexesAndTriggers(t *testing.T) {
+	if os.Getenv("PAD_TEST_POSTGRES_URL") != "" {
+		t.Skip("SQLite-specific schema-introspection test")
+	}
+
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "RebuildShape")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+
+	// Seed an item so we can verify FTS still works post-rebuild.
+	item := createTestItem(t, s, ws.ID, col.ID, "Auth quickref",
+		"OAuth2 authentication flow")
+	if item == nil {
+		t.Fatal("createTestItem returned nil")
+	}
+
+	// All 7 indexes from 005/017/053 must be present on items.
+	wantIndexes := map[string]bool{
+		"idx_items_collection":    false,
+		"idx_items_workspace":     false,
+		"idx_items_parent":        false,
+		"idx_items_updated":       false,
+		"idx_items_assigned_user": false,
+		"idx_items_agent_role":    false,
+		"idx_items_workspace_seq": false,
+	}
+	rows, err := s.db.Query(
+		"SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='items'")
+	if err != nil {
+		t.Fatalf("query sqlite_master for indexes: %v", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var n string
+		if err := rows.Scan(&n); err != nil {
+			t.Fatalf("scan index name: %v", err)
+		}
+		if _, ok := wantIndexes[n]; ok {
+			wantIndexes[n] = true
+		}
+	}
+	for name, seen := range wantIndexes {
+		if !seen {
+			t.Errorf("expected index %q on items, not found in sqlite_master", name)
+		}
+	}
+
+	// All 3 FTS triggers must be present on items.
+	wantTriggers := map[string]bool{
+		"items_fts_insert": false,
+		"items_fts_update": false,
+		"items_fts_delete": false,
+	}
+	trows, err := s.db.Query(
+		"SELECT name FROM sqlite_master WHERE type='trigger' AND tbl_name='items'")
+	if err != nil {
+		t.Fatalf("query sqlite_master for triggers: %v", err)
+	}
+	defer trows.Close()
+	for trows.Next() {
+		var n string
+		if err := trows.Scan(&n); err != nil {
+			t.Fatalf("scan trigger name: %v", err)
+		}
+		if _, ok := wantTriggers[n]; ok {
+			wantTriggers[n] = true
+		}
+	}
+	for name, seen := range wantTriggers {
+		if !seen {
+			t.Errorf("expected trigger %q on items, not found in sqlite_master", name)
+		}
+	}
+
+	// FTS still answers queries against the post-rebuild table.
+	results, err := s.SearchItems(ws.ID, "authentication")
+	if err != nil {
+		t.Fatalf("SearchItems: %v", err)
+	}
+	if len(results) != 1 {
+		var titles []string
+		for _, r := range results {
+			titles = append(titles, r.Item.Title)
+		}
+		sort.Strings(titles)
+		t.Errorf("expected 1 FTS result for 'authentication', got %d (%v)", len(results), titles)
+	}
+}
+
+// TestItemsViewsJSONB_SQLiteRebuildRejectsNullFieldsAfterMigration
+// guards the post-migration NOT NULL constraint on items.fields and
+// items.tags: any attempt to write a literal NULL must fail at the
+// schema level on SQLite (driven by the table-rebuild from migration
+// 056). This is the load-bearing invariant the IDEA-1486 floor adds.
+func TestItemsViewsJSONB_SQLiteRebuildRejectsNullFieldsAfterMigration(t *testing.T) {
+	if os.Getenv("PAD_TEST_POSTGRES_URL") != "" {
+		t.Skip("SQLite-specific test; Postgres counterpart uses ALTER COLUMN SET NOT NULL")
+	}
+
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "NullReject")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+
+	// Direct SQL INSERT bypassing the store helpers, attempting NULL on
+	// the post-migration-hardened columns.
+	for _, col2 := range []string{"fields", "tags"} {
+		stmt := "INSERT INTO items (id, workspace_id, collection_id, title, slug, " + col2 +
+			", created_at, updated_at) VALUES ('null-id-" + col2 + "', ?, ?, ?, ?, NULL, ?, ?)"
+		_, err := s.db.Exec(stmt, ws.ID, col.ID, "null "+col2, "null-slug-"+col2, "2026-05-16T00:00:00Z", "2026-05-16T00:00:00Z")
+		if err == nil {
+			t.Errorf("expected NOT NULL constraint violation inserting NULL %s, got success", col2)
+		}
+	}
+}
+
+// TestItemsViewsJSONB_SQLiteRebuildRejectsNullConfigAfterMigration is
+// the views.config counterpart to the items NULL-reject test.
+func TestItemsViewsJSONB_SQLiteRebuildRejectsNullConfigAfterMigration(t *testing.T) {
+	if os.Getenv("PAD_TEST_POSTGRES_URL") != "" {
+		t.Skip("SQLite-specific test")
+	}
+
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "ViewNullReject")
+
+	_, err := s.db.Exec(
+		"INSERT INTO views (id, workspace_id, name, slug, view_type, config, created_at, updated_at) "+
+			"VALUES ('null-view', ?, 'V', 'v', 'list', NULL, '2026-05-16T00:00:00Z', '2026-05-16T00:00:00Z')",
+		ws.ID,
+	)
+	if err == nil {
+		t.Error("expected NOT NULL constraint violation inserting NULL views.config, got success")
+	}
+}
+
+// TestItemsViewsJSONB_PostgresRejectsNullFieldsAfterMigration is the
+// Postgres counterpart — runs only when PAD_TEST_POSTGRES_URL is set.
+// Verifies the ALTER COLUMN ... SET NOT NULL from pgmigrations/035 + 036
+// actually rejects NULL writes.
+func TestItemsViewsJSONB_PostgresRejectsNullFieldsAfterMigration(t *testing.T) {
+	if os.Getenv("PAD_TEST_POSTGRES_URL") == "" {
+		t.Skip("PAD_TEST_POSTGRES_URL not set")
+	}
+
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "PgNullReject")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+
+	// Attempt to write NULL into each hardened column.
+	for _, c := range []string{"fields", "tags"} {
+		stmt := "INSERT INTO items (id, workspace_id, collection_id, title, slug, " + c +
+			", created_at, updated_at) VALUES ($1, $2, $3, $4, $5, NULL, $6, $7)"
+		_, err := s.db.Exec(stmt,
+			"null-id-"+c, ws.ID, col.ID, "null "+c, "null-slug-"+c,
+			"2026-05-16T00:00:00Z", "2026-05-16T00:00:00Z")
+		if err == nil {
+			t.Errorf("expected NOT NULL constraint violation inserting NULL items.%s, got success", c)
+		}
+	}
+
+	// And on views.config.
+	_, err := s.db.Exec(
+		"INSERT INTO views (id, workspace_id, name, slug, view_type, config, created_at, updated_at) "+
+			"VALUES ($1, $2, $3, $4, $5, NULL, $6, $7)",
+		"null-view", ws.ID, "V", "v-null", "list",
+		"2026-05-16T00:00:00Z", "2026-05-16T00:00:00Z")
+	if err == nil {
+		t.Error("expected NOT NULL constraint violation inserting NULL views.config, got success")
+	}
+}
+
+// TestItemsViewsJSONB_SQLiteRebuildBackfillsNullToDefault exercises the
+// migration backfill path: a pre-existing NULL row in items.fields /
+// items.tags / views.config gets coerced to the shape default during
+// the rebuild. The migration runs on the test store before any test
+// rows are inserted, so this test seeds a "would-be-pre-migration" row
+// via direct SQL, then runs the migration text again on top — verifying
+// the backfill is idempotent.
+//
+// The IDEA-1485 atomic-tx runner re-records the migration if asked to
+// re-apply, so we apply the migration text directly via
+// applySQLiteMigration. Migrations are designed to be idempotent under
+// repeated application (DROP TABLE IF EXISTS items_new; backfill UPDATEs
+// are WHERE x IS NULL; index/trigger DROPs use IF EXISTS).
+func TestItemsViewsJSONB_SQLiteRebuildIsIdempotent(t *testing.T) {
+	if os.Getenv("PAD_TEST_POSTGRES_URL") != "" {
+		t.Skip("SQLite-specific idempotency test")
+	}
+
+	dir := t.TempDir()
+	s, err := New(filepath.Join(dir, "idempotent.db"))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer s.Close()
+
+	mig056, err := migrationsFS.ReadFile("migrations/056_items_jsonb_not_null.sql")
+	if err != nil {
+		t.Fatalf("read 056: %v", err)
+	}
+	mig057, err := migrationsFS.ReadFile("migrations/057_views_config_not_null.sql")
+	if err != nil {
+		t.Fatalf("read 057: %v", err)
+	}
+
+	// Re-apply each migration; both should succeed without error.
+	// Use a unique synthetic name so the schema_migrations bookkeeping
+	// row doesn't collide with the already-applied one.
+	if err := applySQLiteMigration(s.db, "test_056_repeat.sql", string(mig056)); err != nil {
+		t.Fatalf("re-apply 056: %v", err)
+	}
+	if err := applySQLiteMigration(s.db, "test_057_repeat.sql", string(mig057)); err != nil {
+		t.Fatalf("re-apply 057: %v", err)
+	}
+}
+
+// TestItemsViewsJSONB_ItemLinksRoundTripAfterRebuild verifies that the
+// items rebuild preserves the inbound FK from item_links.source_id /
+// target_id → items.id. Since we preserve every id value in the
+// INSERT…SELECT, the FK metadata re-resolves to the renamed table by
+// name and existing links remain valid.
+func TestItemsViewsJSONB_ItemLinksRoundTripAfterRebuild(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "LinkRoundTrip")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+
+	source := createTestItem(t, s, ws.ID, col.ID, "Source", "")
+	target := createTestItem(t, s, ws.ID, col.ID, "Target", "")
+
+	_, err := s.CreateItemLink(ws.ID, models.ItemLinkCreate{
+		TargetID: target.ID,
+		LinkType: "blocks",
+	}, source.ID)
+	if err != nil {
+		t.Fatalf("CreateItemLink: %v", err)
+	}
+
+	links, err := s.GetItemLinks(source.ID)
+	if err != nil {
+		t.Fatalf("GetItemLinks: %v", err)
+	}
+	if len(links) != 1 {
+		t.Fatalf("expected 1 link from source, got %d", len(links))
+	}
+	if links[0].TargetID != target.ID {
+		t.Errorf("link target = %q, want %q", links[0].TargetID, target.ID)
+	}
+}
+
+// TestItemsViewsJSONB_ItemsFTSVirtualTableExists guards that the
+// items_fts virtual table itself survives the items rebuild. (Per
+// design decision D2, the virtual table is NOT dropped — only the
+// three triggers are.)
+func TestItemsViewsJSONB_ItemsFTSVirtualTableExists(t *testing.T) {
+	if os.Getenv("PAD_TEST_POSTGRES_URL") != "" {
+		t.Skip("SQLite-specific (items_fts is a SQLite FTS5 virtual table)")
+	}
+
+	s := testStore(t)
+	var name string
+	err := s.db.QueryRow(
+		"SELECT name FROM sqlite_master WHERE type='table' AND name='items_fts'",
+	).Scan(&name)
+	if err == sql.ErrNoRows {
+		t.Fatal("items_fts virtual table missing after migration")
+	}
+	if err != nil {
+		t.Fatalf("query items_fts: %v", err)
+	}
+}

--- a/internal/store/items_views_jsonb_test.go
+++ b/internal/store/items_views_jsonb_test.go
@@ -161,6 +161,25 @@ func TestItemsViewsJSONB_ImportWorkspaceCoercesEmptyAndMalformed(t *testing.T) {
 				CreatedAt:    "2026-05-16T00:00:00Z",
 				UpdatedAt:    "2026-05-16T00:00:00Z",
 			},
+			{
+				// IDEA-1486 R1 codex P2: imported fields=null and
+				// tags=null must coerce to defaults. Without the
+				// non-nil check in coerceJSONForImport,
+				// json.Unmarshal("null", &m) returns err=nil with m
+				// staying nil, and the raw "null" string would land
+				// in the column — JSONB null on Postgres or text
+				// "null" on SQLite, both of which break downstream
+				// readers expecting an object/array.
+				ID:           "old-item-null",
+				CollectionID: "old-coll-1",
+				Title:        "Item with json null fields and tags",
+				Slug:         "item-null",
+				Content:      "",
+				Fields:       `null`,
+				Tags:         `null`,
+				CreatedAt:    "2026-05-16T00:00:00Z",
+				UpdatedAt:    "2026-05-16T00:00:00Z",
+			},
 		},
 	}
 
@@ -178,6 +197,7 @@ func TestItemsViewsJSONB_ImportWorkspaceCoercesEmptyAndMalformed(t *testing.T) {
 		{"Item with empty fields", "{}", "[]"},
 		{"Item with malformed json", "{}", "[]"},
 		{"Item with valid fields", `{"status":"open"}`, `["urgent"]`},
+		{"Item with json null fields and tags", "{}", "[]"},
 	}
 	for _, tc := range cases {
 		var gotFields, gotTags string
@@ -249,15 +269,19 @@ func TestItemsViewsJSONB_SQLiteRebuildPreservesIndexesAndTriggers(t *testing.T) 
 		t.Fatal("createTestItem returned nil")
 	}
 
-	// All 7 indexes from 005/017/053 must be present on items.
+	// All 8 indexes from 005/017/053/054 must be present on items.
+	// idx_items_invocation_slug_per_collection was added to migration
+	// 056 in IDEA-1486 R1 codex P1.1 after the original draft forgot
+	// to recreate it; this test grew to 8 entries alongside that fix.
 	wantIndexes := map[string]bool{
-		"idx_items_collection":    false,
-		"idx_items_workspace":     false,
-		"idx_items_parent":        false,
-		"idx_items_updated":       false,
-		"idx_items_assigned_user": false,
-		"idx_items_agent_role":    false,
-		"idx_items_workspace_seq": false,
+		"idx_items_collection":                     false,
+		"idx_items_workspace":                      false,
+		"idx_items_parent":                         false,
+		"idx_items_updated":                        false,
+		"idx_items_assigned_user":                  false,
+		"idx_items_agent_role":                     false,
+		"idx_items_workspace_seq":                  false,
+		"idx_items_invocation_slug_per_collection": false,
 	}
 	rows, err := s.db.Query(
 		"SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='items'")

--- a/internal/store/migrations/056_items_jsonb_not_null.sql
+++ b/internal/store/migrations/056_items_jsonb_not_null.sql
@@ -24,11 +24,38 @@
 
 PRAGMA foreign_keys = OFF;
 
--- Backfill any NULL fields / tags before applying the constraint. tags
--- has been de-facto NOT NULL since migration 001 (DEFAULT '[]'), but the
--- explicit backfill is harmless idempotency belt.
-UPDATE items SET fields = '{}' WHERE fields IS NULL;
-UPDATE items SET tags = '[]' WHERE tags IS NULL;
+-- Backfill: repair any row whose fields / tags violates the post-
+-- migration shape contract (NOT NULL + object-or-array JSON). The
+-- WHERE clauses widen the NULL-only filter to cover three pre-
+-- existing failure modes:
+--
+--   1. fields IS NULL                 — the original IDEA-1486 case.
+--   2. json_valid(fields) = 0         — empty-string, "not json", or
+--                                       any other non-JSON text the
+--                                       NOT-NULL-DEFAULT never blocked.
+--   3. json_type(fields) != 'object'  — JSON-but-wrong-shape (e.g.
+--                                       'null', '[]', '"a string"',
+--                                       a number).
+--
+-- Same trio for tags with 'array' as the expected json_type. Per
+-- codex R2 P1: the original NULL-only filter would have left every
+-- malformed row in place. The partial UNIQUE index on
+-- json_extract(fields, '$.invocation_slug') (recreated below) errors
+-- on rows whose fields fails json_valid, so a single bad row would
+-- break the CREATE INDEX mid-migration. Repair has to happen before
+-- the rebuild so both the INSERT…SELECT and the post-rename CREATE
+-- INDEX see only well-shaped rows.
+UPDATE items
+SET fields = '{}'
+WHERE fields IS NULL
+   OR json_valid(fields) = 0
+   OR json_type(fields) != 'object';
+
+UPDATE items
+SET tags = '[]'
+WHERE tags IS NULL
+   OR json_valid(tags) = 0
+   OR json_type(tags) != 'array';
 
 DROP TABLE IF EXISTS items_new;
 

--- a/internal/store/migrations/056_items_jsonb_not_null.sql
+++ b/internal/store/migrations/056_items_jsonb_not_null.sql
@@ -1,0 +1,124 @@
+-- IDEA-1486: harden items.fields and items.tags to NOT NULL DEFAULT.
+-- See also IDEA-1484 / PR #562 (collections.settings precedent at
+-- 055_collections_settings_not_null.sql).
+--
+-- SQLite does not support ALTER COLUMN ... SET NOT NULL, so the table is
+-- rebuilt via the standard SQLite recipe. All inbound FKs to items(id)
+-- (item_links.source_id/target_id, item_versions.item_id, comments.item_id,
+-- item_stars.item_id, grants.item_id, item_yjs_updates.item_id, and the
+-- items.parent_id self-reference) point at the primary key; since we
+-- preserve every `id` value during the copy, those references remain
+-- valid after the rename.
+--
+-- foreign_keys is toggled OFF for the duration to avoid the constraint
+-- checker tripping on the transient DROP TABLE. The IDEA-1485 migration
+-- runner (store.go:applySQLiteMigration) lifts these PRAGMA bookends out
+-- of the wrapping transaction so they actually take effect on SQLite.
+--
+-- This migration also drops + recreates the three items_fts triggers
+-- (auto-dropped with the items table) and issues a `'rebuild'` on the
+-- FTS5 virtual table. The items_fts virtual table itself stays in place:
+-- its `content='items'` link rebinds to the renamed items table by name,
+-- and `'rebuild'` repopulates the internal index against the post-
+-- rebuild rowids. Trigger bodies are copied verbatim from migration 005.
+
+PRAGMA foreign_keys = OFF;
+
+-- Backfill any NULL fields / tags before applying the constraint. tags
+-- has been de-facto NOT NULL since migration 001 (DEFAULT '[]'), but the
+-- explicit backfill is harmless idempotency belt.
+UPDATE items SET fields = '{}' WHERE fields IS NULL;
+UPDATE items SET tags = '[]' WHERE tags IS NULL;
+
+DROP TABLE IF EXISTS items_new;
+
+CREATE TABLE items_new (
+    id                          TEXT PRIMARY KEY,
+    workspace_id                TEXT NOT NULL REFERENCES workspaces(id),
+    collection_id               TEXT NOT NULL REFERENCES collections(id),
+    title                       TEXT NOT NULL,
+    slug                        TEXT NOT NULL,
+    content                     TEXT DEFAULT '',
+    fields                      TEXT NOT NULL DEFAULT '{}',
+    tags                        TEXT NOT NULL DEFAULT '[]',
+    pinned                      INTEGER DEFAULT 0,
+    sort_order                  INTEGER DEFAULT 0,
+    parent_id                   TEXT REFERENCES items(id),
+    created_by                  TEXT DEFAULT 'user',
+    last_modified_by            TEXT DEFAULT 'user',
+    source                      TEXT DEFAULT 'web',
+    created_at                  TEXT NOT NULL,
+    updated_at                  TEXT NOT NULL,
+    deleted_at                  TEXT,
+    item_number                 INTEGER,
+    created_by_user_id          TEXT REFERENCES users(id),
+    last_modified_by_user_id    TEXT REFERENCES users(id),
+    assigned_user_id            TEXT REFERENCES users(id) ON DELETE SET NULL,
+    agent_role_id               TEXT REFERENCES agent_roles(id) ON DELETE SET NULL,
+    role_sort_order             INTEGER NOT NULL DEFAULT 0,
+    content_flushed_at          TEXT,
+    content_flushed_op_log_id   INTEGER,
+    seq                         INTEGER NOT NULL DEFAULT 0,
+    UNIQUE(workspace_id, slug)
+);
+
+INSERT INTO items_new (
+    id, workspace_id, collection_id, title, slug, content, fields, tags,
+    pinned, sort_order, parent_id, created_by, last_modified_by, source,
+    created_at, updated_at, deleted_at, item_number,
+    created_by_user_id, last_modified_by_user_id,
+    assigned_user_id, agent_role_id, role_sort_order,
+    content_flushed_at, content_flushed_op_log_id, seq
+)
+SELECT
+    id, workspace_id, collection_id, title, slug, content,
+    COALESCE(fields, '{}'),
+    COALESCE(tags, '[]'),
+    pinned, sort_order, parent_id, created_by, last_modified_by, source,
+    created_at, updated_at, deleted_at, item_number,
+    created_by_user_id, last_modified_by_user_id,
+    assigned_user_id, agent_role_id, role_sort_order,
+    content_flushed_at, content_flushed_op_log_id, seq
+FROM items;
+
+DROP TABLE items;
+ALTER TABLE items_new RENAME TO items;
+
+-- Recreate all 7 indexes (originally from 005, 017, 053).
+CREATE INDEX IF NOT EXISTS idx_items_collection ON items(collection_id) WHERE deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_items_workspace ON items(workspace_id) WHERE deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_items_parent ON items(parent_id) WHERE deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_items_updated ON items(updated_at) WHERE deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_items_assigned_user ON items(assigned_user_id) WHERE deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_items_agent_role ON items(agent_role_id) WHERE deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_items_workspace_seq ON items(workspace_id, seq DESC);
+
+-- Recreate items_fts triggers (auto-dropped with the items table).
+-- Bodies match 005_collections.sql:96-107 exactly. The IF EXISTS guards
+-- mirror 046_restore_documents_fts_triggers.sql as an idempotency belt;
+-- they are harmless no-ops on the success path because DROP TABLE items
+-- already removed them.
+DROP TRIGGER IF EXISTS items_fts_insert;
+DROP TRIGGER IF EXISTS items_fts_update;
+DROP TRIGGER IF EXISTS items_fts_delete;
+
+CREATE TRIGGER items_fts_insert AFTER INSERT ON items BEGIN
+  INSERT INTO items_fts(rowid, title, content, tags) VALUES (NEW.rowid, NEW.title, NEW.content, NEW.tags);
+END;
+
+CREATE TRIGGER items_fts_update AFTER UPDATE ON items BEGIN
+  INSERT INTO items_fts(items_fts, rowid, title, content, tags) VALUES('delete', OLD.rowid, OLD.title, OLD.content, OLD.tags);
+  INSERT INTO items_fts(rowid, title, content, tags) VALUES (NEW.rowid, NEW.title, NEW.content, NEW.tags);
+END;
+
+CREATE TRIGGER items_fts_delete AFTER DELETE ON items BEGIN
+  INSERT INTO items_fts(items_fts, rowid, title, content, tags) VALUES('delete', OLD.rowid, OLD.title, OLD.content, OLD.tags);
+END;
+
+-- Rebuild the FTS5 internal index from the post-rebuild items table.
+-- The contentless-content link binds by table name, so items_fts re-
+-- attaches to the renamed items table automatically; 'rebuild' clears
+-- and repopulates the internal index against the current rowids.
+INSERT INTO items_fts(items_fts) VALUES ('rebuild');
+
+PRAGMA foreign_keys = ON;

--- a/internal/store/migrations/056_items_jsonb_not_null.sql
+++ b/internal/store/migrations/056_items_jsonb_not_null.sql
@@ -84,7 +84,9 @@ FROM items;
 DROP TABLE items;
 ALTER TABLE items_new RENAME TO items;
 
--- Recreate all 7 indexes (originally from 005, 017, 053).
+-- Recreate all 8 indexes (originally from 005, 017, 053, 054). Every
+-- index is attached to the dropped items table and does NOT survive
+-- DROP TABLE items; each must be re-issued explicitly.
 CREATE INDEX IF NOT EXISTS idx_items_collection ON items(collection_id) WHERE deleted_at IS NULL;
 CREATE INDEX IF NOT EXISTS idx_items_workspace ON items(workspace_id) WHERE deleted_at IS NULL;
 CREATE INDEX IF NOT EXISTS idx_items_parent ON items(parent_id) WHERE deleted_at IS NULL;
@@ -92,6 +94,17 @@ CREATE INDEX IF NOT EXISTS idx_items_updated ON items(updated_at) WHERE deleted_
 CREATE INDEX IF NOT EXISTS idx_items_assigned_user ON items(assigned_user_id) WHERE deleted_at IS NULL;
 CREATE INDEX IF NOT EXISTS idx_items_agent_role ON items(agent_role_id) WHERE deleted_at IS NULL;
 CREATE INDEX IF NOT EXISTS idx_items_workspace_seq ON items(workspace_id, seq DESC);
+
+-- Playbook invocation_slug uniqueness guard (from migration 054). The
+-- body matches 054 verbatim. This is the DB-level TOCTOU protection
+-- that the application-layer checkUniqueFields in handlers_items.go
+-- relies on — dropping it during the rebuild and forgetting to
+-- recreate it would silently lose the uniqueness invariant.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_items_invocation_slug_per_collection
+    ON items(collection_id, json_extract(fields, '$.invocation_slug'))
+    WHERE json_extract(fields, '$.invocation_slug') IS NOT NULL
+      AND json_extract(fields, '$.invocation_slug') != ''
+      AND deleted_at IS NULL;
 
 -- Recreate items_fts triggers (auto-dropped with the items table).
 -- Bodies match 005_collections.sql:96-107 exactly. The IF EXISTS guards

--- a/internal/store/migrations/057_views_config_not_null.sql
+++ b/internal/store/migrations/057_views_config_not_null.sql
@@ -14,8 +14,14 @@
 
 PRAGMA foreign_keys = OFF;
 
--- Backfill any NULL config before applying the constraint.
-UPDATE views SET config = '{}' WHERE config IS NULL;
+-- Backfill: repair any row whose config violates the post-migration
+-- shape contract (NOT NULL + JSON object). See migration 056 for the
+-- full rationale on the widened WHERE clause (codex R2 P1).
+UPDATE views
+SET config = '{}'
+WHERE config IS NULL
+   OR json_valid(config) = 0
+   OR json_type(config) != 'object';
 
 DROP TABLE IF EXISTS views_new;
 

--- a/internal/store/migrations/057_views_config_not_null.sql
+++ b/internal/store/migrations/057_views_config_not_null.sql
@@ -1,0 +1,50 @@
+-- IDEA-1486: harden views.config to NOT NULL DEFAULT '{}'.
+-- See also IDEA-1484 / PR #562 (collections.settings precedent at
+-- 055_collections_settings_not_null.sql) and migration 056 in the same
+-- PR for the parallel items.fields / items.tags hardening.
+--
+-- SQLite does not support ALTER COLUMN ... SET NOT NULL, so the table is
+-- rebuilt via the standard SQLite recipe. The views table has no inbound
+-- FKs, no indexes, and no FTS triggers — this is the smaller of the two
+-- rebuilds in this PR.
+--
+-- foreign_keys is toggled OFF for the duration as the canonical pattern;
+-- the IDEA-1485 migration runner lifts these PRAGMA bookends outside the
+-- wrapping transaction so they actually take effect.
+
+PRAGMA foreign_keys = OFF;
+
+-- Backfill any NULL config before applying the constraint.
+UPDATE views SET config = '{}' WHERE config IS NULL;
+
+DROP TABLE IF EXISTS views_new;
+
+CREATE TABLE views_new (
+    id            TEXT PRIMARY KEY,
+    workspace_id  TEXT NOT NULL REFERENCES workspaces(id),
+    collection_id TEXT REFERENCES collections(id),
+    name          TEXT NOT NULL,
+    slug          TEXT NOT NULL,
+    view_type     TEXT NOT NULL,
+    config        TEXT NOT NULL DEFAULT '{}',
+    sort_order    INTEGER DEFAULT 0,
+    is_default    INTEGER DEFAULT 0,
+    created_at    TEXT NOT NULL,
+    updated_at    TEXT NOT NULL,
+    UNIQUE(workspace_id, slug)
+);
+
+INSERT INTO views_new (
+    id, workspace_id, collection_id, name, slug, view_type, config,
+    sort_order, is_default, created_at, updated_at
+)
+SELECT
+    id, workspace_id, collection_id, name, slug, view_type,
+    COALESCE(config, '{}'),
+    sort_order, is_default, created_at, updated_at
+FROM views;
+
+DROP TABLE views;
+ALTER TABLE views_new RENAME TO views;
+
+PRAGMA foreign_keys = ON;

--- a/internal/store/pgmigrations/035_items_jsonb_not_null.sql
+++ b/internal/store/pgmigrations/035_items_jsonb_not_null.sql
@@ -11,8 +11,17 @@
 -- views.config NOT NULL lands in 036 to keep per-table blast radius
 -- independent.
 
-UPDATE items SET fields = '{}'::jsonb WHERE fields IS NULL;
-UPDATE items SET tags   = '[]'::jsonb WHERE tags IS NULL;
+-- Backfill: repair any row whose fields / tags violates the post-
+-- migration shape contract. The JSONB column type rejects invalid
+-- JSON at write time, so the only pre-existing pathologies that
+-- could survive are SQL NULL and JSONB-valid-but-wrong-shape (e.g.
+-- a JSONB null, an array where an object is required, a primitive).
+-- Codex R2 P1: the original NULL-only filter would have left wrong-
+-- shape rows in place, weakening the IDEA-1488 ceiling — the
+-- handler-layer shape validators reject those shapes on input but
+-- pre-existing rows would have slipped past.
+UPDATE items SET fields = '{}'::jsonb WHERE fields IS NULL OR jsonb_typeof(fields) != 'object';
+UPDATE items SET tags   = '[]'::jsonb WHERE tags   IS NULL OR jsonb_typeof(tags)   != 'array';
 ALTER TABLE items ALTER COLUMN fields SET NOT NULL;
 ALTER TABLE items ALTER COLUMN tags SET NOT NULL;
 ALTER TABLE items ALTER COLUMN fields SET DEFAULT '{}'::jsonb;

--- a/internal/store/pgmigrations/035_items_jsonb_not_null.sql
+++ b/internal/store/pgmigrations/035_items_jsonb_not_null.sql
@@ -1,0 +1,19 @@
+-- IDEA-1486: harden items.fields and items.tags to NOT NULL DEFAULT.
+-- See also IDEA-1484 / PR #562 (collections.settings precedent at
+-- pgmigrations/034_collections_settings_not_null.sql).
+--
+-- The DEFAULT clauses were already '{}'::jsonb / '[]'::jsonb in
+-- 001_initial.sql (lines 131-132), so SET DEFAULT here is a no-op
+-- idempotency belt; SET NOT NULL is the load-bearing change.
+--
+-- Both columns sit on the same table — one ALTER TABLE per column,
+-- atomic-as-a-group makes sense, so they share a single migration file.
+-- views.config NOT NULL lands in 036 to keep per-table blast radius
+-- independent.
+
+UPDATE items SET fields = '{}'::jsonb WHERE fields IS NULL;
+UPDATE items SET tags   = '[]'::jsonb WHERE tags IS NULL;
+ALTER TABLE items ALTER COLUMN fields SET NOT NULL;
+ALTER TABLE items ALTER COLUMN tags SET NOT NULL;
+ALTER TABLE items ALTER COLUMN fields SET DEFAULT '{}'::jsonb;
+ALTER TABLE items ALTER COLUMN tags SET DEFAULT '[]'::jsonb;

--- a/internal/store/pgmigrations/036_views_config_not_null.sql
+++ b/internal/store/pgmigrations/036_views_config_not_null.sql
@@ -1,0 +1,12 @@
+-- IDEA-1486: harden views.config to NOT NULL DEFAULT '{}'::jsonb.
+-- See also IDEA-1484 / PR #562 (collections.settings precedent at
+-- pgmigrations/034_collections_settings_not_null.sql) and migration 035
+-- in the same PR for the parallel items.fields / items.tags hardening.
+--
+-- The DEFAULT clause was already '{}'::jsonb in 001_initial.sql:200, so
+-- SET DEFAULT here is a no-op idempotency belt; SET NOT NULL is the
+-- load-bearing change.
+
+UPDATE views SET config = '{}'::jsonb WHERE config IS NULL;
+ALTER TABLE views ALTER COLUMN config SET NOT NULL;
+ALTER TABLE views ALTER COLUMN config SET DEFAULT '{}'::jsonb;

--- a/internal/store/pgmigrations/036_views_config_not_null.sql
+++ b/internal/store/pgmigrations/036_views_config_not_null.sql
@@ -7,6 +7,9 @@
 -- SET DEFAULT here is a no-op idempotency belt; SET NOT NULL is the
 -- load-bearing change.
 
-UPDATE views SET config = '{}'::jsonb WHERE config IS NULL;
+-- Backfill: repair any row whose config violates the post-migration
+-- shape contract. See migration 035 for the full rationale on the
+-- widened WHERE clause (codex R2 P1).
+UPDATE views SET config = '{}'::jsonb WHERE config IS NULL OR jsonb_typeof(config) != 'object';
 ALTER TABLE views ALTER COLUMN config SET NOT NULL;
 ALTER TABLE views ALTER COLUMN config SET DEFAULT '{}'::jsonb;

--- a/internal/store/views.go
+++ b/internal/store/views.go
@@ -150,8 +150,20 @@ func (s *Store) UpdateView(id string, input models.ViewUpdate) (*models.View, er
 		args = append(args, *input.ViewType)
 	}
 	if input.Config != nil {
+		// IDEA-1486: normalize the empty-string sentinel to a valid JSON
+		// object before writing. After the NOT NULL DEFAULT '{}'
+		// hardening (migration 057 / pgmigrations 036), Postgres rejects
+		// "" at JSONB type-validation and SQLite would silently store
+		// invalid JSON. Mirrors CreateView at views.go:24-27 and the
+		// IDEA-1484 precedent at collections.go:248. Shape validation
+		// (object vs. array vs. primitive) is handled at the handler
+		// boundary by ViewUpdate.UnmarshalJSON (IDEA-1488).
+		config := *input.Config
+		if config == "" {
+			config = "{}"
+		}
 		sets = append(sets, "config = ?")
-		args = append(args, *input.Config)
+		args = append(args, config)
 	}
 	if input.SortOrder != nil {
 		sets = append(sets, "sort_order = ?")


### PR DESCRIPTION
Paired ship of IDEA-1486 (sibling-table JSONB NOT NULL hardening for `items.fields`, `items.tags`, `views.config`) and IDEA-1488 (handler-layer JSON-shape validation for `ViewUpdate` / `CollectionUpdate`). Builds on IDEA-1484's `collections.settings` precedent and IDEA-1485's atomic-migration runner.

## Summary

- Four new schema migrations harden three JSON columns to `NOT NULL DEFAULT` on both drivers:
  - `internal/store/migrations/056_items_jsonb_not_null.sql` — SQLite items rebuild (FK metadata + 8 indexes + 3 FTS triggers + `'rebuild'` directive preserved)
  - `internal/store/migrations/057_views_config_not_null.sql` — SQLite views rebuild
  - `internal/store/pgmigrations/035_items_jsonb_not_null.sql` — Postgres `items.fields` + `items.tags`
  - `internal/store/pgmigrations/036_views_config_not_null.sql` — Postgres `views.config`
- Backfill clauses are shape-aware (catch SQL NULL, invalid JSON, and wrong top-level type), not just SQL NULL — protects the recreated `idx_items_invocation_slug_per_collection` partial index from `malformed JSON` errors on pre-existing wrong-shape rows.
- Store-layer `""→default` coercion added on UPDATE paths (`UpdateItem`, `UpdateView`), import paths (`ImportWorkspace` for `items.fields`/`tags` + `collections.settings`), and the second-pass remap UPDATE (via a `coercedFields`/`coercedTags` map keyed by original ID + `remapFieldIDs("")→"{}"`).
- Handler-layer shape validation on `ViewUpdate` / `CollectionUpdate` (and their Create siblings) via `UnmarshalJSON` mirroring the `ItemUpdate` precedent, with new `ErrInvalidConfigType` / `ErrInvalidSettingsType` sentinels. `handleCreateItem` now also unwraps `ErrInvalidFieldsType` / `ErrInvalidTagsType` consistently with the PATCH path.
- `flexJSONToString` now validates the inner content of JSON-encoded strings — `{"config":"[]"}`, `{"settings":"not json"}`, etc. now return 400 instead of slipping past. Same fix applies uniformly to `ItemUpdate.fields`/`tags`.
- Import path's `coerceJSONForImport` rejects JSON `null` literals (post-`Unmarshal` non-nil check) and structurally logs malformed-shape coercion via `slog.Warn` (`field`, `item_id`/`view_id`/`collection_id`, `workspace_id`, `raw_len` — no raw user content logged).
- Pre-existing `fmt.Printf` warning in `export.go:329` migrated to `slog.Warn` for consistency (small fold-in).

## Architectural decisions

- **No `json_valid(...)` CHECK constraint on the rebuild.** Defer shape enforcement to the handler layer (IDEA-1488); avoids double-validation and matches the `055_collections_settings_not_null.sql` precedent.
- **`items_fts` virtual table is kept in place across the rebuild.** Its `content='items'` link rebinds to the renamed table by name; the three triggers (auto-dropped with `DROP TABLE items`) are recreated verbatim from `005`, then `INSERT INTO items_fts(items_fts) VALUES ('rebuild')` repopulates the FTS5 internal index against the post-rebuild rowids.
- **Postgres migrations split per table** (035 items, 036 views) to mirror SQLite per-table file granularity and `034_collections_settings_not_null.sql`'s per-table precedent.
- **Migration files conform to IDEA-1485's runner contract**: `PRAGMA foreign_keys = OFF;` / `ON;` bookends are lifted around the wrapping transaction by `applySQLiteMigration`'s line-scan classification; no `BEGIN`/`COMMIT` in the body.

## Observable behavior changes

- `POST` / `PATCH` on items/views/collections with malformed shape values (non-object `fields`/`config`/`settings`, non-array `tags`, or JSON-encoded strings carrying wrong-shape inner JSON) return HTTP 400 with a clean sentinel message instead of slipping through or 500ing downstream.
- Workspace imports carrying malformed JSON shapes log a structured warning and coerce to the default rather than fail-stopping the import (legacy-bundle compatibility).
- Post-migration, `items.fields`, `items.tags`, and `views.config` are guaranteed non-NULL on both drivers; SQLite stores valid JSON for these columns (backfill repaired any pre-existing wrong-shape rows).

## Test plan

- [x] `make test` (SQLite default) — PASS
- [x] `make test-pg` equivalent against Postgres — PASS (run against existing port-5445 container; CI will exercise a fresh container)
- [x] `go vet ./...` — clean
- [x] `gofmt -l . | grep -v vendor/` — empty
- [x] Codex review loop converged (R1 → R2 → R3, three distinct framings, R3 found nothing material)
- [x] Toggle-verified: the backfill-shape-repair regression test FAILS at the exact predicted point (`SQL logic error: malformed JSON` at `CREATE UNIQUE INDEX idx_items_invocation_slug_per_collection`) when the widened WHERE is reverted to NULL-only

## Refs

- IDEA-1486 / IDEA-1488 (this PR closes both)
- IDEA-1484 / PR #562 (collections.settings precedent)
- IDEA-1485 / PR #565 (atomic-migration runner used by 056/057)
- BUG-1482 / PR #561 (original NULL-handling fix that surfaced the class)

## Deferred (out of scope, file follow-up if needed)

- Migrations 055 / pg-034 (collections.settings, shipped in PR #562) have the same NULL-only backfill gap. Not retroactively touched — separate IDEA if production rows surface as wrong-shape.
- The test at `handlers_views_collections_jsonb_test.go:91` asserts `200 || 400` for empty-string config rather than locking to one. Codex R3 nit; functional behavior is correct (coerce-at-store-layer → 200), but the assertion could be tightened.