### PR TITLE
feat(links): cross-workspace wiki-link resolution (IDEA-1492)

### DIFF
--- a/internal/server/handlers_ref_resolver.go
+++ b/internal/server/handlers_ref_resolver.go
@@ -1,0 +1,238 @@
+package server
+
+import (
+	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+	"github.com/go-chi/chi/v5"
+)
+
+// refResolverRefPattern matches the wiki-link ref shape: a letter-led
+// alphanumeric prefix, a hyphen, and a positive integer. Mirrors the
+// renderer's client-side regex so a 404 here is congruent with what the
+// editor renders as a broken link. Anchored to reject ambiguous inputs
+// before any DB lookup (the validator runs BEFORE workspace resolution,
+// so a malformed REF can't reveal whether the workspace exists).
+var refResolverRefPattern = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9]*-\d+$`)
+
+// handleResolveCrossWorkspaceRef implements IDEA-1492's resolver route.
+// GET /{username}/{workspace}/ref/{REF} → 302 to the canonical item URL.
+//
+// 404 cases (in order of evaluation):
+//
+//  1. REF doesn't match the wiki-link pattern. Rejected before the DB hit
+//     so anonymous probes can't enumerate workspace existence by ref shape.
+//  2. Workspace slug doesn't resolve, OR resolves but the current viewer
+//     lacks access. We deliberately return 404 (not 403) — the brief calls
+//     for "don't leak workspace existence", so members of a different
+//     workspace see the same response as anonymous viewers.
+//  3. Ref resolves to no item in the target workspace.
+//
+// The 302 redirect target mirrors the same path the SvelteKit page router
+// would produce for a regular item link, so the post-redirect URL is
+// indistinguishable from a direct in-app navigation.
+func (s *Server) handleResolveCrossWorkspaceRef(w http.ResponseWriter, r *http.Request) {
+	username := chi.URLParam(r, "username")
+	workspaceSlug := chi.URLParam(r, "workspace")
+	ref := chi.URLParam(r, "ref")
+
+	// 1. Validate REF shape FIRST — cheap, no DB hit, and doesn't leak
+	//    whether the workspace exists. A malformed REF on a real workspace
+	//    looks the same as a malformed REF on a phantom workspace.
+	if !refResolverRefPattern.MatchString(ref) {
+		s.refResolverNotFound(w, r)
+		return
+	}
+
+	// 2. Resolve the workspace through the same path as /workspaces/{slug}.
+	//    Uses currentUser(r) so the ACL is consistent: members + guests with
+	//    grants see the workspace; everyone else gets nil (→ 404).
+	ws, err := s.resolveWorkspace(workspaceSlug, currentUser(r))
+	if err != nil {
+		// Internal error path — write a generic 404 rather than 500 to keep
+		// the no-leak contract intact for ambiguous failures.
+		s.refResolverNotFound(w, r)
+		return
+	}
+	if ws == nil {
+		s.refResolverNotFound(w, r)
+		return
+	}
+
+	// 3. Resolve the ref within the workspace. We re-parse here (rather than
+	//    just splitting on "-") to mirror store.parseItemRef's uppercase-
+	//    prefix rule — store.GetItemByRef is keyed on the uppercase prefix
+	//    so the redirect must canonicalize the URL ref the same way the
+	//    storage layer does.
+	prefix, number, ok := parseRefForRedirect(ref)
+	if !ok {
+		// Defense in depth — refResolverRefPattern already vetted the shape,
+		// but parseItemRef has its own rules (uppercase-only prefix). If we
+		// disagree, fall back to the same 404 path rather than 500.
+		s.refResolverNotFound(w, r)
+		return
+	}
+	item, err := s.store.GetItemByRef(ws.ID, prefix, number)
+	if err != nil {
+		s.refResolverNotFound(w, r)
+		return
+	}
+	if item == nil {
+		s.refResolverNotFound(w, r)
+		return
+	}
+
+	// 4. ACL: if the viewer's collection visibility excludes this item's
+	//    collection, treat as 404 (same shape as workspace-no-access). We
+	//    inline a lightweight visibility check rather than reuse
+	//    requireItemVisible because that helper assumes RequireWorkspaceAccess
+	//    middleware has already populated context — this route runs outside
+	//    that group.
+	if !s.refResolverItemVisible(r, ws.ID, item) {
+		s.refResolverNotFound(w, r)
+		return
+	}
+
+	// 5. Build the canonical item URL and 302 to it. We prefer the URL-path
+	//    `username` from the request (matches the incoming URL shape) over
+	//    the workspace's owner username, so a user hitting /alice/ws/ref/X
+	//    stays in alice's URL namespace even if the workspace was later
+	//    transferred. SvelteKit's router handles the redirect target the
+	//    same regardless.
+	dest := "/" + username + "/" + ws.Slug + "/" + item.CollectionSlug + "/"
+	if item.ItemNumber != nil && *item.ItemNumber > 0 && item.CollectionPrefix != "" {
+		// Items addressed by ref (formatItemRef-style) when available — this
+		// matches itemUrlId() in the frontend, so the redirect target is
+		// identical to a direct in-app navigation.
+		dest += item.CollectionPrefix + "-" + refItoa(*item.ItemNumber)
+	} else {
+		dest += item.Slug
+	}
+	http.Redirect(w, r, dest, http.StatusFound)
+}
+
+// refResolverNotFound writes a 404 with no body details. Centralized so all
+// failure paths produce identical responses — preventing oracle-style probes
+// that compare response bodies to distinguish "workspace missing" from
+// "ref missing" from "no access".
+func (s *Server) refResolverNotFound(w http.ResponseWriter, _ *http.Request) {
+	writeError(w, http.StatusNotFound, "not_found", "Not found")
+}
+
+// refResolverItemVisible returns true iff the current viewer can see the
+// given item under their workspace role + grant set. Returns false for
+// anonymous viewers on a workspace that requires auth, for guests without a
+// grant on the item's collection, and for members whose collection access
+// excludes the item's collection. Returns true when the viewer has full
+// workspace access (admin / owner / member with "all" collection access).
+//
+// Mirrors requireItemVisible but operates without the RequireWorkspaceAccess
+// middleware's context-populated state — this route is reachable
+// unauthenticated, so we compute visibility from the user + workspace
+// directly. Errors during the grant lookup fall back to "not visible" to
+// keep the no-leak contract.
+func (s *Server) refResolverItemVisible(r *http.Request, workspaceID string, item *models.Item) bool {
+	user := currentUser(r)
+
+	// Pre-setup mode: a fresh instance with no users yet has the whole
+	// system open (matches RequireAuth's bypass). Anonymous probes are
+	// equivalent to "logged in as the eventual admin" here, so the
+	// visibility gate has nothing to enforce.
+	if user == nil {
+		count, err := s.store.UserCount()
+		if err == nil && count == 0 {
+			return true
+		}
+		// Authenticated-instance anonymous viewer: no item-read access via
+		// the resolver route. Share links cover the public-read surface
+		// through /s/{token}.
+		return false
+	}
+
+	// Admin users see everything.
+	if user.Role == "admin" {
+		return true
+	}
+
+	// Owner of the workspace.
+	ws, err := s.store.GetWorkspaceByID(workspaceID)
+	if err != nil || ws == nil {
+		return false
+	}
+	if ws.OwnerID == user.ID {
+		return true
+	}
+
+	// Members with collection access. GetWorkspaceMember returns nil for
+	// non-members; in that case we fall through to the guest grant check.
+	member, _ := s.store.GetWorkspaceMember(workspaceID, user.ID)
+	if member != nil {
+		// "all" access — every collection is visible.
+		if member.CollectionAccess == "" || member.CollectionAccess == "all" {
+			return true
+		}
+		// Restricted access — check member_collection_access.
+		colls, _ := s.store.GetMemberCollectionAccess(workspaceID, user.ID)
+		for _, cID := range colls {
+			if cID == item.CollectionID {
+				return true
+			}
+		}
+		// Member-with-restricted-access can also have explicit item grants.
+		_, grantedItemIDs, _ := s.store.GuestVisibleResources(workspaceID, user.ID)
+		for _, iID := range grantedItemIDs {
+			if iID == item.ID {
+				return true
+			}
+		}
+		return false
+	}
+
+	// Guest path: full collection grants or item grants.
+	fullCollIDs, grantedItemIDs, err := s.store.GuestVisibleResources(workspaceID, user.ID)
+	if err != nil {
+		return false
+	}
+	for _, cID := range fullCollIDs {
+		if cID == item.CollectionID {
+			return true
+		}
+	}
+	for _, iID := range grantedItemIDs {
+		if iID == item.ID {
+			return true
+		}
+	}
+	return false
+}
+
+// refItoa wraps strconv.Itoa for redirect-URL composition. Kept as a one-line
+// helper so the build path through this file stays grep-able for future
+// readers asking "where does the redirect target get composed".
+func refItoa(n int) string {
+	return strconv.Itoa(n)
+}
+
+// parseRefForRedirect splits a validated ref (the regex caller already
+// confirmed `[A-Za-z][A-Za-z0-9]*-\d+`) into its uppercase prefix and
+// number. GetItemByRef's primary path matches on exact prefix; its
+// fallback path (workspace-unique number alone) handles items that have
+// been moved to a different collection, so a digit-bearing prefix that
+// doesn't match store.parseItemRef's stricter A-Z rule still resolves via
+// the number lookup.
+func parseRefForRedirect(s string) (string, int, bool) {
+	up := strings.ToUpper(s)
+	dash := strings.LastIndex(up, "-")
+	if dash <= 0 || dash == len(up)-1 {
+		return "", 0, false
+	}
+	prefix := up[:dash]
+	num, err := strconv.Atoi(up[dash+1:])
+	if err != nil || num <= 0 {
+		return "", 0, false
+	}
+	return prefix, num, true
+}

--- a/internal/server/handlers_ref_resolver.go
+++ b/internal/server/handlers_ref_resolver.go
@@ -19,17 +19,14 @@ import (
 var refResolverRefPattern = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9]*-\d+$`)
 
 // handleResolveCrossWorkspaceRef implements IDEA-1492's resolver route.
-// Registered under two shapes:
 //
-//	GET /{username}/{workspace}/ref/{REF}
-//	GET /{workspace}/ref/{REF}
+//	GET /-/r/{workspace}/{REF}
 //
-// The two-segment form covers renderers that don't have a username in
-// scope (timeline comments, comment threads — neither call site threads
-// a username through renderMarkdown). When the URL-path username is
-// missing, we synthesize the redirect using the workspace owner's
-// username so the post-redirect URL is the canonical three-segment shape
-// SvelteKit's router expects.
+// The `/-/r/` prefix is structurally impossible to collide with any
+// page route under /{username}/{workspace}/{collection}/... because
+// username and collection slugs both require a leading letter. This
+// shape sidesteps Codex round-2 P1.4 (pre-existing `ref`-slugged
+// collections in upgraded workspaces) without a migration.
 //
 // 404 cases (in order of evaluation):
 //
@@ -41,8 +38,12 @@ var refResolverRefPattern = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9]*-\d+$`)
 //     workspace see the same response as anonymous viewers.
 //  3. Ref resolves to no item in the target workspace.
 //  4. The item's collection isn't visible to the viewer.
+//  5. The workspace's owner has no username on record — the canonical
+//     redirect target requires one, and `"/" + "" + "/" + slug + …`
+//     would produce a protocol-relative URL (`//slug/…`) the browser
+//     interprets as a network-path reference. Returning 404 here is
+//     safer than emitting a broken redirect (Codex round-2 P1.3).
 func (s *Server) handleResolveCrossWorkspaceRef(w http.ResponseWriter, r *http.Request) {
-	username := chi.URLParam(r, "username") // "" for the two-segment route
 	workspaceSlug := chi.URLParam(r, "workspace")
 	ref := chi.URLParam(r, "ref")
 
@@ -88,7 +89,7 @@ func (s *Server) handleResolveCrossWorkspaceRef(w http.ResponseWriter, r *http.R
 	// 4. ACL: replay RequireWorkspaceAccess's role-derivation logic for
 	//    the viewer, then delegate to checkItemVisible — the same context-
 	//    free helper the middleware-gated routes use. Drift between the
-	//    resolver's ACL and the rest of the system is now structurally
+	//    resolver's ACL and the rest of the system is structurally
 	//    impossible.
 	visible, err := s.resolverItemVisible(r, ws, item)
 	if err != nil || !visible {
@@ -96,20 +97,21 @@ func (s *Server) handleResolveCrossWorkspaceRef(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	// 5. Build the canonical item URL and 302 to it. URL-path username
-	//    wins when present; otherwise fall back to the workspace owner's
-	//    username so the redirect lands on the same SvelteKit URL the
-	//    in-app router would produce. Pre-setup workspaces with no
-	//    owner_username fall back to an empty path segment — that's the
-	//    same shape SvelteKit's `[username]` param accepts.
+	// 5. Determine the username segment for the canonical redirect target.
+	//    The new URL shape has no URL-path username, so we always synthesize
+	//    from the workspace owner. Empty result → 404 rather than a broken
+	//    `//slug/…` protocol-relative URL (Codex round-2 P1.3).
+	username := s.resolverOwnerUsername(ws)
 	if username == "" {
-		username = s.resolverOwnerUsername(ws)
+		s.refResolverNotFound(w, r)
+		return
 	}
+
+	// 6. Build the canonical item URL and 302 to it. Matches itemUrlId()
+	//    in the frontend so the redirect target is indistinguishable from a
+	//    direct in-app navigation.
 	dest := "/" + username + "/" + ws.Slug + "/" + item.CollectionSlug + "/"
 	if item.ItemNumber != nil && *item.ItemNumber > 0 && item.CollectionPrefix != "" {
-		// Items addressed by ref (formatItemRef-style) when available — this
-		// matches itemUrlId() in the frontend, so the redirect target is
-		// identical to a direct in-app navigation.
 		dest += item.CollectionPrefix + "-" + strconv.Itoa(*item.ItemNumber)
 	} else {
 		dest += item.Slug
@@ -120,7 +122,7 @@ func (s *Server) handleResolveCrossWorkspaceRef(w http.ResponseWriter, r *http.R
 // refResolverNotFound writes a 404 with no body details. Centralized so all
 // failure paths produce identical responses — preventing oracle-style probes
 // that compare response bodies to distinguish "workspace missing" from
-// "ref missing" from "no access".
+// "ref missing" from "no access" from "owner-username missing".
 func (s *Server) refResolverNotFound(w http.ResponseWriter, _ *http.Request) {
 	writeError(w, http.StatusNotFound, "not_found", "Not found")
 }
@@ -147,10 +149,10 @@ func (s *Server) resolverItemVisible(r *http.Request, ws *models.Workspace, item
 	// Pre-setup mode: no users yet, the whole system is open (matches
 	// RequireAuth + RequireWorkspaceAccess's fresh-install bypass). We
 	// short-circuit to visible HERE rather than calling checkItemVisible
-	// with a synthetic "owner" role because checkItemVisible's first
-	// rule is "nil user → not visible" — that rule is correct for the
-	// authenticated-instance anonymous-viewer path below, and inverting
-	// it would weaken the gate for that path.
+	// with a synthetic role because the round-2-extended checkItemVisible
+	// honors role-only bypasses ("owner"/"editor") for tokenized access,
+	// but the pre-setup path is conceptually distinct from a real
+	// authenticated owner — bypassing here keeps the intent explicit.
 	if user == nil {
 		count, err := s.store.UserCount()
 		if err != nil {
@@ -196,11 +198,14 @@ func (s *Server) resolverWorkspaceRole(ws *models.Workspace, user *models.User) 
 	return ""
 }
 
-// resolverOwnerUsername returns the workspace owner's username, used as
-// the fallback for the two-segment route shape. Falls back to the empty
-// string when the owner record is missing or the owner has no username
-// (legacy accounts predating the username column) — SvelteKit's
-// `[username]` param accepts an empty segment.
+// resolverOwnerUsername returns the workspace owner's username — the
+// only source for the leading path segment of the canonical redirect
+// target (since `/-/r/{workspace}/{ref}` URLs carry no username
+// themselves). Returns "" when the owner record is missing or has no
+// username on file. Callers MUST treat empty as "can't build a valid
+// redirect" and 404 — emitting `/` + "" + `/slug/...` yields a
+// protocol-relative URL the browser interprets as a network-path
+// reference (Codex round-2 P1.3).
 func (s *Server) resolverOwnerUsername(ws *models.Workspace) string {
 	if ws.OwnerUsername != "" {
 		return ws.OwnerUsername

--- a/internal/server/handlers_ref_resolver.go
+++ b/internal/server/handlers_ref_resolver.go
@@ -19,7 +19,17 @@ import (
 var refResolverRefPattern = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9]*-\d+$`)
 
 // handleResolveCrossWorkspaceRef implements IDEA-1492's resolver route.
-// GET /{username}/{workspace}/ref/{REF} → 302 to the canonical item URL.
+// Registered under two shapes:
+//
+//	GET /{username}/{workspace}/ref/{REF}
+//	GET /{workspace}/ref/{REF}
+//
+// The two-segment form covers renderers that don't have a username in
+// scope (timeline comments, comment threads — neither call site threads
+// a username through renderMarkdown). When the URL-path username is
+// missing, we synthesize the redirect using the workspace owner's
+// username so the post-redirect URL is the canonical three-segment shape
+// SvelteKit's router expects.
 //
 // 404 cases (in order of evaluation):
 //
@@ -30,12 +40,9 @@ var refResolverRefPattern = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9]*-\d+$`)
 //     for "don't leak workspace existence", so members of a different
 //     workspace see the same response as anonymous viewers.
 //  3. Ref resolves to no item in the target workspace.
-//
-// The 302 redirect target mirrors the same path the SvelteKit page router
-// would produce for a regular item link, so the post-redirect URL is
-// indistinguishable from a direct in-app navigation.
+//  4. The item's collection isn't visible to the viewer.
 func (s *Server) handleResolveCrossWorkspaceRef(w http.ResponseWriter, r *http.Request) {
-	username := chi.URLParam(r, "username")
+	username := chi.URLParam(r, "username") // "" for the two-segment route
 	workspaceSlug := chi.URLParam(r, "workspace")
 	ref := chi.URLParam(r, "ref")
 
@@ -47,9 +54,9 @@ func (s *Server) handleResolveCrossWorkspaceRef(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	// 2. Resolve the workspace through the same path as /workspaces/{slug}.
-	//    Uses currentUser(r) so the ACL is consistent: members + guests with
-	//    grants see the workspace; everyone else gets nil (→ 404).
+	// 2. Resolve the workspace. Uses currentUser(r) so the ACL is
+	//    consistent: members + guests with grants see the workspace;
+	//    everyone else gets nil (→ 404).
 	ws, err := s.resolveWorkspace(workspaceSlug, currentUser(r))
 	if err != nil {
 		// Internal error path — write a generic 404 rather than 500 to keep
@@ -62,52 +69,48 @@ func (s *Server) handleResolveCrossWorkspaceRef(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	// 3. Resolve the ref within the workspace. We re-parse here (rather than
-	//    just splitting on "-") to mirror store.parseItemRef's uppercase-
-	//    prefix rule — store.GetItemByRef is keyed on the uppercase prefix
-	//    so the redirect must canonicalize the URL ref the same way the
-	//    storage layer does.
+	// 3. Resolve the ref within the workspace. parseRefForRedirect
+	//    canonicalizes the prefix to uppercase so it lines up with
+	//    GetItemByRef's exact-prefix path; refs that fail the stricter
+	//    A-Z prefix rule still resolve via the workspace-unique number
+	//    fallback inside GetItemByRef.
 	prefix, number, ok := parseRefForRedirect(ref)
 	if !ok {
-		// Defense in depth — refResolverRefPattern already vetted the shape,
-		// but parseItemRef has its own rules (uppercase-only prefix). If we
-		// disagree, fall back to the same 404 path rather than 500.
 		s.refResolverNotFound(w, r)
 		return
 	}
 	item, err := s.store.GetItemByRef(ws.ID, prefix, number)
-	if err != nil {
-		s.refResolverNotFound(w, r)
-		return
-	}
-	if item == nil {
+	if err != nil || item == nil {
 		s.refResolverNotFound(w, r)
 		return
 	}
 
-	// 4. ACL: if the viewer's collection visibility excludes this item's
-	//    collection, treat as 404 (same shape as workspace-no-access). We
-	//    inline a lightweight visibility check rather than reuse
-	//    requireItemVisible because that helper assumes RequireWorkspaceAccess
-	//    middleware has already populated context — this route runs outside
-	//    that group.
-	if !s.refResolverItemVisible(r, ws.ID, item) {
+	// 4. ACL: replay RequireWorkspaceAccess's role-derivation logic for
+	//    the viewer, then delegate to checkItemVisible — the same context-
+	//    free helper the middleware-gated routes use. Drift between the
+	//    resolver's ACL and the rest of the system is now structurally
+	//    impossible.
+	visible, err := s.resolverItemVisible(r, ws, item)
+	if err != nil || !visible {
 		s.refResolverNotFound(w, r)
 		return
 	}
 
-	// 5. Build the canonical item URL and 302 to it. We prefer the URL-path
-	//    `username` from the request (matches the incoming URL shape) over
-	//    the workspace's owner username, so a user hitting /alice/ws/ref/X
-	//    stays in alice's URL namespace even if the workspace was later
-	//    transferred. SvelteKit's router handles the redirect target the
-	//    same regardless.
+	// 5. Build the canonical item URL and 302 to it. URL-path username
+	//    wins when present; otherwise fall back to the workspace owner's
+	//    username so the redirect lands on the same SvelteKit URL the
+	//    in-app router would produce. Pre-setup workspaces with no
+	//    owner_username fall back to an empty path segment — that's the
+	//    same shape SvelteKit's `[username]` param accepts.
+	if username == "" {
+		username = s.resolverOwnerUsername(ws)
+	}
 	dest := "/" + username + "/" + ws.Slug + "/" + item.CollectionSlug + "/"
 	if item.ItemNumber != nil && *item.ItemNumber > 0 && item.CollectionPrefix != "" {
 		// Items addressed by ref (formatItemRef-style) when available — this
 		// matches itemUrlId() in the frontend, so the redirect target is
 		// identical to a direct in-app navigation.
-		dest += item.CollectionPrefix + "-" + refItoa(*item.ItemNumber)
+		dest += item.CollectionPrefix + "-" + strconv.Itoa(*item.ItemNumber)
 	} else {
 		dest += item.Slug
 	}
@@ -122,98 +125,94 @@ func (s *Server) refResolverNotFound(w http.ResponseWriter, _ *http.Request) {
 	writeError(w, http.StatusNotFound, "not_found", "Not found")
 }
 
-// refResolverItemVisible returns true iff the current viewer can see the
-// given item under their workspace role + grant set. Returns false for
-// anonymous viewers on a workspace that requires auth, for guests without a
-// grant on the item's collection, and for members whose collection access
-// excludes the item's collection. Returns true when the viewer has full
-// workspace access (admin / owner / member with "all" collection access).
+// resolverItemVisible derives the viewer's workspace role outside the
+// RequireWorkspaceAccess middleware path, then delegates to
+// checkItemVisible. The role-derivation mirrors RequireWorkspaceAccess's
+// rules byte-for-byte:
 //
-// Mirrors requireItemVisible but operates without the RequireWorkspaceAccess
-// middleware's context-populated state — this route is reachable
-// unauthenticated, so we compute visibility from the user + workspace
-// directly. Errors during the grant lookup fall back to "not visible" to
-// keep the no-leak contract.
-func (s *Server) refResolverItemVisible(r *http.Request, workspaceID string, item *models.Item) bool {
+//   - Pre-setup mode (UserCount == 0) → implicit "owner" so the
+//     route is reachable before the first admin exists.
+//   - Admin user → "owner" (admin gets owner-equivalent access to every
+//     workspace).
+//   - Workspace owner → "owner".
+//   - Member with explicit role → that role ("owner" / "editor" / "viewer").
+//   - Non-member with workspace grants → "guest".
+//   - Otherwise → not visible (returns false, nil — distinct from an error).
+//
+// The returned (false, err) pair is reserved for genuine DB errors; the
+// caller still maps both to a 404 to honor the no-leak contract.
+func (s *Server) resolverItemVisible(r *http.Request, ws *models.Workspace, item *models.Item) (bool, error) {
 	user := currentUser(r)
 
-	// Pre-setup mode: a fresh instance with no users yet has the whole
-	// system open (matches RequireAuth's bypass). Anonymous probes are
-	// equivalent to "logged in as the eventual admin" here, so the
-	// visibility gate has nothing to enforce.
+	// Pre-setup mode: no users yet, the whole system is open (matches
+	// RequireAuth + RequireWorkspaceAccess's fresh-install bypass). We
+	// short-circuit to visible HERE rather than calling checkItemVisible
+	// with a synthetic "owner" role because checkItemVisible's first
+	// rule is "nil user → not visible" — that rule is correct for the
+	// authenticated-instance anonymous-viewer path below, and inverting
+	// it would weaken the gate for that path.
 	if user == nil {
 		count, err := s.store.UserCount()
-		if err == nil && count == 0 {
-			return true
+		if err != nil {
+			return false, err
+		}
+		if count == 0 {
+			return true, nil
 		}
 		// Authenticated-instance anonymous viewer: no item-read access via
-		// the resolver route. Share links cover the public-read surface
-		// through /s/{token}.
-		return false
+		// the resolver. Share links own the public-read surface via
+		// /s/{token}.
+		return false, nil
 	}
 
-	// Admin users see everything.
-	if user.Role == "admin" {
-		return true
+	// Derive the role the same way RequireWorkspaceAccess does.
+	role := s.resolverWorkspaceRole(ws, user)
+	if role == "" {
+		// Not a member, no grants, not admin/owner. Not visible.
+		return false, nil
 	}
-
-	// Owner of the workspace.
-	ws, err := s.store.GetWorkspaceByID(workspaceID)
-	if err != nil || ws == nil {
-		return false
-	}
-	if ws.OwnerID == user.ID {
-		return true
-	}
-
-	// Members with collection access. GetWorkspaceMember returns nil for
-	// non-members; in that case we fall through to the guest grant check.
-	member, _ := s.store.GetWorkspaceMember(workspaceID, user.ID)
-	if member != nil {
-		// "all" access — every collection is visible.
-		if member.CollectionAccess == "" || member.CollectionAccess == "all" {
-			return true
-		}
-		// Restricted access — check member_collection_access.
-		colls, _ := s.store.GetMemberCollectionAccess(workspaceID, user.ID)
-		for _, cID := range colls {
-			if cID == item.CollectionID {
-				return true
-			}
-		}
-		// Member-with-restricted-access can also have explicit item grants.
-		_, grantedItemIDs, _ := s.store.GuestVisibleResources(workspaceID, user.ID)
-		for _, iID := range grantedItemIDs {
-			if iID == item.ID {
-				return true
-			}
-		}
-		return false
-	}
-
-	// Guest path: full collection grants or item grants.
-	fullCollIDs, grantedItemIDs, err := s.store.GuestVisibleResources(workspaceID, user.ID)
-	if err != nil {
-		return false
-	}
-	for _, cID := range fullCollIDs {
-		if cID == item.CollectionID {
-			return true
-		}
-	}
-	for _, iID := range grantedItemIDs {
-		if iID == item.ID {
-			return true
-		}
-	}
-	return false
+	return s.checkItemVisible(ws.ID, item, user, role)
 }
 
-// refItoa wraps strconv.Itoa for redirect-URL composition. Kept as a one-line
-// helper so the build path through this file stays grep-able for future
-// readers asking "where does the redirect target get composed".
-func refItoa(n int) string {
-	return strconv.Itoa(n)
+// resolverWorkspaceRole reproduces RequireWorkspaceAccess's role lookup
+// for a (workspace, user) pair without the *http.Request scaffolding.
+// Returns "" when the user has no role and no grants in the workspace.
+// The "owner" return value covers admins (admin gets owner-equivalent
+// access) AND the actual workspace owner — checkItemVisible treats
+// "owner" uniformly so the conflation is safe.
+func (s *Server) resolverWorkspaceRole(ws *models.Workspace, user *models.User) string {
+	if user.Role == "admin" || ws.OwnerID == user.ID {
+		return "owner"
+	}
+	member, err := s.store.GetWorkspaceMember(ws.ID, user.ID)
+	if err == nil && member != nil {
+		return member.Role
+	}
+	// Not a member — guest path requires at least one grant.
+	hasGrants, err := s.store.UserHasGrantsInWorkspace(ws.ID, user.ID)
+	if err == nil && hasGrants {
+		return "guest"
+	}
+	return ""
+}
+
+// resolverOwnerUsername returns the workspace owner's username, used as
+// the fallback for the two-segment route shape. Falls back to the empty
+// string when the owner record is missing or the owner has no username
+// (legacy accounts predating the username column) — SvelteKit's
+// `[username]` param accepts an empty segment.
+func (s *Server) resolverOwnerUsername(ws *models.Workspace) string {
+	if ws.OwnerUsername != "" {
+		return ws.OwnerUsername
+	}
+	if ws.OwnerID == "" {
+		return ""
+	}
+	user, err := s.store.GetUser(ws.OwnerID)
+	if err != nil || user == nil {
+		return ""
+	}
+	return user.Username
 }
 
 // parseRefForRedirect splits a validated ref (the regex caller already

--- a/internal/server/handlers_ref_resolver_test.go
+++ b/internal/server/handlers_ref_resolver_test.go
@@ -1,0 +1,160 @@
+package server
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// TestRefResolver_Success creates a workspace + collection + item, then
+// asserts that GET /{username}/{workspace}/ref/{REF} produces a 302 whose
+// Location header points at the canonical item URL itemUrlId() would
+// produce on the frontend.
+func TestRefResolver_Success(t *testing.T) {
+	srv := testServer(t)
+
+	// Workspace + collection + item via the API (the route only depends on
+	// store state, but using the same surface the frontend uses keeps the
+	// test honest about end-to-end shape).
+	rr := doRequest(srv, "POST", "/api/v1/workspaces", map[string]string{"name": "Claude"})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create workspace: %d %s", rr.Code, rr.Body.String())
+	}
+	var ws models.Workspace
+	parseJSON(t, rr, &ws)
+
+	rr = doRequest(srv, "POST", "/api/v1/workspaces/"+ws.Slug+"/collections", map[string]interface{}{
+		"name":   "Decisions",
+		"slug":   "decisions",
+		"prefix": "DECIS",
+	})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create collection: %d %s", rr.Code, rr.Body.String())
+	}
+
+	rr = doRequest(srv, "POST", "/api/v1/workspaces/"+ws.Slug+"/collections/decisions/items", map[string]interface{}{
+		"title": "Orchestration model",
+	})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create item: %d %s", rr.Code, rr.Body.String())
+	}
+	var item models.Item
+	parseJSON(t, rr, &item)
+	if item.Ref == "" {
+		t.Fatalf("expected item Ref, got empty (item=%+v)", item)
+	}
+
+	// Hit the resolver. The username segment is arbitrary in pre-setup mode
+	// (no auth) — the handler uses the URL-path username verbatim in the
+	// redirect target.
+	rr = doRequest(srv, "GET", "/anyuser/"+ws.Slug+"/ref/"+item.Ref, nil)
+	if rr.Code != http.StatusFound {
+		t.Fatalf("expected 302, got %d body=%s", rr.Code, rr.Body.String())
+	}
+	loc := rr.Header().Get("Location")
+	want := "/anyuser/" + ws.Slug + "/decisions/" + item.Ref
+	if loc != want {
+		t.Errorf("Location header: got %q want %q", loc, want)
+	}
+}
+
+// TestRefResolver_UnknownWorkspace asserts 404 for a workspace that doesn't
+// exist. The body shape is intentionally generic — no fields hint at
+// whether the workspace, the ref, or the access check was the failing
+// gate, so callers can't probe workspace existence by diffing responses.
+func TestRefResolver_UnknownWorkspace(t *testing.T) {
+	srv := testServer(t)
+	rr := doRequest(srv, "GET", "/alice/ghost-workspace/ref/TASK-1", nil)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+// TestRefResolver_UnknownRef asserts 404 for a workspace that exists but
+// has no item matching the requested ref. Same response shape as the
+// unknown-workspace case (verified by the generic-404 assertion).
+func TestRefResolver_UnknownRef(t *testing.T) {
+	srv := testServer(t)
+	rr := doRequest(srv, "POST", "/api/v1/workspaces", map[string]string{"name": "Claude"})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create workspace: %d %s", rr.Code, rr.Body.String())
+	}
+	var ws models.Workspace
+	parseJSON(t, rr, &ws)
+
+	rr = doRequest(srv, "GET", "/anyuser/"+ws.Slug+"/ref/DECIS-9999", nil)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for missing ref, got %d body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+// TestRefResolver_MalformedRef asserts 404 for refs that don't match the
+// `[A-Za-z][A-Za-z0-9]*-\d+` pattern. The validator runs BEFORE workspace
+// resolution, so a malformed ref against a real workspace looks the same
+// as a malformed ref against a phantom workspace — no oracle.
+func TestRefResolver_MalformedRef(t *testing.T) {
+	srv := testServer(t)
+
+	cases := []string{
+		"not-a-ref", // missing trailing digits
+		"TASK-",     // empty number
+		"TASK",      // no separator
+		"-5",        // empty prefix
+		"123-5",     // digit-only prefix (rejected by leading-letter rule)
+		"TASK-5abc", // trailing non-digits in number
+		"TASK-1.5",  // non-integer number
+		"a/b",       // path traversal candidate
+		"%2E%2E%2F", // url-encoded traversal
+	}
+	for _, ref := range cases {
+		path := "/anyuser/some-ws/ref/" + ref
+		rr := doRequest(srv, "GET", path, nil)
+		if rr.Code != http.StatusNotFound {
+			t.Errorf("ref %q: expected 404, got %d", ref, rr.Code)
+		}
+	}
+}
+
+// TestRefResolver_NoAccess documents the gap left by the test fixture
+// surface: the existing helpers (testServer / doRequest) don't compose a
+// "real user against a workspace they can't access" path because the
+// no-auth pre-setup bypass swallows the ACL gate. The handler still
+// enforces access in production (see refResolverItemVisible) — its full
+// matrix is covered by manual smoke + the production auth middleware
+// stack. We assert the documented pre-setup behavior (anonymous access
+// permitted) here, with the acknowledgment captured in the test name.
+func TestRefResolver_NoAccess_DocumentsPreSetupBypass(t *testing.T) {
+	srv := testServer(t)
+	rr := doRequest(srv, "POST", "/api/v1/workspaces", map[string]string{"name": "Claude"})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create workspace: %d %s", rr.Code, rr.Body.String())
+	}
+	var ws models.Workspace
+	parseJSON(t, rr, &ws)
+	rr = doRequest(srv, "POST", "/api/v1/workspaces/"+ws.Slug+"/collections", map[string]interface{}{
+		"name":   "Tasks",
+		"slug":   "tasks",
+		"prefix": "TASK",
+	})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create collection: %d %s", rr.Code, rr.Body.String())
+	}
+	rr = doRequest(srv, "POST", "/api/v1/workspaces/"+ws.Slug+"/collections/tasks/items", map[string]interface{}{
+		"title": "T",
+	})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create item: %d %s", rr.Code, rr.Body.String())
+	}
+	var item models.Item
+	parseJSON(t, rr, &item)
+
+	rr = doRequest(srv, "GET", "/anyuser/"+ws.Slug+"/ref/"+item.Ref, nil)
+	if rr.Code != http.StatusFound {
+		t.Fatalf("pre-setup bypass should allow access, got %d body=%s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Header().Get("Location"), "/tasks/") {
+		t.Errorf("expected Location to include /tasks/, got %q", rr.Header().Get("Location"))
+	}
+}

--- a/internal/server/handlers_ref_resolver_test.go
+++ b/internal/server/handlers_ref_resolver_test.go
@@ -33,53 +33,107 @@ func newJSONRequest(t *testing.T, method, path string, body interface{}) *http.R
 	return req
 }
 
-// TestRefResolver_Success creates a workspace + collection + item, then
-// asserts that GET /{username}/{workspace}/ref/{REF} produces a 302 whose
-// Location header points at the canonical item URL itemUrlId() would
-// produce on the frontend.
-func TestRefResolver_Success(t *testing.T) {
+// refResolverFixture seeds a (user, workspace, bearer-token) triple ready
+// for resolver tests that need a real owner-username (so the redirect
+// target's leading path segment is non-empty — Codex round-2 P1.3
+// otherwise 404s an ownerless workspace). Returns helpers that issue
+// authenticated requests against the seeded workspace.
+type refResolverFixture struct {
+	t      *testing.T
+	srv    *Server
+	owner  *models.User
+	ws     *models.Workspace
+	token  string
+	doAs   func(method, path string, body interface{}) *httptest.ResponseRecorder
+	doAuth func(token, method, path string, body interface{}) *httptest.ResponseRecorder
+}
+
+func newRefResolverFixture(t *testing.T) *refResolverFixture {
+	t.Helper()
 	srv := testServer(t)
 
-	// Workspace + collection + item via the API (the route only depends on
-	// store state, but using the same surface the frontend uses keeps the
-	// test honest about end-to-end shape).
-	rr := doRequest(srv, "POST", "/api/v1/workspaces", map[string]string{"name": "Claude"})
-	if rr.Code != http.StatusCreated {
-		t.Fatalf("create workspace: %d %s", rr.Code, rr.Body.String())
-	}
-	var ws models.Workspace
-	parseJSON(t, rr, &ws)
-
-	rr = doRequest(srv, "POST", "/api/v1/workspaces/"+ws.Slug+"/collections", map[string]interface{}{
-		"name":   "Decisions",
-		"slug":   "decisions",
-		"prefix": "DECIS",
+	owner, err := srv.store.CreateUser(models.UserCreate{
+		Email: "owner@example.com", Name: "Owner", Username: "owneruser",
+		Password: "pw-test-12345",
 	})
-	if rr.Code != http.StatusCreated {
-		t.Fatalf("create collection: %d %s", rr.Code, rr.Body.String())
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	ws, err := srv.store.CreateWorkspace(models.WorkspaceCreate{
+		Name: "Claude", OwnerID: owner.ID,
+	})
+	if err != nil {
+		t.Fatalf("CreateWorkspace: %v", err)
+	}
+	if err := srv.store.AddWorkspaceMember(ws.ID, owner.ID, "owner"); err != nil {
+		t.Fatalf("AddWorkspaceMember: %v", err)
+	}
+	tok, err := srv.store.CreateAPIToken(owner.ID, models.APITokenCreate{
+		Name: "owner-tok", WorkspaceID: ws.ID,
+	}, 0, 0)
+	if err != nil {
+		t.Fatalf("CreateAPIToken: %v", err)
 	}
 
-	rr = doRequest(srv, "POST", "/api/v1/workspaces/"+ws.Slug+"/collections/decisions/items", map[string]interface{}{
-		"title": "Orchestration model",
+	doAuth := func(token, method, path string, body interface{}) *httptest.ResponseRecorder {
+		t.Helper()
+		req := newJSONRequest(t, method, path, body)
+		req.Header.Set("Authorization", "Bearer "+token)
+		req.RemoteAddr = "127.0.0.1:0"
+		rec := httptest.NewRecorder()
+		srv.ServeHTTP(rec, req)
+		return rec
+	}
+	doAs := func(method, path string, body interface{}) *httptest.ResponseRecorder {
+		return doAuth(tok.Token, method, path, body)
+	}
+
+	return &refResolverFixture{
+		t: t, srv: srv, owner: owner, ws: ws, token: tok.Token,
+		doAs: doAs, doAuth: doAuth,
+	}
+}
+
+// seedItem creates a collection (idempotent on slug) + an item with the
+// given title, returning the resolved item record.
+func (f *refResolverFixture) seedItem(collSlug, collPrefix, title string) *models.Item {
+	f.t.Helper()
+	rr := f.doAs("POST", "/api/v1/workspaces/"+f.ws.Slug+"/collections", map[string]interface{}{
+		"name": collSlug, "slug": collSlug, "prefix": collPrefix,
 	})
+	// 201 on fresh create; 409 / 200 acceptable on duplicate-slug retries.
+	if rr.Code != http.StatusCreated && rr.Code != http.StatusConflict {
+		f.t.Fatalf("create collection %q: %d %s", collSlug, rr.Code, rr.Body.String())
+	}
+	rr = f.doAs("POST", "/api/v1/workspaces/"+f.ws.Slug+"/collections/"+collSlug+"/items",
+		map[string]interface{}{"title": title})
 	if rr.Code != http.StatusCreated {
-		t.Fatalf("create item: %d %s", rr.Code, rr.Body.String())
+		f.t.Fatalf("create item: %d %s", rr.Code, rr.Body.String())
 	}
 	var item models.Item
-	parseJSON(t, rr, &item)
+	parseJSON(f.t, rr, &item)
 	if item.Ref == "" {
-		t.Fatalf("expected item Ref, got empty (item=%+v)", item)
+		f.t.Fatalf("seeded item has no ref: %+v", item)
 	}
+	return &item
+}
 
-	// Hit the resolver. The username segment is arbitrary in pre-setup mode
-	// (no auth) — the handler uses the URL-path username verbatim in the
-	// redirect target.
-	rr = doRequest(srv, "GET", "/anyuser/"+ws.Slug+"/ref/"+item.Ref, nil)
+// TestRefResolver_Success creates a workspace + collection + item, then
+// asserts that GET /-/r/{workspace}/{REF} produces a 302 whose Location
+// header points at the canonical item URL itemUrlId() would produce on
+// the frontend. The URL shape is the round-2 sentinel /-/r/... — the
+// previous /{username}/{workspace}/ref/{ref} shape risked collision with
+// pre-existing `ref`-slugged collections (Codex round-2 P1.4).
+func TestRefResolver_Success(t *testing.T) {
+	f := newRefResolverFixture(t)
+	item := f.seedItem("decisions", "DECIS", "Orchestration model")
+
+	rr := f.doAs("GET", "/-/r/"+f.ws.Slug+"/"+item.Ref, nil)
 	if rr.Code != http.StatusFound {
 		t.Fatalf("expected 302, got %d body=%s", rr.Code, rr.Body.String())
 	}
 	loc := rr.Header().Get("Location")
-	want := "/anyuser/" + ws.Slug + "/decisions/" + item.Ref
+	want := "/owneruser/" + f.ws.Slug + "/decisions/" + item.Ref
 	if loc != want {
 		t.Errorf("Location header: got %q want %q", loc, want)
 	}
@@ -91,25 +145,17 @@ func TestRefResolver_Success(t *testing.T) {
 // gate, so callers can't probe workspace existence by diffing responses.
 func TestRefResolver_UnknownWorkspace(t *testing.T) {
 	srv := testServer(t)
-	rr := doRequest(srv, "GET", "/alice/ghost-workspace/ref/TASK-1", nil)
+	rr := doRequest(srv, "GET", "/-/r/ghost-workspace/TASK-1", nil)
 	if rr.Code != http.StatusNotFound {
 		t.Fatalf("expected 404, got %d body=%s", rr.Code, rr.Body.String())
 	}
 }
 
 // TestRefResolver_UnknownRef asserts 404 for a workspace that exists but
-// has no item matching the requested ref. Same response shape as the
-// unknown-workspace case (verified by the generic-404 assertion).
+// has no item matching the requested ref.
 func TestRefResolver_UnknownRef(t *testing.T) {
-	srv := testServer(t)
-	rr := doRequest(srv, "POST", "/api/v1/workspaces", map[string]string{"name": "Claude"})
-	if rr.Code != http.StatusCreated {
-		t.Fatalf("create workspace: %d %s", rr.Code, rr.Body.String())
-	}
-	var ws models.Workspace
-	parseJSON(t, rr, &ws)
-
-	rr = doRequest(srv, "GET", "/anyuser/"+ws.Slug+"/ref/DECIS-9999", nil)
+	f := newRefResolverFixture(t)
+	rr := f.doAs("GET", "/-/r/"+f.ws.Slug+"/DECIS-9999", nil)
 	if rr.Code != http.StatusNotFound {
 		t.Fatalf("expected 404 for missing ref, got %d body=%s", rr.Code, rr.Body.String())
 	}
@@ -134,7 +180,7 @@ func TestRefResolver_MalformedRef(t *testing.T) {
 		"%2E%2E%2F", // url-encoded traversal
 	}
 	for _, ref := range cases {
-		path := "/anyuser/some-ws/ref/" + ref
+		path := "/-/r/some-ws/" + ref
 		rr := doRequest(srv, "GET", path, nil)
 		if rr.Code != http.StatusNotFound {
 			t.Errorf("ref %q: expected 404, got %d", ref, rr.Code)
@@ -142,15 +188,11 @@ func TestRefResolver_MalformedRef(t *testing.T) {
 	}
 }
 
-// TestRefResolver_NoAccess documents the gap left by the test fixture
-// surface: the existing helpers (testServer / doRequest) don't compose a
-// "real user against a workspace they can't access" path because the
-// no-auth pre-setup bypass swallows the ACL gate. The handler still
-// enforces access in production (see refResolverItemVisible) — its full
-// matrix is covered by manual smoke + the production auth middleware
-// stack. We assert the documented pre-setup behavior (anonymous access
-// permitted) here, with the acknowledgment captured in the test name.
-func TestRefResolver_NoAccess_DocumentsPreSetupBypass(t *testing.T) {
+// TestRefResolver_PreSetupBypass: pre-setup mode (UserCount == 0) opens
+// every workspace, including resolver-route reads. We exercise the
+// fresh-install path here — distinct from the seeded-fixture path used
+// by other tests.
+func TestRefResolver_PreSetupBypass(t *testing.T) {
 	srv := testServer(t)
 	rr := doRequest(srv, "POST", "/api/v1/workspaces", map[string]string{"name": "Claude"})
 	if rr.Code != http.StatusCreated {
@@ -159,122 +201,12 @@ func TestRefResolver_NoAccess_DocumentsPreSetupBypass(t *testing.T) {
 	var ws models.Workspace
 	parseJSON(t, rr, &ws)
 	rr = doRequest(srv, "POST", "/api/v1/workspaces/"+ws.Slug+"/collections", map[string]interface{}{
-		"name":   "Tasks",
-		"slug":   "tasks",
-		"prefix": "TASK",
-	})
-	if rr.Code != http.StatusCreated {
-		t.Fatalf("create collection: %d %s", rr.Code, rr.Body.String())
-	}
-	rr = doRequest(srv, "POST", "/api/v1/workspaces/"+ws.Slug+"/collections/tasks/items", map[string]interface{}{
-		"title": "T",
-	})
-	if rr.Code != http.StatusCreated {
-		t.Fatalf("create item: %d %s", rr.Code, rr.Body.String())
-	}
-	var item models.Item
-	parseJSON(t, rr, &item)
-
-	rr = doRequest(srv, "GET", "/anyuser/"+ws.Slug+"/ref/"+item.Ref, nil)
-	if rr.Code != http.StatusFound {
-		t.Fatalf("pre-setup bypass should allow access, got %d body=%s", rr.Code, rr.Body.String())
-	}
-	if !strings.Contains(rr.Header().Get("Location"), "/tasks/") {
-		t.Errorf("expected Location to include /tasks/, got %q", rr.Header().Get("Location"))
-	}
-}
-
-// TestRefResolver_RejectsRefAsCollectionSlug pins P1.1: creating a
-// collection whose slug would be "ref" must not produce a collection
-// addressable at /{user}/{ws}/ref/... because that path is the resolver
-// route. The store auto-suffixes reserved slugs with "-collection", so
-// the created collection lands at slug "ref-collection" — verify that
-// outcome (not a hard 4xx rejection) since the suffixing policy mirrors
-// the other reserved slugs (settings, activity, roles, …).
-func TestRefResolver_RejectsRefAsCollectionSlug(t *testing.T) {
-	srv := testServer(t)
-	rr := doRequest(srv, "POST", "/api/v1/workspaces", map[string]string{"name": "Claude"})
-	if rr.Code != http.StatusCreated {
-		t.Fatalf("create workspace: %d %s", rr.Code, rr.Body.String())
-	}
-	var ws models.Workspace
-	parseJSON(t, rr, &ws)
-
-	rr = doRequest(srv, "POST", "/api/v1/workspaces/"+ws.Slug+"/collections", map[string]interface{}{
-		"name":   "Ref",
-		"slug":   "ref",
-		"prefix": "REF",
-	})
-	if rr.Code != http.StatusCreated {
-		t.Fatalf("create collection: %d %s", rr.Code, rr.Body.String())
-	}
-	var coll models.Collection
-	parseJSON(t, rr, &coll)
-	if coll.Slug == "ref" {
-		t.Fatalf("collection slug %q would shadow the /ref/ resolver route — reservation regression", coll.Slug)
-	}
-	if coll.Slug != "ref-collection" {
-		t.Errorf("expected reserved-slug suffix 'ref-collection', got %q", coll.Slug)
-	}
-}
-
-// TestRefResolver_TwoSegmentRouteResolves pins P2.2: renderers without
-// a username in scope (TimelineCommentCard, CommentThread) emit
-// /{workspace}/ref/{REF} hrefs. The two-segment route must resolve and
-// redirect to the canonical three-segment item URL, using the workspace
-// owner's username as the fallback path prefix.
-func TestRefResolver_TwoSegmentRouteResolves(t *testing.T) {
-	srv := testServer(t)
-
-	// Seed a user up front and create the workspace owned by that user
-	// (CreateWorkspace's OwnerID field handles this), so the two-seg
-	// redirect path has a concrete owner-username to fall back on.
-	user, err := srv.store.CreateUser(models.UserCreate{
-		Email:    "owner@example.com",
-		Name:     "Owner",
-		Username: "owneruser",
-		Password: "pw-test-12345",
-	})
-	if err != nil {
-		t.Fatalf("CreateUser: %v", err)
-	}
-
-	ws, err := srv.store.CreateWorkspace(models.WorkspaceCreate{
-		Name:    "Claude",
-		OwnerID: user.ID,
-	})
-	if err != nil {
-		t.Fatalf("CreateWorkspace: %v", err)
-	}
-	if err := srv.store.AddWorkspaceMember(ws.ID, user.ID, "owner"); err != nil {
-		t.Fatalf("AddWorkspaceMember: %v", err)
-	}
-	tok, err := srv.store.CreateAPIToken(user.ID, models.APITokenCreate{
-		Name: "owner-tok", WorkspaceID: ws.ID,
-	}, 0, 0)
-	if err != nil {
-		t.Fatalf("CreateAPIToken: %v", err)
-	}
-
-	// Use Bearer auth for subsequent writes — UserCount() > 0 now, so the
-	// pre-setup bypass is closed.
-	doAs := func(method, path string, body interface{}) *httptest.ResponseRecorder {
-		t.Helper()
-		req := newJSONRequest(t, method, path, body)
-		req.Header.Set("Authorization", "Bearer "+tok.Token)
-		req.RemoteAddr = "127.0.0.1:0"
-		rec := httptest.NewRecorder()
-		srv.ServeHTTP(rec, req)
-		return rec
-	}
-
-	rr := doAs("POST", "/api/v1/workspaces/"+ws.Slug+"/collections", map[string]interface{}{
 		"name": "Tasks", "slug": "tasks", "prefix": "TASK",
 	})
 	if rr.Code != http.StatusCreated {
 		t.Fatalf("create collection: %d %s", rr.Code, rr.Body.String())
 	}
-	rr = doAs("POST", "/api/v1/workspaces/"+ws.Slug+"/collections/tasks/items",
+	rr = doRequest(srv, "POST", "/api/v1/workspaces/"+ws.Slug+"/collections/tasks/items",
 		map[string]interface{}{"title": "T"})
 	if rr.Code != http.StatusCreated {
 		t.Fatalf("create item: %d %s", rr.Code, rr.Body.String())
@@ -282,84 +214,130 @@ func TestRefResolver_TwoSegmentRouteResolves(t *testing.T) {
 	var item models.Item
 	parseJSON(t, rr, &item)
 
-	// Two-segment route — no username in URL. Handler should look up the
-	// workspace owner and synthesize the redirect target with the owner's
-	// username as the leading path segment.
-	rr = doAs("GET", "/"+ws.Slug+"/ref/"+item.Ref, nil)
-	if rr.Code != http.StatusFound {
-		t.Fatalf("two-seg route: expected 302, got %d body=%s", rr.Code, rr.Body.String())
-	}
-	got := rr.Header().Get("Location")
-	want := "/owneruser/" + ws.Slug + "/tasks/" + item.Ref
-	if got != want {
-		t.Errorf("two-seg Location: got %q want %q", got, want)
-	}
-
-	// Three-segment route still works alongside the two-seg shape.
-	rr = doAs("GET", "/explicituser/"+ws.Slug+"/ref/"+item.Ref, nil)
-	if rr.Code != http.StatusFound {
-		t.Fatalf("three-seg route: expected 302, got %d", rr.Code)
-	}
-	got = rr.Header().Get("Location")
-	want = "/explicituser/" + ws.Slug + "/tasks/" + item.Ref
-	if got != want {
-		t.Errorf("three-seg Location: got %q want %q", got, want)
+	// Pre-setup workspace has owner_id="" — Codex round-2 P1.3 says we
+	// must 404 in that case rather than emit a `//slug/...` redirect.
+	// Verify the no-broken-redirect contract holds.
+	rr = doRequest(srv, "GET", "/-/r/"+ws.Slug+"/"+item.Ref, nil)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("ownerless pre-setup workspace: expected 404, got %d location=%q",
+			rr.Code, rr.Header().Get("Location"))
 	}
 }
 
-// TestRefResolver_RestrictedMemberWithCollectionGrant pins P1.2: a
-// restricted member (collection_access="specific" with only collection A
-// in their member_collection_access) PLUS a direct collection grant on
-// collection B must be able to resolve refs that live in collection B.
-// Pre-refactor, refResolverItemVisible's drift-from-requireItemVisible
-// would 404 this case because it didn't consult the guest-grant path
-// when the user was a member. checkItemVisible (the shared helper)
-// closes the gap.
-func TestRefResolver_RestrictedMemberWithCollectionGrant(t *testing.T) {
+// TestRefResolver_RejectsRefAsCollectionSlug pins round-1 P1.1: the
+// reservation prevents `ref` from becoming a collection slug. The round-2
+// URL shape /-/r/... no longer collides with a `ref` collection, but
+// the reservation stays as defense in depth (and to spare ourselves the
+// round-3 risk of someone restoring the older shape and rediscovering
+// the collision).
+func TestRefResolver_RejectsRefAsCollectionSlug(t *testing.T) {
+	f := newRefResolverFixture(t)
+	rr := f.doAs("POST", "/api/v1/workspaces/"+f.ws.Slug+"/collections", map[string]interface{}{
+		"name": "Ref", "slug": "ref", "prefix": "REF",
+	})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create collection: %d %s", rr.Code, rr.Body.String())
+	}
+	var coll models.Collection
+	parseJSON(t, rr, &coll)
+	if coll.Slug == "ref" {
+		t.Fatalf("collection slug %q would shadow the resolver route — reservation regression", coll.Slug)
+	}
+	if coll.Slug != "ref-collection" {
+		t.Errorf("expected reserved-slug suffix 'ref-collection', got %q", coll.Slug)
+	}
+}
+
+// TestRefResolver_URLShapeNonOverlap pins round-2 P1.4 (Option B): the
+// resolver URL shape `/-/r/...` cannot collide with any user-namespace
+// page URL under `/{username}/{workspace}/...` because username + slug
+// grammar both require a leading letter. We verify by routing a request
+// against the shape `/{username}/{workspace}/ref/{slug}` — the URL a
+// pre-existing `ref`-slugged collection's items would have — and
+// confirming the resolver handler is NOT invoked. (Without SetWebUI
+// installed in tests, that URL hits chi's default 404; the assertion
+// here is "the resolver did not intercept it", proved by absence of a
+// 302 Location header.)
+func TestRefResolver_URLShapeNonOverlap(t *testing.T) {
+	f := newRefResolverFixture(t)
+
+	// Hit the page-URL shape directly. The resolver lives at /-/r/...
+	// only; a 4-segment path under /{user}/{ws}/ref/... must never
+	// match the resolver route. We assert "not a 302" — chi's catch-all
+	// 404 is the only acceptable outcome here.
+	rr := f.doAs("GET", "/owneruser/"+f.ws.Slug+"/ref/some-item-slug", nil)
+	if rr.Code == http.StatusFound {
+		t.Errorf("URL /{u}/{ws}/ref/{slug} was intercepted by resolver (got 302 with Location=%q); shape should be inert",
+			rr.Header().Get("Location"))
+	}
+}
+
+// TestCheckItemVisible_TokenizedRoleAllowsNilUser pins round-2 P1.1:
+// the legacy workspace-scoped API token path admits requests with
+// currentUser == nil and a synthesized role ("editor"). Pre-round-2,
+// checkItemVisible's nil-user check fired first and false-404'd these
+// callers; the round-2 reorder lets tokenized roles bypass the gate.
+func TestCheckItemVisible_TokenizedRoleAllowsNilUser(t *testing.T) {
 	srv := testServer(t)
 
-	// Seed owner + workspace + member. CreateWorkspace handles OwnerID
-	// directly, so the workspace is anchored to a real user before any
-	// ACL-sensitive request runs (and pre-setup bypass is closed by
-	// having UserCount > 0).
+	// A real workspace + collection + item — needed because checkItemVisible
+	// dereferences item.CollectionID even when the role short-circuit fires
+	// first, and we want the assertion to reflect the "role allows nil
+	// user" path, not an unrelated DB miss.
 	owner, err := srv.store.CreateUser(models.UserCreate{
-		Email: "owner@example.com", Name: "Owner", Username: "owner",
-		Password: "pw-test-12345",
+		Email: "o@example.com", Name: "O", Username: "o", Password: "pw-test-12345",
 	})
 	if err != nil {
-		t.Fatalf("CreateUser owner: %v", err)
+		t.Fatalf("CreateUser: %v", err)
 	}
-
 	ws, err := srv.store.CreateWorkspace(models.WorkspaceCreate{
-		Name:    "Claude",
-		OwnerID: owner.ID,
+		Name: "WS", OwnerID: owner.ID,
 	})
 	if err != nil {
 		t.Fatalf("CreateWorkspace: %v", err)
 	}
-	if err := srv.store.AddWorkspaceMember(ws.ID, owner.ID, "owner"); err != nil {
-		t.Fatalf("AddWorkspaceMember owner: %v", err)
-	}
-	ownerTok, err := srv.store.CreateAPIToken(owner.ID, models.APITokenCreate{
-		Name: "owner-tok", WorkspaceID: ws.ID,
-	}, 0, 0)
-	if err != nil {
-		t.Fatalf("CreateAPIToken owner: %v", err)
+	item := &models.Item{
+		ID: "stub", WorkspaceID: ws.ID, CollectionID: "stub-coll",
 	}
 
-	asOwner := func(method, path string, body interface{}) *httptest.ResponseRecorder {
-		t.Helper()
-		req := newJSONRequest(t, method, path, body)
-		req.Header.Set("Authorization", "Bearer "+ownerTok.Token)
-		req.RemoteAddr = "127.0.0.1:0"
-		rec := httptest.NewRecorder()
-		srv.ServeHTTP(rec, req)
-		return rec
+	for _, role := range []string{"owner", "editor"} {
+		ok, err := srv.checkItemVisible(ws.ID, item, nil, role)
+		if err != nil {
+			t.Errorf("role=%q: unexpected error: %v", role, err)
+		}
+		if !ok {
+			t.Errorf("role=%q + nil user: expected visible=true (legacy token bypass)", role)
+		}
 	}
 
-	// Two collections — A (member can see directly) and B (member sees
-	// only via the grant we'll attach below).
-	rr := asOwner("POST", "/api/v1/workspaces/"+ws.Slug+"/collections", map[string]interface{}{
+	// Sanity: nil user with no role still rejects (this is the path that
+	// distinguishes legitimate legacy tokens from anonymous probes).
+	if ok, _ := srv.checkItemVisible(ws.ID, item, nil, ""); ok {
+		t.Error("nil user + empty role: expected visible=false")
+	}
+	if ok, _ := srv.checkItemVisible(ws.ID, item, nil, "guest"); ok {
+		t.Error("nil user + guest role: expected visible=false (guest needs grants which require a user)")
+	}
+}
+
+// TestRefResolver_RestrictedMemberWithSystemCollection pins round-2 P1.2:
+// a restricted member with conventions/playbooks (system collections)
+// access plus an item grant in an UNRELATED collection must be able to
+// resolve refs that live in the system collection. Pre-round-2,
+// checkItemVisible's item-grants branch only consulted direct
+// collection_grants + member_collection_access — not system collections —
+// so a restricted member could LIST conventions via the existing API
+// (VisibleCollectionIDs includes system collections) but 404'd on
+// detail-fetch / ref-resolve.
+func TestRefResolver_RestrictedMemberWithSystemCollection(t *testing.T) {
+	f := newRefResolverFixture(t)
+
+	// Seed a regular collection A (the member's "specific" access list
+	// entry) and grab the workspace's default conventions collection
+	// (system collection). Default startup-template collections include
+	// conventions; we look it up via the list endpoint to avoid relying
+	// on internal seed IDs.
+	rr := f.doAs("POST", "/api/v1/workspaces/"+f.ws.Slug+"/collections", map[string]interface{}{
 		"name": "Alpha", "slug": "alpha", "prefix": "ALPHA",
 	})
 	if rr.Code != http.StatusCreated {
@@ -368,7 +346,93 @@ func TestRefResolver_RestrictedMemberWithCollectionGrant(t *testing.T) {
 	var collA models.Collection
 	parseJSON(t, rr, &collA)
 
-	rr = asOwner("POST", "/api/v1/workspaces/"+ws.Slug+"/collections", map[string]interface{}{
+	// Direct store insert for the system collection. CreateWorkspace
+	// (used by the fixture) doesn't apply a template, so default
+	// system-collection seeding doesn't run; seeding manually via the
+	// store keeps the test self-contained and independent of which
+	// template defaults are wired up at the time the test runs.
+	sysColl, err := f.srv.store.CreateCollection(f.ws.ID, models.CollectionCreate{
+		Name: "Conventions", Slug: "conventions", Prefix: "CONV", IsSystem: true,
+	})
+	if err != nil {
+		t.Fatalf("CreateCollection (system): %v", err)
+	}
+
+	// Item directly in the system collection. We use the store path
+	// because some system collections reject API-level item creation.
+	sysItem, err := f.srv.store.CreateItem(f.ws.ID, sysColl.ID, models.ItemCreate{
+		Title: "System target",
+	})
+	if err != nil {
+		t.Fatalf("CreateItem in system collection: %v", err)
+	}
+
+	// And a regular item in A — the unrelated grant target.
+	itemA, err := f.srv.store.CreateItem(f.ws.ID, collA.ID, models.ItemCreate{
+		Title: "Alpha item",
+	})
+	if err != nil {
+		t.Fatalf("CreateItem in alpha: %v", err)
+	}
+
+	// Restricted member: specific access on A only, plus an item grant
+	// on itemA. That grant triggers the item-grants branch of
+	// checkItemVisible — the branch that pre-round-2 missed system
+	// collections.
+	member, err := f.srv.store.CreateUser(models.UserCreate{
+		Email: "m@example.com", Name: "M", Username: "m", Password: "pw-test-12345",
+	})
+	if err != nil {
+		t.Fatalf("CreateUser member: %v", err)
+	}
+	if err := f.srv.store.AddWorkspaceMember(f.ws.ID, member.ID, "viewer"); err != nil {
+		t.Fatalf("AddWorkspaceMember: %v", err)
+	}
+	if err := f.srv.store.SetMemberCollectionAccess(f.ws.ID, member.ID, "specific", []string{collA.ID}); err != nil {
+		t.Fatalf("SetMemberCollectionAccess: %v", err)
+	}
+	if _, err := f.srv.store.CreateItemGrant(f.ws.ID, itemA.ID, member.ID, "view", f.owner.ID); err != nil {
+		t.Fatalf("CreateItemGrant: %v", err)
+	}
+
+	tok, err := f.srv.store.CreateAPIToken(member.ID, models.APITokenCreate{
+		Name: "member-tok", WorkspaceID: f.ws.ID,
+	}, 0, 0)
+	if err != nil {
+		t.Fatalf("CreateAPIToken: %v", err)
+	}
+
+	// Resolver should redirect — system collections must remain visible
+	// to restricted members even when the item-grants branch fires.
+	rr = f.doAuth(tok.Token, "GET", "/-/r/"+f.ws.Slug+"/"+sysItem.Ref, nil)
+	if rr.Code != http.StatusFound {
+		t.Fatalf("restricted member on system collection: expected 302, got %d body=%s",
+			rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Header().Get("Location"), "/"+sysColl.Slug+"/") {
+		t.Errorf("expected redirect under /%s/, got %q", sysColl.Slug, rr.Header().Get("Location"))
+	}
+}
+
+// TestRefResolver_RestrictedMemberWithCollectionGrant pins round-1 P1.2:
+// a restricted member (collection_access="specific" with only collection A
+// in their member_collection_access) PLUS a direct collection grant on
+// collection B must be able to resolve refs that live in collection B.
+func TestRefResolver_RestrictedMemberWithCollectionGrant(t *testing.T) {
+	f := newRefResolverFixture(t)
+
+	// Two collections — A (member can see directly) and B (member sees
+	// only via the collection grant we'll attach below).
+	rr := f.doAs("POST", "/api/v1/workspaces/"+f.ws.Slug+"/collections", map[string]interface{}{
+		"name": "Alpha", "slug": "alpha", "prefix": "ALPHA",
+	})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create collection alpha: %d %s", rr.Code, rr.Body.String())
+	}
+	var collA models.Collection
+	parseJSON(t, rr, &collA)
+
+	rr = f.doAs("POST", "/api/v1/workspaces/"+f.ws.Slug+"/collections", map[string]interface{}{
 		"name": "Beta", "slug": "beta", "prefix": "BETA",
 	})
 	if rr.Code != http.StatusCreated {
@@ -377,9 +441,7 @@ func TestRefResolver_RestrictedMemberWithCollectionGrant(t *testing.T) {
 	var collB models.Collection
 	parseJSON(t, rr, &collB)
 
-	// Seed one item in B — this is the ref we're going to try to resolve
-	// as the restricted member.
-	rr = asOwner("POST", "/api/v1/workspaces/"+ws.Slug+"/collections/beta/items",
+	rr = f.doAs("POST", "/api/v1/workspaces/"+f.ws.Slug+"/collections/beta/items",
 		map[string]interface{}{"title": "Cross-collection target"})
 	if rr.Code != http.StatusCreated {
 		t.Fatalf("create item: %d %s", rr.Code, rr.Body.String())
@@ -387,53 +449,30 @@ func TestRefResolver_RestrictedMemberWithCollectionGrant(t *testing.T) {
 	var item models.Item
 	parseJSON(t, rr, &item)
 
-	// Create the restricted-access member.
-	member, err := srv.store.CreateUser(models.UserCreate{
-		Email: "member@example.com", Name: "Member", Username: "member",
-		Password: "pw-test-12345",
+	member, err := f.srv.store.CreateUser(models.UserCreate{
+		Email: "m@example.com", Name: "M", Username: "m", Password: "pw-test-12345",
 	})
 	if err != nil {
 		t.Fatalf("CreateUser member: %v", err)
 	}
-	if err := srv.store.AddWorkspaceMember(ws.ID, member.ID, "viewer"); err != nil {
+	if err := f.srv.store.AddWorkspaceMember(f.ws.ID, member.ID, "viewer"); err != nil {
 		t.Fatalf("AddWorkspaceMember: %v", err)
 	}
-	// "specific" collection access with ONLY collection A in the access
-	// set. Without the grant on B (added below), the member can see A's
-	// items and not B's.
-	if err := srv.store.SetMemberCollectionAccess(ws.ID, member.ID, "specific", []string{collA.ID}); err != nil {
+	if err := f.srv.store.SetMemberCollectionAccess(f.ws.ID, member.ID, "specific", []string{collA.ID}); err != nil {
 		t.Fatalf("SetMemberCollectionAccess: %v", err)
 	}
-	// Direct collection grant on B — this is the codex-flagged path.
-	// requireItemVisible considers this via guestResourceFilter's
-	// fullCollIDs return; checkItemVisible must do the same.
-	if _, err := srv.store.CreateCollectionGrant(ws.ID, collB.ID, member.ID, "view", owner.ID); err != nil {
+	if _, err := f.srv.store.CreateCollectionGrant(f.ws.ID, collB.ID, member.ID, "view", f.owner.ID); err != nil {
 		t.Fatalf("CreateCollectionGrant: %v", err)
 	}
 
-	// Mint a Bearer token for the restricted member.
-	tok, err := srv.store.CreateAPIToken(member.ID, models.APITokenCreate{
-		Name: "member-tok", WorkspaceID: ws.ID,
+	tok, err := f.srv.store.CreateAPIToken(member.ID, models.APITokenCreate{
+		Name: "member-tok", WorkspaceID: f.ws.ID,
 	}, 0, 0)
 	if err != nil {
 		t.Fatalf("CreateAPIToken: %v", err)
 	}
 
-	doAsMember := func(path string) *httptest.ResponseRecorder {
-		t.Helper()
-		req := httptest.NewRequest("GET", path, nil)
-		req.Header.Set("Authorization", "Bearer "+tok.Token)
-		req.RemoteAddr = "127.0.0.1:0"
-		rec := httptest.NewRecorder()
-		srv.ServeHTTP(rec, req)
-		return rec
-	}
-
-	// The restricted-member-with-grant case: GET on the B-collection
-	// item resolves to 302, not 404. Pre-refactor this returned 404
-	// because the resolver's bespoke ACL didn't merge collection grants
-	// into the member's visible set.
-	rr = doAsMember("/owner/" + ws.Slug + "/ref/" + item.Ref)
+	rr = f.doAuth(tok.Token, "GET", "/-/r/"+f.ws.Slug+"/"+item.Ref, nil)
 	if rr.Code != http.StatusFound {
 		t.Fatalf("restricted-member-with-grant: expected 302, got %d body=%s",
 			rr.Code, rr.Body.String())

--- a/internal/server/handlers_ref_resolver_test.go
+++ b/internal/server/handlers_ref_resolver_test.go
@@ -320,6 +320,101 @@ func TestCheckItemVisible_TokenizedRoleAllowsNilUser(t *testing.T) {
 	}
 }
 
+// TestCheckItemVisible_AuthenticatedEditorWithRestrictedAccess pins
+// round-3: the round-2 bypass at the top of checkItemVisible originally
+// fired for ANY role in {owner, editor}, which silently disabled the
+// per-collection visibility filter for real authenticated editor members
+// with collection_access="specific". This test seeds exactly that
+// scenario — editor + restricted access to collection A only — and
+// asserts visibility on an item in collection B returns false.
+//
+// Pre-round-3 (round-2 buggy state): returned true. Post-round-3: false.
+func TestCheckItemVisible_AuthenticatedEditorWithRestrictedAccess(t *testing.T) {
+	srv := testServer(t)
+
+	// Seed a workspace under a separate owner so the editor under test
+	// isn't accidentally given owner access.
+	owner, err := srv.store.CreateUser(models.UserCreate{
+		Email: "owner@example.com", Name: "Owner", Username: "owner",
+		Password: "pw-test-12345",
+	})
+	if err != nil {
+		t.Fatalf("CreateUser owner: %v", err)
+	}
+	ws, err := srv.store.CreateWorkspace(models.WorkspaceCreate{
+		Name: "WS", OwnerID: owner.ID,
+	})
+	if err != nil {
+		t.Fatalf("CreateWorkspace: %v", err)
+	}
+
+	// Two collections — A is the editor's allowed set, B is forbidden.
+	collA, err := srv.store.CreateCollection(ws.ID, models.CollectionCreate{
+		Name: "Alpha", Slug: "alpha", Prefix: "ALPHA",
+	})
+	if err != nil {
+		t.Fatalf("CreateCollection alpha: %v", err)
+	}
+	collB, err := srv.store.CreateCollection(ws.ID, models.CollectionCreate{
+		Name: "Beta", Slug: "beta", Prefix: "BETA",
+	})
+	if err != nil {
+		t.Fatalf("CreateCollection beta: %v", err)
+	}
+	itemB, err := srv.store.CreateItem(ws.ID, collB.ID, models.ItemCreate{
+		Title: "Forbidden",
+	})
+	if err != nil {
+		t.Fatalf("CreateItem in beta: %v", err)
+	}
+
+	// Real authenticated user with workspace role "editor" and
+	// collection_access="specific" listing only collection A.
+	editor, err := srv.store.CreateUser(models.UserCreate{
+		Email: "editor@example.com", Name: "Editor", Username: "editor",
+		Password: "pw-test-12345",
+	})
+	if err != nil {
+		t.Fatalf("CreateUser editor: %v", err)
+	}
+	if err := srv.store.AddWorkspaceMember(ws.ID, editor.ID, "editor"); err != nil {
+		t.Fatalf("AddWorkspaceMember editor: %v", err)
+	}
+	if err := srv.store.SetMemberCollectionAccess(ws.ID, editor.ID, "specific", []string{collA.ID}); err != nil {
+		t.Fatalf("SetMemberCollectionAccess: %v", err)
+	}
+
+	// The regression assertion: editor + "editor" role + item in
+	// collection B (NOT in their member_collection_access list) must
+	// return false. The round-2 bug returned true here, disabling the
+	// per-collection gate for every read AND write path through
+	// requireItemVisible / the resolver.
+	visible, err := srv.checkItemVisible(ws.ID, itemB, editor, "editor")
+	if err != nil {
+		t.Fatalf("checkItemVisible: unexpected error: %v", err)
+	}
+	if visible {
+		t.Fatal("authenticated editor with collection_access='specific' (only collA) saw item in collB: round-2 bypass regression")
+	}
+
+	// Sanity: same editor on an item in collection A (their allowed
+	// collection) DOES see it. Confirms the test fixture is wired right
+	// and we're not just observing a generic false everywhere.
+	itemA, err := srv.store.CreateItem(ws.ID, collA.ID, models.ItemCreate{
+		Title: "Allowed",
+	})
+	if err != nil {
+		t.Fatalf("CreateItem in alpha: %v", err)
+	}
+	visible, err = srv.checkItemVisible(ws.ID, itemA, editor, "editor")
+	if err != nil {
+		t.Fatalf("checkItemVisible (allowed): %v", err)
+	}
+	if !visible {
+		t.Error("authenticated editor on an allowed-collection item: expected visible=true")
+	}
+}
+
 // TestRefResolver_RestrictedMemberWithSystemCollection pins round-2 P1.2:
 // a restricted member with conventions/playbooks (system collections)
 // access plus an item grant in an UNRELATED collection must be able to

--- a/internal/server/handlers_ref_resolver_test.go
+++ b/internal/server/handlers_ref_resolver_test.go
@@ -1,12 +1,37 @@
 package server
 
 import (
+	"bytes"
+	"encoding/json"
+	"io"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
 	"github.com/PerpetualSoftware/pad/internal/models"
 )
+
+// newJSONRequest is a local helper for tests that need to thread custom
+// headers (Bearer auth, RemoteAddr) through to a request — the package's
+// doRequest helpers wrap the request creation, so they can't compose
+// with per-call Authorization headers.
+func newJSONRequest(t *testing.T, method, path string, body interface{}) *http.Request {
+	t.Helper()
+	var bodyReader io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			t.Fatalf("marshal body: %v", err)
+		}
+		bodyReader = bytes.NewReader(data)
+	}
+	req := httptest.NewRequest(method, path, bodyReader)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	return req
+}
 
 // TestRefResolver_Success creates a workspace + collection + item, then
 // asserts that GET /{username}/{workspace}/ref/{REF} produces a 302 whose
@@ -156,5 +181,264 @@ func TestRefResolver_NoAccess_DocumentsPreSetupBypass(t *testing.T) {
 	}
 	if !strings.Contains(rr.Header().Get("Location"), "/tasks/") {
 		t.Errorf("expected Location to include /tasks/, got %q", rr.Header().Get("Location"))
+	}
+}
+
+// TestRefResolver_RejectsRefAsCollectionSlug pins P1.1: creating a
+// collection whose slug would be "ref" must not produce a collection
+// addressable at /{user}/{ws}/ref/... because that path is the resolver
+// route. The store auto-suffixes reserved slugs with "-collection", so
+// the created collection lands at slug "ref-collection" — verify that
+// outcome (not a hard 4xx rejection) since the suffixing policy mirrors
+// the other reserved slugs (settings, activity, roles, …).
+func TestRefResolver_RejectsRefAsCollectionSlug(t *testing.T) {
+	srv := testServer(t)
+	rr := doRequest(srv, "POST", "/api/v1/workspaces", map[string]string{"name": "Claude"})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create workspace: %d %s", rr.Code, rr.Body.String())
+	}
+	var ws models.Workspace
+	parseJSON(t, rr, &ws)
+
+	rr = doRequest(srv, "POST", "/api/v1/workspaces/"+ws.Slug+"/collections", map[string]interface{}{
+		"name":   "Ref",
+		"slug":   "ref",
+		"prefix": "REF",
+	})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create collection: %d %s", rr.Code, rr.Body.String())
+	}
+	var coll models.Collection
+	parseJSON(t, rr, &coll)
+	if coll.Slug == "ref" {
+		t.Fatalf("collection slug %q would shadow the /ref/ resolver route — reservation regression", coll.Slug)
+	}
+	if coll.Slug != "ref-collection" {
+		t.Errorf("expected reserved-slug suffix 'ref-collection', got %q", coll.Slug)
+	}
+}
+
+// TestRefResolver_TwoSegmentRouteResolves pins P2.2: renderers without
+// a username in scope (TimelineCommentCard, CommentThread) emit
+// /{workspace}/ref/{REF} hrefs. The two-segment route must resolve and
+// redirect to the canonical three-segment item URL, using the workspace
+// owner's username as the fallback path prefix.
+func TestRefResolver_TwoSegmentRouteResolves(t *testing.T) {
+	srv := testServer(t)
+
+	// Seed a user up front and create the workspace owned by that user
+	// (CreateWorkspace's OwnerID field handles this), so the two-seg
+	// redirect path has a concrete owner-username to fall back on.
+	user, err := srv.store.CreateUser(models.UserCreate{
+		Email:    "owner@example.com",
+		Name:     "Owner",
+		Username: "owneruser",
+		Password: "pw-test-12345",
+	})
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	ws, err := srv.store.CreateWorkspace(models.WorkspaceCreate{
+		Name:    "Claude",
+		OwnerID: user.ID,
+	})
+	if err != nil {
+		t.Fatalf("CreateWorkspace: %v", err)
+	}
+	if err := srv.store.AddWorkspaceMember(ws.ID, user.ID, "owner"); err != nil {
+		t.Fatalf("AddWorkspaceMember: %v", err)
+	}
+	tok, err := srv.store.CreateAPIToken(user.ID, models.APITokenCreate{
+		Name: "owner-tok", WorkspaceID: ws.ID,
+	}, 0, 0)
+	if err != nil {
+		t.Fatalf("CreateAPIToken: %v", err)
+	}
+
+	// Use Bearer auth for subsequent writes — UserCount() > 0 now, so the
+	// pre-setup bypass is closed.
+	doAs := func(method, path string, body interface{}) *httptest.ResponseRecorder {
+		t.Helper()
+		req := newJSONRequest(t, method, path, body)
+		req.Header.Set("Authorization", "Bearer "+tok.Token)
+		req.RemoteAddr = "127.0.0.1:0"
+		rec := httptest.NewRecorder()
+		srv.ServeHTTP(rec, req)
+		return rec
+	}
+
+	rr := doAs("POST", "/api/v1/workspaces/"+ws.Slug+"/collections", map[string]interface{}{
+		"name": "Tasks", "slug": "tasks", "prefix": "TASK",
+	})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create collection: %d %s", rr.Code, rr.Body.String())
+	}
+	rr = doAs("POST", "/api/v1/workspaces/"+ws.Slug+"/collections/tasks/items",
+		map[string]interface{}{"title": "T"})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create item: %d %s", rr.Code, rr.Body.String())
+	}
+	var item models.Item
+	parseJSON(t, rr, &item)
+
+	// Two-segment route — no username in URL. Handler should look up the
+	// workspace owner and synthesize the redirect target with the owner's
+	// username as the leading path segment.
+	rr = doAs("GET", "/"+ws.Slug+"/ref/"+item.Ref, nil)
+	if rr.Code != http.StatusFound {
+		t.Fatalf("two-seg route: expected 302, got %d body=%s", rr.Code, rr.Body.String())
+	}
+	got := rr.Header().Get("Location")
+	want := "/owneruser/" + ws.Slug + "/tasks/" + item.Ref
+	if got != want {
+		t.Errorf("two-seg Location: got %q want %q", got, want)
+	}
+
+	// Three-segment route still works alongside the two-seg shape.
+	rr = doAs("GET", "/explicituser/"+ws.Slug+"/ref/"+item.Ref, nil)
+	if rr.Code != http.StatusFound {
+		t.Fatalf("three-seg route: expected 302, got %d", rr.Code)
+	}
+	got = rr.Header().Get("Location")
+	want = "/explicituser/" + ws.Slug + "/tasks/" + item.Ref
+	if got != want {
+		t.Errorf("three-seg Location: got %q want %q", got, want)
+	}
+}
+
+// TestRefResolver_RestrictedMemberWithCollectionGrant pins P1.2: a
+// restricted member (collection_access="specific" with only collection A
+// in their member_collection_access) PLUS a direct collection grant on
+// collection B must be able to resolve refs that live in collection B.
+// Pre-refactor, refResolverItemVisible's drift-from-requireItemVisible
+// would 404 this case because it didn't consult the guest-grant path
+// when the user was a member. checkItemVisible (the shared helper)
+// closes the gap.
+func TestRefResolver_RestrictedMemberWithCollectionGrant(t *testing.T) {
+	srv := testServer(t)
+
+	// Seed owner + workspace + member. CreateWorkspace handles OwnerID
+	// directly, so the workspace is anchored to a real user before any
+	// ACL-sensitive request runs (and pre-setup bypass is closed by
+	// having UserCount > 0).
+	owner, err := srv.store.CreateUser(models.UserCreate{
+		Email: "owner@example.com", Name: "Owner", Username: "owner",
+		Password: "pw-test-12345",
+	})
+	if err != nil {
+		t.Fatalf("CreateUser owner: %v", err)
+	}
+
+	ws, err := srv.store.CreateWorkspace(models.WorkspaceCreate{
+		Name:    "Claude",
+		OwnerID: owner.ID,
+	})
+	if err != nil {
+		t.Fatalf("CreateWorkspace: %v", err)
+	}
+	if err := srv.store.AddWorkspaceMember(ws.ID, owner.ID, "owner"); err != nil {
+		t.Fatalf("AddWorkspaceMember owner: %v", err)
+	}
+	ownerTok, err := srv.store.CreateAPIToken(owner.ID, models.APITokenCreate{
+		Name: "owner-tok", WorkspaceID: ws.ID,
+	}, 0, 0)
+	if err != nil {
+		t.Fatalf("CreateAPIToken owner: %v", err)
+	}
+
+	asOwner := func(method, path string, body interface{}) *httptest.ResponseRecorder {
+		t.Helper()
+		req := newJSONRequest(t, method, path, body)
+		req.Header.Set("Authorization", "Bearer "+ownerTok.Token)
+		req.RemoteAddr = "127.0.0.1:0"
+		rec := httptest.NewRecorder()
+		srv.ServeHTTP(rec, req)
+		return rec
+	}
+
+	// Two collections — A (member can see directly) and B (member sees
+	// only via the grant we'll attach below).
+	rr := asOwner("POST", "/api/v1/workspaces/"+ws.Slug+"/collections", map[string]interface{}{
+		"name": "Alpha", "slug": "alpha", "prefix": "ALPHA",
+	})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create collection alpha: %d %s", rr.Code, rr.Body.String())
+	}
+	var collA models.Collection
+	parseJSON(t, rr, &collA)
+
+	rr = asOwner("POST", "/api/v1/workspaces/"+ws.Slug+"/collections", map[string]interface{}{
+		"name": "Beta", "slug": "beta", "prefix": "BETA",
+	})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create collection beta: %d %s", rr.Code, rr.Body.String())
+	}
+	var collB models.Collection
+	parseJSON(t, rr, &collB)
+
+	// Seed one item in B — this is the ref we're going to try to resolve
+	// as the restricted member.
+	rr = asOwner("POST", "/api/v1/workspaces/"+ws.Slug+"/collections/beta/items",
+		map[string]interface{}{"title": "Cross-collection target"})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create item: %d %s", rr.Code, rr.Body.String())
+	}
+	var item models.Item
+	parseJSON(t, rr, &item)
+
+	// Create the restricted-access member.
+	member, err := srv.store.CreateUser(models.UserCreate{
+		Email: "member@example.com", Name: "Member", Username: "member",
+		Password: "pw-test-12345",
+	})
+	if err != nil {
+		t.Fatalf("CreateUser member: %v", err)
+	}
+	if err := srv.store.AddWorkspaceMember(ws.ID, member.ID, "viewer"); err != nil {
+		t.Fatalf("AddWorkspaceMember: %v", err)
+	}
+	// "specific" collection access with ONLY collection A in the access
+	// set. Without the grant on B (added below), the member can see A's
+	// items and not B's.
+	if err := srv.store.SetMemberCollectionAccess(ws.ID, member.ID, "specific", []string{collA.ID}); err != nil {
+		t.Fatalf("SetMemberCollectionAccess: %v", err)
+	}
+	// Direct collection grant on B — this is the codex-flagged path.
+	// requireItemVisible considers this via guestResourceFilter's
+	// fullCollIDs return; checkItemVisible must do the same.
+	if _, err := srv.store.CreateCollectionGrant(ws.ID, collB.ID, member.ID, "view", owner.ID); err != nil {
+		t.Fatalf("CreateCollectionGrant: %v", err)
+	}
+
+	// Mint a Bearer token for the restricted member.
+	tok, err := srv.store.CreateAPIToken(member.ID, models.APITokenCreate{
+		Name: "member-tok", WorkspaceID: ws.ID,
+	}, 0, 0)
+	if err != nil {
+		t.Fatalf("CreateAPIToken: %v", err)
+	}
+
+	doAsMember := func(path string) *httptest.ResponseRecorder {
+		t.Helper()
+		req := httptest.NewRequest("GET", path, nil)
+		req.Header.Set("Authorization", "Bearer "+tok.Token)
+		req.RemoteAddr = "127.0.0.1:0"
+		rec := httptest.NewRecorder()
+		srv.ServeHTTP(rec, req)
+		return rec
+	}
+
+	// The restricted-member-with-grant case: GET on the B-collection
+	// item resolves to 302, not 404. Pre-refactor this returned 404
+	// because the resolver's bespoke ACL didn't merge collection grants
+	// into the member's visible set.
+	rr = doAsMember("/owner/" + ws.Slug + "/ref/" + item.Ref)
+	if rr.Code != http.StatusFound {
+		t.Fatalf("restricted-member-with-grant: expected 302, got %d body=%s",
+			rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Header().Get("Location"), "/beta/") {
+		t.Errorf("expected redirect under /beta/, got %q", rr.Header().Get("Location"))
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1214,18 +1214,19 @@ func (s *Server) setupRouter() {
 		// existing workspace-access semantics — 404 (not 403) on no-access
 		// so we don't leak whether a workspace exists.
 		//
-		// Two shapes are registered against the same handler:
-		//
-		//   - /{username}/{workspace}/ref/{ref} — the canonical form
-		//     emitted by renderMarkdown when a username is in scope (item
-		//     bodies on /{user}/{ws}/{coll}/{slug} pages).
-		//   - /{workspace}/ref/{ref} — fallback for renderers that don't
-		//     thread a username through (TimelineCommentCard,
-		//     CommentThread). The handler synthesizes the username from
-		//     the workspace owner so the redirect lands on the same
-		//     canonical SvelteKit URL.
-		r.Get("/{username}/{workspace}/ref/{ref}", s.handleResolveCrossWorkspaceRef)
-		r.Get("/{workspace}/ref/{ref}", s.handleResolveCrossWorkspaceRef)
+		// URL shape: `/-/r/{workspace}/{ref}` — the leading `-/r/` prefix
+		// is structurally impossible to collide with any user-namespace
+		// URL because username slugs require a leading letter (slugify
+		// rule), so no existing or future page route under
+		// /{username}/... can shadow this resolver, and no collection
+		// slug under /{u}/{ws}/{coll}/... can intercept it
+		// (slug grammar also requires letter-led). This replaces the
+		// earlier `/{username}/{workspace}/ref/{ref}` shape that risked
+		// collision with collection slugs named "ref" on pre-existing
+		// data (Codex round-2 P1.4 — picked Option B over a migration
+		// because the feature is unshipped, the new shape is more
+		// defensive, and the only cost is a frontend emit-shape change).
+		r.Get("/-/r/{workspace}/{ref}", s.handleResolveCrossWorkspaceRef)
 	}) // end r.Group (full middleware stack)
 
 	s.router = r
@@ -1518,23 +1519,32 @@ func (s *Server) requireItemVisible(w http.ResponseWriter, r *http.Request, work
 //
 // Rules (in order):
 //
-//  1. nil user → not visible. Fresh-install bypass is the caller's
-//     responsibility; once any user exists, the resolver has no
-//     anonymous-read mode (share links own that surface via /s/{token}).
-//  2. Admin user (user.Role == "admin") → always visible.
-//  3. Role "owner" — workspace owner role granted by RequireWorkspaceAccess
-//     for the workspace's owner_id, and "admin" via the same path. Always
-//     visible.
+//  1. Tokenized-access roles ("owner", "editor") bypass the user-nil
+//     check. RequireWorkspaceAccess grants these on the fresh-install
+//     path (synthetic "owner" with currentUser == nil) AND on the legacy
+//     workspace-scoped API token path ("editor" with currentUser == nil).
+//     The middleware already gated access for both paths; checkItemVisible
+//     should not second-guess the middleware's authorization decision
+//     (Codex round-2 P1.1).
+//  2. nil user past rule 1 → not visible. Anonymous viewers without a
+//     tokenized role have no item-read access (share links own the
+//     public-read surface via /s/{token}).
+//  3. Admin user (user.Role == "admin") → always visible.
 //  4. Otherwise: replay the guestResourceFilterCore + member-collection-
-//     access logic that requireItemVisible used to inline.
+//     access logic that requireItemVisible used to inline, with a system-
+//     collections union added to the item-grants branch (Codex round-2
+//     P1.2 — restricted members with conventions/playbooks access plus
+//     an unrelated item grant previously 404'd on system-collection items
+//     because the item-grants branch only checked direct grants + the
+//     member's explicit collection-access list).
 func (s *Server) checkItemVisible(workspaceID string, item *models.Item, user *models.User, role string) (bool, error) {
-	// Pre-setup mode: RequireWorkspaceAccess synthesizes role="owner" for
-	// fresh installs (currentUser stays nil because no user exists yet).
-	// Treat this exactly like an authenticated owner — visibleCollectionIDs's
-	// pre-refactor behavior also returned nil (no filter) for nil user, so
-	// the (user=nil, role="owner") tuple stays "visible" to preserve the
-	// install bypass.
-	if role == "owner" {
+	// Tokenized-role bypass. RequireWorkspaceAccess synthesizes "owner"
+	// on fresh installs (UserCount == 0, currentUser == nil) and "editor"
+	// for legacy workspace-scoped API tokens (currentUser == nil but
+	// tokenWorkspaceID matches). Both are authorized by the middleware
+	// already; rejecting them here on the user-nil check would cause
+	// every requireItemVisible-gated handler to false-404 those clients.
+	if role == "owner" || role == "editor" {
 		return true, nil
 	}
 	if user == nil {
@@ -1581,22 +1591,41 @@ func (s *Server) checkItemVisible(workspaceID string, item *models.Item, user *m
 	// Item-level grants are active. The item is visible when:
 	//   a) the collection itself has a full grant (any item passes), OR
 	//   b) for restricted members: the collection is in member_collection_access
-	//      (system collections + direct member grants), OR
-	//   c) the specific item is in the granted-items list.
+	//      (the member's explicit collection-access list), OR
+	//   c) the item's collection is a system collection — restricted
+	//      members always retain access to system collections (conventions,
+	//      playbooks, …); pre-round-2 this branch missed the system-
+	//      collections union that guestResourceFilterCore performed, so a
+	//      restricted member with an item grant in a non-system collection
+	//      was 404'd on a system-collection item they were entitled to see.
+	//   d) the specific item is in the granted-items list.
 	for _, id := range grantCollIDs {
 		if id == item.CollectionID {
 			return true, nil
 		}
 	}
 	if role != "guest" {
-		// member_collection_access path — restricted members see system
-		// collections and their explicit collection-access list as full
-		// grants alongside any item-level grants.
+		// member_collection_access path — restricted members see their
+		// explicit collection-access list as full grants alongside any
+		// item-level grants.
 		memberColls, err := s.store.GetMemberCollectionAccess(workspaceID, user.ID)
 		if err != nil {
 			return false, err
 		}
 		for _, id := range memberColls {
+			if id == item.CollectionID {
+				return true, nil
+			}
+		}
+		// System-collections union — mirror guestResourceFilterCore's
+		// pre-round-2 behavior. ListSystemCollectionIDs is a workspace-
+		// scoped lookup (no per-user filter), so the same call is correct
+		// for every restricted member in the workspace.
+		sysColls, err := s.store.ListSystemCollectionIDs(workspaceID)
+		if err != nil {
+			return false, err
+		}
+		for _, id := range sysColls {
 			if id == item.CollectionID {
 				return true, nil
 			}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1519,13 +1519,17 @@ func (s *Server) requireItemVisible(w http.ResponseWriter, r *http.Request, work
 //
 // Rules (in order):
 //
-//  1. Tokenized-access roles ("owner", "editor") bypass the user-nil
-//     check. RequireWorkspaceAccess grants these on the fresh-install
-//     path (synthetic "owner" with currentUser == nil) AND on the legacy
-//     workspace-scoped API token path ("editor" with currentUser == nil).
-//     The middleware already gated access for both paths; checkItemVisible
-//     should not second-guess the middleware's authorization decision
-//     (Codex round-2 P1.1).
+//  1. Tokenized-nil-user bypass: when currentUser == nil AND role is one
+//     of the synthesized-by-middleware roles ("owner" for fresh-install,
+//     "editor" for legacy workspace-scoped API tokens),
+//     RequireWorkspaceAccess has already authorized the request — there
+//     is no per-user filter to apply, and the user-nil rejection at
+//     rule 2 would false-404 these callers. The bypass is SCOPED TO
+//     user == nil — real authenticated members with role "owner" /
+//     "editor" must still fall through to the per-collection filter,
+//     otherwise a restricted editor member would bypass their own
+//     collection_access="specific" gate (Codex round-3 regression of
+//     the round-2 P1.1 fix).
 //  2. nil user past rule 1 → not visible. Anonymous viewers without a
 //     tokenized role have no item-read access (share links own the
 //     public-read surface via /s/{token}).
@@ -1538,13 +1542,18 @@ func (s *Server) requireItemVisible(w http.ResponseWriter, r *http.Request, work
 //     because the item-grants branch only checked direct grants + the
 //     member's explicit collection-access list).
 func (s *Server) checkItemVisible(workspaceID string, item *models.Item, user *models.User, role string) (bool, error) {
-	// Tokenized-role bypass. RequireWorkspaceAccess synthesizes "owner"
-	// on fresh installs (UserCount == 0, currentUser == nil) and "editor"
-	// for legacy workspace-scoped API tokens (currentUser == nil but
-	// tokenWorkspaceID matches). Both are authorized by the middleware
-	// already; rejecting them here on the user-nil check would cause
-	// every requireItemVisible-gated handler to false-404 those clients.
-	if role == "owner" || role == "editor" {
+	// Tokenized-nil-user bypass. RequireWorkspaceAccess synthesizes
+	// "owner" on fresh installs (UserCount == 0, currentUser == nil) and
+	// "editor" for legacy workspace-scoped API tokens (currentUser ==
+	// nil but tokenWorkspaceID matches). Both are authorized by the
+	// middleware already. Real authenticated users with these roles
+	// (workspace owners, member.Role=="editor", …) must NOT short-circuit
+	// here — they have to walk the per-collection filter so
+	// collection_access="specific" + member_collection_access actually
+	// gates them (Codex round-3 — the round-2 fix dropped the
+	// `user == nil` qualifier and accidentally disabled the gate for
+	// every real editor too).
+	if user == nil && (role == "owner" || role == "editor") {
 		return true, nil
 	}
 	if user == nil {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1204,6 +1204,16 @@ func (s *Server) setupRouter() {
 			// Search
 			r.Get("/search", s.handleSearch)
 		})
+
+		// Cross-workspace wiki-link resolver (IDEA-1492). Resolves
+		// `[[workspace::REF]]` links emitted by the markdown renderer to
+		// the canonical item URL via a 302 redirect. Lives outside /api/v1
+		// because rendered HTML hrefs target user-facing paths, not API
+		// endpoints. Registered at the outer group level so chi matches
+		// the four-segment URL ahead of the catch-all SPA handler. ACL
+		// check matches existing workspace-access semantics — 404 (not 403)
+		// on no-access so we don't leak whether a workspace exists.
+		r.Get("/{username}/{workspace}/ref/{ref}", s.handleResolveCrossWorkspaceRef)
 	}) // end r.Group (full middleware stack)
 
 	s.router = r

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1210,10 +1210,22 @@ func (s *Server) setupRouter() {
 		// the canonical item URL via a 302 redirect. Lives outside /api/v1
 		// because rendered HTML hrefs target user-facing paths, not API
 		// endpoints. Registered at the outer group level so chi matches
-		// the four-segment URL ahead of the catch-all SPA handler. ACL
-		// check matches existing workspace-access semantics — 404 (not 403)
-		// on no-access so we don't leak whether a workspace exists.
+		// these URLs ahead of the catch-all SPA handler. ACL check matches
+		// existing workspace-access semantics — 404 (not 403) on no-access
+		// so we don't leak whether a workspace exists.
+		//
+		// Two shapes are registered against the same handler:
+		//
+		//   - /{username}/{workspace}/ref/{ref} — the canonical form
+		//     emitted by renderMarkdown when a username is in scope (item
+		//     bodies on /{user}/{ws}/{coll}/{slug} pages).
+		//   - /{workspace}/ref/{ref} — fallback for renderers that don't
+		//     thread a username through (TimelineCommentCard,
+		//     CommentThread). The handler synthesizes the username from
+		//     the workspace owner so the redirect lands on the same
+		//     canonical SvelteKit URL.
 		r.Get("/{username}/{workspace}/ref/{ref}", s.handleResolveCrossWorkspaceRef)
+		r.Get("/{workspace}/ref/{ref}", s.handleResolveCrossWorkspaceRef)
 	}) // end r.Group (full middleware stack)
 
 	s.router = r
@@ -1471,54 +1483,131 @@ func (s *Server) visibleCollectionIDs(r *http.Request, workspaceID string) ([]st
 // specific item is granted (not just the collection). Writes a 404 and returns
 // false if not. Callers should invoke this immediately after resolving an item
 // by slug/ID.
+//
+// Thin shim over checkItemVisible — see that helper for the rules. This
+// wrapper exists for the legacy call-sites that already hold a *http.Request
+// pre-populated by RequireWorkspaceAccess; new callers without that middleware
+// (e.g. handlers_ref_resolver.go) should use checkItemVisible directly with
+// a manually-derived role.
 func (s *Server) requireItemVisible(w http.ResponseWriter, r *http.Request, workspaceID string, item *models.Item) bool {
-	visibleIDs, err := s.visibleCollectionIDs(r, workspaceID)
+	visible, err := s.checkItemVisible(workspaceID, item, currentUser(r), workspaceRole(r))
 	if err != nil {
 		writeInternalError(w, err)
 		return false
 	}
-	if !isCollectionVisible(item.CollectionID, visibleIDs) {
+	if !visible {
 		writeError(w, http.StatusNotFound, "not_found", "Item not found")
 		return false
 	}
-
-	// For users with item-level grants (guests or restricted members),
-	// collection visibility may come from item-level grants.
-	// We need to verify the user actually has a grant on this specific item
-	// (not just another item in the same collection).
-	// Uses guestResourceFilter which skips this check for members with "all" access.
-	fullCollIDs, grantedItemIDs, grantErr := s.guestResourceFilter(r, workspaceID)
-	if grantErr != nil {
-		writeInternalError(w, grantErr)
-		return false
-	}
-	if len(grantedItemIDs) > 0 {
-		// If the collection has a full collection grant, the item is visible
-		for _, id := range fullCollIDs {
-			if id == item.CollectionID {
-				return true
-			}
-		}
-		// Check if this collection came from member_collection_access (not grants)
-		if workspaceRole(r) != "guest" {
-			memberColls, _ := s.store.GetMemberCollectionAccess(workspaceID, currentUserID(r))
-			for _, id := range memberColls {
-				if id == item.CollectionID {
-					return true
-				}
-			}
-		}
-		// Otherwise, the specific item must be in the granted items list
-		for _, id := range grantedItemIDs {
-			if id == item.ID {
-				return true
-			}
-		}
-		writeError(w, http.StatusNotFound, "not_found", "Item not found")
-		return false
-	}
-
 	return true
+}
+
+// checkItemVisible is the context-free visibility decision. Returns (true,
+// nil) when the (user, role) pair can see `item` under the same rules
+// `requireItemVisible` enforces. Centralizes the rule set so the
+// resolver route (IDEA-1492) and the middleware-gated handlers can't drift.
+//
+// Inputs:
+//
+//   - workspaceID — the resolved workspace's UUID.
+//   - item — already-loaded item (so the helper doesn't re-resolve and
+//     accidentally apply a different lookup path).
+//   - user — currentUser(r) at the call site; nil for unauthenticated.
+//   - role — workspaceRole(r) at the call site, or the role derived
+//     manually by callers operating outside RequireWorkspaceAccess.
+//
+// Rules (in order):
+//
+//  1. nil user → not visible. Fresh-install bypass is the caller's
+//     responsibility; once any user exists, the resolver has no
+//     anonymous-read mode (share links own that surface via /s/{token}).
+//  2. Admin user (user.Role == "admin") → always visible.
+//  3. Role "owner" — workspace owner role granted by RequireWorkspaceAccess
+//     for the workspace's owner_id, and "admin" via the same path. Always
+//     visible.
+//  4. Otherwise: replay the guestResourceFilterCore + member-collection-
+//     access logic that requireItemVisible used to inline.
+func (s *Server) checkItemVisible(workspaceID string, item *models.Item, user *models.User, role string) (bool, error) {
+	// Pre-setup mode: RequireWorkspaceAccess synthesizes role="owner" for
+	// fresh installs (currentUser stays nil because no user exists yet).
+	// Treat this exactly like an authenticated owner — visibleCollectionIDs's
+	// pre-refactor behavior also returned nil (no filter) for nil user, so
+	// the (user=nil, role="owner") tuple stays "visible" to preserve the
+	// install bypass.
+	if role == "owner" {
+		return true, nil
+	}
+	if user == nil {
+		return false, nil
+	}
+	// Admin sees everything (matches visibleCollectionIDs's nil-filter shape).
+	if user.Role == "admin" {
+		return true, nil
+	}
+
+	// Visibility filter: nil = unrestricted; non-nil = restricted to the slice.
+	visibleIDs, err := s.store.VisibleCollectionIDs(workspaceID, user.ID)
+	if err != nil {
+		return false, err
+	}
+	if !isCollectionVisible(item.CollectionID, visibleIDs) {
+		return false, nil
+	}
+
+	// Replay guestResourceFilterCore's logic without the *http.Request
+	// dependency. Member-with-all-access short-circuits to "no item-level
+	// filter"; guests + restricted members get the grant filter.
+	if role != "guest" {
+		member, err := s.store.GetWorkspaceMember(workspaceID, user.ID)
+		if err != nil {
+			return false, err
+		}
+		if member != nil && (member.CollectionAccess == "all" || member.CollectionAccess == "") {
+			// Full collection access — visibleIDs filter already passed.
+			return true, nil
+		}
+	}
+
+	grantCollIDs, grantedItemIDs, err := s.store.GuestVisibleResources(workspaceID, user.ID)
+	if err != nil {
+		return false, err
+	}
+	if len(grantedItemIDs) == 0 {
+		// No item-level grants in play. visibleCollectionIDs already
+		// determined the collection is reachable; visibility stands.
+		return true, nil
+	}
+
+	// Item-level grants are active. The item is visible when:
+	//   a) the collection itself has a full grant (any item passes), OR
+	//   b) for restricted members: the collection is in member_collection_access
+	//      (system collections + direct member grants), OR
+	//   c) the specific item is in the granted-items list.
+	for _, id := range grantCollIDs {
+		if id == item.CollectionID {
+			return true, nil
+		}
+	}
+	if role != "guest" {
+		// member_collection_access path — restricted members see system
+		// collections and their explicit collection-access list as full
+		// grants alongside any item-level grants.
+		memberColls, err := s.store.GetMemberCollectionAccess(workspaceID, user.ID)
+		if err != nil {
+			return false, err
+		}
+		for _, id := range memberColls {
+			if id == item.CollectionID {
+				return true, nil
+			}
+		}
+	}
+	for _, id := range grantedItemIDs {
+		if id == item.ID {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // isItemVisibleToGuest checks if an item is visible given grant-based access,

--- a/internal/store/collections.go
+++ b/internal/store/collections.go
@@ -593,6 +593,13 @@ var reservedCollectionSlugs = map[string]bool{
 	"starred":  true,
 	"library":  true,
 	"new":      true,
+	// "ref" is reserved for the cross-workspace wiki-link resolver route
+	// (IDEA-1492): GET /{username}/{workspace}/ref/{REF} → 302 to the
+	// canonical item URL. A collection slug of "ref" would intercept every
+	// item URL under that collection (the resolver's `{ref}` segment can't
+	// match an arbitrary slug shape), so we forbid it at create time
+	// rather than tolerate silent 404s after the fact.
+	"ref": true,
 }
 
 // isReservedCollectionSlug checks whether a slug would collide with a

--- a/web/src/lib/utils/markdown.ts
+++ b/web/src/lib/utils/markdown.ts
@@ -324,6 +324,16 @@ export function renderMarkdown(
 			// happens server-side at click time — the renderer has no
 			// visibility into the target workspace's items.
 			//
+			// URL shape: `/-/r/{workspace}/{ref}`. The leading `/-/r/` is
+			// the resolver's sentinel prefix (Codex round-2 P1.4 / Option
+			// B); it can't collide with any user-namespace URL because
+			// username + collection slugs both require letter-led. The
+			// `username` arg is ignored for cross-workspace links because
+			// the resolver derives the canonical user-namespace segment
+			// from the target workspace's owner — without that, links
+			// would silently 404 when the rendering page's username
+			// doesn't own the target workspace.
+			//
 			// URL components are NOT percent-encoded here. parseCrossWorkspaceBody
 			// already vetted `xw.workspace` against WORKSPACE_SLUG_PATTERN
 			// (`^[a-z][a-z0-9-]*$`) and `xw.ref` against REF_PATTERN
@@ -332,8 +342,7 @@ export function renderMarkdown(
 			// verbatim, so the encode/no-encode choice is symmetric across
 			// both functions (Codex round-1 sanity sweep).
 			const safeDisplay = escapeHtml(xw.display ?? `${xw.workspace}::${xw.ref}`);
-			const hrefPrefix = username ? `/${username}/${xw.workspace}` : `/${xw.workspace}`;
-			return `<a href="${hrefPrefix}/ref/${xw.ref}" class="doc-link cross-workspace">${safeDisplay}</a>`;
+			return `<a href="/-/r/${xw.workspace}/${xw.ref}" class="doc-link cross-workspace">${safeDisplay}</a>`;
 		}
 		// Escape user-controlled title so it can't break out of attribute
 		// quotes. sanitizeMarkdownHtml would strip the worst offenders after
@@ -468,9 +477,10 @@ export function wikiLinksToMarkdown(content: string, items: Item[], workspaceSlu
 				// behavior at the bottom of this function.
 				return _match;
 			}
-			const xwPrefix = username ? `/${username}/${xw.workspace}` : `/${xw.workspace}`;
+			// Cross-workspace: emit the resolver URL (`/-/r/{ws}/{ref}`).
+			// Same shape renderMarkdown emits — Codex round-2 P1.4 / Option B.
 			const display = xw.display ?? `${xw.workspace}::${xw.ref}`;
-			return `[${escapeMarkdownLinkText(display)}](${xwPrefix}/ref/${xw.ref})`;
+			return `[${escapeMarkdownLinkText(display)}](/-/r/${xw.workspace}/${xw.ref})`;
 		}
 
 		// Split optional display override on the FIRST unescaped pipe. We do
@@ -566,10 +576,12 @@ export function wikiLinksToMarkdown(content: string, items: Item[], workspaceSlu
  * Items without a ref fall back to the legacy [[Title]] form.
  */
 export function markdownToWikiLinks(markdown: string, items: Item[]): string {
-	// Cross-workspace ref URLs: /<user?>/<workspace>/ref/<REF> → [[workspace::REF]].
-	// Run BEFORE the same-workspace match below because the regex below also
-	// matches three-segment paths (it accepts {2,3} segments), and would
-	// otherwise consume the URL with `ref` as the "collection" segment.
+	// Cross-workspace ref URLs: /-/r/{workspace}/{REF} → [[workspace::REF]].
+	// Run BEFORE the same-workspace match below because the regex below
+	// accepts two-or-three-segment URL paths and would otherwise misclassify
+	// the resolver URL. The `/-/r/` sentinel prefix can't appear in any
+	// user-namespace URL because username + collection slugs are letter-led
+	// (Codex round-2 P1.4 / Option B).
 	//
 	// Strip the optional `|Display` ONLY when the link text equals the
 	// renderer's DEFAULT (`${ws}::${ref}`). A user who explicitly wrote
@@ -578,8 +590,8 @@ export function markdownToWikiLinks(markdown: string, items: Item[]): string {
 	// which the next render would emit the default `other::TASK-1` and
 	// silently change the visible link text (Codex round-1 P2.1).
 	const withXwRefs = markdown.replace(
-		/\[((?:\\.|[^\]\\])+)\]\(\/(?:([^/]+)\/)?([a-z][a-z0-9-]*)\/ref\/([A-Za-z][A-Za-z0-9]*-\d+)\)/g,
-		(_match, rawText: string, _user: string | undefined, ws: string, ref: string) => {
+		/\[((?:\\.|[^\]\\])+)\]\(\/-\/r\/([a-z][a-z0-9-]*)\/([A-Za-z][A-Za-z0-9]*-\d+)\)/g,
+		(_match, rawText: string, ws: string, ref: string) => {
 			const displayText = unescapeMarkdownLinkText(rawText);
 			const renderDefault = `${ws}::${ref}`;
 			if (displayText === renderDefault) {

--- a/web/src/lib/utils/markdown.ts
+++ b/web/src/lib/utils/markdown.ts
@@ -297,11 +297,44 @@ export function renderMarkdown(
 	visibleCollectionSlugs?: Set<string>,
 	attachmentResolver?: AttachmentResolver
 ): string {
-	const withLinks = content.replace(/\[\[([^\]]+)\]\]/g, (_match, title: string) => {
+	const withLinks = content.replace(/\[\[([^\]]+)\]\]/g, (_match, body: string) => {
+		// Cross-workspace form: [[workspace-slug::REF]] or [[workspace-slug::REF|Display]].
+		// `::` is the unambiguous separator. The workspace prefix is recognized
+		// only when both the slug AND the right-hand side match their expected
+		// shapes — otherwise the body falls through to legacy [[Title]] handling.
+		const xw = parseCrossWorkspaceBody(body);
+		if (xw) {
+			if (xw.workspace === workspaceSlug) {
+				// Same-workspace cross-ws form: behave identically to [[REF]],
+				// resolving against the in-memory item list. Falls through to
+				// the broken-link span if the ref isn't loaded.
+				const sameWsItem = findItemByRef(items, xw.ref);
+				const display = xw.display ?? (sameWsItem?.title ?? xw.ref);
+				const safeDisplay = escapeHtml(display);
+				if (sameWsItem && sameWsItem.collection_slug) {
+					if (visibleCollectionSlugs !== undefined && !visibleCollectionSlugs.has(sameWsItem.collection_slug)) {
+						return `<span class="doc-link locked" title="You don't have access to this item">🔒 ${safeDisplay}</span>`;
+					}
+					const prefix = username ? `/${username}/${workspaceSlug}` : `/${workspaceSlug}`;
+					return `<a href="${prefix}/${sameWsItem.collection_slug}/${itemUrlId(sameWsItem)}" class="doc-link">${safeDisplay}</a>`;
+				}
+				return `<span class="doc-link broken">${safeDisplay}</span>`;
+			}
+			// Cross-workspace: emit a link to the resolver route. Validation
+			// happens server-side at click time — the renderer has no
+			// visibility into the target workspace's items.
+			const prefix = username ? `/${username}/${xw.workspace}` : `/${xw.workspace}`;
+			const safeDisplay = escapeHtml(xw.display ?? `${xw.workspace}::${xw.ref}`);
+			const safeWorkspace = encodeURIComponent(xw.workspace);
+			const safeRef = encodeURIComponent(xw.ref);
+			const hrefPrefix = username ? `/${encodeURIComponent(username)}/${safeWorkspace}` : `/${safeWorkspace}`;
+			return `<a href="${hrefPrefix}/ref/${safeRef}" class="doc-link cross-workspace">${safeDisplay}</a>`;
+		}
 		// Escape user-controlled title so it can't break out of attribute
 		// quotes. sanitizeMarkdownHtml would strip the worst offenders after
 		// the fact, but escaping up-front keeps the intermediate HTML valid
 		// and avoids relying on the sanitizer to paper over bad markup.
+		const title = body;
 		const safeTitle = escapeHtml(title);
 		const item = items.find(i => i.title === title);
 		if (item && item.collection_slug) {
@@ -360,6 +393,41 @@ export function unescapeDocLinks(markdown: string): string {
 // which keeps legacy [[Title]] links working unchanged.
 const REF_PATTERN = /^[A-Za-z][A-Za-z0-9]*-\d+$/;
 
+// Workspace slug pattern. Mirrors the existing slug normalization rules — a
+// lowercase letter followed by lowercase alphanumerics or hyphens. Anchored
+// so anything not slug-shaped (uppercase, leading digit, punctuation) falls
+// through to legacy title handling.
+const WORKSPACE_SLUG_PATTERN = /^[a-z][a-z0-9-]*$/;
+
+// Cross-workspace wiki-link body parser. Returns null when the body isn't a
+// `workspace::REF` (optionally `|Display`) shape, so callers can fall through
+// to legacy [[Title]] semantics without losing pre-existing links whose titles
+// happen to contain `::`. Both the slug and the ref must validate — partial
+// matches (e.g. `[[claude::not-a-ref]]`) return null.
+function parseCrossWorkspaceBody(body: string): { workspace: string; ref: string; display: string | null } | null {
+	const sepIdx = body.indexOf('::');
+	if (sepIdx <= 0) return null;
+	const workspace = body.slice(0, sepIdx);
+	const rest = body.slice(sepIdx + 2);
+	if (!WORKSPACE_SLUG_PATTERN.test(workspace)) return null;
+	// Display override splits on the first unescaped pipe in `rest`, same as
+	// the single-workspace splitter. We reuse splitWikiBody for consistency.
+	const { key: refRaw, displayOverride: displayRaw } = splitWikiBody(rest);
+	const ref = unescapeWikiBody(refRaw).trim();
+	if (!REF_PATTERN.test(ref)) return null;
+	const display = displayRaw == null ? null : unescapeWikiBody(displayRaw);
+	return { workspace, ref, display };
+}
+
+// Locate an item by its PREFIX-NUMBER ref in the in-memory list. Returns
+// undefined if no match — same fall-through semantics as the legacy path.
+function findItemByRef(items: Item[], ref: string): Item | undefined {
+	return items.find(i =>
+		!!i.item_number && !!i.collection_prefix &&
+		`${i.collection_prefix}-${i.item_number}`.toLowerCase() === ref.toLowerCase()
+	);
+}
+
 /**
  * Convert wiki-link storage syntax into markdown links for Tiptap rendering.
  * Supports three forms, in preference order:
@@ -375,6 +443,30 @@ export function wikiLinksToMarkdown(content: string, items: Item[], workspaceSlu
 	// i.e. "a backslash-escaped char OR any non-`]`/non-`\` char".
 	return content.replace(/\[\[((?:\\.|[^\]\\])+)\]\]/g, (_match, body: string) => {
 		const prefix = username ? `/${username}/${workspaceSlug}` : `/${workspaceSlug}`;
+
+		// Cross-workspace form: [[workspace::REF]] / [[workspace::REF|Display]].
+		// If the prefix matches the current workspace, strip it and fall through
+		// to same-workspace ref handling so the link resolves to the canonical
+		// item URL. Otherwise emit a link to the resolver route — the rendered
+		// editor lacks the target workspace's items, so client-side validation
+		// is impossible and we defer to the server's 302/404.
+		const xw = parseCrossWorkspaceBody(body);
+		if (xw) {
+			if (xw.workspace === workspaceSlug) {
+				const sameWsItem = findItemByRef(items, xw.ref);
+				if (sameWsItem && sameWsItem.collection_slug) {
+					const text = xw.display ?? sameWsItem.title;
+					return `[${escapeMarkdownLinkText(text)}](${prefix}/${sameWsItem.collection_slug}/${itemUrlId(sameWsItem)})`;
+				}
+				// Ref didn't resolve in the current workspace — leave the
+				// original wiki-link verbatim, matching the legacy fall-through
+				// behavior at the bottom of this function.
+				return _match;
+			}
+			const xwPrefix = username ? `/${username}/${xw.workspace}` : `/${xw.workspace}`;
+			const display = xw.display ?? `${xw.workspace}::${xw.ref}`;
+			return `[${escapeMarkdownLinkText(display)}](${xwPrefix}/ref/${xw.ref})`;
+		}
 
 		// Split optional display override on the FIRST unescaped pipe. We do
 		// this up-front so REF_PATTERN can check the key alone (a ref like
@@ -469,11 +561,28 @@ export function wikiLinksToMarkdown(content: string, items: Item[], workspaceSlu
  * Items without a ref fall back to the legacy [[Title]] form.
  */
 export function markdownToWikiLinks(markdown: string, items: Item[]): string {
+	// Cross-workspace ref URLs: /<user?>/<workspace>/ref/<REF> → [[workspace::REF]].
+	// Run BEFORE the same-workspace match below because the regex below also
+	// matches three-segment paths (it accepts {2,3} segments), and would
+	// otherwise consume the URL with `ref` as the "collection" segment.
+	// `[[workspace::REF]]` is preferred storage when the display text equals
+	// the bare ref; otherwise we emit the `|Display` override.
+	const withXwRefs = markdown.replace(
+		/\[((?:\\.|[^\]\\])+)\]\(\/(?:([^/]+)\/)?([a-z][a-z0-9-]*)\/ref\/([A-Za-z][A-Za-z0-9]*-\d+)\)/g,
+		(_match, rawText: string, _user: string | undefined, ws: string, ref: string) => {
+			const displayText = unescapeMarkdownLinkText(rawText);
+			if (displayText === ref) {
+				return `[[${ws}::${ref}]]`;
+			}
+			return `[[${ws}::${ref}|${escapeWikiBody(displayText)}]]`;
+		}
+	);
+
 	// Match [Title](/username/workspace/collection/slug-or-REF). Title may
 	// contain backslash-escaped chars (\[, \], \\) that tiptap-markdown emits
 	// when serializing link text. The capture allows `\.` sequences so we
 	// don't terminate on an escaped `]` that's really part of the display.
-	return markdown.replace(/\[((?:\\.|[^\]\\])+)\]\(\/(?:[^/]+\/){2,3}([^)]+)\)/g, (_match, rawText: string, slugOrRef: string) => {
+	return withXwRefs.replace(/\[((?:\\.|[^\]\\])+)\]\(\/(?:[^/]+\/){2,3}([^)]+)\)/g, (_match, rawText: string, slugOrRef: string) => {
 		const item = items.find(i => {
 			if (i.slug === slugOrRef) return true;
 			if (i.item_number && i.collection_prefix) {

--- a/web/src/lib/utils/markdown.ts
+++ b/web/src/lib/utils/markdown.ts
@@ -336,7 +336,7 @@ export function renderMarkdown(
 			//
 			// URL components are NOT percent-encoded here. parseCrossWorkspaceBody
 			// already vetted `xw.workspace` against WORKSPACE_SLUG_PATTERN
-			// (`^[a-z][a-z0-9-]*$`) and `xw.ref` against REF_PATTERN
+			// (`^[a-z0-9][a-z0-9-]*$`) and `xw.ref` against REF_PATTERN
 			// (`^[A-Za-z][A-Za-z0-9]*-\d+$`) — both produce URL-safe ASCII
 			// by construction. wikiLinksToMarkdown emits the same bytes
 			// verbatim, so the encode/no-encode choice is symmetric across
@@ -407,11 +407,14 @@ export function unescapeDocLinks(markdown: string): string {
 // which keeps legacy [[Title]] links working unchanged.
 const REF_PATTERN = /^[A-Za-z][A-Za-z0-9]*-\d+$/;
 
-// Workspace slug pattern. Mirrors the existing slug normalization rules — a
-// lowercase letter followed by lowercase alphanumerics or hyphens. Anchored
-// so anything not slug-shaped (uppercase, leading digit, punctuation) falls
-// through to legacy title handling.
-const WORKSPACE_SLUG_PATTERN = /^[a-z][a-z0-9-]*$/;
+// Workspace slug pattern. Mirrors store.slugify exactly — lowercase
+// alphanumerics + hyphens, with NO leading-letter constraint (slugify
+// preserves digit-leading inputs, e.g. "2026 Roadmap" → "2026-roadmap").
+// The earlier `^[a-z]` constraint was a frontend-only tightening that
+// caused `[[2026-roadmap::TASK-1]]` to fall through as a legacy title
+// link (Codex round-4). Anchored so other non-slug shapes (uppercase,
+// punctuation) still fall through to legacy title handling.
+const WORKSPACE_SLUG_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
 
 // Cross-workspace wiki-link body parser. Returns null when the body isn't a
 // `workspace::REF` (optionally `|Display`) shape, so callers can fall through
@@ -590,7 +593,7 @@ export function markdownToWikiLinks(markdown: string, items: Item[]): string {
 	// which the next render would emit the default `other::TASK-1` and
 	// silently change the visible link text (Codex round-1 P2.1).
 	const withXwRefs = markdown.replace(
-		/\[((?:\\.|[^\]\\])+)\]\(\/-\/r\/([a-z][a-z0-9-]*)\/([A-Za-z][A-Za-z0-9]*-\d+)\)/g,
+		/\[((?:\\.|[^\]\\])+)\]\(\/-\/r\/([a-z0-9][a-z0-9-]*)\/([A-Za-z][A-Za-z0-9]*-\d+)\)/g,
 		(_match, rawText: string, ws: string, ref: string) => {
 			const displayText = unescapeMarkdownLinkText(rawText);
 			const renderDefault = `${ws}::${ref}`;

--- a/web/src/lib/utils/markdown.ts
+++ b/web/src/lib/utils/markdown.ts
@@ -323,12 +323,17 @@ export function renderMarkdown(
 			// Cross-workspace: emit a link to the resolver route. Validation
 			// happens server-side at click time — the renderer has no
 			// visibility into the target workspace's items.
-			const prefix = username ? `/${username}/${xw.workspace}` : `/${xw.workspace}`;
+			//
+			// URL components are NOT percent-encoded here. parseCrossWorkspaceBody
+			// already vetted `xw.workspace` against WORKSPACE_SLUG_PATTERN
+			// (`^[a-z][a-z0-9-]*$`) and `xw.ref` against REF_PATTERN
+			// (`^[A-Za-z][A-Za-z0-9]*-\d+$`) — both produce URL-safe ASCII
+			// by construction. wikiLinksToMarkdown emits the same bytes
+			// verbatim, so the encode/no-encode choice is symmetric across
+			// both functions (Codex round-1 sanity sweep).
 			const safeDisplay = escapeHtml(xw.display ?? `${xw.workspace}::${xw.ref}`);
-			const safeWorkspace = encodeURIComponent(xw.workspace);
-			const safeRef = encodeURIComponent(xw.ref);
-			const hrefPrefix = username ? `/${encodeURIComponent(username)}/${safeWorkspace}` : `/${safeWorkspace}`;
-			return `<a href="${hrefPrefix}/ref/${safeRef}" class="doc-link cross-workspace">${safeDisplay}</a>`;
+			const hrefPrefix = username ? `/${username}/${xw.workspace}` : `/${xw.workspace}`;
+			return `<a href="${hrefPrefix}/ref/${xw.ref}" class="doc-link cross-workspace">${safeDisplay}</a>`;
 		}
 		// Escape user-controlled title so it can't break out of attribute
 		// quotes. sanitizeMarkdownHtml would strip the worst offenders after
@@ -565,13 +570,19 @@ export function markdownToWikiLinks(markdown: string, items: Item[]): string {
 	// Run BEFORE the same-workspace match below because the regex below also
 	// matches three-segment paths (it accepts {2,3} segments), and would
 	// otherwise consume the URL with `ref` as the "collection" segment.
-	// `[[workspace::REF]]` is preferred storage when the display text equals
-	// the bare ref; otherwise we emit the `|Display` override.
+	//
+	// Strip the optional `|Display` ONLY when the link text equals the
+	// renderer's DEFAULT (`${ws}::${ref}`). A user who explicitly wrote
+	// `[[other::TASK-1|TASK-1]]` must round-trip back to itself — comparing
+	// against the bare ref (`displayText === ref`) drops the override, after
+	// which the next render would emit the default `other::TASK-1` and
+	// silently change the visible link text (Codex round-1 P2.1).
 	const withXwRefs = markdown.replace(
 		/\[((?:\\.|[^\]\\])+)\]\(\/(?:([^/]+)\/)?([a-z][a-z0-9-]*)\/ref\/([A-Za-z][A-Za-z0-9]*-\d+)\)/g,
 		(_match, rawText: string, _user: string | undefined, ws: string, ref: string) => {
 			const displayText = unescapeMarkdownLinkText(rawText);
-			if (displayText === ref) {
+			const renderDefault = `${ws}::${ref}`;
+			if (displayText === renderDefault) {
 				return `[[${ws}::${ref}]]`;
 			}
 			return `[[${ws}::${ref}|${escapeWikiBody(displayText)}]]`;


### PR DESCRIPTION
## Summary
- Adds `[[workspace::REF]]` (and `[[workspace::REF|Display]]`) wiki-link syntax for referencing items in other workspaces from any item body or comment.
- Introduces server resolver route `GET /-/r/{workspace}/{REF}` that 302s to the canonical item URL after applying the standard workspace + collection visibility checks.
- Refactors `requireItemVisible` into a context-free `checkItemVisible` helper so the resolver and middleware-gated handlers share one source of ACL truth (no drift).

## Plus
- **Sentinel URL prefix `/-/r/`** structurally cannot collide with any user-namespace URL (`/{user}/{workspace}/{collection}/...`) because username, workspace-slug, and collection-slug grammars all require letter-led starts (slug regex permits digit-leading workspaces but never `-`). Reservation of `ref` as a collection slug remains as defense in depth.
- **No client-side cross-workspace pre-fetch.** The renderer emits the resolver URL without validating the target workspace's items; the redirect route returns 404 on missing-workspace, missing-ref, or no-access. This means existing `renderMarkdown` call sites don't need new arguments.
- **ACL no-leak discipline.** All failure modes (malformed REF, workspace inaccessible, item missing, item invisible, empty owner username) return identical 404 responses to prevent oracle-style probes.
- **Lossless round-trip.** `markdownToWikiLinks` preserves explicit `|Display` overrides; default-display elision only fires when the rendered text matches the renderer's actual default `${ws}::${ref}`.

## Observable behavior changes
- New wiki-link syntax: `[[other-ws::TASK-1]]` renders as a clickable link to the resolver route; same-workspace `[[REF]]` and `[[Title]]` behavior unchanged.
- New route `GET /-/r/{workspace}/{REF}` returns 302 -> canonical item URL, or 404.
- Workspace-slug `ref` is now reserved (defense-in-depth -- the new URL shape doesn't depend on this).

## Test plan
- [ ] CI passes (Go SQLite + Postgres jobs, lint, web build).
- [ ] Manual smoke: render an item containing `[[claude::DECIS-32]]` after install, click the link, confirm the redirect target is the canonical claude-workspace DECIS-32 URL (or 404 if claude is inaccessible to the viewer).
- [ ] Manual smoke: same-workspace `[[REF]]` and `[[Title]]` links still work unchanged.

## Refs
- IDEA-1492 (docapp)
- THREA-52 (claude workspace) -- agent continuity-improvement substrate; first IDEA from this Thread to ship.
- DECIS-32 (claude workspace) -- orchestration model; 11th data point.