### PR TITLE
feat(cli): pad session shape — Claude Code context-window telemetry (IDEA-1491)

### DIFF
--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -150,6 +150,7 @@ func newRootCmd() *cobra.Command {
 		mcpCmd(),
 		bootstrapCmd(),
 		playbookCmd(),
+		sessionCmd(),
 	)
 
 	rootCmd.SetHelpCommand(helpCmd())

--- a/cmd/pad/session.go
+++ b/cmd/pad/session.go
@@ -90,8 +90,16 @@ Side-effect free. The CLI never echoes prompt content, only metrics.`,
 func buildSessionShape(sessionFlag string) (*sessionShapeReport, error) {
 	resolved, err := cli.ResolveSessionLog(cli.ResolveOptions{ExplicitSession: sessionFlag})
 	if err != nil {
-		// Fallback. v1 keeps this minimal — no Pad-invocation-count
-		// derivation yet (IDEA-body sketch is left as a TODO).
+		// If the user explicitly passed --session, a resolver failure
+		// is a real error (typo / wrong UUID / wrong path) and silently
+		// emitting the fallback shape would mask the bug in automation.
+		// Only the autodetect/env-var-implicit paths get to fall back.
+		if sessionFlag != "" {
+			return nil, fmt.Errorf("--session %q: %w", sessionFlag, err)
+		}
+		// Implicit-path fallback. v1 keeps this minimal — no
+		// Pad-invocation-count derivation yet (IDEA-body sketch is a
+		// TODO).
 		return &sessionShapeReport{
 			Agent:         "unknown",
 			FallbackUsed:  true,

--- a/cmd/pad/session.go
+++ b/cmd/pad/session.go
@@ -132,7 +132,13 @@ func buildSessionShape(sessionFlag string) (*sessionShapeReport, error) {
 		if budget, ok := cli.LookupContextBudget(metrics.AgentVersion); ok {
 			report.Budget = &budget
 			report.BudgetSource = "hardcoded_per_agent_version"
-			pct := float64(metrics.Usage.CacheRead) / float64(budget) * 100
+			// Use TotalPrompt (cache_read + cache_creation + input) rather
+			// than CacheRead alone. CacheRead is a steady-state proxy that
+			// under-counts at turn boundaries when fresh content lands in
+			// cache_creation/input but hasn't been folded into the cached
+			// prefix yet. TotalPrompt is the actual prompt footprint sent
+			// to the model this turn — the right numerator vs the budget.
+			pct := float64(metrics.Usage.TotalPrompt) / float64(budget) * 100
 			report.ContextPct = &pct
 			report.ContextClass = cli.ContextClass(pct)
 		} else {
@@ -182,10 +188,10 @@ func sessionShapeMarkdown(r *sessionShapeReport) string {
 	if r.ContextPct != nil && r.Budget != nil {
 		fmt.Fprintf(&b, "- context: **%.1f%%** (%s) — %s / %s tokens\n",
 			*r.ContextPct, r.ContextClass,
-			humanizeInt(r.Tokens.CacheRead), humanizeInt(*r.Budget))
+			humanizeInt(r.Tokens.TotalPrompt), humanizeInt(*r.Budget))
 	} else if r.Tokens != nil {
 		fmt.Fprintf(&b, "- context tokens: %s (no budget for agent_version=%q)\n",
-			humanizeInt(r.Tokens.CacheRead), r.AgentVersion)
+			humanizeInt(r.Tokens.TotalPrompt), r.AgentVersion)
 	}
 	if r.Tokens != nil {
 		fmt.Fprintf(&b, "- tokens: cache_read=%s, cache_creation=%s, input=%s, output=%s\n",

--- a/cmd/pad/session.go
+++ b/cmd/pad/session.go
@@ -1,0 +1,274 @@
+// `pad session shape` — report Claude Code session metrics (token
+// usage, context %, message counts) by reading the session JSONL on
+// disk. See IDEA-1491 for the design.
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+
+	"github.com/PerpetualSoftware/pad/internal/cli"
+)
+
+// sessionShapeReport is the canonical JSON shape returned by
+// `pad session shape`. v1 schema per IDEA-1491 recon update.
+type sessionShapeReport struct {
+	Agent                   string                 `json:"agent"`
+	AgentVersion            string                 `json:"agent_version,omitempty"`
+	SessionID               string                 `json:"session_id,omitempty"`
+	SessionLogPath          string                 `json:"session_log_path,omitempty"`
+	SessionStartedAt        string                 `json:"session_started_at,omitempty"`
+	LastActivityAt          string                 `json:"last_activity_at,omitempty"`
+	ElapsedWallClockSeconds int64                  `json:"elapsed_wall_clock_seconds"`
+	Bytes                   int64                  `json:"bytes"`
+	Lines                   int64                  `json:"lines"`
+	MessageCounts           map[string]int64       `json:"message_counts"`
+	ToolInvocations         int64                  `json:"tool_invocations"`
+	CWD                     string                 `json:"cwd,omitempty"`
+	GitBranch               string                 `json:"git_branch,omitempty"`
+	Tokens                  *cli.SessionUsage      `json:"tokens"`
+	ContextPct              *float64               `json:"context_pct"`
+	ContextClass            string                 `json:"context_class,omitempty"`
+	Budget                  *int64                 `json:"budget"`
+	BudgetSource            string                 `json:"budget_source,omitempty"`
+	FallbackUsed            bool                   `json:"fallback_used"`
+	ResolverSource          string                 `json:"resolver_source,omitempty"`
+	Notes                   map[string]interface{} `json:"notes,omitempty"`
+}
+
+func sessionCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "session",
+		Short: "Inspect the current agent session (Claude Code today)",
+	}
+	cmd.AddCommand(sessionShapeCmd())
+	return cmd
+}
+
+func sessionShapeCmd() *cobra.Command {
+	var sessionFlag string
+	cmd := &cobra.Command{
+		Use:   "shape",
+		Short: "Report Claude Code session shape — tokens, context %, message counts",
+		Long: `Read the current (or specified) Claude Code session JSONL and report
+size, message counts, and — crucially for agent self-pacing — cumulative
+context-window token usage as a percentage of the agent version's
+budget. The percentage is bucketed into low / moderate / heavy / dense.
+
+Source-of-truth precedence:
+  1. --session <id|path>
+  2. $CLAUDE_CODE_SESSION_ID + cwd-derived project slug
+  3. Autodetect under ~/.claude/projects/<cwd-slug>/ when $CLAUDECODE=1
+  4. Fallback (fallback_used: true) — agent=unknown, no token data
+
+Side-effect free. The CLI never echoes prompt content, only metrics.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			report, err := buildSessionShape(sessionFlag)
+			if err != nil {
+				return err
+			}
+			// IDEA-1491: `session shape` defaults to JSON because the
+			// primary caller is an agent reading its own pacing. Only
+			// override the global --format default ("table") when the
+			// user didn't explicitly set it.
+			fmtChoice := formatFlag
+			if !cmd.Root().PersistentFlags().Changed("format") {
+				fmtChoice = "json"
+			}
+			return renderSessionShape(report, fmtChoice)
+		},
+	}
+	cmd.Flags().StringVar(&sessionFlag, "session", "", "session UUID or absolute path to a .jsonl log")
+	return cmd
+}
+
+func buildSessionShape(sessionFlag string) (*sessionShapeReport, error) {
+	resolved, err := cli.ResolveSessionLog(cli.ResolveOptions{ExplicitSession: sessionFlag})
+	if err != nil {
+		// Fallback. v1 keeps this minimal — no Pad-invocation-count
+		// derivation yet (IDEA-body sketch is left as a TODO).
+		return &sessionShapeReport{
+			Agent:         "unknown",
+			FallbackUsed:  true,
+			MessageCounts: map[string]int64{},
+			Tokens:        nil,
+			ContextPct:    nil,
+			Budget:        nil,
+			Notes: map[string]interface{}{
+				"reason": err.Error(),
+			},
+		}, nil
+	}
+
+	metrics, err := cli.ParseSessionJSONL(resolved.Path)
+	if err != nil {
+		return nil, err
+	}
+
+	report := &sessionShapeReport{
+		Agent:                   "claude-code",
+		AgentVersion:            metrics.AgentVersion,
+		SessionID:               resolved.SessionID,
+		SessionLogPath:          resolved.Path,
+		SessionStartedAt:        metrics.SessionStartedAt,
+		LastActivityAt:          metrics.LastActivityAt,
+		ElapsedWallClockSeconds: metrics.ElapsedWallSeconds,
+		Bytes:                   metrics.Bytes,
+		Lines:                   metrics.Lines,
+		MessageCounts:           metrics.MessageCounts,
+		ToolInvocations:         metrics.ToolInvocations,
+		CWD:                     metrics.CWD,
+		GitBranch:               metrics.GitBranch,
+		Tokens:                  metrics.Usage,
+		ResolverSource:          resolved.Source,
+	}
+
+	if metrics.HasUsage {
+		if budget, ok := cli.LookupContextBudget(metrics.AgentVersion); ok {
+			report.Budget = &budget
+			report.BudgetSource = "hardcoded_per_agent_version"
+			pct := float64(metrics.Usage.CacheRead) / float64(budget) * 100
+			report.ContextPct = &pct
+			report.ContextClass = cli.ContextClass(pct)
+		} else {
+			report.Notes = map[string]interface{}{
+				"confidence": "unknown-agent-version",
+			}
+		}
+	}
+
+	// v1 punts: sub-agent JSONLs under <slug>/<session-id>/subagents/ are
+	// not summed. The --include-sidechain flag from the IDEA comment is a
+	// follow-up.
+	// TODO(IDEA-1491): optional --include-sidechain to union parent +
+	// subagents/*.jsonl token usage.
+
+	return report, nil
+}
+
+func renderSessionShape(r *sessionShapeReport, format string) error {
+	switch format {
+	case "json", "":
+		// Default to JSON for `session shape` because the primary
+		// caller is an agent reading its own pacing.
+		outputJSON(r)
+		return nil
+	case "markdown":
+		fmt.Print(sessionShapeMarkdown(r))
+		return nil
+	case "table":
+		printSessionShapeTable(r)
+		return nil
+	default:
+		return fmt.Errorf("unknown format %q (want json, table, markdown)", format)
+	}
+}
+
+func sessionShapeMarkdown(r *sessionShapeReport) string {
+	var b strings.Builder
+	if r.FallbackUsed {
+		fmt.Fprintf(&b, "**Session shape (fallback)** — agent: `%s`, no token data available.\n", r.Agent)
+		return b.String()
+	}
+	fmt.Fprintf(&b, "**Session shape** — `%s` %s\n", r.Agent, r.AgentVersion)
+	if r.SessionID != "" {
+		fmt.Fprintf(&b, "- session: `%s`\n", r.SessionID)
+	}
+	if r.ContextPct != nil && r.Budget != nil {
+		fmt.Fprintf(&b, "- context: **%.1f%%** (%s) — %s / %s tokens\n",
+			*r.ContextPct, r.ContextClass,
+			humanizeInt(r.Tokens.CacheRead), humanizeInt(*r.Budget))
+	} else if r.Tokens != nil {
+		fmt.Fprintf(&b, "- context tokens: %s (no budget for agent_version=%q)\n",
+			humanizeInt(r.Tokens.CacheRead), r.AgentVersion)
+	}
+	if r.Tokens != nil {
+		fmt.Fprintf(&b, "- tokens: cache_read=%s, cache_creation=%s, input=%s, output=%s\n",
+			humanizeInt(r.Tokens.CacheRead), humanizeInt(r.Tokens.CacheCreation),
+			humanizeInt(r.Tokens.Input), humanizeInt(r.Tokens.Output))
+	}
+	fmt.Fprintf(&b, "- log: %d lines / %s, %d tool invocations\n",
+		r.Lines, humanizeBytes(r.Bytes), r.ToolInvocations)
+	if r.SessionStartedAt != "" {
+		fmt.Fprintf(&b, "- started: %s · last activity: %s (elapsed %ds)\n",
+			r.SessionStartedAt, r.LastActivityAt, r.ElapsedWallClockSeconds)
+	}
+	if r.CWD != "" {
+		fmt.Fprintf(&b, "- cwd: `%s`", r.CWD)
+		if r.GitBranch != "" {
+			fmt.Fprintf(&b, " · branch: `%s`", r.GitBranch)
+		}
+		fmt.Fprintln(&b)
+	}
+	return b.String()
+}
+
+func printSessionShapeTable(r *sessionShapeReport) {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	defer w.Flush()
+	if r.FallbackUsed {
+		fmt.Fprintf(w, "Agent:\t%s (fallback)\n", r.Agent)
+		if r.Notes != nil {
+			if reason, ok := r.Notes["reason"].(string); ok {
+				fmt.Fprintf(w, "Reason:\t%s\n", reason)
+			}
+		}
+		return
+	}
+	fmt.Fprintf(w, "Agent:\t%s %s\n", r.Agent, r.AgentVersion)
+	fmt.Fprintf(w, "Session ID:\t%s\n", r.SessionID)
+	fmt.Fprintf(w, "Log path:\t%s\n", r.SessionLogPath)
+	if r.ContextPct != nil && r.Budget != nil {
+		fmt.Fprintf(w, "Context %%:\t%.1f%% (%s)\n", *r.ContextPct, r.ContextClass)
+		fmt.Fprintf(w, "Budget:\t%s tokens\n", humanizeInt(*r.Budget))
+	}
+	if r.Tokens != nil {
+		fmt.Fprintf(w, "Cache read:\t%s\n", humanizeInt(r.Tokens.CacheRead))
+		fmt.Fprintf(w, "Cache creation:\t%s\n", humanizeInt(r.Tokens.CacheCreation))
+		fmt.Fprintf(w, "Input:\t%s\n", humanizeInt(r.Tokens.Input))
+		fmt.Fprintf(w, "Output:\t%s\n", humanizeInt(r.Tokens.Output))
+		fmt.Fprintf(w, "Total prompt:\t%s\n", humanizeInt(r.Tokens.TotalPrompt))
+	}
+	fmt.Fprintf(w, "Lines:\t%d\n", r.Lines)
+	fmt.Fprintf(w, "Bytes:\t%s\n", humanizeBytes(r.Bytes))
+	fmt.Fprintf(w, "Tool invocations:\t%d\n", r.ToolInvocations)
+	for k, v := range r.MessageCounts {
+		fmt.Fprintf(w, "  msg %s:\t%d\n", k, v)
+	}
+	if r.SessionStartedAt != "" {
+		fmt.Fprintf(w, "Started:\t%s\n", r.SessionStartedAt)
+		fmt.Fprintf(w, "Last activity:\t%s\n", r.LastActivityAt)
+		fmt.Fprintf(w, "Elapsed:\t%ds\n", r.ElapsedWallClockSeconds)
+	}
+	if r.CWD != "" {
+		fmt.Fprintf(w, "CWD:\t%s\n", r.CWD)
+	}
+	if r.GitBranch != "" {
+		fmt.Fprintf(w, "Git branch:\t%s\n", r.GitBranch)
+	}
+	fmt.Fprintf(w, "Resolver source:\t%s\n", r.ResolverSource)
+}
+
+func humanizeInt(n int64) string {
+	if n < 1000 {
+		return fmt.Sprintf("%d", n)
+	}
+	// Comma group thousands. Cheap manual impl beats pulling in a dep.
+	s := fmt.Sprintf("%d", n)
+	out := make([]byte, 0, len(s)+len(s)/3)
+	for i, c := range []byte(s) {
+		if i > 0 && (len(s)-i)%3 == 0 {
+			out = append(out, ',')
+		}
+		out = append(out, c)
+	}
+	return string(out)
+}
+
+// Compile-time assertion: report JSON shape stays valid encoding-wise.
+var _ = json.Marshal

--- a/cmd/pad/session_test.go
+++ b/cmd/pad/session_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestBuildSessionShape_ExplicitFlagErrors pins Codex R2 P3: a
+// resolver error under an explicit --session must surface as an
+// error, not as a silent fallback report. Typos in automation should
+// fail loudly.
+func TestBuildSessionShape_ExplicitFlagErrors(t *testing.T) {
+	// Path-traversal-shaped session ID — resolver rejects shape, error
+	// must propagate.
+	_, err := buildSessionShape("../../../etc/passwd")
+	if err == nil {
+		t.Fatal("expected error for path-traversal --session, got nil")
+	}
+	if !strings.Contains(err.Error(), "--session") {
+		t.Errorf("error %q should mention --session for context", err.Error())
+	}
+
+	// Absolute-path that doesn't exist — also must error.
+	_, err = buildSessionShape("/nonexistent/path/to/session.jsonl")
+	if err == nil {
+		t.Fatal("expected error for missing --session path, got nil")
+	}
+}
+
+// TestBuildSessionShape_ImplicitFallback pins the inverse: when no
+// --session was given and the resolver fails, we still return a
+// fallback report (no error) so agents on non-Claude-Code harnesses
+// can call the command without crashing.
+func TestBuildSessionShape_ImplicitFallback(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("CLAUDE_CODE_SESSION_ID", "")
+	t.Setenv("CLAUDECODE", "0")
+
+	report, err := buildSessionShape("")
+	if err != nil {
+		t.Fatalf("implicit fallback should not error: %v", err)
+	}
+	if !report.FallbackUsed {
+		t.Error("expected FallbackUsed=true")
+	}
+	if report.Agent != "unknown" {
+		t.Errorf("Agent = %q, want unknown", report.Agent)
+	}
+}

--- a/internal/cli/claudecode.go
+++ b/internal/cli/claudecode.go
@@ -19,8 +19,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -89,8 +91,13 @@ type jsonlLine struct {
 	GitBranch string `json:"gitBranch"`
 	Version   string `json:"version"`
 	Message   *struct {
-		Usage   *rawUsage         `json:"usage"`
-		Content []json.RawMessage `json:"content"`
+		Usage *rawUsage `json:"usage"`
+		// Content is left as a raw blob (not []json.RawMessage) so a
+		// Claude Code schema variant that emits content as a string or
+		// object doesn't fail the whole line's decode and lose its
+		// type/timestamp/version/usage data. The tool-use scan
+		// re-decodes Content as an array on a best-effort basis.
+		Content json.RawMessage `json:"content"`
 	} `json:"message"`
 }
 
@@ -122,76 +129,41 @@ func ParseSessionJSONL(path string) (*SessionMetrics, error) {
 		MessageCounts: map[string]int64{},
 	}
 
-	// Lines can be large (full prompt + content blocks). 8 MB is well
-	// above any single observed line; bump if Claude Code starts
-	// embedding bigger blobs.
-	scanner := bufio.NewScanner(f)
-	scanner.Buffer(make([]byte, 64*1024), 8*1024*1024)
+	// bufio.Reader instead of bufio.Scanner: Scanner has a hard
+	// per-line cap (MaxScanTokenSize, defaults 64 KiB, bumped to
+	// 8 MiB before) and a single oversized record — e.g. an inline
+	// file attachment — would kill the whole command with
+	// "bufio.Scanner: token too long." ReadBytes('\n') has no length
+	// cap; oversized lines still parse via json.Unmarshal since
+	// encoding/json has no size limit either.
+	reader := bufio.NewReaderSize(f, 64*1024)
 
-	for scanner.Scan() {
-		m.Lines++
-		raw := scanner.Bytes()
-		var line jsonlLine
-		if err := json.Unmarshal(raw, &line); err != nil {
-			// unparseable line — still counted in lines/bytes.
-			continue
-		}
-
-		// Message-count buckets. Anything outside the canonical
-		// user/assistant pair collapses into "other" so the schema
-		// stays stable across Claude Code releases.
-		switch line.Type {
-		case "user", "assistant":
-			m.MessageCounts[line.Type]++
-		case "":
-			m.MessageCounts["other"]++
-		default:
-			m.MessageCounts["other"]++
-		}
-
-		if line.Timestamp != "" {
-			if m.SessionStartedAt == "" {
-				m.SessionStartedAt = line.Timestamp
-			}
-			m.LastActivityAt = line.Timestamp
-		}
-		if line.CWD != "" {
-			m.CWD = line.CWD
-		}
-		if line.GitBranch != "" {
-			m.GitBranch = line.GitBranch
-		}
-		if line.Version != "" {
-			m.AgentVersion = line.Version
-		}
-
-		if line.Type == "assistant" && line.Message != nil {
-			// tool_invocations: count every tool_use block — a single
-			// assistant turn can issue multiple parallel tool calls
-			// (multiple content[] entries with type=tool_use), and the
-			// field name says invocations, not turns-with-any-tool-use.
-			for _, blob := range line.Message.Content {
-				var head struct {
-					Type string `json:"type"`
-				}
-				if err := json.Unmarshal(blob, &head); err == nil && head.Type == "tool_use" {
-					m.ToolInvocations++
+	for {
+		raw, err := reader.ReadBytes('\n')
+		if len(raw) > 0 {
+			m.Lines++
+			// Strip the trailing newline (and an optional \r) before
+			// parsing. encoding/json is tolerant of trailing whitespace
+			// but the strip keeps things tidy and matches the prior
+			// Scanner behavior.
+			trimmed := raw
+			if n := len(trimmed); n > 0 && trimmed[n-1] == '\n' {
+				trimmed = trimmed[:n-1]
+				if n2 := len(trimmed); n2 > 0 && trimmed[n2-1] == '\r' {
+					trimmed = trimmed[:n2-1]
 				}
 			}
-			if u := line.Message.Usage; u != nil {
-				m.HasUsage = true
-				m.Usage = &SessionUsage{
-					CacheRead:     u.CacheReadInputTokens,
-					CacheCreation: u.CacheCreationInputTokens,
-					Input:         u.InputTokens,
-					Output:        u.OutputTokens,
-					TotalPrompt:   u.CacheReadInputTokens + u.CacheCreationInputTokens + u.InputTokens,
-				}
+			if err := parseSessionLine(trimmed, m); err != nil {
+				// unparseable line — still counted in lines/bytes.
+				_ = err
 			}
 		}
-	}
-	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("scan session log: %w", err)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return nil, fmt.Errorf("read session log: %w", err)
+		}
 	}
 
 	if m.SessionStartedAt != "" && m.LastActivityAt != "" {
@@ -206,6 +178,80 @@ func ParseSessionJSONL(path string) (*SessionMetrics, error) {
 	}
 
 	return m, nil
+}
+
+// parseSessionLine decodes one JSONL record and folds its fields into
+// the running SessionMetrics. Returns an error only on decode failure;
+// callers should treat that as "skip this line, keep going."
+func parseSessionLine(raw []byte, m *SessionMetrics) error {
+	if len(raw) == 0 {
+		return nil
+	}
+	var line jsonlLine
+	if err := json.Unmarshal(raw, &line); err != nil {
+		return err
+	}
+
+	// Message-count buckets. Anything outside the canonical
+	// user/assistant pair collapses into "other" so the schema
+	// stays stable across Claude Code releases.
+	switch line.Type {
+	case "user", "assistant":
+		m.MessageCounts[line.Type]++
+	default:
+		m.MessageCounts["other"]++
+	}
+
+	if line.Timestamp != "" {
+		if m.SessionStartedAt == "" {
+			m.SessionStartedAt = line.Timestamp
+		}
+		m.LastActivityAt = line.Timestamp
+	}
+	if line.CWD != "" {
+		m.CWD = line.CWD
+	}
+	if line.GitBranch != "" {
+		m.GitBranch = line.GitBranch
+	}
+	if line.Version != "" {
+		m.AgentVersion = line.Version
+	}
+
+	if line.Type == "assistant" && line.Message != nil {
+		// tool_invocations: count every tool_use block — a single
+		// assistant turn can issue multiple parallel tool calls
+		// (multiple content[] entries with type=tool_use), and the
+		// field name says invocations, not turns-with-any-tool-use.
+		// Content may be array OR string OR object across Claude Code
+		// schema variants; only the array shape carries tool_use
+		// blocks. If the re-decode fails we skip tool counting but
+		// keep the line's other data (already folded in above).
+		if len(line.Message.Content) > 0 {
+			var blocks []json.RawMessage
+			if err := json.Unmarshal(line.Message.Content, &blocks); err == nil {
+				for _, blob := range blocks {
+					var head struct {
+						Type string `json:"type"`
+					}
+					if err := json.Unmarshal(blob, &head); err == nil && head.Type == "tool_use" {
+						m.ToolInvocations++
+					}
+				}
+			}
+		}
+		if u := line.Message.Usage; u != nil {
+			m.HasUsage = true
+			m.Usage = &SessionUsage{
+				CacheRead:     u.CacheReadInputTokens,
+				CacheCreation: u.CacheCreationInputTokens,
+				Input:         u.InputTokens,
+				Output:        u.OutputTokens,
+				TotalPrompt:   u.CacheReadInputTokens + u.CacheCreationInputTokens + u.InputTokens,
+			}
+		}
+	}
+	return nil
 }
 
 // ContextBudgetEntry maps an agent_version prefix to a context-window
@@ -275,6 +321,39 @@ type ResolveResult struct {
 // session log. Callers should switch to the IDEA-body sketch fallback.
 var ErrNoSession = errors.New("claude code session log not found")
 
+// ErrInvalidSessionID is returned when a session-ID-shaped input
+// contains path separators, `..`, or other characters that would
+// allow it to escape the projects-dir when joined as a filename
+// fragment. Caller-facing — `pad session shape` surfaces it directly.
+var ErrInvalidSessionID = errors.New("invalid session id")
+
+// sessionIDPattern matches the UUID-ish shapes Claude Code emits for
+// session IDs (e.g. "e8919313-e76d-420a-bffa-a4646d2d6a83"). We allow
+// hex + dashes generously rather than pinning to canonical UUID
+// length, because future agent versions may shift formats and the
+// goal here is a defense-in-depth filename-safety check, not strict
+// UUID enforcement.
+var sessionIDPattern = regexp.MustCompile(`^[0-9a-fA-F-]{8,}$`)
+
+// validateSessionID rejects values that would be unsafe to use as a
+// filename fragment under ~/.claude/projects/<slug>/. Path separators,
+// `..` segments, and anything that doesn't look UUID-ish trip this.
+func validateSessionID(id string) error {
+	if id == "" {
+		return fmt.Errorf("%w: empty", ErrInvalidSessionID)
+	}
+	if strings.ContainsAny(id, "/\\") {
+		return fmt.Errorf("%w: %q contains a path separator", ErrInvalidSessionID, id)
+	}
+	if id == "." || id == ".." || strings.Contains(id, "..") {
+		return fmt.Errorf("%w: %q contains '..'", ErrInvalidSessionID, id)
+	}
+	if !sessionIDPattern.MatchString(id) {
+		return fmt.Errorf("%w: %q is not a UUID-shaped session id", ErrInvalidSessionID, id)
+	}
+	return nil
+}
+
 // ResolveSessionLog walks the cascade described in IDEA-1491 to locate
 // the JSONL for the current session.
 func ResolveSessionLog(opts ResolveOptions) (*ResolveResult, error) {
@@ -300,7 +379,13 @@ func ResolveSessionLog(opts ResolveOptions) (*ResolveResult, error) {
 			}
 			return nil, fmt.Errorf("--session path %q not found", opts.ExplicitSession)
 		}
-		// Treat as session UUID — search across all project dirs.
+		// Treat as session UUID — validate shape before letting it
+		// become a filename fragment under ~/.claude/projects/<slug>/.
+		// Without this guard, `--session ../../../../../etc/foo` would
+		// escape the projects dir on the os.Stat candidate-check.
+		if err := validateSessionID(opts.ExplicitSession); err != nil {
+			return nil, err
+		}
 		path, err := findSessionByID(opts.ExplicitSession)
 		if err != nil {
 			return nil, err
@@ -310,6 +395,13 @@ func ResolveSessionLog(opts ResolveOptions) (*ResolveResult, error) {
 
 	// Tier 2: $CLAUDE_CODE_SESSION_ID + cwd-derived slug.
 	if id := os.Getenv("CLAUDE_CODE_SESSION_ID"); id != "" {
+		// Same defense as the flag-id branch: env vars are
+		// attacker-influenceable too (e.g. inherited from a parent
+		// process or a sourced .env), so the ID must pass shape
+		// validation before we join it into a filesystem path.
+		if err := validateSessionID(id); err != nil {
+			return nil, err
+		}
 		projectsDir, err := ClaudeCodeProjectsDir()
 		if err != nil {
 			return nil, err
@@ -419,16 +511,22 @@ func tailLineCWD(path string) string {
 		return ""
 	}
 	defer f.Close()
-	scanner := bufio.NewScanner(f)
-	scanner.Buffer(make([]byte, 64*1024), 8*1024*1024)
+	// Use bufio.Reader (no per-line size cap) for parity with
+	// ParseSessionJSONL — an oversized line shouldn't kill autodetect.
+	reader := bufio.NewReaderSize(f, 64*1024)
 	var lastCWD string
-	for scanner.Scan() {
-		var line jsonlLine
-		if err := json.Unmarshal(scanner.Bytes(), &line); err != nil {
-			continue
+	for {
+		raw, err := reader.ReadBytes('\n')
+		if len(raw) > 0 {
+			var line jsonlLine
+			if err := json.Unmarshal(raw, &line); err == nil {
+				if line.CWD != "" {
+					lastCWD = line.CWD
+				}
+			}
 		}
-		if line.CWD != "" {
-			lastCWD = line.CWD
+		if err != nil {
+			break
 		}
 	}
 	return lastCWD

--- a/internal/cli/claudecode.go
+++ b/internal/cli/claudecode.go
@@ -166,15 +166,16 @@ func ParseSessionJSONL(path string) (*SessionMetrics, error) {
 		}
 
 		if line.Type == "assistant" && line.Message != nil {
-			// tool_invocations: assistant turns that contain at least
-			// one tool_use block.
+			// tool_invocations: count every tool_use block — a single
+			// assistant turn can issue multiple parallel tool calls
+			// (multiple content[] entries with type=tool_use), and the
+			// field name says invocations, not turns-with-any-tool-use.
 			for _, blob := range line.Message.Content {
 				var head struct {
 					Type string `json:"type"`
 				}
 				if err := json.Unmarshal(blob, &head); err == nil && head.Type == "tool_use" {
 					m.ToolInvocations++
-					break
 				}
 			}
 			if u := line.Message.Usage; u != nil {

--- a/internal/cli/claudecode.go
+++ b/internal/cli/claudecode.go
@@ -1,0 +1,434 @@
+// Package cli — Claude Code session-shape helpers.
+//
+// This file is the pure-Go data layer for the `pad session shape` CLI
+// command (IDEA-1491). It provides:
+//
+//   - Project-slug derivation from a working directory, matching the
+//     scheme used by Claude Code under ~/.claude/projects/.
+//   - JSONL streaming parser that pulls byte / line / message-count /
+//     usage / metadata metrics off a session log.
+//   - Resolver that walks the cascade env-var → cwd-slug → autodetect
+//     to pick the JSONL for the current session.
+//   - A small per-agent-version context-budget lookup table.
+//
+// No external dependencies. Tests live alongside in claudecode_test.go.
+package cli
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// ClaudeCodeProjectSlug derives Claude Code's project-directory name
+// from an absolute cwd. The rule, verified against ~/.claude/projects/
+// listings on a live install: every '/' becomes '-' and every '.'
+// becomes '-' as well, with a leading '-' on the result.
+//
+// Examples:
+//
+//	/home/dave/Dev/docapp        -> -home-dave-Dev-docapp
+//	/home/dave/.clay/mates       -> -home-dave--clay-mates
+//	/home/dave/claude            -> -home-dave-claude
+//
+// The function does NOT lowercase — letter case is preserved per the
+// observed directory listing.
+func ClaudeCodeProjectSlug(cwd string) string {
+	r := strings.NewReplacer("/", "-", ".", "-")
+	return r.Replace(cwd)
+}
+
+// ClaudeCodeProjectsDir returns ~/.claude/projects, honoring $HOME.
+func ClaudeCodeProjectsDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home directory: %w", err)
+	}
+	return filepath.Join(home, ".claude", "projects"), nil
+}
+
+// SessionUsage is the token-accounting block lifted from the last
+// assistant-message line of a JSONL.
+type SessionUsage struct {
+	CacheRead     int64 `json:"cache_read"`
+	CacheCreation int64 `json:"cache_creation"`
+	Input         int64 `json:"input"`
+	Output        int64 `json:"output"`
+	TotalPrompt   int64 `json:"total_prompt"`
+}
+
+// SessionMetrics is the parsed-from-disk view of a Claude Code session
+// JSONL. Zero values mean "field never seen in the file."
+type SessionMetrics struct {
+	Bytes              int64
+	Lines              int64
+	SessionStartedAt   string
+	LastActivityAt     string
+	CWD                string
+	GitBranch          string
+	AgentVersion       string
+	MessageCounts      map[string]int64
+	ToolInvocations    int64
+	Usage              *SessionUsage
+	HasUsage           bool
+	ElapsedWallSeconds int64
+}
+
+// parseJSONLLine is the subset of a line we care about. Fields are
+// optional; the JSONL has many record types and we want the union.
+type jsonlLine struct {
+	Type      string `json:"type"`
+	Timestamp string `json:"timestamp"`
+	CWD       string `json:"cwd"`
+	GitBranch string `json:"gitBranch"`
+	Version   string `json:"version"`
+	Message   *struct {
+		Usage   *rawUsage         `json:"usage"`
+		Content []json.RawMessage `json:"content"`
+	} `json:"message"`
+}
+
+type rawUsage struct {
+	InputTokens              int64 `json:"input_tokens"`
+	OutputTokens             int64 `json:"output_tokens"`
+	CacheCreationInputTokens int64 `json:"cache_creation_input_tokens"`
+	CacheReadInputTokens     int64 `json:"cache_read_input_tokens"`
+}
+
+// ParseSessionJSONL reads a Claude Code session JSONL and returns the
+// aggregated metrics. Lines that fail to parse are silently skipped
+// (this matches Claude Code's own tolerance for partial writes / mixed
+// schemas across versions); the line and byte totals still include
+// them so the gross-size view stays accurate.
+func ParseSessionJSONL(path string) (*SessionMetrics, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, fmt.Errorf("stat session log: %w", err)
+	}
+	f, err := os.Open(path) //nolint:gosec // path is resolved from a controlled cascade
+	if err != nil {
+		return nil, fmt.Errorf("open session log: %w", err)
+	}
+	defer f.Close()
+
+	m := &SessionMetrics{
+		Bytes:         info.Size(),
+		MessageCounts: map[string]int64{},
+	}
+
+	// Lines can be large (full prompt + content blocks). 8 MB is well
+	// above any single observed line; bump if Claude Code starts
+	// embedding bigger blobs.
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 64*1024), 8*1024*1024)
+
+	for scanner.Scan() {
+		m.Lines++
+		raw := scanner.Bytes()
+		var line jsonlLine
+		if err := json.Unmarshal(raw, &line); err != nil {
+			// unparseable line — still counted in lines/bytes.
+			continue
+		}
+
+		// Message-count buckets. Anything outside the canonical
+		// user/assistant pair collapses into "other" so the schema
+		// stays stable across Claude Code releases.
+		switch line.Type {
+		case "user", "assistant":
+			m.MessageCounts[line.Type]++
+		case "":
+			m.MessageCounts["other"]++
+		default:
+			m.MessageCounts["other"]++
+		}
+
+		if line.Timestamp != "" {
+			if m.SessionStartedAt == "" {
+				m.SessionStartedAt = line.Timestamp
+			}
+			m.LastActivityAt = line.Timestamp
+		}
+		if line.CWD != "" {
+			m.CWD = line.CWD
+		}
+		if line.GitBranch != "" {
+			m.GitBranch = line.GitBranch
+		}
+		if line.Version != "" {
+			m.AgentVersion = line.Version
+		}
+
+		if line.Type == "assistant" && line.Message != nil {
+			// tool_invocations: assistant turns that contain at least
+			// one tool_use block.
+			for _, blob := range line.Message.Content {
+				var head struct {
+					Type string `json:"type"`
+				}
+				if err := json.Unmarshal(blob, &head); err == nil && head.Type == "tool_use" {
+					m.ToolInvocations++
+					break
+				}
+			}
+			if u := line.Message.Usage; u != nil {
+				m.HasUsage = true
+				m.Usage = &SessionUsage{
+					CacheRead:     u.CacheReadInputTokens,
+					CacheCreation: u.CacheCreationInputTokens,
+					Input:         u.InputTokens,
+					Output:        u.OutputTokens,
+					TotalPrompt:   u.CacheReadInputTokens + u.CacheCreationInputTokens + u.InputTokens,
+				}
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scan session log: %w", err)
+	}
+
+	if m.SessionStartedAt != "" && m.LastActivityAt != "" {
+		if a, errA := time.Parse(time.RFC3339, m.SessionStartedAt); errA == nil {
+			if b, errB := time.Parse(time.RFC3339, m.LastActivityAt); errB == nil {
+				m.ElapsedWallSeconds = int64(b.Sub(a).Seconds())
+				if m.ElapsedWallSeconds < 0 {
+					m.ElapsedWallSeconds = 0
+				}
+			}
+		}
+	}
+
+	return m, nil
+}
+
+// ContextBudgetEntry maps an agent_version prefix to a context-window
+// token budget.
+type ContextBudgetEntry struct {
+	Prefix string
+	Budget int64
+}
+
+// DefaultContextBudgets is the seed table. Per IDEA-1491 recon: Claude
+// Code 2.1.x on Claude 4.x has a 1M context window. Future agent
+// versions get new rows.
+//
+// Match semantics: longest prefix wins. Keep the table sorted in
+// descending prefix-length so the linear scan in LookupContextBudget
+// hits specifics before generics.
+var DefaultContextBudgets = []ContextBudgetEntry{
+	{Prefix: "2.1.", Budget: 1_000_000},
+}
+
+// LookupContextBudget returns the matching budget for an agent_version
+// string, or (0, false) when no prefix matches.
+func LookupContextBudget(agentVersion string) (int64, bool) {
+	for _, e := range DefaultContextBudgets {
+		if strings.HasPrefix(agentVersion, e.Prefix) {
+			return e.Budget, true
+		}
+	}
+	return 0, false
+}
+
+// ContextClass buckets a percentage according to the IDEA-1491 design:
+// <25% low, 25-55% moderate, 55-80% heavy, >80% dense.
+func ContextClass(pct float64) string {
+	switch {
+	case pct < 25:
+		return "low"
+	case pct < 55:
+		return "moderate"
+	case pct < 80:
+		return "heavy"
+	default:
+		return "dense"
+	}
+}
+
+// ResolveOptions controls the session-resolver cascade.
+type ResolveOptions struct {
+	// ExplicitSession is the value of --session. It may be an absolute
+	// path to a .jsonl file, or a session UUID to look up under
+	// ~/.claude/projects.
+	ExplicitSession string
+	// CWD overrides os.Getwd() — primarily for tests.
+	CWD string
+}
+
+// ResolveResult is the output of ResolveSessionLog.
+type ResolveResult struct {
+	Path      string
+	SessionID string
+	// Source describes which cascade tier matched, for debugging.
+	// One of: "flag-path", "flag-id", "env-id", "autodetect".
+	Source string
+}
+
+// ErrNoSession is returned when none of the cascade tiers locate a
+// session log. Callers should switch to the IDEA-body sketch fallback.
+var ErrNoSession = errors.New("claude code session log not found")
+
+// ResolveSessionLog walks the cascade described in IDEA-1491 to locate
+// the JSONL for the current session.
+func ResolveSessionLog(opts ResolveOptions) (*ResolveResult, error) {
+	cwd := opts.CWD
+	if cwd == "" {
+		c, err := os.Getwd()
+		if err != nil {
+			return nil, fmt.Errorf("getwd: %w", err)
+		}
+		cwd = c
+	}
+
+	// Tier 1: --session flag.
+	if opts.ExplicitSession != "" {
+		// Absolute path?
+		if filepath.IsAbs(opts.ExplicitSession) {
+			if info, err := os.Stat(opts.ExplicitSession); err == nil && !info.IsDir() {
+				return &ResolveResult{
+					Path:      opts.ExplicitSession,
+					SessionID: strings.TrimSuffix(filepath.Base(opts.ExplicitSession), ".jsonl"),
+					Source:    "flag-path",
+				}, nil
+			}
+			return nil, fmt.Errorf("--session path %q not found", opts.ExplicitSession)
+		}
+		// Treat as session UUID — search across all project dirs.
+		path, err := findSessionByID(opts.ExplicitSession)
+		if err != nil {
+			return nil, err
+		}
+		return &ResolveResult{Path: path, SessionID: opts.ExplicitSession, Source: "flag-id"}, nil
+	}
+
+	// Tier 2: $CLAUDE_CODE_SESSION_ID + cwd-derived slug.
+	if id := os.Getenv("CLAUDE_CODE_SESSION_ID"); id != "" {
+		projectsDir, err := ClaudeCodeProjectsDir()
+		if err != nil {
+			return nil, err
+		}
+		slug := ClaudeCodeProjectSlug(cwd)
+		candidate := filepath.Join(projectsDir, slug, id+".jsonl")
+		if _, err := os.Stat(candidate); err == nil {
+			return &ResolveResult{Path: candidate, SessionID: id, Source: "env-id"}, nil
+		}
+		// Fall through — the env var may name a session in a different
+		// project (e.g. when cwd has shifted mid-session).
+		if path, err := findSessionByID(id); err == nil {
+			return &ResolveResult{Path: path, SessionID: id, Source: "env-id"}, nil
+		}
+	}
+
+	// Tier 3: autodetect when running inside Claude Code.
+	if os.Getenv("CLAUDECODE") == "1" {
+		path, id, err := autodetectSessionLog(cwd)
+		if err == nil {
+			return &ResolveResult{Path: path, SessionID: id, Source: "autodetect"}, nil
+		}
+	}
+
+	return nil, ErrNoSession
+}
+
+func findSessionByID(id string) (string, error) {
+	projectsDir, err := ClaudeCodeProjectsDir()
+	if err != nil {
+		return "", err
+	}
+	entries, err := os.ReadDir(projectsDir)
+	if err != nil {
+		return "", fmt.Errorf("read projects dir: %w", err)
+	}
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		candidate := filepath.Join(projectsDir, e.Name(), id+".jsonl")
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate, nil
+		}
+	}
+	return "", fmt.Errorf("session %q: %w", id, ErrNoSession)
+}
+
+// autodetectSessionLog picks the most-recently-modified JSONL under
+// the cwd-slug directory whose last-line cwd matches the live cwd.
+// This is the "I'm running inside Claude Code but didn't get an env
+// var" path.
+func autodetectSessionLog(cwd string) (string, string, error) {
+	projectsDir, err := ClaudeCodeProjectsDir()
+	if err != nil {
+		return "", "", err
+	}
+	dir := filepath.Join(projectsDir, ClaudeCodeProjectSlug(cwd))
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return "", "", fmt.Errorf("read project slug dir %q: %w", dir, err)
+	}
+
+	type cand struct {
+		path  string
+		mtime time.Time
+	}
+	var candidates []cand
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".jsonl") {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil {
+			continue
+		}
+		candidates = append(candidates, cand{
+			path:  filepath.Join(dir, e.Name()),
+			mtime: info.ModTime(),
+		})
+	}
+	if len(candidates) == 0 {
+		return "", "", ErrNoSession
+	}
+	sort.Slice(candidates, func(i, j int) bool {
+		return candidates[i].mtime.After(candidates[j].mtime)
+	})
+
+	for _, c := range candidates {
+		if lastCWD := tailLineCWD(c.path); lastCWD == cwd {
+			id := strings.TrimSuffix(filepath.Base(c.path), ".jsonl")
+			return c.path, id, nil
+		}
+	}
+	// No cwd match — fall back to most-recent.
+	c := candidates[0]
+	id := strings.TrimSuffix(filepath.Base(c.path), ".jsonl")
+	return c.path, id, nil
+}
+
+// tailLineCWD reads the last parseable line of a JSONL and returns the
+// cwd field (or ""). Used for autodetect's cwd match. Streams (no
+// full-file read) so it stays cheap for multi-MB session logs.
+func tailLineCWD(path string) string {
+	f, err := os.Open(path) //nolint:gosec // path enumerated from projectsDir we control
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 64*1024), 8*1024*1024)
+	var lastCWD string
+	for scanner.Scan() {
+		var line jsonlLine
+		if err := json.Unmarshal(scanner.Bytes(), &line); err != nil {
+			continue
+		}
+		if line.CWD != "" {
+			lastCWD = line.CWD
+		}
+	}
+	return lastCWD
+}

--- a/internal/cli/claudecode_test.go
+++ b/internal/cli/claudecode_test.go
@@ -1,0 +1,260 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestClaudeCodeProjectSlug(t *testing.T) {
+	cases := []struct {
+		cwd  string
+		want string
+	}{
+		// Live-directory-listing-verified rules.
+		{"/home/dave/Dev/docapp", "-home-dave-Dev-docapp"},
+		{"/home/dave/claude", "-home-dave-claude"},
+		{"/home/dave/.clay/mates", "-home-dave--clay-mates"},
+		{"/home/dave/Dev/docapp-session-shape", "-home-dave-Dev-docapp-session-shape"},
+		{"/", "-"},
+	}
+	for _, c := range cases {
+		t.Run(c.cwd, func(t *testing.T) {
+			got := ClaudeCodeProjectSlug(c.cwd)
+			if got != c.want {
+				t.Fatalf("slug(%q) = %q, want %q", c.cwd, got, c.want)
+			}
+		})
+	}
+}
+
+func TestParseSessionJSONL_Normal(t *testing.T) {
+	m, err := ParseSessionJSONL("testdata/sessions/normal.jsonl")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if m.Lines != 8 {
+		t.Errorf("Lines = %d, want 8", m.Lines)
+	}
+	if m.MessageCounts["user"] != 2 {
+		t.Errorf("user count = %d, want 2", m.MessageCounts["user"])
+	}
+	if m.MessageCounts["assistant"] != 3 {
+		t.Errorf("assistant count = %d, want 3", m.MessageCounts["assistant"])
+	}
+	if m.MessageCounts["other"] != 3 {
+		t.Errorf("other count = %d, want 3 (custom-title + attachment + queue-operation)", m.MessageCounts["other"])
+	}
+	if m.ToolInvocations != 2 {
+		t.Errorf("tool_invocations = %d, want 2", m.ToolInvocations)
+	}
+	if m.AgentVersion != "2.1.132" {
+		t.Errorf("AgentVersion = %q, want 2.1.132", m.AgentVersion)
+	}
+	if m.CWD != "/home/test/proj" {
+		t.Errorf("CWD = %q", m.CWD)
+	}
+	if m.GitBranch != "main" {
+		t.Errorf("GitBranch = %q", m.GitBranch)
+	}
+	if !m.HasUsage || m.Usage == nil {
+		t.Fatalf("expected usage on last assistant line")
+	}
+	// Last assistant line's usage wins.
+	if m.Usage.CacheRead != 12345 {
+		t.Errorf("Usage.CacheRead = %d, want 12345", m.Usage.CacheRead)
+	}
+	if m.Usage.TotalPrompt != 12345+50+1 {
+		t.Errorf("TotalPrompt = %d, want %d", m.Usage.TotalPrompt, 12345+50+1)
+	}
+	if m.SessionStartedAt != "2026-05-16T10:00:00Z" {
+		t.Errorf("SessionStartedAt = %q", m.SessionStartedAt)
+	}
+	if m.LastActivityAt != "2026-05-16T10:02:00Z" {
+		t.Errorf("LastActivityAt = %q", m.LastActivityAt)
+	}
+	if m.ElapsedWallSeconds != 120 {
+		t.Errorf("ElapsedWallSeconds = %d, want 120", m.ElapsedWallSeconds)
+	}
+}
+
+func TestParseSessionJSONL_NoUsage(t *testing.T) {
+	m, err := ParseSessionJSONL("testdata/sessions/no_usage.jsonl")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if m.HasUsage {
+		t.Error("expected HasUsage=false")
+	}
+	if m.Usage != nil {
+		t.Error("expected nil Usage")
+	}
+	if m.Lines != 2 {
+		t.Errorf("Lines = %d, want 2", m.Lines)
+	}
+}
+
+func TestParseSessionJSONL_Sidechain(t *testing.T) {
+	// v1: sidechain lines are still counted in totals (not separately
+	// segregated). The parent's last-usage wins regardless of
+	// isSidechain ordering — but here the parent's assistant line is
+	// last, so it should win.
+	m, err := ParseSessionJSONL("testdata/sessions/sidechain.jsonl")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if m.Lines != 3 {
+		t.Errorf("Lines = %d, want 3", m.Lines)
+	}
+	if m.Usage == nil || m.Usage.CacheRead != 3000 {
+		t.Fatalf("expected parent's CacheRead=3000, got %+v", m.Usage)
+	}
+}
+
+func TestLookupContextBudget(t *testing.T) {
+	cases := []struct {
+		ver  string
+		want int64
+		ok   bool
+	}{
+		{"2.1.132", 1_000_000, true},
+		{"2.1.200", 1_000_000, true},
+		{"2.0.99", 0, false},
+		{"", 0, false},
+		{"3.0.0", 0, false},
+	}
+	for _, c := range cases {
+		t.Run(c.ver, func(t *testing.T) {
+			got, ok := LookupContextBudget(c.ver)
+			if ok != c.ok || got != c.want {
+				t.Fatalf("LookupContextBudget(%q) = (%d,%v), want (%d,%v)", c.ver, got, ok, c.want, c.ok)
+			}
+		})
+	}
+}
+
+func TestContextClass(t *testing.T) {
+	cases := []struct {
+		pct  float64
+		want string
+	}{
+		{0, "low"},
+		{24.9, "low"},
+		{25, "moderate"},
+		{54.9, "moderate"},
+		{55, "heavy"},
+		{79.9, "heavy"},
+		{80, "dense"},
+		{99.9, "dense"},
+	}
+	for _, c := range cases {
+		if got := ContextClass(c.pct); got != c.want {
+			t.Errorf("ContextClass(%v) = %q, want %q", c.pct, got, c.want)
+		}
+	}
+}
+
+func TestResolveSessionLog_ExplicitPath(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "abc.jsonl")
+	if err := os.WriteFile(p, []byte(`{"type":"user"}`+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := ResolveSessionLog(ResolveOptions{ExplicitSession: p})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Path != p {
+		t.Errorf("Path = %q, want %q", got.Path, p)
+	}
+	if got.Source != "flag-path" {
+		t.Errorf("Source = %q, want flag-path", got.Source)
+	}
+	if got.SessionID != "abc" {
+		t.Errorf("SessionID = %q", got.SessionID)
+	}
+}
+
+func TestResolveSessionLog_EnvID(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("CLAUDE_CODE_SESSION_ID", "feedface")
+	t.Setenv("CLAUDECODE", "0")
+
+	cwd := "/work/myproj"
+	slug := ClaudeCodeProjectSlug(cwd)
+	projDir := filepath.Join(home, ".claude", "projects", slug)
+	if err := os.MkdirAll(projDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	logPath := filepath.Join(projDir, "feedface.jsonl")
+	if err := os.WriteFile(logPath, []byte(`{"type":"user"}`+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := ResolveSessionLog(ResolveOptions{CWD: cwd})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Path != logPath {
+		t.Errorf("Path = %q, want %q", got.Path, logPath)
+	}
+	if got.Source != "env-id" {
+		t.Errorf("Source = %q, want env-id", got.Source)
+	}
+}
+
+func TestResolveSessionLog_AutodetectByCWD(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("CLAUDE_CODE_SESSION_ID", "")
+	t.Setenv("CLAUDECODE", "1")
+
+	cwd := "/work/auto"
+	slug := ClaudeCodeProjectSlug(cwd)
+	projDir := filepath.Join(home, ".claude", "projects", slug)
+	if err := os.MkdirAll(projDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	// Two candidate logs — older one matches cwd; newer one does NOT.
+	// We expect the cwd-matching one to be picked even though it has
+	// an older mtime.
+	matchPath := filepath.Join(projDir, "match.jsonl")
+	mismatchPath := filepath.Join(projDir, "mismatch.jsonl")
+	if err := os.WriteFile(matchPath, []byte(`{"type":"user","cwd":"`+cwd+`"}`+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(mismatchPath, []byte(`{"type":"user","cwd":"/somewhere/else"}`+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// Make mismatch newer.
+	future := time.Now().Add(time.Hour)
+	if err := os.Chtimes(mismatchPath, future, future); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := ResolveSessionLog(ResolveOptions{CWD: cwd})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Path != matchPath {
+		t.Errorf("Path = %q, want %q", got.Path, matchPath)
+	}
+	if got.Source != "autodetect" {
+		t.Errorf("Source = %q, want autodetect", got.Source)
+	}
+}
+
+func TestResolveSessionLog_FallbackOnMissing(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("CLAUDE_CODE_SESSION_ID", "")
+	t.Setenv("CLAUDECODE", "0")
+
+	_, err := ResolveSessionLog(ResolveOptions{CWD: "/nope"})
+	if err == nil {
+		t.Fatal("expected ErrNoSession")
+	}
+}

--- a/internal/cli/claudecode_test.go
+++ b/internal/cli/claudecode_test.go
@@ -46,8 +46,11 @@ func TestParseSessionJSONL_Normal(t *testing.T) {
 	if m.MessageCounts["other"] != 3 {
 		t.Errorf("other count = %d, want 3 (custom-title + attachment + queue-operation)", m.MessageCounts["other"])
 	}
-	if m.ToolInvocations != 2 {
-		t.Errorf("tool_invocations = %d, want 2", m.ToolInvocations)
+	// One tool_use in turn 2, three parallel tool_use blocks in the
+	// final assistant turn = 4 invocations. Pins the multi-tool-per-turn
+	// counting behavior fixed in Codex R1 P2.
+	if m.ToolInvocations != 4 {
+		t.Errorf("tool_invocations = %d, want 4", m.ToolInvocations)
 	}
 	if m.AgentVersion != "2.1.132" {
 		t.Errorf("AgentVersion = %q, want 2.1.132", m.AgentVersion)

--- a/internal/cli/claudecode_test.go
+++ b/internal/cli/claudecode_test.go
@@ -1,8 +1,10 @@
 package cli
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -259,5 +261,132 @@ func TestResolveSessionLog_FallbackOnMissing(t *testing.T) {
 	_, err := ResolveSessionLog(ResolveOptions{CWD: "/nope"})
 	if err == nil {
 		t.Fatal("expected ErrNoSession")
+	}
+}
+
+// TestResolveSessionLog_RejectsPathTraversal pins the Codex R2 P1 fix:
+// session-ID-shaped input that contains '..', '/', '\\', or doesn't
+// match the UUID-ish shape is rejected before it can become a
+// filename fragment under ~/.claude/projects/<slug>/.
+func TestResolveSessionLog_RejectsPathTraversal(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("CLAUDECODE", "0")
+
+	bad := []string{
+		"../../../../../tmp/foo",
+		"../escape",
+		"foo/bar",
+		`foo\bar`,
+		"..",
+		".",
+		"",
+		"not-a-uuid!",
+		"abc..def",
+	}
+	for _, id := range bad {
+		t.Run("flag-id/"+id, func(t *testing.T) {
+			_, err := ResolveSessionLog(ResolveOptions{ExplicitSession: id, CWD: "/work"})
+			if err == nil {
+				t.Fatalf("expected error for --session %q", id)
+			}
+			if id != "" && !errors.Is(err, ErrInvalidSessionID) {
+				t.Fatalf("err = %v, want ErrInvalidSessionID", err)
+			}
+		})
+		if id == "" {
+			// Env-var case: empty string is treated as "not set" and
+			// would fall through to autodetect, not validation.
+			continue
+		}
+		t.Run("env-id/"+id, func(t *testing.T) {
+			t.Setenv("CLAUDE_CODE_SESSION_ID", id)
+			_, err := ResolveSessionLog(ResolveOptions{CWD: "/work"})
+			if err == nil {
+				t.Fatalf("expected error for env %q", id)
+			}
+			if !errors.Is(err, ErrInvalidSessionID) {
+				t.Fatalf("err = %v, want ErrInvalidSessionID", err)
+			}
+		})
+	}
+}
+
+// TestParseSessionJSONL_OversizedLine pins the Codex R2 P2-Scanner fix:
+// a single record larger than the old bufio.Scanner cap (8 MiB) must
+// parse cleanly instead of failing the whole command with
+// "bufio.Scanner: token too long."
+func TestParseSessionJSONL_OversizedLine(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "big.jsonl")
+	// 10 MiB of inline-attachment-shaped content. Building the JSON by
+	// hand to avoid any encoding-overhead surprise; the text inside the
+	// string is benign ASCII so JSON quoting stays minimal.
+	huge := strings.Repeat("x", 10*1024*1024)
+	body := `{"type":"assistant","timestamp":"2026-05-16T00:00:00Z","version":"2.1.132","message":{"content":[{"type":"text","text":"` + huge + `"}],"usage":{"input_tokens":1,"cache_creation_input_tokens":2,"cache_read_input_tokens":3,"output_tokens":4}}}` + "\n"
+	body += `{"type":"user","timestamp":"2026-05-16T00:00:01Z","message":{"content":[{"type":"text","text":"after"}]}}` + "\n"
+	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	m, err := ParseSessionJSONL(p)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if m.Lines != 2 {
+		t.Errorf("Lines = %d, want 2", m.Lines)
+	}
+	if !m.HasUsage || m.Usage == nil || m.Usage.CacheRead != 3 {
+		t.Errorf("expected usage with cache_read=3, got %+v", m.Usage)
+	}
+	if m.MessageCounts["assistant"] != 1 || m.MessageCounts["user"] != 1 {
+		t.Errorf("message counts = %v", m.MessageCounts)
+	}
+}
+
+// TestParseSessionJSONL_NonArrayContent pins the Codex R2 P2-content
+// fix: a line whose message.content is a string (or any non-array)
+// must still contribute its type/timestamp/version/usage to the
+// metrics — only the tool_use scan is skipped.
+func TestParseSessionJSONL_NonArrayContent(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "variant.jsonl")
+	body := `{"type":"assistant","timestamp":"2026-05-16T00:00:00Z","version":"2.1.999","message":{"content":"just a string","usage":{"input_tokens":7,"cache_creation_input_tokens":11,"cache_read_input_tokens":13,"output_tokens":17}}}` + "\n"
+	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	m, err := ParseSessionJSONL(p)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if m.MessageCounts["assistant"] != 1 {
+		t.Errorf("expected assistant count 1, got %v", m.MessageCounts)
+	}
+	if m.AgentVersion != "2.1.999" {
+		t.Errorf("AgentVersion = %q, want 2.1.999", m.AgentVersion)
+	}
+	if !m.HasUsage || m.Usage == nil || m.Usage.CacheRead != 13 {
+		t.Errorf("expected usage with cache_read=13, got %+v", m.Usage)
+	}
+	if m.ToolInvocations != 0 {
+		t.Errorf("ToolInvocations = %d, want 0 (non-array content)", m.ToolInvocations)
+	}
+}
+
+// TestParseSessionJSONL_ParallelToolUse pins the Codex R1 P2 fix.
+// (Already exercised via normal.jsonl, repeated here as a tight,
+// hermetic check with a single line.)
+func TestParseSessionJSONL_ParallelToolUse(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "parallel.jsonl")
+	body := `{"type":"assistant","timestamp":"2026-05-16T00:00:00Z","version":"2.1.132","message":{"content":[{"type":"tool_use","name":"a"},{"type":"tool_use","name":"b"},{"type":"tool_use","name":"c"},{"type":"text","text":"k"}]}}` + "\n"
+	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	m, err := ParseSessionJSONL(p)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if m.ToolInvocations != 3 {
+		t.Errorf("ToolInvocations = %d, want 3", m.ToolInvocations)
 	}
 }

--- a/internal/cli/testdata/sessions/no_usage.jsonl
+++ b/internal/cli/testdata/sessions/no_usage.jsonl
@@ -1,0 +1,2 @@
+{"type":"custom-title","customTitle":"short"}
+{"type":"user","timestamp":"2026-05-16T11:00:00Z","cwd":"/home/test/p2","gitBranch":"feat","version":"2.1.132","message":{"content":[{"type":"text","text":"start"}]}}

--- a/internal/cli/testdata/sessions/normal.jsonl
+++ b/internal/cli/testdata/sessions/normal.jsonl
@@ -5,4 +5,4 @@
 {"type":"user","timestamp":"2026-05-16T10:01:00Z","message":{"content":[{"type":"text","text":"again"}]}}
 {"type":"assistant","timestamp":"2026-05-16T10:01:10Z","cwd":"/home/test/proj","gitBranch":"main","version":"2.1.132","message":{"content":[{"type":"tool_use","name":"bash"},{"type":"text","text":"running"}],"usage":{"input_tokens":12,"cache_creation_input_tokens":150,"cache_read_input_tokens":7500,"output_tokens":20}}}
 {"type":"queue-operation","timestamp":"2026-05-16T10:01:11Z"}
-{"type":"assistant","timestamp":"2026-05-16T10:02:00Z","cwd":"/home/test/proj","gitBranch":"main","version":"2.1.132","message":{"content":[{"type":"tool_use","name":"read"}],"usage":{"input_tokens":1,"cache_creation_input_tokens":50,"cache_read_input_tokens":12345,"output_tokens":3}}}
+{"type":"assistant","timestamp":"2026-05-16T10:02:00Z","cwd":"/home/test/proj","gitBranch":"main","version":"2.1.132","message":{"content":[{"type":"tool_use","name":"read"},{"type":"tool_use","name":"grep"},{"type":"tool_use","name":"bash"}],"usage":{"input_tokens":1,"cache_creation_input_tokens":50,"cache_read_input_tokens":12345,"output_tokens":3}}}

--- a/internal/cli/testdata/sessions/normal.jsonl
+++ b/internal/cli/testdata/sessions/normal.jsonl
@@ -1,0 +1,8 @@
+{"type":"custom-title","customTitle":"test","sessionId":"abc"}
+{"type":"user","timestamp":"2026-05-16T10:00:00Z","cwd":"/home/test/proj","gitBranch":"main","version":"2.1.132","message":{"content":[{"type":"text","text":"hi"}]}}
+{"type":"assistant","timestamp":"2026-05-16T10:00:05Z","cwd":"/home/test/proj","gitBranch":"main","version":"2.1.132","message":{"content":[{"type":"text","text":"hello"}],"usage":{"input_tokens":10,"cache_creation_input_tokens":200,"cache_read_input_tokens":5000,"output_tokens":15}}}
+{"type":"attachment","timestamp":"2026-05-16T10:00:10Z"}
+{"type":"user","timestamp":"2026-05-16T10:01:00Z","message":{"content":[{"type":"text","text":"again"}]}}
+{"type":"assistant","timestamp":"2026-05-16T10:01:10Z","cwd":"/home/test/proj","gitBranch":"main","version":"2.1.132","message":{"content":[{"type":"tool_use","name":"bash"},{"type":"text","text":"running"}],"usage":{"input_tokens":12,"cache_creation_input_tokens":150,"cache_read_input_tokens":7500,"output_tokens":20}}}
+{"type":"queue-operation","timestamp":"2026-05-16T10:01:11Z"}
+{"type":"assistant","timestamp":"2026-05-16T10:02:00Z","cwd":"/home/test/proj","gitBranch":"main","version":"2.1.132","message":{"content":[{"type":"tool_use","name":"read"}],"usage":{"input_tokens":1,"cache_creation_input_tokens":50,"cache_read_input_tokens":12345,"output_tokens":3}}}

--- a/internal/cli/testdata/sessions/sidechain.jsonl
+++ b/internal/cli/testdata/sessions/sidechain.jsonl
@@ -1,0 +1,3 @@
+{"type":"user","timestamp":"2026-05-16T12:00:00Z","cwd":"/home/test/p3","version":"2.1.132","message":{"content":[{"type":"text","text":"go"}]}}
+{"type":"assistant","timestamp":"2026-05-16T12:00:01Z","isSidechain":true,"cwd":"/home/test/p3","version":"2.1.132","message":{"content":[{"type":"text","text":"sub"}],"usage":{"input_tokens":1,"cache_creation_input_tokens":10,"cache_read_input_tokens":100,"output_tokens":2}}}
+{"type":"assistant","timestamp":"2026-05-16T12:00:02Z","cwd":"/home/test/p3","version":"2.1.132","message":{"content":[{"type":"text","text":"parent"}],"usage":{"input_tokens":2,"cache_creation_input_tokens":20,"cache_read_input_tokens":3000,"output_tokens":4}}}


### PR DESCRIPTION
## Summary
- New `pad session shape [--session <id|path>] [--format json|table|markdown]` CLI command that reads the active Claude Code session JSONL and reports tokens, context %, message counts, and elapsed time.
- Default format is JSON (agents are the primary caller); class buckets are `low` / `moderate` / `heavy` / `dense`.
- Per-agent-version budget table (seeded `2.1.* → 1M tokens`); falls back to `agent: "unknown"` cleanly on non-Claude-Code harnesses.

## Plus
- `context_pct` numerator is `cache_read + cache_creation + input` (full prompt) — accurate at turn boundaries with new content, not just steady-state cache_read.
- Path-traversal hardening on `--session` / `$CLAUDE_CODE_SESSION_ID` inputs (validates UUID-shape; rejects separators).
- JSONL parser tolerates oversized lines (no 8 MiB Scanner cap) and schema variants where `message.content` is non-array.
- Explicit `--session` failures error out; only autodetect/env-var misses fall back.

## Observable behavior changes
None (additive command). Side-effect-free; never echoes prompt content, only metrics.

## Test plan
- [x] `go test ./...` — green
- [x] `golangci-lint run ./...` — clean
- [x] `make build` — green
- [x] Manual smoke against live Claude Code session — `context_pct` plausible and matches independent measurement within ~1%
- [x] Path-traversal adversarial smoke (`./pad session shape --session '../../../etc/passwd'`) — rejected with explicit error
- [x] 3 codex review rounds converged clean

## Refs
- IDEA-1491 (docapp workspace) — design + recon comments
- DECIS-57 (claude workspace) — the operationalization this command formalizes
- HANDO-58 day-9 — origin recon