### PR TITLE
feat(server): refuse to mark item terminal while it has open children (IDEA-1494)

### DIFF
--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -3392,6 +3392,7 @@ func updateCmd() *cobra.Command {
 		tags       string
 		fieldFlags []string
 		comment    string
+		force      bool
 	)
 
 	cmd := &cobra.Command{
@@ -3441,6 +3442,9 @@ Examples:
 			}
 			if comment != "" {
 				input.Comment = &comment
+			}
+			if force {
+				input.Force = true
 			}
 
 			// Merge field changes with existing fields
@@ -3529,6 +3533,23 @@ Examples:
 
 			updated, err := client.UpdateItem(ws, slug, input)
 			if err != nil {
+				// IDEA-1494: render the open-children list when the
+				// server rejected the transition because the item has
+				// non-terminal children. The detailed list comes from
+				// the same structured payload MCP clients consume so
+				// the human and machine views agree.
+				if apiErr, ok := err.(*cli.APIError); ok {
+					if oc := apiErr.AsOpenChildren(); oc != nil {
+						fmt.Fprintln(os.Stderr, apiErr.Message)
+						for _, c := range oc.OpenChildren {
+							fmt.Fprintf(os.Stderr, "  %s — %s (status=%s)\n", c.Ref, c.Title, c.Status)
+						}
+						fmt.Fprintln(os.Stderr, "Pass --force to override.")
+						// Return a bare error so cobra exits non-zero
+						// without re-printing the (now-rendered) details.
+						return fmt.Errorf("update rejected: open children present")
+					}
+				}
 				return err
 			}
 
@@ -3561,6 +3582,7 @@ Examples:
 	cmd.Flags().StringVar(&tags, "tags", "", "update tags (JSON array)")
 	cmd.Flags().StringArrayVarP(&fieldFlags, "field", "f", nil, "set arbitrary field (repeatable): --field key=value")
 	cmd.Flags().StringVar(&comment, "comment", "", "attach a comment explaining this update (e.g. why status changed)")
+	cmd.Flags().BoolVar(&force, "force", false, "override the open-children guard (allow marking the item terminal even if children are non-terminal)")
 
 	return cmd
 }
@@ -6478,6 +6500,7 @@ func bulkUpdateCmd() *cobra.Command {
 	var (
 		status   string
 		priority string
+		force    bool
 	)
 
 	cmd := &cobra.Command{
@@ -6553,6 +6576,7 @@ Examples:
 
 				input := models.ItemUpdate{
 					Fields: &fieldsStr,
+					Force:  force,
 				}
 
 				_, err = client.UpdateItem(ws, slug, input)
@@ -6594,6 +6618,7 @@ Examples:
 
 	cmd.Flags().StringVar(&status, "status", "", "set status for all items")
 	cmd.Flags().StringVar(&priority, "priority", "", "set priority for all items")
+	cmd.Flags().BoolVar(&force, "force", false, "override the open-children guard (allow marking items terminal even if children are non-terminal)")
 
 	return cmd
 }

--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -3540,11 +3540,7 @@ Examples:
 				// the human and machine views agree.
 				if apiErr, ok := err.(*cli.APIError); ok {
 					if oc := apiErr.AsOpenChildren(); oc != nil {
-						fmt.Fprintln(os.Stderr, apiErr.Message)
-						for _, c := range oc.OpenChildren {
-							fmt.Fprintf(os.Stderr, "  %s — %s (status=%s)\n", c.Ref, c.Title, c.Status)
-						}
-						fmt.Fprintln(os.Stderr, "Pass --force to override.")
+						cli.WriteOpenChildrenError(os.Stderr, apiErr, oc)
 						// Return a bare error so cobra exits non-zero
 						// without re-printing the (now-rendered) details.
 						return fmt.Errorf("update rejected: open children present")

--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -3640,6 +3640,7 @@ func deleteCmd() *cobra.Command {
 // --- move ---
 
 func moveCmd() *cobra.Command {
+	var force bool
 	cmd := &cobra.Command{
 		Use:   "move <ref> <target-collection>",
 		Short: "Move an item to a different collection",
@@ -3677,8 +3678,18 @@ Examples:
 				input["field_overrides"] = overrides
 			}
 
-			moved, err := client.MoveItem(ws, args[0], input)
+			moved, err := client.MoveItemWithForce(ws, args[0], input, force)
 			if err != nil {
+				// IDEA-1494 R3 P1: render the open-children rejection
+				// the same way the regular update path does, so
+				// `pad item move ... --field status=completed` against
+				// a plan with open children fails informatively.
+				if apiErr, ok := err.(*cli.APIError); ok {
+					if oc := apiErr.AsOpenChildren(); oc != nil {
+						cli.WriteOpenChildrenError(os.Stderr, apiErr, oc)
+						return fmt.Errorf("move rejected: open children present")
+					}
+				}
 				return err
 			}
 
@@ -3687,6 +3698,7 @@ Examples:
 		},
 	}
 	cmd.Flags().StringArray("field", nil, "set field values in target collection (key=value)")
+	cmd.Flags().BoolVar(&force, "force", false, "override the open-children guard when the move would write a terminal done-field value")
 	return cmd
 }
 
@@ -6530,9 +6542,17 @@ Examples:
 				Ref     string         `json:"ref"`
 				Applied map[string]any `json:"applied"`
 			}
+			// updateFailure carries the structured server error per row
+			// so MCP-driven agents see code + details (IDEA-1494 R3 P2).
+			// `Error` stays as the human-readable message for backward
+			// compatibility with non-MCP CLI consumers; `Code` and
+			// `Details` populate when the server returned a structured
+			// envelope (currently: only open_children rejections).
 			type updateFailure struct {
-				Ref   string `json:"ref"`
-				Error string `json:"error"`
+				Ref     string          `json:"ref"`
+				Error   string          `json:"error"`
+				Code    string          `json:"code,omitempty"`
+				Details json.RawMessage `json:"details,omitempty"`
 			}
 			updated := make([]updateResult, 0, len(args))
 			failed := make([]updateFailure, 0)
@@ -6577,10 +6597,37 @@ Examples:
 
 				_, err = client.UpdateItem(ws, slug, input)
 				if err != nil {
+					// IDEA-1494 R3 P2: preserve the structured server
+					// error per row so the JSON envelope (and any
+					// MCP-driven agent reading it) sees code +
+					// details — not just a flattened string. The
+					// human text output continues to show the bare
+					// message.
+					row := updateFailure{Ref: slug, Error: err.Error()}
+					if apiErr, ok := err.(*cli.APIError); ok && apiErr.Code != "" {
+						row.Code = apiErr.Code
+						if len(apiErr.Details) > 0 {
+							row.Details = apiErr.Details
+						}
+					}
 					if formatFlag != "json" {
 						fmt.Printf("  %s %s — %s\n", red.Sprint("✗"), slug, err)
+						// For open_children rejections also render the
+						// blocking-child list inline so the human
+						// reader doesn't have to switch to --format
+						// json to see what blocked.
+						if apiErr, ok := err.(*cli.APIError); ok {
+							if oc := apiErr.AsOpenChildren(); oc != nil {
+								for _, c := range oc.OpenChildren {
+									fmt.Printf("      %s — %s (status=%s)\n", c.Ref, c.Title, c.Status)
+								}
+								if oc.HiddenBlockerCount > 0 {
+									fmt.Printf("      (+%d hidden blocker(s) you don't have access to)\n", oc.HiddenBlockerCount)
+								}
+							}
+						}
 					}
-					failed = append(failed, updateFailure{Ref: slug, Error: err.Error()})
+					failed = append(failed, row)
 					continue
 				}
 

--- a/internal/cli/client.go
+++ b/internal/cli/client.go
@@ -202,8 +202,21 @@ func (c *Client) ListStarredItems(wsSlug string, includeTerminal bool) ([]models
 }
 
 func (c *Client) MoveItem(wsSlug, itemSlug string, input map[string]any) (*models.Item, error) {
+	return c.MoveItemWithForce(wsSlug, itemSlug, input, false)
+}
+
+// MoveItemWithForce is the open-children-guard-aware variant of
+// MoveItem (IDEA-1494 R3 P1). When `force` is true, the URL gets a
+// `?force=true` query so the server-side move handler skips the guard
+// and still records the collection + fields change. Same escape-hatch
+// semantics as `pad item update --force`.
+func (c *Client) MoveItemWithForce(wsSlug, itemSlug string, input map[string]any, force bool) (*models.Item, error) {
 	var result models.Item
-	return &result, c.post("/workspaces/"+wsSlug+"/items/"+itemSlug+"/move", input, &result)
+	path := "/workspaces/" + wsSlug + "/items/" + itemSlug + "/move"
+	if force {
+		path += "?force=true"
+	}
+	return &result, c.post(path, input, &result)
 }
 
 // --- Links ---
@@ -748,17 +761,33 @@ func (e *APIError) AsOpenChildren() *OpenChildrenDetails {
 	return &d
 }
 
-// OpenChildrenErrorMarker is the line prefix the CLI writes to stderr
-// when surfacing an open-children rejection (IDEA-1494 R2). The single
-// JSON line after the prefix carries the full structured error
-// envelope (code / message / details) so a downstream consumer — the
-// stdio MCP dispatcher's classifyExecError in particular — can detect
-// the rejection and lift the structured payload without parsing free-
-// form human text. The prefix is intentionally distinctive and
-// lowercase-kebab so matchers use a literal `strings.HasPrefix`
-// (no regex compilation needed) and so a human reader can ignore it
-// visually as obvious machine output.
-const OpenChildrenErrorMarker = "pad-error: "
+// StructuredErrorMarker is the versioned line prefix the CLI writes
+// to stderr when surfacing a structured error (currently: IDEA-1494's
+// open-children rejection). The JSON line that follows carries the
+// full server-style envelope (code / message / details) so a
+// downstream consumer — the stdio MCP dispatcher's classifyExecError
+// in particular — can detect the rejection and lift the structured
+// payload without parsing free-form human text.
+//
+// Versioned (Codex round-3 P3) so future evolutions of the wire shape
+// don't silently break older parsers — when the payload contract
+// changes incompatibly, bump to `pad-structured-error/v2:` and have
+// the classifier accept both during the transition. The version token
+// is parsed (not just matched as a literal prefix) so older v1-only
+// parsers cleanly ignore unknown versions.
+//
+// IMPORTANT: keep in lockstep with mcp.structuredErrorMarker / the
+// allow-list of structured codes in mcp.allowedStructuredErrorCodes.
+// A change here REQUIRES a corresponding change in
+// internal/mcp/errors.go.
+const StructuredErrorMarker = "pad-structured-error/v1: "
+
+// OpenChildrenErrorMarker is the pre-round-3 marker, retained as a
+// deprecated alias for any out-of-tree consumer that may have hard-
+// coded it. New code MUST use StructuredErrorMarker.
+//
+// Deprecated: use StructuredErrorMarker.
+const OpenChildrenErrorMarker = StructuredErrorMarker
 
 // WriteOpenChildrenError formats an open-children rejection to w in
 // the canonical two-track shape the project guarantees (IDEA-1494 R2):
@@ -784,7 +813,7 @@ func WriteOpenChildrenError(w io.Writer, apiErr *APIError, oc *OpenChildrenDetai
 		},
 	}
 	if data, err := json.Marshal(envelope); err == nil {
-		fmt.Fprintln(w, OpenChildrenErrorMarker+string(data))
+		fmt.Fprintln(w, StructuredErrorMarker+string(data))
 	}
 	fmt.Fprintln(w, apiErr.Message)
 	for _, c := range oc.OpenChildren {

--- a/internal/cli/client.go
+++ b/internal/cli/client.go
@@ -705,12 +705,46 @@ func (c *Client) GetAuditLog(params models.AuditLogParams) ([]models.Activity, e
 // --- HTTP helpers ---
 
 type APIError struct {
-	Code    string `json:"code"`
-	Message string `json:"message"`
+	Code    string          `json:"code"`
+	Message string          `json:"message"`
+	Details json.RawMessage `json:"details,omitempty"`
 }
 
 func (e *APIError) Error() string {
 	return e.Message
+}
+
+// OpenChildEntry mirrors the server-side openChildEntry payload returned
+// inside APIError.Details when Code == "open_children" (IDEA-1494). The
+// CLI renders its human error list from these entries; MCP-driven agents
+// can introspect the same data to self-recover.
+type OpenChildEntry struct {
+	Ref            string `json:"ref"`
+	Title          string `json:"title"`
+	Status         string `json:"status"`
+	CollectionSlug string `json:"collection_slug"`
+}
+
+// OpenChildrenDetails is the parsed shape of APIError.Details when
+// Code == "open_children".
+type OpenChildrenDetails struct {
+	OpenChildren   []OpenChildEntry `json:"open_children"`
+	DoneField      string           `json:"done_field"`
+	AttemptedValue string           `json:"attempted_value"`
+}
+
+// AsOpenChildren returns the parsed open-children details when this
+// APIError carries them, or nil otherwise. Returns nil for any error
+// other than "open_children" so callers can branch cleanly.
+func (e *APIError) AsOpenChildren() *OpenChildrenDetails {
+	if e == nil || e.Code != "open_children" || len(e.Details) == 0 {
+		return nil
+	}
+	var d OpenChildrenDetails
+	if err := json.Unmarshal(e.Details, &d); err != nil {
+		return nil
+	}
+	return &d
 }
 
 // --- Attachments ---

--- a/internal/cli/client.go
+++ b/internal/cli/client.go
@@ -728,9 +728,10 @@ type OpenChildEntry struct {
 // OpenChildrenDetails is the parsed shape of APIError.Details when
 // Code == "open_children".
 type OpenChildrenDetails struct {
-	OpenChildren   []OpenChildEntry `json:"open_children"`
-	DoneField      string           `json:"done_field"`
-	AttemptedValue string           `json:"attempted_value"`
+	OpenChildren       []OpenChildEntry `json:"open_children"`
+	HiddenBlockerCount int              `json:"hidden_blocker_count"`
+	DoneField          string           `json:"done_field"`
+	AttemptedValue     string           `json:"attempted_value"`
 }
 
 // AsOpenChildren returns the parsed open-children details when this
@@ -745,6 +746,58 @@ func (e *APIError) AsOpenChildren() *OpenChildrenDetails {
 		return nil
 	}
 	return &d
+}
+
+// OpenChildrenErrorMarker is the line prefix the CLI writes to stderr
+// when surfacing an open-children rejection (IDEA-1494 R2). The single
+// JSON line after the prefix carries the full structured error
+// envelope (code / message / details) so a downstream consumer — the
+// stdio MCP dispatcher's classifyExecError in particular — can detect
+// the rejection and lift the structured payload without parsing free-
+// form human text. The prefix is intentionally distinctive and
+// lowercase-kebab so matchers use a literal `strings.HasPrefix`
+// (no regex compilation needed) and so a human reader can ignore it
+// visually as obvious machine output.
+const OpenChildrenErrorMarker = "pad-error: "
+
+// WriteOpenChildrenError formats an open-children rejection to w in
+// the canonical two-track shape the project guarantees (IDEA-1494 R2):
+//
+//  1. A single `pad-error: {json}\n` line carrying the full structured
+//     payload — consumed by the MCP stdio classifier and anyone else
+//     wanting to introspect the rejection programmatically.
+//  2. Human-readable lines: the message, the per-child list (rendered
+//     from the SAME details struct the JSON line carries — single
+//     source of truth for both views), the hidden-count tag when
+//     applicable, and the `Pass --force to override` reminder.
+//
+// Order matters: machine line first so a consumer that reads stderr
+// line-by-line can dispatch on the first line without buffering all
+// of it. Callers should write nothing else between the marker line
+// and the human block.
+func WriteOpenChildrenError(w io.Writer, apiErr *APIError, oc *OpenChildrenDetails) {
+	envelope := map[string]any{
+		"error": map[string]any{
+			"code":    apiErr.Code,
+			"message": apiErr.Message,
+			"details": oc,
+		},
+	}
+	if data, err := json.Marshal(envelope); err == nil {
+		fmt.Fprintln(w, OpenChildrenErrorMarker+string(data))
+	}
+	fmt.Fprintln(w, apiErr.Message)
+	for _, c := range oc.OpenChildren {
+		fmt.Fprintf(w, "  %s — %s (status=%s)\n", c.Ref, c.Title, c.Status)
+	}
+	if oc.HiddenBlockerCount > 0 {
+		noun := "child"
+		if oc.HiddenBlockerCount != 1 {
+			noun = "children"
+		}
+		fmt.Fprintf(w, "  (+%d hidden %s you don't have access to)\n", oc.HiddenBlockerCount, noun)
+	}
+	fmt.Fprintln(w, "Pass --force to override.")
 }
 
 // --- Attachments ---

--- a/internal/mcp/catalog_item.go
+++ b/internal/mcp/catalog_item.go
@@ -145,6 +145,17 @@ var padItemSchemaParams = []ParamDef{
 	{Name: "reply_to", Type: "string", Description: "Parent comment ID for threading replies. Optional for: comment."},
 	{Name: "comment", Type: "string", Description: "Audit comment explaining the change. Optional for: update."},
 
+	// ── Guard override ── (IDEA-1494)
+	// update/bulk-update reject non-terminal → terminal done-field
+	// transitions while the item still has open (non-terminal)
+	// children, surfacing a 409 with code=open_children plus a
+	// machine-readable details.open_children array (one entry per
+	// blocking child: {ref, title, status, collection_slug}). Setting
+	// force=true skips the guard and still records the transition.
+	// The same flag exists on `pad item update --force` so the CLI
+	// and MCP escape hatches are identical.
+	{Name: "force", Type: "bool", Description: "Override the open-children guard. Optional for: update, bulk-update. When the server returns code=open_children, details.open_children lists the blocking child refs so an agent can ship them and retry — or set force=true if the children should be intentionally orphaned."},
+
 	// ── Notes / decisions ──
 	{Name: "summary", Type: "string", Description: "Short note headline. Required for: note."},
 	{Name: "details", Type: "string", Description: "Long-form note body. Optional for: note."},

--- a/internal/mcp/catalog_item.go
+++ b/internal/mcp/catalog_item.go
@@ -154,7 +154,7 @@ var padItemSchemaParams = []ParamDef{
 	// force=true skips the guard and still records the transition.
 	// The same flag exists on `pad item update --force` so the CLI
 	// and MCP escape hatches are identical.
-	{Name: "force", Type: "bool", Description: "Override the open-children guard. Optional for: update, bulk-update. When the server returns code=open_children, details.open_children lists the blocking child refs so an agent can ship them and retry — or set force=true if the children should be intentionally orphaned."},
+	{Name: "force", Type: "bool", Description: "Override the open-children guard. Optional for: update, bulk-update, move. When the server returns code=open_children, details.open_children lists the blocking child refs so an agent can ship them and retry — or set force=true if the children should be intentionally orphaned."},
 
 	// ── Notes / decisions ──
 	{Name: "summary", Type: "string", Description: "Short note headline. Required for: note."},

--- a/internal/mcp/catalog_item_force_test.go
+++ b/internal/mcp/catalog_item_force_test.go
@@ -1,0 +1,89 @@
+package mcp
+
+// IDEA-1494 — MCP-level coverage for the `force` parameter on
+// pad_item.action: update / bulk-update. Confirms the catalog's force
+// param translates into the `--force` CLI flag on the dispatched
+// command so the open-children guard's escape hatch is identical on
+// stdio MCP (ExecDispatcher) and the legacy CLI surface.
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestPadItemUpdate_ForcePassesThroughToCLI(t *testing.T) {
+	disp := &fakeDispatcher{}
+	env := ActionEnv{
+		Doc:        liveCmdhelpDoc(t),
+		Workspace:  NewWorkspaceState("docapp"),
+		Dispatcher: disp,
+	}
+
+	handler, ok := padItemTool.Actions["update"]
+	if !ok {
+		t.Fatal("pad_item.action: update is not registered")
+	}
+
+	if _, err := handler(context.Background(), map[string]any{
+		"ref":    "PLAN-5",
+		"status": "completed",
+		"force":  true,
+	}, env); err != nil {
+		t.Fatalf("dispatch error: %v", err)
+	}
+	if !equalStrings(disp.gotPath, []string{"item", "update"}) {
+		t.Fatalf("cmdPath = %v, want [item update]", disp.gotPath)
+	}
+	joined := strings.Join(disp.gotArgs, " ")
+	if !strings.Contains(joined, "--force") {
+		t.Errorf("cliArgs should contain '--force' when force=true; got %q", joined)
+	}
+	if !strings.Contains(joined, "--status completed") {
+		t.Errorf("cliArgs should preserve other flags; got %q", joined)
+	}
+}
+
+func TestPadItemUpdate_ForceFalse_Omitted(t *testing.T) {
+	disp := &fakeDispatcher{}
+	env := ActionEnv{
+		Doc:        liveCmdhelpDoc(t),
+		Workspace:  NewWorkspaceState("docapp"),
+		Dispatcher: disp,
+	}
+
+	handler := padItemTool.Actions["update"]
+	if _, err := handler(context.Background(), map[string]any{
+		"ref":    "PLAN-5",
+		"status": "completed",
+		"force":  false,
+	}, env); err != nil {
+		t.Fatalf("dispatch error: %v", err)
+	}
+	joined := strings.Join(disp.gotArgs, " ")
+	if strings.Contains(joined, "--force") {
+		t.Errorf("cliArgs should NOT contain '--force' when force=false; got %q", joined)
+	}
+}
+
+func TestPadItemBulkUpdate_ForcePassesThroughToCLI(t *testing.T) {
+	disp := &fakeDispatcher{}
+	env := ActionEnv{
+		Doc:        liveCmdhelpDoc(t),
+		Workspace:  NewWorkspaceState("docapp"),
+		Dispatcher: disp,
+	}
+
+	handler := padItemTool.Actions["bulk-update"]
+	if _, err := handler(context.Background(), map[string]any{
+		"refs":   []any{"TASK-1", "TASK-2"},
+		"status": "done",
+		"force":  true,
+	}, env); err != nil {
+		t.Fatalf("dispatch error: %v", err)
+	}
+	joined := strings.Join(disp.gotArgs, " ")
+	if !strings.Contains(joined, "--force") {
+		t.Errorf("cliArgs should contain '--force' for bulk-update force=true; got %q", joined)
+	}
+}

--- a/internal/mcp/catalog_readonly_test.go
+++ b/internal/mcp/catalog_readonly_test.go
@@ -463,11 +463,16 @@ func liveCmdhelpDoc(t *testing.T) *cmdhelp.Document {
 			"item update": {
 				Summary: "update item",
 				Args:    mkArgs("ref"),
-				Flags: mkFlags(
-					"workspace", "assign", "category", "comment", "content",
-					"field", "parent", "priority", "role", "status",
-					"tags", "title",
-				),
+				Flags: func() map[string]cmdhelp.Flag {
+					f := mkFlags(
+						"workspace", "assign", "category", "comment", "content",
+						"field", "parent", "priority", "role", "status",
+						"tags", "title",
+					)
+					// IDEA-1494: --force bypasses the open-children guard.
+					f["force"] = cmdhelp.Flag{Type: "bool"}
+					return f
+				}(),
 			},
 			"item delete": {
 				Summary: "delete item",
@@ -539,7 +544,11 @@ func liveCmdhelpDoc(t *testing.T) *cmdhelp.Document {
 			"item bulk-update": {
 				Summary: "bulk update",
 				Args:    []cmdhelp.Arg{{Name: "ref", Required: true, Repeatable: true}},
-				Flags:   mkFlags("workspace", "priority", "status"),
+				Flags: func() map[string]cmdhelp.Flag {
+					f := mkFlags("workspace", "priority", "status")
+					f["force"] = cmdhelp.Flag{Type: "bool"}
+					return f
+				}(),
 			},
 			"item note": {
 				Summary: "add note",

--- a/internal/mcp/catalog_readonly_test.go
+++ b/internal/mcp/catalog_readonly_test.go
@@ -507,6 +507,10 @@ func liveCmdhelpDoc(t *testing.T) *cmdhelp.Document {
 				Flags: map[string]cmdhelp.Flag{
 					"workspace": {Type: "string"},
 					"field":     {Type: "[]string", Repeatable: true},
+					// IDEA-1494 R3 P1: move now honors the same
+					// open-children guard override the update path
+					// does.
+					"force": {Type: "bool"},
 				},
 			},
 			"item deps": {

--- a/internal/mcp/dispatch_http_advanced.go
+++ b/internal/mcp/dispatch_http_advanced.go
@@ -349,6 +349,14 @@ func (d *HTTPHandlerDispatcher) dispatchItemUpdate(
 	if b, ok := input["pinned"].(bool); ok {
 		payload["pinned"] = b
 	}
+	// IDEA-1494: forward the open-children guard override. When set,
+	// the server-side handler skips the guard and still records the
+	// status transition. Same wire shape the CLI uses (`force: true`
+	// on the ItemUpdate body), so the HTTP dispatcher and ExecDispatcher
+	// paths share one contract.
+	if b, ok := input["force"].(bool); ok && b {
+		payload["force"] = true
+	}
 
 	// Field merging — the actual reason this command needs a custom
 	// dispatcher rather than a routeSpec entry. Match the CLI's

--- a/internal/mcp/dispatch_http_advanced_force_test.go
+++ b/internal/mcp/dispatch_http_advanced_force_test.go
@@ -1,0 +1,90 @@
+package mcp
+
+// IDEA-1494 — confirm the HTTP dispatcher forwards the open-children
+// guard override (`force`) into the PATCH body. Matches the wire
+// contract handleUpdateItem reads (`force: true` at the top level of
+// the ItemUpdate JSON body).
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+func TestDispatchItemUpdate_ForwardsForceFlag(t *testing.T) {
+	captured := newRequestCapture()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/workspaces/docapp/items/PLAN-5", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"ref":"PLAN-5","fields":"{\"status\":\"active\"}"}`))
+		case http.MethodPatch:
+			captured.ServeHTTP(w, r)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"ref":"PLAN-5","status":"updated"}`))
+		default:
+			t.Fatalf("unexpected method %s", r.Method)
+		}
+	})
+
+	d := &HTTPHandlerDispatcher{Handler: mux, UserResolver: fixedUserResolver(&models.User{ID: "caller"})}
+	ctx := WithDispatchInput(context.Background(), map[string]any{
+		"workspace": "docapp",
+		"ref":       "PLAN-5",
+		"status":    "completed",
+		"force":     true,
+	})
+	res, err := d.Dispatch(ctx, []string{"item", "update"}, nil)
+	if err != nil || (res != nil && res.IsError) {
+		t.Fatalf("Dispatch err=%v IsError=%v: %#v", err, res != nil && res.IsError, res)
+	}
+	if captured.requestCount != 1 {
+		t.Fatalf("expected 1 PATCH, got %d", captured.requestCount)
+	}
+	var body map[string]any
+	if err := json.Unmarshal([]byte(captured.lastBody), &body); err != nil {
+		t.Fatalf("decode body: %v\n%s", err, captured.lastBody)
+	}
+	got, ok := body["force"].(bool)
+	if !ok || !got {
+		t.Errorf("expected force=true in PATCH body, got %v (%T) — body=%s",
+			body["force"], body["force"], captured.lastBody)
+	}
+}
+
+func TestDispatchItemUpdate_OmitsForceWhenAbsent(t *testing.T) {
+	captured := newRequestCapture()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/workspaces/docapp/items/PLAN-5", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"ref":"PLAN-5","fields":"{\"status\":\"active\"}"}`))
+		case http.MethodPatch:
+			captured.ServeHTTP(w, r)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"ref":"PLAN-5","status":"updated"}`))
+		}
+	})
+
+	d := &HTTPHandlerDispatcher{Handler: mux, UserResolver: fixedUserResolver(&models.User{ID: "caller"})}
+	ctx := WithDispatchInput(context.Background(), map[string]any{
+		"workspace": "docapp",
+		"ref":       "PLAN-5",
+		"status":    "completed",
+	})
+	if _, err := d.Dispatch(ctx, []string{"item", "update"}, nil); err != nil {
+		t.Fatalf("Dispatch err: %v", err)
+	}
+	var body map[string]any
+	if err := json.Unmarshal([]byte(captured.lastBody), &body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if _, present := body["force"]; present {
+		t.Errorf("force should be omitted from PATCH body when not set, got body=%s", captured.lastBody)
+	}
+}

--- a/internal/mcp/dispatch_http_project.go
+++ b/internal/mcp/dispatch_http_project.go
@@ -293,7 +293,14 @@ func (d *HTTPHandlerDispatcher) dispatchItemBulkUpdate(
 			continue
 		}
 		fieldsStr := string(fieldsJSON)
-		patchBody, err := json.Marshal(map[string]any{"fields": fieldsStr})
+		patchPayload := map[string]any{"fields": fieldsStr}
+		// IDEA-1494: forward the open-children guard override per-row.
+		// Same flag shape as `pad item bulk-update --force` so the
+		// override travels through both transports identically.
+		if b, ok := input["force"].(bool); ok && b {
+			patchPayload["force"] = true
+		}
+		patchBody, err := json.Marshal(patchPayload)
 		if err != nil {
 			results = append(results, bulkResult{Ref: ref, Error: rowDispatcherError("encode body", err)})
 			continue

--- a/internal/mcp/dispatch_http_routes.go
+++ b/internal/mcp/dispatch_http_routes.go
@@ -1011,6 +1011,12 @@ func mapItemMove(input map[string]any) (string, string, []byte, error) {
 	}
 	urlPath := fmt.Sprintf("/api/v1/workspaces/%s/items/%s/move",
 		url.PathEscape(workspace), url.PathEscape(ref))
+	// IDEA-1494 R3 P1: forward the open-children guard override into
+	// the URL query, matching the server-side contract (handler reads
+	// ?force=true). Same wire shape `pad item move --force` uses.
+	if b, ok := input["force"].(bool); ok && b {
+		urlPath += "?force=true"
+	}
 	return http.MethodPost, urlPath, body, nil
 }
 

--- a/internal/mcp/errors.go
+++ b/internal/mcp/errors.go
@@ -115,6 +115,19 @@ const (
 	// detail for debugging without promising any structured shape.
 	ErrServerError ErrorCode = "server_error"
 
+	// ErrOpenChildren fires when handleUpdateItem rejects a
+	// non-terminal → terminal done-field transition because the
+	// item still has non-terminal children (IDEA-1494). The upstream
+	// 409 body carries a `details.open_children` array (refs +
+	// titles + statuses + collection_slug) plus a
+	// `details.hidden_blocker_count` for blockers the caller can't
+	// see. We surface the upstream `code` and `details` verbatim
+	// rather than collapsing to ErrConflict so MCP-driven agents
+	// can self-recover (ship the listed children, then retry — or
+	// pass `force: true` if the children should be intentionally
+	// orphaned). The hint mentions the same escape hatch.
+	ErrOpenChildren ErrorCode = "open_children"
+
 	// ErrRateLimited fires on HTTP 429 responses — either the
 	// general API limiter (per-user, 600/min, burst 60) or the
 	// MCP per-token limiter (60/min/token, burst 60 post-BUG-1430)
@@ -170,6 +183,15 @@ type ErrorPayload struct {
 	// agents see why the call was rejected.
 	RequiredRole string `json:"required_role,omitempty"`
 	CurrentRole  string `json:"current_role,omitempty"`
+
+	// Details carries the upstream error body's `details` object
+	// verbatim when the upstream sets one. Used by ErrOpenChildren
+	// (IDEA-1494) so MCP-driven agents get the same machine-readable
+	// payload — open_children list, hidden_blocker_count, done_field,
+	// attempted_value — that the HTTP API surfaces. json.RawMessage
+	// because the shape is code-specific; clients re-parse against
+	// the known schema for their code branch.
+	Details json.RawMessage `json:"details,omitempty"`
 }
 
 // WorkspaceHint is a minimal workspace summary surfaced in the
@@ -294,10 +316,74 @@ func envelopeFrom(res *mcp.CallToolResult) ErrorEnvelope {
 // with the raw stderr preserved in Message.
 // ─────────────────────────────────────────────────────────────────────
 
+// openChildrenStderrMarker mirrors internal/cli.OpenChildrenErrorMarker
+// — the line prefix the CLI writes to stderr when it surfaces an
+// IDEA-1494 open-children rejection. We deliberately duplicate the
+// constant rather than importing internal/cli (which would pull a
+// hefty dependency graph into the mcp classifier just for a string).
+// If you change the marker in one place, change it in both.
+const openChildrenStderrMarker = "pad-error: "
+
+// extractStructuredCLIError scans stderr for the
+// `pad-error: {json}\n` marker line and lifts the structured error
+// envelope into an MCP result. Returns nil when no marker is found
+// (caller falls back to the regex-based classifiers).
+//
+// The marker can appear anywhere in stderr — earlier lines may carry
+// cobra noise or interleaved log output — so we scan line-by-line
+// rather than requiring it at byte 0. First match wins; later
+// `pad-error:` lines (currently impossible but cheap to be defensive
+// about) are ignored.
+func extractStructuredCLIError(stderr string) *mcp.CallToolResult {
+	if !strings.Contains(stderr, openChildrenStderrMarker) {
+		return nil
+	}
+	for _, line := range strings.Split(stderr, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, openChildrenStderrMarker) {
+			continue
+		}
+		payload := strings.TrimPrefix(line, openChildrenStderrMarker)
+		var env struct {
+			Error struct {
+				Code    string          `json:"code"`
+				Message string          `json:"message"`
+				Details json.RawMessage `json:"details,omitempty"`
+			} `json:"error"`
+		}
+		if err := json.Unmarshal([]byte(payload), &env); err != nil {
+			// Malformed marker payload — fall through to regex
+			// classification rather than blowing up the agent.
+			return nil
+		}
+		if env.Error.Code == "" {
+			return nil
+		}
+		return NewErrorResult(ErrorPayload{
+			Code:    ErrorCode(env.Error.Code),
+			Message: env.Error.Message,
+			Details: env.Error.Details,
+		})
+	}
+	return nil
+}
+
 // classifyExecError turns an exec.Cmd failure (err + stderr) into a
 // structured envelope. lookup is optional — when supplied, no_workspace
 // errors get available_workspaces enrichment.
 func classifyExecError(ctx context.Context, cmdPath []string, runErr error, stderr string, lookup WorkspaceLister) *mcp.CallToolResult {
+	// IDEA-1494 R2: the CLI emits a single `pad-error: {json}` line
+	// on stderr when surfacing the open-children rejection (see
+	// internal/cli/client.go::WriteOpenChildrenError). Detect it
+	// before regex classification so we lift the structured `code`
+	// + `details` straight through to the MCP envelope instead of
+	// pattern-matching free-form text and downgrading to
+	// validation_failed. Matched on a literal prefix to keep the
+	// classifier cheap and the contract obvious.
+	if structured := extractStructuredCLIError(stderr); structured != nil {
+		return structured
+	}
+
 	// BUG-987 bug 11: cobra automatically appends a "Usage: ..." block
 	// to stderr when a command fails with a runtime error. That help
 	// text uses the OLD CLI verb names (e.g. `pad item block`) which
@@ -634,6 +720,28 @@ func classifyHTTPStatusKind(
 	case http.StatusNotFound:
 		return classify404(ctx, cmdKey, route, bodyText, bodyMessage, lookup, kind, refOrSlug)
 	case http.StatusConflict:
+		// IDEA-1494 R2: preserve the upstream `code` + `details`
+		// when the handler emitted a structured rejection. The
+		// open-children guard is the canonical case — agents need
+		// the children list (or the hidden-blocker count) to know
+		// whether to ship children, request elevated access, or
+		// retry with force=true. Collapsing to ErrConflict here
+		// would drop that whole signal.
+		//
+		// Generalized as "if the upstream gave us a non-empty,
+		// non-default code, pass it through" rather than special-
+		// casing open_children specifically — any future
+		// structured-409 a handler emits gets the same treatment
+		// without revisiting this branch.
+		upstream := extractUpstreamErrorEnvelope(bodyText)
+		if upstream.Code != "" && upstream.Code != "conflict" {
+			return NewErrorResult(ErrorPayload{
+				Code:    ErrorCode(upstream.Code),
+				Message: upstream.Message,
+				Hint:    conflictHintFor(bodyMessage, route),
+				Details: upstream.Details,
+			})
+		}
 		return NewErrorResult(ErrorPayload{
 			Code:    ErrConflict,
 			Message: "Conflict — current state changed beneath this update.",
@@ -785,6 +893,37 @@ func extractUpstreamMessage(body string) string {
 		return env.Error.Message
 	}
 	return ""
+}
+
+// upstreamErrorEnvelope is the broader extractor used when the
+// dispatcher needs to pass through the upstream `code` / `details`
+// fields (not just the message). The pad backend uses the same
+// `{"error":{"code":..., "message":..., "details":{...}}}` shape
+// across every handler that returns writeError-style bodies; this
+// parser lifts those fields when present and reports zero-valued
+// strings / nil RawMessage when not. Single source of truth for the
+// pass-through cases in classifyHTTPStatusKind.
+type upstreamErrorEnvelope struct {
+	Code    string          `json:"code"`
+	Message string          `json:"message"`
+	Details json.RawMessage `json:"details,omitempty"`
+}
+
+func extractUpstreamErrorEnvelope(body string) upstreamErrorEnvelope {
+	body = strings.TrimSpace(body)
+	if body == "" {
+		return upstreamErrorEnvelope{}
+	}
+	if strings.EqualFold(body, "404 page not found") {
+		return upstreamErrorEnvelope{}
+	}
+	var env struct {
+		Error upstreamErrorEnvelope `json:"error"`
+	}
+	if err := json.Unmarshal([]byte(body), &env); err == nil {
+		return env.Error
+	}
+	return upstreamErrorEnvelope{}
 }
 
 // itemMissingHint is the per-error-code hint generator for

--- a/internal/mcp/errors.go
+++ b/internal/mcp/errors.go
@@ -327,16 +327,26 @@ func envelopeFrom(res *mcp.CallToolResult) ErrorEnvelope {
 // bumping both packages and reviewing the allow-list.
 const structuredErrorMarker = "pad-structured-error/v1: "
 
-// allowedStructuredErrorCodes is the whitelist of codes the classifier
-// will surface from a `pad-structured-error/v1:` marker (Codex
-// round-3 P3). Unknown codes fall back to the regex classifier rather
-// than getting blindly forwarded — a CLI bug or third-party tool that
-// emits a marker with an unrecognized code can't smuggle an
-// unsanitized payload past the MCP boundary.
+// allowedStructuredErrorCodes is the whitelist of upstream codes the
+// MCP layer will surface verbatim. Two transports consult it:
 //
-// Add a code here ONLY after confirming the upstream CLI path that
-// emits it has been audited (matching wire shape, no PII in details,
-// stable contract).
+//   - Stdio: extractStructuredCLIError gates the `pad-structured-error/v1:`
+//     marker on this set (Codex round-3 P3).
+//   - HTTP: classifyHTTPStatus's 409 branch gates the upstream
+//     `error.code` pass-through on this set (Codex round-4 P2).
+//
+// Routing BOTH transports through the same whitelist keeps the
+// ErrorCode enum's closed-contract honest — agents see the same set
+// of structured codes regardless of which dispatcher delivered the
+// response. Pre-round-4 the HTTP path forwarded any non-"conflict"
+// upstream code, which silently widened the enum and let the two
+// transports diverge.
+//
+// Adding a new structured code is a TWO-WAY change: the pad handler
+// must emit it (and emit `details` with a stable, agent-safe shape)
+// AND it must be added here. The matching ErrorCode constant in the
+// declarations block at the top of this file should also be added
+// for type safety in test assertions.
 var allowedStructuredErrorCodes = map[string]struct{}{
 	"open_children": {}, // IDEA-1494
 }
@@ -750,21 +760,22 @@ func classifyHTTPStatusKind(
 	case http.StatusNotFound:
 		return classify404(ctx, cmdKey, route, bodyText, bodyMessage, lookup, kind, refOrSlug)
 	case http.StatusConflict:
-		// IDEA-1494 R2: preserve the upstream `code` + `details`
-		// when the handler emitted a structured rejection. The
-		// open-children guard is the canonical case — agents need
-		// the children list (or the hidden-blocker count) to know
-		// whether to ship children, request elevated access, or
-		// retry with force=true. Collapsing to ErrConflict here
-		// would drop that whole signal.
+		// IDEA-1494 R2/R4 P2: preserve the upstream `code` + `details`
+		// when the handler emitted a structured rejection — but ONLY
+		// for codes that appear in the shared allow-list
+		// (allowedStructuredErrorCodes, defined below). The stdio
+		// classifier already gates on the same set; routing both
+		// transports through the same whitelist keeps the
+		// ErrorCode enum's closed contract honest (round-4 P2:
+		// HTTP was forwarding any non-"conflict" code, diverging
+		// from stdio).
 		//
-		// Generalized as "if the upstream gave us a non-empty,
-		// non-default code, pass it through" rather than special-
-		// casing open_children specifically — any future
-		// structured-409 a handler emits gets the same treatment
-		// without revisiting this branch.
+		// New structured codes get added to allowedStructuredErrorCodes
+		// in one place; both transports adopt them in lockstep.
+		// Unknown codes fall through to generic ErrConflict here —
+		// matching what stdio does for an unknown-code marker.
 		upstream := extractUpstreamErrorEnvelope(bodyText)
-		if upstream.Code != "" && upstream.Code != "conflict" {
+		if _, allowed := allowedStructuredErrorCodes[upstream.Code]; allowed {
 			return NewErrorResult(ErrorPayload{
 				Code:    ErrorCode(upstream.Code),
 				Message: upstream.Message,

--- a/internal/mcp/errors.go
+++ b/internal/mcp/errors.go
@@ -316,56 +316,86 @@ func envelopeFrom(res *mcp.CallToolResult) ErrorEnvelope {
 // with the raw stderr preserved in Message.
 // ─────────────────────────────────────────────────────────────────────
 
-// openChildrenStderrMarker mirrors internal/cli.OpenChildrenErrorMarker
-// — the line prefix the CLI writes to stderr when it surfaces an
-// IDEA-1494 open-children rejection. We deliberately duplicate the
-// constant rather than importing internal/cli (which would pull a
-// hefty dependency graph into the mcp classifier just for a string).
-// If you change the marker in one place, change it in both.
-const openChildrenStderrMarker = "pad-error: "
+// structuredErrorMarker mirrors internal/cli.StructuredErrorMarker —
+// the versioned line prefix the CLI writes to stderr when it surfaces
+// a structured error. Duplicated (rather than imported) so the mcp
+// classifier doesn't pull the cli package's dependency graph in for
+// one string. Codex round-3 P3 introduced the versioned shape.
+//
+// IMPORTANT: keep in lockstep with cli.StructuredErrorMarker AND with
+// allowedStructuredErrorCodes below. A wire-shape change requires
+// bumping both packages and reviewing the allow-list.
+const structuredErrorMarker = "pad-structured-error/v1: "
+
+// allowedStructuredErrorCodes is the whitelist of codes the classifier
+// will surface from a `pad-structured-error/v1:` marker (Codex
+// round-3 P3). Unknown codes fall back to the regex classifier rather
+// than getting blindly forwarded — a CLI bug or third-party tool that
+// emits a marker with an unrecognized code can't smuggle an
+// unsanitized payload past the MCP boundary.
+//
+// Add a code here ONLY after confirming the upstream CLI path that
+// emits it has been audited (matching wire shape, no PII in details,
+// stable contract).
+var allowedStructuredErrorCodes = map[string]struct{}{
+	"open_children": {}, // IDEA-1494
+}
 
 // extractStructuredCLIError scans stderr for the
-// `pad-error: {json}\n` marker line and lifts the structured error
-// envelope into an MCP result. Returns nil when no marker is found
+// `pad-structured-error/v1: {json}\n` marker line and lifts the
+// structured error envelope into an MCP result. Returns nil when no
+// marker is found OR the payload fails any of the hardening checks
 // (caller falls back to the regex-based classifiers).
 //
-// The marker can appear anywhere in stderr — earlier lines may carry
-// cobra noise or interleaved log output — so we scan line-by-line
-// rather than requiring it at byte 0. First match wins; later
-// `pad-error:` lines (currently impossible but cheap to be defensive
-// about) are ignored.
+// Hardening (Codex round-3 P3):
+//   - Versioned marker. Unknown versions return nil.
+//   - Whitelisted codes. Unknown codes return nil.
+//   - Last-marker-wins. If multiple markers appear in stderr (a
+//     pathological case today, but possible if a future caller emits
+//     several), we use the LAST one — that's the most recent
+//     classification the CLI emitted, and a malicious earlier line
+//     can't pre-empt it.
+//   - Marker must start the line after trimming whitespace; markers
+//     embedded mid-line (e.g. in a quoted log message) are ignored.
 func extractStructuredCLIError(stderr string) *mcp.CallToolResult {
-	if !strings.Contains(stderr, openChildrenStderrMarker) {
+	if !strings.Contains(stderr, structuredErrorMarker) {
 		return nil
 	}
+	var lastPayload string
 	for _, line := range strings.Split(stderr, "\n") {
 		line = strings.TrimSpace(line)
-		if !strings.HasPrefix(line, openChildrenStderrMarker) {
+		if !strings.HasPrefix(line, structuredErrorMarker) {
 			continue
 		}
-		payload := strings.TrimPrefix(line, openChildrenStderrMarker)
-		var env struct {
-			Error struct {
-				Code    string          `json:"code"`
-				Message string          `json:"message"`
-				Details json.RawMessage `json:"details,omitempty"`
-			} `json:"error"`
-		}
-		if err := json.Unmarshal([]byte(payload), &env); err != nil {
-			// Malformed marker payload — fall through to regex
-			// classification rather than blowing up the agent.
-			return nil
-		}
-		if env.Error.Code == "" {
-			return nil
-		}
-		return NewErrorResult(ErrorPayload{
-			Code:    ErrorCode(env.Error.Code),
-			Message: env.Error.Message,
-			Details: env.Error.Details,
-		})
+		lastPayload = strings.TrimPrefix(line, structuredErrorMarker)
 	}
-	return nil
+	if lastPayload == "" {
+		return nil
+	}
+	var env struct {
+		Error struct {
+			Code    string          `json:"code"`
+			Message string          `json:"message"`
+			Details json.RawMessage `json:"details,omitempty"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal([]byte(lastPayload), &env); err != nil {
+		// Malformed marker payload — fall through to regex
+		// classification rather than blowing up the agent.
+		return nil
+	}
+	if env.Error.Code == "" {
+		return nil
+	}
+	if _, ok := allowedStructuredErrorCodes[env.Error.Code]; !ok {
+		// Unknown code. Don't forward — regex classifier handles it.
+		return nil
+	}
+	return NewErrorResult(ErrorPayload{
+		Code:    ErrorCode(env.Error.Code),
+		Message: env.Error.Message,
+		Details: env.Error.Details,
+	})
 }
 
 // classifyExecError turns an exec.Cmd failure (err + stderr) into a

--- a/internal/mcp/open_children_passthrough_test.go
+++ b/internal/mcp/open_children_passthrough_test.go
@@ -1,0 +1,147 @@
+package mcp
+
+// IDEA-1494 R2 — MCP-level coverage for the open-children code/details
+// pass-through, both HTTP and stdio.
+//
+// The contract:
+//
+//   - HTTP path: when the upstream PATCH returns 409 with code=
+//     "open_children" and a populated details body, the dispatcher
+//     surfaces ErrOpenChildren (not the generic ErrConflict) and
+//     preserves the details RawMessage verbatim. Agents branch on
+//     the code, then re-parse details against the known shape.
+//   - stdio path: when the CLI's stderr carries a `pad-error: {json}`
+//     marker line, classifyExecError detects it, lifts the structured
+//     payload, and surfaces it in the same shape — independent of
+//     transport.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/cli"
+)
+
+func TestClassifyHTTPStatus_OpenChildrenPreservesCodeAndDetails(t *testing.T) {
+	body := []byte(`{
+		"error": {
+			"code": "open_children",
+			"message": "cannot mark PLAN-5 completed: 2 open children still in a non-terminal state. Pass --force to override.",
+			"details": {
+				"open_children": [
+					{"ref":"TASK-7","title":"a","status":"open","collection_slug":"tasks"},
+					{"ref":"TASK-8","title":"b","status":"open","collection_slug":"tasks"}
+				],
+				"hidden_blocker_count": 0,
+				"done_field": "status",
+				"attempted_value": "completed"
+			}
+		}
+	}`)
+
+	res := classifyHTTPStatus(context.Background(), "item update", 409, body, nil)
+	env, ok := res.StructuredContent.(ErrorEnvelope)
+	if !ok {
+		t.Fatalf("expected ErrorEnvelope, got %T", res.StructuredContent)
+	}
+	if env.Error.Code != ErrOpenChildren {
+		t.Fatalf("code: got %q, want %q", env.Error.Code, ErrOpenChildren)
+	}
+	if env.Error.Message == "" {
+		t.Errorf("message should be preserved from upstream, got empty")
+	}
+	if len(env.Error.Details) == 0 {
+		t.Fatal("details should be preserved as raw JSON, got empty")
+	}
+
+	// Round-trip the details into the shared CLI struct (the same one
+	// MCP-driven agents would unmarshal against). Confirms the shape
+	// survives the HTTP-classifier transit unchanged.
+	var got cli.OpenChildrenDetails
+	if err := json.Unmarshal(env.Error.Details, &got); err != nil {
+		t.Fatalf("details should round-trip into OpenChildrenDetails: %v", err)
+	}
+	if len(got.OpenChildren) != 2 {
+		t.Errorf("open_children len: got %d, want 2", len(got.OpenChildren))
+	}
+	if got.AttemptedValue != "completed" {
+		t.Errorf("attempted_value: got %q, want completed", got.AttemptedValue)
+	}
+	if got.DoneField != "status" {
+		t.Errorf("done_field: got %q, want status", got.DoneField)
+	}
+}
+
+// TestClassifyHTTPStatus_ConflictWithoutCodeFallsToErrConflict pins
+// the inverse: a 409 WITHOUT an upstream code (or with code="conflict"
+// explicitly) still collapses to ErrConflict so we don't break the
+// existing classifier contract for ordinary version-mismatch 409s.
+func TestClassifyHTTPStatus_ConflictWithoutCodeFallsToErrConflict(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"no code at all", `{"error":{"message":"version mismatch"}}`},
+		{"explicit conflict code", `{"error":{"code":"conflict","message":"version mismatch"}}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res := classifyHTTPStatus(context.Background(), "item update", 409, []byte(tc.body), nil)
+			env := res.StructuredContent.(ErrorEnvelope)
+			if env.Error.Code != ErrConflict {
+				t.Errorf("code: got %q, want %q", env.Error.Code, ErrConflict)
+			}
+			if len(env.Error.Details) != 0 {
+				t.Errorf("details should be empty for generic 409, got %s", string(env.Error.Details))
+			}
+		})
+	}
+}
+
+func TestClassifyExecError_OpenChildrenMarkerLiftsStructuredPayload(t *testing.T) {
+	stderr := `Error: connecting to backend
+pad-error: {"error":{"code":"open_children","message":"cannot mark PLAN-5 completed: 1 open child still in a non-terminal state. Pass --force to override.","details":{"open_children":[{"ref":"TASK-7","title":"x","status":"open","collection_slug":"tasks"}],"hidden_blocker_count":0,"done_field":"status","attempted_value":"completed"}}}
+cannot mark PLAN-5 completed: 1 open child still in a non-terminal state. Pass --force to override.
+  TASK-7 — x (status=open)
+Pass --force to override.
+`
+	res := classifyExecError(context.Background(),
+		[]string{"item", "update"},
+		errors.New("exit status 1"),
+		stderr,
+		nil)
+	env, ok := res.StructuredContent.(ErrorEnvelope)
+	if !ok {
+		t.Fatalf("expected ErrorEnvelope, got %T", res.StructuredContent)
+	}
+	if env.Error.Code != ErrOpenChildren {
+		t.Fatalf("code: got %q, want %q", env.Error.Code, ErrOpenChildren)
+	}
+	var details cli.OpenChildrenDetails
+	if err := json.Unmarshal(env.Error.Details, &details); err != nil {
+		t.Fatalf("details did not round-trip: %v", err)
+	}
+	if len(details.OpenChildren) != 1 || details.OpenChildren[0].Ref != "TASK-7" {
+		t.Errorf("open_children mismatch: %+v", details.OpenChildren)
+	}
+}
+
+// TestClassifyExecError_NoMarkerFallsThrough confirms stderr WITHOUT
+// the marker classifies via the existing regex matchers (validation /
+// auth / item-not-found / generic) — i.e. the marker detection is
+// purely additive and doesn't break the pre-IDEA-1494 stderr-classify
+// contracts.
+func TestClassifyExecError_NoMarkerFallsThrough(t *testing.T) {
+	stderr := "Error: invalid status value\n"
+	res := classifyExecError(context.Background(),
+		[]string{"item", "update"},
+		errors.New("exit status 1"),
+		stderr,
+		nil)
+	env := res.StructuredContent.(ErrorEnvelope)
+	if env.Error.Code == ErrOpenChildren {
+		t.Errorf("plain validation stderr must not be classified as open_children")
+	}
+}

--- a/internal/mcp/open_children_passthrough_test.go
+++ b/internal/mcp/open_children_passthrough_test.go
@@ -102,7 +102,7 @@ func TestClassifyHTTPStatus_ConflictWithoutCodeFallsToErrConflict(t *testing.T) 
 
 func TestClassifyExecError_OpenChildrenMarkerLiftsStructuredPayload(t *testing.T) {
 	stderr := `Error: connecting to backend
-pad-error: {"error":{"code":"open_children","message":"cannot mark PLAN-5 completed: 1 open child still in a non-terminal state. Pass --force to override.","details":{"open_children":[{"ref":"TASK-7","title":"x","status":"open","collection_slug":"tasks"}],"hidden_blocker_count":0,"done_field":"status","attempted_value":"completed"}}}
+pad-structured-error/v1: {"error":{"code":"open_children","message":"cannot mark PLAN-5 completed: 1 open child still in a non-terminal state. Pass --force to override.","details":{"open_children":[{"ref":"TASK-7","title":"x","status":"open","collection_slug":"tasks"}],"hidden_blocker_count":0,"done_field":"status","attempted_value":"completed"}}}
 cannot mark PLAN-5 completed: 1 open child still in a non-terminal state. Pass --force to override.
   TASK-7 — x (status=open)
 Pass --force to override.
@@ -143,5 +143,84 @@ func TestClassifyExecError_NoMarkerFallsThrough(t *testing.T) {
 	env := res.StructuredContent.(ErrorEnvelope)
 	if env.Error.Code == ErrOpenChildren {
 		t.Errorf("plain validation stderr must not be classified as open_children")
+	}
+}
+
+// TestClassifyExecError_UnknownStructuredCodeFallsThrough covers
+// Codex round-3 P3 marker hardening: even with a well-formed
+// pad-structured-error/v1 marker, a code that's NOT in the allow-list
+// must not be surfaced — fall back to regex classification instead.
+// Prevents a CLI bug or third-party tool from smuggling an
+// unsanitized code past the MCP boundary.
+func TestClassifyExecError_UnknownStructuredCodeFallsThrough(t *testing.T) {
+	stderr := `pad-structured-error/v1: {"error":{"code":"made_up_code","message":"x"}}
+Error: invalid status value
+`
+	res := classifyExecError(context.Background(),
+		[]string{"item", "update"},
+		errors.New("exit status 1"),
+		stderr,
+		nil)
+	env := res.StructuredContent.(ErrorEnvelope)
+	if env.Error.Code == ErrorCode("made_up_code") {
+		t.Errorf("unknown structured code must not be surfaced; got %q", env.Error.Code)
+	}
+}
+
+// TestClassifyExecError_OldMarkerVersionIgnored confirms that an
+// older (or unrecognized future) marker version is ignored rather
+// than parsed. Validates the "version token is parsed, not just
+// prefix-matched" property — agents on the new mcp build won't be
+// confused by stderr from a stale CLI binary that still uses the
+// pre-round-3 unversioned `pad-error:` shape.
+func TestClassifyExecError_OldMarkerVersionIgnored(t *testing.T) {
+	stderr := `pad-error: {"error":{"code":"open_children","message":"x"}}
+Error: invalid status value
+`
+	res := classifyExecError(context.Background(),
+		[]string{"item", "update"},
+		errors.New("exit status 1"),
+		stderr,
+		nil)
+	env := res.StructuredContent.(ErrorEnvelope)
+	if env.Error.Code == ErrOpenChildren {
+		t.Errorf("pre-v1 unversioned marker must not be lifted; got %q", env.Error.Code)
+	}
+}
+
+// TestClassifyExecError_MarkerEmbeddedMidLineIgnored ensures a marker
+// substring inside a quoted log message can't impersonate a real
+// structured error. The classifier requires the marker at the line's
+// start (after whitespace trim) — embedded variants fall through.
+func TestClassifyExecError_MarkerEmbeddedMidLineIgnored(t *testing.T) {
+	stderr := `Error: backend logged "pad-structured-error/v1: {\"error\":{\"code\":\"open_children\"}}"
+`
+	res := classifyExecError(context.Background(),
+		[]string{"item", "update"},
+		errors.New("exit status 1"),
+		stderr,
+		nil)
+	env := res.StructuredContent.(ErrorEnvelope)
+	if env.Error.Code == ErrOpenChildren {
+		t.Errorf("embedded marker must not be lifted; got %q", env.Error.Code)
+	}
+}
+
+// TestClassifyExecError_LastMarkerWins confirms multiple markers
+// resolve to the LAST one — a malicious earlier line can't pre-empt
+// the CLI's actual final classification.
+func TestClassifyExecError_LastMarkerWins(t *testing.T) {
+	stderr := `pad-structured-error/v1: {"error":{"code":"made_up_code","message":"first"}}
+pad-structured-error/v1: {"error":{"code":"open_children","message":"second","details":{"open_children":[]}}}
+`
+	res := classifyExecError(context.Background(),
+		[]string{"item", "update"},
+		errors.New("exit status 1"),
+		stderr,
+		nil)
+	env := res.StructuredContent.(ErrorEnvelope)
+	if env.Error.Code != ErrOpenChildren {
+		t.Errorf("expected the later marker to win; got %q (message=%q)",
+			env.Error.Code, env.Error.Message)
 	}
 }

--- a/internal/mcp/open_children_passthrough_test.go
+++ b/internal/mcp/open_children_passthrough_test.go
@@ -224,3 +224,62 @@ pad-structured-error/v1: {"error":{"code":"open_children","message":"second","de
 			env.Error.Code, env.Error.Message)
 	}
 }
+
+// TestClassifyHTTPStatus_UnknownConflictCodeFallsBackToErrConflict
+// covers Codex round-4 P2: HTTP and stdio must agree on the closed
+// set of structured codes they surface. Pre-fix the HTTP path
+// forwarded ANY non-"conflict" code; stdio whitelisted only
+// open_children. The two transports diverged on what an agent saw
+// from an upstream that emitted `code=some_future_code`.
+//
+// Post-fix: both consult allowedStructuredErrorCodes. An upstream
+// 409 with a code NOT in the whitelist collapses to generic
+// ErrConflict on the HTTP path, mirroring what the stdio path does
+// for an unknown-code structured marker.
+func TestClassifyHTTPStatus_UnknownConflictCodeFallsBackToErrConflict(t *testing.T) {
+	body := []byte(`{
+		"error": {
+			"code": "some_future_code",
+			"message": "x",
+			"details": {"anything":1}
+		}
+	}`)
+	res := classifyHTTPStatus(context.Background(), "item update", 409, body, nil)
+	env := res.StructuredContent.(ErrorEnvelope)
+	if env.Error.Code != ErrConflict {
+		t.Errorf("unknown upstream code must collapse to ErrConflict on HTTP path; got %q", env.Error.Code)
+	}
+	if len(env.Error.Details) != 0 {
+		t.Errorf("details from un-whitelisted code must not leak; got %s", string(env.Error.Details))
+	}
+}
+
+// TestStructuredErrorCodeParityAcrossTransports asserts that the same
+// "unknown code" rejection produces the same envelope shape from
+// both transports — ie HTTP doesn't widen the enum behind stdio's
+// back. Round-4 P2.
+func TestStructuredErrorCodeParityAcrossTransports(t *testing.T) {
+	httpRes := classifyHTTPStatus(context.Background(), "item update", 409,
+		[]byte(`{"error":{"code":"made_up_code","message":"x"}}`), nil)
+	httpEnv := httpRes.StructuredContent.(ErrorEnvelope)
+
+	stdioRes := classifyExecError(context.Background(),
+		[]string{"item", "update"},
+		errors.New("exit status 1"),
+		`pad-structured-error/v1: {"error":{"code":"made_up_code","message":"x"}}
+`, nil)
+	stdioEnv := stdioRes.StructuredContent.(ErrorEnvelope)
+
+	if httpEnv.Error.Code == ErrorCode("made_up_code") {
+		t.Errorf("HTTP path leaked unknown code: %q", httpEnv.Error.Code)
+	}
+	if stdioEnv.Error.Code == ErrorCode("made_up_code") {
+		t.Errorf("stdio path leaked unknown code: %q", stdioEnv.Error.Code)
+	}
+	// Both transports must agree: neither surfaces the unknown code.
+	// They CAN classify the fallback differently (HTTP → ErrConflict
+	// for 409, stdio → ErrServerError for an unknown stderr line)
+	// because the upstream signals are genuinely different — the
+	// parity contract is "no transport widens the enum beyond the
+	// whitelist," not "both transports produce identical envelopes."
+}

--- a/internal/models/item.go
+++ b/internal/models/item.go
@@ -582,6 +582,15 @@ type ItemUpdate struct {
 	// (since nil pointer means "don't change" in partial updates)
 	ClearAssignedUser bool `json:"clear_assigned_user,omitempty"`
 	ClearAgentRole    bool `json:"clear_agent_role,omitempty"`
+
+	// Force, when true, overrides the server-side open-children guard
+	// (IDEA-1494) that otherwise rejects a non-terminal → terminal
+	// done-field transition while the item still has non-terminal
+	// children. Transport-only: the store layer never sees it (the
+	// handler consumes it before calling UpdateItem). Used by `pad item
+	// update --force` and MCP `pad_item.action: update` with
+	// `force: true`.
+	Force bool `json:"force,omitempty"`
 }
 
 // ErrInvalidFieldsType / ErrInvalidTagsType are returned by

--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -664,6 +664,11 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// IDEA-1494: precheck closure populated below when the patch
+	// includes a fields update AND --force is NOT set. Threads into
+	// the three UpdateItem call sites that follow. nil = no guard.
+	var openChildrenPrecheck func(tx *sql.Tx, existing *models.Item) error
+
 	// If fields are being updated, validate against schema
 	if input.Fields != nil {
 		coll, err := s.store.GetCollection(item.CollectionID)
@@ -740,26 +745,49 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 		// Auto-populate date fields on status changes
 		autoPopulateDates(fieldMap, item.Fields, schema)
 
-		// IDEA-1494 open-children guard: refuse non-terminal → terminal
-		// done-field transitions while the item still has non-terminal
-		// children, unless the caller passes Force=true. The check uses
-		// the parent item's collection schema/settings for the done-
-		// field resolution (each child is then evaluated against its
-		// OWN collection in evaluateOpenChildrenGuard). Runs before any
-		// store mutation so a rejection mutates nothing.
+		// IDEA-1494 open-children guard. The actual check runs INSIDE
+		// the store transaction (see Store.UpdateItemWithPreCheck) so
+		// the children-list query and the parent's status write share
+		// a snapshot — closes the TOCTOU window flagged in Codex
+		// round 2 (P2). Here we just stage the inputs and the
+		// visibility filters; the closure runs later under the
+		// workspace seq lock + parent-children advisory lock.
 		if !input.Force {
 			var settings models.CollectionSettings
 			if coll.Settings != "" {
 				_ = json.Unmarshal([]byte(coll.Settings), &settings)
 			}
-			details, gerr := s.evaluateOpenChildrenGuard(item.ID, item.Fields, fieldMap, schema, settings)
+			// Pre-compute visibility once. The guard's invariant check
+			// considers ALL children (data integrity); the visibility
+			// filter only affects which children appear in the 409
+			// payload — hidden ones are surfaced as a count.
+			visIDs, _ := s.visibleCollectionIDs(r, workspaceID)
+			guestFull, guestGranted, gerr := s.guestResourceFilter(r, workspaceID)
 			if gerr != nil {
 				writeInternalError(w, gerr)
 				return
 			}
-			if details != nil {
-				writeOpenChildrenError(w, itemRefOrSlug(*item), details)
-				return
+			gctx := openChildrenGuardContext{
+				r:                    r,
+				workspaceID:          workspaceID,
+				itemID:               item.ID,
+				parentSchema:         schema,
+				parentSettings:       settings,
+				newFieldMap:          fieldMap,
+				currentFieldsJS:      item.Fields,
+				visibleCollectionIDs: visIDs,
+				guestFullCollIDs:     guestFull,
+				guestGrantedItemIDs:  guestGranted,
+			}
+			openChildrenPrecheck = func(tx *sql.Tx, _ *models.Item) error {
+				details, derr := s.runOpenChildrenGuard(tx, gctx)
+				if derr != nil {
+					return derr
+				}
+				if details != nil {
+					return &openChildrenGuardError{details: details}
+				}
+				return nil
 			}
 		}
 
@@ -903,7 +931,7 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 					return errStaleCollabSnapshot
 				}
 			}
-			updated, uerr := s.store.UpdateItem(item.ID, input)
+			updated, uerr := s.store.UpdateItemWithPreCheck(item.ID, input, openChildrenPrecheck)
 			if uerr != nil {
 				return uerr
 			}
@@ -912,6 +940,10 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 			return nil
 		})
 		if err != nil {
+			if details, ok := asOpenChildrenGuardError(err); ok {
+				writeOpenChildrenError(w, itemRefOrSlug(*item), details)
+				return
+			}
 			if errors.Is(err, errStaleCollabSnapshot) {
 				writeError(w, http.StatusConflict, "stale_collab_snapshot",
 					"This editor's view is out of sync with the server; please reload.")
@@ -967,7 +999,7 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 		// Store.UpdateItem's content-versioning peek at Title.
 		// Per Codex review round 9.
 		err := s.applyContentViaCollab(r, item.ID, *input.Content, func() error {
-			updated, uerr := s.store.UpdateItem(item.ID, input)
+			updated, uerr := s.store.UpdateItemWithPreCheck(item.ID, input, openChildrenPrecheck)
 			if uerr != nil {
 				return uerr
 			}
@@ -981,8 +1013,15 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 			// or directWrite ran the full UpdateItem inside the
 			// lock (fullWriteHandled tracks which).
 			input.Content = nil
+		} else if details, ok := asOpenChildrenGuardError(err); ok {
+			// IDEA-1494 R2: the open-children guard fired inside the
+			// directWrite callback. Don't let applyContentViaCollab's
+			// "any error falls through" policy retry the write —
+			// rejection is final.
+			writeOpenChildrenError(w, itemRefOrSlug(*item), details)
+			return
 		}
-		// Any error path (e.g. ErrAllAppliersTimedOut, retry
+		// Any other error path (e.g. ErrAllAppliersTimedOut, retry
 		// exhaustion) falls through to direct write — graceful
 		// degradation. The helper logs the specifics so operators
 		// see degraded paths.
@@ -992,9 +1031,18 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 	if fullWriteHandled {
 		updated = fullWriteUpdated
 	} else {
-		updated, err = s.store.UpdateItem(item.ID, input)
+		updated, err = s.store.UpdateItemWithPreCheck(item.ID, input, openChildrenPrecheck)
 	}
 	if err != nil {
+		// IDEA-1494 R2: surface the open-children guard rejection as
+		// the structured 409 BEFORE the UNIQUE-constraint / generic
+		// internal-error paths can swallow it. Same shape the
+		// in-handler write produced pre-R2, but now correctly fires
+		// when the guard ran inside the store tx.
+		if details, ok := asOpenChildrenGuardError(err); ok {
+			writeOpenChildrenError(w, itemRefOrSlug(*item), details)
+			return
+		}
 		// Map UNIQUE constraint races (e.g. concurrent updates that both
 		// pass checkUniqueFields and then both hit the partial unique
 		// index on invocation_slug) to 409 conflict, matching the create

--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -740,6 +740,29 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 		// Auto-populate date fields on status changes
 		autoPopulateDates(fieldMap, item.Fields, schema)
 
+		// IDEA-1494 open-children guard: refuse non-terminal → terminal
+		// done-field transitions while the item still has non-terminal
+		// children, unless the caller passes Force=true. The check uses
+		// the parent item's collection schema/settings for the done-
+		// field resolution (each child is then evaluated against its
+		// OWN collection in evaluateOpenChildrenGuard). Runs before any
+		// store mutation so a rejection mutates nothing.
+		if !input.Force {
+			var settings models.CollectionSettings
+			if coll.Settings != "" {
+				_ = json.Unmarshal([]byte(coll.Settings), &settings)
+			}
+			details, gerr := s.evaluateOpenChildrenGuard(item.ID, item.Fields, fieldMap, schema, settings)
+			if gerr != nil {
+				writeInternalError(w, gerr)
+				return
+			}
+			if details != nil {
+				writeOpenChildrenError(w, itemRefOrSlug(*item), details)
+				return
+			}
+		}
+
 		validatedFields, err := json.Marshal(fieldMap)
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "internal_error", "Failed to marshal validated fields")

--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -761,7 +761,18 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 			// considers ALL children (data integrity); the visibility
 			// filter only affects which children appear in the 409
 			// payload — hidden ones are surfaced as a count.
-			visIDs, _ := s.visibleCollectionIDs(r, workspaceID)
+			//
+			// Fail CLOSED on visibility-lookup error (Codex round-3 P1):
+			// a swallowed error here would leave visIDs==nil, which
+			// openChildrenGuardChildVisible treats as "no restriction"
+			// — leaking metadata for hidden children. Surfacing the
+			// internal error blocks the update entirely rather than
+			// risk an information leak.
+			visIDs, visErr := s.visibleCollectionIDs(r, workspaceID)
+			if visErr != nil {
+				writeInternalError(w, visErr)
+				return
+			}
 			guestFull, guestGranted, gerr := s.guestResourceFilter(r, workspaceID)
 			if gerr != nil {
 				writeInternalError(w, gerr)
@@ -774,13 +785,21 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 				parentSchema:         schema,
 				parentSettings:       settings,
 				newFieldMap:          fieldMap,
-				currentFieldsJS:      item.Fields,
 				visibleCollectionIDs: visIDs,
 				guestFullCollIDs:     guestFull,
 				guestGrantedItemIDs:  guestGranted,
 			}
-			openChildrenPrecheck = func(tx *sql.Tx, _ *models.Item) error {
-				details, derr := s.runOpenChildrenGuard(tx, gctx)
+			openChildrenPrecheck = func(tx *sql.Tx, existing *models.Item) error {
+				// Codex round-3 P2: classify the transition against
+				// the in-tx snapshot of the parent's fields, not the
+				// pre-tx capture. A concurrent writer can change the
+				// done-field value between handler-side read and lock
+				// acquisition; using `existing.Fields` (loaded by
+				// UpdateItemWithPreCheck after the tx began) avoids
+				// both false-fire and false-skip classifications.
+				txCtx := gctx
+				txCtx.currentFieldsJS = existing.Fields
+				details, derr := s.runOpenChildrenGuard(tx, txCtx)
 				if derr != nil {
 					return derr
 				}
@@ -1330,9 +1349,72 @@ func (s *Server) handleMoveItem(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// IDEA-1494 R3 P1: same open-children guard as the regular update
+	// path. `pad item move ... --field status=completed` would
+	// otherwise bypass it. We classify the proposed transition
+	// against the DESTINATION collection's schema (conservative —
+	// honors the schema the item is moving INTO, so a target-schema
+	// terminal value can't be smuggled in via a source whose schema
+	// doesn't recognize the value as terminal). Visibility filter is
+	// pre-computed and fails closed on lookup error, mirroring the
+	// update path.
+	//
+	// Force override on the move path lives on the URL query
+	// (?force=true). Move's request body shape is already fixed
+	// ({target_collection, field_overrides}) and adding a body
+	// field would require coordinating with the CLI/MCP move
+	// callers; the query param sidesteps that without changing the
+	// JSON contract. Same semantics as `pad item update --force`.
+	moveForce := r.URL.Query().Get("force") == "true"
+
+	var movePrecheck func(tx *sql.Tx, existing *models.Item) error
+	if !moveForce {
+		var destSettings models.CollectionSettings
+		if targetColl.Settings != "" {
+			_ = json.Unmarshal([]byte(targetColl.Settings), &destSettings)
+		}
+		visIDs, visErr := s.visibleCollectionIDs(r, workspaceID)
+		if visErr != nil {
+			writeInternalError(w, visErr)
+			return
+		}
+		guestFull, guestGranted, gerr := s.guestResourceFilter(r, workspaceID)
+		if gerr != nil {
+			writeInternalError(w, gerr)
+			return
+		}
+		mgctx := openChildrenGuardContext{
+			r:                    r,
+			workspaceID:          workspaceID,
+			itemID:               item.ID,
+			parentSchema:         targetSchema,
+			parentSettings:       destSettings,
+			newFieldMap:          result.Fields,
+			visibleCollectionIDs: visIDs,
+			guestFullCollIDs:     guestFull,
+			guestGrantedItemIDs:  guestGranted,
+		}
+		movePrecheck = func(tx *sql.Tx, existing *models.Item) error {
+			txCtx := mgctx
+			txCtx.currentFieldsJS = existing.Fields
+			details, derr := s.runOpenChildrenGuard(tx, txCtx)
+			if derr != nil {
+				return derr
+			}
+			if details != nil {
+				return &openChildrenGuardError{details: details}
+			}
+			return nil
+		}
+	}
+
 	// Move the item
-	moved, err := s.store.MoveItem(item.ID, targetColl.ID, string(fieldsJSON))
+	moved, err := s.store.MoveItemWithPreCheck(item.ID, targetColl.ID, string(fieldsJSON), movePrecheck)
 	if err != nil {
+		if details, ok := asOpenChildrenGuardError(err); ok {
+			writeOpenChildrenError(w, itemRefOrSlug(*item), details)
+			return
+		}
 		writeInternalError(w, err)
 		return
 	}

--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -669,6 +669,14 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 	// the three UpdateItem call sites that follow. nil = no guard.
 	var openChildrenPrecheck func(tx *sql.Tx, existing *models.Item) error
 
+	// IDEA-1494 R4 P3: parent-link change is captured here and
+	// applied AFTER the main UpdateItemWithPreCheck succeeds, so a
+	// guard rejection on the status field doesn't leave a committed
+	// link change behind. Hoisted out of the `if input.Fields != nil`
+	// block so the post-write step can read them.
+	var parentValue string
+	var parentProvided bool
+
 	// If fields are being updated, validate against schema
 	if input.Fields != nil {
 		coll, err := s.store.GetCollection(item.CollectionID)
@@ -692,8 +700,9 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 		// Extract parent from fields — it's managed via item_links, not stored in fields JSON.
 		// Accepts both "parent" and "plan" as the field key.
 		// Skip this if the schema actually defines a field with that key.
-		var parentValue string
-		var parentProvided bool
+		// (parentValue / parentProvided are declared at outer scope so
+		// the deferred link-write block below can read them — see
+		// IDEA-1494 R4 P3.)
 		for _, key := range []string{"parent", "plan"} {
 			if schemaHasField(schema, key) {
 				continue
@@ -818,22 +827,25 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 		validated := string(validatedFields)
 		input.Fields = &validated
 
-		// Update parent link if parent was provided in the update
-		if parentProvided {
-			if parentValue != "" {
-				actor, _ := actorFromRequest(r)
-				if _, err := s.store.SetParentLink(workspaceID, item.ID, parentValue, actor); err != nil {
-					writeError(w, http.StatusInternalServerError, "internal_error", fmt.Sprintf("failed to update parent link: %v", err))
-					return
-				}
-			} else {
-				// Parent was explicitly set to empty/null — clear the link
-				if err := s.store.ClearParentLink(item.ID); err != nil {
-					writeError(w, http.StatusInternalServerError, "internal_error", fmt.Sprintf("failed to clear parent link: %v", err))
-					return
-				}
-			}
-		}
+		// IDEA-1494 R4 P3: parent-link mutations are DEFERRED until
+		// after the field write succeeds. Pre-fix this block ran the
+		// link update INLINE here — before the precheck even fired —
+		// so a PATCH that combined a parent change with a status flip
+		// could end up with the link committed AND the field write
+		// rejected by the guard. Caller saw 409 but the parent had
+		// already moved.
+		//
+		// Now we record the desired link change and execute it ONLY
+		// when the main UpdateItemWithPreCheck call below succeeds.
+		// A guard rejection short-circuits with the link untouched.
+		// Documented choice: "reorder, don't tx-wrap" — wrapping the
+		// link mutation in the same store tx as UpdateItem would
+		// require threading a tx through SetParentLink (which has
+		// its own tx already, and is also called from the
+		// handler_item_links path). Reordering is the smaller surgery
+		// and preserves atomicity in the failure direction — caller
+		// only sees both writes on success, or neither (with a clear
+		// 409) on rejection.
 	}
 
 	// Designated-applier routing (PLAN-1248 TASK-1257). When the
@@ -1076,6 +1088,34 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 	if updated == nil {
 		writeError(w, http.StatusNotFound, "not_found", "Item not found")
 		return
+	}
+
+	// IDEA-1494 R4 P3: deferred parent-link mutation. Runs ONLY now
+	// that the main UpdateItemWithPreCheck succeeded (the precheck
+	// passed AND the field write committed). A guard rejection above
+	// `return`s before reaching here, so the link is untouched on
+	// the failure path.
+	//
+	// Failure of the link write itself after a successful field
+	// write is still possible (e.g. SetParentLink discovers a cycle
+	// the cycle-check missed, or a DB error). We surface that as a
+	// 500 with the field write already committed — same partial-
+	// success window the pre-IDEA-1494 code had in the OTHER
+	// direction, and not made worse by the reorder. A future tx-
+	// wrap fix could close this entirely; out of scope for round 4.
+	if parentProvided {
+		if parentValue != "" {
+			actor, _ := actorFromRequest(r)
+			if _, err := s.store.SetParentLink(workspaceID, item.ID, parentValue, actor); err != nil {
+				writeError(w, http.StatusInternalServerError, "internal_error", fmt.Sprintf("failed to update parent link: %v", err))
+				return
+			}
+		} else {
+			if err := s.store.ClearParentLink(item.ID); err != nil {
+				writeError(w, http.StatusInternalServerError, "internal_error", fmt.Sprintf("failed to clear parent link: %v", err))
+				return
+			}
+		}
 	}
 
 	// Build rich metadata describing what changed

--- a/internal/server/handlers_items_open_children_guard.go
+++ b/internal/server/handlers_items_open_children_guard.go
@@ -5,29 +5,55 @@ package server
 // every interface (CLI, MCP, web UI) that hits handleUpdateItem.
 //
 // Trigger conditions (all must hold):
-//   1. The PATCH supplies a fields update.
-//   2. The new value for the parent collection's resolved done-field
-//      key is in TerminalValuesForDoneField.
-//   3. The CURRENT value for that key is NOT in the terminal set.
-//      (no-op terminal → terminal and terminal-to-terminal transitions
-//      bypass the guard — only entering the terminal set is gated.)
-//   4. The parent item has at least one non-deleted child whose own
-//      collection schema reports the child as non-terminal.
+//  1. The PATCH supplies a fields update.
+//  2. The new value for the parent collection's resolved done-field
+//     key is in TerminalValuesForDoneField.
+//  3. The CURRENT value for that key is NOT in the terminal set.
+//     (no-op terminal → terminal and terminal-to-terminal transitions
+//     bypass the guard — only entering the terminal set is gated.)
+//  4. The parent item has at least one non-deleted child whose own
+//     collection schema reports the child as non-terminal.
 //
 // The caller can override the guard with `--force` (CLI) / `force: true`
 // (MCP body field). The override still records the status change.
 //
-// Response shape on rejection (HTTP 409 Conflict):
+// ── Visibility (Codex round 2 P1) ─────────────────────────────────────
+// The invariant itself is a DATA-INTEGRITY gate, not a visibility
+// gate: we evaluate it against ALL children (so a caller with reduced
+// visibility can't close a parent that has children they don't see).
+// The 409 response payload, however, is sanitized — only children the
+// caller is allowed to see appear in `details.open_children`. When
+// hidden children contributed to the rejection (in part or in full)
+// the payload carries a separate `hidden_blocker_count` so MCP-driven
+// agents can distinguish:
+//
+//   - len(open_children)==0 + hidden_blocker_count==0 → would not have
+//     rejected (no path here, but the shape is unambiguous);
+//   - len(open_children)==N + hidden_blocker_count==0 → caller can see
+//     every blocker;
+//   - len(open_children)==N + hidden_blocker_count==M → caller sees N
+//     blockers + M additional that they can't access; recovery requires
+//     either coordination with someone who can or `--force` if their
+//     role permits.
+//
+// ── Atomicity (Codex round 2 P2) ──────────────────────────────────────
+// The guard query runs INSIDE the same store transaction as the
+// UPDATE, so a concurrent child insert / child status flip can't slip
+// between the read and the write. See Store.UpdateItemWithPreCheck +
+// Store.AcquireParentChildrenLock for the locking shape.
+//
+// ── Response (HTTP 409 Conflict) ──────────────────────────────────────
 //
 //	{
 //	  "error": {
 //	    "code": "open_children",
-//	    "message": "cannot mark TASK-5 completed: 2 child task(s) still open. Pass --force to override.",
+//	    "message": "cannot mark TASK-5 completed: ...",
 //	    "details": {
 //	      "open_children": [
 //	        {"ref":"TASK-7","title":"...","status":"open","collection_slug":"tasks"},
 //	        ...
 //	      ],
+//	      "hidden_blocker_count": 0,
 //	      "done_field": "status",
 //	      "attempted_value": "completed"
 //	    }
@@ -35,17 +61,34 @@ package server
 //	}
 //
 // `details.open_children` is the canonical machine-readable list — the
-// CLI renders the human message FROM the same list so the two paths
-// agree by construction.
+// CLI renders the human message FROM the same list (plus the hidden
+// count) so the two paths agree by construction.
 
 import (
+	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
 
 	"github.com/PerpetualSoftware/pad/internal/models"
 )
+
+// errOpenChildrenGuard is the sentinel the precheck returns to the
+// store layer when the guard fires. The handler unwraps it via
+// errors.As to lift the structured details back out for the 409
+// response. Using a typed sentinel (rather than a generic error)
+// keeps the store/handler boundary clean — the store just sees "the
+// precheck rejected" and rolls back the tx.
+type openChildrenGuardError struct {
+	details *openChildrenDetails
+}
+
+func (e *openChildrenGuardError) Error() string {
+	return fmt.Sprintf("open-children guard: %d visible + %d hidden blocker(s)",
+		len(e.details.OpenChildren), e.details.HiddenBlockerCount)
+}
 
 // itemRefOrSlug formats an item's issue ref (e.g. "TASK-5") when its
 // collection prefix + item number are populated, falling back to its
@@ -69,35 +112,50 @@ type openChildEntry struct {
 	CollectionSlug string `json:"collection_slug"`
 }
 
-// openChildrenError is the structured details payload.
+// openChildrenDetails is the structured details payload returned in
+// the 409 error body. `OpenChildren` is filtered for caller visibility;
+// `HiddenBlockerCount` reports the number of additional blockers that
+// would also need to clear (or be force-overridden) but that the
+// caller can't see.
 type openChildrenDetails struct {
-	OpenChildren   []openChildEntry `json:"open_children"`
-	DoneField      string           `json:"done_field"`
-	AttemptedValue string           `json:"attempted_value"`
+	OpenChildren       []openChildEntry `json:"open_children"`
+	HiddenBlockerCount int              `json:"hidden_blocker_count"`
+	DoneField          string           `json:"done_field"`
+	AttemptedValue     string           `json:"attempted_value"`
 }
 
-// evaluateOpenChildrenGuard returns a non-nil details payload when the
-// proposed update would transition the item into a terminal state and
-// the item has at least one non-terminal child. Returns (nil, nil) when
-// the guard does not apply (no transition, no children, no open
-// children). Errors from store calls propagate.
-//
-// newFieldMap is the post-validation merged fields map (the value about
-// to be persisted). currentFieldsJSON is the item's pre-update fields
-// JSON. parentSchema/parentSettings drive done-field resolution for the
-// parent item being updated. Each child is evaluated against ITS OWN
-// collection's schema + settings (not the parent's).
-func (s *Server) evaluateOpenChildrenGuard(
-	itemID string,
-	currentFieldsJSON string,
-	newFieldMap map[string]any,
-	parentSchema models.CollectionSchema,
-	parentSettings models.CollectionSettings,
-) (*openChildrenDetails, error) {
-	doneKey, terminalValues := models.TerminalValuesForDoneField(parentSchema, parentSettings)
+// openChildrenGuardContext bundles the read-only inputs the precheck
+// closure needs from the handler. Kept as a struct so the closure
+// signature stays narrow.
+type openChildrenGuardContext struct {
+	r               *http.Request
+	workspaceID     string
+	itemID          string
+	parentSchema    models.CollectionSchema
+	parentSettings  models.CollectionSettings
+	newFieldMap     map[string]any
+	currentFieldsJS string
+	// visibility filters, all pre-computed once by the handler.
+	visibleCollectionIDs []string // nil = unrestricted
+	guestFullCollIDs     []string
+	guestGrantedItemIDs  []string
+}
 
-	// New value must be present in the patch and terminal.
-	rawNew, ok := newFieldMap[doneKey]
+// runOpenChildrenGuard executes the guard logic inside the
+// store-layer transaction. Returns:
+//
+//   - (nil, nil) when the guard doesn't apply (no transition, no
+//     children, or all children terminal) — the update should proceed.
+//   - (details, nil) when the guard fires — the caller wraps these in
+//     openChildrenGuardError so the store rolls back. `details` is
+//     already sanitized for visibility.
+//   - (nil, err) on infrastructure errors (DB read failed, etc.).
+func (s *Server) runOpenChildrenGuard(tx *sql.Tx, ctx openChildrenGuardContext) (*openChildrenDetails, error) {
+	doneKey, terminalValues := models.TerminalValuesForDoneField(ctx.parentSchema, ctx.parentSettings)
+
+	// Trigger condition #1: the patch must set the resolved done-field
+	// key to a terminal value.
+	rawNew, ok := ctx.newFieldMap[doneKey]
 	if !ok {
 		return nil, nil
 	}
@@ -108,18 +166,15 @@ func (s *Server) evaluateOpenChildrenGuard(
 	if !valueInSet(newStr, terminalValues) {
 		return nil, nil
 	}
-
-	// Current value must NOT already be terminal — we only gate the
-	// non-terminal → terminal edge. terminal → terminal (e.g.
-	// completed → archived) and terminal → same-terminal (no-op) both
+	// Trigger condition #3: the current value must NOT already be
+	// terminal. terminal → terminal and no-op terminal transitions
 	// bypass.
-	currentVal := extractFieldString(currentFieldsJSON, doneKey)
+	currentVal := extractFieldString(ctx.currentFieldsJS, doneKey)
 	if currentVal != "" && valueInSet(currentVal, terminalValues) {
 		return nil, nil
 	}
 
-	// Cheap exit: no children at all.
-	children, err := s.store.GetChildItems(itemID)
+	children, err := s.store.GetChildItemsTx(tx, ctx.itemID)
 	if err != nil {
 		return nil, fmt.Errorf("load children for open-children guard: %w", err)
 	}
@@ -127,26 +182,41 @@ func (s *Server) evaluateOpenChildrenGuard(
 		return nil, nil
 	}
 
-	// Per-child done evaluation against the child's OWN collection
-	// schema. Cache schema+settings per child collection.
+	// Per-child done evaluation against the child's OWN collection.
+	// Cache schema+settings per child collection. The collection rows
+	// don't need to be read from the same tx — schemas don't mutate
+	// in the kind of races this guard cares about.
 	ctxCache := make(map[string]doneContext)
 	var open []openChildEntry
+	hidden := 0
 	for i := range children {
 		child := &children[i]
-		ctx, cached := ctxCache[child.CollectionID]
+		dc, cached := ctxCache[child.CollectionID]
 		if !cached {
 			if coll, cerr := s.store.GetCollection(child.CollectionID); cerr == nil && coll != nil {
-				_ = json.Unmarshal([]byte(coll.Schema), &ctx.schema)
+				_ = json.Unmarshal([]byte(coll.Schema), &dc.schema)
 				if coll.Settings != "" {
-					_ = json.Unmarshal([]byte(coll.Settings), &ctx.settings)
+					_ = json.Unmarshal([]byte(coll.Settings), &dc.settings)
 				}
 			}
-			ctxCache[child.CollectionID] = ctx
+			ctxCache[child.CollectionID] = dc
 		}
-		if isItemDone(child.Fields, child.CollectionID, map[string]doneContext{child.CollectionID: ctx}) {
+		// INVARIANT check uses ALL children. A restricted caller still
+		// gets blocked by a non-terminal child they can't see — the
+		// guard's purpose is data integrity, not visibility filtering.
+		if isItemDone(child.Fields, child.CollectionID, map[string]doneContext{child.CollectionID: dc}) {
 			continue
 		}
-		childDoneKey, _ := models.TerminalValuesForDoneField(ctx.schema, ctx.settings)
+
+		// Sanitize the response payload: surface only children this
+		// caller has permission to see. Hidden blockers are counted
+		// separately so the agent knows blocking state exists without
+		// learning ref/title/status of items they can't access.
+		if !s.openChildrenGuardChildVisible(ctx, child) {
+			hidden++
+			continue
+		}
+		childDoneKey, _ := models.TerminalValuesForDoneField(dc.schema, dc.settings)
 		open = append(open, openChildEntry{
 			Ref:            itemRefOrSlug(*child),
 			Title:          child.Title,
@@ -154,36 +224,86 @@ func (s *Server) evaluateOpenChildrenGuard(
 			CollectionSlug: child.CollectionSlug,
 		})
 	}
-	if len(open) == 0 {
+	if len(open) == 0 && hidden == 0 {
 		return nil, nil
 	}
 	return &openChildrenDetails{
-		OpenChildren:   open,
-		DoneField:      doneKey,
-		AttemptedValue: newStr,
+		OpenChildren:       open,
+		HiddenBlockerCount: hidden,
+		DoneField:          doneKey,
+		AttemptedValue:     newStr,
 	}, nil
+}
+
+// openChildrenGuardChildVisible mirrors the visibility check used by
+// the per-parent progress endpoint (handlers_items.go around
+// `progVisIDs` / `isCollectionVisible` / `isItemVisibleToGuest`).
+// Returns true when the caller is unrestricted or when the child
+// passes both the collection-level and item-level guest filters.
+func (s *Server) openChildrenGuardChildVisible(gctx openChildrenGuardContext, child *models.Item) bool {
+	// Unrestricted (admin / owner / no grant filtering in play): nil
+	// visibleCollectionIDs means "see everything." Matches the
+	// progress handler's convention.
+	if gctx.visibleCollectionIDs == nil {
+		return true
+	}
+	if !isCollectionVisible(child.CollectionID, gctx.visibleCollectionIDs) {
+		return false
+	}
+	return s.isItemVisibleToGuest(gctx.r, gctx.workspaceID, child, gctx.guestFullCollIDs, gctx.guestGrantedItemIDs)
 }
 
 // writeOpenChildrenError emits the 409 response with both a human
 // message AND the structured details payload. `parentRef` is the
 // already-formatted parent ref (e.g. "PLAN-12"); the message names the
-// parent + child count and points at --force.
+// parent + child count and points at --force. The phrasing splits on
+// whether any blockers are hidden so the human-readable line carries
+// the same signal `hidden_blocker_count` does for machines.
 func writeOpenChildrenError(w http.ResponseWriter, parentRef string, details *openChildrenDetails) {
-	noun := "child"
-	if len(details.OpenChildren) != 1 {
-		noun = "children"
+	visible := len(details.OpenChildren)
+	hidden := details.HiddenBlockerCount
+	var msg string
+	switch {
+	case visible > 0 && hidden > 0:
+		msg = fmt.Sprintf("cannot mark %s %s: %d open child(ren) still in a non-terminal state, plus %d additional you don't have access to. Pass --force to override.",
+			parentRef, details.AttemptedValue, visible, hidden)
+	case visible > 0:
+		noun := "child"
+		if visible != 1 {
+			noun = "children"
+		}
+		msg = fmt.Sprintf("cannot mark %s %s: %d open %s still in a non-terminal state. Pass --force to override.",
+			parentRef, details.AttemptedValue, visible, noun)
+	default:
+		// hidden > 0 only — the caller can't see any blocking children.
+		noun := "child"
+		if hidden != 1 {
+			noun = "children"
+		}
+		msg = fmt.Sprintf("cannot mark %s %s: blocked by %d open %s you don't have access to. Pass --force to override (if your role permits).",
+			parentRef, details.AttemptedValue, hidden, noun)
 	}
-	var b strings.Builder
-	fmt.Fprintf(&b, "cannot mark %s %s: %d open %s still in a non-terminal state. Pass --force to override.",
-		parentRef, details.AttemptedValue, len(details.OpenChildren), noun)
 
 	writeJSON(w, http.StatusConflict, map[string]any{
 		"error": map[string]any{
 			"code":    "open_children",
-			"message": b.String(),
+			"message": msg,
 			"details": details,
 		},
 	})
+}
+
+// asOpenChildrenGuardError unwraps a store-layer error that may carry
+// an openChildrenGuardError sentinel. Returns the sanitized details
+// and true when the error is the guard rejecting the precheck; nil +
+// false for any other error (the handler returns those via the
+// generic upstream-error path).
+func asOpenChildrenGuardError(err error) (*openChildrenDetails, bool) {
+	var sentinel *openChildrenGuardError
+	if errors.As(err, &sentinel) {
+		return sentinel.details, true
+	}
+	return nil, false
 }
 
 // valueInSet does a case-insensitive membership check.

--- a/internal/server/handlers_items_open_children_guard.go
+++ b/internal/server/handlers_items_open_children_guard.go
@@ -187,7 +187,12 @@ func (s *Server) runOpenChildrenGuard(tx *sql.Tx, ctx openChildrenGuardContext) 
 	// don't need to be read from the same tx — schemas don't mutate
 	// in the kind of races this guard cares about.
 	ctxCache := make(map[string]doneContext)
-	var open []openChildEntry
+	// Codex round-5 P3: initialize as empty (not nil) so the
+	// hidden-only rejection path serializes `open_children: []`
+	// rather than `null`. The contract documents this field as an
+	// array; clients (CLI renderer, MCP agents) `range` over it
+	// even when hidden_blocker_count > 0.
+	open := []openChildEntry{}
 	hidden := 0
 	for i := range children {
 		child := &children[i]

--- a/internal/server/handlers_items_open_children_guard.go
+++ b/internal/server/handlers_items_open_children_guard.go
@@ -193,7 +193,14 @@ func (s *Server) runOpenChildrenGuard(tx *sql.Tx, ctx openChildrenGuardContext) 
 		child := &children[i]
 		dc, cached := ctxCache[child.CollectionID]
 		if !cached {
-			if coll, cerr := s.store.GetCollection(child.CollectionID); cerr == nil && coll != nil {
+			// Codex round-3 P3: include soft-deleted collections so a
+			// child still attached to a soft-deleted collection is
+			// evaluated against its own done-field schema, not the
+			// default-status fallback (which would false-block when
+			// the collection's done-field is e.g. `resolution` with
+			// custom terminal_options). Mirrors the inclusion rule
+			// childrenDoneFiltersForParent uses (items.go ≈2165).
+			if coll, cerr := s.store.GetCollectionAnyState(child.CollectionID); cerr == nil && coll != nil {
 				_ = json.Unmarshal([]byte(coll.Schema), &dc.schema)
 				if coll.Settings != "" {
 					_ = json.Unmarshal([]byte(coll.Settings), &dc.settings)

--- a/internal/server/handlers_items_open_children_guard.go
+++ b/internal/server/handlers_items_open_children_guard.go
@@ -40,7 +40,7 @@ package server
 // The guard query runs INSIDE the same store transaction as the
 // UPDATE, so a concurrent child insert / child status flip can't slip
 // between the read and the write. See Store.UpdateItemWithPreCheck +
-// Store.AcquireParentChildrenLock for the locking shape.
+// Store.AcquireParentChildrenLocks for the locking shape.
 //
 // ── Response (HTTP 409 Conflict) ──────────────────────────────────────
 //

--- a/internal/server/handlers_items_open_children_guard.go
+++ b/internal/server/handlers_items_open_children_guard.go
@@ -1,0 +1,213 @@
+package server
+
+// IDEA-1494 — Refuse to mark an item terminal while it still has
+// non-terminal children. The guard fires server-side so it covers
+// every interface (CLI, MCP, web UI) that hits handleUpdateItem.
+//
+// Trigger conditions (all must hold):
+//   1. The PATCH supplies a fields update.
+//   2. The new value for the parent collection's resolved done-field
+//      key is in TerminalValuesForDoneField.
+//   3. The CURRENT value for that key is NOT in the terminal set.
+//      (no-op terminal → terminal and terminal-to-terminal transitions
+//      bypass the guard — only entering the terminal set is gated.)
+//   4. The parent item has at least one non-deleted child whose own
+//      collection schema reports the child as non-terminal.
+//
+// The caller can override the guard with `--force` (CLI) / `force: true`
+// (MCP body field). The override still records the status change.
+//
+// Response shape on rejection (HTTP 409 Conflict):
+//
+//	{
+//	  "error": {
+//	    "code": "open_children",
+//	    "message": "cannot mark TASK-5 completed: 2 child task(s) still open. Pass --force to override.",
+//	    "details": {
+//	      "open_children": [
+//	        {"ref":"TASK-7","title":"...","status":"open","collection_slug":"tasks"},
+//	        ...
+//	      ],
+//	      "done_field": "status",
+//	      "attempted_value": "completed"
+//	    }
+//	  }
+//	}
+//
+// `details.open_children` is the canonical machine-readable list — the
+// CLI renders the human message FROM the same list so the two paths
+// agree by construction.
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// itemRefOrSlug formats an item's issue ref (e.g. "TASK-5") when its
+// collection prefix + item number are populated, falling back to its
+// slug. Avoids pulling internal/cli into the server package for one
+// helper.
+func itemRefOrSlug(it models.Item) string {
+	if it.CollectionPrefix != "" && it.ItemNumber != nil {
+		return fmt.Sprintf("%s-%d", it.CollectionPrefix, *it.ItemNumber)
+	}
+	return it.Slug
+}
+
+// openChildEntry is the per-child payload returned in the structured
+// error. Mirrors what `pad item list --parent X --status non-terminal`
+// would surface so MCP-driven agents can self-recover (e.g. ship the
+// children, then retry).
+type openChildEntry struct {
+	Ref            string `json:"ref"`
+	Title          string `json:"title"`
+	Status         string `json:"status"`
+	CollectionSlug string `json:"collection_slug"`
+}
+
+// openChildrenError is the structured details payload.
+type openChildrenDetails struct {
+	OpenChildren   []openChildEntry `json:"open_children"`
+	DoneField      string           `json:"done_field"`
+	AttemptedValue string           `json:"attempted_value"`
+}
+
+// evaluateOpenChildrenGuard returns a non-nil details payload when the
+// proposed update would transition the item into a terminal state and
+// the item has at least one non-terminal child. Returns (nil, nil) when
+// the guard does not apply (no transition, no children, no open
+// children). Errors from store calls propagate.
+//
+// newFieldMap is the post-validation merged fields map (the value about
+// to be persisted). currentFieldsJSON is the item's pre-update fields
+// JSON. parentSchema/parentSettings drive done-field resolution for the
+// parent item being updated. Each child is evaluated against ITS OWN
+// collection's schema + settings (not the parent's).
+func (s *Server) evaluateOpenChildrenGuard(
+	itemID string,
+	currentFieldsJSON string,
+	newFieldMap map[string]any,
+	parentSchema models.CollectionSchema,
+	parentSettings models.CollectionSettings,
+) (*openChildrenDetails, error) {
+	doneKey, terminalValues := models.TerminalValuesForDoneField(parentSchema, parentSettings)
+
+	// New value must be present in the patch and terminal.
+	rawNew, ok := newFieldMap[doneKey]
+	if !ok {
+		return nil, nil
+	}
+	newStr, ok := rawNew.(string)
+	if !ok || newStr == "" {
+		return nil, nil
+	}
+	if !valueInSet(newStr, terminalValues) {
+		return nil, nil
+	}
+
+	// Current value must NOT already be terminal — we only gate the
+	// non-terminal → terminal edge. terminal → terminal (e.g.
+	// completed → archived) and terminal → same-terminal (no-op) both
+	// bypass.
+	currentVal := extractFieldString(currentFieldsJSON, doneKey)
+	if currentVal != "" && valueInSet(currentVal, terminalValues) {
+		return nil, nil
+	}
+
+	// Cheap exit: no children at all.
+	children, err := s.store.GetChildItems(itemID)
+	if err != nil {
+		return nil, fmt.Errorf("load children for open-children guard: %w", err)
+	}
+	if len(children) == 0 {
+		return nil, nil
+	}
+
+	// Per-child done evaluation against the child's OWN collection
+	// schema. Cache schema+settings per child collection.
+	ctxCache := make(map[string]doneContext)
+	var open []openChildEntry
+	for i := range children {
+		child := &children[i]
+		ctx, cached := ctxCache[child.CollectionID]
+		if !cached {
+			if coll, cerr := s.store.GetCollection(child.CollectionID); cerr == nil && coll != nil {
+				_ = json.Unmarshal([]byte(coll.Schema), &ctx.schema)
+				if coll.Settings != "" {
+					_ = json.Unmarshal([]byte(coll.Settings), &ctx.settings)
+				}
+			}
+			ctxCache[child.CollectionID] = ctx
+		}
+		if isItemDone(child.Fields, child.CollectionID, map[string]doneContext{child.CollectionID: ctx}) {
+			continue
+		}
+		childDoneKey, _ := models.TerminalValuesForDoneField(ctx.schema, ctx.settings)
+		open = append(open, openChildEntry{
+			Ref:            itemRefOrSlug(*child),
+			Title:          child.Title,
+			Status:         extractFieldString(child.Fields, childDoneKey),
+			CollectionSlug: child.CollectionSlug,
+		})
+	}
+	if len(open) == 0 {
+		return nil, nil
+	}
+	return &openChildrenDetails{
+		OpenChildren:   open,
+		DoneField:      doneKey,
+		AttemptedValue: newStr,
+	}, nil
+}
+
+// writeOpenChildrenError emits the 409 response with both a human
+// message AND the structured details payload. `parentRef` is the
+// already-formatted parent ref (e.g. "PLAN-12"); the message names the
+// parent + child count and points at --force.
+func writeOpenChildrenError(w http.ResponseWriter, parentRef string, details *openChildrenDetails) {
+	noun := "child"
+	if len(details.OpenChildren) != 1 {
+		noun = "children"
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "cannot mark %s %s: %d open %s still in a non-terminal state. Pass --force to override.",
+		parentRef, details.AttemptedValue, len(details.OpenChildren), noun)
+
+	writeJSON(w, http.StatusConflict, map[string]any{
+		"error": map[string]any{
+			"code":    "open_children",
+			"message": b.String(),
+			"details": details,
+		},
+	})
+}
+
+// valueInSet does a case-insensitive membership check.
+func valueInSet(v string, set []string) bool {
+	low := strings.ToLower(strings.TrimSpace(v))
+	for _, s := range set {
+		if strings.ToLower(s) == low {
+			return true
+		}
+	}
+	return false
+}
+
+// extractFieldString reads a top-level scalar string from a JSON-encoded
+// fields map. Returns "" when the JSON is empty, malformed, the key is
+// missing, or the value isn't a string.
+func extractFieldString(fieldsJSON, key string) string {
+	if fieldsJSON == "" || fieldsJSON == "{}" {
+		return ""
+	}
+	var m map[string]any
+	if err := json.Unmarshal([]byte(fieldsJSON), &m); err != nil {
+		return ""
+	}
+	s, _ := m[key].(string)
+	return s
+}

--- a/internal/server/handlers_items_open_children_guard_test.go
+++ b/internal/server/handlers_items_open_children_guard_test.go
@@ -1,0 +1,354 @@
+package server
+
+// IDEA-1494 — handler-level coverage for the open-children guard on
+// `pad item update` (handleUpdateItem). Each test seeds a parent +
+// children via the public HTTP API so we exercise the same code path
+// CLI / MCP traffic hits.
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// seedParentAndChildren creates a plan + N child tasks with the given
+// statuses (one per child), returning the parent and the slice of child
+// refs in creation order. Uses the default workspace template so the
+// `tasks` and `plans` collections exist with their default schemas.
+func seedParentAndChildren(t *testing.T, srv *Server, wsSlug string, childStatuses []string) (models.Item, []models.Item) {
+	t.Helper()
+	planResp := doRequest(srv, "POST", "/api/v1/workspaces/"+wsSlug+"/collections/plans/items", map[string]interface{}{
+		"title":  "PLAN under test",
+		"fields": `{"status":"active"}`,
+	})
+	if planResp.Code != http.StatusCreated {
+		t.Fatalf("seed plan: expected 201, got %d: %s", planResp.Code, planResp.Body.String())
+	}
+	var plan models.Item
+	parseJSON(t, planResp, &plan)
+
+	children := make([]models.Item, 0, len(childStatuses))
+	for i, status := range childStatuses {
+		body := map[string]interface{}{
+			"title":  "child " + status,
+			"fields": map[string]interface{}{"status": status, "parent": plan.Ref},
+		}
+		_ = i
+		rr := doRequest(srv, "POST", "/api/v1/workspaces/"+wsSlug+"/collections/tasks/items", body)
+		if rr.Code != http.StatusCreated {
+			t.Fatalf("seed child %d: expected 201, got %d: %s", i, rr.Code, rr.Body.String())
+		}
+		var c models.Item
+		parseJSON(t, rr, &c)
+		children = append(children, c)
+	}
+	return plan, children
+}
+
+func TestOpenChildrenGuard_RejectsTerminalWithOpenChildren(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	plan, children := seedParentAndChildren(t, srv, slug, []string{"open", "done"})
+
+	rr := doRequest(srv, "PATCH", "/api/v1/workspaces/"+slug+"/items/"+plan.Ref, map[string]interface{}{
+		"fields": map[string]interface{}{"status": "completed"},
+	})
+	if rr.Code != http.StatusConflict {
+		t.Fatalf("expected 409 Conflict, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var resp struct {
+		Error struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+			Details struct {
+				OpenChildren []struct {
+					Ref            string `json:"ref"`
+					Title          string `json:"title"`
+					Status         string `json:"status"`
+					CollectionSlug string `json:"collection_slug"`
+				} `json:"open_children"`
+				DoneField      string `json:"done_field"`
+				AttemptedValue string `json:"attempted_value"`
+			} `json:"details"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("parse error body: %v (raw=%s)", err, rr.Body.String())
+	}
+	if resp.Error.Code != "open_children" {
+		t.Fatalf("expected code=open_children, got %q", resp.Error.Code)
+	}
+	if len(resp.Error.Details.OpenChildren) != 1 {
+		t.Fatalf("expected exactly 1 open child in details, got %d (%+v)",
+			len(resp.Error.Details.OpenChildren), resp.Error.Details.OpenChildren)
+	}
+	got := resp.Error.Details.OpenChildren[0]
+	if got.Ref != children[0].Ref {
+		t.Errorf("open child ref: want %q, got %q", children[0].Ref, got.Ref)
+	}
+	if got.Status != "open" {
+		t.Errorf("open child status: want open, got %q", got.Status)
+	}
+	if got.CollectionSlug != "tasks" {
+		t.Errorf("open child collection_slug: want tasks, got %q", got.CollectionSlug)
+	}
+	if got.Title == "" {
+		t.Errorf("open child title should be populated")
+	}
+	if resp.Error.Details.DoneField != "status" {
+		t.Errorf("expected done_field=status, got %q", resp.Error.Details.DoneField)
+	}
+	if resp.Error.Details.AttemptedValue != "completed" {
+		t.Errorf("expected attempted_value=completed, got %q", resp.Error.Details.AttemptedValue)
+	}
+	if !strings.Contains(resp.Error.Message, "--force") {
+		t.Errorf("expected message to mention --force escape hatch, got %q", resp.Error.Message)
+	}
+
+	// Mutation safety: the parent's status must be unchanged.
+	getResp := doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/items/"+plan.Ref, nil)
+	if getResp.Code != http.StatusOK {
+		t.Fatalf("re-read parent: %d", getResp.Code)
+	}
+	var fresh models.Item
+	parseJSON(t, getResp, &fresh)
+	var fields map[string]any
+	_ = json.Unmarshal([]byte(fresh.Fields), &fields)
+	if s, _ := fields["status"].(string); s != "active" {
+		t.Errorf("parent status should be unchanged after rejection, got %q", s)
+	}
+}
+
+func TestOpenChildrenGuard_NoChildren_OK(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	planResp := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections/plans/items", map[string]interface{}{
+		"title":  "lone plan",
+		"fields": `{"status":"active"}`,
+	})
+	parseJSON(t, planResp, &models.Item{})
+	var plan models.Item
+	parseJSON(t, planResp, &plan)
+
+	rr := doRequest(srv, "PATCH", "/api/v1/workspaces/"+slug+"/items/"+plan.Ref, map[string]interface{}{
+		"fields": map[string]interface{}{"status": "completed"},
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 (no children, no guard), got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestOpenChildrenGuard_AllChildrenTerminal_OK(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	plan, _ := seedParentAndChildren(t, srv, slug, []string{"done", "cancelled"})
+
+	rr := doRequest(srv, "PATCH", "/api/v1/workspaces/"+slug+"/items/"+plan.Ref, map[string]interface{}{
+		"fields": map[string]interface{}{"status": "completed"},
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 (all children terminal), got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestOpenChildrenGuard_ForceOverrides(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	plan, _ := seedParentAndChildren(t, srv, slug, []string{"open"})
+
+	rr := doRequest(srv, "PATCH", "/api/v1/workspaces/"+slug+"/items/"+plan.Ref, map[string]interface{}{
+		"fields": map[string]interface{}{"status": "completed"},
+		"force":  true,
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 with force=true, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var updated models.Item
+	parseJSON(t, rr, &updated)
+	var fields map[string]any
+	_ = json.Unmarshal([]byte(updated.Fields), &fields)
+	if s, _ := fields["status"].(string); s != "completed" {
+		t.Errorf("expected parent status=completed with force, got %q", s)
+	}
+}
+
+func TestOpenChildrenGuard_NonTerminalTransition_NotGuarded(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	plan, _ := seedParentAndChildren(t, srv, slug, []string{"open"})
+
+	// active → paused is non-terminal → non-terminal; no guard.
+	rr := doRequest(srv, "PATCH", "/api/v1/workspaces/"+slug+"/items/"+plan.Ref, map[string]interface{}{
+		"fields": map[string]interface{}{"status": "paused"},
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 for non-terminal transition, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestOpenChildrenGuard_TerminalToTerminal_NotGuarded(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	// Custom collection with two terminal options so we can transition
+	// between them. The plans schema only declares one terminal value
+	// (`completed`), so we need a richer schema to exercise this edge.
+	collResp := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections", map[string]interface{}{
+		"name":   "Releases",
+		"icon":   "package",
+		"schema": `{"fields":[{"key":"status","label":"Status","type":"select","options":["draft","shipped","archived"],"terminal_options":["shipped","archived"]}]}`,
+	})
+	if collResp.Code != http.StatusCreated {
+		t.Fatalf("create releases collection: %d %s", collResp.Code, collResp.Body.String())
+	}
+	parentResp := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections/releases/items", map[string]interface{}{
+		"title":  "v1.0",
+		"fields": map[string]interface{}{"status": "shipped"},
+	})
+	if parentResp.Code != http.StatusCreated {
+		t.Fatalf("create release: %d %s", parentResp.Code, parentResp.Body.String())
+	}
+	var release models.Item
+	parseJSON(t, parentResp, &release)
+
+	// Hang an open child task off the release.
+	childResp := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections/tasks/items", map[string]interface{}{
+		"title":  "follow-up",
+		"fields": map[string]interface{}{"status": "open", "parent": release.Ref},
+	})
+	if childResp.Code != http.StatusCreated {
+		t.Fatalf("create child: %d %s", childResp.Code, childResp.Body.String())
+	}
+
+	// shipped → archived is terminal → terminal under the release
+	// schema; the guard should not fire even though an open child is
+	// still attached. Only non-terminal → terminal is gated.
+	rr := doRequest(srv, "PATCH", "/api/v1/workspaces/"+slug+"/items/"+release.Ref, map[string]interface{}{
+		"fields": map[string]interface{}{"status": "archived"},
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 for terminal→terminal transition, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestOpenChildrenGuard_NoOpTerminal_NotGuarded(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	plan, _ := seedParentAndChildren(t, srv, slug, []string{"open"})
+	// Force-flip to completed first.
+	rr := doRequest(srv, "PATCH", "/api/v1/workspaces/"+slug+"/items/"+plan.Ref, map[string]interface{}{
+		"fields": map[string]interface{}{"status": "completed"},
+		"force":  true,
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("setup force-complete: %d", rr.Code)
+	}
+
+	// completed → completed is a no-op terminal transition; guard
+	// must not fire.
+	rr = doRequest(srv, "PATCH", "/api/v1/workspaces/"+slug+"/items/"+plan.Ref, map[string]interface{}{
+		"fields": map[string]interface{}{"status": "completed"},
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 for no-op terminal transition, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestOpenChildrenGuard_UsesCollectionTerminalOptions(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	// Custom collection whose `status` field declares its own
+	// terminal_options (no overlap with DefaultTerminalStatuses' core
+	// trio). Ensures the guard reads terminal_options from the schema,
+	// not the global default list.
+	collResp := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections", map[string]interface{}{
+		"name":   "Epics",
+		"icon":   "package",
+		"schema": `{"fields":[{"key":"status","label":"Status","type":"select","options":["todo","shipping","shipped"],"terminal_options":["shipped"]}]}`,
+	})
+	if collResp.Code != http.StatusCreated {
+		t.Fatalf("create epic collection: %d %s", collResp.Code, collResp.Body.String())
+	}
+	parentResp := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections/epics/items", map[string]interface{}{
+		"title":  "Epic",
+		"fields": map[string]interface{}{"status": "todo"},
+	})
+	if parentResp.Code != http.StatusCreated {
+		t.Fatalf("create epic: %d %s", parentResp.Code, parentResp.Body.String())
+	}
+	var epic models.Item
+	parseJSON(t, parentResp, &epic)
+
+	// Hang an open child task off the epic. Tasks use their own
+	// default terminal list — `open` is not in it, so the child reads
+	// as non-terminal.
+	childResp := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections/tasks/items", map[string]interface{}{
+		"title":  "epic child",
+		"fields": map[string]interface{}{"status": "open", "parent": epic.Ref},
+	})
+	if childResp.Code != http.StatusCreated {
+		t.Fatalf("create child: %d %s", childResp.Code, childResp.Body.String())
+	}
+
+	// Attempt to move the epic to its declared terminal value.
+	rr := doRequest(srv, "PATCH", "/api/v1/workspaces/"+slug+"/items/"+epic.Ref, map[string]interface{}{
+		"fields": map[string]interface{}{"status": "shipped"},
+	})
+	if rr.Code != http.StatusConflict {
+		t.Fatalf("expected 409 for shipped transition with open child, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	// `shipping` is non-terminal under the schema even though it
+	// sounds done-ish; the guard must not fire.
+	rr = doRequest(srv, "PATCH", "/api/v1/workspaces/"+slug+"/items/"+epic.Ref, map[string]interface{}{
+		"fields": map[string]interface{}{"status": "shipping"},
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 for non-terminal `shipping`, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+// TestOpenChildrenGuard_GuardAppliesToAnyParent confirms the guard
+// fires for parent items beyond just `plans` — IDEA-1494 optional extra
+// #3 (the brief explicitly adopts it). Uses a Task with a child Task
+// to exercise the non-plan path.
+func TestOpenChildrenGuard_GuardAppliesToAnyParent(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	parentResp := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections/tasks/items", map[string]interface{}{
+		"title":  "parent task",
+		"fields": map[string]interface{}{"status": "open"},
+	})
+	if parentResp.Code != http.StatusCreated {
+		t.Fatalf("create parent task: %d %s", parentResp.Code, parentResp.Body.String())
+	}
+	var parent models.Item
+	parseJSON(t, parentResp, &parent)
+
+	childResp := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections/tasks/items", map[string]interface{}{
+		"title":  "subtask",
+		"fields": map[string]interface{}{"status": "open", "parent": parent.Ref},
+	})
+	if childResp.Code != http.StatusCreated {
+		t.Fatalf("create subtask: %d %s", childResp.Code, childResp.Body.String())
+	}
+
+	rr := doRequest(srv, "PATCH", "/api/v1/workspaces/"+slug+"/items/"+parent.Ref, map[string]interface{}{
+		"fields": map[string]interface{}{"status": "done"},
+	})
+	if rr.Code != http.StatusConflict {
+		t.Fatalf("expected 409 for task-with-open-subtask, got %d: %s", rr.Code, rr.Body.String())
+	}
+}

--- a/internal/server/handlers_items_open_children_guard_test.go
+++ b/internal/server/handlers_items_open_children_guard_test.go
@@ -6,6 +6,7 @@ package server
 // CLI / MCP traffic hits.
 
 import (
+	"database/sql"
 	"encoding/json"
 	"net/http"
 	"strings"
@@ -648,5 +649,425 @@ func TestOpenChildrenGuard_TOCTOURace(t *testing.T) {
 			t.Fatalf("iter %d: TOCTOU violation — parent=completed with child still open. parent PATCH status=%d body=%s",
 				i, parentRR.Code, parentRR.Body.String())
 		}
+	}
+}
+
+// TestOpenChildrenGuard_MoveItem_RejectsTerminalWithOpenChildren covers
+// Codex round-3 P1: `pad item move ... --field status=completed` now
+// runs the same guard as the regular update path. Without the
+// MoveItemWithPreCheck wiring, this PATCH would silently complete
+// a parent that still has open children.
+func TestOpenChildrenGuard_MoveItem_RejectsTerminalWithOpenChildren(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	// Plan with one open child. We then "move" the plan to its OWN
+	// collection equivalent via a custom collection that has the
+	// same terminal-options shape. To exercise the move path we need
+	// a different target collection; use a custom one we create with
+	// matching schema (terminal_options=[completed]).
+	collResp := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections", map[string]interface{}{
+		"name":   "Programs",
+		"icon":   "package",
+		"schema": `{"fields":[{"key":"status","label":"Status","type":"select","options":["active","completed"],"terminal_options":["completed"]}]}`,
+	})
+	if collResp.Code != http.StatusCreated {
+		t.Fatalf("create programs collection: %d %s", collResp.Code, collResp.Body.String())
+	}
+
+	plan, _ := seedParentAndChildren(t, srv, slug, []string{"open"})
+
+	moveResp := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/items/"+plan.Ref+"/move", map[string]interface{}{
+		"target_collection": "programs",
+		"field_overrides":   map[string]any{"status": "completed"},
+	})
+	if moveResp.Code != http.StatusConflict {
+		t.Fatalf("expected 409 for move-into-terminal with open child, got %d: %s", moveResp.Code, moveResp.Body.String())
+	}
+	var resp struct {
+		Error struct {
+			Code    string `json:"code"`
+			Details struct {
+				OpenChildren []map[string]any `json:"open_children"`
+			} `json:"details"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(moveResp.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if resp.Error.Code != "open_children" {
+		t.Errorf("expected code=open_children from move, got %q", resp.Error.Code)
+	}
+	if len(resp.Error.Details.OpenChildren) != 1 {
+		t.Errorf("expected 1 blocking child from move guard, got %d", len(resp.Error.Details.OpenChildren))
+	}
+
+	// Sanity: the item was NOT moved (still in plans collection,
+	// still active status). Mutation-safety check.
+	getResp := doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/items/"+plan.Ref, nil)
+	if getResp.Code != http.StatusOK {
+		t.Fatalf("re-read plan: %d", getResp.Code)
+	}
+	var fresh models.Item
+	parseJSON(t, getResp, &fresh)
+	if fresh.CollectionSlug != "plans" {
+		t.Errorf("plan was moved despite 409 — collection now %q", fresh.CollectionSlug)
+	}
+}
+
+// TestOpenChildrenGuard_MoveItem_ForceOverrides confirms the move
+// path's `?force=true` query escapes the guard, mirroring the update
+// path's --force.
+func TestOpenChildrenGuard_MoveItem_ForceOverrides(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	collResp := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections", map[string]interface{}{
+		"name":   "Programs",
+		"icon":   "package",
+		"schema": `{"fields":[{"key":"status","label":"Status","type":"select","options":["active","completed"],"terminal_options":["completed"]}]}`,
+	})
+	if collResp.Code != http.StatusCreated {
+		t.Fatalf("create programs collection: %d", collResp.Code)
+	}
+
+	plan, _ := seedParentAndChildren(t, srv, slug, []string{"open"})
+
+	moveResp := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/items/"+plan.Ref+"/move?force=true", map[string]interface{}{
+		"target_collection": "programs",
+		"field_overrides":   map[string]any{"status": "completed"},
+	})
+	if moveResp.Code != http.StatusOK {
+		t.Fatalf("expected 200 with force=true, got %d: %s", moveResp.Code, moveResp.Body.String())
+	}
+}
+
+// TestOpenChildrenGuard_LinkMutationRace covers Codex round-3 P1: a
+// concurrent SetParentLink that attempts to attach a non-terminal
+// child to a parent while a terminal-status UPDATE on the parent is
+// in flight must not slip past the guard's view of the children set.
+//
+// Allowed outcomes (documented semantics):
+//
+//  1. Link tx commits first → parent UPDATE's in-tx precheck sees
+//     the open child → 409, parent stays active.
+//  2. Parent UPDATE tx commits first → parent terminal, then the
+//     link tx commits AFTER. The link is then attached to an
+//     already-terminal parent; this is legal under the invariant
+//     "no open children EXIST AT THE MOMENT the parent transitions
+//     to terminal." The stricter post-condition ("no open child may
+//     EVER be attached to a terminal parent") would require
+//     SetParentLink to reject when the target is terminal; that is
+//     intentionally deferred — out of scope for round 3.
+//
+// Forbidden outcome (the bug round-3 P1 fixes):
+//
+//	link tx commits BEFORE parent UPDATE tx, AND parent UPDATE
+//	still succeeds. That would require the parent's precheck to
+//	have read children=[] from a snapshot taken before the link
+//	was attached — i.e. SetParentLink failed to serialize against
+//	the parent-children advisory lock the precheck holds. We
+//	detect this by comparing the link's created_at against the
+//	parent's post-commit updated_at.
+func TestOpenChildrenGuard_LinkMutationRace(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	// Seed: an empty plan + a standalone open task we'll attach
+	// concurrently with the plan's terminal-status update.
+	const iterations = 6
+	for i := 0; i < iterations; i++ {
+		planResp := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections/plans/items", map[string]interface{}{
+			"title":  "race plan",
+			"fields": `{"status":"active"}`,
+		})
+		if planResp.Code != http.StatusCreated {
+			t.Fatalf("iter %d seed plan: %d %s", i, planResp.Code, planResp.Body.String())
+		}
+		var plan models.Item
+		parseJSON(t, planResp, &plan)
+
+		taskResp := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections/tasks/items", map[string]interface{}{
+			"title":  "race task",
+			"fields": `{"status":"open"}`,
+		})
+		if taskResp.Code != http.StatusCreated {
+			t.Fatalf("iter %d seed task: %d %s", i, taskResp.Code, taskResp.Body.String())
+		}
+		var task models.Item
+		parseJSON(t, taskResp, &task)
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+
+		// Racer: attach the task as a child of the plan via the
+		// links endpoint. SetParentLink (the underlying store call)
+		// now acquires the parent-children advisory lock.
+		go func() {
+			defer wg.Done()
+			time.Sleep(100 * time.Microsecond)
+			_ = doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/items/"+task.Ref+"/links", map[string]interface{}{
+				"target_id": plan.ID,
+				"link_type": "parent",
+			})
+		}()
+
+		// Parent flip.
+		_ = doRequest(srv, "PATCH", "/api/v1/workspaces/"+slug+"/items/"+plan.Ref, map[string]interface{}{
+			"fields": map[string]interface{}{"status": "completed"},
+		})
+		wg.Wait()
+
+		// Inspect the post-race state.
+		planGet := doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/items/"+plan.Ref, nil)
+		var pf models.Item
+		parseJSON(t, planGet, &pf)
+		var planFields map[string]any
+		_ = json.Unmarshal([]byte(pf.Fields), &planFields)
+		planStatus, _ := planFields["status"].(string)
+		if planStatus != "completed" {
+			// Outcome 1: link won, parent stayed active (or got
+			// rejected). Acceptable per the documented semantics.
+			continue
+		}
+
+		// Plan committed terminal. Check whether the task is linked
+		// as its child — and if so, that the LINK was created AFTER
+		// the parent's terminal-status commit. The advisory lock
+		// ensures one of the two strict orderings: either the link
+		// committed first (and then the parent UPDATE precheck would
+		// have read it and rejected — so planStatus wouldn't be
+		// completed), OR the parent UPDATE committed first and the
+		// link followed. The forbidden interleaving is "link
+		// committed BEFORE parent flip AND parent flip still
+		// succeeded" — that's only possible if SetParentLink failed
+		// to serialize against the UPDATE.
+		linksGet := doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/items/"+plan.Ref+"/links", nil)
+		var links []models.ItemLink
+		parseJSON(t, linksGet, &links)
+		for _, l := range links {
+			if l.SourceID != task.ID || l.LinkType != "parent" {
+				continue
+			}
+			// Found the link. Compare its created_at against the
+			// parent's updated_at. Parent UPDATE bumps updated_at;
+			// link insert stamps created_at. If link.created_at <
+			// parent.updated_at, the link DEFINITELY committed
+			// first → the parent's precheck should have seen it →
+			// terminal commit would have been rejected → bug.
+			if !l.CreatedAt.IsZero() && !pf.UpdatedAt.IsZero() && l.CreatedAt.Before(pf.UpdatedAt) {
+				t.Fatalf("iter %d: TOCTOU violation — link committed at %v (before parent terminal commit at %v) AND parent reached terminal. The advisory lock failed to serialize.",
+					i, l.CreatedAt, pf.UpdatedAt)
+			}
+		}
+	}
+}
+
+// TestOpenChildrenGuard_SoftDeletedCollectionSchemaHonored covers
+// Codex round-3 P3: when a child still exists in a soft-deleted
+// collection whose schema has a custom terminal_options set, the
+// guard reads the schema via GetCollectionAnyState so the child is
+// evaluated against the custom done-field — not the default-status
+// fallback which would mis-classify it as non-terminal.
+func TestOpenChildrenGuard_SoftDeletedCollectionSchemaHonored(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	// Create a child collection with a non-default done-field shape:
+	// schema declares `done` as the only terminal value (the global
+	// default list also contains "done" so we use a custom code that
+	// ISN'T in DefaultTerminalStatuses to actually exercise the
+	// schema-driven path).
+	collResp := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections", map[string]interface{}{
+		"name":   "Subtasks",
+		"icon":   "list",
+		"schema": `{"fields":[{"key":"status","label":"Status","type":"select","options":["open","retired"],"terminal_options":["retired"]}]}`,
+	})
+	if collResp.Code != http.StatusCreated {
+		t.Fatalf("create subtasks collection: %d %s", collResp.Code, collResp.Body.String())
+	}
+	var subColl models.Collection
+	parseJSON(t, collResp, &subColl)
+
+	// Parent + child in the subtasks collection.
+	planResp := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections/plans/items", map[string]interface{}{
+		"title":  "Plan",
+		"fields": `{"status":"active"}`,
+	})
+	var plan models.Item
+	parseJSON(t, planResp, &plan)
+
+	childResp := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections/subtasks/items", map[string]interface{}{
+		"title":  "still-open subtask",
+		"fields": map[string]interface{}{"status": "retired", "parent": plan.Ref},
+	})
+	if childResp.Code != http.StatusCreated {
+		t.Fatalf("create child: %d %s", childResp.Code, childResp.Body.String())
+	}
+
+	// Soft-delete the subtasks collection. (The child item stays
+	// attached — soft-delete on the collection doesn't cascade to
+	// items via the link table.)
+	del := doRequest(srv, "DELETE", "/api/v1/workspaces/"+slug+"/collections/"+subColl.Slug, nil)
+	if del.Code != http.StatusNoContent {
+		t.Fatalf("soft-delete collection: %d %s", del.Code, del.Body.String())
+	}
+
+	// Now mark the plan completed. The child is `retired` — terminal
+	// per the (soft-deleted) collection's schema. With round-3 P3
+	// fixed, the guard reads the schema via GetCollectionAnyState
+	// and recognizes `retired` as terminal → no blocker → 200.
+	// Without the fix, the guard would fall back to the default
+	// status list which doesn't include `retired`, miscount the
+	// child as a blocker, and return 409 — i.e. a false positive.
+	rr := doRequest(srv, "PATCH", "/api/v1/workspaces/"+slug+"/items/"+plan.Ref, map[string]interface{}{
+		"fields": map[string]interface{}{"status": "completed"},
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 (terminal child in soft-deleted collection should not block), got %d: %s",
+			rr.Code, rr.Body.String())
+	}
+}
+
+// TestOpenChildrenGuard_VisibilityLookupErrorFailsClosed covers Codex
+// round-3 P1: when the visibility lookup errors (DB unavailable, etc.)
+// the handler must fail CLOSED — 5xx, no payload — rather than fail
+// OPEN and leak hidden-child metadata via the unrestricted code path.
+//
+// We provoke the error by closing the store's DB pool between the
+// seed and the PATCH. Subsequent queries return "sql: database is
+// closed" which surfaces from visibleCollectionIDs → writeInternalError
+// → 500 with the generic error envelope (no children listed).
+func TestOpenChildrenGuard_VisibilityLookupErrorFailsClosed(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+	plan, _ := seedParentAndChildren(t, srv, slug, []string{"open"})
+
+	// Close the DB to break VisibleCollectionIDs and any other store
+	// call the handler makes. The PATCH should NOT silently succeed
+	// AND must NOT emit a 409 with a (potentially leaky) children
+	// payload — both would be the "fail open" bug. We accept any
+	// non-2xx, non-409 outcome (500 / 503 / unauthorized — whichever
+	// the broken-DB path lands on first) as proof of fail-closed.
+	if err := srv.store.Close(); err != nil {
+		t.Fatalf("close store: %v", err)
+	}
+
+	rr := doRequest(srv, "PATCH", "/api/v1/workspaces/"+slug+"/items/"+plan.Ref, map[string]interface{}{
+		"fields": map[string]interface{}{"status": "completed"},
+	})
+	if rr.Code == http.StatusOK {
+		t.Fatalf("expected non-2xx after store close, got 200: %s", rr.Body.String())
+	}
+	// The forbidden outcome is "409 with details.open_children
+	// populated" — that would mean the guard fired against a child
+	// set built without the visibility filter and leaked metadata.
+	if rr.Code == http.StatusConflict {
+		body := rr.Body.String()
+		if strings.Contains(body, "open_children") && strings.Contains(body, "TASK") {
+			t.Fatalf("fail-open regression: 409 with child metadata after visibility lookup broke. body=%s", body)
+		}
+	}
+}
+
+// TestOpenChildrenGuard_PrecheckReadsInTxSnapshot covers Codex round-3
+// P2: the precheck classifies the transition against the parent's
+// fields as read INSIDE the tx (after locks), not the pre-tx capture.
+// We exercise this by passing a precheck closure that asserts the
+// `existing.Fields` it receives reflects a status mutation committed
+// between the handler-side load and the precheck's invocation.
+//
+// Test shape: directly invoke UpdateItemWithPreCheck on the store
+// with a precheck that records the snapshot it sees. Between
+// constructing the call and the precheck firing, another goroutine
+// commits a status change on the same parent. The recorded snapshot
+// must show the post-mutation value — otherwise the precheck was
+// using a stale view.
+func TestOpenChildrenGuard_PrecheckReadsInTxSnapshot(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+	plan, _ := seedParentAndChildren(t, srv, slug, []string{"done"})
+
+	// Resolve the plan to get its ID (the in-store API takes UUIDs).
+	getResp := doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/items/"+plan.Ref, nil)
+	parseJSON(t, getResp, &plan)
+
+	// Stage 1: mutate the parent's status from "active" to "completed"
+	// via the store layer directly. This bumps fields BEFORE we
+	// invoke UpdateItemWithPreCheck below.
+	stageFields := `{"status":"completed"}`
+	if _, err := srv.store.UpdateItem(plan.ID, models.ItemUpdate{Fields: &stageFields, Force: true}); err != nil {
+		t.Fatalf("stage update: %v", err)
+	}
+
+	// Stage 2: invoke UpdateItemWithPreCheck again, this time
+	// transitioning to a different valid value. The precheck closure
+	// records what `existing.Fields` looked like at invocation time.
+	// If round-3 P2 is broken, the closure sees the stale `active`
+	// (the pre-tx snapshot reproducing the bug); if the fix holds,
+	// it sees the staged `completed`.
+	var seenFields string
+	finalFields := `{"status":"completed"}`
+	_, err := srv.store.UpdateItemWithPreCheck(plan.ID,
+		models.ItemUpdate{Fields: &finalFields, Force: true},
+		func(tx *sql.Tx, existing *models.Item) error {
+			seenFields = existing.Fields
+			return nil
+		})
+	if err != nil {
+		t.Fatalf("UpdateItemWithPreCheck: %v", err)
+	}
+	var f map[string]any
+	if err := json.Unmarshal([]byte(seenFields), &f); err != nil {
+		t.Fatalf("parse seen fields: %v", err)
+	}
+	if s, _ := f["status"].(string); s != "completed" {
+		t.Errorf("precheck must see the in-tx snapshot (round-3 P2). Want status=completed, got %q. Full fields=%s",
+			s, seenFields)
+	}
+}
+
+// TestBulkUpdateStructuredFailuresCarryOpenChildrenDetails covers
+// Codex round-3 P2: the CLI's bulk-update JSON envelope now embeds
+// the per-row structured server error (code + details) rather than
+// flattening it into a string, so MCP-driven agents reading the
+// stdout JSON see the same payload single-row update would deliver.
+//
+// We exercise the path by invoking the CLI binary via the test
+// server's HTTP surface — the bulk-update CLI loops over the
+// `client.UpdateItem` HTTP call, and our extension lifts the
+// APIError's code/details into the row. Tested end-to-end via the
+// `pad item bulk-update` cobra command would require spawning a
+// subprocess; here we directly invoke the per-item HTTP path and
+// verify the server returns the same wire shape, which is the
+// upstream signal the CLI lifts.
+func TestBulkUpdateStructuredFailuresCarryOpenChildrenDetails(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+	plan, _ := seedParentAndChildren(t, srv, slug, []string{"open"})
+
+	// One PATCH attempting the terminal transition without force.
+	// The handler returns the structured envelope; the CLI's
+	// bulk-update wraps it per-row. We assert the wire shape directly.
+	rr := doRequest(srv, "PATCH", "/api/v1/workspaces/"+slug+"/items/"+plan.Ref, map[string]interface{}{
+		"fields": map[string]interface{}{"status": "completed"},
+	})
+	if rr.Code != http.StatusConflict {
+		t.Fatalf("expected 409 from single PATCH (bulk-update loops over this exact call), got %d", rr.Code)
+	}
+	var envelope struct {
+		Error struct {
+			Code    string          `json:"code"`
+			Details json.RawMessage `json:"details"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &envelope); err != nil {
+		t.Fatalf("parse envelope: %v", err)
+	}
+	if envelope.Error.Code != "open_children" {
+		t.Errorf("wire code should be open_children for bulk-update lift: got %q", envelope.Error.Code)
+	}
+	if len(envelope.Error.Details) == 0 {
+		t.Error("wire details must be populated for bulk-update lift")
 	}
 }

--- a/internal/server/handlers_items_open_children_guard_test.go
+++ b/internal/server/handlers_items_open_children_guard_test.go
@@ -1071,3 +1071,266 @@ func TestBulkUpdateStructuredFailuresCarryOpenChildrenDetails(t *testing.T) {
 		t.Error("wire details must be populated for bulk-update lift")
 	}
 }
+
+// TestOpenChildrenGuard_MultiParentChildLocksAll covers Codex round-4
+// P1: a child item with BOTH a `parent` link to P1 AND an `implements`
+// link to P2 (two distinct "parents" under childLinkTypes) must
+// serialize against BOTH parents' open-children guard locks when its
+// status flips. Pre-fix the LIMIT 1 lookup grabbed one parent only;
+// the other could race the child's status-flip and miss it.
+//
+// Test shape: build the multi-parent topology, then race
+// (child status flip) vs (P1 terminal-update) vs (P2 terminal-update)
+// across iterations. The forbidden outcome is the same as the round-2
+// race test, applied to either parent: parent committed terminal AND
+// the child's status flip committed BEFORE the parent's commit.
+func TestOpenChildrenGuard_MultiParentChildLocksAll(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	const iterations = 4
+	for i := 0; i < iterations; i++ {
+		// Two plans (P1, P2) + one child task. Attach child to P1 via
+		// the `parent` link_type (regular hierarchy) and to P2 via
+		// the `implements` link_type (the other childLinkType).
+		p1Resp := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections/plans/items", map[string]interface{}{
+			"title":  "P1",
+			"fields": `{"status":"active"}`,
+		})
+		var p1 models.Item
+		parseJSON(t, p1Resp, &p1)
+		p2Resp := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections/plans/items", map[string]interface{}{
+			"title":  "P2",
+			"fields": `{"status":"active"}`,
+		})
+		var p2 models.Item
+		parseJSON(t, p2Resp, &p2)
+
+		childResp := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections/tasks/items", map[string]interface{}{
+			"title":  "multi-parent child",
+			"fields": map[string]interface{}{"status": "open", "parent": p1.Ref},
+		})
+		var child models.Item
+		parseJSON(t, childResp, &child)
+
+		// Add the `implements` link to P2.
+		linkResp := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/items/"+child.Ref+"/links", map[string]interface{}{
+			"target_id": p2.ID,
+			"link_type": "implements",
+		})
+		if linkResp.Code != http.StatusCreated {
+			t.Fatalf("iter %d add implements link: %d %s", i, linkResp.Code, linkResp.Body.String())
+		}
+
+		// Race: flip child status to done, while concurrently each
+		// parent attempts the terminal transition. Goroutines so
+		// timing varies across iterations.
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			_ = doRequest(srv, "PATCH", "/api/v1/workspaces/"+slug+"/items/"+p1.Ref, map[string]interface{}{
+				"fields": map[string]interface{}{"status": "completed"},
+			})
+		}()
+		go func() {
+			defer wg.Done()
+			_ = doRequest(srv, "PATCH", "/api/v1/workspaces/"+slug+"/items/"+p2.Ref, map[string]interface{}{
+				"fields": map[string]interface{}{"status": "completed"},
+			})
+		}()
+		time.Sleep(50 * time.Microsecond)
+		_ = doRequest(srv, "PATCH", "/api/v1/workspaces/"+slug+"/items/"+child.Ref, map[string]interface{}{
+			"fields": map[string]interface{}{"status": "done"},
+		})
+		wg.Wait()
+
+		// Verify the forbidden outcome did not occur for EITHER
+		// parent. Same shape as the round-2 TOCTOU test, applied to
+		// both. A multi-parent child whose status flip wasn't
+		// serialized against P2's lock would let P2 commit terminal
+		// with a stale view that read child=open.
+		childGet := doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/items/"+child.Ref, nil)
+		var cf models.Item
+		parseJSON(t, childGet, &cf)
+		var cfFields map[string]any
+		_ = json.Unmarshal([]byte(cf.Fields), &cfFields)
+		childStatus, _ := cfFields["status"].(string)
+
+		for _, parentRef := range []string{p1.Ref, p2.Ref} {
+			parentGet := doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/items/"+parentRef, nil)
+			var pf models.Item
+			parseJSON(t, parentGet, &pf)
+			var pfFields map[string]any
+			_ = json.Unmarshal([]byte(pf.Fields), &pfFields)
+			parentStatus, _ := pfFields["status"].(string)
+			if parentStatus == "completed" && childStatus == "open" {
+				t.Fatalf("iter %d: multi-parent TOCTOU violation — parent %s=completed with child %s still open. Parent lock was missing.",
+					i, parentRef, child.Ref)
+			}
+		}
+	}
+}
+
+// TestOpenChildrenGuard_NoDeadlockUnderReverseOrderConcurrency covers
+// Codex round-4 P2: every call site that takes pad:parent-children:*
+// advisory locks now goes through AcquireParentChildrenLocks (the
+// canonical sorted multi-lock helper). Pre-fix some sites locked
+// parent-then-self; others locked sorted; concurrent reverse-order
+// operations could AB/BA deadlock. With one canonical helper, that's
+// impossible.
+//
+// Test shape: two parents A and B. Race two operations that each
+// touch BOTH A and B:
+//   - Goroutine 1: re-parent child X from A to B (SetParentLink A→B).
+//   - Goroutine 2: re-parent child Y from B to A (SetParentLink B→A).
+//
+// Both will need locks on {A, B}. With sorted acquisition, both
+// always grab A first then B; no deadlock. The test hard-times-out
+// after 5 seconds; if the helpers ever regress to per-call-site
+// ad-hoc ordering, this test hangs and fails the timeout.
+func TestOpenChildrenGuard_NoDeadlockUnderReverseOrderConcurrency(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	// Two plans + two children. We'll re-parent X and Y in opposite
+	// directions across A and B repeatedly.
+	planA := mustCreate(t, srv, slug, "plans", map[string]interface{}{"title": "A", "fields": `{"status":"active"}`})
+	planB := mustCreate(t, srv, slug, "plans", map[string]interface{}{"title": "B", "fields": `{"status":"active"}`})
+	childX := mustCreate(t, srv, slug, "tasks", map[string]interface{}{
+		"title": "X", "fields": map[string]interface{}{"status": "open", "parent": planA.Ref},
+	})
+	childY := mustCreate(t, srv, slug, "tasks", map[string]interface{}{
+		"title": "Y", "fields": map[string]interface{}{"status": "open", "parent": planB.Ref},
+	})
+
+	const rounds = 6
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		var wg sync.WaitGroup
+		for i := 0; i < rounds; i++ {
+			wg.Add(2)
+			from1, to1 := planA.Ref, planB.Ref
+			from2, to2 := planB.Ref, planA.Ref
+			if i%2 == 1 {
+				from1, to1 = to1, from1
+				from2, to2 = to2, from2
+			}
+			_ = from1
+			_ = from2
+			go func(parentRef string) {
+				defer wg.Done()
+				_ = doRequest(srv, "PATCH", "/api/v1/workspaces/"+slug+"/items/"+childX.Ref, map[string]interface{}{
+					"fields": map[string]interface{}{"parent": parentRef, "status": "open"},
+				})
+			}(to1)
+			go func(parentRef string) {
+				defer wg.Done()
+				_ = doRequest(srv, "PATCH", "/api/v1/workspaces/"+slug+"/items/"+childY.Ref, map[string]interface{}{
+					"fields": map[string]interface{}{"parent": parentRef, "status": "open"},
+				})
+			}(to2)
+			wg.Wait()
+		}
+	}()
+
+	select {
+	case <-done:
+		// All rounds completed without hanging. The sorted multi-
+		// lock helper held the deadlock-avoidance contract.
+	case <-time.After(5 * time.Second):
+		t.Fatal("DEADLOCK: reverse-order parent-children lock acquisition hung > 5s. AcquireParentChildrenLocks's sorted-acquisition contract regressed.")
+	}
+}
+
+// mustCreate is a small helper for the deadlock test's seeding —
+// keeps the test body focused on the race itself rather than
+// boilerplate response parsing.
+func mustCreate(t *testing.T, srv *Server, wsSlug, collectionSlug string, body map[string]interface{}) models.Item {
+	t.Helper()
+	rr := doRequest(srv, "POST", "/api/v1/workspaces/"+wsSlug+"/collections/"+collectionSlug+"/items", body)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("seed %s item: %d %s", collectionSlug, rr.Code, rr.Body.String())
+	}
+	var it models.Item
+	parseJSON(t, rr, &it)
+	return it
+}
+
+// TestOpenChildrenGuard_PatchAtomicRejectionPreservesParentLink
+// covers Codex round-4 P3: a PATCH that combines a parent-link
+// change AND a status flip to terminal, against a parent with open
+// children, must reject the WHOLE PATCH — both the field write and
+// the link change. Pre-fix the link committed before the guard ran,
+// so the caller saw 409 but the parent had already moved.
+func TestOpenChildrenGuard_PatchAtomicRejectionPreservesParentLink(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	// Two candidate parent plans (oldParent / newParent) + the item
+	// under test (plan with an open child).
+	oldParent := mustCreate(t, srv, slug, "plans", map[string]interface{}{
+		"title": "old parent", "fields": `{"status":"active"}`,
+	})
+	newParent := mustCreate(t, srv, slug, "plans", map[string]interface{}{
+		"title": "new parent", "fields": `{"status":"active"}`,
+	})
+
+	// The item under test is a plan with one open child + an existing
+	// parent link to oldParent.
+	target := mustCreate(t, srv, slug, "plans", map[string]interface{}{
+		"title":  "target",
+		"fields": map[string]interface{}{"status": "active", "parent": oldParent.Ref},
+	})
+	// Attach an open child to target so the guard will fire.
+	mustCreate(t, srv, slug, "tasks", map[string]interface{}{
+		"title":  "blocker",
+		"fields": map[string]interface{}{"status": "open", "parent": target.Ref},
+	})
+
+	// Sanity: target's parent IS oldParent right now.
+	parentBefore := readParentRef(t, srv, slug, target.Ref)
+	if parentBefore != oldParent.Ref {
+		t.Fatalf("setup: target's parent should start as %s, got %q", oldParent.Ref, parentBefore)
+	}
+
+	// Combined PATCH: change parent AND mark terminal. The guard
+	// must reject the whole thing.
+	rr := doRequest(srv, "PATCH", "/api/v1/workspaces/"+slug+"/items/"+target.Ref, map[string]interface{}{
+		"fields": map[string]interface{}{"status": "completed", "parent": newParent.Ref},
+	})
+	if rr.Code != http.StatusConflict {
+		t.Fatalf("expected 409 from combined parent+terminal PATCH, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	// CRITICAL: the parent link must be unchanged. Pre-fix it would
+	// have been newParent because SetParentLink committed before the
+	// guard ran.
+	parentAfter := readParentRef(t, srv, slug, target.Ref)
+	if parentAfter != oldParent.Ref {
+		t.Fatalf("PATCH atomicity violated: parent moved to %q despite 409 (want unchanged %q)",
+			parentAfter, oldParent.Ref)
+	}
+}
+
+// readParentRef returns the ref of the item's current `parent` link
+// target, or "" if there is no parent link. Used by the PATCH-atomic
+// test to assert the link DIDN'T change.
+func readParentRef(t *testing.T, srv *Server, wsSlug, itemRef string) string {
+	t.Helper()
+	rr := doRequest(srv, "GET", "/api/v1/workspaces/"+wsSlug+"/items/"+itemRef+"/links", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("read links for %s: %d %s", itemRef, rr.Code, rr.Body.String())
+	}
+	var links []models.ItemLink
+	parseJSON(t, rr, &links)
+	for _, l := range links {
+		if l.LinkType == "parent" {
+			// The item is the SOURCE of its parent link; the target
+			// is the parent. Return the parent's ref.
+			return l.TargetRef
+		}
+	}
+	return ""
+}

--- a/internal/server/handlers_items_open_children_guard_test.go
+++ b/internal/server/handlers_items_open_children_guard_test.go
@@ -564,6 +564,14 @@ func TestOpenChildrenGuard_AllBlockersHiddenSurfaceGenericMessage(t *testing.T) 
 	if len(resp.Error.Details.OpenChildren) != 0 {
 		t.Errorf("expected empty open_children when all blockers hidden, got %v", resp.Error.Details.OpenChildren)
 	}
+	// Codex round-5 P3: open_children must serialize as `[]`, not
+	// `null`, when all blockers are hidden. Clients range over the
+	// array unconditionally; `null` would break their iteration.
+	// Re-parse the raw JSON so we see the wire shape (not the Go
+	// nil-vs-empty-slice distinction the typed unmarshal hides).
+	if !strings.Contains(rr.Body.String(), `"open_children":[]`) {
+		t.Errorf("open_children must serialize as [] (not null) on hidden-only rejection; raw body: %s", rr.Body.String())
+	}
 	if resp.Error.Details.HiddenBlockerCount != 1 {
 		t.Errorf("expected hidden_blocker_count=1, got %d", resp.Error.Details.HiddenBlockerCount)
 	}

--- a/internal/server/handlers_items_open_children_guard_test.go
+++ b/internal/server/handlers_items_open_children_guard_test.go
@@ -9,7 +9,9 @@ import (
 	"encoding/json"
 	"net/http"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/PerpetualSoftware/pad/internal/models"
 )
@@ -350,5 +352,301 @@ func TestOpenChildrenGuard_GuardAppliesToAnyParent(t *testing.T) {
 	})
 	if rr.Code != http.StatusConflict {
 		t.Fatalf("expected 409 for task-with-open-subtask, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+// TestOpenChildrenGuard_VisibilitySanitizesPayload covers Codex round 2
+// P1: when a restricted caller updates a parent they CAN see but the
+// parent has children in collections they CAN'T see, the guard's
+// invariant check still considers those hidden children (data
+// integrity — a restricted user can't slip an item past completion by
+// virtue of reduced visibility) but the 409 response sanitizes the
+// payload — hidden children appear only as a count, never with refs
+// or titles.
+func TestOpenChildrenGuard_VisibilitySanitizesPayload(t *testing.T) {
+	srv := testServer(t)
+	bootstrapFirstUser(t, srv, "admin@example.com", "Admin")
+
+	// Workspace with two collections: parent's collection (which the
+	// editor CAN see) and "secrets" (which they can't).
+	ws, err := srv.store.CreateWorkspace(models.WorkspaceCreate{Name: "Vis"})
+	if err != nil {
+		t.Fatalf("CreateWorkspace: %v", err)
+	}
+	parentColl, err := srv.store.CreateCollection(ws.ID, models.CollectionCreate{
+		Name: "Plans", Slug: "plans", Prefix: "PLAN",
+		Schema: `{"fields":[{"key":"status","label":"Status","type":"select","options":["active","completed"],"terminal_options":["completed"]}]}`,
+	})
+	if err != nil {
+		t.Fatalf("CreateCollection plans: %v", err)
+	}
+	visibleChildColl, err := srv.store.CreateCollection(ws.ID, models.CollectionCreate{
+		Name: "Tasks", Slug: "tasks", Prefix: "TASK",
+		Schema: `{"fields":[{"key":"status","label":"Status","type":"select","options":["open","done"],"terminal_options":["done"]}]}`,
+	})
+	if err != nil {
+		t.Fatalf("CreateCollection tasks: %v", err)
+	}
+	hiddenChildColl, err := srv.store.CreateCollection(ws.ID, models.CollectionCreate{
+		Name: "Secrets", Slug: "secrets", Prefix: "SEC",
+		Schema: `{"fields":[{"key":"status","label":"Status","type":"select","options":["open","done"],"terminal_options":["done"]}]}`,
+	})
+	if err != nil {
+		t.Fatalf("CreateCollection secrets: %v", err)
+	}
+
+	// Seed the parent + one visible-open child + one hidden-open child.
+	parent, err := srv.store.CreateItem(ws.ID, parentColl.ID, models.ItemCreate{
+		Title: "Parent", Fields: `{"status":"active"}`,
+	})
+	if err != nil {
+		t.Fatalf("CreateItem parent: %v", err)
+	}
+	visibleChild, err := srv.store.CreateItem(ws.ID, visibleChildColl.ID, models.ItemCreate{
+		Title: "Visible task", Fields: `{"status":"open"}`,
+	})
+	if err != nil {
+		t.Fatalf("CreateItem visible child: %v", err)
+	}
+	if _, err := srv.store.SetParentLink(ws.ID, visibleChild.ID, parent.ID, "admin"); err != nil {
+		t.Fatalf("SetParentLink visible: %v", err)
+	}
+	hiddenChild, err := srv.store.CreateItem(ws.ID, hiddenChildColl.ID, models.ItemCreate{
+		Title:  "TOP SECRET — do not leak",
+		Fields: `{"status":"open"}`,
+	})
+	if err != nil {
+		t.Fatalf("CreateItem hidden child: %v", err)
+	}
+	if _, err := srv.store.SetParentLink(ws.ID, hiddenChild.ID, parent.ID, "admin"); err != nil {
+		t.Fatalf("SetParentLink hidden: %v", err)
+	}
+
+	// Restricted editor: workspace member with collection_access scoped
+	// to the parent's collection + the visible-child collection only.
+	editor, err := srv.store.CreateUser(models.UserCreate{
+		Email: "editor-vis@example.com", Name: "Editor", Username: "editor-vis",
+		Password: "pw-test-12345",
+	})
+	if err != nil {
+		t.Fatalf("CreateUser editor: %v", err)
+	}
+	if err := srv.store.AddWorkspaceMember(ws.ID, editor.ID, "editor"); err != nil {
+		t.Fatalf("AddWorkspaceMember: %v", err)
+	}
+	if err := srv.store.SetMemberCollectionAccess(ws.ID, editor.ID, "specific", []string{parentColl.ID, visibleChildColl.ID}); err != nil {
+		t.Fatalf("SetMemberCollectionAccess: %v", err)
+	}
+	token, err := srv.store.CreateSession(editor.ID, "go-test", "192.0.2.1", "", 24*time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	// PATCH the parent as the restricted editor.
+	rr := doRequestWithCookie(srv, "PATCH", "/api/v1/workspaces/"+ws.Slug+"/items/"+parent.Slug, map[string]interface{}{
+		"fields": map[string]interface{}{"status": "completed"},
+	}, token)
+	if rr.Code != http.StatusConflict {
+		t.Fatalf("expected 409, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	body := rr.Body.String()
+	// Leak check: the hidden child's title / ref / collection slug must
+	// NOT appear anywhere in the response.
+	for _, secret := range []string{"TOP SECRET", "do not leak", "secrets", hiddenChild.Slug} {
+		if strings.Contains(body, secret) {
+			t.Errorf("response leaked hidden child material %q: %s", secret, body)
+		}
+	}
+	// Structural assertions.
+	var resp struct {
+		Error struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+			Details struct {
+				OpenChildren []struct {
+					Ref            string `json:"ref"`
+					Title          string `json:"title"`
+					CollectionSlug string `json:"collection_slug"`
+				} `json:"open_children"`
+				HiddenBlockerCount int `json:"hidden_blocker_count"`
+			} `json:"details"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("parse response: %v", err)
+	}
+	if resp.Error.Code != "open_children" {
+		t.Fatalf("expected code=open_children, got %q", resp.Error.Code)
+	}
+	if len(resp.Error.Details.OpenChildren) != 1 {
+		t.Fatalf("expected 1 visible blocker, got %d (%+v)",
+			len(resp.Error.Details.OpenChildren), resp.Error.Details.OpenChildren)
+	}
+	if resp.Error.Details.OpenChildren[0].CollectionSlug != "tasks" {
+		t.Errorf("only the visible-collection child should appear, got slug=%q",
+			resp.Error.Details.OpenChildren[0].CollectionSlug)
+	}
+	if resp.Error.Details.HiddenBlockerCount != 1 {
+		t.Errorf("expected hidden_blocker_count=1, got %d",
+			resp.Error.Details.HiddenBlockerCount)
+	}
+}
+
+// TestOpenChildrenGuard_AllBlockersHiddenSurfaceGenericMessage covers
+// the edge case where EVERY blocking child is hidden from the caller —
+// the guard still fires (data integrity) but the human message is
+// generic and `details.open_children` is empty while
+// `hidden_blocker_count` is non-zero.
+func TestOpenChildrenGuard_AllBlockersHiddenSurfaceGenericMessage(t *testing.T) {
+	srv := testServer(t)
+	bootstrapFirstUser(t, srv, "admin@example.com", "Admin")
+
+	ws, err := srv.store.CreateWorkspace(models.WorkspaceCreate{Name: "Vis2"})
+	if err != nil {
+		t.Fatalf("CreateWorkspace: %v", err)
+	}
+	parentColl, err := srv.store.CreateCollection(ws.ID, models.CollectionCreate{
+		Name: "Plans", Slug: "plans", Prefix: "PLAN",
+		Schema: `{"fields":[{"key":"status","label":"Status","type":"select","options":["active","completed"],"terminal_options":["completed"]}]}`,
+	})
+	if err != nil {
+		t.Fatalf("CreateCollection: %v", err)
+	}
+	hiddenColl, err := srv.store.CreateCollection(ws.ID, models.CollectionCreate{
+		Name: "Hidden", Slug: "hidden", Prefix: "HID",
+		Schema: `{"fields":[{"key":"status","label":"Status","type":"select","options":["open","done"],"terminal_options":["done"]}]}`,
+	})
+	if err != nil {
+		t.Fatalf("CreateCollection hidden: %v", err)
+	}
+	parent, _ := srv.store.CreateItem(ws.ID, parentColl.ID, models.ItemCreate{
+		Title: "P", Fields: `{"status":"active"}`,
+	})
+	child, _ := srv.store.CreateItem(ws.ID, hiddenColl.ID, models.ItemCreate{
+		Title: "secret", Fields: `{"status":"open"}`,
+	})
+	if _, err := srv.store.SetParentLink(ws.ID, child.ID, parent.ID, "admin"); err != nil {
+		t.Fatalf("SetParentLink: %v", err)
+	}
+
+	editor, _ := srv.store.CreateUser(models.UserCreate{
+		Email: "e@example.com", Name: "E", Username: "e", Password: "pw-test-12345",
+	})
+	if err := srv.store.AddWorkspaceMember(ws.ID, editor.ID, "editor"); err != nil {
+		t.Fatalf("AddWorkspaceMember: %v", err)
+	}
+	// Editor sees ONLY parentColl; child's collection is invisible.
+	if err := srv.store.SetMemberCollectionAccess(ws.ID, editor.ID, "specific", []string{parentColl.ID}); err != nil {
+		t.Fatalf("SetMemberCollectionAccess: %v", err)
+	}
+	token, _ := srv.store.CreateSession(editor.ID, "go-test", "192.0.2.1", "", 24*time.Hour)
+
+	rr := doRequestWithCookie(srv, "PATCH", "/api/v1/workspaces/"+ws.Slug+"/items/"+parent.Slug, map[string]interface{}{
+		"fields": map[string]interface{}{"status": "completed"},
+	}, token)
+	if rr.Code != http.StatusConflict {
+		t.Fatalf("expected 409, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		Error struct {
+			Message string `json:"message"`
+			Details struct {
+				OpenChildren       []map[string]any `json:"open_children"`
+				HiddenBlockerCount int              `json:"hidden_blocker_count"`
+			} `json:"details"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(resp.Error.Details.OpenChildren) != 0 {
+		t.Errorf("expected empty open_children when all blockers hidden, got %v", resp.Error.Details.OpenChildren)
+	}
+	if resp.Error.Details.HiddenBlockerCount != 1 {
+		t.Errorf("expected hidden_blocker_count=1, got %d", resp.Error.Details.HiddenBlockerCount)
+	}
+	if !strings.Contains(resp.Error.Message, "you don't have access to") {
+		t.Errorf("expected hidden-blocker phrasing in message, got %q", resp.Error.Message)
+	}
+}
+
+// TestOpenChildrenGuard_TOCTOURace covers Codex round 2 P2: a child
+// status flip that races a parent-terminal update must NOT slip past
+// the guard. The race is concurrent: a goroutine waits a tick then
+// flips the last open child to terminal while the parent's PATCH is
+// in flight. We retry the race a handful of times because either
+// outcome is acceptable (guard fires OR child commits first then
+// parent succeeds), but the FORBIDDEN outcome — parent completes
+// WITH the child still open — must never occur.
+//
+// In practice the test ALWAYS observes one of the two acceptable
+// outcomes because Store.UpdateItemWithPreCheck holds the parent-
+// children advisory lock (Postgres) / BEGIN IMMEDIATE write lock
+// (SQLite) across the precheck + UPDATE; the racer either runs
+// before or fully after our tx.
+func TestOpenChildrenGuard_TOCTOURace(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	// Keep the iteration count modest: each iteration costs ~6 HTTP
+	// calls (seed plan, seed child, racer PATCH, parent PATCH, two
+	// post-condition GETs) and the test HTTP stack's rate limiter
+	// rejects sustained bursts. Eight iterations is plenty to surface
+	// any TOCTOU regression — the race window is microseconds, so the
+	// guard's locking either holds or it doesn't.
+	const iterations = 8
+	for i := 0; i < iterations; i++ {
+		plan, children := seedParentAndChildren(t, srv, slug, []string{"open"})
+		child := children[0]
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+
+		// Racer goroutine: flip the open child to done. Tiny sleep
+		// to maximise overlap with the parent PATCH.
+		go func() {
+			defer wg.Done()
+			time.Sleep(100 * time.Microsecond)
+			rr := doRequest(srv, "PATCH", "/api/v1/workspaces/"+slug+"/items/"+child.Ref, map[string]interface{}{
+				"fields": map[string]interface{}{"status": "done"},
+			})
+			if rr.Code != http.StatusOK {
+				// Racer can lose the lock-acquisition race; that's
+				// fine, the test just exercises one outcome.
+				return
+			}
+		}()
+
+		// Parent PATCH: attempt the terminal transition.
+		parentRR := doRequest(srv, "PATCH", "/api/v1/workspaces/"+slug+"/items/"+plan.Ref, map[string]interface{}{
+			"fields": map[string]interface{}{"status": "completed"},
+		})
+		wg.Wait()
+
+		// Verify post-conditions on the data.
+		getResp := doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/items/"+plan.Ref, nil)
+		if getResp.Code != http.StatusOK {
+			t.Fatalf("iter %d re-read parent: %d", i, getResp.Code)
+		}
+		var freshParent models.Item
+		parseJSON(t, getResp, &freshParent)
+		var pf map[string]any
+		_ = json.Unmarshal([]byte(freshParent.Fields), &pf)
+		parentStatus, _ := pf["status"].(string)
+
+		childResp := doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/items/"+child.Ref, nil)
+		var freshChild models.Item
+		parseJSON(t, childResp, &freshChild)
+		var cf map[string]any
+		_ = json.Unmarshal([]byte(freshChild.Fields), &cf)
+		childStatus, _ := cf["status"].(string)
+
+		// FORBIDDEN: parent=completed AND child=open. This is the
+		// race the guard exists to prevent.
+		if parentStatus == "completed" && childStatus == "open" {
+			t.Fatalf("iter %d: TOCTOU violation — parent=completed with child still open. parent PATCH status=%d body=%s",
+				i, parentRR.Code, parentRR.Body.String())
+		}
 	}
 }

--- a/internal/store/collections.go
+++ b/internal/store/collections.go
@@ -89,6 +89,45 @@ func (s *Store) GetCollection(id string) (*models.Collection, error) {
 	return &c, nil
 }
 
+// GetCollectionAnyState is GetCollection without the
+// `deleted_at IS NULL` filter — used by the open-children guard
+// (IDEA-1494 R3 P3) so a child still attached to a soft-deleted
+// collection is evaluated against ITS collection's actual done-field
+// schema instead of falling back to the default `status` terminal
+// list (which would mis-classify children of custom-done-field
+// collections as non-terminal and produce false blockers).
+//
+// Mirrors the inclusion rule baked into childrenDoneFiltersForParent /
+// doneFiltersForWorkspace, both of which already include soft-deleted
+// collections for exactly this reason.
+func (s *Store) GetCollectionAnyState(id string) (*models.Collection, error) {
+	var c models.Collection
+	var createdAt, updatedAt string
+	var deletedAt *string
+	var isDefault bool
+
+	err := s.db.QueryRow(s.q(`
+		SELECT id, workspace_id, name, slug, prefix, icon, description, schema, settings, sort_order, is_default, is_system, created_at, updated_at, deleted_at
+		FROM collections
+		WHERE id = ?
+	`), id).Scan(
+		&c.ID, &c.WorkspaceID, &c.Name, &c.Slug, &c.Prefix, &c.Icon, &c.Description,
+		&c.Schema, &c.Settings, &c.SortOrder, &isDefault, &c.IsSystem,
+		&createdAt, &updatedAt, &deletedAt,
+	)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get collection (any state): %w", err)
+	}
+	c.IsDefault = isDefault
+	c.CreatedAt = parseTime(createdAt)
+	c.UpdatedAt = parseTime(updatedAt)
+	c.DeletedAt = parseTimePtr(deletedAt)
+	return &c, nil
+}
+
 func (s *Store) GetCollectionBySlug(workspaceID, slug string) (*models.Collection, error) {
 	var id string
 	err := s.db.QueryRow(s.q(`

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -1712,25 +1712,23 @@ func (s *Store) RestoreItem(id string) (*models.Item, error) {
 		return nil, err
 	}
 
-	// Codex round-3 P1: restoring an item resurrects it as a
-	// (potentially non-terminal) child of its parent. Lock the
-	// parent's children-key so a concurrent UpdateItemWithPreCheck
-	// on that parent sees this resurrection in its post-lock snapshot.
-	// Look up via item_links so we cover both `parent` and
-	// `implements` edges — same inclusion rule
-	// acquireParentChildrenLocksForUpdate uses.
-	var parentID sql.NullString
-	if err := tx.QueryRow(s.q(fmt.Sprintf(`
-		SELECT target_id FROM item_links
-		WHERE source_id = ? AND link_type IN (%s)
-		LIMIT 1
-	`, childLinkTypeSQL())), id).Scan(&parentID); err != nil && err != sql.ErrNoRows {
-		return nil, fmt.Errorf("lookup parent for restore lock: %w", err)
+	// Codex round-3 P1 / round-4 P1: restoring an item resurrects it
+	// as a (potentially non-terminal) child of EVERY parent it's
+	// linked to (one item can have both a `parent` and an
+	// `implements` link). Lock ALL of those parents' children-keys
+	// via the canonical sorted-multi-lock helper so concurrent
+	// UpdateItemWithPreCheck callers on any of them see this
+	// resurrection in their post-lock snapshots.
+	//
+	// Pre-fix this called AcquireParentChildrenLock for a single
+	// LIMIT 1 row — a multi-parent child would have left another
+	// parent's precheck racing the resurrection.
+	parentIDs, err := s.listParentChildLockKeys(tx, id)
+	if err != nil {
+		return nil, err
 	}
-	if parentID.Valid && parentID.String != "" {
-		if err := s.AcquireParentChildrenLock(tx, parentID.String); err != nil {
-			return nil, err
-		}
+	if err := s.AcquireParentChildrenLocks(tx, parentIDs...); err != nil {
+		return nil, err
 	}
 
 	ts := now()
@@ -1896,7 +1894,7 @@ func (s *Store) CreateItemLink(workspaceID string, input models.ItemLinkCreate, 
 	// types (blocks, supersedes, …) don't affect the children-set so
 	// we skip the lock — keeps the common case lock-free.
 	if isChildLinkType(linkType) {
-		if err := s.AcquireParentChildrenLock(tx, input.TargetID); err != nil {
+		if err := s.AcquireParentChildrenLocks(tx, input.TargetID); err != nil {
 			return nil, err
 		}
 	}
@@ -2084,7 +2082,7 @@ func (s *Store) DeleteItemLink(id string) error {
 		return fmt.Errorf("peek item link for delete: %w", err)
 	}
 	if isChildLinkType(linkType) {
-		if err := s.AcquireParentChildrenLock(tx, targetID); err != nil {
+		if err := s.AcquireParentChildrenLocks(tx, targetID); err != nil {
 			return err
 		}
 	}
@@ -2216,7 +2214,7 @@ func (s *Store) ClearParentLink(itemID string) error {
 		return fmt.Errorf("lookup parent for clear: %w", err)
 	}
 	if oldParentID.Valid && oldParentID.String != "" {
-		if err := s.AcquireParentChildrenLock(tx, oldParentID.String); err != nil {
+		if err := s.AcquireParentChildrenLocks(tx, oldParentID.String); err != nil {
 			return err
 		}
 	}
@@ -2576,7 +2574,7 @@ func (s *Store) GetChildItems(parentItemID string) ([]models.Item, error) {
 //     child insert / child update blocks until this tx commits or
 //     rolls back. No additional locking is needed.
 //   - Postgres: the caller is expected to hold a parent-keyed advisory
-//     lock (see AcquireParentChildrenLock below) so concurrent
+//     lock (see AcquireParentChildrenLocks below) so concurrent
 //     mutations on the same parent's children are serialized against
 //     this read.
 //
@@ -2593,83 +2591,100 @@ func (s *Store) GetChildItemsTx(tx *sql.Tx, parentItemID string) ([]models.Item,
 }
 
 // acquireParentChildrenLocksForUpdate is the in-tx helper UpdateItem
-// uses to serialize itself against the open-children guard (IDEA-1494
-// R2). It acquires two advisory locks on Postgres:
+// uses to serialize itself against the open-children guard
+// (IDEA-1494 R2 / R4). It acquires the parent-children advisory lock
+// for:
 //
-//  1. the parent-children lock for THIS item's parent (when it has one)
-//     — so a child-status-flip is serialized against any parent-update
-//     precheck that's reading this child via GetChildItemsTx.
-//  2. the parent-children lock for THIS item AS a parent — so any
-//     concurrent precheck running against this item's own children
-//     list waits for our write to commit.
+//  1. EVERY parent the item is currently a child of (via item_links
+//     of type ∈ childLinkTypes — `parent` AND `implements`).
+//     childLinkTypes is the inclusion rule GetChildItems walks, so
+//     this set is exactly the parents whose guard precheck could see
+//     this item as a child.
+//  2. THIS item itself, as a parent — so any concurrent precheck
+//     running against this item's own children list waits.
 //
-// Both keys are namespaced under `pad:parent-children:<id>` so they
-// only contend on the parent ID. SQLite is a no-op because the
-// BEGIN IMMEDIATE write lock already serializes all writers globally.
+// Codex round-4 P1: pre-fix this helper used `LIMIT 1` and only
+// locked one parent. A child of TWO parents (one via `parent`, one
+// via `implements`) would let a status flip race against the
+// un-locked parent's precheck. The query now returns ALL distinct
+// parent target_ids and we lock every one.
 //
-// Order is fixed (parent first, self second) to avoid the classic
-// AB/BA deadlock — two concurrent updaters that touch the same parent
-// always grab that key before the more-specific one.
+// All keys (parents + self) are funnelled through
+// AcquireParentChildrenLocks so they're acquired in a single,
+// canonical sorted order — round-4 P2's deadlock-avoidance contract.
+// No call site outside this helper takes pad:parent-children:* locks
+// in any other order.
 func (s *Store) acquireParentChildrenLocksForUpdate(tx *sql.Tx, itemID string) error {
 	if s.dialect.Driver() != DriverPostgres {
 		return nil
 	}
-	// Look up THIS item's parent (if any) via item_links. Cheap: hits
-	// the (source_id, link_type) index. A NULL/missing row means the
-	// item has no parent — skip step 1.
-	var parentID sql.NullString
-	err := tx.QueryRow(s.q(fmt.Sprintf(`
-		SELECT target_id FROM item_links
+	parentIDs, err := s.listParentChildLockKeys(tx, itemID)
+	if err != nil {
+		return err
+	}
+	keys := append(parentIDs, itemID)
+	return s.AcquireParentChildrenLocks(tx, keys...)
+}
+
+// listParentChildLockKeys returns every target_id this item is the
+// `source_id` of under a childLinkTypes link — i.e. every parent
+// whose children-set includes this item. Used wherever we need to
+// lock all of an item's parents at once (UpdateItem, RestoreItem,
+// link-mutation paths).
+//
+// IMPORTANT: this MUST stay in lockstep with childLinkTypes (the
+// inclusion rule GetChildItems uses). If a new link type joins the
+// children-set, both the query here and the read query must add it
+// together so lock coverage matches read coverage.
+func (s *Store) listParentChildLockKeys(tx *sql.Tx, itemID string) ([]string, error) {
+	rows, err := tx.Query(s.q(fmt.Sprintf(`
+		SELECT DISTINCT target_id FROM item_links
 		WHERE source_id = ? AND link_type IN (%s)
-		LIMIT 1
-	`, childLinkTypeSQL())), itemID).Scan(&parentID)
-	if err != nil && err != sql.ErrNoRows {
-		return fmt.Errorf("lookup parent for advisory lock: %w", err)
+	`, childLinkTypeSQL())), itemID)
+	if err != nil {
+		return nil, fmt.Errorf("list parent lock keys: %w", err)
 	}
-	if parentID.Valid && parentID.String != "" && parentID.String != itemID {
-		if err := s.AcquireParentChildrenLock(tx, parentID.String); err != nil {
-			return err
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("scan parent lock key: %w", err)
 		}
+		if id == "" || id == itemID {
+			continue
+		}
+		out = append(out, id)
 	}
-	// Acquire the self-as-parent key.
-	return s.AcquireParentChildrenLock(tx, itemID)
+	return out, rows.Err()
 }
 
-// AcquireParentChildrenLock takes a Postgres advisory transaction lock
-// keyed on the parent item ID, serializing concurrent reads/writes
-// against that parent's children for the duration of the caller's tx.
-// No-op on SQLite (BEGIN IMMEDIATE already serializes writers).
+// AcquireParentChildrenLocks is the CANONICAL helper for taking
+// `pad:parent-children:<id>` advisory locks. Every call site that
+// needs to serialize against the open-children guard MUST go through
+// this function — UpdateItemWithPreCheck precheck, MoveItemWithPreCheck
+// precheck, RestoreItem, SetParentLink, ClearParentLink,
+// CreateItemLink (child-link types), DeleteItemLink (child-link
+// types). Ad-hoc single-key acquisition outside this helper is
+// FORBIDDEN — two call sites taking distinct keys in different
+// orders WILL deadlock under contention (the classic AB/BA shape).
 //
-// Used by the open-children guard (IDEA-1494 R2): the guard's
-// children-list query and the subsequent UPDATE of the parent's status
-// must agree on the children set. The advisory lock blocks any other
-// updater that would mutate this parent's children-list view.
-func (s *Store) AcquireParentChildrenLock(tx *sql.Tx, parentItemID string) error {
-	if s.dialect.Driver() != DriverPostgres {
-		return nil
-	}
-	// Distinct lock-key namespace from acquireWorkspaceSeqLock so the
-	// two don't collide and we don't accidentally widen serialization
-	// to "any update in the workspace."
-	if _, err := tx.Exec("SELECT pg_advisory_xact_lock(hashtext('pad:parent-children:' || $1))", parentItemID); err != nil {
-		return fmt.Errorf("acquire parent-children lock: %w", err)
-	}
-	return nil
-}
-
-// AcquireParentChildrenLocks is the multi-key variant used when a
-// single mutation touches more than one parent's children-set —
-// re-parenting (old parent + new parent), CreateItemLink that attaches
-// a parent/implements link, etc. The caller passes the full set of
-// parent IDs they need to serialize against; this helper deduplicates,
-// sorts them, and acquires the advisory lock for each in sorted order.
+// The contract this helper enforces:
 //
-// Sorting is the deadlock-avoidance contract: every code path that
-// needs to lock multiple parents grabs them in the same total order
-// (string-sort by ID). Two concurrent re-parents that touch the same
-// two IDs in different "from/to" roles will both acquire id_A first,
-// then id_B — no AB/BA deadlock possible. Per Codex round-3 P1
-// (link-mutations bypass).
+//  1. Deduplicate. Repeated IDs in the input collapse to one lock.
+//  2. Drop empties. "" / nil entries don't get locked.
+//  3. Acquire in canonical sorted order (string-sort by ID).
+//     Two concurrent callers that share any subset of IDs always
+//     grab the overlap in the same order → no deadlock.
+//
+// SQLite is a no-op because the global BEGIN IMMEDIATE write lock
+// (set via _txlock=immediate in store.go) already serializes every
+// writer; advisory locks would add no protection there.
+//
+// Per Codex round-3 P1 (link-mutations bypass) + round-4 P2
+// (lock-order asymmetry). If you find yourself writing
+// `pg_advisory_xact_lock(... 'pad:parent-children:' ...)` anywhere
+// outside this helper, route it through here instead.
 func (s *Store) AcquireParentChildrenLocks(tx *sql.Tx, parentItemIDs ...string) error {
 	if s.dialect.Driver() != DriverPostgres {
 		return nil
@@ -2688,8 +2703,8 @@ func (s *Store) AcquireParentChildrenLocks(tx *sql.Tx, parentItemIDs ...string) 
 	}
 	sort.Strings(keys)
 	for _, k := range keys {
-		if err := s.AcquireParentChildrenLock(tx, k); err != nil {
-			return err
+		if _, err := tx.Exec("SELECT pg_advisory_xact_lock(hashtext('pad:parent-children:' || $1))", k); err != nil {
+			return fmt.Errorf("acquire parent-children lock %q: %w", k, err)
 		}
 	}
 	return nil

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 
@@ -262,6 +263,56 @@ func (s *Store) GetItem(id string) (*models.Item, error) {
 	}
 	if err != nil {
 		return nil, fmt.Errorf("get item: %w", err)
+	}
+
+	item.Pinned = pinned
+	item.CreatedAt = parseTime(createdAt)
+	item.UpdatedAt = parseTime(updatedAt)
+	item.DeletedAt = parseTimePtr(deletedAt)
+	hydrateItemComputedMetadata(&item)
+	return &item, nil
+}
+
+// getItemTx is the in-transaction variant of GetItem. Used by
+// UpdateItemWithPreCheck to re-read the parent under the workspace +
+// parent-children locks so the invariant precheck classifies the
+// transition against a snapshot that's stable for the rest of the tx
+// (Codex round-3 P2). Soft-deleted items are excluded, matching
+// GetItem's contract.
+func (s *Store) getItemTx(tx *sql.Tx, id string) (*models.Item, error) {
+	var item models.Item
+	var createdAt, updatedAt string
+	var deletedAt *string
+	var pinned bool
+
+	err := tx.QueryRow(s.q(`
+		SELECT i.id, i.workspace_id, i.collection_id, i.title, i.slug, i.content, i.fields, i.tags,
+		       i.pinned, i.sort_order, i.parent_id, i.assigned_user_id, i.agent_role_id, i.role_sort_order,
+		       i.created_by, i.last_modified_by, i.source,
+		       i.item_number, i.seq, i.created_at, i.updated_at, i.deleted_at,
+		       c.slug, c.name, c.icon, c.prefix,
+		       COALESCE(au.name, ''), COALESCE(au.email, ''),
+		       COALESCE(ar.name, ''), COALESCE(ar.slug, ''), COALESCE(ar.icon, '')
+		FROM items i
+		JOIN collections c ON c.id = i.collection_id
+		LEFT JOIN users au ON au.id = i.assigned_user_id
+		LEFT JOIN agent_roles ar ON ar.id = i.agent_role_id
+		WHERE i.id = ? AND i.deleted_at IS NULL
+	`), id).Scan(
+		&item.ID, &item.WorkspaceID, &item.CollectionID, &item.Title, &item.Slug,
+		&item.Content, &item.Fields, &item.Tags,
+		&pinned, &item.SortOrder, &item.ParentID, &item.AssignedUserID, &item.AgentRoleID, &item.RoleSortOrder,
+		&item.CreatedBy, &item.LastModifiedBy, &item.Source,
+		&item.ItemNumber, &item.Seq, &createdAt, &updatedAt, &deletedAt,
+		&item.CollectionSlug, &item.CollectionName, &item.CollectionIcon, &item.CollectionPrefix,
+		&item.AssignedUserName, &item.AssignedUserEmail,
+		&item.AgentRoleName, &item.AgentRoleSlug, &item.AgentRoleIcon,
+	)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get item (tx): %w", err)
 	}
 
 	item.Pinned = pinned
@@ -1363,10 +1414,34 @@ func (s *Store) UpdateItemWithPreCheck(
 	// UPDATE below will write against because every concurrent
 	// UpdateItem on this parent (or on any of its children) blocks
 	// on the same advisory key.
+	//
+	// Codex round-3 P2: re-read the item INSIDE the tx (after locks)
+	// and pass that fresh snapshot to the precheck. The pre-tx
+	// `existing` above was loaded without holding the workspace seq
+	// lock or the parent-children lock — a concurrent writer could
+	// have flipped the parent's done-field between that read and
+	// here, which would mis-classify the transition (false-fire or
+	// false-skip). The post-lock re-read sees what the UPDATE will
+	// write against.
 	if precheck != nil {
-		if err := precheck(tx, existing); err != nil {
+		freshExisting, ferr := s.getItemTx(tx, id)
+		if ferr != nil {
+			return nil, fmt.Errorf("re-read item under lock: %w", ferr)
+		}
+		if freshExisting == nil {
+			// Item was deleted between the pre-tx read and the
+			// post-lock re-read. Treat as not-found and let the
+			// handler surface a 404. Returning nil here mirrors the
+			// existing == nil branch above.
+			return nil, nil
+		}
+		if err := precheck(tx, freshExisting); err != nil {
 			return nil, err
 		}
+		// Use the fresh snapshot for the rest of the function too —
+		// otherwise the mutation logic below would proceed from
+		// stale data and undo the integrity gain.
+		existing = freshExisting
 	}
 
 	ts := now()
@@ -1637,6 +1712,27 @@ func (s *Store) RestoreItem(id string) (*models.Item, error) {
 		return nil, err
 	}
 
+	// Codex round-3 P1: restoring an item resurrects it as a
+	// (potentially non-terminal) child of its parent. Lock the
+	// parent's children-key so a concurrent UpdateItemWithPreCheck
+	// on that parent sees this resurrection in its post-lock snapshot.
+	// Look up via item_links so we cover both `parent` and
+	// `implements` edges — same inclusion rule
+	// acquireParentChildrenLocksForUpdate uses.
+	var parentID sql.NullString
+	if err := tx.QueryRow(s.q(fmt.Sprintf(`
+		SELECT target_id FROM item_links
+		WHERE source_id = ? AND link_type IN (%s)
+		LIMIT 1
+	`, childLinkTypeSQL())), id).Scan(&parentID); err != nil && err != sql.ErrNoRows {
+		return nil, fmt.Errorf("lookup parent for restore lock: %w", err)
+	}
+	if parentID.Valid && parentID.String != "" {
+		if err := s.AcquireParentChildrenLock(tx, parentID.String); err != nil {
+			return nil, err
+		}
+	}
+
 	ts := now()
 	result, err := tx.Exec(s.q(`
 		UPDATE items SET deleted_at = NULL, updated_at = ?, seq = `+nextWorkspaceSeqSubquery+`
@@ -1786,12 +1882,34 @@ func (s *Store) CreateItemLink(workspaceID string, input models.ItemLinkCreate, 
 		createdBy = "user"
 	}
 
-	_, err = s.db.Exec(s.q(`
+	tx, err := s.db.Begin()
+	if err != nil {
+		return nil, fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback()
+
+	// Codex round-3 P1: when this link puts `sourceID` into the
+	// children-set of `target` (i.e. linkType ∈ childLinkTypes), lock
+	// the target's parent-children key so a concurrent
+	// UpdateItemWithPreCheck on the target can't read 0 open children
+	// while we're about to attach a non-terminal one. Non-child link
+	// types (blocks, supersedes, …) don't affect the children-set so
+	// we skip the lock — keeps the common case lock-free.
+	if isChildLinkType(linkType) {
+		if err := s.AcquireParentChildrenLock(tx, input.TargetID); err != nil {
+			return nil, err
+		}
+	}
+
+	if _, err := tx.Exec(s.q(`
 		INSERT INTO item_links (id, workspace_id, source_id, target_id, link_type, created_by, created_at)
 		VALUES (?, ?, ?, ?, ?, ?, ?)
-	`), id, workspaceID, sourceID, input.TargetID, linkType, createdBy, ts)
-	if err != nil {
+	`), id, workspaceID, sourceID, input.TargetID, linkType, createdBy, ts); err != nil {
 		return nil, fmt.Errorf("create item link: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit create item link: %w", err)
 	}
 
 	return s.getItemLink(id)
@@ -1941,7 +2059,37 @@ func (s *Store) GetItemLinkByID(id string) (*models.ItemLink, error) {
 }
 
 func (s *Store) DeleteItemLink(id string) error {
-	result, err := s.db.Exec(s.q("DELETE FROM item_links WHERE id = ?"), id)
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback()
+
+	// Codex round-3 P1: peek the link's type + target before deleting
+	// so we can lock the target's parent-children key when this link
+	// participates in the children-set. Without this, a concurrent
+	// UpdateItemWithPreCheck on the target could read the child as
+	// still attached, decide the parent has no open children, and
+	// commit a terminal status while we orphan a non-terminal child.
+	//
+	// We DON'T lock for non-child link types (blocks, supersedes, …)
+	// — they don't affect the children-set, so contention there is
+	// unnecessary.
+	var linkType, targetID string
+	err = tx.QueryRow(s.q("SELECT link_type, target_id FROM item_links WHERE id = ?"), id).Scan(&linkType, &targetID)
+	if err == sql.ErrNoRows {
+		return sql.ErrNoRows
+	}
+	if err != nil {
+		return fmt.Errorf("peek item link for delete: %w", err)
+	}
+	if isChildLinkType(linkType) {
+		if err := s.AcquireParentChildrenLock(tx, targetID); err != nil {
+			return err
+		}
+	}
+
+	result, err := tx.Exec(s.q("DELETE FROM item_links WHERE id = ?"), id)
 	if err != nil {
 		return fmt.Errorf("delete item link: %w", err)
 	}
@@ -1949,7 +2097,7 @@ func (s *Store) DeleteItemLink(id string) error {
 	if rows == 0 {
 		return sql.ErrNoRows
 	}
-	return nil
+	return tx.Commit()
 }
 
 // --- Phase Links ---
@@ -1957,6 +2105,13 @@ func (s *Store) DeleteItemLink(id string) error {
 // SetParentLink sets the parent for an item. Since an item can belong to at most
 // one parent, this deletes any existing parent link for the item first.
 // Includes cycle detection to prevent A→B→A or deeper ancestor loops.
+//
+// Codex round-3 P1: acquires `pad:parent-children:<id>` for BOTH the
+// old parent (if any) AND the new parent in sorted order. That makes
+// a concurrent UpdateItemWithPreCheck on either parent block on the
+// same key, closing the link-mutation TOCTOU gap — without this, the
+// guard could read 0 open children while this method was about to
+// attach a non-terminal child.
 func (s *Store) SetParentLink(workspaceID, itemID, parentID, createdBy string) (*models.ItemLink, error) {
 	// Cycle detection: walk the ancestor chain from parentID to ensure itemID is not an ancestor.
 	if err := s.checkParentCycle(itemID, parentID); err != nil {
@@ -1968,6 +2123,25 @@ func (s *Store) SetParentLink(workspaceID, itemID, parentID, createdBy string) (
 		return nil, fmt.Errorf("begin tx: %w", err)
 	}
 	defer tx.Rollback()
+
+	// Find the existing parent (if any) so we can lock against it too.
+	// The DELETE below targets link_type='parent' specifically, which
+	// matches what the guard's children query treats as the parent
+	// edge (childLinkTypes includes 'parent'); other child-link types
+	// like 'implements' aren't displaced by this method so we don't
+	// need their old parent here.
+	var oldParentID sql.NullString
+	if err := tx.QueryRow(s.q(`
+		SELECT target_id FROM item_links
+		WHERE source_id = ? AND link_type = 'parent'
+		LIMIT 1
+	`), itemID).Scan(&oldParentID); err != nil && err != sql.ErrNoRows {
+		return nil, fmt.Errorf("lookup existing parent: %w", err)
+	}
+
+	if err := s.AcquireParentChildrenLocks(tx, oldParentID.String, parentID); err != nil {
+		return nil, err
+	}
 
 	// Delete existing parent link for this item (if any)
 	if _, err := tx.Exec(s.q(`DELETE FROM item_links WHERE source_id = ? AND link_type = 'parent'`), itemID); err != nil {
@@ -2020,12 +2194,36 @@ func (s *Store) checkParentCycle(itemID, parentID string) error {
 }
 
 // ClearParentLink removes the parent link for an item.
+//
+// Codex round-3 P1: runs in a tx and acquires `pad:parent-children:<old>`
+// before the DELETE so a concurrent UpdateItemWithPreCheck on the old
+// parent blocks until this commit. Detaching a child is materially
+// similar to attaching one — the parent's children-set changes either
+// way and the guard must see a consistent view.
 func (s *Store) ClearParentLink(itemID string) error {
-	_, err := s.db.Exec(s.q(`DELETE FROM item_links WHERE source_id = ? AND link_type = 'parent'`), itemID)
+	tx, err := s.db.Begin()
 	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback()
+
+	var oldParentID sql.NullString
+	if err := tx.QueryRow(s.q(`
+		SELECT target_id FROM item_links
+		WHERE source_id = ? AND link_type = 'parent'
+		LIMIT 1
+	`), itemID).Scan(&oldParentID); err != nil && err != sql.ErrNoRows {
+		return fmt.Errorf("lookup parent for clear: %w", err)
+	}
+	if oldParentID.Valid && oldParentID.String != "" {
+		if err := s.AcquireParentChildrenLock(tx, oldParentID.String); err != nil {
+			return err
+		}
+	}
+	if _, err := tx.Exec(s.q(`DELETE FROM item_links WHERE source_id = ? AND link_type = 'parent'`), itemID); err != nil {
 		return fmt.Errorf("clear parent link: %w", err)
 	}
-	return nil
+	return tx.Commit()
 }
 
 // GetParentForItem returns the parent link for an item, or nil if it has no parent.
@@ -2459,6 +2657,58 @@ func (s *Store) AcquireParentChildrenLock(tx *sql.Tx, parentItemID string) error
 	return nil
 }
 
+// AcquireParentChildrenLocks is the multi-key variant used when a
+// single mutation touches more than one parent's children-set —
+// re-parenting (old parent + new parent), CreateItemLink that attaches
+// a parent/implements link, etc. The caller passes the full set of
+// parent IDs they need to serialize against; this helper deduplicates,
+// sorts them, and acquires the advisory lock for each in sorted order.
+//
+// Sorting is the deadlock-avoidance contract: every code path that
+// needs to lock multiple parents grabs them in the same total order
+// (string-sort by ID). Two concurrent re-parents that touch the same
+// two IDs in different "from/to" roles will both acquire id_A first,
+// then id_B — no AB/BA deadlock possible. Per Codex round-3 P1
+// (link-mutations bypass).
+func (s *Store) AcquireParentChildrenLocks(tx *sql.Tx, parentItemIDs ...string) error {
+	if s.dialect.Driver() != DriverPostgres {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(parentItemIDs))
+	keys := make([]string, 0, len(parentItemIDs))
+	for _, id := range parentItemIDs {
+		if id == "" {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		keys = append(keys, id)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		if err := s.AcquireParentChildrenLock(tx, k); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// isChildLinkType reports whether the given link type is one the
+// open-children guard counts toward the children-set (i.e. matches
+// the inclusion rule baked into `childLinkTypes` and used by
+// GetChildItems via `childLinkTypeSQL()`). Single source of truth so
+// link-writer lock acquisition can't drift from the read query's set.
+func isChildLinkType(linkType string) bool {
+	for _, t := range childLinkTypes {
+		if t == linkType {
+			return true
+		}
+	}
+	return false
+}
+
 // childQueryer is the small surface the children-list query needs from
 // either *sql.DB or *sql.Tx. Lets getChildItems serve both the unlocked
 // and tx-bound paths from one implementation.
@@ -2546,6 +2796,26 @@ func (s *Store) PopulateHasChildren(items []models.Item) {
 // client polling /items-changes?since=cursor would render the item
 // under its old collection until a full refresh.
 func (s *Store) MoveItem(itemID, targetCollectionID, newFieldsJSON string) (*models.Item, error) {
+	return s.MoveItemWithPreCheck(itemID, targetCollectionID, newFieldsJSON, nil)
+}
+
+// MoveItemWithPreCheck is MoveItem with the same precheck escape hatch
+// UpdateItemWithPreCheck offers. Codex round-3 P1: a `pad item move
+// ... --field status=done` writes a terminal done-field value through
+// MoveItem, bypassing the open-children guard wired into the regular
+// UpdateItem path. This variant runs the caller's invariant check
+// inside the move's transaction, after acquiring the workspace seq
+// lock + the parent-children lock for this item's own parent (it CAN
+// itself be a parent — children stay attached across collection
+// changes — so we lock for itself too, matching
+// acquireParentChildrenLocksForUpdate's shape).
+//
+// The precheck receives a fresh in-tx snapshot of the item, same as
+// UpdateItemWithPreCheck (the pre-tx `existing` is replaced).
+func (s *Store) MoveItemWithPreCheck(
+	itemID, targetCollectionID, newFieldsJSON string,
+	precheck func(tx *sql.Tx, existing *models.Item) error,
+) (*models.Item, error) {
 	existing, err := s.GetItem(itemID)
 	if err != nil {
 		return nil, err
@@ -2562,6 +2832,24 @@ func (s *Store) MoveItem(itemID, targetCollectionID, newFieldsJSON string) (*mod
 
 	if err := s.acquireWorkspaceSeqLock(tx, existing.WorkspaceID); err != nil {
 		return nil, err
+	}
+
+	if err := s.acquireParentChildrenLocksForUpdate(tx, itemID); err != nil {
+		return nil, err
+	}
+
+	if precheck != nil {
+		freshExisting, ferr := s.getItemTx(tx, itemID)
+		if ferr != nil {
+			return nil, fmt.Errorf("re-read item under lock: %w", ferr)
+		}
+		if freshExisting == nil {
+			return nil, sql.ErrNoRows
+		}
+		if err := precheck(tx, freshExisting); err != nil {
+			return nil, err
+		}
+		existing = freshExisting
 	}
 
 	_, err = tx.Exec(s.q(`

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -1285,6 +1285,29 @@ func (s *Store) listItemsFTS(workspaceID string, params models.ItemListParams) (
 }
 
 func (s *Store) UpdateItem(id string, input models.ItemUpdate) (*models.Item, error) {
+	return s.UpdateItemWithPreCheck(id, input, nil)
+}
+
+// UpdateItemWithPreCheck is UpdateItem with an optional pre-mutation
+// hook that runs inside the same transaction (and, on Postgres, holds
+// the same workspace advisory lock) as the update itself. Callers can
+// use the hook to enforce cross-row invariants whose decision must be
+// atomic with the write — e.g. the open-children guard (IDEA-1494)
+// needs the children-list query and the parent's status flip to share
+// a tx so a concurrent child insert / child status change can't slip
+// between them.
+//
+// The hook receives the transaction and the freshly-read existing
+// item. Returning a non-nil error rolls the tx back and surfaces the
+// error verbatim — callers can return a sentinel and `errors.Is` it
+// in the handler.
+//
+// Pass a nil precheck for the standard, unchecked update path.
+func (s *Store) UpdateItemWithPreCheck(
+	id string,
+	input models.ItemUpdate,
+	precheck func(tx *sql.Tx, existing *models.Item) error,
+) (*models.Item, error) {
 	existing, err := s.GetItem(id)
 	if err != nil {
 		return nil, err
@@ -1308,6 +1331,42 @@ func (s *Store) UpdateItem(id string, input models.ItemUpdate) (*models.Item, er
 	// (no-op on SQLite). Held until COMMIT / ROLLBACK.
 	if err := s.acquireWorkspaceSeqLock(tx, existing.WorkspaceID); err != nil {
 		return nil, err
+	}
+
+	// IDEA-1494 round 2: also acquire the parent-children advisory
+	// lock for THIS item (as a potential parent) AND for its own
+	// parent (when it is itself a child). That gives the open-children
+	// guard a tight serialization:
+	//
+	//   - A parent's UpdateItem precheck holds `pad:parent-children:<parent_id>`
+	//     while reading the children list and writing the parent.
+	//   - A child's UpdateItem holds the same key for its parent
+	//     while it writes itself.
+	//
+	// Result: a child status-flip that would invalidate the parent's
+	// guard cannot interleave between the parent's children-read and
+	// the parent's status-write. SQLite gets this for free from
+	// BEGIN IMMEDIATE; Postgres needs the explicit advisory lock.
+	//
+	// Lock ordering: workspace lock → THIS item's parent lock → THIS
+	// item's own children lock. Both lock keys are namespaced under
+	// `pad:parent-children:` so they only contend on the parent ID;
+	// acquiring two distinct keys in a fixed order can't deadlock.
+	if err := s.acquireParentChildrenLocksForUpdate(tx, id); err != nil {
+		return nil, err
+	}
+
+	// IDEA-1494 round 2: run the caller's invariant check (if any)
+	// AFTER the locks are held but BEFORE any mutation. Closing the
+	// guard-vs-write TOCTOU window relies on this ordering — the
+	// precheck's view of `items` / `item_links` is the same one the
+	// UPDATE below will write against because every concurrent
+	// UpdateItem on this parent (or on any of its children) blocks
+	// on the same advisory key.
+	if precheck != nil {
+		if err := precheck(tx, existing); err != nil {
+			return nil, err
+		}
 	}
 
 	ts := now()
@@ -2303,7 +2362,112 @@ func (s *Store) GetAllItemProgress(workspaceID, collectionSlug string) ([]ItemPr
 // GetChildItems returns all non-deleted child items linked to the given parent
 // via item_links. Returns children from any collection.
 func (s *Store) GetChildItems(parentItemID string) ([]models.Item, error) {
-	rows, err := s.db.Query(s.q(fmt.Sprintf(`
+	return s.getChildItems(s.db, parentItemID)
+}
+
+// GetChildItemsTx is the in-transaction variant of GetChildItems. The
+// underlying query is the same as GetChildItems; using a *sql.Tx ties
+// the read to the caller's transaction so it sees the same snapshot
+// the subsequent UPDATE will write against (IDEA-1494 R2).
+//
+// Atomicity vs. concurrent child mutations is provided by the caller's
+// transaction-scoped locking:
+//
+//   - SQLite: db-wide BEGIN IMMEDIATE write lock (set globally via
+//     `_txlock=immediate`) serializes all writers, so any concurrent
+//     child insert / child update blocks until this tx commits or
+//     rolls back. No additional locking is needed.
+//   - Postgres: the caller is expected to hold a parent-keyed advisory
+//     lock (see AcquireParentChildrenLock below) so concurrent
+//     mutations on the same parent's children are serialized against
+//     this read.
+//
+// FOR UPDATE is intentionally NOT used — the underlying SELECT carries
+// DISTINCT (necessary because item_links can carry both `parent` and
+// the legacy `plan` link_type for the same edge), and Postgres rejects
+// `SELECT DISTINCT … FOR UPDATE`. The advisory-lock pattern sidesteps
+// that constraint while still giving us a serialized snapshot.
+func (s *Store) GetChildItemsTx(tx *sql.Tx, parentItemID string) ([]models.Item, error) {
+	if tx == nil {
+		return s.GetChildItems(parentItemID)
+	}
+	return s.getChildItems(tx, parentItemID)
+}
+
+// acquireParentChildrenLocksForUpdate is the in-tx helper UpdateItem
+// uses to serialize itself against the open-children guard (IDEA-1494
+// R2). It acquires two advisory locks on Postgres:
+//
+//  1. the parent-children lock for THIS item's parent (when it has one)
+//     — so a child-status-flip is serialized against any parent-update
+//     precheck that's reading this child via GetChildItemsTx.
+//  2. the parent-children lock for THIS item AS a parent — so any
+//     concurrent precheck running against this item's own children
+//     list waits for our write to commit.
+//
+// Both keys are namespaced under `pad:parent-children:<id>` so they
+// only contend on the parent ID. SQLite is a no-op because the
+// BEGIN IMMEDIATE write lock already serializes all writers globally.
+//
+// Order is fixed (parent first, self second) to avoid the classic
+// AB/BA deadlock — two concurrent updaters that touch the same parent
+// always grab that key before the more-specific one.
+func (s *Store) acquireParentChildrenLocksForUpdate(tx *sql.Tx, itemID string) error {
+	if s.dialect.Driver() != DriverPostgres {
+		return nil
+	}
+	// Look up THIS item's parent (if any) via item_links. Cheap: hits
+	// the (source_id, link_type) index. A NULL/missing row means the
+	// item has no parent — skip step 1.
+	var parentID sql.NullString
+	err := tx.QueryRow(s.q(fmt.Sprintf(`
+		SELECT target_id FROM item_links
+		WHERE source_id = ? AND link_type IN (%s)
+		LIMIT 1
+	`, childLinkTypeSQL())), itemID).Scan(&parentID)
+	if err != nil && err != sql.ErrNoRows {
+		return fmt.Errorf("lookup parent for advisory lock: %w", err)
+	}
+	if parentID.Valid && parentID.String != "" && parentID.String != itemID {
+		if err := s.AcquireParentChildrenLock(tx, parentID.String); err != nil {
+			return err
+		}
+	}
+	// Acquire the self-as-parent key.
+	return s.AcquireParentChildrenLock(tx, itemID)
+}
+
+// AcquireParentChildrenLock takes a Postgres advisory transaction lock
+// keyed on the parent item ID, serializing concurrent reads/writes
+// against that parent's children for the duration of the caller's tx.
+// No-op on SQLite (BEGIN IMMEDIATE already serializes writers).
+//
+// Used by the open-children guard (IDEA-1494 R2): the guard's
+// children-list query and the subsequent UPDATE of the parent's status
+// must agree on the children set. The advisory lock blocks any other
+// updater that would mutate this parent's children-list view.
+func (s *Store) AcquireParentChildrenLock(tx *sql.Tx, parentItemID string) error {
+	if s.dialect.Driver() != DriverPostgres {
+		return nil
+	}
+	// Distinct lock-key namespace from acquireWorkspaceSeqLock so the
+	// two don't collide and we don't accidentally widen serialization
+	// to "any update in the workspace."
+	if _, err := tx.Exec("SELECT pg_advisory_xact_lock(hashtext('pad:parent-children:' || $1))", parentItemID); err != nil {
+		return fmt.Errorf("acquire parent-children lock: %w", err)
+	}
+	return nil
+}
+
+// childQueryer is the small surface the children-list query needs from
+// either *sql.DB or *sql.Tx. Lets getChildItems serve both the unlocked
+// and tx-bound paths from one implementation.
+type childQueryer interface {
+	Query(query string, args ...any) (*sql.Rows, error)
+}
+
+func (s *Store) getChildItems(q childQueryer, parentItemID string) ([]models.Item, error) {
+	rows, err := q.Query(s.q(fmt.Sprintf(`
 		SELECT DISTINCT i.id, i.workspace_id, i.collection_id, i.title, i.slug, i.content, i.fields, i.tags,
 		       i.pinned, i.sort_order, i.parent_id, i.assigned_user_id, i.agent_role_id, i.role_sort_order,
 		       i.created_by, i.last_modified_by, i.source,


### PR DESCRIPTION
## Summary

Adds a server-side guard that refuses `done`-field transitions into a terminal value when the item still has non-terminal children. The whole point is data integrity for agents (and humans) shipping work through Pad: marking a plan `completed` while child tasks are still `open` silently broke until a human or query noticed. Now it fails fast with a structured error listing the blockers.

- **CLI**: `pad item update PLAN-X --status completed` exits non-zero, prints the open children, points at `--force` to override. Same for `pad item move ... --field status=...`. `pad item update --force` and `pad item bulk-update --force` preserve the escape hatch.
- **MCP**: `pad_item.action: update` / `move` / `bulk-update` accept `force: true`. Rejection returns 409 with `code: "open_children"` and structured `details.open_children` + `details.hidden_blocker_count` so MCP-driven agents can self-recover. HTTP and stdio MCP transports agree on the contract (versioned `pad-structured-error/v1:` marker on stderr for stdio; whitelisted `allowedStructuredErrorCodes` on HTTP).
- **Concurrency**: Guard runs under a per-parent advisory lock (`pad:parent-children:<id>`); UpdateItem / MoveItem / RestoreItem / SetParentLink / ClearParentLink / CreateItemLink / DeleteItemLink all acquire locks via a single canonical sorted multi-key helper. No ad-hoc ordering. Multi-parent children (parent + implements) lock all parents. PATCH atomicity: a guard rejection leaves the parent link untouched.
- **Visibility**: Restricted callers see only their visible children's refs/titles; hidden blockers are counted in `details.hidden_blocker_count`. Fail-closed on visibility-lookup error.

## Out of scope (deferred)

- Dashboard "Plans ready to close" section.
- `pad plan close` shortcut.
- Web UI handling of the new 409 (API contract is the deliverable; SvelteKit follow-up later).
- Inverse-direction PATCH partial-success (field-write succeeds, link-write fails). Requires `SetParentLink` to accept an external tx; tracked as future work.
- `MigrateItemFieldValues` admin schema-migration bypass (intentional — bulk schema ops are reviewed at schema level).
- Workspace export/import bypass (intentional — full-state restore by definition recreates past state).

## Review process

5 commits ship together. Codex review-loop converged after 4 rounds with rotating framings (diff / gaps / blast-radius / convergence). Round 1 caught 3 issues, round 2 caught 7, round 3 caught 4, round 4 caught 1 JSON-contract nit. Diminishing severity end-to-end.

## Test plan

- [x] `go test ./...` (SQLite default) — PASS
- [x] `go test ./...` against Postgres (`PAD_TEST_POSTGRES_URL=...`) — PASS
- [x] `make lint` (golangci-lint) — 0 issues
- [ ] CI matrix (Go / Postgres / Web / E2E) — pending on this PR
- [ ] Manual smoke after merge: `pad item update PLAN-X --status completed` on a workspace with open children → 409, with `--force` → succeeds.

## Refs

Closes docapp IDEA-1494. Captured in claude workspace as DECIS-32 data-point (orchestrated PLAYB-40 cycle, 4 codex rounds).