### PR TITLE
feat(cli,mcp): expose 'collection update' via CLI and MCP catalog (TASK-1510)

### DIFF
--- a/cmd/pad/groups.go
+++ b/cmd/pad/groups.go
@@ -114,11 +114,12 @@ func itemCmd() *cobra.Command {
 func collectionCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "collection",
-		Short: "List and create collections",
+		Short: "List, create, and update collections",
 	}
 	cmd.AddCommand(
 		collectionsCmd(),
 		collectionsCreateCmd(),
+		collectionsUpdateCmd(),
 	)
 	return cmd
 }

--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -5311,41 +5311,12 @@ func readSchemaInputBytes(input string, stdin io.Reader) ([]byte, error) {
 	}
 }
 
-// parseFieldsDSL parses the legacy --fields DSL (key:type[:options];...) into
-// a CollectionSchema. Empty input returns an empty schema with no error.
+// parseFieldsDSL is the cmd/pad-local alias for the canonical parser
+// at collections.ParseFieldsDSL. Moved up to internal/collections so
+// the MCP HTTP route mapper can share the same parser when accepting
+// `fields=...` on `pad_collection update` (PR #572).
 func parseFieldsDSL(fieldsDSL string) (models.CollectionSchema, error) {
-	schema := models.CollectionSchema{}
-	if fieldsDSL == "" {
-		return schema, nil
-	}
-	for _, f := range strings.Split(fieldsDSL, ";") {
-		f = strings.TrimSpace(f)
-		if f == "" {
-			continue
-		}
-		parts := strings.SplitN(f, ":", 3)
-		if len(parts) < 2 {
-			return schema, fmt.Errorf("invalid field definition: %q (expected key:type[:options])", f)
-		}
-		fd := models.FieldDef{
-			Key:   parts[0],
-			Label: cases.Title(language.English).String(strings.ReplaceAll(parts[0], "_", " ")),
-			Type:  parts[1],
-		}
-		if len(parts) == 3 && parts[2] != "" {
-			fd.Options = strings.Split(parts[2], ",")
-		}
-		// First select field gets required+default — preserved for
-		// backward compat with the pre-existing DSL behavior.
-		if fd.Type == "select" && fd.Key == "status" {
-			fd.Required = true
-			if len(fd.Options) > 0 {
-				fd.Default = fd.Options[0]
-			}
-		}
-		schema.Fields = append(schema.Fields, fd)
-	}
-	return schema, nil
+	return collections.ParseFieldsDSL(fieldsDSL)
 }
 
 func collectionsCreateCmd() *cobra.Command {

--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -5451,6 +5451,121 @@ the --fields DSL does. Set "label" explicitly when you want a custom display nam
 	return cmd
 }
 
+// collectionsUpdateCmd updates an existing collection's name, icon,
+// description, prefix, schema, or sort order. Only flags the caller
+// explicitly sets are sent — every CollectionUpdate field is a pointer
+// type server-side so omitted values are preserved.
+//
+// --schema (and the legacy --fields alias) accept the same input modes
+// as `pad collection create`: inline JSON literal, @path to a file, or
+// "-" for stdin. The flag is parsed via the shared
+// collectionSchemaJSONFromFlags helper so DSL parity stays.
+//
+// Schema changes can rename / reshape select options on existing items
+// via the server-side `migrations []FieldMigration` field; that's not
+// exposed on the CLI flag surface here because the typical agent flow
+// is "rewrite the seeded schema during onboarding before items exist"
+// (PLAN-1496 → TASK-1499). When the migration path is needed, drive
+// the PATCH through the API client directly.
+func collectionsUpdateCmd() *cobra.Command {
+	var (
+		name        string
+		icon        string
+		description string
+		prefix      string
+		fieldsDSL   string
+		schemaInput string
+		sortOrder   int
+	)
+
+	cmd := &cobra.Command{
+		Use:   "update <slug>",
+		Short: "Update an existing collection",
+		Long: `Update an existing collection's name, icon, description, prefix,
+schema, or sort order.
+
+Only flags you explicitly set are sent — every other property is left
+untouched. Use this to rename collections, swap icons, or reshape the
+schema (e.g. change status enum options or add/remove fields).
+
+The --schema and --fields flags accept the same input modes as
+'pad collection create':
+
+  --fields  Compact DSL for the simple case: key:type[:option1,option2,...]
+  --schema  Full CollectionSchema JSON: inline, @path, or - for stdin
+
+Examples:
+  pad collection update tasks --name Issues --icon 🎯
+  pad collection update conventions --description "Updated rules"
+  pad collection update bugs --schema @./new-bug-schema.json
+  pad collection update tasks --fields "status:select:open,doing,done;priority:select:high,medium,low"
+
+Collections can be referenced by slug (e.g. 'tasks') only — there is no
+issue-ID equivalent for collections themselves.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, _ := getClient()
+			ws := getWorkspace()
+			collSlug := args[0]
+
+			input := models.CollectionUpdate{}
+
+			if cmd.Flags().Changed("name") {
+				input.Name = &name
+			}
+			if cmd.Flags().Changed("icon") {
+				input.Icon = &icon
+			}
+			if cmd.Flags().Changed("description") {
+				input.Description = &description
+			}
+			if cmd.Flags().Changed("prefix") {
+				input.Prefix = &prefix
+			}
+			if cmd.Flags().Changed("sort-order") {
+				input.SortOrder = &sortOrder
+			}
+
+			// Schema is only resolved when the user passed --schema or --fields.
+			// Calling the helper with both empty returns "{}" which would wipe
+			// the existing schema — guard against that footgun.
+			if cmd.Flags().Changed("schema") || cmd.Flags().Changed("fields") {
+				schemaJSON, err := collectionSchemaJSONFromFlags(schemaInput, fieldsDSL, os.Stdin)
+				if err != nil {
+					return err
+				}
+				input.Schema = &schemaJSON
+			}
+
+			updated, err := client.UpdateCollection(ws, collSlug, input)
+			if err != nil {
+				return err
+			}
+
+			if formatFlag == "json" {
+				return cli.PrintJSON(updated)
+			}
+
+			collIcon := updated.Icon
+			if collIcon == "" {
+				collIcon = "📦"
+			}
+			fmt.Printf("Updated collection %s %s (slug: %s)\n", collIcon, updated.Name, updated.Slug)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&name, "name", "", "new display name")
+	cmd.Flags().StringVar(&icon, "icon", "", "new emoji icon (use empty string to clear)")
+	cmd.Flags().StringVar(&description, "description", "", "new description (use empty string to clear)")
+	cmd.Flags().StringVar(&prefix, "prefix", "", "new issue-ID prefix (e.g. TASK, BUG)")
+	cmd.Flags().StringVar(&fieldsDSL, "fields", "", "replacement schema via DSL: \"key:type[:options]; ...\"")
+	cmd.Flags().StringVar(&schemaInput, "schema", "", "replacement CollectionSchema JSON: inline, @path, or - for stdin")
+	cmd.Flags().IntVar(&sortOrder, "sort-order", 0, "new sort order (lower = appears first)")
+
+	return cmd
+}
+
 // --- edit ---
 
 func editCmd() *cobra.Command {

--- a/internal/collections/dsl.go
+++ b/internal/collections/dsl.go
@@ -1,0 +1,79 @@
+// Package collections holds collection-shape utilities shared by the
+// CLI, the MCP HTTP dispatcher, and (eventually) any other surface
+// that needs to translate user-friendly DSL forms into the canonical
+// JSON shapes the API consumes.
+//
+// `dsl.go` is the home for the legacy "compact field DSL" parser that
+// originally lived in cmd/pad/main.go. Moved up to this shared package
+// (PR #572 follow-up to Codex finding on TASK-1510) so the MCP HTTP
+// route mapper can accept `fields=...` for `collection update` without
+// reimplementing the parser. The CLI calls the same helper via
+// CollectionSchemaJSONFromDSL; both surfaces now have parity.
+package collections
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+)
+
+// ParseFieldsDSL parses the compact field DSL (key:type[:options];...)
+// into a CollectionSchema. Empty input returns an empty schema with no
+// error.
+//
+// First select field named `status` automatically gets `required=true`
+// and `default=<first option>` — backward-compatible behavior preserved
+// from the original cmd/pad implementation.
+func ParseFieldsDSL(fieldsDSL string) (models.CollectionSchema, error) {
+	schema := models.CollectionSchema{}
+	if fieldsDSL == "" {
+		return schema, nil
+	}
+	for _, f := range strings.Split(fieldsDSL, ";") {
+		f = strings.TrimSpace(f)
+		if f == "" {
+			continue
+		}
+		parts := strings.SplitN(f, ":", 3)
+		if len(parts) < 2 {
+			return schema, fmt.Errorf("invalid field definition: %q (expected key:type[:options])", f)
+		}
+		fd := models.FieldDef{
+			Key:   parts[0],
+			Label: cases.Title(language.English).String(strings.ReplaceAll(parts[0], "_", " ")),
+			Type:  parts[1],
+		}
+		if len(parts) == 3 && parts[2] != "" {
+			fd.Options = strings.Split(parts[2], ",")
+		}
+		if fd.Type == "select" && fd.Key == "status" {
+			fd.Required = true
+			if len(fd.Options) > 0 {
+				fd.Default = fd.Options[0]
+			}
+		}
+		schema.Fields = append(schema.Fields, fd)
+	}
+	return schema, nil
+}
+
+// FieldsDSLToSchemaJSON parses the DSL and returns the marshaled
+// CollectionSchema JSON string. Empty input returns "{}" — an empty
+// schema. Convenience wrapper for callers that want to feed the
+// result straight into models.CollectionUpdate.Schema (which is a
+// *string).
+func FieldsDSLToSchemaJSON(fieldsDSL string) (string, error) {
+	schema, err := ParseFieldsDSL(fieldsDSL)
+	if err != nil {
+		return "", err
+	}
+	out, err := json.Marshal(schema)
+	if err != nil {
+		return "", fmt.Errorf("marshal schema from DSL: %w", err)
+	}
+	return string(out), nil
+}

--- a/internal/mcp/catalog_collection.go
+++ b/internal/mcp/catalog_collection.go
@@ -1,7 +1,14 @@
 package mcp
 
-// padCollectionTool exposes collection management. Two actions in
-// v0.2: list (read-only) and create (admin-mutating).
+// padCollectionTool exposes collection management. Three actions:
+// list (read-only), create (admin-mutating), update (admin-mutating).
+//
+// `update` (TASK-1510) is the adaptation primitive for the `/pad
+// onboard` playbook (PLAN-1496): the agent rewrites the seeded schema
+// during onboarding so collection field shapes, status enums, icons,
+// and names match the project's actual vocabulary instead of the
+// template defaults. Server-side handler at handlers_collections.go
+// requires the workspace owner role; viewers/editors can't mutate.
 //
 // `schema` was discussed in DOC-978 but dropped from v0.2 — the CLI
 // has no `collection schema` command, and consumers can read each
@@ -20,9 +27,14 @@ var padCollectionTool = ToolDef{
 		Workspace: true,
 		Params: []ParamDef{
 			{
+				Name:        "slug",
+				Type:        "string",
+				Description: "Collection slug (e.g. \"tasks\", \"conventions\"). Required for action=update; identifies which collection to mutate.",
+			},
+			{
 				Name:        "name",
 				Type:        "string",
-				Description: "Display name of the collection. Required for action=create.",
+				Description: "Display name of the collection. Required for action=create. Optional for action=update — provide to rename.",
 			},
 			{
 				Name:        "fields",
@@ -61,15 +73,26 @@ var padCollectionTool = ToolDef{
 				Type:        "string",
 				Description: "Field key to group by when in board view. Optional for action=create. Defaults to \"status\".",
 			},
+			{
+				Name:        "prefix",
+				Type:        "string",
+				Description: "Issue-ID prefix (e.g. \"TASK\", \"BUG\"). Optional for action=update — provide to change how new items in this collection are numbered.",
+			},
+			{
+				Name:        "sort_order",
+				Type:        "number",
+				Description: "Display sort order (lower = appears first). Optional for action=update.",
+			},
 		},
 	},
 	Actions: map[string]ActionFn{
 		"list":   passThrough([]string{"collection", "list"}),
 		"create": passThrough([]string{"collection", "create"}),
+		"update": passThrough([]string{"collection", "update"}),
 	},
 }
 
-const padCollectionToolDescription = `Collection management — list and create collection types.
+const padCollectionToolDescription = `Collection management — list, create, and update collection types.
 
 Actions:
   list    — List collections in the workspace with their schemas + counts.
@@ -84,6 +107,16 @@ Actions:
             active/complete counts) or when fields need defaults, computed
             flags, suffixes, or relation collections — the DSL cannot express
             those.
+  update  — Update an existing collection's name, icon, description, prefix,
+            schema, or sort order. Workspace owner only.
+            Required: workspace, slug.
+            Optional: name, icon, description, prefix, fields OR schema
+                      (mutually exclusive), sort_order. Only fields you
+                      explicitly set are mutated; everything else is left
+                      untouched.
+            This is the adaptation primitive for the onboarding playbook
+            (/pad onboard) — rewrite seeded collections to match the
+            project's actual vocabulary instead of template defaults.
 
 Schema for an individual collection is included in the list response — read it
 from there rather than calling list again. v0.2 does not expose a dedicated

--- a/internal/mcp/catalog_readonly_test.go
+++ b/internal/mcp/catalog_readonly_test.go
@@ -83,6 +83,7 @@ func TestReadOnlyCatalog_ActionsMatchCmdhelp(t *testing.T) {
 
 		{"pad_collection", "list"}:   {"collection", "list"},
 		{"pad_collection", "create"}: {"collection", "create"},
+		{"pad_collection", "update"}: {"collection", "update"},
 
 		{"pad_project", "dashboard"}: {"project", "dashboard"},
 		{"pad_project", "next"}:      {"project", "next"},
@@ -203,6 +204,7 @@ func TestReadOnlyCatalog_ActionsDispatchExpectedCmdPath(t *testing.T) {
 
 		{"pad_collection", "list"}:   {"collection", "list"},
 		{"pad_collection", "create"}: {"collection", "create"},
+		{"pad_collection", "update"}: {"collection", "update"},
 
 		{"pad_project", "dashboard"}: {"project", "dashboard"},
 		{"pad_project", "next"}:      {"project", "next"},
@@ -409,6 +411,14 @@ func liveCmdhelpDoc(t *testing.T) *cmdhelp.Document {
 				Flags: mkFlags(
 					"workspace", "fields", "icon", "description",
 					"layout", "default-view", "board-group-by",
+				),
+			},
+			"collection update": {
+				Summary: "update col",
+				Args:    mkArgs("slug"),
+				Flags: mkFlags(
+					"workspace", "name", "icon", "description", "prefix",
+					"fields", "schema", "sort-order",
 				),
 			},
 			// Project

--- a/internal/mcp/dispatch_http_routes.go
+++ b/internal/mcp/dispatch_http_routes.go
@@ -657,28 +657,33 @@ func mapCollectionUpdate(input map[string]any) (string, string, []byte, error) {
 	// schema vs fields: the catalog advertises both forms as mutually
 	// exclusive (matching `pad collection create`/`update`). The CLI
 	// resolves them via collectionSchemaJSONFromFlags; we mirror that
-	// resolution here so HTTP MCP callers get parity. Either input
-	// produces a JSON-encoded string on the wire — CollectionUpdate.
-	// Schema is *string and its UnmarshalJSON does not coerce objects.
+	// resolution here so HTTP MCP callers get parity.
+	//
+	// Normalize empty inputs as absent BEFORE checking exclusivity so
+	// optional empty params (`schema:null`, `schema:""`) don't block a
+	// legitimate `fields=...` update. Mirrors the relaxed handling on
+	// collection create.
 	rawSchema, hasSchema := input["schema"]
+	if rawSchema == nil {
+		hasSchema = false
+	} else if s, ok := rawSchema.(string); ok && s == "" {
+		hasSchema = false
+	}
 	rawFields, _ := input["fields"].(string)
 	if hasSchema && rawFields != "" {
 		return "", "", nil, fmt.Errorf("fields and schema are mutually exclusive")
 	}
 	switch {
-	case hasSchema && rawSchema != nil:
-		switch s := rawSchema.(type) {
-		case string:
-			if s != "" {
-				payload["schema"] = s
-			}
-		default:
-			encoded, err := json.Marshal(rawSchema)
-			if err != nil {
-				return "", "", nil, fmt.Errorf("encode schema: %w", err)
-			}
-			payload["schema"] = string(encoded)
+	case hasSchema:
+		// Reuse the encoder collection-create uses (dispatch_http_routes.go:418).
+		// Backfills missing field labels via the Title-Case-of-key heuristic and
+		// validates the schema shape before sending — catches malformed objects
+		// at the boundary instead of letting the server return a 400.
+		encoded, err := encodeSchemaForBody(rawSchema)
+		if err != nil {
+			return "", "", nil, err
 		}
+		payload["schema"] = string(encoded)
 	case rawFields != "":
 		schemaJSON, err := collections.FieldsDSLToSchemaJSON(rawFields)
 		if err != nil {

--- a/internal/mcp/dispatch_http_routes.go
+++ b/internal/mcp/dispatch_http_routes.go
@@ -253,6 +253,7 @@ func init() {
 			method:       http.MethodGet,
 			pathTemplate: "/api/v1/workspaces/{workspace}/collections",
 		}.toRouteMapper(),
+		"collection update": mapCollectionUpdate,
 		"role list": routeSpec{
 			method:       http.MethodGet,
 			pathTemplate: "/api/v1/workspaces/{workspace}/agent-roles",
@@ -599,6 +600,70 @@ func mapItemStarred(input map[string]any) (string, string, []byte, error) {
 		urlPath += "?include_terminal=true"
 	}
 	return http.MethodGet, urlPath, nil, nil
+}
+
+// mapCollectionUpdate dispatches `pad collection update <slug>
+// [--name ...] [--icon ...] [--description ...] [--prefix ...]
+// [--schema ...] [--fields ...] [--sort-order ...]`.
+//
+// PATCH /api/v1/workspaces/{ws}/collections/{slug} with a body matching
+// models.CollectionUpdate. Only the keys actually present on `input`
+// are included — every CollectionUpdate field is a pointer, so omitted
+// fields preserve the existing value server-side.
+//
+// `schema` is the awkward one: the catalog declares it as a JSON object
+// for MCP ergonomics (agents send `{"fields":[...]}` as a nested
+// object), but CollectionUpdate.Schema is *string. The
+// CollectionUpdate UnmarshalJSON does NOT do the object→string
+// coercion for schema (only for settings — see collection.go:140).
+// So we re-marshal an object input here to its JSON-string form
+// before sending. This is symmetric to what the CLI does via
+// collectionSchemaJSONFromFlags.
+func mapCollectionUpdate(input map[string]any) (string, string, []byte, error) {
+	workspace, _ := input["workspace"].(string)
+	if workspace == "" {
+		return "", "", nil, fmt.Errorf("workspace is required")
+	}
+	slug, _ := input["slug"].(string)
+	if slug == "" {
+		return "", "", nil, fmt.Errorf("slug is required")
+	}
+
+	payload := map[string]any{}
+	for _, key := range []string{"name", "icon", "description", "prefix"} {
+		if v, _ := input[key].(string); v != "" {
+			payload[key] = v
+		}
+	}
+	if v, ok := input["sort_order"]; ok && v != nil {
+		// JSON numbers arrive as float64; CollectionUpdate.SortOrder
+		// is *int, but encoding/json on the receiving side coerces
+		// fine since the field's tag is plain integer.
+		payload["sort_order"] = v
+	}
+	// schema: accept either an object (preferred MCP shape) or a
+	// pre-encoded JSON string. The receiver expects a string.
+	if rawSchema, ok := input["schema"]; ok && rawSchema != nil {
+		switch s := rawSchema.(type) {
+		case string:
+			if s != "" {
+				payload["schema"] = s
+			}
+		default:
+			encoded, err := json.Marshal(rawSchema)
+			if err != nil {
+				return "", "", nil, fmt.Errorf("encode schema: %w", err)
+			}
+			payload["schema"] = string(encoded)
+		}
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return "", "", nil, fmt.Errorf("encode body: %w", err)
+	}
+	urlPath := "/api/v1/workspaces/" + url.PathEscape(workspace) + "/collections/" + url.PathEscape(slug)
+	return http.MethodPatch, urlPath, body, nil
 }
 
 // mapRoleCreate dispatches `pad role create <name> [--description ...]

--- a/internal/mcp/dispatch_http_routes.go
+++ b/internal/mcp/dispatch_http_routes.go
@@ -630,9 +630,22 @@ func mapCollectionUpdate(input map[string]any) (string, string, []byte, error) {
 	}
 
 	payload := map[string]any{}
+	// String fields use KEY PRESENCE (not "v != \"\"") because every
+	// CollectionUpdate field is a pointer server-side, and the store
+	// honors *string("") as "clear this column" (collections.go:271+).
+	// The CLI's --icon "" / --description "" flag help advertises this
+	// behavior; the MCP HTTP path must preserve it. Codex review on
+	// PR #572 caught the empty-string filter regression.
 	for _, key := range []string{"name", "icon", "description", "prefix"} {
-		if v, _ := input[key].(string); v != "" {
-			payload[key] = v
+		v, ok := input[key]
+		if !ok || v == nil {
+			continue
+		}
+		// Coerce string-typed input only — non-string values in these
+		// keys are programmer error and we'd rather the server reject
+		// the body than silently mishandle it.
+		if s, ok := v.(string); ok {
+			payload[key] = s
 		}
 	}
 	if v, ok := input["sort_order"]; ok && v != nil {
@@ -641,9 +654,19 @@ func mapCollectionUpdate(input map[string]any) (string, string, []byte, error) {
 		// fine since the field's tag is plain integer.
 		payload["sort_order"] = v
 	}
-	// schema: accept either an object (preferred MCP shape) or a
-	// pre-encoded JSON string. The receiver expects a string.
-	if rawSchema, ok := input["schema"]; ok && rawSchema != nil {
+	// schema vs fields: the catalog advertises both forms as mutually
+	// exclusive (matching `pad collection create`/`update`). The CLI
+	// resolves them via collectionSchemaJSONFromFlags; we mirror that
+	// resolution here so HTTP MCP callers get parity. Either input
+	// produces a JSON-encoded string on the wire — CollectionUpdate.
+	// Schema is *string and its UnmarshalJSON does not coerce objects.
+	rawSchema, hasSchema := input["schema"]
+	rawFields, _ := input["fields"].(string)
+	if hasSchema && rawFields != "" {
+		return "", "", nil, fmt.Errorf("fields and schema are mutually exclusive")
+	}
+	switch {
+	case hasSchema && rawSchema != nil:
 		switch s := rawSchema.(type) {
 		case string:
 			if s != "" {
@@ -656,6 +679,12 @@ func mapCollectionUpdate(input map[string]any) (string, string, []byte, error) {
 			}
 			payload["schema"] = string(encoded)
 		}
+	case rawFields != "":
+		schemaJSON, err := collections.FieldsDSLToSchemaJSON(rawFields)
+		if err != nil {
+			return "", "", nil, fmt.Errorf("parse fields DSL: %w", err)
+		}
+		payload["schema"] = schemaJSON
 	}
 
 	body, err := json.Marshal(payload)

--- a/internal/mcp/dispatch_http_routes_extras_test.go
+++ b/internal/mcp/dispatch_http_routes_extras_test.go
@@ -166,11 +166,15 @@ func TestMapCollectionUpdate_EncodesSchemaObjectToString(t *testing.T) {
 	}
 }
 
-// TestMapCollectionUpdate_PassesSchemaStringVerbatim allows the
-// pre-encoded string form (mirrors what the CLI's
-// collectionSchemaJSONFromFlags produces) so callers can stay
-// symmetric with the create path.
-func TestMapCollectionUpdate_PassesSchemaStringVerbatim(t *testing.T) {
+// TestMapCollectionUpdate_AcceptsSchemaString lets callers pass the
+// pre-encoded JSON string form (mirrors what the CLI's
+// collectionSchemaJSONFromFlags produces) so MCP and CLI stay
+// symmetric with the create path. The encoder validates + backfills
+// missing labels — verbatim pass-through is NOT a property we
+// promise (Codex round-2 finding on PR #572: schema bodies should
+// go through encodeSchemaForBody so structured-but-label-missing
+// input gets normalized the same way collection-create handles it).
+func TestMapCollectionUpdate_AcceptsSchemaString(t *testing.T) {
 	schemaStr := `{"fields":[{"key":"status","type":"select","options":["a","b"]}]}`
 	_, _, body, err := mapCollectionUpdate(map[string]any{
 		"workspace": "docapp",
@@ -184,8 +188,49 @@ func TestMapCollectionUpdate_PassesSchemaStringVerbatim(t *testing.T) {
 	if err := json.Unmarshal(body, &got); err != nil {
 		t.Fatalf("decode body: %v", err)
 	}
-	if got["schema"] != schemaStr {
-		t.Errorf("schema should pass through unmodified; got %v", got["schema"])
+	gotSchema, ok := got["schema"].(string)
+	if !ok || gotSchema == "" {
+		t.Fatalf("schema-string input should still produce a schema string; got %T (%v)", got["schema"], got["schema"])
+	}
+	// Round-trip parity: the encoded schema decodes to a valid
+	// CollectionSchema containing the same field key the input had.
+	var parsed models.CollectionSchema
+	if err := json.Unmarshal([]byte(gotSchema), &parsed); err != nil {
+		t.Fatalf("encoded schema is not a valid CollectionSchema: %v\n%s", err, gotSchema)
+	}
+	if len(parsed.Fields) != 1 || parsed.Fields[0].Key != "status" {
+		t.Errorf("schema round-trip lost the status field: %+v", parsed.Fields)
+	}
+	// And the missing label gets backfilled — the encoder uses the
+	// Title-Case-of-key heuristic, matching collection create.
+	if parsed.Fields[0].Label != "Status" {
+		t.Errorf("missing label should be backfilled to %q; got %q", "Status", parsed.Fields[0].Label)
+	}
+}
+
+// TestMapCollectionUpdate_EmptySchemaDoesNotBlockFields covers the
+// Codex round-2 P3 finding: optional empty params should normalize as
+// "absent" before the mutual-exclusion check fires, so an MCP client
+// that sends `schema:null` (or `""`) plus a real `fields=...` update
+// doesn't get a spurious exclusivity error.
+func TestMapCollectionUpdate_EmptySchemaDoesNotBlockFields(t *testing.T) {
+	for _, emptySchema := range []any{nil, ""} {
+		_, _, body, err := mapCollectionUpdate(map[string]any{
+			"workspace": "docapp",
+			"slug":      "tasks",
+			"schema":    emptySchema,
+			"fields":    "status:select:open,done",
+		})
+		if err != nil {
+			t.Fatalf("empty schema=%v + fields should NOT trip exclusivity: %v", emptySchema, err)
+		}
+		var got map[string]any
+		if err := json.Unmarshal(body, &got); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if _, ok := got["schema"].(string); !ok {
+			t.Errorf("fields should still produce a schema PATCH body even when schema=%v; got %v", emptySchema, got)
+		}
 	}
 }
 

--- a/internal/mcp/dispatch_http_routes_extras_test.go
+++ b/internal/mcp/dispatch_http_routes_extras_test.go
@@ -218,6 +218,89 @@ func TestMapCollectionUpdate_RequiresWorkspaceAndSlug(t *testing.T) {
 	}
 }
 
+// TestMapCollectionUpdate_EmptyStringClearsField guards a Codex round-1
+// finding: the catalog advertises icon/description as clearable (the
+// CLI flag help says `--icon "" / --description ""` clears the column,
+// and the store treats *string("") as "clear"). The mapper must use
+// key-presence semantics — not v != "" — so MCP HTTP callers can clear
+// fields the same way CLI callers can.
+func TestMapCollectionUpdate_EmptyStringClearsField(t *testing.T) {
+	_, _, body, err := mapCollectionUpdate(map[string]any{
+		"workspace":   "docapp",
+		"slug":        "tasks",
+		"icon":        "",
+		"description": "",
+	})
+	if err != nil {
+		t.Fatalf("mapCollectionUpdate: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	for _, key := range []string{"icon", "description"} {
+		v, present := got[key]
+		if !present {
+			t.Errorf("explicit empty %q should be sent through to clear the column; got %v", key, got)
+			continue
+		}
+		if v != "" {
+			t.Errorf("%q should serialize as empty string; got %v (%T)", key, v, v)
+		}
+	}
+}
+
+// TestMapCollectionUpdate_AcceptsFieldsDSL covers the second Codex
+// finding: the catalog advertises `fields OR schema`, but the original
+// mapper only handled `schema`. Calling with `fields=...` must produce
+// a valid schema PATCH body, parsed through the shared
+// collections.FieldsDSLToSchemaJSON helper.
+func TestMapCollectionUpdate_AcceptsFieldsDSL(t *testing.T) {
+	_, _, body, err := mapCollectionUpdate(map[string]any{
+		"workspace": "docapp",
+		"slug":      "tasks",
+		"fields":    "status:select:open,done;priority:select:high,medium,low",
+	})
+	if err != nil {
+		t.Fatalf("mapCollectionUpdate: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	schemaStr, ok := got["schema"].(string)
+	if !ok || schemaStr == "" {
+		t.Fatalf("fields DSL should produce schema string; got %T (%v)", got["schema"], got["schema"])
+	}
+	// Confirm it's parseable as a CollectionSchema with the expected fields.
+	var parsed models.CollectionSchema
+	if err := json.Unmarshal([]byte(schemaStr), &parsed); err != nil {
+		t.Fatalf("schema JSON is not a valid CollectionSchema: %v\n%s", err, schemaStr)
+	}
+	if len(parsed.Fields) != 2 {
+		t.Fatalf("expected 2 fields, got %d: %+v", len(parsed.Fields), parsed.Fields)
+	}
+	if parsed.Fields[0].Key != "status" || parsed.Fields[1].Key != "priority" {
+		t.Errorf("field order/keys wrong: %+v", parsed.Fields)
+	}
+}
+
+// TestMapCollectionUpdate_RejectsFieldsAndSchemaTogether mirrors the
+// CLI's mutual-exclusion guard (collectionSchemaJSONFromFlags). The
+// catalog description says "fields OR schema (mutually exclusive)";
+// the mapper must enforce it.
+func TestMapCollectionUpdate_RejectsFieldsAndSchemaTogether(t *testing.T) {
+	_, _, _, err := mapCollectionUpdate(map[string]any{
+		"workspace": "docapp",
+		"slug":      "tasks",
+		"fields":    "status:select:a,b",
+		"schema":    map[string]any{"fields": []any{}},
+	})
+	if err == nil {
+		t.Errorf("expected error when both fields and schema are passed")
+	}
+}
+
 // --- Roles ---
 
 func TestMapRoleCreate_BuildsCanonicalBody(t *testing.T) {

--- a/internal/mcp/dispatch_http_routes_extras_test.go
+++ b/internal/mcp/dispatch_http_routes_extras_test.go
@@ -82,6 +82,142 @@ func TestMapItemStarred_RequiresWorkspace(t *testing.T) {
 	}
 }
 
+// --- Collections (TASK-1510 / PLAN-1496) ---
+
+// TestMapCollectionUpdate_BuildsPatchBody confirms the mapper routes
+// to the canonical PATCH endpoint and copies through every supported
+// flat-string field. Schema-object → string coercion has its own test
+// below.
+func TestMapCollectionUpdate_BuildsPatchBody(t *testing.T) {
+	m, p, body, err := mapCollectionUpdate(map[string]any{
+		"workspace":   "docapp",
+		"slug":        "tasks",
+		"name":        "Issues",
+		"icon":        "🎯",
+		"description": "Tracks work to ship",
+		"prefix":      "ISS",
+		"sort_order":  float64(2), // JSON numbers arrive as float64
+	})
+	if err != nil {
+		t.Fatalf("mapCollectionUpdate: %v", err)
+	}
+	if m != http.MethodPatch {
+		t.Errorf("method = %q, want PATCH", m)
+	}
+	if p != "/api/v1/workspaces/docapp/collections/tasks" {
+		t.Errorf("path = %q", p)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	want := map[string]any{
+		"name":        "Issues",
+		"icon":        "🎯",
+		"description": "Tracks work to ship",
+		"prefix":      "ISS",
+		"sort_order":  float64(2),
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("body[%q] = %v (%T), want %v (%T)", k, got[k], got[k], v, v)
+		}
+	}
+}
+
+// TestMapCollectionUpdate_EncodesSchemaObjectToString verifies the
+// MCP-friendly object form of the `schema` parameter gets re-marshaled
+// to the JSON-string form CollectionUpdate.Schema (*string) actually
+// expects. Without this coercion the server would reject the PATCH.
+func TestMapCollectionUpdate_EncodesSchemaObjectToString(t *testing.T) {
+	schemaObj := map[string]any{
+		"fields": []any{
+			map[string]any{
+				"key":     "status",
+				"type":    "select",
+				"options": []any{"new", "done"},
+			},
+		},
+	}
+	_, _, body, err := mapCollectionUpdate(map[string]any{
+		"workspace": "docapp",
+		"slug":      "tasks",
+		"schema":    schemaObj,
+	})
+	if err != nil {
+		t.Fatalf("mapCollectionUpdate: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	gotSchema, ok := got["schema"].(string)
+	if !ok {
+		t.Fatalf("schema should serialize as string for server consumption; got %T (%v)", got["schema"], got["schema"])
+	}
+	// Round-trip through CollectionUpdate.UnmarshalJSON to confirm
+	// the server can actually decode this body.
+	var update models.CollectionUpdate
+	if err := json.Unmarshal(body, &update); err != nil {
+		t.Fatalf("CollectionUpdate.UnmarshalJSON rejected body: %v", err)
+	}
+	if update.Schema == nil || *update.Schema != gotSchema {
+		t.Errorf("CollectionUpdate.Schema round-trip lost data: got %v, body had %q", update.Schema, gotSchema)
+	}
+}
+
+// TestMapCollectionUpdate_PassesSchemaStringVerbatim allows the
+// pre-encoded string form (mirrors what the CLI's
+// collectionSchemaJSONFromFlags produces) so callers can stay
+// symmetric with the create path.
+func TestMapCollectionUpdate_PassesSchemaStringVerbatim(t *testing.T) {
+	schemaStr := `{"fields":[{"key":"status","type":"select","options":["a","b"]}]}`
+	_, _, body, err := mapCollectionUpdate(map[string]any{
+		"workspace": "docapp",
+		"slug":      "tasks",
+		"schema":    schemaStr,
+	})
+	if err != nil {
+		t.Fatalf("mapCollectionUpdate: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if got["schema"] != schemaStr {
+		t.Errorf("schema should pass through unmodified; got %v", got["schema"])
+	}
+}
+
+func TestMapCollectionUpdate_OmitsEmptyFields(t *testing.T) {
+	_, _, body, err := mapCollectionUpdate(map[string]any{
+		"workspace": "docapp",
+		"slug":      "tasks",
+		// All other fields absent — should send an empty body.
+	})
+	if err != nil {
+		t.Fatalf("mapCollectionUpdate: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	for _, key := range []string{"name", "icon", "description", "prefix", "sort_order", "schema"} {
+		if _, present := got[key]; present {
+			t.Errorf("empty %q should be omitted; got %v", key, got)
+		}
+	}
+}
+
+func TestMapCollectionUpdate_RequiresWorkspaceAndSlug(t *testing.T) {
+	if _, _, _, err := mapCollectionUpdate(map[string]any{"slug": "tasks"}); err == nil {
+		t.Errorf("expected error when workspace missing")
+	}
+	if _, _, _, err := mapCollectionUpdate(map[string]any{"workspace": "docapp"}); err == nil {
+		t.Errorf("expected error when slug missing")
+	}
+}
+
 // --- Roles ---
 
 func TestMapRoleCreate_BuildsCanonicalBody(t *testing.T) {


### PR DESCRIPTION
## Summary

The HTTP handler at \`handlers_collections.go::handleUpdateCollection\` already supported PATCHing a collection's name, icon, description, prefix, schema, settings, and sort_order. The CLI and MCP surfaces never exposed it. This wires both to the existing handler.

This is a hard blocker for the adaptive \`/pad onboard\` playbook (TASK-1499) — that playbook needs to rewrite seeded collections to match each project's actual vocabulary, which requires being able to mutate collection schemas through agent-facing tools.

## Changes

- **\`cmd/pad\`** — new \`pad collection update <slug>\` Cobra subcommand. Flags: \`--name\`, \`--icon\`, \`--description\`, \`--prefix\`, \`--schema\`, \`--fields\`, \`--sort-order\`. Only flags explicitly set are sent (\`cmd.Flags().Changed\`). \`--schema\` and \`--fields\` reuse the existing \`collectionSchemaJSONFromFlags\` helper for parity with \`pad collection create\`.
- **\`internal/mcp/catalog_collection\`** — add \`update\` action; add \`slug\`, \`prefix\`, \`sort_order\` params; update description.
- **\`internal/mcp/dispatch_http_routes\`** — new \`mapCollectionUpdate\` mapper. The catalog declares \`schema\` as a JSON object for MCP ergonomics; \`CollectionUpdate.Schema\` is \`*string\` and its \`UnmarshalJSON\` only flexes \`settings\`. The mapper re-marshals an object input to its JSON-string form before sending, symmetric to what the CLI does.

## Context

Implements TASK-1510 under PLAN-1496 (adaptive onboarding playbook). Identified by TASK-1497 capability spike.

## Test plan

- [x] \`go build ./...\` — clean
- [x] \`go vet ./...\` — clean
- [x] \`golangci-lint run --timeout=5m ./...\` — 0 issues
- [x] \`go test ./...\` — all packages pass
- [x] \`cd web && npm run build\` — clean
- [x] New tests in \`dispatch_http_routes_extras_test.go\`:
  - \`TestMapCollectionUpdate_BuildsPatchBody\` (canonical flat fields)
  - \`TestMapCollectionUpdate_EncodesSchemaObjectToString\` (round-trips through \`CollectionUpdate.UnmarshalJSON\` to prove the server can decode the body)
  - \`TestMapCollectionUpdate_PassesSchemaStringVerbatim\`
  - \`TestMapCollectionUpdate_OmitsEmptyFields\`
  - \`TestMapCollectionUpdate_RequiresWorkspaceAndSlug\`
- [x] Catalog bijection test (\`TestReadOnlyCatalog_ActionsMatchCmdhelp\` + \`TestReadOnlyCatalog_ActionsDispatchExpectedCmdPath\`) green after adding the new entry
- [x] Manual: \`pad collection update --help\` renders the new command

Note: \`make check\` fails at the \`npm audit\` step due to pre-existing security advisories in svelte / mermaid / devalue — unrelated to this change.