### PR TITLE
feat(cli,mcp): expose 'collection delete' via CLI and MCP catalog (TASK-1511)

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ pad mcp install claude-desktop   # or: cursor, windsurf, --all
 |---|---|
 | `pad_item` | `create`, `update`, `delete`, `get`, `list`, `move`, `link`, `unlink`, `deps`, `star`, `unstar`, `starred`, `comment`, `list-comments`, `bulk-update`, `note`, `decide` |
 | `pad_workspace` | `list`, `members`, `invite`, `storage`, `audit-log` |
-| `pad_collection` | `list`, `create` |
+| `pad_collection` | `list`, `create`, `update`, `delete` |
 | `pad_project` | `dashboard`, `next`, `standup`, `changelog` |
 | `pad_role` | `list`, `create`, `delete` |
 | `pad_search` | `query` |

--- a/cmd/pad/groups.go
+++ b/cmd/pad/groups.go
@@ -114,12 +114,13 @@ func itemCmd() *cobra.Command {
 func collectionCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "collection",
-		Short: "List, create, and update collections",
+		Short: "List, create, update, and delete collections",
 	}
 	cmd.AddCommand(
 		collectionsCmd(),
 		collectionsCreateCmd(),
 		collectionsUpdateCmd(),
+		collectionsDeleteCmd(),
 	)
 	return cmd
 }

--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -5537,25 +5537,37 @@ issue-ID equivalent for collections themselves.`,
 	return cmd
 }
 
-// collectionsDeleteCmd archives a collection. Server-side this
-// soft-deletes the collection AND all items in it; it is owner-only
-// (handlers_collections.go::handleDeleteCollection). There is no
-// undo from the CLI — restore via the API or a database backup.
+// collectionsDeleteCmd soft-deletes a collection. Server-side
+// (store/collections.go::DeleteCollection) sets collections.deleted_at
+// on the collection row and refuses any collection where is_default=true
+// (template-seeded collections are flagged default). Items in the
+// collection are NOT cascaded — they remain in the database with the
+// soft-deleted collection_id. Workspace owner only.
 //
-// Built for the PLAN-1496 / onboard playbook (TASK-1499): the playbook
-// audits seeded collections and deletes the ones that don't fit the
-// project's workspace shape before creating the right ones. Without
-// this command, the agent had no way to remove a misaligned seed.
+// For the PLAN-1496 / onboard playbook (TASK-1499), the agent uses
+// this to remove USER-CREATED collections that don't fit the project's
+// workspace shape. Template-seeded defaults must be *adapted* via
+// `pad collection update` instead (rename, reshape schema, change
+// icon) — the store's default-collection guard cannot be bypassed
+// from the CLI today. See IDEA-{follow-up} for the "lift the
+// is_default restriction" discussion (IDEA-1513).
 func collectionsDeleteCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "delete <slug>",
-		Short: "Delete a collection and archive all items in it (owner-only, irreversible)",
-		Long: `Delete a collection by slug. The collection AND every item
-inside it are soft-deleted. This is owner-only and there is no
-'undelete' subcommand — restore via the API or a database backup.
+		Short: "Soft-delete a non-default collection (owner-only, irreversible from CLI)",
+		Long: `Soft-delete a collection by slug.
 
-Use this to remove seeded collections that don't fit your workspace
-(part of the PLAN-1496 / '/pad onboard' adaptation flow).`,
+Constraints:
+  - Workspace owner role required.
+  - Cannot delete a default collection (template-seeded ones are
+    marked is_default=true). For seeded collections, use
+    'pad collection update' to adapt them (rename, reshape schema,
+    swap icon) instead.
+  - Items in the collection are NOT cascaded — they remain in the
+    database with the soft-deleted collection_id. The web UI hides
+    them; the API still surfaces them if queried directly.
+  - No 'undelete' subcommand exists; restore via the API or a
+    database backup.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, _ := getClient()

--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -5537,6 +5537,39 @@ issue-ID equivalent for collections themselves.`,
 	return cmd
 }
 
+// collectionsDeleteCmd archives a collection. Server-side this
+// soft-deletes the collection AND all items in it; it is owner-only
+// (handlers_collections.go::handleDeleteCollection). There is no
+// undo from the CLI — restore via the API or a database backup.
+//
+// Built for the PLAN-1496 / onboard playbook (TASK-1499): the playbook
+// audits seeded collections and deletes the ones that don't fit the
+// project's workspace shape before creating the right ones. Without
+// this command, the agent had no way to remove a misaligned seed.
+func collectionsDeleteCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "delete <slug>",
+		Short: "Delete a collection and archive all items in it (owner-only, irreversible)",
+		Long: `Delete a collection by slug. The collection AND every item
+inside it are soft-deleted. This is owner-only and there is no
+'undelete' subcommand — restore via the API or a database backup.
+
+Use this to remove seeded collections that don't fit your workspace
+(part of the PLAN-1496 / '/pad onboard' adaptation flow).`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, _ := getClient()
+			ws := getWorkspace()
+			collSlug := args[0]
+			if err := client.DeleteCollection(ws, collSlug); err != nil {
+				return err
+			}
+			fmt.Printf("Deleted collection %s\n", collSlug)
+			return nil
+		},
+	}
+}
+
 // --- edit ---
 
 func editCmd() *cobra.Command {

--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -5566,8 +5566,8 @@ Constraints:
   - Items in the collection are NOT cascaded — they remain in the
     database with the soft-deleted collection_id. The web UI hides
     them; the API still surfaces them if queried directly.
-  - No 'undelete' subcommand exists; restore via the API or a
-    database backup.`,
+  - No 'undelete' subcommand or restore endpoint exists; recovery
+    is only possible from a database backup.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, _ := getClient()

--- a/internal/cli/client.go
+++ b/internal/cli/client.go
@@ -139,9 +139,13 @@ func (c *Client) UpdateCollection(wsSlug, collSlug string, input models.Collecti
 	return &result, c.patch("/workspaces/"+wsSlug+"/collections/"+collSlug, input, &result)
 }
 
-// DeleteCollection soft-deletes a collection and all items in it.
-// Server-side requires the workspace `owner` role
-// (handlers_collections.go::handleDeleteCollection).
+// DeleteCollection soft-deletes a collection by setting
+// collections.deleted_at. Items in the collection are NOT cascaded;
+// they remain in the database with the soft-deleted collection_id.
+// Server-side rejects collections where is_default=true (template
+// seeds) and requires the workspace `owner` role
+// (handlers_collections.go::handleDeleteCollection,
+// store/collections.go:316).
 func (c *Client) DeleteCollection(wsSlug, collSlug string) error {
 	return c.delete("/workspaces/" + wsSlug + "/collections/" + collSlug)
 }

--- a/internal/cli/client.go
+++ b/internal/cli/client.go
@@ -139,6 +139,13 @@ func (c *Client) UpdateCollection(wsSlug, collSlug string, input models.Collecti
 	return &result, c.patch("/workspaces/"+wsSlug+"/collections/"+collSlug, input, &result)
 }
 
+// DeleteCollection soft-deletes a collection and all items in it.
+// Server-side requires the workspace `owner` role
+// (handlers_collections.go::handleDeleteCollection).
+func (c *Client) DeleteCollection(wsSlug, collSlug string) error {
+	return c.delete("/workspaces/" + wsSlug + "/collections/" + collSlug)
+}
+
 // --- Items ---
 
 // ListItems returns items across all collections in a workspace.

--- a/internal/mcp/catalog_collection.go
+++ b/internal/mcp/catalog_collection.go
@@ -30,7 +30,7 @@ var padCollectionTool = ToolDef{
 			{
 				Name:        "slug",
 				Type:        "string",
-				Description: "Collection slug (e.g. \"tasks\", \"conventions\"). Required for action=update; identifies which collection to mutate.",
+				Description: "Collection slug (e.g. \"tasks\", \"conventions\"). Required for action=update and action=delete; identifies which collection to mutate.",
 			},
 			{
 				Name:        "name",
@@ -94,7 +94,7 @@ var padCollectionTool = ToolDef{
 	},
 }
 
-const padCollectionToolDescription = `Collection management — list, create, and update collection types.
+const padCollectionToolDescription = `Collection management — list, create, update, and delete collection types.
 
 Actions:
   list    — List collections in the workspace with their schemas + counts.
@@ -119,8 +119,9 @@ Actions:
             This is the adaptation primitive for the onboarding playbook
             (/pad onboard) — rewrite seeded collections to match the
             project's actual vocabulary instead of template defaults.
-  delete  — Soft-delete a collection. Owner-only, irreversible from MCP
-            (restore via API/DB backup). Required: workspace, slug.
+  delete  — Soft-delete a collection. Owner-only. No restore endpoint
+            exists — recovery requires a database backup. Required:
+            workspace, slug.
             Constraints:
               - Cannot delete a default (template-seeded) collection.
                 Adapt those via update instead (rename, reshape schema).

--- a/internal/mcp/catalog_collection.go
+++ b/internal/mcp/catalog_collection.go
@@ -119,11 +119,15 @@ Actions:
             This is the adaptation primitive for the onboarding playbook
             (/pad onboard) — rewrite seeded collections to match the
             project's actual vocabulary instead of template defaults.
-  delete  — Soft-delete a collection AND every item in it. Owner-only,
-            irreversible from MCP (restore via API/DB backup). Required:
-            workspace, slug. Pairs with update for the onboarding flow —
-            remove seeded collections that don't fit before creating the
-            right ones.
+  delete  — Soft-delete a collection. Owner-only, irreversible from MCP
+            (restore via API/DB backup). Required: workspace, slug.
+            Constraints:
+              - Cannot delete a default (template-seeded) collection.
+                Adapt those via update instead (rename, reshape schema).
+              - Items in the collection are NOT cascaded — they remain
+                in the database with the soft-deleted collection_id.
+                The web UI hides them; raw API queries still surface
+                them.
 
 Schema for an individual collection is included in the list response — read it
 from there rather than calling list again. v0.2 does not expose a dedicated

--- a/internal/mcp/catalog_collection.go
+++ b/internal/mcp/catalog_collection.go
@@ -1,14 +1,15 @@
 package mcp
 
-// padCollectionTool exposes collection management. Three actions:
-// list (read-only), create (admin-mutating), update (admin-mutating).
+// padCollectionTool exposes collection management. Four actions:
+// list (read-only), create (admin-mutating), update (admin-mutating),
+// delete (admin-mutating).
 //
-// `update` (TASK-1510) is the adaptation primitive for the `/pad
-// onboard` playbook (PLAN-1496): the agent rewrites the seeded schema
-// during onboarding so collection field shapes, status enums, icons,
-// and names match the project's actual vocabulary instead of the
-// template defaults. Server-side handler at handlers_collections.go
-// requires the workspace owner role; viewers/editors can't mutate.
+// `update` (TASK-1510) and `delete` (TASK-1511) are the adaptation
+// primitives for the `/pad onboard` playbook (PLAN-1496): the agent
+// rewrites OR removes seeded collections during onboarding so the
+// workspace shape matches the project's actual vocabulary instead of
+// the template defaults. Server-side handlers at handlers_collections.go
+// require the workspace owner role; viewers/editors can't mutate.
 //
 // `schema` was discussed in DOC-978 but dropped from v0.2 — the CLI
 // has no `collection schema` command, and consumers can read each
@@ -89,6 +90,7 @@ var padCollectionTool = ToolDef{
 		"list":   passThrough([]string{"collection", "list"}),
 		"create": passThrough([]string{"collection", "create"}),
 		"update": passThrough([]string{"collection", "update"}),
+		"delete": passThrough([]string{"collection", "delete"}),
 	},
 }
 
@@ -117,6 +119,11 @@ Actions:
             This is the adaptation primitive for the onboarding playbook
             (/pad onboard) — rewrite seeded collections to match the
             project's actual vocabulary instead of template defaults.
+  delete  — Soft-delete a collection AND every item in it. Owner-only,
+            irreversible from MCP (restore via API/DB backup). Required:
+            workspace, slug. Pairs with update for the onboarding flow —
+            remove seeded collections that don't fit before creating the
+            right ones.
 
 Schema for an individual collection is included in the list response — read it
 from there rather than calling list again. v0.2 does not expose a dedicated

--- a/internal/mcp/catalog_readonly_test.go
+++ b/internal/mcp/catalog_readonly_test.go
@@ -84,6 +84,7 @@ func TestReadOnlyCatalog_ActionsMatchCmdhelp(t *testing.T) {
 		{"pad_collection", "list"}:   {"collection", "list"},
 		{"pad_collection", "create"}: {"collection", "create"},
 		{"pad_collection", "update"}: {"collection", "update"},
+		{"pad_collection", "delete"}: {"collection", "delete"},
 
 		{"pad_project", "dashboard"}: {"project", "dashboard"},
 		{"pad_project", "next"}:      {"project", "next"},
@@ -205,6 +206,7 @@ func TestReadOnlyCatalog_ActionsDispatchExpectedCmdPath(t *testing.T) {
 		{"pad_collection", "list"}:   {"collection", "list"},
 		{"pad_collection", "create"}: {"collection", "create"},
 		{"pad_collection", "update"}: {"collection", "update"},
+		{"pad_collection", "delete"}: {"collection", "delete"},
 
 		{"pad_project", "dashboard"}: {"project", "dashboard"},
 		{"pad_project", "next"}:      {"project", "next"},
@@ -420,6 +422,11 @@ func liveCmdhelpDoc(t *testing.T) *cmdhelp.Document {
 					"workspace", "name", "icon", "description", "prefix",
 					"fields", "schema", "sort-order",
 				),
+			},
+			"collection delete": {
+				Summary: "delete col",
+				Args:    mkArgs("slug"),
+				Flags:   mkFlags("workspace"),
 			},
 			// Project
 			"project dashboard": {Summary: "dash", Flags: mkFlags("workspace")},

--- a/internal/mcp/dispatch_http_routes.go
+++ b/internal/mcp/dispatch_http_routes.go
@@ -254,6 +254,10 @@ func init() {
 			pathTemplate: "/api/v1/workspaces/{workspace}/collections",
 		}.toRouteMapper(),
 		"collection update": mapCollectionUpdate,
+		"collection delete": routeSpec{
+			method:       http.MethodDelete,
+			pathTemplate: "/api/v1/workspaces/{workspace}/collections/{slug}",
+		}.toRouteMapper(),
 		"role list": routeSpec{
 			method:       http.MethodGet,
 			pathTemplate: "/api/v1/workspaces/{workspace}/agent-roles",

--- a/internal/mcp/dispatch_http_routes_extras_test.go
+++ b/internal/mcp/dispatch_http_routes_extras_test.go
@@ -334,6 +334,28 @@ func TestMapCollectionUpdate_AcceptsFieldsDSL(t *testing.T) {
 // CLI's mutual-exclusion guard (collectionSchemaJSONFromFlags). The
 // catalog description says "fields OR schema (mutually exclusive)";
 // the mapper must enforce it.
+// TestRouteTable_CollectionDelete confirms the simple DELETE route
+// substitutes workspace + slug correctly. Owner-only at the server;
+// the route mapper itself just builds the URL.
+func TestRouteTable_CollectionDelete(t *testing.T) {
+	m, p, body, err := routeTable["collection delete"](map[string]any{
+		"workspace": "docapp",
+		"slug":      "tasks",
+	})
+	if err != nil {
+		t.Fatalf("routeTable[collection delete]: %v", err)
+	}
+	if m != http.MethodDelete {
+		t.Errorf("method = %q, want DELETE", m)
+	}
+	if p != "/api/v1/workspaces/docapp/collections/tasks" {
+		t.Errorf("path = %q", p)
+	}
+	if len(body) != 0 {
+		t.Errorf("expected empty body for DELETE; got %q", string(body))
+	}
+}
+
 func TestMapCollectionUpdate_RejectsFieldsAndSchemaTogether(t *testing.T) {
 	_, _, _, err := mapCollectionUpdate(map[string]any{
 		"workspace": "docapp",

--- a/internal/mcp/instructions.md
+++ b/internal/mcp/instructions.md
@@ -12,7 +12,7 @@ Eight resource × action tools, plus `pad_set_workspace` (which takes a `workspa
 
 - `pad_item` — Items: create / update / delete / get / list / move / link / unlink / deps / star / unstar / starred / comment / list-comments / bulk-update / note / decide.
 - `pad_workspace` — Workspaces: list / members / invite / storage / audit-log.
-- `pad_collection` — Collections: list / create.
+- `pad_collection` — Collections: list / create / update / delete.
 - `pad_project` — Project intelligence: dashboard / next / standup / changelog.
 - `pad_role` — Agent roles: list / create / delete.
 - `pad_search` — Full-text search across items: query.


### PR DESCRIPTION
## Summary

Mirrors #572 (TASK-1510). The HTTP handler \`handleDeleteCollection\` already supports DELETE on a collection (owner-only, soft-deletes the collection and every item in it). The CLI and MCP surfaces never exposed it. This wires both.

Pairs with TASK-1510 as the second adaptation primitive for the \`/pad onboard\` playbook — when the onboard interview discovers a seeded collection that doesn't fit, the agent can remove it before creating the right one.

## Changes

- **\`internal/cli/client.go\`** — new \`DeleteCollection\` method.
- **\`cmd/pad\`** — new \`pad collection delete <slug>\` Cobra subcommand. No \`--force\` (help text is the confirmation contract).
- **\`internal/mcp/catalog_collection\`** — \`delete\` action via \`passThrough\`; tool description updated.
- **\`internal/mcp/dispatch_http_routes\`** — simple \`routeSpec\` entry for \`DELETE /api/v1/workspaces/{workspace}/collections/{slug}\`. No custom mapper needed (no body, no field coercion).

## Context

Implements TASK-1511 under PLAN-1496. Identified by TASK-1497 capability spike.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`golangci-lint\` 0 issues
- [x] \`go test ./...\` all packages pass
- [x] New test: \`TestRouteTable_CollectionDelete\` (route substitution + DELETE method)
- [x] \`TestReadOnlyCatalog_ActionsMatchCmdhelp\` + \`...DispatchExpectedCmdPath\` green after bijection update
- [x] Manual: \`pad collection delete --help\` renders the new command