### PR TITLE
feat(cli,mcp): expose 'role update' via CLI and MCP catalog (TASK-1512)

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ pad mcp install claude-desktop   # or: cursor, windsurf, --all
 | `pad_workspace` | `list`, `members`, `invite`, `storage`, `audit-log` |
 | `pad_collection` | `list`, `create`, `update`, `delete` |
 | `pad_project` | `dashboard`, `next`, `standup`, `changelog` |
-| `pad_role` | `list`, `create`, `delete` |
+| `pad_role` | `list`, `create`, `update`, `delete` |
 | `pad_search` | `query` |
 | `pad_playbook` | `list`, `get`, `run` |
 | `pad_meta` | `server-info`, `version`, `tool-surface`, `bootstrap` |

--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -6343,7 +6343,7 @@ func roleCmd() *cobra.Command {
 		Short: "Manage agent roles",
 		Long:  "Agent roles define capability specializations (e.g. Planner, Implementer, Reviewer) for human-agent work assignment.",
 	}
-	cmd.AddCommand(roleListCmd(), roleCreateCmd(), roleDeleteCmd())
+	cmd.AddCommand(roleListCmd(), roleCreateCmd(), roleUpdateCmd(), roleDeleteCmd())
 	return cmd
 }
 
@@ -6415,6 +6415,98 @@ func roleCreateCmd() *cobra.Command {
 	cmd.Flags().StringVar(&description, "description", "", "role description")
 	cmd.Flags().StringVar(&icon, "icon", "", "role icon (emoji)")
 	cmd.Flags().StringVar(&tools, "tools", "", "preferred tools/models (e.g. 'Claude Code + Sonnet 4.6')")
+	return cmd
+}
+
+// roleUpdateCmd updates an existing agent role's name, description,
+// icon, tools, slug, or sort_order. Only flags explicitly set are
+// sent — every AgentRoleUpdate field is a pointer server-side
+// (models/agent_role.go::AgentRoleUpdate) so omitted values are
+// preserved.
+//
+// Built for the PLAN-1496 / onboard playbook (TASK-1499): the agent
+// needs to rewrite role descriptions and icons during onboarding to
+// match how the user's team actually divides work. Without this
+// command, the agent could only create or delete roles — adapting
+// the existing ones required deleting and re-creating, which loses
+// the agent_role_id references on assigned items.
+//
+// The slug arg can be a role slug ("planner") or its UUID — the
+// server-side store resolves both via ResolveAgentRoleID.
+func roleUpdateCmd() *cobra.Command {
+	var (
+		name        string
+		slug        string
+		description string
+		icon        string
+		tools       string
+		sortOrder   int
+	)
+
+	cmd := &cobra.Command{
+		Use:   "update <slug>",
+		Short: "Update an existing agent role",
+		Long: `Update an existing agent role's name, slug, description,
+icon, tools, or sort order.
+
+Only flags you explicitly set are sent — every other property is left
+untouched. The <slug> positional accepts either the role's current
+slug ("planner") or its UUID.
+
+Examples:
+  pad role update planner --description "Decomposes plans into tasks"
+  pad role update reviewer --icon 👁️
+  pad role update implementer --name "Engineer" --slug engineer`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, _ := getClient()
+			ws := getWorkspace()
+			ref := args[0]
+
+			input := models.AgentRoleUpdate{}
+
+			if cmd.Flags().Changed("name") {
+				input.Name = &name
+			}
+			if cmd.Flags().Changed("slug") {
+				input.Slug = &slug
+			}
+			if cmd.Flags().Changed("description") {
+				input.Description = &description
+			}
+			if cmd.Flags().Changed("icon") {
+				input.Icon = &icon
+			}
+			if cmd.Flags().Changed("tools") {
+				input.Tools = &tools
+			}
+			if cmd.Flags().Changed("sort-order") {
+				input.SortOrder = &sortOrder
+			}
+
+			role, err := client.UpdateAgentRole(ws, ref, input)
+			if err != nil {
+				return err
+			}
+			if formatFlag == "json" {
+				return cli.PrintJSON(role)
+			}
+			iconStr := ""
+			if role.Icon != "" {
+				iconStr = role.Icon + " "
+			}
+			fmt.Printf("Updated role %s%s (%s)\n", iconStr, role.Name, role.Slug)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&name, "name", "", "new display name")
+	cmd.Flags().StringVar(&slug, "slug", "", "new slug (kebab-case identifier)")
+	cmd.Flags().StringVar(&description, "description", "", "new description (empty string clears)")
+	cmd.Flags().StringVar(&icon, "icon", "", "new emoji icon (empty string clears)")
+	cmd.Flags().StringVar(&tools, "tools", "", "preferred tools/models string")
+	cmd.Flags().IntVar(&sortOrder, "sort-order", 0, "new sort order (lower = appears first)")
+
 	return cmd
 }
 

--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -6436,7 +6436,7 @@ func roleCreateCmd() *cobra.Command {
 func roleUpdateCmd() *cobra.Command {
 	var (
 		name        string
-		slug        string
+		newSlug     string
 		description string
 		icon        string
 		tools       string
@@ -6453,10 +6453,15 @@ Only flags you explicitly set are sent — every other property is left
 untouched. The <slug> positional accepts either the role's current
 slug ("planner") or its UUID.
 
+NOTE: the rename flag is --new-slug, not --slug. This is deliberate:
+the MCP catalog passes the positional via MCP property "slug" and
+the rename target via "new_slug"; calling the CLI flag --slug too
+would collide on the local stdio MCP path (Codex review on PR #574).
+
 Examples:
   pad role update planner --description "Decomposes plans into tasks"
   pad role update reviewer --icon 👁️
-  pad role update implementer --name "Engineer" --slug engineer`,
+  pad role update implementer --name "Engineer" --new-slug engineer`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, _ := getClient()
@@ -6468,8 +6473,8 @@ Examples:
 			if cmd.Flags().Changed("name") {
 				input.Name = &name
 			}
-			if cmd.Flags().Changed("slug") {
-				input.Slug = &slug
+			if cmd.Flags().Changed("new-slug") {
+				input.Slug = &newSlug
 			}
 			if cmd.Flags().Changed("description") {
 				input.Description = &description
@@ -6501,7 +6506,7 @@ Examples:
 	}
 
 	cmd.Flags().StringVar(&name, "name", "", "new display name")
-	cmd.Flags().StringVar(&slug, "slug", "", "new slug (kebab-case identifier)")
+	cmd.Flags().StringVar(&newSlug, "new-slug", "", "rename target — new slug (kebab-case identifier)")
 	cmd.Flags().StringVar(&description, "description", "", "new description (empty string clears)")
 	cmd.Flags().StringVar(&icon, "icon", "", "new emoji icon (empty string clears)")
 	cmd.Flags().StringVar(&tools, "tools", "", "preferred tools/models string")

--- a/internal/mcp/catalog_readonly_test.go
+++ b/internal/mcp/catalog_readonly_test.go
@@ -93,6 +93,7 @@ func TestReadOnlyCatalog_ActionsMatchCmdhelp(t *testing.T) {
 
 		{"pad_role", "list"}:   {"role", "list"},
 		{"pad_role", "create"}: {"role", "create"},
+		{"pad_role", "update"}: {"role", "update"},
 		{"pad_role", "delete"}: {"role", "delete"},
 
 		{"pad_search", "query"}: {"item", "search"},
@@ -215,6 +216,7 @@ func TestReadOnlyCatalog_ActionsDispatchExpectedCmdPath(t *testing.T) {
 
 		{"pad_role", "list"}:   {"role", "list"},
 		{"pad_role", "create"}: {"role", "create"},
+		{"pad_role", "update"}: {"role", "update"},
 		{"pad_role", "delete"}: {"role", "delete"},
 
 		{"pad_search", "query"}: {"item", "search"},
@@ -453,6 +455,14 @@ func liveCmdhelpDoc(t *testing.T) *cmdhelp.Document {
 				Summary: "create role",
 				Args:    mkArgs("name"),
 				Flags:   mkFlags("workspace", "description", "icon", "tools"),
+			},
+			"role update": {
+				Summary: "update role",
+				Args:    mkArgs("slug"),
+				Flags: mkFlags(
+					"workspace", "name", "slug", "description", "icon",
+					"tools", "sort-order",
+				),
 			},
 			"role delete": {
 				Summary: "delete role",

--- a/internal/mcp/catalog_readonly_test.go
+++ b/internal/mcp/catalog_readonly_test.go
@@ -460,7 +460,7 @@ func liveCmdhelpDoc(t *testing.T) *cmdhelp.Document {
 				Summary: "update role",
 				Args:    mkArgs("slug"),
 				Flags: mkFlags(
-					"workspace", "name", "slug", "description", "icon",
+					"workspace", "name", "new-slug", "description", "icon",
 					"tools", "sort-order",
 				),
 			},

--- a/internal/mcp/catalog_role.go
+++ b/internal/mcp/catalog_role.go
@@ -3,6 +3,13 @@ package mcp
 // padRoleTool exposes agent-role management. Roles let users organize
 // items by what kind of thinking is required (Planner / Implementer /
 // Reviewer). One per (user, role) assignment on items.
+//
+// `update` (TASK-1512) is the role-side adaptation primitive for the
+// `/pad onboard` playbook (PLAN-1496): the agent rewrites seeded role
+// descriptions and icons during onboarding so they match how the
+// user's team actually splits work. Deleting and re-creating loses
+// the agent_role_id references on items already assigned to the role,
+// so update is the only safe way to adapt.
 
 func init() {
 	appendToCatalog(padRoleTool)
@@ -17,33 +24,44 @@ var padRoleTool = ToolDef{
 			{
 				Name:        "name",
 				Type:        "string",
-				Description: "Display name of the role (e.g. \"Implementer\"). Required for action=create.",
+				Description: "Display name of the role (e.g. \"Implementer\"). Required for action=create. Optional for action=update — provide to rename.",
 			},
 			{
 				Name:        "slug",
 				Type:        "string",
-				Description: "Role slug (e.g. \"implementer\"). Required for action=delete.",
+				Description: "Role slug (e.g. \"implementer\") or UUID. Required for action=update and action=delete; identifies which role to mutate. To RENAME a role, also pass new_slug.",
+			},
+			{
+				Name:        "new_slug",
+				Type:        "string",
+				Description: "Replacement slug when renaming an existing role. Optional for action=update; ignored otherwise.",
 			},
 			{
 				Name:        "description",
 				Type:        "string",
-				Description: "What kind of work this role does. Optional for action=create.",
+				Description: "What kind of work this role does. Optional for action=create and action=update.",
 			},
 			{
 				Name:        "icon",
 				Type:        "string",
-				Description: "Emoji icon for the role (e.g. \"🔨\"). Optional for action=create.",
+				Description: "Emoji icon for the role (e.g. \"🔨\"). Optional for action=create and action=update.",
 			},
 			{
 				Name:        "tools",
 				Type:        "string",
-				Description: "Comma-separated list of tools/integrations the role uses. Optional for action=create.",
+				Description: "Comma-separated list of tools/integrations the role uses. Optional for action=create and action=update.",
+			},
+			{
+				Name:        "sort_order",
+				Type:        "number",
+				Description: "Display sort order (lower = appears first). Optional for action=update.",
 			},
 		},
 	},
 	Actions: map[string]ActionFn{
 		"list":   passThrough([]string{"role", "list"}),
 		"create": passThrough([]string{"role", "create"}),
+		"update": passThrough([]string{"role", "update"}),
 		"delete": passThrough([]string{"role", "delete"}),
 	},
 }
@@ -56,6 +74,15 @@ Actions:
   create  — Create a new role.
             Required: workspace, name.
             Optional: description, icon, tools.
+  update  — Update an existing role's name, slug, description, icon, tools,
+            or sort_order. Only fields you explicitly set are mutated.
+            Required: workspace, slug.
+            Optional: name, description, icon, tools, sort_order, new_slug
+                      (the rename target; pass slug for lookup AND
+                      new_slug for the replacement value).
+            This is the adaptation primitive for the /pad onboard playbook
+            (PLAN-1496): rewriting seeded role descriptions/icons to match
+            the team's actual division of work.
   delete  — Delete a role by slug.
             Required: workspace, slug.
 

--- a/internal/mcp/dispatch_http_routes.go
+++ b/internal/mcp/dispatch_http_routes.go
@@ -287,6 +287,7 @@ func init() {
 
 		// --- Roles (admin) ---
 		"role create": mapRoleCreate,
+		"role update": mapRoleUpdate,
 		"role delete": routeSpec{
 			method:       http.MethodDelete,
 			pathTemplate: "/api/v1/workspaces/{workspace}/agent-roles/{slug}",
@@ -701,6 +702,64 @@ func mapCollectionUpdate(input map[string]any) (string, string, []byte, error) {
 		return "", "", nil, fmt.Errorf("encode body: %w", err)
 	}
 	urlPath := "/api/v1/workspaces/" + url.PathEscape(workspace) + "/collections/" + url.PathEscape(slug)
+	return http.MethodPatch, urlPath, body, nil
+}
+
+// mapRoleUpdate dispatches `pad role update <slug>
+// [--name ...] [--slug ...] [--description ...] [--icon ...]
+// [--tools ...] [--sort-order ...]`.
+//
+// PATCH /api/v1/workspaces/{ws}/agent-roles/{slug} with a body
+// matching models.AgentRoleUpdate. The path's {slug} identifies the
+// role to mutate (server resolves slug-or-UUID via
+// store.ResolveAgentRoleID); the body's `slug` field, populated from
+// MCP input `new_slug`, supplies the rename target so the two
+// semantics stay disambiguated on the MCP surface.
+//
+// String fields use KEY PRESENCE (not "v != \"\"") because every
+// AgentRoleUpdate field is a pointer, and the store treats *string("")
+// as "clear this column" the same way collections do. The CLI's flag
+// help advertises empty-string clears for description and icon — the
+// MCP surface preserves that behavior.
+func mapRoleUpdate(input map[string]any) (string, string, []byte, error) {
+	workspace, _ := input["workspace"].(string)
+	if workspace == "" {
+		return "", "", nil, fmt.Errorf("workspace is required")
+	}
+	slug, _ := input["slug"].(string)
+	if slug == "" {
+		return "", "", nil, fmt.Errorf("slug is required")
+	}
+
+	payload := map[string]any{}
+	// Standard string fields — key presence, not value-non-empty,
+	// so empty strings can clear.
+	for _, key := range []string{"name", "description", "icon", "tools"} {
+		v, ok := input[key]
+		if !ok || v == nil {
+			continue
+		}
+		if s, ok := v.(string); ok {
+			payload[key] = s
+		}
+	}
+	// new_slug → body["slug"]: the rename target lives under a
+	// distinct MCP input key so it doesn't collide with the
+	// lookup slug in the path.
+	if v, ok := input["new_slug"]; ok && v != nil {
+		if s, ok := v.(string); ok && s != "" {
+			payload["slug"] = s
+		}
+	}
+	if v, ok := input["sort_order"]; ok && v != nil {
+		payload["sort_order"] = v
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return "", "", nil, fmt.Errorf("encode body: %w", err)
+	}
+	urlPath := "/api/v1/workspaces/" + url.PathEscape(workspace) + "/agent-roles/" + url.PathEscape(slug)
 	return http.MethodPatch, urlPath, body, nil
 }
 

--- a/internal/mcp/dispatch_http_routes_extras_test.go
+++ b/internal/mcp/dispatch_http_routes_extras_test.go
@@ -426,6 +426,118 @@ func TestMapRoleCreate_OmitsEmptyOptionalFields(t *testing.T) {
 	}
 }
 
+// --- Role update (TASK-1512 / PLAN-1496) ---
+
+func TestMapRoleUpdate_BuildsPatchBody(t *testing.T) {
+	m, p, body, err := mapRoleUpdate(map[string]any{
+		"workspace":   "docapp",
+		"slug":        "implementer",
+		"name":        "Engineer",
+		"description": "Writes code, ships PRs",
+		"icon":        "🔨",
+		"tools":       "claude-code",
+		"sort_order":  float64(3),
+	})
+	if err != nil {
+		t.Fatalf("mapRoleUpdate: %v", err)
+	}
+	if m != http.MethodPatch {
+		t.Errorf("method = %q, want PATCH", m)
+	}
+	if p != "/api/v1/workspaces/docapp/agent-roles/implementer" {
+		t.Errorf("path = %q", p)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	want := map[string]any{
+		"name":        "Engineer",
+		"description": "Writes code, ships PRs",
+		"icon":        "🔨",
+		"tools":       "claude-code",
+		"sort_order":  float64(3),
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("body[%q] = %v (%T), want %v (%T)", k, got[k], got[k], v, v)
+		}
+	}
+	// Round-trip through AgentRoleUpdate to confirm the body shape
+	// is what the server's decodeJSON expects.
+	var update models.AgentRoleUpdate
+	if err := json.Unmarshal(body, &update); err != nil {
+		t.Fatalf("AgentRoleUpdate.Unmarshal rejected body: %v", err)
+	}
+	if update.Name == nil || *update.Name != "Engineer" {
+		t.Errorf("AgentRoleUpdate.Name round-trip wrong: %v", update.Name)
+	}
+}
+
+// TestMapRoleUpdate_NewSlugMapsToBodySlug confirms the disambiguation:
+// MCP input `slug` identifies the role in the path; MCP input `new_slug`
+// becomes the body's `slug` field (rename target). Without this, the
+// catalog would conflate the two meanings on the single `slug` param.
+func TestMapRoleUpdate_NewSlugMapsToBodySlug(t *testing.T) {
+	_, p, body, err := mapRoleUpdate(map[string]any{
+		"workspace": "docapp",
+		"slug":      "implementer",
+		"new_slug":  "engineer",
+	})
+	if err != nil {
+		t.Fatalf("mapRoleUpdate: %v", err)
+	}
+	if p != "/api/v1/workspaces/docapp/agent-roles/implementer" {
+		t.Errorf("path should use lookup slug; got %q", p)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if got["slug"] != "engineer" {
+		t.Errorf("body[slug] should be the new_slug; got %v", got["slug"])
+	}
+}
+
+// TestMapRoleUpdate_EmptyStringClearsField mirrors the same behavior
+// the collection-update mapper has: explicit empty strings round-trip
+// to the store so the column can be cleared. The CLI's --description
+// "" / --icon "" expose this; the MCP path must preserve it.
+func TestMapRoleUpdate_EmptyStringClearsField(t *testing.T) {
+	_, _, body, err := mapRoleUpdate(map[string]any{
+		"workspace":   "docapp",
+		"slug":        "planner",
+		"description": "",
+		"icon":        "",
+	})
+	if err != nil {
+		t.Fatalf("mapRoleUpdate: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	for _, key := range []string{"description", "icon"} {
+		v, present := got[key]
+		if !present {
+			t.Errorf("explicit empty %q should be sent through to clear the column; got %v", key, got)
+			continue
+		}
+		if v != "" {
+			t.Errorf("%q should serialize as empty string; got %v (%T)", key, v, v)
+		}
+	}
+}
+
+func TestMapRoleUpdate_RequiresWorkspaceAndSlug(t *testing.T) {
+	if _, _, _, err := mapRoleUpdate(map[string]any{"slug": "planner"}); err == nil {
+		t.Errorf("expected error when workspace missing")
+	}
+	if _, _, _, err := mapRoleUpdate(map[string]any{"workspace": "docapp"}); err == nil {
+		t.Errorf("expected error when slug missing")
+	}
+}
+
 func TestMapRoleCreate_RequiresName(t *testing.T) {
 	_, _, _, err := mapRoleCreate(map[string]any{"workspace": "ws"})
 	if err == nil {

--- a/internal/mcp/instructions.md
+++ b/internal/mcp/instructions.md
@@ -14,7 +14,7 @@ Eight resource × action tools, plus `pad_set_workspace` (which takes a `workspa
 - `pad_workspace` — Workspaces: list / members / invite / storage / audit-log.
 - `pad_collection` — Collections: list / create / update / delete.
 - `pad_project` — Project intelligence: dashboard / next / standup / changelog.
-- `pad_role` — Agent roles: list / create / delete.
+- `pad_role` — Agent roles: list / create / update / delete.
 - `pad_search` — Full-text search across items: query.
 - `pad_playbook` — Invokable procedures: list / get / run. Use `run` to bind args against a playbook's declared spec and get the rendered body back; side-effect-free.
 - `pad_meta` — Server introspection: server-info / version / tool-surface / bootstrap. The `bootstrap` action returns one-shot workspace context (user + collections + always-on conventions + roles + playbook metadata + dashboard + recent activity).


### PR DESCRIPTION
## Summary

Third of three TASK-1497 capability-spike follow-ups (after #572 and #573). The HTTP handler at \`handlers_agent_roles.go::handleUpdateAgentRole\` and the \`UpdateAgentRole\` HTTP client method already existed; only the agent-facing surfaces were missing.

Completes the workspace-mutation trio (collection update + collection delete + role update) the \`/pad onboard\` playbook (TASK-1499) needs to adapt seeded roles, collections, and schemas to each project's actual shape.

## Changes

- **\`cmd/pad\`** — new \`pad role update <slug-or-uuid>\` Cobra subcommand. Flags: \`--name\`, \`--slug\`, \`--description\`, \`--icon\`, \`--tools\`, \`--sort-order\`. Empty-string clears for description/icon (the store honors \`*string("")\` as "clear" — same as collection update).
- **\`internal/mcp/catalog_role\`** — new \`update\` action; supporting params (\`new_slug\`, \`sort_order\`). Catalog disambiguates lookup-slug (path) from rename-target (body) via the \`new_slug\` input, avoiding conflated semantics on the single \`slug\` param.
- **\`internal/mcp/dispatch_http_routes\`** — new \`mapRoleUpdate\` mapper. Path uses \`input.slug\` for lookup; body's \`slug\` key is sourced from \`input.new_slug\`. String fields use key-presence semantics.
- **\`README.md\`** + **\`internal/mcp/instructions.md\`** — pad_role action lists updated to include \`update\`.

## Test plan

- [x] \`go build\`, \`golangci-lint\` (0 issues), full \`go test\` pass
- [x] \`TestMapRoleUpdate_BuildsPatchBody\` — canonical body shape + AgentRoleUpdate round-trip
- [x] \`TestMapRoleUpdate_NewSlugMapsToBodySlug\` — lookup-vs-rename disambiguation
- [x] \`TestMapRoleUpdate_EmptyStringClearsField\`
- [x] \`TestMapRoleUpdate_RequiresWorkspaceAndSlug\`
- [x] Catalog bijection (\`TestReadOnlyCatalog_ActionsMatchCmdhelp\` + dispatch) green
- [x] \`pad role update --help\` renders the new command

Parent: PLAN-1496.