### PR TITLE
feat(templates): finalize 'blank' template with minimal-vocab seeds for /pad onboard (TASK-1498)

### DIFF
--- a/internal/collections/templates.go
+++ b/internal/collections/templates.go
@@ -736,13 +736,30 @@ var templates = []WorkspaceTemplate{
 	hiringTemplate(),
 	interviewingTemplate(),
 	{
+		// blank — minimal entry-point for the /pad onboard playbook
+		// flow (PLAN-1496 / TASK-1498; originally IDEA-1479).
+		//
+		// Ships only the two SYSTEM collections (Conventions,
+		// Playbooks) — infrastructure the rest of the pipeline
+		// assumes exists (bootstrap surfaces them, the convention
+		// loader queries them, the onboard playbook itself lives in
+		// `playbooks`). No user-facing collections, no seeded
+		// conventions, no seeded playbooks, no sample items.
+		//
+		// Trigger / scope vocabularies are deliberately minimal
+		// (`always`+`manual`, `all`) so the seed doesn't leak a
+		// domain. The /pad onboard playbook calls `pad collection
+		// update` (TASK-1510) during its interview to broaden the
+		// vocabulary to whatever the workspace's actual domain
+		// needs — software gets `on-commit` / `on-implement`,
+		// hiring gets `on-candidate-advance`, etc.
 		Name:        "blank",
 		Category:    CategoryCustom,
-		Description: "Just Conventions & Playbooks — build the rest yourself",
-		Icon:        "\U0001F4DD", // 📝
+		Description: "Empty workspace — run /pad onboard to build it out",
+		Icon:        "✨", // ✨
 		Collections: []DefaultCollection{
-			conventionsCollection(0, SoftwareConventionTriggers, SoftwareConventionScopes),
-			playbooksCollection(1, SoftwarePlaybookTriggers, SoftwarePlaybookScopes),
+			conventionsCollection(0, BlankConventionTriggers, BlankConventionScopes),
+			playbooksCollection(1, BlankPlaybookTriggers, BlankPlaybookScopes),
 		},
 		// No SeedItems, no Conventions, no Playbooks, no OnboardingPrimaryRef —
 		// system rails only. Users build the rest via `pad collection create`.

--- a/internal/collections/templates_blank.go
+++ b/internal/collections/templates_blank.go
@@ -1,0 +1,30 @@
+package collections
+
+// templates_blank.go holds the seed vocabularies for the `blank`
+// workspace template registered in templates.go. The template entry
+// itself stays inline with the other templates so the registration
+// list keeps a single shape; only the trigger / scope vocabularies
+// live here because they're the part most likely to change (and most
+// worth a focused diff when they do).
+//
+// Design notes — PLAN-1496 / TASK-1498 (originally IDEA-1479):
+//   - The `blank` template is the minimal entry-point for the
+//     /pad onboard playbook flow. Only the two SYSTEM collections
+//     (Conventions, Playbooks) are seeded.
+//   - Trigger / scope vocabularies are deliberately tiny: `always`
+//     for conventions (universal "follow this" rule), `manual` for
+//     playbooks (the seeded onboard playbook itself is
+//     manual-triggered), and `all` for both scopes.
+//   - The /pad onboard playbook broadens these via `pad collection
+//     update` (TASK-1510) once the interview reveals the workspace's
+//     actual domain — software adds `on-commit`/`on-implement`,
+//     hiring adds `on-candidate-advance`, research adds
+//     `on-experiment-run`, etc. Keeping the seed minimal forces that
+//     conversation up-front rather than carrying baked-in assumptions.
+
+var (
+	BlankConventionTriggers = []string{"always"}
+	BlankConventionScopes   = []string{"all"}
+	BlankPlaybookTriggers   = []string{"manual"}
+	BlankPlaybookScopes     = []string{"all"}
+)

--- a/internal/collections/templates_test.go
+++ b/internal/collections/templates_test.go
@@ -887,6 +887,43 @@ func TestBlankTemplateExcludesSoftwareCollections(t *testing.T) {
 	}
 }
 
+// TestBlankTemplateUsesMinimalVocabularies locks in the design choice
+// from PLAN-1496 / TASK-1498: the blank template's seeded system
+// collections use deliberately tiny trigger/scope option sets so the
+// template doesn't leak a domain. The /pad onboard playbook is
+// expected to broaden these via `pad collection update` (TASK-1510)
+// once the interview reveals what the workspace's actual vocabulary
+// should be (software gets on-commit/on-implement, hiring gets
+// on-candidate-advance, etc.).
+//
+// If this test breaks, it means someone added a domain-flavored
+// trigger or scope to the blank seed — that change needs a different
+// task and a fresh design conversation.
+func TestBlankTemplateUsesMinimalVocabularies(t *testing.T) {
+	tmpl := GetTemplate("blank")
+	if tmpl == nil {
+		t.Fatal("blank template missing")
+	}
+	for _, c := range tmpl.Collections {
+		switch c.Slug {
+		case "conventions":
+			if got := findFieldOptions(c, "trigger"); !reflect.DeepEqual(got, BlankConventionTriggers) {
+				t.Errorf("conventions.trigger options = %v, want %v (minimal seed)", got, BlankConventionTriggers)
+			}
+			if got := findFieldOptions(c, "scope"); !reflect.DeepEqual(got, BlankConventionScopes) {
+				t.Errorf("conventions.scope options = %v, want %v (minimal seed)", got, BlankConventionScopes)
+			}
+		case "playbooks":
+			if got := findFieldOptions(c, "trigger"); !reflect.DeepEqual(got, BlankPlaybookTriggers) {
+				t.Errorf("playbooks.trigger options = %v, want %v (minimal seed)", got, BlankPlaybookTriggers)
+			}
+			if got := findFieldOptions(c, "scope"); !reflect.DeepEqual(got, BlankPlaybookScopes) {
+				t.Errorf("playbooks.scope options = %v, want %v (minimal seed)", got, BlankPlaybookScopes)
+			}
+		}
+	}
+}
+
 // TestBlankTemplateAppearsInPicker verifies the blank template is surfaced
 // by GroupTemplatesByCategory under a Custom group. The picker iterates
 // this helper, so a missing Custom group would hide the template entirely.

--- a/internal/collections/templates_test.go
+++ b/internal/collections/templates_test.go
@@ -900,6 +900,21 @@ func TestBlankTemplateExcludesSoftwareCollections(t *testing.T) {
 // trigger or scope to the blank seed — that change needs a different
 // task and a fresh design conversation.
 func TestBlankTemplateUsesMinimalVocabularies(t *testing.T) {
+	// Literal expected slices — NOT the BlankConventionTriggers /
+	// BlankPlaybookTriggers vars. Comparing against those would be
+	// tautological (the template is built from them, so widening
+	// the var would silently widen the "minimal" definition).
+	// Codex round-1 finding on PR #575 fixed this.
+	const (
+		alwaysTrigger = "always"
+		manualTrigger = "manual"
+		allScope      = "all"
+	)
+	wantConventionTriggers := []string{alwaysTrigger}
+	wantConventionScopes := []string{allScope}
+	wantPlaybookTriggers := []string{manualTrigger}
+	wantPlaybookScopes := []string{allScope}
+
 	tmpl := GetTemplate("blank")
 	if tmpl == nil {
 		t.Fatal("blank template missing")
@@ -907,18 +922,18 @@ func TestBlankTemplateUsesMinimalVocabularies(t *testing.T) {
 	for _, c := range tmpl.Collections {
 		switch c.Slug {
 		case "conventions":
-			if got := findFieldOptions(c, "trigger"); !reflect.DeepEqual(got, BlankConventionTriggers) {
-				t.Errorf("conventions.trigger options = %v, want %v (minimal seed)", got, BlankConventionTriggers)
+			if got := findFieldOptions(c, "trigger"); !reflect.DeepEqual(got, wantConventionTriggers) {
+				t.Errorf("conventions.trigger options = %v, want %v (minimal seed)", got, wantConventionTriggers)
 			}
-			if got := findFieldOptions(c, "scope"); !reflect.DeepEqual(got, BlankConventionScopes) {
-				t.Errorf("conventions.scope options = %v, want %v (minimal seed)", got, BlankConventionScopes)
+			if got := findFieldOptions(c, "scope"); !reflect.DeepEqual(got, wantConventionScopes) {
+				t.Errorf("conventions.scope options = %v, want %v (minimal seed)", got, wantConventionScopes)
 			}
 		case "playbooks":
-			if got := findFieldOptions(c, "trigger"); !reflect.DeepEqual(got, BlankPlaybookTriggers) {
-				t.Errorf("playbooks.trigger options = %v, want %v (minimal seed)", got, BlankPlaybookTriggers)
+			if got := findFieldOptions(c, "trigger"); !reflect.DeepEqual(got, wantPlaybookTriggers) {
+				t.Errorf("playbooks.trigger options = %v, want %v (minimal seed)", got, wantPlaybookTriggers)
 			}
-			if got := findFieldOptions(c, "scope"); !reflect.DeepEqual(got, BlankPlaybookScopes) {
-				t.Errorf("playbooks.scope options = %v, want %v (minimal seed)", got, BlankPlaybookScopes)
+			if got := findFieldOptions(c, "scope"); !reflect.DeepEqual(got, wantPlaybookScopes) {
+				t.Errorf("playbooks.scope options = %v, want %v (minimal seed)", got, wantPlaybookScopes)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

A blank template entry was already present in \`templates.go\` (drafted for IDEA-1479) but its seeded trigger/scope vocabularies leaked the software domain — \`on-commit\`, \`on-pr-create\`, \`on-implement\`, etc., baked into a template whose whole point is being domain-agnostic. This finalizes the template for the \`/pad onboard\` flow (PLAN-1496 / TASK-1499).

## Changes

- **\`internal/collections/templates.go\`** — replace software-flavored seed vocabularies with minimal sets: \`always\` for conventions, \`manual\` for playbooks, \`all\` for both scopes. New in-place comment explains the design choice. Description + icon updated to point at the onboard flow.
- **\`internal/collections/templates_blank.go\`** (new) — holds the minimal-vocab constants in a focused file. The template entry itself stays inline with the others; only the vocabularies live here.
- **\`internal/collections/templates_test.go\`** — new \`TestBlankTemplateUsesMinimalVocabularies\` locks the design choice. Existing IDEA-1479 tests (Shape, ExcludesSoftwareCollections, AppearsInPicker) continue to pass.

The /pad onboard playbook (TASK-1499) will broaden these vocabularies during its interview via \`pad collection update\` (TASK-1510, already shipped) — software gets \`on-commit\`/\`on-implement\`, hiring gets \`on-candidate-advance\`, etc.

## Test plan

- [x] \`go build\` clean, \`golangci-lint\` 0 issues, full \`go test\` passes
- [x] All four blank-template tests pass
- [x] Pre-existing IDEA-1479 tests untouched and green

Parent: PLAN-1496.