### PR TITLE
feat(bootstrap,skill): add needs_onboarding + retire legacy Onboarding workflow (TASK-1504/1505)

### DIFF
--- a/internal/mcp/prompts_data.go
+++ b/internal/mcp/prompts_data.go
@@ -60,31 +60,13 @@ Always confirm before creating or mutating items.
 
 const promptOnboardBody = `# Pad: Onboard workflow
 
-You are helping the user set up a fresh pad workspace, or scan an existing codebase for context.
+The canonical workspace-onboarding interview lives in the ` + "`/pad onboard`" + ` invokable library playbook (PLAN-1496 / TASK-1499). Every new workspace auto-seeds it as ` + "`status=active`" + ` (TASK-1500), so it should be directly invokable.
 
-1. **Check workspace state.** ` + "`pad project dashboard --format json`" + `. If the workspace already has items, ask whether they want to add more or start fresh sections.
+To run it:
 
-2. **Check for a workspace-specific onboarding playbook.** Some templates ship their own:
-   ` + "```bash" + `
-   pad item list playbooks --field status=active --format json
-   ` + "```" + `
-   Look for a playbook whose title starts with "Onboarding" (or is explicitly about onboarding for this workspace type). If one exists, **follow its steps in order** — it's the template's opinion about how to get this kind of workspace set up.
+1. Confirm the playbook is activated. ` + "`pad playbook list --format json`" + ` and look for ` + "`invocation_slug=onboard`" + ` with ` + "`status=active`" + `. If it's missing, activate from the library: ` + "`pad library activate playbook \"Onboard a workspace\"`" + ` (web UI: ` + "`/{ws}/library?tab=playbooks`" + `).
+2. Load the body. ` + "`pad playbook show onboard --format markdown`" + `.
+3. Follow the body's instructions. It teaches you the surface-agnostic interview: discover the domain, propose collections, adapt seeded conventions/playbooks to the project's actual tooling, suggest roles, seed a first item. The body is the source of truth — this prompt is just the dispatcher.
 
-3. **If the playbook is software-flavored or absent, do a codebase scan.** Skip this step for non-code workspaces:
-   - ` + "`README.md`" + ` / ` + "`README`" + ` — project overview, setup instructions
-   - ` + "`CLAUDE.md`" + ` — existing AI/agent instructions
-   - Build config: ` + "`Makefile`, `package.json`, `go.mod`, `Cargo.toml`, `pyproject.toml`, `pom.xml`" + `
-   - CI config: ` + "`.github/workflows/`, `.gitlab-ci.yml`, `.circleci/`" + `
-   - Directory structure
-   - Detect language, build system, test runner, linter — use the actual commands the project uses when suggesting conventions.
-
-4. **Suggest conventions.** Present relevant conventions from the library as a checklist and ask which to activate. For code workspaces, customize with the actual commands found (e.g., "Run ` + "`make test`" + `" instead of "Run the test suite"). For non-code workspaces, lean on the template's starter pack.
-
-5. **Draft a seed doc.** Summarize whatever's appropriate for the workspace type — an architecture doc for a codebase, a process doc for hiring, a research-agenda doc for a research workspace. Offer to save as a Doc item.
-
-6. **Propose an initial plan.** For codebases, base it on recent ` + "`git log`" + ` and open TODOs. For other workspace types, base it on the first thing the user wants to track. Ask before creating.
-
-7. **Suggest agent roles.** If no roles exist yet, suggest roles appropriate for the workspace type. Dev: Planner, Implementer, Reviewer. Hiring: Recruiter, Hiring Manager, Interviewer. Research: Researcher, Reviewer. Don't auto-create — ask first.
-
-8. **Always confirm before creating each item.** Show what will be created, get approval, then create.
+The pre-PLAN-1496 step-by-step workflow that used to live here (codebase-scan / suggest-conventions / draft-doc / propose-plan / suggest-roles) was retired in TASK-1505. All of it is now embedded in the playbook body, surface-agnostic so MCP-only agents can follow it too.
 `

--- a/internal/mcp/prompts_test.go
+++ b/internal/mcp/prompts_test.go
@@ -73,8 +73,13 @@ func TestPromptsLockstep_CoreCommands(t *testing.T) {
 			"pad item update PLAN-",
 		},
 		PromptOnboard: {
-			"pad project dashboard",
-			"pad item list playbooks",
+			// PLAN-1496 / TASK-1505: prompt body now delegates to the
+			// /pad onboard library playbook rather than carrying its
+			// own step-by-step script. Lock the dispatch fragments —
+			// these are the operative CLI calls the prompt instructs
+			// agents to run.
+			"pad playbook list",
+			"pad playbook show onboard",
 		},
 	}
 	for name, fragments := range cases {

--- a/internal/server/handlers_bootstrap.go
+++ b/internal/server/handlers_bootstrap.go
@@ -27,6 +27,20 @@ type AgentBootstrap struct {
 	Roles       []BootstrapRole              `json:"roles"`
 	Playbooks   []AgentBootstrapPlaybookMeta `json:"playbooks"`
 	Dashboard   *BootstrapDashboard          `json:"dashboard,omitempty"`
+	// NeedsOnboarding is true when the workspace has ZERO user-created
+	// items — i.e. nothing beyond what SeedCollectionsFromTemplate seeded
+	// at init time. The agent skill reads this on every /pad invocation
+	// and renders a "this workspace hasn't been set up yet — say /pad
+	// onboard" nudge while it's true; the moment any user (or agent on
+	// their behalf) creates the first real item, the flag flips to false
+	// and the nudge disappears. PLAN-1496 / TASK-1504.
+	//
+	// Computed per-request (not stored). The store predicate is "any
+	// item with source != 'template'" — see
+	// Store.WorkspaceHasUserCreatedItems for the rationale on why we
+	// exclude template seeds rather than enumerating user-side source
+	// values.
+	NeedsOnboarding bool `json:"needs_onboarding"`
 }
 
 // BootstrapCollection is the lightweight collection projection delivered
@@ -538,6 +552,17 @@ func (s *Server) BuildAgentBootstrap(workspaceID string, user *models.User, r *h
 		if derr == nil && dash != nil {
 			out.Dashboard = capBootstrapDashboard(dash)
 		}
+	}
+
+	// NeedsOnboarding: workspace-level signal (no per-caller visibility
+	// filtering — see Store.WorkspaceHasUserCreatedItems comment for
+	// the rationale). On a query error we fall back to false, which
+	// matches the safe default of "don't nag the agent." Worst case is
+	// a missed nudge; the opposite (nagging an already-onboarded
+	// workspace) is worse UX. PLAN-1496 / TASK-1504.
+	hasUserItems, hErr := s.store.WorkspaceHasUserCreatedItems(workspaceID)
+	if hErr == nil {
+		out.NeedsOnboarding = !hasUserItems
 	}
 
 	return out, nil

--- a/internal/server/handlers_bootstrap_test.go
+++ b/internal/server/handlers_bootstrap_test.go
@@ -55,6 +55,86 @@ func TestBootstrapEmptyWorkspace(t *testing.T) {
 	}
 }
 
+// TestBootstrapNeedsOnboardingFlag locks PLAN-1496 / TASK-1504's
+// contract: the `needs_onboarding` flag is true on a freshly-created
+// workspace (no user items yet — only template seeds) and flips to
+// false the moment any user/agent-created item exists.
+//
+// The flag drives the agent skill's bootstrap nudge ("this workspace
+// hasn't been set up yet — say /pad onboard"). If this test breaks,
+// the nudge fires forever or never.
+func TestBootstrapNeedsOnboardingFlag(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	// Step 1: fresh workspace. createWSForTest hits POST /workspaces
+	// with no Template field, so SeedCollectionsFromTemplate runs
+	// with templateName="" — backward-compat path that ships ONLY
+	// the default system collections and zero seeded items
+	// (TASK-1500's onboard auto-seed is gated on a non-empty
+	// templateName). Same shape pad-cloud uses for its in-process
+	// seed. needs_onboarding should be true here.
+	rr := doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/agent/bootstrap", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("bootstrap (initial): %d %s", rr.Code, rr.Body.String())
+	}
+	var b AgentBootstrap
+	parseJSON(t, rr, &b)
+	if !b.NeedsOnboarding {
+		t.Errorf("fresh workspace: needs_onboarding = false, want true (no user items yet)")
+	}
+
+	// Step 2: create a user-side item. Any source != 'template'
+	// flips the flag. Item creation via POST /items defaults to
+	// source='cli' (matches CLI + Remote MCP attribution).
+	rr = doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections/tasks/items", map[string]any{
+		"title": "First real task",
+	})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create user item: %d %s", rr.Code, rr.Body.String())
+	}
+
+	// Step 3: re-fetch bootstrap; flag must be false now.
+	rr = doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/agent/bootstrap", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("bootstrap (after user item): %d %s", rr.Code, rr.Body.String())
+	}
+	b = AgentBootstrap{}
+	parseJSON(t, rr, &b)
+	if b.NeedsOnboarding {
+		t.Errorf("after creating user item: needs_onboarding = true, want false (nudge should disappear)")
+	}
+}
+
+// TestBootstrapNeedsOnboardingIgnoresTemplateSeeds is a focused guard:
+// even when a templated workspace ships seeded items
+// (conventions/playbooks/the onboard playbook itself), they MUST NOT
+// flip needs_onboarding to false — only USER-created items count.
+// Otherwise startup/scrum/product workspaces would never show the
+// nudge and the /pad onboard discovery loop falls apart.
+func TestBootstrapNeedsOnboardingIgnoresTemplateSeeds(t *testing.T) {
+	srv := testServer(t)
+	rr := doRequest(srv, "POST", "/api/v1/workspaces", map[string]string{
+		"name":     "Startup Needs Onboarding",
+		"template": "startup",
+	})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create workspace: %d %s", rr.Code, rr.Body.String())
+	}
+	var ws models.Workspace
+	parseJSON(t, rr, &ws)
+
+	rr = doRequest(srv, "GET", "/api/v1/workspaces/"+ws.Slug+"/agent/bootstrap", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("bootstrap: %d %s", rr.Code, rr.Body.String())
+	}
+	var b AgentBootstrap
+	parseJSON(t, rr, &b)
+	if !b.NeedsOnboarding {
+		t.Errorf("startup template workspace with only seeded conventions/playbooks: needs_onboarding = false, want true (template seeds don't count)")
+	}
+}
+
 // TestBootstrapEmptyArraysNotNull verifies the JSON wire shape: arrays
 // must serialize as [] not null so the agent skill can iterate without
 // defensive nil checks.

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -3259,6 +3259,47 @@ func (s *Store) WorkspaceHasAgentActivity(workspaceID string, collectionIDs, ite
 	return has, nil
 }
 
+// WorkspaceHasUserCreatedItems reports whether ANY non-deleted item
+// in the workspace was created by something other than template
+// seeding. Used by the agent bootstrap to compute the
+// `needs_onboarding` flag — true when zero user-created items exist,
+// false the moment the user (or an agent on their behalf) creates
+// the first real item. PLAN-1496 / TASK-1504.
+//
+// "User-created" is the inverse of "template seed": items written
+// during workspace init via SeedCollectionsFromTemplate carry
+// source="template" + created_by="system". Everything else — CLI,
+// web UI, MCP, future surfaces — is treated as user activity. The
+// query filters on `source != 'template'` rather than enumerating
+// the user-side values so new surfaces (mcp, api, etc.) are
+// included automatically without code changes here.
+//
+// Visibility filtering is intentionally omitted: needs_onboarding
+// is a workspace-level state signal, not a per-user view. Two
+// callers reading bootstrap concurrently should see the same answer
+// regardless of their individual collection-access grants — the
+// flag describes whether the WORKSPACE has been activated, not
+// whether the calling user has done so. Server already gates the
+// bootstrap endpoint on workspace membership, so unauthorized
+// callers never reach this code path.
+//
+// Backed by EXISTS so it short-circuits on the first match.
+func (s *Store) WorkspaceHasUserCreatedItems(workspaceID string) (bool, error) {
+	const query = `
+		SELECT EXISTS(
+			SELECT 1 FROM items
+			WHERE workspace_id = ?
+			  AND deleted_at IS NULL
+			  AND (source IS NULL OR source != 'template')
+		)
+	`
+	var has bool
+	if err := s.db.QueryRow(s.q(query), workspaceID).Scan(&has); err != nil {
+		return false, fmt.Errorf("workspace has user-created items: %w", err)
+	}
+	return has, nil
+}
+
 func hydrateItemComputedMetadata(item *models.Item) {
 	if item == nil {
 		return

--- a/skills/pad/SKILL.md
+++ b/skills/pad/SKILL.md
@@ -36,6 +36,7 @@ The returned `AgentBootstrap` blob carries everything the skill needs to start a
 - `roles [...]` — agent roles configured in the workspace
 - `playbooks [...]` — METADATA ONLY: `ref`, `title`, `slug`, `invocation_slug`, `trigger`, `scope`, `status`, `has_arguments`, `summary`. Full bodies load on invocation via `pad playbook show <slug>`.
 - `dashboard {...}` — active items, attention, suggested next, recent activity. Five sub-arrays are capped to 5 entries each (`attention`, `recent_activity`, `active_items`, `active_plans`, `by_role`); each pairs with a `<name>_overflow_count` int field surfaced when truncation kicked in. Use `pad project dashboard` to pull the full set when any overflow > 0.
+- `needs_onboarding: bool` — true when the workspace has zero user-created items (template seeds don't count). PLAN-1496 / TASK-1504. **When this is true, lead your response with a one-line nudge:** *"This workspace hasn't been set up yet — say `/pad onboard` to walk through setup."* Then proceed with whatever else the user asked. The flag flips to false the moment any user/agent-created item exists; don't nag past that point. If the user has already declined onboarding (look at recent conversation), respect that and skip the nudge for this session.
 
 If the conventions list includes items, treat them as project rules you must follow. The vocabulary depends on the workspace domain — a software workspace ships rules like "use conventional commit format," a hiring workspace ships rules like "anonymize candidate names in exports," a research workspace ships rules like "always cite sources." Follow whatever the workspace has configured.
 
@@ -171,7 +172,8 @@ Interpret the user's intent and route to the appropriate action. Here are common
 **Retrospective:** "plan X is done, let's retro" → Review completed work via the playbook (or inline if none active), save retro as a Doc.
 
 **Onboarding:**
-- "set up my workspace" / "onboard me" / "scan this codebase" / **"use pad to get IDEA-1"** (legacy phrasing — the IDEA-1/PLAN-2/TASK-3/DOC-4 seed-item pattern was retired in PLAN-1496 / TASK-1501) → Dispatch to the `/pad onboard` playbook (canonical entry; activate via library if the bootstrap's `playbooks` array lacks `invocation_slug=onboard, status=active` — only newly-created workspaces auto-seed it, so workspaces created before PLAN-1496 may need a one-time library activation). The playbook body teaches you the interview flow: discover the domain, propose collections, adapt seeded conventions/playbooks to the project's actual tooling, suggest roles, seed a first item. Do NOT try to fetch `IDEA-1` directly — it no longer exists in any newly-created workspace.
+- "set up my workspace" / "onboard me" / "scan this codebase" → `/pad onboard` (canonical entry; activate via library if the bootstrap's `playbooks` array lacks `invocation_slug=onboard, status=active`). The playbook's body is the script — surface-agnostic interview, codebase scan if available, adapt seeded artifacts to the project, seed a first item.
+- "use pad to get IDEA-1" → also `/pad onboard`. Legacy phrasing from before PLAN-1496; the IDEA-1/PLAN-2/TASK-3/DOC-4 seed-item pattern was retired. Don't try to fetch `IDEA-1` directly — newly-created workspaces don't have it.
 
 **Creating a playbook:** "save this workflow as a playbook" / "let's make a playbook for X" / "I want a `/pad <slug>` for this" → Create an item in the `playbooks` collection. Two fields make it user-callable:
 
@@ -336,33 +338,9 @@ Use the `decompose` invokable playbook: **`/pad decompose <PLAN-ref>`**. Accepts
 3. Run `pad project dashboard --format json` for blockers/attention items
 4. Present as: Yesterday / Today / Blockers format
 
-### Onboarding: "Set up my workspace" / "Scan this codebase"
+### Onboarding
 
-1. **Check workspace state:** `pad project dashboard --format json` — if the workspace already has items, ask if they want to add more or start fresh sections.
-
-2. **Check for a workspace-specific onboarding playbook.** Some templates ship their own onboarding flow:
-   ```bash
-   pad item list playbooks --field status=active --format json
-   ```
-   Look for a playbook whose title starts with "Onboarding" (or is explicitly about onboarding for this workspace type). If one exists, **follow its steps in order** — it's the template's opinion about how to get this kind of workspace set up. The software templates ship "Onboarding to a Project" from the library; non-software templates ship their own (hiring: prompt for first requisition; interviewing: prompt for first application; etc.).
-
-3. **If the playbook is software-flavored or absent, do a codebase scan.** Skip this step for non-code workspaces:
-   - `README.md` / `README` — project overview, setup instructions
-   - `CLAUDE.md` — existing AI/agent instructions
-   - Build config: `Makefile`, `package.json`, `go.mod`, `Cargo.toml`, `pyproject.toml`, `pom.xml`
-   - CI config: `.github/workflows/`, `.gitlab-ci.yml`, `.circleci/`
-   - Directory structure
-   - Detect language, build system, test runner, linter — use the actual commands the project uses when suggesting conventions.
-
-4. **Suggest conventions.** Present relevant conventions from the library as a checklist and ask which to activate. For code workspaces, customize with the actual commands found (e.g., "Run `make test`" instead of "Run the test suite"). For non-code workspaces, lean on the template's starter pack and any conventions that fit the domain.
-
-5. **Draft a seed doc.** Summarize whatever's appropriate for the workspace type — an architecture doc for a codebase, a process doc for hiring, a research-agenda doc for a research workspace. Offer to save as a Doc item.
-
-6. **Propose an initial plan.** For codebases, base it on recent `git log` and open TODOs. For other workspace types, base it on the first thing the user wants to track (the first requisition, the first research question, the first content series). Ask before creating.
-
-7. **Suggest agent roles.** If no roles exist yet, suggest roles appropriate for the workspace type. Dev: Planner, Implementer, Reviewer. Hiring: Recruiter, Hiring Manager, Interviewer. Research: Researcher, Reviewer. Don't auto-create — ask first.
-
-8. **Always confirm before creating each item.** Show what will be created, get approval, then create.
+Use the `/pad onboard` invokable playbook — see the **Onboarding** entry under Natural Language Routing above. The playbook body is the canonical instruction set (interview flow, codebase scan if available, collection/convention/role/playbook adaptation, first-item seed). Don't reimplement it here; this skill is the dispatcher, the playbook is the script. PLAN-1496 / TASK-1499 retired the standalone Onboarding workflow that used to live in this file.
 
 ### Retrospective: "Plan X is done, let's retro"
 


### PR DESCRIPTION
## Summary

PLAN-1496's bootstrap-signal + skill-cleanup pair. Combining them because TASK-1505's nudge rendering needs TASK-1504's bootstrap field to exist.

- **TASK-1504** — Adds \`needs_onboarding bool\` to the bootstrap response. True when the workspace has zero items where \`source != 'template'\`. Computed per-request via a new EXISTS query.
- **TASK-1505** — Deletes the standalone \"Onboarding\" workflow section from \`skills/pad/SKILL.md\` (replaced by the \`/pad onboard\` playbook); adds the \`needs_onboarding\` nudge to the Context Loading section; simplifies the routing entry; replaces the duplicated step-by-step script in the \`pad_onboard\` MCP prompt body with the same dispatch-to-playbook pointer.

## Changes

- **\`internal/store/items.go\`** — \`WorkspaceHasUserCreatedItems(workspaceID)\` store method (EXISTS-backed, \`source != 'template'\` predicate).
- **\`internal/server/handlers_bootstrap.go\`** — \`AgentBootstrap.NeedsOnboarding\` field + compute in \`BuildAgentBootstrap\`.
- **\`internal/server/handlers_bootstrap_test.go\`** — \`TestBootstrapNeedsOnboardingFlag\` (lifecycle: fresh → user item → flag flips) + \`TestBootstrapNeedsOnboardingIgnoresTemplateSeeds\` (startup template seeded items don't flip it).
- **\`skills/pad/SKILL.md\`** — bootstrap-bullet nudge docs, deleted Onboarding workflow section (~30 lines), cleaner routing entry.
- **\`internal/mcp/prompts_data.go\`** + **\`internal/mcp/prompts_test.go\`** — \`pad_onboard\` MCP prompt body now points at \`/pad onboard\` playbook; lockstep test fragments updated.

## Test plan

- [x] \`go build\`, \`golangci-lint\` 0 issues, full \`go test\` clean
- [x] New bootstrap lifecycle tests pass
- [x] \`TestPromptsLockstep_CoreCommands\` updated for the new prompt body

Parent: PLAN-1496.