### PR TITLE
test,docs: onboarding integration test + CLAUDE.md update (TASK-1507/1508)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,7 @@ REST API at `/api/v1/`. Key endpoints:
 - `GET/PATCH /api/v1/admin/settings` — platform settings (admin-only)
 - `POST /api/v1/admin/test-email` — send test email (admin-only)
 - `POST /api/v1/invitations/{code}/accept` — accept workspace invitation
+- `GET /api/v1/workspaces/{ws}/agent/bootstrap` — one-round-trip agent context (workspace + user + collections + always-on conventions + roles + playbook metadata + dashboard + `needs_onboarding` flag). Same payload as the MCP `pad://workspace/{ws}/bootstrap` resource and the `pad_set_workspace` embed.
 
 ## Authentication
 
@@ -232,10 +233,12 @@ Code lives in `internal/mcp/` (built on `github.com/mark3labs/mcp-go`). Public d
 - **Templates** are grouped by category so Pad supports more than just software workflows:
   - **Software:** `startup` (default), `scrum`, `product`
   - **People:** `hiring` (company-side: Requisitions → Candidates → Loops → Feedback), `interviewing` (candidate-side: Applications, Interviews, Companies, Contacts)
+  - **Custom:** `blank` — system collections only (Conventions, Playbooks), no user-facing seeds. Designed as the entry point for the `/pad onboard` agent-driven flow (see [Onboarding](#onboarding) below). PLAN-1496 / TASK-1498.
   - *Research / Content / Operations / Personal are reserved categories awaiting their first templates.*
-- Each template ships a curated starter pack (conventions + playbooks + sample items) appropriate to its domain — trigger vocabularies vary (`on-commit` vs `on-candidate-advance` vs `on-interview-scheduled`).
+- Each non-blank template ships a curated starter pack (conventions + playbooks) appropriate to its domain — trigger vocabularies vary (`on-commit` vs `on-candidate-advance` vs `on-interview-scheduled`).
+- **The IDEA-1 / BACK-1 / FEAT-1 first-person seed-item pattern was retired in PLAN-1496** (TASK-1501 / TASK-1502). Templates no longer seed sample items; the `/pad onboard` playbook (auto-seeded into every workspace, TASK-1500) drives setup conversationally instead.
 - Set the template via `pad workspace init --template <name>`. Running `pad init` with no flag in a TTY opens an interactive picker grouped by category. Run `pad workspace init --list-templates` to see the current catalog.
-- See `PLAN-609` and `IDEA-583` in this workspace for the design history.
+- See `PLAN-609` and `IDEA-583` for original design history; `PLAN-1496` for the onboarding refactor.
 
 ## Playbooks
 
@@ -272,6 +275,42 @@ Playbooks are first-class invokable procedures. They live in the `playbooks` col
 - `web/src/lib/playbooks/arguments.ts` — `## Arguments` parser/generator, `INVOCATION_SLUG_PATTERN`, `buildTestInvocation`.
 
 See `PLAN-1377` (invocation model) and `PLAN-1397` (library overhaul) in this workspace for the design history.
+
+## Onboarding
+
+Workspace setup is driven by the canonical **`/pad onboard`** invokable library playbook (PLAN-1496 / TASK-1499). Pad does not run a baked-in CLI onboarding wizard; the playbook body IS the onboarding script, and any agent that can dispatch a playbook (Claude Code, MCP client, CLI) can run it.
+
+**Auto-seeded everywhere.** `pad workspace init` (with any non-blank `--template`) seeds the onboard playbook into the new workspace as `status=active, invocation_slug=onboard` (TASK-1500). The `blank` template ships it as the workspace's ONLY user-facing content. Empty-template-name workspace creation (`SeedCollectionsFromTemplate(ws, "")` — used by tests and direct API callers) intentionally skips the seed; see `internal/store/collections.go::SeedCollectionsFromTemplate` for the gating logic.
+
+**Surface-agnostic body.** The playbook body (`internal/collections/playbook_library_onboard.go::onboardPlaybookBody`) describes intent, not specific CLI commands. It instructs the agent to use whatever surface it has — `pad_item` MCP, `pad item` CLI, `pad_collection` MCP, etc. — and works for pure-MCP agents (no shell) the same as for Claude Code. The body covers four modes: `build` (blank workspace, build from scratch), `audit` (templated workspace, adapt seeded items), `revisit` (already-onboarded, change something specific), and `defaults` (escape hatch — pick sensible defaults and report).
+
+**Adaptation posture, not curation.** The body explicitly tells the agent: library entries are STARTING POINTS, not finished artifacts. Read the rule, rewrite using the project's actual commands and vocabulary. Invent when the library has nothing close. If the template seeded something that doesn't fit, edit or delete it. This is the core posture PLAN-1496 codifies — software templates seed generic "run the test suite" conventions, and `/pad onboard` rewrites them to `make test` / `go test ./...` / whatever the project actually uses.
+
+**Mutation primitives.** The adaptation posture depends on agent-facing mutation tools, exposed by TASK-1510 / TASK-1511 / TASK-1512:
+
+- `pad collection update <slug>` + `pad_collection.action: update` — rename collections, swap icons, reshape schemas (TASK-1510)
+- `pad collection delete <slug>` + `pad_collection.action: delete` — remove user-created collections that don't fit (TASK-1511)
+- `pad role update <slug>` + `pad_role.action: update` — rewrite role descriptions and icons (TASK-1512)
+
+Server handlers existed pre-PLAN-1496; these tasks just wired CLI subcommands and MCP catalog actions to the existing HTTP endpoints. All three are owner-only server-side.
+
+**`needs_onboarding` bootstrap flag.** `AgentBootstrap.NeedsOnboarding` (PLAN-1496 / TASK-1504) is true when the workspace has zero items with `source != 'template'` — i.e. nothing beyond what the template seeded. The agent skill (`skills/pad/SKILL.md`) renders a nudge when true: *"This workspace hasn't been set up yet — say `/pad onboard` to walk through setup."* The flag flips to false the moment any user/agent-created item exists; the nudge stops firing past that point. Computed per-request via `Store.WorkspaceHasUserCreatedItems(workspaceID)` (EXISTS-backed). PLAN-1496 / TASK-1505 also retired the standalone "Onboarding" workflow section from the skill — the playbook body owns that script now.
+
+**Retired surfaces.** The pre-PLAN-1496 design had several surfaces that the playbook replaces; all retired:
+
+- `pad onboard` Cobra subcommand (was: codebase scan + convention suggestions) — TASK-1502.
+- `OnboardingPrimaryRef` field on `WorkspaceTemplate` (was: named IDEA-1 / BACK-1 / FEAT-1 per template) — TASK-1502. Dashboard banner auto-discovers seeds via `item_number=1 + source='template'` if a future template ever wants to reintroduce them.
+- The `*OnboardingItems()` generators in `internal/collections/templates_onboarding*.go` (deleted files) — TASK-1501.
+- The skill's standalone "Onboarding" workflow section — TASK-1505. Replaced by a one-paragraph pointer at the playbook.
+
+**Code map:**
+
+- `internal/collections/playbook_library_onboard.go` — the canonical playbook body + `OnboardPlaybook()` library entry + `OnboardSeedPlaybook()` auto-seed.
+- `internal/collections/templates_blank.go` — minimal trigger/scope vocabularies for the blank template's seeded system collections.
+- `internal/store/collections.go::SeedCollectionsFromTemplate` — wires the auto-seed for every non-empty templateName.
+- `internal/store/items.go::WorkspaceHasUserCreatedItems` — the `needs_onboarding` query predicate.
+- `internal/server/handlers_bootstrap.go::AgentBootstrap.NeedsOnboarding` — the bootstrap field.
+- `skills/pad/SKILL.md` — the nudge-rendering rule in Context Loading; the routing entry under "set up my workspace".
 
 ## Testing
 

--- a/internal/server/handlers_bootstrap_test.go
+++ b/internal/server/handlers_bootstrap_test.go
@@ -106,6 +106,70 @@ func TestBootstrapNeedsOnboardingFlag(t *testing.T) {
 	}
 }
 
+// TestBootstrapBlankWorkspaceOnboardReady is the end-to-end happy-path
+// integration test for PLAN-1496. It ties together the three pieces a
+// fresh `blank` workspace needs for the agent-driven onboarding flow
+// to work on day one:
+//
+//  1. needs_onboarding == true so the skill renders the bootstrap nudge.
+//  2. The /pad onboard playbook is seeded into the workspace.
+//  3. The playbook is status=active (so slug routing dispatches to it).
+//
+// Each piece has its own focused test elsewhere (NeedsOnboardingFlag,
+// SeedFromTemplateAlwaysIncludesOnboardPlaybook,
+// OnboardPlaybook_Contract). This test is the integration smoke: if
+// any one of them silently regresses, /pad onboard breaks in a fresh
+// blank workspace and the design's premise collapses. PLAN-1496 /
+// TASK-1507.
+func TestBootstrapBlankWorkspaceOnboardReady(t *testing.T) {
+	srv := testServer(t)
+	rr := doRequest(srv, "POST", "/api/v1/workspaces", map[string]string{
+		"name":     "Blank Onboard Ready",
+		"template": "blank",
+	})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create blank workspace: %d %s", rr.Code, rr.Body.String())
+	}
+	var ws models.Workspace
+	parseJSON(t, rr, &ws)
+
+	rr = doRequest(srv, "GET", "/api/v1/workspaces/"+ws.Slug+"/agent/bootstrap", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("bootstrap: %d %s", rr.Code, rr.Body.String())
+	}
+	var b AgentBootstrap
+	parseJSON(t, rr, &b)
+
+	if !b.NeedsOnboarding {
+		t.Errorf("blank workspace: needs_onboarding = false, want true — the bootstrap nudge will never fire")
+	}
+
+	// Find the onboard playbook by its invocation_slug. The skill
+	// dispatches /pad onboard by slug-routing through this exact
+	// field; if it's missing or not active, slug routing falls
+	// through to NL and the playbook is effectively invisible.
+	var onboard *AgentBootstrapPlaybookMeta
+	for i := range b.Playbooks {
+		if b.Playbooks[i].InvocationSlug == "onboard" {
+			onboard = &b.Playbooks[i]
+			break
+		}
+	}
+	if onboard == nil {
+		titles := make([]string, 0, len(b.Playbooks))
+		for _, p := range b.Playbooks {
+			titles = append(titles, p.Title)
+		}
+		t.Fatalf("blank workspace bootstrap missing onboard playbook; got titles: %v", titles)
+	}
+	if onboard.Status != "active" {
+		t.Errorf("onboard playbook status = %q, want %q (slug routing only dispatches active playbooks)", onboard.Status, "active")
+	}
+	if onboard.Trigger != "manual" {
+		t.Errorf("onboard playbook trigger = %q, want %q (must be in the blank template's seeded vocabulary)", onboard.Trigger, "manual")
+	}
+}
+
 // TestBootstrapNeedsOnboardingIgnoresTemplateSeeds is a focused guard:
 // even when a templated workspace ships seeded items
 // (conventions/playbooks/the onboard playbook itself), they MUST NOT


### PR DESCRIPTION
## Summary

PLAN-1496's final consolidation pair — closes the plan out.

- **TASK-1507** — adds one integration smoke test (\`TestBootstrapBlankWorkspaceOnboardReady\`) that ties the three onboarding subsystems together at the bootstrap layer. Most of the focused test coverage already landed incrementally in PRs #575, #576, #577, #578.
- **TASK-1508** — updates \`CLAUDE.md\` to document the new onboarding model: Blank in the Templates section, the agent/bootstrap endpoint in the API list (with needs_onboarding callout), and a new top-level \"Onboarding\" section between Playbooks and Testing.

## Changes

### Test
- **\`internal/server/handlers_bootstrap_test.go\`** — \`TestBootstrapBlankWorkspaceOnboardReady\`: creates a blank-template workspace, fetches bootstrap, asserts \`needs_onboarding=true\` AND onboard playbook is in \`bootstrap.playbooks\` AND \`status=\"active\"\` AND \`trigger=\"manual\"\`. Catches silent regressions across the three integrated subsystems.

### Docs
- **\`CLAUDE.md\`** Data Model / Templates: Blank added under new \"Custom\" category; pre-PLAN-1496 IDEA-1/BACK-1/FEAT-1 retirement called out; PLAN-1496 added to design history references.
- **\`CLAUDE.md\`** API: \`GET /api/v1/workspaces/{ws}/agent/bootstrap\` endpoint added with \`needs_onboarding\` callout.
- **\`CLAUDE.md\`** new \"Onboarding\" section: auto-seed everywhere, surface-agnostic body, adaptation posture, the three TASK-1510/1511/1512 mutation primitives, \`needs_onboarding\` + skill nudge, four retired surfaces, code map.

## Test plan

- [x] \`go test ./...\` clean (full suite passes including the new integration test)
- [x] \`golangci-lint\` 0 issues
- [x] The new integration test exercises all four parts of the contract (flag, presence, status, trigger)

Parent: PLAN-1496. Closes out the plan.