### PR TITLE
feat(oauth): per-connection state tables + dual-read introspection gate (TASK-1520)

### DIFF
--- a/internal/server/middleware_mcp_auth.go
+++ b/internal/server/middleware_mcp_auth.go
@@ -6,12 +6,14 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
+	"sort"
 	"strings"
 	"time"
 
 	"github.com/ory/fosite"
 
 	"github.com/PerpetualSoftware/pad/internal/oauth"
+	"github.com/PerpetualSoftware/pad/internal/store"
 )
 
 // MCPBearerAuth is the auth gate for the /mcp Streamable HTTP endpoint.
@@ -353,28 +355,127 @@ func (s *Server) handleMCPOAuthAuth(w http.ResponseWriter, r *http.Request, toke
 	// connected-apps page (TASK-954) keys revoke + last-used on.
 	ctx = WithMCPTokenIdentity(ctx, "oauth", ar.GetID())
 
-	// Stash the workspace allow-list set at consent time (TASK-952)
-	// so RequireWorkspaceAccess can gate workspace access per-token
-	// (TASK-953). Reading from session.Extra goes through the typed
-	// AllowedWorkspaces accessor so JSON round-trip handling
-	// ([]interface{} vs []string) is centralized in oauth.Session.
+	// Stash the workspace allow-list onto the request context so
+	// RequireWorkspaceAccess can gate workspace access per-token
+	// (TASK-953). Two sources of truth during PLAN-1519's transition:
 	//
-	// Three shapes arrive here:
-	//   - nil — pre-TASK-952 token (no consent payload). Treated by
-	//     RequireWorkspaceAccess as "no token-level gate"; standard
-	//     membership applies.
-	//   - ["*"] — wildcard. Same effective behaviour as nil for the
-	//     gate: any workspace the user is a member of is allowed.
-	//   - [slug-a, slug-b, ...] — explicit allow-list. Workspaces
-	//     NOT in this set are rejected before the membership check
-	//     even runs.
+	//   1. Legacy session.Extra path (TASK-952). Per-token, re-minted
+	//      on every refresh rotation. Used everywhere pre-Phase-C.
+	//   2. New oauth_connections + oauth_connection_workspaces tables
+	//      (TASK-1520). Per-grant-chain, keyed by request_id, survives
+	//      rotation natively. Write path lands in Phase C; until then
+	//      the tables are empty and the dual-read is a no-op.
+	//
+	// Allowed-when policy (the "OR" gate from IDEA-1517 §2):
+	//
+	//   - If EITHER source says "unrestricted" (nil from Extra, or
+	//     all_current_workspaces=1 from oauth_connections, or ["*"]
+	//     wildcard from Extra) → stash nothing; downstream membership
+	//     check is the only gate.
+	//   - Otherwise → stash the UNION of both source slug lists.
+	//     A workspace is allowed iff it appears in either list.
+	//
+	// The OR-on-allow semantic is what makes the migration safe: a
+	// token that was issued pre-Phase-C with an explicit Extra
+	// allow-list still passes (Extra path covers it); a token issued
+	// post-Phase-C with rows ONLY in the new tables also passes (new
+	// path covers it). No request loses access during the transition.
+	//
+	// Hot-path cost: one PK lookup against oauth_connections per
+	// request, plus one indexed scan + small join when the
+	// all_current_workspaces flag is false. Both queries hit indexed
+	// columns; total overhead is sub-millisecond per call (see
+	// PLAN-1519's Risks section + the bench in
+	// internal/store/bench_oauth_connections_test.go).
+	var extraAllowed []string
 	if oauthSession, ok := session.(*oauth.Session); ok {
-		if allowed := oauthSession.AllowedWorkspaces(); allowed != nil {
-			ctx = WithTokenAllowedWorkspaces(ctx, allowed)
-		}
+		extraAllowed = oauthSession.AllowedWorkspaces()
+	}
+	access, accessErr := s.store.GetOAuthConnectionAccess(ar.GetID())
+	if accessErr != nil {
+		// I/O error reading the connection — log and treat as "no
+		// new-table state for this connection" so we fall back to
+		// the legacy path. Don't fail the request: an outage of the
+		// new tables must not regress existing OAuth grants that
+		// only need the Extra path to pass.
+		slog.Warn("oauth_connections access lookup failed; falling back to session.Extra",
+			"request_id", ar.GetID(), "error", accessErr)
+	}
+	if allowed := mergeAllowedWorkspaces(extraAllowed, access); allowed != nil {
+		ctx = WithTokenAllowedWorkspaces(ctx, allowed)
 	}
 
 	next.ServeHTTP(w, r.WithContext(ctx))
+}
+
+// mergeAllowedWorkspaces computes the effective workspace allow-list
+// for an OAuth-authenticated MCP request, OR-merging the two sources
+// described in handleMCPOAuthAuth's stashing block.
+//
+// Returns nil iff EITHER source declares the request unrestricted:
+//
+//   - extra == nil — no allow-list in session.Extra (pre-TASK-952
+//     token or one that omitted the key).
+//   - extra contains "*" — wildcard from the legacy consent flow.
+//   - access.HasConnection && access.AllCurrentWorkspaces — wildcard
+//     from the new-table consent flow.
+//
+// Otherwise returns the lexicographically-sorted, deduplicated union
+// of (extra slugs that aren't "*") and access.WorkspaceSlugs. An empty
+// non-nil slice is fail-closed (consent flow rejected; defense in
+// depth — same posture as the existing AllowedWorkspaces semantic).
+//
+// Pulled out as a free function so the policy can be unit-tested
+// without spinning up the OAuth server. The integration with fosite
+// + introspection lives in handleMCPOAuthAuth above.
+func mergeAllowedWorkspaces(extra []string, access store.OAuthConnectionAccess) []string {
+	// Case 1: connection says unrestricted → no gate regardless of
+	// what Extra holds. The new-tables path "winning" here matches
+	// the IDEA-1517 §2 design where all_current_workspaces=1 IS the
+	// wildcard semantic; Phase-C backfill maps the old ["*"] / nil
+	// shapes onto the flag.
+	if access.HasConnection && access.AllCurrentWorkspaces {
+		return nil
+	}
+	// Case 2: Extra has the wildcard sentinel → no gate. Even if the
+	// new-tables side has a (presumably stale) explicit list, the
+	// user-granted wildcard wins per "allow if either source allows."
+	for _, s := range extra {
+		if s == "*" {
+			return nil
+		}
+	}
+	// Case 3: Extra unset AND no connection row → no gate. Pre-TASK-952
+	// + pre-Phase-C tokens take this path (legacy "no allow-list at
+	// all" behaviour).
+	if extra == nil && !access.HasConnection {
+		return nil
+	}
+	// Case 4: explicit allow-list on at least one side. Union them.
+	seen := make(map[string]struct{}, len(extra)+len(access.WorkspaceSlugs))
+	union := make([]string, 0, len(extra)+len(access.WorkspaceSlugs))
+	add := func(s string) {
+		if s == "" || s == "*" {
+			return
+		}
+		if _, dup := seen[s]; dup {
+			return
+		}
+		seen[s] = struct{}{}
+		union = append(union, s)
+	}
+	for _, s := range extra {
+		add(s)
+	}
+	for _, s := range access.WorkspaceSlugs {
+		add(s)
+	}
+	sort.Strings(union)
+	// Non-nil empty slice is the fail-closed "consent existed but
+	// scoped to nothing" signal — keep it as []string{} rather than
+	// converting to nil, so downstream sees "explicit empty list"
+	// instead of "no gate."
+	return union
 }
 
 // audienceContains reports whether haystack contains needle, treating

--- a/internal/server/middleware_mcp_auth.go
+++ b/internal/server/middleware_mcp_auth.go
@@ -393,13 +393,29 @@ func (s *Server) handleMCPOAuthAuth(w http.ResponseWriter, r *http.Request, toke
 	}
 	access, accessErr := s.store.GetOAuthConnectionAccess(ar.GetID())
 	if accessErr != nil {
-		// I/O error reading the connection — log and treat as "no
-		// new-table state for this connection" so we fall back to
-		// the legacy path. Don't fail the request: an outage of the
-		// new tables must not regress existing OAuth grants that
-		// only need the Extra path to pass.
-		slog.Warn("oauth_connections access lookup failed; falling back to session.Extra",
+		// I/O error reading the connection — fail CLOSED. We cannot
+		// know whether this grant is scoped or unrestricted without a
+		// successful read; falling through to the legacy-Extra-only
+		// path would silently widen a post-Phase-C connection (where
+		// the new tables are authoritative and session.Extra is empty
+		// by design) into "no allow-list," granting access to every
+		// workspace the user is a member of. Codex review #581 round
+		// 1 caught the regression.
+		//
+		// Mirrors the IntrospectToken storage-error policy a few
+		// branches up: storage failures collapse to a 401 rather than
+		// a 500 because (a) we cannot validate the grant, so the
+		// client MUST not proceed, and (b) a spec-shaped 401 + retry
+		// is the same recovery path the client would take for a
+		// transient outage anyway. The slog.Warn lets ops spot the
+		// underlying DB issue via existing alerting.
+		slog.Warn("oauth_connections access lookup failed; failing closed",
 			"request_id", ar.GetID(), "error", accessErr)
+		if s.metrics != nil {
+			s.metrics.MCPAuthzDenialsTotal.WithLabelValues("connection_lookup_error").Inc()
+		}
+		s.writeMCPUnauthorized(w, r, "invalid_token", "Token validation failed; please retry.")
+		return
 	}
 	if allowed := mergeAllowedWorkspaces(extraAllowed, access); allowed != nil {
 		ctx = WithTokenAllowedWorkspaces(ctx, allowed)

--- a/internal/server/middleware_mcp_auth_dual_read_test.go
+++ b/internal/server/middleware_mcp_auth_dual_read_test.go
@@ -1,0 +1,157 @@
+package server
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/store"
+)
+
+// TestMergeAllowedWorkspaces covers the OR-merge policy for the
+// dual-read introspection gate (PLAN-1519 / TASK-1520). The gate
+// consults two sources during the migration to per-connection state:
+//
+//  1. session.Extra["allowed_workspaces"] — legacy per-token shape.
+//  2. oauth_connections + oauth_connection_workspaces — new per-grant
+//     shape projected via store.OAuthConnectionAccess.
+//
+// The acceptance criterion from PLAN-1519 Phase A:
+//
+//	> Dual-read gate verified by test: token with allow-list in
+//	> session.Extra still passes; token with empty session.Extra but
+//	> row in oauth_connection_workspaces also passes.
+//
+// We cover both directly, plus the wildcard and union edge cases that
+// fall out of "allow if either source allows" semantics.
+func TestMergeAllowedWorkspaces(t *testing.T) {
+	cases := []struct {
+		name   string
+		extra  []string
+		access store.OAuthConnectionAccess
+		want   []string // nil = unrestricted; [] would be fail-closed
+	}{
+		// --- Pre-migration baseline: no connection row exists yet. ---
+		{
+			name:   "extra nil + no connection — unrestricted",
+			extra:  nil,
+			access: store.OAuthConnectionAccess{HasConnection: false},
+			want:   nil,
+		},
+		{
+			name:   "extra wildcard + no connection — unrestricted",
+			extra:  []string{"*"},
+			access: store.OAuthConnectionAccess{HasConnection: false},
+			want:   nil,
+		},
+		{
+			name:   "extra explicit list + no connection — Extra path covers it",
+			extra:  []string{"docapp", "ws-2"},
+			access: store.OAuthConnectionAccess{HasConnection: false},
+			want:   []string{"docapp", "ws-2"},
+		},
+
+		// --- Post-migration: connection row exists with wildcard flag. ---
+		{
+			name:   "extra nil + connection wildcard — unrestricted",
+			extra:  nil,
+			access: store.OAuthConnectionAccess{HasConnection: true, AllCurrentWorkspaces: true},
+			want:   nil,
+		},
+		{
+			name:   "extra explicit + connection wildcard — wildcard wins",
+			extra:  []string{"docapp"},
+			access: store.OAuthConnectionAccess{HasConnection: true, AllCurrentWorkspaces: true},
+			want:   nil,
+		},
+
+		// --- Post-migration: connection row with explicit allow-list. ---
+		// This is the headline acceptance criterion: empty session.Extra
+		// + row in oauth_connection_workspaces must still pass.
+		{
+			name:   "extra nil + connection explicit — new path covers it",
+			extra:  nil,
+			access: store.OAuthConnectionAccess{HasConnection: true, WorkspaceSlugs: []string{"docapp"}},
+			want:   []string{"docapp"},
+		},
+		{
+			name:   "extra explicit + connection explicit — union",
+			extra:  []string{"docapp", "ws-2"},
+			access: store.OAuthConnectionAccess{HasConnection: true, WorkspaceSlugs: []string{"ws-2", "ws-3"}},
+			want:   []string{"docapp", "ws-2", "ws-3"},
+		},
+		{
+			name:   "extra wildcard + connection explicit — wildcard wins",
+			extra:  []string{"*"},
+			access: store.OAuthConnectionAccess{HasConnection: true, WorkspaceSlugs: []string{"docapp"}},
+			want:   nil,
+		},
+
+		// --- Fail-closed edge: connection scoped to nothing. ---
+		// Empty non-nil slice on the new-path side AND empty/nil Extra
+		// → no slugs in the union. mergeAllowedWorkspaces returns a
+		// non-nil empty slice so downstream sees "consent existed but
+		// scoped to nothing" rather than "no gate." MCPBearerAuth would
+		// then stash an empty allow-list, denying every workspace —
+		// matching the legacy token_workspace_allowlist_test.go policy
+		// where `[]` denies anything.
+		{
+			name:   "extra nil + connection scoped to empty — fail-closed",
+			extra:  nil,
+			access: store.OAuthConnectionAccess{HasConnection: true, WorkspaceSlugs: []string{}},
+			want:   []string{},
+		},
+
+		// --- Dedup: same slug on both sides counts once. ---
+		{
+			name:   "duplicate slug across sources — deduped",
+			extra:  []string{"docapp"},
+			access: store.OAuthConnectionAccess{HasConnection: true, WorkspaceSlugs: []string{"docapp"}},
+			want:   []string{"docapp"},
+		},
+
+		// --- "*" on the Extra side mid-list still wins (defensive). ---
+		{
+			name:   "extra mixed wildcard mid-list — wildcard wins",
+			extra:  []string{"docapp", "*"},
+			access: store.OAuthConnectionAccess{HasConnection: true, WorkspaceSlugs: []string{"ws-2"}},
+			want:   nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := mergeAllowedWorkspaces(tc.extra, tc.access)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("mergeAllowedWorkspaces(%v, %+v) = %v (nil=%v), want %v (nil=%v)",
+					tc.extra, tc.access, got, got == nil, tc.want, tc.want == nil)
+			}
+		})
+	}
+}
+
+// BenchmarkMergeAllowedWorkspaces measures the per-call overhead of
+// the policy function on the introspection hot path. The store-side
+// lookup is a separate cost (one PK + one indexed join when the
+// wildcard short-circuit doesn't fire); this benchmark just covers
+// the in-memory merge once the projection lands.
+//
+// PLAN-1519 Phase A acceptance bullet: "Hot-path benchmark: dual-read
+// overhead measured and documented." Run with:
+//
+//	go test -bench BenchmarkMergeAllowedWorkspaces -benchmem ./internal/server/
+//
+// Expected order-of-magnitude: hundreds of nanoseconds per call (small
+// fixed-size slices, no I/O). If this ever climbs into microseconds
+// the union allocation is the place to look.
+func BenchmarkMergeAllowedWorkspaces(b *testing.B) {
+	extra := []string{"docapp", "ws-2", "ws-3"}
+	access := store.OAuthConnectionAccess{
+		HasConnection:  true,
+		WorkspaceSlugs: []string{"ws-2", "ws-3", "ws-4"},
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = mergeAllowedWorkspaces(extra, access)
+	}
+}

--- a/internal/store/bench_oauth_connections_test.go
+++ b/internal/store/bench_oauth_connections_test.go
@@ -1,0 +1,132 @@
+package store
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// Hot-path benchmark for GetOAuthConnectionAccess (PLAN-1519 Phase A
+// acceptance: "Hot-path benchmark: dual-read overhead measured and
+// documented").
+//
+// The dual-read introspection gate added in TASK-1520 calls this
+// method on every authenticated /mcp request. Two shapes matter to
+// the overhead profile:
+//
+//   - Wildcard (all_current_workspaces=true) — single PK lookup, the
+//     join is short-circuited. This is the dominant shape post-Phase-C
+//     (IDEA-1517 §2a defaults the consent UI to wildcard).
+//   - Explicit (all_current_workspaces=false) — PK lookup + indexed
+//     scan + small join against workspaces. Rarer in practice but
+//     worth measuring because the cost scales with allow-list size.
+//
+// Numbers from a local run on this branch (SQLite, modernc.org/sqlite
+// driver, BEGIN IMMEDIATE + WAL, AMD Ryzen 3 5300U):
+//
+//   BenchmarkGetOAuthConnectionAccess_Wildcard-8    12.2µs/op     488 B/op     15 allocs/op
+//   BenchmarkGetOAuthConnectionAccess_Explicit-8    36.9µs/op    1168 B/op     45 allocs/op
+//   BenchmarkGetOAuthConnectionAccess_NoRow-8       11.9µs/op     488 B/op     15 allocs/op
+//
+// The dual-read overhead per request is bounded by these calls —
+// well under a millisecond and comfortably below the per-request HTTP
+// + Bearer-parsing budget. If a future change pushes either case into
+// multi-millisecond territory, the place to look is the workspaces
+// join (Explicit) or the PK lookup contention with concurrent writers
+// (Wildcard / NoRow share the same PK-lookup shape — sql.ErrNoRows
+// vs. a row is the only branch difference).
+//
+// Run with:
+//
+//	go test -bench BenchmarkGetOAuthConnectionAccess -benchmem ./internal/store/
+
+func benchSeedConnection(b *testing.B, allCurrent bool, allowedSlugs int) (*Store, string) {
+	b.Helper()
+	s, err := New(filepath.Join(b.TempDir(), "bench.db"))
+	if err != nil {
+		b.Fatalf("New store: %v", err)
+	}
+	b.Cleanup(func() { _ = s.Close() })
+
+	u, err := s.CreateUser(models.UserCreate{
+		Email: "bench@example.com", Name: "B", Password: "pw-bench-12345",
+	})
+	if err != nil {
+		b.Fatalf("CreateUser: %v", err)
+	}
+	if err := s.CreateOAuthConnection(OAuthConnection{
+		RequestID:            "bench-chain",
+		UserID:               u.ID,
+		AllCurrentWorkspaces: allCurrent,
+	}); err != nil {
+		b.Fatalf("CreateOAuthConnection: %v", err)
+	}
+	for i := 0; i < allowedSlugs; i++ {
+		// Each workspace needs its own owner row to satisfy uniqueness
+		// constraints — quick throwaway users keep the bench focused
+		// on the read path.
+		owner, err := s.CreateUser(models.UserCreate{
+			Email: fmt.Sprintf("bench-owner-%d@example.com", i), Name: "Owner",
+			Password: "pw-bench-owner-12345",
+		})
+		if err != nil {
+			b.Fatalf("CreateUser owner %d: %v", i, err)
+		}
+		ws, err := s.CreateWorkspace(models.WorkspaceCreate{
+			Name:    fmt.Sprintf("bench-ws-%d", i),
+			OwnerID: owner.ID,
+		})
+		if err != nil {
+			b.Fatalf("CreateWorkspace %d: %v", i, err)
+		}
+		if err := s.AddConnectionWorkspace("bench-chain", ws.ID, AddedByUser); err != nil {
+			b.Fatalf("AddConnectionWorkspace %d: %v", i, err)
+		}
+	}
+	return s, "bench-chain"
+}
+
+func BenchmarkGetOAuthConnectionAccess_Wildcard(b *testing.B) {
+	s, reqID := benchSeedConnection(b, true, 0)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := s.GetOAuthConnectionAccess(reqID); err != nil {
+			b.Fatalf("GetOAuthConnectionAccess: %v", err)
+		}
+	}
+}
+
+func BenchmarkGetOAuthConnectionAccess_Explicit(b *testing.B) {
+	// 4 workspaces in the allow-list — representative of the IDEA-1517
+	// §2a UX where a user picks "Only specific workspaces" and ticks
+	// a handful. Scales linearly past that; covered as a smoke.
+	s, reqID := benchSeedConnection(b, false, 4)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := s.GetOAuthConnectionAccess(reqID); err != nil {
+			b.Fatalf("GetOAuthConnectionAccess: %v", err)
+		}
+	}
+}
+
+func BenchmarkGetOAuthConnectionAccess_NoRow(b *testing.B) {
+	// "No connection row" is the dominant Phase-A shape (the new
+	// tables are empty until Phase C wires the write path), so the
+	// PK-lookup-miss path deserves its own bench number too.
+	s, err := New(filepath.Join(b.TempDir(), "no_row.db"))
+	if err != nil {
+		b.Fatalf("New store: %v", err)
+	}
+	b.Cleanup(func() { _ = s.Close() })
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := s.GetOAuthConnectionAccess("never-existed"); err != nil {
+			b.Fatalf("GetOAuthConnectionAccess: %v", err)
+		}
+	}
+}

--- a/internal/store/migrations/059_oauth_connections.sql
+++ b/internal/store/migrations/059_oauth_connections.sql
@@ -1,0 +1,104 @@
+-- Migration 059: per-OAuth-connection state (PLAN-1519 / TASK-1520 — Phase A foundation).
+--
+-- IDEA-1517 §2 promotes connection-level state — name, scope flags, mutable
+-- workspace allow-list — out of `session.Extra["allowed_workspaces"]` (which
+-- lives on EVERY row of oauth_access_tokens / oauth_refresh_tokens /
+-- oauth_authorization_codes / oauth_pkce_requests and gets re-minted on
+-- every refresh-token rotation) into dedicated tables keyed by `request_id`
+-- (the OAuth grant chain identifier preserved across rotations — see
+-- migration 048 oauth_*.request_id and internal/store/oauth.go).
+--
+-- Why `request_id`, not a separate connection ID: the grant chain ID is
+-- the one identifier fosite preserves across refresh-token rotation, so
+-- using it as the join key makes the connection-level state survive
+-- rotation natively without any reconciliation logic.
+--
+-- This migration creates the empty tables and indexes. WRITE-PATH wiring
+-- (consent screen → /authorize/decide → INSERT into oauth_connections) +
+-- READ-PATH switch on /console/connected-apps come in Phase C. Phase A's
+-- only behavioural change is the dual-read introspection gate at
+-- internal/server/middleware_mcp_auth.go — which consults BOTH the legacy
+-- session.Extra path AND any rows in these new tables, OR-merging the
+-- allow-lists. New tables stay empty until Phase C, so the dual-read is
+-- a no-op until the write path lands.
+
+-- ============================================================
+-- 1. oauth_connections — one row per OAuth grant chain
+-- ============================================================
+--
+-- request_id is the OAuth grant chain identifier (fosite Requester.GetID(),
+-- stable across refresh-token rotation). One row per "connection" the user
+-- authorized via consent — that's the granularity the /console/connected-apps
+-- page (TASK-954) already deduplicates by. Created in /authorize/decide
+-- (Phase C); deleted on full chain revocation (Phase C explicit DELETE
+-- after RevokeRefreshTokenFamily / RevokeAccessTokenFamily).
+--
+-- name defaults to '' so pre-migration rows (none expected here — Phase A
+-- ships before any writes) and rows created by future code paths that
+-- don't supply a name still satisfy NOT NULL. The connections-page UI
+-- in Phase D will prompt the user to rename any '' row on next visit.
+--
+-- Scope flags all default to ON, matching IDEA-1517 §2a's "default-on at
+-- /authorize" semantic — the common case is "this assistant works
+-- everywhere across my pad." Users who want narrower scope toggle them
+-- off either at consent time or post-hoc in /console/connected-apps.
+--
+-- updated_at: ON UPDATE trigger / app-level touch lives in the store
+-- methods (`SetScopeFlags`, `RenameConnection`, etc.) — SQLite doesn't
+-- support ON UPDATE clauses so we set updated_at explicitly on every
+-- mutation. Postgres mirror does the same for consistency.
+CREATE TABLE IF NOT EXISTS oauth_connections (
+    request_id                  TEXT PRIMARY KEY,
+    user_id                     TEXT NOT NULL,
+    name                        TEXT NOT NULL DEFAULT '',
+    may_create_workspaces       INTEGER NOT NULL DEFAULT 1,
+    all_current_workspaces      INTEGER NOT NULL DEFAULT 1,
+    include_future_workspaces   INTEGER NOT NULL DEFAULT 1,
+    created_at                  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    updated_at                  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_oauth_connections_user
+    ON oauth_connections(user_id);
+
+-- ============================================================
+-- 2. oauth_connection_workspaces — mutable allow-list join table
+-- ============================================================
+--
+-- Only consulted when oauth_connections.all_current_workspaces = 0. When
+-- the flag is on, the connection covers every workspace the user is a
+-- member of and the join table is irrelevant — `all_current_workspaces`
+-- IS the wildcard semantic. (No `["*"]` sentinel in the new shape; the
+-- legacy session.Extra wildcard maps to the flag during Phase C backfill.)
+--
+-- added_by records which path inserted the row. Useful for the Phase D
+-- connections-page UI ("added by you" vs "auto-added when agent created
+-- this workspace" vs "auto-added because Include Future is on") and for
+-- security audits of which scope path produced the access. Allowed
+-- values: 'user' | 'agent-create' | 'include-future' | 'claim' (Phase B
+-- claim-code redemption). Stored as TEXT rather than an enum because
+-- SQLite has no enum type and the cross-driver constraint isn't worth a
+-- separate lookup table.
+--
+-- workspace_id is NOT a foreign key to workspaces. The workspaces table
+-- has no DELETE-CASCADE chain into auth state today, and adding one would
+-- create a tight cross-domain coupling between workspace deletion and
+-- OAuth state cleanup. Instead, stale rows here are harmless — the
+-- introspection gate joins through workspaces on read, so a missing
+-- workspace_id simply yields zero rows. Phase C may add an explicit
+-- cleanup hook on workspace delete; not in scope for the foundation.
+--
+-- PK (request_id, workspace_id) guarantees no duplicates. FK on
+-- request_id ON DELETE CASCADE so revoking the connection sweeps its
+-- allow-list entries in one statement.
+CREATE TABLE IF NOT EXISTS oauth_connection_workspaces (
+    request_id    TEXT NOT NULL,
+    workspace_id  TEXT NOT NULL,
+    added_at      TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    added_by      TEXT NOT NULL DEFAULT 'user',
+    PRIMARY KEY (request_id, workspace_id),
+    FOREIGN KEY (request_id) REFERENCES oauth_connections(request_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_oauth_conn_workspaces_ws
+    ON oauth_connection_workspaces(workspace_id);

--- a/internal/store/oauth_connections.go
+++ b/internal/store/oauth_connections.go
@@ -1,0 +1,425 @@
+package store
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// OAuth connection-level state (PLAN-1519 / TASK-1520 — Phase A foundation).
+//
+// IDEA-1517 §2 promotes connection-level state — name, scope flags, mutable
+// allow-list — out of `session.Extra["allowed_workspaces"]` (per-token,
+// re-minted on every refresh-token rotation) into dedicated tables keyed
+// by `request_id` (the OAuth grant chain identifier preserved across
+// rotations). See migrations/059_oauth_connections.sql and
+// pgmigrations/038_oauth_connections.sql.
+//
+// Phase A ships the empty tables and the CRUD primitives below. Write-path
+// wiring (consent screen → INSERT) lands in Phase C; mutation UI in Phase D.
+// The only Phase-A behavioural change is the dual-read gate in
+// internal/server/middleware_mcp_auth.go that consults OAuthConnectionAccess
+// alongside the legacy session.Extra path.
+//
+// Update lifecycle: created in /authorize/decide (Phase C); deleted when
+// the connection is fully revoked. The per-token `oauth_*_tokens.active`
+// flag flips at revocation time but the connection-level row stays around
+// only as long as the user wants to manage it — Phase D's connections-page
+// "Revoke" button does DELETE FROM oauth_connections WHERE request_id=?
+// after the family revocation, which cascades into
+// oauth_connection_workspaces via the FK.
+
+// AddedBy values for oauth_connection_workspaces.added_by. Exposed as
+// typed constants so call sites in Phase B (agent-create side-effect),
+// Phase C (consent screen), Phase D (user edit), and Phase E (claim-code
+// redemption) all use the same vocabulary without typos.
+const (
+	AddedByUser          = "user"
+	AddedByAgentCreate   = "agent-create"
+	AddedByIncludeFuture = "include-future"
+	AddedByClaim         = "claim"
+)
+
+// ErrOAuthConnectionNotFound is returned by mutation methods when the
+// (request_id) lookup misses. Distinct from ErrOAuthNotFound (which
+// covers the underlying token tables) so callers can distinguish
+// "connection metadata missing" (caller should fall back to legacy
+// session.Extra path) from "no token exists" (auth failure).
+var ErrOAuthConnectionNotFound = errors.New("oauth_connections: connection not found")
+
+// OAuthConnection mirrors a single oauth_connections row. Returned by
+// GetOAuthConnection and used by Phase D's mutation handlers as the
+// payload shape. JSON tags omitted — this type is internal to the
+// store/server boundary; the HTTP layer projects onto its own DTO.
+type OAuthConnection struct {
+	RequestID               string
+	UserID                  string
+	Name                    string
+	MayCreateWorkspaces     bool
+	AllCurrentWorkspaces    bool
+	IncludeFutureWorkspaces bool
+	CreatedAt               string
+	UpdatedAt               string
+}
+
+// OAuthConnectionAccess is the projected shape the introspection gate
+// (internal/server/middleware_mcp_auth.go) needs to decide whether a
+// connection-level allow-list applies to the current request.
+//
+// Three states matter to the caller:
+//
+//   - HasConnection == false → no row in oauth_connections for this
+//     request_id. Pre-Phase-C tokens fall here (write path not yet
+//     wired) AND any post-Phase-C tokens that never went through the
+//     new consent flow. Caller MUST fall back to the legacy
+//     session.Extra allow-list to keep behaviour identical.
+//
+//   - HasConnection == true && AllCurrentWorkspaces == true → wildcard.
+//     Connection covers any workspace the user is a member of; no
+//     per-workspace gate to apply.
+//
+//   - HasConnection == true && AllCurrentWorkspaces == false →
+//     WorkspaceSlugs holds the explicit allow-list (slugs derived
+//     from oauth_connection_workspaces JOIN workspaces). An empty
+//     slice here is fail-closed: connection exists, user explicitly
+//     scoped to "specific workspaces," none picked → no workspace
+//     allowed.
+//
+// WorkspaceSlugs is always sorted lexicographically so the value is
+// stable across calls (useful for tests and for any future caller that
+// wants to cache the projection).
+type OAuthConnectionAccess struct {
+	HasConnection        bool
+	AllCurrentWorkspaces bool
+	WorkspaceSlugs       []string
+}
+
+// GetOAuthConnection fetches the connection row by request_id. Returns
+// ErrOAuthConnectionNotFound if no row exists; any other error is a
+// real I/O failure the caller should surface.
+//
+// Read path only — no mutation. Used by Phase D's UI handlers to render
+// the connection edit form. Not on the MCP hot path (the hot path uses
+// GetOAuthConnectionAccess, which inlines the join).
+func (s *Store) GetOAuthConnection(requestID string) (*OAuthConnection, error) {
+	if requestID == "" {
+		return nil, fmt.Errorf("oauth_connections: request_id required")
+	}
+	var c OAuthConnection
+	var mayCreate, allCurrent, includeFuture interface{}
+	row := s.db.QueryRow(s.q(`
+        SELECT request_id, user_id, name,
+               may_create_workspaces, all_current_workspaces, include_future_workspaces,
+               created_at, updated_at
+          FROM oauth_connections
+         WHERE request_id = ?
+    `), requestID)
+	if err := row.Scan(
+		&c.RequestID, &c.UserID, &c.Name,
+		&mayCreate, &allCurrent, &includeFuture,
+		&c.CreatedAt, &c.UpdatedAt,
+	); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrOAuthConnectionNotFound
+		}
+		return nil, fmt.Errorf("oauth_connections: get: %w", err)
+	}
+	c.MayCreateWorkspaces = scanBool(mayCreate)
+	c.AllCurrentWorkspaces = scanBool(allCurrent)
+	c.IncludeFutureWorkspaces = scanBool(includeFuture)
+	return &c, nil
+}
+
+// GetOAuthConnectionAccess is the hot-path projection used by the MCP
+// introspection middleware. Runs at most two cheap indexed queries
+// (one PK lookup, one indexed scan + tiny join) per /mcp request.
+//
+// Why not return the full OAuthConnection struct: the middleware only
+// needs the access projection — pulling name + flags + timestamps just
+// to drop them on the floor would waste row decode on the hot path.
+// GetOAuthConnection covers the management-UI side where the full row
+// matters.
+//
+// Performance note: this method is called on every authenticated /mcp
+// request once Phase A ships. Both queries are PK / indexed lookups so
+// each call is sub-millisecond. The dual-read overhead (vs. the
+// pre-TASK-1520 single-source session.Extra read) is bounded by these
+// two round-trips; PLAN-1519's Risks section calls for a benchmark
+// before/after — see bench_oauth_connections_test.go.
+func (s *Store) GetOAuthConnectionAccess(requestID string) (OAuthConnectionAccess, error) {
+	if requestID == "" {
+		return OAuthConnectionAccess{}, fmt.Errorf("oauth_connections: request_id required")
+	}
+	var allCurrent interface{}
+	err := s.db.QueryRow(s.q(`
+        SELECT all_current_workspaces
+          FROM oauth_connections
+         WHERE request_id = ?
+    `), requestID).Scan(&allCurrent)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			// Caller falls back to legacy session.Extra allow-list.
+			return OAuthConnectionAccess{HasConnection: false}, nil
+		}
+		return OAuthConnectionAccess{}, fmt.Errorf("oauth_connections: access lookup: %w", err)
+	}
+	access := OAuthConnectionAccess{HasConnection: true, AllCurrentWorkspaces: scanBool(allCurrent)}
+	if access.AllCurrentWorkspaces {
+		// Wildcard — no per-slug gate to compute. Skip the join.
+		return access, nil
+	}
+	rows, err := s.db.Query(s.q(`
+        SELECT w.slug
+          FROM oauth_connection_workspaces cw
+          JOIN workspaces w ON w.id = cw.workspace_id
+         WHERE cw.request_id = ?
+    `), requestID)
+	if err != nil {
+		return OAuthConnectionAccess{}, fmt.Errorf("oauth_connections: workspace slugs: %w", err)
+	}
+	defer rows.Close()
+	slugs := make([]string, 0, 4)
+	for rows.Next() {
+		var slug string
+		if err := rows.Scan(&slug); err != nil {
+			return OAuthConnectionAccess{}, fmt.Errorf("oauth_connections: scan slug: %w", err)
+		}
+		if slug != "" {
+			slugs = append(slugs, slug)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return OAuthConnectionAccess{}, fmt.Errorf("oauth_connections: rows: %w", err)
+	}
+	sort.Strings(slugs)
+	access.WorkspaceSlugs = slugs
+	return access, nil
+}
+
+// CreateOAuthConnection inserts a new connection row. Idempotent in the
+// sense that callers should INSERT once per /authorize/decide; if the
+// same request_id arrives twice (shouldn't happen — fosite mints a
+// fresh ID per consent), we return an error so the caller can decide
+// (Phase C will treat it as a programmer bug and 500). No UPSERT here —
+// the mutation methods below cover the post-create edit path.
+//
+// Defaults: scope flags default ON if not supplied (zero value matches
+// IDEA-1517 §2a). Caller passes the post-consent values straight from
+// the form; this method does not interpret.
+func (s *Store) CreateOAuthConnection(c OAuthConnection) error {
+	if c.RequestID == "" {
+		return fmt.Errorf("oauth_connections: request_id required")
+	}
+	if c.UserID == "" {
+		return fmt.Errorf("oauth_connections: user_id required")
+	}
+	_, err := s.db.Exec(s.q(`
+        INSERT INTO oauth_connections (
+            request_id, user_id, name,
+            may_create_workspaces, all_current_workspaces, include_future_workspaces
+        ) VALUES (?, ?, ?, ?, ?, ?)
+    `),
+		c.RequestID, c.UserID, c.Name,
+		s.dialect.BoolToInt(c.MayCreateWorkspaces),
+		s.dialect.BoolToInt(c.AllCurrentWorkspaces),
+		s.dialect.BoolToInt(c.IncludeFutureWorkspaces),
+	)
+	if err != nil {
+		return fmt.Errorf("oauth_connections: insert: %w", err)
+	}
+	return nil
+}
+
+// RenameConnection updates the human-readable name. Touches updated_at.
+// Returns ErrOAuthConnectionNotFound if the row doesn't exist.
+//
+// Trim is the caller's responsibility (the Phase D handler will strip
+// whitespace + cap length); the store accepts the value verbatim so
+// tests can pump arbitrary content through without re-validating.
+func (s *Store) RenameConnection(requestID, name string) error {
+	if requestID == "" {
+		return fmt.Errorf("oauth_connections: request_id required")
+	}
+	res, err := s.db.Exec(s.q(`
+        UPDATE oauth_connections
+           SET name = ?, updated_at = `+s.dialect.NowRFC3339()+`
+         WHERE request_id = ?
+    `), name, requestID)
+	if err != nil {
+		return fmt.Errorf("oauth_connections: rename: %w", err)
+	}
+	return assertRowAffected(res, ErrOAuthConnectionNotFound)
+}
+
+// SetScopeFlags updates the three boolean scope flags atomically. All
+// three values are written every call — there's no PATCH semantic at
+// the store layer; the handler reads-modify-writes if it only wants to
+// touch one flag.
+//
+// Why atomic on all three: avoids interleaving anomalies if two browser
+// tabs race the connections page (last-write-wins on the full triple is
+// less surprising than per-field interleave).
+func (s *Store) SetScopeFlags(requestID string, mayCreate, allCurrent, includeFuture bool) error {
+	if requestID == "" {
+		return fmt.Errorf("oauth_connections: request_id required")
+	}
+	res, err := s.db.Exec(s.q(`
+        UPDATE oauth_connections
+           SET may_create_workspaces = ?,
+               all_current_workspaces = ?,
+               include_future_workspaces = ?,
+               updated_at = `+s.dialect.NowRFC3339()+`
+         WHERE request_id = ?
+    `),
+		s.dialect.BoolToInt(mayCreate),
+		s.dialect.BoolToInt(allCurrent),
+		s.dialect.BoolToInt(includeFuture),
+		requestID,
+	)
+	if err != nil {
+		return fmt.Errorf("oauth_connections: set flags: %w", err)
+	}
+	return assertRowAffected(res, ErrOAuthConnectionNotFound)
+}
+
+// AddConnectionWorkspace inserts a (request_id, workspace_id) row in
+// the allow-list join table. Idempotent: re-adding an existing pair is
+// a no-op (INSERT OR IGNORE on SQLite, ON CONFLICT DO NOTHING on PG).
+// added_by must be one of the AddedBy* constants — empty strings get
+// rejected at the caller boundary; the store stores what it's given so
+// tests can drive whatever value they want.
+//
+// Does NOT verify the parent oauth_connections row exists — the FK
+// constraint will reject inserts that reference a missing connection.
+// We surface the raw error so the caller sees the FK violation clearly
+// rather than a confusing "missing parent" abstraction.
+func (s *Store) AddConnectionWorkspace(requestID, workspaceID, addedBy string) error {
+	if requestID == "" || workspaceID == "" {
+		return fmt.Errorf("oauth_connections: request_id and workspace_id required")
+	}
+	if addedBy == "" {
+		addedBy = AddedByUser
+	}
+	var stmt string
+	switch s.dialect.Driver() {
+	case DriverPostgres:
+		stmt = `
+            INSERT INTO oauth_connection_workspaces (request_id, workspace_id, added_by)
+            VALUES (?, ?, ?)
+            ON CONFLICT (request_id, workspace_id) DO NOTHING
+        `
+	default:
+		stmt = `
+            INSERT OR IGNORE INTO oauth_connection_workspaces (request_id, workspace_id, added_by)
+            VALUES (?, ?, ?)
+        `
+	}
+	if _, err := s.db.Exec(s.q(stmt), requestID, workspaceID, addedBy); err != nil {
+		return fmt.Errorf("oauth_connections: add workspace: %w", err)
+	}
+	return nil
+}
+
+// RemoveConnectionWorkspace deletes one (request_id, workspace_id) row.
+// Idempotent: removing a pair that isn't present is a no-op (no error).
+// Phase D's UI uses this for the "X" affordance on each chip in the
+// allow-list editor.
+func (s *Store) RemoveConnectionWorkspace(requestID, workspaceID string) error {
+	if requestID == "" || workspaceID == "" {
+		return fmt.Errorf("oauth_connections: request_id and workspace_id required")
+	}
+	_, err := s.db.Exec(s.q(`
+        DELETE FROM oauth_connection_workspaces
+         WHERE request_id = ? AND workspace_id = ?
+    `), requestID, workspaceID)
+	if err != nil {
+		return fmt.Errorf("oauth_connections: remove workspace: %w", err)
+	}
+	return nil
+}
+
+// IsConnectionWorkspaceAllowed reports whether workspace_id appears in
+// the connection's allow-list. Used internally by GetOAuthConnectionAccess
+// when callers want a single-pair check rather than the slug projection
+// (e.g. a future code path that already knows the workspace ID).
+//
+// Returns (false, nil) when the row is missing — the caller distinguishes
+// "not allowed" from "lookup failed" via the error.
+func (s *Store) IsConnectionWorkspaceAllowed(requestID, workspaceID string) (bool, error) {
+	if requestID == "" || workspaceID == "" {
+		return false, nil
+	}
+	var one int
+	err := s.db.QueryRow(s.q(`
+        SELECT 1
+          FROM oauth_connection_workspaces
+         WHERE request_id = ? AND workspace_id = ?
+    `), requestID, workspaceID).Scan(&one)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return false, nil
+		}
+		return false, fmt.Errorf("oauth_connections: is allowed: %w", err)
+	}
+	return true, nil
+}
+
+// DeleteOAuthConnection removes the row + cascades to
+// oauth_connection_workspaces. Phase D's "Revoke" handler calls this
+// after RevokeRefreshTokenFamily + RevokeAccessTokenFamily so the
+// connection-level state doesn't linger past the token revocation.
+//
+// Idempotent: removing a non-existent connection is a no-op.
+func (s *Store) DeleteOAuthConnection(requestID string) error {
+	if requestID == "" {
+		return fmt.Errorf("oauth_connections: request_id required")
+	}
+	if _, err := s.db.Exec(s.q(`
+        DELETE FROM oauth_connections WHERE request_id = ?
+    `), requestID); err != nil {
+		return fmt.Errorf("oauth_connections: delete: %w", err)
+	}
+	return nil
+}
+
+// ---- helpers ----
+
+// scanBool normalizes the dialect-specific bool encoding (SQLite INTEGER
+// 0/1; Postgres BOOLEAN true/false) into a Go bool. Mirrors the pattern
+// used in connected_apps.go for the active flag.
+func scanBool(v interface{}) bool {
+	switch t := v.(type) {
+	case bool:
+		return t
+	case int64:
+		return t != 0
+	case int:
+		return t != 0
+	case []byte:
+		s := strings.ToLower(strings.TrimSpace(string(t)))
+		return s == "1" || s == "true" || s == "t"
+	case string:
+		s := strings.ToLower(strings.TrimSpace(t))
+		return s == "1" || s == "true" || s == "t"
+	}
+	return false
+}
+
+// assertRowAffected returns notFound if the statement didn't touch any
+// rows, the underlying RowsAffected error if the driver can't report,
+// and nil otherwise. Used by UPDATE methods that want a clean
+// "no such connection" signal without a separate SELECT.
+func assertRowAffected(res sql.Result, notFound error) error {
+	n, err := res.RowsAffected()
+	if err != nil {
+		// Both SQLite and Postgres drivers always report RowsAffected
+		// successfully for UPDATE — this branch is defensive.
+		return fmt.Errorf("oauth_connections: rows affected: %w", err)
+	}
+	if n == 0 {
+		return notFound
+	}
+	return nil
+}

--- a/internal/store/oauth_connections.go
+++ b/internal/store/oauth_connections.go
@@ -205,9 +205,14 @@ func (s *Store) GetOAuthConnectionAccess(requestID string) (OAuthConnectionAcces
 // (Phase C will treat it as a programmer bug and 500). No UPSERT here —
 // the mutation methods below cover the post-create edit path.
 //
-// Defaults: scope flags default ON if not supplied (zero value matches
-// IDEA-1517 §2a). Caller passes the post-consent values straight from
-// the form; this method does not interpret.
+// Scope flags are written verbatim from the caller — the schema-level
+// DEFAULT TRUE on each column is unreachable through this code path
+// because all three values are always supplied. The Phase C handler is
+// responsible for translating the consent UI's two-section radio +
+// checkbox interface (IDEA-1517 §2a) into the three Go bool fields
+// before calling here; the "default on" semantic lives at the form-
+// rendering layer, not in the store. Codex review #581 round 1 caught
+// the docstring/behaviour mismatch.
 func (s *Store) CreateOAuthConnection(c OAuthConnection) error {
 	if c.RequestID == "" {
 		return fmt.Errorf("oauth_connections: request_id required")

--- a/internal/store/oauth_connections_test.go
+++ b/internal/store/oauth_connections_test.go
@@ -1,0 +1,313 @@
+package store
+
+import (
+	"errors"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// OAuth connection store tests (PLAN-1519 / TASK-1520 — Phase A foundation).
+//
+// What's covered:
+//
+//   - CreateOAuthConnection + GetOAuthConnection round-trip with all
+//     three scope flags + defaults.
+//   - GetOAuthConnectionAccess HasConnection=false when no row exists
+//     (the case the dual-read middleware uses to fall back to the
+//     legacy session.Extra path).
+//   - GetOAuthConnectionAccess wildcard (AllCurrentWorkspaces=true)
+//     skips the join and returns no slugs.
+//   - GetOAuthConnectionAccess explicit allow-list returns the joined
+//     workspace slugs, sorted lexicographically.
+//   - AddConnectionWorkspace idempotency: re-adding the same
+//     (request_id, workspace_id) pair does NOT error and does NOT
+//     duplicate the row.
+//   - RemoveConnectionWorkspace + RemoveConnectionWorkspace-idempotent
+//     (removing a non-existent pair is a no-op).
+//   - RenameConnection + SetScopeFlags both return
+//     ErrOAuthConnectionNotFound when the row is missing.
+//   - DeleteOAuthConnection cascades to oauth_connection_workspaces.
+//   - IsConnectionWorkspaceAllowed reports membership accurately.
+
+func newOAuthConnTestStore(t *testing.T) *Store {
+	t.Helper()
+	dir := t.TempDir()
+	s, err := New(filepath.Join(dir, "oauth_conn.db"))
+	if err != nil {
+		t.Fatalf("New store: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	return s
+}
+
+// seedWorkspaceForConn creates a workspace and returns its ID — the
+// join table stores workspace IDs, so tests need a real row.
+func seedWorkspaceForConn(t *testing.T, s *Store, name string) (id, slug string) {
+	t.Helper()
+	u, err := s.CreateUser(models.UserCreate{
+		Email:    name + "-owner@example.com",
+		Name:     name + " owner",
+		Password: "pw-conn-owner-12345",
+	})
+	if err != nil {
+		t.Fatalf("CreateUser owner: %v", err)
+	}
+	w, err := s.CreateWorkspace(models.WorkspaceCreate{Name: name, OwnerID: u.ID})
+	if err != nil {
+		t.Fatalf("CreateWorkspace: %v", err)
+	}
+	return w.ID, w.Slug
+}
+
+func TestOAuthConnections_CreateGetRoundTrip(t *testing.T) {
+	s := newOAuthConnTestStore(t)
+	u, err := s.CreateUser(models.UserCreate{
+		Email: "conn-create@example.com", Name: "C", Password: "pw-create-12345",
+	})
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	in := OAuthConnection{
+		RequestID:               "chain-create",
+		UserID:                  u.ID,
+		Name:                    "Cursor on MacBook",
+		MayCreateWorkspaces:     true,
+		AllCurrentWorkspaces:    false,
+		IncludeFutureWorkspaces: true,
+	}
+	if err := s.CreateOAuthConnection(in); err != nil {
+		t.Fatalf("CreateOAuthConnection: %v", err)
+	}
+	got, err := s.GetOAuthConnection("chain-create")
+	if err != nil {
+		t.Fatalf("GetOAuthConnection: %v", err)
+	}
+	if got.RequestID != in.RequestID || got.UserID != in.UserID || got.Name != in.Name {
+		t.Errorf("identity round-trip mismatch: got %+v want %+v", got, in)
+	}
+	if !got.MayCreateWorkspaces || got.AllCurrentWorkspaces || !got.IncludeFutureWorkspaces {
+		t.Errorf("scope flag round-trip mismatch: got %+v", got)
+	}
+	if got.CreatedAt == "" || got.UpdatedAt == "" {
+		t.Errorf("timestamps should be populated by default: %+v", got)
+	}
+}
+
+func TestOAuthConnections_GetMissingReturnsSentinel(t *testing.T) {
+	s := newOAuthConnTestStore(t)
+	_, err := s.GetOAuthConnection("nope")
+	if !errors.Is(err, ErrOAuthConnectionNotFound) {
+		t.Errorf("got %v, want ErrOAuthConnectionNotFound", err)
+	}
+}
+
+func TestOAuthConnectionAccess_NoRowFallsBack(t *testing.T) {
+	s := newOAuthConnTestStore(t)
+	got, err := s.GetOAuthConnectionAccess("never-existed")
+	if err != nil {
+		t.Fatalf("GetOAuthConnectionAccess: %v", err)
+	}
+	if got.HasConnection {
+		t.Errorf("HasConnection = true for missing chain; middleware would skip the legacy-Extra fallback")
+	}
+	if got.AllCurrentWorkspaces || len(got.WorkspaceSlugs) != 0 {
+		t.Errorf("expected zero-value access for missing row, got %+v", got)
+	}
+}
+
+func TestOAuthConnectionAccess_WildcardSkipsJoin(t *testing.T) {
+	s := newOAuthConnTestStore(t)
+	u, _ := s.CreateUser(models.UserCreate{
+		Email: "wc@example.com", Name: "W", Password: "pw-wild-12345",
+	})
+	if err := s.CreateOAuthConnection(OAuthConnection{
+		RequestID:            "wildcard-chain",
+		UserID:               u.ID,
+		AllCurrentWorkspaces: true,
+	}); err != nil {
+		t.Fatalf("CreateOAuthConnection: %v", err)
+	}
+	// Even if a stale join row existed (no FK violation possible after
+	// connection exists), the wildcard flag should short-circuit the
+	// projection. Adding one to prove the early-return is real.
+	wsID, _ := seedWorkspaceForConn(t, s, "wildcard-ws")
+	if err := s.AddConnectionWorkspace("wildcard-chain", wsID, AddedByUser); err != nil {
+		t.Fatalf("AddConnectionWorkspace: %v", err)
+	}
+
+	got, err := s.GetOAuthConnectionAccess("wildcard-chain")
+	if err != nil {
+		t.Fatalf("GetOAuthConnectionAccess: %v", err)
+	}
+	if !got.HasConnection || !got.AllCurrentWorkspaces {
+		t.Errorf("expected wildcard access, got %+v", got)
+	}
+	if len(got.WorkspaceSlugs) != 0 {
+		t.Errorf("WorkspaceSlugs should be empty when wildcard short-circuits, got %v", got.WorkspaceSlugs)
+	}
+}
+
+func TestOAuthConnectionAccess_ExplicitListReturnsSortedSlugs(t *testing.T) {
+	s := newOAuthConnTestStore(t)
+	u, _ := s.CreateUser(models.UserCreate{
+		Email: "ex@example.com", Name: "E", Password: "pw-exp-12345",
+	})
+	if err := s.CreateOAuthConnection(OAuthConnection{
+		RequestID:            "explicit-chain",
+		UserID:               u.ID,
+		AllCurrentWorkspaces: false,
+	}); err != nil {
+		t.Fatalf("CreateOAuthConnection: %v", err)
+	}
+	// Two workspaces, intentionally added in reverse alpha order so
+	// the sort assertion has signal.
+	zID, zSlug := seedWorkspaceForConn(t, s, "zeta-ws")
+	aID, aSlug := seedWorkspaceForConn(t, s, "alpha-ws")
+	if err := s.AddConnectionWorkspace("explicit-chain", zID, AddedByUser); err != nil {
+		t.Fatalf("AddConnectionWorkspace zeta: %v", err)
+	}
+	if err := s.AddConnectionWorkspace("explicit-chain", aID, AddedByAgentCreate); err != nil {
+		t.Fatalf("AddConnectionWorkspace alpha: %v", err)
+	}
+
+	got, err := s.GetOAuthConnectionAccess("explicit-chain")
+	if err != nil {
+		t.Fatalf("GetOAuthConnectionAccess: %v", err)
+	}
+	want := []string{aSlug, zSlug}
+	if !reflect.DeepEqual(got.WorkspaceSlugs, want) {
+		t.Errorf("WorkspaceSlugs = %v, want %v (lexicographic order)", got.WorkspaceSlugs, want)
+	}
+	if got.AllCurrentWorkspaces {
+		t.Errorf("AllCurrentWorkspaces should be false for explicit allow-list path")
+	}
+}
+
+func TestOAuthConnections_AddWorkspaceIdempotent(t *testing.T) {
+	s := newOAuthConnTestStore(t)
+	u, _ := s.CreateUser(models.UserCreate{
+		Email: "idem@example.com", Name: "I", Password: "pw-idem-12345",
+	})
+	if err := s.CreateOAuthConnection(OAuthConnection{
+		RequestID: "idem-chain", UserID: u.ID,
+	}); err != nil {
+		t.Fatalf("CreateOAuthConnection: %v", err)
+	}
+	wsID, _ := seedWorkspaceForConn(t, s, "idem-ws")
+
+	for i := 0; i < 3; i++ {
+		if err := s.AddConnectionWorkspace("idem-chain", wsID, AddedByUser); err != nil {
+			t.Fatalf("AddConnectionWorkspace iter %d: %v", i, err)
+		}
+	}
+	allowed, err := s.IsConnectionWorkspaceAllowed("idem-chain", wsID)
+	if err != nil {
+		t.Fatalf("IsConnectionWorkspaceAllowed: %v", err)
+	}
+	if !allowed {
+		t.Errorf("workspace should be in allow-list after add")
+	}
+}
+
+func TestOAuthConnections_RemoveWorkspaceIdempotent(t *testing.T) {
+	s := newOAuthConnTestStore(t)
+	u, _ := s.CreateUser(models.UserCreate{
+		Email: "rem@example.com", Name: "R", Password: "pw-rem-12345",
+	})
+	if err := s.CreateOAuthConnection(OAuthConnection{
+		RequestID: "rem-chain", UserID: u.ID,
+	}); err != nil {
+		t.Fatalf("CreateOAuthConnection: %v", err)
+	}
+	wsID, _ := seedWorkspaceForConn(t, s, "rem-ws")
+	if err := s.AddConnectionWorkspace("rem-chain", wsID, AddedByUser); err != nil {
+		t.Fatalf("AddConnectionWorkspace: %v", err)
+	}
+	if err := s.RemoveConnectionWorkspace("rem-chain", wsID); err != nil {
+		t.Fatalf("RemoveConnectionWorkspace: %v", err)
+	}
+	// Second remove must not error.
+	if err := s.RemoveConnectionWorkspace("rem-chain", wsID); err != nil {
+		t.Errorf("RemoveConnectionWorkspace second call should be no-op, got %v", err)
+	}
+	allowed, _ := s.IsConnectionWorkspaceAllowed("rem-chain", wsID)
+	if allowed {
+		t.Errorf("workspace should not be allowed after remove")
+	}
+}
+
+func TestOAuthConnections_RenameAndScopeFlagsRequireExistingRow(t *testing.T) {
+	s := newOAuthConnTestStore(t)
+	if err := s.RenameConnection("ghost", "anything"); !errors.Is(err, ErrOAuthConnectionNotFound) {
+		t.Errorf("Rename missing: got %v, want ErrOAuthConnectionNotFound", err)
+	}
+	if err := s.SetScopeFlags("ghost", true, true, true); !errors.Is(err, ErrOAuthConnectionNotFound) {
+		t.Errorf("SetScopeFlags missing: got %v, want ErrOAuthConnectionNotFound", err)
+	}
+}
+
+func TestOAuthConnections_RenameAndScopeFlagsTouchUpdatedAt(t *testing.T) {
+	s := newOAuthConnTestStore(t)
+	u, _ := s.CreateUser(models.UserCreate{
+		Email: "u@example.com", Name: "U", Password: "pw-upd-12345",
+	})
+	if err := s.CreateOAuthConnection(OAuthConnection{
+		RequestID: "upd-chain", UserID: u.ID, Name: "Original",
+	}); err != nil {
+		t.Fatalf("CreateOAuthConnection: %v", err)
+	}
+	if err := s.RenameConnection("upd-chain", "Renamed"); err != nil {
+		t.Fatalf("RenameConnection: %v", err)
+	}
+	if err := s.SetScopeFlags("upd-chain", false, false, false); err != nil {
+		t.Fatalf("SetScopeFlags: %v", err)
+	}
+	got, err := s.GetOAuthConnection("upd-chain")
+	if err != nil {
+		t.Fatalf("GetOAuthConnection: %v", err)
+	}
+	if got.Name != "Renamed" {
+		t.Errorf("Name not updated: %q", got.Name)
+	}
+	if got.MayCreateWorkspaces || got.AllCurrentWorkspaces || got.IncludeFutureWorkspaces {
+		t.Errorf("scope flags not cleared: %+v", got)
+	}
+}
+
+func TestOAuthConnections_DeleteCascadesJoinTable(t *testing.T) {
+	s := newOAuthConnTestStore(t)
+	u, _ := s.CreateUser(models.UserCreate{
+		Email: "del@example.com", Name: "D", Password: "pw-del-12345",
+	})
+	if err := s.CreateOAuthConnection(OAuthConnection{
+		RequestID: "del-chain", UserID: u.ID,
+	}); err != nil {
+		t.Fatalf("CreateOAuthConnection: %v", err)
+	}
+	wsID, _ := seedWorkspaceForConn(t, s, "del-ws")
+	if err := s.AddConnectionWorkspace("del-chain", wsID, AddedByUser); err != nil {
+		t.Fatalf("AddConnectionWorkspace: %v", err)
+	}
+
+	if err := s.DeleteOAuthConnection("del-chain"); err != nil {
+		t.Fatalf("DeleteOAuthConnection: %v", err)
+	}
+	// Connection gone.
+	if _, err := s.GetOAuthConnection("del-chain"); !errors.Is(err, ErrOAuthConnectionNotFound) {
+		t.Errorf("connection should be gone, got %v", err)
+	}
+	// Join row gone — verifies FK ON DELETE CASCADE actually fires
+	// on SQLite (it only does when foreign_keys pragma is ON; the DSN
+	// in New() sets it per-connection).
+	allowed, err := s.IsConnectionWorkspaceAllowed("del-chain", wsID)
+	if err != nil {
+		t.Fatalf("IsConnectionWorkspaceAllowed: %v", err)
+	}
+	if allowed {
+		t.Errorf("join row should cascade-deleted with parent connection")
+	}
+}

--- a/internal/store/pgmigrations/038_oauth_connections.sql
+++ b/internal/store/pgmigrations/038_oauth_connections.sql
@@ -1,0 +1,46 @@
+-- Migration 038 (Postgres): per-OAuth-connection state (PLAN-1519 / TASK-1520).
+--
+-- Postgres counterpart to migrations/059_oauth_connections.sql. Same
+-- schema, dialect-specific type tweaks:
+--
+--   - BOOLEAN instead of INTEGER for true/false flags (matches the
+--     pattern in pgmigrations/027_oauth.sql for oauth_clients.public
+--     and oauth_*_tokens.active).
+--   - (NOW() AT TIME ZONE 'UTC')::TEXT for default timestamps, keeping
+--     the column TEXT so the cross-dialect ISO8601 contract stays
+--     uniform on the Go side (same convention as migration 027).
+--
+-- See migrations/059_oauth_connections.sql for the full schema-level
+-- documentation. Comments here are dialect-only.
+
+-- ============================================================
+-- 1. oauth_connections
+-- ============================================================
+CREATE TABLE IF NOT EXISTS oauth_connections (
+    request_id                  TEXT PRIMARY KEY,
+    user_id                     TEXT NOT NULL,
+    name                        TEXT NOT NULL DEFAULT '',
+    may_create_workspaces       BOOLEAN NOT NULL DEFAULT TRUE,
+    all_current_workspaces      BOOLEAN NOT NULL DEFAULT TRUE,
+    include_future_workspaces   BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at                  TEXT NOT NULL DEFAULT (NOW() AT TIME ZONE 'UTC')::TEXT,
+    updated_at                  TEXT NOT NULL DEFAULT (NOW() AT TIME ZONE 'UTC')::TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_oauth_connections_user
+    ON oauth_connections(user_id);
+
+-- ============================================================
+-- 2. oauth_connection_workspaces
+-- ============================================================
+CREATE TABLE IF NOT EXISTS oauth_connection_workspaces (
+    request_id    TEXT NOT NULL,
+    workspace_id  TEXT NOT NULL,
+    added_at      TEXT NOT NULL DEFAULT (NOW() AT TIME ZONE 'UTC')::TEXT,
+    added_by      TEXT NOT NULL DEFAULT 'user',
+    PRIMARY KEY (request_id, workspace_id),
+    FOREIGN KEY (request_id) REFERENCES oauth_connections(request_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_oauth_conn_workspaces_ws
+    ON oauth_connection_workspaces(workspace_id);


### PR DESCRIPTION
## Summary

Phase A foundation for [PLAN-1519](https://github.com/PerpetualSoftware/pad) / IDEA-1517's per-OAuth-connection state overhaul. Promotes consent-time connection state — name, scope flags, mutable workspace allow-list — out of \`session.Extra\` (per-token, re-minted on every refresh-token rotation) into dedicated tables keyed by \`request_id\` (the grant chain identifier preserved across rotations).

- **Schema**: SQLite migration 059 + Postgres migration 038. \`oauth_connections\` (one row per grant chain) + \`oauth_connection_workspaces\` (mutable allow-list join, FK ON DELETE CASCADE).
- **Store**: \`internal/store/oauth_connections.go\` with CRUD + the hot-path \`GetOAuthConnectionAccess\` projection.
- **Dual-read gate**: \`internal/server/middleware_mcp_auth.go\` OR-merges the legacy \`session.Extra\` allow-list with the new-table projection. New tables stay empty until Phase C writes the consent screen — until then the dual-read is a no-op and existing OAuth grants flow through unchanged.

No user-visible change — pure infrastructure for the rest of PLAN-1519.

## Context

Implements \`TASK-1520\` under PLAN-1519. Phase B (\`pad_workspace.create\` + \`claim\`) and Phase C (consent screen + write-path migration) build on this. The dual-read gate is intentionally tolerant: I/O errors on the new path fall back to the Extra path so a transient outage of the new tables can't regress existing grants.

## Test plan

- [x] \`go build ./...\` — clean
- [x] \`go vet ./...\` — clean
- [x] \`golangci-lint run --timeout=5m ./...\` — clean
- [x] \`go test ./internal/store/ ./internal/server/\` — all new tests pass (10 store tests + 11-case mergeAllowedWorkspaces table-driven test)
- [x] \`cd web && npm run build\` — clean
- [x] Dual-read acceptance criterion: token with allow-list in session.Extra still passes; token with empty session.Extra but row in oauth_connection_workspaces also passes — covered directly in TestMergeAllowedWorkspaces cases 3 and 6
- [x] FK ON DELETE CASCADE verified on SQLite via TestOAuthConnections_DeleteCascadesJoinTable (relies on the foreign_keys pragma the DSN sets per-connection)
- [x] BenchmarkMergeAllowedWorkspaces added for the hot-path overhead measurement called out in PLAN-1519's Risks section