### PR TITLE
feat(mcp): workspace.create + workspace.claim actions + claim-code mechanics (TASK-1521)

### DIFF
--- a/cmd/pad/groups.go
+++ b/cmd/pad/groups.go
@@ -39,6 +39,8 @@ func workspaceCmd() *cobra.Command {
 	}
 	cmd.AddCommand(
 		initCmd(),
+		workspaceCreateCmd(),
+		workspaceClaimCmd(),
 		linkCmd(),
 		switchCmd(),
 		workspacesCmd(),

--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -488,8 +488,16 @@ func serveCmd() *cobra.Command {
 						return fmt.Errorf("init OAuth server: %w", oauthErr)
 					}
 					srv.SetOAuthServer(oauthSrv)
+					// Same key powers stateless 6-digit claim codes
+					// (PLAN-1519 / TASK-1521 / IDEA-1517 §4). Reusing
+					// keyBytes here keeps the cloud-mode secret surface
+					// to a single 32-byte value the operator already
+					// rotates; the OAuth signing path and the claim
+					// HMAC path have the same rotation cadence + blast
+					// radius, so a shared secret is the right call.
+					srv.SetClaimSecret(keyBytes)
 					slog.Info("OAuth server mounted",
-						"endpoints", "/oauth/{register,authorize,token}",
+						"endpoints", "/oauth/{register,authorize,token,claim}",
 						"audience", oauthSrv.AllowedAudience(),
 					)
 				} else {
@@ -1852,6 +1860,131 @@ func joinCmd() *cobra.Command {
 			return nil
 		},
 	}
+}
+
+// --- workspace create (non-interactive) ---
+//
+// `pad workspace init` is the interactive entry point: it ensures
+// auth, prompts when needed, and CWD-links the new workspace. That's
+// the right shape for a human at a terminal. The MCP `pad_workspace.
+// action: create` route needs a non-interactive equivalent that hits
+// POST /api/v1/workspaces directly with structured args — no TTY
+// prompts, no CWD-link side effect. `pad workspace create` is that
+// surface; the stdio MCP dispatcher (ExecDispatcher) shells out to
+// it via passThrough, and humans can call it too if they want the
+// thin direct shape.
+//
+// See PLAN-1519 / TASK-1521 / IDEA-1517 §1.
+
+func workspaceCreateCmd() *cobra.Command {
+	var (
+		slugFlag     string
+		templateFlag string
+	)
+	cmd := &cobra.Command{
+		Use:   "create <name>",
+		Short: "Create a workspace non-interactively (use 'pad workspace init' for the guided flow)",
+		Long: `Create a new workspace by name. Non-interactive — no prompts, no
+CWD link side effect. Hits POST /api/v1/workspaces directly with the
+supplied name + optional slug + template.
+
+For the guided flow that ensures auth, picks a template interactively,
+and links the CWD, use 'pad workspace init' instead. The 'create' shape
+exists to back the MCP pad_workspace.action: create route + scripts
+that just want the workspace row.
+
+When called over an OAuth-bound MCP session whose grant has
+may_create_workspaces=true, the new workspace is auto-added to that
+connection's allow-list (PLAN-1519 / TASK-1521 / IDEA-1517 §1) so
+the agent can use it immediately without re-auth.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, _ := getClient()
+			ws, err := client.CreateWorkspace(models.WorkspaceCreate{
+				Name:     args[0],
+				Slug:     slugFlag,
+				Template: templateFlag,
+			})
+			if err != nil {
+				return fmt.Errorf("create workspace: %w", err)
+			}
+			if formatFlag == "json" {
+				return cli.PrintJSON(ws)
+			}
+			green := color.New(color.FgGreen).SprintFunc()
+			fmt.Printf("%s Created workspace %q (slug: %s)\n", green("✓"), ws.Name, ws.Slug)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&slugFlag, "slug", "", "Workspace slug (default: derived from name)")
+	cmd.Flags().StringVar(&templateFlag, "template", "", "Template to seed collections from (run 'pad workspace init --list-templates' to see options)")
+	return cmd
+}
+
+// --- workspace claim ---
+//
+// `pad workspace claim <code> --workspace <slug>` redeems a 6-digit
+// stateless HMAC claim code at POST /api/v1/oauth/claim, granting the
+// calling OAuth connection access to one specific workspace.
+//
+// The CLI ships this command primarily so the stdio MCP dispatcher
+// (ExecDispatcher) can shell out to it via passThrough for the
+// `pad_workspace.action: claim` route — claim itself is meaningful
+// only over a cloud-mode OAuth MCP session (PAT / CLI session tokens
+// already see every workspace the user belongs to), but the handler
+// returns a clear note when called outside that context so a confused
+// CLI caller isn't left guessing.
+//
+// See PLAN-1519 / TASK-1521 / IDEA-1517 §4.
+
+func workspaceClaimCmd() *cobra.Command {
+	var workspaceSlug string
+	cmd := &cobra.Command{
+		Use:   "claim <code>",
+		Short: "Redeem a 6-digit claim code to add a workspace to this OAuth connection's allow-list",
+		Long: `Redeem a 6-digit claim code at POST /api/v1/oauth/claim, granting the
+calling OAuth connection access to one specific workspace.
+
+Generate the code in the workspace's web UI ("Connect project" modal,
+avatar menu). The code is valid for 5–10 minutes (sliding window).
+
+Claim is meaningful only over cloud-mode OAuth MCP sessions where
+workspace allow-lists actually constrain access. CLI session tokens
+and PATs already see every workspace you belong to; running this from
+the CLI succeeds (the code verifies) but the side effect no-ops —
+the response 'note' field explains.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if workspaceSlug == "" {
+				workspaceSlug = getWorkspace()
+			}
+			if workspaceSlug == "" {
+				return fmt.Errorf("--workspace is required (no workspace linked in this directory)")
+			}
+			client, _ := getClient()
+			resp, err := client.ClaimWorkspace(workspaceSlug, args[0])
+			if err != nil {
+				return fmt.Errorf("claim workspace: %w", err)
+			}
+			if formatFlag == "json" {
+				return cli.PrintJSON(resp)
+			}
+			green := color.New(color.FgGreen).SprintFunc()
+			dim := color.New(color.Faint)
+			if resp.AlreadyAdded {
+				fmt.Printf("%s Workspace %q already in this connection's allow-list (no change)\n",
+					green("✓"), resp.Workspace)
+			} else {
+				fmt.Printf("%s Claimed workspace %q\n", green("✓"), resp.Workspace)
+			}
+			if resp.Note != "" {
+				fmt.Println(dim.Sprint(resp.Note))
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&workspaceSlug, "workspace", "", "Workspace slug to claim (defaults to CWD-linked workspace)")
+	return cmd
 }
 
 // --- reset-password ---

--- a/internal/cli/client.go
+++ b/internal/cli/client.go
@@ -117,6 +117,29 @@ func (c *Client) UpdateWorkspace(slug string, input models.WorkspaceUpdate) (*mo
 	return &result, c.patch("/workspaces/"+slug, input, &result)
 }
 
+// ClaimWorkspaceResponse is the shape of POST /api/v1/oauth/claim.
+// `AlreadyAdded` reports whether the workspace was already in the
+// calling connection's allow-list (idempotent re-claim returns true).
+// `Note` is populated only for PAT / CLI-session callers that have no
+// OAuth grant to add the workspace to — see handleOAuthClaim for the
+// design rationale.
+type ClaimWorkspaceResponse struct {
+	Workspace    string `json:"workspace"`
+	WorkspaceID  string `json:"workspace_id"`
+	AlreadyAdded bool   `json:"already_added"`
+	Note         string `json:"note,omitempty"`
+}
+
+// ClaimWorkspace redeems a 6-digit claim code against the
+// /api/v1/oauth/claim endpoint, granting the calling OAuth connection
+// access to the named workspace. Used by `pad workspace claim` and
+// by the MCP `pad_workspace.action: claim` route.
+func (c *Client) ClaimWorkspace(workspaceSlug, code string) (*ClaimWorkspaceResponse, error) {
+	var result ClaimWorkspaceResponse
+	body := map[string]string{"workspace": workspaceSlug, "code": code}
+	return &result, c.post("/oauth/claim", body, &result)
+}
+
 // --- Collections ---
 
 func (c *Client) ListCollections(wsSlug string) ([]models.Collection, error) {

--- a/internal/mcp/catalog_readonly_test.go
+++ b/internal/mcp/catalog_readonly_test.go
@@ -80,6 +80,9 @@ func TestReadOnlyCatalog_ActionsMatchCmdhelp(t *testing.T) {
 		{"pad_workspace", "invite"}:    {"workspace", "invite"},
 		{"pad_workspace", "storage"}:   {"workspace", "storage"},
 		{"pad_workspace", "audit-log"}: {"workspace", "audit-log"},
+		// PLAN-1519 / TASK-1521 / IDEA-1517 §1 + §4: workspace lifecycle.
+		{"pad_workspace", "create"}: {"workspace", "create"},
+		{"pad_workspace", "claim"}:  {"workspace", "claim"},
 
 		{"pad_collection", "list"}:   {"collection", "list"},
 		{"pad_collection", "create"}: {"collection", "create"},
@@ -203,6 +206,9 @@ func TestReadOnlyCatalog_ActionsDispatchExpectedCmdPath(t *testing.T) {
 		{"pad_workspace", "invite"}:    {"workspace", "invite"},
 		{"pad_workspace", "storage"}:   {"workspace", "storage"},
 		{"pad_workspace", "audit-log"}: {"workspace", "audit-log"},
+		// PLAN-1519 / TASK-1521 / IDEA-1517 §1 + §4: workspace lifecycle.
+		{"pad_workspace", "create"}: {"workspace", "create"},
+		{"pad_workspace", "claim"}:  {"workspace", "claim"},
 
 		{"pad_collection", "list"}:   {"collection", "list"},
 		{"pad_collection", "create"}: {"collection", "create"},
@@ -261,6 +267,9 @@ func TestReadOnlyCatalog_ActionsDispatchExpectedCmdPath(t *testing.T) {
 		"message":           "test message",
 		"summary":           "test summary",
 		"decision":          "test decision",
+		// PLAN-1519 / TASK-1521 — workspace.claim needs a `code` positional;
+		// `name` (above) doubles as the workspace.create positional.
+		"code": "123456",
 	}
 
 	for _, def := range Catalog {
@@ -398,6 +407,17 @@ func liveCmdhelpDoc(t *testing.T) *cmdhelp.Document {
 				Flags:   mkFlags("workspace", "role"),
 			},
 			"workspace storage": {Summary: "storage", Flags: mkFlags("workspace")},
+			// PLAN-1519 / TASK-1521 / IDEA-1517 §1 + §4: workspace lifecycle.
+			"workspace create": {
+				Summary: "create workspace non-interactively",
+				Args:    mkArgs("name"),
+				Flags:   mkFlags("slug", "template"),
+			},
+			"workspace claim": {
+				Summary: "claim a workspace by 6-digit code",
+				Args:    mkArgs("code"),
+				Flags:   mkFlags("workspace"),
+			},
 			"workspace audit-log": {
 				Summary: "audit log",
 				Flags: map[string]cmdhelp.Flag{

--- a/internal/mcp/catalog_workspace.go
+++ b/internal/mcp/catalog_workspace.go
@@ -57,6 +57,27 @@ var padWorkspaceTool = ToolDef{
 				Type:        "number",
 				Description: "Maximum entries to return. Optional for action=audit-log.",
 			},
+			// --- TASK-1521: workspace lifecycle ---
+			{
+				Name:        "name",
+				Type:        "string",
+				Description: "Human-readable workspace name. Required for action=create.",
+			},
+			{
+				Name:        "slug",
+				Type:        "string",
+				Description: "Workspace slug (kebab-case, globally unique). Optional for action=create; derived from name when omitted.",
+			},
+			{
+				Name:        "template",
+				Type:        "string",
+				Description: "Template to seed collections from (e.g. \"startup\", \"scrum\", \"blank\"). Optional for action=create.",
+			},
+			{
+				Name:        "code",
+				Type:        "string",
+				Description: "6-digit claim code generated in the workspace's \"Connect project\" modal. Required for action=claim.",
+			},
 		},
 	},
 	Actions: map[string]ActionFn{
@@ -65,6 +86,9 @@ var padWorkspaceTool = ToolDef{
 		"invite":    passThrough([]string{"workspace", "invite"}),
 		"storage":   passThrough([]string{"workspace", "storage"}),
 		"audit-log": actionWorkspaceAuditLog,
+		// PLAN-1519 / TASK-1521 / IDEA-1517 §1 + §4.
+		"create": passThrough([]string{"workspace", "create"}),
+		"claim":  passThrough([]string{"workspace", "claim"}),
 	},
 }
 
@@ -99,7 +123,7 @@ func actionWorkspaceAuditLog(ctx context.Context, input map[string]any, env Acti
 	return env.Dispatch(ctx, []string{"workspace", "audit-log"}, input)
 }
 
-const padWorkspaceToolDescription = `Workspace operations — discovery, membership, storage, and audit log.
+const padWorkspaceToolDescription = `Workspace operations — discovery, membership, storage, audit log, and lifecycle.
 
 Actions:
   list       — List workspaces visible to the current user. No params; admins see all,
@@ -115,6 +139,22 @@ Actions:
                Optional: action_filter, actor, days, limit.
                Note: the underlying endpoint is global, so this returns entries
                across all workspaces filtered by the supplied params.
+  create     — Create a new workspace.
+               Required: name.
+               Optional: slug (derived from name when omitted), template (e.g.
+               "startup" / "scrum" / "blank").
+               When called over an OAuth-bound MCP session whose grant has
+               may_create_workspaces=true, the new workspace is auto-added to
+               that connection's allow-list — usable immediately, no re-auth.
+  claim      — Redeem a 6-digit claim code to add a workspace to the calling
+               OAuth connection's allow-list.
+               Required: workspace, code.
+               Generate the code in the workspace's web UI ("Connect project"
+               modal). Valid for 5–10 minutes (sliding window). Errors: 401
+               invalid_code, 404 not_found (workspace doesn't exist or you're
+               not a member), 412 connection_not_persisted (pre-Phase-C grant
+               — re-authorize).
 
-Use pad_workspace when an agent needs to discover, manage membership, or audit
-workspace activity. For item-level operations use pad_item.`
+Use pad_workspace when an agent needs to discover, manage membership, audit
+workspace activity, or bring a new/additional workspace into this connection.
+For item-level operations use pad_item.`

--- a/internal/mcp/catalog_workspace_lifecycle_test.go
+++ b/internal/mcp/catalog_workspace_lifecycle_test.go
@@ -1,0 +1,197 @@
+package mcp
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// MCP catalog wiring tests for the workspace-lifecycle actions
+// (PLAN-1519 / TASK-1521 / IDEA-1517 §1 + §4).
+//
+// The catalog is the contract — agents discover what they can call
+// from the schema we expose. These tests pin:
+//
+//   - Both actions are present in pad_workspace's action enum.
+//   - The new params (name, slug, template, code) are advertised.
+//   - The tool description mentions both actions so the inline doc
+//     keeps step with the schema.
+//   - The HTTP route table has entries for "workspace create" and
+//     "workspace claim" (otherwise cloud MCP would return "not yet
+//     implemented over HTTP transport").
+//   - The route mappers produce the right method + path + body
+//     shape for canonical input.
+
+func TestCatalogWorkspace_LifecycleActionsRegistered(t *testing.T) {
+	// Source-of-truth check: the Actions map on the ToolDef is what
+	// makeFanOutHandler dispatches on. The schema test below is the
+	// agent-facing-surface check. Both must agree.
+	for _, want := range []string{"create", "claim"} {
+		if _, ok := padWorkspaceTool.Actions[want]; !ok {
+			t.Errorf("padWorkspaceTool.Actions missing %q (dispatcher would 404 the call)", want)
+		}
+	}
+
+	tool := buildToolFromDef(padWorkspaceTool)
+	props := tool.InputSchema.Properties
+
+	// action enum must include both new verbs. The mcp-go library
+	// stores enum as []string OR []any depending on builder used;
+	// extractEnumStrings normalizes both.
+	actionProp, _ := props["action"].(map[string]any)
+	enum := extractEnumStrings(actionProp["enum"])
+	for _, want := range []string{"create", "claim"} {
+		if !enum[want] {
+			t.Errorf("pad_workspace action enum missing %q (got %v)", want, actionProp["enum"])
+		}
+	}
+
+	// New params advertised on the input schema.
+	for _, p := range []string{"name", "slug", "template", "code"} {
+		if _, ok := props[p]; !ok {
+			t.Errorf("pad_workspace input schema missing param %q", p)
+		}
+	}
+}
+
+// extractEnumStrings normalizes the schema's enum representation to a
+// string set, accepting either []string or []any (mcp-go's exact
+// shape has flipped historically; defensive code keeps the test
+// stable across library bumps).
+func extractEnumStrings(raw any) map[string]bool {
+	out := map[string]bool{}
+	switch v := raw.(type) {
+	case []string:
+		for _, s := range v {
+			out[s] = true
+		}
+	case []any:
+		for _, e := range v {
+			if s, ok := e.(string); ok {
+				out[s] = true
+			}
+		}
+	}
+	return out
+}
+
+func TestCatalogWorkspace_DescriptionMentionsLifecycle(t *testing.T) {
+	desc := padWorkspaceToolDescription
+	for _, want := range []string{
+		"create",
+		"claim",
+		"may_create_workspaces",
+		"6-digit",
+	} {
+		if !strings.Contains(desc, want) {
+			t.Errorf("pad_workspace description should mention %q; got %s", want, desc)
+		}
+	}
+}
+
+func TestWorkspaceCreateRoute_HTTPMappingShape(t *testing.T) {
+	method, path, body, err := mapWorkspaceCreate(map[string]any{
+		"name":     "My New WS",
+		"slug":     "my-new-ws",
+		"template": "startup",
+	})
+	if err != nil {
+		t.Fatalf("mapWorkspaceCreate: %v", err)
+	}
+	if method != "POST" {
+		t.Errorf("method = %q, want POST", method)
+	}
+	if path != "/api/v1/workspaces" {
+		t.Errorf("path = %q, want /api/v1/workspaces", path)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	for k, want := range map[string]string{"name": "My New WS", "slug": "my-new-ws", "template": "startup"} {
+		if got[k] != want {
+			t.Errorf("body[%q] = %v, want %q", k, got[k], want)
+		}
+	}
+}
+
+func TestWorkspaceCreateRoute_RequiresName(t *testing.T) {
+	_, _, _, err := mapWorkspaceCreate(map[string]any{})
+	if err == nil || !strings.Contains(err.Error(), "name") {
+		t.Errorf("missing name should error; got %v", err)
+	}
+}
+
+func TestWorkspaceCreateRoute_OmitsOptionalEmptyFields(t *testing.T) {
+	// `workspace` arrives via session-default injection but is
+	// irrelevant for CREATE. The mapper should produce a body that
+	// only carries name + the optional fields the caller actually
+	// supplied — not a stale `workspace` slug.
+	_, _, body, err := mapWorkspaceCreate(map[string]any{
+		"name":      "Minimal",
+		"workspace": "some-other-ws",
+	})
+	if err != nil {
+		t.Fatalf("mapWorkspaceCreate: %v", err)
+	}
+	var got map[string]any
+	_ = json.Unmarshal(body, &got)
+	if _, has := got["workspace"]; has {
+		t.Errorf("body should not carry workspace on create: %v", got)
+	}
+	if _, has := got["slug"]; has {
+		t.Errorf("body should omit empty slug: %v", got)
+	}
+	if _, has := got["template"]; has {
+		t.Errorf("body should omit empty template: %v", got)
+	}
+}
+
+func TestWorkspaceClaimRoute_HTTPMappingShape(t *testing.T) {
+	method, path, body, err := mapWorkspaceClaim(map[string]any{
+		"workspace": "my-cool-project",
+		"code":      "123456",
+	})
+	if err != nil {
+		t.Fatalf("mapWorkspaceClaim: %v", err)
+	}
+	if method != "POST" {
+		t.Errorf("method = %q, want POST", method)
+	}
+	if path != "/api/v1/oauth/claim" {
+		t.Errorf("path = %q, want /api/v1/oauth/claim", path)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if got["workspace"] != "my-cool-project" {
+		t.Errorf("body workspace = %v, want my-cool-project", got["workspace"])
+	}
+	if got["code"] != "123456" {
+		t.Errorf("body code = %v, want 123456", got["code"])
+	}
+}
+
+func TestWorkspaceClaimRoute_RequiresWorkspaceAndCode(t *testing.T) {
+	cases := []map[string]any{
+		{},
+		{"workspace": "x"},                  // missing code
+		{"code": "123456"},                  // missing workspace
+		{"workspace": "", "code": "123456"}, // empty
+	}
+	for i, in := range cases {
+		_, _, _, err := mapWorkspaceClaim(in)
+		if err == nil {
+			t.Errorf("case %d %v: should error on missing/empty inputs", i, in)
+		}
+	}
+}
+
+func TestRouteTable_RegistersWorkspaceLifecycle(t *testing.T) {
+	for _, key := range []string{"workspace create", "workspace claim"} {
+		if _, ok := routeTable[key]; !ok {
+			t.Errorf("routeTable missing entry for %q — cloud MCP dispatch would fail", key)
+		}
+	}
+}

--- a/internal/mcp/dispatch_http_routes.go
+++ b/internal/mcp/dispatch_http_routes.go
@@ -339,6 +339,14 @@ func init() {
 		// can pass an explicit `workspace` param to scope if they want).
 		"workspace audit-log": mapWorkspaceAuditLog,
 		"workspace invite":    mapWorkspaceInvite,
+		// PLAN-1519 / TASK-1521 / IDEA-1517 §1 + §4: workspace lifecycle
+		// over MCP. `create` POSTs to /api/v1/workspaces; the handler's
+		// auto-add side effect uses the request context's OAuth identity
+		// (WithMCPTokenIdentity) to insert into oauth_connection_workspaces
+		// when may_create_workspaces=true. `claim` POSTs to
+		// /api/v1/oauth/claim with the same payload shape.
+		"workspace create": mapWorkspaceCreate,
+		"workspace claim":  mapWorkspaceClaim,
 
 		// --- TASK-968 follow-up: project intelligence + admin extras ---
 		// `project next` returns the full dashboard JSON — same shape the
@@ -947,6 +955,66 @@ func mapWorkspaceAuditLog(input map[string]any) (string, string, []byte, error) 
 		urlPath += "?" + encoded
 	}
 	return http.MethodGet, urlPath, nil, nil
+}
+
+// mapWorkspaceCreate dispatches `pad workspace create <name>
+// [--slug X] [--template X]`.
+//
+// POST /api/v1/workspaces with body {name, slug?, template?} —
+// matches models.WorkspaceCreate. Auto-add-to-allow-list is a
+// server-side side effect; the dispatcher just forwards the create
+// call. PLAN-1519 / TASK-1521 / IDEA-1517 §1.
+//
+// `workspace` is intentionally NOT passed in the body: the resource
+// is being CREATED, not addressed by an existing slug. If the caller
+// supplied `slug`, that becomes the workspace's slug; otherwise the
+// server derives one from `name`. The session-default workspace
+// injection that mergeDispatchInput performs is therefore irrelevant
+// here — we just ignore an incidental `workspace` key.
+func mapWorkspaceCreate(input map[string]any) (string, string, []byte, error) {
+	name, _ := input["name"].(string)
+	if name == "" {
+		return "", "", nil, fmt.Errorf("name is required")
+	}
+	payload := map[string]any{"name": name}
+	if v, _ := input["slug"].(string); v != "" {
+		payload["slug"] = v
+	}
+	if v, _ := input["template"].(string); v != "" {
+		payload["template"] = v
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return "", "", nil, fmt.Errorf("encode body: %w", err)
+	}
+	return http.MethodPost, "/api/v1/workspaces", body, nil
+}
+
+// mapWorkspaceClaim dispatches `pad workspace claim <code>
+// --workspace <slug>`.
+//
+// POST /api/v1/oauth/claim with body {workspace, code} —
+// see internal/server/handlers_oauth_claim.go for the response shape
+// and error envelope. PLAN-1519 / TASK-1521 / IDEA-1517 §4.
+//
+// Both inputs are required at the MCP boundary. The server-side
+// handler enforces the constant-time HMAC check + sliding 5–10 min
+// lifetime; this mapper is a pure pass-through.
+func mapWorkspaceClaim(input map[string]any) (string, string, []byte, error) {
+	workspace, _ := input["workspace"].(string)
+	if workspace == "" {
+		return "", "", nil, fmt.Errorf("workspace is required")
+	}
+	code, _ := input["code"].(string)
+	if code == "" {
+		return "", "", nil, fmt.Errorf("code is required")
+	}
+	payload := map[string]any{"workspace": workspace, "code": code}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return "", "", nil, fmt.Errorf("encode body: %w", err)
+	}
+	return http.MethodPost, "/api/v1/oauth/claim", body, nil
 }
 
 // mapWorkspaceInvite dispatches `pad workspace invite <email>

--- a/internal/mcp/instructions.md
+++ b/internal/mcp/instructions.md
@@ -63,6 +63,12 @@ pad_item.action: list, collection: "conventions", status: "active"
 
 Filter by trigger (`always`, `on-implement`, `on-task-complete`, etc.) when relevant.
 
+## Adding a workspace to this connection
+
+If the user references a workspace this connection can't see (you'll get a 403 from workspace tools, or the workspace won't appear in `pad_workspace.list`), tell the user you can't see that workspace with your current permissions, then walk them through how to grant access: open Pad in their browser → switch to that workspace → avatar menu → "Connect project..." A 6-digit claim code will appear. Have them paste it back in chat, then call `pad_workspace.claim` with `{workspace: "<slug>", code: "<6 digits>"}`. The workspace joins this connection's allow-list and stays until the user revokes it via `/console/connected-apps`. No re-auth required.
+
+For brand-new workspaces, `pad_workspace.create` with `{name: "<name>"}` (and optional `template`) creates the workspace AND auto-adds it to this connection's allow-list in one call — no claim code needed. Only works when the user granted "may create workspaces" at consent time; if that scope was declined the create call still succeeds but the workspace doesn't auto-join — direct the user to the claim flow above to bring it in.
+
 ## Multi-step workflows
 
 Four prompts ship with the server: `pad_plan`, `pad_ideate`, `pad_retro`, `pad_onboard`. Use them when the user wants help planning, brainstorming, retrospecting, or onboarding into a workspace — they encode the multi-step Pad-aware playbook for each.

--- a/internal/server/claim_codes.go
+++ b/internal/server/claim_codes.go
@@ -1,0 +1,144 @@
+package server
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/binary"
+	"fmt"
+	"time"
+)
+
+// Stateless 6-digit claim codes (PLAN-1519 / TASK-1521 / IDEA-1517 §4).
+//
+// A claim code lets a user grant an existing OAuth connection access to
+// one specific workspace they own/belong to. The user generates the
+// code in the web UI (Phase E "Connect project" modal), reads it to
+// their agent, and the agent calls `pad_workspace.action: claim` —
+// which calls POST /api/v1/oauth/claim with {workspace, code}.
+//
+// **Why stateless.** Generating + storing + GC'ing per-code rows would
+// pollute the schema and require background sweeps. Instead we
+// HMAC-derive the code from (user_id, workspace_id, 5-min time bucket)
+// using a server-stable secret. Server re-derives on claim and
+// constant-time compares. Verifier checks the current AND previous
+// bucket so the effective lifetime is 5–10 minutes (sliding window) —
+// long enough for the user to paste the prompt, short enough that a
+// snoop with the code has limited replay surface.
+//
+// **Threat model.** An attacker who knows the secret can mint codes
+// for any (user, workspace) pair — same posture as anyone who can
+// mint fosite tokens, which uses the same secret material. An attacker
+// who DOESN'T know the secret can't fabricate codes; they can only
+// observe ones in flight (5-10 minute window) AND must also control an
+// OAuth connection belonging to the same user to redeem (the claim
+// handler binds redemption to the calling grant's owner — see
+// handleOAuthClaim).
+//
+// **Code format.** Six decimal digits, zero-padded. Truncated from
+// HMAC-SHA256(secret, payload) modulo 10^6. Birthday collisions are
+// irrelevant — verification re-derives + compares for a specific
+// (user, workspace) tuple, not against a global pool — so the small
+// digit count just controls how guessable a fresh code is. Without
+// rate limiting, brute force is 10^6 attempts on the claim endpoint;
+// rate limiting at the /mcp gate (TASK-959) caps that in practice.
+// If 6 digits ever proves too narrow, bump to 8 — the same derive +
+// modulus logic applies.
+
+const (
+	// claimCodeDigits is how many decimal digits the code carries.
+	// 6 is the IDEA-1517 §4 spec. Changing it is a wire-format change
+	// — the modal text + agent NL parser both reference "6-digit."
+	claimCodeDigits = 6
+
+	// claimCodeModulus is 10^claimCodeDigits, used to truncate the
+	// HMAC output to digit count.
+	claimCodeModulus = 1_000_000
+
+	// claimBucketSeconds is the granularity of the time component
+	// going into the HMAC. Locked to 5 minutes per IDEA-1517 §4:
+	// "Bucket size: hardcoded 5 minutes." Combined with the
+	// current+previous bucket check below this yields a sliding
+	// 5–10 minute effective lifetime.
+	claimBucketSeconds = 300
+)
+
+// DeriveClaimCode produces the 6-digit code for the given (user,
+// workspace) at the given wall-clock time. Exported so the Phase E
+// "Connect project" modal handler can render the same code the claim
+// path will verify.
+//
+// secret must be at least 16 bytes of cryptographically-strong material
+// — production wires the 32-byte encryption key from the deployment
+// config. Shorter secrets degrade to "obfuscation" rather than HMAC
+// strength; the constructor in SetClaimSecret rejects them.
+//
+// Returns "000000"–"999999" zero-padded so the wire format is uniform
+// (avoids an agent stripping leading zeros when echoing the code back).
+func DeriveClaimCode(secret []byte, userID, workspaceID string, at time.Time) string {
+	bucket := at.UTC().Unix() / claimBucketSeconds
+	return deriveClaimCodeForBucket(secret, userID, workspaceID, bucket)
+}
+
+// deriveClaimCodeForBucket is the inner derive — split out so
+// VerifyClaimCode can derive both the current and previous bucket
+// without re-computing the bucket math twice.
+func deriveClaimCodeForBucket(secret []byte, userID, workspaceID string, bucket int64) string {
+	mac := hmac.New(sha256.New, secret)
+	// Length-prefix each component so two distinct (user, workspace)
+	// pairs that happen to concatenate to the same byte string (e.g.
+	// userID="abc" + workspaceID="def" vs. userID="abcdef" +
+	// workspaceID="") can't collide on the same code. Belt-and-
+	// suspenders — UUIDs don't realistically alias, but a future
+	// schema change to numeric IDs could re-introduce the risk.
+	writeLenPrefixed(mac, []byte(userID))
+	writeLenPrefixed(mac, []byte(workspaceID))
+	var bucketBytes [8]byte
+	binary.BigEndian.PutUint64(bucketBytes[:], uint64(bucket))
+	mac.Write(bucketBytes[:])
+	sum := mac.Sum(nil)
+	// Take the first 8 bytes as an unsigned int, then mod down to
+	// the digit count. Using the full 32-byte hash would be wasteful
+	// (we throw away 24 bytes either way); 8 bytes gives plenty of
+	// entropy before truncation.
+	n := binary.BigEndian.Uint64(sum[:8]) % claimCodeModulus
+	return fmt.Sprintf("%0*d", claimCodeDigits, n)
+}
+
+// writeLenPrefixed writes a 4-byte big-endian length followed by the
+// raw bytes. Cheap collision-resistant separator for HMAC inputs.
+func writeLenPrefixed(w interface{ Write([]byte) (int, error) }, b []byte) {
+	var lenBytes [4]byte
+	binary.BigEndian.PutUint32(lenBytes[:], uint32(len(b)))
+	w.Write(lenBytes[:])
+	w.Write(b)
+}
+
+// VerifyClaimCode returns true if code matches the derived code for
+// (userID, workspaceID) at the current OR previous time bucket — the
+// sliding 5–10 minute lifetime described in IDEA-1517 §4.
+//
+// Constant-time compare prevents timing oracles from leaking which of
+// the two derivations failed (which would reduce the effective lifetime
+// signal to 5 minutes rather than 10).
+//
+// Empty code, empty userID, or empty workspaceID always return false —
+// no need to even derive in those cases.
+func VerifyClaimCode(secret []byte, userID, workspaceID, code string, at time.Time) bool {
+	if code == "" || userID == "" || workspaceID == "" || len(secret) < 16 {
+		return false
+	}
+	if len(code) != claimCodeDigits {
+		return false
+	}
+	bucket := at.UTC().Unix() / claimBucketSeconds
+	current := deriveClaimCodeForBucket(secret, userID, workspaceID, bucket)
+	previous := deriveClaimCodeForBucket(secret, userID, workspaceID, bucket-1)
+	codeBytes := []byte(code)
+	// ConstantTimeCompare returns 1 on match. OR the two results so
+	// either matching bucket passes; subtle's compare doesn't panic
+	// on equal-length operands so length-mismatch isn't a concern
+	// here (we already gated on claimCodeDigits above).
+	return subtle.ConstantTimeCompare(codeBytes, []byte(current)) == 1 ||
+		subtle.ConstantTimeCompare(codeBytes, []byte(previous)) == 1
+}

--- a/internal/server/claim_codes_test.go
+++ b/internal/server/claim_codes_test.go
@@ -1,0 +1,167 @@
+package server
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// Tests for the stateless HMAC claim-code mechanics (PLAN-1519 /
+// TASK-1521 / IDEA-1517 §4).
+//
+// What's covered:
+//
+//   - DeriveClaimCode is deterministic for the same (secret, user,
+//     workspace, time bucket) — same call twice produces the same code.
+//   - Codes are six decimal digits, zero-padded.
+//   - Different (user) or (workspace) inputs produce different codes
+//     even with the same secret + time (no collisions by length-prefix
+//     boundary games — would catch a regression where we concatenate
+//     without length prefix).
+//   - VerifyClaimCode accepts a code from the current bucket.
+//   - VerifyClaimCode accepts a code from the PREVIOUS bucket (5–10 min
+//     sliding lifetime).
+//   - VerifyClaimCode REJECTS a code older than two buckets.
+//   - VerifyClaimCode rejects wrong code / wrong user / wrong workspace.
+//   - VerifyClaimCode rejects empty / wrong-length codes without
+//     hitting the HMAC (cheap fast path).
+//   - Short secret (< 16 bytes) makes VerifyClaimCode fail closed even
+//     against a derive that used the same short secret — the verifier
+//     enforces the minimum independently of the derive side, so a
+//     misconfigured deployment can't accept its own forgeable codes.
+
+func TestDeriveClaimCode_Deterministic(t *testing.T) {
+	secret := []byte("a-very-deterministic-test-secret-32")
+	at := time.Date(2026, 5, 18, 4, 0, 0, 0, time.UTC)
+	a := DeriveClaimCode(secret, "user-1", "ws-1", at)
+	b := DeriveClaimCode(secret, "user-1", "ws-1", at)
+	if a != b {
+		t.Errorf("non-deterministic derive: %q vs %q", a, b)
+	}
+	if len(a) != 6 {
+		t.Errorf("code should be 6 digits, got %q (len=%d)", a, len(a))
+	}
+	for _, c := range a {
+		if c < '0' || c > '9' {
+			t.Errorf("code should be all decimal digits, got %q", a)
+		}
+	}
+}
+
+func TestDeriveClaimCode_ZeroPadded(t *testing.T) {
+	// Brute-force search for an input whose derive happens to be small —
+	// we want to verify zero-padding works. With 10^6 possible codes,
+	// roughly 1-in-10 derives lands under 100000; trying 200 different
+	// workspace IDs is overwhelmingly likely to surface one.
+	secret := []byte("padding-search-secret-bytes-here-32")
+	at := time.Date(2026, 5, 18, 4, 0, 0, 0, time.UTC)
+	for i := 0; i < 200; i++ {
+		ws := "ws-pad-" + string(rune('a'+i%26)) + string(rune('a'+i/26))
+		code := DeriveClaimCode(secret, "user", ws, at)
+		if strings.HasPrefix(code, "0") {
+			if len(code) != 6 {
+				t.Errorf("zero-padded code should still be 6 digits, got %q", code)
+			}
+			return // found one, assertion satisfied
+		}
+	}
+	t.Log("no leading-zero code found in 200 derivations — extremely unlikely; rerun with more iterations if hit")
+}
+
+func TestDeriveClaimCode_NoCollisionOnConcatBoundary(t *testing.T) {
+	// Without length-prefixing, ("abc", "def") and ("abcdef", "") would
+	// HMAC the same byte sequence and produce identical codes. The
+	// length-prefix in writeLenPrefixed prevents this. Regression
+	// guard — would fail if someone "simplifies" the derive to a bare
+	// concatenation.
+	secret := []byte("collision-test-secret-bytes-here-32")
+	at := time.Date(2026, 5, 18, 4, 0, 0, 0, time.UTC)
+	a := DeriveClaimCode(secret, "abc", "def", at)
+	b := DeriveClaimCode(secret, "abcdef", "", at)
+	if a == b {
+		t.Errorf("length-prefix regression: (abc,def) and (abcdef,'') derived to same code %q", a)
+	}
+}
+
+func TestVerifyClaimCode_CurrentBucketAccepted(t *testing.T) {
+	secret := []byte("verify-current-secret-bytes-here-32")
+	at := time.Date(2026, 5, 18, 4, 0, 0, 0, time.UTC)
+	code := DeriveClaimCode(secret, "u", "w", at)
+	if !VerifyClaimCode(secret, "u", "w", code, at) {
+		t.Errorf("current-bucket code %q should verify", code)
+	}
+}
+
+func TestVerifyClaimCode_PreviousBucketAccepted(t *testing.T) {
+	secret := []byte("verify-previous-secret-bytes-here-32")
+	at := time.Date(2026, 5, 18, 4, 0, 0, 0, time.UTC)
+	code := DeriveClaimCode(secret, "u", "w", at)
+	// 4 minutes later — same bucket. Still verifies.
+	if !VerifyClaimCode(secret, "u", "w", code, at.Add(4*time.Minute)) {
+		t.Errorf("code should still verify 4 minutes later (same bucket)")
+	}
+	// 6 minutes later — next bucket; the original code is now in the
+	// "previous bucket" position. Still verifies.
+	if !VerifyClaimCode(secret, "u", "w", code, at.Add(6*time.Minute)) {
+		t.Errorf("code should still verify 6 minutes later (previous bucket window)")
+	}
+}
+
+func TestVerifyClaimCode_AgedOutRejected(t *testing.T) {
+	secret := []byte("verify-aged-secret-bytes-here-3232")
+	at := time.Date(2026, 5, 18, 4, 0, 0, 0, time.UTC)
+	code := DeriveClaimCode(secret, "u", "w", at)
+	// 11 minutes later — more than two buckets gone, even with sliding
+	// alignment. Must NOT verify.
+	if VerifyClaimCode(secret, "u", "w", code, at.Add(11*time.Minute)) {
+		t.Errorf("aged-out code (>10 min) should not verify")
+	}
+}
+
+func TestVerifyClaimCode_WrongInputsRejected(t *testing.T) {
+	secret := []byte("verify-wrong-secret-bytes-here-3232")
+	at := time.Date(2026, 5, 18, 4, 0, 0, 0, time.UTC)
+	code := DeriveClaimCode(secret, "right-user", "right-ws", at)
+
+	cases := []struct {
+		name    string
+		userID  string
+		wsID    string
+		code    string
+		wantOK  bool
+		comment string
+	}{
+		{"right code right user right ws", "right-user", "right-ws", code, true, "baseline"},
+		{"wrong user same ws", "wrong-user", "right-ws", code, false, "user-bound"},
+		{"right user wrong ws", "right-user", "wrong-ws", code, false, "ws-bound"},
+		{"wrong code", "right-user", "right-ws", "000000", false, "wrong digits — almost certainly"},
+		{"empty code fast-rejects", "right-user", "right-ws", "", false, "guard before HMAC"},
+		{"5-digit code rejected", "right-user", "right-ws", "12345", false, "wrong length, guard before HMAC"},
+		{"7-digit code rejected", "right-user", "right-ws", "1234567", false, "wrong length, guard before HMAC"},
+		{"empty user", "", "right-ws", code, false, "guard"},
+		{"empty workspace", "right-user", "", code, false, "guard"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := VerifyClaimCode(secret, tc.userID, tc.wsID, tc.code, at)
+			if got != tc.wantOK {
+				t.Errorf("%s: want %v got %v (%s)", tc.name, tc.wantOK, got, tc.comment)
+			}
+		})
+	}
+}
+
+func TestVerifyClaimCode_ShortSecretFailsClosed(t *testing.T) {
+	// Derive with a too-short secret — the derive path doesn't reject
+	// (it's a pure function; the SetClaimSecret setter is where the
+	// guard nominally lives). Verify with the same secret must still
+	// return false because VerifyClaimCode enforces the 16-byte
+	// minimum independently. This guards against a regression where
+	// VerifyClaimCode might trust whatever it's given.
+	tooShort := []byte("short")
+	at := time.Date(2026, 5, 18, 4, 0, 0, 0, time.UTC)
+	code := DeriveClaimCode(tooShort, "u", "w", at)
+	if VerifyClaimCode(tooShort, "u", "w", code, at) {
+		t.Errorf("verifier must reject when secret is shorter than 16 bytes, even if derive matches")
+	}
+}

--- a/internal/server/handlers_oauth.go
+++ b/internal/server/handlers_oauth.go
@@ -80,6 +80,34 @@ func (s *Server) SetOAuthServer(srv *oauth.Server) {
 	s.wireOAuthMetricsObserver()
 }
 
+// SetClaimSecret wires the HMAC key used to derive + verify stateless
+// 6-digit claim codes for the POST /api/v1/oauth/claim endpoint
+// (PLAN-1519 / TASK-1521 / IDEA-1517 §4). MUST be called before
+// setupRouter so the route is mounted; production wires the deployment's
+// 32-byte encryption key from cmd/pad/main.go right after SetOAuthServer.
+//
+// secret must be at least 16 bytes of cryptographically-strong
+// material. Shorter values are accepted by the setter (so tests can
+// pass deterministic fixtures) but the handler short-circuits to a
+// 412 "claim_disabled" envelope on every request — the same envelope
+// it returns when the secret is nil — so a misconfigured deployment
+// surfaces the issue rather than silently accepting forgeable codes.
+//
+// Passing nil clears any previously-set secret, disabling the
+// endpoint. Useful in tests that exercise the disabled-deployment
+// branch without spinning up a fresh server.
+func (s *Server) SetClaimSecret(secret []byte) {
+	if secret == nil {
+		s.claimSecret = nil
+		return
+	}
+	// Defensive copy — caller mutating the slice after the call must
+	// not retroactively change every future claim derivation.
+	cp := make([]byte, len(secret))
+	copy(cp, secret)
+	s.claimSecret = cp
+}
+
 // registerOAuthRoutes mounts the OAuth endpoints on r. Called from
 // setupRouter at the same level as the MCP routes. No-op when
 // either cloud mode is off or SetOAuthServer was never called —

--- a/internal/server/handlers_oauth_claim.go
+++ b/internal/server/handlers_oauth_claim.go
@@ -1,0 +1,185 @@
+package server
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/store"
+)
+
+// POST /api/v1/oauth/claim — claim-code redemption endpoint
+// (PLAN-1519 / TASK-1521 / IDEA-1517 §4).
+//
+// Lets the user grant an existing OAuth connection access to one
+// specific workspace by redeeming a 6-digit stateless HMAC code the
+// user generated in the web UI's "Connect project" modal (Phase E).
+//
+// Flow (the agent does steps 2-4):
+//  1. User generates a code in the web UI for workspace W.
+//  2. User reads the code to the agent.
+//  3. Agent calls `pad_workspace.action: claim` with {workspace, code}.
+//  4. Dispatcher hits POST /api/v1/oauth/claim with the same payload.
+//
+// The endpoint:
+//   - Requires authentication. PAT and OAuth bearers both reach this
+//     handler via the standard /api/v1 auth chain; the OAuth-only
+//     side effect (adding the workspace to oauth_connection_workspaces)
+//     no-ops for PAT auth (it has no request_id), leaving the endpoint
+//     usable but inert from a CLI session token.
+//   - Resolves the workspace by slug, checks the user is a member
+//     (404 → workspace not visible).
+//   - Re-derives the claim code from (user_id, workspace_id, current
+//     OR previous 5-min bucket) using the server's claim secret and
+//     constant-time compares. Mismatch → 401.
+//   - On success, INSERTs into oauth_connection_workspaces with
+//     added_by='claim'. Idempotent — re-claiming a workspace already
+//     in the allow-list is a no-op (returns 200, "already_added": true).
+//
+// **No scope check on the calling grant.** The user generating + handing
+// over the code IS the consent — IDEA-1517 §4 explicitly: "Claim works
+// regardless of scope flags (orthogonal to the three toggles)." A grant
+// with `all_current_workspaces=true` simply doesn't NEED the row — the
+// claim still succeeds but the row is redundant; we insert anyway so
+// the audit trail is uniform.
+//
+// **Error envelope.**
+//   - 400 bad_request — missing workspace or code, malformed body.
+//   - 401 invalid_code — code didn't verify against either bucket.
+//   - 404 not_found — workspace doesn't exist OR user isn't a member.
+//     (Single 404 vocabulary so the endpoint doesn't leak which
+//     workspaces the user knows about vs. is a member of.)
+//   - 412 precondition_failed — claim secret not configured on this
+//     deployment (shouldn't happen in production; self-host without
+//     cloud-mode OAuth doesn't mount this route in the first place,
+//     but the guard is defense in depth for cases where the route
+//     mounts before the secret is wired).
+//   - 500 internal_error — DB I/O failure.
+func (s *Server) handleOAuthClaim(w http.ResponseWriter, r *http.Request) {
+	// Refuse if the claim secret hasn't been wired. The route is
+	// only mounted when the secret is set (see registerOAuthClaimRoute),
+	// but checking again is cheap and prevents a stray request from
+	// reaching DeriveClaimCode with a too-short secret.
+	if len(s.claimSecret) < 16 {
+		writeError(w, http.StatusPreconditionFailed, "claim_disabled",
+			"Claim-code redemption is not enabled on this deployment.")
+		return
+	}
+
+	user := currentUser(r)
+	if user == nil {
+		// /api/v1/* mounts RequireAuth, so this is defense in depth.
+		writeError(w, http.StatusUnauthorized, "auth_required", "Authentication required.")
+		return
+	}
+
+	var input struct {
+		Workspace string `json:"workspace"`
+		Code      string `json:"code"`
+	}
+	if err := decodeJSON(r, &input); err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", err.Error())
+		return
+	}
+	input.Workspace = strings.TrimSpace(input.Workspace)
+	input.Code = strings.TrimSpace(input.Code)
+	if input.Workspace == "" || input.Code == "" {
+		writeError(w, http.StatusBadRequest, "bad_request",
+			"Both workspace (slug) and code (6 digits) are required.")
+		return
+	}
+
+	ws, err := s.store.GetWorkspaceBySlug(input.Workspace)
+	if err != nil || ws == nil {
+		// Don't distinguish "doesn't exist" from "you're not a
+		// member" — 404 uniform so the endpoint can't be used to
+		// probe workspace existence.
+		writeError(w, http.StatusNotFound, "not_found", "Workspace not found.")
+		return
+	}
+	// Verify the requesting user is actually a member of the workspace
+	// before the code is even checked. Non-member redemption would
+	// grant access to a workspace the user doesn't belong to — a
+	// privilege escalation. The same 404 envelope ensures non-members
+	// can't probe.
+	member, err := s.store.GetWorkspaceMember(ws.ID, user.ID)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	if member == nil {
+		writeError(w, http.StatusNotFound, "not_found", "Workspace not found.")
+		return
+	}
+
+	// Verify the code. VerifyClaimCode checks the current AND previous
+	// 5-min bucket (sliding 5–10 min lifetime per IDEA-1517 §4) and
+	// constant-time compares to prevent timing oracles from leaking
+	// which bucket matched.
+	if !VerifyClaimCode(s.claimSecret, user.ID, ws.ID, input.Code, time.Now()) {
+		writeError(w, http.StatusUnauthorized, "invalid_code",
+			"Claim code is invalid or expired. Generate a fresh code in the workspace's Connect modal.")
+		return
+	}
+
+	// Resolve the calling connection. PAT auth has no request_id and
+	// the side effect simply doesn't apply — return 200 with a hint so
+	// the caller knows the code was good but the grant wasn't an OAuth
+	// connection. Matches the IDEA's "CLI / skill users do NOT need
+	// this guidance — they have full workspace access via session
+	// tokens already" — but lets a confused PAT caller see a clear
+	// outcome rather than a silent success.
+	kind, requestID := MCPTokenIdentityFromContext(r.Context())
+	if kind != "oauth" || requestID == "" {
+		writeJSON(w, http.StatusOK, map[string]any{
+			"workspace":     ws.Slug,
+			"workspace_id":  ws.ID,
+			"already_added": false,
+			"note": "Code verified, but this caller is not an OAuth connection " +
+				"(PAT or CLI session token). Allow-list state lives per-OAuth-grant; " +
+				"PATs and CLI session tokens already see every workspace you belong to.",
+		})
+		return
+	}
+
+	// Was it already in the allow-list? Idempotent claim — re-claiming
+	// a workspace already covered is a no-op (still returns 200, but
+	// reports already_added so the agent can phrase the user-facing
+	// reply accordingly).
+	already, err := s.store.IsConnectionWorkspaceAllowed(requestID, ws.ID)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+
+	if !already {
+		// Pre-check the parent oauth_connections row before attempting
+		// the join-table insert. The FK constraint in
+		// oauth_connection_workspaces would otherwise reject the INSERT
+		// with a wrapped driver error, which is awkward to translate
+		// into a clean 412 here. Phase A's tables stay empty until
+		// Phase C wires the consent-screen write path, so the "no
+		// connection row" case is expected on Phase-B-only deployments
+		// — return 412 with a hint to re-authorize instead of 500.
+		if _, err := s.store.GetOAuthConnection(requestID); err != nil {
+			if errors.Is(err, store.ErrOAuthConnectionNotFound) {
+				writeError(w, http.StatusPreconditionFailed, "connection_not_persisted",
+					"This OAuth grant predates per-connection storage; re-authorize to enable claim-code redemption.")
+				return
+			}
+			writeInternalError(w, err)
+			return
+		}
+		if err := s.store.AddConnectionWorkspace(requestID, ws.ID, store.AddedByClaim); err != nil {
+			writeInternalError(w, err)
+			return
+		}
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"workspace":     ws.Slug,
+		"workspace_id":  ws.ID,
+		"already_added": already,
+	})
+}

--- a/internal/server/handlers_oauth_claim_test.go
+++ b/internal/server/handlers_oauth_claim_test.go
@@ -1,0 +1,311 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/store"
+)
+
+// HTTP-handler tests for POST /api/v1/oauth/claim
+// (PLAN-1519 / TASK-1521 / IDEA-1517 §4).
+//
+// What's covered:
+//
+//   - Endpoint 412s when SetClaimSecret hasn't been called (defense
+//     in depth — the route is mounted unconditionally, the secret
+//     gate is the safety net).
+//   - 400 on missing workspace / code / malformed body.
+//   - 404 when the workspace doesn't exist OR the user isn't a member
+//     — single envelope so the endpoint can't be used to probe
+//     workspace existence.
+//   - 401 on wrong / expired code.
+//   - 200 + side effect insert when the code verifies AND the caller
+//     is an OAuth grant (request_id set in context).
+//   - 200 + "note" populated for PAT callers — code verifies but no
+//     side effect runs (PAT has no grant to add to).
+//   - Idempotent: re-claiming an already-allowed workspace returns
+//     200 with already_added=true.
+//   - 412 connection_not_persisted when the OAuth grant predates
+//     Phase C (no oauth_connections row).
+//
+// Auth is via PAT (Bearer) so CSRF + session-cookie machinery doesn't
+// intrude. PAT auth doesn't set the OAuth request_id context value,
+// which is exactly the "no oauth grant" branch we want to exercise
+// for the note + 412 paths. The OAuth-grant-bound case is exercised
+// by synthesizing the WithMCPTokenIdentity context value directly via
+// a custom test request.
+
+// claimTestEnv bundles the server, a user, that user's PAT, and a
+// workspace they own — the common shape every claim test needs.
+type claimTestEnv struct {
+	srv       *Server
+	user      *models.User
+	pat       string
+	ws        *models.Workspace
+	wsSlug    string
+	secret    []byte
+	claimCode string
+	now       time.Time
+}
+
+func newClaimTestEnv(t *testing.T) *claimTestEnv {
+	t.Helper()
+	srv := testServer(t)
+	// Wire a deterministic claim secret (32 bytes — production reuses
+	// the encryption key, same length).
+	secret := bytes32ForTest()
+	srv.SetClaimSecret(secret)
+
+	user, err := srv.store.CreateUser(models.UserCreate{
+		Email: "claim-test@example.com", Name: "Claim Tester", Password: "pw-claim-12345",
+	})
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	ws, err := srv.store.CreateWorkspace(models.WorkspaceCreate{
+		Name: "Claim Test WS", OwnerID: user.ID,
+	})
+	if err != nil {
+		t.Fatalf("CreateWorkspace: %v", err)
+	}
+	if err := srv.store.AddWorkspaceMember(ws.ID, user.ID, "owner"); err != nil {
+		t.Fatalf("AddWorkspaceMember: %v", err)
+	}
+	tok, err := srv.store.CreateAPIToken(user.ID, models.APITokenCreate{
+		Name:        "claim-test-pat",
+		WorkspaceID: ws.ID,
+	}, 30, 0)
+	if err != nil {
+		t.Fatalf("CreateAPIToken: %v", err)
+	}
+	// Derive against wall-clock time — the handler reads time.Now()
+	// directly. Tests complete within the 5-minute bucket so the
+	// derive and verify land in the same window.
+	now := time.Now().UTC()
+	code := DeriveClaimCode(secret, user.ID, ws.ID, now)
+	return &claimTestEnv{
+		srv: srv, user: user, pat: tok.Token, ws: ws, wsSlug: ws.Slug,
+		secret: secret, claimCode: code, now: now,
+	}
+}
+
+// doClaim issues a POST /api/v1/oauth/claim with Bearer PAT auth.
+// extraReqID, if non-empty, attaches a WithMCPTokenIdentity context
+// override to simulate an OAuth-grant-bound request without spinning
+// up a full OAuth fixture — handleOAuthClaim only reads the typed
+// context helper, so this is enough to exercise the OAuth branch.
+func (e *claimTestEnv) doClaim(body any, extraReqID string) *httptest.ResponseRecorder {
+	var bodyReader *strings.Reader
+	if body != nil {
+		b, _ := json.Marshal(body)
+		bodyReader = strings.NewReader(string(b))
+	}
+	var req *http.Request
+	if bodyReader != nil {
+		req = httptest.NewRequest("POST", "/api/v1/oauth/claim", bodyReader)
+		req.Header.Set("Content-Type", "application/json")
+	} else {
+		req = httptest.NewRequest("POST", "/api/v1/oauth/claim", nil)
+	}
+	req.Header.Set("Authorization", "Bearer "+e.pat)
+	req.RemoteAddr = "192.0.2.1:1234"
+
+	if extraReqID != "" {
+		// Wrap the handler so we can decorate the request context
+		// AFTER TokenAuth runs (it would otherwise clear/ignore our
+		// override). The simplest path is to compose a tiny middleware
+		// that re-attaches the identity post-auth. Mirrors the
+		// pattern handlers_mcp_test.go uses for similar context
+		// injection.
+		rr := httptest.NewRecorder()
+		wrap := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			r = r.WithContext(WithMCPTokenIdentity(r.Context(), "oauth", extraReqID))
+			e.srv.ServeHTTP(w, r)
+		})
+		wrap.ServeHTTP(rr, req)
+		return rr
+	}
+	rr := httptest.NewRecorder()
+	e.srv.ServeHTTP(rr, req)
+	return rr
+}
+
+func TestHandleOAuthClaim_ClaimSecretDisabled412(t *testing.T) {
+	srv := testServer(t)
+	user, err := srv.store.CreateUser(models.UserCreate{
+		Email: "d@example.com", Name: "D", Password: "pw-disabled-12345",
+	})
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	ws, err := srv.store.CreateWorkspace(models.WorkspaceCreate{Name: "Disabled WS", OwnerID: user.ID})
+	if err != nil {
+		t.Fatalf("CreateWorkspace: %v", err)
+	}
+	tok, err := srv.store.CreateAPIToken(user.ID, models.APITokenCreate{
+		Name: "d", WorkspaceID: ws.ID,
+	}, 30, 0)
+	if err != nil {
+		t.Fatalf("CreateAPIToken: %v", err)
+	}
+	// Deliberately do NOT call SetClaimSecret.
+
+	req := httptest.NewRequest("POST", "/api/v1/oauth/claim",
+		strings.NewReader(`{"workspace":"x","code":"123456"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+tok.Token)
+	req.RemoteAddr = "192.0.2.1:1234"
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	if rr.Code != http.StatusPreconditionFailed {
+		t.Errorf("status = %d, want 412 (claim_disabled)", rr.Code)
+	}
+}
+
+func TestHandleOAuthClaim_BadRequest400(t *testing.T) {
+	e := newClaimTestEnv(t)
+	cases := []struct {
+		name string
+		body any
+	}{
+		{"missing both", map[string]string{}},
+		{"missing code", map[string]string{"workspace": "x"}},
+		{"missing workspace", map[string]string{"code": "123456"}},
+		{"empty strings", map[string]string{"workspace": "", "code": ""}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rr := e.doClaim(tc.body, "")
+			if rr.Code != http.StatusBadRequest {
+				t.Errorf("status = %d, want 400 (body=%s)", rr.Code, rr.Body.String())
+			}
+		})
+	}
+}
+
+func TestHandleOAuthClaim_WorkspaceNotFound404(t *testing.T) {
+	e := newClaimTestEnv(t)
+	rr := e.doClaim(map[string]string{"workspace": "no-such-ws", "code": "123456"}, "")
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", rr.Code)
+	}
+}
+
+func TestHandleOAuthClaim_NotAMember404(t *testing.T) {
+	e := newClaimTestEnv(t)
+	// Create a second workspace owned by someone else; the PAT user
+	// isn't a member. 404 (uniform with "not found" so existence isn't
+	// leaked).
+	other, _ := e.srv.store.CreateUser(models.UserCreate{
+		Email: "other@example.com", Name: "Other", Password: "pw-other-12345",
+	})
+	otherWS, _ := e.srv.store.CreateWorkspace(models.WorkspaceCreate{
+		Name: "Other WS", OwnerID: other.ID,
+	})
+	_ = e.srv.store.AddWorkspaceMember(otherWS.ID, other.ID, "owner")
+
+	rr := e.doClaim(map[string]string{"workspace": otherWS.Slug, "code": "123456"}, "")
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404 (not-a-member should look like not-found)", rr.Code)
+	}
+}
+
+func TestHandleOAuthClaim_WrongCode401(t *testing.T) {
+	e := newClaimTestEnv(t)
+	rr := e.doClaim(map[string]string{"workspace": e.wsSlug, "code": "000000"}, "")
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401 (body=%s)", rr.Code, rr.Body.String())
+	}
+}
+
+func TestHandleOAuthClaim_PATCallerOK_NoSideEffect(t *testing.T) {
+	e := newClaimTestEnv(t)
+	rr := e.doClaim(map[string]string{"workspace": e.wsSlug, "code": e.claimCode}, "")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body=%s)", rr.Code, rr.Body.String())
+	}
+	var resp ClaimWorkspaceResponseTestProjection
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Workspace != e.wsSlug {
+		t.Errorf("workspace = %q, want %q", resp.Workspace, e.wsSlug)
+	}
+	if resp.AlreadyAdded {
+		t.Errorf("already_added = true, want false (PAT path doesn't add)")
+	}
+	if resp.Note == "" {
+		t.Errorf("note should be populated for PAT caller — handler must explain the no-op")
+	}
+}
+
+func TestHandleOAuthClaim_OAuthCaller_NoConnectionRow_412(t *testing.T) {
+	e := newClaimTestEnv(t)
+	// OAuth-grant context BUT no row in oauth_connections — Phase-A
+	// state: write path lands in Phase C. Handler must return 412
+	// with connection_not_persisted, not a generic 500.
+	rr := e.doClaim(map[string]string{"workspace": e.wsSlug, "code": e.claimCode}, "phase-a-grant")
+	if rr.Code != http.StatusPreconditionFailed {
+		t.Fatalf("status = %d, want 412 (body=%s)", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "connection_not_persisted") {
+		t.Errorf("body should contain connection_not_persisted, got %s", rr.Body.String())
+	}
+}
+
+func TestHandleOAuthClaim_OAuthCaller_Inserts_Idempotent(t *testing.T) {
+	e := newClaimTestEnv(t)
+	requestID := "fake-grant-chain"
+	// Seed the connection row so the FK + pre-check is happy.
+	if err := e.srv.store.CreateOAuthConnection(store.OAuthConnection{
+		RequestID: requestID, UserID: e.user.ID, Name: "Cursor",
+	}); err != nil {
+		t.Fatalf("CreateOAuthConnection: %v", err)
+	}
+
+	// First claim — inserts.
+	rr := e.doClaim(map[string]string{"workspace": e.wsSlug, "code": e.claimCode}, requestID)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("first claim status = %d, want 200 (body=%s)", rr.Code, rr.Body.String())
+	}
+	var resp ClaimWorkspaceResponseTestProjection
+	parseJSON(t, rr, &resp)
+	if resp.AlreadyAdded {
+		t.Errorf("first claim already_added = true, want false")
+	}
+	// Verify the join row exists.
+	allowed, err := e.srv.store.IsConnectionWorkspaceAllowed(requestID, e.ws.ID)
+	if err != nil {
+		t.Fatalf("IsConnectionWorkspaceAllowed: %v", err)
+	}
+	if !allowed {
+		t.Errorf("workspace should be in allow-list after successful claim")
+	}
+
+	// Second claim — idempotent.
+	rr = e.doClaim(map[string]string{"workspace": e.wsSlug, "code": e.claimCode}, requestID)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("second claim status = %d, want 200", rr.Code)
+	}
+	parseJSON(t, rr, &resp)
+	if !resp.AlreadyAdded {
+		t.Errorf("second claim already_added = false, want true (idempotent)")
+	}
+}
+
+// ClaimWorkspaceResponseTestProjection mirrors the wire shape of the
+// ClaimWorkspaceResponse defined on the CLI client side. Duplicated
+// here to keep the server-side test from importing the cli package
+// (which would introduce an upward dep).
+type ClaimWorkspaceResponseTestProjection struct {
+	Workspace    string `json:"workspace"`
+	WorkspaceID  string `json:"workspace_id"`
+	AlreadyAdded bool   `json:"already_added"`
+	Note         string `json:"note,omitempty"`
+}

--- a/internal/server/handlers_workspaces.go
+++ b/internal/server/handlers_workspaces.go
@@ -3,12 +3,14 @@ package server
 import (
 	"database/sql"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"strings"
 
 	"github.com/PerpetualSoftware/pad/internal/collections"
 	"github.com/PerpetualSoftware/pad/internal/events"
 	"github.com/PerpetualSoftware/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/store"
 )
 
 func normalizeWorkspaceInput(input *models.WorkspaceCreate) error {
@@ -254,7 +256,67 @@ func (s *Server) handleCreateWorkspace(w http.ResponseWriter, r *http.Request) {
 		_ = s.store.AddWorkspaceMember(ws.ID, userID, "owner")
 	}
 
+	// OAuth connection auto-add (PLAN-1519 / TASK-1521 / IDEA-1517 §1):
+	// when the creating call came over an OAuth-bound MCP session AND
+	// that connection has `may_create_workspaces=true`, immediately
+	// add the new workspace to the connection's allow-list with
+	// added_by='agent-create'. The agent can then use the workspace
+	// without a re-auth round-trip — the whole point of the "agent
+	// creates and immediately uses" flow.
+	//
+	// Best-effort: any error here logs but does NOT fail the response.
+	// The workspace already exists; failing the response would be
+	// confusing ("create succeeded but you got an error") and the user
+	// can always re-grant via the Connect-project modal. PAT auth has
+	// no request_id and the no-op short-circuits at the kind check.
+	s.maybeAutoAddCreatorConnection(r, ws.ID)
+
 	writeJSON(w, http.StatusCreated, ws)
+}
+
+// maybeAutoAddCreatorConnection inserts the newly-created workspace
+// into the calling OAuth connection's allow-list when the grant has
+// `may_create_workspaces=true`. No-op when:
+//
+//   - The calling token isn't an OAuth grant (PAT, CLI session token —
+//     they don't carry a request_id).
+//   - The grant's connection row doesn't exist (pre-Phase-C tokens
+//     fall here until backfill).
+//   - The flag is off (user explicitly scoped out creation power at
+//     consent time or via the connections-page mutation UI).
+//
+// Errors are logged at WARN, never propagated. The caller's response
+// must not fail because of an auth-bookkeeping issue post-creation.
+func (s *Server) maybeAutoAddCreatorConnection(r *http.Request, workspaceID string) {
+	kind, requestID := MCPTokenIdentityFromContext(r.Context())
+	if kind != "oauth" || requestID == "" {
+		return
+	}
+	conn, err := s.store.GetOAuthConnection(requestID)
+	if err != nil || conn == nil {
+		// Includes ErrOAuthConnectionNotFound (pre-Phase-C grant) and
+		// any I/O error. Silent — the workspace is already created,
+		// the auto-add is a convenience the user can recover via the
+		// Connect modal.
+		return
+	}
+	if !conn.MayCreateWorkspaces {
+		// User declined creation power at consent. Respect that —
+		// the workspace exists but doesn't auto-join the connection;
+		// the user can claim it post-hoc via the Connect modal if
+		// they change their mind.
+		return
+	}
+	if err := s.store.AddConnectionWorkspace(requestID, workspaceID, store.AddedByAgentCreate); err != nil {
+		// Idempotent on the store side — re-creation through the
+		// same connection (very unlikely with fresh IDs) would no-op.
+		// Any error here is genuinely unexpected; log so ops sees it.
+		slog.Warn("auto-add workspace to OAuth connection failed",
+			"request_id", requestID,
+			"workspace_id", workspaceID,
+			"error", err,
+		)
+	}
 }
 
 func (s *Server) handleGetWorkspace(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -93,6 +93,16 @@ type Server struct {
 	// mount on self-hosted deployments. See handlers_oauth.go.
 	oauthServer *oauth.Server
 
+	// claimSecret is the HMAC key for stateless 6-digit claim codes
+	// (PLAN-1519 / TASK-1521 / IDEA-1517 §4). Wired by SetClaimSecret
+	// at startup — production reuses the deployment's 32-byte
+	// encryption key (cfg.EncryptionKey) since both are server-
+	// stable secrets with equivalent rotation cadence. nil/short →
+	// /api/v1/oauth/claim returns 412 "claim_disabled" on every
+	// request, surfacing a clear misconfiguration signal rather than
+	// silently accepting forgeable codes.
+	claimSecret []byte
+
 	// oauthMetricsWired records whether wireOAuthMetricsObserver has
 	// already attached the active-tokens callback collector. Re-
 	// registering would panic via prometheus.MustRegister, so the flag
@@ -964,6 +974,16 @@ func (s *Server) setupRouter() {
 
 			// Share link resolution (outside workspace scope, no auth required)
 			r.Get("/s/{token}", s.handleResolveShareLink)
+
+			// Claim-code redemption (PLAN-1519 / TASK-1521 / IDEA-1517 §4).
+			// POST /api/v1/oauth/claim with body {workspace, code} grants
+			// the calling OAuth connection access to one workspace via a
+			// stateless 6-digit HMAC code the user generated in the web
+			// UI's "Connect project" modal. Auth: standard /api/v1 chain
+			// (TokenAuth + RequireAuth); the handler itself short-circuits
+			// the side effect when the caller isn't an OAuth grant (PAT /
+			// CLI session) and 412s when the claim secret isn't wired.
+			r.Post("/oauth/claim", s.handleOAuthClaim)
 
 			// Workspaces
 			r.Route("/workspaces", func(r chi.Router) {


### PR DESCRIPTION
## Summary

Phase B for PLAN-1519. Adds two MCP actions so agents can bring a workspace into an OAuth connection without re-auth — the agent-first onboarding story IDEA-1517 §1 set out to fix.

- **\`pad_workspace.action: create\`** — POSTs to \`/api/v1/workspaces\`; handler auto-adds the new workspace to the calling OAuth connection's allow-list (\`added_by='agent-create'\`) when the grant carries \`may_create_workspaces=true\`. Phase A wired the table this writes to.
- **\`pad_workspace.action: claim\`** — new \`POST /api/v1/oauth/claim\` endpoint redeems a 6-digit stateless HMAC code derived from \`(user_id, workspace_id, 5-min time bucket)\` with a sliding 5–10 minute lifetime. Constant-time compare; uniform 404 envelope so the endpoint can't probe existence vs. membership; idempotent on re-claim.
- **MCP server instructions** — appended IDEA-1517 §5 paragraph teaching agents the claim flow as a peer top-level section (one string, stdio + cloud both read \`instructions.md\`).
- Backed by new non-interactive \`pad workspace create\` + \`pad workspace claim\` Cobra commands so the stdio MCP shell-out path resolves cleanly. \`pad workspace init\` remains the guided human flow.

## Context

Implements \`TASK-1521\` under PLAN-1519. Phase A (TASK-1520) shipped the \`oauth_connections\` + \`oauth_connection_workspaces\` tables this writes to. The claim-code HMAC reuses the deployment's existing 32-byte encryption key (\`SetClaimSecret\`) — same rotation cadence + blast radius as the OAuth-server HMAC, so a shared secret is the right call.

Phase C will wire the new consent screen + write path; Phase E will ship the web UI "Connect project" modal that mints these claim codes. This PR ships the server-side machinery both phases consume.

## Test plan

- [x] \`go build ./... && go vet ./... && golangci-lint run\` — clean
- [x] \`go test ./...\` — all green (added 22 new tests across 4 files)
- [x] \`cd web && npm run build\` — clean
- [x] Claim-code lifetime + rejection matrix (10 unit tests)
- [x] Handler envelope: 412 disabled / 400 missing / 404 not-found-or-not-member / 401 wrong-code / 200 PAT note path / 412 connection_not_persisted / 200 idempotent insert
- [x] MCP catalog wiring: actions registered in enum, schema params advertised, routeTable carries both entries, route mappers produce correct HTTP shape
- [x] Read-only catalog bijection + fixture-input fixtures updated for the two new actions