### PR TITLE
feat(oauth): backfill session.Extra into oauth_connections + switch read path (TASK-1522)

### DIFF
--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -500,6 +500,42 @@ func serveCmd() *cobra.Command {
 						"endpoints", "/oauth/{register,authorize,token,claim}",
 						"audience", oauthSrv.AllowedAudience(),
 					)
+
+					// One-shot backfill of pre-TASK-1522 grant chains
+					// into oauth_connections + oauth_connection_workspaces
+					// (PLAN-1519 / TASK-1522 / IDEA-1517 §2). Idempotent:
+					// the inserts are ON CONFLICT DO NOTHING / INSERT OR
+					// IGNORE, so re-running on every startup is cheap and
+					// safe. The rewritten ListUserOAuthConnections reads
+					// from the new tables; running this BEFORE the HTTP
+					// server starts means /console/connected-apps never
+					// renders an empty page during the brief window
+					// between server-up and backfill-complete.
+					//
+					// Backfill failures don't abort startup — a partial
+					// run leaves the tables in a consistent state the
+					// next run completes (per-chain failures are logged
+					// and the run continues). The rewritten read path
+					// also has a defensive fallback for chains without
+					// connection rows, so any chain the backfill misses
+					// still renders.
+					if bf, bfErr := s.BackfillOAuthConnections(); bfErr != nil {
+						slog.Warn("oauth_connections backfill failed; non-fatal",
+							"error", bfErr)
+					} else if bf.ConnectionsCreated > 0 || bf.WorkspacesAdded > 0 {
+						slog.Info("oauth_connections backfill complete",
+							"chains_seen", bf.ChainsSeen,
+							"connections_created", bf.ConnectionsCreated,
+							"workspaces_added", bf.WorkspacesAdded,
+							"unresolved_slugs", bf.UnresolvedSlugs,
+						)
+					} else if bf.ChainsSeen > 0 {
+						// Quiet log on steady-state re-runs (chains
+						// scanned, nothing new to write) so ops can
+						// confirm the call ran without log noise.
+						slog.Debug("oauth_connections backfill no-op",
+							"chains_seen", bf.ChainsSeen)
+					}
 				} else {
 					slog.Warn("PAD_MCP_PUBLIC_URL not set — OAuth server NOT mounted (no canonical audience to bind tokens to)")
 				}

--- a/internal/models/connected_apps.go
+++ b/internal/models/connected_apps.go
@@ -49,15 +49,33 @@ type OAuthConnection struct {
 	LogoURL      string
 	RedirectURIs []string
 
-	// AllowedWorkspaces is the workspace allow-list set at consent
-	// time (TASK-952). Three shapes:
-	//   - nil — pre-TASK-952 token (no consent payload). Treated as
-	//     "any workspace the user belongs to."
-	//   - ["*"] — wildcard (user explicitly granted any).
-	//   - explicit slugs — the user's selection.
-	// The page renders chips per slug, or an "Any workspace" badge
-	// for nil / wildcard.
+	// AllowedWorkspaces is the workspace allow-list. Post-TASK-1522
+	// it's the projection of oauth_connection_workspaces rows joined
+	// to workspaces by ID (slug list, sorted). Two shapes the UI
+	// renders against:
+	//   - nil — the connection's all_current_workspaces flag is on
+	//     (covers every workspace the user is a member of). UI shows
+	//     an "Any workspace" badge.
+	//   - explicit slugs — all_current_workspaces=false; UI shows the
+	//     slug list as chips.
+	// (Pre-TASK-1522 the same field also held ["*"] for wildcard
+	// tokens; the backfill normalizes those to the flag and the field
+	// is nil for them now. The wire DTO's nullable shape is unchanged
+	// so frontend code keeps working.)
 	AllowedWorkspaces []string
+
+	// Connection-level scope flags + name from oauth_connections
+	// (PLAN-1519 / TASK-1520 / IDEA-1517 §2). Pre-TASK-1522 these
+	// were unsourced (the field didn't exist); post-backfill every
+	// active connection has a row and the values mean what the page
+	// should render. Phase D's mutation UI reads + writes these.
+	//
+	// Name is empty string for backfilled rows that haven't been
+	// renamed yet — UI prompts on first connections-page visit.
+	Name                    string
+	MayCreateWorkspaces     bool
+	AllCurrentWorkspaces    bool
+	IncludeFutureWorkspaces bool
 
 	// GrantedScopes is the raw space-separated scope string fosite
 	// recorded at grant time. Surfaced in the per-connection expand

--- a/internal/server/handlers_connected_apps_test.go
+++ b/internal/server/handlers_connected_apps_test.go
@@ -137,6 +137,26 @@ func TestHandleListConnectedApps_DTOShapeAndAuditEnrichment(t *testing.T) {
 	seedGrantChain(t, srv, clientID, user.ID, "shape-chain",
 		`{"extra":{"allowed_workspaces":["alpha","beta"]}}`, "pad:read pad:write")
 
+	// TASK-1522: the read path now projects allowed_workspaces from
+	// oauth_connection_workspaces, not session.Extra. Mirror production
+	// startup by creating the referenced workspaces + running the
+	// backfill so the slugs resolve to real rows and seed join entries.
+	owner, err := srv.store.CreateUser(models.UserCreate{
+		Email: "shape-chain-ws-owner@example.com", Name: "Owner",
+		Password: "pw-shape-owner-12345",
+	})
+	if err != nil {
+		t.Fatalf("CreateUser ws-owner: %v", err)
+	}
+	for _, slug := range []string{"alpha", "beta"} {
+		if _, wsErr := srv.store.CreateWorkspace(models.WorkspaceCreate{Name: slug, OwnerID: owner.ID}); wsErr != nil {
+			t.Fatalf("CreateWorkspace %s: %v", slug, wsErr)
+		}
+	}
+	if _, bfErr := srv.store.BackfillOAuthConnections(); bfErr != nil {
+		t.Fatalf("BackfillOAuthConnections: %v", bfErr)
+	}
+
 	// Seed a couple of audit rows so calls_30d > 0 + last_used populates.
 	insertAudit := func(ts time.Time) {
 		err := srv.store.InsertMCPAuditEntry(models.MCPAuditEntryInput{

--- a/internal/store/connected_apps.go
+++ b/internal/store/connected_apps.go
@@ -179,14 +179,27 @@ func (s *Store) ListUserOAuthConnections(userID string) ([]models.OAuthConnectio
 		}
 
 		// Hydrate from oauth_connections + oauth_connection_workspaces.
-		// Backfilled chains all have a row; brand-new chains that
-		// somehow reach the read path before Phase C2's write hook
-		// fires fall back to the pre-TASK-1522 default (any workspace,
-		// scope flags all on, no name) so the page still renders the
-		// connection rather than silently dropping it. Defense in
-		// depth — the backfill at startup should keep this branch
-		// unreachable in production.
-		if access, accessErr := s.GetOAuthConnectionAccess(reqID); accessErr == nil && access.HasConnection {
+		// Three branches:
+		//   - access lookup errored      → surface (Codex #583 round 4:
+		//                                  silently broadening to "any
+		//                                  workspace" on a real store
+		//                                  failure could expose
+		//                                  workspaces the user explicitly
+		//                                  scoped out via the Phase D
+		//                                  mutation UI).
+		//   - HasConnection == true      → project flags + slugs.
+		//   - HasConnection == false     → defensive fallback (legacy
+		//                                  "any workspace, default-on
+		//                                  flags"); reachable only if a
+		//                                  chain somehow exists without
+		//                                  a backfilled connection row,
+		//                                  which startup backfill should
+		//                                  prevent in production.
+		access, accessErr := s.GetOAuthConnectionAccess(reqID)
+		if accessErr != nil {
+			return nil, fmt.Errorf("hydrate connection access %s: %w", reqID, accessErr)
+		}
+		if access.HasConnection {
 			if access.AllCurrentWorkspaces {
 				conn.AllCurrentWorkspaces = true
 				conn.AllowedWorkspaces = nil
@@ -199,11 +212,16 @@ func (s *Store) ListUserOAuthConnections(userID string) ([]models.OAuthConnectio
 			// shape as GetOAuthConnectionAccess; combined this is two
 			// indexed reads per chain, which on user-scale lists
 			// (~handful) is well under the audit-log enrichment cost.
-			if meta, metaErr := s.GetOAuthConnection(reqID); metaErr == nil {
-				conn.Name = meta.Name
-				conn.MayCreateWorkspaces = meta.MayCreateWorkspaces
-				conn.IncludeFutureWorkspaces = meta.IncludeFutureWorkspaces
+			meta, metaErr := s.GetOAuthConnection(reqID)
+			if metaErr != nil {
+				// HasConnection said the row exists; a follow-up
+				// lookup failing is a genuine store error — same
+				// rationale as the access lookup above.
+				return nil, fmt.Errorf("hydrate connection metadata %s: %w", reqID, metaErr)
 			}
+			conn.Name = meta.Name
+			conn.MayCreateWorkspaces = meta.MayCreateWorkspaces
+			conn.IncludeFutureWorkspaces = meta.IncludeFutureWorkspaces
 		} else {
 			// No oauth_connections row — treat as the legacy "any
 			// workspace, default-on flags" shape so existing UI keeps

--- a/internal/store/connected_apps.go
+++ b/internal/store/connected_apps.go
@@ -2,7 +2,6 @@ package store
 
 import (
 	"database/sql"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"sort"
@@ -40,16 +39,19 @@ var ErrConnectionNotFound = errors.New("connected_apps: connection not found")
 // in the chain still has active=TRUE — revoked chains drop off the
 // list immediately rather than lingering.
 //
-// Implementation walks oauth_access_tokens grouped by request_id,
-// taking MIN(requested_at) as ConnectedAt + the most recent row's
-// session_data + granted_scopes (which carry the consent allow-list
-// and scope policy). Joins to oauth_clients for the DCR metadata.
+// Post-TASK-1522 read path: connection-level state (name, scope flags,
+// workspace allow-list) now reads from oauth_connections +
+// oauth_connection_workspaces. We still walk oauth_access_tokens +
+// oauth_refresh_tokens to know which chains are active and to pull
+// ConnectedAt + GrantedScopes (those live per-token, not per-grant).
+// The backfill in BackfillOAuthConnections seeds the new tables once
+// at startup so this read path sees every legacy chain too — no
+// dual-shape fork inside the read loop.
 //
-// The audit-log enrichments (LastUsedAt + Calls30d) come from the
-// caller — we return MCPConnectionStatsForUser separately so the
-// caller can call both methods in parallel if they want, and so the
-// store layer doesn't require the audit table to be present (this
-// method works on a fresh install with no audit rows yet).
+// Two queries: one chain scan, one batch-hydrate of the connection
+// rows. Slug projection lives in a per-chain helper because the join
+// shape is small (a handful of slugs per chain at most) and stays
+// readable.
 //
 // Sort: ConnectedAt DESC so newest authorizations land at the top of
 // the page, which matches every other "list of things I've added"
@@ -67,7 +69,7 @@ func (s *Store) ListUserOAuthConnections(userID string) ([]models.OAuthConnectio
 	// a handful of clients, not thousands), so the in-memory dedup
 	// is cheap.
 	rows, err := s.db.Query(s.q(`
-		SELECT request_id, client_id, requested_at, session_data, granted_scopes
+		SELECT request_id, client_id, requested_at, granted_scopes
 		FROM oauth_access_tokens
 		WHERE subject = ? AND active = ?
 		ORDER BY request_id, requested_at DESC
@@ -78,42 +80,38 @@ func (s *Store) ListUserOAuthConnections(userID string) ([]models.OAuthConnectio
 	defer rows.Close()
 
 	type chainAgg struct {
-		clientID      string
-		earliest      time.Time
-		newest        time.Time
-		newestSession string
-		newestScopes  string
+		clientID     string
+		earliest     time.Time
+		newest       time.Time
+		newestScopes string
 	}
 	chains := make(map[string]*chainAgg)
-	for rows.Next() {
-		var (
-			reqID, clientID, sessionData, scopes string
-			requestedAt                          string
-		)
-		if err := rows.Scan(&reqID, &clientID, &requestedAt, &sessionData, &scopes); err != nil {
-			return nil, fmt.Errorf("scan user connection (access): %w", err)
-		}
+	absorb := func(reqID, clientID, requestedAt, scopes string) {
 		ts := parseTime(requestedAt)
 		c, ok := chains[reqID]
 		if !ok {
-			c = &chainAgg{
-				clientID:      clientID,
-				earliest:      ts,
-				newest:        ts,
-				newestSession: sessionData,
-				newestScopes:  scopes,
+			chains[reqID] = &chainAgg{
+				clientID:     clientID,
+				earliest:     ts,
+				newest:       ts,
+				newestScopes: scopes,
 			}
-			chains[reqID] = c
-			continue
+			return
 		}
 		if ts.Before(c.earliest) {
 			c.earliest = ts
 		}
 		if ts.After(c.newest) {
 			c.newest = ts
-			c.newestSession = sessionData
 			c.newestScopes = scopes
 		}
+	}
+	for rows.Next() {
+		var reqID, clientID, scopes, requestedAt string
+		if err := rows.Scan(&reqID, &clientID, &requestedAt, &scopes); err != nil {
+			return nil, fmt.Errorf("scan user connection (access): %w", err)
+		}
+		absorb(reqID, clientID, requestedAt, scopes)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("iterate user connections (access): %w", err)
@@ -126,7 +124,7 @@ func (s *Store) ListUserOAuthConnections(userID string) ([]models.OAuthConnectio
 	// call in a while would see an empty list right after a token
 	// expiry.
 	rrows, err := s.db.Query(s.q(`
-		SELECT request_id, client_id, requested_at, session_data, granted_scopes
+		SELECT request_id, client_id, requested_at, granted_scopes
 		FROM oauth_refresh_tokens
 		WHERE subject = ? AND active = ?
 		ORDER BY request_id, requested_at DESC
@@ -136,34 +134,11 @@ func (s *Store) ListUserOAuthConnections(userID string) ([]models.OAuthConnectio
 	}
 	defer rrows.Close()
 	for rrows.Next() {
-		var (
-			reqID, clientID, sessionData, scopes string
-			requestedAt                          string
-		)
-		if err := rrows.Scan(&reqID, &clientID, &requestedAt, &sessionData, &scopes); err != nil {
+		var reqID, clientID, scopes, requestedAt string
+		if err := rrows.Scan(&reqID, &clientID, &requestedAt, &scopes); err != nil {
 			return nil, fmt.Errorf("scan user connection (refresh): %w", err)
 		}
-		ts := parseTime(requestedAt)
-		c, ok := chains[reqID]
-		if !ok {
-			c = &chainAgg{
-				clientID:      clientID,
-				earliest:      ts,
-				newest:        ts,
-				newestSession: sessionData,
-				newestScopes:  scopes,
-			}
-			chains[reqID] = c
-			continue
-		}
-		if ts.Before(c.earliest) {
-			c.earliest = ts
-		}
-		if ts.After(c.newest) {
-			c.newest = ts
-			c.newestSession = sessionData
-			c.newestScopes = scopes
-		}
+		absorb(reqID, clientID, requestedAt, scopes)
 	}
 	if err := rrows.Err(); err != nil {
 		return nil, fmt.Errorf("iterate user connections (refresh): %w", err)
@@ -196,13 +171,51 @@ func (s *Store) ListUserOAuthConnections(userID string) ([]models.OAuthConnectio
 	for reqID, c := range chains {
 		client := clientCache[c.clientID]
 		conn := models.OAuthConnection{
-			RequestID:         reqID,
-			ClientID:          c.clientID,
-			ConnectedAt:       c.earliest,
-			GrantedScopes:     c.newestScopes,
-			CapabilityTier:    classifyCapabilityTier(c.newestScopes),
-			AllowedWorkspaces: parseAllowedWorkspacesFromSession(c.newestSession),
+			RequestID:      reqID,
+			ClientID:       c.clientID,
+			ConnectedAt:    c.earliest,
+			GrantedScopes:  c.newestScopes,
+			CapabilityTier: classifyCapabilityTier(c.newestScopes),
 		}
+
+		// Hydrate from oauth_connections + oauth_connection_workspaces.
+		// Backfilled chains all have a row; brand-new chains that
+		// somehow reach the read path before Phase C2's write hook
+		// fires fall back to the pre-TASK-1522 default (any workspace,
+		// scope flags all on, no name) so the page still renders the
+		// connection rather than silently dropping it. Defense in
+		// depth — the backfill at startup should keep this branch
+		// unreachable in production.
+		if access, accessErr := s.GetOAuthConnectionAccess(reqID); accessErr == nil && access.HasConnection {
+			if access.AllCurrentWorkspaces {
+				conn.AllCurrentWorkspaces = true
+				conn.AllowedWorkspaces = nil
+			} else {
+				conn.AllCurrentWorkspaces = false
+				conn.AllowedWorkspaces = access.WorkspaceSlugs
+			}
+			// Pull the rest of the connection metadata (name + the
+			// other two scope flags) with one PK lookup. Same cost
+			// shape as GetOAuthConnectionAccess; combined this is two
+			// indexed reads per chain, which on user-scale lists
+			// (~handful) is well under the audit-log enrichment cost.
+			if meta, metaErr := s.GetOAuthConnection(reqID); metaErr == nil {
+				conn.Name = meta.Name
+				conn.MayCreateWorkspaces = meta.MayCreateWorkspaces
+				conn.IncludeFutureWorkspaces = meta.IncludeFutureWorkspaces
+			}
+		} else {
+			// No oauth_connections row — treat as the legacy "any
+			// workspace, default-on flags" shape so existing UI keeps
+			// rendering. ListUserOAuthConnections returns the same
+			// nil AllowedWorkspaces semantic the pre-TASK-1522 read
+			// path used for pre-TASK-952 / wildcard tokens, so the
+			// DTO + frontend behave identically.
+			conn.AllCurrentWorkspaces = true
+			conn.MayCreateWorkspaces = true
+			conn.IncludeFutureWorkspaces = true
+		}
+
 		if client != nil {
 			conn.ClientName = client.Name
 			conn.LogoURL = client.LogoURL
@@ -327,53 +340,14 @@ func classifyCapabilityTier(scopes string) models.CapabilityTier {
 	return models.CapabilityTierUnknown
 }
 
-// parseAllowedWorkspacesFromSession extracts the workspace allow-list
-// from a serialized fosite session. The producer side
-// (oauth.Session.SetAllowedWorkspaces in /authorize/decide) stashes
-// the list under the "allowed_workspaces" key in DefaultSession.Extra.
-// JSON round-trip mangles []string into []interface{}, so we accept
-// both shapes here — same as oauth.Session.AllowedWorkspaces.
-//
-// Returns nil for missing key (pre-TASK-952 token); empty []string
-// for an explicit empty list (would be unusual but distinguishable
-// from "unset"); the slug list otherwise. The handler surfaces
-// nil + ["*"] as "Any workspace"; anything else as chips.
-//
-// Defensive: any parse failure returns nil rather than propagating
-// — a malformed session payload shouldn't 500 the connected-apps
-// page. Worst case the user sees "Any workspace" instead of the
-// actual chip list, which is a less-bad failure mode than a broken
-// page.
-func parseAllowedWorkspacesFromSession(sessionData string) []string {
-	if sessionData == "" {
-		return nil
-	}
-	// fosite serializes the session as JSON. We only care about
-	// session.Extra.allowed_workspaces — peek into that path
-	// without depending on the fosite types.
-	var outer struct {
-		Extra map[string]interface{} `json:"extra"`
-	}
-	if err := json.Unmarshal([]byte(sessionData), &outer); err != nil || outer.Extra == nil {
-		return nil
-	}
-	raw, ok := outer.Extra["allowed_workspaces"]
-	if !ok {
-		return nil
-	}
-	switch v := raw.(type) {
-	case []string:
-		out := make([]string, len(v))
-		copy(out, v)
-		return out
-	case []interface{}:
-		out := make([]string, 0, len(v))
-		for _, e := range v {
-			if s, ok := e.(string); ok && s != "" {
-				out = append(out, s)
-			}
-		}
-		return out
-	}
-	return nil
-}
+// parseAllowedWorkspacesFromSession was retired in TASK-1522 when the
+// connected-apps read path switched to consuming oauth_connections +
+// oauth_connection_workspaces instead of parsing session.Extra strings.
+// The session.Extra producer side still exists (oauth.Session.
+// SetAllowedWorkspaces) until Phase C2 retires it from
+// /authorize/decide; the dual-read introspection gate in
+// internal/server/middleware_mcp_auth.go consults both shapes during
+// transition. After the soak period (tracked in PLAN-1519 follow-ups)
+// the producer + dual-read can come out together. See
+// internal/store/oauth_connections_backfill.go for the migration that
+// seeded the new tables from the existing session.Extra payloads.

--- a/internal/store/connected_apps_test.go
+++ b/internal/store/connected_apps_test.go
@@ -111,6 +111,18 @@ func TestListUserOAuthConnections_DeduplicatesChain(t *testing.T) {
 	seedAccess(t, s, "chain-1", clientID, uid, now.Add(-2*time.Hour), sessionData, "pad:read pad:write", true)
 	seedAccess(t, s, "chain-1", clientID, uid, now.Add(-1*time.Hour), sessionData, "pad:read pad:write", true)
 
+	// Workspace + backfill so the rewritten read path (TASK-1522)
+	// projects AllowedWorkspaces from oauth_connection_workspaces
+	// instead of the retired session.Extra parse. Production wires
+	// the same call at startup; tests do it explicitly.
+	ownerForWS := seedUser(t, s, "chain-1-ws-owner@example.com")
+	if _, wsErr := s.CreateWorkspace(models.WorkspaceCreate{Name: "docapp", OwnerID: ownerForWS}); wsErr != nil {
+		t.Fatalf("CreateWorkspace docapp: %v", wsErr)
+	}
+	if _, bfErr := s.BackfillOAuthConnections(); bfErr != nil {
+		t.Fatalf("BackfillOAuthConnections: %v", bfErr)
+	}
+
 	conns, err := s.ListUserOAuthConnections(uid)
 	if err != nil {
 		t.Fatalf("ListUserOAuthConnections: %v", err)
@@ -263,29 +275,57 @@ func TestClassifyCapabilityTier(t *testing.T) {
 	}
 }
 
-func TestParseAllowedWorkspacesFromSession(t *testing.T) {
+// TestExtractAllowedWorkspacesFromSessionExtra covers the parse helper
+// that drives the TASK-1522 backfill from session.Extra into the new
+// oauth_connections + oauth_connection_workspaces tables. Replaces the
+// retired parseAllowedWorkspacesFromSession test (which was the
+// previous read-path's parse helper, removed when the read path
+// switched to the new tables).
+//
+// Shape mapping (per IDEA-1517 §2 backfill spec):
+//
+//   - missing / malformed / non-array → (hasKey=false, isStar=false, slugs=nil)
+//     → seeder writes all_current_workspaces=1, no join rows.
+//   - ["*"] singleton                  → (hasKey=true, isStar=true, slugs=nil)
+//     → seeder writes all_current_workspaces=1, no join rows.
+//   - explicit slug list               → (hasKey=true, isStar=false, slugs=<list>)
+//     → seeder writes all_current_workspaces=0, one join row per slug.
+func TestExtractAllowedWorkspacesFromSessionExtra(t *testing.T) {
 	cases := []struct {
-		name string
-		in   string
-		want []string
+		name      string
+		in        string
+		wantKey   bool
+		wantStar  bool
+		wantSlugs []string
 	}{
-		{"empty", "", nil},
-		{"missing extra key", `{"extra":{}}`, nil},
-		{"string slice", `{"extra":{"allowed_workspaces":["alpha","beta"]}}`, []string{"alpha", "beta"}},
-		{"wildcard", `{"extra":{"allowed_workspaces":["*"]}}`, []string{"*"}},
-		{"non-string elements skipped", `{"extra":{"allowed_workspaces":["alpha",42,"beta"]}}`, []string{"alpha", "beta"}},
-		{"malformed", `not json`, nil},
+		{"empty session", "", false, false, nil},
+		{"missing extra key", `{"extra":{}}`, false, false, nil},
+		{"explicit slug list", `{"extra":{"allowed_workspaces":["alpha","beta"]}}`, true, false, []string{"alpha", "beta"}},
+		{"wildcard singleton", `{"extra":{"allowed_workspaces":["*"]}}`, true, true, nil},
+		{"non-string elements dropped", `{"extra":{"allowed_workspaces":["alpha",42,"beta"]}}`, true, false, []string{"alpha", "beta"}},
+		{"explicit empty list", `{"extra":{"allowed_workspaces":[]}}`, true, false, nil},
+		{"wildcard mixed with slug", `{"extra":{"allowed_workspaces":["*","alpha"]}}`, true, false, []string{"*", "alpha"}},
+		{"malformed JSON", `not json`, false, false, nil},
+		{"non-array value", `{"extra":{"allowed_workspaces":"alpha"}}`, false, false, nil},
 	}
 	for _, tc := range cases {
-		got := parseAllowedWorkspacesFromSession(tc.in)
-		if len(got) != len(tc.want) {
-			t.Errorf("%s: len = %d, want %d (got %v)", tc.name, len(got), len(tc.want), got)
-			continue
-		}
-		for i := range got {
-			if got[i] != tc.want[i] {
-				t.Errorf("%s: [%d] = %q, want %q", tc.name, i, got[i], tc.want[i])
+		t.Run(tc.name, func(t *testing.T) {
+			got := extractAllowedWorkspacesFromSessionExtra(tc.in)
+			if got.hasKey != tc.wantKey {
+				t.Errorf("hasKey = %v, want %v", got.hasKey, tc.wantKey)
 			}
-		}
+			if got.isStar != tc.wantStar {
+				t.Errorf("isStar = %v, want %v", got.isStar, tc.wantStar)
+			}
+			if len(got.slugs) != len(tc.wantSlugs) {
+				t.Errorf("slugs len = %d (%v), want %d (%v)", len(got.slugs), got.slugs, len(tc.wantSlugs), tc.wantSlugs)
+				return
+			}
+			for i := range got.slugs {
+				if got.slugs[i] != tc.wantSlugs[i] {
+					t.Errorf("slugs[%d] = %q, want %q", i, got.slugs[i], tc.wantSlugs[i])
+				}
+			}
+		})
 	}
 }

--- a/internal/store/oauth_connections_backfill.go
+++ b/internal/store/oauth_connections_backfill.go
@@ -1,7 +1,9 @@
 package store
 
 import (
+	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 )
@@ -218,98 +220,120 @@ func (s *Store) backfillOneChain(requestID string, chain backfillChain) (created
 	allowed := extractAllowedWorkspacesFromSessionExtra(chain.SessionData)
 	allCurrent, explicit := allowed.toShape()
 
-	// Probe BEFORE the insert so the counter reflects actual new
-	// work — RowsAffected isn't portable across SQLite + Postgres
-	// for "OR IGNORE" / "ON CONFLICT DO NOTHING" semantics (some
-	// drivers report 0, some 1), and a wall-clock heuristic over
-	// updated_at vs created_at over-reports on every steady-state
-	// startup once the row's been backfilled and never edited.
-	// Codex review #583 round 1 caught the over-report.
-	if _, getErr := s.GetOAuthConnection(requestID); getErr != nil {
-		// Row doesn't exist — we're about to insert it. Insert and
-		// flag created=true.
-		if err := s.insertOAuthConnectionIfAbsent(requestID, chain.UserID, allCurrent); err != nil {
-			return false, 0, 0, fmt.Errorf("insert parent: %w", err)
+	// Per-chain transaction (Codex review #583 round 3) so the parent
+	// row and ALL join rows land atomically. Previous round 2's gate
+	// "only seed slugs when parent was just created" protected
+	// user-removed workspaces from resurrection but introduced a new
+	// failure mode: if the process crashed (or AddConnectionWorkspace
+	// errored) between parent insert and the slug loop completing, a
+	// subsequent backfill would see created=false and skip the
+	// unfinished slug seeding — leaving the connection permanently
+	// scoped to a partial allow-list.
+	//
+	// The atomic invariant: either all rows for this chain commit, or
+	// none do. A crash mid-loop rolls the parent insert back too, so
+	// the NEXT backfill sees the chain as un-seeded and retries from
+	// scratch — preserving both Codex round 2's "no resurrection"
+	// guarantee and round 3's "no permanent partial seed."
+	//
+	// Scope: per-chain (small) tx, not whole-backfill. The original
+	// rationale for the no-transaction design was to avoid holding a
+	// writer lock across O(thousands) of chains; that concern doesn't
+	// apply at chain granularity (one row + a handful of join rows
+	// inserts, sub-millisecond hold).
+	tx, err := s.db.Begin()
+	if err != nil {
+		return false, 0, 0, fmt.Errorf("begin: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
 		}
-		created = true
-	}
-	// Re-runs on an existing row don't update — connection-level
-	// state (name + scope flags) is user-owned post-backfill and
-	// the backfill must not stomp it. Same posture as IDEA-1517 §2's
-	// "name defaults to empty until the user edits."
+	}()
 
-	if !created {
-		// Parent already existed from a prior backfill run — the
-		// connection-level state (name, scope flags) AND the join
-		// table is user-owned post-backfill. Specifically: if the
-		// user removes a workspace via RemoveConnectionWorkspace, a
-		// subsequent backfill re-adding it from stale session.Extra
-		// would silently revert their decision on every restart.
-		// Codex review #583 round 2 caught the regression.
-		//
-		// "Backfill" means SEED — once. After that the new tables
-		// are authoritative. The slug loop below only runs when we
-		// just inserted a fresh parent row.
-		return created, 0, 0, nil
+	// Existence check inside the tx so concurrent writers (theoretical:
+	// the OAuth-server's /authorize/decide handler running while
+	// backfill is up) can't insert between probe and seed.
+	var one int
+	probeErr := tx.QueryRow(s.q(`SELECT 1 FROM oauth_connections WHERE request_id = ?`), requestID).Scan(&one)
+	switch {
+	case probeErr == nil:
+		// Parent already exists from a prior backfill or live consent
+		// flow. The new tables are authoritative — leave the row + its
+		// join entries alone. This is the path that protects user
+		// removals (Codex review round 2) from getting resurrected.
+		if commitErr := tx.Commit(); commitErr != nil {
+			return false, 0, 0, fmt.Errorf("commit (no-op): %w", commitErr)
+		}
+		committed = true
+		return false, 0, 0, nil
+	case !errors.Is(probeErr, sql.ErrNoRows):
+		return false, 0, 0, fmt.Errorf("probe parent: %w", probeErr)
 	}
+
+	// Parent missing — atomic seed begins. Insert parent.
+	insertStmt := `
+        INSERT INTO oauth_connections (
+            request_id, user_id, name,
+            may_create_workspaces, all_current_workspaces, include_future_workspaces
+        ) VALUES (?, ?, '', ?, ?, ?)
+    `
+	// No need for OR IGNORE / ON CONFLICT here — we just probed inside
+	// the same tx and confirmed absence. A racing inserter would
+	// surface as a PK violation; let it propagate so the rollback
+	// fires cleanly and the next backfill retries.
+	if _, err := tx.Exec(s.q(insertStmt),
+		requestID, chain.UserID,
+		s.dialect.BoolToInt(true), // may_create_workspaces default ON
+		s.dialect.BoolToInt(allCurrent),
+		s.dialect.BoolToInt(true), // include_future_workspaces default ON
+	); err != nil {
+		return false, 0, 0, fmt.Errorf("insert parent: %w", err)
+	}
+
 	if explicit == nil {
-		// Wildcard / pre-TASK-952 — no join rows to write.
-		return created, 0, 0, nil
+		// Wildcard / pre-TASK-952 — commit parent-only, no join rows.
+		if commitErr := tx.Commit(); commitErr != nil {
+			return false, 0, 0, fmt.Errorf("commit (wildcard): %w", commitErr)
+		}
+		committed = true
+		return true, 0, 0, nil
 	}
 
-	// Resolve each slug to a workspace ID. Missing slugs (workspace
-	// deleted, never existed in this DB) skip without failing; the
-	// unresolved count surfaces in the result so ops can spot data
-	// hygiene issues. No need for IsConnectionWorkspaceAllowed
-	// probes here — by construction the parent row was just inserted,
-	// so the join table cannot contain any rows for this request_id
-	// yet (Phase A's CASCADE FK ensures parent + join lifecycle stay
-	// linked).
+	// Explicit-list path: resolve each slug + insert join row within
+	// the same tx. Workspace lookups use the regular DB handle (not
+	// the tx) because the workspaces table is read-only relative to
+	// this transaction — no risk of dirty reads, and keeping the
+	// lookup off the tx avoids holding the writer lock during the
+	// (very rare) deleted-slug fast-path. SQLite + Postgres both honor
+	// repeatable reads of static data here.
 	for _, slug := range explicit {
 		ws, getErr := s.GetWorkspaceBySlug(slug)
 		if getErr != nil || ws == nil {
 			slugsMissed++
 			continue
 		}
-		if err := s.AddConnectionWorkspace(requestID, ws.ID, AddedByUser); err != nil {
-			return created, slugsAdded, slugsMissed, fmt.Errorf("insert workspace %s: %w", slug, err)
+		// Plain INSERT (no OR IGNORE / ON CONFLICT) — by construction
+		// the parent row was just minted in this tx, so the join
+		// table has no pre-existing rows for this request_id. A
+		// duplicate slug in the source list is the only edge that
+		// could trip the PK; treat it as a programmer-error data
+		// shape and let the rollback fire so the operator notices.
+		if _, err := tx.Exec(s.q(`
+            INSERT INTO oauth_connection_workspaces (request_id, workspace_id, added_by)
+            VALUES (?, ?, ?)
+        `), requestID, ws.ID, AddedByUser); err != nil {
+			return false, 0, 0, fmt.Errorf("insert workspace %s: %w", slug, err)
 		}
 		slugsAdded++
 	}
-	return created, slugsAdded, slugsMissed, nil
-}
 
-// insertOAuthConnectionIfAbsent inserts the oauth_connections row
-// idempotently. all_current_workspaces is the only flag derived from
-// session.Extra; the other two default to ON per IDEA-1517 §2a
-// ("all scope flags default to on" for the migrated set so existing
-// connections preserve their behaviour until the user edits them).
-func (s *Store) insertOAuthConnectionIfAbsent(requestID, userID string, allCurrent bool) error {
-	var stmt string
-	switch s.dialect.Driver() {
-	case DriverPostgres:
-		stmt = `
-            INSERT INTO oauth_connections (
-                request_id, user_id, name,
-                may_create_workspaces, all_current_workspaces, include_future_workspaces
-            ) VALUES (?, ?, '', ?, ?, ?)
-            ON CONFLICT (request_id) DO NOTHING
-        `
-	default:
-		stmt = `
-            INSERT OR IGNORE INTO oauth_connections (
-                request_id, user_id, name,
-                may_create_workspaces, all_current_workspaces, include_future_workspaces
-            ) VALUES (?, ?, '', ?, ?, ?)
-        `
+	if commitErr := tx.Commit(); commitErr != nil {
+		return false, slugsAdded, slugsMissed, fmt.Errorf("commit: %w", commitErr)
 	}
-	_, err := s.db.Exec(s.q(stmt),
-		requestID, userID,
-		s.dialect.BoolToInt(true), // may_create_workspaces default ON
-		s.dialect.BoolToInt(allCurrent),
-		s.dialect.BoolToInt(true), // include_future_workspaces default ON
-	)
-	return err
+	committed = true
+	return true, slugsAdded, slugsMissed, nil
 }
 
 // extractedAllowed captures one of the three IDEA-1517 §2 backfill

--- a/internal/store/oauth_connections_backfill.go
+++ b/internal/store/oauth_connections_backfill.go
@@ -1,0 +1,408 @@
+package store
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+)
+
+// One-shot backfill from session.Extra["allowed_workspaces"] into the
+// new per-connection tables (PLAN-1519 / TASK-1522 / IDEA-1517 §2).
+//
+// Phase A (TASK-1520) shipped oauth_connections + oauth_connection_workspaces
+// empty. Phase C2 (TASK-1523) will rewrite /authorize/decide to write
+// these tables on consent. THIS file seeds existing grant chains so the
+// new read path (rewritten ListUserOAuthConnections in connected_apps.go)
+// can render every connection — both pre-migration and post-migration —
+// uniformly off the new tables. Without backfill, the rewritten read
+// path would show an empty list for every existing OAuth connection.
+//
+// Why a Go function instead of a SQL migration: the backfill needs to
+// parse JSON session.Extra blobs out of session_data and resolve
+// workspace slugs → workspace_id rows for the join table. SQLite's
+// json_extract() could do the parse half but the cross-table slug
+// resolution + the dialect symmetry (SQLite vs Postgres JSON shape)
+// would make for an awkward .sql file. A Go pass is shorter and the
+// idempotent INSERT OR IGNORE / ON CONFLICT DO NOTHING semantics keep
+// it safe to re-run on every startup — which is exactly what
+// cmd/pad/main.go does post-OAuth-server-wire.
+//
+// Idempotence: every INSERT is OR-IGNORE / ON CONFLICT DO NOTHING; the
+// chains scan over the existing oauth_*_tokens tables which never
+// shrink (revoked rows stay around with active=false). Subsequent
+// runs are no-ops with a near-zero cost beyond the scan itself.
+
+// BackfillOAuthConnectionsResult reports how the backfill shaped the
+// tables — useful for the startup log so operators can see "N chains
+// seeded, M skipped" and notice if a re-run finds new work (which
+// would indicate live token issuance between server starts).
+type BackfillOAuthConnectionsResult struct {
+	// ChainsSeen is the count of distinct request_id chains the scan
+	// touched (sum across access + refresh tokens, deduplicated).
+	ChainsSeen int
+
+	// ConnectionsCreated is the count of NEW oauth_connections rows
+	// the backfill inserted. Repeat runs report 0 here once stable.
+	ConnectionsCreated int
+
+	// WorkspacesAdded is the count of (request_id, workspace_id) join
+	// rows inserted across all chains with explicit allow-lists.
+	WorkspacesAdded int
+
+	// UnresolvedSlugs counts cases where a slug from session.Extra
+	// didn't match any workspace row (workspace deleted, renamed,
+	// typo'd in a fixture, etc.). Logged at WARN so they're visible
+	// without failing the backfill — a missing slug is data hygiene,
+	// not a correctness blocker.
+	UnresolvedSlugs int
+}
+
+// BackfillOAuthConnections walks every distinct grant chain found in
+// oauth_access_tokens and oauth_refresh_tokens, parses the newest
+// chain row's session_data.Extra.allowed_workspaces, and seeds the new
+// oauth_connections + oauth_connection_workspaces tables.
+//
+// Shape mapping (IDEA-1517 §2 backfill spec):
+//
+//   - No key (pre-TASK-952 token)   → all_current_workspaces=1, no join rows.
+//   - ["*"] wildcard                → all_current_workspaces=1, no join rows.
+//   - Explicit slug list            → all_current_workspaces=0, one join
+//     row per resolvable slug, all
+//     added_by='user'.
+//
+// In all cases:
+//
+//   - name defaults to ” (Phase D UI prompts on first connections-
+//     page visit to name unnamed connections).
+//   - may_create_workspaces, include_future_workspaces both default
+//     ON (the new-grant default per §2a's consent screen).
+//
+// Operates outside any transaction. The individual INSERTs are
+// idempotent, and crashing mid-run leaves the tables in a consistent
+// partial state that the next run completes. Wrapping in a single
+// transaction would extend the writer hold across the entire grant-
+// chain scan, which for cloud-mode deployments with O(thousands) of
+// active chains could measurably stall concurrent /authorize traffic
+// on startup.
+//
+// If chain-scale ever becomes a problem the right answer is per-chain
+// transactions or a chunked walk (PLAN-1519 Risks bullet); both stay
+// within idempotent semantics so a v2 doesn't have to migrate state.
+func (s *Store) BackfillOAuthConnections() (BackfillOAuthConnectionsResult, error) {
+	result := BackfillOAuthConnectionsResult{}
+
+	// One scan that unions access + refresh tokens, grouped by
+	// request_id with the newest row's session_data per chain. The
+	// chain may exist in either table (refresh-only when access has
+	// expired but refresh hasn't been used yet) so we walk both.
+	//
+	// We don't filter on active=true here: an inactive chain still
+	// renders on /console/connected-apps as long as a token row
+	// exists — the existing read path (and the rewritten one) hides
+	// inactive chains itself. Seeding inactive chains gives the
+	// rewrite a clean "every chain has a connection row" invariant.
+	//
+	// Per-dialect: SQLite needs the ORDER BY in the inner query
+	// because GROUP BY's row-selection is undefined; Postgres allows
+	// DISTINCT ON. Keeping a uniform LEFT-JOIN-style aggregation in
+	// Go is simpler than two SQL paths.
+	chains, err := s.collectGrantChainsForBackfill()
+	if err != nil {
+		return result, fmt.Errorf("oauth_connections backfill: collect chains: %w", err)
+	}
+	result.ChainsSeen = len(chains)
+	if len(chains) == 0 {
+		return result, nil
+	}
+
+	for requestID, chain := range chains {
+		created, slugsAdded, slugsMissed, err := s.backfillOneChain(requestID, chain)
+		if err != nil {
+			// Per-chain failure is logged + continues. A single
+			// malformed session_data row shouldn't poison the rest
+			// of the backfill.
+			slog.Warn("oauth_connections backfill: chain skipped",
+				"request_id", requestID, "error", err)
+			continue
+		}
+		if created {
+			result.ConnectionsCreated++
+		}
+		result.WorkspacesAdded += slugsAdded
+		result.UnresolvedSlugs += slugsMissed
+	}
+	return result, nil
+}
+
+// backfillChain is the per-chain payload the scan returns. Only the
+// fields the seeder needs travel — keeping this struct lean lets the
+// chain map stay cheap even on cloud-mode datasets.
+type backfillChain struct {
+	UserID      string
+	SessionData string
+}
+
+// collectGrantChainsForBackfill returns a map keyed by request_id with
+// the newest session_data + the subject (user_id) per chain. Walks
+// both oauth_access_tokens and oauth_refresh_tokens — chains may live
+// only on the refresh side after their access token expires. Uses the
+// in-memory dedup pattern from ListUserOAuthConnections (same constraint
+// — SQLite/PG GROUP BY semantics differ for non-aggregated columns).
+func (s *Store) collectGrantChainsForBackfill() (map[string]backfillChain, error) {
+	chains := map[string]backfillChain{}
+	// requestedAtPerChain remembers the newest ISO timestamp seen so
+	// the access + refresh walks can each contribute and the latest
+	// row across both still wins.
+	requestedAtPerChain := map[string]string{}
+
+	scan := func(query string) error {
+		rows, err := s.db.Query(s.q(query))
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var requestID, subject, requestedAt, sessionData string
+			if err := rows.Scan(&requestID, &subject, &requestedAt, &sessionData); err != nil {
+				return err
+			}
+			if subject == "" {
+				// A token row with no subject can't be attributed to
+				// a user — skip, the chain won't show up on any
+				// connections page anyway.
+				continue
+			}
+			// String compare on ISO-8601 lexicographic order matches
+			// chronological order for this format. Cheaper than parsing
+			// timestamps inside the hot loop.
+			if existing, ok := requestedAtPerChain[requestID]; ok && requestedAt <= existing {
+				continue
+			}
+			requestedAtPerChain[requestID] = requestedAt
+			chains[requestID] = backfillChain{UserID: subject, SessionData: sessionData}
+		}
+		return rows.Err()
+	}
+
+	if err := scan(`
+        SELECT request_id, subject, requested_at, session_data
+        FROM oauth_access_tokens
+    `); err != nil {
+		return nil, fmt.Errorf("scan access tokens: %w", err)
+	}
+	if err := scan(`
+        SELECT request_id, subject, requested_at, session_data
+        FROM oauth_refresh_tokens
+    `); err != nil {
+		return nil, fmt.Errorf("scan refresh tokens: %w", err)
+	}
+	return chains, nil
+}
+
+// backfillOneChain seeds the oauth_connections + (when applicable)
+// oauth_connection_workspaces rows for a single grant chain.
+//
+// Returns:
+//   - created       — true iff we inserted a fresh oauth_connections row
+//     (false on idempotent re-runs).
+//   - slugsAdded    — count of join rows successfully inserted.
+//   - slugsMissed   — count of slugs we couldn't resolve to a workspace
+//     ID (deleted workspace, renamed since consent,
+//     etc.); logged at WARN by the caller via the
+//     aggregated UnresolvedSlugs counter.
+//   - err           — only for I/O failures the caller should surface;
+//     parse failures map to "wildcard" (no allow-list
+//     constraint) rather than erroring, matching the
+//     defensive posture in parseAllowedWorkspacesFromSession.
+func (s *Store) backfillOneChain(requestID string, chain backfillChain) (created bool, slugsAdded, slugsMissed int, err error) {
+	allowed := extractAllowedWorkspacesFromSessionExtra(chain.SessionData)
+	allCurrent, explicit := allowed.toShape()
+
+	// Insert the parent row. Use the dialect's INSERT-or-IGNORE form
+	// so a re-run is a clean no-op when the row already exists.
+	if err := s.insertOAuthConnectionIfAbsent(requestID, chain.UserID, allCurrent); err != nil {
+		return false, 0, 0, fmt.Errorf("insert parent: %w", err)
+	}
+
+	// Was this a fresh insert? Probe via a SELECT; cheap (PK lookup)
+	// and lets the result reporting stay accurate across re-runs.
+	// (RowsAffected isn't portable here — SQLite reports 0 for "or
+	// ignore" hits in some driver versions, Postgres reports the
+	// expected 1/0. Probing is the safe path.)
+	if _, getErr := s.GetOAuthConnection(requestID); getErr != nil {
+		// Parent disappeared between insert + probe — extreme race,
+		// skip the join writes rather than FK-violate.
+		return false, 0, 0, nil
+	}
+
+	// Heuristic: if explicit is non-nil, we're on the "fresh write"
+	// path on first pass. On a re-run we can't distinguish "we wrote
+	// this last time" from "we wrote this just now," but the only
+	// observable difference is the `created` flag returned for the
+	// counters — which the caller treats as a logging metric, not a
+	// correctness signal. To keep the count meaningful on first runs,
+	// use a side query: a chain whose updated_at == created_at is one
+	// we just inserted. This is best-effort; on re-runs the counter
+	// will under-report rather than over-report, which is fine.
+	created = wasFreshlyInserted(s, requestID)
+
+	if explicit == nil {
+		// Wildcard / pre-TASK-952 — no join rows to write.
+		return created, 0, 0, nil
+	}
+
+	// Resolve each slug to a workspace ID and insert. Missing slugs
+	// (workspace deleted, never existed in this DB) skip without
+	// failing; the unresolved count surfaces in the result so ops
+	// can spot data hygiene issues.
+	for _, slug := range explicit {
+		ws, getErr := s.GetWorkspaceBySlug(slug)
+		if getErr != nil || ws == nil {
+			slugsMissed++
+			continue
+		}
+		if err := s.AddConnectionWorkspace(requestID, ws.ID, AddedByUser); err != nil {
+			return created, slugsAdded, slugsMissed, fmt.Errorf("insert workspace %s: %w", slug, err)
+		}
+		slugsAdded++
+	}
+	return created, slugsAdded, slugsMissed, nil
+}
+
+// insertOAuthConnectionIfAbsent inserts the oauth_connections row
+// idempotently. all_current_workspaces is the only flag derived from
+// session.Extra; the other two default to ON per IDEA-1517 §2a
+// ("all scope flags default to on" for the migrated set so existing
+// connections preserve their behaviour until the user edits them).
+func (s *Store) insertOAuthConnectionIfAbsent(requestID, userID string, allCurrent bool) error {
+	var stmt string
+	switch s.dialect.Driver() {
+	case DriverPostgres:
+		stmt = `
+            INSERT INTO oauth_connections (
+                request_id, user_id, name,
+                may_create_workspaces, all_current_workspaces, include_future_workspaces
+            ) VALUES (?, ?, '', ?, ?, ?)
+            ON CONFLICT (request_id) DO NOTHING
+        `
+	default:
+		stmt = `
+            INSERT OR IGNORE INTO oauth_connections (
+                request_id, user_id, name,
+                may_create_workspaces, all_current_workspaces, include_future_workspaces
+            ) VALUES (?, ?, '', ?, ?, ?)
+        `
+	}
+	_, err := s.db.Exec(s.q(stmt),
+		requestID, userID,
+		s.dialect.BoolToInt(true), // may_create_workspaces default ON
+		s.dialect.BoolToInt(allCurrent),
+		s.dialect.BoolToInt(true), // include_future_workspaces default ON
+	)
+	return err
+}
+
+// wasFreshlyInserted reports whether the oauth_connections row for
+// requestID has updated_at equal to created_at — the cheap "did we
+// just insert this?" probe used to keep the backfill counters
+// accurate without relying on per-driver RowsAffected semantics.
+//
+// On re-runs (no insert happened, no UPDATE either) this returns
+// true as well, so the counter is technically a "freshly created or
+// untouched since" reading. That's fine for the logging use case:
+// operators care about "did the backfill find work to do," and
+// over-counting on a long-stale row is no worse than missing it.
+// First-run reporting is the meaningful axis and the equality check
+// works there.
+func wasFreshlyInserted(s *Store, requestID string) bool {
+	var createdAt, updatedAt string
+	err := s.db.QueryRow(s.q(`
+        SELECT created_at, updated_at FROM oauth_connections WHERE request_id = ?
+    `), requestID).Scan(&createdAt, &updatedAt)
+	if err != nil {
+		return false
+	}
+	return createdAt == updatedAt
+}
+
+// extractedAllowed captures one of the three IDEA-1517 §2 backfill
+// input shapes parsed out of session.Extra.allowed_workspaces.
+type extractedAllowed struct {
+	hasKey bool // true if session.Extra had the key at all
+	isStar bool // true iff the only entry is "*" (wildcard)
+	slugs  []string
+}
+
+// toShape converts the parsed extract into the (all_current, explicit)
+// pair the seeder consumes. Three branches:
+//
+//   - hasKey == false        → all_current=true, explicit=nil
+//     (pre-TASK-952 token; legacy semantic was "any workspace")
+//   - isStar == true         → all_current=true, explicit=nil
+//     (post-TASK-952 wildcard)
+//   - explicit slug list     → all_current=false, explicit=<slugs>
+//
+// An explicit empty list (consent flow rejected) lands here too —
+// all_current=false, explicit=[]string{} — yielding a connection
+// scoped to nothing. That matches IDEA-1517's fail-closed posture
+// (the consent flow rejects empty lists, so this case is exotic but
+// preserved verbatim rather than silently widened).
+func (e extractedAllowed) toShape() (allCurrent bool, explicit []string) {
+	if !e.hasKey {
+		return true, nil
+	}
+	if e.isStar {
+		return true, nil
+	}
+	return false, e.slugs
+}
+
+// extractAllowedWorkspacesFromSessionExtra parses session_data JSON
+// and returns the extracted shape. Defensive: malformed JSON,
+// non-object .extra, non-string array entries, etc. all collapse to
+// "no key" (wildcard semantic) — matching parseAllowedWorkspacesFromSession's
+// posture. The backfill is one-shot data motion; a few malformed
+// rows shouldn't fail the run.
+func extractAllowedWorkspacesFromSessionExtra(sessionData string) extractedAllowed {
+	if sessionData == "" {
+		return extractedAllowed{}
+	}
+	var outer struct {
+		Extra map[string]interface{} `json:"extra"`
+	}
+	if err := json.Unmarshal([]byte(sessionData), &outer); err != nil || outer.Extra == nil {
+		return extractedAllowed{}
+	}
+	raw, ok := outer.Extra["allowed_workspaces"]
+	if !ok {
+		return extractedAllowed{}
+	}
+	out := extractedAllowed{hasKey: true}
+	var collected []string
+	switch v := raw.(type) {
+	case []string:
+		collected = append([]string(nil), v...)
+	case []interface{}:
+		for _, e := range v {
+			if s, ok := e.(string); ok && s != "" {
+				collected = append(collected, s)
+			}
+		}
+	default:
+		// Key present but with a non-array shape: treat as if absent
+		// rather than fail-closed; preserves the legacy "unrecognized
+		// payload = unrestricted" behaviour of the existing helper.
+		return extractedAllowed{}
+	}
+	// A list containing exactly one "*" is the wildcard sentinel.
+	// Other shapes (["*","foo"], multiple wildcards, etc.) fall
+	// through to the explicit-list branch where the seeder drops
+	// the wildcard via the slug-resolve step (no workspace has
+	// slug "*", so it lands in UnresolvedSlugs).
+	if len(collected) == 1 && collected[0] == "*" {
+		out.isStar = true
+		return out
+	}
+	out.slugs = collected
+	return out
+}

--- a/internal/store/oauth_connections_backfill.go
+++ b/internal/store/oauth_connections_backfill.go
@@ -308,9 +308,26 @@ func (s *Store) backfillOneChain(requestID string, chain backfillChain) (created
 	// lookup off the tx avoids holding the writer lock during the
 	// (very rare) deleted-slug fast-path. SQLite + Postgres both honor
 	// repeatable reads of static data here.
+	//
+	// Slug resolution distinguishes two failure modes:
+	//   - (nil, nil) — workspace doesn't exist (deleted, never
+	//     existed, renamed since consent). Counted in slugsMissed +
+	//     continues; the missing slug is data hygiene, not a
+	//     correctness blocker.
+	//   - (nil, err) — real I/O failure on the store-side query.
+	//     Surface so the per-chain transaction ROLLS BACK rather
+	//     than committing a partial allow-list. Without this branch
+	//     a real DB error mid-loop would silently emit a chain
+	//     scoped to only the slugs lookup succeeded for — and the
+	//     next backfill would short-circuit on parentExists, making
+	//     the partial scope permanent. Codex review #583 round 4
+	//     caught the gap.
 	for _, slug := range explicit {
 		ws, getErr := s.GetWorkspaceBySlug(slug)
-		if getErr != nil || ws == nil {
+		if getErr != nil {
+			return false, 0, 0, fmt.Errorf("workspace lookup %s: %w", slug, getErr)
+		}
+		if ws == nil {
 			slugsMissed++
 			continue
 		}

--- a/internal/store/oauth_connections_backfill.go
+++ b/internal/store/oauth_connections_backfill.go
@@ -218,47 +218,52 @@ func (s *Store) backfillOneChain(requestID string, chain backfillChain) (created
 	allowed := extractAllowedWorkspacesFromSessionExtra(chain.SessionData)
 	allCurrent, explicit := allowed.toShape()
 
-	// Insert the parent row. Use the dialect's INSERT-or-IGNORE form
-	// so a re-run is a clean no-op when the row already exists.
-	if err := s.insertOAuthConnectionIfAbsent(requestID, chain.UserID, allCurrent); err != nil {
-		return false, 0, 0, fmt.Errorf("insert parent: %w", err)
-	}
-
-	// Was this a fresh insert? Probe via a SELECT; cheap (PK lookup)
-	// and lets the result reporting stay accurate across re-runs.
-	// (RowsAffected isn't portable here — SQLite reports 0 for "or
-	// ignore" hits in some driver versions, Postgres reports the
-	// expected 1/0. Probing is the safe path.)
+	// Probe BEFORE the insert so the counter reflects actual new
+	// work — RowsAffected isn't portable across SQLite + Postgres
+	// for "OR IGNORE" / "ON CONFLICT DO NOTHING" semantics (some
+	// drivers report 0, some 1), and a wall-clock heuristic over
+	// updated_at vs created_at over-reports on every steady-state
+	// startup once the row's been backfilled and never edited.
+	// Codex review #583 round 1 caught the over-report.
 	if _, getErr := s.GetOAuthConnection(requestID); getErr != nil {
-		// Parent disappeared between insert + probe — extreme race,
-		// skip the join writes rather than FK-violate.
-		return false, 0, 0, nil
+		// Row doesn't exist — we're about to insert it. Insert and
+		// flag created=true.
+		if err := s.insertOAuthConnectionIfAbsent(requestID, chain.UserID, allCurrent); err != nil {
+			return false, 0, 0, fmt.Errorf("insert parent: %w", err)
+		}
+		created = true
 	}
-
-	// Heuristic: if explicit is non-nil, we're on the "fresh write"
-	// path on first pass. On a re-run we can't distinguish "we wrote
-	// this last time" from "we wrote this just now," but the only
-	// observable difference is the `created` flag returned for the
-	// counters — which the caller treats as a logging metric, not a
-	// correctness signal. To keep the count meaningful on first runs,
-	// use a side query: a chain whose updated_at == created_at is one
-	// we just inserted. This is best-effort; on re-runs the counter
-	// will under-report rather than over-report, which is fine.
-	created = wasFreshlyInserted(s, requestID)
+	// Re-runs on an existing row don't update — connection-level
+	// state (name + scope flags) is user-owned post-backfill and
+	// the backfill must not stomp it. Same posture as IDEA-1517 §2's
+	// "name defaults to empty until the user edits."
 
 	if explicit == nil {
 		// Wildcard / pre-TASK-952 — no join rows to write.
 		return created, 0, 0, nil
 	}
 
-	// Resolve each slug to a workspace ID and insert. Missing slugs
-	// (workspace deleted, never existed in this DB) skip without
-	// failing; the unresolved count surfaces in the result so ops
-	// can spot data hygiene issues.
+	// Resolve each slug to a workspace ID. Missing slugs (workspace
+	// deleted, never existed in this DB) skip without failing; the
+	// unresolved count surfaces in the result so ops can spot data
+	// hygiene issues. Existence-probe each (request_id, workspace_id)
+	// pair before insert so the slugsAdded counter reflects new
+	// rows, not "OR IGNORE" no-ops.
 	for _, slug := range explicit {
 		ws, getErr := s.GetWorkspaceBySlug(slug)
 		if getErr != nil || ws == nil {
 			slugsMissed++
+			continue
+		}
+		alreadyAllowed, checkErr := s.IsConnectionWorkspaceAllowed(requestID, ws.ID)
+		if checkErr != nil {
+			return created, slugsAdded, slugsMissed, fmt.Errorf("check workspace %s: %w", slug, checkErr)
+		}
+		if alreadyAllowed {
+			// Pre-existing join row from a prior backfill run. Don't
+			// re-issue the INSERT — the OR-IGNORE would no-op anyway,
+			// but skipping keeps the DB write path cleaner and the
+			// counter honest.
 			continue
 		}
 		if err := s.AddConnectionWorkspace(requestID, ws.ID, AddedByUser); err != nil {
@@ -300,29 +305,6 @@ func (s *Store) insertOAuthConnectionIfAbsent(requestID, userID string, allCurre
 		s.dialect.BoolToInt(true), // include_future_workspaces default ON
 	)
 	return err
-}
-
-// wasFreshlyInserted reports whether the oauth_connections row for
-// requestID has updated_at equal to created_at — the cheap "did we
-// just insert this?" probe used to keep the backfill counters
-// accurate without relying on per-driver RowsAffected semantics.
-//
-// On re-runs (no insert happened, no UPDATE either) this returns
-// true as well, so the counter is technically a "freshly created or
-// untouched since" reading. That's fine for the logging use case:
-// operators care about "did the backfill find work to do," and
-// over-counting on a long-stale row is no worse than missing it.
-// First-run reporting is the meaningful axis and the equality check
-// works there.
-func wasFreshlyInserted(s *Store, requestID string) bool {
-	var createdAt, updatedAt string
-	err := s.db.QueryRow(s.q(`
-        SELECT created_at, updated_at FROM oauth_connections WHERE request_id = ?
-    `), requestID).Scan(&createdAt, &updatedAt)
-	if err != nil {
-		return false
-	}
-	return createdAt == updatedAt
 }
 
 // extractedAllowed captures one of the three IDEA-1517 §2 backfill

--- a/internal/store/oauth_connections_backfill.go
+++ b/internal/store/oauth_connections_backfill.go
@@ -238,6 +238,20 @@ func (s *Store) backfillOneChain(requestID string, chain backfillChain) (created
 	// the backfill must not stomp it. Same posture as IDEA-1517 §2's
 	// "name defaults to empty until the user edits."
 
+	if !created {
+		// Parent already existed from a prior backfill run — the
+		// connection-level state (name, scope flags) AND the join
+		// table is user-owned post-backfill. Specifically: if the
+		// user removes a workspace via RemoveConnectionWorkspace, a
+		// subsequent backfill re-adding it from stale session.Extra
+		// would silently revert their decision on every restart.
+		// Codex review #583 round 2 caught the regression.
+		//
+		// "Backfill" means SEED — once. After that the new tables
+		// are authoritative. The slug loop below only runs when we
+		// just inserted a fresh parent row.
+		return created, 0, 0, nil
+	}
 	if explicit == nil {
 		// Wildcard / pre-TASK-952 — no join rows to write.
 		return created, 0, 0, nil
@@ -246,24 +260,15 @@ func (s *Store) backfillOneChain(requestID string, chain backfillChain) (created
 	// Resolve each slug to a workspace ID. Missing slugs (workspace
 	// deleted, never existed in this DB) skip without failing; the
 	// unresolved count surfaces in the result so ops can spot data
-	// hygiene issues. Existence-probe each (request_id, workspace_id)
-	// pair before insert so the slugsAdded counter reflects new
-	// rows, not "OR IGNORE" no-ops.
+	// hygiene issues. No need for IsConnectionWorkspaceAllowed
+	// probes here — by construction the parent row was just inserted,
+	// so the join table cannot contain any rows for this request_id
+	// yet (Phase A's CASCADE FK ensures parent + join lifecycle stay
+	// linked).
 	for _, slug := range explicit {
 		ws, getErr := s.GetWorkspaceBySlug(slug)
 		if getErr != nil || ws == nil {
 			slugsMissed++
-			continue
-		}
-		alreadyAllowed, checkErr := s.IsConnectionWorkspaceAllowed(requestID, ws.ID)
-		if checkErr != nil {
-			return created, slugsAdded, slugsMissed, fmt.Errorf("check workspace %s: %w", slug, checkErr)
-		}
-		if alreadyAllowed {
-			// Pre-existing join row from a prior backfill run. Don't
-			// re-issue the INSERT — the OR-IGNORE would no-op anyway,
-			// but skipping keeps the DB write path cleaner and the
-			// counter honest.
 			continue
 		}
 		if err := s.AddConnectionWorkspace(requestID, ws.ID, AddedByUser); err != nil {

--- a/internal/store/oauth_connections_backfill_test.go
+++ b/internal/store/oauth_connections_backfill_test.go
@@ -338,6 +338,66 @@ func TestBackfillOAuthConnections_DoesNotResurrectRemovedWorkspace(t *testing.T)
 	}
 }
 
+// TestBackfillOAuthConnections_AtomicOnMidLoopFailure verifies that
+// the per-chain transaction rolls BOTH the parent oauth_connections
+// row AND any join rows back when a slug INSERT fails mid-loop. The
+// regression guard for Codex review #583 round 3: without atomicity,
+// a partial seed (parent inserted, slug loop crashed) would leave the
+// connection permanently scoped to an incomplete allow-list because
+// the subsequent backfill sees the parent row and short-circuits.
+//
+// We force a mid-loop INSERT failure by stuffing the same slug twice
+// into session.Extra. The second INSERT against
+// oauth_connection_workspaces hits the (request_id, workspace_id) PK
+// uniqueness constraint, raising an error. The atomic rollback should
+// unwind the parent row too — re-running backfill on a CORRECTED
+// payload (deduped) then succeeds.
+//
+// In practice the consent flow would never emit a duplicate slug, but
+// the test exercises the same rollback path any other error would
+// trigger (network glitch, FK violation, etc.).
+func TestBackfillOAuthConnections_AtomicOnMidLoopFailure(t *testing.T) {
+	s := newBackfillTestStore(t)
+	uid := seedBackfillUser(t, s, "atomic@example.com")
+	client := seedBackfillClient(t, s, "Atomic Client")
+	_, slug := seedBackfillWorkspace(t, s, "atomic-ws", uid)
+
+	// Duplicate slug → second insert violates PK, errors mid-loop.
+	seedBackfillAccess(t, s, "atomic-chain", client, uid, time.Now().UTC(),
+		`{"extra":{"allowed_workspaces":["`+slug+`","`+slug+`"]}}`)
+
+	// First run: chain processing fails. The backfill logs the chain
+	// at WARN + continues, but the parent row + any partial join
+	// rows must be rolled back so the next clean run can finish the
+	// seed.
+	if _, err := s.BackfillOAuthConnections(); err != nil {
+		t.Fatalf("first BackfillOAuthConnections: %v", err)
+	}
+	if _, err := s.GetOAuthConnection("atomic-chain"); err == nil {
+		t.Fatalf("parent row should have rolled back on mid-loop INSERT failure")
+	}
+
+	// Simulate the operator fixing the corrupt session.Extra by
+	// deleting the chain's existing token rows and reseeding with a
+	// clean payload. In production this would happen naturally on
+	// the next token refresh through /authorize/decide.
+	if _, err := s.db.Exec(`DELETE FROM oauth_access_tokens WHERE request_id = ?`, "atomic-chain"); err != nil {
+		t.Fatalf("DELETE oauth_access_tokens: %v", err)
+	}
+	seedBackfillAccess(t, s, "atomic-chain", client, uid, time.Now().UTC(),
+		`{"extra":{"allowed_workspaces":["`+slug+`"]}}`)
+
+	// Second run: clean payload. Atomic insert lands parent + slug
+	// together. No half-seeded artifact from the first failed run.
+	res, err := s.BackfillOAuthConnections()
+	if err != nil {
+		t.Fatalf("second BackfillOAuthConnections: %v", err)
+	}
+	if res.ConnectionsCreated != 1 || res.WorkspacesAdded != 1 {
+		t.Errorf("clean retry should fully seed; got %+v", res)
+	}
+}
+
 func TestBackfillOAuthConnections_Idempotent(t *testing.T) {
 	s := newBackfillTestStore(t)
 	uid := seedBackfillUser(t, s, "idem@example.com")

--- a/internal/store/oauth_connections_backfill_test.go
+++ b/internal/store/oauth_connections_backfill_test.go
@@ -286,6 +286,58 @@ func TestBackfillOAuthConnections_RefreshOnlyChain(t *testing.T) {
 	}
 }
 
+// TestBackfillOAuthConnections_DoesNotResurrectRemovedWorkspace is the
+// regression guard for Codex review #583 round 2: a user who removes a
+// slug from their connection's allow-list (via Phase D's mutation UI)
+// must NOT see the slug come back on the next server restart's
+// backfill run. Backfill is a one-shot seed; once the oauth_connections
+// row exists, the new tables are authoritative and the legacy
+// session.Extra payload is frozen reference data, not a source of
+// truth the backfill keeps reconciling against.
+func TestBackfillOAuthConnections_DoesNotResurrectRemovedWorkspace(t *testing.T) {
+	s := newBackfillTestStore(t)
+	uid := seedBackfillUser(t, s, "resurrect@example.com")
+	client := seedBackfillClient(t, s, "Resurrect Client")
+	keepID, keepSlug := seedBackfillWorkspace(t, s, "keep", uid)
+	removeID, removeSlug := seedBackfillWorkspace(t, s, "remove", uid)
+
+	seedBackfillAccess(t, s, "res-chain", client, uid, time.Now().UTC(),
+		`{"extra":{"allowed_workspaces":["`+keepSlug+`","`+removeSlug+`"]}}`)
+
+	// First run seeds both slugs.
+	if _, err := s.BackfillOAuthConnections(); err != nil {
+		t.Fatalf("first BackfillOAuthConnections: %v", err)
+	}
+
+	// User removes the second workspace via the connections-page UI.
+	// (Simulated directly through the store — the wire path lands in
+	// Phase D, but the semantic is identical.)
+	if err := s.RemoveConnectionWorkspace("res-chain", removeID); err != nil {
+		t.Fatalf("RemoveConnectionWorkspace: %v", err)
+	}
+
+	// Second backfill run — the same session.Extra still references
+	// the removed slug, but we must NOT reinstate it.
+	if _, err := s.BackfillOAuthConnections(); err != nil {
+		t.Fatalf("second BackfillOAuthConnections: %v", err)
+	}
+
+	allowedKeep, err := s.IsConnectionWorkspaceAllowed("res-chain", keepID)
+	if err != nil {
+		t.Fatalf("IsConnectionWorkspaceAllowed keep: %v", err)
+	}
+	if !allowedKeep {
+		t.Errorf("keep workspace should still be in allow-list (backfill must not touch it)")
+	}
+	allowedRemoved, err := s.IsConnectionWorkspaceAllowed("res-chain", removeID)
+	if err != nil {
+		t.Fatalf("IsConnectionWorkspaceAllowed remove: %v", err)
+	}
+	if allowedRemoved {
+		t.Errorf("removed workspace must NOT be resurrected by backfill rerun (user's removal would silently revert)")
+	}
+}
+
 func TestBackfillOAuthConnections_Idempotent(t *testing.T) {
 	s := newBackfillTestStore(t)
 	uid := seedBackfillUser(t, s, "idem@example.com")

--- a/internal/store/oauth_connections_backfill_test.go
+++ b/internal/store/oauth_connections_backfill_test.go
@@ -307,13 +307,17 @@ func TestBackfillOAuthConnections_Idempotent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("second BackfillOAuthConnections: %v", err)
 	}
-	// Idempotent: chain scan re-counts but no new oauth_connections
-	// rows are inserted. The AddConnectionWorkspace path uses INSERT
-	// OR IGNORE / ON CONFLICT DO NOTHING, so re-issuing the same join
-	// inserts is a no-op at the DB layer; the WorkspacesAdded counter
-	// reflects calls that returned success (including no-op no-error
-	// inserts), so we don't assert on the counter value. The real
-	// invariant is the resulting row count below.
+	// Idempotent: chain scan re-counts but every counter for "new
+	// work" must report 0 — pre-insert existence probes prevent
+	// no-op INSERTs from incrementing the counters. Codex review
+	// #583 round 1 caught the prior over-report; this assertion is
+	// the regression guard.
+	if second.ConnectionsCreated != 0 {
+		t.Errorf("idempotent re-run ConnectionsCreated = %d, want 0", second.ConnectionsCreated)
+	}
+	if second.WorkspacesAdded != 0 {
+		t.Errorf("idempotent re-run WorkspacesAdded = %d, want 0", second.WorkspacesAdded)
+	}
 	access, err := s.GetOAuthConnectionAccess("idem-chain")
 	if err != nil {
 		t.Fatalf("GetOAuthConnectionAccess: %v", err)

--- a/internal/store/oauth_connections_backfill_test.go
+++ b/internal/store/oauth_connections_backfill_test.go
@@ -1,0 +1,327 @@
+package store
+
+import (
+	"path/filepath"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// BackfillOAuthConnections tests (PLAN-1519 / TASK-1522 / IDEA-1517 §2).
+//
+// What's covered:
+//
+//   - Pre-TASK-952 session (no key)           → all_current=1, no join rows.
+//   - Wildcard session (`["*"]`)              → all_current=1, no join rows.
+//   - Explicit slug list, all slugs resolvable → all_current=0, one join
+//                                                row per slug, added_by='user'.
+//   - Explicit slug list with a deleted slug   → unresolved counter ticks,
+//                                                the rest of the slugs land.
+//   - Multi-row chain (refresh-token rotation) → newest row drives the
+//                                                seeded shape, not earliest.
+//   - Refresh-only chain (no access row)       → still backfilled.
+//   - Idempotent re-run                        → no double inserts, counters
+//                                                report zero new work.
+//   - Empty database                           → no-op, no error.
+
+func newBackfillTestStore(t *testing.T) *Store {
+	t.Helper()
+	dir := t.TempDir()
+	s, err := New(filepath.Join(dir, "backfill.db"))
+	if err != nil {
+		t.Fatalf("New store: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	return s
+}
+
+func seedBackfillUser(t *testing.T, s *Store, email string) string {
+	t.Helper()
+	u, err := s.CreateUser(models.UserCreate{
+		Email: email, Name: "Backfill Tester",
+		Password: "pw-backfill-12345",
+	})
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	return u.ID
+}
+
+func seedBackfillWorkspace(t *testing.T, s *Store, name, ownerID string) (id, slug string) {
+	t.Helper()
+	w, err := s.CreateWorkspace(models.WorkspaceCreate{Name: name, OwnerID: ownerID})
+	if err != nil {
+		t.Fatalf("CreateWorkspace %s: %v", name, err)
+	}
+	return w.ID, w.Slug
+}
+
+// seedBackfillClient mirrors seedClient in connected_apps_test.go but
+// stays internal to this file so the backfill suite can run in
+// isolation when other tests in the package fail.
+func seedBackfillClient(t *testing.T, s *Store, name string) string {
+	t.Helper()
+	c, err := s.CreateOAuthClient(models.OAuthClientCreate{
+		Name:                    name,
+		RedirectURIs:            []string{"https://example.test/cb"},
+		GrantTypes:              []string{"authorization_code", "refresh_token"},
+		ResponseTypes:           []string{"code"},
+		TokenEndpointAuthMethod: "none",
+		Scopes:                  []string{"pad:read", "pad:write"},
+		Public:                  true,
+	})
+	if err != nil {
+		t.Fatalf("CreateOAuthClient: %v", err)
+	}
+	return c.ID
+}
+
+func seedBackfillAccess(t *testing.T, s *Store, requestID, clientID, subject string, ts time.Time, sessionData string) {
+	t.Helper()
+	if err := s.CreateAccessToken(models.OAuthRequest{
+		Signature:     newID(),
+		RequestID:     requestID,
+		RequestedAt:   ts,
+		ClientID:      clientID,
+		GrantedScopes: "pad:read pad:write",
+		SessionData:   sessionData,
+		Subject:       subject,
+	}); err != nil {
+		t.Fatalf("CreateAccessToken: %v", err)
+	}
+}
+
+func seedBackfillRefresh(t *testing.T, s *Store, requestID, clientID, subject string, ts time.Time, sessionData string) {
+	t.Helper()
+	if err := s.CreateRefreshToken(models.OAuthRequest{
+		Signature:     newID(),
+		RequestID:     requestID,
+		RequestedAt:   ts,
+		ClientID:      clientID,
+		GrantedScopes: "pad:read pad:write",
+		SessionData:   sessionData,
+		Subject:       subject,
+	}); err != nil {
+		t.Fatalf("CreateRefreshToken: %v", err)
+	}
+}
+
+func TestBackfillOAuthConnections_EmptyDatabase(t *testing.T) {
+	s := newBackfillTestStore(t)
+	res, err := s.BackfillOAuthConnections()
+	if err != nil {
+		t.Fatalf("BackfillOAuthConnections: %v", err)
+	}
+	if res.ChainsSeen != 0 || res.ConnectionsCreated != 0 || res.WorkspacesAdded != 0 {
+		t.Errorf("empty DB result = %+v, want all zero", res)
+	}
+}
+
+func TestBackfillOAuthConnections_PreTASK952_WildcardSemantic(t *testing.T) {
+	s := newBackfillTestStore(t)
+	uid := seedBackfillUser(t, s, "pre-952@example.com")
+	client := seedBackfillClient(t, s, "Pre-952 Client")
+
+	// No allowed_workspaces key in session.Extra at all — pre-TASK-952
+	// token shape. Should seed all_current_workspaces=1.
+	seedBackfillAccess(t, s, "pre-952-chain", client, uid, time.Now().UTC(), `{"extra":{}}`)
+
+	res, err := s.BackfillOAuthConnections()
+	if err != nil {
+		t.Fatalf("BackfillOAuthConnections: %v", err)
+	}
+	if res.ConnectionsCreated != 1 {
+		t.Errorf("ConnectionsCreated = %d, want 1", res.ConnectionsCreated)
+	}
+	if res.WorkspacesAdded != 0 {
+		t.Errorf("WorkspacesAdded = %d, want 0 (wildcard shape)", res.WorkspacesAdded)
+	}
+
+	conn, err := s.GetOAuthConnection("pre-952-chain")
+	if err != nil {
+		t.Fatalf("GetOAuthConnection: %v", err)
+	}
+	if !conn.AllCurrentWorkspaces {
+		t.Errorf("all_current_workspaces = false, want true for pre-TASK-952 token")
+	}
+	if !conn.MayCreateWorkspaces || !conn.IncludeFutureWorkspaces {
+		t.Errorf("scope flags should default ON for backfilled rows, got %+v", conn)
+	}
+	if conn.Name != "" {
+		t.Errorf("backfilled name should be empty; got %q", conn.Name)
+	}
+}
+
+func TestBackfillOAuthConnections_Wildcard(t *testing.T) {
+	s := newBackfillTestStore(t)
+	uid := seedBackfillUser(t, s, "wildcard@example.com")
+	client := seedBackfillClient(t, s, "Wildcard Client")
+
+	seedBackfillAccess(t, s, "wc-chain", client, uid, time.Now().UTC(),
+		`{"extra":{"allowed_workspaces":["*"]}}`)
+
+	res, err := s.BackfillOAuthConnections()
+	if err != nil {
+		t.Fatalf("BackfillOAuthConnections: %v", err)
+	}
+	if res.ConnectionsCreated != 1 || res.WorkspacesAdded != 0 {
+		t.Errorf("result = %+v, want 1 connection / 0 workspaces", res)
+	}
+	conn, _ := s.GetOAuthConnection("wc-chain")
+	if !conn.AllCurrentWorkspaces {
+		t.Errorf("wildcard should map to all_current=true")
+	}
+}
+
+func TestBackfillOAuthConnections_ExplicitList(t *testing.T) {
+	s := newBackfillTestStore(t)
+	uid := seedBackfillUser(t, s, "explicit@example.com")
+	client := seedBackfillClient(t, s, "Explicit Client")
+	_, alphaSlug := seedBackfillWorkspace(t, s, "alpha", uid)
+	_, betaSlug := seedBackfillWorkspace(t, s, "beta", uid)
+
+	seedBackfillAccess(t, s, "exp-chain", client, uid, time.Now().UTC(),
+		`{"extra":{"allowed_workspaces":["`+alphaSlug+`","`+betaSlug+`"]}}`)
+
+	res, err := s.BackfillOAuthConnections()
+	if err != nil {
+		t.Fatalf("BackfillOAuthConnections: %v", err)
+	}
+	if res.ConnectionsCreated != 1 {
+		t.Errorf("ConnectionsCreated = %d, want 1", res.ConnectionsCreated)
+	}
+	if res.WorkspacesAdded != 2 {
+		t.Errorf("WorkspacesAdded = %d, want 2", res.WorkspacesAdded)
+	}
+	if res.UnresolvedSlugs != 0 {
+		t.Errorf("UnresolvedSlugs = %d, want 0", res.UnresolvedSlugs)
+	}
+
+	conn, _ := s.GetOAuthConnection("exp-chain")
+	if conn.AllCurrentWorkspaces {
+		t.Errorf("explicit-list chain should have all_current=false")
+	}
+	access, _ := s.GetOAuthConnectionAccess("exp-chain")
+	gotSlugs := append([]string(nil), access.WorkspaceSlugs...)
+	sort.Strings(gotSlugs)
+	want := []string{alphaSlug, betaSlug}
+	sort.Strings(want)
+	if len(gotSlugs) != 2 || gotSlugs[0] != want[0] || gotSlugs[1] != want[1] {
+		t.Errorf("WorkspaceSlugs = %v, want %v", gotSlugs, want)
+	}
+}
+
+func TestBackfillOAuthConnections_UnresolvedSlugIsCounted(t *testing.T) {
+	s := newBackfillTestStore(t)
+	uid := seedBackfillUser(t, s, "unresolved@example.com")
+	client := seedBackfillClient(t, s, "Unresolved Client")
+	_, realSlug := seedBackfillWorkspace(t, s, "real-ws", uid)
+
+	// Mix one real slug with one that points at a workspace that
+	// doesn't exist. The backfill should land the real one and tick
+	// the unresolved counter — not fail the whole chain.
+	seedBackfillAccess(t, s, "u-chain", client, uid, time.Now().UTC(),
+		`{"extra":{"allowed_workspaces":["`+realSlug+`","never-existed"]}}`)
+
+	res, err := s.BackfillOAuthConnections()
+	if err != nil {
+		t.Fatalf("BackfillOAuthConnections: %v", err)
+	}
+	if res.WorkspacesAdded != 1 {
+		t.Errorf("WorkspacesAdded = %d, want 1", res.WorkspacesAdded)
+	}
+	if res.UnresolvedSlugs != 1 {
+		t.Errorf("UnresolvedSlugs = %d, want 1", res.UnresolvedSlugs)
+	}
+}
+
+func TestBackfillOAuthConnections_NewestRowDrivesShape(t *testing.T) {
+	s := newBackfillTestStore(t)
+	uid := seedBackfillUser(t, s, "rotation@example.com")
+	client := seedBackfillClient(t, s, "Rotation Client")
+	_, alphaSlug := seedBackfillWorkspace(t, s, "alpha-rot", uid)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	// Oldest row has wildcard; newest row has an explicit list.
+	// Backfill must take the explicit list (the user's most recent
+	// scope decision). If we accidentally picked the oldest row we'd
+	// seed all_current=true and zero join rows.
+	seedBackfillAccess(t, s, "rot-chain", client, uid, now.Add(-2*time.Hour),
+		`{"extra":{"allowed_workspaces":["*"]}}`)
+	seedBackfillAccess(t, s, "rot-chain", client, uid, now,
+		`{"extra":{"allowed_workspaces":["`+alphaSlug+`"]}}`)
+
+	if _, err := s.BackfillOAuthConnections(); err != nil {
+		t.Fatalf("BackfillOAuthConnections: %v", err)
+	}
+	conn, _ := s.GetOAuthConnection("rot-chain")
+	if conn.AllCurrentWorkspaces {
+		t.Errorf("newest row was explicit; all_current should be false, got %+v", conn)
+	}
+	access, _ := s.GetOAuthConnectionAccess("rot-chain")
+	if len(access.WorkspaceSlugs) != 1 || access.WorkspaceSlugs[0] != alphaSlug {
+		t.Errorf("WorkspaceSlugs = %v, want [%q]", access.WorkspaceSlugs, alphaSlug)
+	}
+}
+
+func TestBackfillOAuthConnections_RefreshOnlyChain(t *testing.T) {
+	s := newBackfillTestStore(t)
+	uid := seedBackfillUser(t, s, "refresh-only@example.com")
+	client := seedBackfillClient(t, s, "Refresh Client")
+
+	// Chain lives only on the refresh side (access token already
+	// expired, but the refresh hasn't been used yet). Backfill must
+	// still seed it.
+	seedBackfillRefresh(t, s, "r-only-chain", client, uid, time.Now().UTC(),
+		`{"extra":{"allowed_workspaces":["*"]}}`)
+
+	res, err := s.BackfillOAuthConnections()
+	if err != nil {
+		t.Fatalf("BackfillOAuthConnections: %v", err)
+	}
+	if res.ConnectionsCreated != 1 {
+		t.Errorf("ConnectionsCreated = %d, want 1 for refresh-only chain", res.ConnectionsCreated)
+	}
+}
+
+func TestBackfillOAuthConnections_Idempotent(t *testing.T) {
+	s := newBackfillTestStore(t)
+	uid := seedBackfillUser(t, s, "idem@example.com")
+	client := seedBackfillClient(t, s, "Idem Client")
+	_, alphaSlug := seedBackfillWorkspace(t, s, "alpha-idem", uid)
+
+	seedBackfillAccess(t, s, "idem-chain", client, uid, time.Now().UTC(),
+		`{"extra":{"allowed_workspaces":["`+alphaSlug+`"]}}`)
+
+	first, err := s.BackfillOAuthConnections()
+	if err != nil {
+		t.Fatalf("first BackfillOAuthConnections: %v", err)
+	}
+	if first.ConnectionsCreated != 1 || first.WorkspacesAdded != 1 {
+		t.Errorf("first run = %+v, want 1 conn / 1 workspace", first)
+	}
+
+	second, err := s.BackfillOAuthConnections()
+	if err != nil {
+		t.Fatalf("second BackfillOAuthConnections: %v", err)
+	}
+	// Idempotent: chain scan re-counts but no new oauth_connections
+	// rows are inserted. The AddConnectionWorkspace path uses INSERT
+	// OR IGNORE / ON CONFLICT DO NOTHING, so re-issuing the same join
+	// inserts is a no-op at the DB layer; the WorkspacesAdded counter
+	// reflects calls that returned success (including no-op no-error
+	// inserts), so we don't assert on the counter value. The real
+	// invariant is the resulting row count below.
+	access, err := s.GetOAuthConnectionAccess("idem-chain")
+	if err != nil {
+		t.Fatalf("GetOAuthConnectionAccess: %v", err)
+	}
+	if len(access.WorkspaceSlugs) != 1 {
+		t.Errorf("after idempotent re-run, WorkspaceSlugs = %v; want exactly 1 entry", access.WorkspaceSlugs)
+	}
+	if second.ChainsSeen != 1 {
+		t.Errorf("second run ChainsSeen = %d, want 1", second.ChainsSeen)
+	}
+}


### PR DESCRIPTION
## Summary

Phase C1 for PLAN-1519. Seeds existing OAuth grant chains into the new connection tables (Phase A) and switches \`/console/connected-apps\` to read from them, retiring the session.Extra parse on the read path.

- **Backfill** (\`internal/store/oauth_connections_backfill.go\`) — idempotent walk of \`oauth_access_tokens\` + \`oauth_refresh_tokens\`, newest-row-per-chain drives the seeded shape, slugs resolve to workspace IDs, unresolved slugs counted + logged.
- **Read path** (\`internal/store/connected_apps.go\`) — \`ListUserOAuthConnections\` projects \`AllowedWorkspaces\` from \`oauth_connection_workspaces\` (via \`GetOAuthConnectionAccess\`); hydrates new \`Name\` / scope-flag fields from \`oauth_connections\`; defensive fallback for chains without a connection row.
- **Model** — adds \`Name\` / \`MayCreateWorkspaces\` / \`AllCurrentWorkspaces\` / \`IncludeFutureWorkspaces\`. \`AllowedWorkspaces\` semantics unchanged (nil = "any", explicit slugs = chips) so the DTO + frontend keep working.
- **Startup wiring** — runs once after \`SetOAuthServer\`/\`SetClaimSecret\`. Non-fatal on error; quiet on steady-state re-runs.
- \`parseAllowedWorkspacesFromSession\` retired; the session.Extra producer side stays until Phase C2 retires it from \`/authorize/decide\`.

## Context

Implements \`TASK-1522\` under PLAN-1519. Phase A (TASK-1520) shipped the empty tables; Phase B (TASK-1521) the MCP create/claim actions; this PR seeds the tables from existing data and switches the connected-apps page read path. Phase C2 (TASK-1523, consent screen rewrite) will retire the session.Extra producer side, and the dual-read introspection gate added in Phase A can come out together after a soak period (separate follow-up).

## Test plan

- [x] \`go build ./... && go vet ./... && golangci-lint run\` — clean
- [x] \`go test ./...\` — all green (8 new backfill tests + extract-helper test + updated list-path / handler tests)
- [x] \`cd web && npm run build\` — clean
- [x] Backfill shape matrix: pre-TASK-952 (no key) → all_current=1; wildcard → all_current=1; explicit slugs → all_current=0 + join rows; mixed resolvable / unresolved slugs counted; multi-row chain → newest drives shape; refresh-only chain seeded; idempotent re-run no-ops (verified via post-run row count)
- [x] Read-path: \`AllowedWorkspaces\` projects from new tables; new \`Name\` + flag fields hydrate