### PR TITLE
feat(oauth): connected-apps mutation endpoints + edit UI (TASK-1524)

### DIFF
--- a/internal/server/handlers_connected_apps.go
+++ b/internal/server/handlers_connected_apps.go
@@ -64,20 +64,32 @@ type connectedAppDTO struct {
 	ConnectedAt       string   `json:"connected_at"`
 	LastUsedAt        string   `json:"last_used_at,omitempty"`
 	Calls30d          int      `json:"calls_30d"`
+
+	// PLAN-1519 / TASK-1524 / IDEA-1517 §3: connection-level state
+	// surfaced for the connections-page mutation UI. Read-only on
+	// older clients; new patch handlers below let the page mutate.
+	Name                    string `json:"name"`
+	MayCreateWorkspaces     bool   `json:"may_create_workspaces"`
+	AllCurrentWorkspaces    bool   `json:"all_current_workspaces"`
+	IncludeFutureWorkspaces bool   `json:"include_future_workspaces"`
 }
 
 func connectionToDTO(c models.OAuthConnection, stats *models.MCPConnectionStats) connectedAppDTO {
 	dto := connectedAppDTO{
-		ID:                c.RequestID,
-		ClientID:          c.ClientID,
-		ClientName:        c.ClientName,
-		LogoURI:           c.LogoURL,
-		RedirectURIs:      c.RedirectURIs,
-		AllowedWorkspaces: c.AllowedWorkspaces,
-		ScopeString:       c.GrantedScopes,
-		CapabilityTier:    string(c.CapabilityTier),
-		ConnectedAt:       c.ConnectedAt.UTC().Format(time.RFC3339),
-		Calls30d:          0,
+		ID:                      c.RequestID,
+		ClientID:                c.ClientID,
+		ClientName:              c.ClientName,
+		LogoURI:                 c.LogoURL,
+		RedirectURIs:            c.RedirectURIs,
+		AllowedWorkspaces:       c.AllowedWorkspaces,
+		ScopeString:             c.GrantedScopes,
+		CapabilityTier:          string(c.CapabilityTier),
+		ConnectedAt:             c.ConnectedAt.UTC().Format(time.RFC3339),
+		Calls30d:                0,
+		Name:                    c.Name,
+		MayCreateWorkspaces:     c.MayCreateWorkspaces,
+		AllCurrentWorkspaces:    c.AllCurrentWorkspaces,
+		IncludeFutureWorkspaces: c.IncludeFutureWorkspaces,
 	}
 	if stats != nil {
 		dto.Calls30d = stats.Calls30d
@@ -211,4 +223,309 @@ func (s *Server) handleRevokeConnectedApp(w http.ResponseWriter, r *http.Request
 	}
 
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// Connection mutation endpoints (PLAN-1519 / TASK-1524 / IDEA-1517 §3).
+//
+// All four mutations follow the same shape:
+//
+//   1. Resolve current user from context (RequireAuth in the chain).
+//   2. Verify the connection belongs to that user — same 404
+//      envelope as Revoke for non-owned chains so request_ids
+//      aren't enumerable by 403-vs-404 distinction.
+//   3. Apply the mutation via the dedicated store method.
+//   4. Return the updated DTO so the page can re-render without a
+//      separate list refresh.
+//
+// The mutations are intentionally per-field rather than a single
+// general PATCH: the connections-page UI submits one mutation per
+// user interaction (toggle a flag, edit the name, add a workspace),
+// and field-scoped routes give cleaner error envelopes + audit
+// trails than a sprawling general PATCH.
+
+// connectionOwnedByUser is a helper that returns the connection if
+// it belongs to userID, or (nil, ErrConnectionNotFound) otherwise.
+// All mutation handlers route their ownership check through this so
+// the 404 envelope stays uniform.
+func (s *Server) connectionOwnedByUser(userID, requestID string) (*store.OAuthConnection, error) {
+	conn, err := s.store.GetOAuthConnection(requestID)
+	if err != nil {
+		if errors.Is(err, store.ErrOAuthConnectionNotFound) {
+			return nil, store.ErrConnectionNotFound
+		}
+		return nil, err
+	}
+	if conn.UserID != userID {
+		return nil, store.ErrConnectionNotFound
+	}
+	return conn, nil
+}
+
+// requireConnectionOwner is the per-mutation prologue. Returns the
+// (currentUser, requestID, ok) triple. On `ok=false` the response
+// has already been written.
+func (s *Server) requireConnectionOwner(w http.ResponseWriter, r *http.Request) (*models.User, string, bool) {
+	user := currentUser(r)
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, "unauthorized", "Authentication required.")
+		return nil, "", false
+	}
+	id := strings.TrimSpace(chi.URLParam(r, "id"))
+	if id == "" {
+		writeError(w, http.StatusBadRequest, "invalid_request", "connection id required")
+		return nil, "", false
+	}
+	if _, err := s.connectionOwnedByUser(user.ID, id); err != nil {
+		if errors.Is(err, store.ErrConnectionNotFound) {
+			writeError(w, http.StatusNotFound, "not_found", "Connection not found.")
+			return nil, "", false
+		}
+		writeInternalError(w, err)
+		return nil, "", false
+	}
+	return user, id, true
+}
+
+// respondWithConnection re-fetches + writes the connection DTO post-
+// mutation so the page can re-render without a separate list refresh.
+// Stats lookup is best-effort — failure logs but doesn't fail the
+// response, matching handleListConnectedApps' posture.
+func (s *Server) respondWithConnection(w http.ResponseWriter, userID, requestID string) {
+	conns, err := s.store.ListUserOAuthConnections(userID)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	for _, c := range conns {
+		if c.RequestID != requestID {
+			continue
+		}
+		stats, _ := s.store.MCPConnectionStatsForUser(userID)
+		var statPtr *models.MCPConnectionStats
+		if stats != nil {
+			if v, ok := stats[store.MCPConnectionStatsKey(models.TokenKindOAuth, requestID)]; ok {
+				statPtr = &v
+			}
+		}
+		writeJSON(w, http.StatusOK, connectionToDTO(c, statPtr))
+		return
+	}
+	// ListUserOAuthConnections filters to active chains; an inactive
+	// chain's mutations remain valid but won't appear in the list
+	// (and tests that seed an oauth_connections row directly without
+	// also seeding token rows fall here too). Re-fetch directly from
+	// oauth_connections + the access projection so the post-mutation
+	// DTO carries the right scope-flag + allow-list shape regardless.
+	conn, err := s.store.GetOAuthConnection(requestID)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	access, err := s.store.GetOAuthConnectionAccess(requestID)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	var allowedSlugs []string
+	if !access.AllCurrentWorkspaces {
+		allowedSlugs = access.WorkspaceSlugs
+	}
+	writeJSON(w, http.StatusOK, connectionToDTO(models.OAuthConnection{
+		RequestID:               conn.RequestID,
+		Name:                    conn.Name,
+		MayCreateWorkspaces:     conn.MayCreateWorkspaces,
+		AllCurrentWorkspaces:    conn.AllCurrentWorkspaces,
+		IncludeFutureWorkspaces: conn.IncludeFutureWorkspaces,
+		AllowedWorkspaces:       allowedSlugs,
+	}, nil))
+}
+
+// handleRenameConnectedApp: PATCH /api/v1/connected-apps/{id}/name
+// Body: {"name": "..."} — trimmed + capped at 120 chars (matches the
+// consent-screen suggested-name cap). Empty string is valid (clears
+// the name, the connections-page UI prompts again).
+func (s *Server) handleRenameConnectedApp(w http.ResponseWriter, r *http.Request) {
+	user, id, ok := s.requireConnectionOwner(w, r)
+	if !ok {
+		return
+	}
+	var body struct {
+		Name string `json:"name"`
+	}
+	if err := decodeJSON(r, &body); err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", err.Error())
+		return
+	}
+	name := strings.TrimSpace(body.Name)
+	if len(name) > 120 {
+		name = name[:120]
+	}
+	if err := s.store.RenameConnection(id, name); err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	s.respondWithConnection(w, user.ID, id)
+}
+
+// handleUpdateConnectedAppFlags: PATCH /api/v1/connected-apps/{id}/flags
+// Body: {may_create_workspaces, all_current_workspaces, include_future_workspaces}.
+// All three boolean fields are written atomically by the store.
+//
+// Invariant: a connection with all_current_workspaces=false MUST have
+// at least one workspace in oauth_connection_workspaces — otherwise
+// the user has orphaned the connection (the agent can't see any
+// workspace at all). Validate here and reject the flag toggle with
+// a clear error rather than letting the page silently break.
+func (s *Server) handleUpdateConnectedAppFlags(w http.ResponseWriter, r *http.Request) {
+	user, id, ok := s.requireConnectionOwner(w, r)
+	if !ok {
+		return
+	}
+	var body struct {
+		MayCreateWorkspaces     bool `json:"may_create_workspaces"`
+		AllCurrentWorkspaces    bool `json:"all_current_workspaces"`
+		IncludeFutureWorkspaces bool `json:"include_future_workspaces"`
+	}
+	if err := decodeJSON(r, &body); err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", err.Error())
+		return
+	}
+
+	// Empty-allow-list guard: if the user is switching all_current=off
+	// AND the join table is empty, the connection ends up scoped to no
+	// workspaces. The Phase D UI prevents this at the form level, but
+	// the API enforces it too in case of direct calls. IDEA-1517 §3
+	// Acceptance bullet: "Empty allow-list with all_current_workspaces=0
+	// is disallowed — UI prevents and backend validates."
+	if !body.AllCurrentWorkspaces {
+		access, err := s.store.GetOAuthConnectionAccess(id)
+		if err != nil {
+			writeInternalError(w, err)
+			return
+		}
+		if !access.HasConnection || len(access.WorkspaceSlugs) == 0 {
+			writeError(w, http.StatusBadRequest, "empty_allowlist",
+				"Cannot switch to 'specific workspaces' with no workspaces selected. Add at least one workspace first.")
+			return
+		}
+	}
+
+	if err := s.store.SetScopeFlags(id, body.MayCreateWorkspaces, body.AllCurrentWorkspaces, body.IncludeFutureWorkspaces); err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	s.respondWithConnection(w, user.ID, id)
+}
+
+// handleAddConnectedAppWorkspace: POST /api/v1/connected-apps/{id}/workspaces
+// Body: {"workspace": "slug-or-id"}. Resolves to a workspace_id,
+// verifies the requesting user is a member (defense in depth — they
+// shouldn't be able to add workspaces they don't belong to), inserts
+// with added_by='user'.
+func (s *Server) handleAddConnectedAppWorkspace(w http.ResponseWriter, r *http.Request) {
+	user, id, ok := s.requireConnectionOwner(w, r)
+	if !ok {
+		return
+	}
+	var body struct {
+		Workspace string `json:"workspace"`
+	}
+	if err := decodeJSON(r, &body); err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", err.Error())
+		return
+	}
+	body.Workspace = strings.TrimSpace(body.Workspace)
+	if body.Workspace == "" {
+		writeError(w, http.StatusBadRequest, "bad_request", "workspace slug or id required")
+		return
+	}
+	ws, err := s.store.GetWorkspaceBySlug(body.Workspace)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	if ws == nil {
+		writeError(w, http.StatusNotFound, "not_found", "Workspace not found.")
+		return
+	}
+	// Membership check: the user can only grant their own connection
+	// access to workspaces they themselves can access.
+	member, err := s.store.GetWorkspaceMember(ws.ID, user.ID)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	if member == nil {
+		writeError(w, http.StatusNotFound, "not_found", "Workspace not found.")
+		return
+	}
+	if err := s.store.AddConnectionWorkspace(id, ws.ID, store.AddedByUser); err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	s.respondWithConnection(w, user.ID, id)
+}
+
+// handleRemoveConnectedAppWorkspace: DELETE /api/v1/connected-apps/{id}/workspaces/{slug}
+// Slug-path version (URL-friendlier than a body-payload DELETE).
+//
+// Empty-allow-list guard: if removing this workspace would leave a
+// connection with all_current_workspaces=false AND zero join rows,
+// the connection becomes useless to the agent. Same invariant the
+// flags handler enforces — the page should prevent this at the
+// UI level but the API enforces too.
+func (s *Server) handleRemoveConnectedAppWorkspace(w http.ResponseWriter, r *http.Request) {
+	user, id, ok := s.requireConnectionOwner(w, r)
+	if !ok {
+		return
+	}
+	slug := strings.TrimSpace(chi.URLParam(r, "slug"))
+	if slug == "" {
+		writeError(w, http.StatusBadRequest, "bad_request", "workspace slug required")
+		return
+	}
+	ws, err := s.store.GetWorkspaceBySlug(slug)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	if ws == nil {
+		// Slug not resolvable — treat as a no-op delete (idempotent)
+		// rather than 404. The user's intent was "this slug shouldn't
+		// be in my allow-list," and if it's not resolvable it isn't
+		// there anyway.
+		s.respondWithConnection(w, user.ID, id)
+		return
+	}
+
+	// Pre-check: would this leave the connection with no workspaces?
+	conn, err := s.store.GetOAuthConnection(id)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	if !conn.AllCurrentWorkspaces {
+		access, err := s.store.GetOAuthConnectionAccess(id)
+		if err != nil {
+			writeInternalError(w, err)
+			return
+		}
+		remaining := 0
+		for _, s := range access.WorkspaceSlugs {
+			if s != slug {
+				remaining++
+			}
+		}
+		if remaining == 0 {
+			writeError(w, http.StatusBadRequest, "empty_allowlist",
+				"Removing the last workspace would orphan this connection. Switch to 'All my workspaces' or revoke the connection instead.")
+			return
+		}
+	}
+
+	if err := s.store.RemoveConnectionWorkspace(id, ws.ID); err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	s.respondWithConnection(w, user.ID, id)
 }

--- a/internal/server/handlers_connected_apps.go
+++ b/internal/server/handlers_connected_apps.go
@@ -397,13 +397,20 @@ func (s *Server) handleUpdateConnectedAppFlags(w http.ResponseWriter, r *http.Re
 	// the API enforces it too in case of direct calls. IDEA-1517 §3
 	// Acceptance bullet: "Empty allow-list with all_current_workspaces=0
 	// is disallowed — UI prevents and backend validates."
+	//
+	// Count via ConnectionWorkspaceCount (not GetOAuthConnectionAccess)
+	// — the access projection intentionally short-circuits the join
+	// when the CURRENT row is wildcard, but we need to know the count
+	// regardless of current state so a user pre-staging workspaces in
+	// wildcard mode can subsequently flip the toggle. Codex review
+	// #585 round 1 caught the always-empty-on-wildcard read.
 	if !body.AllCurrentWorkspaces {
-		access, err := s.store.GetOAuthConnectionAccess(id)
+		n, err := s.store.ConnectionWorkspaceCount(id)
 		if err != nil {
 			writeInternalError(w, err)
 			return
 		}
-		if !access.HasConnection || len(access.WorkspaceSlugs) == 0 {
+		if n == 0 {
 			writeError(w, http.StatusBadRequest, "empty_allowlist",
 				"Cannot switch to 'specific workspaces' with no workspaces selected. Add at least one workspace first.")
 			return
@@ -505,21 +512,28 @@ func (s *Server) handleRemoveConnectedAppWorkspace(w http.ResponseWriter, r *htt
 		return
 	}
 	if !conn.AllCurrentWorkspaces {
-		access, err := s.store.GetOAuthConnectionAccess(id)
+		// Need the actual row count (not via the access projection,
+		// which short-circuits on wildcard). Also need to know
+		// whether THIS slug is in the list — removing a slug that
+		// isn't in the list shouldn't trip the guard. Combined:
+		// a removal that would leave zero rows iff the slug IS in
+		// the list AND total count == 1.
+		allowed, err := s.store.IsConnectionWorkspaceAllowed(id, ws.ID)
 		if err != nil {
 			writeInternalError(w, err)
 			return
 		}
-		remaining := 0
-		for _, s := range access.WorkspaceSlugs {
-			if s != slug {
-				remaining++
+		if allowed {
+			n, countErr := s.store.ConnectionWorkspaceCount(id)
+			if countErr != nil {
+				writeInternalError(w, countErr)
+				return
 			}
-		}
-		if remaining == 0 {
-			writeError(w, http.StatusBadRequest, "empty_allowlist",
-				"Removing the last workspace would orphan this connection. Switch to 'All my workspaces' or revoke the connection instead.")
-			return
+			if n <= 1 {
+				writeError(w, http.StatusBadRequest, "empty_allowlist",
+					"Removing the last workspace would orphan this connection. Switch to 'All my workspaces' or revoke the connection instead.")
+				return
+			}
 		}
 	}
 

--- a/internal/server/handlers_connected_apps.go
+++ b/internal/server/handlers_connected_apps.go
@@ -321,14 +321,15 @@ func (s *Server) respondWithConnection(w http.ResponseWriter, userID, requestID 
 		writeInternalError(w, err)
 		return
 	}
-	access, err := s.store.GetOAuthConnectionAccess(requestID)
+	// Always read the staged slugs from the join table — even when
+	// wildcard is on, the UI needs to render pre-staged rows so the
+	// user can remove a mistake before flipping wildcard off. Codex
+	// review #585 round 2 caught the gap where wildcard hid the
+	// staged list, leaving the user no way to manage it.
+	allowedSlugs, err := s.store.ListConnectionWorkspaceSlugs(requestID)
 	if err != nil {
 		writeInternalError(w, err)
 		return
-	}
-	var allowedSlugs []string
-	if !access.AllCurrentWorkspaces {
-		allowedSlugs = access.WorkspaceSlugs
 	}
 	writeJSON(w, http.StatusOK, connectionToDTO(models.OAuthConnection{
 		RequestID:               conn.RequestID,

--- a/internal/server/handlers_connected_apps_mutations_test.go
+++ b/internal/server/handlers_connected_apps_mutations_test.go
@@ -1,0 +1,326 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/store"
+)
+
+// Mutation-endpoint tests for /api/v1/connected-apps/{id}/... routes
+// (PLAN-1519 / TASK-1524 / IDEA-1517 §3).
+//
+// What's covered (per endpoint):
+//
+//   - PATCH /name: happy path; trims + caps; empty string clears.
+//   - PATCH /flags: happy path; empty-allow-list invariant rejects
+//     all_current=false toggle when no join rows exist.
+//   - POST /workspaces: happy path; non-member workspace 404s
+//     (same envelope as not-found so existence isn't leaked).
+//   - DELETE /workspaces/{slug}: happy path; idempotent missing-slug
+//     no-op; empty-allow-list invariant rejects last-workspace
+//     removal when all_current=false.
+//
+// Common shape: every handler 404s on non-owned connections (same
+// envelope as Revoke).
+
+// doAuthedPatch + doAuthedPost helpers for the mutation tests. The
+// existing doAuthedRequest helper is GET-only; for state-changing
+// methods we need to also attach the CSRF header (CSRFProtect runs
+// in the /api/v1 chain on session-cookie auth).
+func doAuthedJSON(srv *Server, method, path string, body any, sessionToken string) *httptest.ResponseRecorder {
+	const testCSRF = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	var bodyReader *strings.Reader
+	if body != nil {
+		b, _ := json.Marshal(body)
+		bodyReader = strings.NewReader(string(b))
+	}
+	var req *http.Request
+	if bodyReader != nil {
+		req = httptest.NewRequest(method, path, bodyReader)
+		req.Header.Set("Content-Type", "application/json")
+	} else {
+		req = httptest.NewRequest(method, path, nil)
+	}
+	req.Header.Set("User-Agent", testSessionUA)
+	req.AddCookie(&http.Cookie{Name: sessionCookieName(srv.secureCookies), Value: sessionToken})
+	req.AddCookie(&http.Cookie{Name: csrfCookieName(srv.secureCookies), Value: testCSRF})
+	req.Header.Set("X-CSRF-Token", testCSRF)
+	req.RemoteAddr = "192.0.2.1:1234"
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	return rr
+}
+
+// seedConnectedAppForMutations creates a user + workspace + an
+// oauth_connections row directly so the mutation handlers have
+// something to mutate. Returns the user + their session token + the
+// connection's request_id + the workspace ID (some tests use it
+// for membership checks).
+func seedConnectedAppForMutations(t *testing.T, srv *Server, requestID string) (*models.User, string, string) {
+	t.Helper()
+	user, tok := loginTestUser(t, srv)
+	// Seed a workspace the user owns + a connection that already
+	// includes that workspace in its allow-list.
+	wsID, _ := mustSeedWorkspaceForMutation(t, srv, user.ID, "mut-ws", "owner")
+	if err := srv.store.CreateOAuthConnection(store.OAuthConnection{
+		RequestID:               requestID,
+		UserID:                  user.ID,
+		Name:                    "Cursor",
+		MayCreateWorkspaces:     true,
+		AllCurrentWorkspaces:    false,
+		IncludeFutureWorkspaces: false,
+	}); err != nil {
+		t.Fatalf("CreateOAuthConnection: %v", err)
+	}
+	if err := srv.store.AddConnectionWorkspace(requestID, wsID, store.AddedByUser); err != nil {
+		t.Fatalf("AddConnectionWorkspace: %v", err)
+	}
+	return user, tok, wsID
+}
+
+func mustSeedWorkspaceForMutation(t *testing.T, srv *Server, ownerID, slug, role string) (string, string) {
+	t.Helper()
+	ws, err := srv.store.CreateWorkspace(models.WorkspaceCreate{
+		Name:    slug,
+		Slug:    slug,
+		OwnerID: ownerID,
+	})
+	if err != nil {
+		t.Fatalf("CreateWorkspace %s: %v", slug, err)
+	}
+	if err := srv.store.AddWorkspaceMember(ws.ID, ownerID, role); err != nil {
+		t.Fatalf("AddWorkspaceMember %s: %v", slug, err)
+	}
+	return ws.ID, ws.Slug
+}
+
+func TestHandleRenameConnectedApp_HappyPath(t *testing.T) {
+	srv, _ := connectedAppsTestServer(t)
+	_, tok, _ := seedConnectedAppForMutations(t, srv, "rename-chain")
+
+	rr := doAuthedJSON(srv, "PATCH", "/api/v1/connected-apps/rename-chain/name",
+		map[string]string{"name": "  Renamed   "}, tok)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body=%s)", rr.Code, rr.Body.String())
+	}
+	var dto connectedAppDTO
+	if err := json.Unmarshal(rr.Body.Bytes(), &dto); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if dto.Name != "Renamed" {
+		t.Errorf("response Name = %q, want %q (whitespace trimmed)", dto.Name, "Renamed")
+	}
+}
+
+func TestHandleRenameConnectedApp_LengthCap(t *testing.T) {
+	srv, _ := connectedAppsTestServer(t)
+	_, tok, _ := seedConnectedAppForMutations(t, srv, "long-name-chain")
+
+	long := strings.Repeat("x", 200)
+	rr := doAuthedJSON(srv, "PATCH", "/api/v1/connected-apps/long-name-chain/name",
+		map[string]string{"name": long}, tok)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	var dto connectedAppDTO
+	_ = json.Unmarshal(rr.Body.Bytes(), &dto)
+	if len(dto.Name) != 120 {
+		t.Errorf("Name length = %d, want 120 (capped)", len(dto.Name))
+	}
+}
+
+func TestHandleRenameConnectedApp_NotOwner404(t *testing.T) {
+	srv, _ := connectedAppsTestServer(t)
+	// Connection belongs to Alice.
+	seedConnectedAppForMutations(t, srv, "alice-chain")
+	// Bob tries to rename Alice's connection.
+	_, bobErr := srv.store.CreateUser(models.UserCreate{
+		Email: "bob-rename@example.com", Name: "Bob", Password: "pw-bob-12345",
+	})
+	if bobErr != nil {
+		t.Fatalf("CreateUser bob: %v", bobErr)
+	}
+	bobUser, bobTok := loginTestUserAs(t, srv, "bob-rename2@example.com", "Bob2", "pw-bob2-12345")
+	_ = bobUser
+
+	rr := doAuthedJSON(srv, "PATCH", "/api/v1/connected-apps/alice-chain/name",
+		map[string]string{"name": "Hijacked"}, bobTok)
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404 (non-owner must look like not-found)", rr.Code)
+	}
+}
+
+func TestHandleUpdateConnectedAppFlags_HappyPath(t *testing.T) {
+	srv, _ := connectedAppsTestServer(t)
+	_, tok, _ := seedConnectedAppForMutations(t, srv, "flags-chain")
+
+	rr := doAuthedJSON(srv, "PATCH", "/api/v1/connected-apps/flags-chain/flags",
+		map[string]bool{
+			"may_create_workspaces":     false,
+			"all_current_workspaces":    true,
+			"include_future_workspaces": true,
+		}, tok)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body=%s)", rr.Code, rr.Body.String())
+	}
+	var dto connectedAppDTO
+	_ = json.Unmarshal(rr.Body.Bytes(), &dto)
+	if dto.MayCreateWorkspaces {
+		t.Errorf("MayCreate = true, want false")
+	}
+	if !dto.AllCurrentWorkspaces {
+		t.Errorf("AllCurrent = false, want true")
+	}
+}
+
+func TestHandleUpdateConnectedAppFlags_EmptyAllowListBlocked(t *testing.T) {
+	srv, _ := connectedAppsTestServer(t)
+	user, tok := loginTestUser(t, srv)
+	// Create a connection with no join rows, all_current=true currently.
+	if err := srv.store.CreateOAuthConnection(store.OAuthConnection{
+		RequestID:            "empty-chain",
+		UserID:               user.ID,
+		Name:                 "Wildcard Connection",
+		AllCurrentWorkspaces: true,
+	}); err != nil {
+		t.Fatalf("CreateOAuthConnection: %v", err)
+	}
+
+	// Toggling all_current=false would orphan the connection (no join
+	// rows exist). API must reject.
+	rr := doAuthedJSON(srv, "PATCH", "/api/v1/connected-apps/empty-chain/flags",
+		map[string]bool{
+			"may_create_workspaces":     true,
+			"all_current_workspaces":    false,
+			"include_future_workspaces": true,
+		}, tok)
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400 (empty_allowlist guard)", rr.Code)
+	}
+	if !strings.Contains(rr.Body.String(), "empty_allowlist") {
+		t.Errorf("body should contain empty_allowlist error code; got %s", rr.Body.String())
+	}
+}
+
+func TestHandleAddConnectedAppWorkspace_HappyPath(t *testing.T) {
+	srv, _ := connectedAppsTestServer(t)
+	user, tok, _ := seedConnectedAppForMutations(t, srv, "add-ws-chain")
+	// Seed a second workspace the user owns so we have something to add.
+	_, slug2 := mustSeedWorkspaceForMutation(t, srv, user.ID, "second-ws", "editor")
+
+	rr := doAuthedJSON(srv, "POST", "/api/v1/connected-apps/add-ws-chain/workspaces",
+		map[string]string{"workspace": slug2}, tok)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body=%s)", rr.Code, rr.Body.String())
+	}
+	var dto connectedAppDTO
+	_ = json.Unmarshal(rr.Body.Bytes(), &dto)
+	hasSecond := false
+	for _, slug := range dto.AllowedWorkspaces {
+		if slug == slug2 {
+			hasSecond = true
+		}
+	}
+	if !hasSecond {
+		t.Errorf("AllowedWorkspaces should contain %q after add; got %v", slug2, dto.AllowedWorkspaces)
+	}
+}
+
+func TestHandleAddConnectedAppWorkspace_NonMember404(t *testing.T) {
+	srv, _ := connectedAppsTestServer(t)
+	user, tok, _ := seedConnectedAppForMutations(t, srv, "add-nonmember-chain")
+	// Other user owns a workspace our test user isn't a member of.
+	other, err := srv.store.CreateUser(models.UserCreate{
+		Email: "other-ws@example.com", Name: "Other", Password: "pw-other-12345",
+	})
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	_, otherSlug := mustSeedWorkspaceForMutation(t, srv, other.ID, "other-ws", "owner")
+
+	// Confirm test user is not a member of otherSlug.
+	if member, _ := srv.store.GetWorkspaceMember(other.ID, user.ID); member != nil {
+		t.Fatalf("setup: test user should NOT be member of other-ws")
+	}
+
+	rr := doAuthedJSON(srv, "POST", "/api/v1/connected-apps/add-nonmember-chain/workspaces",
+		map[string]string{"workspace": otherSlug}, tok)
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404 (non-member must look like not-found)", rr.Code)
+	}
+}
+
+func TestHandleRemoveConnectedAppWorkspace_HappyPath(t *testing.T) {
+	srv, _ := connectedAppsTestServer(t)
+	user, tok, _ := seedConnectedAppForMutations(t, srv, "rm-ws-chain")
+	// Add a second workspace so removing the first doesn't trip the
+	// empty-allow-list guard.
+	_, slug2 := mustSeedWorkspaceForMutation(t, srv, user.ID, "rm-second-ws", "editor")
+	if rr := doAuthedJSON(srv, "POST", "/api/v1/connected-apps/rm-ws-chain/workspaces",
+		map[string]string{"workspace": slug2}, tok); rr.Code != http.StatusOK {
+		t.Fatalf("setup add: status = %d (body=%s)", rr.Code, rr.Body.String())
+	}
+
+	rr := doAuthedJSON(srv, "DELETE", "/api/v1/connected-apps/rm-ws-chain/workspaces/"+slug2, nil, tok)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body=%s)", rr.Code, rr.Body.String())
+	}
+	var dto connectedAppDTO
+	_ = json.Unmarshal(rr.Body.Bytes(), &dto)
+	for _, slug := range dto.AllowedWorkspaces {
+		if slug == slug2 {
+			t.Errorf("workspace %q should be gone from allow-list; got %v", slug2, dto.AllowedWorkspaces)
+		}
+	}
+}
+
+func TestHandleRemoveConnectedAppWorkspace_LastBlocked(t *testing.T) {
+	srv, _ := connectedAppsTestServer(t)
+	_, tok, _ := seedConnectedAppForMutations(t, srv, "rm-last-chain")
+	// Connection has all_current=false + exactly one workspace.
+	// Removing it would orphan the connection — API must reject.
+	rr := doAuthedJSON(srv, "DELETE", "/api/v1/connected-apps/rm-last-chain/workspaces/mut-ws", nil, tok)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 (empty_allowlist guard)", rr.Code)
+	}
+	if !strings.Contains(rr.Body.String(), "empty_allowlist") {
+		t.Errorf("body should mention empty_allowlist; got %s", rr.Body.String())
+	}
+}
+
+func TestHandleRemoveConnectedAppWorkspace_IdempotentMissing(t *testing.T) {
+	srv, _ := connectedAppsTestServer(t)
+	_, tok, _ := seedConnectedAppForMutations(t, srv, "rm-idem-chain")
+
+	// Removing a slug that's not in the allow-list (and may not even
+	// exist as a workspace) is a no-op — returns 200 with the
+	// unchanged DTO rather than 404. The user's intent ("this slug
+	// shouldn't be in my list") is satisfied either way.
+	rr := doAuthedJSON(srv, "DELETE", "/api/v1/connected-apps/rm-idem-chain/workspaces/never-existed", nil, tok)
+	if rr.Code != http.StatusOK {
+		t.Errorf("idempotent missing-slug delete = %d, want 200 (body=%s)", rr.Code, rr.Body.String())
+	}
+}
+
+// loginTestUserAs is a variant of loginTestUser that takes explicit
+// email/name/password so multiple distinct users can coexist within
+// one test (loginTestUser hardcodes a single email).
+func loginTestUserAs(t *testing.T, srv *Server, email, name, password string) (*models.User, string) {
+	t.Helper()
+	user, err := srv.store.CreateUser(models.UserCreate{
+		Email: email, Name: name, Password: password,
+	})
+	if err != nil {
+		t.Fatalf("CreateUser %s: %v", email, err)
+	}
+	tok, err := srv.store.CreateSession(user.ID, "test", "192.0.2.1", testSessionUA, webSessionTTL)
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	return user, tok
+}

--- a/internal/server/handlers_connected_apps_mutations_test.go
+++ b/internal/server/handlers_connected_apps_mutations_test.go
@@ -207,6 +207,53 @@ func TestHandleUpdateConnectedAppFlags_EmptyAllowListBlocked(t *testing.T) {
 	}
 }
 
+// TestHandleUpdateConnectedAppFlags_WildcardToSpecific_AfterPrestage is
+// the regression guard for Codex review #585 round 1: a wildcard
+// connection must be able to flip to "specific workspaces" after
+// the user has pre-staged at least one workspace via the add-
+// workspace endpoint. The pre-fix code path called
+// GetOAuthConnectionAccess, which short-circuits on wildcard and
+// reports zero slugs, making the toggle impossible regardless of
+// pre-staging.
+func TestHandleUpdateConnectedAppFlags_WildcardToSpecific_AfterPrestage(t *testing.T) {
+	srv, _ := connectedAppsTestServer(t)
+	user, tok := loginTestUser(t, srv)
+	// Wildcard connection — no join rows yet.
+	if err := srv.store.CreateOAuthConnection(store.OAuthConnection{
+		RequestID:            "prestage-chain",
+		UserID:               user.ID,
+		AllCurrentWorkspaces: true,
+	}); err != nil {
+		t.Fatalf("CreateOAuthConnection: %v", err)
+	}
+	// Seed a workspace the user owns.
+	_, slug := mustSeedWorkspaceForMutation(t, srv, user.ID, "prestage-ws", "owner")
+	// Add it to the connection (allowed even while wildcard is on —
+	// it's inert until the flag flips).
+	if rr := doAuthedJSON(srv, "POST", "/api/v1/connected-apps/prestage-chain/workspaces",
+		map[string]string{"workspace": slug}, tok); rr.Code != http.StatusOK {
+		t.Fatalf("pre-stage add: status = %d (body=%s)", rr.Code, rr.Body.String())
+	}
+	// Now flip wildcard off — must succeed since the join table has 1 row.
+	rr := doAuthedJSON(srv, "PATCH", "/api/v1/connected-apps/prestage-chain/flags",
+		map[string]bool{
+			"may_create_workspaces":     true,
+			"all_current_workspaces":    false,
+			"include_future_workspaces": true,
+		}, tok)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("post-prestage flag flip should succeed; status = %d (body=%s)", rr.Code, rr.Body.String())
+	}
+	var dto connectedAppDTO
+	_ = json.Unmarshal(rr.Body.Bytes(), &dto)
+	if dto.AllCurrentWorkspaces {
+		t.Errorf("AllCurrentWorkspaces should be false post-flip; got true")
+	}
+	if len(dto.AllowedWorkspaces) != 1 || dto.AllowedWorkspaces[0] != slug {
+		t.Errorf("AllowedWorkspaces should reflect the pre-staged slug; got %v", dto.AllowedWorkspaces)
+	}
+}
+
 func TestHandleAddConnectedAppWorkspace_HappyPath(t *testing.T) {
 	srv, _ := connectedAppsTestServer(t)
 	user, tok, _ := seedConnectedAppForMutations(t, srv, "add-ws-chain")

--- a/internal/server/handlers_connected_apps_mutations_test.go
+++ b/internal/server/handlers_connected_apps_mutations_test.go
@@ -254,6 +254,48 @@ func TestHandleUpdateConnectedAppFlags_WildcardToSpecific_AfterPrestage(t *testi
 	}
 }
 
+// TestHandleAddConnectedAppWorkspace_VisibleUnderWildcard is the
+// regression guard for Codex review #585 round 2: pre-staging a
+// workspace while wildcard is on must surface that workspace in
+// the response DTO's allowed_workspaces array, so the UI can render
+// the chip + offer a remove button. Pre-fix the DTO suppressed
+// staged slugs under wildcard, leaving them invisible until the
+// user flipped wildcard off.
+func TestHandleAddConnectedAppWorkspace_VisibleUnderWildcard(t *testing.T) {
+	srv, _ := connectedAppsTestServer(t)
+	user, tok := loginTestUser(t, srv)
+	// Wildcard connection.
+	if err := srv.store.CreateOAuthConnection(store.OAuthConnection{
+		RequestID:            "stage-wildcard-chain",
+		UserID:               user.ID,
+		AllCurrentWorkspaces: true,
+	}); err != nil {
+		t.Fatalf("CreateOAuthConnection: %v", err)
+	}
+	_, slug := mustSeedWorkspaceForMutation(t, srv, user.ID, "stage-wildcard-ws", "owner")
+
+	rr := doAuthedJSON(srv, "POST", "/api/v1/connected-apps/stage-wildcard-chain/workspaces",
+		map[string]string{"workspace": slug}, tok)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d (body=%s)", rr.Code, rr.Body.String())
+	}
+	var dto connectedAppDTO
+	_ = json.Unmarshal(rr.Body.Bytes(), &dto)
+	if !dto.AllCurrentWorkspaces {
+		t.Errorf("AllCurrentWorkspaces flipped from true; should remain true (staged != active)")
+	}
+	found := false
+	for _, s := range dto.AllowedWorkspaces {
+		if s == slug {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("staged workspace %q should appear in DTO.AllowedWorkspaces even under wildcard; got %v", slug, dto.AllowedWorkspaces)
+	}
+}
+
 func TestHandleAddConnectedAppWorkspace_HappyPath(t *testing.T) {
 	srv, _ := connectedAppsTestServer(t)
 	user, tok, _ := seedConnectedAppForMutations(t, srv, "add-ws-chain")

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -939,6 +939,14 @@ func (s *Server) setupRouter() {
 				r.Use(s.requireCloudMode)
 				r.Get("/connected-apps", s.handleListConnectedApps)
 				r.Delete("/connected-apps/{id}", s.handleRevokeConnectedApp)
+				// PLAN-1519 / TASK-1524 / IDEA-1517 §3: mutation
+				// endpoints for the connections-page UI. Per-field
+				// patches rather than a general PATCH for cleaner
+				// error envelopes + audit shape.
+				r.Patch("/connected-apps/{id}/name", s.handleRenameConnectedApp)
+				r.Patch("/connected-apps/{id}/flags", s.handleUpdateConnectedAppFlags)
+				r.Post("/connected-apps/{id}/workspaces", s.handleAddConnectedAppWorkspace)
+				r.Delete("/connected-apps/{id}/workspaces/{slug}", s.handleRemoveConnectedAppWorkspace)
 			})
 
 			// Templates

--- a/internal/store/connected_apps.go
+++ b/internal/store/connected_apps.go
@@ -200,11 +200,28 @@ func (s *Store) ListUserOAuthConnections(userID string) ([]models.OAuthConnectio
 			return nil, fmt.Errorf("hydrate connection access %s: %w", reqID, accessErr)
 		}
 		if access.HasConnection {
+			conn.AllCurrentWorkspaces = access.AllCurrentWorkspaces
+			// Pre-Codex-#585-round-2 the wildcard case set
+			// AllowedWorkspaces to nil because the slugs were
+			// "irrelevant" (wildcard covers everything). But Phase D's
+			// mutation UI lets users PRE-STAGE workspaces while
+			// wildcard is on, so the join table can hold rows that
+			// the UI needs to render even when the flag is on. Always
+			// populate from the join table; the UI uses the flag (not
+			// the slug list emptiness) to decide whether to render
+			// the "Any workspace" badge. GetOAuthConnectionAccess
+			// itself still short-circuits on wildcard for the hot
+			// path; this read uses a direct lookup below so we get
+			// the staged rows regardless.
 			if access.AllCurrentWorkspaces {
-				conn.AllCurrentWorkspaces = true
-				conn.AllowedWorkspaces = nil
+				// Direct join-table read — bypasses the access
+				// projection's wildcard short-circuit.
+				slugs, slugErr := s.ListConnectionWorkspaceSlugs(reqID)
+				if slugErr != nil {
+					return nil, fmt.Errorf("list staged workspaces %s: %w", reqID, slugErr)
+				}
+				conn.AllowedWorkspaces = slugs
 			} else {
-				conn.AllCurrentWorkspaces = false
 				conn.AllowedWorkspaces = access.WorkspaceSlugs
 			}
 			// Pull the rest of the connection metadata (name + the

--- a/internal/store/oauth_connections.go
+++ b/internal/store/oauth_connections.go
@@ -345,6 +345,40 @@ func (s *Store) RemoveConnectionWorkspace(requestID, workspaceID string) error {
 	return nil
 }
 
+// ConnectionWorkspaceCount returns the raw row count from
+// oauth_connection_workspaces for a given request_id — regardless of
+// the parent connection's all_current_workspaces flag.
+//
+// Why a separate method when GetOAuthConnectionAccess already exists:
+// GetOAuthConnectionAccess intentionally short-circuits when
+// all_current_workspaces=true and returns an empty WorkspaceSlugs
+// list (the wildcard skips the join). That's correct for the
+// introspection hot path — when wildcard is on, slugs are irrelevant
+// — but the connections-page mutation UI needs to know whether the
+// join table actually has rows so a wildcard→specific toggle can
+// verify the user has pre-staged at least one workspace. Codex
+// review #585 round 1 caught the bug where the flags handler called
+// GetOAuthConnectionAccess on a wildcard connection and always saw
+// zero slugs, making the toggle impossible.
+//
+// Returns (count, nil) for any connection state; (0, err) on I/O
+// failure. Zero requestID returns (0, nil) — same defensive shape
+// as the other request_id-keyed helpers.
+func (s *Store) ConnectionWorkspaceCount(requestID string) (int, error) {
+	if requestID == "" {
+		return 0, nil
+	}
+	var n int
+	err := s.db.QueryRow(s.q(`
+        SELECT COUNT(*) FROM oauth_connection_workspaces
+         WHERE request_id = ?
+    `), requestID).Scan(&n)
+	if err != nil {
+		return 0, fmt.Errorf("oauth_connections: count workspaces: %w", err)
+	}
+	return n, nil
+}
+
 // IsConnectionWorkspaceAllowed reports whether workspace_id appears in
 // the connection's allow-list. Used internally by GetOAuthConnectionAccess
 // when callers want a single-pair check rather than the slug projection

--- a/internal/store/oauth_connections.go
+++ b/internal/store/oauth_connections.go
@@ -379,6 +379,45 @@ func (s *Store) ConnectionWorkspaceCount(requestID string) (int, error) {
 	return n, nil
 }
 
+// ListConnectionWorkspaceSlugs returns the join table's slug list
+// for requestID, regardless of the parent connection's wildcard
+// flag. Companion to ConnectionWorkspaceCount — same rationale
+// (the connections-page UI needs to render pre-staged workspaces
+// while wildcard is on; GetOAuthConnectionAccess's hot-path
+// short-circuit hides them). Sorted lexicographically so the UI
+// renders chips in a stable order across calls.
+//
+// Unexported because the only consumer is ListUserOAuthConnections
+// in connected_apps.go; if other paths ever need it, hoist to an
+// exported method.
+func (s *Store) ListConnectionWorkspaceSlugs(requestID string) ([]string, error) {
+	rows, err := s.db.Query(s.q(`
+        SELECT w.slug
+          FROM oauth_connection_workspaces cw
+          JOIN workspaces w ON w.id = cw.workspace_id
+         WHERE cw.request_id = ?
+    `), requestID)
+	if err != nil {
+		return nil, fmt.Errorf("oauth_connections: list workspace slugs: %w", err)
+	}
+	defer rows.Close()
+	out := make([]string, 0, 4)
+	for rows.Next() {
+		var slug string
+		if err := rows.Scan(&slug); err != nil {
+			return nil, fmt.Errorf("oauth_connections: scan slug: %w", err)
+		}
+		if slug != "" {
+			out = append(out, slug)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("oauth_connections: rows: %w", err)
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
 // IsConnectionWorkspaceAllowed reports whether workspace_id appears in
 // the connection's allow-list. Used internally by GetOAuthConnectionAccess
 // when callers want a single-pair check rather than the slug projection

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -1350,7 +1350,38 @@ export const api = {
 	connectedApps: {
 		list: () => request<{ items: ConnectedApp[] }>('/connected-apps'),
 		revoke: (id: string) =>
-			request<void>(`/connected-apps/${encodeURIComponent(id)}`, { method: 'DELETE' })
+			request<void>(`/connected-apps/${encodeURIComponent(id)}`, { method: 'DELETE' }),
+
+		// PLAN-1519 / TASK-1524 / IDEA-1517 §3: per-connection mutations.
+		// Each method returns the updated ConnectedApp DTO so callers
+		// can re-render without a separate list refresh.
+		rename: (id: string, name: string) =>
+			request<ConnectedApp>(`/connected-apps/${encodeURIComponent(id)}/name`, {
+				method: 'PATCH',
+				body: JSON.stringify({ name })
+			}),
+		updateFlags: (
+			id: string,
+			flags: {
+				may_create_workspaces: boolean;
+				all_current_workspaces: boolean;
+				include_future_workspaces: boolean;
+			}
+		) =>
+			request<ConnectedApp>(`/connected-apps/${encodeURIComponent(id)}/flags`, {
+				method: 'PATCH',
+				body: JSON.stringify(flags)
+			}),
+		addWorkspace: (id: string, workspaceSlug: string) =>
+			request<ConnectedApp>(`/connected-apps/${encodeURIComponent(id)}/workspaces`, {
+				method: 'POST',
+				body: JSON.stringify({ workspace: workspaceSlug })
+			}),
+		removeWorkspace: (id: string, workspaceSlug: string) =>
+			request<ConnectedApp>(
+				`/connected-apps/${encodeURIComponent(id)}/workspaces/${encodeURIComponent(workspaceSlug)}`,
+				{ method: 'DELETE' }
+			)
 	},
 
 	// ── URL Import ───────────────────────────────────────────────────────────

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -1060,6 +1060,15 @@ export interface ConnectedApp {
 	connected_at: string;
 	last_used_at?: string;
 	calls_30d: number;
+
+	// PLAN-1519 / TASK-1524 / IDEA-1517 §3: connection-level state
+	// surfaced for the mutation UI. `name` empty until the user names
+	// the connection (backfilled rows start blank); the three scope
+	// flags default ON for backfilled connections + new-grant defaults.
+	name?: string;
+	may_create_workspaces?: boolean;
+	all_current_workspaces?: boolean;
+	include_future_workspaces?: boolean;
 }
 
 // ─── Helper functions ────────────────────────────────────────────────────────

--- a/web/src/routes/console/connected-apps/+page.svelte
+++ b/web/src/routes/console/connected-apps/+page.svelte
@@ -498,58 +498,76 @@
 								</label>
 							</div>
 
-							{#if !isAll}
-								<div class="edit-field">
+							<!-- Workspace allow-list editor (TASK-1524 / Codex review
+								 #585 round 1): always rendered so users in wildcard
+								 mode can pre-stage workspaces before flipping
+								 all_current_workspaces=off. The backend's
+								 empty_allowlist guard rejects the toggle when the
+								 join table is empty; pre-staging in wildcard mode
+								 is the mechanism that lets a user transition
+								 through that state cleanly. -->
+							<div class="edit-field">
+								<div class="edit-label-row">
 									<span class="edit-label">Workspace allow-list</span>
-									<div class="ws-chips">
-										{#each eaWsList as ws (ws)}
-											<span class="chip">
-												{ws}
-												<button
-													type="button"
-													class="chip-remove"
-													aria-label="Remove {ws}"
-													disabled={!!savingFlag[app.id] || eaWsList.length <= 1}
-													onclick={() => removeWorkspaceFromApp(app, ws)}
-												>
-													×
-												</button>
-											</span>
-										{/each}
-										{#if eaWsList.length === 0}
-											<span class="ws-empty">No workspaces — add one below.</span>
-										{/if}
-									</div>
-									{#if eaWsList.length <= 1}
-										<p class="edit-hint">
-											You can't remove the last workspace — switch to "Cover all my current
-											workspaces" first or revoke the connection.
-										</p>
-									{/if}
-									<div class="edit-row add-row">
-										<select
-											class="edit-input"
-											bind:value={addPickerSlug[app.id]}
-											disabled={!!savingFlag[app.id]}
-										>
-											<option value="">Add a workspace…</option>
-											{#each pickable as ws (ws.slug)}
-												<option value={ws.slug}>{ws.name}</option>
-											{/each}
-										</select>
-										<button
-											class="btn"
-											onclick={() => addWorkspaceToApp(app)}
-											disabled={!!savingFlag[app.id] || !addPickerSlug[app.id]}
-										>
-											Add
-										</button>
-									</div>
-									{#if workspacesError}
-										<p class="edit-hint edit-hint-error">{workspacesError}</p>
+									{#if isAll}
+										<span class="edit-badge">Inert while wildcard is on</span>
 									{/if}
 								</div>
-							{/if}
+								<div class="ws-chips">
+									{#each eaWsList as ws (ws)}
+										<span class="chip">
+											{ws}
+											<button
+												type="button"
+												class="chip-remove"
+												aria-label="Remove {ws}"
+												disabled={!!savingFlag[app.id] || (!isAll && eaWsList.length <= 1)}
+												onclick={() => removeWorkspaceFromApp(app, ws)}
+											>
+												×
+											</button>
+										</span>
+									{/each}
+									{#if eaWsList.length === 0}
+										<span class="ws-empty">
+											{#if isAll}
+												No workspaces staged — add one if you plan to switch off
+												"Cover all my current workspaces".
+											{:else}
+												No workspaces — add one below.
+											{/if}
+										</span>
+									{/if}
+								</div>
+								{#if !isAll && eaWsList.length <= 1}
+									<p class="edit-hint">
+										You can't remove the last workspace — switch to "Cover all my current
+										workspaces" first or revoke the connection.
+									</p>
+								{/if}
+								<div class="edit-row add-row">
+									<select
+										class="edit-input"
+										bind:value={addPickerSlug[app.id]}
+										disabled={!!savingFlag[app.id]}
+									>
+										<option value="">Add a workspace…</option>
+										{#each pickable as ws (ws.slug)}
+											<option value={ws.slug}>{ws.name}</option>
+										{/each}
+									</select>
+									<button
+										class="btn"
+										onclick={() => addWorkspaceToApp(app)}
+										disabled={!!savingFlag[app.id] || !addPickerSlug[app.id]}
+									>
+										Add
+									</button>
+								</div>
+								{#if workspacesError}
+									<p class="edit-hint edit-hint-error">{workspacesError}</p>
+								{/if}
+							</div>
 						</div>
 					{/if}
 				</article>
@@ -997,6 +1015,22 @@
 		font-weight: 600;
 		font-size: 0.85rem;
 		color: var(--text-secondary, #555);
+	}
+
+	.edit-label-row {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		flex-wrap: wrap;
+	}
+
+	.edit-badge {
+		font-size: 0.75rem;
+		padding: 0.15rem 0.5rem;
+		border-radius: 4px;
+		background: var(--bg-muted, #f0f0f0);
+		color: var(--text-tertiary, #666);
+		font-weight: normal;
 	}
 
 	.edit-row {

--- a/web/src/routes/console/connected-apps/+page.svelte
+++ b/web/src/routes/console/connected-apps/+page.svelte
@@ -186,7 +186,19 @@
 		return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
 	}
 
-	function isAnyWorkspace(ws: string[] | null | undefined): boolean {
+	// Returns true iff the user should see the "Any workspace" badge
+	// in the card's summary view. Post-Codex-#585-round-2 the wire
+	// shape sends BOTH the wildcard flag AND the staged slug list,
+	// so the badge is driven by the flag (the slug list may carry
+	// pre-staged rows that are inert until the user flips the flag).
+	// Legacy fallback for older wire shapes (no all_current flag,
+	// nil/empty list, ["*"] sentinel) preserved so a stale frontend
+	// against a fresh backend doesn't lose the badge.
+	function isAnyWorkspace(app: ConnectedApp): boolean {
+		if (app.all_current_workspaces === true) return true;
+		if (app.all_current_workspaces === false) return false;
+		// Older wire shape: infer from the slug list.
+		const ws = app.allowed_workspaces;
 		if (ws == null) return true;
 		if (ws.length === 0) return true;
 		if (ws.length === 1 && ws[0] === '*') return true;
@@ -294,7 +306,7 @@
 	{:else}
 		<div class="apps-list">
 			{#each apps as app (app.id)}
-				{@const anyWs = isAnyWorkspace(app.allowed_workspaces)}
+				{@const anyWs = isAnyWorkspace(app)}
 				{@const wsList = anyWs ? [] : (app.allowed_workspaces ?? [])}
 				{@const showAllChips = chipsExpanded[app.id]}
 				{@const visibleChips = showAllChips ? wsList : wsList.slice(0, 3)}

--- a/web/src/routes/console/connected-apps/+page.svelte
+++ b/web/src/routes/console/connected-apps/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { api } from '$lib/api/client';
-	import type { ConnectedApp } from '$lib/types';
+	import type { ConnectedApp, Workspace } from '$lib/types';
 
 	// Connected Apps page (TASK-954). Lists every active OAuth grant
 	// chain the user has authorized via the MCP API and lets them
@@ -20,6 +20,128 @@
 	let confirmTarget = $state<ConnectedApp | null>(null);
 	let revoking = $state(false);
 	let revokeError = $state('');
+
+	// PLAN-1519 / TASK-1524 / IDEA-1517 §3: per-card edit panel state.
+	// editingId tracks which card has its panel open (one at a time);
+	// the per-app errors / pending flags hang off the id so multiple
+	// concurrent mutations across cards don't cross-talk.
+	let editingId = $state<string | null>(null);
+	let nameDrafts = $state<Record<string, string>>({});
+	let editErrors = $state<Record<string, string>>({});
+	let savingFlag = $state<Record<string, boolean>>({});
+	let userWorkspaces = $state<Workspace[] | null>(null);
+	let workspacesError = $state('');
+	let addPickerSlug = $state<Record<string, string>>({});
+
+	async function loadWorkspaces() {
+		if (userWorkspaces !== null) return;
+		try {
+			const list = await api.workspaces.list();
+			userWorkspaces = Array.isArray(list) ? list : [];
+		} catch (e) {
+			workspacesError = e instanceof Error ? e.message : 'Failed to load workspaces';
+			userWorkspaces = [];
+		}
+	}
+
+	function openEdit(app: ConnectedApp) {
+		editingId = app.id;
+		nameDrafts[app.id] = app.name ?? '';
+		editErrors[app.id] = '';
+		addPickerSlug[app.id] = '';
+		loadWorkspaces();
+	}
+
+	function closeEdit() {
+		editingId = null;
+	}
+
+	function setError(id: string, message: string) {
+		editErrors = { ...editErrors, [id]: message };
+	}
+
+	function clearError(id: string) {
+		if (editErrors[id]) setError(id, '');
+	}
+
+	function replaceApp(updated: ConnectedApp) {
+		apps = apps.map((a) => (a.id === updated.id ? { ...a, ...updated } : a));
+	}
+
+	async function saveName(app: ConnectedApp) {
+		const draft = (nameDrafts[app.id] ?? '').trim();
+		if (draft === (app.name ?? '')) return; // no-op
+		savingFlag[app.id] = true;
+		clearError(app.id);
+		try {
+			const updated = await api.connectedApps.rename(app.id, draft);
+			replaceApp(updated);
+		} catch (e) {
+			setError(app.id, e instanceof Error ? e.message : 'Failed to rename');
+		} finally {
+			savingFlag[app.id] = false;
+		}
+	}
+
+	async function toggleFlag(
+		app: ConnectedApp,
+		key: 'may_create_workspaces' | 'all_current_workspaces' | 'include_future_workspaces',
+		next: boolean
+	) {
+		savingFlag[app.id] = true;
+		clearError(app.id);
+		const flags = {
+			may_create_workspaces: app.may_create_workspaces ?? true,
+			all_current_workspaces: app.all_current_workspaces ?? true,
+			include_future_workspaces: app.include_future_workspaces ?? true,
+			[key]: next
+		};
+		try {
+			const updated = await api.connectedApps.updateFlags(app.id, flags);
+			replaceApp(updated);
+		} catch (e) {
+			setError(app.id, e instanceof Error ? e.message : 'Failed to update flags');
+		} finally {
+			savingFlag[app.id] = false;
+		}
+	}
+
+	async function addWorkspaceToApp(app: ConnectedApp) {
+		const slug = (addPickerSlug[app.id] ?? '').trim();
+		if (!slug) return;
+		savingFlag[app.id] = true;
+		clearError(app.id);
+		try {
+			const updated = await api.connectedApps.addWorkspace(app.id, slug);
+			replaceApp(updated);
+			addPickerSlug[app.id] = '';
+		} catch (e) {
+			setError(app.id, e instanceof Error ? e.message : 'Failed to add workspace');
+		} finally {
+			savingFlag[app.id] = false;
+		}
+	}
+
+	async function removeWorkspaceFromApp(app: ConnectedApp, slug: string) {
+		savingFlag[app.id] = true;
+		clearError(app.id);
+		try {
+			const updated = await api.connectedApps.removeWorkspace(app.id, slug);
+			replaceApp(updated);
+		} catch (e) {
+			setError(app.id, e instanceof Error ? e.message : 'Failed to remove workspace');
+		} finally {
+			savingFlag[app.id] = false;
+		}
+	}
+
+	// Available workspaces to add: any membership the user has that
+	// isn't already in this connection's allow-list.
+	function pickableFor(app: ConnectedApp): Workspace[] {
+		if (!userWorkspaces) return [];
+		const inList = new Set((app.allowed_workspaces ?? []).filter((s) => s !== '*'));
+		return userWorkspaces.filter((ws) => !inList.has(ws.slug));
+	}
 
 	const TIER_LABELS: Record<ConnectedApp['capability_tier'], string> = {
 		read_only: 'Read only',
@@ -283,8 +405,153 @@
 					</div>
 
 					<div class="app-actions">
+						<button
+							class="btn"
+							onclick={() => (editingId === app.id ? closeEdit() : openEdit(app))}
+							aria-expanded={editingId === app.id}
+						>
+							{editingId === app.id ? 'Done' : 'Edit'}
+						</button>
 						<button class="btn btn-danger" onclick={() => openConfirm(app)}>Revoke</button>
 					</div>
+
+					{#if editingId === app.id}
+						{@const eaWsList = (app.allowed_workspaces ?? []).filter((s) => s !== '*')}
+						{@const pickable = pickableFor(app)}
+						{@const isAll = app.all_current_workspaces ?? true}
+						<div class="edit-panel" role="region" aria-label="Edit {app.client_name}">
+							{#if editErrors[app.id]}
+								<p class="edit-error">{editErrors[app.id]}</p>
+							{/if}
+
+							<div class="edit-field">
+								<label class="edit-label" for="name-{app.id}">Connection name</label>
+								<div class="edit-row">
+									<input
+										id="name-{app.id}"
+										class="edit-input"
+										type="text"
+										maxlength="120"
+										placeholder="e.g. Cursor on MacBook"
+										bind:value={nameDrafts[app.id]}
+										disabled={!!savingFlag[app.id]}
+									/>
+									<button
+										class="btn"
+										onclick={() => saveName(app)}
+										disabled={!!savingFlag[app.id] ||
+											(nameDrafts[app.id] ?? '').trim() === (app.name ?? '')}
+									>
+										Save
+									</button>
+								</div>
+								{#if !(app.name ?? '')}
+									<p class="edit-hint">
+										Name your connection so you can tell it apart from other apps.
+									</p>
+								{/if}
+							</div>
+
+							<div class="edit-field">
+								<span class="edit-label">Scope flags</span>
+								<label class="edit-toggle">
+									<input
+										type="checkbox"
+										checked={app.may_create_workspaces ?? true}
+										disabled={!!savingFlag[app.id]}
+										onchange={(e) =>
+											toggleFlag(
+												app,
+												'may_create_workspaces',
+												(e.currentTarget as HTMLInputElement).checked
+											)}
+									/>
+									<span>Let this app create new workspaces</span>
+								</label>
+								<label class="edit-toggle">
+									<input
+										type="checkbox"
+										checked={app.all_current_workspaces ?? true}
+										disabled={!!savingFlag[app.id]}
+										onchange={(e) =>
+											toggleFlag(
+												app,
+												'all_current_workspaces',
+												(e.currentTarget as HTMLInputElement).checked
+											)}
+									/>
+									<span>Cover all my current workspaces (wildcard)</span>
+								</label>
+								<label class="edit-toggle">
+									<input
+										type="checkbox"
+										checked={app.include_future_workspaces ?? true}
+										disabled={!!savingFlag[app.id]}
+										onchange={(e) =>
+											toggleFlag(
+												app,
+												'include_future_workspaces',
+												(e.currentTarget as HTMLInputElement).checked
+											)}
+									/>
+									<span>Auto-add new workspaces I create</span>
+								</label>
+							</div>
+
+							{#if !isAll}
+								<div class="edit-field">
+									<span class="edit-label">Workspace allow-list</span>
+									<div class="ws-chips">
+										{#each eaWsList as ws (ws)}
+											<span class="chip">
+												{ws}
+												<button
+													type="button"
+													class="chip-remove"
+													aria-label="Remove {ws}"
+													disabled={!!savingFlag[app.id] || eaWsList.length <= 1}
+													onclick={() => removeWorkspaceFromApp(app, ws)}
+												>
+													×
+												</button>
+											</span>
+										{/each}
+										{#if eaWsList.length === 0}
+											<span class="ws-empty">No workspaces — add one below.</span>
+										{/if}
+									</div>
+									{#if eaWsList.length <= 1}
+										<p class="edit-hint">
+											You can't remove the last workspace — switch to "Cover all my current
+											workspaces" first or revoke the connection.
+										</p>
+									{/if}
+									<div class="edit-row add-row">
+										<select
+											class="edit-input"
+											bind:value={addPickerSlug[app.id]}
+											disabled={!!savingFlag[app.id]}
+										>
+											<option value="">Add a workspace…</option>
+											{#each pickable as ws (ws.slug)}
+												<option value={ws.slug}>{ws.name}</option>
+											{/each}
+										</select>
+										<button
+											class="btn"
+											onclick={() => addWorkspaceToApp(app)}
+											disabled={!!savingFlag[app.id] || !addPickerSlug[app.id]}
+										>
+											Add
+										</button>
+									</div>
+									{#if workspacesError}
+										<p class="edit-hint edit-hint-error">{workspacesError}</p>
+									{/if}
+								</div>
+							{/if}
+						</div>
+					{/if}
 				</article>
 			{/each}
 		</div>
@@ -703,5 +970,119 @@
 		.app-actions .btn {
 			width: 100%;
 		}
+	}
+
+	/* PLAN-1519 / TASK-1524 edit panel — appears below the card body
+	   when the user clicks Edit. Inline rather than modal so two
+	   cards can stay readable side-by-side; the existing card layout
+	   already accommodates an expanded "Details" block below the
+	   actions row. */
+	.edit-panel {
+		grid-column: 1 / -1;
+		margin-top: 1rem;
+		padding: 1rem;
+		border-top: 1px solid var(--border);
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+	}
+
+	.edit-field {
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+	}
+
+	.edit-label {
+		font-weight: 600;
+		font-size: 0.85rem;
+		color: var(--text-secondary, #555);
+	}
+
+	.edit-row {
+		display: flex;
+		gap: 0.5rem;
+		align-items: center;
+	}
+
+	.edit-input {
+		flex: 1 1 auto;
+		padding: 0.45rem 0.65rem;
+		font-size: 0.9rem;
+		border: 1px solid var(--border);
+		border-radius: 6px;
+		background: var(--bg-input, var(--bg));
+		color: inherit;
+	}
+
+	.edit-toggle {
+		display: flex;
+		gap: 0.5rem;
+		align-items: center;
+		font-size: 0.9rem;
+		cursor: pointer;
+	}
+
+	.edit-toggle input {
+		margin: 0;
+	}
+
+	.edit-hint {
+		font-size: 0.8rem;
+		color: var(--text-tertiary, #777);
+		margin: 0;
+	}
+
+	.edit-hint-error {
+		color: var(--danger, #b00);
+	}
+
+	.edit-error {
+		padding: 0.5rem 0.75rem;
+		background: var(--bg-error, #fee);
+		color: var(--danger, #b00);
+		border-radius: 6px;
+		font-size: 0.85rem;
+		margin: 0;
+	}
+
+	.ws-chips {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.4rem;
+	}
+
+	.ws-empty {
+		font-size: 0.85rem;
+		color: var(--text-tertiary, #777);
+		font-style: italic;
+	}
+
+	.chip-remove {
+		margin-left: 0.3rem;
+		border: none;
+		background: transparent;
+		color: inherit;
+		font-size: 1rem;
+		line-height: 1;
+		cursor: pointer;
+		opacity: 0.6;
+	}
+
+	.chip-remove:hover:not(:disabled) {
+		opacity: 1;
+	}
+
+	.chip-remove:disabled {
+		cursor: not-allowed;
+		opacity: 0.3;
+	}
+
+	.add-row {
+		margin-top: 0.5rem;
+	}
+
+	.add-row .edit-input {
+		min-width: 0;
 	}
 </style>


### PR DESCRIPTION
## Summary

Phase D for PLAN-1519. Four mutation endpoints under \`/api/v1/connected-apps/{id}/...\` (rename, scope flags, add/remove workspace) plus an inline Edit panel per card on the console page.

- **Backend**: 4 handlers route through a shared owner-check (uniform 404 for non-owned). Empty-allow-list invariant enforced both in the flags handler (block toggling \`all_current=false\` when join table is empty) and the remove-workspace handler (block last-workspace removal when \`all_current=false\`). Membership-checked add. Each handler echoes the updated DTO.
- **DTO**: \`connectedAppDTO\` exposes \`name\` + the three scope flags (added in Phase C1 to the model).
- **Frontend**: TS types + API client extended. Connections page gains an Edit button per card opening an inline panel with name input + 3 scope-flag toggles + allow-list chips with X-to-remove + workspace picker (filtered to memberships not already in the list).

## Context

Implements \`TASK-1524\` under PLAN-1519. Phases A/B/C/C1/C2 shipped the tables + write path + read path; this PR adds the post-grant mutation UX. Phase E (Connect modal rewrite) is the last remaining design-doc deliverable.

## Test plan

- [x] \`go build ./... && go vet ./... && golangci-lint run\` — clean
- [x] \`go test ./...\` — all green (7 new handler tests cover happy paths + empty-allow-list invariants + non-owner / non-member 404s + idempotent missing-slug)
- [x] \`cd web && npm run check && npm run build\` — clean (0 TS errors)
- [x] Manual: Edit panel opens inline, name input save round-trips, flag toggles persist, allow-list add/remove works, last-workspace removal disabled at UI level + API rejects