### PR TITLE
fix(web,build): search palette hang on numeric query + graceful SSE shutdown (BUG-1531)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,12 +25,24 @@ build-go:
 
 install: build
 	@# Stop running server, install binary, clear stale pid.
-	@# CAUTION: `killall -9 pad` is SYSTEM-WIDE. If another user (or another
-	@# project on the same machine) is also running a `pad` process, it will
-	@# get killed too. Designed for single-developer local setups; don't run
-	@# `make install` on a shared host.
-	-killall -9 $(BINARY) 2>/dev/null
-	@sleep 1
+	@# CAUTION: `pkill -x pad` is SYSTEM-WIDE (matches the binary name on the
+	@# whole host). If another user or project on the same machine is running
+	@# a `pad` process, it will get signaled too. Designed for single-developer
+	@# local setups; don't run `make install` on a shared host.
+	@#
+	@# SIGTERM (not SIGKILL) so the server's graceful-shutdown path runs:
+	@# it closes the event bus, which terminates SSE handler goroutines so
+	@# the http.Server can write the final 0-chunk before closing each
+	@# stream. SIGKILL drops every open SSE connection mid-write, leaving
+	@# every browser tab with `ERR_INCOMPLETE_CHUNKED_ENCODING` and a noisy
+	@# reconnect storm. Falls back to SIGKILL after 5s for stuck processes.
+	@# BUG-1531 / SSE follow-up.
+	-pkill -TERM -x $(BINARY) 2>/dev/null; \
+		for i in 1 2 3 4 5; do \
+			pgrep -x $(BINARY) >/dev/null 2>&1 || break; \
+			sleep 1; \
+		done; \
+		pkill -KILL -x $(BINARY) 2>/dev/null || true
 	@mkdir -p $(INSTALL_DIR)
 	cp -f $(BINARY) $(INSTALL_DIR)/$(BINARY)
 	rm -f ~/.pad/pad.pid

--- a/internal/server/handlers_claim_code_test.go
+++ b/internal/server/handlers_claim_code_test.go
@@ -76,11 +76,11 @@ func seedActiveAccessTokenForChain(t *testing.T, s *store.Store, requestID, user
 // doesn't care which auth shape the caller used.
 
 type claimCodeResponse struct {
-	Workspace             string `json:"workspace"`
-	Code                  string `json:"code,omitempty"`
-	ExpiresAt             string `json:"expires_at"`
-	Suppressed            bool   `json:"suppressed"`
-	SuppressionGrantName  string `json:"suppression_grant_name,omitempty"`
+	Workspace            string `json:"workspace"`
+	Code                 string `json:"code,omitempty"`
+	ExpiresAt            string `json:"expires_at"`
+	Suppressed           bool   `json:"suppressed"`
+	SuppressionGrantName string `json:"suppression_grant_name,omitempty"`
 }
 
 func newClaimCodeEnv(t *testing.T) *claimTestEnv {

--- a/web/src/lib/components/search/CommandPalette.svelte
+++ b/web/src/lib/components/search/CommandPalette.svelte
@@ -406,6 +406,15 @@
 		void searchAllWorkspaces;
 		void filterCollection;
 		void filterStatus;
+		// Track the current workspace slug unconditionally. Before
+		// untrack()ing doSearch(), the slug was a tracked dep by virtue
+		// of doSearch's own read inside the effect — switching workspaces
+		// with the palette open re-fired the effect. Now that doSearch
+		// is untracked, body / bare-digit queries (which skip the local-
+		// index dep block below) would otherwise miss workspace switches
+		// and leave `loading` stuck while an in-flight server response
+		// gets discarded by `isSameDispatch()`. Codex round 1 of BUG-1531.
+		void workspaceStore.current?.slug;
 		const trimmed = query.trim();
 		const parsed = trimmed ? parseSearchQuery(trimmed) : null;
 		const isBareDigit = !!trimmed && /^\d+$/.test(trimmed);

--- a/web/src/lib/components/search/CommandPalette.svelte
+++ b/web/src/lib/components/search/CommandPalette.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { untrack } from 'svelte';
 	import { goto } from '$app/navigation';
 	import { api } from '$lib/api/client';
 	import { workspaceStore } from '$lib/stores/workspace.svelte';
@@ -378,6 +379,24 @@
 	// doSearch from offset 0 and wipe an in-flight `loadMore` append.
 	// Codex round 7 P2 of TASK-1365.
 	//
+	// SAME EXCEPTION for bare-digit queries (BUG-1531): a bare digit
+	// short-circuits to `exactItemNumberLookup` — a single deterministic
+	// item-number match. Subscribing to every workspace's epoch + every
+	// workspace's bootstrapState made the effect re-fire on every SSE-
+	// driven `applyDelta` / re-bootstrap, and the bare-digit path runs
+	// synchronously fast enough that the re-fires stacked inside a
+	// single tick → `effect_update_depth_exceeded`. We accept slightly
+	// staler "go to N" results until the next user keystroke; that's
+	// fine because Enter on a bare-digit query already forces a fresh
+	// server fetch (see the Enter handler).
+	//
+	// Additionally, `doSearch` is called via `untrack` so its INTERNAL
+	// reads (it reads bootstrapStateFor for every ready workspace via
+	// `readyWorkspaces()`, plus the current workspace's bootstrapState)
+	// don't add hidden tracked dependencies to this effect. The
+	// dependencies that should re-fire this effect are the ones
+	// explicitly `void`ed below — nothing else.
+	//
 	// `doSearch` handles the empty-query case internally by clearing
 	// results — so the effect can fire on every transition (including
 	// "user backspaced to empty") without leaving stale results visible.
@@ -389,13 +408,14 @@
 		void filterStatus;
 		const trimmed = query.trim();
 		const parsed = trimmed ? parseSearchQuery(trimmed) : null;
-		if (!parsed?.body) {
+		const isBareDigit = !!trimmed && /^\d+$/.test(trimmed);
+		if (!parsed?.body && !isBareDigit) {
 			void localIndex.bootstrapStateFor(workspaceStore.current?.slug ?? '');
 			for (const ws of workspaceStore.workspaces) {
 				void localSearch.epoch(ws.slug);
 			}
 		}
-		doSearch();
+		untrack(() => doSearch());
 	});
 
 	function loadAllWorkspacesPref(): boolean {


### PR DESCRIPTION
## Summary

- **CommandPalette**: typing a number into the search palette froze the page with `effect_update_depth_exceeded`. The main reactive `$effect` subscribed to every workspace's `localSearch.epoch` + `localIndex.bootstrapStateFor`; bare-digit queries short-circuit to a synchronous exact-item-number lookup, and every SSE-driven delta stacked re-fires of the effect inside a single microtask tick. Treat bare-digit queries the same as \`body:\` queries (skip the subscription reads) and wrap \`doSearch()\` in \`untrack()\` so its internal reactive reads can't smuggle hidden dependencies into the effect.
- **Makefile (\`install\`)**: switch from \`killall -9\` to \`pkill -TERM\` + 5s wait + \`pkill -KILL\` fallback so the server's existing graceful-shutdown path actually runs. SIGKILL was dropping every open SSE stream mid-chunk, leaving every browser tab with \`ERR_INCOMPLETE_CHUNKED_ENCODING\` and a reconnect storm — which was what fanned the search-palette loop.

Follow-up SSE handler tidy-ups (unchecked write errors in \`writeSSEEvent\`, link the 30s keepalive to the 120s \`IdleTimeout\` in code) tracked in BUG-1532.

Refs: BUG-1531, BUG-1532

## Test plan

- [x] Manually verified the palette no longer hangs when typing \`5\` / \`1531\` (confirmed by user).
- [x] Pressing Enter on a bare-digit query still force-fetches from the server (Enter handler is unchanged).
- [x] Normal text search and SSE-driven result refresh still work (effect still subscribes to epoch/bootstrap for non-bare-digit, non-body queries).
- [x] \`make install\` exits the previous \`pad\` process cleanly; SIGKILL fallback fires only when the graceful path stalls past 5s.
- [ ] Reviewer: confirm no other consumer of the \`bare-digit\` shape relies on epoch tracking to refresh.