### PR TITLE
chore(web): npm audit fix — svelte 5.55.8, devalue 5.8.1, mermaid 11.15.0

### DIFF
--- a/internal/server/handlers_oauth_test.go
+++ b/internal/server/handlers_oauth_test.go
@@ -1123,8 +1123,13 @@ func TestConsent_ApproveWithSpecificWorkspaces(t *testing.T) {
 	// New invariant: the oauth_connections row created by the consent
 	// flow must carry name + scope flags, and the join table must
 	// hold the selected workspace slugs (TASK-1523 / IDEA-1517 §2a).
-	// Locate the chain via the user's connection list; the most
-	// recent connection is this approve flow's grant.
+	// We can't rely on conns[0] being this approve flow's grant: the
+	// bearer-mint above (runAuthCodeFlow) creates a SECOND connection
+	// with `allowed_workspaces=["*"]`, and ListUserOAuthConnections
+	// orders ConnectedAt DESC — so conns[0] is the wildcard bearer
+	// row, not the alpha+beta row this test asserts on. Locate by
+	// shape instead: the specific-workspaces flow is the only one
+	// here with AllCurrentWorkspaces=false.
 	conns, err := srv.store.ListUserOAuthConnections(user.ID)
 	if err != nil {
 		t.Fatalf("ListUserOAuthConnections: %v", err)
@@ -1132,9 +1137,15 @@ func TestConsent_ApproveWithSpecificWorkspaces(t *testing.T) {
 	if len(conns) == 0 {
 		t.Fatalf("expected at least one connection after approve flow")
 	}
-	c := conns[0]
-	if c.AllCurrentWorkspaces {
-		t.Errorf("specific-workspaces consent should yield all_current_workspaces=false; got true")
+	var c *models.OAuthConnection
+	for i := range conns {
+		if !conns[i].AllCurrentWorkspaces {
+			c = &conns[i]
+			break
+		}
+	}
+	if c == nil {
+		t.Fatalf("no specific-workspaces connection found among %d connections", len(conns))
 	}
 	want := map[string]bool{"alpha": true, "beta": true}
 	if len(c.AllowedWorkspaces) != len(want) {

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -68,41 +68,10 @@
 			"integrity": "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==",
 			"license": "MIT"
 		},
-		"node_modules/@chevrotain/cst-dts-gen": {
-			"version": "12.0.0",
-			"resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-12.0.0.tgz",
-			"integrity": "sha512-fSL4KXjTl7cDgf0B5Rip9Q05BOrYvkJV/RrBTE/bKDN096E4hN/ySpcBK5B24T76dlQ2i32Zc3PAE27jFnFrKg==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@chevrotain/gast": "12.0.0",
-				"@chevrotain/types": "12.0.0"
-			}
-		},
-		"node_modules/@chevrotain/gast": {
-			"version": "12.0.0",
-			"resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-12.0.0.tgz",
-			"integrity": "sha512-1ne/m3XsIT8aEdrvT33so0GUC+wkctpUPK6zU9IlOyJLUbR0rg4G7ZiApiJbggpgPir9ERy3FRjT6T7lpgetnQ==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@chevrotain/types": "12.0.0"
-			}
-		},
-		"node_modules/@chevrotain/regexp-to-ast": {
-			"version": "12.0.0",
-			"resolved": "https://registry.npmjs.org/@chevrotain/regexp-to-ast/-/regexp-to-ast-12.0.0.tgz",
-			"integrity": "sha512-p+EW9MaJwgaHguhoqwOtx/FwuGr+DnNn857sXWOi/mClXIkPGl3rn7hGNWvo31HA3vyeQxjqe+H36yZJwYU8cA==",
-			"license": "Apache-2.0"
-		},
 		"node_modules/@chevrotain/types": {
-			"version": "12.0.0",
-			"resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-12.0.0.tgz",
-			"integrity": "sha512-S+04vjFQKeuYw0/eW3U52LkAHQsB1ASxsPGsLPUyQgrZ2iNNibQrsidruDzjEX2JYfespXMG0eZmXlhA6z7nWA==",
-			"license": "Apache-2.0"
-		},
-		"node_modules/@chevrotain/utils": {
-			"version": "12.0.0",
-			"resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-12.0.0.tgz",
-			"integrity": "sha512-lB59uJoaGIfOOL9knQqQRfhl9g7x8/wqFkp13zTdkRu1huG9kg6IJs1O8hqj9rs6h7orGxHJUKb+mX3rPbWGhA==",
+			"version": "11.1.2",
+			"resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.1.2.tgz",
+			"integrity": "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==",
 			"license": "Apache-2.0"
 		},
 		"node_modules/@emnapi/core": {
@@ -227,12 +196,12 @@
 			}
 		},
 		"node_modules/@mermaid-js/parser": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.1.0.tgz",
-			"integrity": "sha512-gxK9ZX2+Fex5zu8LhRQoMeMPEHbc73UKZ0FQ54YrQtUxE1VVhMwzeNtKRPAu5aXks4FasbMe4xB4bWrmq6Jlxw==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.1.1.tgz",
+			"integrity": "sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==",
 			"license": "MIT",
 			"dependencies": {
-				"langium": "^4.0.0"
+				"@chevrotain/types": "~11.1.1"
 			}
 		},
 		"node_modules/@napi-rs/wasm-runtime": {
@@ -1611,34 +1580,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/chevrotain": {
-			"version": "12.0.0",
-			"resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-12.0.0.tgz",
-			"integrity": "sha512-csJvb+6kEiQaqo1woTdSAuOWdN0WTLIydkKrBnS+V5gZz0oqBrp4kQ35519QgK6TpBThiG3V1vNSHlIkv4AglQ==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@chevrotain/cst-dts-gen": "12.0.0",
-				"@chevrotain/gast": "12.0.0",
-				"@chevrotain/regexp-to-ast": "12.0.0",
-				"@chevrotain/types": "12.0.0",
-				"@chevrotain/utils": "12.0.0"
-			},
-			"engines": {
-				"node": ">=22.0.0"
-			}
-		},
-		"node_modules/chevrotain-allstar": {
-			"version": "0.4.3",
-			"resolved": "https://registry.npmjs.org/chevrotain-allstar/-/chevrotain-allstar-0.4.3.tgz",
-			"integrity": "sha512-2X4mkroolSMKqW+H22pyPMUVDqYZzPhephTmg/NODKb1IGYPHfxfhcW0EjS7wcPJNbze2i4vBWT7zT5FKF2lrQ==",
-			"license": "MIT",
-			"dependencies": {
-				"lodash-es": "^4.18.1"
-			},
-			"peerDependencies": {
-				"chevrotain": "^12.0.0"
-			}
-		},
 		"node_modules/chokidar": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
@@ -2274,9 +2215,9 @@
 			}
 		},
 		"node_modules/devalue": {
-			"version": "5.8.0",
-			"resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.0.tgz",
-			"integrity": "sha512-2zA9pFEsnp7vWBZbXF5JAgAq0fsUIt/1XPbRiAmRV3lp/2C3upzH+sADiyy66aFCihoLEsrQHxNM5w1gIDfsBg==",
+			"version": "5.8.1",
+			"resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.1.tgz",
+			"integrity": "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==",
 			"license": "MIT"
 		},
 		"node_modules/devlop": {
@@ -2333,6 +2274,16 @@
 			"funding": {
 				"url": "https://github.com/fb55/entities?sponsor=1"
 			}
+		},
+		"node_modules/es-toolkit": {
+			"version": "1.46.1",
+			"resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.1.tgz",
+			"integrity": "sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==",
+			"license": "MIT",
+			"workspaces": [
+				"docs",
+				"benchmarks"
+			]
 		},
 		"node_modules/esm-env": {
 			"version": "1.2.2",
@@ -2530,24 +2481,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
-			}
-		},
-		"node_modules/langium": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/langium/-/langium-4.2.3.tgz",
-			"integrity": "sha512-sOPIi4hISFnY7twwV97ca1TsxpBtXq0URu/LL1AvxwccPG/RIBBlKS7a/f/EL6w8lTNaS0EFs/F+IdSOaqYpng==",
-			"license": "MIT",
-			"dependencies": {
-				"@chevrotain/regexp-to-ast": "~12.0.0",
-				"chevrotain": "~12.0.0",
-				"chevrotain-allstar": "~0.4.3",
-				"vscode-languageserver": "~9.0.1",
-				"vscode-languageserver-textdocument": "~1.0.11",
-				"vscode-uri": "~3.1.0"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
 			}
 		},
 		"node_modules/layout-base": {
@@ -2956,14 +2889,14 @@
 			"license": "MIT"
 		},
 		"node_modules/mermaid": {
-			"version": "11.14.0",
-			"resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.14.0.tgz",
-			"integrity": "sha512-GSGloRsBs+JINmmhl0JDwjpuezCsHB4WGI4NASHxL3fHo3o/BRXTxhDLKnln8/Q0lRFRyDdEjmk1/d5Sn1Xz8g==",
+			"version": "11.15.0",
+			"resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.15.0.tgz",
+			"integrity": "sha512-pTMbcf3rWdtLiYGpmoTjHEpeY8seiy6sR+9nD7LOs8KfUbHE4lOUAprTRqRAcWSQ6MQpdX+YEsxShtGsINtPtw==",
 			"license": "MIT",
 			"dependencies": {
 				"@braintree/sanitize-url": "^7.1.1",
 				"@iconify/utils": "^3.0.2",
-				"@mermaid-js/parser": "^1.1.0",
+				"@mermaid-js/parser": "^1.1.1",
 				"@types/d3": "^7.4.3",
 				"@upsetjs/venn.js": "^2.0.0",
 				"cytoscape": "^3.33.1",
@@ -2974,14 +2907,14 @@
 				"dagre-d3-es": "7.0.14",
 				"dayjs": "^1.11.19",
 				"dompurify": "^3.3.1",
+				"es-toolkit": "^1.45.1",
 				"katex": "^0.16.25",
 				"khroma": "^2.1.0",
-				"lodash-es": "^4.17.23",
 				"marked": "^16.3.0",
 				"roughjs": "^4.6.6",
 				"stylis": "^4.3.6",
 				"ts-dedent": "^2.2.0",
-				"uuid": "^11.1.0"
+				"uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0"
 			}
 		},
 		"node_modules/mermaid/node_modules/marked": {
@@ -3592,9 +3525,9 @@
 			"license": "MIT"
 		},
 		"node_modules/svelte": {
-			"version": "5.55.5",
-			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.5.tgz",
-			"integrity": "sha512-2uCs/LZ9us+AktdzYJM8OcxQ8qnPS1kpaO7syGT/MgO+6Qr1Ybl+TqPq+97u7PHqmmMlye5ZkoyXONy5mjjAbw==",
+			"version": "5.55.8",
+			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.8.tgz",
+			"integrity": "sha512-4D6lyrMHmDaZalQOEBMCWCCidyZjSnec14/oPn0k627G6goxcck9xqMwz1tFLlQz+ZFvtTTHfFOlUayuAz0z6Q==",
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/remapping": "^2.3.4",
@@ -3606,7 +3539,7 @@
 				"aria-query": "5.3.1",
 				"axobject-query": "^4.1.0",
 				"clsx": "^2.1.1",
-				"devalue": "^5.6.4",
+				"devalue": "^5.8.1",
 				"esm-env": "^1.2.1",
 				"esrap": "^2.2.4",
 				"is-reference": "^3.0.3",
@@ -3874,55 +3807,6 @@
 					"optional": true
 				}
 			}
-		},
-		"node_modules/vscode-jsonrpc": {
-			"version": "8.2.0",
-			"resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
-			"integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/vscode-languageserver": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
-			"integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
-			"license": "MIT",
-			"dependencies": {
-				"vscode-languageserver-protocol": "3.17.5"
-			},
-			"bin": {
-				"installServerIntoExtension": "bin/installServerIntoExtension"
-			}
-		},
-		"node_modules/vscode-languageserver-protocol": {
-			"version": "3.17.5",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
-			"integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
-			"license": "MIT",
-			"dependencies": {
-				"vscode-jsonrpc": "8.2.0",
-				"vscode-languageserver-types": "3.17.5"
-			}
-		},
-		"node_modules/vscode-languageserver-textdocument": {
-			"version": "1.0.12",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
-			"integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
-			"license": "MIT"
-		},
-		"node_modules/vscode-languageserver-types": {
-			"version": "3.17.5",
-			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
-			"integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
-			"license": "MIT"
-		},
-		"node_modules/vscode-uri": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
-			"integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
-			"license": "MIT"
 		},
 		"node_modules/w3c-keyname": {
 			"version": "2.2.8",


### PR DESCRIPTION
## Summary

Clears all three advisories the Web CI job has been failing on. All in-range patch bumps — \`package.json\` is untouched, only \`package-lock.json\` changes.

| Package | Was | Now | Severity × count |
|---|---|---|---|
| \`svelte\` | 5.55.5 | 5.55.8 | moderate × 4 (SSR XSS via spread; hydratable Promise XSS; DOM clobbering of framework state; ReDoS in \`<svelte:element>\`) |
| \`devalue\` (transitive via SvelteKit) | 5.6.x | 5.8.1 | high × 1 (DoS via sparse-array deser) |
| \`mermaid\` (transitive) | 11.14.x | 11.15.0 | moderate × 4 (Gantt infinite-loop DoS; \`classDef\` CSS/HTML injection; config CSS injection) |

**Tiptap deliberately untouched** — \`@tiptap/core\`, \`@tiptap/extension-collaboration\`, \`@tiptap/y-tiptap\` all stay at 3.22.5. The CLAUDE.md lockstep rule (coordinated bumps + Y.Doc schema-version bump) only kicks in when those three move together; this PR doesn't move them.

## Verification

- \`npm audit\` → 0 vulnerabilities
- \`npm run check\` → 0 errors (6 pre-existing warnings unchanged)
- \`make build && make install\` → clean; server boots and serves the new bundle locally
- \`go test ./internal/server -run TestSSE\` → pass (no Go changes; sanity only)

## Test plan

- [x] CI Web job goes green (was the only block)
- [ ] Reviewer: smoke-test rich-text editor and any Mermaid-rendered diagrams in the running app to confirm no rendering regressions from the mermaid patch bump