### PR TITLE
fix(sse): surface write errors and link keepalive to IdleTimeout (BUG-1532)

### DIFF
--- a/internal/server/handlers_events.go
+++ b/internal/server/handlers_events.go
@@ -13,6 +13,28 @@ import (
 	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
+// sseKeepaliveInterval is how often we write a comment line to an
+// otherwise-idle SSE stream so (a) intermediate proxies/LBs don't
+// idle the connection out, and (b) the kernel-level TCP keep-alive
+// has traffic to ride. Must land well inside the http.Server's
+// IdleTimeout (httpIdleTimeout in server.go) — the init() guard
+// below enforces 3 × keepalive < IdleTimeout so a couple of dropped
+// writes don't slip past the deadline.
+//
+// Bumping this past httpIdleTimeout / 3 without bumping
+// httpIdleTimeout in lockstep is a programming error caught at
+// process start, not at runtime. BUG-1532.
+const sseKeepaliveInterval = 30 * time.Second
+
+func init() {
+	if 3*sseKeepaliveInterval >= httpIdleTimeout {
+		panic(fmt.Sprintf(
+			"invariant violated: 3 × sseKeepaliveInterval (%s) must be < httpIdleTimeout (%s); "+
+				"bump httpIdleTimeout in server.go or reduce sseKeepaliveInterval. BUG-1532.",
+			3*sseKeepaliveInterval, httpIdleTimeout))
+	}
+}
+
 // handleSSE streams Server-Sent Events for a workspace.
 // GET /api/v1/events?workspace=<slug>
 //
@@ -132,11 +154,17 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 		return true
 	}
 
-	// Send initial connected event
-	writeSSEEvent(w, "connected", 0, map[string]string{
+	// Send initial connected event. If even this first write fails the
+	// client is already gone — bail before subscribing to anything
+	// else. BUG-1532.
+	if err := writeSSEEvent(w, "connected", 0, map[string]string{
 		"workspace_id": ws.ID,
 		"workspace":    ws.Slug,
-	})
+	}); err != nil {
+		slog.Debug("SSE: initial connected write failed, closing",
+			"workspace", ws.Slug, "error", err)
+		return
+	}
 	flusher.Flush()
 
 	// Replay missed events if the client provided Last-Event-ID.
@@ -149,16 +177,24 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 				// Gap too large — buffer evicted. Tell client to do a full sync.
 				slog.Info("SSE replay gap too large, sending sync_required",
 					"workspace", ws.Slug, "last_event_id", lastID)
-				writeSSEEvent(w, "sync_required", 0, map[string]string{
+				if err := writeSSEEvent(w, "sync_required", 0, map[string]string{
 					"reason": "Event buffer exceeded. Full sync required.",
-				})
+				}); err != nil {
+					slog.Debug("SSE: sync_required write failed, closing",
+						"workspace", ws.Slug, "error", err)
+					return
+				}
 				flusher.Flush()
 			} else if len(missed) > 0 {
 				slog.Info("SSE replaying missed events",
 					"workspace", ws.Slug, "last_event_id", lastID, "count", len(missed))
 				for _, event := range missed {
 					if sseEventVisible(event) {
-						writeSSEEvent(w, event.Type, event.ID, event)
+						if err := writeSSEEvent(w, event.Type, event.ID, event); err != nil {
+							slog.Debug("SSE: replay write failed, closing",
+								"workspace", ws.Slug, "error", err)
+							return
+						}
 						flusher.Flush()
 					}
 				}
@@ -167,8 +203,9 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Keepalive ticker
-	keepalive := time.NewTicker(30 * time.Second)
+	// Keepalive ticker — see sseKeepaliveInterval doc for why the
+	// interval is linked to httpIdleTimeout.
+	keepalive := time.NewTicker(sseKeepaliveInterval)
 	defer keepalive.Stop()
 
 	// Membership revalidation timer. The initial subscribe only checked
@@ -207,13 +244,32 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 			if sseEventVisible(event) {
-				writeSSEEvent(w, event.Type, event.ID, event)
+				// Broken-pipe / EOF on the live event path means the
+				// client has gone away. Exit the handler so the bus
+				// subscription is released (the deferred Unsubscribe
+				// runs) and we stop pulling events off the channel for
+				// a peer that can't receive them. ctx.Done() will fire
+				// on the next iteration anyway in most cases, but
+				// surfacing the write error closes the gap where the
+				// client TCP went away but the cancellation hasn't
+				// propagated yet. BUG-1532.
+				if err := writeSSEEvent(w, event.Type, event.ID, event); err != nil {
+					slog.Debug("SSE: event write failed, closing",
+						"workspace", ws.Slug, "event_type", event.Type, "error", err)
+					return
+				}
 				flusher.Flush()
 			}
 
 		case <-keepalive.C:
-			// Send keepalive comment to prevent proxy/LB timeouts
-			fmt.Fprintf(w, ": keepalive\n\n")
+			// Send keepalive comment to prevent proxy/LB timeouts.
+			// Write error → client gone → exit. Same rationale as the
+			// event-write path above. BUG-1532.
+			if _, err := fmt.Fprintf(w, ": keepalive\n\n"); err != nil {
+				slog.Debug("SSE: keepalive write failed, closing",
+					"workspace", ws.Slug, "error", err)
+				return
+			}
 			flusher.Flush()
 
 		case <-membershipCheck.C:
@@ -225,11 +281,18 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 					"workspace", ws.Slug, "user_id", sseUserID)
 				// Tell the client why — the frontend's EventSource handler
 				// can use this to redirect to login / dismiss the workspace
-				// instead of reconnecting in a tight loop.
-				writeSSEEvent(w, "unauthorized", 0, map[string]string{
+				// instead of reconnecting in a tight loop. Best-effort:
+				// if the write fails the client is already gone, which
+				// is operationally equivalent to "they got the message"
+				// — either way we exit.
+				if err := writeSSEEvent(w, "unauthorized", 0, map[string]string{
 					"reason": "Your access to this workspace was revoked.",
-				})
-				flusher.Flush()
+				}); err != nil {
+					slog.Debug("SSE: unauthorized write failed (client likely already gone)",
+						"workspace", ws.Slug, "error", err)
+				} else {
+					flusher.Flush()
+				}
 				return
 			}
 			// Still a member — but the scope of that membership may have
@@ -480,15 +543,24 @@ func (s *Server) sseSubscriberStillHasAccess(r *http.Request, workspaceID string
 
 // writeSSEEvent writes a single SSE event to the response writer.
 // If eventID > 0, an "id:" field is included for Last-Event-ID support.
-func writeSSEEvent(w http.ResponseWriter, eventType string, eventID int64, data interface{}) {
+//
+// Returns nil for both the happy path AND the JSON-marshal failure
+// path: a marshal error is local to this event and shouldn't tear
+// down a healthy stream. Returns the underlying Fprintf error only
+// when the actual network write fails — the caller should treat that
+// as "the stream is gone" and exit the handler so the bus
+// subscription is released and we don't keep pulling events off the
+// channel for a broken peer. BUG-1532.
+func writeSSEEvent(w http.ResponseWriter, eventType string, eventID int64, data interface{}) error {
 	jsonData, err := json.Marshal(data)
 	if err != nil {
-		slog.Error("failed to marshal SSE event", "error", err)
-		return
+		slog.Error("failed to marshal SSE event", "error", err, "event_type", eventType)
+		return nil
 	}
 	if eventID > 0 {
-		fmt.Fprintf(w, "id: %d\nevent: %s\ndata: %s\n\n", eventID, eventType, jsonData)
+		_, err = fmt.Fprintf(w, "id: %d\nevent: %s\ndata: %s\n\n", eventID, eventType, jsonData)
 	} else {
-		fmt.Fprintf(w, "event: %s\ndata: %s\n\n", eventType, jsonData)
+		_, err = fmt.Fprintf(w, "event: %s\ndata: %s\n\n", eventType, jsonData)
 	}
+	return err
 }

--- a/internal/server/handlers_events_test.go
+++ b/internal/server/handlers_events_test.go
@@ -462,3 +462,65 @@ func TestSSELimitsExistingConnectionsUnaffected(t *testing.T) {
 		t.Errorf("expected 1 subscriber still active, got %d", got)
 	}
 }
+
+// failingWriter is an http.ResponseWriter whose Write always returns
+// an error. Used to verify writeSSEEvent surfaces write failures
+// rather than swallowing them. BUG-1532.
+type failingWriter struct {
+	header http.Header
+	err    error
+}
+
+func (f *failingWriter) Header() http.Header {
+	if f.header == nil {
+		f.header = http.Header{}
+	}
+	return f.header
+}
+func (f *failingWriter) Write(_ []byte) (int, error) { return 0, f.err }
+func (f *failingWriter) WriteHeader(_ int)           {}
+
+// TestWriteSSEEvent_SurfacesWriteErrors locks in the BUG-1532 contract:
+// writeSSEEvent must return the underlying write error so the handler
+// can exit cleanly when the client has gone away. Previously the error
+// was silently dropped from fmt.Fprintf and the handler kept looping.
+func TestWriteSSEEvent_SurfacesWriteErrors(t *testing.T) {
+	want := fmt.Errorf("broken pipe")
+	fw := &failingWriter{err: want}
+
+	got := writeSSEEvent(fw, "item.created", 42, map[string]string{"k": "v"})
+	if got == nil {
+		t.Fatal("writeSSEEvent: expected write error, got nil")
+	}
+	// fmt.Fprintf wraps Write errors verbatim; the underlying error
+	// must be reachable for callers that want to distinguish broken-pipe
+	// from real bugs.
+	if !strings.Contains(got.Error(), want.Error()) {
+		t.Errorf("writeSSEEvent error: got %q, want it to contain %q", got.Error(), want.Error())
+	}
+}
+
+// TestWriteSSEEvent_MarshalErrorIsLocal verifies that a JSON-marshal
+// failure for a single event does NOT bubble up as a write error —
+// the caller would otherwise tear down a healthy stream because one
+// payload had an un-marshalable field. BUG-1532.
+func TestWriteSSEEvent_MarshalErrorIsLocal(t *testing.T) {
+	// Channels aren't JSON-encodable; json.Marshal returns
+	// UnsupportedTypeError.
+	got := writeSSEEvent(httptest.NewRecorder(), "weird", 0, make(chan int))
+	if got != nil {
+		t.Fatalf("writeSSEEvent on un-marshalable data: got %v, want nil (marshal errors should not tear down the stream)", got)
+	}
+}
+
+// TestSSEKeepaliveIdleTimeoutInvariant is a belt-and-suspenders check
+// for the relationship enforced by handlers_events.go's init() guard.
+// If this assertion ever flips, the init() guard would panic at
+// process start, but having it in the test suite gives an immediate,
+// readable failure during local development. BUG-1532.
+func TestSSEKeepaliveIdleTimeoutInvariant(t *testing.T) {
+	if 3*sseKeepaliveInterval >= httpIdleTimeout {
+		t.Fatalf("invariant: 3 × sseKeepaliveInterval (%s) must be < httpIdleTimeout (%s)",
+			3*sseKeepaliveInterval, httpIdleTimeout)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1344,6 +1344,18 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	s.router.ServeHTTP(w, r)
 }
 
+// httpIdleTimeout caps the keep-alive idle window on every HTTP
+// connection. Tracked here (not in handlers_events.go) because it
+// applies to ALL connections, not just SSE — but it has a hard
+// invariant relationship with sseKeepaliveInterval: an idle SSE
+// stream is kept alive by periodic comment writes, and those must
+// land more frequently than IdleTimeout or the connection will be
+// closed mid-stream by the http.Server. The guard in
+// handlers_events.go's init() enforces 3 × sseKeepaliveInterval <
+// httpIdleTimeout so we tolerate one or two missed/dropped writes
+// (network blip, scheduler hiccup) before tripping the deadline.
+const httpIdleTimeout = 120 * time.Second
+
 func (s *Server) ListenAndServe(addr string) error {
 	s.ensureRouter()
 
@@ -1352,7 +1364,7 @@ func (s *Server) ListenAndServe(addr string) error {
 		Handler:           s.router,
 		ReadTimeout:       15 * time.Second,
 		ReadHeaderTimeout: 5 * time.Second,
-		IdleTimeout:       120 * time.Second,
+		IdleTimeout:       httpIdleTimeout,
 		// Cap total header bytes (default 1 MB) to 64 KB — well above any
 		// legitimate request (cookies, auth, content-type, a few CSRF/CORS
 		// headers) and tight enough to cheaply reject header-flood DoS.


### PR DESCRIPTION
## Summary

Closes **BUG-1532** — the SSE handler tidy-ups flagged during the BUG-1531 investigation.

### 1. \`writeSSEEvent\` now returns the underlying write error

Previously the \`fmt.Fprintf\` calls in \`writeSSEEvent\` and the keepalive write silently dropped any error from the response writer. When the client TCP went away the handler kept looping, pulling events off the bus channel and discarding them while waiting for \`ctx.Done()\` cancellation to propagate. Now any write failure exits the handler immediately so the bus subscription is released and we stop fanning broadcast traffic into a dead socket.

- All five callsites + the keepalive \`Fprintf\` are updated.
- Logging is at \`DEBUG\` — broken-pipe on client disconnect is normal traffic, not WARN-worthy noise.
- Marshal errors stay local (don't tear down a healthy stream over one un-marshalable payload).

### 2. 30s keepalive + 120s IdleTimeout are now named + linked

- \`sseKeepaliveInterval = 30s\` lives in \`handlers_events.go\`.
- \`httpIdleTimeout = 120s\` lives in \`server.go\`.
- An \`init()\` guard panics if \`3 × keepalive >= IdleTimeout\` — a misconfigured constant is visible at process start, not three months later when someone notices intermittent reconnect storms.

## New tests

- \`TestWriteSSEEvent_SurfacesWriteErrors\` — locks in the new error-return contract via a synthetic failing writer.
- \`TestWriteSSEEvent_MarshalErrorIsLocal\` — verifies an un-marshalable payload doesn't tear down the stream.
- \`TestSSEKeepaliveIdleTimeoutInvariant\` — belt-and-suspenders for the init() guard.

## Verification

- \`go test ./internal/server -count=1\` → pass (~78s)
- \`go vet ./...\` → clean
- New tests pass individually and in the full suite

## Test plan

- [ ] Reviewer: open the web UI, trigger a server restart (\`make install\` graceful path from BUG-1531), confirm SSE reconnects cleanly with no \`ERR_INCOMPLETE_CHUNKED_ENCODING\` in console.
- [ ] Reviewer: leave a tab open idle for >2 minutes (longer than \`httpIdleTimeout\`); confirm the connection stays up (keepalive lands inside the window).