### PR TITLE
feat(web): blank-as-default workspace modal + auto-open Connect modal post-create

### DIFF
--- a/web/src/lib/components/layout/CreateWorkspaceModal.svelte
+++ b/web/src/lib/components/layout/CreateWorkspaceModal.svelte
@@ -4,12 +4,35 @@
 	import { uiStore } from '$lib/stores/ui.svelte';
 	import { api } from '$lib/api/client';
 	import { toastStore } from '$lib/stores/toast.svelte';
-	import type { WorkspaceTemplate } from '$lib/types';
+	import type { Workspace, WorkspaceTemplate } from '$lib/types';
 	import { groupTemplatesByCategory } from '$lib/utils/templates';
 
+	interface Props {
+		/**
+		 * Optional callback fired after a successful create OR import, before
+		 * the modal closes and the user is navigated to the new workspace.
+		 *
+		 * Phase 1 (TASK-1528) defines the API; Phase F (TASK-1526) wires it
+		 * to `uiStore.requestConnectAfterNavigate(ws.slug)` so the workspace's
+		 * +page.svelte auto-opens ConnectWorkspaceModal once the user lands
+		 * on the new workspace. The modal still owns navigation + close —
+		 * the callback is side-effect-only.
+		 */
+		onWorkspaceCreated?: (workspace: Workspace) => void;
+	}
+
+	let { onWorkspaceCreated }: Props = $props();
+
+	// Default selection is `blank` per IDEA-1516 §2 — agent-driven onboarding
+	// is the recommended path, the primary "Start blank" card represents that.
+	// Picking any template card replaces 'blank' with that template's name.
 	let mode = $state<'create' | 'import'>('create');
 	let newName = $state('');
-	let selectedTemplate = $state('startup');
+	let selectedTemplate = $state('blank');
+	// Independent of `selectedTemplate` — collapsed by default per IDEA-1516
+	// §2. Users who expand and pick a template flip `selectedTemplate` to
+	// that template; users who never expand keep `blank`.
+	let templatesExpanded = $state(false);
 	let templates = $state<WorkspaceTemplate[]>([]);
 	let loadingTemplates = $state(false);
 	let importing = $state(false);
@@ -19,14 +42,23 @@
 	let dragging = $state(false);
 	let dragCounter = 0;
 
-	let grouped = $derived(groupTemplatesByCategory(templates));
+	// Group by category and filter out Blank — the primary card above replaces
+	// it. If the templates list ever ships without a `blank` entry we'd still
+	// behave correctly (filter is a no-op).
+	let grouped = $derived(
+		groupTemplatesByCategory(templates).map((g) => ({
+			...g,
+			templates: g.templates.filter((t) => t.name !== 'blank'),
+		})).filter((g) => g.templates.length > 0)
+	);
 
 	$effect(() => {
 		if (uiStore.createWorkspaceOpen) {
 			// Reset state on open
 			mode = 'create';
 			newName = '';
-			selectedTemplate = 'startup';
+			selectedTemplate = 'blank';
+			templatesExpanded = false;
 			importFile = null;
 			importing = false;
 			// Load templates
@@ -43,6 +75,29 @@
 		uiStore.closeCreateWorkspace();
 	}
 
+	function selectBlank() {
+		selectedTemplate = 'blank';
+	}
+
+	function pickTemplate(name: string) {
+		selectedTemplate = name;
+	}
+
+	function toggleTemplates() {
+		templatesExpanded = !templatesExpanded;
+		// First time the user expands the section, pre-select `startup` to
+		// match the pre-IDEA-1516 default behavior — they obviously want a
+		// template if they bothered expanding, and `blank` would still be
+		// selected from the primary card otherwise. We only do this when
+		// the current selection is still `blank` (user hasn't picked yet)
+		// AND startup is actually in the templates list.
+		if (templatesExpanded && selectedTemplate === 'blank') {
+			if (templates.some((t) => t.name === 'startup')) {
+				selectedTemplate = 'startup';
+			}
+		}
+	}
+
 	async function createWorkspace() {
 		if (!newName.trim()) return;
 		try {
@@ -50,6 +105,11 @@
 				name: newName.trim(),
 				template: selectedTemplate || undefined
 			});
+			// Fire the Phase F hook BEFORE close + goto so the consumer can
+			// stage state (e.g. uiStore.requestConnectAfterNavigate) that
+			// the destination route will read on mount. Callback is purely
+			// for side effects — navigation stays our responsibility.
+			onWorkspaceCreated?.(ws);
 			close();
 			goto(`/${ws.owner_username}/${ws.slug}`);
 		} catch {
@@ -63,6 +123,10 @@
 		try {
 			const ws = await api.workspaces.importBundle(importFile, newName.trim() || undefined);
 			await workspaceStore.loadAll();
+			// Same Phase F hook as create — claim code is equally useful for
+			// imported workspaces, and the user explicitly opted into this
+			// modal so opening the Connect modal post-import isn't surprising.
+			onWorkspaceCreated?.(ws);
 			close();
 			toastStore.show(`Imported workspace "${ws.name}"`, 'success');
 			goto(`/${ws.owner_username}/${ws.slug}`);
@@ -150,27 +214,84 @@
 			/>
 
 			{#if mode === 'create'}
-				{#if templates.length > 0}
-					<span class="field-label">Template</span>
-					<div class="template-list">
-						{#each grouped as group (group.category)}
-							<span class="cat-label">{group.label}</span>
-							{#each group.templates as tpl (tpl.name)}
-								<button
-									class="template-card"
-									class:selected={selectedTemplate === tpl.name}
-									onclick={() => (selectedTemplate = tpl.name)}
-								>
-									{#if tpl.icon}
-										<span class="tpl-icon">{tpl.icon}</span>
-									{/if}
-									<span class="tpl-text">
-										<span class="tpl-name">{tpl.name}</span>
-										<span class="tpl-desc">{tpl.collections.join(', ')}</span>
-									</span>
-								</button>
-							{/each}
-						{/each}
+				<!--
+					Primary "Start blank" card — visually selected when
+					selectedTemplate === 'blank'. Clicking it returns to
+					the blank selection from any template pick. Per IDEA-1516
+					§2: agent-driven onboarding is the recommended path.
+				-->
+				<button
+					type="button"
+					class="blank-card"
+					class:selected={selectedTemplate === 'blank'}
+					onclick={selectBlank}
+					aria-pressed={selectedTemplate === 'blank'}
+				>
+					<span class="blank-card-icon" aria-hidden="true">✨</span>
+					<span class="blank-card-text">
+						<span class="blank-card-title">Start blank</span>
+						<span class="blank-card-desc">
+							Recommended. Just conventions and playbooks to start. Your agent
+							will walk you through setting up the rest.
+						</span>
+					</span>
+				</button>
+
+				<!--
+					Templates section — collapsed by default. Header is a
+					button so keyboard users can toggle it; aria-expanded
+					mirrors visual state for AT.
+				-->
+				<button
+					type="button"
+					class="templates-toggle"
+					onclick={toggleTemplates}
+					aria-expanded={templatesExpanded}
+					aria-controls="ws-create-templates"
+				>
+					<span class="templates-toggle-label">Or pick a template</span>
+					<span class="templates-toggle-chevron" class:expanded={templatesExpanded} aria-hidden="true">▾</span>
+				</button>
+
+				{#if templatesExpanded}
+					<div id="ws-create-templates" class="templates-section">
+						{#if loadingTemplates && templates.length === 0}
+							<span class="templates-loading">Loading templates…</span>
+						{:else if grouped.length === 0}
+							<span class="templates-loading">No templates available.</span>
+						{:else}
+							<div class="template-list">
+								{#each grouped as group (group.category)}
+									<span class="cat-label">{group.label}</span>
+									{#each group.templates as tpl (tpl.name)}
+										<button
+											type="button"
+											class="template-card"
+											class:selected={selectedTemplate === tpl.name}
+											onclick={() => pickTemplate(tpl.name)}
+										>
+											{#if tpl.icon}
+												<span class="tpl-icon">{tpl.icon}</span>
+											{/if}
+											<span class="tpl-text">
+												<span class="tpl-name">{tpl.name}</span>
+												<span class="tpl-desc">{tpl.collections.join(', ')}</span>
+											</span>
+										</button>
+									{/each}
+								{/each}
+							</div>
+							<!--
+								Footnote per IDEA-1516 §2 — reminds users that
+								the agent flow still applies even if they
+								picked a template. Mirrors the locked-decisions
+								copy verbatim.
+							-->
+							<p class="templates-footnote">
+								Picked a template? Your agent can still adapt it later — type
+								<code>/pad onboard</code>.
+							</p>
+						{/if}
 					</div>
 				{/if}
 			{:else}
@@ -315,6 +436,104 @@
 	}
 	.modal-body input:focus { outline: none; border-color: var(--accent-blue); }
 
+	/* Primary "Start blank" card — bigger than a template card to anchor it
+	   as the recommended option. Same selection treatment (accent border +
+	   tinted background) for visual consistency with the template grid. */
+	.blank-card {
+		display: flex;
+		flex-direction: row;
+		align-items: flex-start;
+		gap: var(--space-3);
+		padding: var(--space-3) var(--space-4);
+		border-radius: var(--radius);
+		background: var(--bg-tertiary);
+		text-align: left;
+		cursor: pointer;
+		border: 1px solid transparent;
+		transition: border-color 0.1s, background 0.1s;
+		width: 100%;
+		margin-top: var(--space-1);
+	}
+	.blank-card:hover { border-color: var(--border); }
+	.blank-card.selected {
+		border-color: var(--accent-blue);
+		background: color-mix(in srgb, var(--accent-blue) 8%, var(--bg-tertiary));
+	}
+	.blank-card-icon {
+		font-size: 1.4em;
+		line-height: 1.2;
+		flex-shrink: 0;
+	}
+	.blank-card-text {
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+		min-width: 0;
+	}
+	.blank-card-title {
+		font-size: 0.95em;
+		font-weight: 600;
+		color: var(--text-primary);
+	}
+	.blank-card-desc {
+		font-size: 0.82em;
+		color: var(--text-muted);
+		line-height: 1.45;
+	}
+
+	/* Toggle row — flat button with chevron that rotates when expanded. */
+	.templates-toggle {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: var(--space-2);
+		padding: var(--space-2) var(--space-3);
+		background: none;
+		border: 1px solid transparent;
+		border-radius: var(--radius-sm);
+		color: var(--text-secondary);
+		font-size: 0.88em;
+		font-weight: 500;
+		cursor: pointer;
+		text-align: left;
+		width: 100%;
+		transition: color 0.1s, background 0.1s;
+	}
+	.templates-toggle:hover {
+		color: var(--text-primary);
+		background: var(--bg-hover);
+	}
+	.templates-toggle-label { flex: 1; }
+	.templates-toggle-chevron {
+		font-size: 0.9em;
+		color: var(--text-muted);
+		transition: transform 0.15s;
+	}
+	.templates-toggle-chevron.expanded { transform: rotate(180deg); }
+
+	.templates-section {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-2);
+	}
+	.templates-loading {
+		font-size: 0.85em;
+		color: var(--text-muted);
+		padding: var(--space-2) var(--space-3);
+	}
+	.templates-footnote {
+		margin: var(--space-2) 0 0;
+		font-size: 0.8em;
+		color: var(--text-muted);
+		line-height: 1.5;
+	}
+	.templates-footnote code {
+		background: var(--bg-tertiary);
+		padding: 1px 4px;
+		border-radius: var(--radius-sm);
+		font-size: 0.95em;
+	}
+
 	.template-list { display: flex; flex-direction: column; gap: 4px; }
 	.cat-label {
 		font-size: 0.72em;
@@ -400,4 +619,12 @@
 		border: 1px solid var(--border); cursor: pointer;
 	}
 	.cancel-btn:hover { background: var(--bg-hover); color: var(--text-primary); }
+
+	/* Mobile: tighter padding inside the modal so the blank card body and the
+	   expanded template categories don't overflow horizontally at 480px. */
+	@media (max-width: 480px) {
+		.modal-body { padding: var(--space-4); }
+		.blank-card { padding: var(--space-3); }
+		.blank-card-desc { font-size: 0.8em; }
+	}
 </style>

--- a/web/src/lib/stores/ui.svelte.ts
+++ b/web/src/lib/stores/ui.svelte.ts
@@ -10,6 +10,12 @@ let createWorkspaceOpen = $state(false);
 let quickAddRequested = $state(false);
 let quickAddTargetSlug = $state<string | null>(null);
 let collectionSearchHandler = $state<(() => void) | null>(null);
+// Slug of a workspace whose Connect modal should auto-open as soon as the
+// user lands on its workspace page. Set by CreateWorkspaceModal (via
+// +layout.svelte's onWorkspaceCreated wire-up) right before `goto`; consumed
+// by the workspace +page.svelte when its slug matches. Mirrors the
+// request/clear pattern used by quickAdd above. PLAN-1519 / TASK-1526.
+let connectAfterNavigateSlug = $state<string | null>(null);
 
 if (browser) {
 	window.addEventListener('resize', () => {
@@ -76,6 +82,20 @@ export const uiStore = {
 	get quickAddTargetSlug() { return quickAddTargetSlug; },
 	requestQuickAdd(collectionSlug?: string) { quickAddTargetSlug = collectionSlug ?? null; quickAddRequested = true; },
 	clearQuickAddRequest() { quickAddRequested = false; quickAddTargetSlug = null; },
+
+	// Connect-modal auto-open signal (PLAN-1519 / TASK-1526). Fired by
+	// CreateWorkspaceModal after a successful create/import, consumed by
+	// the workspace +page.svelte when the user lands on the matching
+	// workspace. Always read via `consumeConnectAfterNavigate()` so the
+	// signal is single-shot — re-reading the value would leave the request
+	// stuck and reopen the modal on every reactive re-run.
+	get connectAfterNavigateSlug() { return connectAfterNavigateSlug; },
+	requestConnectAfterNavigate(slug: string) { connectAfterNavigateSlug = slug; },
+	consumeConnectAfterNavigate(): string | null {
+		const slug = connectAfterNavigateSlug;
+		connectAfterNavigateSlug = null;
+		return slug;
+	},
 
 	// Collection search (Cmd+F) registry — pages that want to handle Cmd+F
 	// register a handler on mount and unregister on destroy. The layout's

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -239,7 +239,17 @@
 	</div>
 
 	<CommandPalette />
-	<CreateWorkspaceModal />
+	<!--
+		Stage the Connect-modal auto-open signal (PLAN-1519 / TASK-1526)
+		from the post-create/import success path. The modal handles its
+		own goto() so the signal is sitting on uiStore by the time the
+		workspace +page.svelte mounts and consumes it. Import is wired
+		intentionally — claim-code value is independent of how the
+		workspace got created.
+	-->
+	<CreateWorkspaceModal
+		onWorkspaceCreated={(ws) => uiStore.requestConnectAfterNavigate(ws.slug)}
+	/>
 	<ToastContainer />
 	<KeyboardShortcuts visible={showShortcuts} onclose={() => showShortcuts = false} />
 {/if}

--- a/web/src/routes/[username]/[workspace]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/+page.svelte
@@ -82,6 +82,22 @@
 		}
 	});
 
+	// Phase F (PLAN-1519 / TASK-1526): consume the post-create Connect-modal
+	// auto-open signal staged by CreateWorkspaceModal via +layout.svelte.
+	// Kept as its OWN effect per CONVE-606 — entangling it with the
+	// dismissed-state sync (or with the load() effect below) would re-fire
+	// on unrelated reactive churn. The consume helper is single-shot, so
+	// re-runs after a workspace switch are harmless: any non-matching slug
+	// is left in place for the right destination page to pick up.
+	$effect(() => {
+		if (!browser || !wsSlug) return;
+		const requestedSlug = uiStore.connectAfterNavigateSlug;
+		if (requestedSlug && requestedSlug === wsSlug) {
+			uiStore.consumeConnectAfterNavigate();
+			connectOpen = true;
+		}
+	});
+
 	function dismissOnboarding() {
 		onboardingDismissed = true;
 		if (browser) localStorage.setItem(`pad-onboarding-dismissed-${wsSlug}`, 'true');


### PR DESCRIPTION
## Summary

Combines IDEA-1516 Phase 1 (CreateWorkspaceModal redesign — [[TASK-1528]]) with PLAN-1519 Phase F (Connect-modal auto-open wiring — [[TASK-1526]]). Phase 1's callback API and Phase F's consumer are the same integration surface, so they ship together to stay PR-sized.

**Phase 1 — modal redesign**
- Default selection: `startup` → `blank`
- New primary "Start blank" card per IDEA-1516 §2
- Templates section collapsed by default; expanding pre-selects `startup` so users who explicitly want a template still land on the pre-redesign default
- Existing grouped categories preserved inside the section, Blank filtered out
- Footnote pointing at `/pad onboard`
- Optional `onWorkspaceCreated` callback prop fired after successful create OR import, before close+goto

**Phase F — auto-open wiring**
- `uiStore.requestConnectAfterNavigate(slug)` + single-shot `consumeConnectAfterNavigate()` (mirrors `requestQuickAdd` / `clearQuickAddRequest`)
- `+layout.svelte` wires the modal callback to the new uiStore setter
- Workspace `+page.svelte` consumes the signal in a dedicated effect (kept separate per CONVE-606) and opens the already-mounted `ConnectWorkspaceModal` when the slug matches
- Import flow gets the same treatment — claim-code value is independent of how the workspace got created

No backend changes; Phase E ([[TASK-1525]]) already shipped the claim-code generation + smart suppression that the auto-opened modal renders.

## Context

Implements [[TASK-1528]] and [[TASK-1526]] under [[PLAN-1519]] (IDEA-1517 sequencing). Three handoffs, each focused on one thing: create workspace → connect agent → onboard. Phase 1 unblocks Phase F, so combining them eliminates a coordination step.

## Test plan

- [x] `cd web && npm run build` — clean
- [x] `make install` — clean (binary rebuilt + restarted)
- [x] `go test ./...` — clean (all packages pass)
- [x] svelte-autofixer on all edited files — zero issues; only pre-existing pattern suggestions
- [ ] Manual: open New Workspace modal, confirm Blank pre-selected, expand templates, pick Startup, create → Connect modal opens on the new workspace page
- [ ] Manual: Import a workspace bundle, confirm Connect modal auto-opens post-import
- [ ] Manual: 480px / 768px / desktop visual check on the redesigned modal