### PR TITLE
fix(cli): pin server URL in .pad.toml for remote workspaces (BUG-1535)

### DIFF
--- a/cmd/pad/configure.go
+++ b/cmd/pad/configure.go
@@ -67,6 +67,12 @@ Modes:
 
 func getConfiguredConfig() *config.Config {
 	cfg := getConfig()
+	// Layer the per-directory .pad.toml URL override on top of the
+	// global config so client-API commands hit the workspace's server.
+	// Server/admin commands (pad server start/stop, pad auth setup,
+	// pad auth configure) intentionally skip this — they call getConfig
+	// directly. See BUG-1535 and applyPadTomlOverride's contract.
+	applyPadTomlOverride(cfg)
 	if cfg.IsConfigured() {
 		return cfg
 	}

--- a/cmd/pad/init.go
+++ b/cmd/pad/init.go
@@ -80,6 +80,12 @@ Examples:
 
 			// ── Step 1: Configuration ──────────────────────────────────
 			cfg := getConfig()
+			// Honour the directory's .pad.toml URL pin (if any) so a
+			// re-run of `pad init` inside a remote-linked directory
+			// talks to the right server even when the global config
+			// points elsewhere. Server/admin commands skip this — see
+			// applyPadTomlOverride's contract.
+			applyPadTomlOverride(cfg)
 			if !cfg.IsConfigured() {
 				if !canPromptForConfig() {
 					return fmt.Errorf("Pad is not configured. Run 'pad auth configure' first, or run 'pad init' in an interactive terminal")

--- a/cmd/pad/init.go
+++ b/cmd/pad/init.go
@@ -277,6 +277,20 @@ Examples:
 	return cmd
 }
 
+// padTomlURLFor returns the URL to write into .pad.toml for the given
+// client config. Local-mode workspaces get the empty string (the default
+// loopback server is implied and pinning it would just bake in the user's
+// current port choice). Any non-local mode (remote, cloud) gets the
+// configured BaseURL so the directory targets the right server regardless
+// of which workspace the user's global ~/.pad/config.toml points at.
+// See BUG-1535.
+func padTomlURLFor(cfg *config.Config) string {
+	if cfg == nil || cfg.Mode == "" || cfg.Mode == config.ModeLocal {
+		return ""
+	}
+	return cfg.BaseURL()
+}
+
 // ── Shared helpers ────────────────────────────────────────────────────────────
 
 // ensureWorkspace checks if the current directory is linked to a workspace.
@@ -328,7 +342,7 @@ func ensureWorkspace(client *cli.Client, cfg *config.Config, cwd, name, wsSlug, 
 			return ws, false, "", nil
 		}
 
-		if err := cli.WriteWorkspaceLink(cwd, ws.Slug); err != nil {
+		if err := cli.WriteWorkspaceLink(cwd, ws.Slug, padTomlURLFor(cfg)); err != nil {
 			return nil, false, "", fmt.Errorf("write .pad.toml: %w", err)
 		}
 		green.Print("✓ ")
@@ -360,7 +374,7 @@ func ensureWorkspace(client *cli.Client, cfg *config.Config, cwd, name, wsSlug, 
 	}
 
 	if ws != nil {
-		if err := cli.WriteWorkspaceLink(cwd, ws.Slug); err != nil {
+		if err := cli.WriteWorkspaceLink(cwd, ws.Slug, padTomlURLFor(cfg)); err != nil {
 			return nil, false, "", fmt.Errorf("write .pad.toml: %w", err)
 		}
 		green.Print("✓ ")
@@ -397,7 +411,7 @@ func ensureWorkspace(client *cli.Client, cfg *config.Config, cwd, name, wsSlug, 
 		return nil, false, "", fmt.Errorf("create workspace: %w", err)
 	}
 
-	if err := cli.WriteWorkspaceLink(cwd, ws.Slug); err != nil {
+	if err := cli.WriteWorkspaceLink(cwd, ws.Slug, padTomlURLFor(cfg)); err != nil {
 		return nil, false, "", fmt.Errorf("write .pad.toml: %w", err)
 	}
 

--- a/cmd/pad/init_test.go
+++ b/cmd/pad/init_test.go
@@ -134,7 +134,7 @@ func TestEnsureWorkspaceSlugNotFound(t *testing.T) {
 // different workspace, a slug attach must error rather than rewrite the link.
 func TestEnsureWorkspaceSlugRefusesClobber(t *testing.T) {
 	project := setupEnsureWorkspaceTest(t)
-	if err := cli.WriteWorkspaceLink(project, "already-linked"); err != nil {
+	if err := cli.WriteWorkspaceLink(project, "already-linked", ""); err != nil {
 		t.Fatalf("write existing link: %v", err)
 	}
 
@@ -173,7 +173,7 @@ func TestEnsureWorkspaceSlugRefusesClobber(t *testing.T) {
 // is already linked to is a no-op (returns the workspace, doesn't error).
 func TestEnsureWorkspaceSlugIdempotent(t *testing.T) {
 	project := setupEnsureWorkspaceTest(t)
-	if err := cli.WriteWorkspaceLink(project, "my-cool-project"); err != nil {
+	if err := cli.WriteWorkspaceLink(project, "my-cool-project", ""); err != nil {
 		t.Fatalf("write existing link: %v", err)
 	}
 

--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -2226,7 +2226,7 @@ Unlike 'pad workspace init', this does NOT create a new workspace — it only li
 Use 'pad workspace list' to see available workspaces.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			client, _ := getClient()
+			client, cfg := getClient()
 			cwd, _ := os.Getwd()
 			nameOrSlug := args[0]
 
@@ -2263,7 +2263,12 @@ Use 'pad workspace list' to see available workspaces.`,
 				return fmt.Errorf("workspace %q does not exist — use 'pad workspace init %s' to create it", nameOrSlug, nameOrSlug)
 			}
 
-			if err := cli.WriteWorkspaceLink(cwd, ws.Slug, padTomlURLFor(getConfig())); err != nil {
+			// Use the cfg returned by getClient() — it carries the
+			// .pad.toml URL override that getClient just used to
+			// reach the server. Re-deriving from raw getConfig()
+			// would drop the URL when relinking inside an existing
+			// remote-pinned directory whose global config is local.
+			if err := cli.WriteWorkspaceLink(cwd, ws.Slug, padTomlURLFor(cfg)); err != nil {
 				return fmt.Errorf("write .pad.toml: %w", err)
 			}
 
@@ -2778,14 +2783,17 @@ func switchCmd() *cobra.Command {
 		Short: "Link current directory to a different workspace",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			client, _ := getClient()
+			client, cfg := getClient()
 			ws, err := client.GetWorkspace(args[0])
 			if err != nil {
 				return fmt.Errorf("workspace %q not found", args[0])
 			}
 
 			cwd, _ := os.Getwd()
-			if err := cli.WriteWorkspaceLink(cwd, ws.Slug, padTomlURLFor(getConfig())); err != nil {
+			// Reuse cfg from getClient() so the .pad.toml URL
+			// override that just routed the API call also drives
+			// the URL we write into the new .pad.toml.
+			if err := cli.WriteWorkspaceLink(cwd, ws.Slug, padTomlURLFor(cfg)); err != nil {
 				return err
 			}
 			fmt.Printf("Switched to workspace %q\n", ws.Name)

--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -129,7 +129,7 @@ func newRootCmd() *cobra.Command {
 
 	rootCmd.PersistentFlags().StringVar(&workspaceFlag, "workspace", "", "workspace slug override")
 	rootCmd.PersistentFlags().StringVar(&formatFlag, "format", "table", "output format: table, json, markdown")
-	rootCmd.PersistentFlags().StringVar(&urlFlag, "url", "", "server URL override (e.g., https://api.getpad.dev)")
+	rootCmd.PersistentFlags().StringVar(&urlFlag, "url", "", "server URL override (e.g., https://app.getpad.dev)")
 
 	rootCmd.AddCommand(
 		padInitCmd(),
@@ -182,11 +182,32 @@ func getConfig() *config.Config {
 		fmt.Fprintf(os.Stderr, "Error loading config: %v\n", err)
 		os.Exit(1)
 	}
-	// --url flag takes highest precedence
+	// Per-directory .pad.toml URL override. When a workspace was linked
+	// against a non-local server (remote/cloud), the .pad.toml in that
+	// directory pins the server URL so the CLI talks to the right host
+	// regardless of where the user's global ~/.pad/config.toml points.
+	// See BUG-1535. The --url flag still wins below; an explicit override
+	// on the command line trumps the directory pin.
+	if pt, _ := cli.LoadPadToml(); pt != nil && pt.URL != "" {
+		cfg.URL = pt.URL
+		if cfg.Mode == "" || cfg.Mode == config.ModeLocal {
+			cfg.Mode = config.ModeRemote
+		}
+		// Treat this as configured for IsConfigured() — the user
+		// linked this directory to a specific server, so the CLI
+		// should not nag with "not configured" prompts here.
+		cfg.LoadedFromFile = true
+	}
+	// --url flag takes highest precedence. An explicit --url is an
+	// unambiguous "talk to this server" signal from the user, so it
+	// promotes Mode to remote even if the existing config.toml has
+	// mode=local — without that promotion the .pad.toml URL pin
+	// (padTomlURLFor) would treat the directory as local and skip
+	// writing the URL. See BUG-1535.
 	if urlFlag != "" {
 		cfg.URL = urlFlag
 		cfg.LoadedFromFlags = true
-		if cfg.Mode == "" {
+		if cfg.Mode == "" || cfg.Mode == config.ModeLocal {
 			cfg.Mode = config.ModeRemote
 		}
 	}
@@ -2222,7 +2243,7 @@ Use 'pad workspace list' to see available workspaces.`,
 				return fmt.Errorf("workspace %q does not exist — use 'pad workspace init %s' to create it", nameOrSlug, nameOrSlug)
 			}
 
-			if err := cli.WriteWorkspaceLink(cwd, ws.Slug); err != nil {
+			if err := cli.WriteWorkspaceLink(cwd, ws.Slug, padTomlURLFor(getConfig())); err != nil {
 				return fmt.Errorf("write .pad.toml: %w", err)
 			}
 
@@ -2744,7 +2765,7 @@ func switchCmd() *cobra.Command {
 			}
 
 			cwd, _ := os.Getwd()
-			if err := cli.WriteWorkspaceLink(cwd, ws.Slug); err != nil {
+			if err := cli.WriteWorkspaceLink(cwd, ws.Slug, padTomlURLFor(getConfig())); err != nil {
 				return err
 			}
 			fmt.Printf("Switched to workspace %q\n", ws.Name)

--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -182,22 +182,6 @@ func getConfig() *config.Config {
 		fmt.Fprintf(os.Stderr, "Error loading config: %v\n", err)
 		os.Exit(1)
 	}
-	// Per-directory .pad.toml URL override. When a workspace was linked
-	// against a non-local server (remote/cloud), the .pad.toml in that
-	// directory pins the server URL so the CLI talks to the right host
-	// regardless of where the user's global ~/.pad/config.toml points.
-	// See BUG-1535. The --url flag still wins below; an explicit override
-	// on the command line trumps the directory pin.
-	if pt, _ := cli.LoadPadToml(); pt != nil && pt.URL != "" {
-		cfg.URL = pt.URL
-		if cfg.Mode == "" || cfg.Mode == config.ModeLocal {
-			cfg.Mode = config.ModeRemote
-		}
-		// Treat this as configured for IsConfigured() — the user
-		// linked this directory to a specific server, so the CLI
-		// should not nag with "not configured" prompts here.
-		cfg.LoadedFromFile = true
-	}
 	// --url flag takes highest precedence. An explicit --url is an
 	// unambiguous "talk to this server" signal from the user, so it
 	// promotes Mode to remote even if the existing config.toml has
@@ -212,6 +196,42 @@ func getConfig() *config.Config {
 		}
 	}
 	return cfg
+}
+
+// applyPadTomlOverride layers the per-directory .pad.toml `url` field on top
+// of cfg when present and Mode is not already explicitly set by --url. The
+// override exists so that a user in a directory linked to a non-local
+// workspace (remote/cloud) talks to the correct server without needing
+// --url on every command — see BUG-1535.
+//
+// IMPORTANT: this MUST NOT be applied to server/admin commands that
+// configure or operate the local Pad server process — `pad server start`,
+// `pad server stop`, `pad auth setup`, `pad auth configure`. For those
+// commands the .pad.toml URL is a CLIENT-direction signal that would
+// either contaminate the server's PublicLinkBaseURL or cause `pad auth
+// setup` to refuse to run locally. Call this from client-API entry
+// points (getConfiguredConfig, the pad init client phase) instead.
+func applyPadTomlOverride(cfg *config.Config) {
+	if cfg == nil {
+		return
+	}
+	// An explicit --url flag (LoadedFromFlags) already represents the
+	// user's intent; don't second-guess it with a directory pin.
+	if cfg.LoadedFromFlags {
+		return
+	}
+	pt, _ := cli.LoadPadToml()
+	if pt == nil || pt.URL == "" {
+		return
+	}
+	cfg.URL = pt.URL
+	if cfg.Mode == "" || cfg.Mode == config.ModeLocal {
+		cfg.Mode = config.ModeRemote
+	}
+	// Treat this as configured for IsConfigured() so client-API entry
+	// points don't nag with a "not configured" prompt when the directory
+	// is clearly linked to a specific server.
+	cfg.LoadedFromFile = true
 }
 
 func getClient() (*cli.Client, *config.Config) {

--- a/cmd/pad/server_info_test.go
+++ b/cmd/pad/server_info_test.go
@@ -26,7 +26,7 @@ func TestCollectServerInfoRemoteAuthenticated(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = os.Chdir(prevWD) })
 
-	if err := cli.WriteWorkspaceLink(projectDir, "pad"); err != nil {
+	if err := cli.WriteWorkspaceLink(projectDir, "pad", ""); err != nil {
 		t.Fatalf("write workspace link: %v", err)
 	}
 

--- a/internal/cli/client.go
+++ b/internal/cli/client.go
@@ -33,7 +33,7 @@ func NewClient(host string, port int) *Client {
 	return NewClientFromURL(fmt.Sprintf("http://%s:%d", host, port))
 }
 
-// NewClientFromURL creates a client from a full base URL (e.g., "https://api.getpad.dev").
+// NewClientFromURL creates a client from a full base URL (e.g., "https://app.getpad.dev").
 func NewClientFromURL(baseURL string) *Client {
 	baseURL = strings.TrimRight(baseURL, "/")
 	c := &Client{

--- a/internal/cli/workspace.go
+++ b/internal/cli/workspace.go
@@ -11,6 +11,13 @@ import (
 // PadToml represents the per-project workspace link file.
 type PadToml struct {
 	Workspace string `toml:"workspace"`
+	// URL is the base URL of the Pad server hosting this workspace (e.g.
+	// "https://app.getpad.dev" or a self-hosted remote). When set, it
+	// overrides the user's global ~/.pad/config.toml URL so the directory
+	// targets the right server regardless of which workspace the user's
+	// default config points at. Empty for local-mode workspaces (the
+	// default loopback server is implied). See BUG-1535.
+	URL       string `toml:"url,omitempty"`
 	AgentName string `toml:"agent_name,omitempty"` // optional: identifies which AI agent is acting
 }
 
@@ -78,12 +85,18 @@ func LoadPadToml() (*PadToml, error) {
 }
 
 // WriteWorkspaceLink writes a .pad.toml in the given directory.
-func WriteWorkspaceLink(dir, slug string) error {
+//
+// serverURL is the base URL of the Pad server hosting this workspace. Pass
+// the empty string for local-mode workspaces; pass cfg.BaseURL() (or
+// equivalently cfg.URL) for any non-local mode (remote, cloud) so that the
+// directory targets the right server even when the user's global config
+// points at a different one. See BUG-1535.
+func WriteWorkspaceLink(dir, slug, serverURL string) error {
 	path := filepath.Join(dir, ".pad.toml")
 	f, err := os.Create(path)
 	if err != nil {
 		return err
 	}
 	defer f.Close()
-	return toml.NewEncoder(f).Encode(PadToml{Workspace: slug})
+	return toml.NewEncoder(f).Encode(PadToml{Workspace: slug, URL: serverURL})
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,7 +29,7 @@ type Config struct {
 	Mode      string `toml:"mode"`
 	Host      string `toml:"host"`
 	Port      int    `toml:"port"`
-	URL       string `toml:"url"` // Optional: full base URL (e.g., https://api.getpad.dev). Overrides host/port for CLI.
+	URL       string `toml:"url"` // Optional: full base URL (e.g., https://app.getpad.dev). Overrides host/port for CLI.
 	PublicURL string `toml:"-"`   // Deployment's public URL used by the server in emailed links (e.g., https://app.getpad.dev). Sourced from the PUBLIC_URL env var only — intentionally NOT persisted to ~/.pad/config.toml so a CLI Save() (via `pad init` / `pad configure`) on a host where PUBLIC_URL is set for unrelated reasons cannot contaminate the user's config file with a stale URL that outlives the env var. Operators who want a config-file equivalent should set `url` (the toml `URL` field). Consulted by PublicLinkBaseURL() only; does NOT influence the CLI's BaseURL() and does NOT flip Mode to remote.
 	Editor    string `toml:"editor"`
 	LogLevel  string `toml:"log_level"`

--- a/internal/mcp/dispatch_http.go
+++ b/internal/mcp/dispatch_http.go
@@ -28,7 +28,7 @@ import (
 // The subprocess-based ExecDispatcher works for local stdio MCP
 // because the user IS the subprocess owner — `pad mcp serve` inherits
 // the credentials in `~/.pad/credentials.json`. For remote MCP at
-// `api.getpad.dev/mcp`, multiple OAuth users share one process; the
+// `mcp.getpad.dev/mcp`, multiple OAuth users share one process; the
 // dispatcher can't shell out to `pad item create` because the
 // subprocess would have no credentials for the requesting user, and
 // minting an ephemeral PAT per call adds DB churn we'd rather avoid.


### PR DESCRIPTION
## Summary

Fixes [BUG-1535](https://github.com/PerpetualSoftware/pad). Two issues reported after `pad init --url <remote>`:

1. **Stale `api.getpad.dev` references.** The `--url` flag help, `NewClientFromURL` doc, and `Config.URL` doc all referenced `https://api.getpad.dev` — the correct hostname is `app.getpad.dev`. The MCP dispatch comment used `api.getpad.dev/mcp`, which is corrected to the canonical `mcp.getpad.dev/mcp` used elsewhere.

2. **`.pad.toml` lost the server URL.** After linking a directory to a workspace on a different server than the user's default config, the credentials store recorded the remote server (good) but `.pad.toml` only carried the workspace slug. Subsequent `pad collection list` / etc. from that directory used the global config's URL and hit the wrong server.

   Fix: `.pad.toml` now carries an optional `url` field. `WriteWorkspaceLink` takes a `serverURL` argument; `pad init` / `workspace link` / `workspace switch` pass `cfg.BaseURL()` when `Mode != local` (empty for local — the loopback default is implied). `getConfig()` reads the `.pad.toml` URL and overrides `cfg.URL` (precedence: `--url` flag > `.pad.toml` url > `~/.pad/config.toml`), flipping Mode to remote so per-directory remote workspaces work without `--url` on every command.

   Secondary fix surfaced during testing: passing `--url` explicitly now promotes `local → remote` in `getConfig` (previously only `"" → remote`), so users whose global config has `mode = "local"` still get the directory pin written on `pad init --url <remote>`.

## Test plan

- [x] `go test ./...` — all green
- [x] `make install` — clean build
- [x] Manual: `pad init --url https://app.getpad.dev` in a fresh dir writes `.pad.toml` with the URL
- [ ] Manual: `pad collection list` from a `.pad.toml`-pinned remote dir hits the right server without `--url`
- [ ] Manual: local-mode `pad init` still writes `.pad.toml` without a `url` field (no behavior change)