### PR TITLE
feat(cli): add --sort-order flag to pad item update (BUG-1536)

### DIFF
--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -3441,6 +3441,7 @@ func updateCmd() *cobra.Command {
 		fieldFlags []string
 		comment    string
 		force      bool
+		sortOrder  int
 	)
 
 	cmd := &cobra.Command{
@@ -3471,6 +3472,17 @@ Examples:
 
 			if title != "" {
 				input.Title = &title
+			}
+
+			// --sort-order sets the top-level items.sort_order column.
+			// Don't accept negative values — sort_order is an ascending
+			// rank, and the drag handler in ChildItems.svelte assumes
+			// non-negative indices.
+			if cmd.Flags().Changed("sort-order") {
+				if sortOrder < 0 {
+					return fmt.Errorf("--sort-order must be >= 0")
+				}
+				input.SortOrder = &sortOrder
 			}
 
 			// Handle content
@@ -3625,6 +3637,7 @@ Examples:
 	cmd.Flags().StringVar(&category, "category", "", "update category field")
 	cmd.Flags().StringVar(&tags, "tags", "", "update tags (JSON array)")
 	cmd.Flags().StringArrayVarP(&fieldFlags, "field", "f", nil, "set arbitrary field (repeatable): --field key=value")
+	cmd.Flags().IntVar(&sortOrder, "sort-order", 0, "set the item's sort_order rank (lower appears first; used by child lists and drag-reorder)")
 	cmd.Flags().StringVar(&comment, "comment", "", "attach a comment explaining this update (e.g. why status changed)")
 	cmd.Flags().BoolVar(&force, "force", false, "override the open-children guard (allow marking the item terminal even if children are non-terminal)")
 


### PR DESCRIPTION
## Summary

Fixes [BUG-1536](https://github.com/PerpetualSoftware/pad). The agent-driven attempt to reorder children with `pad item update TASK-N --field sort_order=K` was silently writing into the per-collection `fields` JSON blob instead of the top-level `items.sort_order` column, so the parent view's `ORDER BY i.sort_order ASC, i.created_at ASC` only ever saw default zeros and rendered children in creation (numerical) order.

Add a first-class `--sort-order int` flag on `pad item update` so it shows up in `pad item update --help` and agents discover the correct path.

The existing `--field` route is intentionally left alone — top-level item columns and per-collection schema fields share a namespace by accident, and silently rerouting one key without the others would be more surprising than the current behavior.

Follow-up [TASK-1537](https://github.com/PerpetualSoftware/pad) tracks discoverability for the existing drag-and-drop reorder on the parent view (`ChildItems.svelte` already wires this up via `svelte-dnd-action`).

## Test plan

- [x] `pad item update --help` shows the new flag
- [x] `pad item update BUG-1536 --sort-order 1` writes `items.sort_order = 1` and leaves the `fields` blob untouched
- [x] Negative values rejected
- [x] `go test ./cmd/pad/` green; `make install` clean