### PR TITLE
fix(web): surface open_children 409 + offer force override (BUG-1538)

### DIFF
--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -670,15 +670,32 @@ export const api = {
 				method: 'POST'
 			}),
 
-		move: (ws: string, slug: string, targetCollection: string, fieldOverrides?: Record<string, any>) =>
-			request<Item>(`/workspaces/${ws}/items/${slug}/move`, {
-				method: 'POST',
-				body: JSON.stringify({
-					target_collection: targetCollection,
-					field_overrides: fieldOverrides,
-					source: 'web'
-				})
-			}),
+		/**
+		 * Move an item to a different collection. The server applies
+		 * the same open-children guard the PATCH path uses (IDEA-1494)
+		 * — pass `force: true` to override when moving a parent whose
+		 * current done-field value would land terminal in the target
+		 * collection. Mirrors the CLI's `--force` and the server's
+		 * `?force=true` query param on POST /move.
+		 */
+		move: (
+			ws: string,
+			slug: string,
+			targetCollection: string,
+			fieldOverrides?: Record<string, any>,
+			opts?: { force?: boolean }
+		) =>
+			request<Item>(
+				`/workspaces/${ws}/items/${slug}/move${opts?.force ? '?force=true' : ''}`,
+				{
+					method: 'POST',
+					body: JSON.stringify({
+						target_collection: targetCollection,
+						field_overrides: fieldOverrides,
+						source: 'web'
+					})
+				}
+			),
 
 		/** Get child items linked to a parent item */
 		children: (ws: string, slug: string) =>

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -62,9 +62,19 @@ const BASE = '/api/v1';
 
 class PadApiError extends Error {
 	code: string;
+	/**
+	 * Structured details for error codes that carry recovery
+	 * information. Shape varies by code; call sites branching on
+	 * `code` cast to the matching payload. The canonical consumer
+	 * today is `open_children` (IDEA-1494 / BUG-1538), whose details
+	 * carry `{ open_children, hidden_blocker_count, done_field,
+	 * attempted_value }`. Undefined for codes that don't supply it.
+	 */
+	details?: Record<string, unknown>;
 	constructor(err: ApiError) {
 		super(err.message);
 		this.code = err.code;
+		this.details = err.details;
 	}
 }
 

--- a/web/src/lib/components/OpenChildrenDialog.svelte
+++ b/web/src/lib/components/OpenChildrenDialog.svelte
@@ -1,0 +1,346 @@
+<script lang="ts">
+	// BUG-1538 / TASK-1539 — Confirm dialog that surfaces the server's
+	// `open_children` 409 guard (IDEA-1494) in the web UI. Mounted once
+	// from +layout.svelte; driven by the openChildrenDialog singleton
+	// store so call sites just `await openChildrenDialog.request(...)`
+	// and don't render any dialog markup themselves.
+	//
+	// The modal mirrors EditCollectionModal's overlay+modal pattern
+	// (.overlay backdrop / .modal box / Escape closes) so it looks like
+	// the rest of the app's modals without pulling in a heavy dialog
+	// abstraction. Child items render as inline links to their detail
+	// pages — the whole point is helping the user see WHY the move was
+	// blocked and either resolve the children or force-override.
+
+	import { page } from '$app/state';
+	import { openChildrenDialog } from '$lib/stores/openChildrenDialog.svelte';
+
+	let active = $derived(openChildrenDialog.active);
+
+	function onCancel() {
+		openChildrenDialog.cancel();
+	}
+
+	function onConfirm() {
+		openChildrenDialog.confirm();
+	}
+
+	function onKeydown(e: KeyboardEvent) {
+		if (!active) return;
+		if (e.key === 'Escape') {
+			e.preventDefault();
+			onCancel();
+		} else if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+			e.preventDefault();
+			onConfirm();
+		}
+	}
+
+	// Item URLs are /[username]/[workspace]/[collection]/[slug]. The
+	// dialog is global so we pull both segments from page.params rather
+	// than threading them through. Matches the TableView / roles page
+	// pattern (the canonical href shape elsewhere in the app).
+	let username = $derived(page.params.username || '');
+	let workspaceSlug = $derived(page.params.workspace || '');
+	let canLink = $derived(!!username && !!workspaceSlug);
+
+	function childHref(refOrSlug: string, collection: string): string {
+		return `/${username}/${workspaceSlug}/${collection}/${refOrSlug}`;
+	}
+</script>
+
+<svelte:window onkeydown={onKeydown} />
+
+{#if active}
+	<!-- svelte-ignore a11y_click_events_have_key_events -->
+	<!-- svelte-ignore a11y_no_static_element_interactions -->
+	<div
+		class="overlay"
+		onclick={onCancel}
+		role="dialog"
+		aria-modal="true"
+		aria-labelledby="open-children-title"
+		tabindex="-1"
+	>
+		<div class="modal" onclick={(e) => e.stopPropagation()}>
+			<div class="modal-header">
+				<h2 id="open-children-title">Children still open</h2>
+				<button class="close-btn" type="button" onclick={onCancel} aria-label="Cancel"
+					>&#10005;</button
+				>
+			</div>
+
+			<div class="modal-body">
+				<p class="lead">
+					Cannot mark <strong>{active.parentRef}</strong>
+					<code>{active.details.attempted_value}</code> while child items are still in a
+					non-terminal state.
+				</p>
+
+				{#if active.details.open_children.length > 0}
+					<div class="child-section">
+						<div class="section-label">
+							{active.details.open_children.length} blocking
+							{active.details.open_children.length === 1 ? 'child' : 'children'}:
+						</div>
+						<ul class="child-list">
+							{#each active.details.open_children as child (child.ref)}
+								<li class="child-row">
+									{#if canLink}
+										<a
+											class="child-ref"
+											href={childHref(child.ref, child.collection_slug)}
+											target="_blank"
+											rel="noopener"
+										>
+											{child.ref}
+										</a>
+									{:else}
+										<span class="child-ref">{child.ref}</span>
+									{/if}
+									<span class="child-title">{child.title}</span>
+									<span class="child-status">{child.status}</span>
+								</li>
+							{/each}
+						</ul>
+					</div>
+				{/if}
+
+				{#if active.details.hidden_blocker_count > 0}
+					<div class="hidden-note">
+						Plus <strong>{active.details.hidden_blocker_count}</strong> additional
+						{active.details.hidden_blocker_count === 1 ? 'child' : 'children'} you don't have access
+						to.
+					</div>
+				{/if}
+
+				<div class="explainer">
+					Close those items first, or override the guard to mark
+					<strong>{active.parentRef}</strong> terminal anyway.
+				</div>
+			</div>
+
+			<div class="modal-footer">
+				<button type="button" class="btn btn-secondary" onclick={onCancel}>Cancel</button>
+				<button type="button" class="btn btn-danger" onclick={onConfirm}>
+					Override and mark {active.details.attempted_value}
+				</button>
+			</div>
+		</div>
+	</div>
+{/if}
+
+<style>
+	.overlay {
+		position: fixed;
+		inset: 0;
+		background: rgba(0, 0, 0, 0.5);
+		z-index: 60;
+		display: flex;
+		justify-content: center;
+		align-items: flex-start;
+		padding: 12vh var(--space-4) var(--space-4);
+		animation: overlay-in 140ms ease-out;
+	}
+
+	.modal {
+		width: 100%;
+		max-width: 540px;
+		background: var(--bg-secondary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius-lg);
+		box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
+		display: flex;
+		flex-direction: column;
+		max-height: 75vh;
+		animation: modal-in 160ms ease-out;
+	}
+
+	@keyframes overlay-in {
+		from { opacity: 0; }
+		to { opacity: 1; }
+	}
+	@keyframes modal-in {
+		from { transform: translateY(8px); opacity: 0; }
+		to { transform: translateY(0); opacity: 1; }
+	}
+	@media (prefers-reduced-motion: reduce) {
+		.overlay, .modal { animation: none; }
+	}
+
+	.modal-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: var(--space-4) var(--space-6);
+		flex-shrink: 0;
+		border-bottom: 1px solid var(--border);
+	}
+
+	.modal-header h2 {
+		margin: 0;
+		font-size: 1.05em;
+		font-weight: 600;
+	}
+
+	.close-btn {
+		background: none;
+		border: 0;
+		font-size: 1em;
+		color: var(--text-secondary);
+		cursor: pointer;
+		padding: var(--space-1) var(--space-2);
+		border-radius: var(--radius-sm);
+	}
+	.close-btn:hover {
+		background: var(--bg-tertiary);
+		color: var(--text-primary);
+	}
+
+	.modal-body {
+		flex: 1;
+		overflow-y: auto;
+		padding: var(--space-5) var(--space-6);
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-4);
+		min-height: 0;
+	}
+
+	.lead {
+		margin: 0;
+		color: var(--text-primary);
+		line-height: 1.5;
+	}
+
+	.lead code {
+		background: var(--bg-tertiary);
+		padding: 0 var(--space-1);
+		border-radius: var(--radius-sm);
+		font-size: 0.9em;
+	}
+
+	.section-label {
+		font-size: 0.85em;
+		color: var(--text-secondary);
+		margin-bottom: var(--space-2);
+	}
+
+	.child-list {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-2);
+		border: 1px solid var(--border);
+		border-radius: var(--radius-md);
+		background: var(--bg-tertiary);
+	}
+
+	.child-row {
+		display: flex;
+		align-items: baseline;
+		gap: var(--space-3);
+		padding: var(--space-2) var(--space-3);
+		border-bottom: 1px solid var(--border);
+	}
+	.child-row:last-child {
+		border-bottom: 0;
+	}
+
+	.child-ref {
+		font-family: var(--font-mono, ui-monospace, monospace);
+		font-size: 0.85em;
+		color: var(--accent, var(--text-primary));
+		text-decoration: none;
+		white-space: nowrap;
+		font-weight: 600;
+	}
+	.child-ref:hover {
+		text-decoration: underline;
+	}
+
+	.child-title {
+		flex: 1;
+		color: var(--text-primary);
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.child-status {
+		font-size: 0.8em;
+		color: var(--text-secondary);
+		background: var(--bg-secondary);
+		padding: 2px var(--space-2);
+		border-radius: var(--radius-sm);
+		white-space: nowrap;
+	}
+
+	.hidden-note {
+		font-size: 0.9em;
+		color: var(--text-secondary);
+		background: var(--bg-tertiary);
+		padding: var(--space-2) var(--space-3);
+		border-radius: var(--radius-md);
+	}
+
+	.explainer {
+		font-size: 0.9em;
+		color: var(--text-secondary);
+		line-height: 1.5;
+	}
+
+	.modal-footer {
+		display: flex;
+		justify-content: flex-end;
+		gap: var(--space-2);
+		padding: var(--space-4) var(--space-6);
+		border-top: 1px solid var(--border);
+		flex-shrink: 0;
+	}
+
+	.btn {
+		padding: var(--space-2) var(--space-4);
+		border-radius: var(--radius-md);
+		font-size: 0.9em;
+		font-weight: 500;
+		cursor: pointer;
+		border: 1px solid transparent;
+	}
+
+	.btn-secondary {
+		background: var(--bg-tertiary);
+		color: var(--text-primary);
+		border-color: var(--border);
+	}
+	.btn-secondary:hover {
+		background: var(--bg-secondary);
+	}
+
+	.btn-danger {
+		background: var(--color-danger, #dc2626);
+		color: white;
+	}
+	.btn-danger:hover {
+		filter: brightness(1.08);
+	}
+
+	@media (max-width: 600px) {
+		.overlay {
+			padding: var(--space-3);
+			align-items: stretch;
+		}
+		.modal {
+			max-width: 100%;
+			max-height: calc(100vh - var(--space-6));
+		}
+		.modal-header,
+		.modal-body,
+		.modal-footer {
+			padding-left: var(--space-4);
+			padding-right: var(--space-4);
+		}
+	}
+</style>

--- a/web/src/lib/components/OpenChildrenDialog.svelte
+++ b/web/src/lib/components/OpenChildrenDialog.svelte
@@ -16,6 +16,25 @@
 	import { openChildrenDialog } from '$lib/stores/openChildrenDialog.svelte';
 
 	let active = $derived(openChildrenDialog.active);
+	let cancelBtn: HTMLButtonElement | undefined = $state();
+	let modalEl: HTMLDivElement | undefined = $state();
+	let previouslyFocused: HTMLElement | null = null;
+
+	// On open: remember whatever had focus so we can restore it on
+	// close, then move focus to the safe action (Cancel) — keyboard
+	// users land on a defined target and the destructive "Override"
+	// action stays one Tab away. On close: restore the original focus
+	// so the user lands back where they were (drag handle, status
+	// dropdown, etc.).
+	$effect(() => {
+		if (active) {
+			previouslyFocused = (document.activeElement as HTMLElement) ?? null;
+			cancelBtn?.focus();
+		} else if (previouslyFocused) {
+			previouslyFocused.focus();
+			previouslyFocused = null;
+		}
+	});
 
 	function onCancel() {
 		openChildrenDialog.cancel();
@@ -25,15 +44,47 @@
 		openChildrenDialog.confirm();
 	}
 
+	// Focus trap. While the dialog is open, Tab / Shift-Tab cycle
+	// between the focusable elements WITHIN the modal — anything
+	// outside is off-limits until the user cancels or confirms.
+	// Cheap implementation: collect focusable descendants on each
+	// Tab press (modal contents are small + static while open) and
+	// wrap selection at the ends.
+	function trapTab(e: KeyboardEvent) {
+		if (!active || e.key !== 'Tab' || !modalEl) return;
+		const nodes = modalEl.querySelectorAll<HTMLElement>(
+			'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"]), input, select, textarea'
+		);
+		if (nodes.length === 0) return;
+		const first = nodes[0];
+		const last = nodes[nodes.length - 1];
+		const current = document.activeElement as HTMLElement | null;
+		if (e.shiftKey && current === first) {
+			e.preventDefault();
+			last.focus();
+		} else if (!e.shiftKey && current === last) {
+			e.preventDefault();
+			first.focus();
+		} else if (current && !modalEl.contains(current)) {
+			// Focus escaped (e.g. via programmatic blur) — re-anchor.
+			e.preventDefault();
+			first.focus();
+		}
+	}
+
 	function onKeydown(e: KeyboardEvent) {
 		if (!active) return;
 		if (e.key === 'Escape') {
 			e.preventDefault();
 			onCancel();
-		} else if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+			return;
+		}
+		if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
 			e.preventDefault();
 			onConfirm();
+			return;
 		}
+		trapTab(e);
 	}
 
 	// Item URLs are /[username]/[workspace]/[collection]/[slug]. The
@@ -62,7 +113,7 @@
 		aria-labelledby="open-children-title"
 		tabindex="-1"
 	>
-		<div class="modal" onclick={(e) => e.stopPropagation()}>
+		<div class="modal" bind:this={modalEl} onclick={(e) => e.stopPropagation()}>
 			<div class="modal-header">
 				<h2 id="open-children-title">Children still open</h2>
 				<button class="close-btn" type="button" onclick={onCancel} aria-label="Cancel"
@@ -121,7 +172,12 @@
 			</div>
 
 			<div class="modal-footer">
-				<button type="button" class="btn btn-secondary" onclick={onCancel}>Cancel</button>
+				<button
+					bind:this={cancelBtn}
+					type="button"
+					class="btn btn-secondary"
+					onclick={onCancel}>Cancel</button
+				>
 				<button type="button" class="btn btn-danger" onclick={onConfirm}>
 					Override and mark {active.details.attempted_value}
 				</button>

--- a/web/src/lib/items/openChildrenError.ts
+++ b/web/src/lib/items/openChildrenError.ts
@@ -1,0 +1,128 @@
+// BUG-1538 / TASK-1539 — Surface the server's `open_children` 409
+// guard (IDEA-1494) in the web UI so users can see WHY a status change
+// to a terminal value was rejected and decide whether to force.
+//
+// Server contract (see internal/server/handlers_items_open_children_guard.go):
+//   HTTP 409 { error: { code: "open_children", message, details: {
+//     open_children: [{ ref, title, status, collection_slug }],
+//     hidden_blocker_count: number,
+//     done_field: string,
+//     attempted_value: string,
+//   }}}
+//
+// The CLI exposes a `--force` flag for the same override. The web
+// equivalent is `ItemUpdate.force = true` on the PATCH body
+// (transport-only field consumed by the handler).
+//
+// This helper is the single place call sites delegate to when an
+// item-PATCH catches an error. If the error is `open_children`, it
+// prompts the user with a structured confirm and retries with
+// force=true on confirmation. Returns the freshly-updated item on
+// success (so callers can mirror their normal success path), or
+// `null` when the user cancelled or the error was something else.
+// On non-open_children errors it re-throws so the caller's existing
+// error handling (toast, etc.) still fires.
+//
+// The prompt itself is rendered by the singleton <OpenChildrenDialog />
+// mounted at the app shell. This helper publishes the request to the
+// `openChildrenDialog` store and awaits the user's response; call sites
+// remain dialog-free.
+
+import { PadApiError } from '$lib/api/client';
+import { openChildrenDialog } from '$lib/stores/openChildrenDialog.svelte';
+
+export interface OpenChildEntry {
+	ref: string;
+	title: string;
+	status: string;
+	collection_slug: string;
+}
+
+export interface OpenChildrenDetails {
+	open_children: OpenChildEntry[];
+	hidden_blocker_count: number;
+	done_field: string;
+	attempted_value: string;
+}
+
+/**
+ * Type-narrowing predicate. Returns true when `err` is a
+ * `PadApiError` carrying the `open_children` code with a usable
+ * details payload.
+ */
+export function isOpenChildrenError(
+	err: unknown
+): err is PadApiError & { details: OpenChildrenDetails } {
+	if (!(err instanceof PadApiError)) return false;
+	if (err.code !== 'open_children') return false;
+	const d = err.details as Partial<OpenChildrenDetails> | undefined;
+	return !!d && Array.isArray(d.open_children) && typeof d.hidden_blocker_count === 'number';
+}
+
+/**
+ * Build the human-readable confirm message from a parsed details
+ * payload. Mirrors the CLI's phrasing in `writeOpenChildrenError`
+ * (server-side) for consistency.
+ *
+ * `parentRef` is the parent item's issue ref (e.g. "BUG-1536"). Pass
+ * `item.ref || item.slug` from the call site.
+ */
+export function formatOpenChildrenPrompt(parentRef: string, d: OpenChildrenDetails): string {
+	const visible = d.open_children.length;
+	const hidden = d.hidden_blocker_count;
+	const lines: string[] = [];
+	if (visible > 0 && hidden > 0) {
+		lines.push(
+			`Cannot mark ${parentRef} ${d.attempted_value}: ${visible} open child${
+				visible === 1 ? '' : 'ren'
+			} still in a non-terminal state, plus ${hidden} additional you don't have access to.`
+		);
+	} else if (visible > 0) {
+		lines.push(
+			`Cannot mark ${parentRef} ${d.attempted_value}: ${visible} open child${
+				visible === 1 ? '' : 'ren'
+			} still in a non-terminal state.`
+		);
+	} else {
+		lines.push(
+			`Cannot mark ${parentRef} ${d.attempted_value}: blocked by ${hidden} open child${
+				hidden === 1 ? '' : 'ren'
+			} you don't have access to.`
+		);
+	}
+	if (visible > 0) {
+		lines.push('');
+		lines.push('Blocking children:');
+		for (const c of d.open_children) {
+			lines.push(`  • ${c.ref} — ${c.title} (${c.status})`);
+		}
+	}
+	lines.push('');
+	lines.push('Override the guard and mark it anyway?');
+	return lines.join('\n');
+}
+
+/**
+ * Confirm-and-retry helper. Call sites pass:
+ *   - `err`: the caught error from the original PATCH
+ *   - `parentRef`: the item's issue ref for the prompt
+ *   - `retryWithForce`: a callback that re-issues the same PATCH with
+ *     `force: true` and returns the updated entity
+ *
+ * Returns the updated entity on confirm+success, `null` when the
+ * error was open_children but the user cancelled, and re-throws for
+ * any other error so the caller's existing toast/log path runs.
+ *
+ * Kept generic over `T` so call sites that get back a richer view
+ * (e.g. the detail-page `Item`) preserve their type.
+ */
+export async function confirmOpenChildrenOrThrow<T>(
+	err: unknown,
+	parentRef: string,
+	retryWithForce: () => Promise<T>
+): Promise<T | null> {
+	if (!isOpenChildrenError(err)) throw err;
+	const proceed = await openChildrenDialog.request(parentRef, err.details);
+	if (!proceed) return null;
+	return await retryWithForce();
+}

--- a/web/src/lib/stores/openChildrenDialog.svelte.ts
+++ b/web/src/lib/stores/openChildrenDialog.svelte.ts
@@ -1,0 +1,69 @@
+// BUG-1538 / TASK-1539 — Singleton state for the open-children-guard
+// confirm dialog. Mounted once in +layout.svelte via
+// <OpenChildrenDialog />; producer code (the API error helper) calls
+// `openChildrenDialog.request(...)` to surface a modal and awaits the
+// user's choice. Decoupling the producer from the renderer keeps call
+// sites in collection/detail pages free of dialog markup.
+//
+// The store enforces a single in-flight prompt — concurrent calls
+// queue. In practice an item PATCH only fires one at a time per user
+// action, so this matters mostly for the BoardView drag-drop case
+// where a quick second drop could fire before the first confirm
+// resolves; queueing avoids dropping the second prompt on the floor.
+
+import type { OpenChildrenDetails } from '$lib/items/openChildrenError';
+
+interface PendingRequest {
+	parentRef: string;
+	details: OpenChildrenDetails;
+	resolve: (confirmed: boolean) => void;
+}
+
+let active = $state<PendingRequest | null>(null);
+const queue: PendingRequest[] = [];
+
+function advanceQueue(): void {
+	active = queue.shift() ?? null;
+}
+
+/**
+ * Surface the confirm dialog. Resolves true when the user clicks
+ * "Override anyway", false when they cancel (button click, backdrop
+ * click, or Escape).
+ *
+ * Multiple concurrent requests serialize — the second waits until
+ * the first resolves before showing.
+ */
+function request(parentRef: string, details: OpenChildrenDetails): Promise<boolean> {
+	return new Promise<boolean>((resolve) => {
+		const entry: PendingRequest = { parentRef, details, resolve };
+		if (active === null) {
+			active = entry;
+		} else {
+			queue.push(entry);
+		}
+	});
+}
+
+function confirm(): void {
+	const a = active;
+	if (!a) return;
+	a.resolve(true);
+	advanceQueue();
+}
+
+function cancel(): void {
+	const a = active;
+	if (!a) return;
+	a.resolve(false);
+	advanceQueue();
+}
+
+export const openChildrenDialog = {
+	get active(): PendingRequest | null {
+		return active;
+	},
+	request,
+	confirm,
+	cancel
+};

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -554,6 +554,14 @@ export interface ItemUpdate {
 	last_modified_by?: string;
 	source?: string;
 	comment?: string;
+	/**
+	 * When true, overrides the server-side open-children guard (IDEA-1494)
+	 * that otherwise rejects non-terminal → terminal done-field transitions
+	 * while the item still has non-terminal children. Mirror of the
+	 * CLI's `--force` flag and `models.ItemUpdate.Force` server-side.
+	 * BUG-1538 / TASK-1539.
+	 */
+	force?: boolean;
 }
 
 // ─── Versions ────────────────────────────────────────────────────────────────
@@ -876,6 +884,14 @@ export interface PlaybookLibraryResponse {
 export interface ApiError {
 	code: string;
 	message: string;
+	/**
+	 * Optional structured details supplied by the server for codes that
+	 * carry recovery information. Shape varies by code — e.g.
+	 * `open_children` (IDEA-1494) returns
+	 * `{ open_children: [...], hidden_blocker_count: N, done_field, attempted_value }`.
+	 * Consumers branching on `code` cast this to the matching shape.
+	 */
+	details?: Record<string, unknown>;
 }
 
 // ─── Admin Billing Stats (PLAN-825) ──────────────────────────────────────────

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -14,6 +14,7 @@
 	import CommandPalette from '$lib/components/search/CommandPalette.svelte';
 	import ToastContainer from '$lib/components/common/ToastContainer.svelte';
 	import CreateWorkspaceModal from '$lib/components/layout/CreateWorkspaceModal.svelte';
+	import OpenChildrenDialog from '$lib/components/OpenChildrenDialog.svelte';
 	import { isMod, isInputFocused } from '$lib/utils/keyboard';
 	import KeyboardShortcuts from '$lib/components/common/KeyboardShortcuts.svelte';
 
@@ -201,6 +202,7 @@
 		onWorkspaceCreated={(ws) => uiStore.requestConnectAfterNavigate(ws.slug)}
 	/>
 	<ToastContainer />
+	<OpenChildrenDialog />
 {:else}
 	{#if uiStore.isMobile}
 		<!--
@@ -265,6 +267,7 @@
 		onWorkspaceCreated={(ws) => uiStore.requestConnectAfterNavigate(ws.slug)}
 	/>
 	<ToastContainer />
+	<OpenChildrenDialog />
 	<KeyboardShortcuts visible={showShortcuts} onclose={() => showShortcuts = false} />
 {/if}
 

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -24,7 +24,7 @@
 	import { localIndex } from '$lib/stores/localIndex.svelte';
 	import { localSearch, parseSearchQuery } from '$lib/stores/localSearch.svelte';
 	import { createScrollRestoration } from '$lib/scroll/restore.svelte';
-	import { confirmOpenChildrenOrThrow } from '$lib/items/openChildrenError';
+	import { confirmOpenChildrenOrThrow, isOpenChildrenError } from '$lib/items/openChildrenError';
 
 	type ViewMode = 'list' | 'board' | 'table';
 
@@ -781,38 +781,38 @@
 			// BUG-1538 / TASK-1539: the server's open-children guard
 			// (IDEA-1494) returns a structured 409 when transitioning a
 			// parent to a terminal status while it still has open
-			// children. Offer the user the same `--force` override the
-			// CLI has, then retry on confirm. confirmOpenChildrenOrThrow
-			// re-throws non-open_children errors to the catch tail.
-			try {
-				const forced = await confirmOpenChildrenOrThrow(e, parentRef, () => doUpdate(true));
+			// children. Branch on the error shape so a USER cancel of
+			// the modal doesn't get logged as an "update failure" and
+			// the toast/log noise matches user intent.
+			if (isOpenChildrenError(e)) {
+				let forced;
+				try {
+					forced = await confirmOpenChildrenOrThrow(e, parentRef, () => doUpdate(true));
+				} catch (retryErr) {
+					// The retry-with-force itself failed (network /
+					// 500 / fresh validation error). Surface that
+					// distinctly from the original guard.
+					const msg = retryErr instanceof Error ? retryErr.message : 'Failed to update status';
+					console.error('Forced status update failed:', retryErr);
+					toastStore.show(msg, 'error');
+					throw retryErr;
+				}
 				if (forced) {
 					localIndex.upsert(ws, forced);
 					toastStore.show(`Moved to ${formatLabel(newValue)}`, 'success');
 					return;
 				}
-				// User cancelled the override; surface a quiet info toast
-				// so it's clear nothing happened, then signal the caller
-				// (BoardView) that the move did not persist.
+				// User cancelled the override. Quiet info toast — this
+				// is an intentional no-op, not a failure. Re-throw so
+				// the BoardView drag-handler can unwind its optimistic
+				// reorder.
 				toastStore.show('Status change cancelled', 'info');
 				throw e;
-			} catch (inner) {
-				if (inner !== e) {
-					// Inner error is the retry's failure, not the original
-					// guard. Surface its message if we have one.
-					const msg = inner instanceof Error ? inner.message : 'Failed to update status';
-					console.error('Forced status update failed:', inner);
-					toastStore.show(msg, 'error');
-					throw inner;
-				}
-				console.error('Failed to update item:', e);
-				// Only show the generic toast when we DIDN'T already show
-				// the open-children-cancelled info toast above.
-				if (!(e instanceof PadApiError) || e.code !== 'open_children') {
-					toastStore.show('Failed to update status', 'error');
-				}
-				throw e; // Re-throw so BoardView knows the move failed
 			}
+			// Any other failure mode — network, validation, 500, etc.
+			console.error('Failed to update item:', e);
+			toastStore.show('Failed to update status', 'error');
+			throw e; // Re-throw so BoardView knows the move failed
 		}
 	}
 

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -3,7 +3,7 @@
 	import { goto } from '$app/navigation';
 	import { api, PadApiError } from '$lib/api/client';
 	import type { Collection, Item, QuickAction, View, ViewConfig } from '$lib/types';
-	import { parseSettings, parseFields, parseSchema, getStatusOptions, itemUrlId } from '$lib/types';
+	import { parseSettings, parseFields, parseSchema, getStatusOptions, itemUrlId, formatItemRef } from '$lib/types';
 	import BoardView from '$lib/components/collections/BoardView.svelte';
 	import ListView from '$lib/components/collections/ListView.svelte';
 	import TableView from '$lib/components/collections/TableView.svelte';
@@ -24,6 +24,7 @@
 	import { localIndex } from '$lib/stores/localIndex.svelte';
 	import { localSearch, parseSearchQuery } from '$lib/stores/localSearch.svelte';
 	import { createScrollRestoration } from '$lib/scroll/restore.svelte';
+	import { confirmOpenChildrenOrThrow } from '$lib/items/openChildrenError';
 
 	type ViewMode = 'list' | 'board' | 'table';
 
@@ -763,18 +764,55 @@
 		if (!wsSlug) return;
 		const fields = parseFields(item);
 		fields[groupField] = newValue;
+		const fieldsPayload = JSON.stringify(fields);
+		const ws = wsSlug;
+		const parentRef = formatItemRef(item) ?? item.slug;
+
+		const doUpdate = (force: boolean) =>
+			api.items.update(ws, item.id, { fields: fieldsPayload, ...(force ? { force: true } : {}) });
+
 		try {
-			const updated = await api.items.update(wsSlug, item.id, {
-				fields: JSON.stringify(fields)
-			});
+			const updated = await doUpdate(false);
 			// Push the canonical post-update row into the local index;
 			// the `items` derived view re-renders automatically.
-			localIndex.upsert(wsSlug, updated);
+			localIndex.upsert(ws, updated);
 			toastStore.show(`Moved to ${formatLabel(newValue)}`, 'success');
 		} catch (e) {
-			console.error('Failed to update item:', e);
-			toastStore.show('Failed to update status', 'error');
-			throw e; // Re-throw so BoardView knows the move failed
+			// BUG-1538 / TASK-1539: the server's open-children guard
+			// (IDEA-1494) returns a structured 409 when transitioning a
+			// parent to a terminal status while it still has open
+			// children. Offer the user the same `--force` override the
+			// CLI has, then retry on confirm. confirmOpenChildrenOrThrow
+			// re-throws non-open_children errors to the catch tail.
+			try {
+				const forced = await confirmOpenChildrenOrThrow(e, parentRef, () => doUpdate(true));
+				if (forced) {
+					localIndex.upsert(ws, forced);
+					toastStore.show(`Moved to ${formatLabel(newValue)}`, 'success');
+					return;
+				}
+				// User cancelled the override; surface a quiet info toast
+				// so it's clear nothing happened, then signal the caller
+				// (BoardView) that the move did not persist.
+				toastStore.show('Status change cancelled', 'info');
+				throw e;
+			} catch (inner) {
+				if (inner !== e) {
+					// Inner error is the retry's failure, not the original
+					// guard. Surface its message if we have one.
+					const msg = inner instanceof Error ? inner.message : 'Failed to update status';
+					console.error('Forced status update failed:', inner);
+					toastStore.show(msg, 'error');
+					throw inner;
+				}
+				console.error('Failed to update item:', e);
+				// Only show the generic toast when we DIDN'T already show
+				// the open-children-cancelled info toast above.
+				if (!(e instanceof PadApiError) || e.code !== 'open_children') {
+					toastStore.show('Failed to update status', 'error');
+				}
+				throw e; // Re-throw so BoardView knows the move failed
+			}
 		}
 	}
 

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
 	import { page } from '$app/state';
 	import { tick, onMount, onDestroy } from 'svelte';
-	import { api, type ImportURLResponse } from '$lib/api/client';
+	import { api, PadApiError, type ImportURLResponse } from '$lib/api/client';
+	import { confirmOpenChildrenOrThrow } from '$lib/items/openChildrenError';
 	import { marked } from 'marked';
 	import { collectionStore } from '$lib/stores/collections.svelte';
 	import { syncService } from '$lib/services/sync.svelte';
@@ -1043,13 +1044,55 @@
 	async function updateField(key: string, value: any) {
 		if (!item) return;
 		const updated = { ...fields, [key]: value };
+		const payload = JSON.stringify(updated);
+		const targetItem = item;
+		const targetWs = wsSlug;
 		saveStatus = 'saving';
+
+		const doUpdate = (force: boolean) =>
+			api.items.update(targetWs, targetItem.id, {
+				fields: payload,
+				...(force ? { force: true } : {})
+			});
+
 		try {
-			item = await api.items.update(wsSlug, item.id, { fields: JSON.stringify(updated) });
+			const fresh = await doUpdate(false);
+			if (item && item.id === targetItem.id) item = fresh;
 			showSaved();
-		} catch {
-			saveStatus = 'idle';
-			toastStore.show('Failed to save', 'error');
+		} catch (e) {
+			// BUG-1538 / TASK-1539: same open-children-guard recovery
+			// path as the collection page's handleStatusChange. When the
+			// user is editing the done-field (status) inline on the
+			// detail page, surface the structured 409 and offer to
+			// force-override instead of toasting a vague "Failed to
+			// save".
+			const parentRef = formatItemRef(targetItem) ?? targetItem.slug;
+			try {
+				const forced = await confirmOpenChildrenOrThrow(e, parentRef, () => doUpdate(true));
+				if (forced) {
+					if (item && item.id === targetItem.id) item = forced;
+					showSaved();
+					return;
+				}
+				// User declined to override. Snap the on-page field back
+				// to its prior value by leaving `item.fields` untouched
+				// and dropping the in-flight save indicator.
+				saveStatus = 'idle';
+				toastStore.show('Status change cancelled', 'info');
+			} catch (inner) {
+				saveStatus = 'idle';
+				if (inner !== e) {
+					const msg = inner instanceof Error ? inner.message : 'Failed to save';
+					console.error('Forced field update failed:', inner);
+					toastStore.show(msg, 'error');
+				} else {
+					// Re-thrown original (non-open_children) error.
+					if (!(e instanceof PadApiError) || e.code !== 'open_children') {
+						console.error('Failed to save field:', e);
+						toastStore.show('Failed to save', 'error');
+					}
+				}
+			}
 		}
 	}
 

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -1916,16 +1916,32 @@
 		if (!item || moving) return;
 		moving = true;
 		showMoveMenu = false;
-		// Capture identity so an in-flight modal-decision doesn't apply
-		// to a navigation that happened in the meantime.
+		// Capture FULL route identity (workspace, username, source
+		// slug, source item id, parent ref) at the moment the user
+		// kicked off the move. If the user navigates while the
+		// open-children modal is up, we don't want a confirmed force
+		// retry to fire against the new route's workspace — that
+		// could move the wrong item (Codex review round 2 P1).
+		const sourceItem = item;
 		const sourceSlug = item.slug;
-		const parentRef = formatItemRef(item) ?? item.slug;
+		const sourceWs = wsSlug;
+		const sourceUsername = username;
+		const parentRef = formatItemRef(sourceItem) ?? sourceItem.slug;
 		const doMove = (force: boolean) =>
-			api.items.move(wsSlug, sourceSlug, targetSlug, undefined, force ? { force: true } : undefined);
+			api.items.move(sourceWs, sourceSlug, targetSlug, undefined, force ? { force: true } : undefined);
+		// After the modal resolves, only honor the success path's
+		// navigation/toast if the page still represents the same item.
+		// On a stale match we keep the move silent rather than yanking
+		// the user away from whatever they navigated to.
+		const navIfStillCurrent = (toSlug: string) => {
+			if (item && item.id === sourceItem.id && wsSlug === sourceWs && username === sourceUsername) {
+				goto(`/${sourceUsername}/${sourceWs}/${targetSlug}/${toSlug}`, { replaceState: true });
+			}
+		};
 		try {
 			const moved = await doMove(false);
 			toastStore.show(`Moved to ${targetSlug}`, 'success');
-			goto(`/${username}/${wsSlug}/${targetSlug}/${moved.slug}`, { replaceState: true });
+			navIfStillCurrent(moved.slug);
 		} catch (e: any) {
 			// BUG-1538 / Codex review round 1: the server's
 			// open-children guard also fires on POST /move when the
@@ -1943,7 +1959,7 @@
 				}
 				if (forced) {
 					toastStore.show(`Moved to ${targetSlug}`, 'success');
-					goto(`/${username}/${wsSlug}/${targetSlug}/${forced.slug}`, { replaceState: true });
+					navIfStillCurrent(forced.slug);
 				} else {
 					toastStore.show('Move cancelled', 'info');
 				}

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -2,7 +2,7 @@
 	import { page } from '$app/state';
 	import { tick, onMount, onDestroy } from 'svelte';
 	import { api, PadApiError, type ImportURLResponse } from '$lib/api/client';
-	import { confirmOpenChildrenOrThrow } from '$lib/items/openChildrenError';
+	import { confirmOpenChildrenOrThrow, isOpenChildrenError } from '$lib/items/openChildrenError';
 	import { marked } from 'marked';
 	import { collectionStore } from '$lib/stores/collections.svelte';
 	import { syncService } from '$lib/services/sync.svelte';
@@ -1066,9 +1066,20 @@
 			// detail page, surface the structured 409 and offer to
 			// force-override instead of toasting a vague "Failed to
 			// save".
-			const parentRef = formatItemRef(targetItem) ?? targetItem.slug;
-			try {
-				const forced = await confirmOpenChildrenOrThrow(e, parentRef, () => doUpdate(true));
+			if (isOpenChildrenError(e)) {
+				const parentRef = formatItemRef(targetItem) ?? targetItem.slug;
+				let forced;
+				try {
+					forced = await confirmOpenChildrenOrThrow(e, parentRef, () => doUpdate(true));
+				} catch (retryErr) {
+					// The force retry itself failed (network / 500 /
+					// fresh validation error after the override).
+					saveStatus = 'idle';
+					const msg = retryErr instanceof Error ? retryErr.message : 'Failed to save';
+					console.error('Forced field update failed:', retryErr);
+					toastStore.show(msg, 'error');
+					return;
+				}
 				if (forced) {
 					if (item && item.id === targetItem.id) item = forced;
 					showSaved();
@@ -1076,23 +1087,19 @@
 				}
 				// User declined to override. Snap the on-page field back
 				// to its prior value by leaving `item.fields` untouched
-				// and dropping the in-flight save indicator.
+				// (FieldEditor re-renders from `value` prop) and drop
+				// the in-flight save indicator. Force `item` to a fresh
+				// reference so child components re-prop unambiguously
+				// even if they cache by identity.
 				saveStatus = 'idle';
+				if (item && item.id === targetItem.id) item = { ...item };
 				toastStore.show('Status change cancelled', 'info');
-			} catch (inner) {
-				saveStatus = 'idle';
-				if (inner !== e) {
-					const msg = inner instanceof Error ? inner.message : 'Failed to save';
-					console.error('Forced field update failed:', inner);
-					toastStore.show(msg, 'error');
-				} else {
-					// Re-thrown original (non-open_children) error.
-					if (!(e instanceof PadApiError) || e.code !== 'open_children') {
-						console.error('Failed to save field:', e);
-						toastStore.show('Failed to save', 'error');
-					}
-				}
+				return;
 			}
+			// Any other failure mode — network, validation, 500, etc.
+			saveStatus = 'idle';
+			console.error('Failed to save field:', e);
+			toastStore.show('Failed to save', 'error');
 		}
 	}
 
@@ -1909,11 +1916,39 @@
 		if (!item || moving) return;
 		moving = true;
 		showMoveMenu = false;
+		// Capture identity so an in-flight modal-decision doesn't apply
+		// to a navigation that happened in the meantime.
+		const sourceSlug = item.slug;
+		const parentRef = formatItemRef(item) ?? item.slug;
+		const doMove = (force: boolean) =>
+			api.items.move(wsSlug, sourceSlug, targetSlug, undefined, force ? { force: true } : undefined);
 		try {
-			const moved = await api.items.move(wsSlug, item.slug, targetSlug);
+			const moved = await doMove(false);
 			toastStore.show(`Moved to ${targetSlug}`, 'success');
 			goto(`/${username}/${wsSlug}/${targetSlug}/${moved.slug}`, { replaceState: true });
 		} catch (e: any) {
+			// BUG-1538 / Codex review round 1: the server's
+			// open-children guard also fires on POST /move when the
+			// move would land the parent terminal in the target
+			// collection. Wire the same modal + ?force=true override
+			// path used for PATCH status changes.
+			if (isOpenChildrenError(e)) {
+				let forced;
+				try {
+					forced = await confirmOpenChildrenOrThrow(e, parentRef, () => doMove(true));
+				} catch (retryErr: any) {
+					console.error('Forced move failed:', retryErr);
+					toastStore.show(retryErr?.message ?? 'Failed to move item', 'error');
+					return; // outer finally still resets `moving`
+				}
+				if (forced) {
+					toastStore.show(`Moved to ${targetSlug}`, 'success');
+					goto(`/${username}/${wsSlug}/${targetSlug}/${forced.slug}`, { replaceState: true });
+				} else {
+					toastStore.show('Move cancelled', 'info');
+				}
+				return;
+			}
 			toastStore.show(e.message ?? 'Failed to move item', 'error');
 		} finally {
 			moving = false;

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -1926,15 +1926,28 @@
 		const sourceSlug = item.slug;
 		const sourceWs = wsSlug;
 		const sourceUsername = username;
+		const sourceCollSlug = collSlug;
+		const sourceItemSlug = itemSlug;
 		const parentRef = formatItemRef(sourceItem) ?? sourceItem.slug;
 		const doMove = (force: boolean) =>
 			api.items.move(sourceWs, sourceSlug, targetSlug, undefined, force ? { force: true } : undefined);
 		// After the modal resolves, only honor the success path's
-		// navigation/toast if the page still represents the same item.
-		// On a stale match we keep the move silent rather than yanking
-		// the user away from whatever they navigated to.
+		// navigation/toast if the page is STILL on the source item.
+		// We check both `item.id` (cheap object-identity guard) AND
+		// the route params (page.params.{username,workspace,
+		// collection,slug}) — during same-component navigation `item`
+		// can briefly still hold the old object while the URL has
+		// already advanced. Comparing both closes that race
+		// (Codex review round 3 P1). Stale resolutions complete
+		// silently rather than yanking the user back.
 		const navIfStillCurrent = (toSlug: string) => {
-			if (item && item.id === sourceItem.id && wsSlug === sourceWs && username === sourceUsername) {
+			const itemStillCurrent = item && item.id === sourceItem.id;
+			const routeStillCurrent =
+				wsSlug === sourceWs &&
+				username === sourceUsername &&
+				collSlug === sourceCollSlug &&
+				itemSlug === sourceItemSlug;
+			if (itemStillCurrent && routeStillCurrent) {
 				goto(`/${sourceUsername}/${sourceWs}/${targetSlug}/${toSlug}`, { replaceState: true });
 			}
 		};


### PR DESCRIPTION
## Summary

- The server's open-children guard (IDEA-1494) returns a structured 409 when transitioning a parent to a terminal status while it still has non-terminal children. The web UI was catching this generically and toasting *"Failed to update status"* — users couldn't tell why or that `--force` exists.
- A singleton `<OpenChildrenDialog />` (mounted at `+layout.svelte`, driven by `openChildrenDialog` store with a promise-based `request()`) now lists the blocking children as links, surfaces `hidden_blocker_count`, and offers an "Override and mark `<value>`" button that retries the PATCH with `force: true` — same semantics as the CLI's `--force`.
- Wired into the two PATCH sites that touch the done-field: `handleStatusChange` (collection page — covers Board drag-drop + inline status changes) and `updateField` (detail page FieldEditor).

## Files

- `web/src/lib/types/index.ts` — `ApiError.details?`, `ItemUpdate.force?` mirror the server contract.
- `web/src/lib/api/client.ts` — `PadApiError` carries `details` through to call sites.
- `web/src/lib/items/openChildrenError.ts` *(new)* — `isOpenChildrenError`, `formatOpenChildrenPrompt`, `confirmOpenChildrenOrThrow` helper that handles detect / prompt / retry-with-force.
- `web/src/lib/stores/openChildrenDialog.svelte.ts` *(new)* — singleton state with promise-based `request()` and a queue for concurrent prompts.
- `web/src/lib/components/OpenChildrenDialog.svelte` *(new)* — modal mirroring EditCollectionModal's overlay+modal pattern; Escape cancels, ⌘/Ctrl+Enter confirms.
- `web/src/routes/+layout.svelte` — mounts the dialog next to ToastContainer in console + main shell branches.
- `web/src/routes/[username]/[workspace]/[collection]/+page.svelte` — `handleStatusChange` integration.
- `web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte` — `updateField` integration.

## Test plan

- [ ] Repro pre-fix: parent with open child → terminal status via dropdown → confirm the OLD behavior of vague "Failed to update status" toast no longer fires.
- [ ] Detail-page status dropdown on a parent with open children → modal appears listing children + hidden count → Cancel → field snaps back, info toast "Status change cancelled".
- [ ] Same flow → Override anyway → PATCH retries with `force: true` → success toast, item moves to terminal status.
- [ ] Board view drag-drop onto a terminal column on a parent with open children → same modal → confirm/cancel both work; cancelled drop re-syncs.
- [ ] Modal accessibility: Escape closes, ⌘/Ctrl+Enter confirms, backdrop click cancels, child-ref links open the right item URL in a new tab.
- [ ] Non-409 errors (network drop, validation, 500) still surface as a generic error toast — no regression.
- [ ] No regressions on terminal → terminal or no-op status updates (guard shouldn't fire).
- [ ] svelte-check clean; `go test ./internal/server/ -run OpenChildren` green.

## Related

- BUG-1538 (bug report), TASK-1539 (implementation task)
- Server guard: `internal/server/handlers_items_open_children_guard.go`
- IDEA-1494 (original guard design)