### PR TITLE
feat(store): add users.last_write_at column + write-path hook (TASK-1543)

### DIFF
--- a/internal/server/handlers_attachments.go
+++ b/internal/server/handlers_attachments.go
@@ -254,6 +254,11 @@ func (s *Server) handleUploadAttachment(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	// Uploads count as user writes for engagement-metric purposes (PLAN-1542
+	// / TASK-1543). Attachments don't go through logActivity, so the hook is
+	// explicit here. Throttled + no-ops on empty userID.
+	s.store.TouchUserWrite(r.Context(), currentUserID(r))
+
 	// Bump the storage-usage cache so the next GET sees fresh used_bytes
 	// without waiting for TTL expiry. Done eagerly here (and after each
 	// thumbnail derivation / transform) so the Settings → Storage UI

--- a/internal/server/handlers_comments.go
+++ b/internal/server/handlers_comments.go
@@ -232,6 +232,12 @@ func (s *Server) handleCreateReply(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Comment replies don't go through logActivity (no "commented" activity
+	// row is emitted for replies — see handleCreateComment for the non-reply
+	// path that does). Bump last_write_at explicitly so engagement metrics
+	// reflect reply authorship too (PLAN-1542 / TASK-1543).
+	s.store.TouchUserWrite(r.Context(), currentUserID(r))
+
 	// Resolve the item's collection slug for SSE filtering
 	replyCollSlug := ""
 	if replyItem, err := s.store.GetItem(parentComment.ItemID); err == nil && replyItem != nil {

--- a/internal/server/handlers_documents.go
+++ b/internal/server/handlers_documents.go
@@ -308,17 +308,24 @@ func (s *Server) logActivityWithMeta(workspaceID, documentID, action string, r *
 func (s *Server) logActivityWithMetaReturningID(workspaceID, documentID, action string, r *http.Request, metadata string) (string, error) {
 	actor, source := actorFromRequest(r)
 	metadata = agentMeta(r, metadata)
-	return s.store.CreateActivityDebounced(models.Activity{
+	uid := currentUserID(r)
+	id, err := s.store.CreateActivityDebounced(models.Activity{
 		WorkspaceID: workspaceID,
 		DocumentID:  documentID,
 		Action:      action,
 		Actor:       actor,
 		Source:      source,
 		Metadata:    metadata,
-		UserID:      currentUserID(r),
+		UserID:      uid,
 		IPAddress:   clientIP(r),
 		UserAgent:   r.Header.Get("User-Agent"),
 	})
+	// Bump last_write_at on the actor. Every action that flows through this
+	// helper (created/updated/archived/restored/moved/commented) is a write.
+	// PLAN-1542 / TASK-1543. TouchUserWrite is throttled + no-ops on empty
+	// userID, so we can call unconditionally.
+	s.store.TouchUserWrite(r.Context(), uid)
+	return id, err
 }
 
 // logAuditEvent logs a non-workspace audit event (e.g. login, logout).

--- a/internal/store/migrations/060_user_last_write_at.sql
+++ b/internal/store/migrations/060_user_last_write_at.sql
@@ -1,0 +1,29 @@
+-- Migration 060: per-user last-write timestamp (PLAN-1542 / TASK-1543).
+--
+-- Adds a dedicated `last_write_at` column on `users` so admin engagement
+-- metrics can distinguish active writers from passive readers. The existing
+-- `last_active_at` column is bumped on any authenticated request (throttled
+-- by TouchUserActivity), so it can't tell us whether the user actually
+-- created or modified anything.
+--
+-- The hook (TouchUserWrite + handler-layer call sites) is wired in the same
+-- task; this migration is the data-layer half.
+--
+-- Backfill draws from the existing `activities` table — the canonical record
+-- of who did what — rather than from items.last_modified_by (which holds
+-- attribution strings like "user"/"agent", not user IDs). The action values
+-- below match what handlers_items.go and handlers_comments.go pass into
+-- logActivity / logActivityWithMeta.
+
+ALTER TABLE users ADD COLUMN last_write_at TEXT DEFAULT NULL;
+CREATE INDEX IF NOT EXISTS idx_users_last_write_at ON users(last_write_at);
+
+UPDATE users
+SET last_write_at = (
+    SELECT MAX(a.created_at)
+    FROM activities a
+    WHERE a.user_id = users.id
+      AND a.action IN ('created', 'updated', 'archived', 'restored',
+                       'moved', 'commented')
+)
+WHERE last_write_at IS NULL;

--- a/internal/store/pgmigrations/039_user_last_write_at.sql
+++ b/internal/store/pgmigrations/039_user_last_write_at.sql
@@ -1,0 +1,26 @@
+-- Migration 039 (Postgres): per-user last-write timestamp (PLAN-1542 / TASK-1543).
+--
+-- Postgres counterpart to migrations/060_user_last_write_at.sql. Same intent:
+-- a dedicated last_write_at signal distinct from last_active_at (which fires
+-- on any authenticated request and so includes reads). Hook lives at the
+-- handler layer; this migration is the data-layer half.
+--
+-- Backfill reads from the activities table (canonical record of who-did-what)
+-- using the action set that handlers_items.go / handlers_comments.go actually
+-- emit through logActivity / logActivityWithMeta.
+
+ALTER TABLE users ADD COLUMN IF NOT EXISTS last_write_at TEXT DEFAULT NULL;
+CREATE INDEX IF NOT EXISTS idx_users_last_write_at ON users(last_write_at);
+
+UPDATE users u
+SET last_write_at = sub.max_ts
+FROM (
+    SELECT a.user_id, MAX(a.created_at) AS max_ts
+    FROM activities a
+    WHERE a.user_id IS NOT NULL
+      AND a.action IN ('created', 'updated', 'archived', 'restored',
+                       'moved', 'commented')
+    GROUP BY a.user_id
+) sub
+WHERE sub.user_id = u.id
+  AND u.last_write_at IS NULL;

--- a/internal/store/users.go
+++ b/internal/store/users.go
@@ -506,6 +506,27 @@ func (s *Store) TouchUserActivity(ctx context.Context, userID string) {
 	`), ts, userID, throttleTime(ts))
 }
 
+// TouchUserWrite updates last_write_at for a user, throttled to avoid write
+// amplification. Only writes if the stored value is older than 5 minutes.
+// Best-effort: errors are swallowed (matches TouchUserActivity).
+//
+// Unlike last_active_at (which fires on any authenticated request), this is
+// only called from write-path handler sites — item create/update/delete/move,
+// comment authored, attachment uploaded. See handlers_documents.go's
+// logActivityWithMetaReturningID and handlers_attachments.go's upload handler.
+//
+// Silent no-op on empty userID so callers don't have to guard.
+func (s *Store) TouchUserWrite(ctx context.Context, userID string) {
+	if userID == "" {
+		return
+	}
+	ts := now()
+	s.db.ExecContext(ctx, s.q(`
+		UPDATE users SET last_write_at = ?
+		WHERE id = ? AND (last_write_at IS NULL OR last_write_at < ?)
+	`), ts, userID, throttleTime(ts))
+}
+
 // throttleTime returns a timestamp 5 minutes before the given RFC3339 time string.
 func throttleTime(ts string) string {
 	t, err := time.Parse(time.RFC3339, ts)

--- a/internal/store/users_test.go
+++ b/internal/store/users_test.go
@@ -252,6 +252,63 @@ func TestCountBillingAggregates(t *testing.T) {
 	}
 }
 
+// TestTouchUserWrite verifies the last_write_at bump path:
+//   - empty userID is a no-op
+//   - first call populates the column
+//   - second call within 5 minutes does NOT overwrite (throttle)
+//   - a forced backdated timestamp followed by Touch DOES overwrite (past throttle)
+func TestTouchUserWrite(t *testing.T) {
+	s := testStore(t)
+	u := createTestUser(t, s, "writer@example.com", "Writer", "password123")
+	ctx := t.Context()
+
+	// Empty userID: silent no-op, no error, no row touched.
+	s.TouchUserWrite(ctx, "")
+
+	readLastWrite := func() string {
+		t.Helper()
+		var lw *string
+		if err := s.db.QueryRow(s.q(`SELECT last_write_at FROM users WHERE id = ?`), u.ID).Scan(&lw); err != nil {
+			t.Fatalf("query last_write_at: %v", err)
+		}
+		if lw == nil {
+			return ""
+		}
+		return *lw
+	}
+
+	if got := readLastWrite(); got != "" {
+		t.Fatalf("expected last_write_at to start NULL, got %q", got)
+	}
+
+	// First call populates the column.
+	s.TouchUserWrite(ctx, u.ID)
+	first := readLastWrite()
+	if first == "" {
+		t.Fatalf("expected last_write_at to be set after first touch")
+	}
+
+	// Second call within the throttle window must not overwrite — re-touch
+	// then verify the value is unchanged. (Without throttle the value would
+	// change because `now()` advances per call.)
+	time.Sleep(1100 * time.Millisecond) // ensure now() RFC3339 second-resolution moves forward
+	s.TouchUserWrite(ctx, u.ID)
+	if got := readLastWrite(); got != first {
+		t.Fatalf("expected throttle to suppress second write within 5m; first=%q got=%q", first, got)
+	}
+
+	// Backdate to outside the throttle window, then touch — value SHOULD
+	// move forward.
+	old := time.Now().Add(-10 * time.Minute).UTC().Format(time.RFC3339)
+	if _, err := s.db.Exec(s.q(`UPDATE users SET last_write_at = ? WHERE id = ?`), old, u.ID); err != nil {
+		t.Fatalf("backdate: %v", err)
+	}
+	s.TouchUserWrite(ctx, u.ID)
+	if got := readLastWrite(); got == old {
+		t.Fatalf("expected touch outside throttle to advance last_write_at; still %q", got)
+	}
+}
+
 // insertWithPlanAndDate is a test-only helper that inserts a user with a
 // specific plan + created_at timestamp. CreateUser doesn't expose either
 // directly. Times are RFC3339-formatted strings (matching store.now) so


### PR DESCRIPTION
## Summary

- Adds `users.last_write_at` column (migration 060) backfilled from the `activities` table
- New `Store.TouchUserWrite(ctx, userID)` — throttled mirror of `TouchUserActivity`
- Hooks every item-write action via `logActivityWithMetaReturningID` (single chokepoint) and attachment uploads explicitly
- Distinct from `last_active_at` so engagement metrics can tell writers from readers

First of five backend PRs from PLAN-1542 (admin user management enhancements, IDEA-1541).

## Architecture note

`items.last_modified_by` / `comments.created_by` are **attribution strings** (`"user"` / `"agent"` / `"cli"`), not user IDs. The user identity lives in `activities.user_id`, populated at the handler layer where `currentUser` is in scope. That's why the hook lives in handlers — not the store layer — and why the backfill reads from `activities`.

## Test plan

- [x] `go test ./internal/store/ -run TestTouchUserWrite` — new test covers empty-userID no-op, first-write set, in-throttle suppression, out-of-throttle advance
- [x] `go test ./...` — full suite green
- [x] `cd web && npm run build` — baseline web build green
- [ ] Migration applies cleanly on fresh DB (covered by store init in tests)
- [ ] Migration applies on a DB at 059 with existing activities (manual verification recommended)

## Broken state after merge

None — purely additive. Column exists, hook fires, but no reader consumes it yet (T1547/T1548 will).