### PR TITLE
feat(admin): extend user list with aggregations + sort/filter (TASK-1544)

### DIFF
--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -24,7 +24,8 @@ type User struct {
 	OAuthProviders   string    `json:"-"`                        // JSON array of linked providers, e.g. ["github","google"]
 	PasswordSet      bool      `json:"password_set"`             // True if the user explicitly set a password (vs. OAuth placeholder hash)
 	DisabledAt       string    `json:"disabled_at,omitempty"`    // Non-empty = account disabled
-	LastActiveAt     string    `json:"last_active_at,omitempty"` // Last authenticated API request
+	LastActiveAt     string    `json:"last_active_at,omitempty"` // Last authenticated API request (any read or write)
+	LastWriteAt      string    `json:"last_write_at,omitempty"`  // Last mutating action (item/comment/attachment); see Store.TouchUserWrite. PLAN-1542 / TASK-1543.
 	CreatedAt        time.Time `json:"created_at"`
 	UpdatedAt        time.Time `json:"updated_at"`
 }

--- a/internal/server/handlers_admin_users.go
+++ b/internal/server/handlers_admin_users.go
@@ -58,14 +58,20 @@ func (s *Server) handleAdminListUsers(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Tri-state bool filters: only set the pointer when the param is
-	// present, so omitting it means "no filter" (not "false").
+	// present, so omitting it means "no filter" (not "false"). Uses
+	// strconv.ParseBool so the full set of canonical truthy/falsy values
+	// is accepted ("true"/"True"/"TRUE"/"1"/"t" and the parallel falses);
+	// anything else is treated as "no filter" rather than silently false
+	// (Codex review on PR #599).
 	if v := q.Get("disabled"); v != "" {
-		b := v == "true" || v == "1"
-		params.Disabled = &b
+		if b, err := strconv.ParseBool(v); err == nil {
+			params.Disabled = &b
+		}
 	}
 	if v := q.Get("has_workspaces"); v != "" {
-		b := v == "true" || v == "1"
-		params.HasWorkspaces = &b
+		if b, err := strconv.ParseBool(v); err == nil {
+			params.HasWorkspaces = &b
+		}
 	}
 	if v := q.Get("active_within_days"); v != "" {
 		if n, err := strconv.Atoi(v); err == nil && n > 0 {

--- a/internal/server/handlers_admin_users.go
+++ b/internal/server/handlers_admin_users.go
@@ -14,69 +14,111 @@ import (
 
 // --- Admin User Management (TASK-502) ---
 
-// handleAdminListUsers returns a paginated list of users with plan info.
+// handleAdminListUsers returns a paginated list of users with plan info,
+// cheap aggregations (workspace_count, storage_bytes, last_write_at,
+// status), and sort/filter support. PLAN-1542 / TASK-1544.
+//
 // GET /api/v1/admin/users?q=search&plan=free&offset=0&limit=50
+//
+//	Additional query params:
+//	  role=admin|member               filter by role
+//	  disabled=true|false             filter disabled state (omit = both)
+//	  active_within_days=N            only users with last_write_at within N days
+//	  has_workspaces=true|false       filter on workspace_count > 0 (omit = both)
+//	  sort=email|last_write|last_active|storage|workspaces|created
+//	  order=asc|desc                  default desc
 func (s *Server) handleAdminListUsers(w http.ResponseWriter, r *http.Request) {
 	if !requireAdmin(w, r) {
 		return
 	}
 
+	q := r.URL.Query()
+
 	limit := 50
-	if v := r.URL.Query().Get("limit"); v != "" {
+	if v := q.Get("limit"); v != "" {
 		if n, err := strconv.Atoi(v); err == nil && n > 0 {
 			limit = n
 		}
 	}
 	offset := 0
-	if v := r.URL.Query().Get("offset"); v != "" {
+	if v := q.Get("offset"); v != "" {
 		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
 			offset = n
 		}
 	}
 
-	result, err := s.store.SearchUsers(store.AdminUserSearchParams{
-		Query:  r.URL.Query().Get("q"),
-		Plan:   r.URL.Query().Get("plan"),
+	params := store.AdminUserSearchParams{
+		Query:  q.Get("q"),
+		Plan:   q.Get("plan"),
+		Role:   q.Get("role"),
 		Limit:  limit,
 		Offset: offset,
-	})
+		Sort:   q.Get("sort"),
+		Order:  q.Get("order"),
+	}
+
+	// Tri-state bool filters: only set the pointer when the param is
+	// present, so omitting it means "no filter" (not "false").
+	if v := q.Get("disabled"); v != "" {
+		b := v == "true" || v == "1"
+		params.Disabled = &b
+	}
+	if v := q.Get("has_workspaces"); v != "" {
+		b := v == "true" || v == "1"
+		params.HasWorkspaces = &b
+	}
+	if v := q.Get("active_within_days"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			params.ActiveWithinDays = &n
+		}
+	}
+
+	result, err := s.store.SearchUsers(params)
 	if err != nil {
 		writeInternalError(w, err)
 		return
 	}
 
 	type adminUser struct {
-		ID            string `json:"id"`
-		Email         string `json:"email"`
-		Username      string `json:"username"`
-		Name          string `json:"name"`
-		Role          string `json:"role"`
-		Plan          string `json:"plan"`
-		PlanExpiresAt string `json:"plan_expires_at,omitempty"`
-		PlanOverrides string `json:"plan_overrides,omitempty"`
-		TOTPEnabled   bool   `json:"totp_enabled"`
-		DisabledAt    string `json:"disabled_at,omitempty"`
-		LastActiveAt  string `json:"last_active_at,omitempty"`
-		CreatedAt     string `json:"created_at"`
-		UpdatedAt     string `json:"updated_at"`
+		ID             string `json:"id"`
+		Email          string `json:"email"`
+		Username       string `json:"username"`
+		Name           string `json:"name"`
+		Role           string `json:"role"`
+		Plan           string `json:"plan"`
+		PlanExpiresAt  string `json:"plan_expires_at,omitempty"`
+		PlanOverrides  string `json:"plan_overrides,omitempty"`
+		TOTPEnabled    bool   `json:"totp_enabled"`
+		DisabledAt     string `json:"disabled_at,omitempty"`
+		LastActiveAt   string `json:"last_active_at,omitempty"`
+		LastWriteAt    string `json:"last_write_at,omitempty"`
+		CreatedAt      string `json:"created_at"`
+		UpdatedAt      string `json:"updated_at"`
+		WorkspaceCount int    `json:"workspace_count"`
+		StorageBytes   int64  `json:"storage_bytes"`
+		Status         string `json:"status"`
 	}
 
 	users := make([]adminUser, 0, len(result.Users))
 	for _, u := range result.Users {
 		users = append(users, adminUser{
-			ID:            u.ID,
-			Email:         u.Email,
-			Username:      u.Username,
-			Name:          u.Name,
-			Role:          u.Role,
-			Plan:          u.Plan,
-			PlanExpiresAt: u.PlanExpiresAt,
-			PlanOverrides: u.PlanOverrides,
-			TOTPEnabled:   u.TOTPEnabled,
-			DisabledAt:    u.DisabledAt,
-			LastActiveAt:  u.LastActiveAt,
-			CreatedAt:     u.CreatedAt.Format("2006-01-02T15:04:05Z"),
-			UpdatedAt:     u.UpdatedAt.Format("2006-01-02T15:04:05Z"),
+			ID:             u.ID,
+			Email:          u.Email,
+			Username:       u.Username,
+			Name:           u.Name,
+			Role:           u.Role,
+			Plan:           u.Plan,
+			PlanExpiresAt:  u.PlanExpiresAt,
+			PlanOverrides:  u.PlanOverrides,
+			TOTPEnabled:    u.TOTPEnabled,
+			DisabledAt:     u.DisabledAt,
+			LastActiveAt:   u.LastActiveAt,
+			LastWriteAt:    u.LastWriteAt,
+			CreatedAt:      u.CreatedAt.Format("2006-01-02T15:04:05Z"),
+			UpdatedAt:      u.UpdatedAt.Format("2006-01-02T15:04:05Z"),
+			WorkspaceCount: u.WorkspaceCount,
+			StorageBytes:   u.StorageBytes,
+			Status:         u.Status,
 		})
 	}
 

--- a/internal/store/users.go
+++ b/internal/store/users.go
@@ -387,26 +387,33 @@ func (s *Store) SearchUsers(params AdminUserSearchParams) (*AdminUserSearchResul
 	// LEFT JOIN against grouped subqueries (not bare workspaces/attachments)
 	// so the row count stays one-per-user even when a user owns 50 workspaces
 	// with thousands of attachments each.
-	const fromClause = `
-		FROM users u
+	const workspaceCountJoin = `
 		LEFT JOIN (
 			SELECT owner_id, COUNT(*) AS cnt
 			FROM workspaces
 			WHERE deleted_at IS NULL
 			GROUP BY owner_id
-		) wc ON wc.owner_id = u.id
+		) wc ON wc.owner_id = u.id`
+	const storageBytesJoin = `
 		LEFT JOIN (
 			SELECT w.owner_id, COALESCE(SUM(a.size_bytes), 0) AS bytes
 			FROM workspaces w
 			JOIN attachments a ON a.workspace_id = w.id AND a.deleted_at IS NULL
 			WHERE w.deleted_at IS NULL
 			GROUP BY w.owner_id
-		) sb ON sb.owner_id = u.id
-	`
+		) sb ON sb.owner_id = u.id`
 
-	// Count query — uses the same FROM + WHERE so HasWorkspaces filtering
-	// is consistent with the page result.
-	countQuery := s.q("SELECT COUNT(*) " + fromClause + " " + whereClause)
+	// Page query needs both aggregations (the row carries them). The count
+	// query only needs the workspace_count join when HasWorkspaces filtering
+	// is active — skipping the storage SUM avoids scanning every attachment
+	// on every list call (Codex review on PR #599).
+	fromClause := "FROM users u" + workspaceCountJoin + storageBytesJoin
+	countFromClause := "FROM users u"
+	if params.HasWorkspaces != nil {
+		countFromClause += workspaceCountJoin
+	}
+
+	countQuery := s.q("SELECT COUNT(*) " + countFromClause + " " + whereClause)
 	var total int
 	if err := s.db.QueryRow(countQuery, args...).Scan(&total); err != nil {
 		return nil, fmt.Errorf("search users count: %w", err)

--- a/internal/store/users.go
+++ b/internal/store/users.go
@@ -27,7 +27,7 @@ var usernameCleanRe = regexp.MustCompile(`[^a-z0-9-]+`)
 var bcryptCost = 12
 
 // user SELECT columns — used by all user queries.
-const userColumns = `id, email, username, name, password_hash, role, avatar_url, totp_secret, totp_enabled, recovery_codes, plan, plan_expires_at, stripe_customer_id, plan_overrides, oauth_providers, password_set, disabled_at, last_active_at, created_at, updated_at`
+const userColumns = `id, email, username, name, password_hash, role, avatar_url, totp_secret, totp_enabled, recovery_codes, plan, plan_expires_at, stripe_customer_id, plan_overrides, oauth_providers, password_set, disabled_at, last_active_at, last_write_at, created_at, updated_at`
 
 // scanUser scans a user row into a User struct.
 // Note: does NOT decrypt the TOTP secret — call store.decryptUserTOTP() after
@@ -36,19 +36,22 @@ func scanUser(row interface{ Scan(...interface{}) error }) (*models.User, error)
 	var u models.User
 	var createdAt, updatedAt string
 
-	var disabledAt, lastActiveAt sql.NullString
+	var disabledAt, lastActiveAt, lastWriteAt sql.NullString
 	err := row.Scan(
 		&u.ID, &u.Email, &u.Username, &u.Name, &u.PasswordHash, &u.Role, &u.AvatarURL,
 		&u.TOTPSecret, &u.TOTPEnabled, &u.RecoveryCodes,
 		&u.Plan, &u.PlanExpiresAt, &u.StripeCustomerID, &u.PlanOverrides, &u.OAuthProviders,
 		&u.PasswordSet,
-		&disabledAt, &lastActiveAt, &createdAt, &updatedAt,
+		&disabledAt, &lastActiveAt, &lastWriteAt, &createdAt, &updatedAt,
 	)
 	if disabledAt.Valid {
 		u.DisabledAt = disabledAt.String
 	}
 	if lastActiveAt.Valid {
 		u.LastActiveAt = lastActiveAt.String
+	}
+	if lastWriteAt.Valid {
+		u.LastWriteAt = lastWriteAt.String
 	}
 	if err == sql.ErrNoRows {
 		return nil, nil
@@ -244,21 +247,94 @@ func (s *Store) ListUsers() ([]models.User, error) {
 }
 
 // AdminUserSearchParams holds parameters for the admin user search query.
+// Filters apply ANDed; nil pointer fields mean "no filter" (distinguished
+// from the zero value so e.g. Disabled=false can mean "show enabled users
+// only" rather than "no filter").
 type AdminUserSearchParams struct {
 	Query  string // Search in email, name, username
 	Plan   string // Filter by plan (free, pro, self-hosted)
+	Role   string // Filter by role (admin, member)
 	Limit  int    // Max results (default 50, max 200)
 	Offset int    // Pagination offset
+
+	// Sort key. One of: email, last_write, last_active, storage, workspaces,
+	// created. Empty defaults to "created" desc to preserve legacy order.
+	Sort string
+	// Order direction: "asc" or "desc". Empty defaults to desc.
+	Order string
+
+	// ActiveWithinDays filters to users whose last_write_at is within the
+	// last N days. nil = no filter. Zero days is invalid (treated as nil).
+	ActiveWithinDays *int
+	// HasWorkspaces: nil = no filter, true = workspace_count > 0,
+	// false = workspace_count == 0.
+	HasWorkspaces *bool
+	// Disabled: nil = no filter, true = disabled_at IS NOT NULL, false = IS NULL.
+	Disabled *bool
+}
+
+// AdminUserListEntry is one row returned by SearchUsers: the User model
+// plus the cheap aggregations the admin user table renders at a glance.
+// PLAN-1542 / TASK-1544.
+type AdminUserListEntry struct {
+	models.User
+	// WorkspaceCount is the number of non-deleted workspaces this user owns.
+	WorkspaceCount int `json:"workspace_count"`
+	// StorageBytes is the SUM(size_bytes) of all non-deleted attachments
+	// across workspaces this user owns. Matches WorkspaceStorageUsage's
+	// definition (includes derived blobs like thumbnails).
+	StorageBytes int64 `json:"storage_bytes"`
+	// Status is a computed bucket for at-a-glance triage. One of:
+	// "disabled", "no-workspace", "inactive", "active". Precedence:
+	// disabled > no-workspace > inactive (>=30d since last write or never)
+	// > active.
+	Status string `json:"status"`
 }
 
 // AdminUserSearchResult holds the paginated search results.
 type AdminUserSearchResult struct {
-	Users []models.User `json:"users"`
-	Total int           `json:"total"`
+	Users []AdminUserListEntry `json:"users"`
+	Total int                  `json:"total"`
+}
+
+// computeAdminUserStatus derives the at-a-glance status pill from the
+// underlying fields. Precedence is intentional: a disabled user with no
+// workspace is still "disabled" first, because that's the most actionable
+// signal for the admin. Exported for unit testing.
+func computeAdminUserStatus(disabledAt, lastWriteAt string, workspaceCount int) string {
+	if disabledAt != "" {
+		return "disabled"
+	}
+	if workspaceCount == 0 {
+		return "no-workspace"
+	}
+	if lastWriteAt == "" {
+		return "inactive"
+	}
+	t, err := time.Parse(time.RFC3339, lastWriteAt)
+	if err != nil {
+		// Malformed timestamp — treat as inactive rather than crashing the
+		// list view. The row is still useful; the status pill just isn't
+		// claiming "active" for a value we can't parse.
+		return "inactive"
+	}
+	if time.Since(t) > 30*24*time.Hour {
+		return "inactive"
+	}
+	return "active"
 }
 
 // SearchUsers returns a filtered, paginated list of users for admin management.
-// Filters and pagination are pushed into SQL to avoid loading all users into memory.
+//
+// Each row carries the User model plus two cheap aggregations the admin
+// table renders at a glance: workspace_count (non-deleted workspaces owned)
+// and storage_bytes (SUM of non-deleted attachments across owned workspaces).
+// Both are computed via LEFT JOIN against pre-grouped subqueries so the
+// aggregation doesn't multiply the user count.
+//
+// Filters and pagination are pushed into SQL to avoid loading all users
+// into memory; sort/filter/pagination is documented on AdminUserSearchParams.
+// PLAN-1542 / TASK-1544.
 func (s *Store) SearchUsers(params AdminUserSearchParams) (*AdminUserSearchResult, error) {
 	if params.Limit <= 0 || params.Limit > 200 {
 		params.Limit = 50
@@ -272,12 +348,35 @@ func (s *Store) SearchUsers(params AdminUserSearchParams) (*AdminUserSearchResul
 
 	if params.Query != "" {
 		q := "%" + strings.ToLower(params.Query) + "%"
-		where = append(where, "(LOWER(email) LIKE ? OR LOWER(name) LIKE ? OR LOWER(username) LIKE ?)")
+		where = append(where, "(LOWER(u.email) LIKE ? OR LOWER(u.name) LIKE ? OR LOWER(u.username) LIKE ?)")
 		args = append(args, q, q, q)
 	}
 	if params.Plan != "" {
-		where = append(where, "plan = ?")
+		where = append(where, "u.plan = ?")
 		args = append(args, params.Plan)
+	}
+	if params.Role != "" {
+		where = append(where, "u.role = ?")
+		args = append(args, params.Role)
+	}
+	if params.Disabled != nil {
+		if *params.Disabled {
+			where = append(where, "u.disabled_at IS NOT NULL")
+		} else {
+			where = append(where, "u.disabled_at IS NULL")
+		}
+	}
+	if params.ActiveWithinDays != nil && *params.ActiveWithinDays > 0 {
+		cutoff := time.Now().UTC().Add(-time.Duration(*params.ActiveWithinDays) * 24 * time.Hour).Format(time.RFC3339)
+		where = append(where, "u.last_write_at >= ?")
+		args = append(args, cutoff)
+	}
+	if params.HasWorkspaces != nil {
+		if *params.HasWorkspaces {
+			where = append(where, "COALESCE(wc.cnt, 0) > 0")
+		} else {
+			where = append(where, "COALESCE(wc.cnt, 0) = 0")
+		}
 	}
 
 	whereClause := ""
@@ -285,15 +384,42 @@ func (s *Store) SearchUsers(params AdminUserSearchParams) (*AdminUserSearchResul
 		whereClause = "WHERE " + strings.Join(where, " AND ")
 	}
 
-	// Get total count
-	countQuery := s.q("SELECT COUNT(*) FROM users " + whereClause)
+	// LEFT JOIN against grouped subqueries (not bare workspaces/attachments)
+	// so the row count stays one-per-user even when a user owns 50 workspaces
+	// with thousands of attachments each.
+	const fromClause = `
+		FROM users u
+		LEFT JOIN (
+			SELECT owner_id, COUNT(*) AS cnt
+			FROM workspaces
+			WHERE deleted_at IS NULL
+			GROUP BY owner_id
+		) wc ON wc.owner_id = u.id
+		LEFT JOIN (
+			SELECT w.owner_id, COALESCE(SUM(a.size_bytes), 0) AS bytes
+			FROM workspaces w
+			JOIN attachments a ON a.workspace_id = w.id AND a.deleted_at IS NULL
+			WHERE w.deleted_at IS NULL
+			GROUP BY w.owner_id
+		) sb ON sb.owner_id = u.id
+	`
+
+	// Count query — uses the same FROM + WHERE so HasWorkspaces filtering
+	// is consistent with the page result.
+	countQuery := s.q("SELECT COUNT(*) " + fromClause + " " + whereClause)
 	var total int
 	if err := s.db.QueryRow(countQuery, args...).Scan(&total); err != nil {
 		return nil, fmt.Errorf("search users count: %w", err)
 	}
 
-	// Get paginated results
-	query := s.q("SELECT " + userColumns + " FROM users " + whereClause + " ORDER BY created_at DESC LIMIT ? OFFSET ?")
+	// Resolve sort. Allow-list to prevent injection; default matches the
+	// pre-T1544 behavior (created_at DESC).
+	orderBy := adminUserSortClause(params.Sort, params.Order)
+
+	// Build the column list: alias the userColumns onto `u.` so scanUser
+	// keeps working. The two aggregation columns come after.
+	aliasedUserCols := prefixColumns(userColumns, "u.")
+	query := s.q(`SELECT ` + aliasedUserCols + `, COALESCE(wc.cnt, 0), COALESCE(sb.bytes, 0) ` + fromClause + ` ` + whereClause + ` ORDER BY ` + orderBy + ` LIMIT ? OFFSET ?`)
 	fullArgs := append(args, params.Limit, params.Offset)
 	rows, err := s.db.Query(query, fullArgs...)
 	if err != nil {
@@ -301,23 +427,96 @@ func (s *Store) SearchUsers(params AdminUserSearchParams) (*AdminUserSearchResul
 	}
 	defer rows.Close()
 
-	var users []models.User
+	entries := make([]AdminUserListEntry, 0)
 	for rows.Next() {
-		u, err := scanUser(rows)
-		if err != nil {
+		var entry AdminUserListEntry
+		var createdAt, updatedAt string
+		var disabledAt, lastActiveAt, lastWriteAt sql.NullString
+		var workspaceCount int
+		var storageBytes int64
+		if err := rows.Scan(
+			&entry.ID, &entry.Email, &entry.Username, &entry.Name, &entry.PasswordHash, &entry.Role, &entry.AvatarURL,
+			&entry.TOTPSecret, &entry.TOTPEnabled, &entry.RecoveryCodes,
+			&entry.Plan, &entry.PlanExpiresAt, &entry.StripeCustomerID, &entry.PlanOverrides, &entry.OAuthProviders,
+			&entry.PasswordSet,
+			&disabledAt, &lastActiveAt, &lastWriteAt, &createdAt, &updatedAt,
+			&workspaceCount, &storageBytes,
+		); err != nil {
 			return nil, fmt.Errorf("search users scan: %w", err)
 		}
-		_ = s.decryptUserTOTP(u)
-		users = append(users, *u)
+		if disabledAt.Valid {
+			entry.DisabledAt = disabledAt.String
+		}
+		if lastActiveAt.Valid {
+			entry.LastActiveAt = lastActiveAt.String
+		}
+		if lastWriteAt.Valid {
+			entry.LastWriteAt = lastWriteAt.String
+		}
+		entry.CreatedAt = parseTime(createdAt)
+		entry.UpdatedAt = parseTime(updatedAt)
+		entry.WorkspaceCount = workspaceCount
+		entry.StorageBytes = storageBytes
+		entry.Status = computeAdminUserStatus(entry.DisabledAt, entry.LastWriteAt, entry.WorkspaceCount)
+		_ = s.decryptUserTOTP(&entry.User)
+		entries = append(entries, entry)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("search users rows: %w", err)
 	}
 
 	return &AdminUserSearchResult{
-		Users: users,
+		Users: entries,
 		Total: total,
 	}, nil
+}
+
+// adminUserSortClause maps the public sort key + order into a safe ORDER BY
+// expression. Hard-coded allow-list to avoid SQL injection; an unknown key
+// falls back to the legacy default (created_at DESC).
+func adminUserSortClause(key, order string) string {
+	dir := "DESC"
+	if strings.EqualFold(order, "asc") {
+		dir = "ASC"
+	}
+	switch key {
+	case "email":
+		return "u.email " + dir
+	case "last_write":
+		// NULL last writes go to the bottom in DESC order, top in ASC. The
+		// COALESCE forces nulls to sort opposite-extreme so the page is
+		// usable either way.
+		if dir == "DESC" {
+			return "u.last_write_at DESC NULLS LAST, u.created_at DESC"
+		}
+		return "u.last_write_at ASC NULLS LAST, u.created_at ASC"
+	case "last_active":
+		if dir == "DESC" {
+			return "u.last_active_at DESC NULLS LAST, u.created_at DESC"
+		}
+		return "u.last_active_at ASC NULLS LAST, u.created_at ASC"
+	case "storage":
+		return "COALESCE(sb.bytes, 0) " + dir + ", u.created_at DESC"
+	case "workspaces":
+		return "COALESCE(wc.cnt, 0) " + dir + ", u.created_at DESC"
+	case "created", "":
+		return "u.created_at " + dir
+	default:
+		return "u.created_at DESC"
+	}
+}
+
+// prefixColumns rewrites a comma-separated SELECT list with the given
+// prefix, e.g. "id, email" with "u." → "u.id, u.email". Small helper to
+// keep userColumns as a single source of truth even when we need to
+// alias the users table in a JOIN.
+func prefixColumns(cols, prefix string) string {
+	parts := strings.Split(cols, ",")
+	out := make([]string, len(parts))
+	for i, p := range parts {
+		out[i] = prefix + strings.TrimSpace(p)
+	}
+	return strings.Join(out, ", ")
 }
 
 // UserCount returns the total number of registered users.

--- a/internal/store/users_test.go
+++ b/internal/store/users_test.go
@@ -252,6 +252,195 @@ func TestCountBillingAggregates(t *testing.T) {
 	}
 }
 
+// TestComputeAdminUserStatus locks in the precedence order: disabled wins
+// over no-workspace wins over inactive wins over active. Documented in the
+// admin user list contract (PLAN-1542 / TASK-1544).
+func TestComputeAdminUserStatus(t *testing.T) {
+	recent := time.Now().UTC().Add(-1 * time.Hour).Format(time.RFC3339)
+	old := time.Now().UTC().Add(-60 * 24 * time.Hour).Format(time.RFC3339)
+	cases := []struct {
+		name           string
+		disabledAt     string
+		lastWriteAt    string
+		workspaceCount int
+		want           string
+	}{
+		{"disabled overrides everything", "2026-01-01T00:00:00Z", recent, 5, "disabled"},
+		{"disabled with no workspace still disabled", "2026-01-01T00:00:00Z", "", 0, "disabled"},
+		{"no workspace beats inactive", "", "", 0, "no-workspace"},
+		{"never written, has workspace", "", "", 3, "inactive"},
+		{"wrote long ago", "", old, 1, "inactive"},
+		{"wrote recently", "", recent, 1, "active"},
+		{"malformed timestamp treated as inactive", "", "not-a-date", 1, "inactive"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := computeAdminUserStatus(c.disabledAt, c.lastWriteAt, c.workspaceCount)
+			if got != c.want {
+				t.Fatalf("want %q got %q", c.want, got)
+			}
+		})
+	}
+}
+
+// TestSearchUsersAggregations verifies that SearchUsers returns correct
+// workspace_count + storage_bytes + status aggregations and that the new
+// sort/filter knobs route to the right rows. Single end-to-end test against
+// a multi-user fixture; finer-grained assertions are split into subtests.
+func TestSearchUsersAggregations(t *testing.T) {
+	s := testStore(t)
+
+	// Three users:
+	//   alice — owns 2 workspaces; one has a 100-byte attachment, one empty
+	//   bob   — owns 1 workspace, no attachments
+	//   carol — owns 0 workspaces, disabled
+	alice := createTestUser(t, s, "alice@example.com", "Alice", "password123")
+	bob := createTestUser(t, s, "bob@example.com", "Bob", "password123")
+	carol := createTestUser(t, s, "carol@example.com", "Carol", "password123")
+	if err := s.DisableUser(carol.ID); err != nil {
+		t.Fatalf("disable carol: %v", err)
+	}
+
+	mkWS := func(owner string, slug string) string {
+		ws, err := s.CreateWorkspace(models.WorkspaceCreate{Name: slug, Slug: slug, OwnerID: owner})
+		if err != nil {
+			t.Fatalf("create ws %s: %v", slug, err)
+		}
+		return ws.ID
+	}
+	aliceWS1 := mkWS(alice.ID, "alice-ws-1")
+	mkWS(alice.ID, "alice-ws-2")
+	mkWS(bob.ID, "bob-ws-1")
+
+	// Drop a 100-byte attachment row into alice's first workspace. Skip the
+	// real upload pipeline (we don't need blob bytes for the SUM check).
+	if _, err := s.db.Exec(s.q(`
+		INSERT INTO attachments (id, workspace_id, item_id, uploaded_by, storage_key, content_hash, mime_type, size_bytes, filename, created_at)
+		VALUES (?, ?, NULL, ?, ?, ?, ?, ?, ?, ?)
+	`), newID(), aliceWS1, alice.ID, "k1", "h1", "text/plain", int64(100), "a.txt", now()); err != nil {
+		t.Fatalf("seed attachment: %v", err)
+	}
+
+	// Plain list (no filters) — all three users, ordered by created_at DESC
+	// (carol newest, alice oldest because tests insert in order).
+	res, err := s.SearchUsers(AdminUserSearchParams{})
+	if err != nil {
+		t.Fatalf("SearchUsers: %v", err)
+	}
+	if res.Total != 3 {
+		t.Fatalf("total: want 3 got %d", res.Total)
+	}
+	if len(res.Users) != 3 {
+		t.Fatalf("rows: want 3 got %d", len(res.Users))
+	}
+	byEmail := map[string]AdminUserListEntry{}
+	for _, u := range res.Users {
+		byEmail[u.Email] = u
+	}
+	if got := byEmail["alice@example.com"].WorkspaceCount; got != 2 {
+		t.Errorf("alice workspace_count: want 2 got %d", got)
+	}
+	if got := byEmail["alice@example.com"].StorageBytes; got != 100 {
+		t.Errorf("alice storage_bytes: want 100 got %d", got)
+	}
+	if got := byEmail["bob@example.com"].WorkspaceCount; got != 1 {
+		t.Errorf("bob workspace_count: want 1 got %d", got)
+	}
+	if got := byEmail["bob@example.com"].StorageBytes; got != 0 {
+		t.Errorf("bob storage_bytes: want 0 got %d", got)
+	}
+	if got := byEmail["carol@example.com"].WorkspaceCount; got != 0 {
+		t.Errorf("carol workspace_count: want 0 got %d", got)
+	}
+	// Status precedence: carol = disabled (regardless of workspace_count=0).
+	if got := byEmail["carol@example.com"].Status; got != "disabled" {
+		t.Errorf("carol status: want disabled got %q", got)
+	}
+	// Bob has a workspace but never wrote anything → inactive.
+	if got := byEmail["bob@example.com"].Status; got != "inactive" {
+		t.Errorf("bob status: want inactive got %q", got)
+	}
+
+	t.Run("filter disabled=true", func(t *testing.T) {
+		yes := true
+		res, err := s.SearchUsers(AdminUserSearchParams{Disabled: &yes})
+		if err != nil {
+			t.Fatalf("SearchUsers: %v", err)
+		}
+		if res.Total != 1 || res.Users[0].Email != "carol@example.com" {
+			t.Fatalf("want only carol; got total=%d users=%v", res.Total, res.Users)
+		}
+	})
+
+	t.Run("filter has_workspaces=true", func(t *testing.T) {
+		yes := true
+		res, err := s.SearchUsers(AdminUserSearchParams{HasWorkspaces: &yes})
+		if err != nil {
+			t.Fatalf("SearchUsers: %v", err)
+		}
+		if res.Total != 2 {
+			t.Fatalf("want 2 (alice+bob), got total=%d", res.Total)
+		}
+	})
+
+	t.Run("sort by workspaces desc", func(t *testing.T) {
+		res, err := s.SearchUsers(AdminUserSearchParams{Sort: "workspaces", Order: "desc"})
+		if err != nil {
+			t.Fatalf("SearchUsers: %v", err)
+		}
+		if res.Users[0].Email != "alice@example.com" {
+			t.Fatalf("want alice first (2 workspaces); got %v", res.Users[0].Email)
+		}
+	})
+
+	t.Run("sort by storage desc", func(t *testing.T) {
+		res, err := s.SearchUsers(AdminUserSearchParams{Sort: "storage", Order: "desc"})
+		if err != nil {
+			t.Fatalf("SearchUsers: %v", err)
+		}
+		if res.Users[0].Email != "alice@example.com" {
+			t.Fatalf("want alice first (100 bytes); got %v", res.Users[0].Email)
+		}
+	})
+
+	t.Run("sort by email asc", func(t *testing.T) {
+		res, err := s.SearchUsers(AdminUserSearchParams{Sort: "email", Order: "asc"})
+		if err != nil {
+			t.Fatalf("SearchUsers: %v", err)
+		}
+		emails := []string{res.Users[0].Email, res.Users[1].Email, res.Users[2].Email}
+		want := []string{"alice@example.com", "bob@example.com", "carol@example.com"}
+		for i := range want {
+			if emails[i] != want[i] {
+				t.Fatalf("asc sort: want %v got %v", want, emails)
+			}
+		}
+	})
+
+	t.Run("active_within_days filters on last_write_at", func(t *testing.T) {
+		// Touch alice's last_write_at to "now"; bob stays NULL.
+		s.TouchUserWrite(t.Context(), alice.ID)
+		n := 7
+		res, err := s.SearchUsers(AdminUserSearchParams{ActiveWithinDays: &n})
+		if err != nil {
+			t.Fatalf("SearchUsers: %v", err)
+		}
+		if res.Total != 1 || res.Users[0].Email != "alice@example.com" {
+			t.Fatalf("want only alice; got total=%d users=%v", res.Total, res.Users)
+		}
+	})
+
+	t.Run("query filter still works", func(t *testing.T) {
+		res, err := s.SearchUsers(AdminUserSearchParams{Query: "alice"})
+		if err != nil {
+			t.Fatalf("SearchUsers: %v", err)
+		}
+		if res.Total != 1 || res.Users[0].Email != "alice@example.com" {
+			t.Fatalf("query filter: want only alice; got total=%d", res.Total)
+		}
+	})
+}
+
 // TestTouchUserWrite verifies the last_write_at bump path:
 //   - empty userID is a no-op
 //   - first call populates the column


### PR DESCRIPTION
## Summary

- Extends `GET /admin/users` with per-user `workspace_count`, `storage_bytes`, `last_write_at`, and a computed `status` pill (disabled / no-workspace / inactive / active)
- Adds sort (`email`, `last_write`, `last_active`, `storage`, `workspaces`, `created`) and filter (`role`, `disabled`, `has_workspaces`, `active_within_days`) query params
- SQL aggregations use LEFT-JOINed grouped subqueries so multi-workspace users don't multiply the row count
- Status precedence locked in by unit test

Second of five backend PRs from PLAN-1542 (admin user management enhancements).

## Test plan

- [x] `TestComputeAdminUserStatus` — precedence table (disabled > no-workspace > inactive > active)
- [x] `TestSearchUsersAggregations` — workspace_count, storage_bytes, status, plus each filter/sort knob over a 3-user fixture
- [x] Existing `TestUserCRUD` / `TestListUsers` / `TestUserCount` regressions clean
- [x] Full `go test ./...` green
- [ ] Manual: hit the admin endpoint with a real workspace fixture; verify JSON shape

## Broken state after merge

None — purely additive. The admin UI doesn't consume the new fields yet (T1548/T1549 will).

## Depends on

TASK-1543 (merged in #598) — uses the new `last_write_at` column for filtering and status computation.