### PR TITLE
feat(admin): GET /admin/users/{id}/detail per-workspace breakdown (TASK-1545)

### DIFF
--- a/internal/server/handlers_admin_users.go
+++ b/internal/server/handlers_admin_users.go
@@ -177,6 +177,60 @@ func (s *Server) handleAdminGetUser(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// handleAdminGetUserDetail returns a combined per-user payload: the user
+// vitals plus a per-workspace breakdown enriched with aggregations
+// (collections_count, items_open, items_total, members_count,
+// storage_bytes, last_activity_at). Powers the Workspaces tab of the
+// admin user modal (T1552) in a single round-trip.
+//
+// PLAN-1542 / TASK-1545. GET /api/v1/admin/users/{userID}/detail.
+func (s *Server) handleAdminGetUserDetail(w http.ResponseWriter, r *http.Request) {
+	if !requireAdmin(w, r) {
+		return
+	}
+
+	userID := chi.URLParam(r, "userID")
+	user, err := s.store.GetUser(userID)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	if user == nil {
+		writeError(w, http.StatusNotFound, "not_found", "User not found")
+		return
+	}
+
+	workspaces, err := s.store.GetUserWorkspacesDetailed(userID)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	if workspaces == nil {
+		// Defensive: ensure JSON serializes as `[]` rather than `null`.
+		workspaces = []store.AdminUserWorkspaceDetail{}
+	}
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"user": map[string]interface{}{
+			"id":              user.ID,
+			"email":           user.Email,
+			"username":        user.Username,
+			"name":            user.Name,
+			"role":            user.Role,
+			"plan":            user.Plan,
+			"plan_expires_at": user.PlanExpiresAt,
+			"plan_overrides":  user.PlanOverrides,
+			"totp_enabled":    user.TOTPEnabled,
+			"disabled_at":     user.DisabledAt,
+			"last_active_at":  user.LastActiveAt,
+			"last_write_at":   user.LastWriteAt,
+			"created_at":      user.CreatedAt,
+			"updated_at":      user.UpdatedAt,
+		},
+		"workspaces": workspaces,
+	})
+}
+
 // handleAdminGetUserWorkspaces returns workspace memberships for a user.
 // GET /api/v1/admin/users/{userID}/workspaces
 func (s *Server) handleAdminGetUserWorkspaces(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -894,6 +894,7 @@ func (s *Server) setupRouter() {
 				r.Patch("/users/{userID}", s.handleAdminUpdateUser)
 				r.Post("/users/{userID}/reset-password", s.handleAdminResetPassword)
 				r.Get("/users/{userID}/workspaces", s.handleAdminGetUserWorkspaces)
+				r.Get("/users/{userID}/detail", s.handleAdminGetUserDetail)
 				r.Post("/users/{userID}/disable", s.handleAdminDisableUser)
 				r.Post("/users/{userID}/enable", s.handleAdminEnableUser)
 

--- a/internal/store/workspace_members.go
+++ b/internal/store/workspace_members.go
@@ -947,34 +947,27 @@ type AdminUserWorkspaceDetail struct {
 	LastActivityAt string `json:"last_activity_at,omitempty"`
 }
 
-// terminal item statuses. Hardcoded for now — a proper terminal-aware
-// count would JOIN against collections.schema and pull each collection's
-// terminal_options. Follow-up tracked alongside TASK-1545. Values cover
-// the canonical terminals across the default templates: software (done,
-// completed, archived, rejected, implemented, cancelled).
-var adminOpenItemTerminalStatuses = []string{"done", "completed", "rejected", "archived", "implemented", "cancelled"}
-
 // adminOpenItemsCountClause returns a SQL fragment (no leading AND) that
-// excludes terminal-status items. Built from adminOpenItemTerminalStatuses
-// so the list is single-sourced.
-func adminOpenItemsCountClause() string {
-	if len(adminOpenItemTerminalStatuses) == 0 {
-		return "1=1"
+// excludes terminal-status items. Single-sourced from
+// models.DefaultTerminalStatuses to match the rest of the codebase, and
+// uses the dialect's JSON-extract helper so the query runs identically on
+// SQLite and Postgres. Wraps the extracted value in LOWER(COALESCE(...,'')
+// so items with NULL/missing status (NULL NOT IN (...) is not TRUE in SQL)
+// and case-variant statuses still register as "open" — matching how
+// search.go and items.go interpret terminal-status checks.
+func (s *Store) adminOpenItemsCountClause() (clause string, args []interface{}) {
+	terms := models.DefaultTerminalStatuses
+	if len(terms) == 0 {
+		return "1=1", nil
 	}
-	placeholders := make([]string, len(adminOpenItemTerminalStatuses))
-	for i := range placeholders {
+	placeholders := make([]string, len(terms))
+	args = make([]interface{}, len(terms))
+	for i, v := range terms {
 		placeholders[i] = "?"
+		args[i] = strings.ToLower(v)
 	}
-	return "JSON_EXTRACT(i.fields, '$.status') NOT IN (" + strings.Join(placeholders, ", ") + ")"
-}
-
-// adminOpenItemTerminalArgs returns the bound args for adminOpenItemsCountClause.
-func adminOpenItemTerminalArgs() []interface{} {
-	out := make([]interface{}, len(adminOpenItemTerminalStatuses))
-	for i, v := range adminOpenItemTerminalStatuses {
-		out[i] = v
-	}
-	return out
+	expr := "LOWER(COALESCE(" + s.dialect.JSONExtractText("i.fields", "status") + ", ''))"
+	return expr + " NOT IN (" + strings.Join(placeholders, ", ") + ")", args
 }
 
 // GetUserWorkspacesDetailed returns each workspace this user is a member
@@ -983,8 +976,7 @@ func adminOpenItemTerminalArgs() []interface{} {
 // T1552; the headroom is for future tabs that might want the full list).
 // PLAN-1542 / TASK-1545.
 func (s *Store) GetUserWorkspacesDetailed(userID string) ([]AdminUserWorkspaceDetail, error) {
-	openClause := adminOpenItemsCountClause()
-	openArgs := adminOpenItemTerminalArgs()
+	openClause, openArgs := s.adminOpenItemsCountClause()
 
 	// Aggregations live in correlated subqueries rather than a wide JOIN +
 	// GROUP BY because the workspaces a single user belongs to are at most

--- a/internal/store/workspace_members.go
+++ b/internal/store/workspace_members.go
@@ -922,6 +922,137 @@ type AdminUserWorkspace struct {
 	JoinedAt      string `json:"joined_at"`
 }
 
+// AdminUserWorkspaceDetail extends AdminUserWorkspace with per-workspace
+// aggregations rendered in the admin user modal's Workspaces tab.
+// PLAN-1542 / TASK-1545.
+type AdminUserWorkspaceDetail struct {
+	AdminUserWorkspace
+	// CollectionsCount excludes system collections (playbooks, conventions —
+	// collections.is_system = 1). Counts non-deleted user-facing collections.
+	CollectionsCount int `json:"collections_count"`
+	// ItemsOpen counts non-deleted items whose status is NOT in the
+	// terminal set. The terminal set is currently hardcoded (see
+	// adminOpenItemsCountClause); a schema-aware terminal_options check
+	// is a separate follow-up.
+	ItemsOpen int `json:"items_open"`
+	// ItemsTotal counts all non-deleted items in the workspace.
+	ItemsTotal int `json:"items_total"`
+	// MembersCount counts workspace_members rows (includes the owner).
+	MembersCount int `json:"members_count"`
+	// StorageBytes mirrors WorkspaceStorageUsage's definition: SUM of
+	// non-deleted attachment size_bytes (including derived blobs).
+	StorageBytes int64 `json:"storage_bytes"`
+	// LastActivityAt is MAX(items.updated_at) across non-deleted items.
+	// Empty string when the workspace has no items yet.
+	LastActivityAt string `json:"last_activity_at,omitempty"`
+}
+
+// terminal item statuses. Hardcoded for now — a proper terminal-aware
+// count would JOIN against collections.schema and pull each collection's
+// terminal_options. Follow-up tracked alongside TASK-1545. Values cover
+// the canonical terminals across the default templates: software (done,
+// completed, archived, rejected, implemented, cancelled).
+var adminOpenItemTerminalStatuses = []string{"done", "completed", "rejected", "archived", "implemented", "cancelled"}
+
+// adminOpenItemsCountClause returns a SQL fragment (no leading AND) that
+// excludes terminal-status items. Built from adminOpenItemTerminalStatuses
+// so the list is single-sourced.
+func adminOpenItemsCountClause() string {
+	if len(adminOpenItemTerminalStatuses) == 0 {
+		return "1=1"
+	}
+	placeholders := make([]string, len(adminOpenItemTerminalStatuses))
+	for i := range placeholders {
+		placeholders[i] = "?"
+	}
+	return "JSON_EXTRACT(i.fields, '$.status') NOT IN (" + strings.Join(placeholders, ", ") + ")"
+}
+
+// adminOpenItemTerminalArgs returns the bound args for adminOpenItemsCountClause.
+func adminOpenItemTerminalArgs() []interface{} {
+	out := make([]interface{}, len(adminOpenItemTerminalStatuses))
+	for i, v := range adminOpenItemTerminalStatuses {
+		out[i] = v
+	}
+	return out
+}
+
+// GetUserWorkspacesDetailed returns each workspace this user is a member
+// of with the per-workspace aggregations the admin modal's Workspaces tab
+// renders. Caps the result at 50 rows (frontend caps display at 20 in
+// T1552; the headroom is for future tabs that might want the full list).
+// PLAN-1542 / TASK-1545.
+func (s *Store) GetUserWorkspacesDetailed(userID string) ([]AdminUserWorkspaceDetail, error) {
+	openClause := adminOpenItemsCountClause()
+	openArgs := adminOpenItemTerminalArgs()
+
+	// Aggregations live in correlated subqueries rather than a wide JOIN +
+	// GROUP BY because the workspaces a single user belongs to are at most
+	// tens, not thousands — the subquery cost is fine and the SQL stays
+	// readable. items_open uses JSON_EXTRACT on the fields blob to read
+	// the status field, matching how the rest of the store queries it
+	// (see search.go).
+	query := `
+		SELECT
+			w.id, w.name, w.slug,
+			COALESCE(ou.username, ''),
+			wm.role, wm.created_at,
+			(SELECT COUNT(*) FROM collections c
+				WHERE c.workspace_id = w.id AND c.deleted_at IS NULL AND c.is_system = 0),
+			(SELECT COUNT(*) FROM items i
+				WHERE i.workspace_id = w.id AND i.deleted_at IS NULL AND ` + openClause + `),
+			(SELECT COUNT(*) FROM items i
+				WHERE i.workspace_id = w.id AND i.deleted_at IS NULL),
+			(SELECT COUNT(*) FROM workspace_members wm2 WHERE wm2.workspace_id = w.id),
+			(SELECT COALESCE(SUM(a.size_bytes), 0) FROM attachments a
+				WHERE a.workspace_id = w.id AND a.deleted_at IS NULL),
+			(SELECT MAX(i.updated_at) FROM items i
+				WHERE i.workspace_id = w.id AND i.deleted_at IS NULL)
+		FROM workspace_members wm
+		JOIN workspaces w ON w.id = wm.workspace_id
+		LEFT JOIN users ou ON ou.id = w.owner_id
+		WHERE wm.user_id = ? AND w.deleted_at IS NULL
+		ORDER BY w.name ASC
+		LIMIT 50`
+
+	// Two placeholder copies of openArgs because the subquery is
+	// referenced once but each `?` is a separate placeholder. The order
+	// is: openClause placeholders first, then wm.user_id.
+	args := make([]interface{}, 0, len(openArgs)+1)
+	args = append(args, openArgs...)
+	args = append(args, userID)
+
+	rows, err := s.db.Query(s.q(query), args...)
+	if err != nil {
+		return nil, fmt.Errorf("get user workspaces detailed: %w", err)
+	}
+	defer rows.Close()
+
+	out := make([]AdminUserWorkspaceDetail, 0)
+	for rows.Next() {
+		var d AdminUserWorkspaceDetail
+		var lastActivity sql.NullString
+		if err := rows.Scan(
+			&d.WorkspaceID, &d.WorkspaceName, &d.WorkspaceSlug,
+			&d.OwnerUsername,
+			&d.Role, &d.JoinedAt,
+			&d.CollectionsCount,
+			&d.ItemsOpen,
+			&d.ItemsTotal,
+			&d.MembersCount,
+			&d.StorageBytes,
+			&lastActivity,
+		); err != nil {
+			return nil, fmt.Errorf("scan workspace detail: %w", err)
+		}
+		if lastActivity.Valid {
+			d.LastActivityAt = lastActivity.String
+		}
+		out = append(out, d)
+	}
+	return out, rows.Err()
+}
+
 // GetUserWorkspaceMemberships returns workspace memberships for admin user detail.
 func (s *Store) GetUserWorkspaceMemberships(userID string) ([]AdminUserWorkspace, error) {
 	rows, err := s.db.Query(s.q(`

--- a/internal/store/workspace_members_admin_detail_test.go
+++ b/internal/store/workspace_members_admin_detail_test.go
@@ -1,0 +1,111 @@
+package store
+
+import (
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// TestGetUserWorkspacesDetailed seeds a workspace owned by a user with:
+//   - two user-facing collections, one system collection (counted as 0)
+//   - three items: one open (status=open), one done (terminal), one different collection
+//   - one attachment
+//   - one extra member
+//
+// And verifies all six aggregations land correctly.
+// PLAN-1542 / TASK-1545.
+func TestGetUserWorkspacesDetailed(t *testing.T) {
+	s := testStore(t)
+	owner := createTestUser(t, s, "owner@example.com", "Owner", "password123")
+	guest := createTestUser(t, s, "guest@example.com", "Guest", "password123")
+
+	ws, err := s.CreateWorkspace(models.WorkspaceCreate{Name: "Acme", Slug: "acme", OwnerID: owner.ID})
+	if err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	// In production the handler adds the owner to workspace_members at
+	// creation time (see internal/server/handlers_workspaces.go:256). Mimic
+	// that here so the membership-based query under test returns the row.
+	if err := s.AddWorkspaceMember(ws.ID, owner.ID, "owner"); err != nil {
+		t.Fatalf("add owner as member: %v", err)
+	}
+
+	// Two user-facing collections. createTestCollection seeds a select-status schema.
+	tasks := createTestCollection(t, s, ws.ID, "Tasks")
+	createTestCollection(t, s, ws.ID, "Ideas")
+
+	// System collection (should be excluded from collections_count).
+	if _, err := s.db.Exec(s.q(`
+		INSERT INTO collections (id, workspace_id, name, slug, prefix, icon, description, schema, settings, sort_order, is_default, is_system, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`), newID(), ws.ID, "Conventions", "conventions", "CONVE", "", "", `{"fields":[]}`, `{}`, 0, 0, 1, now(), now()); err != nil {
+		t.Fatalf("seed system collection: %v", err)
+	}
+
+	// Three items in the Tasks collection: open + done + a second open one
+	// just to verify the "open" predicate filters terminals.
+	_, _ = s.CreateItem(ws.ID, tasks.ID, models.ItemCreate{Title: "Open A", Fields: `{"status":"open"}`})
+	_, _ = s.CreateItem(ws.ID, tasks.ID, models.ItemCreate{Title: "Open B", Fields: `{"status":"open"}`})
+	// "done" is in the hardcoded terminal set; this counts as items_total but not items_open.
+	_, _ = s.CreateItem(ws.ID, tasks.ID, models.ItemCreate{Title: "Done", Fields: `{"status":"done"}`})
+
+	// Workspace_members: owner is auto-membered by CreateWorkspace; add guest.
+	if err := s.AddWorkspaceMember(ws.ID, guest.ID, "editor"); err != nil {
+		t.Fatalf("add guest member: %v", err)
+	}
+
+	// Attachment row: 250 bytes.
+	if _, err := s.db.Exec(s.q(`
+		INSERT INTO attachments (id, workspace_id, item_id, uploaded_by, storage_key, content_hash, mime_type, size_bytes, filename, created_at)
+		VALUES (?, ?, NULL, ?, ?, ?, ?, ?, ?, ?)
+	`), newID(), ws.ID, owner.ID, "k", "h", "image/png", int64(250), "x.png", now()); err != nil {
+		t.Fatalf("seed attachment: %v", err)
+	}
+
+	// As owner: should see one workspace with the right aggregations.
+	got, err := s.GetUserWorkspacesDetailed(owner.ID)
+	if err != nil {
+		t.Fatalf("GetUserWorkspacesDetailed: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("want 1 workspace; got %d", len(got))
+	}
+	w := got[0]
+	if w.CollectionsCount != 2 {
+		t.Errorf("collections_count (excl system): want 2 got %d", w.CollectionsCount)
+	}
+	if w.ItemsOpen != 2 {
+		t.Errorf("items_open (excl terminals): want 2 got %d", w.ItemsOpen)
+	}
+	if w.ItemsTotal != 3 {
+		t.Errorf("items_total: want 3 got %d", w.ItemsTotal)
+	}
+	if w.MembersCount != 2 {
+		t.Errorf("members_count (owner + guest): want 2 got %d", w.MembersCount)
+	}
+	if w.StorageBytes != 250 {
+		t.Errorf("storage_bytes: want 250 got %d", w.StorageBytes)
+	}
+	if w.LastActivityAt == "" {
+		t.Errorf("last_activity_at: want non-empty (items exist), got empty")
+	}
+
+	// Guest sees the same workspace via membership.
+	got, err = s.GetUserWorkspacesDetailed(guest.ID)
+	if err != nil {
+		t.Fatalf("guest view: %v", err)
+	}
+	if len(got) != 1 || got[0].WorkspaceID != ws.ID {
+		t.Fatalf("guest should see acme; got %+v", got)
+	}
+
+	// User with no memberships gets [].
+	loner := createTestUser(t, s, "loner@example.com", "Loner", "password123")
+	got, err = s.GetUserWorkspacesDetailed(loner.ID)
+	if err != nil {
+		t.Fatalf("loner view: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("loner should see no workspaces; got %d", len(got))
+	}
+}


### PR DESCRIPTION
## Summary

- New endpoint `GET /api/v1/admin/users/{userID}/detail` returns user vitals + per-workspace breakdown with six aggregations: `collections_count` (excludes system), `items_open`, `items_total`, `members_count`, `storage_bytes`, `last_activity_at`
- Single round-trip for the modal Workspaces tab (T1552 consumer)
- Hardcoded terminal-status set for the items_open count — schema-aware variant flagged as a follow-up

Third of five backend PRs from PLAN-1542.

## Implementation notes

- `Store.GetUserWorkspacesDetailed` uses correlated subqueries (one per aggregation) — a user belongs to at most tens of workspaces in practice, readability wins
- `AdminUserWorkspaceDetail` embeds the existing `AdminUserWorkspace` so the JSON shape is backward-compatible
- Result capped at 50 rows; the frontend Workspaces tab will cap visible at 20

## Test plan

- [x] `TestGetUserWorkspacesDetailed` — full aggregation fixture (collections excl system, items open vs terminal, members, storage, last_activity)
- [x] Empty-workspace user returns `[]`
- [x] Guest-member user sees workspace via membership join
- [x] Full `go test ./...` green

## Broken state after merge

None — purely additive endpoint. T1552 (modal Workspaces tab) consumes it.

## Depends on

TASK-1543 (merged), TASK-1544 (merged) — uses `LastWriteAt` field added to `models.User`.