### PR TITLE
feat(admin): GET /admin/users/{id}/metrics endpoint (TASK-1547)

### DIFF
--- a/internal/server/handlers_admin_users.go
+++ b/internal/server/handlers_admin_users.go
@@ -177,6 +177,37 @@ func (s *Server) handleAdminGetUser(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// handleAdminGetUserMetrics returns the windowed engagement metrics for
+// a single user — days_since_write, writes_7d, collections_touched_30d.
+// Powers the metric tiles on the admin user modal's Overview tab (T1553).
+//
+// Intentionally a small set of cheap signals. Per-request API tracking
+// is filed as a follow-up (IDEA-1556) and will surface as an additive
+// api_requests_7d field once the request-log table exists.
+//
+// PLAN-1542 / TASK-1547. GET /api/v1/admin/users/{userID}/metrics.
+func (s *Server) handleAdminGetUserMetrics(w http.ResponseWriter, r *http.Request) {
+	if !requireAdmin(w, r) {
+		return
+	}
+
+	userID := chi.URLParam(r, "userID")
+	if user, err := s.store.GetUser(userID); err != nil {
+		writeInternalError(w, err)
+		return
+	} else if user == nil {
+		writeError(w, http.StatusNotFound, "not_found", "User not found")
+		return
+	}
+
+	metrics, err := s.store.GetUserMetrics(userID)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, metrics)
+}
+
 // handleAdminGetUserActivity returns a paginated chronological feed of
 // activities originated by the user — item writes, comments, logins,
 // account changes the user made themselves. Powers the Activity tab of

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -896,6 +896,7 @@ func (s *Server) setupRouter() {
 				r.Get("/users/{userID}/workspaces", s.handleAdminGetUserWorkspaces)
 				r.Get("/users/{userID}/detail", s.handleAdminGetUserDetail)
 				r.Get("/users/{userID}/activity", s.handleAdminGetUserActivity)
+				r.Get("/users/{userID}/metrics", s.handleAdminGetUserMetrics)
 				r.Post("/users/{userID}/disable", s.handleAdminDisableUser)
 				r.Post("/users/{userID}/enable", s.handleAdminEnableUser)
 

--- a/internal/store/users.go
+++ b/internal/store/users.go
@@ -700,6 +700,100 @@ func (s *Store) RemoveOAuthProvider(userID, provider string) error {
 // ErrLastAdmin is returned when a role change would leave zero admins.
 var ErrLastAdmin = fmt.Errorf("cannot demote the last admin")
 
+// AdminUserMetrics carries the windowed engagement metrics rendered by the
+// admin user modal's Overview tab (T1553). Values are intentionally a
+// small handful of cheap signals; per-request API tracking is filed as a
+// follow-up (IDEA-1556). PLAN-1542 / TASK-1547.
+type AdminUserMetrics struct {
+	// DaysSinceWrite is days since users.last_write_at, rounded down.
+	// nil when the user has never had a write recorded.
+	DaysSinceWrite *int `json:"days_since_write"`
+	// Writes7d is the count of write activities (items + comments)
+	// authored in the last 7 days.
+	Writes7d int `json:"writes_7d"`
+	// CollectionsTouched30d is the count of DISTINCT collection_ids
+	// touched by this user's item-write activities in the last 30 days.
+	CollectionsTouched30d int `json:"collections_touched_30d"`
+}
+
+// GetUserMetrics computes the AdminUserMetrics bundle. Cheap by design:
+//   - days_since_write reads users.last_write_at directly (one row)
+//   - writes_7d is a COUNT over activities (indexed on user_id, created_at)
+//   - collections_touched_30d JOINs activities to items to pull collection_id
+//     (items.last_modified_by is an attribution string, not a user FK — see
+//     the T1543 architecture note — so we go through activities.user_id).
+//
+// PLAN-1542 / TASK-1547. Caching is intentionally not implemented here;
+// the queries are all index-backed scalar aggregations, and a per-user
+// short cache lives more naturally at the handler boundary if needed.
+func (s *Store) GetUserMetrics(userID string) (*AdminUserMetrics, error) {
+	now := time.Now().UTC()
+	cutoff7d := now.Add(-7 * 24 * time.Hour).Format(time.RFC3339)
+	cutoff30d := now.Add(-30 * 24 * time.Hour).Format(time.RFC3339)
+
+	out := &AdminUserMetrics{}
+
+	// days_since_write
+	var lwa sql.NullString
+	if err := s.db.QueryRow(s.q(`SELECT last_write_at FROM users WHERE id = ?`), userID).Scan(&lwa); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, fmt.Errorf("user not found")
+		}
+		return nil, fmt.Errorf("get user metrics last_write_at: %w", err)
+	}
+	if lwa.Valid && lwa.String != "" {
+		if t, err := time.Parse(time.RFC3339, lwa.String); err == nil {
+			d := int(now.Sub(t).Hours() / 24)
+			if d < 0 {
+				d = 0
+			}
+			out.DaysSinceWrite = &d
+		}
+	}
+
+	// writes_7d — write-class activities by this user in the last 7d.
+	writeActions := []string{"created", "updated", "archived", "restored", "moved", "commented"}
+	placeholders := make([]string, len(writeActions))
+	args := make([]interface{}, 0, len(writeActions)+2)
+	args = append(args, userID, cutoff7d)
+	for i, a := range writeActions {
+		placeholders[i] = "?"
+		args = append(args, a)
+	}
+	writesQuery := s.q(`
+		SELECT COUNT(*)
+		FROM activities
+		WHERE user_id = ? AND created_at >= ?
+		  AND action IN (` + strings.Join(placeholders, ", ") + `)
+	`)
+	if err := s.db.QueryRow(writesQuery, args...).Scan(&out.Writes7d); err != nil {
+		return nil, fmt.Errorf("get user metrics writes_7d: %w", err)
+	}
+
+	// collections_touched_30d — DISTINCT collection_id of items the user
+	// has authored writes for in the last 30d. Restrict to item-scoped
+	// activities (document_id IS NOT NULL); commented activities live on
+	// the same document so they count too.
+	args = args[:0]
+	args = append(args, userID, cutoff30d)
+	for _, a := range writeActions {
+		args = append(args, a)
+	}
+	collQuery := s.q(`
+		SELECT COUNT(DISTINCT i.collection_id)
+		FROM activities a
+		JOIN items i ON i.id = a.document_id
+		WHERE a.user_id = ? AND a.created_at >= ?
+		  AND a.action IN (` + strings.Join(placeholders, ", ") + `)
+		  AND i.deleted_at IS NULL
+	`)
+	if err := s.db.QueryRow(collQuery, args...).Scan(&out.CollectionsTouched30d); err != nil {
+		return nil, fmt.Errorf("get user metrics collections_touched_30d: %w", err)
+	}
+
+	return out, nil
+}
+
 // TouchUserActivity updates last_active_at for a user, throttled to avoid
 // write amplification. Only writes if the stored value is older than 5 minutes.
 // Accepts a context so callers can bound the write duration.

--- a/internal/store/users_metrics_test.go
+++ b/internal/store/users_metrics_test.go
@@ -1,0 +1,91 @@
+package store
+
+import (
+	"testing"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// TestGetUserMetrics covers the three engagement metrics from T1547:
+// days_since_write, writes_7d, collections_touched_30d.
+func TestGetUserMetrics(t *testing.T) {
+	s := testStore(t)
+	alice := createTestUser(t, s, "alice@example.com", "Alice", "password123")
+	ws, err := s.CreateWorkspace(models.WorkspaceCreate{Name: "Acme", Slug: "acme", OwnerID: alice.ID})
+	if err != nil {
+		t.Fatalf("workspace: %v", err)
+	}
+	tasks := createTestCollection(t, s, ws.ID, "Tasks")
+	ideas := createTestCollection(t, s, ws.ID, "Ideas")
+
+	// One item in each of two collections — needed for the
+	// collections_touched_30d DISTINCT count.
+	taskItem := createTestItem(t, s, ws.ID, tasks.ID, "T1", "")
+	ideaItem := createTestItem(t, s, ws.ID, ideas.ID, "I1", "")
+
+	// Touch last_write_at to now via the production code path.
+	s.TouchUserWrite(t.Context(), alice.ID)
+
+	// Seed write activities. Five "created"/"updated" within the 7d
+	// window, one "commented" within the window, one "updated" 60 days
+	// ago (outside both windows).
+	mk := func(docID, action, when string) {
+		// Bypass logActivity helper — write directly so we control timestamp.
+		if _, err := s.db.Exec(s.q(`
+			INSERT INTO activities (id, workspace_id, document_id, action, actor, source, metadata, user_id, ip_address, user_agent, created_at)
+			VALUES (?, ?, ?, ?, 'user', 'web', '{}', ?, NULL, NULL, ?)
+		`), newID(), ws.ID, docID, action, alice.ID, when); err != nil {
+			t.Fatalf("seed activity: %v", err)
+		}
+	}
+	recent := time.Now().UTC().Format(time.RFC3339)
+	ancient := time.Now().UTC().Add(-60 * 24 * time.Hour).Format(time.RFC3339)
+
+	mk(taskItem.ID, "created", recent)
+	mk(taskItem.ID, "updated", recent)
+	mk(taskItem.ID, "updated", recent)
+	mk(ideaItem.ID, "created", recent)
+	mk(ideaItem.ID, "commented", recent)
+	mk(taskItem.ID, "updated", ancient) // outside both windows
+
+	m, err := s.GetUserMetrics(alice.ID)
+	if err != nil {
+		t.Fatalf("GetUserMetrics: %v", err)
+	}
+
+	// days_since_write — TouchUserWrite ran moments ago, so this is 0.
+	if m.DaysSinceWrite == nil || *m.DaysSinceWrite != 0 {
+		t.Errorf("days_since_write: want 0, got %v", m.DaysSinceWrite)
+	}
+	// writes_7d — 5 within window (created/updated/updated/created/commented).
+	// The ancient row is excluded by the 7-day cutoff.
+	if m.Writes7d != 5 {
+		t.Errorf("writes_7d: want 5, got %d", m.Writes7d)
+	}
+	// collections_touched_30d — distinct collection_id from items written
+	// in last 30d. Two collections touched (tasks + ideas).
+	if m.CollectionsTouched30d != 2 {
+		t.Errorf("collections_touched_30d: want 2, got %d", m.CollectionsTouched30d)
+	}
+}
+
+// TestGetUserMetricsEmptyUser ensures a user with no activity returns
+// zero counts and a nil days_since_write rather than an error.
+func TestGetUserMetricsEmptyUser(t *testing.T) {
+	s := testStore(t)
+	u := createTestUser(t, s, "fresh@example.com", "Fresh", "password123")
+	m, err := s.GetUserMetrics(u.ID)
+	if err != nil {
+		t.Fatalf("GetUserMetrics on empty user: %v", err)
+	}
+	if m.DaysSinceWrite != nil {
+		t.Errorf("days_since_write: want nil, got %d", *m.DaysSinceWrite)
+	}
+	if m.Writes7d != 0 {
+		t.Errorf("writes_7d: want 0, got %d", m.Writes7d)
+	}
+	if m.CollectionsTouched30d != 0 {
+		t.Errorf("collections_touched_30d: want 0, got %d", m.CollectionsTouched30d)
+	}
+}


### PR DESCRIPTION
## Summary

- New endpoint `GET /api/v1/admin/users/{userID}/metrics` returns the three engagement signals for the user modal's Overview tab tiles
- `days_since_write` (from `users.last_write_at`), `writes_7d` (COUNT activities), `collections_touched_30d` (DISTINCT collection_id from items the user wrote)
- `api_requests_7d` deliberately omitted — no per-request log exists; tracked as IDEA-1556

Last of five backend PRs from PLAN-1542. The full backend tier of admin user management enhancements is now in place; frontend tasks (T1548-T1555) consume these endpoints.

## Test plan

- [x] `TestGetUserMetrics` — full 3-metric fixture: days-since-write (0 after TouchUserWrite), writes_7d (5 in-window, 1 ancient excluded), collections_touched_30d (DISTINCT over 2 collections)
- [x] `TestGetUserMetricsEmptyUser` — nil days_since_write + zero counts (no error)
- [x] Full `go test ./...` green

## Broken state after merge

None — purely additive. T1553 (modal Overview tab) consumes it.

## Depends on

TASK-1543 (merged) — uses `users.last_write_at`.