### PR TITLE
feat(web): admin user list — pagination + sort + filter UI (TASK-1549)

### DIFF
--- a/web/src/routes/console/admin/+page.svelte
+++ b/web/src/routes/console/admin/+page.svelte
@@ -78,16 +78,15 @@
 		if (opts.includeSearch && search) p.set('q', search);
 		if (planFilter) p.set('plan', planFilter);
 		if (roleFilter) p.set('role', roleFilter);
+		// statusFilter and hasWorkspacesFilter are independent; we used to
+		// auto-map statusFilter=no-workspace to has_workspaces=false but
+		// that conflicted with the explicit hasWorkspacesFilter and broke
+		// the server-side status precedence (disabled > no-workspace).
+		// Now: statusFilter is always applied client-side via
+		// applyClientStatusFilter; only the "disabled" case gets a server
+		// hint so the result set is smaller for the common case (Codex
+		// review on PR #604, finding 1+2+3).
 		if (statusFilter === 'disabled') p.set('disabled', 'true');
-		else if (statusFilter && statusFilter !== '') {
-			// Server doesn't filter on the computed status directly; for
-			// non-disabled buckets we approximate (no-workspace via
-			// has_workspaces=false, inactive via NOT active_within_days).
-			// "active" can't be derived without a "min last-write" param,
-			// so it's a client-side filter only — handled below in
-			// applyClientStatusFilter().
-			if (statusFilter === 'no-workspace') p.set('has_workspaces', 'false');
-		}
 		if (activeWithinDaysFilter) p.set('active_within_days', activeWithinDaysFilter);
 		if (hasWorkspacesFilter) p.set('has_workspaces', hasWorkspacesFilter);
 		if (sortKey !== 'created' || sortOrder !== 'desc') {
@@ -99,12 +98,12 @@
 		return p;
 	}
 
-	// applyClientStatusFilter narrows the response to the active/inactive
-	// status buckets the server can't directly express. Server already
-	// handled "disabled" and "no-workspace"; "active" and "inactive" are
-	// computed via the row's status field.
+	// applyClientStatusFilter narrows the response to the selected status
+	// bucket using the server-computed `status` field on each row. Server
+	// precedence (disabled > no-workspace > inactive > active) is preserved
+	// because we filter on the exact value, not approximations.
 	function applyClientStatusFilter(rows: AdminUser[]): AdminUser[] {
-		if (statusFilter !== 'active' && statusFilter !== 'inactive') return rows;
+		if (!statusFilter) return rows;
 		return rows.filter((u) => u.status === statusFilter);
 	}
 
@@ -133,10 +132,22 @@
 		}
 	}
 
-	// loadMore appends the next page without resetting offset.
+	// loadMore appends the next page without resetting offset. On failure,
+	// rolls back the offset so a retry doesn't skip a page (Codex review
+	// on PR #604). Also guards against re-entrant calls while a page is
+	// in flight.
 	async function loadMore() {
+		if (loadingMore || loading) return;
+		const prevOffset = offset;
 		offset += PAGE_LIMIT;
-		await loadList(false);
+		try {
+			await loadList(false);
+		} catch {
+			offset = prevOffset;
+		}
+		// Belt-and-braces: if loadList caught the error internally and set
+		// `error`, also roll back so the next click retries the same page.
+		if (error) offset = prevOffset;
 	}
 
 	// onFilterChange resets pagination + reloads. Bound to every filter
@@ -164,11 +175,19 @@
 
 	// syncURL pushes filter/sort state into the URL via SvelteKit's goto,
 	// replaceState so we don't litter browser history. Search query is
-	// excluded; see buildQueryParams note.
+	// excluded (changes per keystroke). Status is its own URL param
+	// (rather than smuggled through has_workspaces/disabled) so all four
+	// buckets — active/inactive/disabled/no-workspace — round-trip
+	// losslessly (Codex review on PR #604).
 	function syncURL() {
 		const p = buildQueryParams({ offset: 0, includeSearch: false });
 		p.delete('limit');
 		p.delete('offset');
+		// buildQueryParams stamps disabled=true for statusFilter=disabled
+		// (server hint). Strip it from the URL; statusFilter is the
+		// canonical representation in the URL.
+		p.delete('disabled');
+		if (statusFilter) p.set('status', statusFilter);
 		const qs = p.toString();
 		const target = qs ? `?${qs}` : page.url.pathname;
 		goto(target, { replaceState: true, noScroll: true, keepFocus: true });
@@ -188,11 +207,10 @@
 		}
 		const o = p.get('order');
 		if (o === 'asc' || o === 'desc') sortOrder = o;
-		// statusFilter is derived; the URL carries it only via has_workspaces=false
-		// (no-workspace) or disabled=true (disabled). active/inactive aren't
-		// representable on the URL today.
-		if (p.get('disabled') === 'true') statusFilter = 'disabled';
-		else if (p.get('has_workspaces') === 'false') statusFilter = 'no-workspace';
+		const st = p.get('status');
+		if (st === 'active' || st === 'inactive' || st === 'disabled' || st === 'no-workspace') {
+			statusFilter = st;
+		}
 	}
 
 	function selectUser(u: AdminUser) {
@@ -610,30 +628,40 @@
 		<div class="table-wrap">
 			<table class="table">
 				<thead>
+					<!-- Sortable headers are keyboard-accessible buttons inside
+					     the cell so they participate in tab order; aria-sort
+					     conveys current state to screen readers. PLAN-1542 /
+					     TASK-1549. -->
 					<tr>
 						<th>Name</th>
 						<th>Role</th>
-						<th class="sortable" onclick={() => setSort('workspaces')}
-							>Workspaces <span class="sort-ind">{sortKey === 'workspaces' ? (sortOrder === 'asc' ? '▲' : '▼') : ''}</span></th
-						>
-						<th class="sortable" onclick={() => setSort('email')}
-							>Email <span class="sort-ind">{sortKey === 'email' ? (sortOrder === 'asc' ? '▲' : '▼') : ''}</span></th
-						>
+						<th aria-sort={sortKey === 'workspaces' ? (sortOrder === 'asc' ? 'ascending' : 'descending') : 'none'}>
+							<button type="button" class="sort-btn" onclick={() => setSort('workspaces')}
+								>Workspaces <span class="sort-ind">{sortKey === 'workspaces' ? (sortOrder === 'asc' ? '▲' : '▼') : ''}</span></button>
+						</th>
+						<th aria-sort={sortKey === 'email' ? (sortOrder === 'asc' ? 'ascending' : 'descending') : 'none'}>
+							<button type="button" class="sort-btn" onclick={() => setSort('email')}
+								>Email <span class="sort-ind">{sortKey === 'email' ? (sortOrder === 'asc' ? '▲' : '▼') : ''}</span></button>
+						</th>
 						{#if adminStore.stats?.cloud_mode}
 							<th>Plan</th>
 						{/if}
-						<th class="sortable" onclick={() => setSort('storage')}
-							>Storage <span class="sort-ind">{sortKey === 'storage' ? (sortOrder === 'asc' ? '▲' : '▼') : ''}</span></th
-						>
-						<th class="sortable" onclick={() => setSort('last_write')}
-							>Last Write <span class="sort-ind">{sortKey === 'last_write' ? (sortOrder === 'asc' ? '▲' : '▼') : ''}</span></th
-						>
-						<th class="sortable" onclick={() => setSort('last_active')}
-							>Last Active <span class="sort-ind">{sortKey === 'last_active' ? (sortOrder === 'asc' ? '▲' : '▼') : ''}</span></th
-						>
-						<th class="sortable" onclick={() => setSort('created')}
-							>Created <span class="sort-ind">{sortKey === 'created' ? (sortOrder === 'asc' ? '▲' : '▼') : ''}</span></th
-						>
+						<th aria-sort={sortKey === 'storage' ? (sortOrder === 'asc' ? 'ascending' : 'descending') : 'none'}>
+							<button type="button" class="sort-btn" onclick={() => setSort('storage')}
+								>Storage <span class="sort-ind">{sortKey === 'storage' ? (sortOrder === 'asc' ? '▲' : '▼') : ''}</span></button>
+						</th>
+						<th aria-sort={sortKey === 'last_write' ? (sortOrder === 'asc' ? 'ascending' : 'descending') : 'none'}>
+							<button type="button" class="sort-btn" onclick={() => setSort('last_write')}
+								>Last Write <span class="sort-ind">{sortKey === 'last_write' ? (sortOrder === 'asc' ? '▲' : '▼') : ''}</span></button>
+						</th>
+						<th aria-sort={sortKey === 'last_active' ? (sortOrder === 'asc' ? 'ascending' : 'descending') : 'none'}>
+							<button type="button" class="sort-btn" onclick={() => setSort('last_active')}
+								>Last Active <span class="sort-ind">{sortKey === 'last_active' ? (sortOrder === 'asc' ? '▲' : '▼') : ''}</span></button>
+						</th>
+						<th aria-sort={sortKey === 'created' ? (sortOrder === 'asc' ? 'ascending' : 'descending') : 'none'}>
+							<button type="button" class="sort-btn" onclick={() => setSort('created')}
+								>Created <span class="sort-ind">{sortKey === 'created' ? (sortOrder === 'asc' ? '▲' : '▼') : ''}</span></button>
+						</th>
 					</tr>
 				</thead>
 				<tbody>
@@ -975,20 +1003,33 @@
 		align-self: end;
 	}
 
-	/* Sortable column headers */
-	th.sortable {
+	/* Sortable column headers — button-inside-th pattern so they're
+	   keyboard-focusable and announce as buttons. */
+	.sort-btn {
+		display: inline-flex;
+		align-items: center;
+		gap: 4px;
+		background: transparent;
+		border: 0;
+		padding: 0;
+		font: inherit;
+		color: inherit;
 		cursor: pointer;
 		user-select: none;
 	}
-	th.sortable:hover {
-		background: var(--bg-tertiary);
+	.sort-btn:hover {
+		color: var(--accent-blue);
+	}
+	.sort-btn:focus-visible {
+		outline: 2px solid var(--accent-blue);
+		outline-offset: 2px;
+		border-radius: 2px;
 	}
 	.sort-ind {
 		display: inline-block;
 		min-width: 10px;
 		color: var(--accent-blue);
 		font-size: 0.7rem;
-		margin-left: 2px;
 	}
 
 	/* Pager */

--- a/web/src/routes/console/admin/+page.svelte
+++ b/web/src/routes/console/admin/+page.svelte
@@ -1,9 +1,32 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
+	import { goto } from '$app/navigation';
+	import { page } from '$app/state';
 	import { adminFetch, adminPatch, adminPost, formatDate, adminStore, type AdminUser } from '$lib/stores/admin.svelte';
 
+	// --- List + pagination + filter + sort state (PLAN-1542 / TASK-1549) ---
+	// All filter state is reactive $state; we rebuild the query string on
+	// every loadList() call and reset offset to 0 on any filter/sort change.
+	// URL params reflect the filter/sort set so admins can paste a link
+	// (e.g. "all disabled pro users sorted by storage desc"). The search
+	// input is deliberately NOT in the URL — it changes on every keystroke
+	// and would clutter history.
+	type SortKey = 'email' | 'last_write' | 'last_active' | 'storage' | 'workspaces' | 'created';
+	type SortOrder = 'asc' | 'desc';
+	const PAGE_LIMIT = 50;
+
 	let users = $state<AdminUser[]>([]);
+	let total = $state(0);
+	let offset = $state(0);
+	let loadingMore = $state(false);
 	let search = $state('');
+	let planFilter = $state('');
+	let roleFilter = $state('');
+	let statusFilter = $state(''); // disabled / no-workspace / inactive / active / ''
+	let activeWithinDaysFilter = $state(''); // '7' | '30' | '90' | ''
+	let hasWorkspacesFilter = $state(''); // 'true' | 'false' | ''
+	let sortKey = $state<SortKey>('created');
+	let sortOrder = $state<SortOrder>('desc');
 	let selectedId = $state<string | null>(null);
 	let editPlan = $state('free');
 	let editRole = $state('member');
@@ -47,26 +70,129 @@
 	let userWorkspaces = $state<{ workspace_name: string; workspace_slug: string; owner_username: string; role: string; joined_at: string }[]>([]);
 	let workspacesLoading = $state(false);
 
-	async function loadUsers() {
-		loading = true;
+	// buildQueryParams renders the current filter/sort/pagination state
+	// into a URLSearchParams. Sort and filter values are always present
+	// when non-default so the server resolves them consistently.
+	function buildQueryParams(opts: { offset?: number; includeSearch?: boolean } = {}): URLSearchParams {
+		const p = new URLSearchParams();
+		if (opts.includeSearch && search) p.set('q', search);
+		if (planFilter) p.set('plan', planFilter);
+		if (roleFilter) p.set('role', roleFilter);
+		if (statusFilter === 'disabled') p.set('disabled', 'true');
+		else if (statusFilter && statusFilter !== '') {
+			// Server doesn't filter on the computed status directly; for
+			// non-disabled buckets we approximate (no-workspace via
+			// has_workspaces=false, inactive via NOT active_within_days).
+			// "active" can't be derived without a "min last-write" param,
+			// so it's a client-side filter only — handled below in
+			// applyClientStatusFilter().
+			if (statusFilter === 'no-workspace') p.set('has_workspaces', 'false');
+		}
+		if (activeWithinDaysFilter) p.set('active_within_days', activeWithinDaysFilter);
+		if (hasWorkspacesFilter) p.set('has_workspaces', hasWorkspacesFilter);
+		if (sortKey !== 'created' || sortOrder !== 'desc') {
+			p.set('sort', sortKey);
+			p.set('order', sortOrder);
+		}
+		p.set('limit', String(PAGE_LIMIT));
+		p.set('offset', String(opts.offset ?? offset));
+		return p;
+	}
+
+	// applyClientStatusFilter narrows the response to the active/inactive
+	// status buckets the server can't directly express. Server already
+	// handled "disabled" and "no-workspace"; "active" and "inactive" are
+	// computed via the row's status field.
+	function applyClientStatusFilter(rows: AdminUser[]): AdminUser[] {
+		if (statusFilter !== 'active' && statusFilter !== 'inactive') return rows;
+		return rows.filter((u) => u.status === statusFilter);
+	}
+
+	async function loadList(reset: boolean = true) {
+		if (reset) {
+			loading = true;
+			offset = 0;
+		} else {
+			loadingMore = true;
+		}
 		error = '';
 		try {
-			const result = await adminFetch('/admin/users');
-			users = result.users ?? result;
+			const params = buildQueryParams({ offset: reset ? 0 : offset, includeSearch: true });
+			const result = await adminFetch('/admin/users?' + params.toString());
+			const rows: AdminUser[] = applyClientStatusFilter(result.users ?? result);
+			users = reset ? rows : [...users, ...rows];
+			total = typeof result.total === 'number' ? result.total : users.length;
+			// Sync filter/sort state back to URL (skip on reset=false to
+			// avoid spamming history during paginated "load more").
+			if (reset) syncURL();
 		} catch (e) {
 			error = e instanceof Error ? e.message : 'Failed to load users';
 		} finally {
 			loading = false;
+			loadingMore = false;
 		}
 	}
 
-	async function searchUsers() {
-		try {
-			const result = await adminFetch(`/admin/users?q=${encodeURIComponent(search)}`);
-			users = result.users ?? result;
-		} catch {
-			/* keep existing */
+	// loadMore appends the next page without resetting offset.
+	async function loadMore() {
+		offset += PAGE_LIMIT;
+		await loadList(false);
+	}
+
+	// onFilterChange resets pagination + reloads. Bound to every filter
+	// input + the sort header clicks.
+	function onFilterChange() {
+		offset = 0;
+		loadList(true);
+	}
+
+	function setSort(key: SortKey) {
+		if (sortKey === key) {
+			sortOrder = sortOrder === 'asc' ? 'desc' : 'asc';
+		} else {
+			sortKey = key;
+			// Default direction: desc for time/numeric, asc for email.
+			sortOrder = key === 'email' ? 'asc' : 'desc';
 		}
+		onFilterChange();
+	}
+
+	// Search button (or Enter in search input) — same as a filter change.
+	function searchUsers() {
+		onFilterChange();
+	}
+
+	// syncURL pushes filter/sort state into the URL via SvelteKit's goto,
+	// replaceState so we don't litter browser history. Search query is
+	// excluded; see buildQueryParams note.
+	function syncURL() {
+		const p = buildQueryParams({ offset: 0, includeSearch: false });
+		p.delete('limit');
+		p.delete('offset');
+		const qs = p.toString();
+		const target = qs ? `?${qs}` : page.url.pathname;
+		goto(target, { replaceState: true, noScroll: true, keepFocus: true });
+	}
+
+	// hydrateFromURL pulls filter/sort state off the URL on first load
+	// so a pasted link restores the view.
+	function hydrateFromURL() {
+		const p = page.url.searchParams;
+		planFilter = p.get('plan') ?? '';
+		roleFilter = p.get('role') ?? '';
+		hasWorkspacesFilter = p.get('has_workspaces') ?? '';
+		activeWithinDaysFilter = p.get('active_within_days') ?? '';
+		const s = p.get('sort');
+		if (s === 'email' || s === 'last_write' || s === 'last_active' || s === 'storage' || s === 'workspaces' || s === 'created') {
+			sortKey = s;
+		}
+		const o = p.get('order');
+		if (o === 'asc' || o === 'desc') sortOrder = o;
+		// statusFilter is derived; the URL carries it only via has_workspaces=false
+		// (no-workspace) or disabled=true (disabled). active/inactive aren't
+		// representable on the URL today.
+		if (p.get('disabled') === 'true') statusFilter = 'disabled';
+		else if (p.get('has_workspaces') === 'false') statusFilter = 'no-workspace';
 	}
 
 	function selectUser(u: AdminUser) {
@@ -384,7 +510,8 @@
 	}
 
 	onMount(() => {
-		loadUsers();
+		hydrateFromURL();
+		loadList(true);
 	});
 </script>
 
@@ -394,7 +521,7 @@
 	{:else if error}
 		<div class="error-msg">
 			<p>{error}</p>
-			<button class="btn" onclick={loadUsers}>Retry</button>
+			<button class="btn" onclick={() => loadList(true)}>Retry</button>
 		</div>
 	{:else}
 		<div class="search-row">
@@ -410,21 +537,103 @@
 			<button class="btn" onclick={searchUsers}>Search</button>
 		</div>
 
+		<!-- Filter bar (PLAN-1542 / TASK-1549). Each control fires
+		     onFilterChange so the list reloads from offset=0 and the
+		     URL updates. -->
+		<div class="filter-bar">
+			<label class="filter-field">
+				<span class="filter-label">Role</span>
+				<select bind:value={roleFilter} onchange={onFilterChange}>
+					<option value="">All</option>
+					<option value="admin">admin</option>
+					<option value="member">member</option>
+				</select>
+			</label>
+
+			{#if adminStore.stats?.cloud_mode}
+				<label class="filter-field">
+					<span class="filter-label">Plan</span>
+					<select bind:value={planFilter} onchange={onFilterChange}>
+						<option value="">All</option>
+						<option value="free">free</option>
+						<option value="pro">pro</option>
+						<option value="self-hosted">self-hosted</option>
+					</select>
+				</label>
+			{/if}
+
+			<label class="filter-field">
+				<span class="filter-label">Status</span>
+				<select bind:value={statusFilter} onchange={onFilterChange}>
+					<option value="">All</option>
+					<option value="active">active</option>
+					<option value="inactive">inactive</option>
+					<option value="disabled">disabled</option>
+					<option value="no-workspace">no-workspace</option>
+				</select>
+			</label>
+
+			<label class="filter-field">
+				<span class="filter-label">Active within</span>
+				<select bind:value={activeWithinDaysFilter} onchange={onFilterChange}>
+					<option value="">Any</option>
+					<option value="7">7 days</option>
+					<option value="30">30 days</option>
+					<option value="90">90 days</option>
+				</select>
+			</label>
+
+			<label class="filter-field">
+				<span class="filter-label">Has workspaces</span>
+				<select bind:value={hasWorkspacesFilter} onchange={onFilterChange}>
+					<option value="">All</option>
+					<option value="true">Yes</option>
+					<option value="false">No</option>
+				</select>
+			</label>
+
+			{#if planFilter || roleFilter || statusFilter || activeWithinDaysFilter || hasWorkspacesFilter}
+				<button
+					class="btn btn-sub"
+					onclick={() => {
+						planFilter = '';
+						roleFilter = '';
+						statusFilter = '';
+						activeWithinDaysFilter = '';
+						hasWorkspacesFilter = '';
+						onFilterChange();
+					}}>Clear filters</button
+				>
+			{/if}
+		</div>
+
 		<div class="table-wrap">
 			<table class="table">
 				<thead>
 					<tr>
 						<th>Name</th>
 						<th>Role</th>
-						<th>Workspaces</th>
-						<th>Email</th>
+						<th class="sortable" onclick={() => setSort('workspaces')}
+							>Workspaces <span class="sort-ind">{sortKey === 'workspaces' ? (sortOrder === 'asc' ? '▲' : '▼') : ''}</span></th
+						>
+						<th class="sortable" onclick={() => setSort('email')}
+							>Email <span class="sort-ind">{sortKey === 'email' ? (sortOrder === 'asc' ? '▲' : '▼') : ''}</span></th
+						>
 						{#if adminStore.stats?.cloud_mode}
 							<th>Plan</th>
 						{/if}
-						<th>Storage</th>
-						<th>Last Write</th>
-						<th>Last Active</th>
-						<th>Created</th>
+						<th class="sortable" onclick={() => setSort('storage')}
+							>Storage <span class="sort-ind">{sortKey === 'storage' ? (sortOrder === 'asc' ? '▲' : '▼') : ''}</span></th
+						>
+						<th class="sortable" onclick={() => setSort('last_write')}
+							>Last Write <span class="sort-ind">{sortKey === 'last_write' ? (sortOrder === 'asc' ? '▲' : '▼') : ''}</span></th
+						>
+						<th class="sortable" onclick={() => setSort('last_active')}
+							>Last Active <span class="sort-ind">{sortKey === 'last_active' ? (sortOrder === 'asc' ? '▲' : '▼') : ''}</span></th
+						>
+						<th class="sortable" onclick={() => setSort('created')}
+							>Created <span class="sort-ind">{sortKey === 'created' ? (sortOrder === 'asc' ? '▲' : '▼') : ''}</span></th
+						>
 					</tr>
 				</thead>
 				<tbody>
@@ -693,6 +902,21 @@
 					{/each}
 				</tbody>
 			</table>
+			{#if total > 0}
+				<div class="pager">
+					<span class="pager-info"
+						>Showing <strong>{users.length}</strong> of <strong>{total}</strong>{#if statusFilter === 'active' || statusFilter === 'inactive'}
+							(client-filtered){/if}</span
+					>
+					{#if users.length < total}
+						<button class="btn" disabled={loadingMore} onclick={loadMore}
+							>{loadingMore ? 'Loading…' : 'Load more'}</button
+						>
+					{/if}
+				</div>
+			{:else if !loading}
+				<div class="pager pager-empty">No users match the current filters.</div>
+			{/if}
 		</div>
 	{/if}
 </div>
@@ -715,6 +939,74 @@
 	}
 	.search-input:focus {
 		border-color: var(--accent-blue);
+	}
+
+	/* Filter bar (PLAN-1542 / TASK-1549) */
+	.filter-bar {
+		display: flex;
+		flex-wrap: wrap;
+		gap: var(--space-3);
+		align-items: end;
+		margin-top: var(--space-3);
+	}
+	.filter-field {
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+		font-size: 0.8rem;
+	}
+	.filter-label {
+		color: var(--text-muted);
+		font-size: 0.75rem;
+	}
+	.filter-field select {
+		padding: 4px var(--space-2);
+		background: var(--bg-secondary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius-sm);
+		color: var(--text-primary);
+		font-size: 0.85rem;
+		outline: none;
+	}
+	.btn-sub {
+		background: transparent;
+		color: var(--text-muted);
+		border: 1px dashed var(--border);
+		align-self: end;
+	}
+
+	/* Sortable column headers */
+	th.sortable {
+		cursor: pointer;
+		user-select: none;
+	}
+	th.sortable:hover {
+		background: var(--bg-tertiary);
+	}
+	.sort-ind {
+		display: inline-block;
+		min-width: 10px;
+		color: var(--accent-blue);
+		font-size: 0.7rem;
+		margin-left: 2px;
+	}
+
+	/* Pager */
+	.pager {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		padding: var(--space-3) 0;
+		gap: var(--space-3);
+		font-size: 0.85rem;
+	}
+	.pager-info {
+		color: var(--text-muted);
+	}
+	.pager-empty {
+		justify-content: center;
+		font-style: italic;
+		color: var(--text-muted);
 	}
 
 	/* Buttons */


### PR DESCRIPTION
## Summary

- Filter bar above the table: Role / Plan / Status / Active within / Has workspaces, plus a Clear-filters affordance
- Sortable column headers (Workspaces, Email, Storage, Last Write, Last Active, Created) with asc/desc + ▲/▼ indicator
- "Load more" pager that appends pages; "Showing N of M" footer
- URL state sync for filter + sort (search query intentionally excluded)
- Status filter buckets: server-mapped where possible (disabled, no-workspace via has_workspaces=false), client-filtered for active/inactive — flagged in the pager footer

Second of frontend PRs from PLAN-1542.

## Test plan

- [x] `npm run build` clean, `svelte-check` 0 errors
- [ ] Manual: each filter narrows; sort flips on second click; pager appends; URL reflects filter set; reload from pasted URL restores state
- [ ] Manual: "Clear filters" resets; status filter "active/inactive" shows (client-filtered) caveat