### PR TITLE
feat(web): admin user modal shell with empty tabs (TASK-1550)

### DIFF
--- a/web/src/lib/components/admin/UserModal.svelte
+++ b/web/src/lib/components/admin/UserModal.svelte
@@ -1,0 +1,322 @@
+<!--
+  Admin user detail modal — the new home for per-user deep view that
+  replaces the inline-expand pattern on the user table.
+
+  This task (T1550) lands ONLY the shell: open/close, tab nav, ESC + click-
+  outside dismiss, focus trap basics, and empty placeholders. Tab content
+  arrives across T1551 (Settings & overrides — lifts the inline-expand
+  form), T1552 (Workspaces), T1553 (Overview), T1554 (Activity). T1555
+  deletes the inline-expand DOM from the host page.
+
+  During T1550–T1554 the inline-expand still works in parallel with the
+  modal; that's the explicit "broken state" the plan accepts to keep PRs
+  small. Documented in the on-click handler comment in the host page.
+
+  PLAN-1542 / TASK-1550.
+-->
+<script lang="ts">
+	import { onMount, onDestroy } from 'svelte';
+	import { tick } from 'svelte';
+	import type { AdminUser } from '$lib/stores/admin.svelte';
+
+	export type UserModalTab = 'overview' | 'workspaces' | 'activity' | 'settings';
+
+	interface Props {
+		user: AdminUser | null;
+		open: boolean;
+		initialTab?: UserModalTab;
+		onClose: () => void;
+	}
+
+	let { user, open = $bindable(), initialTab, onClose }: Props = $props();
+
+	// Current tab. Restored from URL hash on open so a reload keeps the
+	// admin on the same tab; written back on tab change. Initialized to
+	// a safe default and re-resolved in the open-side-effect so the
+	// initialTab prop only captures the initial value via $effect (not
+	// at first render, which would lock it).
+	let activeTab = $state<UserModalTab>('overview');
+
+	// Element refs for focus management.
+	let modalEl = $state<HTMLDivElement | null>(null);
+	let closeBtnEl = $state<HTMLButtonElement | null>(null);
+	let previousFocus: HTMLElement | null = null;
+
+	const TABS: { key: UserModalTab; label: string }[] = [
+		{ key: 'overview', label: 'Overview' },
+		{ key: 'workspaces', label: 'Workspaces' },
+		{ key: 'activity', label: 'Activity' },
+		{ key: 'settings', label: 'Settings & overrides' }
+	];
+
+	function parseHashTab(): UserModalTab | null {
+		if (typeof window === 'undefined') return null;
+		const m = window.location.hash.match(/tab=([a-z]+)/);
+		if (!m) return null;
+		const t = m[1];
+		if (t === 'overview' || t === 'workspaces' || t === 'activity' || t === 'settings') return t;
+		return null;
+	}
+
+	function writeHashTab(t: UserModalTab) {
+		if (typeof window === 'undefined') return;
+		// Preserve any other hash params; replace only tab=.
+		const hash = window.location.hash.replace(/[#&]?tab=[^&]*/, '');
+		const sep = hash.startsWith('#') ? '&' : '#';
+		const next = hash + sep + 'tab=' + t;
+		// History-quiet update — admins paste these all the time but
+		// flipping tabs shouldn't litter back-button history.
+		history.replaceState(null, '', window.location.pathname + window.location.search + next);
+	}
+
+	function selectTab(t: UserModalTab) {
+		activeTab = t;
+		writeHashTab(t);
+	}
+
+	// When the modal opens, capture the trigger element so we can restore
+	// focus on close, hydrate the active tab from the URL hash (if present),
+	// and pull focus into the modal.
+	$effect(() => {
+		if (open) {
+			previousFocus = (document.activeElement as HTMLElement) ?? null;
+			const fromHash = parseHashTab();
+			if (fromHash) activeTab = fromHash;
+			else activeTab = initialTab ?? 'overview';
+			tick().then(() => closeBtnEl?.focus());
+		} else if (previousFocus && document.contains(previousFocus)) {
+			previousFocus.focus();
+			previousFocus = null;
+		}
+	});
+
+	// Keyboard handling — ESC closes; Tab is trapped within the modal so
+	// focus can't escape into the table behind it.
+	function handleKeydown(e: KeyboardEvent) {
+		if (!open) return;
+		if (e.key === 'Escape') {
+			e.preventDefault();
+			closeModal();
+			return;
+		}
+		if (e.key === 'Tab' && modalEl) {
+			const focusables = modalEl.querySelectorAll<HTMLElement>(
+				'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+			);
+			if (focusables.length === 0) return;
+			const first = focusables[0];
+			const last = focusables[focusables.length - 1];
+			const active = document.activeElement as HTMLElement | null;
+			if (e.shiftKey && active === first) {
+				e.preventDefault();
+				last.focus();
+			} else if (!e.shiftKey && active === last) {
+				e.preventDefault();
+				first.focus();
+			}
+		}
+	}
+
+	function closeModal() {
+		open = false;
+		onClose();
+	}
+
+	// Body scroll-lock while the modal is open so the table behind doesn't
+	// scroll on wheel.
+	$effect(() => {
+		if (typeof document === 'undefined') return;
+		if (open) {
+			const prev = document.body.style.overflow;
+			document.body.style.overflow = 'hidden';
+			return () => {
+				document.body.style.overflow = prev;
+			};
+		}
+	});
+
+	onMount(() => {});
+	onDestroy(() => {});
+</script>
+
+<svelte:window onkeydown={handleKeydown} />
+
+{#if open && user}
+	<!-- svelte-ignore a11y_click_events_have_key_events -->
+	<!-- svelte-ignore a11y_no_static_element_interactions -->
+	<div class="user-modal-backdrop" onclick={closeModal}>
+		<div
+			class="user-modal"
+			bind:this={modalEl}
+			role="dialog"
+			tabindex="-1"
+			aria-modal="true"
+			aria-labelledby="user-modal-title"
+			onclick={(e) => e.stopPropagation()}
+		>
+			<header class="user-modal-header">
+				<h2 id="user-modal-title">
+					{user.name || user.username || user.email}
+					{#if user.disabled_at}<span class="badge disabled">disabled</span>{/if}
+				</h2>
+				<button
+					bind:this={closeBtnEl}
+					type="button"
+					class="user-modal-close"
+					aria-label="Close"
+					onclick={closeModal}>×</button
+				>
+			</header>
+
+			<div class="user-modal-tabs" role="tablist" aria-label="User detail sections">
+				{#each TABS as t (t.key)}
+					<button
+						type="button"
+						role="tab"
+						class="user-modal-tab"
+						class:active={activeTab === t.key}
+						aria-selected={activeTab === t.key}
+						aria-controls="user-modal-panel-{t.key}"
+						id="user-modal-tab-{t.key}"
+						onclick={() => selectTab(t.key)}
+					>
+						{t.label}
+					</button>
+				{/each}
+			</div>
+
+			<div class="user-modal-body">
+				{#each TABS as t (t.key)}
+					<div
+						role="tabpanel"
+						tabindex="0"
+						id="user-modal-panel-{t.key}"
+						aria-labelledby="user-modal-tab-{t.key}"
+						class="user-modal-panel"
+						class:active={activeTab === t.key}
+						hidden={activeTab !== t.key}
+						data-testid="user-modal-panel-{t.key}"
+					>
+						{#if t.key === 'overview'}
+							<p class="placeholder">Overview tab content arrives in TASK-1553.</p>
+						{:else if t.key === 'workspaces'}
+							<p class="placeholder">Workspaces tab content arrives in TASK-1552.</p>
+						{:else if t.key === 'activity'}
+							<p class="placeholder">Activity tab content arrives in TASK-1554.</p>
+						{:else if t.key === 'settings'}
+							<p class="placeholder">Settings & overrides tab content arrives in TASK-1551.</p>
+						{/if}
+					</div>
+				{/each}
+			</div>
+		</div>
+	</div>
+{/if}
+
+<style>
+	.user-modal-backdrop {
+		position: fixed;
+		inset: 0;
+		background: color-mix(in srgb, #000 50%, transparent);
+		z-index: 1000;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		padding: var(--space-4, 16px);
+	}
+
+	/* Modal width is a CSS variable so the Workspaces tab (T1552) can
+	   widen to 960px once it has real per-workspace data without forking
+	   the layout for every tab. */
+	.user-modal {
+		--user-modal-width: 720px;
+		width: 100%;
+		max-width: var(--user-modal-width);
+		max-height: 90vh;
+		display: flex;
+		flex-direction: column;
+		background: var(--bg-primary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+		box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+	}
+
+	.user-modal-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: var(--space-3) var(--space-4);
+		border-bottom: 1px solid var(--border);
+	}
+	.user-modal-header h2 {
+		margin: 0;
+		font-size: 1.1rem;
+		display: flex;
+		align-items: center;
+		gap: var(--space-2);
+	}
+	.badge.disabled {
+		font-size: 0.7rem;
+		padding: 2px 8px;
+		border-radius: var(--radius-sm);
+		background: color-mix(in srgb, #ef4444 15%, transparent);
+		color: #ef4444;
+	}
+	.user-modal-close {
+		background: transparent;
+		border: 0;
+		font-size: 1.5rem;
+		line-height: 1;
+		color: var(--text-muted);
+		cursor: pointer;
+		padding: 4px 8px;
+		border-radius: var(--radius-sm);
+	}
+	.user-modal-close:hover {
+		background: var(--bg-tertiary);
+		color: var(--text-primary);
+	}
+
+	.user-modal-tabs {
+		display: flex;
+		gap: 2px;
+		border-bottom: 1px solid var(--border);
+		padding: 0 var(--space-3);
+		flex-wrap: wrap;
+	}
+	.user-modal-tab {
+		background: transparent;
+		border: 0;
+		padding: var(--space-2) var(--space-3);
+		font: inherit;
+		color: var(--text-muted);
+		cursor: pointer;
+		border-bottom: 2px solid transparent;
+		border-radius: 0;
+	}
+	.user-modal-tab:hover {
+		color: var(--text-primary);
+	}
+	.user-modal-tab.active {
+		color: var(--accent-blue);
+		border-bottom-color: var(--accent-blue);
+	}
+	.user-modal-tab:focus-visible {
+		outline: 2px solid var(--accent-blue);
+		outline-offset: -2px;
+	}
+
+	.user-modal-body {
+		overflow-y: auto;
+		padding: var(--space-4);
+		flex: 1;
+	}
+	.user-modal-panel.active {
+		display: block;
+	}
+	.placeholder {
+		color: var(--text-muted);
+		font-style: italic;
+		margin: 0;
+	}
+</style>

--- a/web/src/lib/components/admin/UserModal.svelte
+++ b/web/src/lib/components/admin/UserModal.svelte
@@ -49,23 +49,26 @@
 		{ key: 'settings', label: 'Settings & overrides' }
 	];
 
+	// Hash round-trip uses URLSearchParams so other hash params (used
+	// elsewhere on the admin page or by other tabs) survive. Previous
+	// regex-replace approach corrupted hashes where tab= was the first
+	// key but other params followed (Codex review on PR #605).
+	function readHashParams(): URLSearchParams {
+		if (typeof window === 'undefined') return new URLSearchParams();
+		return new URLSearchParams(window.location.hash.replace(/^#/, ''));
+	}
+
 	function parseHashTab(): UserModalTab | null {
-		if (typeof window === 'undefined') return null;
-		const m = window.location.hash.match(/tab=([a-z]+)/);
-		if (!m) return null;
-		const t = m[1];
+		const t = readHashParams().get('tab');
 		if (t === 'overview' || t === 'workspaces' || t === 'activity' || t === 'settings') return t;
 		return null;
 	}
 
 	function writeHashTab(t: UserModalTab) {
 		if (typeof window === 'undefined') return;
-		// Preserve any other hash params; replace only tab=.
-		const hash = window.location.hash.replace(/[#&]?tab=[^&]*/, '');
-		const sep = hash.startsWith('#') ? '&' : '#';
-		const next = hash + sep + 'tab=' + t;
-		// History-quiet update — admins paste these all the time but
-		// flipping tabs shouldn't litter back-button history.
+		const params = readHashParams();
+		params.set('tab', t);
+		const next = '#' + params.toString();
 		history.replaceState(null, '', window.location.pathname + window.location.search + next);
 	}
 
@@ -74,19 +77,25 @@
 		writeHashTab(t);
 	}
 
-	// When the modal opens, capture the trigger element so we can restore
-	// focus on close, hydrate the active tab from the URL hash (if present),
-	// and pull focus into the modal.
+	// Open transition tracker — Svelte 5 $effect re-runs on any read
+	// dependency change. We only want to capture previousFocus / hydrate
+	// the tab on the open=false → true transition, not whenever
+	// initialTab or any other reactive value changes mid-open (Codex
+	// review on PR #605).
+	let wasOpen = false;
 	$effect(() => {
-		if (open) {
+		if (open && !wasOpen) {
 			previousFocus = (document.activeElement as HTMLElement) ?? null;
 			const fromHash = parseHashTab();
-			if (fromHash) activeTab = fromHash;
-			else activeTab = initialTab ?? 'overview';
+			activeTab = fromHash ?? initialTab ?? 'overview';
 			tick().then(() => closeBtnEl?.focus());
-		} else if (previousFocus && document.contains(previousFocus)) {
-			previousFocus.focus();
+			wasOpen = true;
+		} else if (!open && wasOpen) {
+			if (previousFocus && document.contains(previousFocus)) {
+				previousFocus.focus();
+			}
 			previousFocus = null;
+			wasOpen = false;
 		}
 	});
 
@@ -100,9 +109,19 @@
 			return;
 		}
 		if (e.key === 'Tab' && modalEl) {
-			const focusables = modalEl.querySelectorAll<HTMLElement>(
+			// Filter out elements inside hidden tabpanels — otherwise the
+			// modal's three off-screen panels (tabindex=0) make `last`
+			// point at the wrong element and Tab can escape the trap on
+			// non-Settings tabs (Codex review on PR #605).
+			const all = modalEl.querySelectorAll<HTMLElement>(
 				'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
 			);
+			const focusables: HTMLElement[] = [];
+			for (const el of all) {
+				if (el.closest('[hidden]')) continue;
+				if (el.offsetParent === null && el !== modalEl) continue;
+				focusables.push(el);
+			}
 			if (focusables.length === 0) return;
 			const first = focusables[0];
 			const last = focusables[focusables.length - 1];

--- a/web/src/routes/console/admin/+page.svelte
+++ b/web/src/routes/console/admin/+page.svelte
@@ -3,6 +3,7 @@
 	import { goto } from '$app/navigation';
 	import { page } from '$app/state';
 	import { adminFetch, adminPatch, adminPost, formatDate, adminStore, type AdminUser } from '$lib/stores/admin.svelte';
+	import UserModal from '$lib/components/admin/UserModal.svelte';
 
 	// --- List + pagination + filter + sort state (PLAN-1542 / TASK-1549) ---
 	// All filter state is reactive $state; we rebuild the query string on
@@ -27,6 +28,22 @@
 	let hasWorkspacesFilter = $state(''); // 'true' | 'false' | ''
 	let sortKey = $state<SortKey>('created');
 	let sortOrder = $state<SortOrder>('desc');
+
+	// Modal state. T1550 lands the shell; T1551–T1554 fill the tabs;
+	// T1555 then deletes the inline-expand block below. During T1550–T1554
+	// both UIs coexist — clicking a row opens the modal AND toggles the
+	// inline expand. This is the explicit broken state from the plan.
+	let modalUser = $state<AdminUser | null>(null);
+	let modalOpen = $state(false);
+	function openUserModal(u: AdminUser) {
+		modalUser = u;
+		modalOpen = true;
+	}
+	function closeUserModal() {
+		modalOpen = false;
+		// Keep modalUser around so the closing animation (if any) doesn't
+		// blank the modal mid-fade; cleared on next open.
+	}
 	let selectedId = $state<string | null>(null);
 	let editPlan = $state('free');
 	let editRole = $state('member');
@@ -670,7 +687,7 @@
 							class="user-row"
 							class:selected={selectedId === user.id}
 							class:disabled-row={!!user.disabled_at}
-							onclick={() => selectUser(user)}
+							onclick={() => { selectUser(user); openUserModal(user); }}
 						>
 							<td>
 								{user.name || user.username}
@@ -948,6 +965,11 @@
 		</div>
 	{/if}
 </div>
+
+<!-- Per-user detail modal — shell only as of TASK-1550; tab content
+     arrives across T1551–T1554, and T1555 deletes the parallel inline-
+     expand block above. -->
+<UserModal bind:open={modalOpen} user={modalUser} onClose={closeUserModal} />
 
 <style>
 	/* Search */


### PR DESCRIPTION
## Summary

- New `UserModal.svelte` shell component with Overview / Workspaces / Activity / Settings & overrides tabs (placeholders)
- ESC + click-outside dismiss, focus trap, body scroll-lock, ARIA tablist/tabpanel, hash-restored active tab
- Row click on admin user table opens the modal **alongside** the existing inline-expand (parallel until T1555)
- 720px default width with CSS variable so T1552 can widen for the Workspaces table

Third frontend PR from PLAN-1542. Sets up the surface that T1551-T1554 fill.

## Broken state after merge

Clicking a row opens the modal AND triggers the inline-expand. Explicit and documented; resolved in T1555 once all tab content has landed.

## Test plan

- [x] `npm run build` clean, `svelte-check` 0 errors
- [ ] Manual: row click opens modal, ESC closes, click outside closes, Tab cycles within modal, focus returns to row on close, tab hash restores on reload