### PR TITLE
feat(cli): pad library get + list --full + server-side category filter (TASK-1562)

### DIFF
--- a/cmd/pad/groups.go
+++ b/cmd/pad/groups.go
@@ -136,6 +136,7 @@ func libraryGroupCmd() *cobra.Command {
 	}
 	cmd.AddCommand(
 		libraryCmd(),
+		libraryGetCmd(),
 		libraryActivateCmd(),
 	)
 	return cmd

--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -5786,40 +5786,73 @@ func normalizeCollectionSlug(input string) string {
 func libraryCmd() *cobra.Command {
 	var categoryFilter string
 	var typeFilter string
+	var fullFlag bool
 
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "Browse pre-built conventions and playbooks",
 		Long: `Browse the convention and playbook libraries and activate items in your workspace.
 
+JSON output: conventions always carry their full content (bodies are short).
+Playbooks carry a short ` + "`summary`" + ` instead of full ` + "`content`" + ` by default — use
+` + "`--full`" + ` to opt into full playbook bodies (e.g. when piping into a tool that
+needs the entire text). For one entry's full body use ` + "`pad library get <title>`" + `.
+
 Examples:
   pad library list                     # List both conventions and playbooks
   pad library list --type conventions  # List conventions only
   pad library list --type playbooks    # List playbooks only
-  pad library list --category git      # Filter by category
-  pad library list --format json       # JSON output
+  pad library list --category git      # Server-side category filter
+  pad library list --format json       # JSON output (playbook bodies as summaries)
+  pad library list --full --format json   # JSON output, full playbook bodies
+  pad library get "Ship tasks"            # Full body of one entry
   pad library activate "Commit after task completion"  # Activate a convention or playbook`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, _ := getClient()
 
 			showConventions := typeFilter == "" || typeFilter == "conventions"
 			showPlaybooks := typeFilter == "" || typeFilter == "playbooks"
+			if !showConventions && !showPlaybooks {
+				return fmt.Errorf("unknown --type %q (expected: conventions, playbooks)", typeFilter)
+			}
 
+			// Fetch each side once. Default: playbook bodies as summaries.
+			// --full opts into full bodies (passes summary=false to the server).
+			var lib *cli.ConventionLibraryResponse
+			var plib *cli.PlaybookLibraryResponse
+			var err error
 			if showConventions {
-				lib, err := client.GetConventionLibrary()
+				lib, err = client.GetConventionLibrary(categoryFilter)
 				if err != nil {
 					return err
 				}
-
-				if formatFlag == "json" && !showPlaybooks {
-					return cli.PrintJSON(lib)
+			}
+			if showPlaybooks {
+				plib, err = client.GetPlaybookLibrary(categoryFilter, !fullFlag)
+				if err != nil {
+					return err
 				}
+			}
 
+			// JSON output paths.
+			if formatFlag == "json" {
+				switch {
+				case showConventions && showPlaybooks:
+					return cli.PrintJSON(map[string]interface{}{
+						"conventions": lib,
+						"playbooks":   plib,
+					})
+				case showConventions:
+					return cli.PrintJSON(lib)
+				default:
+					return cli.PrintJSON(plib)
+				}
+			}
+
+			// Table output.
+			if showConventions {
 				fmt.Printf("\n=== CONVENTIONS ===\n")
 				for _, cat := range lib.Categories {
-					if categoryFilter != "" && cat.Name != categoryFilter {
-						continue
-					}
 					fmt.Printf("\n%s (%s)\n", strings.ToUpper(cat.Name), cat.Description)
 					fmt.Println(strings.Repeat("─", 60))
 
@@ -5843,36 +5876,25 @@ Examples:
 			}
 
 			if showPlaybooks {
-				plib, err := client.GetPlaybookLibrary()
-				if err != nil {
-					return err
-				}
-
-				if formatFlag == "json" && !showConventions {
-					return cli.PrintJSON(plib)
-				}
-
 				fmt.Printf("\n=== PLAYBOOKS ===\n")
 				for _, cat := range plib.Categories {
-					if categoryFilter != "" && cat.Name != categoryFilter {
-						continue
-					}
 					fmt.Printf("\n%s (%s)\n", strings.ToUpper(cat.Name), cat.Description)
 					fmt.Println(strings.Repeat("─", 60))
 
 					for _, pb := range cat.Playbooks {
-						fmt.Printf("  %-45s %s [%s]\n", pb.Title, pb.Trigger, pb.Scope)
+						invocationTag := ""
+						if pb.InvocationSlug != "" {
+							invocationTag = " /pad " + pb.InvocationSlug
+						}
+						fmt.Printf("  %-45s %s [%s]%s\n", pb.Title, pb.Trigger, pb.Scope, invocationTag)
+						// Surface the summary as a hint line when the server
+						// returned one (default mode). Skipped under --full so
+						// the table output doesn't double-print the body.
+						if !fullFlag && pb.Summary != "" {
+							fmt.Printf("    %s\n", truncateForTable(pb.Summary, 80))
+						}
 					}
 				}
-			}
-
-			if formatFlag == "json" && showConventions && showPlaybooks {
-				lib, _ := client.GetConventionLibrary()
-				plib, _ := client.GetPlaybookLibrary()
-				return cli.PrintJSON(map[string]interface{}{
-					"conventions": lib,
-					"playbooks":   plib,
-				})
 			}
 
 			fmt.Println()
@@ -5880,9 +5902,111 @@ Examples:
 		},
 	}
 
-	cmd.Flags().StringVar(&categoryFilter, "category", "", "filter by category")
+	cmd.Flags().StringVar(&categoryFilter, "category", "", "server-side filter by category")
 	cmd.Flags().StringVar(&typeFilter, "type", "", "filter by type: conventions, playbooks")
+	cmd.Flags().BoolVar(&fullFlag, "full", false, "return full playbook bodies instead of summaries")
 	return cmd
+}
+
+// truncateForTable shortens a string to fit a table column, appending an
+// ellipsis when truncation occurs. Operates on runes so multi-byte
+// characters don't get sliced mid-codepoint. Used by `pad library list`
+// to render the playbook summary hint line in table mode.
+func truncateForTable(s string, max int) string {
+	if max <= 0 {
+		return ""
+	}
+	runes := []rune(s)
+	if len(runes) <= max {
+		return s
+	}
+	return string(runes[:max-1]) + "…"
+}
+
+func libraryGetCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "get <title>",
+		Short: "Show the full body of one library convention or playbook by exact title",
+		Long: `Fetch a single library entry by exact title match. Conventions are checked
+first, then playbooks — same precedence ` + "`pad library activate`" + ` uses, so a title
+resolves to the same kind in both surfaces.
+
+Pair with ` + "`pad library list`" + ` (which returns summaries for playbooks by default)
+to browse, then ` + "`pad library get`" + ` for the full body of any entry you want to
+read end-to-end before activating.
+
+Examples:
+  pad library get "Commit after task completion"   # Convention
+  pad library get "Ship tasks"                     # Playbook
+  pad library get "Ship tasks" --format json       # Full envelope
+`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, _ := getClient()
+			title := args[0]
+
+			entry, err := client.GetLibraryEntry(title)
+			if err != nil {
+				// Surface 404 as a clean exit-1 instead of the raw envelope.
+				if apiErr, ok := err.(*cli.APIError); ok && apiErr.Code == "not_found" {
+					return fmt.Errorf("not found in library: %q", title)
+				}
+				return err
+			}
+
+			if formatFlag == "json" {
+				return cli.PrintJSON(entry)
+			}
+
+			// Human-readable card.
+			switch entry.Type {
+			case "convention":
+				c := entry.Convention
+				if c == nil {
+					return fmt.Errorf("server returned type=convention with no payload")
+				}
+				fmt.Printf("\n%s\n", c.Title)
+				fmt.Println(strings.Repeat("─", 60))
+				fmt.Printf("Type:        convention\n")
+				fmt.Printf("Category:    %s\n", c.Category)
+				fmt.Printf("Trigger:     %s\n", c.Trigger)
+				if len(c.Surfaces) > 0 {
+					fmt.Printf("Surfaces:    %s\n", strings.Join(c.Surfaces, ", "))
+				}
+				if c.Enforcement != "" {
+					fmt.Printf("Enforcement: %s\n", c.Enforcement)
+				}
+				if len(c.Commands) > 0 {
+					fmt.Printf("Commands:    %s\n", strings.Join(c.Commands, " ; "))
+				}
+				fmt.Println(strings.Repeat("─", 60))
+				fmt.Println(c.Content)
+			case "playbook":
+				p := entry.Playbook
+				if p == nil {
+					return fmt.Errorf("server returned type=playbook with no payload")
+				}
+				fmt.Printf("\n%s\n", p.Title)
+				fmt.Println(strings.Repeat("─", 60))
+				fmt.Printf("Type:           playbook\n")
+				fmt.Printf("Category:       %s\n", p.Category)
+				fmt.Printf("Trigger:        %s\n", p.Trigger)
+				fmt.Printf("Scope:          %s\n", p.Scope)
+				if p.InvocationSlug != "" {
+					fmt.Printf("Invocation:     /pad %s\n", p.InvocationSlug)
+				}
+				if len(p.Arguments) > 0 {
+					fmt.Printf("Arguments:      %d declared (see body's `## Arguments` section)\n", len(p.Arguments))
+				}
+				fmt.Println(strings.Repeat("─", 60))
+				fmt.Println(p.Content)
+			default:
+				return fmt.Errorf("unexpected library entry type: %q", entry.Type)
+			}
+			fmt.Println()
+			return nil
+		},
+	}
 }
 
 func libraryActivateCmd() *cobra.Command {
@@ -5902,8 +6026,9 @@ Examples:
 
 			title := args[0]
 
-			// First check conventions library
-			lib, err := client.GetConventionLibrary()
+			// First check conventions library. No category filter; activate
+			// needs to scan the whole list. Bodies are full by default.
+			lib, err := client.GetConventionLibrary("")
 			if err != nil {
 				return err
 			}
@@ -5952,8 +6077,9 @@ Examples:
 				return nil
 			}
 
-			// Then check playbooks library
-			plib, err := client.GetPlaybookLibrary()
+			// Then check playbooks library. summary=false — we activate the
+			// full body into the workspace, not the truncated hint.
+			plib, err := client.GetPlaybookLibrary("", false)
 			if err != nil {
 				return err
 			}

--- a/internal/cli/client.go
+++ b/internal/cli/client.go
@@ -393,9 +393,18 @@ type LibraryConvention struct {
 }
 
 // GetConventionLibrary fetches the convention library from the server.
-func (c *Client) GetConventionLibrary() (*ConventionLibraryResponse, error) {
+//
+// category — when non-empty, server-side filter against LibraryCategory.Name
+// (case-sensitive exact match). PLAN-1560 / TASK-1561.
+func (c *Client) GetConventionLibrary(category string) (*ConventionLibraryResponse, error) {
+	path := "/convention-library"
+	if category != "" {
+		params := url.Values{}
+		params.Set("category", category)
+		path += "?" + params.Encode()
+	}
 	var result ConventionLibraryResponse
-	return &result, c.get("/convention-library", &result)
+	return &result, c.get(path, &result)
 }
 
 // --- Playbook Library ---
@@ -417,9 +426,15 @@ type PlaybookCategory struct {
 // InvocationSlug and Arguments are PLAN-1377's invocation surface and
 // must round-trip through `pad library activate` so a library entry
 // that declares them produces a `/pad <slug>`-routable workspace item.
+//
+// Content vs Summary: the server returns full Content by default; passing
+// summary=true on the library-list endpoint strips Content and returns a
+// short Summary instead (PLAN-1560 / TASK-1561). Both fields use omitempty
+// so a single struct round-trips both shapes without zero-value noise.
 type LibraryPlaybook struct {
 	Title          string           `json:"title"`
-	Content        string           `json:"content"`
+	Content        string           `json:"content,omitempty"`
+	Summary        string           `json:"summary,omitempty"`
 	Category       string           `json:"category"`
 	Trigger        string           `json:"trigger"`
 	Scope          string           `json:"scope"`
@@ -428,9 +443,50 @@ type LibraryPlaybook struct {
 }
 
 // GetPlaybookLibrary fetches the playbook library from the server.
-func (c *Client) GetPlaybookLibrary() (*PlaybookLibraryResponse, error) {
+//
+// category — when non-empty, server-side filter against PlaybookCategory.Name
+// (case-sensitive exact match).
+// summary — when true, server strips LibraryPlaybook.Content and injects
+// Summary (first non-heading paragraph, ~240 char cap). Use false for
+// activate/get-by-title flows that need the full body. PLAN-1560 / TASK-1561.
+func (c *Client) GetPlaybookLibrary(category string, summary bool) (*PlaybookLibraryResponse, error) {
+	params := url.Values{}
+	if category != "" {
+		params.Set("category", category)
+	}
+	if summary {
+		params.Set("summary", "true")
+	}
+	path := "/playbook-library"
+	if encoded := params.Encode(); encoded != "" {
+		path += "?" + encoded
+	}
 	var result PlaybookLibraryResponse
-	return &result, c.get("/playbook-library", &result)
+	return &result, c.get(path, &result)
+}
+
+// --- Library Entry ---
+
+// LibraryEntryResponse is the envelope returned by /library/entry. Exactly
+// one of Convention or Playbook is set; Type is "convention" or "playbook"
+// so callers can switch without inspecting which pointer is non-nil.
+type LibraryEntryResponse struct {
+	Type       string             `json:"type"`
+	Convention *LibraryConvention `json:"convention,omitempty"`
+	Playbook   *LibraryPlaybook   `json:"playbook,omitempty"`
+}
+
+// GetLibraryEntry fetches one library entry by exact title match. Conventions-
+// first precedence — a title that resolves to a convention is returned as
+// one even if a playbook of the same title existed. Returns *APIError with
+// Code="not_found" when the title doesn't match anything; CLI callers can
+// type-assert to detect that case. PLAN-1560 / TASK-1561 (endpoint) +
+// TASK-1562 (CLI plumbing).
+func (c *Client) GetLibraryEntry(title string) (*LibraryEntryResponse, error) {
+	params := url.Values{}
+	params.Set("title", title)
+	var result LibraryEntryResponse
+	return &result, c.get("/library/entry?"+params.Encode(), &result)
 }
 
 // --- Webhooks ---

--- a/internal/server/handlers_library_entry.go
+++ b/internal/server/handlers_library_entry.go
@@ -34,9 +34,7 @@ type libraryEntryResponse struct {
 func (s *Server) handleLibraryEntry(w http.ResponseWriter, r *http.Request) {
 	title := r.URL.Query().Get("title")
 	if title == "" {
-		writeJSON(w, http.StatusBadRequest, map[string]string{
-			"error": "title query parameter is required",
-		})
+		writeError(w, http.StatusBadRequest, "bad_request", "title query parameter is required")
 		return
 	}
 
@@ -56,7 +54,6 @@ func (s *Server) handleLibraryEntry(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeJSON(w, http.StatusNotFound, map[string]string{
-		"error": "not found in convention or playbook library: " + title,
-	})
+	writeError(w, http.StatusNotFound, "not_found",
+		"not found in convention or playbook library: "+title)
 }

--- a/internal/server/handlers_library_test.go
+++ b/internal/server/handlers_library_test.go
@@ -271,20 +271,44 @@ func TestLibraryEntry_Playbook(t *testing.T) {
 	}
 }
 
-// TestLibraryEntry_MissingTitle — 400 when title is missing.
+// TestLibraryEntry_MissingTitle — 400 in the canonical {error: {code, message}}
+// envelope (matches the rest of the API). CLI parseError relies on this shape.
 func TestLibraryEntry_MissingTitle(t *testing.T) {
 	srv := testServer(t)
 	rr := doRequest(srv, "GET", "/api/v1/library/entry", nil)
 	if rr.Code != http.StatusBadRequest {
 		t.Errorf("expected 400 for missing title, got %d", rr.Code)
 	}
+	var resp struct {
+		Error struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	parseJSON(t, rr, &resp)
+	if resp.Error.Code != "bad_request" {
+		t.Errorf("expected error.code=bad_request, got %q", resp.Error.Code)
+	}
+	if resp.Error.Message == "" {
+		t.Error("expected non-empty error.message")
+	}
 }
 
-// TestLibraryEntry_NotFound — 404 when title doesn't match anything.
+// TestLibraryEntry_NotFound — 404 with the canonical envelope.
 func TestLibraryEntry_NotFound(t *testing.T) {
 	srv := testServer(t)
 	rr := doRequest(srv, "GET", "/api/v1/library/entry?title="+url.QueryEscape("definitely not a real library entry"), nil)
 	if rr.Code != http.StatusNotFound {
 		t.Errorf("expected 404, got %d", rr.Code)
+	}
+	var resp struct {
+		Error struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	parseJSON(t, rr, &resp)
+	if resp.Error.Code != "not_found" {
+		t.Errorf("expected error.code=not_found, got %q", resp.Error.Code)
 	}
 }


### PR DESCRIPTION
## Summary

CLI layer for [PLAN-1560](https://github.com/PerpetualSoftware/pad) (\`pad_library\` MCP tool + matching CLI surface). Wires the HTTP work from #612 through to the \`pad library\` subcommands.

**\`pad library list\`:**
- \`--category\` is now a server-side filter.
- New \`--full\` flag. Default JSON output for playbooks returns \`summary\` (first non-heading paragraph, ~240 char cap) instead of full \`content\`; \`--full\` opts back into full bodies.
- Table output gains a summary hint line under each playbook + \`/pad <slug>\` chip when an invocation slug is declared.
- \`--type\` validates explicitly on unknown values.

**NEW \`pad library get <title>\`:** Calls \`/library/entry?title=X\`, renders a conventions or playbooks card (or full JSON envelope). Conventions-first precedence matches \`pad library activate\`. 404 → exit-1 with a clean \`not found in library: \"<title>\"\` message.

**Drive-by:** \`/library/entry\` 400/404 switched from a flat \`{error: \"...\"}\` body to the canonical \`writeError(code, message)\` envelope so the CLI's \`parseError\` produces a typed \`*APIError\` the \`get\` command can pattern-match on.

## Context

Implements TASK-1562 under PLAN-1560 (parent plan adds \`pad_library\` MCP tool + matching CLI). Builds on TASK-1561 (PR #612). Unblocks TASK-1563 (MCP catalog wiring).

## Test plan

- [x] \`go build ./...\` / \`go vet ./...\` — clean
- [x] \`go test ./...\` — full suite green (library entry tests updated for new envelope shape)
- [x] \`golangci-lint run ./cmd/pad/... ./internal/cli/... ./internal/server/...\` — 0 issues
- [x] End-to-end smoke via the installed binary:
  - \`pad library list --type playbooks\` — table with summary hint lines + \`/pad <slug>\` chips
  - \`pad library list --type playbooks --format json\` — \`content\` stripped, \`summary\` + \`invocation_slug\` present
  - \`pad library list --type playbooks --full --format json\` — full content (\`Ship tasks\` = 9512 chars)
  - \`pad library list --category git --type conventions\` — server-side filter
  - \`pad library get \"Commit after task completion\"\` — convention card
  - \`pad library get \"Ship tasks\" --format json\` — full envelope
  - \`pad library get \"nope\"\` — exit 1 + clean message
  - \`pad library list --type whatever\` — exit 1 + validation error