### PR TITLE
chore(store): rephrase comment to unblock gofmt (BUG-1565)

### DIFF
--- a/internal/store/workspace_members.go
+++ b/internal/store/workspace_members.go
@@ -951,10 +951,11 @@ type AdminUserWorkspaceDetail struct {
 // excludes terminal-status items. Single-sourced from
 // models.DefaultTerminalStatuses to match the rest of the codebase, and
 // uses the dialect's JSON-extract helper so the query runs identically on
-// SQLite and Postgres. Wraps the extracted value in LOWER(COALESCE(...,'')
-// so items with NULL/missing status (NULL NOT IN (...) is not TRUE in SQL)
-// and case-variant statuses still register as "open" — matching how
-// search.go and items.go interpret terminal-status checks.
+// SQLite and Postgres. The extracted value is COALESCEd against the empty
+// string and LOWER-cased so items with NULL/missing status (NULL NOT IN
+// (...) is not TRUE in SQL) and case-variant statuses still register as
+// "open" — matching how search.go and items.go interpret terminal-status
+// checks.
 func (s *Store) adminOpenItemsCountClause() (clause string, args []interface{}) {
 	terms := models.DefaultTerminalStatuses
 	if len(terms) == 0 {


### PR DESCRIPTION
## Summary

Comment-only edit to \`internal/store/workspace_members.go\` so \`make check\` (golangci-lint v2.11.4 → gofmt) passes again.

## Why

Go 1.26's \`gofmt\` rewrites paired ASCII apostrophes (\`''\` — used here as the SQL empty-string literal) into a typographic right-curly double quote (U+201D). The rewrite fires even inside markdown backticks, so escaping the SQL fragment as a code span doesn't help.

Two non-options ruled out at edit time:

- Accept the gofmt rewrite → comment becomes semantically wrong (curly quote isn't SQL).
- Use backticks → gofmt still rewrites the apostrophes inside the code span.

The fix rephrases the comment to describe the \`COALESCE/LOWER\` pattern in words instead of embedding the SQL literal. \`adminOpenItemsCountClause\` itself is unchanged.

## Context

Surfaced during PLAN-1560 / TASK-1561 ship loop when \`make check\` blocked on this single pre-existing gofmt failure. Resolves BUG-1565.

## Test plan

- [x] \`gofmt -l internal/store/workspace_members.go\` — clean
- [x] \`golangci-lint run ./internal/store/...\` — 0 issues
- [x] \`make check\` end-to-end — Go lint + tests + web svelte-check all pass (0 errors)