### PR TITLE
chore(mcp): point library-activate not-found hint at pad_library (TASK-1564)

### DIFF
--- a/internal/mcp/dispatch_http_slice4.go
+++ b/internal/mcp/dispatch_http_slice4.go
@@ -571,7 +571,7 @@ func (d *HTTPHandlerDispatcher) dispatchLibraryActivate(
 	return NewErrorResult(ErrorPayload{
 		Code:    ErrNotFound,
 		Message: fmt.Sprintf("%s: %q not found in convention or playbook library", cmdKey, title),
-		Hint:    "Use `pad_project action=library-list` to enumerate available titles.",
+		Hint:    "Use `pad_library action=list` to enumerate available titles.",
 	}), nil
 }
 


### PR DESCRIPTION
## Summary

One-line hint fix. The dispatcher's \`library activate\` not-found error envelope referenced a \`pad_project action=library-list\` action that never existed — leftover from an earlier design draft for IDEA-1514. Now points at the actual shipped tool: \`pad_library action=list\`.

## Context

Final cleanup under [PLAN-1560](https://github.com/PerpetualSoftware/pad). Closes TASK-1564.

TASK-1564 was originally scoped to three items: this hint fix, an onboard playbook body update, and a CHANGELOG entry. The onboard body update shipped in PR #615 (commit 1638bdf) per Codex review. The CHANGELOG entry is skipped — the project has no top-level CHANGELOG.md and tracks history via git + Pad items.

This PR completes PLAN-1560 and closes IDEA-1514.

## Test plan

- [x] \`make check\` — clean
- [x] grep confirms no other stale \`library-list\` references in source