### PR TITLE
docs: add cross-link nav row to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,19 @@
     <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue" alt="License"></a>
     <a href="https://github.com/sponsors/xarmian"><img src="https://img.shields.io/github/sponsors/xarmian?label=sponsors&logo=github" alt="GitHub Sponsors"></a>
   </p>
+  <p align="center">
+    <a href="https://getpad.dev">Website</a>
+    &nbsp;·&nbsp;
+    <a href="https://getpad.dev/docs">Docs</a>
+    &nbsp;·&nbsp;
+    <a href="https://getpad.dev/blog">Blog</a>
+    &nbsp;·&nbsp;
+    <a href="https://getpad.dev/changelog">Changelog</a>
+    &nbsp;·&nbsp;
+    <a href="https://x.com/getpaddev">X</a>
+    &nbsp;·&nbsp;
+    <a href="https://bsky.app/profile/getpaddev.bsky.social">Bluesky</a>
+  </p>
 </p>
 
 ---


### PR DESCRIPTION
## Summary

- Adds a centered nav row right under the badges with six outbound links: **Website · Docs · Blog · Changelog · X · Bluesky**
- Gives readers a 1-click path from the GitHub repo to the marketing surface (getpad.dev), the blog, the changelog, and our social handles — none of which were previously linked anywhere in the README
- Single edit covers two tasks since TASK-1574 explicitly called out the overlap with TASK-1569

## Tasks

- TASK-1569 — Add blog, X, Bluesky, getpad.dev links to Pad README
- TASK-1574 — Add blog/changelog/getpad.dev quick-links to README intro

Both under PLAN-1571 (Cross-linking & discoverability sweep).

## Test plan

- [ ] GitHub renders the nav row correctly under the badges (centered, `·` separators, no wrap weirdness on narrow widths)
- [ ] All six links resolve (Website, Docs, Blog, Changelog, X profile, Bluesky profile)
- [ ] README still renders cleanly on the npm registry / pkg.go.dev / GHCR (anywhere it gets re-rendered) — absolute URLs were used so this should be fine