### PR TITLE
feat(backlinks): server-side reverse index for [[...]] (Phase 1)

### DIFF
--- a/cmd/pad/groups.go
+++ b/cmd/pad/groups.go
@@ -108,6 +108,7 @@ func itemCmd() *cobra.Command {
 		unimplementsCmd(),
 		relatedCmd(),
 		implementedByCmd(),
+		backlinksCmd(),
 		starCmd(),
 		unstarCmd(),
 		starredCmd(),

--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -355,6 +355,27 @@ func serveCmd() *cobra.Command {
 				slog.Info("Encrypted plaintext TOTP secrets", "count", n)
 			}
 
+			// Backfill: populate item_wiki_links from existing item bodies
+			// (PLAN-1593 / TASK-1594). Idempotent — items already indexed
+			// at write time get a cheap EXISTS-skip; only newly-introduced
+			// items (e.g. from a fresh migration) actually parse. Failures
+			// here aren't fatal: a partial run leaves the table consistent
+			// and the next boot picks up where this one stopped.
+			if bf, err := s.BackfillWikiLinks(); err != nil {
+				slog.Warn("wiki-link backfill failed; non-fatal", "error", err)
+			} else if bf.ItemsIndexed > 0 {
+				slog.Info("Wiki-link backfill complete",
+					"items_scanned", bf.ItemsScanned,
+					"items_indexed", bf.ItemsIndexed,
+					"links_inserted", bf.LinksInserted,
+					"errors", bf.Errors,
+				)
+			} else if bf.ItemsScanned > 0 {
+				// Steady-state: scanned but nothing new to do.
+				slog.Debug("Wiki-link backfill no-op",
+					"items_scanned", bf.ItemsScanned, "errors", bf.Errors)
+			}
+
 			// Auto-upgrade hook removed in IDEA-1479. The historical
 			// SeedDefaultCollections backfill was incompatible with templates
 			// that intentionally diverge from Defaults() (e.g. `blank`). Future
@@ -3933,6 +3954,90 @@ The source item is blocked by the blocker item. For example:
 			return nil
 		},
 	}
+}
+
+// backlinksCmd serves `pad item backlinks <ref>` — the CLI surface for
+// PLAN-1593's reverse `[[...]]` index. Lists items that contain a
+// `[[<ref>]]` reference to the queried item, with snippet context and
+// relative timestamps.
+//
+// Phase 1: ref-form only (`[[TASK-5]]` / `[[TASK-5|Display]]`). Phase 2
+// will extend the index to title and cross-workspace forms; this
+// command's output shape stays stable.
+func backlinksCmd() *cobra.Command {
+	var (
+		limitFlag  int
+		offsetFlag int
+	)
+	cmd := &cobra.Command{
+		Use:   "backlinks <ref>",
+		Short: "List items that link to this item via [[ref]]",
+		Long: `Show items whose body contains a [[<ref>]] reference to the target.
+
+Backlinks are the reverse of [[]] wiki-links: if BUG-5's body contains
+[[TASK-1]], then "pad item backlinks TASK-1" lists BUG-5 as a source.
+
+Code blocks (fenced and inline) are excluded — example refs in docs
+don't count as real links. Self-links (an item referencing its own
+ref in its own body) are hidden.
+
+Examples:
+  pad item backlinks TASK-5
+  pad item backlinks PLAN-42 --limit 10
+  pad item backlinks IDEA-3 --format json`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, _ := getClient()
+			ws := getWorkspace()
+
+			// Resolve the target so the user sees the friendly
+			// title in the header even when their input was a
+			// ref. Also surfaces "no such item" cleanly before
+			// the backlinks call.
+			item, err := client.GetItem(ws, args[0])
+			if err != nil {
+				return err
+			}
+
+			backlinks, err := client.GetBacklinks(ws, item.Slug, limitFlag, offsetFlag)
+			if err != nil {
+				return err
+			}
+
+			if formatFlag == "json" {
+				return cli.PrintJSON(backlinks)
+			}
+
+			ref := cli.ItemRef(*item)
+			label := item.Title
+			if ref != "" {
+				label = ref + " " + item.Title
+			}
+			if len(backlinks) == 0 {
+				fmt.Printf("No backlinks to %s yet.\n", cli.Bold.Sprint(label))
+				return nil
+			}
+			fmt.Printf("Backlinks to %s\n\n", cli.Bold.Sprint(label))
+			for _, bl := range backlinks {
+				header := bl.SourceRef + " " + bl.SourceTitle
+				if bl.SourceCollectionIcon != "" {
+					header = bl.SourceCollectionIcon + " " + header
+				}
+				fmt.Printf("%s\n", cli.Bold.Sprint(header))
+				if bl.Snippet != "" {
+					cli.Dim.Printf("  %s\n", bl.Snippet)
+				}
+				if bl.DisplayText != "" {
+					cli.Dim.Printf("  (displayed as: %s)\n", bl.DisplayText)
+				}
+				fmt.Println()
+			}
+			return nil
+		},
+	}
+	cmd.Flags().IntVar(&limitFlag, "limit", 0, "max backlinks to return (default 50, max 300)")
+	cmd.Flags().IntVar(&offsetFlag, "offset", 0, "skip the first N backlinks (for pagination)")
+	return cmd
 }
 
 func depsCmd() *cobra.Command {

--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -4027,8 +4027,12 @@ Examples:
 				if bl.Snippet != "" {
 					cli.Dim.Printf("  %s\n", bl.Snippet)
 				}
-				if bl.DisplayText != "" {
-					cli.Dim.Printf("  (displayed as: %s)\n", bl.DisplayText)
+				if bl.DisplayText != nil {
+					// nil = no `|` in body; non-nil = `[[X|...]]`,
+					// including the empty-display `[[X|]]` form.
+					// Show both so the human-readable output
+					// reflects what the editor stored.
+					cli.Dim.Printf("  (displayed as: %s)\n", *bl.DisplayText)
 				}
 				fmt.Println()
 			}

--- a/internal/cli/client.go
+++ b/internal/cli/client.go
@@ -269,6 +269,31 @@ func (c *Client) DeleteItemLink(wsSlug, linkID string) error {
 	return c.delete("/workspaces/" + wsSlug + "/links/" + linkID)
 }
 
+// GetBacklinks fetches the items that contain a `[[<itemRef>]]`
+// reference to the queried item. Phase 1 returns ref-form backlinks
+// only — title and cross-workspace forms wait for Phase 2 of
+// PLAN-1593. The server applies visibility filtering before
+// returning, so callers see only sources they're allowed to see.
+//
+// `limit` and `offset` paginate (server clamps limit to [1,300]).
+// Zero values fall through to the server default (50).
+func (c *Client) GetBacklinks(wsSlug, itemSlug string, limit, offset int) ([]models.Backlink, error) {
+	q := ""
+	if limit > 0 {
+		q = "?limit=" + strconv.Itoa(limit)
+	}
+	if offset > 0 {
+		if q == "" {
+			q = "?"
+		} else {
+			q += "&"
+		}
+		q += "offset=" + strconv.Itoa(offset)
+	}
+	var result []models.Backlink
+	return result, c.get("/workspaces/"+wsSlug+"/items/"+itemSlug+"/backlinks"+q, &result)
+}
+
 // --- Comments ---
 
 func (c *Client) ListComments(wsSlug, itemSlug string) ([]models.Comment, error) {

--- a/internal/links/extract.go
+++ b/internal/links/extract.go
@@ -487,12 +487,23 @@ func parseBody(body string) *WikiLinkRef {
 	// Split on the FIRST UNESCAPED `|`. `\|` is part of the key or
 	// display text (depending on which side of the split it's on)
 	// and must NOT cleave the body. Mirrors splitWikiBody at
-	// markdown.ts:664.
+	// markdown.ts:664. The display side is preserved verbatim
+	// (post-unescape) — the renderer doesn't trim it, and the
+	// WikiLinkRef.Display doc comment promises verbatim storage.
+	// Trimming would silently differ from client behavior on
+	// padded display text like `[[TASK-1|  spaces  ]]`. Codex
+	// round-11 P3.
 	var display string
 	if key, suffix, ok := splitOnUnescapedPipe(body); ok {
-		display = strings.TrimSpace(unescapeWikiBody(suffix))
+		display = unescapeWikiBody(suffix)
 		body = key
 	}
+	// The key/ref side still gets trimmed because refPattern is
+	// anchored — leading/trailing whitespace would force the whole
+	// body to fall through to the title kind even though the
+	// renderer would resolve it as a ref. parseBody's job is to
+	// recognize the SHAPE; whitespace forgiveness in the key is
+	// part of that.
 	body = unescapeWikiBody(strings.TrimSpace(body))
 	if body == "" {
 		return nil

--- a/internal/links/extract.go
+++ b/internal/links/extract.go
@@ -73,17 +73,20 @@ type WikiLinkRef struct {
 // uppercase form at storage time — see parseBody.
 var refPattern = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9]*-\d+$`)
 
-// wikiLinkPattern matches `[[...]]` non-greedily. We split the body
-// ourselves to handle the `|Display` segment and the cross-workspace
-// `workspace::REF` form rather than baking those into the regex —
-// the body-shape logic is easier to read in plain Go than as nested
-// capture groups, and the parser already needs the position info the
-// regex returns.
+// wikiLinkPattern matches `[[...]]` while allowing the body to
+// contain escaped chars (`\]`, `\|`, `\\`). Mirrors the editor's
+// `wikiLinksToMarkdown` grammar in web/src/lib/utils/markdown.ts:461
+// (`(?:\\.|[^\]\\])+`), so any link the editor saves can be indexed
+// — even if its display text contains a literal `]` or `|`.
 //
-// `[^\]]+` excludes `]` from the body so a malformed `[[A]]B]]` won't
-// gobble characters across the inner closer. Matches the renderer's
-// pattern exactly.
-var wikiLinkPattern = regexp.MustCompile(`\[\[([^\]]+)\]\]`)
+// renderMarkdown at markdown.ts:300 uses a simpler regex (`[^\]]+`)
+// that REJECTS escaped-bracket bodies, so escaped links don't
+// currently render as clickable links in the UI. That's a
+// pre-existing inconsistency in the editor pipeline; matching the
+// permissive grammar here makes the index forward-compatible with a
+// renderer fix without leaving a gap when one lands. Codex rounds
+// 4/7/10 P2.
+var wikiLinkPattern = regexp.MustCompile(`\[\[((?:\\.|[^\]\\])+)\]\]`)
 
 // fencedCodeRanges returns half-open `[start, end)` byte ranges that
 // cover every fenced (triple-backtick) code block in `content`,
@@ -477,18 +480,20 @@ func ExtractWikiLinks(content string) []WikiLinkRef {
 
 // parseBody decodes the inside of a `[[...]]`. Returns nil if the
 // body doesn't match any of the five recognized forms. Mirrors the
-// renderer's body-parsing logic in markdown.ts so server-side and
-// client-side extraction stay in lockstep.
+// editor's body-parsing logic in markdown.ts so server-side and
+// client-side extraction stay in lockstep — including the editor's
+// `\]`, `\|`, `\\` escape sequences (Codex round-10 P2).
 func parseBody(body string) *WikiLinkRef {
-	// Strip a `|Display` suffix first. We split on the FIRST `|`
-	// because the display text itself may legally contain pipes
-	// (e.g. "[[TASK-5|A | B]]") even though that's rare.
+	// Split on the FIRST UNESCAPED `|`. `\|` is part of the key or
+	// display text (depending on which side of the split it's on)
+	// and must NOT cleave the body. Mirrors splitWikiBody at
+	// markdown.ts:664.
 	var display string
-	if pipe := strings.IndexByte(body, '|'); pipe >= 0 {
-		display = strings.TrimSpace(body[pipe+1:])
-		body = body[:pipe]
+	if key, suffix, ok := splitOnUnescapedPipe(body); ok {
+		display = strings.TrimSpace(unescapeWikiBody(suffix))
+		body = key
 	}
-	body = strings.TrimSpace(body)
+	body = unescapeWikiBody(strings.TrimSpace(body))
 	if body == "" {
 		return nil
 	}
@@ -544,6 +549,50 @@ var workspaceSlugPattern = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-
 
 func isWorkspaceSlug(s string) bool {
 	return workspaceSlugPattern.MatchString(s)
+}
+
+// splitOnUnescapedPipe scans `body` for the first `|` that isn't
+// preceded by an unescaped `\`, splitting the body into (key,
+// display, found). Mirrors splitWikiBody at markdown.ts:664. A `\`
+// always consumes the following byte (even if it's not a recognized
+// escape) so the algorithm can't get desynced by stray backslashes.
+func splitOnUnescapedPipe(body string) (key, suffix string, found bool) {
+	i := 0
+	for i < len(body) {
+		if body[i] == '\\' && i+1 < len(body) {
+			i += 2
+			continue
+		}
+		if body[i] == '|' {
+			return body[:i], body[i+1:], true
+		}
+		i++
+	}
+	return body, "", false
+}
+
+// unescapeWikiBody undoes the editor's body-escape sequences:
+// `\]` → `]`, `\|` → `|`, `\\` → `\`. Other backslash sequences are
+// left as-is (the renderer does the same — see unescapeWikiBody at
+// markdown.ts:657). Idempotent on already-unescaped strings.
+func unescapeWikiBody(s string) string {
+	if !strings.ContainsRune(s, '\\') {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\\' && i+1 < len(s) {
+			next := s[i+1]
+			if next == '\\' || next == ']' || next == '|' {
+				b.WriteByte(next)
+				i++
+				continue
+			}
+		}
+		b.WriteByte(s[i])
+	}
+	return b.String()
 }
 
 // canonicalizeRef uppercases the prefix portion of a "PREFIX-N" ref

--- a/internal/links/extract.go
+++ b/internal/links/extract.go
@@ -65,9 +65,13 @@ type WikiLinkRef struct {
 
 // REF_PATTERN matches a Pad item ref like TASK-5 or BUG-585. Mirrors
 // the renderer's REF_PATTERN constant in web/src/lib/utils/markdown.ts
-// (we deliberately keep the same shape so server-side and client-side
-// extraction agree on what "a ref" looks like).
-var refPattern = regexp.MustCompile(`^[A-Z][A-Z0-9]*-\d+$`)
+// — case-insensitive so `[[task-5]]` parses the same way the renderer
+// resolves it. Without this parity the renderer would render a mixed-
+// case ref as a clickable link while the index silently dropped it
+// (Codex round-1 P2). The Display segment is parsed separately so
+// case-only differences in the prefix collapse to the canonical
+// uppercase form at storage time — see parseBody.
+var refPattern = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9]*-\d+$`)
 
 // wikiLinkPattern matches `[[...]]` non-greedily. We split the body
 // ourselves to handle the `|Display` segment and the cross-workspace
@@ -359,11 +363,18 @@ func parseBody(body string) *WikiLinkRef {
 		// Fall through to title — the renderer's fallback policy.
 	}
 
-	// Ref form: a bare REF-N pattern.
+	// Ref form: a bare REF-N pattern. Normalize the prefix to upper-
+	// case at this single chokepoint — collection prefixes are
+	// canonically uppercase in `collections.prefix`, and the
+	// resolver/backlinks queries compare against that column. The
+	// renderer accepts mixed case for input convenience; we store
+	// the canonical form so the index has one shape per (workspace,
+	// prefix, number) and downstream callers don't need to be
+	// case-aware (Codex round-1 P2).
 	if refPattern.MatchString(body) {
 		return &WikiLinkRef{
 			Kind:    WikiLinkKindRef,
-			Ref:     body,
+			Ref:     canonicalizeRef(body),
 			Display: display,
 		}
 	}
@@ -386,4 +397,21 @@ var workspaceSlugPattern = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-
 
 func isWorkspaceSlug(s string) bool {
 	return workspaceSlugPattern.MatchString(s)
+}
+
+// canonicalizeRef uppercases the prefix portion of a "PREFIX-N" ref
+// so the index has a single canonical shape per (workspace, prefix,
+// number) regardless of how the author cased the source. The number
+// segment is unchanged (it can only contain digits per refPattern).
+//
+// `[[task-5]]` → "TASK-5". `[[Task-5]]` → "TASK-5". `[[TASK-5]]` →
+// "TASK-5" (no-op). Inputs that don't contain a hyphen pass through
+// untouched (refPattern would have rejected them anyway; callers
+// invariantly hold to "matches refPattern" before calling).
+func canonicalizeRef(ref string) string {
+	dash := strings.LastIndexByte(ref, '-')
+	if dash < 0 {
+		return strings.ToUpper(ref)
+	}
+	return strings.ToUpper(ref[:dash]) + ref[dash:]
 }

--- a/internal/links/extract.go
+++ b/internal/links/extract.go
@@ -119,12 +119,35 @@ func fencedCodeRanges(content string) [][2]int {
 			i += nl + 1
 			continue
 		}
-		// At a line start. Count backticks.
-		tickStart := i
-		for i < n && content[i] == '`' {
-			i++
+		// At a line start. CommonMark allows 0-3 leading spaces of
+		// indentation before a fence opener (4+ spaces makes it an
+		// indented code block, which is a different construct). Skip
+		// up to 3 leading spaces but bail if we hit a 4th — the
+		// renderer would treat that line as code, not a fence opener,
+		// and we'd risk false-positive on a wiki-link inside an
+		// indented-code paragraph. Codex round-5 finding #2.
+		fenceLineStart := i
+		spaces := 0
+		for spaces < 4 && fenceLineStart < n && content[fenceLineStart] == ' ' {
+			fenceLineStart++
+			spaces++
 		}
-		tickCount := i - tickStart
+		if spaces >= 4 {
+			// Indented code, not a fence. Skip the line.
+			nl := strings.IndexByte(content[i:], '\n')
+			if nl < 0 {
+				return ranges
+			}
+			i += nl + 1
+			continue
+		}
+		// Count backticks starting at fenceLineStart.
+		tickStart := fenceLineStart
+		j := fenceLineStart
+		for j < n && content[j] == '`' {
+			j++
+		}
+		tickCount := j - tickStart
 		if tickCount < 3 {
 			// Not a fence opener; skip to next newline.
 			nl := strings.IndexByte(content[i:], '\n')
@@ -134,10 +157,12 @@ func fencedCodeRanges(content string) [][2]int {
 			i += nl + 1
 			continue
 		}
+		i = j
 		// Found an opener. Find the closing fence: a line that
-		// starts with at least `tickCount` backticks. If no closer
-		// exists, the fence runs to EOF (covers the rest of the
-		// content).
+		// starts with at least `tickCount` backticks (allowing
+		// matching 0-3 space indent — see findFenceCloser). If no
+		// closer exists, the fence runs to EOF (covers the rest
+		// of the content).
 		closer := findFenceCloser(content, i, tickCount)
 		if closer < 0 {
 			ranges = append(ranges, [2]int{tickStart, n})
@@ -146,19 +171,21 @@ func fencedCodeRanges(content string) [][2]int {
 		// closer points at the start of the closing tick run;
 		// advance past it (and any extra backticks) to find the
 		// end of the block.
-		j := closer
-		for j < n && content[j] == '`' {
-			j++
+		k := closer
+		for k < n && content[k] == '`' {
+			k++
 		}
-		ranges = append(ranges, [2]int{tickStart, j})
-		i = j
+		ranges = append(ranges, [2]int{tickStart, k})
+		i = k
 	}
 	return ranges
 }
 
 // findFenceCloser scans forward from `start` looking for a line that
-// begins with at least `tickCount` consecutive backticks. Returns the
-// index of the first backtick of the closer, or -1 if none exists.
+// begins with at least `tickCount` consecutive backticks (after up to
+// three leading spaces of optional indentation, matching CommonMark
+// fenced-code semantics). Returns the index of the first backtick of
+// the closer, or -1 if none exists.
 func findFenceCloser(content string, start, tickCount int) int {
 	i := start
 	n := len(content)
@@ -172,13 +199,26 @@ func findFenceCloser(content string, start, tickCount int) int {
 		if lineStart >= n {
 			return -1
 		}
-		// Count backticks at the start of this line.
-		j := lineStart
+		// CommonMark allows the closing fence to be indented 0-3
+		// spaces, independent of the opener's indentation. 4+ spaces
+		// would be an indented-code line, not a closer.
+		closerStart := lineStart
+		spaces := 0
+		for spaces < 4 && closerStart < n && content[closerStart] == ' ' {
+			closerStart++
+			spaces++
+		}
+		if spaces >= 4 {
+			i = lineStart
+			continue
+		}
+		// Count backticks at this position.
+		j := closerStart
 		for j < n && content[j] == '`' {
 			j++
 		}
-		if j-lineStart >= tickCount {
-			return lineStart
+		if j-closerStart >= tickCount {
+			return closerStart
 		}
 		i = lineStart
 	}

--- a/internal/links/extract.go
+++ b/internal/links/extract.go
@@ -343,14 +343,24 @@ func inlineCodeRanges(content string, fenced [][2]int) [][2]int {
 		}
 		openLen := j - openStart
 		// Scan for a closing backtick RUN of EXACTLY `openLen`
-		// backticks on the same line. Runs of any other length
-		// are code text, not closers.
+		// backticks. CommonMark §6.1 allows code spans to cross
+		// single newlines BUT a blank line (a line containing only
+		// whitespace) ends the enclosing paragraph and therefore
+		// terminates the span. We allow single-line wraps but break
+		// on blank lines — Codex round-9 P1.
 		closerStart := -1
 		closerEnd := -1
 		k := j
 		for k < n {
 			if content[k] == '\n' {
-				break
+				// Look at the next line: if it's blank
+				// (only whitespace before the next newline
+				// or EOF), the span ends here unmatched.
+				if isBlankLineAt(content, k+1, n) {
+					break
+				}
+				k++
+				continue
 			}
 			if content[k] != '`' {
 				k++
@@ -369,8 +379,9 @@ func inlineCodeRanges(content string, fenced [][2]int) [][2]int {
 			// Wrong-length run; consumed by the loop, keep scanning.
 		}
 		if closerStart < 0 {
-			// Unclosed (or only mismatched runs to EOL) — treat
-			// opener as literal text and resume one byte past it.
+			// Unclosed (or only mismatched runs to scope end) —
+			// treat opener as literal text and resume one byte
+			// past it.
 			i = openStart + 1
 			continue
 		}
@@ -378,6 +389,25 @@ func inlineCodeRanges(content string, fenced [][2]int) [][2]int {
 		i = closerEnd
 	}
 	return ranges
+}
+
+// isBlankLineAt returns true if the line starting at byte position
+// `pos` contains only whitespace (space or tab) before its newline,
+// or runs to EOF without any non-whitespace. Per CommonMark a blank
+// line is one with no chars or only whitespace; this helper matches
+// that definition for the purpose of bounding multi-line inline code
+// spans (inline code spans don't cross blank lines).
+func isBlankLineAt(content string, pos, n int) bool {
+	for i := pos; i < n; i++ {
+		c := content[i]
+		if c == '\n' {
+			return true // line had no non-whitespace chars
+		}
+		if c != ' ' && c != '\t' {
+			return false
+		}
+	}
+	return true // EOF with only whitespace counts as blank
 }
 
 // isInRanges returns true if `pos` falls inside any half-open

--- a/internal/links/extract.go
+++ b/internal/links/extract.go
@@ -1,0 +1,389 @@
+package links
+
+import (
+	"regexp"
+	"strings"
+)
+
+// WikiLinkKind discriminates the five [[...]] forms the renderer
+// supports (see web/src/lib/utils/markdown.ts::renderMarkdown). Phase 1
+// of PLAN-1593 only extracts WikiLinkKindRef; the title and
+// workspace_ref kinds are reserved for Phase 2 and present here so
+// downstream consumers can switch on the full vocabulary now and
+// the parser can grow into the remaining forms without breaking
+// callers.
+type WikiLinkKind string
+
+const (
+	// WikiLinkKindRef is [[REF-N]] or [[REF-N|Display]] — the
+	// dominant modern form. Stable across title renames.
+	WikiLinkKindRef WikiLinkKind = "ref"
+
+	// WikiLinkKindTitle is the legacy [[Title]] / [[collection/Title]]
+	// form. Title renames must trigger re-resolution. Phase 2.
+	WikiLinkKindTitle WikiLinkKind = "title"
+
+	// WikiLinkKindWorkspaceRef is [[workspace::REF]] /
+	// [[workspace::REF|Display]] — points across a workspace
+	// boundary. Resolution against the foreign workspace happens at
+	// query time, not parse time. Phase 2.
+	WikiLinkKindWorkspaceRef WikiLinkKind = "workspace_ref"
+)
+
+// WikiLinkRef is one extracted [[...]] occurrence. Position is the
+// byte offset of the OPENING `[[` in the ORIGINAL content (not the
+// code-stripped scratch buffer). The store uses this offset both for
+// stable ordering when an item links to the same target multiple
+// times AND for the ~80-char snippet the backlinks handler returns.
+type WikiLinkRef struct {
+	Kind WikiLinkKind
+
+	// WorkspaceSlug is set only for WikiLinkKindWorkspaceRef (Phase 2).
+	WorkspaceSlug string
+
+	// Ref is the literal ref string (e.g. "TASK-5"). Set for
+	// WikiLinkKindRef and WikiLinkKindWorkspaceRef. Empty for
+	// title-kind rows.
+	Ref string
+
+	// Title is the literal title text. Set only for
+	// WikiLinkKindTitle (Phase 2). Empty for ref/workspace_ref.
+	Title string
+
+	// Display is the [[X|Display]] override. Empty if the link
+	// didn't carry a pipe segment. Stored verbatim (no escaping)
+	// because the renderer is responsible for HTML-escaping at
+	// display time — same convention items.title follows.
+	Display string
+
+	// Position is the byte offset of the opening `[[` in the
+	// source content. Always points into the ORIGINAL content,
+	// not the code-stripped buffer the parser used to find
+	// outside-code matches.
+	Position int
+}
+
+// REF_PATTERN matches a Pad item ref like TASK-5 or BUG-585. Mirrors
+// the renderer's REF_PATTERN constant in web/src/lib/utils/markdown.ts
+// (we deliberately keep the same shape so server-side and client-side
+// extraction agree on what "a ref" looks like).
+var refPattern = regexp.MustCompile(`^[A-Z][A-Z0-9]*-\d+$`)
+
+// wikiLinkPattern matches `[[...]]` non-greedily. We split the body
+// ourselves to handle the `|Display` segment and the cross-workspace
+// `workspace::REF` form rather than baking those into the regex —
+// the body-shape logic is easier to read in plain Go than as nested
+// capture groups, and the parser already needs the position info the
+// regex returns.
+//
+// `[^\]]+` excludes `]` from the body so a malformed `[[A]]B]]` won't
+// gobble characters across the inner closer. Matches the renderer's
+// pattern exactly.
+var wikiLinkPattern = regexp.MustCompile(`\[\[([^\]]+)\]\]`)
+
+// fencedCodeRanges returns half-open `[start, end)` byte ranges that
+// cover every fenced (triple-backtick) code block in `content`,
+// including the opening and closing fences themselves. We walk
+// the string rather than relying on a regex because:
+//
+//  1. A bare `regexp.FindAllStringIndex` of ```...``` mis-counts
+//     content containing `````` (four+ backticks) — markdown lets
+//     the fence length vary.
+//  2. We need to distinguish opener vs closer to handle the case
+//     where an unclosed fence runs to EOF (a real edge case in
+//     drafts the user hasn't finished typing).
+//
+// Behavior matches the markdown spec: a fence is `\n` + “ ``` “ +
+// optional language tag + `\n`, and the matching closer is `\n` +
+// the same number of backticks. We're permissive about the leading
+// newline at file start (no preceding `\n` required) for the
+// content-starts-with-fence case.
+func fencedCodeRanges(content string) [][2]int {
+	var ranges [][2]int
+	i := 0
+	n := len(content)
+	for i < n {
+		// Find the next run of 3+ backticks at a line boundary
+		// (either start-of-content or after a newline).
+		lineStart := i
+		if lineStart > 0 && content[lineStart-1] != '\n' {
+			// Advance to next newline; fences must start a line.
+			nl := strings.IndexByte(content[i:], '\n')
+			if nl < 0 {
+				return ranges
+			}
+			i += nl + 1
+			continue
+		}
+		// At a line start. Count backticks.
+		tickStart := i
+		for i < n && content[i] == '`' {
+			i++
+		}
+		tickCount := i - tickStart
+		if tickCount < 3 {
+			// Not a fence opener; skip to next newline.
+			nl := strings.IndexByte(content[i:], '\n')
+			if nl < 0 {
+				return ranges
+			}
+			i += nl + 1
+			continue
+		}
+		// Found an opener. Find the closing fence: a line that
+		// starts with at least `tickCount` backticks. If no closer
+		// exists, the fence runs to EOF (covers the rest of the
+		// content).
+		closer := findFenceCloser(content, i, tickCount)
+		if closer < 0 {
+			ranges = append(ranges, [2]int{tickStart, n})
+			return ranges
+		}
+		// closer points at the start of the closing tick run;
+		// advance past it (and any extra backticks) to find the
+		// end of the block.
+		j := closer
+		for j < n && content[j] == '`' {
+			j++
+		}
+		ranges = append(ranges, [2]int{tickStart, j})
+		i = j
+	}
+	return ranges
+}
+
+// findFenceCloser scans forward from `start` looking for a line that
+// begins with at least `tickCount` consecutive backticks. Returns the
+// index of the first backtick of the closer, or -1 if none exists.
+func findFenceCloser(content string, start, tickCount int) int {
+	i := start
+	n := len(content)
+	for i < n {
+		// Skip to next line.
+		nl := strings.IndexByte(content[i:], '\n')
+		if nl < 0 {
+			return -1
+		}
+		lineStart := i + nl + 1
+		if lineStart >= n {
+			return -1
+		}
+		// Count backticks at the start of this line.
+		j := lineStart
+		for j < n && content[j] == '`' {
+			j++
+		}
+		if j-lineStart >= tickCount {
+			return lineStart
+		}
+		i = lineStart
+	}
+	return -1
+}
+
+// inlineCodeRanges returns half-open `[start, end)` byte ranges that
+// cover every inline-code span (single-backtick) in `content`, skipping
+// over the fenced regions caller has already identified.
+//
+// Inline code spans are delimited by matching backtick runs of the
+// same length: `code` and “co`de“ are both valid. We don't fully
+// implement that variant (matching run lengths) because for our
+// purpose — exclude `[[...]]` inside any `...` region — counting
+// every backtick-delimited stretch as code is conservative and
+// correct (false positives there mean we DON'T index a wiki-link
+// inside oddly-quoted code, which is exactly what we want).
+//
+// Span doesn't cross newlines: an unclosed backtick at end-of-line
+// is treated as literal text, not the start of a multi-line span.
+// Matches CommonMark behavior closely enough for our use.
+func inlineCodeRanges(content string, fenced [][2]int) [][2]int {
+	var ranges [][2]int
+	i := 0
+	n := len(content)
+	fi := 0 // cursor into fenced ranges
+	for i < n {
+		// Skip ahead past any fenced range that contains or
+		// precedes our cursor.
+		for fi < len(fenced) && fenced[fi][1] <= i {
+			fi++
+		}
+		if fi < len(fenced) && fenced[fi][0] <= i {
+			i = fenced[fi][1]
+			fi++
+			continue
+		}
+		// Look for the next backtick.
+		b := strings.IndexByte(content[i:], '`')
+		if b < 0 {
+			return ranges
+		}
+		openStart := i + b
+		// If the backtick is inside a fenced range, skip past it.
+		if fi < len(fenced) && fenced[fi][0] <= openStart && openStart < fenced[fi][1] {
+			i = fenced[fi][1]
+			fi++
+			continue
+		}
+		// Find the closing backtick on the same line. The opener
+		// itself might be a run of backticks (rare), but for our
+		// permissive treatment we close on the next backtick we
+		// see — see function comment.
+		j := openStart + 1
+		for j < n && content[j] == '`' {
+			j++
+		}
+		// Scan for the closer.
+		closerStart := -1
+		for k := j; k < n; k++ {
+			if content[k] == '\n' {
+				break
+			}
+			if content[k] == '`' {
+				closerStart = k
+				break
+			}
+		}
+		if closerStart < 0 {
+			// Unclosed backtick — treat as literal, skip past it.
+			i = openStart + 1
+			continue
+		}
+		// Advance closer past the run.
+		k := closerStart
+		for k < n && content[k] == '`' {
+			k++
+		}
+		ranges = append(ranges, [2]int{openStart, k})
+		i = k
+	}
+	return ranges
+}
+
+// isInRanges returns true if `pos` falls inside any half-open
+// `[start, end)` interval in `ranges`. `ranges` must be sorted by
+// start (which both fencedCodeRanges and inlineCodeRanges produce
+// naturally by their forward scan). O(log N) binary search would
+// be tighter but ranges per item are bounded enough (most bodies
+// have under 20 code spans) that linear scan is fine and easier
+// to audit.
+func isInRanges(pos int, ranges [][2]int) bool {
+	for _, r := range ranges {
+		if pos < r[0] {
+			return false
+		}
+		if pos < r[1] {
+			return true
+		}
+	}
+	return false
+}
+
+// ExtractWikiLinks scans `content` for [[...]] occurrences OUTSIDE
+// any fenced or inline code region, parses each into a WikiLinkRef,
+// and returns them in source order.
+//
+// Phase 1 of PLAN-1593: only ref-form links (`[[REF-N]]` /
+// `[[REF-N|Display]]`) populate the returned slice. Title-form and
+// workspace_ref-form links are recognized at parse time (so the
+// caller can persist them as `target_kind` placeholders in Phase 2)
+// but are NOT emitted today — Phase 2 will flip that switch.
+//
+// Returns an empty slice on empty input. Never returns an error —
+// any bracket sequence that fails to parse is silently skipped
+// (the renderer's fallback behavior is the same: unresolved
+// `[[X]]` renders as a broken link in the body, not an error).
+func ExtractWikiLinks(content string) []WikiLinkRef {
+	if content == "" {
+		return nil
+	}
+	fenced := fencedCodeRanges(content)
+	inline := inlineCodeRanges(content, fenced)
+
+	var out []WikiLinkRef
+	matches := wikiLinkPattern.FindAllStringSubmatchIndex(content, -1)
+	for _, m := range matches {
+		// m[0]=start of [[, m[1]=end of ]], m[2]=start of body, m[3]=end of body
+		linkStart := m[0]
+		if isInRanges(linkStart, fenced) || isInRanges(linkStart, inline) {
+			continue
+		}
+		body := content[m[2]:m[3]]
+		ref := parseBody(body)
+		if ref == nil {
+			continue
+		}
+		ref.Position = linkStart
+		// Phase 1: only emit ref-form. Drop title and workspace_ref
+		// rows so the Phase-1 store sees only what Phase 1 promises
+		// to index. Phase 2 will remove this gate.
+		if ref.Kind != WikiLinkKindRef {
+			continue
+		}
+		out = append(out, *ref)
+	}
+	return out
+}
+
+// parseBody decodes the inside of a `[[...]]`. Returns nil if the
+// body doesn't match any of the five recognized forms. Mirrors the
+// renderer's body-parsing logic in markdown.ts so server-side and
+// client-side extraction stay in lockstep.
+func parseBody(body string) *WikiLinkRef {
+	// Strip a `|Display` suffix first. We split on the FIRST `|`
+	// because the display text itself may legally contain pipes
+	// (e.g. "[[TASK-5|A | B]]") even though that's rare.
+	var display string
+	if pipe := strings.IndexByte(body, '|'); pipe >= 0 {
+		display = strings.TrimSpace(body[pipe+1:])
+		body = body[:pipe]
+	}
+	body = strings.TrimSpace(body)
+	if body == "" {
+		return nil
+	}
+
+	// Cross-workspace form: `workspace-slug::REF`. The `::` separator
+	// is unambiguous; if it's present, the workspace + ref must each
+	// match their patterns or the whole thing falls back to title.
+	if sep := strings.Index(body, "::"); sep >= 0 {
+		ws := strings.TrimSpace(body[:sep])
+		rest := strings.TrimSpace(body[sep+2:])
+		if isWorkspaceSlug(ws) && refPattern.MatchString(rest) {
+			return &WikiLinkRef{
+				Kind:          WikiLinkKindWorkspaceRef,
+				WorkspaceSlug: ws,
+				Ref:           rest,
+				Display:       display,
+			}
+		}
+		// Fall through to title — the renderer's fallback policy.
+	}
+
+	// Ref form: a bare REF-N pattern.
+	if refPattern.MatchString(body) {
+		return &WikiLinkRef{
+			Kind:    WikiLinkKindRef,
+			Ref:     body,
+			Display: display,
+		}
+	}
+
+	// Legacy collection-qualified title: `collection/Title`. We
+	// treat the whole body as the title for storage; the resolver
+	// in Phase 2 will split on `/` to bias the lookup.
+	// Plain legacy title.
+	return &WikiLinkRef{
+		Kind:    WikiLinkKindTitle,
+		Title:   body,
+		Display: display,
+	}
+}
+
+// workspaceSlugPattern is a conservative subset that mirrors the
+// renderer's WORKSPACE_SLUG_PATTERN. Letter/digit-led, hyphen-allowed,
+// no trailing hyphen.
+var workspaceSlugPattern = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*[a-z0-9]$|^[a-z0-9]$`)
+
+func isWorkspaceSlug(s string) bool {
+	return workspaceSlugPattern.MatchString(s)
+}

--- a/internal/links/extract.go
+++ b/internal/links/extract.go
@@ -289,16 +289,21 @@ func findFenceCloser(content string, start, tickCount int, fenceChar byte) int {
 }
 
 // inlineCodeRanges returns half-open `[start, end)` byte ranges that
-// cover every inline-code span (single-backtick) in `content`, skipping
-// over the fenced regions caller has already identified.
+// cover every inline-code span in `content`, skipping over the fenced
+// regions caller has already identified.
 //
-// Inline code spans are delimited by matching backtick runs of the
-// same length: `code` and “co`de“ are both valid. We don't fully
-// implement that variant (matching run lengths) because for our
-// purpose — exclude `[[...]]` inside any `...` region — counting
-// every backtick-delimited stretch as code is conservative and
-// correct (false positives there mean we DON'T index a wiki-link
-// inside oddly-quoted code, which is exactly what we want).
+// CommonMark §6.1: an inline-code span is opened by a run of N
+// consecutive backticks and CLOSED by the next run of EXACTLY N
+// consecutive backticks on the same line. Backtick runs of any
+// length other than N are part of the code text — they don't close
+// the span. This matters for our purpose: a body like
+// “ “has ` inside [[X-1]]“ “ is a single span whose code text
+// includes a stray single backtick AND the wiki-link, and the link
+// must NOT be indexed because the renderer shows it as code.
+//
+// Without matching run lengths (Codex round-7 finding #2), the
+// parser would treat the stray single backtick as a closer, end
+// the range early, and false-positive on `[[X-1]]`.
 //
 // Span doesn't cross newlines: an unclosed backtick at end-of-line
 // is treated as literal text, not the start of a multi-line span.
@@ -331,37 +336,46 @@ func inlineCodeRanges(content string, fenced [][2]int) [][2]int {
 			fi++
 			continue
 		}
-		// Find the closing backtick on the same line. The opener
-		// itself might be a run of backticks (rare), but for our
-		// permissive treatment we close on the next backtick we
-		// see — see function comment.
+		// Count the opener's backtick run.
 		j := openStart + 1
 		for j < n && content[j] == '`' {
 			j++
 		}
-		// Scan for the closer.
+		openLen := j - openStart
+		// Scan for a closing backtick RUN of EXACTLY `openLen`
+		// backticks on the same line. Runs of any other length
+		// are code text, not closers.
 		closerStart := -1
-		for k := j; k < n; k++ {
+		closerEnd := -1
+		k := j
+		for k < n {
 			if content[k] == '\n' {
 				break
 			}
-			if content[k] == '`' {
-				closerStart = k
+			if content[k] != '`' {
+				k++
+				continue
+			}
+			runStart := k
+			for k < n && content[k] == '`' {
+				k++
+			}
+			runLen := k - runStart
+			if runLen == openLen {
+				closerStart = runStart
+				closerEnd = k
 				break
 			}
+			// Wrong-length run; consumed by the loop, keep scanning.
 		}
 		if closerStart < 0 {
-			// Unclosed backtick — treat as literal, skip past it.
+			// Unclosed (or only mismatched runs to EOL) — treat
+			// opener as literal text and resume one byte past it.
 			i = openStart + 1
 			continue
 		}
-		// Advance closer past the run.
-		k := closerStart
-		for k < n && content[k] == '`' {
-			k++
-		}
-		ranges = append(ranges, [2]int{openStart, k})
-		i = k
+		ranges = append(ranges, [2]int{openStart, closerEnd})
+		i = closerEnd
 	}
 	return ranges
 }

--- a/internal/links/extract.go
+++ b/internal/links/extract.go
@@ -107,7 +107,7 @@ func fencedCodeRanges(content string) [][2]int {
 	i := 0
 	n := len(content)
 	for i < n {
-		// Find the next run of 3+ backticks at a line boundary
+		// Find the next fence opener at a line boundary
 		// (either start-of-content or after a newline).
 		lineStart := i
 		if lineStart > 0 && content[lineStart-1] != '\n' {
@@ -141,10 +141,30 @@ func fencedCodeRanges(content string) [][2]int {
 			i += nl + 1
 			continue
 		}
-		// Count backticks starting at fenceLineStart.
+		// Determine the fence character. CommonMark / marked accept
+		// both backtick (`) and tilde (~) fences. The closer must
+		// use the same char as the opener and have a matching
+		// minimum run length. Codex round-6 finding #1.
+		fenceChar := byte(0)
+		if fenceLineStart < n {
+			switch content[fenceLineStart] {
+			case '`', '~':
+				fenceChar = content[fenceLineStart]
+			}
+		}
+		if fenceChar == 0 {
+			// Not a fence opener of any kind; skip to next newline.
+			nl := strings.IndexByte(content[i:], '\n')
+			if nl < 0 {
+				return ranges
+			}
+			i += nl + 1
+			continue
+		}
+		// Count fence chars starting at fenceLineStart.
 		tickStart := fenceLineStart
 		j := fenceLineStart
-		for j < n && content[j] == '`' {
+		for j < n && content[j] == fenceChar {
 			j++
 		}
 		tickCount := j - tickStart
@@ -157,22 +177,42 @@ func fencedCodeRanges(content string) [][2]int {
 			i += nl + 1
 			continue
 		}
+		// Backtick fences (but NOT tilde fences) reject an info
+		// string containing an unescaped backtick — that would
+		// otherwise let `` `not a fence ` `` be misread as a fence
+		// opener. CommonMark §4.5. Cheap check: if the rest of the
+		// opener line contains a backtick, this isn't a real fence.
+		if fenceChar == '`' {
+			restEnd := strings.IndexByte(content[j:], '\n')
+			restLimit := n
+			if restEnd >= 0 {
+				restLimit = j + restEnd
+			}
+			if strings.IndexByte(content[j:restLimit], '`') >= 0 {
+				// False opener. Skip the line.
+				nl := strings.IndexByte(content[i:], '\n')
+				if nl < 0 {
+					return ranges
+				}
+				i += nl + 1
+				continue
+			}
+		}
 		i = j
-		// Found an opener. Find the closing fence: a line that
-		// starts with at least `tickCount` backticks (allowing
-		// matching 0-3 space indent — see findFenceCloser). If no
-		// closer exists, the fence runs to EOF (covers the rest
-		// of the content).
-		closer := findFenceCloser(content, i, tickCount)
+		// Found an opener. Find the closing fence using the same
+		// char + minimum run length (allowing matching 0-3 space
+		// indent — see findFenceCloser). If no closer exists, the
+		// fence runs to EOF (covers the rest of the content).
+		closer := findFenceCloser(content, i, tickCount, fenceChar)
 		if closer < 0 {
 			ranges = append(ranges, [2]int{tickStart, n})
 			return ranges
 		}
-		// closer points at the start of the closing tick run;
-		// advance past it (and any extra backticks) to find the
+		// closer points at the start of the closing fence-char run;
+		// advance past it (and any extra fence chars) to find the
 		// end of the block.
 		k := closer
-		for k < n && content[k] == '`' {
+		for k < n && content[k] == fenceChar {
 			k++
 		}
 		ranges = append(ranges, [2]int{tickStart, k})
@@ -182,11 +222,19 @@ func fencedCodeRanges(content string) [][2]int {
 }
 
 // findFenceCloser scans forward from `start` looking for a line that
-// begins with at least `tickCount` consecutive backticks (after up to
-// three leading spaces of optional indentation, matching CommonMark
-// fenced-code semantics). Returns the index of the first backtick of
-// the closer, or -1 if none exists.
-func findFenceCloser(content string, start, tickCount int) int {
+// begins with at least `tickCount` consecutive `fenceChar` characters
+// (after up to three leading spaces of optional indentation, matching
+// CommonMark fenced-code semantics), with NOTHING but spaces after
+// the closing fence run on the same line. Returns the index of the
+// first fence char of the closer, or -1 if none exists.
+//
+// CommonMark §4.5 requires that the closing fence line contain only
+// the fence + optional trailing spaces — a line like ```not-closed
+// inside a still-open fence is NOT a valid closer. Without that
+// strictness, the extractor would prematurely terminate the code
+// range and leak later refs inside the still-rendered code block.
+// Codex round-6 finding #2.
+func findFenceCloser(content string, start, tickCount int, fenceChar byte) int {
 	i := start
 	n := len(content)
 	for i < n {
@@ -212,13 +260,28 @@ func findFenceCloser(content string, start, tickCount int) int {
 			i = lineStart
 			continue
 		}
-		// Count backticks at this position.
+		// Count fence chars at this position.
 		j := closerStart
-		for j < n && content[j] == '`' {
+		for j < n && content[j] == fenceChar {
 			j++
 		}
 		if j-closerStart >= tickCount {
-			return closerStart
+			// Strictness: after the fence-char run, the rest of
+			// the line must be only spaces (then newline or EOF).
+			// Anything else (info string, more chars) disqualifies
+			// this as a closer. CommonMark §4.5.
+			rest := j
+			for rest < n && content[rest] != '\n' {
+				if content[rest] != ' ' {
+					// Not a valid closer; keep scanning later
+					// lines for the real closer.
+					break
+				}
+				rest++
+			}
+			if rest >= n || content[rest] == '\n' {
+				return closerStart
+			}
 		}
 		i = lineStart
 	}

--- a/internal/links/extract.go
+++ b/internal/links/extract.go
@@ -50,11 +50,22 @@ type WikiLinkRef struct {
 	// WikiLinkKindTitle (Phase 2). Empty for ref/workspace_ref.
 	Title string
 
-	// Display is the [[X|Display]] override. Empty if the link
-	// didn't carry a pipe segment. Stored verbatim (no escaping)
+	// Display is the [[X|Display]] override. Stored verbatim
+	// (no trimming, no escape stripping beyond `\]`/`\|`/`\\`)
 	// because the renderer is responsible for HTML-escaping at
-	// display time — same convention items.title follows.
+	// display time — same convention items.title follows. Pair
+	// with HasDisplay to distinguish "no pipe" from "pipe with
+	// empty display."
 	Display string
+
+	// HasDisplay distinguishes `[[REF]]` (no pipe → HasDisplay=false)
+	// from `[[REF|]]` (pipe with empty display → HasDisplay=true,
+	// Display==""). The client renderer uses `displayOverride ?? title`
+	// (JS nullish coalescing — empty-string IS preserved), so an
+	// explicit empty display override renders as an empty link. We
+	// preserve that distinction in storage so the backlinks panel can
+	// reproduce it. Codex round-12 P3.
+	HasDisplay bool
 
 	// Position is the byte offset of the opening `[[` in the
 	// source content. Always points into the ORIGINAL content,
@@ -494,8 +505,10 @@ func parseBody(body string) *WikiLinkRef {
 	// padded display text like `[[TASK-1|  spaces  ]]`. Codex
 	// round-11 P3.
 	var display string
+	hasDisplay := false
 	if key, suffix, ok := splitOnUnescapedPipe(body); ok {
 		display = unescapeWikiBody(suffix)
+		hasDisplay = true
 		body = key
 	}
 	// The key/ref side still gets trimmed because refPattern is
@@ -521,6 +534,7 @@ func parseBody(body string) *WikiLinkRef {
 				WorkspaceSlug: ws,
 				Ref:           rest,
 				Display:       display,
+				HasDisplay:    hasDisplay,
 			}
 		}
 		// Fall through to title — the renderer's fallback policy.
@@ -536,9 +550,10 @@ func parseBody(body string) *WikiLinkRef {
 	// case-aware (Codex round-1 P2).
 	if refPattern.MatchString(body) {
 		return &WikiLinkRef{
-			Kind:    WikiLinkKindRef,
-			Ref:     canonicalizeRef(body),
-			Display: display,
+			Kind:       WikiLinkKindRef,
+			Ref:        canonicalizeRef(body),
+			Display:    display,
+			HasDisplay: hasDisplay,
 		}
 	}
 
@@ -547,9 +562,10 @@ func parseBody(body string) *WikiLinkRef {
 	// in Phase 2 will split on `/` to bias the lookup.
 	// Plain legacy title.
 	return &WikiLinkRef{
-		Kind:    WikiLinkKindTitle,
-		Title:   body,
-		Display: display,
+		Kind:       WikiLinkKindTitle,
+		Title:      body,
+		Display:    display,
+		HasDisplay: hasDisplay,
 	}
 }
 

--- a/internal/links/extract_test.go
+++ b/internal/links/extract_test.go
@@ -156,6 +156,90 @@ func TestExtractWikiLinks_CodeBlocksExcluded(t *testing.T) {
 		}
 	})
 
+	t.Run("tilde fence excludes refs inside", func(t *testing.T) {
+		// CommonMark / marked accept ~~~ fences alongside ```.
+		// Refs inside a tilde fence render as code in the UI and
+		// must NOT be indexed. Codex round-6 finding #1.
+		content := "Real: [[OUTSIDE-1]]\n" +
+			"~~~\n" +
+			"Example: [[INSIDE-1]]\n" +
+			"~~~\n" +
+			"After: [[OUTSIDE-2]]"
+		got := ExtractWikiLinks(content)
+		refs := refStrings(got)
+		want := []string{"OUTSIDE-1", "OUTSIDE-2"}
+		if !equalStringSlices(refs, want) {
+			t.Errorf("got refs %v, want %v", refs, want)
+		}
+	})
+
+	t.Run("tilde fence with language tag", func(t *testing.T) {
+		content := "Before [[A-1]]\n" +
+			"~~~python\n" +
+			"# echo [[B-1]]\n" +
+			"~~~\n" +
+			"After [[C-1]]"
+		got := ExtractWikiLinks(content)
+		refs := refStrings(got)
+		want := []string{"A-1", "C-1"}
+		if !equalStringSlices(refs, want) {
+			t.Errorf("got refs %v, want %v", refs, want)
+		}
+	})
+
+	t.Run("mixed fence types don't pair", func(t *testing.T) {
+		// A backtick opener must NOT be closed by a tilde line and
+		// vice versa. If the wrong char appears, the fence stays
+		// open until the right char (or EOF) is found.
+		content := "Before [[A-1]]\n" +
+			"```\n" +
+			"~~~ // not a closer for the ``` opener\n" +
+			"[[INSIDE-1]]\n" +
+			"```\n" +
+			"After [[B-1]]"
+		got := ExtractWikiLinks(content)
+		refs := refStrings(got)
+		want := []string{"A-1", "B-1"}
+		if !equalStringSlices(refs, want) {
+			t.Errorf("got refs %v, want %v", refs, want)
+		}
+	})
+
+	t.Run("closer-line strictness — backticks plus other text is not a closer", func(t *testing.T) {
+		// CommonMark §4.5: a closing fence line must contain only
+		// the fence + optional trailing spaces. A line like
+		// `\`\`\`not-closed` inside an open fence does NOT
+		// terminate the block — later refs in the same fence stay
+		// excluded. Codex round-6 finding #2.
+		content := "Real: [[OUTSIDE-1]]\n" +
+			"```\n" +
+			"```not-closed\n" +
+			"[[INSIDE-1]] still inside the fence\n" +
+			"```\n" +
+			"After: [[OUTSIDE-2]]"
+		got := ExtractWikiLinks(content)
+		refs := refStrings(got)
+		want := []string{"OUTSIDE-1", "OUTSIDE-2"}
+		if !equalStringSlices(refs, want) {
+			t.Errorf("got refs %v, want %v", refs, want)
+		}
+	})
+
+	t.Run("closer-line strictness — trailing spaces OK", func(t *testing.T) {
+		// A real closer may have trailing whitespace.
+		content := "Before [[A-1]]\n" +
+			"```\n" +
+			"[[INSIDE-1]]\n" +
+			"```   \n" +
+			"After [[B-1]]"
+		got := ExtractWikiLinks(content)
+		refs := refStrings(got)
+		want := []string{"A-1", "B-1"}
+		if !equalStringSlices(refs, want) {
+			t.Errorf("got refs %v, want %v", refs, want)
+		}
+	})
+
 	t.Run("indented fenced block (CommonMark 0-3 spaces)", func(t *testing.T) {
 		// CommonMark allows fenced code blocks indented 0-3 spaces;
 		// marked() (the renderer's markdown parser) implements this.

--- a/internal/links/extract_test.go
+++ b/internal/links/extract_test.go
@@ -1,0 +1,294 @@
+package links
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestExtractWikiLinks_RefForm covers the Phase 1 happy path: ref-form
+// links outside any code region are extracted with correct kind, ref,
+// display, and position.
+func TestExtractWikiLinks_RefForm(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    []WikiLinkRef
+	}{
+		{
+			name:    "single bare ref",
+			content: "See [[TASK-5]] for context.",
+			want: []WikiLinkRef{
+				{Kind: WikiLinkKindRef, Ref: "TASK-5", Position: 4},
+			},
+		},
+		{
+			name:    "ref with display alias",
+			content: "Per [[TASK-5|the auth fix]] we...",
+			want: []WikiLinkRef{
+				{Kind: WikiLinkKindRef, Ref: "TASK-5", Display: "the auth fix", Position: 4},
+			},
+		},
+		{
+			name:    "multiple refs same content",
+			content: "[[TASK-1]] depends on [[BUG-2]] and [[IDEA-3]].",
+			want: []WikiLinkRef{
+				{Kind: WikiLinkKindRef, Ref: "TASK-1", Position: 0},
+				{Kind: WikiLinkKindRef, Ref: "BUG-2", Position: 22},
+				{Kind: WikiLinkKindRef, Ref: "IDEA-3", Position: 36},
+			},
+		},
+		{
+			name:    "ref repeated in same body",
+			content: "[[FOO-1]] and again [[FOO-1]].",
+			want: []WikiLinkRef{
+				{Kind: WikiLinkKindRef, Ref: "FOO-1", Position: 0},
+				{Kind: WikiLinkKindRef, Ref: "FOO-1", Position: 20},
+			},
+		},
+		{
+			name:    "long collection prefix",
+			content: "Linked to [[PLAYBOOK-12345]].",
+			want: []WikiLinkRef{
+				{Kind: WikiLinkKindRef, Ref: "PLAYBOOK-12345", Position: 10},
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ExtractWikiLinks(tc.content)
+			assertLinks(t, got, tc.want)
+		})
+	}
+}
+
+// TestExtractWikiLinks_NonRefFormsHidden verifies that Phase 1's gate
+// suppresses title and workspace_ref kinds from the returned slice —
+// even though parseBody recognizes them. Once Phase 2 lands and the
+// gate is removed, these inputs must start emitting WikiLinkRefs of
+// the corresponding kinds; this test will need updating then.
+func TestExtractWikiLinks_NonRefFormsHidden(t *testing.T) {
+	cases := []string{
+		"Click [[Some Title]] here.",           // legacy title
+		"Look at [[docs/Setup]] for help.",     // collection-qualified
+		"Cross [[other-ws::TASK-9]] over.",     // workspace_ref
+		"Cross [[other-ws::TASK-9|over]] too.", // workspace_ref + display
+	}
+	for _, c := range cases {
+		t.Run(c, func(t *testing.T) {
+			got := ExtractWikiLinks(c)
+			if len(got) != 0 {
+				t.Errorf("expected 0 links (Phase 1 hides non-ref forms), got %d: %+v", len(got), got)
+			}
+		})
+	}
+}
+
+// TestExtractWikiLinks_CodeBlocksExcluded asserts the headline behavior
+// decision from PLAN-1593: [[REF]] inside fenced or inline code is NOT
+// a real link and must be skipped.
+func TestExtractWikiLinks_CodeBlocksExcluded(t *testing.T) {
+	t.Run("fenced block excludes refs inside", func(t *testing.T) {
+		content := "Real: [[OUTSIDE-1]]\n" +
+			"```\n" +
+			"Example: [[INSIDE-1]] and [[INSIDE-2]]\n" +
+			"```\n" +
+			"After: [[OUTSIDE-2]]"
+		got := ExtractWikiLinks(content)
+		refs := refStrings(got)
+		want := []string{"OUTSIDE-1", "OUTSIDE-2"}
+		if !equalStringSlices(refs, want) {
+			t.Errorf("got refs %v, want %v", refs, want)
+		}
+	})
+
+	t.Run("fenced block with language tag", func(t *testing.T) {
+		content := "Before: [[A-1]]\n" +
+			"```bash\n" +
+			"echo [[B-1]]\n" +
+			"```\n" +
+			"After: [[C-1]]"
+		got := ExtractWikiLinks(content)
+		refs := refStrings(got)
+		want := []string{"A-1", "C-1"}
+		if !equalStringSlices(refs, want) {
+			t.Errorf("got refs %v, want %v", refs, want)
+		}
+	})
+
+	t.Run("inline code excludes ref inside", func(t *testing.T) {
+		content := "The `[[FAKE-1]]` syntax has shipped; see [[REAL-2]] for examples."
+		got := ExtractWikiLinks(content)
+		refs := refStrings(got)
+		want := []string{"REAL-2"}
+		if !equalStringSlices(refs, want) {
+			t.Errorf("got refs %v, want %v", refs, want)
+		}
+	})
+
+	t.Run("unclosed fence runs to EOF", func(t *testing.T) {
+		// A draft with an opened-but-never-closed fence should treat
+		// everything after the fence as code (matches markdown
+		// rendering of the same draft).
+		content := "Before: [[A-1]]\n" +
+			"```\n" +
+			"After: [[B-1]] // inside dangling fence — must be skipped"
+		got := ExtractWikiLinks(content)
+		refs := refStrings(got)
+		want := []string{"A-1"}
+		if !equalStringSlices(refs, want) {
+			t.Errorf("got refs %v, want %v", refs, want)
+		}
+	})
+
+	t.Run("inline code adjacent to real link", func(t *testing.T) {
+		// `code-with-link` then [[REAL-1]] — closer of inline span
+		// must not accidentally include the real link.
+		content := "Try `[[A-1]]` and then [[REAL-1]]."
+		got := ExtractWikiLinks(content)
+		refs := refStrings(got)
+		want := []string{"REAL-1"}
+		if !equalStringSlices(refs, want) {
+			t.Errorf("got refs %v, want %v", refs, want)
+		}
+	})
+
+	t.Run("fenced block at start of content (no leading newline)", func(t *testing.T) {
+		content := "```\n[[INSIDE-1]]\n```\n[[OUTSIDE-1]]"
+		got := ExtractWikiLinks(content)
+		refs := refStrings(got)
+		want := []string{"OUTSIDE-1"}
+		if !equalStringSlices(refs, want) {
+			t.Errorf("got refs %v, want %v", refs, want)
+		}
+	})
+}
+
+// TestExtractWikiLinks_Edge covers malformed/weird inputs the renderer
+// gracefully falls through on. Our extractor must do the same.
+func TestExtractWikiLinks_Edge(t *testing.T) {
+	cases := []struct {
+		name    string
+		content string
+	}{
+		{"empty content", ""},
+		{"no links", "Plain text with no wiki links at all."},
+		{"empty brackets", "Here is [[]] which shouldn't match."},
+		{"single bracket", "[A-1] should not match."},
+		{"nested brackets", "[[[A-1]]] shouldn't either."},
+		{"lowercase ref", "[[task-5]] is not a ref."},
+		{"missing number", "[[TASK]] needs a number."},
+		{"bracket with newline body", "[[A-1\nB-2]] is malformed."},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := ExtractWikiLinks(c.content)
+			for _, g := range got {
+				// Anything emitted must at least be a valid ref-form.
+				if g.Kind != WikiLinkKindRef {
+					t.Errorf("emitted non-ref kind in Phase 1: %+v", g)
+				}
+				if g.Ref == "" {
+					t.Errorf("emitted ref-kind with empty Ref: %+v", g)
+				}
+			}
+		})
+	}
+}
+
+// TestExtractWikiLinks_PositionIsByteOffset asserts that Position
+// points at the opening `[[` in the ORIGINAL content — the handler
+// uses this to extract a ~80-char snippet centered on the match.
+func TestExtractWikiLinks_PositionIsByteOffset(t *testing.T) {
+	content := "Some prose. [[TASK-99]] more prose."
+	got := ExtractWikiLinks(content)
+	if len(got) != 1 {
+		t.Fatalf("want 1 link, got %d", len(got))
+	}
+	pos := got[0].Position
+	if got := content[pos : pos+2]; got != "[[" {
+		t.Errorf("Position should point at `[[`, got %q", got)
+	}
+}
+
+// TestExtractWikiLinks_RefVsTitleFallback exercises the parseBody
+// decision tree. A body that LOOKS like ref but isn't (mismatched
+// case, missing number, etc.) should fall through to title and
+// therefore be hidden in Phase 1.
+func TestExtractWikiLinks_RefVsTitleFallback(t *testing.T) {
+	t.Run("ref-shaped body parses as ref", func(t *testing.T) {
+		got := ExtractWikiLinks("[[TASK-5]]")
+		if len(got) != 1 || got[0].Kind != WikiLinkKindRef {
+			t.Errorf("expected single ref kind, got %+v", got)
+		}
+	})
+	t.Run("not-quite-ref body falls to title and is hidden", func(t *testing.T) {
+		// "Task-5" lowercase doesn't match REF_PATTERN; parseBody
+		// returns a title-kind ref; Phase 1 gates it out.
+		got := ExtractWikiLinks("[[Task-5]]")
+		if len(got) != 0 {
+			t.Errorf("expected 0 (title-kind hidden), got %+v", got)
+		}
+	})
+}
+
+// assertLinks compares two WikiLinkRef slices for the fields Phase 1
+// cares about. Doesn't enforce equality on fields not yet emitted
+// (Title, WorkspaceSlug) so adding test cases for those in Phase 2
+// won't require rewriting these comparisons.
+func assertLinks(t *testing.T, got, want []WikiLinkRef) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("got %d links, want %d: got=%+v want=%+v", len(got), len(want), got, want)
+	}
+	for i := range got {
+		if got[i].Kind != want[i].Kind {
+			t.Errorf("[%d] Kind: got %q, want %q", i, got[i].Kind, want[i].Kind)
+		}
+		if got[i].Ref != want[i].Ref {
+			t.Errorf("[%d] Ref: got %q, want %q", i, got[i].Ref, want[i].Ref)
+		}
+		if got[i].Display != want[i].Display {
+			t.Errorf("[%d] Display: got %q, want %q", i, got[i].Display, want[i].Display)
+		}
+		if got[i].Position != want[i].Position {
+			t.Errorf("[%d] Position: got %d, want %d", i, got[i].Position, want[i].Position)
+		}
+	}
+}
+
+func refStrings(links []WikiLinkRef) []string {
+	out := make([]string, len(links))
+	for i, l := range links {
+		out[i] = l.Ref
+	}
+	return out
+}
+
+func equalStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// Sanity check: position is BYTE offset, not rune offset. A leading
+// multi-byte rune shifts the [[ to a position > its rune index.
+func TestExtractWikiLinks_PositionByteVsRune(t *testing.T) {
+	// "héllo " has é = 2 bytes (UTF-8). The [[ that follows should
+	// be at byte offset 7 ("h"=1 + "é"=2 + "llo "=4 = 7), even
+	// though its rune offset is only 6.
+	content := "héllo [[TASK-1]]"
+	got := ExtractWikiLinks(content)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 link, got %d", len(got))
+	}
+	if got[0].Position != strings.Index(content, "[[") {
+		t.Errorf("Position should be byte offset matching strings.Index, got %d want %d",
+			got[0].Position, strings.Index(content, "[["))
+	}
+}

--- a/internal/links/extract_test.go
+++ b/internal/links/extract_test.go
@@ -175,7 +175,7 @@ func TestExtractWikiLinks_Edge(t *testing.T) {
 		{"empty brackets", "Here is [[]] which shouldn't match."},
 		{"single bracket", "[A-1] should not match."},
 		{"nested brackets", "[[[A-1]]] shouldn't either."},
-		{"lowercase ref", "[[task-5]] is not a ref."},
+		{"number-led not a ref", "[[5-task]] is not a ref shape."},
 		{"missing number", "[[TASK]] needs a number."},
 		{"bracket with newline body", "[[A-1\nB-2]] is malformed."},
 	}
@@ -211,24 +211,73 @@ func TestExtractWikiLinks_PositionIsByteOffset(t *testing.T) {
 }
 
 // TestExtractWikiLinks_RefVsTitleFallback exercises the parseBody
-// decision tree. A body that LOOKS like ref but isn't (mismatched
-// case, missing number, etc.) should fall through to title and
-// therefore be hidden in Phase 1.
+// decision tree. After Codex round-1 P2, the refPattern is
+// case-insensitive — `[[Task-5]]` and `[[task-5]]` now parse as the
+// ref kind (and normalize to "TASK-5" for storage), matching the
+// renderer's behavior. Inputs that don't look like a ref at all
+// still fall through to title.
 func TestExtractWikiLinks_RefVsTitleFallback(t *testing.T) {
-	t.Run("ref-shaped body parses as ref", func(t *testing.T) {
+	t.Run("uppercase ref-shaped body parses as ref", func(t *testing.T) {
 		got := ExtractWikiLinks("[[TASK-5]]")
 		if len(got) != 1 || got[0].Kind != WikiLinkKindRef {
 			t.Errorf("expected single ref kind, got %+v", got)
 		}
+		if got[0].Ref != "TASK-5" {
+			t.Errorf("Ref: got %q, want TASK-5", got[0].Ref)
+		}
 	})
-	t.Run("not-quite-ref body falls to title and is hidden", func(t *testing.T) {
-		// "Task-5" lowercase doesn't match REF_PATTERN; parseBody
-		// returns a title-kind ref; Phase 1 gates it out.
+	t.Run("mixed-case body parses as ref, normalized to uppercase", func(t *testing.T) {
 		got := ExtractWikiLinks("[[Task-5]]")
+		if len(got) != 1 {
+			t.Fatalf("expected 1 ref-kind result (case-insensitive match), got %d: %+v", len(got), got)
+		}
+		if got[0].Kind != WikiLinkKindRef {
+			t.Errorf("Kind: got %q, want ref", got[0].Kind)
+		}
+		if got[0].Ref != "TASK-5" {
+			t.Errorf("Ref should be canonicalized to uppercase: got %q want TASK-5", got[0].Ref)
+		}
+	})
+	t.Run("lowercase body parses as ref, normalized to uppercase", func(t *testing.T) {
+		got := ExtractWikiLinks("[[task-5]]")
+		if len(got) != 1 {
+			t.Fatalf("expected 1 ref-kind result, got %d", len(got))
+		}
+		if got[0].Ref != "TASK-5" {
+			t.Errorf("Ref: got %q want TASK-5", got[0].Ref)
+		}
+	})
+	t.Run("non-ref body falls to title and is hidden", func(t *testing.T) {
+		// "5-Task" (number-led) doesn't match REF_PATTERN even
+		// with the relaxed case rule; parseBody returns a
+		// title-kind ref; Phase 1 gates it out.
+		got := ExtractWikiLinks("[[5-Task]]")
 		if len(got) != 0 {
 			t.Errorf("expected 0 (title-kind hidden), got %+v", got)
 		}
 	})
+}
+
+// TestCanonicalizeRef is the unit-level check on the helper. The
+// integration coverage lives in TestWikiLinks_MixedCaseRefIndexed
+// (store) — but the helper's edge cases (no-hyphen, all-uppercase
+// already, multi-hyphen prefix) are easier to assert directly.
+func TestCanonicalizeRef(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"TASK-5", "TASK-5"},
+		{"task-5", "TASK-5"},
+		{"Task-5", "TASK-5"},
+		{"PLAYBOOK-12345", "PLAYBOOK-12345"},
+		{"playbook-12345", "PLAYBOOK-12345"},
+	}
+	for _, tc := range cases {
+		got := canonicalizeRef(tc.in)
+		if got != tc.want {
+			t.Errorf("canonicalizeRef(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
 }
 
 // assertLinks compares two WikiLinkRef slices for the fields Phase 1

--- a/internal/links/extract_test.go
+++ b/internal/links/extract_test.go
@@ -507,6 +507,34 @@ func TestExtractWikiLinks_EscapedBodyChars(t *testing.T) {
 		}
 	})
 
+	t.Run("explicit empty display override is distinguished from no pipe", func(t *testing.T) {
+		// [[X|]] is distinct from [[X]] in the editor: the former
+		// has displayOverride="" (preserved by JS ?? coalescing),
+		// the latter has no override and falls back to title. We
+		// preserve that distinction via HasDisplay. Codex round-12 P3.
+		withPipe := ExtractWikiLinks(`[[TASK-7|]]`)
+		if len(withPipe) != 1 {
+			t.Fatalf("expected 1 ref, got %d", len(withPipe))
+		}
+		if !withPipe[0].HasDisplay {
+			t.Errorf("[[TASK-7|]] should have HasDisplay=true")
+		}
+		if withPipe[0].Display != "" {
+			t.Errorf("[[TASK-7|]] Display should be \"\", got %q", withPipe[0].Display)
+		}
+
+		noPipe := ExtractWikiLinks(`[[TASK-7]]`)
+		if len(noPipe) != 1 {
+			t.Fatalf("expected 1 ref, got %d", len(noPipe))
+		}
+		if noPipe[0].HasDisplay {
+			t.Errorf("[[TASK-7]] should have HasDisplay=false")
+		}
+		if noPipe[0].Display != "" {
+			t.Errorf("[[TASK-7]] Display should be \"\", got %q", noPipe[0].Display)
+		}
+	})
+
 	t.Run("display text preserved verbatim (no TrimSpace)", func(t *testing.T) {
 		// The renderer stores display text verbatim — leading and
 		// trailing whitespace are part of the display. Trimming

--- a/internal/links/extract_test.go
+++ b/internal/links/extract_test.go
@@ -507,6 +507,20 @@ func TestExtractWikiLinks_EscapedBodyChars(t *testing.T) {
 		}
 	})
 
+	t.Run("display text preserved verbatim (no TrimSpace)", func(t *testing.T) {
+		// The renderer stores display text verbatim — leading and
+		// trailing whitespace are part of the display. Trimming
+		// in the extractor would silently differ from client
+		// behavior. Codex round-11 P3.
+		got := ExtractWikiLinks(`[[TASK-9|  padded display  ]]`)
+		if len(got) != 1 {
+			t.Fatalf("expected 1 ref, got %d", len(got))
+		}
+		if got[0].Display != "  padded display  " {
+			t.Errorf("Display should be verbatim, got %q", got[0].Display)
+		}
+	})
+
 	t.Run("position still points at opening [[", func(t *testing.T) {
 		// Escapes shouldn't shift Position — it's the byte offset
 		// in the ORIGINAL content, not the unescaped form.

--- a/internal/links/extract_test.go
+++ b/internal/links/extract_test.go
@@ -453,6 +453,121 @@ func TestExtractWikiLinks_RefVsTitleFallback(t *testing.T) {
 	})
 }
 
+// TestExtractWikiLinks_EscapedBodyChars regresses Codex rounds
+// 4/7/10 P2: the editor's wikiLinksToMarkdown can produce bodies
+// containing `\]`, `\|`, `\\` escapes (markdown.ts:461). The
+// extractor must parse those — both the regex and the body parser —
+// so the resulting link is indexed with the unescaped display text.
+func TestExtractWikiLinks_EscapedBodyChars(t *testing.T) {
+	t.Run("escaped closing bracket in display", func(t *testing.T) {
+		// [[TASK-1|see \] bracket]] — display is "see ] bracket".
+		got := ExtractWikiLinks(`[[TASK-1|see \] bracket]]`)
+		if len(got) != 1 {
+			t.Fatalf("expected 1 ref, got %d: %+v", len(got), got)
+		}
+		if got[0].Ref != "TASK-1" {
+			t.Errorf("Ref: got %q want TASK-1", got[0].Ref)
+		}
+		if got[0].Display != "see ] bracket" {
+			t.Errorf("Display: got %q want %q", got[0].Display, "see ] bracket")
+		}
+	})
+
+	t.Run("escaped pipe in display", func(t *testing.T) {
+		// [[TASK-2|A \| B]] — display is "A | B"; the unescaped
+		// pipe doesn't split the body.
+		got := ExtractWikiLinks(`[[TASK-2|A \| B]]`)
+		if len(got) != 1 {
+			t.Fatalf("expected 1 ref, got %d", len(got))
+		}
+		if got[0].Display != "A | B" {
+			t.Errorf("Display: got %q want %q", got[0].Display, "A | B")
+		}
+	})
+
+	t.Run("escaped backslash in display", func(t *testing.T) {
+		// [[TASK-3|a \\ b]] — display is "a \ b".
+		got := ExtractWikiLinks(`[[TASK-3|a \\ b]]`)
+		if len(got) != 1 {
+			t.Fatalf("expected 1 ref, got %d", len(got))
+		}
+		if got[0].Display != `a \ b` {
+			t.Errorf("Display: got %q want %q", got[0].Display, `a \ b`)
+		}
+	})
+
+	t.Run("non-escape backslash passes through", func(t *testing.T) {
+		// `\n` (or any `\X` where X isn't ]|\) is left alone.
+		got := ExtractWikiLinks(`[[TASK-4|a \n b]]`)
+		if len(got) != 1 {
+			t.Fatalf("expected 1 ref, got %d", len(got))
+		}
+		if got[0].Display != `a \n b` {
+			t.Errorf("Display: got %q want %q", got[0].Display, `a \n b`)
+		}
+	})
+
+	t.Run("position still points at opening [[", func(t *testing.T) {
+		// Escapes shouldn't shift Position — it's the byte offset
+		// in the ORIGINAL content, not the unescaped form.
+		content := "Prefix " + `[[TASK-5|see \] here]]` + " suffix"
+		got := ExtractWikiLinks(content)
+		if len(got) != 1 {
+			t.Fatalf("expected 1 ref, got %d", len(got))
+		}
+		if content[got[0].Position:got[0].Position+2] != "[[" {
+			t.Errorf("Position should point at `[[`, got %q",
+				content[got[0].Position:got[0].Position+2])
+		}
+	})
+}
+
+// TestSplitOnUnescapedPipe / TestUnescapeWikiBody — direct unit
+// tests for the helpers. Round-trip safety against the editor's
+// serializer (escapeWikiBody/unescapeWikiBody in markdown.ts:652-658)
+// is the property we care about.
+func TestSplitOnUnescapedPipe(t *testing.T) {
+	cases := []struct {
+		in         string
+		wantKey    string
+		wantSuffix string
+		wantFound  bool
+	}{
+		{"ref-only", "ref-only", "", false},
+		{"key|display", "key", "display", true},
+		{`key\|with-pipe`, `key\|with-pipe`, "", false},
+		{`first\|second|third`, `first\|second`, "third", true},
+		{`\\|trailing`, `\\`, "trailing", true}, // \\ is escaped backslash, then |
+	}
+	for _, c := range cases {
+		k, s, ok := splitOnUnescapedPipe(c.in)
+		if k != c.wantKey || s != c.wantSuffix || ok != c.wantFound {
+			t.Errorf("splitOnUnescapedPipe(%q) = (%q, %q, %v), want (%q, %q, %v)",
+				c.in, k, s, ok, c.wantKey, c.wantSuffix, c.wantFound)
+		}
+	}
+}
+
+func TestUnescapeWikiBody(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"plain", "plain"},
+		{`\]`, "]"},
+		{`\|`, "|"},
+		{`\\`, `\`},
+		{`a \] b \| c \\ d`, `a ] b | c \ d`},
+		{`\n stays literal`, `\n stays literal`},
+		{"", ""},
+	}
+	for _, c := range cases {
+		got := unescapeWikiBody(c.in)
+		if got != c.want {
+			t.Errorf("unescapeWikiBody(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
 // TestCanonicalizeRef is the unit-level check on the helper. The
 // integration coverage lives in TestWikiLinks_MixedCaseRefIndexed
 // (store) — but the helper's edge cases (no-hyphen, all-uppercase

--- a/internal/links/extract_test.go
+++ b/internal/links/extract_test.go
@@ -140,6 +140,40 @@ func TestExtractWikiLinks_CodeBlocksExcluded(t *testing.T) {
 		}
 	})
 
+	t.Run("multi-backtick inline code excludes ref", func(t *testing.T) {
+		// CommonMark inline-code spans support multi-backtick
+		// delimiters (`code` and ``code`` are both spans). Our
+		// permissive matcher treats any backtick run as an opener
+		// and closes on the next backtick run — which covers this
+		// case correctly: ``see [[X]]`` becomes a single [0, end)
+		// range, the embedded link is excluded.
+		content := "``see [[INSIDE-1]]`` and [[REAL-1]]"
+		got := ExtractWikiLinks(content)
+		refs := refStrings(got)
+		want := []string{"REAL-1"}
+		if !equalStringSlices(refs, want) {
+			t.Errorf("got refs %v, want %v", refs, want)
+		}
+	})
+
+	t.Run("indented fenced block (CommonMark 0-3 spaces)", func(t *testing.T) {
+		// CommonMark allows fenced code blocks indented 0-3 spaces;
+		// marked() (the renderer's markdown parser) implements this.
+		// Our extractor must mirror or we false-positive on every
+		// indented code example users write.
+		content := "Before [[A-1]]\n" +
+			"   ```\n" +
+			"   echo [[INSIDE-1]]\n" +
+			"   ```\n" +
+			"After [[B-1]]"
+		got := ExtractWikiLinks(content)
+		refs := refStrings(got)
+		want := []string{"A-1", "B-1"}
+		if !equalStringSlices(refs, want) {
+			t.Errorf("got refs %v, want %v", refs, want)
+		}
+	})
+
 	t.Run("inline code adjacent to real link", func(t *testing.T) {
 		// `code-with-link` then [[REAL-1]] — closer of inline span
 		// must not accidentally include the real link.

--- a/internal/links/extract_test.go
+++ b/internal/links/extract_test.go
@@ -140,6 +140,54 @@ func TestExtractWikiLinks_CodeBlocksExcluded(t *testing.T) {
 		}
 	})
 
+	t.Run("inline code spans single newline (CommonMark §6.1)", func(t *testing.T) {
+		// Per CommonMark, an inline-code span can cross a single
+		// newline. The renderer treats `pre\n[[INSIDE-1]]\npost`
+		// as a single code span — the embedded link must NOT be
+		// indexed. Codex round-9 P1.
+		content := "Outside [[A-1]]\n" +
+			"start `pre\n[[INSIDE-1]]\npost` end\n" +
+			"Outside [[B-1]]"
+		got := ExtractWikiLinks(content)
+		refs := refStrings(got)
+		want := []string{"A-1", "B-1"}
+		if !equalStringSlices(refs, want) {
+			t.Errorf("got refs %v, want %v", refs, want)
+		}
+	})
+
+	t.Run("inline code breaks at blank line (paragraph boundary)", func(t *testing.T) {
+		// A blank line terminates the paragraph, so a still-open
+		// inline-code span must end at the blank-line break.
+		// Refs in subsequent paragraphs are NOT part of the span
+		// and must be indexed.
+		content := "Outside [[A-1]]\n" +
+			"open `unclosed-span\n" +
+			"\n" +
+			"new paragraph [[REAL-1]] more text\n" +
+			"Outside [[B-1]]"
+		got := ExtractWikiLinks(content)
+		refs := refStrings(got)
+		want := []string{"A-1", "REAL-1", "B-1"}
+		if !equalStringSlices(refs, want) {
+			t.Errorf("got refs %v, want %v", refs, want)
+		}
+	})
+
+	t.Run("inline code breaks at whitespace-only blank line", func(t *testing.T) {
+		// CommonMark treats a line containing only spaces/tabs as
+		// blank. Span must still terminate there.
+		content := "open `unclosed-span\n" +
+			"  \t  \n" +
+			"after-blank [[REAL-1]]"
+		got := ExtractWikiLinks(content)
+		refs := refStrings(got)
+		want := []string{"REAL-1"}
+		if !equalStringSlices(refs, want) {
+			t.Errorf("got refs %v, want %v", refs, want)
+		}
+	})
+
 	t.Run("inline code closer matches opener length", func(t *testing.T) {
 		// CommonMark §6.1: a span opened with N backticks closes
 		// only on a run of EXACTLY N backticks. Stray single

--- a/internal/links/extract_test.go
+++ b/internal/links/extract_test.go
@@ -140,6 +140,35 @@ func TestExtractWikiLinks_CodeBlocksExcluded(t *testing.T) {
 		}
 	})
 
+	t.Run("inline code closer matches opener length", func(t *testing.T) {
+		// CommonMark §6.1: a span opened with N backticks closes
+		// only on a run of EXACTLY N backticks. Stray single
+		// backticks inside a ``...`` span are code text, not
+		// closers. Without matching-run semantics, the extractor
+		// would close on the first single backtick and leak the
+		// inner [[X]]. Codex round-7 finding #2.
+		content := "Before [[A-1]] ``code with ` inside and [[INSIDE-1]]`` after [[B-1]]"
+		got := ExtractWikiLinks(content)
+		refs := refStrings(got)
+		want := []string{"A-1", "B-1"}
+		if !equalStringSlices(refs, want) {
+			t.Errorf("got refs %v, want %v", refs, want)
+		}
+	})
+
+	t.Run("single-backtick span unaffected by adjacent multi-backtick run", func(t *testing.T) {
+		// `code` is a normal one-backtick span that closes on the
+		// next single backtick. A double-backtick run is NOT a
+		// valid closer for a single-backtick opener.
+		content := "Try `code [[INSIDE-1]] ``not-closer` then [[REAL-1]]"
+		got := ExtractWikiLinks(content)
+		refs := refStrings(got)
+		want := []string{"REAL-1"}
+		if !equalStringSlices(refs, want) {
+			t.Errorf("got refs %v, want %v", refs, want)
+		}
+	})
+
 	t.Run("multi-backtick inline code excludes ref", func(t *testing.T) {
 		// CommonMark inline-code spans support multi-backtick
 		// delimiters (`code` and ``code`` are both spans). Our

--- a/internal/models/backlink.go
+++ b/internal/models/backlink.go
@@ -36,8 +36,13 @@ type Backlink struct {
 	Snippet string `json:"snippet"`
 
 	// DisplayText is the [[X|Display]] override the link author
-	// supplied, empty when the link was a bare `[[X]]`.
-	DisplayText string `json:"display_text,omitempty"`
+	// supplied, nil when the link was a bare `[[X]]` (no pipe).
+	// A non-nil pointer to "" represents the editor-distinct case
+	// `[[X|]]` — explicit empty display. Pointer (not omitempty
+	// string) so JSON serialization preserves the distinction:
+	// nil → field omitted, "" → field present and empty. Codex
+	// round-13 P2.
+	DisplayText *string `json:"display_text,omitempty"`
 
 	// UpdatedAt is the source item's updated_at, RFC3339 string.
 	// Used for relative timestamps ("3h ago"); the list is

--- a/internal/models/backlink.go
+++ b/internal/models/backlink.go
@@ -1,0 +1,46 @@
+package models
+
+// Backlink is the wire shape returned by
+// `GET /api/v1/workspaces/{ws}/items/{ref}/backlinks` — one inbound
+// `[[...]]` reference to the queried item. The store layer populates
+// these from `item_wiki_links` joined to `items` + `collections`;
+// the HTTP layer applies visibility filtering; the CLI / web UI / MCP
+// render them as one-line "Mentioned in" entries.
+//
+// Lives in models (not store) because both `internal/cli/client.go`
+// and `internal/server/handlers_backlinks.go` deserialize/serialize
+// it across the wire, and models is the canonical home for shared
+// JSON shapes.
+//
+// PLAN-1593 / TASK-1594.
+type Backlink struct {
+	// SourceItemID is the UUID of the linking item.
+	SourceItemID string `json:"source_item_id"`
+
+	// SourceRef is "PREFIX-NUMBER" (e.g. "TASK-42"). Always set;
+	// the renderer uses it as the primary identifier on each row.
+	SourceRef string `json:"source_ref"`
+
+	// SourceTitle is the linking item's title at query time.
+	SourceTitle string `json:"source_title"`
+
+	// SourceCollectionSlug + SourceCollectionIcon let the renderer
+	// pick a route prefix and visual badge without a second
+	// round-trip per backlink.
+	SourceCollectionSlug string `json:"source_collection_slug"`
+	SourceCollectionIcon string `json:"source_collection_icon"`
+
+	// Snippet is ~80 chars of the source item's body centered on
+	// the link's position, with internal newlines collapsed to
+	// spaces. Empty when the source item has no body.
+	Snippet string `json:"snippet"`
+
+	// DisplayText is the [[X|Display]] override the link author
+	// supplied, empty when the link was a bare `[[X]]`.
+	DisplayText string `json:"display_text,omitempty"`
+
+	// UpdatedAt is the source item's updated_at, RFC3339 string.
+	// Used for relative timestamps ("3h ago"); the list is
+	// already ordered most-recent first.
+	UpdatedAt string `json:"updated_at"`
+}

--- a/internal/server/handlers_backlinks.go
+++ b/internal/server/handlers_backlinks.go
@@ -20,10 +20,15 @@ import (
 //   - The TARGET item must be visible to the requester (visibility
 //     check via requireItemVisible). If the requester can't see the
 //     target, they don't get to know who links to it.
-//   - SOURCE items are filtered by per-row collection visibility +
-//     guest grants — a backlink from a hidden collection or a
-//     guest-walled item is dropped so this endpoint can't leak the
-//     existence of unviewable items via the snippet field.
+//   - SOURCE items are filtered by per-row collection visibility in
+//     SQL (via visibleCollectionIDs → GetBacklinks). Filtering in
+//     SQL — not post-fetch — is essential for correct pagination:
+//     the LIMIT/OFFSET counts visible rows, not raw rows. Otherwise
+//     a restricted user asking for limit=50 could receive an empty
+//     page even when later visible backlinks exist (Codex round-1
+//     P1). Item-level guest grants apply on top of the collection
+//     gate; they're rare enough that the residual handler-side trim
+//     doesn't materially shrink pages.
 //
 // Pagination:
 //   - `?limit=N` (1–300, default 50). Out-of-range values are
@@ -65,7 +70,19 @@ func (s *Server) handleGetItemBacklinks(w http.ResponseWriter, r *http.Request) 
 		}
 	}
 
-	backlinks, err := s.store.GetBacklinks(item.ID, workspaceID, limit, offset)
+	// Visibility gate. nil → no restriction (owner/editor/root tokens);
+	// non-empty → SQL-side filter for SOURCE collection visibility.
+	// Passing this into the store query (not filtering after the
+	// fetch) is what makes the LIMIT/OFFSET pagination correct for
+	// restricted users — see the function-level comment above and
+	// Codex round-1 P1.
+	visibleIDs, visErr := s.visibleCollectionIDs(r, workspaceID)
+	if visErr != nil {
+		writeInternalError(w, visErr)
+		return
+	}
+
+	backlinks, err := s.store.GetBacklinks(item.ID, workspaceID, limit, offset, visibleIDs)
 	if err != nil {
 		writeInternalError(w, err)
 		return
@@ -77,15 +94,12 @@ func (s *Server) handleGetItemBacklinks(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	// Per-source visibility filter. The store-level query already
-	// gates source.deleted_at IS NULL and excludes self-links, but
-	// it has no view into the requester's permissions — that's
-	// strictly an HTTP-layer concern.
-	visibleIDs, visErr := s.visibleCollectionIDs(r, workspaceID)
-	if visErr != nil {
-		writeInternalError(w, visErr)
-		return
-	}
+	// Item-level guest grants apply on top of the SQL collection
+	// gate. These are item-by-item ACL overrides; pushing them into
+	// SQL would mean expanding the WHERE clause per request, which
+	// isn't worth it for an N≤50 page. For the common authenticated
+	// case (no guest grants active) this loop runs N times and drops
+	// nothing.
 	fullCollIDs, grantedItemIDs, grantErr := s.guestResourceFilter(r, workspaceID)
 	if grantErr != nil {
 		writeInternalError(w, grantErr)
@@ -94,17 +108,8 @@ func (s *Server) handleGetItemBacklinks(w http.ResponseWriter, r *http.Request) 
 	if visibleIDs != nil {
 		filtered := backlinks[:0]
 		for _, bl := range backlinks {
-			// Re-resolve the source item just enough to apply
-			// the existing visibility helpers. A second lookup
-			// per backlink isn't free, but for N≤50 it's well
-			// within the latency budget; if this becomes hot
-			// we can extend GetBacklinks to return collection_id
-			// alongside the slug.
 			src, err := s.store.GetItem(bl.SourceItemID)
 			if err != nil || src == nil {
-				continue
-			}
-			if !isCollectionVisible(src.CollectionID, visibleIDs) {
 				continue
 			}
 			if !s.isItemVisibleToGuest(r, workspaceID, src, fullCollIDs, grantedItemIDs) {

--- a/internal/server/handlers_backlinks.go
+++ b/internal/server/handlers_backlinks.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/PerpetualSoftware/pad/internal/models"
+	"github.com/PerpetualSoftware/pad/internal/store"
 	"github.com/go-chi/chi/v5"
 )
 
@@ -20,15 +20,18 @@ import (
 //   - The TARGET item must be visible to the requester (visibility
 //     check via requireItemVisible). If the requester can't see the
 //     target, they don't get to know who links to it.
-//   - SOURCE items are filtered by per-row collection visibility in
-//     SQL (via visibleCollectionIDs → GetBacklinks). Filtering in
-//     SQL — not post-fetch — is essential for correct pagination:
-//     the LIMIT/OFFSET counts visible rows, not raw rows. Otherwise
-//     a restricted user asking for limit=50 could receive an empty
-//     page even when later visible backlinks exist (Codex round-1
-//     P1). Item-level guest grants apply on top of the collection
-//     gate; they're rare enough that the residual handler-side trim
-//     doesn't materially shrink pages.
+//   - SOURCE items are filtered IN SQL using the precise
+//     `(fullCollIDs, grantedItemIDs)` shape returned by
+//     guestResourceFilter. Pagination correctness depends on this:
+//     filtering AFTER the fetch would let hidden rows consume LIMIT
+//     slots and shrink pages silently — Codex round-1 P1 and
+//     round-2 P1 both flagged variants of that bug.
+//
+// Visibility model passed to the store:
+//   - admin or full-access member          → Unrestricted=true
+//   - guest or restricted member with grants → the (fullColl, grantedItem)
+//     lists from guestResourceFilter; the store builds
+//     `AND (s.collection_id IN <full> OR s.id IN <granted>)`
 //
 // Pagination:
 //   - `?limit=N` (1–300, default 50). Out-of-range values are
@@ -70,19 +73,22 @@ func (s *Server) handleGetItemBacklinks(w http.ResponseWriter, r *http.Request) 
 		}
 	}
 
-	// Visibility gate. nil → no restriction (owner/editor/root tokens);
-	// non-empty → SQL-side filter for SOURCE collection visibility.
-	// Passing this into the store query (not filtering after the
-	// fetch) is what makes the LIMIT/OFFSET pagination correct for
-	// restricted users — see the function-level comment above and
-	// Codex round-1 P1.
-	visibleIDs, visErr := s.visibleCollectionIDs(r, workspaceID)
-	if visErr != nil {
-		writeInternalError(w, visErr)
+	// Resolve the precise visibility primitives. nil/nil ↦
+	// Unrestricted (admin / full-access member / root token);
+	// non-nil ↦ restricted user, build the SQL filter from the
+	// exact (full-coll, granted-item) lists.
+	fullCollIDs, grantedItemIDs, gErr := s.guestResourceFilter(r, workspaceID)
+	if gErr != nil {
+		writeInternalError(w, gErr)
 		return
 	}
+	vis := store.BacklinksVisibility{Unrestricted: fullCollIDs == nil && grantedItemIDs == nil}
+	if !vis.Unrestricted {
+		vis.FullCollectionIDs = fullCollIDs
+		vis.GrantedItemIDs = grantedItemIDs
+	}
 
-	backlinks, err := s.store.GetBacklinks(item.ID, workspaceID, limit, offset, visibleIDs)
+	backlinks, err := s.store.GetBacklinks(item.ID, workspaceID, limit, offset, vis)
 	if err != nil {
 		writeInternalError(w, err)
 		return
@@ -92,38 +98,6 @@ func (s *Server) handleGetItemBacklinks(w http.ResponseWriter, r *http.Request) 
 		// clients to consume without special-casing.
 		writeJSON(w, http.StatusOK, []any{})
 		return
-	}
-
-	// Item-level guest grants apply on top of the SQL collection
-	// gate. These are item-by-item ACL overrides; pushing them into
-	// SQL would mean expanding the WHERE clause per request, which
-	// isn't worth it for an N≤50 page. For the common authenticated
-	// case (no guest grants active) this loop runs N times and drops
-	// nothing.
-	fullCollIDs, grantedItemIDs, grantErr := s.guestResourceFilter(r, workspaceID)
-	if grantErr != nil {
-		writeInternalError(w, grantErr)
-		return
-	}
-	if visibleIDs != nil {
-		filtered := backlinks[:0]
-		for _, bl := range backlinks {
-			src, err := s.store.GetItem(bl.SourceItemID)
-			if err != nil || src == nil {
-				continue
-			}
-			if !s.isItemVisibleToGuest(r, workspaceID, src, fullCollIDs, grantedItemIDs) {
-				continue
-			}
-			filtered = append(filtered, bl)
-		}
-		backlinks = filtered
-	}
-
-	// Defensive: never return null even after the filter loop
-	// emptied the slice.
-	if backlinks == nil {
-		backlinks = []models.Backlink{}
 	}
 	writeJSON(w, http.StatusOK, backlinks)
 }

--- a/internal/server/handlers_backlinks.go
+++ b/internal/server/handlers_backlinks.go
@@ -1,0 +1,124 @@
+package server
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+	"github.com/go-chi/chi/v5"
+)
+
+// handleGetItemBacklinks serves
+// `GET /api/v1/workspaces/{ws}/items/{itemSlug}/backlinks` — the
+// REST surface for PLAN-1593's reverse `[[...]]` index. Returns a
+// JSON array of Backlink rows, ordered most-recently-updated source
+// first.
+//
+// Auth + scoping:
+//   - Workspace lookup follows the standard middleware-resolved path
+//     (getWorkspaceID).
+//   - The TARGET item must be visible to the requester (visibility
+//     check via requireItemVisible). If the requester can't see the
+//     target, they don't get to know who links to it.
+//   - SOURCE items are filtered by per-row collection visibility +
+//     guest grants — a backlink from a hidden collection or a
+//     guest-walled item is dropped so this endpoint can't leak the
+//     existence of unviewable items via the snippet field.
+//
+// Pagination:
+//   - `?limit=N` (1–300, default 50). Out-of-range values are
+//     normalized in the store layer.
+//   - `?offset=N` (>=0). Skipped page lets the UI / CLI build a
+//     paged "see more" affordance.
+//
+// PLAN-1593 / TASK-1594.
+func (s *Server) handleGetItemBacklinks(w http.ResponseWriter, r *http.Request) {
+	workspaceID, ok := s.getWorkspaceID(w, r)
+	if !ok {
+		return
+	}
+
+	itemSlug := chi.URLParam(r, "itemSlug")
+	item, err := s.store.ResolveItem(workspaceID, itemSlug)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	if item == nil {
+		writeError(w, http.StatusNotFound, "not_found", "Item not found")
+		return
+	}
+	if !s.requireItemVisible(w, r, workspaceID, item) {
+		return
+	}
+
+	limit := 50
+	if v := r.URL.Query().Get("limit"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			limit = n
+		}
+	}
+	offset := 0
+	if v := r.URL.Query().Get("offset"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+			offset = n
+		}
+	}
+
+	backlinks, err := s.store.GetBacklinks(item.ID, workspaceID, limit, offset)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	if backlinks == nil {
+		// Always emit a JSON array, never null — easier for
+		// clients to consume without special-casing.
+		writeJSON(w, http.StatusOK, []any{})
+		return
+	}
+
+	// Per-source visibility filter. The store-level query already
+	// gates source.deleted_at IS NULL and excludes self-links, but
+	// it has no view into the requester's permissions — that's
+	// strictly an HTTP-layer concern.
+	visibleIDs, visErr := s.visibleCollectionIDs(r, workspaceID)
+	if visErr != nil {
+		writeInternalError(w, visErr)
+		return
+	}
+	fullCollIDs, grantedItemIDs, grantErr := s.guestResourceFilter(r, workspaceID)
+	if grantErr != nil {
+		writeInternalError(w, grantErr)
+		return
+	}
+	if visibleIDs != nil {
+		filtered := backlinks[:0]
+		for _, bl := range backlinks {
+			// Re-resolve the source item just enough to apply
+			// the existing visibility helpers. A second lookup
+			// per backlink isn't free, but for N≤50 it's well
+			// within the latency budget; if this becomes hot
+			// we can extend GetBacklinks to return collection_id
+			// alongside the slug.
+			src, err := s.store.GetItem(bl.SourceItemID)
+			if err != nil || src == nil {
+				continue
+			}
+			if !isCollectionVisible(src.CollectionID, visibleIDs) {
+				continue
+			}
+			if !s.isItemVisibleToGuest(r, workspaceID, src, fullCollIDs, grantedItemIDs) {
+				continue
+			}
+			filtered = append(filtered, bl)
+		}
+		backlinks = filtered
+	}
+
+	// Defensive: never return null even after the filter loop
+	// emptied the slice.
+	if backlinks == nil {
+		backlinks = []models.Backlink{}
+	}
+	writeJSON(w, http.StatusOK, backlinks)
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1117,6 +1117,7 @@ func (s *Server) setupRouter() {
 						r.Get("/timeline", s.handleListItemTimeline)
 						r.Get("/children", s.handleGetItemChildren)
 						r.Get("/progress", s.handleGetItemProgress)
+						r.Get("/backlinks", s.handleGetItemBacklinks)
 						r.Get("/tasks", s.handleGetItemChildren) // deprecated alias
 						r.Get("/grants", s.handleListItemGrants)
 						r.Post("/grants", s.handleCreateItemGrant)

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -215,6 +215,16 @@ func (s *Store) tryCreateItem(id, workspaceID, collectionID, slug, ts, fields, t
 		}
 	}
 
+	// Index [[...]] wiki-links from the new content. Lives inside the
+	// same tx as the items INSERT so partial state never lands and a
+	// content rollback also rolls back the index rows. Empty content
+	// is fine — replaceWikiLinks short-circuits after deleting any
+	// prior rows (there are none on initial create). PLAN-1593 /
+	// TASK-1594.
+	if err := s.replaceWikiLinks(tx, id, workspaceID, input.Content); err != nil {
+		return fmt.Errorf("index wiki links: %w", err)
+	}
+
 	return tx.Commit()
 }
 
@@ -1638,6 +1648,19 @@ func (s *Store) UpdateItemWithPreCheck(
 	_, err = tx.Exec(s.q(query), args...)
 	if err != nil {
 		return nil, fmt.Errorf("update item: %w", err)
+	}
+
+	// Re-index [[...]] wiki-links if the content was part of this
+	// update (regardless of whether the new content equals the old —
+	// the caller already paid the UPDATE cost so the delete-then-insert
+	// is cheap and keeps the index consistent if a previous reparse
+	// left stale rows). When `input.Content == nil` the content wasn't
+	// touched, so the existing rows remain valid and we skip work.
+	// PLAN-1593 / TASK-1594.
+	if input.Content != nil {
+		if err := s.replaceWikiLinks(tx, id, existing.WorkspaceID, *input.Content); err != nil {
+			return nil, fmt.Errorf("index wiki links: %w", err)
+		}
 	}
 
 	if err := tx.Commit(); err != nil {

--- a/internal/store/migrations/061_item_wiki_links.sql
+++ b/internal/store/migrations/061_item_wiki_links.sql
@@ -1,0 +1,63 @@
+-- Migration 061: server-side reverse index for [[...]] wiki-links
+-- (PLAN-1593 / TASK-1594).
+--
+-- Today the [[...]] syntax is parsed only at render time on the client.
+-- There's no way to ask "who links to TASK-5?" without a full-text scan.
+-- This migration adds the materialized index that the parse-on-save
+-- bookkeeping (internal/links/extract.go + items.go write paths) will
+-- populate.
+--
+-- Phase 1 (this migration + TASK-1594) only stores 'ref'-kind rows. The
+-- schema accommodates all five wiki-link forms (ref / title / collection-
+-- qualified title / cross-workspace ref) up-front so Phase 2 doesn't
+-- require a follow-up ALTER. See PLAN-1593's "Schema (sketch)" section.
+--
+-- Field notes:
+--   * target_kind ∈ {'ref','title','workspace_ref'}. Constrained by a
+--     CHECK so a typo from the application layer fails loudly instead
+--     of silently inserting unqueryable rows.
+--   * target_workspace_id is NULL for same-workspace links. The
+--     (workspace_id, ref) shape on the composite index supports the
+--     cross-workspace reverse lookup Phase 2 will add without a
+--     schema change.
+--   * target_item_id is NULL when the link couldn't be resolved at
+--     parse time (broken ref like [[NOTAREAL-99]] or a title that
+--     doesn't match any item yet). Persisting unresolved rows
+--     intentionally — feeds a future broken-links report and lets
+--     a later resolver run pick them up.
+--   * position is the byte offset of the match in the source item's
+--     content. Used for the ~80-char snippet the handler returns
+--     and for stable per-source ordering when an item links to the
+--     same target multiple times.
+--
+-- The CASCADE on source_item_id matches every other items-referencing
+-- table — when an item is hard-deleted (or soft-deleted then GC'd) its
+-- outgoing links disappear with it. Targets are not FK'd because a
+-- broken-ref row legitimately has no target row to reference.
+
+CREATE TABLE IF NOT EXISTS item_wiki_links (
+    source_item_id      TEXT NOT NULL,
+    target_kind         TEXT NOT NULL CHECK (target_kind IN ('ref','title','workspace_ref')),
+    target_workspace_id TEXT,
+    target_item_id      TEXT,
+    target_ref          TEXT,
+    target_title        TEXT,
+    display_text        TEXT,
+    position            INTEGER NOT NULL,
+    FOREIGN KEY (source_item_id) REFERENCES items(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_wiki_links_source
+    ON item_wiki_links(source_item_id);
+
+CREATE INDEX IF NOT EXISTS idx_wiki_links_target_item
+    ON item_wiki_links(target_item_id)
+    WHERE target_item_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_wiki_links_target_ref
+    ON item_wiki_links(target_workspace_id, target_ref)
+    WHERE target_ref IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_wiki_links_target_title
+    ON item_wiki_links(target_title)
+    WHERE target_title IS NOT NULL;

--- a/internal/store/pgmigrations/040_item_wiki_links.sql
+++ b/internal/store/pgmigrations/040_item_wiki_links.sql
@@ -1,0 +1,37 @@
+-- Postgres mirror of SQLite migration 061 (PLAN-1593 / TASK-1594).
+-- See internal/store/migrations/061_item_wiki_links.sql for the field-
+-- by-field rationale; this file diverges only where SQLite vs Postgres
+-- syntax requires it.
+--
+-- Differences from the SQLite migration:
+--   * No backtick-style identifier quoting needed.
+--   * Partial-index WHERE clauses use the same syntax in both engines
+--     (both support it) so the index definitions are byte-identical
+--     apart from formatting.
+
+CREATE TABLE IF NOT EXISTS item_wiki_links (
+    source_item_id      TEXT NOT NULL,
+    target_kind         TEXT NOT NULL CHECK (target_kind IN ('ref','title','workspace_ref')),
+    target_workspace_id TEXT,
+    target_item_id      TEXT,
+    target_ref          TEXT,
+    target_title        TEXT,
+    display_text        TEXT,
+    position            INTEGER NOT NULL,
+    FOREIGN KEY (source_item_id) REFERENCES items(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_wiki_links_source
+    ON item_wiki_links(source_item_id);
+
+CREATE INDEX IF NOT EXISTS idx_wiki_links_target_item
+    ON item_wiki_links(target_item_id)
+    WHERE target_item_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_wiki_links_target_ref
+    ON item_wiki_links(target_workspace_id, target_ref)
+    WHERE target_ref IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_wiki_links_target_title
+    ON item_wiki_links(target_title)
+    WHERE target_title IS NOT NULL;

--- a/internal/store/wiki_links.go
+++ b/internal/store/wiki_links.go
@@ -71,8 +71,12 @@ func (s *Store) replaceWikiLinks(tx *sql.Tx, sourceItemID, workspaceID, content 
 				targetID = resolveRefTx(tx, s, workspaceID, prefix, number)
 				resolved[key] = targetID
 			}
+			// HasDisplay (not Display != "") distinguishes "no
+			// pipe" from "pipe with empty display." Mirrors the
+			// client renderer's `displayOverride ?? title`
+			// semantics, which preserve "". Codex round-12 P3.
 			displayText := sql.NullString{}
-			if link.Display != "" {
+			if link.HasDisplay {
 				displayText = sql.NullString{String: link.Display, Valid: true}
 			}
 			if _, err := tx.Exec(s.q(`

--- a/internal/store/wiki_links.go
+++ b/internal/store/wiki_links.go
@@ -154,6 +154,32 @@ func splitRef(ref string) (prefix string, number int, ok bool) {
 	return prefix, n, true
 }
 
+// BacklinksVisibility is the per-call visibility scope GetBacklinks
+// applies in SQL. Mirrors the (fullCollIDs, grantedItemIDs) shape
+// `Server.guestResourceFilter` returns so callers can pass the
+// primitives straight through.
+//
+// Semantics:
+//
+//   - Unrestricted == true: no visibility filter; the caller has
+//     full read access to the workspace (admin / full-access
+//     member / root-scoped token). FullCollectionIDs and
+//     GrantedItemIDs are ignored.
+//
+//   - Unrestricted == false: a source row is visible iff
+//     `source.collection_id IN FullCollectionIDs` OR
+//     `source.id IN GrantedItemIDs`. Both empty means "see nothing"
+//     — the query short-circuits to an empty result.
+//
+// Pushing both lists into SQL (rather than post-filtering in Go) is
+// what makes LIMIT/OFFSET pagination correct for guests / restricted
+// members. Codex review of TASK-1594 round-1 P1 + round-2 P1.
+type BacklinksVisibility struct {
+	Unrestricted      bool
+	FullCollectionIDs []string
+	GrantedItemIDs    []string
+}
+
 // GetBacklinks returns the items in `workspaceID` that contain a
 // resolved `[[...]]` reference to `targetItemID`. Phase 1 only
 // returns ref-kind backlinks (the only kind the parser indexes); the
@@ -172,14 +198,10 @@ func splitRef(ref string) (prefix string, number int, ok bool) {
 // `limit` and `offset` paginate. A limit <=0 is normalized to a
 // hard cap (300) so a buggy caller can't ask for unbounded results.
 //
-// `visibleCollectionIDs` constrains the source collections the caller
-// is allowed to see. Pass nil for "no restriction" (owners, editors,
-// CLI/MCP root-scoped tokens). Pass an empty slice for "see nothing"
-// (deliberately locked-out caller). Pass a non-empty slice to gate
-// SQL-side; this matters for correct LIMIT/OFFSET pagination — Codex
-// round-1 P1 — otherwise the handler would have to over-fetch and
-// trim, and pages would unpredictably shrink under restricted access.
-func (s *Store) GetBacklinks(targetItemID, workspaceID string, limit, offset int, visibleCollectionIDs []string) ([]models.Backlink, error) {
+// `vis` constrains source visibility in SQL — see BacklinksVisibility.
+// Filtering in SQL is essential for pagination correctness under
+// restricted access: LIMIT/OFFSET counts visible rows, not raw rows.
+func (s *Store) GetBacklinks(targetItemID, workspaceID string, limit, offset int, vis BacklinksVisibility) ([]models.Backlink, error) {
 	if limit <= 0 || limit > 300 {
 		limit = 50
 	}
@@ -187,28 +209,41 @@ func (s *Store) GetBacklinks(targetItemID, workspaceID string, limit, offset int
 		offset = 0
 	}
 
-	// An empty (non-nil) visibility set means "show nothing." Return
-	// an empty slice up-front so we don't issue a `WHERE c.id IN ()`
-	// query that's syntactically dialect-divergent (Postgres rejects
-	// the empty-list form; SQLite is more permissive). Mirrors the
-	// renderer's locked-out branch (returns the 🔒 broken link rather
-	// than fetching).
-	if visibleCollectionIDs != nil && len(visibleCollectionIDs) == 0 {
+	// Restricted + nothing-to-see → empty up-front. Avoids issuing
+	// a `WHERE … IN ()` query (Postgres rejects the empty-list
+	// form; SQLite tolerates it but matches nothing anyway).
+	if !vis.Unrestricted && len(vis.FullCollectionIDs) == 0 && len(vis.GrantedItemIDs) == 0 {
 		return nil, nil
 	}
 
-	// Build the visibility predicate. nil → omit (no restriction);
-	// non-empty → IN (?, ?, ...) with positional placeholders that
-	// work in both SQLite and Postgres after s.q() rewrites them.
+	// Build the visibility predicate. Unrestricted → omit. Otherwise
+	// `collection_id IN (...)` OR `id IN (...)` — either branch alone
+	// is acceptable so a granted-item-only access still resolves; an
+	// empty IN-list is replaced with a sentinel "IN (NULL)" so the
+	// predicate evaluates to FALSE for that branch without breaking
+	// Postgres's empty-list rejection.
 	visClause := ""
 	args := []interface{}{targetItemID, workspaceID, targetItemID}
-	if visibleCollectionIDs != nil {
-		placeholders := make([]string, len(visibleCollectionIDs))
-		for i, cid := range visibleCollectionIDs {
-			placeholders[i] = "?"
-			args = append(args, cid)
+	if !vis.Unrestricted {
+		collClause := "FALSE"
+		if len(vis.FullCollectionIDs) > 0 {
+			placeholders := make([]string, len(vis.FullCollectionIDs))
+			for i, cid := range vis.FullCollectionIDs {
+				placeholders[i] = "?"
+				args = append(args, cid)
+			}
+			collClause = "s.collection_id IN (" + strings.Join(placeholders, ",") + ")"
 		}
-		visClause = " AND s.collection_id IN (" + strings.Join(placeholders, ",") + ")"
+		itemClause := "FALSE"
+		if len(vis.GrantedItemIDs) > 0 {
+			placeholders := make([]string, len(vis.GrantedItemIDs))
+			for i, iid := range vis.GrantedItemIDs {
+				placeholders[i] = "?"
+				args = append(args, iid)
+			}
+			itemClause = "s.id IN (" + strings.Join(placeholders, ",") + ")"
+		}
+		visClause = " AND (" + collClause + " OR " + itemClause + ")"
 	}
 	args = append(args, limit, offset)
 

--- a/internal/store/wiki_links.go
+++ b/internal/store/wiki_links.go
@@ -330,9 +330,19 @@ func snippetAround(content string, position int) string {
 		end = n
 	}
 	// Trim back to a rune boundary at the start so we don't slice
-	// mid-codepoint. The forward end is safe to clamp at n.
+	// mid-codepoint. UTF-8 continuation bytes have the bit pattern
+	// 10xxxxxx (i.e. (b & 0xC0) == 0x80); advance past them to land
+	// on a leading byte (or ASCII).
 	for start < n && (content[start]&0xC0) == 0x80 {
 		start++
+	}
+	// Same treatment for `end`: if the cut lands inside a multi-byte
+	// rune, advance forward past the continuation bytes so we don't
+	// emit invalid UTF-8. Going forward (not backward) keeps the
+	// snippet anchored slightly past the link rather than slightly
+	// before it. Codex round-8 P3.
+	for end < n && (content[end]&0xC0) == 0x80 {
+		end++
 	}
 	snippet := content[start:end]
 	// Collapse internal newlines so the one-line UI doesn't have to.

--- a/internal/store/wiki_links.go
+++ b/internal/store/wiki_links.go
@@ -1,0 +1,280 @@
+package store
+
+import (
+	"database/sql"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/PerpetualSoftware/pad/internal/links"
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// snippetRadius is how many bytes either side of a link's position
+// the snippet captures. ~80 chars total feels right for a one-line
+// "Mentioned in" panel row; the renderer can trim further or expand
+// on click.
+const snippetRadius = 40
+
+// replaceWikiLinks deletes prior wiki-link rows for `sourceItemID`
+// and inserts fresh ones extracted from `content`. Resolution
+// against the workspace's items happens here (Phase 1: ref-kind
+// only) so the backlinks query is a single index hit.
+//
+// Must run inside `tx` — the caller owns transactionality. Callers
+// from CreateItem / UpdateItem are already inside their write
+// transactions; the backfill caller wraps its own per-source tx.
+//
+// Idempotent: calling with the same (sourceItemID, content) twice
+// yields the same final row set.
+func (s *Store) replaceWikiLinks(tx *sql.Tx, sourceItemID, workspaceID, content string) error {
+	// Delete first so callers don't need to pre-clear. This is the
+	// canonical "re-parse this item" path; an empty content body
+	// correctly leaves zero rows behind.
+	if _, err := tx.Exec(s.q(`DELETE FROM item_wiki_links WHERE source_item_id = ?`), sourceItemID); err != nil {
+		return fmt.Errorf("delete prior wiki links: %w", err)
+	}
+	if content == "" {
+		return nil
+	}
+
+	extracted := links.ExtractWikiLinks(content)
+	if len(extracted) == 0 {
+		return nil
+	}
+
+	// Resolve refs to target_item_id within the same workspace. We
+	// build a per-(prefix, number) cache so repeat references in
+	// the same body (`[[TASK-5]]` mentioned three times) don't
+	// re-query. The cache scope is one call to replaceWikiLinks
+	// since target item IDs can't change during one source-item
+	// write transaction in any way that would matter for
+	// resolution.
+	type refKey struct {
+		prefix string
+		number int
+	}
+	resolved := map[refKey]sql.NullString{}
+
+	for _, link := range extracted {
+		switch link.Kind {
+		case links.WikiLinkKindRef:
+			prefix, number, ok := splitRef(link.Ref)
+			if !ok {
+				// parseBody already vetted the shape but defensive
+				// in case the constants ever drift.
+				continue
+			}
+			key := refKey{prefix: prefix, number: number}
+			targetID, cached := resolved[key]
+			if !cached {
+				targetID = resolveRefTx(tx, s, workspaceID, prefix, number)
+				resolved[key] = targetID
+			}
+			displayText := sql.NullString{}
+			if link.Display != "" {
+				displayText = sql.NullString{String: link.Display, Valid: true}
+			}
+			if _, err := tx.Exec(s.q(`
+				INSERT INTO item_wiki_links (
+					source_item_id, target_kind, target_workspace_id,
+					target_item_id, target_ref, target_title,
+					display_text, position
+				) VALUES (?, ?, NULL, ?, ?, NULL, ?, ?)
+			`), sourceItemID, string(links.WikiLinkKindRef),
+				targetID, link.Ref, displayText, link.Position); err != nil {
+				return fmt.Errorf("insert wiki link: %w", err)
+			}
+		default:
+			// Phase 1 skips title and workspace_ref kinds. The
+			// parser's gate should already prevent them from
+			// arriving here; this default branch is a safety
+			// net for the day Phase 2 lifts the gate.
+			continue
+		}
+	}
+	return nil
+}
+
+// resolveRefTx looks up a (prefix, number) pair to an item ID within
+// a workspace. Returns a NULL sql.NullString if the ref doesn't
+// resolve — broken refs intentionally persist as unresolved rows
+// (PLAN-1593's "broken refs persisted" decision), so they're easy
+// to surface in a future broken-links report.
+//
+// Tries the exact prefix+number match first, then falls back to a
+// number-only match (matching GetItemByRef's behavior so an item
+// that has been moved between collections still resolves under its
+// old prefix).
+func resolveRefTx(tx *sql.Tx, s *Store, workspaceID, prefix string, number int) sql.NullString {
+	var id string
+	err := tx.QueryRow(s.q(`
+		SELECT i.id FROM items i
+		JOIN collections c ON c.id = i.collection_id
+		WHERE i.workspace_id = ? AND c.prefix = ? AND i.item_number = ?
+		  AND i.deleted_at IS NULL
+	`), workspaceID, prefix, number).Scan(&id)
+	if err == nil {
+		return sql.NullString{String: id, Valid: true}
+	}
+	if err != sql.ErrNoRows {
+		// A real DB error during resolution is rare and not worth
+		// failing the whole item write over — log-and-skip would
+		// be ideal but we don't have a logger handle here. Return
+		// NULL so the row persists as unresolved; if the error
+		// repeats on every write the broken-links report (Phase 3+)
+		// will surface it.
+		return sql.NullString{}
+	}
+	// Number-only fallback for the cross-collection-move case.
+	err = tx.QueryRow(s.q(`
+		SELECT id FROM items
+		WHERE workspace_id = ? AND item_number = ? AND deleted_at IS NULL
+	`), workspaceID, number).Scan(&id)
+	if err != nil {
+		return sql.NullString{}
+	}
+	return sql.NullString{String: id, Valid: true}
+}
+
+// splitRef parses "TASK-5" into ("TASK", 5). The trailing -<number>
+// is required; everything before the last '-' is the prefix.
+// Returns ok=false on shapes ExtractWikiLinks shouldn't produce
+// (defensive — keeps the helper robust to future parser changes).
+func splitRef(ref string) (prefix string, number int, ok bool) {
+	dash := strings.LastIndexByte(ref, '-')
+	if dash <= 0 || dash >= len(ref)-1 {
+		return "", 0, false
+	}
+	prefix = ref[:dash]
+	n, err := strconv.Atoi(ref[dash+1:])
+	if err != nil {
+		return "", 0, false
+	}
+	return prefix, n, true
+}
+
+// GetBacklinks returns the items in `workspaceID` that contain a
+// resolved `[[...]]` reference to `targetItemID`. Phase 1 only
+// returns ref-kind backlinks (the only kind the parser indexes); the
+// query JOINs against items.deleted_at IS NULL so soft-deleted
+// sources don't surface.
+//
+// Self-links are filtered out at query time — an item that mentions
+// its own title in its own body shouldn't appear in its own
+// "Mentioned in" panel (PLAN-1593 behavior decision). The row stays
+// in the index for completeness; the filter is purely cosmetic.
+//
+// Ordering: most-recently-updated source first; within an updated_at
+// tie (e.g. two backlinks land in the same second), break by
+// position ASC so the order is at least deterministic.
+//
+// `limit` and `offset` paginate. A limit <=0 is normalized to a
+// hard cap (300) so a buggy caller can't ask for unbounded results.
+func (s *Store) GetBacklinks(targetItemID, workspaceID string, limit, offset int) ([]models.Backlink, error) {
+	if limit <= 0 || limit > 300 {
+		limit = 50
+	}
+	if offset < 0 {
+		offset = 0
+	}
+
+	rows, err := s.db.Query(s.q(`
+		SELECT s.id, c.prefix, s.item_number, s.title, c.slug, c.icon,
+		       s.content, wl.position, wl.display_text, s.updated_at
+		FROM item_wiki_links wl
+		JOIN items s       ON s.id = wl.source_item_id
+		JOIN collections c ON c.id = s.collection_id
+		WHERE wl.target_item_id = ?
+		  AND s.workspace_id = ?
+		  AND s.deleted_at IS NULL
+		  AND s.id != ?
+		ORDER BY s.updated_at DESC, wl.position ASC
+		LIMIT ? OFFSET ?
+	`), targetItemID, workspaceID, targetItemID, limit, offset)
+	if err != nil {
+		return nil, fmt.Errorf("query backlinks: %w", err)
+	}
+	defer rows.Close()
+
+	var out []models.Backlink
+	for rows.Next() {
+		var (
+			sourceID, prefix, title, collSlug, collIcon, content, updatedAt string
+			itemNumber                                                      int
+			position                                                        int
+			displayText                                                     sql.NullString
+		)
+		if err := rows.Scan(&sourceID, &prefix, &itemNumber, &title, &collSlug, &collIcon, &content, &position, &displayText, &updatedAt); err != nil {
+			return nil, fmt.Errorf("scan backlink row: %w", err)
+		}
+		bl := models.Backlink{
+			SourceItemID:         sourceID,
+			SourceRef:            formatRef(prefix, itemNumber),
+			SourceTitle:          title,
+			SourceCollectionSlug: collSlug,
+			SourceCollectionIcon: collIcon,
+			Snippet:              snippetAround(content, position),
+			UpdatedAt:            updatedAt,
+		}
+		if displayText.Valid {
+			bl.DisplayText = displayText.String
+		}
+		out = append(out, bl)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate backlinks: %w", err)
+	}
+	return out, nil
+}
+
+// formatRef rebuilds "PREFIX-NUMBER" from its parts. Kept inline
+// rather than reaching for a models package helper to avoid an
+// import cycle from store→models→store via the dialect helpers.
+func formatRef(prefix string, number int) string {
+	return prefix + "-" + strconv.Itoa(number)
+}
+
+// snippetAround returns roughly `snippetRadius*2` bytes of `content`
+// centered on `position` (the start of the `[[`). Caller doesn't
+// need the snippet to be exact — the UI usually further trims to
+// fit a single line — but we DO trim at rune boundaries so a
+// multi-byte rune at the cut point doesn't produce invalid UTF-8.
+//
+// Empty content yields empty snippet.
+func snippetAround(content string, position int) string {
+	if content == "" {
+		return ""
+	}
+	n := len(content)
+	if position < 0 {
+		position = 0
+	}
+	if position > n {
+		position = n
+	}
+	start := position - snippetRadius
+	if start < 0 {
+		start = 0
+	}
+	end := position + snippetRadius
+	if end > n {
+		end = n
+	}
+	// Trim back to a rune boundary at the start so we don't slice
+	// mid-codepoint. The forward end is safe to clamp at n.
+	for start < n && (content[start]&0xC0) == 0x80 {
+		start++
+	}
+	snippet := content[start:end]
+	// Collapse internal newlines so the one-line UI doesn't have to.
+	snippet = strings.ReplaceAll(snippet, "\n", " ")
+	// Add an ellipsis hint when we truncated on either side.
+	if start > 0 {
+		snippet = "…" + snippet
+	}
+	if end < n {
+		snippet = snippet + "…"
+	}
+	return snippet
+}

--- a/internal/store/wiki_links.go
+++ b/internal/store/wiki_links.go
@@ -290,7 +290,11 @@ func (s *Store) GetBacklinks(targetItemID, workspaceID string, limit, offset int
 			UpdatedAt:            updatedAt,
 		}
 		if displayText.Valid {
-			bl.DisplayText = displayText.String
+			// Pointer-typed so the JSON wire shape preserves the
+			// nil-vs-empty-string distinction even when the
+			// override is "". Codex round-13 P2.
+			s := displayText.String
+			bl.DisplayText = &s
 		}
 		out = append(out, bl)
 	}

--- a/internal/store/wiki_links.go
+++ b/internal/store/wiki_links.go
@@ -171,13 +171,46 @@ func splitRef(ref string) (prefix string, number int, ok bool) {
 //
 // `limit` and `offset` paginate. A limit <=0 is normalized to a
 // hard cap (300) so a buggy caller can't ask for unbounded results.
-func (s *Store) GetBacklinks(targetItemID, workspaceID string, limit, offset int) ([]models.Backlink, error) {
+//
+// `visibleCollectionIDs` constrains the source collections the caller
+// is allowed to see. Pass nil for "no restriction" (owners, editors,
+// CLI/MCP root-scoped tokens). Pass an empty slice for "see nothing"
+// (deliberately locked-out caller). Pass a non-empty slice to gate
+// SQL-side; this matters for correct LIMIT/OFFSET pagination — Codex
+// round-1 P1 — otherwise the handler would have to over-fetch and
+// trim, and pages would unpredictably shrink under restricted access.
+func (s *Store) GetBacklinks(targetItemID, workspaceID string, limit, offset int, visibleCollectionIDs []string) ([]models.Backlink, error) {
 	if limit <= 0 || limit > 300 {
 		limit = 50
 	}
 	if offset < 0 {
 		offset = 0
 	}
+
+	// An empty (non-nil) visibility set means "show nothing." Return
+	// an empty slice up-front so we don't issue a `WHERE c.id IN ()`
+	// query that's syntactically dialect-divergent (Postgres rejects
+	// the empty-list form; SQLite is more permissive). Mirrors the
+	// renderer's locked-out branch (returns the 🔒 broken link rather
+	// than fetching).
+	if visibleCollectionIDs != nil && len(visibleCollectionIDs) == 0 {
+		return nil, nil
+	}
+
+	// Build the visibility predicate. nil → omit (no restriction);
+	// non-empty → IN (?, ?, ...) with positional placeholders that
+	// work in both SQLite and Postgres after s.q() rewrites them.
+	visClause := ""
+	args := []interface{}{targetItemID, workspaceID, targetItemID}
+	if visibleCollectionIDs != nil {
+		placeholders := make([]string, len(visibleCollectionIDs))
+		for i, cid := range visibleCollectionIDs {
+			placeholders[i] = "?"
+			args = append(args, cid)
+		}
+		visClause = " AND s.collection_id IN (" + strings.Join(placeholders, ",") + ")"
+	}
+	args = append(args, limit, offset)
 
 	rows, err := s.db.Query(s.q(`
 		SELECT s.id, c.prefix, s.item_number, s.title, c.slug, c.icon,
@@ -188,10 +221,10 @@ func (s *Store) GetBacklinks(targetItemID, workspaceID string, limit, offset int
 		WHERE wl.target_item_id = ?
 		  AND s.workspace_id = ?
 		  AND s.deleted_at IS NULL
-		  AND s.id != ?
+		  AND s.id != ?`+visClause+`
 		ORDER BY s.updated_at DESC, wl.position ASC
 		LIMIT ? OFFSET ?
-	`), targetItemID, workspaceID, targetItemID, limit, offset)
+	`), args...)
 	if err != nil {
 		return nil, fmt.Errorf("query backlinks: %w", err)
 	}

--- a/internal/store/wiki_links_backfill.go
+++ b/internal/store/wiki_links_backfill.go
@@ -1,0 +1,156 @@
+package store
+
+import (
+	"fmt"
+	"log/slog"
+)
+
+// BackfillWikiLinksResult reports what the backfill did so cmd/pad/main.go
+// can log a one-line summary at startup. Repeat runs should report
+// ItemsScanned > 0 but LinksInserted near 0 (already-indexed items
+// re-parse to the same row set, and we cap the per-source work with a
+// short-circuit on "already has rows" — see below).
+type BackfillWikiLinksResult struct {
+	// ItemsScanned is the number of items the backfill iterated.
+	// Counts every non-soft-deleted item with non-empty content,
+	// regardless of whether the item produced any link rows.
+	ItemsScanned int
+
+	// ItemsIndexed is the count of items that actually got new
+	// rows on this run. On a healthy steady-state install this
+	// should be 0 (every item already indexed at write time).
+	ItemsIndexed int
+
+	// LinksInserted is the total number of `item_wiki_links` rows
+	// the backfill inserted.
+	LinksInserted int
+
+	// Errors tracks items the backfill skipped due to a parse or
+	// write failure. Errors are logged at WARN but don't abort
+	// the run — a broken row beats a missing whole index.
+	Errors int
+}
+
+// BackfillWikiLinks scans every item with non-empty content and
+// re-parses its body to populate `item_wiki_links`. Designed to be
+// called from server startup after migrations have run. Idempotent:
+//
+//   - On first boot after migration 061, the table is empty and
+//     every item with content produces its full link row set.
+//   - On every subsequent boot, items that already have rows in
+//     `item_wiki_links` are skipped via a cheap EXISTS check — the
+//     work-per-startup decays to "scan the items list and short-circuit".
+//   - If an item is rewritten between boots (write-time hook ran),
+//     its rows are already current and the backfill skips it.
+//
+// The short-circuit pattern is intentionally conservative: a future
+// "force re-parse" flag could clear `item_wiki_links` and re-run this
+// function to pick up parser improvements. We don't expose that flag
+// yet — the schema is fresh — but the structure supports it.
+//
+// Per-item write uses its own transaction so a single bad row doesn't
+// poison the whole pass. The per-item work is small enough that
+// per-tx overhead is dominated by parser cost.
+//
+// PLAN-1593 / TASK-1594.
+func (s *Store) BackfillWikiLinks() (*BackfillWikiLinksResult, error) {
+	result := &BackfillWikiLinksResult{}
+
+	// Stream items rather than buffering — large workspaces could
+	// have tens of thousands of items. SQLite handles streaming
+	// fine; the modernc.org driver doesn't buffer everything by
+	// default.
+	rows, err := s.db.Query(s.q(`
+		SELECT id, workspace_id, content
+		FROM items
+		WHERE content != '' AND deleted_at IS NULL
+	`))
+	if err != nil {
+		return nil, fmt.Errorf("scan items for backfill: %w", err)
+	}
+	defer rows.Close()
+
+	// Collect ids first to release the rows iterator before we
+	// begin per-item transactions — some drivers (including
+	// modernc.org/sqlite at high concurrency) get unhappy about
+	// nested writes while a SELECT cursor is open.
+	type itemRef struct {
+		id, workspaceID, content string
+	}
+	var items []itemRef
+	for rows.Next() {
+		var ir itemRef
+		if err := rows.Scan(&ir.id, &ir.workspaceID, &ir.content); err != nil {
+			return nil, fmt.Errorf("scan backfill row: %w", err)
+		}
+		items = append(items, ir)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate backfill rows: %w", err)
+	}
+	rows.Close()
+
+	for _, ir := range items {
+		result.ItemsScanned++
+
+		// Short-circuit: an item that already has rows in the
+		// wiki-links table was indexed at write time and doesn't
+		// need re-parsing. Cheap EXISTS check.
+		var has int
+		if err := s.db.QueryRow(s.q(`
+			SELECT EXISTS(SELECT 1 FROM item_wiki_links WHERE source_item_id = ?)
+		`), ir.id).Scan(&has); err != nil {
+			slog.Warn("backfill wiki links: existence check failed",
+				slog.String("item_id", ir.id), slog.String("err", err.Error()))
+			result.Errors++
+			continue
+		}
+		if has == 1 {
+			continue
+		}
+
+		// Open a tiny tx for this one item. If `replaceWikiLinks`
+		// fails, the tx rolls back and we log + move on.
+		tx, err := s.db.Begin()
+		if err != nil {
+			slog.Warn("backfill wiki links: begin tx failed",
+				slog.String("item_id", ir.id), slog.String("err", err.Error()))
+			result.Errors++
+			continue
+		}
+		if err := s.replaceWikiLinks(tx, ir.id, ir.workspaceID, ir.content); err != nil {
+			tx.Rollback()
+			slog.Warn("backfill wiki links: replace failed",
+				slog.String("item_id", ir.id), slog.String("err", err.Error()))
+			result.Errors++
+			continue
+		}
+
+		// Count rows inserted via a SELECT before commit — we
+		// could derive this from replaceWikiLinks's return but
+		// keeping that function's signature minimal pays off
+		// across other call sites; the extra COUNT(*) is cheap
+		// on the just-inserted rows.
+		var inserted int
+		if err := tx.QueryRow(s.q(`
+			SELECT COUNT(*) FROM item_wiki_links WHERE source_item_id = ?
+		`), ir.id).Scan(&inserted); err != nil {
+			tx.Rollback()
+			slog.Warn("backfill wiki links: count failed",
+				slog.String("item_id", ir.id), slog.String("err", err.Error()))
+			result.Errors++
+			continue
+		}
+		if err := tx.Commit(); err != nil {
+			slog.Warn("backfill wiki links: commit failed",
+				slog.String("item_id", ir.id), slog.String("err", err.Error()))
+			result.Errors++
+			continue
+		}
+		if inserted > 0 {
+			result.ItemsIndexed++
+			result.LinksInserted += inserted
+		}
+	}
+	return result, nil
+}

--- a/internal/store/wiki_links_backfill.go
+++ b/internal/store/wiki_links_backfill.go
@@ -96,7 +96,16 @@ func (s *Store) BackfillWikiLinks() (*BackfillWikiLinksResult, error) {
 		// Short-circuit: an item that already has rows in the
 		// wiki-links table was indexed at write time and doesn't
 		// need re-parsing. Cheap EXISTS check.
-		var has int
+		//
+		// Scanned into a bool — not an int — because `SELECT EXISTS`
+		// returns a boolean on Postgres (`true`/`false`) and an
+		// integer 0/1 on SQLite. Both database/sql drivers in use
+		// (modernc.org/sqlite and lib/pq) coerce their native
+		// representation into Go's bool, so this single shape works
+		// on both engines. Scanning into `int` happened to work on
+		// SQLite but blew up on Postgres, silently disabling the
+		// backfill there (Codex round-3 P1).
+		var has bool
 		if err := s.db.QueryRow(s.q(`
 			SELECT EXISTS(SELECT 1 FROM item_wiki_links WHERE source_item_id = ?)
 		`), ir.id).Scan(&has); err != nil {
@@ -105,7 +114,7 @@ func (s *Store) BackfillWikiLinks() (*BackfillWikiLinksResult, error) {
 			result.Errors++
 			continue
 		}
-		if has == 1 {
+		if has {
 			continue
 		}
 

--- a/internal/store/wiki_links_test.go
+++ b/internal/store/wiki_links_test.go
@@ -257,6 +257,54 @@ func TestWikiLinks_BackfillIdempotent(t *testing.T) {
 	}
 }
 
+// TestWikiLinks_EmptyDisplayDistinct regresses Codex round-12 P3:
+// `[[TASK|]]` (explicit empty display override) and `[[TASK]]` (no
+// override) are distinct shapes in the editor and must store distinct
+// rows. Empty override → display_text=”, no override → display_text
+// IS NULL.
+func TestWikiLinks_EmptyDisplayDistinct(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Test")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+
+	target := createTestItem(t, s, ws.ID, col.ID, "Target", "")
+	tref := refOf(target)
+
+	// Two source items: one references with an explicit empty
+	// override `[[REF|]]`, the other with no override `[[REF]]`.
+	srcWith := createTestItem(t, s, ws.ID, col.ID, "With empty override",
+		"See ["+"["+tref+"|]] for details.")
+	srcNo := createTestItem(t, s, ws.ID, col.ID, "No override",
+		"See ["+"["+tref+"]] for details.")
+
+	var withDispValid bool
+	var withText string
+	err := s.db.QueryRow(s.q(`
+		SELECT display_text IS NOT NULL, COALESCE(display_text, '')
+		FROM item_wiki_links WHERE source_item_id = ?
+	`), srcWith.ID).Scan(&withDispValid, &withText)
+	if err != nil {
+		t.Fatalf("query empty-override row: %v", err)
+	}
+	if !withDispValid {
+		t.Errorf("[[REF|]] should store display_text as '' (not NULL)")
+	}
+	if withText != "" {
+		t.Errorf("[[REF|]] display_text should be empty string, got %q", withText)
+	}
+
+	var noDispValid bool
+	err = s.db.QueryRow(s.q(`
+		SELECT display_text IS NOT NULL FROM item_wiki_links WHERE source_item_id = ?
+	`), srcNo.ID).Scan(&noDispValid)
+	if err != nil {
+		t.Fatalf("query no-override row: %v", err)
+	}
+	if noDispValid {
+		t.Errorf("[[REF]] should store display_text as NULL")
+	}
+}
+
 // TestWikiLinks_SnippetIsValidUTF8 — `snippetAround` may slice
 // `content` at boundaries that fall mid-rune. The function must
 // extend both edges to rune boundaries so the snippet is always

--- a/internal/store/wiki_links_test.go
+++ b/internal/store/wiki_links_test.go
@@ -303,6 +303,28 @@ func TestWikiLinks_EmptyDisplayDistinct(t *testing.T) {
 	if noDispValid {
 		t.Errorf("[[REF]] should store display_text as NULL")
 	}
+
+	// Wire-shape check: GetBacklinks must surface the distinction
+	// via the *string typed DisplayText field. Codex round-13 P2.
+	withBLs, _ := s.GetBacklinks(target.ID, ws.ID, 50, 0, BacklinksVisibility{Unrestricted: true})
+	var withBL, noBL *models.Backlink
+	for i, bl := range withBLs {
+		switch bl.SourceItemID {
+		case srcWith.ID:
+			withBL = &withBLs[i]
+		case srcNo.ID:
+			noBL = &withBLs[i]
+		}
+	}
+	if withBL == nil || noBL == nil {
+		t.Fatalf("expected both source backlinks; got withBL=%v noBL=%v", withBL, noBL)
+	}
+	if withBL.DisplayText == nil || *withBL.DisplayText != "" {
+		t.Errorf("[[REF|]] DisplayText should be non-nil pointer to \"\", got %+v", withBL.DisplayText)
+	}
+	if noBL.DisplayText != nil {
+		t.Errorf("[[REF]] DisplayText should be nil, got %+v", *noBL.DisplayText)
+	}
 }
 
 // TestWikiLinks_SnippetIsValidUTF8 — `snippetAround` may slice

--- a/internal/store/wiki_links_test.go
+++ b/internal/store/wiki_links_test.go
@@ -20,7 +20,7 @@ func TestWikiLinks_CreateItemIndexesRefs(t *testing.T) {
 	source := createTestItem(t, s, ws.ID, col.ID, "Source item",
 		"Please see ["+"["+target.CollectionPrefix+"-"+itoa(*target.ItemNumber)+"]] for context.")
 
-	backlinks, err := s.GetBacklinks(target.ID, ws.ID, 50, 0)
+	backlinks, err := s.GetBacklinks(target.ID, ws.ID, 50, 0, nil)
 	if err != nil {
 		t.Fatalf("GetBacklinks: %v", err)
 	}
@@ -56,7 +56,7 @@ func TestWikiLinks_UpdateItemReplacesIndex(t *testing.T) {
 		"Mentions [["+refOf(a)+"]] only.")
 
 	// A should have one backlink.
-	got, _ := s.GetBacklinks(a.ID, ws.ID, 50, 0)
+	got, _ := s.GetBacklinks(a.ID, ws.ID, 50, 0, nil)
 	if len(got) != 1 {
 		t.Fatalf("step 1: expected A to have 1 backlink, got %d", len(got))
 	}
@@ -67,10 +67,10 @@ func TestWikiLinks_UpdateItemReplacesIndex(t *testing.T) {
 	if _, err := s.UpdateItem(source.ID, models.ItemUpdate{Content: &newContent}); err != nil {
 		t.Fatalf("UpdateItem: %v", err)
 	}
-	if got, _ := s.GetBacklinks(a.ID, ws.ID, 50, 0); len(got) != 0 {
+	if got, _ := s.GetBacklinks(a.ID, ws.ID, 50, 0, nil); len(got) != 0 {
 		t.Errorf("step 2: A should have 0 backlinks after rewrite, got %d", len(got))
 	}
-	if got, _ := s.GetBacklinks(b.ID, ws.ID, 50, 0); len(got) != 1 {
+	if got, _ := s.GetBacklinks(b.ID, ws.ID, 50, 0, nil); len(got) != 1 {
 		t.Errorf("step 2: B should have 1 backlink after rewrite, got %d", len(got))
 	}
 }
@@ -89,7 +89,7 @@ func TestWikiLinks_DeleteItemCascadesOutboundRows(t *testing.T) {
 	source := createTestItem(t, s, ws.ID, col.ID, "Source",
 		"Mentions [["+refOf(target)+"]].")
 
-	if got, _ := s.GetBacklinks(target.ID, ws.ID, 50, 0); len(got) != 1 {
+	if got, _ := s.GetBacklinks(target.ID, ws.ID, 50, 0, nil); len(got) != 1 {
 		t.Fatalf("baseline: expected 1 backlink, got %d", len(got))
 	}
 
@@ -99,7 +99,7 @@ func TestWikiLinks_DeleteItemCascadesOutboundRows(t *testing.T) {
 	if err := s.DeleteItem(source.ID); err != nil {
 		t.Fatalf("DeleteItem: %v", err)
 	}
-	if got, _ := s.GetBacklinks(target.ID, ws.ID, 50, 0); len(got) != 0 {
+	if got, _ := s.GetBacklinks(target.ID, ws.ID, 50, 0, nil); len(got) != 0 {
 		t.Errorf("after soft-delete source: expected 0 backlinks, got %d", len(got))
 	}
 }
@@ -120,7 +120,7 @@ func TestWikiLinks_SelfLinkHidden(t *testing.T) {
 	if _, err := s.UpdateItem(self.ID, models.ItemUpdate{Content: &body}); err != nil {
 		t.Fatalf("UpdateItem: %v", err)
 	}
-	got, err := s.GetBacklinks(self.ID, ws.ID, 50, 0)
+	got, err := s.GetBacklinks(self.ID, ws.ID, 50, 0, nil)
 	if err != nil {
 		t.Fatalf("GetBacklinks: %v", err)
 	}
@@ -182,7 +182,7 @@ func TestWikiLinks_RepeatedRefStoresMultipleRows(t *testing.T) {
 
 	// GetBacklinks returns one row per stored row (snippet differs
 	// per position). Display dedupe is a higher layer's concern.
-	bls, err := s.GetBacklinks(target.ID, ws.ID, 50, 0)
+	bls, err := s.GetBacklinks(target.ID, ws.ID, 50, 0, nil)
 	if err != nil {
 		t.Fatalf("GetBacklinks: %v", err)
 	}
@@ -208,7 +208,7 @@ func TestWikiLinks_CodeBlocksExcludedAtIndexTime(t *testing.T) {
 		"After block."
 	createTestItem(t, s, ws.ID, col.ID, "Mixed", body)
 
-	bls, err := s.GetBacklinks(target.ID, ws.ID, 50, 0)
+	bls, err := s.GetBacklinks(target.ID, ws.ID, 50, 0, nil)
 	if err != nil {
 		t.Fatalf("GetBacklinks: %v", err)
 	}
@@ -250,10 +250,110 @@ func TestWikiLinks_BackfillIdempotent(t *testing.T) {
 	}
 
 	// The reverse-index query should still find the source.
-	bls, _ := s.GetBacklinks(target.ID, ws.ID, 50, 0)
+	bls, _ := s.GetBacklinks(target.ID, ws.ID, 50, 0, nil)
 	if len(bls) != 1 {
 		t.Errorf("after backfill: expected 1 backlink, got %d", len(bls))
 	}
+}
+
+// TestWikiLinks_MixedCaseRefIndexed regresses Codex round-1 P2: a
+// body containing `[[task-5]]` must produce a backlink row pointing
+// at the same target as `[[TASK-5]]`. Renderer permissiveness and
+// indexer behavior have to agree, otherwise users see broken silent
+// data divergence.
+func TestWikiLinks_MixedCaseRefIndexed(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Test")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+
+	target := createTestItem(t, s, ws.ID, col.ID, "Target", "")
+	// Author writes a mixed-case ref. Renderer accepts; indexer
+	// must too. The store should normalize to the canonical
+	// uppercase form so the backlinks query (which compares
+	// against `collections.prefix`, canonically uppercase)
+	// returns the row.
+	lc := strings.ToLower(refOf(target))
+	createTestItem(t, s, ws.ID, col.ID, "Lowercased ref source", "See ["+"["+lc+"]] please.")
+
+	bls, err := s.GetBacklinks(target.ID, ws.ID, 50, 0, nil)
+	if err != nil {
+		t.Fatalf("GetBacklinks: %v", err)
+	}
+	if len(bls) != 1 {
+		t.Fatalf("expected 1 backlink for mixed-case ref input, got %d", len(bls))
+	}
+	// The stored target_ref should be the canonical uppercase form.
+	var storedRef string
+	err = s.db.QueryRow(s.q(`SELECT target_ref FROM item_wiki_links WHERE source_item_id = ?`),
+		bls[0].SourceItemID).Scan(&storedRef)
+	if err != nil {
+		t.Fatalf("read stored target_ref: %v", err)
+	}
+	if storedRef != refOf(target) {
+		t.Errorf("stored target_ref should be uppercase %q, got %q", refOf(target), storedRef)
+	}
+}
+
+// TestWikiLinks_VisibilityAwarePagination regresses Codex round-1 P1:
+// when GetBacklinks is called with a visibility-restricted
+// `visibleCollectionIDs` slice, the LIMIT/OFFSET counts only visible
+// rows. A page asking for `limit=2` must return 2 visible rows even
+// if the underlying raw set has hidden rows interleaved with them.
+//
+// Setup:
+//   - target receives 3 backlinks: src1 (visible), src2 (HIDDEN), src3 (visible).
+//   - With nil visibility (no restriction): all 3 are returned.
+//   - With visibility = [visible collection only]: limit=2 returns
+//     [src3, src1] (newest-first), NOT [src3] (which would be the
+//     bug — hidden src2 silently consuming a slot).
+func TestWikiLinks_VisibilityAwarePagination(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Test")
+	visible := createTestCollection(t, s, ws.ID, "Visible")
+	hidden := createTestCollection(t, s, ws.ID, "Hidden")
+
+	target := createTestItem(t, s, ws.ID, visible.ID, "Target", "")
+	tref := refOf(target)
+	// Insert in update_at order: src1 → src2 → src3.
+	// Newest (src3) appears first in the sorted result.
+	createTestItem(t, s, ws.ID, visible.ID, "Src1 visible", "Refs ["+"["+tref+"]].")
+	createTestItem(t, s, ws.ID, hidden.ID, "Src2 hidden", "Refs ["+"["+tref+"]].")
+	createTestItem(t, s, ws.ID, visible.ID, "Src3 visible", "Refs ["+"["+tref+"]].")
+
+	t.Run("nil visibility returns all 3", func(t *testing.T) {
+		bls, err := s.GetBacklinks(target.ID, ws.ID, 50, 0, nil)
+		if err != nil {
+			t.Fatalf("GetBacklinks: %v", err)
+		}
+		if len(bls) != 3 {
+			t.Errorf("nil visibility: expected 3 backlinks, got %d", len(bls))
+		}
+	})
+
+	t.Run("visible-only limit=2 returns 2 visible rows", func(t *testing.T) {
+		bls, err := s.GetBacklinks(target.ID, ws.ID, 2, 0, []string{visible.ID})
+		if err != nil {
+			t.Fatalf("GetBacklinks: %v", err)
+		}
+		if len(bls) != 2 {
+			t.Fatalf("expected exactly 2 visible backlinks (limit honored), got %d: %+v", len(bls), bls)
+		}
+		for _, bl := range bls {
+			if bl.SourceCollectionSlug != "visible" {
+				t.Errorf("expected only visible-collection sources, got slug=%q", bl.SourceCollectionSlug)
+			}
+		}
+	})
+
+	t.Run("empty visibility returns nothing", func(t *testing.T) {
+		bls, err := s.GetBacklinks(target.ID, ws.ID, 50, 0, []string{})
+		if err != nil {
+			t.Fatalf("GetBacklinks: %v", err)
+		}
+		if len(bls) != 0 {
+			t.Errorf("empty visibility set: expected 0 backlinks, got %d", len(bls))
+		}
+	})
 }
 
 // refOf builds a PREFIX-NUMBER string from a fresh item — used by the

--- a/internal/store/wiki_links_test.go
+++ b/internal/store/wiki_links_test.go
@@ -20,7 +20,7 @@ func TestWikiLinks_CreateItemIndexesRefs(t *testing.T) {
 	source := createTestItem(t, s, ws.ID, col.ID, "Source item",
 		"Please see ["+"["+target.CollectionPrefix+"-"+itoa(*target.ItemNumber)+"]] for context.")
 
-	backlinks, err := s.GetBacklinks(target.ID, ws.ID, 50, 0, nil)
+	backlinks, err := s.GetBacklinks(target.ID, ws.ID, 50, 0, BacklinksVisibility{Unrestricted: true})
 	if err != nil {
 		t.Fatalf("GetBacklinks: %v", err)
 	}
@@ -56,7 +56,7 @@ func TestWikiLinks_UpdateItemReplacesIndex(t *testing.T) {
 		"Mentions [["+refOf(a)+"]] only.")
 
 	// A should have one backlink.
-	got, _ := s.GetBacklinks(a.ID, ws.ID, 50, 0, nil)
+	got, _ := s.GetBacklinks(a.ID, ws.ID, 50, 0, BacklinksVisibility{Unrestricted: true})
 	if len(got) != 1 {
 		t.Fatalf("step 1: expected A to have 1 backlink, got %d", len(got))
 	}
@@ -67,10 +67,10 @@ func TestWikiLinks_UpdateItemReplacesIndex(t *testing.T) {
 	if _, err := s.UpdateItem(source.ID, models.ItemUpdate{Content: &newContent}); err != nil {
 		t.Fatalf("UpdateItem: %v", err)
 	}
-	if got, _ := s.GetBacklinks(a.ID, ws.ID, 50, 0, nil); len(got) != 0 {
+	if got, _ := s.GetBacklinks(a.ID, ws.ID, 50, 0, BacklinksVisibility{Unrestricted: true}); len(got) != 0 {
 		t.Errorf("step 2: A should have 0 backlinks after rewrite, got %d", len(got))
 	}
-	if got, _ := s.GetBacklinks(b.ID, ws.ID, 50, 0, nil); len(got) != 1 {
+	if got, _ := s.GetBacklinks(b.ID, ws.ID, 50, 0, BacklinksVisibility{Unrestricted: true}); len(got) != 1 {
 		t.Errorf("step 2: B should have 1 backlink after rewrite, got %d", len(got))
 	}
 }
@@ -89,7 +89,7 @@ func TestWikiLinks_DeleteItemCascadesOutboundRows(t *testing.T) {
 	source := createTestItem(t, s, ws.ID, col.ID, "Source",
 		"Mentions [["+refOf(target)+"]].")
 
-	if got, _ := s.GetBacklinks(target.ID, ws.ID, 50, 0, nil); len(got) != 1 {
+	if got, _ := s.GetBacklinks(target.ID, ws.ID, 50, 0, BacklinksVisibility{Unrestricted: true}); len(got) != 1 {
 		t.Fatalf("baseline: expected 1 backlink, got %d", len(got))
 	}
 
@@ -99,7 +99,7 @@ func TestWikiLinks_DeleteItemCascadesOutboundRows(t *testing.T) {
 	if err := s.DeleteItem(source.ID); err != nil {
 		t.Fatalf("DeleteItem: %v", err)
 	}
-	if got, _ := s.GetBacklinks(target.ID, ws.ID, 50, 0, nil); len(got) != 0 {
+	if got, _ := s.GetBacklinks(target.ID, ws.ID, 50, 0, BacklinksVisibility{Unrestricted: true}); len(got) != 0 {
 		t.Errorf("after soft-delete source: expected 0 backlinks, got %d", len(got))
 	}
 }
@@ -120,7 +120,7 @@ func TestWikiLinks_SelfLinkHidden(t *testing.T) {
 	if _, err := s.UpdateItem(self.ID, models.ItemUpdate{Content: &body}); err != nil {
 		t.Fatalf("UpdateItem: %v", err)
 	}
-	got, err := s.GetBacklinks(self.ID, ws.ID, 50, 0, nil)
+	got, err := s.GetBacklinks(self.ID, ws.ID, 50, 0, BacklinksVisibility{Unrestricted: true})
 	if err != nil {
 		t.Fatalf("GetBacklinks: %v", err)
 	}
@@ -182,7 +182,7 @@ func TestWikiLinks_RepeatedRefStoresMultipleRows(t *testing.T) {
 
 	// GetBacklinks returns one row per stored row (snippet differs
 	// per position). Display dedupe is a higher layer's concern.
-	bls, err := s.GetBacklinks(target.ID, ws.ID, 50, 0, nil)
+	bls, err := s.GetBacklinks(target.ID, ws.ID, 50, 0, BacklinksVisibility{Unrestricted: true})
 	if err != nil {
 		t.Fatalf("GetBacklinks: %v", err)
 	}
@@ -208,7 +208,7 @@ func TestWikiLinks_CodeBlocksExcludedAtIndexTime(t *testing.T) {
 		"After block."
 	createTestItem(t, s, ws.ID, col.ID, "Mixed", body)
 
-	bls, err := s.GetBacklinks(target.ID, ws.ID, 50, 0, nil)
+	bls, err := s.GetBacklinks(target.ID, ws.ID, 50, 0, BacklinksVisibility{Unrestricted: true})
 	if err != nil {
 		t.Fatalf("GetBacklinks: %v", err)
 	}
@@ -250,7 +250,7 @@ func TestWikiLinks_BackfillIdempotent(t *testing.T) {
 	}
 
 	// The reverse-index query should still find the source.
-	bls, _ := s.GetBacklinks(target.ID, ws.ID, 50, 0, nil)
+	bls, _ := s.GetBacklinks(target.ID, ws.ID, 50, 0, BacklinksVisibility{Unrestricted: true})
 	if len(bls) != 1 {
 		t.Errorf("after backfill: expected 1 backlink, got %d", len(bls))
 	}
@@ -275,7 +275,7 @@ func TestWikiLinks_MixedCaseRefIndexed(t *testing.T) {
 	lc := strings.ToLower(refOf(target))
 	createTestItem(t, s, ws.ID, col.ID, "Lowercased ref source", "See ["+"["+lc+"]] please.")
 
-	bls, err := s.GetBacklinks(target.ID, ws.ID, 50, 0, nil)
+	bls, err := s.GetBacklinks(target.ID, ws.ID, 50, 0, BacklinksVisibility{Unrestricted: true})
 	if err != nil {
 		t.Fatalf("GetBacklinks: %v", err)
 	}
@@ -321,7 +321,7 @@ func TestWikiLinks_VisibilityAwarePagination(t *testing.T) {
 	createTestItem(t, s, ws.ID, visible.ID, "Src3 visible", "Refs ["+"["+tref+"]].")
 
 	t.Run("nil visibility returns all 3", func(t *testing.T) {
-		bls, err := s.GetBacklinks(target.ID, ws.ID, 50, 0, nil)
+		bls, err := s.GetBacklinks(target.ID, ws.ID, 50, 0, BacklinksVisibility{Unrestricted: true})
 		if err != nil {
 			t.Fatalf("GetBacklinks: %v", err)
 		}
@@ -331,7 +331,9 @@ func TestWikiLinks_VisibilityAwarePagination(t *testing.T) {
 	})
 
 	t.Run("visible-only limit=2 returns 2 visible rows", func(t *testing.T) {
-		bls, err := s.GetBacklinks(target.ID, ws.ID, 2, 0, []string{visible.ID})
+		bls, err := s.GetBacklinks(target.ID, ws.ID, 2, 0, BacklinksVisibility{
+			FullCollectionIDs: []string{visible.ID},
+		})
 		if err != nil {
 			t.Fatalf("GetBacklinks: %v", err)
 		}
@@ -346,7 +348,7 @@ func TestWikiLinks_VisibilityAwarePagination(t *testing.T) {
 	})
 
 	t.Run("empty visibility returns nothing", func(t *testing.T) {
-		bls, err := s.GetBacklinks(target.ID, ws.ID, 50, 0, []string{})
+		bls, err := s.GetBacklinks(target.ID, ws.ID, 50, 0, BacklinksVisibility{})
 		if err != nil {
 			t.Fatalf("GetBacklinks: %v", err)
 		}
@@ -354,6 +356,80 @@ func TestWikiLinks_VisibilityAwarePagination(t *testing.T) {
 			t.Errorf("empty visibility set: expected 0 backlinks, got %d", len(bls))
 		}
 	})
+}
+
+// TestWikiLinks_ItemGrantPagination regresses Codex round-2 P1: when
+// a guest has an item-level grant on ONE source item in a collection
+// they can't otherwise see, the rest of that collection must NOT
+// leak into the page. Previously the handler computed
+// `visibleCollectionIDs` as the UNION (full-collection grants ∪
+// collections containing granted items), then filtered each row's
+// item-level visibility in Go AFTER fetching — letting hidden rows
+// consume LIMIT slots. The refactor pushes the precise
+// (FullCollectionIDs OR GrantedItemIDs) predicate into SQL.
+//
+// Setup:
+//   - target in collection A (no relevance to grants — just the item
+//     being linked to).
+//   - Three sources, all linking to target, in collection B (which
+//     the guest has NO full access to):
+//   - src_g: the granted item
+//   - src_x, src_y: also in B, not granted (hidden)
+//   - Guest visibility: FullCollectionIDs=[] (no full access),
+//     GrantedItemIDs=[src_g.ID].
+//
+// Expectation: limit=2 returns exactly [src_g], not [src_g] + leaked
+// rows from B. The bad-pagination version returned 0 or 1 depending
+// on how the hidden rows interleaved.
+func TestWikiLinks_ItemGrantPagination(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Test")
+	a := createTestCollection(t, s, ws.ID, "A")
+	b := createTestCollection(t, s, ws.ID, "B")
+
+	target := createTestItem(t, s, ws.ID, a.ID, "Target", "")
+	tref := refOf(target)
+
+	// Three sources in B, all referencing target. src_g is the one
+	// we'll grant the guest access to; src_x and src_y are hidden.
+	srcG := createTestItem(t, s, ws.ID, b.ID, "Granted", "Refs [["+tref+"]].")
+	createTestItem(t, s, ws.ID, b.ID, "Hidden X", "Refs [["+tref+"]].")
+	createTestItem(t, s, ws.ID, b.ID, "Hidden Y", "Refs [["+tref+"]].")
+
+	// Sanity: unrestricted view sees all three.
+	all, err := s.GetBacklinks(target.ID, ws.ID, 50, 0, BacklinksVisibility{Unrestricted: true})
+	if err != nil {
+		t.Fatalf("GetBacklinks unrestricted: %v", err)
+	}
+	if len(all) != 3 {
+		t.Fatalf("baseline: expected 3 unrestricted backlinks, got %d", len(all))
+	}
+
+	// Guest with item-grant only on src_g, no full collection access.
+	vis := BacklinksVisibility{
+		FullCollectionIDs: nil, // no full-collection grants
+		GrantedItemIDs:    []string{srcG.ID},
+	}
+	bls, err := s.GetBacklinks(target.ID, ws.ID, 50, 0, vis)
+	if err != nil {
+		t.Fatalf("GetBacklinks restricted: %v", err)
+	}
+	if len(bls) != 1 {
+		t.Fatalf("expected exactly 1 backlink (the granted item), got %d: %+v", len(bls), bls)
+	}
+	if bls[0].SourceItemID != srcG.ID {
+		t.Errorf("expected granted item %q, got %q", srcG.ID, bls[0].SourceItemID)
+	}
+
+	// Pagination must agree: limit=2 should still return exactly
+	// [srcG] without the hidden B-collection rows consuming slots.
+	bls2, err := s.GetBacklinks(target.ID, ws.ID, 2, 0, vis)
+	if err != nil {
+		t.Fatalf("GetBacklinks restricted limit=2: %v", err)
+	}
+	if len(bls2) != 1 {
+		t.Errorf("limit=2 should return 1 visible row, not silently shrink: got %d", len(bls2))
+	}
 }
 
 // refOf builds a PREFIX-NUMBER string from a fresh item — used by the

--- a/internal/store/wiki_links_test.go
+++ b/internal/store/wiki_links_test.go
@@ -3,6 +3,7 @@ package store
 import (
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/PerpetualSoftware/pad/internal/models"
 )
@@ -253,6 +254,37 @@ func TestWikiLinks_BackfillIdempotent(t *testing.T) {
 	bls, _ := s.GetBacklinks(target.ID, ws.ID, 50, 0, BacklinksVisibility{Unrestricted: true})
 	if len(bls) != 1 {
 		t.Errorf("after backfill: expected 1 backlink, got %d", len(bls))
+	}
+}
+
+// TestWikiLinks_SnippetIsValidUTF8 — `snippetAround` may slice
+// `content` at boundaries that fall mid-rune. The function must
+// extend both edges to rune boundaries so the snippet is always
+// valid UTF-8. Codex round-8 P3.
+func TestWikiLinks_SnippetIsValidUTF8(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Test")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+
+	target := createTestItem(t, s, ws.ID, col.ID, "Target", "")
+	tref := refOf(target)
+	// Pad each side of the link with enough multi-byte runes that
+	// the ±40-byte snippet window will likely cut through one.
+	// "🎉" is 4 bytes. "héllo" has é = 2 bytes. Both should round-trip.
+	body := "🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉 héllo " + "[" + "[" + tref + "]] héllo 🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉"
+	createTestItem(t, s, ws.ID, col.ID, "Source", body)
+
+	bls, err := s.GetBacklinks(target.ID, ws.ID, 50, 0, BacklinksVisibility{Unrestricted: true})
+	if err != nil {
+		t.Fatalf("GetBacklinks: %v", err)
+	}
+	if len(bls) != 1 {
+		t.Fatalf("expected 1 backlink, got %d", len(bls))
+	}
+	// `utf8.ValidString` is the canonical check; the snippet must
+	// pass regardless of where the ±40-byte cut landed.
+	if !utf8.ValidString(bls[0].Snippet) {
+		t.Errorf("snippet is invalid UTF-8: %q", bls[0].Snippet)
 	}
 }
 

--- a/internal/store/wiki_links_test.go
+++ b/internal/store/wiki_links_test.go
@@ -1,0 +1,294 @@
+package store
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// TestWikiLinks_CreateItemIndexesRefs is the headline Phase 1 test:
+// creating an item with `[[REF]]` in its body produces queryable
+// backlinks for the target item. End-to-end coverage of the write
+// path → resolver → GetBacklinks read path.
+func TestWikiLinks_CreateItemIndexesRefs(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Test")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+
+	target := createTestItem(t, s, ws.ID, col.ID, "Target item", "")
+	source := createTestItem(t, s, ws.ID, col.ID, "Source item",
+		"Please see ["+"["+target.CollectionPrefix+"-"+itoa(*target.ItemNumber)+"]] for context.")
+
+	backlinks, err := s.GetBacklinks(target.ID, ws.ID, 50, 0)
+	if err != nil {
+		t.Fatalf("GetBacklinks: %v", err)
+	}
+	if len(backlinks) != 1 {
+		t.Fatalf("expected 1 backlink, got %d: %+v", len(backlinks), backlinks)
+	}
+	bl := backlinks[0]
+	if bl.SourceItemID != source.ID {
+		t.Errorf("SourceItemID: got %q want %q", bl.SourceItemID, source.ID)
+	}
+	if bl.SourceTitle != "Source item" {
+		t.Errorf("SourceTitle: got %q", bl.SourceTitle)
+	}
+	if bl.SourceRef != source.CollectionPrefix+"-"+itoa(*source.ItemNumber) {
+		t.Errorf("SourceRef: got %q", bl.SourceRef)
+	}
+	if !strings.Contains(bl.Snippet, "for context.") {
+		t.Errorf("snippet should contain surrounding text, got %q", bl.Snippet)
+	}
+}
+
+// TestWikiLinks_UpdateItemReplacesIndex confirms re-parsing kicks in
+// on UpdateItem: changing the body to remove a [[]] removes its
+// backlink row, and adding a new [[]] adds a row.
+func TestWikiLinks_UpdateItemReplacesIndex(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Test")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+
+	a := createTestItem(t, s, ws.ID, col.ID, "A", "")
+	b := createTestItem(t, s, ws.ID, col.ID, "B", "")
+	source := createTestItem(t, s, ws.ID, col.ID, "Source",
+		"Mentions [["+refOf(a)+"]] only.")
+
+	// A should have one backlink.
+	got, _ := s.GetBacklinks(a.ID, ws.ID, 50, 0)
+	if len(got) != 1 {
+		t.Fatalf("step 1: expected A to have 1 backlink, got %d", len(got))
+	}
+
+	// Rewrite body to mention B instead. Expect: A loses its
+	// backlink, B gains one.
+	newContent := "Now mentions [[" + refOf(b) + "]] instead."
+	if _, err := s.UpdateItem(source.ID, models.ItemUpdate{Content: &newContent}); err != nil {
+		t.Fatalf("UpdateItem: %v", err)
+	}
+	if got, _ := s.GetBacklinks(a.ID, ws.ID, 50, 0); len(got) != 0 {
+		t.Errorf("step 2: A should have 0 backlinks after rewrite, got %d", len(got))
+	}
+	if got, _ := s.GetBacklinks(b.ID, ws.ID, 50, 0); len(got) != 1 {
+		t.Errorf("step 2: B should have 1 backlink after rewrite, got %d", len(got))
+	}
+}
+
+// TestWikiLinks_DeleteItemCascadesOutboundRows verifies the FK
+// ON DELETE CASCADE: when a source item is hard-deleted, its
+// outbound wiki-link rows go with it. Soft-delete (the default for
+// items) doesn't trigger this — the rows persist but GetBacklinks
+// filters via items.deleted_at IS NULL on the source.
+func TestWikiLinks_DeleteItemCascadesOutboundRows(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Test")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+
+	target := createTestItem(t, s, ws.ID, col.ID, "Target", "")
+	source := createTestItem(t, s, ws.ID, col.ID, "Source",
+		"Mentions [["+refOf(target)+"]].")
+
+	if got, _ := s.GetBacklinks(target.ID, ws.ID, 50, 0); len(got) != 1 {
+		t.Fatalf("baseline: expected 1 backlink, got %d", len(got))
+	}
+
+	// Soft-delete the source. Backlinks should hide it via the
+	// items.deleted_at IS NULL filter even though the row is still
+	// in item_wiki_links.
+	if err := s.DeleteItem(source.ID); err != nil {
+		t.Fatalf("DeleteItem: %v", err)
+	}
+	if got, _ := s.GetBacklinks(target.ID, ws.ID, 50, 0); len(got) != 0 {
+		t.Errorf("after soft-delete source: expected 0 backlinks, got %d", len(got))
+	}
+}
+
+// TestWikiLinks_SelfLinkHidden — an item that mentions its own
+// ref/title in its own body shouldn't appear in its own "Mentioned
+// in" panel (PLAN-1593 behavior decision).
+func TestWikiLinks_SelfLinkHidden(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Test")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+
+	// We can't reference an item by ref in its OWN body at create
+	// time because the ref isn't assigned until after the INSERT.
+	// So create-empty-then-update with the self-link.
+	self := createTestItem(t, s, ws.ID, col.ID, "Self-link", "")
+	body := "I mention myself: [[" + refOf(self) + "]]."
+	if _, err := s.UpdateItem(self.ID, models.ItemUpdate{Content: &body}); err != nil {
+		t.Fatalf("UpdateItem: %v", err)
+	}
+	got, err := s.GetBacklinks(self.ID, ws.ID, 50, 0)
+	if err != nil {
+		t.Fatalf("GetBacklinks: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected 0 backlinks (self filtered), got %d: %+v", len(got), got)
+	}
+}
+
+// TestWikiLinks_BrokenRefPersisted — a `[[NOTAREAL-99]]` saves with
+// target_item_id = NULL. Verifies the broken-link row reaches the
+// table even though it can't be queried via the target-id index.
+// Feeds the future broken-links report.
+func TestWikiLinks_BrokenRefPersisted(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Test")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+
+	src := createTestItem(t, s, ws.ID, col.ID, "Has broken ref",
+		"This ref doesn't exist: [[NOTAREAL-99]].")
+
+	var count int
+	err := s.db.QueryRow(s.q(`
+		SELECT COUNT(*) FROM item_wiki_links
+		WHERE source_item_id = ? AND target_item_id IS NULL AND target_ref = ?
+	`), src.ID, "NOTAREAL-99").Scan(&count)
+	if err != nil {
+		t.Fatalf("count broken refs: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 unresolved row, got %d", count)
+	}
+}
+
+// TestWikiLinks_RepeatedRefStoresMultipleRows — same target mentioned
+// N times in one source body produces N rows (different positions).
+// Display-side dedupe is the renderer's job; storage keeps every
+// occurrence so future "show me where" features can highlight each.
+func TestWikiLinks_RepeatedRefStoresMultipleRows(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Test")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+
+	target := createTestItem(t, s, ws.ID, col.ID, "Target", "")
+	ref := refOf(target)
+	body := "First [[" + ref + "]], second [[" + ref + "]], third [[" + ref + "]]."
+	src := createTestItem(t, s, ws.ID, col.ID, "Mentions thrice", body)
+
+	var count int
+	err := s.db.QueryRow(s.q(`
+		SELECT COUNT(*) FROM item_wiki_links
+		WHERE source_item_id = ? AND target_item_id = ?
+	`), src.ID, target.ID).Scan(&count)
+	if err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count != 3 {
+		t.Errorf("expected 3 rows for repeated ref, got %d", count)
+	}
+
+	// GetBacklinks returns one row per stored row (snippet differs
+	// per position). Display dedupe is a higher layer's concern.
+	bls, err := s.GetBacklinks(target.ID, ws.ID, 50, 0)
+	if err != nil {
+		t.Fatalf("GetBacklinks: %v", err)
+	}
+	if len(bls) != 3 {
+		t.Errorf("expected 3 backlinks (one per stored row), got %d", len(bls))
+	}
+}
+
+// TestWikiLinks_CodeBlocksExcludedAtIndexTime is the integration
+// counterpart to the parser test: a fenced block with [[REF]] inside
+// must NOT produce a backlink row. Parser exclusion proven end-to-end.
+func TestWikiLinks_CodeBlocksExcludedAtIndexTime(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Test")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+
+	target := createTestItem(t, s, ws.ID, col.ID, "Target", "")
+	ref := refOf(target)
+	body := "Real link: [[" + ref + "]]\n" +
+		"```\n" +
+		"In code: [[" + ref + "]] should NOT count\n" +
+		"```\n" +
+		"After block."
+	createTestItem(t, s, ws.ID, col.ID, "Mixed", body)
+
+	bls, err := s.GetBacklinks(target.ID, ws.ID, 50, 0)
+	if err != nil {
+		t.Fatalf("GetBacklinks: %v", err)
+	}
+	if len(bls) != 1 {
+		t.Errorf("expected 1 backlink (code-block one excluded), got %d", len(bls))
+	}
+}
+
+// TestWikiLinks_BackfillIdempotent — calling BackfillWikiLinks twice
+// produces the same final state. The first call populates rows; the
+// second short-circuits via the EXISTS check and inserts nothing new.
+func TestWikiLinks_BackfillIdempotent(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Test")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+
+	target := createTestItem(t, s, ws.ID, col.ID, "Target", "")
+	createTestItem(t, s, ws.ID, col.ID, "Source", "Links to [["+refOf(target)+"]].")
+
+	// Wipe to simulate "backfill has never run."
+	if _, err := s.db.Exec(`DELETE FROM item_wiki_links`); err != nil {
+		t.Fatalf("clear table: %v", err)
+	}
+
+	bf1, err := s.BackfillWikiLinks()
+	if err != nil {
+		t.Fatalf("BackfillWikiLinks (1st): %v", err)
+	}
+	if bf1.LinksInserted == 0 {
+		t.Errorf("first backfill should have inserted rows, got 0")
+	}
+
+	bf2, err := s.BackfillWikiLinks()
+	if err != nil {
+		t.Fatalf("BackfillWikiLinks (2nd): %v", err)
+	}
+	if bf2.LinksInserted != 0 {
+		t.Errorf("second backfill should be a no-op, got %d new rows", bf2.LinksInserted)
+	}
+
+	// The reverse-index query should still find the source.
+	bls, _ := s.GetBacklinks(target.ID, ws.ID, 50, 0)
+	if len(bls) != 1 {
+		t.Errorf("after backfill: expected 1 backlink, got %d", len(bls))
+	}
+}
+
+// refOf builds a PREFIX-NUMBER string from a fresh item — used by the
+// integration tests since the canonical ref isn't on the model
+// directly. ItemNumber is *int on the model so handle nil
+// defensively (shouldn't happen for created items but the type lets
+// callers express "no number yet").
+func refOf(item *models.Item) string {
+	num := 0
+	if item.ItemNumber != nil {
+		num = *item.ItemNumber
+	}
+	return item.CollectionPrefix + "-" + itoa(num)
+}
+
+// itoa is strconv.Itoa renamed to keep test bodies readable when
+// they're already heavy on ref-formatting.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}


### PR DESCRIPTION
First phase of PLAN-1593. Adds a materialized reverse index for `[[...]]` wiki-links plus the REST + CLI surfaces to query it. Phase 2 (TASK-1595) extends to title/cross-workspace forms; Phase 3 (TASK-1596) adds the web UI panel + MCP action.

## What's new

### Storage (migrations 061 SQLite / 040 Postgres)

New `item_wiki_links` table — schema accommodates all 5 wiki-link forms up-front so Phase 2 doesn't ALTER:

```sql
CREATE TABLE item_wiki_links (
    source_item_id      TEXT NOT NULL,
    target_kind         TEXT NOT NULL CHECK (target_kind IN ('ref','title','workspace_ref')),
    target_workspace_id TEXT,
    target_item_id      TEXT,
    target_ref          TEXT,
    target_title        TEXT,
    display_text        TEXT,
    position            INTEGER NOT NULL,
    FOREIGN KEY (source_item_id) REFERENCES items(id) ON DELETE CASCADE
);
-- partial indexes on target_item_id, (target_workspace_id, target_ref), target_title
```

### Parser (`internal/links/extract.go`)

- Strips fenced and inline code regions before extracting `[[...]]`. Example refs inside `\`\`\`bash...\`\`\`` or `` `[[X]]` `` don't pollute the index.
- Phase 1 emits only `WikiLinkKindRef`. Title / workspace_ref parse successfully but are gated out — Phase 2 lifts the gate.
- Position is byte offset (UTF-8 safe) so the snippet pipeline can slice without re-walking.

### Store hooks (`internal/store/wiki_links.go`)

- `replaceWikiLinks(tx, sourceID, wsID, content)` — delete-then-insert inside the caller's transaction. Idempotent.
- Ref → target_item_id resolution at parse time, with a (prefix, number) cache to dedupe repeated mentions within one body.
- Broken refs (`[[NOTAREAL-99]]`) intentionally persist as unresolved rows. Feeds a future broken-links report.
- `GetBacklinks(targetID, wsID, limit, offset)` — the read path. Filters soft-deleted sources and self-links at query time, orders by source updated_at DESC + position ASC.
- `~80-char` snippet centered on the link position, with internal newlines collapsed to spaces.

### Write-path wiring (`internal/store/items.go`)

- `tryCreateItem`: always calls `replaceWikiLinks` (empty content = no-op DELETE).
- `UpdateItemWithPreCheck`: re-parses whenever `input.Content` is supplied.
- Both run inside the existing write transaction; partial state never lands.

### Backfill (`internal/store/wiki_links_backfill.go`)

- Idempotent. EXISTS short-circuit per source item — steady-state cost is just the items scan.
- Per-item transactions so a single bad row doesn't poison the whole pass.
- Wired into cmd/pad/main.go startup alongside the TOTP / OAuth backfills. Logs `items_scanned / items_indexed / links_inserted` on first run, debug-level no-op on subsequent runs.

### REST handler (`internal/server/handlers_backlinks.go`)

- `GET /api/v1/workspaces/{ws}/items/{itemSlug}/backlinks?limit=N&offset=N`
- Applies workspace-membership + per-source collection visibility + guest grants. The store layer can't see auth context; the HTTP layer adds it.
- Returns a plain JSON array (never `null`).

### CLI (`pad item backlinks <ref>`)

- Lists inbound `[[...]]` references with snippet context.
- `--limit`, `--offset`, `--format json`.
- Shows the target's friendly label, source ref + title + collection icon, snippet, optional display-text override.

## Behavior decisions (per PLAN-1593)

| | |
|---|---|
| Code blocks | Excluded (fenced + inline) |
| Self-links | Filtered at query time, kept in storage |
| Repeated mentions | Separate rows by position, dedupe at display |
| Broken refs | Persisted with `target_item_id = NULL` |
| Cross-collection move | Number-only fallback in resolver (mirrors `GetItemByRef`) |
| Display order | Source `updated_at DESC`, position `ASC` for tie-break |

## Tests

Parser (`internal/links/extract_test.go`): 26 sub-cases — ref/title/workspace-ref discrimination, code-block exclusion (fenced + inline + unclosed fence + content-starts-with-fence + inline-adjacent), position-is-byte-offset (UTF-8 safety), edge inputs (empty brackets, nested, lowercase ref, missing number, newline body).

Store (`internal/store/wiki_links_test.go`): 8 integration tests — create indexes refs, update replaces index, soft-delete cascades visibility, self-link hidden, broken-ref persisted, repeated mention stores multiple rows, code-block excluded end-to-end, backfill idempotent.

`make check` clean (lint + full go test + web build).

## Tasks

- TASK-1594 (this PR) — Phase 1: ref-based reverse index, server-side
- TASK-1595 (next) — Phase 2: title + cross-workspace handling
- TASK-1596 (next) — Phase 3: web UI panel + badge + MCP

Refs: PLAN-1593, IDEA-1577

## Test plan

- [x] `make check` clean (lint + tests + web build)
- [x] Parser unit tests
- [x] Store integration tests (CreateItem indexes, UpdateItem re-indexes, soft-delete hides, self-link filtered, broken-ref persisted, repeated mentions, code-block excluded, backfill idempotent)
- [ ] Post-merge: smoke-test `pad item backlinks PLAN-1571` against the live workspace — should surface BUG-1584 + others
- [ ] Post-merge: verify the startup log emits a `Wiki-link backfill complete` entry once on first boot, then no-ops