### PR TITLE
feat(backlinks): cross-workspace wiki-links + request-independent ACL (Phase 2b)

### DIFF
--- a/internal/links/extract.go
+++ b/internal/links/extract.go
@@ -462,14 +462,13 @@ func isInRanges(pos int, ranges [][2]int) bool {
 // any fenced or inline code region, parses each into a WikiLinkRef,
 // and returns them in source order.
 //
-// Phase 2a of PLAN-1593 (TASK-1595): emits ref-form (`[[REF-N]]`)
-// AND title-form (`[[Title]]`, `[[collection/Title]]`) links.
-// Cross-workspace `[[workspace::REF]]` links are recognized by
-// parseBody but still gated out — TASK-1597 (Phase 2b) lifts that
-// last gate once the request-independent per-workspace ACL helper
-// lands. The two-step rollout is deliberate: cross-ws backlinks
-// need visibility plumbing that doesn't exist yet, so emitting the
-// rows now would leak indexed-but-unqueryable data.
+// Phase 2b of PLAN-1593 (TASK-1597): emits all three kinds — ref
+// (`[[REF-N]]`), title (`[[Title]]` / `[[collection/Title]]`), AND
+// workspace_ref (`[[workspace::REF]]` / `[[workspace::REF|Display]]`).
+// The request-independent ACL helper (Store.ResolveBacklinksVisibility)
+// that TASK-1597 also adds lets the cross-workspace inbound query
+// honor per-source-workspace visibility correctly, so emitting these
+// rows is now safe.
 //
 // Returns an empty slice on empty input. Never returns an error —
 // any bracket sequence that fails to parse is silently skipped
@@ -496,16 +495,12 @@ func ExtractWikiLinks(content string) []WikiLinkRef {
 			continue
 		}
 		ref.Position = linkStart
-		// Phase 2a (TASK-1595): emit ref AND title kinds. The
-		// workspace_ref gate stays until TASK-1597 ships the
-		// per-workspace ACL helper — without it the cross-ws
-		// inbound query can't honor source-workspace visibility,
-		// and emitting rows we can't safely query just bloats
-		// the index. parseBody still RECOGNIZES the kind so
-		// removing the gate in Phase 2b is a one-line change.
-		if ref.Kind == WikiLinkKindWorkspaceRef {
-			continue
-		}
+		// Phase 2b (TASK-1597): all three kinds emit. The
+		// workspace_ref gate is lifted now that the cross-workspace
+		// query path (Store.GetCrossWorkspaceBacklinks) and the
+		// request-independent ACL helper
+		// (Store.ResolveBacklinksVisibility) are in place to honor
+		// per-source-workspace visibility correctly.
 		out = append(out, *ref)
 	}
 	return out

--- a/internal/links/extract.go
+++ b/internal/links/extract.go
@@ -661,6 +661,14 @@ func unescapeWikiBody(s string) string {
 // untouched (refPattern would have rejected them anyway; callers
 // invariantly hold to "matches refPattern" before calling).
 func canonicalizeRef(ref string) string {
+	return CanonicalizeRef(ref)
+}
+
+// CanonicalizeRef is the exported alias for canonicalizeRef so the
+// store layer's same-workspace workspace_ref normalization (Codex
+// round 4 P2 of TASK-1597) can use the same canonicalization without
+// reimplementing the prefix-uppercase logic.
+func CanonicalizeRef(ref string) string {
 	dash := strings.LastIndexByte(ref, '-')
 	if dash < 0 {
 		return strings.ToUpper(ref)

--- a/internal/links/extract_test.go
+++ b/internal/links/extract_test.go
@@ -180,26 +180,73 @@ func TestExtractWikiLinks_TitlePreservesWhitespace(t *testing.T) {
 	})
 }
 
-// TestExtractWikiLinks_WorkspaceRefStillHidden documents that Phase 2a
-// continues to gate workspace_ref kinds. TASK-1597 lifts this gate
-// once the request-independent ACL helper lands — until then,
-// emitting these rows would create indexed-but-unqueryable data
-// (the cross-ws inbound query can't honor source-workspace
-// visibility yet).
-func TestExtractWikiLinks_WorkspaceRefStillHidden(t *testing.T) {
-	cases := []string{
-		"Cross [[other-ws::TASK-9]] over.",
-		"Cross [[other-ws::TASK-9|over]] too.",
-	}
-	for _, c := range cases {
-		t.Run(c, func(t *testing.T) {
-			got := ExtractWikiLinks(c)
-			if len(got) != 0 {
-				t.Errorf("expected 0 (Phase 2a still gates workspace_ref), got %d: %+v",
-					len(got), got)
-			}
-		})
-	}
+// TestExtractWikiLinks_WorkspaceRefForms covers Phase 2b emission
+// (TASK-1597). The gate that suppressed workspace_ref kinds in Phase
+// 2a is lifted now that the cross-workspace query path and request-
+// independent ACL helper are in place. Each `[[ws::REF]]` body
+// produces a WikiLinkKindWorkspaceRef row with the parsed workspace
+// slug + ref.
+func TestExtractWikiLinks_WorkspaceRefForms(t *testing.T) {
+	t.Run("bare workspace ref", func(t *testing.T) {
+		got := ExtractWikiLinks("Cross [[other-ws::TASK-9]] over.")
+		if len(got) != 1 {
+			t.Fatalf("expected 1 link, got %d", len(got))
+		}
+		if got[0].Kind != WikiLinkKindWorkspaceRef {
+			t.Errorf("Kind: got %q, want workspace_ref", got[0].Kind)
+		}
+		if got[0].WorkspaceSlug != "other-ws" {
+			t.Errorf("WorkspaceSlug: got %q, want %q", got[0].WorkspaceSlug, "other-ws")
+		}
+		if got[0].Ref != "TASK-9" {
+			t.Errorf("Ref: got %q, want TASK-9", got[0].Ref)
+		}
+	})
+
+	t.Run("workspace ref with display alias", func(t *testing.T) {
+		got := ExtractWikiLinks("Cross [[other-ws::TASK-9|see this]] too.")
+		if len(got) != 1 {
+			t.Fatalf("expected 1 link, got %d", len(got))
+		}
+		if got[0].Kind != WikiLinkKindWorkspaceRef {
+			t.Errorf("Kind: got %q, want workspace_ref", got[0].Kind)
+		}
+		if got[0].Display != "see this" || !got[0].HasDisplay {
+			t.Errorf("Display: got %q (has=%v), want %q (true)",
+				got[0].Display, got[0].HasDisplay, "see this")
+		}
+	})
+
+	t.Run("mixed-case ref canonicalized in workspace_ref kind", func(t *testing.T) {
+		// parseBody validates the ref segment against refPattern
+		// case-insensitively but does NOT canonicalize for the
+		// workspace_ref kind — the cross-ws resolver compares against
+		// the foreign workspace's own canonical prefix at query time.
+		// What we store IS the verbatim ref the user wrote; matching
+		// happens via LOWER() at lookup. Document this so a future
+		// reviewer doesn't try to "fix" it.
+		got := ExtractWikiLinks("[[other-ws::task-9]]")
+		if len(got) != 1 || got[0].Kind != WikiLinkKindWorkspaceRef {
+			t.Fatalf("expected workspace_ref kind, got %+v", got)
+		}
+		// Verbatim preserved (lowercase here).
+		if got[0].Ref != "task-9" {
+			t.Errorf("Ref: got %q, want task-9 (verbatim)", got[0].Ref)
+		}
+	})
+
+	t.Run("invalid workspace slug falls through to title", func(t *testing.T) {
+		// `INVALID-SLUG::TASK-1` — uppercase slug doesn't match the
+		// workspace slug pattern. parseBody falls through to title
+		// kind, body stored verbatim.
+		got := ExtractWikiLinks("[[INVALID::TASK-1]]")
+		if len(got) != 1 || got[0].Kind != WikiLinkKindTitle {
+			t.Fatalf("expected title fallback for invalid slug, got %+v", got)
+		}
+		if got[0].Title != "INVALID::TASK-1" {
+			t.Errorf("Title: got %q, want %q", got[0].Title, "INVALID::TASK-1")
+		}
+	})
 }
 
 // TestExtractWikiLinks_TitleCodeBlockExclusion ensures Phase 2a

--- a/internal/models/backlink.go
+++ b/internal/models/backlink.go
@@ -48,4 +48,15 @@ type Backlink struct {
 	// Used for relative timestamps ("3h ago"); the list is
 	// already ordered most-recent first.
 	UpdatedAt string `json:"updated_at"`
+
+	// SourceWorkspaceSlug is set ONLY for cross-workspace backlinks
+	// (rows produced by Store.GetCrossWorkspaceBacklinks where the
+	// source item lives in a different workspace than the queried
+	// target). Empty / omitted for same-workspace backlinks so the
+	// existing wire shape is unchanged.
+	//
+	// Renderers use this to route the source link to the correct
+	// workspace's URL prefix and to display a workspace badge next
+	// to the backlink. PLAN-1593 / TASK-1597.
+	SourceWorkspaceSlug string `json:"source_workspace_slug,omitempty"`
 }

--- a/internal/server/handlers_backlinks.go
+++ b/internal/server/handlers_backlinks.go
@@ -67,6 +67,16 @@ func (s *Server) handleGetItemBacklinks(w http.ResponseWriter, r *http.Request) 
 			limit = n
 		}
 	}
+	// Normalize at the handler boundary so the same-ws/cross-ws
+	// split math agrees with the store layer's internal clamping.
+	// Without this, `?limit=301` would let the handler compute
+	// `remaining = 301 - len(sameWs)` while the store fetched only
+	// 50 same-ws rows — same-ws tier exhausted at row 50 but the
+	// handler thinks it has 251 same-ws slots left, so the cross-
+	// ws slice starts incorrectly. Codex round 3 P2.
+	if limit > 300 {
+		limit = 300
+	}
 	offset := 0
 	if v := r.URL.Query().Get("offset"); v != "" {
 		if n, err := strconv.Atoi(v); err == nil && n >= 0 {

--- a/internal/server/handlers_backlinks.go
+++ b/internal/server/handlers_backlinks.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/PerpetualSoftware/pad/internal/models"
 	"github.com/PerpetualSoftware/pad/internal/store"
 	"github.com/go-chi/chi/v5"
 )
@@ -88,16 +89,75 @@ func (s *Server) handleGetItemBacklinks(w http.ResponseWriter, r *http.Request) 
 		vis.GrantedItemIDs = grantedItemIDs
 	}
 
-	backlinks, err := s.store.GetBacklinks(item.ID, workspaceID, limit, offset, vis)
+	// Union pagination across same-ws + cross-ws tiers.
+	//
+	// Tier order: same-workspace first, then cross-workspace —
+	// matches the renderer's UI mental model (your own workspace's
+	// backlinks at the top of the panel, foreign workspaces below).
+	// Within each tier, ordering is updated_at DESC.
+	//
+	// Pagination strategy: count same-ws results so the handler
+	// knows where the cross-ws tier begins. Splits the requested
+	// (limit, offset) window into a same-ws slice and a cross-ws
+	// slice. Computing the count up-front lets pages 2+ correctly
+	// land in the cross-ws tier when same-ws is exhausted.
+	sameCount, err := s.store.CountBacklinks(item.ID, workspaceID, vis)
 	if err != nil {
 		writeInternalError(w, err)
 		return
 	}
-	if backlinks == nil {
+
+	var sameWs []models.Backlink
+	var crossWs []models.Backlink
+
+	// Same-ws slice: offset/limit relative to the same-ws tier.
+	if offset < sameCount {
+		sameLimit := limit
+		if offset+sameLimit > sameCount {
+			sameLimit = sameCount - offset
+		}
+		if sameLimit > 0 {
+			sameWs, err = s.store.GetBacklinks(item.ID, workspaceID, sameLimit, offset, vis)
+			if err != nil {
+				writeInternalError(w, err)
+				return
+			}
+		}
+	}
+
+	// Cross-ws slice: only fetched when there's room left in the
+	// page after same-ws fills (or when offset already exceeded
+	// same-ws). Cross-ws target ref needs the canonical
+	// PREFIX-NUMBER shape derived from the target item.
+	remaining := limit - len(sameWs)
+	if remaining > 0 && item.CollectionPrefix != "" && item.ItemNumber != nil {
+		// crossOffset is the offset INTO the cross-ws tier — zero
+		// when same-ws filled some of the current page, or
+		// (offset - sameCount) when the offset already passed the
+		// same-ws tier entirely.
+		crossOffset := 0
+		if offset > sameCount {
+			crossOffset = offset - sameCount
+		}
+		targetRef := item.CollectionPrefix + "-" + strconv.Itoa(*item.ItemNumber)
+		// Use currentUser from the request — guaranteed non-nil
+		// here because the middleware required workspace access.
+		user := currentUser(r)
+		if user != nil {
+			crossWs, err = s.store.GetCrossWorkspaceBacklinks(workspaceID, targetRef, user.ID, remaining, crossOffset)
+			if err != nil {
+				writeInternalError(w, err)
+				return
+			}
+		}
+	}
+
+	combined := append(sameWs, crossWs...)
+	if combined == nil {
 		// Always emit a JSON array, never null — easier for
 		// clients to consume without special-casing.
 		writeJSON(w, http.StatusOK, []any{})
 		return
 	}
-	writeJSON(w, http.StatusOK, backlinks)
+	writeJSON(w, http.StatusOK, combined)
 }

--- a/internal/server/handlers_backlinks.go
+++ b/internal/server/handlers_backlinks.go
@@ -144,7 +144,16 @@ func (s *Server) handleGetItemBacklinks(w http.ResponseWriter, r *http.Request) 
 		// here because the middleware required workspace access.
 		user := currentUser(r)
 		if user != nil {
-			crossWs, err = s.store.GetCrossWorkspaceBacklinks(workspaceID, targetRef, user.ID, remaining, crossOffset)
+			// Propagate the OAuth/MCP token's workspace allow-list
+			// (TASK-952) into the cross-ws enumeration. nil → no
+			// token gate (PAT or pre-consent token, allow all
+			// enumerated workspaces); a slice gates each source
+			// workspace by slug. Without this, an MCP token
+			// consented for workspace A could leak backlinks from
+			// workspace B that the user has independent access to.
+			// Codex round 2 P1.
+			allowedSlugs := TokenAllowedWorkspacesFromContext(r.Context())
+			crossWs, err = s.store.GetCrossWorkspaceBacklinks(workspaceID, targetRef, user.ID, allowedSlugs, remaining, crossOffset)
 			if err != nil {
 				writeInternalError(w, err)
 				return

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1751,80 +1751,30 @@ func (s *Server) guestResourceFilterIncludeDeletedItems(r *http.Request, workspa
 	return s.guestResourceFilterCore(r, workspaceID, true)
 }
 
-// guestResourceFilterCore is the shared implementation. The
-// includeDeletedItems flag swaps the underlying store query.
+// guestResourceFilterCore is the request-scoped wrapper around
+// Store.ResolveBacklinksVisibility. Delegates the role-determination
+// + merge logic to the store helper so cross-workspace backlinks
+// callers can reuse the same code path without a request context
+// (PLAN-1593 / TASK-1597).
+//
+// The wrapper still exists for two reasons:
+//   - Admin bypass uses currentUser(r).Role rather than re-fetching
+//     the user (saves one DB roundtrip per request on the hot path).
+//   - The signature `(r *http.Request, workspaceID, includeDeleted) →
+//     (fullCollIDs, grantedItemIDs, err)` is established across many
+//     handlers — keeping it stable avoids a sprawling refactor.
+//
+// The includeDeletedItems flag swaps the underlying grant query.
 func (s *Server) guestResourceFilterCore(r *http.Request, workspaceID string, includeDeletedItems bool) (fullCollIDs, grantedItemIDs []string, err error) {
 	user := currentUser(r)
 	if user == nil || user.Role == "admin" {
 		return nil, nil, nil
 	}
-
-	role := workspaceRole(r)
-
-	// For workspace members with "all" collection access, item grants should
-	// not restrict their existing full visibility.
-	if role != "guest" {
-		member, err := s.store.GetWorkspaceMember(workspaceID, user.ID)
-		if err != nil {
-			return nil, nil, err
-		}
-		if member != nil && (member.CollectionAccess == "all" || member.CollectionAccess == "") {
-			return nil, nil, nil
-		}
-	}
-
-	// Get grant-based resources — delta-sync callers ask for the
-	// include-deleted variant so tombstones can flow through.
-	var grantCollIDs []string
-	if includeDeletedItems {
-		grantCollIDs, grantedItemIDs, err = s.store.GuestVisibleResourcesIncludeDeleted(workspaceID, user.ID)
-	} else {
-		grantCollIDs, grantedItemIDs, err = s.store.GuestVisibleResources(workspaceID, user.ID)
-	}
-	if err != nil {
-		return nil, nil, err
-	}
-
-	// For guests, grant resources are the only source of access
-	if role == "guest" {
-		return grantCollIDs, grantedItemIDs, nil
-	}
-
-	// For restricted members ("specific" access), merge their normal
-	// member_collection_access + system collections into fullCollIDs so
-	// item grants are additive, not a replacement. This is critical:
-	// without this merge, a member with access to collection A plus one
-	// item grant in collection B would lose collection A in cross-collection
-	// queries that use these IDs.
-	fullCollSet := make(map[string]bool)
-	for _, id := range grantCollIDs {
-		fullCollSet[id] = true
-	}
-
-	// Add member_collection_access collections
-	memberColls, err := s.store.GetMemberCollectionAccess(workspaceID, user.ID)
-	if err != nil {
-		return nil, nil, err
-	}
-	for _, id := range memberColls {
-		fullCollSet[id] = true
-	}
-
-	// Add system collections (always visible to members)
-	sysColls, err := s.store.ListSystemCollectionIDs(workspaceID)
-	if err != nil {
-		return nil, nil, err
-	}
-	for _, id := range sysColls {
-		fullCollSet[id] = true
-	}
-
-	fullCollIDs = make([]string, 0, len(fullCollSet))
-	for id := range fullCollSet {
-		fullCollIDs = append(fullCollIDs, id)
-	}
-
-	return fullCollIDs, grantedItemIDs, nil
+	// Delegate to the request-independent helper. The store-side
+	// helper duplicates the admin check via GetUser, but for the
+	// request hot path we short-circuit above so the duplicate
+	// lookup never fires.
+	return s.store.ResolveBacklinksVisibility(user.ID, workspaceID, includeDeletedItems)
 }
 
 // isCollectionVisible checks if a collection ID is in the visible set.

--- a/internal/store/backlinks_visibility.go
+++ b/internal/store/backlinks_visibility.go
@@ -1,0 +1,128 @@
+package store
+
+// ResolveBacklinksVisibility computes the (fullCollectionIDs,
+// grantedItemIDs) access vectors for `userID` in `workspaceID`,
+// REQUEST-INDEPENDENT. Mirrors the server's guestResourceFilterCore
+// (internal/server/server.go::guestResourceFilterCore) but determines
+// the user's effective workspace role from a fresh member+grant
+// lookup instead of reading it from the HTTP request context.
+//
+// This separation exists for the cross-workspace backlinks query
+// (PLAN-1593 / TASK-1597), which iterates over every workspace the
+// requesting user has access to and needs per-workspace visibility
+// for each — a request scope only knows the role for ONE workspace
+// (the URL's target), so the cross-ws traversal must compute the
+// rest itself.
+//
+// Decision tree (matches RequireWorkspaceAccess + guestResourceFilterCore):
+//
+//   - Admin user (`users.role = 'admin'`): unrestricted.
+//   - Workspace member with `collection_access = 'all'` or empty:
+//     unrestricted.
+//   - Workspace member with `collection_access = 'specific'`
+//     (restricted member): grant-based collections ∪ explicit
+//     member_collection_access ∪ system collections, plus any
+//     item grants additively.
+//   - Non-member with grants (guest): grant-based collections AND
+//     item grants only.
+//   - Non-member without grants: returns BOTH lists nil (empty
+//     visibility — caller's GetBacklinks short-circuits to "see
+//     nothing").
+//
+// Returns nil fullCollIDs and nil grantedItemIDs for the unrestricted
+// cases; caller should interpret using BacklinksVisibility semantics
+// (Unrestricted=true sets the no-filter shape).
+//
+// `includeDeletedItems` controls the grant query variant:
+//   - false → GuestVisibleResources (live items only). Cross-ws
+//     backlinks callers pass false.
+//   - true → GuestVisibleResourcesIncludeDeleted (tombstones included).
+//     The server delta-sync wrapper at guestResourceFilterIncludeDeletedItems
+//     passes true; cross-ws doesn't need it.
+//
+// The returned error mirrors the underlying store call (DB error
+// surfaces, "user not found" returns an empty result rather than
+// erroring so the cross-ws traversal can keep going).
+func (s *Store) ResolveBacklinksVisibility(userID, workspaceID string, includeDeletedItems bool) (fullCollIDs, grantedItemIDs []string, err error) {
+	// Admin bypass — same as server.guestResourceFilterCore line 1758.
+	user, err := s.GetUser(userID)
+	if err != nil {
+		return nil, nil, err
+	}
+	if user == nil {
+		// User vanished mid-query (or stale workspace membership row).
+		// Empty visibility — caller treats nil/nil/no-error as "see
+		// nothing" via BacklinksVisibility{Unrestricted:false} with
+		// both lists empty.
+		return nil, nil, nil
+	}
+	if user.Role == "admin" {
+		return nil, nil, nil
+	}
+
+	// Member lookup determines whether we treat this as a guest (no
+	// member row but has grants) or a member (with full or specific
+	// access).
+	member, err := s.GetWorkspaceMember(workspaceID, userID)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Full-access member — unrestricted, same as line 1771.
+	if member != nil && (member.CollectionAccess == "all" || member.CollectionAccess == "") {
+		return nil, nil, nil
+	}
+
+	// Resolve grant-based resources. `member == nil` here means
+	// guest; member != nil with specific access means restricted
+	// member — both fall through to grant lookups, then merge
+	// member-specific collections below if applicable.
+	var grantCollIDs []string
+	if includeDeletedItems {
+		grantCollIDs, grantedItemIDs, err = s.GuestVisibleResourcesIncludeDeleted(workspaceID, userID)
+	} else {
+		grantCollIDs, grantedItemIDs, err = s.GuestVisibleResources(workspaceID, userID)
+	}
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Guest branch: grant-only. (No member_collection_access merge
+	// because there's no member row to merge from.) Same as line 1789.
+	if member == nil {
+		// One more sanity check: if there are NO grants either,
+		// this user shouldn't be able to see anything. Returning
+		// empty lists is correct — GetBacklinks short-circuits.
+		// (UserHasGrantsInWorkspace would be redundant here since
+		// GuestVisibleResources already returns empty for non-grant
+		// users.)
+		return grantCollIDs, grantedItemIDs, nil
+	}
+
+	// Restricted member branch — merge grant collections with
+	// member_collection_access + system collections. Same as lines
+	// 1798-1825 of server.guestResourceFilterCore.
+	fullCollSet := make(map[string]bool)
+	for _, id := range grantCollIDs {
+		fullCollSet[id] = true
+	}
+	memberColls, err := s.GetMemberCollectionAccess(workspaceID, userID)
+	if err != nil {
+		return nil, nil, err
+	}
+	for _, id := range memberColls {
+		fullCollSet[id] = true
+	}
+	sysColls, err := s.ListSystemCollectionIDs(workspaceID)
+	if err != nil {
+		return nil, nil, err
+	}
+	for _, id := range sysColls {
+		fullCollSet[id] = true
+	}
+	fullCollIDs = make([]string, 0, len(fullCollSet))
+	for id := range fullCollSet {
+		fullCollIDs = append(fullCollIDs, id)
+	}
+	return fullCollIDs, grantedItemIDs, nil
+}

--- a/internal/store/wiki_links.go
+++ b/internal/store/wiki_links.go
@@ -1017,7 +1017,18 @@ func (s *Store) CountBacklinks(targetItemID, workspaceID string, vis BacklinksVi
 // resolver-route handling at markdown.ts:485 which forwards
 // ref-shapes verbatim to the server-side resolver, which is itself
 // case-insensitive).
-func (s *Store) GetCrossWorkspaceBacklinks(targetWorkspaceID, targetRef, requesterUserID string, limit, offset int) ([]models.Backlink, error) {
+//
+// `allowedWorkspaceSlugs` is the OAuth/MCP token's workspace allow-
+// list (TASK-952). A nil slice means "no token-level gate" (PAT or
+// pre-consent token, allow all enumerated workspaces). A slice
+// containing "*" is wildcard consent (allow all). Otherwise only
+// workspaces whose slug appears in the list contribute source rows
+// — preserves consent scope across the cross-ws boundary (Codex
+// round 2 P1 caught the prior bypass: an MCP token consented for
+// workspace A still leaked cross-ws backlinks from workspace B
+// because the cross-ws path enumerated via the user's full
+// workspace list).
+func (s *Store) GetCrossWorkspaceBacklinks(targetWorkspaceID, targetRef, requesterUserID string, allowedWorkspaceSlugs []string, limit, offset int) ([]models.Backlink, error) {
 	if limit <= 0 || limit > 300 {
 		limit = 50
 	}
@@ -1054,6 +1065,19 @@ func (s *Store) GetCrossWorkspaceBacklinks(targetWorkspaceID, targetRef, request
 		}
 	}
 
+	// Apply token allow-list filter. Pre-compute a small set for
+	// constant-time slug membership tests. nil allowlist == no
+	// gate (allow all); a list containing "*" is wildcard.
+	allowAll := allowedWorkspaceSlugs == nil
+	wildcard := false
+	allowSet := make(map[string]bool, len(allowedWorkspaceSlugs))
+	for _, slug := range allowedWorkspaceSlugs {
+		if slug == "*" {
+			wildcard = true
+		}
+		allowSet[slug] = true
+	}
+
 	// Per-workspace cap is offset+limit because, worst case, all
 	// matching rows come from a single workspace and the global
 	// paginate slice needs at least that many rows from that
@@ -1066,6 +1090,13 @@ func (s *Store) GetCrossWorkspaceBacklinks(targetWorkspaceID, targetRef, request
 	for _, ws := range workspaces {
 		if ws.ID == targetWorkspaceID {
 			// Same-ws backlinks are GetBacklinks's responsibility.
+			continue
+		}
+		// Token allow-list gate. PAT auth / no-token shapes pass
+		// allowAll=true. Wildcard ("*") consent passes wildcard=true.
+		// Otherwise the source workspace's slug must be explicitly
+		// allowed.
+		if !allowAll && !wildcard && !allowSet[ws.Slug] {
 			continue
 		}
 		fullCollIDs, grantedItemIDs, err := s.ResolveBacklinksVisibility(requesterUserID, ws.ID, false)

--- a/internal/store/wiki_links.go
+++ b/internal/store/wiki_links.go
@@ -3,6 +3,7 @@ package store
 import (
 	"database/sql"
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -62,6 +63,12 @@ func (s *Store) replaceWikiLinks(tx *sql.Tx, sourceItemID, workspaceID, content 
 	// caching by lowercase would also work but slightly mismatches
 	// the verbatim-storage contract that the rename hook relies on.
 	resolvedTitles := map[string]sql.NullString{}
+	// Per-call cache for workspace slug → ID lookups. A body that
+	// references the same foreign workspace multiple times
+	// (`[[claude::TASK-1]]`, `[[claude::TASK-2]]`) only hits the
+	// workspaces table once. Empty slug map is normal — most bodies
+	// don't contain cross-workspace refs.
+	resolvedWorkspaces := map[string]sql.NullString{}
 
 	for _, link := range extracted {
 		// HasDisplay (not Display != "") distinguishes "no pipe"
@@ -259,11 +266,42 @@ func (s *Store) replaceWikiLinks(tx *sql.Tx, sourceItemID, workspaceID, content 
 				return fmt.Errorf("insert wiki link (title): %w", err)
 			}
 
+		case links.WikiLinkKindWorkspaceRef:
+			// Phase 2b (TASK-1597). Resolve the workspace slug to a
+			// workspace ID; the ref is stored verbatim and resolution
+			// to a target_item_id is INTENTIONALLY deferred to query
+			// time (cross-workspace target resolution is the cross-ws
+			// inbound query's responsibility — see GetCrossWorkspaceBacklinks
+			// — because it has to honor the foreign workspace's ACLs
+			// per the requesting user, which write-time can't
+			// pre-compute).
+			//
+			// Unknown workspace slugs persist with target_workspace_id
+			// = NULL — broken-link semantics, identical to the way
+			// broken ref-form rows persist with target_item_id=NULL.
+			// The renderer's resolver-route fallback (`/-/r/<ws>/<ref>`
+			// at markdown.ts:485) returns 404 in that case; the index
+			// matches that behavior.
+			cachedWS, hit := resolvedWorkspaces[link.WorkspaceSlug]
+			if !hit {
+				cachedWS = resolveWorkspaceSlugTx(tx, s, link.WorkspaceSlug)
+				resolvedWorkspaces[link.WorkspaceSlug] = cachedWS
+			}
+			if _, err := tx.Exec(s.q(`
+				INSERT INTO item_wiki_links (
+					source_item_id, target_kind, target_workspace_id,
+					target_item_id, target_ref, target_title,
+					display_text, position
+				) VALUES (?, ?, ?, NULL, ?, NULL, ?, ?)
+			`), sourceItemID, string(links.WikiLinkKindWorkspaceRef),
+				cachedWS, link.Ref, displayText, link.Position); err != nil {
+				return fmt.Errorf("insert wiki link (workspace_ref): %w", err)
+			}
+
 		default:
-			// Phase 2a still skips workspace_ref kinds. The parser's
-			// gate prevents them from arriving here; this default
-			// branch is a safety net for the day TASK-1597 lifts
-			// the gate.
+			// All recognized kinds are handled above; this default
+			// branch catches any future kind added to the WikiLinkKind
+			// enum without a corresponding store branch.
 			continue
 		}
 	}
@@ -386,6 +424,31 @@ func resolveTitleTx(tx *sql.Tx, s *Store, workspaceID, title string) sql.NullStr
 		  AND LOWER(i.title) = LOWER(?)
 		LIMIT 1
 	`), workspaceID, collSlug, titleRest).Scan(&id)
+	if err != nil {
+		return sql.NullString{}
+	}
+	return sql.NullString{String: id, Valid: true}
+}
+
+// resolveWorkspaceSlugTx looks up `slug` against the workspaces
+// table and returns the workspace ID as a sql.NullString. Returns
+// a NULL when the slug doesn't match any live workspace — the same
+// broken-link persistence pattern resolveRefTx and resolveTitleTx
+// use (PLAN-1593's "broken refs persisted" decision).
+//
+// Deleted workspaces are excluded (deleted_at IS NULL) so a recently
+// deleted workspace's slug doesn't resolve to its stale ID. A real
+// DB error returns NULL so the write doesn't abort — same
+// conservative posture as the sister helpers.
+func resolveWorkspaceSlugTx(tx *sql.Tx, s *Store, slug string) sql.NullString {
+	if slug == "" {
+		return sql.NullString{}
+	}
+	var id string
+	err := tx.QueryRow(s.q(`
+		SELECT id FROM workspaces
+		WHERE slug = ? AND deleted_at IS NULL
+	`), slug).Scan(&id)
 	if err != nil {
 		return sql.NullString{}
 	}
@@ -864,6 +927,255 @@ func (s *Store) GetBacklinks(targetItemID, workspaceID string, limit, offset int
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("iterate backlinks: %w", err)
+	}
+	return out, nil
+}
+
+// CountBacklinks returns the total number of same-workspace
+// backlinks the requester would see for a given target, applying
+// the same visibility filter as GetBacklinks. Used by the backlinks
+// handler to correctly compute pagination offsets across the
+// same-ws / cross-ws union — without a count, paginating past the
+// first page can't know where the cross-ws "tier" of results
+// begins.
+//
+// Same predicate shape as GetBacklinks but with SELECT COUNT(*)
+// instead of the row projection. PLAN-1593 / TASK-1597.
+func (s *Store) CountBacklinks(targetItemID, workspaceID string, vis BacklinksVisibility) (int, error) {
+	if !vis.Unrestricted && len(vis.FullCollectionIDs) == 0 && len(vis.GrantedItemIDs) == 0 {
+		return 0, nil
+	}
+	visClause := ""
+	args := []interface{}{targetItemID, workspaceID, targetItemID}
+	if !vis.Unrestricted {
+		collClause := "FALSE"
+		if len(vis.FullCollectionIDs) > 0 {
+			placeholders := make([]string, len(vis.FullCollectionIDs))
+			for i, cid := range vis.FullCollectionIDs {
+				placeholders[i] = "?"
+				args = append(args, cid)
+			}
+			collClause = "s.collection_id IN (" + strings.Join(placeholders, ",") + ")"
+		}
+		itemClause := "FALSE"
+		if len(vis.GrantedItemIDs) > 0 {
+			placeholders := make([]string, len(vis.GrantedItemIDs))
+			for i, iid := range vis.GrantedItemIDs {
+				placeholders[i] = "?"
+				args = append(args, iid)
+			}
+			itemClause = "s.id IN (" + strings.Join(placeholders, ",") + ")"
+		}
+		visClause = " AND (" + collClause + " OR " + itemClause + ")"
+	}
+	var n int
+	err := s.db.QueryRow(s.q(`
+		SELECT COUNT(*)
+		FROM item_wiki_links wl
+		JOIN items s       ON s.id = wl.source_item_id
+		JOIN collections c ON c.id = s.collection_id
+		WHERE wl.target_item_id = ?
+		  AND s.workspace_id = ?
+		  AND s.deleted_at IS NULL
+		  AND s.id != ?`+visClause+`
+	`), args...).Scan(&n)
+	if err != nil {
+		return 0, fmt.Errorf("count backlinks: %w", err)
+	}
+	return n, nil
+}
+
+// GetCrossWorkspaceBacklinks returns inbound `[[ws::REF]]` backlinks
+// pointing at the queried target (`targetWorkspaceID`, `targetRef`)
+// from EVERY OTHER workspace the requester has access to. Same-ws
+// backlinks are GetBacklinks's responsibility — this method only
+// surfaces the cross-workspace tier.
+//
+// PLAN-1593 / TASK-1597. The approach:
+//
+//  1. Enumerate workspaces the requester can see via
+//     Store.GetUserWorkspaces (which already unions members +
+//     grant-only guest workspaces — Codex round of the planning
+//     phase identified this as broader than a membership query).
+//  2. For each non-target workspace, compute per-workspace
+//     visibility via Store.ResolveBacklinksVisibility (the request-
+//     independent ACL helper — required because cross-ws traversal
+//     can't read workspaceRole from a request scope).
+//  3. Query that workspace's source rows with the per-ws visibility
+//     predicate inline. Empty-visibility workspaces short-circuit.
+//  4. Merge, sort by updated_at DESC, paginate.
+//
+// Pagination shape: sort in Go after collecting all matching rows.
+// Cross-workspace backlinks are typically sparse (most items don't
+// have cross-ws inbound links), so in-memory sort over a few
+// hundred rows beats UNION ALL's verbosity. If profiling shows
+// per-workspace queries dominating, the trivial optimization is a
+// per-workspace LIMIT (offset+limit) as a safety cap — already
+// applied below.
+//
+// `targetRef` matches case-insensitively (mirrors the renderer's
+// resolver-route handling at markdown.ts:485 which forwards
+// ref-shapes verbatim to the server-side resolver, which is itself
+// case-insensitive).
+func (s *Store) GetCrossWorkspaceBacklinks(targetWorkspaceID, targetRef, requesterUserID string, limit, offset int) ([]models.Backlink, error) {
+	if limit <= 0 || limit > 300 {
+		limit = 50
+	}
+	if offset < 0 {
+		offset = 0
+	}
+
+	workspaces, err := s.GetUserWorkspaces(requesterUserID)
+	if err != nil {
+		return nil, fmt.Errorf("enumerate accessible workspaces: %w", err)
+	}
+
+	// Per-workspace safety cap. A single workspace can't return more
+	// than `offset+limit` rows because anything beyond that would be
+	// trimmed by the final paginate slice anyway. Saves transferring
+	// rows we'd discard.
+	perWsCap := offset + limit
+	if perWsCap > 1000 {
+		perWsCap = 1000 // hard ceiling — defensive
+	}
+
+	var collected []models.Backlink
+	for _, ws := range workspaces {
+		if ws.ID == targetWorkspaceID {
+			// Same-ws backlinks are GetBacklinks's responsibility.
+			continue
+		}
+		fullCollIDs, grantedItemIDs, err := s.ResolveBacklinksVisibility(requesterUserID, ws.ID, false)
+		if err != nil {
+			return nil, fmt.Errorf("resolve visibility for workspace %s: %w", ws.ID, err)
+		}
+		// Unrestricted iff both lists nil (admin user or full-access
+		// member). When restricted with no resources, skip this
+		// workspace entirely — no rows could be visible.
+		unrestricted := fullCollIDs == nil && grantedItemIDs == nil
+		if !unrestricted && len(fullCollIDs) == 0 && len(grantedItemIDs) == 0 {
+			continue
+		}
+		rows, err := s.queryCrossWorkspaceBacklinksForWorkspace(
+			targetWorkspaceID, targetRef, ws, unrestricted,
+			fullCollIDs, grantedItemIDs, perWsCap,
+		)
+		if err != nil {
+			return nil, err
+		}
+		collected = append(collected, rows...)
+	}
+
+	// Sort by updated_at descending; tiebreak by source ID for
+	// deterministic ordering when timestamps collide (same-second
+	// writes).
+	sort.Slice(collected, func(i, j int) bool {
+		if collected[i].UpdatedAt != collected[j].UpdatedAt {
+			return collected[i].UpdatedAt > collected[j].UpdatedAt
+		}
+		return collected[i].SourceItemID < collected[j].SourceItemID
+	})
+
+	// Paginate.
+	if offset >= len(collected) {
+		return nil, nil
+	}
+	end := offset + limit
+	if end > len(collected) {
+		end = len(collected)
+	}
+	return collected[offset:end], nil
+}
+
+// queryCrossWorkspaceBacklinksForWorkspace fetches up to `cap` rows
+// from a single source workspace whose item_wiki_links point at the
+// target via target_workspace_id + target_ref. The visibility
+// predicate is the same shape as GetBacklinks's — collection_id IN
+// (...) OR id IN (...) — with the unrestricted variant skipping the
+// predicate.
+//
+// Each returned Backlink has SourceWorkspaceSlug populated so the
+// caller can route the link to the correct workspace prefix.
+func (s *Store) queryCrossWorkspaceBacklinksForWorkspace(
+	targetWorkspaceID, targetRef string,
+	sourceWs models.Workspace,
+	unrestricted bool, fullCollIDs, grantedItemIDs []string,
+	cap int,
+) ([]models.Backlink, error) {
+	// Build the visibility predicate same as GetBacklinks.
+	visClause := ""
+	args := []interface{}{targetWorkspaceID, targetRef, sourceWs.ID}
+	if !unrestricted {
+		collClause := "FALSE"
+		if len(fullCollIDs) > 0 {
+			placeholders := make([]string, len(fullCollIDs))
+			for i, cid := range fullCollIDs {
+				placeholders[i] = "?"
+				args = append(args, cid)
+			}
+			collClause = "s.collection_id IN (" + strings.Join(placeholders, ",") + ")"
+		}
+		itemClause := "FALSE"
+		if len(grantedItemIDs) > 0 {
+			placeholders := make([]string, len(grantedItemIDs))
+			for i, iid := range grantedItemIDs {
+				placeholders[i] = "?"
+				args = append(args, iid)
+			}
+			itemClause = "s.id IN (" + strings.Join(placeholders, ",") + ")"
+		}
+		visClause = " AND (" + collClause + " OR " + itemClause + ")"
+	}
+	args = append(args, cap)
+
+	rows, err := s.db.Query(s.q(`
+		SELECT s.id, c.prefix, s.item_number, s.title, c.slug, c.icon,
+		       s.content, wl.position, wl.display_text, s.updated_at
+		FROM item_wiki_links wl
+		JOIN items s       ON s.id = wl.source_item_id
+		JOIN collections c ON c.id = s.collection_id
+		WHERE wl.target_kind = 'workspace_ref'
+		  AND wl.target_workspace_id = ?
+		  AND LOWER(wl.target_ref) = LOWER(?)
+		  AND s.workspace_id = ?
+		  AND s.deleted_at IS NULL`+visClause+`
+		ORDER BY s.updated_at DESC, wl.position ASC
+		LIMIT ?
+	`), args...)
+	if err != nil {
+		return nil, fmt.Errorf("query cross-ws backlinks (workspace %s): %w", sourceWs.ID, err)
+	}
+	defer rows.Close()
+
+	var out []models.Backlink
+	for rows.Next() {
+		var (
+			sourceID, prefix, title, collSlug, collIcon, content, updatedAt string
+			itemNumber                                                      int
+			position                                                        int
+			displayText                                                     sql.NullString
+		)
+		if err := rows.Scan(&sourceID, &prefix, &itemNumber, &title, &collSlug, &collIcon, &content, &position, &displayText, &updatedAt); err != nil {
+			return nil, fmt.Errorf("scan cross-ws backlink row: %w", err)
+		}
+		bl := models.Backlink{
+			SourceItemID:         sourceID,
+			SourceRef:            formatRef(prefix, itemNumber),
+			SourceTitle:          title,
+			SourceCollectionSlug: collSlug,
+			SourceCollectionIcon: collIcon,
+			Snippet:              snippetAround(content, position),
+			UpdatedAt:            updatedAt,
+			SourceWorkspaceSlug:  sourceWs.Slug,
+		}
+		if displayText.Valid {
+			ds := displayText.String
+			bl.DisplayText = &ds
+		}
+		out = append(out, bl)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate cross-ws backlinks: %w", err)
 	}
 	return out, nil
 }

--- a/internal/store/wiki_links.go
+++ b/internal/store/wiki_links.go
@@ -80,13 +80,22 @@ func (s *Store) replaceWikiLinks(tx *sql.Tx, sourceItemID, workspaceID, content 
 			displayText = sql.NullString{String: link.Display, Valid: true}
 		}
 
-		// Normalize same-workspace fully-qualified refs to ref-kind.
-		// The renderer's L307 short-circuits `[[<this-slug>::REF]]`
-		// to behave identically to `[[REF]]`, so the index must too —
-		// otherwise the link renders + navigates but no backlink
-		// surfaces (the cross-ws path skips the target workspace
-		// and the same-ws path requires target_item_id which
-		// workspace_ref rows leave NULL). Codex round 4 P2.
+		// Same-workspace fully-qualified refs: `[[<this-slug>::REF]]`.
+		// The renderer's L472-481 short-circuit:
+		//   - Same-workspace qualified form is treated like `[[REF]]`
+		//     for the REF LOOKUP step.
+		//   - BUT on ref miss, the renderer leaves the wiki-link
+		//     verbatim (broken) — it does NOT fall through to title
+		//     lookup like a bare `[[REF]]` would (L513).
+		//
+		// So we handle these inline as ref-kind rows WITHOUT the
+		// title-fallback path: resolved → ref row, unresolved →
+		// broken ref row. Skipping the switch ensures we never
+		// reach the WikiLinkKindRef branch's title-fallback logic.
+		// Codex round 5 P2 caught the round-4 normalization being
+		// over-aggressive — it promoted to Kind=Ref and let title
+		// fallback create ghost backlinks the renderer wouldn't
+		// produce.
 		if link.Kind == links.WikiLinkKindWorkspaceRef {
 			cachedWS, hit := resolvedWorkspaces[link.WorkspaceSlug]
 			if !hit {
@@ -94,14 +103,33 @@ func (s *Store) replaceWikiLinks(tx *sql.Tx, sourceItemID, workspaceID, content 
 				resolvedWorkspaces[link.WorkspaceSlug] = cachedWS
 			}
 			if cachedWS.Valid && cachedWS.String == workspaceID {
-				// Promote to ref-kind. links.CanonicalizeRef
-				// handles case-folding (`task-5` → `TASK-5`) so
-				// the row has the same canonical shape as plain
-				// `[[TASK-5]]`.
-				link.Kind = links.WikiLinkKindRef
-				link.Ref = links.CanonicalizeRef(link.Ref)
-				link.RawKey = link.Ref
-				link.WorkspaceSlug = ""
+				canonicalRef := links.CanonicalizeRef(link.Ref)
+				prefix, number, ok := splitRef(canonicalRef)
+				if !ok {
+					// parseBody vetted the shape — defensive skip.
+					continue
+				}
+				key := refKey{prefix: prefix, number: number}
+				targetID, cached := resolved[key]
+				if !cached {
+					targetID = resolveRefTx(tx, s, workspaceID, prefix, number)
+					resolved[key] = targetID
+				}
+				// Insert as ref-kind row. NO title fallback here —
+				// the renderer's same-ws qualified path doesn't
+				// have one, so we mirror that (a row with
+				// target_item_id=NULL persists as a broken ref).
+				if _, err := tx.Exec(s.q(`
+					INSERT INTO item_wiki_links (
+						source_item_id, target_kind, target_workspace_id,
+						target_item_id, target_ref, target_title,
+						display_text, position
+					) VALUES (?, ?, NULL, ?, ?, NULL, ?, ?)
+				`), sourceItemID, string(links.WikiLinkKindRef),
+					targetID, canonicalRef, displayText, link.Position); err != nil {
+					return fmt.Errorf("insert wiki link (same-ws qualified ref): %w", err)
+				}
+				continue
 			}
 		}
 

--- a/internal/store/wiki_links.go
+++ b/internal/store/wiki_links.go
@@ -1025,19 +1025,42 @@ func (s *Store) GetCrossWorkspaceBacklinks(targetWorkspaceID, targetRef, request
 		offset = 0
 	}
 
-	workspaces, err := s.GetUserWorkspaces(requesterUserID)
+	// Workspace enumeration depends on the requester's user role.
+	// Admins have implicit access to every non-deleted workspace
+	// (matches RequireWorkspaceAccess line 481), so for them we
+	// list everything; non-admins use GetUserWorkspaces which
+	// unions memberships + grant-only guest workspaces. Codex
+	// round 1 P2 caught the prior membership-only path silently
+	// hiding cross-ws backlinks from admin users.
+	user, err := s.GetUser(requesterUserID)
 	if err != nil {
-		return nil, fmt.Errorf("enumerate accessible workspaces: %w", err)
+		return nil, fmt.Errorf("lookup requester user: %w", err)
+	}
+	if user == nil {
+		// Stale user ID — return empty rather than err so the
+		// handler's UX surface stays usable.
+		return nil, nil
+	}
+	var workspaces []models.Workspace
+	if user.Role == "admin" {
+		workspaces, err = s.ListWorkspaces()
+		if err != nil {
+			return nil, fmt.Errorf("admin enumerate workspaces: %w", err)
+		}
+	} else {
+		workspaces, err = s.GetUserWorkspaces(requesterUserID)
+		if err != nil {
+			return nil, fmt.Errorf("enumerate accessible workspaces: %w", err)
+		}
 	}
 
-	// Per-workspace safety cap. A single workspace can't return more
-	// than `offset+limit` rows because anything beyond that would be
-	// trimmed by the final paginate slice anyway. Saves transferring
-	// rows we'd discard.
+	// Per-workspace cap is offset+limit because, worst case, all
+	// matching rows come from a single workspace and the global
+	// paginate slice needs at least that many rows from that
+	// workspace. Codex round 1 P2 caught the prior 1000-row
+	// ceiling silently breaking pagination beyond offset>=1000;
+	// the slice math is what bounds the result, not this cap.
 	perWsCap := offset + limit
-	if perWsCap > 1000 {
-		perWsCap = 1000 // hard ceiling — defensive
-	}
 
 	var collected []models.Backlink
 	for _, ws := range workspaces {
@@ -1094,6 +1117,15 @@ func (s *Store) GetCrossWorkspaceBacklinks(targetWorkspaceID, targetRef, request
 // (...) OR id IN (...) — with the unrestricted variant skipping the
 // predicate.
 //
+// Ref matching is dual: the exact `target_ref` AND a number-only
+// LIKE fallback. The fallback mirrors resolveRefTx's cross-prefix-
+// move logic — `[[other-ws::OLD-42]]` written before the target
+// moved from OLD to NEW collection still resolves in the renderer
+// via item_number, so the cross-ws index query must too. The LIKE
+// pattern `%-<N>` matches any prefix-N ref because Pad prefixes are
+// alphanumeric (no internal `-`), so trailing `-N` uniquely
+// identifies the suffix. Codex round 1 P2.
+//
 // Each returned Backlink has SourceWorkspaceSlug populated so the
 // caller can route the link to the correct workspace prefix.
 func (s *Store) queryCrossWorkspaceBacklinksForWorkspace(
@@ -1102,9 +1134,26 @@ func (s *Store) queryCrossWorkspaceBacklinksForWorkspace(
 	unrestricted bool, fullCollIDs, grantedItemIDs []string,
 	cap int,
 ) ([]models.Backlink, error) {
+	// Derive the number-only LIKE pattern. If targetRef doesn't have
+	// a `-N` suffix (defensive — shouldn't happen for canonical
+	// PREFIX-N inputs), fall back to exact-only matching.
+	likeFallback := ""
+	if dash := strings.LastIndexByte(targetRef, '-'); dash > 0 && dash < len(targetRef)-1 {
+		likeFallback = "%-" + targetRef[dash+1:]
+	}
+
+	refClause := "LOWER(wl.target_ref) = LOWER(?)"
+	args := []interface{}{targetWorkspaceID}
+	if likeFallback != "" {
+		refClause = "(LOWER(wl.target_ref) = LOWER(?) OR LOWER(wl.target_ref) LIKE LOWER(?))"
+		args = append(args, targetRef, likeFallback)
+	} else {
+		args = append(args, targetRef)
+	}
+	args = append(args, sourceWs.ID)
+
 	// Build the visibility predicate same as GetBacklinks.
 	visClause := ""
-	args := []interface{}{targetWorkspaceID, targetRef, sourceWs.ID}
 	if !unrestricted {
 		collClause := "FALSE"
 		if len(fullCollIDs) > 0 {
@@ -1136,7 +1185,7 @@ func (s *Store) queryCrossWorkspaceBacklinksForWorkspace(
 		JOIN collections c ON c.id = s.collection_id
 		WHERE wl.target_kind = 'workspace_ref'
 		  AND wl.target_workspace_id = ?
-		  AND LOWER(wl.target_ref) = LOWER(?)
+		  AND `+refClause+`
 		  AND s.workspace_id = ?
 		  AND s.deleted_at IS NULL`+visClause+`
 		ORDER BY s.updated_at DESC, wl.position ASC

--- a/internal/store/wiki_links.go
+++ b/internal/store/wiki_links.go
@@ -80,6 +80,31 @@ func (s *Store) replaceWikiLinks(tx *sql.Tx, sourceItemID, workspaceID, content 
 			displayText = sql.NullString{String: link.Display, Valid: true}
 		}
 
+		// Normalize same-workspace fully-qualified refs to ref-kind.
+		// The renderer's L307 short-circuits `[[<this-slug>::REF]]`
+		// to behave identically to `[[REF]]`, so the index must too —
+		// otherwise the link renders + navigates but no backlink
+		// surfaces (the cross-ws path skips the target workspace
+		// and the same-ws path requires target_item_id which
+		// workspace_ref rows leave NULL). Codex round 4 P2.
+		if link.Kind == links.WikiLinkKindWorkspaceRef {
+			cachedWS, hit := resolvedWorkspaces[link.WorkspaceSlug]
+			if !hit {
+				cachedWS = resolveWorkspaceSlugTx(tx, s, link.WorkspaceSlug)
+				resolvedWorkspaces[link.WorkspaceSlug] = cachedWS
+			}
+			if cachedWS.Valid && cachedWS.String == workspaceID {
+				// Promote to ref-kind. links.CanonicalizeRef
+				// handles case-folding (`task-5` → `TASK-5`) so
+				// the row has the same canonical shape as plain
+				// `[[TASK-5]]`.
+				link.Kind = links.WikiLinkKindRef
+				link.Ref = links.CanonicalizeRef(link.Ref)
+				link.RawKey = link.Ref
+				link.WorkspaceSlug = ""
+			}
+		}
+
 		switch link.Kind {
 		case links.WikiLinkKindRef:
 			prefix, number, ok := splitRef(link.Ref)

--- a/internal/store/wiki_links_xws_test.go
+++ b/internal/store/wiki_links_xws_test.go
@@ -281,6 +281,113 @@ func TestWikiLinks_CrossWorkspaceSourceWorkspaceSlugPopulated(t *testing.T) {
 	}
 }
 
+// TestWikiLinks_CrossWorkspaceAdminSeesAllWorkspaces regresses Codex
+// round 1 P2: admin users have implicit access to every workspace
+// (see middleware_auth.go:481), so the cross-ws enumeration must
+// use a global workspace list for admins instead of
+// GetUserWorkspaces (which returns only memberships + grant guests).
+// Without this fix, an admin querying for backlinks misses cross-ws
+// links from any workspace they're not explicitly a member of.
+func TestWikiLinks_CrossWorkspaceAdminSeesAllWorkspaces(t *testing.T) {
+	s := testStore(t)
+
+	owner := createTestUser(t, s, "owner@example.com", "Owner", "password123")
+	admin, err := s.CreateUser(models.UserCreate{
+		Email: "admin@example.com", Name: "Admin", Password: "password123",
+		Role: "admin",
+	})
+	if err != nil {
+		t.Fatalf("create admin: %v", err)
+	}
+
+	wsA := createTestWorkspace(t, s, "Workspace A")
+	wsB := createTestWorkspace(t, s, "Workspace B")
+	for _, ws := range []*models.Workspace{wsA, wsB} {
+		if err := s.AddWorkspaceMember(ws.ID, owner.ID, "owner"); err != nil {
+			t.Fatalf("owner→%s: %v", ws.Slug, err)
+		}
+	}
+	// Admin is NOT a member of either workspace; only their
+	// admin role grants access.
+	colA := createTestCollection(t, s, wsA.ID, "Tasks")
+	colB := createTestCollection(t, s, wsB.ID, "Notes")
+
+	target := createTestItem(t, s, wsA.ID, colA.ID, "Cross target", "")
+	targetRef := refOf(target)
+	createTestItem(t, s, wsB.ID, colB.ID, "Cross source",
+		"See [["+wsA.Slug+"::"+targetRef+"]].")
+
+	// Admin should see the cross-ws backlink via the global
+	// workspace enumeration path.
+	got, err := s.GetCrossWorkspaceBacklinks(wsA.ID, targetRef, admin.ID, 50, 0)
+	if err != nil {
+		t.Fatalf("GetCrossWorkspaceBacklinks (admin): %v", err)
+	}
+	if len(got) != 1 {
+		t.Errorf("admin should see cross-ws backlink (admins bypass membership), got %d", len(got))
+	}
+	if len(got) > 0 && got[0].SourceWorkspaceSlug != wsB.Slug {
+		t.Errorf("admin row missing SourceWorkspaceSlug: got %q", got[0].SourceWorkspaceSlug)
+	}
+}
+
+// TestWikiLinks_CrossWorkspaceRefNumberFallback regresses Codex round
+// 1 P2: when a target item is moved to a different collection (changing
+// its prefix), `[[other-ws::OLD-N]]` rows must still surface as
+// backlinks under the new prefix. Mirrors resolveRefTx's same-ws
+// fallback by item_number; cross-ws resolves at query time so the
+// query SQL has the OR-LIKE fallback inline.
+func TestWikiLinks_CrossWorkspaceRefNumberFallback(t *testing.T) {
+	s := testStore(t)
+	user := createTestUser(t, s, "alice@example.com", "Alice", "password123")
+
+	wsA := createTestWorkspace(t, s, "Workspace A")
+	wsB := createTestWorkspace(t, s, "Workspace B")
+	for _, ws := range []*models.Workspace{wsA, wsB} {
+		if err := s.AddWorkspaceMember(ws.ID, user.ID, "owner"); err != nil {
+			t.Fatalf("member %s: %v", ws.Slug, err)
+		}
+	}
+
+	// Target starts in collection OLD.
+	colOld := createTestCollection(t, s, wsA.ID, "OldColl")
+	colNew := createTestCollection(t, s, wsA.ID, "NewColl")
+
+	target := createTestItem(t, s, wsA.ID, colOld.ID, "Target", "")
+	if target.ItemNumber == nil {
+		t.Fatalf("target missing ItemNumber")
+	}
+	originalRef := target.CollectionPrefix + "-" + itoa(*target.ItemNumber)
+
+	// Source in workspace B writes the original-prefix ref.
+	colB := createTestCollection(t, s, wsB.ID, "SourceColl")
+	createTestItem(t, s, wsB.ID, colB.ID, "Source",
+		"See [["+wsA.Slug+"::"+originalRef+"]].")
+
+	// Move target to new collection — changes its prefix.
+	moved, err := s.MoveItem(target.ID, colNew.ID, "{}")
+	if err != nil {
+		t.Fatalf("MoveItem: %v", err)
+	}
+	if moved == nil || moved.ItemNumber == nil {
+		t.Fatalf("moved item missing ItemNumber")
+	}
+	newRef := moved.CollectionPrefix + "-" + itoa(*moved.ItemNumber)
+	if newRef == originalRef {
+		t.Fatalf("expected prefix change, both refs %q", newRef)
+	}
+
+	// Query under the NEW ref — the stored row has OLD ref, but
+	// item_number suffix matches so the fallback should hit.
+	got, err := s.GetCrossWorkspaceBacklinks(wsA.ID, newRef, user.ID, 50, 0)
+	if err != nil {
+		t.Fatalf("GetCrossWorkspaceBacklinks: %v", err)
+	}
+	if len(got) != 1 {
+		t.Errorf("expected number-fallback to surface old-prefix backlink, got %d", len(got))
+	}
+}
+
 // TestResolveBacklinksVisibility_RoleMatrix exercises the request-
 // independent ACL helper across the four caller-visible role
 // shapes: admin, full-access member, restricted member with grants,

--- a/internal/store/wiki_links_xws_test.go
+++ b/internal/store/wiki_links_xws_test.go
@@ -39,7 +39,7 @@ func TestWikiLinks_CrossWorkspaceRefIndexedAndQueryable(t *testing.T) {
 	source := createTestItem(t, s, wsB.ID, colB.ID, "Cross source", body)
 
 	// Cross-ws query from A's perspective should find the source.
-	got, err := s.GetCrossWorkspaceBacklinks(wsA.ID, targetRef, user.ID, 50, 0)
+	got, err := s.GetCrossWorkspaceBacklinks(wsA.ID, targetRef, user.ID, nil, 50, 0)
 	if err != nil {
 		t.Fatalf("GetCrossWorkspaceBacklinks: %v", err)
 	}
@@ -89,12 +89,12 @@ func TestWikiLinks_CrossWorkspaceNonMemberDoesNotSee(t *testing.T) {
 		"See [["+wsA.Slug+"::"+targetRef+"]].")
 
 	// Owner sees the cross-ws backlink.
-	got, _ := s.GetCrossWorkspaceBacklinks(wsA.ID, targetRef, owner.ID, 50, 0)
+	got, _ := s.GetCrossWorkspaceBacklinks(wsA.ID, targetRef, owner.ID, nil, 50, 0)
 	if len(got) != 1 {
 		t.Errorf("owner should see cross-ws backlink, got %d", len(got))
 	}
 	// Outsider does NOT — they have no access to workspace B.
-	got2, _ := s.GetCrossWorkspaceBacklinks(wsA.ID, targetRef, outsider.ID, 50, 0)
+	got2, _ := s.GetCrossWorkspaceBacklinks(wsA.ID, targetRef, outsider.ID, nil, 50, 0)
 	if len(got2) != 0 {
 		t.Errorf("outsider should NOT see cross-ws backlink, got %d", len(got2))
 	}
@@ -142,7 +142,7 @@ func TestWikiLinks_CrossWorkspaceGuestSeesGrantedCollectionOnly(t *testing.T) {
 	_ = hiddenSrc
 
 	// Guest sees ONLY the visible-collection source.
-	got, err := s.GetCrossWorkspaceBacklinks(wsA.ID, targetRef, guest.ID, 50, 0)
+	got, err := s.GetCrossWorkspaceBacklinks(wsA.ID, targetRef, guest.ID, nil, 50, 0)
 	if err != nil {
 		t.Fatalf("GetCrossWorkspaceBacklinks: %v", err)
 	}
@@ -197,7 +197,7 @@ func TestWikiLinks_CrossWorkspaceGuestItemGrantOnlyVisible(t *testing.T) {
 		t.Fatalf("grant item: %v", err)
 	}
 
-	got, _ := s.GetCrossWorkspaceBacklinks(wsA.ID, targetRef, guest.ID, 50, 0)
+	got, _ := s.GetCrossWorkspaceBacklinks(wsA.ID, targetRef, guest.ID, nil, 50, 0)
 	if len(got) != 1 {
 		t.Fatalf("guest should see exactly 1 cross-ws backlink (the granted item), got %d: %+v", len(got), got)
 	}
@@ -232,7 +232,7 @@ func TestWikiLinks_CrossWorkspaceUnknownSlugBroken(t *testing.T) {
 		t.Fatalf("add user wsB: %v", err)
 	}
 
-	got, _ := s.GetCrossWorkspaceBacklinks(wsB.ID, "TASK-1", user.ID, 50, 0)
+	got, _ := s.GetCrossWorkspaceBacklinks(wsB.ID, "TASK-1", user.ID, nil, 50, 0)
 	if len(got) != 0 {
 		t.Errorf("broken cross-ws ref should not surface in cross-ws backlinks, got %d", len(got))
 	}
@@ -261,7 +261,7 @@ func TestWikiLinks_CrossWorkspaceSourceWorkspaceSlugPopulated(t *testing.T) {
 	createTestItem(t, s, wsB.ID, colB.ID, "Cross source",
 		"See [["+wsA.Slug+"::"+targetRef+"]].")
 
-	got, _ := s.GetCrossWorkspaceBacklinks(wsA.ID, targetRef, user.ID, 50, 0)
+	got, _ := s.GetCrossWorkspaceBacklinks(wsA.ID, targetRef, user.ID, nil, 50, 0)
 	if len(got) != 1 {
 		t.Fatalf("expected 1 cross-ws row, got %d", len(got))
 	}
@@ -319,7 +319,7 @@ func TestWikiLinks_CrossWorkspaceAdminSeesAllWorkspaces(t *testing.T) {
 
 	// Admin should see the cross-ws backlink via the global
 	// workspace enumeration path.
-	got, err := s.GetCrossWorkspaceBacklinks(wsA.ID, targetRef, admin.ID, 50, 0)
+	got, err := s.GetCrossWorkspaceBacklinks(wsA.ID, targetRef, admin.ID, nil, 50, 0)
 	if err != nil {
 		t.Fatalf("GetCrossWorkspaceBacklinks (admin): %v", err)
 	}
@@ -379,13 +379,75 @@ func TestWikiLinks_CrossWorkspaceRefNumberFallback(t *testing.T) {
 
 	// Query under the NEW ref — the stored row has OLD ref, but
 	// item_number suffix matches so the fallback should hit.
-	got, err := s.GetCrossWorkspaceBacklinks(wsA.ID, newRef, user.ID, 50, 0)
+	got, err := s.GetCrossWorkspaceBacklinks(wsA.ID, newRef, user.ID, nil, 50, 0)
 	if err != nil {
 		t.Fatalf("GetCrossWorkspaceBacklinks: %v", err)
 	}
 	if len(got) != 1 {
 		t.Errorf("expected number-fallback to surface old-prefix backlink, got %d", len(got))
 	}
+}
+
+// TestWikiLinks_CrossWorkspaceTokenAllowListFilters regresses Codex
+// round 2 P1: cross-ws traversal must honor the OAuth/MCP token's
+// workspace allow-list (TASK-952). A token consented for workspace
+// A must not return source rows from workspace B even when the
+// underlying user has B access — the consent boundary lives at the
+// token, not the user.
+//
+// nil allowlist → no token gate (PAT or pre-consent token).
+// `[]string{"*"}` → wildcard consent.
+// Explicit list → strict slug match.
+func TestWikiLinks_CrossWorkspaceTokenAllowListFilters(t *testing.T) {
+	s := testStore(t)
+	user := createTestUser(t, s, "alice@example.com", "Alice", "password123")
+
+	wsA := createTestWorkspace(t, s, "Workspace A")
+	wsB := createTestWorkspace(t, s, "Workspace B")
+	for _, ws := range []*models.Workspace{wsA, wsB} {
+		if err := s.AddWorkspaceMember(ws.ID, user.ID, "owner"); err != nil {
+			t.Fatalf("member %s: %v", ws.Slug, err)
+		}
+	}
+	colA := createTestCollection(t, s, wsA.ID, "Tasks")
+	colB := createTestCollection(t, s, wsB.ID, "Notes")
+
+	target := createTestItem(t, s, wsA.ID, colA.ID, "Cross target", "")
+	targetRef := refOf(target)
+	createTestItem(t, s, wsB.ID, colB.ID, "Cross source",
+		"See [["+wsA.Slug+"::"+targetRef+"]].")
+
+	t.Run("nil allowlist (PAT / pre-consent) sees cross-ws", func(t *testing.T) {
+		got, _ := s.GetCrossWorkspaceBacklinks(wsA.ID, targetRef, user.ID, nil, 50, 0)
+		if len(got) != 1 {
+			t.Errorf("nil allowlist should allow all, got %d", len(got))
+		}
+	})
+
+	t.Run("wildcard allowlist sees cross-ws", func(t *testing.T) {
+		got, _ := s.GetCrossWorkspaceBacklinks(wsA.ID, targetRef, user.ID, []string{"*"}, 50, 0)
+		if len(got) != 1 {
+			t.Errorf("wildcard should allow all, got %d", len(got))
+		}
+	})
+
+	t.Run("target-only allowlist hides cross-ws sources", func(t *testing.T) {
+		// Token consented for workspace A only — source workspace
+		// B is filtered out even though the user has access.
+		got, _ := s.GetCrossWorkspaceBacklinks(wsA.ID, targetRef, user.ID, []string{wsA.Slug}, 50, 0)
+		if len(got) != 0 {
+			t.Errorf("workspace-A-only token should NOT see source from B, got %d", len(got))
+		}
+	})
+
+	t.Run("explicit source-workspace allowlist sees cross-ws", func(t *testing.T) {
+		// Token consented for both A and B.
+		got, _ := s.GetCrossWorkspaceBacklinks(wsA.ID, targetRef, user.ID,
+			[]string{wsA.Slug, wsB.Slug}, 50, 0)
+		if len(got) != 1 {
+			t.Errorf("A+B allowlist should see cross-ws from B, got %d", len(got))
+		}
+	})
 }
 
 // TestResolveBacklinksVisibility_RoleMatrix exercises the request-

--- a/internal/store/wiki_links_xws_test.go
+++ b/internal/store/wiki_links_xws_test.go
@@ -1,0 +1,355 @@
+package store
+
+import (
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// TestWikiLinks_CrossWorkspaceRefIndexedAndQueryable is the headline
+// Phase 2b test: a `[[other-ws::TASK-5]]` body in workspace B indexes
+// a workspace_ref row, and querying TASK-5's backlinks from workspace
+// A surfaces the cross-ws source — provided the requester has
+// visibility into workspace B. PLAN-1593 / TASK-1597.
+func TestWikiLinks_CrossWorkspaceRefIndexedAndQueryable(t *testing.T) {
+	s := testStore(t)
+	user := createTestUser(t, s, "alice@example.com", "Alice", "password123")
+
+	// Two workspaces, both owned by `user` so the requester is an
+	// admin-equivalent (owner) in each. The simpler ACL path lets us
+	// focus on the index correctness in this test.
+	wsA := createTestWorkspace(t, s, "Workspace A")
+	wsB := createTestWorkspace(t, s, "Workspace B")
+	if err := s.AddWorkspaceMember(wsA.ID, user.ID, "owner"); err != nil {
+		t.Fatalf("add user to wsA: %v", err)
+	}
+	if err := s.AddWorkspaceMember(wsB.ID, user.ID, "owner"); err != nil {
+		t.Fatalf("add user to wsB: %v", err)
+	}
+
+	colA := createTestCollection(t, s, wsA.ID, "Tasks")
+	colB := createTestCollection(t, s, wsB.ID, "Notes")
+
+	// Target lives in workspace A.
+	target := createTestItem(t, s, wsA.ID, colA.ID, "Cross target", "")
+	targetRef := refOf(target)
+
+	// Source lives in workspace B, references target via `[[wsA.slug::REF]]`.
+	body := "Cross-link to [[" + wsA.Slug + "::" + targetRef + "]] from B."
+	source := createTestItem(t, s, wsB.ID, colB.ID, "Cross source", body)
+
+	// Cross-ws query from A's perspective should find the source.
+	got, err := s.GetCrossWorkspaceBacklinks(wsA.ID, targetRef, user.ID, 50, 0)
+	if err != nil {
+		t.Fatalf("GetCrossWorkspaceBacklinks: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 cross-ws backlink, got %d: %+v", len(got), got)
+	}
+	bl := got[0]
+	if bl.SourceItemID != source.ID {
+		t.Errorf("SourceItemID: got %q, want %q", bl.SourceItemID, source.ID)
+	}
+	if bl.SourceWorkspaceSlug != wsB.Slug {
+		t.Errorf("SourceWorkspaceSlug: got %q, want %q", bl.SourceWorkspaceSlug, wsB.Slug)
+	}
+}
+
+// TestWikiLinks_CrossWorkspaceNonMemberDoesNotSee covers the
+// visibility contract: a user with NO access to workspace B (no
+// membership, no grants) cannot see backlinks from B even when
+// querying their own workspace A's target. The cross-ws traversal
+// enumerates only workspaces the requester has access to via
+// GetUserWorkspaces.
+func TestWikiLinks_CrossWorkspaceNonMemberDoesNotSee(t *testing.T) {
+	s := testStore(t)
+
+	owner := createTestUser(t, s, "owner@example.com", "Owner", "password123")
+	outsider := createTestUser(t, s, "outsider@example.com", "Outsider", "password123")
+
+	wsA := createTestWorkspace(t, s, "Workspace A")
+	wsB := createTestWorkspace(t, s, "Workspace B")
+	if err := s.AddWorkspaceMember(wsA.ID, owner.ID, "owner"); err != nil {
+		t.Fatalf("owner→wsA: %v", err)
+	}
+	if err := s.AddWorkspaceMember(wsB.ID, owner.ID, "owner"); err != nil {
+		t.Fatalf("owner→wsB: %v", err)
+	}
+	// Outsider is a member of A only — has NO access to B.
+	if err := s.AddWorkspaceMember(wsA.ID, outsider.ID, "editor"); err != nil {
+		t.Fatalf("outsider→wsA: %v", err)
+	}
+
+	colA := createTestCollection(t, s, wsA.ID, "Tasks")
+	colB := createTestCollection(t, s, wsB.ID, "Notes")
+
+	target := createTestItem(t, s, wsA.ID, colA.ID, "Target", "")
+	targetRef := refOf(target)
+	createTestItem(t, s, wsB.ID, colB.ID, "Source in B",
+		"See [["+wsA.Slug+"::"+targetRef+"]].")
+
+	// Owner sees the cross-ws backlink.
+	got, _ := s.GetCrossWorkspaceBacklinks(wsA.ID, targetRef, owner.ID, 50, 0)
+	if len(got) != 1 {
+		t.Errorf("owner should see cross-ws backlink, got %d", len(got))
+	}
+	// Outsider does NOT — they have no access to workspace B.
+	got2, _ := s.GetCrossWorkspaceBacklinks(wsA.ID, targetRef, outsider.ID, 50, 0)
+	if len(got2) != 0 {
+		t.Errorf("outsider should NOT see cross-ws backlink, got %d", len(got2))
+	}
+}
+
+// TestWikiLinks_CrossWorkspaceGuestSeesGrantedCollectionOnly: a guest
+// in workspace B (only access via a collection_grant on one
+// collection) should see backlinks from that collection but not from
+// other collections in B. Mirrors the same-ws Phase 1 visibility
+// model — Codex round-1/2 P1 — across the cross-ws boundary.
+func TestWikiLinks_CrossWorkspaceGuestSeesGrantedCollectionOnly(t *testing.T) {
+	s := testStore(t)
+
+	owner := createTestUser(t, s, "owner@example.com", "Owner", "password123")
+	guest := createTestUser(t, s, "guest@example.com", "Guest", "password123")
+
+	wsA := createTestWorkspace(t, s, "Workspace A")
+	wsB := createTestWorkspace(t, s, "Workspace B")
+	for _, ws := range []*models.Workspace{wsA, wsB} {
+		if err := s.AddWorkspaceMember(ws.ID, owner.ID, "owner"); err != nil {
+			t.Fatalf("owner→%s: %v", ws.Slug, err)
+		}
+	}
+	// Guest is a member of A (so they can ask for A's backlinks),
+	// but has only a guest-style collection_grant in B.
+	if err := s.AddWorkspaceMember(wsA.ID, guest.ID, "editor"); err != nil {
+		t.Fatalf("guest→wsA: %v", err)
+	}
+
+	colA := createTestCollection(t, s, wsA.ID, "Tasks")
+	visibleColB := createTestCollection(t, s, wsB.ID, "Visible") // guest will get grant on this
+	hiddenColB := createTestCollection(t, s, wsB.ID, "Hidden")   // guest CANNOT see
+
+	// Guest's collection grant in B — on Visible only.
+	if _, err := s.CreateCollectionGrant(wsB.ID, visibleColB.ID, guest.ID, "view", owner.ID); err != nil {
+		t.Fatalf("grant visible collection: %v", err)
+	}
+
+	target := createTestItem(t, s, wsA.ID, colA.ID, "Target", "")
+	targetRef := refOf(target)
+	visibleSrc := createTestItem(t, s, wsB.ID, visibleColB.ID, "Visible source",
+		"See [["+wsA.Slug+"::"+targetRef+"]].")
+	hiddenSrc := createTestItem(t, s, wsB.ID, hiddenColB.ID, "Hidden source",
+		"Also see [["+wsA.Slug+"::"+targetRef+"]].")
+	_ = hiddenSrc
+
+	// Guest sees ONLY the visible-collection source.
+	got, err := s.GetCrossWorkspaceBacklinks(wsA.ID, targetRef, guest.ID, 50, 0)
+	if err != nil {
+		t.Fatalf("GetCrossWorkspaceBacklinks: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("guest should see exactly 1 cross-ws backlink (visible-collection only), got %d: %+v", len(got), got)
+	}
+	if got[0].SourceItemID != visibleSrc.ID {
+		t.Errorf("guest saw wrong source: got %q want %q", got[0].SourceItemID, visibleSrc.ID)
+	}
+	if got[0].SourceWorkspaceSlug != wsB.Slug {
+		t.Errorf("SourceWorkspaceSlug: got %q want %q", got[0].SourceWorkspaceSlug, wsB.Slug)
+	}
+}
+
+// TestWikiLinks_CrossWorkspaceGuestItemGrantOnlyVisible: a guest with
+// an item-level grant on ONE source item in workspace B sees only that
+// item, even if other items in B's collections reference the same
+// target. This is the cross-ws equivalent of
+// TestWikiLinks_ItemGrantPagination from Phase 1.
+func TestWikiLinks_CrossWorkspaceGuestItemGrantOnlyVisible(t *testing.T) {
+	s := testStore(t)
+
+	owner := createTestUser(t, s, "owner@example.com", "Owner", "password123")
+	guest := createTestUser(t, s, "guest@example.com", "Guest", "password123")
+
+	wsA := createTestWorkspace(t, s, "Workspace A")
+	wsB := createTestWorkspace(t, s, "Workspace B")
+	for _, ws := range []*models.Workspace{wsA, wsB} {
+		if err := s.AddWorkspaceMember(ws.ID, owner.ID, "owner"); err != nil {
+			t.Fatalf("owner→%s: %v", ws.Slug, err)
+		}
+	}
+	if err := s.AddWorkspaceMember(wsA.ID, guest.ID, "editor"); err != nil {
+		t.Fatalf("guest→wsA: %v", err)
+	}
+
+	colA := createTestCollection(t, s, wsA.ID, "Tasks")
+	colB := createTestCollection(t, s, wsB.ID, "Notes")
+
+	target := createTestItem(t, s, wsA.ID, colA.ID, "Target", "")
+	targetRef := refOf(target)
+
+	// Two sources in workspace B's same collection, both referencing
+	// the target. Guest gets an item-grant on src1 only.
+	src1 := createTestItem(t, s, wsB.ID, colB.ID, "Granted source",
+		"See [["+wsA.Slug+"::"+targetRef+"]].")
+	src2 := createTestItem(t, s, wsB.ID, colB.ID, "Ungranted source",
+		"Also see [["+wsA.Slug+"::"+targetRef+"]].")
+	_ = src2
+
+	if _, err := s.CreateItemGrant(wsB.ID, src1.ID, guest.ID, "view", owner.ID); err != nil {
+		t.Fatalf("grant item: %v", err)
+	}
+
+	got, _ := s.GetCrossWorkspaceBacklinks(wsA.ID, targetRef, guest.ID, 50, 0)
+	if len(got) != 1 {
+		t.Fatalf("guest should see exactly 1 cross-ws backlink (the granted item), got %d: %+v", len(got), got)
+	}
+	if got[0].SourceItemID != src1.ID {
+		t.Errorf("got %q want granted src1 %q", got[0].SourceItemID, src1.ID)
+	}
+}
+
+// TestWikiLinks_CrossWorkspaceUnknownSlugBroken: a `[[unknown-ws::TASK-1]]`
+// body where the workspace slug doesn't exist persists as a row with
+// target_workspace_id = NULL. The cross-ws query for that ref against
+// the unknown workspace returns nothing (the FK column doesn't match
+// any wsID). Documents the broken-link semantics consistent with the
+// renderer's resolver-route 404 path.
+func TestWikiLinks_CrossWorkspaceUnknownSlugBroken(t *testing.T) {
+	s := testStore(t)
+	user := createTestUser(t, s, "alice@example.com", "Alice", "password123")
+	ws := createTestWorkspace(t, s, "Workspace A")
+	if err := s.AddWorkspaceMember(ws.ID, user.ID, "owner"); err != nil {
+		t.Fatalf("add user: %v", err)
+	}
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+	// Source references a workspace slug that doesn't exist.
+	createTestItem(t, s, ws.ID, col.ID, "Source",
+		"Cross [[nonexistent-ws::TASK-1]] over.")
+
+	// Some other workspace exists too so the cross-ws query has
+	// something to iterate. The query for "nonexistent-ws"'s ref
+	// against our real wsB obviously misses.
+	wsB := createTestWorkspace(t, s, "Workspace B")
+	if err := s.AddWorkspaceMember(wsB.ID, user.ID, "owner"); err != nil {
+		t.Fatalf("add user wsB: %v", err)
+	}
+
+	got, _ := s.GetCrossWorkspaceBacklinks(wsB.ID, "TASK-1", user.ID, 50, 0)
+	if len(got) != 0 {
+		t.Errorf("broken cross-ws ref should not surface in cross-ws backlinks, got %d", len(got))
+	}
+}
+
+// TestWikiLinks_CrossWorkspaceSourceWorkspaceSlugPopulated double-
+// checks the wire-shape promise: cross-ws Backlink rows MUST set
+// SourceWorkspaceSlug so the renderer can route the link to the
+// foreign workspace. Same-ws rows leave it empty.
+func TestWikiLinks_CrossWorkspaceSourceWorkspaceSlugPopulated(t *testing.T) {
+	s := testStore(t)
+	user := createTestUser(t, s, "alice@example.com", "Alice", "password123")
+
+	wsA := createTestWorkspace(t, s, "Workspace A")
+	wsB := createTestWorkspace(t, s, "Workspace B")
+	for _, ws := range []*models.Workspace{wsA, wsB} {
+		if err := s.AddWorkspaceMember(ws.ID, user.ID, "owner"); err != nil {
+			t.Fatalf("member: %v", err)
+		}
+	}
+	colA := createTestCollection(t, s, wsA.ID, "Tasks")
+	colB := createTestCollection(t, s, wsB.ID, "Notes")
+
+	target := createTestItem(t, s, wsA.ID, colA.ID, "Cross target", "")
+	targetRef := refOf(target)
+	createTestItem(t, s, wsB.ID, colB.ID, "Cross source",
+		"See [["+wsA.Slug+"::"+targetRef+"]].")
+
+	got, _ := s.GetCrossWorkspaceBacklinks(wsA.ID, targetRef, user.ID, 50, 0)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 cross-ws row, got %d", len(got))
+	}
+	if got[0].SourceWorkspaceSlug != wsB.Slug {
+		t.Errorf("cross-ws row missing SourceWorkspaceSlug: got %q want %q", got[0].SourceWorkspaceSlug, wsB.Slug)
+	}
+
+	// Same-ws GetBacklinks should leave SourceWorkspaceSlug empty.
+	// (Add a same-ws source so we have something to compare.)
+	createTestItem(t, s, wsA.ID, colA.ID, "Same-ws source", "Link [["+targetRef+"]].")
+	sameBls, _ := s.GetBacklinks(target.ID, wsA.ID, 50, 0, BacklinksVisibility{Unrestricted: true})
+	if len(sameBls) != 1 {
+		t.Fatalf("expected 1 same-ws backlink, got %d", len(sameBls))
+	}
+	if sameBls[0].SourceWorkspaceSlug != "" {
+		t.Errorf("same-ws row leaked SourceWorkspaceSlug: got %q want empty", sameBls[0].SourceWorkspaceSlug)
+	}
+}
+
+// TestResolveBacklinksVisibility_RoleMatrix exercises the request-
+// independent ACL helper across the four caller-visible role
+// shapes: admin, full-access member, restricted member with grants,
+// guest. Each case asserts the (fullCollIDs, grantedItemIDs) shape
+// against the documented contract. PLAN-1593 / TASK-1597.
+func TestResolveBacklinksVisibility_RoleMatrix(t *testing.T) {
+	s := testStore(t)
+	owner := createTestUser(t, s, "owner@example.com", "Owner", "password123")
+	ws := createTestWorkspace(t, s, "Test")
+	if err := s.AddWorkspaceMember(ws.ID, owner.ID, "owner"); err != nil {
+		t.Fatalf("add owner: %v", err)
+	}
+
+	t.Run("admin user returns unrestricted (nil/nil)", func(t *testing.T) {
+		admin, err := s.CreateUser(models.UserCreate{
+			Email: "admin@example.com", Name: "Admin", Password: "password123",
+			Role: "admin",
+		})
+		if err != nil {
+			t.Fatalf("create admin: %v", err)
+		}
+		full, granted, err := s.ResolveBacklinksVisibility(admin.ID, ws.ID, false)
+		if err != nil {
+			t.Fatalf("ResolveBacklinksVisibility: %v", err)
+		}
+		if full != nil || granted != nil {
+			t.Errorf("admin should be unrestricted (nil/nil), got %v / %v", full, granted)
+		}
+	})
+
+	t.Run("full-access member returns unrestricted", func(t *testing.T) {
+		full, granted, err := s.ResolveBacklinksVisibility(owner.ID, ws.ID, false)
+		if err != nil {
+			t.Fatalf("ResolveBacklinksVisibility: %v", err)
+		}
+		if full != nil || granted != nil {
+			t.Errorf("full-access member should be unrestricted, got %v / %v", full, granted)
+		}
+	})
+
+	t.Run("guest with grants returns grant-only lists", func(t *testing.T) {
+		guest := createTestUser(t, s, "guest@example.com", "Guest", "password123")
+		col := createTestCollection(t, s, ws.ID, "GuestColl")
+		if _, err := s.CreateCollectionGrant(ws.ID, col.ID, guest.ID, "view", owner.ID); err != nil {
+			t.Fatalf("grant collection: %v", err)
+		}
+		full, granted, err := s.ResolveBacklinksVisibility(guest.ID, ws.ID, false)
+		if err != nil {
+			t.Fatalf("ResolveBacklinksVisibility: %v", err)
+		}
+		if len(full) != 1 || full[0] != col.ID {
+			t.Errorf("guest fullCollIDs: got %v want [%q]", full, col.ID)
+		}
+		if len(granted) != 0 {
+			t.Errorf("guest grantedItemIDs: got %v want []", granted)
+		}
+	})
+
+	t.Run("non-member non-grant user returns empty lists", func(t *testing.T) {
+		stranger := createTestUser(t, s, "stranger@example.com", "Stranger", "password123")
+		full, granted, err := s.ResolveBacklinksVisibility(stranger.ID, ws.ID, false)
+		if err != nil {
+			t.Fatalf("ResolveBacklinksVisibility: %v", err)
+		}
+		// Both lists empty (not nil-nil) — caller interprets as
+		// "no visibility" via BacklinksVisibility.Unrestricted=false
+		// + both lists empty.
+		if len(full) != 0 || len(granted) != 0 {
+			t.Errorf("stranger should have empty visibility, got %v / %v", full, granted)
+		}
+	})
+}

--- a/internal/store/wiki_links_xws_test.go
+++ b/internal/store/wiki_links_xws_test.go
@@ -319,6 +319,45 @@ func TestWikiLinks_CrossWorkspaceSameWorkspaceQualifiedNormalized(t *testing.T) 
 	}
 }
 
+// TestWikiLinks_SameWorkspaceQualifiedRefNoTitleFallback regresses
+// Codex round 5 P2. `[[<current-ws>::ISO-9001]]` where no ISO-9001
+// ref-item exists must NOT fall through to title lookup the way
+// bare `[[ISO-9001]]` does. The renderer's same-ws qualified path
+// (markdown.ts:478-481) treats ref-misses as broken without title
+// fallback; the index must match or it creates ghost backlinks the
+// UI doesn't render.
+func TestWikiLinks_SameWorkspaceQualifiedRefNoTitleFallback(t *testing.T) {
+	s := testStore(t)
+	user := createTestUser(t, s, "alice@example.com", "Alice", "password123")
+	ws := createTestWorkspace(t, s, "Test")
+	if err := s.AddWorkspaceMember(ws.ID, user.ID, "owner"); err != nil {
+		t.Fatalf("add user: %v", err)
+	}
+	col := createTestCollection(t, s, ws.ID, "Tasks") // prefix TASKS
+
+	// Item literally titled "ISO-9001" (no real ISO collection).
+	titledItem := createTestItem(t, s, ws.ID, col.ID, "ISO-9001", "")
+
+	// Source uses same-ws qualified form for a ref that doesn't
+	// resolve. The renderer would render this as broken (no fall-
+	// through to title); our index must NOT create a backlink to
+	// the title-matching item.
+	createTestItem(t, s, ws.ID, col.ID, "Source", "See [["+ws.Slug+"::ISO-9001]].")
+
+	got, _ := s.GetBacklinks(titledItem.ID, ws.ID, 50, 0, BacklinksVisibility{Unrestricted: true})
+	if len(got) != 0 {
+		t.Errorf("same-ws qualified ref miss must NOT title-fallback, got %d ghost backlinks", len(got))
+	}
+
+	// For contrast: bare `[[ISO-9001]]` SHOULD title-fallback per
+	// markdown.ts:513 (preserves the Phase 2a behavior).
+	createTestItem(t, s, ws.ID, col.ID, "Source2", "See [[ISO-9001]].")
+	got2, _ := s.GetBacklinks(titledItem.ID, ws.ID, 50, 0, BacklinksVisibility{Unrestricted: true})
+	if len(got2) != 1 {
+		t.Errorf("bare ref miss SHOULD title-fallback, got %d", len(got2))
+	}
+}
+
 // TestWikiLinks_CrossWorkspaceAdminSeesAllWorkspaces regresses Codex
 // round 1 P2: admin users have implicit access to every workspace
 // (see middleware_auth.go:481), so the cross-ws enumeration must

--- a/internal/store/wiki_links_xws_test.go
+++ b/internal/store/wiki_links_xws_test.go
@@ -281,6 +281,44 @@ func TestWikiLinks_CrossWorkspaceSourceWorkspaceSlugPopulated(t *testing.T) {
 	}
 }
 
+// TestWikiLinks_CrossWorkspaceSameWorkspaceQualifiedNormalized regresses
+// Codex round 4 P2. The renderer treats `[[<current-ws>::TASK-1]]`
+// identically to `[[TASK-1]]` (markdown.ts:307 short-circuit), so an
+// indexed workspace_ref row pointing at the current workspace must
+// be normalized to a ref-kind row at write time — otherwise the
+// link surfaces in the renderer but produces no backlink: the
+// same-ws query requires target_item_id (workspace_ref leaves it
+// NULL) and the cross-ws query skips the target workspace.
+func TestWikiLinks_CrossWorkspaceSameWorkspaceQualifiedNormalized(t *testing.T) {
+	s := testStore(t)
+	user := createTestUser(t, s, "alice@example.com", "Alice", "password123")
+	ws := createTestWorkspace(t, s, "Test")
+	if err := s.AddWorkspaceMember(ws.ID, user.ID, "owner"); err != nil {
+		t.Fatalf("add user: %v", err)
+	}
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+
+	target := createTestItem(t, s, ws.ID, col.ID, "Target", "")
+	tref := refOf(target)
+	// Source uses the fully-qualified same-workspace form.
+	createTestItem(t, s, ws.ID, col.ID, "Source",
+		"See [["+ws.Slug+"::"+tref+"]] here.")
+
+	// The same-ws GetBacklinks must surface this row — normalization
+	// converted it from workspace_ref to ref-kind so target_item_id
+	// is populated.
+	got, _ := s.GetBacklinks(target.ID, ws.ID, 50, 0, BacklinksVisibility{Unrestricted: true})
+	if len(got) != 1 {
+		t.Errorf("same-ws fully-qualified ref should surface in same-ws backlinks, got %d", len(got))
+	}
+
+	// Cross-ws query must NOT surface it (correctly attributed to same-ws).
+	cross, _ := s.GetCrossWorkspaceBacklinks(ws.ID, tref, user.ID, nil, 50, 0)
+	if len(cross) != 0 {
+		t.Errorf("same-ws fully-qualified ref should not appear in cross-ws backlinks, got %d", len(cross))
+	}
+}
+
 // TestWikiLinks_CrossWorkspaceAdminSeesAllWorkspaces regresses Codex
 // round 1 P2: admin users have implicit access to every workspace
 // (see middleware_auth.go:481), so the cross-ws enumeration must


### PR DESCRIPTION
## Summary

Phase 2b of PLAN-1593 (TASK-1597). Completes the wiki-link reverse index by indexing and surfacing `[[workspace::REF]]` cross-workspace references. Builds on Phase 2a (PR #621). Phase 3 (TASK-1596) owns UI/MCP/CLI rendering.

The structural piece this task introduces is `Store.ResolveBacklinksVisibility(userID, workspaceID, includeDeletedItems)` — a request-independent variant of `server.guestResourceFilterCore` that the cross-workspace traversal can call without a request context. The Codex planning-round review identified the prior plan's "reuse the request-scoped helper" as a hidden architectural cost; this is the resolution.

## What's in the PR

- **Request-independent ACL helper** (`internal/store/backlinks_visibility.go`) — mirrors role determination + collection merge from `guestResourceFilterCore` but determines workspace role itself.
- **`guestResourceFilterCore` refactored** to delegate to the new helper. Handler call sites are unchanged.
- **Workspace_ref emit gate lifted** in `extract.go`. parseBody already recognized the kind.
- **`replaceWikiLinks` workspace_ref branch** stores `(target_workspace_id, target_ref)`; `resolveWorkspaceSlugTx` looks up the slug with per-call caching. Unknown slugs persist with `target_workspace_id=NULL` (broken-link semantics, consistent with ref/title patterns).
- **`Store.GetCrossWorkspaceBacklinks`** enumerates accessible workspaces via `Store.GetUserWorkspaces` (broader than membership — includes guest-only access). Per workspace computes visibility via the new helper and runs the SQL with the per-ws `(FullCollectionIDs, GrantedItemIDs)` predicate inline. Merges and sorts in Go (per-workspace safety cap caps transferred rows).
- **`Store.CountBacklinks`** for same-ws pagination boundary detection so pages 2+ correctly land in the cross-ws tier when same-ws is exhausted.
- **`models.Backlink.SourceWorkspaceSlug`** (omitempty) — populated only by cross-ws rows.
- **Backlinks handler union pagination** — same-ws first (matches the panel's UI mental model: your own workspace's links at the top, foreign workspaces below). Count-based slice math.

## Test plan

- [x] `go test ./internal/links/ ./internal/store/ ./internal/server/` — all green
- [x] `make check` — lint + tests + web build all green
- [x] `make install` — server restarts; binary smoke-checks against existing data
- [x] Six cross-ws integration scenarios + role-matrix unit test cover the visibility contract
- [ ] CI green
- [ ] `/codex review --loop` → CLEAN

## Behavioral decisions

- **Pagination shape:** same-ws first, then cross-ws. Within each tier, `updated_at DESC`. Documented in the handler.
- **Cross-ws sort:** in Go after collecting per-workspace results. Simpler than UNION ALL; cross-ws backlinks are typically sparse so in-memory sort over a few hundred rows beats the SQL verbosity. Profiling-driven swap if real workloads need it.
- **`target_ref` matching:** case-insensitive via `LOWER()` (mirrors the renderer's resolver-route behavior at markdown.ts:485).
- **Self-link cross-ws:** not possible by construction (`[[ws::REF]]` where ws == current workspace would resolve as a same-ws ref instead).

## Out of scope

- UI rendering of cross-ws backlinks (workspace badge + workspace-prefixed ref) — TASK-1596 (Phase 3).
- MCP `pad_item.action: backlinks` cross-ws field plumbing — TASK-1596.
- CLI display tweaks — TASK-1596.

PLAN-1593 / TASK-1597.