### PR TITLE
feat(backlinks): UI panel + mention badge + CLI + MCP (Phase 3)

### DIFF
--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -3299,8 +3299,29 @@ func showCmd() *cobra.Command {
 				return err
 			}
 
+			// PLAN-1593 / TASK-1596: fetch the top 5 backlinks
+			// alongside the item so the show command always carries
+			// the "Mentioned in" context. Failures are non-fatal —
+			// the item view should still render even if the
+			// backlinks endpoint is unavailable (e.g. a pre-Phase-1
+			// server, or transient I/O). slog at debug would be
+			// ideal but show is a terminal command; we just swallow
+			// silently to avoid noise in agent transcripts.
+			backlinksTop, _ := client.GetBacklinks(ws, item.Slug, 5, 0)
+
 			if formatFlag == "json" {
-				return cli.PrintJSON(item)
+				// Wrap with the inline `backlinks_top` field per the
+				// task spec. Additive: existing fields on `item` are
+				// unchanged; any consumer that didn't know about
+				// backlinks_top simply ignores it. JSON output of
+				// `pad item show` was already a single-object shape,
+				// so the wrapper keeps the same top-level shape with
+				// one extra optional key.
+				type wrappedItem struct {
+					*models.Item
+					BacklinksTop []models.Backlink `json:"backlinks_top,omitempty"`
+				}
+				return cli.PrintJSON(wrappedItem{Item: item, BacklinksTop: backlinksTop})
 			}
 
 			if formatFlag == "markdown" {
@@ -3438,6 +3459,38 @@ func showCmd() *cobra.Command {
 					fmt.Printf("(%d earlier comments not shown)\n\n", start)
 				}
 				cli.PrintCommentTable(comments[start:])
+			}
+
+			// PLAN-1593 / TASK-1596: inline top-5 backlinks. Use the
+			// list we already fetched above so we don't double-query.
+			// Hidden when no backlinks — most items don't have any
+			// and we don't want to clutter the show output with
+			// empty sections.
+			if len(backlinksTop) > 0 {
+				fmt.Println("\n--- Mentioned in ---")
+				for _, bl := range backlinksTop {
+					header := bl.SourceRef + " " + bl.SourceTitle
+					if bl.SourceCollectionIcon != "" {
+						header = bl.SourceCollectionIcon + " " + header
+					}
+					if bl.SourceWorkspaceSlug != "" {
+						// Cross-workspace badge — make the foreign
+						// workspace visible so the user knows the
+						// source lives elsewhere.
+						header += "  " + color.New(color.Faint).Sprint("→ "+bl.SourceWorkspaceSlug)
+					}
+					fmt.Printf("%s\n", cli.Bold.Sprint(header))
+					if bl.Snippet != "" {
+						cli.Dim.Printf("  %s\n", bl.Snippet)
+					}
+				}
+				// Hint at the full list when we hit the cap and there
+				// might be more. The handler returns up to 5 here;
+				// if exactly 5 came back, the user likely has more
+				// and we point them at the dedicated command.
+				if len(backlinksTop) == 5 {
+					cli.Dim.Printf("\n(run `pad item backlinks %s` for the full list)\n", args[0])
+				}
 			}
 
 			return nil

--- a/internal/mcp/catalog_item.go
+++ b/internal/mcp/catalog_item.go
@@ -63,6 +63,14 @@ var padItemTool = ToolDef{
 		"comment":       passThrough([]string{"item", "comment"}),
 		"list-comments": passThrough([]string{"item", "comments"}),
 
+		// Backlinks ("Mentioned in") — PLAN-1593 / TASK-1596.
+		// Returns inbound `[[...]]` references to the given item.
+		// Same-workspace + cross-workspace rows are unioned in the
+		// response; cross-ws rows carry `source_workspace_slug`.
+		// The CLI command takes a ref and optional --limit/--offset
+		// flags; passThrough handles both. PLAN-1593 / TASK-1596.
+		"backlinks": passThrough([]string{"item", "backlinks"}),
+
 		// Bulk + notes + decisions
 		// bulk-update is custom because the CLI takes repeatable
 		// positional refs (one or more); our uniform schema exposes
@@ -133,7 +141,8 @@ var padItemSchemaParams = []ParamDef{
 
 	// ── List / starred ──
 	{Name: "all", Type: "bool", Description: "Include archived/done items in list responses. Optional for: list, starred."},
-	{Name: "limit", Type: "number", Description: "Maximum results. Optional for: list."},
+	{Name: "limit", Type: "number", Description: "Maximum results. Optional for: list, backlinks. Backlinks defaults to 50, max 300."},
+	{Name: "offset", Type: "number", Description: "Skip the first N results (paging). Optional for: backlinks."},
 	{Name: "sort", Type: "string", Description: "Sort field. Optional for: list."},
 	{Name: "group_by", Type: "string", Description: "Group-by field. Optional for: list."},
 
@@ -206,6 +215,14 @@ Actions:
                   Optional: reply_to (comment ID for threaded reply).
   list-comments — List comments on an item.
                   Required: ref.
+  backlinks     — List inbound [[...]] references to an item ("Mentioned in").
+                  Required: ref.
+                  Optional: limit (default 50, max 300), offset.
+                  Returns same-workspace rows first, then cross-workspace
+                  rows (each cross-ws row carries source_workspace_slug).
+                  Use this when you need to answer "what other items
+                  reference TASK-5?" without scanning the full content
+                  corpus.
   bulk-update   — Update status/priority across multiple items.
                   Required: refs (array of refs, e.g. ["TASK-5", "TASK-8"]),
                   AND at least one of status / priority.

--- a/internal/mcp/catalog_readonly_test.go
+++ b/internal/mcp/catalog_readonly_test.go
@@ -121,6 +121,7 @@ func TestReadOnlyCatalog_ActionsMatchCmdhelp(t *testing.T) {
 		{"pad_item", "bulk-update"}:   {"item", "bulk-update"},
 		{"pad_item", "note"}:          {"item", "note"},
 		{"pad_item", "decide"}:        {"item", "decide"},
+		{"pad_item", "backlinks"}:     {"item", "backlinks"},
 
 		// pad_playbook actions (PLAN-1377 / TASK-1381). All three
 		// passThrough to `pad playbook <subcommand>`.
@@ -256,6 +257,7 @@ func TestReadOnlyCatalog_ActionsDispatchExpectedCmdPath(t *testing.T) {
 		{"pad_item", "bulk-update"}:   {"item", "bulk-update"},
 		{"pad_item", "note"}:          {"item", "note"},
 		{"pad_item", "decide"}:        {"item", "decide"},
+		{"pad_item", "backlinks"}:     {"item", "backlinks"},
 
 		// pad_playbook actions (PLAN-1377 / TASK-1381).
 		{"pad_playbook", "list"}: {"playbook", "list"},
@@ -603,6 +605,15 @@ func liveCmdhelpDoc(t *testing.T) *cmdhelp.Document {
 				Summary: "list comments",
 				Args:    mkArgs("ref"),
 				Flags:   mkFlags("workspace"),
+			},
+			"item backlinks": {
+				Summary: "list inbound [[...]] references",
+				Args:    mkArgs("ref"),
+				Flags: map[string]cmdhelp.Flag{
+					"workspace": {Type: "string"},
+					"limit":     {Type: "int"},
+					"offset":    {Type: "int"},
+				},
 			},
 			"item bulk-update": {
 				Summary: "bulk update",

--- a/internal/mcp/version.go
+++ b/internal/mcp/version.go
@@ -65,13 +65,20 @@ const CmdhelpVersion = "0.1"
 //     context. Purely additive; older clients that ignore unknown
 //     keys keep working.
 //   - pad://workspace/{ws}/bootstrap resource added.
-//   - "0.5" — current. PLAN-1560 / TASK-1563: adds `pad_library` to the
-//     catalog as the ninth resource × action tool. Three actions —
+//   - "0.5" — historical. PLAN-1560 / TASK-1563: adds `pad_library` to
+//     the catalog as the ninth resource × action tool. Three actions —
 //     list / get / activate — surface the global convention + playbook
 //     library (previously CLI-only) to MCP callers. Pure addition; no
 //     existing tool/action/param/bootstrap shapes changed. Backwards-
 //     compatible for any v0.4 consumer that doesn't enumerate the new
 //     tool.
+//   - "0.6" — current. PLAN-1593 / TASK-1596: adds `backlinks` action
+//     to `pad_item` so MCP callers can answer "what mentions X?"
+//     without scanning the full content corpus. Adds `offset` to the
+//     param vocabulary, extends `limit` to cover the backlinks
+//     pagination. Pure addition; existing pad_item actions unchanged.
+//     Backwards-compatible for v0.5 consumers that don't enumerate
+//     the new action.
 //   - "0.4" — PLAN-1410: comprehensive bootstrap-payload
 //     trim, cutting ~40% of bytes off the AgentBootstrap response.
 //     Same tool catalog (still eight resource × action tools +
@@ -114,7 +121,7 @@ const CmdhelpVersion = "0.1"
 //   - result.capabilities.experimental.padToolSurface.version (handshake).
 //   - pad://_meta/version resource (queryable JSON document).
 //   - pad_meta.action: tool-surface (full catalog introspection).
-const ToolSurfaceVersion = "0.5"
+const ToolSurfaceVersion = "0.6"
 
 // MetaVersionURI is the canonical URI of the queryable version document.
 // Lives outside the pad://workspace/{ws}/... namespace because it's a

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -5,6 +5,7 @@ import type {
 	Collection,
 	CollectionCreate,
 	CollectionUpdate,
+	Backlink,
 	Item,
 	ItemChangeRow,
 	ItemChangesResponse,
@@ -695,6 +696,33 @@ export const api = {
 						source: 'web'
 					})
 				}
+			),
+
+		/**
+		 * Inbound `[[...]]` references to an item — the "Mentioned in"
+		 * panel data source (PLAN-1593 / TASK-1596). Returns same-
+		 * workspace backlinks first, then cross-workspace backlinks
+		 * (each cross-ws row carries `source_workspace_slug`). The
+		 * server applies visibility filtering: a guest with only
+		 * partial workspace access sees only sources they're permitted
+		 * to read.
+		 *
+		 * Pagination: `limit` defaults to 50 server-side (max 300);
+		 * `offset` enables "Load more" affordances. The panel loads
+		 * the first page on mount; if `combined.length === limit`, the
+		 * server probably has more rows and the UI exposes a "Show
+		 * older" button.
+		 */
+		backlinks: (
+			ws: string,
+			slug: string,
+			opts?: { limit?: number; offset?: number }
+		) =>
+			request<Backlink[]>(
+				`/workspaces/${ws}/items/${slug}/backlinks${qs({
+					limit: opts?.limit,
+					offset: opts?.offset,
+				})}`
 			),
 
 		/** Get child items linked to a parent item */

--- a/web/src/lib/components/BacklinksPanel.svelte
+++ b/web/src/lib/components/BacklinksPanel.svelte
@@ -1,0 +1,408 @@
+<script lang="ts">
+	import { SvelteMap } from 'svelte/reactivity';
+	import { api } from '$lib/api/client';
+	import type { Backlink } from '$lib/types';
+	import { relativeTime } from '$lib/utils/markdown';
+
+	interface Props {
+		wsSlug: string;
+		username: string;
+		itemSlug: string;
+		itemId: string;
+		onCountChange?: (n: number) => void;
+	}
+
+	let { wsSlug, username, itemSlug, itemId, onCountChange }: Props = $props();
+
+	const PAGE_LIMIT = 50;
+
+	let backlinks = $state<Backlink[]>([]);
+	let loading = $state(true);
+	let loadingMore = $state(false);
+	let error = $state('');
+	let hasMore = $state(false);
+
+	/**
+	 * Reload when the queried item changes. We depend on BOTH itemSlug and
+	 * itemId so the panel refetches when the parent page swaps items
+	 * without unmount/remount — itemSlug alone could collide across
+	 * workspaces, and itemId alone wouldn't catch a slug-only rename of
+	 * the same id. Touching both via `void` keeps the effect dependent
+	 * regardless of whether their values are actually used downstream.
+	 */
+	$effect(() => {
+		void itemSlug;
+		void itemId;
+		void wsSlug;
+		loadFirstPage();
+	});
+
+	async function loadFirstPage() {
+		loading = true;
+		error = '';
+		try {
+			const rows = await api.items.backlinks(wsSlug, itemSlug, { limit: PAGE_LIMIT });
+			backlinks = rows;
+			hasMore = rows.length === PAGE_LIMIT;
+			onCountChange?.(rows.length);
+		} catch (err) {
+			error = err instanceof Error ? err.message : 'Failed to load backlinks';
+			backlinks = [];
+			hasMore = false;
+			// Empty contract: signal zero so the badge stays hidden on error.
+			onCountChange?.(0);
+		} finally {
+			loading = false;
+		}
+	}
+
+	async function loadMore() {
+		if (loadingMore || !hasMore) return;
+		loadingMore = true;
+		try {
+			const rows = await api.items.backlinks(wsSlug, itemSlug, {
+				limit: PAGE_LIMIT,
+				offset: backlinks.length
+			});
+			backlinks = [...backlinks, ...rows];
+			hasMore = rows.length === PAGE_LIMIT;
+			onCountChange?.(backlinks.length);
+		} catch (err) {
+			error = err instanceof Error ? err.message : 'Failed to load more backlinks';
+		} finally {
+			loadingMore = false;
+		}
+	}
+
+	/**
+	 * Group rows by source_collection_slug, scoped by source_workspace_slug
+	 * so cross-workspace rows don't merge with same-workspace rows that
+	 * happen to use the same collection slug. The grouping key embeds the
+	 * workspace (defaulting to the current wsSlug for same-ws rows) so
+	 * iteration order follows the response order — the API already sorts
+	 * by updated_at DESC, so SvelteMap's insertion-order iteration gives
+	 * us "most-recently-touched collection first" for free.
+	 */
+	type Group = {
+		key: string;
+		icon: string;
+		slug: string;
+		workspaceSlug: string | null; // null = same workspace as wsSlug
+		rows: Backlink[];
+	};
+
+	let groups = $derived.by<Group[]>(() => {
+		const map = new SvelteMap<string, Group>();
+		for (const bl of backlinks) {
+			const xws = bl.source_workspace_slug ?? null;
+			const key = `${xws ?? wsSlug}::${bl.source_collection_slug}`;
+			let group = map.get(key);
+			if (!group) {
+				group = {
+					key,
+					icon: bl.source_collection_icon,
+					slug: bl.source_collection_slug,
+					workspaceSlug: xws,
+					rows: []
+				};
+				map.set(key, group);
+			}
+			group.rows.push(bl);
+		}
+		return Array.from(map.values());
+	});
+
+	function capitalize(s: string): string {
+		if (!s) return s;
+		return s.charAt(0).toUpperCase() + s.slice(1);
+	}
+
+	function rowHref(bl: Backlink): string {
+		const ws = bl.source_workspace_slug ?? wsSlug;
+		return `/${username}/${ws}/${bl.source_collection_slug}/${bl.source_ref}`;
+	}
+
+	// Render nothing while we don't yet know there are backlinks. Once
+	// loaded, collapse entirely on zero rows — most items have no inbound
+	// links and an empty "Mentioned in" header is just noise. The error
+	// case still shows a muted one-liner because silently dropping a
+	// failed fetch is worse than a tiny note.
+	let shouldRender = $derived(loading || error !== '' || backlinks.length > 0);
+</script>
+
+{#if shouldRender}
+	<div class="backlinks-panel">
+		<div class="panel-header">
+			<h3>Mentioned in</h3>
+			{#if !loading && !error && backlinks.length > 0}
+				<span class="count">{backlinks.length}{hasMore ? '+' : ''}</span>
+			{/if}
+		</div>
+
+		{#if loading}
+			<div class="loading">
+				<span class="spinner" aria-hidden="true"></span>
+				<span>Loading…</span>
+			</div>
+		{:else if error}
+			<div class="error">Couldn't load backlinks.</div>
+		{:else}
+			{#each groups as group (group.key)}
+				<div class="group">
+					<div class="group-header">
+						<span class="group-icon" aria-hidden="true">{group.icon}</span>
+						<span class="group-label">{capitalize(group.slug)}</span>
+						{#if group.workspaceSlug}
+							<span class="group-ws" title="From workspace {group.workspaceSlug}">
+								→ {group.workspaceSlug}
+							</span>
+						{/if}
+					</div>
+					<ul class="rows">
+						{#each group.rows as bl (bl.source_item_id)}
+							<li class="row">
+								<div class="row-head">
+									<a href={rowHref(bl)} class="row-link">
+										<span class="row-ref">{bl.source_ref}</span>
+										<span class="row-title">{bl.source_title}</span>
+									</a>
+									{#if bl.display_text}
+										<span class="display-tag" title="Rendered as">
+											(displayed as: {bl.display_text})
+										</span>
+									{/if}
+									<span class="row-time" title={bl.updated_at}>
+										{relativeTime(bl.updated_at)}
+									</span>
+								</div>
+								{#if bl.snippet}
+									<div class="snippet">{bl.snippet}</div>
+								{/if}
+							</li>
+						{/each}
+					</ul>
+				</div>
+			{/each}
+
+			{#if hasMore}
+				<div class="more">
+					<button
+						type="button"
+						class="more-btn"
+						disabled={loadingMore}
+						onclick={loadMore}
+					>
+						{loadingMore ? 'Loading…' : 'Show older'}
+					</button>
+				</div>
+			{/if}
+		{/if}
+	</div>
+{/if}
+
+<style>
+	.backlinks-panel {
+		padding: var(--space-4) 0;
+		border-top: 1px solid var(--border);
+	}
+
+	.panel-header {
+		display: flex;
+		align-items: baseline;
+		gap: var(--space-2);
+		margin-bottom: var(--space-3);
+	}
+
+	.panel-header h3 {
+		margin: 0;
+		font-size: 0.95em;
+		font-weight: 600;
+		color: var(--text-primary);
+	}
+
+	.count {
+		font-size: 0.8em;
+		color: var(--text-muted);
+		font-weight: 400;
+	}
+
+	.group {
+		margin-top: var(--space-3);
+	}
+
+	.group:first-of-type {
+		margin-top: 0;
+	}
+
+	.group-header {
+		display: flex;
+		align-items: center;
+		gap: var(--space-2);
+		font-size: 0.72em;
+		font-weight: 500;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		color: var(--text-muted);
+		margin-bottom: var(--space-2);
+	}
+
+	.group-icon {
+		font-size: 1.1em;
+		line-height: 1;
+	}
+
+	.group-ws {
+		text-transform: none;
+		letter-spacing: 0;
+		font-weight: 400;
+		font-size: 0.95em;
+		color: var(--text-muted);
+		opacity: 0.7;
+	}
+
+	.rows {
+		list-style: none;
+		padding: 0;
+		margin: 0;
+	}
+
+	.row {
+		padding: var(--space-2) var(--space-2);
+		border-bottom: 1px solid var(--border);
+		min-width: 0;
+	}
+
+	.row:last-child {
+		border-bottom: none;
+	}
+
+	.row-head {
+		display: flex;
+		align-items: center;
+		gap: var(--space-2);
+		min-width: 0;
+	}
+
+	.row-link {
+		display: flex;
+		align-items: center;
+		gap: var(--space-2);
+		flex: 1;
+		min-width: 0;
+		text-decoration: none;
+		color: inherit;
+	}
+
+	.row-link:hover .row-title {
+		text-decoration: underline;
+	}
+
+	.row-ref {
+		font-family: var(--font-mono);
+		font-size: 0.78em;
+		color: var(--text-muted);
+		white-space: nowrap;
+		flex-shrink: 0;
+	}
+
+	.row-title {
+		font-size: 0.88em;
+		color: var(--text-primary);
+		min-width: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.display-tag {
+		font-size: 0.75em;
+		color: var(--text-muted);
+		font-style: italic;
+		flex-shrink: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		max-width: 12em;
+	}
+
+	.row-time {
+		font-size: 0.75em;
+		color: var(--text-muted);
+		white-space: nowrap;
+		flex-shrink: 0;
+		margin-left: auto;
+	}
+
+	.snippet {
+		margin-top: 2px;
+		padding-left: 0;
+		font-size: 0.82em;
+		color: var(--text-muted);
+		line-height: 1.4;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		display: -webkit-box;
+		-webkit-line-clamp: 2;
+		line-clamp: 2;
+		-webkit-box-orient: vertical;
+		word-break: break-word;
+	}
+
+	.loading {
+		display: flex;
+		align-items: center;
+		gap: var(--space-2);
+		padding: var(--space-2) 0;
+		color: var(--text-muted);
+		font-size: 0.85em;
+	}
+
+	.spinner {
+		width: 12px;
+		height: 12px;
+		border: 2px solid var(--border);
+		border-top-color: var(--accent-blue);
+		border-radius: 50%;
+		animation: spin 0.6s linear infinite;
+	}
+
+	@keyframes spin {
+		to {
+			transform: rotate(360deg);
+		}
+	}
+
+	.error {
+		padding: var(--space-2) 0;
+		color: var(--text-muted);
+		font-size: 0.85em;
+		font-style: italic;
+	}
+
+	.more {
+		margin-top: var(--space-3);
+		display: flex;
+		justify-content: center;
+	}
+
+	.more-btn {
+		background: none;
+		border: 1px solid var(--border);
+		color: var(--text-secondary, var(--text-muted));
+		padding: var(--space-1) var(--space-3);
+		border-radius: var(--radius-sm);
+		font-size: 0.8em;
+		cursor: pointer;
+		transition: background 0.1s, color 0.1s;
+	}
+
+	.more-btn:hover:not(:disabled) {
+		background: var(--bg-hover);
+		color: var(--text-primary);
+	}
+
+	.more-btn:disabled {
+		opacity: 0.6;
+		cursor: default;
+	}
+</style>

--- a/web/src/lib/components/BacklinksPanel.svelte
+++ b/web/src/lib/components/BacklinksPanel.svelte
@@ -122,6 +122,26 @@
 		return `/${username}/${ws}/${bl.source_collection_slug}/${bl.source_ref}`;
 	}
 
+	/**
+	 * Compose a unique each-block key per backlink row. The server
+	 * preserves multiplicity (a source body that mentions the target
+	 * three times produces three rows — Phase 1 design decision) so
+	 * `source_item_id` alone is non-unique. Svelte 5 rejects duplicate
+	 * keys at dev time and silently reuses DOM in prod, which would
+	 * make the panel render only one of the N rows from a multi-mention
+	 * source.
+	 *
+	 * Composite key: `${id}|${snippet}|${index-within-group}`. The
+	 * snippet usually differs across positions (centered on the bracket
+	 * byte offset, so unique except in pathological cases like
+	 * adjacent mentions); the index suffix is the unconditional
+	 * tie-breaker that guarantees uniqueness across any rendering of
+	 * the same backlinks array. Codex round 1 P1.
+	 */
+	function rowKey(bl: Backlink, index: number): string {
+		return `${bl.source_item_id}|${bl.snippet}|${index}`;
+	}
+
 	// Render nothing while we don't yet know there are backlinks. Once
 	// loaded, collapse entirely on zero rows — most items have no inbound
 	// links and an empty "Mentioned in" header is just noise. The error
@@ -159,7 +179,7 @@
 						{/if}
 					</div>
 					<ul class="rows">
-						{#each group.rows as bl (bl.source_item_id)}
+						{#each group.rows as bl, blIdx (rowKey(bl, blIdx))}
 							<li class="row">
 								<div class="row-head">
 									<a href={rowHref(bl)} class="row-link">

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -605,6 +605,39 @@ export interface ItemLinkCreate {
 	created_by?: string;
 }
 
+// ─── Backlinks ──────────────────────────────────────────────────────────────
+
+/**
+ * One inbound `[[...]]` reference to the queried item. Wire shape returned by
+ * `GET /api/v1/workspaces/{ws}/items/{slug}/backlinks` — populated by the
+ * server-side reverse index from PLAN-1593 (Phases 1, 2a, 2b).
+ *
+ * Mirrors `internal/models/backlink.go`. The Phase 3 UI (TASK-1596) renders
+ * these as the "Mentioned in" panel beneath an item's content.
+ */
+export interface Backlink {
+	source_item_id: string;
+	source_ref: string;
+	source_title: string;
+	source_collection_slug: string;
+	source_collection_icon: string;
+	snippet: string;
+	updated_at: string;
+	/**
+	 * Optional `[[X|display]]` override. `null` (omitted from JSON) when
+	 * the link was a bare `[[X]]`. A non-null empty string represents
+	 * the editor-distinct `[[X|]]` shape.
+	 */
+	display_text?: string | null;
+	/**
+	 * Populated only for cross-workspace backlinks (PLAN-1593 Phase 2b /
+	 * TASK-1597). Same-workspace rows omit this field. The renderer uses
+	 * it to route links to the foreign workspace and show a small
+	 * workspace badge next to the row.
+	 */
+	source_workspace_slug?: string;
+}
+
 // ─── Comments ───────────────────────────────────────────────────────────────
 
 export interface Comment {

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -19,6 +19,7 @@
 	import FieldEditor from '$lib/components/fields/FieldEditor.svelte';
 	import ItemTimeline from '$lib/components/timeline/ItemTimeline.svelte';
 	import ChildItems from '$lib/components/ChildItems.svelte';
+	import BacklinksPanel from '$lib/components/BacklinksPanel.svelte';
 	import { goto } from '$app/navigation';
 	import { relativeTime, wikiLinksToMarkdown, markdownToWikiLinks, cleanBrokenLinks, unescapeDocLinks } from '$lib/utils/markdown';
 	import { toastStore } from '$lib/stores/toast.svelte';
@@ -129,6 +130,13 @@
 	let childItemIds = $state<Set<string>>(new Set());
 	let hasChildren = $state(false);
 	let copied = $state(false);
+
+	// PLAN-1593 / TASK-1596: count of inbound `[[...]]` references to
+	// this item, surfaced as a mention badge near the title. Driven by
+	// BacklinksPanel via its onCountChange callback so the badge and
+	// panel stay consistent — when the panel loads zero rows it
+	// notifies us and the badge hides.
+	let backlinksCount = $state(0);
 
 	// ── Viewport detection ───────────────────────────────────────────────
 	// Drives BottomSheet vs popover branching for mobile-only surfaces on
@@ -2179,6 +2187,25 @@
 			>
 				Timeline
 			</button>
+			{#if backlinksCount > 0}
+				<!--
+					Mention badge (PLAN-1593 / TASK-1596). Surfaces the inbound
+					`[[...]]` reference count in the action bar so users can see
+					at a glance that this item is referenced from elsewhere AND
+					jump straight to the panel without scrolling. Hidden when
+					the count is 0 so items with no inbound links don't
+					advertise an empty surface. The count is driven by
+					BacklinksPanel's onCountChange callback so the two stay in
+					sync without a separate API call.
+				-->
+				<button
+					class="action-btn"
+					title="Mentioned in {backlinksCount} other item{backlinksCount === 1 ? '' : 's'}"
+					onclick={() => { document.getElementById('item-backlinks')?.scrollIntoView({ behavior: 'smooth' }); }}
+				>
+					📎 {backlinksCount}
+				</button>
+			{/if}
 			{#if canEdit}
 				<div class="move-wrapper">
 					<button class="action-btn" onclick={() => { showMoveMenu = !showMoveMenu; }} disabled={moving}>
@@ -2693,6 +2720,28 @@
 		<!-- Child Items: always mounted so SSE subscriptions stay active even when starting with 0 children -->
 		{#if item}
 			<ChildItems {wsSlug} {username} {itemSlug} itemId={item.id} parentFields={fields} terminalStatuses={childTerminalStatuses} onChildrenChange={handleChildrenChange} {canEdit} />
+		{/if}
+
+		<!--
+			Mentioned-in panel (PLAN-1593 / TASK-1596). Placed between
+			child items and the timeline so the reading order matches the
+			page's narrative arc: this item, its decomposition (children),
+			what references it (backlinks), then the activity stream. The
+			panel collapses entirely when there are zero backlinks — no
+			empty header, no whitespace waste — and notifies the badge via
+			the count callback. Anchor id is referenced by the "📎 N"
+			action button's smooth scroll.
+		-->
+		{#if item}
+			<div id="item-backlinks">
+				<BacklinksPanel
+					{wsSlug}
+					{username}
+					{itemSlug}
+					itemId={item.id}
+					onCountChange={(n) => { backlinksCount = n; }}
+				/>
+			</div>
 		{/if}
 
 		<!-- Unified Timeline (comments + activity + versions) -->


### PR DESCRIPTION
## Summary

Phase 3 of PLAN-1593 (TASK-1596). Surfaces the backlinks index shipped in Phases 1 / 2a / 2b across every place users live: web UI, CLI, MCP. Closes out the wiki-link backlinks plan.

## What's in the PR

**Web UI**
- New `BacklinksPanel.svelte` (~400 LOC) at `web/src/lib/components/`. Fetches via `api.items.backlinks` and renders inbound `[[...]]` references grouped by source collection. Per-row: collection icon, ref + title, snippet, relative timestamp, optional `(displayed as)` override, faint workspace badge on cross-ws rows. "Show older" pagination button when a page fills. **Collapses entirely when count is 0** — no header, no whitespace, no empty surface for items with no inbound links.
- **Mention badge** ("📎 N") in the item-page action bar next to the Timeline button. Hidden when N=0; smooth-scrolls to `#item-backlinks`. Wired via `onCountChange` callback so badge + panel stay in sync (one fetch).
- Panel mounted between ChildItems and the timeline — reading order is *this item → its children → who mentions it → activity stream*.
- New `Backlink` TS type at `web/src/lib/types/index.ts`; new `api.items.backlinks(ws, slug, opts)` client method.

**CLI**
- `pad item show <ref>` enriched with inline top-5 "Mentioned in" section (TTY mode, skipped when empty). Hint at `pad item backlinks <ref>` when the inline list hits the 5-row cap.
- JSON output gets an additive `backlinks_top` field — existing fields unchanged; consumers that don't know about it ignore it gracefully.

**MCP**
- New `pad_item.action: backlinks` — passes through to `pad item backlinks <ref>` with optional `limit` (default 50, max 300) + `offset` params.
- `ToolSurfaceVersion` bumped 0.5 → 0.6 with an additive note in `version.go`. Backwards-compatible for v0.5 consumers that don't enumerate the new action.
- Updated `catalog_readonly_test` fixtures so the cmdhelp drift check passes.

## Test plan

- [x] `go build ./...` + `go test ./internal/mcp/` green
- [x] `make check` (lint + Go + web) green (0 errors)
- [x] `make install` + restart
- [x] `pad item show TASK-1596` renders `--- Mentioned in ---` inline
- [x] `pad item show TASK-1596 --format json` includes `backlinks_top` array
- [x] svelte-check 0 errors
- [ ] CI green
- [ ] `/codex review --loop` → CLEAN

## Behavior notes

- The panel uses `source_ref` as the URL slug segment (Pad routes accept both refs and slugs at the item layer).
- Cross-workspace rows use `source_workspace_slug` to build the URL prefix; faint `→ workspace-slug` text surfaces the foreign origin so users notice before clicking.
- Empty display overrides are hidden (`[[X|]]` distinct from `[[X]]` is preserved in storage but not visualized in the panel — it's renderer noise).
- Snippet rendered verbatim; `[[...]]` bracket syntax left intact so users see what the source actually wrote.

## Out of scope

- Force-directed graph visualization of the link network (filed as separate IDEA if anyone asks)
- Broken-links report (target_item_id IS NULL feeds it but is its own feature)

PLAN-1593 / TASK-1596.