### PR TITLE
fix(share): guard nil grants/share-link slices in ShareDialog (BUG-1598)

### DIFF
--- a/internal/server/handlers_grants.go
+++ b/internal/server/handlers_grants.go
@@ -34,6 +34,9 @@ func (s *Server) handleListCollectionGrants(w http.ResponseWriter, r *http.Reque
 		writeInternalError(w, err)
 		return
 	}
+	if grants == nil {
+		grants = []models.CollectionGrant{}
+	}
 	writeJSON(w, http.StatusOK, grants)
 }
 
@@ -146,6 +149,9 @@ func (s *Server) handleListItemGrants(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		writeInternalError(w, err)
 		return
+	}
+	if grants == nil {
+		grants = []models.ItemGrant{}
 	}
 	writeJSON(w, http.StatusOK, grants)
 }

--- a/web/src/lib/components/ShareDialog.svelte
+++ b/web/src/lib/components/ShareDialog.svelte
@@ -54,9 +54,9 @@
 		loadError = '';
 		try {
 			if (type === 'collection') {
-				grants = await api.grants.listCollectionGrants(wsSlug, targetSlug);
+				grants = (await api.grants.listCollectionGrants(wsSlug, targetSlug)) ?? [];
 			} else {
-				grants = await api.grants.listItemGrants(wsSlug, targetSlug);
+				grants = (await api.grants.listItemGrants(wsSlug, targetSlug)) ?? [];
 			}
 		} catch (e: any) {
 			loadError = e.message ?? 'Failed to load grants';
@@ -71,9 +71,9 @@
 		linksError = '';
 		try {
 			if (type === 'collection') {
-				shareLinks = await api.shareLinks.listCollectionShareLinks(wsSlug, targetSlug);
+				shareLinks = (await api.shareLinks.listCollectionShareLinks(wsSlug, targetSlug)) ?? [];
 			} else {
-				shareLinks = await api.shareLinks.listItemShareLinks(wsSlug, targetSlug);
+				shareLinks = (await api.shareLinks.listItemShareLinks(wsSlug, targetSlug)) ?? [];
 			}
 		} catch (e: any) {
 			linksError = e.message ?? 'Failed to load share links';


### PR DESCRIPTION
## Summary
- Clicking Share on any item/collection with zero existing grants threw `Uncaught TypeError: Cannot read properties of null (reading 'length')` — `Store.ListCollectionGrants` / `ListItemGrants` return a nil slice on no rows, `writeJSON` encoded that as JSON `null`, and `ShareDialog.svelte`'s `{:else if grants.length === 0}` then threw on the null assignment.
- Server fix: nil-to-`[]{}` guards in `handleListCollectionGrants` and `handleListItemGrants`, mirroring the existing pattern in `handlers_share_links.go`.
- Client belt: defensive `?? []` in `loadGrants()` and `loadShareLinks()` so a null body can't reach `.length` checks even if a future handler regresses.

Tracking: BUG-1598.

## Test plan
- [x] `make check` (golangci-lint + `go test ./...` + `web npm run build`) — 0 errors
- [x] `make install` — clean build, server restarted
- [x] Codex review (`/codex review --loop`) — CLEAN on round 1
- [ ] Manual smoke: open Share on an item/collection that has never been shared — dialog renders "No one has been granted access yet." and "No share links yet." without console errors