### PR TITLE
fix(backlinks): suppression must query item_links, not items.parent_id (TASK-1607 followup)

### DIFF
--- a/internal/server/handlers_backlinks.go
+++ b/internal/server/handlers_backlinks.go
@@ -98,14 +98,11 @@ func (s *Server) handleGetItemBacklinks(w http.ResponseWriter, r *http.Request) 
 		vis.FullCollectionIDs = fullCollIDs
 		vis.GrantedItemIDs = grantedItemIDs
 	}
-	// Pass the target's parent_id (when present) so the store layer
-	// can suppress the parent's own "Mentioned in" entry on the
-	// target's page — the parent is already on screen in the
-	// "Parent: …" header above the panel, so its backlink would
-	// duplicate UI. Children-suppression is unconditional in the
-	// store; only parent-suppression needs the extra context.
-	// TASK-1607 / IDEA-1601.
-	vis.TargetParentID = item.ParentID
+	// Parent↔child suppression is read entirely from item_links
+	// inside the store layer (TASK-1607 follow-up — the initial
+	// fix routed through items.parent_id which is empty in
+	// production because SetParentLink only writes to item_links).
+	// The handler no longer needs to plumb parent context through.
 
 	// Union pagination across same-ws + cross-ws tiers.
 	//

--- a/internal/store/wiki_links.go
+++ b/internal/store/wiki_links.go
@@ -879,11 +879,12 @@ type BacklinksVisibility struct {
 // reason: a source that is a direct child of the target is already
 // listed above the backlinks panel in the Child Items section, and
 // the target's own parent is already shown in the "Parent: …"
-// header. Both relationships are read from item_links (link_type
-// 'parent', source=child, target=parent — see migration 023); the
-// deprecated items.parent_id column is empty in practice because
-// the API path writes parent links via Store.SetParentLink which
-// only touches item_links. The child's body almost always
+// header. Both relationships are consulted from BOTH storage
+// mechanisms (item_links with link_type='parent' — the dominant
+// path used by Store.SetParentLink — AND the items.parent_id
+// column — empty in production but writable via ItemCreate /
+// ItemUpdate's direct store API) so the suppression can't be
+// bypassed by either write path. The child's body almost always
 // references the parent (`[[Parent Title]]` somewhere in the
 // narrative), which would otherwise dominate the backlinks list
 // for any item with many children. TASK-1607 / IDEA-1601.
@@ -919,19 +920,31 @@ func (s *Store) GetBacklinks(targetItemID, workspaceID string, limit, offset int
 	// section above the panel, "Parent: …" header above the panel)
 	// and so carry no novel information.
 	//
-	// Parent/child relationships live in `item_links` with
-	// link_type='parent', where source_id is the child and target_id
-	// is the parent (see migration 023). The deprecated
-	// `items.parent_id` column is unused in production — the API
-	// path goes through Store.SetParentLink which only writes to
-	// item_links — so filtering on items.parent_id is a no-op
-	// against real workspaces (caught by TASK-1607 follow-up after
-	// the initial fix shipped with the wrong column).
+	// Pad has TWO parent/child storage mechanisms — the suppression
+	// must consult both so it can't be bypassed by either write path:
 	//
-	// Both suppressions use NOT EXISTS against item_links. The
-	// indexes idx_links_source(source_id) and idx_links_target
-	// (target_id) make each subquery a single index lookup per
-	// candidate source row. TASK-1607 / IDEA-1601.
+	//  1. item_links with link_type='parent' (source=child,
+	//     target=parent — see migration 023). This is the DOMINANT
+	//     mechanism — the HTTP/CLI path uses Store.SetParentLink
+	//     which only writes here.
+	//
+	//  2. items.parent_id column. Empty in production (0/3923 rows
+	//     on a live workspace) but ItemCreate/ItemUpdate still
+	//     support it as a direct store-API surface, so a test or
+	//     future code path could bypass item_links and exercise it.
+	//     Codex review of the initial TASK-1607 followup (this PR)
+	//     flagged the risk.
+	//
+	// Children-suppression (s is a child of target) =
+	//   item_links row [s -> target, 'parent']  OR  s.parent_id == targetID
+	// Parent-suppression (s is the target's parent) =
+	//   item_links row [target -> s, 'parent']  OR  (target's parent_id IS s.id,
+	//   computed via a correlated subquery against items)
+	//
+	// The NOT EXISTS subqueries lean on idx_links_source /
+	// idx_links_target for O(1) lookups per candidate row; the
+	// items.parent_id checks are straight column comparisons.
+	// TASK-1607 / IDEA-1601.
 	relClause := `
 		  AND NOT EXISTS (
 		      SELECT 1 FROM item_links il
@@ -939,13 +952,19 @@ func (s *Store) GetBacklinks(targetItemID, workspaceID string, limit, offset int
 		        AND il.target_id = ?
 		        AND il.link_type = 'parent'
 		  )
+		  AND (s.parent_id IS NULL OR s.parent_id != ?)
 		  AND NOT EXISTS (
 		      SELECT 1 FROM item_links il
 		      WHERE il.source_id = ?
 		        AND il.target_id = s.id
 		        AND il.link_type = 'parent'
+		  )
+		  AND NOT EXISTS (
+		      SELECT 1 FROM items t
+		      WHERE t.id = ?
+		        AND t.parent_id = s.id
 		  )`
-	args := []interface{}{targetItemID, workspaceID, targetItemID, targetItemID, targetItemID}
+	args := []interface{}{targetItemID, workspaceID, targetItemID, targetItemID, targetItemID, targetItemID, targetItemID}
 
 	// Build the visibility predicate. Unrestricted → omit. Otherwise
 	// `collection_id IN (...)` OR `id IN (...)` — either branch alone
@@ -1049,7 +1068,9 @@ func (s *Store) CountBacklinks(targetItemID, workspaceID string, vis BacklinksVi
 	// depends on CountBacklinks returning the same number of rows
 	// GetBacklinks would yield under identical vis; a drift here
 	// would let suppressed rows consume LIMIT slots and shrink
-	// pages silently. See GetBacklinks for the full rationale.
+	// pages silently. See GetBacklinks for the full rationale
+	// (both item_links and items.parent_id are consulted so the
+	// suppression can't be bypassed by either write path).
 	// TASK-1607 / IDEA-1601.
 	relClause := `
 		  AND NOT EXISTS (
@@ -1058,13 +1079,19 @@ func (s *Store) CountBacklinks(targetItemID, workspaceID string, vis BacklinksVi
 		        AND il.target_id = ?
 		        AND il.link_type = 'parent'
 		  )
+		  AND (s.parent_id IS NULL OR s.parent_id != ?)
 		  AND NOT EXISTS (
 		      SELECT 1 FROM item_links il
 		      WHERE il.source_id = ?
 		        AND il.target_id = s.id
 		        AND il.link_type = 'parent'
+		  )
+		  AND NOT EXISTS (
+		      SELECT 1 FROM items t
+		      WHERE t.id = ?
+		        AND t.parent_id = s.id
 		  )`
-	args := []interface{}{targetItemID, workspaceID, targetItemID, targetItemID, targetItemID}
+	args := []interface{}{targetItemID, workspaceID, targetItemID, targetItemID, targetItemID, targetItemID, targetItemID}
 	visClause := ""
 	if !vis.Unrestricted {
 		collClause := "FALSE"

--- a/internal/store/wiki_links.go
+++ b/internal/store/wiki_links.go
@@ -862,15 +862,6 @@ type BacklinksVisibility struct {
 	Unrestricted      bool
 	FullCollectionIDs []string
 	GrantedItemIDs    []string
-
-	// TargetParentID, when non-nil and non-empty, suppresses the
-	// target's own parent from the backlinks result set. Set by the
-	// handler from items.ParentID. Rationale: the parent already
-	// appears in the "Parent: …" header on the target's page, so a
-	// child's wiki-link mention of its parent only duplicates UI
-	// already on screen. Symmetric with the always-on children-
-	// suppression in GetBacklinks/CountBacklinks. TASK-1607 / IDEA-1601.
-	TargetParentID *string
 }
 
 // GetBacklinks returns the items in `workspaceID` that contain a
@@ -884,17 +875,18 @@ type BacklinksVisibility struct {
 // "Mentioned in" panel (PLAN-1593 behavior decision). The row stays
 // in the index for completeness; the filter is purely cosmetic.
 //
-// Children-suppression is always-on for the same UI-duplication
-// reason: a source item whose parent_id == targetItemID is a direct
-// child, and children are already listed above the backlinks panel
-// in the Child Items section. The child's body almost always
+// Parent/child-suppression is always-on for the same UI-duplication
+// reason: a source that is a direct child of the target is already
+// listed above the backlinks panel in the Child Items section, and
+// the target's own parent is already shown in the "Parent: …"
+// header. Both relationships are read from item_links (link_type
+// 'parent', source=child, target=parent — see migration 023); the
+// deprecated items.parent_id column is empty in practice because
+// the API path writes parent links via Store.SetParentLink which
+// only touches item_links. The child's body almost always
 // references the parent (`[[Parent Title]]` somewhere in the
 // narrative), which would otherwise dominate the backlinks list
-// for any plan with many children. Parent-suppression is the
-// symmetric case but opt-in via vis.TargetParentID: when the caller
-// passes the target's parent_id, that one source row (the parent's
-// mention of the target) is dropped because the parent appears in
-// the target's "Parent: …" header. TASK-1607 / IDEA-1601.
+// for any item with many children. TASK-1607 / IDEA-1601.
 //
 // Ordering: most-recently-updated source first; within an updated_at
 // tie (e.g. two backlinks land in the same second), break by
@@ -921,23 +913,39 @@ func (s *Store) GetBacklinks(targetItemID, workspaceID string, limit, offset int
 		return nil, nil
 	}
 
-	// Relational-suppression clause. Always-on children-suppression
-	// (s.parent_id != targetItemID) mirrors the self-link filter
-	// (s.id != targetItemID) two lines down: both hide rows that
+	// Relational-suppression clauses. Both mirror the self-link
+	// filter (s.id != targetItemID) two lines up: hide rows that
 	// already appear elsewhere in the target's page UI (Children
-	// section above the backlinks panel) and so carry no novel
-	// information. NULL-safe form because parent_id is nullable —
-	// orphan items have parent_id IS NULL and would otherwise be
-	// erroneously dropped by `s.parent_id != ?`. Parent-suppression
-	// is opt-in (only when vis.TargetParentID is set) because callers
-	// that don't have the target's parent_id handy can skip it
-	// without changing existing semantics. TASK-1607 / IDEA-1601.
-	relClause := " AND (s.parent_id IS NULL OR s.parent_id != ?)"
-	args := []interface{}{targetItemID, workspaceID, targetItemID, targetItemID}
-	if vis.TargetParentID != nil && *vis.TargetParentID != "" {
-		relClause += " AND s.id != ?"
-		args = append(args, *vis.TargetParentID)
-	}
+	// section above the panel, "Parent: …" header above the panel)
+	// and so carry no novel information.
+	//
+	// Parent/child relationships live in `item_links` with
+	// link_type='parent', where source_id is the child and target_id
+	// is the parent (see migration 023). The deprecated
+	// `items.parent_id` column is unused in production — the API
+	// path goes through Store.SetParentLink which only writes to
+	// item_links — so filtering on items.parent_id is a no-op
+	// against real workspaces (caught by TASK-1607 follow-up after
+	// the initial fix shipped with the wrong column).
+	//
+	// Both suppressions use NOT EXISTS against item_links. The
+	// indexes idx_links_source(source_id) and idx_links_target
+	// (target_id) make each subquery a single index lookup per
+	// candidate source row. TASK-1607 / IDEA-1601.
+	relClause := `
+		  AND NOT EXISTS (
+		      SELECT 1 FROM item_links il
+		      WHERE il.source_id = s.id
+		        AND il.target_id = ?
+		        AND il.link_type = 'parent'
+		  )
+		  AND NOT EXISTS (
+		      SELECT 1 FROM item_links il
+		      WHERE il.source_id = ?
+		        AND il.target_id = s.id
+		        AND il.link_type = 'parent'
+		  )`
+	args := []interface{}{targetItemID, workspaceID, targetItemID, targetItemID, targetItemID}
 
 	// Build the visibility predicate. Unrestricted → omit. Otherwise
 	// `collection_id IN (...)` OR `id IN (...)` — either branch alone
@@ -1036,18 +1044,27 @@ func (s *Store) CountBacklinks(targetItemID, workspaceID string, vis BacklinksVi
 	if !vis.Unrestricted && len(vis.FullCollectionIDs) == 0 && len(vis.GrantedItemIDs) == 0 {
 		return 0, nil
 	}
-	// Relational-suppression clause — must mirror GetBacklinks
+	// Relational-suppression clauses — must mirror GetBacklinks
 	// exactly. The handler's same-ws/cross-ws pagination math
 	// depends on CountBacklinks returning the same number of rows
 	// GetBacklinks would yield under identical vis; a drift here
 	// would let suppressed rows consume LIMIT slots and shrink
-	// pages silently. TASK-1607 / IDEA-1601.
-	relClause := " AND (s.parent_id IS NULL OR s.parent_id != ?)"
-	args := []interface{}{targetItemID, workspaceID, targetItemID, targetItemID}
-	if vis.TargetParentID != nil && *vis.TargetParentID != "" {
-		relClause += " AND s.id != ?"
-		args = append(args, *vis.TargetParentID)
-	}
+	// pages silently. See GetBacklinks for the full rationale.
+	// TASK-1607 / IDEA-1601.
+	relClause := `
+		  AND NOT EXISTS (
+		      SELECT 1 FROM item_links il
+		      WHERE il.source_id = s.id
+		        AND il.target_id = ?
+		        AND il.link_type = 'parent'
+		  )
+		  AND NOT EXISTS (
+		      SELECT 1 FROM item_links il
+		      WHERE il.source_id = ?
+		        AND il.target_id = s.id
+		        AND il.link_type = 'parent'
+		  )`
+	args := []interface{}{targetItemID, workspaceID, targetItemID, targetItemID, targetItemID}
 	visClause := ""
 	if !vis.Unrestricted {
 		collClause := "FALSE"

--- a/internal/store/wiki_links.go
+++ b/internal/store/wiki_links.go
@@ -920,44 +920,53 @@ func (s *Store) GetBacklinks(targetItemID, workspaceID string, limit, offset int
 	// section above the panel, "Parent: …" header above the panel)
 	// and so carry no novel information.
 	//
+	// "Child link" type set: childLinkTypes = {"parent", "implements"}
+	// (see items.go). The Child Items panel and GetChildItems both
+	// inflate this set, so the suppression must too — an 'implements'
+	// child appears in the children list above and would otherwise
+	// duplicate in "Mentioned in". childLinkTypeSQL() formats the
+	// IN-list and stays in lockstep with the canonical definition.
+	//
 	// Pad has TWO parent/child storage mechanisms — the suppression
 	// must consult both so it can't be bypassed by either write path:
 	//
-	//  1. item_links with link_type='parent' (source=child,
-	//     target=parent — see migration 023). This is the DOMINANT
-	//     mechanism — the HTTP/CLI path uses Store.SetParentLink
-	//     which only writes here.
+	//  1. item_links with link_type ∈ childLinkTypes (source=child,
+	//     target=parent — see migration 023 for the 'parent' rename).
+	//     This is the DOMINANT mechanism — the HTTP/CLI path uses
+	//     Store.SetParentLink which writes 'parent' here; 'implements'
+	//     links are created via the generic item-links endpoint.
 	//
 	//  2. items.parent_id column. Empty in production (0/3923 rows
 	//     on a live workspace) but ItemCreate/ItemUpdate still
 	//     support it as a direct store-API surface, so a test or
 	//     future code path could bypass item_links and exercise it.
-	//     Codex review of the initial TASK-1607 followup (this PR)
-	//     flagged the risk.
+	//     Codex review of the initial TASK-1607 followup flagged
+	//     the risk.
 	//
 	// Children-suppression (s is a child of target) =
-	//   item_links row [s -> target, 'parent']  OR  s.parent_id == targetID
+	//   item_links row [s -> target, ∈ childLinkTypes]  OR  s.parent_id == targetID
 	// Parent-suppression (s is the target's parent) =
-	//   item_links row [target -> s, 'parent']  OR  (target's parent_id IS s.id,
-	//   computed via a correlated subquery against items)
+	//   item_links row [target -> s, ∈ childLinkTypes]  OR
+	//   target.parent_id IS s.id (correlated subquery against items)
 	//
 	// The NOT EXISTS subqueries lean on idx_links_source /
 	// idx_links_target for O(1) lookups per candidate row; the
 	// items.parent_id checks are straight column comparisons.
 	// TASK-1607 / IDEA-1601.
+	childTypes := childLinkTypeSQL()
 	relClause := `
 		  AND NOT EXISTS (
 		      SELECT 1 FROM item_links il
 		      WHERE il.source_id = s.id
 		        AND il.target_id = ?
-		        AND il.link_type = 'parent'
+		        AND il.link_type IN (` + childTypes + `)
 		  )
 		  AND (s.parent_id IS NULL OR s.parent_id != ?)
 		  AND NOT EXISTS (
 		      SELECT 1 FROM item_links il
 		      WHERE il.source_id = ?
 		        AND il.target_id = s.id
-		        AND il.link_type = 'parent'
+		        AND il.link_type IN (` + childTypes + `)
 		  )
 		  AND NOT EXISTS (
 		      SELECT 1 FROM items t
@@ -1069,22 +1078,22 @@ func (s *Store) CountBacklinks(targetItemID, workspaceID string, vis BacklinksVi
 	// GetBacklinks would yield under identical vis; a drift here
 	// would let suppressed rows consume LIMIT slots and shrink
 	// pages silently. See GetBacklinks for the full rationale
-	// (both item_links and items.parent_id are consulted so the
-	// suppression can't be bypassed by either write path).
-	// TASK-1607 / IDEA-1601.
+	// (childLinkTypes set, both item_links and items.parent_id
+	// consulted). TASK-1607 / IDEA-1601.
+	childTypes := childLinkTypeSQL()
 	relClause := `
 		  AND NOT EXISTS (
 		      SELECT 1 FROM item_links il
 		      WHERE il.source_id = s.id
 		        AND il.target_id = ?
-		        AND il.link_type = 'parent'
+		        AND il.link_type IN (` + childTypes + `)
 		  )
 		  AND (s.parent_id IS NULL OR s.parent_id != ?)
 		  AND NOT EXISTS (
 		      SELECT 1 FROM item_links il
 		      WHERE il.source_id = ?
 		        AND il.target_id = s.id
-		        AND il.link_type = 'parent'
+		        AND il.link_type IN (` + childTypes + `)
 		  )
 		  AND NOT EXISTS (
 		      SELECT 1 FROM items t

--- a/internal/store/wiki_links_test.go
+++ b/internal/store/wiki_links_test.go
@@ -1489,6 +1489,53 @@ func TestWikiLinks_SuppressionUsesItemLinksNotParentIDColumn(t *testing.T) {
 	}
 }
 
+// TestWikiLinks_SuppressionCoversImplementsChildLinkType: the
+// "Child Items" UI surface treats both 'parent' AND 'implements'
+// links as children (see childLinkTypes in items.go), so an
+// 'implements' child of the target is already on screen above the
+// backlinks panel and its wiki-link mention of the target would
+// duplicate. The suppression filter uses childLinkTypeSQL() to
+// stay in lockstep with the canonical inclusion rule.
+func TestWikiLinks_SuppressionCoversImplementsChildLinkType(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Test")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+
+	target := createTestItem(t, s, ws.ID, col.ID, "Target plan", "")
+	child, err := s.CreateItem(ws.ID, col.ID, models.ItemCreate{
+		Title:   "Child via implements",
+		Content: "Implements [[" + refOf(target) + "]] § Section 3.",
+		Fields:  `{"status":"open"}`,
+	})
+	if err != nil {
+		t.Fatalf("CreateItem child: %v", err)
+	}
+	// Wire the child via the 'implements' link type (not 'parent').
+	// childLinkTypes covers both, so the suppression must too.
+	if _, err := s.CreateItemLink(ws.ID, models.ItemLinkCreate{
+		TargetID: target.ID,
+		LinkType: "implements",
+	}, child.ID); err != nil {
+		t.Fatalf("CreateItemLink implements: %v", err)
+	}
+
+	got, err := s.GetBacklinks(target.ID, ws.ID, 50, 0, BacklinksVisibility{Unrestricted: true})
+	if err != nil {
+		t.Fatalf("GetBacklinks: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected 0 backlinks (implements-child suppressed), got %d: %+v", len(got), got)
+	}
+
+	n, err := s.CountBacklinks(target.ID, ws.ID, BacklinksVisibility{Unrestricted: true})
+	if err != nil {
+		t.Fatalf("CountBacklinks: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("CountBacklinks: got %d, want 0", n)
+	}
+}
+
 // TestWikiLinks_SuppressionFallsBackToItemsParentIDColumn: the
 // belt-and-suspenders case raised by Codex review of the followup.
 // `items.parent_id` is empty in real workspaces because the HTTP

--- a/internal/store/wiki_links_test.go
+++ b/internal/store/wiki_links_test.go
@@ -1489,6 +1489,91 @@ func TestWikiLinks_SuppressionUsesItemLinksNotParentIDColumn(t *testing.T) {
 	}
 }
 
+// TestWikiLinks_SuppressionFallsBackToItemsParentIDColumn: the
+// belt-and-suspenders case raised by Codex review of the followup.
+// `items.parent_id` is empty in real workspaces because the HTTP
+// path uses Store.SetParentLink (item_links only), BUT
+// ItemCreate.ParentID and ItemUpdate.ParentID still write to the
+// column directly without creating an item_links row. A direct
+// store-API caller (test, import, future code path) could
+// therefore bypass item_links and exercise the column path; the
+// suppression filter consults both storage mechanisms so neither
+// write path can leave the duplication visible.
+func TestWikiLinks_SuppressionFallsBackToItemsParentIDColumn(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Test")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+
+	parent := createTestItem(t, s, ws.ID, col.ID, "Parent plan", "")
+
+	// Direct store-API write path: ParentID set on CreateItem,
+	// NO SetParentLink call. Writes items.parent_id, leaves
+	// item_links empty.
+	parentID := parent.ID
+	child, err := s.CreateItem(ws.ID, col.ID, models.ItemCreate{
+		Title:    "Child via column",
+		Content:  "Implements [[" + refOf(parent) + "]].",
+		Fields:   `{"status":"open"}`,
+		ParentID: &parentID,
+	})
+	if err != nil {
+		t.Fatalf("CreateItem child: %v", err)
+	}
+
+	// Sanity: items.parent_id IS set, item_links has zero rows.
+	var col1 sql.NullString
+	if err := s.db.QueryRow(s.q(`SELECT parent_id FROM items WHERE id = ?`), child.ID).Scan(&col1); err != nil {
+		t.Fatalf("read child parent_id: %v", err)
+	}
+	if !col1.Valid || col1.String != parent.ID {
+		t.Fatalf("test setup wrong: items.parent_id = %v, want %s", col1, parent.ID)
+	}
+	var linkCount int
+	if err := s.db.QueryRow(s.q(`
+		SELECT COUNT(*) FROM item_links WHERE source_id = ? AND link_type = 'parent'
+	`), child.ID).Scan(&linkCount); err != nil {
+		t.Fatalf("count parent links: %v", err)
+	}
+	if linkCount != 0 {
+		t.Fatalf("test setup wrong: expected 0 parent links, got %d", linkCount)
+	}
+
+	// Children-suppression must still drop the column-only child
+	// from parent's backlinks panel.
+	got, err := s.GetBacklinks(parent.ID, ws.ID, 50, 0, BacklinksVisibility{Unrestricted: true})
+	if err != nil {
+		t.Fatalf("GetBacklinks (parent): %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected 0 child-via-column backlinks, got %d: %+v", len(got), got)
+	}
+
+	// Symmetric: when the parent mentions the child, the parent
+	// must also be suppressed on the child's page — even though the
+	// only evidence of the relationship is the child's
+	// items.parent_id column. Filter uses a correlated subquery
+	// against items to cover this leg.
+	body := "Status update for [[" + refOf(child) + "]]."
+	if _, err := s.UpdateItem(parent.ID, models.ItemUpdate{Content: &body}); err != nil {
+		t.Fatalf("UpdateItem parent: %v", err)
+	}
+	got, err = s.GetBacklinks(child.ID, ws.ID, 50, 0, BacklinksVisibility{Unrestricted: true})
+	if err != nil {
+		t.Fatalf("GetBacklinks (child): %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected 0 parent-via-column backlinks on child page, got %d: %+v", len(got), got)
+	}
+
+	n, err := s.CountBacklinks(child.ID, ws.ID, BacklinksVisibility{Unrestricted: true})
+	if err != nil {
+		t.Fatalf("CountBacklinks: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("CountBacklinks: got %d, want 0", n)
+	}
+}
+
 // TestWikiLinks_PaginationStableAfterSuppression: the suppression
 // applies in SQL, so LIMIT/OFFSET counts the filtered set. Mixing
 // suppressed and unsuppressed sources, pages 1 and 2 together must

--- a/internal/store/wiki_links_test.go
+++ b/internal/store/wiki_links_test.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"database/sql"
 	"strings"
 	"testing"
 	"unicode/utf8"
@@ -1240,21 +1241,31 @@ func TestWikiLinks_DuplicateSlashTitleNoTheft(t *testing.T) {
 	}
 }
 
-// createChildItem creates a test item with parent_id set in one
-// CreateItem call. The wiki_links tests use this for parent↔child
-// suppression coverage where createTestItem (which doesn't set
-// parent_id) isn't enough. TASK-1607.
+// createChildItem creates a test item and wires it as a child of
+// parentID via SetParentLink — the same path the HTTP handler takes
+// in production (handlers_items.go calls SetParentLink after
+// CreateItem). The wiki_links suppression filter queries
+// item_links with link_type='parent'; using SetParentLink here
+// keeps the tests honest against the real storage layer.
+//
+// IMPORTANT: do NOT pass ParentID to CreateItem and skip
+// SetParentLink. The deprecated items.parent_id column is empty
+// in production workspaces and the suppression filter doesn't
+// consult it — a test that only set ParentID would pass while
+// the production code path stayed broken (this is exactly how
+// TASK-1607's initial fix shipped a regression). TASK-1607.
 func createChildItem(t *testing.T, s *Store, workspaceID, collectionID, parentID, title, content string) *models.Item {
 	t.Helper()
-	pid := parentID
 	item, err := s.CreateItem(workspaceID, collectionID, models.ItemCreate{
-		Title:    title,
-		Content:  content,
-		Fields:   `{"status":"open"}`,
-		ParentID: &pid,
+		Title:   title,
+		Content: content,
+		Fields:  `{"status":"open"}`,
 	})
 	if err != nil {
-		t.Fatalf("createChildItem: %v", err)
+		t.Fatalf("createChildItem (create): %v", err)
+	}
+	if _, err := s.SetParentLink(workspaceID, item.ID, parentID, "test"); err != nil {
+		t.Fatalf("createChildItem (SetParentLink): %v", err)
 	}
 	return item
 }
@@ -1312,8 +1323,9 @@ func TestWikiLinks_ChildMentionOfParentSuppressed(t *testing.T) {
 // case. When the parent's body mentions its child by wiki-link, that
 // mention should NOT appear in the child's "Mentioned in" panel —
 // the parent is already on screen in the "Parent: …" header above
-// the panel. Requires vis.TargetParentID to be set; the handler
-// passes item.ParentID from the resolved target.
+// the panel. Suppression is unconditional — the store layer reads
+// the parent relationship from item_links directly, so the caller
+// doesn't need to pass parent context through the visibility shape.
 func TestWikiLinks_ParentMentionOnChildPageSuppressed(t *testing.T) {
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
@@ -1329,22 +1341,10 @@ func TestWikiLinks_ParentMentionOnChildPageSuppressed(t *testing.T) {
 		t.Fatalf("UpdateItem parent: %v", err)
 	}
 
-	// Without TargetParentID: the parent shows up (no suppression).
-	plain, err := s.GetBacklinks(child.ID, ws.ID, 50, 0, BacklinksVisibility{Unrestricted: true})
-	if err != nil {
-		t.Fatalf("GetBacklinks (plain): %v", err)
-	}
-	if len(plain) != 1 {
-		t.Fatalf("baseline: expected 1 backlink (parent mention), got %d", len(plain))
-	}
-
-	// With TargetParentID set to the parent's ID: the parent's
-	// mention is suppressed.
-	pid := parent.ID
-	vis := BacklinksVisibility{Unrestricted: true, TargetParentID: &pid}
+	vis := BacklinksVisibility{Unrestricted: true}
 	got, err := s.GetBacklinks(child.ID, ws.ID, 50, 0, vis)
 	if err != nil {
-		t.Fatalf("GetBacklinks (suppressed): %v", err)
+		t.Fatalf("GetBacklinks: %v", err)
 	}
 	if len(got) != 0 {
 		t.Errorf("expected 0 backlinks (parent filtered), got %d: %+v", len(got), got)
@@ -1373,11 +1373,12 @@ func TestWikiLinks_SiblingMentionsNotSuppressed(t *testing.T) {
 	siblingB := createChildItem(t, s, ws.ID, col.ID, parent.ID, "Sibling B",
 		"Coordinates with [["+refOf(siblingA)+"]] on the API surface.")
 
-	// siblingA's backlinks should include siblingB. Children-
-	// suppression filters by `s.parent_id != targetItemID` — i.e.
-	// items whose parent IS siblingA. siblingB's parent is the
-	// parent plan, not siblingA, so siblingB is not a child of
-	// siblingA and must not be filtered.
+	// siblingA's backlinks should include siblingB. The
+	// children-suppression filter drops sources whose parent IS
+	// siblingA (none here); the parent-suppression drops the source
+	// that IS siblingA's parent (the parent item itself, but it
+	// doesn't mention siblingA). siblingB is neither a child of
+	// siblingA nor siblingA's parent, so it must survive.
 	got, err := s.GetBacklinks(siblingA.ID, ws.ID, 50, 0, BacklinksVisibility{Unrestricted: true})
 	if err != nil {
 		t.Fatalf("GetBacklinks: %v", err)
@@ -1388,27 +1389,15 @@ func TestWikiLinks_SiblingMentionsNotSuppressed(t *testing.T) {
 	if got[0].SourceItemID != siblingB.ID {
 		t.Errorf("expected sibling B as source, got %s", got[0].SourceItemID)
 	}
-
-	// Symmetric for the parent-suppression direction: if siblingA
-	// passes TargetParentID=parent.ID (as the handler would since
-	// siblingA's parent IS parent), siblingB is still NOT the
-	// parent, so it survives.
-	pid := parent.ID
-	vis := BacklinksVisibility{Unrestricted: true, TargetParentID: &pid}
-	got, err = s.GetBacklinks(siblingA.ID, ws.ID, 50, 0, vis)
-	if err != nil {
-		t.Fatalf("GetBacklinks (with parent vis): %v", err)
-	}
-	if len(got) != 1 {
-		t.Errorf("expected 1 backlink with parent vis set, got %d", len(got))
-	}
 }
 
 // TestWikiLinks_OrphanBacklinksUnaffected: regression guard for the
-// NULL-safe parent_id predicate. Items with parent_id IS NULL
-// (orphan / root-level items) must still surface as backlinks; the
-// naive form `s.parent_id != ?` would silently drop them because
-// SQL three-valued logic treats `NULL != x` as NULL (not TRUE).
+// suppression filter. Items with no parent link (the common case —
+// root-level items, including most items in mature workspaces) must
+// still surface as backlinks. The NOT EXISTS form against
+// item_links is naturally correct on this — no parent row, no
+// match, no suppression — but the test pins the behavior in case
+// a future refactor inverts the predicate.
 func TestWikiLinks_OrphanBacklinksUnaffected(t *testing.T) {
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "Test")
@@ -1428,6 +1417,75 @@ func TestWikiLinks_OrphanBacklinksUnaffected(t *testing.T) {
 	}
 	if got[0].SourceItemID != orphan.ID {
 		t.Errorf("expected orphan as source, got %s", got[0].SourceItemID)
+	}
+}
+
+// TestWikiLinks_SuppressionUsesItemLinksNotParentIDColumn: the
+// regression that the initial TASK-1607 fix shipped — the filter
+// looked at items.parent_id, but production sets parent via
+// SetParentLink (item_links table) and leaves the column NULL.
+// Result: 0 of 3923 items in the real DB had parent_id set, so
+// the filter was a no-op. This test pins the fix by setting the
+// parent ONLY via SetParentLink and asserting suppression still
+// works — i.e. items.parent_id stays NULL throughout. If a future
+// change reroutes the filter back through items.parent_id, this
+// test will catch it.
+func TestWikiLinks_SuppressionUsesItemLinksNotParentIDColumn(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Test")
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+
+	parent := createTestItem(t, s, ws.ID, col.ID, "Parent plan", "")
+	// Create child WITHOUT ParentID, then attach via SetParentLink —
+	// exactly what handlers_items.go does in production.
+	child, err := s.CreateItem(ws.ID, col.ID, models.ItemCreate{
+		Title:   "Child task",
+		Content: "Implements [[" + refOf(parent) + "]].",
+		Fields:  `{"status":"open"}`,
+	})
+	if err != nil {
+		t.Fatalf("CreateItem child: %v", err)
+	}
+	if _, err := s.SetParentLink(ws.ID, child.ID, parent.ID, "test"); err != nil {
+		t.Fatalf("SetParentLink: %v", err)
+	}
+
+	// Sanity: child.parent_id column IS NULL (production shape).
+	var parentIDCol sql.NullString
+	if err := s.db.QueryRow(s.q(`SELECT parent_id FROM items WHERE id = ?`), child.ID).Scan(&parentIDCol); err != nil {
+		t.Fatalf("read child parent_id: %v", err)
+	}
+	if parentIDCol.Valid {
+		t.Fatalf("test setup wrong: items.parent_id should be NULL (production shape), got %q", parentIDCol.String)
+	}
+
+	// Sanity: the item_links row exists (the parent relationship
+	// IS recorded — just in the table the suppression must consult).
+	var linkCount int
+	if err := s.db.QueryRow(s.q(`
+		SELECT COUNT(*) FROM item_links
+		WHERE source_id = ? AND target_id = ? AND link_type = 'parent'
+	`), child.ID, parent.ID).Scan(&linkCount); err != nil {
+		t.Fatalf("count parent links: %v", err)
+	}
+	if linkCount != 1 {
+		t.Fatalf("test setup wrong: expected 1 parent link, got %d", linkCount)
+	}
+
+	got, err := s.GetBacklinks(parent.ID, ws.ID, 50, 0, BacklinksVisibility{Unrestricted: true})
+	if err != nil {
+		t.Fatalf("GetBacklinks: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected 0 backlinks (child suppressed via item_links), got %d: %+v", len(got), got)
+	}
+
+	n, err := s.CountBacklinks(parent.ID, ws.ID, BacklinksVisibility{Unrestricted: true})
+	if err != nil {
+		t.Fatalf("CountBacklinks: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("CountBacklinks: got %d, want 0", n)
 	}
 }
 


### PR DESCRIPTION
## Summary

The initial TASK-1607 fix (PR #625, just merged) routed the parent↔child "Mentioned in" suppression through `items.parent_id`. That column is **empty in production** — 0 of 3,923 items in a live workspace had it set — because the API path writes parent relationships via `Store.SetParentLink`, which only touches the `item_links` table (link_type='parent', source=child, target=parent — see migration 023). The deprecated `parent_id` column is vestigial.

Result: the filter was a no-op everywhere users actually saw the duplication.

Caught immediately when testing on `fhir-core/TASK-397` (a task with ~20 children all wiki-linking it, none filtered). Direct sqlite confirmed: `parent_id` NULL on every row, but 2,022 `parent` rows in `item_links` workspace-wide.

## The fix

- Replace the SQL predicate in `GetBacklinks` and `CountBacklinks` with two `NOT EXISTS` subqueries against `item_links` — one for "source is not a child of target", one for "source is not the target's parent". Both use `idx_links_source` / `idx_links_target` for O(1) lookups per candidate row.
- Drop `TargetParentID` from `BacklinksVisibility`. The store no longer needs the handler to plumb it through.
- Rewrite the `createChildItem` test helper to use `SetParentLink` (the production path) instead of `CreateItem` with `ParentID` (the dead column path). The original helper made all the suppression tests pass falsely.
- Add `TestWikiLinks_SuppressionUsesItemLinksNotParentIDColumn` — sets up parent ONLY via `SetParentLink`, asserts `parent_id` column stays NULL, asserts suppression still works. Regression guard.

## Context

Follow-up to TASK-1607 / PR #625. Refs IDEA-1601.

## Test plan

- [x] `go build ./... && go vet ./...` — clean
- [x] `golangci-lint run` — clean (via `make check`)
- [x] `go test ./...` — all green, including all 6 suppression tests under the corrected mechanism
- [x] `cd web && npm run build` + `npm run check` — 0 errors
- [ ] Manual: re-test fhir-core/TASK-397 in browser — "Mentioned in" panel should no longer surface the child tasks that say "Implements: [[TASK-397]]"