### PR TITLE
feat(limits): reduce free-tier workspace cap from 5 to 3 (TASK-1609)

### DIFF
--- a/internal/server/handlers_workspace_cap_test.go
+++ b/internal/server/handlers_workspace_cap_test.go
@@ -1,0 +1,186 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// TestWorkspaceCap_FreeTierAllowsUpToThree verifies that a free-tier user
+// in cloud mode can create exactly 3 workspaces — all three must return 201.
+// TASK-1609: cap reduced from 5 to 3.
+func TestWorkspaceCap_FreeTierAllowsUpToThree(t *testing.T) {
+	srv := testServer(t)
+	srv.SetCloudMode("test-cloud-secret")
+
+	// Bootstrap admin so auth gates open.
+	bootstrapFirstUser(t, srv, "admin@test.com", "Admin")
+
+	// Create a free-tier user.
+	u, err := srv.store.CreateUser(models.UserCreate{
+		Email:    "free@test.com",
+		Name:     "Free User",
+		Password: "correct-horse-battery-staple",
+		Role:     "member",
+	})
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	if err := srv.store.SetUserPlan(u.ID, "free", ""); err != nil {
+		t.Fatalf("SetUserPlan(free): %v", err)
+	}
+	token := loginUser(t, srv, "free@test.com", "correct-horse-battery-staple")
+
+	for i := 1; i <= 3; i++ {
+		rr := doRequestWithCookie(srv, "POST", "/api/v1/workspaces", map[string]string{
+			"name": "Workspace",
+		}, token)
+		if rr.Code != http.StatusCreated {
+			t.Fatalf("workspace %d of 3: expected 201, got %d: %s", i, rr.Code, rr.Body.String())
+		}
+	}
+}
+
+// TestWorkspaceCap_FreeTierBlocksFourth verifies that the 4th workspace
+// creation attempt for a free-tier user in cloud mode returns 403 with
+// error code plan_limit_exceeded. TASK-1609: cap is 3, not 5.
+func TestWorkspaceCap_FreeTierBlocksFourth(t *testing.T) {
+	srv := testServer(t)
+	srv.SetCloudMode("test-cloud-secret")
+
+	bootstrapFirstUser(t, srv, "admin@test.com", "Admin")
+
+	u, err := srv.store.CreateUser(models.UserCreate{
+		Email:    "free@test.com",
+		Name:     "Free User",
+		Password: "correct-horse-battery-staple",
+		Role:     "member",
+	})
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	if err := srv.store.SetUserPlan(u.ID, "free", ""); err != nil {
+		t.Fatalf("SetUserPlan(free): %v", err)
+	}
+	token := loginUser(t, srv, "free@test.com", "correct-horse-battery-staple")
+
+	// Create 3 workspaces (all allowed).
+	for i := 1; i <= 3; i++ {
+		rr := doRequestWithCookie(srv, "POST", "/api/v1/workspaces", map[string]string{
+			"name": "Workspace",
+		}, token)
+		if rr.Code != http.StatusCreated {
+			t.Fatalf("setup workspace %d: expected 201, got %d: %s", i, rr.Code, rr.Body.String())
+		}
+	}
+
+	// 4th attempt must be blocked.
+	rr := doRequestWithCookie(srv, "POST", "/api/v1/workspaces", map[string]string{
+		"name": "Fourth Workspace",
+	}, token)
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("4th workspace: expected 403, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var resp map[string]interface{}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode 403 response: %v", err)
+	}
+	if got, _ := resp["error"].(string); got != "plan_limit_exceeded" {
+		t.Errorf("4th workspace: error=%q, want plan_limit_exceeded", got)
+	}
+	if got, _ := resp["feature"].(string); got != "workspaces" {
+		t.Errorf("4th workspace: feature=%q, want workspaces", got)
+	}
+	// Limit field must report 3 (the new cap), not 5.
+	if got, ok := resp["limit"].(float64); !ok || int(got) != 3 {
+		t.Errorf("4th workspace: limit=%v, want 3", resp["limit"])
+	}
+}
+
+// TestWorkspaceCap_ProTierUnlimited verifies that a pro-tier user in cloud
+// mode can create more than 3 workspaces without being blocked.
+func TestWorkspaceCap_ProTierUnlimited(t *testing.T) {
+	srv := testServer(t)
+	srv.SetCloudMode("test-cloud-secret")
+
+	bootstrapFirstUser(t, srv, "admin@test.com", "Admin")
+
+	u, err := srv.store.CreateUser(models.UserCreate{
+		Email:    "pro@test.com",
+		Name:     "Pro User",
+		Password: "correct-horse-battery-staple",
+		Role:     "member",
+	})
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	if err := srv.store.SetUserPlan(u.ID, "pro", ""); err != nil {
+		t.Fatalf("SetUserPlan(pro): %v", err)
+	}
+	token := loginUser(t, srv, "pro@test.com", "correct-horse-battery-staple")
+
+	// Create 5 workspaces — all must succeed on pro.
+	for i := 1; i <= 5; i++ {
+		rr := doRequestWithCookie(srv, "POST", "/api/v1/workspaces", map[string]string{
+			"name": "Pro Workspace",
+		}, token)
+		if rr.Code != http.StatusCreated {
+			t.Fatalf("pro workspace %d: expected 201, got %d: %s", i, rr.Code, rr.Body.String())
+		}
+	}
+}
+
+// TestWorkspaceCap_SelfHostedNoLimit confirms that without SetCloudMode the
+// workspace cap is not enforced — any number of workspaces can be created.
+func TestWorkspaceCap_SelfHostedNoLimit(t *testing.T) {
+	srv := testServer(t) // no SetCloudMode → self-hosted mode
+	// No auth required when no users exist yet.
+	for i := 1; i <= 5; i++ {
+		rr := doRequest(srv, "POST", "/api/v1/workspaces", map[string]string{
+			"name": "Self-hosted Workspace",
+		})
+		if rr.Code != http.StatusCreated {
+			t.Fatalf("self-hosted workspace %d: expected 201, got %d: %s", i, rr.Code, rr.Body.String())
+		}
+	}
+}
+
+// TestWorkspaceCap_OverrideUnblocks verifies that a per-user plan_overrides
+// entry raising the workspace cap beyond 3 allows a free-tier user to create
+// a 4th workspace in cloud mode.
+func TestWorkspaceCap_OverrideUnblocks(t *testing.T) {
+	srv := testServer(t)
+	srv.SetCloudMode("test-cloud-secret")
+
+	bootstrapFirstUser(t, srv, "admin@test.com", "Admin")
+
+	u, err := srv.store.CreateUser(models.UserCreate{
+		Email:    "override@test.com",
+		Name:     "Override User",
+		Password: "correct-horse-battery-staple",
+		Role:     "member",
+	})
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	if err := srv.store.SetUserPlan(u.ID, "free", ""); err != nil {
+		t.Fatalf("SetUserPlan(free): %v", err)
+	}
+	// Override raises the workspace cap to 10.
+	if err := srv.store.SetUserPlanOverrides(u.ID, `{"workspaces":10}`); err != nil {
+		t.Fatalf("SetUserPlanOverrides: %v", err)
+	}
+	token := loginUser(t, srv, "override@test.com", "correct-horse-battery-staple")
+
+	// Create 4 workspaces — all must succeed because override is 10.
+	for i := 1; i <= 4; i++ {
+		rr := doRequestWithCookie(srv, "POST", "/api/v1/workspaces", map[string]string{
+			"name": "Override Workspace",
+		}, token)
+		if rr.Code != http.StatusCreated {
+			t.Fatalf("override workspace %d: expected 201, got %d: %s", i, rr.Code, rr.Body.String())
+		}
+	}
+}

--- a/internal/store/limits.go
+++ b/internal/store/limits.go
@@ -24,7 +24,7 @@ type PlanLimits struct {
 // DefaultFreeLimits are the hardcoded fallback limits for the free tier.
 // These are used only if the platform_settings table has no stored defaults.
 var DefaultFreeLimits = PlanLimits{
-	Workspaces:          5,
+	Workspaces:          3,
 	ItemsPerWorkspace:   1000,
 	MembersPerWorkspace: 3,
 	APITokens:           10,
@@ -198,6 +198,8 @@ func (s *Store) userFeatureCount(userID, feature string) (int, error) {
 
 	switch feature {
 	case "workspaces":
+		// Note: this count includes soft-deleted workspaces by design — see IDEA-1611
+		// in docapp for the open question on whether this should change post-MVBP.
 		err = s.db.QueryRow(s.q(`SELECT COUNT(*) FROM workspaces WHERE owner_id = ?`), userID).Scan(&count)
 	case "api_tokens":
 		err = s.db.QueryRow(s.q(`SELECT COUNT(*) FROM api_tokens WHERE user_id = ?`), userID).Scan(&count)

--- a/internal/store/limits_test.go
+++ b/internal/store/limits_test.go
@@ -1,0 +1,144 @@
+package store
+
+import (
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// TestCheckUserLimit_WorkspacesFreeTier exercises the workspace-count limit
+// for a free-tier user. The cap must be 3 (DefaultFreeLimits.Workspaces).
+//
+//   - With 0 workspaces: Allowed=true, Current=0, Limit=3
+//   - With 2 workspaces (below cap): Allowed=true, Current=2
+//   - After inserting a 3rd workspace (at cap): Allowed=false, Current=3
+func TestCheckUserLimit_WorkspacesFreeTier(t *testing.T) {
+	s := testStore(t)
+
+	owner := createTestUser(t, s, "owner@example.com", "Owner", "s3cret")
+	if err := s.SetUserPlan(owner.ID, "free", ""); err != nil {
+		t.Fatalf("SetUserPlan(free): %v", err)
+	}
+
+	// 0 workspaces — allowed, limit reported as 3.
+	res, err := s.CheckUserLimit(owner.ID, "workspaces")
+	if err != nil {
+		t.Fatalf("CheckUserLimit (0 workspaces): %v", err)
+	}
+	if !res.Allowed {
+		t.Errorf("0 workspaces: Allowed=false, want true")
+	}
+	if res.Limit != 3 {
+		t.Errorf("0 workspaces: Limit=%d, want 3", res.Limit)
+	}
+	if res.Current != 0 {
+		t.Errorf("0 workspaces: Current=%d, want 0", res.Current)
+	}
+
+	// Create 2 workspaces — still allowed, Current==2.
+	for i := 0; i < 2; i++ {
+		if _, err := s.CreateWorkspace(models.WorkspaceCreate{
+			Name:    "ws-below-cap",
+			OwnerID: owner.ID,
+		}); err != nil {
+			t.Fatalf("CreateWorkspace(%d): %v", i, err)
+		}
+	}
+	res, err = s.CheckUserLimit(owner.ID, "workspaces")
+	if err != nil {
+		t.Fatalf("CheckUserLimit (2 workspaces): %v", err)
+	}
+	if !res.Allowed {
+		t.Errorf("2 workspaces: Allowed=false, want true")
+	}
+	if res.Current != 2 {
+		t.Errorf("2 workspaces: Current=%d, want 2", res.Current)
+	}
+
+	// Create a 3rd workspace — now at cap; next create should be denied.
+	if _, err := s.CreateWorkspace(models.WorkspaceCreate{
+		Name:    "ws-at-cap",
+		OwnerID: owner.ID,
+	}); err != nil {
+		t.Fatalf("CreateWorkspace(3rd): %v", err)
+	}
+	res, err = s.CheckUserLimit(owner.ID, "workspaces")
+	if err != nil {
+		t.Fatalf("CheckUserLimit (3 workspaces): %v", err)
+	}
+	if res.Allowed {
+		t.Errorf("3 workspaces: Allowed=true, want false (at cap)")
+	}
+	if res.Current != 3 {
+		t.Errorf("3 workspaces: Current=%d, want 3", res.Current)
+	}
+	if res.Limit != 3 {
+		t.Errorf("3 workspaces: Limit=%d, want 3", res.Limit)
+	}
+}
+
+// TestCheckUserLimit_WorkspacesFreeWithOverride confirms that a per-user
+// plan_overrides JSON entry raises the cap above the default 3.
+func TestCheckUserLimit_WorkspacesFreeWithOverride(t *testing.T) {
+	s := testStore(t)
+
+	owner := createTestUser(t, s, "override@example.com", "Override", "s3cret")
+	if err := s.SetUserPlan(owner.ID, "free", ""); err != nil {
+		t.Fatalf("SetUserPlan(free): %v", err)
+	}
+	// Override raises cap to 10.
+	if err := s.SetUserPlanOverrides(owner.ID, `{"workspaces":10}`); err != nil {
+		t.Fatalf("SetUserPlanOverrides: %v", err)
+	}
+
+	// Create 4 workspaces (would exceed the 3-default but not the override).
+	for i := 0; i < 4; i++ {
+		if _, err := s.CreateWorkspace(models.WorkspaceCreate{
+			Name:    "ws-override",
+			OwnerID: owner.ID,
+		}); err != nil {
+			t.Fatalf("CreateWorkspace(%d) with override: %v", i, err)
+		}
+	}
+	res, err := s.CheckUserLimit(owner.ID, "workspaces")
+	if err != nil {
+		t.Fatalf("CheckUserLimit with override: %v", err)
+	}
+	if !res.Allowed {
+		t.Errorf("4 workspaces with override=10: Allowed=false, want true")
+	}
+	if res.Limit != 10 {
+		t.Errorf("override limit: Limit=%d, want 10", res.Limit)
+	}
+}
+
+// TestCheckUserLimit_WorkspacesProUnlimited confirms that pro-plan users
+// are always allowed regardless of workspace count.
+func TestCheckUserLimit_WorkspacesProUnlimited(t *testing.T) {
+	s := testStore(t)
+
+	owner := createTestUser(t, s, "pro@example.com", "Pro", "s3cret")
+	if err := s.SetUserPlan(owner.ID, "pro", ""); err != nil {
+		t.Fatalf("SetUserPlan(pro): %v", err)
+	}
+
+	// Create 5 workspaces — should all be allowed on pro.
+	for i := 0; i < 5; i++ {
+		if _, err := s.CreateWorkspace(models.WorkspaceCreate{
+			Name:    "ws-pro",
+			OwnerID: owner.ID,
+		}); err != nil {
+			t.Fatalf("CreateWorkspace(%d) on pro: %v", i, err)
+		}
+	}
+	res, err := s.CheckUserLimit(owner.ID, "workspaces")
+	if err != nil {
+		t.Fatalf("CheckUserLimit (pro): %v", err)
+	}
+	if !res.Allowed {
+		t.Errorf("pro plan (5 workspaces): Allowed=false, want true (unlimited)")
+	}
+	if res.Limit != -1 {
+		t.Errorf("pro plan: Limit=%d, want -1 (unlimited)", res.Limit)
+	}
+}


### PR DESCRIPTION
## Summary

Lowers `DefaultFreeLimits.Workspaces` from 5 to 3 in `internal/store/limits.go`. Part of PLAN-1570 Phase a (MVBP launch — price-discrimination calibration). DE analysis (DOC-66 in `claude` workspace, Theme 4 §19) flagged the prior 5-cap as too generous: most individual users never hit it, so the "Upgrade to Pro" signal never fires.

## Plus

- Single-constant change in `internal/store/limits.go`
- 8 new test cases covering the boundary: 3 allowed, 4 blocked, pro-tier unlimited, self-hosted no-op, override-unblocks
- Data-path audit covered 9 workspace-creation paths; 3 intentional bypasses documented (signup auto-create, JSON import handler, tar.gz import bundle handler — last two tracked under PLAN-890)
- Code comment on `userFeatureCount` references IDEA-1611 for the pre-existing intentional behavior where soft-deleted workspaces count toward the cap (out of scope for this PR)

## Observable behavior changes

- **Fresh installs:** free-tier cap is now 3 workspaces; 4th creation returns 403 `plan_limit_exceeded`
- **Existing cloud deployments:** **UNCHANGED until TASK-1610 ships.** `SeedPlanLimits` is idempotent and won't overwrite existing `platform_settings.plan_limits_free_workspaces` rows. TASK-1610 (production-migration follow-up) covers the deployed-state migration as a separate, deliberately-scoped change.
- **Self-hosted:** no plan limits enforced; behavior unchanged
- **Pro-tier users:** unaffected

## Test plan

- [x] `go test ./...` (SQLite) — 22 packages, all green
- [x] `make test-pg` (Postgres) — 22 packages, all green
- [x] `make lint` (golangci-lint v2.11.4) — 0 issues
- [x] Codex review rounds 1 + 2 — converged; only finding (`SeedPlanLimits` deployment gap) is deliberately deferred to TASK-1610

## Refs

- TASK-1609 — this PR's target
- PLAN-1570 — MVBP launch plan (parent)
- TASK-1610 — production-deployment migration (follow-up)
- IDEA-1611 — soft-delete workspace count question (follow-up)
- DOC-66 (claude workspace) — Disciplined Entrepreneurship pricing analysis