### PR TITLE
Standardize plan-limit error envelope across HTTP/MCP/CLI/UI (TASK-788)

### DIFF
--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -3036,6 +3036,14 @@ Run with --help-collections to see available collections and their status values
 
 			item, err := client.CreateItem(ws, collSlug, input)
 			if err != nil {
+				// TASK-788: emit structured marker so MCP stdio classifier
+				// can surface ErrPlanLimitExceeded instead of ErrServerError.
+				if apiErr, ok := err.(*cli.APIError); ok {
+					if apiErr.AsPlanLimit() != nil {
+						cli.WritePlanLimitError(os.Stderr, apiErr)
+						return fmt.Errorf("item creation blocked: plan limit reached")
+					}
+				}
 				return err
 			}
 
@@ -6228,6 +6236,12 @@ Examples:
 
 				item, err := client.CreateItem(ws, "conventions", input)
 				if err != nil {
+					if apiErr, ok := err.(*cli.APIError); ok {
+						if apiErr.AsPlanLimit() != nil {
+							cli.WritePlanLimitError(os.Stderr, apiErr)
+							return fmt.Errorf("convention activation blocked: plan limit reached")
+						}
+					}
 					return err
 				}
 
@@ -6285,6 +6299,12 @@ Examples:
 
 				item, err := client.CreateItem(ws, "playbooks", input)
 				if err != nil {
+					if apiErr, ok := err.(*cli.APIError); ok {
+						if apiErr.AsPlanLimit() != nil {
+							cli.WritePlanLimitError(os.Stderr, apiErr)
+							return fmt.Errorf("playbook activation blocked: plan limit reached")
+						}
+					}
 					return err
 				}
 

--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -1910,6 +1910,14 @@ func inviteCmd() *cobra.Command {
 				return err
 			}
 			if err := client.PostRaw("/workspaces/"+ws+"/members/invite", raw, &result); err != nil {
+				// TASK-788: emit structured marker so MCP stdio classifier
+				// can surface ErrPlanLimitExceeded instead of ErrServerError.
+				if apiErr, ok := err.(*cli.APIError); ok {
+					if apiErr.AsPlanLimit() != nil {
+						cli.WritePlanLimitError(os.Stderr, apiErr)
+						return fmt.Errorf("invite blocked: plan limit reached")
+					}
+				}
 				return err
 			}
 
@@ -2004,6 +2012,14 @@ the agent can use it immediately without re-auth.`,
 				Template: templateFlag,
 			})
 			if err != nil {
+				// TASK-788: emit structured marker before wrapping so the MCP
+				// stdio classifier can surface ErrPlanLimitExceeded with details.
+				if apiErr, ok := err.(*cli.APIError); ok {
+					if apiErr.AsPlanLimit() != nil {
+						cli.WritePlanLimitError(os.Stderr, apiErr)
+						return fmt.Errorf("workspace creation blocked: plan limit reached")
+					}
+				}
 				return fmt.Errorf("create workspace: %w", err)
 			}
 			if formatFlag == "json" {
@@ -7030,6 +7046,14 @@ Examples:
 
 			hook, err := client.CreateWebhook(ws, input)
 			if err != nil {
+				// TASK-788: emit structured marker so MCP stdio classifier
+				// can surface ErrPlanLimitExceeded instead of ErrServerError.
+				if apiErr, ok := err.(*cli.APIError); ok {
+					if apiErr.AsPlanLimit() != nil {
+						cli.WritePlanLimitError(os.Stderr, apiErr)
+						return fmt.Errorf("webhook creation blocked: plan limit reached")
+					}
+				}
 				return err
 			}
 

--- a/internal/cli/client.go
+++ b/internal/cli/client.go
@@ -944,6 +944,54 @@ func WriteOpenChildrenError(w io.Writer, apiErr *APIError, oc *OpenChildrenDetai
 	fmt.Fprintln(w, "Pass --force to override.")
 }
 
+// PlanLimitDetails is the parsed shape of APIError.Details when
+// Code == "plan_limit_exceeded" (TASK-788).
+type PlanLimitDetails struct {
+	Feature    string `json:"feature"`
+	Limit      int    `json:"limit"`
+	Current    int    `json:"current"`
+	Plan       string `json:"plan"`
+	UpgradeURL string `json:"upgrade_url"`
+}
+
+// AsPlanLimit returns the parsed plan-limit details when this APIError
+// carries them, or nil otherwise. Returns nil for any error other than
+// "plan_limit_exceeded" so callers can branch cleanly.
+func (e *APIError) AsPlanLimit() *PlanLimitDetails {
+	if e == nil || e.Code != "plan_limit_exceeded" || len(e.Details) == 0 {
+		return nil
+	}
+	var d PlanLimitDetails
+	if err := json.Unmarshal(e.Details, &d); err != nil {
+		return nil
+	}
+	return &d
+}
+
+// WritePlanLimitError formats a plan-limit rejection to w in the canonical
+// two-track shape (TASK-788):
+//
+//  1. A single `pad-structured-error/v1: {json}\n` marker line — consumed by
+//     the MCP stdio classifier so it lifts the structured payload instead of
+//     falling through to a generic server_error.
+//  2. A human-readable line: the message from the server envelope.
+//
+// This mirrors WriteOpenChildrenError exactly in structure so the two paths
+// are easy to reason about together.
+func WritePlanLimitError(w io.Writer, apiErr *APIError) {
+	envelope := map[string]any{
+		"error": map[string]any{
+			"code":    apiErr.Code,
+			"message": apiErr.Message,
+			"details": apiErr.Details,
+		},
+	}
+	if data, err := json.Marshal(envelope); err == nil {
+		fmt.Fprintln(w, StructuredErrorMarker+string(data))
+	}
+	fmt.Fprintln(w, apiErr.Message)
+}
+
 // --- Attachments ---
 //
 // AttachmentUploadResult mirrors the JSON returned by

--- a/internal/mcp/errors.go
+++ b/internal/mcp/errors.go
@@ -140,6 +140,15 @@ const (
 	// upstream message so agents have a chance of recognizing
 	// transient vs persistent throttling.
 	ErrRateLimited ErrorCode = "rate_limited"
+
+	// ErrPlanLimitExceeded fires on HTTP 403 responses that carry
+	// error.code="plan_limit_exceeded" — a free-tier plan enforcement
+	// gate (e.g. items_per_workspace, members_per_workspace, workspaces,
+	// api_tokens). Distinct from ErrPermissionDenied (role/RBAC) so
+	// MCP-driven agents can surface an "upgrade to Pro" signal rather
+	// than reporting a permission error. Details carries feature/limit/
+	// current/plan/upgrade_url from the server (TASK-788).
+	ErrPlanLimitExceeded ErrorCode = "plan_limit_exceeded"
 )
 
 // ErrorEnvelope is the wire shape returned to MCP clients on tool
@@ -348,7 +357,8 @@ const structuredErrorMarker = "pad-structured-error/v1: "
 // declarations block at the top of this file should also be added
 // for type safety in test assertions.
 var allowedStructuredErrorCodes = map[string]struct{}{
-	"open_children": {}, // IDEA-1494
+	"open_children":       {}, // IDEA-1494
+	"plan_limit_exceeded": {}, // TASK-788
 }
 
 // extractStructuredCLIError scans stderr for the
@@ -752,6 +762,21 @@ func classifyHTTPStatusKind(
 			Hint:    authHintFor(bodyMessage, route),
 		})
 	case http.StatusForbidden:
+		// TASK-788: when the handler emitted a plan_limit_exceeded structured body,
+		// surface it with the dedicated code + details so MCP-driven agents can
+		// present an upgrade-to-Pro signal instead of a generic permission error.
+		// Whitelisted through allowedStructuredErrorCodes (same pattern as
+		// open_children on 409) so unknown 403 codes still collapse to
+		// ErrPermissionDenied.
+		upstream403 := extractUpstreamErrorEnvelope(bodyText)
+		if _, allowed := allowedStructuredErrorCodes[upstream403.Code]; allowed {
+			return NewErrorResult(ErrorPayload{
+				Code:    ErrorCode(upstream403.Code),
+				Message: upstream403.Message,
+				Hint:    planLimitHintFor(upstream403.Message, route),
+				Details: upstream403.Details,
+			})
+		}
 		return NewErrorResult(ErrorPayload{
 			Code:    ErrPermissionDenied,
 			Message: "Permission denied for this operation.",
@@ -1128,6 +1153,20 @@ func upstreamHintFor(bodyMsg, route string, status int) string {
 // Catch-all — surface enough for an agent to file a bug report.
 func serverHintFor(bodyMsg, route string, status int) string {
 	parts := []string{fmt.Sprintf("Unexpected status %d from backend.", status)}
+	if route != "" {
+		parts = append(parts, fmt.Sprintf("Route: %s.", route))
+	}
+	if bodyMsg != "" {
+		parts = append(parts, fmt.Sprintf("Backend: %s", bodyMsg))
+	}
+	return strings.Join(parts, " ")
+}
+
+// planLimitHintFor generates the actionable hint for ErrPlanLimitExceeded.
+// The upgrade_url is already in the Details blob; the hint surfaces it in
+// prose so agents that only read Hint (not Details) still get the destination.
+func planLimitHintFor(bodyMsg, route string) string {
+	parts := []string{"Upgrade to Pro at /console/billing to remove this limit."}
 	if route != "" {
 		parts = append(parts, fmt.Sprintf("Route: %s.", route))
 	}

--- a/internal/mcp/open_children_passthrough_test.go
+++ b/internal/mcp/open_children_passthrough_test.go
@@ -414,3 +414,45 @@ func TestClassifyExecError_PlanLimitWithoutMarkerFallsThrough(t *testing.T) {
 		t.Errorf("plain text stderr must not be classified as plan_limit_exceeded")
 	}
 }
+
+// TestClassifyExecError_PlanLimitWorkspaceCreate exercises the workspace-create
+// CLI-stdio path (TASK-788 codex R2 Finding 2): WritePlanLimitError on the
+// workspace-create command must round-trip through classifyExecError with
+// ErrPlanLimitExceeded and populated details.
+func TestClassifyExecError_PlanLimitWorkspaceCreate(t *testing.T) {
+	// Simulates stderr produced by WritePlanLimitError when workspace creation
+	// hits the workspaces cap for a free-tier user.
+	stderr := `Error: connecting to backend
+pad-structured-error/v1: {"error":{"code":"plan_limit_exceeded","message":"You've reached the 3-workspace limit on the free plan.","details":{"feature":"workspaces","limit":3,"current":3,"plan":"free","upgrade_url":"/console/billing"}}}
+workspace creation blocked: plan limit reached
+`
+	res := classifyExecError(context.Background(),
+		[]string{"workspace", "init"},
+		errors.New("exit status 1"),
+		stderr,
+		nil)
+	env, ok := res.StructuredContent.(ErrorEnvelope)
+	if !ok {
+		t.Fatalf("expected ErrorEnvelope, got %T", res.StructuredContent)
+	}
+	if env.Error.Code != ErrPlanLimitExceeded {
+		t.Fatalf("code: got %q, want %q", env.Error.Code, ErrPlanLimitExceeded)
+	}
+	if env.Error.Message == "" {
+		t.Errorf("message should be non-empty")
+	}
+
+	var got cli.PlanLimitDetails
+	if err := json.Unmarshal(env.Error.Details, &got); err != nil {
+		t.Fatalf("details should round-trip into PlanLimitDetails: %v", err)
+	}
+	if got.Feature != "workspaces" {
+		t.Errorf("feature: got %q, want workspaces", got.Feature)
+	}
+	if got.Limit != 3 {
+		t.Errorf("limit: got %d, want 3", got.Limit)
+	}
+	if got.UpgradeURL != "/console/billing" {
+		t.Errorf("upgrade_url: got %q, want /console/billing", got.UpgradeURL)
+	}
+}

--- a/internal/mcp/open_children_passthrough_test.go
+++ b/internal/mcp/open_children_passthrough_test.go
@@ -283,3 +283,134 @@ func TestStructuredErrorCodeParityAcrossTransports(t *testing.T) {
 	// parity contract is "no transport widens the enum beyond the
 	// whitelist," not "both transports produce identical envelopes."
 }
+
+// ─── TASK-788: plan_limit_exceeded — HTTP and stdio pass-through ──────────────
+
+// TestClassifyHTTPStatus_PlanLimitPreservesCodeAndDetails exercises the HTTP
+// MCP path: a 403 with code=plan_limit_exceeded must surface ErrPlanLimitExceeded
+// (not the generic ErrPermissionDenied) and preserve the details blob.
+func TestClassifyHTTPStatus_PlanLimitPreservesCodeAndDetails(t *testing.T) {
+	body := []byte(`{
+		"error": {
+			"code": "plan_limit_exceeded",
+			"message": "You've reached the 3-member limit on the free plan.",
+			"details": {
+				"feature": "members_per_workspace",
+				"limit": 3,
+				"current": 3,
+				"plan": "free",
+				"upgrade_url": "/console/billing"
+			}
+		}
+	}`)
+
+	res := classifyHTTPStatus(context.Background(), "workspace invite", 403, body, nil)
+	env, ok := res.StructuredContent.(ErrorEnvelope)
+	if !ok {
+		t.Fatalf("expected ErrorEnvelope, got %T", res.StructuredContent)
+	}
+	if env.Error.Code != ErrPlanLimitExceeded {
+		t.Fatalf("code: got %q, want %q", env.Error.Code, ErrPlanLimitExceeded)
+	}
+	if env.Error.Message == "" {
+		t.Errorf("message should be preserved from upstream, got empty")
+	}
+	if len(env.Error.Details) == 0 {
+		t.Fatal("details should be preserved as raw JSON, got empty")
+	}
+
+	// Round-trip the details to confirm the shape survives the HTTP-classifier
+	// transit unchanged.
+	var got cli.PlanLimitDetails
+	if err := json.Unmarshal(env.Error.Details, &got); err != nil {
+		t.Fatalf("details should round-trip into PlanLimitDetails: %v", err)
+	}
+	if got.Feature != "members_per_workspace" {
+		t.Errorf("feature: got %q, want members_per_workspace", got.Feature)
+	}
+	if got.Limit != 3 {
+		t.Errorf("limit: got %d, want 3", got.Limit)
+	}
+	if got.Plan != "free" {
+		t.Errorf("plan: got %q, want free", got.Plan)
+	}
+	if got.UpgradeURL != "/console/billing" {
+		t.Errorf("upgrade_url: got %q, want /console/billing", got.UpgradeURL)
+	}
+}
+
+// TestClassifyHTTPStatus_Generic403FallsToPermissionDenied confirms the inverse:
+// a plain 403 without a plan_limit_exceeded code still collapses to
+// ErrPermissionDenied so we don't break the existing permission-check contract.
+func TestClassifyHTTPStatus_Generic403FallsToPermissionDenied(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"no error code", `{"error":{"message":"not a member of this workspace"}}`},
+		{"explicit permission_denied code", `{"error":{"code":"permission_denied","message":"not a member"}}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res := classifyHTTPStatus(context.Background(), "workspace read", 403, []byte(tc.body), nil)
+			env := res.StructuredContent.(ErrorEnvelope)
+			if env.Error.Code != ErrPermissionDenied {
+				t.Errorf("code: got %q, want %q", env.Error.Code, ErrPermissionDenied)
+			}
+		})
+	}
+}
+
+// TestClassifyExecError_PlanLimitMarkerLiftsStructuredPayload exercises the
+// CLI-stdio MCP path (TASK-788 Finding A): when cli.WritePlanLimitError writes
+// the structured marker to stderr, classifyExecError must surface
+// ErrPlanLimitExceeded with the correct details — NOT a generic server_error.
+func TestClassifyExecError_PlanLimitMarkerLiftsStructuredPayload(t *testing.T) {
+	stderr := `Error: connecting to backend
+pad-structured-error/v1: {"error":{"code":"plan_limit_exceeded","message":"You've reached the 3-member limit on the free plan.","details":{"feature":"members_per_workspace","limit":3,"current":3,"plan":"free","upgrade_url":"/console/billing"}}}
+item creation blocked: plan limit reached
+`
+	res := classifyExecError(context.Background(),
+		[]string{"item", "create"},
+		errors.New("exit status 1"),
+		stderr,
+		nil)
+	env, ok := res.StructuredContent.(ErrorEnvelope)
+	if !ok {
+		t.Fatalf("expected ErrorEnvelope, got %T", res.StructuredContent)
+	}
+	if env.Error.Code != ErrPlanLimitExceeded {
+		t.Fatalf("code: got %q, want %q", env.Error.Code, ErrPlanLimitExceeded)
+	}
+	if env.Error.Message == "" {
+		t.Errorf("message should be non-empty")
+	}
+
+	var got cli.PlanLimitDetails
+	if err := json.Unmarshal(env.Error.Details, &got); err != nil {
+		t.Fatalf("details should round-trip into PlanLimitDetails: %v", err)
+	}
+	if got.Feature != "members_per_workspace" {
+		t.Errorf("feature: got %q, want members_per_workspace", got.Feature)
+	}
+	if got.Limit != 3 {
+		t.Errorf("limit: got %d, want 3", got.Limit)
+	}
+}
+
+// TestClassifyExecError_PlanLimitWithoutMarkerFallsThrough confirms that a plain
+// "plan limit" text in stderr (no structured marker) does NOT produce
+// ErrPlanLimitExceeded — it falls through to the regex classifiers so old CLI
+// binaries don't accidentally get the new code.
+func TestClassifyExecError_PlanLimitWithoutMarkerFallsThrough(t *testing.T) {
+	stderr := "Error: plan limit reached\n"
+	res := classifyExecError(context.Background(),
+		[]string{"item", "create"},
+		errors.New("exit status 1"),
+		stderr,
+		nil)
+	env := res.StructuredContent.(ErrorEnvelope)
+	if env.Error.Code == ErrPlanLimitExceeded {
+		t.Errorf("plain text stderr must not be classified as plan_limit_exceeded")
+	}
+}

--- a/internal/server/handlers_cloud.go
+++ b/internal/server/handlers_cloud.go
@@ -1128,8 +1128,10 @@ func writePlanLimitError(w http.ResponseWriter, result *store.LimitResult) {
 	})
 }
 
-// planLimitMessage returns a human-readable sentence for a plan limit violation.
-// This is what surfaces in the toast / CLI stderr when no code branch catches it.
+// planLimitMessage returns a human-readable statement-of-fact sentence for a
+// plan limit violation. Each surface (web toast, CLI, MCP hint) appends its
+// own upgrade call-to-action so the message itself doesn't repeat it (B1 fix).
+// Uses hyphenated adjective form ("3-member") per B2 fix. TASK-788.
 func planLimitMessage(result *store.LimitResult) string {
 	featureLabel := map[string]string{
 		"items_per_workspace":   "item",
@@ -1142,13 +1144,10 @@ func planLimitMessage(result *store.LimitResult) string {
 	if !ok {
 		label = result.Feature
 	}
-	var limitStr string
-	if result.Limit == 1 {
-		limitStr = "1 " + label
-	} else {
-		limitStr = fmt.Sprintf("%d %ss", result.Limit, label)
-	}
-	return fmt.Sprintf("You've reached the %s limit on the free plan. Upgrade to Pro to add more.", limitStr)
+	// "3-member", "10-item", "1-workspace", "10-API-token", etc.
+	// Hyphenated form reads as a compound adjective modifying "limit".
+	limitStr := fmt.Sprintf("%d-%s", result.Limit, label)
+	return fmt.Sprintf("You've reached the %s limit on the free plan.", limitStr)
 }
 
 // writeError2 is like writeError but also embeds a details object inside the error

--- a/internal/server/handlers_cloud.go
+++ b/internal/server/handlers_cloud.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/subtle"
 	"encoding/json"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
@@ -1113,14 +1114,52 @@ func (s *Server) enforceUserPlanLimit(w http.ResponseWriter, userID, feature str
 }
 
 // writePlanLimitError writes a structured 403 response for plan limit violations.
+// The envelope follows the standard {"error":{"code":...,"message":...,"details":{...}}}
+// shape so PadApiError (frontend), cli.APIError (CLI), and the MCP classifier can
+// all parse it uniformly. TASK-788.
 func writePlanLimitError(w http.ResponseWriter, result *store.LimitResult) {
-	writeJSON(w, http.StatusForbidden, map[string]interface{}{
-		"error":       "plan_limit_exceeded",
+	msg := planLimitMessage(result)
+	writeError2(w, http.StatusForbidden, "plan_limit_exceeded", msg, map[string]interface{}{
 		"feature":     result.Feature,
 		"limit":       result.Limit,
 		"current":     result.Current,
 		"plan":        result.Plan,
 		"upgrade_url": "/console/billing",
+	})
+}
+
+// planLimitMessage returns a human-readable sentence for a plan limit violation.
+// This is what surfaces in the toast / CLI stderr when no code branch catches it.
+func planLimitMessage(result *store.LimitResult) string {
+	featureLabel := map[string]string{
+		"items_per_workspace":   "item",
+		"members_per_workspace": "member",
+		"workspaces":            "workspace",
+		"api_tokens":            "API token",
+		"webhooks":              "webhook",
+	}
+	label, ok := featureLabel[result.Feature]
+	if !ok {
+		label = result.Feature
+	}
+	var limitStr string
+	if result.Limit == 1 {
+		limitStr = "1 " + label
+	} else {
+		limitStr = fmt.Sprintf("%d %ss", result.Limit, label)
+	}
+	return fmt.Sprintf("You've reached the %s limit on the free plan. Upgrade to Pro to add more.", limitStr)
+}
+
+// writeError2 is like writeError but also embeds a details object inside the error
+// envelope. Shape: {"error":{"code":...,"message":...,"details":{...}}}.
+func writeError2(w http.ResponseWriter, status int, code, message string, details map[string]interface{}) {
+	writeJSON(w, status, map[string]interface{}{
+		"error": map[string]interface{}{
+			"code":    code,
+			"message": message,
+			"details": details,
+		},
 	})
 }
 

--- a/internal/server/handlers_workspace_cap_test.go
+++ b/internal/server/handlers_workspace_cap_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"testing"
 
@@ -83,19 +84,32 @@ func TestWorkspaceCap_FreeTierBlocksFourth(t *testing.T) {
 	if rr.Code != http.StatusForbidden {
 		t.Fatalf("4th workspace: expected 403, got %d: %s", rr.Code, rr.Body.String())
 	}
-	var resp map[string]interface{}
+	// TASK-788: body now follows the standard {"error":{"code":...,"message":...,"details":{...}}} shape.
+	var resp struct {
+		Error struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+			Details struct {
+				Feature string  `json:"feature"`
+				Limit   float64 `json:"limit"`
+			} `json:"details"`
+		} `json:"error"`
+	}
 	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("decode 403 response: %v", err)
 	}
-	if got, _ := resp["error"].(string); got != "plan_limit_exceeded" {
-		t.Errorf("4th workspace: error=%q, want plan_limit_exceeded", got)
+	if resp.Error.Code != "plan_limit_exceeded" {
+		t.Errorf("4th workspace: error.code=%q, want plan_limit_exceeded", resp.Error.Code)
 	}
-	if got, _ := resp["feature"].(string); got != "workspaces" {
-		t.Errorf("4th workspace: feature=%q, want workspaces", got)
+	if resp.Error.Message == "" {
+		t.Errorf("4th workspace: error.message should be non-empty")
+	}
+	if resp.Error.Details.Feature != "workspaces" {
+		t.Errorf("4th workspace: error.details.feature=%q, want workspaces", resp.Error.Details.Feature)
 	}
 	// Limit field must report 3 (the new cap), not 5.
-	if got, ok := resp["limit"].(float64); !ok || int(got) != 3 {
-		t.Errorf("4th workspace: limit=%v, want 3", resp["limit"])
+	if int(resp.Error.Details.Limit) != 3 {
+		t.Errorf("4th workspace: error.details.limit=%v, want 3", resp.Error.Details.Limit)
 	}
 }
 
@@ -182,5 +196,122 @@ func TestWorkspaceCap_OverrideUnblocks(t *testing.T) {
 		if rr.Code != http.StatusCreated {
 			t.Fatalf("override workspace %d: expected 201, got %d: %s", i, rr.Code, rr.Body.String())
 		}
+	}
+}
+
+// TestPlanLimitError_ResponseShape verifies that the 403 body emitted by
+// writePlanLimitError follows the standard {"error":{"code":...,"message":...,"details":{...}}}
+// envelope shape (TASK-788). Uses the member-invite endpoint to exercise
+// enforcePlanLimit("members_per_workspace") — a workspace-scoped limit distinct
+// from the workspace-count limit tested by TestWorkspaceCap_FreeTierBlocksFourth.
+func TestPlanLimitError_ResponseShape(t *testing.T) {
+	srv := testServer(t)
+	srv.SetCloudMode("test-cloud-secret")
+
+	bootstrapFirstUser(t, srv, "admin@test.com", "Admin")
+
+	// Create a free-tier user who will own the workspace.
+	owner, err := srv.store.CreateUser(models.UserCreate{
+		Email:    "owner@test.com",
+		Name:     "Owner",
+		Password: "correct-horse-battery-staple",
+		Role:     "member",
+	})
+	if err != nil {
+		t.Fatalf("CreateUser(owner): %v", err)
+	}
+	if err := srv.store.SetUserPlan(owner.ID, "free", ""); err != nil {
+		t.Fatalf("SetUserPlan(free): %v", err)
+	}
+	ownerToken := loginUser(t, srv, "owner@test.com", "correct-horse-battery-staple")
+
+	// Create a workspace for the owner.
+	wsRR := doRequestWithCookie(srv, "POST", "/api/v1/workspaces", map[string]string{
+		"name": "Test Workspace",
+	}, ownerToken)
+	if wsRR.Code != http.StatusCreated {
+		t.Fatalf("create workspace: expected 201, got %d: %s", wsRR.Code, wsRR.Body.String())
+	}
+	var wsResp struct {
+		Slug string `json:"slug"`
+	}
+	if err := json.Unmarshal(wsRR.Body.Bytes(), &wsResp); err != nil || wsResp.Slug == "" {
+		t.Fatalf("parse workspace response: %v — %s", err, wsRR.Body.String())
+	}
+	wsSlug := wsResp.Slug
+
+	// Add existing users until we're at the member cap (3 for free tier).
+	// The owner themselves count as 1, so invite 2 more real users.
+	for i := 2; i <= 3; i++ {
+		member, err := srv.store.CreateUser(models.UserCreate{
+			Email:    fmt.Sprintf("member%d@test.com", i),
+			Name:     fmt.Sprintf("Member %d", i),
+			Password: "pass",
+			Role:     "member",
+		})
+		if err != nil {
+			t.Fatalf("CreateUser(member%d): %v", i, err)
+		}
+		invRR := doRequestWithCookie(srv, "POST", "/api/v1/workspaces/"+wsSlug+"/members/invite",
+			map[string]string{"email": member.Email, "role": "editor"}, ownerToken)
+		if invRR.Code != http.StatusCreated {
+			t.Fatalf("invite member %d: expected 201, got %d: %s", i, invRR.Code, invRR.Body.String())
+		}
+	}
+
+	// One more invite must be blocked — this is the limit-hit we're testing.
+	extra, err := srv.store.CreateUser(models.UserCreate{
+		Email:    "extra@test.com",
+		Name:     "Extra",
+		Password: "pass",
+		Role:     "member",
+	})
+	if err != nil {
+		t.Fatalf("CreateUser(extra): %v", err)
+	}
+	rr := doRequestWithCookie(srv, "POST", "/api/v1/workspaces/"+wsSlug+"/members/invite",
+		map[string]string{"email": extra.Email, "role": "editor"}, ownerToken)
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("4th member invite: expected 403, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	// Verify the standard error envelope shape (TASK-788).
+	var resp struct {
+		Error struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+			Details struct {
+				Feature    string  `json:"feature"`
+				Limit      float64 `json:"limit"`
+				Current    float64 `json:"current"`
+				Plan       string  `json:"plan"`
+				UpgradeURL string  `json:"upgrade_url"`
+			} `json:"details"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode 403 response: %v — body: %s", err, rr.Body.String())
+	}
+
+	// error.code must be the stable machine-readable token.
+	if resp.Error.Code != "plan_limit_exceeded" {
+		t.Errorf("error.code: got %q, want plan_limit_exceeded", resp.Error.Code)
+	}
+	// error.message must be a non-empty human sentence suitable for display.
+	if resp.Error.Message == "" {
+		t.Errorf("error.message: should be non-empty human-readable text")
+	}
+	// Details must carry the structured limit info.
+	if resp.Error.Details.Feature != "members_per_workspace" {
+		t.Errorf("details.feature: got %q, want members_per_workspace", resp.Error.Details.Feature)
+	}
+	if int(resp.Error.Details.Limit) != 3 {
+		t.Errorf("details.limit: got %v, want 3", resp.Error.Details.Limit)
+	}
+	if resp.Error.Details.Plan != "free" {
+		t.Errorf("details.plan: got %q, want free", resp.Error.Details.Plan)
+	}
+	if resp.Error.Details.UpgradeURL != "/console/billing" {
+		t.Errorf("details.upgrade_url: got %q, want /console/billing", resp.Error.Details.UpgradeURL)
 	}
 }

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -70,6 +70,9 @@ class PadApiError extends Error {
 	 * today is `open_children` (IDEA-1494 / BUG-1538), whose details
 	 * carry `{ open_children, hidden_blocker_count, done_field,
 	 * attempted_value }`. Undefined for codes that don't supply it.
+	 *
+	 * For `plan_limit_exceeded` (TASK-788) the shape is:
+	 *   { feature: string, limit: number, current: number, plan: string, upgrade_url: string }
 	 */
 	details?: Record<string, unknown>;
 	constructor(err: ApiError) {
@@ -77,6 +80,30 @@ class PadApiError extends Error {
 		this.code = err.code;
 		this.details = err.details;
 	}
+}
+
+/**
+ * Returns true when `err` is a PadApiError with code "plan_limit_exceeded".
+ * Use this at every write-operation catch block to branch on plan-gating
+ * rather than showing a generic "Failed to …" toast. TASK-788.
+ */
+function isPlanLimitError(err: unknown): err is PadApiError {
+	return err instanceof PadApiError && err.code === 'plan_limit_exceeded';
+}
+
+/**
+ * Returns a human-readable upgrade-signal message for a plan limit error.
+ * Falls back to the server-supplied `err.message` if details are unavailable,
+ * so the function is always safe to call. TASK-788.
+ *
+ * Example output:
+ *   "You've reached the 3-member limit on the free plan. Upgrade to Pro →"
+ */
+function planLimitMessage(err: PadApiError): string {
+	// The server already sends a good sentence in err.message (TASK-788).
+	// We use it directly here so there is a single source of truth for the
+	// wording; callers append the upgrade link separately in the UI.
+	return err.message || 'Plan limit reached. Upgrade to Pro to continue.';
 }
 
 /**
@@ -1486,4 +1513,4 @@ export const api = {
 	}
 };
 
-export { PadApiError };
+export { PadApiError, isPlanLimitError, planLimitMessage };

--- a/web/src/lib/components/editor/EditorBubbleMenu.svelte
+++ b/web/src/lib/components/editor/EditorBubbleMenu.svelte
@@ -2,7 +2,7 @@
 	import type { Editor } from '@tiptap/core';
 	import type { Collection, Item } from '$lib/types';
 	import { parseSchema } from '$lib/types';
-	import { api } from '$lib/api/client';
+	import { api, isPlanLimitError, planLimitMessage } from '$lib/api/client';
 	import { toastStore } from '$lib/stores/toast.svelte';
 
 	const AGENT_SLUGS = ['conventions', 'playbooks'];
@@ -172,7 +172,11 @@
 			toastStore.show(`Created "${item.title}"`, 'success');
 			hide();
 		} catch (err: any) {
-			errorMsg = err.message || 'Failed to create item';
+			if (isPlanLimitError(err)) {
+				errorMsg = planLimitMessage(err) + ' Upgrade to Pro at /console/billing';
+			} else {
+				errorMsg = err.message || 'Failed to create item';
+			}
 		} finally {
 			creating = false;
 		}

--- a/web/src/lib/components/layout/CreateWorkspaceModal.svelte
+++ b/web/src/lib/components/layout/CreateWorkspaceModal.svelte
@@ -2,7 +2,7 @@
 	import { goto } from '$app/navigation';
 	import { workspaceStore } from '$lib/stores/workspace.svelte';
 	import { uiStore } from '$lib/stores/ui.svelte';
-	import { api } from '$lib/api/client';
+	import { api, isPlanLimitError, planLimitMessage } from '$lib/api/client';
 	import { toastStore } from '$lib/stores/toast.svelte';
 	import type { Workspace, WorkspaceTemplate } from '$lib/types';
 	import { groupTemplatesByCategory } from '$lib/utils/templates';
@@ -112,8 +112,12 @@
 			onWorkspaceCreated?.(ws);
 			close();
 			goto(`/${ws.owner_username}/${ws.slug}`);
-		} catch {
-			toastStore.show('Failed to create workspace', 'error');
+		} catch (err: unknown) {
+			if (isPlanLimitError(err)) {
+				toastStore.show(planLimitMessage(err) + ' Upgrade to Pro at /console/billing', 'error');
+			} else {
+				toastStore.show('Failed to create workspace', 'error');
+			}
 		}
 	}
 

--- a/web/src/lib/components/layout/Sidebar.svelte
+++ b/web/src/lib/components/layout/Sidebar.svelte
@@ -8,7 +8,7 @@
 	import { uiStore } from '$lib/stores/ui.svelte';
 	import { authStore } from '$lib/stores/auth.svelte';
 	import { goto } from '$app/navigation';
-	import { api } from '$lib/api/client';
+	import { api, isPlanLimitError, planLimitMessage } from '$lib/api/client';
 	import { parseSchema, parseSettings, itemUrlId } from '$lib/types';
 	import type { Collection } from '$lib/types';
 	import { toastStore } from '$lib/stores/toast.svelte';
@@ -173,7 +173,11 @@
 			uiStore.onNavigate();
 			goto(`${wsPrefix}/${coll.slug}/${itemUrlId(item)}?new=1`);
 		} catch (err: any) {
-			toastStore.show(err?.message || 'Failed to create item', 'error');
+			if (isPlanLimitError(err)) {
+				toastStore.show(planLimitMessage(err) + ' Upgrade to Pro at /console/billing', 'error');
+			} else {
+				toastStore.show(err?.message || 'Failed to create item', 'error');
+			}
 		}
 	}
 

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { page } from '$app/state';
 	import { goto } from '$app/navigation';
-	import { api, PadApiError } from '$lib/api/client';
+	import { api, PadApiError, isPlanLimitError, planLimitMessage } from '$lib/api/client';
 	import type { Collection, Item, QuickAction, View, ViewConfig } from '$lib/types';
 	import { parseSettings, parseFields, parseSchema, getStatusOptions, itemUrlId, formatItemRef } from '$lib/types';
 	import BoardView from '$lib/components/collections/BoardView.svelte';
@@ -896,7 +896,11 @@
 			});
 			goto(`/${username}/${wsSlug}/${collSlug}/${itemUrlId(item)}?new=1`);
 		} catch (err: any) {
-			toastStore.show(err?.message || 'Failed to create item', 'error');
+			if (isPlanLimitError(err)) {
+				toastStore.show(planLimitMessage(err) + ' Upgrade to Pro at /console/billing', 'error');
+			} else {
+				toastStore.show(err?.message || 'Failed to create item', 'error');
+			}
 		} finally {
 			creatingNew = false;
 		}
@@ -923,7 +927,11 @@
 			quickCreateTitle = '';
 			toastStore.show(`Created "${title}"`, 'success');
 		} catch (err: any) {
-			toastStore.show(err?.message || 'Failed to create item', 'error');
+			if (isPlanLimitError(err)) {
+				toastStore.show(planLimitMessage(err) + ' Upgrade to Pro at /console/billing', 'error');
+			} else {
+				toastStore.show(err?.message || 'Failed to create item', 'error');
+			}
 		} finally {
 			creatingNew = false;
 		}

--- a/web/src/routes/[username]/[workspace]/conventions/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/conventions/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { page } from '$app/state';
-	import { api } from '$lib/api/client';
+	import { api, isPlanLimitError, planLimitMessage } from '$lib/api/client';
 	import type { Collection, Item, ItemConventionMetadata, ItemCreate } from '$lib/types';
 	import { parseFields, parseSchema } from '$lib/types';
 	import { toastStore } from '$lib/stores/toast.svelte';
@@ -247,8 +247,12 @@
 			conventions = [...conventions, created];
 			toastStore.show('Convention created', 'success');
 			resetForm();
-		} catch {
-			toastStore.show('Failed to create convention', 'error');
+		} catch (err: unknown) {
+			if (isPlanLimitError(err)) {
+				toastStore.show(planLimitMessage(err) + ' Upgrade to Pro at /console/billing', 'error');
+			} else {
+				toastStore.show('Failed to create convention', 'error');
+			}
 		} finally {
 			creating = false;
 		}

--- a/web/src/routes/[username]/[workspace]/playbooks/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/playbooks/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { page } from '$app/state';
 	import { goto } from '$app/navigation';
-	import { api } from '$lib/api/client';
+	import { api, isPlanLimitError, planLimitMessage } from '$lib/api/client';
 	import { parseFields, parseSchema, itemUrlId, type Collection, type Item } from '$lib/types';
 	import { toastStore } from '$lib/stores/toast.svelte';
 	import { createScrollRestoration } from '$lib/scroll/restore.svelte';
@@ -225,7 +225,13 @@
 			resetForm();
 			toastStore.show(`Playbook created as ${status}`, 'success');
 			await loadPlaybooks(wsSlug);
-		} catch { toastStore.show('Failed to create playbook', 'error'); }
+		} catch (err: unknown) {
+			if (isPlanLimitError(err)) {
+				toastStore.show(planLimitMessage(err) + ' Upgrade to Pro at /console/billing', 'error');
+			} else {
+				toastStore.show('Failed to create playbook', 'error');
+			}
+		}
 	}
 
 	async function toggleStatus(item: Item) {
@@ -277,8 +283,13 @@
 			});
 			toastStore.show('Playbook duplicated as draft', 'success');
 			await loadPlaybooks(wsSlug);
-		} catch { toastStore.show('Failed to duplicate playbook', 'error'); }
-		finally { duplicating = null; }
+		} catch (err: unknown) {
+			if (isPlanLimitError(err)) {
+				toastStore.show(planLimitMessage(err) + ' Upgrade to Pro at /console/billing', 'error');
+			} else {
+				toastStore.show('Failed to duplicate playbook', 'error');
+			}
+		} finally { duplicating = null; }
 	}
 
 	function clearFilters() { searchQuery = ''; filterTrigger = ''; filterScope = ''; }

--- a/web/src/routes/[username]/[workspace]/roles/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/roles/+page.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
 	import { page } from '$app/state';
 	import { onMount } from 'svelte';
-	import { api } from '$lib/api/client';
+	import { api, isPlanLimitError, planLimitMessage } from '$lib/api/client';
 	import { workspaceStore } from '$lib/stores/workspace.svelte';
 	import { collectionStore } from '$lib/stores/collections.svelte';
 	import { uiStore } from '$lib/stores/ui.svelte';
+	import { toastStore } from '$lib/stores/toast.svelte';
 	import { itemUrlId } from '$lib/types';
 	import { createScrollRestoration } from '$lib/scroll/restore.svelte';
 	import type { Item, Collection, RoleBoardLane, AgentRole } from '$lib/types';
@@ -110,7 +111,11 @@
 			closeNewItem();
 			await loadData();
 		} catch (err) {
-			console.error('Failed to create item:', err);
+			if (isPlanLimitError(err)) {
+				toastStore.show(planLimitMessage(err) + ' Upgrade to Pro at /console/billing', 'error');
+			} else {
+				console.error('Failed to create item:', err);
+			}
 		} finally {
 			newItemSaving = false;
 		}

--- a/web/src/routes/[username]/[workspace]/settings/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/settings/+page.svelte
@@ -2,7 +2,7 @@
 	import { page } from '$app/state';
 	import { goto } from '$app/navigation';
 	import { onMount } from 'svelte';
-	import { api } from '$lib/api/client';
+	import { api, isPlanLimitError, planLimitMessage } from '$lib/api/client';
 	import { workspaceStore } from '$lib/stores/workspace.svelte';
 	import type { Collection, WorkspaceContext } from '$lib/types';
 	import { parseSchema } from '$lib/types';
@@ -238,7 +238,14 @@
 			members = memberData.members ?? [];
 			invitations = memberData.invitations ?? [];
 		} catch (err: unknown) {
-			inviteResult = { message: err instanceof Error ? err.message : 'Failed to invite', type: 'error' };
+			if (isPlanLimitError(err)) {
+				inviteResult = {
+					message: planLimitMessage(err) + ' Upgrade to Pro at /console/billing',
+					type: 'error'
+				};
+			} else {
+				inviteResult = { message: err instanceof Error ? err.message : 'Failed to invite', type: 'error' };
+			}
 		} finally {
 			inviting = false;
 		}

--- a/web/src/routes/console/settings/+page.svelte
+++ b/web/src/routes/console/settings/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
-	import { api } from '$lib/api/client';
+	import { api, isPlanLimitError, planLimitMessage } from '$lib/api/client';
 	import { authStore } from '$lib/stores/auth.svelte';
 	import { copyToClipboard } from '$lib/utils/clipboard';
 	import type { User, APIToken, APITokenWithSecret, TOTPSetupResponse } from '$lib/types';
@@ -312,7 +312,11 @@
 			tokens = [...tokens, token];
 			newTokenName = '';
 		} catch (err) {
-			tokenError = err instanceof Error ? err.message : 'Failed to create token';
+			if (isPlanLimitError(err)) {
+				tokenError = planLimitMessage(err) + ' Upgrade to Pro at /console/billing';
+			} else {
+				tokenError = err instanceof Error ? err.message : 'Failed to create token';
+			}
 		} finally {
 			tokenCreating = false;
 		}


### PR DESCRIPTION
## Summary

Limit-hit UX was actively broken at every enforcement point — `writePlanLimitError` emitted a non-standard flat shape (`{"error": "plan_limit_exceeded", "feature": ..., "limit": ...}`) that the frontend's `PadApiError` constructor couldn't parse, producing garbled toasts and zero upgrade signal at all 5 plan-gated endpoints. This PR migrates the envelope to the standard `{"error": {"code", "message", "details"}}` shape used elsewhere in the codebase, then propagates the contract end-to-end across HTTP, MCP-HTTP, MCP-stdio, CLI, and 9 frontend item-creation surfaces.

## What changed (architectural)

- **Server**: `writePlanLimitError` rewritten to emit the standard envelope. `planLimitMessage` produces a statement-of-fact human-readable sentence (`"You've reached the 3-member limit on the free plan."`) — each surface (web toast, CLI stderr, MCP hint) owns its own action-prompt phrasing so the upgrade verb doesn't double up.
- **MCP HTTP transport**: `classifyHTTPStatusKind`'s 403 branch now passes through whitelisted `plan_limit_exceeded` codes via `allowedStructuredErrorCodes` (mirrors the IDEA-1494 `open_children` on 409 precedent). New `ErrPlanLimitExceeded` ErrorCode + `planLimitHintFor` action-prompt builder.
- **MCP stdio transport**: New `WritePlanLimitError` in `internal/cli/client.go` + `AsPlanLimit()` method + `PlanLimitDetails` struct. Wired into 6 CLI command sites: item create, convention activate, playbook activate, workspace create, workspace invite, webhook create.
- **Frontend**: New `isPlanLimitError(err)` type-guard + `planLimitMessage(err)` helper exported from `client.ts`. Branched at 9 item/workspace/member/token creation catch blocks across the UI.

## Observable behavior changes

| Before | After |
|---|---|
| Frontend `PadApiError` constructed from `body.error` (string) → garbled toast text | Standard envelope: `body.error` is an object; constructor populates `code`, `message`, `details` correctly |
| 5 limit-hit catch blocks showed generic "Failed to ..." toasts | All 9 item/workspace/member/token-create surfaces show "You've reached the N-X limit on the free plan. Upgrade to Pro at /console/billing" |
| MCP-HTTP 403 → generic `ErrPermissionDenied` | MCP-HTTP 403 → `ErrPlanLimitExceeded` with `code`, `message`, `details`, action hint |
| MCP-stdio 403 → generic `server_error` | MCP-stdio 403 → `ErrPlanLimitExceeded` with `code`, `message`, `details`, action hint (for the 6 wrapped CLI commands) |
| CLI showed raw HTTP body for plan-limit errors | CLI shows the human-readable server message via existing `parseError` path |

## Test plan

- [x] `go test ./...` (SQLite default driver) — all 23 packages pass
- [x] `make test-pg` (Postgres driver) — all 23 packages pass
- [x] `make lint` (golangci-lint) — 0 issues
- [x] `npm run check` — 0 errors (4 pre-existing warnings unchanged from main)
- [x] `npm run build` — clean
- [x] New tests: `TestPlanLimitError_ResponseShape` (covers `members_per_workspace` enforcement via member-invite endpoint), `TestClassifyHTTPStatus_PlanLimitPreservesCodeAndDetails`, `TestClassifyExecError_PlanLimitWorkspaceCreate`, plus 3 more MCP round-trip tests covering generic-403-stays-permission-denied and plain-text-fallthrough paths
- [x] Existing `TestWorkspaceCap_FreeTierBlocksFourth` updated to assert the new nested body shape

## Review trail

Three codex review rounds via PATTE-37 framing rotation (default → gap → contract-blast-radius); R3 converged CLEAN with broad codebase-wide blast-radius scan.

## Out of scope (deferred)

- **Workspace-import bypass** (`handlers_workspaces.go:424`, `handlers_import_bundle.go:124`): codex R2 surfaced that the JSON and tar.gz workspace-import paths bypass the workspace cap entirely. This is a known pre-existing gap, already homed at docapp PLAN-890 (limit-enforcement gap coverage). The new envelope shape in this PR will cover those paths automatically once PLAN-890 wires the enforcement — no follow-up needed in TASK-788's scope. Cross-link comment posted on PLAN-890.
- **Token create MCP-stdio coverage**: `cmd/pad/main.go:1912` (token create) was deliberately not wrapped with `WritePlanLimitError`. Agents creating their own auth tokens via MCP-driven workflows is not a real pattern (agents use already-issued tokens). If this assumption changes, the wrapping pattern is one function call.
- **Upgrade CTA destination**: The toast / inline error currently appends `" Upgrade to Pro at /console/billing"` as plain text. TASK-800 will turn this into a clickable button/link with proper checkout-flow wiring. The destination path exists (`/console/billing`); only the UI affordance is deferred.
- **`writeError2` naming**: low-effort name, not a bug. Leaving as-is.

## Refs

- docapp: TASK-788 (this), PLAN-775 (Stage 3 parent), TASK-800 (Stage 3 follow-up), PLAN-890 (limit-enforcement gap, separate concern)
- claude: PATTE-37 (codex framing rotation), PATTE-38 (diff-size ≠ risk-surface), PATTE-39 (verification matrix), MISTA-70 (loop-cleanness vs goal-impact target selection)