### PR TITLE
Wire upgrade CTAs with Stripe-ready billing flow (TASK-800)

### DIFF
--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -397,6 +397,15 @@ func serveCmd() *cobra.Command {
 			srv.SetIPChangeEnforce(cfg.IPChangeEnforce)
 			srv.SetSSELimits(cfg.SSEMaxConnections, cfg.SSEMaxPerWorkspace)
 
+			// Billing CTA gate (TASK-800). PAD_BILLING_AVAILABLE=true when
+			// the pad-cloud sidecar has Stripe keys configured so the web UI
+			// can show "Upgrade to Pro" buttons. Defaults to false so a fresh
+			// cloud deployment without Stripe doesn't expose dead-end CTAs.
+			if v := os.Getenv("PAD_BILLING_AVAILABLE"); v == "true" || v == "1" {
+				srv.SetBillingAvailable(true)
+				slog.Info("Billing CTAs enabled (PAD_BILLING_AVAILABLE)")
+			}
+
 			// Cloud-tenant mode: enable cloud-specific endpoints and
 			// behavior. Gated on IsCloudServer() (env-var opt-in) rather
 			// than IsCloud() (which is also true when a CLI user has

--- a/internal/server/handlers_auth.go
+++ b/internal/server/handlers_auth.go
@@ -125,12 +125,13 @@ func (s *Server) handleCheckUsername(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) setupStatePayload(setupMethod string) map[string]interface{} {
 	return map[string]interface{}{
-		"authenticated":  false,
-		"setup_required": true,
-		"setup_method":   setupMethod,
-		"auth_method":    authMethodPassword,
-		"cloud_mode":     s.cloudMode,
-		"mcp_public_url": s.mcpPublicURL,
+		"authenticated":     false,
+		"setup_required":    true,
+		"setup_method":      setupMethod,
+		"auth_method":       authMethodPassword,
+		"cloud_mode":        s.cloudMode,
+		"mcp_public_url":    s.mcpPublicURL,
+		"billing_available": s.cloudMode && s.billingAvailable,
 	}
 }
 
@@ -140,12 +141,17 @@ func (s *Server) sessionStatePayload(authenticated bool, user *models.User) map[
 	// is unset — the web UI uses presence/absence as the gate that drives the
 	// connect banner mode (Remote MCP vs CLI install). Always emitted, never
 	// omitted, so the frontend can rely on a string value.
+	//
+	// billing_available is true when PAD_BILLING_AVAILABLE=true and the
+	// deployment is in cloud mode. Used by the web UI to show/hide Stripe
+	// Checkout CTAs. TASK-800.
 	payload := map[string]interface{}{
-		"authenticated":  authenticated,
-		"setup_required": false,
-		"auth_method":    authMethodPassword,
-		"cloud_mode":     s.cloudMode,
-		"mcp_public_url": s.mcpPublicURL,
+		"authenticated":     authenticated,
+		"setup_required":    false,
+		"auth_method":       authMethodPassword,
+		"cloud_mode":        s.cloudMode,
+		"mcp_public_url":    s.mcpPublicURL,
+		"billing_available": s.cloudMode && s.billingAvailable,
 	}
 	if authenticated {
 		payload["user"] = sessionUserPayload(user)

--- a/internal/server/handlers_auth_test.go
+++ b/internal/server/handlers_auth_test.go
@@ -110,6 +110,44 @@ func TestAuthSessionEmitsMCPPublicURLWhenConfigured(t *testing.T) {
 	}
 }
 
+// billing_available is false by default and only true when BOTH cloudMode AND
+// billingAvailable are set. Tests for both the default (off) and the enabled
+// state so a future refactor can't accidentally always-expose the CTA. TASK-800.
+func TestAuthSessionBillingAvailable(t *testing.T) {
+	// Default: both flags off — billing_available must be false.
+	srv := testServer(t)
+	rr := doRequest(srv, "GET", "/api/v1/auth/session", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("session check: expected 200, got %d", rr.Code)
+	}
+	var session map[string]interface{}
+	parseJSON(t, rr, &session)
+	if v, ok := session["billing_available"]; !ok {
+		t.Error("billing_available field missing from session payload")
+	} else if v != false {
+		t.Errorf("expected billing_available=false by default, got %v", v)
+	}
+
+	// Cloud mode only (no billingAvailable) — still false.
+	srv2 := testServer(t)
+	srv2.cloudMode = true
+	rr2 := doRequest(srv2, "GET", "/api/v1/auth/session", nil)
+	parseJSON(t, rr2, &session)
+	if session["billing_available"] != false {
+		t.Errorf("expected billing_available=false when cloudMode=true but billingAvailable=false, got %v", session["billing_available"])
+	}
+
+	// Both flags set — billing_available must be true.
+	srv3 := testServer(t)
+	srv3.cloudMode = true
+	srv3.billingAvailable = true
+	rr3 := doRequest(srv3, "GET", "/api/v1/auth/session", nil)
+	parseJSON(t, rr3, &session)
+	if session["billing_available"] != true {
+		t.Errorf("expected billing_available=true when cloudMode+billingAvailable both set, got %v", session["billing_available"])
+	}
+}
+
 func TestAuthBootstrapRequiresLoopback(t *testing.T) {
 	srv := testServer(t)
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -57,6 +57,7 @@ type Server struct {
 	cloudMode             bool                 // true when running as Pad Cloud (PAD_CLOUD=true or PAD_MODE=cloud)
 	cloudSecrets          []string             // shared secrets for sidecar ↔ pad communication (supports rotation)
 	cloudSidecar          CloudSidecar         // reverse pad → pad-cloud client (e.g. Stripe cancel on account delete); nil = not configured
+	billingAvailable      bool                 // true when PAD_BILLING_AVAILABLE=true — gates Stripe Checkout CTAs in the web UI (TASK-800)
 	version               string               // release version (e.g. "dev", "1.2.3")
 	commit                string               // git commit hash
 	buildTime             string               // build timestamp
@@ -379,6 +380,14 @@ type CloudSidecar interface {
 // deploys that don't run a Stripe-backed sidecar have nothing to cascade).
 func (s *Server) SetCloudSidecar(c CloudSidecar) {
 	s.cloudSidecar = c
+}
+
+// SetBillingAvailable marks this deployment as having Stripe Checkout wired
+// up. Called from cmd/pad/main.go when PAD_BILLING_AVAILABLE=true is set.
+// When false (the default), the session payload advertises billing_available=false
+// so the web UI hides Stripe CTAs rather than dead-ending at a 503. TASK-800.
+func (s *Server) SetBillingAvailable(v bool) {
+	s.billingAvailable = v
 }
 
 // IsCloud reports whether the server is running in cloud mode.

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -1529,6 +1529,17 @@ export const api = {
 		 * `window.location.href = url` to start the Stripe-hosted flow.
 		 * Returns HTTP 503 with `{ error: string }` when Stripe is not
 		 * configured (PAD_BILLING_AVAILABLE not yet set on the sidecar).
+		 *
+		 * Cross-service notes (pad-cloud sidecar conventions, not pad's):
+		 *
+		 * CSRF: pad-cloud uses Origin/Referer-based CSRF (`validateOrigin` in
+		 * pad-cloud/stripe.go), NOT header-token CSRF. `credentials: 'same-origin'`
+		 * is what enables this — browsers automatically attach the matching Origin
+		 * header on same-origin POST. No `X-CSRF-Token` forwarding needed.
+		 *
+		 * Error envelope: pad-cloud returns flat `{ error: string }` (its own
+		 * convention) rather than pad's nested `{ error: { code, message } }` from
+		 * TASK-788. Parse accordingly below.
 		 */
 		createCheckoutSession: (): Promise<{ url: string }> =>
 			fetch('/billing/checkout', {

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -320,6 +320,10 @@ export interface AuthSession {
 	// is unset on the server — UI code should use the empty string as the gate
 	// for "Remote MCP not exposed by this instance, fall back to CLI flow."
 	mcp_public_url: string;
+	// billing_available is true when PAD_BILLING_AVAILABLE=true on the server
+	// AND the deployment is in cloud mode. Use authStore.billingAvailable rather
+	// than reading this field directly. TASK-800.
+	billing_available?: boolean;
 	user?: { id: string; email: string; username: string; name: string; role: string; plan?: string };
 }
 
@@ -1510,6 +1514,37 @@ export const api = {
 		// Cloud-mode only (returns 404 in self-host).
 		getBillingStats: () =>
 			request<AdminBillingStats>('/admin/billing-stats')
+	},
+
+	// ── Billing (user-facing Stripe Checkout / Portal) ────────────────────
+	//
+	// These endpoints are served by the pad-cloud sidecar (not the pad binary)
+	// at the same origin via nginx reverse-proxy. They do NOT use the /api/v1/
+	// prefix. TASK-800.
+
+	billing: {
+		/**
+		 * POST /billing/checkout — create a Stripe Checkout session.
+		 * Returns `{ url: string }` on success; the caller must do
+		 * `window.location.href = url` to start the Stripe-hosted flow.
+		 * Returns HTTP 503 with `{ error: string }` when Stripe is not
+		 * configured (PAD_BILLING_AVAILABLE not yet set on the sidecar).
+		 */
+		createCheckoutSession: (): Promise<{ url: string }> =>
+			fetch('/billing/checkout', {
+				method: 'POST',
+				credentials: 'same-origin',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({})
+			}).then(async (r) => {
+				if (!r.ok) {
+					const body = await r.json().catch(() => ({}));
+					throw new Error(
+						(body as { error?: string }).error || `Checkout request failed (${r.status})`
+					);
+				}
+				return r.json() as Promise<{ url: string }>;
+			})
 	}
 };
 

--- a/web/src/lib/components/editor/EditorBubbleMenu.svelte
+++ b/web/src/lib/components/editor/EditorBubbleMenu.svelte
@@ -173,7 +173,7 @@
 			hide();
 		} catch (err: any) {
 			if (isPlanLimitError(err)) {
-				errorMsg = planLimitMessage(err) + ' Upgrade to Pro at /console/billing';
+				toastStore.show(planLimitMessage(err) + ' Upgrade to Pro', 'error', 6000, '/console/billing');
 			} else {
 				errorMsg = err.message || 'Failed to create item';
 			}

--- a/web/src/lib/components/layout/CreateWorkspaceModal.svelte
+++ b/web/src/lib/components/layout/CreateWorkspaceModal.svelte
@@ -114,7 +114,7 @@
 			goto(`/${ws.owner_username}/${ws.slug}`);
 		} catch (err: unknown) {
 			if (isPlanLimitError(err)) {
-				toastStore.show(planLimitMessage(err) + ' Upgrade to Pro at /console/billing', 'error');
+				toastStore.show(planLimitMessage(err) + ' Upgrade to Pro', 'error', 6000, '/console/billing');
 			} else {
 				toastStore.show('Failed to create workspace', 'error');
 			}

--- a/web/src/lib/components/layout/Sidebar.svelte
+++ b/web/src/lib/components/layout/Sidebar.svelte
@@ -174,7 +174,7 @@
 			goto(`${wsPrefix}/${coll.slug}/${itemUrlId(item)}?new=1`);
 		} catch (err: any) {
 			if (isPlanLimitError(err)) {
-				toastStore.show(planLimitMessage(err) + ' Upgrade to Pro at /console/billing', 'error');
+				toastStore.show(planLimitMessage(err) + ' Upgrade to Pro', 'error', 6000, '/console/billing');
 			} else {
 				toastStore.show(err?.message || 'Failed to create item', 'error');
 			}

--- a/web/src/lib/stores/auth.svelte.ts
+++ b/web/src/lib/stores/auth.svelte.ts
@@ -24,6 +24,11 @@ export const authStore = {
 	// Components that conditionally render Remote-MCP onboarding UI should
 	// branch on `authStore.mcpPublicUrl !== ''`.
 	get mcpPublicUrl() { return session?.mcp_public_url ?? ''; },
+	// billingAvailable is true when the server has PAD_BILLING_AVAILABLE=true
+	// AND is in cloud mode. Components gate "Upgrade to Pro" Stripe CTAs on
+	// this value — false means the CTA is hidden entirely, not just disabled.
+	// TASK-800.
+	get billingAvailable() { return session?.billing_available ?? false; },
 	get loading() { return loading; },
 
 	async load() {

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -897,7 +897,7 @@
 			goto(`/${username}/${wsSlug}/${collSlug}/${itemUrlId(item)}?new=1`);
 		} catch (err: any) {
 			if (isPlanLimitError(err)) {
-				toastStore.show(planLimitMessage(err) + ' Upgrade to Pro at /console/billing', 'error');
+				toastStore.show(planLimitMessage(err) + ' Upgrade to Pro', 'error', 6000, '/console/billing');
 			} else {
 				toastStore.show(err?.message || 'Failed to create item', 'error');
 			}
@@ -928,7 +928,7 @@
 			toastStore.show(`Created "${title}"`, 'success');
 		} catch (err: any) {
 			if (isPlanLimitError(err)) {
-				toastStore.show(planLimitMessage(err) + ' Upgrade to Pro at /console/billing', 'error');
+				toastStore.show(planLimitMessage(err) + ' Upgrade to Pro', 'error', 6000, '/console/billing');
 			} else {
 				toastStore.show(err?.message || 'Failed to create item', 'error');
 			}

--- a/web/src/routes/[username]/[workspace]/conventions/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/conventions/+page.svelte
@@ -249,7 +249,7 @@
 			resetForm();
 		} catch (err: unknown) {
 			if (isPlanLimitError(err)) {
-				toastStore.show(planLimitMessage(err) + ' Upgrade to Pro at /console/billing', 'error');
+				toastStore.show(planLimitMessage(err) + ' Upgrade to Pro', 'error', 6000, '/console/billing');
 			} else {
 				toastStore.show('Failed to create convention', 'error');
 			}

--- a/web/src/routes/[username]/[workspace]/playbooks/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/playbooks/+page.svelte
@@ -227,7 +227,7 @@
 			await loadPlaybooks(wsSlug);
 		} catch (err: unknown) {
 			if (isPlanLimitError(err)) {
-				toastStore.show(planLimitMessage(err) + ' Upgrade to Pro at /console/billing', 'error');
+				toastStore.show(planLimitMessage(err) + ' Upgrade to Pro', 'error', 6000, '/console/billing');
 			} else {
 				toastStore.show('Failed to create playbook', 'error');
 			}
@@ -285,7 +285,7 @@
 			await loadPlaybooks(wsSlug);
 		} catch (err: unknown) {
 			if (isPlanLimitError(err)) {
-				toastStore.show(planLimitMessage(err) + ' Upgrade to Pro at /console/billing', 'error');
+				toastStore.show(planLimitMessage(err) + ' Upgrade to Pro', 'error', 6000, '/console/billing');
 			} else {
 				toastStore.show('Failed to duplicate playbook', 'error');
 			}

--- a/web/src/routes/[username]/[workspace]/roles/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/roles/+page.svelte
@@ -112,7 +112,7 @@
 			await loadData();
 		} catch (err) {
 			if (isPlanLimitError(err)) {
-				toastStore.show(planLimitMessage(err) + ' Upgrade to Pro at /console/billing', 'error');
+				toastStore.show(planLimitMessage(err) + ' Upgrade to Pro', 'error', 6000, '/console/billing');
 			} else {
 				console.error('Failed to create item:', err);
 			}

--- a/web/src/routes/[username]/[workspace]/settings/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/settings/+page.svelte
@@ -239,10 +239,7 @@
 			invitations = memberData.invitations ?? [];
 		} catch (err: unknown) {
 			if (isPlanLimitError(err)) {
-				inviteResult = {
-					message: planLimitMessage(err) + ' Upgrade to Pro at /console/billing',
-					type: 'error'
-				};
+				toastStore.show(planLimitMessage(err) + ' Upgrade to Pro', 'error', 6000, '/console/billing');
 			} else {
 				inviteResult = { message: err instanceof Error ? err.message : 'Failed to invite', type: 'error' };
 			}

--- a/web/src/routes/console/billing/+page.svelte
+++ b/web/src/routes/console/billing/+page.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
 	import { authStore } from '$lib/stores/auth.svelte';
+	import { api } from '$lib/api/client';
+	import { toastStore } from '$lib/stores/toast.svelte';
 	import { goto } from '$app/navigation';
 	import { page } from '$app/state';
 	import { onMount, onDestroy } from 'svelte';
@@ -34,22 +36,23 @@
 	let isPro = $derived(plan === 'pro');
 	let limits = $state<{ free: PlanLimits; pro: PlanLimits } | null>(null);
 
-	// Gate for Stripe-backed upgrade affordances. Stripe isn't wired up on
-	// this deployment yet, so the Free → Pro CTAs would dead-end at a 404
-	// from /billing/checkout. Flip this to `true` (or thread it through a
-	// server flag like `authStore.session?.billing_enabled`) once the
-	// pad-cloud sidecar's Stripe integration is live so the "Upgrade to Pro"
-	// buttons return. The "Confirming your upgrade…" / "Upgrade confirmed"
-	// banners below stay wired — they only fire when ?checkout=success is
-	// present in the URL, which can only happen after a real Stripe redirect.
-	const STRIPE_AVAILABLE = false;
+	// Gate for Stripe-backed upgrade affordances. Driven by the server-side
+	// PAD_BILLING_AVAILABLE flag so the CTA appears only when the pad-cloud
+	// sidecar has Stripe keys loaded — no code change needed at deploy time.
+	// TASK-800.
+	let stripeAvailable = $derived(authStore.billingAvailable);
+
+	// Checkout-in-progress state. True while the POST /billing/checkout
+	// fetch is in flight so the button shows a spinner and prevents
+	// double-submission.
+	let checkoutInProgress = $state(false);
 
 	// Upgrade-confirmation state. After Stripe Checkout redirects back with
 	// ?checkout=success, pad-cloud's webhook handler needs a moment to land
 	// at pad's /admin/plan endpoint before the user's plan flips to "pro".
 	// Poll authStore.load() on a short interval until the plan updates or we
 	// hit the timeout — a proxy for "something is wrong, please refresh".
-	let upgradeStatus = $state<'idle' | 'checking' | 'confirmed' | 'timeout'>('idle');
+	let upgradeStatus = $state<'idle' | 'checking' | 'confirmed' | 'timeout' | 'cancelled'>('idle');
 	let pollTimer: ReturnType<typeof setInterval> | null = null;
 	let pollStartedAt = 0;
 	// Guards every post-await state write: an authStore.load() or plan-limits
@@ -182,18 +185,43 @@
 		}
 	}
 
+	// startCheckout POSTs to pad-cloud's /billing/checkout endpoint, parses
+	// the returned {url} and redirects the browser to the Stripe-hosted
+	// checkout page. Uses window.location.href so the Stripe session is
+	// opened in the same tab (matching Stripe's UX recommendation).
+	// Called from the "Upgrade to Pro" buttons. TASK-800.
+	async function startCheckout() {
+		if (checkoutInProgress) return;
+		checkoutInProgress = true;
+		try {
+			const result = await api.billing.createCheckoutSession();
+			// Redirect to Stripe Checkout — leaves the SPA.
+			window.location.href = result.url;
+		} catch (err) {
+			checkoutInProgress = false;
+			const msg = err instanceof Error ? err.message : 'Failed to start checkout. Please try again.';
+			toastStore.show(msg, 'error');
+		}
+	}
+
 	onMount(() => {
 		if (!authStore.cloudMode) {
 			goto('/console', { replaceState: true });
 			return;
 		}
 
-		// Kick off the two independent async tasks in parallel. Neither is
+		// Kick off the three independent async tasks in parallel. None are
 		// awaited here — onMount returns immediately so Svelte can run the
 		// onDestroy cleanup path synchronously if the user navigates away
-		// before either task resolves (the `destroyed` guard handles that).
-		if (page.url.searchParams.get('checkout') === 'success') {
+		// before any task resolves (the `destroyed` guard handles that).
+		const checkoutParam = page.url.searchParams.get('checkout');
+		if (checkoutParam === 'success') {
 			startUpgradeConfirmation();
+		} else if (checkoutParam === 'cancelled') {
+			// User abandoned the Stripe Checkout page. Show a brief notice
+			// and clear the query param so a reload doesn't re-fire it.
+			upgradeStatus = 'cancelled';
+			clearCheckoutQuery();
 		}
 		loadPlanLimits();
 	});
@@ -225,6 +253,10 @@
 		<div class="upgrade-banner warning" role="status" aria-live="polite">
 			<span>Your payment went through but we haven't confirmed your upgrade yet. Try refreshing in a moment; if your plan still shows Free, contact <a href="mailto:support@getpad.dev">support@getpad.dev</a>.</span>
 		</div>
+	{:else if upgradeStatus === 'cancelled'}
+		<div class="upgrade-banner cancelled" role="status" aria-live="polite">
+			<span>No charge — you returned to your workspace without completing checkout.</span>
+		</div>
 	{/if}
 
 	<section class="card">
@@ -250,8 +282,14 @@
 
 			{#if isPro}
 				<a href="/billing/portal" class="secondary-btn">Manage Billing</a>
-			{:else if STRIPE_AVAILABLE}
-				<a href="/billing/checkout" class="primary-btn">Upgrade to Pro</a>
+			{:else if stripeAvailable}
+				<button
+					class="primary-btn"
+					onclick={startCheckout}
+					disabled={checkoutInProgress}
+				>
+					{checkoutInProgress ? 'Redirecting…' : 'Upgrade to Pro'}
+				</button>
 			{/if}
 		</div>
 	</section>
@@ -288,9 +326,15 @@
 				</tbody>
 			</table>
 			{#if !isPro}
-				{#if STRIPE_AVAILABLE}
+				{#if stripeAvailable}
 					<div class="compare-cta">
-						<a href="/billing/checkout" class="primary-btn">Upgrade to Pro</a>
+						<button
+							class="primary-btn"
+							onclick={startCheckout}
+							disabled={checkoutInProgress}
+						>
+							{checkoutInProgress ? 'Redirecting…' : 'Upgrade to Pro'}
+						</button>
 					</div>
 				{:else}
 					<div class="compare-cta coming-soon">
@@ -388,16 +432,23 @@
 		padding: var(--space-2) var(--space-5);
 		background: var(--accent-blue);
 		color: #fff;
+		border: none;
 		border-radius: var(--radius);
 		font-size: 0.9rem;
 		font-weight: 500;
 		text-decoration: none;
+		cursor: pointer;
 		transition: opacity 0.15s;
 	}
 
-	.primary-btn:hover {
+	.primary-btn:hover:not(:disabled) {
 		opacity: 0.9;
 		text-decoration: none;
+	}
+
+	.primary-btn:disabled {
+		opacity: 0.6;
+		cursor: not-allowed;
 	}
 
 	.secondary-btn {
@@ -575,6 +626,12 @@
 		background: color-mix(in srgb, var(--accent-yellow, #eab308) 12%, transparent);
 		border-color: color-mix(in srgb, var(--accent-yellow, #eab308) 35%, transparent);
 		color: var(--text-primary);
+	}
+
+	.upgrade-banner.cancelled {
+		background: color-mix(in srgb, var(--text-muted, #6b7280) 10%, transparent);
+		border-color: color-mix(in srgb, var(--text-muted, #6b7280) 25%, transparent);
+		color: var(--text-secondary);
 	}
 
 	.upgrade-banner a {

--- a/web/src/routes/console/settings/+page.svelte
+++ b/web/src/routes/console/settings/+page.svelte
@@ -2,6 +2,7 @@
 	import { onMount } from 'svelte';
 	import { api, isPlanLimitError, planLimitMessage } from '$lib/api/client';
 	import { authStore } from '$lib/stores/auth.svelte';
+	import { toastStore } from '$lib/stores/toast.svelte';
 	import { copyToClipboard } from '$lib/utils/clipboard';
 	import type { User, APIToken, APITokenWithSecret, TOTPSetupResponse } from '$lib/types';
 
@@ -313,7 +314,7 @@
 			newTokenName = '';
 		} catch (err) {
 			if (isPlanLimitError(err)) {
-				tokenError = planLimitMessage(err) + ' Upgrade to Pro at /console/billing';
+				toastStore.show(planLimitMessage(err) + ' Upgrade to Pro', 'error', 6000, '/console/billing');
 			} else {
 				tokenError = err instanceof Error ? err.message : 'Failed to create token';
 			}
@@ -547,6 +548,39 @@
 			</section>
 		{/if}
 
+		<!-- Plan (cloud mode only) — TASK-800 -->
+		{#if authStore.cloudMode}
+			<section class="card">
+				<h2 class="card-title">Plan</h2>
+				<div class="card-body">
+					<div class="plan-row">
+						<div class="plan-info">
+							<span class="plan-name">
+								{authStore.user?.plan === 'pro' ? 'Pro' : 'Free'}
+							</span>
+							<span class="plan-badge" class:pro={authStore.user?.plan === 'pro'} class:free={authStore.user?.plan !== 'pro'}>
+								{authStore.user?.plan === 'pro' ? 'Active' : 'Current'}
+							</span>
+						</div>
+						<p class="plan-desc">
+							{#if authStore.user?.plan === 'pro'}
+								You have full access to all Pad features.
+							{:else}
+								The free plan includes basic workspace management with limited features.
+							{/if}
+						</p>
+					</div>
+					{#if authStore.user?.plan !== 'pro'}
+						<a href="/console/billing" class="primary-btn">
+							{authStore.billingAvailable ? 'Upgrade to Pro' : 'View Plans'}
+						</a>
+					{:else}
+						<a href="/console/billing" class="secondary-btn">Manage Billing</a>
+					{/if}
+				</div>
+			</section>
+		{/if}
+
 		<!-- API Tokens -->
 		<section class="card">
 			<h2 class="card-title">API Tokens</h2>
@@ -686,6 +720,48 @@
 	.success {
 		color: var(--accent-green);
 		font-size: 0.85rem;
+	}
+
+	/* Plan section (TASK-800) */
+	.plan-row {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-2);
+	}
+
+	.plan-info {
+		display: flex;
+		align-items: center;
+		gap: var(--space-3);
+	}
+
+	.plan-name {
+		font-size: 1rem;
+		font-weight: 700;
+		color: var(--text-primary);
+	}
+
+	.plan-badge {
+		padding: 2px var(--space-2);
+		border-radius: var(--radius-sm);
+		font-size: 0.75rem;
+		font-weight: 500;
+	}
+
+	.plan-badge.pro {
+		background: color-mix(in srgb, var(--accent-green) 15%, transparent);
+		color: var(--accent-green);
+	}
+
+	.plan-badge.free {
+		background: color-mix(in srgb, var(--accent-gray, #6b7280) 15%, transparent);
+		color: var(--text-secondary);
+	}
+
+	.plan-desc {
+		color: var(--text-secondary);
+		font-size: 0.85rem;
+		line-height: 1.4;
 	}
 
 	.primary-btn {


### PR DESCRIPTION
## Summary

TASK-788 (PR #628) standardized the plan-limit error envelope and made the upgrade-prompt text show up correctly at every limit-hit. TASK-800 wires those prompts into actual destinations: clickable toasts that navigate to `/console/billing`, a new Plan section in `/console/settings`, a fixed (and now POST-correct) checkout button on the billing page, and the `?checkout=cancelled` return-from-Stripe banner.

**Stripe Test mode is not yet configured** on pad-cloud, so the checkout button is gated behind a new `PAD_BILLING_AVAILABLE` env var. Everything else in the PR ships and improves UX today; the live checkout flow stages for a one-env-flip activation once Stripe keys are loaded.

## What changed (architectural)

- **Session payload**: new `billing_available bool` field driven by `PAD_BILLING_AVAILABLE=true` env var AND cloud mode. Surfaced via `authStore.billingAvailable` in the SvelteKit app. Replaces the hardcoded `STRIPE_AVAILABLE = false` flag previously sitting in `/console/billing/+page.svelte`.
- **Checkout call shape**: new `api.billing.createCheckoutSession()` POSTs to pad-cloud's `/billing/checkout` (NOT under `/api/v1/` — pad-cloud is reverse-proxied at the same origin). Parses `{url: string}` and redirects via `window.location.href`. The previous `<a href="/billing/checkout">` GET-anchors would have 405'd at runtime; now corrected to POST-buttons.
- **Plan section in `/console/settings`**: new cloud-mode-gated section showing current plan + a "Upgrade to Pro" / "View Plans" / "Manage Billing" link (label adapts based on `billing_available` + current plan). Links to `/console/billing` for the actual checkout flow.
- **`?checkout=cancelled` handling**: `/console/billing` now renders a brief "No charge — you returned to your workspace without completing checkout" banner when Stripe redirects back with that param. Mirrors the existing `?checkout=success` flow.
- **11 limit-hit sites → clickable toasts**: all item-create, member-invite, workspace-create, token-create surfaces now use `toastStore.show(msg, 'error', 6000, '/console/billing')` — the existing toast component's link signature is honored end-to-end. Three sites previously rendered inline `<p>` errors; switched to the uniform toast pattern to avoid `{@html}` XSS risk.
- **Cross-service contract docs**: inline comment on `createCheckoutSession()` documents pad-cloud's Origin/Referer CSRF model (NOT header-token, unlike pad's own API) and pad-cloud's flat `{error: string}` envelope (NOT pad's nested `{error: {code, message, details}}` from TASK-788). Two real cross-service divergences a future reader needs to know.

## Observable behavior changes

| Before | After |
|---|---|
| Limit-hit toast: `"You've reached the 3-member limit on the free plan. Upgrade to Pro at /console/billing"` (plain text, not clickable) | Toast: `"You've reached the 3-member limit on the free plan. Upgrade to Pro →"` clickable to `/console/billing` |
| `/console/billing` upgrade button: `<a href="/billing/checkout">` (GET) → 405 from pad-cloud (POST endpoint) | `<button>` posts to `/billing/checkout`, parses `{url}`, redirects to Stripe Checkout. Gated on `PAD_BILLING_AVAILABLE=true` |
| `/console/settings`: no Plan visibility | New cloud-mode-gated Plan section with current plan + upgrade affordance |
| `/console/billing?checkout=cancelled`: no handling | Brief "No charge — you returned to your workspace" banner; query param cleared |
| Limit-hit inline messages (3 sites): inline `<p>` with plain text | All converted to clickable toasts; consistent pattern across all 11 sites |

## Activation

When pad-cloud has Stripe Test (or Live) keys loaded, set `PAD_BILLING_AVAILABLE=true` on the pad binary's deployment env. The session payload flips, the upgrade buttons appear, and the checkout flow goes live. No code change required at activation time.

## Test plan

- [x] `go test ./...` (SQLite) — all packages pass
- [x] `make test-pg` (Postgres) — all packages pass
- [x] `make lint` (golangci-lint) — 0 issues
- [x] `npm run check` — 0 errors (4 pre-existing warnings unchanged from main)
- [x] `npm run build` — clean
- [x] New test: `TestAuthSessionBillingAvailable` (three cases: cloud-off → false, cloud-on + flag-off → false, both-on → true) on `handlers_auth_test.go`.

## Review trail

Three codex review rounds via PATTE-37 framing rotation (default → gap-lens → contract-blast-radius). R1 CLEAN. R2 CLEAN with one CSRF concern that I investigated against pad-cloud's source and resolved via inline documentation (pad-cloud uses Origin/Referer CSRF via `validateOrigin`, not header-token CSRF — same-origin POST with `credentials: 'same-origin'` satisfies this automatically). R3 CLEAN under contract-blast-radius lens.

## Out of scope (deferred)

- **Live Stripe Checkout end-to-end testing**: gated on Stripe key configuration. The `PAD_BILLING_AVAILABLE` env var is the one-flip activation.
- **Stripe webhook subscription-lifecycle handling**: separate concern; this PR is the click-flow only.
- **Email notifications on checkout success**: separate concern.
- **Annual vs monthly billing toggle**: phase later.
- **Standalone `/pricing` route**: the existing `/console/billing` page already serves as the plan-comparison surface; no separate route created.
- **Workspace-import bypass**: PLAN-890 territory (per yesterday's HANDO-72 and TASK-788's PR-body deferral).
- **pad-cloud-side error envelope migration**: pad-cloud uses flat `{error: string}` while pad uses nested `{error: {code, message, details}}` from TASK-788. The divergence is documented inline in `createCheckoutSession()`; if pad-cloud is ever migrated for consistency, the parser would need a coordinated update. Known future-coupling.

## Refs

- docapp: TASK-800 (this), PLAN-775 (Stage 3 parent), TASK-788 (PR #628 — Stage 2 upstream that landed earlier today), PLAN-890 (limit-enforcement gap, separate concern)
- claude: PATTE-37 (codex framing rotation), PATTE-38 (diff-size ≠ risk-surface), PATTE-39 (verification matrix), MISTA-70 (loop-cleanness vs goal-impact target selection)