### PR TITLE
fix(auth): scope admin platform role to cookie session auth (BUG-1616)

### DIFF
--- a/internal/server/handlers_admin_bearer_gate_test.go
+++ b/internal/server/handlers_admin_bearer_gate_test.go
@@ -1,0 +1,248 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// BUG-1616 extended coverage — admin-via-bearer gate at the SSE and
+// WebSocket-collab entry points that sit OUTSIDE RequireWorkspaceAccess.
+// These endpoints (handlers_events.go::handleSSE,
+// handlers_collab.go::authorizeCollabAccess) maintain their own auth
+// logic with their own admin bypass branches; the middleware fix at
+// internal/server/middleware_auth.go does not reach them.
+//
+// Codex review (round 1) caught the gap. These tests pin the four sites
+// fixed in the same round:
+//
+//   1. handleSSE entry — explicit GetWorkspaceMember check after the
+//      slug resolve for bearer-borne admin.
+//   2. sseSubscriberStillHasAccess — admin-bypass gated on
+//      !isBearerAuth(r), plus membership-only stance on the grants
+//      fallback.
+//   3. computeSSEVisibility — admin-bypass gated on !isBearerAuth(r);
+//      bearer-admin gets a real VisibleCollectionIDs filter snapshot.
+//   4. authorizeCollabAccess — admin-bypass gated on !isBearerAuth(r),
+//      plus membership-only stance on the grants fallback.
+
+// mkAdminBearerReq builds an *http.Request that looks like a bearer-
+// authenticated call: ctxCurrentUser set, Authorization: Bearer header
+// present. The header content doesn't have to be a real token because
+// the helper functions under test read isBearerAuth(r), which only
+// checks header *presence*.
+func mkAdminBearerReq(t *testing.T, path string, admin *models.User) *http.Request {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	req.Header.Set("Authorization", "Bearer pad_test_fake_token_value_not_validated_here")
+	return req.WithContext(context.WithValue(req.Context(), ctxCurrentUser, admin))
+}
+
+// mkAdminCookieReq is the same shape minus the Authorization header.
+// Simulates the cookie-session path where isBearerAuth must return
+// false and the admin bypass must continue to fire.
+func mkAdminCookieReq(t *testing.T, path string, admin *models.User) *http.Request {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	return req.WithContext(context.WithValue(req.Context(), ctxCurrentUser, admin))
+}
+
+// TestSSESubscriberStillHasAccess_AdminBearer_DeniedOnNonMember pins
+// the bearer-aware revalidation path. Cookie admin → still has access;
+// bearer admin (Authorization: Bearer header) → denied.
+func TestSSESubscriberStillHasAccess_AdminBearer_DeniedOnNonMember(t *testing.T) {
+	srv := testServer(t)
+
+	admin, err := srv.store.CreateUser(models.UserCreate{
+		Email: "admin@example.com", Name: "Admin", Password: "correct-horse-battery-staple", Role: "admin",
+	})
+	if err != nil {
+		t.Fatalf("create admin: %v", err)
+	}
+	// Need a second admin so we don't accidentally hit the
+	// last-admin guard in any future SetUserRole assertion.
+	if _, err := srv.store.CreateUser(models.UserCreate{
+		Email: "admin2@example.com", Name: "Admin2", Password: "correct-horse-battery-staple", Role: "admin",
+	}); err != nil {
+		t.Fatalf("create second admin: %v", err)
+	}
+	ws, err := srv.store.CreateWorkspace(models.WorkspaceCreate{Name: "BearerSSE"})
+	if err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+
+	// Cookie path — admin bypass fires, access granted.
+	if !srv.sseSubscriberStillHasAccess(mkAdminCookieReq(t, "/api/v1/events?workspace="+ws.Slug, admin), ws.ID) {
+		t.Fatal("cookie-session admin should still have access (web UI / SPA path)")
+	}
+
+	// Bearer path — admin bypass suppressed, no membership row →
+	// denied. This is the BUG-1616 extension Codex called out.
+	if srv.sseSubscriberStillHasAccess(mkAdminBearerReq(t, "/api/v1/events?workspace="+ws.Slug, admin), ws.ID) {
+		t.Fatal("bearer-borne admin without workspace membership must NOT pass SSE revalidation (BUG-1616)")
+	}
+}
+
+// TestSSESubscriberStillHasAccess_AdminBearer_DeniedEvenWithGrants
+// pins the membership-only stance: a bearer-admin with a guest grant
+// on a workspace they didn't join still loses access on the next
+// revalidation tick. Mirrors the same stance enforced by
+// RequireWorkspaceAccess.
+func TestSSESubscriberStillHasAccess_AdminBearer_DeniedEvenWithGrants(t *testing.T) {
+	srv := testServer(t)
+
+	admin, err := srv.store.CreateUser(models.UserCreate{
+		Email: "admin@example.com", Name: "Admin", Password: "correct-horse-battery-staple", Role: "admin",
+	})
+	if err != nil {
+		t.Fatalf("create admin: %v", err)
+	}
+	owner, err := srv.store.CreateUser(models.UserCreate{
+		Email: "owner@example.com", Name: "Owner", Password: "correct-horse-battery-staple", Role: "member",
+	})
+	if err != nil {
+		t.Fatalf("create owner: %v", err)
+	}
+	ws, err := srv.store.CreateWorkspace(models.WorkspaceCreate{Name: "BearerSSEGrant", OwnerID: owner.ID})
+	if err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	if err := srv.store.AddWorkspaceMember(ws.ID, owner.ID, "owner"); err != nil {
+		t.Fatalf("add owner: %v", err)
+	}
+	// Seed a collection + grant the admin view access. Admin is NOT
+	// in workspace_members.
+	coll, err := srv.store.CreateCollection(ws.ID, models.CollectionCreate{
+		Name: "Tasks", Slug: "tasks", Prefix: "TASK",
+	})
+	if err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	if _, err := srv.store.CreateCollectionGrant(ws.ID, coll.ID, admin.ID, "view", owner.ID); err != nil {
+		t.Fatalf("create grant: %v", err)
+	}
+
+	if srv.sseSubscriberStillHasAccess(mkAdminBearerReq(t, "/api/v1/events?workspace="+ws.Slug, admin), ws.ID) {
+		t.Fatal("bearer-admin with only a guest grant must NOT pass SSE revalidation (membership-only stance)")
+	}
+}
+
+// TestComputeSSEVisibility_AdminBearer_GetsFilter verifies the
+// per-tick visibility recompute applies the bearer-admin gate too.
+// Without the gate, an admin who's a workspace member with
+// CollectionAccess="specific" would still see events from every
+// collection because the recompute fell through the admin bypass
+// before resolving VisibleCollectionIDs.
+func TestComputeSSEVisibility_AdminBearer_GetsFilter(t *testing.T) {
+	srv := testServer(t)
+
+	admin, err := srv.store.CreateUser(models.UserCreate{
+		Email: "admin@example.com", Name: "Admin", Password: "correct-horse-battery-staple", Role: "admin",
+	})
+	if err != nil {
+		t.Fatalf("create admin: %v", err)
+	}
+	ws, err := srv.store.CreateWorkspace(models.WorkspaceCreate{Name: "VisBearer", OwnerID: admin.ID})
+	if err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	if err := srv.store.AddWorkspaceMember(ws.ID, admin.ID, "editor"); err != nil {
+		t.Fatalf("add admin as member: %v", err)
+	}
+	// Two collections; restrict admin to one.
+	visible, err := srv.store.CreateCollection(ws.ID, models.CollectionCreate{
+		Name: "Visible", Slug: "visible", Prefix: "VIS",
+	})
+	if err != nil {
+		t.Fatalf("create visible collection: %v", err)
+	}
+	if _, err := srv.store.CreateCollection(ws.ID, models.CollectionCreate{
+		Name: "Hidden", Slug: "hidden", Prefix: "HID",
+	}); err != nil {
+		t.Fatalf("create hidden collection: %v", err)
+	}
+	if err := srv.store.SetMemberCollectionAccess(ws.ID, admin.ID, "specific", []string{visible.ID}); err != nil {
+		t.Fatalf("set member collection access: %v", err)
+	}
+
+	// Cookie path — admin bypass fires, no collection filter.
+	vCookie := srv.computeSSEVisibility(mkAdminCookieReq(t, "/api/v1/events?workspace="+ws.Slug, admin), ws.ID)
+	if vCookie.visibleSlugSet != nil {
+		t.Errorf("cookie admin should see all events (nil filter); got %v", vCookie.visibleSlugSet)
+	}
+
+	// Bearer path — bypass suppressed, real filter applied.
+	vBearer := srv.computeSSEVisibility(mkAdminBearerReq(t, "/api/v1/events?workspace="+ws.Slug, admin), ws.ID)
+	if vBearer.visibleSlugSet == nil {
+		t.Fatalf("bearer admin should get a filtered visibility set; got nil (no filter)")
+	}
+	if !vBearer.visibleSlugSet["visible"] {
+		t.Errorf("bearer admin should see the granted 'visible' collection; got %v", vBearer.visibleSlugSet)
+	}
+	if vBearer.visibleSlugSet["hidden"] {
+		t.Errorf("bearer admin should NOT see the unrestricted 'hidden' collection; got %v", vBearer.visibleSlugSet)
+	}
+}
+
+// TestAuthorizeCollabAccess_AdminBearer_DeniedOnNonMember pins the
+// WebSocket-collab entry gate. Bearer-admin on a non-member workspace's
+// item → forbidden. Cookie-admin → allowed (web UI preserves the
+// global-admin affordance).
+func TestAuthorizeCollabAccess_AdminBearer_DeniedOnNonMember(t *testing.T) {
+	srv := testServer(t)
+
+	admin, err := srv.store.CreateUser(models.UserCreate{
+		Email: "admin@example.com", Name: "Admin", Password: "correct-horse-battery-staple", Role: "admin",
+	})
+	if err != nil {
+		t.Fatalf("create admin: %v", err)
+	}
+	owner, err := srv.store.CreateUser(models.UserCreate{
+		Email: "owner@example.com", Name: "Owner", Password: "correct-horse-battery-staple", Role: "member",
+	})
+	if err != nil {
+		t.Fatalf("create owner: %v", err)
+	}
+	ws, err := srv.store.CreateWorkspace(models.WorkspaceCreate{Name: "CollabBearer", OwnerID: owner.ID})
+	if err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	if err := srv.store.AddWorkspaceMember(ws.ID, owner.ID, "owner"); err != nil {
+		t.Fatalf("add owner: %v", err)
+	}
+	coll, err := srv.store.CreateCollection(ws.ID, models.CollectionCreate{
+		Name: "Tasks", Slug: "tasks", Prefix: "TASK",
+	})
+	if err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	item, err := srv.store.CreateItem(ws.ID, coll.ID, models.ItemCreate{
+		Title: "Secret", CreatedBy: "user", Source: "test",
+	})
+	if err != nil {
+		t.Fatalf("create item: %v", err)
+	}
+
+	// Cookie-session admin — bypass fires, access allowed.
+	if err := srv.authorizeCollabAccess(
+		mkAdminCookieReq(t, "/api/v1/collab/"+item.ID, admin), item,
+	); err != nil {
+		t.Fatalf("cookie admin should be allowed on collab WS; got error %v", err)
+	}
+
+	// Bearer admin — bypass suppressed, no membership → 403.
+	err = srv.authorizeCollabAccess(
+		mkAdminBearerReq(t, "/api/v1/collab/"+item.ID, admin), item,
+	)
+	if err == nil {
+		t.Fatal("bearer admin without workspace membership must NOT pass authorizeCollabAccess (BUG-1616)")
+	}
+	if se, ok := err.(*statusError); !ok {
+		t.Errorf("expected *statusError, got %T: %v", err, err)
+	} else if se.code != http.StatusForbidden {
+		t.Errorf("expected 403, got %d (msg=%s)", se.code, se.Error())
+	}
+}

--- a/internal/server/handlers_collab.go
+++ b/internal/server/handlers_collab.go
@@ -579,7 +579,11 @@ func (s *Server) authorizeCollabAccess(r *http.Request, item *models.Item) error
 	if fresh.IsDisabled() {
 		return newStatusError(http.StatusForbidden, "forbidden", "User is disabled")
 	}
-	if fresh.Role == "admin" {
+	// Admin platform-role bypass — cookie session auth only (BUG-1616).
+	// Bearer-borne admin (CLI / PAT / MCP) falls through to the
+	// membership-only check below. Mirrors RequireWorkspaceAccess.
+	isBearer := isBearerAuth(r)
+	if fresh.Role == "admin" && !isBearer {
 		return nil
 	}
 
@@ -594,6 +598,13 @@ func (s *Server) authorizeCollabAccess(r *http.Request, item *models.Item) error
 	}
 	hasWorkspaceLevelAccess := member != nil
 	if !hasWorkspaceLevelAccess {
+		// Bearer-admin (BUG-1616): membership-only stance. Skip the
+		// guest-grants fallback exactly like RequireWorkspaceAccess.
+		if fresh.Role == "admin" && isBearer {
+			s.recordMCPAuthzDenial(r, "not_a_member")
+			return newStatusError(http.StatusForbidden, "forbidden",
+				"You are not a member of this workspace")
+		}
 		hasGrants, err := s.store.UserHasGrantsInWorkspace(wsID, fresh.ID)
 		if err != nil {
 			return err

--- a/internal/server/handlers_events.go
+++ b/internal/server/handlers_events.go
@@ -78,6 +78,28 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Admin-via-bearer membership gate (BUG-1616). resolveWorkspace
+	// above uses a global slug lookup for admin users, so a bearer-
+	// borne admin (CLI / PAT / MCP) would otherwise sail through and
+	// subscribe to any workspace's event stream without ever appearing
+	// in workspace_members. The cookie-borne web UI keeps the bypass
+	// (admin can subscribe from /console/admin); bearer callers fall
+	// through to a strict membership check, exactly matching the
+	// policy enforced by RequireWorkspaceAccess on /api/v1/* and by
+	// authorizeCollabAccess on the WS upgrade.
+	if u := currentUser(r); u != nil && u.Role == "admin" && isBearerAuth(r) {
+		member, err := s.store.GetWorkspaceMember(ws.ID, u.ID)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "internal_error", "Failed to check workspace access")
+			return
+		}
+		if member == nil {
+			s.recordMCPAuthzDenial(r, "not_a_member")
+			writeError(w, http.StatusForbidden, "forbidden", "You are not a member of this workspace")
+			return
+		}
+	}
+
 	// Verify streaming support
 	flusher, ok := w.(http.Flusher)
 	if !ok {
@@ -374,12 +396,20 @@ func (s *Server) computeSSEVisibility(r *http.Request, workspaceID string) sseVi
 	// Collection-level visibility first. Mirrors visibleCollectionIDs
 	// but with a freshly-fetched user so a mid-stream admin-to-member
 	// demotion immediately applies the collection filter.
+	//
+	// Admin bypass ("no filtering") fires for cookie session auth only
+	// (BUG-1616). For bearer-borne admin (CLI / PAT / MCP) we compute
+	// the real VisibleCollectionIDs based on their actual member /
+	// grant rows — same policy as RequireWorkspaceAccess. Without
+	// this, a bearer-admin who happens to be a "specific"-access
+	// member would still see every collection's events.
 	var visibleIDs []string
 	var err error
-	if user != nil && user.Role != "admin" {
+	useAdminBypass := user != nil && user.Role == "admin" && !isBearerAuth(r)
+	if user != nil && !useAdminBypass {
 		visibleIDs, err = s.store.VisibleCollectionIDs(workspaceID, user.ID)
 	}
-	// (user == nil || user.Role == "admin") falls through with nil
+	// (user == nil || useAdminBypass) falls through with nil
 	// visibleIDs — nil means "no filtering" in the snapshot below.
 	if err != nil {
 		// Fail closed: if we can't determine visibility, deny all
@@ -513,8 +543,12 @@ func (s *Server) sseSubscriberStillHasAccess(r *http.Request, workspaceID string
 	if user.IsDisabled() {
 		return false
 	}
-	// Admins can access any workspace.
-	if user.Role == "admin" {
+	// Admins can access any workspace — but only via cookie session
+	// auth (BUG-1616). Bearer-borne admin (CLI / PAT / MCP) falls
+	// through to the membership-only check below; revalidation must
+	// match the entry-time policy or a live stream would survive past
+	// what the entry handler would now reject on reconnect.
+	if user.Role == "admin" && !isBearerAuth(r) {
 		return true
 	}
 	// Direct workspace member?
@@ -530,6 +564,13 @@ func (s *Server) sseSubscriberStillHasAccess(r *http.Request, workspaceID string
 	}
 	if member != nil {
 		return true
+	}
+	// Bearer-admin (BUG-1616): membership-only stance. Skip the
+	// guest-grants fallback so a platform admin who happens to hold
+	// a guest grant somewhere can't keep a bearer-borne SSE stream
+	// open against a workspace they didn't join.
+	if user.Role == "admin" && isBearerAuth(r) {
+		return false
 	}
 	// Not a member — check guest grants.
 	has, err := s.store.UserHasGrantsInWorkspace(workspaceID, user.ID)

--- a/internal/server/middleware_auth.go
+++ b/internal/server/middleware_auth.go
@@ -383,6 +383,32 @@ func isAPITokenAuth(r *http.Request) bool {
 	return v
 }
 
+// isBearerAuth reports whether the request was authenticated via an
+// Authorization: Bearer header rather than a browser session cookie.
+// True for: PATs on /api/v1, PATs on /mcp, OAuth bearers on /mcp, AND
+// CLI session-bearer tokens (padsess_* delivered via Authorization:
+// Bearer, see TokenAuth's session-bearer branch at line 92-132).
+// False for: cookie-borne SessionAuth (the web UI / SPA path).
+//
+// Mirrors the dual signal used by middleware_csrf.go (line 73-80) —
+// either an Authorization: Bearer header on the live request OR a
+// ctxIsAPIToken stash on context counts as "non-browser caller."
+//
+// Used by RequireWorkspaceAccess (BUG-1616) to suppress the
+// platform-admin global bypass: admin identity carries owner-level
+// authority over every workspace ONLY for the cookie-borne web UI
+// surface. Bearer-borne callers (CLI, PAT, MCP) get the strict
+// workspace_members check — a leaked admin token, or an MCP client
+// that picked "all current workspaces" at consent time, must not
+// silently widen access from "workspaces the admin joined" to
+// "every workspace on the server."
+func isBearerAuth(r *http.Request) bool {
+	if auth := r.Header.Get("Authorization"); strings.HasPrefix(auth, "Bearer ") {
+		return true
+	}
+	return isAPITokenAuth(r)
+}
+
 // currentUserID returns the authenticated user's ID, or empty string.
 func currentUserID(r *http.Request) string {
 	if u := currentUser(r); u != nil {
@@ -477,8 +503,38 @@ func (s *Server) RequireWorkspaceAccess(next http.Handler) http.Handler {
 			return
 		}
 
-		// Admin users get owner access to all workspaces
-		if user.Role == "admin" {
+		// Admin users get owner access to all workspaces — but ONLY for
+		// browser cookie session auth (the web UI / SPA surface). For
+		// every bearer-borne path (PATs on /api/v1, PATs and OAuth
+		// bearers on /mcp, AND padsess_* session bearers from the CLI),
+		// the platform-admin global bypass is suppressed and the admin
+		// falls through to the membership-only check below.
+		//
+		// Rationale (BUG-1616): a token — including a CLI session
+		// bearer — carries the user's identity, not the user's
+		// platform-admin authority. The OAuth consent UI's "All
+		// current workspaces" option, and the CLI's general affordance
+		// of "log in once and address every workspace by slug," are
+		// both meant to mean "every workspace the user is a member of"
+		// — not "every workspace on the entire server, by virtue of
+		// the user holding the platform admin role." A leaked admin
+		// token, an MCP client that picked the wide consent scope, or
+		// even a CLI session running on a compromised machine, would
+		// otherwise reach data the admin never joined.
+		//
+		// The cookie-borne web UI keeps the bypass because the UI
+		// shows the admin's chosen workspace explicitly and the
+		// /console/admin surface is the documented spot to act
+		// cross-workspace; the deliberate UI affordance + same-origin
+		// cookie binding make that a different threat model from the
+		// programmatic surfaces.
+		//
+		// isBearerAuth folds two signals (Authorization: Bearer header
+		// OR ctxIsAPIToken stash) so MCP-dispatcher synthesized
+		// requests and CLI session bearers are both covered — see
+		// the helper's comment for the full table.
+		isBearer := isBearerAuth(r)
+		if user.Role == "admin" && !isBearer {
 			ctx = context.WithValue(ctx, ctxWorkspaceRole, "owner")
 			next.ServeHTTP(w, r.WithContext(ctx))
 			return
@@ -490,6 +546,18 @@ func (s *Server) RequireWorkspaceAccess(next http.Handler) http.Handler {
 			return
 		}
 		if member == nil {
+			// Admin-via-bearer (BUG-1616): membership-only. Skip the
+			// guest-grants fallback so a platform admin who happens to
+			// hold a guest grant on some workspace still can't reach
+			// it via a bearer-borne caller (CLI / PAT / MCP) —
+			// strictly the workspaces they're actually a member of.
+			// Falls through to the same not_a_member denial non-admin
+			// non-members hit.
+			if user.Role == "admin" && isBearer {
+				s.recordMCPAuthzDenial(r, "not_a_member")
+				writeError(w, http.StatusForbidden, "forbidden", "You are not a member of this workspace")
+				return
+			}
 			// Not a member — check for guest access via grants
 			hasGrants, grantErr := s.store.UserHasGrantsInWorkspace(ws.ID, user.ID)
 			if grantErr != nil {

--- a/internal/server/middleware_auth_admin_token_gate_test.go
+++ b/internal/server/middleware_auth_admin_token_gate_test.go
@@ -1,0 +1,284 @@
+package server
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// BUG-1616 regression suite — verifies that an admin platform role does
+// NOT silently grant cross-workspace access when the request is
+// authenticated via an API token (PAT on /api/v1, PAT on /mcp, or OAuth
+// bearer on /mcp). Session-cookie admin access — the canonical web UI /
+// CLI session affordance — is unaffected.
+//
+// All four tests exercise RequireWorkspaceAccess end-to-end via
+// srv.ServeHTTP. The hot endpoint is GET /api/v1/workspaces/{slug}/dashboard
+// — it's behind RequireWorkspaceAccess + requireMinRole("viewer"), so the
+// middleware decision is what we're measuring; the dashboard payload is
+// irrelevant for these tests.
+
+// Uses doRequestWithBearer from middleware_auth_public_paths_test.go —
+// signature is (srv, method, path, bearer, body). We pass nil bodies.
+
+// TestRequireWorkspaceAccess_AdminPAT_DeniedOnNonMemberWorkspace pins the
+// BUG-1616 fix: an admin user holding a PAT cannot reach a workspace
+// they are not a member of. Pre-fix this returned 200 because the admin
+// bypass at middleware_auth.go:480 short-circuited to owner role without
+// consulting workspace_members. Post-fix the token-auth signal
+// (isAPITokenAuth(r)) suppresses the bypass and the regular membership
+// check produces a 403.
+func TestRequireWorkspaceAccess_AdminPAT_DeniedOnNonMemberWorkspace(t *testing.T) {
+	srv := testServer(t)
+
+	// One platform admin, plus a regular user who owns the workspace.
+	// The admin is NOT a member of that workspace — that's the
+	// invariant the bypass used to silently violate.
+	admin, err := srv.store.CreateUser(models.UserCreate{
+		Email: "admin@example.com", Name: "Admin", Password: "correct-horse-battery-staple", Role: "admin",
+	})
+	if err != nil {
+		t.Fatalf("create admin: %v", err)
+	}
+	owner, err := srv.store.CreateUser(models.UserCreate{
+		Email: "owner@example.com", Name: "Owner", Password: "correct-horse-battery-staple", Role: "member",
+	})
+	if err != nil {
+		t.Fatalf("create owner: %v", err)
+	}
+	ws, err := srv.store.CreateWorkspace(models.WorkspaceCreate{Name: "Private", OwnerID: owner.ID})
+	if err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	if err := srv.store.AddWorkspaceMember(ws.ID, owner.ID, "owner"); err != nil {
+		t.Fatalf("add owner as member: %v", err)
+	}
+
+	// Issue an unscoped PAT for the admin user. Unscoped (no
+	// WorkspaceID) is the user-owned-token shape that TokenAuth
+	// resolves to the admin user via apiToken.UserID — exactly the
+	// shape MCP also uses.
+	// CreateAPIToken requires WorkspaceID (legacy NOT NULL column,
+	// see migrations/011_api_tokens.sql). We satisfy the constraint
+	// by reusing ws.ID — the legacy-workspace guard in
+	// RequireWorkspaceAccess at middleware_auth.go:463 only fires
+	// when currentUser is nil, and the user-owned token resolves to
+	// the admin user via apiToken.UserID, so the column value is
+	// effectively a no-op for routing. The interesting axis is
+	// whether the admin's USER row gets owner access despite not
+	// being in workspace_members.
+	tok, err := srv.store.CreateAPIToken(admin.ID, models.APITokenCreate{
+		Name: "admin-pat", WorkspaceID: ws.ID,
+	}, 0, 0)
+	if err != nil {
+		t.Fatalf("CreateAPIToken: %v", err)
+	}
+
+	rr := doRequestWithBearer(srv, "GET", "/api/v1/workspaces/"+ws.Slug+"/dashboard", tok.Token, nil)
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("admin PAT against non-member workspace: got status %d, want 403 (BUG-1616 regression); body=%s",
+			rr.Code, rr.Body.String())
+	}
+}
+
+// TestRequireWorkspaceAccess_AdminPAT_DeniedEvenWithGuestGrants confirms
+// the membership-only stance (policy decision #1 on BUG-1616): admin
+// via token doesn't fall back to the guest-grants path either. Even
+// when the admin holds a workspace-scoped grant on a collection, a
+// token-borne request is denied with `not_a_member`.
+//
+// Rationale: token-borne admin identity should be strictly the
+// workspaces the admin actually joined. A leaked admin token with a
+// stray collection grant somewhere shouldn't reach that collection's
+// workspace through the token surface.
+func TestRequireWorkspaceAccess_AdminPAT_DeniedEvenWithGuestGrants(t *testing.T) {
+	srv := testServer(t)
+
+	admin, err := srv.store.CreateUser(models.UserCreate{
+		Email: "admin@example.com", Name: "Admin", Password: "correct-horse-battery-staple", Role: "admin",
+	})
+	if err != nil {
+		t.Fatalf("create admin: %v", err)
+	}
+	owner, err := srv.store.CreateUser(models.UserCreate{
+		Email: "owner@example.com", Name: "Owner", Password: "correct-horse-battery-staple", Role: "member",
+	})
+	if err != nil {
+		t.Fatalf("create owner: %v", err)
+	}
+	ws, err := srv.store.CreateWorkspace(models.WorkspaceCreate{Name: "Granted", OwnerID: owner.ID})
+	if err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	if err := srv.store.AddWorkspaceMember(ws.ID, owner.ID, "owner"); err != nil {
+		t.Fatalf("add owner as member: %v", err)
+	}
+
+	// Seed a collection on the target workspace (testServer doesn't
+	// pre-seed any defaults) and grant the admin view access on it.
+	// They are still NOT a workspace_members row — they're a guest.
+	// The pre-BUG-1616 code path for token+admin would have already
+	// 200'd via the bypass; with the fix the admin-token gate fires
+	// BEFORE the guest-grants fallback gets a chance.
+	coll, err := srv.store.CreateCollection(ws.ID, models.CollectionCreate{
+		Name: "Tasks", Slug: "tasks", Prefix: "TASK",
+	})
+	if err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	if _, err := srv.store.CreateCollectionGrant(ws.ID, coll.ID, admin.ID, "view", owner.ID); err != nil {
+		t.Fatalf("create grant: %v", err)
+	}
+
+	// Token's WorkspaceID column is satisfied by reusing ws.ID — the
+	// legacy-workspace guard in RequireWorkspaceAccess doesn't fire
+	// because the token carries a user_id (currentUser is non-nil),
+	// so the column value is effectively a no-op for routing.
+	tok, err := srv.store.CreateAPIToken(admin.ID, models.APITokenCreate{
+		Name: "admin-pat", WorkspaceID: ws.ID,
+	}, 0, 0)
+	if err != nil {
+		t.Fatalf("CreateAPIToken: %v", err)
+	}
+
+	rr := doRequestWithBearer(srv, "GET", "/api/v1/workspaces/"+ws.Slug+"/dashboard", tok.Token, nil)
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("admin PAT against grant-only workspace: got status %d, want 403 (membership-only stance); body=%s",
+			rr.Code, rr.Body.String())
+	}
+}
+
+// TestRequireWorkspaceAccess_AdminPAT_AllowedOnMemberWorkspace is the
+// positive control: when the admin IS a member of the workspace, the
+// token request succeeds. This catches an over-correction where the new
+// gate accidentally denies admins even on workspaces they legitimately
+// joined.
+func TestRequireWorkspaceAccess_AdminPAT_AllowedOnMemberWorkspace(t *testing.T) {
+	srv := testServer(t)
+
+	admin, err := srv.store.CreateUser(models.UserCreate{
+		Email: "admin@example.com", Name: "Admin", Password: "correct-horse-battery-staple", Role: "admin",
+	})
+	if err != nil {
+		t.Fatalf("create admin: %v", err)
+	}
+	ws, err := srv.store.CreateWorkspace(models.WorkspaceCreate{Name: "Mine", OwnerID: admin.ID})
+	if err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	if err := srv.store.AddWorkspaceMember(ws.ID, admin.ID, "owner"); err != nil {
+		t.Fatalf("add admin as member: %v", err)
+	}
+
+	tok, err := srv.store.CreateAPIToken(admin.ID, models.APITokenCreate{
+		Name: "admin-pat", WorkspaceID: ws.ID,
+	}, 0, 0)
+	if err != nil {
+		t.Fatalf("CreateAPIToken: %v", err)
+	}
+
+	rr := doRequestWithBearer(srv, "GET", "/api/v1/workspaces/"+ws.Slug+"/dashboard", tok.Token, nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("admin PAT against own workspace: got status %d, want 200; body=%s",
+			rr.Code, rr.Body.String())
+	}
+}
+
+// TestRequireWorkspaceAccess_AdminCLISessionBearer_DeniedOnNonMember
+// extends BUG-1616 to cover the CLI auth path. `pad auth login` mints a
+// padsess_<hex> session token and the CLI sends it via
+// Authorization: Bearer (NOT as a cookie) — TokenAuth's session-bearer
+// branch (middleware_auth.go:92-132) resolves it to the user but does
+// NOT set ctxIsAPIToken. The gate-by-Authorization-header dual check in
+// isBearerAuth is what closes this hole: admin via CLI to a workspace
+// they didn't join → 403.
+//
+// Reproduces the user-reported expansion: "admin really shouldn't be
+// able to access workspaces it's not a member of via CLI either."
+func TestRequireWorkspaceAccess_AdminCLISessionBearer_DeniedOnNonMember(t *testing.T) {
+	srv := testServer(t)
+
+	admin, err := srv.store.CreateUser(models.UserCreate{
+		Email: "admin@example.com", Name: "Admin", Password: "correct-horse-battery-staple", Role: "admin",
+	})
+	if err != nil {
+		t.Fatalf("create admin: %v", err)
+	}
+	owner, err := srv.store.CreateUser(models.UserCreate{
+		Email: "owner@example.com", Name: "Owner", Password: "correct-horse-battery-staple", Role: "member",
+	})
+	if err != nil {
+		t.Fatalf("create owner: %v", err)
+	}
+	ws, err := srv.store.CreateWorkspace(models.WorkspaceCreate{Name: "CLIPrivate", OwnerID: owner.ID})
+	if err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	if err := srv.store.AddWorkspaceMember(ws.ID, owner.ID, "owner"); err != nil {
+		t.Fatalf("add owner as member: %v", err)
+	}
+
+	// Mint a session token (the padsess_<hex> shape `pad auth login`
+	// produces). UA empty so the binding check is a no-op against the
+	// bearer call below (which also doesn't set a UA).
+	sessTok, err := srv.store.CreateSession(admin.ID, "cli-test", "192.0.2.1", "", webSessionTTL)
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	// Deliver the session token via Authorization: Bearer — the exact
+	// shape internal/cli/client.go sends. This is the CLI path the
+	// user wants closed.
+	rr := doRequestWithBearer(srv, "GET", "/api/v1/workspaces/"+ws.Slug+"/dashboard", sessTok, nil)
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("admin CLI session bearer against non-member workspace: got status %d, want 403; body=%s",
+			rr.Code, rr.Body.String())
+	}
+}
+
+// TestRequireWorkspaceAccess_AdminSession_StillBypassesNonMember pins the
+// preserved web-UI affordance: when the admin authenticates with a
+// session cookie (no API token), the platform-admin global bypass still
+// fires and grants owner-role access to any workspace. This is the
+// expected behavior for the /console/admin pages and the workspace
+// switcher, and the BUG-1616 fix must NOT regress it.
+func TestRequireWorkspaceAccess_AdminSession_StillBypassesNonMember(t *testing.T) {
+	srv := testServer(t)
+
+	admin, err := srv.store.CreateUser(models.UserCreate{
+		Email: "admin@example.com", Name: "Admin", Password: "correct-horse-battery-staple", Role: "admin",
+	})
+	if err != nil {
+		t.Fatalf("create admin: %v", err)
+	}
+	owner, err := srv.store.CreateUser(models.UserCreate{
+		Email: "owner@example.com", Name: "Owner", Password: "correct-horse-battery-staple", Role: "member",
+	})
+	if err != nil {
+		t.Fatalf("create owner: %v", err)
+	}
+	ws, err := srv.store.CreateWorkspace(models.WorkspaceCreate{Name: "OtherWS", OwnerID: owner.ID})
+	if err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	if err := srv.store.AddWorkspaceMember(ws.ID, owner.ID, "owner"); err != nil {
+		t.Fatalf("add owner as member: %v", err)
+	}
+
+	// Session cookie (NOT a Bearer token) — exercises the SessionAuth
+	// path which does NOT set ctxIsAPIToken, so the admin global bypass
+	// in RequireWorkspaceAccess still fires. UA is empty to match the
+	// empty UA that doRequestWithCookie produces (UAHash binding check
+	// compares hashes — empty vs empty is fine).
+	sessTok, err := srv.store.CreateSession(admin.ID, "web-test", "192.0.2.1", "", webSessionTTL)
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	rr := doRequestWithCookie(srv, "GET", "/api/v1/workspaces/"+ws.Slug+"/dashboard", nil, sessTok)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("admin session against non-member workspace: got status %d, want 200 (session-auth admin bypass preserved); body=%s",
+			rr.Code, rr.Body.String())
+	}
+}


### PR DESCRIPTION
## Summary

- Admin platform role no longer grants owner access to non-member workspaces when authenticated via Bearer (PATs, CLI session bearers, MCP OAuth) — it now applies only to cookie session auth (web UI / `/console/admin`).
- Gates four surfaces in lockstep so the policy is uniform: `RequireWorkspaceAccess` (covers `/api/v1/*`), `handleSSE` entry + revalidation + visibility recompute (`/api/v1/events`), and `authorizeCollabAccess` (`/api/v1/collab/{itemID}` WebSocket upgrade).
- New shared helper `isBearerAuth(r)` mirrors the dual check `middleware_csrf.go` already uses (Authorization header OR `ctxIsAPIToken`), so MCP-dispatcher synthesized requests and CLI `padsess_*` bearers are both covered.

## Background

An admin with "All current workspaces" consent on an MCP client — or a leaked admin token of any kind — could reach data the admin never joined. The OAuth consent UI's "all current workspaces" option, and the CLI's "log in once and address any workspace by slug" affordance, were both intended to mean "every workspace the user is a member of" — not "every workspace on the server by virtue of the platform admin role." This change reifies that intent.

Companion item **BUG-1617** tracks the store-layer admin bypass at `internal/store/backlinks_visibility.go:47` — different code path, separate PR.

## Behavior matrix

| Surface | Admin via cookie | Admin via bearer (CLI / PAT / MCP) |
|---|---|---|
| `/api/v1/*` (middleware) | Owner on any workspace | Membership-only, no grants fallback |
| `/api/v1/events` (SSE) | Subscribe to any workspace, no filter | 403 if non-member; filtered visibility if `collection_access=specific` member |
| `/api/v1/collab/{itemID}` (WS) | Allow on any item | 403 if workspace non-member |

## Test plan

- [x] `go test ./internal/server/` — 82s, all green
- [x] `make lint` — `0 issues.`
- [x] Codex re-review — CLEAN
- [x] `make install` — server restarted, no startup errors
- [x] 9 new tests pass: 5 middleware permutations (`middleware_auth_admin_token_gate_test.go`) + 4 SSE/collab gates (`handlers_admin_bearer_gate_test.go`)
- [ ] Manual smoke: admin user, CLI bearer → `pad item list --workspace <foreign-workspace>` should now 403 (was: silently returned items)

## Files changed

- `internal/server/middleware_auth.go` — `isBearerAuth(r)` helper + gated admin bypass in `RequireWorkspaceAccess`
- `internal/server/handlers_events.go` — 3 gates: SSE entry, revalidation, visibility recompute
- `internal/server/handlers_collab.go` — 1 gate: WS auth
- `internal/server/middleware_auth_admin_token_gate_test.go` — NEW, 5 tests
- `internal/server/handlers_admin_bearer_gate_test.go` — NEW, 4 tests

🤖 BUG-1616