### PR TITLE
fix(backlinks): scope cross-workspace admin enumeration to membership for bearer auth (BUG-1617)

### DIFF
--- a/internal/server/handlers_backlinks.go
+++ b/internal/server/handlers_backlinks.go
@@ -168,7 +168,11 @@ func (s *Server) handleGetItemBacklinks(w http.ResponseWriter, r *http.Request) 
 			// workspace B that the user has independent access to.
 			// Codex round 2 P1.
 			allowedSlugs := TokenAllowedWorkspacesFromContext(r.Context())
-			crossWs, err = s.store.GetCrossWorkspaceBacklinks(workspaceID, targetRef, user.ID, allowedSlugs, remaining, crossOffset)
+			// Pass the bearer-auth signal so the store-layer admin
+			// bypass mirrors BUG-1616's policy: bearer-borne admin
+			// (CLI / PAT / MCP) enumerates only their member /
+			// grant workspaces; cookie admin keeps the global view.
+			crossWs, err = s.store.GetCrossWorkspaceBacklinks(workspaceID, targetRef, user.ID, allowedSlugs, remaining, crossOffset, isBearerAuth(r))
 			if err != nil {
 				writeInternalError(w, err)
 				return

--- a/internal/server/handlers_backlinks_admin_bearer_test.go
+++ b/internal/server/handlers_backlinks_admin_bearer_test.go
@@ -1,0 +1,154 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// TestCrossWorkspaceBacklinks_AdminBearer_OnlySeesMembershipWorkspaces
+// is the BUG-1617 HTTP integration test. It exercises the full chain
+// (handler → guestResourceFilterCore → Store.GetCrossWorkspaceBacklinks
+// → Store.ResolveBacklinksVisibility) with both auth surfaces an admin
+// user can present:
+//
+//   - Cookie session admin → sees cross-ws backlinks from EVERY
+//     workspace (BUG-1616's preserved web-UI affordance).
+//   - PAT-bearer admin → sees cross-ws backlinks ONLY from workspaces
+//     they're a member of. The non-member workspace's source row is
+//     stripped at the GetUserWorkspaces enumeration step.
+//
+// Setup: two workspaces — wsA owned by the admin (target lives here),
+// wsB owned by a different user, with a source item that wiki-links
+// the target via `[[wsA-slug::TASK-N]]`.
+func TestCrossWorkspaceBacklinks_AdminBearer_OnlySeesMembershipWorkspaces(t *testing.T) {
+	srv := testServer(t)
+
+	admin, err := srv.store.CreateUser(models.UserCreate{
+		Email: "admin@example.com", Name: "Admin", Password: "correct-horse-battery-staple", Role: "admin",
+	})
+	if err != nil {
+		t.Fatalf("create admin: %v", err)
+	}
+	owner, err := srv.store.CreateUser(models.UserCreate{
+		Email: "owner@example.com", Name: "Owner", Password: "correct-horse-battery-staple", Role: "member",
+	})
+	if err != nil {
+		t.Fatalf("create owner: %v", err)
+	}
+	// wsA: admin owns. Target lives here. Admin IS a member.
+	wsA, err := srv.store.CreateWorkspace(models.WorkspaceCreate{Name: "AdminHomeWS", OwnerID: admin.ID})
+	if err != nil {
+		t.Fatalf("create wsA: %v", err)
+	}
+	if err := srv.store.AddWorkspaceMember(wsA.ID, admin.ID, "owner"); err != nil {
+		t.Fatalf("add admin to wsA: %v", err)
+	}
+	// wsB: owner owns. Admin is NOT a member. Source with cross-ws
+	// wiki-link lives here.
+	wsB, err := srv.store.CreateWorkspace(models.WorkspaceCreate{Name: "OtherUserWS", OwnerID: owner.ID})
+	if err != nil {
+		t.Fatalf("create wsB: %v", err)
+	}
+	if err := srv.store.AddWorkspaceMember(wsB.ID, owner.ID, "owner"); err != nil {
+		t.Fatalf("add owner to wsB: %v", err)
+	}
+
+	tasksA, err := srv.store.CreateCollection(wsA.ID, models.CollectionCreate{
+		Name: "Tasks", Slug: "tasks", Prefix: "TASK",
+	})
+	if err != nil {
+		t.Fatalf("create tasks (wsA): %v", err)
+	}
+	notesB, err := srv.store.CreateCollection(wsB.ID, models.CollectionCreate{
+		Name: "Notes", Slug: "notes", Prefix: "NOTE",
+	})
+	if err != nil {
+		t.Fatalf("create notes (wsB): %v", err)
+	}
+
+	target, err := srv.store.CreateItem(wsA.ID, tasksA.ID, models.ItemCreate{
+		Title: "Cross target", CreatedBy: "user", Source: "test",
+	})
+	if err != nil {
+		t.Fatalf("create target: %v", err)
+	}
+	// Source in wsB referencing wsA's target via [[wsA-slug::TASK-N]].
+	// item_number is the canonical ref form the cross-ws resolver
+	// expects; ItemCreate doesn't set it directly, so we derive it
+	// from the target after creation.
+	if target.ItemNumber == nil || *target.ItemNumber <= 0 {
+		t.Fatalf("target item_number missing/zero (need it for ref): %+v", target)
+	}
+	targetRef := "TASK-" + strconv.Itoa(*target.ItemNumber)
+	if _, err := srv.store.CreateItem(wsB.ID, notesB.ID, models.ItemCreate{
+		Title:     "Cross source",
+		Content:   "See [[" + wsA.Slug + "::" + targetRef + "]] for context.",
+		CreatedBy: "user", Source: "test",
+	}); err != nil {
+		t.Fatalf("create source: %v", err)
+	}
+
+	// Issue an admin PAT. Token's workspace_id satisfies the NOT
+	// NULL constraint; the user-owned-token shape (apiToken.UserID
+	// set) is what RequireWorkspaceAccess actually keys on.
+	tok, err := srv.store.CreateAPIToken(admin.ID, models.APITokenCreate{
+		Name: "admin-bearer-test", WorkspaceID: wsA.ID,
+	}, 0, 0)
+	if err != nil {
+		t.Fatalf("CreateAPIToken: %v", err)
+	}
+	// Cookie session for the same admin — exercises the preserved
+	// admin bypass.
+	sessTok, err := srv.store.CreateSession(admin.ID, "web-test", "192.0.2.1", "", webSessionTTL)
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	// Endpoint under test: backlinks for the target item in wsA.
+	// guestResourceFilterCore and GetCrossWorkspaceBacklinks both
+	// run inside the handler so this exercises the full BUG-1617
+	// fix chain.
+	backlinksURL := "/api/v1/workspaces/" + wsA.Slug + "/items/" + target.Slug + "/backlinks"
+
+	t.Run("cookie session admin sees cross-ws backlink from non-member workspace", func(t *testing.T) {
+		rr := doRequestWithCookie(srv, "GET", backlinksURL, nil, sessTok)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("cookie admin: got %d, want 200; body=%s", rr.Code, rr.Body.String())
+		}
+		var rows []models.Backlink
+		if err := json.Unmarshal(rr.Body.Bytes(), &rows); err != nil {
+			t.Fatalf("decode: %v body=%s", err, rr.Body.String())
+		}
+		// Expect at least one cross-ws row (SourceWorkspaceSlug
+		// populated only for cross-ws hits — see models/backlink.go).
+		var foundCross bool
+		for _, r := range rows {
+			if r.SourceWorkspaceSlug == wsB.Slug {
+				foundCross = true
+			}
+		}
+		if !foundCross {
+			t.Errorf("cookie admin should see cross-ws backlink from wsB; got %d rows: %+v", len(rows), rows)
+		}
+	})
+
+	t.Run("bearer admin does NOT see cross-ws backlink from non-member workspace (BUG-1617)", func(t *testing.T) {
+		rr := doRequestWithBearer(srv, "GET", backlinksURL, tok.Token, nil)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("bearer admin: got %d, want 200; body=%s", rr.Code, rr.Body.String())
+		}
+		var rows []models.Backlink
+		if err := json.Unmarshal(rr.Body.Bytes(), &rows); err != nil {
+			t.Fatalf("decode: %v body=%s", err, rr.Body.String())
+		}
+		for _, r := range rows {
+			if r.SourceWorkspaceSlug == wsB.Slug {
+				t.Errorf("bearer admin must NOT see cross-ws backlink from wsB (non-member workspace); leaked row=%+v", r)
+			}
+		}
+	})
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1773,17 +1773,31 @@ func (s *Server) guestResourceFilterIncludeDeletedItems(r *http.Request, workspa
 //     (fullCollIDs, grantedItemIDs, err)` is established across many
 //     handlers — keeping it stable avoids a sprawling refactor.
 //
+// Admin bypass policy (BUG-1617 — companion to BUG-1616): the
+// short-circuit only fires for cookie session auth. Bearer-borne
+// admins (CLI / PAT / MCP — detected via isBearerAuth) fall through
+// to the store helper which runs the regular member/grants pipeline
+// against the platform-admin's actual workspace_members row. Without
+// this, an admin's MCP token could pass RequireWorkspaceAccess's
+// bearer gate (BUG-1616) on the URL's workspace but still see
+// unrestricted visibility filters in any downstream backlinks /
+// activity / delta-sync query that ran for the same workspace.
+//
 // The includeDeletedItems flag swaps the underlying grant query.
 func (s *Server) guestResourceFilterCore(r *http.Request, workspaceID string, includeDeletedItems bool) (fullCollIDs, grantedItemIDs []string, err error) {
 	user := currentUser(r)
-	if user == nil || user.Role == "admin" {
+	if user == nil {
+		return nil, nil, nil
+	}
+	authIsBearer := isBearerAuth(r)
+	if user.Role == "admin" && !authIsBearer {
 		return nil, nil, nil
 	}
 	// Delegate to the request-independent helper. The store-side
 	// helper duplicates the admin check via GetUser, but for the
-	// request hot path we short-circuit above so the duplicate
-	// lookup never fires.
-	return s.store.ResolveBacklinksVisibility(user.ID, workspaceID, includeDeletedItems)
+	// request hot path we short-circuit above (cookie admin only)
+	// so the duplicate lookup never fires for the common case.
+	return s.store.ResolveBacklinksVisibility(user.ID, workspaceID, includeDeletedItems, authIsBearer)
 }
 
 // isCollectionVisible checks if a collection ID is in the visible set.

--- a/internal/store/backlinks_visibility.go
+++ b/internal/store/backlinks_visibility.go
@@ -16,7 +16,13 @@ package store
 //
 // Decision tree (matches RequireWorkspaceAccess + guestResourceFilterCore):
 //
-//   - Admin user (`users.role = 'admin'`): unrestricted.
+//   - Admin user (`users.role = 'admin'`) AND NOT bearer-authenticated:
+//     unrestricted.
+//   - Admin user AND bearer-authenticated: falls through to the
+//     non-admin path (BUG-1617). The bearer-borne admin identity is
+//     treated as a regular user for cross-workspace visibility — a
+//     platform admin's MCP / CLI / PAT token must not silently see
+//     into workspaces the admin never joined.
 //   - Workspace member with `collection_access = 'all'` or empty:
 //     unrestricted.
 //   - Workspace member with `collection_access = 'specific'`
@@ -40,11 +46,17 @@ package store
 //     The server delta-sync wrapper at guestResourceFilterIncludeDeletedItems
 //     passes true; cross-ws doesn't need it.
 //
+// `authIsBearer` is the BUG-1616/1617 gate: true when the upstream
+// HTTP request was bearer-authenticated (PAT on /api/v1, PAT or OAuth
+// on /mcp, CLI session-bearer). Callers without a request context
+// (tests, internal jobs) pass false — same as cookie-session admin.
+// Derived via server.isBearerAuth at the HTTP boundary and threaded
+// down.
+//
 // The returned error mirrors the underlying store call (DB error
 // surfaces, "user not found" returns an empty result rather than
 // erroring so the cross-ws traversal can keep going).
-func (s *Store) ResolveBacklinksVisibility(userID, workspaceID string, includeDeletedItems bool) (fullCollIDs, grantedItemIDs []string, err error) {
-	// Admin bypass — same as server.guestResourceFilterCore line 1758.
+func (s *Store) ResolveBacklinksVisibility(userID, workspaceID string, includeDeletedItems, authIsBearer bool) (fullCollIDs, grantedItemIDs []string, err error) {
 	user, err := s.GetUser(userID)
 	if err != nil {
 		return nil, nil, err
@@ -56,7 +68,11 @@ func (s *Store) ResolveBacklinksVisibility(userID, workspaceID string, includeDe
 		// both lists empty.
 		return nil, nil, nil
 	}
-	if user.Role == "admin" {
+	// Admin bypass — cookie session auth only (BUG-1617). Bearer-borne
+	// admin (CLI / PAT / MCP) falls through to the non-admin path so
+	// they're treated identically to a regular user — membership /
+	// grants determine visibility, not the platform admin role.
+	if user.Role == "admin" && !authIsBearer {
 		return nil, nil, nil
 	}
 
@@ -91,11 +107,25 @@ func (s *Store) ResolveBacklinksVisibility(userID, workspaceID string, includeDe
 	// because there's no member row to merge from.) Same as line 1789.
 	if member == nil {
 		// One more sanity check: if there are NO grants either,
-		// this user shouldn't be able to see anything. Returning
-		// empty lists is correct — GetBacklinks short-circuits.
-		// (UserHasGrantsInWorkspace would be redundant here since
-		// GuestVisibleResources already returns empty for non-grant
-		// users.)
+		// this user shouldn't be able to see anything. Return
+		// NON-NIL empty slices so the caller can distinguish "no
+		// visibility" from the admin / full-access-member
+		// "(nil, nil) = unrestricted" sentinel. Without this, a
+		// bearer-borne admin (BUG-1617) on a non-member workspace
+		// would land here with grant queries that returned nil and
+		// be misread as unrestricted. In production this latent
+		// case is gated upstream (GetCrossWorkspaceBacklinks
+		// enumerates via GetUserWorkspaces which already excludes
+		// non-member non-grant workspaces), but the explicit
+		// non-nil shape closes the gap for any caller that bypasses
+		// the upstream filter — including tests that exercise this
+		// helper directly.
+		if grantCollIDs == nil {
+			grantCollIDs = []string{}
+		}
+		if grantedItemIDs == nil {
+			grantedItemIDs = []string{}
+		}
 		return grantCollIDs, grantedItemIDs, nil
 	}
 

--- a/internal/store/wiki_links.go
+++ b/internal/store/wiki_links.go
@@ -1188,7 +1188,7 @@ func (s *Store) CountBacklinks(targetItemID, workspaceID string, vis BacklinksVi
 // that for same-ws): item.parent_id is workspace-scoped, so a
 // cross-ws source row can never be the target's parent or child
 // by construction. TASK-1607.
-func (s *Store) GetCrossWorkspaceBacklinks(targetWorkspaceID, targetRef, requesterUserID string, allowedWorkspaceSlugs []string, limit, offset int) ([]models.Backlink, error) {
+func (s *Store) GetCrossWorkspaceBacklinks(targetWorkspaceID, targetRef, requesterUserID string, allowedWorkspaceSlugs []string, limit, offset int, authIsBearer bool) ([]models.Backlink, error) {
 	if limit <= 0 || limit > 300 {
 		limit = 50
 	}
@@ -1196,13 +1196,23 @@ func (s *Store) GetCrossWorkspaceBacklinks(targetWorkspaceID, targetRef, request
 		offset = 0
 	}
 
-	// Workspace enumeration depends on the requester's user role.
-	// Admins have implicit access to every non-deleted workspace
-	// (matches RequireWorkspaceAccess line 481), so for them we
-	// list everything; non-admins use GetUserWorkspaces which
-	// unions memberships + grant-only guest workspaces. Codex
-	// round 1 P2 caught the prior membership-only path silently
-	// hiding cross-ws backlinks from admin users.
+	// Workspace enumeration depends on the requester's user role AND
+	// the auth surface. Three paths:
+	//
+	//   - Cookie-session admin (Role=admin && !authIsBearer):
+	//     `ListWorkspaces()` — implicit access to every non-deleted
+	//     workspace (matches the cookie-admin global bypass in
+	//     RequireWorkspaceAccess).
+	//   - Bearer-borne admin (Role=admin && authIsBearer, BUG-1617):
+	//     `GetUserMemberWorkspaces` — STRICT membership only, no
+	//     grants fallback. Mirrors RequireWorkspaceAccess's
+	//     membership-only stance for bearer-admin (BUG-1616). Without
+	//     this, an admin with a stray collection / item grant on
+	//     workspace C would still get cross-ws backlinks from C via
+	//     the grants-aware GetUserWorkspaces, even though direct
+	//     bearer access to C is denied.
+	//   - Non-admin (any auth): `GetUserWorkspaces` — memberships ∪
+	//     grant-only guest workspaces. Same as before.
 	user, err := s.GetUser(requesterUserID)
 	if err != nil {
 		return nil, fmt.Errorf("lookup requester user: %w", err)
@@ -1213,12 +1223,18 @@ func (s *Store) GetCrossWorkspaceBacklinks(targetWorkspaceID, targetRef, request
 		return nil, nil
 	}
 	var workspaces []models.Workspace
-	if user.Role == "admin" {
+	switch {
+	case user.Role == "admin" && !authIsBearer:
 		workspaces, err = s.ListWorkspaces()
 		if err != nil {
 			return nil, fmt.Errorf("admin enumerate workspaces: %w", err)
 		}
-	} else {
+	case user.Role == "admin" && authIsBearer:
+		workspaces, err = s.GetUserMemberWorkspaces(requesterUserID)
+		if err != nil {
+			return nil, fmt.Errorf("bearer admin enumerate member workspaces: %w", err)
+		}
+	default:
 		workspaces, err = s.GetUserWorkspaces(requesterUserID)
 		if err != nil {
 			return nil, fmt.Errorf("enumerate accessible workspaces: %w", err)
@@ -1259,7 +1275,7 @@ func (s *Store) GetCrossWorkspaceBacklinks(targetWorkspaceID, targetRef, request
 		if !allowAll && !wildcard && !allowSet[ws.Slug] {
 			continue
 		}
-		fullCollIDs, grantedItemIDs, err := s.ResolveBacklinksVisibility(requesterUserID, ws.ID, false)
+		fullCollIDs, grantedItemIDs, err := s.ResolveBacklinksVisibility(requesterUserID, ws.ID, false, authIsBearer)
 		if err != nil {
 			return nil, fmt.Errorf("resolve visibility for workspace %s: %w", ws.ID, err)
 		}

--- a/internal/store/wiki_links_xws_test.go
+++ b/internal/store/wiki_links_xws_test.go
@@ -39,7 +39,7 @@ func TestWikiLinks_CrossWorkspaceRefIndexedAndQueryable(t *testing.T) {
 	source := createTestItem(t, s, wsB.ID, colB.ID, "Cross source", body)
 
 	// Cross-ws query from A's perspective should find the source.
-	got, err := s.GetCrossWorkspaceBacklinks(wsA.ID, targetRef, user.ID, nil, 50, 0)
+	got, err := s.GetCrossWorkspaceBacklinks(wsA.ID, targetRef, user.ID, nil, 50, 0, false)
 	if err != nil {
 		t.Fatalf("GetCrossWorkspaceBacklinks: %v", err)
 	}
@@ -89,12 +89,12 @@ func TestWikiLinks_CrossWorkspaceNonMemberDoesNotSee(t *testing.T) {
 		"See [["+wsA.Slug+"::"+targetRef+"]].")
 
 	// Owner sees the cross-ws backlink.
-	got, _ := s.GetCrossWorkspaceBacklinks(wsA.ID, targetRef, owner.ID, nil, 50, 0)
+	got, _ := s.GetCrossWorkspaceBacklinks(wsA.ID, targetRef, owner.ID, nil, 50, 0, false)
 	if len(got) != 1 {
 		t.Errorf("owner should see cross-ws backlink, got %d", len(got))
 	}
 	// Outsider does NOT — they have no access to workspace B.
-	got2, _ := s.GetCrossWorkspaceBacklinks(wsA.ID, targetRef, outsider.ID, nil, 50, 0)
+	got2, _ := s.GetCrossWorkspaceBacklinks(wsA.ID, targetRef, outsider.ID, nil, 50, 0, false)
 	if len(got2) != 0 {
 		t.Errorf("outsider should NOT see cross-ws backlink, got %d", len(got2))
 	}
@@ -142,7 +142,7 @@ func TestWikiLinks_CrossWorkspaceGuestSeesGrantedCollectionOnly(t *testing.T) {
 	_ = hiddenSrc
 
 	// Guest sees ONLY the visible-collection source.
-	got, err := s.GetCrossWorkspaceBacklinks(wsA.ID, targetRef, guest.ID, nil, 50, 0)
+	got, err := s.GetCrossWorkspaceBacklinks(wsA.ID, targetRef, guest.ID, nil, 50, 0, false)
 	if err != nil {
 		t.Fatalf("GetCrossWorkspaceBacklinks: %v", err)
 	}
@@ -197,7 +197,7 @@ func TestWikiLinks_CrossWorkspaceGuestItemGrantOnlyVisible(t *testing.T) {
 		t.Fatalf("grant item: %v", err)
 	}
 
-	got, _ := s.GetCrossWorkspaceBacklinks(wsA.ID, targetRef, guest.ID, nil, 50, 0)
+	got, _ := s.GetCrossWorkspaceBacklinks(wsA.ID, targetRef, guest.ID, nil, 50, 0, false)
 	if len(got) != 1 {
 		t.Fatalf("guest should see exactly 1 cross-ws backlink (the granted item), got %d: %+v", len(got), got)
 	}
@@ -232,7 +232,7 @@ func TestWikiLinks_CrossWorkspaceUnknownSlugBroken(t *testing.T) {
 		t.Fatalf("add user wsB: %v", err)
 	}
 
-	got, _ := s.GetCrossWorkspaceBacklinks(wsB.ID, "TASK-1", user.ID, nil, 50, 0)
+	got, _ := s.GetCrossWorkspaceBacklinks(wsB.ID, "TASK-1", user.ID, nil, 50, 0, false)
 	if len(got) != 0 {
 		t.Errorf("broken cross-ws ref should not surface in cross-ws backlinks, got %d", len(got))
 	}
@@ -261,7 +261,7 @@ func TestWikiLinks_CrossWorkspaceSourceWorkspaceSlugPopulated(t *testing.T) {
 	createTestItem(t, s, wsB.ID, colB.ID, "Cross source",
 		"See [["+wsA.Slug+"::"+targetRef+"]].")
 
-	got, _ := s.GetCrossWorkspaceBacklinks(wsA.ID, targetRef, user.ID, nil, 50, 0)
+	got, _ := s.GetCrossWorkspaceBacklinks(wsA.ID, targetRef, user.ID, nil, 50, 0, false)
 	if len(got) != 1 {
 		t.Fatalf("expected 1 cross-ws row, got %d", len(got))
 	}
@@ -313,7 +313,7 @@ func TestWikiLinks_CrossWorkspaceSameWorkspaceQualifiedNormalized(t *testing.T) 
 	}
 
 	// Cross-ws query must NOT surface it (correctly attributed to same-ws).
-	cross, _ := s.GetCrossWorkspaceBacklinks(ws.ID, tref, user.ID, nil, 50, 0)
+	cross, _ := s.GetCrossWorkspaceBacklinks(ws.ID, tref, user.ID, nil, 50, 0, false)
 	if len(cross) != 0 {
 		t.Errorf("same-ws fully-qualified ref should not appear in cross-ws backlinks, got %d", len(cross))
 	}
@@ -394,17 +394,135 @@ func TestWikiLinks_CrossWorkspaceAdminSeesAllWorkspaces(t *testing.T) {
 	createTestItem(t, s, wsB.ID, colB.ID, "Cross source",
 		"See [["+wsA.Slug+"::"+targetRef+"]].")
 
-	// Admin should see the cross-ws backlink via the global
-	// workspace enumeration path.
-	got, err := s.GetCrossWorkspaceBacklinks(wsA.ID, targetRef, admin.ID, nil, 50, 0)
+	// Admin via cookie session auth (authIsBearer=false): sees the
+	// cross-ws backlink via the global workspace enumeration path.
+	got, err := s.GetCrossWorkspaceBacklinks(wsA.ID, targetRef, admin.ID, nil, 50, 0, false)
 	if err != nil {
-		t.Fatalf("GetCrossWorkspaceBacklinks (admin): %v", err)
+		t.Fatalf("GetCrossWorkspaceBacklinks (cookie admin): %v", err)
 	}
 	if len(got) != 1 {
-		t.Errorf("admin should see cross-ws backlink (admins bypass membership), got %d", len(got))
+		t.Errorf("cookie admin should see cross-ws backlink (admins bypass membership), got %d", len(got))
 	}
 	if len(got) > 0 && got[0].SourceWorkspaceSlug != wsB.Slug {
-		t.Errorf("admin row missing SourceWorkspaceSlug: got %q", got[0].SourceWorkspaceSlug)
+		t.Errorf("cookie admin row missing SourceWorkspaceSlug: got %q", got[0].SourceWorkspaceSlug)
+	}
+
+	// Admin via bearer auth (authIsBearer=true): bypass suppressed
+	// per BUG-1617. Admin is NOT a member of wsB, so they should NOT
+	// see the cross-ws backlink. Mirrors BUG-1616's policy: bearer-
+	// borne admin identity does not carry cross-workspace authority.
+	gotBearer, err := s.GetCrossWorkspaceBacklinks(wsA.ID, targetRef, admin.ID, nil, 50, 0, true)
+	if err != nil {
+		t.Fatalf("GetCrossWorkspaceBacklinks (bearer admin): %v", err)
+	}
+	if len(gotBearer) != 0 {
+		t.Errorf("bearer admin should NOT see cross-ws backlink from non-member workspace (BUG-1617); got %d rows: %+v", len(gotBearer), gotBearer)
+	}
+}
+
+// TestWikiLinks_CrossWorkspaceBearerAdminGrantOnlyWorkspaceFiltered
+// pins Codex's BUG-1617 round-2 finding: GetCrossWorkspaceBacklinks
+// for bearer-admin must NOT include workspaces where the admin only
+// holds a guest grant. Direct bearer access to such a workspace would
+// be denied by RequireWorkspaceAccess (BUG-1616's membership-only
+// stance skips the grants fallback), so cross-ws enumeration must
+// match — otherwise the bearer-admin's grant elsewhere becomes a
+// side-channel into a workspace they can't open directly.
+func TestWikiLinks_CrossWorkspaceBearerAdminGrantOnlyWorkspaceFiltered(t *testing.T) {
+	s := testStore(t)
+
+	owner := createTestUser(t, s, "owner@example.com", "Owner", "password123")
+	admin, err := s.CreateUser(models.UserCreate{
+		Email: "admin@example.com", Name: "Admin", Password: "password123",
+		Role: "admin",
+	})
+	if err != nil {
+		t.Fatalf("create admin: %v", err)
+	}
+
+	// wsA: admin is a member (owner). Target lives here.
+	wsA := createTestWorkspace(t, s, "Workspace A")
+	if err := s.AddWorkspaceMember(wsA.ID, admin.ID, "owner"); err != nil {
+		t.Fatalf("admin→wsA: %v", err)
+	}
+	// wsB: admin is NOT a member, but holds a collection grant —
+	// the grants-aware GetUserWorkspaces would include this.
+	wsB := createTestWorkspace(t, s, "Workspace B")
+	if err := s.AddWorkspaceMember(wsB.ID, owner.ID, "owner"); err != nil {
+		t.Fatalf("owner→wsB: %v", err)
+	}
+	colA := createTestCollection(t, s, wsA.ID, "Tasks")
+	colB := createTestCollection(t, s, wsB.ID, "Notes")
+	if _, err := s.CreateCollectionGrant(wsB.ID, colB.ID, admin.ID, "view", owner.ID); err != nil {
+		t.Fatalf("grant admin on wsB.Notes: %v", err)
+	}
+
+	target := createTestItem(t, s, wsA.ID, colA.ID, "Target", "")
+	targetRef := refOf(target)
+	// Source in wsB referencing the cross-ws target.
+	createTestItem(t, s, wsB.ID, colB.ID, "Cross source",
+		"See [["+wsA.Slug+"::"+targetRef+"]].")
+
+	// Bearer admin: expect ZERO rows from wsB. The collection grant
+	// on wsB doesn't elevate them to a member; cross-ws enumeration
+	// must reflect that.
+	got, err := s.GetCrossWorkspaceBacklinks(wsA.ID, targetRef, admin.ID, nil, 50, 0, true)
+	if err != nil {
+		t.Fatalf("GetCrossWorkspaceBacklinks: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("bearer admin must NOT see cross-ws backlinks via a guest grant in the source workspace (membership-only stance); got %d rows: %+v", len(got), got)
+	}
+
+	// Cookie admin: same setup, sees the row via the global
+	// ListWorkspaces enumeration. Confirms the gate is specifically
+	// bearer-shaped, not a blanket lockdown.
+	gotCookie, err := s.GetCrossWorkspaceBacklinks(wsA.ID, targetRef, admin.ID, nil, 50, 0, false)
+	if err != nil {
+		t.Fatalf("GetCrossWorkspaceBacklinks (cookie admin): %v", err)
+	}
+	if len(gotCookie) != 1 {
+		t.Errorf("cookie admin should see cross-ws backlink (preserves global-admin web UI affordance); got %d", len(gotCookie))
+	}
+}
+
+// TestWikiLinks_CrossWorkspaceBearerAdminSeesMemberWorkspaces is the
+// positive control for BUG-1617's bearer-admin path. When the admin
+// IS a member of the source workspace, the cross-ws backlink is
+// visible even via bearer auth — the gate's job is to suppress the
+// PLATFORM admin role, not membership-based access.
+func TestWikiLinks_CrossWorkspaceBearerAdminSeesMemberWorkspaces(t *testing.T) {
+	s := testStore(t)
+
+	admin, err := s.CreateUser(models.UserCreate{
+		Email: "admin@example.com", Name: "Admin", Password: "password123",
+		Role: "admin",
+	})
+	if err != nil {
+		t.Fatalf("create admin: %v", err)
+	}
+
+	wsA := createTestWorkspace(t, s, "Workspace A")
+	wsB := createTestWorkspace(t, s, "Workspace B")
+	// Admin IS a member of both workspaces this time.
+	for _, ws := range []*models.Workspace{wsA, wsB} {
+		if err := s.AddWorkspaceMember(ws.ID, admin.ID, "owner"); err != nil {
+			t.Fatalf("admin→%s: %v", ws.Slug, err)
+		}
+	}
+	colA := createTestCollection(t, s, wsA.ID, "Tasks")
+	colB := createTestCollection(t, s, wsB.ID, "Notes")
+	target := createTestItem(t, s, wsA.ID, colA.ID, "Cross target", "")
+	targetRef := refOf(target)
+	createTestItem(t, s, wsB.ID, colB.ID, "Cross source",
+		"See [["+wsA.Slug+"::"+targetRef+"]].")
+
+	got, err := s.GetCrossWorkspaceBacklinks(wsA.ID, targetRef, admin.ID, nil, 50, 0, true)
+	if err != nil {
+		t.Fatalf("GetCrossWorkspaceBacklinks (bearer admin, member): %v", err)
+	}
+	if len(got) != 1 {
+		t.Errorf("bearer admin should still see cross-ws backlinks from workspaces they're a member of; got %d", len(got))
 	}
 }
 
@@ -456,7 +574,7 @@ func TestWikiLinks_CrossWorkspaceRefNumberFallback(t *testing.T) {
 
 	// Query under the NEW ref — the stored row has OLD ref, but
 	// item_number suffix matches so the fallback should hit.
-	got, err := s.GetCrossWorkspaceBacklinks(wsA.ID, newRef, user.ID, nil, 50, 0)
+	got, err := s.GetCrossWorkspaceBacklinks(wsA.ID, newRef, user.ID, nil, 50, 0, false)
 	if err != nil {
 		t.Fatalf("GetCrossWorkspaceBacklinks: %v", err)
 	}
@@ -495,14 +613,14 @@ func TestWikiLinks_CrossWorkspaceTokenAllowListFilters(t *testing.T) {
 		"See [["+wsA.Slug+"::"+targetRef+"]].")
 
 	t.Run("nil allowlist (PAT / pre-consent) sees cross-ws", func(t *testing.T) {
-		got, _ := s.GetCrossWorkspaceBacklinks(wsA.ID, targetRef, user.ID, nil, 50, 0)
+		got, _ := s.GetCrossWorkspaceBacklinks(wsA.ID, targetRef, user.ID, nil, 50, 0, false)
 		if len(got) != 1 {
 			t.Errorf("nil allowlist should allow all, got %d", len(got))
 		}
 	})
 
 	t.Run("wildcard allowlist sees cross-ws", func(t *testing.T) {
-		got, _ := s.GetCrossWorkspaceBacklinks(wsA.ID, targetRef, user.ID, []string{"*"}, 50, 0)
+		got, _ := s.GetCrossWorkspaceBacklinks(wsA.ID, targetRef, user.ID, []string{"*"}, 50, 0, false)
 		if len(got) != 1 {
 			t.Errorf("wildcard should allow all, got %d", len(got))
 		}
@@ -511,7 +629,7 @@ func TestWikiLinks_CrossWorkspaceTokenAllowListFilters(t *testing.T) {
 	t.Run("target-only allowlist hides cross-ws sources", func(t *testing.T) {
 		// Token consented for workspace A only — source workspace
 		// B is filtered out even though the user has access.
-		got, _ := s.GetCrossWorkspaceBacklinks(wsA.ID, targetRef, user.ID, []string{wsA.Slug}, 50, 0)
+		got, _ := s.GetCrossWorkspaceBacklinks(wsA.ID, targetRef, user.ID, []string{wsA.Slug}, 50, 0, false)
 		if len(got) != 0 {
 			t.Errorf("workspace-A-only token should NOT see source from B, got %d", len(got))
 		}
@@ -520,7 +638,7 @@ func TestWikiLinks_CrossWorkspaceTokenAllowListFilters(t *testing.T) {
 	t.Run("explicit source-workspace allowlist sees cross-ws", func(t *testing.T) {
 		// Token consented for both A and B.
 		got, _ := s.GetCrossWorkspaceBacklinks(wsA.ID, targetRef, user.ID,
-			[]string{wsA.Slug, wsB.Slug}, 50, 0)
+			[]string{wsA.Slug, wsB.Slug}, 50, 0, false)
 		if len(got) != 1 {
 			t.Errorf("A+B allowlist should see cross-ws from B, got %d", len(got))
 		}
@@ -548,7 +666,7 @@ func TestResolveBacklinksVisibility_RoleMatrix(t *testing.T) {
 		if err != nil {
 			t.Fatalf("create admin: %v", err)
 		}
-		full, granted, err := s.ResolveBacklinksVisibility(admin.ID, ws.ID, false)
+		full, granted, err := s.ResolveBacklinksVisibility(admin.ID, ws.ID, false, false)
 		if err != nil {
 			t.Fatalf("ResolveBacklinksVisibility: %v", err)
 		}
@@ -558,7 +676,7 @@ func TestResolveBacklinksVisibility_RoleMatrix(t *testing.T) {
 	})
 
 	t.Run("full-access member returns unrestricted", func(t *testing.T) {
-		full, granted, err := s.ResolveBacklinksVisibility(owner.ID, ws.ID, false)
+		full, granted, err := s.ResolveBacklinksVisibility(owner.ID, ws.ID, false, false)
 		if err != nil {
 			t.Fatalf("ResolveBacklinksVisibility: %v", err)
 		}
@@ -573,7 +691,7 @@ func TestResolveBacklinksVisibility_RoleMatrix(t *testing.T) {
 		if _, err := s.CreateCollectionGrant(ws.ID, col.ID, guest.ID, "view", owner.ID); err != nil {
 			t.Fatalf("grant collection: %v", err)
 		}
-		full, granted, err := s.ResolveBacklinksVisibility(guest.ID, ws.ID, false)
+		full, granted, err := s.ResolveBacklinksVisibility(guest.ID, ws.ID, false, false)
 		if err != nil {
 			t.Fatalf("ResolveBacklinksVisibility: %v", err)
 		}
@@ -587,7 +705,7 @@ func TestResolveBacklinksVisibility_RoleMatrix(t *testing.T) {
 
 	t.Run("non-member non-grant user returns empty lists", func(t *testing.T) {
 		stranger := createTestUser(t, s, "stranger@example.com", "Stranger", "password123")
-		full, granted, err := s.ResolveBacklinksVisibility(stranger.ID, ws.ID, false)
+		full, granted, err := s.ResolveBacklinksVisibility(stranger.ID, ws.ID, false, false)
 		if err != nil {
 			t.Fatalf("ResolveBacklinksVisibility: %v", err)
 		}
@@ -596,6 +714,59 @@ func TestResolveBacklinksVisibility_RoleMatrix(t *testing.T) {
 		// + both lists empty.
 		if len(full) != 0 || len(granted) != 0 {
 			t.Errorf("stranger should have empty visibility, got %v / %v", full, granted)
+		}
+	})
+
+	t.Run("admin via bearer auth on non-member workspace gets empty visibility (BUG-1617)", func(t *testing.T) {
+		// Fresh admin with no relationship to `ws`. Pre-BUG-1617
+		// this returned (nil, nil) — "unrestricted" — even though
+		// the bearer-borne admin had never joined the workspace.
+		// Post-fix: bearer-admin falls through the non-admin path,
+		// hitting the GetWorkspaceMember branch and ending up on
+		// the guest path with no grants → empty lists.
+		admin, err := s.CreateUser(models.UserCreate{
+			Email: "admin-bearer@example.com", Name: "AdminBearer", Password: "password123",
+			Role: "admin",
+		})
+		if err != nil {
+			t.Fatalf("create admin: %v", err)
+		}
+		full, granted, err := s.ResolveBacklinksVisibility(admin.ID, ws.ID, false, true)
+		if err != nil {
+			t.Fatalf("ResolveBacklinksVisibility (bearer admin): %v", err)
+		}
+		// Both lists empty, NOT nil/nil. Mirrors the non-member-
+		// non-grant stranger case above — that's the desired
+		// equivalence: a bearer-borne admin is treated as a regular
+		// user for cross-workspace visibility.
+		if full == nil && granted == nil {
+			t.Errorf("bearer admin must NOT be treated as unrestricted (nil/nil) on a non-member workspace; got (nil, nil)")
+		}
+		if len(full) != 0 || len(granted) != 0 {
+			t.Errorf("bearer admin on non-member workspace should have empty visibility, got %v / %v", full, granted)
+		}
+	})
+
+	t.Run("admin via bearer auth on member workspace uses member access", func(t *testing.T) {
+		// Positive control: when the bearer-admin IS a member, they
+		// get the same visibility shape as any other member of that
+		// role. Owner-equivalent membership → unrestricted (nil/nil).
+		adminMember, err := s.CreateUser(models.UserCreate{
+			Email: "admin-member@example.com", Name: "AdminMember", Password: "password123",
+			Role: "admin",
+		})
+		if err != nil {
+			t.Fatalf("create admin: %v", err)
+		}
+		if err := s.AddWorkspaceMember(ws.ID, adminMember.ID, "owner"); err != nil {
+			t.Fatalf("add admin as member: %v", err)
+		}
+		full, granted, err := s.ResolveBacklinksVisibility(adminMember.ID, ws.ID, false, true)
+		if err != nil {
+			t.Fatalf("ResolveBacklinksVisibility (bearer admin, member): %v", err)
+		}
+		if full != nil || granted != nil {
+			t.Errorf("bearer admin who's a workspace owner should be unrestricted (nil/nil), got %v / %v", full, granted)
 		}
 	})
 }

--- a/internal/store/workspace_members.go
+++ b/internal/store/workspace_members.go
@@ -351,6 +351,60 @@ func (s *Store) ListSystemCollectionIDs(workspaceID string) ([]string, error) {
 	return ids, rows.Err()
 }
 
+// GetUserMemberWorkspaces returns only workspaces where the user has
+// a workspace_members row — NO guest-grant fallback. Mirrors the
+// first half of GetUserWorkspaces but without the UNION with
+// collection_grants / item_grants tables.
+//
+// Use this when the caller needs the strict "is the user a member?"
+// shape — e.g. BUG-1617's bearer-admin cross-workspace enumeration:
+// RequireWorkspaceAccess gives bearer-admin membership-only access
+// (no grants fallback), and the cross-ws backlinks enumeration must
+// match that policy. Without this, a bearer-admin with a stray
+// collection grant on workspace C would still see cross-ws backlinks
+// from C even though direct bearer access to C is denied.
+//
+// The returned slice does NOT include the "last item activity"
+// MAX(items.updated_at) computation — callers wanting that detail
+// should use GetUserWorkspaces. This helper is for membership-set
+// enumeration only, where the UpdatedAt of each row is the raw
+// workspace row timestamp.
+func (s *Store) GetUserMemberWorkspaces(userID string) ([]models.Workspace, error) {
+	rows, err := s.db.Query(s.q(`
+		SELECT w.id, w.name, w.slug, w.owner_id, COALESCE(ou.username, ''), w.description, w.settings, w.created_at, w.updated_at, w.deleted_at,
+		       wm.sort_order
+		FROM workspaces w
+		JOIN workspace_members wm ON wm.workspace_id = w.id
+		LEFT JOIN users ou ON ou.id = w.owner_id
+		WHERE wm.user_id = ? AND w.deleted_at IS NULL
+		ORDER BY wm.sort_order ASC, w.name ASC
+	`), userID)
+	if err != nil {
+		return nil, fmt.Errorf("get user member workspaces: %w", err)
+	}
+	defer rows.Close()
+
+	var result []models.Workspace
+	for rows.Next() {
+		var ws models.Workspace
+		var createdAt, updatedAt string
+		var deletedAt *string
+		if err := rows.Scan(
+			&ws.ID, &ws.Name, &ws.Slug, &ws.OwnerID, &ws.OwnerUsername, &ws.Description, &ws.Settings,
+			&createdAt, &updatedAt, &deletedAt,
+			&ws.SortOrder,
+		); err != nil {
+			return nil, fmt.Errorf("scan workspace: %w", err)
+		}
+		ws.CreatedAt = parseTime(createdAt)
+		ws.UpdatedAt = parseTime(updatedAt)
+		ws.DeletedAt = parseTimePtr(deletedAt)
+		ws.HydrateDerivedFields()
+		result = append(result, ws)
+	}
+	return result, rows.Err()
+}
+
 // GetUserWorkspaces returns all workspaces a user has access to,
 // sorted by the user's custom sort order (then name as tiebreaker).
 func (s *Store) GetUserWorkspaces(userID string) ([]models.Workspace, error) {


### PR DESCRIPTION
## Summary

- Companion to [#632](https://github.com/PerpetualSoftware/pad/pull/632) (BUG-1616). The admin platform role granted unrestricted cross-workspace visibility at the **store layer**, BEFORE the BUG-1616 middleware gate could fire. A bearer-borne admin (CLI / PAT / MCP) could enumerate cross-workspace backlinks from every workspace on the server.
- Threads `authIsBearer bool` from the HTTP boundary down into the store layer (`Store.ResolveBacklinksVisibility`, `Store.GetCrossWorkspaceBacklinks`). Bearer-borne admins now get strict membership-only enumeration; cookie-session admins keep the global view.
- New helper `Store.GetUserMemberWorkspaces` — strict membership enumeration with no guest-grant fallback. Used by the bearer-admin cross-ws path so a stray collection / item grant on workspace C can't side-channel into cross-ws backlinks from C.

## Codex review history

Round 1 caught a real inconsistency: my initial fix used `GetUserWorkspaces` for bearer-admin, which still includes guest-grant workspaces — letting a bearer-admin with a stray collection grant on workspace C see cross-ws backlinks from C even though direct access to C is denied. Fixed by adding `GetUserMemberWorkspaces` and routing bearer-admin to it. Round 2 review: **CLEAN**.

## Behavior matrix

| Caller | Workspace enumeration | Per-workspace visibility |
|---|---|---|
| Cookie admin | `ListWorkspaces()` (all non-deleted) | `nil/nil` (unrestricted) |
| **Bearer admin** | **`GetUserMemberWorkspaces` (NEW, members-only)** | **Real member/grants pipeline** |
| Non-admin | `GetUserWorkspaces` (members ∪ guest workspaces) | Real member/grants pipeline |

## Test plan

- [x] `go test ./...` — full suite green
- [x] `make lint` — `0 issues.`
- [x] Codex re-review — CLEAN (round 2)
- [x] `make install` — server restarted, no startup errors
- [x] 5 new/updated tests:
  - `TestWikiLinks_CrossWorkspaceAdminSeesAllWorkspaces` (extended to cover bearer + cookie)
  - `TestWikiLinks_CrossWorkspaceBearerAdminGrantOnlyWorkspaceFiltered` (NEW — Codex round-2 regression)
  - `TestWikiLinks_CrossWorkspaceBearerAdminSeesMemberWorkspaces` (NEW — positive control)
  - `TestResolveBacklinksVisibility_RoleMatrix` (+2 bearer-admin subtests)
  - `TestCrossWorkspaceBacklinks_AdminBearer_OnlySeesMembershipWorkspaces` (NEW — HTTP integration, cookie + bearer subtests)

## Files changed

- `internal/store/backlinks_visibility.go` — gated admin bypass, tightened "no visibility" return shape
- `internal/store/wiki_links.go` — three-way switch for workspace enumeration
- `internal/store/workspace_members.go` — new `GetUserMemberWorkspaces` helper
- `internal/server/server.go` — gated admin bypass in `guestResourceFilterCore`
- `internal/server/handlers_backlinks.go` — pass `isBearerAuth(r)` to store
- `internal/store/wiki_links_xws_test.go` — updated existing + 3 new tests
- `internal/server/handlers_backlinks_admin_bearer_test.go` — NEW, HTTP integration

🤖 BUG-1617