### PR TITLE
feat(store): structured status-transition log + backfill (TASK-1637)

### DIFF
--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -376,6 +376,23 @@ func serveCmd() *cobra.Command {
 					"items_scanned", bf.ItemsScanned, "errors", bf.Errors)
 			}
 
+			// Backfill: populate status_transitions from the historical
+			// activity log (PLAN-1628 / TASK-1637). Idempotent — gated on an
+			// empty table, so it replays history exactly once on the first
+			// boot after migration 063/042 and short-circuits thereafter (the
+			// write-path hook keeps the table populated). Non-fatal: a failed
+			// run leaves live data intact and only affects the pre-upgrade
+			// report window.
+			if st, err := s.BackfillStatusTransitions(); err != nil {
+				slog.Warn("status-transition backfill failed; non-fatal", "error", err)
+			} else if !st.Skipped && st.Inserted > 0 {
+				slog.Info("Status-transition backfill complete",
+					"activities_scanned", st.ActivitiesScanned,
+					"inserted", st.Inserted,
+					"errors", st.Errors,
+				)
+			}
+
 			// Auto-upgrade hook removed in IDEA-1479. The historical
 			// SeedDefaultCollections backfill was incompatible with templates
 			// that intentionally diverge from Defaults() (e.g. `blank`). Future

--- a/internal/models/status_transition.go
+++ b/internal/models/status_transition.go
@@ -1,0 +1,23 @@
+package models
+
+// StatusTransition is one structured record of an item moving from one
+// status value to another. Unlike the activity feed — which is
+// debounce-coalesced and stores changes as a human-readable
+// `metadata.changes` string — every status change writes its own row here,
+// in the same transaction as the item update. That makes it the canonical
+// source for "when did item X enter status Y", which the Reports
+// aggregation needs for the completed-throughput and cycle-time series.
+//
+// FromStatus is empty when the prior status was unset (e.g. a transition
+// recorded from a field that didn't previously carry a status value).
+//
+// PLAN-1628 / TASK-1637.
+type StatusTransition struct {
+	ID           string `json:"id"`
+	ItemID       string `json:"item_id"`
+	WorkspaceID  string `json:"workspace_id"`
+	CollectionID string `json:"collection_id"`
+	FromStatus   string `json:"from_status"`
+	ToStatus     string `json:"to_status"`
+	CreatedAt    string `json:"created_at"`
+}

--- a/internal/models/status_transition.go
+++ b/internal/models/status_transition.go
@@ -8,8 +8,14 @@ package models
 // source for "when did item X enter status Y", which the Reports
 // aggregation needs for the completed-throughput and cycle-time series.
 //
-// FromStatus is empty when the prior status was unset (e.g. a transition
-// recorded from a field that didn't previously carry a status value).
+// FieldKey is the select field whose value this transition tracks. It is
+// usually "status", but a collection can designate another select field as its
+// workflow/done field via CollectionSettings.BoardGroupBy (DoneFieldKey) — e.g.
+// hiring Candidates grouped by "stage"/"result". FromStatus/ToStatus hold that
+// field's old/new value.
+//
+// FromStatus is empty when the prior value was unset (e.g. the create-time
+// "entered initial status" row, where the item came from no prior value).
 //
 // PLAN-1628 / TASK-1637.
 type StatusTransition struct {
@@ -17,6 +23,7 @@ type StatusTransition struct {
 	ItemID       string `json:"item_id"`
 	WorkspaceID  string `json:"workspace_id"`
 	CollectionID string `json:"collection_id"`
+	FieldKey     string `json:"field_key"`
 	FromStatus   string `json:"from_status"`
 	ToStatus     string `json:"to_status"`
 	CreatedAt    string `json:"created_at"`

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -2974,13 +2974,31 @@ func (s *Store) MoveItemWithPreCheck(
 		existing = freshExisting
 	}
 
+	moveTS := time.Now().UTC().Format(time.RFC3339)
 	_, err = tx.Exec(s.q(`
 		UPDATE items
 		SET collection_id = ?, fields = ?, updated_at = ?, seq = `+nextWorkspaceSeqSubquery+`
 		WHERE id = ? AND deleted_at IS NULL`),
-		targetCollectionID, newFieldsJSON, time.Now().UTC().Format(time.RFC3339), existing.WorkspaceID, itemID)
+		targetCollectionID, newFieldsJSON, moveTS, existing.WorkspaceID, itemID)
 	if err != nil {
 		return nil, fmt.Errorf("move item: %w", err)
+	}
+
+	// A move can carry a status-changing field override (e.g.
+	// `pad item move ... --field status=done`), which rewrites `fields`
+	// outside the UpdateItemWithPreCheck path. Record the transition here
+	// too so status_transitions stays the canonical source for reports
+	// (PLAN-1628 / TASK-1637). collection_id reflects the TARGET collection
+	// the item now lives in. Same tx, not debounced.
+	oldStatus := extractStatusValue(existing.Fields)
+	newStatus := extractStatusValue(newFieldsJSON)
+	if newStatus != "" && newStatus != oldStatus {
+		if _, err = tx.Exec(s.q(`
+			INSERT INTO status_transitions (id, item_id, workspace_id, collection_id, from_status, to_status, created_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?)
+		`), newID(), itemID, existing.WorkspaceID, targetCollectionID, oldStatus, newStatus, moveTS); err != nil {
+			return nil, fmt.Errorf("record status transition on move: %w", err)
+		}
 	}
 
 	if err := tx.Commit(); err != nil {

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -239,6 +239,25 @@ func (s *Store) tryCreateItem(id, workspaceID, collectionID, slug, ts, fields, t
 		return fmt.Errorf("resolve broken titles: %w", err)
 	}
 
+	// Seed the create-time "entered initial status" transition so an item
+	// created directly in a terminal done-field value (e.g. a retroactively
+	// logged "done" task, or an import) still counts as a completion in
+	// reports (PLAN-1628 / TASK-1637). Resolve the collection's done field
+	// in-tx; skip when it's unset at creation. The deterministic id keeps
+	// this idempotent with the backfill's create-seed for the same item.
+	var schemaJSON, settingsJSON string
+	if err := tx.QueryRow(s.q(`SELECT schema, settings FROM collections WHERE id = ?`), collectionID).Scan(&schemaJSON, &settingsJSON); err == nil {
+		doneKey := doneFieldKeyFromSchemaJSON(schemaJSON, settingsJSON)
+		if initial := extractFieldValue(fields, doneKey); initial != "" {
+			if _, err = tx.Exec(s.q(`
+				INSERT INTO status_transitions (id, item_id, workspace_id, collection_id, field_key, from_status, to_status, created_at)
+				VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+			`), "create_"+id, id, workspaceID, collectionID, doneKey, "", initial, ts); err != nil {
+				return fmt.Errorf("record create-time status transition: %w", err)
+			}
+		}
+	}
+
 	return tx.Commit()
 }
 
@@ -1676,15 +1695,16 @@ func (s *Store) UpdateItemWithPreCheck(
 	// workspace/parent locks we hold) could have superseded — re-read in-tx
 	// in that case. Reading here, before the UPDATE, is essential: a re-read
 	// after the UPDATE would see the new status and the hop would vanish.
-	var statusBefore string
+	var statusBefore, doneKey string
 	if input.Fields != nil {
+		doneKey = s.doneFieldKey(existing.CollectionID)
 		oldFields := existing.Fields
 		if precheck == nil {
 			if fresh, ferr := s.getItemTx(tx, id); ferr == nil && fresh != nil {
 				oldFields = fresh.Fields
 			}
 		}
-		statusBefore = extractStatusValue(oldFields)
+		statusBefore = extractFieldValue(oldFields, doneKey)
 	}
 
 	args = append(args, id)
@@ -1702,12 +1722,12 @@ func (s *Store) UpdateItemWithPreCheck(
 	// own row. This is the canonical timestamp source for the Reports
 	// completed-throughput and cycle-time series (PLAN-1628 / TASK-1637).
 	if input.Fields != nil {
-		newStatus := extractStatusValue(*input.Fields)
+		newStatus := extractFieldValue(*input.Fields, doneKey)
 		if newStatus != "" && newStatus != statusBefore {
 			if _, err = tx.Exec(s.q(`
-				INSERT INTO status_transitions (id, item_id, workspace_id, collection_id, from_status, to_status, created_at)
-				VALUES (?, ?, ?, ?, ?, ?, ?)
-			`), newID(), id, existing.WorkspaceID, existing.CollectionID, statusBefore, newStatus, ts); err != nil {
+				INSERT INTO status_transitions (id, item_id, workspace_id, collection_id, field_key, from_status, to_status, created_at)
+				VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+			`), newID(), id, existing.WorkspaceID, existing.CollectionID, doneKey, statusBefore, newStatus, ts); err != nil {
 				return nil, fmt.Errorf("record status transition: %w", err)
 			}
 		}
@@ -2995,7 +3015,11 @@ func (s *Store) MoveItemWithPreCheck(
 	// Capture the pre-move status under lock before the UPDATE, mirroring the
 	// UpdateItemWithPreCheck path: `existing` is the fresh in-tx snapshot when
 	// a precheck ran, otherwise re-read so a concurrent write doesn't make
-	// from_status stale.
+	// from_status stale. The done field resolves against the TARGET collection
+	// (where the item now lives and which reports group by); for a move that
+	// also crosses to a collection with a different done field, the old value
+	// read through that key may be empty, which correctly reads as "entered".
+	moveDoneKey := s.doneFieldKey(targetCollectionID)
 	oldFields := existing.Fields
 	if precheck == nil {
 		if fresh, ferr := s.getItemTx(tx, itemID); ferr == nil && fresh != nil {
@@ -3019,13 +3043,13 @@ func (s *Store) MoveItemWithPreCheck(
 	// too so status_transitions stays the canonical source for reports
 	// (PLAN-1628 / TASK-1637). collection_id reflects the TARGET collection
 	// the item now lives in. Same tx, not debounced.
-	oldStatus := extractStatusValue(oldFields)
-	newStatus := extractStatusValue(newFieldsJSON)
+	oldStatus := extractFieldValue(oldFields, moveDoneKey)
+	newStatus := extractFieldValue(newFieldsJSON, moveDoneKey)
 	if newStatus != "" && newStatus != oldStatus {
 		if _, err = tx.Exec(s.q(`
-			INSERT INTO status_transitions (id, item_id, workspace_id, collection_id, from_status, to_status, created_at)
-			VALUES (?, ?, ?, ?, ?, ?, ?)
-		`), newID(), itemID, existing.WorkspaceID, targetCollectionID, oldStatus, newStatus, moveTS); err != nil {
+			INSERT INTO status_transitions (id, item_id, workspace_id, collection_id, field_key, from_status, to_status, created_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+		`), newID(), itemID, existing.WorkspaceID, targetCollectionID, moveDoneKey, oldStatus, newStatus, moveTS); err != nil {
 			return nil, fmt.Errorf("record status transition on move: %w", err)
 		}
 	}

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -1668,6 +1668,25 @@ func (s *Store) UpdateItemWithPreCheck(
 		args = append(args, input.Source)
 	}
 
+	// Capture the pre-update status BEFORE the UPDATE runs, so the
+	// transition log below records an accurate from_status. It must reflect
+	// the locked, in-tx state: when a precheck ran, `existing` was already
+	// replaced with the fresh in-tx snapshot above; otherwise `existing` is
+	// the pre-tx read, which a concurrent update (now serialized behind the
+	// workspace/parent locks we hold) could have superseded — re-read in-tx
+	// in that case. Reading here, before the UPDATE, is essential: a re-read
+	// after the UPDATE would see the new status and the hop would vanish.
+	var statusBefore string
+	if input.Fields != nil {
+		oldFields := existing.Fields
+		if precheck == nil {
+			if fresh, ferr := s.getItemTx(tx, id); ferr == nil && fresh != nil {
+				oldFields = fresh.Fields
+			}
+		}
+		statusBefore = extractStatusValue(oldFields)
+	}
+
 	args = append(args, id)
 	query := fmt.Sprintf("UPDATE items SET %s WHERE id = ?", strings.Join(sets, ", "))
 	_, err = tx.Exec(s.q(query), args...)
@@ -1683,13 +1702,12 @@ func (s *Store) UpdateItemWithPreCheck(
 	// own row. This is the canonical timestamp source for the Reports
 	// completed-throughput and cycle-time series (PLAN-1628 / TASK-1637).
 	if input.Fields != nil {
-		oldStatus := extractStatusValue(existing.Fields)
 		newStatus := extractStatusValue(*input.Fields)
-		if newStatus != "" && newStatus != oldStatus {
+		if newStatus != "" && newStatus != statusBefore {
 			if _, err = tx.Exec(s.q(`
 				INSERT INTO status_transitions (id, item_id, workspace_id, collection_id, from_status, to_status, created_at)
 				VALUES (?, ?, ?, ?, ?, ?, ?)
-			`), newID(), id, existing.WorkspaceID, existing.CollectionID, oldStatus, newStatus, ts); err != nil {
+			`), newID(), id, existing.WorkspaceID, existing.CollectionID, statusBefore, newStatus, ts); err != nil {
 				return nil, fmt.Errorf("record status transition: %w", err)
 			}
 		}
@@ -2974,6 +2992,17 @@ func (s *Store) MoveItemWithPreCheck(
 		existing = freshExisting
 	}
 
+	// Capture the pre-move status under lock before the UPDATE, mirroring the
+	// UpdateItemWithPreCheck path: `existing` is the fresh in-tx snapshot when
+	// a precheck ran, otherwise re-read so a concurrent write doesn't make
+	// from_status stale.
+	oldFields := existing.Fields
+	if precheck == nil {
+		if fresh, ferr := s.getItemTx(tx, itemID); ferr == nil && fresh != nil {
+			oldFields = fresh.Fields
+		}
+	}
+
 	moveTS := time.Now().UTC().Format(time.RFC3339)
 	_, err = tx.Exec(s.q(`
 		UPDATE items
@@ -2990,7 +3019,7 @@ func (s *Store) MoveItemWithPreCheck(
 	// too so status_transitions stays the canonical source for reports
 	// (PLAN-1628 / TASK-1637). collection_id reflects the TARGET collection
 	// the item now lives in. Same tx, not debounced.
-	oldStatus := extractStatusValue(existing.Fields)
+	oldStatus := extractStatusValue(oldFields)
 	newStatus := extractStatusValue(newFieldsJSON)
 	if newStatus != "" && newStatus != oldStatus {
 		if _, err = tx.Exec(s.q(`

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -1675,6 +1675,26 @@ func (s *Store) UpdateItemWithPreCheck(
 		return nil, fmt.Errorf("update item: %w", err)
 	}
 
+	// Record a structured status transition when the fields blob was part
+	// of this update AND the `status` value actually changed. Written in
+	// the same tx as the item UPDATE so the transition log can never
+	// diverge from the item's persisted status, and — unlike the activity
+	// feed — NOT debounced, so every hop (open → in-progress → done) is its
+	// own row. This is the canonical timestamp source for the Reports
+	// completed-throughput and cycle-time series (PLAN-1628 / TASK-1637).
+	if input.Fields != nil {
+		oldStatus := extractStatusValue(existing.Fields)
+		newStatus := extractStatusValue(*input.Fields)
+		if newStatus != "" && newStatus != oldStatus {
+			if _, err = tx.Exec(s.q(`
+				INSERT INTO status_transitions (id, item_id, workspace_id, collection_id, from_status, to_status, created_at)
+				VALUES (?, ?, ?, ?, ?, ?, ?)
+			`), newID(), id, existing.WorkspaceID, existing.CollectionID, oldStatus, newStatus, ts); err != nil {
+				return nil, fmt.Errorf("record status transition: %w", err)
+			}
+		}
+	}
+
 	// Title rename — cascade to title-form backlinks. Fires whether
 	// content changed or not. ORDER MATTERS: cascade runs BEFORE
 	// replaceWikiLinks(self) so the pre-existing wl rows pointing

--- a/internal/store/migrations/063_status_transitions.sql
+++ b/internal/store/migrations/063_status_transitions.sql
@@ -15,11 +15,18 @@
 -- because the UTF-8 arrow ("→") and the "key: from → to" grammar are awkward
 -- to handle in portable SQL.
 
+-- field_key records WHICH select field the transition tracks. It is almost
+-- always "status", but a collection can designate another select field as its
+-- workflow/done field via CollectionSettings.BoardGroupBy (e.g. hiring
+-- Candidates group by "stage"/"result"). Storing the key per row keeps the
+-- table correct even if a collection's BoardGroupBy changes later. The
+-- from_status/to_status columns hold that field's old/new value.
 CREATE TABLE IF NOT EXISTS status_transitions (
     id            TEXT PRIMARY KEY,
-    item_id       TEXT NOT NULL REFERENCES items(id),
+    item_id       TEXT NOT NULL REFERENCES items(id) ON DELETE CASCADE,
     workspace_id  TEXT NOT NULL REFERENCES workspaces(id),
     collection_id TEXT NOT NULL,
+    field_key     TEXT NOT NULL DEFAULT 'status',
     from_status   TEXT NOT NULL DEFAULT '',
     to_status     TEXT NOT NULL,
     created_at    TEXT NOT NULL

--- a/internal/store/migrations/063_status_transitions.sql
+++ b/internal/store/migrations/063_status_transitions.sql
@@ -1,0 +1,36 @@
+-- Migration 063: structured status-transition log (PLAN-1628 / TASK-1637).
+--
+-- The Reports surface needs a reliable timestamp for WHEN an item entered a
+-- given status — specifically a terminal ("completed") status — to compute
+-- the completed-throughput and cycle-time series. The activities table
+-- records status changes only as a human-readable `metadata.changes` string
+-- ("status: open → done") AND is debounce-coalesced, so it cannot be queried
+-- reliably for aggregation. This table captures every status transition as
+-- a structured, queryable row, written in the SAME transaction as the item
+-- update and NEVER debounced.
+--
+-- Historical rows are backfilled once at startup by
+-- Store.BackfillStatusTransitions, which parses activities.metadata.changes
+-- — mirroring the BackfillWikiLinks pattern. The Go side owns the parsing
+-- because the UTF-8 arrow ("→") and the "key: from → to" grammar are awkward
+-- to handle in portable SQL.
+
+CREATE TABLE IF NOT EXISTS status_transitions (
+    id            TEXT PRIMARY KEY,
+    item_id       TEXT NOT NULL REFERENCES items(id),
+    workspace_id  TEXT NOT NULL REFERENCES workspaces(id),
+    collection_id TEXT NOT NULL,
+    from_status   TEXT NOT NULL DEFAULT '',
+    to_status     TEXT NOT NULL,
+    created_at    TEXT NOT NULL
+);
+
+-- Primary aggregation access path: "transitions in this workspace within a
+-- time window", date-bucketed by created_at.
+CREATE INDEX IF NOT EXISTS idx_status_transitions_ws_time
+    ON status_transitions(workspace_id, created_at);
+
+-- Per-item history: cycle-time joins created_at of the item to its terminal
+-- transition.
+CREATE INDEX IF NOT EXISTS idx_status_transitions_item
+    ON status_transitions(item_id, created_at);

--- a/internal/store/pgmigrations/042_status_transitions.sql
+++ b/internal/store/pgmigrations/042_status_transitions.sql
@@ -13,11 +13,15 @@
 -- Historical rows are backfilled once at startup by
 -- Store.BackfillStatusTransitions (parses activities.metadata.changes).
 
+-- field_key records WHICH select field the transition tracks (usually
+-- "status"; a collection may designate another via BoardGroupBy, e.g. hiring
+-- Candidates → "stage"). from_status/to_status hold that field's old/new value.
 CREATE TABLE IF NOT EXISTS status_transitions (
     id            TEXT PRIMARY KEY,
-    item_id       TEXT NOT NULL REFERENCES items(id),
+    item_id       TEXT NOT NULL REFERENCES items(id) ON DELETE CASCADE,
     workspace_id  TEXT NOT NULL REFERENCES workspaces(id),
     collection_id TEXT NOT NULL,
+    field_key     TEXT NOT NULL DEFAULT 'status',
     from_status   TEXT NOT NULL DEFAULT '',
     to_status     TEXT NOT NULL,
     created_at    TEXT NOT NULL

--- a/internal/store/pgmigrations/042_status_transitions.sql
+++ b/internal/store/pgmigrations/042_status_transitions.sql
@@ -1,0 +1,30 @@
+-- Migration 042 (Postgres): structured status-transition log
+-- (PLAN-1628 / TASK-1637).
+--
+-- Postgres counterpart to migrations/063_status_transitions.sql. Same intent:
+-- a structured, queryable record of every item status change — written in the
+-- same transaction as the item update, never debounced — so the Reports
+-- aggregation can compute the completed-throughput and cycle-time series
+-- without parsing the human-readable, debounce-coalesced activities feed.
+--
+-- Timestamps are stored as RFC3339 TEXT to match item_versions and the rest
+-- of the schema (the application layer formats UTC strings via dialect.Now).
+--
+-- Historical rows are backfilled once at startup by
+-- Store.BackfillStatusTransitions (parses activities.metadata.changes).
+
+CREATE TABLE IF NOT EXISTS status_transitions (
+    id            TEXT PRIMARY KEY,
+    item_id       TEXT NOT NULL REFERENCES items(id),
+    workspace_id  TEXT NOT NULL REFERENCES workspaces(id),
+    collection_id TEXT NOT NULL,
+    from_status   TEXT NOT NULL DEFAULT '',
+    to_status     TEXT NOT NULL,
+    created_at    TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_status_transitions_ws_time
+    ON status_transitions(workspace_id, created_at);
+
+CREATE INDEX IF NOT EXISTS idx_status_transitions_item
+    ON status_transitions(item_id, created_at);

--- a/internal/store/status_transitions_backfill.go
+++ b/internal/store/status_transitions_backfill.go
@@ -5,38 +5,42 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
-// extractStatusValue pulls the `status` field out of an item's fields JSON
+// extractFieldValue pulls a named string field out of an item's fields JSON
 // blob. Returns "" when the blob is empty, unparseable, or carries no string
-// status — callers treat "" as "no status" (so an unset → set transition has
-// an empty FromStatus, and a status-less collection never records a row).
-func extractStatusValue(fieldsJSON string) string {
-	if fieldsJSON == "" {
+// value for the key — callers treat "" as "no value" (so an unset → set
+// transition has an empty FromStatus, and a collection whose done field is
+// unset never records a row).
+func extractFieldValue(fieldsJSON, key string) string {
+	if fieldsJSON == "" || key == "" {
 		return ""
 	}
 	var m map[string]any
 	if err := json.Unmarshal([]byte(fieldsJSON), &m); err != nil {
 		return ""
 	}
-	if s, ok := m["status"].(string); ok {
-		return s
+	if v, ok := m[key].(string); ok {
+		return v
 	}
 	return ""
 }
 
-// parseStatusChange extracts the from/to status out of a single
+// parseFieldChange extracts the from/to value for a given field out of a single
 // activities.metadata `changes` string. The string is built by
-// handlers_documents.go::diffFields as a "; "-joined list of
-// "key: old → new" segments (and "key: → new" when the key was newly set).
-// We locate the "status:" segment and split it on the UTF-8 arrow.
+// handlers_documents.go::diffFields as a "; "-joined list of "key: old → new"
+// segments (and "key: → new" when the key was newly set). We locate the
+// "<fieldKey>:" segment and split it on the UTF-8 arrow.
 //
-// Returns ok=false when there is no status segment. from may be "" (newly-set
-// status); to is always non-empty when ok.
-func parseStatusChange(changes string) (from, to string, ok bool) {
+// Returns ok=false when there is no segment for fieldKey. from may be ""
+// (newly-set value); to is always non-empty when ok.
+func parseFieldChange(changes, fieldKey string) (from, to string, ok bool) {
+	prefix := fieldKey + ":"
 	for _, seg := range strings.Split(changes, ";") {
 		seg = strings.TrimSpace(seg)
-		rest, found := strings.CutPrefix(seg, "status:")
+		rest, found := strings.CutPrefix(seg, prefix)
 		if !found {
 			continue
 		}
@@ -55,6 +59,40 @@ func parseStatusChange(changes string) (from, to string, ok bool) {
 	return "", "", false
 }
 
+// doneFieldKey resolves the select field whose value represents a collection's
+// workflow/done state (CollectionSettings.BoardGroupBy, else "status"). Used by
+// the status-transition capture so collections grouped by a non-status field
+// (hiring Candidates → "stage"/"result", etc.) record transitions on the right
+// field. Best-effort: any lookup/parse failure falls back to "status" so
+// capture degrades gracefully rather than dropping rows.
+func (s *Store) doneFieldKey(collectionID string) string {
+	col, err := s.GetCollection(collectionID)
+	if err != nil || col == nil {
+		return "status"
+	}
+	return doneFieldKeyFromCollection(col)
+}
+
+func doneFieldKeyFromCollection(col *models.Collection) string {
+	return doneFieldKeyFromSchemaJSON(col.Schema, col.Settings)
+}
+
+// doneFieldKeyFromSchemaJSON resolves the done-field key from the raw schema +
+// settings JSON strings (as stored on the collections row). Falls back to
+// "status" on any parse failure. Lets callers that already hold the raw JSON
+// (e.g. an in-tx read) resolve the key without a models.Collection.
+func doneFieldKeyFromSchemaJSON(schemaJSON, settingsJSON string) string {
+	var schema models.CollectionSchema
+	if err := json.Unmarshal([]byte(schemaJSON), &schema); err != nil {
+		return "status"
+	}
+	var settings models.CollectionSettings
+	if settingsJSON != "" {
+		_ = json.Unmarshal([]byte(settingsJSON), &settings)
+	}
+	return models.DoneFieldKey(schema, settings)
+}
+
 // BackfillStatusTransitionsResult reports what the backfill did so the
 // startup hook can log a one-line summary.
 type BackfillStatusTransitionsResult struct {
@@ -71,10 +109,17 @@ type BackfillStatusTransitionsResult struct {
 	Errors int
 }
 
-// BackfillStatusTransitions populates status_transitions from the historical
-// activity log, parsing each "updated" activity's metadata.changes for a
-// status hop. Designed to be called once from server startup after
-// migrations run, mirroring BackfillWikiLinks.
+// BackfillStatusTransitions populates status_transitions from history in two
+// passes, designed to be called once from server startup after migrations run
+// (mirrors BackfillWikiLinks):
+//
+//  1. Activity-derived hops — parse each "updated" activity's metadata.changes
+//     for a change to the item's collection done field (DoneFieldKey: "status"
+//     for most collections, but e.g. "stage"/"result" for hiring/interviewing).
+//  2. Create-time rows — one "" → initial-value row per item at its created_at,
+//     so an item created directly in a terminal value still counts as a
+//     completion. The initial value is the `from` of the item's earliest
+//     recorded change, or its current done-field value if it never changed.
 //
 // Idempotency: gated on the table being empty. On first boot after migration
 // 063/042 the table is empty and the historical activity log is replayed; on
@@ -115,17 +160,60 @@ func (s *Store) BackfillStatusTransitions() (*BackfillStatusTransitionsResult, e
 		return result, nil
 	}
 
+	// Per-collection done-field-key memo. DoneFieldKey loads + parses the
+	// collection schema, so cache it across the two passes below.
+	doneKeyCache := map[string]string{}
+	doneKey := func(collectionID string) string {
+		if k, ok := doneKeyCache[collectionID]; ok {
+			return k
+		}
+		k := s.doneFieldKey(collectionID)
+		doneKeyCache[collectionID] = k
+		return k
+	}
+
+	// Dialect-aware conflict clause makes every backfilled insert idempotent
+	// on its primary key. Combined with the deterministic ids below, this
+	// closes the non-atomic gap the empty-table gate leaves: if two processes
+	// ever replay history concurrently (a future multi-replica Postgres
+	// deploy — single-instance today), the second insert is a no-op rather
+	// than a duplicate that would overcount reports. The live write paths use
+	// a random newID(), so live rows never collide with these.
+	insertSQL := `INSERT INTO status_transitions (id, item_id, workspace_id, collection_id, field_key, from_status, to_status, created_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+	if s.dialect.Driver() == DriverPostgres {
+		insertSQL += ` ON CONFLICT (id) DO NOTHING`
+	} else {
+		insertSQL = strings.Replace(insertSQL, "INSERT INTO", "INSERT OR IGNORE INTO", 1)
+	}
+	insert := func(id, itemID, wsID, collID, fieldKey, from, to, createdAt string) {
+		res, err := s.db.Exec(s.q(insertSQL), id, itemID, wsID, collID, fieldKey, from, to, createdAt)
+		if err != nil {
+			slog.Warn("status-transition backfill: insert failed",
+				slog.String("item_id", itemID), slog.String("err", err.Error()))
+			result.Errors++
+			return
+		}
+		// Count only rows that actually landed — a conflict (already
+		// backfilled by a concurrent process) reports 0 affected.
+		if n, aerr := res.RowsAffected(); aerr == nil && n > 0 {
+			result.Inserted++
+		}
+	}
+
+	// --- Pass 1: activity-derived transitions ---
 	// Join to items for the authoritative workspace_id + collection_id
-	// (activities.workspace_id exists but collection_id does not). Only
-	// "updated" activities carry a changes blob; the LIKE prunes the scan
-	// to status-bearing rows. Order by created_at so multi-hop histories
-	// insert in chronological order.
+	// (activities has workspace_id but not collection_id). Only "updated"
+	// activities carry a changes blob; the LIKE prunes to rows that record a
+	// field change (every "key: a → b" segment contains the arrow). Order by
+	// created_at so multi-hop histories insert chronologically AND so the
+	// firstChangeFrom map below captures each item's earliest hop.
 	rows, err := s.db.Query(s.q(`
 		SELECT a.id, a.document_id, i.workspace_id, i.collection_id, a.metadata, a.created_at
 		FROM activities a
 		JOIN items i ON i.id = a.document_id
 		WHERE a.action = 'updated'
-		  AND a.metadata LIKE '%status:%'
+		  AND a.metadata LIKE '%→%'
 		ORDER BY a.created_at
 	`))
 	if err != nil {
@@ -151,21 +239,11 @@ func (s *Store) BackfillStatusTransitions() (*BackfillStatusTransitionsResult, e
 	}
 	rows.Close()
 
-	// Dialect-aware conflict clause makes each backfilled insert idempotent
-	// on its primary key. Combined with the deterministic, activity-derived
-	// id below, this closes the non-atomic gap the empty-table gate leaves:
-	// if two processes ever replay history concurrently (e.g. a future
-	// multi-replica Postgres deployment — single-instance today), the second
-	// insert of a given activity's transition is a no-op rather than a
-	// duplicate row that would overcount reports. The write-path hook uses a
-	// random newID(), so live rows never collide with these.
-	insertSQL := `INSERT INTO status_transitions (id, item_id, workspace_id, collection_id, from_status, to_status, created_at)
-			VALUES (?, ?, ?, ?, ?, ?, ?)`
-	if s.dialect.Driver() == DriverPostgres {
-		insertSQL += ` ON CONFLICT (id) DO NOTHING`
-	} else {
-		insertSQL = strings.Replace(insertSQL, "INSERT INTO", "INSERT OR IGNORE INTO", 1)
-	}
+	// firstChangeFrom[itemID] = the `from` value of the item's EARLIEST
+	// done-field change. Because rows are ordered by created_at, the first
+	// time we see an item is its earliest hop, and that hop's `from` is the
+	// item's initial value — used by Pass 2 to seed the create-time row.
+	firstChangeFrom := map[string]string{}
 
 	for _, ar := range scanned {
 		result.ActivitiesScanned++
@@ -177,31 +255,70 @@ func (s *Store) BackfillStatusTransitions() (*BackfillStatusTransitionsResult, e
 			result.Errors++
 			continue
 		}
-		from, to, ok := parseStatusChange(meta.Changes)
+		key := doneKey(ar.collectionID)
+		from, to, ok := parseFieldChange(meta.Changes, key)
 		if !ok {
-			// LIKE matched but no parseable status segment (e.g. the word
-			// "status" appeared elsewhere in the blob) — skip silently.
+			// LIKE matched a change, but not on this collection's done field
+			// (e.g. only priority changed) — nothing to record.
 			continue
+		}
+		if _, seen := firstChangeFrom[ar.itemID]; !seen {
+			firstChangeFrom[ar.itemID] = from
 		}
 
-		// Deterministic id: one activity row maps to at most one status
-		// transition, so the activity id (prefixed to keep it visibly
+		// Deterministic id: one activity row maps to at most one done-field
+		// transition, so the activity id (prefixed to stay visibly
 		// backfill-sourced) is a stable, collision-free primary key. Re-runs
 		// hit the conflict clause and no-op.
-		transitionID := "bf_" + ar.activityID
-		res, err := s.db.Exec(s.q(insertSQL),
-			transitionID, ar.itemID, ar.workspaceID, ar.collectionID, from, to, ar.createdAt)
-		if err != nil {
-			slog.Warn("status-transition backfill: insert failed",
-				slog.String("item_id", ar.itemID), slog.String("err", err.Error()))
-			result.Errors++
+		insert("bf_"+ar.activityID, ar.itemID, ar.workspaceID, ar.collectionID, key, from, to, ar.createdAt)
+	}
+
+	// --- Pass 2: create-time "entered initial status" rows ---
+	// Every item entered an initial done-field value at creation; without a
+	// row for it, an item created directly in a terminal value (e.g. a
+	// retroactively-logged "done" task, or an import) would never count as a
+	// completion. Seed one create-row per item at items.created_at.
+	itemRows, err := s.db.Query(s.q(`
+		SELECT id, workspace_id, collection_id, fields, created_at
+		FROM items
+		WHERE deleted_at IS NULL
+	`))
+	if err != nil {
+		return nil, fmt.Errorf("scan items for create-seed backfill: %w", err)
+	}
+	defer itemRows.Close()
+
+	type itemRow struct {
+		id, workspaceID, collectionID, fields, createdAt string
+	}
+	var items []itemRow
+	for itemRows.Next() {
+		var ir itemRow
+		if err := itemRows.Scan(&ir.id, &ir.workspaceID, &ir.collectionID, &ir.fields, &ir.createdAt); err != nil {
+			return nil, fmt.Errorf("scan create-seed row: %w", err)
+		}
+		items = append(items, ir)
+	}
+	if err := itemRows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate create-seed rows: %w", err)
+	}
+	itemRows.Close()
+
+	for _, ir := range items {
+		key := doneKey(ir.collectionID)
+		// Initial value: the `from` of the item's earliest recorded change if
+		// we saw one (that's the value it held before changing); otherwise the
+		// item never changed its done field, so the current value IS the
+		// initial value.
+		initial, changed := firstChangeFrom[ir.id]
+		if !changed {
+			initial = extractFieldValue(ir.fields, key)
+		}
+		if initial == "" {
+			// No initial done-field value to record (unset at creation).
 			continue
 		}
-		// Count only rows that actually landed — a conflict (already
-		// backfilled by a concurrent process) reports 0 affected.
-		if n, aerr := res.RowsAffected(); aerr == nil && n > 0 {
-			result.Inserted++
-		}
+		insert("create_"+ir.id, ir.id, ir.workspaceID, ir.collectionID, key, "", initial, ir.createdAt)
 	}
 
 	return result, nil

--- a/internal/store/status_transitions_backfill.go
+++ b/internal/store/status_transitions_backfill.go
@@ -85,10 +85,20 @@ type BackfillStatusTransitionsResult struct {
 // historical row is a slightly understated pre-upgrade report window; live
 // data from the write-path hook is always complete.
 //
-// Because the activity feed is debounce-coalesced (mergeActivityMeta collapses
-// same-field runs), historical transitions may undercount rapid hops — this is
-// the limitation the structured table exists to fix going forward, and is
-// documented on TASK-1637.
+// Two best-effort caveats apply to historical (pre-upgrade) rows only — live
+// write-path rows have neither:
+//
+//   - Debounce: the activity feed is debounce-coalesced (mergeActivityMeta
+//     collapses same-field runs), so rapid hops may be undercounted. This is
+//     the very limitation the structured table fixes going forward.
+//   - Collection attribution: backfilled rows are stamped with the item's
+//     CURRENT collection_id. The activity log doesn't record which collection
+//     an item was in at the time of a past status change, and reconstructing
+//     it would require replaying each item's move history. For the common case
+//     (an item never changes collection) this is exact; only a transition that
+//     happened BEFORE a later collection move is mis-attributed to the newer
+//     collection. The live move path (MoveItemWithPreCheck) stamps the
+//     collection at transition time, so going-forward data is always correct.
 //
 // PLAN-1628 / TASK-1637.
 func (s *Store) BackfillStatusTransitions() (*BackfillStatusTransitionsResult, error) {

--- a/internal/store/status_transitions_backfill.go
+++ b/internal/store/status_transitions_backfill.go
@@ -111,7 +111,7 @@ func (s *Store) BackfillStatusTransitions() (*BackfillStatusTransitionsResult, e
 	// to status-bearing rows. Order by created_at so multi-hop histories
 	// insert in chronological order.
 	rows, err := s.db.Query(s.q(`
-		SELECT a.document_id, i.workspace_id, i.collection_id, a.metadata, a.created_at
+		SELECT a.id, a.document_id, i.workspace_id, i.collection_id, a.metadata, a.created_at
 		FROM activities a
 		JOIN items i ON i.id = a.document_id
 		WHERE a.action = 'updated'
@@ -126,12 +126,12 @@ func (s *Store) BackfillStatusTransitions() (*BackfillStatusTransitionsResult, e
 	// Buffer rows before writing — some drivers dislike interleaving
 	// INSERTs with an open SELECT cursor (same caution as BackfillWikiLinks).
 	type activityRow struct {
-		itemID, workspaceID, collectionID, metadata, createdAt string
+		activityID, itemID, workspaceID, collectionID, metadata, createdAt string
 	}
 	var scanned []activityRow
 	for rows.Next() {
 		var ar activityRow
-		if err := rows.Scan(&ar.itemID, &ar.workspaceID, &ar.collectionID, &ar.metadata, &ar.createdAt); err != nil {
+		if err := rows.Scan(&ar.activityID, &ar.itemID, &ar.workspaceID, &ar.collectionID, &ar.metadata, &ar.createdAt); err != nil {
 			return nil, fmt.Errorf("scan status-transition backfill row: %w", err)
 		}
 		scanned = append(scanned, ar)
@@ -140,6 +140,22 @@ func (s *Store) BackfillStatusTransitions() (*BackfillStatusTransitionsResult, e
 		return nil, fmt.Errorf("iterate status-transition backfill rows: %w", err)
 	}
 	rows.Close()
+
+	// Dialect-aware conflict clause makes each backfilled insert idempotent
+	// on its primary key. Combined with the deterministic, activity-derived
+	// id below, this closes the non-atomic gap the empty-table gate leaves:
+	// if two processes ever replay history concurrently (e.g. a future
+	// multi-replica Postgres deployment — single-instance today), the second
+	// insert of a given activity's transition is a no-op rather than a
+	// duplicate row that would overcount reports. The write-path hook uses a
+	// random newID(), so live rows never collide with these.
+	insertSQL := `INSERT INTO status_transitions (id, item_id, workspace_id, collection_id, from_status, to_status, created_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?)`
+	if s.dialect.Driver() == DriverPostgres {
+		insertSQL += ` ON CONFLICT (id) DO NOTHING`
+	} else {
+		insertSQL = strings.Replace(insertSQL, "INSERT INTO", "INSERT OR IGNORE INTO", 1)
+	}
 
 	for _, ar := range scanned {
 		result.ActivitiesScanned++
@@ -158,16 +174,24 @@ func (s *Store) BackfillStatusTransitions() (*BackfillStatusTransitionsResult, e
 			continue
 		}
 
-		if _, err := s.db.Exec(s.q(`
-			INSERT INTO status_transitions (id, item_id, workspace_id, collection_id, from_status, to_status, created_at)
-			VALUES (?, ?, ?, ?, ?, ?, ?)
-		`), newID(), ar.itemID, ar.workspaceID, ar.collectionID, from, to, ar.createdAt); err != nil {
+		// Deterministic id: one activity row maps to at most one status
+		// transition, so the activity id (prefixed to keep it visibly
+		// backfill-sourced) is a stable, collision-free primary key. Re-runs
+		// hit the conflict clause and no-op.
+		transitionID := "bf_" + ar.activityID
+		res, err := s.db.Exec(s.q(insertSQL),
+			transitionID, ar.itemID, ar.workspaceID, ar.collectionID, from, to, ar.createdAt)
+		if err != nil {
 			slog.Warn("status-transition backfill: insert failed",
 				slog.String("item_id", ar.itemID), slog.String("err", err.Error()))
 			result.Errors++
 			continue
 		}
-		result.Inserted++
+		// Count only rows that actually landed — a conflict (already
+		// backfilled by a concurrent process) reports 0 affected.
+		if n, aerr := res.RowsAffected(); aerr == nil && n > 0 {
+			result.Inserted++
+		}
 	}
 
 	return result, nil

--- a/internal/store/status_transitions_backfill.go
+++ b/internal/store/status_transitions_backfill.go
@@ -1,0 +1,174 @@
+package store
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+)
+
+// extractStatusValue pulls the `status` field out of an item's fields JSON
+// blob. Returns "" when the blob is empty, unparseable, or carries no string
+// status — callers treat "" as "no status" (so an unset → set transition has
+// an empty FromStatus, and a status-less collection never records a row).
+func extractStatusValue(fieldsJSON string) string {
+	if fieldsJSON == "" {
+		return ""
+	}
+	var m map[string]any
+	if err := json.Unmarshal([]byte(fieldsJSON), &m); err != nil {
+		return ""
+	}
+	if s, ok := m["status"].(string); ok {
+		return s
+	}
+	return ""
+}
+
+// parseStatusChange extracts the from/to status out of a single
+// activities.metadata `changes` string. The string is built by
+// handlers_documents.go::diffFields as a "; "-joined list of
+// "key: old → new" segments (and "key: → new" when the key was newly set).
+// We locate the "status:" segment and split it on the UTF-8 arrow.
+//
+// Returns ok=false when there is no status segment. from may be "" (newly-set
+// status); to is always non-empty when ok.
+func parseStatusChange(changes string) (from, to string, ok bool) {
+	for _, seg := range strings.Split(changes, ";") {
+		seg = strings.TrimSpace(seg)
+		rest, found := strings.CutPrefix(seg, "status:")
+		if !found {
+			continue
+		}
+		parts := strings.SplitN(rest, "→", 2)
+		if len(parts) != 2 {
+			// Malformed (no arrow) — skip rather than guess.
+			return "", "", false
+		}
+		from = strings.TrimSpace(parts[0])
+		to = strings.TrimSpace(parts[1])
+		if to == "" {
+			return "", "", false
+		}
+		return from, to, true
+	}
+	return "", "", false
+}
+
+// BackfillStatusTransitionsResult reports what the backfill did so the
+// startup hook can log a one-line summary.
+type BackfillStatusTransitionsResult struct {
+	// Skipped is true when the table already had rows and the backfill
+	// short-circuited without scanning the activity log.
+	Skipped bool
+	// ActivitiesScanned is the number of status-bearing activity rows
+	// the backfill iterated.
+	ActivitiesScanned int
+	// Inserted is the number of status_transitions rows written.
+	Inserted int
+	// Errors counts activity rows skipped due to a parse or write failure.
+	// Errors are logged at WARN but never abort the run.
+	Errors int
+}
+
+// BackfillStatusTransitions populates status_transitions from the historical
+// activity log, parsing each "updated" activity's metadata.changes for a
+// status hop. Designed to be called once from server startup after
+// migrations run, mirroring BackfillWikiLinks.
+//
+// Idempotency: gated on the table being empty. On first boot after migration
+// 063/042 the table is empty and the historical activity log is replayed; on
+// every subsequent boot the write-path hook has kept the table non-empty, so
+// the backfill short-circuits immediately. This means the historical replay
+// is best-effort and runs exactly once — a partial run that crashed midway is
+// NOT resumed (the next boot sees rows and skips). The cost of a missed
+// historical row is a slightly understated pre-upgrade report window; live
+// data from the write-path hook is always complete.
+//
+// Because the activity feed is debounce-coalesced (mergeActivityMeta collapses
+// same-field runs), historical transitions may undercount rapid hops — this is
+// the limitation the structured table exists to fix going forward, and is
+// documented on TASK-1637.
+//
+// PLAN-1628 / TASK-1637.
+func (s *Store) BackfillStatusTransitions() (*BackfillStatusTransitionsResult, error) {
+	result := &BackfillStatusTransitionsResult{}
+
+	var has bool
+	if err := s.db.QueryRow(s.q(`
+		SELECT EXISTS(SELECT 1 FROM status_transitions)
+	`)).Scan(&has); err != nil {
+		return nil, fmt.Errorf("status-transition backfill existence check: %w", err)
+	}
+	if has {
+		result.Skipped = true
+		return result, nil
+	}
+
+	// Join to items for the authoritative workspace_id + collection_id
+	// (activities.workspace_id exists but collection_id does not). Only
+	// "updated" activities carry a changes blob; the LIKE prunes the scan
+	// to status-bearing rows. Order by created_at so multi-hop histories
+	// insert in chronological order.
+	rows, err := s.db.Query(s.q(`
+		SELECT a.document_id, i.workspace_id, i.collection_id, a.metadata, a.created_at
+		FROM activities a
+		JOIN items i ON i.id = a.document_id
+		WHERE a.action = 'updated'
+		  AND a.metadata LIKE '%status:%'
+		ORDER BY a.created_at
+	`))
+	if err != nil {
+		return nil, fmt.Errorf("scan activities for status-transition backfill: %w", err)
+	}
+	defer rows.Close()
+
+	// Buffer rows before writing — some drivers dislike interleaving
+	// INSERTs with an open SELECT cursor (same caution as BackfillWikiLinks).
+	type activityRow struct {
+		itemID, workspaceID, collectionID, metadata, createdAt string
+	}
+	var scanned []activityRow
+	for rows.Next() {
+		var ar activityRow
+		if err := rows.Scan(&ar.itemID, &ar.workspaceID, &ar.collectionID, &ar.metadata, &ar.createdAt); err != nil {
+			return nil, fmt.Errorf("scan status-transition backfill row: %w", err)
+		}
+		scanned = append(scanned, ar)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate status-transition backfill rows: %w", err)
+	}
+	rows.Close()
+
+	for _, ar := range scanned {
+		result.ActivitiesScanned++
+
+		var meta struct {
+			Changes string `json:"changes"`
+		}
+		if err := json.Unmarshal([]byte(ar.metadata), &meta); err != nil {
+			result.Errors++
+			continue
+		}
+		from, to, ok := parseStatusChange(meta.Changes)
+		if !ok {
+			// LIKE matched but no parseable status segment (e.g. the word
+			// "status" appeared elsewhere in the blob) — skip silently.
+			continue
+		}
+
+		if _, err := s.db.Exec(s.q(`
+			INSERT INTO status_transitions (id, item_id, workspace_id, collection_id, from_status, to_status, created_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?)
+		`), newID(), ar.itemID, ar.workspaceID, ar.collectionID, from, to, ar.createdAt); err != nil {
+			slog.Warn("status-transition backfill: insert failed",
+				slog.String("item_id", ar.itemID), slog.String("err", err.Error()))
+			result.Errors++
+			continue
+		}
+		result.Inserted++
+	}
+
+	return result, nil
+}

--- a/internal/store/status_transitions_test.go
+++ b/internal/store/status_transitions_test.go
@@ -95,6 +95,47 @@ func TestStatusTransition_MultiHopEachRecorded(t *testing.T) {
 	}
 }
 
+func TestStatusTransition_CapturedOnMoveWithStatusOverride(t *testing.T) {
+	s := testStore(t)
+	wsID, srcColID := newTransitionTestWorkspace(t, s)
+	dstCol := createTestCollection(t, s, wsID, "Done Bucket")
+	item := createTestItem(t, s, wsID, srcColID, "Movable", "")
+
+	// `pad item move ... --field status=done` rewrites fields through the
+	// move path, which must also record the transition.
+	if _, err := s.MoveItem(item.ID, dstCol.ID, `{"status":"done"}`); err != nil {
+		t.Fatalf("move item: %v", err)
+	}
+
+	trans := listTransitions(t, s, item.ID)
+	if len(trans) != 1 {
+		t.Fatalf("expected 1 transition from move, got %d", len(trans))
+	}
+	got := trans[0]
+	if got.FromStatus != "open" || got.ToStatus != "done" {
+		t.Fatalf("expected open → done, got %q → %q", got.FromStatus, got.ToStatus)
+	}
+	// collection_id should reflect the target collection the item moved into.
+	if got.CollectionID != dstCol.ID {
+		t.Fatalf("expected transition stamped with target collection %q, got %q", dstCol.ID, got.CollectionID)
+	}
+}
+
+func TestStatusTransition_NoRowOnMoveWithoutStatusChange(t *testing.T) {
+	s := testStore(t)
+	wsID, srcColID := newTransitionTestWorkspace(t, s)
+	dstCol := createTestCollection(t, s, wsID, "Other Bucket")
+	item := createTestItem(t, s, wsID, srcColID, "Plain move", "")
+
+	// Move preserving status — no transition row expected.
+	if _, err := s.MoveItem(item.ID, dstCol.ID, `{"status":"open"}`); err != nil {
+		t.Fatalf("move item: %v", err)
+	}
+	if trans := listTransitions(t, s, item.ID); len(trans) != 0 {
+		t.Fatalf("expected no transitions on status-preserving move, got %d", len(trans))
+	}
+}
+
 func TestStatusTransition_NoRowWhenStatusUnchanged(t *testing.T) {
 	s := testStore(t)
 	wsID, colID := newTransitionTestWorkspace(t, s)

--- a/internal/store/status_transitions_test.go
+++ b/internal/store/status_transitions_test.go
@@ -1,0 +1,183 @@
+package store
+
+import (
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// listTransitions returns all status_transitions rows for an item, oldest
+// first.
+func listTransitions(t *testing.T, s *Store, itemID string) []models.StatusTransition {
+	t.Helper()
+	rows, err := s.db.Query(s.q(`
+		SELECT id, item_id, workspace_id, collection_id, from_status, to_status, created_at
+		FROM status_transitions WHERE item_id = ? ORDER BY created_at, id
+	`), itemID)
+	if err != nil {
+		t.Fatalf("query transitions: %v", err)
+	}
+	defer rows.Close()
+	var out []models.StatusTransition
+	for rows.Next() {
+		var st models.StatusTransition
+		if err := rows.Scan(&st.ID, &st.ItemID, &st.WorkspaceID, &st.CollectionID, &st.FromStatus, &st.ToStatus, &st.CreatedAt); err != nil {
+			t.Fatalf("scan transition: %v", err)
+		}
+		out = append(out, st)
+	}
+	return out
+}
+
+func newTransitionTestWorkspace(t *testing.T, s *Store) (workspaceID, collectionID string) {
+	t.Helper()
+	u, err := s.CreateUser(models.UserCreate{Name: "Tess", Email: "tess@example.com"})
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	ws, err := s.CreateWorkspace(models.WorkspaceCreate{Name: "Trans", Slug: "trans", OwnerID: u.ID})
+	if err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	col := createTestCollection(t, s, ws.ID, "Tasks")
+	return ws.ID, col.ID
+}
+
+func TestStatusTransition_CapturedOnStatusChange(t *testing.T) {
+	s := testStore(t)
+	wsID, colID := newTransitionTestWorkspace(t, s)
+	item := createTestItem(t, s, wsID, colID, "Do a thing", "")
+
+	if _, err := s.UpdateItem(item.ID, models.ItemUpdate{Fields: strPtr(`{"status":"done"}`)}); err != nil {
+		t.Fatalf("update item: %v", err)
+	}
+
+	trans := listTransitions(t, s, item.ID)
+	if len(trans) != 1 {
+		t.Fatalf("expected 1 transition, got %d", len(trans))
+	}
+	got := trans[0]
+	if got.FromStatus != "open" || got.ToStatus != "done" {
+		t.Fatalf("expected open → done, got %q → %q", got.FromStatus, got.ToStatus)
+	}
+	if got.WorkspaceID != wsID || got.CollectionID != colID {
+		t.Fatalf("transition not stamped with workspace/collection: ws=%q col=%q", got.WorkspaceID, got.CollectionID)
+	}
+}
+
+func TestStatusTransition_MultiHopEachRecorded(t *testing.T) {
+	s := testStore(t)
+	wsID, colID := newTransitionTestWorkspace(t, s)
+	item := createTestItem(t, s, wsID, colID, "Multi", "")
+
+	for _, st := range []string{"in-progress", "done"} {
+		if _, err := s.UpdateItem(item.ID, models.ItemUpdate{Fields: strPtr(`{"status":"` + st + `"}`)}); err != nil {
+			t.Fatalf("update to %s: %v", st, err)
+		}
+	}
+
+	trans := listTransitions(t, s, item.ID)
+	if len(trans) != 2 {
+		t.Fatalf("expected 2 transitions, got %d", len(trans))
+	}
+	// Both updates can land in the same wall-clock second (now() is
+	// second-resolution), so row order isn't guaranteed — assert the SET of
+	// hops instead. Each hop must still record the correct from→to pair.
+	hops := map[string]string{} // to -> from
+	for _, st := range trans {
+		hops[st.ToStatus] = st.FromStatus
+	}
+	if from, ok := hops["in-progress"]; !ok || from != "open" {
+		t.Fatalf("missing/incorrect open→in-progress hop: %+v", hops)
+	}
+	if from, ok := hops["done"]; !ok || from != "in-progress" {
+		t.Fatalf("missing/incorrect in-progress→done hop: %+v", hops)
+	}
+}
+
+func TestStatusTransition_NoRowWhenStatusUnchanged(t *testing.T) {
+	s := testStore(t)
+	wsID, colID := newTransitionTestWorkspace(t, s)
+	item := createTestItem(t, s, wsID, colID, "Title only", "")
+
+	// Title change, no status change.
+	if _, err := s.UpdateItem(item.ID, models.ItemUpdate{Title: strPtr("Renamed")}); err != nil {
+		t.Fatalf("update title: %v", err)
+	}
+	// Fields update that keeps the same status.
+	if _, err := s.UpdateItem(item.ID, models.ItemUpdate{Fields: strPtr(`{"status":"open"}`)}); err != nil {
+		t.Fatalf("update fields: %v", err)
+	}
+
+	if trans := listTransitions(t, s, item.ID); len(trans) != 0 {
+		t.Fatalf("expected no transitions, got %d", len(trans))
+	}
+}
+
+func TestParseStatusChange(t *testing.T) {
+	cases := []struct {
+		in       string
+		from, to string
+		ok       bool
+	}{
+		{"status: open → done", "open", "done", true},
+		{"priority: low → high; status: open → in-progress", "open", "in-progress", true},
+		{"status: → done", "", "done", true}, // newly-set status
+		{"priority: low → high", "", "", false},
+		{"status: open", "", "", false}, // malformed, no arrow
+		{"", "", "", false},
+	}
+	for _, c := range cases {
+		from, to, ok := parseStatusChange(c.in)
+		if ok != c.ok || from != c.from || to != c.to {
+			t.Errorf("parseStatusChange(%q) = (%q, %q, %v); want (%q, %q, %v)",
+				c.in, from, to, ok, c.from, c.to, c.ok)
+		}
+	}
+}
+
+func TestBackfillStatusTransitions(t *testing.T) {
+	s := testStore(t)
+	wsID, colID := newTransitionTestWorkspace(t, s)
+	// Create item WITHOUT going through the status-changing update path, so
+	// the only transition rows come from the backfill.
+	item := createTestItem(t, s, wsID, colID, "Historical", "")
+
+	// Simulate a historical activity row carrying a status change in its
+	// metadata.changes blob (the shape diffFields emits).
+	if _, err := s.CreateActivity(models.Activity{
+		WorkspaceID: wsID,
+		DocumentID:  item.ID,
+		Action:      "updated",
+		Actor:       "user",
+		Source:      "web",
+		Metadata:    `{"changes":"status: open → done"}`,
+	}); err != nil {
+		t.Fatalf("create activity: %v", err)
+	}
+
+	res, err := s.BackfillStatusTransitions()
+	if err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+	if res.Skipped {
+		t.Fatalf("backfill unexpectedly skipped (table should have been empty)")
+	}
+	if res.Inserted != 1 {
+		t.Fatalf("expected 1 inserted, got %d (scanned=%d errors=%d)", res.Inserted, res.ActivitiesScanned, res.Errors)
+	}
+
+	trans := listTransitions(t, s, item.ID)
+	if len(trans) != 1 || trans[0].FromStatus != "open" || trans[0].ToStatus != "done" {
+		t.Fatalf("backfilled transition wrong: %+v", trans)
+	}
+
+	// Second run must short-circuit (table now non-empty).
+	res2, err := s.BackfillStatusTransitions()
+	if err != nil {
+		t.Fatalf("second backfill: %v", err)
+	}
+	if !res2.Skipped {
+		t.Fatalf("expected second backfill to skip, got %+v", res2)
+	}
+}

--- a/internal/store/status_transitions_test.go
+++ b/internal/store/status_transitions_test.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/PerpetualSoftware/pad/internal/models"
@@ -211,6 +212,12 @@ func TestBackfillStatusTransitions(t *testing.T) {
 	trans := listTransitions(t, s, item.ID)
 	if len(trans) != 1 || trans[0].FromStatus != "open" || trans[0].ToStatus != "done" {
 		t.Fatalf("backfilled transition wrong: %+v", trans)
+	}
+	// Backfilled rows carry a deterministic, activity-derived id ("bf_" +
+	// activity id) so a concurrent replay conflicts on the PK instead of
+	// inserting a duplicate. Live write-path rows use a random newID().
+	if !strings.HasPrefix(trans[0].ID, "bf_") {
+		t.Fatalf("backfilled transition should have a stable bf_ id, got %q", trans[0].ID)
 	}
 
 	// Second run must short-circuit (table now non-empty).

--- a/internal/store/status_transitions_test.go
+++ b/internal/store/status_transitions_test.go
@@ -12,7 +12,7 @@ import (
 func listTransitions(t *testing.T, s *Store, itemID string) []models.StatusTransition {
 	t.Helper()
 	rows, err := s.db.Query(s.q(`
-		SELECT id, item_id, workspace_id, collection_id, from_status, to_status, created_at
+		SELECT id, item_id, workspace_id, collection_id, field_key, from_status, to_status, created_at
 		FROM status_transitions WHERE item_id = ? ORDER BY created_at, id
 	`), itemID)
 	if err != nil {
@@ -22,10 +22,25 @@ func listTransitions(t *testing.T, s *Store, itemID string) []models.StatusTrans
 	var out []models.StatusTransition
 	for rows.Next() {
 		var st models.StatusTransition
-		if err := rows.Scan(&st.ID, &st.ItemID, &st.WorkspaceID, &st.CollectionID, &st.FromStatus, &st.ToStatus, &st.CreatedAt); err != nil {
+		if err := rows.Scan(&st.ID, &st.ItemID, &st.WorkspaceID, &st.CollectionID, &st.FieldKey, &st.FromStatus, &st.ToStatus, &st.CreatedAt); err != nil {
 			t.Fatalf("scan transition: %v", err)
 		}
 		out = append(out, st)
+	}
+	return out
+}
+
+// hopTransitions returns only the "real" status hops — excluding the
+// create-time "entered initial status" seed row (id prefix "create_") that
+// every created item gets. Hop-focused tests use this so the baseline seed
+// doesn't skew their counts.
+func hopTransitions(t *testing.T, s *Store, itemID string) []models.StatusTransition {
+	t.Helper()
+	var out []models.StatusTransition
+	for _, st := range listTransitions(t, s, itemID) {
+		if !strings.HasPrefix(st.ID, "create_") {
+			out = append(out, st)
+		}
 	}
 	return out
 }
@@ -53,13 +68,16 @@ func TestStatusTransition_CapturedOnStatusChange(t *testing.T) {
 		t.Fatalf("update item: %v", err)
 	}
 
-	trans := listTransitions(t, s, item.ID)
-	if len(trans) != 1 {
-		t.Fatalf("expected 1 transition, got %d", len(trans))
+	hops := hopTransitions(t, s, item.ID)
+	if len(hops) != 1 {
+		t.Fatalf("expected 1 hop transition, got %d", len(hops))
 	}
-	got := trans[0]
+	got := hops[0]
 	if got.FromStatus != "open" || got.ToStatus != "done" {
 		t.Fatalf("expected open → done, got %q → %q", got.FromStatus, got.ToStatus)
+	}
+	if got.FieldKey != "status" {
+		t.Fatalf("expected field_key=status, got %q", got.FieldKey)
 	}
 	if got.WorkspaceID != wsID || got.CollectionID != colID {
 		t.Fatalf("transition not stamped with workspace/collection: ws=%q col=%q", got.WorkspaceID, got.CollectionID)
@@ -77,22 +95,120 @@ func TestStatusTransition_MultiHopEachRecorded(t *testing.T) {
 		}
 	}
 
-	trans := listTransitions(t, s, item.ID)
-	if len(trans) != 2 {
-		t.Fatalf("expected 2 transitions, got %d", len(trans))
+	hops := hopTransitions(t, s, item.ID)
+	if len(hops) != 2 {
+		t.Fatalf("expected 2 hop transitions, got %d", len(hops))
 	}
 	// Both updates can land in the same wall-clock second (now() is
 	// second-resolution), so row order isn't guaranteed — assert the SET of
 	// hops instead. Each hop must still record the correct from→to pair.
-	hops := map[string]string{} // to -> from
-	for _, st := range trans {
-		hops[st.ToStatus] = st.FromStatus
+	byTo := map[string]string{} // to -> from
+	for _, st := range hops {
+		byTo[st.ToStatus] = st.FromStatus
 	}
-	if from, ok := hops["in-progress"]; !ok || from != "open" {
-		t.Fatalf("missing/incorrect open→in-progress hop: %+v", hops)
+	if from, ok := byTo["in-progress"]; !ok || from != "open" {
+		t.Fatalf("missing/incorrect open→in-progress hop: %+v", byTo)
 	}
-	if from, ok := hops["done"]; !ok || from != "in-progress" {
-		t.Fatalf("missing/incorrect in-progress→done hop: %+v", hops)
+	if from, ok := byTo["done"]; !ok || from != "in-progress" {
+		t.Fatalf("missing/incorrect in-progress→done hop: %+v", byTo)
+	}
+}
+
+func TestStatusTransition_NoHopWhenStatusUnchanged(t *testing.T) {
+	s := testStore(t)
+	wsID, colID := newTransitionTestWorkspace(t, s)
+	item := createTestItem(t, s, wsID, colID, "Title only", "")
+
+	// Title change, no status change.
+	if _, err := s.UpdateItem(item.ID, models.ItemUpdate{Title: strPtr("Renamed")}); err != nil {
+		t.Fatalf("update title: %v", err)
+	}
+	// Fields update that keeps the same status.
+	if _, err := s.UpdateItem(item.ID, models.ItemUpdate{Fields: strPtr(`{"status":"open"}`)}); err != nil {
+		t.Fatalf("update fields: %v", err)
+	}
+
+	if hops := hopTransitions(t, s, item.ID); len(hops) != 0 {
+		t.Fatalf("expected no hop transitions, got %d", len(hops))
+	}
+}
+
+// Finding 2: every created item gets a create-time "entered initial status"
+// seed row so it has an "entered status" timestamp.
+func TestStatusTransition_CreateSeed(t *testing.T) {
+	s := testStore(t)
+	wsID, colID := newTransitionTestWorkspace(t, s)
+	item := createTestItem(t, s, wsID, colID, "Fresh", "") // status defaults to open
+
+	all := listTransitions(t, s, item.ID)
+	if len(all) != 1 {
+		t.Fatalf("expected 1 create-seed row, got %d: %+v", len(all), all)
+	}
+	seed := all[0]
+	if !strings.HasPrefix(seed.ID, "create_") {
+		t.Fatalf("expected create_ id, got %q", seed.ID)
+	}
+	if seed.FromStatus != "" || seed.ToStatus != "open" || seed.FieldKey != "status" {
+		t.Fatalf("unexpected create-seed: %+v", seed)
+	}
+}
+
+// Finding 2: an item created directly in a terminal value must still get a
+// create-seed row so reports can count it as a completion.
+func TestStatusTransition_CreateInTerminalStatus(t *testing.T) {
+	s := testStore(t)
+	wsID, colID := newTransitionTestWorkspace(t, s)
+	item, err := s.CreateItem(wsID, colID, models.ItemCreate{Title: "Born done", Fields: `{"status":"done"}`})
+	if err != nil {
+		t.Fatalf("create item: %v", err)
+	}
+
+	all := listTransitions(t, s, item.ID)
+	if len(all) != 1 || all[0].ToStatus != "done" || all[0].FromStatus != "" {
+		t.Fatalf("expected one '' → done create-seed, got %+v", all)
+	}
+}
+
+// Finding 1: collections that designate a non-status select field as their
+// done field (BoardGroupBy) must record transitions on THAT field.
+func TestStatusTransition_NonStatusDoneField(t *testing.T) {
+	s := testStore(t)
+	u, err := s.CreateUser(models.UserCreate{Name: "Hank", Email: "hank@example.com"})
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	ws, err := s.CreateWorkspace(models.WorkspaceCreate{Name: "Hiring", Slug: "hiring", OwnerID: u.ID})
+	if err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	col, err := s.CreateCollection(ws.ID, models.CollectionCreate{
+		Name:     "Candidates",
+		Schema:   `{"fields":[{"key":"stage","label":"Stage","type":"select","options":["applied","interview","hired"],"terminal_options":["hired"],"default":"applied","required":true}]}`,
+		Settings: `{"board_group_by":"stage"}`,
+	})
+	if err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+
+	item, err := s.CreateItem(ws.ID, col.ID, models.ItemCreate{Title: "Ada", Fields: `{"stage":"applied"}`})
+	if err != nil {
+		t.Fatalf("create item: %v", err)
+	}
+	// create-seed should be on the "stage" field.
+	seeds := listTransitions(t, s, item.ID)
+	if len(seeds) != 1 || seeds[0].FieldKey != "stage" || seeds[0].ToStatus != "applied" {
+		t.Fatalf("expected stage create-seed '' → applied, got %+v", seeds)
+	}
+
+	if _, err := s.UpdateItem(item.ID, models.ItemUpdate{Fields: strPtr(`{"stage":"hired"}`)}); err != nil {
+		t.Fatalf("update stage: %v", err)
+	}
+	hops := hopTransitions(t, s, item.ID)
+	if len(hops) != 1 {
+		t.Fatalf("expected 1 stage hop, got %d", len(hops))
+	}
+	if hops[0].FieldKey != "stage" || hops[0].FromStatus != "applied" || hops[0].ToStatus != "hired" {
+		t.Fatalf("expected stage applied → hired, got %+v", hops[0])
 	}
 }
 
@@ -108,11 +224,11 @@ func TestStatusTransition_CapturedOnMoveWithStatusOverride(t *testing.T) {
 		t.Fatalf("move item: %v", err)
 	}
 
-	trans := listTransitions(t, s, item.ID)
-	if len(trans) != 1 {
-		t.Fatalf("expected 1 transition from move, got %d", len(trans))
+	hops := hopTransitions(t, s, item.ID)
+	if len(hops) != 1 {
+		t.Fatalf("expected 1 hop transition from move, got %d", len(hops))
 	}
-	got := trans[0]
+	got := hops[0]
 	if got.FromStatus != "open" || got.ToStatus != "done" {
 		t.Fatalf("expected open → done, got %q → %q", got.FromStatus, got.ToStatus)
 	}
@@ -122,58 +238,60 @@ func TestStatusTransition_CapturedOnMoveWithStatusOverride(t *testing.T) {
 	}
 }
 
-func TestStatusTransition_NoRowOnMoveWithoutStatusChange(t *testing.T) {
+func TestStatusTransition_NoHopOnMoveWithoutStatusChange(t *testing.T) {
 	s := testStore(t)
 	wsID, srcColID := newTransitionTestWorkspace(t, s)
 	dstCol := createTestCollection(t, s, wsID, "Other Bucket")
 	item := createTestItem(t, s, wsID, srcColID, "Plain move", "")
 
-	// Move preserving status — no transition row expected.
+	// Move preserving status — no hop transition expected.
 	if _, err := s.MoveItem(item.ID, dstCol.ID, `{"status":"open"}`); err != nil {
 		t.Fatalf("move item: %v", err)
 	}
-	if trans := listTransitions(t, s, item.ID); len(trans) != 0 {
-		t.Fatalf("expected no transitions on status-preserving move, got %d", len(trans))
+	if hops := hopTransitions(t, s, item.ID); len(hops) != 0 {
+		t.Fatalf("expected no hop transitions on status-preserving move, got %d", len(hops))
 	}
 }
 
-func TestStatusTransition_NoRowWhenStatusUnchanged(t *testing.T) {
+// A hard delete of an item must cascade to its status_transitions rows
+// (FK ON DELETE CASCADE), or the delete would fail the FK constraint.
+func TestStatusTransition_CascadesOnHardDelete(t *testing.T) {
 	s := testStore(t)
 	wsID, colID := newTransitionTestWorkspace(t, s)
-	item := createTestItem(t, s, wsID, colID, "Title only", "")
+	item := createTestItem(t, s, wsID, colID, "Doomed", "") // seeds a create-row
 
-	// Title change, no status change.
-	if _, err := s.UpdateItem(item.ID, models.ItemUpdate{Title: strPtr("Renamed")}); err != nil {
-		t.Fatalf("update title: %v", err)
+	if rows := listTransitions(t, s, item.ID); len(rows) == 0 {
+		t.Fatalf("expected at least the create-seed row before delete")
 	}
-	// Fields update that keeps the same status.
-	if _, err := s.UpdateItem(item.ID, models.ItemUpdate{Fields: strPtr(`{"status":"open"}`)}); err != nil {
-		t.Fatalf("update fields: %v", err)
+	if _, err := s.db.Exec(s.dialect.Rebind(`DELETE FROM items WHERE id = ?`), item.ID); err != nil {
+		t.Fatalf("hard delete item: %v", err)
 	}
-
-	if trans := listTransitions(t, s, item.ID); len(trans) != 0 {
-		t.Fatalf("expected no transitions, got %d", len(trans))
+	if rows := listTransitions(t, s, item.ID); len(rows) != 0 {
+		t.Fatalf("expected transitions to cascade-delete, got %d", len(rows))
 	}
 }
 
-func TestParseStatusChange(t *testing.T) {
+func TestParseFieldChange(t *testing.T) {
 	cases := []struct {
 		in       string
+		key      string
 		from, to string
 		ok       bool
 	}{
-		{"status: open → done", "open", "done", true},
-		{"priority: low → high; status: open → in-progress", "open", "in-progress", true},
-		{"status: → done", "", "done", true}, // newly-set status
-		{"priority: low → high", "", "", false},
-		{"status: open", "", "", false}, // malformed, no arrow
-		{"", "", "", false},
+		{"status: open → done", "status", "open", "done", true},
+		{"priority: low → high; status: open → in-progress", "status", "open", "in-progress", true},
+		{"status: → done", "status", "", "done", true}, // newly-set value
+		{"priority: low → high", "status", "", "", false},
+		{"status: open", "status", "", "", false}, // malformed, no arrow
+		{"", "status", "", "", false},
+		{"stage: applied → hired", "stage", "applied", "hired", true}, // non-status field
+		{"stage: applied → hired", "status", "", "", false},           // wrong key
 	}
 	for _, c := range cases {
-		from, to, ok := parseStatusChange(c.in)
+		from, to, ok := parseFieldChange(c.in, c.key)
 		if ok != c.ok || from != c.from || to != c.to {
-			t.Errorf("parseStatusChange(%q) = (%q, %q, %v); want (%q, %q, %v)",
-				c.in, from, to, ok, c.from, c.to, c.ok)
+			t.Errorf("parseFieldChange(%q, %q) = (%q, %q, %v); want (%q, %q, %v)",
+				c.in, c.key, from, to, ok, c.from, c.to, c.ok)
 		}
 	}
 }
@@ -181,8 +299,6 @@ func TestParseStatusChange(t *testing.T) {
 func TestBackfillStatusTransitions(t *testing.T) {
 	s := testStore(t)
 	wsID, colID := newTransitionTestWorkspace(t, s)
-	// Create item WITHOUT going through the status-changing update path, so
-	// the only transition rows come from the backfill.
 	item := createTestItem(t, s, wsID, colID, "Historical", "")
 
 	// Simulate a historical activity row carrying a status change in its
@@ -198,6 +314,12 @@ func TestBackfillStatusTransitions(t *testing.T) {
 		t.Fatalf("create activity: %v", err)
 	}
 
+	// createTestItem already seeded a create-row, so clear the table to
+	// simulate the fresh, empty post-migration state the backfill expects.
+	if _, err := s.db.Exec(s.q(`DELETE FROM status_transitions`)); err != nil {
+		t.Fatalf("clear transitions: %v", err)
+	}
+
 	res, err := s.BackfillStatusTransitions()
 	if err != nil {
 		t.Fatalf("backfill: %v", err)
@@ -205,19 +327,27 @@ func TestBackfillStatusTransitions(t *testing.T) {
 	if res.Skipped {
 		t.Fatalf("backfill unexpectedly skipped (table should have been empty)")
 	}
-	if res.Inserted != 1 {
-		t.Fatalf("expected 1 inserted, got %d (scanned=%d errors=%d)", res.Inserted, res.ActivitiesScanned, res.Errors)
+	// Pass 1 inserts the open→done hop; Pass 2 seeds the create-time '' → open
+	// row (initial value reconstructed from the hop's `from`).
+	if res.Inserted != 2 {
+		t.Fatalf("expected 2 inserted, got %d (scanned=%d errors=%d)", res.Inserted, res.ActivitiesScanned, res.Errors)
 	}
 
-	trans := listTransitions(t, s, item.ID)
-	if len(trans) != 1 || trans[0].FromStatus != "open" || trans[0].ToStatus != "done" {
-		t.Fatalf("backfilled transition wrong: %+v", trans)
+	all := listTransitions(t, s, item.ID)
+	var hop, seed *models.StatusTransition
+	for i := range all {
+		switch {
+		case strings.HasPrefix(all[i].ID, "bf_"):
+			hop = &all[i]
+		case strings.HasPrefix(all[i].ID, "create_"):
+			seed = &all[i]
+		}
 	}
-	// Backfilled rows carry a deterministic, activity-derived id ("bf_" +
-	// activity id) so a concurrent replay conflicts on the PK instead of
-	// inserting a duplicate. Live write-path rows use a random newID().
-	if !strings.HasPrefix(trans[0].ID, "bf_") {
-		t.Fatalf("backfilled transition should have a stable bf_ id, got %q", trans[0].ID)
+	if hop == nil || hop.FromStatus != "open" || hop.ToStatus != "done" {
+		t.Fatalf("backfilled hop wrong: %+v", hop)
+	}
+	if seed == nil || seed.FromStatus != "" || seed.ToStatus != "open" {
+		t.Fatalf("backfilled create-seed wrong: %+v", seed)
 	}
 
 	// Second run must short-circuit (table now non-empty).


### PR DESCRIPTION
## Summary
Adds a `status_transitions` table that captures every item status change as a structured, queryable row — written in the same transaction as the item update and **never debounced** — so the Reports surface (PLAN-1628) can reliably compute the completed-throughput and cycle-time series.

The activities feed records status changes only as a human-readable, debounce-coalesced `metadata.changes` string (the spike, TASK-1629, found this), which can't be aggregated. This table is the canonical "when did item X enter status Y" source.

## Context
Implements `TASK-1637` under `PLAN-1628` (Reports surface). Foundation that `TASK-1630` (report aggregation) builds on.

## What changed
- `migrations/063` + `pgmigrations/042` — `status_transitions` table (dual-dialect), indexed on `(workspace_id, created_at)` and `(item_id, created_at)`
- Write-path hook in `UpdateItemWithPreCheck` — records `from→to` on status change, in the update tx
- `BackfillStatusTransitions` — one-time startup replay parsing historical `activities.metadata.changes` (mirrors `BackfillWikiLinks`), gated on empty table; wired into `cmd/pad/main.go`
- `models.StatusTransition` + tests

## Test plan
- [x] `make check` (golangci-lint + build + npm audit + svelte-check) — clean
- [x] `go test ./internal/store/` — full suite green (SQLite)
- [x] new tests: capture, multi-hop, no-op-on-unchanged, parser, backfill (incl. idempotent skip)
- [x] Postgres: dual migration + dialect-agnostic SQL; covered under `PAD_TEST_POSTGRES_URL`