### PR TITLE
feat(report): windowed project report endpoint + DateBucket dialect (TASK-1630)

### DIFF
--- a/internal/server/handlers_reports.go
+++ b/internal/server/handlers_reports.go
@@ -19,12 +19,19 @@ func (s *Server) handleGetReport(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Scope the report to the caller's visible collections, mirroring the
-	// dashboard. Without this, a member/guest with access to one collection
-	// could infer hidden collections' slugs, throughput, and status
-	// distribution from the aggregate counts. Aggregate reports are a
-	// full-collection-visibility feature; item-level grants are intentionally
-	// not surfaced in workspace-wide counts.
+	// Scope the report to the caller's FULL-collection visibility, mirroring
+	// the dashboard's dashCollIDs logic. Aggregate report counts have no
+	// item-level filtering, so a collection is only in scope if the caller can
+	// see all of it — otherwise a member/guest could infer hidden collections'
+	// slugs, throughput, and status distribution.
+	//
+	//   - visibleCollectionIDs == nil → admin / all-access member: no
+	//     restriction (full workspace report).
+	//   - item-level grants present → use the full-access collection set
+	//     (fullCollIDs); item-grant-only collections are NOT counted, since
+	//     that would leak the whole collection's aggregates.
+	//   - otherwise → the caller's full-collection set (specific members,
+	//     guests with only full-collection grants).
 	visibleIDs, err := s.visibleCollectionIDs(r, workspaceID)
 	if err != nil {
 		writeInternalError(w, err)
@@ -32,9 +39,19 @@ func (s *Server) handleGetReport(w http.ResponseWriter, r *http.Request) {
 	}
 
 	opts := store.ReportOptions{
-		Window:               r.URL.Query().Get("window"),
-		ScopeToVisible:       true,
-		VisibleCollectionIDs: visibleIDs,
+		Window: r.URL.Query().Get("window"),
+	}
+	if visibleIDs != nil {
+		opts.ScopeToVisible = true
+		opts.VisibleCollectionIDs = visibleIDs
+		fullCollIDs, grantedItemIDs, gErr := s.guestResourceFilter(r, workspaceID)
+		if gErr != nil {
+			writeInternalError(w, gErr)
+			return
+		}
+		if len(grantedItemIDs) > 0 {
+			opts.VisibleCollectionIDs = fullCollIDs
+		}
 	}
 	if raw := strings.TrimSpace(r.URL.Query().Get("collections")); raw != "" {
 		for _, slug := range strings.Split(raw, ",") {

--- a/internal/server/handlers_reports.go
+++ b/internal/server/handlers_reports.go
@@ -1,0 +1,39 @@
+package server
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/PerpetualSoftware/pad/internal/store"
+)
+
+// handleGetReport serves the windowed project report (PLAN-1628 / TASK-1630):
+//
+//	GET /workspaces/{slug}/report?window=week&collections=tasks,bugs
+//
+// window ∈ {day, week, 2wk, month} (default week). collections is an optional
+// comma-separated list of collection slugs to include; omitted = all.
+func (s *Server) handleGetReport(w http.ResponseWriter, r *http.Request) {
+	workspaceID, ok := s.getWorkspaceID(w, r)
+	if !ok {
+		return
+	}
+
+	opts := store.ReportOptions{
+		Window: r.URL.Query().Get("window"),
+	}
+	if raw := strings.TrimSpace(r.URL.Query().Get("collections")); raw != "" {
+		for _, slug := range strings.Split(raw, ",") {
+			if s := strings.TrimSpace(slug); s != "" {
+				opts.Collections = append(opts.Collections, s)
+			}
+		}
+	}
+
+	report, err := s.store.GetReport(workspaceID, opts)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, report)
+}

--- a/internal/server/handlers_reports.go
+++ b/internal/server/handlers_reports.go
@@ -19,39 +19,16 @@ func (s *Server) handleGetReport(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Scope the report to the caller's FULL-collection visibility, mirroring
-	// the dashboard's dashCollIDs logic. Aggregate report counts have no
-	// item-level filtering, so a collection is only in scope if the caller can
-	// see all of it — otherwise a member/guest could infer hidden collections'
-	// slugs, throughput, and status distribution.
-	//
-	//   - visibleCollectionIDs == nil → admin / all-access member: no
-	//     restriction (full workspace report).
-	//   - item-level grants present → use the full-access collection set
-	//     (fullCollIDs); item-grant-only collections are NOT counted, since
-	//     that would leak the whole collection's aggregates.
-	//   - otherwise → the caller's full-collection set (specific members,
-	//     guests with only full-collection grants).
-	visibleIDs, err := s.visibleCollectionIDs(r, workspaceID)
+	scopeToVisible, visibleIDs, err := s.reportVisibleCollections(r, workspaceID)
 	if err != nil {
 		writeInternalError(w, err)
 		return
 	}
 
 	opts := store.ReportOptions{
-		Window: r.URL.Query().Get("window"),
-	}
-	if visibleIDs != nil {
-		opts.ScopeToVisible = true
-		opts.VisibleCollectionIDs = visibleIDs
-		fullCollIDs, grantedItemIDs, gErr := s.guestResourceFilter(r, workspaceID)
-		if gErr != nil {
-			writeInternalError(w, gErr)
-			return
-		}
-		if len(grantedItemIDs) > 0 {
-			opts.VisibleCollectionIDs = fullCollIDs
-		}
+		Window:               r.URL.Query().Get("window"),
+		ScopeToVisible:       scopeToVisible,
+		VisibleCollectionIDs: visibleIDs,
 	}
 	if raw := strings.TrimSpace(r.URL.Query().Get("collections")); raw != "" {
 		for _, slug := range strings.Split(raw, ",") {
@@ -67,4 +44,45 @@ func (s *Server) handleGetReport(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, report)
+}
+
+// reportVisibleCollections computes the collection-visibility scope for the
+// aggregate report. Aggregate counts have no item-level filtering, so a
+// collection is only in scope if the caller can see ALL of it — otherwise a
+// member/guest could infer hidden collections' slugs, throughput, and status
+// distribution.
+//
+//   - scopeToVisible=false → unrestricted (no-auth instance, cookie platform
+//     admin, or an all-access member): the full workspace report.
+//   - scopeToVisible=true → restrict to ids (the caller's full-collection set).
+//
+// Bearer-aware: s.visibleCollectionIDs() would grant ANY platform admin an
+// unrestricted view, but RequireWorkspaceAccess suppresses the platform-admin
+// bypass for bearer auth (PAT/CLI/OAuth) and falls through to membership — so a
+// bearer admin who is only a restricted member must be scoped to their actual
+// membership (BUG-1616/1617 pattern). When the caller has item-level grants,
+// scope to the full-access collection set only (item-grant-only collections'
+// aggregates must not leak), mirroring the dashboard's dashCollIDs logic.
+func (s *Server) reportVisibleCollections(r *http.Request, workspaceID string) (scopeToVisible bool, ids []string, err error) {
+	user := currentUser(r)
+	if user == nil || (user.Role == "admin" && !isBearerAuth(r)) {
+		return false, nil, nil // unrestricted
+	}
+	visibleIDs, err := s.store.VisibleCollectionIDs(workspaceID, user.ID)
+	if err != nil {
+		return false, nil, err
+	}
+	if visibleIDs == nil {
+		// all-access member → no filtering.
+		return false, nil, nil
+	}
+	ids = visibleIDs
+	fullCollIDs, grantedItemIDs, gErr := s.guestResourceFilter(r, workspaceID)
+	if gErr != nil {
+		return false, nil, gErr
+	}
+	if len(grantedItemIDs) > 0 {
+		ids = fullCollIDs
+	}
+	return true, ids, nil
 }

--- a/internal/server/handlers_reports.go
+++ b/internal/server/handlers_reports.go
@@ -19,8 +19,22 @@ func (s *Server) handleGetReport(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Scope the report to the caller's visible collections, mirroring the
+	// dashboard. Without this, a member/guest with access to one collection
+	// could infer hidden collections' slugs, throughput, and status
+	// distribution from the aggregate counts. Aggregate reports are a
+	// full-collection-visibility feature; item-level grants are intentionally
+	// not surfaced in workspace-wide counts.
+	visibleIDs, err := s.visibleCollectionIDs(r, workspaceID)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+
 	opts := store.ReportOptions{
-		Window: r.URL.Query().Get("window"),
+		Window:               r.URL.Query().Get("window"),
+		ScopeToVisible:       true,
+		VisibleCollectionIDs: visibleIDs,
 	}
 	if raw := strings.TrimSpace(r.URL.Query().Get("collections")); raw != "" {
 		for _, slug := range strings.Split(raw, ",") {

--- a/internal/server/handlers_reports_test.go
+++ b/internal/server/handlers_reports_test.go
@@ -1,0 +1,61 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/store"
+)
+
+// Exercises the full report HTTP path as the workspace owner (admin/all-access
+// → visibleCollectionIDs returns nil, so the report is unscoped). Store-level
+// tests cover the visibility-scoping mechanics; this locks the route, the
+// nil-visibility branch, and the JSON shape.
+func TestReportEndpoint_OwnerGetsFullReport(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	createItem(t, srv, slug, "tasks", map[string]interface{}{"title": "A"})
+	createItem(t, srv, slug, "tasks", map[string]interface{}{"title": "B"})
+
+	rr := doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/report?window=week", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("report: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var resp store.ReportData
+	parseJSON(t, rr, &resp)
+
+	if resp.Window != "week" || resp.Granularity != "day" {
+		t.Fatalf("expected week/day, got %s/%s", resp.Window, resp.Granularity)
+	}
+	if resp.Totals.Created != 2 {
+		t.Fatalf("expected 2 created, got %d", resp.Totals.Created)
+	}
+
+	// Arrays must serialize as [] not null.
+	var rawMap map[string]json.RawMessage
+	if err := json.Unmarshal(rr.Body.Bytes(), &rawMap); err != nil {
+		t.Fatalf("parse raw: %v", err)
+	}
+	for _, key := range []string{"buckets", "collections", "completed_by_collection", "status_distribution"} {
+		if string(rawMap[key]) == "null" {
+			t.Errorf("expected %s to be [], got null", key)
+		}
+	}
+}
+
+func TestReportEndpoint_DefaultsToWeek(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSWithCollections(t, srv)
+
+	rr := doRequest(srv, "GET", "/api/v1/workspaces/"+slug+"/report", nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("report: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var resp store.ReportData
+	parseJSON(t, rr, &resp)
+	if resp.Window != "week" {
+		t.Fatalf("expected default window=week, got %q", resp.Window)
+	}
+}

--- a/internal/server/handlers_reports_test.go
+++ b/internal/server/handlers_reports_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/PerpetualSoftware/pad/internal/models"
 	"github.com/PerpetualSoftware/pad/internal/store"
 )
 
@@ -42,6 +43,86 @@ func TestReportEndpoint_OwnerGetsFullReport(t *testing.T) {
 		if string(rawMap[key]) == "null" {
 			t.Errorf("expected %s to be [], got null", key)
 		}
+	}
+}
+
+// Pins the bearer-aware visibility gate (BUG-1616/1617 pattern): a platform
+// admin who is only a *restricted* workspace member gets the full report over
+// a cookie session (web UI admin affordance) but a SCOPED report over bearer
+// auth (PAT/CLI/OAuth) — never leaking the hidden collection's aggregates.
+func TestReportEndpoint_AdminBearerIsScoped(t *testing.T) {
+	srv := testServer(t)
+
+	admin, err := srv.store.CreateUser(models.UserCreate{
+		Email: "admin@example.com", Name: "Admin", Password: "correct-horse-battery-staple", Role: "admin",
+	})
+	if err != nil {
+		t.Fatalf("create admin: %v", err)
+	}
+	ws, err := srv.store.CreateWorkspace(models.WorkspaceCreate{Name: "RepBearer", OwnerID: admin.ID})
+	if err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	if err := srv.store.AddWorkspaceMember(ws.ID, admin.ID, "editor"); err != nil {
+		t.Fatalf("add member: %v", err)
+	}
+	visible, err := srv.store.CreateCollection(ws.ID, models.CollectionCreate{
+		Name: "Visible", Slug: "visible", Prefix: "VIS",
+		Schema: `{"fields":[{"key":"status","type":"select","options":["open","done"],"default":"open"}]}`,
+	})
+	if err != nil {
+		t.Fatalf("create visible: %v", err)
+	}
+	hidden, err := srv.store.CreateCollection(ws.ID, models.CollectionCreate{
+		Name: "Hidden", Slug: "hidden", Prefix: "HID",
+		Schema: `{"fields":[{"key":"status","type":"select","options":["open","done"],"default":"open"}]}`,
+	})
+	if err != nil {
+		t.Fatalf("create hidden: %v", err)
+	}
+	if _, err := srv.store.CreateItem(ws.ID, visible.ID, models.ItemCreate{Title: "v", Fields: `{"status":"open"}`}); err != nil {
+		t.Fatalf("create visible item: %v", err)
+	}
+	if _, err := srv.store.CreateItem(ws.ID, hidden.ID, models.ItemCreate{Title: "h", Fields: `{"status":"open"}`}); err != nil {
+		t.Fatalf("create hidden item: %v", err)
+	}
+	if err := srv.store.SetMemberCollectionAccess(ws.ID, admin.ID, "specific", []string{visible.ID}); err != nil {
+		t.Fatalf("set access: %v", err)
+	}
+	_ = hidden
+
+	// Cookie admin → bypass fires, unrestricted (scopeToVisible=false).
+	cookieScope, _, err := srv.reportVisibleCollections(
+		mkAdminCookieReq(t, "/api/v1/workspaces/"+ws.Slug+"/report", admin), ws.ID)
+	if err != nil {
+		t.Fatalf("cookie scope: %v", err)
+	}
+	if cookieScope {
+		t.Errorf("cookie admin should be unrestricted (scopeToVisible=false)")
+	}
+
+	// Bearer admin → bypass suppressed, scoped to the granted collection only.
+	bearerScope, bearerIDs, err := srv.reportVisibleCollections(
+		mkAdminBearerReq(t, "/api/v1/workspaces/"+ws.Slug+"/report", admin), ws.ID)
+	if err != nil {
+		t.Fatalf("bearer scope: %v", err)
+	}
+	if !bearerScope {
+		t.Fatalf("bearer admin must be scoped, got scopeToVisible=false")
+	}
+	if len(bearerIDs) != 1 || bearerIDs[0] != visible.ID {
+		t.Fatalf("bearer admin should be scoped to the 'visible' collection, got %v", bearerIDs)
+	}
+
+	// End-to-end through GetReport: bearer scope sees only the visible item.
+	rep, err := srv.store.GetReport(ws.ID, store.ReportOptions{
+		Window: "week", ScopeToVisible: bearerScope, VisibleCollectionIDs: bearerIDs,
+	})
+	if err != nil {
+		t.Fatalf("GetReport: %v", err)
+	}
+	if rep.Totals.Created != 1 || len(rep.Collections) != 1 || rep.Collections[0] != "visible" {
+		t.Fatalf("bearer-scoped report leaked hidden collection: %+v", rep)
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1229,6 +1229,10 @@ func (s *Server) setupRouter() {
 					// Dashboard (v2)
 					r.Get("/dashboard", s.handleGetDashboard)
 
+					// Project report — windowed throughput/flow/status
+					// stats (PLAN-1628 / TASK-1630).
+					r.Get("/report", s.handleGetReport)
+
 					// Agent bootstrap (PLAN-1377 / TASK-1379) — single
 					// round-trip that returns workspace + user +
 					// collections + always-on conventions + roles +

--- a/internal/store/dialect.go
+++ b/internal/store/dialect.go
@@ -103,6 +103,20 @@ type Dialect interface {
 	// SQLite: "column LIKE ?" with arg `%"value"%`
 	// PostgreSQL: "column::jsonb @> ?::jsonb" with arg `["value"]`
 	JSONArrayContains(column, value string) (string, interface{})
+
+	// DateBucket returns a SQL expression that truncates an RFC3339 UTC
+	// timestamp TEXT column to the start of its bucket, as a sortable TEXT
+	// label, for GROUP BY in time-series reports (PLAN-1628). granularity is
+	// "hour" or "day".
+	//
+	// Implemented via fixed-width substring on both engines: every timestamp
+	// in the schema is stored as UTC RFC3339 ("YYYY-MM-DDTHH:MM:SSZ", see
+	// dialect.NowRFC3339), so "day" = chars 1-10 and "hour" = chars 1-13 are
+	// exact and identical across SQLite and Postgres — and avoid SQLite's
+	// fragile parsing of the trailing 'Z'. Coarser granularities (week/month)
+	// need real date math and would diverge here to strftime (SQLite) vs
+	// date_trunc/to_char (Postgres); they're added when a window needs them.
+	DateBucket(column, granularity string) string
 }
 
 // ---------- SQLite dialect ----------
@@ -173,6 +187,10 @@ func (d *sqliteDialect) FTSRank(_, _ string) string {
 
 func (d *sqliteDialect) JSONArrayContains(column, value string) (string, interface{}) {
 	return column + " LIKE ?", "%\"" + value + "\"%"
+}
+
+func (d *sqliteDialect) DateBucket(column, granularity string) string {
+	return dateBucketSubstr(column, granularity)
 }
 
 // ---------- PostgreSQL dialect ----------
@@ -270,6 +288,21 @@ func (d *postgresDialect) FTSRank(table, column string) string {
 
 func (d *postgresDialect) JSONArrayContains(column, value string) (string, interface{}) {
 	return column + "::jsonb @> ?::jsonb", `["` + value + `"]`
+}
+
+func (d *postgresDialect) DateBucket(column, granularity string) string {
+	return dateBucketSubstr(column, granularity)
+}
+
+// dateBucketSubstr truncates a UTC RFC3339 TEXT timestamp to its day ("hour"
+// → chars 1-13 "YYYY-MM-DDTHH"; otherwise → chars 1-10 "YYYY-MM-DD"). The
+// SUBSTR(text, from, count) form is valid and identical on SQLite and
+// Postgres, so both dialects delegate here for these granularities.
+func dateBucketSubstr(column, granularity string) string {
+	if granularity == "hour" {
+		return fmt.Sprintf("SUBSTR(%s, 1, 13)", column)
+	}
+	return fmt.Sprintf("SUBSTR(%s, 1, 10)", column)
 }
 
 // ---------- Helper ----------

--- a/internal/store/dialect_test.go
+++ b/internal/store/dialect_test.go
@@ -25,6 +25,23 @@ func TestRebindQuery(t *testing.T) {
 	}
 }
 
+func TestDateBucket(t *testing.T) {
+	// Day/hour bucketing is fixed-width substring on the UTC RFC3339 TEXT, so
+	// both dialects emit the same expression. Verify each granularity.
+	for _, d := range []Dialect{&sqliteDialect{}, &postgresDialect{}} {
+		if got := d.DateBucket("created_at", "day"); got != "SUBSTR(created_at, 1, 10)" {
+			t.Errorf("%T day bucket = %q", d, got)
+		}
+		if got := d.DateBucket("created_at", "hour"); got != "SUBSTR(created_at, 1, 13)" {
+			t.Errorf("%T hour bucket = %q", d, got)
+		}
+		// Unknown granularity falls back to day.
+		if got := d.DateBucket("created_at", "week"); got != "SUBSTR(created_at, 1, 10)" {
+			t.Errorf("%T fallback bucket = %q", d, got)
+		}
+	}
+}
+
 func TestSQLiteDialect(t *testing.T) {
 	d := &sqliteDialect{}
 

--- a/internal/store/reports.go
+++ b/internal/store/reports.go
@@ -313,15 +313,23 @@ func (s *Store) reportCompletedBuckets(workspaceID string, colls []reportCollect
 	base := []any{workspaceID, startStr, endStr}
 	bucketExpr := s.dialect.DateBucket("st.created_at", gran)
 
+	// Join live items so a completed-then-soft-deleted item is excluded from
+	// the completion counts too — keeping them consistent with the created and
+	// status-distribution queries (which already filter deleted_at IS NULL).
+	// status_transitions rows survive a soft delete (only a HARD delete
+	// cascades them away).
+	const liveJoin = "JOIN items i ON i.id = st.item_id AND i.deleted_at IS NULL"
+
 	// Buckets.
 	bArgs := append(append([]any{}, base...), posArgs...)
 	bQuery := fmt.Sprintf(`
 		SELECT %s AS bucket, COUNT(*)
 		FROM status_transitions st
+		%s
 		WHERE st.workspace_id = ? AND st.created_at >= ? AND st.created_at <= ?
 		  AND %s
 		GROUP BY bucket
-	`, bucketExpr, posExpr)
+	`, bucketExpr, liveJoin, posExpr)
 	byBucket, err = s.scanBucketCounts(bQuery, bArgs)
 	if err != nil {
 		return nil, nil, err
@@ -332,10 +340,11 @@ func (s *Store) reportCompletedBuckets(workspaceID string, colls []reportCollect
 	cQuery := fmt.Sprintf(`
 		SELECT st.collection_id, COUNT(*)
 		FROM status_transitions st
+		%s
 		WHERE st.workspace_id = ? AND st.created_at >= ? AND st.created_at <= ?
 		  AND %s
 		GROUP BY st.collection_id
-	`, posExpr)
+	`, liveJoin, posExpr)
 	rows, err := s.db.Query(s.q(cQuery), cArgs...)
 	if err != nil {
 		return nil, nil, fmt.Errorf("report completed-by-collection: %w", err)

--- a/internal/store/reports.go
+++ b/internal/store/reports.go
@@ -50,6 +50,15 @@ type ReportOptions struct {
 	// Now is the reference end of the window; zero means time.Now().UTC().
 	// Injectable so tests are deterministic.
 	Now time.Time
+	// ScopeToVisible, when true, restricts the report to VisibleCollectionIDs
+	// (the caller's visible collection set). Aggregate counts for collections
+	// the caller can't see are never computed — preventing a member/guest from
+	// inferring hidden collections' throughput or status distribution. The
+	// HTTP handler sets this from visibleCollectionIDs(); internal/CLI callers
+	// that already run as an authorized principal leave it false for the full
+	// workspace report.
+	ScopeToVisible       bool
+	VisibleCollectionIDs []string
 }
 
 // ReportBucket is one time-series point: items created and completed within
@@ -137,8 +146,9 @@ func (s *Store) GetReport(workspaceID string, opts ReportOptions) (*ReportData, 
 	startStr := start.Format(time.RFC3339)
 	endStr := now.Format(time.RFC3339)
 
-	// Resolve the collections in scope (filtered by slug if requested).
-	colls, err := s.resolveReportCollections(workspaceID, opts.Collections)
+	// Resolve the collections in scope (filtered by slug if requested, and by
+	// the caller's visible set when scoping is enabled).
+	colls, err := s.resolveReportCollections(workspaceID, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -209,19 +219,32 @@ func (s *Store) GetReport(workspaceID string, opts ReportOptions) (*ReportData, 
 // resolveReportCollections lists the workspace's collections (optionally
 // filtered to the given slugs) and resolves each one's done field + positive
 // terminal values.
-func (s *Store) resolveReportCollections(workspaceID string, slugs []string) ([]reportCollection, error) {
+func (s *Store) resolveReportCollections(workspaceID string, opts ReportOptions) ([]reportCollection, error) {
 	all, err := s.ListCollections(workspaceID)
 	if err != nil {
 		return nil, fmt.Errorf("list collections for report: %w", err)
 	}
 	want := map[string]bool{}
-	for _, sl := range slugs {
+	for _, sl := range opts.Collections {
 		want[strings.ToLower(strings.TrimSpace(sl))] = true
+	}
+	// Visibility scope: when enabled, only collections in the caller's visible
+	// set are eligible (an empty set yields an empty report — correct for a
+	// guest with no full-collection access).
+	var visible map[string]bool
+	if opts.ScopeToVisible {
+		visible = make(map[string]bool, len(opts.VisibleCollectionIDs))
+		for _, id := range opts.VisibleCollectionIDs {
+			visible[id] = true
+		}
 	}
 
 	var out []reportCollection
 	for _, c := range all {
 		if len(want) > 0 && !want[strings.ToLower(c.Slug)] {
+			continue
+		}
+		if visible != nil && !visible[c.ID] {
 			continue
 		}
 		var schema models.CollectionSchema

--- a/internal/store/reports.go
+++ b/internal/store/reports.go
@@ -1,0 +1,445 @@
+package store
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// Report aggregation (PLAN-1628 / TASK-1630).
+//
+// GetReport produces a time-windowed project report: created-vs-completed
+// throughput bucketed over a window, net flow, completed-by-collection, and a
+// current status-distribution snapshot. "Completed" is a status_transitions
+// row INTO a *positive* terminal value (a terminal option that isn't a
+// negative outcome like rejected/cancelled — see negativeTerminals), counted
+// per the collection's done field. Created counts items.created_at.
+//
+// Everything routes date math through dialect.DateBucket so the same query
+// runs on SQLite and Postgres.
+
+// negativeTerminals are terminal status values that represent a NON-shipping
+// close (the work didn't complete positively). They're excluded from the
+// "completed" throughput so a rejected idea or cancelled task isn't counted as
+// a completion. Matched case-insensitively against a collection's terminal
+// options. (A future task can make this per-collection configurable; for now
+// it's a sensible global default — PLAN-1628 decision.)
+var negativeTerminals = map[string]bool{
+	"rejected":  true,
+	"cancelled": true,
+	"canceled":  true,
+	"wontfix":   true,
+	"won't fix": true,
+	"duplicate": true,
+	"declined":  true,
+	"abandoned": true,
+}
+
+// ReportOptions parameterizes GetReport.
+type ReportOptions struct {
+	// Window is one of "day", "week", "2wk", "month". Invalid/empty defaults
+	// to "week".
+	Window string
+	// Collections optionally restricts the report to these collection slugs.
+	// Empty means all of the workspace's collections.
+	Collections []string
+	// Now is the reference end of the window; zero means time.Now().UTC().
+	// Injectable so tests are deterministic.
+	Now time.Time
+}
+
+// ReportBucket is one time-series point: items created and completed within
+// the bucket. Bucket is a sortable UTC label ("YYYY-MM-DD", or
+// "YYYY-MM-DDTHH" for the hourly window).
+type ReportBucket struct {
+	Bucket    string `json:"bucket"`
+	Created   int    `json:"created"`
+	Completed int    `json:"completed"`
+}
+
+// ReportCollectionCount is a per-collection tally (collection slug + count).
+type ReportCollectionCount struct {
+	Collection string `json:"collection"`
+	Count      int    `json:"count"`
+}
+
+// ReportStatusCount is a current status-distribution entry.
+type ReportStatusCount struct {
+	Collection string `json:"collection"`
+	Status     string `json:"status"`
+	Count      int    `json:"count"`
+}
+
+// ReportTotals are the window roll-ups.
+type ReportTotals struct {
+	Created   int `json:"created"`
+	Completed int `json:"completed"`
+	NetFlow   int `json:"net_flow"` // Created - Completed
+}
+
+// ReportData is the full report response. This is the stable contract the
+// Reports UI (TASK-1633), CLI/MCP (TASK-1635), and charts (TASK-1632) consume.
+type ReportData struct {
+	Window                string                  `json:"window"`
+	Granularity           string                  `json:"granularity"` // "hour" | "day"
+	RangeStart            string                  `json:"range_start"` // RFC3339 UTC
+	RangeEnd              string                  `json:"range_end"`   // RFC3339 UTC
+	Collections           []string                `json:"collections"` // slugs included
+	Buckets               []ReportBucket          `json:"buckets"`     // chronological, zero-filled
+	Totals                ReportTotals            `json:"totals"`
+	CompletedByCollection []ReportCollectionCount `json:"completed_by_collection"`
+	StatusDistribution    []ReportStatusCount     `json:"status_distribution"`
+}
+
+// windowSpec maps a window to its lookback duration and bucket granularity.
+func windowSpec(window string) (lookback time.Duration, granularity string) {
+	switch window {
+	case "day":
+		return 24 * time.Hour, "hour"
+	case "2wk":
+		return 14 * 24 * time.Hour, "day"
+	case "month":
+		return 30 * 24 * time.Hour, "day"
+	default: // "week"
+		return 7 * 24 * time.Hour, "day"
+	}
+}
+
+// reportCollection is a resolved collection with its done-field + the positive
+// terminal values that count as a completion.
+type reportCollection struct {
+	id                string
+	slug              string
+	doneKey           string
+	positiveTerminals []string
+}
+
+// GetReport computes the windowed project report for a workspace.
+func (s *Store) GetReport(workspaceID string, opts ReportOptions) (*ReportData, error) {
+	window := opts.Window
+	switch window {
+	case "day", "week", "2wk", "month":
+	default:
+		window = "week"
+	}
+	lookback, gran := windowSpec(window)
+
+	now := opts.Now
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	now = now.UTC()
+	start := now.Add(-lookback)
+	startStr := start.Format(time.RFC3339)
+	endStr := now.Format(time.RFC3339)
+
+	// Resolve the collections in scope (filtered by slug if requested).
+	colls, err := s.resolveReportCollections(workspaceID, opts.Collections)
+	if err != nil {
+		return nil, err
+	}
+
+	data := &ReportData{
+		Window:                window,
+		Granularity:           gran,
+		RangeStart:            startStr,
+		RangeEnd:              endStr,
+		Collections:           make([]string, 0, len(colls)),
+		Buckets:               []ReportBucket{},
+		CompletedByCollection: []ReportCollectionCount{},
+		StatusDistribution:    []ReportStatusCount{},
+	}
+	collIDs := make([]string, 0, len(colls))
+	slugByID := make(map[string]string, len(colls))
+	for _, c := range colls {
+		data.Collections = append(data.Collections, c.slug)
+		collIDs = append(collIDs, c.id)
+		slugByID[c.id] = c.slug
+	}
+
+	// No collections in scope → empty (but well-formed) report.
+	if len(collIDs) == 0 {
+		data.Buckets = s.zeroFilledBuckets(start, now, gran, nil, nil)
+		return data, nil
+	}
+
+	createdByBucket, err := s.reportCreatedBuckets(workspaceID, collIDs, startStr, endStr, gran)
+	if err != nil {
+		return nil, err
+	}
+	completedByBucket, completedByColl, err := s.reportCompletedBuckets(workspaceID, colls, startStr, endStr, gran)
+	if err != nil {
+		return nil, err
+	}
+
+	data.Buckets = s.zeroFilledBuckets(start, now, gran, createdByBucket, completedByBucket)
+	for _, b := range data.Buckets {
+		data.Totals.Created += b.Created
+		data.Totals.Completed += b.Completed
+	}
+	data.Totals.NetFlow = data.Totals.Created - data.Totals.Completed
+
+	// completed_by_collection (whole window), ordered by count desc then slug.
+	for id, n := range completedByColl {
+		data.CompletedByCollection = append(data.CompletedByCollection, ReportCollectionCount{
+			Collection: slugByID[id], Count: n,
+		})
+	}
+	sort.Slice(data.CompletedByCollection, func(i, j int) bool {
+		a, b := data.CompletedByCollection[i], data.CompletedByCollection[j]
+		if a.Count != b.Count {
+			return a.Count > b.Count
+		}
+		return a.Collection < b.Collection
+	})
+
+	dist, err := s.reportStatusDistribution(workspaceID, colls)
+	if err != nil {
+		return nil, err
+	}
+	data.StatusDistribution = dist
+
+	return data, nil
+}
+
+// resolveReportCollections lists the workspace's collections (optionally
+// filtered to the given slugs) and resolves each one's done field + positive
+// terminal values.
+func (s *Store) resolveReportCollections(workspaceID string, slugs []string) ([]reportCollection, error) {
+	all, err := s.ListCollections(workspaceID)
+	if err != nil {
+		return nil, fmt.Errorf("list collections for report: %w", err)
+	}
+	want := map[string]bool{}
+	for _, sl := range slugs {
+		want[strings.ToLower(strings.TrimSpace(sl))] = true
+	}
+
+	var out []reportCollection
+	for _, c := range all {
+		if len(want) > 0 && !want[strings.ToLower(c.Slug)] {
+			continue
+		}
+		var schema models.CollectionSchema
+		var settings models.CollectionSettings
+		// Parse failures fall back to status + default terminals, matching
+		// scanCollectionDoneFilters' tolerance.
+		if c.Schema != "" {
+			_ = json.Unmarshal([]byte(c.Schema), &schema)
+		}
+		if c.Settings != "" {
+			_ = json.Unmarshal([]byte(c.Settings), &settings)
+		}
+		doneKey, terminals := models.TerminalValuesForDoneField(schema, settings)
+
+		var positives []string
+		for _, v := range terminals {
+			if negativeTerminals[strings.ToLower(strings.TrimSpace(v))] {
+				continue
+			}
+			positives = append(positives, v)
+		}
+		out = append(out, reportCollection{
+			id:                c.ID,
+			slug:              c.Slug,
+			doneKey:           doneKey,
+			positiveTerminals: positives,
+		})
+	}
+	return out, nil
+}
+
+// reportCreatedBuckets returns created-item counts keyed by bucket label.
+func (s *Store) reportCreatedBuckets(workspaceID string, collIDs []string, startStr, endStr, gran string) (map[string]int, error) {
+	bucketExpr := s.dialect.DateBucket("created_at", gran)
+	placeholders := make([]string, len(collIDs))
+	args := []any{workspaceID, startStr, endStr}
+	for i, id := range collIDs {
+		placeholders[i] = "?"
+		args = append(args, id)
+	}
+	query := fmt.Sprintf(`
+		SELECT %s AS bucket, COUNT(*)
+		FROM items
+		WHERE workspace_id = ? AND deleted_at IS NULL
+		  AND created_at >= ? AND created_at <= ?
+		  AND collection_id IN (%s)
+		GROUP BY bucket
+	`, bucketExpr, strings.Join(placeholders, ","))
+
+	return s.scanBucketCounts(query, args)
+}
+
+// reportCompletedBuckets returns completion counts keyed by bucket label AND
+// the per-collection completion totals over the whole window. A completion is
+// a status_transitions row into a positive terminal for that collection's done
+// field.
+func (s *Store) reportCompletedBuckets(workspaceID string, colls []reportCollection, startStr, endStr, gran string) (byBucket map[string]int, byColl map[string]int, err error) {
+	posExpr, posArgs := s.positiveTerminalExpr(colls)
+	byBucket = map[string]int{}
+	byColl = map[string]int{}
+	if posExpr == "" {
+		// No collection has positive terminals → nothing completes.
+		return byBucket, byColl, nil
+	}
+
+	base := []any{workspaceID, startStr, endStr}
+	bucketExpr := s.dialect.DateBucket("st.created_at", gran)
+
+	// Buckets.
+	bArgs := append(append([]any{}, base...), posArgs...)
+	bQuery := fmt.Sprintf(`
+		SELECT %s AS bucket, COUNT(*)
+		FROM status_transitions st
+		WHERE st.workspace_id = ? AND st.created_at >= ? AND st.created_at <= ?
+		  AND %s
+		GROUP BY bucket
+	`, bucketExpr, posExpr)
+	byBucket, err = s.scanBucketCounts(bQuery, bArgs)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Per-collection totals.
+	cArgs := append(append([]any{}, base...), posArgs...)
+	cQuery := fmt.Sprintf(`
+		SELECT st.collection_id, COUNT(*)
+		FROM status_transitions st
+		WHERE st.workspace_id = ? AND st.created_at >= ? AND st.created_at <= ?
+		  AND %s
+		GROUP BY st.collection_id
+	`, posExpr)
+	rows, err := s.db.Query(s.q(cQuery), cArgs...)
+	if err != nil {
+		return nil, nil, fmt.Errorf("report completed-by-collection: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var id string
+		var n int
+		if err := rows.Scan(&id, &n); err != nil {
+			return nil, nil, fmt.Errorf("scan completed-by-collection: %w", err)
+		}
+		byColl[id] = n
+	}
+	return byBucket, byColl, rows.Err()
+}
+
+// positiveTerminalExpr builds the "this transition is a positive completion"
+// boolean: OR over collections of
+// (st.collection_id = ? AND st.field_key = ? AND LOWER(st.to_status) IN (...)).
+// Returns "" (no args) when no collection has any positive terminal value.
+func (s *Store) positiveTerminalExpr(colls []reportCollection) (string, []any) {
+	var clauses []string
+	var args []any
+	for _, c := range colls {
+		if len(c.positiveTerminals) == 0 {
+			continue
+		}
+		ph := make([]string, len(c.positiveTerminals))
+		args = append(args, c.id, c.doneKey)
+		for i, v := range c.positiveTerminals {
+			ph[i] = "?"
+			args = append(args, strings.ToLower(v))
+		}
+		clauses = append(clauses, fmt.Sprintf(
+			"(st.collection_id = ? AND st.field_key = ? AND LOWER(st.to_status) IN (%s))",
+			strings.Join(ph, ","),
+		))
+	}
+	if len(clauses) == 0 {
+		return "", nil
+	}
+	return "(" + strings.Join(clauses, " OR ") + ")", args
+}
+
+// reportStatusDistribution returns the current per-collection breakdown of
+// items by their done-field value. One small grouped query per collection
+// (the done field differs per collection, so a single GROUP BY can't span
+// them).
+func (s *Store) reportStatusDistribution(workspaceID string, colls []reportCollection) ([]ReportStatusCount, error) {
+	out := []ReportStatusCount{}
+	for _, c := range colls {
+		fieldExpr := s.dialect.JSONExtractText("fields", c.doneKey)
+		query := fmt.Sprintf(`
+			SELECT LOWER(COALESCE(%s, '')) AS st, COUNT(*)
+			FROM items
+			WHERE workspace_id = ? AND collection_id = ? AND deleted_at IS NULL
+			GROUP BY st
+		`, fieldExpr)
+		rows, err := s.db.Query(s.q(query), workspaceID, c.id)
+		if err != nil {
+			return nil, fmt.Errorf("report status distribution: %w", err)
+		}
+		func() {
+			defer rows.Close()
+			for rows.Next() {
+				var status string
+				var n int
+				if scanErr := rows.Scan(&status, &n); scanErr != nil {
+					err = fmt.Errorf("scan status distribution: %w", scanErr)
+					return
+				}
+				if status == "" {
+					continue // items with no done-field value set
+				}
+				out = append(out, ReportStatusCount{Collection: c.slug, Status: status, Count: n})
+			}
+			err = rows.Err()
+		}()
+		if err != nil {
+			return nil, err
+		}
+	}
+	return out, nil
+}
+
+// scanBucketCounts runs a "SELECT <bucket>, COUNT(*) ... GROUP BY <bucket>"
+// query and returns a label→count map.
+func (s *Store) scanBucketCounts(query string, args []any) (map[string]int, error) {
+	rows, err := s.db.Query(s.q(query), args...)
+	if err != nil {
+		return nil, fmt.Errorf("report bucket query: %w", err)
+	}
+	defer rows.Close()
+	out := map[string]int{}
+	for rows.Next() {
+		var bucket string
+		var n int
+		if err := rows.Scan(&bucket, &n); err != nil {
+			return nil, fmt.Errorf("scan report bucket: %w", err)
+		}
+		out[bucket] = n
+	}
+	return out, rows.Err()
+}
+
+// zeroFilledBuckets produces the full chronological bucket series between start
+// and end (inclusive) at the given granularity, merging in created/completed
+// counts (nil maps are treated as empty). Continuous buckets make the series
+// chart-ready without client-side gap-filling.
+func (s *Store) zeroFilledBuckets(start, end time.Time, gran string, created, completed map[string]int) []ReportBucket {
+	var step time.Duration
+	var layout string
+	if gran == "hour" {
+		step, layout = time.Hour, "2006-01-02T15"
+		start = start.Truncate(time.Hour)
+	} else {
+		step, layout = 24*time.Hour, "2006-01-02"
+		start = time.Date(start.Year(), start.Month(), start.Day(), 0, 0, 0, 0, time.UTC)
+	}
+	out := []ReportBucket{}
+	for t := start; !t.After(end); t = t.Add(step) {
+		label := t.UTC().Format(layout)
+		out = append(out, ReportBucket{
+			Bucket:    label,
+			Created:   created[label],
+			Completed: completed[label],
+		})
+	}
+	return out
+}

--- a/internal/store/reports_test.go
+++ b/internal/store/reports_test.go
@@ -138,6 +138,35 @@ func TestGetReport_CollectionFilter(t *testing.T) {
 	}
 }
 
+func TestGetReport_SoftDeletedExcludedFromCompleted(t *testing.T) {
+	s := testStore(t)
+	wsID, colID := newTransitionTestWorkspace(t, s)
+	item := createTestItem(t, s, wsID, colID, "ship then delete", "")
+	if _, err := s.UpdateItem(item.ID, models.ItemUpdate{Fields: strPtr(`{"status":"done"}`)}); err != nil {
+		t.Fatalf("complete: %v", err)
+	}
+	// Soft delete — the status_transitions row survives (only a HARD delete
+	// cascades it). It must drop out of completed counts to stay consistent
+	// with created/status_distribution.
+	if err := s.DeleteItem(item.ID); err != nil {
+		t.Fatalf("soft delete: %v", err)
+	}
+
+	rep, err := s.GetReport(wsID, ReportOptions{Window: "week", Now: time.Now().UTC()})
+	if err != nil {
+		t.Fatalf("GetReport: %v", err)
+	}
+	if rep.Totals.Completed != 0 {
+		t.Fatalf("soft-deleted item must not count as completed, got %d", rep.Totals.Completed)
+	}
+	if collCount(rep.CompletedByCollection, "tasks") != 0 {
+		t.Fatalf("soft-deleted item must not appear in completed_by_collection, got %+v", rep.CompletedByCollection)
+	}
+	if rep.Totals.Created != 0 {
+		t.Fatalf("soft-deleted item should also be absent from created, got %d", rep.Totals.Created)
+	}
+}
+
 func TestGetReport_ScopeToVisibleExcludesHidden(t *testing.T) {
 	s := testStore(t)
 	wsID, tasksID := newTransitionTestWorkspace(t, s)

--- a/internal/store/reports_test.go
+++ b/internal/store/reports_test.go
@@ -138,6 +138,40 @@ func TestGetReport_CollectionFilter(t *testing.T) {
 	}
 }
 
+func TestGetReport_ScopeToVisibleExcludesHidden(t *testing.T) {
+	s := testStore(t)
+	wsID, tasksID := newTransitionTestWorkspace(t, s)
+	secret := createTestCollection(t, s, wsID, "Secret")
+	createTestItem(t, s, wsID, tasksID, "visible task", "")
+	createTestItem(t, s, wsID, secret.ID, "hidden", "")
+
+	// Caller can only see the tasks collection.
+	rep, err := s.GetReport(wsID, ReportOptions{
+		Window:               "week",
+		Now:                  time.Now().UTC(),
+		ScopeToVisible:       true,
+		VisibleCollectionIDs: []string{tasksID},
+	})
+	if err != nil {
+		t.Fatalf("GetReport: %v", err)
+	}
+	if len(rep.Collections) != 1 || rep.Collections[0] != "tasks" {
+		t.Fatalf("expected only the visible 'tasks' collection, got %+v", rep.Collections)
+	}
+	if rep.Totals.Created != 1 {
+		t.Fatalf("hidden collection's item must not be counted; created=%d", rep.Totals.Created)
+	}
+
+	// Empty visible set → empty report (guest with no full-collection access).
+	empty, err := s.GetReport(wsID, ReportOptions{Window: "week", Now: time.Now().UTC(), ScopeToVisible: true, VisibleCollectionIDs: nil})
+	if err != nil {
+		t.Fatalf("GetReport empty: %v", err)
+	}
+	if len(empty.Collections) != 0 || empty.Totals.Created != 0 {
+		t.Fatalf("empty visible set should yield empty report, got %+v", empty)
+	}
+}
+
 func TestGetReport_NonStatusDoneField(t *testing.T) {
 	s := testStore(t)
 	u, _ := s.CreateUser(models.UserCreate{Name: "H", Email: "h@example.com"})

--- a/internal/store/reports_test.go
+++ b/internal/store/reports_test.go
@@ -1,0 +1,207 @@
+package store
+
+import (
+	"testing"
+	"time"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+func findBucket(buckets []ReportBucket, label string) (ReportBucket, bool) {
+	for _, b := range buckets {
+		if b.Bucket == label {
+			return b, true
+		}
+	}
+	return ReportBucket{}, false
+}
+
+func collCount(list []ReportCollectionCount, slug string) int {
+	for _, c := range list {
+		if c.Collection == slug {
+			return c.Count
+		}
+	}
+	return 0
+}
+
+func TestGetReport_ThroughputAndTotals(t *testing.T) {
+	s := testStore(t)
+	wsID, colID := newTransitionTestWorkspace(t, s)
+
+	// Two items created; one moved to done.
+	a := createTestItem(t, s, wsID, colID, "A", "")
+	createTestItem(t, s, wsID, colID, "B", "")
+	if _, err := s.UpdateItem(a.ID, models.ItemUpdate{Fields: strPtr(`{"status":"done"}`)}); err != nil {
+		t.Fatalf("complete A: %v", err)
+	}
+
+	now := time.Now().UTC()
+	rep, err := s.GetReport(wsID, ReportOptions{Window: "week", Now: now})
+	if err != nil {
+		t.Fatalf("GetReport: %v", err)
+	}
+
+	if rep.Granularity != "day" {
+		t.Fatalf("week window should bucket by day, got %q", rep.Granularity)
+	}
+	if rep.Totals.Created != 2 {
+		t.Fatalf("expected 2 created, got %d", rep.Totals.Created)
+	}
+	if rep.Totals.Completed != 1 {
+		t.Fatalf("expected 1 completed (A → done), got %d", rep.Totals.Completed)
+	}
+	if rep.Totals.NetFlow != 1 {
+		t.Fatalf("expected net flow 1, got %d", rep.Totals.NetFlow)
+	}
+
+	// Today's bucket should hold the activity.
+	today := now.Format("2006-01-02")
+	b, ok := findBucket(rep.Buckets, today)
+	if !ok {
+		t.Fatalf("today's bucket %q missing from series", today)
+	}
+	if b.Created != 2 || b.Completed != 1 {
+		t.Fatalf("today bucket = created %d completed %d; want 2/1", b.Created, b.Completed)
+	}
+
+	if collCount(rep.CompletedByCollection, "tasks") != 1 {
+		t.Fatalf("expected tasks completed=1, got %+v", rep.CompletedByCollection)
+	}
+}
+
+func TestGetReport_NegativeTerminalNotCompleted(t *testing.T) {
+	s := testStore(t)
+	wsID, colID := newTransitionTestWorkspace(t, s)
+	item := createTestItem(t, s, wsID, colID, "Doomed idea", "")
+
+	// Move into a negative terminal — recorded as a transition, but must NOT
+	// count as a completion.
+	if _, err := s.UpdateItem(item.ID, models.ItemUpdate{Fields: strPtr(`{"status":"rejected"}`)}); err != nil {
+		t.Fatalf("reject: %v", err)
+	}
+
+	rep, err := s.GetReport(wsID, ReportOptions{Window: "week", Now: time.Now().UTC()})
+	if err != nil {
+		t.Fatalf("GetReport: %v", err)
+	}
+	if rep.Totals.Completed != 0 {
+		t.Fatalf("rejected should not count as completed, got %d", rep.Totals.Completed)
+	}
+	if rep.Totals.Created != 1 {
+		t.Fatalf("expected 1 created, got %d", rep.Totals.Created)
+	}
+}
+
+func TestGetReport_StatusDistribution(t *testing.T) {
+	s := testStore(t)
+	wsID, colID := newTransitionTestWorkspace(t, s)
+	createTestItem(t, s, wsID, colID, "open1", "")
+	createTestItem(t, s, wsID, colID, "open2", "")
+	done := createTestItem(t, s, wsID, colID, "done1", "")
+	if _, err := s.UpdateItem(done.ID, models.ItemUpdate{Fields: strPtr(`{"status":"done"}`)}); err != nil {
+		t.Fatalf("complete: %v", err)
+	}
+
+	rep, err := s.GetReport(wsID, ReportOptions{Window: "week", Now: time.Now().UTC()})
+	if err != nil {
+		t.Fatalf("GetReport: %v", err)
+	}
+	got := map[string]int{}
+	for _, d := range rep.StatusDistribution {
+		if d.Collection == "tasks" {
+			got[d.Status] = d.Count
+		}
+	}
+	if got["open"] != 2 || got["done"] != 1 {
+		t.Fatalf("status distribution wrong: %+v", rep.StatusDistribution)
+	}
+}
+
+func TestGetReport_CollectionFilter(t *testing.T) {
+	s := testStore(t)
+	wsID, tasksID := newTransitionTestWorkspace(t, s)
+	bugs := createTestCollection(t, s, wsID, "Bugs")
+	createTestItem(t, s, wsID, tasksID, "task", "")
+	createTestItem(t, s, wsID, bugs.ID, "bug", "")
+
+	// Filter to bugs only.
+	rep, err := s.GetReport(wsID, ReportOptions{Window: "week", Collections: []string{"bugs"}, Now: time.Now().UTC()})
+	if err != nil {
+		t.Fatalf("GetReport: %v", err)
+	}
+	if len(rep.Collections) != 1 || rep.Collections[0] != "bugs" {
+		t.Fatalf("expected only bugs in scope, got %+v", rep.Collections)
+	}
+	if rep.Totals.Created != 1 {
+		t.Fatalf("expected 1 created (bug only), got %d", rep.Totals.Created)
+	}
+}
+
+func TestGetReport_NonStatusDoneField(t *testing.T) {
+	s := testStore(t)
+	u, _ := s.CreateUser(models.UserCreate{Name: "H", Email: "h@example.com"})
+	ws, _ := s.CreateWorkspace(models.WorkspaceCreate{Name: "Hiring", Slug: "hiring", OwnerID: u.ID})
+	col, err := s.CreateCollection(ws.ID, models.CollectionCreate{
+		Name:     "Candidates",
+		Schema:   `{"fields":[{"key":"stage","label":"Stage","type":"select","options":["applied","interview","hired"],"terminal_options":["hired"],"default":"applied"}]}`,
+		Settings: `{"board_group_by":"stage"}`,
+	})
+	if err != nil {
+		t.Fatalf("create collection: %v", err)
+	}
+	c, err := s.CreateItem(ws.ID, col.ID, models.ItemCreate{Title: "Ada", Fields: `{"stage":"applied"}`})
+	if err != nil {
+		t.Fatalf("create item: %v", err)
+	}
+	if _, err := s.UpdateItem(c.ID, models.ItemUpdate{Fields: strPtr(`{"stage":"hired"}`)}); err != nil {
+		t.Fatalf("hire: %v", err)
+	}
+
+	rep, err := s.GetReport(ws.ID, ReportOptions{Window: "week", Now: time.Now().UTC()})
+	if err != nil {
+		t.Fatalf("GetReport: %v", err)
+	}
+	if rep.Totals.Completed != 1 {
+		t.Fatalf("expected 1 completion on the stage done-field, got %d", rep.Totals.Completed)
+	}
+	if collCount(rep.CompletedByCollection, "candidates") != 1 {
+		t.Fatalf("expected candidates completed=1, got %+v", rep.CompletedByCollection)
+	}
+}
+
+func TestGetReport_ExcludesOutOfWindow(t *testing.T) {
+	s := testStore(t)
+	wsID, colID := newTransitionTestWorkspace(t, s)
+	old := createTestItem(t, s, wsID, colID, "ancient", "")
+	// Backdate the item well outside a 1-week window.
+	if _, err := s.db.Exec(s.dialect.Rebind(`UPDATE items SET created_at = ? WHERE id = ?`),
+		"2020-01-01T00:00:00Z", old.ID); err != nil {
+		t.Fatalf("backdate: %v", err)
+	}
+	createTestItem(t, s, wsID, colID, "recent", "")
+
+	rep, err := s.GetReport(wsID, ReportOptions{Window: "week", Now: time.Now().UTC()})
+	if err != nil {
+		t.Fatalf("GetReport: %v", err)
+	}
+	if rep.Totals.Created != 1 {
+		t.Fatalf("expected only the recent item (1) created in window, got %d", rep.Totals.Created)
+	}
+}
+
+func TestGetReport_DayWindowBucketsByHour(t *testing.T) {
+	s := testStore(t)
+	wsID, _ := newTransitionTestWorkspace(t, s)
+	rep, err := s.GetReport(wsID, ReportOptions{Window: "day", Now: time.Now().UTC()})
+	if err != nil {
+		t.Fatalf("GetReport: %v", err)
+	}
+	if rep.Granularity != "hour" {
+		t.Fatalf("day window should bucket by hour, got %q", rep.Granularity)
+	}
+	// Hourly labels are "YYYY-MM-DDTHH" (13 chars).
+	if len(rep.Buckets) > 0 && len(rep.Buckets[0].Bucket) != 13 {
+		t.Fatalf("hourly bucket label should be 13 chars, got %q", rep.Buckets[0].Bucket)
+	}
+}

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -19,6 +19,8 @@ import type {
 	CommentCreate,
 	Version,
 	DashboardResponse,
+	ReportData,
+	ReportWindow,
 	SearchResponse,
 	SearchFilters,
 	Activity,
@@ -924,6 +926,22 @@ export const api = {
 	dashboard: {
 		get: (ws: string) =>
 			request<DashboardResponse>(`/workspaces/${ws}/dashboard`)
+	},
+
+	// ── Project Report (PLAN-1628 / TASK-1630) ────────────────────────────────
+
+	report: {
+		/**
+		 * Windowed project report. window ∈ {day, week, 2wk, month} (default
+		 * week). collections optionally restricts to the given slugs.
+		 */
+		get: (ws: string, opts?: { window?: ReportWindow; collections?: string[] }) => {
+			const params = new URLSearchParams();
+			if (opts?.window) params.set('window', opts.window);
+			if (opts?.collections?.length) params.set('collections', opts.collections.join(','));
+			const qs = params.toString();
+			return request<ReportData>(`/workspaces/${ws}/report${qs ? `?${qs}` : ''}`);
+		}
 	},
 
 	// ── Incremental Sync ─────────────────────────────────────────────────────

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -815,6 +815,55 @@ export interface DashboardResponse {
 	};
 }
 
+// ─── Project Report (PLAN-1628 / TASK-1630) ──────────────────────────────────
+
+export type ReportWindow = 'day' | 'week' | '2wk' | 'month';
+
+/** One time-series point: items created vs completed within the bucket. */
+export interface ReportBucket {
+	/** Sortable UTC label: "YYYY-MM-DD" (day) or "YYYY-MM-DDTHH" (hour). */
+	bucket: string;
+	created: number;
+	completed: number;
+}
+
+export interface ReportCollectionCount {
+	/** collection slug */
+	collection: string;
+	count: number;
+}
+
+export interface ReportStatusCount {
+	collection: string;
+	status: string;
+	count: number;
+}
+
+export interface ReportTotals {
+	created: number;
+	completed: number;
+	/** created - completed */
+	net_flow: number;
+}
+
+/**
+ * Windowed project report. "completed" counts a status change into a positive
+ * terminal value (terminal options minus negative outcomes like
+ * rejected/cancelled). buckets is chronological and zero-filled, so it renders
+ * directly without client-side gap-filling.
+ */
+export interface ReportData {
+	window: ReportWindow;
+	granularity: 'hour' | 'day';
+	range_start: string; // RFC3339 UTC
+	range_end: string; // RFC3339 UTC
+	collections: string[]; // slugs included
+	buckets: ReportBucket[];
+	totals: ReportTotals;
+	completed_by_collection: ReportCollectionCount[];
+	status_distribution: ReportStatusCount[];
+}
+
 // ─── Incremental Sync ────────────────────────────────────────────────────────
 
 export interface ChangesResponse {


### PR DESCRIPTION
## Summary
Adds `GET /workspaces/{ws}/report?window=week&collections=tasks,bugs` — the aggregation backend for the Reports surface (PLAN-1628). Returns time-bucketed created-vs-completed throughput, net flow, completed-by-collection, and a current status-distribution snapshot.

## Context
Implements `TASK-1630` under `PLAN-1628`, on the `status_transitions` foundation (TASK-1637). Fixes the response contract that `TASK-1632` (charts), `TASK-1633` (UI), and `TASK-1635` (CLI/MCP) consume — that shape is now recorded on each of those tasks.

## What changed
- **`Dialect.DateBucket(column, granularity)`** — day/hour bucketing via fixed-width substring on the UTC RFC3339 TEXT. Identical + exact on SQLite and Postgres, and avoids SQLite's fragile `Z`-suffix parsing. All report date math routes through it (week/month would diverge to strftime/date_trunc when a window needs them).
- **`store.GetReport`** — resolves each collection's done field + *positive* terminals (terminal options minus a negative denylist: rejected/cancelled/etc.), counts completions from `status_transitions` and created from `items.created_at`, zero-fills the bucket series.
- HTTP handler + route; web `ReportData` type + `api.report.get` client.

## Windows
`day` → 24 hourly buckets; `week`/`2wk`/`month` → daily buckets (7/14/30).

## Test plan
- [x] `go test ./internal/store/ ./internal/server/` — green
- [x] `make check` (lint + web build + svelte-check) — clean
- [x] Report tests: throughput/totals, negative-terminal exclusion, status distribution, collection filter, non-status done-field (stage), out-of-window exclusion, hourly day-window; `DateBucket` per granularity. Dual-dialect via `testStore` (also runs under `PAD_TEST_POSTGRES_URL`).