### PR TITLE
feat(web): LayerCake chart component library for Reports (TASK-1632)

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -23,9 +23,11 @@
 				"@tiptap/starter-kit": "^3.22.5",
 				"@tiptap/suggestion": "^3.22.5",
 				"@tiptap/y-tiptap": "^3.0.3",
+				"d3-scale": "4.0.2",
 				"diff": "^9.0.0",
 				"dompurify": "^3.4.2",
 				"idb": "^8.0.3",
+				"layercake": "10.0.2",
 				"lowlight": "^3.3.0",
 				"mermaid": "^11.14.0",
 				"minisearch": "7.2.0",
@@ -41,6 +43,7 @@
 				"@sveltejs/adapter-static": "^3.0.10",
 				"@sveltejs/kit": "^2.59.1",
 				"@sveltejs/vite-plugin-svelte": "^7.1.2",
+				"@types/d3-scale": "4.0.9",
 				"@types/qrcode": "^1.5.6",
 				"marked": "^18.0.3",
 				"svelte": "^5.55.5",
@@ -2483,6 +2486,25 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/layercake": {
+			"version": "10.0.2",
+			"resolved": "https://registry.npmjs.org/layercake/-/layercake-10.0.2.tgz",
+			"integrity": "sha512-cYtPVA+AL/HbAzsH5xDL9/pbuNuhboGUI9GBtrC1Akjsx4V74rvBmUHZW8lO2ufCDMu+J2CtBRKgO8rkONsYBw==",
+			"license": "MIT",
+			"dependencies": {
+				"d3-array": "^3.2.4",
+				"d3-color": "^3.1.0",
+				"d3-scale": "^4.0.2",
+				"d3-shape": "^3.2.0"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			},
+			"peerDependencies": {
+				"svelte": ">=5",
+				"typescript": "^5.0.2"
+			}
+		},
 		"node_modules/layout-base": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
@@ -3659,7 +3681,6 @@
 			"version": "6.0.3",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
 			"integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
 				"tsc": "bin/tsc",

--- a/web/package.json
+++ b/web/package.json
@@ -21,6 +21,7 @@
 		"@sveltejs/adapter-static": "^3.0.10",
 		"@sveltejs/kit": "^2.59.1",
 		"@sveltejs/vite-plugin-svelte": "^7.1.2",
+		"@types/d3-scale": "4.0.9",
 		"@types/qrcode": "^1.5.6",
 		"marked": "^18.0.3",
 		"svelte": "^5.55.5",
@@ -29,7 +30,10 @@
 		"vite": "^8.0.11"
 	},
 	"overrides": {
-		"cookie": "^0.7.2"
+		"cookie": "^0.7.2",
+		"layercake": {
+			"typescript": "$typescript"
+		}
 	},
 	"dependencies": {
 		"@tiptap/core": "^3.22.5",
@@ -46,9 +50,11 @@
 		"@tiptap/starter-kit": "^3.22.5",
 		"@tiptap/suggestion": "^3.22.5",
 		"@tiptap/y-tiptap": "^3.0.3",
+		"d3-scale": "4.0.2",
 		"diff": "^9.0.0",
 		"dompurify": "^3.4.2",
 		"idb": "^8.0.3",
+		"layercake": "10.0.2",
 		"lowlight": "^3.3.0",
 		"mermaid": "^11.14.0",
 		"minisearch": "7.2.0",

--- a/web/src/lib/components/charts/BarChart.svelte
+++ b/web/src/lib/components/charts/BarChart.svelte
@@ -1,0 +1,112 @@
+<script lang="ts">
+	import { LayerCake, Svg } from 'layercake';
+	import { scaleBand, scaleLinear } from 'd3-scale';
+	import Bars from './layers/Bars.svelte';
+	import AxisX from './layers/AxisX.svelte';
+	import AxisY from './layers/AxisY.svelte';
+	import { resolveColor, type ChartDatum, type ResolvedSeries } from './theme';
+
+	interface Props {
+		data: ChartDatum[];
+		x: string;
+		series: { key: string; label: string; color?: string }[];
+		height?: number;
+		ariaLabel: string;
+	}
+
+	let { data, x, series, height = 240, ariaLabel }: Props = $props();
+
+	const resolvedSeries = $derived<ResolvedSeries[]>(
+		series.map((s, i) => ({ key: s.key, label: s.label, color: resolveColor(s.color, i) }))
+	);
+
+	const hasData = $derived(data.length > 0 && series.length > 0);
+	const padding = { top: 12, right: 12, bottom: 28, left: 36 };
+
+	// y accessor returns the largest series value per datum so the linear
+	// y-domain (yDomain={[0, null]}) accommodates the tallest grouped bar.
+	const yAccessor = $derived.by(() => {
+		const ser = resolvedSeries;
+		return (d: ChartDatum) => {
+			let max = 0;
+			for (const s of ser) {
+				const v = d[s.key];
+				const n = typeof v === 'number' ? v : Number(v) || 0;
+				if (n > max) max = n;
+			}
+			return max;
+		};
+	});
+</script>
+
+<div class="chart" role="img" aria-label={ariaLabel}>
+	{#if hasData}
+		<div class="legend">
+			{#each resolvedSeries as s (s.key)}
+				<span class="legend-item">
+					<span class="swatch" style:background-color={s.color}></span>
+					{s.label}
+				</span>
+			{/each}
+		</div>
+		<div class="canvas" style:height={`${height}px`}>
+			<LayerCake
+				{data}
+				{x}
+				y={yAccessor}
+				xScale={scaleBand().paddingInner(0.2)}
+				yScale={scaleLinear()}
+				yDomain={[0, null]}
+				{padding}
+			>
+				<Svg>
+					<AxisY />
+					<AxisX />
+					<Bars series={resolvedSeries} />
+				</Svg>
+			</LayerCake>
+		</div>
+	{:else}
+		<div class="empty" style:height={`${height}px`}>No data</div>
+	{/if}
+</div>
+
+<style>
+	.chart {
+		width: 100%;
+	}
+
+	.canvas {
+		width: 100%;
+	}
+
+	.legend {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.75rem;
+		margin-bottom: 0.5rem;
+		font-size: 0.75rem;
+		color: var(--text-muted, #6b7280);
+	}
+
+	.legend-item {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.35rem;
+	}
+
+	.swatch {
+		display: inline-block;
+		width: 0.7rem;
+		height: 0.7rem;
+		border-radius: 2px;
+	}
+
+	.empty {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		color: var(--text-muted, #6b7280);
+		font-size: 0.875rem;
+	}
+</style>

--- a/web/src/lib/components/charts/LineChart.svelte
+++ b/web/src/lib/components/charts/LineChart.svelte
@@ -1,0 +1,112 @@
+<script lang="ts">
+	import { LayerCake, Svg } from 'layercake';
+	import { scalePoint, scaleLinear } from 'd3-scale';
+	import Lines from './layers/Lines.svelte';
+	import AxisX from './layers/AxisX.svelte';
+	import AxisY from './layers/AxisY.svelte';
+	import { resolveColor, type ChartDatum, type ResolvedSeries } from './theme';
+
+	interface Props {
+		data: ChartDatum[];
+		x: string;
+		series: { key: string; label: string; color?: string }[];
+		height?: number;
+		ariaLabel: string;
+	}
+
+	let { data, x, series, height = 240, ariaLabel }: Props = $props();
+
+	const resolvedSeries = $derived<ResolvedSeries[]>(
+		series.map((s, i) => ({ key: s.key, label: s.label, color: resolveColor(s.color, i) }))
+	);
+
+	const hasData = $derived(data.length > 0 && series.length > 0);
+	const padding = { top: 12, right: 16, bottom: 28, left: 36 };
+
+	// y accessor spans the largest series value per datum so the linear
+	// y-domain accommodates every line.
+	const yAccessor = $derived.by(() => {
+		const ser = resolvedSeries;
+		return (d: ChartDatum) => {
+			let max = 0;
+			for (const s of ser) {
+				const v = d[s.key];
+				const n = typeof v === 'number' ? v : Number(v) || 0;
+				if (n > max) max = n;
+			}
+			return max;
+		};
+	});
+</script>
+
+<div class="chart" role="img" aria-label={ariaLabel}>
+	{#if hasData}
+		<div class="legend">
+			{#each resolvedSeries as s (s.key)}
+				<span class="legend-item">
+					<span class="swatch" style:background-color={s.color}></span>
+					{s.label}
+				</span>
+			{/each}
+		</div>
+		<div class="canvas" style:height={`${height}px`}>
+			<LayerCake
+				{data}
+				{x}
+				y={yAccessor}
+				xScale={scalePoint()}
+				yScale={scaleLinear()}
+				yDomain={[0, null]}
+				{padding}
+			>
+				<Svg>
+					<AxisY />
+					<AxisX />
+					<Lines series={resolvedSeries} />
+				</Svg>
+			</LayerCake>
+		</div>
+	{:else}
+		<div class="empty" style:height={`${height}px`}>No data</div>
+	{/if}
+</div>
+
+<style>
+	.chart {
+		width: 100%;
+	}
+
+	.canvas {
+		width: 100%;
+	}
+
+	.legend {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.75rem;
+		margin-bottom: 0.5rem;
+		font-size: 0.75rem;
+		color: var(--text-muted, #6b7280);
+	}
+
+	.legend-item {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.35rem;
+	}
+
+	.swatch {
+		display: inline-block;
+		width: 0.7rem;
+		height: 0.7rem;
+		border-radius: 2px;
+	}
+
+	.empty {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		color: var(--text-muted, #6b7280);
+		font-size: 0.875rem;
+	}
+</style>

--- a/web/src/lib/components/charts/Sparkline.svelte
+++ b/web/src/lib/components/charts/Sparkline.svelte
@@ -1,0 +1,72 @@
+<script lang="ts">
+	interface Props {
+		values: number[];
+		width?: number;
+		height?: number;
+		color?: string;
+		ariaLabel?: string;
+	}
+
+	let {
+		values,
+		width = 80,
+		height = 24,
+		color = 'var(--chart-1, #4f46e5)',
+		ariaLabel = 'Sparkline'
+	}: Props = $props();
+
+	const path = $derived.by(() => {
+		const n = values.length;
+		if (n === 0) return '';
+
+		const min = Math.min(...values);
+		const max = Math.max(...values);
+		const span = max - min || 1;
+		const pad = 1; // keep the stroke inside the viewbox
+		const usableH = height - pad * 2;
+
+		// Single point: draw a flat line across the middle.
+		if (n === 1) {
+			const y = pad + usableH / 2;
+			return `M0,${y} L${width},${y}`;
+		}
+
+		const stepX = width / (n - 1);
+		return values
+			.map((v, i) => {
+				const x = i * stepX;
+				const y = pad + usableH - ((v - min) / span) * usableH;
+				return `${i === 0 ? 'M' : 'L'}${x},${y}`;
+			})
+			.join(' ');
+	});
+</script>
+
+{#if values.length > 0}
+	<svg
+		class="sparkline"
+		viewBox="0 0 {width} {height}"
+		width={width}
+		height={height}
+		preserveAspectRatio="none"
+		role="img"
+		aria-label={ariaLabel}
+	>
+		<path
+			d={path}
+			fill="none"
+			stroke={color}
+			stroke-width="1.5"
+			stroke-linejoin="round"
+			stroke-linecap="round"
+			vector-effect="non-scaling-stroke"
+		/>
+	</svg>
+{/if}
+
+<style>
+	.sparkline {
+		display: inline-block;
+		vertical-align: middle;
+	}
+</style>

--- a/web/src/lib/components/charts/layers/AxisX.svelte
+++ b/web/src/lib/components/charts/layers/AxisX.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+	import { getContext } from 'svelte';
+	import type { LayerCakeContext, ChartDatum } from '../theme';
+
+	interface Props {
+		maxTicks?: number;
+	}
+
+	let { maxTicks = 8 }: Props = $props();
+
+	const { data, x, xGet, xScale, width, height } = getContext<LayerCakeContext>('LayerCake');
+
+	// Show every Nth label so dense category axes stay readable.
+	const step = $derived(Math.max(1, Math.ceil($data.length / maxTicks)));
+
+	function center(d: ChartDatum): number {
+		const half = typeof $xScale.bandwidth === 'function' ? $xScale.bandwidth() / 2 : 0;
+		return $xGet(d) + half;
+	}
+</script>
+
+<g class="axis-x">
+	<line x1={0} y1={$height} x2={$width} y2={$height} stroke="var(--border, #e5e7eb)" stroke-width="1" />
+	{#each $data as d, i (i)}
+		{#if i % step === 0}
+			<text
+				x={center(d)}
+				y={$height + 16}
+				text-anchor="middle"
+				fill="var(--text-muted, #6b7280)"
+				font-size="11"
+			>
+				{$x(d)}
+			</text>
+		{/if}
+	{/each}
+</g>

--- a/web/src/lib/components/charts/layers/AxisY.svelte
+++ b/web/src/lib/components/charts/layers/AxisY.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+	import { getContext } from 'svelte';
+	import type { LayerCakeContext } from '../theme';
+
+	const { yScale, width } = getContext<LayerCakeContext>('LayerCake');
+
+	const ticks = $derived($yScale.ticks(4));
+</script>
+
+<g class="axis-y">
+	{#each ticks as tick (tick)}
+		<line
+			x1={0}
+			y1={$yScale(tick)}
+			x2={$width}
+			y2={$yScale(tick)}
+			stroke="var(--border, #e5e7eb)"
+			stroke-width="0.5"
+		/>
+		<text
+			x={-8}
+			y={$yScale(tick)}
+			text-anchor="end"
+			dominant-baseline="middle"
+			fill="var(--text-muted, #6b7280)"
+			font-size="11"
+		>
+			{tick}
+		</text>
+	{/each}
+</g>

--- a/web/src/lib/components/charts/layers/Bars.svelte
+++ b/web/src/lib/components/charts/layers/Bars.svelte
@@ -1,0 +1,48 @@
+<script lang="ts">
+	import { getContext } from 'svelte';
+	import { scaleBand } from 'd3-scale';
+	import type { LayerCakeContext, ChartDatum, ResolvedSeries } from '../theme';
+
+	interface Props {
+		series: ResolvedSeries[];
+	}
+
+	let { series }: Props = $props();
+
+	const { data, xGet, xScale, yScale, height } = getContext<LayerCakeContext>('LayerCake');
+
+	const bandwidth = $derived(
+		typeof $xScale.bandwidth === 'function' ? $xScale.bandwidth() : 0
+	);
+
+	// Inner scale positioning each series side-by-side within a band.
+	const inner = $derived(
+		scaleBand<string>()
+			.domain(series.map((s) => s.key))
+			.range([0, bandwidth])
+			.paddingInner(0.1)
+	);
+
+	function barX(d: ChartDatum, key: string): number {
+		return $xGet(d) + (inner(key) ?? 0);
+	}
+
+	function num(d: ChartDatum, key: string): number {
+		const v = d[key];
+		return typeof v === 'number' ? v : Number(v) || 0;
+	}
+</script>
+
+<g class="bars">
+	{#each $data as d, i (i)}
+		{#each series as s (s.key)}
+			<rect
+				x={barX(d, s.key)}
+				y={$yScale(num(d, s.key))}
+				width={inner.bandwidth()}
+				height={Math.max(0, $height - $yScale(num(d, s.key)))}
+				fill={s.color}
+			/>
+		{/each}
+	{/each}
+</g>

--- a/web/src/lib/components/charts/layers/Lines.svelte
+++ b/web/src/lib/components/charts/layers/Lines.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+	import { getContext } from 'svelte';
+	import type { LayerCakeContext, ChartDatum, ResolvedSeries } from '../theme';
+
+	interface Props {
+		series: ResolvedSeries[];
+	}
+
+	let { series }: Props = $props();
+
+	const { data, xGet, yScale, xScale } = getContext<LayerCakeContext>('LayerCake');
+
+	// Center the point within a band when the x scale is categorical (band).
+	function cx(d: ChartDatum): number {
+		const half = typeof $xScale.bandwidth === 'function' ? $xScale.bandwidth() / 2 : 0;
+		return $xGet(d) + half;
+	}
+
+	function num(d: ChartDatum, key: string): number {
+		const v = d[key];
+		return typeof v === 'number' ? v : Number(v) || 0;
+	}
+
+	function path(key: string): string {
+		return $data
+			.map((d, i) => `${i === 0 ? 'M' : 'L'}${cx(d)},${$yScale(num(d, key))}`)
+			.join(' ');
+	}
+</script>
+
+<g class="lines">
+	{#each series as s (s.key)}
+		<path d={path(s.key)} fill="none" stroke={s.color} stroke-width="2" stroke-linejoin="round" />
+	{/each}
+</g>

--- a/web/src/lib/components/charts/theme.ts
+++ b/web/src/lib/components/charts/theme.ts
@@ -1,0 +1,58 @@
+import type { Readable } from 'svelte/store';
+
+/**
+ * Default color palette for chart series. Each entry references a CSS custom
+ * property with a hex fallback, so apps can theme charts via `--chart-N`
+ * without the variables being required to exist.
+ */
+export const PALETTE = [
+	'var(--chart-1, #4f46e5)',
+	'var(--chart-2, #06b6d4)',
+	'var(--chart-3, #f59e0b)',
+	'var(--chart-4, #10b981)'
+];
+
+/** Resolve a series color: explicit color wins, else fall back to the palette by index. */
+export function resolveColor(color: string | undefined, index: number): string {
+	return color ?? PALETTE[index % PALETTE.length];
+}
+
+/** A datum is a flat record of category/value pairs. */
+export type ChartDatum = Record<string, string | number>;
+
+/** Resolved series after color fallback has been applied. */
+export interface ResolvedSeries {
+	key: string;
+	label: string;
+	color: string;
+}
+
+/**
+ * The shape of the `'LayerCake'` context. LayerCake exposes its values as
+ * Svelte stores (it's built on legacy `writable`/`derived`), so each field is
+ * a `Readable`. Typing the `getContext` result this way keeps svelte-check
+ * happy instead of leaving everything `unknown`.
+ */
+export interface LayerCakeContext {
+	data: Readable<ChartDatum[]>;
+	xGet: Readable<(d: ChartDatum) => number>;
+	yGet: Readable<(d: ChartDatum) => number>;
+	xScale: Readable<{
+		(value: unknown): number;
+		bandwidth?: () => number;
+		ticks?: (count?: number) => number[];
+		domain: () => unknown[];
+	}>;
+	yScale: Readable<{
+		(value: unknown): number;
+		bandwidth?: () => number;
+		ticks: (count?: number) => number[];
+		domain: () => unknown[];
+	}>;
+	x: Readable<(d: ChartDatum) => string | number>;
+	y: Readable<(d: ChartDatum) => string | number>;
+	width: Readable<number>;
+	height: Readable<number>;
+	xRange: Readable<number[]>;
+	yRange: Readable<number[]>;
+}


### PR DESCRIPTION
## Summary
Adds a reusable charting component library under `web/src/lib/components/charts/` to power the upcoming Reports surface (TASK-1633). LayerCake chosen over uPlot/hand-rolled SVG: Svelte-native, SVG-based (themeable with existing CSS), tiny — and the report data volume (≤30 buckets) makes raw perf irrelevant.

## Context
Implements `TASK-1632` under `PLAN-1628`. Consumes nothing; the Reports UI (TASK-1633) imports it. Response contract for the data it'll render is fixed in TASK-1630.

## What changed
- `BarChart` / `LineChart` / `Sparkline` (public) + `Bars`/`Lines`/`AxisX`/`AxisY` layers + `theme.ts`
- Svelte 5 runes throughout; `role="img"` + `aria-label`; "No data" empty states; responsive width / fixed height
- `theme.ts`: `var(--chart-N, #hex)` palette (CSS-overridable, hex fallbacks) + a typed LayerCake context interface
- Deps: `layercake@10.0.2` + `d3-scale@4.0.2` (+`@types/d3-scale`); npm `override` lets layercake accept the repo's TypeScript 6 (its peer range caps at TS5)

## Bundle-size impact
~8–12 KB gzipped added **only when the Reports bundle imports these** (tree-shaken: only `LayerCake`+`Svg` and `scaleBand`/`scaleLinear`/`scalePoint`). `Sparkline` is dependency-free hand-rolled SVG.

## Test plan
- [x] `make check` — golangci-lint + web build + `npm audit --audit-level=high` (0) + svelte-check (**0 errors**; only pre-existing warnings in unrelated files)
- [x] Svelte MCP autofixer clean on every component
- [x] Library only — not wired into a page (verified no imports yet)