### PR TITLE
feat(cli,mcp): pad project report + pad_project report action (TASK-1635)

### DIFF
--- a/cmd/pad/groups.go
+++ b/cmd/pad/groups.go
@@ -71,6 +71,7 @@ func projectCmd() *cobra.Command {
 		staleCmd(),
 		standupCmd(),
 		changelogCmd(),
+		reportCmd(),
 		watchCmd(),
 		reconcileCmd(),
 	)

--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -5247,6 +5247,129 @@ func standupCmd() *cobra.Command {
 
 // --- changelog ---
 
+func reportCmd() *cobra.Command {
+	var window string
+	var collections string
+
+	cmd := &cobra.Command{
+		Use:   "report",
+		Short: "Windowed project report — throughput, net flow, completions, status mix",
+		Long: `Show a time-windowed project report: items created vs completed per bucket,
+net flow, completed-by-collection, and a current status-distribution snapshot.
+
+--window day|week|2wk|month (default week; day buckets hourly, others daily).
+--collections restricts to a comma-separated list of collection slugs.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, _ := getClient()
+			ws := getWorkspace()
+
+			repJSON, err := client.GetReport(ws, window, collections)
+			if err != nil {
+				return err
+			}
+			if formatFlag == "json" {
+				return cli.PrintJSON(repJSON)
+			}
+
+			var rep struct {
+				Window      string   `json:"window"`
+				Granularity string   `json:"granularity"`
+				RangeStart  string   `json:"range_start"`
+				RangeEnd    string   `json:"range_end"`
+				Collections []string `json:"collections"`
+				Buckets     []struct {
+					Bucket    string `json:"bucket"`
+					Created   int    `json:"created"`
+					Completed int    `json:"completed"`
+				} `json:"buckets"`
+				Totals struct {
+					Created   int `json:"created"`
+					Completed int `json:"completed"`
+					NetFlow   int `json:"net_flow"`
+				} `json:"totals"`
+				CompletedByCollection []struct {
+					Collection string `json:"collection"`
+					Count      int    `json:"count"`
+				} `json:"completed_by_collection"`
+				StatusDistribution []struct {
+					Collection string `json:"collection"`
+					Status     string `json:"status"`
+					Count      int    `json:"count"`
+				} `json:"status_distribution"`
+			}
+			if err := json.Unmarshal(repJSON, &rep); err != nil {
+				fmt.Println(string(repJSON))
+				return nil
+			}
+
+			bold := color.New(color.Bold)
+			dim := color.New(color.Faint)
+			green := color.New(color.FgGreen)
+			red := color.New(color.FgRed)
+
+			bold.Printf("📊 Report — %s", rep.Window)
+			if len(rep.Collections) > 0 {
+				dim.Printf("  (%s)", strings.Join(rep.Collections, ", "))
+			}
+			fmt.Println()
+			dim.Printf("   %s → %s\n\n", rep.RangeStart, rep.RangeEnd)
+
+			net := fmt.Sprintf("%+d", rep.Totals.NetFlow)
+			fmt.Printf("   Created: ")
+			green.Printf("%d", rep.Totals.Created)
+			fmt.Printf("   Completed: ")
+			green.Printf("%d", rep.Totals.Completed)
+			fmt.Printf("   Net flow: ")
+			if rep.Totals.NetFlow >= 0 {
+				bold.Print(net)
+			} else {
+				red.Print(net)
+			}
+			fmt.Print("\n\n")
+
+			// Per-bucket throughput (skip all-zero buckets to keep it compact).
+			any := false
+			for _, b := range rep.Buckets {
+				if b.Created == 0 && b.Completed == 0 {
+					continue
+				}
+				if !any {
+					bold.Println("   Throughput (created / completed)")
+					any = true
+				}
+				fmt.Printf("   %-13s ", b.Bucket)
+				green.Printf("+%d", b.Created)
+				fmt.Print(" / ")
+				red.Printf("-%d", b.Completed)
+				fmt.Println()
+			}
+			if !any {
+				dim.Println("   No activity in this window.")
+			}
+
+			if len(rep.CompletedByCollection) > 0 {
+				fmt.Println()
+				bold.Println("   Completed by collection")
+				for _, c := range rep.CompletedByCollection {
+					fmt.Printf("   %-16s %d\n", c.Collection, c.Count)
+				}
+			}
+
+			if len(rep.StatusDistribution) > 0 {
+				fmt.Println()
+				bold.Println("   Status distribution")
+				for _, s := range rep.StatusDistribution {
+					fmt.Printf("   %-16s %-14s %d\n", s.Collection, s.Status, s.Count)
+				}
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&window, "window", "week", "Report window: day|week|2wk|month")
+	cmd.Flags().StringVar(&collections, "collections", "", "Comma-separated collection slugs to include (default: all visible)")
+	return cmd
+}
+
 func changelogCmd() *cobra.Command {
 	var days int
 	var since string

--- a/internal/cli/client.go
+++ b/internal/cli/client.go
@@ -319,6 +319,25 @@ func (c *Client) GetDashboard(wsSlug string) (json.RawMessage, error) {
 	return result, c.get("/workspaces/"+wsSlug+"/dashboard", &result)
 }
 
+// GetReport returns the windowed project report JSON (PLAN-1628 / TASK-1630).
+// window is one of day|week|2wk|month (empty = server default "week");
+// collections is an optional comma-separated list of collection slugs.
+func (c *Client) GetReport(wsSlug, window, collections string) (json.RawMessage, error) {
+	q := url.Values{}
+	if window != "" {
+		q.Set("window", window)
+	}
+	if collections != "" {
+		q.Set("collections", collections)
+	}
+	path := "/workspaces/" + wsSlug + "/report"
+	if len(q) > 0 {
+		path += "?" + q.Encode()
+	}
+	var result json.RawMessage
+	return result, c.get(path, &result)
+}
+
 // --- Bootstrap ---
 
 // GetAgentBootstrap returns the consolidated bootstrap blob — workspace +

--- a/internal/mcp/catalog_project.go
+++ b/internal/mcp/catalog_project.go
@@ -28,6 +28,16 @@ var padProjectTool = ToolDef{
 				Type:        "string",
 				Description: "Parent item ref (e.g. PLAN-2). Optional for action=changelog — scope the changelog to items under this parent.",
 			},
+			{
+				Name:        "window",
+				Type:        "string",
+				Description: "Report window for action=report: day | week | 2wk | month (default week).",
+			},
+			{
+				Name:        "collections",
+				Type:        "string",
+				Description: "Comma-separated collection slugs to include for action=report (default: all visible).",
+			},
 		},
 	},
 	Actions: map[string]ActionFn{
@@ -35,6 +45,7 @@ var padProjectTool = ToolDef{
 		"next":      passThrough([]string{"project", "next"}),
 		"standup":   passThrough([]string{"project", "standup"}),
 		"changelog": passThrough([]string{"project", "changelog"}),
+		"report":    passThrough([]string{"project", "report"}),
 	},
 }
 
@@ -53,6 +64,11 @@ Actions:
                Required: workspace.
                Optional: days (default 7), since (ISO date), parent (item ref to scope).
                Use parent=PLAN-N to generate a release-notes view for one plan.
+  report     — Windowed project report: created-vs-completed throughput, net
+               flow, completed-by-collection, current status distribution.
+               Required: workspace.
+               Optional: window (day|week|2wk|month, default week),
+               collections (comma-separated slugs, default all visible).
 
 Use pad_project when an agent needs to summarize progress, plan next work, or
 generate retro / standup / changelog reports.`

--- a/internal/mcp/catalog_readonly_test.go
+++ b/internal/mcp/catalog_readonly_test.go
@@ -95,6 +95,7 @@ func TestReadOnlyCatalog_ActionsMatchCmdhelp(t *testing.T) {
 		{"pad_project", "next"}:      {"project", "next"},
 		{"pad_project", "standup"}:   {"project", "standup"},
 		{"pad_project", "changelog"}: {"project", "changelog"},
+		{"pad_project", "report"}:    {"project", "report"},
 
 		{"pad_role", "list"}:   {"role", "list"},
 		{"pad_role", "create"}: {"role", "create"},
@@ -232,6 +233,7 @@ func TestReadOnlyCatalog_ActionsDispatchExpectedCmdPath(t *testing.T) {
 		{"pad_project", "next"}:      {"project", "next"},
 		{"pad_project", "standup"}:   {"project", "standup"},
 		{"pad_project", "changelog"}: {"project", "changelog"},
+		{"pad_project", "report"}:    {"project", "report"},
 
 		{"pad_role", "list"}:   {"role", "list"},
 		{"pad_role", "create"}: {"role", "create"},
@@ -481,6 +483,14 @@ func liveCmdhelpDoc(t *testing.T) *cmdhelp.Document {
 					"days":      {Type: "int"},
 					"since":     {Type: "string"},
 					"parent":    {Type: "string"},
+				},
+			},
+			"project report": {
+				Summary: "report",
+				Flags: map[string]cmdhelp.Flag{
+					"workspace":   {Type: "string"},
+					"window":      {Type: "string"},
+					"collections": {Type: "string"},
 				},
 			},
 			// Role


### PR DESCRIPTION
## Summary
Exposes the report aggregation (TASK-1630) to agents via CLI and MCP.

## Context
Implements `TASK-1635` under `PLAN-1628`, on the `GET /workspaces/{ws}/report` endpoint.

## What changed
- **CLI** `pad project report` — `--window day|week|2wk|month` (default week), `--collections a,b` (default all visible). Renders a colored summary (totals + net flow, per-bucket throughput, completed-by-collection, status distribution); `--format json` prints the raw payload. Server-computed (fetch + render, like `pad project dashboard`).
- `cli.Client.GetReport` HTTP method.
- **MCP** `pad_project` gains `action: report` (passThrough to `project report`) with `window` + `collections` params. Catalog-readonly test stub + both `expected` maps updated for the new action↔cmdPath binding.

## Test plan
- [x] `go test ./internal/mcp/... ./cmd/...` — green (catalog bijection + dispatch tests pass for `pad_project.report`)
- [x] `make check` — lint + web build + svelte-check, clean