### PR TITLE
feat(web): add Insights sidebar nav link (TASK-1636)

### DIFF
--- a/web/src/lib/components/layout/Sidebar.svelte
+++ b/web/src/lib/components/layout/Sidebar.svelte
@@ -30,6 +30,7 @@
 	let wsPrefix = $derived(wsUsername && wsSlug ? `/${wsUsername}/${wsSlug}` : '');
 	let isGuest = $derived(workspaceStore.current?.is_guest ?? false);
 	let isDashboardPage = $derived(wsPrefix ? page.url.pathname === wsPrefix : false);
+	let isInsightsPage = $derived(wsPrefix ? page.url.pathname === `${wsPrefix}/insights` : false);
 	let isRolesPage = $derived(wsPrefix ? page.url.pathname === `${wsPrefix}/roles` : false);
 	let isActivityPage = $derived(wsPrefix ? page.url.pathname === `${wsPrefix}/activity` : false);
 	let isStarredPage = $derived(wsPrefix ? page.url.pathname === `${wsPrefix}/starred` : false);
@@ -411,6 +412,15 @@
 				>
 					<span class="nav-icon">📊</span>
 					<span class="nav-label">Dashboard</span>
+				</a>
+				<a
+					href="{wsPrefix}/insights"
+					class="nav-item"
+					class:active={isInsightsPage}
+					onclick={() => uiStore.onNavigate()}
+				>
+					<span class="nav-icon">📈</span>
+					<span class="nav-label">Insights</span>
 				</a>
 				<a
 					href="{wsPrefix}/roles"


### PR DESCRIPTION
## Summary
Adds an **"Insights"** nav item to the workspace sidebar, directly under **Dashboard**, routing to `/[username]/[workspace]/insights` (the Reports surface from TASK-1633). Makes the Insights page discoverable.

## Context
Implements `TASK-1636` under `PLAN-1628`, unblocked by TASK-1633 (the page) which just merged. Per owner directive: a sidebar link (not a dashboard widget/CTA), labeled "Insights".

## What changed
- `Sidebar.svelte`: new `isInsightsPage` derived + an Insights nav item (`📈`) between Dashboard and Roles, mirroring the existing pattern. (Guest-gated like the other workspace nav items.)
- `insights` was already added to the sidebar's reserved-slug filter + server `reservedCollectionSlugs` in TASK-1633.

## Test plan
- [x] `make check` — web build + svelte-check, 0 errors