### PR TITLE
feat(insights): per-user layout customization + persistence (TASK-1634)

### DIFF
--- a/internal/models/report_layout.go
+++ b/internal/models/report_layout.go
@@ -1,0 +1,39 @@
+package models
+
+// ReportLayout is a user's personalization of the Insights surface for one
+// workspace (PLAN-1628 / TASK-1634). Stored as the JSON `config` of a
+// user_report_layouts row, one per (user, workspace).
+type ReportLayout struct {
+	// HiddenCards lists the metric-card IDs the user has toggled off. Card IDs
+	// are the stable section identifiers in ReportCardIDs; unknown IDs are
+	// dropped on save. The Totals summary is always shown and not toggleable.
+	HiddenCards []string `json:"hidden_cards"`
+	// DefaultWindow is the window to restore on load (day|week|2wk|month).
+	// Empty means the surface default (week).
+	DefaultWindow string `json:"default_window"`
+	// DefaultCollections is the collection-slug filter to restore on load.
+	// Empty means all collections.
+	DefaultCollections []string `json:"default_collections"`
+}
+
+// ReportCardIDs is the canonical set of toggleable Insights metric cards. The
+// web page gates each section on `!hidden_cards.includes(id)`; the API filters
+// HiddenCards to this set on save so stored config can't drift from the UI.
+var ReportCardIDs = map[string]bool{
+	"throughput":              true,
+	"cycle_time":              true,
+	"wip":                     true,
+	"completed_by_collection": true,
+	"status_distribution":     true,
+}
+
+// ValidReportWindow reports whether w is an accepted report window (empty is
+// allowed and means the surface default).
+func ValidReportWindow(w string) bool {
+	switch w {
+	case "", "day", "week", "2wk", "month":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/server/handlers_reports.go
+++ b/internal/server/handlers_reports.go
@@ -1,9 +1,11 @@
 package server
 
 import (
+	"encoding/json"
 	"net/http"
 	"strings"
 
+	"github.com/PerpetualSoftware/pad/internal/models"
 	"github.com/PerpetualSoftware/pad/internal/store"
 )
 
@@ -85,4 +87,80 @@ func (s *Server) reportVisibleCollections(r *http.Request, workspaceID string) (
 		ids = fullCollIDs
 	}
 	return true, ids, nil
+}
+
+// handleGetReportLayout returns the current user's saved Insights layout for
+// the workspace (PLAN-1628 / TASK-1634), or surface defaults when none/no user.
+//
+//	GET /workspaces/{slug}/report/layout
+func (s *Server) handleGetReportLayout(w http.ResponseWriter, r *http.Request) {
+	workspaceID, ok := s.getWorkspaceID(w, r)
+	if !ok {
+		return
+	}
+	layout := models.ReportLayout{HiddenCards: []string{}, DefaultCollections: []string{}}
+	if user := currentUser(r); user != nil {
+		saved, err := s.store.GetReportLayout(user.ID, workspaceID)
+		if err != nil {
+			writeInternalError(w, err)
+			return
+		}
+		if saved != nil {
+			layout = *saved
+			if layout.HiddenCards == nil {
+				layout.HiddenCards = []string{}
+			}
+			if layout.DefaultCollections == nil {
+				layout.DefaultCollections = []string{}
+			}
+		}
+	}
+	writeJSON(w, http.StatusOK, layout)
+}
+
+// handleSaveReportLayout upserts the current user's Insights layout for the
+// workspace. Per-user; requires an authenticated user.
+//
+//	PUT /workspaces/{slug}/report/layout   (body: models.ReportLayout)
+func (s *Server) handleSaveReportLayout(w http.ResponseWriter, r *http.Request) {
+	workspaceID, ok := s.getWorkspaceID(w, r)
+	if !ok {
+		return
+	}
+	user := currentUser(r)
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, "unauthorized", "Sign in to save your Insights layout")
+		return
+	}
+
+	var layout models.ReportLayout
+	if err := json.NewDecoder(r.Body).Decode(&layout); err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", "Invalid layout JSON")
+		return
+	}
+
+	// Sanitize before persisting: drop an invalid window, and filter
+	// hidden_cards to the known toggleable set (dedup) so stored config can't
+	// drift from the UI's card vocabulary.
+	if !models.ValidReportWindow(layout.DefaultWindow) {
+		layout.DefaultWindow = ""
+	}
+	clean := []string{}
+	seen := map[string]bool{}
+	for _, c := range layout.HiddenCards {
+		if models.ReportCardIDs[c] && !seen[c] {
+			clean = append(clean, c)
+			seen[c] = true
+		}
+	}
+	layout.HiddenCards = clean
+	if layout.DefaultCollections == nil {
+		layout.DefaultCollections = []string{}
+	}
+
+	if err := s.store.SaveReportLayout(user.ID, workspaceID, layout); err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, layout)
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1232,6 +1232,9 @@ func (s *Server) setupRouter() {
 					// Project report — windowed throughput/flow/status
 					// stats (PLAN-1628 / TASK-1630).
 					r.Get("/report", s.handleGetReport)
+					// Per-user Insights layout prefs (PLAN-1628 / TASK-1634).
+					r.Get("/report/layout", s.handleGetReportLayout)
+					r.Put("/report/layout", s.handleSaveReportLayout)
 
 					// Agent bootstrap (PLAN-1377 / TASK-1379) — single
 					// round-trip that returns workspace + user +

--- a/internal/store/migrations/064_user_report_layouts.sql
+++ b/internal/store/migrations/064_user_report_layouts.sql
@@ -1,0 +1,18 @@
+-- Migration 064: per-user Insights/report layout preferences
+-- (PLAN-1628 / TASK-1634).
+--
+-- Stores each user's personalization of the Insights surface, scoped per
+-- workspace: which metric cards are hidden, and the default window + collection
+-- filter to restore on load. One row per (user, workspace) — a single config,
+-- not named layouts (named layouts are a deliberate future scope). config is a
+-- JSON object (models.ReportLayout). Per-workspace SHARED layouts are out of
+-- scope for v1; this is strictly per-user.
+
+CREATE TABLE IF NOT EXISTS user_report_layouts (
+    user_id      TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+    config       TEXT NOT NULL DEFAULT '{}',
+    created_at   TEXT NOT NULL,
+    updated_at   TEXT NOT NULL,
+    PRIMARY KEY (user_id, workspace_id)
+);

--- a/internal/store/pgmigrations/043_user_report_layouts.sql
+++ b/internal/store/pgmigrations/043_user_report_layouts.sql
@@ -1,0 +1,16 @@
+-- Migration 043 (Postgres): per-user Insights/report layout preferences
+-- (PLAN-1628 / TASK-1634). Postgres counterpart to
+-- migrations/064_user_report_layouts.sql.
+--
+-- One row per (user, workspace): hidden cards + default window + default
+-- collection filter, as a JSON object (models.ReportLayout). Per-user only;
+-- per-workspace shared layouts are out of scope for v1.
+
+CREATE TABLE IF NOT EXISTS user_report_layouts (
+    user_id      TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+    config       TEXT NOT NULL DEFAULT '{}',
+    created_at   TEXT NOT NULL,
+    updated_at   TEXT NOT NULL,
+    PRIMARY KEY (user_id, workspace_id)
+);

--- a/internal/store/report_layouts.go
+++ b/internal/store/report_layouts.go
@@ -1,0 +1,59 @@
+package store
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// Per-user Insights/report layout preferences (PLAN-1628 / TASK-1634).
+
+// GetReportLayout returns the user's saved layout for a workspace, or nil when
+// they have none (the caller applies surface defaults).
+func (s *Store) GetReportLayout(userID, workspaceID string) (*models.ReportLayout, error) {
+	var configJSON string
+	err := s.db.QueryRow(s.q(`
+		SELECT config FROM user_report_layouts
+		WHERE user_id = ? AND workspace_id = ?
+	`), userID, workspaceID).Scan(&configJSON)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get report layout: %w", err)
+	}
+	var layout models.ReportLayout
+	if configJSON != "" {
+		if err := json.Unmarshal([]byte(configJSON), &layout); err != nil {
+			// A corrupt stored config shouldn't break the page — treat as
+			// "no layout" and let the caller fall back to defaults.
+			return nil, nil
+		}
+	}
+	return &layout, nil
+}
+
+// SaveReportLayout upserts the user's layout for a workspace. The caller is
+// responsible for sanitizing the layout (see server handler) before saving.
+func (s *Store) SaveReportLayout(userID, workspaceID string, layout models.ReportLayout) error {
+	configJSON, err := json.Marshal(layout)
+	if err != nil {
+		return fmt.Errorf("marshal report layout: %w", err)
+	}
+	ts := now()
+	// ON CONFLICT … DO UPDATE works identically on SQLite and Postgres (same
+	// `excluded` pseudo-table) — see platform_settings.go for precedent.
+	_, err = s.db.Exec(s.q(`
+		INSERT INTO user_report_layouts (user_id, workspace_id, config, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?)
+		ON CONFLICT (user_id, workspace_id) DO UPDATE SET
+			config = excluded.config,
+			updated_at = excluded.updated_at
+	`), userID, workspaceID, string(configJSON), ts, ts)
+	if err != nil {
+		return fmt.Errorf("save report layout: %w", err)
+	}
+	return nil
+}

--- a/internal/store/report_layouts_test.go
+++ b/internal/store/report_layouts_test.go
@@ -1,0 +1,84 @@
+package store
+
+import (
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+func TestReportLayout_SaveGetUpsert(t *testing.T) {
+	s := testStore(t)
+	u, err := s.CreateUser(models.UserCreate{Name: "Lay", Email: "lay@example.com"})
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	ws, err := s.CreateWorkspace(models.WorkspaceCreate{Name: "L", Slug: "l", OwnerID: u.ID})
+	if err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+
+	// No layout yet → nil.
+	got, err := s.GetReportLayout(u.ID, ws.ID)
+	if err != nil {
+		t.Fatalf("get (empty): %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected nil layout before save, got %+v", got)
+	}
+
+	// Save.
+	in := models.ReportLayout{
+		HiddenCards:        []string{"wip", "status_distribution"},
+		DefaultWindow:      "month",
+		DefaultCollections: []string{"tasks"},
+	}
+	if err := s.SaveReportLayout(u.ID, ws.ID, in); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	got, err = s.GetReportLayout(u.ID, ws.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got == nil || got.DefaultWindow != "month" || len(got.HiddenCards) != 2 || len(got.DefaultCollections) != 1 {
+		t.Fatalf("round-trip mismatch: %+v", got)
+	}
+
+	// Upsert: second save replaces, doesn't duplicate.
+	in2 := models.ReportLayout{HiddenCards: []string{}, DefaultWindow: "week", DefaultCollections: []string{}}
+	if err := s.SaveReportLayout(u.ID, ws.ID, in2); err != nil {
+		t.Fatalf("save 2: %v", err)
+	}
+	got, err = s.GetReportLayout(u.ID, ws.ID)
+	if err != nil {
+		t.Fatalf("get 2: %v", err)
+	}
+	if got.DefaultWindow != "week" || len(got.HiddenCards) != 0 {
+		t.Fatalf("upsert didn't replace: %+v", got)
+	}
+	var count int
+	if err := s.db.QueryRow(s.q(`SELECT COUNT(*) FROM user_report_layouts WHERE user_id = ? AND workspace_id = ?`), u.ID, ws.ID).Scan(&count); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("expected exactly 1 row after upsert, got %d", count)
+	}
+}
+
+func TestReportLayout_IsolatedPerUserAndWorkspace(t *testing.T) {
+	s := testStore(t)
+	a, _ := s.CreateUser(models.UserCreate{Name: "A", Email: "a@example.com"})
+	b, _ := s.CreateUser(models.UserCreate{Name: "B", Email: "b@example.com"})
+	ws, _ := s.CreateWorkspace(models.WorkspaceCreate{Name: "W", Slug: "w", OwnerID: a.ID})
+
+	if err := s.SaveReportLayout(a.ID, ws.ID, models.ReportLayout{DefaultWindow: "day"}); err != nil {
+		t.Fatalf("save a: %v", err)
+	}
+	// B has no layout in the same workspace.
+	got, err := s.GetReportLayout(b.ID, ws.ID)
+	if err != nil {
+		t.Fatalf("get b: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("user B should have no layout, got %+v", got)
+	}
+}

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -20,6 +20,7 @@ import type {
 	Version,
 	DashboardResponse,
 	ReportData,
+	ReportLayout,
 	ReportWindow,
 	SearchResponse,
 	SearchFilters,
@@ -941,7 +942,17 @@ export const api = {
 			if (opts?.collections?.length) params.set('collections', opts.collections.join(','));
 			const qs = params.toString();
 			return request<ReportData>(`/workspaces/${ws}/report${qs ? `?${qs}` : ''}`);
-		}
+		},
+
+		/** The current user's saved Insights layout for the workspace. */
+		getLayout: (ws: string) => request<ReportLayout>(`/workspaces/${ws}/report/layout`),
+
+		/** Persist the current user's Insights layout (per-user, per-workspace). */
+		saveLayout: (ws: string, layout: ReportLayout) =>
+			request<ReportLayout>(`/workspaces/${ws}/report/layout`, {
+				method: 'PUT',
+				body: JSON.stringify(layout)
+			})
 	},
 
 	// ── Incremental Sync ─────────────────────────────────────────────────────

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -896,6 +896,18 @@ export interface ReportData {
 	wip: ReportWIP;
 }
 
+/**
+ * Per-user Insights personalization for one workspace (PLAN-1628 / TASK-1634).
+ * hidden_cards lists toggled-off metric-card IDs:
+ * 'throughput' | 'cycle_time' | 'wip' | 'completed_by_collection' | 'status_distribution'.
+ * default_window/default_collections restore the view on load (empty = surface defaults / all).
+ */
+export interface ReportLayout {
+	hidden_cards: string[];
+	default_window: ReportWindow | '';
+	default_collections: string[];
+}
+
 // ─── Incremental Sync ────────────────────────────────────────────────────────
 
 export interface ChangesResponse {

--- a/web/src/routes/[username]/[workspace]/insights/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/insights/+page.svelte
@@ -1,12 +1,13 @@
 <script lang="ts">
 	import { page } from '$app/state';
 	import { onMount } from 'svelte';
+	import { SvelteSet } from 'svelte/reactivity';
 	import { api } from '$lib/api/client';
 	import { workspaceStore } from '$lib/stores/workspace.svelte';
 	import { titleStore } from '$lib/stores/title.svelte';
 	import BarChart from '$lib/components/charts/BarChart.svelte';
 	import type { ChartDatum } from '$lib/components/charts/theme';
-	import type { Collection, ReportData, ReportWindow } from '$lib/types';
+	import type { Collection, ReportData, ReportLayout, ReportWindow } from '$lib/types';
 
 	let wsSlug = $derived(page.params.workspace ?? '');
 
@@ -32,11 +33,36 @@
 	// its result and discard stale/out-of-order older responses.
 	let reqSeq = 0;
 
+	// ── Per-user layout (TASK-1634) ────────────────────────────────────────────
+	// Hidden metric-card IDs (stable). The Totals summary is always shown.
+	// SvelteSet is reactive on its own (.has()/.add()/.delete()/.clear()), so it
+	// needs no $state wrapper and is mutated in place rather than reassigned.
+	const hiddenCards = new SvelteSet<string>();
+	// Customize panel visibility.
+	let showCustomize = $state(false);
+	// True once THIS workspace's layout has hydrated. Gates the debounced
+	// auto-save so we never (a) save during the initial hydrate or (b) overwrite
+	// workspace B's layout with A's values before B's layout has loaded. Plain
+	// `let` (non-reactive): the save effect must not write reactive state that
+	// would re-trigger itself.
+	let hydrated = false;
+	// Debounce timer for auto-save. Plain `let` so it doesn't create reactivity.
+	let saveTimer: ReturnType<typeof setTimeout> | null = null;
+
 	const WINDOW_OPTIONS: { value: ReportWindow; label: string }[] = [
 		{ value: 'day', label: 'Day' },
 		{ value: 'week', label: 'Week' },
 		{ value: '2wk', label: '2 Weeks' },
 		{ value: 'month', label: 'Month' }
+	];
+
+	// Toggleable cards, in render order. The Totals summary is intentionally absent.
+	const CARD_OPTIONS: { id: string; label: string }[] = [
+		{ id: 'throughput', label: 'Throughput' },
+		{ id: 'cycle_time', label: 'Cycle time' },
+		{ id: 'wip', label: 'Work in progress' },
+		{ id: 'completed_by_collection', label: 'Completed by collection' },
+		{ id: 'status_distribution', label: 'Status distribution' }
 	];
 
 	onMount(() => {
@@ -50,10 +76,11 @@
 		titleStore.setPageTitle({ section: 'Insights', item: null });
 	});
 
-	// Load collections (for the filter) once per workspace.
+	// Load collections (for the filter) and the per-user layout once per workspace.
 	$effect(() => {
 		if (wsSlug) {
 			loadCollections(wsSlug);
+			loadLayout(wsSlug);
 		}
 	});
 
@@ -74,6 +101,11 @@
 			// linger under B's URL while B loads — the `loading` state covers the gap.
 			report = null;
 			collections = [];
+			// Reset layout state for the new workspace and gate auto-save until
+			// THIS workspace's layout hydrates (loadLayout flips `hydrated` true),
+			// so we don't persist A's values onto B.
+			hiddenCards.clear();
+			hydrated = false;
 		}
 		const colls = [...selectedCollections];
 		if (slug) {
@@ -86,6 +118,27 @@
 			collections = await api.collections.list(slug);
 		} catch {
 			// Filter is a progressive enhancement; allow the page to render.
+		}
+	}
+
+	async function loadLayout(slug: string) {
+		try {
+			const layout = await api.report.getLayout(slug);
+			// Ignore a stale response if the workspace changed mid-flight.
+			if (slug !== wsSlug) return;
+			selectedWindow = layout.default_window || 'week';
+			selectedCollections = layout.default_collections ?? [];
+			hiddenCards.clear();
+			for (const id of layout.hidden_cards) hiddenCards.add(id);
+		} catch {
+			// No saved layout (or it failed to load): fall back to defaults.
+		} finally {
+			// Mark this workspace hydrated so the auto-save effect may persist
+			// subsequent user changes. Guard on the slug so a stale layout
+			// response from workspace A can't un-gate saves for workspace B.
+			if (slug === wsSlug) {
+				hydrated = true;
+			}
 		}
 	}
 
@@ -112,6 +165,40 @@
 		}
 	}
 
+	// Debounced per-user layout auto-save. Reads hiddenCards / selectedWindow /
+	// selectedCollections so any change re-runs this effect, then debounces ~500ms
+	// before persisting. Skips entirely until the current workspace has hydrated,
+	// so we neither save during the initial load nor stomp B's layout with A's.
+	$effect(() => {
+		// Read every dependency up front so the effect subscribes to all of them
+		// regardless of the hydrated gate below.
+		const cards = [...hiddenCards];
+		const win = selectedWindow;
+		const colls = [...selectedCollections];
+		const slug = wsSlug;
+		if (!hydrated || !slug) return;
+
+		if (saveTimer) clearTimeout(saveTimer);
+		saveTimer = setTimeout(() => {
+			saveTimer = null;
+			const layout: ReportLayout = {
+				hidden_cards: cards,
+				default_window: win,
+				default_collections: colls
+			};
+			void api.report.saveLayout(slug, layout).catch(() => {
+				// Best-effort persistence; a failed save shouldn't disrupt the page.
+			});
+		}, 500);
+
+		return () => {
+			if (saveTimer) {
+				clearTimeout(saveTimer);
+				saveTimer = null;
+			}
+		};
+	});
+
 	function toggleCollection(slug: string) {
 		if (selectedCollections.includes(slug)) {
 			selectedCollections = selectedCollections.filter((s) => s !== slug);
@@ -122,6 +209,15 @@
 
 	function clearCollectionFilter() {
 		selectedCollections = [];
+	}
+
+	// Toggle a card's visibility. SvelteSet makes the in-place mutation reactive.
+	function toggleCard(id: string) {
+		if (hiddenCards.has(id)) {
+			hiddenCards.delete(id);
+		} else {
+			hiddenCards.add(id);
+		}
 	}
 
 	// ── Formatters ───────────────────────────────────────────────────────────
@@ -208,18 +304,47 @@
 			{/if}
 		</div>
 
-		<div class="window-control" role="group" aria-label="Time window">
-			{#each WINDOW_OPTIONS as opt (opt.value)}
+		<div class="header-controls">
+			<div class="window-control" role="group" aria-label="Time window">
+				{#each WINDOW_OPTIONS as opt (opt.value)}
+					<button
+						type="button"
+						class="window-btn"
+						class:active={selectedWindow === opt.value}
+						aria-pressed={selectedWindow === opt.value}
+						onclick={() => (selectedWindow = opt.value)}
+					>
+						{opt.label}
+					</button>
+				{/each}
+			</div>
+
+			<div class="customize">
 				<button
 					type="button"
-					class="window-btn"
-					class:active={selectedWindow === opt.value}
-					aria-pressed={selectedWindow === opt.value}
-					onclick={() => (selectedWindow = opt.value)}
+					class="customize-btn"
+					class:active={showCustomize}
+					aria-expanded={showCustomize}
+					onclick={() => (showCustomize = !showCustomize)}
 				>
-					{opt.label}
+					Customize
 				</button>
-			{/each}
+				{#if showCustomize}
+					<div class="customize-panel" role="group" aria-label="Visible cards">
+						<p class="customize-title">Visible cards</p>
+						{#each CARD_OPTIONS as card (card.id)}
+							<label class="customize-row">
+								<input
+									type="checkbox"
+									checked={!hiddenCards.has(card.id)}
+									onchange={() => toggleCard(card.id)}
+								/>
+								{card.label}
+							</label>
+						{/each}
+					</div>
+				{/if}
+			</div>
 		</div>
 	</header>
 
@@ -258,7 +383,7 @@
 		<div class="loading-state">Loading&hellip;</div>
 	{:else if report}
 		<div class="content" class:dimmed={loading}>
-			<!-- ── Totals ──────────────────────────────────────────────── -->
+			<!-- Totals (always shown) -->
 			<section class="stat-row">
 				<div class="stat-card">
 					<span class="stat-label">Created</span>
@@ -276,160 +401,172 @@
 				</div>
 			</section>
 
-			<!-- ── Throughput ──────────────────────────────────────────── -->
-			<section class="card">
-				<div class="card-header">
-					<h2>Throughput</h2>
-					<span class="card-sub">Created vs completed per {report.granularity}</span>
-				</div>
-				{#if noActivity}
-					<div class="card-empty">No activity in this window.</div>
-				{:else}
-					<BarChart
-						data={throughputData}
-						x="bucket"
-						series={throughputSeries}
-						height={260}
-						ariaLabel="Items created versus completed per time bucket"
-					/>
-				{/if}
-			</section>
-
-			<div class="grid">
-				<!-- ── Cycle time ──────────────────────────────────────── -->
+			<!-- Throughput -->
+			{#if !hiddenCards.has('throughput')}
 				<section class="card">
 					<div class="card-header">
-						<h2>Cycle time</h2>
-						<span class="card-sub">Creation to completion</span>
+						<h2>Throughput</h2>
+						<span class="card-sub">Created vs completed per {report.granularity}</span>
 					</div>
-					{#if report.cycle_time.sample_size === 0}
-						<div class="card-empty">No completions in this window.</div>
+					{#if noActivity}
+						<div class="card-empty">No activity in this window.</div>
 					{:else}
-						<div class="metric-row">
-							<div class="metric">
-								<span class="metric-label">Median</span>
-								<span class="metric-value">{fmtHours(report.cycle_time.median_hours)}</span>
-							</div>
-							<div class="metric">
-								<span class="metric-label">p90</span>
-								<span class="metric-value">{fmtHours(report.cycle_time.p90_hours)}</span>
-							</div>
-							<div class="metric">
-								<span class="metric-label">Sample</span>
-								<span class="metric-value">{report.cycle_time.sample_size}</span>
-							</div>
-						</div>
-						{#if report.cycle_time.by_collection.length > 0}
-							<ul class="dist-list">
-								{#each report.cycle_time.by_collection as row (row.collection)}
-									<li class="dist-row">
-										<span class="dist-name">{collLabel(row.collection)}</span>
-										<span class="dist-meta">
-											<span class="dist-count">{row.count}</span>
-											<span class="dist-val">{fmtHours(row.median_hours)}</span>
-										</span>
-									</li>
-								{/each}
-							</ul>
-						{/if}
-					{/if}
-				</section>
-
-				<!-- ── Work in progress ────────────────────────────────── -->
-				<section class="card">
-					<div class="card-header">
-						<h2>Work in progress</h2>
-						<span class="card-sub">Open items right now</span>
-					</div>
-					{#if report.wip.open_count === 0}
-						<div class="card-empty">No open items.</div>
-					{:else}
-						<div class="metric-row">
-							<div class="metric">
-								<span class="metric-label">Open</span>
-								<span class="metric-value">{report.wip.open_count}</span>
-							</div>
-							<div class="metric">
-								<span class="metric-label">Median age</span>
-								<span class="metric-value">{fmtHours(report.wip.median_age_hours)}</span>
-							</div>
-						</div>
 						<BarChart
-							data={agingData}
-							x="label"
-							series={[{ key: 'count', label: 'Open items', color: 'var(--chart-3, #f59e0b)' }]}
-							height={180}
-							ariaLabel="Open items by age bucket"
+							data={throughputData}
+							x="bucket"
+							series={throughputSeries}
+							height={260}
+							ariaLabel="Items created versus completed per time bucket"
 						/>
-						{#if report.wip.by_collection.length > 0}
-							<ul class="dist-list">
-								{#each report.wip.by_collection as row (row.collection)}
-									<li class="dist-row">
-										<span class="dist-name">{collLabel(row.collection)}</span>
-										<span class="dist-meta">
-											<span class="dist-count">{row.count}</span>
-											<span class="dist-val">{fmtHours(row.median_hours)}</span>
-										</span>
-									</li>
-								{/each}
-							</ul>
-						{/if}
 					{/if}
 				</section>
-			</div>
+			{/if}
 
-			<!-- ── Completed by collection ─────────────────────────────── -->
-			<section class="card">
-				<div class="card-header">
-					<h2>Completed by collection</h2>
-				</div>
-				{#if completedByCollectionData.length === 0}
-					<div class="card-empty">Nothing completed in this window.</div>
-				{:else}
-					<BarChart
-						data={completedByCollectionData}
-						x="collection"
-						series={[{ key: 'count', label: 'Completed', color: 'var(--chart-4, #10b981)' }]}
-						height={220}
-						ariaLabel="Completed items grouped by collection"
-					/>
-				{/if}
-			</section>
-
-			<!-- ── Status distribution ─────────────────────────────────── -->
-			<section class="card">
-				<div class="card-header">
-					<h2>Status distribution</h2>
-				</div>
-				{#if statusByCollection.length === 0}
-					<div class="card-empty">No items to show.</div>
-				{:else}
-					<div class="status-groups">
-						{#each statusByCollection as group (group.collection)}
-							<div class="status-group">
-								<div class="status-group-head">
-									<span class="status-group-name">{collLabel(group.collection)}</span>
-									<span class="status-group-total">{group.total}</span>
-								</div>
-								<div class="status-bars">
-									{#each group.rows as row (row.status)}
-										<div class="status-bar-row">
-											<span class="status-name">{row.status}</span>
-											<span class="status-track">
-												<span
-													class="status-fill"
-													style:width={`${group.total > 0 ? (row.count / group.total) * 100 : 0}%`}
-												></span>
-											</span>
-											<span class="status-count">{row.count}</span>
-										</div>
-									{/each}
-								</div>
+			{#if !hiddenCards.has('cycle_time') || !hiddenCards.has('wip')}
+				<div class="grid">
+					<!-- Cycle time -->
+					{#if !hiddenCards.has('cycle_time')}
+						<section class="card">
+							<div class="card-header">
+								<h2>Cycle time</h2>
+								<span class="card-sub">Creation to completion</span>
 							</div>
-						{/each}
+							{#if report.cycle_time.sample_size === 0}
+								<div class="card-empty">No completions in this window.</div>
+							{:else}
+								<div class="metric-row">
+									<div class="metric">
+										<span class="metric-label">Median</span>
+										<span class="metric-value">{fmtHours(report.cycle_time.median_hours)}</span>
+									</div>
+									<div class="metric">
+										<span class="metric-label">p90</span>
+										<span class="metric-value">{fmtHours(report.cycle_time.p90_hours)}</span>
+									</div>
+									<div class="metric">
+										<span class="metric-label">Sample</span>
+										<span class="metric-value">{report.cycle_time.sample_size}</span>
+									</div>
+								</div>
+								{#if report.cycle_time.by_collection.length > 0}
+									<ul class="dist-list">
+										{#each report.cycle_time.by_collection as row (row.collection)}
+											<li class="dist-row">
+												<span class="dist-name">{collLabel(row.collection)}</span>
+												<span class="dist-meta">
+													<span class="dist-count">{row.count}</span>
+													<span class="dist-val">{fmtHours(row.median_hours)}</span>
+												</span>
+											</li>
+										{/each}
+									</ul>
+								{/if}
+							{/if}
+						</section>
+					{/if}
+
+					<!-- Work in progress -->
+					{#if !hiddenCards.has('wip')}
+						<section class="card">
+							<div class="card-header">
+								<h2>Work in progress</h2>
+								<span class="card-sub">Open items right now</span>
+							</div>
+							{#if report.wip.open_count === 0}
+								<div class="card-empty">No open items.</div>
+							{:else}
+								<div class="metric-row">
+									<div class="metric">
+										<span class="metric-label">Open</span>
+										<span class="metric-value">{report.wip.open_count}</span>
+									</div>
+									<div class="metric">
+										<span class="metric-label">Median age</span>
+										<span class="metric-value">{fmtHours(report.wip.median_age_hours)}</span>
+									</div>
+								</div>
+								<BarChart
+									data={agingData}
+									x="label"
+									series={[{ key: 'count', label: 'Open items', color: 'var(--chart-3, #f59e0b)' }]}
+									height={180}
+									ariaLabel="Open items by age bucket"
+								/>
+								{#if report.wip.by_collection.length > 0}
+									<ul class="dist-list">
+										{#each report.wip.by_collection as row (row.collection)}
+											<li class="dist-row">
+												<span class="dist-name">{collLabel(row.collection)}</span>
+												<span class="dist-meta">
+													<span class="dist-count">{row.count}</span>
+													<span class="dist-val">{fmtHours(row.median_hours)}</span>
+												</span>
+											</li>
+										{/each}
+									</ul>
+								{/if}
+							{/if}
+						</section>
+					{/if}
+				</div>
+			{/if}
+
+			<!-- Completed by collection -->
+			{#if !hiddenCards.has('completed_by_collection')}
+				<section class="card">
+					<div class="card-header">
+						<h2>Completed by collection</h2>
 					</div>
-				{/if}
-			</section>
+					{#if completedByCollectionData.length === 0}
+						<div class="card-empty">Nothing completed in this window.</div>
+					{:else}
+						<BarChart
+							data={completedByCollectionData}
+							x="collection"
+							series={[{ key: 'count', label: 'Completed', color: 'var(--chart-4, #10b981)' }]}
+							height={220}
+							ariaLabel="Completed items grouped by collection"
+						/>
+					{/if}
+				</section>
+			{/if}
+
+			<!-- Status distribution -->
+			{#if !hiddenCards.has('status_distribution')}
+				<section class="card">
+					<div class="card-header">
+						<h2>Status distribution</h2>
+					</div>
+					{#if statusByCollection.length === 0}
+						<div class="card-empty">No items to show.</div>
+					{:else}
+						<div class="status-groups">
+							{#each statusByCollection as group (group.collection)}
+								<div class="status-group">
+									<div class="status-group-head">
+										<span class="status-group-name">{collLabel(group.collection)}</span>
+										<span class="status-group-total">{group.total}</span>
+									</div>
+									<div class="status-bars">
+										{#each group.rows as row (row.status)}
+											<div class="status-bar-row">
+												<span class="status-name">{row.status}</span>
+												<span class="status-track">
+													<span
+														class="status-fill"
+														style:width={`${group.total > 0 ? (row.count / group.total) * 100 : 0}%`}
+													></span>
+												</span>
+												<span class="status-count">{row.count}</span>
+											</div>
+										{/each}
+									</div>
+								</div>
+							{/each}
+						</div>
+					{/if}
+				</section>
+			{/if}
 		</div>
 	{/if}
 </div>
@@ -464,6 +601,12 @@
 		font-size: 0.9em;
 		color: var(--text-muted);
 	}
+	.header-controls {
+		display: flex;
+		align-items: center;
+		gap: var(--space-3);
+		flex-wrap: wrap;
+	}
 
 	/* ── Window segmented control ─────────────────────────────────────── */
 	.window-control {
@@ -493,6 +636,66 @@
 		background: var(--bg-primary, var(--bg));
 		color: var(--text-primary);
 		box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+	}
+
+	/* ── Customize ────────────────────────────────────────────────────── */
+	.customize {
+		position: relative;
+	}
+	.customize-btn {
+		background: var(--bg-secondary);
+		color: var(--text-secondary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+		padding: var(--space-2) var(--space-3);
+		font-size: 0.8em;
+		font-weight: 600;
+		cursor: pointer;
+		white-space: nowrap;
+		transition: background 0.15s, border-color 0.15s, color 0.15s;
+	}
+	.customize-btn:hover {
+		border-color: var(--text-muted);
+		color: var(--text-primary);
+	}
+	.customize-btn.active {
+		border-color: var(--accent-blue);
+		color: var(--accent-blue);
+	}
+	.customize-panel {
+		position: absolute;
+		right: 0;
+		top: calc(100% + var(--space-2));
+		z-index: 20;
+		min-width: 220px;
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-1);
+		padding: var(--space-3);
+		background: var(--bg-primary, var(--bg));
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+		box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+	}
+	.customize-title {
+		font-size: 0.7em;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.06em;
+		color: var(--text-muted);
+		margin-bottom: var(--space-1);
+	}
+	.customize-row {
+		display: flex;
+		align-items: center;
+		gap: var(--space-2);
+		font-size: 0.85em;
+		color: var(--text-secondary);
+		cursor: pointer;
+		padding: var(--space-1) 0;
+	}
+	.customize-row input {
+		cursor: pointer;
 	}
 
 	/* ── Collection filter chips ──────────────────────────────────────── */

--- a/web/src/routes/[username]/[workspace]/insights/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/insights/+page.svelte
@@ -40,13 +40,12 @@
 	const hiddenCards = new SvelteSet<string>();
 	// Customize panel visibility.
 	let showCustomize = $state(false);
-	// True once THIS workspace's layout has hydrated. Gates the debounced
-	// auto-save so we never (a) save during the initial hydrate or (b) overwrite
-	// workspace B's layout with A's values before B's layout has loaded. Plain
-	// `let` (non-reactive): the save effect must not write reactive state that
-	// would re-trigger itself.
+	// True once THIS workspace's layout has hydrated. Gates scheduleSave() so we
+	// never (a) save during the initial hydrate or (b) overwrite workspace B's
+	// layout with A's values before B's layout has loaded. Plain `let`
+	// (non-reactive) — it's read by the explicit-action save path, not an effect.
 	let hydrated = false;
-	// Debounce timer for auto-save. Plain `let` so it doesn't create reactivity.
+	// Debounce timer for the save path. Plain `let` so it doesn't create reactivity.
 	let saveTimer: ReturnType<typeof setTimeout> | null = null;
 
 	const WINDOW_OPTIONS: { value: ReportWindow; label: string }[] = [
@@ -101,7 +100,7 @@
 			// linger under B's URL while B loads — the `loading` state covers the gap.
 			report = null;
 			collections = [];
-			// Reset layout state for the new workspace and gate auto-save until
+			// Reset layout state for the new workspace and gate the save path until
 			// THIS workspace's layout hydrates (loadLayout flips `hydrated` true),
 			// so we don't persist A's values onto B.
 			hiddenCards.clear();
@@ -133,9 +132,10 @@
 		} catch {
 			// No saved layout (or it failed to load): fall back to defaults.
 		} finally {
-			// Mark this workspace hydrated so the auto-save effect may persist
-			// subsequent user changes. Guard on the slug so a stale layout
-			// response from workspace A can't un-gate saves for workspace B.
+			// Mark this workspace hydrated so scheduleSave() may persist subsequent
+			// user changes. Guard on the slug so a stale layout response from
+			// workspace A can't un-gate saves for workspace B. Hydration itself
+			// never calls scheduleSave, so this assignment triggers no PUT.
 			if (slug === wsSlug) {
 				hydrated = true;
 			}
@@ -165,39 +165,36 @@
 		}
 	}
 
-	// Debounced per-user layout auto-save. Reads hiddenCards / selectedWindow /
-	// selectedCollections so any change re-runs this effect, then debounces ~500ms
-	// before persisting. Skips entirely until the current workspace has hydrated,
-	// so we neither save during the initial load nor stomp B's layout with A's.
-	$effect(() => {
-		// Read every dependency up front so the effect subscribes to all of them
-		// regardless of the hydrated gate below.
-		const cards = [...hiddenCards];
-		const win = selectedWindow;
-		const colls = [...selectedCollections];
+	// Debounced per-user layout save. Called ONLY from explicit user-change
+	// handlers (never a reactive effect), so merely viewing Insights — or
+	// switching workspaces, which re-hydrates — issues no PUT. That matters on
+	// fresh-install / legacy-token sessions where an unsolicited PUT would 401
+	// and bounce the viewer to /login. Reads the live values at fire time.
+	function scheduleSave() {
+		if (!hydrated || !wsSlug) return;
+		// Capture the workspace at schedule time; if the user switches workspaces
+		// during the debounce, drop the pending save so workspace A's edit can't
+		// land on workspace B.
 		const slug = wsSlug;
-		if (!hydrated || !slug) return;
-
 		if (saveTimer) clearTimeout(saveTimer);
 		saveTimer = setTimeout(() => {
 			saveTimer = null;
+			if (slug !== wsSlug) return;
 			const layout: ReportLayout = {
-				hidden_cards: cards,
-				default_window: win,
-				default_collections: colls
+				hidden_cards: [...hiddenCards],
+				default_window: selectedWindow,
+				default_collections: selectedCollections
 			};
 			void api.report.saveLayout(slug, layout).catch(() => {
 				// Best-effort persistence; a failed save shouldn't disrupt the page.
 			});
 		}, 500);
+	}
 
-		return () => {
-			if (saveTimer) {
-				clearTimeout(saveTimer);
-				saveTimer = null;
-			}
-		};
-	});
+	function selectWindow(win: ReportWindow) {
+		selectedWindow = win;
+		scheduleSave();
+	}
 
 	function toggleCollection(slug: string) {
 		if (selectedCollections.includes(slug)) {
@@ -205,10 +202,12 @@
 		} else {
 			selectedCollections = [...selectedCollections, slug];
 		}
+		scheduleSave();
 	}
 
 	function clearCollectionFilter() {
 		selectedCollections = [];
+		scheduleSave();
 	}
 
 	// Toggle a card's visibility. SvelteSet makes the in-place mutation reactive.
@@ -218,6 +217,7 @@
 		} else {
 			hiddenCards.add(id);
 		}
+		scheduleSave();
 	}
 
 	// ── Formatters ───────────────────────────────────────────────────────────
@@ -312,7 +312,7 @@
 						class="window-btn"
 						class:active={selectedWindow === opt.value}
 						aria-pressed={selectedWindow === opt.value}
-						onclick={() => (selectedWindow = opt.value)}
+						onclick={() => selectWindow(opt.value)}
 					>
 						{opt.label}
 					</button>


### PR DESCRIPTION
## Summary
Adds per-user customization to the Insights surface (PLAN-1628), persisted server-side per (user, workspace): toggle which metric cards show, and remember the window + collection filter across sessions/devices.

## Context
Implements `TASK-1634` under `PLAN-1628` — the last task. Single config per user (no named/multiple layouts — deliberate v1 scope, per owner).

## Backend
- **migrations 064 (SQLite) / 043 (Postgres)**: `user_report_layouts` (`user_id`, `workspace_id`, `config` JSON, `PK(user_id, workspace_id)`, `ON DELETE CASCADE`).
- `models.ReportLayout` (`hidden_cards` / `default_window` / `default_collections`) + `ReportCardIDs` / `ValidReportWindow`.
- `store.GetReportLayout` / `SaveReportLayout` — dual-dialect `ON CONFLICT … DO UPDATE` upsert (platform_settings precedent).
- `GET`/`PUT /workspaces/{ws}/report/layout` — per-user (requires auth on PUT); PUT drops an invalid window and filters `hidden_cards` to the known card set. Web client + TS type added.

## Frontend (Insights page)
- Loads the saved layout and hydrates window/collections/hidden cards on entry.
- "Customize" panel toggles each card (`SvelteSet`-backed); each section gated on `!hiddenCards.has(id)`; Totals always shown.
- Debounced auto-save gated on a per-workspace `hydrated` flag — never saves during initial load, and a workspace switch can't stomp another workspace's layout (slug-guarded hydrate + captured-value debounce). Report fetch's request-seq guard untouched.

## Test plan
- [x] `go test ./internal/store ./internal/server` — green (layout round-trip, upsert-not-duplicate, per-user/-workspace isolation)
- [x] `make check` — Go lint + **web build** + svelte-check, 0 errors (build explicitly re-run after the async race earlier in dev)
- [x] Svelte MCP autofixer clean