### PR TITLE
chore(deps,docs): bump x/image v0.41.0 + sync seed ship-playbook codex guidance

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/trustelem/zxcvbn v1.0.1
 	go.yaml.in/yaml/v4 v4.0.0-rc.4
 	golang.org/x/crypto v0.51.0
-	golang.org/x/image v0.39.0
+	golang.org/x/image v0.41.0
 	golang.org/x/term v0.43.0
 	golang.org/x/text v0.37.0
 	golang.org/x/time v0.15.0

--- a/go.sum
+++ b/go.sum
@@ -601,8 +601,8 @@ golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMk
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/image v0.0.0-20191009234506-e7c1f5e7dbb8/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
-golang.org/x/image v0.39.0 h1:skVYidAEVKgn8lZ602XO75asgXBgLj9G/FE3RbuPFww=
-golang.org/x/image v0.39.0/go.mod h1:sIbmppfU+xFLPIG0FoVUTvyBMmgng1/XAMhQ2ft0hpA=
+golang.org/x/image v0.41.0 h1:8wS72eGJMJaBxK6okTzd4WaXumUlTVlb753MlsSvTCo=
+golang.org/x/image v0.41.0/go.mod h1:uIc348UZMSvS5Z65CVZ7iDPaNobNFEPeJ4kbqTOszmA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190301231843-5614ed5bae6f/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/internal/collections/templates_startup_ship.go
+++ b/internal/collections/templates_startup_ship.go
@@ -155,7 +155,9 @@ This is the core of the workflow — request an automated review, address every
 finding, push, re-review, exit when the reviewer returns zero findings (or the
 safety cap trips).
 
-The example below uses Codex CLI (` + "`codex exec -s read-only -o <file> < /dev/null`" + `).
+The example below uses Codex CLI (` + "`codex exec -s read-only -o <file> \"<review prompt>\" < /dev/null`" + `).
+Pass the prompt as a positional argument — ` + "`codex exec`" + ` reads it from stdin
+when none is given, so with ` + "`< /dev/null`" + ` an arg-less command reviews nothing.
 **Swap for your review tool of choice** — Gemini, ` + "`claude review`" + `, a GitHub bot,
 whatever you have. The loop shape (synchronous review → address findings →
 push → re-review) is the part worth keeping.

--- a/internal/collections/templates_startup_ship.go
+++ b/internal/collections/templates_startup_ship.go
@@ -155,10 +155,16 @@ This is the core of the workflow — request an automated review, address every
 finding, push, re-review, exit when the reviewer returns zero findings (or the
 safety cap trips).
 
-The example below uses Codex CLI (` + "`codex exec -s read-only --full-auto -o <file>`" + `).
+The example below uses Codex CLI (` + "`codex exec -s read-only -o <file> < /dev/null`" + `).
 **Swap for your review tool of choice** — Gemini, ` + "`claude review`" + `, a GitHub bot,
 whatever you have. The loop shape (synchronous review → address findings →
 push → re-review) is the part worth keeping.
+
+**If you use ` + "`codex exec`" + `: always redirect stdin from ` + "`/dev/null`" + `.** It reads
+extra input from stdin and hangs with zero output when stdin stays open (piped
+or backgrounded) — which looks exactly like a prompt-length wedge but is NOT
+fixed by a leaner prompt; only closing stdin fixes it. (The deprecated
+` + "`--full-auto`" + ` flag has been dropped; ` + "`-s read-only`" + ` is sufficient.)
 
 ` + "```" + `
 iteration = 0
@@ -199,12 +205,15 @@ doesn't keep flagging it.
 
 **Review prompt size matters.** Verbose prompts (focus areas, max-finding
 caps, severity-format directives) can wedge some review CLIs. Keep it lean
-— the shortest possible ask is the most reliable.
+— the shortest possible ask is the most reliable. (With ` + "`codex exec`" + `, rule
+out open stdin FIRST — see above — since that produces the identical
+zero-output symptom and isn't fixed by shortening the prompt.)
 
 **Safety exits:**
 - ` + "`iteration >= 5`" + ` — cap reached. Report remaining findings to the user.
-- Review CLI fails or wedges twice on the lean prompt — the tool itself is
-  broken. Report and ask.
+- Review CLI fails or wedges twice on the lean prompt (for ` + "`codex exec`" + `,
+  after confirming stdin is closed with ` + "`< /dev/null`" + `) — the tool itself
+  is broken. Report and ask.
 
 ### 10. Merge
 


### PR DESCRIPTION
## Summary
Unblocks the Insights-tweaks ship batch and completes the codex-guidance sync.

- **`golang.org/x/image` v0.39.0 → v0.41.0** — clears the freshly-published GO-2026-5031/5032 (reachable via attachment image decode); `make check`'s `vuln` gate was failing for every task. `go mod tidy`; `govulncheck` clean.
- **`templates_startup_ship.go`** (the ship playbook seeded into new workspaces) — drop deprecated `--full-auto`, use `codex exec -s read-only -o <file> < /dev/null`, and add the codex-specific note that **open stdin** (piped/backgrounded) causes the zero-output "wedge" — not prompt length — plus the stdin-first rule-out in the wedge/safety notes. Brings it in line with the `ship-tasks` skill and live `PLAYB-1405`.

## Test plan
- [x] `go build ./...`, `go test ./internal/collections/...`, lint — green
- [x] `govulncheck ./...` — 0 vulnerabilities