### PR TITLE
feat(charts): per-category hover tooltips + a11y titles (TASK-1638)

### DIFF
--- a/web/src/lib/components/charts/BarChart.svelte
+++ b/web/src/lib/components/charts/BarChart.svelte
@@ -23,6 +23,28 @@
 	const hasData = $derived(data.length > 0 && series.length > 0);
 	const padding = { top: 12, right: 12, bottom: 28, left: 36 };
 
+	// Per-band hover state, lifted from <Bars> so the parent owns the tooltip.
+	let hover = $state<{ index: number; centerX: number } | null>(null);
+	let canvasWidth = $state(0);
+	let tooltipWidth = $state(0);
+
+	const hovered = $derived(hover ? data[hover.index] : null);
+
+	// Clamp the tooltip's left edge so it never overflows the canvas. The tooltip
+	// is centered over the band, then nudged back inside the [0, canvasWidth] range.
+	const tooltipLeft = $derived.by(() => {
+		if (!hover) return 0;
+		const half = tooltipWidth / 2;
+		const min = half;
+		const max = Math.max(half, canvasWidth - half);
+		return Math.min(Math.max(hover.centerX, min), max);
+	});
+
+	function num(d: ChartDatum, key: string): number {
+		const v = d[key];
+		return typeof v === 'number' ? v : Number(v) || 0;
+	}
+
 	// y accessor returns the largest series value per datum so the linear
 	// y-domain (yDomain={[0, null]}) accommodates the tallest grouped bar.
 	const yAccessor = $derived.by(() => {
@@ -49,7 +71,7 @@
 				</span>
 			{/each}
 		</div>
-		<div class="canvas" style:height={`${height}px`}>
+		<div class="canvas" style:height={`${height}px`} bind:clientWidth={canvasWidth}>
 			<LayerCake
 				{data}
 				{x}
@@ -62,9 +84,26 @@
 				<Svg>
 					<AxisY />
 					<AxisX />
-					<Bars series={resolvedSeries} />
+					<Bars series={resolvedSeries} onHover={(h) => (hover = h)} />
 				</Svg>
 			</LayerCake>
+
+			{#if hover && hovered}
+				<div
+					class="tooltip"
+					style:left={`${tooltipLeft}px`}
+					bind:clientWidth={tooltipWidth}
+				>
+					<div class="tooltip-header">{hovered[x]}</div>
+					{#each resolvedSeries as s (s.key)}
+						<div class="tooltip-row">
+							<span class="tooltip-swatch" style:background-color={s.color}></span>
+							<span class="tooltip-label">{s.label}</span>
+							<span class="tooltip-value">{num(hovered, s.key)}</span>
+						</div>
+					{/each}
+				</div>
+			{/if}
 		</div>
 	{:else}
 		<div class="empty" style:height={`${height}px`}>No data</div>
@@ -78,6 +117,58 @@
 
 	.canvas {
 		width: 100%;
+		position: relative;
+	}
+
+	.tooltip {
+		position: absolute;
+		top: 8px;
+		transform: translateX(-50%);
+		pointer-events: none;
+		z-index: 1;
+		min-width: max-content;
+		padding: 0.4rem 0.55rem;
+		border-radius: 6px;
+		background: var(--surface, #ffffff);
+		border: 1px solid var(--border, #e5e7eb);
+		box-shadow: 0 2px 8px rgb(0 0 0 / 0.12);
+		font-size: 0.75rem;
+		color: var(--text, #111827);
+	}
+
+	.tooltip-header {
+		font-weight: 600;
+		margin-bottom: 0.25rem;
+		white-space: nowrap;
+	}
+
+	.tooltip-row {
+		display: flex;
+		align-items: center;
+		gap: 0.4rem;
+		white-space: nowrap;
+	}
+
+	.tooltip-row + .tooltip-row {
+		margin-top: 0.15rem;
+	}
+
+	.tooltip-swatch {
+		display: inline-block;
+		width: 0.6rem;
+		height: 0.6rem;
+		border-radius: 2px;
+		flex-shrink: 0;
+	}
+
+	.tooltip-label {
+		color: var(--text-muted, #6b7280);
+	}
+
+	.tooltip-value {
+		margin-left: auto;
+		font-weight: 600;
+		font-variant-numeric: tabular-nums;
 	}
 
 	.legend {

--- a/web/src/lib/components/charts/BarChart.svelte
+++ b/web/src/lib/components/charts/BarChart.svelte
@@ -92,6 +92,7 @@
 				<div
 					class="tooltip"
 					style:left={`${tooltipLeft}px`}
+					style:max-width={canvasWidth > 0 ? `${canvasWidth}px` : undefined}
 					bind:clientWidth={tooltipWidth}
 				>
 					<div class="tooltip-header">{hovered[x]}</div>
@@ -126,7 +127,8 @@
 		transform: translateX(-50%);
 		pointer-events: none;
 		z-index: 1;
-		min-width: max-content;
+		box-sizing: border-box;
+		width: max-content;
 		padding: 0.4rem 0.55rem;
 		border-radius: 6px;
 		background: var(--surface, #ffffff);
@@ -139,14 +141,13 @@
 	.tooltip-header {
 		font-weight: 600;
 		margin-bottom: 0.25rem;
-		white-space: nowrap;
+		overflow-wrap: anywhere;
 	}
 
 	.tooltip-row {
 		display: flex;
 		align-items: center;
 		gap: 0.4rem;
-		white-space: nowrap;
 	}
 
 	.tooltip-row + .tooltip-row {
@@ -163,10 +164,15 @@
 
 	.tooltip-label {
 		color: var(--text-muted, #6b7280);
+		min-width: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
 	}
 
 	.tooltip-value {
 		margin-left: auto;
+		flex-shrink: 0;
 		font-weight: 600;
 		font-variant-numeric: tabular-nums;
 	}

--- a/web/src/lib/components/charts/Sparkline.svelte
+++ b/web/src/lib/components/charts/Sparkline.svelte
@@ -40,6 +40,15 @@
 			})
 			.join(' ');
 	});
+
+	const summary = $derived.by(() => {
+		const n = values.length;
+		if (n === 0) return ariaLabel;
+		const latest = values[n - 1];
+		const min = Math.min(...values);
+		const max = Math.max(...values);
+		return `latest ${latest} (min ${min}, max ${max})`;
+	});
 </script>
 
 {#if values.length > 0}
@@ -52,6 +61,7 @@
 		role="img"
 		aria-label={ariaLabel}
 	>
+		<title>{summary}</title>
 		<path
 			d={path}
 			fill="none"

--- a/web/src/lib/components/charts/layers/Bars.svelte
+++ b/web/src/lib/components/charts/layers/Bars.svelte
@@ -5,11 +5,13 @@
 
 	interface Props {
 		series: ResolvedSeries[];
+		onHover?: (hover: { index: number; centerX: number } | null) => void;
 	}
 
-	let { series }: Props = $props();
+	let { series, onHover }: Props = $props();
 
-	const { data, xGet, xScale, yScale, height } = getContext<LayerCakeContext>('LayerCake');
+	const { data, x, xGet, xScale, yScale, height, padding } =
+		getContext<LayerCakeContext>('LayerCake');
 
 	const bandwidth = $derived(
 		typeof $xScale.bandwidth === 'function' ? $xScale.bandwidth() : 0
@@ -31,6 +33,18 @@
 		const v = d[key];
 		return typeof v === 'number' ? v : Number(v) || 0;
 	}
+
+	// Per-band summary for the accessible <title> on hit-rects: "May 28 — Created 5, Completed 3".
+	function bandSummary(d: ChartDatum): string {
+		const label = String($x(d));
+		const parts = series.map((s) => `${s.label} ${num(d, s.key)}`);
+		return `${label} — ${parts.join(', ')}`;
+	}
+
+	// Band center in canvas pixels: plot-area scale + left padding offset.
+	function bandCenter(d: ChartDatum): number {
+		return $padding.left + $xGet(d) + bandwidth / 2;
+	}
 </script>
 
 <g class="bars">
@@ -42,7 +56,33 @@
 				width={inner.bandwidth()}
 				height={Math.max(0, $height - $yScale(num(d, s.key)))}
 				fill={s.color}
-			/>
+			>
+				<title>{s.label}: {num(d, s.key)}</title>
+			</rect>
 		{/each}
 	{/each}
+
+	<!-- Invisible full-height hit-rect per band drives per-category hover. -->
+	{#each $data as d, i (i)}
+		<rect
+			class="hit"
+			x={$xGet(d)}
+			y={0}
+			width={bandwidth}
+			height={$height}
+			fill="transparent"
+			onpointerenter={() => onHover?.({ index: i, centerX: bandCenter(d) })}
+			onpointermove={() => onHover?.({ index: i, centerX: bandCenter(d) })}
+			onpointerleave={() => onHover?.(null)}
+			role="presentation"
+		>
+			<title>{bandSummary(d)}</title>
+		</rect>
+	{/each}
 </g>
+
+<style>
+	.hit {
+		pointer-events: all;
+	}
+</style>

--- a/web/src/lib/components/charts/theme.ts
+++ b/web/src/lib/components/charts/theme.ts
@@ -55,4 +55,5 @@ export interface LayerCakeContext {
 	height: Readable<number>;
 	xRange: Readable<number[]>;
 	yRange: Readable<number[]>;
+	padding: Readable<{ top: number; right: number; bottom: number; left: number }>;
 }


### PR DESCRIPTION
## Summary
Hovering an Insights chart now shows exact numbers. The shared `BarChart` gains a **per-category** tooltip (hover a bucket → its x-label + all series with color swatches), so it lands on throughput, WIP aging, and completed-by-collection at once.

## Context
Implements `TASK-1638` under `PLAN-1628`.

## What changed
- `Bars` layer: invisible full-height hit-rect per band reports the hovered index + band center; lifted to `BarChart`, which renders an **edge-clamped**, absolutely-positioned HTML tooltip. Grouped inner-band layout unchanged.
- **A11y**: native `<title>` per visible `<rect>` (+ a band-summary title on the hit-rect); chart keeps `role="img"` + aria-label.
- `Sparkline`: concise native `<title>` (latest / min–max).

## Test plan
- [x] `make check` — lint + web build + svelte-check (0 errors) + govulncheck (0)
- [x] Svelte MCP autofixer clean; `npm run build` passes
- [ ] manual hover check post-merge