### PR TITLE
feat(insights): reconstruct historical WIP + status snapshot for past periods (TASK-1640)

### DIFF
--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -1723,7 +1723,12 @@ func (s *Store) UpdateItemWithPreCheck(
 	// completed-throughput and cycle-time series (PLAN-1628 / TASK-1637).
 	if input.Fields != nil {
 		newStatus := extractFieldValue(*input.Fields, doneKey)
-		if newStatus != "" && newStatus != statusBefore {
+		// Record any change in the done-field value, INCLUDING a clear
+		// (X → ""). input.Fields is the full merged blob (CLI/handler merge
+		// before write), so newStatus == "" genuinely means the field was
+		// cleared, not omitted — recording it keeps the as-of-T reconstruction
+		// accurate (an item cleared back to no-status reads as open).
+		if newStatus != statusBefore {
 			if _, err = tx.Exec(s.q(`
 				INSERT INTO status_transitions (id, item_id, workspace_id, collection_id, field_key, from_status, to_status, created_at)
 				VALUES (?, ?, ?, ?, ?, ?, ?, ?)
@@ -3045,7 +3050,9 @@ func (s *Store) MoveItemWithPreCheck(
 	// the item now lives in. Same tx, not debounced.
 	oldStatus := extractFieldValue(oldFields, moveDoneKey)
 	newStatus := extractFieldValue(newFieldsJSON, moveDoneKey)
-	if newStatus != "" && newStatus != oldStatus {
+	// Record any done-field change, including a clear (X → "") — see the
+	// UpdateItemWithPreCheck hook for the rationale.
+	if newStatus != oldStatus {
 		if _, err = tx.Exec(s.q(`
 			INSERT INTO status_transitions (id, item_id, workspace_id, collection_id, field_key, from_status, to_status, created_at)
 			VALUES (?, ?, ?, ?, ?, ?, ?, ?)

--- a/internal/store/reports.go
+++ b/internal/store/reports.go
@@ -264,25 +264,133 @@ func (s *Store) GetReport(workspaceID string, opts ReportOptions) (*ReportData, 
 		return a.Collection < b.Collection
 	})
 
-	dist, err := s.reportStatusDistribution(workspaceID, colls)
-	if err != nil {
-		return nil, err
-	}
-	data.StatusDistribution = dist
-
 	cycle, err := s.reportCycleTime(workspaceID, colls, startStr, endStr, slugByID)
 	if err != nil {
 		return nil, err
 	}
 	data.CycleTime = cycle
 
-	wip, err := s.reportWIP(workspaceID, colls, now)
-	if err != nil {
-		return nil, err
+	// Snapshot metrics (status distribution + WIP). At offset 0 they reflect
+	// "now" from the live items table (ground truth). For a PAST period
+	// (offset > 0) we reconstruct them as-of the window end from the
+	// status-transition history, so they reflect the selected period rather
+	// than the current moment (PLAN-1628 / TASK-1640).
+	if offset > 0 {
+		dist, wip, rerr := s.reportSnapshotAsOf(workspaceID, colls, end)
+		if rerr != nil {
+			return nil, rerr
+		}
+		data.StatusDistribution = dist
+		data.WIP = wip
+	} else {
+		dist, derr := s.reportStatusDistribution(workspaceID, colls)
+		if derr != nil {
+			return nil, derr
+		}
+		data.StatusDistribution = dist
+		wip, werr := s.reportWIP(workspaceID, colls, now)
+		if werr != nil {
+			return nil, werr
+		}
+		data.WIP = wip
 	}
-	data.WIP = wip
 
 	return data, nil
+}
+
+// reportSnapshotAsOf reconstructs the status-distribution and WIP snapshot as
+// they stood at time t, from the status-transition history (PLAN-1628 /
+// TASK-1640). An item's status as-of-t is the to_status of its latest
+// transition on the collection's done field with created_at <= t. Per
+// collection (the done field varies), it scans items currently in that
+// collection that existed at t (created_at <= t) and weren't deleted by then
+// (deleted_at IS NULL OR > t), resolving each one's as-of-t value via a
+// "no later transition <= t" NOT EXISTS — dual-dialect, no window functions.
+//
+// Accuracy: exact for post-launch history (the live write path records every
+// status change); approximate for pre-launch history, since the backfill
+// parsed the debounce-coalesced activity log. Same caveat as the backfill.
+func (s *Store) reportSnapshotAsOf(workspaceID string, colls []reportCollection, t time.Time) ([]ReportStatusCount, ReportWIP, error) {
+	tStr := t.Format(time.RFC3339)
+	dist := []ReportStatusCount{}
+	wip := ReportWIP{AgingBuckets: []ReportAgingBucket{}, ByCollection: []ReportDuration{}}
+
+	var openAges []float64
+	perColl := map[string][]float64{}
+	slugByID := map[string]string{}
+
+	for _, c := range colls {
+		slugByID[c.id] = c.slug
+		terminals := map[string]bool{}
+		for _, v := range c.allTerminals {
+			terminals[strings.ToLower(v)] = true
+		}
+		// Per-item as-of-t value: the to_status of the latest transition on
+		// this collection's done field at or before t, for items currently in
+		// the collection that existed at t and weren't deleted by t.
+		query := `
+			SELECT st.to_status, i.created_at
+			FROM status_transitions st
+			JOIN items i ON i.id = st.item_id
+			WHERE i.workspace_id = ? AND i.collection_id = ?
+			  AND i.created_at <= ?
+			  AND (i.deleted_at IS NULL OR i.deleted_at > ?)
+			  AND st.field_key = ? AND st.created_at <= ?
+			  AND NOT EXISTS (
+				SELECT 1 FROM status_transitions st2
+				WHERE st2.item_id = st.item_id AND st2.field_key = st.field_key
+				  AND st2.created_at <= ?
+				  AND (st2.created_at > st.created_at
+				    OR (st2.created_at = st.created_at AND st2.id > st.id))
+			  )
+		`
+		rows, err := s.db.Query(s.q(query), workspaceID, c.id, tStr, tStr, c.doneKey, tStr, tStr)
+		if err != nil {
+			return nil, ReportWIP{}, fmt.Errorf("reconstruct snapshot: %w", err)
+		}
+		statusCounts := map[string]int{}
+		func() {
+			defer rows.Close()
+			for rows.Next() {
+				var status, createdAt string
+				if scanErr := rows.Scan(&status, &createdAt); scanErr != nil {
+					err = fmt.Errorf("scan snapshot row: %w", scanErr)
+					return
+				}
+				status = strings.ToLower(status)
+				if status != "" {
+					statusCounts[status]++
+				}
+				// WIP: open = not a terminal value; age measured against t.
+				if !terminals[status] {
+					if h, ok := durationHours(createdAt, tStr); ok {
+						openAges = append(openAges, h)
+						perColl[c.id] = append(perColl[c.id], h)
+					}
+				}
+			}
+			err = rows.Err()
+		}()
+		if err != nil {
+			return nil, ReportWIP{}, err
+		}
+		for status, n := range statusCounts {
+			dist = append(dist, ReportStatusCount{Collection: c.slug, Status: status, Count: n})
+		}
+	}
+
+	sort.Slice(dist, func(i, j int) bool {
+		if dist[i].Collection != dist[j].Collection {
+			return dist[i].Collection < dist[j].Collection
+		}
+		return dist[i].Status < dist[j].Status
+	})
+
+	wip.OpenCount = len(openAges)
+	wip.MedianAgeHours = percentile(openAges, 0.5)
+	wip.ByCollection = durationsByCollection(perColl, slugByID)
+	wip.AgingBuckets = agingBuckets(openAges)
+	return dist, wip, nil
 }
 
 // reportCycleTime computes created→positive-terminal durations for completions

--- a/internal/store/reports.go
+++ b/internal/store/reports.go
@@ -320,6 +320,11 @@ func (s *Store) GetReport(workspaceID string, opts ReportOptions) (*ReportData, 
 //     status-preserving moves record no transition), so this is a deliberate
 //     limitation — the same current-collection attribution the backfill and
 //     completed-by-collection use. Items rarely change collection.
+//   - same-second resolution: created_at is second-precision and transition
+//     ids are random UUIDs, so "the latest transition <= t" is nondeterministic
+//     when an item changes status 2+ times within ONE second — it may resolve
+//     to either same-second value. Rare (requires sub-second multi-hops on one
+//     item); a monotonic ordering column would fix it (tracked as a follow-up).
 func (s *Store) reportSnapshotAsOf(workspaceID string, colls []reportCollection, t time.Time) ([]ReportStatusCount, ReportWIP, error) {
 	tStr := t.Format(time.RFC3339)
 	dist := []ReportStatusCount{}

--- a/internal/store/reports.go
+++ b/internal/store/reports.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"math"
@@ -325,26 +326,25 @@ func (s *Store) reportSnapshotAsOf(workspaceID string, colls []reportCollection,
 		for _, v := range c.allTerminals {
 			terminals[strings.ToLower(v)] = true
 		}
-		// Per-item as-of-t value: the to_status of the latest transition on
-		// this collection's done field at or before t, for items currently in
-		// the collection that existed at t and weren't deleted by t.
+		// Start from items (not transitions) so an item that existed at t but
+		// had no done-field transition yet is still counted — matching the
+		// live path, which treats a missing/empty done value as open. For each
+		// in-scope item that existed at t and wasn't deleted by t, the
+		// correlated subquery resolves its as-of-t value: the to_status of the
+		// latest transition on the done field at or before t (NULL if none →
+		// treated as empty/open). LIMIT 1 ORDER BY created_at,id is valid on
+		// both dialects (no window functions).
 		query := `
-			SELECT st.to_status, i.created_at
-			FROM status_transitions st
-			JOIN items i ON i.id = st.item_id
+			SELECT i.created_at,
+			  (SELECT st.to_status FROM status_transitions st
+			   WHERE st.item_id = i.id AND st.field_key = ? AND st.created_at <= ?
+			   ORDER BY st.created_at DESC, st.id DESC LIMIT 1) AS asof_status
+			FROM items i
 			WHERE i.workspace_id = ? AND i.collection_id = ?
 			  AND i.created_at <= ?
 			  AND (i.deleted_at IS NULL OR i.deleted_at > ?)
-			  AND st.field_key = ? AND st.created_at <= ?
-			  AND NOT EXISTS (
-				SELECT 1 FROM status_transitions st2
-				WHERE st2.item_id = st.item_id AND st2.field_key = st.field_key
-				  AND st2.created_at <= ?
-				  AND (st2.created_at > st.created_at
-				    OR (st2.created_at = st.created_at AND st2.id > st.id))
-			  )
 		`
-		rows, err := s.db.Query(s.q(query), workspaceID, c.id, tStr, tStr, c.doneKey, tStr, tStr)
+		rows, err := s.db.Query(s.q(query), c.doneKey, tStr, workspaceID, c.id, tStr, tStr)
 		if err != nil {
 			return nil, ReportWIP{}, fmt.Errorf("reconstruct snapshot: %w", err)
 		}
@@ -352,16 +352,20 @@ func (s *Store) reportSnapshotAsOf(workspaceID string, colls []reportCollection,
 		func() {
 			defer rows.Close()
 			for rows.Next() {
-				var status, createdAt string
-				if scanErr := rows.Scan(&status, &createdAt); scanErr != nil {
+				var createdAt string
+				var asof sql.NullString
+				if scanErr := rows.Scan(&createdAt, &asof); scanErr != nil {
 					err = fmt.Errorf("scan snapshot row: %w", scanErr)
 					return
 				}
-				status = strings.ToLower(status)
+				status := strings.ToLower(asof.String) // "" when NULL
+				// Status distribution skips items with no done value (matches
+				// the live path).
 				if status != "" {
 					statusCounts[status]++
 				}
-				// WIP: open = not a terminal value; age measured against t.
+				// WIP: open = not a terminal value (a missing/empty value is
+				// open too); age measured against t.
 				if !terminals[status] {
 					if h, ok := durationHours(createdAt, tStr); ok {
 						openAges = append(openAges, h)

--- a/internal/store/reports.go
+++ b/internal/store/reports.go
@@ -308,9 +308,18 @@ func (s *Store) GetReport(workspaceID string, opts ReportOptions) (*ReportData, 
 // (deleted_at IS NULL OR > t), resolving each one's as-of-t value via a
 // "no later transition <= t" NOT EXISTS — dual-dialect, no window functions.
 //
-// Accuracy: exact for post-launch history (the live write path records every
-// status change); approximate for pre-launch history, since the backfill
-// parsed the debounce-coalesced activity log. Same caveat as the backfill.
+// Accuracy (historical periods are best-effort, matching the rest of the
+// feature's historical posture):
+//   - exact for post-launch history (the live write path records every
+//     status change, including clears); approximate for pre-launch history,
+//     since the backfill parsed the debounce-coalesced activity log.
+//   - collection attribution uses the item's CURRENT collection, not the one
+//     it belonged to at t. An item moved between collections is attributed to
+//     its present collection for past periods too. Reconstructing historical
+//     collection membership would require replaying move history (and
+//     status-preserving moves record no transition), so this is a deliberate
+//     limitation — the same current-collection attribution the backfill and
+//     completed-by-collection use. Items rarely change collection.
 func (s *Store) reportSnapshotAsOf(workspaceID string, colls []reportCollection, t time.Time) ([]ReportStatusCount, ReportWIP, error) {
 	tStr := t.Format(time.RFC3339)
 	dist := []ReportStatusCount{}

--- a/internal/store/reports_test.go
+++ b/internal/store/reports_test.go
@@ -420,3 +420,74 @@ func TestGetReport_OffsetShiftsWindow(t *testing.T) {
 		t.Fatalf("negative offset should clamp to 0, got offset=%d", rNeg.Offset)
 	}
 }
+
+func TestReportSnapshotAsOf(t *testing.T) {
+	s := testStore(t)
+	wsID, colID := newTransitionTestWorkspace(t, s) // tasks; "done" is a default terminal
+	item := createTestItem(t, s, wsID, colID, "historical", "")
+	// Control the transition history precisely.
+	if _, err := s.db.Exec(s.dialect.Rebind(`DELETE FROM status_transitions WHERE item_id = ?`), item.ID); err != nil {
+		t.Fatalf("clear transitions: %v", err)
+	}
+	backdateItem(t, s, item.ID, 20*24) // existed 20d ago
+
+	now := time.Now().UTC()
+	ins := func(id, from, to string, hoursAgo float64) {
+		ts := now.Add(-time.Duration(hoursAgo * float64(time.Hour))).Format(time.RFC3339)
+		if _, err := s.db.Exec(s.q(`INSERT INTO status_transitions (id, item_id, workspace_id, collection_id, field_key, from_status, to_status, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`),
+			id, item.ID, wsID, colID, "status", from, to, ts); err != nil {
+			t.Fatalf("insert transition: %v", err)
+		}
+	}
+	ins("t1", "", "open", 20*24)    // 20d ago: open
+	ins("t2", "open", "done", 5*24) // 5d ago: done
+
+	colls, err := s.resolveReportCollections(wsID, ReportOptions{})
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+
+	statusOf := func(dist []ReportStatusCount, status string) int {
+		for _, d := range dist {
+			if d.Collection == "tasks" && d.Status == status {
+				return d.Count
+			}
+		}
+		return 0
+	}
+
+	// As of 10 days ago: latest transition <= then is t1 → "open" (the t2 done
+	// at 5d ago is AFTER T, so it must NOT be reflected).
+	dist10, wip10, err := s.reportSnapshotAsOf(wsID, colls, now.Add(-10*24*time.Hour))
+	if err != nil {
+		t.Fatalf("asof 10d: %v", err)
+	}
+	if statusOf(dist10, "open") != 1 || statusOf(dist10, "done") != 0 {
+		t.Fatalf("as-of-10d should be open (pre-done), got %+v", dist10)
+	}
+	if wip10.OpenCount != 1 {
+		t.Fatalf("as-of-10d WIP open should be 1, got %d", wip10.OpenCount)
+	}
+
+	// As of 3 days ago: latest <= then is t2 → "done" (terminal → not WIP).
+	dist3, wip3, err := s.reportSnapshotAsOf(wsID, colls, now.Add(-3*24*time.Hour))
+	if err != nil {
+		t.Fatalf("asof 3d: %v", err)
+	}
+	if statusOf(dist3, "done") != 1 || statusOf(dist3, "open") != 0 {
+		t.Fatalf("as-of-3d should be done, got %+v", dist3)
+	}
+	if wip3.OpenCount != 0 {
+		t.Fatalf("as-of-3d WIP open should be 0 (done is terminal), got %d", wip3.OpenCount)
+	}
+
+	// Existed-at-T: as of 30 days ago (before the item's created_at), it must
+	// not appear at all.
+	dist30, wip30, err := s.reportSnapshotAsOf(wsID, colls, now.Add(-30*24*time.Hour))
+	if err != nil {
+		t.Fatalf("asof 30d: %v", err)
+	}
+	if len(dist30) != 0 || wip30.OpenCount != 0 {
+		t.Fatalf("as-of-30d (before creation) should be empty, got dist=%+v wip.open=%d", dist30, wip30.OpenCount)
+	}
+}

--- a/internal/store/reports_test.go
+++ b/internal/store/reports_test.go
@@ -490,4 +490,25 @@ func TestReportSnapshotAsOf(t *testing.T) {
 	if len(dist30) != 0 || wip30.OpenCount != 0 {
 		t.Fatalf("as-of-30d (before creation) should be empty, got dist=%+v wip.open=%d", dist30, wip30.OpenCount)
 	}
+
+	// An item that existed at T with NO done-field transition (created with no
+	// status) must count as open — matching the live WIP path — not be dropped.
+	noStatus, err := s.CreateItem(wsID, colID, models.ItemCreate{Title: "no-status"})
+	if err != nil {
+		t.Fatalf("create no-status item: %v", err)
+	}
+	if _, err := s.db.Exec(s.dialect.Rebind(`DELETE FROM status_transitions WHERE item_id = ?`), noStatus.ID); err != nil {
+		t.Fatalf("clear: %v", err)
+	}
+	backdateItem(t, s, noStatus.ID, 8*24) // existed 8d ago, no transitions ever
+	_, wipNow, err := s.reportSnapshotAsOf(wsID, colls, now.Add(-3*24*time.Hour))
+	if err != nil {
+		t.Fatalf("asof 3d (with no-status item): %v", err)
+	}
+	// As of 3d ago: the original item is "done" (t2 at 5d ago is <= 3d ago →
+	// terminal, not open); the no-status item existed (8d ago) with no
+	// transition → counts as open. So exactly 1 open.
+	if wipNow.OpenCount != 1 {
+		t.Fatalf("expected the no-transition no-status item to count as open (1), got %d", wipNow.OpenCount)
+	}
 }

--- a/internal/store/status_transitions_test.go
+++ b/internal/store/status_transitions_test.go
@@ -359,3 +359,31 @@ func TestBackfillStatusTransitions(t *testing.T) {
 		t.Fatalf("expected second backfill to skip, got %+v", res2)
 	}
 }
+
+func TestStatusTransition_RecordsStatusClear(t *testing.T) {
+	s := testStore(t)
+	wsID, colID := newTransitionTestWorkspace(t, s)
+	item := createTestItem(t, s, wsID, colID, "clearable", "") // status open
+	if _, err := s.UpdateItem(item.ID, models.ItemUpdate{Fields: strPtr(`{"status":"done"}`)}); err != nil {
+		t.Fatalf("to done: %v", err)
+	}
+	// Clear the status (full merged blob with no status key) — must record a
+	// done → "" transition so as-of reconstruction sees it reopen.
+	if _, err := s.UpdateItem(item.ID, models.ItemUpdate{Fields: strPtr(`{}`)}); err != nil {
+		t.Fatalf("clear: %v", err)
+	}
+	hops := hopTransitions(t, s, item.ID)
+	if len(hops) != 2 {
+		t.Fatalf("expected 2 hops (open→done, done→\"\"), got %d: %+v", len(hops), hops)
+	}
+	// Same-second created_at makes row order nondeterministic — assert the SET.
+	foundClear := false
+	for _, h := range hops {
+		if h.FromStatus == "done" && h.ToStatus == "" {
+			foundClear = true
+		}
+	}
+	if !foundClear {
+		t.Fatalf("expected a done → \"\" clear hop, got %+v", hops)
+	}
+}

--- a/web/src/routes/[username]/[workspace]/insights/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/insights/+page.svelte
@@ -295,9 +295,9 @@
 
 	const netFlow = $derived(report?.totals.net_flow ?? 0);
 
-	// True when viewing a past period. WIP + status distribution are point-in-time
-	// snapshots that, for now, only render meaningfully for the current period;
-	// hide them in the past until a follow-up makes them historical.
+	// True when viewing a past period. WIP + status distribution now render in the
+	// past too (backend reconstructs them as-of the selected period's end); this
+	// only drives the period chip + the "reconstructed as of…" note.
 	const inPast = $derived(offset > 0);
 
 	// Short relative label for the period nav.
@@ -453,7 +453,8 @@
 
 			{#if inPast}
 				<p class="past-note">
-					Work-in-progress and status distribution show the current period only.
+					Work-in-progress and status distribution are reconstructed as of this
+					period's end; older periods may be approximate.
 				</p>
 			{/if}
 
@@ -478,7 +479,7 @@
 				</section>
 			{/if}
 
-			{#if !hiddenCards.has('cycle_time') || (!hiddenCards.has('wip') && !inPast)}
+			{#if !hiddenCards.has('cycle_time') || !hiddenCards.has('wip')}
 				<div class="grid">
 					<!-- Cycle time -->
 					{#if !hiddenCards.has('cycle_time')}
@@ -522,7 +523,7 @@
 					{/if}
 
 					<!-- Work in progress -->
-					{#if !hiddenCards.has('wip') && !inPast}
+					{#if !hiddenCards.has('wip')}
 						<section class="card">
 							<div class="card-header">
 								<h2>Work in progress</h2>
@@ -588,7 +589,7 @@
 			{/if}
 
 			<!-- Status distribution -->
-			{#if !hiddenCards.has('status_distribution') && !inPast}
+			{#if !hiddenCards.has('status_distribution')}
 				<section class="card">
 					<div class="card-header">
 						<h2>Status distribution</h2>

--- a/web/src/routes/[username]/[workspace]/insights/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/insights/+page.svelte
@@ -527,7 +527,7 @@
 						<section class="card">
 							<div class="card-header">
 								<h2>Work in progress</h2>
-								<span class="card-sub">Open items right now</span>
+								<span class="card-sub">{inPast ? 'Open as of this period' : 'Open items right now'}</span>
 							</div>
 							{#if report.wip.open_count === 0}
 								<div class="card-empty">No open items.</div>


### PR DESCRIPTION
## Summary
When viewing a PAST period on Insights, the WIP + status-distribution snapshots are now **reconstructed as-of the period end** from the status-transition history — instead of being hidden (TASK-1639's interim).

## Context
Implements `TASK-1640` under `PLAN-1628`, on TASK-1639 (offset nav) + the `status_transitions` foundation (TASK-1637, incl. create-seed rows so every item has a `"" → initial` transition).

## How
- `reportSnapshotAsOf(ws, colls, T)`: an item's status as-of-T = the `to_status` of its latest transition on the collection's done field with `created_at ≤ T`, resolved via a `NOT EXISTS` "no later transition ≤ T" correlated subquery (dual-dialect, no window functions). Counts only items that **existed at T** (`created_at ≤ T`) and **weren't deleted by T** (`deleted_at IS NULL OR > T`). WIP age is measured against T.
- `offset 0` keeps the existing live-from-`items` path (ground truth for "now"); `offset > 0` uses reconstruction.
- Frontend drops the interim hide; the snapshot cards show in the past with a note that they're reconstructed (older periods may be approximate — the backfill parsed the debounce-coalesced activity log).

## Test plan
- [x] `go test ./internal/store ./internal/server` — green. New: as-of-T resolves to the pre-T value (not a later change), terminal→not-WIP, items created after T excluded.
- [x] `make check` — lint + web build + svelte-check (0) + govulncheck (0); Svelte MCP autofixer clean