### PR TITLE
chore(templates): tool-neutral seeded ship-playbook review loop (TASK-1644)

### DIFF
--- a/internal/collections/templates_startup_ship.go
+++ b/internal/collections/templates_startup_ship.go
@@ -50,8 +50,8 @@ check fails, report what's wrong and stop — don't guess.
 2. **Clean working tree on main.** ` + "`git status`" + ` clean, ` + "`git branch --show-current`" + ` = main.
 3. **Up to date with remote.** ` + "`git fetch origin && git rev-list HEAD..origin/main --count`" + ` = 0.
 4. **GitHub CLI authed.** ` + "`gh auth status`" + ` (only required if the project uses GitHub).
-5. **Review CLI available.** ` + "`codex --version`" + ` (or whichever review tool the project uses —
-   swap for ` + "`gemini`" + `, ` + "`claude`" + `, etc. The loop shape is what matters).
+5. **Review tool available.** Whatever the project uses for the review loop in step 9
+   (a review CLI, a GitHub review bot, etc.) — confirm it's reachable. The loop shape is what matters.
 6. **Tests pass on baseline.** Run the project's test command. If the baseline is already
    red, stop — don't compound problems.
 
@@ -155,18 +155,11 @@ This is the core of the workflow — request an automated review, address every
 finding, push, re-review, exit when the reviewer returns zero findings (or the
 safety cap trips).
 
-The example below uses Codex CLI (` + "`codex exec -s read-only -o <file> \"<review prompt>\" < /dev/null`" + `).
-Pass the prompt as a positional argument — ` + "`codex exec`" + ` reads it from stdin
-when none is given, so with ` + "`< /dev/null`" + ` an arg-less command reviews nothing.
-**Swap for your review tool of choice** — Gemini, ` + "`claude review`" + `, a GitHub bot,
-whatever you have. The loop shape (synchronous review → address findings →
-push → re-review) is the part worth keeping.
-
-**If you use ` + "`codex exec`" + `: always redirect stdin from ` + "`/dev/null`" + `.** It reads
-extra input from stdin and hangs with zero output when stdin stays open (piped
-or backgrounded) — which looks exactly like a prompt-length wedge but is NOT
-fixed by a leaner prompt; only closing stdin fixes it. (The deprecated
-` + "`--full-auto`" + ` flag has been dropped; ` + "`-s read-only`" + ` is sufficient.)
+Use **whatever synchronous review tool you have** — a review CLI, ` + "`claude review`" + `,
+a GitHub review bot, etc. The loop shape (request a review → address findings →
+push → re-review) is the part worth keeping; the specific command is yours.
+(An independent reviewer — a different AI model than the one that implemented —
+catches more than self-review; ` + "`/pad onboard`" + ` can help you wire one up.)
 
 ` + "```" + `
 iteration = 0
@@ -207,15 +200,12 @@ doesn't keep flagging it.
 
 **Review prompt size matters.** Verbose prompts (focus areas, max-finding
 caps, severity-format directives) can wedge some review CLIs. Keep it lean
-— the shortest possible ask is the most reliable. (With ` + "`codex exec`" + `, rule
-out open stdin FIRST — see above — since that produces the identical
-zero-output symptom and isn't fixed by shortening the prompt.)
+— the shortest possible ask is the most reliable.
 
 **Safety exits:**
 - ` + "`iteration >= 5`" + ` — cap reached. Report remaining findings to the user.
-- Review CLI fails or wedges twice on the lean prompt (for ` + "`codex exec`" + `,
-  after confirming stdin is closed with ` + "`< /dev/null`" + `) — the tool itself
-  is broken. Report and ask.
+- The review tool fails or hangs twice on the lean prompt — the tool itself
+  is broken (or misconfigured). Report and ask.
 
 ### 10. Merge
 


### PR DESCRIPTION
## Summary
The seeded ship playbook (`templates_startup_ship.go`) ships into every new workspace, so it must stay review-tool-agnostic. PR #646 over-fitted it with our local Codex operational lore (`< /dev/null`, `--full-auto`, stdin-wedge diagnosis). This strips the Codex name + those specifics → a tool-neutral review loop, with a pointer that `/pad onboard` can help wire up an independent reviewer (TASK-1645).

Our Codex specifics remain only where they belong — this workspace's `PLAYB-1405` and the personal `ship-tasks` skill.

## Test plan
- [x] `go build`, `go test ./internal/collections/...`, lint — green; no `codex`/`/dev/null`/`--full-auto` strings remain in the seed