### PR TITLE
feat(onboard): suggest an independent AI code reviewer (TASK-1645)

### DIFF
--- a/internal/collections/convention_library.go
+++ b/internal/collections/convention_library.go
@@ -108,6 +108,14 @@ func ConventionLibrary() []LibraryCategory {
 					Surfaces:    []string{"all"},
 					Enforcement: "should",
 				},
+				{
+					Title:       "Independent AI code review",
+					Content:     "Have an independent AI reviewer look at your changes before merge — and use a DIFFERENT model than the one that implemented them. A second, independent model catches issues self-review misses; reviewing with the same model that wrote the code is closer to self-review. Use whatever review tool you have (a review CLI, `claude review`, a GitHub review bot); the loop shape is request review → address every finding → re-review until clean. Pick the reviewer model to differ from your implementer model (e.g. implement with one model, review with another).",
+					Category:    "quality",
+					Trigger:     "on-pr-create",
+					Surfaces:    []string{"all"},
+					Enforcement: "nice-to-have",
+				},
 			},
 		},
 		{

--- a/internal/collections/playbook_library_onboard.go
+++ b/internal/collections/playbook_library_onboard.go
@@ -131,6 +131,24 @@ For each rewritten convention, propose it to the user. Confirm. Create via ` + "
 
 If the library has nothing close to what the user needs, INVENT a convention.
 
+**Independent code reviewer (software projects).** One library convention is worth
+calling out specially: **"Independent AI code review."** The principle — a reviewer
+model DIFFERENT from your implementer model catches far more than self-review;
+reviewing with the same model that wrote the code is closer to self-review. To
+suggest it well, do two checks:
+1. **Your model = the implementer.** You are the agent running this onboarding, so
+   you know your own model (e.g. Claude). That's the implementer.
+2. **Is a different-model review tool available?** If you have a shell, probe for one
+   (e.g. ` + "`codex --version`" + `, ` + "`gemini --version`" + `); if you're a pure-MCP agent with no
+   shell, just ask the user what review tools they have.
+
+If a review tool is present AND it's a different model than yours, propose activating
+the "Independent AI code review" convention and name the detected tool — e.g. *"I see
+` + "`codex`" + ` installed; since you're implementing with Claude, it'd be a genuine independent
+reviewer for the ship loop."* If the only available reviewer would be the SAME model
+that implements, skip it (or suggest adding a different one). Never block — it's a
+suggestion, and the convention states the principle (not any tool's operational details).
+
 ### B4. Propose roles
 
 If the workspace has multiple agents or humans collaborating on different kinds of work, suggest roles. Three common starter sets:
@@ -183,6 +201,11 @@ For each seeded convention, READ ITS BODY. Ask:
 - Are the commands in the body the real ones for this project? (The library version says "run the test suite"; the seeded version might say "run ` + "`make test`" + `"; the user's project might actually use ` + "`go test -race ./...`" + ` or ` + "`npm test`" + `.)
 
 Rewrite the body via ` + "`pad item update <CONVE-ref> --stdin`" + ` (or MCP). Delete conventions that don't apply via ` + "`pad item delete`" + `.
+
+For software workspaces, also consider proposing the **"Independent AI code review"**
+library convention if a different-model review tool is available — same check as build
+mode's reviewer note (your model is the implementer; probe for/ask about a review tool;
+suggest only when the reviewer model differs from yours).
 
 ### A4. Walk the playbooks
 


### PR DESCRIPTION
## Summary
Encodes the **independent-reviewer principle** — a reviewer model different from the implementer catches more than self-review — as opt-in onboarding guidance. No tool-specific operational lore (our Codex `< /dev/null` details stay in `PLAYB-1405` + the personal skill).

## Context
Implements `TASK-1645` under `PLAN-1628`; pairs with TASK-1644 (tool-neutral seed).

## What changed
- **Library convention "Independent AI code review"** (quality / `on-pr-create` / nice-to-have): states the principle; names review tools (a review CLI, `claude review`, a GitHub bot) only as examples, no operational depth.
- **`/pad onboard`** build (B3) + audit (A3): the agent notes its own model (the implementer), probes for / asks about a review tool, and when a *different-model* reviewer is available, proposes activating the convention — naming the detected tool (e.g. `codex`) as the concrete suggestion. Skips when the only reviewer would be the same model. Never blocks.

## Test plan
- [x] `go build`, `go test ./internal/collections/...`, lint — green