### PR TITLE
fix(store): monotonic seq tiebreak for same-second status transitions (TASK-1643)

### DIFF
--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -76,6 +76,14 @@ const maxItemNumberRetries = 10
 // writes can't both read the same MAX(seq) and produce duplicates.
 const nextWorkspaceSeqSubquery = "(SELECT COALESCE(MAX(seq), 0) + 1 FROM items WHERE workspace_id = ?)"
 
+// nextTransitionSeqSubquery assigns a monotonic, insertion-ordered seq to each
+// status_transitions row (global MAX+1 — cross-row dupes across items/workspaces
+// are harmless since the ordering is only used WITHIN a single item's history).
+// It's the precise tiebreak for "latest transition <= T" when created_at
+// (second precision) ties (PLAN-1628 / TASK-1643). The inserts that use it run
+// inside the workspace seq lock, so per-item assignment is serialized.
+const nextTransitionSeqSubquery = "(SELECT COALESCE(MAX(seq), 0) + 1 FROM status_transitions)"
+
 // acquireWorkspaceSeqLock takes a Postgres advisory transaction lock
 // keyed on the workspace ID so concurrent seq-bumping mutations
 // serialize. The lock auto-releases on COMMIT / ROLLBACK. On SQLite
@@ -250,8 +258,8 @@ func (s *Store) tryCreateItem(id, workspaceID, collectionID, slug, ts, fields, t
 		doneKey := doneFieldKeyFromSchemaJSON(schemaJSON, settingsJSON)
 		if initial := extractFieldValue(fields, doneKey); initial != "" {
 			if _, err = tx.Exec(s.q(`
-				INSERT INTO status_transitions (id, item_id, workspace_id, collection_id, field_key, from_status, to_status, created_at)
-				VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+				INSERT INTO status_transitions (id, item_id, workspace_id, collection_id, field_key, from_status, to_status, created_at, seq)
+				VALUES (?, ?, ?, ?, ?, ?, ?, ?, `+nextTransitionSeqSubquery+`)
 			`), "create_"+id, id, workspaceID, collectionID, doneKey, "", initial, ts); err != nil {
 				return fmt.Errorf("record create-time status transition: %w", err)
 			}
@@ -1730,8 +1738,8 @@ func (s *Store) UpdateItemWithPreCheck(
 		// accurate (an item cleared back to no-status reads as open).
 		if newStatus != statusBefore {
 			if _, err = tx.Exec(s.q(`
-				INSERT INTO status_transitions (id, item_id, workspace_id, collection_id, field_key, from_status, to_status, created_at)
-				VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+				INSERT INTO status_transitions (id, item_id, workspace_id, collection_id, field_key, from_status, to_status, created_at, seq)
+				VALUES (?, ?, ?, ?, ?, ?, ?, ?, `+nextTransitionSeqSubquery+`)
 			`), newID(), id, existing.WorkspaceID, existing.CollectionID, doneKey, statusBefore, newStatus, ts); err != nil {
 				return nil, fmt.Errorf("record status transition: %w", err)
 			}
@@ -3054,8 +3062,8 @@ func (s *Store) MoveItemWithPreCheck(
 	// UpdateItemWithPreCheck hook for the rationale.
 	if newStatus != oldStatus {
 		if _, err = tx.Exec(s.q(`
-			INSERT INTO status_transitions (id, item_id, workspace_id, collection_id, field_key, from_status, to_status, created_at)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+			INSERT INTO status_transitions (id, item_id, workspace_id, collection_id, field_key, from_status, to_status, created_at, seq)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, `+nextTransitionSeqSubquery+`)
 		`), newID(), itemID, existing.WorkspaceID, targetCollectionID, moveDoneKey, oldStatus, newStatus, moveTS); err != nil {
 			return nil, fmt.Errorf("record status transition on move: %w", err)
 		}

--- a/internal/store/migrations/065_status_transitions_seq.sql
+++ b/internal/store/migrations/065_status_transitions_seq.sql
@@ -1,0 +1,18 @@
+-- Migration 065: monotonic ordering column for status_transitions
+-- (PLAN-1628 / TASK-1643).
+--
+-- created_at is second-precision and ids are random UUIDs, so resolving "the
+-- latest transition <= T" for the as-of historical snapshot is nondeterministic
+-- when an item changes status 2+ times within ONE second. A monotonic `seq`
+-- (assigned MAX(seq)+1 at insert, like items.seq) gives a stable insertion-order
+-- tiebreak. Backfill existing rows in chronological order so legacy data orders
+-- correctly too; new inserts continue from MAX(seq).
+
+ALTER TABLE status_transitions ADD COLUMN seq INTEGER NOT NULL DEFAULT 0;
+
+WITH ordered AS (
+    SELECT id, ROW_NUMBER() OVER (ORDER BY created_at, id) AS rn
+    FROM status_transitions
+)
+UPDATE status_transitions
+SET seq = (SELECT rn FROM ordered WHERE ordered.id = status_transitions.id);

--- a/internal/store/pgmigrations/044_status_transitions_seq.sql
+++ b/internal/store/pgmigrations/044_status_transitions_seq.sql
@@ -1,0 +1,19 @@
+-- Migration 044 (Postgres): monotonic ordering column for status_transitions
+-- (PLAN-1628 / TASK-1643). Postgres counterpart to
+-- migrations/065_status_transitions_seq.sql.
+--
+-- `seq` (MAX(seq)+1 at insert, like items.seq) gives a stable insertion-order
+-- tiebreak for the as-of-T snapshot's "latest transition <= T" resolution,
+-- which is otherwise nondeterministic for 2+ same-second hops on one item.
+-- Backfill existing rows chronologically; new inserts continue from MAX(seq).
+
+ALTER TABLE status_transitions ADD COLUMN IF NOT EXISTS seq INTEGER NOT NULL DEFAULT 0;
+
+WITH ordered AS (
+    SELECT id, ROW_NUMBER() OVER (ORDER BY created_at, id) AS rn
+    FROM status_transitions
+)
+UPDATE status_transitions
+SET seq = ordered.rn
+FROM ordered
+WHERE ordered.id = status_transitions.id;

--- a/internal/store/reports.go
+++ b/internal/store/reports.go
@@ -439,11 +439,11 @@ func (s *Store) reportCompletedItems(workspaceID string, colls []reportCollectio
 //     status-preserving moves record no transition), so this is a deliberate
 //     limitation — the same current-collection attribution the backfill and
 //     completed-by-collection use. Items rarely change collection.
-//   - same-second resolution: created_at is second-precision and transition
-//     ids are random UUIDs, so "the latest transition <= t" is nondeterministic
-//     when an item changes status 2+ times within ONE second — it may resolve
-//     to either same-second value. Rare (requires sub-second multi-hops on one
-//     item); a monotonic ordering column would fix it (tracked as a follow-up).
+//
+// Same-second multi-hops (an item changing status 2+ times within one second)
+// are resolved deterministically via the monotonic `seq` tiebreak (TASK-1643):
+// "latest transition <= t" orders by created_at, then seq (insertion order),
+// then id — so the chronologically-last same-second hop wins.
 func (s *Store) reportSnapshotAsOf(workspaceID string, colls []reportCollection, t time.Time) ([]ReportStatusCount, ReportWIP, error) {
 	tStr := t.Format(time.RFC3339)
 	dist := []ReportStatusCount{}
@@ -471,7 +471,7 @@ func (s *Store) reportSnapshotAsOf(workspaceID string, colls []reportCollection,
 			SELECT i.created_at,
 			  (SELECT st.to_status FROM status_transitions st
 			   WHERE st.item_id = i.id AND st.field_key = ? AND st.created_at <= ?
-			   ORDER BY st.created_at DESC, st.id DESC LIMIT 1) AS asof_status
+			   ORDER BY st.created_at DESC, st.seq DESC, st.id DESC LIMIT 1) AS asof_status
 			FROM items i
 			WHERE i.workspace_id = ? AND i.collection_id = ?
 			  AND i.created_at <= ?

--- a/internal/store/reports_test.go
+++ b/internal/store/reports_test.go
@@ -649,3 +649,51 @@ func TestReportSnapshotAsOf_SameSecondSeqTiebreak(t *testing.T) {
 		t.Fatalf("expected seq tiebreak to resolve to the highest-seq (open) hop → 1 open, got %d (id-only tiebreak would give 0)", wip.OpenCount)
 	}
 }
+
+func TestBackfillStatusTransitions_SeedSeqBelowHop(t *testing.T) {
+	s := testStore(t)
+	wsID, colID := newTransitionTestWorkspace(t, s)
+	item := createTestItem(t, s, wsID, colID, "create-and-change", "")
+	// Clear the live create-seed so only the backfill populates the table.
+	if _, err := s.db.Exec(s.q(`DELETE FROM status_transitions`)); err != nil {
+		t.Fatalf("clear: %v", err)
+	}
+	// A historical status change → the backfill produces a hop AND a create-seed.
+	if _, err := s.CreateActivity(models.Activity{
+		WorkspaceID: wsID, DocumentID: item.ID, Action: "updated", Actor: "user", Source: "web",
+		Metadata: `{"changes":"status: open → done"}`,
+	}); err != nil {
+		t.Fatalf("activity: %v", err)
+	}
+	if _, err := s.BackfillStatusTransitions(); err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+
+	// The create-seed must get a LOWER seq than the hop, so a same-second
+	// create-and-change resolves to the hop (the later state), not the seed.
+	rows, err := s.db.Query(s.q(`SELECT id, seq FROM status_transitions WHERE item_id = ?`), item.ID)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	defer rows.Close()
+	seedSeq, hopSeq := -1, -1
+	for rows.Next() {
+		var id string
+		var seq int
+		if err := rows.Scan(&id, &seq); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		switch {
+		case strings.HasPrefix(id, "create_"):
+			seedSeq = seq
+		case strings.HasPrefix(id, "bf_"):
+			hopSeq = seq
+		}
+	}
+	if seedSeq < 0 || hopSeq < 0 {
+		t.Fatalf("expected both a seed and a hop row, got seedSeq=%d hopSeq=%d", seedSeq, hopSeq)
+	}
+	if !(seedSeq < hopSeq) {
+		t.Fatalf("create-seed seq (%d) must be below the hop seq (%d)", seedSeq, hopSeq)
+	}
+}

--- a/internal/store/reports_test.go
+++ b/internal/store/reports_test.go
@@ -609,3 +609,43 @@ func TestGetReport_CompletedItemsRespectsCurrentCollectionVisibility(t *testing.
 		t.Fatalf("unscoped should list the item under its current collection, got %+v", full.CompletedItems)
 	}
 }
+
+func TestReportSnapshotAsOf_SameSecondSeqTiebreak(t *testing.T) {
+	s := testStore(t)
+	wsID, colID := newTransitionTestWorkspace(t, s)
+	item := createTestItem(t, s, wsID, colID, "flipper", "")
+	if _, err := s.db.Exec(s.dialect.Rebind(`DELETE FROM status_transitions WHERE item_id = ?`), item.ID); err != nil {
+		t.Fatalf("clear: %v", err)
+	}
+	backdateItem(t, s, item.ID, 10*24)
+
+	// Three hops with the SAME created_at (one second) — only seq disambiguates
+	// which is "latest". Without the seq tiebreak the random-id order could pick
+	// the middle (done) hop and undercount open work.
+	same := time.Now().UTC().Add(-5 * 24 * time.Hour).Format(time.RFC3339)
+	ins := func(id, from, to string, seq int) {
+		if _, err := s.db.Exec(s.q(`INSERT INTO status_transitions (id, item_id, workspace_id, collection_id, field_key, from_status, to_status, created_at, seq) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`),
+			id, item.ID, wsID, colID, "status", from, to, same, seq); err != nil {
+			t.Fatalf("insert %s: %v", id, err)
+		}
+	}
+	// IDs and seq deliberately DISAGREE on the answer:
+	//   - highest seq (3, the true latest) is "open"  → correct result: 1 open
+	//   - highest id ("z…") is "done"                 → an id-only tiebreak: 0 open
+	// So asserting 1 open proves seq (not id) is the tiebreak.
+	ins("m-first-open", "", "open", 1)
+	ins("z-mid-done", "open", "done", 2)   // highest id, but NOT the latest
+	ins("a-final-open", "done", "open", 3) // lowest id, highest seq → the latest
+
+	colls, err := s.resolveReportCollections(wsID, ReportOptions{})
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	_, wip, err := s.reportSnapshotAsOf(wsID, colls, time.Now().UTC().Add(-3*24*time.Hour))
+	if err != nil {
+		t.Fatalf("asof: %v", err)
+	}
+	if wip.OpenCount != 1 {
+		t.Fatalf("expected seq tiebreak to resolve to the highest-seq (open) hop → 1 open, got %d (id-only tiebreak would give 0)", wip.OpenCount)
+	}
+}

--- a/internal/store/status_transitions_backfill.go
+++ b/internal/store/status_transitions_backfill.go
@@ -245,6 +245,17 @@ func (s *Store) BackfillStatusTransitions() (*BackfillStatusTransitionsResult, e
 	// item's initial value — used by Pass 2 to seed the create-time row.
 	firstChangeFrom := map[string]string{}
 
+	// Buffer hop inserts rather than writing them here: create-seed rows
+	// (Pass 2) must be inserted BEFORE the hops so they receive a lower seq.
+	// A seed is the item's initial state at created_at — always chronologically
+	// first for its item — so when its created_at ties a hop's (same-second
+	// create-and-change), the hop's higher seq must win the "latest <= t"
+	// ordering. Inserting seeds first guarantees that (TASK-1643 review).
+	type hopInsert struct {
+		id, itemID, wsID, collID, key, from, to, createdAt string
+	}
+	var hops []hopInsert
+
 	for _, ar := range scanned {
 		result.ActivitiesScanned++
 
@@ -270,7 +281,7 @@ func (s *Store) BackfillStatusTransitions() (*BackfillStatusTransitionsResult, e
 		// transition, so the activity id (prefixed to stay visibly
 		// backfill-sourced) is a stable, collision-free primary key. Re-runs
 		// hit the conflict clause and no-op.
-		insert("bf_"+ar.activityID, ar.itemID, ar.workspaceID, ar.collectionID, key, from, to, ar.createdAt)
+		hops = append(hops, hopInsert{"bf_" + ar.activityID, ar.itemID, ar.workspaceID, ar.collectionID, key, from, to, ar.createdAt})
 	}
 
 	// --- Pass 2: create-time "entered initial status" rows ---
@@ -319,6 +330,13 @@ func (s *Store) BackfillStatusTransitions() (*BackfillStatusTransitionsResult, e
 			continue
 		}
 		insert("create_"+ir.id, ir.id, ir.workspaceID, ir.collectionID, key, "", initial, ir.createdAt)
+	}
+
+	// Now the hops — AFTER the seeds, so every hop's seq exceeds its item's
+	// create-seed seq. Buffered in chronological order (the Pass 1 query sorts
+	// by created_at), so multi-hop histories get increasing seq too.
+	for _, h := range hops {
+		insert(h.id, h.itemID, h.wsID, h.collID, h.key, h.from, h.to, h.createdAt)
 	}
 
 	return result, nil

--- a/internal/store/status_transitions_backfill.go
+++ b/internal/store/status_transitions_backfill.go
@@ -179,8 +179,8 @@ func (s *Store) BackfillStatusTransitions() (*BackfillStatusTransitionsResult, e
 	// deploy — single-instance today), the second insert is a no-op rather
 	// than a duplicate that would overcount reports. The live write paths use
 	// a random newID(), so live rows never collide with these.
-	insertSQL := `INSERT INTO status_transitions (id, item_id, workspace_id, collection_id, field_key, from_status, to_status, created_at)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+	insertSQL := `INSERT INTO status_transitions (id, item_id, workspace_id, collection_id, field_key, from_status, to_status, created_at, seq)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ` + nextTransitionSeqSubquery + `)`
 	if s.dialect.Driver() == DriverPostgres {
 		insertSQL += ` ON CONFLICT (id) DO NOTHING`
 	} else {


### PR DESCRIPTION
## Summary
Closes the documented historical-snapshot precision edge from TASK-1640: `created_at` is second-precision and transition ids are random UUIDs, so "latest transition ≤ T" was nondeterministic for 2+ same-second status hops on one item.

## What changed
- Add a monotonic **`seq`** column (MAX+1 at insert, mirroring `items.seq`; assigned inside the workspace seq lock so per-item order is serialized — cross-row dupes across items/workspaces are harmless, ordering is only used within one item's history).
- **migrations 065 / 044**: add `seq` + backfill existing rows chronologically (`ROW_NUMBER() OVER (ORDER BY created_at, id)`), dual-dialect.
- `seq` set on all four insert sites (update / move / create-seed hooks + the backfill).
- `reportSnapshotAsOf` orders by `created_at DESC, seq DESC, id DESC`; the doc caveat is updated (now resolved).

## Test plan
- [x] `go test ./internal/store ./internal/server` — green (migration applies on fresh SQLite). New test inserts same-`created_at` rows where id-order and seq-order **disagree** on the answer, proving `seq` is the tiebreak (id-only would give the wrong result).
- [x] lint — 0 issues