### PR TITLE
feat(tags): workspace tag enumeration endpoint + cross-collection filter (TASK-1653)

### DIFF
--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -143,6 +143,7 @@ func newRootCmd() *cobra.Command {
 		agentCmd(),
 		githubCmd(),
 		roleCmd(),
+		tagCmd(),
 		webhooksCmd(),
 		attachmentCmd(),
 		dbCmd(),
@@ -6915,6 +6916,45 @@ func roleCmd() *cobra.Command {
 	}
 	cmd.AddCommand(roleListCmd(), roleCreateCmd(), roleUpdateCmd(), roleDeleteCmd())
 	return cmd
+}
+
+func tagCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "tag",
+		Short: "Inspect tags used across the workspace",
+		Long:  "Tags are free-form labels on items. They span collections, so a single tag groups items of any type (an Idea and a Bug can share one tag).",
+	}
+	cmd.AddCommand(tagListCmd())
+	return cmd
+}
+
+func tagListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List distinct tags in the workspace with item counts",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, _ := getClient()
+			ws := getWorkspace()
+			tags, err := client.ListTags(ws)
+			if err != nil {
+				return err
+			}
+			if formatFlag == "json" {
+				return cli.PrintJSON(tags)
+			}
+			if len(tags) == 0 {
+				fmt.Println("No tags yet. Add tags to an item to start grouping across collections.")
+				return nil
+			}
+			w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+			fmt.Fprintln(w, "TAG\tITEMS")
+			for _, t := range tags {
+				fmt.Fprintf(w, "%s\t%d\n", t.Tag, t.Count)
+			}
+			w.Flush()
+			return nil
+		},
+	}
 }
 
 func roleListCmd() *cobra.Command {

--- a/internal/cli/client.go
+++ b/internal/cli/client.go
@@ -186,6 +186,13 @@ func (c *Client) ListItems(wsSlug string, params url.Values) ([]models.Item, err
 	return result, c.get(path, &result)
 }
 
+// ListTags returns the distinct tags used across a workspace's items with
+// per-tag item counts (ordered by count desc then tag asc).
+func (c *Client) ListTags(wsSlug string) ([]models.TagCount, error) {
+	var result []models.TagCount
+	return result, c.get("/workspaces/"+wsSlug+"/tags", &result)
+}
+
 // ListCollectionItems returns items within a specific collection.
 func (c *Client) ListCollectionItems(wsSlug, collSlug string, params url.Values) ([]models.Item, error) {
 	var result []models.Item

--- a/internal/models/item.go
+++ b/internal/models/item.go
@@ -802,6 +802,14 @@ type ItemListParams struct {
 	Offset          int
 }
 
+// TagCount is a distinct tag used within a workspace and the number of items
+// carrying it. Returned by Store.ListWorkspaceTags and the
+// GET /workspaces/{ws}/tags endpoint, ordered by Count desc then Tag asc.
+type TagCount struct {
+	Tag   string `json:"tag"`
+	Count int    `json:"count"`
+}
+
 type ItemLink struct {
 	ID          string    `json:"id"`
 	WorkspaceID string    `json:"workspace_id"`

--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -73,6 +73,45 @@ func (s *Server) handleListItems(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, result)
 }
 
+// handleListTags returns the distinct tags used across the workspace's items
+// with per-tag item counts, ordered by count desc then tag asc. Respects the
+// same collection-visibility and item-grant filters as handleListItems so tag
+// counts never include items the caller can't see.
+func (s *Server) handleListTags(w http.ResponseWriter, r *http.Request) {
+	workspaceID, ok := s.getWorkspaceID(w, r)
+	if !ok {
+		return
+	}
+
+	collIDs, err := s.visibleCollectionIDs(r, workspaceID)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+
+	var itemIDs []string
+	fullCollIDs, grantedItemIDs, grantErr := s.guestResourceFilter(r, workspaceID)
+	if grantErr != nil {
+		writeInternalError(w, grantErr)
+		return
+	}
+	if len(grantedItemIDs) > 0 {
+		collIDs = fullCollIDs
+		itemIDs = grantedItemIDs
+	}
+
+	tags, err := s.store.ListWorkspaceTags(workspaceID, collIDs, itemIDs)
+	if err != nil {
+		writeInternalError(w, err)
+		return
+	}
+	if tags == nil {
+		tags = []models.TagCount{}
+	}
+
+	writeJSON(w, http.StatusOK, tags)
+}
+
 // itemsIndexResponse wraps the skinny-projection items list with bookkeeping
 // the local-first read model (PLAN-1343) needs:
 //   - total: the row count so the client can size its in-memory array.

--- a/internal/server/handlers_tags_test.go
+++ b/internal/server/handlers_tags_test.go
@@ -1,0 +1,79 @@
+package server
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// seedTaggedItem POSTs an item with the given JSON tags array into a collection.
+func seedTaggedItem(t *testing.T, srv *Server, ws, coll, title, tags string) {
+	t.Helper()
+	// Omit fields so each collection's schema default fills status (tasks and
+	// ideas have different status enums) — the test only cares about tags.
+	rr := doRequest(srv, "POST",
+		"/api/v1/workspaces/"+ws+"/collections/"+coll+"/items",
+		map[string]interface{}{
+			"title": title,
+			"tags":  tags,
+		})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("seed %q: expected 201, got %d: %s", title, rr.Code, rr.Body.String())
+	}
+}
+
+// A tag spans collections, so a single tag must group an Idea and a Task
+// together — both the cross-collection `?tag=` filter and the `/tags`
+// enumeration endpoint are exercised here.
+func TestTagsAcrossCollections(t *testing.T) {
+	srv := testServer(t)
+	ws := createWSWithCollections(t, srv)
+
+	seedTaggedItem(t, srv, ws, "tasks", "Task A", `["User feedback","ux"]`)
+	seedTaggedItem(t, srv, ws, "ideas", "Idea A", `["User feedback"]`)
+	seedTaggedItem(t, srv, ws, "ideas", "Idea B", `["perf"]`)
+
+	t.Run("cross-collection ?tag= filter returns items from every collection", func(t *testing.T) {
+		rr := doRequest(srv, "GET",
+			"/api/v1/workspaces/"+ws+"/items?tag="+url.QueryEscape("User feedback"), nil)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("list items by tag: expected 200, got %d: %s", rr.Code, rr.Body.String())
+		}
+		var items []models.Item
+		parseJSON(t, rr, &items)
+		if len(items) != 2 {
+			t.Fatalf("expected 2 items tagged 'User feedback', got %d: %+v", len(items), items)
+		}
+		colls := map[string]bool{}
+		for _, it := range items {
+			colls[it.CollectionSlug] = true
+		}
+		if !colls["tasks"] || !colls["ideas"] {
+			t.Errorf("expected the tag to span tasks AND ideas, got collections %v", colls)
+		}
+	})
+
+	t.Run("GET /tags enumerates distinct tags with counts, ordered", func(t *testing.T) {
+		rr := doRequest(srv, "GET", "/api/v1/workspaces/"+ws+"/tags", nil)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("list tags: expected 200, got %d: %s", rr.Code, rr.Body.String())
+		}
+		var tags []models.TagCount
+		parseJSON(t, rr, &tags)
+		want := []models.TagCount{
+			{Tag: "User feedback", Count: 2},
+			{Tag: "perf", Count: 1},
+			{Tag: "ux", Count: 1},
+		}
+		if len(tags) != len(want) {
+			t.Fatalf("got %d tags, want %d: %+v", len(tags), len(want), tags)
+		}
+		for i, w := range want {
+			if tags[i] != w {
+				t.Errorf("tag[%d] = %+v, want %+v", i, tags[i], w)
+			}
+		}
+	})
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1108,6 +1108,9 @@ func (s *Server) setupRouter() {
 					// Starred items
 					r.Get("/starred", s.handleListStarredItems)
 
+					// Distinct tags across the workspace (with item counts)
+					r.Get("/tags", s.handleListTags)
+
 					// Items (cross-collection, v2)
 					r.Get("/items", s.handleListItems)
 					r.Route("/items/{itemSlug}", func(r chi.Router) {

--- a/internal/store/dialect.go
+++ b/internal/store/dialect.go
@@ -104,6 +104,14 @@ type Dialect interface {
 	// PostgreSQL: "column::jsonb @> ?::jsonb" with arg `["value"]`
 	JSONArrayContains(column, value string) (string, interface{})
 
+	// JSONArrayElements returns a FROM-clause table-function fragment that
+	// unnests a JSON text-array column into one row per element, plus the
+	// expression yielding each element's text value. Intended as a comma
+	// cross-join: `FROM items i, <fromExpr> WHERE ...` selecting <valueExpr>.
+	// SQLite:   fromExpr "json_each(i.tags) je",                                valueExpr "je.value"
+	// PostgreSQL: fromExpr "jsonb_array_elements_text(i.tags::jsonb) AS je(value)", valueExpr "je.value"
+	JSONArrayElements(column, alias string) (fromExpr, valueExpr string)
+
 	// DateBucket returns a SQL expression that truncates an RFC3339 UTC
 	// timestamp TEXT column to the start of its bucket, as a sortable TEXT
 	// label, for GROUP BY in time-series reports (PLAN-1628). granularity is
@@ -187,6 +195,10 @@ func (d *sqliteDialect) FTSRank(_, _ string) string {
 
 func (d *sqliteDialect) JSONArrayContains(column, value string) (string, interface{}) {
 	return column + " LIKE ?", "%\"" + value + "\"%"
+}
+
+func (d *sqliteDialect) JSONArrayElements(column, alias string) (string, string) {
+	return "json_each(" + column + ") " + alias, alias + ".value"
 }
 
 func (d *sqliteDialect) DateBucket(column, granularity string) string {
@@ -288,6 +300,10 @@ func (d *postgresDialect) FTSRank(table, column string) string {
 
 func (d *postgresDialect) JSONArrayContains(column, value string) (string, interface{}) {
 	return column + "::jsonb @> ?::jsonb", `["` + value + `"]`
+}
+
+func (d *postgresDialect) JSONArrayElements(column, alias string) (string, string) {
+	return "jsonb_array_elements_text(" + column + "::jsonb) AS " + alias + "(value)", alias + ".value"
 }
 
 func (d *postgresDialect) DateBucket(column, granularity string) string {

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -830,6 +830,75 @@ func (s *Store) ListItems(workspaceID string, params models.ItemListParams) ([]m
 	return scanItems(rows)
 }
 
+// ListWorkspaceTags returns the distinct tags used across a workspace's items
+// with the number of (non-archived) items carrying each, ordered by count
+// desc then tag asc.
+//
+// collectionIDs / itemIDs are the same permission filters ListItems takes and
+// carry identical semantics: nil collectionIDs means no restriction (admins /
+// owners); a non-nil empty collectionIDs with no itemIDs means "no visible
+// collections" and returns an empty result. When both are non-empty (a guest
+// with collection- and item-level grants) the filters are OR'd, matching
+// ListItems exactly so tag counts can never leak items the caller can't see.
+func (s *Store) ListWorkspaceTags(workspaceID string, collectionIDs, itemIDs []string) ([]models.TagCount, error) {
+	if collectionIDs != nil && len(collectionIDs) == 0 && len(itemIDs) == 0 {
+		return []models.TagCount{}, nil
+	}
+
+	fromExpr, valueExpr := s.dialect.JSONArrayElements("i.tags", "je")
+	query := `
+		SELECT ` + valueExpr + ` AS tag, COUNT(*) AS cnt
+		FROM items i, ` + fromExpr + `
+		WHERE i.workspace_id = ? AND i.deleted_at IS NULL`
+	args := []interface{}{workspaceID}
+
+	if len(collectionIDs) > 0 && len(itemIDs) > 0 {
+		collPlaceholders := make([]string, len(collectionIDs))
+		for i, id := range collectionIDs {
+			collPlaceholders[i] = "?"
+			args = append(args, id)
+		}
+		itemPlaceholders := make([]string, len(itemIDs))
+		for i, id := range itemIDs {
+			itemPlaceholders[i] = "?"
+			args = append(args, id)
+		}
+		query += " AND (i.collection_id IN (" + strings.Join(collPlaceholders, ",") + ") OR i.id IN (" + strings.Join(itemPlaceholders, ",") + "))"
+	} else if len(collectionIDs) > 0 {
+		placeholders := make([]string, len(collectionIDs))
+		for i, id := range collectionIDs {
+			placeholders[i] = "?"
+			args = append(args, id)
+		}
+		query += " AND i.collection_id IN (" + strings.Join(placeholders, ",") + ")"
+	} else if len(itemIDs) > 0 {
+		placeholders := make([]string, len(itemIDs))
+		for i, id := range itemIDs {
+			placeholders[i] = "?"
+			args = append(args, id)
+		}
+		query += " AND i.id IN (" + strings.Join(placeholders, ",") + ")"
+	}
+
+	query += " GROUP BY " + valueExpr + " ORDER BY cnt DESC, tag ASC"
+
+	rows, err := s.db.Query(s.q(query), args...)
+	if err != nil {
+		return nil, fmt.Errorf("list workspace tags: %w", err)
+	}
+	defer rows.Close()
+
+	tags := []models.TagCount{}
+	for rows.Next() {
+		var tc models.TagCount
+		if err := rows.Scan(&tc.Tag, &tc.Count); err != nil {
+			return nil, fmt.Errorf("scan tag count: %w", err)
+		}
+		tags = append(tags, tc)
+	}
+	return tags, rows.Err()
+}
+
 // ItemIndexParams is the trimmed parameter set for ListItemsIndex.
 // It deliberately omits sort/search/pagination/field-filter knobs that the
 // "skinny projection" endpoint doesn't expose — the local-first read model

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -846,8 +846,12 @@ func (s *Store) ListWorkspaceTags(workspaceID string, collectionIDs, itemIDs []s
 	}
 
 	fromExpr, valueExpr := s.dialect.JSONArrayElements("i.tags", "je")
+	// COUNT(DISTINCT i.id), not COUNT(*): the contract is "items carrying the
+	// tag". The unnest produces one row per array element, so an item with
+	// duplicate tags (e.g. ["ux","ux"] — the write path doesn't enforce
+	// per-item uniqueness) would otherwise be counted twice.
 	query := `
-		SELECT ` + valueExpr + ` AS tag, COUNT(*) AS cnt
+		SELECT ` + valueExpr + ` AS tag, COUNT(DISTINCT i.id) AS cnt
 		FROM items i, ` + fromExpr + `
 		WHERE i.workspace_id = ? AND i.deleted_at IS NULL`
 	args := []interface{}{workspaceID}

--- a/internal/store/tags_test.go
+++ b/internal/store/tags_test.go
@@ -1,0 +1,101 @@
+package store
+
+import (
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// createTaggedItem creates an item with the given JSON tags array.
+func createTaggedItem(t *testing.T, s *Store, wsID, collID, title, tags string) *models.Item {
+	t.Helper()
+	item, err := s.CreateItem(wsID, collID, models.ItemCreate{
+		Title:  title,
+		Fields: `{"status":"open"}`,
+		Tags:   tags,
+	})
+	if err != nil {
+		t.Fatalf("failed to create tagged item: %v", err)
+	}
+	return item
+}
+
+func TestListWorkspaceTags(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "Tags WS")
+	ideas := createTestCollection(t, s, ws.ID, "Ideas")
+	bugs := createTestCollection(t, s, ws.ID, "Bugs")
+
+	// "User feedback" spans BOTH collections (2 ideas + 1 bug) — the
+	// cross-collection aggregation is the whole point of the feature.
+	createTaggedItem(t, s, ws.ID, ideas.ID, "Idea A", `["User feedback","ux"]`)
+	createTaggedItem(t, s, ws.ID, ideas.ID, "Idea B", `["User feedback"]`)
+	createTaggedItem(t, s, ws.ID, bugs.ID, "Bug A", `["User feedback"]`)
+	createTaggedItem(t, s, ws.ID, bugs.ID, "Bug B", `["perf"]`)
+	createTaggedItem(t, s, ws.ID, bugs.ID, "Bug C", `[]`) // untagged — excluded
+
+	t.Run("unfiltered aggregates across collections, ordered by count then tag", func(t *testing.T) {
+		tags, err := s.ListWorkspaceTags(ws.ID, nil, nil)
+		if err != nil {
+			t.Fatalf("ListWorkspaceTags: %v", err)
+		}
+		want := []models.TagCount{
+			{Tag: "User feedback", Count: 3},
+			{Tag: "perf", Count: 1},
+			{Tag: "ux", Count: 1},
+		}
+		if len(tags) != len(want) {
+			t.Fatalf("got %d tags, want %d: %+v", len(tags), len(want), tags)
+		}
+		for i, w := range want {
+			if tags[i] != w {
+				t.Errorf("tag[%d] = %+v, want %+v", i, tags[i], w)
+			}
+		}
+	})
+
+	t.Run("collection filter scopes counts to visible collections", func(t *testing.T) {
+		tags, err := s.ListWorkspaceTags(ws.ID, []string{ideas.ID}, nil)
+		if err != nil {
+			t.Fatalf("ListWorkspaceTags: %v", err)
+		}
+		want := []models.TagCount{
+			{Tag: "User feedback", Count: 2}, // only the 2 ideas, not the bug
+			{Tag: "ux", Count: 1},
+		}
+		if len(tags) != len(want) {
+			t.Fatalf("got %d tags, want %d: %+v", len(tags), len(want), tags)
+		}
+		for i, w := range want {
+			if tags[i] != w {
+				t.Errorf("tag[%d] = %+v, want %+v", i, tags[i], w)
+			}
+		}
+	})
+
+	t.Run("non-nil empty collection set returns no tags", func(t *testing.T) {
+		tags, err := s.ListWorkspaceTags(ws.ID, []string{}, nil)
+		if err != nil {
+			t.Fatalf("ListWorkspaceTags: %v", err)
+		}
+		if len(tags) != 0 {
+			t.Errorf("expected empty result for no visible collections, got %+v", tags)
+		}
+	})
+
+	t.Run("archived items are excluded", func(t *testing.T) {
+		extra := createTaggedItem(t, s, ws.ID, ideas.ID, "Idea Archived", `["archive-only"]`)
+		if err := s.DeleteItem(extra.ID); err != nil {
+			t.Fatalf("DeleteItem: %v", err)
+		}
+		tags, err := s.ListWorkspaceTags(ws.ID, nil, nil)
+		if err != nil {
+			t.Fatalf("ListWorkspaceTags: %v", err)
+		}
+		for _, tc := range tags {
+			if tc.Tag == "archive-only" {
+				t.Errorf("archived item's tag leaked into results: %+v", tags)
+			}
+		}
+	})
+}

--- a/internal/store/tags_test.go
+++ b/internal/store/tags_test.go
@@ -83,6 +83,21 @@ func TestListWorkspaceTags(t *testing.T) {
 		}
 	})
 
+	t.Run("duplicate tags on one item count the item once", func(t *testing.T) {
+		dupWS := createTestWorkspace(t, s, "Dup WS")
+		coll := createTestCollection(t, s, dupWS.ID, "Ideas")
+		// The write path doesn't enforce per-item tag uniqueness, so a single
+		// item can carry ["ux","ux"]. The count is "items carrying the tag".
+		createTaggedItem(t, s, dupWS.ID, coll.ID, "Dup", `["ux","ux"]`)
+		tags, err := s.ListWorkspaceTags(dupWS.ID, nil, nil)
+		if err != nil {
+			t.Fatalf("ListWorkspaceTags: %v", err)
+		}
+		if len(tags) != 1 || tags[0].Tag != "ux" || tags[0].Count != 1 {
+			t.Errorf("expected ux:1 (item counted once), got %+v", tags)
+		}
+	})
+
 	t.Run("archived items are excluded", func(t *testing.T) {
 		extra := createTaggedItem(t, s, ws.ID, ideas.ID, "Idea Archived", `["archive-only"]`)
 		if err := s.DeleteItem(extra.ID); err != nil {

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -10,6 +10,7 @@ import type {
 	ItemChangeRow,
 	ItemChangesResponse,
 	ItemCreate,
+	TagCount,
 	ItemIndexResponse,
 	ItemIndexRow,
 	ItemUpdate,
@@ -510,6 +511,15 @@ export const api = {
 	},
 
 	// ── Items ─────────────────────────────────────────────────────────────────
+
+	tags: {
+		/**
+		 * Distinct tags used across the workspace's items with per-tag item
+		 * counts, ordered by count desc then tag asc. Powers the tags index
+		 * page and tag-input autocomplete.
+		 */
+		list: (ws: string) => request<TagCount[]>(`/workspaces/${ws}/tags`),
+	},
 
 	items: {
 		/** Cross-collection item listing with optional query params. */

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -426,6 +426,16 @@ export interface ItemDecisionLogEntry {
 	created_by?: string;
 }
 
+/**
+ * A distinct tag used within a workspace and the number of items carrying it.
+ * Returned by `GET /workspaces/{ws}/tags` (api.tags.list), ordered by count
+ * desc then tag asc.
+ */
+export interface TagCount {
+	tag: string;
+	count: number;
+}
+
 export interface Item {
 	id: string;
 	workspace_id: string;


### PR DESCRIPTION
## Summary
Foundation for the tags feature (PLAN-1652 / IDEA-1649). The item write path and the per-collection `?tag=` filter already existed in the backend; this adds **tag enumeration** and verifies the **cross-collection** read, so a single tag can group items of any type (an Idea and a Bug under `User feedback`).

## What's new
- **Store:** `dialect.JSONArrayElements` unnests a JSON text-array column (`json_each` on SQLite, `jsonb_array_elements_text` on Postgres). `Store.ListWorkspaceTags` returns distinct tags + item counts, ordered by count desc then tag asc, applying the same collection/item ACL filters as `ListItems` so counts never leak items the caller can't see.
- **Server:** `GET /workspaces/{ws}/tags` → `[{tag, count}]`, respecting collection visibility + guest item grants. Confirmed the workspace-wide `GET /items` already routes `?tag=` through `parseItemListParams` → cross-collection filter works.
- **Models:** `TagCount{tag, count}`.
- **CLI:** `client.ListTags` + `pad tag list`.
- **Web:** `api.tags.list` + `TagCount` type (`items.list` already forwards a `tag` param via `qs()`).

## Context
Implements `TASK-1653` under `PLAN-1652`. Downstream tasks consume this: the tag editor (autocomplete), tag chips, and the dedicated tags pages.

## Test plan
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./...` — all pass
- [x] `cd web && npm run build` — clean
- [x] Store test: cross-collection aggregation, collection scoping, non-nil-empty set = empty, archived excluded
- [x] Handler test: a Task + an Idea sharing one tag returned by `?tag=`; `GET /tags` counts + ordering