### PR TITLE
feat(tags): tag chip editor on the item detail page (TASK-1654)

### DIFF
--- a/web/src/lib/components/fields/TagInput.svelte
+++ b/web/src/lib/components/fields/TagInput.svelte
@@ -1,0 +1,197 @@
+<script lang="ts">
+	/**
+	 * Free-form tag chip editor. Tags live on `item.tags` (a JSON-array
+	 * string), NOT in the collection schema — so this is a sibling of
+	 * FieldEditor rather than a field type. Emits the full new tag array via
+	 * `onchange`; the parent persists it (PATCH items.tags). Dedupe is
+	 * case-insensitive but tags are stored as typed (human-readable).
+	 */
+	interface Props {
+		tags: string[];
+		onchange: (tags: string[]) => void;
+		suggestions?: string[];
+		readonly?: boolean;
+	}
+
+	let { tags, onchange, suggestions = [], readonly = false }: Props = $props();
+
+	let inputValue = $state('');
+	let showSuggestions = $state(false);
+
+	function hasTag(value: string): boolean {
+		const v = value.trim().toLowerCase();
+		return tags.some((t) => t.toLowerCase() === v);
+	}
+
+	function addTag(raw: string) {
+		const value = raw.trim();
+		inputValue = '';
+		showSuggestions = false;
+		if (!value || hasTag(value)) return;
+		onchange([...tags, value]);
+	}
+
+	function removeTag(index: number) {
+		onchange(tags.filter((_, i) => i !== index));
+	}
+
+	function handleKeydown(e: KeyboardEvent) {
+		if (e.key === 'Enter' || e.key === ',') {
+			e.preventDefault();
+			addTag(inputValue);
+		} else if (e.key === 'Backspace' && inputValue === '' && tags.length > 0) {
+			removeTag(tags.length - 1);
+		} else if (e.key === 'Escape') {
+			showSuggestions = false;
+		}
+	}
+
+	// Suggestions not already applied, matched case-insensitively to the input.
+	let filteredSuggestions = $derived.by(() => {
+		const q = inputValue.trim().toLowerCase();
+		return suggestions
+			.filter((s) => !hasTag(s))
+			.filter((s) => q === '' || s.toLowerCase().includes(q))
+			.slice(0, 8);
+	});
+</script>
+
+{#if readonly}
+	<div class="tag-chips">
+		{#if tags.length === 0}
+			<span class="tag-empty">No tags</span>
+		{:else}
+			{#each tags as tag (tag)}
+				<span class="tag-chip readonly">{tag}</span>
+			{/each}
+		{/if}
+	</div>
+{:else}
+	<div class="tag-input">
+		<div class="tag-chips">
+			{#each tags as tag, i (tag)}
+				<span class="tag-chip">
+					{tag}
+					<button
+						type="button"
+						class="tag-remove"
+						aria-label={`Remove ${tag}`}
+						onclick={() => removeTag(i)}>×</button
+					>
+				</span>
+			{/each}
+			<input
+				bind:value={inputValue}
+				class="tag-entry"
+				type="text"
+				placeholder={tags.length === 0 ? 'Add tags…' : ''}
+				onkeydown={handleKeydown}
+				onfocus={() => (showSuggestions = true)}
+				onblur={() => setTimeout(() => (showSuggestions = false), 120)}
+			/>
+		</div>
+		{#if showSuggestions && filteredSuggestions.length > 0}
+			<div class="tag-suggestions">
+				{#each filteredSuggestions as s (s)}
+					<button
+						type="button"
+						class="tag-suggestion"
+						onmousedown={(e) => {
+							e.preventDefault();
+							addTag(s);
+						}}>{s}</button
+					>
+				{/each}
+			</div>
+		{/if}
+	</div>
+{/if}
+
+<style>
+	.tag-input {
+		position: relative;
+		width: 100%;
+	}
+	.tag-chips {
+		display: flex;
+		flex-wrap: wrap;
+		gap: var(--space-1, 0.25rem);
+		align-items: center;
+	}
+	.tag-chip {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.25em;
+		padding: 0.1em 0.5em;
+		font-size: var(--text-xs, 0.75rem);
+		line-height: 1.5;
+		background: var(--bg-secondary);
+		border: 1px solid var(--border);
+		border-radius: 999px;
+		color: var(--text-primary);
+		white-space: nowrap;
+	}
+	.tag-chip.readonly {
+		color: var(--text-secondary);
+	}
+	.tag-remove {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		padding: 0;
+		width: 1.1em;
+		height: 1.1em;
+		border: none;
+		background: transparent;
+		color: var(--text-secondary);
+		font-size: 1.1em;
+		line-height: 1;
+		cursor: pointer;
+		border-radius: 50%;
+	}
+	.tag-remove:hover {
+		color: var(--text-primary);
+		background: var(--bg-hover, rgba(0, 0, 0, 0.06));
+	}
+	.tag-entry {
+		flex: 1;
+		min-width: 6ch;
+		border: none;
+		background: transparent;
+		color: var(--text-primary);
+		font-size: var(--text-sm, 0.875rem);
+		padding: 0.15em 0.1em;
+		outline: none;
+	}
+	.tag-empty {
+		font-size: var(--text-xs, 0.75rem);
+		color: var(--text-tertiary, var(--text-secondary));
+	}
+	.tag-suggestions {
+		position: absolute;
+		top: calc(100% + 2px);
+		left: 0;
+		z-index: 20;
+		min-width: 10rem;
+		max-width: 100%;
+		display: flex;
+		flex-direction: column;
+		background: var(--bg-primary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius-md, 6px);
+		box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+		overflow: hidden;
+	}
+	.tag-suggestion {
+		text-align: left;
+		padding: 0.35em 0.6em;
+		border: none;
+		background: transparent;
+		color: var(--text-primary);
+		font-size: var(--text-sm, 0.875rem);
+		cursor: pointer;
+	}
+	.tag-suggestion:hover {
+		background: var(--bg-hover, var(--bg-secondary));
+	}
+</style>

--- a/web/src/lib/components/fields/TagInput.svelte
+++ b/web/src/lib/components/fields/TagInput.svelte
@@ -61,7 +61,9 @@
 		{#if tags.length === 0}
 			<span class="tag-empty">No tags</span>
 		{:else}
-			{#each tags as tag (tag)}
+			<!-- Key by index: the write path doesn't enforce per-item tag
+			     uniqueness, so a value key would collide on ["ux","ux"]. -->
+			{#each tags as tag, i (i)}
 				<span class="tag-chip readonly">{tag}</span>
 			{/each}
 		{/if}
@@ -69,7 +71,7 @@
 {:else}
 	<div class="tag-input">
 		<div class="tag-chips">
-			{#each tags as tag, i (tag)}
+			{#each tags as tag, i (i)}
 				<span class="tag-chip">
 					{tag}
 					<button

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -1124,6 +1124,14 @@
 		}
 	}
 
+	// Monotonic guard so overlapping tag saves can't clobber each other. The
+	// chip input makes rapid edits easy (add a, add b, remove c before the
+	// first PATCH resolves); only the LATEST request may apply its server
+	// result or revert, so a late-resolving older request can't replace the
+	// newer tag set with stale data. Combined with the item.id check it's also
+	// safe across navigation. Per Codex PR #659 round 1.
+	let tagSaveSeq = 0;
+
 	// Persist a new tag set. Tags are a top-level item column (item.tags), not
 	// a schema field, so this mirrors updateField but PATCHes `tags` and has
 	// no open-children guard (tags never gate completion). Optimistic so chips
@@ -1134,18 +1142,21 @@
 		const targetWs = wsSlug;
 		const prevTags = targetItem.tags;
 		const payload = JSON.stringify(newTags);
+		const seq = ++tagSaveSeq;
 		if (item.id === targetItem.id) item = { ...item, tags: payload };
 		saveStatus = 'saving';
 		try {
 			const fresh = await api.items.update(targetWs, targetItem.id, { tags: payload });
+			if (seq !== tagSaveSeq) return; // superseded by a newer save
 			if (item && item.id === targetItem.id) item = fresh;
 			showSaved();
 			// A newly-created tag should appear in autocomplete next time.
 			void loadTagSuggestions(targetWs);
 		} catch (e) {
+			console.error('Failed to save tags:', e);
+			if (seq !== tagSaveSeq) return; // a newer save owns the state now
 			if (item && item.id === targetItem.id) item = { ...item, tags: prevTags };
 			saveStatus = 'idle';
-			console.error('Failed to save tags:', e);
 			toastStore.show('Failed to save', 'error');
 		}
 	}

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -1155,7 +1155,11 @@
 		running: boolean;
 		confirmed: string; // last server-acknowledged tags JSON (revert target)
 	};
-	let tagSaver: TagSaver | null = null;
+	// Keyed by item id so each item's in-flight saver stays discoverable across
+	// navigation — navigating away from A and back must find A's running saver
+	// and coalesce into it, not spawn a second concurrent A saver. Per Codex
+	// PR #659 round 6.
+	const tagSavers = new Map<string, TagSaver>();
 
 	function updateTags(newTags: string[]) {
 		if (!item) return;
@@ -1164,20 +1168,23 @@
 		// Optimistic so chips react instantly.
 		item = { ...item, tags: JSON.stringify(newTags) };
 
-		// Reuse the running saver only when it's for THIS item; otherwise start
-		// a fresh one (a saver for a previous item keeps draining on its own).
-		if (tagSaver && tagSaver.running && tagSaver.itemId === targetItem.id) {
-			tagSaver.pending = newTags; // coalesce
+		// Coalesce into this item's running saver if one exists; otherwise
+		// start a fresh one. The currently-displayed item is the only one whose
+		// tags can be edited, so targetItem.id keys the right saver.
+		const existing = tagSavers.get(targetItem.id);
+		if (existing && existing.running) {
+			existing.pending = newTags;
 			return;
 		}
-		tagSaver = {
+		const saver: TagSaver = {
 			itemId: targetItem.id,
 			ws: targetWs,
 			pending: newTags,
 			running: false,
 			confirmed: targetItem.tags // confirmed baseline captured at burst start
 		};
-		void flushTagSaver(tagSaver);
+		tagSavers.set(targetItem.id, saver);
+		void flushTagSaver(saver);
 	}
 
 	async function flushTagSaver(saver: TagSaver) {
@@ -1211,6 +1218,11 @@
 			}
 		} finally {
 			saver.running = false;
+			// Drop the entry once fully drained so the map doesn't accumulate
+			// stale savers; guard on identity so a newer saver isn't evicted.
+			if (saver.pending === null && tagSavers.get(saver.itemId) === saver) {
+				tagSavers.delete(saver.itemId);
+			}
 		}
 	}
 

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -1162,14 +1162,19 @@
 		try {
 			const fresh = await api.items.update(targetWs, targetItem.id, { tags: payload });
 			if (seq !== tagSaveSeq) return; // superseded by a newer save
-			if (item && item.id === targetItem.id) item = fresh;
+			// Also bail if the user navigated to a different item while this
+			// was in flight — otherwise the completion UI (item swap, ✓ Saved,
+			// suggestion refresh) would fire on an unrelated page.
+			if (!item || item.id !== targetItem.id) return;
+			item = fresh;
 			showSaved();
 			// A newly-created tag should appear in autocomplete next time.
 			void loadTagSuggestions(targetWs);
 		} catch (e) {
 			console.error('Failed to save tags:', e);
 			if (seq !== tagSaveSeq) return; // a newer save owns the state now
-			if (item && item.id === targetItem.id) item = { ...item, tags: prevTags };
+			if (!item || item.id !== targetItem.id) return; // navigated away
+			item = { ...item, tags: prevTags };
 			saveStatus = 'idle';
 			toastStore.show('Failed to save', 'error');
 		}

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -1079,7 +1079,7 @@
 
 		try {
 			const fresh = await doUpdate(false);
-			if (item && item.id === targetItem.id) item = fresh;
+			if (item && item.id === targetItem.id) item = withInflightTags(fresh);
 			showSaved();
 		} catch (e) {
 			// BUG-1538 / TASK-1539: same open-children-guard recovery
@@ -1103,7 +1103,7 @@
 					return;
 				}
 				if (forced) {
-					if (item && item.id === targetItem.id) item = forced;
+					if (item && item.id === targetItem.id) item = withInflightTags(forced);
 					showSaved();
 					return;
 				}

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -483,6 +483,14 @@
 			const inFlightTagSaver = tagSavers.get(itemData.id);
 			if (inFlightTagSaver?.running) {
 				item = { ...itemData, tags: JSON.stringify(inFlightTagSaver.desired) };
+				// loadData reset saveStatus to 'idle' above, but a tag PATCH is
+				// still in flight. Restore 'saving' so the SSE/sync refresh
+				// guards (saveStatus === 'saving') keep skipping snapshot
+				// adoption until it drains — otherwise a stale server snapshot
+				// could land and a follow-up edit would build on it, dropping
+				// the in-flight tags. The saver's own completion path resets the
+				// indicator. Per Codex PR #659 round 8.
+				saveStatus = 'saving';
 			}
 			collection = collData;
 			collectionStore.setActiveItem(itemData);

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -1138,45 +1138,79 @@
 		}
 	}
 
-	// Monotonic guard so overlapping tag saves can't clobber each other. The
-	// chip input makes rapid edits easy (add a, add b, remove c before the
-	// first PATCH resolves); only the LATEST request may apply its server
-	// result or revert, so a late-resolving older request can't replace the
-	// newer tag set with stale data. Combined with the item.id check it's also
-	// safe across navigation. Per Codex PR #659 round 1.
-	let tagSaveSeq = 0;
+	// Serialized, coalescing tag saver. Tags are a top-level item column
+	// (item.tags), not a schema field, and the chip input makes rapid edits
+	// easy — so instead of firing concurrent PATCHes and guarding the races,
+	// we keep ONE save in flight per item and coalesce to the latest desired
+	// set. This structurally removes the overlap class: no stale completion
+	// can clobber a newer set, and `confirmed` always tracks the last
+	// server-acknowledged tags so a failed save reverts to server truth (not
+	// to an optimistic, unconfirmed value). Scoped by item id so a save still
+	// draining for a previous item can't touch the current one. Per Codex
+	// PR #659 rounds 1/4/5.
+	type TagSaver = {
+		itemId: string;
+		ws: string;
+		pending: string[] | null; // latest desired set not yet sent (coalesced)
+		running: boolean;
+		confirmed: string; // last server-acknowledged tags JSON (revert target)
+	};
+	let tagSaver: TagSaver | null = null;
 
-	// Persist a new tag set. Tags are a top-level item column (item.tags), not
-	// a schema field, so this mirrors updateField but PATCHes `tags` and has
-	// no open-children guard (tags never gate completion). Optimistic so chips
-	// react instantly; reverts on failure.
-	async function updateTags(newTags: string[]) {
+	function updateTags(newTags: string[]) {
 		if (!item) return;
 		const targetItem = item;
 		const targetWs = wsSlug;
-		const prevTags = targetItem.tags;
-		const payload = JSON.stringify(newTags);
-		const seq = ++tagSaveSeq;
-		if (item.id === targetItem.id) item = { ...item, tags: payload };
+		// Optimistic so chips react instantly.
+		item = { ...item, tags: JSON.stringify(newTags) };
+
+		// Reuse the running saver only when it's for THIS item; otherwise start
+		// a fresh one (a saver for a previous item keeps draining on its own).
+		if (tagSaver && tagSaver.running && tagSaver.itemId === targetItem.id) {
+			tagSaver.pending = newTags; // coalesce
+			return;
+		}
+		tagSaver = {
+			itemId: targetItem.id,
+			ws: targetWs,
+			pending: newTags,
+			running: false,
+			confirmed: targetItem.tags // confirmed baseline captured at burst start
+		};
+		void flushTagSaver(tagSaver);
+	}
+
+	async function flushTagSaver(saver: TagSaver) {
+		saver.running = true;
 		saveStatus = 'saving';
 		try {
-			const fresh = await api.items.update(targetWs, targetItem.id, { tags: payload });
-			if (seq !== tagSaveSeq) return; // superseded by a newer save
-			// Also bail if the user navigated to a different item while this
-			// was in flight — otherwise the completion UI (item swap, ✓ Saved,
-			// suggestion refresh) would fire on an unrelated page.
-			if (!item || item.id !== targetItem.id) return;
-			item = fresh;
-			showSaved();
+			while (saver.pending !== null) {
+				const toSave = saver.pending;
+				saver.pending = null;
+				const fresh = await api.items.update(saver.ws, saver.itemId, {
+					tags: JSON.stringify(toSave)
+				});
+				saver.confirmed = fresh.tags;
+				// Reconcile the UI to server truth only when nothing newer is
+				// queued (avoids flicker) and we're still on this item.
+				if (saver.pending === null && item && item.id === saver.itemId) {
+					item = fresh;
+				}
+			}
+			if (item && item.id === saver.itemId) showSaved();
 			// A newly-created tag should appear in autocomplete next time.
-			void loadTagSuggestions(targetWs);
+			void loadTagSuggestions(saver.ws);
 		} catch (e) {
 			console.error('Failed to save tags:', e);
-			if (seq !== tagSaveSeq) return; // a newer save owns the state now
-			if (!item || item.id !== targetItem.id) return; // navigated away
-			item = { ...item, tags: prevTags };
-			saveStatus = 'idle';
-			toastStore.show('Failed to save', 'error');
+			saver.pending = null;
+			if (item && item.id === saver.itemId) {
+				// Revert to the last server-confirmed tags, not the optimistic set.
+				item = { ...item, tags: saver.confirmed };
+				saveStatus = 'idle';
+				toastStore.show('Failed to save', 'error');
+			}
+		} finally {
+			saver.running = false;
 		}
 	}
 

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -311,11 +311,7 @@
 						// a debounced save is in flight, but a user
 						// mid-keystroke with no save yet pending would
 						// still lose chars without this branch.
-						if (collabProvider) {
-							item = updated;
-						} else {
-							item = { ...updated, content: item.content };
-						}
+						item = adoptServerItem(updated);
 						const links = await api.links.list(reqWsSlug, updated.slug).catch(() => []);
 						if (!item || item.id !== reqItemId) return;
 						itemLinks = links;
@@ -328,11 +324,7 @@
 					try {
 						const updated = await api.items.get(reqWsSlug, reqItemSlug);
 						if (!item || item.id !== reqItemId) return;
-						if (collabProvider) {
-							item = updated;
-						} else {
-							item = { ...updated, content: item.content };
-						}
+						item = adoptServerItem(updated);
 					} catch {
 						// Ignore — will catch up on next event
 					}
@@ -374,11 +366,7 @@
 					// Same collab-aware adoption rule as the SSE
 					// handler above (TASK-1262).
 					if (!item || item.id !== reqItemId) return;
-					if (collabProvider) {
-						item = updated;
-					} else {
-						item = { ...updated, content: item.content };
-					}
+					item = adoptServerItem(updated);
 					const links = await api.links.list(reqWsSlug, updated.slug).catch(() => []);
 					if (!item || item.id !== reqItemId) return;
 					itemLinks = links;
@@ -390,11 +378,7 @@
 			try {
 				const updated = await api.items.get(reqWsSlug, reqItemSlug);
 				if (!item || item.id !== reqItemId) return;
-				if (collabProvider) {
-					item = updated;
-				} else {
-					item = { ...updated, content: item.content };
-				}
+				item = adoptServerItem(updated);
 				const links = await api.links.list(reqWsSlug, updated.slug).catch(() => []);
 				if (!item || item.id !== reqItemId) return;
 				itemLinks = links;
@@ -474,24 +458,10 @@
 				api.collections.get(wsSlug, collSlug),
 				itemsPromise
 			]);
-			item = itemData;
-			// If a tag save for this item is still in flight, the freshly
-			// loaded server tags may predate the optimistic edit. Reapply the
-			// saver's latest desired set so navigating away and back can't
-			// visually drop an unsaved tag edit (and then let a follow-up edit
-			// built on stale tags overwrite it). Per Codex PR #659 round 7.
-			const inFlightTagSaver = tagSavers.get(itemData.id);
-			if (inFlightTagSaver?.running) {
-				item = { ...itemData, tags: JSON.stringify(inFlightTagSaver.desired) };
-				// loadData reset saveStatus to 'idle' above, but a tag PATCH is
-				// still in flight. Restore 'saving' so the SSE/sync refresh
-				// guards (saveStatus === 'saving') keep skipping snapshot
-				// adoption until it drains — otherwise a stale server snapshot
-				// could land and a follow-up edit would build on it, dropping
-				// the in-flight tags. The saver's own completion path resets the
-				// indicator. Per Codex PR #659 round 8.
-				saveStatus = 'saving';
-			}
+			// Overlay any in-flight optimistic tag edit so navigating away and
+			// back mid-save can't show (and then let a follow-up edit overwrite
+			// with) stale server tags. See withInflightTags. Per Codex PR #659.
+			item = withInflightTags(itemData);
 			collection = collData;
 			collectionStore.setActiveItem(itemData);
 			editorStore.resetForDoc();
@@ -844,7 +814,7 @@
 						// item; a navigation away should not stamp
 						// fresh content into the OTHER item's slot.
 						if (item && item.id === refreshCtx.itemId) {
-							item = fresh;
+							item = withInflightTags(fresh);
 						}
 						// Refetch succeeded → safe to rebuild.
 						forceRefreshNonce += 1;
@@ -1074,7 +1044,7 @@
 		if (!item || titleDraft.trim() === item.title) return;
 		saveStatus = 'saving';
 		try {
-			item = await api.items.update(wsSlug, item.id, { title: titleDraft.trim() });
+			item = withInflightTags(await api.items.update(wsSlug, item.id, { title: titleDraft.trim() }));
 			showSaved();
 		} catch {
 			saveStatus = 'idle';
@@ -1246,6 +1216,29 @@
 		}
 	}
 
+	// Overlay an in-flight optimistic tag edit onto any server snapshot of an
+	// item before it's assigned to `item`. EVERY `item = <server data>`
+	// assignment (realtime SSE/sync, content-save echo, post-action refresh,
+	// initial load) must route through this: a tag PATCH owns `item.tags` until
+	// it drains, and the refresh handlers' `saveStatus === 'saving'` guard is
+	// racy (checked before their own await, not after), so overlaying the
+	// saver's latest desired set at assignment time is the only race-free
+	// guarantee that a concurrent snapshot can't drop the unsaved tags. Per
+	// Codex PR #659 rounds 8/9.
+	function withInflightTags(next: Item): Item {
+		const saver = tagSavers.get(next.id);
+		return saver?.running ? { ...next, tags: JSON.stringify(saver.desired) } : next;
+	}
+
+	// Realtime-refresh convenience: applies the content-adoption rule (under
+	// collab the editor reads Y.Doc so adopt server content verbatim; otherwise
+	// preserve the live local content) and the tag overlay.
+	function adoptServerItem(updated: Item): Item {
+		return withInflightTags(
+			collabProvider ? updated : { ...updated, content: item?.content ?? updated.content }
+		);
+	}
+
 	// Load the workspace's distinct tags for autocomplete. Pure data-fetch
 	// keyed on the workspace slug (see the $effect below) — kept separate from
 	// the item-load path per the Svelte 5 effect-splitting convention.
@@ -1314,7 +1307,7 @@
 				fields: JSON.stringify(merged)
 			});
 			if (item && item.id === targetItem.id) {
-				item = fresh;
+				item = withInflightTags(fresh);
 			}
 		} catch (err) {
 			// Non-fatal: the content was inserted regardless of whether
@@ -1427,7 +1420,7 @@
 			} else {
 				update.clear_assigned_user = true;
 			}
-			item = await api.items.update(wsSlug, item.id, update);
+			item = withInflightTags(await api.items.update(wsSlug, item.id, update));
 			showSaved();
 		} catch {
 			saveStatus = 'idle';
@@ -1445,7 +1438,7 @@
 			} else {
 				update.clear_agent_role = true;
 			}
-			item = await api.items.update(wsSlug, item.id, update);
+			item = withInflightTags(await api.items.update(wsSlug, item.id, update));
 			showSaved();
 		} catch {
 			saveStatus = 'idle';
@@ -1734,7 +1727,7 @@
 				// drop the queued edit. Mirrors the Round 8 fix in
 				// flushRawIfPending. Per Codex review round 9.
 				if (rawPendingMarkdown === toSave) {
-					item = updated;
+					item = withInflightTags(updated);
 					rawPendingMarkdown = null;
 					editorStore.setDirty(false);
 					showSaved();
@@ -1742,7 +1735,7 @@
 					// Newer pending edit; keep local content, adopt
 					// server-side metadata only. The next debounce
 					// cycle will land the queued edit.
-					item = { ...updated, content: item.content };
+					item = withInflightTags({ ...updated, content: item.content });
 				}
 			}).catch(() => {
 				if (!item || item.id !== reqItemId) return;
@@ -1823,13 +1816,13 @@
 					// from under the user's keystrokes and lose the
 					// queued edit. Per Codex review round 8.
 					if (rawPendingMarkdown === markdown) {
-						item = updated;
+						item = withInflightTags(updated);
 						rawPendingMarkdown = null;
 					} else {
 						// Newer edit pending — keep our local
 						// content but adopt server-side metadata
 						// (timestamps, version, modified_by).
-						item = { ...updated, content: item.content };
+						item = withInflightTags({ ...updated, content: item.content });
 					}
 				} catch {
 					saveStatus = 'idle';
@@ -1995,7 +1988,7 @@
 	}
 
 	function handleVersionRestore(updatedItem: Item) {
-		item = updatedItem;
+		item = withInflightTags(updatedItem);
 	}
 
 	async function handleDelete() {
@@ -2022,7 +2015,7 @@
 			itemLinks = itemLinks.filter(l => l.id !== linkId);
 			// Refresh item to update parent info
 			const refreshed = await api.items.get(wsSlug, itemSlug);
-			item = { ...refreshed, content: item.content };
+			item = withInflightTags({ ...refreshed, content: item.content });
 			toastStore.show('Relationship removed', 'success');
 		} catch (e: any) {
 			toastStore.show(e.message ?? 'Failed to remove relationship', 'error');
@@ -2070,7 +2063,7 @@
 			addLinkResults = [];
 			// Refresh item to update parent info
 			const refreshed = await api.items.get(wsSlug, itemSlug);
-			item = { ...refreshed, content: item.content };
+			item = withInflightTags({ ...refreshed, content: item.content });
 			toastStore.show('Relationship added', 'success');
 		} catch (e: any) {
 			toastStore.show(e.message ?? 'Failed to add relationship', 'error');

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -475,6 +475,15 @@
 				itemsPromise
 			]);
 			item = itemData;
+			// If a tag save for this item is still in flight, the freshly
+			// loaded server tags may predate the optimistic edit. Reapply the
+			// saver's latest desired set so navigating away and back can't
+			// visually drop an unsaved tag edit (and then let a follow-up edit
+			// built on stale tags overwrite it). Per Codex PR #659 round 7.
+			const inFlightTagSaver = tagSavers.get(itemData.id);
+			if (inFlightTagSaver?.running) {
+				item = { ...itemData, tags: JSON.stringify(inFlightTagSaver.desired) };
+			}
 			collection = collData;
 			collectionStore.setActiveItem(itemData);
 			editorStore.resetForDoc();
@@ -1152,6 +1161,7 @@
 		itemId: string;
 		ws: string;
 		pending: string[] | null; // latest desired set not yet sent (coalesced)
+		desired: string[]; // latest desired set (in-flight OR pending) for reload reapply
 		running: boolean;
 		confirmed: string; // last server-acknowledged tags JSON (revert target)
 	};
@@ -1174,12 +1184,14 @@
 		const existing = tagSavers.get(targetItem.id);
 		if (existing && existing.running) {
 			existing.pending = newTags;
+			existing.desired = newTags;
 			return;
 		}
 		const saver: TagSaver = {
 			itemId: targetItem.id,
 			ws: targetWs,
 			pending: newTags,
+			desired: newTags,
 			running: false,
 			confirmed: targetItem.tags // confirmed baseline captured at burst start
 		};

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -17,6 +17,7 @@
 	import { userColor } from '$lib/collab/cursorColor';
 	import { authStore } from '$lib/stores/auth.svelte';
 	import FieldEditor from '$lib/components/fields/FieldEditor.svelte';
+	import TagInput from '$lib/components/fields/TagInput.svelte';
 	import ItemTimeline from '$lib/components/timeline/ItemTimeline.svelte';
 	import ChildItems from '$lib/components/ChildItems.svelte';
 	import BacklinksPanel from '$lib/components/BacklinksPanel.svelte';
@@ -97,6 +98,18 @@
 	let titleInputEl = $state<HTMLTextAreaElement>();
 
 	let fields = $derived<Record<string, any>>(item ? parseFields(item) : {});
+	// Tags live on item.tags (a JSON-array string), NOT in the schema. Parse
+	// defensively — the column defaults to "[]" but tolerate empty/garbage.
+	let tags = $derived.by<string[]>(() => {
+		if (!item?.tags) return [];
+		try {
+			const parsed = JSON.parse(item.tags);
+			return Array.isArray(parsed) ? parsed : [];
+		} catch {
+			return [];
+		}
+	});
+	let tagSuggestions = $state<string[]>([]);
 	let schema = $derived(collection ? parseSchema(collection) : { fields: [] });
 	let settings = $derived<CollectionSettings>(collection ? parseSettings(collection) : { layout: 'balanced', default_view: 'list' });
 	let layout = $derived(settings.layout);
@@ -1110,6 +1123,49 @@
 			toastStore.show('Failed to save', 'error');
 		}
 	}
+
+	// Persist a new tag set. Tags are a top-level item column (item.tags), not
+	// a schema field, so this mirrors updateField but PATCHes `tags` and has
+	// no open-children guard (tags never gate completion). Optimistic so chips
+	// react instantly; reverts on failure.
+	async function updateTags(newTags: string[]) {
+		if (!item) return;
+		const targetItem = item;
+		const targetWs = wsSlug;
+		const prevTags = targetItem.tags;
+		const payload = JSON.stringify(newTags);
+		if (item.id === targetItem.id) item = { ...item, tags: payload };
+		saveStatus = 'saving';
+		try {
+			const fresh = await api.items.update(targetWs, targetItem.id, { tags: payload });
+			if (item && item.id === targetItem.id) item = fresh;
+			showSaved();
+			// A newly-created tag should appear in autocomplete next time.
+			void loadTagSuggestions(targetWs);
+		} catch (e) {
+			if (item && item.id === targetItem.id) item = { ...item, tags: prevTags };
+			saveStatus = 'idle';
+			console.error('Failed to save tags:', e);
+			toastStore.show('Failed to save', 'error');
+		}
+	}
+
+	// Load the workspace's distinct tags for autocomplete. Pure data-fetch
+	// keyed on the workspace slug (see the $effect below) — kept separate from
+	// the item-load path per the Svelte 5 effect-splitting convention.
+	async function loadTagSuggestions(ws: string) {
+		if (!ws) return;
+		try {
+			const all = await api.tags.list(ws);
+			tagSuggestions = all.map((t) => t.tag);
+		} catch {
+			tagSuggestions = [];
+		}
+	}
+
+	$effect(() => {
+		loadTagSuggestions(wsSlug);
+	});
 
 	// stampSourceUrl writes the pad_source_url + pad_imported_at orphan
 	// keys into the item's `fields` JSON. The keys aren't declared in
@@ -2342,6 +2398,19 @@
 						</div>
 					{/if}
 				{/each}
+
+				<!-- Tags (item.tags — spans collections, not a schema field) -->
+				<div class="field-row">
+					<span class="field-label">Tags</span>
+					<div class="field-value">
+						<TagInput
+							{tags}
+							suggestions={tagSuggestions}
+							onchange={updateTags}
+							readonly={!canEdit}
+						/>
+					</div>
+				</div>
 
 				<!-- Assignment: user + role -->
 				{#if workspaceMembers.length > 0 || agentRoles.length > 0}

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -104,7 +104,21 @@
 		if (!item?.tags) return [];
 		try {
 			const parsed = JSON.parse(item.tags);
-			return Array.isArray(parsed) ? parsed : [];
+			if (!Array.isArray(parsed)) return [];
+			// Dedupe case-insensitively (keep first as typed). The write path
+			// doesn't enforce per-item uniqueness, so an API/imported item can
+			// carry ["ux","ux"]; cleaning here keeps rendering keys unique and
+			// the dedupe gets persisted on the next save.
+			const seen = new Set<string>();
+			const out: string[] = [];
+			for (const t of parsed) {
+				if (typeof t !== 'string') continue;
+				const key = t.toLowerCase();
+				if (seen.has(key)) continue;
+				seen.add(key);
+				out.push(t);
+			}
+			return out;
 		} catch {
 			return [];
 		}

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -1189,9 +1189,13 @@
 				});
 				saver.confirmed = fresh.tags;
 				// Reconcile the UI to server truth only when nothing newer is
-				// queued (avoids flicker) and we're still on this item.
+				// queued (avoids flicker) and we're still on this item. Route
+				// through adoptServerItem so the tag PATCH echo can't clobber
+				// unsaved editor content — its response carries the server's
+				// `content`, and non-collab editors mirror item.content. Per
+				// Codex PR #659 round 11.
 				if (saver.pending === null && item && item.id === saver.itemId) {
-					item = fresh;
+					item = adoptServerItem(fresh);
 				}
 			}
 			if (item && item.id === saver.itemId) showSaved();

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -1168,9 +1168,14 @@
 		if (!ws) return;
 		try {
 			const all = await api.tags.list(ws);
+			// Drop stale results: if the workspace changed while this request
+			// was in flight (page instance reused across navigation, or a
+			// post-save reload for a now-previous workspace), don't overwrite
+			// the current workspace's suggestions. Per Codex PR #659 round 2.
+			if (ws !== wsSlug) return;
 			tagSuggestions = all.map((t) => t.tag);
 		} catch {
-			tagSuggestions = [];
+			if (ws === wsSlug) tagSuggestions = [];
 		}
 	}
 


### PR DESCRIPTION
## Summary
Adds a tag chip editor to the item detail page. Tags live on `item.tags` (a JSON-array string), **not** the collection schema, so this is a sibling of `FieldEditor` rather than a field type.

- **`TagInput.svelte`** — chip editor: Enter/comma to add, Backspace or × to remove, **case-insensitive dedupe** (stored as typed, e.g. `User feedback`), and an **autocomplete dropdown** sourced from the workspace tag set (`api.tags.list`). `readonly` mode renders plain chips. Validated via the Svelte MCP autofixer (0 issues).
- **Item detail page** — derives `tags` from `item.tags` (defensive parse), loads `tagSuggestions` via a workspace-keyed `$effect` kept separate from the item-load path (per the Svelte 5 effect-splitting convention), and `updateTags()` mirrors `updateField()` — optimistic local update with revert-on-failure, PATCHing `tags`. The Tags row sits between the schema fields and the Assignment section.

`api.items.update` already accepted `tags` via `ItemUpdate`, so no client-layer change was needed.

## Context
Implements `TASK-1654` under `PLAN-1652`. Builds on the enumeration endpoint from #658. Chip *display* across board/list and the dedicated tag pages are the following tasks.

## Test plan
- [x] `cd web && npm run build` — clean (type-checks via the Svelte plugin)
- [x] Svelte autofixer on TagInput — 0 issues
- [ ] Manual: add/remove tags on an item, autocomplete suggests existing tags, dedupe is case-insensitive, optimistic update reverts on a failed save