### PR TITLE
feat(tags): render tag chips on cards, list rows, and the item header (TASK-1655)

### DIFF
--- a/internal/store/collections.go
+++ b/internal/store/collections.go
@@ -654,6 +654,7 @@ var reservedCollectionSlugs = map[string]bool{
 	"activity": true,
 	"roles":    true,
 	"starred":  true,
+	"tags":     true, // Tag pages: /{ws}/tags and /{ws}/tags/{tag} (PLAN-1652)
 	"library":  true,
 	"insights": true, // Insights analytics page route (PLAN-1628 / TASK-1633)
 	"new":      true,

--- a/web/src/lib/components/collections/ItemCard.svelte
+++ b/web/src/lib/components/collections/ItemCard.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
 	import { page } from '$app/state';
+	import { goto } from '$app/navigation';
 	import type { Item, Collection } from '$lib/types';
-	import { parseFields, parseSchema, formatItemRef, itemUrlId } from '$lib/types';
+	import { parseFields, parseSchema, parseTags, formatItemRef, itemUrlId } from '$lib/types';
 	import { starredStore } from '$lib/stores/starred.svelte';
 
 	interface Props {
@@ -27,6 +28,19 @@
 	let priorityField = $derived(schema.fields.find((f) => f.key === 'priority'));
 	let itemUrl = $derived(`/${username}/${wsSlug}/${collection.slug}/${itemUrlId(item)}`);
 	let itemRef = $derived(formatItemRef(item));
+	let tags = $derived(parseTags(item));
+
+	function tagUrl(tag: string): string {
+		return `/${username}/${wsSlug}/tags/${encodeURIComponent(tag)}`;
+	}
+
+	// The card is an <a>; navigate to the tag page programmatically (like the
+	// star/PR/status controls) so the chip doesn't trigger the card link.
+	function openTag(e: MouseEvent, tag: string) {
+		e.preventDefault();
+		e.stopPropagation();
+		goto(tagUrl(tag));
+	}
 	let starred = $derived(starredStore.isStarred(item.id));
 
 	let statusCyclable = $derived(
@@ -172,6 +186,16 @@
 			<span class="meta-assignee">{item.assigned_user_name}</span>
 		{/if}
 	</div>
+
+	{#if tags.length > 0}
+		<div class="card-tags">
+			{#each tags as tag, i (i)}
+				<button type="button" class="card-tag" onclick={(e) => openTag(e, tag)} title="View items tagged “{tag}”">
+					{tag}
+				</button>
+			{/each}
+		</div>
+	{/if}
 
 	{#if progress && progress.total > 0}
 		<div class="card-progress">
@@ -398,6 +422,34 @@
 		color: var(--accent-blue);
 		margin-left: auto;
 		white-space: nowrap;
+	}
+
+	.card-tags {
+		display: flex;
+		flex-wrap: wrap;
+		gap: var(--space-1, 0.25rem);
+	}
+
+	.card-tag {
+		display: inline-flex;
+		align-items: center;
+		padding: 0.05em 0.45em;
+		font-size: 0.68em;
+		line-height: 1.5;
+		background: var(--bg-secondary);
+		border: 1px solid var(--border);
+		border-radius: 999px;
+		color: var(--text-secondary);
+		cursor: pointer;
+		max-width: 12rem;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.card-tag:hover {
+		color: var(--text-primary);
+		border-color: var(--text-tertiary, var(--text-secondary));
 	}
 
 	.card-progress {

--- a/web/src/lib/components/layout/Sidebar.svelte
+++ b/web/src/lib/components/layout/Sidebar.svelte
@@ -34,7 +34,12 @@
 	let isRolesPage = $derived(wsPrefix ? page.url.pathname === `${wsPrefix}/roles` : false);
 	let isActivityPage = $derived(wsPrefix ? page.url.pathname === `${wsPrefix}/activity` : false);
 	let isStarredPage = $derived(wsPrefix ? page.url.pathname === `${wsPrefix}/starred` : false);
-	let isTagsPage = $derived(wsPrefix ? page.url.pathname.startsWith(`${wsPrefix}/tags`) : false);
+	let isTagsPage = $derived(
+		wsPrefix
+			? page.url.pathname === `${wsPrefix}/tags` ||
+					page.url.pathname.startsWith(`${wsPrefix}/tags/`)
+			: false
+	);
 
 	let activeCollectionSlug = $derived.by(() => {
 		if (!wsPrefix) return null;

--- a/web/src/lib/components/layout/Sidebar.svelte
+++ b/web/src/lib/components/layout/Sidebar.svelte
@@ -34,6 +34,7 @@
 	let isRolesPage = $derived(wsPrefix ? page.url.pathname === `${wsPrefix}/roles` : false);
 	let isActivityPage = $derived(wsPrefix ? page.url.pathname === `${wsPrefix}/activity` : false);
 	let isStarredPage = $derived(wsPrefix ? page.url.pathname === `${wsPrefix}/starred` : false);
+	let isTagsPage = $derived(wsPrefix ? page.url.pathname.startsWith(`${wsPrefix}/tags`) : false);
 
 	let activeCollectionSlug = $derived.by(() => {
 		if (!wsPrefix) return null;
@@ -42,7 +43,7 @@
 		if (!path.startsWith(prefix)) return null;
 		const rest = path.slice(prefix.length);
 		const slug = rest.split('/')[0];
-		if (slug === 'settings' || slug === 'new' || slug === 'library' || slug === 'activity' || slug === 'starred' || slug === 'roles' || slug === 'insights' || slug === '') return null;
+		if (slug === 'settings' || slug === 'new' || slug === 'library' || slug === 'activity' || slug === 'starred' || slug === 'tags' || slug === 'roles' || slug === 'insights' || slug === '') return null;
 		return slug;
 	});
 
@@ -448,6 +449,15 @@
 				>
 					<span class="nav-icon">⭐</span>
 					<span class="nav-label">Starred</span>
+				</a>
+				<a
+					href="{wsPrefix}/tags"
+					class="nav-item"
+					class:active={isTagsPage}
+					onclick={() => uiStore.onNavigate()}
+				>
+					<span class="nav-icon">🏷</span>
+					<span class="nav-label">Tags</span>
 				</a>
 				{/if}
 

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -1274,6 +1274,32 @@ export function parseFields(item: Item): Record<string, any> {
 	}
 }
 
+/**
+ * Parse an item's `tags` JSON-array string into a clean string[]: tolerant of
+ * empty/garbage (returns []), drops non-strings, and dedupes case-insensitively
+ * keeping the first-typed casing. The write path doesn't enforce per-item tag
+ * uniqueness, so deduping here keeps rendering keys unique and display tidy.
+ */
+export function parseTags(item: Pick<Item, 'tags'> | null | undefined): string[] {
+	if (!item?.tags) return [];
+	try {
+		const parsed = JSON.parse(item.tags);
+		if (!Array.isArray(parsed)) return [];
+		const seen = new Set<string>();
+		const out: string[] = [];
+		for (const t of parsed) {
+			if (typeof t !== 'string') continue;
+			const key = t.toLowerCase();
+			if (seen.has(key)) continue;
+			seen.add(key);
+			out.push(t);
+		}
+		return out;
+	} catch {
+		return [];
+	}
+}
+
 const schemaDefaults = (): CollectionSchema => ({ fields: [] });
 
 export function parseSchema(collection: Collection): CollectionSchema {

--- a/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/[slug]/+page.svelte
@@ -26,7 +26,7 @@
 	import { toastStore } from '$lib/stores/toast.svelte';
 	import { editorStore } from '$lib/stores/editor.svelte';
 	import type { Item, Collection, CollectionSettings, QuickAction, ItemLink, AgentRole } from '$lib/types';
-	import { parseFields, parseSchema, parseSettings, formatItemRef, getTerminalOptions } from '$lib/types';
+	import { parseFields, parseSchema, parseSettings, parseTags, formatItemRef, getTerminalOptions } from '$lib/types';
 	import QuickActionsMenu from '$lib/components/common/QuickActionsMenu.svelte';
 	import BottomSheet from '$lib/components/common/BottomSheet.svelte';
 	import ContentSkeleton from '$lib/components/common/ContentSkeleton.svelte';
@@ -98,31 +98,10 @@
 	let titleInputEl = $state<HTMLTextAreaElement>();
 
 	let fields = $derived<Record<string, any>>(item ? parseFields(item) : {});
-	// Tags live on item.tags (a JSON-array string), NOT in the schema. Parse
-	// defensively — the column defaults to "[]" but tolerate empty/garbage.
-	let tags = $derived.by<string[]>(() => {
-		if (!item?.tags) return [];
-		try {
-			const parsed = JSON.parse(item.tags);
-			if (!Array.isArray(parsed)) return [];
-			// Dedupe case-insensitively (keep first as typed). The write path
-			// doesn't enforce per-item uniqueness, so an API/imported item can
-			// carry ["ux","ux"]; cleaning here keeps rendering keys unique and
-			// the dedupe gets persisted on the next save.
-			const seen = new Set<string>();
-			const out: string[] = [];
-			for (const t of parsed) {
-				if (typeof t !== 'string') continue;
-				const key = t.toLowerCase();
-				if (seen.has(key)) continue;
-				seen.add(key);
-				out.push(t);
-			}
-			return out;
-		} catch {
-			return [];
-		}
-	});
+	// Tags live on item.tags (a JSON-array string), NOT in the schema.
+	// parseTags is defensive (tolerates empty/garbage) and dedupes
+	// case-insensitively so rendering keys stay unique.
+	let tags = $derived(parseTags(item));
 	let tagSuggestions = $state<string[]>([]);
 	let schema = $derived(collection ? parseSchema(collection) : { fields: [] });
 	let settings = $derived<CollectionSettings>(collection ? parseSettings(collection) : { layout: 'balanced', default_view: 'list' });
@@ -2283,6 +2262,14 @@
 			{/if}
 		</div>
 
+		{#if tags.length > 0}
+			<div class="header-tags">
+				{#each tags as tag, i (i)}
+					<a class="header-tag" href={`/${username}/${wsSlug}/tags/${encodeURIComponent(tag)}`}>{tag}</a>
+				{/each}
+			</div>
+		{/if}
+
 		<!-- Meta info -->
 		<div class="meta-info">
 			<span title={new Date(item.created_at).toLocaleString()}>Created {relativeTime(item.created_at)} by {item.created_by || 'unknown'}</span>
@@ -3076,6 +3063,29 @@
 
 	/* Title */
 	.title-row { margin-bottom: var(--space-2); display: flex; align-items: baseline; gap: var(--space-2); }
+	.header-tags {
+		display: flex;
+		flex-wrap: wrap;
+		gap: var(--space-1, 0.25rem);
+		margin-bottom: var(--space-2);
+	}
+	.header-tag {
+		display: inline-flex;
+		align-items: center;
+		padding: 0.1em 0.55em;
+		font-size: 0.75em;
+		line-height: 1.5;
+		background: var(--bg-secondary);
+		border: 1px solid var(--border);
+		border-radius: 999px;
+		color: var(--text-secondary);
+		text-decoration: none;
+		white-space: nowrap;
+	}
+	.header-tag:hover {
+		color: var(--text-primary);
+		border-color: var(--text-tertiary, var(--text-secondary));
+	}
 	.item-ref {
 		font-family: var(--font-mono);
 		font-size: 0.85em;

--- a/web/src/routes/[username]/[workspace]/tags/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/tags/+page.svelte
@@ -1,0 +1,201 @@
+<script lang="ts">
+	import { page } from '$app/state';
+	import { api } from '$lib/api/client';
+	import { workspaceStore } from '$lib/stores/workspace.svelte';
+	import { createScrollRestoration } from '$lib/scroll/restore.svelte';
+	import type { TagCount } from '$lib/types';
+
+	let wsSlug = $derived(page.params.workspace ?? '');
+	let username = $derived(page.params.username ?? '');
+
+	let tags = $state<TagCount[]>([]);
+	let loading = $state(true);
+	let loadSeq = 0;
+
+	const scrollRestoration = createScrollRestoration({
+		ready: () => !loading,
+		persistKey: () => (wsSlug ? `pad-last-scroll-${wsSlug}-${page.url.pathname}` : null)
+	});
+	export const snapshot = scrollRestoration.snapshot;
+
+	$effect(() => {
+		if (wsSlug) loadTags(wsSlug);
+	});
+
+	async function loadTags(ws: string) {
+		loading = true;
+		const seq = ++loadSeq;
+		try {
+			const result = await api.tags.list(ws);
+			if (seq !== loadSeq) return;
+			tags = result;
+		} catch {
+			if (seq !== loadSeq) return;
+			tags = [];
+		} finally {
+			if (seq === loadSeq) loading = false;
+		}
+	}
+
+	function tagUrl(tag: string): string {
+		return `/${username}/${wsSlug}/tags/${encodeURIComponent(tag)}`;
+	}
+</script>
+
+<svelte:head>
+	<title>Tags - {workspaceStore.current?.name ?? wsSlug} | Pad</title>
+</svelte:head>
+
+<div class="tags-page">
+	<div class="page-header">
+		<div class="page-header-left">
+			<h1>🏷 Tags</h1>
+			<span class="item-count">{tags.length} tag{tags.length !== 1 ? 's' : ''}</span>
+		</div>
+	</div>
+
+	{#if loading}
+		<div class="tag-cloud">
+			{#each Array(6) as _, i (i)}
+				<div class="skeleton-chip"></div>
+			{/each}
+		</div>
+	{:else if tags.length === 0}
+		<div class="empty-state">
+			<div class="empty-icon">🏷</div>
+			<h2>No tags yet</h2>
+			<p>
+				Add tags to an item from its detail page. Tags span collections, so one tag can group
+				items of any type — a useful way to view related work together.
+			</p>
+		</div>
+	{:else}
+		<div class="tag-cloud">
+			{#each tags as t (t.tag)}
+				<a class="tag-card" href={tagUrl(t.tag)}>
+					<span class="tag-name">{t.tag}</span>
+					<span class="tag-count">{t.count}</span>
+				</a>
+			{/each}
+		</div>
+	{/if}
+</div>
+
+<style>
+	.tags-page {
+		max-width: var(--content-max-width);
+		margin: 0 auto;
+		padding: var(--space-8) var(--space-6);
+	}
+
+	.page-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: var(--space-4);
+		margin-bottom: var(--space-6);
+		flex-wrap: wrap;
+	}
+
+	.page-header-left {
+		display: flex;
+		align-items: baseline;
+		gap: var(--space-3);
+	}
+
+	.page-header h1 {
+		font-size: 1.6em;
+		font-weight: 700;
+		color: var(--text-primary);
+		margin: 0;
+	}
+
+	.item-count {
+		font-size: 0.85em;
+		color: var(--text-muted);
+	}
+
+	.tag-cloud {
+		display: flex;
+		flex-wrap: wrap;
+		gap: var(--space-3);
+	}
+
+	.tag-card {
+		display: inline-flex;
+		align-items: center;
+		gap: var(--space-2);
+		padding: var(--space-2) var(--space-4);
+		background: var(--bg-secondary);
+		border: 1px solid var(--border);
+		border-radius: 999px;
+		text-decoration: none;
+		color: var(--text-primary);
+		transition:
+			border-color 0.15s ease,
+			background 0.15s ease;
+	}
+
+	.tag-card:hover {
+		border-color: var(--text-tertiary, var(--text-secondary));
+		background: var(--bg-tertiary);
+	}
+
+	.tag-name {
+		font-size: 0.9em;
+		font-weight: 500;
+		word-break: break-word;
+	}
+
+	.tag-count {
+		font-size: 0.75em;
+		color: var(--text-muted);
+		background: var(--bg-tertiary);
+		padding: 1px 7px;
+		border-radius: 10px;
+	}
+
+	.skeleton-chip {
+		width: 6rem;
+		height: 36px;
+		background: var(--bg-secondary);
+		border-radius: 999px;
+		animation: pulse 1.5s ease-in-out infinite;
+	}
+
+	@keyframes pulse {
+		0%,
+		100% {
+			opacity: 0.4;
+		}
+		50% {
+			opacity: 0.7;
+		}
+	}
+
+	.empty-state {
+		text-align: center;
+		padding: var(--space-12) var(--space-6);
+		color: var(--text-muted);
+	}
+
+	.empty-icon {
+		font-size: 3em;
+		margin-bottom: var(--space-4);
+		opacity: 0.4;
+	}
+
+	.empty-state h2 {
+		font-size: 1.1em;
+		font-weight: 600;
+		color: var(--text-secondary);
+		margin: 0 0 var(--space-2);
+	}
+
+	.empty-state p {
+		font-size: 0.9em;
+		line-height: 1.5;
+		max-width: 400px;
+		margin: 0 auto;
+	}
+</style>

--- a/web/src/routes/[username]/[workspace]/tags/[tag]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/tags/[tag]/+page.svelte
@@ -1,0 +1,272 @@
+<script lang="ts">
+	import { page } from '$app/state';
+	import { api } from '$lib/api/client';
+	import { workspaceStore } from '$lib/stores/workspace.svelte';
+	import { createScrollRestoration } from '$lib/scroll/restore.svelte';
+	import ItemCard from '$lib/components/collections/ItemCard.svelte';
+	import type { Item, Collection } from '$lib/types';
+
+	let wsSlug = $derived(page.params.workspace ?? '');
+	// Route params arrive URL-decoded, so this is the human-readable tag.
+	let tag = $derived(page.params.tag ?? '');
+
+	let fetchedItems = $state<Item[]>([]);
+	let collections = $state<Collection[]>([]);
+	let loading = $state(true);
+	let loadSeq = 0;
+
+	const scrollRestoration = createScrollRestoration({
+		ready: () => !loading,
+		persistKey: () => (wsSlug ? `pad-last-scroll-${wsSlug}-${page.url.pathname}` : null)
+	});
+	export const snapshot = scrollRestoration.snapshot;
+
+	// Re-fetch when the workspace or the tag changes. Pure data-fetch effect
+	// keyed on (wsSlug, tag) — kept free of unrelated route logic per the
+	// Svelte 5 effect-splitting convention.
+	$effect(() => {
+		const ws = wsSlug;
+		const t = tag;
+		if (ws && t) loadTagged(ws, t);
+	});
+
+	async function loadTagged(ws: string, t: string) {
+		loading = true;
+		const seq = ++loadSeq;
+		try {
+			const [items, colls] = await Promise.all([
+				api.items.list(ws, { tag: t }),
+				api.collections.list(ws)
+			]);
+			if (seq !== loadSeq) return;
+			fetchedItems = items;
+			collections = colls;
+		} catch {
+			if (seq !== loadSeq) return;
+			fetchedItems = [];
+		} finally {
+			if (seq === loadSeq) loading = false;
+		}
+	}
+
+	function getCollection(collectionId: string): Collection | undefined {
+		return collections.find((c) => c.id === collectionId);
+	}
+
+	// Aggregate tagged items the way collections are viewed: grouped by
+	// collection (the shared axis across heterogeneous status enums), each
+	// group ordered by the collection's sort_order.
+	let groupedItems = $derived.by(() => {
+		const map = new Map<string, Item[]>();
+		for (const item of fetchedItems) {
+			const key = item.collection_id;
+			if (!map.has(key)) map.set(key, []);
+			map.get(key)!.push(item);
+		}
+		const groups: { collection: Collection; items: Item[] }[] = [];
+		for (const [collId, collItems] of map) {
+			const coll = getCollection(collId);
+			if (coll) groups.push({ collection: coll, items: collItems });
+		}
+		groups.sort((a, b) => a.collection.sort_order - b.collection.sort_order);
+		return groups;
+	});
+</script>
+
+<svelte:head>
+	<title>#{tag} - {workspaceStore.current?.name ?? wsSlug} | Pad</title>
+</svelte:head>
+
+<div class="tag-page">
+	<div class="page-header">
+		<div class="page-header-left">
+			<a class="back-link" href="/{page.params.username}/{wsSlug}/tags">🏷 Tags</a>
+			<span class="crumb-sep">/</span>
+			<h1>{tag}</h1>
+			<span class="item-count">{fetchedItems.length} item{fetchedItems.length !== 1 ? 's' : ''}</span>
+		</div>
+	</div>
+
+	{#if loading}
+		<div class="loading-state">
+			<div class="skeleton-list">
+				{#each Array(3) as _, i (i)}
+					<div class="skeleton-card"></div>
+				{/each}
+			</div>
+		</div>
+	{:else if fetchedItems.length === 0}
+		<div class="empty-state">
+			<div class="empty-icon">🏷</div>
+			<h2>No items tagged “{tag}”</h2>
+			<p>Add this tag to an item from its detail page to group it here.</p>
+		</div>
+	{:else}
+		<div class="tag-list">
+			{#each groupedItems as group (group.collection.id)}
+				<div class="collection-group">
+					<div class="group-header">
+						<span class="group-icon">{group.collection.icon || '📁'}</span>
+						<span class="group-name">{group.collection.name}</span>
+						<span class="group-count">{group.items.length}</span>
+					</div>
+					<div class="group-items">
+						{#each group.items as item (item.id)}
+							<ItemCard {item} collection={group.collection} showCollection={false} />
+						{/each}
+					</div>
+				</div>
+			{/each}
+		</div>
+	{/if}
+</div>
+
+<style>
+	.tag-page {
+		max-width: var(--content-max-width);
+		margin: 0 auto;
+		padding: var(--space-8) var(--space-6);
+	}
+
+	.page-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: var(--space-4);
+		margin-bottom: var(--space-6);
+		flex-wrap: wrap;
+	}
+
+	.page-header-left {
+		display: flex;
+		align-items: baseline;
+		gap: var(--space-3);
+		flex-wrap: wrap;
+	}
+
+	.back-link {
+		font-size: 0.95em;
+		font-weight: 600;
+		color: var(--text-secondary);
+		text-decoration: none;
+	}
+
+	.back-link:hover {
+		color: var(--text-primary);
+	}
+
+	.crumb-sep {
+		color: var(--text-muted);
+	}
+
+	.page-header h1 {
+		font-size: 1.6em;
+		font-weight: 700;
+		color: var(--text-primary);
+		margin: 0;
+		word-break: break-word;
+	}
+
+	.item-count {
+		font-size: 0.85em;
+		color: var(--text-muted);
+	}
+
+	.loading-state {
+		padding: var(--space-4) 0;
+	}
+
+	.skeleton-list {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-3);
+	}
+
+	.skeleton-card {
+		height: 72px;
+		background: var(--bg-secondary);
+		border-radius: var(--radius);
+		animation: pulse 1.5s ease-in-out infinite;
+	}
+
+	@keyframes pulse {
+		0%,
+		100% {
+			opacity: 0.4;
+		}
+		50% {
+			opacity: 0.7;
+		}
+	}
+
+	.empty-state {
+		text-align: center;
+		padding: var(--space-12) var(--space-6);
+		color: var(--text-muted);
+	}
+
+	.empty-icon {
+		font-size: 3em;
+		margin-bottom: var(--space-4);
+		opacity: 0.4;
+	}
+
+	.empty-state h2 {
+		font-size: 1.1em;
+		font-weight: 600;
+		color: var(--text-secondary);
+		margin: 0 0 var(--space-2);
+	}
+
+	.empty-state p {
+		font-size: 0.9em;
+		line-height: 1.5;
+		max-width: 400px;
+		margin: 0 auto;
+	}
+
+	.tag-list {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-6);
+	}
+
+	.collection-group {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-2);
+	}
+
+	.group-header {
+		display: flex;
+		align-items: center;
+		gap: var(--space-2);
+		padding: var(--space-2) 0;
+	}
+
+	.group-icon {
+		font-size: 0.9em;
+	}
+
+	.group-name {
+		font-size: 0.85em;
+		font-weight: 600;
+		color: var(--text-secondary);
+		text-transform: uppercase;
+		letter-spacing: 0.03em;
+	}
+
+	.group-count {
+		font-size: 0.75em;
+		color: var(--text-muted);
+		background: var(--bg-tertiary);
+		padding: 1px 6px;
+		border-radius: 10px;
+	}
+
+	.group-items {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-2);
+	}
+</style>

--- a/web/src/routes/[username]/[workspace]/tags/[tag]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/tags/[tag]/+page.svelte
@@ -53,21 +53,47 @@
 		return collections.find((c) => c.id === collectionId);
 	}
 
+	// A restricted member can see an item via an item-level grant without being
+	// able to list its collection (collections.list is filtered by visible
+	// collections). Synthesize a minimal collection from the metadata already
+	// embedded on the item so those rows still render — dropping them would
+	// make the header count disagree with the visible list. The empty schema
+	// means ItemCard just omits status/priority for these rows. Per Codex
+	// PR #660 round 3. Sorted last (no real sort_order available).
+	function syntheticCollection(item: Item): Collection {
+		return {
+			id: item.collection_id,
+			workspace_id: item.workspace_id,
+			name: item.collection_name ?? 'Items',
+			slug: item.collection_slug ?? '',
+			icon: item.collection_icon ?? '📁',
+			description: '',
+			schema: '{"fields":[]}',
+			settings: '{}',
+			sort_order: Number.MAX_SAFE_INTEGER,
+			is_default: false,
+			is_system: false,
+			created_at: item.created_at,
+			updated_at: item.updated_at,
+			prefix: item.collection_prefix ?? ''
+		};
+	}
+
 	// Aggregate tagged items the way collections are viewed: grouped by
 	// collection (the shared axis across heterogeneous status enums), each
 	// group ordered by the collection's sort_order.
 	let groupedItems = $derived.by(() => {
-		const map = new Map<string, Item[]>();
+		const map = new Map<string, { collection: Collection; items: Item[] }>();
 		for (const item of fetchedItems) {
 			const key = item.collection_id;
-			if (!map.has(key)) map.set(key, []);
-			map.get(key)!.push(item);
+			let group = map.get(key);
+			if (!group) {
+				group = { collection: getCollection(key) ?? syntheticCollection(item), items: [] };
+				map.set(key, group);
+			}
+			group.items.push(item);
 		}
-		const groups: { collection: Collection; items: Item[] }[] = [];
-		for (const [collId, collItems] of map) {
-			const coll = getCollection(collId);
-			if (coll) groups.push({ collection: coll, items: collItems });
-		}
+		const groups = [...map.values()];
 		groups.sort((a, b) => a.collection.sort_order - b.collection.sort_order);
 		return groups;
 	});


### PR DESCRIPTION
## Summary
Surfaces tags wherever items appear, each chip linking to the (forthcoming) tag page.

- **`lib/types`** — shared `parseTags()`: defensive JSON-array parse + case-insensitive dedupe. The item detail page drops its inline duplicate of this logic and reuses it.
- **`ItemCard`** (shared by `BoardView` + `ListView`) — a clickable tag-chip row. Since the card is an `<a>`, chips are `<button>`s that `goto` the tag page with `stopPropagation` (same pattern as the existing star/PR/status controls), avoiding nested anchors.
- **Item detail header** — tag chips as real `<a>` links (not nested in a card anchor).

Chips link to `/[username]/[workspace]/tags/[tag]`; those pages arrive in TASK-1657, so the links are inert until then.

## Context
Implements `TASK-1655` under `PLAN-1652`. Builds on the tag editor (#659) and enumeration endpoint (#658).

## Test plan
- [x] `cd web && npm run build` — clean (type-checks via the Svelte plugin)
- [ ] Manual: chips render on board cards + list rows + item header; clicking a card chip navigates to the tag page without opening the item; dedupe is case-insensitive