### PR TITLE
feat(cli): add --tag filter to `pad item list` (TASK-1658)

### DIFF
--- a/cmd/pad/main.go
+++ b/cmd/pad/main.go
@@ -3148,6 +3148,7 @@ func listCmd() *cobra.Command {
 		priorityFilter string
 		assigneeFilter string
 		roleFilter     string
+		tagFilter      string
 		parentFilter   string
 		sortBy         string
 		groupBy        string
@@ -3211,6 +3212,9 @@ Examples:
 			if roleFilter != "" {
 				params.Set("agent_role_id", roleFilter)
 			}
+			if tagFilter != "" {
+				params.Set("tag", tagFilter)
+			}
 			if parentFilter != "" {
 				params.Set("parent", parentFilter)
 			}
@@ -3266,6 +3270,7 @@ Examples:
 	cmd.Flags().StringVar(&priorityFilter, "priority", "", "filter by priority")
 	cmd.Flags().StringVar(&assigneeFilter, "assign", "", "filter by assigned user (name or email)")
 	cmd.Flags().StringVar(&roleFilter, "role", "", "filter by agent role (slug)")
+	cmd.Flags().StringVar(&tagFilter, "tag", "", "filter by tag (exact match; spans collections)")
 	cmd.Flags().StringVar(&parentFilter, "parent", "", "filter by parent item (ref, slug, or ID)")
 	cmd.Flags().StringVar(&sortBy, "sort", "", "sort order (e.g. priority:desc,created_at:asc)")
 	cmd.Flags().StringVar(&groupBy, "group-by", "", "group results by field")


### PR DESCRIPTION
## Summary
Wires the `--tag` filter on `pad item list`. The HTTP endpoints already parse `?tag=` (cross-collection on the workspace route, per #658), but the CLI had no flag to forward it — a gap noticed during the tags-feature ship.

- Adds `--tag` to `pad item list`, forwarded as the `tag` query param alongside `--status`/`--role`/`--parent`.
- The MCP `pad_item` list action inherits it via the cmdhelp passthrough — no catalog change.

## Verification
```
$ pad item list --tag "User feedback"
IDEA-1648 / IDEA-1649 / IDEA-1650 / BUG-1651  (3 Ideas + 1 Bug, cross-collection)
```

## Context
Follow-up under PLAN-1652, closing the CLI gap left after the tags feature shipped.

## Test plan
- [x] `go build ./...` / `go vet ./...` — clean
- [x] Manual: `pad item list --tag "User feedback"` returns the 4 tagged items across collections; `--tag` composes with `--status`/`--all`