### PR TITLE
feat(comments): paste/drop image attachments in comments + inline render (IDEA-1650)

### DIFF
--- a/internal/server/orphan_gc.go
+++ b/internal/server/orphan_gc.go
@@ -70,14 +70,15 @@ func (s *Server) runOrphanGCSweep(ctx context.Context, graceCutoff time.Time) (*
 			return res, err
 		}
 		// "Never-attached" rows (item_id IS NULL, deleted_at IS NULL)
-		// can still be referenced from item content via
-		// `pad-attachment:UUID` — the editor uploads first, then
-		// PATCHes content with the reference, but the attachments
+		// can still be referenced from item content or a comment body
+		// via `pad-attachment:UUID` — the editor / comment composer
+		// upload first, then save the reference, but the attachments
 		// row's item_id stays NULL. Scan items.content + items.fields
-		// before reclaiming so the GC doesn't destroy a legitimate
-		// reference. Codex P1 on PR #307 round 1.
+		// + comment bodies before reclaiming so the GC doesn't destroy
+		// a legitimate reference. Codex P1 on PR #307 round 1;
+		// comment-body coverage added for IDEA-1650.
 		if a.ItemID == nil && a.DeletedAt == nil {
-			referenced, err := s.store.AttachmentReferencedInItems(a.WorkspaceID, a.ID)
+			referenced, err := s.store.AttachmentReferenced(a.WorkspaceID, a.ID)
 			if err != nil {
 				slog.Warn("orphan GC: ref-scan failed",
 					"attachment_id", a.ID, "workspace_id", a.WorkspaceID, "error", err)

--- a/internal/server/orphan_gc_test.go
+++ b/internal/server/orphan_gc_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"sync"
 	"testing"
@@ -270,6 +271,67 @@ func TestOrphanGC_KeepsReferencedNeverAttachedRows(t *testing.T) {
 	}
 	if got, _ := srv.store.GetAttachment(id); got == nil {
 		t.Errorf("referenced attachment was hard-deleted by GC; row gone")
+	}
+}
+
+// TestOrphanGC_KeepsAttachmentReferencedFromComment is the IDEA-1650
+// sibling of the item-content case above: a screenshot pasted into a
+// comment is referenced ONLY from comments.body, with attachments.item_id
+// left NULL. The GC's reference scan must cover comment bodies, otherwise
+// a never-attached row past the grace period would be reclaimed and the
+// comment's embed would break.
+func TestOrphanGC_KeepsAttachmentReferencedFromComment(t *testing.T) {
+	srv, slug := testServerWithAttachments(t)
+	wsID := workspaceIDForSlug(t, srv, slug)
+
+	if rr := doMultipartUpload(srv, slug, "kept.png", realPNG()); rr.Code != 201 {
+		t.Fatalf("upload: %d", rr.Code)
+	}
+	id := getOnlyAttachmentID(t, srv, wsID)
+
+	// Create a plain item (no reference in its content), then post a
+	// comment that references the attachment — mirrors the comment
+	// composer flow (upload → post comment with the ref). item_id on
+	// the attachment row stays NULL.
+	rr := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections/docs/items",
+		map[string]any{"title": "Has A Comment"})
+	if rr.Code != 201 {
+		t.Fatalf("create item: %d %s", rr.Code, rr.Body.String())
+	}
+	var item map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &item); err != nil {
+		t.Fatalf("decode item: %v", err)
+	}
+	itemSlug, _ := item["slug"].(string)
+	if itemSlug == "" {
+		t.Fatalf("item response missing slug: %s", rr.Body.String())
+	}
+
+	rr = doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/items/"+itemSlug+"/comments",
+		map[string]any{"body": "see ![](pad-attachment:" + id + ")"})
+	if rr.Code != 201 {
+		t.Fatalf("create comment: %d %s", rr.Code, rr.Body.String())
+	}
+
+	// Backdate the attachment past the 30-day grace so the orphan
+	// SELECT picks it up.
+	pastTs := time.Now().UTC().Add(-31 * 24 * time.Hour).Format(time.RFC3339)
+	if _, err := srv.store.DB().Exec(
+		`UPDATE attachments SET created_at = ? WHERE id = ?`, pastTs, id,
+	); err != nil {
+		t.Fatalf("backdate: %v", err)
+	}
+
+	res, err := srv.runOrphanGCSweep(context.Background(),
+		time.Now().UTC().Add(-30*24*time.Hour))
+	if err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+	if res.Deleted != 0 {
+		t.Errorf("Deleted=%d, want 0 (a comment references the attachment)", res.Deleted)
+	}
+	if got, _ := srv.store.GetAttachment(id); got == nil {
+		t.Errorf("comment-referenced attachment was hard-deleted by GC; row gone")
 	}
 }
 

--- a/internal/store/attachments.go
+++ b/internal/store/attachments.go
@@ -612,14 +612,18 @@ func (s *Store) CountProtectingAttachmentsForHash(hash, excludeID string, graceC
 	return n, nil
 }
 
-// AttachmentReferencedInItems returns true when any live item in the
-// workspace mentions "pad-attachment:<id>" in its content or fields
-// JSON. The editor upload flow leaves attachments.item_id NULL —
-// the canonical association is the markdown reference inside the
-// item's content, NOT a column in the attachments table — so the
-// orphan GC has to look at item content directly before reclaiming
-// a "never-attached" row, otherwise it'd hard-delete attachments
-// that markdown still points at.
+// AttachmentReferenced returns true when anything in the workspace
+// mentions "pad-attachment:<id>" — either a live item's content/fields
+// JSON or a comment body. The editor and comment-composer upload flows
+// both leave attachments.item_id NULL: the canonical association is the
+// markdown reference inside the item's content or a comment, NOT a
+// column in the attachments table — so the orphan GC has to look at
+// that text directly before reclaiming a "never-attached" row,
+// otherwise it'd hard-delete attachments that markdown still points at.
+//
+// Comments are covered because a pasted screenshot (IDEA-1650) may be
+// referenced ONLY from a comment body; without the comments scan the GC
+// would reclaim it after the grace period and break the embed.
 //
 // Scoped to one workspace because a "pad-attachment:UUID" reference
 // only resolves within the workspace where the attachment lives;
@@ -629,8 +633,9 @@ func (s *Store) CountProtectingAttachmentsForHash(hash, excludeID string, graceC
 // PostgreSQL (see migrations + pgmigrations). LIKE doesn't work on
 // JSONB so the Postgres path casts to text first. Codex P1 round 2
 // caught this — without the cast, the GC's reference scan errored
-// on Postgres and every never-attached row got skipped.
-func (s *Store) AttachmentReferencedInItems(workspaceID, attachmentID string) (bool, error) {
+// on Postgres and every never-attached row got skipped. comments.body
+// is TEXT on both dialects, so it needs no cast.
+func (s *Store) AttachmentReferenced(workspaceID, attachmentID string) (bool, error) {
 	if workspaceID == "" || attachmentID == "" {
 		return false, nil
 	}
@@ -644,12 +649,15 @@ func (s *Store) AttachmentReferencedInItems(workspaceID, attachmentID string) (b
 
 	var n int
 	err := s.db.QueryRow(s.q(`
-		SELECT COUNT(*) FROM items
-		WHERE workspace_id = ? AND deleted_at IS NULL
-		  AND (content LIKE ? OR `+fieldsExpr+` LIKE ?)
-	`), workspaceID, pattern, pattern).Scan(&n)
+		SELECT
+		  (SELECT COUNT(*) FROM items
+		     WHERE workspace_id = ? AND deleted_at IS NULL
+		       AND (content LIKE ? OR `+fieldsExpr+` LIKE ?))
+		+ (SELECT COUNT(*) FROM comments
+		     WHERE workspace_id = ? AND body LIKE ?)
+	`), workspaceID, pattern, pattern, workspaceID, pattern).Scan(&n)
 	if err != nil {
-		return false, fmt.Errorf("attachment referenced in items: %w", err)
+		return false, fmt.Errorf("attachment referenced: %w", err)
 	}
 	return n > 0, nil
 }

--- a/web/src/lib/components/timeline/ItemTimeline.svelte
+++ b/web/src/lib/components/timeline/ItemTimeline.svelte
@@ -11,6 +11,7 @@
 	import {
 		filesFromPaste,
 		filesFromDrop,
+		isFileDrag,
 		uploadIntoTextarea,
 		attachmentRefsIn
 	} from '$lib/utils/commentAttachments';
@@ -117,6 +118,13 @@
 		if (files.length === 0) return;
 		e.preventDefault();
 		startComposeUploads(files);
+	}
+
+	function handleComposeDragOver(e: DragEvent) {
+		// Cancel only file drags so the browser delivers the drop here
+		// instead of navigating; text drag-drop within the textarea is left
+		// to default handling.
+		if (isFileDrag(e)) e.preventDefault();
 	}
 
 	function handleComposeDrop(e: DragEvent) {
@@ -321,6 +329,7 @@
 				bind:value={newBody}
 				onkeydown={handleKeydown}
 				onpaste={handleComposePaste}
+				ondragover={handleComposeDragOver}
 				ondrop={handleComposeDrop}
 				disabled={submitting}
 			></textarea>

--- a/web/src/lib/components/timeline/ItemTimeline.svelte
+++ b/web/src/lib/components/timeline/ItemTimeline.svelte
@@ -8,6 +8,14 @@
 	import TimelineCommentCard from './TimelineCommentCard.svelte';
 	import TimelineActivityCard from './TimelineActivityCard.svelte';
 	import TimelineVersionCard from './TimelineVersionCard.svelte';
+	import {
+		filesFromPaste,
+		filesFromDrop,
+		uploadIntoTextarea,
+		attachmentRefsIn
+	} from '$lib/utils/commentAttachments';
+	import { fetchAttachmentMetadata } from '$lib/components/editor/attachment-metadata';
+	import { attachmentDownloadUrl, type AttachmentMeta } from '$lib/markdown/attachments';
 
 	interface Props {
 		wsSlug: string;
@@ -42,6 +50,81 @@
 	let loadingMore: boolean = $state(false);
 	let error: string = $state('');
 	let newBody: string = $state('');
+
+	// Comment composer attachment state (IDEA-1650). pendingUploads gates
+	// submit while a paste/drop upload is in flight; composeTextarea is the
+	// caret anchor the upload helper splices markdown into.
+	let pendingUploads: number = $state(0);
+	let composeTextarea: HTMLTextAreaElement | undefined = $state();
+
+	// Resolver for `pad-attachment:UUID` references in comment bodies.
+	// Metadata (MIME + size) is fetched lazily per UUID via a HEAD probe and
+	// cached here; renderMarkdown reads it through the derived resolver so a
+	// newly-resolved attachment re-renders its comment inline.
+	let attMeta = $state<Map<string, AttachmentMeta>>(new Map());
+	let attachmentResolver = $derived((uuid: string) => attMeta.get(uuid) ?? null);
+
+	// In-flight / settled UUIDs — a non-reactive guard so the probe effect
+	// fires one HEAD per attachment without re-triggering on attMeta writes.
+	const probed = new Set<string>();
+
+	function probeAttachment(uuid: string) {
+		if (probed.has(uuid)) return;
+		probed.add(uuid);
+		fetchAttachmentMetadata(wsSlug, uuid, (id, variant) =>
+			attachmentDownloadUrl(wsSlug, id, variant)
+		).then((m) => {
+			if (!m) return;
+			const next = new Map(attMeta);
+			// filename is left empty — the markdown alt text is the chip/img
+			// label, and renderAttachmentImage only falls back to filename
+			// when alt is blank.
+			next.set(uuid, { id: uuid, mime_type: m.mime, filename: '', size_bytes: m.size });
+			attMeta = next;
+		});
+	}
+
+	// Probe every attachment referenced by a comment or reply as the
+	// timeline loads / changes. Depends only on `entries`.
+	$effect(() => {
+		for (const entry of entries) {
+			if (entry.kind !== 'comment' || !entry.comment) continue;
+			for (const id of attachmentRefsIn(entry.comment.body)) probeAttachment(id);
+			for (const reply of entry.comment.replies ?? []) {
+				for (const id of attachmentRefsIn(reply.body)) probeAttachment(id);
+			}
+		}
+	});
+
+	function startComposeUploads(files: File[]) {
+		if (!composeTextarea) return;
+		uploadIntoTextarea(files, composeTextarea, wsSlug, {
+			getValue: () => newBody,
+			setValue: (v) => {
+				newBody = v;
+			},
+			onPendingDelta: (d) => {
+				pendingUploads += d;
+			},
+			onError: (msg) => {
+				error = msg;
+			}
+		});
+	}
+
+	function handleComposePaste(e: ClipboardEvent) {
+		const files = filesFromPaste(e);
+		if (files.length === 0) return;
+		e.preventDefault();
+		startComposeUploads(files);
+	}
+
+	function handleComposeDrop(e: DragEvent) {
+		const files = filesFromDrop(e);
+		if (files.length === 0) return;
+		e.preventDefault();
+		startComposeUploads(files);
+	}
 
 	// Current user ID for reaction toggle — read from the global auth store.
 	let currentUserId = $derived(authStore.userId);
@@ -146,7 +229,7 @@
 	let submitting: boolean = $state(false);
 
 	async function submitComment() {
-		if (!newBody.trim() || submitting) return;
+		if (!newBody.trim() || submitting || pendingUploads > 0) return;
 		submitting = true;
 		try {
 			await api.comments.create(wsSlug, itemSlug, {
@@ -233,17 +316,24 @@
 		<div class="compose">
 			<textarea
 				class="compose-input"
-				placeholder="Write a comment..."
+				bind:this={composeTextarea}
+				placeholder="Write a comment... (paste or drop an image to attach)"
 				bind:value={newBody}
 				onkeydown={handleKeydown}
+				onpaste={handleComposePaste}
+				ondrop={handleComposeDrop}
 				disabled={submitting}
 			></textarea>
 			<div class="compose-actions">
-				<span class="shortcut-hint">Ctrl+Enter to submit</span>
+				<span class="shortcut-hint">
+					{pendingUploads > 0
+						? `Uploading ${pendingUploads} file${pendingUploads === 1 ? '' : 's'}…`
+						: 'Ctrl+Enter to submit'}
+				</span>
 				<button
 					class="submit-btn"
 					type="button"
-					disabled={!newBody.trim() || submitting}
+					disabled={!newBody.trim() || submitting || pendingUploads > 0}
 					onclick={submitComment}
 				>
 					{submitting ? 'Posting...' : 'Comment'}
@@ -279,6 +369,7 @@
 								{items}
 								{currentUserId}
 								{canEdit}
+								{attachmentResolver}
 								onDelete={handleDelete}
 								onReply={handleReply}
 								onReaction={handleReaction}

--- a/web/src/lib/components/timeline/TimelineCommentCard.svelte
+++ b/web/src/lib/components/timeline/TimelineCommentCard.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import type { Comment, Item, Reaction } from '$lib/types';
 	import { relativeTime, renderMarkdown } from '$lib/utils/markdown';
+	import type { AttachmentResolver } from '$lib/markdown/attachments';
+	import { filesFromPaste, filesFromDrop, uploadIntoTextarea } from '$lib/utils/commentAttachments';
 	import ReactionPicker from './ReactionPicker.svelte';
 
 	interface Props {
@@ -18,21 +20,64 @@
 		 * don't pass it.
 		 */
 		canEdit?: boolean;
+		/**
+		 * Resolves `pad-attachment:UUID` references in the comment / reply
+		 * bodies to inline images or file chips (IDEA-1650). Optional —
+		 * without it those references render as plain (broken) markdown
+		 * links, the same graceful degradation renderMarkdown uses elsewhere.
+		 */
+		attachmentResolver?: AttachmentResolver;
 		onDelete: (commentId: string) => void;
 		onReply: (commentId: string, body: string) => void | Promise<void>;
 		onReaction: (commentId: string, emoji: string) => void;
 		onRemoveReaction: (commentId: string, emoji: string) => void;
 	}
 
-	let { comment, wsSlug, username = '', items, currentUserId = '', canEdit = true, onDelete, onReply, onReaction, onRemoveReaction }: Props = $props();
+	let { comment, wsSlug, username = '', items, currentUserId = '', canEdit = true, attachmentResolver, onDelete, onReply, onReaction, onRemoveReaction }: Props = $props();
 
 	let showReplyForm = $state(false);
 	let replyBody = $state('');
 	let submittingReply = $state(false);
 
+	// Reply-box attachment upload (IDEA-1650). Mirrors the top-level
+	// composer in ItemTimeline; replyPending gates submit while a
+	// paste/drop upload is in flight.
+	let replyTextarea: HTMLTextAreaElement | undefined = $state();
+	let replyPending = $state(0);
+
+	function startReplyUploads(files: File[]) {
+		if (!replyTextarea) return;
+		uploadIntoTextarea(files, replyTextarea, wsSlug, {
+			getValue: () => replyBody,
+			setValue: (v) => {
+				replyBody = v;
+			},
+			onPendingDelta: (d) => {
+				replyPending += d;
+			},
+			onError: (msg) => {
+				if (typeof window !== 'undefined') window.alert(`Couldn't upload: ${msg}`);
+			}
+		});
+	}
+
+	function handleReplyPaste(e: ClipboardEvent) {
+		const files = filesFromPaste(e);
+		if (files.length === 0) return;
+		e.preventDefault();
+		startReplyUploads(files);
+	}
+
+	function handleReplyDrop(e: DragEvent) {
+		const files = filesFromDrop(e);
+		if (files.length === 0) return;
+		e.preventDefault();
+		startReplyUploads(files);
+	}
+
 	async function submitReply() {
 		const body = replyBody.trim();
-		if (!body || submittingReply) return;
+		if (!body || submittingReply || replyPending > 0) return;
 		submittingReply = true;
 		try {
 			await onReply(comment.id, body);
@@ -160,7 +205,7 @@
 	{/if}
 
 	<div class="comment-body prose">
-		{@html renderMarkdown(comment.body, items, wsSlug, username)}
+		{@html renderMarkdown(comment.body, items, wsSlug, username, undefined, attachmentResolver)}
 	</div>
 
 	<div class="comment-footer">
@@ -198,16 +243,23 @@
 		<div class="reply-compose">
 			<textarea
 				class="reply-input"
-				placeholder="Write a reply..."
+				bind:this={replyTextarea}
+				placeholder="Write a reply... (paste or drop an image to attach)"
 				bind:value={replyBody}
 				onkeydown={handleReplyKeydown}
+				onpaste={handleReplyPaste}
+				ondrop={handleReplyDrop}
 				disabled={submittingReply}
 			></textarea>
 			<div class="reply-actions">
-				<span class="reply-hint">Ctrl+Enter to submit · Esc to cancel</span>
+				<span class="reply-hint">
+					{replyPending > 0
+						? `Uploading ${replyPending} file${replyPending === 1 ? '' : 's'}…`
+						: 'Ctrl+Enter to submit · Esc to cancel'}
+				</span>
 				<div class="reply-buttons">
 					<button class="reply-cancel" type="button" onclick={() => { showReplyForm = false; replyBody = ''; }}>Cancel</button>
-					<button class="reply-submit" type="button" disabled={!replyBody.trim() || submittingReply} onclick={submitReply}>
+					<button class="reply-submit" type="button" disabled={!replyBody.trim() || submittingReply || replyPending > 0} onclick={submitReply}>
 						{submittingReply ? 'Posting...' : 'Reply'}
 					</button>
 				</div>
@@ -243,7 +295,7 @@
 					</div>
 
 					<div class="reply-body prose">
-						{@html renderMarkdown(reply.body, items, wsSlug, username)}
+						{@html renderMarkdown(reply.body, items, wsSlug, username, undefined, attachmentResolver)}
 					</div>
 
 						<div class="reactions-row">

--- a/web/src/lib/components/timeline/TimelineCommentCard.svelte
+++ b/web/src/lib/components/timeline/TimelineCommentCard.svelte
@@ -2,7 +2,7 @@
 	import type { Comment, Item, Reaction } from '$lib/types';
 	import { relativeTime, renderMarkdown } from '$lib/utils/markdown';
 	import type { AttachmentResolver } from '$lib/markdown/attachments';
-	import { filesFromPaste, filesFromDrop, uploadIntoTextarea } from '$lib/utils/commentAttachments';
+	import { filesFromPaste, filesFromDrop, isFileDrag, uploadIntoTextarea } from '$lib/utils/commentAttachments';
 	import ReactionPicker from './ReactionPicker.svelte';
 
 	interface Props {
@@ -66,6 +66,10 @@
 		if (files.length === 0) return;
 		e.preventDefault();
 		startReplyUploads(files);
+	}
+
+	function handleReplyDragOver(e: DragEvent) {
+		if (isFileDrag(e)) e.preventDefault();
 	}
 
 	function handleReplyDrop(e: DragEvent) {
@@ -248,6 +252,7 @@
 				bind:value={replyBody}
 				onkeydown={handleReplyKeydown}
 				onpaste={handleReplyPaste}
+				ondragover={handleReplyDragOver}
 				ondrop={handleReplyDrop}
 				disabled={submittingReply}
 			></textarea>

--- a/web/src/lib/utils/commentAttachments.ts
+++ b/web/src/lib/utils/commentAttachments.ts
@@ -53,13 +53,24 @@ export function attachmentRefsIn(text: string): string[] {
 }
 
 /**
+ * Escape the characters that would break out of a markdown link/image
+ * label (`[label](...)`). Backslash first so we don't double-escape the
+ * escapes we add; `[` / `]` close or reopen the label; newlines would
+ * terminate the construct. Filenames are user-controlled, so an
+ * unescaped `]` in a name would otherwise produce malformed markdown.
+ */
+function escapeMarkdownLabel(s: string): string {
+	return s.replace(/[\\[\]]/g, '\\$&').replace(/[\r\n]+/g, ' ');
+}
+
+/**
  * Markdown snippet for an uploaded attachment. Image MIMEs use image
  * syntax (inline embed); everything else uses link syntax (file chip) —
  * mirrors the editor's nodeForResult image/chip split so a comment and
  * the item body render the same upload identically.
  */
 export function markdownRefFor(result: AttachmentUploadResult): string {
-	const name = result.filename || 'attachment';
+	const name = escapeMarkdownLabel(result.filename || 'attachment');
 	const ref = `pad-attachment:${result.id}`;
 	return result.category === 'image' ? `![${name}](${ref})` : `[${name}](${ref})`;
 }

--- a/web/src/lib/utils/commentAttachments.ts
+++ b/web/src/lib/utils/commentAttachments.ts
@@ -38,6 +38,18 @@ export function filesFromDrop(event: DragEvent): File[] {
 	return Array.from(dt.files);
 }
 
+/**
+ * True when a drag carries files (rather than dragged text / a selection).
+ * Used to decide whether to `preventDefault()` on `dragover` — browsers
+ * only deliver a file `drop` to a custom target if its `dragover` cancels
+ * the default; without that the page navigates to the file instead. We
+ * gate on file-ness so in-textarea text drag-and-drop keeps working.
+ */
+export function isFileDrag(event: DragEvent): boolean {
+	const types = event.dataTransfer?.types;
+	return !!types && Array.from(types).includes('Files');
+}
+
 // UUIDs are the only thing after the `pad-attachment:` prefix in a
 // well-formed reference; the 36-char canonical form is what the upload
 // handler returns. Anchored to that shape so trailing `)`/whitespace in

--- a/web/src/lib/utils/commentAttachments.ts
+++ b/web/src/lib/utils/commentAttachments.ts
@@ -1,0 +1,137 @@
+/**
+ * Paste / drag-drop attachment upload for the plain-textarea comment
+ * composers (ItemTimeline + TimelineCommentCard reply box). The rich
+ * item editor has its own ProseMirror-based plugin (attachment-upload.ts);
+ * comments are plain markdown textareas, so they get this lighter helper:
+ * upload the file, splice a `pad-attachment:UUID` markdown reference into
+ * the bound value at the caret, and let the existing render path resolve
+ * it to an inline `<img>` / file chip (IDEA-1650).
+ *
+ * Uploads leave attachments.item_id NULL — exactly like the editor —
+ * because the canonical association is the markdown reference in the
+ * posted comment body, not a column. The orphan GC's reference scan
+ * (Store.AttachmentReferenced) covers comment bodies so a posted
+ * screenshot is protected; an abandoned draft (placeholder never
+ * resolved into a posted comment) falls to GC after the grace period.
+ */
+
+import { api } from '$lib/api/client';
+import type { AttachmentUploadResult } from '$lib/types';
+
+/** Extract file payloads from a paste event (screenshots, copied files). */
+export function filesFromPaste(event: ClipboardEvent): File[] {
+	const dt = event.clipboardData;
+	if (!dt) return [];
+	const out: File[] = [];
+	for (const item of Array.from(dt.items)) {
+		if (item.kind !== 'file') continue;
+		const file = item.getAsFile();
+		if (file) out.push(file);
+	}
+	return out;
+}
+
+/** Extract dropped files from a drop event. */
+export function filesFromDrop(event: DragEvent): File[] {
+	const dt = event.dataTransfer;
+	if (!dt || dt.files.length === 0) return [];
+	return Array.from(dt.files);
+}
+
+// UUIDs are the only thing after the `pad-attachment:` prefix in a
+// well-formed reference; the 36-char canonical form is what the upload
+// handler returns. Anchored to that shape so trailing `)`/whitespace in
+// the markdown doesn't bleed into the captured id.
+const ATTACHMENT_REF_RE = /pad-attachment:([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})/g;
+
+/** Every `pad-attachment:UUID` id referenced in a markdown string. */
+export function attachmentRefsIn(text: string): string[] {
+	if (!text) return [];
+	const out: string[] = [];
+	for (const m of text.matchAll(ATTACHMENT_REF_RE)) out.push(m[1]);
+	return out;
+}
+
+/**
+ * Markdown snippet for an uploaded attachment. Image MIMEs use image
+ * syntax (inline embed); everything else uses link syntax (file chip) —
+ * mirrors the editor's nodeForResult image/chip split so a comment and
+ * the item body render the same upload identically.
+ */
+export function markdownRefFor(result: AttachmentUploadResult): string {
+	const name = result.filename || 'attachment';
+	const ref = `pad-attachment:${result.id}`;
+	return result.category === 'image' ? `![${name}](${ref})` : `[${name}](${ref})`;
+}
+
+/** Bound-value accessors the host component supplies for a textarea. */
+export interface TextareaUploadHandle {
+	/** Read the current textarea value. */
+	getValue(): string;
+	/** Write a new value back to the bound state. */
+	setValue(next: string): void;
+	/** +1 when an upload starts, -1 when it settles — drives the busy gate. */
+	onPendingDelta(delta: number): void;
+	/** Surface an upload failure to the user. */
+	onError(message: string): void;
+}
+
+// Monotonic across the page so concurrent uploads never share a token.
+let uploadCounter = 0;
+
+/**
+ * Upload pasted/dropped files and weave `pad-attachment:` markdown into
+ * the bound textarea value. Each file gets a visible placeholder spliced
+ * in at the caret immediately; the placeholder is swapped for the real
+ * reference on success or removed on failure. Uploads run concurrently
+ * and each replaces its own (unique) placeholder regardless of completion
+ * order — so editing or pasting more while one is in flight is safe.
+ */
+export function uploadIntoTextarea(
+	files: File[],
+	textarea: HTMLTextAreaElement,
+	wsSlug: string,
+	handle: TextareaUploadHandle
+): void {
+	if (files.length === 0) return;
+
+	const value = handle.getValue();
+	const start = textarea.selectionStart ?? value.length;
+	const end = textarea.selectionEnd ?? start;
+
+	const jobs = files.map((file) => {
+		uploadCounter += 1;
+		const token = `pad-upload-${Date.now().toString(36)}-${uploadCounter}`;
+		const name = file.name || 'attachment';
+		// The token sits in the href slot so the placeholder string is
+		// unique even when two files share a filename — string replace
+		// below then targets exactly this upload.
+		return { file, placeholder: `![Uploading ${name}…](${token})` };
+	});
+
+	// Splice all placeholders in at the selection, space-separated so
+	// adjacent embeds stay distinct markdown tokens. Pad with leading /
+	// trailing spaces only when the surrounding text would otherwise abut.
+	const inserted = jobs.map((j) => j.placeholder).join(' ');
+	const lead = start > 0 && !/\s$/.test(value.slice(0, start)) ? ' ' : '';
+	const trail = end < value.length && !/^\s/.test(value.slice(end)) ? ' ' : '';
+	handle.setValue(value.slice(0, start) + lead + inserted + trail + value.slice(end));
+
+	for (const job of jobs) {
+		handle.onPendingDelta(1);
+		api.attachments
+			.upload(wsSlug, job.file)
+			.then((res) => {
+				handle.setValue(handle.getValue().replace(job.placeholder, markdownRefFor(res)));
+			})
+			.catch((err) => {
+				// Drop the placeholder (and a trailing space it introduced) so a
+				// failed upload leaves the draft as if nothing was pasted.
+				handle.setValue(
+					handle.getValue().replace(`${job.placeholder} `, '').replace(job.placeholder, '')
+				);
+				handle.onError(err instanceof Error ? err.message : 'Upload failed');
+			})
+			.finally(() => handle.onPendingDelta(-1));
+	}
+}


### PR DESCRIPTION
## Summary
Adds image/file attachment support to item comments (IDEA-1650). Paste or drag-drop into the comment composer or reply box → upload → inline render. The idea's note pointed at `CommentThread.svelte`, which is dead code; the live UI is `ItemTimeline` (composer) + `TimelineCommentCard` (display + reply).

## What changed
- **Compose** — shared `commentAttachments.ts` helper drives paste/drop upload for both the comment composer and the reply box: placeholder at caret → concurrent upload via the existing attachment API → swap for `pad-attachment:UUID` markdown (image syntax for images, chip syntax otherwise). Submit gated while uploads are in flight.
- **Display** — `ItemTimeline` lazily HEAD-probes referenced UUIDs (reusing the editor's `fetchAttachmentMetadata` cache), builds a reactive resolver, and threads it into `renderMarkdown` for comments + replies so refs render inline.
- **Orphan GC** — comment uploads leave `attachments.item_id` NULL like the editor, but the GC reference scan only checked `items`. Renamed `AttachmentReferencedInItems` → `AttachmentReferenced` and extended it to scan `comments.body`, so a screenshot referenced only from a comment isn't reclaimed after the grace period.

## Context
Implements `IDEA-1650`. Follow-up refinement (thumbnails + click-to-expand lightbox) captured as `IDEA-1660`.

## Test plan
- [x] go build ./... — clean
- [x] go test ./internal/store/ ./internal/server/ — pass (incl. new `TestOrphanGC_KeepsAttachmentReferencedFromComment`)
- [x] cd web && npm run build — clean
- [x] cd web && npm run check — 0 errors
- [ ] Manual: paste a screenshot into a comment, confirm inline render + post (needs a browser session)