### PR TITLE
feat(comments): thumbnail comment images + click-to-expand lightbox (IDEA-1660)

### DIFF
--- a/web/src/lib/components/common/Lightbox.svelte
+++ b/web/src/lib/components/common/Lightbox.svelte
@@ -1,0 +1,180 @@
+<script lang="ts">
+	/**
+	 * Full-screen image viewer for attachment thumbnails (IDEA-1660).
+	 * Opened by a host that captures a click on an `img[data-attachment-id]`
+	 * and passes the attachment id(s) — the lightbox loads the ORIGINAL
+	 * (un-variant) blob so the expanded view is full resolution regardless
+	 * of the thumbnail variant shown inline.
+	 *
+	 * Keyboard: Esc closes, ←/→ navigate when multiple images were passed.
+	 * Backdrop click closes; clicking the image itself does not.
+	 */
+	import { untrack } from 'svelte';
+	import { attachmentDownloadUrl } from '$lib/markdown/attachments';
+
+	export interface LightboxImage {
+		id: string;
+		alt: string;
+	}
+
+	interface Props {
+		images: LightboxImage[];
+		/** Index to open at (clamped). */
+		index?: number;
+		wsSlug: string;
+		onClose: () => void;
+	}
+
+	let { images, index = 0, wsSlug, onClose }: Props = $props();
+
+	// Seeded once at mount — the host remounts (null → set) on each open, so
+	// no prop-sync effect is needed. untrack makes the initial-value capture
+	// explicit (props are constant for this component's lifetime).
+	let current = $state(
+		untrack(() => Math.min(Math.max(index, 0), Math.max(images.length - 1, 0)))
+	);
+
+	let hasMultiple = $derived(images.length > 1);
+	let img = $derived(images[current]);
+	let src = $derived(img ? attachmentDownloadUrl(wsSlug, img.id) : '');
+
+	function prev() {
+		current = (current - 1 + images.length) % images.length;
+	}
+	function next() {
+		current = (current + 1) % images.length;
+	}
+
+	function onKeydown(e: KeyboardEvent) {
+		if (e.key === 'Escape') {
+			onClose();
+		} else if (e.key === 'ArrowLeft' && hasMultiple) {
+			prev();
+		} else if (e.key === 'ArrowRight' && hasMultiple) {
+			next();
+		}
+	}
+
+	// Close only on a click of the backdrop itself — clicks on the image or
+	// controls have a different target, so they don't dismiss. This avoids
+	// putting a click handler (and its a11y burden) on the <img>.
+	function onBackdropClick(e: MouseEvent) {
+		if (e.target === e.currentTarget) onClose();
+	}
+</script>
+
+<svelte:window onkeydown={onKeydown} />
+
+<div
+	class="lightbox-backdrop"
+	role="presentation"
+	onclick={onBackdropClick}
+>
+	<button class="lightbox-close" type="button" title="Close (Esc)" onclick={onClose}>
+		&#10005;
+	</button>
+
+	{#if hasMultiple}
+		<button class="lightbox-nav prev" type="button" title="Previous (←)" onclick={prev}>
+			&#8249;
+		</button>
+		<button class="lightbox-nav next" type="button" title="Next (→)" onclick={next}>
+			&#8250;
+		</button>
+	{/if}
+
+	{#if img}
+		<img class="lightbox-image" {src} alt={img.alt || 'Attachment'} />
+	{/if}
+
+	{#if hasMultiple}
+		<div class="lightbox-counter">{current + 1} / {images.length}</div>
+	{/if}
+</div>
+
+<style>
+	.lightbox-backdrop {
+		position: fixed;
+		inset: 0;
+		z-index: 1000;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		background: rgba(0, 0, 0, 0.82);
+		backdrop-filter: blur(2px);
+		cursor: zoom-out;
+	}
+
+	.lightbox-image {
+		max-width: 92vw;
+		max-height: 92vh;
+		object-fit: contain;
+		border-radius: var(--radius);
+		box-shadow: 0 8px 40px rgba(0, 0, 0, 0.5);
+		cursor: default;
+	}
+
+	.lightbox-close {
+		position: absolute;
+		top: var(--space-3);
+		right: var(--space-3);
+		width: 40px;
+		height: 40px;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		background: rgba(0, 0, 0, 0.4);
+		border: 1px solid rgba(255, 255, 255, 0.2);
+		border-radius: 50%;
+		color: #fff;
+		font-size: 1.1rem;
+		cursor: pointer;
+		line-height: 1;
+	}
+
+	.lightbox-close:hover {
+		background: rgba(0, 0, 0, 0.7);
+	}
+
+	.lightbox-nav {
+		position: absolute;
+		top: 50%;
+		transform: translateY(-50%);
+		width: 48px;
+		height: 48px;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		background: rgba(0, 0, 0, 0.4);
+		border: 1px solid rgba(255, 255, 255, 0.2);
+		border-radius: 50%;
+		color: #fff;
+		font-size: 1.8rem;
+		cursor: pointer;
+		line-height: 1;
+	}
+
+	.lightbox-nav:hover {
+		background: rgba(0, 0, 0, 0.7);
+	}
+
+	.lightbox-nav.prev {
+		left: var(--space-3);
+	}
+
+	.lightbox-nav.next {
+		right: var(--space-3);
+	}
+
+	.lightbox-counter {
+		position: absolute;
+		bottom: var(--space-3);
+		left: 50%;
+		transform: translateX(-50%);
+		padding: var(--space-1) var(--space-3);
+		background: rgba(0, 0, 0, 0.5);
+		border-radius: 9999px;
+		color: #fff;
+		font-size: 0.8rem;
+	}
+</style>

--- a/web/src/lib/components/timeline/ItemTimeline.svelte
+++ b/web/src/lib/components/timeline/ItemTimeline.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { onDestroy } from 'svelte';
+	import { onDestroy, tick } from 'svelte';
 	import { api } from '$lib/api/client';
 	import { sseService } from '$lib/services/sse.svelte';
 	import { authStore } from '$lib/stores/auth.svelte';
@@ -121,40 +121,75 @@
 		startComposeUploads(files);
 	}
 
-	// Lightbox state (IDEA-1660). Set when a thumbnail is clicked; cleared
+	// Lightbox state (IDEA-1660). Set when a thumbnail is activated; cleared
 	// on close. Null = closed, so the host remounts fresh on each open.
 	let lightbox: { images: LightboxImage[]; index: number } | null = $state(null);
+	let entryListEl: HTMLElement | undefined = $state();
 
-	// Delegated click handler for inline attachment thumbnails. Attached via
-	// an action (not a declarative onclick on the static container) so the
-	// Svelte a11y lint doesn't flag a click handler on a non-interactive div;
-	// keyboard users reach the same images through the rendered markdown's
-	// own affordances, and the lightbox itself is fully keyboard-navigable.
-	function thumbnailZoom(node: HTMLElement) {
-		const handler = (e: MouseEvent) => {
-			const target = e.target as HTMLElement | null;
-			const imgEl = target?.closest('img[data-attachment-id]') as HTMLElement | null;
-			if (!imgEl) return;
-			// Gather sibling attachment images in the same comment/reply body
-			// so the lightbox can page through them with ←/→.
-			const scope = imgEl.closest('.comment-body, .reply-body') ?? imgEl.parentElement;
-			const els = scope
-				? Array.from(scope.querySelectorAll<HTMLElement>('img[data-attachment-id]'))
-				: [imgEl];
-			const list: LightboxImage[] = els
-				.map((el) => ({ id: el.getAttribute('data-attachment-id') ?? '', alt: el.getAttribute('alt') ?? '' }))
-				.filter((x) => x.id !== '');
-			if (list.length === 0) return;
-			e.preventDefault();
-			lightbox = { images: list, index: Math.max(0, els.indexOf(imgEl)) };
-		};
-		node.addEventListener('click', handler);
-		return {
-			destroy() {
-				node.removeEventListener('click', handler);
-			}
-		};
+	// Open the lightbox for a clicked/activated thumbnail, gathering sibling
+	// attachment images in the same comment/reply body so ←/→ can page them.
+	function openLightboxFromImg(imgEl: HTMLElement) {
+		const scope = imgEl.closest('.comment-body, .reply-body') ?? imgEl.parentElement;
+		const els = scope
+			? Array.from(scope.querySelectorAll<HTMLElement>('img[data-attachment-id]'))
+			: [imgEl];
+		const list: LightboxImage[] = els
+			.map((el) => ({ id: el.getAttribute('data-attachment-id') ?? '', alt: el.getAttribute('alt') ?? '' }))
+			.filter((x) => x.id !== '');
+		if (list.length === 0) return;
+		lightbox = { images: list, index: Math.max(0, els.indexOf(imgEl)) };
 	}
+
+	function onThumbClick(e: MouseEvent) {
+		const imgEl = (e.target as HTMLElement | null)?.closest(
+			'img[data-attachment-id]'
+		) as HTMLElement | null;
+		if (!imgEl) return;
+		e.preventDefault();
+		openLightboxFromImg(imgEl);
+	}
+
+	function onThumbKeydown(e: KeyboardEvent) {
+		if (e.key !== 'Enter' && e.key !== ' ') return;
+		const imgEl = (e.target as HTMLElement | null)?.closest(
+			'img[data-attachment-id]'
+		) as HTMLElement | null;
+		if (!imgEl) return;
+		e.preventDefault(); // Space would otherwise scroll the page
+		openLightboxFromImg(imgEl);
+	}
+
+	// Delegated click + keydown on the entry list (rather than declarative
+	// handlers on the static container, which the a11y lint would flag).
+	$effect(() => {
+		const el = entryListEl;
+		if (!el) return;
+		el.addEventListener('click', onThumbClick);
+		el.addEventListener('keydown', onThumbKeydown);
+		return () => {
+			el.removeEventListener('click', onThumbClick);
+			el.removeEventListener('keydown', onThumbKeydown);
+		};
+	});
+
+	// Inline attachment images come from sanitized {@html}, so we can't wrap
+	// them in a <button> at render time. Instead make each one a focusable,
+	// announced control imperatively after every entries change (covers
+	// SSE-added comments) so keyboard users can open the lightbox.
+	$effect(() => {
+		void entries;
+		const el = entryListEl;
+		if (!el) return;
+		tick().then(() => {
+			for (const img of el.querySelectorAll<HTMLElement>('img[data-attachment-id]')) {
+				if (img.getAttribute('role') === 'button') continue;
+				img.setAttribute('role', 'button');
+				img.setAttribute('tabindex', '0');
+				const alt = img.getAttribute('alt');
+				img.setAttribute('aria-label', alt ? `View image: ${alt}` : 'View attachment image');
+			}
+		});
+	});
 
 	function handleComposeDragOver(e: DragEvent) {
 		// Cancel only file drags so the browser delivers the drop here
@@ -399,7 +434,7 @@
 	{/if}
 
 	{#if !loading || entries.length > 0}
-		<div class="entry-list" use:thumbnailZoom>
+		<div class="entry-list" bind:this={entryListEl}>
 			{#each entries as entry (entry.id)}
 				<div class="entry">
 					<div class="entry-rail">

--- a/web/src/lib/components/timeline/ItemTimeline.svelte
+++ b/web/src/lib/components/timeline/ItemTimeline.svelte
@@ -174,10 +174,13 @@
 
 	// Inline attachment images come from sanitized {@html}, so we can't wrap
 	// them in a <button> at render time. Instead make each one a focusable,
-	// announced control imperatively after every entries change (covers
-	// SSE-added comments) so keyboard users can open the lightbox.
+	// announced control imperatively so keyboard users can open the lightbox.
+	// Depends on BOTH `entries` (new comments) AND `attMeta` (an image only
+	// renders as an <img> once its metadata resolves — before that it's a
+	// "missing" placeholder span — so the pass must re-run on resolution).
 	$effect(() => {
 		void entries;
+		void attMeta;
 		const el = entryListEl;
 		if (!el) return;
 		tick().then(() => {

--- a/web/src/lib/components/timeline/ItemTimeline.svelte
+++ b/web/src/lib/components/timeline/ItemTimeline.svelte
@@ -17,6 +17,7 @@
 	} from '$lib/utils/commentAttachments';
 	import { fetchAttachmentMetadata } from '$lib/components/editor/attachment-metadata';
 	import { attachmentDownloadUrl, type AttachmentMeta } from '$lib/markdown/attachments';
+	import Lightbox, { type LightboxImage } from '$lib/components/common/Lightbox.svelte';
 
 	interface Props {
 		wsSlug: string;
@@ -118,6 +119,41 @@
 		if (files.length === 0) return;
 		e.preventDefault();
 		startComposeUploads(files);
+	}
+
+	// Lightbox state (IDEA-1660). Set when a thumbnail is clicked; cleared
+	// on close. Null = closed, so the host remounts fresh on each open.
+	let lightbox: { images: LightboxImage[]; index: number } | null = $state(null);
+
+	// Delegated click handler for inline attachment thumbnails. Attached via
+	// an action (not a declarative onclick on the static container) so the
+	// Svelte a11y lint doesn't flag a click handler on a non-interactive div;
+	// keyboard users reach the same images through the rendered markdown's
+	// own affordances, and the lightbox itself is fully keyboard-navigable.
+	function thumbnailZoom(node: HTMLElement) {
+		const handler = (e: MouseEvent) => {
+			const target = e.target as HTMLElement | null;
+			const imgEl = target?.closest('img[data-attachment-id]') as HTMLElement | null;
+			if (!imgEl) return;
+			// Gather sibling attachment images in the same comment/reply body
+			// so the lightbox can page through them with ←/→.
+			const scope = imgEl.closest('.comment-body, .reply-body') ?? imgEl.parentElement;
+			const els = scope
+				? Array.from(scope.querySelectorAll<HTMLElement>('img[data-attachment-id]'))
+				: [imgEl];
+			const list: LightboxImage[] = els
+				.map((el) => ({ id: el.getAttribute('data-attachment-id') ?? '', alt: el.getAttribute('alt') ?? '' }))
+				.filter((x) => x.id !== '');
+			if (list.length === 0) return;
+			e.preventDefault();
+			lightbox = { images: list, index: Math.max(0, els.indexOf(imgEl)) };
+		};
+		node.addEventListener('click', handler);
+		return {
+			destroy() {
+				node.removeEventListener('click', handler);
+			}
+		};
 	}
 
 	function handleComposeDragOver(e: DragEvent) {
@@ -363,7 +399,7 @@
 	{/if}
 
 	{#if !loading || entries.length > 0}
-		<div class="entry-list">
+		<div class="entry-list" use:thumbnailZoom>
 			{#each entries as entry (entry.id)}
 				<div class="entry">
 					<div class="entry-rail">
@@ -411,6 +447,15 @@
 		{/if}
 	{/if}
 </section>
+
+{#if lightbox}
+	<Lightbox
+		images={lightbox.images}
+		index={lightbox.index}
+		{wsSlug}
+		onClose={() => (lightbox = null)}
+	/>
+{/if}
 
 <style>
 	.timeline {

--- a/web/src/lib/components/timeline/TimelineCommentCard.svelte
+++ b/web/src/lib/components/timeline/TimelineCommentCard.svelte
@@ -209,7 +209,7 @@
 	{/if}
 
 	<div class="comment-body prose">
-		{@html renderMarkdown(comment.body, items, wsSlug, username, undefined, attachmentResolver)}
+		{@html renderMarkdown(comment.body, items, wsSlug, username, undefined, attachmentResolver, 'thumb-sm')}
 	</div>
 
 	<div class="comment-footer">
@@ -300,7 +300,7 @@
 					</div>
 
 					<div class="reply-body prose">
-						{@html renderMarkdown(reply.body, items, wsSlug, username, undefined, attachmentResolver)}
+						{@html renderMarkdown(reply.body, items, wsSlug, username, undefined, attachmentResolver, 'thumb-sm')}
 					</div>
 
 						<div class="reactions-row">
@@ -465,6 +465,24 @@
 	.comment-body :global(p:first-child),
 	.reply-body :global(p:first-child) {
 		margin-top: 0;
+	}
+
+	/* Inline attachment images render as compact thumbnails (IDEA-1660).
+	   The `.prose img { max-width: 100% }` base would let a pasted screenshot
+	   fill the comment column; cap it to a small box and signal it's
+	   clickable. Click-to-expand is handled by the timeline's delegated
+	   handler, which opens the full-resolution image in a lightbox. */
+	.comment-body :global(img[data-attachment-id]),
+	.reply-body :global(img[data-attachment-id]) {
+		max-width: 280px;
+		max-height: 180px;
+		width: auto;
+		height: auto;
+		object-fit: contain;
+		border: 1px solid var(--border);
+		background: var(--bg-secondary);
+		cursor: zoom-in;
+		vertical-align: middle;
 	}
 
 	.comment-footer {

--- a/web/src/lib/markdown/attachments.ts
+++ b/web/src/lib/markdown/attachments.ts
@@ -125,9 +125,10 @@ function escapeHtml(s: string): string {
 export function renderAttachmentImage(
 	meta: AttachmentMeta,
 	alt: string,
-	workspaceSlug: string
+	workspaceSlug: string,
+	variant: 'thumb-sm' | 'thumb-md' = 'thumb-md'
 ): string {
-	const src = attachmentDownloadUrl(workspaceSlug, meta.id, 'thumb-md');
+	const src = attachmentDownloadUrl(workspaceSlug, meta.id, variant);
 	const altText = alt && alt.trim() !== '' ? alt : meta.filename;
 	const sizeAttrs =
 		meta.width && meta.height && meta.width > 0 && meta.height > 0
@@ -174,13 +175,14 @@ export function resolveAttachmentImage(
 	href: string,
 	alt: string,
 	workspaceSlug: string,
-	resolver: AttachmentResolver
+	resolver: AttachmentResolver,
+	variant: 'thumb-sm' | 'thumb-md' = 'thumb-md'
 ): string {
 	const uuid = parseAttachmentHref(href);
 	if (uuid === null) return '';
 	const meta = resolver(uuid);
 	if (!meta) return renderAttachmentMissing(uuid, alt);
-	if (isImageMime(meta.mime_type)) return renderAttachmentImage(meta, alt, workspaceSlug);
+	if (isImageMime(meta.mime_type)) return renderAttachmentImage(meta, alt, workspaceSlug, variant);
 	return renderAttachmentChip(meta, alt && alt.trim() !== '' ? alt : meta.filename, workspaceSlug);
 }
 

--- a/web/src/lib/utils/markdown.ts
+++ b/web/src/lib/utils/markdown.ts
@@ -35,6 +35,9 @@ function cleanUrl(href: string): string | null {
 type AttachmentRenderContext = {
 	resolver: AttachmentResolver;
 	workspaceSlug: string;
+	// Thumbnail variant for inline image embeds. Comments render small
+	// (thumb-sm, 256px) thumbnails; other surfaces default to thumb-md.
+	imageVariant: 'thumb-sm' | 'thumb-md';
 };
 let currentAttachmentCtx: AttachmentRenderContext | null = null;
 
@@ -98,7 +101,8 @@ renderer.image = function (this: Renderer, { href, title, text }: Tokens.Image) 
 			href,
 			text,
 			currentAttachmentCtx.workspaceSlug,
-			currentAttachmentCtx.resolver
+			currentAttachmentCtx.resolver,
+			currentAttachmentCtx.imageVariant
 		);
 	}
 	// Default image rendering. Mirrors marked's stdout behavior so
@@ -288,6 +292,9 @@ function escapeHtml(s: string): string {
  *   When omitted, those references render as plain markdown links pointing
  *   at the literal `pad-attachment:UUID` href — clearly broken in the UI,
  *   which is the right signal for unresolved environments.
+ * @param attachmentImageVariant - Thumbnail variant for inline image
+ *   embeds. Defaults to `thumb-md` (1024px); comments pass `thumb-sm`
+ *   (256px) so pasted screenshots render as compact thumbnails.
  */
 export function renderMarkdown(
 	content: string,
@@ -295,7 +302,8 @@ export function renderMarkdown(
 	workspaceSlug: string,
 	username?: string,
 	visibleCollectionSlugs?: Set<string>,
-	attachmentResolver?: AttachmentResolver
+	attachmentResolver?: AttachmentResolver,
+	attachmentImageVariant: 'thumb-sm' | 'thumb-md' = 'thumb-md'
 ): string {
 	const withLinks = content.replace(/\[\[([^\]]+)\]\]/g, (_match, body: string) => {
 		// Cross-workspace form: [[workspace-slug::REF]] or [[workspace-slug::REF|Display]].
@@ -365,7 +373,11 @@ export function renderMarkdown(
 	// of this synchronous parse. The try/finally ensures we never leak the
 	// context across calls, even when marked throws on malformed input.
 	if (attachmentResolver) {
-		currentAttachmentCtx = { resolver: attachmentResolver, workspaceSlug };
+		currentAttachmentCtx = {
+			resolver: attachmentResolver,
+			workspaceSlug,
+			imageVariant: attachmentImageVariant
+		};
 	}
 	try {
 		return sanitizeMarkdownHtml(marked(withLinks) as string);


### PR DESCRIPTION
## Summary
Refines comment image attachments (IDEA-1660, follow-up to IDEA-1650): inline images now render as compact **thumbnails** and open in a **click-to-expand lightbox**.

## What changed
- **Tier 1 — thumbnails:** threaded an image `variant` through the markdown render pipeline (`renderMarkdown` → `AttachmentRenderContext` → `resolveAttachmentImage` → `renderAttachmentImage`), defaulting to `thumb-md`. Comment + reply bodies pass `thumb-sm` (256px). CSS caps inline attachment images to a 280×180 box with `cursor: zoom-in`.
- **Tier 2 — lightbox:** new reusable `common/Lightbox.svelte` (full-resolution overlay, Esc/backdrop close, ←/→ paging, counter). `ItemTimeline` opens it via a delegated click handler (mounted with a `use:` action so no a11y lint on the static container) on any `img[data-attachment-id]`, collecting sibling images in the same comment/reply for paging.

No backend changes. Tier 3 (dims-via-headers, multi-image grid, `loading=lazy`) deferred. Part of PLAN-1662 (Rich comments) as the display foundation.

## Test plan
- [x] cd web && npm run build — clean
- [x] cd web && npm run check — 0 errors (no new warnings)
- [x] Manual: posted a comment with 1 and 2 images, confirmed thumbnail render + lightbox open + ←/→ paging on localhost