### PR TITLE
feat(comments): comment editing backend — user_id, UpdateComment, PATCH, SSE (TASK-1663)

### DIFF
--- a/internal/events/bus.go
+++ b/internal/events/bus.go
@@ -23,6 +23,7 @@ const (
 
 	// Comment events
 	CommentCreated = "comment_created"
+	CommentUpdated = "comment_updated"
 	CommentDeleted = "comment_deleted"
 
 	// Reaction events

--- a/internal/models/comment.go
+++ b/internal/models/comment.go
@@ -8,6 +8,11 @@ type Comment struct {
 	ItemID      string    `json:"item_id"`
 	WorkspaceID string    `json:"workspace_id"`
 	Author      string    `json:"author"`
+	// UserID is the authenticated user who authored the comment. Empty for
+	// pre-identity comments (created before TASK-1663) and agent/system
+	// comments; the comment-edit permission check treats empty as
+	// "no provable author" → admin-only.
+	UserID      string    `json:"user_id,omitempty"`
 	Body        string    `json:"body"`
 	CreatedBy   string    `json:"created_by"`
 	Source      string    `json:"source"`

--- a/internal/server/handlers_comments.go
+++ b/internal/server/handlers_comments.go
@@ -119,7 +119,7 @@ func (s *Server) handleCreateComment(w http.ResponseWriter, r *http.Request) {
 		input.ActivityID = activityID
 	}
 
-	comment, err := s.store.CreateComment(workspaceID, item.ID, input)
+	comment, err := s.store.CreateComment(workspaceID, item.ID, currentUserID(r), input)
 	if err != nil {
 		writeInternalError(w, err)
 		return
@@ -169,6 +169,81 @@ func (s *Server) handleDeleteComment(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// handleUpdateComment edits a comment's body. Editing is an authorship
+// operation — distinct from delete, which any item editor may do — so only
+// the comment author (matching user_id) or a platform admin may edit.
+// Comments with no recorded user_id (created before TASK-1663, or
+// agent/system comments) are admin-only. (PLAN-1662.)
+func (s *Server) handleUpdateComment(w http.ResponseWriter, r *http.Request) {
+	workspaceID, ok := s.getWorkspaceID(w, r)
+	if !ok {
+		return
+	}
+
+	commentID := chi.URLParam(r, "commentID")
+
+	comment, cerr := s.store.GetComment(commentID)
+	if cerr != nil || comment == nil || comment.WorkspaceID != workspaceID {
+		writeError(w, http.StatusNotFound, "not_found", "Comment not found")
+		return
+	}
+	if !s.requireCommentVisible(w, r, workspaceID, comment) {
+		return
+	}
+	if !s.canEditComment(r, comment) {
+		writeError(w, http.StatusForbidden, "forbidden", "Only the comment author or an admin can edit this comment")
+		return
+	}
+
+	var input struct {
+		Body string `json:"body"`
+	}
+	if err := decodeJSON(r, &input); err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", err.Error())
+		return
+	}
+	body := strings.TrimSpace(input.Body)
+	if body == "" {
+		writeError(w, http.StatusBadRequest, "bad_request", "body is required (use delete to remove a comment)")
+		return
+	}
+
+	updated, err := s.store.UpdateComment(commentID, body)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			writeError(w, http.StatusNotFound, "not_found", "Comment not found")
+			return
+		}
+		writeInternalError(w, err)
+		return
+	}
+
+	actor, source := actorFromRequest(r)
+	var title, collSlug string
+	if item, ierr := s.store.GetItem(updated.ItemID); ierr == nil && item != nil {
+		title = item.Title
+		collSlug = item.CollectionSlug
+	}
+	s.publishCommentEvent(events.CommentUpdated, workspaceID, updated.ItemID, updated.ID, title, collSlug, actor, source)
+	s.dispatchWebhook(workspaceID, "comment.updated", updated)
+
+	writeJSON(w, http.StatusOK, updated)
+}
+
+// canEditComment reports whether the requester may edit the given comment:
+// the authenticated author (matching user_id) or a platform admin. A comment
+// with an empty user_id has no provable author, so only admins can edit it.
+func (s *Server) canEditComment(r *http.Request, comment *models.Comment) bool {
+	u := currentUser(r)
+	if u == nil {
+		return false
+	}
+	if u.Role == "admin" {
+		return true
+	}
+	return comment.UserID != "" && comment.UserID == u.ID
 }
 
 // handleCreateReply creates a reply to an existing comment.
@@ -226,7 +301,7 @@ func (s *Server) handleCreateReply(w http.ResponseWriter, r *http.Request) {
 	}
 	input.ParentID = commentID
 
-	comment, err := s.store.CreateComment(workspaceID, parentComment.ItemID, input)
+	comment, err := s.store.CreateComment(workspaceID, parentComment.ItemID, currentUserID(r), input)
 	if err != nil {
 		writeInternalError(w, err)
 		return

--- a/internal/server/handlers_comments_edit_test.go
+++ b/internal/server/handlers_comments_edit_test.go
@@ -1,0 +1,125 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// TestUpdateComment_Permissions pins the comment-edit authorization model
+// (TASK-1663 / PLAN-1662): only the comment author or a platform admin may
+// edit; non-author non-admins are rejected; empty bodies are rejected.
+func TestUpdateComment_Permissions(t *testing.T) {
+	env := setupRBACEnv(t)
+
+	// Owner (the bootstrap user) is the platform admin. Create an item.
+	rr := doRequestWithCookie(env.srv, "POST",
+		"/api/v1/workspaces/"+env.wsSlug+"/collections/docs/items",
+		map[string]any{"title": "Commentable"}, env.ownerToken)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create item: %d %s", rr.Code, rr.Body.String())
+	}
+	var item map[string]any
+	parseJSON(t, rr, &item)
+	slug, _ := item["slug"].(string)
+
+	// Editor posts a comment → user_id should be populated with the editor.
+	rr = doRequestWithCookie(env.srv, "POST",
+		"/api/v1/workspaces/"+env.wsSlug+"/items/"+slug+"/comments",
+		map[string]any{"body": "original"}, env.editorToken)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("post comment: %d %s", rr.Code, rr.Body.String())
+	}
+	var c map[string]any
+	parseJSON(t, rr, &c)
+	cid, _ := c["id"].(string)
+	if uid, _ := c["user_id"].(string); uid == "" {
+		t.Error("expected user_id to be populated on create, got empty")
+	}
+
+	patch := func(token string, body string) *httptest.ResponseRecorder {
+		return doRequestWithCookie(env.srv, "PATCH",
+			"/api/v1/workspaces/"+env.wsSlug+"/comments/"+cid,
+			map[string]any{"body": body}, token)
+	}
+
+	// 1. Author (editor) edits own comment → 200, body updated.
+	rr = patch(env.editorToken, "edited by author")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("author edit: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var up map[string]any
+	parseJSON(t, rr, &up)
+	if up["body"] != "edited by author" {
+		t.Errorf("body not updated: %v", up["body"])
+	}
+
+	// 2. Viewer (non-author, non-admin) edits → 403.
+	rr = patch(env.viewerToken, "hacked")
+	if rr.Code != http.StatusForbidden {
+		t.Errorf("non-author edit: expected 403, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	// 3. Admin (owner) edits the editor's comment → 200.
+	rr = patch(env.ownerToken, "edited by admin")
+	if rr.Code != http.StatusOK {
+		t.Errorf("admin edit: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	// 4. Empty / whitespace body → 400 (delete is the way to remove).
+	rr = patch(env.editorToken, "   ")
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("empty body: expected 400, got %d: %s", rr.Code, rr.Body.String())
+	}
+}
+
+// TestUpdateComment_NullUserIDIsAdminOnly pins the fallback: a comment with
+// no recorded user_id (pre-identity / agent / imported) has no provable
+// author, so only an admin can edit it.
+func TestUpdateComment_NullUserIDIsAdminOnly(t *testing.T) {
+	env := setupRBACEnv(t)
+	wsID := workspaceIDForSlug(t, env.srv, env.wsSlug)
+
+	// Create an item as owner, grab its id for a direct store insert.
+	rr := doRequestWithCookie(env.srv, "POST",
+		"/api/v1/workspaces/"+env.wsSlug+"/collections/docs/items",
+		map[string]any{"title": "Legacy comments"}, env.ownerToken)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create item: %d %s", rr.Code, rr.Body.String())
+	}
+	var item map[string]any
+	parseJSON(t, rr, &item)
+	itemID, _ := item["id"].(string)
+
+	// Insert a comment with NO user_id, mirroring a pre-TASK-1663 / agent row.
+	comment, err := env.srv.store.CreateComment(wsID, itemID, "", models.CommentCreate{
+		Body:      "legacy comment",
+		Author:    "Editor",
+		CreatedBy: "user",
+		Source:    "web",
+	})
+	if err != nil {
+		t.Fatalf("seed comment: %v", err)
+	}
+	if comment.UserID != "" {
+		t.Fatalf("expected empty user_id, got %q", comment.UserID)
+	}
+
+	path := "/api/v1/workspaces/" + env.wsSlug + "/comments/" + comment.ID
+
+	// Editor (non-admin) cannot edit a comment with no provable author → 403.
+	rr = doRequestWithCookie(env.srv, "PATCH", path,
+		map[string]any{"body": "editor tries"}, env.editorToken)
+	if rr.Code != http.StatusForbidden {
+		t.Errorf("editor on null-user_id comment: expected 403, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	// Admin can.
+	rr = doRequestWithCookie(env.srv, "PATCH", path,
+		map[string]any{"body": "admin fixes"}, env.ownerToken)
+	if rr.Code != http.StatusOK {
+		t.Errorf("admin on null-user_id comment: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+}

--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -1194,7 +1194,7 @@ func (s *Server) handleUpdateItem(w http.ResponseWriter, r *http.Request) {
 		}
 		commentInput.CreatedBy = actor
 		commentInput.Source = source
-		comment, cerr := s.store.CreateComment(workspaceID, updated.ID, commentInput)
+		comment, cerr := s.store.CreateComment(workspaceID, updated.ID, currentUserID(r), commentInput)
 		if cerr != nil {
 			slog.Warn("failed to create comment on item update", "item_id", updated.ID, "error", cerr)
 		}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1151,6 +1151,7 @@ func (s *Server) setupRouter() {
 
 					// Comments (v2)
 					r.Route("/comments/{commentID}", func(r chi.Router) {
+						r.Patch("/", s.handleUpdateComment)
 						r.Delete("/", s.handleDeleteComment)
 						r.Post("/replies", s.handleCreateReply)
 						r.Post("/reactions", s.handleAddReaction)

--- a/internal/store/account_deletion_comments_test.go
+++ b/internal/store/account_deletion_comments_test.go
@@ -1,0 +1,61 @@
+package store
+
+import (
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// TestDeleteAccountAtomic_DetachesAuthoredComments is a regression test for the
+// FK that became live when TASK-1663 started populating comments.user_id:
+// deleting an account that authored comments must NULL those references rather
+// than fail on the comments.user_id -> users(id) foreign key. The comments
+// survive (with their display-name author preserved) and just become
+// admin-only to edit. testStore enables PRAGMA foreign_keys, so without the
+// detach step this fails with a FK violation.
+func TestDeleteAccountAtomic_DetachesAuthoredComments(t *testing.T) {
+	s := testStore(t)
+
+	user, err := s.CreateUser(models.UserCreate{
+		Email:    "author@test.com",
+		Name:     "Author",
+		Password: "correct-horse-battery-staple",
+	})
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+
+	ws := createTestWorkspace(t, s, "Owned")
+	coll := createTestCollection(t, s, ws.ID, "Tasks")
+	item := createTestItem(t, s, ws.ID, coll.ID, "Item", "")
+
+	comment, err := s.CreateComment(ws.ID, item.ID, user.ID, models.CommentCreate{
+		Body:      "authored",
+		Author:    "Author",
+		CreatedBy: "user",
+		Source:    "web",
+	})
+	if err != nil {
+		t.Fatalf("create comment: %v", err)
+	}
+	if comment.UserID != user.ID {
+		t.Fatalf("expected comment.user_id=%s, got %q", user.ID, comment.UserID)
+	}
+
+	// Must not fail on the comments.user_id FK.
+	if err := s.DeleteAccountAtomic(user.ID, []string{ws.Slug}); err != nil {
+		t.Fatalf("DeleteAccountAtomic: %v", err)
+	}
+
+	// The comment survives, with its author reference nulled.
+	got, err := s.GetComment(comment.ID)
+	if err != nil {
+		t.Fatalf("get comment after deletion: %v", err)
+	}
+	if got == nil {
+		t.Fatal("comment was deleted; expected it to survive with null user_id")
+	}
+	if got.UserID != "" {
+		t.Errorf("expected user_id cleared after account deletion, got %q", got.UserID)
+	}
+}

--- a/internal/store/comments.go
+++ b/internal/store/comments.go
@@ -8,8 +8,12 @@ import (
 	"github.com/PerpetualSoftware/pad/internal/models"
 )
 
-// CreateComment adds a new comment to an item.
-func (s *Store) CreateComment(workspaceID, itemID string, input models.CommentCreate) (*models.Comment, error) {
+// CreateComment adds a new comment to an item. userID is the authenticated
+// user authoring the comment (empty for agent/system comments); it's stored
+// as the canonical author identity for the comment-edit permission check —
+// the caller passes it explicitly rather than via the request body so it
+// can't be spoofed.
+func (s *Store) CreateComment(workspaceID, itemID, userID string, input models.CommentCreate) (*models.Comment, error) {
 	id := newID()
 	ts := now()
 
@@ -27,9 +31,9 @@ func (s *Store) CreateComment(workspaceID, itemID string, input models.CommentCr
 	}
 
 	_, err := s.db.Exec(s.q(`
-		INSERT INTO comments (id, item_id, workspace_id, author, body, created_by, source, activity_id, parent_id, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`),
-		id, itemID, workspaceID, author, input.Body, createdBy, source,
+		INSERT INTO comments (id, item_id, workspace_id, author, user_id, body, created_by, source, activity_id, parent_id, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`),
+		id, itemID, workspaceID, author, nilIfEmpty(userID), input.Body, createdBy, source,
 		nilIfEmpty(input.ActivityID), nilIfEmpty(input.ParentID), ts, ts,
 	)
 	if err != nil {
@@ -39,10 +43,27 @@ func (s *Store) CreateComment(workspaceID, itemID string, input models.CommentCr
 	return s.GetComment(id)
 }
 
+// UpdateComment replaces a comment's body and bumps updated_at. The
+// comments_fts_update trigger re-indexes the new body. Returns
+// sql.ErrNoRows when no live comment matches. Permission (author or
+// admin) is enforced by the handler, not here.
+func (s *Store) UpdateComment(id, body string) (*models.Comment, error) {
+	ts := now()
+	res, err := s.db.Exec(s.q(`UPDATE comments SET body = ?, updated_at = ? WHERE id = ?`), body, ts, id)
+	if err != nil {
+		return nil, fmt.Errorf("update comment: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return nil, sql.ErrNoRows
+	}
+	return s.GetComment(id)
+}
+
 // GetComment returns a single comment by ID.
 func (s *Store) GetComment(id string) (*models.Comment, error) {
 	row := s.db.QueryRow(s.q(`
-		SELECT c.id, c.item_id, c.workspace_id, c.author, c.body,
+		SELECT c.id, c.item_id, c.workspace_id, c.author, COALESCE(c.user_id, ''), c.body,
 		       c.created_by, c.source, COALESCE(c.activity_id, ''), COALESCE(c.parent_id, ''),
 		       c.created_at, c.updated_at,
 		       i.title, i.slug
@@ -53,7 +74,7 @@ func (s *Store) GetComment(id string) (*models.Comment, error) {
 	var c models.Comment
 	var createdAt, updatedAt string
 	err := row.Scan(
-		&c.ID, &c.ItemID, &c.WorkspaceID, &c.Author, &c.Body,
+		&c.ID, &c.ItemID, &c.WorkspaceID, &c.Author, &c.UserID, &c.Body,
 		&c.CreatedBy, &c.Source, &c.ActivityID, &c.ParentID,
 		&createdAt, &updatedAt,
 		&c.ItemTitle, &c.ItemSlug,
@@ -72,7 +93,7 @@ func (s *Store) GetComment(id string) (*models.Comment, error) {
 // ListComments returns all comments for an item, ordered chronologically.
 func (s *Store) ListComments(itemID string) ([]models.Comment, error) {
 	rows, err := s.db.Query(s.q(`
-		SELECT c.id, c.item_id, c.workspace_id, c.author, c.body,
+		SELECT c.id, c.item_id, c.workspace_id, c.author, COALESCE(c.user_id, ''), c.body,
 		       c.created_by, c.source, COALESCE(c.activity_id, ''), COALESCE(c.parent_id, ''),
 		       c.created_at, c.updated_at
 		FROM comments c
@@ -88,7 +109,7 @@ func (s *Store) ListComments(itemID string) ([]models.Comment, error) {
 		var c models.Comment
 		var createdAt, updatedAt string
 		if err := rows.Scan(
-			&c.ID, &c.ItemID, &c.WorkspaceID, &c.Author, &c.Body,
+			&c.ID, &c.ItemID, &c.WorkspaceID, &c.Author, &c.UserID, &c.Body,
 			&c.CreatedBy, &c.Source, &c.ActivityID, &c.ParentID,
 			&createdAt, &updatedAt,
 		); err != nil {
@@ -110,7 +131,7 @@ func (s *Store) ListComments(itemID string) ([]models.Comment, error) {
 // bind parameter (SQLSTATE 22021). See BUG-1086.
 func (s *Store) ListCommentsBeforeTime(itemID string, before time.Time, beforeID string, limit int) ([]models.Comment, error) {
 	ts := before.Format(time.RFC3339)
-	const selectCols = `c.id, c.item_id, c.workspace_id, c.author, c.body,
+	const selectCols = `c.id, c.item_id, c.workspace_id, c.author, COALESCE(c.user_id, ''), c.body,
 		       c.created_by, c.source, COALESCE(c.activity_id, ''), COALESCE(c.parent_id, ''),
 		       c.created_at, c.updated_at`
 	const orderLimit = `ORDER BY c.created_at DESC, c.id DESC LIMIT ?`
@@ -140,7 +161,7 @@ func (s *Store) ListCommentsBeforeTime(itemID string, before time.Time, beforeID
 		var c models.Comment
 		var createdAt, updatedAt string
 		if err := rows.Scan(
-			&c.ID, &c.ItemID, &c.WorkspaceID, &c.Author, &c.Body,
+			&c.ID, &c.ItemID, &c.WorkspaceID, &c.Author, &c.UserID, &c.Body,
 			&c.CreatedBy, &c.Source, &c.ActivityID, &c.ParentID,
 			&createdAt, &updatedAt,
 		); err != nil {

--- a/internal/store/timeline_pagination_test.go
+++ b/internal/store/timeline_pagination_test.go
@@ -32,7 +32,7 @@ func timelineFixture(t *testing.T, s *Store) (*models.Item, []models.Comment) {
 
 	var comments []models.Comment
 	for i, body := range []string{"first", "second", "third"} {
-		c, err := s.CreateComment(ws.ID, item.ID, models.CommentCreate{
+		c, err := s.CreateComment(ws.ID, item.ID, "", models.CommentCreate{
 			Body:      body,
 			Author:    "Tester",
 			CreatedBy: "user",
@@ -100,7 +100,7 @@ func TestListCommentsBeforeTime_SameSecondCursor(t *testing.T) {
 	// Three comments back-to-back with no sleep — they will share a second
 	// at RFC3339 precision (which is what the store stores).
 	for _, body := range []string{"a", "b", "c"} {
-		if _, err := s.CreateComment(ws.ID, item.ID, models.CommentCreate{
+		if _, err := s.CreateComment(ws.ID, item.ID, "", models.CommentCreate{
 			Body:      body,
 			Author:    "Tester",
 			CreatedBy: "user",

--- a/internal/store/users.go
+++ b/internal/store/users.go
@@ -962,6 +962,17 @@ func (s *Store) DeleteAccountAtomic(userID string, ownedWorkspaceSlugs []string)
 		return fmt.Errorf("delete account: delete api tokens: %w", err)
 	}
 
+	// 3b. Detach authored comments. comments.user_id is a FK to users(id)
+	// (TASK-1663 started populating it); the user's comments live on in
+	// soft-deleted owned workspaces and in other workspaces they're a member
+	// of, so null the reference rather than let the FK block deletion. The
+	// comments.author display name is preserved; nulling user_id just makes
+	// those comments admin-only to edit going forward, which is correct once
+	// the author's account is gone.
+	if _, err := tx.Exec(s.q("UPDATE comments SET user_id = NULL WHERE user_id = ?"), userID); err != nil {
+		return fmt.Errorf("delete account: detach comments: %w", err)
+	}
+
 	// 4. Delete the user record
 	if _, err := tx.Exec(s.q("DELETE FROM users WHERE id = ?"), userID); err != nil {
 		return fmt.Errorf("delete account: delete user: %w", err)

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -872,6 +872,12 @@ export const api = {
 				body: JSON.stringify(data)
 			}),
 
+		update: (ws: string, commentId: string, data: { body: string }) =>
+			request<Comment>(`/workspaces/${ws}/comments/${commentId}`, {
+				method: 'PATCH',
+				body: JSON.stringify(data)
+			}),
+
 		delete: (ws: string, commentId: string) =>
 			request<void>(`/workspaces/${ws}/comments/${commentId}`, {
 				method: 'DELETE'

--- a/web/src/lib/components/timeline/ItemTimeline.svelte
+++ b/web/src/lib/components/timeline/ItemTimeline.svelte
@@ -263,6 +263,7 @@
 	// visible shakiness and rate-limit errors from rapid SSE replay.
 	const relevantEvents = new Set([
 		'comment_created',
+		'comment_updated',
 		'comment_deleted',
 		'reaction_added',
 		'reaction_removed'

--- a/web/src/lib/services/sse.svelte.ts
+++ b/web/src/lib/services/sse.svelte.ts
@@ -34,6 +34,7 @@ const ITEM_EVENTS = [
 	'item_restored',
 	'workspace_updated',
 	'comment_created',
+	'comment_updated',
 	'comment_deleted',
 	'reaction_added',
 	'reaction_removed'

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -655,6 +655,8 @@ export interface Comment {
 	item_id: string;
 	workspace_id: string;
 	author: string;
+	/** Authenticated author's user id; empty for pre-identity / agent comments. */
+	user_id?: string;
 	body: string;
 	created_by: string;
 	source: string;


### PR DESCRIPTION
## Summary
Backend foundation for comment editing (PLAN-1662, first of three). No migration — `comments.user_id` already exists (012) but was never written or exposed.

## What changed
- **Author identity:** `CreateComment` now takes an explicit `userID` param, passed from `currentUserID` by the handlers (not via request body, so it can't be spoofed). `user_id` exposed on `models.Comment` + all SELECTs/scans. Export path left as-is (imported comments → NULL user_id → admin-only edit, matching the fallback).
- **`Store.UpdateComment(id, body)`** — replaces body + bumps `updated_at`; FTS trigger re-indexes.
- **`PATCH /workspaces/{ws}/comments/{commentID}`** — author-or-admin only (`canEditComment`), rejects empty body. Editing is an authorship op, distinct from delete (item editors). NULL `user_id` → admin-only.
- **`comment_updated` SSE** — broadcast from the handler; added to the web sse allowlist + `ItemTimeline` refresh set.
- **web:** `api.comments.update()`, `Comment.user_id` type.

## Context
Implements `TASK-1663` under `PLAN-1662` (Rich comments). Unblocks `TASK-1665` (edit UI). Independent of `TASK-1664` (CommentEditor).

## Test plan
- [x] go build ./... / go vet ./internal/... — clean
- [x] go test ./internal/store/ ./internal/server/ — pass
- [x] New: TestUpdateComment_Permissions (author 200 / non-author 403 / admin 200 / empty 400) + TestUpdateComment_NullUserIDIsAdminOnly
- [x] cd web && npm run build + npm run check — 0 errors