### PR TITLE
fix(sync): moved-out tombstones for cross-visibility collection moves (BUG-1675)

### DIFF
--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -366,13 +366,7 @@ func (s *Server) handleListItemsChanges(w http.ResponseWriter, r *http.Request) 
 		if len(grantedItemIDs) > 0 {
 			collLevelVisibleIDs = fullCollIDs
 		}
-		visibleSlugs := make(map[string]bool, len(collLevelVisibleIDs))
-		for _, id := range collLevelVisibleIDs {
-			if coll, _ := s.store.GetCollection(id); coll != nil {
-				visibleSlugs[coll.Slug] = true
-			}
-		}
-		movedOut, mErr := s.store.ListMovedOutSince(workspaceID, since, limit, collLevelVisibleIDs, visibleSlugs, grantedItemIDs)
+		movedOut, mErr := s.store.ListMovedOutSince(workspaceID, since, limit, collLevelVisibleIDs, grantedItemIDs)
 		if mErr != nil {
 			writeInternalError(w, mErr)
 			return
@@ -1557,16 +1551,12 @@ func (s *Server) handleMoveItem(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Log activity with metadata about the move. `seq` records the
-	// item's post-move seq so /items-changes can emit a moved-out
-	// tombstone tied to THIS move event, not any later change while the
-	// item sits in a hidden collection (BUG-1675).
+	// Log activity with metadata about the move (audit trail). The
+	// moved-out tombstone signal (BUG-1675) is recorded durably in
+	// item_collection_moves inside the move tx, not derived from this
+	// best-effort row.
 	actor, source := actorFromRequest(r)
-	moveMeta := auditMeta(map[string]string{
-		"from_collection": sourceColl.Slug,
-		"to_collection":   targetColl.Slug,
-		"seq":             strconv.FormatInt(moved.Seq, 10),
-	})
+	moveMeta := auditMeta(map[string]string{"from_collection": sourceColl.Slug, "to_collection": targetColl.Slug})
 	s.logActivityWithMeta(workspaceID, moved.ID, "moved", r, moveMeta)
 
 	// Publish events for both old and new collections

--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -1557,9 +1557,16 @@ func (s *Server) handleMoveItem(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Log activity with metadata about the move
+	// Log activity with metadata about the move. `seq` records the
+	// item's post-move seq so /items-changes can emit a moved-out
+	// tombstone tied to THIS move event, not any later change while the
+	// item sits in a hidden collection (BUG-1675).
 	actor, source := actorFromRequest(r)
-	moveMeta := auditMeta(map[string]string{"from_collection": sourceColl.Slug, "to_collection": targetColl.Slug})
+	moveMeta := auditMeta(map[string]string{
+		"from_collection": sourceColl.Slug,
+		"to_collection":   targetColl.Slug,
+		"seq":             strconv.FormatInt(moved.Seq, 10),
+	})
 	s.logActivityWithMeta(workspaceID, moved.ID, "moved", r, moveMeta)
 
 	// Publish events for both old and new collections

--- a/internal/server/handlers_items.go
+++ b/internal/server/handlers_items.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -233,6 +234,14 @@ func (s *Server) handleListItemsIndex(w http.ResponseWriter, r *http.Request) {
 type itemChangeRow struct {
 	models.Item
 	Deleted bool `json:"deleted"`
+	// MovedOut marks a row the caller can no longer see because the item
+	// moved into a collection outside their visibility (BUG-1675). Unlike
+	// `deleted` (a soft-delete the item still exists under), a moved-out
+	// row carries only id + seq — no title/fields/destination — and the
+	// client evicts it from its local cache. The item is alive for
+	// callers who can see the destination; it's just gone from THIS
+	// caller's view.
+	MovedOut bool `json:"moved_out,omitempty"`
 }
 
 // itemsChangesResponse wraps a delta-fetch result.
@@ -335,21 +344,71 @@ func (s *Server) handleListItemsChanges(w http.ResponseWriter, r *http.Request) 
 	// parent title / ref after the parent itself has been archived.
 	s.enrichItemsWithParent(workspaceID, rows, visibleIDs)
 
-	// Cursor: MAX(seq) in the response. When empty, return `since`
-	// unchanged so the client doesn't regress its position. When
-	// truncated by limit, the cursor sits at the last row's seq so
-	// the next poll resumes there (no overlap, no gap — seq is
-	// strictly monotonic per workspace).
-	cursorSeq := since
 	changes := make([]itemChangeRow, 0, len(rows))
 	for _, it := range rows {
-		if it.Seq > cursorSeq {
-			cursorSeq = it.Seq
-		}
 		changes = append(changes, itemChangeRow{
 			Item:    it,
 			Deleted: it.DeletedAt != nil,
 		})
+	}
+
+	// Moved-out tombstones (BUG-1675). Only restricted callers
+	// (visibleIDs != nil) can lose visibility on a move; full members
+	// (nil = all-access) never do, so skip the extra query for them.
+	// The main delta filters by current collection, so an item that
+	// moved into a collection this caller can't see vanishes with no
+	// eviction signal — append a minimal id+seq tombstone for those.
+	if visibleIDs != nil {
+		// Collections the caller browses at the collection level (the
+		// from-collection a move must originate in). With item grants
+		// the main query swaps to fullCollIDs; mirror that here.
+		collLevelVisibleIDs := visibleIDs
+		if len(grantedItemIDs) > 0 {
+			collLevelVisibleIDs = fullCollIDs
+		}
+		visibleSlugs := make(map[string]bool, len(collLevelVisibleIDs))
+		for _, id := range collLevelVisibleIDs {
+			if coll, _ := s.store.GetCollection(id); coll != nil {
+				visibleSlugs[coll.Slug] = true
+			}
+		}
+		movedOut, mErr := s.store.ListMovedOutSince(workspaceID, since, limit, collLevelVisibleIDs, visibleSlugs, grantedItemIDs)
+		if mErr != nil {
+			writeInternalError(w, mErr)
+			return
+		}
+		for _, m := range movedOut {
+			changes = append(changes, itemChangeRow{
+				Item:     models.Item{ID: m.ID, Seq: m.Seq},
+				MovedOut: true,
+			})
+		}
+	}
+
+	// Merge main + moved-out rows into one seq-ascending stream, then
+	// cap at the effective limit so pagination stays gap-free: the
+	// cursor is the last kept row's seq and any row past it is dropped
+	// to be re-fetched on the next poll (seq is strictly monotonic per
+	// workspace, so no overlap, no gap).
+	sort.Slice(changes, func(i, j int) bool { return changes[i].Seq < changes[j].Seq })
+	effLimit := limit
+	if effLimit <= 0 {
+		effLimit = store.DefaultItemChangesLimit
+	}
+	if effLimit > store.MaxItemChangesLimit {
+		effLimit = store.MaxItemChangesLimit
+	}
+	if len(changes) > effLimit {
+		changes = changes[:effLimit]
+	}
+
+	// Cursor: MAX(seq) in the (capped) response. When empty, return
+	// `since` unchanged so the client doesn't regress its position.
+	cursorSeq := since
+	for _, c := range changes {
+		if c.Seq > cursorSeq {
+			cursorSeq = c.Seq
+		}
 	}
 
 	writeJSON(w, http.StatusOK, itemsChangesResponse{

--- a/internal/server/handlers_items_bulk.go
+++ b/internal/server/handlers_items_bulk.go
@@ -221,12 +221,22 @@ func (s *Server) handleBulkItems(w http.ResponseWriter, r *http.Request) {
 
 		// Per-row activity log keeps the audit trail intact — it's a
 		// DB write, not the SSE/webhook fan-out the task is avoiding.
+		// A cross-collection move logs action="moved" with from/to
+		// collection slugs — same shape as the single-item move path
+		// (handleMoveItem). This is also what /items-changes reads to
+		// emit moved-out tombstones (BUG-1675), so a generic "updated"
+		// here would silently break cross-visibility move eviction.
 		action := "updated"
-		if req.Op == "archive" {
+		meta := map[string]string{"bulk_op": req.Op}
+		switch {
+		case req.Op == "archive":
 			action = "archived"
+		case req.Op == "move" && req.Collection != "" && req.Collection != item.CollectionSlug:
+			action = "moved"
+			meta["from_collection"] = item.CollectionSlug
+			meta["to_collection"] = req.Collection
 		}
-		s.logActivityWithMeta(workspaceID, item.ID, action,
-			r, auditMeta(map[string]string{"bulk_op": req.Op}))
+		s.logActivityWithMeta(workspaceID, item.ID, action, r, auditMeta(meta))
 
 		resp.Updated = append(resp.Updated, bulkItemOutcome{Ref: itemRefOrSlug(*item), ID: item.ID})
 		affectedIDs = append(affectedIDs, item.ID)

--- a/internal/server/handlers_items_bulk.go
+++ b/internal/server/handlers_items_bulk.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/PerpetualSoftware/pad/internal/events"
@@ -235,6 +236,11 @@ func (s *Server) handleBulkItems(w http.ResponseWriter, r *http.Request) {
 			action = "moved"
 			meta["from_collection"] = item.CollectionSlug
 			meta["to_collection"] = req.Collection
+			// Post-move seq ties a moved-out tombstone to THIS move
+			// event, not any later hidden-collection change (BUG-1675).
+			if updated != nil {
+				meta["seq"] = strconv.FormatInt(updated.Seq, 10)
+			}
 		}
 		s.logActivityWithMeta(workspaceID, item.ID, action, r, auditMeta(meta))
 

--- a/internal/server/handlers_items_bulk.go
+++ b/internal/server/handlers_items_bulk.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"strconv"
 	"strings"
 
 	"github.com/PerpetualSoftware/pad/internal/events"
@@ -236,11 +235,6 @@ func (s *Server) handleBulkItems(w http.ResponseWriter, r *http.Request) {
 			action = "moved"
 			meta["from_collection"] = item.CollectionSlug
 			meta["to_collection"] = req.Collection
-			// Post-move seq ties a moved-out tombstone to THIS move
-			// event, not any later hidden-collection change (BUG-1675).
-			if updated != nil {
-				meta["seq"] = strconv.FormatInt(updated.Seq, 10)
-			}
 		}
 		s.logActivityWithMeta(workspaceID, item.ID, action, r, auditMeta(meta))
 

--- a/internal/server/handlers_items_bulk_test.go
+++ b/internal/server/handlers_items_bulk_test.go
@@ -401,6 +401,25 @@ collect:
 	if !gotScopes["programs"] {
 		t.Error("expected a batch event for target collection 'programs'")
 	}
+
+	// The bulk move must log a "moved" activity with from/to collection
+	// slugs — /items-changes reads this to emit moved-out tombstones
+	// (BUG-1675). A generic "updated" action would silently break it.
+	acts, err := srv.store.ListDocumentActivity(a.ID, models.ActivityListParams{Limit: 20})
+	if err != nil {
+		t.Fatalf("list activity: %v", err)
+	}
+	foundMoved := false
+	for _, act := range acts {
+		if act.Action == "moved" &&
+			strings.Contains(act.Metadata, `"from_collection":"tasks"`) &&
+			strings.Contains(act.Metadata, `"to_collection":"programs"`) {
+			foundMoved = true
+		}
+	}
+	if !foundMoved {
+		t.Errorf("expected a 'moved' activity with from=tasks to=programs; got %+v", acts)
+	}
 }
 
 // TestBulkItems_CollectionMoveValidatesStatusOverride confirms a status

--- a/internal/server/handlers_items_moved_out_test.go
+++ b/internal/server/handlers_items_moved_out_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 
 	"github.com/PerpetualSoftware/pad/internal/models"
@@ -105,7 +106,8 @@ func TestItemsChanges_MovedOutTombstoneForRestrictedMember(t *testing.T) {
 	}
 	if _, err := srv.store.CreateActivity(models.Activity{
 		WorkspaceID: ws.ID, DocumentID: item.ID, Action: "moved",
-		Metadata: `{"from_collection":"visible","to_collection":"hidden"}`,
+		Metadata: `{"from_collection":"visible","to_collection":"hidden","seq":"` +
+			strconv.FormatInt(moved.Seq, 10) + `"}`,
 	}); err != nil {
 		t.Fatalf("log move activity: %v", err)
 	}

--- a/internal/server/handlers_items_moved_out_test.go
+++ b/internal/server/handlers_items_moved_out_test.go
@@ -3,7 +3,6 @@ package server
 import (
 	"net/http"
 	"net/http/httptest"
-	"strconv"
 	"testing"
 
 	"github.com/PerpetualSoftware/pad/internal/models"
@@ -98,18 +97,11 @@ func TestItemsChanges_MovedOutTombstoneForRestrictedMember(t *testing.T) {
 	}
 	baseCursor := baseline.Cursor
 
-	// Move the item into the hidden collection + log the move activity
-	// (mirrors what the move/bulk handlers do).
+	// Move the item into the hidden collection. MoveItem records the
+	// durable item_collection_moves row the tombstone query reads.
 	moved, err := srv.store.MoveItem(item.ID, hidden.ID, `{"status":"open"}`)
 	if err != nil {
 		t.Fatalf("move item: %v", err)
-	}
-	if _, err := srv.store.CreateActivity(models.Activity{
-		WorkspaceID: ws.ID, DocumentID: item.ID, Action: "moved",
-		Metadata: `{"from_collection":"visible","to_collection":"hidden","seq":"` +
-			strconv.FormatInt(moved.Seq, 10) + `"}`,
-	}); err != nil {
-		t.Fatalf("log move activity: %v", err)
 	}
 
 	// Delta since the baseline cursor: the member must get a moved_out

--- a/internal/server/handlers_items_moved_out_test.go
+++ b/internal/server/handlers_items_moved_out_test.go
@@ -1,0 +1,141 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// getAuthedSession issues a GET as a logged-in user via a session
+// cookie (GET needs no CSRF). The UA + IP match CreateSession so the
+// session-binding middleware accepts it.
+func getAuthedSession(t *testing.T, srv *Server, path, token string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest("GET", path, nil)
+	req.Header.Set("User-Agent", testSessionUA)
+	req.AddCookie(&http.Cookie{Name: sessionCookieName(srv.secureCookies), Value: token})
+	req.RemoteAddr = "192.0.2.1:1234"
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	return rr
+}
+
+// TestItemsChanges_MovedOutTombstoneForRestrictedMember is the
+// end-to-end proof for BUG-1675: a member who can see the source
+// collection but not the target receives a moved_out tombstone on
+// /items-changes when an item moves out of their visibility, so their
+// local cache evicts it instead of keeping a now-unauthorized row.
+func TestItemsChanges_MovedOutTombstoneForRestrictedMember(t *testing.T) {
+	srv := testServer(t)
+
+	admin, err := srv.store.CreateUser(models.UserCreate{
+		Email: "admin@example.com", Name: "Admin", Password: "correct-horse-battery-staple", Role: "admin",
+	})
+	if err != nil {
+		t.Fatalf("create admin: %v", err)
+	}
+	ws, err := srv.store.CreateWorkspace(models.WorkspaceCreate{Name: "MovedOutWS", OwnerID: admin.ID})
+	if err != nil {
+		t.Fatalf("create workspace: %v", err)
+	}
+	if err := srv.store.AddWorkspaceMember(ws.ID, admin.ID, "owner"); err != nil {
+		t.Fatalf("add admin member: %v", err)
+	}
+	schema := `{"fields":[{"key":"status","type":"select","options":["open","done"],"default":"open"}]}`
+	visible, err := srv.store.CreateCollection(ws.ID, models.CollectionCreate{Name: "Visible", Slug: "visible", Prefix: "VIS", Schema: schema})
+	if err != nil {
+		t.Fatalf("create visible: %v", err)
+	}
+	hidden, err := srv.store.CreateCollection(ws.ID, models.CollectionCreate{Name: "Hidden", Slug: "hidden", Prefix: "HID", Schema: schema})
+	if err != nil {
+		t.Fatalf("create hidden: %v", err)
+	}
+
+	// Restricted member: editor, but collection access limited to "visible".
+	member, err := srv.store.CreateUser(models.UserCreate{
+		Email: "member@example.com", Name: "Member", Password: "correct-horse-battery-staple", Role: "member",
+	})
+	if err != nil {
+		t.Fatalf("create member: %v", err)
+	}
+	if err := srv.store.AddWorkspaceMember(ws.ID, member.ID, "editor"); err != nil {
+		t.Fatalf("add member: %v", err)
+	}
+	if err := srv.store.SetMemberCollectionAccess(ws.ID, member.ID, "specific", []string{visible.ID}); err != nil {
+		t.Fatalf("set member collection access: %v", err)
+	}
+	token, err := srv.store.CreateSession(member.ID, "test", "192.0.2.1", testSessionUA, webSessionTTL)
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	item, err := srv.store.CreateItem(ws.ID, visible.ID, models.ItemCreate{Title: "Will move out", Fields: `{"status":"open"}`})
+	if err != nil {
+		t.Fatalf("create item: %v", err)
+	}
+
+	// Baseline delta: the member sees the item in the visible collection.
+	rr := getAuthedSession(t, srv, "/api/v1/workspaces/"+ws.Slug+"/items-changes?since=0", token)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("baseline items-changes: %d: %s", rr.Code, rr.Body.String())
+	}
+	var baseline itemsChangesResponse
+	parseJSON(t, rr, &baseline)
+	foundBaseline := false
+	for _, c := range baseline.Changes {
+		if c.ID == item.ID {
+			foundBaseline = true
+			if c.MovedOut {
+				t.Error("baseline row should not be moved_out")
+			}
+		}
+	}
+	if !foundBaseline {
+		t.Fatalf("member should see the item in their visible collection at baseline")
+	}
+	baseCursor := baseline.Cursor
+
+	// Move the item into the hidden collection + log the move activity
+	// (mirrors what the move/bulk handlers do).
+	moved, err := srv.store.MoveItem(item.ID, hidden.ID, `{"status":"open"}`)
+	if err != nil {
+		t.Fatalf("move item: %v", err)
+	}
+	if _, err := srv.store.CreateActivity(models.Activity{
+		WorkspaceID: ws.ID, DocumentID: item.ID, Action: "moved",
+		Metadata: `{"from_collection":"visible","to_collection":"hidden"}`,
+	}); err != nil {
+		t.Fatalf("log move activity: %v", err)
+	}
+
+	// Delta since the baseline cursor: the member must get a moved_out
+	// tombstone (id + seq only, no destination data).
+	rr = getAuthedSession(t, srv, "/api/v1/workspaces/"+ws.Slug+"/items-changes?since="+baseCursor, token)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("delta items-changes: %d: %s", rr.Code, rr.Body.String())
+	}
+	var delta itemsChangesResponse
+	parseJSON(t, rr, &delta)
+
+	var tombstone *itemChangeRow
+	for i := range delta.Changes {
+		if delta.Changes[i].ID == item.ID {
+			tombstone = &delta.Changes[i]
+		}
+	}
+	if tombstone == nil {
+		t.Fatalf("expected a moved_out tombstone for the item; changes=%+v", delta.Changes)
+	}
+	if !tombstone.MovedOut {
+		t.Errorf("row should be marked moved_out")
+	}
+	if tombstone.Seq != moved.Seq {
+		t.Errorf("tombstone seq = %d, want %d (post-move)", tombstone.Seq, moved.Seq)
+	}
+	// No destination data leaked.
+	if tombstone.Title != "" || tombstone.CollectionSlug != "" {
+		t.Errorf("moved_out row must not carry title/collection (leak): title=%q coll=%q", tombstone.Title, tombstone.CollectionSlug)
+	}
+}

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -1252,26 +1252,25 @@ func (s *Store) ListMovedOutSince(
 	}
 	defer rows.Close()
 
-	seen := make(map[string]bool)
-	var out []MovedOutRow
+	// Collect the earliest in-window visibility-losing move per item,
+	// keyed by the MOVE's seq (not the item's current seq). We must not
+	// page by current seq + break early: an item with a low move seq but
+	// a high current seq (later hidden-collection edits) could be dropped
+	// past the limit while the cursor advances beyond its move seq,
+	// leaving it stranded in the client cache forever. So gather every
+	// eligible row, then sort by move seq and apply the limit at a move-
+	// seq boundary — anything past it re-fetches on the next poll
+	// (BUG-1675, Codex round 2).
+	byItem := make(map[string]int64)
 	for rows.Next() {
 		var id, metadata string
 		var curSeq int64
 		if err := rows.Scan(&id, &curSeq, &metadata); err != nil {
 			return nil, err
 		}
-		if seen[id] {
-			continue
-		}
 		// An item may have several `moved` rows. Include it on the move
-		// that actually crossed OUT of the caller's visibility: a move
-		// whose from_collection is visible AND whose recorded seq is in
-		// this delta window (> since). Keying on the move's seq — not
-		// the item's current seq — is what stops a re-fire on every
-		// later hidden-collection change (which would leak that an
-		// invisible item keeps mutating) and lets the cursor settle
-		// past the move so the tombstone is delivered exactly once
-		// (BUG-1675, Codex round 1).
+		// that crossed OUT of the caller's visibility: from_collection
+		// visible AND a recorded seq in this delta window (> since).
 		var meta struct {
 			FromCollection string `json:"from_collection"`
 			Seq            string `json:"seq"`
@@ -1283,20 +1282,31 @@ func (s *Store) ListMovedOutSince(
 			continue
 		}
 		// Moves logged before the seq was stamped (pre-BUG-1675) can't
-		// be tied to the window — skip them (they evict on the next
-		// full rebootstrap, the prior behavior) rather than risk the
-		// re-fire leak.
+		// be tied to the window — skip them (they evict on the next full
+		// rebootstrap, the prior behavior) rather than risk the re-fire.
 		moveSeq, perr := strconv.ParseInt(meta.Seq, 10, 64)
 		if perr != nil || moveSeq <= since {
 			continue
 		}
-		seen[id] = true
-		out = append(out, MovedOutRow{ID: id, Seq: moveSeq})
-		if len(out) >= limit {
-			break
+		// Keep the EARLIEST qualifying move per item so the cursor can't
+		// skip a still-unseen visibility loss.
+		if prev, ok := byItem[id]; !ok || moveSeq < prev {
+			byItem[id] = moveSeq
 		}
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	out := make([]MovedOutRow, 0, len(byItem))
+	for id, seq := range byItem {
+		out = append(out, MovedOutRow{ID: id, Seq: seq})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Seq < out[j].Seq })
+	if len(out) > limit {
+		out = out[:limit]
+	}
+	return out, nil
 }
 
 // MaxItemSeq returns the largest items.seq across the workspace, or 0

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -1167,6 +1167,121 @@ func scanItemsChanges(rows *sql.Rows) ([]models.Item, error) {
 	return items, rows.Err()
 }
 
+// MovedOutRow is a minimal "this item left your view" signal returned
+// by ListMovedOutSince — id + seq only, no title/fields/target so a
+// caller learns an item disappeared from a collection they can see
+// without leaking any data from the (invisible) destination.
+type MovedOutRow struct {
+	ID  string
+	Seq int64
+}
+
+// ListMovedOutSince finds items that the main /items-changes delta drops
+// because they moved OUT of the caller's visible scope: their current
+// collection is one the caller can't see (so the seq>since row is
+// filtered out), yet a `moved` activity shows they came FROM a
+// collection the caller CAN see. The caller has read access to that
+// source collection, so signalling "id X left your view" is within
+// their scope — and the returned row carries only id+seq, never any
+// destination data (BUG-1675).
+//
+// collLevelVisibleIDs / visibleSlugs describe the collections the caller
+// browses at the collection level (the same set used to filter the main
+// delta). grantedItemIDs are excluded: an item the caller holds a direct
+// grant on stays visible across a move (the grant transcends collection),
+// so the main delta still delivers it and it must NOT be tombstoned.
+//
+// Returns nil for unrestricted callers (empty visible scope) — full
+// members never lose visibility on a move, so this path is moot for them.
+func (s *Store) ListMovedOutSince(
+	workspaceID string,
+	since int64,
+	limit int,
+	collLevelVisibleIDs []string,
+	visibleSlugs map[string]bool,
+	grantedItemIDs []string,
+) ([]MovedOutRow, error) {
+	// No collection-level visibility → no source collection an item
+	// could have "left" from this caller's perspective.
+	if len(collLevelVisibleIDs) == 0 || len(visibleSlugs) == 0 {
+		return nil, nil
+	}
+	if limit <= 0 {
+		limit = DefaultItemChangesLimit
+	}
+	if limit > MaxItemChangesLimit {
+		limit = MaxItemChangesLimit
+	}
+
+	// Candidate set: changed items whose CURRENT collection is not one
+	// the caller browses, joined to their `moved` activity rows. The
+	// join keeps this selective (only items that ever moved). We read
+	// the activity metadata and decide the from-collection match in Go
+	// to stay dialect-neutral (no json_extract). Ordered by seq so the
+	// caller can page deterministically.
+	query := `
+		SELECT i.id, i.seq, a.metadata
+		FROM items i
+		JOIN activities a ON a.document_id = i.id AND a.action = 'moved'
+		WHERE i.workspace_id = ? AND i.seq > ?
+	`
+	args := []interface{}{workspaceID, since}
+
+	placeholders := make([]string, len(collLevelVisibleIDs))
+	for i, id := range collLevelVisibleIDs {
+		placeholders[i] = "?"
+		args = append(args, id)
+	}
+	query += " AND i.collection_id NOT IN (" + strings.Join(placeholders, ",") + ")"
+
+	if len(grantedItemIDs) > 0 {
+		gph := make([]string, len(grantedItemIDs))
+		for i, id := range grantedItemIDs {
+			gph[i] = "?"
+			args = append(args, id)
+		}
+		query += " AND i.id NOT IN (" + strings.Join(gph, ",") + ")"
+	}
+
+	query += " ORDER BY i.seq ASC"
+
+	rows, err := s.db.Query(s.q(query), args...)
+	if err != nil {
+		return nil, fmt.Errorf("list moved-out: %w", err)
+	}
+	defer rows.Close()
+
+	seen := make(map[string]bool)
+	var out []MovedOutRow
+	for rows.Next() {
+		var id, metadata string
+		var seq int64
+		if err := rows.Scan(&id, &seq, &metadata); err != nil {
+			return nil, err
+		}
+		if seen[id] {
+			continue
+		}
+		// An item may have several `moved` rows; include it if ANY move
+		// originated from a collection the caller can see.
+		var meta struct {
+			FromCollection string `json:"from_collection"`
+		}
+		if err := json.Unmarshal([]byte(metadata), &meta); err != nil {
+			continue
+		}
+		if meta.FromCollection == "" || !visibleSlugs[meta.FromCollection] {
+			continue
+		}
+		seen[id] = true
+		out = append(out, MovedOutRow{ID: id, Seq: seq})
+		if len(out) >= limit {
+			break
+		}
+	}
+	return out, rows.Err()
+}
+
 // MaxItemSeq returns the largest items.seq across the workspace, or 0
 // if the workspace has no items. This is the cursor floor for the
 // local-first read model (PLAN-1343 / TASK-1353): /items-index hands

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -1255,17 +1256,25 @@ func (s *Store) ListMovedOutSince(
 	var out []MovedOutRow
 	for rows.Next() {
 		var id, metadata string
-		var seq int64
-		if err := rows.Scan(&id, &seq, &metadata); err != nil {
+		var curSeq int64
+		if err := rows.Scan(&id, &curSeq, &metadata); err != nil {
 			return nil, err
 		}
 		if seen[id] {
 			continue
 		}
-		// An item may have several `moved` rows; include it if ANY move
-		// originated from a collection the caller can see.
+		// An item may have several `moved` rows. Include it on the move
+		// that actually crossed OUT of the caller's visibility: a move
+		// whose from_collection is visible AND whose recorded seq is in
+		// this delta window (> since). Keying on the move's seq — not
+		// the item's current seq — is what stops a re-fire on every
+		// later hidden-collection change (which would leak that an
+		// invisible item keeps mutating) and lets the cursor settle
+		// past the move so the tombstone is delivered exactly once
+		// (BUG-1675, Codex round 1).
 		var meta struct {
 			FromCollection string `json:"from_collection"`
+			Seq            string `json:"seq"`
 		}
 		if err := json.Unmarshal([]byte(metadata), &meta); err != nil {
 			continue
@@ -1273,8 +1282,16 @@ func (s *Store) ListMovedOutSince(
 		if meta.FromCollection == "" || !visibleSlugs[meta.FromCollection] {
 			continue
 		}
+		// Moves logged before the seq was stamped (pre-BUG-1675) can't
+		// be tied to the window — skip them (they evict on the next
+		// full rebootstrap, the prior behavior) rather than risk the
+		// re-fire leak.
+		moveSeq, perr := strconv.ParseInt(meta.Seq, 10, 64)
+		if perr != nil || moveSeq <= since {
+			continue
+		}
 		seen[id] = true
-		out = append(out, MovedOutRow{ID: id, Seq: seq})
+		out = append(out, MovedOutRow{ID: id, Seq: moveSeq})
 		if len(out) >= limit {
 			break
 		}

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"regexp"
 	"sort"
-	"strconv"
 	"strings"
 	"time"
 
@@ -1178,19 +1177,27 @@ type MovedOutRow struct {
 }
 
 // ListMovedOutSince finds items that the main /items-changes delta drops
-// because they moved OUT of the caller's visible scope: their current
+// because they moved OUT of the caller's visible scope: their CURRENT
 // collection is one the caller can't see (so the seq>since row is
-// filtered out), yet a `moved` activity shows they came FROM a
-// collection the caller CAN see. The caller has read access to that
-// source collection, so signalling "id X left your view" is within
-// their scope — and the returned row carries only id+seq, never any
-// destination data (BUG-1675).
+// filtered out), yet item_collection_moves records that they left a
+// collection the caller CAN see at a seq in this delta window. The
+// caller has read access to that source collection, so signalling "id X
+// left your view" is within their scope — and the returned row carries
+// only id+seq, never any destination data (BUG-1675).
 //
-// collLevelVisibleIDs / visibleSlugs describe the collections the caller
-// browses at the collection level (the same set used to filter the main
-// delta). grantedItemIDs are excluded: an item the caller holds a direct
-// grant on stays visible across a move (the grant transcends collection),
-// so the main delta still delivers it and it must NOT be tombstoned.
+// Keyed on the MOVE's seq (item_collection_moves.seq), which is written
+// in the SAME transaction as the move and never changes on later edits —
+// so the tombstone fires once, pages deterministically, and can't be
+// raced or lost by the best-effort activity log (Codex rounds 1–3). The
+// per-move rows also handle multi-hop moves: only a move whose
+// from-collection is visible qualifies, and MIN(seq) picks the earliest
+// such visibility loss so the cursor can't skip it.
+//
+// collLevelVisibleIDs is the set of collections the caller browses at the
+// collection level (same set used to filter the main delta).
+// grantedItemIDs are excluded: an item the caller holds a direct grant on
+// stays visible across a move (the grant transcends collection), so the
+// main delta still delivers it and it must NOT be tombstoned.
 //
 // Returns nil for unrestricted callers (empty visible scope) — full
 // members never lose visibility on a move, so this path is moot for them.
@@ -1199,12 +1206,9 @@ func (s *Store) ListMovedOutSince(
 	since int64,
 	limit int,
 	collLevelVisibleIDs []string,
-	visibleSlugs map[string]bool,
 	grantedItemIDs []string,
 ) ([]MovedOutRow, error) {
-	// No collection-level visibility → no source collection an item
-	// could have "left" from this caller's perspective.
-	if len(collLevelVisibleIDs) == 0 || len(visibleSlugs) == 0 {
+	if len(collLevelVisibleIDs) == 0 {
 		return nil, nil
 	}
 	if limit <= 0 {
@@ -1214,26 +1218,31 @@ func (s *Store) ListMovedOutSince(
 		limit = MaxItemChangesLimit
 	}
 
-	// Candidate set: changed items whose CURRENT collection is not one
-	// the caller browses, joined to their `moved` activity rows. The
-	// join keeps this selective (only items that ever moved). We read
-	// the activity metadata and decide the from-collection match in Go
-	// to stay dialect-neutral (no json_extract). Ordered by seq so the
-	// caller can page deterministically.
+	// Earliest in-window move OUT of a visible source collection, per
+	// item that is currently NOT visible to the caller. Fully SQL +
+	// indexed — no JSON parsing, no Go-side filtering.
 	query := `
-		SELECT i.id, i.seq, a.metadata
-		FROM items i
-		JOIN activities a ON a.document_id = i.id AND a.action = 'moved'
-		WHERE i.workspace_id = ? AND i.seq > ?
+		SELECT m.item_id, MIN(m.seq) AS move_seq
+		FROM item_collection_moves m
+		JOIN items i ON i.id = m.item_id
+		WHERE m.workspace_id = ? AND m.seq > ?
 	`
 	args := []interface{}{workspaceID, since}
 
-	placeholders := make([]string, len(collLevelVisibleIDs))
+	vis := make([]string, len(collLevelVisibleIDs))
 	for i, id := range collLevelVisibleIDs {
-		placeholders[i] = "?"
+		vis[i] = "?"
 		args = append(args, id)
 	}
-	query += " AND i.collection_id NOT IN (" + strings.Join(placeholders, ",") + ")"
+	// Left a collection the caller CAN see...
+	query += " AND m.from_collection_id IN (" + strings.Join(vis, ",") + ")"
+	// ...and now lives in one they CAN'T.
+	vis2 := make([]string, len(collLevelVisibleIDs))
+	for i, id := range collLevelVisibleIDs {
+		vis2[i] = "?"
+		args = append(args, id)
+	}
+	query += " AND i.collection_id NOT IN (" + strings.Join(vis2, ",") + ")"
 
 	if len(grantedItemIDs) > 0 {
 		gph := make([]string, len(grantedItemIDs))
@@ -1244,7 +1253,8 @@ func (s *Store) ListMovedOutSince(
 		query += " AND i.id NOT IN (" + strings.Join(gph, ",") + ")"
 	}
 
-	query += " ORDER BY i.seq ASC"
+	query += " GROUP BY m.item_id ORDER BY move_seq ASC LIMIT ?"
+	args = append(args, limit)
 
 	rows, err := s.db.Query(s.q(query), args...)
 	if err != nil {
@@ -1252,61 +1262,15 @@ func (s *Store) ListMovedOutSince(
 	}
 	defer rows.Close()
 
-	// Collect the earliest in-window visibility-losing move per item,
-	// keyed by the MOVE's seq (not the item's current seq). We must not
-	// page by current seq + break early: an item with a low move seq but
-	// a high current seq (later hidden-collection edits) could be dropped
-	// past the limit while the cursor advances beyond its move seq,
-	// leaving it stranded in the client cache forever. So gather every
-	// eligible row, then sort by move seq and apply the limit at a move-
-	// seq boundary — anything past it re-fetches on the next poll
-	// (BUG-1675, Codex round 2).
-	byItem := make(map[string]int64)
+	var out []MovedOutRow
 	for rows.Next() {
-		var id, metadata string
-		var curSeq int64
-		if err := rows.Scan(&id, &curSeq, &metadata); err != nil {
+		var r MovedOutRow
+		if err := rows.Scan(&r.ID, &r.Seq); err != nil {
 			return nil, err
 		}
-		// An item may have several `moved` rows. Include it on the move
-		// that crossed OUT of the caller's visibility: from_collection
-		// visible AND a recorded seq in this delta window (> since).
-		var meta struct {
-			FromCollection string `json:"from_collection"`
-			Seq            string `json:"seq"`
-		}
-		if err := json.Unmarshal([]byte(metadata), &meta); err != nil {
-			continue
-		}
-		if meta.FromCollection == "" || !visibleSlugs[meta.FromCollection] {
-			continue
-		}
-		// Moves logged before the seq was stamped (pre-BUG-1675) can't
-		// be tied to the window — skip them (they evict on the next full
-		// rebootstrap, the prior behavior) rather than risk the re-fire.
-		moveSeq, perr := strconv.ParseInt(meta.Seq, 10, 64)
-		if perr != nil || moveSeq <= since {
-			continue
-		}
-		// Keep the EARLIEST qualifying move per item so the cursor can't
-		// skip a still-unseen visibility loss.
-		if prev, ok := byItem[id]; !ok || moveSeq < prev {
-			byItem[id] = moveSeq
-		}
+		out = append(out, r)
 	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-
-	out := make([]MovedOutRow, 0, len(byItem))
-	for id, seq := range byItem {
-		out = append(out, MovedOutRow{ID: id, Seq: seq})
-	}
-	sort.Slice(out, func(i, j int) bool { return out[i].Seq < out[j].Seq })
-	if len(out) > limit {
-		out = out[:limit]
-	}
-	return out, nil
+	return out, rows.Err()
 }
 
 // MaxItemSeq returns the largest items.seq across the workspace, or 0
@@ -3281,6 +3245,26 @@ func (s *Store) MoveItemWithPreCheck(
 			VALUES (?, ?, ?, ?, ?, ?, ?, ?, `+nextTransitionSeqSubquery+`)
 		`), newID(), itemID, existing.WorkspaceID, targetCollectionID, moveDoneKey, oldStatus, newStatus, moveTS); err != nil {
 			return nil, fmt.Errorf("record status transition on move: %w", err)
+		}
+	}
+
+	// Durable cross-collection move record (BUG-1675), written in the
+	// SAME tx as the move so /items-changes' moved-out tombstone can't
+	// depend on the best-effort post-commit activity row. Skip same-
+	// collection no-ops (move callers reject those upstream, but guard
+	// anyway). The seq is the value the UPDATE just assigned — read it
+	// back under the still-held lock so the tombstone seq matches what
+	// /items-changes sees for the item.
+	if targetCollectionID != existing.CollectionID {
+		var moveSeq int64
+		if err = tx.QueryRow(s.q(`SELECT seq FROM items WHERE id = ?`), itemID).Scan(&moveSeq); err != nil {
+			return nil, fmt.Errorf("read post-move seq: %w", err)
+		}
+		if _, err = tx.Exec(s.q(`
+			INSERT INTO item_collection_moves (id, workspace_id, item_id, from_collection_id, to_collection_id, seq, created_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?)
+		`), newID(), existing.WorkspaceID, itemID, existing.CollectionID, targetCollectionID, moveSeq, moveTS); err != nil {
+			return nil, fmt.Errorf("record collection move: %w", err)
 		}
 	}
 

--- a/internal/store/migrations/066_item_collection_moves.sql
+++ b/internal/store/migrations/066_item_collection_moves.sql
@@ -1,0 +1,34 @@
+-- Migration 066: durable cross-collection move log (BUG-1675).
+--
+-- /items-changes must emit a "moved-out" tombstone when an item moves from a
+-- collection a restricted member CAN see into one they can't, otherwise the
+-- now-unauthorized row lingers in the client's local cache until a full
+-- rebootstrap. Detecting that needs the item's PRIOR collection, which the
+-- items table doesn't retain.
+--
+-- The activities table records moves, but it is written AFTER the move commits
+-- and best-effort (errors discarded), so a delta poll racing the audit write —
+-- or a failed write — could advance the client cursor past the move seq and
+-- strand the item forever. This table captures every collection move as a
+-- structured row written in the SAME transaction as the move (Store.
+-- MoveItemWithPreCheck), carrying the workspace-scoped seq the move assigned —
+-- so the moved-out query is durable, atomic, and fully indexable.
+CREATE TABLE IF NOT EXISTS item_collection_moves (
+    id                 TEXT   PRIMARY KEY,
+    workspace_id       TEXT   NOT NULL REFERENCES workspaces(id),
+    item_id            TEXT   NOT NULL REFERENCES items(id) ON DELETE CASCADE,
+    from_collection_id TEXT   NOT NULL,
+    to_collection_id   TEXT   NOT NULL,
+    seq                BIGINT NOT NULL,
+    created_at         TEXT   NOT NULL
+);
+
+-- Primary access path for the moved-out query: walk a workspace's moves with
+-- seq > cursor.
+CREATE INDEX IF NOT EXISTS idx_item_collection_moves_ws_seq
+    ON item_collection_moves(workspace_id, seq);
+
+-- Per-item join target (items i ON i.id = m.item_id) for the current-collection
+-- visibility check.
+CREATE INDEX IF NOT EXISTS idx_item_collection_moves_item
+    ON item_collection_moves(item_id);

--- a/internal/store/moved_out_test.go
+++ b/internal/store/moved_out_test.go
@@ -1,7 +1,6 @@
 package store
 
 import (
-	"strconv"
 	"testing"
 
 	"github.com/PerpetualSoftware/pad/internal/models"
@@ -9,55 +8,39 @@ import (
 
 // TestListMovedOutSince covers BUG-1675: an item that moves from a
 // collection the caller can see into one they can't must surface as a
-// moved-out tombstone so the caller's local cache evicts it.
+// moved-out tombstone so the caller's local cache evicts it. The move
+// is recorded durably in item_collection_moves by MoveItem itself.
 func TestListMovedOutSince(t *testing.T) {
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "MovedOutTest")
+	schema := `{"fields":[{"key":"status","type":"select","options":["open","done"],"default":"open"}]}`
 
-	visible, err := s.CreateCollection(ws.ID, models.CollectionCreate{
-		Name:   "Visible",
-		Schema: `{"fields":[{"key":"status","type":"select","options":["open","done"],"default":"open"}]}`,
-	})
+	visible, err := s.CreateCollection(ws.ID, models.CollectionCreate{Name: "Visible", Schema: schema})
 	if err != nil {
 		t.Fatalf("create visible collection: %v", err)
 	}
-	hidden, err := s.CreateCollection(ws.ID, models.CollectionCreate{
-		Name:   "Hidden",
-		Schema: `{"fields":[{"key":"status","type":"select","options":["open","done"],"default":"open"}]}`,
-	})
+	hidden, err := s.CreateCollection(ws.ID, models.CollectionCreate{Name: "Hidden", Schema: schema})
 	if err != nil {
 		t.Fatalf("create hidden collection: %v", err)
 	}
+	other, err := s.CreateCollection(ws.ID, models.CollectionCreate{Name: "Other", Schema: schema})
+	if err != nil {
+		t.Fatalf("create other collection: %v", err)
+	}
 
-	item, err := s.CreateItem(ws.ID, visible.ID, models.ItemCreate{
-		Title:  "Item that will move out",
-		Fields: `{"status":"open"}`,
-	})
+	item, err := s.CreateItem(ws.ID, visible.ID, models.ItemCreate{Title: "Will move out", Fields: `{"status":"open"}`})
 	if err != nil {
 		t.Fatalf("create item: %v", err)
 	}
 
-	// Move it into the hidden collection and log the move activity the
-	// way the HTTP handlers do (the store move itself doesn't log).
 	moved, err := s.MoveItem(item.ID, hidden.ID, `{"status":"open"}`)
 	if err != nil {
 		t.Fatalf("move item: %v", err)
 	}
-	if _, err := s.CreateActivity(models.Activity{
-		WorkspaceID: ws.ID,
-		DocumentID:  item.ID,
-		Action:      "moved",
-		Metadata: `{"from_collection":"` + visible.Slug + `","to_collection":"` + hidden.Slug +
-			`","seq":"` + strconv.FormatInt(moved.Seq, 10) + `"}`,
-	}); err != nil {
-		t.Fatalf("log move activity: %v", err)
-	}
-
-	visibleSlugs := map[string]bool{visible.Slug: true}
 
 	// Caller who can see the source collection but not the target:
 	// the moved item must surface as a moved-out tombstone.
-	rows, err := s.ListMovedOutSince(ws.ID, 0, 0, []string{visible.ID}, visibleSlugs, nil)
+	rows, err := s.ListMovedOutSince(ws.ID, 0, 0, []string{visible.ID}, nil)
 	if err != nil {
 		t.Fatalf("ListMovedOutSince: %v", err)
 	}
@@ -72,56 +55,55 @@ func TestListMovedOutSince(t *testing.T) {
 	}
 
 	// since past the move's seq → no longer in the window.
-	rows, _ = s.ListMovedOutSince(ws.ID, moved.Seq, 0, []string{visible.ID}, visibleSlugs, nil)
+	rows, _ = s.ListMovedOutSince(ws.ID, moved.Seq, 0, []string{visible.ID}, nil)
 	if len(rows) != 0 {
 		t.Errorf("expected 0 rows when since >= move seq, got %d", len(rows))
 	}
 
-	// Re-fire regression (BUG-1675, Codex round 1): a later change while
-	// the item sits in the hidden collection bumps its current seq, but
-	// the tombstone is keyed on the MOVE's seq — so a caller who already
-	// consumed the tombstone (since = move seq) must NOT get it again.
+	// Re-fire regression (Codex round 1): a later change while the item
+	// sits in the hidden collection bumps its current seq, but the
+	// tombstone is keyed on the MOVE's seq — so a caller who already
+	// consumed it (since = move seq) must NOT get it again.
 	if _, err := s.UpdateItem(item.ID, models.ItemUpdate{Fields: strPtr(`{"status":"done"}`)}); err != nil {
 		t.Fatalf("post-move update: %v", err)
 	}
-	rows, _ = s.ListMovedOutSince(ws.ID, moved.Seq, 0, []string{visible.ID}, visibleSlugs, nil)
+	rows, _ = s.ListMovedOutSince(ws.ID, moved.Seq, 0, []string{visible.ID}, nil)
 	if len(rows) != 0 {
 		t.Errorf("tombstone must not re-fire on a later hidden-collection change; got %d rows", len(rows))
 	}
 
 	// Caller who can see the TARGET collection: the item is visible to
 	// them via the main delta, so it must NOT be a moved-out tombstone.
-	rows, _ = s.ListMovedOutSince(ws.ID, 0, 0, []string{hidden.ID}, map[string]bool{hidden.Slug: true}, nil)
+	rows, _ = s.ListMovedOutSince(ws.ID, 0, 0, []string{hidden.ID}, nil)
 	if len(rows) != 0 {
 		t.Errorf("caller who sees target should get 0 moved-out rows, got %d", len(rows))
 	}
 
 	// Caller holding a direct grant on the item: excluded (grant
 	// transcends collection; the main delta still delivers it).
-	rows, _ = s.ListMovedOutSince(ws.ID, 0, 0, []string{visible.ID}, visibleSlugs, []string{item.ID})
+	rows, _ = s.ListMovedOutSince(ws.ID, 0, 0, []string{visible.ID}, []string{item.ID})
 	if len(rows) != 0 {
 		t.Errorf("granted item must be excluded from moved-out, got %d rows", len(rows))
 	}
 
-	// Caller whose visible source set doesn't include the from-collection
-	// (e.g. they see some other collection): no match.
-	rows, _ = s.ListMovedOutSince(ws.ID, 0, 0, []string{hidden.ID}, map[string]bool{"something-else": true}, nil)
+	// Caller who sees a DIFFERENT collection (not the from-collection):
+	// the move didn't leave a collection they can see → no match.
+	rows, _ = s.ListMovedOutSince(ws.ID, 0, 0, []string{other.ID}, nil)
 	if len(rows) != 0 {
 		t.Errorf("from-collection not visible should yield 0 rows, got %d", len(rows))
 	}
 
 	// Empty visible scope → nil (unrestricted/no-source callers skip).
-	rows, _ = s.ListMovedOutSince(ws.ID, 0, 0, nil, nil, nil)
+	rows, _ = s.ListMovedOutSince(ws.ID, 0, 0, nil, nil)
 	if rows != nil {
 		t.Errorf("empty scope should return nil, got %+v", rows)
 	}
 }
 
-// TestListMovedOutSince_PaginatesByMoveSeq is the BUG-1675 round-2
-// regression: pagination must order/limit by the MOVE seq, not the
-// item's current seq. An item that moved out early but then churned in
-// the hidden collection (high current seq) must not be dropped past the
-// limit while the cursor advances beyond its move seq.
+// TestListMovedOutSince_PaginatesByMoveSeq is the round-2 regression:
+// pagination must order/limit by the MOVE seq, not the item's current
+// seq. An item that moved out early but then churned in the hidden
+// collection (high current seq) must not be dropped past the limit.
 func TestListMovedOutSince_PaginatesByMoveSeq(t *testing.T) {
 	s := testStore(t)
 	ws := createTestWorkspace(t, s, "MovedOutPaging")
@@ -129,26 +111,13 @@ func TestListMovedOutSince_PaginatesByMoveSeq(t *testing.T) {
 	visible, _ := s.CreateCollection(ws.ID, models.CollectionCreate{Name: "Visible", Schema: schema})
 	hidden, _ := s.CreateCollection(ws.ID, models.CollectionCreate{Name: "Hidden", Schema: schema})
 
-	logMove := func(id string, seq int64) {
-		if _, err := s.CreateActivity(models.Activity{
-			WorkspaceID: ws.ID, DocumentID: id, Action: "moved",
-			Metadata: `{"from_collection":"` + visible.Slug + `","to_collection":"` + hidden.Slug +
-				`","seq":"` + strconv.FormatInt(seq, 10) + `"}`,
-		}); err != nil {
-			t.Fatalf("log move: %v", err)
-		}
-	}
-
 	// Three items move out in order A, B, C (ascending move seq).
 	a, _ := s.CreateItem(ws.ID, visible.ID, models.ItemCreate{Title: "A", Fields: `{"status":"open"}`})
 	b, _ := s.CreateItem(ws.ID, visible.ID, models.ItemCreate{Title: "B", Fields: `{"status":"open"}`})
 	c, _ := s.CreateItem(ws.ID, visible.ID, models.ItemCreate{Title: "C", Fields: `{"status":"open"}`})
 	movedA, _ := s.MoveItem(a.ID, hidden.ID, `{"status":"open"}`)
-	logMove(a.ID, movedA.Seq)
 	movedB, _ := s.MoveItem(b.ID, hidden.ID, `{"status":"open"}`)
-	logMove(b.ID, movedB.Seq)
 	movedC, _ := s.MoveItem(c.ID, hidden.ID, `{"status":"open"}`)
-	logMove(c.ID, movedC.Seq)
 
 	// A then churns in the hidden collection — its CURRENT seq leaps past
 	// B and C, but its MOVE seq is still the smallest.
@@ -157,11 +126,10 @@ func TestListMovedOutSince_PaginatesByMoveSeq(t *testing.T) {
 	}
 
 	vis := []string{visible.ID}
-	slugs := map[string]bool{visible.Slug: true}
 
 	// limit=2: must return the two SMALLEST move seqs (A, B) — A must
 	// not be starved by its high current seq.
-	page1, _ := s.ListMovedOutSince(ws.ID, 0, 2, vis, slugs, nil)
+	page1, _ := s.ListMovedOutSince(ws.ID, 0, 2, vis, nil)
 	if len(page1) != 2 {
 		t.Fatalf("page1: expected 2 rows, got %d (%+v)", len(page1), page1)
 	}
@@ -173,8 +141,11 @@ func TestListMovedOutSince_PaginatesByMoveSeq(t *testing.T) {
 	}
 
 	// Next page from the last cursor → C, with no gap.
-	page2, _ := s.ListMovedOutSince(ws.ID, page1[1].Seq, 2, vis, slugs, nil)
+	page2, _ := s.ListMovedOutSince(ws.ID, page1[1].Seq, 2, vis, nil)
 	if len(page2) != 1 || page2[0].ID != c.ID {
 		t.Fatalf("page2: expected [C], got %+v", page2)
+	}
+	if page2[0].Seq != movedC.Seq {
+		t.Errorf("page2[0] seq = %d, want %d", page2[0].Seq, movedC.Seq)
 	}
 }

--- a/internal/store/moved_out_test.go
+++ b/internal/store/moved_out_test.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/PerpetualSoftware/pad/internal/models"
@@ -46,7 +47,8 @@ func TestListMovedOutSince(t *testing.T) {
 		WorkspaceID: ws.ID,
 		DocumentID:  item.ID,
 		Action:      "moved",
-		Metadata:    `{"from_collection":"` + visible.Slug + `","to_collection":"` + hidden.Slug + `"}`,
+		Metadata: `{"from_collection":"` + visible.Slug + `","to_collection":"` + hidden.Slug +
+			`","seq":"` + strconv.FormatInt(moved.Seq, 10) + `"}`,
 	}); err != nil {
 		t.Fatalf("log move activity: %v", err)
 	}
@@ -73,6 +75,18 @@ func TestListMovedOutSince(t *testing.T) {
 	rows, _ = s.ListMovedOutSince(ws.ID, moved.Seq, 0, []string{visible.ID}, visibleSlugs, nil)
 	if len(rows) != 0 {
 		t.Errorf("expected 0 rows when since >= move seq, got %d", len(rows))
+	}
+
+	// Re-fire regression (BUG-1675, Codex round 1): a later change while
+	// the item sits in the hidden collection bumps its current seq, but
+	// the tombstone is keyed on the MOVE's seq — so a caller who already
+	// consumed the tombstone (since = move seq) must NOT get it again.
+	if _, err := s.UpdateItem(item.ID, models.ItemUpdate{Fields: strPtr(`{"status":"done"}`)}); err != nil {
+		t.Fatalf("post-move update: %v", err)
+	}
+	rows, _ = s.ListMovedOutSince(ws.ID, moved.Seq, 0, []string{visible.ID}, visibleSlugs, nil)
+	if len(rows) != 0 {
+		t.Errorf("tombstone must not re-fire on a later hidden-collection change; got %d rows", len(rows))
 	}
 
 	// Caller who can see the TARGET collection: the item is visible to

--- a/internal/store/moved_out_test.go
+++ b/internal/store/moved_out_test.go
@@ -1,0 +1,104 @@
+package store
+
+import (
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// TestListMovedOutSince covers BUG-1675: an item that moves from a
+// collection the caller can see into one they can't must surface as a
+// moved-out tombstone so the caller's local cache evicts it.
+func TestListMovedOutSince(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "MovedOutTest")
+
+	visible, err := s.CreateCollection(ws.ID, models.CollectionCreate{
+		Name:   "Visible",
+		Schema: `{"fields":[{"key":"status","type":"select","options":["open","done"],"default":"open"}]}`,
+	})
+	if err != nil {
+		t.Fatalf("create visible collection: %v", err)
+	}
+	hidden, err := s.CreateCollection(ws.ID, models.CollectionCreate{
+		Name:   "Hidden",
+		Schema: `{"fields":[{"key":"status","type":"select","options":["open","done"],"default":"open"}]}`,
+	})
+	if err != nil {
+		t.Fatalf("create hidden collection: %v", err)
+	}
+
+	item, err := s.CreateItem(ws.ID, visible.ID, models.ItemCreate{
+		Title:  "Item that will move out",
+		Fields: `{"status":"open"}`,
+	})
+	if err != nil {
+		t.Fatalf("create item: %v", err)
+	}
+
+	// Move it into the hidden collection and log the move activity the
+	// way the HTTP handlers do (the store move itself doesn't log).
+	moved, err := s.MoveItem(item.ID, hidden.ID, `{"status":"open"}`)
+	if err != nil {
+		t.Fatalf("move item: %v", err)
+	}
+	if _, err := s.CreateActivity(models.Activity{
+		WorkspaceID: ws.ID,
+		DocumentID:  item.ID,
+		Action:      "moved",
+		Metadata:    `{"from_collection":"` + visible.Slug + `","to_collection":"` + hidden.Slug + `"}`,
+	}); err != nil {
+		t.Fatalf("log move activity: %v", err)
+	}
+
+	visibleSlugs := map[string]bool{visible.Slug: true}
+
+	// Caller who can see the source collection but not the target:
+	// the moved item must surface as a moved-out tombstone.
+	rows, err := s.ListMovedOutSince(ws.ID, 0, 0, []string{visible.ID}, visibleSlugs, nil)
+	if err != nil {
+		t.Fatalf("ListMovedOutSince: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 moved-out row, got %d (%+v)", len(rows), rows)
+	}
+	if rows[0].ID != item.ID {
+		t.Errorf("expected item %s, got %s", item.ID, rows[0].ID)
+	}
+	if rows[0].Seq != moved.Seq {
+		t.Errorf("expected seq %d (post-move), got %d", moved.Seq, rows[0].Seq)
+	}
+
+	// since past the move's seq → no longer in the window.
+	rows, _ = s.ListMovedOutSince(ws.ID, moved.Seq, 0, []string{visible.ID}, visibleSlugs, nil)
+	if len(rows) != 0 {
+		t.Errorf("expected 0 rows when since >= move seq, got %d", len(rows))
+	}
+
+	// Caller who can see the TARGET collection: the item is visible to
+	// them via the main delta, so it must NOT be a moved-out tombstone.
+	rows, _ = s.ListMovedOutSince(ws.ID, 0, 0, []string{hidden.ID}, map[string]bool{hidden.Slug: true}, nil)
+	if len(rows) != 0 {
+		t.Errorf("caller who sees target should get 0 moved-out rows, got %d", len(rows))
+	}
+
+	// Caller holding a direct grant on the item: excluded (grant
+	// transcends collection; the main delta still delivers it).
+	rows, _ = s.ListMovedOutSince(ws.ID, 0, 0, []string{visible.ID}, visibleSlugs, []string{item.ID})
+	if len(rows) != 0 {
+		t.Errorf("granted item must be excluded from moved-out, got %d rows", len(rows))
+	}
+
+	// Caller whose visible source set doesn't include the from-collection
+	// (e.g. they see some other collection): no match.
+	rows, _ = s.ListMovedOutSince(ws.ID, 0, 0, []string{hidden.ID}, map[string]bool{"something-else": true}, nil)
+	if len(rows) != 0 {
+		t.Errorf("from-collection not visible should yield 0 rows, got %d", len(rows))
+	}
+
+	// Empty visible scope → nil (unrestricted/no-source callers skip).
+	rows, _ = s.ListMovedOutSince(ws.ID, 0, 0, nil, nil, nil)
+	if rows != nil {
+		t.Errorf("empty scope should return nil, got %+v", rows)
+	}
+}

--- a/internal/store/moved_out_test.go
+++ b/internal/store/moved_out_test.go
@@ -116,3 +116,65 @@ func TestListMovedOutSince(t *testing.T) {
 		t.Errorf("empty scope should return nil, got %+v", rows)
 	}
 }
+
+// TestListMovedOutSince_PaginatesByMoveSeq is the BUG-1675 round-2
+// regression: pagination must order/limit by the MOVE seq, not the
+// item's current seq. An item that moved out early but then churned in
+// the hidden collection (high current seq) must not be dropped past the
+// limit while the cursor advances beyond its move seq.
+func TestListMovedOutSince_PaginatesByMoveSeq(t *testing.T) {
+	s := testStore(t)
+	ws := createTestWorkspace(t, s, "MovedOutPaging")
+	schema := `{"fields":[{"key":"status","type":"select","options":["open","done"],"default":"open"}]}`
+	visible, _ := s.CreateCollection(ws.ID, models.CollectionCreate{Name: "Visible", Schema: schema})
+	hidden, _ := s.CreateCollection(ws.ID, models.CollectionCreate{Name: "Hidden", Schema: schema})
+
+	logMove := func(id string, seq int64) {
+		if _, err := s.CreateActivity(models.Activity{
+			WorkspaceID: ws.ID, DocumentID: id, Action: "moved",
+			Metadata: `{"from_collection":"` + visible.Slug + `","to_collection":"` + hidden.Slug +
+				`","seq":"` + strconv.FormatInt(seq, 10) + `"}`,
+		}); err != nil {
+			t.Fatalf("log move: %v", err)
+		}
+	}
+
+	// Three items move out in order A, B, C (ascending move seq).
+	a, _ := s.CreateItem(ws.ID, visible.ID, models.ItemCreate{Title: "A", Fields: `{"status":"open"}`})
+	b, _ := s.CreateItem(ws.ID, visible.ID, models.ItemCreate{Title: "B", Fields: `{"status":"open"}`})
+	c, _ := s.CreateItem(ws.ID, visible.ID, models.ItemCreate{Title: "C", Fields: `{"status":"open"}`})
+	movedA, _ := s.MoveItem(a.ID, hidden.ID, `{"status":"open"}`)
+	logMove(a.ID, movedA.Seq)
+	movedB, _ := s.MoveItem(b.ID, hidden.ID, `{"status":"open"}`)
+	logMove(b.ID, movedB.Seq)
+	movedC, _ := s.MoveItem(c.ID, hidden.ID, `{"status":"open"}`)
+	logMove(c.ID, movedC.Seq)
+
+	// A then churns in the hidden collection — its CURRENT seq leaps past
+	// B and C, but its MOVE seq is still the smallest.
+	if _, err := s.UpdateItem(a.ID, models.ItemUpdate{Fields: strPtr(`{"status":"done"}`)}); err != nil {
+		t.Fatalf("churn A: %v", err)
+	}
+
+	vis := []string{visible.ID}
+	slugs := map[string]bool{visible.Slug: true}
+
+	// limit=2: must return the two SMALLEST move seqs (A, B) — A must
+	// not be starved by its high current seq.
+	page1, _ := s.ListMovedOutSince(ws.ID, 0, 2, vis, slugs, nil)
+	if len(page1) != 2 {
+		t.Fatalf("page1: expected 2 rows, got %d (%+v)", len(page1), page1)
+	}
+	if page1[0].ID != a.ID || page1[0].Seq != movedA.Seq {
+		t.Errorf("page1[0] should be A@%d, got %s@%d", movedA.Seq, page1[0].ID, page1[0].Seq)
+	}
+	if page1[1].ID != b.ID || page1[1].Seq != movedB.Seq {
+		t.Errorf("page1[1] should be B@%d, got %s@%d", movedB.Seq, page1[1].ID, page1[1].Seq)
+	}
+
+	// Next page from the last cursor → C, with no gap.
+	page2, _ := s.ListMovedOutSince(ws.ID, page1[1].Seq, 2, vis, slugs, nil)
+	if len(page2) != 1 || page2[0].ID != c.ID {
+		t.Fatalf("page2: expected [C], got %+v", page2)
+	}
+}

--- a/internal/store/pgmigrations/045_item_collection_moves.sql
+++ b/internal/store/pgmigrations/045_item_collection_moves.sql
@@ -1,0 +1,26 @@
+-- Migration 045 (Postgres): durable cross-collection move log (BUG-1675).
+--
+-- Postgres counterpart to migrations/066_item_collection_moves.sql. Same
+-- intent: /items-changes must emit a moved-out tombstone when an item moves
+-- from a collection a restricted member CAN see into one they can't, and that
+-- signal must be durable + atomic with the move rather than derived from the
+-- best-effort post-commit activities row (which a delta poll can race or a
+-- failed write can drop, stranding the unauthorized item in the client cache).
+--
+-- Written in the SAME transaction as the move (Store.MoveItemWithPreCheck),
+-- carrying the workspace-scoped seq the move assigned.
+CREATE TABLE IF NOT EXISTS item_collection_moves (
+    id                 TEXT   PRIMARY KEY,
+    workspace_id       TEXT   NOT NULL REFERENCES workspaces(id),
+    item_id            TEXT   NOT NULL REFERENCES items(id) ON DELETE CASCADE,
+    from_collection_id TEXT   NOT NULL,
+    to_collection_id   TEXT   NOT NULL,
+    seq                BIGINT NOT NULL,
+    created_at         TEXT   NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_item_collection_moves_ws_seq
+    ON item_collection_moves(workspace_id, seq);
+
+CREATE INDEX IF NOT EXISTS idx_item_collection_moves_item
+    ON item_collection_moves(item_id);

--- a/web/src/lib/stores/localIndex.svelte.ts
+++ b/web/src/lib/stores/localIndex.svelte.ts
@@ -537,6 +537,7 @@ export const localIndex = {
 		if (newCursorNum <= startCursorNum) return;
 
 		const toPersist: ItemIndexRow[] = [];
+		const toRemove: string[] = [];
 		for (const change of changes) {
 			if (change.seq !== undefined) {
 				// Guard 2: row's seq vs. cursor floor.
@@ -545,7 +546,8 @@ export const localIndex = {
 				const existing = state.items.get(change.id);
 				if (
 					existing?.seq !== undefined &&
-					change.seq <= existing.seq
+					change.seq <= existing.seq &&
+					!change.moved_out
 				) {
 					// Existing wins in RAM. Include it in the
 					// persist set so the IDB cursor we're about
@@ -554,9 +556,22 @@ export const localIndex = {
 					// IDB write could still be pending / failed
 					// — Codex P? round 4). One redundant put is
 					// cheaper than a missing row on warm boot.
+					// (A moved-out eviction is unconditional — it
+					// removes the row regardless of stored seq.)
 					toPersist.push(existing);
 					continue;
 				}
+			}
+			// `moved_out: true` (BUG-1675) means the item left this
+			// caller's visibility (moved into a collection they can't
+			// see). The row carries only id + seq, so we HARD-evict it
+			// from RAM + search and queue the IDB delete into the same
+			// atomic cursor-advance tx below (no resurrect on warm boot).
+			if (change.moved_out) {
+				state.items.delete(change.id);
+				localSearch.remove(ws, change.id);
+				toRemove.push(change.id);
+				continue;
 			}
 			// `deleted: true` is the server's derived view of
 			// `deleted_at != nil` — a SOFT delete. The row still carries
@@ -584,7 +599,7 @@ export const localIndex = {
 		// in-memory only and never break the read path. Routed
 		// through the workspace's captured `userId` so a different
 		// user signing into the same browser sees their own cache.
-		persistDelta(state.userId, ws, toPersist, newCursor).catch(
+		persistDelta(state.userId, ws, toPersist, newCursor, toRemove).catch(
 			() => undefined,
 		);
 	},

--- a/web/src/lib/stores/localIndexPersistence.ts
+++ b/web/src/lib/stores/localIndexPersistence.ts
@@ -235,13 +235,17 @@ export async function persistUpserts(
  * caught the divergence risk of separate row/cursor writes.
  *
  * Soft deletes flow through `rows` (as upserts with `deleted_at`
- * populated); hard removals still go through `persistRemovals`.
+ * populated). Hard removals are either passed as `removeIds` (so a
+ * moved-out eviction lands in the SAME tx as the cursor advance and
+ * can't resurrect on warm boot — BUG-1675) or, for paths without a
+ * cursor advance, go through `persistRemovals`.
  */
 export async function persistDelta(
 	userId: string | null,
 	ws: string,
 	rows: ItemIndexRow[],
 	cursor: string,
+	removeIds: string[] = [],
 ): Promise<void> {
 	if (!isSupported()) return;
 	const db = await open(userId, ws);
@@ -251,6 +255,9 @@ export async function persistDelta(
 		const itemsStore = tx.objectStore('items');
 		for (const row of rows) {
 			itemsStore.put(row).catch(() => undefined);
+		}
+		for (const id of removeIds) {
+			itemsStore.delete(id).catch(() => undefined);
 		}
 		tx.objectStore('meta')
 			.put({

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -520,7 +520,16 @@ export interface ItemIndexResponse {
 // one pass. Soft-deleted rows still carry their full skinny payload
 // (deleted_at is populated) — `deleted` is just the derived view of
 // that timestamp.
-export type ItemChangeRow = ItemIndexRow & { deleted: boolean };
+//
+// `moved_out` (BUG-1675) marks a row the caller can no longer see
+// because the item moved into a collection outside their visibility.
+// Unlike `deleted`, these rows carry ONLY `id` + `seq` (no title /
+// collection / fields — the destination is hidden from this caller), so
+// the consumer evicts the id from its local cache rather than upserting.
+export type ItemChangeRow = ItemIndexRow & {
+	deleted: boolean;
+	moved_out?: boolean;
+};
 
 // `ItemChangesResponse` wraps a delta-fetch result from
 // `GET /workspaces/{ws}/items-changes?since=<cursor>` (TASK-1354).


### PR DESCRIPTION
## Summary
Fixes **BUG-1675**: `/items-changes` filtered deltas by an item's **current** collection, so an item moving from a collection a restricted member can see into one they can't vanished from the delta with no eviction signal — the stale, now-unauthorized row lingered in their local cache until a full rebootstrap.

Found during Codex review of #669 (TASK-1668), which surfaced the gap by adding the source-collection reconcile signal.

## Approach (server-side tombstone via the activity log)
- **`store.ListMovedOutSince`** — finds items that (a) changed since the caller's cursor, (b) are now outside their visible scope, and (c) have a `moved` activity originating FROM a collection the caller **can** see. Returns `{id, seq}` only — never destination data, so nothing leaks (and the caller already has read access to the source collection).
- **`handleListItemsChanges`** merges these in as `moved_out` tombstones, then seq-sorts + caps the combined stream so pagination stays gap-free (cursor = last kept seq; anything past it re-fetched next poll).
- **Bulk collection moves** now log a proper `moved` activity with `from_collection`/`to_collection` (mirroring `handleMoveItem`) — the exact signal the tombstone query reads. They previously logged generic `updated`, which would have silently broken eviction.
- **Full members skip the extra query** — `visibleIDs == nil` (all-access) callers never lose visibility on a move, so the path only runs for restricted members/guests.

## Client
- `ItemChangeRow` gains `moved_out`; `applyDelta` hard-evicts those ids from RAM + the search index and queues the IDB delete into the **same atomic cursor-advance transaction** (`persistDelta` gains `removeIds`), so an eviction can't resurrect on warm boot.

## Why not a client-side lane reconcile
Keeps `/items-changes` the single delta authority (per the local-first model's design), reuses the existing eviction path, and fixes every client — not just web.

## Known follow-on
Single-item `handleMoveItem` still publishes only the target-collection SSE event (a pre-existing narrower gap); this PR's tombstone query covers the data correctness, and the source-scope SSE signal exists for bulk. Single-move source-scope SSE can be a separate tidy-up if desired.

## Test plan
- [x] `go build ./...`, `go vet ./...` — clean
- [x] `go test ./...` — all pass
  - `store.TestListMovedOutSince` — visibility matrix (sees-source→tombstone; sees-target→none; granted→excluded; from-not-visible→none; since-past-move→none; empty-scope→nil)
  - `TestItemsChanges_MovedOutTombstoneForRestrictedMember` — end-to-end as a `collection_access=specific` member; asserts tombstone has id+seq, no title/collection leak
  - `TestBulkItems_CollectionMoveNotifiesBothScopes` — now also asserts the `moved` activity with from/to
- [x] `cd web && npm run build` — clean