### PR TITLE
feat(web): bulk-mutation API client method + types (TASK-1669)

### DIFF
--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -7,6 +7,8 @@ import type {
 	CollectionUpdate,
 	Backlink,
 	Item,
+	BulkItemsRequest,
+	BulkItemsResponse,
 	ItemChangeRow,
 	ItemChangesResponse,
 	ItemCreate,
@@ -708,6 +710,26 @@ export const api = {
 		delete: (ws: string, slug: string) =>
 			request<void>(`/workspaces/${ws}/items/${slug}`, {
 				method: 'DELETE'
+			}),
+
+		/**
+		 * Apply one mutation verb (archive / move / tag / untag /
+		 * set-priority / assign) to many items in a single request
+		 * (TASK-1668 / TASK-1669). Editor/owner gated.
+		 *
+		 * Emits ONE `items_bulk_updated` SSE event per affected collection
+		 * + one webhook instead of per-item fan-out — used by the lane-
+		 * header bulk actions, which operate on a whole filtered lane.
+		 *
+		 * The call resolves 200 even when some rows fail: inspect the
+		 * `failed` array (each carries `error` and, for structured
+		 * rejections like `open_children`, `code` + `details`). `updated`
+		 * lists the rows that changed and `total === updated + failed`.
+		 */
+		bulk: (ws: string, data: BulkItemsRequest) =>
+			request<BulkItemsResponse>(`/workspaces/${ws}/items/bulk`, {
+				method: 'POST',
+				body: JSON.stringify(data)
 			}),
 
 		restore: (ws: string, slug: string) =>

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -616,8 +616,11 @@ export type BulkItemsRequest =
 	| {
 			op: 'assign';
 			ids: string[];
-			assigned_user_id?: string | null;
-			agent_role_id?: string | null;
+			// Set an assignee/role by id. To CLEAR, use the clear flags —
+			// the server treats JSON null as absent (mirrors ItemUpdate),
+			// so `assigned_user_id: null` would be rejected, not a clear.
+			assigned_user_id?: string;
+			agent_role_id?: string;
 			clear_assigned_user?: boolean;
 			clear_agent_role?: boolean;
 			force?: boolean;

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -583,6 +583,71 @@ export interface ItemUpdate {
 	force?: boolean;
 }
 
+// ─── Bulk mutation (TASK-1668 / TASK-1669) ───────────────────────────────────
+
+// The verbs the bulk endpoint accepts. One mutation applied to many items
+// in a single request (POST /workspaces/{ws}/items/bulk), emitting one SSE
+// event per affected collection + one webhook instead of per-item fan-out.
+export type BulkItemOp =
+	| 'archive'
+	| 'move'
+	| 'tag'
+	| 'untag'
+	| 'set-priority'
+	| 'assign';
+
+// `BulkItemsRequest` is a discriminated union on `op` so each verb only
+// accepts (and requires) its own params. `ids` are item refs (TASK-5) or
+// UUIDs. `force` overrides the open-children guard on status-bearing moves
+// (mirrors ItemUpdate.force). `move` requires status and/or collection
+// (target slug) — kept both-optional here; the server validates the
+// at-least-one rule.
+export type BulkItemsRequest =
+	| { op: 'archive'; ids: string[]; force?: boolean }
+	| {
+			op: 'move';
+			ids: string[];
+			status?: string;
+			collection?: string;
+			force?: boolean;
+	  }
+	| { op: 'set-priority'; ids: string[]; priority: string; force?: boolean }
+	| { op: 'tag' | 'untag'; ids: string[]; tags: string[]; force?: boolean }
+	| {
+			op: 'assign';
+			ids: string[];
+			assigned_user_id?: string | null;
+			agent_role_id?: string | null;
+			clear_assigned_user?: boolean;
+			clear_agent_role?: boolean;
+			force?: boolean;
+	  };
+
+// One successfully-mutated row.
+export interface BulkItemOutcome {
+	ref: string;
+	id: string;
+}
+
+// One row that failed. `code`/`details` carry the structured server error
+// when present (e.g. `open_children` with the blocking-child list); `error`
+// is always the human-readable message.
+export interface BulkItemFailure {
+	ref: string;
+	error: string;
+	code?: string;
+	details?: unknown;
+}
+
+// Per-row outcome envelope. The HTTP call resolves 200 even on partial
+// failure — branch on `failed` to react. `total === updated + failed`.
+export interface BulkItemsResponse {
+	op: BulkItemOp;
+	updated: BulkItemOutcome[];
+	failed: BulkItemFailure[];
+	total: number;
+}
+
 // ─── Versions ────────────────────────────────────────────────────────────────
 
 export interface Version {


### PR DESCRIPTION
## Summary
Frontend client + types for the bulk-mutation endpoint shipped in TASK-1668 (PR #669). Unblocks the lane-header bulk-action UI (TASK-1672).

- **`api.items.bulk(ws, data)`** → `POST /workspaces/{ws}/items/bulk`. Resolves 200 even on partial failure; callers branch on the `failed` array.
- **Types** (`lib/types/index.ts`):
  - `BulkItemOp` — the six verbs
  - `BulkItemsRequest` — a **discriminated union on `op`**, so each verb only accepts (and requires) its own params (e.g. `set-priority` requires `priority`, `tag`/`untag` require `tags`)
  - `BulkItemOutcome` / `BulkItemFailure` / `BulkItemsResponse` — the per-row outcome envelope (`details` typed `unknown`, matching the server's `json.RawMessage`)

Wire contract matches the backend `bulkItemsRequest`/response structs field-for-field (documented on TASK-1668).

## Test plan
- [x] `npm run check` (svelte-check / tsc) — 0 errors
- [x] `npm run build` — clean
- [x] No backend changes