### PR TITLE
feat(board): wire bulk lane actions via the bulk endpoint (TASK-1672)

### DIFF
--- a/web/src/lib/components/collections/BoardView.svelte
+++ b/web/src/lib/components/collections/BoardView.svelte
@@ -82,6 +82,21 @@
 		openMenuColumn = null;
 	}
 
+	// The ⋯ menu is shown when at least one of its entries is wired. Each
+	// callback already encodes the user's permission for that action, so
+	// this is the single source of truth for kebab visibility (TASK-1672).
+	let hasMenuActions = $derived(
+		!!(
+			onCreateInColumn ||
+			onArchiveColumn ||
+			onMoveColumn ||
+			onTagColumn ||
+			onUntagColumn ||
+			onSetPriorityColumn ||
+			onAssignColumn
+		)
+	);
+
 	// Dismiss the open lane menu on any click outside it (mirrors the
 	// QuickActionsMenu pattern). The menu markup lives under
 	// `.lane-menu-wrap`, so clicks there don't close it.
@@ -307,15 +322,22 @@
 				<span class="column-name">{formatLabel(colValue)}</span>
 				<div class="column-actions">
 					<span class="column-count">{colItems.length}</span>
-					{#if canEdit}
-						{#if onCreateInColumn}
-							<button
-								class="lane-btn lane-add-btn"
-								title="Add item to {formatLabel(colValue).toLowerCase()}"
-								aria-label="Add item to {formatLabel(colValue)}"
-								onclick={() => onCreateInColumn?.(colValue)}
-							>+</button>
-						{/if}
+					<!-- Affordance visibility is driven purely by callback
+					     presence — each callback already encodes its own
+					     permission (the `+` create is grant-aware; the bulk
+					     verbs are owner/editor-gated by the page). Don't gate
+					     on `canEdit`, or an owner/editor without a collection
+					     edit grant (canBulkEdit true, canEdit false) couldn't
+					     open the menu at all. TASK-1672 / Codex round 4. -->
+					{#if onCreateInColumn}
+						<button
+							class="lane-btn lane-add-btn"
+							title="Add item to {formatLabel(colValue).toLowerCase()}"
+							aria-label="Add item to {formatLabel(colValue)}"
+							onclick={() => onCreateInColumn?.(colValue)}
+						>+</button>
+					{/if}
+					{#if hasMenuActions}
 						<div class="lane-menu-wrap">
 							<button
 								class="lane-btn lane-menu-btn"

--- a/web/src/lib/components/collections/BoardView.svelte
+++ b/web/src/lib/components/collections/BoardView.svelte
@@ -6,6 +6,7 @@
 	import type { DndEvent } from 'svelte-dnd-action';
 	import ItemCard from './ItemCard.svelte';
 	import EmptyState from '../common/EmptyState.svelte';
+	import LaneActionsMenu from './LaneActionsMenu.svelte';
 
 
 	interface Props {
@@ -25,6 +26,21 @@
 		 * lane-header button calls this. Gated behind `canEdit`.
 		 */
 		onCreateInColumn?: (groupValue: string) => void;
+		/**
+		 * Bulk lane actions (TASK-1672), each operating on the lane's
+		 * CURRENTLY-FILTERED items via the bulk endpoint. Surfaced in the
+		 * ⋯ LaneActionsMenu. All canEdit-gated by the caller.
+		 */
+		onMoveColumn?: (items: Item[], status: string) => void;
+		onTagColumn?: (items: Item[], tag: string) => void;
+		onUntagColumn?: (items: Item[], tag: string) => void;
+		onSetPriorityColumn?: (items: Item[], priority: string) => void;
+		onAssignColumn?: (items: Item[], userId: string) => void;
+		/** Workspace members (for "Assign all") and tag suggestions (for "Tag all"). */
+		members?: { user_id: string; user_name?: string }[];
+		tagSuggestions?: string[];
+		/** True when a search/filter is narrowing the lanes — shown in menu labels. */
+		filtered?: boolean;
 		itemProgress?: Record<string, { total: number; done: number }>;
 		progressLabel?: string;
 		/**
@@ -51,23 +67,19 @@
 		sortMode?: SortMode;
 	}
 
-	let { items, collection, wsSlug = '', groupField = 'status', focusedItemId = null, onStatusChange, onReorder, onArchiveColumn, onGroupReorder, oncreate, onCreateInColumn, itemProgress, progressLabel = 'tasks', canEdit = true, preserveOrder = false, sortMode = 'manual' }: Props = $props();
+	let { items, collection, wsSlug = '', groupField = 'status', focusedItemId = null, onStatusChange, onReorder, onArchiveColumn, onGroupReorder, oncreate, onCreateInColumn, onMoveColumn, onTagColumn, onUntagColumn, onSetPriorityColumn, onAssignColumn, members = [], tagSuggestions = [], filtered = false, itemProgress, progressLabel = 'tasks', canEdit = true, preserveOrder = false, sortMode = 'manual' }: Props = $props();
 
-	let confirmArchiveColumn = $state<string | null>(null);
-	// Which lane's ⋯ menu is open (null = none). The menu is the new home
-	// for the column actions (archive today; move/tag/priority/assign land
-	// in TASK-1672). One menu open at a time.
+	// Which lane's ⋯ menu is open (null = none). One menu open at a time;
+	// the LaneActionsMenu component owns the drill-down + confirm state.
 	let openMenuColumn = $state<string | null>(null);
 	let isMobile = $state(false);
 
 	function toggleMenu(colValue: string) {
 		openMenuColumn = openMenuColumn === colValue ? null : colValue;
-		confirmArchiveColumn = null;
 	}
 
 	function closeMenu() {
 		openMenuColumn = null;
-		confirmArchiveColumn = null;
 	}
 
 	// Dismiss the open lane menu on any click outside it (mirrors the
@@ -314,47 +326,23 @@
 								onclick={(e) => { e.stopPropagation(); toggleMenu(colValue); }}
 							>⋯</button>
 							{#if openMenuColumn === colValue}
-								<!-- stopPropagation on every in-menu click: an
-								     onclick that mutates state (e.g. showing the
-								     archive confirm) re-renders and detaches the
-								     clicked button before the event bubbles to
-								     <svelte:window onclick>, where closest() on the
-								     now-orphaned node returns null and slams the
-								     menu shut. Same Svelte 5 same-click bubbling
-								     issue documented in console/+layout.svelte. -->
-								<div class="lane-menu" role="menu">
-									{#if onCreateInColumn}
-										<button
-											class="lane-menu-item"
-											role="menuitem"
-											onclick={(e) => { e.stopPropagation(); onCreateInColumn?.(colValue); closeMenu(); }}
-										>
-											<span class="lmi-icon" aria-hidden="true">＋</span> Add item here
-										</button>
-									{/if}
-									{#if onArchiveColumn && colItems.length > 0}
-										{#if onCreateInColumn}
-											<div class="lane-menu-sep"></div>
-										{/if}
-										{#if confirmArchiveColumn === colValue}
-											<div class="lane-menu-confirm">
-												<span>Archive {colItems.length} item{colItems.length === 1 ? '' : 's'}?</span>
-												<div class="lmc-actions">
-													<button class="lmc-yes" onclick={(e) => { e.stopPropagation(); onArchiveColumn?.(colItems); closeMenu(); }}>Archive</button>
-													<button class="lmc-no" onclick={(e) => { e.stopPropagation(); confirmArchiveColumn = null; }}>Cancel</button>
-												</div>
-											</div>
-										{:else}
-											<button
-												class="lane-menu-item lmi-danger"
-												role="menuitem"
-												onclick={(e) => { e.stopPropagation(); confirmArchiveColumn = colValue; }}
-											>
-												<span class="lmi-icon" aria-hidden="true">🗃</span> Archive all ({colItems.length})
-											</button>
-										{/if}
-									{/if}
-								</div>
+								<LaneActionsMenu
+									items={colItems}
+									groupValue={colValue}
+									{groupField}
+									{collection}
+									{filtered}
+									{members}
+									{tagSuggestions}
+									onClose={closeMenu}
+									onAddItem={() => onCreateInColumn?.(colValue)}
+									onArchive={() => onArchiveColumn?.(colItems)}
+									onMove={(status) => onMoveColumn?.(colItems, status)}
+									onTag={(tag) => onTagColumn?.(colItems, tag)}
+									onUntag={(tag) => onUntagColumn?.(colItems, tag)}
+									onSetPriority={(p) => onSetPriorityColumn?.(colItems, p)}
+									onAssign={(userId) => onAssignColumn?.(colItems, userId)}
+								/>
 							{/if}
 						</div>
 					{/if}
@@ -539,96 +527,8 @@
 		display: inline-flex;
 	}
 
-	.lane-menu {
-		position: absolute;
-		top: calc(100% + 4px);
-		right: 0;
-		z-index: 20;
-		min-width: 180px;
-		padding: var(--space-1);
-		background: var(--bg-primary);
-		border: 1px solid var(--border);
-		border-radius: var(--radius-md);
-		box-shadow: var(--shadow-md, 0 4px 12px rgba(0, 0, 0, 0.15));
-		display: flex;
-		flex-direction: column;
-		gap: 2px;
-	}
-
-	.lane-menu-item {
-		display: flex;
-		align-items: center;
-		gap: var(--space-2);
-		width: 100%;
-		padding: 8px 10px;
-		background: none;
-		border: none;
-		border-radius: var(--radius-sm);
-		color: var(--text-primary);
-		font-size: 0.875em;
-		text-align: left;
-		cursor: pointer;
-	}
-
-	.lane-menu-item:hover {
-		background: var(--bg-hover);
-	}
-
-	.lane-menu-item.lmi-danger {
-		color: var(--accent-red, #ef4444);
-	}
-
-	.lane-menu-item.lmi-danger:hover {
-		background: color-mix(in srgb, var(--accent-red, #ef4444) 10%, transparent);
-	}
-
-	.lmi-icon {
-		width: 1.1em;
-		text-align: center;
-		flex-shrink: 0;
-	}
-
-	.lane-menu-sep {
-		height: 1px;
-		margin: 2px 0;
-		background: var(--border);
-	}
-
-	.lane-menu-confirm {
-		display: flex;
-		flex-direction: column;
-		gap: var(--space-2);
-		padding: 8px 10px;
-		font-size: 0.8125em;
-		color: var(--text-secondary);
-	}
-
-	.lmc-actions {
-		display: flex;
-		gap: var(--space-2);
-	}
-
-	.lmc-yes {
-		flex: 1;
-		padding: 6px 10px;
-		background: var(--accent-red, #ef4444);
-		border: none;
-		border-radius: var(--radius-sm);
-		color: #fff;
-		font-size: 0.8125em;
-		cursor: pointer;
-	}
-
-	.lmc-no {
-		flex: 1;
-		padding: 6px 10px;
-		background: var(--bg-tertiary);
-		border: none;
-		border-radius: var(--radius-sm);
-		color: var(--text-primary);
-		font-size: 0.8125em;
-		cursor: pointer;
-	}
+	/* The lane menu panel + its drill-down styles live in
+	   LaneActionsMenu.svelte (TASK-1672). */
 
 	@media (max-width: 768px) {
 		.lane-btn {

--- a/web/src/lib/components/collections/BoardView.svelte
+++ b/web/src/lib/components/collections/BoardView.svelte
@@ -335,13 +335,13 @@
 									{members}
 									{tagSuggestions}
 									onClose={closeMenu}
-									onAddItem={() => onCreateInColumn?.(colValue)}
-									onArchive={() => onArchiveColumn?.(colItems)}
-									onMove={(status) => onMoveColumn?.(colItems, status)}
-									onTag={(tag) => onTagColumn?.(colItems, tag)}
-									onUntag={(tag) => onUntagColumn?.(colItems, tag)}
-									onSetPriority={(p) => onSetPriorityColumn?.(colItems, p)}
-									onAssign={(userId) => onAssignColumn?.(colItems, userId)}
+									onAddItem={onCreateInColumn ? () => onCreateInColumn?.(colValue) : undefined}
+									onArchive={onArchiveColumn ? () => onArchiveColumn?.(colItems) : undefined}
+									onMove={onMoveColumn ? (status) => onMoveColumn?.(colItems, status) : undefined}
+									onTag={onTagColumn ? (tag) => onTagColumn?.(colItems, tag) : undefined}
+									onUntag={onUntagColumn ? (tag) => onUntagColumn?.(colItems, tag) : undefined}
+									onSetPriority={onSetPriorityColumn ? (p) => onSetPriorityColumn?.(colItems, p) : undefined}
+									onAssign={onAssignColumn ? (userId) => onAssignColumn?.(colItems, userId) : undefined}
 								/>
 							{/if}
 						</div>

--- a/web/src/lib/components/collections/BoardView.svelte
+++ b/web/src/lib/components/collections/BoardView.svelte
@@ -82,12 +82,14 @@
 		openMenuColumn = null;
 	}
 
-	// The ⋯ menu is shown when at least one of its entries is wired. Each
-	// callback already encodes the user's permission for that action, so
-	// this is the single source of truth for kebab visibility (TASK-1672).
-	let hasMenuActions = $derived(
+	// Any bulk verb wired (each encodes its own owner/editor permission).
+	// The bulk menu entries only render for a NON-empty lane, so kebab
+	// visibility is computed per-lane below as `onCreateInColumn ||
+	// (laneHasItems && hasBulkActions)` — otherwise a role-only bulk
+	// editor would get a ⋯ that opens an empty panel on an empty lane
+	// (TASK-1672 / Codex round 5).
+	let hasBulkActions = $derived(
 		!!(
-			onCreateInColumn ||
 			onArchiveColumn ||
 			onMoveColumn ||
 			onTagColumn ||
@@ -337,7 +339,7 @@
 							onclick={() => onCreateInColumn?.(colValue)}
 						>+</button>
 					{/if}
-					{#if hasMenuActions}
+					{#if onCreateInColumn || (colItems.length > 0 && hasBulkActions)}
 						<div class="lane-menu-wrap">
 							<button
 								class="lane-btn lane-menu-btn"

--- a/web/src/lib/components/collections/LaneActionsMenu.svelte
+++ b/web/src/lib/components/collections/LaneActionsMenu.svelte
@@ -16,13 +16,17 @@
 		/** Workspace tag suggestions for "Tag all". */
 		tagSuggestions: string[];
 		onClose: () => void;
-		onAddItem: () => void;
-		onArchive: () => void;
-		onMove: (status: string) => void;
-		onTag: (tag: string) => void;
-		onUntag: (tag: string) => void;
-		onSetPriority: (priority: string) => void;
-		onAssign: (userId: string) => void;
+		// Each action is optional: the caller passes only the ones the
+		// current user is permitted to perform (the single `+` create is
+		// grant-aware; the bulk verbs require workspace owner/editor — see
+		// the page). An undefined callback hides its menu entry.
+		onAddItem?: () => void;
+		onArchive?: () => void;
+		onMove?: (status: string) => void;
+		onTag?: (tag: string) => void;
+		onUntag?: (tag: string) => void;
+		onSetPriority?: (priority: string) => void;
+		onAssign?: (userId: string) => void;
 	}
 
 	let {
@@ -95,7 +99,7 @@
 	function submitTag() {
 		const t = tagInput.trim();
 		if (t) {
-			onTag(t);
+			onTag?.(t);
 			onClose();
 		}
 	}
@@ -103,81 +107,87 @@
 
 <div class="lane-menu" role="menu" onkeydown={(e) => { if (e.key === 'Escape') onClose(); }} tabindex="-1">
 	{#if view === 'root'}
-		<button class="lane-menu-item" role="menuitem" onclick={(e) => run(e, () => { onAddItem(); onClose(); })}>
-			<span class="lmi-icon" aria-hidden="true">＋</span> Add item here
-		</button>
+		{#if onAddItem}
+			<button class="lane-menu-item" role="menuitem" onclick={(e) => run(e, () => { onAddItem?.(); onClose(); })}>
+				<span class="lmi-icon" aria-hidden="true">＋</span> Add item here
+			</button>
+		{/if}
 
 		{#if count > 0}
 			<div class="lane-menu-sep"></div>
 
-			{#if moveTargets.length > 0}
+			{#if onMove && moveTargets.length > 0}
 				<button class="lane-menu-item" role="menuitem" onclick={(e) => run(e, () => (view = 'move'))}>
 					<span class="lmi-icon" aria-hidden="true">→</span> Move all to <span class="lmi-chevron">›</span>
 				</button>
 			{/if}
 
-			<button class="lane-menu-item" role="menuitem" onclick={(e) => run(e, () => (view = 'tag'))}>
-				<span class="lmi-icon" aria-hidden="true">🏷</span> Tag all <span class="lmi-chevron">›</span>
-			</button>
+			{#if onTag}
+				<button class="lane-menu-item" role="menuitem" onclick={(e) => run(e, () => (view = 'tag'))}>
+					<span class="lmi-icon" aria-hidden="true">🏷</span> Tag all <span class="lmi-chevron">›</span>
+				</button>
+			{/if}
 
-			{#if laneTags.length > 0}
+			{#if onUntag && laneTags.length > 0}
 				<button class="lane-menu-item" role="menuitem" onclick={(e) => run(e, () => (view = 'untag'))}>
 					<span class="lmi-icon" aria-hidden="true">⌫</span> Untag all <span class="lmi-chevron">›</span>
 				</button>
 			{/if}
 
-			{#if priorityOptions.length > 0}
+			{#if onSetPriority && priorityOptions.length > 0}
 				<button class="lane-menu-item" role="menuitem" onclick={(e) => run(e, () => (view = 'priority'))}>
 					<span class="lmi-icon" aria-hidden="true">⚑</span> Set priority <span class="lmi-chevron">›</span>
 				</button>
 			{/if}
 
-			{#if members.length > 0}
+			{#if onAssign && members.length > 0}
 				<button class="lane-menu-item" role="menuitem" onclick={(e) => run(e, () => (view = 'assign'))}>
 					<span class="lmi-icon" aria-hidden="true">👤</span> Assign all <span class="lmi-chevron">›</span>
 				</button>
 			{/if}
 
-			<div class="lane-menu-sep"></div>
-			{#if confirmArchive}
-				<div class="lane-menu-confirm">
-					<span>Archive {count} item{count === 1 ? '' : 's'}{scopeNote}?</span>
-					<div class="lmc-actions">
-						<button class="lmc-yes" onclick={(e) => run(e, () => { onArchive(); onClose(); })}>Archive</button>
-						<button class="lmc-no" onclick={(e) => run(e, () => (confirmArchive = false))}>Cancel</button>
+			{#if onArchive}
+				<div class="lane-menu-sep"></div>
+				{#if confirmArchive}
+					<div class="lane-menu-confirm">
+						<span>Archive {count} item{count === 1 ? '' : 's'}{scopeNote}?</span>
+						<div class="lmc-actions">
+							<button class="lmc-yes" onclick={(e) => run(e, () => { onArchive?.(); onClose(); })}>Archive</button>
+							<button class="lmc-no" onclick={(e) => run(e, () => (confirmArchive = false))}>Cancel</button>
+						</div>
 					</div>
-				</div>
-			{:else}
-				<button class="lane-menu-item lmi-danger" role="menuitem" onclick={(e) => run(e, () => (confirmArchive = true))}>
-					<span class="lmi-icon" aria-hidden="true">🗃</span> Archive all ({count}{scopeNote})
-				</button>
+				{:else}
+					<button class="lane-menu-item lmi-danger" role="menuitem" onclick={(e) => run(e, () => (confirmArchive = true))}>
+						<span class="lmi-icon" aria-hidden="true">🗃</span> Archive all ({count}{scopeNote})
+					</button>
+				{/if}
 			{/if}
 		{/if}
 	{:else if view === 'move'}
 		<button class="lane-menu-back" onclick={(e) => run(e, () => (view = 'root'))}>‹ Move all to{scopeNote}</button>
 		{#each moveTargets as target (target)}
-			<button class="lane-menu-item" role="menuitem" onclick={(e) => run(e, () => { onMove(target); onClose(); })}>
+			<button class="lane-menu-item" role="menuitem" onclick={(e) => run(e, () => { onMove?.(target); onClose(); })}>
 				{fmt(target)}
 			</button>
 		{/each}
 	{:else if view === 'priority'}
 		<button class="lane-menu-back" onclick={(e) => run(e, () => (view = 'root'))}>‹ Set priority{scopeNote}</button>
 		{#each priorityOptions as p (p)}
-			<button class="lane-menu-item" role="menuitem" onclick={(e) => run(e, () => { onSetPriority(p); onClose(); })}>
+			<button class="lane-menu-item" role="menuitem" onclick={(e) => run(e, () => { onSetPriority?.(p); onClose(); })}>
 				{fmt(p)}
 			</button>
 		{/each}
 	{:else if view === 'assign'}
 		<button class="lane-menu-back" onclick={(e) => run(e, () => (view = 'root'))}>‹ Assign all{scopeNote}</button>
 		{#each members as m (m.user_id)}
-			<button class="lane-menu-item" role="menuitem" onclick={(e) => run(e, () => { onAssign(m.user_id); onClose(); })}>
+			<button class="lane-menu-item" role="menuitem" onclick={(e) => run(e, () => { onAssign?.(m.user_id); onClose(); })}>
 				{m.user_name || m.user_id}
 			</button>
 		{/each}
 	{:else if view === 'untag'}
 		<button class="lane-menu-back" onclick={(e) => run(e, () => (view = 'root'))}>‹ Untag all{scopeNote}</button>
 		{#each laneTags as t (t)}
-			<button class="lane-menu-item" role="menuitem" onclick={(e) => run(e, () => { onUntag(t); onClose(); })}>
+			<button class="lane-menu-item" role="menuitem" onclick={(e) => run(e, () => { onUntag?.(t); onClose(); })}>
 				{t}
 			</button>
 		{/each}
@@ -196,7 +206,7 @@
 		{#if tagSuggestions.length > 0}
 			<div class="lane-menu-sep"></div>
 			{#each tagSuggestions as t (t)}
-				<button class="lane-menu-item" role="menuitem" onclick={(e) => run(e, () => { onTag(t); onClose(); })}>
+				<button class="lane-menu-item" role="menuitem" onclick={(e) => run(e, () => { onTag?.(t); onClose(); })}>
 					{t}
 				</button>
 			{/each}

--- a/web/src/lib/components/collections/LaneActionsMenu.svelte
+++ b/web/src/lib/components/collections/LaneActionsMenu.svelte
@@ -1,0 +1,353 @@
+<script lang="ts">
+	import type { Item, Collection } from '$lib/types';
+	import { parseSchema } from '$lib/types';
+
+	interface Props {
+		/** The lane's CURRENTLY-FILTERED items — every action operates on these. */
+		items: Item[];
+		/** The lane's group value (e.g. the status) — used to label the lane. */
+		groupValue: string;
+		/** Which field the board groups by. "Move all to" only applies when 'status'. */
+		groupField: string;
+		collection: Collection;
+		/** True when a filter/search is narrowing the lane — surfaced in labels. */
+		filtered: boolean;
+		members: { user_id: string; user_name?: string }[];
+		/** Workspace tag suggestions for "Tag all". */
+		tagSuggestions: string[];
+		onClose: () => void;
+		onAddItem: () => void;
+		onArchive: () => void;
+		onMove: (status: string) => void;
+		onTag: (tag: string) => void;
+		onUntag: (tag: string) => void;
+		onSetPriority: (priority: string) => void;
+		onAssign: (userId: string) => void;
+	}
+
+	let {
+		items,
+		groupValue,
+		groupField,
+		collection,
+		filtered,
+		members,
+		tagSuggestions,
+		onClose,
+		onAddItem,
+		onArchive,
+		onMove,
+		onTag,
+		onUntag,
+		onSetPriority,
+		onAssign
+	}: Props = $props();
+
+	type View = 'root' | 'move' | 'tag' | 'untag' | 'priority' | 'assign';
+	let view = $state<View>('root');
+	let confirmArchive = $state(false);
+	let tagInput = $state('');
+
+	let count = $derived(items.length);
+	let scopeNote = $derived(filtered ? ' (filtered)' : '');
+
+	let schema = $derived(parseSchema(collection));
+	let statusField = $derived(schema.fields.find((f) => f.key === 'status'));
+	let priorityFieldDef = $derived(
+		schema.fields.find((f) => f.key === 'priority' && f.type === 'select')
+	);
+
+	// Move targets = the other lanes. Only offered when the board groups by
+	// status, since the bulk `move` op sets the status field (TASK-1668).
+	let moveTargets = $derived(
+		groupField === 'status'
+			? (statusField?.options ?? []).filter((o) => o !== groupValue)
+			: []
+	);
+	let priorityOptions = $derived(priorityFieldDef?.options ?? []);
+
+	// Untag offers only the tags actually present on the lane's items.
+	let laneTags = $derived.by(() => {
+		const set = new Set<string>();
+		for (const it of items) {
+			try {
+				for (const t of JSON.parse(it.tags || '[]')) set.add(t);
+			} catch {
+				/* malformed tags JSON — skip */
+			}
+		}
+		return [...set].sort();
+	});
+
+	function fmt(v: string): string {
+		return v.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+	}
+
+	// stopPropagation on every click: a click that mutates state (drill-down,
+	// archive confirm) re-renders and detaches the clicked node before the
+	// event bubbles to BoardView's <svelte:window> outside-click handler,
+	// where closest() on the orphan returns null and slams the menu shut.
+	// Same Svelte 5 same-click issue documented in console/+layout.svelte.
+	function run(e: MouseEvent, fn: () => void) {
+		e.stopPropagation();
+		fn();
+	}
+	function submitTag() {
+		const t = tagInput.trim();
+		if (t) {
+			onTag(t);
+			onClose();
+		}
+	}
+</script>
+
+<div class="lane-menu" role="menu" onkeydown={(e) => { if (e.key === 'Escape') onClose(); }} tabindex="-1">
+	{#if view === 'root'}
+		<button class="lane-menu-item" role="menuitem" onclick={(e) => run(e, () => { onAddItem(); onClose(); })}>
+			<span class="lmi-icon" aria-hidden="true">＋</span> Add item here
+		</button>
+
+		{#if count > 0}
+			<div class="lane-menu-sep"></div>
+
+			{#if moveTargets.length > 0}
+				<button class="lane-menu-item" role="menuitem" onclick={(e) => run(e, () => (view = 'move'))}>
+					<span class="lmi-icon" aria-hidden="true">→</span> Move all to <span class="lmi-chevron">›</span>
+				</button>
+			{/if}
+
+			<button class="lane-menu-item" role="menuitem" onclick={(e) => run(e, () => (view = 'tag'))}>
+				<span class="lmi-icon" aria-hidden="true">🏷</span> Tag all <span class="lmi-chevron">›</span>
+			</button>
+
+			{#if laneTags.length > 0}
+				<button class="lane-menu-item" role="menuitem" onclick={(e) => run(e, () => (view = 'untag'))}>
+					<span class="lmi-icon" aria-hidden="true">⌫</span> Untag all <span class="lmi-chevron">›</span>
+				</button>
+			{/if}
+
+			{#if priorityOptions.length > 0}
+				<button class="lane-menu-item" role="menuitem" onclick={(e) => run(e, () => (view = 'priority'))}>
+					<span class="lmi-icon" aria-hidden="true">⚑</span> Set priority <span class="lmi-chevron">›</span>
+				</button>
+			{/if}
+
+			{#if members.length > 0}
+				<button class="lane-menu-item" role="menuitem" onclick={(e) => run(e, () => (view = 'assign'))}>
+					<span class="lmi-icon" aria-hidden="true">👤</span> Assign all <span class="lmi-chevron">›</span>
+				</button>
+			{/if}
+
+			<div class="lane-menu-sep"></div>
+			{#if confirmArchive}
+				<div class="lane-menu-confirm">
+					<span>Archive {count} item{count === 1 ? '' : 's'}{scopeNote}?</span>
+					<div class="lmc-actions">
+						<button class="lmc-yes" onclick={(e) => run(e, () => { onArchive(); onClose(); })}>Archive</button>
+						<button class="lmc-no" onclick={(e) => run(e, () => (confirmArchive = false))}>Cancel</button>
+					</div>
+				</div>
+			{:else}
+				<button class="lane-menu-item lmi-danger" role="menuitem" onclick={(e) => run(e, () => (confirmArchive = true))}>
+					<span class="lmi-icon" aria-hidden="true">🗃</span> Archive all ({count}{scopeNote})
+				</button>
+			{/if}
+		{/if}
+	{:else if view === 'move'}
+		<button class="lane-menu-back" onclick={(e) => run(e, () => (view = 'root'))}>‹ Move all to{scopeNote}</button>
+		{#each moveTargets as target (target)}
+			<button class="lane-menu-item" role="menuitem" onclick={(e) => run(e, () => { onMove(target); onClose(); })}>
+				{fmt(target)}
+			</button>
+		{/each}
+	{:else if view === 'priority'}
+		<button class="lane-menu-back" onclick={(e) => run(e, () => (view = 'root'))}>‹ Set priority{scopeNote}</button>
+		{#each priorityOptions as p (p)}
+			<button class="lane-menu-item" role="menuitem" onclick={(e) => run(e, () => { onSetPriority(p); onClose(); })}>
+				{fmt(p)}
+			</button>
+		{/each}
+	{:else if view === 'assign'}
+		<button class="lane-menu-back" onclick={(e) => run(e, () => (view = 'root'))}>‹ Assign all{scopeNote}</button>
+		{#each members as m (m.user_id)}
+			<button class="lane-menu-item" role="menuitem" onclick={(e) => run(e, () => { onAssign(m.user_id); onClose(); })}>
+				{m.user_name || m.user_id}
+			</button>
+		{/each}
+	{:else if view === 'untag'}
+		<button class="lane-menu-back" onclick={(e) => run(e, () => (view = 'root'))}>‹ Untag all{scopeNote}</button>
+		{#each laneTags as t (t)}
+			<button class="lane-menu-item" role="menuitem" onclick={(e) => run(e, () => { onUntag(t); onClose(); })}>
+				{t}
+			</button>
+		{/each}
+	{:else if view === 'tag'}
+		<button class="lane-menu-back" onclick={(e) => run(e, () => (view = 'root'))}>‹ Tag all{scopeNote}</button>
+		<div class="lane-menu-tag-input">
+			<input
+				type="text"
+				placeholder="Add tag…"
+				bind:value={tagInput}
+				onclick={(e) => e.stopPropagation()}
+				onkeydown={(e) => { if (e.key === 'Enter') { e.stopPropagation(); submitTag(); } }}
+			/>
+			<button class="lmc-yes" disabled={!tagInput.trim()} onclick={(e) => run(e, submitTag)}>Add</button>
+		</div>
+		{#if tagSuggestions.length > 0}
+			<div class="lane-menu-sep"></div>
+			{#each tagSuggestions as t (t)}
+				<button class="lane-menu-item" role="menuitem" onclick={(e) => run(e, () => { onTag(t); onClose(); })}>
+					{t}
+				</button>
+			{/each}
+		{/if}
+	{/if}
+</div>
+
+<style>
+	.lane-menu {
+		position: absolute;
+		top: calc(100% + 4px);
+		right: 0;
+		z-index: 20;
+		min-width: 200px;
+		max-height: 320px;
+		overflow-y: auto;
+		padding: var(--space-1);
+		background: var(--bg-primary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius-md);
+		box-shadow: var(--shadow-md, 0 4px 12px rgba(0, 0, 0, 0.15));
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+	}
+
+	.lane-menu-item {
+		display: flex;
+		align-items: center;
+		gap: var(--space-2);
+		width: 100%;
+		padding: 8px 10px;
+		background: none;
+		border: none;
+		border-radius: var(--radius-sm);
+		color: var(--text-primary);
+		font-size: 0.875em;
+		text-align: left;
+		cursor: pointer;
+	}
+
+	.lane-menu-item:hover {
+		background: var(--bg-hover);
+	}
+
+	.lane-menu-item.lmi-danger {
+		color: var(--accent-red, #ef4444);
+	}
+
+	.lane-menu-item.lmi-danger:hover {
+		background: color-mix(in srgb, var(--accent-red, #ef4444) 10%, transparent);
+	}
+
+	.lmi-icon {
+		width: 1.1em;
+		text-align: center;
+		flex-shrink: 0;
+	}
+
+	.lmi-chevron {
+		margin-left: auto;
+		color: var(--text-muted);
+	}
+
+	.lane-menu-back {
+		display: flex;
+		align-items: center;
+		width: 100%;
+		padding: 6px 10px;
+		margin-bottom: 2px;
+		background: none;
+		border: none;
+		border-bottom: 1px solid var(--border);
+		border-radius: 0;
+		color: var(--text-muted);
+		font-size: 0.8125em;
+		font-weight: 600;
+		text-align: left;
+		cursor: pointer;
+	}
+
+	.lane-menu-back:hover {
+		color: var(--text-primary);
+	}
+
+	.lane-menu-sep {
+		height: 1px;
+		margin: 2px 0;
+		background: var(--border);
+	}
+
+	.lane-menu-confirm {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-2);
+		padding: 8px 10px;
+		font-size: 0.8125em;
+		color: var(--text-secondary);
+	}
+
+	.lmc-actions {
+		display: flex;
+		gap: var(--space-2);
+	}
+
+	.lmc-yes {
+		flex: 1;
+		padding: 6px 10px;
+		background: var(--accent-red, #ef4444);
+		border: none;
+		border-radius: var(--radius-sm);
+		color: #fff;
+		font-size: 0.8125em;
+		cursor: pointer;
+	}
+
+	.lmc-yes:disabled {
+		opacity: 0.5;
+		cursor: default;
+	}
+
+	.lmc-no {
+		flex: 1;
+		padding: 6px 10px;
+		background: var(--bg-tertiary);
+		border: none;
+		border-radius: var(--radius-sm);
+		color: var(--text-primary);
+		font-size: 0.8125em;
+		cursor: pointer;
+	}
+
+	.lane-menu-tag-input {
+		display: flex;
+		gap: var(--space-2);
+		padding: 6px 8px;
+	}
+
+	.lane-menu-tag-input input {
+		flex: 1;
+		min-width: 0;
+		padding: 6px 8px;
+		background: var(--bg-secondary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius-sm);
+		color: var(--text-primary);
+		font-size: 0.8125em;
+	}
+
+	.lane-menu-tag-input .lmc-yes {
+		flex: 0 0 auto;
+		background: var(--accent-blue);
+	}
+</style>

--- a/web/src/lib/components/collections/ListView.svelte
+++ b/web/src/lib/components/collections/ListView.svelte
@@ -284,7 +284,12 @@
 					<span class="group-title">{formatLabel(groupName)}</span>
 					<span class="group-actions">
 						<span class="group-count">{itemCount(grpItems)}</span>
-						{#if canEdit && onArchiveGroup && itemCount(grpItems) > 0}
+						<!-- Gate on onArchiveGroup alone (not canEdit): archive-all
+						     is owner/editor-gated by the page via the callback, so
+						     an owner/editor without a collection edit grant
+						     (canEdit false) can still bulk-archive. TASK-1672 /
+						     Codex round 4. -->
+						{#if onArchiveGroup && itemCount(grpItems) > 0}
 							{#if confirmArchiveGroup === groupName}
 								<span class="archive-confirm">
 									<button class="archive-yes" onclick={(e) => { e.stopPropagation(); onArchiveGroup(grpItems); confirmArchiveGroup = null; }}>Archive {itemCount(grpItems)}?</button>

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -2,7 +2,7 @@
 	import { page } from '$app/state';
 	import { goto } from '$app/navigation';
 	import { api, PadApiError, isPlanLimitError, planLimitMessage } from '$lib/api/client';
-	import type { Collection, Item, QuickAction, View, ViewConfig } from '$lib/types';
+	import type { BulkItemsRequest, Collection, Item, QuickAction, View, ViewConfig } from '$lib/types';
 	import { parseSettings, parseFields, parseSchema, parseTags, getStatusOptions, itemUrlId, formatItemRef } from '$lib/types';
 	import BoardView from '$lib/components/collections/BoardView.svelte';
 	import ListView from '$lib/components/collections/ListView.svelte';
@@ -77,7 +77,7 @@
 	let shareDialogOpen = $state(false);
 	let editCollectionOpen = $state(false);
 	let editCollectionSection = $state<'general' | 'fields' | 'display' | 'actions' | undefined>(undefined);
-	let workspaceMembers = $state<{ user_id: string; role: string }[]>([]);
+	let workspaceMembers = $state<{ user_id: string; role: string; user_name?: string; user_email?: string }[]>([]);
 	let searchInputEl = $state<HTMLInputElement>();
 	// `searchResultRank` is a Map<itemId, rank> where rank is the 0-indexed
 	// position in the ranked result list. `null` means no search active.
@@ -660,6 +660,10 @@
 			.sort((a, b) => b.count - a.count || a.tag.localeCompare(b.tag));
 	});
 
+	// Tag suggestions for the lane "Tag all" action (TASK-1672) — the
+	// workspace's tags by frequency.
+	let tagSuggestions = $derived(tagCounts.map((t) => t.tag));
+
 	const emptyHintMap: Record<string, string> = {
 		tasks: '/pad break down my current work into tasks',
 		ideas: "/pad I have an idea for...",
@@ -1155,33 +1159,59 @@
 		});
 	}
 
-	async function handleBulkArchive(itemsToArchive: Item[]) {
-		if (!wsSlug) return;
-		const count = itemsToArchive.length;
+	// Shared runner for the lane bulk actions (TASK-1672). One bulk call,
+	// then a deltaSync so the view reflects the change. `verb` is the past-
+	// tense word for the toast ("Archived", "Moved", …). Returns the
+	// affected item ids on success (for TASK-1674's undo); [] on failure.
+	async function runBulk(req: BulkItemsRequest, verb: string): Promise<string[]> {
+		if (!wsSlug) return [];
 		try {
-			for (const item of itemsToArchive) {
-				await api.items.delete(wsSlug, item.id);
-			}
-			// Server-side delete succeeded; pull the soft-delete
-			// tombstones into the local index. Gate the success
-			// toast on a successful deltaSync so the user sees the
-			// rows actually disappear from the view (Codex P3 round 2
-			// of TASK-1357). On deltaSync failure the deletes are
-			// still real server-side — SSE catches the cache up — but
-			// we surface a softer "queued" message so the user knows
-			// the UI hasn't reflected it yet.
-			const ok = await deltaSync(wsSlug);
-			if (ok) {
-				toastStore.show(`Archived ${count} item${count !== 1 ? 's' : ''}`, 'success');
+			const res = await api.items.bulk(wsSlug, req);
+			// Pull the change into the local index so rows update/disappear.
+			// On deltaSync failure the mutation is still real server-side
+			// (SSE catches the cache up) — soften the toast so the user
+			// knows the UI hasn't reflected it yet (matches the old
+			// archive flow, Codex P3 round 2 of TASK-1357).
+			const synced = await deltaSync(wsSlug);
+			const ok = res.updated.length;
+			const failed = res.failed.length;
+			if (failed > 0) {
+				toastStore.show(
+					`${verb} ${ok} item${ok !== 1 ? 's' : ''}, ${failed} failed`,
+					ok > 0 ? 'success' : 'error'
+				);
 			} else {
 				toastStore.show(
-					`Archived ${count} item${count !== 1 ? 's' : ''} (updating…)`,
-					'success',
+					`${verb} ${ok} item${ok !== 1 ? 's' : ''}${synced ? '' : ' (updating…)'}`,
+					'success'
 				);
 			}
-		} catch {
-			toastStore.show('Failed to archive some items', 'error');
+			return res.updated.map((u) => u.id);
+		} catch (e: any) {
+			toastStore.show(e?.message || `Failed to ${verb.toLowerCase()} items`, 'error');
+			return [];
 		}
+	}
+
+	const idsOf = (items: Item[]) => items.map((i) => i.id);
+
+	function handleBulkArchive(items: Item[]) {
+		return runBulk({ op: 'archive', ids: idsOf(items) }, 'Archived');
+	}
+	function handleBulkMove(items: Item[], status: string) {
+		return runBulk({ op: 'move', ids: idsOf(items), status }, 'Moved');
+	}
+	function handleBulkTag(items: Item[], tag: string) {
+		return runBulk({ op: 'tag', ids: idsOf(items), tags: [tag] }, 'Tagged');
+	}
+	function handleBulkUntag(items: Item[], tag: string) {
+		return runBulk({ op: 'untag', ids: idsOf(items), tags: [tag] }, 'Untagged');
+	}
+	function handleBulkSetPriority(items: Item[], priority: string) {
+		return runBulk({ op: 'set-priority', ids: idsOf(items), priority }, 'Updated');
+	}
+	function handleBulkAssign(items: Item[], userId: string) {
+		return runBulk({ op: 'assign', ids: idsOf(items), assigned_user_id: userId }, 'Assigned');
 	}
 
 	async function handleRestore(item: Item) {
@@ -1837,10 +1867,18 @@
 				{focusedItemId}
 				onStatusChange={handleStatusChange}
 				onReorder={handleReorder}
-				onArchiveColumn={handleBulkArchive}
+				onArchiveColumn={canEditThisCollection ? handleBulkArchive : undefined}
 				onGroupReorder={handleGroupReorder}
 				oncreate={canEditThisCollection ? openQuickCreate : undefined}
 				onCreateInColumn={canEditThisCollection ? quickCreateInColumn : undefined}
+				onMoveColumn={canEditThisCollection ? handleBulkMove : undefined}
+				onTagColumn={canEditThisCollection ? handleBulkTag : undefined}
+				onUntagColumn={canEditThisCollection ? handleBulkUntag : undefined}
+				onSetPriorityColumn={canEditThisCollection ? handleBulkSetPriority : undefined}
+				onAssignColumn={canEditThisCollection ? handleBulkAssign : undefined}
+				members={workspaceMembers}
+				{tagSuggestions}
+				filtered={hasActiveFilters}
 				{itemProgress}
 				{progressLabel}
 				canEdit={canEditThisCollection}

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -184,6 +184,13 @@
 	let canEditThisCollection = $derived(
 		collection ? workspaceStore.canEditCollection(collection.id) : false
 	);
+	// The bulk endpoint (TASK-1668) gates on workspace owner/editor role —
+	// it is NOT grant-aware like single-item CRUD. So the lane BULK actions
+	// (move/tag/untag/set-priority/assign/archive-all) are gated on role
+	// here, not canEditThisCollection, or a collection-edit-grant guest
+	// would see them and get a 403 per click (TASK-1672 / Codex round 3).
+	// The single `+` create stays on canEditThisCollection (grant-aware).
+	let canBulkEdit = $derived(['owner', 'editor'].includes(workspaceStore.currentRole ?? ''));
 
 	// Persist view mode to localStorage per collection
 	function saveViewMode(mode: ViewMode) {
@@ -1886,15 +1893,15 @@
 				{focusedItemId}
 				onStatusChange={handleStatusChange}
 				onReorder={handleReorder}
-				onArchiveColumn={canEditThisCollection ? handleBulkArchive : undefined}
+				onArchiveColumn={canBulkEdit ? handleBulkArchive : undefined}
 				onGroupReorder={handleGroupReorder}
 				oncreate={canEditThisCollection ? openQuickCreate : undefined}
 				onCreateInColumn={canEditThisCollection ? quickCreateInColumn : undefined}
-				onMoveColumn={canEditThisCollection ? handleBulkMove : undefined}
-				onTagColumn={canEditThisCollection ? handleBulkTag : undefined}
-				onUntagColumn={canEditThisCollection ? handleBulkUntag : undefined}
-				onSetPriorityColumn={canEditThisCollection ? handleBulkSetPriority : undefined}
-				onAssignColumn={canEditThisCollection ? handleBulkAssign : undefined}
+				onMoveColumn={canBulkEdit ? handleBulkMove : undefined}
+				onTagColumn={canBulkEdit ? handleBulkTag : undefined}
+				onUntagColumn={canBulkEdit ? handleBulkUntag : undefined}
+				onSetPriorityColumn={canBulkEdit ? handleBulkSetPriority : undefined}
+				onAssignColumn={canBulkEdit ? handleBulkAssign : undefined}
 				members={workspaceMembers}
 				{tagSuggestions}
 				filtered={hasActiveFilters}
@@ -1924,7 +1931,7 @@
 				{statusOptions}
 				onStatusChange={handleStatusChange}
 				onReorder={handleReorder}
-				onArchiveGroup={handleBulkArchive}
+				onArchiveGroup={canBulkEdit ? handleBulkArchive : undefined}
 				onGroupReorder={handleGroupReorder}
 				oncreate={canEditThisCollection ? openQuickCreate : undefined}
 				{itemProgress}

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -1174,30 +1174,35 @@
 	async function runBulk(req: BulkItemsRequest, verb: string): Promise<string[]> {
 		if (!wsSlug || req.ids.length === 0) return [];
 		const okIds: string[] = [];
-		let failed = 0;
-		try {
-			for (let i = 0; i < req.ids.length; i += BULK_CHUNK) {
-				const chunk = req.ids.slice(i, i + BULK_CHUNK);
+		let errMsg = '';
+		// A thrown chunk (network / auth / 4xx) stops further chunks but
+		// must NOT skip finalization: earlier chunks may already have
+		// mutated up to 1000+ items server-side, so we still deltaSync and
+		// report the partial result rather than leaving the UI stale behind
+		// a generic error. Codex round 2.
+		for (let i = 0; i < req.ids.length; i += BULK_CHUNK) {
+			const chunk = req.ids.slice(i, i + BULK_CHUNK);
+			try {
 				const res = await api.items.bulk(wsSlug, { ...req, ids: chunk });
 				for (const u of res.updated) okIds.push(u.id);
-				failed += res.failed.length;
+			} catch (e: any) {
+				errMsg = e?.message || '';
+				break;
 			}
-		} catch (e: any) {
-			toastStore.show(e?.message || `Failed to ${verb.toLowerCase()} items`, 'error');
-			return okIds;
 		}
-		// Pull the change into the local index so rows update/disappear.
-		// On deltaSync failure the mutation is still real server-side (SSE
-		// catches the cache up) — soften the toast so the user knows the UI
-		// hasn't reflected it yet (matches the old archive flow, Codex P3
-		// round 2 of TASK-1357).
-		const synced = await deltaSync(wsSlug);
 		const ok = okIds.length;
-		if (failed > 0) {
-			toastStore.show(
-				`${verb} ${ok} item${ok !== 1 ? 's' : ''}, ${failed} failed`,
-				ok > 0 ? 'success' : 'error'
-			);
+		// Everything not in okIds — per-row rejections AND items in an
+		// un-attempted chunk after a throw — is a failure for the toast.
+		const failed = req.ids.length - ok;
+		// Sync so the succeeded rows update/disappear. On deltaSync failure
+		// the mutation is still real server-side (SSE catches the cache up)
+		// — soften the toast (matches the old archive flow, Codex P3 round 2
+		// of TASK-1357).
+		const synced = ok > 0 ? await deltaSync(wsSlug) : true;
+		if (ok === 0) {
+			toastStore.show(errMsg || `Failed to ${verb.toLowerCase()} items`, 'error');
+		} else if (failed > 0) {
+			toastStore.show(`${verb} ${ok} item${ok !== 1 ? 's' : ''}, ${failed} failed`, 'success');
 		} else {
 			toastStore.show(
 				`${verb} ${ok} item${ok !== 1 ? 's' : ''}${synced ? '' : ' (updating…)'}`,

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -1159,38 +1159,52 @@
 		});
 	}
 
-	// Shared runner for the lane bulk actions (TASK-1672). One bulk call,
-	// then a deltaSync so the view reflects the change. `verb` is the past-
-	// tense word for the toast ("Archived", "Moved", …). Returns the
-	// affected item ids on success (for TASK-1674's undo); [] on failure.
+	// The server's bulk endpoint caps a single request at 1000 ids
+	// (maxBulkItems). The old per-item archive loop had no ceiling, so
+	// chunk to keep very large filtered lanes working — one bulk call per
+	// chunk (a few SSE events instead of thousands; still far better than
+	// per-item). TASK-1672 / Codex round 1.
+	const BULK_CHUNK = 1000;
+
+	// Shared runner for the lane bulk actions (TASK-1672). Chunks ids,
+	// deltaSyncs so the view reflects the change, and toasts the aggregate
+	// updated/failed counts. `verb` is the past-tense toast word
+	// ("Archived", "Moved", …). Returns the affected item ids on success
+	// (for TASK-1674's undo); [] when nothing succeeded.
 	async function runBulk(req: BulkItemsRequest, verb: string): Promise<string[]> {
-		if (!wsSlug) return [];
+		if (!wsSlug || req.ids.length === 0) return [];
+		const okIds: string[] = [];
+		let failed = 0;
 		try {
-			const res = await api.items.bulk(wsSlug, req);
-			// Pull the change into the local index so rows update/disappear.
-			// On deltaSync failure the mutation is still real server-side
-			// (SSE catches the cache up) — soften the toast so the user
-			// knows the UI hasn't reflected it yet (matches the old
-			// archive flow, Codex P3 round 2 of TASK-1357).
-			const synced = await deltaSync(wsSlug);
-			const ok = res.updated.length;
-			const failed = res.failed.length;
-			if (failed > 0) {
-				toastStore.show(
-					`${verb} ${ok} item${ok !== 1 ? 's' : ''}, ${failed} failed`,
-					ok > 0 ? 'success' : 'error'
-				);
-			} else {
-				toastStore.show(
-					`${verb} ${ok} item${ok !== 1 ? 's' : ''}${synced ? '' : ' (updating…)'}`,
-					'success'
-				);
+			for (let i = 0; i < req.ids.length; i += BULK_CHUNK) {
+				const chunk = req.ids.slice(i, i + BULK_CHUNK);
+				const res = await api.items.bulk(wsSlug, { ...req, ids: chunk });
+				for (const u of res.updated) okIds.push(u.id);
+				failed += res.failed.length;
 			}
-			return res.updated.map((u) => u.id);
 		} catch (e: any) {
 			toastStore.show(e?.message || `Failed to ${verb.toLowerCase()} items`, 'error');
-			return [];
+			return okIds;
 		}
+		// Pull the change into the local index so rows update/disappear.
+		// On deltaSync failure the mutation is still real server-side (SSE
+		// catches the cache up) — soften the toast so the user knows the UI
+		// hasn't reflected it yet (matches the old archive flow, Codex P3
+		// round 2 of TASK-1357).
+		const synced = await deltaSync(wsSlug);
+		const ok = okIds.length;
+		if (failed > 0) {
+			toastStore.show(
+				`${verb} ${ok} item${ok !== 1 ? 's' : ''}, ${failed} failed`,
+				ok > 0 ? 'success' : 'error'
+			);
+		} else {
+			toastStore.show(
+				`${verb} ${ok} item${ok !== 1 ? 's' : ''}${synced ? '' : ' (updating…)'}`,
+				'success'
+			);
+		}
+		return okIds;
 	}
 
 	const idsOf = (items: Item[]) => items.map((i) => i.id);


### PR DESCRIPTION
## Summary
Populates the lane kebab menu (shell from TASK-1671) with the full bulk mutation set, each operating on the lane's **currently-filtered** items via `api.items.bulk` (TASK-1669 client → TASK-1668 endpoint).

Extracts **`LaneActionsMenu.svelte`** — an in-place **drill-down** menu (clicking "Set priority ▸" swaps the panel to the options with a back arrow; mobile-friendly, no flyouts):
- **Archive all** — count + "(filtered)" in the confirm
- **Move all to ▸** — other status lanes (status-grouped boards only; the bulk `move` op sets `status`)
- **Tag all ▸** — free-text input + workspace tag suggestions
- **Untag all ▸** — only tags present on the lane's items
- **Set priority ▸** — the priority field's options
- **Assign all ▸** — workspace members by name

Page handlers funnel through a shared `runBulk()` (one bulk call → `deltaSync` → toast of updated/failed counts); it returns the affected ids for **TASK-1674's** undo. `BoardView` threads the lane's items + member/tag data + callbacks into the menu; the inline menu markup/styles from TASK-1671 move into the component.

## Decisions (confirmed with maintainer)
- **Move scope = status/lane only** (cross-collection is a follow-up)
- **Assign = workspace members only** (agent-role assignment is a follow-up)
- All actions `canEdit`-gated; drill-down clicks `stopPropagation` (Svelte 5 same-click detach fix from TASK-1671)

## Follow-ups in this plan
- Confirm + **undo toast** for destructive actions → TASK-1674 (next)
- Per-lane sort override in this same menu → TASK-1673

## Test plan
- [x] `npm run check` — 0 errors, no new warnings
- [x] Svelte autofixer on LaneActionsMenu — no issues
- [x] `npm run build` — clean
- [ ] Manual: each action mutates the filtered lane; labels show count/(filtered); Move hidden on non-status boards; menu drill-down + back; canEdit-gated