### PR TITLE
feat(api): bulk restore op for undo (TASK-1674 backend)

### DIFF
--- a/internal/server/handlers_items_bulk.go
+++ b/internal/server/handlers_items_bulk.go
@@ -126,6 +126,7 @@ func (s *Server) handleBulkItems(w http.ResponseWriter, r *http.Request) {
 	// request fails fast before touching any rows.
 	switch req.Op {
 	case "archive":
+	case "restore":
 	case "move":
 		if req.Status == "" && req.Collection == "" {
 			writeError(w, http.StatusBadRequest, "bad_request", "move requires status or collection")
@@ -186,7 +187,15 @@ func (s *Server) handleBulkItems(w http.ResponseWriter, r *http.Request) {
 	batches := map[string]*collBatch{}
 
 	for _, ref := range req.IDs {
-		item, err := s.store.ResolveItem(workspaceID, ref)
+		// `restore` operates on ARCHIVED items, which ResolveItem hides —
+		// resolve include-deleted for that op (used by undo, TASK-1674).
+		var item *models.Item
+		var err error
+		if req.Op == "restore" {
+			item, err = s.store.ResolveItemIncludeDeleted(workspaceID, ref)
+		} else {
+			item, err = s.store.ResolveItem(workspaceID, ref)
+		}
 		if err != nil {
 			resp.Failed = append(resp.Failed, bulkItemFailure{Ref: ref, Error: err.Error()})
 			continue
@@ -231,6 +240,8 @@ func (s *Server) handleBulkItems(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case req.Op == "archive":
 			action = "archived"
+		case req.Op == "restore":
+			action = "restored"
 		case req.Op == "move" && req.Collection != "" && req.Collection != item.CollectionSlug:
 			action = "moved"
 			meta["from_collection"] = item.CollectionSlug
@@ -308,6 +319,24 @@ func (s *Server) applyBulkOp(r *http.Request, workspaceID string, item *models.I
 			return d, nil
 		}
 		return item, nil
+
+	case "restore":
+		// Undo of a bulk archive (TASK-1674). RestoreItem clears
+		// deleted_at and bumps seq; returns the live row.
+		restored, err := s.store.RestoreItem(item.ID)
+		if err != nil {
+			if err == sql.ErrNoRows {
+				return nil, &bulkOpError{message: "item not found or not archived"}
+			}
+			if strings.Contains(err.Error(), "UNIQUE constraint") || strings.Contains(err.Error(), "duplicate key") {
+				return nil, &bulkOpError{
+					message: "cannot restore: another item has claimed this slug or invocation slug",
+					code:    "conflict",
+				}
+			}
+			return nil, &bulkOpError{message: err.Error()}
+		}
+		return restored, nil
 
 	case "move":
 		if req.Collection != "" {

--- a/internal/server/handlers_items_bulk_test.go
+++ b/internal/server/handlers_items_bulk_test.go
@@ -168,6 +168,50 @@ func TestBulkItems_Archive(t *testing.T) {
 	}
 }
 
+// TestBulkItems_Restore covers the undo path (TASK-1674): a bulk archive
+// followed by a bulk restore brings the items back, resolving the
+// archived (soft-deleted) rows that ResolveItem normally hides.
+func TestBulkItems_Restore(t *testing.T) {
+	srv := testServer(t)
+	ws := createWSWithCollections(t, srv)
+
+	a := createBulkTestItem(t, srv, ws, "A", `{"status":"open"}`)
+	b := createBulkTestItem(t, srv, ws, "B", `{"status":"open"}`)
+
+	// Archive both.
+	rr := doRequest(srv, "POST", "/api/v1/workspaces/"+ws+"/items/bulk", map[string]any{
+		"ids": []string{a.Ref, b.Ref}, "op": "archive",
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("bulk archive: %d: %s", rr.Code, rr.Body.String())
+	}
+	rr = doRequest(srv, "GET", "/api/v1/workspaces/"+ws+"/items", nil)
+	var items []models.Item
+	parseJSON(t, rr, &items)
+	if len(items) != 0 {
+		t.Fatalf("expected 0 live items after archive, got %d", len(items))
+	}
+
+	// Restore by id (the bulk response / undo passes ids).
+	rr = doRequest(srv, "POST", "/api/v1/workspaces/"+ws+"/items/bulk", map[string]any{
+		"ids": []string{a.ID, b.ID}, "op": "restore",
+	})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("bulk restore: %d: %s", rr.Code, rr.Body.String())
+	}
+	var resp bulkItemsResponse
+	parseJSON(t, rr, &resp)
+	if len(resp.Updated) != 2 || len(resp.Failed) != 0 {
+		t.Fatalf("expected 2 restored / 0 failed, got %+v", resp)
+	}
+
+	rr = doRequest(srv, "GET", "/api/v1/workspaces/"+ws+"/items", nil)
+	parseJSON(t, rr, &items)
+	if len(items) != 2 {
+		t.Errorf("expected 2 live items after restore, got %d", len(items))
+	}
+}
+
 func TestBulkItems_PartialFailure(t *testing.T) {
 	srv := testServer(t)
 	ws := createWSWithCollections(t, srv)

--- a/internal/store/items.go
+++ b/internal/store/items.go
@@ -482,6 +482,17 @@ func isUUID(s string) bool {
 
 // ResolveItemIncludeDeleted is like ResolveItem but includes soft-deleted items.
 func (s *Store) ResolveItemIncludeDeleted(workspaceID, slugOrRef string) (*models.Item, error) {
+	// UUID lookup first, mirroring ResolveItem — but include-deleted so a
+	// bulk restore (TASK-1674) can resolve archived rows by id.
+	if isUUID(slugOrRef) {
+		item, err := s.GetItemIncludeDeleted(slugOrRef)
+		if err != nil {
+			return nil, err
+		}
+		if item != nil && item.WorkspaceID == workspaceID {
+			return item, nil
+		}
+	}
 	if prefix, number, ok := parseItemRef(slugOrRef); ok {
 		var item models.Item
 		var createdAt, updatedAt string

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -590,6 +590,7 @@ export interface ItemUpdate {
 // event per affected collection + one webhook instead of per-item fan-out.
 export type BulkItemOp =
 	| 'archive'
+	| 'restore'
 	| 'move'
 	| 'tag'
 	| 'untag'
@@ -604,6 +605,7 @@ export type BulkItemOp =
 // at-least-one rule.
 export type BulkItemsRequest =
 	| { op: 'archive'; ids: string[]; force?: boolean }
+	| { op: 'restore'; ids: string[] }
 	| {
 			op: 'move';
 			ids: string[];


### PR DESCRIPTION
## Summary
Backend half of TASK-1674: a `restore` verb on the bulk endpoint so undoing a bulk archive is a single call (the chosen undo approach).

- Loop resolves **include-deleted** for `restore` (archived rows are hidden from `ResolveItem`); `applyBulkOp` calls `store.RestoreItem`, maps UNIQUE-constraint races → `conflict` and `sql.ErrNoRows` → not-found, and logs `action="restored"`.
- `ResolveItemIncludeDeleted` is now **UUID-aware** (mirrors `ResolveItem`) so restore resolves by the ids the bulk response returns.
- Adds `restore` to the TS `BulkItemOp` / `BulkItemsRequest` union.

The frontend undo toast (toast action-button support + wiring on archive/move) follows in the TASK-1674 frontend PR.

## Test plan
- [x] `go build`/`vet`/`test ./...` — pass (new `TestBulkItems_Restore`: archive → restore round-trip by id)
- [x] `npm run check` — 0 errors (type union updated)