### PR TITLE
feat(board): confirm + undo toast for destructive bulk actions (TASK-1674)

### DIFF
--- a/web/src/lib/components/common/ToastContainer.svelte
+++ b/web/src/lib/components/common/ToastContainer.svelte
@@ -36,6 +36,12 @@
 			>
 				<span class="toast-icon">{iconForType(toast.type)}</span>
 				<span class="toast-message">{toast.message}{#if toast.link}<span class="toast-link-hint"> →</span>{/if}</span>
+				{#if toast.action}
+					<button
+						class="toast-action"
+						onclick={(e) => { e.stopPropagation(); toast.action?.onAction(); toastStore.dismiss(toast.id); }}
+					>{toast.action.label}</button>
+				{/if}
 				<button
 					class="toast-dismiss"
 					onclick={(e) => { e.stopPropagation(); toastStore.dismiss(toast.id); }}
@@ -119,6 +125,21 @@
 		flex: 1;
 		min-width: 0;
 		line-height: 1.4;
+	}
+
+	.toast-action {
+		flex-shrink: 0;
+		padding: 4px 10px;
+		border-radius: var(--radius-sm);
+		border: 1px solid var(--accent-blue);
+		background: none;
+		color: var(--accent-blue);
+		font-size: 0.9em;
+		font-weight: 600;
+		cursor: pointer;
+	}
+	.toast-action:hover {
+		background: color-mix(in srgb, var(--accent-blue) 12%, transparent);
 	}
 
 	.toast-dismiss {

--- a/web/src/lib/stores/toast.svelte.ts
+++ b/web/src/lib/stores/toast.svelte.ts
@@ -1,9 +1,18 @@
+export interface ToastAction {
+	label: string;
+	onAction: () => void;
+}
+
 export interface Toast {
 	id: string;
 	message: string;
 	type: 'success' | 'error' | 'info';
 	duration: number;
 	link?: string;
+	// Optional inline action button (e.g. "Undo" on a bulk archive,
+	// TASK-1674). Distinct from `link`, which navigates. Not persisted to
+	// history — the callback is only meaningful while the toast is live.
+	action?: ToastAction;
 }
 
 export interface HistoryEntry {
@@ -27,9 +36,9 @@ function generateId(): string {
 	return Date.now().toString(36) + Math.random().toString(36).slice(2, 7);
 }
 
-function show(message: string, type: Toast['type'] = 'info', duration: number = DEFAULT_DURATION, link?: string): string {
+function show(message: string, type: Toast['type'] = 'info', duration: number = DEFAULT_DURATION, link?: string, action?: ToastAction): string {
 	const id = generateId();
-	const toast: Toast = { id, message, type, duration, link };
+	const toast: Toast = { id, message, type, duration, link, action };
 
 	toasts.push(toast);
 

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -1173,12 +1173,21 @@
 	// per-item). TASK-1672 / Codex round 1.
 	const BULK_CHUNK = 1000;
 
+	// Longer dwell for toasts carrying an Undo so the user can react
+	// (TASK-1674).
+	const UNDO_TOAST_MS = 7000;
+
 	// Shared runner for the lane bulk actions (TASK-1672). Chunks ids,
 	// deltaSyncs so the view reflects the change, and toasts the aggregate
 	// updated/failed counts. `verb` is the past-tense toast word
-	// ("Archived", "Moved", …). Returns the affected item ids on success
-	// (for TASK-1674's undo); [] when nothing succeeded.
-	async function runBulk(req: BulkItemsRequest, verb: string): Promise<string[]> {
+	// ("Archived", "Moved", …). `opts.undo` (TASK-1674) adds an Undo button
+	// to the success toast, invoked with the affected ids. Returns the
+	// affected item ids on success; [] when nothing succeeded.
+	async function runBulk(
+		req: BulkItemsRequest,
+		verb: string,
+		opts?: { undo?: (okIds: string[]) => void }
+	): Promise<string[]> {
 		if (!wsSlug || req.ids.length === 0) return [];
 		const okIds: string[] = [];
 		let errMsg = '';
@@ -1206,14 +1215,30 @@
 		// — soften the toast (matches the old archive flow, Codex P3 round 2
 		// of TASK-1357).
 		const synced = ok > 0 ? await deltaSync(wsSlug) : true;
+		// Attach an Undo button only when the action succeeded and the
+		// caller supplied an undo (archive / move — the destructive ops).
+		const undoAction =
+			ok > 0 && opts?.undo
+				? { label: 'Undo', onAction: () => opts.undo?.(okIds) }
+				: undefined;
+		const dwell = undoAction ? UNDO_TOAST_MS : undefined;
 		if (ok === 0) {
 			toastStore.show(errMsg || `Failed to ${verb.toLowerCase()} items`, 'error');
 		} else if (failed > 0) {
-			toastStore.show(`${verb} ${ok} item${ok !== 1 ? 's' : ''}, ${failed} failed`, 'success');
+			toastStore.show(
+				`${verb} ${ok} item${ok !== 1 ? 's' : ''}, ${failed} failed`,
+				'success',
+				dwell,
+				undefined,
+				undoAction
+			);
 		} else {
 			toastStore.show(
 				`${verb} ${ok} item${ok !== 1 ? 's' : ''}${synced ? '' : ' (updating…)'}`,
-				'success'
+				'success',
+				dwell,
+				undefined,
+				undoAction
 			);
 		}
 		return okIds;
@@ -1221,11 +1246,22 @@
 
 	const idsOf = (items: Item[]) => items.map((i) => i.id);
 
+	// Destructive bulk actions (archive / move) carry an Undo (TASK-1674):
+	// archive undoes via the bulk `restore` op; move undoes by moving the
+	// items back to their source lane (they all shared the lane's status).
 	function handleBulkArchive(items: Item[]) {
-		return runBulk({ op: 'archive', ids: idsOf(items) }, 'Archived');
+		return runBulk({ op: 'archive', ids: idsOf(items) }, 'Archived', {
+			undo: (okIds) => runBulk({ op: 'restore', ids: okIds }, 'Restored')
+		});
 	}
 	function handleBulkMove(items: Item[], status: string) {
-		return runBulk({ op: 'move', ids: idsOf(items), status }, 'Moved');
+		// All lane items shared the lane's status; undo moves them back.
+		const sourceStatus = items.length ? String(parseFields(items[0]).status ?? '') : '';
+		return runBulk({ op: 'move', ids: idsOf(items), status }, 'Moved', {
+			undo: sourceStatus
+				? (okIds) => runBulk({ op: 'move', ids: okIds, status: sourceStatus }, 'Moved back')
+				: undefined
+		});
 	}
 	function handleBulkTag(items: Item[], tag: string) {
 		return runBulk({ op: 'tag', ids: idsOf(items), tags: [tag] }, 'Tagged');

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -1183,12 +1183,17 @@
 	// ("Archived", "Moved", …). `opts.undo` (TASK-1674) adds an Undo button
 	// to the success toast, invoked with the affected ids. Returns the
 	// affected item ids on success; [] when nothing succeeded.
-	async function runBulk(
+	// `ws` is captured by the caller at action time, NOT read live —
+	// the undo toast lives 7s and is global, so navigating to another
+	// workspace before clicking Undo must still target the workspace the
+	// original action ran on (Codex round 1 of TASK-1674).
+	async function runBulkOn(
+		ws: string,
 		req: BulkItemsRequest,
 		verb: string,
 		opts?: { undo?: (okIds: string[]) => void }
 	): Promise<string[]> {
-		if (!wsSlug || req.ids.length === 0) return [];
+		if (!ws || req.ids.length === 0) return [];
 		const okIds: string[] = [];
 		let errMsg = '';
 		// A thrown chunk (network / auth / 4xx) stops further chunks but
@@ -1199,7 +1204,7 @@
 		for (let i = 0; i < req.ids.length; i += BULK_CHUNK) {
 			const chunk = req.ids.slice(i, i + BULK_CHUNK);
 			try {
-				const res = await api.items.bulk(wsSlug, { ...req, ids: chunk });
+				const res = await api.items.bulk(ws, { ...req, ids: chunk });
 				for (const u of res.updated) okIds.push(u.id);
 			} catch (e: any) {
 				errMsg = e?.message || '';
@@ -1214,7 +1219,7 @@
 		// the mutation is still real server-side (SSE catches the cache up)
 		// — soften the toast (matches the old archive flow, Codex P3 round 2
 		// of TASK-1357).
-		const synced = ok > 0 ? await deltaSync(wsSlug) : true;
+		const synced = ok > 0 ? await deltaSync(ws) : true;
 		// Attach an Undo button only when the action succeeded and the
 		// caller supplied an undo (archive / move — the destructive ops).
 		const undoAction =
@@ -1244,22 +1249,36 @@
 		return okIds;
 	}
 
+	// Convenience for the non-deferred actions: bind to the live workspace
+	// at call time (these complete immediately, no cross-workspace race).
+	function runBulk(
+		req: BulkItemsRequest,
+		verb: string,
+		opts?: { undo?: (okIds: string[]) => void }
+	): Promise<string[]> {
+		return runBulkOn(wsSlug, req, verb, opts);
+	}
+
 	const idsOf = (items: Item[]) => items.map((i) => i.id);
 
 	// Destructive bulk actions (archive / move) carry an Undo (TASK-1674):
 	// archive undoes via the bulk `restore` op; move undoes by moving the
 	// items back to their source lane (they all shared the lane's status).
+	// Both capture `ws` so a deferred Undo targets the original workspace
+	// even after the user navigates away (Codex round 1).
 	function handleBulkArchive(items: Item[]) {
-		return runBulk({ op: 'archive', ids: idsOf(items) }, 'Archived', {
-			undo: (okIds) => runBulk({ op: 'restore', ids: okIds }, 'Restored')
+		const ws = wsSlug;
+		return runBulkOn(ws, { op: 'archive', ids: idsOf(items) }, 'Archived', {
+			undo: (okIds) => runBulkOn(ws, { op: 'restore', ids: okIds }, 'Restored')
 		});
 	}
 	function handleBulkMove(items: Item[], status: string) {
+		const ws = wsSlug;
 		// All lane items shared the lane's status; undo moves them back.
 		const sourceStatus = items.length ? String(parseFields(items[0]).status ?? '') : '';
-		return runBulk({ op: 'move', ids: idsOf(items), status }, 'Moved', {
+		return runBulkOn(ws, { op: 'move', ids: idsOf(items), status }, 'Moved', {
 			undo: sourceStatus
-				? (okIds) => runBulk({ op: 'move', ids: okIds, status: sourceStatus }, 'Moved back')
+				? (okIds) => runBulkOn(ws, { op: 'move', ids: okIds, status: sourceStatus }, 'Moved back')
 				: undefined
 		});
 	}


### PR DESCRIPTION
## Summary
Frontend half of TASK-1674 (backend `restore` op merged in #675). Adds an **Undo** affordance to the destructive bulk lane actions.

- **Toast store**: optional inline `action` button (`{ label, onAction }`), rendered in `ToastContainer` next to the dismiss `×` (distinct from `link`, which navigates; not persisted to history).
- **Undo wiring** (`runBulk` gains an optional `undo` callback invoked with the affected ids; undo-bearing toasts get a 7s dwell):
  - **Archive all** → "Archived N" with **Undo** → bulk `restore` of the affected ids.
  - **Move all to** → "Moved N" with **Undo** → bulk move back to the source lane (all lane items shared its status).

Archive keeps its in-menu count confirm (TASK-1672); the undo toast is the safety affordance "replacing the single-item inline confirm" called for in the task. Tag/Untag/Set-priority/Assign are non-destructive — no undo.

## Test plan
- [x] `npm run check` — 0 errors, no new warnings
- [x] `npm run build` — clean
- [ ] Manual: archive a lane → Undo restores it; move a lane → Undo moves it back; toast dwells ~7s; non-destructive actions show no Undo