### PR TITLE
feat(board): Trello-style inline draft card creation (TASK-1676)

### DIFF
--- a/web/src/lib/components/collections/BoardView.svelte
+++ b/web/src/lib/components/collections/BoardView.svelte
@@ -7,7 +7,6 @@
 	import ItemCard from './ItemCard.svelte';
 	import EmptyState from '../common/EmptyState.svelte';
 	import LaneActionsMenu from './LaneActionsMenu.svelte';
-	import { beforeNavigate, goto } from '$app/navigation';
 
 
 	interface Props {
@@ -29,6 +28,15 @@
 		 * Gated behind `canEdit`. When wired, the `+`/menu open a draft.
 		 */
 		onCreateInColumn?: (groupValue: string, title: string, navigate: boolean) => Promise<unknown> | void;
+		/**
+		 * Inline draft state (TASK-1676) — owned by the page (which holds
+		 * the leave guard + dialog) so a draft survives a board↔list view
+		 * switch that unmounts this component. Keyed by lane value:
+		 * `draftText` is the in-progress title, `draftOpen` the card
+		 * visibility. Bound.
+		 */
+		draftText?: Record<string, string>;
+		draftOpen?: Record<string, boolean>;
 		/**
 		 * Bulk lane actions (TASK-1672), each operating on the lane's
 		 * CURRENTLY-FILTERED items via the bulk endpoint. Surfaced in the
@@ -70,7 +78,10 @@
 		sortMode?: SortMode;
 	}
 
-	let { items, collection, wsSlug = '', groupField = 'status', focusedItemId = null, onStatusChange, onReorder, onArchiveColumn, onGroupReorder, oncreate, onCreateInColumn, onMoveColumn, onTagColumn, onUntagColumn, onSetPriorityColumn, onAssignColumn, members = [], tagSuggestions = [], filtered = false, itemProgress, progressLabel = 'tasks', canEdit = true, preserveOrder = false, sortMode = 'manual' }: Props = $props();
+	let { items, collection, wsSlug = '', groupField = 'status', focusedItemId = null, onStatusChange, onReorder, onArchiveColumn, onGroupReorder, oncreate, onCreateInColumn, onMoveColumn, onTagColumn, onUntagColumn, onSetPriorityColumn, onAssignColumn, members = [], tagSuggestions = [], filtered = false, itemProgress, progressLabel = 'tasks', canEdit = true, preserveOrder = false, sortMode = 'manual', draftText = $bindable({}), draftOpen = $bindable({}) }: Props = $props();
+
+	// Local — disables the draft card while its Enter-create is in flight.
+	let savingDraft = $state(false);
 
 	// Which lane's ⋯ menu is open (null = none). One menu open at a time;
 	// the LaneActionsMenu component owns the drill-down + confirm state.
@@ -100,17 +111,11 @@
 
 	// ── Inline draft cards (TASK-1676) ──────────────────────────────────
 	// Trello/GitHub-style: the `+` opens an editable draft card in the
-	// lane; no item exists until Enter. `draftText` retains content per
-	// lane until reload (even after Escape hides the card); `draftOpen`
-	// controls visibility. Blur keeps the card but doesn't save.
-	let draftText = $state<Record<string, string>>({});
-	let draftOpen = $state<Record<string, boolean>>({});
+	// lane; no item exists until Enter. The draft STATE lives on the page
+	// (bound here) so it survives a board↔list view switch (which unmounts
+	// this component) — the page also owns the leave guard + dialog. Blur
+	// keeps the card; Escape hides it but retains text (page state).
 	let draftInputs: Record<string, HTMLTextAreaElement | undefined> = {};
-	let savingDraft = $state(false);
-
-	let hasUnsavedDrafts = $derived(
-		Object.values(draftText).some((t) => t.trim().length > 0)
-	);
 
 	function openDraft(col: string) {
 		if (!onCreateInColumn) return;
@@ -127,8 +132,8 @@
 		const title = (draftText[col] ?? '').trim();
 		if (!title || savingDraft || !onCreateInColumn) return;
 		savingDraft = true;
-		// Clear optimistically BEFORE the create navigates, so the nav
-		// guard (which fires when onCreateInColumn opens the new item)
+		// Clear optimistically BEFORE the create navigates, so the page's
+		// leave guard (fires when onCreateInColumn opens the new item)
 		// doesn't re-flag this lane.
 		const prior = draftText[col];
 		delete draftText[col];
@@ -142,64 +147,6 @@
 		} finally {
 			savingDraft = false;
 		}
-	}
-
-	// ── Leave guard: prompt to save/discard unsaved drafts (in-app nav) ──
-	let pendingNavUrl = $state<URL | null>(null);
-	let showLeaveDialog = $state(false);
-	let bypassGuard = false;
-
-	beforeNavigate((nav) => {
-		// Only guard in-app navigations with an unsaved draft. `nav.to`
-		// is null for full unload (reload / tab close / external) — the
-		// spec keeps drafts only until reload, so we don't guard those.
-		if (bypassGuard || !hasUnsavedDrafts || !nav.to) return;
-		nav.cancel();
-		pendingNavUrl = nav.to.url;
-		showLeaveDialog = true;
-	});
-
-	function proceedNav() {
-		const url = pendingNavUrl;
-		pendingNavUrl = null;
-		showLeaveDialog = false;
-		if (url) {
-			bypassGuard = true;
-			goto(url).finally(() => {
-				bypassGuard = false;
-			});
-		}
-	}
-
-	async function leaveSaveAll() {
-		if (savingDraft) return;
-		savingDraft = true;
-		try {
-			for (const [col, text] of Object.entries(draftText)) {
-				const title = text.trim();
-				if (title) await onCreateInColumn?.(col, title, false);
-			}
-			draftText = {};
-			draftOpen = {};
-		} catch {
-			// A create failed (page toasted it) — keep the dialog open so
-			// the user can retry or discard rather than navigating away.
-			savingDraft = false;
-			return;
-		}
-		savingDraft = false;
-		proceedNav();
-	}
-
-	function leaveDiscard() {
-		draftText = {};
-		draftOpen = {};
-		proceedNav();
-	}
-
-	function leaveStay() {
-		pendingNavUrl = null;
-		showLeaveDialog = false;
 	}
 
 	// Dismiss the open lane menu on any click outside it (mirrors the
@@ -557,27 +504,6 @@
 </div>
 {/if}
 
-{#if showLeaveDialog}
-	<!-- Leave guard (TASK-1676): an in-app navigation was intercepted
-	     because at least one lane has an unsaved draft. -->
-	<div
-		class="leave-overlay"
-		role="presentation"
-		onclick={(e) => { if (e.target === e.currentTarget) leaveStay(); }}
-		onkeydown={(e) => { if (e.key === 'Escape') leaveStay(); }}
-	>
-		<div class="leave-dialog" role="dialog" aria-modal="true" aria-label="Unsaved card" tabindex="-1">
-			<h3 class="leave-title">Unsaved card</h3>
-			<p class="leave-body">You have an unsaved card. Save it before leaving?</p>
-			<div class="leave-actions">
-				<button class="leave-stay" disabled={savingDraft} onclick={leaveStay}>Stay</button>
-				<button class="leave-discard" disabled={savingDraft} onclick={leaveDiscard}>Discard</button>
-				<button class="leave-save" disabled={savingDraft} onclick={leaveSaveAll}>Save</button>
-			</div>
-		</div>
-	</div>
-{/if}
-
 <style>
 	.board-view {
 		display: flex;
@@ -897,70 +823,4 @@
 		background: var(--bg-hover);
 	}
 
-	/* Leave-guard dialog (TASK-1676). */
-	.leave-overlay {
-		position: fixed;
-		inset: 0;
-		z-index: 1000;
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		background: rgba(0, 0, 0, 0.45);
-		padding: var(--space-4);
-	}
-
-	.leave-dialog {
-		width: 100%;
-		max-width: 360px;
-		padding: var(--space-4);
-		background: var(--bg-primary);
-		border: 1px solid var(--border);
-		border-radius: var(--radius-lg);
-		box-shadow: var(--shadow-lg, 0 10px 30px rgba(0, 0, 0, 0.3));
-	}
-
-	.leave-title {
-		margin: 0 0 var(--space-2);
-		font-size: 1em;
-		color: var(--text-primary);
-	}
-
-	.leave-body {
-		margin: 0 0 var(--space-4);
-		font-size: 0.875em;
-		color: var(--text-secondary);
-	}
-
-	.leave-actions {
-		display: flex;
-		justify-content: flex-end;
-		gap: var(--space-2);
-	}
-
-	.leave-actions button {
-		padding: 6px 14px;
-		border-radius: var(--radius-sm);
-		font-size: 0.8125em;
-		cursor: pointer;
-		border: 1px solid var(--border);
-	}
-	.leave-actions button:disabled {
-		opacity: 0.5;
-		cursor: default;
-	}
-
-	.leave-stay {
-		background: var(--bg-secondary);
-		color: var(--text-primary);
-	}
-	.leave-discard {
-		background: none;
-		border-color: var(--accent-red, #ef4444) !important;
-		color: var(--accent-red, #ef4444);
-	}
-	.leave-save {
-		background: var(--accent-blue);
-		border-color: var(--accent-blue) !important;
-		color: #fff;
-	}
 </style>

--- a/web/src/lib/components/collections/BoardView.svelte
+++ b/web/src/lib/components/collections/BoardView.svelte
@@ -7,6 +7,7 @@
 	import ItemCard from './ItemCard.svelte';
 	import EmptyState from '../common/EmptyState.svelte';
 	import LaneActionsMenu from './LaneActionsMenu.svelte';
+	import { beforeNavigate, goto } from '$app/navigation';
 
 
 	interface Props {
@@ -21,11 +22,13 @@
 		onGroupReorder?: (newOrder: string[]) => void;
 		oncreate?: () => void;
 		/**
-		 * Create an item directly in this lane, pre-filling the lane's
-		 * group field with its column value (folds IDEA-1159). The `+`
-		 * lane-header button calls this. Gated behind `canEdit`.
+		 * Create an item in this lane from the inline draft card
+		 * (TASK-1676), pre-filling the lane's group value. `navigate` true
+		 * (Enter) opens the new item; false (nav-guard Save) just lands it
+		 * in the lane. Throws on failure so the draft can be restored.
+		 * Gated behind `canEdit`. When wired, the `+`/menu open a draft.
 		 */
-		onCreateInColumn?: (groupValue: string) => void;
+		onCreateInColumn?: (groupValue: string, title: string, navigate: boolean) => Promise<unknown> | void;
 		/**
 		 * Bulk lane actions (TASK-1672), each operating on the lane's
 		 * CURRENTLY-FILTERED items via the bulk endpoint. Surfaced in the
@@ -94,6 +97,110 @@
 		}
 	}
 	const laneSortFor = (colValue: string): SortMode => laneSortOverrides[colValue] ?? sortMode;
+
+	// ── Inline draft cards (TASK-1676) ──────────────────────────────────
+	// Trello/GitHub-style: the `+` opens an editable draft card in the
+	// lane; no item exists until Enter. `draftText` retains content per
+	// lane until reload (even after Escape hides the card); `draftOpen`
+	// controls visibility. Blur keeps the card but doesn't save.
+	let draftText = $state<Record<string, string>>({});
+	let draftOpen = $state<Record<string, boolean>>({});
+	let draftInputs: Record<string, HTMLTextAreaElement | undefined> = {};
+	let savingDraft = $state(false);
+
+	let hasUnsavedDrafts = $derived(
+		Object.values(draftText).some((t) => t.trim().length > 0)
+	);
+
+	function openDraft(col: string) {
+		if (!onCreateInColumn) return;
+		draftOpen[col] = true;
+		requestAnimationFrame(() => draftInputs[col]?.focus());
+	}
+
+	// Escape hides the card but KEEPS the text so reopening restores it.
+	function escapeDraft(col: string) {
+		draftOpen[col] = false;
+	}
+
+	async function submitDraft(col: string) {
+		const title = (draftText[col] ?? '').trim();
+		if (!title || savingDraft || !onCreateInColumn) return;
+		savingDraft = true;
+		// Clear optimistically BEFORE the create navigates, so the nav
+		// guard (which fires when onCreateInColumn opens the new item)
+		// doesn't re-flag this lane.
+		const prior = draftText[col];
+		delete draftText[col];
+		draftOpen[col] = false;
+		try {
+			await onCreateInColumn(col, title, true);
+		} catch {
+			// Restore the draft on failure (the page toasts the error).
+			draftText[col] = prior;
+			draftOpen[col] = true;
+		} finally {
+			savingDraft = false;
+		}
+	}
+
+	// ── Leave guard: prompt to save/discard unsaved drafts (in-app nav) ──
+	let pendingNavUrl = $state<URL | null>(null);
+	let showLeaveDialog = $state(false);
+	let bypassGuard = false;
+
+	beforeNavigate((nav) => {
+		// Only guard in-app navigations with an unsaved draft. `nav.to`
+		// is null for full unload (reload / tab close / external) — the
+		// spec keeps drafts only until reload, so we don't guard those.
+		if (bypassGuard || !hasUnsavedDrafts || !nav.to) return;
+		nav.cancel();
+		pendingNavUrl = nav.to.url;
+		showLeaveDialog = true;
+	});
+
+	function proceedNav() {
+		const url = pendingNavUrl;
+		pendingNavUrl = null;
+		showLeaveDialog = false;
+		if (url) {
+			bypassGuard = true;
+			goto(url).finally(() => {
+				bypassGuard = false;
+			});
+		}
+	}
+
+	async function leaveSaveAll() {
+		if (savingDraft) return;
+		savingDraft = true;
+		try {
+			for (const [col, text] of Object.entries(draftText)) {
+				const title = text.trim();
+				if (title) await onCreateInColumn?.(col, title, false);
+			}
+			draftText = {};
+			draftOpen = {};
+		} catch {
+			// A create failed (page toasted it) — keep the dialog open so
+			// the user can retry or discard rather than navigating away.
+			savingDraft = false;
+			return;
+		}
+		savingDraft = false;
+		proceedNav();
+	}
+
+	function leaveDiscard() {
+		draftText = {};
+		draftOpen = {};
+		proceedNav();
+	}
+
+	function leaveStay() {
+		pendingNavUrl = null;
+		showLeaveDialog = false;
+	}
 
 	// Dismiss the open lane menu on any click outside it (mirrors the
 	// QuickActionsMenu pattern). The menu markup lives under
@@ -332,7 +439,7 @@
 							class="lane-btn lane-add-btn"
 							title="Add item to {formatLabel(colValue).toLowerCase()}"
 							aria-label="Add item to {formatLabel(colValue)}"
-							onclick={() => onCreateInColumn?.(colValue)}
+							onclick={() => openDraft(colValue)}
 						>+</button>
 					{/if}
 					<!-- Kebab shows for create OR any non-empty lane (sort is
@@ -360,7 +467,7 @@
 									laneSort={laneSortOverrides[colValue]}
 									onSetLaneSort={(m) => setLaneSort(colValue, m)}
 									onClose={closeMenu}
-									onAddItem={onCreateInColumn ? () => onCreateInColumn?.(colValue) : undefined}
+									onAddItem={onCreateInColumn ? () => openDraft(colValue) : undefined}
 									onArchive={onArchiveColumn ? () => onArchiveColumn?.(colItems) : undefined}
 									onMove={onMoveColumn ? (status) => onMoveColumn?.(colItems, status) : undefined}
 									onTag={onTagColumn ? (tag) => onTagColumn?.(colItems, tag) : undefined}
@@ -373,6 +480,37 @@
 					{/if}
 				</div>
 			</div>
+			{#if draftOpen[colValue]}
+				<!-- Inline draft card (TASK-1676). Lives ABOVE the dndzone so
+				     it isn't draggable and isn't a real item until saved. -->
+				<div class="lane-draft">
+					<textarea
+						bind:this={draftInputs[colValue]}
+						bind:value={draftText[colValue]}
+						class="lane-draft-input"
+						placeholder="Enter a title…"
+						rows="2"
+						disabled={savingDraft}
+						onkeydown={(e) => {
+							if (e.key === 'Enter' && !e.shiftKey) {
+								e.preventDefault();
+								submitDraft(colValue);
+							} else if (e.key === 'Escape') {
+								e.preventDefault();
+								escapeDraft(colValue);
+							}
+						}}
+					></textarea>
+					<div class="lane-draft-actions">
+						<button
+							class="lane-draft-add"
+							disabled={!draftText[colValue]?.trim() || savingDraft}
+							onclick={() => submitDraft(colValue)}
+						>Add card</button>
+						<button class="lane-draft-close" onclick={() => escapeDraft(colValue)}>Close</button>
+					</div>
+				</div>
+			{/if}
 			<!-- svelte-ignore a11y_no_static_element_interactions -->
 			<div
 				class="column-cards"
@@ -417,6 +555,27 @@
 		</div>
 	{/each}
 </div>
+{/if}
+
+{#if showLeaveDialog}
+	<!-- Leave guard (TASK-1676): an in-app navigation was intercepted
+	     because at least one lane has an unsaved draft. -->
+	<div
+		class="leave-overlay"
+		role="presentation"
+		onclick={(e) => { if (e.target === e.currentTarget) leaveStay(); }}
+		onkeydown={(e) => { if (e.key === 'Escape') leaveStay(); }}
+	>
+		<div class="leave-dialog" role="dialog" aria-modal="true" aria-label="Unsaved card" tabindex="-1">
+			<h3 class="leave-title">Unsaved card</h3>
+			<p class="leave-body">You have an unsaved card. Save it before leaving?</p>
+			<div class="leave-actions">
+				<button class="leave-stay" disabled={savingDraft} onclick={leaveStay}>Stay</button>
+				<button class="leave-discard" disabled={savingDraft} onclick={leaveDiscard}>Discard</button>
+				<button class="leave-save" disabled={savingDraft} onclick={leaveSaveAll}>Save</button>
+			</div>
+		</div>
+	</div>
 {/if}
 
 <style>
@@ -675,5 +834,133 @@
 		.column-drag-handle {
 			display: none;
 		}
+	}
+
+	/* Inline draft card (TASK-1676). */
+	.lane-draft {
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-2);
+		margin: var(--space-2) var(--space-2) 0;
+		padding: var(--space-2);
+		background: var(--bg-primary);
+		border: 1px solid var(--accent-blue);
+		border-radius: var(--radius-md);
+		box-shadow: var(--shadow-sm, 0 1px 3px rgba(0, 0, 0, 0.12));
+	}
+
+	.lane-draft-input {
+		width: 100%;
+		resize: vertical;
+		min-height: 2.4em;
+		padding: var(--space-2);
+		background: var(--bg-secondary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius-sm);
+		color: var(--text-primary);
+		font-size: 0.875em;
+		font-family: inherit;
+		line-height: 1.4;
+	}
+
+	.lane-draft-actions {
+		display: flex;
+		gap: var(--space-2);
+	}
+
+	.lane-draft-add {
+		padding: 5px 12px;
+		background: var(--accent-blue);
+		border: none;
+		border-radius: var(--radius-sm);
+		color: #fff;
+		font-size: 0.8125em;
+		font-weight: 600;
+		cursor: pointer;
+	}
+	.lane-draft-add:disabled {
+		opacity: 0.5;
+		cursor: default;
+	}
+
+	.lane-draft-close {
+		padding: 5px 10px;
+		background: none;
+		border: none;
+		border-radius: var(--radius-sm);
+		color: var(--text-muted);
+		font-size: 0.8125em;
+		cursor: pointer;
+	}
+	.lane-draft-close:hover {
+		color: var(--text-primary);
+		background: var(--bg-hover);
+	}
+
+	/* Leave-guard dialog (TASK-1676). */
+	.leave-overlay {
+		position: fixed;
+		inset: 0;
+		z-index: 1000;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		background: rgba(0, 0, 0, 0.45);
+		padding: var(--space-4);
+	}
+
+	.leave-dialog {
+		width: 100%;
+		max-width: 360px;
+		padding: var(--space-4);
+		background: var(--bg-primary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius-lg);
+		box-shadow: var(--shadow-lg, 0 10px 30px rgba(0, 0, 0, 0.3));
+	}
+
+	.leave-title {
+		margin: 0 0 var(--space-2);
+		font-size: 1em;
+		color: var(--text-primary);
+	}
+
+	.leave-body {
+		margin: 0 0 var(--space-4);
+		font-size: 0.875em;
+		color: var(--text-secondary);
+	}
+
+	.leave-actions {
+		display: flex;
+		justify-content: flex-end;
+		gap: var(--space-2);
+	}
+
+	.leave-actions button {
+		padding: 6px 14px;
+		border-radius: var(--radius-sm);
+		font-size: 0.8125em;
+		cursor: pointer;
+		border: 1px solid var(--border);
+	}
+	.leave-actions button:disabled {
+		opacity: 0.5;
+		cursor: default;
+	}
+
+	.leave-stay {
+		background: var(--bg-secondary);
+		color: var(--text-primary);
+	}
+	.leave-discard {
+		background: none;
+		border-color: var(--accent-red, #ef4444) !important;
+		color: var(--accent-red, #ef4444);
+	}
+	.leave-save {
+		background: var(--accent-blue);
+		border-color: var(--accent-blue) !important;
+		color: #fff;
 	}
 </style>

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -1081,10 +1081,21 @@
 		// prompting would be wrong (Codex round 2).
 		if (nav.to.url.pathname === nav.from?.url.pathname) return;
 		const url = nav.to.url;
+		// Replay Back/Forward via history.go(delta) so cancelling +
+		// re-navigating preserves history order (a goto would push the
+		// target as a NEW entry, corrupting Back). Codex round 4.
+		const popDelta = nav.type === 'popstate' ? nav.delta : undefined;
 		nav.cancel();
 		pendingNav = () => {
 			bypassNavGuard = true;
-			goto(url).finally(() => { bypassNavGuard = false; });
+			if (typeof popDelta === 'number') {
+				history.go(popDelta);
+				// popstate has no completion promise — reset the bypass
+				// once the navigation has settled.
+				setTimeout(() => { bypassNavGuard = false; }, 0);
+			} else {
+				goto(url).finally(() => { bypassNavGuard = false; });
+			}
 		};
 		showLeaveDialog = true;
 	});

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -1069,6 +1069,12 @@
 	// kept only until reload, so those aren't guarded.
 	beforeNavigate((nav) => {
 		if (bypassNavGuard || !hasUnsavedDrafts || !nav.to) return;
+		// Ignore same-pathname navigations — those are internal query/view
+		// state syncs (updateUrlFilters' replaceState goto on a view/filter/
+		// search change), not a real "leave". The draft survives those (it's
+		// page state), so prompting would be wrong. Only guard true leaves
+		// to a different page. Codex round 2.
+		if (nav.to.url.pathname === nav.from?.url.pathname) return;
 		const url = nav.to.url;
 		nav.cancel();
 		pendingNav = () => {

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -1069,11 +1069,16 @@
 	// kept only until reload, so those aren't guarded.
 	beforeNavigate((nav) => {
 		if (bypassNavGuard || !hasUnsavedDrafts || !nav.to) return;
-		// Ignore same-pathname navigations — those are internal query/view
-		// state syncs (updateUrlFilters' replaceState goto on a view/filter/
-		// search change), not a real "leave". The draft survives those (it's
-		// page state), so prompting would be wrong. Only guard true leaves
-		// to a different page. Codex round 2.
+		// Only guard CLIENT-SIDE, in-app leaves we can replay with goto.
+		// `willUnload` (external links, hard document navigations) and
+		// full unload (reload / tab close, nav.to === null) are treated
+		// like reload — drafts live only until then, and goto can't replay
+		// a native navigation anyway (Codex round 3).
+		if (nav.willUnload) return;
+		// Same-pathname navigations are internal query/view state syncs
+		// (updateUrlFilters' replaceState on a view/filter/search change),
+		// not a real "leave" — the draft survives those (page state), so
+		// prompting would be wrong (Codex round 2).
 		if (nav.to.url.pathname === nav.from?.url.pathname) return;
 		const url = nav.to.url;
 		nav.cancel();

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { page } from '$app/state';
-	import { goto } from '$app/navigation';
+	import { goto, beforeNavigate } from '$app/navigation';
 	import { api, PadApiError, isPlanLimitError, planLimitMessage } from '$lib/api/client';
 	import type { BulkItemsRequest, Collection, Item, QuickAction, View, ViewConfig } from '$lib/types';
 	import { parseSettings, parseFields, parseSchema, parseTags, getStatusOptions, itemUrlId, formatItemRef } from '$lib/types';
@@ -1050,6 +1050,76 @@
 		}
 	}
 
+	// ── Inline draft cards: page-owned state + leave guard (TASK-1676) ──
+	// State lives here (not in BoardView) so a draft survives a
+	// board↔list view switch that unmounts BoardView, and so the leave
+	// guard + dialog stay mounted regardless of view. BoardView binds
+	// these and renders the per-lane draft cards.
+	let draftText = $state<Record<string, string>>({});
+	let draftOpen = $state<Record<string, boolean>>({});
+	let savingDrafts = $state(false);
+	let showLeaveDialog = $state(false);
+	let pendingNav = $state<(() => void) | null>(null);
+	let bypassNavGuard = false;
+
+	let hasUnsavedDrafts = $derived(Object.values(draftText).some((t) => t.trim().length > 0));
+
+	// Intercept in-app navigation while a draft is unsaved. `nav.to` is
+	// null for full unload (reload / tab close / external) — drafts are
+	// kept only until reload, so those aren't guarded.
+	beforeNavigate((nav) => {
+		if (bypassNavGuard || !hasUnsavedDrafts || !nav.to) return;
+		const url = nav.to.url;
+		nav.cancel();
+		pendingNav = () => {
+			bypassNavGuard = true;
+			goto(url).finally(() => { bypassNavGuard = false; });
+		};
+		showLeaveDialog = true;
+	});
+
+	function runPendingNav() {
+		const act = pendingNav;
+		pendingNav = null;
+		showLeaveDialog = false;
+		act?.();
+	}
+
+	async function leaveSaveAll() {
+		if (savingDrafts) return;
+		savingDrafts = true;
+		try {
+			// Clear EACH draft as its create succeeds (not all at the end),
+			// so retrying after a partial failure can't re-create the ones
+			// that already saved (Codex round 1).
+			for (const [col, text] of Object.entries(draftText)) {
+				const title = text.trim();
+				if (!title) continue;
+				await quickCreateInColumn(col, title, false);
+				delete draftText[col];
+				delete draftOpen[col];
+			}
+		} catch {
+			// A create failed (already toasted) — keep the dialog open with
+			// the still-unsaved drafts so the user can retry or discard.
+			savingDrafts = false;
+			return;
+		}
+		savingDrafts = false;
+		runPendingNav();
+	}
+
+	function leaveDiscard() {
+		draftText = {};
+		draftOpen = {};
+		runPendingNav();
+	}
+
+	function leaveStay() {
+		pendingNav = null;
+		showLeaveDialog = false;
+	}
+
 	async function quickCreate() {
 		const title = quickCreateTitle.trim();
 		if (!title || !wsSlug || !collSlug || creatingNew) return;
@@ -1963,6 +2033,8 @@
 				onGroupReorder={handleGroupReorder}
 				oncreate={canEditThisCollection ? openQuickCreate : undefined}
 				onCreateInColumn={canEditThisCollection ? quickCreateInColumn : undefined}
+				bind:draftText
+				bind:draftOpen
 				onMoveColumn={canBulkEdit ? handleBulkMove : undefined}
 				onTagColumn={canBulkEdit ? handleBulkTag : undefined}
 				onUntagColumn={canBulkEdit ? handleBulkUntag : undefined}
@@ -2041,7 +2113,88 @@
 	/>
 {/if}
 
+{#if showLeaveDialog}
+	<!-- Leave guard (TASK-1676): an in-app navigation was intercepted
+	     because a lane has an unsaved draft card. -->
+	<div
+		class="leave-overlay"
+		role="presentation"
+		onclick={(e) => { if (e.target === e.currentTarget) leaveStay(); }}
+		onkeydown={(e) => { if (e.key === 'Escape') leaveStay(); }}
+	>
+		<div class="leave-dialog" role="dialog" aria-modal="true" aria-label="Unsaved card" tabindex="-1">
+			<h3 class="leave-title">Unsaved card</h3>
+			<p class="leave-body">You have an unsaved card. Save it before leaving?</p>
+			<div class="leave-actions">
+				<button class="leave-stay" disabled={savingDrafts} onclick={leaveStay}>Stay</button>
+				<button class="leave-discard" disabled={savingDrafts} onclick={leaveDiscard}>Discard</button>
+				<button class="leave-save" disabled={savingDrafts} onclick={leaveSaveAll}>Save</button>
+			</div>
+		</div>
+	</div>
+{/if}
+
 <style>
+	.leave-overlay {
+		position: fixed;
+		inset: 0;
+		z-index: 1000;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		background: rgba(0, 0, 0, 0.45);
+		padding: var(--space-4);
+	}
+	.leave-dialog {
+		width: 100%;
+		max-width: 360px;
+		padding: var(--space-4);
+		background: var(--bg-primary);
+		border: 1px solid var(--border);
+		border-radius: var(--radius-lg);
+		box-shadow: var(--shadow-lg, 0 10px 30px rgba(0, 0, 0, 0.3));
+	}
+	.leave-title {
+		margin: 0 0 var(--space-2);
+		font-size: 1em;
+		color: var(--text-primary);
+	}
+	.leave-body {
+		margin: 0 0 var(--space-4);
+		font-size: 0.875em;
+		color: var(--text-secondary);
+	}
+	.leave-actions {
+		display: flex;
+		justify-content: flex-end;
+		gap: var(--space-2);
+	}
+	.leave-actions button {
+		padding: 6px 14px;
+		border-radius: var(--radius-sm);
+		font-size: 0.8125em;
+		cursor: pointer;
+		border: 1px solid var(--border);
+	}
+	.leave-actions button:disabled {
+		opacity: 0.5;
+		cursor: default;
+	}
+	.leave-stay {
+		background: var(--bg-secondary);
+		color: var(--text-primary);
+	}
+	.leave-discard {
+		background: none;
+		border-color: var(--accent-red, #ef4444) !important;
+		color: var(--accent-red, #ef4444);
+	}
+	.leave-save {
+		background: var(--accent-blue);
+		border-color: var(--accent-blue) !important;
+		color: #fff;
+	}
+
 	.collection-page {
 		max-width: var(--content-max-width);
 		margin: 0 auto;

--- a/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
+++ b/web/src/routes/[username]/[workspace]/[collection]/+page.svelte
@@ -1004,13 +1004,20 @@
 		}
 	}
 
-	// Create an item directly in a board lane (TASK-1671 / IDEA-1159),
-	// pre-filling the lane's group field with its column value so it
-	// lands in that lane. Navigates to the new item to title it, like
-	// the top-level "+ New" → createNewItem flow.
-	async function quickCreateInColumn(groupValue: string) {
-		if (!wsSlug || !collSlug || creatingNew) return;
-		creatingNew = true;
+	// Create an item in a board lane from the inline draft card
+	// (TASK-1676, refines TASK-1671 / IDEA-1159). Pre-fills the lane's
+	// group field so the item lands in that lane. `navigate` true (Enter
+	// in the draft) opens the new item; false (nav-guard "Save") just
+	// upserts it into the local index and stays put. Throws on failure so
+	// BoardView can restore the draft. Returns the created item.
+	async function quickCreateInColumn(
+		groupValue: string,
+		title: string,
+		navigate: boolean
+	): Promise<Item | null> {
+		if (!wsSlug || !collSlug) return null;
+		const trimmed = title.trim();
+		if (!trimmed) return null;
 		try {
 			const schema = collection ? parseSchema(collection) : { fields: [] };
 			const defaultFields: Record<string, any> = {};
@@ -1022,20 +1029,24 @@
 			// board_group_by select) so the item opens in this lane.
 			defaultFields[groupField] = groupValue;
 			const item = await api.items.create(wsSlug, collSlug, {
-				title: 'Untitled',
+				title: trimmed,
 				content: '',
 				fields: JSON.stringify(defaultFields),
 				source: 'web'
 			});
-			goto(`/${username}/${wsSlug}/${collSlug}/${itemUrlId(item)}?new=1`);
+			if (navigate) {
+				goto(`/${username}/${wsSlug}/${collSlug}/${itemUrlId(item)}?new=1`);
+			} else {
+				localIndex.upsert(wsSlug, item);
+			}
+			return item;
 		} catch (err: any) {
 			if (isPlanLimitError(err)) {
 				toastStore.show(planLimitMessage(err) + ' Upgrade to Pro', 'error', 6000, '/console/billing');
 			} else {
 				toastStore.show(err?.message || 'Failed to create item', 'error');
 			}
-		} finally {
-			creatingNew = false;
+			throw err;
 		}
 	}
 


### PR DESCRIPTION
## Summary
Replaces the lane `+` direct-navigate (TASK-1671) with an inline **draft card** (Trello/GitHub style).

- Click `+` (or "Add item here") → an editable card opens in the lane, focused. **No item exists yet.**
- **Enter** → creates it (lane's group value pre-filled) and opens it.
- **Blur** → the card stays, unsaved.
- **Escape** → hides the card but **retains the text**; reopening restores it (until reload).
- Drafts are **per-lane**, in-memory.
- A **`beforeNavigate`** guard intercepts in-app navigation while any lane has unsaved draft text and shows a **Save / Discard / Stay** dialog: Save creates all pending drafts in place (no navigate) then proceeds; Discard drops them; Stay cancels. Reload/tab-close aren't guarded (`nav.to` is null) — drafts intentionally live only until reload.

`quickCreateInColumn` now takes `(groupValue, title, navigate)` and returns the item / throws so the draft restores on failure. The draft card renders above the dndzone so it isn't draggable.

## Decisions (confirmed with maintainer)
One draft per lane · board-only · in-app `beforeNavigate` guard only · 3-way Save/Discard/Stay dialog.

## Test plan
- [x] `npm run check` — 0 errors, no new warnings
- [x] `npm run build` — clean
- [ ] Manual: `+` opens a draft (no item created); Enter creates in the right lane + opens it; blur keeps; Escape hides + retains on reopen; navigating away prompts Save/Discard/Stay; Save creates pending then continues; canEdit-gated