### PR TITLE
feat(server): enrich collection share payload with settings, schema, item content (TASK-1678)

### DIFF
--- a/internal/server/handlers_share_links.go
+++ b/internal/server/handlers_share_links.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
@@ -13,6 +14,20 @@ import (
 	"github.com/PerpetualSoftware/pad/internal/store"
 	"github.com/go-chi/chi/v5"
 )
+
+// publicCollectionSettings is the anonymous-viewer projection of
+// models.CollectionSettings exposed on the public share-link DTO
+// (TASK-1678). It carries only the presentation fields a read-only
+// viewer needs to reproduce the owner's view type and grouping; the
+// authoring affordances on the full struct (quick_actions,
+// content_template) are intentionally excluded from the public path.
+type publicCollectionSettings struct {
+	Layout       string `json:"layout,omitempty"`
+	DefaultView  string `json:"default_view,omitempty"`
+	BoardGroupBy string `json:"board_group_by,omitempty"`
+	ListSortBy   string `json:"list_sort_by,omitempty"`
+	ListGroupBy  string `json:"list_group_by,omitempty"`
+}
 
 // validateShareLinkOpts checks that share link creation constraints are sane.
 // Returns an error message string (empty if valid).
@@ -364,23 +379,54 @@ func (s *Server) handleResolveShareLink(w http.ResponseWriter, r *http.Request) 
 			writeInternalError(w, err)
 			return
 		}
-		// Build public item list with only safe fields
+		// Build public item list with only safe fields. content is the
+		// item's markdown body, included so the public viewer can render an
+		// inline read-only row expand (TASK-1678 / TASK-1684) without a
+		// second round-trip. No internal IDs, creator, or timestamps.
 		publicItems := make([]map[string]interface{}, 0, len(items))
 		for _, it := range items {
 			publicItem := map[string]interface{}{
-				"title":  it.Title,
-				"ref":    it.Ref,
-				"fields": it.Fields,
+				"title":   it.Title,
+				"ref":     it.Ref,
+				"fields":  it.Fields,
+				"content": it.Content,
 			}
 			publicItems = append(publicItems, publicItem)
 		}
+
+		// Public collection DTO. settings/schema are emitted as parsed JSON
+		// objects (not raw strings) so the public viewer can render the
+		// owner's chosen view type, grouping, labels, and status colors.
+		// settings is projected to the presentation-only view fields —
+		// quick_actions and content_template are deliberately omitted, as
+		// they're authoring affordances an anonymous viewer has no use for.
+		publicCollection := map[string]interface{}{
+			"name":        coll.Name,
+			"icon":        coll.Icon,
+			"description": coll.Description,
+		}
+		if s := strings.TrimSpace(coll.Settings); s != "" {
+			var settings models.CollectionSettings
+			if err := json.Unmarshal([]byte(s), &settings); err == nil {
+				publicCollection["settings"] = publicCollectionSettings{
+					Layout:       settings.Layout,
+					DefaultView:  settings.DefaultView,
+					BoardGroupBy: settings.BoardGroupBy,
+					ListSortBy:   settings.ListSortBy,
+					ListGroupBy:  settings.ListGroupBy,
+				}
+			}
+		}
+		if s := strings.TrimSpace(coll.Schema); s != "" {
+			var schema models.CollectionSchema
+			if err := json.Unmarshal([]byte(s), &schema); err == nil {
+				publicCollection["schema"] = schema
+			}
+		}
+
 		writeJSON(w, http.StatusOK, map[string]interface{}{
-			"type": "collection",
-			"collection": map[string]interface{}{
-				"name":        coll.Name,
-				"icon":        coll.Icon,
-				"description": coll.Description,
-			},
+			"type":       "collection",
+			"collection": publicCollection,
 			"items":      publicItems,
 			"permission": "view",
 			"share_link": map[string]interface{}{

--- a/internal/server/handlers_share_links_test.go
+++ b/internal/server/handlers_share_links_test.go
@@ -1,0 +1,185 @@
+package server
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/PerpetualSoftware/pad/internal/models"
+)
+
+// TestResolveCollectionShareLink_EnrichedPayload pins TASK-1678: the
+// public collection share DTO must carry the collection's parsed
+// settings + schema (as JSON objects, not raw strings) and each item's
+// markdown content, so the anonymous viewer can reproduce the owner's
+// view type/grouping and render an inline read-only row expand. It must
+// NOT leak internal IDs, creator, timestamps, or authoring-only settings
+// (quick_actions / content_template).
+func TestResolveCollectionShareLink_EnrichedPayload(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSForTest(t, srv)
+
+	// Create a collection with an explicit schema + settings. settings
+	// includes quick_actions + content_template precisely so we can assert
+	// they're stripped from the public projection.
+	rr := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections", map[string]interface{}{
+		"name":   "Roadmap",
+		"prefix": "ROAD",
+		"icon": "🗺️",
+		// schema is a JSON-encoded string on CollectionCreate.
+		"schema": `{"fields":[` +
+			`{"key":"status","label":"Status","type":"select","options":["open","doing","done"],"terminal_options":["done"]},` +
+			`{"key":"points","label":"Points","type":"number","suffix":"pts"}` +
+			`]}`,
+		"settings": map[string]interface{}{
+			"default_view":     "board",
+			"board_group_by":   "status",
+			"list_sort_by":     "points",
+			"list_group_by":    "status",
+			"layout":           "fields-primary",
+			"content_template": "## Secret authoring template",
+			"quick_actions": []map[string]interface{}{
+				{"label": "Do thing", "prompt": "internal prompt", "scope": "item"},
+			},
+		},
+	})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create collection: expected 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var coll models.Collection
+	parseJSON(t, rr, &coll)
+
+	// Add an item with markdown content.
+	rr = doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections/roadmap/items", map[string]interface{}{
+		"title":   "Ship it",
+		"content": "# Ship it\n\nDetailed body for inline expand.",
+		"fields":  map[string]interface{}{"status": "doing", "points": 3},
+	})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create item: expected 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	// Create a public collection share link directly via the store. The
+	// HTTP create route gates on owner role + a created_by user FK; this
+	// test exercises the public resolve path, so we mint the link with a
+	// real user to satisfy the FK without standing up an auth session.
+	owner, err := srv.store.CreateUser(models.UserCreate{Email: "owner@test.com", Name: "Owner", Password: "pw-owner"})
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	ws, err := srv.store.GetWorkspaceBySlug(slug)
+	if err != nil || ws == nil {
+		t.Fatalf("get workspace: %v", err)
+	}
+	link, err := srv.store.CreateShareLink(ws.ID, "collection", coll.ID, "view", owner.ID, nil)
+	if err != nil {
+		t.Fatalf("create share link: %v", err)
+	}
+	if link.Token == "" {
+		t.Fatal("expected a share link token")
+	}
+
+	// Resolve the share link as an anonymous viewer.
+	rr = doRequest(srv, "GET", "/api/v1/s/"+link.Token, nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("resolve share link: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var resp struct {
+		Type       string `json:"type"`
+		Collection struct {
+			Name        string `json:"name"`
+			Icon        string `json:"icon"`
+			Description string `json:"description"`
+			Settings    *struct {
+				Layout          string `json:"layout"`
+				DefaultView     string `json:"default_view"`
+				BoardGroupBy    string `json:"board_group_by"`
+				ListSortBy      string `json:"list_sort_by"`
+				ListGroupBy     string `json:"list_group_by"`
+				QuickActions    any    `json:"quick_actions"`
+				ContentTemplate any    `json:"content_template"`
+			} `json:"settings"`
+			Schema *models.CollectionSchema `json:"schema"`
+		} `json:"collection"`
+		Items []struct {
+			Title   string `json:"title"`
+			Ref     string `json:"ref"`
+			Fields  any    `json:"fields"`
+			Content string `json:"content"`
+		} `json:"items"`
+	}
+	parseJSON(t, rr, &resp)
+
+	if resp.Type != "collection" {
+		t.Fatalf("expected type 'collection', got %q", resp.Type)
+	}
+
+	// settings: present, parsed, and projected to view fields only.
+	if resp.Collection.Settings == nil {
+		t.Fatal("expected collection.settings on the public payload")
+	}
+	if resp.Collection.Settings.DefaultView != "board" {
+		t.Errorf("expected default_view 'board', got %q", resp.Collection.Settings.DefaultView)
+	}
+	if resp.Collection.Settings.BoardGroupBy != "status" {
+		t.Errorf("expected board_group_by 'status', got %q", resp.Collection.Settings.BoardGroupBy)
+	}
+	if resp.Collection.Settings.ListSortBy != "points" {
+		t.Errorf("expected list_sort_by 'points', got %q", resp.Collection.Settings.ListSortBy)
+	}
+	if resp.Collection.Settings.ListGroupBy != "status" {
+		t.Errorf("expected list_group_by 'status', got %q", resp.Collection.Settings.ListGroupBy)
+	}
+	if resp.Collection.Settings.Layout != "fields-primary" {
+		t.Errorf("expected layout 'fields-primary', got %q", resp.Collection.Settings.Layout)
+	}
+	// Authoring-only fields MUST NOT leak.
+	if resp.Collection.Settings.QuickActions != nil {
+		t.Errorf("quick_actions must not appear in public settings, got %#v", resp.Collection.Settings.QuickActions)
+	}
+	if resp.Collection.Settings.ContentTemplate != nil {
+		t.Errorf("content_template must not appear in public settings, got %#v", resp.Collection.Settings.ContentTemplate)
+	}
+
+	// schema: present, parsed as an object, with the presentation fields.
+	if resp.Collection.Schema == nil {
+		t.Fatal("expected collection.schema on the public payload")
+	}
+	if len(resp.Collection.Schema.Fields) != 2 {
+		t.Fatalf("expected 2 schema fields, got %d", len(resp.Collection.Schema.Fields))
+	}
+	statusField := resp.Collection.Schema.Fields[0]
+	if statusField.Key != "status" || statusField.Type != "select" {
+		t.Errorf("unexpected status field: %#v", statusField)
+	}
+	if len(statusField.Options) != 3 {
+		t.Errorf("expected 3 status options, got %d", len(statusField.Options))
+	}
+	if len(statusField.TerminalOptions) != 1 || statusField.TerminalOptions[0] != "done" {
+		t.Errorf("expected terminal_options [done], got %#v", statusField.TerminalOptions)
+	}
+	if resp.Collection.Schema.Fields[1].Suffix != "pts" {
+		t.Errorf("expected suffix 'pts', got %q", resp.Collection.Schema.Fields[1].Suffix)
+	}
+
+	// items: content included for inline expand.
+	if len(resp.Items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(resp.Items))
+	}
+	it := resp.Items[0]
+	if it.Ref == "" {
+		t.Error("expected item ref")
+	}
+	if it.Content != "# Ship it\n\nDetailed body for inline expand." {
+		t.Errorf("expected item content to be included, got %q", it.Content)
+	}
+
+	// Guard against leaking internal fields in the raw JSON body.
+	body := rr.Body.String()
+	for _, forbidden := range []string{`"id"`, `"workspace_id"`, `"created_by"`, `"created_at"`, `"updated_at"`, "content_template", "quick_actions"} {
+		if strings.Contains(body, forbidden) {
+			t.Errorf("public share payload leaks forbidden token %q: %s", forbidden, body)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Enriches the public collection share-link payload (`handleResolveShareLink`, `collection` branch in `internal/server/handlers_share_links.go`) so an anonymous viewer at `/s/{token}` can reproduce the owner's chosen view type, grouping, field labels/status colors, and render an inline read-only row expand.

Backend only — Phase 1 of PLAN-1677. Frontend integration is TASK-1680.

## Context

Previously the public collection DTO returned only `{name, icon, description}` plus a flat `{title, ref, fields}` per item — no settings, no schema, no item body. This adds the data the redesigned anonymous viewer needs while keeping the public DTO safe (no internal IDs, creator, workspace internals, or timestamps).

Per the orchestration decision on TASK-1678: settings and schema are emitted as **parsed JSON objects** (not raw strings), and each item now includes its **`content`** (markdown) for the inline read-only row expand decided in TASK-1684.

## Final payload shape

`GET /api/v1/s/{token}` for a `target_type: collection` link now returns:

```jsonc
{
  "type": "collection",
  "collection": {
    "name": "Roadmap",
    "icon": "🗺️",
    "description": "",
    "settings": {                      // parsed object; presentation-only projection
      "layout": "fields-primary",      // omitempty
      "default_view": "board",         // omitempty — list | board | table
      "board_group_by": "status",      // omitempty
      "list_sort_by": "points",        // omitempty
      "list_group_by": "status"        // omitempty
    },
    "schema": {                        // parsed models.CollectionSchema object
      "fields": [
        {
          "key": "status",
          "label": "Status",
          "type": "select",
          "options": ["open", "doing", "done"],
          "terminal_options": ["done"]
        },
        { "key": "points", "label": "Points", "type": "number", "suffix": "pts" }
      ]
    }
  },
  "items": [
    {
      "title": "Ship it",
      "ref": "ROAD-1",
      "fields": "{\"status\":\"doing\",\"points\":3}",   // unchanged: stored fields JSON string
      "content": "# Ship it\n\nDetailed body for inline expand."   // NEW
    }
  ],
  "permission": "view",
  "share_link": { "target_type": "collection" }
}
```

### Notes for the frontend integration (TASK-1680)

- **`collection.settings`** is a deliberate **presentation-only projection** of `models.CollectionSettings`. It carries the five view fields only. The authoring affordances `quick_actions` and `content_template` are **intentionally omitted** from the public path.
- **`collection.settings`** is **absent** (key not present) if the collection has no stored settings or the stored settings JSON is malformed. `default_view` may be empty — default to `board`/`list` client-side as appropriate.
- **`collection.schema`** is the full parsed `CollectionSchema` (`fields[]` with `key`, `label`, `type`, `options`, `terminal_options`, `suffix`, etc.). Absent if unset/malformed.
- **`items[].fields`** is unchanged — still the stored fields JSON **string** (callers already parse it). Only `content` is new on each item.
- Both settings and schema parse **defensively**: a malformed stored blob is omitted rather than failing the whole resolve.

## Test plan

- `go build ./...` — pass
- `go vet ./...` — pass
- `go test ./...` — pass (full suite)
- New test `TestResolveCollectionShareLink_EnrichedPayload` (`internal/server/handlers_share_links_test.go`) asserts:
  - `settings` is present, parsed, and carries the five view fields
  - `quick_actions` / `content_template` do **not** appear
  - `schema` is a parsed object with the expected fields/options/terminal_options/suffix
  - `items[].content` is included
  - raw response body contains no `id` / `workspace_id` / `created_by` / `created_at` / `updated_at` / authoring-only tokens

Parent: PLAN-1677. Security review of content exposure: TASK-1685.
