### PR TITLE
feat(share): include saved views in collection share payload (TASK-1681)

### DIFF
--- a/internal/server/handlers_share_links.go
+++ b/internal/server/handlers_share_links.go
@@ -29,6 +29,22 @@ type publicCollectionSettings struct {
 	ListGroupBy  string `json:"list_group_by,omitempty"`
 }
 
+// publicShareView is the anonymous-viewer projection of models.View
+// exposed on the public collection share-link DTO (TASK-1681). It carries
+// only the presentation fields the read-only view switcher needs; internal
+// UUIDs (id, workspace_id, collection_id) and timestamps are stripped so
+// the public payload leaks nothing addressable. Config is emitted as a
+// parsed JSON object (not the raw stored string) to match how settings/
+// schema are projected.
+type publicShareView struct {
+	Name      string          `json:"name"`
+	Slug      string          `json:"slug"`
+	ViewType  string          `json:"view_type"`
+	Config    json.RawMessage `json:"config"`
+	IsDefault bool            `json:"is_default"`
+	SortOrder int             `json:"sort_order"`
+}
+
 // validateShareLinkOpts checks that share link creation constraints are sane.
 // Returns an error message string (empty if valid).
 func validateShareLinkOpts(expiresAt *string, maxViews *int) string {
@@ -423,6 +439,33 @@ func (s *Server) handleResolveShareLink(w http.ResponseWriter, r *http.Request) 
 				publicCollection["schema"] = schema
 			}
 		}
+
+		// Saved views power the read-only view switcher (TASK-1681 →
+		// TASK-1682). Projected to a public shape — internal UUIDs and
+		// timestamps stripped, config parsed to an object. ListViews returns
+		// them ordered by sort_order; we always emit an array (never null) so
+		// the switcher can fall back to settings.default_view when empty.
+		views, err := s.store.ListViews(link.WorkspaceID, coll.ID)
+		if err != nil {
+			writeInternalError(w, err)
+			return
+		}
+		publicViews := make([]publicShareView, 0, len(views))
+		for _, v := range views {
+			config := json.RawMessage("{}")
+			if c := strings.TrimSpace(v.Config); c != "" && json.Valid([]byte(c)) {
+				config = json.RawMessage(c)
+			}
+			publicViews = append(publicViews, publicShareView{
+				Name:      v.Name,
+				Slug:      v.Slug,
+				ViewType:  v.ViewType,
+				Config:    config,
+				IsDefault: v.IsDefault,
+				SortOrder: v.SortOrder,
+			})
+		}
+		publicCollection["views"] = publicViews
 
 		writeJSON(w, http.StatusOK, map[string]interface{}{
 			"type":       "collection",

--- a/internal/server/handlers_share_links_test.go
+++ b/internal/server/handlers_share_links_test.go
@@ -75,13 +75,24 @@ func TestResolveCollectionShareLink_EnrichedPayload(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create board view: %v", err)
 	}
-	_, err = srv.store.CreateView(ws0.ID, models.ViewCreate{
+	tableView, err := srv.store.CreateView(ws0.ID, models.ViewCreate{
 		CollectionID: &coll.ID,
 		Name:         "Table",
 		ViewType:     "table",
 	})
 	if err != nil {
 		t.Fatalf("create table view: %v", err)
+	}
+	// Pin distinct sort_order values. CreateView always inserts sort_order=0
+	// and now() is second-granularity, so without this the "ORDER BY
+	// sort_order, created_at" tie could return either order and flake the
+	// position-based assertion below.
+	zero, one := 0, 1
+	if _, err := srv.store.UpdateView(boardView.ID, models.ViewUpdate{SortOrder: &zero}); err != nil {
+		t.Fatalf("set board sort_order: %v", err)
+	}
+	if _, err := srv.store.UpdateView(tableView.ID, models.ViewUpdate{SortOrder: &one}); err != nil {
+		t.Fatalf("set table sort_order: %v", err)
 	}
 
 	// Create a public collection share link directly via the store. The
@@ -202,7 +213,7 @@ func TestResolveCollectionShareLink_EnrichedPayload(t *testing.T) {
 		t.Fatalf("expected 2 saved views, got %d", len(resp.Collection.Views))
 	}
 	board := resp.Collection.Views[0]
-	if board.Name != "Board" || board.ViewType != "board" {
+	if board.Name != "Board" || board.ViewType != "board" || board.SortOrder != 0 {
 		t.Errorf("unexpected first view: %#v", board)
 	}
 	if board.Slug != boardView.Slug {
@@ -211,8 +222,8 @@ func TestResolveCollectionShareLink_EnrichedPayload(t *testing.T) {
 	if got, _ := board.Config["group_by"].(string); got != "status" {
 		t.Errorf("expected board config group_by 'status', got %#v", board.Config)
 	}
-	if resp.Collection.Views[1].ViewType != "table" {
-		t.Errorf("expected second view type 'table', got %q", resp.Collection.Views[1].ViewType)
+	if table := resp.Collection.Views[1]; table.ViewType != "table" || table.SortOrder != 1 {
+		t.Errorf("expected second view to be table at sort_order 1, got %#v", table)
 	}
 
 	// items: content included for inline expand.

--- a/internal/server/handlers_share_links_test.go
+++ b/internal/server/handlers_share_links_test.go
@@ -59,6 +59,31 @@ func TestResolveCollectionShareLink_EnrichedPayload(t *testing.T) {
 		t.Fatalf("create item: expected 201, got %d: %s", rr.Code, rr.Body.String())
 	}
 
+	// Resolve the collection so we can attach saved views (TASK-1681). Views
+	// are workspace-scoped + collection-scoped; ListViews returns them ordered
+	// by sort_order, and the public projection must strip internal UUIDs.
+	ws0, err := srv.store.GetWorkspaceBySlug(slug)
+	if err != nil || ws0 == nil {
+		t.Fatalf("get workspace for views: %v", err)
+	}
+	boardView, err := srv.store.CreateView(ws0.ID, models.ViewCreate{
+		CollectionID: &coll.ID,
+		Name:         "Board",
+		ViewType:     "board",
+		Config:       `{"group_by":"status"}`,
+	})
+	if err != nil {
+		t.Fatalf("create board view: %v", err)
+	}
+	_, err = srv.store.CreateView(ws0.ID, models.ViewCreate{
+		CollectionID: &coll.ID,
+		Name:         "Table",
+		ViewType:     "table",
+	})
+	if err != nil {
+		t.Fatalf("create table view: %v", err)
+	}
+
 	// Create a public collection share link directly via the store. The
 	// HTTP create route gates on owner role + a created_by user FK; this
 	// test exercises the public resolve path, so we mint the link with a
@@ -101,6 +126,14 @@ func TestResolveCollectionShareLink_EnrichedPayload(t *testing.T) {
 				ContentTemplate any    `json:"content_template"`
 			} `json:"settings"`
 			Schema *models.CollectionSchema `json:"schema"`
+			Views  []struct {
+				Name      string         `json:"name"`
+				Slug      string         `json:"slug"`
+				ViewType  string         `json:"view_type"`
+				Config    map[string]any `json:"config"`
+				IsDefault bool           `json:"is_default"`
+				SortOrder int            `json:"sort_order"`
+			} `json:"views"`
 		} `json:"collection"`
 		Items []struct {
 			Title   string `json:"title"`
@@ -163,6 +196,25 @@ func TestResolveCollectionShareLink_EnrichedPayload(t *testing.T) {
 		t.Errorf("expected suffix 'pts', got %q", resp.Collection.Schema.Fields[1].Suffix)
 	}
 
+	// views: present, projected to public shape, ordered by sort_order,
+	// config parsed to an object (TASK-1681).
+	if len(resp.Collection.Views) != 2 {
+		t.Fatalf("expected 2 saved views, got %d", len(resp.Collection.Views))
+	}
+	board := resp.Collection.Views[0]
+	if board.Name != "Board" || board.ViewType != "board" {
+		t.Errorf("unexpected first view: %#v", board)
+	}
+	if board.Slug != boardView.Slug {
+		t.Errorf("expected board view slug %q, got %q", boardView.Slug, board.Slug)
+	}
+	if got, _ := board.Config["group_by"].(string); got != "status" {
+		t.Errorf("expected board config group_by 'status', got %#v", board.Config)
+	}
+	if resp.Collection.Views[1].ViewType != "table" {
+		t.Errorf("expected second view type 'table', got %q", resp.Collection.Views[1].ViewType)
+	}
+
 	// items: content included for inline expand.
 	if len(resp.Items) != 1 {
 		t.Fatalf("expected 1 item, got %d", len(resp.Items))
@@ -181,5 +233,60 @@ func TestResolveCollectionShareLink_EnrichedPayload(t *testing.T) {
 		if strings.Contains(body, forbidden) {
 			t.Errorf("public share payload leaks forbidden token %q: %s", forbidden, body)
 		}
+	}
+}
+
+// TestResolveCollectionShareLink_NoViewsEmptyArray pins TASK-1681's empty
+// contract: a collection with no saved views emits `views: []` (not null), so
+// the read-only switcher (TASK-1682) can reliably fall back to
+// settings.default_view without a null check.
+func TestResolveCollectionShareLink_NoViewsEmptyArray(t *testing.T) {
+	srv := testServer(t)
+	slug := createWSForTest(t, srv)
+
+	rr := doRequest(srv, "POST", "/api/v1/workspaces/"+slug+"/collections", map[string]interface{}{
+		"name":   "Notes",
+		"prefix": "NOTE",
+	})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create collection: expected 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var coll models.Collection
+	parseJSON(t, rr, &coll)
+
+	owner, err := srv.store.CreateUser(models.UserCreate{Email: "noviews@test.com", Name: "Owner", Password: "pw-owner"})
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	ws, err := srv.store.GetWorkspaceBySlug(slug)
+	if err != nil || ws == nil {
+		t.Fatalf("get workspace: %v", err)
+	}
+	link, err := srv.store.CreateShareLink(ws.ID, "collection", coll.ID, "view", owner.ID, nil)
+	if err != nil {
+		t.Fatalf("create share link: %v", err)
+	}
+
+	rr = doRequest(srv, "GET", "/api/v1/s/"+link.Token, nil)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("resolve share link: expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	// `views` must be present as an empty array, not null/absent.
+	if !strings.Contains(rr.Body.String(), `"views":[]`) {
+		t.Errorf("expected empty views array in payload, got: %s", rr.Body.String())
+	}
+
+	var resp struct {
+		Collection struct {
+			Views []any `json:"views"`
+		} `json:"collection"`
+	}
+	parseJSON(t, rr, &resp)
+	if resp.Collection.Views == nil {
+		t.Error("expected non-nil empty views slice")
+	}
+	if len(resp.Collection.Views) != 0 {
+		t.Errorf("expected 0 views, got %d", len(resp.Collection.Views))
 	}
 }

--- a/web/src/lib/types/index.ts
+++ b/web/src/lib/types/index.ts
@@ -80,15 +80,30 @@ export type PublicShareSettings = Pick<
 	'layout' | 'default_view' | 'board_group_by' | 'list_sort_by' | 'list_group_by'
 >;
 
+/** One saved view in the public share payload (TASK-1681). Projected from
+ *  models.View with internal UUIDs (id, workspace_id, collection_id) and
+ *  timestamps stripped; `config` is a parsed JSON object. Powers the
+ *  read-only view switcher (TASK-1682). */
+export interface PublicShareView {
+	name: string;
+	slug: string;
+	view_type: string;
+	config: Record<string, unknown>;
+	is_default: boolean;
+	sort_order: number;
+}
+
 /** The `collection` branch of the public share payload (TASK-1678). `settings`
  *  and `schema` are parsed JSON objects, present only when the source collection
- *  defined them. */
+ *  defined them. `views` (TASK-1681) is always present — an empty array when the
+ *  collection has no saved views (the switcher falls back to settings.default_view). */
 export interface PublicShareCollection {
 	name: string;
 	icon?: string;
 	description?: string;
 	settings?: PublicShareSettings;
 	schema?: CollectionSchema;
+	views?: PublicShareView[];
 }
 
 /** One item in the public share payload. `fields` is still a JSON string;


### PR DESCRIPTION
## What

Phase 2 (backend half) of PLAN-1677 — enrich the public collection share payload (`GET /s/{token}`) with the collection's saved views so the read-only view switcher (TASK-1682) can render and toggle them.

## Changes

- `internal/server/handlers_share_links.go` — in the `case "collection":` branch of `handleResolveShareLink`, fetch saved views via `Store.ListViews(workspaceID, collectionID)` (ordered by `sort_order`) and project to a public shape under **`collection.views`**: `{name, slug, view_type, config, is_default, sort_order}`. Internal UUIDs (id, workspace_id, collection_id) and timestamps are stripped. `config` is emitted as a parsed JSON object (consistent with how `settings`/`schema` are projected). Always an array, never null — empty when the collection has no saved views, so the switcher falls back to `settings.default_view`.
- `web/src/lib/types/index.ts` — additive: new `PublicShareView` interface + optional `views` array on `PublicShareCollection`.
- `internal/server/handlers_share_links_test.go` — extended the enriched-payload test to create + assert two saved views (order, slug, parsed config, view_type), and added `TestResolveCollectionShareLink_NoViewsEmptyArray` pinning the empty-array contract.

## Placement choice

Put `views` under **`collection.views`** (not top-level) to match where TASK-1680/TASK-1678 put `settings` and `schema` — keeps the collection shape cohesive.

## Verification

`go build ./... && go vet ./... && go test ./...` and `cd web && npm run build` all pass.

Parent: PLAN-1677.